### PR TITLE
concepts: Implement resolution to LWG-3329

### DIFF
--- a/stl/inc/concepts
+++ b/stl/inc/concepts
@@ -273,9 +273,9 @@ concept totally_ordered = equality_comparable<_Ty> && _Half_ordered<_Ty, _Ty>;
 // CONCEPT totally_ordered_with
 template <class _Ty1, class _Ty2>
 concept totally_ordered_with = totally_ordered<_Ty1> && totally_ordered<_Ty2>
-    && common_reference_with<const remove_reference_t<_Ty1>&, const remove_reference_t<_Ty2>&>
+    && equality_comparable_with<_Ty1, _Ty2>
     && totally_ordered<common_reference_t<const remove_reference_t<_Ty1>&, const remove_reference_t<_Ty2>&>>
-    && equality_comparable_with<_Ty1, _Ty2> && _Partially_ordered_with<_Ty1, _Ty2>;
+    && _Partially_ordered_with<_Ty1, _Ty2>;
 
 // CONCEPT copyable
 template <class _Ty>


### PR DESCRIPTION
# Description

Implements LWG-3329.

`equality_comparable_with` subsumes `common_reference_with<const remove_reference_t<T>&, const remove_reference_t<U>&>` so move it up and remove the duplicated constraint

# Checklist

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [ ] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
