### PR TITLE
Implement P0325R4 to_array

### DIFF
--- a/stl/inc/array
+++ b/stl/inc/array
@@ -411,6 +411,39 @@ _NODISCARD bool operator>=(const array<_Ty, _Size>& _Left, const array<_Ty, _Siz
     return !(_Left < _Right);
 }
 
+#if _HAS_CXX20
+// FUNCTION TEMPLATE to_array
+template <class _Ty, size_t _Size, size_t... _Idx>
+_NODISCARD constexpr array<remove_cv_t<_Ty>, _Size> _To_array_lvalue_impl(
+    _Ty (&_Array)[_Size], index_sequence<_Idx...>) {
+    return {{_Array[_Idx]...}};
+}
+
+template <class _Ty, size_t _Size, size_t... _Idx>
+_NODISCARD constexpr array<remove_cv_t<_Ty>, _Size> _To_array_rvalue_impl(
+    _Ty(&&_Array)[_Size], index_sequence<_Idx...>) {
+    return {{_STD move(_Array[_Idx])...}};
+}
+
+template <class _Ty, size_t _Size>
+_NODISCARD constexpr array<remove_cv_t<_Ty>, _Size> to_array(_Ty (&_Array)[_Size]) {
+    static_assert(!is_array_v<_Ty>, "N4830 [array.creation]/1: "
+                                    "to_array does not accept multidimensional arrays.");
+    static_assert(is_constructible_v<_Ty, _Ty&>, "N4830 [array.creation]/1: "
+                                                 "to_array requires copy constructible elements.");
+    return _To_array_lvalue_impl(_Array, make_index_sequence<_Size>{});
+}
+
+template <class _Ty, size_t _Size>
+_NODISCARD constexpr array<remove_cv_t<_Ty>, _Size> to_array(_Ty(&&_Array)[_Size]) {
+    static_assert(!is_array_v<_Ty>, "N4830 [array.creation]/4: "
+                                    "to_array does not accept multidimensional arrays.");
+    static_assert(is_move_constructible_v<_Ty>, "N4830 [array.creation]/4: "
+                                                "to_array requires move constructible elements.");
+    return _To_array_rvalue_impl(_STD move(_Array), make_index_sequence<_Size>{});
+}
+#endif // _HAS_CXX20
+
 // TUPLE INTERFACE TO array
 template <size_t _Idx, class _Ty, size_t _Size>
 _NODISCARD constexpr _Ty& get(array<_Ty, _Size>& _Arr) noexcept {

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -21,6 +21,7 @@
 // _HAS_CXX20 directly controls:
 // P0020R6 atomic<float>, atomic<double>, atomic<long double>
 // P0318R1 unwrap_reference, unwrap_ref_decay
+// P0325R4 to_array()
 // P0457R2 starts_with()/ends_with() For basic_string/basic_string_view
 // P0458R2 contains() For Ordered And Unordered Associative Containers
 // P0463R1 endian
@@ -912,6 +913,7 @@
 
 #define __cpp_lib_generic_unordered_lookup 201811L
 #define __cpp_lib_list_remove_return_type 201806L
+#define __cpp_lib_to_array 201907L
 #endif // _HAS_CXX20
 
 // EXPERIMENTAL


### PR DESCRIPTION
This is a replay of internal PR 203285

Resolves #9

# Checklist:

- [X] I understand README.md.
- [X] If this is a feature addition, that feature has been voted into the C++
  Working Draft.
- [X] Identifiers in any product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 .
- [X] Identifiers in test code changes are *not* `_Ugly`.
- [X] Test code includes the correct headers as per the Standard, not just
  what happens to compile.
- [x] The STL builds and test harnesses have passed (must be manually verified
  by an STL maintainer before CI is online, leave this unchecked for initial
  submission).
- [X] This change introduces no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate or
  trivially copyable, etc.). If unsure, leave this box unchecked and ask a
  maintainer for help.
