### PR TITLE
Make enforce-clang-format.cmd also run `git diff`.

### DIFF
--- a/azure-devops/enforce-clang-format.cmd
+++ b/azure-devops/enforce-clang-format.cmd
@@ -9,6 +9,8 @@ tools/inc ^
 tools/jobify/jobify.cpp ^
 tools/parallelize/parallelize.cpp ^
 tools/validate/validate.cpp
-@echo If your build fails here, you need to format the following files with
+@echo If your build fails here, you need to format the following files with:
 @clang-format.exe --version
 @git status --porcelain stl tools 1>&2
+@echo clang-format will produce the following diff:
+@git diff stl tools 1>&2

--- a/azure-devops/run_build.yml
+++ b/azure-devops/run_build.yml
@@ -1,7 +1,5 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-parameters:
-  targetPlatform: 'x64'
 
 jobs:
 - job: ${{ parameters.targetPlatform }}

--- a/azure-devops/run_build.yml
+++ b/azure-devops/run_build.yml
@@ -23,22 +23,26 @@ jobs:
         filePath: $(Build.SourcesDirectory)/azure-devops/install_msvc_preview.ps1
     - task: CacheBeta@0
       displayName: Cache vcpkg
+      timeoutInMinutes: 5
       inputs:
         key: $(vcpkgResponseFile) | $(Build.SourcesDirectory)/.git/modules/vcpkg/HEAD
         path: '$(vcpkgLocation)'
     - task: run-vcpkg@0
       displayName: 'Run vcpkg to Install boost-build'
+      timeoutInMinutes: 5
       inputs:
         vcpkgArguments: 'boost-build:x86-windows'
         vcpkgDirectory: '$(vcpkgLocation)'
     - task: run-vcpkg@0
       displayName: 'Run vcpkg'
+      timeoutInMinutes: 5
       inputs:
         vcpkgArguments: '@$(vcpkgResponseFile)'
         vcpkgDirectory: '$(vcpkgLocation)'
         vcpkgTriplet: ${{ parameters.targetPlatform }}-windows
     - task: run-cmake@0
       displayName: 'Build Support Tools'
+      timeoutInMinutes: 5
       condition: eq('${{ parameters.targetPlatform }}', 'x64')
       inputs:
         cmakeListsTxtPath: 'tools/CMakeSettings.json'
@@ -47,6 +51,7 @@ jobs:
         buildDirectory: $(Build.ArtifactStagingDirectory)/tools
     - task: BatchScript@1
       displayName: 'Enforce clang-format'
+      timeoutInMinutes: 5
       condition: eq('${{ parameters.targetPlatform }}', 'x64')
       inputs:
         filename: 'azure-devops/enforce-clang-format.cmd'
@@ -54,6 +59,7 @@ jobs:
         arguments: '$(Build.ArtifactStagingDirectory)/tools/parallelize/parallelize.exe'
     - task: BatchScript@1
       displayName: 'Validate Files'
+      timeoutInMinutes: 5
       condition: eq('${{ parameters.targetPlatform }}', 'x64')
       inputs:
         filename: 'azure-devops/validate-files.cmd'
@@ -61,6 +67,7 @@ jobs:
         arguments: '$(Build.ArtifactStagingDirectory)/tools/validate/validate.exe'
     - task: run-cmake@0
       displayName: 'Build the STL'
+      timeoutInMinutes: 5
       inputs:
         cmakeListsTxtPath: 'CMakeSettings.json'
         useVcpkgToolchainFile: true

--- a/azure-devops/run_build.yml
+++ b/azure-devops/run_build.yml
@@ -16,6 +16,7 @@ jobs:
       submodules: recursive
     - task: PowerShell@2
       displayName: 'Install MSVC Preview'
+      timeoutInMinutes: 30
       # on "Hosted" agents only:
       condition: or(contains(variables['Agent.Name'], 'Azure Pipelines'), contains(variables['Agent.Name'], 'Hosted Agent'))
       inputs:
@@ -23,26 +24,26 @@ jobs:
         filePath: $(Build.SourcesDirectory)/azure-devops/install_msvc_preview.ps1
     - task: CacheBeta@0
       displayName: Cache vcpkg
-      timeoutInMinutes: 5
+      timeoutInMinutes: 10
       inputs:
         key: $(vcpkgResponseFile) | $(Build.SourcesDirectory)/.git/modules/vcpkg/HEAD
         path: '$(vcpkgLocation)'
     - task: run-vcpkg@0
       displayName: 'Run vcpkg to Install boost-build'
-      timeoutInMinutes: 5
+      timeoutInMinutes: 10
       inputs:
         vcpkgArguments: 'boost-build:x86-windows'
         vcpkgDirectory: '$(vcpkgLocation)'
     - task: run-vcpkg@0
       displayName: 'Run vcpkg'
-      timeoutInMinutes: 5
+      timeoutInMinutes: 10
       inputs:
         vcpkgArguments: '@$(vcpkgResponseFile)'
         vcpkgDirectory: '$(vcpkgLocation)'
         vcpkgTriplet: ${{ parameters.targetPlatform }}-windows
     - task: run-cmake@0
       displayName: 'Build Support Tools'
-      timeoutInMinutes: 5
+      timeoutInMinutes: 2
       condition: eq('${{ parameters.targetPlatform }}', 'x64')
       inputs:
         cmakeListsTxtPath: 'tools/CMakeSettings.json'
@@ -59,7 +60,7 @@ jobs:
         arguments: '$(Build.ArtifactStagingDirectory)/tools/parallelize/parallelize.exe'
     - task: BatchScript@1
       displayName: 'Validate Files'
-      timeoutInMinutes: 5
+      timeoutInMinutes: 2
       condition: eq('${{ parameters.targetPlatform }}', 'x64')
       inputs:
         filename: 'azure-devops/validate-files.cmd'
@@ -67,7 +68,7 @@ jobs:
         arguments: '$(Build.ArtifactStagingDirectory)/tools/validate/validate.exe'
     - task: run-cmake@0
       displayName: 'Build the STL'
-      timeoutInMinutes: 5
+      timeoutInMinutes: 10
       inputs:
         cmakeListsTxtPath: 'CMakeSettings.json'
         useVcpkgToolchainFile: true


### PR DESCRIPTION
# Description

Make enforce-clang-format.cmd also run `git diff`.

This will produce more informative output for clang-format failures.

Also add 5-minute timeouts to every task in `run_build.yml` except `'Install MSVC Preview'`. This number was chosen semi-arbitrarily (successful runs appear to have sub-1-minute times for each task).

# Checklist

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [x] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository and
  the C++ Working Draft as a reference (and any other cited standards).
  If they were derived from a project that's already listed in NOTICE.txt,
  that's fine, but please mention it. If they were derived from any other
  project (including Boost and libc++, which are not yet listed in
  NOTICE.txt), you *must* mention it here, so we can determine whether the
  license is compatible and what else needs to be done.
