### PR TITLE
yvals_core.h: Remove "toolset update" workaround.

### DIFF
--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -977,10 +977,9 @@
 #define __cpp_lib_generic_unordered_lookup 201811L
 #define __cpp_lib_int_pow2                 201806L
 
-#if defined(__clang__) || defined(__EDG__) \
-    || (defined(_MSC_VER) && _MSC_VER >= 1925 && !(_MSC_FULL_VER == 192528318 && _MSC_BUILD == 97))
+#if defined(__clang__) || defined(__EDG__) || (defined(_MSC_VER) && _MSC_VER >= 1925)
 #define __cpp_lib_is_constant_evaluated 201811L
-#endif // TRANSITION, VS 2019 16.5 Preview 2 and toolset update
+#endif // TRANSITION, VS 2019 16.5 Preview 2
 
 #define __cpp_lib_list_remove_return_type 201806L
 #define __cpp_lib_math_constants          201907L


### PR DESCRIPTION
# Description

Currently, we're building the STL in both our Microsoft-internal MSVC
repo and in GitHub, as we work on the migration. The MSVC repo uses a
checked-in compiler (the "toolset") to build the STL and the compiler
itself. Earlier, the checked-in toolset identified itself as
19.25.28318.97 but lacked support for `is_constant_evaluated`, so we
needed to detect that exact version number. Now, the toolset has been
updated, so this workaround is no longer necessary.

When VS 2019 16.5 Preview 2 is available in the future, we'll begin
requiring it to build the GitHub sources, at which point we'll be able
to unconditionally define `__cpp_lib_is_constant_evaluated`.

# Checklist

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [ ] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
