### PR TITLE
Fix #441: _CONTAINER_DEBUG_LEVEL mismatch.

### DIFF
--- a/stl/inc/array
+++ b/stl/inc/array
@@ -144,6 +144,7 @@ public:
         return _Elems[_Pos];
     }
 
+    _TEMPLATE_CDL
     _NODISCARD _CONSTEXPR17 reference operator[](_In_range_(0, _Size - 1) size_type _Pos) noexcept /* strengthened */ {
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(_Pos < _Size, "array subscript out of range");
@@ -152,6 +153,7 @@ public:
         return _Elems[_Pos];
     }
 
+    _TEMPLATE_CDL
     _NODISCARD constexpr const_reference operator[](_In_range_(0, _Size - 1) size_type _Pos) const
         noexcept /* strengthened */ {
 #if _CONTAINER_DEBUG_LEVEL > 0
@@ -313,6 +315,7 @@ public:
         _Xran();
     }
 
+    _TEMPLATE_CDL
     _NODISCARD reference operator[](size_type) noexcept /* strengthened */ {
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_REPORT_ERROR("array subscript out of range");
@@ -321,6 +324,7 @@ public:
         return _Elems[0];
     }
 
+    _TEMPLATE_CDL
     _NODISCARD const_reference operator[](size_type) const noexcept /* strengthened */ {
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_REPORT_ERROR("array subscript out of range");
@@ -329,6 +333,7 @@ public:
         return _Elems[0];
     }
 
+    _TEMPLATE_CDL
     _NODISCARD reference front() noexcept /* strengthened */ {
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_REPORT_ERROR("array<T, 0>::front() invalid");
@@ -337,6 +342,7 @@ public:
         return _Elems[0];
     }
 
+    _TEMPLATE_CDL
     _NODISCARD const_reference front() const noexcept /* strengthened */ {
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_REPORT_ERROR("array<T, 0>::front() invalid");
@@ -345,6 +351,7 @@ public:
         return _Elems[0];
     }
 
+    _TEMPLATE_CDL
     _NODISCARD reference back() noexcept /* strengthened */ {
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_REPORT_ERROR("array<T, 0>::back() invalid");
@@ -353,6 +360,7 @@ public:
         return _Elems[0];
     }
 
+    _TEMPLATE_CDL
     _NODISCARD const_reference back() const noexcept /* strengthened */ {
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_REPORT_ERROR("array<T, 0>::back() invalid");

--- a/stl/inc/deque
+++ b/stl/inc/deque
@@ -1028,6 +1028,7 @@ public:
         return *(begin() + static_cast<difference_type>(_Pos));
     }
 
+    _TEMPLATE_CDL
     _NODISCARD const_reference operator[](size_type _Pos) const noexcept /* strengthened */ {
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(_Pos < _Mysize(), "deque subscript out of range");
@@ -1036,6 +1037,7 @@ public:
         return *(_Unchecked_begin() + static_cast<difference_type>(_Pos));
     }
 
+    _TEMPLATE_CDL
     _NODISCARD reference operator[](size_type _Pos) noexcept /* strengthened */ {
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(_Pos < _Mysize(), "deque subscript out of range");
@@ -1044,6 +1046,7 @@ public:
         return *(_Unchecked_begin() + static_cast<difference_type>(_Pos));
     }
 
+    _TEMPLATE_CDL
     _NODISCARD reference front() noexcept /* strengthened */ {
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(!empty(), "front() called on empty deque");
@@ -1052,6 +1055,7 @@ public:
         return *_Unchecked_begin();
     }
 
+    _TEMPLATE_CDL
     _NODISCARD const_reference front() const noexcept /* strengthened */ {
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(!empty(), "front() called on empty deque");
@@ -1060,6 +1064,7 @@ public:
         return *_Unchecked_begin();
     }
 
+    _TEMPLATE_CDL
     _NODISCARD reference back() noexcept /* strengthened */ {
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(!empty(), "back() called on empty deque");
@@ -1068,6 +1073,7 @@ public:
         return *(_Unchecked_end() - 1);
     }
 
+    _TEMPLATE_CDL
     _NODISCARD const_reference back() const noexcept /* strengthened */ {
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(!empty(), "back() called on empty deque");

--- a/stl/inc/forward_list
+++ b/stl/inc/forward_list
@@ -886,6 +886,7 @@ public:
         return static_cast<allocator_type>(_Getal());
     }
 
+    _TEMPLATE_CDL
     _NODISCARD reference front() noexcept /* strengthened */ {
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(_Mypair._Myval2._Myhead != nullptr, "front() called on empty forward_list");
@@ -894,6 +895,7 @@ public:
         return _Mypair._Myval2._Myhead->_Myval;
     }
 
+    _TEMPLATE_CDL
     _NODISCARD const_reference front() const noexcept /* strengthened */ {
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(_Mypair._Myval2._Myhead != nullptr, "front() called on empty forward_list");

--- a/stl/inc/list
+++ b/stl/inc/list
@@ -1205,6 +1205,7 @@ public:
         return static_cast<allocator_type>(_Getal());
     }
 
+    _TEMPLATE_CDL
     _NODISCARD reference front() noexcept /* strengthened */ {
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(_Mypair._Myval2._Mysize != 0, "front() called on empty list");
@@ -1213,6 +1214,7 @@ public:
         return _Mypair._Myval2._Myhead->_Next->_Myval;
     }
 
+    _TEMPLATE_CDL
     _NODISCARD const_reference front() const noexcept /* strengthened */ {
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(_Mypair._Myval2._Mysize != 0, "front() called on empty list");
@@ -1221,6 +1223,7 @@ public:
         return _Mypair._Myval2._Myhead->_Next->_Myval;
     }
 
+    _TEMPLATE_CDL
     _NODISCARD reference back() noexcept /* strengthened */ {
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(_Mypair._Myval2._Mysize != 0, "back() called on empty list");
@@ -1229,6 +1232,7 @@ public:
         return _Mypair._Myval2._Myhead->_Prev->_Myval;
     }
 
+    _TEMPLATE_CDL
     _NODISCARD const_reference back() const noexcept /* strengthened */ {
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(_Mypair._Myval2._Mysize != 0, "back() called on empty list");
@@ -1241,6 +1245,7 @@ public:
         _Emplace(_Mypair._Myval2._Myhead->_Next, _Val);
     }
 
+    _TEMPLATE_CDL
     void pop_front() noexcept /* strengthened */ {
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(_Mypair._Myval2._Mysize != 0, "pop_front called on empty list");
@@ -1253,6 +1258,7 @@ public:
         _Emplace(_Mypair._Myval2._Myhead, _Val);
     }
 
+    _TEMPLATE_CDL
     void pop_back() noexcept /* strengthened */ {
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(_Mypair._Myval2._Mysize != 0, "pop_back called on empty list");

--- a/stl/inc/span
+++ b/stl/inc/span
@@ -359,7 +359,7 @@ public:
     // clang-format off
     constexpr span() noexcept requires (_Extent == 0 || _Extent == dynamic_extent) = default;
 
-    template <_Is_span_compatible_iterator<element_type> _It>
+    template <_Is_span_compatible_iterator<element_type> _It _COMMA_INT_CDL>
     constexpr span(_It _First, size_type _Count) noexcept // strengthened
         : _Mybase(_Count), _Mydata(_STD to_address(_Get_unwrapped_n(_First, _Count))) {
 #if _CONTAINER_DEBUG_LEVEL > 0
@@ -369,7 +369,8 @@ public:
 #endif // _CONTAINER_DEBUG_LEVEL > 0
     }
 
-    template <_Is_span_compatible_iterator<element_type> _It, _Is_span_compatible_sentinel<_It> _Sentinel>
+    template <_Is_span_compatible_iterator<element_type> _It, _Is_span_compatible_sentinel<_It> _Sentinel
+        _COMMA_INT_CDL>
     constexpr span(_It _First, _Sentinel _Last) noexcept(noexcept(_Last - _First)) // strengthened
         : _Mybase(static_cast<size_type>(_Last - _First)), _Mydata(_STD to_address(_First)) {
         _Adl_verify_range(_First, _Last);
@@ -409,6 +410,7 @@ public:
     template <size_t _Ext = _Extent, enable_if_t<_Ext == 0 || _Ext == dynamic_extent, int> = 0>
     constexpr span() noexcept {}
 
+    _TEMPLATE_CDL
     constexpr span(pointer _Ptr, size_type _Count) noexcept // strengthened
         : _Mybase(_Count), _Mydata(_Ptr) {
 #if _CONTAINER_DEBUG_LEVEL > 0
@@ -418,6 +420,7 @@ public:
 #endif // _CONTAINER_DEBUG_LEVEL > 0
     }
 
+    _TEMPLATE_CDL
     constexpr span(pointer _First, pointer _Last) noexcept // strengthened
         : _Mybase(static_cast<size_type>(_Last - _First)), _Mydata(_First) {
         _Adl_verify_range(_First, _Last);
@@ -461,7 +464,7 @@ public:
 #endif // !__cpp_lib_concepts
 
     // [span.sub] Subviews
-    template <size_t _Count>
+    template <size_t _Count _COMMA_INT_CDL>
     _NODISCARD constexpr span<element_type, _Count> first() const noexcept /* strengthened */ {
         if constexpr (_Extent != dynamic_extent) {
             static_assert(_Count <= _Extent, "Count out of range in span::first()");
@@ -474,6 +477,7 @@ public:
         return {_Mydata, _Count};
     }
 
+    _TEMPLATE_CDL
     _NODISCARD constexpr span<element_type, dynamic_extent> first(const size_type _Count) const noexcept
     /* strengthened */ {
 #if _CONTAINER_DEBUG_LEVEL > 0
@@ -482,7 +486,7 @@ public:
         return {_Mydata, _Count};
     }
 
-    template <size_t _Count>
+    template <size_t _Count _COMMA_INT_CDL>
     _NODISCARD constexpr span<element_type, _Count> last() const noexcept /* strengthened */ {
         if constexpr (_Extent != dynamic_extent) {
             static_assert(_Count <= _Extent, "Count out of range in span::last()");
@@ -495,6 +499,7 @@ public:
         return {_Mydata + (this->size() - _Count), _Count};
     }
 
+    _TEMPLATE_CDL
     _NODISCARD constexpr span<element_type, dynamic_extent> last(const size_type _Count) const noexcept
     /* strengthened */ {
 #if _CONTAINER_DEBUG_LEVEL > 0
@@ -503,7 +508,7 @@ public:
         return {_Mydata + (this->size() - _Count), _Count};
     }
 
-    template <size_t _Offset, size_t _Count = dynamic_extent>
+    template <size_t _Offset, size_t _Count = dynamic_extent _COMMA_INT_CDL>
     _NODISCARD constexpr span<element_type,
         _Count != dynamic_extent ? _Count : (_Extent != dynamic_extent ? _Extent - _Offset : dynamic_extent)>
         subspan() const noexcept /* strengthened */ {
@@ -524,6 +529,7 @@ public:
         return {_Mydata + _Offset, _Count == dynamic_extent ? this->size() - _Offset : _Count};
     }
 
+    _TEMPLATE_CDL
     _NODISCARD constexpr span<element_type, dynamic_extent> subspan(
         const size_type _Offset, const size_type _Count = dynamic_extent) const noexcept /* strengthened */ {
 #if _CONTAINER_DEBUG_LEVEL > 0
@@ -535,6 +541,7 @@ public:
     }
 
     // [span.obs] Observers
+    _TEMPLATE_CDL
     _NODISCARD constexpr size_type size_bytes() const noexcept {
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(this->size() <= dynamic_extent / sizeof(element_type),
@@ -548,6 +555,7 @@ public:
     }
 
     // [span.elem] Element access
+    _TEMPLATE_CDL
     _NODISCARD constexpr reference operator[](const size_type _Off) const noexcept /* strengthened */ {
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(_Off < this->size(), "span index out of range");
@@ -555,6 +563,7 @@ public:
         return _Mydata[_Off];
     }
 
+    _TEMPLATE_CDL
     _NODISCARD constexpr reference front() const noexcept /* strengthened */ {
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(this->size() > 0, "front of empty span");
@@ -562,6 +571,7 @@ public:
         return _Mydata[0];
     }
 
+    _TEMPLATE_CDL
     _NODISCARD constexpr reference back() const noexcept /* strengthened */ {
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(this->size() > 0, "back of empty span");

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -1494,6 +1494,7 @@ public:
         return static_cast<size_type>(_My_data._Myend - _My_data._Myfirst);
     }
 
+    _TEMPLATE_CDL
     _NODISCARD _Ty& operator[](const size_type _Pos) noexcept /* strengthened */ {
         auto& _My_data = _Mypair._Myval2;
 #if _CONTAINER_DEBUG_LEVEL > 0
@@ -1504,6 +1505,7 @@ public:
         return _My_data._Myfirst[_Pos];
     }
 
+    _TEMPLATE_CDL
     _NODISCARD const _Ty& operator[](const size_type _Pos) const noexcept /* strengthened */ {
         auto& _My_data = _Mypair._Myval2;
 #if _CONTAINER_DEBUG_LEVEL > 0
@@ -1532,6 +1534,7 @@ public:
         return _My_data._Myfirst[_Pos];
     }
 
+    _TEMPLATE_CDL
     _NODISCARD _Ty& front() noexcept /* strengthened */ {
         auto& _My_data = _Mypair._Myval2;
 #if _CONTAINER_DEBUG_LEVEL > 0
@@ -1541,6 +1544,7 @@ public:
         return *_My_data._Myfirst;
     }
 
+    _TEMPLATE_CDL
     _NODISCARD const _Ty& front() const noexcept /* strengthened */ {
         auto& _My_data = _Mypair._Myval2;
 #if _CONTAINER_DEBUG_LEVEL > 0
@@ -1550,6 +1554,7 @@ public:
         return *_My_data._Myfirst;
     }
 
+    _TEMPLATE_CDL
     _NODISCARD _Ty& back() noexcept /* strengthened */ {
         auto& _My_data = _Mypair._Myval2;
 #if _CONTAINER_DEBUG_LEVEL > 0
@@ -1559,6 +1564,7 @@ public:
         return _My_data._Mylast[-1];
     }
 
+    _TEMPLATE_CDL
     _NODISCARD const _Ty& back() const noexcept /* strengthened */ {
         auto& _My_data = _Mypair._Myval2;
 #if _CONTAINER_DEBUG_LEVEL > 0
@@ -2585,6 +2591,7 @@ public:
         return (*this)[_Off];
     }
 
+    _TEMPLATE_CDL
     _NODISCARD const_reference operator[](size_type _Off) const noexcept /* strengthened */ {
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(_Off < this->_Mysize, "vector<bool> subscript out of range");
@@ -2595,6 +2602,7 @@ public:
         return *_It;
     }
 
+    _TEMPLATE_CDL
     _NODISCARD reference operator[](size_type _Off) noexcept /* strengthened */ {
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(_Off < this->_Mysize, "vector<bool> subscript out of range");
@@ -2605,6 +2613,7 @@ public:
         return *_It;
     }
 
+    _TEMPLATE_CDL
     _NODISCARD reference front() noexcept /* strengthened */ {
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(this->_Mysize != 0, "front() called on empty vector<bool>");
@@ -2613,6 +2622,7 @@ public:
         return *begin();
     }
 
+    _TEMPLATE_CDL
     _NODISCARD const_reference front() const noexcept /* strengthened */ {
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(this->_Mysize != 0, "front() called on empty vector<bool>");
@@ -2621,6 +2631,7 @@ public:
         return *begin();
     }
 
+    _TEMPLATE_CDL
     _NODISCARD reference back() noexcept /* strengthened */ {
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(this->_Mysize != 0, "back() called on empty vector<bool>");
@@ -2629,6 +2640,7 @@ public:
         return *(end() - 1);
     }
 
+    _TEMPLATE_CDL
     _NODISCARD const_reference back() const noexcept /* strengthened */ {
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(this->_Mysize != 0, "back() called on empty vector<bool>");

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -1180,6 +1180,7 @@ public:
     /* implicit */ constexpr basic_string_view(_In_z_ const const_pointer _Ntcts) noexcept // strengthened
         : _Mydata(_Ntcts), _Mysize(_Traits::length(_Ntcts)) {}
 
+    _TEMPLATE_CDL
     constexpr basic_string_view(
         _In_reads_(_Count) const const_pointer _Cts, const size_type _Count) noexcept // strengthened
         : _Mydata(_Cts), _Mysize(_Count) {
@@ -1258,6 +1259,7 @@ public:
         return _Min_value(static_cast<size_t>(PTRDIFF_MAX), static_cast<size_t>(-1) / sizeof(_Elem));
     }
 
+    _TEMPLATE_CDL
     _NODISCARD constexpr const_reference operator[](const size_type _Off) const noexcept /* strengthened */ {
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(_Off < _Mysize, "string_view subscript out of range");
@@ -1271,6 +1273,7 @@ public:
         return _Mydata[_Off];
     }
 
+    _TEMPLATE_CDL
     _NODISCARD constexpr const_reference front() const noexcept /* strengthened */ {
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(_Mysize != 0, "cannot call front on empty string_view");
@@ -1278,6 +1281,7 @@ public:
         return _Mydata[0];
     }
 
+    _TEMPLATE_CDL
     _NODISCARD constexpr const_reference back() const noexcept /* strengthened */ {
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(_Mysize != 0, "cannot call back on empty string_view");
@@ -1285,6 +1289,7 @@ public:
         return _Mydata[_Mysize - 1];
     }
 
+    _TEMPLATE_CDL
     constexpr void remove_prefix(const size_type _Count) noexcept /* strengthened */ {
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(_Mysize >= _Count, "cannot remove prefix longer than total size");
@@ -1293,6 +1298,7 @@ public:
         _Mysize -= _Count;
     }
 
+    _TEMPLATE_CDL
     constexpr void remove_suffix(const size_type _Count) noexcept /* strengthened */ {
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(_Mysize >= _Count, "cannot remove suffix longer than total size");
@@ -3486,6 +3492,7 @@ public:
         return _Mypair._Myval2._Myptr()[_Off];
     }
 
+    _TEMPLATE_CDL
     _NODISCARD reference operator[](const size_type _Off) noexcept /* strengthened */ {
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(_Off <= _Mypair._Myval2._Mysize, "string subscript out of range");
@@ -3493,6 +3500,7 @@ public:
         return _Mypair._Myval2._Myptr()[_Off];
     }
 
+    _TEMPLATE_CDL
     _NODISCARD const_reference operator[](const size_type _Off) const noexcept /* strengthened */ {
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(_Off <= _Mypair._Myval2._Mysize, "string subscript out of range");
@@ -3535,6 +3543,7 @@ public:
         _Eos(_Old_size - 1);
     }
 
+    _TEMPLATE_CDL
     _NODISCARD reference front() noexcept /* strengthened */ {
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(_Mypair._Myval2._Mysize != 0, "front() called on empty string");
@@ -3543,6 +3552,7 @@ public:
         return _Mypair._Myval2._Myptr()[0];
     }
 
+    _TEMPLATE_CDL
     _NODISCARD const_reference front() const noexcept /* strengthened */ {
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(_Mypair._Myval2._Mysize != 0, "front() called on empty string");
@@ -3551,6 +3561,7 @@ public:
         return _Mypair._Myval2._Myptr()[0];
     }
 
+    _TEMPLATE_CDL
     _NODISCARD reference back() noexcept /* strengthened */ {
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(_Mypair._Myval2._Mysize != 0, "back() called on empty string");
@@ -3559,6 +3570,7 @@ public:
         return _Mypair._Myval2._Myptr()[_Mypair._Myval2._Mysize - 1];
     }
 
+    _TEMPLATE_CDL
     _NODISCARD const_reference back() const noexcept /* strengthened */ {
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(_Mypair._Myval2._Mysize != 0, "back() called on empty string");

--- a/stl/inc/yvals.h
+++ b/stl/inc/yvals.h
@@ -178,6 +178,14 @@ _STL_DISABLE_CLANG_WARNINGS
 #error _ITERATOR_DEBUG_LEVEL != 0 must imply _CONTAINER_DEBUG_LEVEL == 1.
 #endif // _ITERATOR_DEBUG_LEVEL != 0 && _CONTAINER_DEBUG_LEVEL == 0
 
+#if _CONTAINER_DEBUG_LEVEL > 0
+#define _TEMPLATE_CDL  template <int _Cdl = _CONTAINER_DEBUG_LEVEL>
+#define _COMMA_INT_CDL , int _Cdl = _CONTAINER_DEBUG_LEVEL
+#else // _CONTAINER_DEBUG_LEVEL > 0
+#define _TEMPLATE_CDL
+#define _COMMA_INT_CDL
+#endif // _CONTAINER_DEBUG_LEVEL > 0
+
 #define _STL_REPORT_ERROR(mesg)              \
     do {                                     \
         _RPTF0(_CRT_ASSERT, mesg);           \


### PR DESCRIPTION
# Description

To mitigate linker issues, this templatizes (or adds template parameters) to any member functions that are affected by `_CONTAINER_DEBUG_LEVEL`. To be non-intrusive, the template parameters appear only when `_CONTAINER_DEBUG_LEVEL` is set, so code is unaffected by default.

This doesn't enforce that `_CONTAINER_DEBUG_LEVEL` is consistent throughout a binary, but it does ensure that checked and unchecked instantiations aren't randomly selected by the linker.

However, it doesn't apply transitively. If a function calling (for example) `span::operator[]` is compiled with and without `_CONTAINER_DEBUG_LEVEL`, and it's an inline/template function, the linker will randomly pick one instantiation (regardless of whether `operator[]` is inlined).

```
C:\Temp>undname ??A?$span@H$0PPPPPPPP@@std@@QBEAAHI@Z
Microsoft (R) C++ Name Undecorator
Copyright (C) Microsoft Corporation. All rights reserved.

Undecoration of :- "??A?$span@H$0PPPPPPPP@@std@@QBEAAHI@Z"
is :- "public: int & __thiscall std::span<int,4294967295>::operator[](unsigned int)const "

C:\Temp>undname ??$?A$00@?$span@H$0PPPPPPPP@@std@@QBEAAHI@Z
Microsoft (R) C++ Name Undecorator
Copyright (C) Microsoft Corporation. All rights reserved.

Undecoration of :- "??$?A$00@?$span@H$0PPPPPPPP@@std@@QBEAAHI@Z"
is :- "public: int & __thiscall std::span<int,4294967295>::operator[]<1>(unsigned int)const "
```

Note: Due to the lack of transitive behavior, I am uncertain whether we should proceed with this change, or revisit whether `_CONTAINER_DEBUG_LEVEL` should be supported at all.

# Checklist

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [ ] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [ ] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
