### PR TITLE
system_error: Map errc::broken_pipe to ERROR_BROKEN_PIPE.

### DIFF
--- a/stl/src/syserror.cpp
+++ b/stl/src/syserror.cpp
@@ -20,6 +20,7 @@ static const _Win_errtab_t _Win_errtab[] = {
     {ERROR_ACCESS_DENIED, errc::permission_denied},
     {ERROR_ALREADY_EXISTS, errc::file_exists},
     {ERROR_BAD_UNIT, errc::no_such_device},
+    {ERROR_BROKEN_PIPE, errc::broken_pipe},
     {ERROR_BUFFER_OVERFLOW, errc::filename_too_long},
     {ERROR_BUSY, errc::device_or_resource_busy},
     {ERROR_BUSY_DRIVE, errc::device_or_resource_busy},


### PR DESCRIPTION
# Description

I noticed `std::error_code(ERROR_BROKEN_PIPE, std::system_category()) == std::errc::broken_pipe` didn't work so I checked the source and found there isn't a mapping for it. This PR adds the missing mapping.

# Checklist

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [x] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
