### PR TITLE
<numeric> Implement P1645R1 "constexpr for <numeric> algorithms"

### DIFF
--- a/stl/inc/numeric
+++ b/stl/inc/numeric
@@ -75,20 +75,25 @@ _NODISCARD _CONSTEXPR20_ICE _Ty reduce(const _InIt _First, const _InIt _Last, _T
     _Adl_verify_range(_First, _Last);
     auto _UFirst      = _Get_unwrapped(_First);
     const auto _ULast = _Get_unwrapped(_Last);
-    if constexpr (_Plus_on_arithmetic_ranges_reduction_v<_Unwrapped_t<const _InIt&>, _Ty, _BinOp>) {
 #ifdef __cpp_lib_is_constant_evaluated
-        if (!_STD is_constant_evaluated())
+    if (_STD is_constant_evaluated()) {
+        for (; _UFirst != _ULast; ++_UFirst) {
+            _Val = _Reduce_op(_STD move(_Val), *_UFirst); // Requirement missing from N4713
+        }
+        return _Val;
+    } else
 #endif // __cpp_lib_is_constant_evaluated
-        {
+    {
+        if constexpr (_Plus_on_arithmetic_ranges_reduction_v<_Unwrapped_t<const _InIt&>, _Ty, _BinOp>) {
             (void) _Reduce_op; // TRANSITION, VSO-486357
             return _Reduce_plus_arithmetic_ranges(_UFirst, _ULast, _Val);
+        } else {
+            for (; _UFirst != _ULast; ++_UFirst) {
+                _Val = _Reduce_op(_STD move(_Val), *_UFirst); // Requirement missing from N4713
+            }
+            return _Val;
         }
     }
-    for (; _UFirst != _ULast; ++_UFirst) {
-        _Val = _Reduce_op(_STD move(_Val), *_UFirst); // Requirement missing from N4713
-    }
-
-    return _Val;
 }
 
 template <class _InIt, class _Ty>
@@ -205,22 +210,28 @@ _NODISCARD _CONSTEXPR20_ICE _Ty transform_reduce(
     auto _UFirst1      = _Get_unwrapped(_First1);
     const auto _ULast1 = _Get_unwrapped(_Last1);
     auto _UFirst2      = _Get_unwrapped_n(_First2, _Idl_distance<_InIt1>(_UFirst1, _ULast1));
-    if constexpr (_Default_ops_transform_reduce_v<_Unwrapped_t<const _InIt1&>, _Unwrapped_t<const _InIt2&>, _Ty,
-                      _BinOp1, _BinOp2>) {
 #ifdef __cpp_lib_is_constant_evaluated
-        if (!_STD is_constant_evaluated())
+    if (_STD is_constant_evaluated()) {
+        for (; _UFirst1 != _ULast1; ++_UFirst1, (void) ++_UFirst2) {
+            _Val = _Reduce_op(_STD move(_Val), _Transform_op(*_UFirst1, *_UFirst2)); // Requirement missing from N4713
+        }
+        return _Val;
+    } else
 #endif // __cpp_lib_is_constant_evaluated
-        {
+    {
+        if constexpr (_Default_ops_transform_reduce_v<_Unwrapped_t<const _InIt1&>, _Unwrapped_t<const _InIt2&>, _Ty,
+                          _BinOp1, _BinOp2>) {
             (void) _Reduce_op; // TRANSITION, VSO-486357
             (void) _Transform_op; // TRANSITION, VSO-486357
             return _Transform_reduce_arithmetic_defaults(_UFirst1, _ULast1, _UFirst2, _STD move(_Val));
+        } else {
+            for (; _UFirst1 != _ULast1; ++_UFirst1, (void) ++_UFirst2) {
+                _Val =
+                    _Reduce_op(_STD move(_Val), _Transform_op(*_UFirst1, *_UFirst2)); // Requirement missing from N4713
+            }
+            return _Val;
         }
     }
-    for (; _UFirst1 != _ULast1; ++_UFirst1, (void) ++_UFirst2) {
-        _Val = _Reduce_op(_STD move(_Val), _Transform_op(*_UFirst1, *_UFirst2)); // Requirement missing from N4713
-    }
-
-    return _Val;
 }
 
 #if _ITERATOR_DEBUG_ARRAY_OVERLOADS

--- a/stl/inc/numeric
+++ b/stl/inc/numeric
@@ -355,7 +355,7 @@ _CONSTEXPR20 _DestTy* partial_sum(_InIt _First, _InIt _Last, _DestTy (&_Dest)[_D
 #if _HAS_CXX17
 // FUNCTION TEMPLATE exclusive_scan
 template <class _InIt, class _OutIt, class _Ty, class _BinOp>
-_OutIt exclusive_scan(const _InIt _First, const _InIt _Last, _OutIt _Dest, _Ty _Val, _BinOp _Reduce_op) {
+_CONSTEXPR20 _OutIt exclusive_scan(const _InIt _First, const _InIt _Last, _OutIt _Dest, _Ty _Val, _BinOp _Reduce_op) {
     // set each value in [_Dest, _Dest + (_Last - _First)) to the associative reduction of predecessors and _Val
     _Adl_verify_range(_First, _Last);
     auto _UFirst      = _Get_unwrapped(_First);
@@ -381,7 +381,7 @@ _OutIt exclusive_scan(const _InIt _First, const _InIt _Last, _OutIt _Dest, _Ty _
 
 #if _ITERATOR_DEBUG_ARRAY_OVERLOADS
 template <class _InIt, class _DestTy, size_t _DestSize, class _Ty, class _BinOp>
-_DestTy* exclusive_scan(
+_CONSTEXPR20 _DestTy* exclusive_scan(
     const _InIt _First, const _InIt _Last, _DestTy (&_Dest)[_DestSize], _Ty _Val, _BinOp _Reduce_op) {
     // set each value in [_Dest, _Dest + (_Last - _First)) to the associative reduction of predecessors and _Val
     return _STD exclusive_scan(
@@ -391,14 +391,14 @@ _DestTy* exclusive_scan(
 #endif // _ITERATOR_DEBUG_ARRAY_OVERLOADS
 
 template <class _InIt, class _OutIt, class _Ty>
-_OutIt exclusive_scan(const _InIt _First, const _InIt _Last, const _OutIt _Dest, _Ty _Val) {
+_CONSTEXPR20 _OutIt exclusive_scan(const _InIt _First, const _InIt _Last, const _OutIt _Dest, _Ty _Val) {
     // set each value in [_Dest, _Dest + (_Last - _First)) to the associative reduction of predecessors and _Val
     return _STD exclusive_scan(_First, _Last, _Dest, _STD move(_Val), plus<>{});
 }
 
 #if _ITERATOR_DEBUG_ARRAY_OVERLOADS
 template <class _InIt, class _DestTy, size_t _DestSize, class _Ty>
-_DestTy* exclusive_scan(const _InIt _First, const _InIt _Last, _DestTy (&_Dest)[_DestSize], _Ty _Val) {
+_CONSTEXPR20 _DestTy* exclusive_scan(const _InIt _First, const _InIt _Last, _DestTy (&_Dest)[_DestSize], _Ty _Val) {
     // set each value in [_Dest, _Dest + (_Last - _First)) to the associative reduction of predecessors and _Val
     return _STD exclusive_scan(_First, _Last, _Dest, _STD move(_Val), plus<>{});
 }

--- a/stl/inc/numeric
+++ b/stl/inc/numeric
@@ -23,7 +23,7 @@ _STL_DISABLE_CLANG_WARNINGS
 _STD_BEGIN
 // FUNCTION TEMPLATE accumulate
 template <class _InIt, class _Ty, class _Fn>
-_NODISCARD _Ty accumulate(const _InIt _First, const _InIt _Last, _Ty _Val, _Fn _Reduce_op) {
+_NODISCARD _CONSTEXPR20 _Ty accumulate(const _InIt _First, const _InIt _Last, _Ty _Val, _Fn _Reduce_op) {
     // return noncommutative and nonassociative reduction of _Val and all in [_First, _Last), using _Reduce_op
     _Adl_verify_range(_First, _Last);
     auto _UFirst      = _Get_unwrapped(_First);
@@ -39,7 +39,7 @@ _NODISCARD _Ty accumulate(const _InIt _First, const _InIt _Last, _Ty _Val, _Fn _
 }
 
 template <class _InIt, class _Ty>
-_NODISCARD _Ty accumulate(const _InIt _First, const _InIt _Last, _Ty _Val) {
+_NODISCARD _CONSTEXPR20 _Ty accumulate(const _InIt _First, const _InIt _Last, _Ty _Val) {
     // return noncommutative and nonassociative reduction of _Val and all in [_First, _Last)
     return _STD accumulate(_First, _Last, _Val, plus<>());
 }

--- a/stl/inc/numeric
+++ b/stl/inc/numeric
@@ -197,7 +197,7 @@ inline constexpr bool _Default_ops_transform_reduce_v = false;
 #endif // _STD_VECTORIZE_WITH_FLOAT_CONTROL
 
 template <class _InIt1, class _InIt2, class _Ty, class _BinOp1, class _BinOp2>
-_NODISCARD _Ty transform_reduce(
+_NODISCARD _CONSTEXPR20_ICE _Ty transform_reduce(
     _InIt1 _First1, _InIt1 _Last1, _InIt2 _First2, _Ty _Val, _BinOp1 _Reduce_op, _BinOp2 _Transform_op) {
     // return commutative and associative transform-reduction of sequences, using
     // _Reduce_op and _Transform_op
@@ -207,22 +207,26 @@ _NODISCARD _Ty transform_reduce(
     auto _UFirst2      = _Get_unwrapped_n(_First2, _Idl_distance<_InIt1>(_UFirst1, _ULast1));
     if constexpr (_Default_ops_transform_reduce_v<_Unwrapped_t<const _InIt1&>, _Unwrapped_t<const _InIt2&>, _Ty,
                       _BinOp1, _BinOp2>) {
-        (void) _Reduce_op; // TRANSITION, VSO-486357
-        (void) _Transform_op; // TRANSITION, VSO-486357
-        return _Transform_reduce_arithmetic_defaults(_UFirst1, _ULast1, _UFirst2, _STD move(_Val));
-    } else {
-        for (; _UFirst1 != _ULast1; ++_UFirst1, (void) ++_UFirst2) {
-            _Val = _Reduce_op(_STD move(_Val), _Transform_op(*_UFirst1, *_UFirst2)); // Requirement missing from N4713
+#ifdef __cpp_lib_is_constant_evaluated
+        if (!_STD is_constant_evaluated())
+#endif // __cpp_lib_is_constant_evaluated
+        {
+            (void) _Reduce_op; // TRANSITION, VSO-486357
+            (void) _Transform_op; // TRANSITION, VSO-486357
+            return _Transform_reduce_arithmetic_defaults(_UFirst1, _ULast1, _UFirst2, _STD move(_Val));
         }
-
-        return _Val;
     }
+    for (; _UFirst1 != _ULast1; ++_UFirst1, (void) ++_UFirst2) {
+        _Val = _Reduce_op(_STD move(_Val), _Transform_op(*_UFirst1, *_UFirst2)); // Requirement missing from N4713
+    }
+
+    return _Val;
 }
 
 #if _ITERATOR_DEBUG_ARRAY_OVERLOADS
 template <class _InIt1, class _RightTy, size_t _RightSize, class _Ty, class _BinOp1, class _BinOp2>
-_NODISCARD _Ty transform_reduce(const _InIt1 _First1, const _InIt1 _Last1, _RightTy (&_First2)[_RightSize], _Ty _Val,
-    _BinOp1 _Reduce_op, _BinOp2 _Transform_op) {
+_NODISCARD _CONSTEXPR20_ICE _Ty transform_reduce(const _InIt1 _First1, const _InIt1 _Last1,
+    _RightTy (&_First2)[_RightSize], _Ty _Val, _BinOp1 _Reduce_op, _BinOp2 _Transform_op) {
     // return commutative and associative transform-reduction of
     // sequences, using _Reduce_op and _Transform_op
     return _STD transform_reduce(_First1, _Last1, _Array_iterator<_RightTy, _RightSize>(_First2), _STD move(_Val),
@@ -231,21 +235,22 @@ _NODISCARD _Ty transform_reduce(const _InIt1 _First1, const _InIt1 _Last1, _Righ
 #endif // _ITERATOR_DEBUG_ARRAY_OVERLOADS
 
 template <class _InIt1, class _InIt2, class _Ty>
-_NODISCARD _Ty transform_reduce(_InIt1 _First1, _InIt1 _Last1, _InIt2 _First2, _Ty _Val) {
+_NODISCARD _CONSTEXPR20_ICE _Ty transform_reduce(_InIt1 _First1, _InIt1 _Last1, _InIt2 _First2, _Ty _Val) {
     // return commutative and associative transform-reduction of sequences
     return _STD transform_reduce(_First1, _Last1, _First2, _STD move(_Val), plus<>{}, multiplies<>{});
 }
 
 #if _ITERATOR_DEBUG_ARRAY_OVERLOADS
 template <class _InIt1, class _RightTy, size_t _RightSize, class _Ty>
-_NODISCARD _Ty transform_reduce(_InIt1 _First1, _InIt1 _Last1, _RightTy (&_First2)[_RightSize], _Ty _Val) {
+_NODISCARD _CONSTEXPR20_ICE _Ty transform_reduce(
+    _InIt1 _First1, _InIt1 _Last1, _RightTy (&_First2)[_RightSize], _Ty _Val) {
     // return commutative and associative transform-reduction of sequences
     return _STD transform_reduce(_First1, _Last1, _First2, _STD move(_Val), plus<>{}, multiplies<>{});
 }
 #endif // _ITERATOR_DEBUG_ARRAY_OVERLOADS
 
 template <class _InIt, class _Ty, class _BinOp, class _UnaryOp>
-_NODISCARD _Ty transform_reduce(
+_NODISCARD _CONSTEXPR20 _Ty transform_reduce(
     const _InIt _First, const _InIt _Last, _Ty _Val, _BinOp _Reduce_op, _UnaryOp _Transform_op) {
     // return commutative and associative reduction of transformed sequence, using
     // _Reduce_op and _Transform_op

--- a/stl/inc/numeric
+++ b/stl/inc/numeric
@@ -568,7 +568,7 @@ _DestTy* inclusive_scan(
 
 // FUNCTION TEMPLATE transform_exclusive_scan
 template <class _InIt, class _OutIt, class _Ty, class _BinOp, class _UnaryOp>
-_OutIt transform_exclusive_scan(
+_CONSTEXPR20 _OutIt transform_exclusive_scan(
     const _InIt _First, const _InIt _Last, _OutIt _Dest, _Ty _Val, _BinOp _Reduce_op, _UnaryOp _Transform_op) {
     // set each value in [_Dest, _Dest + (_Last - _First)) to the associative reduction of transformed predecessors
     _Adl_verify_range(_First, _Last);
@@ -595,8 +595,8 @@ _OutIt transform_exclusive_scan(
 
 #if _ITERATOR_DEBUG_ARRAY_OVERLOADS
 template <class _InIt, class _DestTy, size_t _DestSize, class _Ty, class _BinOp, class _UnaryOp>
-_DestTy* transform_exclusive_scan(const _InIt _First, const _InIt _Last, _DestTy (&_Dest)[_DestSize], _Ty _Val,
-    _BinOp _Reduce_op, _UnaryOp _Transform_op) {
+_CONSTEXPR20 _DestTy* transform_exclusive_scan(const _InIt _First, const _InIt _Last, _DestTy (&_Dest)[_DestSize],
+    _Ty _Val, _BinOp _Reduce_op, _UnaryOp _Transform_op) {
     // set each value in [_Dest, _Dest + (_Last - _First)) to the associative reduction of transformed predecessors
     return _STD transform_exclusive_scan(_First, _Last, _Array_iterator<_DestTy, _DestSize>(_Dest), _STD move(_Val),
         _Pass_fn(_Reduce_op), _Pass_fn(_Transform_op))

--- a/stl/inc/numeric
+++ b/stl/inc/numeric
@@ -725,7 +725,7 @@ _DestTy* transform_inclusive_scan(_ExPo&& _Exec, const _FwdIt1 _First, const _Fw
 
 // FUNCTION TEMPLATE adjacent_difference
 template <class _InIt, class _OutIt, class _BinOp>
-_OutIt adjacent_difference(const _InIt _First, const _InIt _Last, _OutIt _Dest, _BinOp _Func) {
+_CONSTEXPR20 _OutIt adjacent_difference(const _InIt _First, const _InIt _Last, _OutIt _Dest, _BinOp _Func) {
     // compute adjacent differences into _Dest
     _Adl_verify_range(_First, _Last);
     auto _UFirst      = _Get_unwrapped(_First);
@@ -753,7 +753,8 @@ _OutIt adjacent_difference(const _InIt _First, const _InIt _Last, _OutIt _Dest, 
 
 #if _ITERATOR_DEBUG_ARRAY_OVERLOADS
 template <class _InIt, class _DestTy, size_t _DestSize, class _BinOp>
-_DestTy* adjacent_difference(const _InIt _First, const _InIt _Last, _DestTy (&_Dest)[_DestSize], _BinOp _Func) {
+_CONSTEXPR20 _DestTy* adjacent_difference(
+    const _InIt _First, const _InIt _Last, _DestTy (&_Dest)[_DestSize], _BinOp _Func) {
     // compute adjacent differences into _Dest
     return _STD adjacent_difference(_First, _Last, _Array_iterator<_DestTy, _DestSize>(_Dest), _Pass_fn(_Func))
         ._Unwrapped();
@@ -761,14 +762,14 @@ _DestTy* adjacent_difference(const _InIt _First, const _InIt _Last, _DestTy (&_D
 #endif // _ITERATOR_DEBUG_ARRAY_OVERLOADS
 
 template <class _InIt, class _OutIt>
-_OutIt adjacent_difference(const _InIt _First, const _InIt _Last, const _OutIt _Dest) {
+_CONSTEXPR20 _OutIt adjacent_difference(const _InIt _First, const _InIt _Last, const _OutIt _Dest) {
     // compute adjacent differences into _Dest
     return _STD adjacent_difference(_First, _Last, _Dest, minus<>());
 }
 
 #if _ITERATOR_DEBUG_ARRAY_OVERLOADS
 template <class _InIt, class _DestTy, size_t _DestSize>
-_DestTy* adjacent_difference(const _InIt _First, const _InIt _Last, _DestTy (&_Dest)[_DestSize]) {
+_CONSTEXPR20 _DestTy* adjacent_difference(const _InIt _First, const _InIt _Last, _DestTy (&_Dest)[_DestSize]) {
     // compute adjacent differences into _Dest
     return _STD adjacent_difference(_First, _Last, _Dest, minus<>());
 }

--- a/stl/inc/numeric
+++ b/stl/inc/numeric
@@ -439,7 +439,7 @@ _DestTy* exclusive_scan(_ExPo&& _Exec, const _FwdIt1 _First, const _FwdIt1 _Last
 
 // FUNCTION TEMPLATE inclusive_scan
 template <class _InIt, class _OutIt, class _Ty, class _BinOp>
-_OutIt inclusive_scan(const _InIt _First, const _InIt _Last, _OutIt _Dest, _BinOp _Reduce_op, _Ty _Val) {
+_CONSTEXPR20 _OutIt inclusive_scan(const _InIt _First, const _InIt _Last, _OutIt _Dest, _BinOp _Reduce_op, _Ty _Val) {
     // compute partial noncommutative and associative reductions including _Val into _Dest, using _Reduce_op
     _Adl_verify_range(_First, _Last);
     auto _UFirst      = _Get_unwrapped(_First);
@@ -457,7 +457,7 @@ _OutIt inclusive_scan(const _InIt _First, const _InIt _Last, _OutIt _Dest, _BinO
 
 #if _ITERATOR_DEBUG_ARRAY_OVERLOADS
 template <class _InIt, class _DestTy, size_t _DestSize, class _Ty, class _BinOp>
-_DestTy* inclusive_scan(
+_CONSTEXPR20 _DestTy* inclusive_scan(
     const _InIt _First, const _InIt _Last, _DestTy (&_Dest)[_DestSize], _BinOp _Reduce_op, _Ty _Val) {
     // compute partial noncommutative and associative reductions including _Val into _Dest, using _Reduce_op
     return _STD inclusive_scan(
@@ -467,7 +467,7 @@ _DestTy* inclusive_scan(
 #endif // _ITERATOR_DEBUG_ARRAY_OVERLOADS
 
 template <class _InIt, class _OutIt, class _BinOp>
-_OutIt inclusive_scan(const _InIt _First, const _InIt _Last, _OutIt _Dest, _BinOp _Reduce_op) {
+_CONSTEXPR20 _OutIt inclusive_scan(const _InIt _First, const _InIt _Last, _OutIt _Dest, _BinOp _Reduce_op) {
     // compute partial noncommutative and associative reductions into _Dest, using _Reduce_op
     _Adl_verify_range(_First, _Last);
     auto _UFirst      = _Get_unwrapped(_First);
@@ -493,7 +493,8 @@ _OutIt inclusive_scan(const _InIt _First, const _InIt _Last, _OutIt _Dest, _BinO
 
 #if _ITERATOR_DEBUG_ARRAY_OVERLOADS
 template <class _InIt, class _DestTy, size_t _DestSize, class _BinOp>
-_DestTy* inclusive_scan(const _InIt _First, const _InIt _Last, _DestTy (&_Dest)[_DestSize], _BinOp _Reduce_op) {
+_CONSTEXPR20 _DestTy* inclusive_scan(
+    const _InIt _First, const _InIt _Last, _DestTy (&_Dest)[_DestSize], _BinOp _Reduce_op) {
     // compute partial noncommutative and associative reductions into _Dest, using _Reduce_op
     return _STD inclusive_scan(_First, _Last, _Array_iterator<_DestTy, _DestSize>(_Dest), _Pass_fn(_Reduce_op))
         ._Unwrapped();
@@ -501,14 +502,14 @@ _DestTy* inclusive_scan(const _InIt _First, const _InIt _Last, _DestTy (&_Dest)[
 #endif // _ITERATOR_DEBUG_ARRAY_OVERLOADS
 
 template <class _InIt, class _OutIt>
-_OutIt inclusive_scan(const _InIt _First, const _InIt _Last, const _OutIt _Dest) {
+_CONSTEXPR20 _OutIt inclusive_scan(const _InIt _First, const _InIt _Last, const _OutIt _Dest) {
     // compute partial noncommutative and associative reductions into _Dest
     return _STD inclusive_scan(_First, _Last, _Dest, plus<>{});
 }
 
 #if _ITERATOR_DEBUG_ARRAY_OVERLOADS
 template <class _InIt, class _DestTy, size_t _DestSize>
-_DestTy* inclusive_scan(const _InIt _First, const _InIt _Last, _DestTy (&_Dest)[_DestSize]) {
+_CONSTEXPR20 _DestTy* inclusive_scan(const _InIt _First, const _InIt _Last, _DestTy (&_Dest)[_DestSize]) {
     // compute partial noncommutative and associative reductions into _Dest
     return _STD inclusive_scan(_First, _Last, _Dest, plus<>{});
 }

--- a/stl/inc/numeric
+++ b/stl/inc/numeric
@@ -623,7 +623,7 @@ _DestTy* transform_exclusive_scan(_ExPo&& _Exec, const _FwdIt1 _First, const _Fw
 
 // FUNCTION TEMPLATE transform_inclusive_scan
 template <class _InIt, class _OutIt, class _Ty, class _BinOp, class _UnaryOp>
-_OutIt transform_inclusive_scan(
+_CONSTEXPR20 _OutIt transform_inclusive_scan(
     const _InIt _First, const _InIt _Last, _OutIt _Dest, _BinOp _Reduce_op, _UnaryOp _Transform_op, _Ty _Val) {
     // compute partial noncommutative and associative transformed reductions including _Val into _Dest
     _Adl_verify_range(_First, _Last);
@@ -642,8 +642,8 @@ _OutIt transform_inclusive_scan(
 
 #if _ITERATOR_DEBUG_ARRAY_OVERLOADS
 template <class _InIt, class _DestTy, size_t _DestSize, class _Ty, class _BinOp, class _UnaryOp>
-_DestTy* transform_inclusive_scan(const _InIt _First, const _InIt _Last, _DestTy (&_Dest)[_DestSize], _BinOp _Reduce_op,
-    _UnaryOp _Transform_op, _Ty _Val) {
+_CONSTEXPR20 _DestTy* transform_inclusive_scan(const _InIt _First, const _InIt _Last, _DestTy (&_Dest)[_DestSize],
+    _BinOp _Reduce_op, _UnaryOp _Transform_op, _Ty _Val) {
     // compute partial noncommutative and associative transformed reductions including _Val into _Dest
     return _STD transform_inclusive_scan(_First, _Last, _Array_iterator<_DestTy, _DestSize>(_Dest),
         _Pass_fn(_Reduce_op), _Pass_fn(_Transform_op), _STD move(_Val))
@@ -652,7 +652,7 @@ _DestTy* transform_inclusive_scan(const _InIt _First, const _InIt _Last, _DestTy
 #endif // _ITERATOR_DEBUG_ARRAY_OVERLOADS
 
 template <class _InIt, class _OutIt, class _BinOp, class _UnaryOp>
-_OutIt transform_inclusive_scan(
+_CONSTEXPR20 _OutIt transform_inclusive_scan(
     const _InIt _First, const _InIt _Last, _OutIt _Dest, _BinOp _Reduce_op, _UnaryOp _Transform_op) {
     // compute partial noncommutative and associative transformed reductions into _Dest
     _Adl_verify_range(_First, _Last);
@@ -679,7 +679,7 @@ _OutIt transform_inclusive_scan(
 
 #if _ITERATOR_DEBUG_ARRAY_OVERLOADS
 template <class _InIt, class _DestTy, size_t _DestSize, class _BinOp, class _UnaryOp>
-_DestTy* transform_inclusive_scan(
+_CONSTEXPR20 _DestTy* transform_inclusive_scan(
     const _InIt _First, const _InIt _Last, _DestTy (&_Dest)[_DestSize], _BinOp _Reduce_op, _UnaryOp _Transform_op) {
     // compute partial noncommutative and associative transformed reductions into _Dest
     return _STD transform_inclusive_scan(

--- a/stl/inc/numeric
+++ b/stl/inc/numeric
@@ -811,7 +811,7 @@ _DestTy* adjacent_difference(
 
 // FUNCTION TEMPLATE iota
 template <class _FwdIt, class _Ty>
-void iota(_FwdIt _First, _FwdIt _Last, _Ty _Val) {
+_CONSTEXPR20 void iota(_FwdIt _First, _FwdIt _Last, _Ty _Val) {
     // compute increasing sequence into [_First, _Last)
     _Adl_verify_range(_First, _Last);
     auto _UFirst      = _Get_unwrapped(_First);

--- a/stl/inc/numeric
+++ b/stl/inc/numeric
@@ -76,6 +76,7 @@ _NODISCARD _CONSTEXPR20_ICE _Ty reduce(const _InIt _First, const _InIt _Last, _T
     auto _UFirst      = _Get_unwrapped(_First);
     const auto _ULast = _Get_unwrapped(_Last);
 #ifdef __cpp_lib_is_constant_evaluated
+    // TRANSITION, DevCom-878972
     if (_STD is_constant_evaluated()) {
         for (; _UFirst != _ULast; ++_UFirst) {
             _Val = _Reduce_op(_STD move(_Val), *_UFirst); // Requirement missing from N4713
@@ -211,6 +212,7 @@ _NODISCARD _CONSTEXPR20_ICE _Ty transform_reduce(
     const auto _ULast1 = _Get_unwrapped(_Last1);
     auto _UFirst2      = _Get_unwrapped_n(_First2, _Idl_distance<_InIt1>(_UFirst1, _ULast1));
 #ifdef __cpp_lib_is_constant_evaluated
+    // TRANSITION, DevCom-878972
     if (_STD is_constant_evaluated()) {
         for (; _UFirst1 != _ULast1; ++_UFirst1, (void) ++_UFirst2) {
             _Val = _Reduce_op(_STD move(_Val), _Transform_op(*_UFirst1, *_UFirst2)); // Requirement missing from N4713

--- a/stl/inc/numeric
+++ b/stl/inc/numeric
@@ -122,7 +122,7 @@ _NODISCARD _Iter_value_t<_FwdIt> reduce(
 
 // FUNCTION TEMPLATE inner_product
 template <class _InIt1, class _InIt2, class _Ty, class _BinOp1, class _BinOp2>
-_NODISCARD _Ty inner_product(
+_NODISCARD _CONSTEXPR20 _Ty inner_product(
     _InIt1 _First1, _InIt1 _Last1, _InIt2 _First2, _Ty _Val, _BinOp1 _Reduce_op, _BinOp2 _Transform_op) {
     // return noncommutative and nonassociative transform-reduction of sequences, using
     // _Reduce_op and _Transform_op
@@ -143,8 +143,8 @@ _NODISCARD _Ty inner_product(
 
 #if _ITERATOR_DEBUG_ARRAY_OVERLOADS
 template <class _InIt1, class _RightTy, size_t _RightSize, class _Ty, class _BinOp1, class _BinOp2>
-_NODISCARD _Ty inner_product(const _InIt1 _First1, const _InIt1 _Last1, _RightTy (&_First2)[_RightSize], _Ty _Val,
-    _BinOp1 _Reduce_op, _BinOp2 _Transform_op) {
+_NODISCARD _CONSTEXPR20 _Ty inner_product(const _InIt1 _First1, const _InIt1 _Last1, _RightTy (&_First2)[_RightSize],
+    _Ty _Val, _BinOp1 _Reduce_op, _BinOp2 _Transform_op) {
     // return noncommutative and nonassociative transform-reduction of sequences, using
     // _Reduce_op and _Transform_op
     return _STD inner_product(_First1, _Last1, _Array_iterator<_RightTy, _RightSize>(_First2), _STD move(_Val),
@@ -153,14 +153,15 @@ _NODISCARD _Ty inner_product(const _InIt1 _First1, const _InIt1 _Last1, _RightTy
 #endif // _ITERATOR_DEBUG_ARRAY_OVERLOADS
 
 template <class _InIt1, class _InIt2, class _Ty>
-_NODISCARD _Ty inner_product(const _InIt1 _First1, const _InIt1 _Last1, const _InIt2 _First2, _Ty _Val) {
+_NODISCARD _CONSTEXPR20 _Ty inner_product(const _InIt1 _First1, const _InIt1 _Last1, const _InIt2 _First2, _Ty _Val) {
     // return noncommutative and nonassociative transform-reduction of sequences
     return _STD inner_product(_First1, _Last1, _First2, _STD move(_Val), plus<>(), multiplies<>());
 }
 
 #if _ITERATOR_DEBUG_ARRAY_OVERLOADS
 template <class _InIt1, class _RightTy, size_t _RightSize, class _Ty>
-_NODISCARD _Ty inner_product(const _InIt1 _First1, const _InIt1 _Last1, _RightTy (&_First2)[_RightSize], _Ty _Val) {
+_NODISCARD _CONSTEXPR20 _Ty inner_product(
+    const _InIt1 _First1, const _InIt1 _Last1, _RightTy (&_First2)[_RightSize], _Ty _Val) {
     // return noncommutative and nonassociative transform-reduction of sequences
     return _STD inner_product(_First1, _Last1, _First2, _STD move(_Val), plus<>(), multiplies<>());
 }

--- a/stl/inc/numeric
+++ b/stl/inc/numeric
@@ -301,7 +301,7 @@ _NODISCARD _Ty transform_reduce(_ExPo&& _Exec, const _FwdIt _First1, const _FwdI
 
 // FUNCTION TEMPLATE partial_sum
 template <class _InIt, class _OutIt, class _BinOp>
-_OutIt partial_sum(const _InIt _First, const _InIt _Last, _OutIt _Dest, _BinOp _Reduce_op) {
+_CONSTEXPR20 _OutIt partial_sum(const _InIt _First, const _InIt _Last, _OutIt _Dest, _BinOp _Reduce_op) {
     // compute partial noncommutative and nonassociative reductions into _Dest, using _Reduce_op
     _Adl_verify_range(_First, _Last);
     auto _UFirst      = _Get_unwrapped(_First);
@@ -331,7 +331,7 @@ _OutIt partial_sum(const _InIt _First, const _InIt _Last, _OutIt _Dest, _BinOp _
 
 #if _ITERATOR_DEBUG_ARRAY_OVERLOADS
 template <class _InIt, class _DestTy, size_t _DestSize, class _BinOp>
-_DestTy* partial_sum(_InIt _First, _InIt _Last, _DestTy (&_Dest)[_DestSize], _BinOp _Reduce_op) {
+_CONSTEXPR20 _DestTy* partial_sum(_InIt _First, _InIt _Last, _DestTy (&_Dest)[_DestSize], _BinOp _Reduce_op) {
     // compute partial noncommutative and nonassociative reductions into _Dest, using _Reduce_op
     return _STD partial_sum(_First, _Last, _Array_iterator<_DestTy, _DestSize>(_Dest), _Pass_fn(_Reduce_op))
         ._Unwrapped();
@@ -339,14 +339,14 @@ _DestTy* partial_sum(_InIt _First, _InIt _Last, _DestTy (&_Dest)[_DestSize], _Bi
 #endif // _ITERATOR_DEBUG_ARRAY_OVERLOADS
 
 template <class _InIt, class _OutIt>
-_OutIt partial_sum(_InIt _First, _InIt _Last, _OutIt _Dest) {
+_CONSTEXPR20 _OutIt partial_sum(_InIt _First, _InIt _Last, _OutIt _Dest) {
     // compute partial noncommutative and nonassociative reductions into _Dest
     return _STD partial_sum(_First, _Last, _Dest, plus<>());
 }
 
 #if _ITERATOR_DEBUG_ARRAY_OVERLOADS
 template <class _InIt, class _DestTy, size_t _DestSize>
-_DestTy* partial_sum(_InIt _First, _InIt _Last, _DestTy (&_Dest)[_DestSize]) {
+_CONSTEXPR20 _DestTy* partial_sum(_InIt _First, _InIt _Last, _DestTy (&_Dest)[_DestSize]) {
     // compute partial noncommutative and nonassociative reductions into _Dest
     return _STD partial_sum(_First, _Last, _Dest, plus<>());
 }

--- a/stl/inc/numeric
+++ b/stl/inc/numeric
@@ -70,31 +70,35 @@ inline constexpr bool _Plus_on_arithmetic_ranges_reduction_v = false;
 #endif // _STD_VECTORIZE_WITH_FLOAT_CONTROL
 
 template <class _InIt, class _Ty, class _BinOp>
-_NODISCARD _Ty reduce(const _InIt _First, const _InIt _Last, _Ty _Val, _BinOp _Reduce_op) {
+_NODISCARD _CONSTEXPR20_ICE _Ty reduce(const _InIt _First, const _InIt _Last, _Ty _Val, _BinOp _Reduce_op) {
     // return commutative and associative reduction of _Val and [_First, _Last), using _Reduce_op
     _Adl_verify_range(_First, _Last);
     auto _UFirst      = _Get_unwrapped(_First);
     const auto _ULast = _Get_unwrapped(_Last);
     if constexpr (_Plus_on_arithmetic_ranges_reduction_v<_Unwrapped_t<const _InIt&>, _Ty, _BinOp>) {
-        (void) _Reduce_op; // TRANSITION, VSO-486357
-        return _Reduce_plus_arithmetic_ranges(_UFirst, _ULast, _Val);
-    } else {
-        for (; _UFirst != _ULast; ++_UFirst) {
-            _Val = _Reduce_op(_STD move(_Val), *_UFirst); // Requirement missing from N4713
+#ifdef __cpp_lib_is_constant_evaluated
+        if (!_STD is_constant_evaluated())
+#endif // __cpp_lib_is_constant_evaluated
+        {
+            (void) _Reduce_op; // TRANSITION, VSO-486357
+            return _Reduce_plus_arithmetic_ranges(_UFirst, _ULast, _Val);
         }
-
-        return _Val;
     }
+    for (; _UFirst != _ULast; ++_UFirst) {
+        _Val = _Reduce_op(_STD move(_Val), *_UFirst); // Requirement missing from N4713
+    }
+
+    return _Val;
 }
 
 template <class _InIt, class _Ty>
-_NODISCARD _Ty reduce(const _InIt _First, const _InIt _Last, _Ty _Val) {
+_NODISCARD _CONSTEXPR20_ICE _Ty reduce(const _InIt _First, const _InIt _Last, _Ty _Val) {
     // return commutative and associative reduction of _Val and [_First, _Last)
     return _STD reduce(_First, _Last, _STD move(_Val), plus<>{});
 }
 
 template <class _InIt>
-_NODISCARD _Iter_value_t<_InIt> reduce(const _InIt _First, const _InIt _Last) {
+_NODISCARD _CONSTEXPR20_ICE _Iter_value_t<_InIt> reduce(const _InIt _First, const _InIt _Last) {
     // return commutative and associative reduction of
     // iterator_traits<_InIt>::value_type{} and [_First, _Last)
     return _STD reduce(_First, _Last, _Iter_value_t<_InIt>{}, plus<>{});

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -1330,7 +1330,7 @@ using _Enable_if_execution_policy_t = typename remove_reference_t<_ExPo>::_Stand
 // FUNCTION TEMPLATE _Idl_distance
 #if _HAS_IF_CONSTEXPR
 template <class _Checked, class _Iter>
-constexpr auto _Idl_distance(const _Iter& _First, const _Iter& _Last) {
+_NODISCARD constexpr auto _Idl_distance(const _Iter& _First, const _Iter& _Last) {
     // tries to get the distance between _First and _Last if they are random-access iterators
     if constexpr (_Is_random_iter_v<_Iter>) {
         return static_cast<_Iter_diff_t<_Checked>>(_Last - _First);
@@ -1342,19 +1342,19 @@ constexpr auto _Idl_distance(const _Iter& _First, const _Iter& _Last) {
 }
 #else // ^^^ _HAS_IF_CONSTEXPR / !_HAS_IF_CONSTEXPR vvv
 template <class _Checked, class _Iter>
-constexpr _Distance_unknown _Idl_distance1(const _Iter&, const _Iter&, input_iterator_tag) {
+_NODISCARD constexpr _Distance_unknown _Idl_distance1(const _Iter&, const _Iter&, input_iterator_tag) {
     // _Idl_distance for non-random-access iterators
     return {};
 }
 
 template <class _Checked, class _Iter>
-constexpr _Iter_diff_t<_Checked> _Idl_distance1(const _Iter& _First, const _Iter& _Last, random_access_iterator_tag) {
+_NODISCARD constexpr _Iter_diff_t<_Checked> _Idl_distance1(const _Iter& _First, const _Iter& _Last, random_access_iterator_tag) {
     // _Idl_distance for random-access iterators
     return static_cast<_Iter_diff_t<_Checked>>(_Last - _First);
 }
 
 template <class _Checked, class _Iter>
-constexpr auto _Idl_distance(const _Iter& _First, const _Iter& _Last) {
+_NODISCARD constexpr auto _Idl_distance(const _Iter& _First, const _Iter& _Last) {
     // tries to get the distance between _First and _Last if they are random-access iterators
     return _Idl_distance1<_Checked>(_First, _Last, _Iter_cat_t<_Iter>());
 }

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -1348,7 +1348,8 @@ _NODISCARD constexpr _Distance_unknown _Idl_distance1(const _Iter&, const _Iter&
 }
 
 template <class _Checked, class _Iter>
-_NODISCARD constexpr _Iter_diff_t<_Checked> _Idl_distance1(const _Iter& _First, const _Iter& _Last, random_access_iterator_tag) {
+_NODISCARD constexpr _Iter_diff_t<_Checked> _Idl_distance1(
+    const _Iter& _First, const _Iter& _Last, random_access_iterator_tag) {
     // _Idl_distance for random-access iterators
     return static_cast<_Iter_diff_t<_Checked>>(_Last - _First);
 }

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -1330,7 +1330,7 @@ using _Enable_if_execution_policy_t = typename remove_reference_t<_ExPo>::_Stand
 // FUNCTION TEMPLATE _Idl_distance
 #if _HAS_IF_CONSTEXPR
 template <class _Checked, class _Iter>
-auto _Idl_distance(const _Iter& _First, const _Iter& _Last) {
+constexpr auto _Idl_distance(const _Iter& _First, const _Iter& _Last) {
     // tries to get the distance between _First and _Last if they are random-access iterators
     if constexpr (_Is_random_iter_v<_Iter>) {
         return static_cast<_Iter_diff_t<_Checked>>(_Last - _First);
@@ -1342,19 +1342,19 @@ auto _Idl_distance(const _Iter& _First, const _Iter& _Last) {
 }
 #else // ^^^ _HAS_IF_CONSTEXPR / !_HAS_IF_CONSTEXPR vvv
 template <class _Checked, class _Iter>
-_Distance_unknown _Idl_distance1(const _Iter&, const _Iter&, input_iterator_tag) {
+constexpr _Distance_unknown _Idl_distance1(const _Iter&, const _Iter&, input_iterator_tag) {
     // _Idl_distance for non-random-access iterators
     return {};
 }
 
 template <class _Checked, class _Iter>
-_Iter_diff_t<_Checked> _Idl_distance1(const _Iter& _First, const _Iter& _Last, random_access_iterator_tag) {
+constexpr _Iter_diff_t<_Checked> _Idl_distance1(const _Iter& _First, const _Iter& _Last, random_access_iterator_tag) {
     // _Idl_distance for random-access iterators
     return static_cast<_Iter_diff_t<_Checked>>(_Last - _First);
 }
 
 template <class _Checked, class _Iter>
-auto _Idl_distance(const _Iter& _First, const _Iter& _Last) {
+constexpr auto _Idl_distance(const _Iter& _First, const _Iter& _Last) {
     // tries to get the distance between _First and _Last if they are random-access iterators
     return _Idl_distance1<_Checked>(_First, _Last, _Iter_cat_t<_Iter>());
 }

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -471,13 +471,6 @@
 #define _CONSTEXPR20 inline
 #endif // ^^^ inline (not constexpr) in C++17 and earlier ^^^
 
-// Functions that became constexpr in C++20, and requires is_constant_evaluated
-#ifdef __cpp_lib_is_constant_evaluated
-#define _CONSTEXPR20_ICE constexpr
-#else // ^^^ constexpr with is_constant_evaluated / vvv not constexpr without is_constant_evaluated vvv
-#define _CONSTEXPR20_ICE
-#endif // ^^^ not constexpr without is_constant_evaluated ^^^
-
 // P0607R0 Inline Variables For The STL
 #if _HAS_CXX17
 #define _INLINE_VAR inline
@@ -1018,6 +1011,12 @@
 #define __cpp_lib_experimental_erase_if   201411L
 #define __cpp_lib_experimental_filesystem 201406L
 
+// Functions that became constexpr in C++20, and requires is_constant_evaluated
+#ifdef __cpp_lib_is_constant_evaluated
+#define _CONSTEXPR20_ICE constexpr
+#else // ^^^ constexpr with is_constant_evaluated / vvv not constexpr without is_constant_evaluated vvv
+#define _CONSTEXPR20_ICE
+#endif // ^^^ not constexpr without is_constant_evaluated ^^^
 
 #ifdef _RTC_CONVERSION_CHECKS_ENABLED
 #ifndef _ALLOW_RTCc_IN_STL

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -1011,10 +1011,10 @@
 #define __cpp_lib_experimental_erase_if   201411L
 #define __cpp_lib_experimental_filesystem 201406L
 
-// Functions that became constexpr in C++20, and requires is_constant_evaluated
+// Functions that became constexpr in C++20, and require is_constant_evaluated
 #ifdef __cpp_lib_is_constant_evaluated
 #define _CONSTEXPR20_ICE constexpr
-#else // ^^^ constexpr with is_constant_evaluated / vvv not constexpr without is_constant_evaluated vvv
+#else // ^^^ constexpr with is_constant_evaluated / not constexpr without is_constant_evaluated vvv
 #define _CONSTEXPR20_ICE
 #endif // ^^^ not constexpr without is_constant_evaluated ^^^
 

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -165,6 +165,7 @@
 // P1357R1 is_bounded_array, is_unbounded_array
 // P1456R1 Move-Only Views
 // P1612R1 Relocating endian To <bit>
+// P1645R1 constexpr For <numeric> Algorithms
 // P1651R0 bind_front() Should Not Unwrap reference_wrapper
 // P1690R1 Refining Heterogeneous Lookup For Unordered Containers
 // P1754R1 Rename Concepts To standard_case
@@ -990,6 +991,7 @@
 #endif // _HAS_STD_BOOLEAN
 #endif // defined(__cpp_concepts) && __cpp_concepts > 201507L
 
+#define __cpp_lib_constexpr_numeric        201911L
 #define __cpp_lib_endian                   201907L
 #define __cpp_lib_erase_if                 201811L
 #define __cpp_lib_generic_unordered_lookup 201811L

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -1014,9 +1014,9 @@
 // Functions that became constexpr in C++20, and require is_constant_evaluated
 #ifdef __cpp_lib_is_constant_evaluated
 #define _CONSTEXPR20_ICE constexpr
-#else // ^^^ constexpr with is_constant_evaluated / not constexpr without is_constant_evaluated vvv
-#define _CONSTEXPR20_ICE
-#endif // ^^^ not constexpr without is_constant_evaluated ^^^
+#else // ^^^ constexpr with is_constant_evaluated / inline without is_constant_evaluated vvv
+#define _CONSTEXPR20_ICE inline
+#endif // __cpp_lib_is_constant_evaluated
 
 #ifdef _RTC_CONVERSION_CHECKS_ENABLED
 #ifndef _ALLOW_RTCc_IN_STL

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -470,6 +470,13 @@
 #define _CONSTEXPR20 inline
 #endif // ^^^ inline (not constexpr) in C++17 and earlier ^^^
 
+// Functions that became constexpr in C++20, and requires is_constant_evaluated
+#ifdef __cpp_lib_is_constant_evaluated
+#define _CONSTEXPR20_ICE constexpr
+#else // ^^^ constexpr witn is_constant_evaluated / vvv inline (not constexpr) without is_constant_evaluated vvv
+#define _CONSTEXPR20_ICE inline
+#endif // ^^^ inline (not constexpr) without is_constant_evaluated ^^^
+
 // P0607R0 Inline Variables For The STL
 #if _HAS_CXX17
 #define _INLINE_VAR inline

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -984,7 +984,6 @@
 #endif // _HAS_STD_BOOLEAN
 #endif // defined(__cpp_concepts) && __cpp_concepts > 201507L
 
-#define __cpp_lib_constexpr_numeric        201911L
 #define __cpp_lib_endian                   201907L
 #define __cpp_lib_erase_if                 201811L
 #define __cpp_lib_generic_unordered_lookup 201811L
@@ -1005,6 +1004,11 @@
 #define __cpp_lib_to_array                201907L
 #define __cpp_lib_type_identity           201806L
 #define __cpp_lib_unwrap_ref              201811L
+
+#ifdef __cpp_lib_is_constant_evaluated
+#define __cpp_lib_constexpr_numeric 201911L
+#endif // __cpp_lib_is_constant_evaluated
+
 #endif // _HAS_CXX20
 
 // EXPERIMENTAL

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -474,9 +474,9 @@
 // Functions that became constexpr in C++20, and requires is_constant_evaluated
 #ifdef __cpp_lib_is_constant_evaluated
 #define _CONSTEXPR20_ICE constexpr
-#else // ^^^ constexpr witn is_constant_evaluated / vvv inline (not constexpr) without is_constant_evaluated vvv
-#define _CONSTEXPR20_ICE inline
-#endif // ^^^ inline (not constexpr) without is_constant_evaluated ^^^
+#else // ^^^ constexpr with is_constant_evaluated / vvv not constexpr without is_constant_evaluated vvv
+#define _CONSTEXPR20_ICE
+#endif // ^^^ not constexpr without is_constant_evaluated ^^^
 
 // P0607R0 Inline Variables For The STL
 #if _HAS_CXX17


### PR DESCRIPTION
# Description

This is an in-progress implementation of constexpr `<numeric>`.
Will resolve issue #337.

# Checklist
- [x] fix #337

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [x] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
