### PR TITLE
Improve the PR and issue templates

### DIFF
--- a/azure-devops/run_build.yml
+++ b/azure-devops/run_build.yml
@@ -50,7 +50,7 @@ jobs:
         buildDirectory: $(Build.ArtifactStagingDirectory)/tools
     - task: BatchScript@1
       displayName: 'Enforce clang-format'
-      timeoutInMinutes: 5
+      timeoutInMinutes: 60
       condition: eq('${{ parameters.targetPlatform }}', 'x64')
       inputs:
         filename: 'azure-devops/enforce-clang-format.cmd'

--- a/docs/ISSUE_TEMPLATE.md
+++ b/docs/ISSUE_TEMPLATE.md
@@ -17,7 +17,7 @@ to the right place are there.
 STL version (git commit or Visual Studio version):
 
 ```
-C:\Users\billy\Desktop>type repro.cpp
+C:\Temp>type repro.cpp
 #include <iostream>
 
 int main() {
@@ -28,7 +28,7 @@ int main() {
     std::cout << "test failure\n";
 }
 
-C:\Users\billy\Desktop>cl /EHsc /W4 /WX .\repro.cpp
+C:\Temp>cl /EHsc /W4 /WX .\repro.cpp
 Microsoft (R) C/C++ Optimizing Compiler Version 19.23.28019.1 for x64
 Copyright (C) Microsoft Corporation.  All rights reserved.
 
@@ -39,7 +39,7 @@ Copyright (C) Microsoft Corporation.  All rights reserved.
 /out:repro.exe
 repro.obj
 
-C:\Users\billy\Desktop>.\repro.exe
+C:\Temp>.\repro.exe
 test failure
 ```
 

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -16,10 +16,11 @@ If you're unsure about a box, leave it unchecked. A maintainer will help you.
 - [ ] These changes introduce no known ABI breaks (adding members, renaming
   members, adding virtual functions, changing whether a type is an aggregate
   or trivially copyable, etc.).
-- [ ] These changes were written from scratch using only this repository and
-  the C++ Working Draft as a reference (and any other cited standards).
-  If they were derived from a project that's already listed in NOTICE.txt,
-  that's fine, but please mention it. If they were derived from any other
-  project (including Boost and libc++, which are not yet listed in
-  NOTICE.txt), you *must* mention it here, so we can determine whether the
-  license is compatible and what else needs to be done.
+- [ ] These changes were written from scratch using only this repository,
+  the C++ Working Draft (including any cited standards), other WG21 papers,
+  and LWG issues as reference material. If they were derived from a project
+  that's already listed in NOTICE.txt, that's fine, but please mention it.
+  If they were derived from any other project (including Boost and libc++,
+  which are not yet listed in NOTICE.txt), you *must* mention it here,
+  so we can determine whether the license is compatible and what else needs
+  to be done.

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -17,7 +17,8 @@ If you're unsure about a box, leave it unchecked. A maintainer will help you.
   members, adding virtual functions, changing whether a type is an aggregate
   or trivially copyable, etc.).
 - [ ] These changes were written from scratch using only this repository,
-  the C++ Working Draft (including any cited standards), other WG21 papers,
+  the C++ Working Draft (including any cited standards), other WG21 papers
+  (excluding reference implementations outside of proposed standard wording),
   and LWG issues as reference material. If they were derived from a project
   that's already listed in NOTICE.txt, that's fine, but please mention it.
   If they were derived from any other project (including Boost and libc++,


### PR DESCRIPTION
# Description

* Add WG21 papers and LWG issues as acceptable reference material in the PR template.

* Simplify the paths in the issue template.

# Checklist

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [ ] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository and
  the C++ Working Draft as a reference (and any other cited standards).
  If they were derived from a project that's already listed in NOTICE.txt,
  that's fine, but please mention it. If they were derived from any other
  project (including Boost and libc++, which are not yet listed in
  NOTICE.txt), you *must* mention it here, so we can determine whether the
  license is compatible and what else needs to be done.
