### PR TITLE
LWG 3158 issue addressed

### DIFF
--- a/stl/inc/tuple
+++ b/stl/inc/tuple
@@ -428,14 +428,15 @@ public:
         : _Mybase(allocator_arg, _Al), _Myfirst(_Al, allocator_arg) {}
 #else // ^^^ _HAS_CONDITIONAL_EXPLICIT ^^^ / vvv !_HAS_CONDITIONAL_EXPLICIT vvv
     template <class _Alloc, class _This2 = _This,
-        enable_if_t<
-            conjunction_v<_Is_implicitly_default_constructible<_This2>, _Is_implicitly_default_constructible<_Rest>...>,
+        enable_if_t<conjunction_v<is_default_constructible<_This2>, is_default_constructible<_Rest>...,
+                        _Is_implicitly_default_constructible<_This2>, _Is_implicitly_default_constructible<_Rest>...>,
             int> = 0>
     tuple(allocator_arg_t, const _Alloc& _Al) : _Mybase(allocator_arg, _Al), _Myfirst(_Al, allocator_arg) {}
 
     template <class _Alloc, class _This2 = _This,
-        enable_if_t<!conjunction_v<_Is_implicitly_default_constructible<_This2>,
-                        _Is_implicitly_default_constructible<_Rest>...>,
+        enable_if_t<conjunction_v<is_default_constructible<_This2>, is_default_constructible<_Rest>...,
+                        negation<conjunction<_Is_implicitly_default_constructible<_This2>,
+                            _Is_implicitly_default_constructible<_Rest>...>>>,
             int> = 0>
     explicit tuple(allocator_arg_t, const _Alloc& _Al) : _Mybase(allocator_arg, _Al), _Myfirst(_Al, allocator_arg) {}
 #endif // ^^^ !_HAS_CONDITIONAL_EXPLICIT ^^^

--- a/stl/inc/tuple
+++ b/stl/inc/tuple
@@ -419,9 +419,18 @@ public:
         : tuple(_Unpack_tuple_t{}, _STD move(_Right)) {}
 #endif // ^^^ !_HAS_CONDITIONAL_EXPLICIT ^^^
 
+#if _HAS_CONDITIONAL_EXPLICIT
+    template <class _Alloc, class _This2 = _This,
+        enable_if_t<conjunction_v<is_default_constructible<_This2>, is_default_constructible<_Rest>...>, int> = 0>
+    explicit(
+        !conjunction_v<_Is_implicitly_default_constructible<_This2>, _Is_implicitly_default_constructible<_Rest>...>)
+        tuple(allocator_arg_t, const _Alloc& _Al)
+        : _Mybase(allocator_arg, _Al), _Myfirst(_Al, allocator_arg) {}
+#else // ^^^ _HAS_CONDITIONAL_EXPLICIT ^^^ / vvv !_HAS_CONDITIONAL_EXPLICIT vvv
     template <class _Alloc, class _This2 = _This,
         enable_if_t<conjunction_v<is_default_constructible<_This2>, is_default_constructible<_Rest>...>, int> = 0>
     tuple(allocator_arg_t, const _Alloc& _Al) : _Mybase(allocator_arg, _Al), _Myfirst(_Al, allocator_arg) {}
+#endif // ^^^ !_HAS_CONDITIONAL_EXPLICIT ^^^
 
 #if _HAS_CONDITIONAL_EXPLICIT
     template <class _Alloc, class _This2 = _This,

--- a/stl/inc/tuple
+++ b/stl/inc/tuple
@@ -428,8 +428,16 @@ public:
         : _Mybase(allocator_arg, _Al), _Myfirst(_Al, allocator_arg) {}
 #else // ^^^ _HAS_CONDITIONAL_EXPLICIT ^^^ / vvv !_HAS_CONDITIONAL_EXPLICIT vvv
     template <class _Alloc, class _This2 = _This,
-        enable_if_t<conjunction_v<is_default_constructible<_This2>, is_default_constructible<_Rest>...>, int> = 0>
+        enable_if_t<
+            conjunction_v<_Is_implicitly_default_constructible<_This2>, _Is_implicitly_default_constructible<_Rest>...>,
+            int> = 0>
     tuple(allocator_arg_t, const _Alloc& _Al) : _Mybase(allocator_arg, _Al), _Myfirst(_Al, allocator_arg) {}
+
+    template <class _Alloc, class _This2 = _This,
+        enable_if_t<!conjunction_v<_Is_implicitly_default_constructible<_This2>,
+                        _Is_implicitly_default_constructible<_Rest>...>,
+            int> = 0>
+    explicit tuple(allocator_arg_t, const _Alloc& _Al) : _Mybase(allocator_arg, _Al), _Myfirst(_Al, allocator_arg) {}
 #endif // ^^^ !_HAS_CONDITIONAL_EXPLICIT ^^^
 
 #if _HAS_CONDITIONAL_EXPLICIT


### PR DESCRIPTION
# Description

Add a conditional explicit to `std::tuple::tuple(std::allocator_arg_t, const Alloc&)`.
Fixes issue #69  

# Checklist

- [x] I understand README.md. I also understand that acceptance of
  community PRs will be delayed until the test and CI systems are online.
- [ ] If this is a feature addition, that feature has been voted into the
  C++ Working Draft.
**I believe this is a bugfix, not a feature.**
- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 .
- [ ] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before CI is online, leave this unchecked for
  initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository and
  the C++ Working Draft as a reference (and any other cited standards).
  If they were derived from a project that's already listed in NOTICE.txt,
  that's fine, but please mention it. If they were derived from any other
  project (including Boost and libc++, which are not yet listed in
  NOTICE.txt), you *must* mention it here, so we can determine whether the
  license is compatible and what else needs to be done.
