### PR TITLE
Implement P0738R2 istream_iterator cleanup

### DIFF
--- a/stl/inc/iterator
+++ b/stl/inc/iterator
@@ -134,22 +134,21 @@ public:
     using istream_type = basic_istream<_Elem, _Traits>;
 
     static_assert(conjunction_v<is_default_constructible<_Ty>, is_copy_constructible<_Ty>, is_copy_assignable<_Ty>>,
-        "The type T shall meet the Cpp17DefaultConstructible, Cpp17CopyConstructible, and Cpp17CopyAssignable "
-        "requirements. (Enabled unconditionally from CXX20)");
+        "istream_iterator<T> requires T to be default constructible, copy constructible, and copy assignable. (N4835 [istream.iterator]/2)");
 
-    constexpr istream_iterator() {};
+    constexpr istream_iterator() {}
 
     istream_iterator(istream_type& _Istr) : _Myistr(_STD addressof(_Istr)) {
         _Getval();
     }
 
     _NODISCARD const _Ty& operator*() const {
-        _STL_ASSERT(_Myistr, "The stored stream pointer in_stream must be non null");
+        _STL_ASSERT(_Myistr, "The stored stream pointer in_stream must be non-null");
         return _Myval;
     }
 
     _NODISCARD const _Ty* operator->() const {
-        _STL_ASSERT(_Myistr, "The stored stream pointer in_stream must be non null");
+        _STL_ASSERT(_Myistr, "The stored stream pointer in_stream must be non-null");
         return _STD addressof(_Myval);
     }
 
@@ -168,10 +167,10 @@ public:
         return _Myistr == _Right._Myistr;
     }
 
-protected:
+private:
     void _Getval() { // get a _Ty value if possible
-        _STL_ASSERT(_Myistr, "The stored stream pointer in_stream must be non null");
-        if (_Myistr && !(*_Myistr >> _Myval)) {
+        _STL_ASSERT(_Myistr, "The stored stream pointer in_stream must be non-null");
+        if (!(*_Myistr >> _Myval)) {
             _Myistr = nullptr;
         }
     }

--- a/stl/inc/iterator
+++ b/stl/inc/iterator
@@ -133,17 +133,23 @@ public:
     using traits_type  = _Traits;
     using istream_type = basic_istream<_Elem, _Traits>;
 
-    constexpr istream_iterator() : _Myistr(nullptr), _Myval() {}
+    static_assert(conjunction_v<is_default_constructible<_Ty>, is_copy_constructible<_Ty>, is_copy_assignable<_Ty>>,
+        "The type T shall meet the Cpp17DefaultConstructible, Cpp17CopyConstructible, and Cpp17CopyAssignable "
+        "requirements. (Enabled unconditionally from CXX20)");
+
+    constexpr istream_iterator() {};
 
     istream_iterator(istream_type& _Istr) : _Myistr(_STD addressof(_Istr)) {
         _Getval();
     }
 
     _NODISCARD const _Ty& operator*() const {
+        _STL_ASSERT(_Myistr, "The stored stream pointer in_stream must be non null");
         return _Myval;
     }
 
     _NODISCARD const _Ty* operator->() const {
+        _STL_ASSERT(_Myistr, "The stored stream pointer in_stream must be non null");
         return _STD addressof(_Myval);
     }
 
@@ -164,13 +170,14 @@ public:
 
 protected:
     void _Getval() { // get a _Ty value if possible
+        _STL_ASSERT(_Myistr, "The stored stream pointer in_stream must be non null");
         if (_Myistr && !(*_Myistr >> _Myval)) {
             _Myistr = nullptr;
         }
     }
 
-    istream_type* _Myistr; // pointer to input stream
-    _Ty _Myval; // lookahead value (valid if _Myistr is not null)
+    istream_type* _Myistr{nullptr}; // pointer to input stream
+    _Ty _Myval{}; // lookahead value (valid if _Myistr is not null)
 };
 
 template <class _Ty, class _Elem, class _Traits, class _Diff>

--- a/stl/inc/iterator
+++ b/stl/inc/iterator
@@ -134,7 +134,8 @@ public:
     using istream_type = basic_istream<_Elem, _Traits>;
 
     static_assert(conjunction_v<is_default_constructible<_Ty>, is_copy_constructible<_Ty>, is_copy_assignable<_Ty>>,
-        "istream_iterator<T> requires T to be default constructible, copy constructible, and copy assignable. (N4835 [istream.iterator]/2)");
+        "istream_iterator<T> requires T to be default constructible, copy constructible, and copy assignable. "
+        "(N4835 [istream.iterator]/2)");
 
     constexpr istream_iterator() {}
 

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -35,7 +35,6 @@
 // P0646R1 list/forward_list remove()/remove_if()/unique() Return size_type
 // P0653R2 to_address()
 // P0655R1 visit<R>()
-// P0738R2 istream_iterator Cleanup. The minstrel know it as "I Stream, You Stream, We All Stream for istream_iterator"
 // P0758R1 is_nothrow_convertible
 // P0768R1 Library Support For The Spaceship Comparison Operator <=>
 //     (partially implemented)

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -35,6 +35,7 @@
 // P0646R1 list/forward_list remove()/remove_if()/unique() Return size_type
 // P0653R2 to_address()
 // P0655R1 visit<R>()
+// P0738R2 istream_iterator Cleanup. The minstrel know it as "I Stream, You Stream, We All Stream for istream_iterator"
 // P0758R1 is_nothrow_convertible
 // P0768R1 Library Support For The Spaceship Comparison Operator <=>
 //     (partially implemented)
@@ -159,6 +160,7 @@
 // P0548R1 Tweaking common_type And duration
 // P0558R1 Resolving atomic<T> Named Base Class Inconsistencies
 // P0599R1 noexcept hash
+// P0738R2 istream_iterator Cleanup
 // P0771R1 noexcept For std::function's Move Constructor
 // P0777R1 Avoiding Unnecessary decay
 // P0809R0 Comparing Unordered Containers


### PR DESCRIPTION
# Description

This addresses #35 implementing P0738R2

I went for the ugly solution with an `_HAS_CXX20` ifdef. The cleaner solution would certainly be to utilize member initialization and simply default the default constructor. However I assume that this is not a backward compatible change.

# Checklist

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [ ] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository and
  the C++ Working Draft as a reference (and any other cited standards).
  If they were derived from a project that's already listed in NOTICE.txt,
  that's fine, but please mention it. If they were derived from any other
  project (including Boost and libc++, which are not yet listed in
  NOTICE.txt), you *must* mention it here, so we can determine whether the
  license is compatible and what else needs to be done.
