### PR TITLE
Implement is_constant_evaluated(), more feature-test macros, and LWG issues

### DIFF
--- a/stl/inc/bitset
+++ b/stl/inc/bitset
@@ -532,9 +532,14 @@ basic_istream<_Elem, _Tr>& operator>>(basic_istream<_Elem, _Tr>& _Istr, bitset<_
         _CATCH_IO_(_Istr_t, _Istr)
     }
 
-    if (!_Changed) {
-        _State |= _Istr_t::failbit;
-    }
+    constexpr bool _Has_bits = _Bits > 0;
+
+    if
+        _CONSTEXPR_IF(_Has_bits) {
+            if (!_Changed) {
+                _State |= _Istr_t::failbit;
+            }
+        }
 
     _Istr.setstate(_State);
     _Right = bitset<_Bits>(_Str); // convert string and store

--- a/stl/inc/charconv
+++ b/stl/inc/charconv
@@ -190,6 +190,8 @@ inline to_chars_result to_chars(char* const _First, char* const _Last, const uns
     return _Integer_to_chars(_First, _Last, _Value, _Base);
 }
 
+to_chars_result to_chars(char* _First, char* _Last, bool _Value, int _Base = 10) = delete;
+
 
 // FUNCTION TEMPLATE _Bit_cast
 template <class _To, class _From,

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -1775,6 +1775,14 @@ inline constexpr bool is_nothrow_invocable_r_v =
     _Invoke_traits<void, _Callable, _Args...>::template _Is_nothrow_invocable_r<_Rx>::value;
 #endif // _HAS_CXX17
 
+#if _HAS_CXX20
+#ifdef __cpp_lib_is_constant_evaluated // TRANSITION, VS 2019 16.5 Preview 2
+// FUNCTION is_constant_evaluated
+_NODISCARD constexpr bool is_constant_evaluated() noexcept {
+    return __builtin_is_constant_evaluated();
+}
+#endif // __cpp_lib_is_constant_evaluated
+#endif // _HAS_CXX20
 
 // STRUCT TEMPLATE _Weak_types
 template <class _Ty, class = void>

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -18,49 +18,46 @@
 #endif // _STL_COMPILER_PREPROCESSOR
 
 #if _STL_COMPILER_PREPROCESSOR
-// _HAS_CXX20 directly controls:
-// P0020R6 atomic<float>, atomic<double>, atomic<long double>
-// P0318R1 unwrap_reference, unwrap_ref_decay
-// P0325R4 to_array()
-// P0356R5 bind_front()
-// P0439R0 enum class memory_order
-// P0457R2 starts_with()/ends_with() For basic_string/basic_string_view
-// P0458R2 contains() For Ordered And Unordered Associative Containers
-// P0463R1 endian
-// P0482R6 Library Support For char8_t
-//     (mbrtoc8 and c8rtomb not yet implemented)
-// P0487R1 Fixing operator>>(basic_istream&, CharT*)
-// P0550R2 remove_cvref
-// P0553R4 <bit> Rotating And Counting Functions
-// P0556R3 <bit> ispow2(), ceil2(), floor2(), log2p1()
-//            (log2p1() is called bit_length() as of D1956)
-// P0595R2 is_constant_evaluated()
-// P0616R0 Using move() In <numeric>
-// P0631R8 <numbers> Math Constants
-// P0646R1 list/forward_list remove()/remove_if()/unique() Return size_type
-// P0653R2 to_address()
-// P0655R1 visit<R>()
-// P0758R1 is_nothrow_convertible
-// P0768R1 Library Support For The Spaceship Comparison Operator <=>
-//     (partially implemented)
-// P0769R2 shift_left(), shift_right()
-// P0811R3 midpoint(), lerp()
-//     (partially implemented, lerp() not yet constexpr)
-// P0887R1 type_identity
-// P0896R4 Ranges
-//     (partially implemented)
-// P0898R3 Standard Library Concepts
-// P0919R3 Heterogeneous Lookup For Unordered Containers
-// P0966R1 string::reserve() Should Not Shrink
-// P1209R0 erase_if(), erase()
-// P1227R2 Signed std::ssize(), Unsigned span::size()
-//     (partially implemented)
-// P1357R1 is_bounded_array, is_unbounded_array
-// P1612R1 Relocating endian To <bit>
-// P1651R0 bind_front() Should Not Unwrap reference_wrapper
-// P1690R1 Refining Heterogeneous Lookup For Unordered Containers
-// P1754R1 Rename Concepts To standard_case
-// P????R? directory_entry::clear_cache()
+// Implemented unconditionally:
+// N3911 void_t
+// N4089 Safe Conversions In unique_ptr<T[]>
+// N4169 invoke()
+// N4258 noexcept Cleanups
+// N4259 uncaught_exceptions()
+// N4277 Trivially Copyable reference_wrapper
+// N4279 insert_or_assign()/try_emplace() For map/unordered_map
+// N4280 size(), empty(), data()
+// N4366 Precisely Constraining unique_ptr Assignment
+// N4387 Improving pair And tuple
+// N4389 bool_constant
+// N4508 shared_mutex (Untimed)
+// N4510 Supporting Incomplete Types In vector/list/forward_list
+// P0006R0 Variable Templates For Type Traits (is_same_v, etc.)
+// P0007R1 as_const()
+// P0013R1 Logical Operator Type Traits (conjunction, etc.)
+// P0033R1 Rewording enable_shared_from_this
+// P0063R3 C11 Standard Library
+// P0074R0 owner_less<>
+// P0092R1 <chrono> floor(), ceil(), round(), abs()
+// P0340R3 SFINAE-Friendly underlying_type
+// P0414R2 shared_ptr<T[]>, shared_ptr<T[N]>
+// P0418R2 atomic compare_exchange memory_order Requirements
+// P0435R1 Overhauling common_type
+// P0497R0 Fixing shared_ptr For Arrays
+// P0513R0 Poisoning hash
+// P0516R0 Marking shared_future Copying As noexcept
+// P0517R0 Constructing future_error From future_errc
+// P0548R1 Tweaking common_type And duration
+// P0558R1 Resolving atomic<T> Named Base Class Inconsistencies
+// P0599R1 noexcept hash
+// P0738R2 istream_iterator Cleanup
+// P0771R1 noexcept For std::function's Move Constructor
+// P0777R1 Avoiding Unnecessary decay
+// P0809R0 Comparing Unordered Containers
+// P0941R2 Feature-Test Macros
+// P0972R0 noexcept For <chrono> zero(), min(), max()
+// P1164R1 Making create_directory() Intuitive
+// P1902R1 Missing Feature-Test Macros 2017-2019
 
 // _HAS_CXX17 directly controls:
 // P0005R4 not_fn()
@@ -122,64 +119,63 @@
 // The non-Standard std::tr1 namespace and TR1-only machinery
 // Enforcement of matching allocator value_types
 
-// _HAS_NODISCARD (in vcruntime.h) controls:
-// [[nodiscard]] attributes on STL functions
-
 // _HAS_CXX17 and _SILENCE_ALL_CXX17_DEPRECATION_WARNINGS control:
 // P0174R2 Deprecating Vestigial Library Parts
 // P0521R0 Deprecating shared_ptr::unique()
 // P0618R0 Deprecating <codecvt>
 // Other C++17 deprecation warnings
 
+// _HAS_CXX20 directly controls:
+// P0020R6 atomic<float>, atomic<double>, atomic<long double>
+// P0318R1 unwrap_reference, unwrap_ref_decay
+// P0325R4 to_array()
+// P0356R5 bind_front()
+// P0439R0 enum class memory_order
+// P0457R2 starts_with()/ends_with() For basic_string/basic_string_view
+// P0458R2 contains() For Ordered And Unordered Associative Containers
+// P0463R1 endian
+// P0482R6 Library Support For char8_t
+//     (mbrtoc8 and c8rtomb not yet implemented)
+// P0487R1 Fixing operator>>(basic_istream&, CharT*)
+// P0550R2 remove_cvref
+// P0553R4 <bit> Rotating And Counting Functions
+// P0556R3 <bit> ispow2(), ceil2(), floor2(), log2p1()
+//            (log2p1() is called bit_length() as of D1956)
+// P0595R2 is_constant_evaluated()
+// P0616R0 Using move() In <numeric>
+// P0631R8 <numbers> Math Constants
+// P0646R1 list/forward_list remove()/remove_if()/unique() Return size_type
+// P0653R2 to_address()
+// P0655R1 visit<R>()
+// P0758R1 is_nothrow_convertible
+// P0768R1 Library Support For The Spaceship Comparison Operator <=>
+//     (partially implemented)
+// P0769R2 shift_left(), shift_right()
+// P0811R3 midpoint(), lerp()
+//     (partially implemented, lerp() not yet constexpr)
+// P0887R1 type_identity
+// P0896R4 Ranges
+//     (partially implemented)
+// P0898R3 Standard Library Concepts
+// P0919R3 Heterogeneous Lookup For Unordered Containers
+// P0966R1 string::reserve() Should Not Shrink
+// P1209R0 erase_if(), erase()
+// P1227R2 Signed std::ssize(), Unsigned span::size()
+//     (partially implemented)
+// P1357R1 is_bounded_array, is_unbounded_array
+// P1612R1 Relocating endian To <bit>
+// P1651R0 bind_front() Should Not Unwrap reference_wrapper
+// P1690R1 Refining Heterogeneous Lookup For Unordered Containers
+// P1754R1 Rename Concepts To standard_case
+// P????R? directory_entry::clear_cache()
+
 // _HAS_CXX20 and _SILENCE_ALL_CXX20_DEPRECATION_WARNINGS control:
 // P0767R1 Deprecating is_pod
 // Other C++20 deprecation warnings
 
-// Implemented unconditionally:
-// N3911 void_t
-// N4089 Safe Conversions In unique_ptr<T[]>
-// N4169 invoke()
-// N4258 noexcept Cleanups
-// N4259 uncaught_exceptions()
-// N4277 Trivially Copyable reference_wrapper
-// N4279 insert_or_assign()/try_emplace() For map/unordered_map
-// N4280 size(), empty(), data()
-// N4366 Precisely Constraining unique_ptr Assignment
-// N4387 Improving pair And tuple
-// N4389 bool_constant
-// N4508 shared_mutex (Untimed)
-// N4510 Supporting Incomplete Types In vector/list/forward_list
-// P0006R0 Variable Templates For Type Traits (is_same_v, etc.)
-// P0007R1 as_const()
-// P0013R1 Logical Operator Type Traits (conjunction, etc.)
-// P0033R1 Rewording enable_shared_from_this
-// P0063R3 C11 Standard Library
-// P0074R0 owner_less<>
-// P0092R1 <chrono> floor(), ceil(), round(), abs()
-// P0340R3 SFINAE-Friendly underlying_type
-// P0414R2 shared_ptr<T[]>, shared_ptr<T[N]>
-// P0418R2 atomic compare_exchange memory_order Requirements
-// P0435R1 Overhauling common_type
-// P0497R0 Fixing shared_ptr For Arrays
-// P0513R0 Poisoning hash
-// P0516R0 Marking shared_future Copying As noexcept
-// P0517R0 Constructing future_error From future_errc
-// P0548R1 Tweaking common_type And duration
-// P0558R1 Resolving atomic<T> Named Base Class Inconsistencies
-// P0599R1 noexcept hash
-// P0738R2 istream_iterator Cleanup
-// P0771R1 noexcept For std::function's Move Constructor
-// P0777R1 Avoiding Unnecessary decay
-// P0809R0 Comparing Unordered Containers
-// P0941R2 Feature-Test Macros
-// P0972R0 noexcept For <chrono> zero(), min(), max()
-// P1164R1 Making create_directory() Intuitive
-// P1902R1 Missing Feature-Test Macros 2017-2019
-
 // Parallel Algorithms Notes
-// C++ allows an implementation to implement parallel algorithms as calls to the
-// serial algorithms. This implementation parallelizes several common algorithm
-// calls, but not all.
+// C++ allows an implementation to implement parallel algorithms as calls to the serial algorithms.
+// This implementation parallelizes several common algorithm calls, but not all.
 //
 // The following algorithms are parallelized.
 // * adjacent_difference
@@ -224,9 +220,8 @@
 //
 // The following are not presently parallelized:
 //
-// No apparent parallelism performance improvement on target hardware; all
-// algorithms which merely copy or permute elements with no branches are
-// typically memory bandwidth limited.
+// No apparent parallelism performance improvement on target hardware; all algorithms which
+// merely copy or permute elements with no branches are typically memory bandwidth limited.
 // * copy
 // * copy_n
 // * fill
@@ -240,8 +235,7 @@
 // * shift_right
 // * swap_ranges
 //
-// Confusion over user parallelism requirements exists; likely in the above
-// category anyway.
+// Confusion over user parallelism requirements exists; likely in the above category anyway.
 // * generate
 // * generate_n
 //
@@ -249,8 +243,7 @@
 // * partial_sort
 // * partial_sort_copy
 //
-// Not yet evaluated; parallelism may be implemented in a future release and is
-// suspected to be beneficial.
+// Not yet evaluated; parallelism may be implemented in a future release and is suspected to be beneficial.
 // * copy_if
 // * includes
 // * inplace_merge
@@ -289,6 +282,9 @@
 #if _STL_WARNING_LEVEL > 4
 #error _STL_WARNING_LEVEL cannot be greater than 4.
 #endif // _STL_WARNING_LEVEL > 4
+
+// _HAS_NODISCARD (in vcruntime.h) controls:
+// [[nodiscard]] attributes on STL functions
 
 // Controls whether the STL uses "if constexpr" internally
 #ifndef _HAS_IF_CONSTEXPR

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -173,6 +173,7 @@
 // P0941R2 Feature-Test Macros
 // P0972R0 noexcept For <chrono> zero(), min(), max()
 // P1164R1 Making create_directory() Intuitive
+// P1902R1 Missing Feature-Test Macros 2017-2019
 
 // Parallel Algorithms Notes
 // C++ allows an implementation to implement parallel algorithms as calls to the
@@ -949,14 +950,18 @@
 
 // C++20
 #if _HAS_CXX20
-#define __cpp_lib_bind_front 201907L
+#define __cpp_lib_atomic_float 201711L
+#define __cpp_lib_bind_front   201907L
+
 #if defined(__clang__) || defined(__EDG__)
 #define __cpp_lib_bitops 201907L
 #else // ^^^ Clang and EDG / MSVC vvv
 // a future MSVC update will embed CPU feature detection into <bit> intrinsics
 // TRANSITION, VSO-1020212
 #endif // defined(__clang__) || defined(__EDG__)
+
 #define __cpp_lib_bounded_array_traits 201902L
+
 #ifdef __cpp_char8_t
 #define __cpp_lib_char8_t 201811L
 #endif // __cpp_char8_t
@@ -973,9 +978,18 @@
 #define __cpp_lib_endian                   201907L
 #define __cpp_lib_erase_if                 201811L
 #define __cpp_lib_generic_unordered_lookup 201811L
+#define __cpp_lib_int_pow2                 201806L
 #define __cpp_lib_list_remove_return_type  201806L
 #define __cpp_lib_math_constants           201907L
+#define __cpp_lib_nothrow_convertible      201806L
+#define __cpp_lib_remove_cvref             201711L
+#define __cpp_lib_shift                    201806L
+#define __cpp_lib_ssize                    201902L
+#define __cpp_lib_starts_ends_with         201711L
+#define __cpp_lib_to_address               201711L
 #define __cpp_lib_to_array                 201907L
+#define __cpp_lib_type_identity            201806L
+#define __cpp_lib_unwrap_ref               201811L
 #endif // _HAS_CXX20
 
 // EXPERIMENTAL

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -34,6 +34,7 @@
 // P0553R4 <bit> Rotating And Counting Functions
 // P0556R3 <bit> ispow2(), ceil2(), floor2(), log2p1()
 //            (log2p1() is called bit_length() as of D1956)
+// P0595R2 is_constant_evaluated()
 // P0616R0 Using move() In <numeric>
 // P0631R8 <numbers> Math Constants
 // P0646R1 list/forward_list remove()/remove_if()/unique() Return size_type
@@ -979,17 +980,23 @@
 #define __cpp_lib_erase_if                 201811L
 #define __cpp_lib_generic_unordered_lookup 201811L
 #define __cpp_lib_int_pow2                 201806L
-#define __cpp_lib_list_remove_return_type  201806L
-#define __cpp_lib_math_constants           201907L
-#define __cpp_lib_nothrow_convertible      201806L
-#define __cpp_lib_remove_cvref             201711L
-#define __cpp_lib_shift                    201806L
-#define __cpp_lib_ssize                    201902L
-#define __cpp_lib_starts_ends_with         201711L
-#define __cpp_lib_to_address               201711L
-#define __cpp_lib_to_array                 201907L
-#define __cpp_lib_type_identity            201806L
-#define __cpp_lib_unwrap_ref               201811L
+
+#if defined(__clang__) || defined(__EDG__) \
+    || (defined(_MSC_VER) && _MSC_VER >= 1925 && !(_MSC_FULL_VER == 192528318 && _MSC_BUILD == 97))
+#define __cpp_lib_is_constant_evaluated 201811L
+#endif // TRANSITION, VS 2019 16.5 Preview 2 and toolset update
+
+#define __cpp_lib_list_remove_return_type 201806L
+#define __cpp_lib_math_constants          201907L
+#define __cpp_lib_nothrow_convertible     201806L
+#define __cpp_lib_remove_cvref            201711L
+#define __cpp_lib_shift                   201806L
+#define __cpp_lib_ssize                   201902L
+#define __cpp_lib_starts_ends_with        201711L
+#define __cpp_lib_to_address              201711L
+#define __cpp_lib_to_array                201907L
+#define __cpp_lib_type_identity           201806L
+#define __cpp_lib_unwrap_ref              201811L
 #endif // _HAS_CXX20
 
 // EXPERIMENTAL

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -907,7 +907,7 @@
 #if _HAS_CXX17
 #define __cpp_lib_any                        201606L
 #define __cpp_lib_apply                      201603L
-#define __cpp_lib_array_constexpr            201603L
+#define __cpp_lib_array_constexpr            201803L
 #define __cpp_lib_atomic_is_always_lock_free 201603L
 #define __cpp_lib_boyer_moore_searcher       201603L
 #if _HAS_STD_BYTE
@@ -940,7 +940,7 @@
 #define __cpp_lib_sample                201603L
 #define __cpp_lib_scoped_lock           201703L
 #define __cpp_lib_shared_ptr_weak_type  201606L
-#define __cpp_lib_string_view           201606L
+#define __cpp_lib_string_view           201803L
 #define __cpp_lib_to_chars              201611L
 #define __cpp_lib_variant               201606L
 #else // _HAS_CXX17


### PR DESCRIPTION
# Description

* Fix #156: WG21-P0595 `is_constant_evaluated()`
  * This is enabled for Clang 9 and VS 2019 16.5 Preview 2 (the first preview with `_MSC_VER` set to `1925`) because it depends on `__builtin_is_constant_evaluated`. Thanks to Jennifer Yao who implemented this in C1XX (the MSVC compiler front-end).
  * Currently, we need additional preprocessor logic to disable this for the Microsoft-internal "checked-in toolset"; that logic looks strange because the checked-in toolset's version is currently 19.25.28318.97 while a freshly-built compiler is (for example) 19.25.26504.99.
* Fix #339: WG21-P1902 Missing Feature-Test Macros 2017-2019
  * For unimplemented features affected by this paper, I've updated all of their GitHub issues.
  * For implemented features affected by this paper, I'm adding feature-test macros here. All of those features were directly controlled by `_HAS_CXX20` and are gaining new macros (instead of having existing macros increased).
  * Note that `__cpp_lib_ssize` is slightly special, as that paper also patched `span`. I believe that we should simply define the feature-test macro now, given its name.
* Fix #70: LWG-3199 `istream >> bitset<0>` fails
* Fix #335: LWG-3257 Missing feature testing macro update from WG21-P0858
* Fix #332: LWG-3266 `to_chars(bool)` should be deleted
* Reorder and rewrap `yvals_core.h` comments.

# Checklist

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [ ] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
