### PR TITLE
Fix #340: <functional>: _HAS_STATIC_RTTI=0 shouldn't say typeid(void)

### DIFF
--- a/stl/inc/functional
+++ b/stl/inc/functional
@@ -866,7 +866,7 @@ private:
 #if _HAS_STATIC_RTTI
         return typeid(_Callable);
 #else // _HAS_STATIC_RTTI
-        return typeid(void);
+        _CSTD abort();
 #endif // _HAS_STATIC_RTTI
     }
 
@@ -930,7 +930,7 @@ private:
 #if _HAS_STATIC_RTTI
         return typeid(_Callable);
 #else // _HAS_STATIC_RTTI
-        return typeid(void);
+        _CSTD abort();
 #endif // _HAS_STATIC_RTTI
     }
 

--- a/stl/inc/xlocale
+++ b/stl/inc/xlocale
@@ -438,7 +438,7 @@ const _Facet& __CRTDECL use_facet(const locale& _Loc) { // get facet reference f
 #if _HAS_EXCEPTIONS
             _Throw_bad_cast(); // lazy disallowed
 #else // _HAS_EXCEPTIONS
-            abort(); // lazy disallowed
+            _CSTD abort(); // lazy disallowed
 #endif // _HAS_EXCEPTIONS
         } else { // queue up lazy facet for destruction
             auto _Pfmod = const_cast<locale::facet*>(_Psave);


### PR DESCRIPTION
# Description

This calls `abort()` as there's no need to invoke the terminate handler.

(This is a virtual function, so eliminating it entirely would risk ODR
violations leading to crashes. It's much safer to provide a definition
that can't be called.)

Additionally, fix `<xlocale>` to qualify `_CSTD abort()`.

# Checklist

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [ ] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
