### PR TITLE
Cleanup <any> and allow overaligned types

### DIFF
--- a/stl/inc/any
+++ b/stl/inc/any
@@ -41,31 +41,31 @@ public:
     _THROW(bad_any_cast{});
 }
 
-constexpr size_t _Any_trivial_space_size = (_Small_object_num_ptrs - 1) * sizeof(void*);
+inline constexpr size_t _Any_trivial_space_size = (_Small_object_num_ptrs - 1) * sizeof(void*);
 
 template <class _Ty>
-using _Any_is_trivial = bool_constant<alignof(_Ty) <= alignof(max_align_t)
-                                      && is_trivially_copyable_v<_Ty> && sizeof(_Ty) <= _Any_trivial_space_size>;
+inline constexpr bool _Any_is_trivial = alignof(_Ty) <= alignof(max_align_t)
+                                        && is_trivially_copyable_v<_Ty> && sizeof(_Ty) <= _Any_trivial_space_size;
 
-constexpr size_t _Any_small_space_size = (_Small_object_num_ptrs - 2) * sizeof(void*);
+inline constexpr size_t _Any_small_space_size = (_Small_object_num_ptrs - 2) * sizeof(void*);
 
 template <class _Ty>
-using _Any_is_small = bool_constant<alignof(_Ty) <= alignof(max_align_t)
-                                    && is_nothrow_move_constructible_v<_Ty> && sizeof(_Ty) <= _Any_small_space_size>;
+inline constexpr bool _Any_is_small = alignof(_Ty) <= alignof(max_align_t)
+                                      && is_nothrow_move_constructible_v<_Ty> && sizeof(_Ty) <= _Any_small_space_size;
 
 enum class _Any_representation : uintptr_t { _Trivial, _Big, _Small };
 
 struct _Any_big_RTTI { // Hand-rolled vtable for types that must be heap allocated in an any
-    using _Destroy_fn = void __CLRCALL_PURE_OR_CDECL(void*) /* noexcept */;
+    using _Destroy_fn = void __CLRCALL_PURE_OR_CDECL(void*) noexcept;
     using _Copy_fn    = void* __CLRCALL_PURE_OR_CDECL(const void*);
 
     template <class _Ty>
-    static void __CLRCALL_PURE_OR_CDECL _Destroy_impl(void* const _Target) noexcept { // Implements destruction for _Ty
+    static void __CLRCALL_PURE_OR_CDECL _Destroy_impl(void* const _Target) noexcept {
         ::delete static_cast<_Ty*>(_Target);
     }
 
     template <class _Ty>
-    static void* __CLRCALL_PURE_OR_CDECL _Copy_impl(const void* const _Source) { // Implements copy for _Ty
+    _NODISCARD static void* __CLRCALL_PURE_OR_CDECL _Copy_impl(const void* const _Source) {
         return ::new _Ty(*static_cast<const _Ty*>(_Source));
     }
 
@@ -74,24 +74,22 @@ struct _Any_big_RTTI { // Hand-rolled vtable for types that must be heap allocat
 };
 
 struct _Any_small_RTTI { // Hand-rolled vtable for nontrivial types that can be stored internally in an any
-    using _Destroy_fn = void __CLRCALL_PURE_OR_CDECL(void*) /* noexcept */;
+    using _Destroy_fn = void __CLRCALL_PURE_OR_CDECL(void*) noexcept;
     using _Copy_fn    = void __CLRCALL_PURE_OR_CDECL(void*, const void*);
-    using _Move_fn    = void __CLRCALL_PURE_OR_CDECL(void*, void*) /* noexcept */;
+    using _Move_fn    = void __CLRCALL_PURE_OR_CDECL(void*, void*) noexcept;
 
     template <class _Ty>
-    static void __CLRCALL_PURE_OR_CDECL _Destroy_impl(void* const _Target) noexcept { // Implements destruction for _Ty
+    static void __CLRCALL_PURE_OR_CDECL _Destroy_impl(void* const _Target) noexcept {
         _Destroy_in_place(*static_cast<_Ty*>(_Target));
     }
 
     template <class _Ty>
-    static void __CLRCALL_PURE_OR_CDECL _Copy_impl(
-        void* const _Target, const void* const _Source) { // Implements copy for _Ty
+    static void __CLRCALL_PURE_OR_CDECL _Copy_impl(void* const _Target, const void* const _Source) {
         _Construct_in_place(*static_cast<_Ty*>(_Target), *static_cast<const _Ty*>(_Source));
     }
 
     template <class _Ty>
-    static void __CLRCALL_PURE_OR_CDECL _Move_impl(
-        void* const _Target, void* const _Source) noexcept { // Implements move for _Ty
+    static void __CLRCALL_PURE_OR_CDECL _Move_impl(void* const _Target, void* const _Source) noexcept {
         _Construct_in_place(*static_cast<_Ty*>(_Target), _STD move(*static_cast<_Ty*>(_Source)));
     }
 
@@ -112,22 +110,22 @@ inline constexpr _Any_small_RTTI _Any_small_RTTI_obj = {
 class any { // storage for any (CopyConstructible) type
 public:
     // Construction and destruction [any.cons]
-    constexpr any() noexcept : _Storage{} {}
+    constexpr any() noexcept {}
 
     any(const any& _That) {
-        _TypeData() = _That._TypeData();
+        _Storage._TypeData = _That._Storage._TypeData;
         switch (_Rep()) {
         case _Any_representation::_Small:
-            _SmallRTTI() = _That._SmallRTTI();
-            _SmallRTTI()->_Copy(_SmallData(), _That._SmallData());
+            _Storage._SmallStorage._RTTI = _That._Storage._SmallStorage._RTTI;
+            _Storage._SmallStorage._RTTI->_Copy(&_Storage._SmallStorage._Data, &_That._Storage._SmallStorage._Data);
             break;
         case _Any_representation::_Big:
-            _BigRTTI()    = _That._BigRTTI();
-            _BigPointer() = _BigRTTI()->_Copy(_That._BigPointer());
+            _Storage._BigStorage._RTTI = _That._Storage._BigStorage._RTTI;
+            _Storage._BigStorage._Ptr  = _Storage._BigStorage._RTTI->_Copy(_That._Storage._BigStorage._Ptr);
             break;
         case _Any_representation::_Trivial:
         default:
-            _Storage._TrivialData = _That._Storage._TrivialData;
+            _CSTD memcpy(_Storage._TrivialData, _That._Storage._TrivialData, sizeof(_Storage._TrivialData));
             break;
         }
     }
@@ -145,7 +143,8 @@ public:
     }
 
     template <class _ValueType, class... _Types,
-        enable_if_t<is_constructible_v<decay_t<_ValueType>, _Types...> && is_copy_constructible_v<decay_t<_ValueType>>,
+        enable_if_t<
+            conjunction_v<is_constructible<decay_t<_ValueType>, _Types...>, is_copy_constructible<decay_t<_ValueType>>>,
             int> = 0>
     explicit any(in_place_type_t<_ValueType>, _Types&&... _Args) {
         // in-place initialize a value of type decay_t<_ValueType> with _Args...
@@ -153,8 +152,8 @@ public:
     }
 
     template <class _ValueType, class _Elem, class... _Types,
-        enable_if_t<is_constructible_v<decay_t<_ValueType>, initializer_list<_Elem>&,
-                        _Types...> && is_copy_constructible_v<decay_t<_ValueType>>,
+        enable_if_t<conjunction_v<is_constructible<decay_t<_ValueType>, initializer_list<_Elem>&, _Types...>,
+                        is_copy_constructible<decay_t<_ValueType>>>,
             int> = 0>
     explicit any(in_place_type_t<_ValueType>, initializer_list<_Elem> _Ilist, _Types&&... _Args) {
         // in-place initialize a value of type decay_t<_ValueType> with _Ilist and _Args...
@@ -167,7 +166,6 @@ public:
 
     // Assignment [any.assign]
     any& operator=(const any& _That) {
-
         *this = any{_That};
         return *this;
     }
@@ -183,14 +181,14 @@ public:
                                     int> = 0>
     any& operator=(_ValueType&& _Value) {
         // replace contained value with an object of type decay_t<_ValueType> initialized from _Value
-
         *this = any{_STD forward<_ValueType>(_Value)};
         return *this;
     }
 
     // Modifiers [any.modifiers]
     template <class _ValueType, class... _Types,
-        enable_if_t<is_constructible_v<decay_t<_ValueType>, _Types...> && is_copy_constructible_v<decay_t<_ValueType>>,
+        enable_if_t<
+            conjunction_v<is_constructible<decay_t<_ValueType>, _Types...>, is_copy_constructible<decay_t<_ValueType>>>,
             int> = 0>
     decay_t<_ValueType>& emplace(_Types&&... _Args) {
         // replace contained value with an object of type decay_t<_ValueType> initialized from _Args...
@@ -198,8 +196,8 @@ public:
         return _Emplace<decay_t<_ValueType>>(_STD forward<_Types>(_Args)...);
     }
     template <class _ValueType, class _Elem, class... _Types,
-        enable_if_t<is_constructible_v<decay_t<_ValueType>, initializer_list<_Elem>&,
-                        _Types...> && is_copy_constructible_v<decay_t<_ValueType>>,
+        enable_if_t<conjunction_v<is_constructible<decay_t<_ValueType>, initializer_list<_Elem>&, _Types...>,
+                        is_copy_constructible<decay_t<_ValueType>>>,
             int> = 0>
     decay_t<_ValueType>& emplace(initializer_list<_Elem> _Ilist, _Types&&... _Args) {
         // replace contained value with an object of type decay_t<_ValueType> initialized from _Ilist and _Args...
@@ -210,16 +208,16 @@ public:
     void reset() noexcept { // transition to the empty state
         switch (_Rep()) {
         case _Any_representation::_Small:
-            _SmallRTTI()->_Destroy(_SmallData());
+            _Storage._SmallStorage._RTTI->_Destroy(&_Storage._SmallStorage._Data);
             break;
         case _Any_representation::_Big:
-            _BigRTTI()->_Destroy(_BigPointer());
+            _Storage._BigStorage._RTTI->_Destroy(_Storage._BigStorage._Ptr);
             break;
         case _Any_representation::_Trivial:
         default:
             break;
         }
-        _TypeData() = 0;
+        _Storage._TypeData = 0;
     }
 
     void swap(any& _That) noexcept {
@@ -228,7 +226,7 @@ public:
 
     // Observers [any.observers]
     _NODISCARD bool has_value() const noexcept {
-        return _TypeData() != 0;
+        return _Storage._TypeData != 0;
     }
 
     _NODISCARD const type_info& type() const noexcept {
@@ -242,164 +240,114 @@ public:
     }
 
     template <class _Decayed>
-    const _Decayed* _Cast() const noexcept { // if *this contains a value of type _Decayed, return a pointer to it
+    _NODISCARD const _Decayed* _Cast() const noexcept {
+        // if *this contains a value of type _Decayed, return a pointer to it
         const type_info* const _Info = _TypeInfo();
-        if (_Info && *_Info == typeid(_Decayed)) {
-            return _Cast1<_Decayed>(_Any_is_small<_Decayed>{}, _Any_is_trivial<_Decayed>{});
+        if (!_Info || *_Info != typeid(_Decayed)) {
+            return nullptr;
         }
 
-        return nullptr;
+        if constexpr (_Any_is_trivial<_Decayed>) {
+            // get a pointer to the contained _Trivial value of type _Decayed
+            return reinterpret_cast<const _Decayed*>(&_Storage._TrivialData);
+        } else if constexpr (_Any_is_small<_Decayed>) {
+            // get a pointer to the contained _Small value of type _Decayed
+            return reinterpret_cast<const _Decayed*>(&_Storage._SmallStorage._Data);
+        } else {
+            // get a pointer to the contained _Big value of type _Decayed
+            return static_cast<const _Decayed*>(_Storage._BigStorage._Ptr);
+        }
     }
 
     template <class _Decayed>
-    _Decayed* _Cast() noexcept { // if *this contains a value of type _Decayed, return a pointer to it
-        return const_cast<_Decayed*>(const_cast<const any*>(this)->_Cast<_Decayed>());
+    _NODISCARD _Decayed* _Cast() noexcept { // if *this contains a value of type _Decayed, return a pointer to it
+        return const_cast<_Decayed*>(static_cast<const any*>(this)->_Cast<_Decayed>());
     }
 
 private:
     static constexpr uintptr_t _Rep_mask = 3;
 
-    _Any_representation _Rep() const { // extract the representation format from _TypeData
-        return static_cast<_Any_representation>(_TypeData() & _Rep_mask);
+    _NODISCARD _Any_representation _Rep() const noexcept { // extract the representation format from _TypeData
+        return static_cast<_Any_representation>(_Storage._TypeData & _Rep_mask);
     }
-    const type_info* _TypeInfo() const { // extract the type_info from _TypeData
-        return reinterpret_cast<const type_info*>(_TypeData() & ~_Rep_mask);
+    _NODISCARD const type_info* _TypeInfo() const noexcept { // extract the type_info from _TypeData
+        return reinterpret_cast<const type_info*>(_Storage._TypeData & ~_Rep_mask);
     }
 
-    void _Move_from(any& _That) {
-        _TypeData() = _That._TypeData();
+    void _Move_from(any& _That) noexcept {
+        _Storage._TypeData = _That._Storage._TypeData;
         switch (_Rep()) {
         case _Any_representation::_Small:
-            _SmallRTTI() = _That._SmallRTTI();
-            _SmallRTTI()->_Move(_SmallData(), _That._SmallData());
+            _Storage._SmallStorage._RTTI = _That._Storage._SmallStorage._RTTI;
+            _Storage._SmallStorage._RTTI->_Move(&_Storage._SmallStorage._Data, &_That._Storage._SmallStorage._Data);
             break;
         case _Any_representation::_Big:
-            _BigRTTI()        = _That._BigRTTI();
-            _BigPointer()     = _That._BigPointer();
-            _That._TypeData() = 0;
+            _Storage._BigStorage._RTTI = _That._Storage._BigStorage._RTTI;
+            _Storage._BigStorage._Ptr  = _That._Storage._BigStorage._Ptr;
+            _That._Storage._TypeData   = 0;
             break;
         case _Any_representation::_Trivial:
         default:
-            _Storage._TrivialData = _That._Storage._TrivialData;
+            _CSTD memcpy(_Storage._TrivialData, _That._Storage._TrivialData, sizeof(_Storage._TrivialData));
             break;
         }
     }
 
     template <class _Decayed, class... _Types>
-    _Decayed& _Emplace(_Types&&... _Args) {
-        static_assert(alignof(_Decayed) <= alignof(max_align_t),
-            "Sorry: std::any doesn't support over-aligned types at this time.");
-        return _Emplace1<_Decayed>(
-            _Any_is_small<_Decayed>{}, _Any_is_trivial<_Decayed>{}, _STD forward<_Types>(_Args)...);
-    }
-
-    template <class _Decayed, class... _Types>
-    _Decayed& _Emplace1(false_type, false_type, _Types&&... _Args) {
-        // emplace construct _Decayed using the _Big representation
-        _Decayed* const _Ptr = ::new _Decayed(_STD forward<_Types>(_Args)...);
-        _BigPointer()        = _Ptr;
-        _BigRTTI()           = &_Any_big_RTTI_obj<_Decayed>;
-        _TypeData() =
-            reinterpret_cast<uintptr_t>(&typeid(_Decayed)) | static_cast<uintptr_t>(_Any_representation::_Big);
-        return *_Ptr;
-    }
-
-    template <class _Decayed, class... _Types>
-    _Decayed& _Emplace1(true_type, false_type, _Types&&... _Args) {
-        // emplace construct _Decayed using the _Small representation
-        auto& _Obj = reinterpret_cast<_Decayed&>(_Storage._SmallStorage._Data);
-        _Construct_in_place(_Obj, _STD forward<_Types>(_Args)...);
-        _SmallRTTI() = &_Any_small_RTTI_obj<_Decayed>;
-        _TypeData() =
-            reinterpret_cast<uintptr_t>(&typeid(_Decayed)) | static_cast<uintptr_t>(_Any_representation::_Small);
-        return _Obj;
-    }
-
-    template <class _Decayed, class... _Types>
-    _Decayed& _Emplace1(_Any_tag, true_type, _Types&&... _Args) {
-        // emplace construct _Decayed using the _Trivial representation
-        auto& _Obj = reinterpret_cast<_Decayed&>(_Storage._TrivialData);
-        _Construct_in_place(_Obj, _STD forward<_Types>(_Args)...);
-        _TypeData() =
-            reinterpret_cast<uintptr_t>(&typeid(_Decayed)) | static_cast<uintptr_t>(_Any_representation::_Trivial);
-        return _Obj;
-    }
-
-    template <class _Decayed>
-    const _Decayed* _Cast1(false_type, false_type) const noexcept {
-        // get a pointer to the contained _Big value of type _Decayed
-        return static_cast<const _Decayed*>(_BigPointer());
-    }
-
-    template <class _Decayed>
-    const _Decayed* _Cast1(true_type, false_type) const noexcept {
-        // get a pointer to the contained _Small value of type _Decayed
-        return static_cast<const _Decayed*>(_SmallData());
-    }
-
-    template <class _Decayed>
-    const _Decayed* _Cast1(_Any_tag, true_type) const noexcept {
-        // get a pointer to the contained _Trivial value of type _Decayed
-        return reinterpret_cast<const _Decayed*>(&_Storage._TrivialData);
-    }
-
-    uintptr_t& _TypeData() & {
-        return _Storage._TypeData;
-    }
-    const uintptr_t& _TypeData() const& {
-        return _Storage._TypeData;
-    }
-
-    void*& _BigPointer() & {
-        return _Storage._BigStorage._Ptr;
-    }
-    void* const& _BigPointer() const& {
-        return _Storage._BigStorage._Ptr;
-    }
-
-    const _Any_big_RTTI*& _BigRTTI() & {
-        return _Storage._BigStorage._RTTI;
-    }
-    const _Any_big_RTTI* const& _BigRTTI() const& {
-        return _Storage._BigStorage._RTTI;
-    }
-
-    void* _SmallData() & {
-        return &_Storage._SmallStorage._Data;
-    }
-    const void* _SmallData() const& {
-        return &_Storage._SmallStorage._Data;
-    }
-
-    const _Any_small_RTTI*& _SmallRTTI() & {
-        return _Storage._SmallStorage._RTTI;
-    }
-    const _Any_small_RTTI* const& _SmallRTTI() const& {
-        return _Storage._SmallStorage._RTTI;
+    _Decayed& _Emplace(_Types&&... _Args) { // emplace construct _Decayed
+        if constexpr (_Any_is_trivial<_Decayed>) {
+            // using the _Trivial representation
+            auto& _Obj = reinterpret_cast<_Decayed&>(_Storage._TrivialData);
+            _Construct_in_place(_Obj, _STD forward<_Types>(_Args)...);
+            _Storage._TypeData =
+                reinterpret_cast<uintptr_t>(&typeid(_Decayed)) | static_cast<uintptr_t>(_Any_representation::_Trivial);
+            return _Obj;
+        } else if constexpr (_Any_is_small<_Decayed>) {
+            // using the _Small representation
+            auto& _Obj = reinterpret_cast<_Decayed&>(_Storage._SmallStorage._Data);
+            _Construct_in_place(_Obj, _STD forward<_Types>(_Args)...);
+            _Storage._SmallStorage._RTTI = &_Any_small_RTTI_obj<_Decayed>;
+            _Storage._TypeData =
+                reinterpret_cast<uintptr_t>(&typeid(_Decayed)) | static_cast<uintptr_t>(_Any_representation::_Small);
+            return _Obj;
+        } else {
+            // using the _Big representation
+            _Decayed* const _Ptr       = ::new _Decayed(_STD forward<_Types>(_Args)...);
+            _Storage._BigStorage._Ptr  = _Ptr;
+            _Storage._BigStorage._RTTI = &_Any_big_RTTI_obj<_Decayed>;
+            _Storage._TypeData =
+                reinterpret_cast<uintptr_t>(&typeid(_Decayed)) | static_cast<uintptr_t>(_Any_representation::_Big);
+            return *_Ptr;
+        }
     }
 
     struct _Small_storage_t {
-        aligned_union_t<_Any_small_space_size, void*> _Data;
+        unsigned char _Data[_Any_small_space_size];
         const _Any_small_RTTI* _RTTI;
     };
+    static_assert(sizeof(_Small_storage_t) == _Any_trivial_space_size);
 
     struct _Big_storage_t {
-        char _Padding[_Any_small_space_size - sizeof(void*)]; // "push down" the active members near to _TypeData
+        // Pad so that _Ptr and _RTTI might share _TypeData's cache line
+        unsigned char _Padding[_Any_small_space_size - sizeof(void*)];
         void* _Ptr;
         const _Any_big_RTTI* _RTTI;
     };
+    static_assert(sizeof(_Big_storage_t) == _Any_trivial_space_size);
 
     struct _Storage_t {
         union {
-            aligned_union_t<_Any_trivial_space_size, void*> _TrivialData;
+            unsigned char _TrivialData[_Any_trivial_space_size];
             _Small_storage_t _SmallStorage;
             _Big_storage_t _BigStorage;
         };
         uintptr_t _TypeData;
     };
+    static_assert(sizeof(_Storage_t) == _Any_trivial_space_size + sizeof(void*));
+    static_assert(is_standard_layout_v<_Storage_t>);
 
     union {
-        _Storage_t _Storage;
+        _Storage_t _Storage{};
         max_align_t _Dummy;
     };
 };
@@ -420,52 +368,41 @@ _NODISCARD any make_any(initializer_list<_Elem> _Ilist, _Types&&... _Args) {
 }
 
 template <class _ValueType>
-const _ValueType* _Any_cast1(const any*, true_type) noexcept { // retrieve a pointer to a function/array type
-    return nullptr;
-}
-template <class _ValueType>
-_ValueType* _Any_cast1(any*, true_type) noexcept { // retrieve a pointer to a function/array type
-    return nullptr;
-}
-template <class _ValueType>
-const _ValueType* _Any_cast1(
-    const any* const _Any, false_type) noexcept { // retrieve a pointer to the _ValueType contained in _Any, or null
-    return _Any->_Cast<decay_t<_ValueType>>();
-}
-template <class _ValueType>
-_ValueType* _Any_cast1(
-    any* const _Any, false_type) noexcept { // retrieve a pointer to the _ValueType contained in _Any, or null
-    return _Any->_Cast<decay_t<_ValueType>>();
-}
-
-template <class _Ty>
-using _Any_is_function_or_array = bool_constant<is_function_v<_Ty> || is_array_v<_Ty>>;
-
-template <class _ValueType>
 _NODISCARD const _ValueType* any_cast(const any* const _Any) noexcept {
     // retrieve a pointer to the _ValueType contained in _Any, or null
     static_assert(!is_void_v<_ValueType>, "std::any cannot contain void.");
-    if (_Any) {
-        return _Any_cast1<_ValueType>(_Any, _Any_is_function_or_array<_ValueType>{});
-    }
 
-    return nullptr;
+    if constexpr (is_function_v<_ValueType> || is_array_v<_ValueType>) {
+        return nullptr;
+    } else {
+        if (!_Any) {
+            return nullptr;
+        }
+
+        return _Any->_Cast<_Remove_cvref_t<_ValueType>>();
+    }
 }
 template <class _ValueType>
 _NODISCARD _ValueType* any_cast(any* const _Any) noexcept {
     // retrieve a pointer to the _ValueType contained in _Any, or null
     static_assert(!is_void_v<_ValueType>, "std::any cannot contain void.");
-    if (_Any) {
-        return _Any_cast1<_ValueType>(_Any, _Any_is_function_or_array<_ValueType>{});
-    }
 
-    return nullptr;
+    if constexpr (is_function_v<_ValueType> || is_array_v<_ValueType>) {
+        return nullptr;
+    } else {
+        if (!_Any) {
+            return nullptr;
+        }
+
+        return _Any->_Cast<_Remove_cvref_t<_ValueType>>();
+    }
 }
 
 template <class _Ty>
 _NODISCARD _Ty any_cast(const any& _Any) { // retrieve _Any's contained value as _Ty
     static_assert(is_constructible_v<_Ty, const _Remove_cvref_t<_Ty>&>,
         "any_cast<T>(const any&) requires T to be constructible from const remove_cv_t<remove_reference_t<T>>&");
+
     const auto _Ptr = _STD any_cast<_Remove_cvref_t<_Ty>>(&_Any);
     if (!_Ptr) {
         _Throw_bad_any_cast();
@@ -477,6 +414,7 @@ template <class _Ty>
 _NODISCARD _Ty any_cast(any& _Any) { // retrieve _Any's contained value as _Ty
     static_assert(is_constructible_v<_Ty, _Remove_cvref_t<_Ty>&>,
         "any_cast<T>(any&) requires T to be constructible from remove_cv_t<remove_reference_t<T>>&");
+
     const auto _Ptr = _STD any_cast<_Remove_cvref_t<_Ty>>(&_Any);
     if (!_Ptr) {
         _Throw_bad_any_cast();
@@ -488,6 +426,7 @@ template <class _Ty>
 _NODISCARD _Ty any_cast(any&& _Any) { // retrieve _Any's contained value as _Ty
     static_assert(is_constructible_v<_Ty, _Remove_cvref_t<_Ty>>,
         "any_cast<T>(any&&) requires T to be constructible from remove_cv_t<remove_reference_t<T>>");
+
     const auto _Ptr = _STD any_cast<_Remove_cvref_t<_Ty>>(&_Any);
     if (!_Ptr) {
         _Throw_bad_any_cast();


### PR DESCRIPTION
# Description

`<any>` cleanup:

* Prefer variable templates to class templates
* Prefer `if constexpr` to tag dispatch
* Function pointers may be `noexcept` in C++17
* Remove the layer of "symbolic member name" functions to improve debug codegen
* Conventionally use `enable_if_t<conjunction_v<meow, woof>>` instead of `enable_if_t<meow::value && woof::value>`
* Apply `_NODISCARD` and `noexcept` to internal functions as appropriate
* Allow overaligned types, which are properly handled by the `_Big` representation

Resolves DevCom-724444.

(This is a replay of Microsoft-internal PR [207713](https://devdiv.visualstudio.com/DevDiv/_git/msvc/pullrequest/207713).)

# Checklist

If you're unsure about a box, leave it unchecked. A maintainer will help you.

If a box isn't applicable, add an explanation in **bold**.
For example: **(N/A: this is a bugfix, not a feature)**

- [X] I understand README.md. I also understand that acceptance of
  community PRs will be delayed until the test and CI systems are online.
- [X] If this is a feature addition, that feature has been voted into the
  C++ Working Draft.
- [X] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 .
- [X] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before CI is online, leave this unchecked for
  initial submission).
- [X] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [X] These changes were written from scratch using only this repository and
  the C++ Working Draft as a reference (and any other cited standards).
  If they were derived from a project that's already listed in `NOTICE.txt`,
  that's fine, but please mention it. If they were derived from any other
  project (including Boost and libc++, which are not yet listed in
  `NOTICE.txt`), you *must* mention it here, so we can determine whether the
  license is compatible and what else needs to be done.
