### PR TITLE
Remove workarounds for VSO-895622

### DIFF
--- a/stl/inc/concepts
+++ b/stl/inc/concepts
@@ -131,10 +131,6 @@ concept _Has_class_or_enum_type = __is_class(remove_reference_t<_Ty>) || __is_en
 // CUSTOMIZATION POINT OBJECT ranges::swap
 namespace ranges {
     namespace _Swap {
-#ifndef __clang__ // TRANSITION, VSO-895622
-        void swap();
-#endif // TRANSITION
-
         template <class _Ty>
         void swap(_Ty&, _Ty&) = delete;
 

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -833,10 +833,6 @@ concept indirectly_movable_storable = indirectly_movable<_In, _Out> && writable<
 // CUSTOMIZATION POINT OBJECT iter_swap
 namespace ranges {
     namespace _Iter_swap {
-#ifndef __clang__ // TRANSITION, VSO-895622
-        void iter_swap();
-#endif // TRANSITION, VSO-895622
-
         template <class _Ty1, class _Ty2>
         void iter_swap(_Ty1, _Ty2) = delete;
 
@@ -2081,10 +2077,6 @@ namespace ranges {
 
     // CUSTOMIZATION POINT OBJECT ranges::begin
     namespace _Begin {
-#ifndef __clang__ // TRANSITION, VSO-895622
-        void begin();
-#endif // TRANSITION, VSO-895622
-
         template <class _Ty>
         void begin(_Ty&&) = delete;
         template <class _Ty>
@@ -2147,10 +2139,6 @@ namespace ranges {
 
     // CUSTOMIZATION POINT OBJECT ranges::end
     namespace _End {
-#ifndef __clang__ // TRANSITION, VSO-895622
-        void end();
-#endif // TRANSITION, VSO-895622
-
         template <class _Ty>
         void end(_Ty&&) = delete;
         template <class _Ty>
@@ -2282,10 +2270,6 @@ namespace ranges {
 
     // CUSTOMIZATION POINT OBJECT ranges::rbegin
     namespace _Rbegin {
-#ifndef __clang__ // TRANSITION, VSO-895622
-        void rbegin();
-#endif // TRANSITION, VSO-895622
-
         template <class _Ty>
         void rbegin(_Ty&&) = delete;
         template <class _Ty>
@@ -2355,10 +2339,6 @@ namespace ranges {
 
     // CUSTOMIZATION POINT OBJECT ranges::rend
     namespace _Rend {
-#ifndef __clang__ // TRANSITION, VSO-895622
-        void rend();
-#endif // TRANSITION, VSO-895622
-
         template <class _Ty>
         void rend(_Ty&&) = delete;
         template <class _Ty>
@@ -2464,10 +2444,6 @@ namespace ranges {
 
     // CUSTOMIZATION POINT OBJECT ranges::size
     namespace _Size {
-#ifndef __clang__ // TRANSITION, VSO-895622
-        void size();
-#endif // TRANSITION, VSO-895622
-
         template <class _Ty>
         void size(_Ty&&) = delete;
 


### PR DESCRIPTION
# Description

This bug is triggered when unqualified name lookup for `f` in `f(x)` finds only deleted function (template)s at template definition time, resulting in MSVC refusing to perform argument dependent lookup at template instantiation time. Unsurprisingly, all of the C++20 CPOs required workarounds.

[This is a dual of the internal MSVC-PR-221621.]

# Checklist

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [X] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [ ] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [X] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [X] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
