### PR TITLE
Consistently use "int = 0" SFINAE

### DIFF
--- a/stl/inc/array
+++ b/stl/inc/array
@@ -376,7 +376,7 @@ public:
     _Ty _Elems[1];
 };
 
-template <class _Ty, size_t _Size, class = enable_if_t<_Size == 0 || _Is_swappable<_Ty>::value>>
+template <class _Ty, size_t _Size, enable_if_t<_Size == 0 || _Is_swappable<_Ty>::value, int> = 0>
 void swap(array<_Ty, _Size>& _Left, array<_Ty, _Size>& _Right) noexcept(noexcept(_Left.swap(_Right))) {
     return _Left.swap(_Right);
 }

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -374,7 +374,7 @@ namespace chrono {
     }
 
     // FUNCTION TEMPLATE duration_cast
-    template <class _To, class _Rep, class _Period, int>
+    template <class _To, class _Rep, class _Period, enable_if_t<_Is_duration_v<_To>, int> _Enabled>
     _NODISCARD constexpr _To duration_cast(const duration<_Rep, _Period>& _Dur) noexcept(
         is_arithmetic_v<_Rep>&& is_arithmetic_v<typename _To::rep>) /* strengthened */ {
         // convert duration to another duration; truncate

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -58,7 +58,7 @@ namespace chrono {
     template <class _Ty>
     _INLINE_VAR constexpr bool _Is_duration_v = _Is_specialization_v<_Ty, duration>;
 
-    template <class _To, class _Rep, class _Period, class = enable_if_t<_Is_duration_v<_To>>>
+    template <class _To, class _Rep, class _Period, enable_if_t<_Is_duration_v<_To>, int> = 0>
     constexpr _To duration_cast(const duration<_Rep, _Period>&) noexcept(
         is_arithmetic_v<_Rep>&& is_arithmetic_v<typename _To::rep>); // strengthened
 
@@ -75,16 +75,18 @@ namespace chrono {
         constexpr duration() = default;
 
         template <class _Rep2,
-            class = enable_if_t<is_convertible_v<const _Rep2&,
-                                    _Rep> && (treat_as_floating_point_v<_Rep> || !treat_as_floating_point_v<_Rep2>)>>
+            enable_if_t<is_convertible_v<const _Rep2&,
+                            _Rep> && (treat_as_floating_point_v<_Rep> || !treat_as_floating_point_v<_Rep2>),
+                int> = 0>
         constexpr explicit duration(const _Rep2& _Val) noexcept(
             is_arithmetic_v<_Rep>&& is_arithmetic_v<_Rep2>) // strengthened
             : _MyRep(static_cast<_Rep>(_Val)) {}
 
         template <class _Rep2, class _Period2,
-            class = enable_if_t<
+            enable_if_t<
                 treat_as_floating_point_v<
-                    _Rep> || (_Ratio_divide_sfinae<_Period2, _Period>::den == 1 && !treat_as_floating_point_v<_Rep2>)>>
+                    _Rep> || (_Ratio_divide_sfinae<_Period2, _Period>::den == 1 && !treat_as_floating_point_v<_Rep2>),
+                int> = 0>
         constexpr duration(const duration<_Rep2, _Period2>& _Dur) noexcept(
             is_arithmetic_v<_Rep>&& is_arithmetic_v<_Rep2>) // strengthened
             : _MyRep(chrono::duration_cast<duration>(_Dur).count()) {}
@@ -185,7 +187,7 @@ namespace chrono {
         constexpr explicit time_point(const _Duration& _Other) noexcept(is_arithmetic_v<rep>) // strengthened
             : _MyDur(_Other) {}
 
-        template <class _Duration2, class = enable_if_t<is_convertible_v<_Duration2, _Duration>>>
+        template <class _Duration2, enable_if_t<is_convertible_v<_Duration2, _Duration>, int> = 0>
         constexpr time_point(const time_point<_Clock, _Duration2>& _Tp) noexcept(
             is_arithmetic_v<rep>&& is_arithmetic_v<typename _Duration2::rep>) // strengthened
             : _MyDur(_Tp.time_since_epoch()) {}
@@ -256,7 +258,7 @@ namespace chrono {
     }
 
     template <class _Rep1, class _Period1, class _Rep2,
-        class = enable_if_t<is_convertible_v<const _Rep2&, common_type_t<_Rep1, _Rep2>>>>
+        enable_if_t<is_convertible_v<const _Rep2&, common_type_t<_Rep1, _Rep2>>, int> = 0>
     _NODISCARD constexpr duration<common_type_t<_Rep1, _Rep2>, _Period1> operator*(
         const duration<_Rep1, _Period1>& _Left,
         const _Rep2& _Right) noexcept(is_arithmetic_v<_Rep1>&& is_arithmetic_v<_Rep2>) /* strengthened */ {
@@ -266,7 +268,7 @@ namespace chrono {
     }
 
     template <class _Rep1, class _Rep2, class _Period2,
-        class = enable_if_t<is_convertible_v<const _Rep1&, common_type_t<_Rep1, _Rep2>>>>
+        enable_if_t<is_convertible_v<const _Rep1&, common_type_t<_Rep1, _Rep2>>, int> = 0>
     _NODISCARD constexpr duration<common_type_t<_Rep1, _Rep2>, _Period2>
         operator*(const _Rep1& _Left, const duration<_Rep2, _Period2>& _Right) noexcept(
             is_arithmetic_v<_Rep1>&& is_arithmetic_v<_Rep2>) /* strengthened */ {
@@ -372,7 +374,7 @@ namespace chrono {
     }
 
     // FUNCTION TEMPLATE duration_cast
-    template <class _To, class _Rep, class _Period, class _Enabled>
+    template <class _To, class _Rep, class _Period, int>
     _NODISCARD constexpr _To duration_cast(const duration<_Rep, _Period>& _Dur) noexcept(
         is_arithmetic_v<_Rep>&& is_arithmetic_v<typename _To::rep>) /* strengthened */ {
         // convert duration to another duration; truncate
@@ -403,7 +405,7 @@ namespace chrono {
     }
 
     // FUNCTION TEMPLATE floor
-    template <class _To, class _Rep, class _Period, class = enable_if_t<_Is_duration_v<_To>>>
+    template <class _To, class _Rep, class _Period, enable_if_t<_Is_duration_v<_To>, int> = 0>
     _NODISCARD constexpr _To floor(const duration<_Rep, _Period>& _Dur) noexcept(
         is_arithmetic_v<_Rep>&& is_arithmetic_v<typename _To::rep>) /* strengthened */ {
         // convert duration to another duration; round towards negative infinity
@@ -417,7 +419,7 @@ namespace chrono {
     }
 
     // FUNCTION TEMPLATE ceil
-    template <class _To, class _Rep, class _Period, class = enable_if_t<_Is_duration_v<_To>>>
+    template <class _To, class _Rep, class _Period, enable_if_t<_Is_duration_v<_To>, int> = 0>
     _NODISCARD constexpr _To ceil(const duration<_Rep, _Period>& _Dur) noexcept(
         is_arithmetic_v<_Rep>&& is_arithmetic_v<typename _To::rep>) /* strengthened */ {
         // convert duration to another duration; round towards positive infinity
@@ -438,7 +440,7 @@ namespace chrono {
     }
 
     template <class _To, class _Rep, class _Period,
-        class = enable_if_t<_Is_duration_v<_To> && !treat_as_floating_point_v<typename _To::rep>>>
+        enable_if_t<_Is_duration_v<_To> && !treat_as_floating_point_v<typename _To::rep>, int> = 0>
     _NODISCARD constexpr _To round(const duration<_Rep, _Period>& _Dur) noexcept(
         is_arithmetic_v<_Rep>&& is_arithmetic_v<typename _To::rep>) /* strengthened */ {
         // convert duration to another duration, round to nearest, ties to even
@@ -455,7 +457,7 @@ namespace chrono {
     }
 
     // FUNCTION TEMPLATE abs
-    template <class _Rep, class _Period, class = enable_if_t<numeric_limits<_Rep>::is_signed>>
+    template <class _Rep, class _Period, enable_if_t<numeric_limits<_Rep>::is_signed, int> = 0>
     _NODISCARD constexpr duration<_Rep, _Period> abs(const duration<_Rep, _Period> _Dur) noexcept(
         is_arithmetic_v<_Rep>) /* strengthened */ {
         // create a duration with count() the absolute value of _Dur.count()
@@ -545,7 +547,7 @@ namespace chrono {
     }
 
     // FUNCTION TEMPLATE time_point_cast
-    template <class _To, class _Clock, class _Duration, class = enable_if_t<_Is_duration_v<_To>>>
+    template <class _To, class _Clock, class _Duration, enable_if_t<_Is_duration_v<_To>, int> = 0>
     _NODISCARD constexpr time_point<_Clock, _To> time_point_cast(const time_point<_Clock, _Duration>& _Time) noexcept(
         is_arithmetic_v<typename _Duration::rep>&& is_arithmetic_v<typename _To::rep>) /* strengthened */ {
         // change the duration type of a time_point; truncate
@@ -553,7 +555,7 @@ namespace chrono {
     }
 
     // FUNCTION TEMPLATE floor (for time_point instances)
-    template <class _To, class _Clock, class _Duration, class = enable_if_t<_Is_duration_v<_To>>>
+    template <class _To, class _Clock, class _Duration, enable_if_t<_Is_duration_v<_To>, int> = 0>
     _NODISCARD constexpr time_point<_Clock, _To> floor(const time_point<_Clock, _Duration>& _Time) noexcept(
         is_arithmetic_v<typename _Duration::rep>&& is_arithmetic_v<typename _To::rep>) /* strengthened */ {
         // change the duration type of a time_point; round towards negative infinity
@@ -561,7 +563,7 @@ namespace chrono {
     }
 
     // FUNCTION TEMPLATE ceil (for time_point instances)
-    template <class _To, class _Clock, class _Duration, class = enable_if_t<_Is_duration_v<_To>>>
+    template <class _To, class _Clock, class _Duration, enable_if_t<_Is_duration_v<_To>, int> = 0>
     _NODISCARD constexpr time_point<_Clock, _To> ceil(const time_point<_Clock, _Duration>& _Time) noexcept(
         is_arithmetic_v<typename _Duration::rep>&& is_arithmetic_v<typename _To::rep>) /* strengthened */ {
         // change the duration type of a time_point; round towards positive infinity
@@ -570,7 +572,7 @@ namespace chrono {
 
     // FUNCTION TEMPLATE round (for time_point instances)
     template <class _To, class _Clock, class _Duration,
-        class = enable_if_t<_Is_duration_v<_To> && !treat_as_floating_point_v<typename _To::rep>>>
+        enable_if_t<_Is_duration_v<_To> && !treat_as_floating_point_v<typename _To::rep>, int> = 0>
     _NODISCARD constexpr time_point<_Clock, _To> round(const time_point<_Clock, _Duration>& _Time) noexcept(
         is_arithmetic_v<typename _Duration::rep>&& is_arithmetic_v<typename _To::rep>) /* strengthened */ {
         // change the duration type of a time_point; round to nearest, ties to even

--- a/stl/inc/complex
+++ b/stl/inc/complex
@@ -1774,13 +1774,13 @@ struct _Promote_to_float { // promote integral to double
 };
 
 #define _GENERIC_MATHC0X(FUN, VAL)                                      \
-    template <class _Ty, class = enable_if_t<is_arithmetic_v<_Ty>>>     \
+    template <class _Ty, enable_if_t<is_arithmetic_v<_Ty>, int> = 0>    \
     _NODISCARD typename _Promote_to_float<_Ty>::type FUN(_Ty) {         \
         return static_cast<typename _Promote_to_float<_Ty>::type>(VAL); \
     }
 
 #define _GENERIC_MATHC1X(FUN, VAL)                                      \
-    template <class _Ty, class = enable_if_t<is_arithmetic_v<_Ty>>>     \
+    template <class _Ty, enable_if_t<is_arithmetic_v<_Ty>, int> = 0>    \
     _NODISCARD typename _Promote_to_float<_Ty>::type FUN(_Ty _Left) {   \
         return static_cast<typename _Promote_to_float<_Ty>::type>(VAL); \
     }
@@ -1816,7 +1816,7 @@ _NODISCARD complex<_Common_float_type_t<_Ty1, _Ty2>> pow(const _Ty1& _Left, cons
     return _STD pow(type(_Left), type(_Right));
 }
 
-template <class _Ty1, class _Ty2, class = enable_if_t<is_integral_v<_Ty1> && is_integral_v<_Ty2>>>
+template <class _Ty1, class _Ty2, enable_if_t<is_integral_v<_Ty1> && is_integral_v<_Ty2>, int> = 0>
 _NODISCARD complex<_Ty1> pow(const complex<_Ty1>& _Left, _Ty2& _Right) {
     // raise Gaussian integer to an integer power
     using type = complex<_Ty1>;

--- a/stl/inc/deque
+++ b/stl/inc/deque
@@ -638,7 +638,7 @@ public:
         _Proxy._Release();
     }
 
-    template <class _Iter, class = enable_if_t<_Is_iterator_v<_Iter>>>
+    template <class _Iter, enable_if_t<_Is_iterator_v<_Iter>, int> = 0>
     deque(_Iter _First, _Iter _Last) : _Mypair(_Zero_then_variadic_args_t()) {
         _Alproxy_ty _Alproxy(_Getal());
         _Container_proxy_ptr12<_Alproxy_ty> _Proxy(_Alproxy, _Get_data());
@@ -646,7 +646,7 @@ public:
         _Proxy._Release();
     }
 
-    template <class _Iter, class = enable_if_t<_Is_iterator_v<_Iter>>>
+    template <class _Iter, enable_if_t<_Is_iterator_v<_Iter>, int> = 0>
     deque(_Iter _First, _Iter _Last, const _Alloc& _Al) : _Mypair(_One_then_variadic_args_t(), _Al) {
         _Alproxy_ty _Alproxy(_Getal());
         _Container_proxy_ptr12<_Alproxy_ty> _Proxy(_Alproxy, _Get_data());
@@ -1147,7 +1147,7 @@ public:
 #endif // _ITERATOR_DEBUG_LEVEL == 2
     }
 
-    template <class _Iter, class = enable_if_t<_Is_iterator_v<_Iter>>>
+    template <class _Iter, enable_if_t<_Is_iterator_v<_Iter>, int> = 0>
     void assign(_Iter _First, _Iter _Last) {
         _Orphan_all();
         _Adl_verify_range(_First, _Last);
@@ -1214,7 +1214,7 @@ public:
         return begin() + static_cast<difference_type>(_Off);
     }
 
-    template <class _Iter, class = enable_if_t<_Is_iterator_v<_Iter>>>
+    template <class _Iter, enable_if_t<_Is_iterator_v<_Iter>, int> = 0>
     iterator insert(const_iterator _Where, _Iter _First, _Iter _Last) {
         // insert [_First, _Last) at _Where, input iterators
         size_type _Off = static_cast<size_type>(_Where - begin());

--- a/stl/inc/experimental/filesystem
+++ b/stl/inc/experimental/filesystem
@@ -749,7 +749,7 @@ public:
 
     // ARBITRARY SOURCE CONSTRUCT
 
-    template <class _InIt, class = enable_if_t<_Is_iterator_v<_InIt>>>
+    template <class _InIt, enable_if_t<_Is_iterator_v<_InIt>, int> = 0>
     path(_InIt _First, _InIt _Last) {
         using _Valty = _Iter_value_t<_InIt>;
         basic_string<_Valty> _Str(_First, _Last);
@@ -757,7 +757,7 @@ public:
         *this /= _Path_cvt<_Valty, value_type>::_Cvt(_Str_out, _Str.c_str(), _Str.size());
     }
 
-    template <class _InIt, class = enable_if_t<_Is_iterator_v<_InIt>>>
+    template <class _InIt, enable_if_t<_Is_iterator_v<_InIt>, int> = 0>
     path(_InIt _First) {
         using _Valty = _Iter_value_t<_InIt>;
         basic_string<_Valty> _Str;
@@ -777,7 +777,7 @@ public:
 
     // ARBITRARY SOURCE CONSTRUCT, WITH LOCALE
 
-    template <class _InIt, class = enable_if_t<_Is_iterator_v<_InIt>>>
+    template <class _InIt, enable_if_t<_Is_iterator_v<_InIt>, int> = 0>
     path(_InIt _First, _InIt _Last, const locale& _Loc) {
         using _Valty = _Iter_value_t<_InIt>;
         basic_string<_Valty> _Str(_First, _Last);
@@ -785,7 +785,7 @@ public:
         *this /= _Path_cvt<_Valty, value_type>::_Cvt(_Str_out, _Str.c_str(), _Str.size(), _Loc);
     }
 
-    template <class _InIt, class = enable_if_t<_Is_iterator_v<_InIt>>>
+    template <class _InIt, enable_if_t<_Is_iterator_v<_InIt>, int> = 0>
     path(_InIt _First, const locale& _Loc) {
         using _Valty = _Iter_value_t<_InIt>;
         basic_string<_Valty> _Str;
@@ -1305,14 +1305,14 @@ basic_istream<_Elem, _Traits>& operator>>(basic_istream<_Elem, _Traits>& _Istr, 
 }
 
 // FUNCTION TEMPLATE u8path
-template <class _InIt, class = enable_if_t<_Is_iterator_v<_InIt>>>
+template <class _InIt, enable_if_t<_Is_iterator_v<_InIt>, int> = 0>
 _NODISCARD path u8path(_InIt _First, _InIt _Last) { // make path from [_First, _Last) UTF8, given iterators
     string _Str(_First, _Last);
     path::string_type _Str_out;
     return path(_Path_cvt<_Char8_t, _Pchar>::_Cvt(_Str_out, _Str.c_str(), _Str.size()));
 }
 
-template <class _InIt, class = enable_if_t<_Is_iterator_v<_InIt>>>
+template <class _InIt, enable_if_t<_Is_iterator_v<_InIt>, int> = 0>
 _NODISCARD path u8path(_InIt _First) { // make path from NTBS UTF8, given iterator
     string _Str;
     for (; *_First != '\0'; ++_First) {

--- a/stl/inc/forward_list
+++ b/stl/inc/forward_list
@@ -560,7 +560,7 @@ public:
         _Insert_op._Attach_after(_Mypair._Myval2._Before_head());
     }
 
-    template <class _Iter, class = enable_if_t<_Is_iterator_v<_Iter>>>
+    template <class _Iter, enable_if_t<_Is_iterator_v<_Iter>, int> = 0>
     forward_list(_Iter _First, _Iter _Last) : _Mypair(_Zero_then_variadic_args_t()) {
         _Adl_verify_range(_First, _Last);
         _Flist_insert_after_op<_Alnode> _Insert_op(_Getal());
@@ -569,7 +569,7 @@ public:
         _Insert_op._Attach_after(_Mypair._Myval2._Before_head());
     }
 
-    template <class _Iter, class = enable_if_t<_Is_iterator_v<_Iter>>>
+    template <class _Iter, enable_if_t<_Is_iterator_v<_Iter>, int> = 0>
     forward_list(_Iter _First, _Iter _Last, const _Alloc& _Al) : _Mypair(_One_then_variadic_args_t(), _Al) {
         _Adl_verify_range(_First, _Last);
         _Flist_insert_after_op<_Alnode> _Insert_op(_Getal());
@@ -908,7 +908,7 @@ private:
     }
 
 public:
-    template <class _Iter, class = enable_if_t<_Is_iterator_v<_Iter>>>
+    template <class _Iter, enable_if_t<_Is_iterator_v<_Iter>, int> = 0>
     void assign(_Iter _First, _Iter _Last) {
         _Adl_verify_range(_First, _Last);
         _Assign_unchecked(_Get_unwrapped(_First), _Get_unwrapped(_Last));
@@ -944,7 +944,7 @@ public:
         return _Make_iter(_Where._Ptr);
     }
 
-    template <class _Iter, class = enable_if_t<_Is_iterator_v<_Iter>>>
+    template <class _Iter, enable_if_t<_Is_iterator_v<_Iter>, int> = 0>
     iterator insert_after(const_iterator _Where, _Iter _First, _Iter _Last) {
         // insert [_First, _Last) after _Where
 #if _ITERATOR_DEBUG_LEVEL == 2

--- a/stl/inc/functional
+++ b/stl/inc/functional
@@ -894,7 +894,7 @@ public:
     using _Mybase       = _Func_base<_Rx, _Types...>;
     using _Nothrow_move = is_nothrow_move_constructible<_Callable>;
 
-    template <class _Other, class = enable_if_t<!is_same_v<_Func_impl_no_alloc, decay_t<_Other>>>>
+    template <class _Other, enable_if_t<!is_same_v<_Func_impl_no_alloc, decay_t<_Other>>, int> = 0>
     explicit _Func_impl_no_alloc(_Other&& _Val) : _Callee(_STD forward<_Other>(_Val)) {}
 
     // dtor non-virtual due to _Delete_this()

--- a/stl/inc/future
+++ b/stl/inc/future
@@ -1352,7 +1352,7 @@ public:
 
     packaged_task() noexcept : _MyPromise(0) {}
 
-    template <class _Fty2, class = enable_if_t<!is_same_v<_Remove_cvref_t<_Fty2>, packaged_task>>>
+    template <class _Fty2, enable_if_t<!is_same_v<_Remove_cvref_t<_Fty2>, packaged_task>, int> = 0>
     explicit packaged_task(_Fty2&& _Fnarg) : _MyPromise(new _MyStateType(_STD forward<_Fty2>(_Fnarg))) {}
 
     packaged_task(packaged_task&& _Other) noexcept : _MyPromise(_STD move(_Other._MyPromise)) {}
@@ -1363,7 +1363,7 @@ public:
     }
 
 #if _HAS_FUNCTION_ALLOCATOR_SUPPORT
-    template <class _Fty2, class _Alloc, class = enable_if_t<!is_same_v<_Remove_cvref_t<_Fty2>, packaged_task>>>
+    template <class _Fty2, class _Alloc, enable_if_t<!is_same_v<_Remove_cvref_t<_Fty2>, packaged_task>, int> = 0>
     packaged_task(allocator_arg_t, const _Alloc& _Al, _Fty2&& _Fnarg)
         : _MyPromise(_Make_packaged_state<_MyStateType>(_STD forward<_Fty2>(_Fnarg), _Al)) {}
 #endif // _HAS_FUNCTION_ALLOCATOR_SUPPORT

--- a/stl/inc/hash_map
+++ b/stl/inc/hash_map
@@ -190,12 +190,12 @@ namespace stdext {
 
         using _Mybase::insert;
 
-        template <class _Valty, class = enable_if_t<is_constructible_v<value_type, _Valty>>>
+        template <class _Valty, enable_if_t<is_constructible_v<value_type, _Valty>, int> = 0>
         pair<iterator, bool> insert(_Valty&& _Val) {
             return this->emplace(_STD forward<_Valty>(_Val));
         }
 
-        template <class _Valty, class = enable_if_t<is_constructible_v<value_type, _Valty>>>
+        template <class _Valty, enable_if_t<is_constructible_v<value_type, _Valty>, int> = 0>
         iterator insert(const_iterator _Where, _Valty&& _Val) {
             return this->emplace_hint(_Where, _STD forward<_Valty>(_Val));
         }
@@ -373,12 +373,12 @@ namespace stdext {
 
         using _Mybase::insert;
 
-        template <class _Valty, class = enable_if_t<is_constructible_v<value_type, _Valty>>>
+        template <class _Valty, enable_if_t<is_constructible_v<value_type, _Valty>, int> = 0>
         iterator insert(_Valty&& _Val) {
             return this->emplace(_STD forward<_Valty>(_Val));
         }
 
-        template <class _Valty, class = enable_if_t<is_constructible_v<value_type, _Valty>>>
+        template <class _Valty, enable_if_t<is_constructible_v<value_type, _Valty>, int> = 0>
         iterator insert(const_iterator _Where, _Valty&& _Val) {
             return this->emplace_hint(_Where, _STD forward<_Valty>(_Val));
         }

--- a/stl/inc/hash_map
+++ b/stl/inc/hash_map
@@ -190,12 +190,12 @@ namespace stdext {
 
         using _Mybase::insert;
 
-        template <class _Valty, enable_if_t<is_constructible_v<value_type, _Valty>, int> = 0>
+        template <class _Valty, class = enable_if_t<is_constructible_v<value_type, _Valty>>> // TRANSITION, GH-249
         pair<iterator, bool> insert(_Valty&& _Val) {
             return this->emplace(_STD forward<_Valty>(_Val));
         }
 
-        template <class _Valty, enable_if_t<is_constructible_v<value_type, _Valty>, int> = 0>
+        template <class _Valty, class = enable_if_t<is_constructible_v<value_type, _Valty>>> // TRANSITION, GH-249
         iterator insert(const_iterator _Where, _Valty&& _Val) {
             return this->emplace_hint(_Where, _STD forward<_Valty>(_Val));
         }
@@ -373,12 +373,12 @@ namespace stdext {
 
         using _Mybase::insert;
 
-        template <class _Valty, enable_if_t<is_constructible_v<value_type, _Valty>, int> = 0>
+        template <class _Valty, class = enable_if_t<is_constructible_v<value_type, _Valty>>> // TRANSITION, GH-249
         iterator insert(_Valty&& _Val) {
             return this->emplace(_STD forward<_Valty>(_Val));
         }
 
-        template <class _Valty, enable_if_t<is_constructible_v<value_type, _Valty>, int> = 0>
+        template <class _Valty, class = enable_if_t<is_constructible_v<value_type, _Valty>>> // TRANSITION, GH-249
         iterator insert(const_iterator _Where, _Valty&& _Val) {
             return this->emplace_hint(_Where, _STD forward<_Valty>(_Val));
         }

--- a/stl/inc/list
+++ b/stl/inc/list
@@ -855,13 +855,13 @@ public:
         _Construct_range_unchecked(_Right._Unchecked_begin(), _Right._Unchecked_end());
     }
 
-    template <class _Iter, class = enable_if_t<_Is_iterator_v<_Iter>>>
+    template <class _Iter, enable_if_t<_Is_iterator_v<_Iter>, int> = 0>
     list(_Iter _First, _Iter _Last) : _Mypair(_Zero_then_variadic_args_t()) {
         _Adl_verify_range(_First, _Last);
         _Construct_range_unchecked(_Get_unwrapped(_First), _Get_unwrapped(_Last));
     }
 
-    template <class _Iter, class = enable_if_t<_Is_iterator_v<_Iter>>>
+    template <class _Iter, enable_if_t<_Is_iterator_v<_Iter>, int> = 0>
     list(_Iter _First, _Iter _Last, const _Alloc& _Al) : _Mypair(_One_then_variadic_args_t(), _Al) {
         _Adl_verify_range(_First, _Last);
         _Construct_range_unchecked(_Get_unwrapped(_First), _Get_unwrapped(_Last));
@@ -1267,7 +1267,7 @@ private:
     }
 
 public:
-    template <class _Iter, class = enable_if_t<_Is_iterator_v<_Iter>>>
+    template <class _Iter, enable_if_t<_Is_iterator_v<_Iter>, int> = 0>
     void assign(_Iter _First, _Iter _Last) {
         _Assign_cast<reference>(_Get_unwrapped(_First), _Get_unwrapped(_Last));
     }
@@ -1313,7 +1313,7 @@ public:
         return _Make_iter(_Op._Attach_before(_Mypair._Myval2, _Where._Ptr));
     }
 
-    template <class _Iter, class = enable_if_t<_Is_iterator_v<_Iter>>>
+    template <class _Iter, enable_if_t<_Is_iterator_v<_Iter>, int> = 0>
     iterator insert(const const_iterator _Where, _Iter _First, _Iter _Last) { // insert [_First, _Last) before _Where
 #if _ITERATOR_DEBUG_LEVEL == 2
         _STL_VERIFY(_Where._Getcont() == _STD addressof(_Mypair._Myval2), "list insert iterator outside range");

--- a/stl/inc/map
+++ b/stl/inc/map
@@ -160,12 +160,12 @@ public:
 
     using _Mybase::insert;
 
-    template <class _Valty, class = enable_if_t<is_constructible_v<value_type, _Valty>>>
+    template <class _Valty, enable_if_t<is_constructible_v<value_type, _Valty>, int> = 0>
     pair<iterator, bool> insert(_Valty&& _Val) {
         return this->emplace(_STD forward<_Valty>(_Val));
     }
 
-    template <class _Valty, class = enable_if_t<is_constructible_v<value_type, _Valty>>>
+    template <class _Valty, enable_if_t<is_constructible_v<value_type, _Valty>, int> = 0>
     iterator insert(const_iterator _Where, _Valty&& _Val) {
         return this->emplace_hint(_Where, _STD forward<_Valty>(_Val));
     }
@@ -464,12 +464,12 @@ public:
 
     using _Mybase::insert;
 
-    template <class _Valty, class = enable_if_t<is_constructible_v<value_type, _Valty>>>
+    template <class _Valty, enable_if_t<is_constructible_v<value_type, _Valty>, int> = 0>
     iterator insert(_Valty&& _Val) {
         return this->emplace(_STD forward<_Valty>(_Val));
     }
 
-    template <class _Valty, class = enable_if_t<is_constructible_v<value_type, _Valty>>>
+    template <class _Valty, enable_if_t<is_constructible_v<value_type, _Valty>, int> = 0>
     iterator insert(const_iterator _Where, _Valty&& _Val) {
         return this->emplace_hint(_Where, _STD forward<_Valty>(_Val));
     }

--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -1931,11 +1931,12 @@ public:
     constexpr unique_ptr() noexcept : _Mypair(_Zero_then_variadic_args_t()) {}
 
     template <class _Uty, class _Is_nullptr = is_same<_Uty, nullptr_t>>
-    using _Enable_ctor_reset = enable_if_t<is_same_v<_Uty, pointer> //
-                                           || _Is_nullptr::value //
-                                           || (is_same_v<pointer, element_type*> //
-                                               && is_pointer_v<_Uty> //
-                                               && is_convertible_v<remove_pointer_t<_Uty> (*)[], element_type (*)[]>)>;
+    using _Enable_ctor_reset =
+        enable_if_t<is_same_v<_Uty, pointer> //
+                    || _Is_nullptr::value //
+                    || (is_same_v<pointer, element_type*> //
+                        && is_pointer_v<_Uty> //
+                        && is_convertible_v<remove_pointer_t<_Uty> (*)[], element_type (*)[]>)>; // TRANSITION, GH-248
 
     template <class _Uty, class _Dx2 = _Dx, _Unique_ptr_enable_default_t<_Dx2> = 0, class = _Enable_ctor_reset<_Uty>>
     explicit unique_ptr(_Uty _Ptr) noexcept : _Mypair(_Zero_then_variadic_args_t(), _Ptr) {}
@@ -1974,8 +1975,9 @@ public:
 
     template <class _Uty, class _Ex, class _More, class _UP_pointer = typename unique_ptr<_Uty, _Ex>::pointer,
         class _UP_element_type = typename unique_ptr<_Uty, _Ex>::element_type>
-    using _Enable_conversion = enable_if_t<conjunction_v<is_array<_Uty>, is_same<pointer, element_type*>,
-        is_same<_UP_pointer, _UP_element_type*>, is_convertible<_UP_element_type (*)[], element_type (*)[]>, _More>>;
+    using _Enable_conversion = enable_if_t<
+        conjunction_v<is_array<_Uty>, is_same<pointer, element_type*>, is_same<_UP_pointer, _UP_element_type*>,
+            is_convertible<_UP_element_type (*)[], element_type (*)[]>, _More>>; // TRANSITION, GH-248
 
     template <class _Uty, class _Ex,
         class = _Enable_conversion<_Uty, _Ex,

--- a/stl/inc/thread
+++ b/stl/inc/thread
@@ -51,7 +51,7 @@ private:
     }
 
 public:
-    template <class _Fn, class... _Args, class = enable_if_t<!is_same_v<_Remove_cvref_t<_Fn>, thread>>>
+    template <class _Fn, class... _Args, enable_if_t<!is_same_v<_Remove_cvref_t<_Fn>, thread>, int> = 0>
     explicit thread(_Fn&& _Fx, _Args&&... _Ax) {
         using _Tuple                 = tuple<decay_t<_Fn>, decay_t<_Args>...>;
         auto _Decay_copied           = _STD make_unique<_Tuple>(_STD forward<_Fn>(_Fx), _STD forward<_Args>(_Ax)...);

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -1926,7 +1926,7 @@ struct _Is_nothrow_swappable;
 #if _HAS_CXX17
 template <class _Ty, enable_if_t<is_move_constructible_v<_Ty> && is_move_assignable_v<_Ty>, int> = 0>
 #else // ^^^ _HAS_CXX17 / !_HAS_CXX17 vvv
-template <class _Ty, int = 0>
+template <class _Ty, int _Enabled = 0>
 #endif // _HAS_CXX17
 void swap(_Ty&, _Ty&) noexcept(is_nothrow_move_constructible_v<_Ty>&& is_nothrow_move_assignable_v<_Ty>);
 

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -1924,13 +1924,13 @@ struct _Is_nothrow_swappable;
 
 // FUNCTION TEMPLATE swap
 #if _HAS_CXX17
-template <class _Ty, class = enable_if_t<is_move_constructible_v<_Ty> && is_move_assignable_v<_Ty>>>
+template <class _Ty, enable_if_t<is_move_constructible_v<_Ty> && is_move_assignable_v<_Ty>, int> = 0>
 #else // ^^^ _HAS_CXX17 / !_HAS_CXX17 vvv
-template <class _Ty, class = void>
+template <class _Ty, int = 0>
 #endif // _HAS_CXX17
 void swap(_Ty&, _Ty&) noexcept(is_nothrow_move_constructible_v<_Ty>&& is_nothrow_move_assignable_v<_Ty>);
 
-template <class _Ty, size_t _Size, class = enable_if_t<_Is_swappable<_Ty>::value>>
+template <class _Ty, size_t _Size, enable_if_t<_Is_swappable<_Ty>::value, int> = 0>
 void swap(_Ty (&)[_Size], _Ty (&)[_Size]) noexcept(_Is_nothrow_swappable<_Ty>::value);
 
 // STRUCT TEMPLATE _Swappable_with_helper

--- a/stl/inc/unordered_map
+++ b/stl/inc/unordered_map
@@ -234,12 +234,12 @@ public:
 
     using _Mybase::insert;
 
-    template <class _Valty, class = enable_if_t<is_constructible_v<value_type, _Valty>>>
+    template <class _Valty, enable_if_t<is_constructible_v<value_type, _Valty>, int> = 0>
     pair<iterator, bool> insert(_Valty&& _Val) {
         return this->emplace(_STD forward<_Valty>(_Val));
     }
 
-    template <class _Valty, class = enable_if_t<is_constructible_v<value_type, _Valty>>>
+    template <class _Valty, enable_if_t<is_constructible_v<value_type, _Valty>, int> = 0>
     iterator insert(const_iterator _Where, _Valty&& _Val) {
         return this->emplace_hint(_Where, _STD forward<_Valty>(_Val));
     }
@@ -641,12 +641,12 @@ public:
 
     using _Mybase::insert;
 
-    template <class _Valty, class = enable_if_t<is_constructible_v<value_type, _Valty>>>
+    template <class _Valty, enable_if_t<is_constructible_v<value_type, _Valty>, int> = 0>
     iterator insert(_Valty&& _Val) {
         return this->emplace(_STD forward<_Valty>(_Val));
     }
 
-    template <class _Valty, class = enable_if_t<is_constructible_v<value_type, _Valty>>>
+    template <class _Valty, enable_if_t<is_constructible_v<value_type, _Valty>, int> = 0>
     iterator insert(const_iterator _Where, _Valty&& _Val) {
         return this->emplace_hint(_Where, _STD forward<_Valty>(_Val));
     }

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -44,7 +44,7 @@ void iter_swap(_FwdIt1 _Left, _FwdIt2 _Right) { // swap *_Left and *_Right
 }
 
 // FUNCTION TEMPLATE swap
-template <class _Ty, size_t _Size, enable_if_t<_Is_swappable<_Ty>::value, int>>
+template <class _Ty, size_t _Size, enable_if_t<_Is_swappable<_Ty>::value, int> _Enabled>
 void swap(_Ty (&_Left)[_Size], _Ty (&_Right)[_Size]) noexcept(_Is_nothrow_swappable<_Ty>::value) {
     if (&_Left != &_Right) {
         _Ty* _First1 = _Left;
@@ -57,9 +57,9 @@ void swap(_Ty (&_Left)[_Size], _Ty (&_Right)[_Size]) noexcept(_Is_nothrow_swappa
 }
 
 #if _HAS_CXX17
-template <class _Ty, enable_if_t<is_move_constructible_v<_Ty> && is_move_assignable_v<_Ty>, int>>
+template <class _Ty, enable_if_t<is_move_constructible_v<_Ty> && is_move_assignable_v<_Ty>, int> _Enabled>
 #else // ^^^ _HAS_CXX17 / !_HAS_CXX17 vvv
-template <class _Ty, int>
+template <class _Ty, int _Enabled>
 #endif // _HAS_CXX17
 void swap(_Ty& _Left, _Ty& _Right) noexcept(is_nothrow_move_constructible_v<_Ty>&& is_nothrow_move_assignable_v<_Ty>) {
     _Ty _Tmp = _STD move(_Left);

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -44,7 +44,7 @@ void iter_swap(_FwdIt1 _Left, _FwdIt2 _Right) { // swap *_Left and *_Right
 }
 
 // FUNCTION TEMPLATE swap
-template <class _Ty, size_t _Size, class>
+template <class _Ty, size_t _Size, enable_if_t<_Is_swappable<_Ty>::value, int>>
 void swap(_Ty (&_Left)[_Size], _Ty (&_Right)[_Size]) noexcept(_Is_nothrow_swappable<_Ty>::value) {
     if (&_Left != &_Right) {
         _Ty* _First1 = _Left;
@@ -56,7 +56,11 @@ void swap(_Ty (&_Left)[_Size], _Ty (&_Right)[_Size]) noexcept(_Is_nothrow_swappa
     }
 }
 
-template <class _Ty, class>
+#if _HAS_CXX17
+template <class _Ty, enable_if_t<is_move_constructible_v<_Ty> && is_move_assignable_v<_Ty>, int>>
+#else // ^^^ _HAS_CXX17 / !_HAS_CXX17 vvv
+template <class _Ty, int>
+#endif // _HAS_CXX17
 void swap(_Ty& _Left, _Ty& _Right) noexcept(is_nothrow_move_constructible_v<_Ty>&& is_nothrow_move_assignable_v<_Ty>) {
     _Ty _Tmp = _STD move(_Left);
     _Left    = _STD move(_Right);
@@ -291,7 +295,7 @@ template <class _Ty1, class _Ty2>
 pair(_Ty1, _Ty2)->pair<_Ty1, _Ty2>;
 #endif // _HAS_CXX17
 
-template <class _Ty1, class _Ty2, class = enable_if_t<_Is_swappable<_Ty1>::value && _Is_swappable<_Ty2>::value>>
+template <class _Ty1, class _Ty2, enable_if_t<_Is_swappable<_Ty1>::value && _Is_swappable<_Ty2>::value, int> = 0>
 void swap(pair<_Ty1, _Ty2>& _Left, pair<_Ty1, _Ty2>& _Right) noexcept(noexcept(_Left.swap(_Right))) {
     _Left.swap(_Right);
 }

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -500,7 +500,7 @@ private:
     }
 
 public:
-    template <class _Iter, class = enable_if_t<_Is_iterator_v<_Iter>>>
+    template <class _Iter, enable_if_t<_Is_iterator_v<_Iter>, int> = 0>
     vector(_Iter _First, _Iter _Last, const _Alloc& _Al = _Alloc()) : _Mypair(_One_then_variadic_args_t(), _Al) {
         auto&& _Alproxy = _GET_PROXY_ALLOCATOR(_Alty, _Getal());
         _Container_proxy_ptr<_Alty> _Proxy(_Alproxy, _Mypair._Myval2);
@@ -1013,7 +1013,7 @@ private:
     }
 
 public:
-    template <class _Iter, class = enable_if_t<_Is_iterator_v<_Iter>>>
+    template <class _Iter, enable_if_t<_Is_iterator_v<_Iter>, int> = 0>
     iterator insert(const_iterator _Where, _Iter _First, _Iter _Last) {
         const pointer _Whereptr = _Where._Ptr;
         auto& _My_data          = _Mypair._Myval2;
@@ -1136,7 +1136,7 @@ private:
     }
 
 public:
-    template <class _Iter, class = enable_if_t<_Is_iterator_v<_Iter>>>
+    template <class _Iter, enable_if_t<_Is_iterator_v<_Iter>, int> = 0>
     void assign(_Iter _First, _Iter _Last) {
         _Adl_verify_range(_First, _Last);
         _Assign_range(_Get_unwrapped(_First), _Get_unwrapped(_Last), _Iter_cat_t<_Iter>{});
@@ -2295,7 +2295,7 @@ public:
 
     vector(const vector& _Right, const _Alloc& _Al) : _Mybase(_Right, _Al) {}
 
-    template <class _Iter, class = enable_if_t<_Is_iterator_v<_Iter>>>
+    template <class _Iter, enable_if_t<_Is_iterator_v<_Iter>, int> = 0>
     vector(_Iter _First, _Iter _Last, const _Alloc& _Al = _Alloc()) : _Mybase(_Al) {
         _BConstruct(_First, _Last);
     }
@@ -2645,7 +2645,7 @@ public:
         erase(end() - 1);
     }
 
-    template <class _Iter, class = enable_if_t<_Is_iterator_v<_Iter>>>
+    template <class _Iter, enable_if_t<_Is_iterator_v<_Iter>, int> = 0>
     void assign(_Iter _First, _Iter _Last) {
         clear();
         insert(begin(), _First, _Last);
@@ -2664,7 +2664,7 @@ public:
         return _Insert_n(_Where, _Count, _Val);
     }
 
-    template <class _Iter, class = enable_if_t<_Is_iterator_v<_Iter>>>
+    template <class _Iter, enable_if_t<_Is_iterator_v<_Iter>, int> = 0>
     iterator insert(const_iterator _Where, _Iter _First, _Iter _Last) {
         difference_type _Off = _Where - begin();
         _Insert(_Where, _First, _Last, _Iter_cat_t<_Iter>());

--- a/stl/inc/xhash
+++ b/stl/inc/xhash
@@ -1233,7 +1233,7 @@ private:
     }
 
 public:
-    template <class _Iter = iterator, class = enable_if_t<!is_same_v<_Iter, const_iterator>>>
+    template <class _Iter = iterator, enable_if_t<!is_same_v<_Iter, const_iterator>, int> = 0>
     iterator erase(iterator _Plist) noexcept(_Nothrow_hash<_Traits, key_type>) /* strengthened */ {
         return _List._Make_iter(_Unchecked_erase(_Plist._Ptr));
     }

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -2263,7 +2263,8 @@ private:
     template <class _StringViewIsh>
     using _Is_string_view_ish =
         enable_if_t<conjunction_v<is_convertible<const _StringViewIsh&, basic_string_view<_Elem, _Traits>>,
-            negation<is_convertible<const _StringViewIsh&, const _Elem*>>>, int>;
+                        negation<is_convertible<const _StringViewIsh&, const _Elem*>>>,
+            int>;
 #endif // _HAS_CXX17
 
 public:

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -2370,7 +2370,7 @@ public:
         _Proxy._Release();
     }
 
-    template <class _Iter, class = enable_if_t<_Is_iterator_v<_Iter>>>
+    template <class _Iter, enable_if_t<_Is_iterator_v<_Iter>, int> = 0>
     basic_string(_Iter _First, _Iter _Last, const _Alloc& _Al = _Alloc()) : _Mypair(_One_then_variadic_args_t(), _Al) {
         auto&& _Alproxy = _GET_PROXY_ALLOCATOR(_Alty, _Getal());
         _Container_proxy_ptr<_Alty> _Proxy(_Alproxy, _Mypair._Myval2);
@@ -2809,7 +2809,7 @@ public:
     }
 
 #if _HAS_IF_CONSTEXPR
-    template <class _Iter, class = enable_if_t<_Is_iterator_v<_Iter>>>
+    template <class _Iter, enable_if_t<_Is_iterator_v<_Iter>, int> = 0>
     basic_string& append(const _Iter _First, const _Iter _Last) { // append [_First, _Last), input iterators
         _Adl_verify_range(_First, _Last);
         const auto _UFirst = _Get_unwrapped(_First);
@@ -2833,7 +2833,7 @@ public:
         return append(_Right._Mypair._Myval2._Myptr(), _Right._Mypair._Myval2._Mysize);
     }
 
-    template <class _Iter, class = enable_if_t<_Is_iterator_v<_Iter>>>
+    template <class _Iter, enable_if_t<_Is_iterator_v<_Iter>, int> = 0>
     basic_string& append(const _Iter _First, const _Iter _Last) { // append [_First, _Last), input iterators {
         _Adl_verify_range(_First, _Last);
         const auto _UFirst = _Get_unwrapped(_First);
@@ -2910,7 +2910,7 @@ public:
     }
 
 #if _HAS_IF_CONSTEXPR
-    template <class _Iter, class = enable_if_t<_Is_iterator_v<_Iter>>>
+    template <class _Iter, enable_if_t<_Is_iterator_v<_Iter>, int> = 0>
     basic_string& assign(const _Iter _First, const _Iter _Last) {
         _Adl_verify_range(_First, _Last);
         const auto _UFirst = _Get_unwrapped(_First);
@@ -2946,7 +2946,7 @@ public:
         }
     }
 
-    template <class _Iter, class = enable_if_t<_Is_iterator_v<_Iter>>>
+    template <class _Iter, enable_if_t<_Is_iterator_v<_Iter>, int> = 0>
     basic_string& assign(const _Iter _First, const _Iter _Last) {
         _Adl_verify_range(_First, _Last);
         const auto _UFirst = _Get_unwrapped(_First);
@@ -3068,7 +3068,7 @@ public:
     }
 
 #if _HAS_IF_CONSTEXPR
-    template <class _Iter, class = enable_if_t<_Is_iterator_v<_Iter>>>
+    template <class _Iter, enable_if_t<_Is_iterator_v<_Iter>, int> = 0>
     iterator insert(const const_iterator _Where, const _Iter _First, const _Iter _Last) {
         // insert [_First, _Last) at _Where, input iterators
 #if _ITERATOR_DEBUG_LEVEL != 0
@@ -3099,7 +3099,7 @@ public:
         insert(_Off, _Right._Mypair._Myval2._Myptr(), _Right._Mypair._Myval2._Mysize);
     }
 
-    template <class _Iter, class = enable_if_t<_Is_iterator_v<_Iter>>>
+    template <class _Iter, enable_if_t<_Is_iterator_v<_Iter>, int> = 0>
     iterator insert(const const_iterator _Where, const _Iter _First, const _Iter _Last) {
         // insert [_First, _Last) at _Where, input iterators
 #if _ITERATOR_DEBUG_LEVEL != 0
@@ -3337,7 +3337,7 @@ public:
     }
 
 #if _HAS_IF_CONSTEXPR
-    template <class _Iter, class = enable_if_t<_Is_iterator_v<_Iter>>>
+    template <class _Iter, enable_if_t<_Is_iterator_v<_Iter>, int> = 0>
     basic_string& replace(
         const const_iterator _First, const const_iterator _Last, const _Iter _First2, const _Iter _Last2) {
         // replace [_First, _Last) with [_First2, _Last2), input iterators
@@ -3373,7 +3373,7 @@ public:
         return replace(_Off, _Length, _Right._Mypair._Myval2._Myptr(), _Right._Mypair._Myval2._Mysize);
     }
 
-    template <class _Iter, class = enable_if_t<_Is_iterator_v<_Iter>>>
+    template <class _Iter, enable_if_t<_Is_iterator_v<_Iter>, int> = 0>
     basic_string& replace(
         const const_iterator _First, const const_iterator _Last, const _Iter _First2, const _Iter _Last2) {
         // replace [_First, _Last) with [_First2, _Last2), input iterators

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -2263,7 +2263,7 @@ private:
     template <class _StringViewIsh>
     using _Is_string_view_ish =
         enable_if_t<conjunction_v<is_convertible<const _StringViewIsh&, basic_string_view<_Elem, _Traits>>,
-            negation<is_convertible<const _StringViewIsh&, const _Elem*>>>>;
+            negation<is_convertible<const _StringViewIsh&, const _Elem*>>>, int>;
 #endif // _HAS_CXX17
 
 public:
@@ -2437,7 +2437,7 @@ public:
     }
 
 #if _HAS_CXX17
-    template <class _StringViewIsh, class = _Is_string_view_ish<_StringViewIsh>>
+    template <class _StringViewIsh, _Is_string_view_ish<_StringViewIsh> = 0>
     explicit basic_string(const _StringViewIsh& _Right, const _Alloc& _Al = _Alloc())
         : _Mypair(_One_then_variadic_args_t(), _Al) {
         auto&& _Alproxy = _GET_PROXY_ALLOCATOR(_Alty, _Getal());
@@ -2447,7 +2447,7 @@ public:
         _Proxy._Release();
     }
 
-    template <class _StringViewIsh, class = _Is_string_view_ish<_StringViewIsh>>
+    template <class _StringViewIsh, _Is_string_view_ish<_StringViewIsh> = 0>
     basic_string(
         const _StringViewIsh& _Right, const size_type _Roff, const size_type _Count, const _Alloc& _Al = _Alloc())
         : _Mypair(_One_then_variadic_args_t(), _Al) { // construct from _Right [_Roff, _Roff + _Count) using _Al
@@ -2697,7 +2697,7 @@ public:
     }
 
 #if _HAS_CXX17
-    template <class _StringViewIsh, class = _Is_string_view_ish<_StringViewIsh>>
+    template <class _StringViewIsh, _Is_string_view_ish<_StringViewIsh> = 0>
     basic_string& operator=(const _StringViewIsh& _Right) {
         return assign(_Right);
     }
@@ -2720,7 +2720,7 @@ public:
     }
 
 #if _HAS_CXX17
-    template <class _StringViewIsh, class = _Is_string_view_ish<_StringViewIsh>>
+    template <class _StringViewIsh, _Is_string_view_ish<_StringViewIsh> = 0>
     basic_string& operator+=(const _StringViewIsh& _Right) {
         return append(_Right);
     }
@@ -2747,13 +2747,13 @@ public:
     }
 
 #if _HAS_CXX17
-    template <class _StringViewIsh, class = _Is_string_view_ish<_StringViewIsh>>
+    template <class _StringViewIsh, _Is_string_view_ish<_StringViewIsh> = 0>
     basic_string& append(const _StringViewIsh& _Right) {
         const basic_string_view<_Elem, _Traits> _As_view = _Right;
         return append(_As_view.data(), _Convert_size<size_type>(_As_view.size()));
     }
 
-    template <class _StringViewIsh, class = _Is_string_view_ish<_StringViewIsh>>
+    template <class _StringViewIsh, _Is_string_view_ish<_StringViewIsh> = 0>
     basic_string& append(const _StringViewIsh& _Right, const size_type _Roff, const size_type _Count = npos) {
         // append _Right [_Roff, _Roff + _Count)
         basic_string_view<_Elem, _Traits> _As_view = _Right;
@@ -2854,13 +2854,13 @@ public:
     }
 
 #if _HAS_CXX17
-    template <class _StringViewIsh, class = _Is_string_view_ish<_StringViewIsh>>
+    template <class _StringViewIsh, _Is_string_view_ish<_StringViewIsh> = 0>
     basic_string& assign(const _StringViewIsh& _Right) {
         const basic_string_view<_Elem, _Traits> _As_view = _Right;
         return assign(_As_view.data(), _Convert_size<size_type>(_As_view.size()));
     }
 
-    template <class _StringViewIsh, class = _Is_string_view_ish<_StringViewIsh>>
+    template <class _StringViewIsh, _Is_string_view_ish<_StringViewIsh> = 0>
     basic_string& assign(const _StringViewIsh& _Right, const size_type _Roff, const size_type _Count = npos) {
         // assign _Right [_Roff, _Roff + _Count)
         basic_string_view<_Elem, _Traits> _As_view = _Right;
@@ -2967,13 +2967,13 @@ public:
     }
 
 #if _HAS_CXX17
-    template <class _StringViewIsh, class = _Is_string_view_ish<_StringViewIsh>>
+    template <class _StringViewIsh, _Is_string_view_ish<_StringViewIsh> = 0>
     basic_string& insert(const size_type _Off, const _StringViewIsh& _Right) { // insert _Right at _Off
         const basic_string_view<_Elem, _Traits> _As_view = _Right;
         return insert(_Off, _As_view.data(), _Convert_size<size_type>(_As_view.size()));
     }
 
-    template <class _StringViewIsh, class = _Is_string_view_ish<_StringViewIsh>>
+    template <class _StringViewIsh, _Is_string_view_ish<_StringViewIsh> = 0>
     basic_string& insert(const size_type _Off, const _StringViewIsh& _Right, const size_type _Roff,
         const size_type _Count = npos) { // insert _Right [_Roff, _Roff + _Count) at _Off
         basic_string_view<_Elem, _Traits> _As_view = _Right;
@@ -3168,14 +3168,14 @@ public:
     }
 
 #if _HAS_CXX17
-    template <class _StringViewIsh, class = _Is_string_view_ish<_StringViewIsh>>
+    template <class _StringViewIsh, _Is_string_view_ish<_StringViewIsh> = 0>
     basic_string& replace(const size_type _Off, const size_type _N0, const _StringViewIsh& _Right) {
         // replace [_Off, _Off + _N0) with _Right
         basic_string_view<_Elem, _Traits> _As_view = _Right;
         return replace(_Off, _N0, _As_view.data(), _Convert_size<size_type>(_As_view.size()));
     }
 
-    template <class _StringViewIsh, class = _Is_string_view_ish<_StringViewIsh>>
+    template <class _StringViewIsh, _Is_string_view_ish<_StringViewIsh> = 0>
     basic_string& replace(const size_type _Off, const size_type _N0, const _StringViewIsh& _Right,
         const size_type _Roff, const size_type _Count = npos) {
         // replace [_Off, _Off + _N0) with _Right [_Roff, _Roff + _Count)
@@ -3292,7 +3292,7 @@ public:
     }
 
 #if _HAS_CXX17
-    template <class _StringViewIsh, class = _Is_string_view_ish<_StringViewIsh>>
+    template <class _StringViewIsh, _Is_string_view_ish<_StringViewIsh> = 0>
     basic_string& replace(const const_iterator _First, const const_iterator _Last, const _StringViewIsh& _Right) {
         // replace [_First, _Last) with _Right
         _Adl_verify_range(_First, _Last);
@@ -3760,7 +3760,7 @@ public:
     }
 
 #if _HAS_CXX17
-    template <class _StringViewIsh, class = _Is_string_view_ish<_StringViewIsh>>
+    template <class _StringViewIsh, _Is_string_view_ish<_StringViewIsh> = 0>
     _NODISCARD size_type find(const _StringViewIsh& _Right, const size_type _Off = 0) const {
         // look for _Right beginning at or after _Off
         basic_string_view<_Elem, _Traits> _As_view = _Right;
@@ -3796,7 +3796,7 @@ public:
     }
 
 #if _HAS_CXX17
-    template <class _StringViewIsh, class = _Is_string_view_ish<_StringViewIsh>>
+    template <class _StringViewIsh, _Is_string_view_ish<_StringViewIsh> = 0>
     _NODISCARD size_type rfind(const _StringViewIsh& _Right, const size_type _Off = npos) const {
         // look for _Right beginning before _Off
         basic_string_view<_Elem, _Traits> _As_view = _Right;
@@ -3832,7 +3832,7 @@ public:
     }
 
 #if _HAS_CXX17
-    template <class _StringViewIsh, class = _Is_string_view_ish<_StringViewIsh>>
+    template <class _StringViewIsh, _Is_string_view_ish<_StringViewIsh> = 0>
     _NODISCARD size_type find_first_of(const _StringViewIsh& _Right, const size_type _Off = 0) const {
         // look for one of _Right at or after _Off
         basic_string_view<_Elem, _Traits> _As_view = _Right;
@@ -3869,7 +3869,7 @@ public:
     }
 
 #if _HAS_CXX17
-    template <class _StringViewIsh, class = _Is_string_view_ish<_StringViewIsh>>
+    template <class _StringViewIsh, _Is_string_view_ish<_StringViewIsh> = 0>
     _NODISCARD size_type find_last_of(const _StringViewIsh& _Right, const size_type _Off = npos) const {
         // look for one of _Right before _Off
         basic_string_view<_Elem, _Traits> _As_view = _Right;
@@ -3906,7 +3906,7 @@ public:
     }
 
 #if _HAS_CXX17
-    template <class _StringViewIsh, class = _Is_string_view_ish<_StringViewIsh>>
+    template <class _StringViewIsh, _Is_string_view_ish<_StringViewIsh> = 0>
     _NODISCARD size_type find_first_not_of(const _StringViewIsh& _Right, const size_type _Off = 0) const {
         // look for none of _Right at or after _Off
         basic_string_view<_Elem, _Traits> _As_view = _Right;
@@ -3945,7 +3945,7 @@ public:
     }
 
 #if _HAS_CXX17
-    template <class _StringViewIsh, class = _Is_string_view_ish<_StringViewIsh>>
+    template <class _StringViewIsh, _Is_string_view_ish<_StringViewIsh> = 0>
     _NODISCARD size_type find_last_not_of(const _StringViewIsh& _Right, const size_type _Off = npos) const {
         // look for none of _Right before _Off
         basic_string_view<_Elem, _Traits> _As_view = _Right;
@@ -4004,14 +4004,14 @@ public:
     }
 
 #if _HAS_CXX17
-    template <class _StringViewIsh, class = _Is_string_view_ish<_StringViewIsh>>
+    template <class _StringViewIsh, _Is_string_view_ish<_StringViewIsh> = 0>
     _NODISCARD int compare(const _StringViewIsh& _Right) const { // compare [0, size()) with _Right
         basic_string_view<_Elem, _Traits> _As_view = _Right;
         return _Traits_compare<_Traits>(
             _Mypair._Myval2._Myptr(), _Mypair._Myval2._Mysize, _As_view.data(), _As_view.size());
     }
 
-    template <class _StringViewIsh, class = _Is_string_view_ish<_StringViewIsh>>
+    template <class _StringViewIsh, _Is_string_view_ish<_StringViewIsh> = 0>
     _NODISCARD int compare(const size_type _Off, const size_type _N0, const _StringViewIsh& _Right) const {
         // compare [_Off, _Off + _N0) with _Right
         basic_string_view<_Elem, _Traits> _As_view = _Right;
@@ -4020,7 +4020,7 @@ public:
             _As_view.data(), _As_view.size());
     }
 
-    template <class _StringViewIsh, class = _Is_string_view_ish<_StringViewIsh>>
+    template <class _StringViewIsh, _Is_string_view_ish<_StringViewIsh> = 0>
     _NODISCARD int compare(const size_type _Off, const size_type _N0, const _StringViewIsh& _Right,
         const size_type _Roff, const size_type _Count = npos) const {
         // compare [_Off, _Off + _N0) with _Right [_Roff, _Roff + _Count)

--- a/stl/inc/xtgmath.h
+++ b/stl/inc/xtgmath.h
@@ -27,13 +27,13 @@ using _Common_float_type_t = conditional_t<is_same_v<_Ty1, long double> || is_sa
 _STD_END
 
 // FUNCTION TEMPLATE frexp
-template <class _Ty, class = _STD enable_if_t<_STD is_integral_v<_Ty>>>
+template <class _Ty, _STD enable_if_t<_STD is_integral_v<_Ty>, int> = 0>
 double frexp(_Ty _Value, _Out_ int* const _Exp) noexcept /* strengthened */ {
     return _CSTD frexp(static_cast<double>(_Value), _Exp);
 }
 
 // FUNCTION TEMPLATE pow
-template <class _Ty1, class _Ty2, class = _STD enable_if_t<_STD is_arithmetic_v<_Ty1> && _STD is_arithmetic_v<_Ty2>>>
+template <class _Ty1, class _Ty2, _STD enable_if_t<_STD is_arithmetic_v<_Ty1> && _STD is_arithmetic_v<_Ty2>, int> = 0>
 _NODISCARD _STD _Common_float_type_t<_Ty1, _Ty2> pow(const _Ty1 _Left, const _Ty2 _Right) noexcept /* strengthened */ {
     using _Common = _STD _Common_float_type_t<_Ty1, _Ty2>;
     return _CSTD pow(static_cast<_Common>(_Left), static_cast<_Common>(_Right));
@@ -55,7 +55,7 @@ inline long double _Fma(long double _Left, long double _Middle, long double _Rig
 #endif // !_HAS_IF_CONSTEXPR
 
 template <class _Ty1, class _Ty2, class _Ty3,
-    class = _STD enable_if_t<_STD is_arithmetic_v<_Ty1> && _STD is_arithmetic_v<_Ty2> && _STD is_arithmetic_v<_Ty3>>>
+    _STD enable_if_t<_STD is_arithmetic_v<_Ty1> && _STD is_arithmetic_v<_Ty2> && _STD is_arithmetic_v<_Ty3>, int> = 0>
 _NODISCARD _STD _Common_float_type_t<_Ty1, _STD _Common_float_type_t<_Ty2, _Ty3>> fma(
     _Ty1 _Left, _Ty2 _Middle, _Ty3 _Right) noexcept /* strengthened */ {
     using _Common = _STD _Common_float_type_t<_Ty1, _STD _Common_float_type_t<_Ty2, _Ty3>>;
@@ -87,7 +87,7 @@ inline long double _Remquo(long double _Left, long double _Right, int* _Pquo) no
 }
 #endif // !_HAS_IF_CONSTEXPR
 
-template <class _Ty1, class _Ty2, class = _STD enable_if_t<_STD is_arithmetic_v<_Ty1> && _STD is_arithmetic_v<_Ty2>>>
+template <class _Ty1, class _Ty2, _STD enable_if_t<_STD is_arithmetic_v<_Ty1> && _STD is_arithmetic_v<_Ty2>, int> = 0>
 _STD _Common_float_type_t<_Ty1, _Ty2> remquo(_Ty1 _Left, _Ty2 _Right, int* _Pquo) noexcept /* strengthened */ {
     using _Common = _STD _Common_float_type_t<_Ty1, _Ty2>;
 #if _HAS_IF_CONSTEXPR
@@ -103,23 +103,23 @@ _STD _Common_float_type_t<_Ty1, _Ty2> remquo(_Ty1 _Left, _Ty2 _Right, int* _Pquo
 #endif // _HAS_IF_CONSTEXPR
 }
 
-#define _GENERIC_MATH1R(FUN, RET)                                           \
-    template <class _Ty, class = _STD enable_if_t<_STD is_integral_v<_Ty>>> \
-    _NODISCARD RET FUN(_Ty _Left) noexcept /* strengthened */ {             \
-        return _CSTD FUN(static_cast<double>(_Left));                       \
+#define _GENERIC_MATH1R(FUN, RET)                                            \
+    template <class _Ty, _STD enable_if_t<_STD is_integral_v<_Ty>, int> = 0> \
+    _NODISCARD RET FUN(_Ty _Left) noexcept /* strengthened */ {              \
+        return _CSTD FUN(static_cast<double>(_Left));                        \
     }
 
 #define _GENERIC_MATH1(FUN) _GENERIC_MATH1R(FUN, double)
 
 #define _GENERIC_MATH1X(FUN, ARG2)                                             \
-    template <class _Ty, class = _STD enable_if_t<_STD is_integral_v<_Ty>>>    \
+    template <class _Ty, _STD enable_if_t<_STD is_integral_v<_Ty>, int> = 0>   \
     _NODISCARD double FUN(_Ty _Left, ARG2 _Arg2) noexcept /* strengthened */ { \
         return _CSTD FUN(static_cast<double>(_Left), _Arg2);                   \
     }
 
 #define _GENERIC_MATH2(FUN)                                                                                     \
     template <class _Ty1, class _Ty2,                                                                           \
-        class = _STD enable_if_t<_STD is_arithmetic_v<_Ty1> && _STD is_arithmetic_v<_Ty2>>>                     \
+        _STD enable_if_t<_STD is_arithmetic_v<_Ty1> && _STD is_arithmetic_v<_Ty2>, int> = 0>                    \
     _NODISCARD _STD _Common_float_type_t<_Ty1, _Ty2> FUN(_Ty1 _Left, _Ty2 _Right) noexcept /* strengthened */ { \
         using _Common = _STD _Common_float_type_t<_Ty1, _Ty2>;                                                  \
         return _CSTD FUN(static_cast<_Common>(_Left), static_cast<_Common>(_Right));                            \

--- a/stl/inc/xtree
+++ b/stl/inc/xtree
@@ -1407,7 +1407,7 @@ private:
     }
 
 public:
-    template <class _Iter = iterator, class = enable_if_t<!is_same_v<_Iter, const_iterator>>>
+    template <class _Iter = iterator, enable_if_t<!is_same_v<_Iter, const_iterator>, int> = 0>
     iterator erase(iterator _Where) noexcept /* strengthened */ {
         const auto _Scary = _Get_scary();
 #if _ITERATOR_DEBUG_LEVEL == 2

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -4528,7 +4528,7 @@ _NODISCARD bool is_permutation(_FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2,
 }
 
 #if _ITERATOR_DEBUG_ARRAY_OVERLOADS
-template <class _FwdIt1, class _RightTy, size_t _RightSize, class _Pr, class = enable_if_t<!is_same_v<_RightTy*, _Pr>>>
+template <class _FwdIt1, class _RightTy, size_t _RightSize, class _Pr, enable_if_t<!is_same_v<_RightTy*, _Pr>, int> = 0>
 _NODISCARD bool is_permutation(_FwdIt1 _First1, _FwdIt1 _Last1, _RightTy (&_First2)[_RightSize], _Pr _Pred) {
     // test if [_First1, _Last1) == permuted [_First2, ...), using _Pred
     return _STD is_permutation(_First1, _Last1, _Array_iterator<_RightTy, _RightSize>(_First2), _Pass_fn(_Pred));


### PR DESCRIPTION
# Description
I had too much time at hand, so this addresses #187

I grepped for all occurences of `class = ` and fixed those that were followed by an `enable_if`

# Checklist

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] I understand README.md. I also understand that acceptance of
  community PRs will be delayed until the test and CI systems are online.
- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [ ] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before CI is online, leave this unchecked for
  initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository and
  the C++ Working Draft as a reference (and any other cited standards).
  If they were derived from a project that's already listed in NOTICE.txt,
  that's fine, but please mention it. If they were derived from any other
  project (including Boost and libc++, which are not yet listed in
  NOTICE.txt), you *must* mention it here, so we can determine whether the
  license is compatible and what else needs to be done.
