### PR TITLE
syserror.cpp: Use range-for #479

### DIFF
--- a/stl/src/syserror.cpp
+++ b/stl/src/syserror.cpp
@@ -99,9 +99,9 @@ static const _Win_errtab_t _Win_errtab[] = {
 
 _CRTIMP2_PURE int __CLRCALL_PURE_OR_CDECL _Winerror_map(int _Errcode) {
     // convert Windows error to Posix error if possible, otherwise 0
-    for (const auto& [_Windows, _Posix] : _Win_errtab) {
-        if (_Windows == _Errcode) {
-            return static_cast<int>(_Posix);
+    for (const auto& _Entry : _Win_errtab) {
+        if (_Entry._Windows == _Errcode) {
+            return static_cast<int>(_Entry._Posix);
         }
     }
 
@@ -109,9 +109,9 @@ _CRTIMP2_PURE int __CLRCALL_PURE_OR_CDECL _Winerror_map(int _Errcode) {
 }
 
 _CRTIMP2_PURE unsigned long __CLRCALL_PURE_OR_CDECL _Winerror_message(
-    unsigned long _Message_id, char* _Narrow, unsigned long _Size) { // convert to name of Windows error, return 0 for
-                                                                     // failure, otherwise return number of chars
-                                                                     // written pre: _Size < INT_MAX
+    unsigned long _Message_id, char* _Narrow, unsigned long _Size) {
+    // convert to name of Windows error, return 0 for failure, otherwise return number of chars written
+    // pre: _Size < INT_MAX
     const unique_ptr<wchar_t[]> _Wide(new wchar_t[_Size]); // not using make_unique because we want default-init
     const auto _First = _Wide.get();
     unsigned long _Wide_chars =
@@ -223,9 +223,9 @@ static const _Sys_errtab_t _Sys_errtab[] = {
 };
 
 _CRTIMP2_PURE const char* __CLRCALL_PURE_OR_CDECL _Syserror_map(int _Errcode) { // convert to name of generic error
-    for (const auto& [_Code, _Name] : _Sys_errtab) {
-        if (static_cast<int>(_Code) == _Errcode) {
-            return _Name;
+    for (const auto& _Entry : _Sys_errtab) {
+        if (static_cast<int>(_Entry._Errcode) == _Errcode) {
+            return _Entry._Name;
         }
     }
 

--- a/stl/src/syserror.cpp
+++ b/stl/src/syserror.cpp
@@ -97,9 +97,8 @@ static const _Win_errtab_t _Win_errtab[] = {
     {WSAEWOULDBLOCK, errc::operation_would_block},
 };
 
-_CRTIMP2_PURE int __CLRCALL_PURE_OR_CDECL _Winerror_map(
-    int _Errcode) { // convert Windows error to Posix error if possible, otherwise 0
-
+_CRTIMP2_PURE int __CLRCALL_PURE_OR_CDECL _Winerror_map(int _Errcode) {
+    // convert Windows error to Posix error if possible, otherwise 0
     for (const auto& [_Windows, _Posix] : _Win_errtab) {
         if (_Windows == _Errcode) {
             return static_cast<int>(_Posix);
@@ -224,7 +223,6 @@ static const _Sys_errtab_t _Sys_errtab[] = {
 };
 
 _CRTIMP2_PURE const char* __CLRCALL_PURE_OR_CDECL _Syserror_map(int _Errcode) { // convert to name of generic error
-
     for (const auto& [_Code, _Name] : _Sys_errtab) {
         if (static_cast<int>(_Code) == _Errcode) {
             return _Name;

--- a/stl/src/syserror.cpp
+++ b/stl/src/syserror.cpp
@@ -99,10 +99,10 @@ static const _Win_errtab_t _Win_errtab[] = {
 
 _CRTIMP2_PURE int __CLRCALL_PURE_OR_CDECL _Winerror_map(
     int _Errcode) { // convert Windows error to Posix error if possible, otherwise 0
-    const _Win_errtab_t* _Ptr = &_Win_errtab[0];
-    for (; _Ptr != _STD end(_Win_errtab); ++_Ptr) {
-        if (_Ptr->_Windows == _Errcode) {
-            return static_cast<int>(_Ptr->_Posix);
+
+    for (const auto& [_Windows, _Posix] : _Win_errtab) {
+        if (_Windows == _Errcode) {
+            return static_cast<int>(_Posix);
         }
     }
 
@@ -224,10 +224,10 @@ static const _Sys_errtab_t _Sys_errtab[] = {
 };
 
 _CRTIMP2_PURE const char* __CLRCALL_PURE_OR_CDECL _Syserror_map(int _Errcode) { // convert to name of generic error
-    const _Sys_errtab_t* _Ptr = &_Sys_errtab[0];
-    for (; _Ptr != _STD end(_Sys_errtab); ++_Ptr) {
-        if ((int) _Ptr->_Errcode == _Errcode) {
-            return _Ptr->_Name;
+
+    for (const auto& [_Code, _Name] : _Sys_errtab) {
+        if (static_cast<int>(_Code) == _Errcode) {
+            return _Name;
         }
     }
 


### PR DESCRIPTION
# Description
Resolves #479 by converting two raw loops into range-for and structured bindings.
Additional a C-Style cast is modernized to a static_cast

# Checklist

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [x] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
