### PR TITLE
Workaround clang __is_base_of bug in <type_traits>

### DIFF
--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -1187,6 +1187,17 @@ template <class _Ty, unsigned int _Ix = 0>
 struct extent : integral_constant<size_t, extent_v<_Ty, _Ix>> {};
 
 // STRUCT TEMPLATE is_base_of
+#ifdef __clang__ // TRANSITION, Clang 9
+template <class _Base, class _Derived, bool = __is_class(_Base) && __is_class(_Derived)>
+_INLINE_VAR constexpr bool is_base_of_v = __is_base_of(_Base, _Derived);
+
+template <class _Base, class _Derived>
+_INLINE_VAR constexpr bool is_base_of_v<_Base, _Derived, false> = false;
+
+template <class _Base, class _Derived>
+struct is_base_of : bool_constant<is_base_of_v<_Base, _Derived>> {};
+
+#else // ^^^ workaround / no workaround vvv
 template <class _Base, class _Derived>
 struct is_base_of : bool_constant<__is_base_of(_Base, _Derived)> {
     // determine whether _Base is a base of or the same as _Derived
@@ -1194,6 +1205,7 @@ struct is_base_of : bool_constant<__is_base_of(_Base, _Derived)> {
 
 template <class _Base, class _Derived>
 _INLINE_VAR constexpr bool is_base_of_v = __is_base_of(_Base, _Derived);
+#endif // TRANSITION, Clang 9
 
 // STRUCT TEMPLATE decay
 template <class _Ty>


### PR DESCRIPTION
# Description

Clang's `__is_base_of` intrinsic incorrectly handles some corner cases involving incomplete union types before LLVM 9. Workaround by guarding with `__is_class`.

(This is a replay of [Microsoft-internal PR 206866](https://devdiv.visualstudio.com/DevDiv/_git/msvc/pullrequest/206866).)

# Checklist

If you're unsure about a box, leave it unchecked. A maintainer will help you.

If a box isn't applicable, add an explanation in **bold**.
For example: **(N/A: this is a bugfix, not a feature)**

- [X] I understand README.md. I also understand that acceptance of
  community PRs will be delayed until the test and CI systems are online.
- [X] If this is a feature addition, that feature has been voted into the
  C++ Working Draft.
- [X] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 .
- [X] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before CI is online, leave this unchecked for
  initial submission).
- [X] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [X] These changes were written from scratch using only this repository and
  the C++ Working Draft as a reference (and any other cited standards).
  If they were derived from a project that's already listed in NOTICE.txt,
  that's fine, but please mention it. If they were derived from any other
  project (including Boost and libc++, which are not yet listed in
  NOTICE.txt), you *must* mention it here, so we can determine whether the
  license is compatible and what else needs to be done.
