### PR TITLE
Refuse to allow clang to include coroutine headers

### DIFF
--- a/stl/inc/experimental/resumable
+++ b/stl/inc/experimental/resumable
@@ -25,6 +25,12 @@ _STL_DISABLE_CLANG_WARNINGS
 #pragma push_macro("new")
 #undef new
 
+#if defined(__clang__) && !defined(_SILENCE_CLANG_COROUTINE_MESSAGE)
+#error The <experimental/coroutine>, <experimental/generator>, and <experimental/resumable> headers currently do not \
+support Clang. You can define _SILENCE_CLANG_COROUTINE_MESSAGE to silence this message and acknowledge that this is \
+unsupported.
+#endif // defined(__clang__) && !defined(_SILENCE_CLANG_COROUTINE_MESSAGE)
+
 // intrinsics used in implementation of coroutine_handle
 extern "C" size_t _coro_resume(void*);
 extern "C" void _coro_destroy(void*);


### PR DESCRIPTION
# Description

Resolves #105.

[This is a replay of internal PR [203451](https://devdiv.visualstudio.com/DevDiv/_git/msvc/pullrequest/203451)].

# Checklist:

- [X] I understand README.md.
- [ ] If this is a feature addition, that feature has been voted into the C++
  Working Draft. **(N/A)**
- [X] Identifiers in any product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 .
- [X] Identifiers in test code changes are *not* `_Ugly`.
- [X] Test code includes the correct headers as per the Standard, not just
  what happens to compile.
- [X] The STL builds and test harnesses have passed (must be manually verified
  by an STL maintainer before CI is online, leave this unchecked for initial
  submission).
- [X] This change introduces no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate or
  trivially copyable, etc.). If unsure, leave this box unchecked and ask a
  maintainer for help.
