### PR TITLE
<span>: fix cross-type iterator operations

### DIFF
--- a/stl/inc/span
+++ b/stl/inc/span
@@ -177,8 +177,7 @@ struct _Span_iterator {
 #endif // _ITERATOR_DEBUG_LEVEL >= 1
         return _Myptr <=> _Right._Myptr;
     }
-
-#else // ^^^ use spaceship / don't spaceship vvv
+#else // ^^^ use spaceship / no spaceship vvv
     _NODISCARD constexpr bool operator!=(const _Span_iterator& _Right) const noexcept {
         return !(*this == _Right);
     }

--- a/stl/inc/span
+++ b/stl/inc/span
@@ -16,6 +16,10 @@
 #include <type_traits>
 #include <xutility>
 
+#if defined(__cpp_impl_three_way_comparison) && __cpp_impl_three_way_comparison >= 201902L
+#include <compare>
+#endif // defined(__cpp_impl_three_way_comparison) && __cpp_impl_three_way_comparison >= 201902L
+
 #pragma pack(push, _CRT_PACKING)
 #pragma warning(push, _STL_WARNING_LEVEL)
 #pragma warning(disable : _STL_DISABLED_WARNINGS)
@@ -121,6 +125,10 @@ struct _Span_iterator {
         return _Tmp;
     }
 
+    _NODISCARD friend constexpr _Span_iterator operator+(const difference_type _Off, _Span_iterator _Next) noexcept {
+        return _Next += _Off;
+    }
+
     constexpr _Span_iterator& operator-=(const difference_type _Off) noexcept {
         _Verify_offset(-_Off);
         _Myptr -= _Off;
@@ -133,13 +141,21 @@ struct _Span_iterator {
         return _Tmp;
     }
 
-    _NODISCARD constexpr difference_type operator-(const _Span_iterator& _Right) const noexcept {
+    // clang-format off
+#ifdef __cpp_lib_concepts
+    template <class _Ty2>
+    requires same_as<remove_cv_t<_Ty2>, value_type>
+#else // ^^^ use concepts / no concepts vvv
+    template <class _Ty2, enable_if_t<is_same_v<remove_cv_t<_Ty2>, value_type>, int> = 0>
+#endif // __cpp_lib_concepts
+    _NODISCARD constexpr difference_type operator-(const _Span_iterator<_Ty2>& _Right) const noexcept {
 #if _ITERATOR_DEBUG_LEVEL >= 1
         _STL_VERIFY(
             _Mybegin == _Right._Mybegin && _Myend == _Right._Myend, "cannot subtract incompatible span iterators");
 #endif // _ITERATOR_DEBUG_LEVEL >= 1
         return _Myptr - _Right._Myptr;
     }
+    // clang-format on
 
     _NODISCARD constexpr reference operator[](const difference_type _Off) const noexcept {
         return *(*this + _Off);
@@ -153,6 +169,16 @@ struct _Span_iterator {
         return _Myptr == _Right._Myptr;
     }
 
+#if defined(__cpp_impl_three_way_comparison) && __cpp_impl_three_way_comparison >= 201902L
+    _NODISCARD constexpr strong_ordering operator<=>(const _Span_iterator& _Right) const noexcept {
+#if _ITERATOR_DEBUG_LEVEL >= 1
+        _STL_VERIFY(
+            _Mybegin == _Right._Mybegin && _Myend == _Right._Myend, "cannot compare incompatible span iterators");
+#endif // _ITERATOR_DEBUG_LEVEL >= 1
+        return _Myptr <=> _Right._Myptr;
+    }
+
+#else // ^^^ use spaceship / don't spaceship vvv
     _NODISCARD constexpr bool operator!=(const _Span_iterator& _Right) const noexcept {
         return !(*this == _Right);
     }
@@ -176,6 +202,7 @@ struct _Span_iterator {
     _NODISCARD constexpr bool operator>=(const _Span_iterator& _Right) const noexcept {
         return !(*this < _Right);
     }
+#endif // defined(__cpp_impl_three_way_comparison) && __cpp_impl_three_way_comparison >= 201902L
 
 #if _ITERATOR_DEBUG_LEVEL >= 1
     friend constexpr void _Verify_range(const _Span_iterator& _First, const _Span_iterator& _Last) noexcept {
@@ -203,11 +230,6 @@ struct _Span_iterator {
     pointer _Myend   = nullptr;
 #endif // _ITERATOR_DEBUG_LEVEL >= 1
 };
-
-template <class _Ty>
-_NODISCARD _Span_iterator<_Ty> operator+(const ptrdiff_t _Off, _Span_iterator<_Ty> _Next) noexcept {
-    return _Next += _Off;
-}
 
 template <class _Ty>
 struct pointer_traits<_Span_iterator<_Ty>> {


### PR DESCRIPTION
# Description

* Implement `<=>` for C++20 relational operator rewrites.
* `span<T>::operator-` now accepts `_Span_iterator<U>` when `remove_cv_t<T>` and `remove_cv_t<U>` are the same type.

Drive-by: implement `n + span_iterator` as a hidden friend, and make it `constexpr`.

Fixes #473.

[This is a dual of internal MSVC-PR-225927.]

# Checklist

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [X] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [X] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [X] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [X] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
