### PR TITLE
Improve comment about begin overload in xstring

### DIFF
--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -1206,7 +1206,7 @@ public:
 
 #ifdef __cpp_lib_concepts
     _NODISCARD friend constexpr const_iterator begin(const basic_string_view& _Right) noexcept {
-        // non-member overload that accepts rvalues to model the exposition-only forwarding-range concept
+        // non-member overload to model the exposition-only forwarding-range concept
         return _Right.begin();
     }
     _NODISCARD friend constexpr const_iterator end(const basic_string_view& _Right) noexcept {


### PR DESCRIPTION
# Description
While the comment is technically correct, it is also surprising. By removing the mentioned rvalue reference it becomes clearer. (See #104)

# Checklist:

- [x] I understand README.md.
- [x] This change introduces no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate or
  trivially copyable, etc.). If unsure, leave this box unchecked and ask a
  maintainer for help.

I believe all other points do not really apply to comments
