### PR TITLE
Update the PR template to fix #117.

### DIFF
--- a/docs/ISSUE_TEMPLATE.md
+++ b/docs/ISSUE_TEMPLATE.md
@@ -23,8 +23,8 @@ C:\Users\billy\Desktop>type repro.cpp
 int main() {
     // Replace this program with one demonstrating your actual bug report,
     // along with the following compilation command. Please leave compiler
-    // version banners in the output (don't use /nologo), and include output of
-    // your test program, if any.
+    // version banners in the output (don't use /nologo), and include output
+    // of your test program, if any.
     std::cout << "test failure\n";
 }
 
@@ -44,8 +44,9 @@ test failure
 ```
 
 **Expected behavior**
-A clear and concise description of what you expected to happen. Alternately,
-include `static_assert`s or `assert`s in your test case above whose failure clearly indicates the problem.
+A clear and concise description of what you expected to happen. Alternatively,
+include `static_assert`s or `assert`s in your test case above whose failure
+clearly indicates the problem.
 
 **Additional context**
 Add any other context about the problem here.

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -15,9 +15,6 @@ For example: **(N/A: this is a bugfix, not a feature)**
   C++ Working Draft.
 - [ ] Identifiers in product code changes are properly `_Ugly` as per
   https://eel.is/c++draft/lex.name#3.1 .
-- [ ] Identifiers in test code changes are *not* `_Ugly`. **(N/A: no tests)**
-- [ ] Test code includes the correct headers as per the Standard, not just
-  what happens to compile. **(N/A: no tests)**
 - [ ] The STL builds successfully and all tests have passed (must be manually
   verified by an STL maintainer before CI is online, leave this unchecked for
   initial submission).
@@ -27,7 +24,7 @@ For example: **(N/A: this is a bugfix, not a feature)**
 - [ ] These changes were written from scratch using only this repository and
   the C++ Working Draft as a reference (and any other cited standards).
   If they were derived from a project that's already listed in NOTICE.txt,
-  that's fine, but please mention it. If they were derived from any other open
-  source project (including Boost and libc++, which are not yet listed in
+  that's fine, but please mention it. If they were derived from any other
+  project (including Boost and libc++, which are not yet listed in
   NOTICE.txt), you *must* mention it here, so we can determine whether the
   license is compatible and what else needs to be done.

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,23 +1,33 @@
-Please note that acceptance of community PRs will be delayed while we are
-bringing our test and CI systems online. For more information, see the
-README.md.
-
 # Description
 
-# Checklist:
 
-- [ ] I understand README.md.
-- [ ] If this is a feature addition, that feature has been voted into the C++
-  Working Draft.
-- [ ] Identifiers in any product code changes are properly `_Ugly` as per
+
+# Checklist
+
+If you're unsure about a box, leave it unchecked. A maintainer will help you.
+
+If a box isn't applicable, add an explanation in **bold**.
+For example: **(N/A: this is a bugfix, not a feature)**
+
+- [ ] I understand README.md. I also understand that acceptance of
+  community PRs will be delayed until the test and CI systems are online.
+- [ ] If this is a feature addition, that feature has been voted into the
+  C++ Working Draft.
+- [ ] Identifiers in product code changes are properly `_Ugly` as per
   https://eel.is/c++draft/lex.name#3.1 .
-- [ ] Identifiers in test code changes are *not* `_Ugly`.
+- [ ] Identifiers in test code changes are *not* `_Ugly`. **(N/A: no tests)**
 - [ ] Test code includes the correct headers as per the Standard, not just
-  what happens to compile.
-- [ ] The STL builds and test harnesses have passed (must be manually verified
-  by an STL maintainer before CI is online, leave this unchecked for initial
-  submission).
-- [ ] This change introduces no known ABI breaks (adding members, renaming
-  members, adding virtual functions, changing whether a type is an aggregate or
-  trivially copyable, etc.). If unsure, leave this box unchecked and ask a
-  maintainer for help.
+  what happens to compile. **(N/A: no tests)**
+- [ ] The STL builds successfully and all tests have passed (must be manually
+  verified by an STL maintainer before CI is online, leave this unchecked for
+  initial submission).
+- [ ] These changes introduce no known ABI breaks (adding members, renaming
+  members, adding virtual functions, changing whether a type is an aggregate
+  or trivially copyable, etc.).
+- [ ] These changes were written from scratch using only this repository and
+  the C++ Working Draft as a reference (and any other cited standards).
+  If they were derived from a project that's already listed in NOTICE.txt,
+  that's fine, but please mention it. If they were derived from any other open
+  source project (including Boost and libc++, which are not yet listed in
+  NOTICE.txt), you *must* mention it here, so we can determine whether the
+  license is compatible and what else needs to be done.


### PR DESCRIPTION
# Description

This adds a checkbox to the PR template mentioning
license discipline.

It clarifies the instructions regarding unchecked
and inapplicable boxes.

It fuses the "acceptance will be delayed" disclaimer
into the README checkbox.

This also rewraps the issue template (we usually wrap to 120,
but 80 is friendlier to the issue textbox) and improves the
wording by changing "Alternately" to "Alternatively".

# Checklist

If you're unsure about a box, leave it unchecked. A maintainer will help you.

If a box isn't applicable, add an explanation in **bold**.
For example: **(N/A: this is a bugfix, not a feature)**

- [x] I understand README.md. I also understand that acceptance of
  community PRs will be delayed until the test and CI systems are online.
- [ ] If this is a feature addition, that feature has been voted into the
  C++ Working Draft. **(N/A: docs only)**
- [ ] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 . **(N/A: docs only)**
- [ ] Identifiers in test code changes are *not* `_Ugly`. **(N/A: no tests)**
- [ ] Test code includes the correct headers as per the Standard, not just
  what happens to compile. **(N/A: no tests)**
- [ ] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before CI is online, leave this unchecked for
  initial submission). **(N/A: docs only)**
- [ ] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.). **(N/A: docs only)**
- [x] These changes were written from scratch using only this repository and
  the C++ Working Draft as a reference (and any other cited standards).
  If they were derived from a project that's already listed in NOTICE.txt,
  that's fine, but please mention it. If they were derived from any other open
  source project (including Boost and libc++, which are not yet listed in
  NOTICE.txt), you *must* mention it here, so we can determine whether the
  license is compatible and what else needs to be done.
