### PR TITLE
<complex> fix pow overload

### DIFF
--- a/stl/inc/complex
+++ b/stl/inc/complex
@@ -1585,26 +1585,6 @@ _NODISCARD complex<_Ty> log(const complex<_Ty>& _Left) {
 
 // FUNCTION TEMPLATE pow
 template <class _Ty>
-_NODISCARD complex<_Ty> pow(const complex<_Ty>& _Left, int _Right) {
-    complex<_Ty> _Tmp = _Left;
-    auto _Count       = static_cast<unsigned int>(_Right);
-
-    if (_Right < 0) {
-        _Count = 0 - _Count; // safe negation as unsigned
-    }
-
-    for (complex<_Ty> _Zv = complex<_Ty>(1);; _Tmp *= _Tmp) { // fold in _Left ^ (2 ^ _Count) as needed
-        if ((_Count & 1) != 0) {
-            _Zv *= _Tmp;
-        }
-
-        if ((_Count >>= 1) == 0) {
-            return _Right < 0 ? complex<_Ty>(1) / _Zv : _Zv;
-        }
-    }
-}
-
-template <class _Ty>
 complex<_Ty> _Pow(const _Ty& _Left, const _Ty& _Right) {
     if (0 <= _Left) {
         return _Ctraits<_Ty>::pow(_Left, _Right);
@@ -1804,39 +1784,63 @@ _NODISCARD complex<_Common_float_type_t<_Ty1, _Ty2>> pow(const complex<_Ty1>& _L
     return _STD pow(type(_Left), type(_Right));
 }
 
-template <class _Ty1, class _Ty2>
+template <class _Ty1, class _Ty2,
+    enable_if_t<!((is_floating_point_v<_Ty1> || is_integral_v<_Ty1>) && is_integral_v<_Ty2>), int> = 0>
 _NODISCARD complex<_Common_float_type_t<_Ty1, _Ty2>> pow(const complex<_Ty1>& _Left, const _Ty2& _Right) {
     using type = complex<_Common_float_type_t<_Ty1, _Ty2>>;
     return _STD pow(type(_Left), type(_Right));
+}
+
+template <class _Ty1, class _Ty2, enable_if_t<is_floating_point_v<_Ty1> && is_integral_v<_Ty2>, int> = 0>
+_NODISCARD complex<_Common_float_type_t<_Ty1, _Ty2>> pow(const complex<_Ty1>& _Left, const _Ty2 _Right) {
+    using type = complex<_Common_float_type_t<_Ty1, _Ty2>>;
+
+    type _Tmp   = _Left;
+    auto _Count = static_cast<make_signed_t<_Ty2>>(_Right);
+
+    if (_Right < 0) {
+        _Count = 0 - _Count; // safe negation as unsigned
+    }
+
+    for (type _Zv(1);; _Tmp *= _Tmp) { // fold in _Left ^ (2 ^ _Count) as needed
+        if ((_Count & 1) != 0) {
+            _Zv *= _Tmp;
+        }
+
+        if ((_Count >>= 1) == 0) {
+            return _Right < 0 ? type(1) / _Zv : _Zv;
+        }
+    }
+}
+
+template <class _Ty1, class _Ty2, enable_if_t<is_integral_v<_Ty1> && is_integral_v<_Ty2>, int> = 0>
+_NODISCARD complex<_Ty1> pow(const complex<_Ty1>& _Left, const _Ty2 _Right) {
+    // raise Gaussian integer to an integer power
+    using type = complex<_Ty1>;
+
+    type _Ans   = type(1, 0);
+    auto _Count = _Right;
+
+    if (_Count < 0) {
+        _Ans = type(0, 0); // ignore 1/type(0, 0) error
+    } else if (0 < _Count) { // raise to a positive power
+        for (type _Factor = _Left;; _Factor *= _Factor) { // fold in _Left^(2^N))
+            if ((_Count & 1) != 0) {
+                _Ans *= _Factor;
+            }
+
+            if ((_Count >>= 1) == 0) {
+                break;
+            }
+        }
+    }
+    return _Ans;
 }
 
 template <class _Ty1, class _Ty2>
 _NODISCARD complex<_Common_float_type_t<_Ty1, _Ty2>> pow(const _Ty1& _Left, const complex<_Ty2>& _Right) {
     using type = complex<_Common_float_type_t<_Ty1, _Ty2>>;
     return _STD pow(type(_Left), type(_Right));
-}
-
-template <class _Ty1, class _Ty2, enable_if_t<is_integral_v<_Ty1> && is_integral_v<_Ty2>, int> = 0>
-_NODISCARD complex<_Ty1> pow(const complex<_Ty1>& _Left, _Ty2& _Right) {
-    // raise Gaussian integer to an integer power
-    using type = complex<_Ty1>;
-
-    type _Ans = type(1, 0);
-
-    if (_Right < 0) {
-        _Ans = type(0, 0); // ignore 1/type(0, 0) error
-    } else if (0 < _Right) { // raise to a positive power
-        for (type _Factor = _Left;; _Factor *= _Factor) { // fold in _Left^(2^N))
-            if ((_Right & 1) != 0) {
-                _Ans *= _Factor;
-            }
-
-            if ((_Right >>= 1) == 0) {
-                break;
-            }
-        }
-    }
-    return _Ans;
 }
 
 // FUNCTION TEMPLATE operator>>

--- a/stl/inc/complex
+++ b/stl/inc/complex
@@ -77,7 +77,7 @@ public:
     }
 
     static _Ty _Infv() { // return infinity
-        return static_cast<_Ty>(numeric_limits<double>::infinity());
+        return numeric_limits<_Ty>::infinity();
     }
 
     static bool _Isinf(_Ty _Left) { // test for infinity
@@ -91,7 +91,7 @@ public:
     }
 
     static _Ty _Nanv() { // return NaN
-        return static_cast<_Ty>(numeric_limits<double>::quiet_NaN());
+        return numeric_limits<_Ty>::quiet_NaN();
     }
 
     static _Ty _Sinh(_Ty _Left, _Ty _Right) { // return sinh(_Left) * _Right
@@ -1795,7 +1795,7 @@ _NODISCARD complex<_Common_float_type_t<_Ty1, _Ty2>> pow(const complex<_Ty1>& _L
     using type = complex<_Common_float_type_t<_Ty1, _Ty2>>;
 
     type _Tmp   = _Left;
-    auto _Count = static_cast<make_signed_t<_Ty2>>(_Right);
+    auto _Count = static_cast<make_unsigned_t<_Ty2>>(_Right);
 
     if (_Right < 0) {
         _Count = 0 - _Count; // safe negation as unsigned
@@ -1813,22 +1813,21 @@ _NODISCARD complex<_Common_float_type_t<_Ty1, _Ty2>> pow(const complex<_Ty1>& _L
 }
 
 template <class _Ty1, class _Ty2, enable_if_t<is_integral_v<_Ty1> && is_integral_v<_Ty2>, int> = 0>
-_NODISCARD complex<_Ty1> pow(const complex<_Ty1>& _Left, const _Ty2 _Right) {
+_NODISCARD complex<_Ty1> pow(const complex<_Ty1>& _Left, _Ty2 _Right) {
     // raise Gaussian integer to an integer power
     using type = complex<_Ty1>;
 
-    type _Ans   = type(1, 0);
-    auto _Count = _Right;
+    type _Ans = type(1, 0);
 
-    if (_Count < 0) {
+    if (_Right < 0) {
         _Ans = type(0, 0); // ignore 1/type(0, 0) error
-    } else if (0 < _Count) { // raise to a positive power
+    } else if (0 < _Right) { // raise to a positive power
         for (type _Factor = _Left;; _Factor *= _Factor) { // fold in _Left^(2^N))
-            if ((_Count & 1) != 0) {
+            if ((_Right & 1) != 0) {
                 _Ans *= _Factor;
             }
 
-            if ((_Count >>= 1) == 0) {
+            if ((_Right >>= 1) == 0) {
                 break;
             }
         }

--- a/stl/inc/complex
+++ b/stl/inc/complex
@@ -66,7 +66,7 @@ public:
     }
 
     static _Ty _Cosh(_Ty _Left, _Ty _Right) { // return cosh(_Left) * _Right
-        return _CSTD _Cosh(static_cast<double>(_Left), static_cast<double>(_Right));
+        return static_cast<_Ty>(_CSTD _Cosh(static_cast<double>(_Left), static_cast<double>(_Right)));
     }
 
     static short _Exp(_Ty* _Pleft, _Ty _Right, short _Exponent) { // compute exp(*_Pleft) * _Right * 2 ^ _Exponent
@@ -77,7 +77,7 @@ public:
     }
 
     static _Ty _Infv() { // return infinity
-        return numeric_limits<double>::infinity();
+        return static_cast<_Ty>(numeric_limits<double>::infinity());
     }
 
     static bool _Isinf(_Ty _Left) { // test for infinity
@@ -91,11 +91,11 @@ public:
     }
 
     static _Ty _Nanv() { // return NaN
-        return numeric_limits<double>::quiet_NaN();
+        return static_cast<_Ty>(numeric_limits<double>::quiet_NaN());
     }
 
     static _Ty _Sinh(_Ty _Left, _Ty _Right) { // return sinh(_Left) * _Right
-        return _CSTD _Sinh(static_cast<double>(_Left), static_cast<double>(_Right));
+        return static_cast<_Ty>(_CSTD _Sinh(static_cast<double>(_Left), static_cast<double>(_Right)));
     }
 
     static _Ty asinh(_Ty _Left) {
@@ -114,27 +114,27 @@ public:
             _Ans = log(_Left) + _Ln2;
         }
 
-        return _Neg ? -_Ans : _Ans;
+        return static_cast<_Ty>(_Neg ? -_Ans : _Ans);
     }
 
     static _Ty atan2(_Ty _Yval, _Ty _Xval) { // return atan(_Yval / _Xval)
-        return _CSTD atan2(static_cast<double>(_Yval), static_cast<double>(_Xval));
+        return static_cast<_Ty>(_CSTD atan2(static_cast<double>(_Yval), static_cast<double>(_Xval)));
     }
 
     static _Ty cos(_Ty _Left) {
-        return _CSTD cos(static_cast<double>(_Left));
+        return static_cast<_Ty>(_CSTD cos(static_cast<double>(_Left)));
     }
 
     static _Ty exp(_Ty _Left) {
-        return _CSTD exp(static_cast<double>(_Left));
+        return static_cast<_Ty>(_CSTD exp(static_cast<double>(_Left)));
     }
 
     static _Ty ldexp(_Ty _Left, int _Exponent) { // return _Left * 2 ^ _Exponent
-        return _CSTD ldexp(static_cast<double>(_Left), _Exponent);
+        return static_cast<_Ty>(_CSTD ldexp(static_cast<double>(_Left), _Exponent));
     }
 
     static _Ty log(_Ty _Left) {
-        return _CSTD log(static_cast<double>(_Left));
+        return static_cast<_Ty>(_CSTD log(static_cast<double>(_Left)));
     }
 
     static _Ty log1p(_Ty _Left) { // return log(1 + _Left)
@@ -149,23 +149,23 @@ public:
     }
 
     static _Ty pow(_Ty _Left, _Ty _Right) {
-        return _CSTD pow(static_cast<double>(_Left), static_cast<double>(_Right));
+        return static_cast<_Ty>(_CSTD pow(static_cast<double>(_Left), static_cast<double>(_Right)));
     }
 
     static _Ty sin(_Ty _Left) {
-        return _CSTD sin(static_cast<double>(_Left));
+        return static_cast<_Ty>(_CSTD sin(static_cast<double>(_Left)));
     }
 
     static _Ty sqrt(_Ty _Left) {
-        return _CSTD sqrt(static_cast<double>(_Left));
+        return static_cast<_Ty>(_CSTD sqrt(static_cast<double>(_Left)));
     }
 
     static _Ty tan(_Ty _Left) {
-        return _CSTD tan(static_cast<double>(_Left));
+        return static_cast<_Ty>(_CSTD tan(static_cast<double>(_Left)));
     }
 
     static _Ty hypot(_Ty _Left, _Ty _Right) {
-        return _CSTD hypot(static_cast<double>(_Left), static_cast<double>(_Right));
+        return static_cast<_Ty>(_CSTD hypot(static_cast<double>(_Left), static_cast<double>(_Right)));
     }
 };
 

--- a/stl/inc/complex
+++ b/stl/inc/complex
@@ -1784,14 +1784,13 @@ _NODISCARD complex<_Common_float_type_t<_Ty1, _Ty2>> pow(const complex<_Ty1>& _L
     return _STD pow(type(_Left), type(_Right));
 }
 
-template <class _Ty1, class _Ty2,
-    enable_if_t<!((is_floating_point_v<_Ty1> || is_integral_v<_Ty1>) && is_integral_v<_Ty2>), int> = 0>
+template <class _Ty1, class _Ty2, enable_if_t<!is_integral_v<_Ty2>, int> = 0>
 _NODISCARD complex<_Common_float_type_t<_Ty1, _Ty2>> pow(const complex<_Ty1>& _Left, const _Ty2& _Right) {
     using type = complex<_Common_float_type_t<_Ty1, _Ty2>>;
     return _STD pow(type(_Left), type(_Right));
 }
 
-template <class _Ty1, class _Ty2, enable_if_t<is_floating_point_v<_Ty1> && is_integral_v<_Ty2>, int> = 0>
+template <class _Ty1, class _Ty2, enable_if_t<!is_integral_v<_Ty1> && is_integral_v<_Ty2>, int> = 0>
 _NODISCARD complex<_Common_float_type_t<_Ty1, _Ty2>> pow(const complex<_Ty1>& _Left, const _Ty2 _Right) {
     using type = complex<_Common_float_type_t<_Ty1, _Ty2>>;
 


### PR DESCRIPTION
# Description
Will resolve issue #325.

# Checklist
- [x] fix #325

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [x] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
