### PR TITLE
Add back the missing unique_ptr swap

### DIFF
--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -2057,6 +2057,11 @@ _NODISCARD unique_ptr<_Ty> make_unique(size_t _Size) { // make a unique_ptr
 template <class _Ty, class... _Types, enable_if_t<extent_v<_Ty> != 0, int> = 0>
 void make_unique(_Types&&...) = delete;
 
+template <class _Ty, class _Dx, enable_if_t<_Is_swappable<_Dx>::value, int> = 0>
+void swap(unique_ptr<_Ty, _Dx>& _Left, unique_ptr<_Ty, _Dx>& _Right) noexcept {
+    _Left.swap(_Right);
+}
+
 template <class _Ty1, class _Dx1, class _Ty2, class _Dx2>
 _NODISCARD bool operator==(const unique_ptr<_Ty1, _Dx1>& _Left, const unique_ptr<_Ty2, _Dx2>& _Right) {
     return _Left.get() == _Right.get();


### PR DESCRIPTION
Add back the missing `unique_ptr` `swap` damaged by (Microsoft-internal, pre-GitHub commit) f84d346b33eff67c3e5038fbb32342a82abdb4f2

Resolves DevCom-754487 / VSO-1000729

# Description

It looks like when I moved around allocator support for `std::unique_ptr` to fix our many `allocator::construct` bugs, I accidentally deleted this overload. Everything appeared to continue to work because the default `std::swap` does the right thing, although less efficiently and instantiating more templates than necessary.

# Checklist

If you're unsure about a box, leave it unchecked. A maintainer will help you.

If a box isn't applicable, add an explanation in **bold**.
For example: **(N/A: this is a bugfix, not a feature)**

- [x] I understand README.md. I also understand that acceptance of
  community PRs will be delayed until the test and CI systems are online.
- [x] If this is a feature addition, that feature has been voted into the
  C++ Working Draft. **Bugfix**
- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 .
- [x] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before CI is online, leave this unchecked for
  initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository and
  the C++ Working Draft as a reference (and any other cited standards).
  If they were derived from a project that's already listed in NOTICE.txt,
  that's fine, but please mention it. If they were derived from any other
  project (including Boost and libc++, which are not yet listed in
  NOTICE.txt), you *must* mention it here, so we can determine whether the
  license is compatible and what else needs to be done.
