### PR TITLE
Update for VS 2019 16.5 Preview 2 and N4849.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ issue. The [bug tag][] and [enhancement tag][] are being populated.
 
 # Goals
 
-We're implementing the latest C++ Working Draft, currently [N4842][], which will eventually become the next C++
+We're implementing the latest C++ Working Draft, currently [N4849][], which will eventually become the next C++
 International Standard (which is sometimes referred to as C++2a, but we optimistically refer to it as C++20). The terms
 Working Draft (WD) and Working Paper (WP) are interchangeable; we often informally refer to these drafts as "the
 Standard" while being aware of the difference. (There are other relevant Standards; for example, supporting `/std:c++14`
@@ -139,7 +139,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 The STL uses boost-math headers to provide P0226R1 Mathematical Special Functions. We recommend using [vcpkg][] to
 acquire this dependency.
 
-1. Install Visual Studio 2019 16.4 or later.
+1. Install Visual Studio 2019 16.5 Preview 2 or later.
 2. Invoke `git clone https://github.com/microsoft/vcpkg`
 3. Invoke `cd vcpkg`
 4. Invoke `.\bootstrap-vcpkg.bat`
@@ -158,7 +158,7 @@ acquire this dependency.
 These instructions assume you're targeting `x64-windows`; you can change this constant below to target other
 architectures.
 
-1. Install [CMake][] 3.15 or later, [Ninja][] 1.8.2 or later, and Visual Studio 2019 16.4 or later.
+1. Install [CMake][] 3.15 or later, [Ninja][] 1.8.2 or later, and Visual Studio 2019 16.5 Preview 2 or later.
 2. Invoke `git clone https://github.com/microsoft/vcpkg`
 3. Invoke `cd vcpkg`
 4. Invoke `.\bootstrap-vcpkg.bat`
@@ -258,7 +258,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 [LWG issues]: https://cplusplus.github.io/LWG/lwg-toc.html
 [LWG tag]: https://github.com/microsoft/STL/issues?q=is%3Aopen+is%3Aissue+label%3ALWG
 [Microsoft Open Source Code of Conduct]: https://opensource.microsoft.com/codeofconduct/
-[N4842]: https://wg21.link/n4842
+[N4849]: https://wg21.link/n4849
 [NOTICE.txt]: NOTICE.txt
 [Ninja]: https://ninja-build.org
 [Pipelines]: https://dev.azure.com/vclibs/STL/_build/latest?definitionId=2&branchName=master

--- a/stl/inc/compare
+++ b/stl/inc/compare
@@ -21,119 +21,14 @@ _STL_DISABLE_CLANG_WARNINGS
 #pragma push_macro("new")
 #undef new
 
-// TRANSITION, toolset update AND Visual Studio 2019 16.5 Preview 2 release
-#if defined(__clang__) || defined(__EDG__) || (defined(_MSC_VER) && defined(__cpp_impl_p1959r0))
-#define _HAS_EQUALITY_COMPARISON_CATEGORIES 0
-#else // ^^^ implements P1959R0 / doesn't implement P1959R0 vvv
-#define _HAS_EQUALITY_COMPARISON_CATEGORIES 1
-#endif // ^^^ doesn't implement P1959R0 ^^^
-
 _STD_BEGIN
 using _Literal_zero = decltype(nullptr);
 using _Compare_t    = signed char;
 
 // These "pretty" enumerator names are safe since they reuse names of user-facing entities.
-enum class _Compare_eq : _Compare_t { equal = 0, equivalent = equal, _Nonequal = 1, _Nonequivalent = _Nonequal };
+enum class _Compare_eq : _Compare_t { equal = 0, equivalent = equal };
 enum class _Compare_ord : _Compare_t { less = -1, greater = 1 };
 enum class _Compare_ncmp : _Compare_t { unordered = -127 };
-
-#if _HAS_EQUALITY_COMPARISON_CATEGORIES
-// CLASS weak_equality
-class weak_equality {
-public:
-    _NODISCARD constexpr explicit weak_equality(const _Compare_eq _Value_) noexcept
-        : _Value(static_cast<_Compare_t>(_Value_)) {}
-
-    static const weak_equality equivalent;
-    static const weak_equality nonequivalent;
-
-    _NODISCARD friend constexpr bool operator==(const weak_equality _Val, _Literal_zero) noexcept {
-        return _Val._Value == 0;
-    }
-
-#if defined(__cpp_impl_three_way_comparison) && __cpp_impl_three_way_comparison >= 201902L
-    _NODISCARD friend constexpr bool operator==(const weak_equality&, const weak_equality&) noexcept = default;
-
-    _NODISCARD friend constexpr weak_equality operator<=>(const weak_equality _Val, _Literal_zero) noexcept {
-        return _Val;
-    }
-
-    _NODISCARD friend constexpr weak_equality operator<=>(_Literal_zero, const weak_equality _Val) noexcept {
-        return _Val;
-    }
-#else // ^^^ supports <=> and P1185 / supports neither vvv
-    _NODISCARD friend constexpr bool operator!=(const weak_equality _Val, _Literal_zero) noexcept {
-        return _Val._Value != 0;
-    }
-
-    _NODISCARD friend constexpr bool operator==(_Literal_zero, const weak_equality _Val) noexcept {
-        return _Val._Value == 0;
-    }
-
-    _NODISCARD friend constexpr bool operator!=(_Literal_zero, const weak_equality _Val) noexcept {
-        return _Val._Value != 0;
-    }
-#endif // defined(__cpp_impl_three_way_comparison) && __cpp_impl_three_way_comparison >= 201902L
-
-private:
-    _Compare_t _Value;
-};
-
-inline constexpr weak_equality weak_equality::equivalent(_Compare_eq::equivalent);
-inline constexpr weak_equality weak_equality::nonequivalent(_Compare_eq::_Nonequivalent);
-
-// CLASS strong_equality
-class strong_equality {
-public:
-    _NODISCARD constexpr explicit strong_equality(const _Compare_eq _Value_) noexcept
-        : _Value(static_cast<_Compare_t>(_Value_)) {}
-
-    static const strong_equality equal;
-    static const strong_equality nonequal;
-    static const strong_equality equivalent;
-    static const strong_equality nonequivalent;
-
-    constexpr operator weak_equality() const noexcept {
-        return weak_equality{static_cast<_Compare_eq>(_Value != 0)};
-    }
-
-    _NODISCARD friend constexpr bool operator==(const strong_equality _Val, _Literal_zero) noexcept {
-        return _Val._Value == 0;
-    }
-
-#if defined(__cpp_impl_three_way_comparison) && __cpp_impl_three_way_comparison >= 201902L
-    _NODISCARD friend constexpr bool operator==(const strong_equality&, const strong_equality&) noexcept = default;
-
-    _NODISCARD friend constexpr strong_equality operator<=>(const strong_equality _Val, _Literal_zero) noexcept {
-        return _Val;
-    }
-
-    _NODISCARD friend constexpr strong_equality operator<=>(_Literal_zero, const strong_equality _Val) noexcept {
-        return _Val;
-    }
-#else // ^^^ supports <=> and P1185 / supports neither vvv
-    _NODISCARD friend constexpr bool operator!=(const strong_equality _Val, _Literal_zero) noexcept {
-        return _Val._Value != 0;
-    }
-
-    _NODISCARD friend constexpr bool operator==(_Literal_zero, const strong_equality _Val) noexcept {
-        return _Val._Value == 0;
-    }
-
-    _NODISCARD friend constexpr bool operator!=(_Literal_zero, const strong_equality _Val) noexcept {
-        return _Val._Value != 0;
-    }
-#endif // defined(__cpp_impl_three_way_comparison) && __cpp_impl_three_way_comparison >= 201902L
-
-private:
-    _Compare_t _Value;
-};
-
-inline constexpr strong_equality strong_equality::equal(_Compare_eq::equal);
-inline constexpr strong_equality strong_equality::nonequal(_Compare_eq::_Nonequal);
-inline constexpr strong_equality strong_equality::equivalent(_Compare_eq::equivalent);
-inline constexpr strong_equality strong_equality::nonequivalent(_Compare_eq::_Nonequivalent);
-#endif // _HAS_EQUALITY_COMPARISON_CATEGORIES
 
 // CLASS partial_ordering
 class partial_ordering {
@@ -149,12 +44,6 @@ public:
     static const partial_ordering equivalent;
     static const partial_ordering greater;
     static const partial_ordering unordered;
-
-#if _HAS_EQUALITY_COMPARISON_CATEGORIES
-    constexpr operator weak_equality() const noexcept {
-        return weak_equality{static_cast<_Compare_eq>(_Value != 0)};
-    }
-#endif // _HAS_EQUALITY_COMPARISON_CATEGORIES
 
     _NODISCARD friend constexpr bool operator==(const partial_ordering _Val, _Literal_zero) noexcept {
         return _Val._Is_ordered && _Val._Value == 0;
@@ -239,12 +128,6 @@ public:
     static const weak_ordering less;
     static const weak_ordering equivalent;
     static const weak_ordering greater;
-
-#if _HAS_EQUALITY_COMPARISON_CATEGORIES
-    constexpr operator weak_equality() const noexcept {
-        return weak_equality{static_cast<_Compare_eq>(_Value != 0)};
-    }
-#endif // _HAS_EQUALITY_COMPARISON_CATEGORIES
 
     constexpr operator partial_ordering() const noexcept {
         return partial_ordering{static_cast<_Compare_ord>(_Value)};
@@ -332,16 +215,6 @@ public:
     static const strong_ordering equal;
     static const strong_ordering equivalent;
     static const strong_ordering greater;
-
-#if _HAS_EQUALITY_COMPARISON_CATEGORIES
-    constexpr operator weak_equality() const noexcept {
-        return weak_equality{static_cast<_Compare_eq>(_Value != 0)};
-    }
-
-    constexpr operator strong_equality() const noexcept {
-        return strong_equality{static_cast<_Compare_eq>(_Value != 0)};
-    }
-#endif // _HAS_EQUALITY_COMPARISON_CATEGORIES
 
     constexpr operator partial_ordering() const noexcept {
         return partial_ordering{static_cast<_Compare_ord>(_Value)};

--- a/stl/inc/functional
+++ b/stl/inc/functional
@@ -949,12 +949,11 @@ private:
 };
 #pragma warning(pop)
 
-// TRANSITION, Visual Studio 2019 16.5 + CUDA
-#if (defined(_MSC_VER) && _MSC_VER < 1925) || defined(__CUDACC__)
+#ifdef __CUDACC__ // TRANSITION, CUDA
 #define _USE_FUNCTION_INT_0_SFINAE 0
 #else
 #define _USE_FUNCTION_INT_0_SFINAE 1
-#endif // (defined(_MSC_VER) && _MSC_VER < 1925) || defined(__CUDACC__)
+#endif // __CUDACC__
 
 // CLASS TEMPLATE _Func_class
 template <class _Ret, class... _Types>


### PR DESCRIPTION
# Description

Now that VS 2019 16.5 Preview 2 is available, in addition to #430, we can remove a couple of workarounds. We also need to update the README's instructions, for VS and the new WP WG21-N4849.

# Checklist

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [x] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
