### PR TITLE
clean our repo before running CI

### DIFF
--- a/azure-devops/run_build.yml
+++ b/azure-devops/run_build.yml
@@ -10,6 +10,7 @@ jobs:
     vcpkgLocation: '$(Build.SourcesDirectory)/vcpkg'
   steps:
     - checkout: self
+      clean: true
       submodules: recursive
     - task: PowerShell@2
       displayName: 'Install MSVC Preview'


### PR DESCRIPTION
# Description

tell azure pipelines to clean our repo before building, to prevent badness and broken CI pipelines.

This is a workaround for #396

# Checklist

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [x] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
