### PR TITLE
Tell Github's linguist tool that our files are C++, including extensionless ones

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,6 @@
 # Disable CRLF-mapping for all files.
 * -text
 
-# Ensure GitHub detects our C++ code as C++ code
-/stl/inc/**/* linguist-language=C++
-/stl/src/**/* linguist-language=C++
+# Ensure GitHub detects our C++ code as C++ code.
+/stl/inc/** linguist-language=C++
+/stl/src/** linguist-language=C++


### PR DESCRIPTION
The web site doesn't update very often so I installed github-linguist in WSL locally and verified:

billy@BION-XPS13C:/mnt/c/Dev/STL$ github-linguist
99.72%  C++
0.28%   CMake

Resolves #1