### PR TITLE
Activate FrameHandler4 to fix #118.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,8 +63,7 @@ add_compile_definitions(
     _CRT_DECLARE_NONSTDC_NAMES=1 )
 
 # TRANSITION, /analyze ?
-# TRANSITION, /d2FH4- ?
-add_compile_options(/diagnostics:caret /W4 /WX /w14265 /w15038 /d1FastFail /guard:cf /Z7 /d2Zi+ /Gm- /Gy /Zp8 /std:c++latest /permissive- /Zc:threadSafeInit- /d2FH4-)
+add_compile_options(/diagnostics:caret /W4 /WX /w14265 /w15038 /d1FastFail /guard:cf /Z7 /d2Zi+ /Gm- /Gy /Zp8 /std:c++latest /permissive- /Zc:threadSafeInit-)
 
 set(VCLIBS_DEBUG_OPTIONS "/Od")
 set(VCLIBS_RELEASE_FLAGS "/O2;/Os") # TRANSITION: Potentially remove /Os


### PR DESCRIPTION
# Description

Activate FrameHandler4 to fix #118.

This affects the x64 build. Before this change, msvcp140.dll
was 601,600 bytes. After this change, it's 540,672 bytes.

This ports a Microsoft-internal PR:
https://devdiv.visualstudio.com/DevDiv/_git/msvc/pullrequest/204636

# Checklist

If you're unsure about a box, leave it unchecked. A maintainer will help you.

If a box isn't applicable, add an explanation in **bold**.
For example: **(N/A: this is a bugfix, not a feature)**

- [x] I understand README.md. I also understand that acceptance of
  community PRs will be delayed until the test and CI systems are online.
- [ ] If this is a feature addition, that feature has been voted into the
  C++ Working Draft. **(N/A: not a feature)**
- [ ] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 . **(N/A: build system changes, not product code)**
- [x] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before CI is online, leave this unchecked for
  initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository and
  the C++ Working Draft as a reference (and any other cited standards).
  If they were derived from a project that's already listed in NOTICE.txt,
  that's fine, but please mention it. If they were derived from any other
  project (including Boost and libc++, which are not yet listed in
  NOTICE.txt), you *must* mention it here, so we can determine whether the
  license is compatible and what else needs to be done.
