### PR TITLE
<tuple>: tuple_cat for tuple-like types

### DIFF
--- a/stl/inc/tuple
+++ b/stl/inc/tuple
@@ -867,7 +867,7 @@ template <size_t _Idx, class _Ty, size_t _Size>
 _NODISCARD constexpr const _Ty&& get(const array<_Ty, _Size>&& _Arr) noexcept;
 
 // STRUCT TEMPLATE _Repeat_type_in_tuple
-template <class _Ty, class... _Meta>
+template <class _Ty, class _Indices>
 struct _Repeat_type_in_tuple {
     static_assert(_Always_false<_Ty>, "Requires index_sequence as second template argument.");
 };
@@ -878,14 +878,14 @@ struct _Repeat_type_in_tuple<_Ty, index_sequence<_Ix...>> {
 };
 
 // STRUCT TEMPLATE _Is_tuple_like
-template <class _Ty, class = int>
-struct _Is_tuple_like : false_type {};
+template <class _Ty, class = void>
+_INLINE_VAR constexpr bool _Is_tuple_like_v = false;
 
 template <class _Ty>
-struct _Is_tuple_like<_Ty, decltype((void)tuple_size<_Ty>::size, 0)> : true_type {}; 
+_INLINE_VAR constexpr bool _Is_tuple_like_v<_Ty, decltype((void) tuple_size_v<_Ty>, 0)> = true;
 
 // STRUCT TEMPLATE _View_custom_as_tuple
-template <class _Ty, class... _Meta>
+template <class _Ty, class _Indices>
 struct _View_custom_as_tuple {
     static_assert(_Always_false<_Ty>, "Requires index_sequence as second template argument.");
 };
@@ -898,8 +898,8 @@ struct _View_custom_as_tuple<_Ty, index_sequence<_Ix...>> {
 // STRUCT TEMPLATE _View_as_tuple
 template <class _Ty>
 struct _View_as_tuple {
-    static_assert(_Is_tuple_like<_Ty>::value, "Unsupported tuple_cat arguments.");
-    using type = typename _View_custom_as_tuple<_Ty, make_index_sequence<tuple_size<_Ty>::size>>::type;
+    static_assert(_Is_tuple_like_v<_Ty>, "Unsupported tuple_cat arguments.");
+    using type = typename _View_custom_as_tuple<_Ty, make_index_sequence<tuple_size_v<_Ty>>>::type;
 };
 
 template <class... _Types>

--- a/stl/inc/tuple
+++ b/stl/inc/tuple
@@ -866,10 +866,40 @@ _NODISCARD constexpr _Ty&& get(array<_Ty, _Size>&& _Arr) noexcept;
 template <size_t _Idx, class _Ty, size_t _Size>
 _NODISCARD constexpr const _Ty&& get(const array<_Ty, _Size>&& _Arr) noexcept;
 
+// STRUCT TEMPLATE _Repeat_type_in_tuple
+template <class _Ty, class... _Meta>
+struct _Repeat_type_in_tuple {
+    static_assert(_Always_false<_Ty>, "Requires index_sequence as second template argument.");
+};
+
+template <class _Ty, size_t... _Ix>
+struct _Repeat_type_in_tuple<_Ty, index_sequence<_Ix...>> {
+    using type = tuple<typename remove_reference_t<decltype(_Ix, declval<_Identity<_Ty>>())>::type...>;
+};
+
+// STRUCT TEMPLATE _Is_tuple_like
+template <class _Ty, class = int>
+struct _Is_tuple_like : false_type {};
+
+template <class _Ty>
+struct _Is_tuple_like<_Ty, decltype((void)tuple_size<_Ty>::size, 0)> : true_type {}; 
+
+// STRUCT TEMPLATE _View_custom_as_tuple
+template <class _Ty, class... _Meta>
+struct _View_custom_as_tuple {
+    static_assert(_Always_false<_Ty>, "Requires index_sequence as second template argument.");
+};
+
+template <class _Ty, size_t... _Ix>
+struct _View_custom_as_tuple<_Ty, index_sequence<_Ix...>> {
+    using type = tuple<tuple_element_t<_Ix, _Ty>...>;
+};
+
 // STRUCT TEMPLATE _View_as_tuple
-template <class _Ty, class... _For_array>
-struct _View_as_tuple { // tuple_cat() supports only tuples, pairs, and arrays
-    static_assert(_Always_false<_Ty>, "Unsupported tuple_cat arguments.");
+template <class _Ty>
+struct _View_as_tuple {
+    static_assert(_Is_tuple_like<_Ty>::value, "Unsupported tuple_cat arguments.");
+    using type = typename _View_custom_as_tuple<_Ty, make_index_sequence<tuple_size<_Ty>::size>>::type;
 };
 
 template <class... _Types>
@@ -882,14 +912,9 @@ struct _View_as_tuple<pair<_Ty1, _Ty2>> { // view a pair as a tuple
     using type = tuple<_Ty1, _Ty2>;
 };
 
-template <class _Ty, class... _Types>
-struct _View_as_tuple<array<_Ty, 0>, _Types...> { // view an array as a tuple; ends recursion at 0
-    using type = tuple<_Types...>;
-};
-
-template <class _Ty, size_t _Size, class... _Types>
-struct _View_as_tuple<array<_Ty, _Size>, _Types...>
-    : _View_as_tuple<array<_Ty, _Size - 1>, _Ty, _Types...> { // view an array as a tuple; counts down to 0
+template <class _Ty, size_t _Size>
+struct _View_as_tuple<array<_Ty, _Size>> { // view an array as a tuple
+    using type = typename _Repeat_type_in_tuple<_Ty, make_index_sequence<_Size>>::type;
 };
 
 // STRUCT TEMPLATE _Repeat_for

--- a/stl/inc/tuple
+++ b/stl/inc/tuple
@@ -866,15 +866,21 @@ _NODISCARD constexpr _Ty&& get(array<_Ty, _Size>&& _Arr) noexcept;
 template <size_t _Idx, class _Ty, size_t _Size>
 _NODISCARD constexpr const _Ty&& get(const array<_Ty, _Size>&& _Arr) noexcept;
 
-// STRUCT TEMPLATE _Repeat_type_in_tuple
-template <class _Ty, class _Indices>
-struct _Repeat_type_in_tuple {
-    static_assert(_Always_false<_Ty>, "Requires index_sequence as second template argument.");
-};
+// ALIAS TEMPLATE _Meta_repeat_n_c
+template <class, class, template <class...> class>
+struct _Meta_repeat_n_c_;
 
-template <class _Ty, size_t... _Ix>
-struct _Repeat_type_in_tuple<_Ty, index_sequence<_Ix...>> {
-    using type = tuple<typename remove_reference_t<decltype(_Ix, declval<_Identity<_Ty>>())>::type...>;
+template <size_t _Count, class _Ty, template <class...> class _Continue>
+using _Meta_repeat_n_c =
+    // construct a sequence consisting of repetitions of _Ty
+    typename _Meta_repeat_n_c_<_Ty, make_index_sequence<_Count>, _Continue>::type;
+
+template <class _Ty, size_t>
+using _Meta_repeat_first_helper = _Ty;
+
+template <class _Ty, size_t... _Idxs, template <class...> class _Continue>
+struct _Meta_repeat_n_c_<_Ty, index_sequence<_Idxs...>, _Continue> {
+    using type = _Continue<_Meta_repeat_first_helper<_Ty, _Idxs>...>;
 };
 
 // STRUCT TEMPLATE _Is_tuple_like
@@ -882,7 +888,7 @@ template <class _Ty, class = void>
 _INLINE_VAR constexpr bool _Is_tuple_like_v = false;
 
 template <class _Ty>
-_INLINE_VAR constexpr bool _Is_tuple_like_v<_Ty, decltype((void) tuple_size_v<_Ty>, 0)> = true;
+_INLINE_VAR constexpr bool _Is_tuple_like_v<_Ty, void_t<decltype(tuple_size_v<_Ty>)>> = true;
 
 // STRUCT TEMPLATE _View_custom_as_tuple
 template <class _Ty, class _Indices>
@@ -914,7 +920,7 @@ struct _View_as_tuple<pair<_Ty1, _Ty2>> { // view a pair as a tuple
 
 template <class _Ty, size_t _Size>
 struct _View_as_tuple<array<_Ty, _Size>> { // view an array as a tuple
-    using type = typename _Repeat_type_in_tuple<_Ty, make_index_sequence<_Size>>::type;
+    using type = _Meta_repeat_n_c<_Size, _Ty, tuple>;
 };
 
 // STRUCT TEMPLATE _Repeat_for

--- a/stl/inc/variant
+++ b/stl/inc/variant
@@ -148,22 +148,6 @@ struct _Meta_transform_<_Fn, _List<_Types...>> {
     using type = _List<_Meta_invoke<_Fn, _Types>...>;
 };
 
-// ALIAS TEMPLATE _Meta_repeat_n_c
-template <class, class, template <class...> class>
-struct _Meta_repeat_n_c_;
-template <size_t _Count, class _Ty, template <class...> class _Continue>
-using _Meta_repeat_n_c =
-    // construct a sequence consisting of repetitions of _Ty
-    typename _Meta_repeat_n_c_<_Ty, make_index_sequence<_Count>, _Continue>::type;
-
-template <class _Ty, size_t>
-using _Meta_repeat_first_helper = _Ty;
-
-template <class _Ty, size_t... _Idxs, template <class...> class _Continue>
-struct _Meta_repeat_n_c_<_Ty, index_sequence<_Idxs...>, _Continue> {
-    using type = _Continue<_Meta_repeat_first_helper<_Ty, _Idxs>...>;
-};
-
 // ALIAS TEMPLATE _Meta_at_c
 template <class _List, size_t _Idx, class = void>
 struct _Meta_at_;


### PR DESCRIPTION
# Description

Closes #260. I also replaced recursive impl of `_View_as_tuple` for arrays with `index_sequence`.

# Checklist

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [ ] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
