### PR TITLE
Fix #347: <shared_mutex>: Do we still need the _USING_V110_SDK71_ guard?

### DIFF
--- a/stl/inc/shared_mutex
+++ b/stl/inc/shared_mutex
@@ -28,7 +28,6 @@ _STL_DISABLE_CLANG_WARNINGS
 
 
 _STD_BEGIN
-#ifdef __cpp_lib_shared_mutex
 // CLASS shared_mutex
 class shared_mutex { // class for mutual exclusion shared across threads
 public:
@@ -73,7 +72,6 @@ public:
 private:
     _Smtx_t _Myhandle;
 };
-#endif // __cpp_lib_shared_mutex
 
 // shared_timed_mutex is not supported under /clr
 #ifndef _M_CEE

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -892,15 +892,13 @@
 #define __cpp_lib_logical_traits                   201510L
 #define __cpp_lib_map_try_emplace                  201411L
 #define __cpp_lib_nonmember_container_access       201411L
-#ifndef _USING_V110_SDK71_
-#define __cpp_lib_shared_mutex 201505L
-#endif // _USING_V110_SDK71_
-#define __cpp_lib_shared_ptr_arrays             201611L
-#define __cpp_lib_transparent_operators         201510L
-#define __cpp_lib_type_trait_variable_templates 201510L
-#define __cpp_lib_uncaught_exceptions           201411L
-#define __cpp_lib_unordered_map_try_emplace     201411L
-#define __cpp_lib_void_t                        201411L
+#define __cpp_lib_shared_mutex                     201505L
+#define __cpp_lib_shared_ptr_arrays                201611L
+#define __cpp_lib_transparent_operators            201510L
+#define __cpp_lib_type_trait_variable_templates    201510L
+#define __cpp_lib_uncaught_exceptions              201411L
+#define __cpp_lib_unordered_map_try_emplace        201411L
+#define __cpp_lib_void_t                           201411L
 
 #if _HAS_CXX17
 #define __cpp_lib_any                        201606L


### PR DESCRIPTION
# Description

While we must continue to support `msvcp140.dll` running on Windows XP,
we don't need to support compiling our headers with the (removed)
`v140_xp` toolset and its corresponding old Windows SDK. Accordingly,
we can unconditionally define `shared_mutex`. (This is a C++17 feature,
but it was implemented before Standard modes, so it's not guarded by
`_HAS_CXX17`.)

# Checklist

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [ ] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
