### PR TITLE
Enable more clang-format.

### DIFF
--- a/stl/inc/iso646.h
+++ b/stl/inc/iso646.h
@@ -10,7 +10,6 @@
 #if _STL_COMPILER_PREPROCESSOR
 
 #if !defined(__cplusplus) || defined(_MSC_EXTENSIONS)
-// clang-format off
 #define and &&
 #define and_eq &=
 #define bitand &
@@ -22,7 +21,6 @@
 #define or_eq |=
 #define xor ^
 #define xor_eq ^=
-// clang-format on
 #endif // !defined(__cplusplus) || defined(_MSC_EXTENSIONS)
 #endif // _STL_COMPILER_PREPROCESSOR
 #endif // _ISO646

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -4095,18 +4095,15 @@ struct _Is_character_or_byte<byte> : true_type {};
 #endif // _HAS_STD_BYTE
 
 // _Fill_memset_is_safe determines if _FwdIt and _Ty are eligible for memset optimization in fill
-// clang-format off
 template <class _FwdIt, class _Ty, bool = is_pointer_v<_FwdIt>>
-_INLINE_VAR constexpr bool _Fill_memset_is_safe =
-    conjunction_v<
-        disjunction<
-            conjunction<_Is_character_or_byte<_Unwrap_enum_t<_Ty>>, _Is_character_or_byte<_Unwrap_enum_t<_Iter_value_t<_FwdIt>>>>,
-            conjunction<is_same<bool, _Unwrap_enum_t<_Ty>>, is_same<bool, _Unwrap_enum_t<_Iter_value_t<_FwdIt>>>>>,
-        is_assignable<_Iter_ref_t<_FwdIt>, const _Ty&>>;
+_INLINE_VAR constexpr bool _Fill_memset_is_safe = conjunction_v<
+    disjunction<conjunction<_Is_character_or_byte<_Unwrap_enum_t<_Ty>>,
+                    _Is_character_or_byte<_Unwrap_enum_t<_Iter_value_t<_FwdIt>>>>,
+        conjunction<is_same<bool, _Unwrap_enum_t<_Ty>>, is_same<bool, _Unwrap_enum_t<_Iter_value_t<_FwdIt>>>>>,
+    is_assignable<_Iter_ref_t<_FwdIt>, const _Ty&>>;
 
 template <class _FwdIt, class _Ty>
 _INLINE_VAR constexpr bool _Fill_memset_is_safe<_FwdIt, _Ty, false> = false;
-// clang-format on
 
 #if _HAS_IF_CONSTEXPR
 template <class _FwdIt, class _Ty>


### PR DESCRIPTION
# Description

iso646.h: This suppression is no longer necessary. (Apparently
unrelated to LLVM-43531, fixed after Clang 9.)

xutility: This exceeded 120 columns. clang-format doesn't make it
unreadable, so we should just enable it.

# Checklist

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [x] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
