### PR TITLE
[ranges] Implement some range concepts

### DIFF
--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -28,6 +28,10 @@ namespace ranges {
     // CONCEPT ranges::common_range
     template <class _Rng>
     concept common_range = range<_Rng> && same_as<iterator_t<_Rng>, sentinel_t<_Rng>>;
+
+    // CONCEPT ranges::viewable_range
+    template <class _Rng>
+    concept viewable_range = range<_Rng> && (safe_range<_Rng> || view<decay_t<_Rng>>);
     // clang-format on
 } // namespace ranges
 _STD_END

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -31,7 +31,7 @@ namespace ranges {
 
     // CONCEPT ranges::viewable_range
     template <class _Rng>
-    concept viewable_range = range<_Rng> && (safe_range<_Rng> || view<decay_t<_Rng>>);
+    concept viewable_range = range<_Rng> && (safe_range<_Rng> || view<remove_cvref_t<_Rng>>);
     // clang-format on
 } // namespace ranges
 _STD_END

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -17,10 +17,6 @@
 #include <xpolymorphic_allocator.h>
 #endif // _HAS_CXX17
 
-#ifdef __cpp_lib_concepts
-#include <xutility>
-#endif // __cpp_lib_concepts
-
 #pragma pack(push, _CRT_PACKING)
 #pragma warning(push, _STL_WARNING_LEVEL)
 #pragma warning(disable : _STL_DISABLED_WARNINGS)

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -1579,7 +1579,6 @@ private:
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    // VARIABLE TEMPLATE enable_safe_range
     template <class _Elem, class _Traits>
     inline constexpr bool enable_safe_range<basic_string_view<_Elem, _Traits>> = true;
 } // namespace ranges

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -17,6 +17,10 @@
 #include <xpolymorphic_allocator.h>
 #endif // _HAS_CXX17
 
+#ifdef __cpp_lib_concepts
+#include <xutility>
+#endif // __cpp_lib_concepts
+
 #pragma pack(push, _CRT_PACKING)
 #pragma warning(push, _STL_WARNING_LEVEL)
 #pragma warning(disable : _STL_DISABLED_WARNINGS)
@@ -1204,17 +1208,6 @@ public:
 #endif // _ITERATOR_DEBUG_LEVEL
     }
 
-#ifdef __cpp_lib_concepts
-    _NODISCARD friend constexpr const_iterator begin(basic_string_view _Right) noexcept {
-        // non-member overload to model the exposition-only forwarding-range concept
-        return _Right.begin();
-    }
-    _NODISCARD friend constexpr const_iterator end(basic_string_view _Right) noexcept {
-        // Ditto modeling forwarding-range
-        return _Right.end();
-    }
-#endif // __cpp_lib_concepts
-
     _NODISCARD constexpr const_iterator cbegin() const noexcept {
         return begin();
     }
@@ -1584,6 +1577,13 @@ private:
     size_type _Mysize;
 };
 
+#ifdef __cpp_lib_concepts
+namespace ranges {
+    // VARIABLE TEMPLATE enable_safe_range
+    template <class _Elem, class _Traits>
+    inline constexpr bool enable_safe_range<basic_string_view<_Elem, _Traits>> = true;
+} // namespace ranges
+#endif // __cpp_lib_concepts
 
 // FUNCTION TEMPLATES operator== FOR basic_string_view
 template <class _Elem, class _Traits>

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -2077,7 +2077,7 @@ namespace ranges {
     inline constexpr bool enable_safe_range = false;
 
     template <class _Rng>
-    concept _Safe_range_like = is_lvalue_reference_v<_Rng> || enable_safe_range<remove_cvref_t<_Rng>>;
+    concept _Should_range_access = is_lvalue_reference_v<_Rng> || enable_safe_range<remove_cvref_t<_Rng>>;
 
     // CUSTOMIZATION POINT OBJECT ranges::begin
     namespace _Begin {
@@ -2124,7 +2124,7 @@ namespace ranges {
 
         public:
             // clang-format off
-            template <_Safe_range_like _Ty>
+            template <_Should_range_access _Ty>
                 requires (_Choice<_Ty>._Strategy != _St::_None)
             _NODISCARD constexpr auto operator()(_Ty&& _Val) const noexcept(_Choice<_Ty>._No_throw) {
                 if constexpr (_Choice<_Ty>._Strategy == _St::_Array) {
@@ -2190,7 +2190,7 @@ namespace ranges {
 
         public:
             // clang-format off
-            template <_Safe_range_like _Ty>
+            template <_Should_range_access _Ty>
                 requires (_Choice<_Ty>._Strategy != _St::_None)
             _NODISCARD constexpr auto operator()(_Ty&& _Val) const noexcept(_Choice<_Ty>._No_throw) {
                 if constexpr (_Choice<_Ty>._Strategy == _St::_Array) {
@@ -2221,7 +2221,7 @@ namespace ranges {
     // CONCEPT ranges::safe_range
     // clang-format off
     template <class _Rng>
-    concept safe_range = range<_Rng> && _Safe_range_like<_Rng>;
+    concept safe_range = range<_Rng> && _Should_range_access<_Rng>;
     // clang-format on
 
     // ALIAS TEMPLATE ranges::iterator_t
@@ -2332,7 +2332,7 @@ namespace ranges {
 
         public:
             // clang-format off
-            template <_Safe_range_like _Ty>
+            template <_Should_range_access _Ty>
                 requires (_Choice<_Ty>._Strategy != _St::_None)
             _NODISCARD constexpr auto operator()(_Ty&& _Val) const noexcept(_Choice<_Ty>._No_throw) {
                 if constexpr (_Choice<_Ty>._Strategy == _St::_Member) {
@@ -2412,7 +2412,7 @@ namespace ranges {
 
         public:
             // clang-format off
-            template <_Safe_range_like _Ty>
+            template <_Should_range_access _Ty>
                 requires (_Choice<_Ty>._Strategy != _St::_None)
             _NODISCARD constexpr auto operator()(_Ty&& _Val) const noexcept(_Choice<_Ty>._No_throw) {
                 if constexpr (_Choice<_Ty>._Strategy == _St::_Member) {

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -2076,7 +2076,6 @@ namespace ranges {
     template <class>
     inline constexpr bool enable_safe_range = false;
 
-    // CONCEPT ranges::safe_range
     template <class _Rng>
     concept _Safe_range_like = is_lvalue_reference_v<_Rng> || enable_safe_range<remove_cvref_t<_Rng>>;
 

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -2114,9 +2114,9 @@ namespace ranges {
                     return {_St::_Member, noexcept(_Fake_decay_copy(_STD declval<_Ty&>().begin()))};
                 } else if constexpr (_Has_ADL<_Ty&>) {
                     return {_St::_Non_member, noexcept(_Fake_decay_copy(begin(_STD declval<_Ty&>())))};
+                } else {
+                    return {_St::_None};
                 }
-
-                return {_St::_None};
             }
 
             template <class _Ty>
@@ -2180,9 +2180,9 @@ namespace ranges {
                     return {_St::_Member, noexcept(_Fake_decay_copy(_STD declval<_Ty&>().end()))};
                 } else if constexpr (_Has_ADL<_Ty&>) {
                     return {_St::_Non_member, noexcept(_Fake_decay_copy(end(_STD declval<_Ty&>())))};
+                } else {
+                    return {_St::_None};
                 }
-
-                return {_St::_None};
             }
 
             template <class _Ty>
@@ -2366,11 +2366,6 @@ namespace ranges {
 
         // clang-format off
         template <class _Ty>
-        concept _Can_rbegin = requires(_Ty&& __t) {
-            _RANGES rbegin(static_cast<_Ty&&>(__t));
-        };
-
-        template <class _Ty>
         concept _Has_member = requires(_Ty& __t) {
             { _Fake_decay_copy(__t.rend()) } -> sentinel_for<decltype(_RANGES rbegin(__t))>;
         };
@@ -2393,18 +2388,16 @@ namespace ranges {
 
             template <class _Ty>
             _NODISCARD static _CONSTEVAL _Choice_t<_St> _Choose() noexcept {
-                if constexpr (_Can_rbegin<_Ty>) {
-                    if constexpr (_Has_member<_Ty&>) {
-                        return {_St::_Member, noexcept(_Fake_decay_copy(_STD declval<_Ty&>().rend()))};
-                    } else if constexpr (_Has_ADL<_Ty&>) {
-                        return {_St::_Non_member, noexcept(_Fake_decay_copy(rend(_STD declval<_Ty&>())))};
-                    } else if constexpr (_Can_make_reverse<_Ty&>) {
-                        return {_St::_Make_reverse,
-                            noexcept(_STD make_reverse_iterator(_RANGES begin(_STD declval<_Ty&>())))};
-                    }
+                if constexpr (_Has_member<_Ty&>) {
+                    return {_St::_Member, noexcept(_Fake_decay_copy(_STD declval<_Ty&>().rend()))};
+                } else if constexpr (_Has_ADL<_Ty&>) {
+                    return {_St::_Non_member, noexcept(_Fake_decay_copy(rend(_STD declval<_Ty&>())))};
+                } else if constexpr (_Can_make_reverse<_Ty&>) {
+                    return {_St::_Make_reverse,
+                        noexcept(_STD make_reverse_iterator(_RANGES begin(_STD declval<_Ty&>())))};
+                } else {
+                    return {_St::_None};
                 }
-
-                return {_St::_None};
             }
 
             template <class _Ty>

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -2320,8 +2320,8 @@ namespace ranges {
                 } else if constexpr (_Has_ADL<_Ty&>) {
                     return {_St::_Non_member, noexcept(_Fake_decay_copy(rbegin(_STD declval<_Ty&>())))};
                 } else if constexpr (_Can_make_reverse<_Ty&>) {
-                    return {_St::_Make_reverse,
-                        noexcept(_STD make_reverse_iterator(_RANGES end(_STD declval<_Ty&>())))};
+                    return {
+                        _St::_Make_reverse, noexcept(_STD make_reverse_iterator(_RANGES end(_STD declval<_Ty&>())))};
                 } else {
                     return {_St::_None};
                 }

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -2393,8 +2393,8 @@ namespace ranges {
                 } else if constexpr (_Has_ADL<_Ty&>) {
                     return {_St::_Non_member, noexcept(_Fake_decay_copy(rend(_STD declval<_Ty&>())))};
                 } else if constexpr (_Can_make_reverse<_Ty&>) {
-                    return {_St::_Make_reverse,
-                        noexcept(_STD make_reverse_iterator(_RANGES begin(_STD declval<_Ty&>())))};
+                    return {
+                        _St::_Make_reverse, noexcept(_STD make_reverse_iterator(_RANGES begin(_STD declval<_Ty&>())))};
                 } else {
                     return {_St::_None};
                 }

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -2072,6 +2072,14 @@ _NODISCARD _Ty _Fake_decay_copy(_Ty) noexcept;
 // (3) is non-throwing if and only if both conversion from decltype((E)) to T and destruction of T are non-throwing.
 
 namespace ranges {
+    // VARIABLE TEMPLATE ranges::enable_safe_range
+    template <class>
+    inline constexpr bool enable_safe_range = false;
+
+    // CONCEPT ranges::safe_range
+    template <class _Rng>
+    concept _Safe_range_like = is_lvalue_reference_v<_Rng> || enable_safe_range<remove_cvref_t<_Rng>>;
+
     // CUSTOMIZATION POINT OBJECT ranges::begin
     namespace _Begin {
 #ifndef __clang__ // TRANSITION, VSO-895622
@@ -2101,13 +2109,9 @@ namespace ranges {
 
             template <class _Ty>
             _NODISCARD static _CONSTEVAL _Choice_t<_St> _Choose() noexcept {
-                constexpr bool _Is_lvalue = is_lvalue_reference_v<_Ty>;
-
                 if constexpr (is_array_v<remove_reference_t<_Ty>>) {
-                    if constexpr (_Is_lvalue) {
-                        return {_St::_Array, true};
-                    }
-                } else if constexpr (_Is_lvalue && _Has_member<_Ty>) {
+                    return {_St::_Array, true};
+                } else if constexpr (_Has_member<_Ty>) {
                     return {_St::_Member, noexcept(_Fake_decay_copy(_STD declval<_Ty>().begin()))};
                 } else if constexpr (_Has_ADL<_Ty>) {
                     return {_St::_Non_member, noexcept(_Fake_decay_copy(begin(_STD declval<_Ty>())))};
@@ -2121,7 +2125,7 @@ namespace ranges {
 
         public:
             // clang-format off
-            template <class _Ty>
+            template <_Safe_range_like _Ty>
                 requires (_Choice<_Ty>._Strategy != _St::_None)
             _NODISCARD constexpr auto operator()(_Ty&& _Val) const noexcept(_Choice<_Ty>._No_throw) {
                 if constexpr (_Choice<_Ty>._Strategy == _St::_Array) {
@@ -2172,13 +2176,9 @@ namespace ranges {
 
             template <class _Ty>
             _NODISCARD static _CONSTEVAL _Choice_t<_St> _Choose() noexcept {
-                constexpr bool _Is_lvalue = is_lvalue_reference_v<_Ty>;
-
                 if constexpr (is_array_v<remove_reference_t<_Ty>>) {
-                    if constexpr (_Is_lvalue) {
-                        return {_St::_Array, true};
-                    }
-                } else if constexpr (_Is_lvalue && _Has_member<_Ty>) {
+                    return {_St::_Array, true};
+                } else if constexpr (_Has_member<_Ty>) {
                     return {_St::_Member, noexcept(_Fake_decay_copy(_STD declval<_Ty>().end()))};
                 } else if constexpr (_Has_ADL<_Ty>) {
                     return {_St::_Non_member, noexcept(_Fake_decay_copy(end(_STD declval<_Ty>())))};
@@ -2192,7 +2192,7 @@ namespace ranges {
 
         public:
             // clang-format off
-            template <class _Ty>
+            template <_Safe_range_like _Ty>
                 requires (_Choice<_Ty>._Strategy != _St::_None)
             _NODISCARD constexpr auto operator()(_Ty&& _Val) const noexcept(_Choice<_Ty>._No_throw) {
                 if constexpr (_Choice<_Ty>._Strategy == _St::_Array) {
@@ -2215,19 +2215,14 @@ namespace ranges {
 
     // CONCEPT ranges::range
     template <class _Rng>
-    concept _Range_impl = requires(_Rng&& __r) {
-        _RANGES begin(static_cast<_Rng&&>(__r));
-        _RANGES end(static_cast<_Rng&&>(__r));
+    concept range = requires(_Rng& __r) {
+        _RANGES begin(__r);
+        _RANGES end(__r);
     };
 
+    // CONCEPT ranges::safe_range
     template <class _Rng>
-    concept range = _Range_impl<_Rng&>;
-
-    // CONCEPT ranges::_Forwarding_range
-    // clang-format off
-    template <class _Rng>
-    concept _Forwarding_range = range<_Rng> && _Range_impl<_Rng>;
-    // clang-format on
+    concept safe_range = range<_Rng>&& _Safe_range_like<_Rng>;
 
     // ALIAS TEMPLATE ranges::iterator_t
     template <range _Rng>
@@ -2336,7 +2331,7 @@ namespace ranges {
 
         public:
             // clang-format off
-            template <class _Ty>
+            template <_Safe_range_like _Ty>
                 requires (_Choice<_Ty>._Strategy != _St::_None)
             _NODISCARD constexpr auto operator()(_Ty&& _Val) const noexcept(_Choice<_Ty>._No_throw) {
                 if constexpr (_Choice<_Ty>._Strategy == _St::_Member) {
@@ -2417,7 +2412,7 @@ namespace ranges {
 
         public:
             // clang-format off
-            template <class _Ty>
+            template <_Safe_range_like _Ty>
                 requires (_Choice<_Ty>._Strategy != _St::_None)
             _NODISCARD constexpr auto operator()(_Ty&& _Val) const noexcept(_Choice<_Ty>._No_throw) {
                 if constexpr (_Choice<_Ty>._Strategy == _St::_Member) {

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -2098,8 +2098,8 @@ namespace ranges {
         };
 
         template <class _Ty>
-        concept _Has_ADL = requires(_Ty&& __t) {
-            { _Fake_decay_copy(begin(static_cast<_Ty&&>(__t))) } -> input_or_output_iterator;
+        concept _Has_ADL = requires(_Ty& __t) {
+            { _Fake_decay_copy(begin(__t)) } -> input_or_output_iterator;
         };
         // clang-format on
 
@@ -2111,10 +2111,10 @@ namespace ranges {
             _NODISCARD static _CONSTEVAL _Choice_t<_St> _Choose() noexcept {
                 if constexpr (is_array_v<remove_reference_t<_Ty>>) {
                     return {_St::_Array, true};
-                } else if constexpr (_Has_member<_Ty>) {
-                    return {_St::_Member, noexcept(_Fake_decay_copy(_STD declval<_Ty>().begin()))};
-                } else if constexpr (_Has_ADL<_Ty>) {
-                    return {_St::_Non_member, noexcept(_Fake_decay_copy(begin(_STD declval<_Ty>())))};
+                } else if constexpr (_Has_member<_Ty&>) {
+                    return {_St::_Member, noexcept(_Fake_decay_copy(_STD declval<_Ty&>().begin()))};
+                } else if constexpr (_Has_ADL<_Ty&>) {
+                    return {_St::_Non_member, noexcept(_Fake_decay_copy(begin(_STD declval<_Ty&>())))};
                 }
 
                 return {_St::_None};
@@ -2133,7 +2133,7 @@ namespace ranges {
                 } else if constexpr (_Choice<_Ty>._Strategy == _St::_Member) {
                     return _Val.begin();
                 } else if constexpr (_Choice<_Ty>._Strategy == _St::_Non_member) {
-                    return begin(static_cast<_Ty&&>(_Val));
+                    return begin(_Val);
                 } else {
                     static_assert(_Always_false<_Ty>, "Should be unreachable");
                 }
@@ -2164,9 +2164,8 @@ namespace ranges {
         };
 
         template <class _Ty>
-        concept _Has_ADL = requires(_Ty&& __t) {
-            { _Fake_decay_copy(end(static_cast<_Ty&&>(__t))) } ->
-                sentinel_for<decltype(_RANGES begin(static_cast<_Ty&&>(__t)))>;
+        concept _Has_ADL = requires(_Ty& __t) {
+            { _Fake_decay_copy(end(__t)) } -> sentinel_for<decltype(_RANGES begin(__t))>;
         };
         // clang-format on
 
@@ -2178,10 +2177,10 @@ namespace ranges {
             _NODISCARD static _CONSTEVAL _Choice_t<_St> _Choose() noexcept {
                 if constexpr (is_array_v<remove_reference_t<_Ty>>) {
                     return {_St::_Array, true};
-                } else if constexpr (_Has_member<_Ty>) {
-                    return {_St::_Member, noexcept(_Fake_decay_copy(_STD declval<_Ty>().end()))};
-                } else if constexpr (_Has_ADL<_Ty>) {
-                    return {_St::_Non_member, noexcept(_Fake_decay_copy(end(_STD declval<_Ty>())))};
+                } else if constexpr (_Has_member<_Ty&>) {
+                    return {_St::_Member, noexcept(_Fake_decay_copy(_STD declval<_Ty&>().end()))};
+                } else if constexpr (_Has_ADL<_Ty&>) {
+                    return {_St::_Non_member, noexcept(_Fake_decay_copy(end(_STD declval<_Ty&>())))};
                 }
 
                 return {_St::_None};
@@ -2200,7 +2199,7 @@ namespace ranges {
                 } else if constexpr (_Choice<_Ty>._Strategy == _St::_Member) {
                     return _Val.end();
                 } else if constexpr (_Choice<_Ty>._Strategy == _St::_Non_member) {
-                    return end(static_cast<_Ty&&>(_Val));
+                    return end(_Val);
                 } else {
                     static_assert(_Always_false<_Ty>, "should be unreachable");
                 }
@@ -2221,8 +2220,10 @@ namespace ranges {
     };
 
     // CONCEPT ranges::safe_range
+    // clang-format off
     template <class _Rng>
-    concept safe_range = range<_Rng>&& _Safe_range_like<_Rng>;
+    concept safe_range = range<_Rng> && _Safe_range_like<_Rng>;
+    // clang-format on
 
     // ALIAS TEMPLATE ranges::iterator_t
     template <range _Rng>
@@ -2293,19 +2294,19 @@ namespace ranges {
 
         // clang-format off
         template <class _Ty>
-        concept _Has_member = is_lvalue_reference_v<_Ty> && requires(_Ty& __t) {
+        concept _Has_member = requires(_Ty& __t) {
             { _Fake_decay_copy(__t.rbegin()) } -> input_or_output_iterator;
         };
 
         template <class _Ty>
-        concept _Has_ADL = requires(_Ty&& __t) {
-            { _Fake_decay_copy(rbegin(static_cast<_Ty&&>(__t))) } -> input_or_output_iterator;
+        concept _Has_ADL = requires(_Ty& __t) {
+            { _Fake_decay_copy(rbegin(__t)) } -> input_or_output_iterator;
         };
 
         template <class _Ty>
-        concept _Can_make_reverse = requires(_Ty&& __t) {
-            { _RANGES begin(static_cast<_Ty&&>(__t)) } -> bidirectional_iterator;
-            { _RANGES end(static_cast<_Ty&&>(__t)) } -> same_as<decltype(_RANGES begin(static_cast<_Ty&&>(__t)))>;
+        concept _Can_make_reverse = requires(_Ty& __t) {
+            { _RANGES begin(__t) } -> bidirectional_iterator;
+            { _RANGES end(__t) } -> same_as<decltype(_RANGES begin(__t))>;
         };
         // clang-format on
 
@@ -2315,12 +2316,13 @@ namespace ranges {
 
             template <class _Ty>
             _NODISCARD static _CONSTEVAL _Choice_t<_St> _Choose() noexcept {
-                if constexpr (_Has_member<_Ty>) {
-                    return {_St::_Member, noexcept(_Fake_decay_copy(_STD declval<_Ty>().rbegin()))};
-                } else if constexpr (_Has_ADL<_Ty>) {
-                    return {_St::_Non_member, noexcept(_Fake_decay_copy(rbegin(_STD declval<_Ty>())))};
-                } else if constexpr (_Can_make_reverse<_Ty>) {
-                    return {_St::_Make_reverse, noexcept(_STD make_reverse_iterator(_RANGES end(_STD declval<_Ty>())))};
+                if constexpr (_Has_member<_Ty&>) {
+                    return {_St::_Member, noexcept(_Fake_decay_copy(_STD declval<_Ty&>().rbegin()))};
+                } else if constexpr (_Has_ADL<_Ty&>) {
+                    return {_St::_Non_member, noexcept(_Fake_decay_copy(rbegin(_STD declval<_Ty&>())))};
+                } else if constexpr (_Can_make_reverse<_Ty&>) {
+                    return {_St::_Make_reverse,
+                        noexcept(_STD make_reverse_iterator(_RANGES end(_STD declval<_Ty&>())))};
                 } else {
                     return {_St::_None};
                 }
@@ -2337,9 +2339,9 @@ namespace ranges {
                 if constexpr (_Choice<_Ty>._Strategy == _St::_Member) {
                     return _Val.rbegin();
                 } else if constexpr (_Choice<_Ty>._Strategy == _St::_Non_member) {
-                    return rbegin(static_cast<_Ty&&>(_Val));
+                    return rbegin(_Val);
                 } else if constexpr (_Choice<_Ty>._Strategy == _St::_Make_reverse) {
-                    return _STD make_reverse_iterator(_RANGES end(static_cast<_Ty&&>(_Val)));
+                    return _STD make_reverse_iterator(_RANGES end(_Val));
                 } else {
                     static_assert(_Always_false<_Ty>, "should be unreachable");
                 }
@@ -2370,20 +2372,19 @@ namespace ranges {
         };
 
         template <class _Ty>
-        concept _Has_member = is_lvalue_reference_v<_Ty> && requires(_Ty& __t) {
+        concept _Has_member = requires(_Ty& __t) {
             { _Fake_decay_copy(__t.rend()) } -> sentinel_for<decltype(_RANGES rbegin(__t))>;
         };
 
         template <class _Ty>
-        concept _Has_ADL = requires(_Ty&& __t) {
-            { _Fake_decay_copy(rend(static_cast<_Ty&&>(__t))) } ->
-                sentinel_for<decltype(_RANGES rbegin(static_cast<_Ty&&>(__t)))>;
+        concept _Has_ADL = requires(_Ty& __t) {
+            { _Fake_decay_copy(rend(__t)) } -> sentinel_for<decltype(_RANGES rbegin(__t))>;
         };
 
         template <class _Ty>
-        concept _Can_make_reverse = requires(_Ty&& __t) {
-            { _RANGES begin(static_cast<_Ty&&>(__t)) } -> bidirectional_iterator;
-            { _RANGES end(static_cast<_Ty&&>(__t)) } -> same_as<decltype(_RANGES begin(static_cast<_Ty&&>(__t)))>;
+        concept _Can_make_reverse = requires(_Ty& __t) {
+            { _RANGES begin(__t) } -> bidirectional_iterator;
+            { _RANGES end(__t) } -> same_as<decltype(_RANGES begin(__t))>;
         };
         // clang-format on
 
@@ -2394,13 +2395,13 @@ namespace ranges {
             template <class _Ty>
             _NODISCARD static _CONSTEVAL _Choice_t<_St> _Choose() noexcept {
                 if constexpr (_Can_rbegin<_Ty>) {
-                    if constexpr (_Has_member<_Ty>) {
-                        return {_St::_Member, noexcept(_Fake_decay_copy(_STD declval<_Ty>().rend()))};
-                    } else if constexpr (_Has_ADL<_Ty>) {
-                        return {_St::_Non_member, noexcept(_Fake_decay_copy(rend(_STD declval<_Ty>())))};
-                    } else if constexpr (_Can_make_reverse<_Ty>) {
+                    if constexpr (_Has_member<_Ty&>) {
+                        return {_St::_Member, noexcept(_Fake_decay_copy(_STD declval<_Ty&>().rend()))};
+                    } else if constexpr (_Has_ADL<_Ty&>) {
+                        return {_St::_Non_member, noexcept(_Fake_decay_copy(rend(_STD declval<_Ty&>())))};
+                    } else if constexpr (_Can_make_reverse<_Ty&>) {
                         return {_St::_Make_reverse,
-                            noexcept(_STD make_reverse_iterator(_RANGES begin(_STD declval<_Ty>())))};
+                            noexcept(_STD make_reverse_iterator(_RANGES begin(_STD declval<_Ty&>())))};
                     }
                 }
 
@@ -2418,9 +2419,9 @@ namespace ranges {
                 if constexpr (_Choice<_Ty>._Strategy == _St::_Member) {
                     return _Val.rend();
                 } else if constexpr (_Choice<_Ty>._Strategy == _St::_Non_member) {
-                    return rend(static_cast<_Ty&&>(_Val));
+                    return rend(_Val);
                 } else if constexpr (_Choice<_Ty>._Strategy == _St::_Make_reverse) {
-                    return _STD make_reverse_iterator(_RANGES begin(static_cast<_Ty&&>(_Val)));
+                    return _STD make_reverse_iterator(_RANGES begin(_Val));
                 } else {
                     static_assert(_Always_false<_Ty>, "should be unreachable");
                 }

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -2714,7 +2714,7 @@ namespace ranges {
     // clang-format off
     // CONCEPT ranges::view
     template <class _Ty>
-    concept view = range<_Ty> && semiregular<_Ty> && enable_view<_Ty>;
+    concept view = range<_Ty> && movable<_Ty> && default_initializable<_Ty> && enable_view<_Ty>;
 
     // CONCEPT ranges::output_range
     template <class _Rng, class _Ty>

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -163,12 +163,12 @@
 // P1227R2 Signed std::ssize(), Unsigned span::size()
 //     (partially implemented)
 // P1357R1 is_bounded_array, is_unbounded_array
-// P1456R1 Move-only Views
+// P1456R1 Move-Only Views
 // P1612R1 Relocating endian To <bit>
 // P1651R0 bind_front() Should Not Unwrap reference_wrapper
 // P1690R1 Refining Heterogeneous Lookup For Unordered Containers
 // P1754R1 Rename Concepts To standard_case
-// P1870R1 forwarding-range Is Too Subtle
+// P1870R1 safe_range
 // P1959R0 Removing weak_equality And strong_equality
 // P????R? directory_entry::clear_cache()
 

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -163,6 +163,7 @@
 // P1227R2 Signed std::ssize(), Unsigned span::size()
 //     (partially implemented)
 // P1357R1 is_bounded_array, is_unbounded_array
+// P1456R1 Move-only Views
 // P1612R1 Relocating endian To <bit>
 // P1651R0 bind_front() Should Not Unwrap reference_wrapper
 // P1690R1 Refining Heterogeneous Lookup For Unordered Containers

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -167,6 +167,7 @@
 // P1651R0 bind_front() Should Not Unwrap reference_wrapper
 // P1690R1 Refining Heterogeneous Lookup For Unordered Containers
 // P1754R1 Rename Concepts To standard_case
+// P1870R1 forwarding-range Is Too Subtle
 // P1959R0 Removing weak_equality And strong_equality
 // P????R? directory_entry::clear_cache()
 


### PR DESCRIPTION
# Description
This implements P1870R1 with the new safe_range concept instead of forwarding-range
and the removal of the poison pill for rvalue references

It also implements P1456R1 Move-only Views although they are not really used right now. 

While we are at it add the final missing `viewable_range` concept so that we have all range refinements

# Checklist

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [x] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
