### PR TITLE
Fix issue-218 - remove public redundancy

### DIFF
--- a/stl/inc/deque
+++ b/stl/inc/deque
@@ -523,7 +523,7 @@ struct _Deque_iter_types {
 };
 
 template <class _Ty>
-struct _Deque_simple_types : public _Simple_types<_Ty> {
+struct _Deque_simple_types : _Simple_types<_Ty> {
     using _Mapptr = _Ty**;
 };
 

--- a/stl/inc/forward_list
+++ b/stl/inc/forward_list
@@ -256,7 +256,7 @@ struct _Flist_node { // forward_list node
 };
 
 template <class _Ty>
-struct _Flist_simple_types : public _Simple_types<_Ty> {
+struct _Flist_simple_types : _Simple_types<_Ty> {
     using _Node    = _Flist_node<_Ty, void*>;
     using _Nodeptr = _Node*;
 };

--- a/stl/inc/future
+++ b/stl/inc/future
@@ -92,7 +92,7 @@ enum class future_status { // names for timed wait function returns
 
 // STRUCT TEMPLATE SPECIALIZATION is_error_code_enum
 template <>
-struct is_error_code_enum<future_errc> : public true_type {};
+struct is_error_code_enum<future_errc> : true_type {};
 
 _NODISCARD const error_category& future_category() noexcept;
 

--- a/stl/inc/list
+++ b/stl/inc/list
@@ -332,7 +332,7 @@ struct _List_node { // list node
 };
 
 template <class _Ty>
-struct _List_simple_types : public _Simple_types<_Ty> {
+struct _List_simple_types : _Simple_types<_Ty> {
     using _Node    = _List_node<_Ty, void*>;
     using _Nodeptr = _Node*;
 };

--- a/stl/inc/random
+++ b/stl/inc/random
@@ -1910,7 +1910,7 @@ public:
     using _Mypbase    = typename _Mybase::param_type;
     using result_type = typename _Mybase::result_type;
 
-    struct param_type : public _Mypbase { // parameter package
+    struct param_type : _Mypbase { // parameter package
         using distribution_type = uniform_int_distribution;
 
         explicit param_type(result_type _Min0 = 0, result_type _Max0 = (numeric_limits<_Ty>::max)())
@@ -2653,7 +2653,7 @@ public:
     using _Mypbase    = typename _Mybase::param_type;
     using result_type = typename _Mybase::result_type;
 
-    struct param_type : public _Mypbase { // parameter package
+    struct param_type : _Mypbase { // parameter package
         using distribution_type = uniform_real_distribution;
 
         explicit param_type(_Ty _Min0 = _Ty{0}, _Ty _Max0 = _Ty{1}) : _Mypbase(_Min0, _Max0) {}
@@ -4475,7 +4475,7 @@ public:
     using _Noinit     = typename _Mypbase::_Noinit;
     using result_type = _Ty;
 
-    struct param_type : public _Mypbase { // parameter package
+    struct param_type : _Mypbase { // parameter package
         using distribution_type = piecewise_constant_distribution;
 
         param_type() {
@@ -4677,7 +4677,7 @@ public:
     using _Noinit     = typename _Mypbase::_Noinit;
     using result_type = _Ty;
 
-    struct param_type : public _Mypbase { // parameter package
+    struct param_type : _Mypbase { // parameter package
         using distribution_type = piecewise_linear_distribution;
 
         param_type() {

--- a/stl/inc/scoped_allocator
+++ b/stl/inc/scoped_allocator
@@ -62,7 +62,7 @@ struct _Scoped_base;
 struct _Secret_scoped_allocator_construct_tag {};
 
 template <class _Outer, class _Inner0, class... _Inner>
-struct _Scoped_base<_Outer, _Inner0, _Inner...> : public _Outer { // nest of allocators, arbitrary depth
+struct _Scoped_base<_Outer, _Inner0, _Inner...> : _Outer { // nest of allocators, arbitrary depth
     using _Myadaptor           = scoped_allocator_adaptor<_Outer, _Inner0, _Inner...>;
     using inner_allocator_type = scoped_allocator_adaptor<_Inner0, _Inner...>;
 
@@ -99,7 +99,7 @@ struct _Scoped_base<_Outer, _Inner0, _Inner...> : public _Outer { // nest of all
 };
 
 template <class _Outer>
-struct _Scoped_base<_Outer> : public _Outer { // nest of allocators, one deep
+struct _Scoped_base<_Outer> : _Outer { // nest of allocators, one deep
     using _Myadaptor           = scoped_allocator_adaptor<_Outer>;
     using inner_allocator_type = scoped_allocator_adaptor<_Outer>;
 

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -407,20 +407,20 @@ template <size_t _Index, class _Tuple>
 struct tuple_element;
 
 template <size_t _Index, class _Tuple>
-struct tuple_element<_Index, const _Tuple> : public tuple_element<_Index, _Tuple> { // tuple_element for const
+struct tuple_element<_Index, const _Tuple> : tuple_element<_Index, _Tuple> { // tuple_element for const
     using _Mybase = tuple_element<_Index, _Tuple>;
     using type    = add_const_t<typename _Mybase::type>;
 };
 
 template <size_t _Index, class _Tuple>
-struct tuple_element<_Index, volatile _Tuple> : public tuple_element<_Index, _Tuple> { // tuple_element for volatile
+struct tuple_element<_Index, volatile _Tuple> : tuple_element<_Index, _Tuple> { // tuple_element for volatile
     using _Mybase = tuple_element<_Index, _Tuple>;
     using type    = add_volatile_t<typename _Mybase::type>;
 };
 
 template <size_t _Index, class _Tuple>
 struct tuple_element<_Index, const volatile _Tuple>
-    : public tuple_element<_Index, _Tuple> { // tuple_element for const volatile
+    : tuple_element<_Index, _Tuple> { // tuple_element for const volatile
     using _Mybase = tuple_element<_Index, _Tuple>;
     using type    = add_cv_t<typename _Mybase::type>;
 };
@@ -463,7 +463,7 @@ struct tuple_element<0, tuple<_This, _Rest...>> { // select first element
 
 template <size_t _Index, class _This, class... _Rest>
 struct tuple_element<_Index, tuple<_This, _Rest...>>
-    : public tuple_element<_Index - 1, tuple<_Rest...>> { // recursive tuple_element definition
+    : tuple_element<_Index - 1, tuple<_Rest...>> { // recursive tuple_element definition
 };
 
 // TUPLE INTERFACE TO pair

--- a/stl/inc/xiosbase
+++ b/stl/inc/xiosbase
@@ -478,7 +478,7 @@ protected:
 
 private:
     // STRUCT _Iosarray
-    struct _Iosarray : public _Crt_new_delete { // list element for open-ended sparse array of longs/pointers
+    struct _Iosarray : _Crt_new_delete { // list element for open-ended sparse array of longs/pointers
     public:
         __CLR_OR_THIS_CALL _Iosarray(int _Idx, _Iosarray* _Link)
             : _Next(_Link), _Index(_Idx), _Lo(0), _Vp(nullptr) { // construct node for index _Idx and link it in
@@ -491,7 +491,7 @@ private:
     };
 
     // STRUCT _Fnarray
-    struct _Fnarray : public _Crt_new_delete { // list element for open-ended sparse array of event handlers
+    struct _Fnarray : _Crt_new_delete { // list element for open-ended sparse array of event handlers
         __CLR_OR_THIS_CALL _Fnarray(int _Idx, event_callback _Pnew, _Fnarray* _Link)
             : _Next(_Link), _Index(_Idx), _Pfn(_Pnew) { // construct node for index _Idx and link it in
         }

--- a/stl/inc/xlocale
+++ b/stl/inc/xlocale
@@ -2398,7 +2398,7 @@ protected:
 };
 
 // STRUCT ctype_base
-struct _CRTIMP2_PURE_IMPORT ctype_base : public locale::facet { // base for ctype
+struct _CRTIMP2_PURE_IMPORT ctype_base : locale::facet { // base for ctype
     enum { // constants for character classifications
         alnum  = _DI | _LO | _UP | _XA,
         alpha  = _LO | _UP | _XA,

--- a/stl/inc/xlocmes
+++ b/stl/inc/xlocmes
@@ -19,7 +19,7 @@ _STL_DISABLE_CLANG_WARNINGS
 
 _STD_BEGIN
 // STRUCT messages_base
-struct messages_base : public locale::facet { // base class for messages
+struct messages_base : locale::facet { // base class for messages
     using catalog = int;
 
     explicit messages_base(size_t _Refs = 0) : locale::facet(_Refs) {}

--- a/stl/inc/xlocmon
+++ b/stl/inc/xlocmon
@@ -19,7 +19,7 @@ _STL_DISABLE_CLANG_WARNINGS
 
 _STD_BEGIN
 // STRUCT money_base
-struct money_base : public locale::facet { // ultimate base class for moneypunct
+struct money_base : locale::facet { // ultimate base class for moneypunct
     enum { // constants for different format codes
         symbol = '$',
         sign   = '+',

--- a/stl/inc/xloctime
+++ b/stl/inc/xloctime
@@ -20,7 +20,7 @@ _STL_DISABLE_CLANG_WARNINGS
 
 _STD_BEGIN
 // STRUCT time_base
-struct _CRTIMP2_PURE_IMPORT time_base : public locale::facet { // base class for time_get
+struct _CRTIMP2_PURE_IMPORT time_base : locale::facet { // base class for time_get
     enum dateorder { // constants for different orders of date components
         no_order,
         dmy,

--- a/stl/inc/xtree
+++ b/stl/inc/xtree
@@ -382,7 +382,7 @@ struct _Tree_node {
 };
 
 template <class _Ty>
-struct _Tree_simple_types : public _Simple_types<_Ty> {
+struct _Tree_simple_types : _Simple_types<_Ty> {
     using _Node    = _Tree_node<_Ty, void*>;
     using _Nodeptr = _Node*;
 };


### PR DESCRIPTION
# Checklist

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] I understand README.md. I also understand that acceptance of
  community PRs will be delayed until the test and CI systems are online.
- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [ ] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before CI is online, leave this unchecked for
  initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository and
  the C++ Working Draft as a reference (and any other cited standards).
  If they were derived from a project that's already listed in NOTICE.txt,
  that's fine, but please mention it. If they were derived from any other
  project (including Boost and libc++, which are not yet listed in
  NOTICE.txt), you *must* mention it here, so we can determine whether the
  license is compatible and what else needs to be done.
