### PR TITLE
Update workaround for DevCom#675827 in <type_traits>

### DIFF
--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -1347,11 +1347,11 @@ template <class _Ty1, class _Ty2, class = void>
 struct _Common_reference2A : _Common_reference2B<_Ty1, _Ty2> {};
 
 template <class _Ty1, class _Ty2, class _Result = _Cond_res<_Copy_cv<_Ty1, _Ty2>&, _Copy_cv<_Ty2, _Ty1>&>,
-#ifdef __EDG__ // TRANSITION, VSO#948614
+#ifdef __CUDACC__ // TRANSITION
     enable_if_t<is_lvalue_reference<_Result>::value, int> = 0>
 #else // ^^^ workaround / no workaround vvv
     enable_if_t<is_lvalue_reference_v<_Result>, int> = 0>
-#endif // TRANSITION, VSO#948614
+#endif // TRANSITION
 using _LL_common_ref = _Result;
 
 template <class _Ty1, class _Ty2>


### PR DESCRIPTION
# Description

[DevCom#675827](https://developercommunity.visualstudio.com/content/problem/675827/code-pattern-in-common-reference-kills-intellisens.html) has been fixed in the IntelliSense front end; make the workaround CUDA-only. 

[This is a replay of Microsoft-internal PR [202876](https://devdiv.visualstudio.com/DevDiv/_git/msvc/pullrequest/202876).]

# Checklist:

- [X] I understand README.md.
- [ ] If this is a feature addition, that feature has been voted into the C++
  Working Draft. **(N/A)**
- [X] Any code files edited have been processed by clang-format 8.0.1.
  (The version is important because clang-format's behavior sometimes changes.)
- [X] Identifiers in any product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 .
- [X] Identifiers in test code changes are *not* `_Ugly`.
- [X] Test code includes the correct headers as per the Standard, not just
  what happens to compile.
- [X] The STL builds and test harnesses have passed (must be manually verified
  by an STL maintainer before CI is online, leave this unchecked for initial
  submission).
- [X] This change introduces no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate or
  trivially copyable, etc.). If unsure, leave this box unchecked and ask a
  maintainer for help.
