### PR TITLE
Suppress warning C4180 STL-wide

### DIFF
--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -17,8 +17,6 @@ _STL_DISABLE_CLANG_WARNINGS
 #pragma push_macro("new")
 #undef new
 
-#pragma warning(disable : 4180) // qualifier applied to function type has no meaning; ignored
-
 _STD_BEGIN
 // STRUCT TEMPLATE integer_sequence
 template <class _Ty, _Ty... _Vals>

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -317,6 +317,7 @@
 #define _STL_EXTRA_DISABLED_WARNINGS
 #endif // _STL_EXTRA_DISABLED_WARNINGS
 
+// warning C4180: qualifier applied to function type has no meaning; ignored
 // warning C4412: function signature contains type 'meow'; C++ objects are unsafe to pass between pure code
 //                and mixed or native. (/Wall)
 // warning C4455: literal suffix identifiers that do not start with an underscore are reserved
@@ -347,9 +348,9 @@
 #ifndef _STL_DISABLED_WARNINGS
 // clang-format off
 #define _STL_DISABLED_WARNINGS                        \
-    4412 4455 4472 4494 4514 4571 4574 4582 4583 4587 \
-    4588 4619 4623 4625 4626 4643 4702 4793 4820 4988 \
-    5026 5027 5045                                    \
+    4180 4412 4455 4472 4494 4514 4571 4574 4582 4583 \
+    4587 4588 4619 4623 4625 4626 4643 4702 4793 4820 \
+    4988 5026 5027 5045                               \
     _STL_DISABLED_WARNING_C4577                       \
     _STL_DISABLED_WARNING_C4984                       \
     _STL_DISABLED_WARNING_C5053                       \


### PR DESCRIPTION
C4180 "qualifier applied to function type has no meaning; ignored" is emitted from `std::remove_reference<T>` when `T` is a function type or reference to such after applying the changes in #82. We could suppress it locally, but the warning is extremely low-value for the STL in general so let's simply suppress it globally.

[This is a replay of Microsoft-internal PR [201455](https://devdiv.visualstudio.com/DevDiv/_git/msvc/pullrequest/201455).]