### PR TITLE
_Has_class_or_enum_type concept should admit unions

### DIFF
--- a/stl/inc/concepts
+++ b/stl/inc/concepts
@@ -123,7 +123,8 @@ concept move_constructible = constructible_from<_Ty, _Ty> && convertible_to<_Ty,
 
 // CONCEPT _Has_class_or_enum_type
 template <class _Ty>
-concept _Has_class_or_enum_type = __is_class(remove_reference_t<_Ty>) || __is_enum(remove_reference_t<_Ty>);
+concept _Has_class_or_enum_type = __is_class(remove_reference_t<_Ty>) || __is_enum(remove_reference_t<_Ty>)
+    || __is_union(remove_reference_t<_Ty>);
 
 // CUSTOMIZATION POINT OBJECT ranges::swap
 namespace ranges {


### PR DESCRIPTION
Unions have "class type", despite that `is_class_v` is false for unions. Fixes a bug in which the behavior of `std::ranges::swap` cannot be customized for union types.