### PR TITLE
Implement char8_t compatibility remedies

### DIFF
--- a/stl/inc/ostream
+++ b/stl/inc/ostream
@@ -925,7 +925,7 @@ template <class _Traits>
 basic_ostream<wchar_t, _Traits>& operator<<(basic_ostream<wchar_t, _Traits>&, char8_t) = delete;
 #endif // __cpp_char8_t
 
-#if _HAS_CXX20
+#if _HAS_CXX20 && !_HAS_STREAM_INSERTIONS_REMOVED_BY_P1423
 template <class _Traits>
 basic_ostream<char, _Traits>& operator<<(basic_ostream<char, _Traits>&, wchar_t) = delete;
 template <class _Traits>
@@ -949,7 +949,7 @@ template <class _Traits>
 basic_ostream<wchar_t, _Traits>& operator<<(basic_ostream<wchar_t, _Traits>&, const char16_t*) = delete;
 template <class _Traits>
 basic_ostream<wchar_t, _Traits>& operator<<(basic_ostream<wchar_t, _Traits>&, const char32_t*) = delete;
-#endif // !_HAS_CXX20
+#endif // _HAS_CXX20 && !_HAS_STREAM_INSERTIONS_REMOVED_BY_P1423
 
 template <class _Ostr, class _Ty, class = void>
 struct _Can_stream_out : false_type {};

--- a/stl/inc/ostream
+++ b/stl/inc/ostream
@@ -925,9 +925,15 @@ template <class _Traits>
 basic_ostream<wchar_t, _Traits>& operator<<(basic_ostream<wchar_t, _Traits>&, char8_t) = delete;
 #endif // __cpp_char8_t
 
-#if !_HAS_STREAM_INSERTIONS_REMOVED_IN_CXX20
+#if !_HAS_STREAM_INSERTION_OPERATORS_DELETED_IN_CXX20
+#ifdef _NATIVE_WCHAR_T_DEFINED
 template <class _Traits>
 basic_ostream<char, _Traits>& operator<<(basic_ostream<char, _Traits>&, wchar_t) = delete;
+
+template <class _Traits>
+basic_ostream<char, _Traits>& operator<<(basic_ostream<char, _Traits>&, const wchar_t*) = delete;
+#endif // _NATIVE_WCHAR_T_DEFINED
+
 template <class _Traits>
 basic_ostream<char, _Traits>& operator<<(basic_ostream<char, _Traits>&, char16_t) = delete;
 template <class _Traits>
@@ -939,8 +945,6 @@ template <class _Traits>
 basic_ostream<wchar_t, _Traits>& operator<<(basic_ostream<wchar_t, _Traits>&, char32_t) = delete;
 
 template <class _Traits>
-basic_ostream<char, _Traits>& operator<<(basic_ostream<char, _Traits>&, const wchar_t*) = delete;
-template <class _Traits>
 basic_ostream<char, _Traits>& operator<<(basic_ostream<char, _Traits>&, const char16_t*) = delete;
 template <class _Traits>
 basic_ostream<char, _Traits>& operator<<(basic_ostream<char, _Traits>&, const char32_t*) = delete;
@@ -949,7 +953,7 @@ template <class _Traits>
 basic_ostream<wchar_t, _Traits>& operator<<(basic_ostream<wchar_t, _Traits>&, const char16_t*) = delete;
 template <class _Traits>
 basic_ostream<wchar_t, _Traits>& operator<<(basic_ostream<wchar_t, _Traits>&, const char32_t*) = delete;
-#endif // !_HAS_STREAM_INSERTIONS_REMOVED_IN_CXX20
+#endif // !_HAS_STREAM_INSERTION_OPERATORS_DELETED_IN_CXX20
 
 template <class _Ostr, class _Ty, class = void>
 struct _Can_stream_out : false_type {};

--- a/stl/inc/ostream
+++ b/stl/inc/ostream
@@ -912,14 +912,45 @@ basic_ostream<char, _Traits>& operator<<(
 }
 
 #ifdef __cpp_char8_t // These deleted overloads are specified in P1423.
+// don't insert a UTF-8 NTBS
 template <class _Traits>
-basic_ostream<char, _Traits>& operator<<(
-    basic_ostream<char, _Traits>&, const char8_t*) = delete; // don't insert a UTF-8 NTBS
+basic_ostream<char, _Traits>& operator<<(basic_ostream<char, _Traits>&, const char8_t*) = delete;
+template <class _Traits>
+basic_ostream<wchar_t, _Traits>& operator<<(basic_ostream<wchar_t, _Traits>&, const char8_t*) = delete;
+
+// don't insert a UTF-8 code unit
+template <class _Traits>
+basic_ostream<char, _Traits>& operator<<(basic_ostream<char, _Traits>&, char8_t) = delete;
+template <class _Traits>
+basic_ostream<wchar_t, _Traits>& operator<<(basic_ostream<wchar_t, _Traits>&, char8_t) = delete;
+#endif // __cpp_char8_t
+
+#if _HAS_CXX20
+template <class _Traits>
+basic_ostream<char, _Traits>& operator<<(basic_ostream<char, _Traits>&, wchar_t) = delete;
+template <class _Traits>
+basic_ostream<char, _Traits>& operator<<(basic_ostream<char, _Traits>&, char16_t) = delete;
+template <class _Traits>
+basic_ostream<char, _Traits>& operator<<(basic_ostream<char, _Traits>&, char32_t) = delete;
 
 template <class _Traits>
-basic_ostream<char, _Traits>& operator<<(
-    basic_ostream<char, _Traits>&, char8_t) = delete; // don't insert a UTF-8 code unit
-#endif // __cpp_char8_t
+basic_ostream<wchar_t, _Traits>& operator<<(basic_ostream<wchar_t, _Traits>&, char16_t) = delete;
+template <class _Traits>
+basic_ostream<wchar_t, _Traits>& operator<<(basic_ostream<wchar_t, _Traits>&, char32_t) = delete;
+
+template <class _Traits>
+basic_ostream<char, _Traits>& operator<<(basic_ostream<char, _Traits>&, const wchar_t*) = delete;
+template <class _Traits>
+basic_ostream<char, _Traits>& operator<<(basic_ostream<char, _Traits>&, const char16_t*) = delete;
+template <class _Traits>
+basic_ostream<char, _Traits>& operator<<(basic_ostream<char, _Traits>&, const char32_t*) = delete;
+
+template <class _Traits>
+basic_ostream<wchar_t, _Traits>& operator<<(basic_ostream<wchar_t, _Traits>&, const char16_t*) = delete;
+template <class _Traits>
+basic_ostream<wchar_t, _Traits>& operator<<(basic_ostream<wchar_t, _Traits>&, const char32_t*) = delete;
+
+#endif // !_HAS_CXX20
 
 template <class _Ostr, class _Ty, class = void>
 struct _Can_stream_out : false_type {};

--- a/stl/inc/ostream
+++ b/stl/inc/ostream
@@ -925,7 +925,7 @@ template <class _Traits>
 basic_ostream<wchar_t, _Traits>& operator<<(basic_ostream<wchar_t, _Traits>&, char8_t) = delete;
 #endif // __cpp_char8_t
 
-#if _HAS_CXX20 && !_HAS_STREAM_INSERTIONS_REMOVED_BY_P1423
+#if !_HAS_STREAM_INSERTIONS_REMOVED_IN_CXX20
 template <class _Traits>
 basic_ostream<char, _Traits>& operator<<(basic_ostream<char, _Traits>&, wchar_t) = delete;
 template <class _Traits>
@@ -949,7 +949,7 @@ template <class _Traits>
 basic_ostream<wchar_t, _Traits>& operator<<(basic_ostream<wchar_t, _Traits>&, const char16_t*) = delete;
 template <class _Traits>
 basic_ostream<wchar_t, _Traits>& operator<<(basic_ostream<wchar_t, _Traits>&, const char32_t*) = delete;
-#endif // _HAS_CXX20 && !_HAS_STREAM_INSERTIONS_REMOVED_BY_P1423
+#endif // !_HAS_STREAM_INSERTIONS_REMOVED_IN_CXX20
 
 template <class _Ostr, class _Ty, class = void>
 struct _Can_stream_out : false_type {};

--- a/stl/inc/ostream
+++ b/stl/inc/ostream
@@ -949,7 +949,6 @@ template <class _Traits>
 basic_ostream<wchar_t, _Traits>& operator<<(basic_ostream<wchar_t, _Traits>&, const char16_t*) = delete;
 template <class _Traits>
 basic_ostream<wchar_t, _Traits>& operator<<(basic_ostream<wchar_t, _Traits>&, const char32_t*) = delete;
-
 #endif // !_HAS_CXX20
 
 template <class _Ostr, class _Ty, class = void>

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -588,9 +588,9 @@
 
 // P1423R3 char8_t Backward Compatibility Remediation
 // Controls whether we allow the stream insertions this proposal forbids
-#ifndef _HAS_STREAM_INSERTIONS_REMOVED_BY_P1423
-#define _HAS_STREAM_INSERTIONS_REMOVED_BY_P1423 0
-#endif // _HAS_STREAM_INSERTIONS_REMOVED_BY_P1423
+#ifndef _HAS_STREAM_INSERTIONS_REMOVED_IN_CXX20
+#define _HAS_STREAM_INSERTIONS_REMOVED_IN_CXX20 (!_HAS_CXX20)
+#endif // _HAS_STREAM_INSERTIONS_REMOVED_IN_CXX20
 
 // P0174R2 Deprecating Vestigial Library Parts
 // P0521R0 Deprecating shared_ptr::unique()

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -588,9 +588,9 @@
 
 // P1423R3 char8_t Backward Compatibility Remediation
 // Controls whether we allow the stream insertions this proposal forbids
-#ifndef _HAS_STREAM_INSERTIONS_REMOVED_IN_CXX20
-#define _HAS_STREAM_INSERTIONS_REMOVED_IN_CXX20 (!_HAS_CXX20)
-#endif // _HAS_STREAM_INSERTIONS_REMOVED_IN_CXX20
+#ifndef _HAS_STREAM_INSERTION_OPERATORS_DELETED_IN_CXX20
+#define _HAS_STREAM_INSERTION_OPERATORS_DELETED_IN_CXX20 (!_HAS_CXX20)
+#endif // _HAS_STREAM_INSERTION_OPERATORS_DELETED_IN_CXX20
 
 // P0174R2 Deprecating Vestigial Library Parts
 // P0521R0 Deprecating shared_ptr::unique()

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -586,6 +586,12 @@
 #endif // _M_FP_EXCEPT
 #endif // _STD_VECTORIZE_WITH_FLOAT_CONTROL
 
+// P1423R3 char8_t Backward Compatibility Remediation
+// Controls whether we allow the stream insertions this proposal forbids
+#ifndef _HAS_STREAM_INSERTIONS_REMOVED_BY_P1423
+#define _HAS_STREAM_INSERTIONS_REMOVED_BY_P1423 0
+#endif // _HAS_STREAM_INSERTIONS_REMOVED_BY_P1423
+
 // P0174R2 Deprecating Vestigial Library Parts
 // P0521R0 Deprecating shared_ptr::unique()
 // Other C++17 deprecation warnings

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -59,6 +59,7 @@
 // P0941R2 Feature-Test Macros
 // P0972R0 noexcept For <chrono> zero(), min(), max()
 // P1164R1 Making create_directory() Intuitive
+// P1423R3 char8_t Backward Compatibility Remediation
 // P1902R1 Missing Feature-Test Macros 2017-2019
 
 // _HAS_CXX17 directly controls:
@@ -1007,7 +1008,7 @@
 #define __cpp_lib_bounded_array_traits 201902L
 
 #ifdef __cpp_char8_t
-#define __cpp_lib_char8_t 201811L
+#define __cpp_lib_char8_t 201907L
 #endif // __cpp_char8_t
 
 #if defined(__cpp_concepts) && __cpp_concepts > 201507L

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -59,7 +59,6 @@
 // P0941R2 Feature-Test Macros
 // P0972R0 noexcept For <chrono> zero(), min(), max()
 // P1164R1 Making create_directory() Intuitive
-// P1423R3 char8_t Backward Compatibility Remediation
 // P1902R1 Missing Feature-Test Macros 2017-2019
 
 // _HAS_CXX17 directly controls:
@@ -173,6 +172,7 @@
 // P1227R2 Signed std::ssize(), Unsigned span::size()
 // P1357R1 is_bounded_array, is_unbounded_array
 // P1394R4 Range Constructor For span
+// P1423R3 char8_t Backward Compatibility Remediation
 // P1456R1 Move-Only Views
 // P1612R1 Relocating endian To <bit>
 // P1645R1 constexpr For <numeric> Algorithms

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -51,6 +51,13 @@ containers\unord\unord.set\insert_and_emplace_allocator_requirements.pass.cpp
 # See https://reviews.llvm.org/D73138
 containers\views\span.sub\subspan.pass.cpp
 
+# libcxx doesn't yet implement P1423R3, so it expects an "old" value for __cpp_lib_char8_t
+language.support\support.limits\support.limits.general\filesystem.version.pass.cpp
+language.support\support.limits\support.limits.general\istream.version.pass.cpp
+language.support\support.limits\support.limits.general\limits.version.pass.cpp
+language.support\support.limits\support.limits.general\locale.version.pass.cpp
+language.support\support.limits\support.limits.general\ostream.version.pass.cpp
+
 
 # *** INTERACTIONS WITH CONTEST / C1XX THAT UPSTREAM LIKELY WON'T FIX ***
 # Tracked by VSO-593630 "<filesystem> Enable libcxx filesystem tests"


### PR DESCRIPTION
# Description
This addresses #59 by adding the missing deleted overloads to `basic_ostream<meow>::operator<<(bark)`

The other changesin that proposal have already been implemented. As there was no switch the changes have been implemented unconditionally.

# Checklist

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [x] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
