### PR TITLE
Reflect directory structure of includes in ${PROJECT_BINARY_DIR}/out/inc

### DIFF
--- a/stl/CMakeLists.txt
+++ b/stl/CMakeLists.txt
@@ -229,8 +229,8 @@ set(HEADERS
 )
 
 foreach(header ${HEADERS})
-    get_filename_component(_header_name "${header}" NAME)
-    configure_file("${header}" "${PROJECT_BINARY_DIR}/out/inc/${_header_name}" COPYONLY)
+    file(RELATIVE_PATH _header_path "${CMAKE_CURRENT_LIST_DIR}/inc" "${header}")
+    configure_file("${header}" "${PROJECT_BINARY_DIR}/out/inc/${_header_path}" COPYONLY)
 endforeach()
 
 # Objs that exist in both libcpmt[d][01].lib and msvcprt[d].lib.


### PR DESCRIPTION
Configured headers were flattened during configuration. This patch
keep original directory structure.

For example without this for 'deque` is replaced by `experimental/deque`.

Please note that acceptance of community PRs will be delayed while we are
bringing our test and CI systems online. For more information, see the
README.md.

# Description
Configured headers were flattened during configuration rendering build broken
as some headers were replaced by counterparts in subdirectories.
For example without this for 'deque` is replaced by `experimental/deque`.

# Checklist:

- [x] I understand README.md.
- [ ] If this is a feature addition, that feature has been voted into the C++
  Working Draft.
- [ ] Any code files edited have been processed by clang-format.
- [ ] Identifiers in any product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 .
- [ ] Identifiers in test code changes are *not* `_Ugly`.
- [ ] Test code includes the correct headers as per the Standard, not just
  what happens to compile.
- [x] The STL builds and test harnesses have passed (must be manually verified
  by an STL maintainer before CI is online, leave this unchecked for initial
  submission).
- [x] This change introduces no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate or
  trivially copyable, etc.). If unsure, leave this box unchecked and ask a
  maintainer for help.

Note: This is change in CMakeLists.txt only, C++ code was not touched