### PR TITLE
Hide std::unreachable_sentinel_t's friends harder

### DIFF
--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -3548,27 +3548,31 @@ struct default_sentinel_t {};
 inline constexpr default_sentinel_t default_sentinel{};
 
 // STRUCT unreachable_sentinel_t
-struct unreachable_sentinel_t {
-    template <weakly_incrementable _Winc>
-    _NODISCARD friend constexpr bool operator==(unreachable_sentinel_t, const _Winc&) noexcept {
-        return false;
-    }
+struct unreachable_sentinel_t;
+namespace _Unreachable_sentinel_detail {
+    struct _Base {
+        template <weakly_incrementable _Winc>
+        _NODISCARD friend constexpr bool operator==(unreachable_sentinel_t, const _Winc&) noexcept {
+            return false;
+        }
 #if !defined(__cpp_impl_three_way_comparison) || __cpp_impl_three_way_comparison < 201902L
-    template <weakly_incrementable _Winc>
-    _NODISCARD friend constexpr bool operator==(const _Winc&, unreachable_sentinel_t) noexcept {
-        return false;
-    }
+        template <weakly_incrementable _Winc>
+        _NODISCARD friend constexpr bool operator==(const _Winc&, unreachable_sentinel_t) noexcept {
+            return false;
+        }
 
-    template <weakly_incrementable _Winc>
-    _NODISCARD friend constexpr bool operator!=(unreachable_sentinel_t, const _Winc&) noexcept {
-        return true;
-    }
-    template <weakly_incrementable _Winc>
-    _NODISCARD friend constexpr bool operator!=(const _Winc&, unreachable_sentinel_t) noexcept {
-        return true;
-    }
+        template <weakly_incrementable _Winc>
+        _NODISCARD friend constexpr bool operator!=(unreachable_sentinel_t, const _Winc&) noexcept {
+            return true;
+        }
+        template <weakly_incrementable _Winc>
+        _NODISCARD friend constexpr bool operator!=(const _Winc&, unreachable_sentinel_t) noexcept {
+            return true;
+        }
 #endif // !defined(__cpp_impl_three_way_comparison) || __cpp_impl_three_way_comparison < 201902L
-};
+    };
+} // namespace _Unreachable_sentinel_detail
+struct unreachable_sentinel_t : _Unreachable_sentinel_detail::_Base {}; // TRANSITION, /permissive-
 
 // VARIABLE unreachable_sentinel
 inline constexpr unreachable_sentinel_t unreachable_sentinel{};


### PR DESCRIPTION
# Description

Hidden friends aren't hidden in C1XX's permissive mode, so let's use an alternate mechanism to make these operators truly ADL-only. (We want to avoid checking `weakly_incrementable` for every type that is compared via `==` or `!=` with a type associated with namespace `std`.)

[This is a replay of Microsoft-internal MSVC-PR-216763.]

# Checklist

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [X] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [X] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [X] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [X] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
