### PR TITLE
Adds a description of why we implement invoke as we do

### DIFF
--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -1473,16 +1473,16 @@ _NODISCARD constexpr conditional_t<!is_nothrow_move_constructible_v<_Ty> && is_c
     return _STD move(_Arg);
 }
 
-// std::invoke isn't constexpr in C++17, and implementers are forbidden from "strengthening"
-// constexpr, yet both std::apply and std::visit are required to be constexpr and have invoke-like behavior. We solve
-// this by using a macro to stamp out both public non-constexpr and internal constexpr implementations.
-
-// Now that a Core Language issue affecting constexpr invoke() has been fixed (CWG1581), we may make this unconditional
-// and remove the macro (which violates the strengthening rule in C++14/17 mode).
-// TRANSITION, P1065R2
-
 template <class _Ty>
 class reference_wrapper;
+
+// std::invoke isn't constexpr in C++17, and implementers are forbidden from
+// "strengthening" constexpr (WG21-N4842 [constexpr.functions]/1), yet both std::apply and std::visit are required to be
+// constexpr and have invoke-like behavior. We solve this by using a macro to stamp out both public non-constexpr and
+// internal constexpr implementations.
+
+// Now that a Core Language issue affecting constexpr std::invoke has been fixed (CWG-1581), we may make this
+// unconditional and remove the macro (which violates the strengthening rule in C++14/17 mode). TRANSITION, P1065R2
 
 #define _CONCATX(x, y) x##y
 #define _CONCAT(x, y)  _CONCATX(x, y)

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -1477,8 +1477,8 @@ _NODISCARD constexpr conditional_t<!is_nothrow_move_constructible_v<_Ty> && is_c
 // it to be constexpr, yet variant visit() is required to be constexpr and have invoke-like behavior. We solve this by
 // using a macro to stamp out a public non-constexpr and internal constexpr implementation.
 
-// Now that a Core Language issue affecting constexpr invoke() has been fixed, we’ll probably make this unconditional
-// and remove the macro (which would technically violate the strengthening rule in C++14/17 mode, but meh).
+// Now that a Core Language issue affecting constexpr invoke() has been fixed, we may make this unconditional
+// and remove the macro (which would technically violate the strengthening rule in C++14/17 mode).
 // TRANSITION, P1065R2
 
 template <class _Ty>

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -1473,9 +1473,9 @@ _NODISCARD constexpr conditional_t<!is_nothrow_move_constructible_v<_Ty> && is_c
     return _STD move(_Arg);
 }
 
-// invoke() isn’t constexpr in C++17, and implementers are forbidden from “strengthening”
-// constexpr, yet both std::apply and std::visit are required to be constexpr and have invoke-like behavior. We solve this by
-// using a macro to stamp out both public non-constexpr and internal constexpr implementations.
+// std::invoke isn’t constexpr in C++17, and implementers are forbidden from “strengthening”
+// constexpr, yet both std::apply and std::visit are required to be constexpr and have invoke-like behavior. We solve
+// this by using a macro to stamp out both public non-constexpr and internal constexpr implementations.
 
 // Now that a Core Language issue affecting constexpr invoke() has been fixed (CWG1581), we may make this unconditional
 // and remove the macro (which violates the strengthening rule in C++14/17 mode).

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -1473,7 +1473,7 @@ _NODISCARD constexpr conditional_t<!is_nothrow_move_constructible_v<_Ty> && is_c
     return _STD move(_Arg);
 }
 
-// Currently, invoke() isn’t depicted as constexpr in the Standard, and implementers are forbidden from “strengthening”
+// invoke() isn’t constexpr in C++17, and implementers are forbidden from “strengthening”
 // it to be constexpr, yet variant visit() is required to be constexpr and have invoke-like behavior. We solve this by
 // using a macro to stamp out a public non-constexpr and internal constexpr implementation.
 

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -1475,7 +1475,7 @@ _NODISCARD constexpr conditional_t<!is_nothrow_move_constructible_v<_Ty> && is_c
 
 // invoke() isn’t constexpr in C++17, and implementers are forbidden from “strengthening”
 // it to be constexpr, yet variant visit() is required to be constexpr and have invoke-like behavior. We solve this by
-// using a macro to stamp out a public non-constexpr and internal constexpr implementation.
+// using a macro to stamp out both public non-constexpr and internal constexpr implementations.
 
 // Now that a Core Language issue affecting constexpr invoke() has been fixed (CWG1581), we may make this unconditional
 // and remove the macro (which would technically violate the strengthening rule in C++14/17 mode).

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -1481,9 +1481,6 @@ class reference_wrapper;
 // behavior. We solve this by using a macro to stamp out both public non-constexpr and internal constexpr
 // implementations.
 
-// Now that a Core Language issue affecting constexpr std::invoke has been fixed (CWG-1581), we may make this
-// unconditional and remove the macro (which violates the strengthening rule in C++14/17 mode). TRANSITION, P1065R2
-
 #define _CONCATX(x, y) x##y
 #define _CONCAT(x, y)  _CONCATX(x, y)
 

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -1476,10 +1476,10 @@ _NODISCARD constexpr conditional_t<!is_nothrow_move_constructible_v<_Ty> && is_c
 template <class _Ty>
 class reference_wrapper;
 
-// std::invoke isn't constexpr in C++17, and implementers are forbidden from
-// "strengthening" constexpr (WG21-N4842 [constexpr.functions]/1), yet both std::apply and std::visit are required to be
-// constexpr and have invoke-like behavior. We solve this by using a macro to stamp out both public non-constexpr and
-// internal constexpr implementations.
+// std::invoke isn't constexpr in C++17, and implementers are forbidden from "strengthening" constexpr (WG21-N4842
+// [constexpr.functions]/1), yet both std::apply and std::visit are required to be constexpr and have invoke-like
+// behavior. We solve this by using a macro to stamp out both public non-constexpr and internal constexpr
+// implementations.
 
 // Now that a Core Language issue affecting constexpr std::invoke has been fixed (CWG-1581), we may make this
 // unconditional and remove the macro (which violates the strengthening rule in C++14/17 mode). TRANSITION, P1065R2

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -1474,7 +1474,7 @@ _NODISCARD constexpr conditional_t<!is_nothrow_move_constructible_v<_Ty> && is_c
 }
 
 // invoke() isn’t constexpr in C++17, and implementers are forbidden from “strengthening”
-// it to be constexpr, yet variant visit() is required to be constexpr and have invoke-like behavior. We solve this by
+// constexpr, yet both std::apply and std::visit are required to be constexpr and have invoke-like behavior. We solve this by
 // using a macro to stamp out both public non-constexpr and internal constexpr implementations.
 
 // Now that a Core Language issue affecting constexpr invoke() has been fixed (CWG1581), we may make this unconditional

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -1473,7 +1473,7 @@ _NODISCARD constexpr conditional_t<!is_nothrow_move_constructible_v<_Ty> && is_c
     return _STD move(_Arg);
 }
 
-// std::invoke isn’t constexpr in C++17, and implementers are forbidden from “strengthening”
+// std::invoke isn’t constexpr in C++17, and implementers are forbidden from "strengthening"
 // constexpr, yet both std::apply and std::visit are required to be constexpr and have invoke-like behavior. We solve
 // this by using a macro to stamp out both public non-constexpr and internal constexpr implementations.
 

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -1478,7 +1478,7 @@ _NODISCARD constexpr conditional_t<!is_nothrow_move_constructible_v<_Ty> && is_c
 // using a macro to stamp out both public non-constexpr and internal constexpr implementations.
 
 // Now that a Core Language issue affecting constexpr invoke() has been fixed (CWG1581), we may make this unconditional
-// and remove the macro (which would technically violate the strengthening rule in C++14/17 mode).
+// and remove the macro (which violates the strengthening rule in C++14/17 mode).
 // TRANSITION, P1065R2
 
 template <class _Ty>

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -1479,7 +1479,7 @@ class reference_wrapper;
 // std::invoke isn't constexpr in C++17, and implementers are forbidden from "strengthening" constexpr (WG21-N4842
 // [constexpr.functions]/1), yet both std::apply and std::visit are required to be constexpr and have invoke-like
 // behavior. We solve this by using a macro to stamp out both public non-constexpr and internal constexpr
-// implementations.
+// implementations. TRANSITION, P1065R2
 
 #define _CONCATX(x, y) x##y
 #define _CONCAT(x, y)  _CONCATX(x, y)

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -1473,6 +1473,14 @@ _NODISCARD constexpr conditional_t<!is_nothrow_move_constructible_v<_Ty> && is_c
     return _STD move(_Arg);
 }
 
+// Currently, invoke() isn’t depicted as constexpr in the Standard, and implementers are forbidden from “strengthening”
+// it to be constexpr, yet variant visit() is required to be constexpr and have invoke-like behavior. We solve this by
+// using a macro to stamp out a public non-constexpr and internal constexpr implementation.
+
+// Now that a Core Language issue affecting constexpr invoke() has been fixed, we’ll probably make this unconditional
+// and remove the macro (which would technically violate the strengthening rule in C++14/17 mode, but meh).
+// TRANSITION, P1065R2
+
 template <class _Ty>
 class reference_wrapper;
 

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -1477,7 +1477,7 @@ _NODISCARD constexpr conditional_t<!is_nothrow_move_constructible_v<_Ty> && is_c
 // it to be constexpr, yet variant visit() is required to be constexpr and have invoke-like behavior. We solve this by
 // using a macro to stamp out a public non-constexpr and internal constexpr implementation.
 
-// Now that a Core Language issue affecting constexpr invoke() has been fixed, we may make this unconditional
+// Now that a Core Language issue affecting constexpr invoke() has been fixed (CWG1581), we may make this unconditional
 // and remove the macro (which would technically violate the strengthening rule in C++14/17 mode).
 // TRANSITION, P1065R2
 

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -1473,7 +1473,7 @@ _NODISCARD constexpr conditional_t<!is_nothrow_move_constructible_v<_Ty> && is_c
     return _STD move(_Arg);
 }
 
-// std::invoke isn’t constexpr in C++17, and implementers are forbidden from "strengthening"
+// std::invoke isn't constexpr in C++17, and implementers are forbidden from "strengthening"
 // constexpr, yet both std::apply and std::visit are required to be constexpr and have invoke-like behavior. We solve
 // this by using a macro to stamp out both public non-constexpr and internal constexpr implementations.
 


### PR DESCRIPTION
# Description
I ran across [this](https://www.reddit.com/r/cpp/comments/e7oynp/what_are_you_excited_for_c20_to_bring/fa7pcxp/) comment on reddit from our very own @StephanTLavavej about why we need the `_IMPLEMENT_INVOKE` macro. I thought it was helpful and I had bounced off that particular macro a few times, so I added his explanation as a comment in the code (with some minor editing)


# Checklist

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [x] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
