### PR TITLE
Make _Hash lookup functions not be overloads

### DIFF
--- a/stl/inc/hash_map
+++ b/stl/inc/hash_map
@@ -28,7 +28,7 @@ namespace stdext {
     using _STD is_constructible_v;
     using _STD pair;
     using _STD swap;
-    using _STD _Hash;
+    using _STD _Hash_transparency_facade;
     using _STD _Is_nothrow_swappable;
     using _STD _Swap_adl;
     using _STD _Xout_of_range;
@@ -57,9 +57,7 @@ namespace stdext {
 
         template <class... _Args>
         using _In_place_key_extractor = _STD _In_place_key_extract_map<_Kty, _Args...>;
-        template <class>
-        using _Deduce_key = const _Kty&;
-        using key_equal   = _Tr;
+        using key_equal               = _Tr;
 
         _Hmap_traits() = default;
 
@@ -112,10 +110,10 @@ namespace stdext {
     // CLASS TEMPLATE hash_map
     template <class _Kty, class _Ty, class _Tr = hash_compare<_Kty, less<_Kty>>,
         class _Alloc = allocator<pair<const _Kty, _Ty>>>
-    class hash_map : public _Hash<_Hmap_traits<_Kty, _Ty, _Tr, _Alloc, false>> {
+    class hash_map : public _Hash_transparency_facade<_Hmap_traits<_Kty, _Ty, _Tr, _Alloc, false>> {
         // hash table of {key, mapped} values, unique keys
     public:
-        using _Mybase         = _Hash<_Hmap_traits<_Kty, _Ty, _Tr, _Alloc, false>>;
+        using _Mybase         = _Hash_transparency_facade<_Hmap_traits<_Kty, _Ty, _Tr, _Alloc, false>>;
         using key_type        = _Kty;
         using mapped_type     = _Ty;
         using referent_type   = _Ty;
@@ -302,10 +300,10 @@ namespace stdext {
     // CLASS TEMPLATE hash_multimap
     template <class _Kty, class _Ty, class _Tr = hash_compare<_Kty, less<_Kty>>,
         class _Alloc = allocator<pair<const _Kty, _Ty>>>
-    class hash_multimap : public _Hash<_Hmap_traits<_Kty, _Ty, _Tr, _Alloc, true>> {
+    class hash_multimap : public _Hash_transparency_facade<_Hmap_traits<_Kty, _Ty, _Tr, _Alloc, true>> {
         // hash table of {key, mapped} values, non-unique keys
     public:
-        using _Mybase         = _Hash<_Hmap_traits<_Kty, _Ty, _Tr, _Alloc, true>>;
+        using _Mybase         = _Hash_transparency_facade<_Hmap_traits<_Kty, _Ty, _Tr, _Alloc, true>>;
         using key_type        = _Kty;
         using mapped_type     = _Ty;
         using referent_type   = _Ty; // old name, magically gone

--- a/stl/inc/hash_set
+++ b/stl/inc/hash_set
@@ -25,7 +25,7 @@ _SILENCE_STDEXT_HASH_DEPRECATION_WARNINGS to acknowledge that you have received 
 namespace stdext {
     using _STD allocator;
     using _STD swap;
-    using _STD _Hash;
+    using _STD _Hash_transparency_facade;
     using _STD _Is_nothrow_swappable;
     using _STD _Swap_adl;
 
@@ -52,9 +52,7 @@ namespace stdext {
 
         template <class... _Args>
         using _In_place_key_extractor = _STD _In_place_key_extract_set<_Kty, _Args...>;
-        template <class>
-        using _Deduce_key = const _Kty&;
-        using key_equal   = _Tr;
+        using key_equal               = _Tr;
 
         _Hset_traits() = default;
 
@@ -89,9 +87,10 @@ namespace stdext {
 
     // CLASS TEMPLATE hash_set
     template <class _Kty, class _Tr = hash_compare<_Kty, less<_Kty>>, class _Alloc = allocator<_Kty>>
-    class hash_set : public _Hash<_Hset_traits<_Kty, _Tr, _Alloc, false>> { // hash table of key values, unique keys
+    class hash_set : public _Hash_transparency_facade<_Hset_traits<_Kty, _Tr, _Alloc, false>> {
+        // hash table of key values, unique keys
     public:
-        using _Mybase         = _Hash<_Hset_traits<_Kty, _Tr, _Alloc, false>>;
+        using _Mybase         = _Hash_transparency_facade<_Hset_traits<_Kty, _Tr, _Alloc, false>>;
         using key_type        = _Kty;
         using key_compare     = _Tr;
         using value_compare   = typename _Mybase::_Value_compare;
@@ -235,10 +234,10 @@ namespace stdext {
 
     // CLASS TEMPLATE hash_multiset
     template <class _Kty, class _Tr = hash_compare<_Kty, less<_Kty>>, class _Alloc = allocator<_Kty>>
-    class hash_multiset
-        : public _Hash<_Hset_traits<_Kty, _Tr, _Alloc, true>> { // hash table of key values, non-unique keys
+    class hash_multiset : public _Hash_transparency_facade<_Hset_traits<_Kty, _Tr, _Alloc, true>> {
+        // hash table of key values, non-unique keys
     public:
-        using _Mybase         = _Hash<_Hset_traits<_Kty, _Tr, _Alloc, true>>;
+        using _Mybase         = _Hash_transparency_facade<_Hset_traits<_Kty, _Tr, _Alloc, true>>;
         using key_type        = _Kty;
         using key_compare     = _Tr;
         using value_compare   = typename _Mybase::_Value_compare;

--- a/stl/inc/unordered_map
+++ b/stl/inc/unordered_map
@@ -83,15 +83,17 @@ public:
 // CLASS TEMPLATE unordered_map
 template <class _Kty, class _Ty, class _Hasher = hash<_Kty>, class _Keyeq = equal_to<_Kty>,
     class _Alloc = allocator<pair<const _Kty, _Ty>>>
-class unordered_map : public _Hash<_Umap_traits<_Kty, _Ty, _Uhash_compare<_Kty, _Hasher, _Keyeq>, _Alloc, false>> {
+class unordered_map
+    : public _Hash_transparency_facade<_Umap_traits<_Kty, _Ty, _Uhash_compare<_Kty, _Hasher, _Keyeq>, _Alloc, false>> {
     // hash table of {key, mapped} values, unique keys
 public:
     static_assert(!_ENFORCE_MATCHING_ALLOCATORS || is_same_v<pair<const _Kty, _Ty>, typename _Alloc::value_type>,
         _MISMATCHED_ALLOCATOR_MESSAGE("unordered_map<Key, Value, Hasher, Eq, Allocator>", "pair<const Key, Value>"));
 
 private:
-    using _Mytraits      = _Uhash_compare<_Kty, _Hasher, _Keyeq>;
-    using _Mybase        = _Hash<_Umap_traits<_Kty, _Ty, _Mytraits, _Alloc, false>>;
+    using _Mytraits = _Uhash_compare<_Kty, _Hasher, _Keyeq>;
+    using _Mybase =
+        _Hash_transparency_facade<_Umap_traits<_Kty, _Ty, _Uhash_compare<_Kty, _Hasher, _Keyeq>, _Alloc, false>>;
     using _Alnode        = typename _Mybase::_Alnode;
     using _Alnode_traits = typename _Mybase::_Alnode_traits;
     using _Nodeptr       = typename _Mybase::_Nodeptr;
@@ -495,7 +497,8 @@ _NODISCARD bool operator!=(const unordered_map<_Kty, _Ty, _Hasher, _Keyeq, _Allo
 // CLASS TEMPLATE unordered_multimap
 template <class _Kty, class _Ty, class _Hasher = hash<_Kty>, class _Keyeq = equal_to<_Kty>,
     class _Alloc = allocator<pair<const _Kty, _Ty>>>
-class unordered_multimap : public _Hash<_Umap_traits<_Kty, _Ty, _Uhash_compare<_Kty, _Hasher, _Keyeq>, _Alloc, true>> {
+class unordered_multimap
+    : public _Hash_transparency_facade<_Umap_traits<_Kty, _Ty, _Uhash_compare<_Kty, _Hasher, _Keyeq>, _Alloc, true>> {
     // hash table of {key, mapped} values, non-unique keys
 public:
     static_assert(!_ENFORCE_MATCHING_ALLOCATORS || is_same_v<pair<const _Kty, _Ty>, typename _Alloc::value_type>,
@@ -503,8 +506,9 @@ public:
             "unordered_multimap<Key, Value, Hasher, Eq, Allocator>", "pair<const Key, Value>"));
 
 private:
-    using _Mytraits      = _Uhash_compare<_Kty, _Hasher, _Keyeq>;
-    using _Mybase        = _Hash<_Umap_traits<_Kty, _Ty, _Mytraits, _Alloc, true>>;
+    using _Mytraits = _Uhash_compare<_Kty, _Hasher, _Keyeq>;
+    using _Mybase =
+        _Hash_transparency_facade<_Umap_traits<_Kty, _Ty, _Uhash_compare<_Kty, _Hasher, _Keyeq>, _Alloc, true>>;
     using _Alnode        = typename _Mybase::_Alnode;
     using _Alnode_traits = typename _Mybase::_Alnode_traits;
     using _Key_compare   = typename _Mybase::_Key_compare;

--- a/stl/inc/unordered_set
+++ b/stl/inc/unordered_set
@@ -62,16 +62,17 @@ public:
 
 // CLASS TEMPLATE unordered_set
 template <class _Kty, class _Hasher = hash<_Kty>, class _Keyeq = equal_to<_Kty>, class _Alloc = allocator<_Kty>>
-class unordered_set : public _Hash<_Uset_traits<_Kty, _Uhash_compare<_Kty, _Hasher, _Keyeq>, _Alloc, false>> {
+class unordered_set
+    : public _Hash_transparency_facade<_Uset_traits<_Kty, _Uhash_compare<_Kty, _Hasher, _Keyeq>, _Alloc, false>> {
     // hash table of key-values, unique keys
 public:
     static_assert(!_ENFORCE_MATCHING_ALLOCATORS || is_same_v<_Kty, typename _Alloc::value_type>,
         _MISMATCHED_ALLOCATOR_MESSAGE("unordered_set<T, Hasher, Eq, Allocator>", "T"));
 
 private:
-    using _Mytraits      = _Uhash_compare<_Kty, _Hasher, _Keyeq>;
-    using _Mybase        = _Hash<_Uset_traits<_Kty, _Mytraits, _Alloc, false>>;
-    using _Alnode        = typename _Mybase::_Alnode;
+    using _Mytraits = _Uhash_compare<_Kty, _Hasher, _Keyeq>;
+    using _Mybase = _Hash_transparency_facade<_Uset_traits<_Kty, _Uhash_compare<_Kty, _Hasher, _Keyeq>, _Alloc, false>>;
+    using _Alnode = typename _Mybase::_Alnode;
     using _Alnode_traits = typename _Mybase::_Alnode_traits;
     using _Key_compare   = typename _Mybase::_Key_compare;
 
@@ -330,16 +331,17 @@ _NODISCARD bool operator!=(const unordered_set<_Kty, _Hasher, _Keyeq, _Alloc>& _
 
 // CLASS TEMPLATE unordered_multiset
 template <class _Kty, class _Hasher = hash<_Kty>, class _Keyeq = equal_to<_Kty>, class _Alloc = allocator<_Kty>>
-class unordered_multiset : public _Hash<_Uset_traits<_Kty, _Uhash_compare<_Kty, _Hasher, _Keyeq>, _Alloc, true>> {
+class unordered_multiset
+    : public _Hash_transparency_facade<_Uset_traits<_Kty, _Uhash_compare<_Kty, _Hasher, _Keyeq>, _Alloc, true>> {
     // hash table of key-values, non-unique keys
 public:
     static_assert(!_ENFORCE_MATCHING_ALLOCATORS || is_same_v<_Kty, typename _Alloc::value_type>,
         _MISMATCHED_ALLOCATOR_MESSAGE("unordered_multiset<T, Hasher, Eq, Allocator>", "T"));
 
 private:
-    using _Mytraits      = _Uhash_compare<_Kty, _Hasher, _Keyeq>;
-    using _Mybase        = _Hash<_Uset_traits<_Kty, _Mytraits, _Alloc, true>>;
-    using _Alnode        = typename _Mybase::_Alnode;
+    using _Mytraits = _Uhash_compare<_Kty, _Hasher, _Keyeq>;
+    using _Mybase = _Hash_transparency_facade<_Uset_traits<_Kty, _Uhash_compare<_Kty, _Hasher, _Keyeq>, _Alloc, true>>;
+    using _Alnode = typename _Mybase::_Alnode;
     using _Alnode_traits = typename _Mybase::_Alnode_traits;
     using _Key_compare   = typename _Mybase::_Key_compare;
 

--- a/stl/inc/xhash
+++ b/stl/inc/xhash
@@ -109,35 +109,20 @@ namespace stdext {
 _STD_BEGIN
 using stdext::hash_compare; // TRANSITION, protobuf used this until v3.7.0, released Feb 28, 2019
 
-template <class _Kty, class _Hasher, class _Keyeq, class = void>
-struct _Uhash_choose_transparency {
-    // transparency selector for non-transparent hashed containers
-    template <class>
-    using _Deduce_key = const _Kty&;
-};
-
-#if _HAS_CXX20
-template <class _Kty, class _Hasher, class _Keyeq>
-struct _Uhash_choose_transparency<_Kty, _Hasher, _Keyeq,
-    void_t<typename _Hasher::is_transparent, typename _Keyeq::is_transparent>> {
-    // transparency selector for transparent hashed containers
-    template <class _Keyty>
-    using _Deduce_key = const _Keyty&;
-};
-#endif // _HAS_CXX20
-
 template <class _Hasher, class _Kty>
 _INLINE_VAR constexpr bool _Nothrow_hash = noexcept(
     static_cast<size_t>(_STD declval<const _Hasher&>()(_STD declval<const _Kty&>())));
 
 // CLASS TEMPLATE _Uhash_compare
 template <class _Kty, class _Hasher, class _Keyeq>
-class _Uhash_compare
-    : public _Uhash_choose_transparency<_Kty, _Hasher, _Keyeq> { // traits class for unordered containers
+class _Uhash_compare { // traits class for unordered containers
 public:
     enum { // parameters for hash table
         bucket_size = 1 // 0 < bucket_size
     };
+
+    using hasher    = _Hasher;
+    using key_equal = _Keyeq;
 
     _Uhash_compare() noexcept(
         conjunction_v<is_nothrow_default_constructible<_Hasher>, is_nothrow_default_constructible<_Keyeq>>)
@@ -1282,7 +1267,7 @@ public:
         _STD fill(_Vec._Mypair._Myval2._Myfirst, _Vec._Mypair._Myval2._Mylast, _Unchecked_end());
     }
 
-private:
+protected:
     template <class _Keyty>
     _NODISCARD _Nodeptr _Find_first(const _Keyty& _Keyval, const size_t _Hashval) const {
         // find node pointer to first node matching _Keyval (with hash _Hashval) if it exists; otherwise, end
@@ -1332,35 +1317,6 @@ private:
     }
 
 public:
-    template <class _Keyty = void>
-    _NODISCARD iterator find(typename _Traits::template _Deduce_key<_Keyty> _Keyval) {
-        return _List._Make_iter(_Find(_Keyval, _Traitsobj(_Keyval)));
-    }
-
-    template <class _Keyty = void>
-    _NODISCARD const_iterator find(typename _Traits::template _Deduce_key<_Keyty> _Keyval) const {
-        return _List._Make_const_iter(_Find(_Keyval, _Traitsobj(_Keyval)));
-    }
-
-#if _HAS_CXX20
-    template <class _Keyty = void>
-    _NODISCARD bool contains(typename _Traits::template _Deduce_key<_Keyty> _Keyval) const {
-        return static_cast<bool>(_Find_last(_Keyval, _Traitsobj(_Keyval))._Duplicate);
-    }
-#endif // _HAS_CXX20
-
-    template <class _Keyty = void>
-    _NODISCARD size_type count(typename _Traits::template _Deduce_key<_Keyty> _Keyval) const {
-        const size_t _Hashval = _Traitsobj(_Keyval);
-        if
-            _CONSTEXPR_IF(_Multi) {
-                return _Equal_range(_Keyval, _Hashval)._Distance;
-            }
-        else {
-            return static_cast<bool>(_Find_last(_Keyval, _Hashval)._Duplicate);
-        }
-    }
-
     _DEPRECATE_STDEXT_HASH_LOWER_BOUND _NODISCARD iterator lower_bound(const key_type& _Keyval) {
         return _List._Make_iter(_Find(_Keyval, _Traitsobj(_Keyval)));
     }
@@ -1391,7 +1347,7 @@ public:
         return _List._Make_const_iter(_Target);
     }
 
-private:
+protected:
     struct _Equal_range_result {
         _Unchecked_const_iterator _First;
         _Unchecked_const_iterator _Last;
@@ -1449,19 +1405,6 @@ private:
     }
 
 public:
-    template <class _Keyty = void>
-    _NODISCARD pair<iterator, iterator> equal_range(typename _Traits::template _Deduce_key<_Keyty> _Keyval) {
-        const auto _Result = _Equal_range(_Keyval, _Traitsobj(_Keyval));
-        return {_List._Make_iter(_Result._First._Ptr), _List._Make_iter(_Result._Last._Ptr)};
-    }
-
-    template <class _Keyty = void>
-    _NODISCARD pair<const_iterator, const_iterator> equal_range(
-        typename _Traits::template _Deduce_key<_Keyty> _Keyval) const {
-        const auto _Result = _Equal_range(_Keyval, _Traitsobj(_Keyval));
-        return {_List._Make_const_iter(_Result._First._Ptr), _List._Make_const_iter(_Result._Last._Ptr)};
-    }
-
     void swap(_Hash& _Right) noexcept(noexcept(_Traitsobj.swap(_Right._Traitsobj))) /* strengthened */ {
         if (this != _STD addressof(_Right)) {
             _Traitsobj.swap(_Right._Traitsobj);
@@ -1994,6 +1937,106 @@ protected:
     size_type _Mask; // the key mask
     size_type _Maxidx; // current maximum key value, must be a power of 2
 };
+
+template <class _Traits, class = void>
+struct _Hash_transparency_facade : _Hash<_Traits> {
+    // provide non-transparent versions of lookup functions
+    using key_type       = typename _Hash<_Traits>::key_type;
+    using iterator       = typename _Hash<_Traits>::iterator;
+    using const_iterator = typename _Hash<_Traits>::const_iterator;
+    using size_type      = typename _Hash<_Traits>::size_type;
+
+    using _Hash<_Traits>::_Hash;
+
+    _NODISCARD iterator find(const key_type& _Keyval) {
+        return this->_List._Make_iter(this->_Find(_Keyval, this->_Traitsobj(_Keyval)));
+    }
+
+    _NODISCARD const_iterator find(const key_type& _Keyval) const {
+        return this->_List._Make_const_iter(this->_Find(_Keyval, this->_Traitsobj(_Keyval)));
+    }
+
+#if _HAS_CXX20
+    _NODISCARD bool contains(const key_type& _Keyval) const {
+        return static_cast<bool>(this->_Find_last(_Keyval, this->_Traitsobj(_Keyval))._Duplicate);
+    }
+#endif // _HAS_CXX20
+
+    _NODISCARD size_type count(const key_type& _Keyval) const {
+        const size_t _Hashval = this->_Traitsobj(_Keyval);
+        if
+            _CONSTEXPR_IF(_Traits::_Multi) {
+                return this->_Equal_range(_Keyval, _Hashval)._Distance;
+            }
+        else {
+            return static_cast<bool>(this->_Find_last(_Keyval, _Hashval)._Duplicate);
+        }
+    }
+
+    _NODISCARD pair<iterator, iterator> equal_range(const key_type& _Keyval) {
+        const auto _Result = this->_Equal_range(_Keyval, this->_Traitsobj(_Keyval));
+        return {this->_List._Make_iter(_Result._First._Ptr), this->_List._Make_iter(_Result._Last._Ptr)};
+    }
+
+    _NODISCARD pair<const_iterator, const_iterator> equal_range(const key_type& _Keyval) const {
+        const auto _Result = this->_Equal_range(_Keyval, this->_Traitsobj(_Keyval));
+        return {this->_List._Make_const_iter(_Result._First._Ptr), this->_List._Make_const_iter(_Result._Last._Ptr)};
+    }
+};
+
+#if _HAS_CXX20
+template <class _Traits>
+struct _Hash_transparency_facade<_Traits, void_t<typename _Traits::key_compare::hasher::is_transparent,
+                                              typename _Traits::key_compare::key_equal::is_transparent>>
+    : _Hash<_Traits> {
+    // provide transparent versions of lookup functions
+
+    using iterator       = typename _Hash<_Traits>::iterator;
+    using const_iterator = typename _Hash<_Traits>::const_iterator;
+    using size_type      = typename _Hash<_Traits>::size_type;
+
+    using _Hash<_Traits>::_Hash;
+
+    template <class _Keyty>
+    _NODISCARD iterator find(const _Keyty& _Keyval) {
+        return this->_List._Make_iter(this->_Find(_Keyval, this->_Traitsobj(_Keyval)));
+    }
+
+    template <class _Keyty>
+    _NODISCARD const_iterator find(const _Keyty& _Keyval) const {
+        return this->_List._Make_const_iter(this->_Find(_Keyval, this->_Traitsobj(_Keyval)));
+    }
+
+    template <class _Keyty>
+    _NODISCARD bool contains(const _Keyty& _Keyval) const {
+        return static_cast<bool>(this->_Find_last(_Keyval, this->_Traitsobj(_Keyval))._Duplicate);
+    }
+
+    template <class _Keyty>
+    _NODISCARD size_type count(const _Keyty& _Keyval) const {
+        const size_t _Hashval = this->_Traitsobj(_Keyval);
+        if
+            _CONSTEXPR_IF(_Traits::_Multi) {
+                return this->_Equal_range(_Keyval, _Hashval)._Distance;
+            }
+        else {
+            return static_cast<bool>(this->_Find_last(_Keyval, _Hashval)._Duplicate);
+        }
+    }
+
+    template <class _Keyty>
+    _NODISCARD pair<iterator, iterator> equal_range(const _Keyty& _Keyval) {
+        const auto _Result = this->_Equal_range(_Keyval, this->_Traitsobj(_Keyval));
+        return {this->_List._Make_iter(_Result._First._Ptr), this->_List._Make_iter(_Result._Last._Ptr)};
+    }
+
+    template <class _Keyty>
+    _NODISCARD pair<const_iterator, const_iterator> equal_range(const _Keyty& _Keyval) const {
+        const auto _Result = this->_Equal_range(_Keyval, this->_Traitsobj(_Keyval));
+        return {this->_List._Make_const_iter(_Result._First._Ptr), this->_List._Make_const_iter(_Result._Last._Ptr)};
+    }
+};
+#endif // _HAS_CXX20
 
 #if _HAS_CXX17
 // ALIAS TEMPLATE _Is_hasher FOR CONSTRAINING DEDUCTION GUIDES, N4687 26.2.7 [unord.req]/17.3


### PR DESCRIPTION
Make _Hash lookup functions not be overloads when not using transparent lookup.

Hopefully this can improve throughput because no overload resolution need be done for those functions when C++20 transparent lookup is disengaged. Also resolves a breaking change for customers who were taking the address of these functions; though we still don't support doing that.

Resolves VSO-999214 and DevCom-769300.

# Checklist

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [x] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
