### PR TITLE
Use casts in _Atomic_reinterpret_as for integral and pointer types.

### DIFF
--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -238,9 +238,18 @@ template <class _Integral, class _Ty>
 _NODISCARD _Integral _Atomic_reinterpret_as(const _Ty& _Source) noexcept {
     // interprets _Source as the supplied integral type
     static_assert(is_integral_v<_Integral>, "Tried to reinterpret memory as non-integral");
-    _Integral _Result{}; // zero padding bits
-    _CSTD memcpy(&_Result, _STD addressof(_Source), sizeof(_Source));
-    return _Result;
+#if _HAS_IF_CONSTEXPR
+    if constexpr (is_integral_v<_Ty> && sizeof(_Integral) == sizeof(_Ty)) {
+        return static_cast<_Integral>(_Source);
+    } else if constexpr (is_pointer_v<_Ty> && sizeof(_Integral) == sizeof(_Ty)) {
+        return reinterpret_cast<_Integral>(_Source);
+    } else
+#endif // _HAS_IF_CONSTEXPR
+    {
+        _Integral _Result{}; // zero padding bits
+        _CSTD memcpy(&_Result, _STD addressof(_Source), sizeof(_Source));
+        return _Result;
+    }
 }
 
 // FUNCTION _Load_barrier


### PR DESCRIPTION
Resolves #85 / DevCom-706195

# Description

Casey applying the new atomic implementation fixed us breaking the strict aliasing rules, but the memcpy is causing a code size regression for non-`/Oi` customers. This change should restore code size for the most common uses of atomic, which are `atomic<integral>` and `atomic<pointer>`.

# Checklist

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] I understand README.md. I also understand that acceptance of
  community PRs will be delayed until the test and CI systems are online.
- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [x] The STL builds successfully and all tests have passed
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository and
  the C++ Working Draft as a reference (and any other cited standards).
  If they were derived from a project that's already listed in NOTICE.txt,
  that's fine, but please mention it. If they were derived from any other
  project (including Boost and libc++, which are not yet listed in
  NOTICE.txt), you *must* mention it here, so we can determine whether the
  license is compatible and what else needs to be done.
