### PR TITLE
Avoid reinterpret_cast in filesystem_space.cpp

### DIFF
--- a/stl/src/filesystem_space.cpp
+++ b/stl/src/filesystem_space.cpp
@@ -22,9 +22,9 @@ namespace {
         if (GetVolumePathNameW(_Target, _Temp_buffer, _Temp_buffer_characters)) {
             ULARGE_INTEGER _Available_union, _Total_bytes_union, _Free_bytes_union;
             if (GetDiskFreeSpaceExW(_Temp_buffer, &_Available_union, &_Total_bytes_union, &_Free_bytes_union)) {
-                *_Available = _Available_union.QuadPart;
+                *_Available   = _Available_union.QuadPart;
                 *_Total_bytes = _Total_bytes_union.QuadPart;
-                *_Free_bytes = _Free_bytes_union.QuadPart;
+                *_Free_bytes  = _Free_bytes_union.QuadPart;
                 return __std_win_error::_Success;
             }
         }

--- a/stl/src/filesystem_space.cpp
+++ b/stl/src/filesystem_space.cpp
@@ -16,15 +16,15 @@
 #include <Windows.h>
 
 namespace {
-    static_assert(sizeof(uintmax_t) == sizeof(ULARGE_INTEGER) && alignof(uintmax_t) == alignof(ULARGE_INTEGER),
-        "Size and alignment must match for reinterpret_cast<PULARGE_INTEGER>");
-
     [[nodiscard]] __std_win_error _Fs_space_attempt(wchar_t* const _Temp_buffer, const DWORD _Temp_buffer_characters,
         const wchar_t* const _Target, uintmax_t* const _Available, uintmax_t* const _Total_bytes,
         uintmax_t* const _Free_bytes) noexcept {
         if (GetVolumePathNameW(_Target, _Temp_buffer, _Temp_buffer_characters)) {
-            if (GetDiskFreeSpaceExW(_Temp_buffer, reinterpret_cast<PULARGE_INTEGER>(_Available),
-                    reinterpret_cast<PULARGE_INTEGER>(_Total_bytes), reinterpret_cast<PULARGE_INTEGER>(_Free_bytes))) {
+            ULARGE_INTEGER _Available_union, _Total_bytes_union, _Free_bytes_union;
+            if (GetDiskFreeSpaceExW(_Temp_buffer, &_Available_union, &_Total_bytes_union, &_Free_bytes_union)) {
+                *_Available = _Available_union.QuadPart;
+                *_Total_bytes = _Total_bytes_union.QuadPart;
+                *_Free_bytes = _Free_bytes_union.QuadPart;
                 return __std_win_error::_Success;
             }
         }


### PR DESCRIPTION
# Description
Fixes #357 by using `ULARGE_INTEGER` local variables and assigning them to the passed `uintmax_t` pointer afterwards, instead of `reinterpret_cast`ing said pointers.


# Checklist

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [ ] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
