### PR TITLE
P0655R1 visit<R>()

### DIFF
--- a/stl/inc/variant
+++ b/stl/inc/variant
@@ -1523,10 +1523,9 @@ struct _Variant_all_visit_results_implicitly_convertible; // undefined
 template <class _To, class _Callable, class... _IndexVectors, class... _Variants>
 struct _Variant_all_visit_results_implicitly_convertible<_To, _Callable, _Meta_list<_IndexVectors...>, _Variants...>
     : _Convertible_from_all<_To,
-          typename _Variant_single_visit_result<_Callable, _IndexVectors,
-              _Variants...>::type...>::type { // true_type if invocation of _Callable on the elements
-                                              // of _Variants with all sequences of indices in
-                                              // _IndexVectors is implicitly convertible to _To.
+          typename _Variant_single_visit_result<_Callable, _IndexVectors, _Variants...>::type...>::type {
+    // true_type if invocation of _Callable on the elements of _Variants with all sequences of indices in _IndexVectors
+    // is implicitly convertible to _To.
 };
 
 template <int _Strategy>
@@ -1644,11 +1643,12 @@ constexpr _Variant_visit_result_t<_Callable, _As_variant<_Variants>...> visit(_C
         _Meta_list<_Meta_as_list<make_index_sequence<1 + variant_size_v<_Remove_cvref_t<_As_variant<_Variants>>>>>...>;
     using _ListOfIndexVectors =
         _Meta_transform<_Meta_quote<_Meta_as_integer_sequence>, _Meta_cartesian_product<_ListOfIndexLists>>;
+    using _Ret = _Variant_visit_result_t<_Callable, _As_variant<_Variants>...>;
     static_assert(_Variant_all_visit_results_same<_Callable, _ListOfIndexVectors, _As_variant<_Variants>...>::value,
         "visit() requires the result of all potential invocations to have the same type and value category "
         "(N4835 [variant.visit]/2).");
 
-    return _Visit_impl<_Size, _ListOfIndexVectors, _Variant_visit_result_t<_Callable, _As_variant<_Variants>...>>(
+    return _Visit_impl<_Size, _ListOfIndexVectors, _Ret>(
         static_cast<_Callable&&>(_Obj), static_cast<_Variants&&>(_Args)...);
 }
 

--- a/stl/inc/variant
+++ b/stl/inc/variant
@@ -39,11 +39,10 @@ struct _All_same : true_type {};
 template <class _First, class... _Rest>
 struct _All_same<_First, _Rest...> : bool_constant<conjunction_v<is_same<_First, _Rest>...>> {}; // variadic is_same
 
-template <class...>
-struct _All_convertible : true_type {};
 template <class _To, class... _From>
-struct _All_convertible<_To, _From...> : bool_constant<conjunction_v<is_convertible<_From, _To>...>> {
-}; // variadic is_convertible
+struct _Convertible_from_all : bool_constant<conjunction_v<is_convertible<_From, _To>...>> {
+    // variadic is_convertible
+};
 
 // METAPROGRAMMING UTILITIES
 template <class...>
@@ -1008,7 +1007,7 @@ public:
         "variant<Types...> requires all of the Types to meet the Cpp17Destructible requirements "
         "N4828 [variant.variant]/2.");
     static_assert(sizeof...(_Types) > 0,
-        "variant<> (with no template arguments) may not be instantiated (N4828 [variant.variant]/3).");
+        "variant<> (with no template arguments) may not be instantiated (N4835 [variant.variant]/3).");
     using _Mybase = _SMF_control<_Variant_destroy_layer<_Types...>, _Types...>;
 
     // constructors [variant.ctor]
@@ -1133,9 +1132,9 @@ public:
         // exchange the contained values if *this and _That hold the same alternative, otherwise exchange the values of
         // the variants themselves
         static_assert(conjunction_v<is_move_constructible<_Types>...>,
-            "variant<Types...>::swap requires all of the Types... to be move constructible. (N4828 [variant.swap]/1)");
+            "variant<Types...>::swap requires all of the Types... to be move constructible. (N4835 [variant.swap]/1)");
         static_assert(disjunction_v<negation<is_move_constructible<_Types>>..., conjunction<is_swappable<_Types>...>>,
-            "variant<Types...>::swap requires all of the Types... to be swappable. (N4828 [variant.swap]/1)");
+            "variant<Types...>::swap requires all of the Types... to be swappable. (N4835 [variant.swap]/1)");
         if constexpr (conjunction_v<_Is_trivially_swappable<_Types>...>) {
             using _BaseTy = _Variant_base<_Types...>;
             _STD swap(static_cast<_BaseTy&>(*this), static_cast<_BaseTy&>(_That));
@@ -1242,7 +1241,7 @@ _NODISCARD constexpr bool holds_alternative(
     const variant<_Types...>& _Var) noexcept { // true iff _Var holds alternative _Ty
     constexpr size_t _Idx = _Meta_find_unique_index<variant<_Types...>, _Ty>::value;
     static_assert(_Idx != _Meta_npos, "holds_alternative<T>(const variant<Types...>&) requires T to occur exactly "
-                                      "once in Types. (N4828 [variant.get]/1)");
+                                      "once in Types. (N4835 [variant.get]/1)");
     return _Var.index() == _Idx;
 }
 
@@ -1292,7 +1291,7 @@ _NODISCARD constexpr decltype(auto) get(
     variant<_Types...>& _Var) { // access the contained value of _Var if its alternative _Ty is active
     constexpr size_t _Idx = _Meta_find_unique_index<variant<_Types...>, _Ty>::value;
     static_assert(_Idx < sizeof...(_Types),
-        "get<T>(variant<Types...>&) requires T to occur exactly once in Types. (N4828 [variant.get]/5)");
+        "get<T>(variant<Types...>&) requires T to occur exactly once in Types. (N4835 [variant.get]/5)");
     return _STD get<_Idx>(_Var);
 }
 template <class _Ty, class... _Types>
@@ -1300,7 +1299,7 @@ _NODISCARD constexpr decltype(auto) get(
     variant<_Types...>&& _Var) { // access the contained value of _Var if its alternative _Ty is active
     constexpr size_t _Idx = _Meta_find_unique_index<variant<_Types...>, _Ty>::value;
     static_assert(_Idx < sizeof...(_Types),
-        "get<T>(variant<Types...>&&) requires T to occur exactly once in Types. (N4828 [variant.get]/5)");
+        "get<T>(variant<Types...>&&) requires T to occur exactly once in Types. (N4835 [variant.get]/5)");
     return _STD get<_Idx>(_STD move(_Var));
 }
 template <class _Ty, class... _Types>
@@ -1308,7 +1307,7 @@ _NODISCARD constexpr decltype(auto) get(
     const variant<_Types...>& _Var) { // access the contained value of _Var if its alternative _Ty is active
     constexpr size_t _Idx = _Meta_find_unique_index<variant<_Types...>, _Ty>::value;
     static_assert(_Idx < sizeof...(_Types),
-        "get<T>(const variant<Types...>&) requires T to occur exactly once in Types. (N4828 [variant.get]/5)");
+        "get<T>(const variant<Types...>&) requires T to occur exactly once in Types. (N4835 [variant.get]/5)");
     return _STD get<_Idx>(_Var);
 }
 template <class _Ty, class... _Types>
@@ -1316,7 +1315,7 @@ _NODISCARD constexpr decltype(auto) get(
     const variant<_Types...>&& _Var) { // access the contained value of _Var if its alternative _Ty is active
     constexpr size_t _Idx = _Meta_find_unique_index<variant<_Types...>, _Ty>::value;
     static_assert(_Idx < sizeof...(_Types),
-        "get<T>(const variant<Types...>&&) requires T to occur exactly once in Types. (N4828 [variant.get]/5)");
+        "get<T>(const variant<Types...>&&) requires T to occur exactly once in Types. (N4835 [variant.get]/5)");
     return _STD get<_Idx>(_STD move(_Var));
 }
 
@@ -1338,7 +1337,7 @@ _NODISCARD constexpr add_pointer_t<_Ty> get_if(
     variant<_Types...>* _Ptr) noexcept { // get the address of *_Ptr's contained value if it holds alternative _Ty
     constexpr size_t _Idx = _Meta_find_unique_index<variant<_Types...>, _Ty>::value;
     static_assert(_Idx != _Meta_npos,
-        "get_if<T>(variant<Types...> *) requires T to occur exactly once in Types. (N4828 [variant.get]/9)");
+        "get_if<T>(variant<Types...> *) requires T to occur exactly once in Types. (N4835 [variant.get]/9)");
     return _STD get_if<_Idx>(_Ptr);
 }
 template <class _Ty, class... _Types>
@@ -1346,7 +1345,7 @@ _NODISCARD constexpr add_pointer_t<const _Ty> get_if(
     const variant<_Types...>* _Ptr) noexcept { // get the address of *_Ptr's contained value if it holds alternative _Ty
     constexpr size_t _Idx = _Meta_find_unique_index<variant<_Types...>, _Ty>::value;
     static_assert(_Idx != _Meta_npos,
-        "get_if<T>(const variant<Types...> *) requires T to occur exactly once in Types. (N4828 [variant.get]/9)");
+        "get_if<T>(const variant<Types...> *) requires T to occur exactly once in Types. (N4835 [variant.get]/9)");
     return _STD get_if<_Idx>(_Ptr);
 }
 
@@ -1467,24 +1466,21 @@ struct _Variant_dispatcher;
 template <size_t... _Is>
 struct _Variant_dispatcher<index_sequence<_Is...>> {
     template <class _Ret, class _Callable, class... _Types, bool _Any_valueless = ((_Is == 0) || ...)>
-    _NODISCARD static constexpr _Ret _Dispatch(_Callable&& _Obj, _Types&&... _Args) {
+    _NODISCARD static constexpr _Ret _Dispatch2(_Callable&& _Obj, _Types&&... _Args) {
         if constexpr (_Any_valueless) {
             (void) _Obj;
             ((void) _Args, ...); // TRANSITION, VSO-486357
             _Throw_bad_variant_access();
-        } else {
+        }
 #if _HAS_CXX20
-            if constexpr (is_void_v<_Ret>) {
-                static_cast<void>(_C_invoke(static_cast<_Callable&&>(_Obj),
-                    _Variant_raw_get<_Is - 1>(static_cast<_Types&&>(_Args)._Storage())...));
-            } else {
-                return _C_invoke(static_cast<_Callable&&>(_Obj),
-                    _Variant_raw_get<_Is - 1>(static_cast<_Types&&>(_Args)._Storage())...);
-            }
-#else // _HAS_CXX20
+        else if constexpr (is_void_v<_Ret>) {
+            static_cast<void>(_C_invoke(
+                static_cast<_Callable&&>(_Obj), _Variant_raw_get<_Is - 1>(static_cast<_Types&&>(_Args)._Storage())...));
+        }
+#endif // _HAS_CXX20
+        else {
             return _C_invoke(
                 static_cast<_Callable&&>(_Obj), _Variant_raw_get<_Is - 1>(static_cast<_Types&&>(_Args)._Storage())...);
-#endif // _HAS_CXX20
         }
     }
 };
@@ -1497,7 +1493,7 @@ struct _Variant_dispatch_table<_Ret, _Meta_list<_Ordinals...>, _Callable,
     _Meta_list<_Variants...>> { // map from canonical index to visitation target
     using _Dispatch_t                     = _Ret (*)(_Callable&&, _Variants&&...);
     static constexpr _Dispatch_t _Array[] = {
-        &_Variant_dispatcher<_Ordinals>::template _Dispatch<_Ret, _Callable, _Variants...>...};
+        &_Variant_dispatcher<_Ordinals>::template _Dispatch2<_Ret, _Callable, _Variants...>...};
 };
 
 template <class _Callable, class _IndexSequence, class... _Variants>
@@ -1526,10 +1522,11 @@ struct _Variant_all_visit_results_implicitly_convertible; // undefined
 
 template <class _To, class _Callable, class... _IndexVectors, class... _Variants>
 struct _Variant_all_visit_results_implicitly_convertible<_To, _Callable, _Meta_list<_IndexVectors...>, _Variants...>
-    : _All_convertible<_To, typename _Variant_single_visit_result<_Callable, _IndexVectors,
-                                _Variants...>::type...>::type { // true_type if invocation of _Callable on the elements
-                                                                // of _Variants with all sequences of indices in
-                                                                // _IndexVectors is implicitly convertible to _To.
+    : _Convertible_from_all<_To,
+          typename _Variant_single_visit_result<_Callable, _IndexVectors,
+              _Variants...>::type...>::type { // true_type if invocation of _Callable on the elements
+                                              // of _Variants with all sequences of indices in
+                                              // _IndexVectors is implicitly convertible to _To.
 };
 
 template <int _Strategy>
@@ -1539,7 +1536,7 @@ template <>
 struct _Visit_strategy<-1> { // Fallback strategy for visitations with too many total states for the
                              // following "switch" strategies.
     template <class _Ret, class _ListOfIndexVectors, class _Callable, class... _Variants>
-    static constexpr _Ret _Visit(
+    static constexpr _Ret _Visit2(
         size_t _Idx, _Callable&& _Obj, _Variants&&... _Args) { // dispatch a visitation with many potential states
         constexpr size_t _Size = _Variant_total_states<_Remove_cvref_t<_Variants>...>;
         static_assert(_Size > 256);
@@ -1552,18 +1549,22 @@ struct _Visit_strategy<-1> { // Fallback strategy for visitations with too many 
 template <>
 struct _Visit_strategy<0> {
     template <class _Ret, class, class _Callable>
-    static constexpr _Ret _Visit(size_t, _Callable&& _Obj) { // dispatch a visitation with 4^0 potential states
-        return static_cast<_Callable&&>(_Obj)();
+    static constexpr _Ret _Visit2(size_t, _Callable&& _Obj) { // dispatch a visitation with 4^0 potential states
+        if constexpr (is_void_v<_Ret>) {
+            return static_cast<void>(static_cast<_Callable&&>(_Obj)());
+        } else {
+            return static_cast<_Callable&&>(_Obj)();
+        }
     }
 };
 
-#define _STL_CASE(n)                                                                                 \
-    case (n):                                                                                        \
-        if constexpr ((n) < _Size) {                                                                 \
-            using _Indices = _Meta_at_c<_ListOfIndexVectors, (n)>;                                   \
-            return _Variant_dispatcher<_Indices>::template _Dispatch<_Ret, _Callable, _Variants...>( \
-                static_cast<_Callable&&>(_Obj), static_cast<_Variants&&>(_Args)...);                 \
-        }                                                                                            \
+#define _STL_CASE(n)                                                                                  \
+    case (n):                                                                                         \
+        if constexpr ((n) < _Size) {                                                                  \
+            using _Indices = _Meta_at_c<_ListOfIndexVectors, (n)>;                                    \
+            return _Variant_dispatcher<_Indices>::template _Dispatch2<_Ret, _Callable, _Variants...>( \
+                static_cast<_Callable&&>(_Obj), static_cast<_Variants&&>(_Args)...);                  \
+        }                                                                                             \
         _STL_UNREACHABLE
 
 #define _STL_VISIT_STAMP(stamper, n)                                               \
@@ -1578,7 +1579,7 @@ struct _Visit_strategy<0> {
 template <>
 struct _Visit_strategy<1> {
     template <class _Ret, class _ListOfIndexVectors, class _Callable, class... _Variants>
-    static constexpr _Ret _Visit(
+    static constexpr _Ret _Visit2(
         size_t _Idx, _Callable&& _Obj, _Variants&&... _Args) { // dispatch a visitation with 4^1 potential states
         _STL_STAMP(4, _STL_VISIT_STAMP);
     }
@@ -1587,7 +1588,7 @@ struct _Visit_strategy<1> {
 template <>
 struct _Visit_strategy<2> {
     template <class _Ret, class _ListOfIndexVectors, class _Callable, class... _Variants>
-    static constexpr _Ret _Visit(
+    static constexpr _Ret _Visit2(
         size_t _Idx, _Callable&& _Obj, _Variants&&... _Args) { // dispatch a visitation with 4^2 potential states
         _STL_STAMP(16, _STL_VISIT_STAMP);
     }
@@ -1596,7 +1597,7 @@ struct _Visit_strategy<2> {
 template <>
 struct _Visit_strategy<3> {
     template <class _Ret, class _ListOfIndexVectors, class _Callable, class... _Variants>
-    static constexpr _Ret _Visit(
+    static constexpr _Ret _Visit2(
         size_t _Idx, _Callable&& _Obj, _Variants&&... _Args) { // dispatch a visitation with 4^3 potential states
         _STL_STAMP(64, _STL_VISIT_STAMP);
     }
@@ -1605,7 +1606,7 @@ struct _Visit_strategy<3> {
 template <>
 struct _Visit_strategy<4> {
     template <class _Ret, class _ListOfIndexVectors, class _Callable, class... _Variants>
-    static constexpr _Ret _Visit(
+    static constexpr _Ret _Visit2(
         size_t _Idx, _Callable&& _Obj, _Variants&&... _Args) { // dispatch a visitation with 4^4 potential states
         _STL_STAMP(256, _STL_VISIT_STAMP);
     }
@@ -1626,12 +1627,11 @@ template <class _Ty>
 using _As_variant = // Deduce variant specialization from a derived type
     decltype(_As_variant_(_STD declval<_Ty>()));
 
-#if _HAS_CXX20
 template <size_t _Size, class _ListOfIndexVectors, class _Ret, class _Callable, class... _Variants>
 constexpr _Ret _Visit_impl(_Callable&& _Obj, _Variants&&... _Args) {
     constexpr int _Strategy =
         _Size == 1 ? 0 : _Size <= 4 ? 1 : _Size <= 16 ? 2 : _Size <= 64 ? 3 : _Size <= 256 ? 4 : -1;
-    return _Visit_strategy<_Strategy>::template _Visit<_Ret, _ListOfIndexVectors>(
+    return _Visit_strategy<_Strategy>::template _Visit2<_Ret, _ListOfIndexVectors>(
         _Variant_visit_index1(0, static_cast<_As_variant<_Variants>&>(_Args)...), static_cast<_Callable&&>(_Obj),
         static_cast<_As_variant<_Variants>&&>(_Args)...);
 }
@@ -1646,15 +1646,15 @@ constexpr _Variant_visit_result_t<_Callable, _As_variant<_Variants>...> visit(_C
         _Meta_transform<_Meta_quote<_Meta_as_integer_sequence>, _Meta_cartesian_product<_ListOfIndexLists>>;
     static_assert(_Variant_all_visit_results_same<_Callable, _ListOfIndexVectors, _As_variant<_Variants>...>::value,
         "visit() requires the result of all potential invocations to have the same type and value category "
-        "(N4828 [variant.visit]/2).");
+        "(N4835 [variant.visit]/2).");
 
     return _Visit_impl<_Size, _ListOfIndexVectors, _Variant_visit_result_t<_Callable, _As_variant<_Variants>...>>(
-        _STD forward<_Callable>(_Obj), _STD forward<_Variants>(_Args)...);
+        static_cast<_Callable&&>(_Obj), static_cast<_Variants&&>(_Args)...);
 }
 
+#if _HAS_CXX20
 template <class _Ret, class _Callable, class... _Variants, class = void_t<_As_variant<_Variants>...>>
 constexpr _Ret visit(_Callable&& _Obj, _Variants&&... _Args) {
-    // Invoke _Obj with the contained values of _Args...
     constexpr auto _Size = _Variant_total_states<_Remove_cvref_t<_As_variant<_Variants>>...>;
     using _ListOfIndexLists =
         _Meta_list<_Meta_as_list<make_index_sequence<1 + variant_size_v<_Remove_cvref_t<_As_variant<_Variants>>>>>...>;
@@ -1664,30 +1664,11 @@ constexpr _Ret visit(_Callable&& _Obj, _Variants&&... _Args) {
         static_assert(_Variant_all_visit_results_implicitly_convertible<_Ret, _Callable, _ListOfIndexVectors,
                           _As_variant<_Variants>...>::value,
             "visit<R>() requires the result of all potential invocations to be implicitly convertible to R "
-            "(N4828 [variant.visit]/2).");
+            "(N4835 [variant.visit]/2).");
     }
 
     return _Visit_impl<_Size, _ListOfIndexVectors, _Ret>(
-        _STD forward<_Callable>(_Obj), _STD forward<_Variants>(_Args)...);
-}
-#else // _HAS_CXX20
-template <class _Callable, class... _Variants, class = void_t<_As_variant<_Variants>...>>
-constexpr _Variant_visit_result_t<_Callable, _As_variant<_Variants>...> visit(_Callable&& _Obj, _Variants&&... _Args) {
-    // Invoke _Obj with the contained values of _Args...
-    constexpr auto _Size = _Variant_total_states<_Remove_cvref_t<_As_variant<_Variants>>...>;
-    using _ListOfIndexLists =
-        _Meta_list<_Meta_as_list<make_index_sequence<1 + variant_size_v<_Remove_cvref_t<_As_variant<_Variants>>>>>...>;
-    using _ListOfIndexVectors =
-        _Meta_transform<_Meta_quote<_Meta_as_integer_sequence>, _Meta_cartesian_product<_ListOfIndexLists>>;
-    static_assert(_Variant_all_visit_results_same<_Callable, _ListOfIndexVectors, _As_variant<_Variants>...>::value,
-        "visit() requires the result of all potential invocations to have the same type and value category "
-        "(N4828 [variant.visit]/2).");
-
-    constexpr int _Strategy =
-        _Size == 1 ? 0 : _Size <= 4 ? 1 : _Size <= 16 ? 2 : _Size <= 64 ? 3 : _Size <= 256 ? 4 : -1;
-    return _Visit_strategy<_Strategy>::template _Visit<_Variant_visit_result_t<_Callable, _As_variant<_Variants>...>,
-        _ListOfIndexVectors>(_Variant_visit_index1(0, static_cast<_As_variant<_Variants>&>(_Args)...),
-        static_cast<_Callable&&>(_Obj), static_cast<_As_variant<_Variants>&&>(_Args)...);
+        static_cast<_Callable&&>(_Obj), static_cast<_Variants&&>(_Args)...);
 }
 #endif // _HAS_CXX20
 

--- a/stl/inc/variant
+++ b/stl/inc/variant
@@ -39,6 +39,12 @@ struct _All_same : true_type {};
 template <class _First, class... _Rest>
 struct _All_same<_First, _Rest...> : bool_constant<conjunction_v<is_same<_First, _Rest>...>> {}; // variadic is_same
 
+template <class...>
+struct _All_convertible : true_type {};
+template <class _To, class... _From>
+struct _All_convertible<_To, _From...> : bool_constant<conjunction_v<is_convertible<_From, _To>...>> {
+}; // variadic is_convertible
+
 // METAPROGRAMMING UTILITIES
 template <class...>
 struct _Meta_list {}; // a sequence of types
@@ -1460,29 +1466,38 @@ struct _Variant_dispatcher;
 
 template <size_t... _Is>
 struct _Variant_dispatcher<index_sequence<_Is...>> {
-    template <class _Callable, class... _Types, bool _Any_valueless = ((_Is == 0) || ...)>
-    _NODISCARD static constexpr _Variant_visit_result_t<_Callable, _Types...> _Dispatch(
-        _Callable&& _Obj, _Types&&... _Args) {
+    template <class _Ret, class _Callable, class... _Types, bool _Any_valueless = ((_Is == 0) || ...)>
+    _NODISCARD static constexpr _Ret _Dispatch(_Callable&& _Obj, _Types&&... _Args) {
         if constexpr (_Any_valueless) {
             (void) _Obj;
             ((void) _Args, ...); // TRANSITION, VSO-486357
             _Throw_bad_variant_access();
         } else {
+#if _HAS_CXX20
+            if constexpr (is_void_v<_Ret>) {
+                static_cast<void>(_C_invoke(static_cast<_Callable&&>(_Obj),
+                    _Variant_raw_get<_Is - 1>(static_cast<_Types&&>(_Args)._Storage())...));
+            } else {
+                return _C_invoke(static_cast<_Callable&&>(_Obj),
+                    _Variant_raw_get<_Is - 1>(static_cast<_Types&&>(_Args)._Storage())...);
+            }
+#else // _HAS_CXX20
             return _C_invoke(
                 static_cast<_Callable&&>(_Obj), _Variant_raw_get<_Is - 1>(static_cast<_Types&&>(_Args)._Storage())...);
+#endif // _HAS_CXX20
         }
     }
 };
 
-template <class _Ordinals, class _Callable, class _Variants>
+template <class _Ret, class _Ordinals, class _Callable, class _Variants>
 struct _Variant_dispatch_table; // undefined
 
-template <class... _Ordinals, class _Callable, class... _Variants>
-struct _Variant_dispatch_table<_Meta_list<_Ordinals...>, _Callable,
+template <class _Ret, class... _Ordinals, class _Callable, class... _Variants>
+struct _Variant_dispatch_table<_Ret, _Meta_list<_Ordinals...>, _Callable,
     _Meta_list<_Variants...>> { // map from canonical index to visitation target
-    using _Dispatch_t = _Variant_visit_result_t<_Callable, _Variants...> (*)(_Callable&&, _Variants&&...);
+    using _Dispatch_t                     = _Ret (*)(_Callable&&, _Variants&&...);
     static constexpr _Dispatch_t _Array[] = {
-        &_Variant_dispatcher<_Ordinals>::template _Dispatch<_Callable, _Variants...>...};
+        &_Variant_dispatcher<_Ordinals>::template _Dispatch<_Ret, _Callable, _Variants...>...};
 };
 
 template <class _Callable, class _IndexSequence, class... _Variants>
@@ -1506,39 +1521,49 @@ struct _Variant_all_visit_results_same<_Callable, _Meta_list<_IndexVectors...>, 
                                           // sequences of indices in _IndexVectors has the same type and value category.
 };
 
+template <class _To, class _Callable, class _ListOfIndexVectors, class... _Variants>
+struct _Variant_all_visit_results_implicitly_convertible; // undefined
+
+template <class _To, class _Callable, class... _IndexVectors, class... _Variants>
+struct _Variant_all_visit_results_implicitly_convertible<_To, _Callable, _Meta_list<_IndexVectors...>, _Variants...>
+    : _All_convertible<_To, typename _Variant_single_visit_result<_Callable, _IndexVectors,
+                                _Variants...>::type...>::type { // true_type if invocation of _Callable on the elements
+                                                                // of _Variants with all sequences of indices in
+                                                                // _IndexVectors is implicitly convertible to _To.
+};
+
 template <int _Strategy>
 struct _Visit_strategy;
 
 template <>
 struct _Visit_strategy<-1> { // Fallback strategy for visitations with too many total states for the
                              // following "switch" strategies.
-    template <class _ListOfIndexVectors, class _Callable, class... _Variants>
-    static constexpr _Variant_visit_result_t<_Callable, _Variants...> _Visit(
+    template <class _Ret, class _ListOfIndexVectors, class _Callable, class... _Variants>
+    static constexpr _Ret _Visit(
         size_t _Idx, _Callable&& _Obj, _Variants&&... _Args) { // dispatch a visitation with many potential states
         constexpr size_t _Size = _Variant_total_states<_Remove_cvref_t<_Variants>...>;
         static_assert(_Size > 256);
         constexpr auto& _Array =
-            _Variant_dispatch_table<_ListOfIndexVectors, _Callable, _Meta_list<_Variants...>>::_Array;
+            _Variant_dispatch_table<_Ret, _ListOfIndexVectors, _Callable, _Meta_list<_Variants...>>::_Array;
         return _Array[_Idx](static_cast<_Callable&&>(_Obj), static_cast<_Variants&&>(_Args)...);
     }
 };
 
 template <>
 struct _Visit_strategy<0> {
-    template <class, class _Callable>
-    static constexpr _Variant_visit_result_t<_Callable> _Visit(
-        size_t, _Callable&& _Obj) { // dispatch a visitation with 4^0 potential states
+    template <class _Ret, class, class _Callable>
+    static constexpr _Ret _Visit(size_t, _Callable&& _Obj) { // dispatch a visitation with 4^0 potential states
         return static_cast<_Callable&&>(_Obj)();
     }
 };
 
-#define _STL_CASE(n)                                                                           \
-    case (n):                                                                                  \
-        if constexpr ((n) < _Size) {                                                           \
-            using _Indices = _Meta_at_c<_ListOfIndexVectors, (n)>;                             \
-            return _Variant_dispatcher<_Indices>::template _Dispatch<_Callable, _Variants...>( \
-                static_cast<_Callable&&>(_Obj), static_cast<_Variants&&>(_Args)...);           \
-        }                                                                                      \
+#define _STL_CASE(n)                                                                                 \
+    case (n):                                                                                        \
+        if constexpr ((n) < _Size) {                                                                 \
+            using _Indices = _Meta_at_c<_ListOfIndexVectors, (n)>;                                   \
+            return _Variant_dispatcher<_Indices>::template _Dispatch<_Ret, _Callable, _Variants...>( \
+                static_cast<_Callable&&>(_Obj), static_cast<_Variants&&>(_Args)...);                 \
+        }                                                                                            \
         _STL_UNREACHABLE
 
 #define _STL_VISIT_STAMP(stamper, n)                                               \
@@ -1552,8 +1577,8 @@ struct _Visit_strategy<0> {
 
 template <>
 struct _Visit_strategy<1> {
-    template <class _ListOfIndexVectors, class _Callable, class... _Variants>
-    static constexpr _Variant_visit_result_t<_Callable, _Variants...> _Visit(
+    template <class _Ret, class _ListOfIndexVectors, class _Callable, class... _Variants>
+    static constexpr _Ret _Visit(
         size_t _Idx, _Callable&& _Obj, _Variants&&... _Args) { // dispatch a visitation with 4^1 potential states
         _STL_STAMP(4, _STL_VISIT_STAMP);
     }
@@ -1561,8 +1586,8 @@ struct _Visit_strategy<1> {
 
 template <>
 struct _Visit_strategy<2> {
-    template <class _ListOfIndexVectors, class _Callable, class... _Variants>
-    static constexpr _Variant_visit_result_t<_Callable, _Variants...> _Visit(
+    template <class _Ret, class _ListOfIndexVectors, class _Callable, class... _Variants>
+    static constexpr _Ret _Visit(
         size_t _Idx, _Callable&& _Obj, _Variants&&... _Args) { // dispatch a visitation with 4^2 potential states
         _STL_STAMP(16, _STL_VISIT_STAMP);
     }
@@ -1570,8 +1595,8 @@ struct _Visit_strategy<2> {
 
 template <>
 struct _Visit_strategy<3> {
-    template <class _ListOfIndexVectors, class _Callable, class... _Variants>
-    static constexpr _Variant_visit_result_t<_Callable, _Variants...> _Visit(
+    template <class _Ret, class _ListOfIndexVectors, class _Callable, class... _Variants>
+    static constexpr _Ret _Visit(
         size_t _Idx, _Callable&& _Obj, _Variants&&... _Args) { // dispatch a visitation with 4^3 potential states
         _STL_STAMP(64, _STL_VISIT_STAMP);
     }
@@ -1579,8 +1604,8 @@ struct _Visit_strategy<3> {
 
 template <>
 struct _Visit_strategy<4> {
-    template <class _ListOfIndexVectors, class _Callable, class... _Variants>
-    static constexpr _Variant_visit_result_t<_Callable, _Variants...> _Visit(
+    template <class _Ret, class _ListOfIndexVectors, class _Callable, class... _Variants>
+    static constexpr _Ret _Visit(
         size_t _Idx, _Callable&& _Obj, _Variants&&... _Args) { // dispatch a visitation with 4^4 potential states
         _STL_STAMP(256, _STL_VISIT_STAMP);
     }
@@ -1601,6 +1626,51 @@ template <class _Ty>
 using _As_variant = // Deduce variant specialization from a derived type
     decltype(_As_variant_(_STD declval<_Ty>()));
 
+#if _HAS_CXX20
+template <size_t _Size, class _ListOfIndexVectors, class _Ret, class _Callable, class... _Variants>
+constexpr _Ret _Visit_impl(_Callable&& _Obj, _Variants&&... _Args) {
+    constexpr int _Strategy =
+        _Size == 1 ? 0 : _Size <= 4 ? 1 : _Size <= 16 ? 2 : _Size <= 64 ? 3 : _Size <= 256 ? 4 : -1;
+    return _Visit_strategy<_Strategy>::template _Visit<_Ret, _ListOfIndexVectors>(
+        _Variant_visit_index1(0, static_cast<_As_variant<_Variants>&>(_Args)...), static_cast<_Callable&&>(_Obj),
+        static_cast<_As_variant<_Variants>&&>(_Args)...);
+}
+
+template <class _Callable, class... _Variants, class = void_t<_As_variant<_Variants>...>>
+constexpr _Variant_visit_result_t<_Callable, _As_variant<_Variants>...> visit(_Callable&& _Obj, _Variants&&... _Args) {
+    // Invoke _Obj with the contained values of _Args...
+    constexpr auto _Size = _Variant_total_states<_Remove_cvref_t<_As_variant<_Variants>>...>;
+    using _ListOfIndexLists =
+        _Meta_list<_Meta_as_list<make_index_sequence<1 + variant_size_v<_Remove_cvref_t<_As_variant<_Variants>>>>>...>;
+    using _ListOfIndexVectors =
+        _Meta_transform<_Meta_quote<_Meta_as_integer_sequence>, _Meta_cartesian_product<_ListOfIndexLists>>;
+    static_assert(_Variant_all_visit_results_same<_Callable, _ListOfIndexVectors, _As_variant<_Variants>...>::value,
+        "visit() requires the result of all potential invocations to have the same type and value category "
+        "(N4828 [variant.visit]/2).");
+
+    return _Visit_impl<_Size, _ListOfIndexVectors, _Variant_visit_result_t<_Callable, _As_variant<_Variants>...>>(
+        _STD forward<_Callable>(_Obj), _STD forward<_Variants>(_Args)...);
+}
+
+template <class _Ret, class _Callable, class... _Variants, class = void_t<_As_variant<_Variants>...>>
+constexpr _Ret visit(_Callable&& _Obj, _Variants&&... _Args) {
+    // Invoke _Obj with the contained values of _Args...
+    constexpr auto _Size = _Variant_total_states<_Remove_cvref_t<_As_variant<_Variants>>...>;
+    using _ListOfIndexLists =
+        _Meta_list<_Meta_as_list<make_index_sequence<1 + variant_size_v<_Remove_cvref_t<_As_variant<_Variants>>>>>...>;
+    using _ListOfIndexVectors =
+        _Meta_transform<_Meta_quote<_Meta_as_integer_sequence>, _Meta_cartesian_product<_ListOfIndexLists>>;
+    if constexpr (!is_void_v<_Ret>) {
+        static_assert(_Variant_all_visit_results_implicitly_convertible<_Ret, _Callable, _ListOfIndexVectors,
+                          _As_variant<_Variants>...>::value,
+            "visit<R>() requires the result of all potential invocations to be implicitly convertible to R "
+            "(N4828 [variant.visit]/2).");
+    }
+
+    return _Visit_impl<_Size, _ListOfIndexVectors, _Ret>(
+        _STD forward<_Callable>(_Obj), _STD forward<_Variants>(_Args)...);
+}
+#else // _HAS_CXX20
 template <class _Callable, class... _Variants, class = void_t<_As_variant<_Variants>...>>
 constexpr _Variant_visit_result_t<_Callable, _As_variant<_Variants>...> visit(_Callable&& _Obj, _Variants&&... _Args) {
     // Invoke _Obj with the contained values of _Args...
@@ -1615,10 +1685,11 @@ constexpr _Variant_visit_result_t<_Callable, _As_variant<_Variants>...> visit(_C
 
     constexpr int _Strategy =
         _Size == 1 ? 0 : _Size <= 4 ? 1 : _Size <= 16 ? 2 : _Size <= 64 ? 3 : _Size <= 256 ? 4 : -1;
-    return _Visit_strategy<_Strategy>::template _Visit<_ListOfIndexVectors>(
-        _Variant_visit_index1(0, static_cast<_As_variant<_Variants>&>(_Args)...), static_cast<_Callable&&>(_Obj),
-        static_cast<_As_variant<_Variants>&&>(_Args)...);
+    return _Visit_strategy<_Strategy>::template _Visit<_Variant_visit_result_t<_Callable, _As_variant<_Variants>...>,
+        _ListOfIndexVectors>(_Variant_visit_index1(0, static_cast<_As_variant<_Variants>&>(_Args)...),
+        static_cast<_Callable&&>(_Obj), static_cast<_As_variant<_Variants>&&>(_Args)...);
 }
+#endif // _HAS_CXX20
 
 // CLASS monostate [variant.monostate]
 struct monostate {};

--- a/stl/inc/variant
+++ b/stl/inc/variant
@@ -1625,7 +1625,7 @@ template <class _Ty>
 using _As_variant = // Deduce variant specialization from a derived type
     decltype(_As_variant_(_STD declval<_Ty>()));
 
-template <size_t _Size, class _ListOfIndexVectors, class _Ret, class _Callable, class... _Variants>
+template <size_t _Size, class _Ret, class _ListOfIndexVectors, class _Callable, class... _Variants>
 constexpr _Ret _Visit_impl(_Callable&& _Obj, _Variants&&... _Args) {
     constexpr int _Strategy =
         _Size == 1 ? 0 : _Size <= 4 ? 1 : _Size <= 16 ? 2 : _Size <= 64 ? 3 : _Size <= 256 ? 4 : -1;
@@ -1647,7 +1647,7 @@ constexpr _Variant_visit_result_t<_Callable, _As_variant<_Variants>...> visit(_C
         "visit() requires the result of all potential invocations to have the same type and value category "
         "(N4835 [variant.visit]/2).");
 
-    return _Visit_impl<_Size, _ListOfIndexVectors, _Ret>(
+    return _Visit_impl<_Size, _Ret, _ListOfIndexVectors>(
         static_cast<_Callable&&>(_Obj), static_cast<_Variants&&>(_Args)...);
 }
 
@@ -1666,7 +1666,7 @@ constexpr _Ret visit(_Callable&& _Obj, _Variants&&... _Args) {
             "(N4835 [variant.visit]/2).");
     }
 
-    return _Visit_impl<_Size, _ListOfIndexVectors, _Ret>(
+    return _Visit_impl<_Size, _Ret, _ListOfIndexVectors>(
         static_cast<_Callable&&>(_Obj), static_cast<_Variants&&>(_Args)...);
 }
 #endif // _HAS_CXX20

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -33,6 +33,7 @@
 // P0616R0 Using move() In <numeric>
 // P0646R1 list/forward_list remove()/remove_if()/unique() Return size_type
 // P0653R2 to_address()
+// P0655R1 visit<R>()
 // P0758R1 is_nothrow_convertible
 // P0768R1 Library Support For The Spaceship Comparison Operator <=>
 //     (partially implemented)


### PR DESCRIPTION
# Description

This is an implementation of `std::visit<R>`.
Addresses issue #31 

# Checklist

- [x] I understand README.md. I also understand that acceptance of
  community PRs will be delayed until the test and CI systems are online.
- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [x] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before CI is online, leave this unchecked for
  initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
**I changed the underlying machinery of `std::variant` to not assume the return type to be `_Variant_visit_result_t` but rather have it be a templated parameter that is passed down by the calling `std::visit` function. I don't believe this causes ABI breaks, but am unsure.**
- [x] These changes were written from scratch using only this repository and
  the C++ Working Draft as a reference (and any other cited standards).
  If they were derived from a project that's already listed in NOTICE.txt,
  that's fine, but please mention it. If they were derived from any other
  project (including Boost and libc++, which are not yet listed in
  NOTICE.txt), you *must* mention it here, so we can determine whether the
  license is compatible and what else needs to be done.
