### PR TITLE
Improve diagnostic for std::function<void() noexcept>

### DIFF
--- a/stl/inc/functional
+++ b/stl/inc/functional
@@ -1107,7 +1107,9 @@ private:
 
 // STRUCT TEMPLATE _Get_function_impl
 template <class _Tx>
-struct _Get_function_impl;
+struct _Get_function_impl {
+    static_assert(_Always_false<_Tx>, "std::function does not accept non-function types as template arguments.");
+};
 
 #define _GET_FUNCTION_IMPL(CALL_OPT, X1, X2, X3)                                                  \
     template <class _Ret, class... _Types>                                                        \
@@ -1117,6 +1119,17 @@ struct _Get_function_impl;
 
 _NON_MEMBER_CALL(_GET_FUNCTION_IMPL, X1, X2, X3)
 #undef _GET_FUNCTION_IMPL
+
+#ifdef __cpp_noexcept_function_type
+#define _GET_FUNCTION_IMPL_NOEXCEPT(CALL_OPT, X1, X2, X3)                                                         \
+    template <class _Ret, class... _Types>                                                                        \
+    struct _Get_function_impl<_Ret CALL_OPT(_Types...) noexcept> {                                                \
+        static_assert(                                                                                            \
+            _Always_false<_Ret>, "std::function does not accept noexcept function types as template arguments."); \
+    };
+_NON_MEMBER_CALL(_GET_FUNCTION_IMPL_NOEXCEPT, X1, X2, X3)
+#undef _GET_FUNCTION_IMPL_NOEXCEPT
+#endif // __cpp_noexcept_function_type
 
 // CLASS TEMPLATE function
 template <class _Fty>
@@ -1264,19 +1277,17 @@ struct _Deduce_signature {}; // can't deduce signature when &_Fx::operator() is 
 
 template <class _Fx>
 struct _Deduce_signature<_Fx, void_t<decltype(&_Fx::operator())>>
-    : _Is_memfunptr<decltype(&_Fx::operator())>::_Guide_type {}; // N4687 23.14.13.2.1 [func.wrap.func.con]/12
+    : _Is_memfunptr<decltype(&_Fx::operator())>::_Guide_type {}; // N4842 [func.wrap.func.con]/12
 
 template <class _Fx>
 function(_Fx)->function<typename _Deduce_signature<_Fx>::type>;
 #endif // _HAS_CXX17
 
-// FUNCTION TEMPLATE swap
 template <class _Fty>
 void swap(function<_Fty>& _Left, function<_Fty>& _Right) noexcept {
     _Left.swap(_Right);
 }
 
-// TEMPLATE NULL POINTER COMPARISONS
 template <class _Fty>
 _NODISCARD bool operator==(const function<_Fty>& _Other, nullptr_t) noexcept {
     return !_Other;


### PR DESCRIPTION
# Description

Programs that include such specializations are ill-formed, since the Standard only specifies a partial specialization of `std::function<T>` for non-`noexcept` function types `T`. The current diagnostic:
```
error C2027: use of undefined type 'std::_Get_function_impl<_Fty>'
```
is not great.

Fixes DevCom-825902.

[This is a replay of Microsoft-internal MSVC-PR-215822.]

# Checklist

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [X] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [X] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [X] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [X] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
