### PR TITLE
Move cgmanifest.json

### DIFF
--- a/docs/cgmanifest.json
+++ b/docs/cgmanifest.json
@@ -8,6 +8,15 @@
                     "commitHash": "59661c3f883dfd39cef6dc8eaf2fcbaae53597e8"
                 }
             }
+        },
+        {
+            "component": {
+                "type": "git",
+                "git": {
+                    "repositoryUrl": "https://github.com/microsoft/STL.git",
+                    "commitHash": "d5c2a9aaaac737216ac6bfa890a26f1a2cd8b4b1"
+                }
+            }
         }
     ],
     "Version": 1


### PR DESCRIPTION
Please note that acceptance of community PRs will be delayed while we are
bringing our test and CI systems online. For more information, see the
README.md.

# Description
Move CGmanifest to a more appropriate location. Fixes #125.

mirror of internal PR https://devdiv.visualstudio.com/DevDiv/_git/msvc/pullrequest/204398?_a=overview


# Checklist:

- [x] I understand README.md.
- [x] If this is a feature addition, that feature has been voted into the C++
  Working Draft.
- [x] Identifiers in any product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 .
- [x] Identifiers in test code changes are *not* `_Ugly`.
- [x] Test code includes the correct headers as per the Standard, not just
  what happens to compile.
- [x] The STL builds and test harnesses have passed (must be manually verified
  by an STL maintainer before CI is online, leave this unchecked for initial
  submission).
- [x] This change introduces no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate or
  trivially copyable, etc.). If unsure, leave this box unchecked and ask a
  maintainer for help.
