### PR TITLE
Fix #345: Remove warning C4265 (non-virtual destructor) suppressions.

### DIFF
--- a/stl/inc/functional
+++ b/stl/inc/functional
@@ -772,8 +772,6 @@ bool _Test_callable(const _Ty& _Arg) noexcept { // determine whether std::functi
 }
 #endif // _HAS_IF_CONSTEXPR
 
-#pragma warning(push)
-#pragma warning(disable : 4265) // class has virtual functions, but destructor is not virtual (/Wall)
 // CLASS TEMPLATE _Func_base
 template <class _Rx, class... _Types>
 class __declspec(novtable) _Func_base { // abstract base for implementation types
@@ -798,16 +796,12 @@ public:
 private:
     virtual const void* _Get() const noexcept = 0;
 };
-#pragma warning(pop)
 
 // ALIAS TEMPLATE _Is_large
 constexpr size_t _Space_size = (_Small_object_num_ptrs - 1) * sizeof(void*);
 
 template <class _Impl> // determine whether _Impl must be dynamically allocated
 _INLINE_VAR constexpr bool _Is_large = (_Space_size < sizeof(_Impl)) || !_Impl::_Nothrow_move::value;
-
-#pragma warning(push)
-#pragma warning(disable : 4265) // class has virtual functions, but destructor is not virtual (/Wall)
 
 #if _HAS_FUNCTION_ALLOCATOR_SUPPORT
 // CLASS TEMPLATE _Func_impl
@@ -947,7 +941,6 @@ private:
 
     _Callable _Callee;
 };
-#pragma warning(pop)
 
 // TRANSITION, Visual Studio 2019 16.5 + CUDA
 #if (defined(_MSC_VER) && _MSC_VER < 1925) || defined(__CUDACC__)

--- a/stl/src/primitives.h
+++ b/stl/src/primitives.h
@@ -43,8 +43,6 @@ namespace Concurrency {
             virtual void destroy()                                               = 0;
         };
 
-#pragma warning(push)
-#pragma warning(disable : 4265) // non-virtual destructor in base class
         class stl_critical_section_vista final : public stl_critical_section_interface {
         public:
             stl_critical_section_vista() {
@@ -264,8 +262,6 @@ namespace Concurrency {
         };
 
 #endif // _STL_CONCRT_SUPPORT
-
-#pragma warning(pop)
 
         inline bool are_win7_sync_apis_available() {
 #if _STL_WIN32_WINNT >= _WIN32_WINNT_WIN7

--- a/stl/src/special_math.cpp
+++ b/stl/src/special_math.cpp
@@ -8,7 +8,6 @@
 #include <utility>
 
 #pragma warning(push)
-#pragma warning(disable : 4265) // '%s': class has virtual functions, but destructor is not virtual
 #pragma warning(disable : 4619) // #pragma warning: there is no warning number '%d'
 #pragma warning(disable : 4643) // Forward declaring '%s' in namespace std is not permitted by the C++ Standard
 #pragma warning(disable : 4702) // unreachable code


### PR DESCRIPTION
# Description

Now that VS 2019 16.5 Preview 2 is available, we can fix #345 by removing warning suppressions where the compiler won't warn anymore. The suppressions for external code in WRL are still necessary.

# Checklist

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [x] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
