### PR TITLE
Implement fixes from D2091R0 "Issues with Range Access CPOs"

### DIFF
--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -2125,7 +2125,7 @@ namespace ranges {
                     static_assert(_Has_complete_elements<_Ty>,
                         "The range access customization point objects "
                         "std::ranges::begin, std::ranges::end, std::ranges::rbegin, and std::ranges::rend "
-                        "do not accept arrays of incomplete element types.");
+                        "do not accept arrays with incomplete element type.");
                     return {_St::_Array, true};
                 } else if constexpr (_Has_member<_Ty>) {
                     return {_St::_Member, noexcept(_Fake_decay_copy(_STD declval<_Ty>().begin()))};
@@ -2202,7 +2202,7 @@ namespace ranges {
                     static_assert(_Has_complete_elements<_UnRef>,
                         "The range access customization point objects "
                         "std::ranges::begin, std::ranges::end, std::ranges::rbegin, and std::ranges::rend "
-                        "do not accept arrays of incomplete element types.");
+                        "do not accept arrays with incomplete element type.");
                     if constexpr (extent_v<_UnRef> != 0) {
                         return {_St::_Array, true};
                     } else {

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -2076,12 +2076,12 @@ _NODISCARD _Ty _Fake_decay_copy(_Ty) noexcept;
 namespace ranges {
     // VARIABLE TEMPLATE _Has_complete_elements
     template <class>
-    static constexpr bool _Has_complete_elements = false;
+    inline constexpr bool _Has_complete_elements = false;
 
     // clang-format off
     template <class _Ty>
         requires requires(_Ty& __t) { sizeof(__t[0]); }
-    static constexpr bool _Has_complete_elements<_Ty> = true;
+    inline constexpr bool _Has_complete_elements<_Ty> = true;
     // clang-format on
 
     // VARIABLE TEMPLATE ranges::enable_safe_range
@@ -2125,7 +2125,7 @@ namespace ranges {
                     static_assert(_Has_complete_elements<_Ty>,
                         "The range access customization point objects "
                         "std::ranges::begin, std::ranges::end, std::ranges::rbegin, and std::ranges::rend "
-                        "do not accept arrays with incomplete element type.");
+                        "do not accept arrays with incomplete element types.");
                     return {_St::_Array, true};
                 } else if constexpr (_Has_member<_Ty>) {
                     return {_St::_Member, noexcept(_Fake_decay_copy(_STD declval<_Ty>().begin()))};
@@ -2202,7 +2202,7 @@ namespace ranges {
                     static_assert(_Has_complete_elements<_UnRef>,
                         "The range access customization point objects "
                         "std::ranges::begin, std::ranges::end, std::ranges::rbegin, and std::ranges::rend "
-                        "do not accept arrays with incomplete element type.");
+                        "do not accept arrays with incomplete element types.");
                     if constexpr (extent_v<_UnRef> != 0) {
                         return {_St::_Array, true};
                     } else {

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -600,11 +600,11 @@ namespace ranges {
     };
 
     namespace _Iter_move {
-        void iter_move(); // Block unqualified lookup
+        void iter_move(); // Block unqualified lookup per LWG-3247
 
         // clang-format off
         template <class _Ty>
-        concept _Has_ADL = _Has_class_or_enum_type<_Ty> // Per LWG-3270
+        concept _Has_ADL = _Has_class_or_enum_type<_Ty> // Per LWG-3299
             && requires(_Ty&& __t) { iter_move(static_cast<_Ty&&>(__t)); };
 
         template <class _Ty>
@@ -843,7 +843,7 @@ namespace ranges {
 
         // clang-format off
         template <class _Ty1, class _Ty2>
-        concept _Has_ADL = (_Has_class_or_enum_type<_Ty1> || _Has_class_or_enum_type<_Ty2>) // Per LWG-3270
+        concept _Has_ADL = (_Has_class_or_enum_type<_Ty1> || _Has_class_or_enum_type<_Ty2>) // Per LWG-3299
             && requires(_Ty1&& __t1, _Ty2&& __t2) {
                 iter_swap(static_cast<_Ty1&&>(__t1), static_cast<_Ty2&&>(__t2));
             };
@@ -2081,25 +2081,25 @@ namespace ranges {
     template <class _Rng>
     concept _Should_range_access = is_lvalue_reference_v<_Rng> || enable_safe_range<remove_cvref_t<_Rng>>;
 
-    // CUSTOMIZATION POINT OBJECT ranges::begin
+    // CUSTOMIZATION POINT OBJECT ranges::begin (Implements D2091R0)
     namespace _Begin {
 #ifndef __clang__ // TRANSITION, VSO-895622
         void begin();
 #endif // TRANSITION, VSO-895622
 
         template <class _Ty>
-        void begin(_Ty&&) = delete;
+        void begin(_Ty&) = delete;
         template <class _Ty>
-        void begin(initializer_list<_Ty>) = delete; // Per PR of LWG-3258
+        void begin(const _Ty&) = delete;
 
         // clang-format off
         template <class _Ty>
-        concept _Has_member = requires(_Ty& __t) {
+        concept _Has_member = requires(_Ty __t) {
             { _Fake_decay_copy(__t.begin()) } -> input_or_output_iterator;
         };
 
         template <class _Ty>
-        concept _Has_ADL = requires(_Ty& __t) {
+        concept _Has_ADL = _Has_class_or_enum_type<_Ty> && requires(_Ty __t) {
             { _Fake_decay_copy(begin(__t)) } -> input_or_output_iterator;
         };
         // clang-format on
@@ -2110,12 +2110,13 @@ namespace ranges {
 
             template <class _Ty>
             _NODISCARD static _CONSTEVAL _Choice_t<_St> _Choose() noexcept {
+                _STL_INTERNAL_CHECK(is_lvalue_reference_v<_Ty>);
                 if constexpr (is_array_v<remove_reference_t<_Ty>>) {
                     return {_St::_Array, true};
-                } else if constexpr (_Has_member<_Ty&>) {
-                    return {_St::_Member, noexcept(_Fake_decay_copy(_STD declval<_Ty&>().begin()))};
-                } else if constexpr (_Has_ADL<_Ty&>) {
-                    return {_St::_Non_member, noexcept(_Fake_decay_copy(begin(_STD declval<_Ty&>())))};
+                } else if constexpr (_Has_member<_Ty>) {
+                    return {_St::_Member, noexcept(_Fake_decay_copy(_STD declval<_Ty>().begin()))};
+                } else if constexpr (_Has_ADL<_Ty>) {
+                    return {_St::_Non_member, noexcept(_Fake_decay_copy(begin(_STD declval<_Ty>())))};
                 } else {
                     return {_St::_None};
                 }
@@ -2127,13 +2128,13 @@ namespace ranges {
         public:
             // clang-format off
             template <_Should_range_access _Ty>
-                requires (_Choice<_Ty>._Strategy != _St::_None)
-            _NODISCARD constexpr auto operator()(_Ty&& _Val) const noexcept(_Choice<_Ty>._No_throw) {
-                if constexpr (_Choice<_Ty>._Strategy == _St::_Array) {
+                requires (_Choice<_Ty&>._Strategy != _St::_None)
+            _NODISCARD constexpr auto operator()(_Ty&& _Val) const noexcept(_Choice<_Ty&>._No_throw) {
+                if constexpr (_Choice<_Ty&>._Strategy == _St::_Array) {
                     return _Val;
-                } else if constexpr (_Choice<_Ty>._Strategy == _St::_Member) {
+                } else if constexpr (_Choice<_Ty&>._Strategy == _St::_Member) {
                     return _Val.begin();
-                } else if constexpr (_Choice<_Ty>._Strategy == _St::_Non_member) {
+                } else if constexpr (_Choice<_Ty&>._Strategy == _St::_Non_member) {
                     return begin(_Val);
                 } else {
                     static_assert(_Always_false<_Ty>, "Should be unreachable");
@@ -2147,26 +2148,30 @@ namespace ranges {
         inline constexpr _Begin::_Cpo begin;
     }
 
-    // CUSTOMIZATION POINT OBJECT ranges::end
+    // ALIAS TEMPLATE ranges::iterator_t (Implements D2091R0)
+    template <class _Ty>
+    using iterator_t = decltype(_RANGES begin(_STD declval<_Ty&>()));
+
+    // CUSTOMIZATION POINT OBJECT ranges::end (Implements D2091R0)
     namespace _End {
 #ifndef __clang__ // TRANSITION, VSO-895622
         void end();
 #endif // TRANSITION, VSO-895622
 
         template <class _Ty>
-        void end(_Ty&&) = delete;
+        void end(_Ty&) = delete;
         template <class _Ty>
-        void end(initializer_list<_Ty>) = delete; // Per PR of LWG-3258
+        void end(const _Ty&) = delete;
 
         // clang-format off
         template <class _Ty>
-        concept _Has_member = requires(_Ty& __t) {
-            { _Fake_decay_copy(__t.end()) } -> sentinel_for<decltype(_RANGES begin(__t))>;
+        concept _Has_member = requires(_Ty __t) {
+            { _Fake_decay_copy(__t.end()) } -> sentinel_for<iterator_t<_Ty>>;
         };
 
         template <class _Ty>
-        concept _Has_ADL = requires(_Ty& __t) {
-            { _Fake_decay_copy(end(__t)) } -> sentinel_for<decltype(_RANGES begin(__t))>;
+        concept _Has_ADL = _Has_class_or_enum_type<_Ty> && requires(_Ty __t) {
+            { _Fake_decay_copy(end(__t)) } -> sentinel_for<iterator_t<_Ty>>;
         };
         // clang-format on
 
@@ -2176,12 +2181,19 @@ namespace ranges {
 
             template <class _Ty>
             _NODISCARD static _CONSTEVAL _Choice_t<_St> _Choose() noexcept {
-                if constexpr (is_array_v<remove_reference_t<_Ty>>) {
-                    return {_St::_Array, true};
-                } else if constexpr (_Has_member<_Ty&>) {
-                    return {_St::_Member, noexcept(_Fake_decay_copy(_STD declval<_Ty&>().end()))};
-                } else if constexpr (_Has_ADL<_Ty&>) {
-                    return {_St::_Non_member, noexcept(_Fake_decay_copy(end(_STD declval<_Ty&>())))};
+                _STL_INTERNAL_CHECK(is_lvalue_reference_v<_Ty>);
+                using _UnRef = remove_reference_t<_Ty>;
+
+                if constexpr (is_array_v<_UnRef>) {
+                    if constexpr (extent_v<_UnRef> != 0) {
+                        return {_St::_Array, true};
+                    } else {
+                        return {_St::_None};
+                    }
+                } else if constexpr (_Has_member<_Ty>) {
+                    return {_St::_Member, noexcept(_Fake_decay_copy(_STD declval<_Ty>().end()))};
+                } else if constexpr (_Has_ADL<_Ty>) {
+                    return {_St::_Non_member, noexcept(_Fake_decay_copy(end(_STD declval<_Ty>())))};
                 } else {
                     return {_St::_None};
                 }
@@ -2193,13 +2205,14 @@ namespace ranges {
         public:
             // clang-format off
             template <_Should_range_access _Ty>
-                requires (_Choice<_Ty>._Strategy != _St::_None)
-            _NODISCARD constexpr auto operator()(_Ty&& _Val) const noexcept(_Choice<_Ty>._No_throw) {
-                if constexpr (_Choice<_Ty>._Strategy == _St::_Array) {
-                    return _Val + extent_v<remove_reference_t<_Ty>>;
-                } else if constexpr (_Choice<_Ty>._Strategy == _St::_Member) {
+                requires (_Choice<_Ty&>._Strategy != _St::_None)
+            _NODISCARD constexpr auto operator()(_Ty&& _Val) const noexcept(_Choice<_Ty&>._No_throw) {
+                if constexpr (_Choice<_Ty&>._Strategy == _St::_Array) {
+                    // extent_v<remove_reference_t<_Ty&>> reuses specializations from _Choose
+                    return _Val + extent_v<remove_reference_t<_Ty&>>;
+                } else if constexpr (_Choice<_Ty&>._Strategy == _St::_Member) {
                     return _Val.end();
-                } else if constexpr (_Choice<_Ty>._Strategy == _St::_Non_member) {
+                } else if constexpr (_Choice<_Ty&>._Strategy == _St::_Non_member) {
                     return end(_Val);
                 } else {
                     static_assert(_Always_false<_Ty>, "should be unreachable");
@@ -2226,28 +2239,24 @@ namespace ranges {
     concept safe_range = range<_Rng> && _Should_range_access<_Rng>;
     // clang-format on
 
-    // ALIAS TEMPLATE ranges::iterator_t
-    template <range _Rng>
-    using iterator_t = decltype(_RANGES begin(_STD declval<_Rng&>()));
-
     // ALIAS TEMPLATE ranges::sentinel_t
     template <range _Rng>
     using sentinel_t = decltype(_RANGES end(_STD declval<_Rng&>()));
 
     // ALIAS TEMPLATE ranges::range_difference_t
-    template <class _Rng>
+    template <range _Rng>
     using range_difference_t = iter_difference_t<iterator_t<_Rng>>;
 
     // ALIAS TEMPLATE ranges::range_value_t
-    template <class _Rng>
+    template <range _Rng>
     using range_value_t = iter_value_t<iterator_t<_Rng>>;
 
     // ALIAS TEMPLATE ranges::range_reference_t
-    template <class _Rng>
+    template <range _Rng>
     using range_reference_t = iter_reference_t<iterator_t<_Rng>>;
 
     // ALIAS TEMPLATE ranges::range_rvalue_reference_t
-    template <class _Rng>
+    template <range _Rng>
     using range_rvalue_reference_t = iter_rvalue_reference_t<iterator_t<_Rng>>;
 
     // CUSTOMIZATION POINT OBJECT ranges::cbegin
@@ -2282,30 +2291,30 @@ namespace ranges {
         inline constexpr _Cend_fn cend;
     }
 
-    // CUSTOMIZATION POINT OBJECT ranges::rbegin
+    // CUSTOMIZATION POINT OBJECT ranges::rbegin (Implements D2091R0)
     namespace _Rbegin {
 #ifndef __clang__ // TRANSITION, VSO-895622
         void rbegin();
 #endif // TRANSITION, VSO-895622
 
         template <class _Ty>
-        void rbegin(_Ty&&) = delete;
+        void rbegin(_Ty&) = delete;
         template <class _Ty>
-        void rbegin(initializer_list<_Ty>) = delete; // Per PR of LWG-3258
+        void rbegin(const _Ty&) = delete;
 
         // clang-format off
         template <class _Ty>
-        concept _Has_member = requires(_Ty& __t) {
+        concept _Has_member = requires(_Ty __t) {
             { _Fake_decay_copy(__t.rbegin()) } -> input_or_output_iterator;
         };
 
         template <class _Ty>
-        concept _Has_ADL = requires(_Ty& __t) {
+        concept _Has_ADL = _Has_class_or_enum_type<_Ty> && requires(_Ty __t) {
             { _Fake_decay_copy(rbegin(__t)) } -> input_or_output_iterator;
         };
 
         template <class _Ty>
-        concept _Can_make_reverse = requires(_Ty& __t) {
+        concept _Can_make_reverse = requires(_Ty __t) {
             { _RANGES begin(__t) } -> bidirectional_iterator;
             { _RANGES end(__t) } -> same_as<decltype(_RANGES begin(__t))>;
         };
@@ -2317,13 +2326,13 @@ namespace ranges {
 
             template <class _Ty>
             _NODISCARD static _CONSTEVAL _Choice_t<_St> _Choose() noexcept {
-                if constexpr (_Has_member<_Ty&>) {
-                    return {_St::_Member, noexcept(_Fake_decay_copy(_STD declval<_Ty&>().rbegin()))};
-                } else if constexpr (_Has_ADL<_Ty&>) {
-                    return {_St::_Non_member, noexcept(_Fake_decay_copy(rbegin(_STD declval<_Ty&>())))};
-                } else if constexpr (_Can_make_reverse<_Ty&>) {
-                    return {
-                        _St::_Make_reverse, noexcept(_STD make_reverse_iterator(_RANGES end(_STD declval<_Ty&>())))};
+                _STL_INTERNAL_CHECK(is_lvalue_reference_v<_Ty>);
+                if constexpr (_Has_member<_Ty>) {
+                    return {_St::_Member, noexcept(_Fake_decay_copy(_STD declval<_Ty>().rbegin()))};
+                } else if constexpr (_Has_ADL<_Ty>) {
+                    return {_St::_Non_member, noexcept(_Fake_decay_copy(rbegin(_STD declval<_Ty>())))};
+                } else if constexpr (_Can_make_reverse<_Ty>) {
+                    return {_St::_Make_reverse, noexcept(_STD make_reverse_iterator(_RANGES end(_STD declval<_Ty>())))};
                 } else {
                     return {_St::_None};
                 }
@@ -2335,13 +2344,13 @@ namespace ranges {
         public:
             // clang-format off
             template <_Should_range_access _Ty>
-                requires (_Choice<_Ty>._Strategy != _St::_None)
-            _NODISCARD constexpr auto operator()(_Ty&& _Val) const noexcept(_Choice<_Ty>._No_throw) {
-                if constexpr (_Choice<_Ty>._Strategy == _St::_Member) {
+                requires (_Choice<_Ty&>._Strategy != _St::_None)
+            _NODISCARD constexpr auto operator()(_Ty&& _Val) const noexcept(_Choice<_Ty&>._No_throw) {
+                if constexpr (_Choice<_Ty&>._Strategy == _St::_Member) {
                     return _Val.rbegin();
-                } else if constexpr (_Choice<_Ty>._Strategy == _St::_Non_member) {
+                } else if constexpr (_Choice<_Ty&>._Strategy == _St::_Non_member) {
                     return rbegin(_Val);
-                } else if constexpr (_Choice<_Ty>._Strategy == _St::_Make_reverse) {
+                } else if constexpr (_Choice<_Ty&>._Strategy == _St::_Make_reverse) {
                     return _STD make_reverse_iterator(_RANGES end(_Val));
                 } else {
                     static_assert(_Always_false<_Ty>, "should be unreachable");
@@ -2355,30 +2364,30 @@ namespace ranges {
         inline constexpr _Rbegin::_Cpo rbegin;
     }
 
-    // CUSTOMIZATION POINT OBJECT ranges::rend
+    // CUSTOMIZATION POINT OBJECT ranges::rend (Implements D2091R0)
     namespace _Rend {
 #ifndef __clang__ // TRANSITION, VSO-895622
         void rend();
 #endif // TRANSITION, VSO-895622
 
         template <class _Ty>
-        void rend(_Ty&&) = delete;
+        void rend(_Ty&) = delete;
         template <class _Ty>
-        void rend(initializer_list<_Ty>) = delete; // Per PR of LWG-3258
+        void rend(const _Ty&) = delete;
 
         // clang-format off
         template <class _Ty>
-        concept _Has_member = requires(_Ty& __t) {
+        concept _Has_member = requires(_Ty __t) {
             { _Fake_decay_copy(__t.rend()) } -> sentinel_for<decltype(_RANGES rbegin(__t))>;
         };
 
         template <class _Ty>
-        concept _Has_ADL = requires(_Ty& __t) {
+        concept _Has_ADL = _Has_class_or_enum_type<_Ty> && requires(_Ty __t) {
             { _Fake_decay_copy(rend(__t)) } -> sentinel_for<decltype(_RANGES rbegin(__t))>;
         };
 
         template <class _Ty>
-        concept _Can_make_reverse = requires(_Ty& __t) {
+        concept _Can_make_reverse = requires(_Ty __t) {
             { _RANGES begin(__t) } -> bidirectional_iterator;
             { _RANGES end(__t) } -> same_as<decltype(_RANGES begin(__t))>;
         };
@@ -2390,13 +2399,14 @@ namespace ranges {
 
             template <class _Ty>
             _NODISCARD static _CONSTEVAL _Choice_t<_St> _Choose() noexcept {
-                if constexpr (_Has_member<_Ty&>) {
-                    return {_St::_Member, noexcept(_Fake_decay_copy(_STD declval<_Ty&>().rend()))};
-                } else if constexpr (_Has_ADL<_Ty&>) {
-                    return {_St::_Non_member, noexcept(_Fake_decay_copy(rend(_STD declval<_Ty&>())))};
-                } else if constexpr (_Can_make_reverse<_Ty&>) {
+                _STL_INTERNAL_CHECK(is_lvalue_reference_v<_Ty>);
+                if constexpr (_Has_member<_Ty>) {
+                    return {_St::_Member, noexcept(_Fake_decay_copy(_STD declval<_Ty>().rend()))};
+                } else if constexpr (_Has_ADL<_Ty>) {
+                    return {_St::_Non_member, noexcept(_Fake_decay_copy(rend(_STD declval<_Ty>())))};
+                } else if constexpr (_Can_make_reverse<_Ty>) {
                     return {
-                        _St::_Make_reverse, noexcept(_STD make_reverse_iterator(_RANGES begin(_STD declval<_Ty&>())))};
+                        _St::_Make_reverse, noexcept(_STD make_reverse_iterator(_RANGES begin(_STD declval<_Ty>())))};
                 } else {
                     return {_St::_None};
                 }
@@ -2408,13 +2418,13 @@ namespace ranges {
         public:
             // clang-format off
             template <_Should_range_access _Ty>
-                requires (_Choice<_Ty>._Strategy != _St::_None)
-            _NODISCARD constexpr auto operator()(_Ty&& _Val) const noexcept(_Choice<_Ty>._No_throw) {
-                if constexpr (_Choice<_Ty>._Strategy == _St::_Member) {
+                requires (_Choice<_Ty&>._Strategy != _St::_None)
+            _NODISCARD constexpr auto operator()(_Ty&& _Val) const noexcept(_Choice<_Ty&>._No_throw) {
+                if constexpr (_Choice<_Ty&>._Strategy == _St::_Member) {
                     return _Val.rend();
-                } else if constexpr (_Choice<_Ty>._Strategy == _St::_Non_member) {
+                } else if constexpr (_Choice<_Ty&>._Strategy == _St::_Non_member) {
                     return rend(_Val);
-                } else if constexpr (_Choice<_Ty>._Strategy == _St::_Make_reverse) {
+                } else if constexpr (_Choice<_Ty&>._Strategy == _St::_Make_reverse) {
                     return _STD make_reverse_iterator(_RANGES begin(_Val));
                 } else {
                     static_assert(_Always_false<_Ty>, "should be unreachable");
@@ -2464,28 +2474,30 @@ namespace ranges {
     template <class>
     inline constexpr bool disable_sized_range = false;
 
-    // CUSTOMIZATION POINT OBJECT ranges::size
+    // CUSTOMIZATION POINT OBJECT ranges::size (Implements D2091R0)
     namespace _Size {
 #ifndef __clang__ // TRANSITION, VSO-895622
         void size();
 #endif // TRANSITION, VSO-895622
 
         template <class _Ty>
-        void size(_Ty&&) = delete;
+        void size(_Ty&) = delete;
+        template <class _Ty>
+        void size(const _Ty&) = delete;
 
         // clang-format off
         template <class _Ty, class _UnCV>
-        concept _Has_member = !disable_sized_range<_UnCV> && requires(_Ty&& __t) {
-            { _Fake_decay_copy(static_cast<_Ty&&>(__t).size()) } -> integral;
+        concept _Has_member = !disable_sized_range<_UnCV> && requires(_Ty __t) {
+            { _Fake_decay_copy(__t.size()) } -> integral;
         };
 
         template <class _Ty, class _UnCV>
-        concept _Has_ADL = !disable_sized_range<_UnCV> && requires(_Ty&& __t) {
-            { _Fake_decay_copy(size(static_cast<_Ty&&>(__t))) } -> integral;
+        concept _Has_ADL = _Has_class_or_enum_type<_Ty> && !disable_sized_range<_UnCV> && requires(_Ty __t) {
+            { _Fake_decay_copy(size(__t)) } -> integral;
         };
 
         template <class _Ty>
-        concept _Can_difference = requires(_Ty&& __t) {
+        concept _Can_difference = requires(_Ty __t) {
             { _RANGES begin(__t) } -> forward_iterator;
             { _RANGES end(__t) } -> sized_sentinel_for<decltype(_RANGES begin(__t))>;
         };
@@ -2497,16 +2509,22 @@ namespace ranges {
 
             template <class _Ty>
             _NODISCARD static _CONSTEVAL _Choice_t<_St> _Choose() noexcept {
+                _STL_INTERNAL_CHECK(is_lvalue_reference_v<_Ty>);
                 using _UnCV = remove_cvref_t<_Ty>;
+
                 if constexpr (is_array_v<_UnCV>) {
-                    return {_St::_Array, true};
+                    if constexpr (extent_v<_UnCV> != 0) {
+                        return {_St::_Array, true};
+                    } else {
+                        return {_St::_None};
+                    }
                 } else if constexpr (_Has_member<_Ty, _UnCV>) {
                     return {_St::_Member, noexcept(_Fake_decay_copy(_STD declval<_Ty>().size()))};
                 } else if constexpr (_Has_ADL<_Ty, _UnCV>) {
                     return {_St::_Non_member, noexcept(_Fake_decay_copy(size(_STD declval<_Ty>())))};
                 } else if constexpr (_Can_difference<_Ty>) {
                     return {_St::_Subtract,
-                        noexcept(_RANGES end(_STD declval<_Ty&>()) - _RANGES begin(_STD declval<_Ty&>()))};
+                        noexcept(_RANGES end(_STD declval<_Ty>()) - _RANGES begin(_STD declval<_Ty>()))};
                 } else {
                     return {_St::_None};
                 }
@@ -2518,15 +2536,16 @@ namespace ranges {
         public:
             // clang-format off
             template <class _Ty>
-                requires (_Choice<_Ty>._Strategy != _St::_None)
-            _NODISCARD constexpr auto operator()([[maybe_unused]] _Ty&& _Val) const noexcept(_Choice<_Ty>._No_throw) {
-                if constexpr (_Choice<_Ty>._Strategy == _St::_Array) {
-                    return extent_v<remove_cvref_t<_Ty>>;
-                } else if constexpr (_Choice<_Ty>._Strategy == _St::_Member) {
-                    return static_cast<_Ty&&>(_Val).size();
-                } else if constexpr (_Choice<_Ty>._Strategy == _St::_Non_member) {
-                    return size(static_cast<_Ty&&>(_Val));
-                } else if constexpr (_Choice<_Ty>._Strategy == _St::_Subtract) {
+                requires (_Choice<_Ty&>._Strategy != _St::_None)
+            _NODISCARD constexpr auto operator()([[maybe_unused]] _Ty&& _Val) const noexcept(_Choice<_Ty&>._No_throw) {
+                if constexpr (_Choice<_Ty&>._Strategy == _St::_Array) {
+                    // extent_v<remove_cvref_t<_Ty&>> reuses specializations from _Choose
+                    return extent_v<remove_cvref_t<_Ty&>>;
+                } else if constexpr (_Choice<_Ty&>._Strategy == _St::_Member) {
+                    return _Val.size();
+                } else if constexpr (_Choice<_Ty&>._Strategy == _St::_Non_member) {
+                    return size(_Val);
+                } else if constexpr (_Choice<_Ty&>._Strategy == _St::_Subtract) {
                     const auto _Delta = _RANGES end(_Val) - _RANGES begin(_Val);
                     return static_cast<make_unsigned_t<remove_cv_t<decltype(_Delta)>>>(_Delta);
                 } else {
@@ -2541,21 +2560,21 @@ namespace ranges {
         inline constexpr _Size::_Cpo size;
     }
 
-    // CUSTOMIZATION POINT OBJECT ranges::empty
+    // CUSTOMIZATION POINT OBJECT ranges::empty (Implements D2091R0)
     namespace _Empty {
         // clang-format off
         template <class _Ty>
-        concept _Has_member = requires(_Ty&& __t) {
-            static_cast<bool>(static_cast<_Ty&&>(__t).empty());
+        concept _Has_member = requires(_Ty __t) {
+            static_cast<bool>(__t.empty());
         };
 
         template <class _Ty>
-        concept _Has_size = requires(_Ty&& __t) {
-            _RANGES size(static_cast<_Ty&&>(__t));
+        concept _Has_size = requires(_Ty __t) {
+            _RANGES size(__t);
         };
 
         template <class _Ty>
-        concept _Can_begin_end = requires(_Ty&& __t) {
+        concept _Can_begin_end = requires(_Ty __t) {
             { _RANGES begin(__t) } -> forward_iterator;
             _RANGES end(__t);
         };
@@ -2563,17 +2582,20 @@ namespace ranges {
 
         class _Cpo {
         private:
-            enum class _St { _None, _Member, _Size, _Compare };
+            enum class _St { _None, _Array, _Member, _Size, _Compare };
 
             template <class _Ty>
             _NODISCARD static _CONSTEVAL _Choice_t<_St> _Choose() noexcept {
-                if constexpr (_Has_member<_Ty>) {
+                _STL_INTERNAL_CHECK(is_lvalue_reference_v<_Ty>);
+                if constexpr (is_array_v<remove_reference_t<_Ty>>) {
+                    return {_St::_Array, true};
+                } else if constexpr (_Has_member<_Ty>) {
                     return {_St::_Member, noexcept(static_cast<bool>(_STD declval<_Ty>().empty()))};
                 } else if constexpr (_Has_size<_Ty>) {
                     return {_St::_Size, noexcept(_RANGES size(_STD declval<_Ty>()))};
                 } else if constexpr (_Can_begin_end<_Ty>) {
                     constexpr auto _Nothrow = noexcept(
-                        static_cast<bool>(_RANGES begin(_STD declval<_Ty&>()) == _RANGES end(_STD declval<_Ty&>())));
+                        static_cast<bool>(_RANGES begin(_STD declval<_Ty>()) == _RANGES end(_STD declval<_Ty>())));
                     return {_St::_Compare, _Nothrow};
                 } else {
                     return {_St::_None};
@@ -2586,13 +2608,15 @@ namespace ranges {
         public:
             // clang-format off
             template <class _Ty>
-                requires (_Choice<_Ty>._Strategy != _St::_None)
-            _NODISCARD constexpr bool operator()(_Ty&& _Val) const noexcept(_Choice<_Ty>._No_throw) {
-                if constexpr (_Choice<_Ty>._Strategy == _St::_Member) {
-                    return static_cast<bool>(static_cast<_Ty&&>(_Val).empty());
-                } else if constexpr (_Choice<_Ty>._Strategy == _St::_Size) {
-                    return _RANGES size(static_cast<_Ty&&>(_Val)) == 0;
-                } else if constexpr (_Choice<_Ty>._Strategy == _St::_Compare) {
+                requires (_Choice<_Ty&>._Strategy != _St::_None)
+            _NODISCARD constexpr bool operator()([[maybe_unused]] _Ty&& _Val) const noexcept(_Choice<_Ty&>._No_throw) {
+                if constexpr (_Choice<_Ty&>._Strategy == _St::_Array) {
+                    return false;
+                } else if constexpr (_Choice<_Ty&>._Strategy == _St::_Member) {
+                    return static_cast<bool>(_Val.empty());
+                } else if constexpr (_Choice<_Ty&>._Strategy == _St::_Size) {
+                    return _RANGES size(_Val) == 0;
+                } else if constexpr (_Choice<_Ty&>._Strategy == _St::_Compare) {
                     return static_cast<bool>(_RANGES begin(_Val) == _RANGES end(_Val));
                 } else {
                     static_assert(_Always_false<_Ty>, "should be unreachable");
@@ -2606,20 +2630,20 @@ namespace ranges {
         inline constexpr _Empty::_Cpo empty;
     }
 
-    // CUSTOMIZATION POINT OBJECT ranges::data
+    // CUSTOMIZATION POINT OBJECT ranges::data (Implements D2091R0)
     namespace _Data {
         // clang-format off
         template <class _Ty>
         concept _Points_to_object = is_pointer_v<_Ty> && is_object_v<remove_pointer_t<_Ty>>;
 
         template <class _Ty>
-        concept _Has_member = is_lvalue_reference_v<_Ty> && requires(_Ty& __t) {
+        concept _Has_member = requires(_Ty __t) {
             { _Fake_decay_copy(__t.data()) } -> _Points_to_object;
         };
 
         template <class _Ty>
-        concept _Has_contiguous_iterator = requires(_Ty&& __t) {
-            { _RANGES begin(static_cast<_Ty&&>(__t)) } -> contiguous_iterator;
+        concept _Has_contiguous_iterator = requires(_Ty __t) {
+            { _RANGES begin(__t) } -> contiguous_iterator;
         };
         // clang-format on
 
@@ -2629,8 +2653,9 @@ namespace ranges {
 
             template <class _Ty>
             _NODISCARD static _CONSTEVAL _Choice_t<_St> _Choose() noexcept {
+                _STL_INTERNAL_CHECK(is_lvalue_reference_v<_Ty>);
                 if constexpr (_Has_member<_Ty>) {
-                    return {_St::_Member, noexcept(_STD declval<_Ty&>().data())};
+                    return {_St::_Member, noexcept(_STD declval<_Ty>().data())};
                 } else if constexpr (_Has_contiguous_iterator<_Ty>) {
                     return {_St::_Address, noexcept(_STD to_address(_RANGES begin(_STD declval<_Ty>())))};
                 } else {
@@ -2643,13 +2668,13 @@ namespace ranges {
 
         public:
             // clang-format off
-            template <class _Ty>
-                requires (_Choice<_Ty>._Strategy != _St::_None)
-            _NODISCARD constexpr auto operator()(_Ty&& _Val) const noexcept(_Choice<_Ty>._No_throw) {
-                if constexpr (_Choice<_Ty>._Strategy == _St::_Member) {
+            template <_Should_range_access _Ty>
+                requires (_Choice<_Ty&>._Strategy != _St::_None)
+            _NODISCARD constexpr auto operator()(_Ty&& _Val) const noexcept(_Choice<_Ty&>._No_throw) {
+                if constexpr (_Choice<_Ty&>._Strategy == _St::_Member) {
                     return _Val.data();
-                } else if constexpr (_Choice<_Ty>._Strategy == _St::_Address) {
-                    return _STD to_address(_RANGES begin(static_cast<_Ty&&>(_Val)));
+                } else if constexpr (_Choice<_Ty&>._Strategy == _St::_Address) {
+                    return _STD to_address(_RANGES begin(_Val));
                 } else {
                     static_assert(_Always_false<_Ty>, "should be unreachable");
                 }

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -2074,6 +2074,16 @@ _NODISCARD _Ty _Fake_decay_copy(_Ty) noexcept;
 // (3) is non-throwing if and only if both conversion from decltype((E)) to T and destruction of T are non-throwing.
 
 namespace ranges {
+    // VARIABLE TEMPLATE _Has_complete_elements
+    template <class>
+    static constexpr bool _Has_complete_elements = false;
+
+    // clang-format off
+    template <class _Ty>
+        requires requires(_Ty& __t) { sizeof(__t[0]); }
+    static constexpr bool _Has_complete_elements<_Ty> = true;
+    // clang-format on
+
     // VARIABLE TEMPLATE ranges::enable_safe_range
     template <class>
     inline constexpr bool enable_safe_range = false;
@@ -2110,8 +2120,12 @@ namespace ranges {
 
             template <class _Ty>
             _NODISCARD static _CONSTEVAL _Choice_t<_St> _Choose() noexcept {
-                _STL_INTERNAL_CHECK(is_lvalue_reference_v<_Ty>);
+                _STL_INTERNAL_STATIC_ASSERT(is_lvalue_reference_v<_Ty>);
                 if constexpr (is_array_v<remove_reference_t<_Ty>>) {
+                    static_assert(_Has_complete_elements<_Ty>,
+                        "The range access customization point objects "
+                        "std::ranges::begin, std::ranges::end, std::ranges::rbegin, and std::ranges::rend "
+                        "do not accept arrays of incomplete element types.");
                     return {_St::_Array, true};
                 } else if constexpr (_Has_member<_Ty>) {
                     return {_St::_Member, noexcept(_Fake_decay_copy(_STD declval<_Ty>().begin()))};
@@ -2181,10 +2195,14 @@ namespace ranges {
 
             template <class _Ty>
             _NODISCARD static _CONSTEVAL _Choice_t<_St> _Choose() noexcept {
-                _STL_INTERNAL_CHECK(is_lvalue_reference_v<_Ty>);
+                _STL_INTERNAL_STATIC_ASSERT(is_lvalue_reference_v<_Ty>);
                 using _UnRef = remove_reference_t<_Ty>;
 
                 if constexpr (is_array_v<_UnRef>) {
+                    static_assert(_Has_complete_elements<_UnRef>,
+                        "The range access customization point objects "
+                        "std::ranges::begin, std::ranges::end, std::ranges::rbegin, and std::ranges::rend "
+                        "do not accept arrays of incomplete element types.");
                     if constexpr (extent_v<_UnRef> != 0) {
                         return {_St::_Array, true};
                     } else {
@@ -2326,7 +2344,7 @@ namespace ranges {
 
             template <class _Ty>
             _NODISCARD static _CONSTEVAL _Choice_t<_St> _Choose() noexcept {
-                _STL_INTERNAL_CHECK(is_lvalue_reference_v<_Ty>);
+                _STL_INTERNAL_STATIC_ASSERT(is_lvalue_reference_v<_Ty>);
                 if constexpr (_Has_member<_Ty>) {
                     return {_St::_Member, noexcept(_Fake_decay_copy(_STD declval<_Ty>().rbegin()))};
                 } else if constexpr (_Has_ADL<_Ty>) {
@@ -2399,7 +2417,7 @@ namespace ranges {
 
             template <class _Ty>
             _NODISCARD static _CONSTEVAL _Choice_t<_St> _Choose() noexcept {
-                _STL_INTERNAL_CHECK(is_lvalue_reference_v<_Ty>);
+                _STL_INTERNAL_STATIC_ASSERT(is_lvalue_reference_v<_Ty>);
                 if constexpr (_Has_member<_Ty>) {
                     return {_St::_Member, noexcept(_Fake_decay_copy(_STD declval<_Ty>().rend()))};
                 } else if constexpr (_Has_ADL<_Ty>) {
@@ -2509,7 +2527,7 @@ namespace ranges {
 
             template <class _Ty>
             _NODISCARD static _CONSTEVAL _Choice_t<_St> _Choose() noexcept {
-                _STL_INTERNAL_CHECK(is_lvalue_reference_v<_Ty>);
+                _STL_INTERNAL_STATIC_ASSERT(is_lvalue_reference_v<_Ty>);
                 using _UnCV = remove_cvref_t<_Ty>;
 
                 if constexpr (is_array_v<_UnCV>) {
@@ -2586,7 +2604,7 @@ namespace ranges {
 
             template <class _Ty>
             _NODISCARD static _CONSTEVAL _Choice_t<_St> _Choose() noexcept {
-                _STL_INTERNAL_CHECK(is_lvalue_reference_v<_Ty>);
+                _STL_INTERNAL_STATIC_ASSERT(is_lvalue_reference_v<_Ty>);
                 if constexpr (is_array_v<remove_reference_t<_Ty>>) {
                     return {_St::_Array, true};
                 } else if constexpr (_Has_member<_Ty>) {
@@ -2653,7 +2671,7 @@ namespace ranges {
 
             template <class _Ty>
             _NODISCARD static _CONSTEVAL _Choice_t<_St> _Choose() noexcept {
-                _STL_INTERNAL_CHECK(is_lvalue_reference_v<_Ty>);
+                _STL_INTERNAL_STATIC_ASSERT(is_lvalue_reference_v<_Ty>);
                 if constexpr (_Has_member<_Ty>) {
                     return {_St::_Member, noexcept(_STD declval<_Ty>().data())};
                 } else if constexpr (_Has_contiguous_iterator<_Ty>) {

--- a/stl/inc/yvals.h
+++ b/stl/inc/yvals.h
@@ -201,9 +201,11 @@ _STL_DISABLE_CLANG_WARNINGS
 #endif // _DEBUG
 
 #ifdef _ENABLE_STL_INTERNAL_CHECK
-#define _STL_INTERNAL_CHECK(cond) _STL_VERIFY(cond, "STL internal check: " _CRT_STRINGIZE(cond))
+#define _STL_INTERNAL_CHECK(...)         _STL_VERIFY(__VA_ARGS__, "STL internal check: " #__VA_ARGS__)
+#define _STL_INTERNAL_STATIC_ASSERT(...) static_assert(__VA_ARGS__, #__VA_ARGS__)
 #else // ^^^ _ENABLE_STL_INTERNAL_CHECK ^^^ // vvv !_ENABLE_STL_INTERNAL_CHECK vvv
-#define _STL_INTERNAL_CHECK(cond) _Analysis_assume_(cond)
+#define _STL_INTERNAL_CHECK(...) _Analysis_assume_(__VA_ARGS__)
+#define _STL_INTERNAL_STATIC_ASSERT(...)
 #endif // _ENABLE_STL_INTERNAL_CHECK
 
 #include <use_ansi.h>


### PR DESCRIPTION
# Description

* Pre-existing: Correctly annotate implementations of outstanding `iter_move` LWG issues. LWG-3247 was not annotated, and LWG-3299 incorrectly annotated as LWG-3270 (the number had to be changed after submission).

* Remove the `initializer_list` poison pills for `ranges::begin`, `ranges::end`, `ranges::rbegin`, and `ranges::rend`. They were necessary only to prevent `initializer_list` from inadvertently opting-in to forwarding-range, and P1870R1 "forwarding-range<T> is too subtle" changed the opt-in.

* Always perform lookups for lvalues in `ranges::size`, `ranges::empty`, and `ranges::data` as is already the case for `ranges::begin`, `ranges::end`, `ranges::rbegin`, and `ranges::rend` post-P1870, which makes the CPOs easier to reason about and reduces template instantiations.

* Replace forwarding-reference poison pills with pairs of lvalue/const lvalue poison pills for `ranges::begin`, `ranges::end`, `ranges::rbegin`, `ranges::rend`, and `ranges::size`; the forwarding-reference versions are insufficiently poisonous and allow calls to plain `meow(auto&)`/`meow(const auto&)` templates.

* Only perform ADL probes in `ranges::begin`, `ranges::end`, `ranges::rbegin`, `ranges::rend`, and `ranges::size` for argument expressions of class or enumeration type.

* `ranges::begin`, `ranges::empty`, `ranges::data` accept (lvalue) arrays of unknown bound; `ranges::end` (and consequently `ranges::rbegin` and `ranges::rend`) rejects. Remove `range` constraint from `iterator_t`, so it works with (non-`range`) arrays of unknown bound. Add `range` constraints to the `range_meow_t` "compound" associated type traits, since they no longer get it from `iterator_t`.

[d2091r0.pdf](https://github.com/microsoft/STL/files/4099776/d2091r0.pdf)

[This is a dual of the internal MSVC-PR-224247.]

# Checklist

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [x] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
