### PR TITLE
Specific specialmath

### DIFF
--- a/stl/src/special_math.cpp
+++ b/stl/src/special_math.cpp
@@ -17,8 +17,17 @@
 #define BOOST_MATH_DOMAIN_ERROR_POLICY   errno_on_error
 #define BOOST_MATH_OVERFLOW_ERROR_POLICY ignore_error
 
-// Using headers from Boost.Math 1.66.0
-#include <boost/math/special_functions.hpp>
+// Using headers from Boost.Math
+#include <boost/math/special_functions/bessel.hpp>
+#include <boost/math/special_functions/beta.hpp>
+#include <boost/math/special_functions/ellint_1.hpp>
+#include <boost/math/special_functions/ellint_2.hpp>
+#include <boost/math/special_functions/ellint_3.hpp>
+#include <boost/math/special_functions/expint.hpp>
+#include <boost/math/special_functions/hermite.hpp>
+#include <boost/math/special_functions/laguerre.hpp>
+#include <boost/math/special_functions/legendre.hpp>
+#include <boost/math/special_functions/spherical_harmonic.hpp>
 #include <boost/math/tools/config.hpp>
 #include <boost/math/tools/precision.hpp>
 

--- a/stl/src/special_math.cpp
+++ b/stl/src/special_math.cpp
@@ -28,6 +28,7 @@
 #include <boost/math/special_functions/laguerre.hpp>
 #include <boost/math/special_functions/legendre.hpp>
 #include <boost/math/special_functions/spherical_harmonic.hpp>
+#include <boost/math/special_functions/zeta.hpp>
 #include <boost/math/tools/config.hpp>
 #include <boost/math/tools/precision.hpp>
 


### PR DESCRIPTION
# Description
This fixes the build with boost 1.72, same as #428, however it does so by simply not including the problematic header from upstream boost.


# Checklist

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [ ] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
