### PR TITLE
LWG 2899 Issue Addressed

### DIFF
--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -1821,7 +1821,7 @@ public:
         enable_if_t<conjunction_v<is_reference<_Dx2>, is_constructible<_Dx2, remove_reference_t<_Dx2>>>, int> = 0>
     unique_ptr(pointer, remove_reference_t<_Dx>&&) = delete;
 
-    template <class _MyDx = _Dx, enable_if_t<is_move_constructible_v<_MyDx>, int> = 0>
+    template <class _Dx2 = _Dx, enable_if_t<is_move_constructible_v<_Dx2>, int> = 0>
     unique_ptr(unique_ptr&& _Right) noexcept
         : _Mypair(_One_then_variadic_args_t(), _STD forward<_Dx>(_Right.get_deleter()), _Right.release()) {}
 
@@ -1849,7 +1849,7 @@ public:
         return *this;
     }
 
-    template <class _MyDx = _Dx, enable_if_t<is_move_constructible_v<_MyDx>, int> = 0>
+    template <class _Dx2 = _Dx, enable_if_t<is_move_assignable_v<_Dx2>, int> = 0>
     unique_ptr& operator=(unique_ptr&& _Right) noexcept {
         if (this != _STD addressof(_Right)) {
             reset(_Right.release());
@@ -1948,11 +1948,11 @@ public:
         enable_if_t<conjunction_v<is_reference<_Dx2>, is_constructible<_Dx2, remove_reference_t<_Dx2>>>, int> = 0>
     unique_ptr(_Uty, remove_reference_t<_Dx>&&) = delete;
 
-    template <class _MyDx = _Dx, enable_if_t<is_move_constructible_v<_MyDx>, int> = 0>
+    template <class _Dx2 = _Dx, enable_if_t<is_move_constructible_v<_Dx2>, int> = 0>
     unique_ptr(unique_ptr&& _Right) noexcept
         : _Mypair(_One_then_variadic_args_t(), _STD forward<_Dx>(_Right.get_deleter()), _Right.release()) {}
 
-    template <class _MyDx = _Dx, enable_if_t<is_move_constructible_v<_MyDx>, int> = 0>
+    template <class _Dx2 = _Dx, enable_if_t<is_move_assignable_v<_Dx2>, int> = 0>
     unique_ptr& operator=(unique_ptr&& _Right) noexcept {
         if (this != _STD addressof(_Right)) {
             reset(_Right.release());

--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -1821,9 +1821,12 @@ public:
         enable_if_t<conjunction_v<is_reference<_Dx2>, is_constructible<_Dx2, remove_reference_t<_Dx2>>>, int> = 0>
     unique_ptr(pointer, remove_reference_t<_Dx>&&) = delete;
 
+#ifndef _M_CEE // TRANSITION, VSO-1006185
     template <class _Dx2 = _Dx, enable_if_t<is_move_constructible_v<_Dx2>, int> = 0>
+#endif // _M_CEE
     unique_ptr(unique_ptr&& _Right) noexcept
-        : _Mypair(_One_then_variadic_args_t(), _STD forward<_Dx>(_Right.get_deleter()), _Right.release()) {}
+        : _Mypair(_One_then_variadic_args_t(), _STD forward<_Dx>(_Right.get_deleter()), _Right.release()) {
+    }
 
     template <class _Ty2, class _Dx2,
         enable_if_t<
@@ -1849,7 +1852,9 @@ public:
         return *this;
     }
 
+#ifndef _M_CEE // TRANSITION, VSO-1006185
     template <class _Dx2 = _Dx, enable_if_t<is_move_assignable_v<_Dx2>, int> = 0>
+#endif // _M_CEE
     unique_ptr& operator=(unique_ptr&& _Right) noexcept {
         if (this != _STD addressof(_Right)) {
             reset(_Right.release());
@@ -1948,11 +1953,16 @@ public:
         enable_if_t<conjunction_v<is_reference<_Dx2>, is_constructible<_Dx2, remove_reference_t<_Dx2>>>, int> = 0>
     unique_ptr(_Uty, remove_reference_t<_Dx>&&) = delete;
 
+#ifndef _M_CEE // TRANSITION, VSO-1006185
     template <class _Dx2 = _Dx, enable_if_t<is_move_constructible_v<_Dx2>, int> = 0>
+#endif // _M_CEE
     unique_ptr(unique_ptr&& _Right) noexcept
-        : _Mypair(_One_then_variadic_args_t(), _STD forward<_Dx>(_Right.get_deleter()), _Right.release()) {}
+        : _Mypair(_One_then_variadic_args_t(), _STD forward<_Dx>(_Right.get_deleter()), _Right.release()) {
+    }
 
+#ifndef _M_CEE // TRANSITION, VSO-1006185
     template <class _Dx2 = _Dx, enable_if_t<is_move_assignable_v<_Dx2>, int> = 0>
+#endif // _M_CEE
     unique_ptr& operator=(unique_ptr&& _Right) noexcept {
         if (this != _STD addressof(_Right)) {
             reset(_Right.release());

--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -1821,6 +1821,7 @@ public:
         enable_if_t<conjunction_v<is_reference<_Dx2>, is_constructible<_Dx2, remove_reference_t<_Dx2>>>, int> = 0>
     unique_ptr(pointer, remove_reference_t<_Dx>&&) = delete;
 
+    template <class _MyDx = _Dx, enable_if_t<is_move_constructible_v<_MyDx>, int> = 0>
     unique_ptr(unique_ptr&& _Right) noexcept
         : _Mypair(_One_then_variadic_args_t(), _STD forward<_Dx>(_Right.get_deleter()), _Right.release()) {}
 
@@ -1848,6 +1849,7 @@ public:
         return *this;
     }
 
+    template <class _MyDx = _Dx, enable_if_t<is_move_constructible_v<_MyDx>, int> = 0>
     unique_ptr& operator=(unique_ptr&& _Right) noexcept {
         if (this != _STD addressof(_Right)) {
             reset(_Right.release());
@@ -1946,9 +1948,11 @@ public:
         enable_if_t<conjunction_v<is_reference<_Dx2>, is_constructible<_Dx2, remove_reference_t<_Dx2>>>, int> = 0>
     unique_ptr(_Uty, remove_reference_t<_Dx>&&) = delete;
 
+    template <class _MyDx = _Dx, enable_if_t<is_move_constructible_v<_MyDx>, int> = 0>
     unique_ptr(unique_ptr&& _Right) noexcept
         : _Mypair(_One_then_variadic_args_t(), _STD forward<_Dx>(_Right.get_deleter()), _Right.release()) {}
 
+    template <class _MyDx = _Dx, enable_if_t<is_move_constructible_v<_MyDx>, int> = 0>
     unique_ptr& operator=(unique_ptr&& _Right) noexcept {
         if (this != _STD addressof(_Right)) {
             reset(_Right.release());


### PR DESCRIPTION
# Description

This addresses issue #68 by adding a constraint to `std::unique_ptr`. The move constructors are disabled if the `unique_ptr`'s deleter is not moveable.
The `noexcept()` specifiers and constraint on the move constructor and assignment operator for `std::tuple` are already implemented and work correctly.

- [x] I understand README.md. I also understand that acceptance of
  community PRs will be delayed until the test and CI systems are online.
- [x] If this is a feature addition, that feature has been voted into the
  C++ Working Draft.
- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 .
- [ ] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before CI is online, leave this unchecked for
  initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository and
  the C++ Working Draft as a reference (and any other cited standards).
  If they were derived from a project that's already listed in NOTICE.txt,
  that's fine, but please mention it. If they were derived from any other
  project (including Boost and libc++, which are not yet listed in
  NOTICE.txt), you *must* mention it here, so we can determine whether the
  license is compatible and what else needs to be done.
