### PR TITLE
<experimental/random> Implement randint

### DIFF
--- a/stl/CMakeLists.txt
+++ b/stl/CMakeLists.txt
@@ -130,6 +130,7 @@ set(HEADERS
     ${CMAKE_CURRENT_LIST_DIR}/inc/experimental/generator
     ${CMAKE_CURRENT_LIST_DIR}/inc/experimental/list
     ${CMAKE_CURRENT_LIST_DIR}/inc/experimental/map
+    ${CMAKE_CURRENT_LIST_DIR}/inc/experimental/random
     ${CMAKE_CURRENT_LIST_DIR}/inc/experimental/resumable
     ${CMAKE_CURRENT_LIST_DIR}/inc/experimental/set
     ${CMAKE_CURRENT_LIST_DIR}/inc/experimental/string

--- a/stl/CMakeLists.txt
+++ b/stl/CMakeLists.txt
@@ -123,6 +123,7 @@ set(HEADERS
     ${CMAKE_CURRENT_LIST_DIR}/inc/deque
     ${CMAKE_CURRENT_LIST_DIR}/inc/exception
     ${CMAKE_CURRENT_LIST_DIR}/inc/execution
+    ${CMAKE_CURRENT_LIST_DIR}/inc/experimental/algorithm
     ${CMAKE_CURRENT_LIST_DIR}/inc/experimental/coroutine
     ${CMAKE_CURRENT_LIST_DIR}/inc/experimental/deque
     ${CMAKE_CURRENT_LIST_DIR}/inc/experimental/filesystem

--- a/stl/inc/__msvc_all_public_headers.hpp
+++ b/stl/inc/__msvc_all_public_headers.hpp
@@ -140,6 +140,7 @@
 #include <cuchar>
 #include <cwchar>
 #include <cwctype>
+#include <experimental/algorithm>
 #include <experimental/deque>
 #include <experimental/filesystem>
 #include <experimental/forward_list>

--- a/stl/inc/__msvc_all_public_headers.hpp
+++ b/stl/inc/__msvc_all_public_headers.hpp
@@ -145,6 +145,7 @@
 #include <experimental/forward_list>
 #include <experimental/list>
 #include <experimental/map>
+#include <experimental/random>
 #include <experimental/set>
 #include <experimental/string>
 #include <experimental/unordered_map>

--- a/stl/inc/experimental/algorithm
+++ b/stl/inc/experimental/algorithm
@@ -1,0 +1,45 @@
+// algorithm experimental header
+
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#pragma once
+#ifndef _EXPERIMENTAL_ALGORITHM_
+#define _EXPERIMENTAL_ALGORITHM_
+#include <yvals_core.h>
+#if _STL_COMPILER_PREPROCESSOR
+
+#include <experimental/random>
+
+#pragma pack(push, _CRT_PACKING)
+#pragma warning(push, _STL_WARNING_LEVEL)
+#pragma warning(disable : _STL_DISABLED_WARNINGS)
+_STL_DISABLE_CLANG_WARNINGS
+#pragma push_macro("new")
+#undef new
+
+_STD_BEGIN
+namespace experimental {
+    inline namespace fundamentals_v3 {
+
+        template <class _PopIt, class _SampleIt, class _Diff>
+        _SampleIt sample(_PopIt _First, _PopIt _Last, _SampleIt _Dest, _Diff _Count) {
+            return _STD sample(_First, _Last, _Dest, _Count, _Engine());
+        }
+
+        template <class _RanIt>
+        void shuffle(_RanIt _First, _RanIt _Last) {
+            _STD shuffle(_First, _Last, _Engine());
+        }
+
+    } // namespace fundamentals_v3
+} // namespace experimental
+_STD_END
+
+#pragma pop_macro("new")
+_STL_RESTORE_CLANG_WARNINGS
+#pragma warning(pop)
+#pragma pack(pop)
+
+#endif // _STL_COMPILER_PREPROCESSOR
+#endif // _EXPERIMENTAL_ALGORITHM_

--- a/stl/inc/experimental/algorithm
+++ b/stl/inc/experimental/algorithm
@@ -9,6 +9,7 @@
 #include <yvals_core.h>
 #if _STL_COMPILER_PREPROCESSOR
 
+#include <algorithm>
 #include <experimental/random>
 
 #pragma pack(push, _CRT_PACKING)

--- a/stl/inc/experimental/random
+++ b/stl/inc/experimental/random
@@ -29,9 +29,7 @@ namespace experimental {
 
         template <class _IntType>
         _IntType randint(const _IntType _Min, const _IntType _Max) {
-            static_assert(_Is_any_of_v<remove_cv_t<_IntType>, short, int, long, long long, unsigned short, unsigned int,
-                              unsigned long, unsigned long long>,
-                "template argument does not meet the requirements for IntType.");
+            _RNG_REQUIRE_INTTYPE(randint(), _IntType);
             _STL_ASSERT(_Min <= _Max, "invalid min and max arguments for randint()");
             return uniform_int_distribution<_IntType>{_Min, _Max}(_Engine());
         }

--- a/stl/inc/experimental/random
+++ b/stl/inc/experimental/random
@@ -22,13 +22,13 @@ _STD_BEGIN
 namespace experimental {
     inline namespace fundamentals_v3 {
 
-        inline default_random_engine& _Engine() {
+        _NODISCARD inline default_random_engine& _Engine() {
             thread_local default_random_engine _Eng{random_device{}()};
             return _Eng;
         }
 
         template <class _IntType>
-        _IntType randint(const _IntType _Min, const _IntType _Max) {
+        _NODISCARD _IntType randint(const _IntType _Min, const _IntType _Max) {
             _RNG_REQUIRE_INTTYPE(randint(), _IntType);
             _STL_ASSERT(_Min <= _Max, "invalid min and max arguments for randint()");
             return uniform_int_distribution<_IntType>{_Min, _Max}(_Engine());

--- a/stl/inc/experimental/random
+++ b/stl/inc/experimental/random
@@ -28,7 +28,7 @@ namespace experimental {
         }
 
         template <class _IntType>
-        _IntType randint(_IntType _Min, _IntType _Max) {
+        _IntType randint(const _IntType _Min, const _IntType _Max) {
             static_assert(_Is_any_of_v<remove_cv_t<_IntType>, short, int, long, long long, unsigned short, unsigned int,
                               unsigned long, unsigned long long>,
                 "template argument does not meet the requirements for IntType.");
@@ -36,10 +36,7 @@ namespace experimental {
             return uniform_int_distribution<_IntType>{_Min, _Max}(_Engine());
         }
 
-        inline void reseed() {
-            _Engine().seed(random_device{}());
-        }
-        inline void reseed(default_random_engine::result_type _Value) {
+        inline void reseed(const default_random_engine::result_type _Value = random_device{}()) {
             _Engine().seed(_Value);
         }
     } // namespace fundamentals_v3

--- a/stl/inc/experimental/random
+++ b/stl/inc/experimental/random
@@ -45,7 +45,7 @@ namespace experimental {
             uint32_t _Values[_Nx * _Kx];
             random_device _Rd;
             _STD generate(_STD begin(_Values), _STD end(_Values), _STD ref(_Rd));
-            seed_seq _Seq{_STD cbegin(_Values), _STD cend(_Values)};
+            seed_seq _Seq(_STD cbegin(_Values), _STD cend(_Values));
 
             _Engine().seed(_Seq);
         }

--- a/stl/inc/experimental/random
+++ b/stl/inc/experimental/random
@@ -1,0 +1,55 @@
+// random experimental header
+
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#pragma once
+#ifndef _EXPERIMENTAL_RANDOM_
+#define _EXPERIMENTAL_RANDOM_
+#include <yvals_core.h>
+#if _STL_COMPILER_PREPROCESSOR
+
+#include <random>
+
+#pragma pack(push, _CRT_PACKING)
+#pragma warning(push, _STL_WARNING_LEVEL)
+#pragma warning(disable : _STL_DISABLED_WARNINGS)
+_STL_DISABLE_CLANG_WARNINGS
+#pragma push_macro("new")
+#undef new
+
+_STD_BEGIN
+namespace experimental {
+    inline namespace fundamentals_v3 {
+
+        inline default_random_engine& _Engine() {
+            thread_local default_random_engine _Eng{random_device{}()};
+            return _Eng;
+        }
+
+        template <class _IntType>
+        _IntType randint(_IntType _Min, _IntType _Max) {
+            static_assert(_Is_any_of_v<remove_cv_t<_IntType>, short, int, long, long long, unsigned short, unsigned int,
+                              unsigned long, unsigned long long>,
+                "template argument does not meet the requirements for IntType (C++17 §29.6.1.1)");
+            _STL_ASSERT(_Min <= _Max, "_Min > _Max");
+            return uniform_int_distribution<_IntType>{_Min, _Max}(_Engine());
+        }
+
+        inline void reseed() {
+            _Engine().seed(random_device{}());
+        }
+        inline void reseed(default_random_engine::result_type _Value) {
+            _Engine().seed(_Value);
+        }
+    } // namespace fundamentals_v3
+} // namespace experimental
+_STD_END
+
+#pragma pop_macro("new")
+_STL_RESTORE_CLANG_WARNINGS
+#pragma warning(pop)
+#pragma pack(pop)
+
+#endif // _STL_COMPILER_PREPROCESSOR
+#endif // _EXPERIMENTAL_RANDOM_

--- a/stl/inc/experimental/random
+++ b/stl/inc/experimental/random
@@ -32,7 +32,7 @@ namespace experimental {
             static_assert(_Is_any_of_v<remove_cv_t<_IntType>, short, int, long, long long, unsigned short, unsigned int,
                               unsigned long, unsigned long long>,
                 "template argument does not meet the requirements for IntType.");
-            _STL_ASSERT(_Min <= _Max, "_Min > _Max");
+            _STL_ASSERT(_Min <= _Max, "invalid min and max arguments for randint()");
             return uniform_int_distribution<_IntType>{_Min, _Max}(_Engine());
         }
 

--- a/stl/inc/experimental/random
+++ b/stl/inc/experimental/random
@@ -31,7 +31,7 @@ namespace experimental {
         _IntType randint(_IntType _Min, _IntType _Max) {
             static_assert(_Is_any_of_v<remove_cv_t<_IntType>, short, int, long, long long, unsigned short, unsigned int,
                               unsigned long, unsigned long long>,
-                "template argument does not meet the requirements for IntType (C++17 §29.6.1.1)");
+                "template argument does not meet the requirements for IntType.");
             _STL_ASSERT(_Min <= _Max, "_Min > _Max");
             return uniform_int_distribution<_IntType>{_Min, _Max}(_Engine());
         }

--- a/stl/inc/experimental/random
+++ b/stl/inc/experimental/random
@@ -35,18 +35,19 @@ namespace experimental {
         }
 
         inline void reseed() {
-            constexpr size_t _N = mt19937::state_size;
-            constexpr size_t _W = mt19937::word_size;
-            static_assert(_W % 32 == 0, "mt19937::word_size is not a multiple of 32");
-            constexpr size_t _K = _W / 32;
+            constexpr size_t _Nx = mt19937::state_size;
+            constexpr size_t _Wx = mt19937::word_size;
+            static_assert(_Wx % 32 == 0, "mt19937::word_size is not a multiple of 32");
+            constexpr size_t _Kx = _Wx / 32;
 
-            uint32_t _Values[_N * _K];
+            uint32_t _Values[_Nx * _Kx];
             random_device _Rd;
             _STD generate(_STD begin(_Values), _STD end(_Values), _STD ref(_Rd));
             seed_seq _Seq{_STD cbegin(_Values), _STD cend(_Values)};
 
             _Engine().seed(_Seq);
         }
+
         inline void reseed(const default_random_engine::result_type _Value) {
             _Engine().seed(_Value);
         }

--- a/stl/inc/experimental/random
+++ b/stl/inc/experimental/random
@@ -22,8 +22,22 @@ _STD_BEGIN
 namespace experimental {
     inline namespace fundamentals_v3 {
 
+        const seed_seq _Seed_engine() {
+            static_assert(
+                is_same_v<default_random_engine, mt19937>, "This code assumes that default_random_engine is mt19937");
+            constexpr size_t _Nx = mt19937::state_size;
+            constexpr size_t _Wx = mt19937::word_size;
+            static_assert(_Wx % 32 == 0, "mt19937::word_size is not a multiple of 32");
+            constexpr size_t _Kx = _Wx / 32;
+
+            uint32_t _Values[_Nx * _Kx];
+            random_device _Rd;
+            _STD generate(_STD begin(_Values), _STD end(_Values), _STD ref(_Rd));
+            return seed_seq(_STD cbegin(_Values), _STD cend(_Values));
+        }
+
         _NODISCARD inline default_random_engine& _Engine() {
-            thread_local default_random_engine _Eng{random_device{}()};
+            thread_local default_random_engine _Eng(_Seed_engine());
             return _Eng;
         }
 
@@ -35,19 +49,7 @@ namespace experimental {
         }
 
         inline void reseed() {
-            static_assert(
-                is_same_v<default_random_engine, mt19937>, "This code assumes that default_random_engine is mt19937");
-            constexpr size_t _Nx = mt19937::state_size;
-            constexpr size_t _Wx = mt19937::word_size;
-            static_assert(_Wx % 32 == 0, "mt19937::word_size is not a multiple of 32");
-            constexpr size_t _Kx = _Wx / 32;
-
-            uint32_t _Values[_Nx * _Kx];
-            random_device _Rd;
-            _STD generate(_STD begin(_Values), _STD end(_Values), _STD ref(_Rd));
-            seed_seq _Seq(_STD cbegin(_Values), _STD cend(_Values));
-
-            _Engine().seed(_Seq);
+            _Engine().seed(_Seed_engine());
         }
 
         inline void reseed(const default_random_engine::result_type _Value) {

--- a/stl/inc/experimental/random
+++ b/stl/inc/experimental/random
@@ -42,8 +42,8 @@ namespace experimental {
 
             uint32_t _Values[_N * _K];
             random_device _Rd;
-            generate(begin(_Values), end(_Values), ref(_Rd));
-            seed_seq _Seq(cbegin(_Values), cend(_Values));
+            _STD generate(_STD begin(_Values), _STD end(_Values), _STD ref(_Rd));
+            seed_seq _Seq(_STD cbegin(_Values), _STD cend(_Values));
 
             _Engine().seed(_Seq);
         }

--- a/stl/inc/experimental/random
+++ b/stl/inc/experimental/random
@@ -34,7 +34,20 @@ namespace experimental {
             return uniform_int_distribution<_IntType>{_Min, _Max}(_Engine());
         }
 
-        inline void reseed(const default_random_engine::result_type _Value = random_device{}()) {
+        inline void reseed() {
+            constexpr size_t _N = mt19937::state_size;
+            constexpr size_t _W = mt19937::word_size;
+            static_assert(_W % 32 == 0, "mt19937::word_size is not a multiple of 32");
+            constexpr size_t _K = _W / 32;
+
+            uint32_t _Values[_N * _K];
+            random_device _Rd;
+            generate(begin(_Values), end(_Values), ref(_Rd));
+            seed_seq _Seq(cbegin(_Values), cend(_Values));
+
+            _Engine().seed(_Seq);
+        }
+        inline void reseed(const default_random_engine::result_type _Value) {
             _Engine().seed(_Value);
         }
     } // namespace fundamentals_v3

--- a/stl/inc/experimental/random
+++ b/stl/inc/experimental/random
@@ -43,7 +43,7 @@ namespace experimental {
             uint32_t _Values[_N * _K];
             random_device _Rd;
             _STD generate(_STD begin(_Values), _STD end(_Values), _STD ref(_Rd));
-            seed_seq _Seq(_STD cbegin(_Values), _STD cend(_Values));
+            seed_seq _Seq{_STD cbegin(_Values), _STD cend(_Values)};
 
             _Engine().seed(_Seq);
         }

--- a/stl/inc/experimental/random
+++ b/stl/inc/experimental/random
@@ -35,6 +35,8 @@ namespace experimental {
         }
 
         inline void reseed() {
+            static_assert(
+                is_same_v<default_random_engine, mt19937>, "This code assumes that default_random_engine is mt19937");
             constexpr size_t _Nx = mt19937::state_size;
             constexpr size_t _Wx = mt19937::word_size;
             static_assert(_Wx % 32 == 0, "mt19937::word_size is not a multiple of 32");

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -999,6 +999,7 @@
 #define __cpp_lib_experimental_erase_if   201411L
 #define __cpp_lib_experimental_filesystem 201406L
 #define __cpp_lib_experimental_randint    201511L
+#define __cpp_lib_experimental_sample     201402L
 
 
 #ifdef _RTC_CONVERSION_CHECKS_ENABLED

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -998,6 +998,7 @@
 // EXPERIMENTAL
 #define __cpp_lib_experimental_erase_if   201411L
 #define __cpp_lib_experimental_filesystem 201406L
+#define __cpp_lib_experimental_randint    201511L
 
 
 #ifdef _RTC_CONVERSION_CHECKS_ENABLED


### PR DESCRIPTION
# Description

Implemented `std::experimental::randint` from [library fundamentals v3](https://cplusplus.github.io/fundamentals-ts/v3.html#rand.util.randint).

It's very common for beginners to want random ints for implementing things like tic-tac-toe or a variety of other terminal based games when they're learning C++.
However `rand()` is discouraged (I believe STL said even beginners shouldn't be using it - or something to that effect on reddit before) and `<random>` is not beginner friendly so I believe this would be a nice addition.

# Checklist

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [ ] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
