### PR TITLE
Fix #224: static_assert is_sorted().

### DIFF
--- a/stl/src/winapinls.cpp
+++ b/stl/src/winapinls.cpp
@@ -5,8 +5,10 @@
 
 #if _STL_WIN32_WINNT < _WIN32_WINNT_VISTA
 
+#include <algorithm>
 #include <ctype.h>
 #include <stdlib.h>
+#include <string_view>
 
 namespace {
     struct LCIDTOLOCALENAME {
@@ -255,6 +257,9 @@ namespace {
     };
     // clang-format on
 
+    static_assert(_STD is_sorted(_STD begin(LcidToLocaleNameTable), _STD end(LcidToLocaleNameTable),
+        [](const auto& left, const auto& right) { return left.lcid < right.lcid; }));
+
     // Map of locale name to an index in LcidToLocaleNameTable, for Windows XP.
     // Data in this table has been obtained from National Language Support (NLS) API Reference.
     // The table is sorted to improve search performance.
@@ -490,6 +495,13 @@ namespace {
         { L"zu-za"      , 112 },
     };
     // clang-format on
+
+    // This static_assert is case-sensitive, which is more than sufficient for the case-insensitive runtime lookups.
+    static_assert(_STD is_sorted(
+        _STD begin(LocaleNameToIndexTable), _STD end(LocaleNameToIndexTable), [](const auto& left, const auto& right) {
+            return _STD wstring_view{left.name} < _STD wstring_view{right.name};
+        }));
+
 } // unnamed namespace
 
 // __wcsnicmp_ascii


### PR DESCRIPTION
# Description

Now that #6 has been implemented, we can fix #224 by `static_assert`ing `is_sorted()` for lookup tables. This guarantees safety with zero runtime cost.

# Checklist

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [x] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
