### PR TITLE
Parallelize enforcement of clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -113,7 +113,7 @@ IncludeBlocks:   Regroup
 IncludeCategories:
   - Regex:           '^<yvals(_core)?\.h>$'
     Priority:        1
-  - Regex:           '^<Windows\.h>$'
+  - Regex:           '^<(Windows|userenv)\.h>$'
     Priority:        3
   - Regex:           '^<WinIoCtl\.h>$'
     Priority:        4

--- a/azure-devops/enforce-clang-format.cmd
+++ b/azure-devops/enforce-clang-format.cmd
@@ -1,6 +1,5 @@
 :: Copyright (c) Microsoft Corporation.
 :: SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-@echo off
-"%1" "\"clang-format.exe -style=file -i\"" stl/inc stl/inc/cvt stl/inc/experimental stl/src tools/inc tools/jobify/jobify.cpp tools/parallelize/parallelize.cpp
+"%1" "clang-format.exe -style=file -i" stl/inc stl/inc/cvt stl/inc/experimental stl/src tools/inc tools/jobify/jobify.cpp tools/parallelize/parallelize.cpp
 echo If your build fails here, you need to format the following files with clang-format 8.0.1.
 git status --porcelain stl 1>&2

--- a/azure-devops/enforce-clang-format.cmd
+++ b/azure-devops/enforce-clang-format.cmd
@@ -1,5 +1,6 @@
 :: Copyright (c) Microsoft Corporation.
 :: SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 "%1" "clang-format.exe -style=file -i" stl/inc stl/inc/cvt stl/inc/experimental stl/src tools/inc tools/jobify/jobify.cpp tools/parallelize/parallelize.cpp
-echo If your build fails here, you need to format the following files with clang-format 8.0.1.
-git status --porcelain stl tools 1>&2
+@echo If your build fails here, you need to format the following files with
+@clang-format.exe --version
+@git status --porcelain stl tools 1>&2

--- a/azure-devops/enforce-clang-format.cmd
+++ b/azure-devops/enforce-clang-format.cmd
@@ -2,4 +2,4 @@
 :: SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 "%1" "clang-format.exe -style=file -i" stl/inc stl/inc/cvt stl/inc/experimental stl/src tools/inc tools/jobify/jobify.cpp tools/parallelize/parallelize.cpp
 echo If your build fails here, you need to format the following files with clang-format 8.0.1.
-git status --porcelain stl 1>&2
+git status --porcelain stl tools 1>&2

--- a/azure-devops/enforce-clang-format.cmd
+++ b/azure-devops/enforce-clang-format.cmd
@@ -1,6 +1,6 @@
 :: Copyright (c) Microsoft Corporation.
 :: SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 @echo off
-clang-format -style=file -i stl/inc/* stl/inc/cvt/* stl/inc/experimental/* stl/src/* 2>&1
+"%1" "\"clang-format.exe -style=file -i\"" stl/inc stl/inc/cvt stl/inc/experimental stl/src tools/inc tools/jobify/jobify.cpp tools/parallelize/parallelize.cpp
 echo If your build fails here, you need to format the following files with clang-format 8.0.1.
 git status --porcelain stl 1>&2

--- a/azure-devops/run_build.yml
+++ b/azure-devops/run_build.yml
@@ -14,12 +14,22 @@ jobs:
   steps:
     - checkout: self
       submodules: recursive
+    - task: run-cmake@0
+      displayName: 'Build STL Support Tools'
+      enabled: true
+      condition: eq('${{ parameters.targetPlatform }}', 'x86')
+      inputs:
+        cmakeListsTxtPath: 'tools/CMakeSettings.json'
+        useVcpkgToolchainFile: false
+        configurationRegexFilter: 'x64-Release'
+        buildDirectory: $(Build.ArtifactStagingDirectory)/tools
     - task: BatchScript@1
       displayName: 'Enforce clang-format'
       condition: eq('${{ parameters.targetPlatform }}', 'x86')
       inputs:
         filename: 'azure-devops/enforce-clang-format.cmd'
         failOnStandardError: true
+        arguments: '$(Build.ArtifactStagingDirectory)/tools/parallelize/parallelize.exe'
     - task: PowerShell@2
       displayName: 'Install MSVC preview'
       # on "Hosted" agents only:
@@ -44,7 +54,7 @@ jobs:
         vcpkgDirectory: '$(vcpkgLocation)'
         vcpkgTriplet: ${{ parameters.targetPlatform }}-windows
     - task: run-cmake@0
-      displayName: 'Run CMake with Ninja'
+      displayName: 'Build the STL'
       enabled: true
       inputs:
         cmakeListsTxtPath: 'CMakeSettings.json'

--- a/azure-devops/run_build.yml
+++ b/azure-devops/run_build.yml
@@ -40,7 +40,7 @@ jobs:
     - task: run-cmake@0
       displayName: 'Build STL Support Tools'
       enabled: true
-      condition: eq('${{ parameters.targetPlatform }}', 'x86')
+      condition: eq('${{ parameters.targetPlatform }}', 'x64')
       inputs:
         cmakeListsTxtPath: 'tools/CMakeSettings.json'
         useVcpkgToolchainFile: true
@@ -48,7 +48,7 @@ jobs:
         buildDirectory: $(Build.ArtifactStagingDirectory)/tools
     - task: BatchScript@1
       displayName: 'Enforce clang-format'
-      condition: eq('${{ parameters.targetPlatform }}', 'x86')
+      condition: eq('${{ parameters.targetPlatform }}', 'x64')
       inputs:
         filename: 'azure-devops/enforce-clang-format.cmd'
         failOnStandardError: true

--- a/azure-devops/run_build.yml
+++ b/azure-devops/run_build.yml
@@ -20,7 +20,7 @@ jobs:
       condition: eq('${{ parameters.targetPlatform }}', 'x86')
       inputs:
         cmakeListsTxtPath: 'tools/CMakeSettings.json'
-        useVcpkgToolchainFile: false
+        useVcpkgToolchainFile: true
         configurationRegexFilter: 'x64-Release'
         buildDirectory: $(Build.ArtifactStagingDirectory)/tools
     - task: BatchScript@1

--- a/azure-devops/run_build.yml
+++ b/azure-devops/run_build.yml
@@ -14,22 +14,6 @@ jobs:
   steps:
     - checkout: self
       submodules: recursive
-    - task: run-cmake@0
-      displayName: 'Build STL Support Tools'
-      enabled: true
-      condition: eq('${{ parameters.targetPlatform }}', 'x86')
-      inputs:
-        cmakeListsTxtPath: 'tools/CMakeSettings.json'
-        useVcpkgToolchainFile: true
-        configurationRegexFilter: '.*x64-Release.*'
-        buildDirectory: $(Build.ArtifactStagingDirectory)/tools
-    - task: BatchScript@1
-      displayName: 'Enforce clang-format'
-      condition: eq('${{ parameters.targetPlatform }}', 'x86')
-      inputs:
-        filename: 'azure-devops/enforce-clang-format.cmd'
-        failOnStandardError: true
-        arguments: '$(Build.ArtifactStagingDirectory)/tools/parallelize/parallelize.exe'
     - task: PowerShell@2
       displayName: 'Install MSVC preview'
       # on "Hosted" agents only:
@@ -53,6 +37,22 @@ jobs:
         vcpkgArguments: '@$(vcpkgResponseFile)'
         vcpkgDirectory: '$(vcpkgLocation)'
         vcpkgTriplet: ${{ parameters.targetPlatform }}-windows
+    - task: run-cmake@0
+      displayName: 'Build STL Support Tools'
+      enabled: true
+      condition: eq('${{ parameters.targetPlatform }}', 'x86')
+      inputs:
+        cmakeListsTxtPath: 'tools/CMakeSettings.json'
+        useVcpkgToolchainFile: true
+        configurationRegexFilter: '.*x64-Release.*'
+        buildDirectory: $(Build.ArtifactStagingDirectory)/tools
+    - task: BatchScript@1
+      displayName: 'Enforce clang-format'
+      condition: eq('${{ parameters.targetPlatform }}', 'x86')
+      inputs:
+        filename: 'azure-devops/enforce-clang-format.cmd'
+        failOnStandardError: true
+        arguments: '$(Build.ArtifactStagingDirectory)/tools/parallelize/parallelize.exe'
     - task: run-cmake@0
       displayName: 'Build the STL'
       enabled: true

--- a/azure-devops/run_build.yml
+++ b/azure-devops/run_build.yml
@@ -42,13 +42,10 @@ jobs:
       enabled: true
       condition: eq('${{ parameters.targetPlatform }}', 'x64')
       inputs:
-        cmakeListsOrSettingsJson: 'CMakeListsTxtAdvanced'
-        cmakeListsTxtPath: '$(Build.SourcesDirectory)/tools/CMakeLists.txt'
+        cmakeListsTxtPath: 'tools/CMakeSettings.json'
+        useVcpkgToolchainFile: true
+        configurationRegexFilter: '.*x64-Release.*'
         buildDirectory: $(Build.ArtifactStagingDirectory)/tools
-        useVcpkgToolchainFile: false
-        cmakeBuildType: 'Release'
-        cmakeGenerator: 'Ninja'
-        cmakeAppendedArgs: '-G Ninja -DCMAKE_BUILD_TYPE=Release -DSTL_PIPELINES=1'
     - task: BatchScript@1
       displayName: 'Enforce clang-format'
       condition: eq('${{ parameters.targetPlatform }}', 'x64')

--- a/azure-devops/run_build.yml
+++ b/azure-devops/run_build.yml
@@ -15,7 +15,7 @@ jobs:
     - checkout: self
       submodules: recursive
     - task: PowerShell@2
-      displayName: 'Install MSVC preview'
+      displayName: 'Install MSVC Preview'
       # on "Hosted" agents only:
       condition: or(contains(variables['Agent.Name'], 'Azure Pipelines'), contains(variables['Agent.Name'], 'Hosted Agent'))
       inputs:
@@ -27,7 +27,7 @@ jobs:
         key: $(vcpkgResponseFile) | $(Build.SourcesDirectory)/.git/modules/vcpkg/HEAD
         path: '$(vcpkgLocation)'
     - task: run-vcpkg@0
-      displayName: 'Run vcpkg to install boost-build'
+      displayName: 'Run vcpkg to Install boost-build'
       inputs:
         vcpkgArguments: 'boost-build:x86-windows'
         vcpkgDirectory: '$(vcpkgLocation)'
@@ -38,14 +38,17 @@ jobs:
         vcpkgDirectory: '$(vcpkgLocation)'
         vcpkgTriplet: ${{ parameters.targetPlatform }}-windows
     - task: run-cmake@0
-      displayName: 'Build STL Support Tools'
+      displayName: 'Build Support Tools'
       enabled: true
       condition: eq('${{ parameters.targetPlatform }}', 'x64')
       inputs:
-        cmakeListsTxtPath: 'tools/CMakeSettings.json'
-        useVcpkgToolchainFile: true
-        configurationRegexFilter: '.*x64-Release.*'
+        cmakeListsOrSettingsJson: 'CMakeListsTxtAdvanced'
+        cmakeListsTxtPath: '$(Build.SourcesDirectory)/tools/CMakeLists.txt'
         buildDirectory: $(Build.ArtifactStagingDirectory)/tools
+        useVcpkgToolchainFile: false
+        cmakeBuildType: 'Release'
+        cmakeGenerator: 'Ninja'
+        cmakeAppendedArgs: '-G Ninja -DCMAKE_BUILD_TYPE=Release -DSTL_PIPELINES=1'
     - task: BatchScript@1
       displayName: 'Enforce clang-format'
       condition: eq('${{ parameters.targetPlatform }}', 'x64')

--- a/azure-devops/run_build.yml
+++ b/azure-devops/run_build.yml
@@ -21,7 +21,7 @@ jobs:
       inputs:
         cmakeListsTxtPath: 'tools/CMakeSettings.json'
         useVcpkgToolchainFile: true
-        configurationRegexFilter: 'x64-Release'
+        configurationRegexFilter: '.*x64-Release.*'
         buildDirectory: $(Build.ArtifactStagingDirectory)/tools
     - task: BatchScript@1
       displayName: 'Enforce clang-format'

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,0 +1,22 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+cmake_minimum_required(VERSION 3.15)
+project(msvc_standard_libraries_tools LANGUAGES CXX)
+
+set(CXX_STANDARD 17)
+set(CXX_STANDARD_REQUIRED True)
+set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+
+add_compile_definitions(NOMINMAX _CRT_RAND_S UNICODE _UNICODE)
+
+if(MSVC)
+    add_compile_options(/W4 /WX $<$<NOT:$<CONFIG:Debug>>:/Zi> /std:c++17)
+else()
+    add_compile_options(-Wall -Wextra -pedantic -Werror)
+endif()
+
+include_directories(inc)
+
+add_subdirectory(jobify)
+add_subdirectory(parallelize)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -4,8 +4,6 @@
 cmake_minimum_required(VERSION 3.15)
 project(msvc_standard_libraries_tools LANGUAGES CXX)
 
-set(STL_PIPELINES False CACHE BOOL "Disable some tools unused in microsoft/STL Azure Pipelines")
-
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
@@ -15,8 +13,5 @@ add_compile_options(/W4 /WX $<$<NOT:$<CONFIG:Debug>>:/Zi> /permissive-)
 
 include_directories(inc)
 
-add_subdirectory(parallelize)
-
-if (NOT ${STL_PIPELINES})
 add_subdirectory(jobify)
-endif()
+add_subdirectory(parallelize)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -4,6 +4,8 @@
 cmake_minimum_required(VERSION 3.15)
 project(msvc_standard_libraries_tools LANGUAGES CXX)
 
+set(STL_PIPELINES False CACHE BOOL "Disable some tools unused in microsoft/STL Azure Pipelines")
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
@@ -13,5 +15,8 @@ add_compile_options(/W4 /WX $<$<NOT:$<CONFIG:Debug>>:/Zi> /permissive-)
 
 include_directories(inc)
 
-add_subdirectory(jobify)
 add_subdirectory(parallelize)
+
+if (NOT ${STL_PIPELINES})
+add_subdirectory(jobify)
+endif()

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -4,17 +4,12 @@
 cmake_minimum_required(VERSION 3.15)
 project(msvc_standard_libraries_tools LANGUAGES CXX)
 
-set(CXX_STANDARD 17)
-set(CXX_STANDARD_REQUIRED True)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 
-add_compile_definitions(NOMINMAX _CRT_RAND_S UNICODE _UNICODE)
-
-if(MSVC)
-    add_compile_options(/W4 /WX $<$<NOT:$<CONFIG:Debug>>:/Zi> /std:c++17)
-else()
-    add_compile_options(-Wall -Wextra -pedantic -Werror)
-endif()
+add_compile_definitions(NOMINMAX UNICODE _UNICODE)
+add_compile_options(/W4 /WX $<$<NOT:$<CONFIG:Debug>>:/Zi> /permissive-)
 
 include_directories(inc)
 

--- a/tools/CMakeSettings.json
+++ b/tools/CMakeSettings.json
@@ -1,0 +1,28 @@
+﻿{
+  "configurations": [
+    {
+      "buildCommandArgs": "-v",
+      "buildRoot": "${projectDir}\\out\\build\\${name}",
+      "cmakeCommandArgs": "",
+      "configurationType": "Debug",
+      "ctestCommandArgs": "",
+      "generator": "Ninja",
+      "inheritEnvironments": [ "msvc_x64_x64" ],
+      "installRoot": "${projectDir}\\out\\install\\${name}",
+      "name": "x64-Debug",
+      "variables": []
+    },
+    {
+      "buildCommandArgs": "-v",
+      "buildRoot": "${projectDir}\\out\\build\\${name}",
+      "cmakeCommandArgs": "",
+      "configurationType": "Release",
+      "ctestCommandArgs": "",
+      "generator": "Ninja",
+      "inheritEnvironments": [ "msvc_x64_x64" ],
+      "installRoot": "${projectDir}\\out\\install\\${name}",
+      "name": "x64-Release",
+      "variables": []
+    }
+  ]
+}

--- a/tools/inc/stljobs.h
+++ b/tools/inc/stljobs.h
@@ -1,0 +1,606 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <algorithm>
+#include <assert.h>
+#include <atomic>
+#include <iterator>
+#include <memory>
+#include <stdexcept>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <string>
+#include <string_view>
+#include <userenv.h>
+
+#include <Windows.h>
+
+struct api_exception : std::exception {
+    const char* api;
+    unsigned long lastError;
+
+    explicit api_exception(const char* api_, unsigned long lastError_) noexcept : api(api_), lastError(lastError_){};
+
+    [[noreturn]] void give_up() const {
+        fflush(stdout);
+        fprintf(stderr, "The API %s failed unexpectedly; last error 0x%08lX\n", api, lastError);
+        abort();
+    }
+
+    const char* what() const noexcept override {
+        return "win32 exception";
+    }
+};
+
+[[noreturn]] inline void api_failure(const char* const api, const unsigned long lastError = GetLastError()) {
+    throw api_exception{api, lastError};
+}
+
+struct invalid_handle_value_policy {
+    static constexpr HANDLE Empty = INVALID_HANDLE_VALUE;
+};
+
+struct null_handle_policy {
+    static constexpr HANDLE Empty = 0;
+};
+
+template <class EmptyPolicy>
+class handle {
+public:
+    handle() = default;
+
+    explicit handle(const HANDLE hInitial) noexcept : hImpl(hInitial) {}
+
+    handle(handle&& other) noexcept : hImpl(std::exchange(other.hImpl, EmptyPolicy::Empty)) {}
+
+    handle& operator=(handle&& other) noexcept {
+        handle moved = std::move(other);
+        swap(moved, *this);
+        return *this;
+    }
+
+    handle& operator=(const HANDLE hNew) & noexcept {
+        handle moved{hNew};
+        swap(moved, *this);
+        return *this;
+    }
+
+    ~handle() noexcept {
+        if (hImpl != EmptyPolicy::Empty) {
+            CloseHandle(hImpl);
+        }
+    }
+
+    friend void swap(handle& lhs, handle& rhs) noexcept {
+        using std::swap;
+        swap(lhs.hImpl, rhs.hImpl);
+    }
+
+    void close() noexcept {
+        if (hImpl != EmptyPolicy::Empty) {
+            CloseHandle(hImpl);
+            hImpl = EmptyPolicy::Empty;
+        }
+    }
+
+    [[nodiscard]] explicit operator bool() const noexcept {
+        return hImpl != EmptyPolicy::Empty;
+    }
+
+    [[nodiscard]] HANDLE get() const noexcept {
+        return hImpl;
+    }
+
+    [[nodiscard]] HANDLE detach() noexcept {
+        return std::exchange(hImpl, EmptyPolicy::Empty);
+    }
+
+    [[nodiscard]] HANDLE* out() noexcept {
+        return &hImpl;
+    }
+
+private:
+    HANDLE hImpl{EmptyPolicy::Empty};
+};
+
+inline handle<invalid_handle_value_policy> create_file(const wchar_t* const lpFileName, unsigned long dwDesiredAccess,
+    unsigned long dwShareMode, LPSECURITY_ATTRIBUTES lpSecurityAttributes, unsigned long dwCreationDisposition,
+    unsigned long dwFlagsAndAttributes, HANDLE hTemplateFile) {
+    handle<invalid_handle_value_policy> result{CreateFileW(lpFileName, dwDesiredAccess, dwShareMode,
+        lpSecurityAttributes, dwCreationDisposition, dwFlagsAndAttributes, hTemplateFile)};
+    if (!result) {
+        api_failure("CreateFileW");
+    }
+
+    return result;
+}
+
+inline handle<invalid_handle_value_policy> create_named_pipe(LPCWSTR lpName, DWORD dwOpenMode, DWORD dwPipeMode,
+    DWORD nMaxInstances, DWORD nOutBufferSize, DWORD nInBufferSize, DWORD nDefaultTimeOut,
+    LPSECURITY_ATTRIBUTES lpSecurityAttributes) {
+    handle<invalid_handle_value_policy> result{CreateNamedPipeW(lpName, dwOpenMode, dwPipeMode, nMaxInstances,
+        nOutBufferSize, nInBufferSize, nDefaultTimeOut, lpSecurityAttributes)};
+    if (!result) {
+        api_failure("CreateNamedPipeW");
+    }
+
+    return result;
+}
+
+
+const auto is_space = [](const wchar_t c) { return c == L' '; };
+
+[[nodiscard]] inline handle<null_handle_policy> create_kill_on_job_close_job() {
+    handle<null_handle_policy> hJob{CreateJobObjectW(nullptr, nullptr)};
+    if (!hJob) {
+        api_failure("CreateJobObjectW");
+    }
+
+    JOBOBJECT_EXTENDED_LIMIT_INFORMATION limits{};
+    limits.BasicLimitInformation.LimitFlags =
+        JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE | JOB_OBJECT_LIMIT_DIE_ON_UNHANDLED_EXCEPTION;
+    if (!SetInformationJobObject(hJob.get(), JobObjectExtendedLimitInformation, &limits, sizeof(limits))) {
+        api_failure("SetInformationJobObject");
+    }
+
+    return hJob;
+}
+
+inline void put_self_in_job() {
+    auto hJob = create_kill_on_job_close_job();
+
+    // Put ourselves in that job
+    if (!AssignProcessToJobObject(hJob.get(), GetCurrentProcess())) {
+        api_failure("AssignProcessToJobObject");
+    }
+
+    // Purposely leak hJob to avoid terminating ourselves
+    (void) hJob.detach();
+}
+
+class no_input_pipe {
+public:
+    no_input_pipe() {
+        SECURITY_ATTRIBUTES inheritSa;
+        inheritSa.nLength              = sizeof(inheritSa);
+        inheritSa.lpSecurityDescriptor = nullptr;
+        inheritSa.bInheritHandle       = TRUE;
+        HANDLE read;
+        if (!CreatePipe(&read, hDevNull.out(), &inheritSa, 0)) {
+            api_failure("CreatePipe");
+        }
+
+        CloseHandle(read);
+    }
+
+    no_input_pipe(const no_input_pipe&) = delete;
+    no_input_pipe& operator=(const no_input_pipe&) = delete;
+
+    HANDLE get() const noexcept {
+        return hDevNull.get();
+    }
+
+    static const no_input_pipe& instance() {
+        static no_input_pipe instance_;
+        return instance_;
+    }
+
+private:
+    handle<null_handle_policy> hDevNull;
+};
+
+class tp_io {
+public:
+    tp_io() = default;
+
+    explicit tp_io(handle<invalid_handle_value_policy>&& fileHandle_, PTP_WIN32_IO_CALLBACK callback, void* const pv,
+        const PTP_CALLBACK_ENVIRON pcbe)
+        : io(CreateThreadpoolIo(fileHandle_.get(), callback, pv, pcbe)) {
+        if (!io) {
+            api_failure("CreateThreadpoolIo");
+        }
+
+        fileHandle = std::move(fileHandle_);
+    }
+
+    tp_io(tp_io&& other) noexcept : fileHandle(std::move(other.fileHandle)), io(std::exchange(other.io, nullptr)) {}
+
+    tp_io& operator=(tp_io&& other) noexcept {
+        tp_io moved{std::move(other)};
+        swap(moved, *this);
+        return *this;
+    }
+
+    friend void swap(tp_io& lhs, tp_io& rhs) noexcept {
+        using std::swap;
+        swap(lhs.fileHandle, rhs.fileHandle);
+        swap(lhs.io, rhs.io);
+    }
+
+    [[nodiscard]] HANDLE get_file() const noexcept {
+        return fileHandle.get();
+    }
+
+    void start_threadpool_io() noexcept {
+        StartThreadpoolIo(io);
+    }
+
+    void cancel_threadpool_io() noexcept {
+        CancelThreadpoolIo(io);
+    }
+
+    explicit operator bool() const noexcept {
+        return io != nullptr;
+    }
+
+    handle<invalid_handle_value_policy> close() noexcept {
+        assert(io != nullptr);
+        WaitForThreadpoolIoCallbacks(io, TRUE);
+        CloseThreadpoolIo(io);
+        return std::move(fileHandle);
+    }
+
+    void wait(bool cancelPending) noexcept {
+        WaitForThreadpoolIoCallbacks(io, cancelPending);
+    }
+
+private:
+    handle<invalid_handle_value_policy> fileHandle{};
+    PTP_IO io{};
+};
+
+struct output_collecting_pipe {
+    static constexpr unsigned long kernelBufferSize = 4096;
+    static constexpr unsigned long bufferSize       = 4096;
+
+    output_collecting_pipe() {
+        // generate a random name for the pipe (we must use a named pipe because anonymous pipes from CreatePipe can't
+        // be used in asynchronous mode)
+        constexpr size_t pipeNameBufferCount        = 15 + 8 * 8 + 1;
+        wchar_t pipeNameBuffer[pipeNameBufferCount] = L"\\\\.\\pipe\\Local\\";
+        wchar_t* pipeNameCursor                     = pipeNameBuffer + 15;
+        for (int values = 0; values < 8; ++values) {
+            unsigned int randomValue;
+            rand_s(&randomValue);
+            for (int hexits = 0; hexits < 8; ++hexits) {
+                *pipeNameCursor++ = L"0123456789ABCDEF"[randomValue & 0xFu];
+            }
+        }
+
+        *pipeNameCursor = L'\0';
+
+        auto readHandle = create_named_pipe(pipeNameBuffer,
+            PIPE_ACCESS_INBOUND | FILE_FLAG_FIRST_PIPE_INSTANCE | FILE_FLAG_OVERLAPPED,
+            PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT | PIPE_REJECT_REMOTE_CLIENTS, 1, 0, kernelBufferSize, 0,
+            nullptr);
+
+        if (!SetFileCompletionNotificationModes(
+                readHandle.get(), FILE_SKIP_COMPLETION_PORT_ON_SUCCESS | FILE_SKIP_SET_EVENT_ON_HANDLE)) {
+            api_failure("SetFileCompletionNotificationModes");
+        }
+
+        SECURITY_ATTRIBUTES inheritSa;
+        inheritSa.nLength              = sizeof(inheritSa);
+        inheritSa.lpSecurityDescriptor = nullptr;
+        inheritSa.bInheritHandle       = TRUE;
+        writeHandle = create_file(pipeNameBuffer, GENERIC_WRITE | FILE_READ_ATTRIBUTES, 0, &inheritSa, OPEN_EXISTING,
+            FILE_FLAG_OVERLAPPED, NULL);
+
+        readIo = tp_io{std::move(readHandle), callback, this, nullptr};
+
+        start();
+    }
+
+    ~output_collecting_pipe() {
+        if (readIo) {
+            if (running.load()) {
+                if (!CancelIoEx(readIo.get_file(), &overlapped)) {
+                    api_failure("CancelIoEx");
+                }
+            }
+
+            readIo.close();
+        }
+    }
+
+    output_collecting_pipe(const output_collecting_pipe&) = delete;
+    output_collecting_pipe& operator=(const output_collecting_pipe&) = delete;
+
+    void start() {
+        const auto oldRunning = running.exchange(true);
+        assert(!oldRunning);
+        (void) oldRunning;
+        read_some();
+    }
+
+    void stop() {
+        if (running.exchange(false)) {
+            if (!CancelIoEx(readIo.get_file(), &overlapped)) {
+                api_failure("CancelIoEx");
+            }
+
+            readIo.wait(false);
+        }
+    }
+
+    [[nodiscard]] std::string extract() {
+        stop();
+        std::string result(targetBuffer.data(), validTill);
+        start();
+        return result;
+    }
+
+    [[nodiscard]] std::string extract_and_reset() {
+        stop();
+        auto first = targetBuffer.data();
+        auto last  = first + validTill;
+        first      = std::find_if_not(first, last, is_space);
+        last       = std::find_if_not(std::reverse_iterator(last), std::reverse_iterator(first), is_space).base();
+        std::string result(first, static_cast<size_t>(last - first));
+        validTill = 0;
+        start();
+        return result;
+    }
+
+    [[nodiscard]] const std::string& get_buffer() const noexcept {
+        assert(!running.load());
+        return targetBuffer;
+    }
+
+    [[nodiscard]] HANDLE get_write_pipe() noexcept {
+        return writeHandle.get();
+    }
+
+private:
+    static void __stdcall callback(
+        PTP_CALLBACK_INSTANCE, void* thisRaw, void*, ULONG ioResult, ULONG_PTR bytes, PTP_IO) noexcept {
+        switch (ioResult) {
+        case ERROR_SUCCESS:
+        case ERROR_OPERATION_ABORTED:
+            break;
+        default:
+            api_failure("StartThreadpoolIo callback", ioResult);
+            break;
+        }
+
+        const auto this_ = static_cast<output_collecting_pipe*>(thisRaw);
+        this_->validTill += bytes;
+        if (this_->running) {
+            this_->read_some();
+        }
+    }
+
+    void resize_create_target_buffer() {
+        if (bufferSize < targetBuffer.size() - validTill) {
+            // already has enough space
+            return;
+        }
+
+        targetBuffer.resize(validTill + bufferSize);
+        targetBuffer.resize(std::min(static_cast<size_t>(ULONG_MAX), targetBuffer.capacity()));
+    }
+
+    void read_some() {
+        assert(running.load());
+        DWORD bytesRead = 0;
+        readIo.start_threadpool_io();
+        while (resize_create_target_buffer(),
+            ReadFile(readIo.get_file(), targetBuffer.data() + validTill,
+                static_cast<unsigned long>(targetBuffer.size() - validTill), &bytesRead, &overlapped)) {
+            validTill += bytesRead;
+        }
+
+        const auto lastError = GetLastError();
+        if (lastError == ERROR_IO_PENDING) {
+            return;
+        }
+
+        readIo.cancel_threadpool_io();
+        api_failure("ReadFile", lastError);
+    }
+
+    std::atomic<bool> running{};
+    std::string targetBuffer; // if running, owned by a threadpool thread, otherwise owned by the calling thread
+    std::size_t validTill{};
+    handle<invalid_handle_value_policy> writeHandle;
+    tp_io readIo;
+    OVERLAPPED overlapped{};
+};
+
+struct execution_result {
+    unsigned long exitCode;
+    std::string output;
+};
+
+class environment_block {
+public:
+    environment_block() {
+        default_block defaultBlock;
+        auto blockEnd = static_cast<const wchar_t*>(defaultBlock.blockRaw);
+        for (;;) {
+            const auto thisLen = wcslen(blockEnd);
+            blockEnd += thisLen;
+            ++blockEnd;
+
+            if (thisLen == 0) {
+                break;
+            }
+        }
+
+        block.assign(static_cast<const wchar_t*>(defaultBlock.blockRaw), blockEnd);
+    }
+
+    [[nodiscard]] void* get() noexcept {
+        return block.data();
+    }
+
+    void append_environment(const std::wstring_view key, const std::wstring_view value) {
+        block.reserve(block.size() + key.size() + value.size() + 2);
+        block.append(key);
+        block.push_back('=');
+        block.append(value);
+        block.push_back('\0');
+    }
+
+private:
+    struct default_block {
+        void* blockRaw;
+        default_block() {
+            if (!CreateEnvironmentBlock(&blockRaw, NULL, FALSE)) {
+                api_failure("CreateEnvironmentBlock");
+            }
+        }
+
+        ~default_block() noexcept {
+            DestroyEnvironmentBlock(blockRaw);
+        }
+
+        default_block(const default_block&) = delete;
+        default_block& operator=(const default_block&) = delete;
+    };
+
+    std::wstring block;
+};
+
+struct create_process_result {
+    handle<null_handle_policy> hProcess;
+    handle<null_handle_policy> hThread;
+    unsigned long dwProcessId;
+    unsigned long dwThreadId;
+};
+
+create_process_result create_process(LPCWSTR lpApplicationName, LPWSTR lpCommandLine,
+    LPSECURITY_ATTRIBUTES lpProcessAttributes, LPSECURITY_ATTRIBUTES lpThreadAttributes, BOOL bInheritHandles,
+    DWORD dwCreationFlags, LPVOID lpEnvironment, LPCWSTR lpCurrentDirectory, LPSTARTUPINFOW lpStartupInfo) {
+    PROCESS_INFORMATION procInfo;
+    if (!CreateProcessW(lpApplicationName, lpCommandLine, lpProcessAttributes, lpThreadAttributes, bInheritHandles,
+            dwCreationFlags, lpEnvironment, lpCurrentDirectory, lpStartupInfo, &procInfo)) {
+        api_failure("CreateProcessW");
+    }
+
+    return {handle<null_handle_policy>{procInfo.hProcess}, handle<null_handle_policy>{procInfo.hThread},
+        procInfo.dwProcessId, procInfo.dwThreadId};
+}
+
+class thread_proc_attribute_list {
+public:
+    thread_proc_attribute_list()                             = default;
+    thread_proc_attribute_list(thread_proc_attribute_list&&) = default;
+    thread_proc_attribute_list& operator=(thread_proc_attribute_list&&) = default;
+
+    explicit thread_proc_attribute_list(unsigned long attributeCount) {
+        size_t size;
+        if (InitializeProcThreadAttributeList(nullptr, attributeCount, 0, &size)) {
+            throw std::logic_error("First call to InitializeProcThreadAttributeList should not succeed.");
+        } else {
+            const auto lastError = GetLastError();
+            if (lastError != ERROR_INSUFFICIENT_BUFFER) {
+                api_failure("InitializeProcThreadAttributeList", ERROR_INSUFFICIENT_BUFFER);
+            }
+        }
+
+        buffer = std::make_unique<unsigned char[]>(size);
+        if (!InitializeProcThreadAttributeList(
+                reinterpret_cast<LPPROC_THREAD_ATTRIBUTE_LIST>(buffer.get()), attributeCount, 0, &size)) {
+            api_failure("InitializeProcThreadAttributeList");
+        }
+    }
+
+    ~thread_proc_attribute_list() {
+        DeleteProcThreadAttributeList(reinterpret_cast<LPPROC_THREAD_ATTRIBUTE_LIST>(buffer.get()));
+    }
+
+    void update_attribute(DWORD_PTR Attribute, PVOID lpValue, SIZE_T cbSize) {
+        if (!UpdateProcThreadAttribute(reinterpret_cast<LPPROC_THREAD_ATTRIBUTE_LIST>(buffer.get()), 0, Attribute,
+                lpValue, cbSize, nullptr, nullptr)) {
+            api_failure("UpdateProcThreadAttribute");
+        }
+    }
+
+    operator LPPROC_THREAD_ATTRIBUTE_LIST() const {
+        return reinterpret_cast<LPPROC_THREAD_ATTRIBUTE_LIST>(buffer.get());
+    }
+
+private:
+    std::unique_ptr<unsigned char[]> buffer;
+};
+
+struct subprocess_executive {
+    subprocess_executive() = default;
+    explicit subprocess_executive(const environment_block& environment_) : environment(environment_) {}
+    explicit subprocess_executive(environment_block&& environment_) : environment(std::move(environment_)) {}
+
+    HANDLE get_wait_handle() const noexcept {
+        return runningProcess.get();
+    }
+
+    void begin_execution(const wchar_t* const applicationName, wchar_t* const commandLine, unsigned long creationFlags,
+        const wchar_t* currentDirectory) {
+        thread_proc_attribute_list procAttributeList{2};
+
+        // only inherit these pipe handles, not other handles that might be concurrently in use in this program
+        HANDLE inheritTheseHandles[] = {no_input_pipe::instance().get(), output.get_write_pipe()};
+        procAttributeList.update_attribute(
+            PROC_THREAD_ATTRIBUTE_HANDLE_LIST, &inheritTheseHandles, sizeof(inheritTheseHandles));
+
+        // turn on all reasonable corruption detecting mitigations
+        unsigned long long mitigations = PROCESS_CREATION_MITIGATION_POLICY_DEP_ENABLE
+                                         | PROCESS_CREATION_MITIGATION_POLICY_SEHOP_ENABLE
+                                         | PROCESS_CREATION_MITIGATION_POLICY_FORCE_RELOCATE_IMAGES_ALWAYS_ON_REQ_RELOCS
+                                         | PROCESS_CREATION_MITIGATION_POLICY_HEAP_TERMINATE_ALWAYS_ON
+                                         | PROCESS_CREATION_MITIGATION_POLICY_BOTTOM_UP_ASLR_ALWAYS_ON
+                                         | PROCESS_CREATION_MITIGATION_POLICY_HIGH_ENTROPY_ASLR_ALWAYS_ON
+                                         | PROCESS_CREATION_MITIGATION_POLICY_STRICT_HANDLE_CHECKS_ALWAYS_ON
+                                         | PROCESS_CREATION_MITIGATION_POLICY_WIN32K_SYSTEM_CALL_DISABLE_ALWAYS_ON
+                                         | PROCESS_CREATION_MITIGATION_POLICY_EXTENSION_POINT_DISABLE_ALWAYS_ON
+                                         | PROCESS_CREATION_MITIGATION_POLICY_CONTROL_FLOW_GUARD_ALWAYS_ON
+                                         | PROCESS_CREATION_MITIGATION_POLICY_PROHIBIT_DYNAMIC_CODE_ALWAYS_ON
+                                         | PROCESS_CREATION_MITIGATION_POLICY_FONT_DISABLE_ALWAYS_ON
+                                         | PROCESS_CREATION_MITIGATION_POLICY_IMAGE_LOAD_NO_REMOTE_ALWAYS_ON
+                                         | PROCESS_CREATION_MITIGATION_POLICY_IMAGE_LOAD_NO_LOW_LABEL_ALWAYS_ON;
+        procAttributeList.update_attribute(PROC_THREAD_ATTRIBUTE_MITIGATION_POLICY, &mitigations, sizeof(mitigations));
+
+        STARTUPINFOEXW startupInfo{};
+        startupInfo.StartupInfo.cb          = sizeof(startupInfo);
+        startupInfo.StartupInfo.dwFlags     = STARTF_USESTDHANDLES | STARTF_USESHOWWINDOW;
+        startupInfo.StartupInfo.hStdInput   = inheritTheseHandles[0];
+        startupInfo.StartupInfo.hStdOutput  = inheritTheseHandles[1];
+        startupInfo.StartupInfo.hStdError   = inheritTheseHandles[1];
+        startupInfo.StartupInfo.wShowWindow = SW_HIDE;
+        startupInfo.lpAttributeList         = procAttributeList;
+
+        runningJob = create_kill_on_job_close_job();
+
+        auto procInfo = create_process(applicationName, commandLine, nullptr, nullptr, TRUE,
+            creationFlags | CREATE_UNICODE_ENVIRONMENT | CREATE_SUSPENDED, environment.get(), currentDirectory,
+            &startupInfo.StartupInfo);
+
+        runningProcess = std::move(procInfo.hProcess);
+        if (!AssignProcessToJobObject(runningJob.get(), runningProcess.get())) {
+            api_failure("AssignProcessToJobObject");
+        }
+
+        if (ResumeThread(procInfo.hThread.get()) == static_cast<DWORD>(-1)) {
+            api_failure("ResumeThread");
+        }
+    }
+
+    execution_result complete() {
+        DWORD exitCode;
+        if (!GetExitCodeProcess(runningProcess.get(), &exitCode)) {
+            api_failure("GetExitCodeProcess");
+        }
+
+        runningProcess.close();
+        runningJob.close();
+
+        return {exitCode, output.extract_and_reset()};
+    }
+
+private:
+    output_collecting_pipe output;
+    environment_block environment;
+    handle<null_handle_policy> runningProcess;
+    handle<null_handle_policy> runningJob;
+};

--- a/tools/jobify/CMakeLists.txt
+++ b/tools/jobify/CMakeLists.txt
@@ -1,7 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-.vs/
-.vscode/
-/out/
-/tools/out/
+add_executable(jobify jobify.cpp ../inc/stljobs.h)

--- a/tools/jobify/jobify.cpp
+++ b/tools/jobify/jobify.cpp
@@ -1,33 +1,33 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
 #include "stljobs.h"
 #include <algorithm>
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 
 #include <Windows.h>
 
-wchar_t* get_subcommand() {
-    auto start     = ::GetCommandLineW();
-    const auto end = start + ::wcslen(start);
-    start          = std::find_if_not(start, end, is_space); // skip leading whitespace
-    if (start != end) {
-        if (*start == '"') {
+[[nodiscard]] wchar_t* get_subcommand() {
+    auto first      = GetCommandLineW();
+    const auto last = first + wcslen(first);
+    first           = std::find_if_not(first, last, is_exactly_space); // skip leading whitespace
+    if (first != last) {
+        if (*first == '"') {
             // assumes no escaped quotes in path
-            ++start;
-            start = std::find(start, end, L'"');
-            if (start != end) {
-                ++start;
+            ++first;
+            first = std::find(first, last, L'"');
+            if (first != last) {
+                ++first;
             }
         } else {
-            start = std::find_if(start, end, is_space);
+            first = std::find_if(first, last, is_exactly_space);
         }
 
-        start = std::find_if_not(start, end, is_space);
+        first = std::find_if_not(first, last, is_exactly_space);
     }
 
-    return start;
+    return first;
 }
 
 int main() {
@@ -35,33 +35,31 @@ int main() {
         const auto subcommand = get_subcommand();
         if (*subcommand) {
             put_self_in_job();
-            ::printf("[jobify] Executing: %ls\n", subcommand);
-            ::fflush(stdout);
+            printf("[jobify] Executing: %ls\n", subcommand);
+            fflush(stdout);
 
             STARTUPINFOW si{};
-            si.cb   = sizeof(si);
-            auto pi = create_process(
+            si.cb            = sizeof(si);
+            auto processInfo = create_process(
                 nullptr, subcommand, nullptr, nullptr, TRUE, INHERIT_PARENT_AFFINITY, nullptr, nullptr, &si);
 
-            pi.hThread.close();
-            if (::WaitForSingleObject(pi.hProcess.get(), INFINITE) != WAIT_OBJECT_0) {
+            processInfo.hThread.close();
+            if (WaitForSingleObject(processInfo.hProcess.get(), INFINITE) != WAIT_OBJECT_0) {
                 api_failure("WaitForSingleObject");
             }
 
             unsigned long exitCode;
-            if (!::GetExitCodeProcess(pi.hProcess.get(), &exitCode)) {
+            if (!GetExitCodeProcess(processInfo.hProcess.get(), &exitCode)) {
                 api_failure("GetExitCodeProcess");
             }
 
-            pi.hProcess.close();
-
-            ::printf("[jobify] Command exited with %lX\n", exitCode);
+            printf("[jobify] Command exited with 0x%lX\n", exitCode);
 
             return static_cast<int>(exitCode);
         }
 
-        ::puts("[jobify] Usage: jobify.exe subcommand");
-        ::puts("[jobify] No command supplied, terminating.");
+        puts("[jobify] Usage: jobify.exe subcommand");
+        puts("[jobify] No command supplied, terminating.");
         return 1;
     } catch (api_exception& api) {
         api.give_up();

--- a/tools/jobify/jobify.cpp
+++ b/tools/jobify/jobify.cpp
@@ -8,6 +8,7 @@
 
 #include <Windows.h>
 
+// Gets the command line with the path to jobify.exe removed from the beginning.
 [[nodiscard]] wchar_t* get_subcommand() {
     auto first      = GetCommandLineW();
     const auto last = first + wcslen(first);

--- a/tools/jobify/jobify.cpp
+++ b/tools/jobify/jobify.cpp
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#include "stljobs.h"
+#include <algorithm>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <Windows.h>
+
+wchar_t* get_subcommand() {
+    auto start     = ::GetCommandLineW();
+    const auto end = start + ::wcslen(start);
+    start          = std::find_if_not(start, end, is_space); // skip leading whitespace
+    if (start != end) {
+        if (*start == '"') {
+            // assumes no escaped quotes in path
+            ++start;
+            start = std::find(start, end, L'"');
+            if (start != end) {
+                ++start;
+            }
+        } else {
+            start = std::find_if(start, end, is_space);
+        }
+
+        start = std::find_if_not(start, end, is_space);
+    }
+
+    return start;
+}
+
+int main() {
+    try {
+        const auto subcommand = get_subcommand();
+        if (*subcommand) {
+            put_self_in_job();
+            ::printf("[jobify] Executing: %ls\n", subcommand);
+            ::fflush(stdout);
+
+            STARTUPINFOW si{};
+            si.cb   = sizeof(si);
+            auto pi = create_process(
+                nullptr, subcommand, nullptr, nullptr, TRUE, INHERIT_PARENT_AFFINITY, nullptr, nullptr, &si);
+
+            pi.hThread.close();
+            if (::WaitForSingleObject(pi.hProcess.get(), INFINITE) != WAIT_OBJECT_0) {
+                api_failure("WaitForSingleObject");
+            }
+
+            unsigned long exitCode;
+            if (!::GetExitCodeProcess(pi.hProcess.get(), &exitCode)) {
+                api_failure("GetExitCodeProcess");
+            }
+
+            pi.hProcess.close();
+
+            ::printf("[jobify] Command exited with %lX\n", exitCode);
+
+            return static_cast<int>(exitCode);
+        }
+
+        ::puts("[jobify] Usage: jobify.exe subcommand");
+        ::puts("[jobify] No command supplied, terminating.");
+        return 1;
+    } catch (api_exception& api) {
+        api.give_up();
+    }
+}

--- a/tools/parallelize/CMakeLists.txt
+++ b/tools/parallelize/CMakeLists.txt
@@ -1,0 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+add_executable(parallelize parallelize.cpp ../inc/stljobs.h)
+target_link_libraries(parallelize Userenv.lib)

--- a/tools/parallelize/parallelize.cpp
+++ b/tools/parallelize/parallelize.cpp
@@ -1,0 +1,203 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "stljobs.h"
+#include <algorithm>
+#include <condition_variable>
+#include <filesystem>
+#include <limits.h>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <stdexcept>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <vector>
+
+#include <Windows.h>
+
+class tp_wait {
+public:
+    tp_wait(PTP_WAIT_CALLBACK pfnwa, PVOID pv, PTP_CALLBACK_ENVIRON pcbe)
+        : wait(CreateThreadpoolWait(pfnwa, pv, pcbe)) {
+        if (!wait) {
+            api_failure("CreateThreadpoolWait");
+        }
+    }
+
+    tp_wait(const tp_wait&) = delete;
+    tp_wait& operator=(const tp_wait&) = delete;
+
+    void wait_for(const HANDLE waitOn) noexcept {
+        SetThreadpoolWait(wait, waitOn, nullptr);
+    }
+
+    ~tp_wait() {
+        WaitForThreadpoolWaitCallbacks(wait, TRUE);
+        CloseThreadpoolWait(wait);
+    }
+
+private:
+    PTP_WAIT wait{};
+};
+
+class parallelizer {
+public:
+    parallelizer() : subprocesses(std::make_unique<entry[]>(availableConcurrency)) {
+        for (std::size_t idx = 0; idx < availableConcurrency; ++idx) {
+            subprocesses[idx].parent = this;
+        }
+    }
+
+    void add_command(std::wstring&& toRun) {
+        std::lock_guard lck(mtx);
+        const auto oldCommandsSize = commands.size();
+        commands.emplace_back(std::move(toRun), std::nullopt);
+        auto localConcurrency = runningConcurrency.load(std::memory_order_relaxed);
+        if (availableConcurrency == localConcurrency) {
+            return;
+        }
+
+        runningConcurrency.store(localConcurrency + 1, std::memory_order_relaxed);
+        std::size_t scheduledOn = 0;
+        while (subprocesses[scheduledOn].commandRunning != SIZE_MAX) {
+            ++scheduledOn;
+        }
+
+        nextCommandToRun = oldCommandsSize + 1;
+        subprocesses[scheduledOn].schedule(oldCommandsSize);
+        update_display();
+    }
+
+    void wait_all() noexcept {
+        std::unique_lock lck{mtx};
+        cv.wait(lck, [this] { return runningConcurrency.load(std::memory_order_relaxed) == 0; });
+    }
+
+    const std::vector<std::pair<std::wstring, std::optional<execution_result>>>& results() const {
+        assert(runningConcurrency.load(std::memory_order_relaxed) == 0);
+        return commands;
+    }
+
+private:
+    struct entry;
+    std::mutex mtx{};
+    std::condition_variable cv{};
+    std::vector<std::pair<std::wstring, std::optional<execution_result>>> commands{};
+    std::size_t nextCommandToRun{0};
+    std::size_t availableConcurrency{std::thread::hardware_concurrency()};
+    std::atomic<std::size_t> runningConcurrency{0};
+    std::unique_ptr<entry[]> subprocesses;
+
+    struct entry {
+        parallelizer* parent;
+        std::size_t commandRunning{SIZE_MAX}; // guarded by parent->mtx
+        subprocess_executive executive;
+        tp_wait tpWait{callback, this, nullptr};
+
+        static void __stdcall callback(
+            PTP_CALLBACK_INSTANCE, void* thisRaw, PTP_WAIT, TP_WAIT_RESULT waitDisposition) noexcept {
+            assert(waitDisposition == WAIT_OBJECT_0);
+            (void) waitDisposition;
+            const auto this_  = static_cast<entry*>(thisRaw);
+            const auto parent = this_->parent;
+            auto results      = this_->executive.complete();
+            std::lock_guard lck{parent->mtx};
+            parent->commands[this_->commandRunning].second.emplace(std::move(results));
+            if (parent->nextCommandToRun == parent->commands.size()) {
+                this_->commandRunning = SIZE_MAX;
+                if (parent->runningConcurrency.fetch_sub(1, std::memory_order_relaxed) == 1) {
+                    parent->cv.notify_all();
+                }
+            } else {
+                this_->schedule(parent->nextCommandToRun++);
+            }
+
+            parent->update_display();
+        }
+
+        void schedule(std::size_t command) {
+            commandRunning = command;
+            executive.begin_execution(nullptr, parent->commands[command].first.data(), 0, nullptr);
+            tpWait.wait_for(executive.get_wait_handle());
+        }
+    };
+
+    void update_display() noexcept {
+        const auto commandsSize = commands.size();
+        const auto next         = nextCommandToRun;
+        const auto running      = runningConcurrency.load(std::memory_order_relaxed);
+        assert(running <= next);
+        printf("%zu scheduled %zu completed %zu running\n", commandsSize, next - running, running);
+    }
+};
+
+inline void schedule_command(parallelizer& p, const std::wstring_view commandPrefix, const std::wstring& native) {
+    std::wstring toExecute;
+    toExecute.reserve(commandPrefix.size() + native.size() + 1);
+    toExecute.assign(commandPrefix);
+    toExecute.push_back(L' ');
+    toExecute.append(native);
+    p.add_command(std::move(toExecute));
+}
+
+extern "C" int wmain(int argc, wchar_t* argv[]) {
+    try {
+        if (argc < 3) {
+            puts("Usage: parallelize.exe commandPrefix pathRoots");
+            return 1;
+        }
+
+        parallelizer p;
+        std::wstring_view commandPrefix(argv[1]);
+        for (int idx = 2; idx < argc; ++idx) {
+            std::filesystem::path thisSpec(argv[idx]);
+            if (std::filesystem::is_regular_file(thisSpec)) {
+                schedule_command(p, commandPrefix, thisSpec.native());
+                continue;
+            }
+
+            for (const auto& dirEntry : std::filesystem::recursive_directory_iterator(std::move(thisSpec))) {
+                if (!dirEntry.is_regular_file()) {
+                    printf("Skipping non-regular-file %ls\n", dirEntry.path().c_str());
+                    continue;
+                }
+
+                schedule_command(p, commandPrefix, dirEntry.path().native());
+            }
+        }
+
+        p.wait_all();
+        auto& ran          = p.results();
+        const auto success = [](const std::pair<std::wstring, std::optional<execution_result>>& command) noexcept {
+            auto& result = command.second.value();
+            return result.exitCode == 0 && result.output.empty();
+        };
+
+        const std::size_t successes = std::count_if(ran.begin(), ran.end(), success);
+        printf("%zu commands ran successfully.\n", successes);
+        if (successes == ran.size()) {
+            return 0;
+        }
+
+        for (auto& command : ran) {
+            if (success(command)) {
+                continue;
+            }
+
+            auto& result = command.second.value();
+            printf("%ls exited with 0x%08lX and output:\n%s\n", command.first.c_str(), result.exitCode,
+                result.output.c_str());
+        }
+
+        return 1;
+    } catch (std::filesystem::filesystem_error& err) {
+        fputs(err.what(), stderr);
+        abort();
+    } catch (api_exception& api) {
+        api.give_up();
+    }
+}

--- a/tools/parallelize/parallelize.cpp
+++ b/tools/parallelize/parallelize.cpp
@@ -121,7 +121,7 @@ private:
             parent->update_display();
         }
 
-        void schedule(size_t command) {
+        void schedule(const size_t command) {
             commandRunning = command;
             executive.begin_execution(nullptr, parent->commands[command].first.data(), 0, nullptr);
             tpWait.wait_for(executive.get_wait_handle());


### PR DESCRIPTION
A component we needed as part of our minimal test harness was some ability to capture command line output from multiple subprocesses in parallel. There's a useful program we can build out of that without having test discovery working yet, just a little helper to run a command against every file in tree(s) in parallel, protected by NT Jobs. This helps flush out bugs in the scheduling machinery without also needing to worry about bugs in the test discovery/execution, as well as just producing a useful program we might use elsewhere.

I expect this to actually be most of the code for the test harness since our tests consist of "grep this tree for .cpp files, compile them with compiler switch cocktails, and ensure the output program works".

Time improvement comparison:
Most recent successful build https://dev.azure.com/vclibs/STL/_build/results?buildId=629 spends 37s enforcing clang-format.
First successful build of this PR https://dev.azure.com/vclibs/STL/_build/results?buildId=635 spends 7s building the support tools and 8s enforcing clang-format (60% less time than serial even with building `parallelize.exe` overhead)