### PR TITLE
Update comments to follow custom autolink syntax

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -91,7 +91,7 @@ ColumnLimit:     120
 # DisableFormat:   false
 # ExperimentalAutoDetectBinPacking: false
 
-# NOTE: LLVM#39247, this emits damaged "// namespace _DEPRECATE_TR1_NAMESPACEtr1".
+# NOTE: LLVM-39247, this emits damaged "// namespace _DEPRECATE_TR1_NAMESPACEtr1".
 # FixNamespaceComments: true
 FixNamespaceComments: false
 

--- a/stl/inc/__msvc_all_public_headers.hpp
+++ b/stl/inc/__msvc_all_public_headers.hpp
@@ -12,17 +12,17 @@
 #pragma warning(push)
 #pragma warning(1 : 4668) // 'MEOW' is not defined as a preprocessor macro, replacing with '0' for '#if/#elif'
 
-// DevDiv#255593 "All STL headers should protect themselves from macroized new"
+// All STL headers should protect themselves from macroized new.
 #pragma push_macro("new")
 #undef new
 #define new WILL NOT COMPILE
 
-// VSO#768746: mbctype.h macroizes _MS, _MP, _M1, and _M2. Include it first for test coverage.
+// VSO-768746: mbctype.h macroizes _MS, _MP, _M1, and _M2. Include it first for test coverage.
 #ifndef _MSVC_TESTING_NVCC
 #include <mbctype.h>
 #endif // _MSVC_TESTING_NVCC
 
-#if 1 // TRANSITION, MSFT:17090155 (UCRT)
+#if 1 // TRANSITION, OS-17090155 (UCRT)
 #define _CRT_DECLARE_NONSTDC_NAMES 0
 #ifndef _MSVC_TESTING_NVCC
 #include <sys/stat.h>
@@ -30,7 +30,7 @@
 #include <sys/utime.h>
 #endif // _MSVC_TESTING_NVCC
 #undef _CRT_DECLARE_NONSTDC_NAMES
-#endif // TRANSITION, MSFT:17090155 (UCRT)
+#endif // TRANSITION, OS-17090155 (UCRT)
 
 #define _SILENCE_CXX17_C_HEADER_DEPRECATION_WARNING
 #define _SILENCE_CXX17_STRSTREAM_DEPRECATION_WARNING

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -2619,9 +2619,9 @@ _BidIt stable_partition(_ExPo&&, _BidIt _First, _BidIt _Last, _Pr _Pred) noexcep
 template <class _RanIt, class _Ty, class _Pr>
 void _Push_heap_by_index(_RanIt _First, _Iter_diff_t<_RanIt> _Hole, _Iter_diff_t<_RanIt> _Top, _Ty&& _Val, _Pr _Pred) {
     // percolate _Hole to _Top or where _Val belongs, using _Pred
-    for (_Iter_diff_t<_RanIt> _Idx = (_Hole - 1) >> 1; // TRANSITION, VSO#433486
+    for (_Iter_diff_t<_RanIt> _Idx = (_Hole - 1) >> 1; // TRANSITION, VSO-433486
          _Top < _Hole && _DEBUG_LT_PRED(_Pred, *(_First + _Idx), _Val);
-         _Idx = (_Hole - 1) >> 1) { // TRANSITION, VSO#433486
+         _Idx = (_Hole - 1) >> 1) { // TRANSITION, VSO-433486
         // move _Hole up to parent
         *(_First + _Hole) = _STD move(*(_First + _Idx));
         _Hole             = _Idx;
@@ -2660,7 +2660,7 @@ void _Pop_heap_hole_by_index(_RanIt _First, _Iter_diff_t<_RanIt> _Hole, _Iter_di
 
     // Check whether _Idx can have a child before calculating that child's index, since
     // calculating the child's index can trigger integer overflows
-    const _Diff _Max_sequence_non_leaf = (_Bottom - 1) >> 1; // TRANSITION, VSO#433486
+    const _Diff _Max_sequence_non_leaf = (_Bottom - 1) >> 1; // TRANSITION, VSO-433486
     while (_Idx < _Max_sequence_non_leaf) { // move _Hole down to larger child
         _Idx = 2 * _Idx + 2;
         if (_DEBUG_LT_PRED(_Pred, *(_First + _Idx), *(_First + (_Idx - 1)))) {
@@ -2714,7 +2714,7 @@ template <class _RanIt, class _Pr>
 void _Make_heap_unchecked(_RanIt _First, _RanIt _Last, _Pr _Pred) {
     // make nontrivial [_First, _Last) into a heap, using _Pred
     _Iter_diff_t<_RanIt> _Bottom = _Last - _First;
-    for (_Iter_diff_t<_RanIt> _Hole = _Bottom >> 1; 0 < _Hole;) { // TRANSITION, VSO#433486
+    for (_Iter_diff_t<_RanIt> _Hole = _Bottom >> 1; 0 < _Hole;) { // TRANSITION, VSO-433486
         // reheap top half, bottom to top
         --_Hole;
         _Iter_value_t<_RanIt> _Val = _STD move(*(_First + _Hole));
@@ -2739,7 +2739,7 @@ _RanIt _Is_heap_until_unchecked(_RanIt _First, _RanIt _Last, _Pr _Pred) {
     // find extent of range that is a heap ordered by _Pred
     const _Iter_diff_t<_RanIt> _Size = _Last - _First;
     for (_Iter_diff_t<_RanIt> _Off = 1; _Off < _Size; ++_Off) {
-        if (_DEBUG_LT_PRED(_Pred, _First[(_Off - 1) >> 1], _First[_Off])) { // TRANSITION, VSO#433486
+        if (_DEBUG_LT_PRED(_Pred, _First[(_Off - 1) >> 1], _First[_Off])) { // TRANSITION, VSO-433486
             return _First + _Off;
         }
     }
@@ -2840,7 +2840,7 @@ _NODISCARD _FwdIt upper_bound(_FwdIt _First, _FwdIt _Last, const _Ty& _Val, _Pr 
     _Iter_diff_t<_FwdIt> _Count = _STD distance(_UFirst, _Get_unwrapped(_Last));
 
     while (0 < _Count) { // divide and conquer, find half that contains answer
-        _Iter_diff_t<_FwdIt> _Count2 = _Count >> 1; // TRANSITION, VSO#433486
+        _Iter_diff_t<_FwdIt> _Count2 = _Count >> 1; // TRANSITION, VSO-433486
         const auto _UMid             = _STD next(_UFirst, _Count2);
         if (_Pred(_Val, *_UMid)) {
             _Count = _Count2;
@@ -2878,7 +2878,7 @@ _NODISCARD pair<_FwdIt, _FwdIt> equal_range(_FwdIt _First, _FwdIt _Last, const _
             break;
         }
 
-        _Diff _Count2    = _Count >> 1; // TRANSITION, VSO#433486
+        _Diff _Count2    = _Count >> 1; // TRANSITION, VSO-433486
         const auto _UMid = _STD next(_UFirst, _Count2);
         if (_DEBUG_LT_PRED(_Pred, *_UMid, _Val)) { // range begins above _UMid, loop
             _UFirst = _Next_iter(_UMid);
@@ -3173,13 +3173,13 @@ void _Buffered_inplace_merge_divide_and_conquer(_BidIt _First, _BidIt _Mid, _Bid
     // merge sorted [_First, _Mid) with sorted [_Mid, _Last), using _Pred
     // usual invariants apply
     if (_Count1 <= _Count2) {
-        const _Iter_diff_t<_BidIt> _Count1n = _Count1 >> 1; // TRANSITION, VSO#433486
+        const _Iter_diff_t<_BidIt> _Count1n = _Count1 >> 1; // TRANSITION, VSO-433486
         const _BidIt _Firstn                = _STD next(_First, _Count1n);
         const _BidIt _Lastn                 = _STD lower_bound(_Mid, _Last, *_Firstn, _Pred);
         _Buffered_inplace_merge_divide_and_conquer2(_First, _Mid, _Last, _Count1, _Count2, _Temp_ptr, _Capacity, _Pred,
             _Firstn, _Lastn, _Count1n, _STD distance(_Mid, _Lastn));
     } else {
-        const _Iter_diff_t<_BidIt> _Count2n = _Count2 >> 1; // TRANSITION, VSO#433486
+        const _Iter_diff_t<_BidIt> _Count2n = _Count2 >> 1; // TRANSITION, VSO-433486
         const _BidIt _Lastn                 = _STD next(_Mid, _Count2n);
         const _BidIt _Firstn                = _STD upper_bound(_First, _Mid, *_Lastn, _Pred);
         _Buffered_inplace_merge_divide_and_conquer2(_First, _Mid, _Last, _Count1, _Count2, _Temp_ptr, _Capacity, _Pred,
@@ -3376,7 +3376,7 @@ void _Guess_median_unchecked(_RanIt _First, _RanIt _Mid, _RanIt _Last, _Pr _Pred
 template <class _RanIt, class _Pr>
 pair<_RanIt, _RanIt> _Partition_by_median_guess_unchecked(_RanIt _First, _RanIt _Last, _Pr _Pred) {
     // partition [_First, _Last), using _Pred
-    _RanIt _Mid = _First + ((_Last - _First) >> 1); // TRANSITION, VSO#433486
+    _RanIt _Mid = _First + ((_Last - _First) >> 1); // TRANSITION, VSO-433486
     _Guess_median_unchecked(_First, _Mid, _Last - 1, _Pred);
     _RanIt _Pfirst = _Mid;
     _RanIt _Plast  = _Pfirst + 1;
@@ -3446,7 +3446,7 @@ void _Sort_unchecked(_RanIt _First, _RanIt _Last, _Iter_diff_t<_RanIt> _Ideal, _
     _Iter_diff_t<_RanIt> _Count;
     while (_ISORT_MAX < (_Count = _Last - _First) && 0 < _Ideal) { // divide and conquer by quicksort
         auto _Mid = _Partition_by_median_guess_unchecked(_First, _Last, _Pred);
-        // TRANSITION, VSO#433486
+        // TRANSITION, VSO-433486
         _Ideal = (_Ideal >> 1) + (_Ideal >> 2); // allow 1.5 log2(N) divisions
 
         if (_Mid.first - _First < _Last - _Mid.second) { // loop on second half

--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -1471,11 +1471,11 @@ public:
 
     using _Base::_Base;
 
-#ifdef __clang__ // TRANSITION, VSO#406237
+#ifdef __clang__ // TRANSITION, VSO-406237
     constexpr atomic() noexcept(is_nothrow_default_constructible_v<_Ty>) : _Base() {}
 #else // ^^^ no workaround / workaround vvv
     atomic()                                  = default;
-#endif // TRANSITION, VSO#406237
+#endif // TRANSITION, VSO-406237
 
     atomic(const atomic&) = delete;
     atomic& operator=(const atomic&) = delete;
@@ -1975,11 +1975,11 @@ struct atomic_flag { // flag with test-and-set semantics
         _Storage.store(false, _Order);
     }
 
-#ifdef __clang__ // TRANSITION, VSO#406237
+#ifdef __clang__ // TRANSITION, VSO-406237
     constexpr atomic_flag() noexcept = default;
 #else // ^^^ no workaround / workaround vvv
     atomic_flag() noexcept = default;
-#endif // TRANSITION, VSO#406237
+#endif // TRANSITION, VSO-406237
 
 #if 1 // TRANSITION, ABI
     atomic<long> _Storage;

--- a/stl/inc/charconv
+++ b/stl/inc/charconv
@@ -1676,7 +1676,7 @@ _NODISCARD errc _Convert_hexadecimal_string_to_floating_type(
 
 // C11 6.4.4.2 "Floating constants" (without floating-suffix, hexadecimal-prefix)
 // amended by C11 7.22.1.3 "The strtod, strtof, and strtold functions" making exponents optional
-// LWG 3080: "the sign '+' may only appear in the exponent part"
+// LWG-3080: "the sign '+' may only appear in the exponent part"
 
 // digit-sequence:
 //     digit

--- a/stl/inc/cmath
+++ b/stl/inc/cmath
@@ -1206,7 +1206,7 @@ _NODISCARD /* constexpr */ _Ty _Common_lerp(const _Ty _ArgA, const _Ty _ArgB, co
 }
 
 // As of 2019-06-17 it is unclear whether the "sufficient additional overloads" clause is intended to target lerp;
-// LWG 3223 is pending.
+// LWG-3223 is pending.
 
 _NODISCARD /* constexpr */ inline float lerp(
     const float _ArgA, const float _ArgB, const float _ArgT) noexcept /* strengthened */ {

--- a/stl/inc/concepts
+++ b/stl/inc/concepts
@@ -46,11 +46,11 @@ concept derived_from = __is_base_of(_Base, _Derived)
 // CONCEPT convertible_to
 template <class _From, class _To>
 concept convertible_to = __is_convertible_to(_From, _To)
-#if 1 // Implement the PR of LWG 3151
+#if 1 // Implement the PR of LWG-3151
     && requires { static_cast<_To>(_STD declval<_From>()); };
-#else // ^^^ LWG 3151 / N4810 vvv
+#else // ^^^ LWG-3151 / N4810 vvv
     && requires(_From (&_Fn)()) { static_cast<_To>(_Fn()); };
-#endif // select LWG 3151 vs. N4810
+#endif // select LWG-3151 vs. N4810
 
 // CONCEPT common_reference_with
 template <class _Ty1, class _Ty2>
@@ -113,9 +113,9 @@ concept constructible_from = destructible<_Ty>
     && __is_constructible(_Ty, _ArgTys...);
 
 // CONCEPT default_initializable
-template <class _Ty> // Per P1754R1 and LWG 3149
+template <class _Ty> // Per P1754R1 and LWG-3149
 concept default_initializable = constructible_from<_Ty>
-    && requires { _Ty{}; }; // && __is_default_initializable(_Ty); // TRANSITION, VSO#896348
+    && requires { _Ty{}; }; // && __is_default_initializable(_Ty); // TRANSITION, VSO-896348
 
 // CONCEPT move_constructible
 template <class _Ty>
@@ -129,7 +129,7 @@ concept _Has_class_or_enum_type = __is_class(remove_reference_t<_Ty>) || __is_en
 // CUSTOMIZATION POINT OBJECT ranges::swap
 namespace ranges {
     namespace _Swap {
-#ifndef __clang__ // TRANSITION, VSO#895622
+#ifndef __clang__ // TRANSITION, VSO-895622
         void swap();
 #endif // TRANSITION
 
@@ -184,11 +184,11 @@ concept swappable = requires(_Ty& __x, _Ty& __y) {
 // CONCEPT swappable_with
 template <class _Ty1, class _Ty2>
 concept swappable_with =
-#if 1 // Implement the PR of LWG 3175
+#if 1 // Implement the PR of LWG-3175
     common_reference_with<_Ty1, _Ty2>
-#else // ^^^ LWG 3175 / N4810 vvv
+#else // ^^^ LWG-3175 / N4810 vvv
     common_reference_with<const remove_reference_t<_Ty1>&, const remove_reference_t<_Ty2>&>
-#endif // select LWG 3175 vs. N4810
+#endif // select LWG-3175 vs. N4810
     && requires(_Ty1&& __t, _Ty2&& __u) {
         _STD ranges::swap(static_cast<_Ty1&&>(__t), static_cast<_Ty1&&>(__t));
         _STD ranges::swap(static_cast<_Ty2&&>(__u), static_cast<_Ty2&&>(__u));

--- a/stl/inc/condition_variable
+++ b/stl/inc/condition_variable
@@ -159,7 +159,7 @@ private:
     template <class _Mutex>
     static void _Relock(_Mutex& _Xtrnl) noexcept /* terminates */ {
         // relocks external mutex, terminate() on failure
-        // LWG 2135 says terminate rather than leaving the mutex unlocked;
+        // LWG-2135 says terminate rather than leaving the mutex unlocked;
         // we slam into noexcept here for that for easier user debugging
         _Xtrnl.lock();
     }

--- a/stl/inc/cvt/sjis_0208
+++ b/stl/inc/cvt/sjis_0208
@@ -57,7 +57,7 @@ namespace stdext {
                         // convert 2-byte code
                         unsigned char _By2 = static_cast<unsigned char>(*++_Mid1);
 
-                        if ((_By2 < 0x40 || 0x7e < _By2) && (_By2 < 0x80 && 0xfc < _By2)) { // TRANSITION, VSO#609129
+                        if ((_By2 < 0x40 || 0x7e < _By2) && (_By2 < 0x80 && 0xfc < _By2)) { // TRANSITION, VSO-609129
                             return _Mybase::error; // bad second byte
                         }
 

--- a/stl/inc/cwchar
+++ b/stl/inc/cwchar
@@ -9,7 +9,7 @@
 #include <yvals_core.h>
 #if _STL_COMPILER_PREPROCESSOR
 
-#include <cstdio> // TRANSITION, VSO#661721
+#include <cstdio> // TRANSITION, VSO-661721
 #include <wchar.h>
 
 #pragma pack(push, _CRT_PACKING)

--- a/stl/inc/execution
+++ b/stl/inc/execution
@@ -423,7 +423,7 @@ struct _Parallel_choose_min_chunk {
             }
         }
 
-        lock_guard<mutex> _Lck(_Mtx); // TRANSITION, VSO#671180
+        lock_guard<mutex> _Lck(_Mtx); // TRANSITION, VSO-671180
         if (_Selected_chunk.load(memory_order_relaxed) == _Chunk) {
             _Result = _Local_result;
         }
@@ -458,7 +458,7 @@ struct _Parallel_choose_max_chunk {
             }
         }
 
-        lock_guard<mutex> _Lck(_Mtx); // TRANSITION, VSO#671180
+        lock_guard<mutex> _Lck(_Mtx); // TRANSITION, VSO-671180
         if (_Selected_chunk.load(memory_order_relaxed) == _Chunk) {
             _Result = _Local_result;
         }
@@ -566,7 +566,7 @@ public:
             auto _New_segment = _Segment->_Grow(_Local_b, _Local_t);
             _Circular_buffer<_Ty>* _Detached_segment;
             {
-                lock_guard<mutex> _Lck(_Segment_lock); // TRANSITION, VSO#671180
+                lock_guard<mutex> _Lck(_Segment_lock); // TRANSITION, VSO-671180
                 _Detached_segment = _STD exchange(_Segment, _New_segment);
             } // unlock
 
@@ -591,7 +591,7 @@ public:
 
             _Circular_buffer<_Ty>* _Stealing_segment;
             {
-                lock_guard<mutex> _Lck(_Segment_lock); // TRANSITION, VSO#671180
+                lock_guard<mutex> _Lck(_Segment_lock); // TRANSITION, VSO-671180
                 _Stealing_segment = _Segment;
                 _MT_INCR(_Stealing_segment->_Ref_count);
             }
@@ -730,7 +730,7 @@ struct _Work_stealing_team { // inter-thread communication for threads working o
     _Work_stealing_membership<_Ty> _Join_team() noexcept {
         size_t _Id;
         {
-            lock_guard<mutex> _Lck(_Available_mutex); // TRANSITION, VSO#671180
+            lock_guard<mutex> _Lck(_Available_mutex); // TRANSITION, VSO-671180
             _Id = _Available_queues.top();
             _Available_queues.pop();
         } // unlock
@@ -744,7 +744,7 @@ struct _Work_stealing_team { // inter-thread communication for threads working o
     }
 
     void _Leave_team(size_t _Id) noexcept {
-        lock_guard<mutex> _Lck(_Available_mutex); // TRANSITION, VSO#671180
+        lock_guard<mutex> _Lck(_Available_mutex); // TRANSITION, VSO-671180
         _Available_queues.push(_Id);
     }
 
@@ -1006,16 +1006,16 @@ template <class _InIt1, class _InIt2>
 _Common_diff_t<_InIt1, _InIt2> _Distance_any(_InIt1 _First1, _InIt1 _Last1, _InIt2 _First2,
     _InIt2 _Last2) { // get the distance from 2 ranges which should have identical lengths
     if constexpr (_Is_random_iter_v<_InIt1>) {
-        (void) _First2; // TRANSITION, VSO#486357
-        (void) _Last2; // TRANSITION, VSO#486357
+        (void) _First2; // TRANSITION, VSO-486357
+        (void) _Last2; // TRANSITION, VSO-486357
         return _Last1 - _First1;
     } else if constexpr (_Is_random_iter_v<_InIt2>) {
-        (void) _First1; // TRANSITION, VSO#486357
-        (void) _Last1; // TRANSITION, VSO#486357
+        (void) _First1; // TRANSITION, VSO-486357
+        (void) _Last1; // TRANSITION, VSO-486357
         return _Last2 - _First2;
     } else {
-        (void) _First2; // TRANSITION, VSO#486357
-        (void) _Last2; // TRANSITION, VSO#486357
+        (void) _First2; // TRANSITION, VSO-486357
+        (void) _Last2; // TRANSITION, VSO-486357
         return _STD distance(_First1, _Last1);
     }
 }
@@ -3026,7 +3026,7 @@ void stable_sort(_ExPo&&, const _BidIt _First, const _BidIt _Last, _Pr _Pred) no
         _Hw_threads          = __std_parallel_algorithms_hw_threads();
         _Attempt_parallelism = _Hw_threads > 1;
     } else {
-        (void) _Hw_threads; // TRANSITION, VSO#486357
+        (void) _Hw_threads; // TRANSITION, VSO-486357
         _Attempt_parallelism = false;
     }
 
@@ -4055,7 +4055,7 @@ template <class _InIt, class _Ty, class _BinOp>
 _Ty _Reduce_move_unchecked(_InIt _First, const _InIt _Last, _Ty _Val, _BinOp _Reduce_op) {
     // return reduction, choose optimization
     if constexpr (_Plus_on_arithmetic_ranges_reduction_v<_Unwrapped_t<_InIt>, _Ty, _BinOp>) {
-        (void) _Reduce_op; // TRANSITION, VSO#486357
+        (void) _Reduce_op; // TRANSITION, VSO-486357
         return _Reduce_plus_arithmetic_ranges(_First, _Last, _Val);
     } else {
         for (; _First != _Last; ++_First) {
@@ -4071,7 +4071,7 @@ _Ty _Reduce_at_least_two(const _FwdIt _First, const _FwdIt _Last, _BinOp _Reduce
     // return reduction with no initial value
     // pre: distance(_First, _Last) >= 2
     if constexpr (_Plus_on_arithmetic_ranges_reduction_v<_FwdIt, _Ty, _BinOp>) {
-        (void) _Reduce_op; // TRANSITION, VSO#486357
+        (void) _Reduce_op; // TRANSITION, VSO-486357
         return _Reduce_plus_arithmetic_ranges(_First, _Last, _Ty{0});
     } else {
         auto _Next = _First;

--- a/stl/inc/experimental/generator
+++ b/stl/inc/experimental/generator
@@ -34,7 +34,7 @@ namespace experimental {
         struct promise_type {
             _Ty const* _CurrentValue;
 #ifdef _CPPUNWIND
-            // TRANSITION, VSO#967814
+            // TRANSITION, VSO-967814
             exception_ptr _Eptr;
 #endif // _CPPUNWIND
 

--- a/stl/inc/filesystem
+++ b/stl/inc/filesystem
@@ -594,7 +594,7 @@ namespace filesystem {
 
     _NODISCARD inline bool _Is_drive_prefix_with_slash_slash_question(const wstring_view _Text) {
         // test if _Text starts with a \\?\X: prefix
-        using namespace _STD string_view_literals; // TRANSITION, VSO#571749
+        using namespace _STD string_view_literals; // TRANSITION, VSO-571749
         return _Text.size() >= 6 && _Text._Starts_with(LR"(\\?\)"sv) && _Is_drive_prefix(_Text.data() + 4);
     }
 
@@ -1222,7 +1222,7 @@ namespace filesystem {
         }
 
         _NODISCARD path lexically_normal() const {
-            using namespace _STD string_view_literals; // TRANSITION, VSO#571749
+            using namespace _STD string_view_literals; // TRANSITION, VSO-571749
 
             constexpr wstring_view _Dot     = L"."sv;
             constexpr wstring_view _Dot_dot = L".."sv;
@@ -1354,15 +1354,15 @@ namespace filesystem {
         _NODISCARD inline iterator end() const noexcept; // strengthened
 
         template <class _Elem, class _Traits>
-        friend _STD basic_ostream<_Elem, _Traits>& operator<<( // TRANSITION, VSO#570323
-            _STD basic_ostream<_Elem, _Traits>& _Ostr, const path& _Path) { // TRANSITION, VSO#570323
+        friend _STD basic_ostream<_Elem, _Traits>& operator<<( // TRANSITION, VSO-570323
+            _STD basic_ostream<_Elem, _Traits>& _Ostr, const path& _Path) { // TRANSITION, VSO-570323
             // insert a path into a stream
             return _Ostr << _STD quoted(_Path.string<_Elem, _Traits>());
         }
 
         template <class _Elem, class _Traits>
-        friend _STD basic_istream<_Elem, _Traits>& operator>>( // TRANSITION, VSO#570323
-            _STD basic_istream<_Elem, _Traits>& _Istr, path& _Path) { // TRANSITION, VSO#570323
+        friend _STD basic_istream<_Elem, _Traits>& operator>>( // TRANSITION, VSO-570323
+            _STD basic_istream<_Elem, _Traits>& _Istr, path& _Path) { // TRANSITION, VSO-570323
             // extract a path from a stream
             basic_string<_Elem, _Traits> _Tmp;
             _Istr >> _STD quoted(_Tmp);
@@ -1649,7 +1649,7 @@ namespace filesystem {
     }
 
     _NODISCARD inline path path::lexically_relative(const path& _Base) const {
-        using namespace _STD string_view_literals; // TRANSITION, VSO#571749
+        using namespace _STD string_view_literals; // TRANSITION, VSO-571749
 
         constexpr wstring_view _Dot     = L"."sv;
         constexpr wstring_view _Dot_dot = L".."sv;
@@ -1772,7 +1772,7 @@ namespace filesystem {
 
     private:
         static string _Pretty_message(const string_view _Op, const path& _Path1, const path& _Path2 = {}) {
-            using namespace _STD string_view_literals; // TRANSITION, VSO#571749
+            using namespace _STD string_view_literals; // TRANSITION, VSO-571749
             string _Result;
             const string _Path1_str = _Path1.string();
             const string _Path2_str = _Path2.string();
@@ -1902,7 +1902,7 @@ namespace filesystem {
         create_symlinks   = 0x2000,
         create_hard_links = 0x4000,
 
-        _Unspecified_copy_prevention_tag = 0x10000 // to be removed by LWG3057
+        _Unspecified_copy_prevention_tag = 0x10000 // to be removed by LWG-3057
     };
 
     _BITMASK_OPS(copy_options)
@@ -2512,7 +2512,7 @@ namespace filesystem {
 
         _NODISCARD static __std_win_error _Open_dir(
             path& _Path, const directory_options _Options_arg, _Find_file_handle& _Dir, __std_fs_find_data& _Data) {
-            using namespace _STD string_view_literals; // TRANSITION, VSO#571749
+            using namespace _STD string_view_literals; // TRANSITION, VSO-571749
             const size_t _Null_term_len = _CSTD wcslen(_Path.c_str());
             if (_Null_term_len == 0 || _Null_term_len != _Path.native().size()) {
                 return __std_win_error::_File_not_found;
@@ -2983,7 +2983,7 @@ namespace filesystem {
 
     // FUNCTION canonical
     _NODISCARD inline __std_win_error _Canonical(path& _Result, const wstring& _Text) { // pre: _Result.empty()
-        using namespace _STD string_view_literals; // TRANSITION, VSO#571749
+        using namespace _STD string_view_literals; // TRANSITION, VSO-571749
         if (_Text.empty()) {
             return __std_win_error::_Success;
         }
@@ -4162,13 +4162,13 @@ namespace filesystem {
         const directory_entry& _From, const path& _To, const copy_options _Options, error_code& _Ec) {
         // implement copy, does not clear _Ec for callers
         // Standard quotes herein are relative to N4810
-        // The following parts of LWG3057 are implemented:
+        // The following parts of LWG-3057 are implemented:
         // * guarding equivalent() from nonexistent to
         // * replacing unspecified recursion prevention tag with copy_options::directories_only
-        // Other parts of LWG3057 remain under discussion in the committee and are not yet implemented.
+        // Other parts of LWG-3057 remain under discussion in the committee and are not yet implemented.
         //  (In particular, changes to existing destination flags, and error handling).
         const bool _Flink = (_Options & (copy_options::skip_symlinks | copy_options::copy_symlinks))
-                            != copy_options::none; // create_symlinks intentionally removed by LWG3057
+                            != copy_options::none; // create_symlinks intentionally removed by LWG-3057
         const auto _Fstat = _From._Get_any_status(_Flink ? _Symlink_status_stats_flags : _Status_stats_flags);
         if (_Fstat._Error != __std_win_error::_Success) { // report an error if exists(f) is false
             _Ec = _Make_ec(_Fstat._Error);
@@ -4251,7 +4251,7 @@ namespace filesystem {
             return;
         }
 
-        // The following condition modified by LWG3057:
+        // The following condition modified by LWG-3057:
         if (_STD filesystem::is_directory(_Fstat._Status)) {
             if ((_Options & copy_options::create_symlinks) != copy_options::none) {
                 _Ec = _STD make_error_code(errc::is_a_directory);
@@ -4263,7 +4263,7 @@ namespace filesystem {
                 return;
             }
 
-            // Note LWG3057 uses directories_only as the flag, instead of an unspecified copy_options value:
+            // Note LWG-3057 uses directories_only as the flag, instead of an unspecified copy_options value:
             if ((_Options & copy_options::recursive) != copy_options::none
                 || (_Options & copy_options::directories_only) == copy_options::none) {
                 for (directory_iterator _It(_From, _Ec);; _It.increment(_Ec)) {

--- a/stl/inc/functional
+++ b/stl/inc/functional
@@ -1351,7 +1351,7 @@ struct _Select_fixer<_Cv_TiD, true, false, 0> { // reference_wrapper fixer
 template <class _Cv_TiD>
 struct _Select_fixer<_Cv_TiD, false, true, 0> { // nested bind fixer
 #pragma warning(push)
-#pragma warning(disable : 4100) // TRANSITION, VSO#181496, unreferenced formal parameter
+#pragma warning(disable : 4100) // TRANSITION, VSO-181496, unreferenced formal parameter
     template <class _Untuple, size_t... _Jx>
     static auto _Apply(_Cv_TiD& _Tid, _Untuple&& _Ut,
         index_sequence<_Jx...>) -> decltype(_Tid(_STD get<_Jx>(_STD move(_Ut))...)) { // call a nested bind expression
@@ -1392,7 +1392,7 @@ auto _Fix_arg(_Cv_TiD& _Tid, _Untuple&& _Ut)
 }
 
 #pragma warning(push)
-#pragma warning(disable : 4100) // TRANSITION, VSO#181496, unreferenced formal parameter
+#pragma warning(disable : 4100) // TRANSITION, VSO-181496, unreferenced formal parameter
 // FUNCTION TEMPLATE _Call_binder
 template <class _Ret, size_t... _Ix, class _Cv_FD, class _Cv_tuple_TiD, class _Untuple>
 auto _Call_binder(_Invoker_ret<_Ret>, index_sequence<_Ix...>, _Cv_FD& _Obj, _Cv_tuple_TiD& _Tpl, _Untuple&& _Ut)

--- a/stl/inc/future
+++ b/stl/inc/future
@@ -1439,7 +1439,7 @@ template <class... _Types>
 class _Fake_no_copy_callable_adapter {
     // async() is built on packaged_task internals which incorrectly use
     // std::function, which requires that things be copyable. We can't fix this in an
-    // update, so this adapter turns copies into terminate(). When VSO#153581 is
+    // update, so this adapter turns copies into terminate(). When VSO-153581 is
     // fixed, remove this adapter.
     using _Storaget = tuple<decay_t<_Types>...>;
 

--- a/stl/inc/istream
+++ b/stl/inc/istream
@@ -787,7 +787,7 @@ basic_istream<_Elem, _Traits>& _Istream_extract_into_buffer(
         }
         _CATCH_IO_(ios_base, _Istr)
     }
-    __analysis_assume(static_cast<size_t>(_Current) < _Size); // TRANSITION, VSO#860375
+    __analysis_assume(static_cast<size_t>(_Current) < _Size); // TRANSITION, VSO-860375
     _Str[_Current] = _Elem(); // add terminating null character
     _Istr.width(0);
     if (_Current == 0) {

--- a/stl/inc/iterator
+++ b/stl/inc/iterator
@@ -318,9 +318,9 @@ public:
         return _Tmp;
     }
 
-#ifndef __CUDACC__ // TRANSITION, VSO#568006
+#ifndef __CUDACC__ // TRANSITION, VSO-568006
     _NODISCARD
-#endif // TRANSITION, VSO#568006
+#endif // TRANSITION, VSO-568006
     friend constexpr checked_array_iterator operator+(
         const difference_type _Off, const checked_array_iterator<_Ptr>& _Next) noexcept {
         return _Next + _Off;
@@ -492,9 +492,9 @@ public:
         return _Tmp;
     }
 
-#ifndef __CUDACC__ // TRANSITION, VSO#568006
+#ifndef __CUDACC__ // TRANSITION, VSO-568006
     _NODISCARD
-#endif // TRANSITION, VSO#568006
+#endif // TRANSITION, VSO-568006
     friend constexpr unchecked_array_iterator operator+(
         const difference_type _Off, const unchecked_array_iterator& _Next) noexcept {
         return _Next + _Off;

--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -1590,7 +1590,7 @@ _NODISCARD shared_ptr<_Ty> make_shared(_Types&&... _Args) { // make a shared_ptr
 // FUNCTION TEMPLATE allocate_shared
 template <class _Ty, class _Alloc, class... _Types>
 _NODISCARD shared_ptr<_Ty> allocate_shared(const _Alloc& _Al, _Types&&... _Args) { // make a shared_ptr
-    // Note: As of 2019-05-28, this implements the proposed resolution of LWG 3210 (which controls whether
+    // Note: As of 2019-05-28, this implements the proposed resolution of LWG-3210 (which controls whether
     // allocator::construct sees T or const T when _Ty is const qualified)
     using _Refoa   = _Ref_count_obj_alloc2<remove_cv_t<_Ty>, _Alloc>;
     using _Alblock = _Rebind_alloc_t<_Alloc, _Refoa>;

--- a/stl/inc/memory_resource
+++ b/stl/inc/memory_resource
@@ -114,7 +114,7 @@ namespace pmr {
     struct _Intrusive_list { // intrusive circular list of _Ty (which must derive from _Double_link<_Tag>)
         using _Link_type = _Double_link<_Tag>;
 
-        constexpr _Intrusive_list() noexcept { // TRANSITION, VSO#517878
+        constexpr _Intrusive_list() noexcept { // TRANSITION, VSO-517878
             // initialize this list to the empty state
         }
 

--- a/stl/inc/mutex
+++ b/stl/inc/mutex
@@ -595,7 +595,7 @@ public:
     }
 
     void wait(unique_lock<mutex>& _Lck) { // wait for signal
-        // Nothing to do to comply with LWG 2135 because std::mutex lock/unlock are nothrow
+        // Nothing to do to comply with LWG-2135 because std::mutex lock/unlock are nothrow
         _Check_C_return(_Cnd_wait(_Mycnd(), _Lck.mutex()->_Mymtx()));
     }
 
@@ -662,7 +662,7 @@ public:
             _Throw_Cpp_error(_OPERATION_NOT_PERMITTED);
         }
 
-        // Nothing to do to comply with LWG 2135 because std::mutex lock/unlock are nothrow
+        // Nothing to do to comply with LWG-2135 because std::mutex lock/unlock are nothrow
         const int _Res = _Cnd_timedwait(_Mycnd(), _Lck.mutex()->_Mymtx(), _Abs_time);
         switch (_Res) {
         case _Thrd_success:

--- a/stl/inc/numeric
+++ b/stl/inc/numeric
@@ -76,7 +76,7 @@ _NODISCARD _Ty reduce(const _InIt _First, const _InIt _Last, _Ty _Val, _BinOp _R
     auto _UFirst      = _Get_unwrapped(_First);
     const auto _ULast = _Get_unwrapped(_Last);
     if constexpr (_Plus_on_arithmetic_ranges_reduction_v<_Unwrapped_t<_InIt>, _Ty, _BinOp>) {
-        (void) _Reduce_op; // TRANSITION, VSO#486357
+        (void) _Reduce_op; // TRANSITION, VSO-486357
         return _Reduce_plus_arithmetic_ranges(_UFirst, _ULast, _Val);
     } else {
         for (; _UFirst != _ULast; ++_UFirst) {
@@ -201,8 +201,8 @@ _NODISCARD _Ty transform_reduce(
     const auto _ULast1 = _Get_unwrapped(_Last1);
     auto _UFirst2      = _Get_unwrapped_n(_First2, _Idl_distance<_InIt1>(_UFirst1, _ULast1));
     if constexpr (_Default_ops_transform_reduce_v<_Unwrapped_t<_InIt1>, _Unwrapped_t<_InIt2>, _Ty, _BinOp1, _BinOp2>) {
-        (void) _Reduce_op; // TRANSITION, VSO#486357
-        (void) _Transform_op; // TRANSITION, VSO#486357
+        (void) _Reduce_op; // TRANSITION, VSO-486357
+        (void) _Transform_op; // TRANSITION, VSO-486357
         return _Transform_reduce_arithmetic_defaults(_UFirst1, _ULast1, _UFirst2, _STD move(_Val));
     } else {
         for (; _UFirst1 != _ULast1; ++_UFirst1, (void) ++_UFirst2) {

--- a/stl/inc/ostream
+++ b/stl/inc/ostream
@@ -109,7 +109,7 @@ public:
         _STL_DISABLE_DEPRECATED_WARNING
         __CLR_OR_THIS_CALL ~sentry() noexcept {
 #if _HAS_EXCEPTIONS
-            if (!_STD uncaught_exception()) { // TRANSITION, was OS issue 15518458
+            if (!_STD uncaught_exception()) { // TRANSITION, ArchivedOS-12000909
                 this->_Myostr._Osfx();
             }
 #else // _HAS_EXCEPTIONS

--- a/stl/inc/ostream
+++ b/stl/inc/ostream
@@ -109,7 +109,7 @@ public:
         _STL_DISABLE_DEPRECATED_WARNING
         __CLR_OR_THIS_CALL ~sentry() noexcept {
 #if _HAS_EXCEPTIONS
-            if (!_STD uncaught_exception()) { // TRANSITION, OS#15518458
+            if (!_STD uncaught_exception()) { // TRANSITION, was OS issue 15518458
                 this->_Myostr._Osfx();
             }
 #else // _HAS_EXCEPTIONS
@@ -452,7 +452,7 @@ public:
         return *this;
     }
 
-#if _HAS_CXX17 // LWG 2221 "No formatted output operator for nullptr"
+#if _HAS_CXX17 // LWG-2221 "No formatted output operator for nullptr"
     template <class = void> // TRANSITION, ABI
     basic_ostream& operator<<(nullptr_t) { // insert a null pointer
         return *this << "nullptr";

--- a/stl/inc/random
+++ b/stl/inc/random
@@ -69,11 +69,11 @@ concept uniform_random_bit_generator = invocable<_Ty&> && unsigned_integral<invo
     (_Ty::min)(); requires same_as<decltype((_Ty::min)()), invoke_result_t<_Ty&>>;
     (_Ty::max)(); requires same_as<decltype((_Ty::max)()), invoke_result_t<_Ty&>>;
 #endif // _HAS_EXACT_COMPOUND_REQUIREMENT
-#if 1 // Implement the PR for LWG 3150
+#if 1 // Implement the PR for LWG-3150
     typename _Require_constant<(_Ty::min)()>;
     typename _Require_constant<(_Ty::max)()>;
     requires (_Ty::min)() < (_Ty::max)();
-#endif // LWG 3150
+#endif // LWG-3150
 };
 // clang-format on
 #endif // __cpp_lib_concepts
@@ -486,17 +486,17 @@ public:
         _Prev = _Temp;
     }
 
-#ifndef __CUDACC__ // TRANSITION, VSO#568006
+#ifndef __CUDACC__ // TRANSITION, VSO-568006
     _NODISCARD
-#endif // TRANSITION, VSO#568006
+#endif // TRANSITION, VSO-568006
     friend bool operator==(
         const linear_congruential_engine& _Lhs, const linear_congruential_engine& _Rhs) noexcept /* strengthened */ {
         return _Lhs._Prev == _Rhs._Prev;
     }
 
-#ifndef __CUDACC__ // TRANSITION, VSO#568006
+#ifndef __CUDACC__ // TRANSITION, VSO-568006
     _NODISCARD
-#endif // TRANSITION, VSO#568006
+#endif // TRANSITION, VSO-568006
     friend bool operator!=(
         const linear_congruential_engine& _Lhs, const linear_congruential_engine& _Rhs) noexcept /* strengthened */ {
         return _Lhs._Prev != _Rhs._Prev;
@@ -577,17 +577,17 @@ public:
         _Prev = _Temp;
     }
 
-#ifndef __CUDACC__ // TRANSITION, VSO#568006
+#ifndef __CUDACC__ // TRANSITION, VSO-568006
     _NODISCARD
-#endif // TRANSITION, VSO#568006
+#endif // TRANSITION, VSO-568006
     friend bool operator==(
         const linear_congruential& _Lhs, const linear_congruential& _Rhs) noexcept /* strengthened */ {
         return _Lhs._Prev == _Rhs._Prev;
     }
 
-#ifndef __CUDACC__ // TRANSITION, VSO#568006
+#ifndef __CUDACC__ // TRANSITION, VSO-568006
     _NODISCARD
-#endif // TRANSITION, VSO#568006
+#endif // TRANSITION, VSO-568006
     friend bool operator!=(
         const linear_congruential& _Lhs, const linear_congruential& _Rhs) noexcept /* strengthened */ {
         return _Lhs._Prev != _Rhs._Prev;

--- a/stl/inc/sstream
+++ b/stl/inc/sstream
@@ -294,7 +294,7 @@ protected:
 protected:
     void _Init(const _Elem* _Ptr, _Mysize_type _Count, int _State) {
         // initialize buffer to [_Ptr, _Ptr + _Count), set state
-        if (_Count > INT_MAX) { // TRANSITION, VSO#485517
+        if (_Count > INT_MAX) { // TRANSITION, VSO-485517
             _Xbad_alloc();
         }
 

--- a/stl/inc/string
+++ b/stl/inc/string
@@ -11,7 +11,7 @@
 #include <xstring>
 // The <cctype> include below is to workaround many projects that assumed
 // <string> includes it. We workaround it instead of fixing all the upstream
-// projects because <cctype> is inexpensive. See VSO#663136.
+// projects because <cctype> is inexpensive. See VSO-663136.
 #include <cctype>
 
 #pragma pack(push, _CRT_PACKING)

--- a/stl/inc/tuple
+++ b/stl/inc/tuple
@@ -115,7 +115,7 @@ _INLINE_VAR constexpr bool _Tuple_nothrow_assignable_v =
     _Tuple_nothrow_assignable_v0<tuple_size_v<_Dest> == sizeof...(_Srcs), _Dest, _Srcs...>;
 
 // STRUCT TEMPLATE _Tuple_convert_copy_val
-// Constrain tuple's converting copy constructor (LWG 2549)
+// Constrain tuple's converting copy constructor (LWG-2549)
 template <class _Myself, class... _Other>
 struct _Tuple_convert_copy_val : true_type {};
 
@@ -125,7 +125,7 @@ struct _Tuple_convert_copy_val<tuple<_This>, _Uty>
           is_convertible<const tuple<_Uty>&, _This>>> {};
 
 // STRUCT TEMPLATE _Tuple_convert_move_val
-// Constrain tuple's converting move constructor (LWG 2549)
+// Constrain tuple's converting move constructor (LWG-2549)
 template <class _Myself, class... _Other>
 struct _Tuple_convert_move_val : true_type {};
 
@@ -135,7 +135,7 @@ struct _Tuple_convert_move_val<tuple<_This>, _Uty>
           is_convertible<tuple<_Uty>, _This>>> {};
 
 // STRUCT TEMPLATE _Tuple_perfect_val
-// Constrain tuple's perfect forwarding constructor (LWG 3121)
+// Constrain tuple's perfect forwarding constructor (LWG-3121)
 template <class _Myself, class _This2, class... _Rest2>
 struct _Tuple_perfect_val : true_type {};
 
@@ -902,7 +902,7 @@ struct _Tuple_cat1 : _Tuple_cat2<tuple<>, index_sequence<>, index_sequence<>, 0,
 };
 
 #pragma warning(push)
-#pragma warning(disable : 4100) // TRANSITION, VSO#181496, unreferenced formal parameter
+#pragma warning(disable : 4100) // TRANSITION, VSO-181496, unreferenced formal parameter
 template <class _Ret, size_t... _Kx, size_t... _Ix, class _Ty>
 constexpr _Ret _Tuple_cat(index_sequence<_Kx...>, index_sequence<_Ix...>, _Ty&& _Arg) { // concatenate tuples
     return _Ret(_STD get<_Kx>(_STD get<_Ix>(_STD forward<_Ty>(_Arg)))...);
@@ -919,7 +919,7 @@ _NODISCARD constexpr typename _Tuple_cat1<_Tuples...>::type tuple_cat(_Tuples&&.
 #if _HAS_CXX17
 // FUNCTION TEMPLATE apply
 #pragma warning(push)
-#pragma warning(disable : 4100) // TRANSITION, VSO#181496, unreferenced formal parameter
+#pragma warning(disable : 4100) // TRANSITION, VSO-181496, unreferenced formal parameter
 template <class _Callable, class _Tuple, size_t... _Indices>
 constexpr decltype(auto) _Apply_impl(
     _Callable&& _Obj, _Tuple&& _Tpl, index_sequence<_Indices...>) { // invoke _Obj with the elements of _Tpl
@@ -935,7 +935,7 @@ constexpr decltype(auto) apply(_Callable&& _Obj, _Tuple&& _Tpl) { // invoke _Obj
 
 // FUNCTION TEMPLATE make_from_tuple
 #pragma warning(push)
-#pragma warning(disable : 4100) // TRANSITION, VSO#181496, unreferenced formal parameter
+#pragma warning(disable : 4100) // TRANSITION, VSO-181496, unreferenced formal parameter
 template <class _Ty, class _Tuple, size_t... _Indices>
 constexpr _Ty _Make_from_tuple_impl(
     _Tuple&& _Tpl, index_sequence<_Indices...>) { // construct _Ty from the elements of _Tpl
@@ -966,7 +966,7 @@ void _For_each_tuple_element(_Tpl&& _Tuple, _Fx _Func) { // call _Func() on each
 
 
 #pragma warning(push)
-#pragma warning(disable : 4100) // TRANSITION, VSO#181496, unreferenced formal parameter
+#pragma warning(disable : 4100) // TRANSITION, VSO-181496, unreferenced formal parameter
 // TEMPLATE CONSTRUCTOR pair::pair(tuple, tuple, sequence, sequence)
 template <class _Ty1, class _Ty2>
 template <class _Tuple1, class _Tuple2, size_t... _Indexes1, size_t... _Indexes2>

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -578,7 +578,7 @@ template <class _Ty>
 _CXX17_DEPRECATE_IS_LITERAL_TYPE _INLINE_VAR constexpr bool is_literal_type_v = __is_literal_type(_Ty);
 
 // STRUCT TEMPLATE is_trivial
-#if 1 // TRANSITION, VSO#119526 and LLVM#41915
+#if 1 // TRANSITION, VSO-119526 and LLVM-41915
 template <class _Ty>
 struct is_trivial : bool_constant<__is_trivially_constructible(_Ty) && __is_trivially_copyable(_Ty)> {
     // determine whether _Ty is a trivial type
@@ -1227,7 +1227,7 @@ using _Conditional_type = decltype(false ? _STD declval<_Ty1>() : _STD declval<_
 template <class _Ty1, class _Ty2, class = void>
 struct _Const_lvalue_cond_oper {};
 
-// N4810 [meta.trans.other]/3.3.4 (per P/R of pending LWG issue): "Otherwise, if remove_cvref_t</**/> denotes a type..."
+// N4810 [meta.trans.other]/3.3.4 (per P/R of LWG-3205): "Otherwise, if remove_cvref_t</**/> denotes a type..."
 template <class _Ty1, class _Ty2>
 struct _Const_lvalue_cond_oper<_Ty1, _Ty2, void_t<_Conditional_type<const _Ty1&, const _Ty2&>>> {
     using type = remove_cvref_t<_Conditional_type<const _Ty1&, const _Ty2&>>;
@@ -1381,11 +1381,11 @@ template <class _Ty1, class _Ty2, class = void>
 struct _Common_reference2A : _Common_reference2B<_Ty1, _Ty2> {};
 
 template <class _Ty1, class _Ty2, class _Result = _Cond_res<_Copy_cv<_Ty1, _Ty2>&, _Copy_cv<_Ty2, _Ty1>&>,
-#ifdef __EDG__ // TRANSITION, VSO#948614
+#ifdef __EDG__ // TRANSITION, VSO-948614
     enable_if_t<is_lvalue_reference<_Result>::value, int> = 0>
 #else // ^^^ workaround / no workaround vvv
     enable_if_t<is_lvalue_reference_v<_Result>, int> = 0>
-#endif // TRANSITION, VSO#948614
+#endif // TRANSITION, VSO-948614
 using _LL_common_ref = _Result;
 
 template <class _Ty1, class _Ty2>
@@ -2094,7 +2094,7 @@ struct _Is_trivially_swappable : bool_constant<_Is_trivially_swappable_v<_Ty>> {
 
 // FNV-1a UTILITIES
 // These functions are extremely performance sensitive, check examples like
-// that in VSO#653642 before making changes.
+// that in VSO-653642 before making changes.
 #if defined(_WIN64)
 _INLINE_VAR constexpr size_t _FNV_offset_basis = 14695981039346656037ULL;
 _INLINE_VAR constexpr size_t _FNV_prime        = 1099511628211ULL;

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -115,8 +115,8 @@ struct pair { // store a pair of values
 #if _HAS_CONDITIONAL_EXPLICIT
     template <class _Uty1 = _Ty1, class _Uty2 = _Ty2,
         enable_if_t<conjunction_v<is_copy_constructible<_Uty1>, is_copy_constructible<_Uty2>>, int> = 0>
-    constexpr explicit(!is_convertible<const _Uty1&, _Uty1>::value // TRANSITION, VSO#946746
-                       || !is_convertible<const _Uty2&, _Uty2>::value) // TRANSITION, VSO#946746
+    constexpr explicit(!is_convertible<const _Uty1&, _Uty1>::value // TRANSITION, VSO-946746
+                       || !is_convertible<const _Uty2&, _Uty2>::value) // TRANSITION, VSO-946746
         pair(const _Ty1& _Val1, const _Ty2& _Val2) noexcept(
             is_nothrow_copy_constructible_v<_Uty1>&& is_nothrow_copy_constructible_v<_Uty2>) // strengthened
         : first(_Val1), second(_Val2) {}
@@ -142,8 +142,8 @@ struct pair { // store a pair of values
 #if _HAS_CONDITIONAL_EXPLICIT
     template <class _Other1, class _Other2,
         enable_if_t<conjunction_v<is_constructible<_Ty1, _Other1>, is_constructible<_Ty2, _Other2>>, int> = 0>
-    constexpr explicit(!is_convertible<_Other1, _Ty1>::value // TRANSITION, VSO#946746
-                       || !is_convertible<_Other2, _Ty2>::value) // TRANSITION, VSO#946746
+    constexpr explicit(!is_convertible<_Other1, _Ty1>::value // TRANSITION, VSO-946746
+                       || !is_convertible<_Other2, _Ty2>::value) // TRANSITION, VSO-946746
         pair(_Other1&& _Val1, _Other2&& _Val2) noexcept(
             is_nothrow_constructible_v<_Ty1, _Other1>&& is_nothrow_constructible_v<_Ty2, _Other2>) // strengthened
         : first(_STD forward<_Other1>(_Val1)), second(_STD forward<_Other2>(_Val2)) {}
@@ -172,8 +172,8 @@ struct pair { // store a pair of values
     template <class _Other1, class _Other2,
         enable_if_t<conjunction_v<is_constructible<_Ty1, const _Other1&>, is_constructible<_Ty2, const _Other2&>>,
             int> = 0>
-    constexpr explicit(!is_convertible<const _Other1&, _Ty1>::value // TRANSITION, VSO#946746
-                       || !is_convertible<const _Other2&, _Ty2>::value) // TRANSITION, VSO#946746
+    constexpr explicit(!is_convertible<const _Other1&, _Ty1>::value // TRANSITION, VSO-946746
+                       || !is_convertible<const _Other2&, _Ty2>::value) // TRANSITION, VSO-946746
         pair(const pair<_Other1, _Other2>& _Right) noexcept(is_nothrow_constructible_v<_Ty1, const _Other1&>&&
                 is_nothrow_constructible_v<_Ty2, const _Other2&>) // strengthened
         : first(_Right.first), second(_Right.second) {}
@@ -200,8 +200,8 @@ struct pair { // store a pair of values
 #if _HAS_CONDITIONAL_EXPLICIT
     template <class _Other1, class _Other2,
         enable_if_t<conjunction_v<is_constructible<_Ty1, _Other1>, is_constructible<_Ty2, _Other2>>, int> = 0>
-    constexpr explicit(!is_convertible<_Other1, _Ty1>::value // TRANSITION, VSO#946746
-                       || !is_convertible<_Other2, _Ty2>::value) // TRANSITION, VSO#946746
+    constexpr explicit(!is_convertible<_Other1, _Ty1>::value // TRANSITION, VSO-946746
+                       || !is_convertible<_Other2, _Ty2>::value) // TRANSITION, VSO-946746
         pair(pair<_Other1, _Other2>&& _Right) noexcept(
             is_nothrow_constructible_v<_Ty1, _Other1>&& is_nothrow_constructible_v<_Ty2, _Other2>) // strengthened
         : first(_STD forward<_Other1>(_Right.first)), second(_STD forward<_Other2>(_Right.second)) {}

--- a/stl/inc/variant
+++ b/stl/inc/variant
@@ -525,7 +525,7 @@ public:
     }
 };
 
-#ifdef __cplusplus_winrt // TRANSITION, VSO#586813
+#ifdef __cplusplus_winrt // TRANSITION, VSO-586813
 // C++/CX is unable to store hats in unions. We instead store them inside a
 // wrapper to enable minimal hats-in-variants support.
 template <class _Ty>
@@ -782,7 +782,7 @@ struct _Variant_construct_visitor { // visitor that constructs the same alternat
     void operator()(_Tagged<_Ty, _Idx> _Source) const noexcept(disjunction_v<bool_constant<_Idx == variant_npos>,
         is_nothrow_constructible<remove_reference_t<_Ty>, _Ty>>) { // initialize _Idx-th item in _Self from _Source
                                                                    // pre: _Self.valueless_by_exception()
-        (void) _Source; // TRANSITION, VSO#486357
+        (void) _Source; // TRANSITION, VSO-486357
         if constexpr (_Idx != variant_npos) {
             auto& _Target = _Variant_raw_get<_Idx>(_Self._Storage());
             _Construct_in_place(_Target, static_cast<_Ty&&>(_Source._Val));
@@ -805,7 +805,7 @@ struct _Variant_assign_visitor { // visitor that implements assignment for varia
             is_nothrow_constructible<_Remove_cvref_t<_Ty>, _Ty>>>) {
         // assign the _Idx-th alternative of _Self from _Source
         if constexpr (_Idx == variant_npos) { // assign from valueless _Source
-            (void) _Source; // TRANSITION, VSO#486357
+            (void) _Source; // TRANSITION, VSO-486357
             _Self._Reset();
         } else {
             auto& _Target = _Variant_raw_get<_Idx>(_Self._Storage());
@@ -890,7 +890,7 @@ public:
         if constexpr (!conjunction_v<is_trivially_destructible<_Types>...>) {
             _Variant_raw_visit(
                 index(), _Storage(), [](auto _Ref) noexcept {
-                    (void) _Ref; // TRANSITION, VSO#486357
+                    (void) _Ref; // TRANSITION, VSO-486357
                     if constexpr (decltype(_Ref)::_Idx != variant_npos) {
                         _Destroy_in_place(_Ref._Val);
                     }
@@ -1137,25 +1137,25 @@ public:
             // Limit the size of variants that use this quadratic code size implementation of swap.
             _Variant_raw_visit(index(), _Storage(),
                 [this, &_That](auto _My_ref)
-#ifndef __EDG__ // TRANSITION, VSO#897887
+#ifndef __EDG__ // TRANSITION, VSO-897887
                     noexcept(conjunction_v<is_nothrow_move_constructible<_Types>..., is_nothrow_swappable<_Types>...>)
-#endif // TRANSITION, VSO#897887
+#endif // TRANSITION, VSO-897887
                 {
                     _Variant_raw_visit(_That.index(), _That._Storage(),
                         [this, &_That, _My_ref](auto _That_ref)
-#ifndef __EDG__ // TRANSITION, VSO#897887
+#ifndef __EDG__ // TRANSITION, VSO-897887
                             noexcept(conjunction_v<is_nothrow_move_constructible<_Types>...,
                                 is_nothrow_swappable<_Types>...>)
-#endif // TRANSITION, VSO#897887
+#endif // TRANSITION, VSO-897887
                         {
                             (void) _My_ref;
-                            (void) _That_ref; // TRANSITION, VSO#486357
+                            (void) _That_ref; // TRANSITION, VSO-486357
                             constexpr size_t _That_idx = decltype(_That_ref)::_Idx;
-#ifdef __EDG__ // TRANSITION, VSO#657455
+#ifdef __EDG__ // TRANSITION, VSO-657455
                             constexpr size_t _My_idx = decltype(_My_ref)::_Idx + 0 * _That_idx;
 #else // ^^^ workaround ^^^ / vvv no workaround vvv
                             constexpr size_t _My_idx = decltype(_My_ref)::_Idx;
-#endif // TRANSITION, VSO#657455
+#endif // TRANSITION, VSO-657455
                             if constexpr (_My_idx == _That_idx) { // Same alternatives...
                                 if constexpr (_My_idx != variant_npos) { // ...and not valueless, swap directly
                                     _Swap_adl(_My_ref._Val, _That_ref._Val);
@@ -1167,12 +1167,12 @@ public:
                                 _That._Emplace_valueless<_My_idx>(_STD move(_My_ref._Val));
                                 this->template _Reset<_My_idx>();
                             } else { // different non-valueless alternatives
-#ifdef __EDG__ // TRANSITION, VSO#657455
+#ifdef __EDG__ // TRANSITION, VSO-657455
                                 using _Workaround = enable_if_t<_That_idx != variant_npos, decltype(_My_ref._Val)>;
                                 auto _Tmp         = _STD move(static_cast<_Workaround>(_My_ref._Val));
 #else // ^^^ workaround ^^^ / vvv no workaround vvv
                                 auto _Tmp = _STD move(_My_ref._Val);
-#endif // TRANSITION, VSO#657455
+#endif // TRANSITION, VSO-657455
                                 this->template _Reset<_My_idx>();
                                 this->_Emplace_valueless<_That_idx>(_STD move(_That_ref._Val));
                                 _That.template _Reset<_That_idx>();
@@ -1184,9 +1184,9 @@ public:
             if (this->_Which == _That._Which) {
                 _Variant_raw_visit(static_cast<size_t>(this->_Which), _That._Storage(),
                     [this](auto _Ref)
-#ifndef __EDG__ // TRANSITION, VSO#897887
+#ifndef __EDG__ // TRANSITION, VSO-897887
                         noexcept(conjunction_v<is_nothrow_swappable<_Types>...>)
-#endif // TRANSITION, VSO#897887
+#endif // TRANSITION, VSO-897887
                     {
                         constexpr size_t _Idx = decltype(_Ref)::_Idx;
                         if constexpr (_Idx != variant_npos) {
@@ -1218,9 +1218,9 @@ private:
         this->_Reset();
         _Variant_raw_visit(_That.index(), _That._Storage(),
             [this](auto _Ref)
-#ifndef __EDG__ // TRANSITION, VSO#897887
+#ifndef __EDG__ // TRANSITION, VSO-897887
                 noexcept(conjunction_v<is_nothrow_move_constructible<_Types>...>)
-#endif // TRANSITION, VSO#897887
+#endif // TRANSITION, VSO-897887
             {
                 constexpr size_t _Idx = decltype(_Ref)::_Idx;
                 if constexpr (_Idx != variant_npos) {
@@ -1357,7 +1357,7 @@ struct _Variant_relop_visitor { // evaluate _Op with the contained value of two 
         if constexpr (_Idx != variant_npos) {
             return _Op{}(_Variant_raw_get<_Idx>(_Left), _Right._Val);
         } else { // return whatever _Op returns for equal values
-            (void) _Right; // TRANSITION, VSO#486357
+            (void) _Right; // TRANSITION, VSO-486357
             return _Op{}(0, 0);
         }
     }
@@ -1465,7 +1465,7 @@ struct _Variant_dispatcher<index_sequence<_Is...>> {
         _Callable&& _Obj, _Types&&... _Args) {
         if constexpr (_Any_valueless) {
             (void) _Obj;
-            ((void) _Args, ...); // TRANSITION, VSO#486357
+            ((void) _Args, ...); // TRANSITION, VSO-486357
             _Throw_bad_variant_access();
         } else {
             return _C_invoke(
@@ -1657,7 +1657,7 @@ struct _Variant_hash_visitor { // visitation function for hashing variants
         noexcept(disjunction_v<bool_constant<_Idx == variant_npos>,
             is_nothrow_invocable<hash<_Ty>, const _Ty&>>) { // hash contained value _Obj
         if constexpr (_Idx == variant_npos) { // hash a valueless variant
-            (void) _Obj; // TRANSITION, VSO#486357
+            (void) _Obj; // TRANSITION, VSO-486357
             return 0;
         } else { // hash the contained value
             return hash<_Ty>{}(_Obj._Val);

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -602,7 +602,7 @@ private:
         _Tidy();
 #if _ITERATOR_DEBUG_LEVEL != 0
         if (_Getal() != _Right._Getal()) {
-            // intentionally slams into noexcept on OOM, TRANSITION, VSO#466800
+            // intentionally slams into noexcept on OOM, TRANSITION, VSO-466800
             _Mypair._Myval2._Reload_proxy(
                 _GET_PROXY_ALLOCATOR(_Alty, _Getal()), _GET_PROXY_ALLOCATOR(_Alty, _Right._Getal()));
         }
@@ -2333,7 +2333,7 @@ private:
     void _Move_assign(vector& _Right, _Propagate_allocators) noexcept {
         using _Alproxy_type = _Rebind_alloc_t<_Alvbase, _Container_proxy>;
         if (this->_Getal() != _Right._Getal()) { // reload proxy
-            // intentionally slams into noexcept on OOM, TRANSITION, VSO#466800
+            // intentionally slams into noexcept on OOM, TRANSITION, VSO-466800
             _Alproxy_type _Oldal(this->_Getal());
             _Alproxy_type _Right_proxy_al(_Right._Getal());
             _Container_proxy_ptr<_Alvbase> _Proxy(_Right_proxy_al, _Leave_proxy_unbound{});

--- a/stl/inc/xatomic.h
+++ b/stl/inc/xatomic.h
@@ -65,7 +65,7 @@ enum class memory_order : int {
     acq_rel,
     seq_cst,
 
-    // LWG 3268
+    // LWG-3268
     memory_order_relaxed = relaxed,
     memory_order_consume = consume,
     memory_order_acquire = acquire,

--- a/stl/inc/xcall_once.h
+++ b/stl/inc/xcall_once.h
@@ -64,8 +64,8 @@ int __stdcall _Immortalize_impl(void*, void* _Storage_ptr, void**) noexcept {
 
 template <class _Ty>
 _Ty& _Immortalize() { // return a reference to an object that will live forever
-    static_assert(sizeof(void*) == sizeof(once_flag), "TRANSITION, VSO#406237");
-    static_assert(alignof(void*) == alignof(once_flag), "TRANSITION, VSO#406237");
+    static_assert(sizeof(void*) == sizeof(once_flag), "TRANSITION, VSO-406237");
+    static_assert(alignof(void*) == alignof(once_flag), "TRANSITION, VSO-406237");
     static void* _Flag = nullptr;
     static aligned_union_t<1, _Ty> _Storage;
     if (_Execute_once(reinterpret_cast<once_flag&>(_Flag), _Immortalize_impl<_Ty>, &_Storage) == 0) {

--- a/stl/inc/xcharconv_ryu.h
+++ b/stl/inc/xcharconv_ryu.h
@@ -156,7 +156,7 @@ _NODISCARD inline uint64_t __ryu_shiftright128(const uint64_t __lo, const uint64
 #else // ^^^ intrinsics available ^^^ / vvv intrinsics unavailable vvv
 
 _NODISCARD __forceinline uint64_t __ryu_umul128(const uint64_t __a, const uint64_t __b, uint64_t* const __productHi) {
-  // TRANSITION, VSO#634761
+  // TRANSITION, VSO-634761
   // The casts here help MSVC to avoid calls to the __allmul library function.
   const uint32_t __aLo = static_cast<uint32_t>(__a);
   const uint32_t __aHi = static_cast<uint32_t>(__a >> 32);
@@ -216,7 +216,7 @@ _NODISCARD inline uint64_t __umulh(const uint64_t __a, const uint64_t __b) {
 // On 32-bit platforms, compilers typically generate calls to library
 // functions for 64-bit divisions, even if the divisor is a constant.
 //
-// TRANSITION, LLVM#37932
+// TRANSITION, LLVM-37932
 //
 // The functions here perform division-by-constant using multiplications
 // in the same way as 64-bit compilers would do.
@@ -392,7 +392,7 @@ _NODISCARD inline uint32_t __mulShift_mod1e9(const uint64_t __m, const uint64_t*
 inline void __append_n_digits(const uint32_t __olength, uint32_t __digits, char* const __result) {
   uint32_t __i = 0;
   while (__digits >= 10000) {
-#ifdef __clang__ // TRANSITION, LLVM#38217
+#ifdef __clang__ // TRANSITION, LLVM-38217
     const uint32_t __c = __digits - 10000 * (__digits / 10000);
 #else
     const uint32_t __c = __digits % 10000;
@@ -421,7 +421,7 @@ inline void __append_n_digits(const uint32_t __olength, uint32_t __digits, char*
 inline void __append_d_digits(const uint32_t __olength, uint32_t __digits, char* const __result) {
   uint32_t __i = 0;
   while (__digits >= 10000) {
-#ifdef __clang__ // TRANSITION, LLVM#38217
+#ifdef __clang__ // TRANSITION, LLVM-38217
     const uint32_t __c = __digits - 10000 * (__digits / 10000);
 #else
     const uint32_t __c = __digits % 10000;
@@ -470,7 +470,7 @@ inline void __append_nine_digits(uint32_t __digits, char* const __result) {
   }
 
   for (uint32_t __i = 0; __i < 5; __i += 4) {
-#ifdef __clang__ // TRANSITION, LLVM#38217
+#ifdef __clang__ // TRANSITION, LLVM-38217
     const uint32_t __c = __digits - 10000 * (__digits / 10000);
 #else
     const uint32_t __c = __digits % 10000;
@@ -1125,7 +1125,7 @@ _NODISCARD inline __floating_decimal_32 __f2d(const uint32_t __ieeeMantissa, con
   if (__vmIsTrailingZeros || __vrIsTrailingZeros) {
     // General case, which happens rarely (~4.0%).
     while (__vp / 10 > __vm / 10) {
-#ifdef __clang__ // TRANSITION, LLVM#23106
+#ifdef __clang__ // TRANSITION, LLVM-23106
       __vmIsTrailingZeros &= __vm - (__vm / 10) * 10 == 0;
 #else
       __vmIsTrailingZeros &= __vm % 10 == 0;
@@ -1440,7 +1440,7 @@ _NODISCARD inline to_chars_result __to_chars(char* const _First, char* const _La
     }
 
     while (__output >= 10000) {
-#ifdef __clang__ // TRANSITION, LLVM#38217
+#ifdef __clang__ // TRANSITION, LLVM-38217
       const uint32_t __c = __output - 10000 * (__output / 10000);
 #else
       const uint32_t __c = __output % 10000;
@@ -1492,7 +1492,7 @@ _NODISCARD inline to_chars_result __to_chars(char* const _First, char* const _La
   // Print the decimal digits.
   uint32_t __i = 0;
   while (__output >= 10000) {
-#ifdef __clang__ // TRANSITION, LLVM#38217
+#ifdef __clang__ // TRANSITION, LLVM-38217
     const uint32_t __c = __output - 10000 * (__output / 10000);
 #else
     const uint32_t __c = __output % 10000;
@@ -1660,7 +1660,7 @@ _NODISCARD inline uint64_t __mulShiftAll(const uint64_t __m, const uint64_t* con
 #else // ^^^ intrinsics available ^^^ / vvv intrinsics unavailable vvv
 
 _NODISCARD __forceinline uint64_t __mulShiftAll(uint64_t __m, const uint64_t* const __mul, const int32_t __j,
-  uint64_t* const __vp, uint64_t* const __vm, const uint32_t __mmShift) { // TRANSITION, VSO#634761
+  uint64_t* const __vp, uint64_t* const __vm, const uint32_t __mmShift) { // TRANSITION, VSO-634761
   __m <<= 1;
   // __m is maximum 55 bits
   uint64_t __tmp;
@@ -2079,7 +2079,7 @@ _NODISCARD inline to_chars_result __to_chars(char* const _First, char* const _La
     }
     uint32_t __output2 = static_cast<uint32_t>(__output);
     while (__output2 >= 10000) {
-#ifdef __clang__ // TRANSITION, LLVM#38217
+#ifdef __clang__ // TRANSITION, LLVM-38217
       const uint32_t __c = __output2 - 10000 * (__output2 / 10000);
 #else
       const uint32_t __c = __output2 % 10000;
@@ -2155,7 +2155,7 @@ _NODISCARD inline to_chars_result __to_chars(char* const _First, char* const _La
   }
   uint32_t __output2 = static_cast<uint32_t>(__output);
   while (__output2 >= 10000) {
-#ifdef __clang__ // TRANSITION, LLVM#38217
+#ifdef __clang__ // TRANSITION, LLVM-38217
     const uint32_t __c = __output2 - 10000 * (__output2 / 10000);
 #else
     const uint32_t __c = __output2 % 10000;

--- a/stl/inc/xhash
+++ b/stl/inc/xhash
@@ -223,16 +223,16 @@ struct _Reinterpret_move_iter {
 
     // post ++ intentionally omitted
 
-#ifndef __CUDACC__ // TRANSITION, VSO#568006
+#ifndef __CUDACC__ // TRANSITION, VSO-568006
     _NODISCARD
-#endif // TRANSITION, VSO#568006
+#endif // TRANSITION, VSO-568006
     friend bool operator==(const _Reinterpret_move_iter& _Lhs, const _Reinterpret_move_iter& _Rhs) {
         return _Lhs._Base == _Rhs._Base;
     }
 
-#ifndef __CUDACC__ // TRANSITION, VSO#568006
+#ifndef __CUDACC__ // TRANSITION, VSO-568006
     _NODISCARD
-#endif // TRANSITION, VSO#568006
+#endif // TRANSITION, VSO-568006
     friend bool operator!=(const _Reinterpret_move_iter& _Lhs, const _Reinterpret_move_iter& _Rhs) {
         return _Lhs._Base != _Rhs._Base;
     }
@@ -1271,12 +1271,12 @@ public:
 
     void clear() noexcept {
         // TRANSITION, ABI:
-        // LWG 2550 requires implementations to make clear() O(size()), independent of bucket_count().
+        // LWG-2550 requires implementations to make clear() O(size()), independent of bucket_count().
         // Unfortunately our current data structure / ABI does not allow achieving this in the general case because:
         //   (1) Finding the bucket that goes with an element requires running the hash function
         //   (2) The hash function operator() may throw exceptions, and
         //   (3) clear() is a noexcept function.
-        // We do comply with LWG 2550 if the hash function is noexcept, or if the container was empty.
+        // We do comply with LWG-2550 if the hash function is noexcept, or if the container was empty.
         const auto _Oldsize = _List._Mypair._Myval2._Mysize;
         if (_Oldsize == 0) {
             return;

--- a/stl/inc/xlocale
+++ b/stl/inc/xlocale
@@ -2058,7 +2058,7 @@ protected:
             case -1: // failed conversion
                 return error;
 
-            case 0: // converted NULL character, TRANSITION, VSO#654347
+            case 0: // converted NULL character, TRANSITION, VSO-654347
                 _Bytes = 1;
                 // [[fallthrough]];
 
@@ -2142,7 +2142,7 @@ protected:
                 break;
             }
 
-            if (_Bytes == 0) { // converted NULL character, TRANSITION, VSO#654347
+            if (_Bytes == 0) { // converted NULL character, TRANSITION, VSO-654347
                 _Bytes = 1;
             }
 
@@ -2259,7 +2259,7 @@ protected:
             case -1: // failed conversion
                 return error;
 
-            case 0: // converted NULL character, TRANSITION, VSO#654347
+            case 0: // converted NULL character, TRANSITION, VSO-654347
                 _Bytes = 1;
                 // [[fallthrough]];
 
@@ -2344,7 +2344,7 @@ protected:
                 break;
             }
 
-            if (_Bytes == 0) { // converted NULL character, TRANSITION, VSO#654347
+            if (_Bytes == 0) { // converted NULL character, TRANSITION, VSO-654347
                 _Bytes = 1;
             }
 

--- a/stl/inc/xlocinfo.h
+++ b/stl/inc/xlocinfo.h
@@ -11,7 +11,7 @@
 
 #include <ctype.h>
 #include <locale.h>
-#include <stdio.h> // TRANSITION, VSO#661721
+#include <stdio.h> // TRANSITION, VSO-661721
 #include <wchar.h>
 
 #pragma pack(push, _CRT_PACKING)

--- a/stl/inc/xlocnum
+++ b/stl/inc/xlocnum
@@ -254,7 +254,7 @@ protected:
 };
 
 // STATIC numpunct::id OBJECT
-#if !(defined _CRTBLD && defined _BUILDING_SATELLITE_2) // TRANSITION, VSO#578955
+#if !(defined _CRTBLD && defined _BUILDING_SATELLITE_2) // TRANSITION, VSO-578955
 #ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdllimport-static-field-def"
@@ -391,7 +391,7 @@ protected:
                                   // We should still do numeric conversion with bad digit separators, instead of
                                   // setting 0, but we can't distinguish that from _Getifld's interface, and _Getifld's
                                   // interface can't be changed as it is an exported function.
-                                  // TRANSITION, ABI: Fixing that when ABI allows is tracked by VSO#591516.
+                                  // TRANSITION, ABI: Fixing that when ABI allows is tracked by VSO-591516.
                 _Val   = false;
                 _State = ios_base::failbit;
             } else {
@@ -422,7 +422,7 @@ protected:
         _Adl_verify_range(_First, _Last);
         char _Ac[_MAX_INT_DIG];
         const int _Base = _Getifld(_Ac, _First, _Last, _Iosbase.flags(), _Iosbase.getloc()); // gather field
-        if (_Ac[0] == '\0') { // ditto "fails to convert the entire field" / VSO#591516
+        if (_Ac[0] == '\0') { // ditto "fails to convert the entire field" / VSO-591516
             _State = ios_base::failbit;
             _Val   = 0;
         } else {
@@ -469,7 +469,7 @@ protected:
         _Adl_verify_range(_First, _Last);
         char _Ac[_MAX_INT_DIG];
         const int _Base = _Getifld(_Ac, _First, _Last, _Iosbase.flags(), _Iosbase.getloc()); // gather field
-        if (_Ac[0] == '\0') { // ditto "fails to convert the entire field" / VSO#591516
+        if (_Ac[0] == '\0') { // ditto "fails to convert the entire field" / VSO-591516
             _State = ios_base::failbit;
             _Val   = 0;
         } else {
@@ -493,7 +493,7 @@ protected:
         _Adl_verify_range(_First, _Last);
         char _Ac[_MAX_INT_DIG];
         const int _Base = _Getifld(_Ac, _First, _Last, _Iosbase.flags(), _Iosbase.getloc()); // gather field
-        if (_Ac[0] == '\0') { // ditto "fails to convert the entire field" / VSO#591516
+        if (_Ac[0] == '\0') { // ditto "fails to convert the entire field" / VSO-591516
             _State = ios_base::failbit;
             _Val   = 0;
         } else {
@@ -517,7 +517,7 @@ protected:
         _Adl_verify_range(_First, _Last);
         char _Ac[_MAX_INT_DIG];
         const int _Base = _Getifld(_Ac, _First, _Last, _Iosbase.flags(), _Iosbase.getloc());
-        if (_Ac[0] == '\0') { // ditto "fails to convert the entire field" / VSO#591516
+        if (_Ac[0] == '\0') { // ditto "fails to convert the entire field" / VSO-591516
             _State = ios_base::failbit;
             _Val   = 0;
         } else {
@@ -541,7 +541,7 @@ protected:
         _Adl_verify_range(_First, _Last);
         char _Ac[_MAX_INT_DIG];
         const int _Base = _Getifld(_Ac, _First, _Last, _Iosbase.flags(), _Iosbase.getloc());
-        if (_Ac[0] == '\0') { // ditto "fails to convert the entire field" / VSO#591516
+        if (_Ac[0] == '\0') { // ditto "fails to convert the entire field" / VSO-591516
             _State = ios_base::failbit;
             _Val   = 0;
         } else {
@@ -573,7 +573,7 @@ protected:
         char _Ac[_FLOATING_BUFFER_SIZE];
         int _Hexexp     = _ENABLE_V2_BEHAVIOR;
         const int _Base = _Getffld(_Ac, _First, _Last, _Iosbase, &_Hexexp); // gather field
-        if (_Ac[0] == '\0') { // ditto "fails to convert the entire field" / VSO#591516
+        if (_Ac[0] == '\0') { // ditto "fails to convert the entire field" / VSO-591516
             _State = ios_base::failbit;
             _Val   = 0.0f;
         } else {
@@ -601,7 +601,7 @@ protected:
         char _Ac[_FLOATING_BUFFER_SIZE];
         int _Hexexp     = _ENABLE_V2_BEHAVIOR;
         const int _Base = _Getffld(_Ac, _First, _Last, _Iosbase, &_Hexexp); // gather field
-        if (_Ac[0] == '\0') { // ditto "fails to convert the entire field" / VSO#591516
+        if (_Ac[0] == '\0') { // ditto "fails to convert the entire field" / VSO-591516
             _State = ios_base::failbit;
             _Val   = 0.0;
         } else {
@@ -638,7 +638,7 @@ protected:
         _Adl_verify_range(_First, _Last);
         char _Ac[_MAX_INT_DIG];
         const int _Base = _Getifld(_Ac, _First, _Last, ios_base::hex, _Iosbase.getloc()); // gather field
-        if (_Ac[0] == '\0') { // ditto "fails to convert the entire field" / VSO#591516
+        if (_Ac[0] == '\0') { // ditto "fails to convert the entire field" / VSO-591516
             _State = ios_base::failbit;
             _Val   = nullptr;
         } else {

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -42,7 +42,7 @@ _NODISCARD constexpr size_t _Get_size_of_n(const size_t _Count) {
 // VARIABLE TEMPLATE _New_alignof
 template <class _Ty>
 _INLINE_VAR constexpr size_t _New_alignof = _Max_value(alignof(_Ty),
-    static_cast<size_t>(__STDCPP_DEFAULT_NEW_ALIGNMENT__) // TRANSITION, VSO#522105
+    static_cast<size_t>(__STDCPP_DEFAULT_NEW_ALIGNMENT__) // TRANSITION, VSO-522105
 );
 
 // STRUCT _Default_allocate_traits
@@ -856,8 +856,8 @@ void _Pocca(_Alloc& _Left, const _Alloc& _Right) noexcept {
     if constexpr (allocator_traits<_Alloc>::propagate_on_container_copy_assignment::value) {
         _Left = _Right;
     } else {
-        (void) _Left; // TRANSITION, VSO#486357
-        (void) _Right; // TRANSITION, VSO#486357
+        (void) _Left; // TRANSITION, VSO-486357
+        (void) _Right; // TRANSITION, VSO-486357
     }
 }
 #else // ^^^ _HAS_IF_CONSTEXPR ^^^ // vvv !_HAS_IF_CONSTEXPR vvv
@@ -882,8 +882,8 @@ void _Pocma(_Alloc& _Left, _Alloc& _Right) noexcept { // (maybe) propagate on co
     if constexpr (allocator_traits<_Alloc>::propagate_on_container_move_assignment::value) {
         _Left = _STD move(_Right);
     } else {
-        (void) _Left; // TRANSITION, VSO#486357
-        (void) _Right; // TRANSITION, VSO#486357
+        (void) _Left; // TRANSITION, VSO-486357
+        (void) _Right; // TRANSITION, VSO-486357
     }
 }
 #else // ^^^ _HAS_IF_CONSTEXPR ^^^ // vvv !_HAS_IF_CONSTEXPR vvv
@@ -910,8 +910,8 @@ void _Pocs(_Alloc& _Left, _Alloc& _Right) noexcept {
         _Swap_adl(_Left, _Right);
     } else {
         _STL_ASSERT(_Left == _Right, "containers incompatible for swap");
-        (void) _Left; // TRANSITION, VSO#486357
-        (void) _Right; // TRANSITION, VSO#486357
+        (void) _Left; // TRANSITION, VSO-486357
+        (void) _Right; // TRANSITION, VSO-486357
     }
 }
 #else // ^^^ _HAS_IF_CONSTEXPR ^^^ // vvv !_HAS_IF_CONSTEXPR vvv

--- a/stl/inc/xsmf_control.h
+++ b/stl/inc/xsmf_control.h
@@ -26,7 +26,7 @@ struct _Non_trivial_copy : _Base { // non-trivial copy construction facade
     using _Base::_Base;
 
     _Non_trivial_copy() = default;
-    _Non_trivial_copy(const _Non_trivial_copy& _That) noexcept(noexcept( // TRANSITION, VSO#615127
+    _Non_trivial_copy(const _Non_trivial_copy& _That) noexcept(noexcept( // TRANSITION, VSO-615127
         _STD declval<_Base&>()._Construct_from(static_cast<const _Base&>(_That)))) {
         _Base::_Construct_from(static_cast<const _Base&>(_That));
     }
@@ -49,7 +49,7 @@ struct _Non_trivial_move : _SMF_control_copy<_Base, _Types...> { // non-trivial 
 
     _Non_trivial_move()                         = default;
     _Non_trivial_move(const _Non_trivial_move&) = default;
-    _Non_trivial_move(_Non_trivial_move&& _That) noexcept(noexcept( // TRANSITION, VSO#615127
+    _Non_trivial_move(_Non_trivial_move&& _That) noexcept(noexcept( // TRANSITION, VSO-615127
         _STD declval<_Base&>()._Construct_from(static_cast<_Base&&>(_That)))) {
         _Mybase::_Construct_from(static_cast<_Base&&>(_That));
     }
@@ -74,7 +74,7 @@ struct _Non_trivial_copy_assign : _SMF_control_move<_Base, _Types...> { // non-t
     _Non_trivial_copy_assign(_Non_trivial_copy_assign&&)      = default;
 
     _Non_trivial_copy_assign& operator=(const _Non_trivial_copy_assign& _That) noexcept(
-        noexcept( // TRANSITION, VSO#615127
+        noexcept( // TRANSITION, VSO-615127
             _STD declval<_Base&>()._Assign_from(static_cast<const _Base&>(_That)))) {
         _Mybase::_Assign_from(static_cast<const _Base&>(_That));
         return *this;
@@ -114,7 +114,7 @@ struct _Non_trivial_move_assign : _SMF_control_copy_assign<_Base, _Types...> { /
     _Non_trivial_move_assign(_Non_trivial_move_assign&&)      = default;
     _Non_trivial_move_assign& operator=(const _Non_trivial_move_assign&) = default;
 
-    // TRANSITION, VSO#615127
+    // TRANSITION, VSO-615127
     _Non_trivial_move_assign& operator=(_Non_trivial_move_assign&& _That) noexcept(
         noexcept(_STD declval<_Base&>()._Assign_from(static_cast<_Base&&>(_That)))) {
         _Mybase::_Assign_from(static_cast<_Base&&>(_That));

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -1592,13 +1592,13 @@ _NODISCARD constexpr bool operator==(
     return _Lhs._Equal(_Rhs);
 }
 
-template <class _Elem, class _Traits, int = 1> // TRANSITION, VSO#409326
+template <class _Elem, class _Traits, int = 1> // TRANSITION, VSO-409326
 _NODISCARD constexpr bool operator==(
     const _Identity_t<basic_string_view<_Elem, _Traits>> _Lhs, const basic_string_view<_Elem, _Traits> _Rhs) noexcept {
     return _Lhs._Equal(_Rhs);
 }
 
-template <class _Elem, class _Traits, int = 2> // TRANSITION, VSO#409326
+template <class _Elem, class _Traits, int = 2> // TRANSITION, VSO-409326
 _NODISCARD constexpr bool operator==(
     const basic_string_view<_Elem, _Traits> _Lhs, const _Identity_t<basic_string_view<_Elem, _Traits>> _Rhs) noexcept {
     return _Lhs._Equal(_Rhs);
@@ -1612,13 +1612,13 @@ _NODISCARD constexpr bool operator!=(
     return !_Lhs._Equal(_Rhs);
 }
 
-template <class _Elem, class _Traits, int = 1> // TRANSITION, VSO#409326
+template <class _Elem, class _Traits, int = 1> // TRANSITION, VSO-409326
 _NODISCARD constexpr bool operator!=(
     const _Identity_t<basic_string_view<_Elem, _Traits>> _Lhs, const basic_string_view<_Elem, _Traits> _Rhs) noexcept {
     return !_Lhs._Equal(_Rhs);
 }
 
-template <class _Elem, class _Traits, int = 2> // TRANSITION, VSO#409326
+template <class _Elem, class _Traits, int = 2> // TRANSITION, VSO-409326
 _NODISCARD constexpr bool operator!=(
     const basic_string_view<_Elem, _Traits> _Lhs, const _Identity_t<basic_string_view<_Elem, _Traits>> _Rhs) noexcept {
     return !_Lhs._Equal(_Rhs);
@@ -1632,13 +1632,13 @@ _NODISCARD constexpr bool operator<(
     return _Lhs.compare(_Rhs) < 0;
 }
 
-template <class _Elem, class _Traits, int = 1> // TRANSITION, VSO#409326
+template <class _Elem, class _Traits, int = 1> // TRANSITION, VSO-409326
 _NODISCARD constexpr bool operator<(
     const _Identity_t<basic_string_view<_Elem, _Traits>> _Lhs, const basic_string_view<_Elem, _Traits> _Rhs) noexcept {
     return _Lhs.compare(_Rhs) < 0;
 }
 
-template <class _Elem, class _Traits, int = 2> // TRANSITION, VSO#409326
+template <class _Elem, class _Traits, int = 2> // TRANSITION, VSO-409326
 _NODISCARD constexpr bool operator<(
     const basic_string_view<_Elem, _Traits> _Lhs, const _Identity_t<basic_string_view<_Elem, _Traits>> _Rhs) noexcept {
     return _Lhs.compare(_Rhs) < 0;
@@ -1652,13 +1652,13 @@ _NODISCARD constexpr bool operator>(
     return _Lhs.compare(_Rhs) > 0;
 }
 
-template <class _Elem, class _Traits, int = 1> // TRANSITION, VSO#409326
+template <class _Elem, class _Traits, int = 1> // TRANSITION, VSO-409326
 _NODISCARD constexpr bool operator>(
     const _Identity_t<basic_string_view<_Elem, _Traits>> _Lhs, const basic_string_view<_Elem, _Traits> _Rhs) noexcept {
     return _Lhs.compare(_Rhs) > 0;
 }
 
-template <class _Elem, class _Traits, int = 2> // TRANSITION, VSO#409326
+template <class _Elem, class _Traits, int = 2> // TRANSITION, VSO-409326
 _NODISCARD constexpr bool operator>(
     const basic_string_view<_Elem, _Traits> _Lhs, const _Identity_t<basic_string_view<_Elem, _Traits>> _Rhs) noexcept {
     return _Lhs.compare(_Rhs) > 0;
@@ -1672,13 +1672,13 @@ _NODISCARD constexpr bool operator<=(
     return _Lhs.compare(_Rhs) <= 0;
 }
 
-template <class _Elem, class _Traits, int = 1> // TRANSITION, VSO#409326
+template <class _Elem, class _Traits, int = 1> // TRANSITION, VSO-409326
 _NODISCARD constexpr bool operator<=(
     const _Identity_t<basic_string_view<_Elem, _Traits>> _Lhs, const basic_string_view<_Elem, _Traits> _Rhs) noexcept {
     return _Lhs.compare(_Rhs) <= 0;
 }
 
-template <class _Elem, class _Traits, int = 2> // TRANSITION, VSO#409326
+template <class _Elem, class _Traits, int = 2> // TRANSITION, VSO-409326
 _NODISCARD constexpr bool operator<=(
     const basic_string_view<_Elem, _Traits> _Lhs, const _Identity_t<basic_string_view<_Elem, _Traits>> _Rhs) noexcept {
     return _Lhs.compare(_Rhs) <= 0;
@@ -1692,13 +1692,13 @@ _NODISCARD constexpr bool operator>=(
     return _Lhs.compare(_Rhs) >= 0;
 }
 
-template <class _Elem, class _Traits, int = 1> // TRANSITION, VSO#409326
+template <class _Elem, class _Traits, int = 1> // TRANSITION, VSO-409326
 _NODISCARD constexpr bool operator>=(
     const _Identity_t<basic_string_view<_Elem, _Traits>> _Lhs, const basic_string_view<_Elem, _Traits> _Rhs) noexcept {
     return _Lhs.compare(_Rhs) >= 0;
 }
 
-template <class _Elem, class _Traits, int = 2> // TRANSITION, VSO#409326
+template <class _Elem, class _Traits, int = 2> // TRANSITION, VSO-409326
 _NODISCARD constexpr bool operator>=(
     const basic_string_view<_Elem, _Traits> _Lhs, const _Identity_t<basic_string_view<_Elem, _Traits>> _Rhs) noexcept {
     return _Lhs.compare(_Rhs) >= 0;
@@ -2470,7 +2470,7 @@ private:
         if (_Getal() == _Right._Getal()) {
             _Move_assign(_Right, _Equal_allocators{});
         } else {
-            // intentionally slams into noexcept on OOM, TRANSITION, VSO#466800
+            // intentionally slams into noexcept on OOM, TRANSITION, VSO-466800
             _Mypair._Myval2._Orphan_all();
             _Mypair._Myval2._Reload_proxy(
                 _GET_PROXY_ALLOCATOR(_Alty, _Getal()), _GET_PROXY_ALLOCATOR(_Alty, _Right._Getal()));
@@ -2638,7 +2638,7 @@ public:
 
 private:
     void _Copy_assign_val_from_small(const basic_string& _Right) {
-        // TRANSITION, VSO#761321; inline into only caller when that's fixed
+        // TRANSITION, VSO-761321; inline into only caller when that's fixed
         _Tidy_deallocate();
         if
             _CONSTEXPR_IF(_Can_memcpy_val) {

--- a/stl/inc/xtgmath.h
+++ b/stl/inc/xtgmath.h
@@ -185,9 +185,9 @@ _GENERIC_MATH2(fdim)
 _GENERIC_MATH2(fmax)
 _GENERIC_MATH2(fmin)
 // fma() is hand-crafted
-// lerp() should be exempt, LWG 3223
-// The "classification/comparison functions" (fpclassify(), etc.) are exempt, LWG 1327
-// TRANSITION, VSO#945789, Special Math shouldn't be exempt
+// lerp() should be exempt, LWG-3223
+// The "classification/comparison functions" (fpclassify(), etc.) are exempt, LWG-1327
+// TRANSITION, VSO-945789, Special Math shouldn't be exempt
 
 #undef _GENERIC_MATH1R
 #undef _GENERIC_MATH1

--- a/stl/inc/xtree
+++ b/stl/inc/xtree
@@ -908,7 +908,7 @@ public:
 
 private:
     void _Different_allocator_move_construct(_Tree&& _Right) {
-        // TRANSITION, VSO#675959 (inline into only caller when that is fixed)
+        // TRANSITION, VSO-675959 (inline into only caller when that is fixed)
         auto&& _Alproxy   = _GET_PROXY_ALLOCATOR(_Alnode, _Getal());
         const auto _Scary = _Get_scary();
         _Container_proxy_ptr<_Alty> _Proxy(_Alproxy, *_Scary);

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -150,7 +150,7 @@ _NODISCARD auto to_address(const _Ptr& _Val) noexcept {
 #endif // _HAS_CXX20
 
 // FUNCTION TEMPLATE _Pass_fn
-// TRANSITION, VSO#386225
+// TRANSITION, VSO-386225
 template <class _Fx>
 struct _Ref_fn { // pass function object by value as a reference
     template <class... _Args>
@@ -617,7 +617,7 @@ namespace ranges {
 
         // clang-format off
         template <class _Ty>
-        concept _Has_ADL = _Has_class_or_enum_type<_Ty> // Per LWG 3270
+        concept _Has_ADL = _Has_class_or_enum_type<_Ty> // Per LWG-3270
             && requires(_Ty&& __t) { iter_move(static_cast<_Ty&&>(__t)); };
 
         template <class _Ty>
@@ -886,16 +886,16 @@ concept indirectly_movable_storable = indirectly_movable<_In, _Out> && writable<
 // CUSTOMIZATION POINT OBJECT iter_swap
 namespace ranges {
     namespace _Iter_swap {
-#ifndef __clang__ // TRANSITION, VSO#895622
+#ifndef __clang__ // TRANSITION, VSO-895622
         void iter_swap();
-#endif // TRANSITION, VSO#895622
+#endif // TRANSITION, VSO-895622
 
         template <class _Ty1, class _Ty2>
         void iter_swap(_Ty1, _Ty2) = delete;
 
         // clang-format off
         template <class _Ty1, class _Ty2>
-        concept _Has_ADL = (_Has_class_or_enum_type<_Ty1> || _Has_class_or_enum_type<_Ty2>) // Per LWG 3270
+        concept _Has_ADL = (_Has_class_or_enum_type<_Ty1> || _Has_class_or_enum_type<_Ty2>) // Per LWG-3270
             && requires(_Ty1&& __t1, _Ty2&& __t2) {
                 iter_swap(static_cast<_Ty1&&>(__t1), static_cast<_Ty2&&>(__t2));
             };
@@ -1082,8 +1082,8 @@ constexpr void _Adl_verify_range(const _Iter& _First, const _Sentinel& _Last) {
     if constexpr (_Range_verifiable_v<_Iter, _Sentinel>) {
         _Verify_range(_First, _Last);
     } else {
-        (void) _First; // TRANSITION, VSO#486357
-        (void) _Last; // TRANSITION, VSO#486357
+        (void) _First; // TRANSITION, VSO-486357
+        (void) _Last; // TRANSITION, VSO-486357
     }
 }
 #else // ^^^ _HAS_IF_CONSTEXPR / !_HAS_IF_CONSTEXPR vvv
@@ -1349,8 +1349,8 @@ auto _Idl_distance(const _Iter& _First, const _Iter& _Last) {
     if constexpr (_Is_random_iter_v<_Iter>) {
         return static_cast<_Iter_diff_t<_Checked>>(_Last - _First);
     } else {
-        (void) _First; // TRANSITION, VSO#486357
-        (void) _Last; // TRANSITION, VSO#486357
+        (void) _First; // TRANSITION, VSO-486357
+        (void) _Last; // TRANSITION, VSO-486357
         return _Distance_unknown{};
     }
 }
@@ -1507,9 +1507,9 @@ void _Debug_order_unchecked(_InIt _First, _Sentinel _Last, _Pr&& _Pred) {
             }
         }
     } else {
-        (void) _First; // TRANSITION, VSO#486357
-        (void) _Last; // TRANSITION, VSO#486357
-        (void) _Pred; // TRANSITION, VSO#486357
+        (void) _First; // TRANSITION, VSO-486357
+        (void) _Last; // TRANSITION, VSO-486357
+        (void) _Pred; // TRANSITION, VSO-486357
     }
 }
 #else // ^^^ _HAS_IF_CONSTEXPR / !_HAS_IF_CONSTEXPR vvv
@@ -1543,9 +1543,9 @@ void _Debug_order_set_unchecked(_InIt _First, _InIt _Last, _Pr&& _Pred) {
     if constexpr (is_same_v<_Iter_value_t<_OtherIt>, _Iter_value_t<_InIt>> && _Is_fwd_iter_v<_InIt>) {
         _Debug_order_unchecked(_First, _Last, _Pred);
     } else {
-        (void) _First; // TRANSITION, VSO#486357
-        (void) _Last; // TRANSITION, VSO#486357
-        (void) _Pred; // TRANSITION, VSO#486357
+        (void) _First; // TRANSITION, VSO-486357
+        (void) _Last; // TRANSITION, VSO-486357
+        (void) _Pred; // TRANSITION, VSO-486357
     }
 }
 #else // ^^^ _HAS_IF_CONSTEXPR / !_HAS_IF_CONSTEXPR vvv
@@ -1839,7 +1839,7 @@ protected:
 
 template <class _BidIt, class _BidIt2, enable_if_t<_Range_verifiable_v<_BidIt, _BidIt2>, int> = 0>
 constexpr void _Verify_range(const reverse_iterator<_BidIt>& _First, const reverse_iterator<_BidIt2>& _Last) {
-    // TRANSITION, VSO#612785
+    // TRANSITION, VSO-612785
     _Verify_range(_Last.base(), _First.base()); // note reversed parameters
 }
 
@@ -2066,14 +2066,14 @@ _NODISCARD _Ty _Fake_decay_copy(_Ty) noexcept;
 namespace ranges {
     // CUSTOMIZATION POINT OBJECT ranges::begin
     namespace _Begin {
-#ifndef __clang__ // TRANSITION, VSO#895622
+#ifndef __clang__ // TRANSITION, VSO-895622
         void begin();
-#endif // TRANSITION, VSO#895622
+#endif // TRANSITION, VSO-895622
 
         template <class _Ty>
         void begin(_Ty&&) = delete;
         template <class _Ty>
-        void begin(initializer_list<_Ty>) = delete; // Per PR of LWG 3258
+        void begin(initializer_list<_Ty>) = delete; // Per PR of LWG-3258
 
         // clang-format off
         template <class _Ty>
@@ -2136,14 +2136,14 @@ namespace ranges {
 
     // CUSTOMIZATION POINT OBJECT ranges::end
     namespace _End {
-#ifndef __clang__ // TRANSITION, VSO#895622
+#ifndef __clang__ // TRANSITION, VSO-895622
         void end();
-#endif // TRANSITION, VSO#895622
+#endif // TRANSITION, VSO-895622
 
         template <class _Ty>
         void end(_Ty&&) = delete;
         template <class _Ty>
-        void end(initializer_list<_Ty>) = delete; // Per PR of LWG 3258
+        void end(initializer_list<_Ty>) = delete; // Per PR of LWG-3258
 
         // clang-format off
         template <class _Ty>
@@ -2279,14 +2279,14 @@ namespace ranges {
 
     // CUSTOMIZATION POINT OBJECT ranges::rbegin
     namespace _Rbegin {
-#ifndef __clang__ // TRANSITION, VSO#895622
+#ifndef __clang__ // TRANSITION, VSO-895622
         void rbegin();
-#endif // TRANSITION, VSO#895622
+#endif // TRANSITION, VSO-895622
 
         template <class _Ty>
         void rbegin(_Ty&&) = delete;
         template <class _Ty>
-        void rbegin(initializer_list<_Ty>) = delete; // Per PR of LWG 3258
+        void rbegin(initializer_list<_Ty>) = delete; // Per PR of LWG-3258
 
         // clang-format off
         template <class _Ty>
@@ -2351,14 +2351,14 @@ namespace ranges {
 
     // CUSTOMIZATION POINT OBJECT ranges::rend
     namespace _Rend {
-#ifndef __clang__ // TRANSITION, VSO#895622
+#ifndef __clang__ // TRANSITION, VSO-895622
         void rend();
-#endif // TRANSITION, VSO#895622
+#endif // TRANSITION, VSO-895622
 
         template <class _Ty>
         void rend(_Ty&&) = delete;
         template <class _Ty>
-        void rend(initializer_list<_Ty>) = delete; // Per PR of LWG 3258
+        void rend(initializer_list<_Ty>) = delete; // Per PR of LWG-3258
 
         // clang-format off
         template <class _Ty>
@@ -2467,9 +2467,9 @@ namespace ranges {
 
     // CUSTOMIZATION POINT OBJECT ranges::size
     namespace _Size {
-#ifndef __clang__ // TRANSITION, VSO#895622
+#ifndef __clang__ // TRANSITION, VSO-895622
         void size();
-#endif // TRANSITION, VSO#895622
+#endif // TRANSITION, VSO-895622
 
         template <class _Ty>
         void size(_Ty&&) = delete;
@@ -2682,9 +2682,9 @@ namespace ranges {
     // CONCEPT ranges::sized_range
     template <class _Rng>
     concept sized_range = range<_Rng>
-#if 0 // TRANSITION, LWG 3264
+#if 0 // TRANSITION, LWG-3264
         && !disable_sized_range<remove_cvref_t<_Rng>>
-#endif // TRANSITION, LWG 3264
+#endif // TRANSITION, LWG-3264
         && requires(_Rng& __r) { size(__r); };
     // clang-format on
 
@@ -3016,7 +3016,7 @@ private:
 template <class _Ty, size_t _Size>
 constexpr void _Verify_range(
     const _Array_const_iterator<_Ty, _Size>& _First, const _Array_const_iterator<_Ty, _Size>& _Last) noexcept {
-    // TRANSITION, VSO#612785
+    // TRANSITION, VSO-612785
     _First._Verify_with(_Last);
 }
 #endif // _ITERATOR_DEBUG_LEVEL != 0
@@ -3426,7 +3426,7 @@ _OutIt copy_n(_InIt _First, _Diff _Count_raw, _OutIt _Dest) { // copy [_First, _
                 ++_UDest;
                 --_Count;
                 if (_Count == 0) { // note that we avoid an extra ++_First here to allow istream_iterator to work,
-                                   // see LWG#2471
+                                   // see LWG-2471
                     break;
                 }
 
@@ -3450,7 +3450,7 @@ _OutIt _Copy_n_unchecked4(_InIt _First, _Diff _Count, _OutIt _Dest, false_type) 
         ++_Dest;
         --_Count;
         if (_Count == 0) { // note that we avoid an extra ++_First here to allow istream_iterator to work,
-                           // see LWG#2471
+                           // see LWG-2471
             return _Dest;
         }
 
@@ -4860,7 +4860,7 @@ _NODISCARD _FwdIt lower_bound(_FwdIt _First, const _FwdIt _Last, const _Ty& _Val
     _Iter_diff_t<_FwdIt> _Count = _STD distance(_UFirst, _Get_unwrapped(_Last));
 
     while (0 < _Count) { // divide and conquer, find half that contains answer
-        const _Iter_diff_t<_FwdIt> _Count2 = _Count >> 1; // TRANSITION, VSO#433486
+        const _Iter_diff_t<_FwdIt> _Count2 = _Count >> 1; // TRANSITION, VSO-433486
         const auto _UMid                   = _STD next(_UFirst, _Count2);
         if (_Pred(*_UMid, _Val)) { // try top half
             _UFirst = _Next_iter(_UMid);

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -104,9 +104,9 @@
 // P0004R1 Removing Deprecated Iostreams Aliases
 // P0298R3 std::byte
 // P0302R1 Removing Allocator Support In std::function
-// LWG 2385 function::assign allocator argument doesn't make sense
-// LWG 2921 packaged_task and type-erased allocators
-// LWG 2976 Dangling uses_allocator specialization for packaged_task
+// LWG-2385 function::assign allocator argument doesn't make sense
+// LWG-2921 packaged_task and type-erased allocators
+// LWG-2976 Dangling uses_allocator specialization for packaged_task
 // The non-Standard std::tr1 namespace and TR1-only machinery
 // Enforcement of matching allocator value_types
 
@@ -473,9 +473,9 @@
 #endif // _HAS_STD_BYTE
 
 // P0302R1 Removing Allocator Support In std::function
-// LWG 2385 function::assign allocator argument doesn't make sense
-// LWG 2921 packaged_task and type-erased allocators
-// LWG 2976 Dangling uses_allocator specialization for packaged_task
+// LWG-2385 function::assign allocator argument doesn't make sense
+// LWG-2921 packaged_task and type-erased allocators
+// LWG-2976 Dangling uses_allocator specialization for packaged_task
 #ifndef _HAS_FUNCTION_ALLOCATOR_SUPPORT
 #define _HAS_FUNCTION_ALLOCATOR_SUPPORT (!_HAS_CXX17)
 #endif // _HAS_FUNCTION_ALLOCATOR_SUPPORT

--- a/stl/src/xmbtowc.cpp
+++ b/stl/src/xmbtowc.cpp
@@ -72,7 +72,7 @@ _MRTIMP2 int __cdecl _Mbrtowc(wchar_t* pwc, const char* s, size_t n, mbstate_t* 
         return 0;
     }
 
-    if (!*s) { // handle null terminator, TRANSITION, VSO#654347
+    if (!*s) { // handle null terminator, TRANSITION, VSO-654347
         *pwc = 0;
         return 0;
     }


### PR DESCRIPTION
# Description

I've configured [custom autolinks](https://help.github.com/en/articles/autolinked-references-and-urls) for microsoft/STL. They are:

* LLVM- for Clang/LLVM bugs
* LWG- for LWG issues
* DevCom- for Developer Community bugs and suggestions
* VSO- for Microsoft-internal Azure DevOps bugs (formerly Visual Studio Online)
* OS- for Microsoft-internal UCRT bugs (in the Windows OS database)

This updates our comments accordingly. Note that autolinks are active only in GitHub conversations, not repository files, so these comments won't become magic links - however, they will encourage us to use the right conventions. Examples:

* LLVM-41915
* LWG-3080
* DevCom-724444
* VSO-768746 (Microsoft-internal)
* OS-17090155 (Microsoft-internal)

Additionally, I've set up WG21-N and WG21-P. Note that due to GitHub's syntax, revision numbers aren't supported. Examples: 

* WG21-N4190
* WG21-P1209

At this time, I'm not changing our paper citation comments to follow this format.

# Checklist

If you're unsure about a box, leave it unchecked. A maintainer will help you.

If a box isn't applicable, add an explanation in **bold**.
For example: **(N/A: this is a bugfix, not a feature)**

- [x] I understand README.md. I also understand that acceptance of
  community PRs will be delayed until the test and CI systems are online.
- [ ] If this is a feature addition, that feature has been voted into the
  C++ Working Draft. **(N/A, not a feature)**
- [ ] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 . **(N/A, no identifier changes)**
- [ ] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before CI is online, leave this unchecked for
  initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository and
  the C++ Working Draft as a reference (and any other cited standards).
  If they were derived from a project that's already listed in NOTICE.txt,
  that's fine, but please mention it. If they were derived from any other
  project (including Boost and libc++, which are not yet listed in
  NOTICE.txt), you *must* mention it here, so we can determine whether the
  license is compatible and what else needs to be done.
