### PR TITLE
<semaphore> Implement semaphore - WIP

### DIFF
--- a/stl/CMakeLists.txt
+++ b/stl/CMakeLists.txt
@@ -169,6 +169,7 @@ set(HEADERS
     ${CMAKE_CURRENT_LIST_DIR}/inc/ratio
     ${CMAKE_CURRENT_LIST_DIR}/inc/regex
     ${CMAKE_CURRENT_LIST_DIR}/inc/scoped_allocator
+    ${CMAKE_CURRENT_LIST_DIR}/inc/semaphore
     ${CMAKE_CURRENT_LIST_DIR}/inc/set
     ${CMAKE_CURRENT_LIST_DIR}/inc/shared_mutex
     ${CMAKE_CURRENT_LIST_DIR}/inc/sstream

--- a/stl/inc/semaphore
+++ b/stl/inc/semaphore
@@ -51,8 +51,9 @@ public:
         }
     }
     bool try_acquire() noexcept {
-        if (__counter.load(memory_order_acquire) > 0) {
-            __counter--;
+        ptrdiff_t __old     = __counter.load(memory_order_acquire);
+        ptrdiff_t __desired = __old - 1;
+        if (__old > 0 && __counter.compare_exchange_strong(__old, __desired, memory_order_acquire)) {
             return true;
         }
         return false;

--- a/stl/inc/semaphore
+++ b/stl/inc/semaphore
@@ -34,7 +34,8 @@ public:
         return _LeastMaxValue;
     }
     constexpr explicit counting_semaphore(ptrdiff_t _Desired) {
-        _STL_ASSERT(_Desired >= 0 && _Desired <= max(), "Desired value for the semaphore falls outside of semaphore range");
+        _STL_ASSERT(
+            _Desired >= 0 && _Desired <= max(), "Desired value for the semaphore falls outside of semaphore range");
         atomic_init(&_Counter, _Desired);
     }
     ~counting_semaphore()                         = default;

--- a/stl/inc/semaphore
+++ b/stl/inc/semaphore
@@ -33,39 +33,38 @@ public:
         // _LeastMaxValue is used here so that things such as binary_semaphore are
         return _LeastMaxValue;
     }
-    constexpr explicit counting_semaphore(ptrdiff_t __desired) {
-        assert(__desired >= 0 && __desired <= max());
-        atomic_init(&__counter, __desired);
+    constexpr explicit counting_semaphore(ptrdiff_t _Desired) {
+        _STL_ASSERT(_Desired >= 0 && _Desired <= max(), "Desired value for the semaphore falls outside of semaphore range");
+        atomic_init(&_Counter, _Desired);
     }
     ~counting_semaphore()                         = default;
     counting_semaphore(const counting_semaphore&) = delete;
     counting_semaphore& operator=(const counting_semaphore&) = delete;
 
-    void release(ptrdiff_t __update = 1) {
-        assert(__update >= 0 && __update <= (max() - __counter.load())
-               && "You have released this semaphore more times than you have acquired");
-        __counter.fetch_add(__update, memory_order_release);
+    void release(ptrdiff_t _Update = 1) {
+        _STL_ASSERT(_Update >= 0 && _Update <= (max() - _Counter.load()), "The semaphore has been released more times than acquired");
+        _Counter.fetch_add(_Update, memory_order_release);
     }
     void acquire() {
         while (!try_acquire()) {
         }
     }
     bool try_acquire() noexcept {
-        ptrdiff_t __old     = __counter.load(memory_order_acquire);
-        ptrdiff_t __desired = __old - 1;
-        if (__old > 0 && __counter.compare_exchange_strong(__old, __desired, memory_order_acquire)) {
+        ptrdiff_t _Old     = _Counter.load(memory_order_acquire);
+        ptrdiff_t _Desired = _Old - 1;
+        if (_Old > 0 && _Counter.compare_exchange_strong(_Old, _Desired, memory_order_acquire)) {
             return true;
         }
         return false;
     }
     template <class _Rep, class _Period>
-    bool try_acquire_for(const chrono::duration<_Rep, _Period>& __rel_time) {
-        return try_acquire_until(chrono::steady_clock::now() + __rel_time);
+    bool try_acquire_for(const chrono::duration<_Rep, _Period>& _Rel_time) {
+        return try_acquire_until(chrono::steady_clock::now() + _Rel_time);
     }
     template <class _Clock, class _Duration>
-    bool try_acquire_until(const chrono::time_point<_Clock, _Duration>& __abs_time) {
+    bool try_acquire_until(const chrono::time_point<_Clock, _Duration>& _Abs_time) {
         while (!try_acquire()) {
-            if (_Clock::now() > __abs_time) {
+            if (_Clock::now() > _Abs_time) {
                 return false;
             }
         }
@@ -73,7 +72,7 @@ public:
     }
 
 private:
-    atomic_ptrdiff_t __counter;
+    atomic_ptrdiff_t _Counter;
 };
 using binary_semaphore = counting_semaphore<1>;
 _STD_END

--- a/stl/inc/semaphore
+++ b/stl/inc/semaphore
@@ -42,17 +42,16 @@ public:
     counting_semaphore& operator=(const counting_semaphore&) = delete;
 
     void release(ptrdiff_t _Update = 1) {
-        _STL_ASSERT(_Update >= 0 && _Update <= (max() - _Counter.load()), "The semaphore has been released more times than acquired");
-        _Counter.fetch_add(_Update, memory_order_release);
+        _Counter.fetch_add(_Update, memory_order::release);
     }
     void acquire() {
         while (!try_acquire()) {
         }
     }
     bool try_acquire() noexcept {
-        ptrdiff_t _Old     = _Counter.load(memory_order_acquire);
+        ptrdiff_t _Old     = _Counter.load(memory_order::acquire);
         ptrdiff_t _Desired = _Old - 1;
-        if (_Old > 0 && _Counter.compare_exchange_strong(_Old, _Desired, memory_order_acquire)) {
+        if (_Old > 0 && _Counter.compare_exchange_strong(_Old, _Desired)) {
             return true;
         }
         return false;
@@ -64,7 +63,7 @@ public:
     template <class _Clock, class _Duration>
     bool try_acquire_until(const chrono::time_point<_Clock, _Duration>& _Abs_time) {
         while (!try_acquire()) {
-            if (_Clock::now() > _Abs_time) {
+            if (_Clock::now() >= _Abs_time) {
                 return false;
             }
         }
@@ -72,7 +71,7 @@ public:
     }
 
 private:
-    atomic_ptrdiff_t _Counter;
+    atomic<ptrdiff_t> _Counter;
 };
 using binary_semaphore = counting_semaphore<1>;
 _STD_END

--- a/stl/inc/semaphore
+++ b/stl/inc/semaphore
@@ -1,0 +1,85 @@
+// semaphore standard header
+
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#pragma once
+
+#ifndef _SEMAPHORE_
+#define _SEMAPHORE_
+#include <yvals_core.h>
+#if _STL_COMPILER_PREPROCESSOR
+
+#if !_HAS_CXX20
+#pragma message("The contents of <semaphore> are available only with C++20 or later.")
+#else // ^^^ !_HAS_CXX20 / _HAS_CXX20 vvv
+#include <atomic>
+#include <cassert>
+#include <chrono>
+#include <cstddef>
+
+#pragma pack(push, _CRT_PACKING)
+#pragma warning(push, _STL_WARNING_LEVEL)
+#pragma warning(disable : _STL_DISABLED_WARNINGS)
+_STL_DISABLE_CLANG_WARNINGS
+#pragma push_macro("new")
+#undef new
+
+_STD_BEGIN
+template <ptrdiff_t _LeastMaxValue = 256>
+class counting_semaphore {
+public:
+    static constexpr ptrdiff_t max() noexcept {
+        // _LeastMaxValue is used here so that things such as binary_semaphore are
+        return _LeastMaxValue;
+    }
+    constexpr explicit counting_semaphore(ptrdiff_t __desired) {
+        assert(__desired >= 0 && __desired <= max());
+        atomic_init(&__counter, __desired);
+    }
+    ~counting_semaphore()                         = default;
+    counting_semaphore(const counting_semaphore&) = delete;
+    counting_semaphore& operator=(const counting_semaphore&) = delete;
+
+    void release(ptrdiff_t __update = 1) {
+        assert(__update >= 0 && __update <= (max() - __counter.load())
+               && "You have released this semaphore more times than you have acquired");
+        __counter.fetch_add(__update, memory_order_release);
+    }
+    void acquire() {
+        while (!try_acquire()) {
+        }
+    }
+    bool try_acquire() noexcept {
+        if (__counter.load(memory_order_acquire) > 0) {
+            __counter--;
+            return true;
+        }
+        return false;
+    }
+    template <class _Rep, class _Period>
+    bool try_acquire_for(const chrono::duration<_Rep, _Period>& __rel_time) {
+        return try_acquire_until(chrono::steady_clock::now() + __rel_time);
+    }
+    template <class _Clock, class _Duration>
+    bool try_acquire_until(const chrono::time_point<_Clock, _Duration>& __abs_time) {
+        while (!try_acquire()) {
+            if (_Clock::now() > __abs_time) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+private:
+    atomic_ptrdiff_t __counter;
+};
+using binary_semaphore = counting_semaphore<1>;
+_STD_END
+#pragma pop_macro("new")
+_STL_RESTORE_CLANG_WARNINGS
+#pragma warning(pop)
+#pragma pack(pop)
+#endif
+#endif
+#endif

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -1025,6 +1025,8 @@
 #define __cpp_lib_constexpr_numeric 201911L
 #endif // __cpp_lib_is_constant_evaluated
 
+#define __cpp_lib_semaphore 201907L
+
 #endif // _HAS_CXX20
 
 // EXPERIMENTAL


### PR DESCRIPTION
# Description

This is an implementation of counting_semaphore and binary_semaphore (See: #52 )

I made a basic implementation of the semaphore header, using an atomic_ptrdiff_t instead of the given ptrdiff_t, my reasoning for this was that the semaphore library currently lists the counting_semaphore as doing atomic operations and the only non-mutex way I could think of doing atomic operations here. I'm definitely willing to change it to be something else if required.

I have also tested this (slightly) on my home computer, but have not really ultra-stress tested it other than bleak fooling around.

A question that I have for the implementation itself: what value should be the ultimate hard-cap for the max function? I currently have it set to just copy the value pushed in from _LeastMaxValue but I know that there is a maximum value out there, so should the function just make sure that the value of _LeastMaxValue is above 0 via static_assert and use that or have some sort of hard-cap (PTRDIFF_MAX?) for this.

# Checklist

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [ ] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [ ] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
