### PR TITLE
Fix std::filesystem::remove on ReFS targets

### DIFF
--- a/stl/src/filesystem.cpp
+++ b/stl/src/filesystem.cpp
@@ -660,7 +660,7 @@ __std_win_error __stdcall __std_fs_get_file_id(__std_fs_file_id* const _Id, cons
     switch (_Last_error) {
     case __std_win_error::_Invalid_parameter: // Older Windows versions
     case __std_win_error::_Invalid_function: // Windows 10 1607
-    case __std_win_error::_Not_supported: // Current Windows versions on ReFS (DevCom-857535)
+    case __std_win_error::_Not_supported: // POSIX delete not supported by the file system (e.g. DevCom-857535)
         break; // try non-POSIX delete below
     default:
         return {false, _Last_error};

--- a/stl/src/filesystem.cpp
+++ b/stl/src/filesystem.cpp
@@ -658,12 +658,12 @@ __std_win_error __stdcall __std_fs_get_file_id(__std_fs_file_id* const _Id, cons
 
     _Last_error = __std_win_error{GetLastError()};
     switch (_Last_error) {
-        case __std_win_error::_Invalid_parameter: // Older Windows versions
-        case __std_win_error::_Invalid_function: // Windows 10 1607
-        case __std_win_error::_Not_supported: // Current Windows versions on ReFS (DevCom-857535)
-            break; // try non-POSIX delete below
-        default:
-            return {false, _Last_error};
+    case __std_win_error::_Invalid_parameter: // Older Windows versions
+    case __std_win_error::_Invalid_function: // Windows 10 1607
+    case __std_win_error::_Not_supported: // Current Windows versions on ReFS (DevCom-857535)
+        break; // try non-POSIX delete below
+    default:
+        return {false, _Last_error};
     }
 
     FILE_DISPOSITION_INFO _Info{/* .Delete= */ TRUE};

--- a/stl/src/filesystem.cpp
+++ b/stl/src/filesystem.cpp
@@ -657,11 +657,15 @@ __std_win_error __stdcall __std_fs_get_file_id(__std_fs_file_id* const _Id, cons
     }
 
     _Last_error = __std_win_error{GetLastError()};
-    if (_Last_error != __std_win_error::_Invalid_parameter && _Last_error != __std_win_error::_Invalid_function) {
-        return {false, _Last_error};
+    switch (_Last_error) {
+        case __std_win_error::_Invalid_parameter: // Older Windows versions
+        case __std_win_error::_Invalid_function: // Windows 10 1607
+        case __std_win_error::_Not_supported: // Current Windows versions on ReFS (DevCom-857535)
+            break; // try non-POSIX delete below
+        default:
+            return {false, _Last_error};
     }
 
-    // Filesystem without POSIX delete support, or older than Windows 10 RS1 version without such support:
     FILE_DISPOSITION_INFO _Info{/* .Delete= */ TRUE};
     if (_SetFileInformationByHandle(_Handle._Get(), FileDispositionInfo, &_Info, sizeof(_Info))) {
         return {true, __std_win_error::_Success};

--- a/stl/src/filesystem.cpp
+++ b/stl/src/filesystem.cpp
@@ -660,7 +660,7 @@ __std_win_error __stdcall __std_fs_get_file_id(__std_fs_file_id* const _Id, cons
     switch (_Last_error) {
     case __std_win_error::_Invalid_parameter: // Older Windows versions
     case __std_win_error::_Invalid_function: // Windows 10 1607
-    case __std_win_error::_Not_supported: // POSIX delete not supported by the file system (e.g. DevCom-857535)
+    case __std_win_error::_Not_supported: // POSIX delete not supported by the file system
         break; // try non-POSIX delete below
     default:
         return {false, _Last_error};


### PR DESCRIPTION
Fix std::filesystem::remove on ReFS targets by falling back to standard delete on ERROR_NOT_SUPPORTED.

Resolves DevCom-857535.

# Checklist

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [x] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
