### PR TITLE
P0767R1 Deprecating is_pod

### DIFF
--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -528,10 +528,10 @@ struct is_volatile : bool_constant<is_volatile_v<_Ty>> {};
 
 // STRUCT TEMPLATE is_pod
 template <class _Ty>
-struct is_pod : bool_constant<__is_pod(_Ty)> {}; // determine whether _Ty is a POD type
+struct _CXX20_DEPRECATE_IS_POD is_pod : bool_constant<__is_pod(_Ty)> {}; // determine whether _Ty is a POD type
 
 template <class _Ty>
-_INLINE_VAR constexpr bool is_pod_v = __is_pod(_Ty);
+_CXX20_DEPRECATE_IS_POD _INLINE_VAR constexpr bool is_pod_v = __is_pod(_Ty);
 
 // STRUCT TEMPLATE is_empty
 template <class _Ty>

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -121,6 +121,7 @@
 // Other C++17 deprecation warnings
 
 // _HAS_CXX20 and _SILENCE_ALL_CXX20_DEPRECATION_WARNINGS control:
+// P0767R1 Deprecating is_pod
 // Other C++20 deprecation warnings
 
 // Implemented unconditionally:
@@ -812,9 +813,20 @@
                  "or _SILENCE_ALL_CXX20_DEPRECATION_WARNINGS to acknowledge that you have received this warning.")]]
 #else // ^^^ warning enabled / warning disabled vvv
 #define _CXX20_DEPRECATE_STRING_RESERVE_WITHOUT_ARGUMENT
+
+// P0767R1 [depr.meta.types]
+#if _HAS_CXX20 && !defined(_SILENCE_CXX20_IS_POD_DEPRECATION_WARNING) \
+    && !defined(_SILENCE_ALL_CXX20_DEPRECATION_WARNINGS)
+#define _CXX20_DEPRECATE_IS_POD                                              \
+    [[deprecated("warning STL4024: "                                         \
+                 "std::is_pod and std::is_pod_v are deprecated in C++20. "   \
+                 "You can define _SILENCE_CXX20_IS_POD_DEPRECATION_WARNING " \
+                 "or _SILENCE_ALL_CXX20_DEPRECATION_WARNINGS to acknowledge that you have received this warning.")]]
+#else // ^^^ warning enabled / warning disabled vvv
+#define _CXX20_DEPRECATE_IS_POD
 #endif // ^^^ warning disabled ^^^
 
-// next warning number: STL4025
+// next warning number: STL4026
 
 
 // LIBRARY FEATURE-TEST MACROS

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -813,14 +813,16 @@
                  "or _SILENCE_ALL_CXX20_DEPRECATION_WARNINGS to acknowledge that you have received this warning.")]]
 #else // ^^^ warning enabled / warning disabled vvv
 #define _CXX20_DEPRECATE_STRING_RESERVE_WITHOUT_ARGUMENT
+#endif // ^^^ warning disabled ^^^
 
 // P0767R1 [depr.meta.types]
 #if _HAS_CXX20 && !defined(_SILENCE_CXX20_IS_POD_DEPRECATION_WARNING) \
     && !defined(_SILENCE_ALL_CXX20_DEPRECATION_WARNINGS)
-#define _CXX20_DEPRECATE_IS_POD                                              \
-    [[deprecated("warning STL4024: "                                         \
-                 "std::is_pod and std::is_pod_v are deprecated in C++20. "   \
-                 "You can define _SILENCE_CXX20_IS_POD_DEPRECATION_WARNING " \
+#define _CXX20_DEPRECATE_IS_POD                                                                                     \
+    [[deprecated("warning STL4025: "                                                                                \
+                 "std::is_pod and std::is_pod_v are deprecated in C++20. "                                          \
+                 "The std::is_trivially_copyable and/or std::is_standard_layout traits likely suit your use case. " \
+                 "You can define _SILENCE_CXX20_IS_POD_DEPRECATION_WARNING "                                        \
                  "or _SILENCE_ALL_CXX20_DEPRECATION_WARNINGS to acknowledge that you have received this warning.")]]
 #else // ^^^ warning enabled / warning disabled vvv
 #define _CXX20_DEPRECATE_IS_POD


### PR DESCRIPTION
# Description

Fixes #36 
Added deprecation warning about using is_pod and is_pod_v in C++20 mode

# Checklist

- [x] I understand README.md. I also understand that acceptance of
  community PRs will be delayed until the test and CI systems are online.
- [ ] If this is a feature addition, that feature has been voted into the
  C++ Working Draft.
- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 .
- [ ] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before CI is online, leave this unchecked for
  initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository and
  the C++ Working Draft as a reference (and any other cited standards).
  If they were derived from a project that's already listed in NOTICE.txt,
  that's fine, but please mention it. If they were derived from any other
  project (including Boost and libc++, which are not yet listed in
  NOTICE.txt), you *must* mention it here, so we can determine whether the
  license is compatible and what else needs to be done.
