### PR TITLE
Build only required vcpkg ports in CI

### DIFF
--- a/azure-devops/run_build.yml
+++ b/azure-devops/run_build.yml
@@ -20,11 +20,11 @@ jobs:
       inputs:
         targetType: filePath
         filePath: $(Build.SourcesDirectory)/azure-devops/install_msvc_preview.ps1
-    - task: CacheBeta@0
+    - task: Cache@2
       displayName: Cache vcpkg
       timeoutInMinutes: 10
       inputs:
-        key: $(vcpkgResponseFile) | $(Build.SourcesDirectory)/.git/modules/vcpkg/HEAD
+        key: '"${{ parameters.targetPlatform}}" | $(Build.SourcesDirectory)/.git/modules/vcpkg/HEAD'
         path: '$(vcpkgLocation)'
     - task: run-vcpkg@0
       displayName: 'Run vcpkg to Install boost-build'
@@ -36,7 +36,7 @@ jobs:
       displayName: 'Run vcpkg'
       timeoutInMinutes: 10
       inputs:
-        vcpkgArguments: '@$(vcpkgResponseFile)'
+        vcpkgArguments: 'boost-math:${{ parameters.targetPlatform }}-windows'
         vcpkgDirectory: '$(vcpkgLocation)'
         vcpkgTriplet: ${{ parameters.targetPlatform }}-windows
     - task: run-cmake@0

--- a/azure-devops/run_build.yml
+++ b/azure-devops/run_build.yml
@@ -28,7 +28,7 @@ jobs:
         cacheHitVar: CACHE_RESTORED
     - task: run-vcpkg@0
       displayName: 'Run vcpkg to Install boost-build'
-      condition: ne(variables.CACHE_RESTORED, 'true')
+      condition: and(ne(variables.CACHE_RESTORED, 'true'), contains('${{ parameters.targetPlatform }}', 'arm'))
       timeoutInMinutes: 10
       inputs:
         vcpkgArguments: 'boost-build:x86-windows'
@@ -38,7 +38,14 @@ jobs:
       condition: ne(variables.CACHE_RESTORED, 'true')
       timeoutInMinutes: 10
       inputs:
-        vcpkgArguments: 'boost-math:${{ parameters.targetPlatform }}-windows'
+        vcpkgArguments: 'boost-math'
+        vcpkgDirectory: '$(vcpkgLocation)'
+        vcpkgTriplet: ${{ parameters.targetPlatform }}-windows
+    - task: run-vcpkg@0
+      displayName: 'Set RUNVCPKG_VCPKG_ROOT'
+      condition: eq(variables.CACHE_RESTORED, 'true')
+      inputs:
+        vcpkgArguments: ''
         vcpkgDirectory: '$(vcpkgLocation)'
         vcpkgTriplet: ${{ parameters.targetPlatform }}-windows
     - task: run-cmake@0

--- a/azure-devops/run_build.yml
+++ b/azure-devops/run_build.yml
@@ -25,14 +25,17 @@ jobs:
       inputs:
         key: '"${{ parameters.targetPlatform }}" | $(Build.SourcesDirectory)/.git/modules/vcpkg/HEAD'
         path: '$(vcpkgLocation)'
+        cacheHitVar: CACHE_RESTORED
     - task: run-vcpkg@0
       displayName: 'Run vcpkg to Install boost-build'
+      condition: ne(variables.CACHE_RESTORED, 'true')
       timeoutInMinutes: 10
       inputs:
         vcpkgArguments: 'boost-build:x86-windows'
         vcpkgDirectory: '$(vcpkgLocation)'
     - task: run-vcpkg@0
       displayName: 'Run vcpkg'
+      condition: ne(variables.CACHE_RESTORED, 'true')
       timeoutInMinutes: 10
       inputs:
         vcpkgArguments: 'boost-math:${{ parameters.targetPlatform }}-windows'

--- a/azure-devops/run_build.yml
+++ b/azure-devops/run_build.yml
@@ -24,7 +24,7 @@ jobs:
       displayName: Cache vcpkg
       timeoutInMinutes: 10
       inputs:
-        key: '"${{ parameters.targetPlatform}}" | $(Build.SourcesDirectory)/.git/modules/vcpkg/HEAD'
+        key: '"${{ parameters.targetPlatform }}" | $(Build.SourcesDirectory)/.git/modules/vcpkg/HEAD'
         path: '$(vcpkgLocation)'
     - task: run-vcpkg@0
       displayName: 'Run vcpkg to Install boost-build'

--- a/azure-devops/run_build.yml
+++ b/azure-devops/run_build.yml
@@ -8,7 +8,6 @@ jobs:
 
   variables:
     vcpkgLocation: '$(Build.SourcesDirectory)/vcpkg'
-    vcpkgResponseFile: $(Build.SourcesDirectory)/azure-devops/vcpkg_windows.txt
   steps:
     - checkout: self
       submodules: recursive

--- a/azure-devops/run_build.yml
+++ b/azure-devops/run_build.yml
@@ -35,17 +35,9 @@ jobs:
         vcpkgDirectory: '$(vcpkgLocation)'
     - task: run-vcpkg@0
       displayName: 'Run vcpkg'
-      condition: ne(variables.CACHE_RESTORED, 'true')
       timeoutInMinutes: 10
       inputs:
         vcpkgArguments: 'boost-math'
-        vcpkgDirectory: '$(vcpkgLocation)'
-        vcpkgTriplet: ${{ parameters.targetPlatform }}-windows
-    - task: run-vcpkg@0
-      displayName: 'Set RUNVCPKG_VCPKG_ROOT'
-      condition: eq(variables.CACHE_RESTORED, 'true')
-      inputs:
-        vcpkgArguments: ''
         vcpkgDirectory: '$(vcpkgLocation)'
         vcpkgTriplet: ${{ parameters.targetPlatform }}-windows
     - task: run-cmake@0

--- a/azure-devops/run_build.yml
+++ b/azure-devops/run_build.yml
@@ -28,7 +28,7 @@ jobs:
         cacheHitVar: CACHE_RESTORED
     - task: run-vcpkg@0
       displayName: 'Run vcpkg to Install boost-build'
-      condition: and(ne(variables.CACHE_RESTORED, 'true'), not(contains('${{ parameters.targetPlatform }}', 'arm')))
+      condition: and(ne(variables.CACHE_RESTORED, 'true'), contains('${{ parameters.targetPlatform }}', 'arm'))
       timeoutInMinutes: 10
       inputs:
         vcpkgArguments: 'boost-build:x86-windows'

--- a/azure-devops/run_build.yml
+++ b/azure-devops/run_build.yml
@@ -28,7 +28,7 @@ jobs:
         cacheHitVar: CACHE_RESTORED
     - task: run-vcpkg@0
       displayName: 'Run vcpkg to Install boost-build'
-      condition: and(ne(variables.CACHE_RESTORED, 'true'), contains('${{ parameters.targetPlatform }}', 'arm'))
+      condition: and(ne(variables.CACHE_RESTORED, 'true'), not(contains('${{ parameters.targetPlatform }}', 'arm')))
       timeoutInMinutes: 10
       inputs:
         vcpkgArguments: 'boost-build:x86-windows'

--- a/azure-devops/vcpkg_windows.txt
+++ b/azure-devops/vcpkg_windows.txt
@@ -1,5 +1,0 @@
-boost-build:x86-windows
-boost-math:x86-windows
-boost-math:x64-windows
-boost-math:arm-windows
-boost-math:arm64-windows


### PR DESCRIPTION
# Description

Currently the CI builds `boost-math` for all possible target architectures as opposed to just the target architecture being tested in a given job. This PR resolves that.

# Checklist

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [ ] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
