### PR TITLE
P0966R1 string::reserve() should not shrink

### DIFF
--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -3618,22 +3618,24 @@ public:
 
 #if _HAS_CXX20
     void reserve(_CRT_GUARDOVERFLOW const size_type _Newcap) { // determine new minimum length of allocated storage
-        if (_Mypair._Myval2._Myres < _Newcap) { // reallocate to grow
-            const size_type _Old_size = _Mypair._Myval2._Mysize;
-            _Reallocate_grow_by(
-                _Newcap - _Old_size, [](_Elem* const _New_ptr, const _Elem* const _Old_ptr, const size_type _Old_size) {
-                    _Traits::copy(_New_ptr, _Old_ptr, _Old_size + 1);
-                });
-
-            _Mypair._Myval2._Mysize = _Old_size;
-            return;
+        if (_Mypair._Myval2._Myres >= _Newcap) { // requested capacity is not larger than current capacity, ignore
+            return; // nothing to do
         }
 
-        // ignore requests to reserve to [0, _Myres]
+        const size_type _Old_size = _Mypair._Myval2._Mysize;
+        _Reallocate_grow_by(
+            _Newcap - _Old_size, [](_Elem* const _New_ptr, const _Elem* const _Old_ptr, const size_type _Old_size) {
+                _Traits::copy(_New_ptr, _Old_ptr, _Old_size + 1);
+            });
+
+        _Mypair._Myval2._Mysize = _Old_size;
     }
 
-
-    _CXX20_DEPRECATE_STRING_RESERVE_DEFAULT_ARGUMENT void reserve() {} // no-op
+    _CXX20_DEPRECATE_STRING_RESERVE_WITHOUT_ARGUMENT void reserve() {
+        if (_Mypair._Myval2._Mysize == 0 && _Mypair._Myval2._Large_string_engaged()) {
+            _Become_small();
+        }
+    }
 #else // _HAS_CXX20
     void reserve(_CRT_GUARDOVERFLOW const size_type _Newcap = 0) { // determine new minimum length of allocated storage
         if (_Mypair._Myval2._Mysize > _Newcap) { // requested capacity is not large enough for current size, ignore

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -3616,6 +3616,25 @@ public:
         return _Mypair._Myval2._Myres;
     }
 
+#if _HAS_CXX20
+    void reserve(_CRT_GUARDOVERFLOW const size_type _Newcap) { // determine new minimum length of allocated storage
+        if (_Mypair._Myval2._Myres < _Newcap) { // reallocate to grow
+            const size_type _Old_size = _Mypair._Myval2._Mysize;
+            _Reallocate_grow_by(
+                _Newcap - _Old_size, [](_Elem* const _New_ptr, const _Elem* const _Old_ptr, const size_type _Old_size) {
+                    _Traits::copy(_New_ptr, _Old_ptr, _Old_size + 1);
+                });
+
+            _Mypair._Myval2._Mysize = _Old_size;
+            return;
+        }
+
+        // ignore requests to reserve to [0, _Myres]
+    }
+
+
+    _CXX20_DEPRECATE_STRING_RESERVE_DEFAULT_ARGUMENT void reserve() {} // no-op
+#else // _HAS_CXX20
     void reserve(_CRT_GUARDOVERFLOW const size_type _Newcap = 0) { // determine new minimum length of allocated storage
         if (_Mypair._Myval2._Mysize > _Newcap) { // requested capacity is not large enough for current size, ignore
             return; // nothing to do
@@ -3644,6 +3663,7 @@ public:
 
         // ignore requests to reserve to [_BUF_SIZE, _Myres)
     }
+#endif // _HAS_CXX20
 
     _NODISCARD bool empty() const noexcept {
         return size() == 0;

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -799,7 +799,21 @@
 #define _DEPRECATE_STDEXT_HASH_UPPER_BOUND
 #endif // ^^^ warning disabled ^^^
 
-// next warning number: STL4024
+// P0966R1 [depr.string.capacity]
+#if _HAS_CXX20 && !defined(_SILENCE_CXX20_STRING_RESERVE_DEFAULT_ARGUMENT_DEPRECATION_WARNING) \
+    && !defined(_SILENCE_ALL_CXX20_DEPRECATION_WARNINGS)
+#define _CXX20_DEPRECATE_STRING_RESERVE_DEFAULT_ARGUMENT                                                             \
+    [[deprecated("warning STL4024: "                                                                                 \
+                 "std::string::reserve() with the default arument 0 is deprecated in C++20. "                        \
+                 "If the intention is to shrink the string's capacity, use std::string::shrink_to_fit(). Otherwise, "\
+                 "provide an argument to std::string::reserve(). "                                                   \
+                 "You can define _SILENCE_CXX20_STRING_RESERVE_DEFAULT_ARGUMENT_DEPRECATION_WARNING"                 \
+                 "or _SILENCE_ALL_CXX20_DEPRECATION_WARNINGS to acknowledge that you have received this warning.")]]
+#else // ^^^ warning enabled / warning disabled vvv
+#define _CXX20_DEPRECATE_STRING_RESERVE_DEFAULT_ARGUMENT
+#endif // ^^^ warning disabled ^^^
+
+// next warning number: STL4025
 
 
 // LIBRARY FEATURE-TEST MACROS

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -44,6 +44,7 @@
 //     (partially implemented)
 // P0898R3 Standard Library Concepts
 // P0919R3 Heterogeneous Lookup For Unordered Containers
+// P0966R1 string::reserve() Should Not Shrink
 // P1227R2 Signed std::ssize(), Unsigned span::size()
 //     (partially implemented)
 // P1357R1 is_bounded_array, is_unbounded_array
@@ -412,7 +413,7 @@
 
 #define _CPPLIB_VER 650
 #define _MSVC_STL_VERSION 142
-#define _MSVC_STL_UPDATE 201909L
+#define _MSVC_STL_UPDATE 201910L
 
 #ifndef _ALLOW_COMPILER_AND_STL_VERSION_MISMATCH
 #ifdef __EDG__
@@ -800,17 +801,17 @@
 #endif // ^^^ warning disabled ^^^
 
 // P0966R1 [depr.string.capacity]
-#if _HAS_CXX20 && !defined(_SILENCE_CXX20_STRING_RESERVE_DEFAULT_ARGUMENT_DEPRECATION_WARNING) \
+#if _HAS_CXX20 && !defined(_SILENCE_CXX20_STRING_RESERVE_WITHOUT_ARGUMENT_DEPRECATION_WARNING) \
     && !defined(_SILENCE_ALL_CXX20_DEPRECATION_WARNINGS)
-#define _CXX20_DEPRECATE_STRING_RESERVE_DEFAULT_ARGUMENT                                                             \
+#define _CXX20_DEPRECATE_STRING_RESERVE_WITHOUT_ARGUMENT                                                             \
     [[deprecated("warning STL4024: "                                                                                 \
-                 "std::string::reserve() with the default arument 0 is deprecated in C++20. "                        \
-                 "If the intention is to shrink the string's capacity, use std::string::shrink_to_fit(). Otherwise, "\
-                 "provide an argument to std::string::reserve(). "                                                   \
-                 "You can define _SILENCE_CXX20_STRING_RESERVE_DEFAULT_ARGUMENT_DEPRECATION_WARNING"                 \
+                 "std::string::reserve() without an argument is deprecated in C++20. "                               \
+                 "To shrink the string's capacity, use std::string::shrink_to_fit() instead. Otherwise, provide an " \
+                 "argument to std::string::reserve(). "                                                              \
+                 "You can define _SILENCE_CXX20_STRING_RESERVE_WITHOUT_ARGUMENT_DEPRECATION_WARNING "                \
                  "or _SILENCE_ALL_CXX20_DEPRECATION_WARNINGS to acknowledge that you have received this warning.")]]
 #else // ^^^ warning enabled / warning disabled vvv
-#define _CXX20_DEPRECATE_STRING_RESERVE_DEFAULT_ARGUMENT
+#define _CXX20_DEPRECATE_STRING_RESERVE_WITHOUT_ARGUMENT
 #endif // ^^^ warning disabled ^^^
 
 // next warning number: STL4025


### PR DESCRIPTION
# Description

Addresses P0966R1 by preventing std::string::reserve() with arguments from shrinking the capacity. Also created deprecation warning, since std::string::reserve() with no arguments is deprecated in C++20.
Resolves #42 
# Checklist

- [x] I understand README.md. I also understand that acceptance of
  community PRs will be delayed until the test and CI systems are online.
- [x] If this is a feature addition, that feature has been voted into the
  C++ Working Draft.
- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 .
- [ ] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before CI is online, leave this unchecked for
  initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository and
  the C++ Working Draft as a reference (and any other cited standards).
  If they were derived from a project that's already listed in NOTICE.txt,
  that's fine, but please mention it. If they were derived from any other
  project (including Boost and libc++, which are not yet listed in
  NOTICE.txt), you *must* mention it here, so we can determine whether the
  license is compatible and what else needs to be done.
