### PR TITLE
Avoid double strlen for string operator+ and implement P1165R1

### DIFF
--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -1995,6 +1995,19 @@ struct _Alloc_temporary {
     }
 };
 
+template <class _Alloc>
+_NODISCARD constexpr bool _Allocators_equal(const _Alloc& _Lhs, const _Alloc& _Rhs) noexcept {
+    if
+        _CONSTEXPR_IF(allocator_traits<_Alloc>::is_always_equal::value) {
+            (void) _Lhs;
+            (void) _Rhs;
+            return true;
+        }
+    else {
+        return _Lhs == _Rhs;
+    }
+}
+
 // FUNCTION TEMPLATE remove
 template <class _FwdIt, class _Ty>
 _NODISCARD _CONSTEXPR20 _FwdIt remove(_FwdIt _First, const _FwdIt _Last, const _Ty& _Val) {

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -2197,6 +2197,10 @@ constexpr size_t _Size_after_ebco_v = is_empty_v<_Ty> ? 0 : sizeof(_Ty); // get 
 
 struct _String_constructor_concat_tag {};
 
+[[noreturn]] inline void _Xlen_string() {
+    _Xlength_error("string too long");
+}
+
 template <class _Elem, class _Traits = char_traits<_Elem>, class _Alloc = allocator<_Elem>>
 class basic_string { // null-terminated transparent array of elements
 private:
@@ -4151,7 +4155,7 @@ private:
         // reallocate to store exactly _New_size elements, new buffer prepared by
         // _Fn(_New_ptr, _New_size, _Args...)
         if (_New_size > max_size()) {
-            _Xlen(); // result too long
+            _Xlen_string(); // result too long
         }
 
         const size_type _Old_capacity = _Mypair._Myval2._Myres;
@@ -4179,7 +4183,7 @@ private:
         auto& _My_data            = _Mypair._Myval2;
         const size_type _Old_size = _My_data._Mysize;
         if (max_size() - _Old_size < _Size_increase) {
-            _Xlen(); // result too long
+            _Xlen_string(); // result too long
         }
 
         const size_type _New_size     = _Old_size + _Size_increase;
@@ -4245,10 +4249,6 @@ private:
         _Traits::assign(_Mypair._Myval2._Bx._Buf[0], _Elem());
     }
 
-    [[noreturn]] static void _Xlen() {
-        _Xlength_error("string too long");
-    }
-
 public:
     void _Orphan_all() noexcept { // used by filesystem::path
         _Mypair._Myval2._Orphan_all();
@@ -4299,7 +4299,7 @@ _NODISCARD basic_string<_Elem, _Traits, _Alloc> operator+(
     const basic_string<_Elem, _Traits, _Alloc>& _Left, const basic_string<_Elem, _Traits, _Alloc>& _Right) {
     // return string + string
     if (_Left.max_size() - _Left.size() < _Right.size()) {
-        _Xlength_error("string too long");
+        _Xlen_string();
     }
 
     return basic_string<_Elem, _Traits, _Alloc>(
@@ -4313,7 +4313,7 @@ _NODISCARD basic_string<_Elem, _Traits, _Alloc> operator+(
     using _Size_type      = typename _String_type::size_type;
     const auto _Left_size = _Convert_size<_Size_type>(_Traits::length(_Left));
     if (_Right.max_size() - _Right.size() < _Left_size) {
-        _Xlength_error("string too long");
+        _Xlen_string();
     }
 
     return basic_string<_Elem, _Traits, _Alloc>(
@@ -4324,7 +4324,7 @@ template <class _Elem, class _Traits, class _Alloc>
 _NODISCARD basic_string<_Elem, _Traits, _Alloc> operator+(
     const _Elem _Left, const basic_string<_Elem, _Traits, _Alloc>& _Right) {
     if (_Right.size() == _Right.max_size()) {
-        _Xlength_error("string too long");
+        _Xlen_string();
     }
 
     return basic_string<_Elem, _Traits, _Alloc>(
@@ -4338,7 +4338,7 @@ _NODISCARD basic_string<_Elem, _Traits, _Alloc> operator+(
     using _Size_type       = typename _String_type::size_type;
     const auto _Right_size = _Convert_size<_Size_type>(_Traits::length(_Right));
     if (_Left.max_size() - _Left.size() < _Right_size) {
-        _Xlength_error("string too long");
+        _Xlen_string();
     }
 
     return basic_string<_Elem, _Traits, _Alloc>(
@@ -4349,7 +4349,7 @@ template <class _Elem, class _Traits, class _Alloc>
 _NODISCARD basic_string<_Elem, _Traits, _Alloc> operator+(
     const basic_string<_Elem, _Traits, _Alloc>& _Left, const _Elem _Right) {
     if (_Left.size() == _Left.max_size()) {
-        _Xlength_error("string too long");
+        _Xlen_string();
     }
 
     return basic_string<_Elem, _Traits, _Alloc>(

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -2482,29 +2482,38 @@ public:
         const auto _Right_capacity = _Right_data._Myres;
         // overflow is OK due to max_size() checks:
         const auto _New_size = static_cast<size_type>(_Left_size + _Right_size);
-        if (_Allocators_equal(_Getal(), _Right._Getal()) && _Right_capacity > _Left_capacity
-            && _Left_size <= _Right_capacity - _Right_size) {
-            // take _Right's buffer, max_size() is OK because we're under _Right's capacity
+        if (_Right_size <= _Left_capacity - _Left_size && _Left_capacity >= _Right_capacity) {
+            // take _Left's buffer, max_size() is OK because the result fits in _Left's capacity
             _My_data._Alloc_proxy(_GET_PROXY_ALLOCATOR(_Alty, _Getal())); // throws, hereafter nothrow in this block
-            _Take_contents(_Right, bool_constant<_Can_memcpy_val>{});
-            // _Right had more capacity than left, therefore _Right did not have the minimum capacity,
-            // therefore _Right had _Large_string_engaged(), therefore after _Take_contents we have
-            // _Large_string_engaged() and can save that branch
-            _STL_INTERNAL_CHECK(_My_data._Large_string_engaged());
-            const auto _Ptr = _Unfancy(_My_data._Bx._Ptr);
-            _Traits::move(_Ptr + _Left_size, _Ptr, _My_data._Mysize + 1);
-            _Traits::copy(_Ptr, _Left_data._Myptr(), _Left_size);
+            _Take_contents(_Left, bool_constant<_Can_memcpy_val>{});
+            const auto _Ptr = _My_data._Myptr();
+            _Traits::copy(_Ptr + _My_data._Mysize, _Right_data._Myptr(), _Right_size);
             _My_data._Mysize = _New_size;
             _Traits::assign(_Ptr[_New_size], _Elem());
             return;
         }
 
-        if (_Right_size < _Left_capacity - _Left_size) {
-            // take _Left's buffer, max_size() is OK because we're under _Left's capacity
+        if (_Allocators_equal(_Getal(), _Right._Getal()) && _Left_size <= _Right_capacity - _Right_size) {
+            // take _Right's buffer, max_size() is OK because the result fits in _Right's capacity
+            // At this point, we have tested:
+            // !(_Right_size <= _Left_capacity - _Left_size && _Left_capacity >= _Right_capacity)
+            //     && _Left_size <= _Right_capacity - _Right_size
+            // therefore: (demorgan)
+            // (_Right_size > _Left_capacity - _Left_size || _Left_capacity < _Right_capacity)
+            //     && _Left_size <= _Right_capacity - _Right_size
+            // therefore: (distribute)
+            // (_Right_size > _Left_capacity - _Left_size && _Left_size <= _Right_capacity - _Right_size)
+            // || (_Left_capacity < _Right_capacity && _Left_size <= _Right_capacity - _Right_size)
+            // therefore: either the result fits in _Right's capacity but not in _Left's capacity, so _Right must have
+            //     had more capacity, OR we explicitly tested that _Right had more capacity
+            // therefore: _Right must be in large mode (since it's capacity is larger than the minimum), so save that
+            //     branch
+            _STL_INTERNAL_CHECK(_Right_data._Large_string_engaged());
             _My_data._Alloc_proxy(_GET_PROXY_ALLOCATOR(_Alty, _Getal())); // throws, hereafter nothrow in this block
-            _Take_contents(_Left, bool_constant<_Can_memcpy_val>{});
-            const auto _Ptr = _My_data._Myptr();
-            _Traits::copy(_Ptr + _My_data._Mysize, _Right_data._Myptr(), _Right_size);
+            _Take_contents(_Right, bool_constant<_Can_memcpy_val>{});
+            const auto _Ptr = _Unfancy(_My_data._Bx._Ptr);
+            _Traits::move(_Ptr + _Left_size, _Ptr, _My_data._Mysize);
+            _Traits::copy(_Ptr, _Left_data._Myptr(), _Left_size);
             _My_data._Mysize = _New_size;
             _Traits::assign(_Ptr[_New_size], _Elem());
             return;
@@ -4435,13 +4444,13 @@ _NODISCARD basic_string<_Elem, _Traits, _Alloc> operator+(
 template <class _Elem, class _Traits, class _Alloc>
 _NODISCARD basic_string<_Elem, _Traits, _Alloc> operator+(
     basic_string<_Elem, _Traits, _Alloc>&& _Left, basic_string<_Elem, _Traits, _Alloc>&& _Right) {
-#if _ITERATOR_DEBUG_LEVEL == 2
+#if _CONTAINER_DEBUG_LEVEL == 1
     _STL_VERIFY(_STD addressof(_Left) != _STD addressof(_Right),
         "You cannot concatenate the same moved string to itself. See "
         "N4842 [res.on.arguments]/1.3: If a function argument binds to an rvalue reference "
         "parameter, the implementation may assume that this parameter is a unique reference "
         "to this argument");
-#endif // _ITERATOR_DEBUG_LEVEL == 2
+#endif // _CONTAINER_DEBUG_LEVEL == 1
     return {_String_constructor_concat_tag{}, _Left, _Right};
 }
 

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -2195,7 +2195,9 @@ public:
 template <class _Ty>
 constexpr size_t _Size_after_ebco_v = is_empty_v<_Ty> ? 0 : sizeof(_Ty); // get _Ty's size after being EBCO'd
 
-struct _String_constructor_concat_tag {};
+struct _String_constructor_concat_tag {
+    explicit _String_constructor_concat_tag() = default;
+};
 
 [[noreturn]] inline void _Xlen_string() {
     _Xlength_error("string too long");
@@ -2438,27 +2440,28 @@ public:
         _Proxy._Release();
     }
 
-    explicit basic_string(_String_constructor_concat_tag, const basic_string& _Alsource, const _Elem* const _Left_ptr,
+    basic_string(_String_constructor_concat_tag, const basic_string& _Source_of_al, const _Elem* const _Left_ptr,
         const size_type _Left_size, const _Elem* const _Right_ptr, const size_type _Right_size)
         : _Mypair(
-            _One_then_variadic_args_t(), _Alty_traits::select_on_container_copy_construction(_Alsource._Getal())) {
-        _STL_INTERNAL_CHECK(_Left_size < max_size());
-        _STL_INTERNAL_CHECK(_Right_size < max_size());
-        _STL_INTERNAL_CHECK(max_size() - _Left_size >= _Right_size);
+            _One_then_variadic_args_t(), _Alty_traits::select_on_container_copy_construction(_Source_of_al._Getal())) {
+        _STL_INTERNAL_CHECK(_Left_size <= max_size()); // caller must check for emission of length_error
+        _STL_INTERNAL_CHECK(_Right_size <= max_size());
+        _STL_INTERNAL_CHECK(_Right_size <= max_size() - _Left_size);
         const auto _New_size    = _Left_size + _Right_size;
         size_type _New_capacity = _BUF_SIZE - 1;
-        _Elem* _Ptr             = _Mypair._Myval2._Bx._Buf;
+        auto& _My_data          = _Mypair._Myval2;
+        _Elem* _Ptr             = _My_data._Bx._Buf;
         auto&& _Alproxy         = _GET_PROXY_ALLOCATOR(_Alty, _Getal());
-        _Container_proxy_ptr<_Alty> _Proxy(_Alproxy, _Mypair._Myval2);
+        _Container_proxy_ptr<_Alty> _Proxy(_Alproxy, _My_data); // throws
         if (_New_capacity < _New_size) {
             _New_capacity           = _Calculate_growth(_New_size, _BUF_SIZE - 1, max_size());
             const pointer _Fancyptr = _Getal().allocate(_New_capacity + 1); // throws
             _Ptr                    = _Unfancy(_Fancyptr);
-            _Construct_in_place(_Mypair._Myval2._Bx._Ptr, _Fancyptr);
+            _Construct_in_place(_My_data._Bx._Ptr, _Fancyptr);
         }
 
-        _Mypair._Myval2._Mysize = _New_size;
-        _Mypair._Myval2._Myres  = _New_capacity;
+        _My_data._Mysize = _New_size;
+        _My_data._Myres  = _New_capacity;
         _Traits::copy(_Ptr, _Left_ptr, _Left_size);
         _Traits::copy(_Ptr + static_cast<ptrdiff_t>(_Left_size), _Right_ptr, _Right_size);
         _Traits::assign(_Ptr[_New_size], _Elem());
@@ -4298,62 +4301,61 @@ template <class _Elem, class _Traits, class _Alloc>
 _NODISCARD basic_string<_Elem, _Traits, _Alloc> operator+(
     const basic_string<_Elem, _Traits, _Alloc>& _Left, const basic_string<_Elem, _Traits, _Alloc>& _Right) {
     // return string + string
-    if (_Left.max_size() - _Left.size() < _Right.size()) {
+    const auto _Left_size  = _Left.size();
+    const auto _Right_size = _Right.size();
+    if (_Left.max_size() - _Left_size < _Right_size) {
         _Xlen_string();
     }
 
-    return basic_string<_Elem, _Traits, _Alloc>(
-        _String_constructor_concat_tag{}, _Left, _Left.c_str(), _Left.size(), _Right.c_str(), _Right.size());
+    return {_String_constructor_concat_tag{}, _Left, _Left.c_str(), _Left_size, _Right.c_str(), _Right_size};
 }
 
 template <class _Elem, class _Traits, class _Alloc>
 _NODISCARD basic_string<_Elem, _Traits, _Alloc> operator+(
     _In_z_ const _Elem* const _Left, const basic_string<_Elem, _Traits, _Alloc>& _Right) {
-    using _String_type    = basic_string<_Elem, _Traits, _Alloc>;
-    using _Size_type      = typename _String_type::size_type;
-    const auto _Left_size = _Convert_size<_Size_type>(_Traits::length(_Left));
-    if (_Right.max_size() - _Right.size() < _Left_size) {
+    using _Size_type       = typename basic_string<_Elem, _Traits, _Alloc>::size_type;
+    const auto _Left_size  = _Convert_size<_Size_type>(_Traits::length(_Left));
+    const auto _Right_size = _Right.size();
+    if (_Right.max_size() - _Right_size < _Left_size) {
         _Xlen_string();
     }
 
-    return basic_string<_Elem, _Traits, _Alloc>(
-        _String_constructor_concat_tag{}, _Right, _Left, _Left_size, _Right.c_str(), _Right.size());
+    return {_String_constructor_concat_tag{}, _Right, _Left, _Left_size, _Right.c_str(), _Right_size};
 }
 
 template <class _Elem, class _Traits, class _Alloc>
 _NODISCARD basic_string<_Elem, _Traits, _Alloc> operator+(
     const _Elem _Left, const basic_string<_Elem, _Traits, _Alloc>& _Right) {
-    if (_Right.size() == _Right.max_size()) {
+    const auto _Right_size = _Right.size();
+    if (_Right_size == _Right.max_size()) {
         _Xlen_string();
     }
 
-    return basic_string<_Elem, _Traits, _Alloc>(
-        _String_constructor_concat_tag{}, _Right, _STD addressof(_Left), 1, _Right.c_str(), _Right.size());
+    return {_String_constructor_concat_tag{}, _Right, _STD addressof(_Left), 1, _Right.c_str(), _Right_size};
 }
 
 template <class _Elem, class _Traits, class _Alloc>
 _NODISCARD basic_string<_Elem, _Traits, _Alloc> operator+(
     const basic_string<_Elem, _Traits, _Alloc>& _Left, _In_z_ const _Elem* const _Right) {
-    using _String_type     = basic_string<_Elem, _Traits, _Alloc>;
-    using _Size_type       = typename _String_type::size_type;
+    using _Size_type       = typename basic_string<_Elem, _Traits, _Alloc>::size_type;
+    const auto _Left_size  = _Left.size();
     const auto _Right_size = _Convert_size<_Size_type>(_Traits::length(_Right));
-    if (_Left.max_size() - _Left.size() < _Right_size) {
+    if (_Left.max_size() - _Left_size < _Right_size) {
         _Xlen_string();
     }
 
-    return basic_string<_Elem, _Traits, _Alloc>(
-        _String_constructor_concat_tag{}, _Left, _Left.c_str(), _Left.size(), _Right, _Right_size);
+    return {_String_constructor_concat_tag{}, _Left, _Left.c_str(), _Left_size, _Right, _Right_size};
 }
 
 template <class _Elem, class _Traits, class _Alloc>
 _NODISCARD basic_string<_Elem, _Traits, _Alloc> operator+(
     const basic_string<_Elem, _Traits, _Alloc>& _Left, const _Elem _Right) {
-    if (_Left.size() == _Left.max_size()) {
+    const auto _Left_size = _Left.size();
+    if (_Left_size == _Left.max_size()) {
         _Xlen_string();
     }
 
-    return basic_string<_Elem, _Traits, _Alloc>(
-        _String_constructor_concat_tag{}, _Left, _Left.c_str(), _Left.size(), _STD addressof(_Right), 1);
+    return {_String_constructor_concat_tag{}, _Left, _Left.c_str(), _Left_size, _STD addressof(_Right), 1};
 }
 
 template <class _Elem, class _Traits, class _Alloc>

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -2444,7 +2444,7 @@ public:
         const size_type _Left_size, const _Elem* const _Right_ptr, const size_type _Right_size)
         : _Mypair(
             _One_then_variadic_args_t(), _Alty_traits::select_on_container_copy_construction(_Source_of_al._Getal())) {
-        _STL_INTERNAL_CHECK(_Left_size <= max_size()); // caller must check for emission of length_error
+        _STL_INTERNAL_CHECK(_Left_size <= max_size());
         _STL_INTERNAL_CHECK(_Right_size <= max_size());
         _STL_INTERNAL_CHECK(_Right_size <= max_size() - _Left_size);
         const auto _New_size    = static_cast<size_type>(_Left_size + _Right_size);
@@ -2482,40 +2482,35 @@ public:
         const auto _Right_capacity = _Right_data._Myres;
         // overflow is OK due to max_size() checks:
         const auto _New_size = static_cast<size_type>(_Left_size + _Right_size);
-        if (_Right_size <= _Left_capacity - _Left_size && _Left_capacity >= _Right_capacity) {
-            // take _Left's buffer, max_size() is OK because the result fits in _Left's capacity
+        const bool _Fits_in_left = _Right_size <= _Left_capacity - _Left_size;
+        if (_Fits_in_left && _Right_capacity <= _Left_capacity) {
+            // take _Left's buffer, max_size() is OK because _Fits_in_left
             _My_data._Alloc_proxy(_GET_PROXY_ALLOCATOR(_Alty, _Getal())); // throws, hereafter nothrow in this block
             _Take_contents(_Left, bool_constant<_Can_memcpy_val>{});
             const auto _Ptr = _My_data._Myptr();
-            _Traits::copy(_Ptr + _My_data._Mysize, _Right_data._Myptr(), _Right_size);
+            _Traits::copy(_Ptr + _Left_size, _Right_data._Myptr(), _Right_size + 1);
             _My_data._Mysize = _New_size;
-            _Traits::assign(_Ptr[_New_size], _Elem());
             return;
         }
 
-        if (_Allocators_equal(_Getal(), _Right._Getal()) && _Left_size <= _Right_capacity - _Right_size) {
-            // take _Right's buffer, max_size() is OK because the result fits in _Right's capacity
+        const bool _Fits_in_right = _Left_size <= _Right_capacity - _Right_size;
+        if (_Allocators_equal(_Getal(), _Right._Getal()) && _Fits_in_right) {
+            // take _Right's buffer, max_size() is OK because _Fits_in_right
             // At this point, we have tested:
-            // !(_Right_size <= _Left_capacity - _Left_size && _Left_capacity >= _Right_capacity)
-            //     && _Left_size <= _Right_capacity - _Right_size
-            // therefore: (demorgan)
-            // (_Right_size > _Left_capacity - _Left_size || _Left_capacity < _Right_capacity)
-            //     && _Left_size <= _Right_capacity - _Right_size
-            // therefore: (distribute)
-            // (_Right_size > _Left_capacity - _Left_size && _Left_size <= _Right_capacity - _Right_size)
-            // || (_Left_capacity < _Right_capacity && _Left_size <= _Right_capacity - _Right_size)
-            // therefore: either the result fits in _Right's capacity but not in _Left's capacity, so _Right must have
-            //     had more capacity, OR we explicitly tested that _Right had more capacity
-            // therefore: _Right must be in large mode (since it's capacity is larger than the minimum), so save that
-            //     branch
+            // !(_Fits_in_left && _Right_capacity <= _Left_capacity) && _Fits_in_right
+            // therefore: (by De Morgan's Laws)
+            // (!_Fits_in_left || _Right_capacity > _Left_capacity) && _Fits_in_right
+            // therefore: (by the distributive property)
+            // (!_Fits_in_left && _Fits_in_right)  // implying _Right has more capacity
+            //     || (_Right_capacity > _Left_capacity && _Fits_in_right)  // tests that _Right has more capacity
+            // therefore: _Right must have more than the minimum capacity, so it must be _Large_string_engaged()
             _STL_INTERNAL_CHECK(_Right_data._Large_string_engaged());
             _My_data._Alloc_proxy(_GET_PROXY_ALLOCATOR(_Alty, _Getal())); // throws, hereafter nothrow in this block
             _Take_contents(_Right, bool_constant<_Can_memcpy_val>{});
             const auto _Ptr = _Unfancy(_My_data._Bx._Ptr);
-            _Traits::move(_Ptr + _Left_size, _Ptr, _My_data._Mysize);
+            _Traits::move(_Ptr + _Left_size, _Ptr, _My_data._Mysize + 1);
             _Traits::copy(_Ptr, _Left_data._Myptr(), _Left_size);
             _My_data._Mysize = _New_size;
-            _Traits::assign(_Ptr[_New_size], _Elem());
             return;
         }
 
@@ -2535,8 +2530,7 @@ public:
         _My_data._Myres  = _New_capacity;
         const auto _Ptr  = _Unfancy(_Fancyptr);
         _Traits::copy(_Ptr, _Left_data._Myptr(), _Left_size);
-        _Traits::copy(_Ptr + static_cast<ptrdiff_t>(_Left_size), _Right_data._Myptr(), _Right_size);
-        _Traits::assign(_Ptr[_New_size], _Elem());
+        _Traits::copy(_Ptr + _Left_size, _Right_data._Myptr(), _Right_size + 1);
         _Proxy._Release();
     }
 
@@ -4444,13 +4438,13 @@ _NODISCARD basic_string<_Elem, _Traits, _Alloc> operator+(
 template <class _Elem, class _Traits, class _Alloc>
 _NODISCARD basic_string<_Elem, _Traits, _Alloc> operator+(
     basic_string<_Elem, _Traits, _Alloc>&& _Left, basic_string<_Elem, _Traits, _Alloc>&& _Right) {
-#if _CONTAINER_DEBUG_LEVEL == 1
+#if _ITERATOR_DEBUG_LEVEL == 2
     _STL_VERIFY(_STD addressof(_Left) != _STD addressof(_Right),
         "You cannot concatenate the same moved string to itself. See "
         "N4849 [res.on.arguments]/1.3: If a function argument binds to an rvalue reference "
         "parameter, the implementation may assume that this parameter is a unique reference "
         "to this argument");
-#endif // _CONTAINER_DEBUG_LEVEL == 1
+#endif // _ITERATOR_DEBUG_LEVEL == 2
     return {_String_constructor_concat_tag{}, _Left, _Right};
 }
 

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -2444,7 +2444,7 @@ public:
         const auto _New_size    = _Left_size + _Right_size;
         size_type _New_capacity = _BUF_SIZE - 1;
         _Elem* _Ptr             = _Mypair._Myval2._Bx._Buf;
-        auto&& _Alproxy = _GET_PROXY_ALLOCATOR(_Alty, _Getal());
+        auto&& _Alproxy         = _GET_PROXY_ALLOCATOR(_Alty, _Getal());
         _Container_proxy_ptr<_Alty> _Proxy(_Alproxy, _Mypair._Myval2);
         if (_New_capacity < _New_size) {
             _New_capacity           = _Calculate_growth(_New_size, _BUF_SIZE - 1, max_size());
@@ -4302,22 +4302,22 @@ _NODISCARD basic_string<_Elem, _Traits, _Alloc> operator+(
         _Xlength_error("string too long");
     }
 
-    return basic_string<_Elem, _Traits, _Alloc>(_String_constructor_concat_tag{}, _Left,
-        _Left.c_str(), _Left.size(), _Right.c_str(), _Right.size());
+    return basic_string<_Elem, _Traits, _Alloc>(
+        _String_constructor_concat_tag{}, _Left, _Left.c_str(), _Left.size(), _Right.c_str(), _Right.size());
 }
 
 template <class _Elem, class _Traits, class _Alloc>
 _NODISCARD basic_string<_Elem, _Traits, _Alloc> operator+(
     _In_z_ const _Elem* const _Left, const basic_string<_Elem, _Traits, _Alloc>& _Right) {
-    using _String_type = basic_string<_Elem, _Traits, _Alloc>;
-    using _Size_type   = typename _String_type::size_type;
+    using _String_type    = basic_string<_Elem, _Traits, _Alloc>;
+    using _Size_type      = typename _String_type::size_type;
     const auto _Left_size = _Convert_size<_Size_type>(_Traits::length(_Left));
     if (_Right.max_size() - _Right.size() < _Left_size) {
         _Xlength_error("string too long");
     }
 
-    return basic_string<_Elem, _Traits, _Alloc>(_String_constructor_concat_tag{}, _Right,
-        _Left, _Left_size, _Right.c_str(), _Right.size());
+    return basic_string<_Elem, _Traits, _Alloc>(
+        _String_constructor_concat_tag{}, _Right, _Left, _Left_size, _Right.c_str(), _Right.size());
 }
 
 template <class _Elem, class _Traits, class _Alloc>
@@ -4327,22 +4327,22 @@ _NODISCARD basic_string<_Elem, _Traits, _Alloc> operator+(
         _Xlength_error("string too long");
     }
 
-    return basic_string<_Elem, _Traits, _Alloc>(_String_constructor_concat_tag{}, _Right,
-        _STD addressof(_Left), 1, _Right.c_str(), _Right.size());
+    return basic_string<_Elem, _Traits, _Alloc>(
+        _String_constructor_concat_tag{}, _Right, _STD addressof(_Left), 1, _Right.c_str(), _Right.size());
 }
 
 template <class _Elem, class _Traits, class _Alloc>
 _NODISCARD basic_string<_Elem, _Traits, _Alloc> operator+(
     const basic_string<_Elem, _Traits, _Alloc>& _Left, _In_z_ const _Elem* const _Right) {
-    using _String_type = basic_string<_Elem, _Traits, _Alloc>;
-    using _Size_type   = typename _String_type::size_type;
+    using _String_type     = basic_string<_Elem, _Traits, _Alloc>;
+    using _Size_type       = typename _String_type::size_type;
     const auto _Right_size = _Convert_size<_Size_type>(_Traits::length(_Right));
     if (_Left.max_size() - _Left.size() < _Right_size) {
         _Xlength_error("string too long");
     }
 
-    return basic_string<_Elem, _Traits, _Alloc>(_String_constructor_concat_tag{}, _Left,
-        _Left.c_str(), _Left.size(), _Right, _Right_size);
+    return basic_string<_Elem, _Traits, _Alloc>(
+        _String_constructor_concat_tag{}, _Left, _Left.c_str(), _Left.size(), _Right, _Right_size);
 }
 
 template <class _Elem, class _Traits, class _Alloc>
@@ -4352,8 +4352,8 @@ _NODISCARD basic_string<_Elem, _Traits, _Alloc> operator+(
         _Xlength_error("string too long");
     }
 
-    return basic_string<_Elem, _Traits, _Alloc>(_String_constructor_concat_tag{}, _Left,
-        _Left.c_str(), _Left.size(), _STD addressof(_Right), 1);
+    return basic_string<_Elem, _Traits, _Alloc>(
+        _String_constructor_concat_tag{}, _Left, _Left.c_str(), _Left.size(), _STD addressof(_Right), 1);
 }
 
 template <class _Elem, class _Traits, class _Alloc>

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -2456,8 +2456,8 @@ public:
         _Mypair._Myval2._Mysize = _New_size;
         _Mypair._Myval2._Myres  = _New_capacity;
         _Traits::copy(_Ptr, _Left_ptr, _Left_size);
-        _STL_INTERNAL_CHECK(_Elem() == _Right_ptr[_Right_size]);
-        _Traits::copy(_Ptr + static_cast<ptrdiff_t>(_Left_size), _Right_ptr, _Right_size + 1);
+        _Traits::copy(_Ptr + static_cast<ptrdiff_t>(_Left_size), _Right_ptr, _Right_size);
+        _Traits::assign(_Ptr[_New_size], _Elem());
         _Proxy._Release();
     }
 

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -2196,6 +2196,7 @@ template <class _Ty>
 constexpr size_t _Size_after_ebco_v = is_empty_v<_Ty> ? 0 : sizeof(_Ty); // get _Ty's size after being EBCO'd
 
 struct _String_constructor_concat_tag {
+    // tag to select constructors used by basic_string's concatenation operators (operator+)
     explicit _String_constructor_concat_tag() = default;
 };
 
@@ -2508,7 +2509,7 @@ public:
             _My_data._Alloc_proxy(_GET_PROXY_ALLOCATOR(_Alty, _Getal())); // throws, hereafter nothrow in this block
             _Take_contents(_Right, bool_constant<_Can_memcpy_val>{});
             const auto _Ptr = _Unfancy(_My_data._Bx._Ptr);
-            _Traits::move(_Ptr + _Left_size, _Ptr, _My_data._Mysize + 1);
+            _Traits::move(_Ptr + _Left_size, _Ptr, _Right_size + 1);
             _Traits::copy(_Ptr, _Left_data._Myptr(), _Left_size);
             _My_data._Mysize = _New_size;
             return;

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -2134,7 +2134,7 @@ public:
             ? 15
             : sizeof(value_type) <= 2 ? 7 : sizeof(value_type) <= 4 ? 3 : sizeof(value_type) <= 8 ? 1 : 0;
 
-    value_type* _Myptr() {
+    value_type* _Myptr() noexcept {
         value_type* _Result = _Bx._Buf;
         if (_Large_string_engaged()) {
             _Result = _Unfancy(_Bx._Ptr);
@@ -2143,7 +2143,7 @@ public:
         return _Result;
     }
 
-    const value_type* _Myptr() const {
+    const value_type* _Myptr() const noexcept {
         const value_type* _Result = _Bx._Buf;
         if (_Large_string_engaged()) {
             _Result = _Unfancy(_Bx._Ptr);
@@ -2152,7 +2152,7 @@ public:
         return _Result;
     }
 
-    bool _Large_string_engaged() const {
+    bool _Large_string_engaged() const noexcept {
         return _BUF_SIZE <= _Myres;
     }
 
@@ -2447,7 +2447,7 @@ public:
         _STL_INTERNAL_CHECK(_Left_size <= max_size()); // caller must check for emission of length_error
         _STL_INTERNAL_CHECK(_Right_size <= max_size());
         _STL_INTERNAL_CHECK(_Right_size <= max_size() - _Left_size);
-        const auto _New_size    = _Left_size + _Right_size;
+        const auto _New_size    = static_cast<size_type>(_Left_size + _Right_size);
         size_type _New_capacity = _BUF_SIZE - 1;
         auto& _My_data          = _Mypair._Myval2;
         _Elem* _Ptr             = _My_data._Bx._Buf;
@@ -2464,6 +2464,69 @@ public:
         _My_data._Myres  = _New_capacity;
         _Traits::copy(_Ptr, _Left_ptr, _Left_size);
         _Traits::copy(_Ptr + static_cast<ptrdiff_t>(_Left_size), _Right_ptr, _Right_size);
+        _Traits::assign(_Ptr[_New_size], _Elem());
+        _Proxy._Release();
+    }
+
+    basic_string(_String_constructor_concat_tag, basic_string& _Left, basic_string& _Right)
+        : _Mypair(_One_then_variadic_args_t(), _Left._Getal()) {
+        auto& _My_data    = _Mypair._Myval2;
+        auto& _Left_data  = _Left._Mypair._Myval2;
+        auto& _Right_data = _Right._Mypair._Myval2;
+        _Left_data._Orphan_all();
+        _Right_data._Orphan_all();
+        const auto _Left_size  = _Left_data._Mysize;
+        const auto _Right_size = _Right_data._Mysize;
+
+        const auto _Left_capacity  = _Left_data._Myres;
+        const auto _Right_capacity = _Right_data._Myres;
+        // overflow is OK due to max_size() checks:
+        const auto _New_size = static_cast<size_type>(_Left_size + _Right_size);
+        if (_Allocators_equal(_Getal(), _Right._Getal()) && _Right_capacity > _Left_capacity
+            && _Left_size <= _Right_capacity - _Right_size) {
+            // take _Right's buffer, max_size() is OK because we're under _Right's capacity
+            _My_data._Alloc_proxy(_GET_PROXY_ALLOCATOR(_Alty, _Getal())); // throws, hereafter nothrow in this block
+            _Take_contents(_Right, bool_constant<_Can_memcpy_val>{});
+            // _Right had more capacity than left, therefore _Right did not have the minimum capacity,
+            // therefore _Right had _Large_string_engaged(), therefore after _Take_contents we have
+            // _Large_string_engaged() and can save that branch
+            _STL_INTERNAL_CHECK(_My_data._Large_string_engaged());
+            const auto _Ptr = _Unfancy(_My_data._Bx._Ptr);
+            _Traits::move(_Ptr + _Left_size, _Ptr, _My_data._Mysize + 1);
+            _Traits::copy(_Ptr, _Left_data._Myptr(), _Left_size);
+            _My_data._Mysize = _New_size;
+            _Traits::assign(_Ptr[_New_size], _Elem());
+            return;
+        }
+
+        if (_Right_size < _Left_capacity - _Left_size) {
+            // take _Left's buffer, max_size() is OK because we're under _Left's capacity
+            _My_data._Alloc_proxy(_GET_PROXY_ALLOCATOR(_Alty, _Getal())); // throws, hereafter nothrow in this block
+            _Take_contents(_Left, bool_constant<_Can_memcpy_val>{});
+            const auto _Ptr = _My_data._Myptr();
+            _Traits::copy(_Ptr + _My_data._Mysize, _Right_data._Myptr(), _Right_size);
+            _My_data._Mysize = _New_size;
+            _Traits::assign(_Ptr[_New_size], _Elem());
+            return;
+        }
+
+        // can't use either buffer, reallocate
+        const auto _Max = max_size();
+        if (_Max - _Left_size < _Right_size) { // check if max_size() is OK
+            _Xlen_string();
+        }
+
+        const auto _New_capacity = _Calculate_growth(_New_size, _BUF_SIZE - 1, _Max);
+        auto&& _Alproxy          = _GET_PROXY_ALLOCATOR(_Alty, _Getal());
+        _Container_proxy_ptr<_Alty> _Proxy(_Alproxy, _My_data); // throws
+        const pointer _Fancyptr = _Getal().allocate(_New_capacity + 1); // throws
+        // nothrow hereafter
+        _Construct_in_place(_My_data._Bx._Ptr, _Fancyptr);
+        _My_data._Mysize = _New_size;
+        _My_data._Myres  = _New_capacity;
+        const auto _Ptr  = _Unfancy(_Fancyptr);
+        _Traits::copy(_Ptr, _Left_data._Myptr(), _Left_size);
+        _Traits::copy(_Ptr + static_cast<ptrdiff_t>(_Left_size), _Right_data._Myptr(), _Right_size);
         _Traits::assign(_Ptr[_New_size], _Elem());
         _Proxy._Release();
     }
@@ -4300,7 +4363,6 @@ void swap(basic_string<_Elem, _Traits, _Alloc>& _Left,
 template <class _Elem, class _Traits, class _Alloc>
 _NODISCARD basic_string<_Elem, _Traits, _Alloc> operator+(
     const basic_string<_Elem, _Traits, _Alloc>& _Left, const basic_string<_Elem, _Traits, _Alloc>& _Right) {
-    // return string + string
     const auto _Left_size  = _Left.size();
     const auto _Right_size = _Right.size();
     if (_Left.max_size() - _Left_size < _Right_size) {
@@ -4373,11 +4435,14 @@ _NODISCARD basic_string<_Elem, _Traits, _Alloc> operator+(
 template <class _Elem, class _Traits, class _Alloc>
 _NODISCARD basic_string<_Elem, _Traits, _Alloc> operator+(
     basic_string<_Elem, _Traits, _Alloc>&& _Left, basic_string<_Elem, _Traits, _Alloc>&& _Right) {
-    if (_Right.size() <= _Left.capacity() - _Left.size() || _Right.capacity() - _Right.size() < _Left.size()) {
-        return _STD move(_Left.append(_Right));
-    } else {
-        return _STD move(_Right.insert(0, _Left));
-    }
+#if _ITERATOR_DEBUG_LEVEL == 2
+    _STL_VERIFY(_STD addressof(_Left) != _STD addressof(_Right),
+        "You cannot concatenate the same moved string to itself. See "
+        "N4842 [res.on.arguments]/1.3: If a function argument binds to an rvalue reference "
+        "parameter, the implementation may assume that this parameter is a unique reference "
+        "to this argument");
+#endif // _ITERATOR_DEBUG_LEVEL == 2
+    return {_String_constructor_concat_tag{}, _Left, _Right};
 }
 
 template <class _Elem, class _Traits, class _Alloc>

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -4447,7 +4447,7 @@ _NODISCARD basic_string<_Elem, _Traits, _Alloc> operator+(
 #if _CONTAINER_DEBUG_LEVEL == 1
     _STL_VERIFY(_STD addressof(_Left) != _STD addressof(_Right),
         "You cannot concatenate the same moved string to itself. See "
-        "N4842 [res.on.arguments]/1.3: If a function argument binds to an rvalue reference "
+        "N4849 [res.on.arguments]/1.3: If a function argument binds to an rvalue reference "
         "parameter, the implementation may assume that this parameter is a unique reference "
         "to this argument");
 #endif // _CONTAINER_DEBUG_LEVEL == 1

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -2481,7 +2481,7 @@ public:
         const auto _Left_capacity  = _Left_data._Myres;
         const auto _Right_capacity = _Right_data._Myres;
         // overflow is OK due to max_size() checks:
-        const auto _New_size = static_cast<size_type>(_Left_size + _Right_size);
+        const auto _New_size     = static_cast<size_type>(_Left_size + _Right_size);
         const bool _Fits_in_left = _Right_size <= _Left_capacity - _Left_size;
         if (_Fits_in_left && _Right_capacity <= _Left_capacity) {
             // take _Left's buffer, max_size() is OK because _Fits_in_left

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -2195,6 +2195,8 @@ public:
 template <class _Ty>
 constexpr size_t _Size_after_ebco_v = is_empty_v<_Ty> ? 0 : sizeof(_Ty); // get _Ty's size after being EBCO'd
 
+struct _String_constructor_concat_tag {};
+
 template <class _Elem, class _Traits = char_traits<_Elem>, class _Alloc = allocator<_Elem>>
 class basic_string { // null-terminated transparent array of elements
 private:
@@ -2429,6 +2431,33 @@ public:
             }
 
         _Take_contents(_Right, bool_constant<_Can_memcpy_val>{});
+        _Proxy._Release();
+    }
+
+    explicit basic_string(_String_constructor_concat_tag, const basic_string& _Alsource, const _Elem* const _Left_ptr,
+        const size_type _Left_size, const _Elem* const _Right_ptr, const size_type _Right_size)
+        : _Mypair(
+            _One_then_variadic_args_t(), _Alty_traits::select_on_container_copy_construction(_Alsource._Getal())) {
+        _STL_INTERNAL_CHECK(_Left_size < max_size());
+        _STL_INTERNAL_CHECK(_Right_size < max_size());
+        _STL_INTERNAL_CHECK(max_size() - _Left_size >= _Right_size);
+        const auto _New_size    = _Left_size + _Right_size;
+        size_type _New_capacity = _BUF_SIZE - 1;
+        _Elem* _Ptr             = _Mypair._Myval2._Bx._Buf;
+        auto&& _Alproxy = _GET_PROXY_ALLOCATOR(_Alty, _Getal());
+        _Container_proxy_ptr<_Alty> _Proxy(_Alproxy, _Mypair._Myval2);
+        if (_New_capacity < _New_size) {
+            _New_capacity           = _Calculate_growth(_New_size, _BUF_SIZE - 1, max_size());
+            const pointer _Fancyptr = _Getal().allocate(_New_capacity + 1); // throws
+            _Ptr                    = _Unfancy(_Fancyptr);
+            _Construct_in_place(_Mypair._Myval2._Bx._Ptr, _Fancyptr);
+        }
+
+        _Mypair._Myval2._Mysize = _New_size;
+        _Mypair._Myval2._Myres  = _New_capacity;
+        _Traits::copy(_Ptr, _Left_ptr, _Left_size);
+        _STL_INTERNAL_CHECK(_Elem() == _Right_ptr[_Right_size]);
+        _Traits::copy(_Ptr + static_cast<ptrdiff_t>(_Left_size), _Right_ptr, _Right_size + 1);
         _Proxy._Release();
     }
 
@@ -4269,11 +4298,12 @@ template <class _Elem, class _Traits, class _Alloc>
 _NODISCARD basic_string<_Elem, _Traits, _Alloc> operator+(
     const basic_string<_Elem, _Traits, _Alloc>& _Left, const basic_string<_Elem, _Traits, _Alloc>& _Right) {
     // return string + string
-    basic_string<_Elem, _Traits, _Alloc> _Ans;
-    _Ans.reserve(_Left.size() + _Right.size());
-    _Ans += _Left;
-    _Ans += _Right;
-    return _Ans;
+    if (_Left.max_size() - _Left.size() < _Right.size()) {
+        _Xlength_error("string too long");
+    }
+
+    return basic_string<_Elem, _Traits, _Alloc>(_String_constructor_concat_tag{}, _Left,
+        _Left.c_str(), _Left.size(), _Right.c_str(), _Right.size());
 }
 
 template <class _Elem, class _Traits, class _Alloc>
@@ -4281,21 +4311,24 @@ _NODISCARD basic_string<_Elem, _Traits, _Alloc> operator+(
     _In_z_ const _Elem* const _Left, const basic_string<_Elem, _Traits, _Alloc>& _Right) {
     using _String_type = basic_string<_Elem, _Traits, _Alloc>;
     using _Size_type   = typename _String_type::size_type;
-    _String_type _Ans;
-    _Ans.reserve(_Convert_size<_Size_type>(_Traits::length(_Left) + _Right.size()));
-    _Ans += _Left;
-    _Ans += _Right;
-    return _Ans;
+    const auto _Left_size = _Convert_size<_Size_type>(_Traits::length(_Left));
+    if (_Right.max_size() - _Right.size() < _Left_size) {
+        _Xlength_error("string too long");
+    }
+
+    return basic_string<_Elem, _Traits, _Alloc>(_String_constructor_concat_tag{}, _Right,
+        _Left, _Left_size, _Right.c_str(), _Right.size());
 }
 
 template <class _Elem, class _Traits, class _Alloc>
 _NODISCARD basic_string<_Elem, _Traits, _Alloc> operator+(
     const _Elem _Left, const basic_string<_Elem, _Traits, _Alloc>& _Right) {
-    basic_string<_Elem, _Traits, _Alloc> _Ans;
-    _Ans.reserve(1 + _Right.size());
-    _Ans += _Left;
-    _Ans += _Right;
-    return _Ans;
+    if (_Right.size() == _Right.max_size()) {
+        _Xlength_error("string too long");
+    }
+
+    return basic_string<_Elem, _Traits, _Alloc>(_String_constructor_concat_tag{}, _Right,
+        _STD addressof(_Left), 1, _Right.c_str(), _Right.size());
 }
 
 template <class _Elem, class _Traits, class _Alloc>
@@ -4303,21 +4336,24 @@ _NODISCARD basic_string<_Elem, _Traits, _Alloc> operator+(
     const basic_string<_Elem, _Traits, _Alloc>& _Left, _In_z_ const _Elem* const _Right) {
     using _String_type = basic_string<_Elem, _Traits, _Alloc>;
     using _Size_type   = typename _String_type::size_type;
-    _String_type _Ans;
-    _Ans.reserve(_Convert_size<_Size_type>(_Left.size() + _Traits::length(_Right)));
-    _Ans += _Left;
-    _Ans += _Right;
-    return _Ans;
+    const auto _Right_size = _Convert_size<_Size_type>(_Traits::length(_Right));
+    if (_Left.max_size() - _Left.size() < _Right_size) {
+        _Xlength_error("string too long");
+    }
+
+    return basic_string<_Elem, _Traits, _Alloc>(_String_constructor_concat_tag{}, _Left,
+        _Left.c_str(), _Left.size(), _Right, _Right_size);
 }
 
 template <class _Elem, class _Traits, class _Alloc>
 _NODISCARD basic_string<_Elem, _Traits, _Alloc> operator+(
     const basic_string<_Elem, _Traits, _Alloc>& _Left, const _Elem _Right) {
-    basic_string<_Elem, _Traits, _Alloc> _Ans;
-    _Ans.reserve(_Left.size() + 1);
-    _Ans += _Left;
-    _Ans += _Right;
-    return _Ans;
+    if (_Left.size() == _Left.max_size()) {
+        _Xlength_error("string too long");
+    }
+
+    return basic_string<_Elem, _Traits, _Alloc>(_String_constructor_concat_tag{}, _Left,
+        _Left.c_str(), _Left.size(), _STD addressof(_Right), 1);
 }
 
 template <class _Elem, class _Traits, class _Alloc>

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -59,6 +59,7 @@
 // P0941R2 Feature-Test Macros
 // P0972R0 noexcept For <chrono> zero(), min(), max()
 // P1164R1 Making create_directory() Intuitive
+// P1165R1 Consistently Propagating Stateful Allocators In basic_string's operator+()
 // P1902R1 Missing Feature-Test Macros 2017-2019
 
 // _HAS_CXX17 directly controls:


### PR DESCRIPTION
This change is a competing proposal to GH-419.

Resolves GH-53.
Resolves GH-456.

This change adds a bespoke constructor to `basic_string` to handle string concat use cases, removing any EH states we previously emitted in our operator+s, avoiding double strlen in our operator+s,

The EH states problem comes from our old pattern:

```
S operator+(a, b) {
    S result;
    result.reserve(a.size() +b.size()); // throws
    result += a; // throws
    result += b; // throws
    return result;
}
```

Here, the compiler does not know that the append operation can't throw, because it doesn't understand `basic_string` and doesn't know the `reserve` has made that always safe. As a result, the compiler emitted EH handing code to call `result`'s destructor after each of the reserve and `operator+=` calls.

Using a bespoke concatenating constructor avoids these problems because there is only one throwing operation (in IDL0 mode). As expected, this results in a small performance win in all concats due to avoiding needing to set up EH stuff, and a large performance win for the `const char*` concats due to the avoided second `strlen`:

Performance:

```
#include <benchmark/benchmark.h>
#include <stdint.h>
#include <string>

constexpr size_t big = 2 << 12;
constexpr size_t multiplier = 64;

static void string_concat_string(benchmark::State &state) {
    std::string x(static_cast<size_t>(state.range(0)), 'a');
    std::string y(static_cast<size_t>(state.range(1)), 'b');
    for (auto _ : state) {
        (void)_;
        benchmark::DoNotOptimize(x + y);
    }
}

BENCHMARK(string_concat_string)->RangeMultiplier(multiplier)->Ranges({{2, big}, {2, big}});

static void string_concat_ntbs(benchmark::State &state) {
    std::string x(static_cast<size_t>(state.range(0)), 'a');
    std::string yBuf(static_cast<size_t>(state.range(1)), 'b');
    const char *const y = yBuf.c_str();
    for (auto _ : state) {
        (void)_;
        benchmark::DoNotOptimize(x + y);
    }
}

BENCHMARK(string_concat_ntbs)->RangeMultiplier(multiplier)->Ranges({{2, big}, {2, big}});

static void string_concat_char(benchmark::State &state) {
    std::string x(static_cast<size_t>(state.range(0)), 'a');
    for (auto _ : state) {
        (void)_;
        benchmark::DoNotOptimize(x + 'b');
    }
}

BENCHMARK(string_concat_char)->Range(2, big);

static void ntbs_concat_string(benchmark::State &state) {
    std::string xBuf(static_cast<size_t>(state.range(0)), 'a');
    const char *const x = xBuf.c_str();
    std::string y(static_cast<size_t>(state.range(1)), 'b');
    for (auto _ : state) {
        (void)_;
        benchmark::DoNotOptimize(x + y);
    }
}

BENCHMARK(ntbs_concat_string)->RangeMultiplier(multiplier)->Ranges({{2, big}, {2, big}});

static void char_concat_string(benchmark::State &state) {
    std::string x(static_cast<size_t>(state.range(0)), 'a');
    for (auto _ : state) {
        (void)_;
        benchmark::DoNotOptimize('b' + x);
    }
}

BENCHMARK(char_concat_string)->Range(2, big);

BENCHMARK_MAIN();

```

Times are in NS on a Ryzen Threadripper 3970X, improvements are `((Old/New)-1)*100`

|                                 | old x64 | new x64 | improvement | old x86 | new x86 | improvement |
| ------------------------------- | ------- | ------- | ----------- | ------- |-------- | ----------- |
| string_concat_string/2/2        | 12.8697 | 5.78125 |     122.61% | 13.9029 | 11.0696 |      25.60% |
| string_concat_string/64/2       |  62.779 | 61.3839 |       2.27% | 66.4394 | 61.6296 |       7.80% |
| string_concat_string/4096/2     | 125.558 | 124.512 |       0.84% | 124.477 | 117.606 |       5.84% |
| string_concat_string/8192/2     | 188.337 | 184.152 |       2.27% | 189.982 | 185.598 |       2.36% |
| string_concat_string/2/64       | 64.5229 | 64.1741 |       0.54% | 67.1338 | 61.4962 |       9.17% |
| string_concat_string/64/64      | 65.5692 | 59.9888 |       9.30% | 66.7742 | 60.4781 |      10.41% |
| string_concat_string/4096/64    | 122.768 | 122.768 |       0.00% | 126.774 | 116.327 |       8.98% |
| string_concat_string/8192/64    |  190.43 | 181.362 |       5.00% | 188.516 | 186.234 |       1.23% |
| string_concat_string/2/4096     | 125.558 | 119.978 |       4.65% | 120.444 | 111.524 |       8.00% |
| string_concat_string/64/4096    | 125.558 | 119.978 |       4.65% | 122.911 | 117.136 |       4.93% |
| string_concat_string/4096/4096  | 188.337 | 184.152 |       2.27% | 193.337 | 182.357 |       6.02% |
| string_concat_string/8192/4096  | 273.438 | 266.811 |       2.48% | 267.656 | 255.508 |       4.75% |
| string_concat_string/2/8192     | 205.078 | 194.964 |       5.19% | 175.025 | 170.181 |       2.85% |
| string_concat_string/64/8192    | 205.078 | 188.337 |       8.89% | 191.676 |  183.06 |       4.71% |
| string_concat_string/4096/8192  | 266.811 | 256.696 |       3.94% | 267.455 | 255.221 |       4.79% |
| string_concat_string/8192/8192  |  414.69 | 435.965 |      -4.88% | 412.784 |  403.01 |       2.43% |
| string_concat_ntbs/2/2          | 12.8348 |  5.9375 |     116.17% |   14.74 |  11.132 |      32.41% |
| string_concat_ntbs/64/2         | 71.1496 |  59.375 |      19.83% | 70.6934 | 60.9371 |      16.01% |
| string_concat_ntbs/4096/2       | 128.697 | 114.397 |      12.50% | 126.626 | 121.887 |       3.89% |
| string_concat_ntbs/8192/2       | 194.964 | 176.479 |      10.47% | 196.641 |  186.88 |       5.22% |
| string_concat_ntbs/2/64         | 100.446 |  74.986 |      33.95% | 109.082 | 83.3939 |      30.80% |
| string_concat_ntbs/64/64        | 106.027 | 78.4738 |      35.11% | 109.589 | 84.3635 |      29.90% |
| string_concat_ntbs/4096/64      | 164.969 | 138.114 |      19.44% | 165.417 | 142.116 |      16.40% |
| string_concat_ntbs/8192/64      | 224.958 | 200.195 |      12.37% | 228.769 | 200.347 |      14.19% |
| string_concat_ntbs/2/4096       | 2040.32 | 1074.22 |      89.94% | 2877.33 | 1362.74 |     111.14% |
| string_concat_ntbs/64/4096      | 1994.98 | 1074.22 |      85.71% | 2841.93 | 1481.62 |      91.81% |
| string_concat_ntbs/4096/4096    | 2050.78 | 1147.46 |      78.72% | 2907.78 | 1550.82 |      87.50% |
| string_concat_ntbs/8192/4096    | 2148.44 | 1227.68 |      75.00% | 2966.92 | 1583.78 |      87.33% |
| string_concat_ntbs/2/8192       | 3934.14 | 2099.61 |      87.37% | 5563.32 | 2736.56 |     103.30% |
| string_concat_ntbs/64/8192      | 3989.95 | 1994.98 |     100.00% | 5456.84 | 2823.53 |      93.26% |
| string_concat_ntbs/4096/8192    | 4049.24 | 2197.27 |      84.29% | 5674.02 | 2957.04 |      91.88% |
| string_concat_ntbs/8192/8192    | 4237.58 | 2249.58 |      88.37% | 5755.07 | 3095.65 |      85.91% |
| string_concat_char/2            | 12.8348 | 3.44936 |     272.09% | 11.1104 | 10.6976 |       3.86% |
| string_concat_char/8            | 8.99833 | 3.45285 |     160.61% | 11.1964 | 10.6928 |       4.71% |
| string_concat_char/64           | 65.5692 | 60.9375 |       7.60% | 65.7585 | 60.0182 |       9.56% |
| string_concat_char/512          | 72.5446 | 69.7545 |       4.00% |  83.952 | 79.5254 |       5.57% |
| string_concat_char/4096         | 125.558 | 119.978 |       4.65% | 123.475 | 117.103 |       5.44% |
| string_concat_char/8192         |  190.43 | 187.988 |       1.30% | 189.181 | 185.174 |       2.16% |
| ntbs_concat_string/2/2          | 13.4975 | 6.13839 |     119.89% | 14.8623 |   11.09 |      34.02% |
| ntbs_concat_string/64/2         |  104.98 | 79.5201 |      32.02% | 112.207 | 83.7111 |      34.04% |
| ntbs_concat_string/4096/2       | 2085.66 | 1098.63 |      89.84% | 2815.19 | 1456.08 |      93.34% |
| ntbs_concat_string/8192/2       | 3899.27 | 2099.61 |      85.71% | 5544.52 | 2765.16 |     100.51% |
| ntbs_concat_string/2/64         | 71.4983 |  62.779 |      13.89% | 72.6602 | 63.1953 |      14.98% |
| ntbs_concat_string/64/64        |  104.98 | 80.2176 |      30.87% | 111.073 | 81.8413 |      35.72% |
| ntbs_concat_string/4096/64      | 2085.66 | 1074.22 |      94.16% | 2789.73 |  1318.7 |     111.55% |
| ntbs_concat_string/8192/64      | 3989.95 | 2085.66 |      91.30% | 5486.85 | 2693.83 |     103.68% |
| ntbs_concat_string/2/4096       | 136.719 | 128.348 |       6.52% | 122.605 |  114.44 |       7.13% |
| ntbs_concat_string/64/4096      | 167.411 | 142.997 |      17.07% | 168.572 | 138.566 |      21.65% |
| ntbs_concat_string/4096/40      | 2099.61 | 1171.88 |      79.17% | 2923.85 | 1539.02 |      89.98% |
| ntbs_concat_string/8192/40      | 4098.07 | 2246.09 |      82.45% | 5669.34 | 3005.25 |      88.65% |
| ntbs_concat_string/2/8192       |   213.1 | 199.498 |       6.82% | 178.197 | 168.532 |       5.73% |
| ntbs_concat_string/64/8192      | 223.214 | 214.844 |       3.90% | 232.263 | 203.722 |      14.01% |
| ntbs_concat_string/4096/81      | 2148.44 | 1255.58 |      71.11% | 2980.78 | 1612.97 |      84.80% |
| ntbs_concat_string/8192/81      | 4237.58 | 2406.53 |      76.09% | 5775.55 | 3067.94 |      88.25% |
| char_concat_string/2            | 11.1607 | 3.60631 |     209.48% | 11.2101 | 10.7192 |       4.58% |
| char_concat_string/8            | 11.4746 | 3.52958 |     225.10% | 11.4595 |  10.709 |       7.01% |
| char_concat_string/64           | 65.5692 | 66.9643 |      -2.08% | 66.6272 | 60.8601 |       9.48% |
| char_concat_string/512          | 68.0106 | 73.2422 |      -7.14% | 91.1946 | 83.0791 |       9.77% |
| char_concat_string/4096         | 125.558 | 122.768 |       2.27% | 119.432 | 110.031 |       8.54% |
| char_concat_string/8192         | 199.498 | 199.498 |       0.00% | 171.895 | 169.173 |       1.61% |


Code size:
```
#include <string>

std::string strings(const std::string& a, const std::string& b) {
    return a + b;
}
std::string string_ntbs(const std::string& a, const char * b) {
    return a + b;
}
std::string string_char(const std::string& a, char b) {
    return a + b;
}
std::string ntbs_string(const char * a, const std::string& b) {
    return a + b;
}
std::string char_string(char a, const std::string& b) {
    return a + b;
}
```

Sizes are in bytes for the `.obj`, "Times Original" is New/Old, `cl /EHsc /W4 /WX /c /O2 .\code_size.cpp`:

| Bytes | Before | After  | Times Original |
| ----- | ------ | ------ | -------------- |
| x64   | 70,290 | 34,192 |          0.486 |
| x86   | 47,152 | 28,792 |          0.611 |

# Checklist

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [x] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
