### PR TITLE
Changes made from update to clang-format to 9.0.0.

### DIFF
--- a/stl/inc/mutex
+++ b/stl/inc/mutex
@@ -463,8 +463,7 @@ public:
     }
 
     ~scoped_lock() noexcept {
-        _For_each_tuple_element(
-            _MyMutexes, [](auto& _Mutex) noexcept { _Mutex.unlock(); });
+        _For_each_tuple_element(_MyMutexes, [](auto& _Mutex) noexcept { _Mutex.unlock(); });
     }
 
     scoped_lock(const scoped_lock&) = delete;

--- a/stl/inc/variant
+++ b/stl/inc/variant
@@ -888,13 +888,12 @@ public:
 
     void _Destroy() noexcept { // destroy the contained value, if any
         if constexpr (!conjunction_v<is_trivially_destructible<_Types>...>) {
-            _Variant_raw_visit(
-                index(), _Storage(), [](auto _Ref) noexcept {
-                    (void) _Ref; // TRANSITION, VSO-486357
-                    if constexpr (decltype(_Ref)::_Idx != variant_npos) {
-                        _Destroy_in_place(_Ref._Val);
-                    }
-                });
+            _Variant_raw_visit(index(), _Storage(), [](auto _Ref) noexcept {
+                (void) _Ref; // TRANSITION, VSO-486357
+                if constexpr (decltype(_Ref)::_Idx != variant_npos) {
+                    _Destroy_in_place(_Ref._Val);
+                }
+            });
         }
     }
 


### PR DESCRIPTION
# Description

These changes were made by clang-format when updated to 9.0.0 from 8.0.1.

# Checklist

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] I understand README.md. I also understand that acceptance of
  community PRs will be delayed until the test and CI systems are online.
- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [x] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before CI is online, leave this unchecked for
  initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository and
  the C++ Working Draft as a reference (and any other cited standards).
  If they were derived from a project that's already listed in NOTICE.txt,
  that's fine, but please mention it. If they were derived from any other
  project (including Boost and libc++, which are not yet listed in
  NOTICE.txt), you *must* mention it here, so we can determine whether the
  license is compatible and what else needs to be done.
