### PR TITLE
Do size modifications after iterator transfer strategy selection

### DIFF
--- a/stl/inc/list
+++ b/stl/inc/list
@@ -1732,19 +1732,19 @@ private:
             }
 
             auto& _Right_data = _Right._Mypair._Myval2;
-            _My_data._Mysize += _Count;
-            _Right_data._Mysize -= _Count;
-
 #if _ITERATOR_DEBUG_LEVEL == 2
             // transfer ownership
             if (_Count == 1) {
                 _My_data._Adopt_unique(_Right_data, _First);
-            } else if (_Count == _Right.size()) {
+            } else if (_Count == _Right_data._Mysize) {
                 _My_data._Adopt_all(_Right_data);
             } else {
                 _My_data._Adopt_range(_Right_data, _First, _Last);
             }
 #endif // _ITERATOR_DEBUG_LEVEL == 2
+
+            _My_data._Mysize += _Count;
+            _Right_data._Mysize -= _Count;
         }
 
         return _Scary_val::_Unchecked_splice(_Where, _First, _Last);


### PR DESCRIPTION
# Description

This was the cause of the DevCom reported bug:

https://developercommunity.visualstudio.com/content/problem/739698/vc-163-listsplice-bug.html

where we would choose the incorrect strategy to transfer iterators if and only if the number of transferred iterators was exactly half of the container.

This change replicates internal [PR 203902](https://devdiv.visualstudio.com/DevDiv/_git/msvc/pullrequest/203902)

# Checklist:

- [x] I understand README.md.
- [x] Any code files edited have been processed by clang-format 8.0.1.
  (The version is important because clang-format's behavior sometimes changes.)
- [x] Identifiers in any product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 .
- [x] Identifiers in test code changes are *not* `_Ugly`.
- [x] Test code includes the correct headers as per the Standard, not just
  what happens to compile.
- [x] The STL builds and test harnesses have passed (must be manually verified
  by an STL maintainer before CI is online, leave this unchecked for initial
  submission).
- [x] This change introduces no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate or
  trivially copyable, etc.). If unsure, leave this box unchecked and ask a
  maintainer for help.
