### PR TITLE
Implement range_size_t

### DIFF
--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -2483,10 +2483,6 @@ namespace ranges {
         inline constexpr _Size::_Cpo size;
     }
 
-    // ALIAS TEMPLATE ranges::range_size_t
-    template <sized_range _Rng>
-    using range_size_t = decltype(_RANGES size(_STD declval<_Rng&>()));
-
     // CUSTOMIZATION POINT OBJECT ranges::empty (Implements D2091R0)
     namespace _Empty {
         // clang-format off
@@ -2639,6 +2635,10 @@ namespace ranges {
 #endif // TRANSITION, LWG-3264
         && requires(_Rng& __r) { _RANGES size(__r); };
     // clang-format on
+
+    // ALIAS TEMPLATE ranges::range_size_t
+    template <sized_range _Rng>
+    using range_size_t = decltype(_RANGES size(_STD declval<_Rng&>()));
 
     // STRUCT ranges::view_base
     struct view_base {};

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -2484,7 +2484,7 @@ namespace ranges {
     }
 
     // ALIAS TEMPLATE ranges::range_size_t
-    template <range _Rng>
+    template <sized_range _Rng>
     using range_size_t = decltype(_RANGES size(_STD declval<_Rng&>()));
 
     // CUSTOMIZATION POINT OBJECT ranges::empty (Implements D2091R0)

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -2483,6 +2483,10 @@ namespace ranges {
         inline constexpr _Size::_Cpo size;
     }
 
+    // ALIAS TEMPLATE ranges::range_size_t
+    template <range _Rng>
+    using range_size_t = decltype(_RANGES size(_STD declval<_Rng&>()));
+
     // CUSTOMIZATION POINT OBJECT ranges::empty (Implements D2091R0)
     namespace _Empty {
         // clang-format off

--- a/tests/std/tests/P0896R4_ranges_range_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_range_machinery/test.cpp
@@ -324,6 +324,7 @@ constexpr bool test_size() {
     STATIC_ASSERT(ranges::sized_range<Range> == is_valid<Size>);
     if constexpr (is_valid<Size>) {
         STATIC_ASSERT(std::same_as<decltype(ranges::size(std::declval<Range>())), Size>);
+        STATIC_ASSERT(std::same_as<ranges::range_size_t<Range>, Size>);
 
         STATIC_ASSERT(CanEmpty<Range>);
     }

--- a/tests/std/tests/P0896R4_ranges_range_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_range_machinery/test.cpp
@@ -67,6 +67,9 @@ template <class R>
 concept CanSize = requires(R&& r) { ranges::size(std::forward<R>(r)); };
 
 template <class R>
+concept CanSizeType = requires { typename ranges::range_size_t<R>; };
+
+template <class R>
 concept CanData = requires(R&& r) { ranges::data(std::forward<R>(r)); };
 
 template <class R>
@@ -321,6 +324,7 @@ constexpr bool test_size() {
     STATIC_ASSERT(!is_valid<Size> || std::integral<Size>);
 
     STATIC_ASSERT(CanSize<Range> == is_valid<Size>);
+    STATIC_ASSERT(CanSizeType<Range> == is_valid<Size>);
     STATIC_ASSERT(ranges::sized_range<Range> == is_valid<Size>);
     if constexpr (is_valid<Size>) {
         STATIC_ASSERT(std::same_as<decltype(ranges::size(std::declval<Range>())), Size>);


### PR DESCRIPTION
# Description
This resolves LWG-3335 (at least the applicable parts) by adding ranges_size_t
Note the definition is out of line as the size CPO is defined after the other alias templates

How do we add tests if the features are not yet part of libc++?


# Checklist

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
