### PR TITLE
Update "old" range types

### DIFF
--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -26,13 +26,16 @@ _STD_BEGIN
 template <class _Myvec>
 class _Vector_const_iterator : public _Iterator_base {
 public:
+#ifdef __cpp_lib_concepts
+    using iterator_concept = contiguous_iterator_tag;
+#endif // __cpp_lib_concepts
     using iterator_category = random_access_iterator_tag;
+    using value_type        = typename _Myvec::value_type;
+    using difference_type   = typename _Myvec::difference_type;
+    using pointer           = typename _Myvec::const_pointer;
+    using reference         = const value_type&;
 
-    using value_type      = typename _Myvec::value_type;
-    using difference_type = typename _Myvec::difference_type;
-    using pointer         = typename _Myvec::const_pointer;
-    using reference       = const value_type&;
-    using _Tptr           = typename _Myvec::pointer;
+    using _Tptr = typename _Myvec::pointer;
 
     _Vector_const_iterator() noexcept : _Ptr() {}
 
@@ -201,17 +204,47 @@ _NODISCARD _Vector_const_iterator<_Myvec> operator+(
     return _Next += _Off;
 }
 
+#if _HAS_CXX20
+template <class _Myvec>
+struct pointer_traits<_Vector_const_iterator<_Myvec>> {
+    using pointer         = _Vector_const_iterator<_Myvec>;
+    using element_type    = const typename pointer::value_type;
+    using difference_type = typename pointer::difference_type;
+
+    _NODISCARD static constexpr element_type* to_address(const pointer _Iter) noexcept {
+#if _ITERATOR_DEBUG_LEVEL != 0
+        // A value-initialized iterator is in the domain of to_address. An invalidated end iterator for a vector with
+        // capacity() of 0 is not. This function cannot distinguish those two cases, so it incorrectly does not diagnose
+        // the latter. In practice, this isn't a significant problem since to_address returns nullptr for such an
+        // iterator.
+        const auto _Mycont = static_cast<const _Myvec*>(_Iter._Getcont());
+        if (_Mycont) {
+            _STL_VERIFY(_Mycont->_Myfirst <= _Iter._Ptr && _Iter._Ptr <= _Mycont->_Mylast,
+                "can't convert out-of-range vector iterator to pointer");
+        } else {
+            _STL_VERIFY(!_Iter._Ptr, "can't convert invalid vector iterator to pointer");
+        }
+#endif // _ITERATOR_DEBUG_LEVEL != 0
+
+        return _STD to_address(_Iter._Ptr);
+    }
+};
+#endif // _HAS_CXX20
+
 // CLASS TEMPLATE _Vector_iterator
 template <class _Myvec>
 class _Vector_iterator : public _Vector_const_iterator<_Myvec> {
 public:
-    using _Mybase           = _Vector_const_iterator<_Myvec>;
-    using iterator_category = random_access_iterator_tag;
+    using _Mybase = _Vector_const_iterator<_Myvec>;
 
-    using value_type      = typename _Myvec::value_type;
-    using difference_type = typename _Myvec::difference_type;
-    using pointer         = typename _Myvec::pointer;
-    using reference       = value_type&;
+#ifdef __cpp_lib_concepts
+    using iterator_concept = contiguous_iterator_tag;
+#endif // __cpp_lib_concepts
+    using iterator_category = random_access_iterator_tag;
+    using value_type        = typename _Myvec::value_type;
+    using difference_type   = typename _Myvec::difference_type;
+    using pointer           = typename _Myvec::pointer;
+    using reference         = value_type&;
 
     using _Mybase::_Mybase;
 
@@ -283,6 +316,33 @@ _NODISCARD _Vector_iterator<_Myvec> operator+(
     typename _Vector_iterator<_Myvec>::difference_type _Off, _Vector_iterator<_Myvec> _Next) {
     return _Next += _Off;
 }
+
+#if _HAS_CXX20
+template <class _Myvec>
+struct pointer_traits<_Vector_iterator<_Myvec>> {
+    using pointer         = _Vector_iterator<_Myvec>;
+    using element_type    = typename pointer::value_type;
+    using difference_type = typename pointer::difference_type;
+
+    _NODISCARD static constexpr element_type* to_address(const pointer _Iter) noexcept {
+#if _ITERATOR_DEBUG_LEVEL != 0
+        // A value-initialized iterator is in the domain of to_address. An invalidated end iterator for a vector with
+        // capacity() of 0 is not. This function cannot distinguish those two cases, so it incorrectly does not diagnose
+        // the latter. In practice, this isn't a significant problem since to_address returns nullptr for such an
+        // iterator.
+        const auto _Mycont = static_cast<const _Myvec*>(_Iter._Getcont());
+        if (_Mycont) {
+            _STL_VERIFY(_Mycont->_Myfirst <= _Iter._Ptr && _Iter._Ptr <= _Mycont->_Mylast,
+                "can't convert out-of-range vector iterator to pointer");
+        } else {
+            _STL_VERIFY(!_Iter._Ptr, "can't convert invalid vector iterator to pointer");
+        }
+#endif // _ITERATOR_DEBUG_LEVEL != 0
+
+        return _STD to_address(_Iter._Ptr);
+    }
+};
+#endif // _HAS_CXX20
 
 // vector TYPE WRAPPERS
 template <class _Value_type, class _Size_type, class _Difference_type, class _Pointer, class _Const_pointer,

--- a/stl/inc/xstddef
+++ b/stl/inc/xstddef
@@ -280,12 +280,12 @@ const _Ty* addressof(const _Ty&&) = delete;
 
 // FUNCTION TEMPLATE _Unfancy
 template <class _Ptrty>
-auto _Unfancy(_Ptrty _Ptr) { // converts from a fancy pointer to a plain pointer
+_NODISCARD constexpr auto _Unfancy(_Ptrty _Ptr) noexcept { // converts from a fancy pointer to a plain pointer
     return _STD addressof(*_Ptr);
 }
 
 template <class _Ty>
-_Ty* _Unfancy(_Ty* _Ptr) { // do nothing for plain pointers
+_NODISCARD constexpr _Ty* _Unfancy(_Ty* _Ptr) noexcept { // do nothing for plain pointers
     return _Ptr;
 }
 _STD_END

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -898,6 +898,9 @@ class basic_string_view;
 template <class _Traits>
 class _String_view_iterator {
 public:
+#ifdef __cpp_lib_concepts
+    using iterator_concept = contiguous_iterator_tag;
+#endif // __cpp_lib_concepts
     using iterator_category = random_access_iterator_tag;
     using value_type        = typename _Traits::char_type;
     using difference_type   = ptrdiff_t;
@@ -1132,6 +1135,19 @@ _NODISCARD constexpr _String_view_iterator<_Traits> operator+(
     return _Right;
 }
 
+#if _HAS_CXX20
+template <class _Traits>
+struct pointer_traits<_String_view_iterator<_Traits>> {
+    using pointer         = _String_view_iterator<_Traits>;
+    using element_type    = const typename pointer::value_type;
+    using difference_type = typename pointer::difference_type;
+
+    _NODISCARD static constexpr element_type* to_address(const pointer& _Iter) noexcept {
+        return _Iter._Unwrapped();
+    }
+};
+#endif // _HAS_CXX20
+
 
 // CLASS TEMPLATE basic_string_view
 template <class _Elem, class _Traits>
@@ -1187,6 +1203,17 @@ public:
         return const_iterator(_Mydata + _Mysize);
 #endif // _ITERATOR_DEBUG_LEVEL
     }
+
+#ifdef __cpp_lib_concepts
+    _NODISCARD friend constexpr const_iterator begin(const basic_string_view& _Right) noexcept {
+        // non-member overload that accepts rvalues to model the exposition-only forwarding-range concept
+        return _Right.begin();
+    }
+    _NODISCARD friend constexpr const_iterator end(const basic_string_view& _Right) noexcept {
+        // Ditto modeling forwarding-range
+        return _Right.end();
+    }
+#endif // __cpp_lib_concepts
 
     _NODISCARD constexpr const_iterator cbegin() const noexcept {
         return begin();
@@ -1738,12 +1765,14 @@ inline namespace literals {
 template <class _Mystr>
 class _String_const_iterator : public _Iterator_base {
 public:
+#ifdef __cpp_lib_concepts
+    using iterator_concept = contiguous_iterator_tag;
+#endif // __cpp_lib_concepts
     using iterator_category = random_access_iterator_tag;
-
-    using value_type      = typename _Mystr::value_type;
-    using difference_type = typename _Mystr::difference_type;
-    using pointer         = typename _Mystr::const_pointer;
-    using reference       = const value_type&;
+    using value_type        = typename _Mystr::value_type;
+    using difference_type   = typename _Mystr::difference_type;
+    using pointer           = typename _Mystr::const_pointer;
+    using reference         = const value_type&;
 
     _String_const_iterator() noexcept : _Ptr() {}
 
@@ -1929,17 +1958,51 @@ _NODISCARD _String_const_iterator<_Mystr> operator+(
     return _Next += _Off;
 }
 
+#if _HAS_CXX20
+template <class _Mystr>
+struct pointer_traits<_String_const_iterator<_Mystr>> {
+    using pointer         = _String_const_iterator<_Mystr>;
+    using element_type    = const typename pointer::value_type;
+    using difference_type = typename pointer::difference_type;
+
+    _NODISCARD static constexpr element_type* to_address(const pointer _Iter) noexcept {
+#if _ITERATOR_DEBUG_LEVEL >= 1
+        const auto _Mycont = static_cast<const _Mystr*>(_Iter._Getcont());
+        if (!_Mycont) {
+            _STL_VERIFY(!_Iter._Ptr, "cannot convert string iterator to pointer because the iterator was invalidated "
+                                     "(e.g. reallocation occurred, or the string was destroyed)");
+        }
+#endif // _ITERATOR_DEBUG_LEVEL >= 1
+
+        const auto _Rawptr = _STD to_address(_Iter._Ptr);
+
+#if _ITERATOR_DEBUG_LEVEL >= 1
+        if (_Mycont) {
+            const auto _Contptr = _Mycont->_Myptr();
+            _STL_VERIFY(_Contptr <= _Rawptr && _Rawptr <= _Contptr + _Mycont->_Mysize,
+                "cannot convert string iterator to pointer because it is out of range");
+        }
+#endif // _ITERATOR_DEBUG_LEVEL >= 1
+
+        return _Rawptr;
+    }
+};
+#endif // _HAS_CXX20
+
 // CLASS TEMPLATE _String_iterator
 template <class _Mystr>
 class _String_iterator : public _String_const_iterator<_Mystr> {
 public:
-    using _Mybase           = _String_const_iterator<_Mystr>;
-    using iterator_category = random_access_iterator_tag;
+    using _Mybase = _String_const_iterator<_Mystr>;
 
-    using value_type      = typename _Mystr::value_type;
-    using difference_type = typename _Mystr::difference_type;
-    using pointer         = typename _Mystr::pointer;
-    using reference       = value_type&;
+#ifdef __cpp_lib_concepts
+    using iterator_concept = contiguous_iterator_tag;
+#endif // __cpp_lib_concepts
+    using iterator_category = random_access_iterator_tag;
+    using value_type        = typename _Mystr::value_type;
+    using difference_type   = typename _Mystr::difference_type;
+    using pointer           = typename _Mystr::pointer;
+    using reference         = value_type&;
 
     using _Mybase::_Mybase;
 
@@ -2011,6 +2074,37 @@ _NODISCARD _String_iterator<_Mystr> operator+(
     typename _String_iterator<_Mystr>::difference_type _Off, _String_iterator<_Mystr> _Next) {
     return _Next += _Off;
 }
+
+#if _HAS_CXX20
+template <class _Mystr>
+struct pointer_traits<_String_iterator<_Mystr>> {
+    using pointer         = _String_iterator<_Mystr>;
+    using element_type    = typename pointer::value_type;
+    using difference_type = typename pointer::difference_type;
+
+    _NODISCARD static constexpr element_type* to_address(const pointer _Iter) noexcept {
+#if _ITERATOR_DEBUG_LEVEL >= 1
+        const auto _Mycont = static_cast<const _Mystr*>(_Iter._Getcont());
+        if (!_Mycont) {
+            _STL_VERIFY(!_Iter._Ptr, "cannot convert string iterator to pointer because the iterator was invalidated "
+                                     "(e.g. reallocation occurred, or the string was destroyed)");
+        }
+#endif // _ITERATOR_DEBUG_LEVEL >= 1
+
+        const auto _Rawptr = _STD to_address(_Iter._Ptr);
+
+#if _ITERATOR_DEBUG_LEVEL >= 1
+        if (_Mycont) {
+            const auto _Contptr = _Mycont->_Myptr();
+            _STL_VERIFY(_Contptr <= _Rawptr && _Rawptr <= _Contptr + _Mycont->_Mysize,
+                "cannot convert string iterator to pointer because it is out of range");
+        }
+#endif // _ITERATOR_DEBUG_LEVEL >= 1
+
+        return const_cast<element_type*>(_Rawptr);
+    }
+};
+#endif // _HAS_CXX20
 
 // basic_string TYPE WRAPPERS
 template <class _Value_type, class _Size_type, class _Difference_type, class _Pointer, class _Const_pointer,

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -2133,11 +2133,6 @@ namespace ranges {
 
         // clang-format off
         template <class _Ty>
-        concept _Can_begin = requires(_Ty&& __t) {
-            begin(static_cast<_Ty&&>(__t));
-        };
-
-        template <class _Ty>
         concept _Has_member = requires(_Ty& __t) {
             { _Fake_decay_copy(__t.end()) } -> sentinel_for<decltype(begin(__t))>;
         };
@@ -2155,18 +2150,16 @@ namespace ranges {
 
             template <class _Ty>
             _NODISCARD static _CONSTEVAL _Choice_t<_St> _Choose() noexcept {
-                if constexpr (_Can_begin<_Ty>) {
-                    constexpr bool _Is_lvalue = is_lvalue_reference_v<_Ty>;
+                constexpr bool _Is_lvalue = is_lvalue_reference_v<_Ty>;
 
-                    if constexpr (is_array_v<remove_reference_t<_Ty>>) {
-                        if constexpr (_Is_lvalue) {
-                            return {_St::_Array, true};
-                        }
-                    } else if constexpr (_Is_lvalue && _Has_member<_Ty>) {
-                        return {_St::_Member, noexcept(_Fake_decay_copy(_STD declval<_Ty>().end()))};
-                    } else if constexpr (_Has_ADL<_Ty>) {
-                        return {_St::_Non_member, noexcept(_Fake_decay_copy(end(_STD declval<_Ty>())))};
+                if constexpr (is_array_v<remove_reference_t<_Ty>>) {
+                    if constexpr (_Is_lvalue) {
+                        return {_St::_Array, true};
                     }
+                } else if constexpr (_Is_lvalue && _Has_member<_Ty>) {
+                    return {_St::_Member, noexcept(_Fake_decay_copy(_STD declval<_Ty>().end()))};
+                } else if constexpr (_Has_ADL<_Ty>) {
+                    return {_St::_Non_member, noexcept(_Fake_decay_copy(end(_STD declval<_Ty>())))};
                 }
 
                 return {_St::_None};
@@ -2756,6 +2749,9 @@ class _Array_const_iterator
 #endif // _ITERATOR_DEBUG_LEVEL != 0
 {
 public:
+#ifdef __cpp_lib_concepts
+    using iterator_concept = contiguous_iterator_tag;
+#endif // __cpp_lib_concepts
     using iterator_category = random_access_iterator_tag;
     using value_type        = _Ty;
     using difference_type   = ptrdiff_t;
@@ -3017,12 +3013,28 @@ _NODISCARD _CONSTEXPR17 _Array_const_iterator<_Ty, _Size> operator+(
     return _Next += _Off;
 }
 
+#if _HAS_CXX20
+template <class _Ty, size_t _Size>
+struct pointer_traits<_Array_const_iterator<_Ty, _Size>> {
+    using pointer         = _Array_const_iterator<_Ty, _Size>;
+    using element_type    = const _Ty;
+    using difference_type = ptrdiff_t;
+
+    _NODISCARD static constexpr element_type* to_address(const pointer _Iter) noexcept {
+        return _Iter._Unwrapped();
+    }
+};
+#endif // _HAS_CXX20
+
 // CLASS TEMPLATE _Array_iterator
 template <class _Ty, size_t _Size>
 class _Array_iterator : public _Array_const_iterator<_Ty, _Size> {
 public:
     using _Mybase = _Array_const_iterator<_Ty, _Size>;
 
+#ifdef __cpp_lib_concepts
+    using iterator_concept = contiguous_iterator_tag;
+#endif // __cpp_lib_concepts
     using iterator_category = random_access_iterator_tag;
     using value_type        = _Ty;
     using difference_type   = ptrdiff_t;
@@ -3102,6 +3114,19 @@ template <class _Ty, size_t _Size>
 _NODISCARD _CONSTEXPR17 _Array_iterator<_Ty, _Size> operator+(ptrdiff_t _Off, _Array_iterator<_Ty, _Size> _Next) {
     return _Next += _Off;
 }
+
+#if _HAS_CXX20
+template <class _Ty, size_t _Size>
+struct pointer_traits<_Array_iterator<_Ty, _Size>> {
+    using pointer         = _Array_iterator<_Ty, _Size>;
+    using element_type    = _Ty;
+    using difference_type = ptrdiff_t;
+
+    _NODISCARD static constexpr element_type* to_address(const pointer _Iter) noexcept {
+        return _Iter._Unwrapped();
+    }
+};
+#endif // _HAS_CXX20
 
 // STRUCT _Default_sentinel
 struct _Default_sentinel {}; // empty struct to serve as the end of a range


### PR DESCRIPTION
# Description

* `array`, `basic_string`, `basic_string_view`, `valarray`, and `vector` (`span` is not yet implemented) model `contiguous_range` by defining the nested type `iterator_concept` to `contiguous_iterator_tag` in `iterator` and `const_iterator`, and specializing `pointer_traits` for those types (to fulfill `contiguous_iterator`'s `std::to_address` requirement)

* `basic_string_view` (Ditto, no `span` yet) models the exposition-only *`forwarding-range`* concept (which indicates that the validity of iterators is not bound to the lifetime of the range) by defining hidden-friend overloads of `begin` and `end` that accept rvalues

* Drive-by:
  * mark the `_Unfancy` internal helper function `[[nodiscard]]`
  * Remove redundant `_Can_begin` requirement from `std::ranges::_Begin::_Cpo::_Choose`

* Add test coverage to `devcrt/P0896R4_ranges_range_machinery`:
  * tighten up `test_std_container`:
    * `data` and `cdata` reject rvalue arguments since the returned pointer could potentially dangle (`contiguous_range` codepaths were lacking coverage)
    * the `size_type` of a standard container can be other than `std::size_t` when using fancy pointers
    * we should enforce that each container's iterator type models the expected concept
  * Add test coverage to ensure that contiguous standard library containers model `contiguous_range` even when using an "old" fancy pointer type that does not model `contiguous_iterator`

# Checklist:

- [X] I understand README.md.
- [X] If this is a feature addition, that feature has been voted into the C++
  Working Draft.
- [x] Any code files edited have been processed by clang-format.
- [x] Identifiers in any product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 .
- [x] Identifiers in test code changes are *not* `_Ugly`.
- [x] Test code includes the correct headers as per the Standard, not just
  what happens to compile.
- [x] The STL builds and test harnesses have passed (must be manually verified
  by an STL maintainer before CI is online, leave this unchecked for initial
  submission).
- [x] This change introduces no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate or
  trivially copyable, etc.). If unsure, leave this box unchecked and ask a
  maintainer for help.

This is a replay of Microsoft-internal pull request [201813](https://devdiv.visualstudio.com/DevDiv/_git/msvc/pullrequest/201813).