### PR TITLE
<utility> Deprecate std::rel_ops & resolve #403

### DIFF
--- a/stl/inc/functional
+++ b/stl/inc/functional
@@ -334,7 +334,7 @@ private:
 
 // FUNCTION TEMPLATE not1
 template <class _Fn>
-_NODISCARD _CXX17_DEPRECATE_NEGATORS constexpr unary_negate<_Fn> not1(const _Fn& _Func) {
+_CXX17_DEPRECATE_NEGATORS _NODISCARD constexpr unary_negate<_Fn> not1(const _Fn& _Func) {
     return unary_negate<_Fn>(_Func);
 }
 
@@ -358,7 +358,7 @@ private:
 
 // FUNCTION TEMPLATE not2
 template <class _Fn>
-_NODISCARD _CXX17_DEPRECATE_NEGATORS constexpr binary_negate<_Fn> not2(const _Fn& _Func) {
+_CXX17_DEPRECATE_NEGATORS _NODISCARD constexpr binary_negate<_Fn> not2(const _Fn& _Func) {
     return binary_negate<_Fn>(_Func);
 }
 _STL_RESTORE_DEPRECATED_WARNING

--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -1205,7 +1205,7 @@ public:
         return get()[_Idx];
     }
 
-    _NODISCARD _CXX17_DEPRECATE_SHARED_PTR_UNIQUE bool unique() const noexcept {
+    _CXX17_DEPRECATE_SHARED_PTR_UNIQUE _NODISCARD bool unique() const noexcept {
         // return true if no other shared_ptr object owns this resource
         return this->use_count() == 1;
     }

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -355,7 +355,7 @@ _NODISCARD constexpr pair<_Unrefwrap_t<_Ty1>, _Unrefwrap_t<_Ty2>> make_pair(_Ty1
     return _Mypair(_STD forward<_Ty1>(_Val1), _STD forward<_Ty2>(_Val2));
 }
 
-namespace _DEPRECATE_CXX20_REL_OPS rel_ops { // nested namespace to hide relational operators from std
+namespace _DEPRECATE_CXX20_REL_OPS rel_ops {
     template <class _Ty>
     _DEPRECATE_CXX20_REL_OPS _NODISCARD bool operator!=(const _Ty& _Left, const _Ty& _Right) {
         return !(_Left == _Right);

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -357,22 +357,22 @@ _NODISCARD constexpr pair<_Unrefwrap_t<_Ty1>, _Unrefwrap_t<_Ty2>> make_pair(_Ty1
 
 namespace rel_ops { // nested namespace to hide relational operators from std
     template <class _Ty>
-    _NODISCARD bool operator!=(const _Ty& _Left, const _Ty& _Right) {
+    _DEPRECATE_CXX20_REL_OPS _NODISCARD bool operator!=(const _Ty& _Left, const _Ty& _Right) {
         return !(_Left == _Right);
     }
 
     template <class _Ty>
-    _NODISCARD bool operator>(const _Ty& _Left, const _Ty& _Right) {
+    _DEPRECATE_CXX20_REL_OPS _NODISCARD bool operator>(const _Ty& _Left, const _Ty& _Right) {
         return _Right < _Left;
     }
 
     template <class _Ty>
-    _NODISCARD bool operator<=(const _Ty& _Left, const _Ty& _Right) {
+    _DEPRECATE_CXX20_REL_OPS _NODISCARD bool operator<=(const _Ty& _Left, const _Ty& _Right) {
         return !(_Right < _Left);
     }
 
     template <class _Ty>
-    _NODISCARD bool operator>=(const _Ty& _Left, const _Ty& _Right) {
+    _DEPRECATE_CXX20_REL_OPS _NODISCARD bool operator>=(const _Ty& _Left, const _Ty& _Right) {
         return !(_Left < _Right);
     }
 } // namespace rel_ops

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -355,24 +355,24 @@ _NODISCARD constexpr pair<_Unrefwrap_t<_Ty1>, _Unrefwrap_t<_Ty2>> make_pair(_Ty1
     return _Mypair(_STD forward<_Ty1>(_Val1), _STD forward<_Ty2>(_Val2));
 }
 
-namespace _DEPRECATE_CXX20_REL_OPS rel_ops {
+namespace _CXX20_DEPRECATE_REL_OPS rel_ops {
     template <class _Ty>
-    _DEPRECATE_CXX20_REL_OPS _NODISCARD bool operator!=(const _Ty& _Left, const _Ty& _Right) {
+    _CXX20_DEPRECATE_REL_OPS _NODISCARD bool operator!=(const _Ty& _Left, const _Ty& _Right) {
         return !(_Left == _Right);
     }
 
     template <class _Ty>
-    _DEPRECATE_CXX20_REL_OPS _NODISCARD bool operator>(const _Ty& _Left, const _Ty& _Right) {
+    _CXX20_DEPRECATE_REL_OPS _NODISCARD bool operator>(const _Ty& _Left, const _Ty& _Right) {
         return _Right < _Left;
     }
 
     template <class _Ty>
-    _DEPRECATE_CXX20_REL_OPS _NODISCARD bool operator<=(const _Ty& _Left, const _Ty& _Right) {
+    _CXX20_DEPRECATE_REL_OPS _NODISCARD bool operator<=(const _Ty& _Left, const _Ty& _Right) {
         return !(_Right < _Left);
     }
 
     template <class _Ty>
-    _DEPRECATE_CXX20_REL_OPS _NODISCARD bool operator>=(const _Ty& _Left, const _Ty& _Right) {
+    _CXX20_DEPRECATE_REL_OPS _NODISCARD bool operator>=(const _Ty& _Left, const _Ty& _Right) {
         return !(_Left < _Right);
     }
 } // namespace rel_ops

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -355,7 +355,7 @@ _NODISCARD constexpr pair<_Unrefwrap_t<_Ty1>, _Unrefwrap_t<_Ty2>> make_pair(_Ty1
     return _Mypair(_STD forward<_Ty1>(_Val1), _STD forward<_Ty2>(_Val2));
 }
 
-namespace rel_ops { // nested namespace to hide relational operators from std
+namespace _DEPRECATE_CXX20_REL_OPS rel_ops { // nested namespace to hide relational operators from std
     template <class _Ty>
     _DEPRECATE_CXX20_REL_OPS _NODISCARD bool operator!=(const _Ty& _Left, const _Ty& _Right) {
         return !(_Left == _Right);

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -761,11 +761,11 @@ public:
         using other = allocator<_Other>;
     };
 
-    _NODISCARD _CXX17_DEPRECATE_OLD_ALLOCATOR_MEMBERS _Ty* address(_Ty& _Val) const noexcept {
+    _CXX17_DEPRECATE_OLD_ALLOCATOR_MEMBERS _NODISCARD _Ty* address(_Ty& _Val) const noexcept {
         return _STD addressof(_Val);
     }
 
-    _NODISCARD _CXX17_DEPRECATE_OLD_ALLOCATOR_MEMBERS const _Ty* address(const _Ty& _Val) const noexcept {
+    _CXX17_DEPRECATE_OLD_ALLOCATOR_MEMBERS _NODISCARD const _Ty* address(const _Ty& _Val) const noexcept {
         return _STD addressof(_Val);
     }
 
@@ -784,7 +784,7 @@ public:
         return static_cast<_Ty*>(_Allocate<_New_alignof<_Ty>>(_Get_size_of_n<sizeof(_Ty)>(_Count)));
     }
 
-    _NODISCARD _CXX17_DEPRECATE_OLD_ALLOCATOR_MEMBERS _DECLSPEC_ALLOCATOR _Ty* allocate(
+    _CXX17_DEPRECATE_OLD_ALLOCATOR_MEMBERS _NODISCARD _DECLSPEC_ALLOCATOR _Ty* allocate(
         _CRT_GUARDOVERFLOW const size_t _Count, const void*) {
         return allocate(_Count);
     }
@@ -799,7 +799,7 @@ public:
         _Ptr->~_Uty();
     }
 
-    _NODISCARD _CXX17_DEPRECATE_OLD_ALLOCATOR_MEMBERS size_t max_size() const noexcept {
+    _CXX17_DEPRECATE_OLD_ALLOCATOR_MEMBERS _NODISCARD size_t max_size() const noexcept {
         return static_cast<size_t>(-1) / sizeof(_Ty);
     }
 };
@@ -1910,7 +1910,7 @@ _NoThrowFwdIt _Uninitialized_value_construct_n_unchecked1(_NoThrowFwdIt _UFirst,
 
 // FUNCTION TEMPLATE get_temporary_buffer
 template <class _Ty>
-_NODISCARD _CXX17_DEPRECATE_TEMPORARY_BUFFER pair<_Ty*, ptrdiff_t> get_temporary_buffer(ptrdiff_t _Count) noexcept {
+_CXX17_DEPRECATE_TEMPORARY_BUFFER _NODISCARD pair<_Ty*, ptrdiff_t> get_temporary_buffer(ptrdiff_t _Count) noexcept {
     return _Get_temporary_buffer<_Ty>(_Count);
 }
 

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -866,7 +866,19 @@
 #define _DEPRECATE_EXPERIMENTAL_ERASE
 #endif // ^^^ warning disabled ^^^
 
-// next warning number: STL4027
+// P0768R1 [depr.relops]
+#if _HAS_CXX20 && !defined(_SILENCE_CXX20_REL_OPS_DEPRECATION_WARNING) \
+    && !defined(_SILENCE_ALL_CXX20_DEPRECATION_WARNINGS)
+#define _DEPRECATE_CXX20_REL_OPS                                                              \
+    [[deprecated("warning STL4027: "                                                          \
+                 "std::rel_ops is deprecated in C++20. It has been superseded by <compare>. " \
+                 "You can define _SILENCE_CXX20_REL_OPS_DEPRECATION_WARNING or "              \
+                 "_SILENCE_ALL_CXX20_DEPRECATION_WARNINGS to acknowledge that you have received this warning.")]]
+#else // ^^^ warning enabled / warning disabled vvv
+#define _DEPRECATE_CXX20_REL_OPS
+#endif // ^^^ warning disabled ^^^
+
+// next warning number: STL4028
 
 
 // LIBRARY FEATURE-TEST MACROS

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -869,13 +869,14 @@
 // P0768R1 [depr.relops]
 #if _HAS_CXX20 && !defined(_SILENCE_CXX20_REL_OPS_DEPRECATION_WARNING) \
     && !defined(_SILENCE_ALL_CXX20_DEPRECATION_WARNINGS)
-#define _DEPRECATE_CXX20_REL_OPS                                                              \
-    [[deprecated("warning STL4027: "                                                          \
-                 "std::rel_ops is deprecated in C++20. It has been superseded by <compare>. " \
-                 "You can define _SILENCE_CXX20_REL_OPS_DEPRECATION_WARNING or "              \
+#define _CXX20_DEPRECATE_REL_OPS                                                                \
+    [[deprecated("warning STL4027: "                                                            \
+                 "The namespace std::rel_ops and its contents are deprecated in C++20. "        \
+                 "Their use has been superseded by <compare> in conjunction with operator<=>. " \
+                 "You can define _SILENCE_CXX20_REL_OPS_DEPRECATION_WARNING or "                \
                  "_SILENCE_ALL_CXX20_DEPRECATION_WARNINGS to acknowledge that you have received this warning.")]]
 #else // ^^^ warning enabled / warning disabled vvv
-#define _DEPRECATE_CXX20_REL_OPS
+#define _CXX20_DEPRECATE_REL_OPS
 #endif // ^^^ warning disabled ^^^
 
 // next warning number: STL4028

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -869,11 +869,11 @@
 // P0768R1 [depr.relops]
 #if _HAS_CXX20 && !defined(_SILENCE_CXX20_REL_OPS_DEPRECATION_WARNING) \
     && !defined(_SILENCE_ALL_CXX20_DEPRECATION_WARNINGS)
-#define _CXX20_DEPRECATE_REL_OPS                                                                \
-    [[deprecated("warning STL4027: "                                                            \
-                 "The namespace std::rel_ops and its contents are deprecated in C++20. "        \
-                 "Their use has been superseded by <compare> in conjunction with operator<=>. " \
-                 "You can define _SILENCE_CXX20_REL_OPS_DEPRECATION_WARNING or "                \
+#define _CXX20_DEPRECATE_REL_OPS                                                                                      \
+    [[deprecated("warning STL4027: "                                                                                  \
+                 "The namespace std::rel_ops and its contents are deprecated in C++20. "                              \
+                 "Their use is superseded by C++20's <=> operator and automatic rewrites of relational expressions. " \
+                 "You can define _SILENCE_CXX20_REL_OPS_DEPRECATION_WARNING or "                                      \
                  "_SILENCE_ALL_CXX20_DEPRECATION_WARNINGS to acknowledge that you have received this warning.")]]
 #else // ^^^ warning enabled / warning disabled vvv
 #define _CXX20_DEPRECATE_REL_OPS

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -37,7 +37,7 @@ language.support\support.exception\except.nested\rethrow_if_nested.pass.cpp
 # Testing nonstandard behavior
 utilities\template.bitset\bitset.cons\string_ctor.pass.cpp
 
-# This test has undefined behavior under N4853 [basic.start.term]/6
+# This test has undefined behavior under N4842 [basic.start.term]/6
 thread\futures\futures.task\futures.task.members\dtor.pass.cpp
 
 

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -37,6 +37,9 @@ language.support\support.exception\except.nested\rethrow_if_nested.pass.cpp
 # Testing nonstandard behavior
 utilities\template.bitset\bitset.cons\string_ctor.pass.cpp
 
+# This test has undefined behavior under N4853 [basic.start.term]/6
+thread\futures\futures.task\futures.task.members\dtor.pass.cpp
+
 
 # *** INTERACTIONS WITH CONTEST / C1XX THAT UPSTREAM LIKELY WON'T FIX ***
 # Tracked by VSO-593630 "<filesystem> Enable libcxx filesystem tests"


### PR DESCRIPTION
# Description

Just another check box to tick for #64

Perhaps "the std::rel_ops operators are deprecated..." is better?

# Checklist

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [x] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
