### PR TITLE
Enable clang-format AlignConsecutiveMacros.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-# https://releases.llvm.org/7.0.0/tools/clang/docs/ClangFormatStyleOptions.html
+# https://releases.llvm.org/9.0.0/tools/clang/docs/ClangFormatStyleOptions.html
 
 ---
 # Language:        Cpp
@@ -13,6 +13,9 @@ AccessModifierOffset: -4
 
 # AlignAfterOpenBracket: Align
 AlignAfterOpenBracket: DontAlign
+
+# AlignConsecutiveMacros: false
+AlignConsecutiveMacros: true
 
 # AlignConsecutiveAssignments: false
 AlignConsecutiveAssignments: true
@@ -27,6 +30,8 @@ AlignEscapedNewlines: Left
 # AlignTrailingComments: true
 AlignTrailingComments: false
 
+# AllowAllArgumentsOnNextLine: true
+# AllowAllConstructorInitializersOnNextLine: true
 # AllowAllParametersOfDeclarationOnNextLine: true
 # AllowShortBlocksOnASingleLine: false
 # AllowShortCaseLabelsOnASingleLine: false
@@ -34,22 +39,20 @@ AlignTrailingComments: false
 # AllowShortFunctionsOnASingleLine: All
 AllowShortFunctionsOnASingleLine: Empty
 
-# AllowShortIfStatementsOnASingleLine: false
+# AllowShortLambdasOnASingleLine: All
+# AllowShortIfStatementsOnASingleLine: Never
 # AllowShortLoopsOnASingleLine: false
 # AlwaysBreakAfterDefinitionReturnType: None
 # AlwaysBreakAfterReturnType: None
 # AlwaysBreakBeforeMultilineStrings: false
 
-# Clang 7 default:
 # AlwaysBreakTemplateDeclarations: MultiLine
-# Clang 7 customization:
-# AlwaysBreakTemplateDeclarations: Yes
-# Clang 6 compatible customization:
-AlwaysBreakTemplateDeclarations: true
+AlwaysBreakTemplateDeclarations: Yes
 
 # BinPackArguments: true
 # BinPackParameters: true
 # BraceWrapping:
+#   AfterCaseLabel:  false
 #   AfterClass:      false
 #   AfterControlStatement: false
 #   AfterEnum:       false
@@ -91,7 +94,7 @@ ColumnLimit:     120
 # DisableFormat:   false
 # ExperimentalAutoDetectBinPacking: false
 
-# NOTE: LLVM-39247, this emits damaged "// namespace _DEPRECATE_TR1_NAMESPACEtr1".
+# TRANSITION, LLVM-39247, fixed in clang-format 10.
 # FixNamespaceComments: true
 FixNamespaceComments: false
 
@@ -167,6 +170,7 @@ PointerAlignment: Left
 # SpaceAfterCStyleCast: false
 SpaceAfterCStyleCast: true
 
+# SpaceAfterLogicalNot: false
 # SpaceAfterTemplateKeyword: true
 # SpaceBeforeAssignmentOperators: true
 # SpaceBeforeCpp11BracedList: false
@@ -182,6 +186,9 @@ SpaceAfterCStyleCast: true
 # SpacesInParentheses: false
 # SpacesInSquareBrackets: false
 # Standard:        Cpp11
+# StatementMacros:
+#   - Q_UNUSED
+#   - QT_REQUIRE_VERSION
 # TabWidth:        8
 # UseTab:          Never
 ...

--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -28,26 +28,26 @@ _STL_DISABLE_CLANG_WARNINGS
 #define _Compiler_barrier() _STL_DISABLE_DEPRECATED_WARNING _ReadWriteBarrier() _STL_RESTORE_DEPRECATED_WARNING
 
 #if defined(_M_ARM) || defined(_M_ARM64)
-#define _Memory_barrier() __dmb(0xB) // inner shared data memory barrier
+#define _Memory_barrier()             __dmb(0xB) // inner shared data memory barrier
 #define _Compiler_or_memory_barrier() _Memory_barrier()
 
-#define _ISO_VOLATILE_STORE8(_Storage, _Value) __iso_volatile_store8(_Atomic_address_as<char>(_Storage), _Value)
+#define _ISO_VOLATILE_STORE8(_Storage, _Value)  __iso_volatile_store8(_Atomic_address_as<char>(_Storage), _Value)
 #define _ISO_VOLATILE_STORE16(_Storage, _Value) __iso_volatile_store16(_Atomic_address_as<short>(_Storage), _Value)
 #define _ISO_VOLATILE_STORE32(_Storage, _Value) __iso_volatile_store32(_Atomic_address_as<int>(_Storage), _Value)
 #define _ISO_VOLATILE_STORE64(_Storage, _Value) __iso_volatile_store64(_Atomic_address_as<long long>(_Storage), _Value)
-#define _ISO_VOLATILE_LOAD8(_Storage) __iso_volatile_load8(_Atomic_address_as<const char>(_Storage))
-#define _ISO_VOLATILE_LOAD16(_Storage) __iso_volatile_load16(_Atomic_address_as<const short>(_Storage))
+#define _ISO_VOLATILE_LOAD8(_Storage)           __iso_volatile_load8(_Atomic_address_as<const char>(_Storage))
+#define _ISO_VOLATILE_LOAD16(_Storage)          __iso_volatile_load16(_Atomic_address_as<const short>(_Storage))
 
 #elif defined(_M_IX86) || defined(_M_X64)
 // x86/x64 hardware only emits memory barriers inside _Interlocked intrinsics
 #define _Compiler_or_memory_barrier() _Compiler_barrier()
 
-#define _ISO_VOLATILE_STORE8(_Storage, _Value) (*_Atomic_address_as<char>(_Storage) = _Value)
+#define _ISO_VOLATILE_STORE8(_Storage, _Value)  (*_Atomic_address_as<char>(_Storage) = _Value)
 #define _ISO_VOLATILE_STORE16(_Storage, _Value) (*_Atomic_address_as<short>(_Storage) = _Value)
 #define _ISO_VOLATILE_STORE32(_Storage, _Value) (*_Atomic_address_as<long>(_Storage) = _Value)
 #define _ISO_VOLATILE_STORE64(_Storage, _Value) (*_Atomic_address_as<long long>(_Storage) = _Value)
-#define _ISO_VOLATILE_LOAD8(_Storage) (*_Atomic_address_as<const char>(_Storage))
-#define _ISO_VOLATILE_LOAD16(_Storage) (*_Atomic_address_as<const short>(_Storage))
+#define _ISO_VOLATILE_LOAD8(_Storage)           (*_Atomic_address_as<const char>(_Storage))
+#define _ISO_VOLATILE_LOAD16(_Storage)          (*_Atomic_address_as<const short>(_Storage))
 
 #else // ^^^ x86/x64 / unsupported hardware vvv
 #error Unsupported hardware
@@ -124,12 +124,12 @@ _NODISCARD extern "C" bool __cdecl __std_atomic_has_cmpxchg16b() noexcept;
 #endif // __cpp_lib_char8_t
 #define ATOMIC_CHAR16_T_LOCK_FREE 2
 #define ATOMIC_CHAR32_T_LOCK_FREE 2
-#define ATOMIC_WCHAR_T_LOCK_FREE 2
-#define ATOMIC_SHORT_LOCK_FREE 2
-#define ATOMIC_INT_LOCK_FREE 2
-#define ATOMIC_LONG_LOCK_FREE 2
-#define ATOMIC_LLONG_LOCK_FREE 2
-#define ATOMIC_POINTER_LOCK_FREE 2
+#define ATOMIC_WCHAR_T_LOCK_FREE  2
+#define ATOMIC_SHORT_LOCK_FREE    2
+#define ATOMIC_INT_LOCK_FREE      2
+#define ATOMIC_LONG_LOCK_FREE     2
+#define ATOMIC_LLONG_LOCK_FREE    2
+#define ATOMIC_POINTER_LOCK_FREE  2
 
 _STD_BEGIN
 

--- a/stl/inc/codecvt
+++ b/stl/inc/codecvt
@@ -21,8 +21,8 @@ _STL_DISABLE_CLANG_WARNINGS
 #pragma warning(disable : 4127) // conditional expression is constant
 
 _STD_BEGIN
-#define _LITTLE_FIRST 1
-#define _BIG_FIRST 2
+#define _LITTLE_FIRST   1
+#define _BIG_FIRST      2
 #define _BYTES_PER_WORD 4
 
 enum _CXX17_DEPRECATE_CODECVT_HEADER codecvt_mode { consume_header = 4, generate_header = 2, little_endian = 1 };

--- a/stl/inc/experimental/filesystem
+++ b/stl/inc/experimental/filesystem
@@ -53,11 +53,11 @@ You can define _SILENCE_EXPERIMENTAL_FILESYSTEM_DEPRECATION_WARNING to acknowled
 _FS_BEGIN
 using _Pchar = wchar_t; // UTF16
 #define _FS_ISSEP(x) ((x) == L'/' || (x) == L'\\')
-#define _FS_PREF L'\\'
+#define _FS_PREF     L'\\'
 
-#define _FS_COLON L':'
+#define _FS_COLON  L':'
 #define _FS_PERIOD L'.'
-#define _FS_SLASH L'/'
+#define _FS_SLASH  L'/'
 #define _FS_BSLASH L'\\'
 
 

--- a/stl/inc/iosfwd
+++ b/stl/inc/iosfwd
@@ -39,8 +39,8 @@ _STD_BEGIN
     _CATCH_END
 
 #else // _HAS_EXCEPTIONS
-#define _TRY_IO_BEGIN { // begin try block
-#define _CATCH_IO_END } // catch block for _Myios
+#define _TRY_IO_BEGIN        { // begin try block
+#define _CATCH_IO_END        } // catch block for _Myios
 #define _CATCH_IO_(xtype, x) } // catch block for basic_ios x
 #endif // _HAS_EXCEPTIONS
 

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -1055,9 +1055,6 @@ template <class _Ty>
 _INLINE_VAR constexpr size_t alignment_of_v = alignof(_Ty);
 
 // STRUCT TEMPLATE aligned_storage
-#define _FITS(_Ty)       _Align <= alignof(_Ty)
-#define _NEXT_ALIGN(_Ty) using type = typename _Aligned<_Len, _Align, _Ty, _FITS(_Ty)>::type
-
 template <class _Ty, size_t _Len>
 union _Align_type { // union with size _Len bytes and alignment of _Ty
     _Ty _Val;
@@ -1098,26 +1095,31 @@ struct _Aligned<_Len, _Align, double, false> {
 
 template <size_t _Len, size_t _Align>
 struct _Aligned<_Len, _Align, int, false> {
-    _NEXT_ALIGN(double);
+    using _Next                 = double;
+    static constexpr bool _Fits = _Align <= alignof(_Next);
+    using type                  = typename _Aligned<_Len, _Align, _Next, _Fits>::type;
 };
 
 template <size_t _Len, size_t _Align>
 struct _Aligned<_Len, _Align, short, false> {
-    _NEXT_ALIGN(int);
+    using _Next                 = int;
+    static constexpr bool _Fits = _Align <= alignof(_Next);
+    using type                  = typename _Aligned<_Len, _Align, _Next, _Fits>::type;
 };
 
 template <size_t _Len, size_t _Align>
 struct _Aligned<_Len, _Align, char, false> {
-    _NEXT_ALIGN(short);
+    using _Next                 = short;
+    static constexpr bool _Fits = _Align <= alignof(_Next);
+    using type                  = typename _Aligned<_Len, _Align, _Next, _Fits>::type;
 };
 
 template <size_t _Len, size_t _Align = alignof(max_align_t)>
 struct aligned_storage { // define type with size _Len and alignment _Align
-    using type = typename _Aligned<_Len, _Align, char, _FITS(char)>::type;
+    using _Next                 = char;
+    static constexpr bool _Fits = _Align <= alignof(_Next);
+    using type                  = typename _Aligned<_Len, _Align, _Next, _Fits>::type;
 };
-
-#undef _FITS
-#undef _NEXT_ALIGN
 
 template <size_t _Len, size_t _Align = alignof(max_align_t)>
 using aligned_storage_t = typename aligned_storage<_Len, _Align>::type;

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -1055,7 +1055,7 @@ template <class _Ty>
 _INLINE_VAR constexpr size_t alignment_of_v = alignof(_Ty);
 
 // STRUCT TEMPLATE aligned_storage
-#define _FITS(_Ty) _Align <= alignof(_Ty)
+#define _FITS(_Ty)       _Align <= alignof(_Ty)
 #define _NEXT_ALIGN(_Ty) using type = typename _Aligned<_Len, _Align, _Ty, _FITS(_Ty)>::type
 
 template <class _Ty, size_t _Len>
@@ -1473,7 +1473,7 @@ template <class _Ty>
 class reference_wrapper;
 
 #define _CONCATX(x, y) x##y
-#define _CONCAT(x, y) _CONCATX(x, y)
+#define _CONCAT(x, y)  _CONCATX(x, y)
 
 #define _IMPLEMENT_INVOKE(NAME_PREFIX, CONSTEXPR)                                                                      \
     /* FUNCTION TEMPLATE invoke */                                                                                     \

--- a/stl/inc/xlocinfo.h
+++ b/stl/inc/xlocinfo.h
@@ -37,24 +37,24 @@ _EXTERN_C_UNLESS_PURE
 #define _XD _HEX // '0'-'9', 'A'-'F', 'a'-'f'
 
 // SUPPLEMENTAL LOCALE MACROS AND DECLARATIONS
-#define _X_ALL LC_ALL
-#define _X_COLLATE LC_COLLATE
-#define _X_CTYPE LC_CTYPE
+#define _X_ALL      LC_ALL
+#define _X_COLLATE  LC_COLLATE
+#define _X_CTYPE    LC_CTYPE
 #define _X_MONETARY LC_MONETARY
-#define _X_NUMERIC LC_NUMERIC
-#define _X_TIME LC_TIME
-#define _X_MAX LC_MAX
+#define _X_NUMERIC  LC_NUMERIC
+#define _X_TIME     LC_TIME
+#define _X_MAX      LC_MAX
 #define _X_MESSAGES 6
-#define _NCAT (_X_MESSAGES + 1) // maximum + 1
+#define _NCAT       (_X_MESSAGES + 1) // maximum + 1
 
 #define _CATMASK(n) ((1 << (n)) >> 1)
-#define _M_COLLATE _CATMASK(_X_COLLATE)
-#define _M_CTYPE _CATMASK(_X_CTYPE)
+#define _M_COLLATE  _CATMASK(_X_COLLATE)
+#define _M_CTYPE    _CATMASK(_X_CTYPE)
 #define _M_MONETARY _CATMASK(_X_MONETARY)
-#define _M_NUMERIC _CATMASK(_X_NUMERIC)
-#define _M_TIME _CATMASK(_X_TIME)
+#define _M_NUMERIC  _CATMASK(_X_NUMERIC)
+#define _M_TIME     _CATMASK(_X_TIME)
 #define _M_MESSAGES _CATMASK(_X_MESSAGES)
-#define _M_ALL (_CATMASK(_NCAT) - 1)
+#define _M_ALL      (_CATMASK(_NCAT) - 1)
 
 struct _Collvec { // stuff needed by _Strcoll, etc.
     unsigned int _Page; // UINT

--- a/stl/inc/xstddef
+++ b/stl/inc/xstddef
@@ -307,7 +307,7 @@ _STD_END
 #endif // defined(_M_IX86) && !defined(_M_CEE)
 
 #ifdef _M_IX86
-#define _EMIT_STDCALL(FUNC, OPT1, OPT2, OPT3) FUNC(__stdcall, OPT1, OPT2, OPT3)
+#define _EMIT_STDCALL(FUNC, OPT1, OPT2, OPT3)  FUNC(__stdcall, OPT1, OPT2, OPT3)
 #define _EMIT_THISCALL(FUNC, OPT1, OPT2, OPT3) FUNC(__thiscall, OPT1, OPT2, OPT3)
 
 #else // _M_IX86

--- a/stl/inc/xthreads.h
+++ b/stl/inc/xthreads.h
@@ -28,26 +28,26 @@ struct _Thrd_t { // thread identifier for Win32
 // Size and alignment for _Mtx_internal_imp_t and _Cnd_internal_imp_t
 #ifdef _CRT_WINDOWS
 #ifdef _WIN64
-#define _Mtx_internal_imp_size 32
+#define _Mtx_internal_imp_size      32
 #define _Mtx_internal_imp_alignment 8
-#define _Cnd_internal_imp_size 16
+#define _Cnd_internal_imp_size      16
 #define _Cnd_internal_imp_alignment 8
 #else // _WIN64
-#define _Mtx_internal_imp_size 20
+#define _Mtx_internal_imp_size      20
 #define _Mtx_internal_imp_alignment 4
-#define _Cnd_internal_imp_size 8
+#define _Cnd_internal_imp_size      8
 #define _Cnd_internal_imp_alignment 4
 #endif // _WIN64
 #else // _CRT_WINDOWS
 #ifdef _WIN64
-#define _Mtx_internal_imp_size 80
+#define _Mtx_internal_imp_size      80
 #define _Mtx_internal_imp_alignment 8
-#define _Cnd_internal_imp_size 72
+#define _Cnd_internal_imp_size      72
 #define _Cnd_internal_imp_alignment 8
 #else // _WIN64
-#define _Mtx_internal_imp_size 48
+#define _Mtx_internal_imp_size      48
 #define _Mtx_internal_imp_alignment 4
-#define _Cnd_internal_imp_size 40
+#define _Cnd_internal_imp_size      40
 #define _Cnd_internal_imp_alignment 4
 #endif // _WIN64
 #endif // _CRT_WINDOWS

--- a/stl/inc/xtimec.h
+++ b/stl/inc/xtimec.h
@@ -30,7 +30,7 @@ _CRTIMP2_PURE int __cdecl xtime_get(xtime*, int);
 _CRTIMP2_PURE long __cdecl _Xtime_diff_to_millis(const xtime*);
 _CRTIMP2_PURE long __cdecl _Xtime_diff_to_millis2(const xtime*, const xtime*);
 _CRTIMP2_PURE long long __cdecl _Xtime_get_ticks();
-#define _XTIME_NSECS_PER_TICK 100
+#define _XTIME_NSECS_PER_TICK   100
 #define _XTIME_TICKS_PER_TIME_T 10000000LL
 
 _CRTIMP2_PURE long long __cdecl _Query_perf_counter();

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -1469,7 +1469,7 @@ struct _Ptr_move_cat<move_iterator<_Source*>, _Dest*> : _Ptr_move_cat<_Source*, 
 #define _DEBUG_ORDER_SET_UNWRAPPED(otherIter, first, last, pred)
 
 #else // _ITERATOR_DEBUG_LEVEL < 2
-#define _DEBUG_LT_PRED(pred, x, y) _Debug_lt_pred(pred, x, y)
+#define _DEBUG_LT_PRED(pred, x, y)                _Debug_lt_pred(pred, x, y)
 #define _DEBUG_ORDER_UNWRAPPED(first, last, pred) _Debug_order_unchecked(first, last, pred)
 #define _DEBUG_ORDER_SET_UNWRAPPED(otherIter, first, last, pred) \
     _Debug_order_set_unchecked<otherIter>(first, last, pred)

--- a/stl/inc/ymath.h
+++ b/stl/inc/ymath.h
@@ -18,16 +18,16 @@ _STL_DISABLE_CLANG_WARNINGS
 _EXTERN_C_UNLESS_PURE
 
 // MACROS FOR _Dtest RETURN (0 => ZERO)
-#define _DENORM (-2) // C9X only
-#define _FINITE (-1)
+#define _DENORM  (-2) // C9X only
+#define _FINITE  (-1)
 #define _INFCODE 1
 #define _NANCODE 2
 
 // MACROS FOR _Feraise ARGUMENT
 #define _FE_DIVBYZERO 0x04
-#define _FE_INEXACT 0x20
-#define _FE_INVALID 0x01
-#define _FE_OVERFLOW 0x08
+#define _FE_INEXACT   0x20
+#define _FE_INVALID   0x01
+#define _FE_OVERFLOW  0x08
 #define _FE_UNDERFLOW 0x10
 
 void __CLRCALL_PURE_OR_CDECL _Feraise(int);

--- a/stl/inc/yvals.h
+++ b/stl/inc/yvals.h
@@ -250,9 +250,9 @@ _STL_DISABLE_CLANG_WARNINGS
 
 #ifdef _CRTBLD
 // These functions are for enabling STATIC_CPPLIB functionality
-#define _cpp_stdin (__acrt_iob_func(0))
-#define _cpp_stdout (__acrt_iob_func(1))
-#define _cpp_stderr (__acrt_iob_func(2))
+#define _cpp_stdin         (__acrt_iob_func(0))
+#define _cpp_stdout        (__acrt_iob_func(1))
+#define _cpp_stderr        (__acrt_iob_func(2))
 #define _cpp_isleadbyte(c) (__pctype_func()[static_cast<unsigned char>(c)] & _LEADBYTE)
 #endif // _CRTBLD
 
@@ -291,17 +291,17 @@ _STL_DISABLE_CLANG_WARNINGS
 #endif // _CRTDATA2_IMPORT
 
 // INTEGER PROPERTIES
-#define _MAX_EXP_DIG 8 // for parsing numerics
-#define _MAX_INT_DIG 32
+#define _MAX_EXP_DIG    8 // for parsing numerics
+#define _MAX_INT_DIG    32
 #define _MAX_SIG_DIG_V1 36 // TRANSITION, ABI
 #define _MAX_SIG_DIG_V2 768
 
 // MULTITHREAD PROPERTIES
 // LOCK MACROS
-#define _LOCK_LOCALE 0
-#define _LOCK_MALLOC 1
-#define _LOCK_STREAM 2
-#define _LOCK_DEBUG 3
+#define _LOCK_LOCALE         0
+#define _LOCK_MALLOC         1
+#define _LOCK_STREAM         2
+#define _LOCK_DEBUG          3
 #define _LOCK_AT_THREAD_EXIT 4
 
 #ifdef __cplusplus
@@ -454,7 +454,7 @@ private:
 #define _CATCH_END }
 
 #define _RAISE(x) throw x
-#define _RERAISE throw
+#define _RERAISE  throw
 #define _THROW(x) throw x
 
 #else // _HAS_EXCEPTIONS

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -416,9 +416,9 @@
 #endif // __clang__
 #endif // _STL_RESTORE_DEPRECATED_WARNING
 
-#define _CPPLIB_VER 650
+#define _CPPLIB_VER       650
 #define _MSVC_STL_VERSION 142
-#define _MSVC_STL_UPDATE 201911L
+#define _MSVC_STL_UPDATE  201911L
 
 #ifndef _ALLOW_COMPILER_AND_STL_VERSION_MISMATCH
 #ifdef __EDG__
@@ -853,95 +853,95 @@
 // LIBRARY FEATURE-TEST MACROS
 
 // C++14
-#define __cpp_lib_chrono_udls 201304L
-#define __cpp_lib_complex_udls 201309L
-#define __cpp_lib_exchange_function 201304L
-#define __cpp_lib_generic_associative_lookup 201304L
-#define __cpp_lib_integer_sequence 201304L
-#define __cpp_lib_integral_constant_callable 201304L
-#define __cpp_lib_is_final 201402L
-#define __cpp_lib_is_null_pointer 201309L
-#define __cpp_lib_make_reverse_iterator 201402L
-#define __cpp_lib_make_unique 201304L
-#define __cpp_lib_null_iterators 201304L
-#define __cpp_lib_quoted_string_io 201304L
-#define __cpp_lib_result_of_sfinae 201210L
+#define __cpp_lib_chrono_udls                 201304L
+#define __cpp_lib_complex_udls                201309L
+#define __cpp_lib_exchange_function           201304L
+#define __cpp_lib_generic_associative_lookup  201304L
+#define __cpp_lib_integer_sequence            201304L
+#define __cpp_lib_integral_constant_callable  201304L
+#define __cpp_lib_is_final                    201402L
+#define __cpp_lib_is_null_pointer             201309L
+#define __cpp_lib_make_reverse_iterator       201402L
+#define __cpp_lib_make_unique                 201304L
+#define __cpp_lib_null_iterators              201304L
+#define __cpp_lib_quoted_string_io            201304L
+#define __cpp_lib_result_of_sfinae            201210L
 #define __cpp_lib_robust_nonmodifying_seq_ops 201304L
 #ifndef _M_CEE
 #define __cpp_lib_shared_timed_mutex 201402L
 #endif // _M_CEE
-#define __cpp_lib_string_udls 201304L
+#define __cpp_lib_string_udls                  201304L
 #define __cpp_lib_transformation_trait_aliases 201304L
-#define __cpp_lib_tuple_element_t 201402L
-#define __cpp_lib_tuples_by_type 201304L
+#define __cpp_lib_tuple_element_t              201402L
+#define __cpp_lib_tuples_by_type               201304L
 
 // C++17
-#define __cpp_lib_addressof_constexpr 201603L
+#define __cpp_lib_addressof_constexpr              201603L
 #define __cpp_lib_allocator_traits_is_always_equal 201411L
-#define __cpp_lib_as_const 201510L
-#define __cpp_lib_bool_constant 201505L
-#define __cpp_lib_enable_shared_from_this 201603L
-#define __cpp_lib_incomplete_container_elements 201505L
-#define __cpp_lib_invoke 201411L
-#define __cpp_lib_logical_traits 201510L
-#define __cpp_lib_map_try_emplace 201411L
-#define __cpp_lib_nonmember_container_access 201411L
+#define __cpp_lib_as_const                         201510L
+#define __cpp_lib_bool_constant                    201505L
+#define __cpp_lib_enable_shared_from_this          201603L
+#define __cpp_lib_incomplete_container_elements    201505L
+#define __cpp_lib_invoke                           201411L
+#define __cpp_lib_logical_traits                   201510L
+#define __cpp_lib_map_try_emplace                  201411L
+#define __cpp_lib_nonmember_container_access       201411L
 #ifndef _USING_V110_SDK71_
 #define __cpp_lib_shared_mutex 201505L
 #endif // _USING_V110_SDK71_
-#define __cpp_lib_shared_ptr_arrays 201611L
-#define __cpp_lib_transparent_operators 201510L
+#define __cpp_lib_shared_ptr_arrays             201611L
+#define __cpp_lib_transparent_operators         201510L
 #define __cpp_lib_type_trait_variable_templates 201510L
-#define __cpp_lib_uncaught_exceptions 201411L
-#define __cpp_lib_unordered_map_try_emplace 201411L
-#define __cpp_lib_void_t 201411L
+#define __cpp_lib_uncaught_exceptions           201411L
+#define __cpp_lib_unordered_map_try_emplace     201411L
+#define __cpp_lib_void_t                        201411L
 
 #if _HAS_CXX17
-#define __cpp_lib_any 201606L
-#define __cpp_lib_apply 201603L
-#define __cpp_lib_array_constexpr 201603L
+#define __cpp_lib_any                        201606L
+#define __cpp_lib_apply                      201603L
+#define __cpp_lib_array_constexpr            201603L
 #define __cpp_lib_atomic_is_always_lock_free 201603L
-#define __cpp_lib_boyer_moore_searcher 201603L
+#define __cpp_lib_boyer_moore_searcher       201603L
 #if _HAS_STD_BYTE
 #define __cpp_lib_byte 201603L
 #endif // _HAS_STD_BYTE
 #define __cpp_lib_chrono 201611L
-#define __cpp_lib_clamp 201603L
+#define __cpp_lib_clamp  201603L
 #ifndef _M_CEE
 #define __cpp_lib_execution 201603L
 #endif // _M_CEE
-#define __cpp_lib_filesystem 201703L
-#define __cpp_lib_gcd_lcm 201606L
-#define __cpp_lib_hardware_interference_size 201703L
+#define __cpp_lib_filesystem                        201703L
+#define __cpp_lib_gcd_lcm                           201606L
+#define __cpp_lib_hardware_interference_size        201703L
 #define __cpp_lib_has_unique_object_representations 201606L
-#define __cpp_lib_hypot 201603L
-#define __cpp_lib_is_aggregate 201703L
-#define __cpp_lib_is_invocable 201703L
-#define __cpp_lib_is_swappable 201603L
-#define __cpp_lib_launder 201606L
-#define __cpp_lib_make_from_tuple 201606L
-#define __cpp_lib_math_special_functions 201603L
-#define __cpp_lib_memory_resource 201603L
-#define __cpp_lib_node_extract 201606L
-#define __cpp_lib_not_fn 201603L
-#define __cpp_lib_optional 201606L
+#define __cpp_lib_hypot                             201603L
+#define __cpp_lib_is_aggregate                      201703L
+#define __cpp_lib_is_invocable                      201703L
+#define __cpp_lib_is_swappable                      201603L
+#define __cpp_lib_launder                           201606L
+#define __cpp_lib_make_from_tuple                   201606L
+#define __cpp_lib_math_special_functions            201603L
+#define __cpp_lib_memory_resource                   201603L
+#define __cpp_lib_node_extract                      201606L
+#define __cpp_lib_not_fn                            201603L
+#define __cpp_lib_optional                          201606L
 #ifndef _M_CEE
 #define __cpp_lib_parallel_algorithm 201603L
 #endif // _M_CEE
 #define __cpp_lib_raw_memory_algorithms 201606L
-#define __cpp_lib_sample 201603L
-#define __cpp_lib_scoped_lock 201703L
-#define __cpp_lib_shared_ptr_weak_type 201606L
-#define __cpp_lib_string_view 201606L
-#define __cpp_lib_to_chars 201611L
-#define __cpp_lib_variant 201606L
+#define __cpp_lib_sample                201603L
+#define __cpp_lib_scoped_lock           201703L
+#define __cpp_lib_shared_ptr_weak_type  201606L
+#define __cpp_lib_string_view           201606L
+#define __cpp_lib_to_chars              201611L
+#define __cpp_lib_variant               201606L
 #else // _HAS_CXX17
 #define __cpp_lib_chrono 201510L
 #endif // _HAS_CXX17
 
 // C++20
 #if _HAS_CXX20
-#define __cpp_lib_bind_front 201907L
+#define __cpp_lib_bind_front           201907L
 #define __cpp_lib_bounded_array_traits 201902L
 #ifdef __cpp_char8_t
 #define __cpp_lib_char8_t 201811L
@@ -965,14 +965,14 @@
 #endif // _HAS_STD_BOOLEAN
 #endif // defined(__cpp_concepts) && __cpp_concepts > 201507L
 
-#define __cpp_lib_erase_if 201811L
+#define __cpp_lib_erase_if                 201811L
 #define __cpp_lib_generic_unordered_lookup 201811L
-#define __cpp_lib_list_remove_return_type 201806L
-#define __cpp_lib_to_array 201907L
+#define __cpp_lib_list_remove_return_type  201806L
+#define __cpp_lib_to_array                 201907L
 #endif // _HAS_CXX20
 
 // EXPERIMENTAL
-#define __cpp_lib_experimental_erase_if 201411L
+#define __cpp_lib_experimental_erase_if   201411L
 #define __cpp_lib_experimental_filesystem 201406L
 
 
@@ -991,24 +991,24 @@ compiler option, or define _ALLOW_RTCc_IN_STL to acknowledge that you have recei
 #endif // ^^^ non-Clang ^^^
 #endif // _DECLSPEC_ALLOCATOR
 
-#define _STRINGIZEX(x) #x
-#define _STRINGIZE(x) _STRINGIZEX(x)
+#define _STRINGIZEX(x)  #x
+#define _STRINGIZE(x)   _STRINGIZEX(x)
 #define _EMPTY_ARGUMENT // for empty macro argument
 
 // NAMESPACE
 #define _STD_BEGIN namespace std {
-#define _STD_END }
-#define _STD ::std::
+#define _STD_END   }
+#define _STD       ::std::
 
 // We use the stdext (standard extension) namespace to contain extensions that are not part of the current standard
 #define _STDEXT_BEGIN namespace stdext {
-#define _STDEXT_END }
-#define _STDEXT ::stdext::
+#define _STDEXT_END   }
+#define _STDEXT       ::stdext::
 
 #ifdef __cplusplus
 #define _CSTD ::
 
-#define _EXTERN_C extern "C" {
+#define _EXTERN_C     extern "C" {
 #define _END_EXTERN_C }
 #else // ^^^ __cplusplus / !__cplusplus vvv
 #define _CSTD
@@ -1022,9 +1022,9 @@ compiler option, or define _ALLOW_RTCc_IN_STL to acknowledge that you have recei
 #define _END_EXTERN_C_UNLESS_PURE
 #define _STATIC_UNLESS_PURE // Avoid warning C4640: construction of local static object is not thread-safe (/Wall)
 #else // ^^^ _M_CEE_PURE / !_M_CEE_PURE vvv
-#define _EXTERN_C_UNLESS_PURE _EXTERN_C
+#define _EXTERN_C_UNLESS_PURE     _EXTERN_C
 #define _END_EXTERN_C_UNLESS_PURE _END_EXTERN_C
-#define _STATIC_UNLESS_PURE static
+#define _STATIC_UNLESS_PURE       static
 #endif // _M_CEE_PURE
 
 #if defined(MRTDLL) && !defined(_CRTBLD)

--- a/stl/src/filesystem.cpp
+++ b/stl/src/filesystem.cpp
@@ -127,7 +127,7 @@ namespace {
         &_Not_supported_SetFileInformationByHandle))
 #define _STL_ALWAYS_HAS_SetFileInformationByHandle 0
 #else // ^^^ _STL_WIN32_WINNT < _WIN32_WINNT_VISTA ^^^ // vvv _STL_WIN32_WINNT >= _WIN32_WINNT_VISTA vvv
-#define __vcrt_SetFileInformationByHandle SetFileInformationByHandle
+#define __vcrt_SetFileInformationByHandle          SetFileInformationByHandle
 #define _STL_ALWAYS_HAS_SetFileInformationByHandle 1
 #endif // _STL_WIN32_WINNT < _WIN32_WINNT_VISTA
 

--- a/stl/src/mutex.cpp
+++ b/stl/src/mutex.cpp
@@ -24,8 +24,8 @@ extern "C" _CRTIMP2_PURE void _Thrd_abort(const char* msg) { // abort on precond
 #endif // defined(_THREAD_CHECK) || defined(_DEBUG)
 
 #if _THREAD_CHECKX
-#define _THREAD_QUOTX(x) #x
-#define _THREAD_QUOT(x) _THREAD_QUOTX(x)
+#define _THREAD_QUOTX(x)          #x
+#define _THREAD_QUOT(x)           _THREAD_QUOTX(x)
 #define _THREAD_ASSERT(expr, msg) ((expr) ? (void) 0 : _Thrd_abort(__FILE__ "(" _THREAD_QUOT(__LINE__) "): " msg))
 #else // _THREAD_CHECKX
 #define _THREAD_ASSERT(expr, msg) ((void) 0)

--- a/stl/src/special_math.cpp
+++ b/stl/src/special_math.cpp
@@ -14,7 +14,7 @@
 #pragma warning(disable : 4702) // unreachable code
 
 #define BOOST_CONFIG_SUPPRESS_OUTDATED_MESSAGE
-#define BOOST_MATH_DOMAIN_ERROR_POLICY errno_on_error
+#define BOOST_MATH_DOMAIN_ERROR_POLICY   errno_on_error
 #define BOOST_MATH_OVERFLOW_ERROR_POLICY ignore_error
 
 // Using headers from Boost.Math 1.66.0

--- a/stl/src/ushcerr.cpp
+++ b/stl/src/ushcerr.cpp
@@ -7,18 +7,18 @@
 #include <fstream>
 
 #ifndef wistream
-#define wistream ushistream
-#define wostream ushostream
-#define wfilebuf ushfilebuf
+#define wistream    ushistream
+#define wostream    ushostream
+#define wfilebuf    ushfilebuf
 #define _Init_wcerr _Init_ushcerr
 #define _Init_wcout _Init_ushcout
 #define _Init_wclog _Init_ushclog
-#define _Init_wcin _Init_ushcin
-#define init_wcerr init_ushcerr
-#define init_wcout init_ushcout
-#define init_wclog init_ushclog
-#define init_wcin init_ushcin
-#define _Winit _UShinit
+#define _Init_wcin  _Init_ushcin
+#define init_wcerr  init_ushcerr
+#define init_wcout  init_ushcout
+#define init_wclog  init_ushclog
+#define init_wcin   init_ushcin
+#define _Winit      _UShinit
 #endif
 
 #include "wcerr.cpp"

--- a/stl/src/ushcin.cpp
+++ b/stl/src/ushcin.cpp
@@ -7,18 +7,18 @@
 #include <fstream>
 
 #ifndef wistream
-#define wistream ushistream
-#define wostream ushostream
-#define wfilebuf ushfilebuf
+#define wistream    ushistream
+#define wostream    ushostream
+#define wfilebuf    ushfilebuf
 #define _Init_wcerr _Init_ushcerr
 #define _Init_wcout _Init_ushcout
 #define _Init_wclog _Init_ushclog
-#define _Init_wcin _Init_ushcin
-#define _Winit _UShinit
-#define init_wcerr init_ushcerr
-#define init_wcout init_ushcout
-#define init_wclog init_ushclog
-#define init_wcin init_ushcin
+#define _Init_wcin  _Init_ushcin
+#define _Winit      _UShinit
+#define init_wcerr  init_ushcerr
+#define init_wcout  init_ushcout
+#define init_wclog  init_ushclog
+#define init_wcin   init_ushcin
 #endif
 
 #include "wcin.cpp"

--- a/stl/src/ushclog.cpp
+++ b/stl/src/ushclog.cpp
@@ -7,18 +7,18 @@
 #include <fstream>
 
 #ifndef wistream
-#define wistream ushistream
-#define wostream ushostream
-#define wfilebuf ushfilebuf
+#define wistream    ushistream
+#define wostream    ushostream
+#define wfilebuf    ushfilebuf
 #define _Init_wcerr _Init_ushcerr
 #define _Init_wcout _Init_ushcout
 #define _Init_wclog _Init_ushclog
-#define _Init_wcin _Init_ushcin
-#define _Winit _UShinit
-#define init_wcerr init_ushcerr
-#define init_wcout init_ushcout
-#define init_wclog init_ushclog
-#define init_wcin init_ushcin
+#define _Init_wcin  _Init_ushcin
+#define _Winit      _UShinit
+#define init_wcerr  init_ushcerr
+#define init_wcout  init_ushcout
+#define init_wclog  init_ushclog
+#define init_wcin   init_ushcin
 #endif
 
 #include "wclog.cpp"

--- a/stl/src/ushcout.cpp
+++ b/stl/src/ushcout.cpp
@@ -7,18 +7,18 @@
 #include <fstream>
 
 #ifndef wistream
-#define wistream ushistream
-#define wostream ushostream
-#define wfilebuf ushfilebuf
+#define wistream    ushistream
+#define wostream    ushostream
+#define wfilebuf    ushfilebuf
 #define _Init_wcerr _Init_ushcerr
 #define _Init_wcout _Init_ushcout
 #define _Init_wclog _Init_ushclog
-#define _Init_wcin _Init_ushcin
-#define _Winit _UShinit
-#define init_wcerr init_ushcerr
-#define init_wcout init_ushcout
-#define init_wclog init_ushclog
-#define init_wcin init_ushcin
+#define _Init_wcin  _Init_ushcin
+#define _Winit      _UShinit
+#define init_wcerr  init_ushcerr
+#define init_wcout  init_ushcout
+#define init_wclog  init_ushclog
+#define init_wcin   init_ushcin
 #endif
 
 #include "wcout.cpp"

--- a/stl/src/ushiostr.cpp
+++ b/stl/src/ushiostr.cpp
@@ -6,14 +6,14 @@
 #ifdef _NATIVE_WCHAR_T_DEFINED
 #include <fstream>
 
-#define wistream ushistream
-#define wostream ushostream
-#define wfilebuf ushfilebuf
+#define wistream    ushistream
+#define wostream    ushostream
+#define wfilebuf    ushfilebuf
 #define _Init_wcerr _Init_ushcerr
 #define _Init_wcout _Init_ushcout
 #define _Init_wclog _Init_ushclog
-#define _Init_wcin _Init_ushcin
-#define _Winit _UShinit
+#define _Init_wcin  _Init_ushcin
+#define _Winit      _UShinit
 
 #include <iostream>
 

--- a/stl/src/xstoflt.cpp
+++ b/stl/src/xstoflt.cpp
@@ -10,8 +10,8 @@
 
 _EXTERN_C_UNLESS_PURE
 
-#define BASE 10 // decimal
-#define NDIG 9 // decimal digits per long word
+#define BASE   10 // decimal
+#define NDIG   9 // decimal digits per long word
 #define MAXSIG (5 * NDIG) // maximum significant digits to keep
 
 int _Stoflt(const char* s0, const char* s, char** endptr, long lo[],

--- a/stl/src/xstoxflt.cpp
+++ b/stl/src/xstoxflt.cpp
@@ -11,8 +11,8 @@
 
 _EXTERN_C_UNLESS_PURE
 
-#define BASE 16 // hexadecimal
-#define NDIG 7 // hexadecimal digits per long element
+#define BASE   16 // hexadecimal
+#define NDIG   7 // hexadecimal digits per long element
 #define MAXSIG (5 * NDIG) // maximum significant digits to keep
 
 int _Stoxflt(const char* s0, const char* s, char** endptr, long lo[],

--- a/stl/src/xtime.cpp
+++ b/stl/src/xtime.cpp
@@ -8,10 +8,10 @@
 #include <time.h>
 #include <xtimec.h>
 
-#define NSEC_PER_SEC 1000000000L
+#define NSEC_PER_SEC  1000000000L
 #define NSEC_PER_MSEC 1000000L
 #define NSEC_PER_USEC 1000L
-#define MSEC_PER_SEC 1000
+#define MSEC_PER_SEC  1000
 
 static void xtime_normalize(xtime* xt) { // adjust so that 0 <= nsec < 1 000 000 000
     while (xt->nsec < 0) { // normalize target time
@@ -45,7 +45,7 @@ static xtime xtime_diff(const xtime* xt,
 
 #define EPOCH 0x19DB1DED53E8000i64
 
-#define NSEC100_PER_SEC (NSEC_PER_SEC / 100)
+#define NSEC100_PER_SEC  (NSEC_PER_SEC / 100)
 #define NSEC100_PER_MSEC (NSEC_PER_MSEC / 100)
 
 _EXTERN_C

--- a/stl/src/xwstoflt.cpp
+++ b/stl/src/xwstoflt.cpp
@@ -10,8 +10,8 @@
 
 _EXTERN_C_UNLESS_PURE
 
-#define BASE 10 // decimal
-#define NDIG 9 // decimal digits per long element
+#define BASE   10 // decimal
+#define NDIG   9 // decimal digits per long element
 #define MAXSIG (5 * NDIG) // maximum significant digits to keep
 
 int _WStoflt(const wchar_t* s0, const wchar_t* s, wchar_t** endptr, long lo[],

--- a/stl/src/xwstoxfl.cpp
+++ b/stl/src/xwstoxfl.cpp
@@ -11,8 +11,8 @@
 
 _EXTERN_C_UNLESS_PURE
 
-#define BASE 16 // hexadecimal
-#define NDIG 7 // hexadecimal digits per long element
+#define BASE   16 // hexadecimal
+#define NDIG   7 // hexadecimal digits per long element
 #define MAXSIG (5 * NDIG) // maximum significant digits to keep
 
 int _WStoxflt(const wchar_t* s0, const wchar_t* s, wchar_t** endptr, long lo[],

--- a/stl/src/xxcctype.h
+++ b/stl/src/xxcctype.h
@@ -3,5 +3,5 @@
 
 // parameters for char character type
 
-#define CTYPE char
+#define CTYPE      char
 #define CNAME(fun) _##fun

--- a/stl/src/xxdftype.h
+++ b/stl/src/xxdftype.h
@@ -7,17 +7,17 @@
 
 #include <float.h>
 
-#define FTYPE double
-#define FBITS DBL_MANT_DIG
+#define FTYPE   double
+#define FBITS   DBL_MANT_DIG
 #define FMAXEXP DBL_MAX_EXP
 
-#define FFUN(fun) fun
-#define FNAME(fun) _##fun
+#define FFUN(fun)   fun
+#define FNAME(fun)  _##fun
 #define FCONST(obj) _##obj._Double
-#define FLIT(lit) lit
+#define FLIT(lit)   lit
 
 #define FPMSW(x) (*_Pmsw(&(x)))
 #define FSIGNBIT _DSIGN
 
-#define FISNEG(x) (FPMSW(x) & FSIGNBIT)
+#define FISNEG(x)  (FPMSW(x) & FSIGNBIT)
 #define FNEGATE(x) (FPMSW(x) ^= FSIGNBIT)

--- a/stl/src/xxfftype.h
+++ b/stl/src/xxfftype.h
@@ -7,17 +7,17 @@
 
 #include <float.h>
 
-#define FTYPE float
-#define FBITS FLT_MANT_DIG
+#define FTYPE   float
+#define FBITS   FLT_MANT_DIG
 #define FMAXEXP FLT_MAX_EXP
 
-#define FFUN(fun) fun##f
-#define FNAME(fun) _F##fun
+#define FFUN(fun)   fun##f
+#define FNAME(fun)  _F##fun
 #define FCONST(obj) _F##obj._Float
-#define FLIT(lit) lit##F
+#define FLIT(lit)   lit##F
 
 #define FPMSW(x) (*_FPmsw(&(x)))
 #define FSIGNBIT _FSIGN
 
-#define FISNEG(x) (FPMSW(x) & FSIGNBIT)
+#define FISNEG(x)  (FPMSW(x) & FSIGNBIT)
 #define FNEGATE(x) (FPMSW(x) ^= FSIGNBIT)

--- a/stl/src/xxlftype.h
+++ b/stl/src/xxlftype.h
@@ -7,17 +7,17 @@
 
 #include <float.h>
 
-#define FTYPE long double
-#define FBITS LDBL_MANT_DIG
+#define FTYPE   long double
+#define FBITS   LDBL_MANT_DIG
 #define FMAXEXP LDBL_MAX_EXP
 
-#define FFUN(fun) fun##l
-#define FNAME(fun) _L##fun
+#define FFUN(fun)   fun##l
+#define FNAME(fun)  _L##fun
 #define FCONST(obj) _L##obj._Long_double
-#define FLIT(lit) lit##L
+#define FLIT(lit)   lit##L
 
 #define FPMSW(x) (*_LPmsw(&(x)))
 #define FSIGNBIT _LSIGN
 
-#define FISNEG(x) (FPMSW(x) & FSIGNBIT)
+#define FISNEG(x)  (FPMSW(x) & FSIGNBIT)
 #define FNEGATE(x) (FPMSW(x) ^= FSIGNBIT)

--- a/stl/src/xxwctype.h
+++ b/stl/src/xxwctype.h
@@ -3,5 +3,5 @@
 
 // parameters for wchar_t character type
 
-#define CTYPE wchar_t
+#define CTYPE      wchar_t
 #define CNAME(fun) _W##fun

--- a/stl/src/xxxdtent.h
+++ b/stl/src/xxxdtent.h
@@ -11,7 +11,7 @@ _EXTERN_C
 
 // macros
 #define ACSIZE 4 // size of extended-precision accumulators
-#define BIAS (ACSIZE * (FBITS / 2)) // avoid denorms for finite values
+#define BIAS   (ACSIZE * (FBITS / 2)) // avoid denorms for finite values
 
 #define FRAC_BITS_2 (FRAC_BITS * FRAC_BITS)
 

--- a/stl/src/xxxprec.h
+++ b/stl/src/xxxprec.h
@@ -17,9 +17,9 @@ _EXTERN_C
 #define sqrtf(x) sqrt((double) (x))
 #endif // sqrtf
 
-#define BIG_EXP (2 * FMAXEXP) // very large, as exponents go
+#define BIG_EXP   (2 * FMAXEXP) // very large, as exponents go
 #define BITS_WORD (FBITS / 2) // all words same for now
-#define NBUF 4 // size of delay line for mulh
+#define NBUF      4 // size of delay line for mulh
 
 #define COPY_UP(j, n)                                       \
     {                                                       \


### PR DESCRIPTION
# Description

* Update `.clang-format` defaults.

* Enable `AlignConsecutiveMacros`, newly supported by clang-format 9. We often followed this style before using clang-format, and I believe that it produces generally positive changes.

* Apply clang-format changes.

* Replace `_FITS` and `_NEXT_ALIGN` macros. clang-format didn't damage them, it just brought them to my attention. These macros weren't improving clarity, and the code is more systematic without them. (For the time being, I have refrained from further overhauling the metaprogramming here.)

# Checklist

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [ ] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository and
  the C++ Working Draft as a reference (and any other cited standards).
  If they were derived from a project that's already listed in NOTICE.txt,
  that's fine, but please mention it. If they were derived from any other
  project (including Boost and libc++, which are not yet listed in
  NOTICE.txt), you *must* mention it here, so we can determine whether the
  license is compatible and what else needs to be done.
