### PR TITLE
Fix x64 build with Boost 1.72

### DIFF
--- a/stl/src/special_math.cpp
+++ b/stl/src/special_math.cpp
@@ -13,6 +13,7 @@
 #pragma warning(disable : 4643) // Forward declaring '%s' in namespace std is not permitted by the C++ Standard
 #pragma warning(disable : 4702) // unreachable code
 
+#define BOOST_CHRONO_HEADER_ONLY
 #define BOOST_CONFIG_SUPPRESS_OUTDATED_MESSAGE
 #define BOOST_MATH_DOMAIN_ERROR_POLICY   errno_on_error
 #define BOOST_MATH_OVERFLOW_ERROR_POLICY ignore_error


### PR DESCRIPTION
# Description
Currently, x64 build of STL with Boost 1.72 fails due to a bunch of warnings turned into errors:
```
G:\dev\stl\vcpkg\installed\x64-windows\include\boost/config/abi_prefix.hpp(19,1): error C2220: the following warning is treated as an error
#  include BOOST_ABI_PREFIX
^
G:\dev\stl\vcpkg\installed\x64-windows\include\boost/config/abi_prefix.hpp(19,1): warning C4103: alignment changed after including header, may be due to missing #pragma pack(pop)
#  include BOOST_ABI_PREFIX
^
G:\dev\stl\vcpkg\installed\x64-windows\include\boost/chrono/duration.hpp(63,1): warning C4103: alignment changed after including header, may be due to missing #pragma pack(pop)
#include <boost/config/abi_prefix.hpp> // must be the last #include
^
G:\dev\stl\vcpkg\installed\x64-windows\include\boost/config/abi_suffix.hpp(20,1): warning C4103: alignment changed after including header, may be due to missing #pragma pack(pop)
#  include BOOST_ABI_SUFFIX
^
G:\dev\stl\vcpkg\installed\x64-windows\include\boost/chrono/duration.hpp(795,1): warning C4103: alignment changed after including header, may be due to missing #pragma pack(pop)
#include <boost/config/abi_suffix.hpp> // pops abi_prefix.hpp pragmas
^
G:\dev\stl\vcpkg\installed\x64-windows\include\boost/config/abi_prefix.hpp(19,1): warning C4103: alignment changed after including header, may be due to missing #pragma pack(pop)
#  include BOOST_ABI_PREFIX
^
G:\dev\stl\vcpkg\installed\x64-windows\include\boost/chrono/time_point.hpp(37,1): warning C4103: alignment changed after including header, may be due to missing #pragma pack(pop)
#include <boost/config/abi_prefix.hpp> // must be the last #include
^
G:\dev\stl\vcpkg\installed\x64-windows\include\boost/config/abi_suffix.hpp(20,1): warning C4103: alignment changed after including header, may be due to missing #pragma pack(pop)
#  include BOOST_ABI_SUFFIX
^
G:\dev\stl\vcpkg\installed\x64-windows\include\boost/chrono/time_point.hpp(376,1): warning C4103: alignment changed after including header, may be due to missing #pragma pack(pop)
#include <boost/config/abi_suffix.hpp> // pops abi_prefix.hpp pragmas
^
G:\dev\stl\vcpkg\installed\x64-windows\include\boost/config/abi_prefix.hpp(19,1): warning C4103: alignment changed after including header, may be due to missing #pragma pack(pop)
#  include BOOST_ABI_PREFIX
^
G:\dev\stl\vcpkg\installed\x64-windows\include\boost/chrono/system_clocks.hpp(84,1): warning C4103: alignment changed after including header, may be due to missing #pragma pack(pop)
#include <boost/config/abi_prefix.hpp> // must be the last #include
^
G:\dev\stl\vcpkg\installed\x64-windows\include\boost/config/abi_suffix.hpp(20,1): warning C4103: alignment changed after including header, may be due to missing #pragma pack(pop)
#  include BOOST_ABI_SUFFIX
^
G:\dev\stl\vcpkg\installed\x64-windows\include\boost/chrono/system_clocks.hpp(228,1): warning C4103: alignment changed after including header, may be due to missing #pragma pack(pop)
#include <boost/config/abi_suffix.hpp> // pops abi_prefix.hpp pragmas
^
G:\dev\stl\vcpkg\installed\x64-windows\include\boost/config/abi_prefix.hpp(19,1): warning C4103: alignment changed after including header, may be due to missing #pragma pack(pop)
#  include BOOST_ABI_PREFIX
^
G:\dev\stl\vcpkg\installed\x64-windows\include\boost/chrono/process_cpu_clocks.hpp(28,1): warning C4103: alignment changed after including header, may be due to missing #pragma pack(pop)
#include <boost/config/abi_prefix.hpp> // must be the last #include
^
G:\dev\stl\vcpkg\installed\x64-windows\include\boost/config/abi_suffix.hpp(20,1): warning C4103: alignment changed after including header, may be due to missing #pragma pack(pop)
#  include BOOST_ABI_SUFFIX
^
G:\dev\stl\vcpkg\installed\x64-windows\include\boost/chrono/process_cpu_clocks.hpp(519,1): warning C4103: alignment changed after including header, may be due to missing #pragma pack(pop)
#include <boost/config/abi_suffix.hpp> // pops abi_prefix.hpp pragmas
^
G:\dev\stl\vcpkg\installed\x64-windows\include\boost/config/abi_prefix.hpp(19,1): warning C4103: alignment changed after including header, may be due to missing #pragma pack(pop)
#  include BOOST_ABI_PREFIX
^
G:\dev\stl\vcpkg\installed\x64-windows\include\boost/chrono/thread_clock.hpp(24,1): warning C4103: alignment changed after including header, may be due to missing #pragma pack(pop)
#include <boost/config/abi_prefix.hpp> // must be the last #include
^
G:\dev\stl\vcpkg\installed\x64-windows\include\boost/config/abi_suffix.hpp(20,1): warning C4103: alignment changed after including header, may be due to missing #pragma pack(pop)
#  include BOOST_ABI_SUFFIX
^
G:\dev\stl\vcpkg\installed\x64-windows\include\boost/chrono/thread_clock.hpp(68,1): warning C4103: alignment changed after including header, may be due to missing #pragma pack(pop)
#include <boost/config/abi_suffix.hpp> // pops abi_prefix.hpp pragmas
^
```
It looks like since https://github.com/boostorg/math/commit/f4e5abfbb1f2e3f1c07cb144a895620c8004e712 Boost Math drags in Chrono which guards some of its declarations with pragma packs ([this](https://github.com/boostorg/chrono/blob/5df12496f52e00b1ea324df176a4a3199d3d8bfd/include/boost/chrono/system_clocks.hpp#L84) [pushes](https://github.com/boostorg/config/blob/dc67f3ea657dc70fdd27af8c0c866feb6c335dfc/include/boost/config/abi/msvc_prefix.hpp#L16-L20) and [this](https://github.com/boostorg/chrono/blob/5df12496f52e00b1ea324df176a4a3199d3d8bfd/include/boost/chrono/system_clocks.hpp#L228) [pops](https://github.com/boostorg/config/blob/dc67f3ea657dc70fdd27af8c0c866feb6c335dfc/include/boost/config/abi/msvc_suffix.hpp#L6)). Since STL uses `/Zp8` flag, compiler complains that changes to packing are not popped on header boundaries. In practice Boost restores alignment properly, so I think ignoring these warnings is the right thing to do.

# Checklist

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [ ] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
