### PR TITLE
define _CONSTEXPR20

### DIFF
--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -458,6 +458,13 @@
 #define _CONSTEXPR17 inline
 #endif // _HAS_CXX17
 
+// C++20 constexpr additions
+#if _HAS_CXX20
+#define _CONSTEXPR20 constexpr
+#else // ^^^ has C++20 constexpr additions / no C++20 constexpr additions vvv
+#define _CONSTEXPR20 inline
+#endif // _HAS_CXX20
+
 // P0607R0 Inline Variables For The STL
 #if _HAS_CXX17
 #define _INLINE_VAR inline

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -451,19 +451,22 @@
 #error /GR implies _HAS_STATIC_RTTI.
 #endif // defined(_CPPRTTI) && !_HAS_STATIC_RTTI
 
-// C++17 constexpr additions
+// N4842 [dcl.constexpr]/1: "A function or static data member declared with the
+// constexpr or consteval specifier is implicitly an inline function or variable"
+
+// Functions that became constexpr in C++17
 #if _HAS_CXX17
 #define _CONSTEXPR17 constexpr
-#else // ^^^ has C++17 constexpr additions / no C++17 constexpr additions vvv
+#else // ^^^ constexpr in C++17 and later / inline (not constexpr) in C++14 vvv
 #define _CONSTEXPR17 inline
-#endif // _HAS_CXX17
+#endif // ^^^ inline (not constexpr) in C++14 ^^^
 
-// C++20 constexpr additions
+// Functions that became constexpr in C++20
 #if _HAS_CXX20
 #define _CONSTEXPR20 constexpr
-#else // ^^^ has C++20 constexpr additions / no C++20 constexpr additions vvv
+#else // ^^^ constexpr in C++20 and later / inline (not constexpr) in C++17 and earlier vvv
 #define _CONSTEXPR20 inline
-#endif // _HAS_CXX20
+#endif // ^^^ inline (not constexpr) in C++17 and earlier ^^^
 
 // P0607R0 Inline Variables For The STL
 #if _HAS_CXX17


### PR DESCRIPTION
# Description

By itself, this PR does not fix anything, but `_CONSTEXPR20` is necessary for the implementation of many others: #50, #16, #203, #337 etc.
It would be convenient if it got to the master, and in other pr, it would not be necessary to define it every time anew.

# Checklist
- [x] define `_CONSTEXPR20`

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [x] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
