### PR TITLE
P0439R0 enum class memory_order

### DIFF
--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -161,7 +161,11 @@ _Ty kill_dependency(_Ty _Arg) noexcept { // "magic" template that kills dependen
 // FUNCTION _Check_memory_order
 inline void _Check_memory_order(const memory_order _Order) noexcept {
     // check that _Order is a valid memory_order
+#if _HAS_CXX20
+    if (_Order > memory_order_seq_cst) {
+#else
     if (static_cast<unsigned int>(_Order) > memory_order_seq_cst) {
+#endif
         _INVALID_MEMORY_ORDER;
     }
 }
@@ -230,7 +234,11 @@ _NODISCARD inline memory_order _Combine_cas_memory_orders(
 
     _Check_memory_order(_Success);
     _Check_load_memory_order(_Failure);
+#if _HAS_CXX20
+    return _Combined_memory_orders[static_cast<unsigned int>(_Success)][static_cast<unsigned int>(_Failure)];
+#else
     return _Combined_memory_orders[_Success][_Failure];
+#endif
 }
 
 // FUNCTION TEMPLATE _Atomic_reinterpret_as

--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -161,11 +161,7 @@ _Ty kill_dependency(_Ty _Arg) noexcept { // "magic" template that kills dependen
 // FUNCTION _Check_memory_order
 inline void _Check_memory_order(const memory_order _Order) noexcept {
     // check that _Order is a valid memory_order
-#if _HAS_CXX20
-    if (_Order > memory_order_seq_cst) {
-#else
-    if (static_cast<unsigned int>(_Order) > memory_order_seq_cst) {
-#endif
+    if (static_cast<int>(_Order) > static_cast<int>(memory_order_seq_cst)) {
         _INVALID_MEMORY_ORDER;
     }
 }
@@ -234,7 +230,7 @@ _NODISCARD inline memory_order _Combine_cas_memory_orders(
 
     _Check_memory_order(_Success);
     _Check_load_memory_order(_Failure);
-    return _Combined_memory_orders[static_cast<unsigned int>(_Success)][static_cast<unsigned int>(_Failure)];
+    return _Combined_memory_orders[static_cast<int>(_Success)][static_cast<int>(_Failure)];
 }
 
 // FUNCTION TEMPLATE _Atomic_reinterpret_as

--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -234,11 +234,7 @@ _NODISCARD inline memory_order _Combine_cas_memory_orders(
 
     _Check_memory_order(_Success);
     _Check_load_memory_order(_Failure);
-#if _HAS_CXX20
     return _Combined_memory_orders[static_cast<unsigned int>(_Success)][static_cast<unsigned int>(_Failure)];
-#else
-    return _Combined_memory_orders[_Success][_Failure];
-#endif
 }
 
 // FUNCTION TEMPLATE _Atomic_reinterpret_as

--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -161,7 +161,7 @@ _Ty kill_dependency(_Ty _Arg) noexcept { // "magic" template that kills dependen
 // FUNCTION _Check_memory_order
 inline void _Check_memory_order(const memory_order _Order) noexcept {
     // check that _Order is a valid memory_order
-    if (static_cast<int>(_Order) > static_cast<int>(memory_order_seq_cst)) {
+    if (static_cast<unsigned int>(_Order) > static_cast<unsigned int>(memory_order_seq_cst)) {
         _INVALID_MEMORY_ORDER;
     }
 }

--- a/stl/inc/xatomic.h
+++ b/stl/inc/xatomic.h
@@ -55,15 +55,15 @@ _STL_DISABLE_CLANG_WARNINGS
 
 _STD_BEGIN
 
-//#if _HAS_CXX20
-//enum class memory_order : unsigned int { relaxed, consume, acquire, release, acq_rel, seq_cst };
-//inline constexpr memory_order memory_order_relaxed = memory_order::relaxed;
-//inline constexpr memory_order memory_order_consume = memory_order::consume;
-//inline constexpr memory_order memory_order_acquire = memory_order::acquire;
-//inline constexpr memory_order memory_order_release = memory_order::release;
-//inline constexpr memory_order memory_order_acq_rel = memory_order::acq_rel;
-//inline constexpr memory_order memory_order_seq_cst = memory_order::seq_cst;
-//#else
+#if _HAS_CXX20
+enum class memory_order : unsigned int { relaxed, consume, acquire, release, acq_rel, seq_cst };
+inline constexpr memory_order memory_order_relaxed = memory_order::relaxed;
+inline constexpr memory_order memory_order_consume = memory_order::consume;
+inline constexpr memory_order memory_order_acquire = memory_order::acquire;
+inline constexpr memory_order memory_order_release = memory_order::release;
+inline constexpr memory_order memory_order_acq_rel = memory_order::acq_rel;
+inline constexpr memory_order memory_order_seq_cst = memory_order::seq_cst;
+#else
 enum memory_order {
     memory_order_relaxed,
     memory_order_consume,

--- a/stl/inc/xatomic.h
+++ b/stl/inc/xatomic.h
@@ -55,6 +55,7 @@ _STL_DISABLE_CLANG_WARNINGS
 
 _STD_BEGIN
 
+// ENUM memory_order
 #if _HAS_CXX20
 enum class memory_order : unsigned int { relaxed, consume, acquire, release, acq_rel, seq_cst };
 inline constexpr memory_order memory_order_relaxed = memory_order::relaxed;

--- a/stl/inc/xatomic.h
+++ b/stl/inc/xatomic.h
@@ -57,14 +57,14 @@ _STD_BEGIN
 
 #if _HAS_CXX20
 // ENUM CLASS memory_order
-enum class memory_order : unsigned int { relaxed, consume, acquire, release, acq_rel, seq_cst };
+enum class memory_order : int { relaxed, consume, acquire, release, acq_rel, seq_cst };
 inline constexpr memory_order memory_order_relaxed = memory_order::relaxed;
 inline constexpr memory_order memory_order_consume = memory_order::consume;
 inline constexpr memory_order memory_order_acquire = memory_order::acquire;
 inline constexpr memory_order memory_order_release = memory_order::release;
 inline constexpr memory_order memory_order_acq_rel = memory_order::acq_rel;
 inline constexpr memory_order memory_order_seq_cst = memory_order::seq_cst;
-#else
+#else // _HAS_CXX20
 // ENUM memory_order
 enum memory_order {
     memory_order_relaxed,
@@ -74,7 +74,7 @@ enum memory_order {
     memory_order_acq_rel,
     memory_order_seq_cst
 };
-#endif
+#endif // _HAS_CXX20
 
 using _Atomic_counter_t = unsigned long;
 

--- a/stl/inc/xatomic.h
+++ b/stl/inc/xatomic.h
@@ -55,8 +55,8 @@ _STL_DISABLE_CLANG_WARNINGS
 
 _STD_BEGIN
 
-// ENUM memory_order
 #if _HAS_CXX20
+// ENUM CLASS memory_order
 enum class memory_order : unsigned int { relaxed, consume, acquire, release, acq_rel, seq_cst };
 inline constexpr memory_order memory_order_relaxed = memory_order::relaxed;
 inline constexpr memory_order memory_order_consume = memory_order::consume;
@@ -65,6 +65,7 @@ inline constexpr memory_order memory_order_release = memory_order::release;
 inline constexpr memory_order memory_order_acq_rel = memory_order::acq_rel;
 inline constexpr memory_order memory_order_seq_cst = memory_order::seq_cst;
 #else
+// ENUM memory_order
 enum memory_order {
     memory_order_relaxed,
     memory_order_consume,

--- a/stl/inc/xatomic.h
+++ b/stl/inc/xatomic.h
@@ -73,7 +73,7 @@ enum memory_order {
     memory_order_acq_rel,
     memory_order_seq_cst
 };
-//#endif
+#endif
 
 using _Atomic_counter_t = unsigned long;
 

--- a/stl/inc/xatomic.h
+++ b/stl/inc/xatomic.h
@@ -56,14 +56,13 @@ _STL_DISABLE_CLANG_WARNINGS
 _STD_BEGIN
 
 // ENUM memory_order
-enum memory_order {
-    memory_order_relaxed,
-    memory_order_consume,
-    memory_order_acquire,
-    memory_order_release,
-    memory_order_acq_rel,
-    memory_order_seq_cst
-};
+enum class memory_order { relaxed, consume, acquire, release, acq_rel, seq_cst };
+inline constexpr memory_order memory_order_relaxed = memory_order::relaxed;
+inline constexpr memory_order memory_order_consume = memory_order::consume;
+inline constexpr memory_order memory_order_acquire = memory_order::acquire;
+inline constexpr memory_order memory_order_release = memory_order::release;
+inline constexpr memory_order memory_order_acq_rel = memory_order::acq_rel;
+inline constexpr memory_order memory_order_seq_cst = memory_order::seq_cst;
 
 using _Atomic_counter_t = unsigned long;
 

--- a/stl/inc/xatomic.h
+++ b/stl/inc/xatomic.h
@@ -55,14 +55,24 @@ _STL_DISABLE_CLANG_WARNINGS
 
 _STD_BEGIN
 
-// ENUM memory_order
-enum class memory_order { relaxed, consume, acquire, release, acq_rel, seq_cst };
-inline constexpr memory_order memory_order_relaxed = memory_order::relaxed;
-inline constexpr memory_order memory_order_consume = memory_order::consume;
-inline constexpr memory_order memory_order_acquire = memory_order::acquire;
-inline constexpr memory_order memory_order_release = memory_order::release;
-inline constexpr memory_order memory_order_acq_rel = memory_order::acq_rel;
-inline constexpr memory_order memory_order_seq_cst = memory_order::seq_cst;
+//#if _HAS_CXX20
+//enum class memory_order : unsigned int { relaxed, consume, acquire, release, acq_rel, seq_cst };
+//inline constexpr memory_order memory_order_relaxed = memory_order::relaxed;
+//inline constexpr memory_order memory_order_consume = memory_order::consume;
+//inline constexpr memory_order memory_order_acquire = memory_order::acquire;
+//inline constexpr memory_order memory_order_release = memory_order::release;
+//inline constexpr memory_order memory_order_acq_rel = memory_order::acq_rel;
+//inline constexpr memory_order memory_order_seq_cst = memory_order::seq_cst;
+//#else
+enum memory_order {
+    memory_order_relaxed,
+    memory_order_consume,
+    memory_order_acquire,
+    memory_order_release,
+    memory_order_acq_rel,
+    memory_order_seq_cst
+};
+//#endif
 
 using _Atomic_counter_t = unsigned long;
 

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -22,6 +22,7 @@
 // P0020R6 atomic<float>, atomic<double>, atomic<long double>
 // P0318R1 unwrap_reference, unwrap_ref_decay
 // P0325R4 to_array()
+// P0439R0 enum class memory_order
 // P0457R2 starts_with()/ends_with() For basic_string/basic_string_view
 // P0458R2 contains() For Ordered And Unordered Associative Containers
 // P0463R1 endian


### PR DESCRIPTION
# Description

This PR implements #17.  `memory_order` becomes an `enum class` in cxx20.

# Checklist:

- [x] I understand README.md. 
- [x] If this is a feature addition, that feature has been voted into the C++
  Working Draft.
- [x] Identifiers in any product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 .
- [x] The STL builds and test harnesses have passed (must be manually verified
  by an STL maintainer before CI is online, leave this unchecked for initial
  submission). (Internal PR [204684](https://devdiv.visualstudio.com/DevDiv/_git/msvc/pullrequest/204684))
- [x] This change introduces no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate or
  trivially copyable, etc.). If unsure, leave this box unchecked and ask a
  maintainer for help.
