### PR TITLE
Fix #249 : Change <hash_map> to consistently use  int = 0 SFINAE

### DIFF
--- a/stl/inc/hash_map
+++ b/stl/inc/hash_map
@@ -190,12 +190,12 @@ namespace stdext {
 
         using _Mybase::insert;
 
-        template <class _Valty, class = enable_if_t<is_constructible_v<value_type, _Valty>>> // TRANSITION, GH-249
+        template <class _Valty,  enable_if_t<is_constructible_v<value_type, _Valty>, int> = 0> // TRANSITION, GH-249
         pair<iterator, bool> insert(_Valty&& _Val) {
             return this->emplace(_STD forward<_Valty>(_Val));
         }
 
-        template <class _Valty, class = enable_if_t<is_constructible_v<value_type, _Valty>>> // TRANSITION, GH-249
+        template <class _Valty,  enable_if_t<is_constructible_v<value_type, _Valty>, int> = 0> // TRANSITION, GH-249
         iterator insert(const_iterator _Where, _Valty&& _Val) {
             return this->emplace_hint(_Where, _STD forward<_Valty>(_Val));
         }
@@ -373,12 +373,12 @@ namespace stdext {
 
         using _Mybase::insert;
 
-        template <class _Valty, class = enable_if_t<is_constructible_v<value_type, _Valty>>> // TRANSITION, GH-249
+        template <class _Valty,  enable_if_t<is_constructible_v<value_type, _Valty>, int> = 0> // TRANSITION, GH-249
         iterator insert(_Valty&& _Val) {
             return this->emplace(_STD forward<_Valty>(_Val));
         }
 
-        template <class _Valty, class = enable_if_t<is_constructible_v<value_type, _Valty>>> // TRANSITION, GH-249
+        template <class _Valty,  enable_if_t<is_constructible_v<value_type, _Valty>, int> = 0> // TRANSITION, GH-249
         iterator insert(const_iterator _Where, _Valty&& _Val) {
             return this->emplace_hint(_Where, _STD forward<_Valty>(_Val));
         }

--- a/stl/inc/hash_map
+++ b/stl/inc/hash_map
@@ -121,7 +121,7 @@ namespace stdext {
         using referent_type   = _Ty;
         using key_compare     = _Tr;
         using value_compare   = typename _Mybase::_Value_compare;
-        using value_type      = typename _Mybase::value_type;
+        using value_type      = pair<const _Kty, _Ty>;
         using allocator_type  = typename _Mybase::allocator_type;
         using size_type       = typename _Mybase::size_type;
         using difference_type = typename _Mybase::difference_type;
@@ -311,7 +311,7 @@ namespace stdext {
         using referent_type   = _Ty; // old name, magically gone
         using key_compare     = _Tr;
         using value_compare   = typename _Mybase::_Value_compare;
-        using value_type      = typename _Mybase::value_type;
+        using value_type      = pair<const _Kty, _Ty>;
         using allocator_type  = typename _Mybase::allocator_type;
         using size_type       = typename _Mybase::size_type;
         using difference_type = typename _Mybase::difference_type;

--- a/stl/inc/hash_map
+++ b/stl/inc/hash_map
@@ -190,12 +190,12 @@ namespace stdext {
 
         using _Mybase::insert;
 
-        template <class _Valty, enable_if_t<is_constructible_v<value_type, _Valty>, int> = 0> // TRANSITION, GH-249
+        template <class _Valty, enable_if_t<is_constructible_v<value_type, _Valty>, int> = 0>
         pair<iterator, bool> insert(_Valty&& _Val) {
             return this->emplace(_STD forward<_Valty>(_Val));
         }
 
-        template <class _Valty, enable_if_t<is_constructible_v<value_type, _Valty>, int> = 0> // TRANSITION, GH-249
+        template <class _Valty, enable_if_t<is_constructible_v<value_type, _Valty>, int> = 0>
         iterator insert(const_iterator _Where, _Valty&& _Val) {
             return this->emplace_hint(_Where, _STD forward<_Valty>(_Val));
         }
@@ -373,12 +373,12 @@ namespace stdext {
 
         using _Mybase::insert;
 
-        template <class _Valty, enable_if_t<is_constructible_v<value_type, _Valty>, int> = 0> // TRANSITION, GH-249
+        template <class _Valty, enable_if_t<is_constructible_v<value_type, _Valty>, int> = 0>
         iterator insert(_Valty&& _Val) {
             return this->emplace(_STD forward<_Valty>(_Val));
         }
 
-        template <class _Valty, enable_if_t<is_constructible_v<value_type, _Valty>, int> = 0> // TRANSITION, GH-249
+        template <class _Valty, enable_if_t<is_constructible_v<value_type, _Valty>, int> = 0>
         iterator insert(const_iterator _Where, _Valty&& _Val) {
             return this->emplace_hint(_Where, _STD forward<_Valty>(_Val));
         }

--- a/stl/inc/hash_map
+++ b/stl/inc/hash_map
@@ -190,12 +190,12 @@ namespace stdext {
 
         using _Mybase::insert;
 
-        template <class _Valty,  enable_if_t<is_constructible_v<value_type, _Valty>, int> = 0> // TRANSITION, GH-249
+        template <class _Valty, enable_if_t<is_constructible_v<value_type, _Valty>, int> = 0> // TRANSITION, GH-249
         pair<iterator, bool> insert(_Valty&& _Val) {
             return this->emplace(_STD forward<_Valty>(_Val));
         }
 
-        template <class _Valty,  enable_if_t<is_constructible_v<value_type, _Valty>, int> = 0> // TRANSITION, GH-249
+        template <class _Valty, enable_if_t<is_constructible_v<value_type, _Valty>, int> = 0> // TRANSITION, GH-249
         iterator insert(const_iterator _Where, _Valty&& _Val) {
             return this->emplace_hint(_Where, _STD forward<_Valty>(_Val));
         }
@@ -373,12 +373,12 @@ namespace stdext {
 
         using _Mybase::insert;
 
-        template <class _Valty,  enable_if_t<is_constructible_v<value_type, _Valty>, int> = 0> // TRANSITION, GH-249
+        template <class _Valty, enable_if_t<is_constructible_v<value_type, _Valty>, int> = 0> // TRANSITION, GH-249
         iterator insert(_Valty&& _Val) {
             return this->emplace(_STD forward<_Valty>(_Val));
         }
 
-        template <class _Valty,  enable_if_t<is_constructible_v<value_type, _Valty>, int> = 0> // TRANSITION, GH-249
+        template <class _Valty, enable_if_t<is_constructible_v<value_type, _Valty>, int> = 0> // TRANSITION, GH-249
         iterator insert(const_iterator _Where, _Valty&& _Val) {
             return this->emplace_hint(_Where, _STD forward<_Valty>(_Val));
         }


### PR DESCRIPTION
# Description



# Checklist

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [x] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
