### PR TITLE
<memory>(mostly): Uses-Allocator and guaranteed copy elision For piecewise construction

### DIFF
--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -10,7 +10,6 @@
 #if _STL_COMPILER_PREPROCESSOR
 #include <exception>
 #include <iosfwd>
-#include <tuple>
 #include <type_traits>
 #include <typeinfo>
 #include <xmemory>

--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -10,6 +10,7 @@
 #if _STL_COMPILER_PREPROCESSOR
 #include <exception>
 #include <iosfwd>
+#include <tuple>
 #include <type_traits>
 #include <typeinfo>
 #include <xmemory>

--- a/stl/inc/scoped_allocator
+++ b/stl/inc/scoped_allocator
@@ -236,9 +236,10 @@ public:
     template <class _Ty, class... _Types>
     void construct(_Ty* _Ptr, _Types&&... _Args) { // construct with varying allocator styles
 #if _HAS_CXX20
-        _STD apply([_Ptr, this](auto&&... _New_args) { //
-            _Scoped_outermost_traits<scoped_allocator_adaptor>::construct(
-                _Scoped_outermost(*this), _Ptr, _STD forward<decltype(_New_args)>(_New_args)...);
+        _STD apply(
+            [_Ptr, this](auto&&... _New_args) {
+                _Scoped_outermost_traits<scoped_allocator_adaptor>::construct(
+                    _Scoped_outermost(*this), _Ptr, _STD forward<decltype(_New_args)>(_New_args)...);
             },
             uses_allocator_construction_args<_Ty>(inner_allocator(), _STD forward<_Types>(_Args)...));
 #else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv

--- a/stl/inc/scoped_allocator
+++ b/stl/inc/scoped_allocator
@@ -236,7 +236,11 @@ public:
     template <class _Ty, class... _Types>
     void construct(_Ty* _Ptr, _Types&&... _Args) { // construct with varying allocator styles
 #if _HAS_CXX20
-        _Uses_allocator_construct(_Ptr, _Scoped_outermost(*this), inner_allocator(), _STD forward<_Types>(_Args)...);
+        _STD apply([_Ptr, this](auto&&... _New_args) { //
+            _Scoped_outermost_traits<scoped_allocator_adaptor>::construct(
+                _Scoped_outermost(*this), _Ptr, _STD forward<decltype(_New_args)>(_New_args)...);
+            },
+            uses_allocator_construction_args<_Ty>(inner_allocator(), _STD forward<_Types>(_Args)...));
 #else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
         _Uses_allocator_construct(_Ptr, _Scoped_outermost(*this), inner_allocator(), _STD forward<_Types>(_Args)...);
 #endif

--- a/stl/inc/scoped_allocator
+++ b/stl/inc/scoped_allocator
@@ -235,7 +235,11 @@ public:
 
     template <class _Ty, class... _Types>
     void construct(_Ty* _Ptr, _Types&&... _Args) { // construct with varying allocator styles
+#if _HAS_CXX20
         _Uses_allocator_construct(_Ptr, _Scoped_outermost(*this), inner_allocator(), _STD forward<_Types>(_Args)...);
+#else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
+        _Uses_allocator_construct(_Ptr, _Scoped_outermost(*this), inner_allocator(), _STD forward<_Types>(_Args)...);
+#endif
     }
 
     template <class _Ty>

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -2068,6 +2068,101 @@ void _Erase_nodes_if(_Container& _Cont, _Pr _Pred) { // erase each element satis
         }
     }
 }
+
+#if _HAS_CXX20
+
+template <class>
+struct _Is_pair : false_type {};
+
+template <class _Ty1, class _Ty2>
+struct _Is_pair<pair<_Ty1, _Ty2>> : true_type {};
+
+template <class _Ty, class _Alloc, class... _Types, enable_if_t<!_Is_pair<_Ty>::value, int> = 0>
+auto uses_allocator_construction_args(const _Alloc& _Al, _Types&&... _Args) {
+    if constexpr (!uses_allocator_v<_Ty, _Alloc>) {
+        static_assert(is_constructible_v<_Ty, _Types...>,
+            "uses_allocator_v<_Ty, _Alloc> is false but _Ty is not constructible from _Types...");
+        return _STD forward_as_tuple(_STD forward<_Types>(_Args)...);
+    } else {
+        if constexpr (is_constructible_v<_Ty, allocator_arg_t, _Types...>) {
+            using _Return_type = _STD tuple<allocator_arg_t, const _Alloc&, _Types&&...>;
+            return _ReturnType(allocator_arg, _Al, _STD forward<_Types>(_Args)...);
+        } else if constexpr (is_constructible_v<_Ty, _Types..., _Alloc>) {
+            return _STD forward_as_tuple(_STD forward<_Types>(_Args)..., _Al);
+        } else {
+            static_assert(
+                _Always_false<_Ty>, "uses_allocator_v<_Ty, _Alloc> is true but _Ty is not constructible with _Alloc");
+        }
+    }
+}
+
+template <class _Ty, class _Alloc, class _Tuple1, class _Tuple2, enable_if_t<_Is_pair<_Ty>::value, int> = 0>
+auto uses_allocator_construction_args(const _Alloc& _Al, piecewise_construct_t, _Tuple1&& _Tup1, _Tuple2&& _Tup2) {
+    return _STD make_tuple(piecewise_construct,
+        _STD apply(
+            [&_Al](auto&& _Tuple_args) {
+                return uses_allocator_construction_args<typename _Ty::first_type>(
+                    _Al, _STD forward<decltype(_Tuple_args)>(_Tuple_args)...);
+            },
+            _STD forward<_Tuple1>(_Tup1)),
+        _STD apply(
+            [&_Al](auto&& _Tuple_args) {
+                return uses_allocator_construction_args<typename _Ty::second_type>(
+                    _Al, _STD forward<decltype(_Tuple_args)>(_Tuple_args)...);
+            },
+            _STD forward<_Tuple2>(_Tup2)));
+}
+
+template <class _Ty, class _Alloc, enable_if_t<_Is_pair<_Ty>::value, int> = 0>
+auto uses_allocator_construction_args(const _Alloc& _Al) {
+    // equivalent to
+    // return uses_allocator_construction_args<_Ty>(_Al, piecewise_construct, tuple<>(), tuple<>());
+    return _STD make_tuple(piecewise_construct, uses_allocator_construction_args<typename _Ty::first_type>(_Al),
+        uses_allocator_construction_args<typename _Ty::second_type>(_Al));
+}
+
+template <class _Ty, class _Alloc, class _Uty1, class _Uty2, enable_if_t<_Is_pair<_Ty>::value, int> = 0>
+auto uses_allocator_construction_args(const _Alloc& _Al, _Uty1&& _Val1, _Uty2&& _Val2) {
+    // equivalent to
+    // return uses_allocator_construction_args<_Ty>(_Al, piecewise_construct,
+    //     _STD forward_as_tuple(_STD forward<_Uty1>(_Val1)), _STD forward_as_tuple(_STD forward<_Uty2>(_Val2)));
+    return _STD make_tuple(piecewise_construct,
+        uses_allocator_construction_args<typename _Ty::first_type>(_Al, _STD forward<_Uty1>(_Val1)),
+        uses_allocator_construction_args<typename _Ty::second_type>(_Al, _STD forward<_Uty2>(_Val2)));
+}
+
+template <class _Ty, class _Alloc, class _Uty1, class _Uty2, enable_if_t<_Is_pair<_Ty>::value, int> = 0>
+auto uses_allocator_construction_args(const _Alloc& _Al, const pair<_Uty1, _Uty2>& _Pair) {
+    // equivalent to
+    // return uses_allocator_construction_args<_Ty>(_Al, piecewise_construct,
+    //     _STD forward_as_tuple(pr.first), _STD forward_as_tuple(pr.second));
+    return _STD make_tuple(piecewise_construct,
+        uses_allocator_construction_args<typename _Ty::first_type>(_Al, _Pair.first),
+        uses_allocator_construction_args<typename _Ty::second_type>(_Al, _Pair.second));
+}
+
+template <class _Ty, class _Alloc, class _Uty1, class _Uty2, enable_if_t<_Is_pair<_Ty>::value, int> = 0>
+auto uses_allocator_construction_args(const _Alloc& _Al, pair<_Uty1, _Uty2>&& _Pair) {
+    // equivalent to
+    // return uses_allocator_construction_args<_Ty>(_Al, piecewise_construct,
+    //     _STD forward_as_tuple(_STD move(pr).first), _STD forward_as_tuple(_STD move(pr).second));
+    return _STD make_tuple(piecewise_construct,
+        uses_allocator_construction_args<typename _Ty::first_type>(_Al, _STD move(_Pair).first),
+        uses_allocator_construction_args<typename _Ty::second_type>(_Al, _STD move(_Pair).second));
+}
+
+template <class _Ty, class _Alloc, class... _Types>
+_Ty make_obj_using_allocator(const _Alloc& _Al, _Types&&... _Args) {
+    return _STD make_from_tuple<_Ty>(uses_allocator_construction_args<_Ty>(_Al, _STD forward<_Types>(_Args)...));
+}
+
+template <class _Ty, class _Alloc, class... _Types>
+_Ty* uninitialized_construct_using_allocator(_Ty* _Ptr, const _Alloc& _Al, _Types&&... _Args) {
+    return ::new (static_cast<void*>(_Ptr)) _Ty(make_obj_using_allocator<_Ty>(_Al, _STD forward<_Types>(_Args)...));
+}
+
+#endif // _HAS_CXX20
+
 _STD_END
 
 #pragma pop_macro("new")

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -15,6 +15,10 @@
 #include <xatomic.h>
 #include <xutility>
 
+#if _HAS_CXX20
+#include <tuple>
+#endif // _HAS_CXX20
+
 #pragma pack(push, _CRT_PACKING)
 #pragma warning(push, _STL_WARNING_LEVEL)
 #pragma warning(disable : _STL_DISABLED_WARNINGS)
@@ -2071,58 +2075,62 @@ void _Erase_nodes_if(_Container& _Cont, _Pr _Pred) { // erase each element satis
 
 #if _HAS_CXX20
 
+// VARIABLE TEMPLATE _Is_pair_v
 template <class>
-struct _Is_pair : false_type {};
+inline constexpr bool _Is_pair_v = false;
 
 template <class _Ty1, class _Ty2>
-struct _Is_pair<pair<_Ty1, _Ty2>> : true_type {};
+inline constexpr bool _Is_pair_v<pair<_Ty1, _Ty2>> = true;
 
-template <class _Ty, class _Alloc, class... _Types, enable_if_t<!_Is_pair<_Ty>::value, int> = 0>
-auto uses_allocator_construction_args(const _Alloc& _Al, _Types&&... _Args) {
+template <class _Ty, class _Alloc, class... _Types, enable_if_t<!_Is_pair_v<_Ty>, int> = 0>
+constexpr auto uses_allocator_construction_args(const _Alloc& _Al, _Types&&... _Args) noexcept {
     if constexpr (!uses_allocator_v<_Ty, _Alloc>) {
         static_assert(is_constructible_v<_Ty, _Types...>,
-            "uses_allocator_v<_Ty, _Alloc> is false but _Ty is not constructible from _Types...");
+            "T must be constructible from Types... if uses_allocator_v<T, Alloc> is false");
+        (void) _Al;
         return _STD forward_as_tuple(_STD forward<_Types>(_Args)...);
     } else {
-        if constexpr (is_constructible_v<_Ty, allocator_arg_t, _Types...>) {
-            using _Return_type = _STD tuple<allocator_arg_t, const _Alloc&, _Types&&...>;
+        if constexpr (is_constructible_v<_Ty, allocator_arg_t, const _Alloc&, _Types...>) {
+            using _Return_type = tuple<allocator_arg_t, const _Alloc&, _Types&&...>;
             return _ReturnType(allocator_arg, _Al, _STD forward<_Types>(_Args)...);
-        } else if constexpr (is_constructible_v<_Ty, _Types..., _Alloc>) {
+        } else if constexpr (is_constructible_v<_Ty, _Types..., const _Alloc&>) {
             return _STD forward_as_tuple(_STD forward<_Types>(_Args)..., _Al);
         } else {
-            static_assert(
-                _Always_false<_Ty>, "uses_allocator_v<_Ty, _Alloc> is true but _Ty is not constructible with _Alloc");
+            static_assert(_Always_false<_Ty>,
+                "T must be constructible from either (allocator_arg_t, const Alloc&, Types...)"
+                "or (Types..., const Alloc&) if uses_allocator_v<T, Alloc> is true");
         }
     }
 }
 
-template <class _Ty, class _Alloc, class _Tuple1, class _Tuple2, enable_if_t<_Is_pair<_Ty>::value, int> = 0>
-auto uses_allocator_construction_args(const _Alloc& _Al, piecewise_construct_t, _Tuple1&& _Tup1, _Tuple2&& _Tup2) {
+template <class _Ty, class _Alloc, class _Tuple1, class _Tuple2, enable_if_t<_Is_pair_v<_Ty>, int> = 0>
+constexpr auto uses_allocator_construction_args(
+    const _Alloc& _Al, piecewise_construct_t, _Tuple1&& _Tup1, _Tuple2&& _Tup2) noexcept {
     return _STD make_tuple(piecewise_construct,
         _STD apply(
-            [&_Al](auto&& _Tuple_args) {
+            [&_Al](auto&&... _Tuple_args) {
                 return uses_allocator_construction_args<typename _Ty::first_type>(
                     _Al, _STD forward<decltype(_Tuple_args)>(_Tuple_args)...);
             },
             _STD forward<_Tuple1>(_Tup1)),
         _STD apply(
-            [&_Al](auto&& _Tuple_args) {
+            [&_Al](auto&&... _Tuple_args) {
                 return uses_allocator_construction_args<typename _Ty::second_type>(
                     _Al, _STD forward<decltype(_Tuple_args)>(_Tuple_args)...);
             },
             _STD forward<_Tuple2>(_Tup2)));
 }
 
-template <class _Ty, class _Alloc, enable_if_t<_Is_pair<_Ty>::value, int> = 0>
-auto uses_allocator_construction_args(const _Alloc& _Al) {
+template <class _Ty, class _Alloc, enable_if_t<_Is_pair_v<_Ty>, int> = 0>
+constexpr auto uses_allocator_construction_args(const _Alloc& _Al) noexcept {
     // equivalent to
     // return uses_allocator_construction_args<_Ty>(_Al, piecewise_construct, tuple<>(), tuple<>());
     return _STD make_tuple(piecewise_construct, uses_allocator_construction_args<typename _Ty::first_type>(_Al),
         uses_allocator_construction_args<typename _Ty::second_type>(_Al));
 }
 
-template <class _Ty, class _Alloc, class _Uty1, class _Uty2, enable_if_t<_Is_pair<_Ty>::value, int> = 0>
-auto uses_allocator_construction_args(const _Alloc& _Al, _Uty1&& _Val1, _Uty2&& _Val2) {
+template <class _Ty, class _Alloc, class _Uty1, class _Uty2, enable_if_t<_Is_pair_v<_Ty>, int> = 0>
+constexpr auto uses_allocator_construction_args(const _Alloc& _Al, _Uty1&& _Val1, _Uty2&& _Val2) noexcept {
     // equivalent to
     // return uses_allocator_construction_args<_Ty>(_Al, piecewise_construct,
     //     _STD forward_as_tuple(_STD forward<_Uty1>(_Val1)), _STD forward_as_tuple(_STD forward<_Uty2>(_Val2)));
@@ -2131,8 +2139,8 @@ auto uses_allocator_construction_args(const _Alloc& _Al, _Uty1&& _Val1, _Uty2&& 
         uses_allocator_construction_args<typename _Ty::second_type>(_Al, _STD forward<_Uty2>(_Val2)));
 }
 
-template <class _Ty, class _Alloc, class _Uty1, class _Uty2, enable_if_t<_Is_pair<_Ty>::value, int> = 0>
-auto uses_allocator_construction_args(const _Alloc& _Al, const pair<_Uty1, _Uty2>& _Pair) {
+template <class _Ty, class _Alloc, class _Uty1, class _Uty2, enable_if_t<_Is_pair_v<_Ty>, int> = 0>
+constexpr auto uses_allocator_construction_args(const _Alloc& _Al, const pair<_Uty1, _Uty2>& _Pair) noexcept {
     // equivalent to
     // return uses_allocator_construction_args<_Ty>(_Al, piecewise_construct,
     //     _STD forward_as_tuple(pr.first), _STD forward_as_tuple(pr.second));
@@ -2141,8 +2149,8 @@ auto uses_allocator_construction_args(const _Alloc& _Al, const pair<_Uty1, _Uty2
         uses_allocator_construction_args<typename _Ty::second_type>(_Al, _Pair.second));
 }
 
-template <class _Ty, class _Alloc, class _Uty1, class _Uty2, enable_if_t<_Is_pair<_Ty>::value, int> = 0>
-auto uses_allocator_construction_args(const _Alloc& _Al, pair<_Uty1, _Uty2>&& _Pair) {
+template <class _Ty, class _Alloc, class _Uty1, class _Uty2, enable_if_t<_Is_pair_v<_Ty>, int> = 0>
+constexpr auto uses_allocator_construction_args(const _Alloc& _Al, pair<_Uty1, _Uty2>&& _Pair) noexcept {
     // equivalent to
     // return uses_allocator_construction_args<_Ty>(_Al, piecewise_construct,
     //     _STD forward_as_tuple(_STD move(pr).first), _STD forward_as_tuple(_STD move(pr).second));
@@ -2152,12 +2160,12 @@ auto uses_allocator_construction_args(const _Alloc& _Al, pair<_Uty1, _Uty2>&& _P
 }
 
 template <class _Ty, class _Alloc, class... _Types>
-_Ty make_obj_using_allocator(const _Alloc& _Al, _Types&&... _Args) {
+constexpr _Ty make_obj_using_allocator(const _Alloc& _Al, _Types&&... _Args) {
     return _STD make_from_tuple<_Ty>(uses_allocator_construction_args<_Ty>(_Al, _STD forward<_Types>(_Args)...));
 }
 
 template <class _Ty, class _Alloc, class... _Types>
-_Ty* uninitialized_construct_using_allocator(_Ty* _Ptr, const _Alloc& _Al, _Types&&... _Args) {
+constexpr _Ty* uninitialized_construct_using_allocator(_Ty* _Ptr, const _Alloc& _Al, _Types&&... _Args) {
     return ::new (static_cast<void*>(_Ptr)) _Ty(make_obj_using_allocator<_Ty>(_Al, _STD forward<_Types>(_Args)...));
 }
 

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -2075,14 +2075,7 @@ void _Erase_nodes_if(_Container& _Cont, _Pr _Pred) { // erase each element satis
 
 #if _HAS_CXX20
 
-// VARIABLE TEMPLATE _Is_pair_v
-template <class>
-inline constexpr bool _Is_pair_v = false;
-
-template <class _Ty1, class _Ty2>
-inline constexpr bool _Is_pair_v<pair<_Ty1, _Ty2>> = true;
-
-template <class _Ty, class _Alloc, class... _Types, enable_if_t<!_Is_pair_v<_Ty>, int> = 0>
+template <class _Ty, class _Alloc, class... _Types, enable_if_t<!_Is_specialization_v<_Ty, pair>, int> = 0>
 constexpr auto uses_allocator_construction_args(const _Alloc& _Al, _Types&&... _Args) noexcept {
     if constexpr (!uses_allocator_v<_Ty, _Alloc>) {
         static_assert(is_constructible_v<_Ty, _Types...>,
@@ -2103,7 +2096,7 @@ constexpr auto uses_allocator_construction_args(const _Alloc& _Al, _Types&&... _
     }
 }
 
-template <class _Ty, class _Alloc, class _Tuple1, class _Tuple2, enable_if_t<_Is_pair_v<_Ty>, int> = 0>
+template <class _Ty, class _Alloc, class _Tuple1, class _Tuple2, enable_if_t<_Is_specialization_v<_Ty, pair>, int> = 0>
 constexpr auto uses_allocator_construction_args(
     const _Alloc& _Al, piecewise_construct_t, _Tuple1&& _Tup1, _Tuple2&& _Tup2) noexcept {
     return _STD make_tuple(piecewise_construct,
@@ -2121,7 +2114,7 @@ constexpr auto uses_allocator_construction_args(
             _STD forward<_Tuple2>(_Tup2)));
 }
 
-template <class _Ty, class _Alloc, enable_if_t<_Is_pair_v<_Ty>, int> = 0>
+template <class _Ty, class _Alloc, enable_if_t<_Is_specialization_v<_Ty, pair>, int> = 0>
 constexpr auto uses_allocator_construction_args(const _Alloc& _Al) noexcept {
     // equivalent to
     // return uses_allocator_construction_args<_Ty>(_Al, piecewise_construct, tuple<>(), tuple<>());
@@ -2129,7 +2122,7 @@ constexpr auto uses_allocator_construction_args(const _Alloc& _Al) noexcept {
         uses_allocator_construction_args<typename _Ty::second_type>(_Al));
 }
 
-template <class _Ty, class _Alloc, class _Uty1, class _Uty2, enable_if_t<_Is_pair_v<_Ty>, int> = 0>
+template <class _Ty, class _Alloc, class _Uty1, class _Uty2, enable_if_t<_Is_specialization_v<_Ty, pair>, int> = 0>
 constexpr auto uses_allocator_construction_args(const _Alloc& _Al, _Uty1&& _Val1, _Uty2&& _Val2) noexcept {
     // equivalent to
     // return uses_allocator_construction_args<_Ty>(_Al, piecewise_construct,
@@ -2139,7 +2132,7 @@ constexpr auto uses_allocator_construction_args(const _Alloc& _Al, _Uty1&& _Val1
         uses_allocator_construction_args<typename _Ty::second_type>(_Al, _STD forward<_Uty2>(_Val2)));
 }
 
-template <class _Ty, class _Alloc, class _Uty1, class _Uty2, enable_if_t<_Is_pair_v<_Ty>, int> = 0>
+template <class _Ty, class _Alloc, class _Uty1, class _Uty2, enable_if_t<_Is_specialization_v<_Ty, pair>, int> = 0>
 constexpr auto uses_allocator_construction_args(const _Alloc& _Al, const pair<_Uty1, _Uty2>& _Pair) noexcept {
     // equivalent to
     // return uses_allocator_construction_args<_Ty>(_Al, piecewise_construct,
@@ -2149,7 +2142,7 @@ constexpr auto uses_allocator_construction_args(const _Alloc& _Al, const pair<_U
         uses_allocator_construction_args<typename _Ty::second_type>(_Al, _Pair.second));
 }
 
-template <class _Ty, class _Alloc, class _Uty1, class _Uty2, enable_if_t<_Is_pair_v<_Ty>, int> = 0>
+template <class _Ty, class _Alloc, class _Uty1, class _Uty2, enable_if_t<_Is_specialization_v<_Ty, pair>, int> = 0>
 constexpr auto uses_allocator_construction_args(const _Alloc& _Al, pair<_Uty1, _Uty2>&& _Pair) noexcept {
     // equivalent to
     // return uses_allocator_construction_args<_Ty>(_Al, piecewise_construct,

--- a/stl/inc/xpolymorphic_allocator.h
+++ b/stl/inc/xpolymorphic_allocator.h
@@ -67,6 +67,8 @@ void _Uses_allocator_construct(_Ty* const _Ptr, _Outer_alloc& _Outer, _Inner_all
         _STD forward<_Types>(_Args)...); // TRANSITION, if constexpr
 }
 
+#if !_HAS_CXX20
+
 template <class _Alloc, class... _Types>
 auto _Uses_allocator_piecewise2(true_type, _Alloc& _Al, tuple<_Types...>&& _Tuple) {
     return _STD tuple_cat(tuple<allocator_arg_t, _Alloc&>(allocator_arg, _Al), _STD move(_Tuple));
@@ -133,6 +135,8 @@ void _Uses_allocator_construct(
     _Uses_allocator_construct_pair(_Ptr, _Outer, _Inner, _STD forward_as_tuple(_STD forward<_Uty>(_Pair.first)),
         _STD forward_as_tuple(_STD forward<_Vty>(_Pair.second)));
 }
+
+#endif // !_HAS_CXX20
 
 #if _HAS_CXX17
 namespace pmr {

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -57,6 +57,7 @@
 // P0941R2 Feature-Test Macros
 // P0972R0 noexcept For <chrono> zero(), min(), max()
 // P1164R1 Making create_directory() Intuitive
+// P1165R1 Consistently Propagating Stateful Allocators In basic_string's operator+()
 // P1902R1 Missing Feature-Test Macros 2017-2019
 
 // _HAS_CXX17 directly controls:

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -57,7 +57,6 @@
 // P0941R2 Feature-Test Macros
 // P0972R0 noexcept For <chrono> zero(), min(), max()
 // P1164R1 Making create_directory() Intuitive
-// P1165R1 Consistently Propagating Stateful Allocators In basic_string's operator+()
 // P1902R1 Missing Feature-Test Macros 2017-2019
 
 // _HAS_CXX17 directly controls:
@@ -136,6 +135,7 @@
 // P0457R2 starts_with()/ends_with() For basic_string/basic_string_view
 // P0458R2 contains() For Ordered And Unordered Associative Containers
 // P0463R1 endian
+// P0475R1 Guaranteed Copy Elision For Piecewise Construction
 // P0482R6 Library Support For char8_t
 //     (mbrtoc8 and c8rtomb not yet implemented)
 // P0487R1 Fixing operator>>(basic_istream&, CharT*)
@@ -143,6 +143,7 @@
 // P0553R4 <bit> Rotating And Counting Functions
 // P0556R3 <bit> ispow2(), ceil2(), floor2(), log2p1()
 //            (log2p1() is called bit_length() as of D1956)
+// P0591R4 Utility Functions For Uses-Allocator Construction
 // P0595R2 is_constant_evaluated()
 // P0616R0 Using move() In <numeric>
 // P0631R8 <numbers> Math Constants


### PR DESCRIPTION
# Description

Resolves #19 and resolves #20. I mostly copied standard quotes, unrolled some function calls and _Uglified. Now I wonder if it is possible to merge some code between `uses_allocator_construction_args` and `_Uses_allocator_construct` (from `xpolymorphic_allocator.h`), their purpose is same it seems.

# Checklist

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [ ] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [ ] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
