### PR TITLE
concept floating_point missing??

### DIFF
--- a/stl/inc/concepts
+++ b/stl/inc/concepts
@@ -89,6 +89,10 @@ concept signed_integral = integral<_Ty> && _Ty(-1) < _Ty(0);
 template <class _Ty>
 concept unsigned_integral = integral<_Ty> && !signed_integral<_Ty>;
 
+// CONCEPT floating_point
+template <class _Ty>
+concept floating_point = is_floating_point_v<_Ty>;
+
 // CONCEPT assignable_from
 template <class _LTy, class _RTy>
 concept assignable_from = is_lvalue_reference_v<_LTy>


### PR DESCRIPTION
# Description
https://github.com/gcc-mirror/gcc/blob/master/libstdc%2B%2B-v3/include/std/concepts

I have checked the same file in GCC. libstdc++ does have std::floating_point while VC misses this.


# Checklist

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [ ] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [ ] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [ ] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [ ] These changes were written from scratch using only this repository and
  the C++ Working Draft as a reference (and any other cited standards).
  If they were derived from a project that's already listed in NOTICE.txt,
  that's fine, but please mention it. If they were derived from any other
  project (including Boost and libc++, which are not yet listed in
  NOTICE.txt), you *must* mention it here, so we can determine whether the
  license is compatible and what else needs to be done.
