### PR TITLE
<xutility> Implement signed ssize()

### DIFF
--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -1994,7 +1994,6 @@ _NODISCARD _CONSTEXPR17 auto crend(const _Container& _Cont) -> decltype(_STD ren
     return _STD rend(_Cont);
 }
 
-
 template <class _Container>
 _NODISCARD constexpr auto size(const _Container& _Cont) -> decltype(_Cont.size()) {
     return _Cont.size();
@@ -2004,6 +2003,21 @@ template <class _Ty, size_t _Size>
 _NODISCARD constexpr size_t size(const _Ty (&)[_Size]) noexcept {
     return _Size;
 }
+
+#if _HAS_CXX20
+// FUNCTION TEMPLATE ssize
+template <class _Container>
+_NODISCARD constexpr auto ssize(const _Container& _Cont)
+    -> common_type_t<ptrdiff_t, make_signed_t<decltype(_Cont.size())>> {
+    using _Common = common_type_t<ptrdiff_t, make_signed_t<decltype(_Cont.size())>>;
+    return static_cast<_Common>(_Cont.size());
+}
+
+template <class _Ty, ptrdiff_t _Size>
+_NODISCARD constexpr ptrdiff_t ssize(const _Ty (&)[_Size]) noexcept {
+    return _Size;
+}
+#endif // _HAS_CXX20
 
 template <class _Container>
 _NODISCARD constexpr auto empty(const _Container& _Cont) -> decltype(_Cont.empty()) {

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -44,6 +44,8 @@
 //     (partially implemented)
 // P0898R3 Standard Library Concepts
 // P0919R3 Heterogeneous Lookup For Unordered Containers
+// P1227R2 Signed std::ssize(), Unsigned span::size()
+//     (partially implemented)
 // P1357R1 is_bounded_array, is_unbounded_array
 // P1754R1 Rename Concepts To standard_case
 // P????R? directory_entry::clear_cache()


### PR DESCRIPTION
# Description
This implements P1227R2 "Signed std::ssize()" Note that there is no feature test macro defined in the paper (See #56 )

# Checklist:

- [x] I understand README.md. 
- [x] If this is a feature addition, that feature has been voted into the C++
  Working Draft.
- [x] Identifiers in any product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 .
- [x] The STL builds and test harnesses have passed (must be manually verified
  by an STL maintainer before CI is online, leave this unchecked for initial
  submission). (Internal PR [204684](https://devdiv.visualstudio.com/DevDiv/_git/msvc/pullrequest/204684))
- [x] This change introduces no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate or
  trivially copyable, etc.). If unsure, leave this box unchecked and ask a
  maintainer for help.
