### PR TITLE
Support: <coroutine>

### DIFF
--- a/stl/CMakeLists.txt
+++ b/stl/CMakeLists.txt
@@ -22,6 +22,7 @@ set(HEADERS
     ${CMAKE_CURRENT_LIST_DIR}/inc/clocale
     ${CMAKE_CURRENT_LIST_DIR}/inc/cmath
     ${CMAKE_CURRENT_LIST_DIR}/inc/codecvt
+    ${CMAKE_CURRENT_LIST_DIR}/inc/coroutine
     ${CMAKE_CURRENT_LIST_DIR}/inc/compare
     ${CMAKE_CURRENT_LIST_DIR}/inc/complex
     ${CMAKE_CURRENT_LIST_DIR}/inc/concepts

--- a/stl/CMakeLists.txt
+++ b/stl/CMakeLists.txt
@@ -262,6 +262,7 @@ set(SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/src/clog.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/cond.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/cout.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/coroutine.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/cthread.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/filesys.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/fiopen.cpp

--- a/stl/inc/coroutine
+++ b/stl/inc/coroutine
@@ -24,149 +24,154 @@
 #include <cstdint>
 #include <type_traits>
 
-struct _portable_coro_prefix;
+struct _Portable_coro_prefix;
 
-_CRTIMP2_IMPORT bool _portable_coro_done(_portable_coro_prefix* handle);
-_CRTIMP2_IMPORT void _portable_coro_resume(_portable_coro_prefix* handle);
-_CRTIMP2_IMPORT void _portable_coro_destroy(_portable_coro_prefix* handle);
+_CRTIMP2_IMPORT bool _Portable_coro_done(_Portable_coro_prefix* _Handle);
+_CRTIMP2_IMPORT void _Portable_coro_resume(_Portable_coro_prefix* _Handle);
+_CRTIMP2_IMPORT void _Portable_coro_destroy(_Portable_coro_prefix* _Handle);
 
-_CRTIMP2_IMPORT _portable_coro_prefix* _portable_coro_from_promise(void* promise, ptrdiff_t shift);
-_CRTIMP2_IMPORT void* _portable_coro_get_promise(_portable_coro_prefix* handle, ptrdiff_t shift);
-
-constexpr auto align_req_v = sizeof(void*) * 2;
-template <typename P>
-constexpr auto aligned_size_v = // replaces _ALIGNED_SIZE in <experimental/resumable>
-    std::is_empty_v<P> ? 0 : ((sizeof(P) + align_req_v - 1u) & ~(align_req_v - 1u));
+_CRTIMP2_IMPORT _Portable_coro_prefix* _Portable_coro_from_promise(void* _PromAddr, ptrdiff_t _PromSize);
+_CRTIMP2_IMPORT void* _Portable_coro_get_promise(_Portable_coro_prefix* _Handle, ptrdiff_t _PromSize);
 
 _STD_BEGIN
 
+// 17.12.3, coroutine handle
+template <typename _PromiseT = void>
+struct coroutine_handle;
 
-template <typename PromiseType = void>
-class coroutine_handle;
-
+// STRUCT TEMPLATE coroutine_handle
 template <>
-class coroutine_handle<void> {
-protected:
-    _portable_coro_prefix* handle;
+struct coroutine_handle<void> {
+    // 17.12.3.1, construct
+    coroutine_handle() noexcept = default;
 
-public:
-    coroutine_handle() noexcept                        = default;
-    ~coroutine_handle() noexcept                       = default;
-    coroutine_handle(coroutine_handle const&) noexcept = default;
-    coroutine_handle(coroutine_handle&& rhs) noexcept  = default;
-    coroutine_handle& operator=(coroutine_handle const&) noexcept = default;
-    coroutine_handle& operator=(coroutine_handle&& rhs) noexcept = default;
-
-    explicit coroutine_handle(std::nullptr_t) noexcept : handle{nullptr} {}
+    // 17.12.3.1, reset
+    coroutine_handle(std::nullptr_t) noexcept : _Ptr{nullptr} {}
     coroutine_handle& operator=(nullptr_t) noexcept {
-        handle = nullptr;
+        _Ptr = nullptr;
         return *this;
     }
 
+    // 17.12.3.3, observers
     explicit operator bool() const noexcept {
-        return handle != nullptr;
+        return _Ptr != nullptr;
+    }
+    bool done() const noexcept {
+        return _Portable_coro_done(_Ptr);
+    }
+
+    // 17.12.3.4, resumption
+    void resume() noexcept(false) {
+        return _Portable_coro_resume(_Ptr);
     }
     void operator()() noexcept(false) {
-        return _portable_coro_resume(handle);
-    }
-
-    bool done() const noexcept {
-        return _portable_coro_done(handle);
-    }
-    void resume() noexcept(false) {
-        return _portable_coro_resume(handle);
+        return _Portable_coro_resume(_Ptr);
     }
     void destroy() noexcept {
-        return _portable_coro_destroy(handle);
+        return _Portable_coro_destroy(_Ptr);
     }
 
-public:
+    // 17.12.3.2, export
     void* address() const noexcept {
-        return handle;
+        return _Ptr;
+    }
+    // 17.12.3.2, import
+    static coroutine_handle from_address(void* _Addr) noexcept {
+        coroutine_handle _Result{};
+        _Result._Ptr = reinterpret_cast<_Portable_coro_prefix*>(_Addr);
+        return _Result;
     }
 
-    static coroutine_handle from_address(void* addr) noexcept {
-        coroutine_handle coro{};
-        coro.handle = reinterpret_cast<_portable_coro_prefix*>(addr);
-        return coro;
-    }
+private:
+    _Portable_coro_prefix* _Ptr = nullptr;
 };
 
-template <typename PromiseType>
-class coroutine_handle : public coroutine_handle<void> {
-public:
-    using promise_type = PromiseType;
-
-public:
+template <typename _PromiseT>
+struct coroutine_handle : public coroutine_handle<void> {
+    // 17.12.3.1, construct
     using coroutine_handle<void>::coroutine_handle;
-
+    // 17.12.3.1, reset
     coroutine_handle& operator=(nullptr_t) noexcept {
-        this->handle = nullptr;
+        this->_Ptr = nullptr;
         return *this;
     }
-    auto promise() const noexcept -> const promise_type& {
-        auto ptr        = _portable_coro_get_promise(handle, aligned_size_v<promise_type>);
-        promise_type* p = reinterpret_cast<promise_type*>(ptr);
-        return *p;
-    }
-    auto promise() noexcept -> promise_type& {
-        auto ptr        = _portable_coro_get_promise(handle, aligned_size_v<promise_type>);
-        promise_type* p = reinterpret_cast<promise_type*>(ptr);
-        return *p;
+
+    // 17.12.3.5, promise access
+    _PromiseT& promise() const noexcept {
+        void* _Addr      = _Portable_coro_get_promise(this->_Ptr, sizeof(_PromiseT));
+        _PromiseT* _Prom = reinterpret_cast<_PromiseT*>(_Addr);
+        return *_Prom;
     }
 
-public:
-    static coroutine_handle from_address(void* addr) noexcept {
-        coroutine_handle coro{};
-        coro.handle = reinterpret_cast<_portable_coro_prefix*>(addr);
-        return coro;
+    // 17.12.3.2, import
+    static coroutine_handle from_address(void* _Addr) noexcept {
+        coroutine_handle _Result{};
+        _Result._Ptr = reinterpret_cast<_Portable_coro_prefix*>(_Addr);
+        return _Result;
     }
-    static coroutine_handle from_promise(promise_type& promise) noexcept {
-        auto handle = _portable_coro_from_promise(&promise, sizeof(promise_type));
-        return coroutine_handle::from_address(handle);
+
+    // 17.12.3.1, construct
+    static coroutine_handle from_promise(_PromiseT& _Prom) noexcept {
+        auto* _Addr = _Portable_coro_from_promise(&_Prom, sizeof(_PromiseT));
+        return coroutine_handle::from_address(_Addr);
     }
 };
-static_assert(sizeof(coroutine_handle<void>) == sizeof(void*));
 
-inline bool operator==(const coroutine_handle<void> lhs, const coroutine_handle<void> rhs) noexcept {
-    return lhs.address() == rhs.address();
+// 17.12.3.6, comparison operators
+// C3615: cannot result in a constant expression
+
+inline /*constexpr*/ bool operator==(const coroutine_handle<void> _Left, const coroutine_handle<void> _Right) noexcept {
+    return _Left.address() == _Right.address();
 }
-inline bool operator!=(const coroutine_handle<void> lhs, const coroutine_handle<void> rhs) noexcept {
-    return !(lhs == rhs);
+inline /*constexpr*/ bool operator!=(const coroutine_handle<void> _Left, const coroutine_handle<void> _Right) noexcept {
+    return !(_Left == _Right);
 }
-inline bool operator<(const coroutine_handle<void> lhs, const coroutine_handle<void> rhs) noexcept {
-    return lhs.address() < rhs.address();
+inline /*constexpr*/ bool operator<(const coroutine_handle<void> _Left, const coroutine_handle<void> _Right) noexcept {
+    return _Left.address() < _Right.address();
 }
-inline bool operator>(const coroutine_handle<void> lhs, const coroutine_handle<void> rhs) noexcept {
-    return !(lhs < rhs);
+inline /*constexpr*/ bool operator>(const coroutine_handle<void> _Left, const coroutine_handle<void> _Right) noexcept {
+    return _Right < _Left;
 }
-inline bool operator<=(const coroutine_handle<void> lhs, const coroutine_handle<void> rhs) noexcept {
-    return !(lhs > rhs);
+inline /*constexpr*/ bool operator<=(const coroutine_handle<void> _Left, const coroutine_handle<void> _Right) noexcept {
+    return !(_Left > _Right);
 }
-inline bool operator>=(const coroutine_handle<void> lhs, const coroutine_handle<void> rhs) noexcept {
-    return !(lhs < rhs);
+inline /*constexpr*/ bool operator>=(const coroutine_handle<void> _Left, const coroutine_handle<void> _Right) noexcept {
+    return !(_Left < _Right);
 }
 
+template <class T>
+struct hash;
+
+// 17.12.3.7, hash support
+template <class _PromiseT>
+struct hash<coroutine_handle<_PromiseT>> {
+    // deprecated in C++17
+    using argument_type = coroutine_handle<_PromiseT>;
+    // deprecated in C++17
+    using result_type = size_t;
+
+    _NODISCARD result_type operator()(argument_type const& _Handle) const noexcept {
+        return hash<void*>()(_Handle.address());
+    }
+};
+
+// 17.12.4, no-op coroutines
 struct noop_coroutine_promise {};
 
 template <>
-class coroutine_handle<noop_coroutine_promise> : public coroutine_handle<void> {
-public:
-    coroutine_handle() noexcept : coroutine_handle<void>{} {
-        auto& p      = this->promise();
-        this->handle = reinterpret_cast<_portable_coro_prefix*>(&p);
-    }
+struct coroutine_handle<noop_coroutine_promise> : public coroutine_handle<void> {
 
-public:
+    // 17.12.4.2.1, observers
     constexpr explicit operator bool() const noexcept {
         return true;
     }
-    constexpr void operator()() const noexcept {
-        return;
-    }
-
     constexpr bool done() const noexcept {
         return false;
+    }
+
+    // 17.12.4.2.2, resumption
+    constexpr void operator()() const noexcept {
+        return;
     }
     constexpr void resume() const noexcept {
         return;
@@ -175,32 +180,45 @@ public:
         return;
     }
 
+    // 17.12.4.2.3, promise access
     noop_coroutine_promise& promise() const noexcept {
-        static noop_coroutine_promise p{};
-        return p;
+        static noop_coroutine_promise _Prom{};
+        return _Prom;
     }
+
+    // 17.12.4.2.4, address
+    // A noop_coroutine_handle's ptr is always a non-null pointer value
+    coroutine_handle() noexcept : coroutine_handle<void>{from_address(&this->promise())} {}
+
+    // C3615: cannot result in a constant expression
+    // constexpr void* address() const noexcept;
 };
 
+// STRUCT noop_coroutine_handle
 using noop_coroutine_handle = coroutine_handle<noop_coroutine_promise>;
 
 _CRTDATA2_IMPORT noop_coroutine_handle noop_coroutine() noexcept;
 
+// 17.12.5, trivial awaitables
+
+// STRUCT suspend_never
 class suspend_never {
 public:
     constexpr bool await_ready() const noexcept {
         return true;
     }
     constexpr void await_resume() const noexcept {}
-    void await_suspend(coroutine_handle<void>) const noexcept {}
+    constexpr void await_suspend(coroutine_handle<void>) const noexcept {}
 };
 
+// STRUCT suspend_always
 class suspend_always {
 public:
     constexpr bool await_ready() const noexcept {
         return false;
     }
     constexpr void await_resume() const noexcept {}
-    void await_suspend(coroutine_handle<void>) const noexcept {}
+    constexpr void await_suspend(coroutine_handle<void>) const noexcept {}
 };
 
 namespace experimental {
@@ -216,8 +234,8 @@ namespace experimental {
     template <typename _Ret, typename... _Ts>
     struct coroutine_traits : _Coroutine_traits_sfinae<_Ret> {};
 
-    // _Resumable_helper_traits class isolates front-end from public surface
-    // naming changes
+    // _Resumable_helper_traits class isolates front-end from public surface naming changes
+
     template <typename _Ret, typename... _Ts>
     struct _Resumable_helper_traits {
         using _Traits      = coroutine_traits<_Ret, _Ts...>;
@@ -252,6 +270,9 @@ namespace experimental {
 
 } // namespace experimental
 
+// 17.12.2, coroutine traits
+
+// STRUCT TEMPLATE coroutine_traits
 template <typename R, typename... _Ts>
 using coroutine_traits = experimental::coroutine_traits<R, _Ts...>;
 

--- a/stl/inc/coroutine
+++ b/stl/inc/coroutine
@@ -1,0 +1,260 @@
+// coroutine standard header
+
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Library Support For Coroutines, https://wg21.link/P0912R5
+
+#pragma once
+#ifndef _COROUTINE_
+#define _COROUTINE_
+#define _EXPERIMENTAL_RESUMABLE_
+
+#include <yvals_core.h>
+
+#if _STL_COMPILER_PREPROCESSOR
+#include <memory>
+#include <new>
+#if _HAS_EXCEPTIONS
+#include <exception>
+#endif // _HAS_EXCEPTIONS
+#endif // _STL_COMPILER_PREPROCESSOR
+
+#include <cstddef>
+#include <cstdint>
+#include <type_traits>
+
+struct _portable_coro_prefix;
+
+_CRTIMP2_IMPORT bool _portable_coro_done(_portable_coro_prefix* handle);
+_CRTIMP2_IMPORT void _portable_coro_resume(_portable_coro_prefix* handle);
+_CRTIMP2_IMPORT void _portable_coro_destroy(_portable_coro_prefix* handle);
+
+_CRTIMP2_IMPORT _portable_coro_prefix* _portable_coro_from_promise(void* promise, ptrdiff_t shift);
+_CRTIMP2_IMPORT void* _portable_coro_get_promise(_portable_coro_prefix* handle, ptrdiff_t shift);
+
+constexpr auto align_req_v = sizeof(void*) * 2;
+template <typename P>
+constexpr auto aligned_size_v = // replaces _ALIGNED_SIZE in <experimental/resumable>
+    std::is_empty_v<P> ? 0 : ((sizeof(P) + align_req_v - 1u) & ~(align_req_v - 1u));
+
+_STD_BEGIN
+
+
+template <typename PromiseType = void>
+class coroutine_handle;
+
+template <>
+class coroutine_handle<void> {
+protected:
+    _portable_coro_prefix* handle;
+
+public:
+    coroutine_handle() noexcept                        = default;
+    ~coroutine_handle() noexcept                       = default;
+    coroutine_handle(coroutine_handle const&) noexcept = default;
+    coroutine_handle(coroutine_handle&& rhs) noexcept  = default;
+    coroutine_handle& operator=(coroutine_handle const&) noexcept = default;
+    coroutine_handle& operator=(coroutine_handle&& rhs) noexcept = default;
+
+    explicit coroutine_handle(std::nullptr_t) noexcept : handle{nullptr} {}
+    coroutine_handle& operator=(nullptr_t) noexcept {
+        handle = nullptr;
+        return *this;
+    }
+
+    explicit operator bool() const noexcept {
+        return handle != nullptr;
+    }
+    void operator()() noexcept(false) {
+        return _portable_coro_resume(handle);
+    }
+
+    bool done() const noexcept {
+        return _portable_coro_done(handle);
+    }
+    void resume() noexcept(false) {
+        return _portable_coro_resume(handle);
+    }
+    void destroy() noexcept {
+        return _portable_coro_destroy(handle);
+    }
+
+public:
+    void* address() const noexcept {
+        return handle;
+    }
+
+    static coroutine_handle from_address(void* addr) noexcept {
+        coroutine_handle coro{};
+        coro.handle = reinterpret_cast<_portable_coro_prefix*>(addr);
+        return coro;
+    }
+};
+
+template <typename PromiseType>
+class coroutine_handle : public coroutine_handle<void> {
+public:
+    using promise_type = PromiseType;
+
+public:
+    using coroutine_handle<void>::coroutine_handle;
+
+    coroutine_handle& operator=(nullptr_t) noexcept {
+        this->handle = nullptr;
+        return *this;
+    }
+    auto promise() const noexcept -> const promise_type& {
+        auto ptr        = _portable_coro_get_promise(handle, aligned_size_v<promise_type>);
+        promise_type* p = reinterpret_cast<promise_type*>(ptr);
+        return *p;
+    }
+    auto promise() noexcept -> promise_type& {
+        auto ptr        = _portable_coro_get_promise(handle, aligned_size_v<promise_type>);
+        promise_type* p = reinterpret_cast<promise_type*>(ptr);
+        return *p;
+    }
+
+public:
+    static coroutine_handle from_address(void* addr) noexcept {
+        coroutine_handle coro{};
+        coro.handle = reinterpret_cast<_portable_coro_prefix*>(addr);
+        return coro;
+    }
+    static coroutine_handle from_promise(promise_type& promise) noexcept {
+        auto handle = _portable_coro_from_promise(&promise, sizeof(promise_type));
+        return coroutine_handle::from_address(handle);
+    }
+};
+static_assert(sizeof(coroutine_handle<void>) == sizeof(void*));
+
+inline bool operator==(const coroutine_handle<void> lhs, const coroutine_handle<void> rhs) noexcept {
+    return lhs.address() == rhs.address();
+}
+inline bool operator!=(const coroutine_handle<void> lhs, const coroutine_handle<void> rhs) noexcept {
+    return !(lhs == rhs);
+}
+inline bool operator<(const coroutine_handle<void> lhs, const coroutine_handle<void> rhs) noexcept {
+    return lhs.address() < rhs.address();
+}
+inline bool operator>(const coroutine_handle<void> lhs, const coroutine_handle<void> rhs) noexcept {
+    return !(lhs < rhs);
+}
+inline bool operator<=(const coroutine_handle<void> lhs, const coroutine_handle<void> rhs) noexcept {
+    return !(lhs > rhs);
+}
+inline bool operator>=(const coroutine_handle<void> lhs, const coroutine_handle<void> rhs) noexcept {
+    return !(lhs < rhs);
+}
+
+struct noop_coroutine_promise {};
+
+template <>
+class coroutine_handle<noop_coroutine_promise> : public coroutine_handle<void> {
+public:
+    coroutine_handle() noexcept : coroutine_handle<void>{} {
+        auto& p      = this->promise();
+        this->handle = reinterpret_cast<_portable_coro_prefix*>(&p);
+    }
+
+public:
+    constexpr explicit operator bool() const noexcept {
+        return true;
+    }
+    constexpr void operator()() const noexcept {
+        return;
+    }
+
+    constexpr bool done() const noexcept {
+        return false;
+    }
+    constexpr void resume() const noexcept {
+        return;
+    }
+    constexpr void destroy() const noexcept {
+        return;
+    }
+
+    noop_coroutine_promise& promise() const noexcept {
+        static noop_coroutine_promise p{};
+        return p;
+    }
+};
+
+using noop_coroutine_handle = coroutine_handle<noop_coroutine_promise>;
+
+_CRTDATA2_IMPORT noop_coroutine_handle noop_coroutine() noexcept;
+
+class suspend_never {
+public:
+    constexpr bool await_ready() const noexcept {
+        return true;
+    }
+    constexpr void await_resume() const noexcept {}
+    void await_suspend(coroutine_handle<void>) const noexcept {}
+};
+
+class suspend_always {
+public:
+    constexpr bool await_ready() const noexcept {
+        return false;
+    }
+    constexpr void await_resume() const noexcept {}
+    void await_suspend(coroutine_handle<void>) const noexcept {}
+};
+
+namespace experimental {
+
+    template <class _Ret, class = void>
+    struct _Coroutine_traits_sfinae {};
+
+    template <class _Ret>
+    struct _Coroutine_traits_sfinae<_Ret, void_t<typename _Ret::promise_type>> {
+        using promise_type = typename _Ret::promise_type;
+    };
+
+    template <typename _Ret, typename... _Ts>
+    struct coroutine_traits : _Coroutine_traits_sfinae<_Ret> {};
+
+    // _Resumable_helper_traits class isolates front-end from public surface
+    // naming changes
+    template <typename _Ret, typename... _Ts>
+    struct _Resumable_helper_traits {
+        using _Traits      = coroutine_traits<_Ret, _Ts...>;
+        using _PromiseT    = typename _Traits::promise_type;
+        using _Handle_type = coroutine_handle<_PromiseT>;
+
+        static _PromiseT* _Promise_from_frame(void* _Addr) noexcept {
+            auto& prom = _Handle_type::from_address(_Addr).promise();
+            return &prom;
+        }
+
+        static _Handle_type _Handle_from_frame(void* _Addr) noexcept {
+            return _Handle_type::from_promise(*_Promise_from_frame(_Addr));
+        }
+
+        static void _Set_exception(void* _Addr) {
+            _Promise_from_frame(_Addr)->set_exception(_STD current_exception());
+        }
+
+        static void _ConstructPromise(void* _Addr, void* _Resume_addr, int _HeapElision) {
+            *reinterpret_cast<void**>(_Addr) = _Resume_addr;
+            *reinterpret_cast<uint32_t*>(reinterpret_cast<uintptr_t>(_Addr) + sizeof(void*)) =
+                2u + (_HeapElision ? 0u : 0x10000u);
+            auto _Prom = _Promise_from_frame(_Addr);
+            ::new (static_cast<void*>(_Prom)) _PromiseT();
+        }
+
+        static void _DestructPromise(void* _Addr) {
+            _Promise_from_frame(_Addr)->~_PromiseT();
+        }
+    };
+
+} // namespace experimental
+
+template <typename R, typename... _Ts>
+using coroutine_traits = experimental::coroutine_traits<R, _Ts...>;
+
+_STD_END
+
+#endif // _COROUTINE_

--- a/stl/src/coroutine.cpp
+++ b/stl/src/coroutine.cpp
@@ -1,0 +1,159 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// coroutine functions
+
+#include <coroutine>
+
+//#include <experimental/generator>
+#include <experimental/resumable>
+
+_STD_BEGIN
+
+_CRTIMP2_IMPORT noop_coroutine_handle noop_coroutine() noexcept {
+    return {};
+}
+
+_STD_END
+
+using procedure_t = void(__cdecl*)(void*);
+
+struct clang_frame_prefix {
+    procedure_t factivate;
+    procedure_t fdestroy;
+};
+static_assert(aligned_size_v<clang_frame_prefix> == 16);
+
+struct msvc_frame_prefix {
+    procedure_t factivate;
+    uint16_t index;
+    uint16_t flag;
+};
+static_assert(aligned_size_v<msvc_frame_prefix> == 16);
+
+extern "C" size_t _coro_resume(void*);
+extern "C" void _coro_destroy(void*);
+// extern "C" size_t _coro_done(void*);
+bool _coro_finished(const msvc_frame_prefix*) noexcept; // replacement of the `_coro_done`
+
+extern "C" bool __builtin_coro_done(void*);
+extern "C" void __builtin_coro_resume(void*);
+extern "C" void __builtin_coro_destroy(void*);
+// void* __builtin_coro_promise(void* ptr, int align, bool p);
+
+#if defined(__clang__)
+static constexpr auto is_clang = true;
+static constexpr auto is_msvc  = !is_clang;
+static constexpr auto is_gcc   = !is_clang;
+
+struct _portable_coro_prefix final : public clang_frame_prefix {};
+
+#elif defined(_MSC_VER)
+static constexpr auto is_msvc  = true;
+static constexpr auto is_clang = !is_msvc;
+static constexpr auto is_gcc   = !is_msvc;
+
+struct _portable_coro_prefix final : public msvc_frame_prefix {};
+
+#endif // __clang__ || _MSC_VER
+
+_CRTIMP2_IMPORT
+bool _portable_coro_done(_portable_coro_prefix* handle) {
+    if constexpr (is_msvc) {
+        return _coro_finished(handle);
+    } else if constexpr (is_clang) {
+        return __builtin_coro_done(handle);
+    } else {
+        return false; // follow `noop_coroutine`
+    }
+}
+
+_CRTIMP2_IMPORT
+void _portable_coro_resume(_portable_coro_prefix* handle) {
+    if constexpr (is_msvc) {
+        _coro_resume(handle);
+    } else if constexpr (is_clang) {
+        __builtin_coro_resume(handle);
+    }
+}
+
+_CRTIMP2_IMPORT
+void _portable_coro_destroy(_portable_coro_prefix* handle) {
+    if constexpr (is_msvc) {
+        _coro_destroy(handle);
+    } else if constexpr (is_clang) {
+        __builtin_coro_destroy(handle);
+    }
+}
+
+_CRTIMP2_IMPORT
+_portable_coro_prefix* _portable_coro_from_promise(void* promise, ptrdiff_t psize) {
+    // calculate the frame prefix's location with the promise object
+    if constexpr (is_clang) {
+        auto* handle = reinterpret_cast<std::byte*>(promise) - psize;
+        return reinterpret_cast<_portable_coro_prefix*>(handle);
+    } else if constexpr (is_msvc) {
+        auto* handle = reinterpret_cast<std::byte*>(promise) + psize;
+        return reinterpret_cast<_portable_coro_prefix*>(handle);
+    } else {
+        // !!! dangerous !!!
+        return nullptr;
+    }
+}
+
+_CRTIMP2_IMPORT
+void* _portable_coro_get_promise(_portable_coro_prefix* handle, ptrdiff_t psize) {
+    // calculate the promise object's location with the frame's prefix
+    if constexpr (is_clang) {
+        // for clang, promise is placed just after frame prefix
+        // see also: `__builtin_coro_promise`
+        auto* promise = reinterpret_cast<std::byte*>(handle) + psize;
+        return promise;
+    } else if constexpr (is_msvc) {
+        // for msvc, promise is placed before frame prefix
+        auto* promise = reinterpret_cast<std::byte*>(handle) - psize;
+        return promise;
+    } else {
+        // !!! dangerous !!!
+        return nullptr;
+    }
+}
+
+#if defined(__clang__)
+//
+//  Note
+//      VC++ header expects msvc intrinsics. Redirect them to Clang intrinsics.
+//      If the project uses libc++ header files, this code won't be a problem
+//      because they wont't be used
+//  Reference
+//      https://clang.llvm.org/docs/LanguageExtensions.html#c-coroutines-support-builtins
+//      https://llvm.org/docs/Coroutines.html#example
+//
+
+bool _coro_finished(const msvc_frame_prefix* m) noexcept {
+    // expect: coroutine == suspended
+    // expect: coroutine != destroyed
+    auto* c = reinterpret_cast<const clang_frame_prefix*>(m);
+    return __builtin_coro_done(const_cast<clang_frame_prefix*>(c));
+}
+
+size_t _coro_resume(void* addr) {
+    auto* c = reinterpret_cast<clang_frame_prefix*>(addr);
+    __builtin_coro_resume(c);
+    return 0;
+}
+
+void _coro_destroy(void* addr) {
+    auto* c = reinterpret_cast<clang_frame_prefix*>(addr);
+    __builtin_coro_destroy(c);
+}
+
+#elif defined(_MSC_VER)
+
+bool _coro_finished(const msvc_frame_prefix* prefix) noexcept {
+    // expect: coroutine == suspended
+    // expect: coroutine != destroyed
+    return prefix->index == 0;
+}
+
+#endif // __clang__ || _MSC_VER


### PR DESCRIPTION
## Summary

This PR contains the change of following parts.

1. Language Support Library: `<coroutine>`
1. Implementation code for the header

This PR should remain unmerged until the test becomes available. 

### Related Document

* N4830
    * Section: 17.12

### Related Issues

* #40 P0912R5 Library Support For Coroutines
* #100 

## Details

### Background with the `<experimental/coroutine>`

The previous implementation of `<experimental/coroutine>` exported MSVC's intrinsics. And the file of the [llvm-mirror/libcxx](https://github.com/llvm-mirror/libcxx) either exported Clang's intrinsics.
Under the situation, Clang-cl couldn't build with MS-STL's `<experimental/coroutine>` since it used MSVC's intrinsics. 

For the reason, to support compiler-independent `coroutine_handle<P>`, the user had to **override** those implementations.
One of the examples is [this file](https://github.com/luncliff/coroutine/blob/master/interface/coroutine/frame.h#L6).
It checks the compiler in a specific condition and selects the compilers' intrinsic using `constexpr if`.

### Suggestion of the PR

* Mock intrinsics
* Address of the promise object
* `noop_coroutine_handle`
* `std::hash<K>`
* `experimental::_Resumable_helper_traits`

#### Mock intrinsics

Considering the comment about translation unit in #40, we can consider providing some intrinsic-like functions in `<coroutine>`. By doing so the future update can replace those to real compiler intrinsic when Clang and MSVC reaches a consensus of ABI.

https://github.com/microsoft/STL/blob/a1bd94a130041d1c4c1dde3a319b007199426e74/stl/inc/coroutine#L26-L35

#### Address of the promise object

However, unlike the usage of `__builtin_coro_promise` in libcxx, it uses `sizeof`. 

https://github.com/microsoft/STL/blob/a1bd94a130041d1c4c1dde3a319b007199426e74/stl/inc/coroutine#L99-L117

The reason is simply that `__alignof` can be considered as ABI dependent usage. Like the case of the `<experimental/resumable>` which used `_ALIGNED_SIZE`. 

https://github.com/microsoft/STL/blob/a1bd94a130041d1c4c1dde3a319b007199426e74/stl/src/coroutine.cpp#L20-L26

The library performs the adjustment under the interface.

##### Promise to Handle

https://github.com/microsoft/STL/blob/a1bd94a130041d1c4c1dde3a319b007199426e74/stl/src/coroutine.cpp#L116-L128

##### Handle to Promise

https://github.com/microsoft/STL/blob/a1bd94a130041d1c4c1dde3a319b007199426e74/stl/src/coroutine.cpp#L99-L114

Those interface functions perform address calculation based on the known frame layout. 
The above part **are expected** to be changed after testing. Of course, it will use `__builtin_coro_promise`.
I'd like to receive a review for the approach.

#### Support: `noop_coroutine_handle`

Since Clang already embedded `__builtin_coro_noop`, the possible way is to use `if defined(__clang__)` and use the function whenever possible.

https://github.com/llvm-mirror/libcxx/blob/release_90/include/experimental/coroutine#L288-L290

For now, in this PR, the header doesn't check for it since **the policy for MSVC** need to be defined first.  

> This part will be updated when build with Clang-cl becomes available. I'm dealing with the recently shipped LLVM 9.0 packages in Chocolatey.

#### Support: `std::hash<K>`

The `hash` implementation just like that of the libc++.

https://github.com/llvm-mirror/libcxx/blob/release_90/include/experimental/coroutine#L323-L329

#### `experimental::_Resumable_helper_traits` still remained

MSVC still requires `std::experimental::_Resumable_helper_traits`. 
So, for `coroutine_traits<R, P...>`, there is no way but to use it again.

https://github.com/microsoft/STL/blob/a1bd94a130041d1c4c1dde3a319b007199426e74/stl/inc/coroutine#L273-L278

## Checklist:

Requesting a review for the blank items. Will be glad to hear from the maintainers. 

- [x] I understand README.md.
- [x] If this is a feature addition, that feature has been voted into the C++
  Working Draft.
- [x] Any code files edited have been processed by clang-format 8.0.1.
  (The version is important because clang-format's behavior sometimes changes.)
- [x] Identifiers in any product code changes are properly `_Ugly` as per https://eel.is/c++draft/lex.name#3.1 .
- [ ] Identifiers in test code changes are *not* `_Ugly`.
- [ ] Test code includes the correct headers as per the Standard, not just
  what happens to compile.
- [ ] The STL builds and test harnesses have passed (must be manually verified
  by an STL maintainer before CI is online, leave this unchecked for initial submission).
- [ ] This change introduces no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate or trivially copyable, etc.). If unsure, leave this box unchecked and ask a maintainer for help.

