### PR TITLE
Don't enumerate libcxx/test/std/pstl

### DIFF
--- a/tests/libcxx/contest.yaml
+++ b/tests/libcxx/contest.yaml
@@ -6,6 +6,7 @@
   skipped-test-lists-relative-to-tests-root: true
   skipped-test-directories:
     - 'experimental'
+    - 'pstl'
   skipped-test-file-names:
     - 'nothing_to_do.pass.cpp'
   skipped-tests-comment-list-files:


### PR DESCRIPTION
# Description

In the test runner, `pstl` is a symlink to `../../../pstl/test/std` (when it exists - which only happens when git is honoring symlinks). The test runner is not prepared for this.

# Checklist

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [X] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [X] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [X] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [X] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
