### PR TITLE
Fix Run-Time Check Failure

### DIFF
--- a/stl/inc/xcharconv_ryu.h
+++ b/stl/inc/xcharconv_ryu.h
@@ -1861,7 +1861,7 @@ _NODISCARD inline __floating_decimal_64 __d2d(const uint64_t __ieeeMantissa, con
     const uint64_t __vmDiv100 = __div100(__vm);
     if (__vpDiv100 > __vmDiv100) { // Optimization: remove two digits at a time (~86.2%).
       const uint64_t __vrDiv100 = __div100(__vr);
-      const uint32_t __vrMod100 = static_cast<uint32_t>(__vr) - 100 * static_cast<uint32_t>(__vrDiv100);
+      const uint32_t __vrMod100 = static_cast<uint32_t>(__vr & 0xffffffff) - 100 * static_cast<uint32_t>(__vrDiv100 & 0xffffffff);
       __roundUp = __vrMod100 >= 50;
       __vr = __vrDiv100;
       __vp = __vpDiv100;
@@ -1879,7 +1879,7 @@ _NODISCARD inline __floating_decimal_64 __d2d(const uint64_t __ieeeMantissa, con
         break;
       }
       const uint64_t __vrDiv10 = __div10(__vr);
-      const uint32_t __vrMod10 = static_cast<uint32_t>(__vr) - 10 * static_cast<uint32_t>(__vrDiv10);
+      const uint32_t __vrMod10 = static_cast<uint32_t>(__vr & 0xffffffff) - 10 * static_cast<uint32_t>(__vrDiv10 & 0xffffffff);
       __roundUp = __vrMod10 >= 5;
       __vr = __vrDiv10;
       __vp = __vpDiv10;


### PR DESCRIPTION
Hey STL,

just watched your cppcon talk. I couldn't help myself and had to implement std::to_chars/std::from_chars immediately. Had a few issues:

1. `#include <charconv>` in my precompiled header file:
=> compiler error: "fatal error C1076: compiler limit: internal heap limit reached"

2. `#include <charconv>` in another header, widely-used in my project:
=> compiler error: "An internal error has occurred in the compiler. (compiler file 'd:\agent\_work\1\s\src\vctools\Compiler\Utc\src\p2\p2symtab.c', line 2618)"

=> created a wrapper and `#include <charconv>` locally in a .cpp file => fine.

3. Runtime check error in std::to_chars (for double(12.34))
=> patch included

Best, Zenju
![fail](https://user-images.githubusercontent.com/7656530/66715253-4397be80-edc1-11e9-92ed-79c65f9153fe.PNG)
