### PR TITLE
Update test for fixed VSO-116925

### DIFF
--- a/tests/std/tests/P0898R3_concepts/test.cpp
+++ b/tests/std/tests/P0898R3_concepts/test.cpp
@@ -1433,11 +1433,9 @@ namespace test_constructible_from {
     };
     STATIC_ASSERT(!test<Multiparameter>());
     STATIC_ASSERT(test<Multiparameter, int>());
-#if defined(__clang__) || defined(__EDG__) // TRANSITION, VSO-116925
-    STATIC_ASSERT(!test<Multiparameter, long>());
-#else // ^^^ no workaround / workaround vvv
-    STATIC_ASSERT(test<Multiparameter, long>());
-#endif // TRANSITION, VSO-116925
+#if defined(__clang__) || defined(__EDG__) || _MSC_VER >= 1927 // TRANSITION, VS 2019 16.7 Preview 1
+    STATIC_ASSERT(!test<Multiparameter, long>() || is_permissive);
+#endif // TRANSITION, VS 2019 16.7 Preview 1
     STATIC_ASSERT(!test<Multiparameter, double>());
     STATIC_ASSERT(!test<Multiparameter, char>());
     STATIC_ASSERT(!test<Multiparameter, void>());


### PR DESCRIPTION
# Description
VSO-116925 (Microsoft internal number) was a long-standing issue with the compiler considering 'long' -> 'int' conversions to be integral promotions instead of integral conversions, and so failed to reject ambiguous overloads in some negative cases. It's been fixed, pending release in VS 2019 16.7 Preview 1.

Enable a test working around the bug for the compiler in that release.

# Checklist

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [x] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
