### PR TITLE
Use consistent phrasing of required standard mode

### DIFF
--- a/stl/inc/any
+++ b/stl/inc/any
@@ -9,7 +9,9 @@
 #include <yvals_core.h>
 #if _STL_COMPILER_PREPROCESSOR
 
-#if _HAS_CXX17
+#if !_HAS_CXX17
+#pragma message("The contents of <any> are only available with C++17 or later.")
+#else // ^^^ !_HAS_CXX17 / _HAS_CXX17 vvv
 #include <initializer_list>
 #include <type_traits>
 #include <typeinfo>
@@ -441,8 +443,6 @@ _STD_END
 _STL_RESTORE_CLANG_WARNINGS
 #pragma warning(pop)
 #pragma pack(pop)
-#else // ^^^ _HAS_CXX17 / !_HAS_CXX17 vvv
-#pragma message("class any is only available with C++17 or later.")
 #endif // _HAS_CXX17
 
 #endif // _STL_COMPILER_PREPROCESSOR

--- a/stl/inc/any
+++ b/stl/inc/any
@@ -10,7 +10,7 @@
 #if _STL_COMPILER_PREPROCESSOR
 
 #if !_HAS_CXX17
-#pragma message("The contents of <any> are only available with C++17 or later.")
+#pragma message("The contents of <any> are available only with C++17 or later.")
 #else // ^^^ !_HAS_CXX17 / _HAS_CXX17 vvv
 #include <initializer_list>
 #include <type_traits>

--- a/stl/inc/charconv
+++ b/stl/inc/charconv
@@ -10,7 +10,7 @@
 #if _STL_COMPILER_PREPROCESSOR
 
 #if !_HAS_CXX17
-#pragma message("The contents of <charconv> are only available with C++17 or later.")
+#pragma message("The contents of <charconv> are available only with C++17 or later.")
 #else // ^^^ !_HAS_CXX17 / _HAS_CXX17 vvv
 #include <float.h>
 #include <intrin0.h>

--- a/stl/inc/charconv
+++ b/stl/inc/charconv
@@ -9,7 +9,9 @@
 #include <yvals.h>
 #if _STL_COMPILER_PREPROCESSOR
 
-#if _HAS_CXX17
+#if !_HAS_CXX17
+#pragma message("The contents of <charconv> are only available with C++17 or later.")
+#else // ^^^ !_HAS_CXX17 / _HAS_CXX17 vvv
 #include <float.h>
 #include <intrin0.h>
 #include <string.h>
@@ -3097,8 +3099,6 @@ _STD_END
 _STL_RESTORE_CLANG_WARNINGS
 #pragma warning(pop)
 #pragma pack(pop)
-#else // ^^^ _HAS_CXX17 / !_HAS_CXX17 vvv
-#pragma message("The contents of <charconv> are only available with C++17 or later.")
 #endif // _HAS_CXX17
 #endif // _STL_COMPILER_PREPROCESSOR
 #endif // _CHARCONV_

--- a/stl/inc/compare
+++ b/stl/inc/compare
@@ -9,7 +9,9 @@
 #include <yvals_core.h>
 #if _STL_COMPILER_PREPROCESSOR
 
-#if _HAS_CXX20
+#if !_HAS_CXX20
+#pragma message("The contents of <compare> are only available with C++20 or later.")
+#else // ^^^ !_HAS_CXX20 / _HAS_CXX20 vvv
 #include <xtr1common>
 
 #pragma pack(push, _CRT_PACKING)
@@ -475,8 +477,6 @@ _STD_END
 _STL_RESTORE_CLANG_WARNINGS
 #pragma warning(pop)
 #pragma pack(pop)
-#else // ^^^ C++20 / not C++20 vvv
-#pragma message("The contents of <compare> are only available with C++20 or later.")
 #endif // _HAS_CXX20
 
 #endif // _STL_COMPILER_PREPROCESSOR

--- a/stl/inc/compare
+++ b/stl/inc/compare
@@ -10,7 +10,7 @@
 #if _STL_COMPILER_PREPROCESSOR
 
 #if !_HAS_CXX20
-#pragma message("The contents of <compare> are only available with C++20 or later.")
+#pragma message("The contents of <compare> are available only with C++20 or later.")
 #else // ^^^ !_HAS_CXX20 / _HAS_CXX20 vvv
 #include <xtr1common>
 

--- a/stl/inc/concepts
+++ b/stl/inc/concepts
@@ -9,7 +9,9 @@
 #include <yvals_core.h>
 #if _STL_COMPILER_PREPROCESSOR
 
-#ifdef __cpp_lib_concepts
+#ifndef __cpp_lib_concepts
+#pragma message("The contents of <concepts> are only available with C++20 or later.")
+#else // ^^^ !__cpp_lib_concepts / __cpp_lib_concepts vvv
 #if defined(__clang__) && !defined(_SILENCE_CLANG_CONCEPTS_MESSAGE)
 #error Despite the presence of some Clang-related bits, this header currently does not support Clang. \
 You can define _SILENCE_CLANG_CONCEPTS_MESSAGE to silence this message and acknowledge that this is unsupported.
@@ -364,8 +366,6 @@ _STD_END
 _STL_RESTORE_CLANG_WARNINGS
 #pragma warning(pop)
 #pragma pack(pop)
-#else // ^^^ <concepts> supported / <concepts> not supported vvv
-#pragma message("The contents of <concepts> are only available with C++20 concepts support.")
 #endif // __cpp_lib_concepts
 #endif // _STL_COMPILER_PREPROCESSOR
 #endif // _CONCEPTS_

--- a/stl/inc/concepts
+++ b/stl/inc/concepts
@@ -11,7 +11,7 @@
 
 #ifndef __cpp_lib_concepts
 #pragma message("The contents of <concepts> are only available with C++20 concepts support.")
-#else // ^^^ !__cpp_lib_concepts / __cpp_lib_concepts vvv
+#else // ^^^ !defined(__cpp_lib_concepts) / defined(__cpp_lib_concepts) vvv
 #if defined(__clang__) && !defined(_SILENCE_CLANG_CONCEPTS_MESSAGE)
 #error Despite the presence of some Clang-related bits, this header currently does not support Clang. \
 You can define _SILENCE_CLANG_CONCEPTS_MESSAGE to silence this message and acknowledge that this is unsupported.

--- a/stl/inc/concepts
+++ b/stl/inc/concepts
@@ -10,7 +10,7 @@
 #if _STL_COMPILER_PREPROCESSOR
 
 #ifndef __cpp_lib_concepts
-#pragma message("The contents of <concepts> are only available with C++20 concepts support.")
+#pragma message("The contents of <concepts> are available only with C++20 concepts support.")
 #else // ^^^ !defined(__cpp_lib_concepts) / defined(__cpp_lib_concepts) vvv
 #if defined(__clang__) && !defined(_SILENCE_CLANG_CONCEPTS_MESSAGE)
 #error Despite the presence of some Clang-related bits, this header currently does not support Clang. \

--- a/stl/inc/concepts
+++ b/stl/inc/concepts
@@ -10,7 +10,7 @@
 #if _STL_COMPILER_PREPROCESSOR
 
 #ifndef __cpp_lib_concepts
-#pragma message("The contents of <concepts> are only available with C++20 or later.")
+#pragma message("The contents of <concepts> are only available with C++20 concepts support.")
 #else // ^^^ !__cpp_lib_concepts / __cpp_lib_concepts vvv
 #if defined(__clang__) && !defined(_SILENCE_CLANG_CONCEPTS_MESSAGE)
 #error Despite the presence of some Clang-related bits, this header currently does not support Clang. \

--- a/stl/inc/execution
+++ b/stl/inc/execution
@@ -10,7 +10,7 @@
 #if _STL_COMPILER_PREPROCESSOR
 
 #if !_HAS_CXX17
-#pragma message("The contents of <execution> are only available with C++17 or later.")
+#pragma message("The contents of <execution> are available only with C++17 or later.")
 #else // ^^^ !_HAS_CXX17 / _HAS_CXX17 vvv
 #include <algorithm>
 #include <atomic>

--- a/stl/inc/execution
+++ b/stl/inc/execution
@@ -2841,10 +2841,10 @@ inline size_t _Get_stable_sort_tree_height(const size_t _Count, const size_t _Hw
     // go to the next smaller power of 2
     const auto _Count_max_tree_height = _Log_count_max_chunks & ~static_cast<size_t>(1);
 
-    const auto _Ideal_chunks       = _Hw_threads * _Oversubscription_multiplier;
-    const size_t _Log_ideal_chunks = _Floor_of_log_2(_Ideal_chunks);
+    const auto _Ideal_chunks           = _Hw_threads * _Oversubscription_multiplier;
+    const size_t _Log_ideal_chunks     = _Floor_of_log_2(_Ideal_chunks);
 #ifdef _WIN64
-    const size_t _Max_tree_height = 62; // to avoid ptrdiff_t overflow
+    const size_t _Max_tree_height      = 62; // to avoid ptrdiff_t overflow
 #else // ^^^ _WIN64 ^^^ // vvv !_WIN64 vvv
     const size_t _Max_tree_height = 30;
 #endif // _WIN64

--- a/stl/inc/execution
+++ b/stl/inc/execution
@@ -9,7 +9,9 @@
 #include <yvals.h>
 #if _STL_COMPILER_PREPROCESSOR
 
-#if _HAS_CXX17
+#if !_HAS_CXX17
+#pragma message("The contents of <execution> are only available with C++17 or later.")
+#else // ^^^ !_HAS_CXX17 / _HAS_CXX17 vvv
 #include <algorithm>
 #include <atomic>
 #include <memory>
@@ -5137,8 +5139,6 @@ _STD_END
 _STL_RESTORE_CLANG_WARNINGS
 #pragma warning(pop)
 #pragma pack(pop)
-#else // ^^^ _HAS_CXX17 / !_HAS_CXX17 vvv
-#pragma message("Parallel algorithms are only available with C++17 or later.")
 #endif // _HAS_CXX17
 #endif // _STL_COMPILER_PREPROCESSOR
 #endif // _EXECUTION_

--- a/stl/inc/filesystem
+++ b/stl/inc/filesystem
@@ -10,7 +10,7 @@
 #if _STL_COMPILER_PREPROCESSOR
 
 #if !_HAS_CXX17
-#pragma message("The contents of <filesystem> are only available with C++17 or later.")
+#pragma message("The contents of <filesystem> are available only with C++17 or later.")
 #else // ^^^ !_HAS_CXX17 / _HAS_CXX17 vvv
 #include <algorithm>
 #include <chrono>

--- a/stl/inc/filesystem
+++ b/stl/inc/filesystem
@@ -9,7 +9,9 @@
 #include <yvals_core.h>
 #if _STL_COMPILER_PREPROCESSOR
 
-#if _HAS_CXX17
+#if !_HAS_CXX17
+#pragma message("The contents of <filesystem> are only available with C++17 or later.")
+#else // ^^^ !_HAS_CXX17 / _HAS_CXX17 vvv
 #include <algorithm>
 #include <chrono>
 #include <cwchar>
@@ -4330,8 +4332,6 @@ _STD_END
 _STL_RESTORE_CLANG_WARNINGS
 #pragma warning(pop)
 #pragma pack(pop)
-#else // ^^^ _HAS_CXX17 / !_HAS_CXX17 vvv
-#pragma message("The contents of <filesystem> are only available with C++17 or later.")
 #endif // _HAS_CXX17
 #endif // _STL_COMPILER_PREPROCESSOR
 #endif // _FILESYSTEM_

--- a/stl/inc/memory_resource
+++ b/stl/inc/memory_resource
@@ -9,7 +9,9 @@
 #include <yvals.h>
 #if _STL_COMPILER_PREPROCESSOR
 
-#if _HAS_CXX17
+#if !_HAS_CXX17
+#pragma message("The contents of <memory_resource> are only available with C++17 or later.")
+#else // ^^^ !_HAS_CXX17 / _HAS_CXX17 vvv
 #include <vector>
 #include <xbit_ops.h>
 #include <xpolymorphic_allocator.h>
@@ -755,8 +757,6 @@ _STD_END
 _STL_RESTORE_CLANG_WARNINGS
 #pragma warning(pop)
 #pragma pack(pop)
-#else // ^^^ _HAS_CXX17 / !_HAS_CXX17 vvv
-#pragma message("The contents of <memory_resource> are only available with C++17 or later.")
 #endif // _HAS_CXX17
 #endif // _STL_COMPILER_PREPROCESSOR
 #endif // _MEMORY_RESOURCE_

--- a/stl/inc/memory_resource
+++ b/stl/inc/memory_resource
@@ -10,7 +10,7 @@
 #if _STL_COMPILER_PREPROCESSOR
 
 #if !_HAS_CXX17
-#pragma message("The contents of <memory_resource> are only available with C++17 or later.")
+#pragma message("The contents of <memory_resource> are available only with C++17 or later.")
 #else // ^^^ !_HAS_CXX17 / _HAS_CXX17 vvv
 #include <vector>
 #include <xbit_ops.h>

--- a/stl/inc/optional
+++ b/stl/inc/optional
@@ -8,7 +8,9 @@
 #define _OPTIONAL_
 #include <yvals.h>
 #if _STL_COMPILER_PREPROCESSOR
-#if _HAS_CXX17
+#if !_HAS_CXX17
+#pragma message("The contents of <optional> are only available with C++17 or later.")
+#else // ^^^ !_HAS_CXX17 / _HAS_CXX17 vvv
 #include <exception>
 #include <initializer_list>
 #include <type_traits>
@@ -637,8 +639,6 @@ _STD_END
 _STL_RESTORE_CLANG_WARNINGS
 #pragma warning(pop)
 #pragma pack(pop)
-#else // ^^^ _HAS_CXX17 / !_HAS_CXX17 vvv
-#pragma message("class template optional is only available with C++17 or later.")
 #endif // _HAS_CXX17
 #endif // _STL_COMPILER_PREPROCESSOR
 #endif // _OPTIONAL_

--- a/stl/inc/optional
+++ b/stl/inc/optional
@@ -9,7 +9,7 @@
 #include <yvals.h>
 #if _STL_COMPILER_PREPROCESSOR
 #if !_HAS_CXX17
-#pragma message("The contents of <optional> are only available with C++17 or later.")
+#pragma message("The contents of <optional> are available only with C++17 or later.")
 #else // ^^^ !_HAS_CXX17 / _HAS_CXX17 vvv
 #include <exception>
 #include <initializer_list>

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -8,7 +8,9 @@
 #define _RANGES_
 #include <yvals_core.h>
 #if _STL_COMPILER_PREPROCESSOR
-#ifdef __cpp_lib_concepts
+#ifndef __cpp_lib_concepts
+#pragma message("The contents of <ranges> are only available with C++20 or later.")
+#else // ^^^ !__cpp_lib_concepts / __cpp_lib_concepts vvv
 #include <iterator>
 
 #pragma pack(push, _CRT_PACKING)
@@ -34,8 +36,6 @@ _STD_END
 _STL_RESTORE_CLANG_WARNINGS
 #pragma warning(pop)
 #pragma pack(pop)
-#else // ^^^ Concepts support / no Concepts vvv
-#pragma message("The contents of <ranges> are only available with C++20 concepts support.")
 #endif // __cpp_lib_concepts
 #endif // _STL_COMPILER_PREPROCESSOR
 #endif // _RANGES_

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -10,7 +10,7 @@
 #if _STL_COMPILER_PREPROCESSOR
 #ifndef __cpp_lib_concepts
 #pragma message("The contents of <ranges> are only available with C++20 concepts support.")
-#else // ^^^ !__cpp_lib_concepts / __cpp_lib_concepts vvv
+#else // ^^^ !defined(__cpp_lib_concepts) / defined(__cpp_lib_concepts) vvv
 #include <iterator>
 
 #pragma pack(push, _CRT_PACKING)

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -9,7 +9,7 @@
 #include <yvals_core.h>
 #if _STL_COMPILER_PREPROCESSOR
 #ifndef __cpp_lib_concepts
-#pragma message("The contents of <ranges> are only available with C++20 or later.")
+#pragma message("The contents of <ranges> are only available with C++20 concepts support.")
 #else // ^^^ !__cpp_lib_concepts / __cpp_lib_concepts vvv
 #include <iterator>
 

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -9,7 +9,7 @@
 #include <yvals_core.h>
 #if _STL_COMPILER_PREPROCESSOR
 #ifndef __cpp_lib_concepts
-#pragma message("The contents of <ranges> are only available with C++20 concepts support.")
+#pragma message("The contents of <ranges> are available only with C++20 concepts support.")
 #else // ^^^ !defined(__cpp_lib_concepts) / defined(__cpp_lib_concepts) vvv
 #include <iterator>
 

--- a/stl/inc/string_view
+++ b/stl/inc/string_view
@@ -10,7 +10,7 @@
 #if _STL_COMPILER_PREPROCESSOR
 
 #if !_HAS_CXX17
-#pragma message("The contents of <string_view> are only available with C++17 or later.")
+#pragma message("The contents of <string_view> are available only with C++17 or later.")
 #else // ^^^ !_HAS_CXX17 / _HAS_CXX17 vvv
 #include <xstring>
 #endif // _HAS_CXX17

--- a/stl/inc/string_view
+++ b/stl/inc/string_view
@@ -9,10 +9,10 @@
 #include <yvals.h>
 #if _STL_COMPILER_PREPROCESSOR
 
-#if _HAS_CXX17
+#if !_HAS_CXX17
+#pragma message("The contents of <string_view> are only available with C++17 or later.")
+#else // ^^^ !_HAS_CXX17 / _HAS_CXX17 vvv
 #include <xstring>
-#else // ^^^ _HAS_CXX17 / !_HAS_CXX17 vvv
-#pragma message("string_view is only available with C++17 or later.")
 #endif // _HAS_CXX17
 #endif // _STL_COMPILER_PREPROCESSOR
 #endif // _STRING_VIEW_

--- a/stl/inc/variant
+++ b/stl/inc/variant
@@ -1158,7 +1158,7 @@ public:
                             (void) _That_ref; // TRANSITION, VSO-486357
                             constexpr size_t _That_idx = decltype(_That_ref)::_Idx;
 #ifdef __EDG__ // TRANSITION, VSO-657455
-                            constexpr size_t _My_idx = decltype(_My_ref)::_Idx + 0 * _That_idx;
+                            constexpr size_t _My_idx   = decltype(_My_ref)::_Idx + 0 * _That_idx;
 #else // ^^^ workaround ^^^ / vvv no workaround vvv
                             constexpr size_t _My_idx = decltype(_My_ref)::_Idx;
 #endif // TRANSITION, VSO-657455

--- a/stl/inc/variant
+++ b/stl/inc/variant
@@ -9,7 +9,9 @@
 #include <yvals.h>
 #if _STL_COMPILER_PREPROCESSOR
 
-#if _HAS_CXX17
+#if !_HAS_CXX17
+#pragma message("The contents of <variant> are only available with C++17 or later.")
+#else // ^^^ !_HAS_CXX17 / _HAS_CXX17 vvv
 #include <exception>
 #include <initializer_list>
 #include <type_traits>
@@ -1749,9 +1751,6 @@ _STD_END
 _STL_RESTORE_CLANG_WARNINGS
 #pragma warning(pop)
 #pragma pack(pop)
-
-#else // ^^^ _HAS_CXX17 ^^^ / vvv !_HAS_CXX17 vvv
-#pragma message("class template variant is only available with C++17 or later.")
 #endif // _HAS_CXX17
 #endif // _STL_COMPILER_PREPROCESSOR
 #endif // _VARIANT_

--- a/stl/inc/variant
+++ b/stl/inc/variant
@@ -10,7 +10,7 @@
 #if _STL_COMPILER_PREPROCESSOR
 
 #if !_HAS_CXX17
-#pragma message("The contents of <variant> are only available with C++17 or later.")
+#pragma message("The contents of <variant> are available only with C++17 or later.")
 #else // ^^^ !_HAS_CXX17 / _HAS_CXX17 vvv
 #include <exception>
 #include <initializer_list>


### PR DESCRIPTION
# Description
 Hopefully resolves #250 as it seemed like you were all in agreement.

* Used the phrase "The contents of `<meow>` are ~only available~ available only with C++meow or later."
* Changed the `#else` comments to use the name of the macro 
* Inverted the condition so the message is at the top of the file.
* Removed a newline in `<variant>` as none of the other headers had one there.

# Checklist

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [ ] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository and
  the C++ Working Draft as a reference (and any other cited standards).
  If they were derived from a project that's already listed in NOTICE.txt,
  that's fine, but please mention it. If they were derived from any other
  project (including Boost and libc++, which are not yet listed in
  NOTICE.txt), you *must* mention it here, so we can determine whether the
  license is compatible and what else needs to be done.
