### PR TITLE
 <type_traits>: Implement is_{un}bounded_array

### DIFF
--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -331,6 +331,28 @@ _INLINE_VAR constexpr bool is_array_v<_Ty[]> = true;
 template <class _Ty>
 struct is_array : bool_constant<is_array_v<_Ty>> {};
 
+#if _HAS_CXX20
+// STRUCT TEMPLATE is_bounded_array
+template <class>
+inline constexpr bool is_bounded_array_v = false;
+
+template <class _Ty, size_t _Nx>
+inline constexpr bool is_bounded_array_v<_Ty[_Nx]> = true;
+
+template <class _Ty>
+struct is_bounded_array : bool_constant<is_bounded_array_v<_Ty>> {};
+
+// STRUCT TEMPLATE is_unbounded_array
+template <class>
+inline constexpr bool is_unbounded_array_v = false;
+
+template <class _Ty>
+inline constexpr bool is_unbounded_array_v<_Ty[]> = true;
+
+template <class _Ty>
+struct is_unbounded_array : bool_constant<is_unbounded_array_v<_Ty>> {};
+#endif // _HAS_CXX20
+
 // STRUCT TEMPLATE is_lvalue_reference
 template <class>
 _INLINE_VAR constexpr bool is_lvalue_reference_v = false; // determine whether type argument is an lvalue reference

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -42,6 +42,7 @@
 //     (partially implemented)
 // P0898R3 Standard Library Concepts
 // P0919R3 Heterogeneous Lookup For Unordered Containers
+// P1357R1 is_bounded_array, is_unbounded_array
 // P1754R1 Rename Concepts To standard_case
 // P????R? directory_entry::clear_cache()
 
@@ -888,6 +889,7 @@
 
 // C++20
 #if _HAS_CXX20
+#define __cpp_lib_bounded_array_traits 201902L
 #ifdef __cpp_char8_t
 #define __cpp_lib_char8_t 201811L
 #endif // __cpp_char8_t


### PR DESCRIPTION
# Description
This relates to P1357R1 as described in #58

There are some differences to the proposed implementation in that paper.
1. The implementation is directly located with is_array
2. The implementation follows the implementation of `is_array` in that it defines is_{un}bounded_array_v and then defines is_{un}bounded_array as bool_constant

# Checklist:

- [x] I understand README.md. 
- [x] If this is a feature addition, that feature has been voted into the C++
  Working Draft.
- [x] Identifiers in any product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 .
- [x] The STL builds and test harnesses have passed (must be manually verified
  by an STL maintainer before CI is online, leave this unchecked for initial
  submission). (Internal PR [204684](https://devdiv.visualstudio.com/DevDiv/_git/msvc/pullrequest/204684))
- [x] This change introduces no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate or
  trivially copyable, etc.). If unsure, leave this box unchecked and ask a
  maintainer for help.
