### PR TITLE
Implement LWG 3268's PR to fix #150.

### DIFF
--- a/stl/inc/xatomic.h
+++ b/stl/inc/xatomic.h
@@ -57,7 +57,22 @@ _STD_BEGIN
 
 #if _HAS_CXX20
 // ENUM CLASS memory_order
-enum class memory_order : int { relaxed, consume, acquire, release, acq_rel, seq_cst };
+enum class memory_order : int {
+    relaxed,
+    consume,
+    acquire,
+    release,
+    acq_rel,
+    seq_cst,
+
+    // LWG 3268
+    memory_order_relaxed = relaxed,
+    memory_order_consume = consume,
+    memory_order_acquire = acquire,
+    memory_order_release = release,
+    memory_order_acq_rel = acq_rel,
+    memory_order_seq_cst = seq_cst
+};
 inline constexpr memory_order memory_order_relaxed = memory_order::relaxed;
 inline constexpr memory_order memory_order_consume = memory_order::consume;
 inline constexpr memory_order memory_order_acquire = memory_order::acquire;


### PR DESCRIPTION
This implements the Proposed Resolution for
[LWG 3268](https://cplusplus.github.io/LWG/issue3268).

This is a back-compat fix for users who were saying things like
`std::memory_order::memory_order_relaxed`. As there is nothing
especially problematic about such usage, and LWG's ultimate resolution
is unknown, I'm not deprecating these enumerators at this time. If and
when this is voted into the WP in the deprecated clause, then we can
add deprecated attributes.

This mirrors a Microsoft-internal PR:
https://devdiv.visualstudio.com/DevDiv/_git/msvc/pullrequest/205250

Please note that acceptance of community PRs will be delayed while we are
bringing our test and CI systems online. For more information, see the
README.md.

# Description

# Checklist:

- [x] I understand README.md.
- [ ] If this is a feature addition, that feature has been voted into the C++
  Working Draft. **(LWG 3268's Proposed Resolution has NOT been voted into the Working Draft, but this change is necessary to avoid breaking real world code that conformed to C++11/14/17.)**
- [x] Identifiers in any product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 .
- [ ] Identifiers in test code changes are *not* `_Ugly`. **(N/A, no tests here)**
- [ ] Test code includes the correct headers as per the Standard, not just
  what happens to compile. **(N/A, no tests here)**
- [x] The STL builds and test harnesses have passed (must be manually verified
  by an STL maintainer before CI is online, leave this unchecked for initial
  submission).
- [x] This change introduces no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate or
  trivially copyable, etc.). If unsure, leave this box unchecked and ask a
  maintainer for help.
