### PR TITLE
Implement LWG-3356

### DIFF
--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -992,9 +992,9 @@
 #define __cpp_lib_is_constant_evaluated 201811L
 #endif // TRANSITION, VS 2019 16.5 Preview 2
 
+#define __cpp_lib_is_nothrow_convertible  201806L
 #define __cpp_lib_list_remove_return_type 201806L
 #define __cpp_lib_math_constants          201907L
-#define __cpp_lib_nothrow_convertible     201806L
 #define __cpp_lib_remove_cvref            201711L
 #define __cpp_lib_shift                   201806L
 #define __cpp_lib_ssize                   201902L


### PR DESCRIPTION
# Description

LWG-3356 renames the feature-test macro `__cpp_lib_nothrow_convertible` to `__cpp_lib_is_nothrow_convertible`. We *just* added this feature-test macro which hasn't yet shipped, and therefore want to rename it quickly - ideally before customers notice it exists. LWG has tentatively approved this issue resolution.

[This is a replay of internal MSVC-PR-219107.]

# Checklist

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [X] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [X] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [X] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [X] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
