### PR TITLE
Fix #463 by avoiding iterator subscripting.

### DIFF
--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -877,7 +877,7 @@ _NODISCARD _CONSTEXPR20 _FwdIt search_n(
                 _Iter_diff_t<_FwdIt> _Count1 = _Count_diff;
                 auto _UMid                   = _UFirst;
 
-                while (_UOld_first != _UFirst && _Pred(_UFirst[-1], _Val)) { // back up over any skipped prefix
+                while (_UOld_first != _UFirst && _Pred(*(_UFirst - 1), _Val)) { // back up over any skipped prefix
                     --_Count1;
                     --_UFirst;
                 }
@@ -958,7 +958,7 @@ _FwdIt _Search_n_unchecked1(_FwdIt _First, const _FwdIt _Last, const _Diff _Coun
             _Iter_diff_t<_FwdIt> _Count1 = _Count_diff;
             _FwdIt _Mid                  = _First;
 
-            while (_Old_first != _First && _Pred(_First[-1], _Val)) {
+            while (_Old_first != _First && _Pred(*(_First - 1), _Val)) {
                 --_Count1; // back up over any skipped prefix
                 --_First;
             }
@@ -2123,12 +2123,12 @@ _SampleIt _Sample_reservoir_unchecked(
             return _Dest + _Sample_pop;
         }
 
-        _Dest[_Sample_pop] = *_First;
+        *(_Dest + _Sample_pop) = *_First;
     }
     for (; _First != _Last; ++_First) {
         const auto _Idx = _RngFunc(++_PopSize);
         if (_Idx < _SCount) {
-            _Dest[static_cast<_Diff_sample>(_Idx)] = *_First; // again, valid narrowing because _Idx < _SCount
+            *(_Dest + static_cast<_Diff_sample>(_Idx)) = *_First; // again, valid narrowing because _Idx < _SCount
         }
     }
     return _Dest + _SCount;
@@ -2690,14 +2690,14 @@ _CONSTEXPR20 void _Push_heap_by_index(
     // percolate _Hole to _Top or where _Val belongs, using _Pred
     using _Diff = _Iter_diff_t<_RanIt>;
     for (_Diff _Idx = (_Hole - 1) >> 1; // shift for codegen
-         _Top < _Hole && _DEBUG_LT_PRED(_Pred, _First[_Idx], _Val); //
+         _Top < _Hole && _DEBUG_LT_PRED(_Pred, *(_First + _Idx), _Val); //
          _Idx = (_Hole - 1) >> 1) { // shift for codegen
         // move _Hole up to parent
-        _First[_Hole] = _STD move(_First[_Idx]);
-        _Hole         = _Idx;
+        *(_First + _Hole) = _STD move(*(_First + _Idx));
+        _Hole             = _Idx;
     }
 
-    _First[_Hole] = _STD move(_Val); // drop _Val into final hole
+    *(_First + _Hole) = _STD move(_Val); // drop _Val into final hole
 }
 
 template <class _RanIt, class _Pr>
@@ -2735,16 +2735,16 @@ _CONSTEXPR20 void _Pop_heap_hole_by_index(
     const _Diff _Max_sequence_non_leaf = (_Bottom - 1) >> 1; // shift for codegen
     while (_Idx < _Max_sequence_non_leaf) { // move _Hole down to larger child
         _Idx = 2 * _Idx + 2;
-        if (_DEBUG_LT_PRED(_Pred, _First[_Idx], _First[_Idx - 1])) {
+        if (_DEBUG_LT_PRED(_Pred, *(_First + _Idx), *(_First + (_Idx - 1)))) {
             --_Idx;
         }
-        _First[_Hole] = _STD move(_First[_Idx]);
-        _Hole         = _Idx;
+        *(_First + _Hole) = _STD move(*(_First + _Idx));
+        _Hole             = _Idx;
     }
 
     if (_Idx == _Max_sequence_non_leaf && _Bottom % 2 == 0) { // only child at bottom, move _Hole down to it
-        _First[_Hole] = _STD move(_First[_Bottom - 1]);
-        _Hole         = _Bottom - 1;
+        *(_First + _Hole) = _STD move(*(_First + (_Bottom - 1)));
+        _Hole             = _Bottom - 1;
     }
 
     _Push_heap_by_index(_First, _Hole, _Top, _STD move(_Val), _Pred);
@@ -2792,7 +2792,7 @@ _CONSTEXPR20 void _Make_heap_unchecked(_RanIt _First, _RanIt _Last, _Pr _Pred) {
     for (_Diff _Hole = _Bottom >> 1; 0 < _Hole;) { // shift for codegen
         // reheap top half, bottom to top
         --_Hole;
-        _Iter_value_t<_RanIt> _Val = _STD move(_First[_Hole]);
+        _Iter_value_t<_RanIt> _Val = _STD move(*(_First + _Hole));
         _Pop_heap_hole_by_index(_First, _Hole, _Bottom, _STD move(_Val), _Pred);
     }
 }
@@ -2815,7 +2815,7 @@ _CONSTEXPR20 _RanIt _Is_heap_until_unchecked(_RanIt _First, _RanIt _Last, _Pr _P
     using _Diff       = _Iter_diff_t<_RanIt>;
     const _Diff _Size = _Last - _First;
     for (_Diff _Off = 1; _Off < _Size; ++_Off) {
-        if (_DEBUG_LT_PRED(_Pred, _First[(_Off - 1) >> 1], _First[_Off])) { // shift for codegen
+        if (_DEBUG_LT_PRED(_Pred, *(_First + ((_Off - 1) >> 1)), *(_First + _Off))) { // shift for codegen
             return _First + _Off;
         }
     }

--- a/stl/inc/execution
+++ b/stl/inc/execution
@@ -3304,7 +3304,7 @@ struct _Static_partitioned_is_heap_until {
 
         const auto _Initial = _Max_value(_Chunk_offset, _Diff{1});
         for (_Diff _Off = _Initial; _Off < _Last; ++_Off) {
-            if (_DEBUG_LT_PRED(_Pred, _Range_first[(_Off - 1) >> 1], _Range_first[_Off])) {
+            if (_DEBUG_LT_PRED(_Pred, *(_Range_first + ((_Off - 1) >> 1)), *(_Range_first + _Off))) {
                 _Results._Imbue(_Key._Chunk_number, _Range_first + _Off);
                 return _Cancellation_status::_Canceled;
             }
@@ -3746,7 +3746,7 @@ void _Place_elements_from_indices(
     const auto _Last_index = _Indices_first + _Num_results;
     for (; _Indices_first != _Last_index; ++_Indices_first) {
         const auto _Curr_index = *_Indices_first;
-        *_Dest                 = _First[static_cast<_Iter_diff_t<_RanIt1>>(_Curr_index)];
+        *_Dest                 = *(_First + static_cast<_Iter_diff_t<_RanIt1>>(_Curr_index));
         ++_Dest;
     }
 }
@@ -3896,10 +3896,10 @@ struct _Set_intersection_per_chunk {
         const auto _Range1_dist                  = _Last1 - _First1;
         const auto _Range2_dist                  = _Last2 - _First2;
         while (_Curr_range1_index < _Range1_dist && _Curr_range1_index < _Range2_dist) {
-            if (_DEBUG_LT_PRED(_Pred, _First1[_Curr_range1_index], _First2[_Curr_range2_index])) {
+            if (_DEBUG_LT_PRED(_Pred, *(_First1 + _Curr_range1_index), *(_First2 + _Curr_range2_index))) {
                 ++_Curr_range1_index;
             } else {
-                if (!_Pred(_First2[_Curr_range2_index], _First1[_Curr_range1_index])) {
+                if (!_Pred(*(_First2 + _Curr_range2_index), *(_First1 + _Curr_range1_index))) {
                     *_Index_chunk_first = static_cast<_Iter_value_t<_BidIt>>(_Curr_range1_index);
                     ++_Index_chunk_first;
                     ++_Curr_range1_index;
@@ -3981,12 +3981,12 @@ struct _Set_difference_per_chunk {
         const auto _Range1_dist                  = _Last1 - _First1;
         const auto _Range2_dist                  = _Last2 - _First2;
         while (_Curr_range1_index < _Range1_dist && _Curr_range2_index < _Range2_dist) {
-            if (_DEBUG_LT_PRED(_Pred, _First1[_Curr_range1_index], _First2[_Curr_range2_index])) {
+            if (_DEBUG_LT_PRED(_Pred, *(_First1 + _Curr_range1_index), *(_First2 + _Curr_range2_index))) {
                 *_Index_chunk_first = static_cast<_Iter_value_t<_BidIt>>(_Curr_range1_index);
                 ++_Index_chunk_first;
                 ++_Curr_range1_index;
             } else {
-                if (!_Pred(_First2[_Curr_range2_index], _First1[_Curr_range1_index])) {
+                if (!_Pred(*(_First2 + _Curr_range2_index), *(_First1 + _Curr_range1_index))) {
                     ++_Curr_range1_index;
                 }
 

--- a/stl/inc/numeric
+++ b/stl/inc/numeric
@@ -834,7 +834,7 @@ _CONSTEXPR20 void iota(_FwdIt _First, _FwdIt _Last, _Ty _Val) {
 #if _HAS_CXX17
 // FUNCTION TEMPLATE _Abs_u
 template <class _Arithmetic>
-[[nodiscard]] constexpr auto _Abs_u(const _Arithmetic _Val) noexcept {
+_NODISCARD constexpr auto _Abs_u(const _Arithmetic _Val) noexcept {
     // computes absolute value of _Val (converting to an unsigned integer type if necessary to avoid overflow
     // representing the negation of the minimum value)
     if constexpr (is_floating_point_v<_Arithmetic>) {


### PR DESCRIPTION
# Description

This reverts #289 and changes several more algorithms.

Unrelated cleanup: this changes one occurrence of `[[nodiscard]]` to `_NODISCARD` for consistency.

# Checklist

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [ ] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
