### PR TITLE
Remove delay comment in PR template because we've been merging PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ yet hardened it against untrusted changes.
 conventions, Standard requirements, Microsoft-specific requirements, binary compatibility (ABI) requirements, and more.
 We're eager to begin accepting features and fixes from the community, but in addition to setting up a CI system, we need
 to write down all of the rules that are currently stored in our brains. (The ABI rules may be useful to other C++
-libraries.) Until that's in place, pull request reviews will be delayed.
+libraries.)
 
 * Issues: **In progress.** We're going to use GitHub issues to track all of the things that we need to work on. This
 includes C++20 features, [LWG issues][], conformance bugs, performance improvements, and other todos. There are

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -6,8 +6,6 @@
 
 If you're unsure about a box, leave it unchecked. A maintainer will help you.
 
-- [ ] I understand README.md. I also understand that acceptance of
-  community PRs will be delayed until the test and CI systems are online.
 - [ ] Identifiers in product code changes are properly `_Ugly` as per
   https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
 - [ ] The STL builds successfully and all tests have passed (must be manually

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -4,13 +4,15 @@
 
 # Checklist
 
+Be sure you've read README.md and understand the scope of this repo.
+
 If you're unsure about a box, leave it unchecked. A maintainer will help you.
 
 - [ ] Identifiers in product code changes are properly `_Ugly` as per
   https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
 - [ ] The STL builds successfully and all tests have passed (must be manually
-  verified by an STL maintainer before CI is online, leave this unchecked for
-  initial submission).
+  verified by an STL maintainer before automated testing is enabled on GitHub,
+  leave this unchecked for initial submission).
 - [ ] These changes introduce no known ABI breaks (adding members, renaming
   members, adding virtual functions, changing whether a type is an aggregate
   or trivially copyable, etc.).


### PR DESCRIPTION
# Checklist

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] I understand README.md. I also understand that acceptance of
  community PRs will be delayed until the test and CI systems are online.
- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [x] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before CI is online, leave this unchecked for
  initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository and
  the C++ Working Draft as a reference (and any other cited standards).
  If they were derived from a project that's already listed in NOTICE.txt,
  that's fine, but please mention it. If they were derived from any other
  project (including Boost and libc++, which are not yet listed in
  NOTICE.txt), you *must* mention it here, so we can determine whether the
  license is compatible and what else needs to be done.
