### PR TITLE
Optimize the is_permutation family and _Hash::operator== for multicontainers

### DIFF
--- a/stl/inc/xhash
+++ b/stl/inc/xhash
@@ -1941,57 +1941,10 @@ protected:
             }
         }
 
+        _Unchecked_const_iterator _Left_stop_at;
         if
             _CONSTEXPR_IF(_Traits::_Standard) {
-                // trim matching prefixes
-                while (*_First1 == *_First2) {
-                    // the right equal_range ends at the end of the bucket or on the first nonequal element
-                    bool _Right_range_end = _First2 == _Bucket_hi;
-                    ++_First2;
-                    if (!_Right_range_end) {
-                        _Right_range_end = _Right._Traitsobj(_Keyval, _Traits::_Kfn(*_First2));
-                    }
-
-                    // the left equal_range ends at the end of the container or on the first nonequal element
-                    ++_First1;
-                    const bool _Left_range_end =
-                        _First1 == _Unchecked_end() || _Traitsobj(_Keyval, _Traits::_Kfn(*_First1));
-
-                    if (_Left_range_end && _Right_range_end) {
-                        // the equal_ranges were completely equal
-                        return {true, _First1};
-                    }
-
-                    if (_Left_range_end || _Right_range_end) {
-                        // one equal_range is a prefix of the other; not equal
-                        return {};
-                    }
-                }
-
-                // found a mismatched element, find the end of the equal_ranges and dispatch to _Check_match_counts
-                auto _Last1 = _First1;
-                auto _Last2 = _First2;
-                for (;;) {
-                    bool _Right_range_end = _Last2 == _Bucket_hi;
-                    ++_Last2;
-                    if (!_Right_range_end) {
-                        _Right_range_end = _Right._Traitsobj(_Keyval, _Traits::_Kfn(*_Last2));
-                    }
-
-                    ++_Last1;
-                    const bool _Left_range_end =
-                        _Last1 == _Unchecked_end() || _Traitsobj(_Keyval, _Traits::_Kfn(*_Last1));
-
-                    if (_Left_range_end && _Right_range_end) {
-                        // equal_ranges had the same length, check for permutation
-                        return {_Check_match_counts(_First1, _Last1, _First2, _Last2, equal_to<>{}), _Last1};
-                    }
-
-                    if (_Left_range_end || _Right_range_end) {
-                        // different number of elements in the range, not a permutation
-                        return {};
-                    }
-                }
+                _Left_stop_at = _Unchecked_end();
             }
         else {
             // check the first elements for equivalence when !_Standard
@@ -1999,61 +1952,58 @@ protected:
                 return {};
             }
 
-            // trim matching prefixes
             const size_t _LHashval   = _Traitsobj(_Keyval);
             const size_type _LBucket = _LHashval & _Mask;
             const auto _LBucket_hi   = _Vec._Mypair._Myval2._Myfirst[(_LBucket << 1) + 1];
-            while (*_First1 == *_First2) {
-                // the right equal_range ends at the end of the bucket or on the first greater element
-                bool _Right_range_end = _First2 == _Bucket_hi;
-                ++_First2;
-                if (!_Right_range_end) {
-                    _Right_range_end = _Right._Traitsobj(_Keyval, _Traits::_Kfn(*_First2));
-                }
+            _Left_stop_at            = _LBucket_hi;
+            ++_Left_stop_at;
+        }
 
-                // the left equal_range ends at the end of the bucket or on the first greater element
-                bool _Left_range_end = _First1 == _LBucket_hi;
-                ++_First1;
-                if (!_Left_range_end) {
-                    _Left_range_end = _Traitsobj(_Keyval, _Traits::_Kfn(*_First1));
-                }
-
-                if (_Left_range_end && _Right_range_end) {
-                    // all elements in both equal_ranges were equal, and the ranges were the same length, match
-                    return {true, _First1};
-                }
-
-                if (_Left_range_end || _Right_range_end) {
-                    // one equal_range is a prefix of the other; not equal
-                    return {};
-                }
+        // trim matching prefixes
+        while (*_First1 == *_First2) {
+            // the right equal_range ends at the end of the bucket or on the first nonequal element
+            bool _Right_range_end = _First2 == _Bucket_hi;
+            ++_First2;
+            if (!_Right_range_end) {
+                _Right_range_end = _Right._Traitsobj(_Keyval, _Traits::_Kfn(*_First2));
             }
 
-            // found a mismatched element, find the end of the equal_ranges and dispatch to _Check_match_counts
-            auto _Last1 = _First1;
-            auto _Last2 = _First2;
-            for (;;) {
-                bool _Right_range_end = _Last2 == _Bucket_hi;
-                ++_Last2;
-                if (!_Right_range_end) {
-                    _Right_range_end = _Right._Traitsobj(_Keyval, _Traits::_Kfn(*_Last2));
-                }
+            // the left equal_range ends at the end of the container or on the first nonequal element
+            ++_First1;
+            const bool _Left_range_end = _First1 == _Left_stop_at || _Traitsobj(_Keyval, _Traits::_Kfn(*_First1));
 
-                bool _Left_range_end = _Last1 == _LBucket_hi;
-                ++_Last1;
-                if (!_Left_range_end) {
-                    _Left_range_end = _Traitsobj(_Keyval, _Traits::_Kfn(*_Last1));
-                }
+            if (_Left_range_end && _Right_range_end) {
+                // the equal_ranges were completely equal
+                return {true, _First1};
+            }
 
-                if (_Left_range_end && _Right_range_end) {
-                    // equal_ranges had the same length, check for permutation
-                    return {_Check_match_counts(_First1, _Last1, _First2, _Last2, equal_to<>{}), _Last1};
-                }
+            if (_Left_range_end || _Right_range_end) {
+                // one equal_range is a prefix of the other; not equal
+                return {};
+            }
+        }
 
-                if (_Left_range_end || _Right_range_end) {
-                    // different number of elements in the range, not a permutation
-                    return {};
-                }
+        // found a mismatched element, find the end of the equal_ranges and dispatch to _Check_match_counts
+        auto _Last1 = _First1;
+        auto _Last2 = _First2;
+        for (;;) {
+            bool _Right_range_end = _Last2 == _Bucket_hi;
+            ++_Last2;
+            if (!_Right_range_end) {
+                _Right_range_end = _Right._Traitsobj(_Keyval, _Traits::_Kfn(*_Last2));
+            }
+
+            ++_Last1;
+            const bool _Left_range_end = _Last1 == _Left_stop_at || _Traitsobj(_Keyval, _Traits::_Kfn(*_Last1));
+
+            if (_Left_range_end && _Right_range_end) {
+                // equal_ranges had the same length, check for permutation
+                return {_Check_match_counts(_First1, _Last1, _First2, _Last2, equal_to<>{}), _Last1};
+            }
+
+            if (_Left_range_end || _Right_range_end) {
+                // different number of elements in the range, not a permutation
+                return {};
             }
         }
     }

--- a/stl/inc/xhash
+++ b/stl/inc/xhash
@@ -1916,13 +1916,14 @@ protected:
     }
 
     struct _Multi_equal_check_result {
-        bool _Equal_possible;
-        _Unchecked_const_iterator _Subsequent_first; // only useful if _Equal_possible
+        bool _Equal_possible = false;
+        _Unchecked_const_iterator _Subsequent_first{}; // only useful if _Equal_possible
     };
 
     _NODISCARD _Multi_equal_check_result _Multi_equal_check_equal_range(
         const _Hash& _Right, _Unchecked_const_iterator _First1) const {
-        // check equal_range of elements matching *_First1 match the equal_range of elements in _Right
+        // check that an equal_range of elements starting with *_First1 are a permutation of the corresponding
+        // equal_range of elements in _Right
         auto& _Keyval = _Traits::_Kfn(*_First1);
         // find the start of the matching run in the other container
         const size_t _Hashval   = _Right._Traitsobj(_Keyval);
@@ -2014,7 +2015,7 @@ protected:
         const auto _Last1 = _Unchecked_end();
         auto _First1      = _Unchecked_begin();
         while (_First1 != _Last1) {
-            auto _Result = _Multi_equal_check_equal_range(_Right, _First1);
+            const auto _Result = _Multi_equal_check_equal_range(_Right, _First1);
             if (!_Result._Equal_possible) {
                 return false;
             }

--- a/stl/inc/xhash
+++ b/stl/inc/xhash
@@ -1930,14 +1930,14 @@ protected:
         auto _First2            = _Right._Vec._Mypair._Myval2._Myfirst[_Bucket << 1];
         if (_First2 == _Right._Unchecked_end()) {
             // no matching bucket, therefore no matching run
-            return {false, {}};
+            return {};
         }
 
         const auto _Bucket_hi = _Right._Vec._Mypair._Myval2._Myfirst[(_Bucket << 1) + 1];
         for (; _Right._Traitsobj(_Traits::_Kfn(*_First2), _Keyval); ++_First2) {
             // find first matching element in _Right
             if (_First2 == _Bucket_hi) {
-                return {false, {}};
+                return {};
             }
         }
 
@@ -1963,8 +1963,8 @@ protected:
                     }
 
                     if (_Left_range_end || _Right_range_end) {
-                        // one equal_range is a prefix of the other; different lengths mean not equal though
-                        return {false, {}};
+                        // one equal_range is a prefix of the other; not equal
+                        return {};
                     }
                 }
 
@@ -1988,15 +1988,15 @@ protected:
                     }
 
                     if (_Left_range_end || _Right_range_end) {
-                        // different number of elements in the range, fail
-                        return {false, {}};
+                        // different number of elements in the range, not a permutation
+                        return {};
                     }
                 }
             }
         else {
-            // equivalence check the first element when !_Standard
+            // check the first elements for equivalence when !_Standard
             if (_Right._Traitsobj(_Keyval, _Traits::_Kfn(*_First2))) {
-                return {false, {}};
+                return {};
             }
 
             // trim matching prefixes
@@ -2024,8 +2024,8 @@ protected:
                 }
 
                 if (_Left_range_end || _Right_range_end) {
-                    // one equal_range is a prefix of the other; different lengths mean not equal though
-                    return {false, {}};
+                    // one equal_range is a prefix of the other; not equal
+                    return {};
                 }
             }
 
@@ -2051,8 +2051,8 @@ protected:
                 }
 
                 if (_Left_range_end || _Right_range_end) {
-                    // different number of elements in the range, fail
-                    return {false, {}};
+                    // different number of elements in the range, not a permutation
+                    return {};
                 }
             }
         }
@@ -2061,9 +2061,6 @@ protected:
     _NODISCARD bool _Multi_equal(const _Hash& _Right) const {
         static_assert(_Traits::_Multi, "This function only works with multi containers");
         _STL_INTERNAL_CHECK(this->size() == _Right.size());
-
-        const auto _End = _Right._Unchecked_end();
-
         const auto _Last1 = _Unchecked_end();
         auto _First1      = _Unchecked_begin();
         while (_First1 != _Last1) {

--- a/stl/inc/xhash
+++ b/stl/inc/xhash
@@ -1401,14 +1401,14 @@ private:
     template <class _Keyty>
     _NODISCARD _Equal_range_result _Equal_range(const _Keyty& _Keyval, const size_t _Hashval) const
         noexcept(_Nothrow_compare<_Traits, key_type, _Keyty>&& _Nothrow_compare<_Traits, _Keyty, key_type>) {
-        const size_type _Bucket                    = _Hashval & _Mask;
-        _Unchecked_const_iterator _Where           = _Vec._Mypair._Myval2._Myfirst[_Bucket << 1];
-        const _Unchecked_const_iterator _Bucket_hi = _Vec._Mypair._Myval2._Myfirst[(_Bucket << 1) + 1];
-        const _Unchecked_const_iterator _End       = _Unchecked_end();
+        const size_type _Bucket              = _Hashval & _Mask;
+        _Unchecked_const_iterator _Where     = _Vec._Mypair._Myval2._Myfirst[_Bucket << 1];
+        const _Unchecked_const_iterator _End = _Unchecked_end();
         if (_Where == _End) {
             return {_End, _End, 0};
         }
 
+        const _Unchecked_const_iterator _Bucket_hi = _Vec._Mypair._Myval2._Myfirst[(_Bucket << 1) + 1];
         for (; _Traitsobj(_Traits::_Kfn(*_Where), _Keyval); ++_Where) {
             if (_Where == _Bucket_hi) {
                 return {_End, _End, 0};
@@ -1915,6 +1915,169 @@ protected:
         return _List._Getal();
     }
 
+    struct _Multi_equal_check_result {
+        bool _Equal_possible;
+        _Unchecked_const_iterator _Subsequent_first; // only useful if _Equal_possible
+    };
+
+    _NODISCARD _Multi_equal_check_result _Multi_equal_check_equal_range(
+        const _Hash& _Right, _Unchecked_const_iterator _First1) const {
+        // check equal_range of elements matching *_First1 match the equal_range of elements in _Right
+        auto& _Keyval = _Traits::_Kfn(*_First1);
+        // find the start of the matching run in the other container
+        const size_t _Hashval   = _Right._Traitsobj(_Keyval);
+        const size_type _Bucket = _Hashval & _Right._Mask;
+        auto _First2            = _Right._Vec._Mypair._Myval2._Myfirst[_Bucket << 1];
+        if (_First2 == _Right._Unchecked_end()) {
+            // no matching bucket, therefore no matching run
+            return {false, {}};
+        }
+
+        const auto _Bucket_hi = _Right._Vec._Mypair._Myval2._Myfirst[(_Bucket << 1) + 1];
+        for (; _Right._Traitsobj(_Traits::_Kfn(*_First2), _Keyval); ++_First2) {
+            // find first matching element in _Right
+            if (_First2 == _Bucket_hi) {
+                return {false, {}};
+            }
+        }
+
+        if
+            _CONSTEXPR_IF(_Traits::_Standard) {
+                // trim matching prefixes
+                while (*_First1 == *_First2) {
+                    // the right equal_range ends at the end of the bucket or on the first nonequal element
+                    bool _Right_range_end = _First2 == _Bucket_hi;
+                    ++_First2;
+                    if (!_Right_range_end) {
+                        _Right_range_end = _Right._Traitsobj(_Keyval, _Traits::_Kfn(*_First2));
+                    }
+
+                    // the left equal_range ends at the end of the container or on the first nonequal element
+                    ++_First1;
+                    const bool _Left_range_end =
+                        _First1 == _Unchecked_end() || _Traitsobj(_Keyval, _Traits::_Kfn(*_First1));
+
+                    if (_Left_range_end && _Right_range_end) {
+                        // the equal_ranges were completely equal
+                        return {true, _First1};
+                    }
+
+                    if (_Left_range_end || _Right_range_end) {
+                        // one equal_range is a prefix of the other; different lengths mean not equal though
+                        return {false, {}};
+                    }
+                }
+
+                // found a mismatched element, find the end of the equal_ranges and dispatch to _Check_match_counts
+                auto _Last1 = _First1;
+                auto _Last2 = _First2;
+                for (;;) {
+                    bool _Right_range_end = _Last2 == _Bucket_hi;
+                    ++_Last2;
+                    if (!_Right_range_end) {
+                        _Right_range_end = _Right._Traitsobj(_Keyval, _Traits::_Kfn(*_Last2));
+                    }
+
+                    ++_Last1;
+                    const bool _Left_range_end =
+                        _Last1 == _Unchecked_end() || _Traitsobj(_Keyval, _Traits::_Kfn(*_Last1));
+
+                    if (_Left_range_end && _Right_range_end) {
+                        // equal_ranges had the same length, check for permutation
+                        return {_Check_match_counts(_First1, _Last1, _First2, _Last2, equal_to<>{}), _Last1};
+                    }
+
+                    if (_Left_range_end || _Right_range_end) {
+                        // different number of elements in the range, fail
+                        return {false, {}};
+                    }
+                }
+            }
+        else {
+            // equivalence check the first element when !_Standard
+            if (_Right._Traitsobj(_Keyval, _Traits::_Kfn(*_First2))) {
+                return {false, {}};
+            }
+
+            // trim matching prefixes
+            const size_t _LHashval   = _Traitsobj(_Keyval);
+            const size_type _LBucket = _LHashval & _Mask;
+            const auto _LBucket_hi   = _Vec._Mypair._Myval2._Myfirst[(_LBucket << 1) + 1];
+            while (*_First1 == *_First2) {
+                // the right equal_range ends at the end of the bucket or on the first greater element
+                bool _Right_range_end = _First2 == _Bucket_hi;
+                ++_First2;
+                if (!_Right_range_end) {
+                    _Right_range_end = _Right._Traitsobj(_Keyval, _Traits::_Kfn(*_First2));
+                }
+
+                // the left equal_range ends at the end of the bucket or on the first greater element
+                bool _Left_range_end = _First1 == _LBucket_hi;
+                ++_First1;
+                if (!_Left_range_end) {
+                    _Left_range_end = _Traitsobj(_Keyval, _Traits::_Kfn(*_First1));
+                }
+
+                if (_Left_range_end && _Right_range_end) {
+                    // all elements in both equal_ranges were equal, and the ranges were the same length, match
+                    return {true, _First1};
+                }
+
+                if (_Left_range_end || _Right_range_end) {
+                    // one equal_range is a prefix of the other; different lengths mean not equal though
+                    return {false, {}};
+                }
+            }
+
+            // found a mismatched element, find the end of the equal_ranges and dispatch to _Check_match_counts
+            auto _Last1 = _First1;
+            auto _Last2 = _First2;
+            for (;;) {
+                bool _Right_range_end = _Last2 == _Bucket_hi;
+                ++_Last2;
+                if (!_Right_range_end) {
+                    _Right_range_end = _Right._Traitsobj(_Keyval, _Traits::_Kfn(*_Last2));
+                }
+
+                bool _Left_range_end = _Last1 == _LBucket_hi;
+                ++_Last1;
+                if (!_Left_range_end) {
+                    _Left_range_end = _Traitsobj(_Keyval, _Traits::_Kfn(*_Last1));
+                }
+
+                if (_Left_range_end && _Right_range_end) {
+                    // equal_ranges had the same length, check for permutation
+                    return {_Check_match_counts(_First1, _Last1, _First2, _Last2, equal_to<>{}), _Last1};
+                }
+
+                if (_Left_range_end || _Right_range_end) {
+                    // different number of elements in the range, fail
+                    return {false, {}};
+                }
+            }
+        }
+    }
+
+    _NODISCARD bool _Multi_equal(const _Hash& _Right) const {
+        static_assert(_Traits::_Multi, "This function only works with multi containers");
+        _STL_INTERNAL_CHECK(this->size() == _Right.size());
+
+        const auto _End = _Right._Unchecked_end();
+
+        const auto _Last1 = _Unchecked_end();
+        auto _First1      = _Unchecked_begin();
+        while (_First1 != _Last1) {
+            auto _Result = _Multi_equal_check_equal_range(_Right, _First1);
+            if (!_Result._Equal_possible) {
+                return false;
+            }
+
+            _First1 = _Result._Subsequent_first;
+        }
+
+        return true;
+    }
+
 #ifdef _ENABLE_STL_INTERNAL_CHECK
 public:
     void _Stl_internal_check_container_invariants() const noexcept {
@@ -2018,23 +2181,7 @@ _NODISCARD bool _Hash_equal_elements(const _Hash<_Traits>& _Left, const _Hash<_T
 
 template <class _Traits>
 _NODISCARD bool _Hash_equal_elements(const _Hash<_Traits>& _Left, const _Hash<_Traits>& _Right, true_type) {
-    const auto _Left_end = _Left._Unchecked_end();
-    for (auto _Next1 = _Left._Unchecked_begin(); _Next1 != _Left_end;) { // look for elements with equivalent keys
-        const auto& _Keyval    = _Traits::_Kfn(*_Next1);
-        const size_t _Lhashval = _Left._Traitsobj(_Keyval);
-        const size_t _Rhashval = _Right._Traitsobj(_Keyval); // P0809 prohibits reusing _Lhashval
-        const auto _Lrange     = _Left._Equal_range(_Keyval, _Lhashval);
-        const auto _Rrange     = _Right._Equal_range(_Keyval, _Rhashval);
-
-        if (_Lrange._Distance != _Rrange._Distance
-            || !_Is_permutation_unchecked(_Lrange._First, _Lrange._Last, _Rrange._First, equal_to<>{})) {
-            return false;
-        }
-
-        _Next1 = _Lrange._Last; // continue just past range
-    }
-
-    return true;
+    return _Left._Multi_equal(_Right);
 }
 #endif // !_HAS_IF_CONSTEXPR
 
@@ -2046,21 +2193,7 @@ _NODISCARD bool _Hash_equal(const _Hash<_Traits>& _Left, const _Hash<_Traits>& _
 
 #if _HAS_IF_CONSTEXPR
     if constexpr (_Traits::_Multi) {
-        const auto _Left_end = _Left._Unchecked_end();
-        for (auto _Next1 = _Left._Unchecked_begin(); _Next1 != _Left_end;) { // look for elements with equivalent keys
-            const auto& _Keyval    = _Traits::_Kfn(*_Next1);
-            const size_t _Lhashval = _Left._Traitsobj(_Keyval);
-            const size_t _Rhashval = _Right._Traitsobj(_Keyval); // P0809 prohibits reusing _Lhashval
-            const auto _Lrange     = _Left._Equal_range(_Keyval, _Lhashval);
-            const auto _Rrange     = _Right._Equal_range(_Keyval, _Rhashval);
-
-            if (_Lrange._Distance != _Rrange._Distance
-                || !_Is_permutation_unchecked(_Lrange._First, _Lrange._Last, _Rrange._First, equal_to<>{})) {
-                return false;
-            }
-
-            _Next1 = _Lrange._Last; // continue just past range
-        }
+        return _Left._Multi_equal(_Right);
     } else {
         for (const auto& _LVal : _Left) {
             // look for element with equivalent key

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -4727,7 +4727,8 @@ void _Trim_matching_suffixes(
 #endif // !_HAS_IF_CONSTEXPR
 
 template <class _FwdIt1, class _FwdIt2, class _Pr>
-_NODISCARD bool _Check_match_counts(const _FwdIt1 _First1, _FwdIt1 _Last1, const _FwdIt2 _First2, _FwdIt2 _Last2, _Pr _Pred) {
+_NODISCARD bool _Check_match_counts(
+    const _FwdIt1 _First1, _FwdIt1 _Last1, const _FwdIt2 _First2, _FwdIt2 _Last2, _Pr _Pred) {
     // test if [_First1, _Last1) == permuted [_First2, _Last2), after matching prefix removal
     _STL_INTERNAL_CHECK(!_Pred(*_First1, *_First2));
     _STL_INTERNAL_CHECK(_STD distance(_First1, _Last1) == _STD distance(_First2, _Last2));

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -4657,18 +4657,6 @@ template <class _ExPo, class _FwdIt, class _Ty, _Enable_if_execution_policy_t<_E
 _NODISCARD _FwdIt find(_ExPo&& _Exec, _FwdIt _First, const _FwdIt _Last, const _Ty& _Val) noexcept; // terminates
 #endif // _HAS_CXX17
 
-// FUNCTION TEMPLATE _Find_pr
-template <class _InIt, class _Ty, class _Pr>
-_InIt _Find_pr(_InIt _First, _InIt _Last, const _Ty& _Val, _Pr _Pred) { // find first matching _Val, using _Pred
-    for (; _First != _Last; ++_First) {
-        if (_Pred(*_First, _Val)) {
-            break;
-        }
-    }
-
-    return _First;
-}
-
 // FUNCTION TEMPLATE count
 template <class _InIt, class _Ty>
 _NODISCARD _Iter_diff_t<_InIt> count(const _InIt _First, const _InIt _Last, const _Ty& _Val) {
@@ -4693,10 +4681,20 @@ _NODISCARD _Iter_diff_t<_FwdIt> count(
     _ExPo&& _Exec, const _FwdIt _First, const _FwdIt _Last, const _Ty& _Val) noexcept; // terminates
 #endif // _HAS_CXX17
 
-// FUNCTION TEMPLATE _Count_pr
+// FUNCTION TEMPLATE is_permutation
 template <class _InIt, class _Ty, class _Pr>
-_Iter_diff_t<_InIt> _Count_pr(_InIt _First, _InIt _Last, const _Ty& _Val, _Pr _Pred) {
-    // count elements that match _Val, using _Pred
+_NODISCARD _InIt _Find_pr(_InIt _First, _InIt _Last, const _Ty& _Val, _Pr _Pred) {
+    for (; _First != _Last; ++_First) {
+        if (_Pred(*_First, _Val)) {
+            break;
+        }
+    }
+
+    return _First;
+}
+
+template <class _InIt, class _Ty, class _Pr>
+_NODISCARD _Iter_diff_t<_InIt> _Count_pr(_InIt _First, _InIt _Last, const _Ty& _Val, _Pr _Pred) {
     _Iter_diff_t<_InIt> _Count = 0;
 
     for (; _First != _Last; ++_First) {
@@ -4708,7 +4706,7 @@ _Iter_diff_t<_InIt> _Count_pr(_InIt _First, _InIt _Last, const _Ty& _Val, _Pr _P
     return _Count;
 }
 
-// FUNCTION TEMPLATE _Trim_matching_suffixes
+#if !_HAS_IF_CONSTEXPR
 template <class _FwdIt1, class _FwdIt2, class _Pr>
 void _Trim_matching_suffixes(_FwdIt1&, _FwdIt2&, _Pr, forward_iterator_tag, forward_iterator_tag) {
     // trim matching suffixes, forward iterators (do nothing)
@@ -4726,12 +4724,24 @@ void _Trim_matching_suffixes(
     ++_Last1;
     ++_Last2;
 }
+#endif // !_HAS_IF_CONSTEXPR
 
-// FUNCTION TEMPLATE _Check_match_counts
 template <class _FwdIt1, class _FwdIt2, class _Pr>
-bool _Check_match_counts(_FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2, _FwdIt2 _Last2, _Pr _Pred) {
-    // test if [_First1, _Last1) == permuted [_First2, _Last2), using _Pred, same lengths
+_NODISCARD bool _Check_match_counts(_FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2, _FwdIt2 _Last2, _Pr _Pred) {
+    // test if [_First1, _Last1) == permuted [_First2, _Last2), after matching prefix removal
+    _STL_INTERNAL_CHECK(_STD distance(_First1, _Last1) == _STD distance(_First2, _Last2));
+#if _HAS_IF_CONSTEXPR
+    if constexpr (_Is_bidi_iter_v<_FwdIt1> && _Is_bidi_iter_v<_FwdIt2>) {
+        do { // find last inequality
+            --_Last1;
+            --_Last2;
+        } while (_Pred(*_Last1, *_Last2));
+        ++_Last1;
+        ++_Last2;
+    }
+#else // ^^^ _HAS_IF_CONSTEXPR // !_HAS_IF_CONSTEXPR vvv
     _Trim_matching_suffixes(_Last1, _Last2, _Pred, _Iter_cat_t<_FwdIt1>(), _Iter_cat_t<_FwdIt2>());
+#endif // _HAS_IF_CONSTEXPR
     for (_FwdIt1 _Next1 = _First1; _Next1 != _Last1; ++_Next1) {
         if (_Next1 == _Find_pr(_First1, _Next1, *_Next1, _Pred)) { // new value, compare match counts
             _Iter_diff_t<_FwdIt2> _Count2 = _Count_pr(_First2, _Last2, *_Next1, _Pred);
@@ -4750,15 +4760,15 @@ bool _Check_match_counts(_FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2, _FwdI
     return true;
 }
 
-// FUNCTION TEMPLATE is_permutation
 template <class _FwdIt1, class _FwdIt2, class _Pr>
-bool _Is_permutation_unchecked(_FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2, _Pr _Pred) {
+_NODISCARD bool _Is_permutation_unchecked(_FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2, _Pr _Pred) {
     // test if [_First1, _Last1) == permuted [_First2, ...), using _Pred
-    for (; _First1 != _Last1; ++_First1, (void) ++_First2) {
+    for (; _First1 != _Last1; ++_First1, (void) ++_First2) { // trim matching prefix
         if (!_Pred(*_First1, *_First2)) {
-            // found first inequality, check match counts in suffix narrowing _Iter_diff_t<_FwdIt1> to
-            // _Iter_diff_t<_FwdIt2> is OK because if the 2nd range is shorter than the 1st, the user already
-            // triggered UB
+            // found first inequality, check match counts in suffix
+            //
+            // narrowing _Iter_diff_t<_FwdIt1> to _Iter_diff_t<_FwdIt2> is OK because if the 2nd range is shorter than
+            // the 1st, the user already triggered UB
             auto _Last2 = _STD next(_First2, static_cast<_Iter_diff_t<_FwdIt2>>(_STD distance(_First1, _Last1)));
             return _Check_match_counts(_First1, _Last1, _First2, _Last2, _Pred);
         }
@@ -4804,17 +4814,41 @@ template <class _FwdIt1, class _FwdIt2, class _Pr>
 bool _Is_permutation_unchecked(_FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2, _FwdIt2 _Last2, _Pr _Pred,
     forward_iterator_tag, forward_iterator_tag) {
     // test if [_First1, _Last1) == permuted [_First2, _Last2), using _Pred, arbitrary iterators
-    for (; _First1 != _Last1 && _First2 != _Last2; ++_First1, (void) ++_First2) {
-        if (!_Pred(*_First1, *_First2)) { // found first inequality, check match counts in suffix
-            if (_STD distance(_First1, _Last1) == _STD distance(_First2, _Last2)) {
-                return _Check_match_counts(_First1, _Last1, _First2, _Last2, _Pred);
-            } else {
-                return false; // lengths differ, fail
-            }
+    for (;;) { // trim matching prefix
+        if (_First1 == _Last1) {
+            return _First2 == _Last2; // sequence equal
         }
+
+        if (_First2 == _Last2) {
+            return false;
+        }
+
+        if (!_Pred(*_First1, *_First2)) { // found first inequality, check match counts in suffix
+            break;
+        }
+
+        ++_First1;
+        ++_First2;
     }
 
-    return _First1 == _Last1 && _First2 == _Last2;
+    auto _Next1 = _First1;
+    auto _Next2 = _First2;
+    for (;;) { // check for same lengths
+        if (_Next1 == _Last1) {
+            if (_Next2 == _Last2) {
+                return _Check_match_counts(_First1, _Last1, _First2, _Last2, _Pred);
+            }
+
+            return false; // sequence 1 shorter than sequence 2, fail
+        }
+
+        if (_Next2 == _Last2) {
+            return false; // sequence 1 longer than sequence 2, fail
+        }
+
+        ++_Next1;
+        ++_Next2;
+    }
 }
 
 template <class _FwdIt1, class _FwdIt2, class _Pr>
@@ -4825,7 +4859,14 @@ bool _Is_permutation_unchecked(_FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2,
         return false;
     }
 
-    return _Is_permutation_unchecked(_First1, _Last1, _First2, _Pred);
+    for (; _First1 != _Last1; ++_First1, (void) ++_First2) { // trim matching prefix
+        if (!_Pred(*_First1, *_First2)) {
+            // found first inequality, check match counts in suffix
+            return _Check_match_counts(_First1, _Last1, _First2, _Last2, _Pred);
+        }
+    }
+
+    return true;
 }
 
 template <class _FwdIt1, class _FwdIt2, class _Pr>
@@ -4837,7 +4878,6 @@ _NODISCARD bool is_permutation(_FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2,
         _Get_unwrapped(_Last2), _Pass_fn(_Pred), _Iter_cat_t<_FwdIt1>(), _Iter_cat_t<_FwdIt2>());
 }
 
-// FUNCTION TEMPLATE is_permutation WITH TWO RANGES
 template <class _FwdIt1, class _FwdIt2>
 _NODISCARD bool is_permutation(_FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2, _FwdIt2 _Last2) {
     // test if [_First1, _Last1) == permuted [_First2, _Last2)

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -4683,7 +4683,7 @@ _NODISCARD _Iter_diff_t<_FwdIt> count(
 
 // FUNCTION TEMPLATE is_permutation
 template <class _InIt, class _Ty, class _Pr>
-_NODISCARD _InIt _Find_pr(_InIt _First, _InIt _Last, const _Ty& _Val, _Pr _Pred) {
+_NODISCARD _InIt _Find_pr(_InIt _First, const _InIt _Last, const _Ty& _Val, _Pr _Pred) {
     for (; _First != _Last; ++_First) {
         if (_Pred(*_First, _Val)) {
             break;
@@ -4694,7 +4694,7 @@ _NODISCARD _InIt _Find_pr(_InIt _First, _InIt _Last, const _Ty& _Val, _Pr _Pred)
 }
 
 template <class _InIt, class _Ty, class _Pr>
-_NODISCARD _Iter_diff_t<_InIt> _Count_pr(_InIt _First, _InIt _Last, const _Ty& _Val, _Pr _Pred) {
+_NODISCARD _Iter_diff_t<_InIt> _Count_pr(_InIt _First, const _InIt _Last, const _Ty& _Val, _Pr _Pred) {
     _Iter_diff_t<_InIt> _Count = 0;
 
     for (; _First != _Last; ++_First) {
@@ -4727,8 +4727,9 @@ void _Trim_matching_suffixes(
 #endif // !_HAS_IF_CONSTEXPR
 
 template <class _FwdIt1, class _FwdIt2, class _Pr>
-_NODISCARD bool _Check_match_counts(_FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2, _FwdIt2 _Last2, _Pr _Pred) {
+_NODISCARD bool _Check_match_counts(const _FwdIt1 _First1, _FwdIt1 _Last1, const _FwdIt2 _First2, _FwdIt2 _Last2, _Pr _Pred) {
     // test if [_First1, _Last1) == permuted [_First2, _Last2), after matching prefix removal
+    _STL_INTERNAL_CHECK(!_Pred(*_First1, *_First2));
     _STL_INTERNAL_CHECK(_STD distance(_First1, _Last1) == _STD distance(_First2, _Last2));
 #if _HAS_IF_CONSTEXPR
     if constexpr (_Is_bidi_iter_v<_FwdIt1> && _Is_bidi_iter_v<_FwdIt2>) {
@@ -4746,13 +4747,13 @@ _NODISCARD bool _Check_match_counts(_FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _Fi
         if (_Next1 == _Find_pr(_First1, _Next1, *_Next1, _Pred)) { // new value, compare match counts
             _Iter_diff_t<_FwdIt2> _Count2 = _Count_pr(_First2, _Last2, *_Next1, _Pred);
             if (_Count2 == 0) {
-                return false; // second range lacks value, fail
+                return false; // second range lacks value, not a permutation
             }
 
             _FwdIt1 _Skip1                = _Next_iter(_Next1);
             _Iter_diff_t<_FwdIt1> _Count1 = _Count_pr(_Skip1, _Last1, *_Next1, _Pred) + 1;
             if (_Count2 != _Count1) {
-                return false; // match counts differ, fail
+                return false; // match counts differ, not a permutation
             }
         }
     }
@@ -4816,7 +4817,7 @@ bool _Is_permutation_unchecked(_FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2,
     // test if [_First1, _Last1) == permuted [_First2, _Last2), using _Pred, arbitrary iterators
     for (;;) { // trim matching prefix
         if (_First1 == _Last1) {
-            return _First2 == _Last2; // sequence equal
+            return _First2 == _Last2; // sequences are equal
         }
 
         if (_First2 == _Last2) {
@@ -4839,11 +4840,11 @@ bool _Is_permutation_unchecked(_FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2,
                 return _Check_match_counts(_First1, _Last1, _First2, _Last2, _Pred);
             }
 
-            return false; // sequence 1 shorter than sequence 2, fail
+            return false; // sequence 1 is shorter than sequence 2, not a permutation
         }
 
         if (_Next2 == _Last2) {
-            return false; // sequence 1 longer than sequence 2, fail
+            return false; // sequence 1 is longer than sequence 2, not a permutation
         }
 
         ++_Next1;

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -4770,8 +4770,8 @@ _NODISCARD bool _Is_permutation_unchecked(_FwdIt1 _First1, _FwdIt1 _Last1, _FwdI
         if (!_Pred(*_First1, *_First2)) {
             // found first inequality, check match counts in suffix
             //
-            // narrowing _Iter_diff_t<_FwdIt1> to _Iter_diff_t<_FwdIt2> is OK because if the 2nd range is shorter than
-            // the 1st, the user already triggered UB
+            // narrowing _Iter_diff_t<_FwdIt1> to _Iter_diff_t<_FwdIt2> is OK because if the second range is shorter
+            // than the first, the user already triggered UB
             auto _Last2 = _STD next(_First2, static_cast<_Iter_diff_t<_FwdIt2>>(_STD distance(_First1, _Last1)));
             return _Check_match_counts(_First1, _Last1, _First2, _Last2, _Pred);
         }
@@ -4819,7 +4819,7 @@ bool _Is_permutation_unchecked(_FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2,
     // test if [_First1, _Last1) == permuted [_First2, _Last2), using _Pred, arbitrary iterators
     for (;;) { // trim matching prefix
         if (_First1 == _Last1) {
-            return _First2 == _Last2; // sequences are equal
+            return _First2 == _Last2;
         }
 
         if (_First2 == _Last2) {


### PR DESCRIPTION
`<xutility>`  
4660: _Find_pr is a helper for is_permutation, so move it down to that area.  
4684: The SHOUTY banners were attached to functions which were implementation details of is_permutation, so I fixed them up to say is_permutation and removed the banners for helper functions.  
4711: Use if constexpr to avoid a tag dispatch call for _Trim_matching_suffixes. Optimizers will like this because they generally hate reference-to-pointer, and it also serves to workaround DevCom-883631 when this algorithm is constexprized.  
4766: Indicate that we are trimming matching prefixes in this loop body, and break apart comment block that was incorrectly merged by clang-format.  
4817: In the dual range forward version of the algorithm, calculate the distances concurrently to avoid wasting lots of time when the distances vary by a lot. For example, is_permutation( a forward range of length 1, a forward range of length 1'000'000 ) used to do the million increments, now it stops at 1 increment.  
4862: In the dual range random-access version, avoid recalculating _Last2 when it has already been supplied to us.  
  
`<xhash>`  
1404: Move down construction of _Bucket_hi in _Equal_range to before the first loop body using it.  
1918: Added a new function to calculate equality for unordered multicontainers. We loop over the elements in the left container, find corresponding ranges in the right container, trim prefixes, then dispatch to is_permutation's helper _Check_match_counts.  
Improvements over the old implementation:  
* For standard containers, we no longer need to hash any elements from the left container; we know that we've found the "run" of equivalent elements because we *started* with an element in that container. We also never go "backwards" or multiply enumerate _Left (even for !_Standard), which improves cache use when the container becomes large.
* Just like the dual range is_permutation improvement above, when the equal_ranges of the containers are of wildly varying lengths, this will stop on the shorter of the lengths.
* We avoid the 3-arg is_permutation doing a linear time operation to discover _Last2 that we already had calculated in determining _Right's equal_range.

The function _Multi_equal_check_equal_range tests one equal_range from the left container against the corresponding equal_range from the right container, while _Multi_equal invokes _Multi_equal_check_equal_range for each equal_range.

Performance results:

![image](https://user-images.githubusercontent.com/1544943/72472988-9a36df00-379a-11ea-8dec-cb1c6692f030.png)

Benchmark code:
```
#undef NDEBUG
#define _SILENCE_STDEXT_HASH_DEPRECATION_WARNINGS
#include <assert.h>
#include <benchmark/benchmark.h>
#include <hash_map>
#include <random>
#include <stddef.h>
#include <unordered_map>
#include <utility>
#include <vector>

using namespace std;

template <template <class...> class MapType> void HashRandomUnequal(benchmark::State &state) {
    std::minstd_rand rng(std::random_device{}());
    const auto range0 = static_cast<ptrdiff_t>(state.range(0));
    vector<pair<unsigned, unsigned>> testData;
    testData.resize(range0 * 5);
    const auto dataEnd = testData.begin() + range0;
    std::generate(testData.begin(), dataEnd, [&]() { return pair<unsigned, unsigned>{rng(), 0u}; });
    std::copy(testData.begin(), dataEnd,
              std::copy(testData.begin(), dataEnd,
                        std::copy(testData.begin(), dataEnd, std::copy(testData.begin(), dataEnd, dataEnd))));
    std::unordered_multimap<unsigned, unsigned> a(testData.begin(), testData.end());
    testData.clear();
    std::unordered_multimap<unsigned, unsigned> b = a;
    next(b.begin(), b.size() - 1)->second = 1u;
    for (auto &&_ : state) {
        (void)_;
        assert(a != b);
    }
}

BENCHMARK_TEMPLATE1(HashRandomUnequal, unordered_multimap)->Arg(1)->Arg(10)->Range(100, 100'000);
BENCHMARK_TEMPLATE1(HashRandomUnequal, hash_multimap)->Arg(1)->Arg(10)->Range(100, 100'000);

template <template <class...> class MapType> void HashRandomEqual(benchmark::State &state) {
    std::minstd_rand rng(std::random_device{}());
    const auto range0 = static_cast<ptrdiff_t>(state.range(0));
    vector<pair<unsigned, unsigned>> testData;
    testData.resize(range0 * 5);
    const auto dataEnd = testData.begin() + range0;
    std::generate(testData.begin(), dataEnd, [&]() { return pair<unsigned, unsigned>{rng(), 0}; });
    std::copy(testData.begin(), dataEnd,
              std::copy(testData.begin(), dataEnd,
                        std::copy(testData.begin(), dataEnd, std::copy(testData.begin(), dataEnd, dataEnd))));
    std::unordered_multimap<unsigned, unsigned> a(testData.begin(), testData.end());
    testData.clear();
    std::unordered_multimap<unsigned, unsigned> b = a;
    for (auto &&_ : state) {
        (void)_;
        assert(a == b);
    }
}

BENCHMARK_TEMPLATE1(HashRandomEqual, unordered_multimap)->Arg(1)->Arg(10)->Range(100, 100'000);
BENCHMARK_TEMPLATE1(HashRandomEqual, hash_multimap)->Arg(1)->Arg(10)->Range(100, 100'000);

template <template <class...> class MapType> void HashUnequalDifferingBuckets(benchmark::State &state) {
    std::unordered_multimap<unsigned, unsigned> a;
    std::unordered_multimap<unsigned, unsigned> b;
    const auto range0 = static_cast<ptrdiff_t>(state.range(0));
    for (ptrdiff_t idx = 0; idx < range0; ++idx) {
        a.emplace(0, 1);
        b.emplace(1, 0);
    }

    a.emplace(1, 0);
    b.emplace(0, 1);
    for (auto &&_ : state) {
        (void)_;
        assert(a != b);
    }
}

BENCHMARK_TEMPLATE1(HashUnequalDifferingBuckets, unordered_multimap)->Arg(2)->Arg(10)->Range(100, 100'000);
BENCHMARK_TEMPLATE1(HashUnequalDifferingBuckets, hash_multimap)->Arg(2)->Arg(10)->Range(100, 100'000);

BENCHMARK_MAIN();
```

# Checklist

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [x] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
