### PR TITLE
Return size_type for erase()/erase_if()

### DIFF
--- a/stl/inc/deque
+++ b/stl/inc/deque
@@ -1610,13 +1610,13 @@ _NODISCARD bool operator>=(const deque<_Ty, _Alloc>& _Left, const deque<_Ty, _Al
 
 #if _HAS_CXX20
 template <class _Ty, class _Alloc, class _Uty>
-void erase(deque<_Ty, _Alloc>& _Cont, const _Uty& _Val) {
-    _Erase_remove(_Cont, _Val);
+typename deque<_Ty>::size_type erase(deque<_Ty, _Alloc>& _Cont, const _Uty& _Val) {
+    return _Erase_remove(_Cont, _Val);
 }
 
 template <class _Ty, class _Alloc, class _Pr>
-void erase_if(deque<_Ty, _Alloc>& _Cont, _Pr _Pred) {
-    _Erase_remove_if(_Cont, _Pass_fn(_Pred));
+typename deque<_Ty>::size_type erase_if(deque<_Ty, _Alloc>& _Cont, _Pr _Pred) {
+    return _Erase_remove_if(_Cont, _Pass_fn(_Pred));
 }
 #endif // _HAS_CXX20
 

--- a/stl/inc/deque
+++ b/stl/inc/deque
@@ -1610,12 +1610,12 @@ _NODISCARD bool operator>=(const deque<_Ty, _Alloc>& _Left, const deque<_Ty, _Al
 
 #if _HAS_CXX20
 template <class _Ty, class _Alloc, class _Uty>
-typename deque<_Ty>::size_type erase(deque<_Ty, _Alloc>& _Cont, const _Uty& _Val) {
+typename deque<_Ty, _Alloc>::size_type erase(deque<_Ty, _Alloc>& _Cont, const _Uty& _Val) {
     return _Erase_remove(_Cont, _Val);
 }
 
 template <class _Ty, class _Alloc, class _Pr>
-typename deque<_Ty>::size_type erase_if(deque<_Ty, _Alloc>& _Cont, _Pr _Pred) {
+typename deque<_Ty, _Alloc>::size_type erase_if(deque<_Ty, _Alloc>& _Cont, _Pr _Pred) {
     return _Erase_remove_if(_Cont, _Pass_fn(_Pred));
 }
 #endif // _HAS_CXX20

--- a/stl/inc/forward_list
+++ b/stl/inc/forward_list
@@ -1556,13 +1556,13 @@ _NODISCARD bool operator>=(const forward_list<_Ty, _Alloc>& _Left, const forward
 
 #if _HAS_CXX20
 template <class _Ty, class _Alloc, class _Uty>
-void erase(forward_list<_Ty, _Alloc>& _Cont, const _Uty& _Val) {
-    _Cont.remove_if([&](_Ty& _Elem) { return _Elem == _Val; });
+typename forward_list<_Ty, _Alloc>::size_type erase(forward_list<_Ty, _Alloc>& _Cont, const _Uty& _Val) {
+    return _Cont.remove_if([&](_Ty& _Elem) { return _Elem == _Val; });
 }
 
 template <class _Ty, class _Alloc, class _Pr>
-void erase_if(forward_list<_Ty, _Alloc>& _Cont, _Pr _Pred) {
-    _Cont.remove_if(_Pass_fn(_Pred));
+typename forward_list<_Ty, _Alloc>::size_type erase_if(forward_list<_Ty, _Alloc>& _Cont, _Pr _Pred) {
+    return _Cont.remove_if(_Pass_fn(_Pred));
 }
 #endif // _HAS_CXX20
 

--- a/stl/inc/list
+++ b/stl/inc/list
@@ -1840,13 +1840,13 @@ _NODISCARD bool operator>=(const list<_Ty, _Alloc>& _Left, const list<_Ty, _Allo
 
 #if _HAS_CXX20
 template <class _Ty, class _Alloc, class _Uty>
-void erase(list<_Ty, _Alloc>& _Cont, const _Uty& _Val) {
-    _Cont.remove_if([&](_Ty& _Elem) { return _Elem == _Val; });
+typename list<_Ty, _Alloc>::size_type erase(list<_Ty, _Alloc>& _Cont, const _Uty& _Val) {
+    return _Cont.remove_if([&](_Ty& _Elem) { return _Elem == _Val; });
 }
 
 template <class _Ty, class _Alloc, class _Pr>
-void erase_if(list<_Ty, _Alloc>& _Cont, _Pr _Pred) {
-    _Cont.remove_if(_Pass_fn(_Pred));
+typename list<_Ty, _Alloc>::size_type erase_if(list<_Ty, _Alloc>& _Cont, _Pr _Pred) {
+    return _Cont.remove_if(_Pass_fn(_Pred));
 }
 #endif // _HAS_CXX20
 

--- a/stl/inc/map
+++ b/stl/inc/map
@@ -371,8 +371,8 @@ void swap(map<_Kty, _Ty, _Pr, _Alloc>& _Left, map<_Kty, _Ty, _Pr, _Alloc>& _Righ
 
 #if _HAS_CXX20
 template <class _Kty, class _Ty, class _Keylt, class _Alloc, class _Pr>
-void erase_if(map<_Kty, _Ty, _Keylt, _Alloc>& _Cont, _Pr _Pred) {
-    _Erase_nodes_if(_Cont, _Pass_fn(_Pred));
+typename map<_Kty, _Ty, _Keylt, _Alloc>::size_type erase_if(map<_Kty, _Ty, _Keylt, _Alloc>& _Cont, _Pr _Pred) {
+    return _Erase_nodes_if(_Cont, _Pass_fn(_Pred));
 }
 #endif // _HAS_CXX20
 
@@ -525,8 +525,9 @@ void swap(multimap<_Kty, _Ty, _Pr, _Alloc>& _Left, multimap<_Kty, _Ty, _Pr, _All
 
 #if _HAS_CXX20
 template <class _Kty, class _Ty, class _Keylt, class _Alloc, class _Pr>
-void erase_if(multimap<_Kty, _Ty, _Keylt, _Alloc>& _Cont, _Pr _Pred) {
-    _Erase_nodes_if(_Cont, _Pass_fn(_Pred));
+typename multimap<_Kty, _Ty, _Keylt, _Alloc>::size_type erase_if(
+    multimap<_Kty, _Ty, _Keylt, _Alloc>& _Cont, _Pr _Pred) {
+    return _Erase_nodes_if(_Cont, _Pass_fn(_Pred));
 }
 #endif // _HAS_CXX20
 

--- a/stl/inc/set
+++ b/stl/inc/set
@@ -181,8 +181,8 @@ void swap(set<_Kty, _Pr, _Alloc>& _Left, set<_Kty, _Pr, _Alloc>& _Right) noexcep
 
 #if _HAS_CXX20
 template <class _Kty, class _Keylt, class _Alloc, class _Pr>
-void erase_if(set<_Kty, _Keylt, _Alloc>& _Cont, _Pr _Pred) {
-    _Erase_nodes_if(_Cont, _Pass_fn(_Pred));
+typename set<_Kty, _Keylt, _Alloc>::size_type erase_if(set<_Kty, _Keylt, _Alloc>& _Cont, _Pr _Pred) {
+    return _Erase_nodes_if(_Cont, _Pass_fn(_Pred));
 }
 #endif // _HAS_CXX20
 
@@ -322,8 +322,8 @@ void swap(multiset<_Kty, _Pr, _Alloc>& _Left, multiset<_Kty, _Pr, _Alloc>& _Righ
 
 #if _HAS_CXX20
 template <class _Kty, class _Keylt, class _Alloc, class _Pr>
-void erase_if(multiset<_Kty, _Keylt, _Alloc>& _Cont, _Pr _Pred) {
-    _Erase_nodes_if(_Cont, _Pass_fn(_Pred));
+typename multiset<_Kty, _Keylt, _Alloc>::size_type erase_if(multiset<_Kty, _Keylt, _Alloc>& _Cont, _Pr _Pred) {
+    return _Erase_nodes_if(_Cont, _Pass_fn(_Pred));
 }
 #endif // _HAS_CXX20
 

--- a/stl/inc/unordered_map
+++ b/stl/inc/unordered_map
@@ -458,8 +458,9 @@ void swap(unordered_map<_Kty, _Ty, _Hasher, _Keyeq, _Alloc>& _Left,
 
 #if _HAS_CXX20
 template <class _Kty, class _Ty, class _Hasher, class _Keyeq, class _Alloc, class _Pr>
-void erase_if(unordered_map<_Kty, _Ty, _Hasher, _Keyeq, _Alloc>& _Cont, _Pr _Pred) {
-    _Erase_nodes_if(_Cont, _Pass_fn(_Pred));
+typename unordered_map<_Kty, _Ty, _Hasher, _Keyeq, _Alloc>::size_type erase_if(
+    unordered_map<_Kty, _Ty, _Hasher, _Keyeq, _Alloc>& _Cont, _Pr _Pred) {
+    return _Erase_nodes_if(_Cont, _Pass_fn(_Pred));
 }
 #endif // _HAS_CXX20
 
@@ -753,8 +754,9 @@ void swap(unordered_multimap<_Kty, _Ty, _Hasher, _Keyeq, _Alloc>& _Left,
 
 #if _HAS_CXX20
 template <class _Kty, class _Ty, class _Hasher, class _Keyeq, class _Alloc, class _Pr>
-void erase_if(unordered_multimap<_Kty, _Ty, _Hasher, _Keyeq, _Alloc>& _Cont, _Pr _Pred) {
-    _Erase_nodes_if(_Cont, _Pass_fn(_Pred));
+typename unordered_multimap<_Kty, _Ty, _Hasher, _Keyeq, _Alloc>::size_type erase_if(
+    unordered_multimap<_Kty, _Ty, _Hasher, _Keyeq, _Alloc>& _Cont, _Pr _Pred) {
+    return _Erase_nodes_if(_Cont, _Pass_fn(_Pred));
 }
 #endif // _HAS_CXX20
 

--- a/stl/inc/unordered_set
+++ b/stl/inc/unordered_set
@@ -311,8 +311,9 @@ void swap(unordered_set<_Kty, _Hasher, _Keyeq, _Alloc>& _Left,
 
 #if _HAS_CXX20
 template <class _Kty, class _Hasher, class _Keyeq, class _Alloc, class _Pr>
-void erase_if(unordered_set<_Kty, _Hasher, _Keyeq, _Alloc>& _Cont, _Pr _Pred) {
-    _Erase_nodes_if(_Cont, _Pass_fn(_Pred));
+typename unordered_set<_Kty, _Hasher, _Keyeq, _Alloc>::size_type erase_if(
+    unordered_set<_Kty, _Hasher, _Keyeq, _Alloc>& _Cont, _Pr _Pred) {
+    return _Erase_nodes_if(_Cont, _Pass_fn(_Pred));
 }
 #endif // _HAS_CXX20
 
@@ -574,8 +575,9 @@ void swap(unordered_multiset<_Kty, _Hasher, _Keyeq, _Alloc>& _Left,
 
 #if _HAS_CXX20
 template <class _Kty, class _Hasher, class _Keyeq, class _Alloc, class _Pr>
-void erase_if(unordered_multiset<_Kty, _Hasher, _Keyeq, _Alloc>& _Cont, _Pr _Pred) {
-    _Erase_nodes_if(_Cont, _Pass_fn(_Pred));
+typename unordered_multiset<_Kty, _Hasher, _Keyeq, _Alloc>::size_type erase_if(
+    unordered_multiset<_Kty, _Hasher, _Keyeq, _Alloc>& _Cont, _Pr _Pred) {
+    return _Erase_nodes_if(_Cont, _Pass_fn(_Pred));
 }
 #endif // _HAS_CXX20
 

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -2865,13 +2865,13 @@ struct hash<vector<bool, _Alloc>> {
 
 #if _HAS_CXX20
 template <class _Ty, class _Alloc, class _Uty>
-void erase(vector<_Ty, _Alloc>& _Cont, const _Uty& _Val) {
-    _Erase_remove(_Cont, _Val);
+typename vector<_Ty>::size_type erase(vector<_Ty, _Alloc>& _Cont, const _Uty& _Val) {
+    return _Erase_remove(_Cont, _Val);
 }
 
 template <class _Ty, class _Alloc, class _Pr>
-void erase_if(vector<_Ty, _Alloc>& _Cont, _Pr _Pred) {
-    _Erase_remove_if(_Cont, _Pass_fn(_Pred));
+typename vector<_Ty>::size_type erase_if(vector<_Ty, _Alloc>& _Cont, _Pr _Pred) {
+    return _Erase_remove_if(_Cont, _Pass_fn(_Pred));
 }
 #endif // _HAS_CXX20
 

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -2865,12 +2865,12 @@ struct hash<vector<bool, _Alloc>> {
 
 #if _HAS_CXX20
 template <class _Ty, class _Alloc, class _Uty>
-typename vector<_Ty>::size_type erase(vector<_Ty, _Alloc>& _Cont, const _Uty& _Val) {
+typename vector<_Ty, _Alloc>::size_type erase(vector<_Ty, _Alloc>& _Cont, const _Uty& _Val) {
     return _Erase_remove(_Cont, _Val);
 }
 
 template <class _Ty, class _Alloc, class _Pr>
-typename vector<_Ty>::size_type erase_if(vector<_Ty, _Alloc>& _Cont, _Pr _Pred) {
+typename vector<_Ty, _Alloc>::size_type erase_if(vector<_Ty, _Alloc>& _Cont, _Pr _Pred) {
     return _Erase_remove_if(_Cont, _Pass_fn(_Pred));
 }
 #endif // _HAS_CXX20

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -2084,23 +2084,23 @@ _NODISCARD _CONSTEXPR20 _FwdIt remove_if(_FwdIt _First, const _FwdIt _Last, _Pr 
 // FUNCTION TEMPLATE _Erase_remove
 template <class _Container, class _Uty>
 typename _Container::size_type _Erase_remove(_Container& _Cont, const _Uty& _Val) { // erase each element matching _Val
-    auto _First      = _Cont.begin();
-    const auto _Last = _Cont.end();
+    auto _First          = _Cont.begin();
+    const auto _Last     = _Cont.end();
+    const auto _Old_size = _Cont.size();
     _Seek_wrapped(_First, _STD remove(_Get_unwrapped(_First), _Get_unwrapped(_Last), _Val));
-    const auto _Removed = _Idl_distance<decltype(_First)>(_Get_unwrapped(_First), _Get_unwrapped(_Last));
     _Cont.erase(_First, _Last);
-    return _Removed;
+    return _Old_size - _Cont.size();
 }
 
 // FUNCTION TEMPLATE _Erase_remove_if
 template <class _Container, class _Pr>
 typename _Container::size_type _Erase_remove_if(_Container& _Cont, _Pr _Pred) { // erase each element satisfying _Pred
-    auto _First      = _Cont.begin();
-    const auto _Last = _Cont.end();
+    auto _First          = _Cont.begin();
+    const auto _Last     = _Cont.end();
+    const auto _Old_size = _Cont.size();
     _Seek_wrapped(_First, _STD remove_if(_Get_unwrapped(_First), _Get_unwrapped(_Last), _Pred));
-    const auto _Removed = _Idl_distance<decltype(_First)>(_Get_unwrapped(_First), _Get_unwrapped(_Last));
     _Cont.erase(_First, _Last);
-    return _Removed;
+    return _Old_size - _Cont.size();
 }
 
 // FUNCTION TEMPLATE _Erase_nodes_if

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -2083,27 +2083,32 @@ _NODISCARD _CONSTEXPR20 _FwdIt remove_if(_FwdIt _First, const _FwdIt _Last, _Pr 
 
 // FUNCTION TEMPLATE _Erase_remove
 template <class _Container, class _Uty>
-void _Erase_remove(_Container& _Cont, const _Uty& _Val) { // erase each element matching _Val
+typename _Container::size_type _Erase_remove(_Container& _Cont, const _Uty& _Val) { // erase each element matching _Val
     auto _First      = _Cont.begin();
     const auto _Last = _Cont.end();
     _Seek_wrapped(_First, _STD remove(_Get_unwrapped(_First), _Get_unwrapped(_Last), _Val));
+    const auto _Removed = _Idl_distance<decltype(_First)>(_Get_unwrapped(_First), _Get_unwrapped(_Last));
     _Cont.erase(_First, _Last);
+    return _Removed;
 }
 
 // FUNCTION TEMPLATE _Erase_remove_if
 template <class _Container, class _Pr>
-void _Erase_remove_if(_Container& _Cont, _Pr _Pred) { // erase each element satisfying _Pred
+typename _Container::size_type _Erase_remove_if(_Container& _Cont, _Pr _Pred) { // erase each element satisfying _Pred
     auto _First      = _Cont.begin();
     const auto _Last = _Cont.end();
     _Seek_wrapped(_First, _STD remove_if(_Get_unwrapped(_First), _Get_unwrapped(_Last), _Pred));
+    const auto _Removed = _Idl_distance<decltype(_First)>(_Get_unwrapped(_First), _Get_unwrapped(_Last));
     _Cont.erase(_First, _Last);
+    return _Removed;
 }
 
 // FUNCTION TEMPLATE _Erase_nodes_if
 template <class _Container, class _Pr>
-void _Erase_nodes_if(_Container& _Cont, _Pr _Pred) { // erase each element satisfying _Pred
-    auto _First      = _Cont.begin();
-    const auto _Last = _Cont.end();
+typename _Container::size_type _Erase_nodes_if(_Container& _Cont, _Pr _Pred) { // erase each element satisfying _Pred
+    auto _First          = _Cont.begin();
+    const auto _Last     = _Cont.end();
+    const auto _Old_size = _Cont.size();
     while (_First != _Last) {
         if (_Pred(*_First)) {
             _First = _Cont.erase(_First);
@@ -2111,6 +2116,7 @@ void _Erase_nodes_if(_Container& _Cont, _Pr _Pred) { // erase each element satis
             ++_First;
         }
     }
+    return _Old_size - _Cont.size();
 }
 _STD_END
 

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -4680,13 +4680,15 @@ inline namespace literals {
 
 #if _HAS_CXX20
 template <class _Elem, class _Traits, class _Alloc, class _Uty>
-void erase(basic_string<_Elem, _Traits, _Alloc>& _Cont, const _Uty& _Val) {
-    _Erase_remove(_Cont, _Val);
+typename basic_string<_Elem, _Traits, _Alloc>::size_type erase(
+    basic_string<_Elem, _Traits, _Alloc>& _Cont, const _Uty& _Val) {
+    return _Erase_remove(_Cont, _Val);
 }
 
 template <class _Elem, class _Traits, class _Alloc, class _Pr>
-void erase_if(basic_string<_Elem, _Traits, _Alloc>& _Cont, _Pr _Pred) {
-    _Erase_remove_if(_Cont, _Pass_fn(_Pred));
+typename basic_string<_Elem, _Traits, _Alloc>::size_type erase_if(
+    basic_string<_Elem, _Traits, _Alloc>& _Cont, _Pr _Pred) {
+    return _Erase_remove_if(_Cont, _Pass_fn(_Pred));
 }
 #endif // _HAS_CXX20
 

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -168,6 +168,7 @@
 // P1006R1 constexpr For pointer_traits<T*>::pointer_to()
 // P1024R3 Enhancing span Usability
 // P1085R2 Removing span Comparisons
+// P1115R3 erase()/erase_if() Return size_type
 // P1209R0 erase_if(), erase()
 // P1227R2 Signed std::ssize(), Unsigned span::size()
 // P1357R1 is_bounded_array, is_unbounded_array
@@ -1082,7 +1083,7 @@
 #define __cpp_lib_constexpr_memory         201811L
 #define __cpp_lib_constexpr_numeric        201911L
 #define __cpp_lib_endian                   201907L
-#define __cpp_lib_erase_if                 201811L
+#define __cpp_lib_erase_if                 202002L
 #define __cpp_lib_generic_unordered_lookup 201811L
 #define __cpp_lib_int_pow2                 202002L
 #define __cpp_lib_is_constant_evaluated    201811L

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -654,6 +654,34 @@ thread\thread.threads\thread.thread.class\thread.thread.member\join.pass.cpp
 depr\depr.c.headers\math_h.pass.cpp
 numerics\c.math\cmath.pass.cpp
 
+# Tests need to be updated for P1115R3 "erase()/erase_if() Return size_type".
+containers\associative\map\map.erasure\erase_if.pass.cpp
+containers\associative\multimap\multimap.erasure\erase_if.pass.cpp
+containers\associative\multiset\multiset.erasure\erase_if.pass.cpp
+containers\associative\set\set.erasure\erase_if.pass.cpp
+containers\sequences\deque\deque.erasure\erase_if.pass.cpp
+containers\sequences\deque\deque.erasure\erase.pass.cpp
+containers\sequences\forwardlist\forwardlist.erasure\erase_if.pass.cpp
+containers\sequences\forwardlist\forwardlist.erasure\erase.pass.cpp
+containers\sequences\list\list.erasure\erase_if.pass.cpp
+containers\sequences\list\list.erasure\erase.pass.cpp
+containers\sequences\vector\vector.erasure\erase_if.pass.cpp
+containers\sequences\vector\vector.erasure\erase.pass.cpp
+containers\unord\unord.map\erase_if.pass.cpp
+containers\unord\unord.multimap\erase_if.pass.cpp
+containers\unord\unord.multiset\erase_if.pass.cpp
+containers\unord\unord.set\erase_if.pass.cpp
+language.support\support.limits\support.limits.general\deque.version.pass.cpp
+language.support\support.limits\support.limits.general\forward_list.version.pass.cpp
+language.support\support.limits\support.limits.general\list.version.pass.cpp
+language.support\support.limits\support.limits.general\map.version.pass.cpp
+language.support\support.limits\support.limits.general\set.version.pass.cpp
+language.support\support.limits\support.limits.general\unordered_map.version.pass.cpp
+language.support\support.limits\support.limits.general\unordered_set.version.pass.cpp
+language.support\support.limits\support.limits.general\vector.version.pass.cpp
+strings\strings.erasure\erase_if.pass.cpp
+strings\strings.erasure\erase.pass.cpp
+
 # Test bug after LWG-2899 "is_(nothrow_)move_constructible and tuple, optional and unique_ptr" was accepted.
 utilities\smartptr\unique.ptr\unique.ptr.class\unique.ptr.asgn\move_convert.pass.cpp
 utilities\smartptr\unique.ptr\unique.ptr.class\unique.ptr.asgn\move_convert.runtime.pass.cpp

--- a/tests/std/tests/Dev11_0000000_user_defined_literals/test.cpp
+++ b/tests/std/tests/Dev11_0000000_user_defined_literals/test.cpp
@@ -582,6 +582,7 @@ int main() {
         std::vector<int> v{1, 2, 3, 4, 5, 6, 7, 6, 5, 4, 3, 2, 1};
         const auto v_removed = std::erase_if(v, is_odd{});
         assert((v == std::vector<int>{2, 4, 6, 6, 4, 2}));
+        assert(v_removed == 7);
         const auto v_removed2 = std::erase(v, 4);
         assert((v == std::vector<int>{2, 6, 6, 2}));
         assert(v_removed2 == 2);

--- a/tests/std/tests/Dev11_0000000_user_defined_literals/test.cpp
+++ b/tests/std/tests/Dev11_0000000_user_defined_literals/test.cpp
@@ -556,12 +556,14 @@ int main() {
         };
 
         std::string str1{"cute fluffy kittens"};
-        std::erase_if(str1, is_vowel{});
+        const auto str1_removed = std::erase_if(str1, is_vowel{});
         assert(str1 == "ct flffy kttns");
+        assert(str1_removed == 5);
 
         std::string str2{"visual studio"};
-        std::erase(str2, 'u');
+        const auto str2_removed = std::erase(str2, 'u');
         assert(str2 == "visal stdio");
+        assert(str2_removed == 2);
 
         struct is_odd : no_copy {
             bool operator()(const int i) const {
@@ -570,28 +572,35 @@ int main() {
         };
 
         std::deque<int> d{1, 2, 3, 4, 5, 6, 7, 6, 5, 4, 3, 2, 1};
-        std::erase_if(d, is_odd{});
+        const auto d_removed = std::erase_if(d, is_odd{});
         assert((d == std::deque<int>{2, 4, 6, 6, 4, 2}));
-        std::erase(d, 4);
+        assert(d_removed == 7);
+        const auto d_removed2 = std::erase(d, 4);
         assert((d == std::deque<int>{2, 6, 6, 2}));
+        assert(d_removed2 == 2);
 
         std::vector<int> v{1, 2, 3, 4, 5, 6, 7, 6, 5, 4, 3, 2, 1};
-        std::erase_if(v, is_odd{});
+        const auto v_removed = std::erase_if(v, is_odd{});
         assert((v == std::vector<int>{2, 4, 6, 6, 4, 2}));
-        std::erase(v, 4);
+        const auto v_removed2 = std::erase(v, 4);
         assert((v == std::vector<int>{2, 6, 6, 2}));
+        assert(v_removed2 == 2);
 
         std::forward_list<int> fl{1, 2, 3, 4, 5, 6, 7, 6, 5, 4, 3, 2, 1};
-        std::erase_if(fl, is_odd{});
+        const auto fl_removed = std::erase_if(fl, is_odd{});
         assert((fl == std::forward_list<int>{2, 4, 6, 6, 4, 2}));
-        std::erase(fl, 4);
+        assert(fl_removed == 7);
+        const auto fl_removed2 = std::erase(fl, 4);
         assert((fl == std::forward_list<int>{2, 6, 6, 2}));
+        assert(fl_removed2 == 2);
 
         std::list<int> l{1, 2, 3, 4, 5, 6, 7, 6, 5, 4, 3, 2, 1};
-        std::erase_if(l, is_odd{});
+        const auto l_removed = std::erase_if(l, is_odd{});
         assert((l == std::list<int>{2, 4, 6, 6, 4, 2}));
-        std::erase(l, 4);
+        assert(l_removed == 7);
+        const auto l_removed2 = std::erase(l, 4);
         assert((l == std::list<int>{2, 6, 6, 2}));
+        assert(l_removed2 == 2);
 
         struct is_first_odd : no_copy {
             bool operator()(const std::pair<const int, int>& p) const {
@@ -600,38 +609,46 @@ int main() {
         };
 
         std::map<int, int> m{{1, 10}, {2, 20}, {3, 30}, {4, 40}, {5, 50}, {6, 60}, {7, 70}};
-        std::erase_if(m, is_first_odd{});
+        const auto m_removed = std::erase_if(m, is_first_odd{});
         assert((m == std::map<int, int>{{2, 20}, {4, 40}, {6, 60}}));
+        assert(m_removed == 4);
 
         std::multimap<int, int> mm{{1, 10}, {2, 20}, {3, 30}, {4, 40}, {5, 50}, {6, 60}, {7, 70}};
-        std::erase_if(mm, is_first_odd{});
+        const auto mm_removed = std::erase_if(mm, is_first_odd{});
         assert((mm == std::multimap<int, int>{{2, 20}, {4, 40}, {6, 60}}));
+        assert(mm_removed == 4);
 
         std::set<int> s{1, 2, 3, 4, 5, 6, 7};
-        std::erase_if(s, is_odd{});
+        const auto s_removed = std::erase_if(s, is_odd{});
         assert((s == std::set<int>{2, 4, 6}));
+        assert(s_removed == 4);
 
         std::multiset<int> ms{1, 2, 3, 4, 5, 6, 7};
-        std::erase_if(ms, is_odd{});
+        const auto ms_removed = std::erase_if(ms, is_odd{});
         assert((ms == std::multiset<int>{2, 4, 6}));
+        assert(ms_removed == 4);
 
         // Note that unordered equality considers permutations.
 
         std::unordered_map<int, int> um{{1, 10}, {2, 20}, {3, 30}, {4, 40}, {5, 50}, {6, 60}, {7, 70}};
-        std::erase_if(um, is_first_odd{});
+        const auto um_removed = std::erase_if(um, is_first_odd{});
         assert((um == std::unordered_map<int, int>{{2, 20}, {4, 40}, {6, 60}}));
+        assert(um_removed == 4);
 
         std::unordered_multimap<int, int> umm{{1, 10}, {2, 20}, {3, 30}, {4, 40}, {5, 50}, {6, 60}, {7, 70}};
-        std::erase_if(umm, is_first_odd{});
+        const auto umm_removed = std::erase_if(umm, is_first_odd{});
         assert((umm == std::unordered_multimap<int, int>{{2, 20}, {4, 40}, {6, 60}}));
+        assert(umm_removed == 4);
 
         std::unordered_set<int> us{1, 2, 3, 4, 5, 6, 7};
-        std::erase_if(us, is_odd{});
+        const auto us_removed = std::erase_if(us, is_odd{});
         assert((us == std::unordered_set<int>{2, 4, 6}));
+        assert(us_removed == 4);
 
         std::unordered_multiset<int> ums{1, 2, 3, 4, 5, 6, 7};
-        std::erase_if(ums, is_odd{});
+        const auto ums_removed = std::erase_if(ums, is_odd{});
         assert((ums == std::unordered_multiset<int>{2, 4, 6}));
+        assert(ums_removed == 4);
     }
 #endif // _HAS_CXX20
 

--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.cpp
@@ -1600,10 +1600,10 @@ STATIC_ASSERT(__cpp_lib_endian == 201907L);
 #if CXX20_MODE
 #ifndef __cpp_lib_erase_if
 #error BOOM
-#elif __cpp_lib_erase_if != 201811L
+#elif __cpp_lib_erase_if != 202002L
 #error BOOM
 #else
-STATIC_ASSERT(__cpp_lib_erase_if == 201811L);
+STATIC_ASSERT(__cpp_lib_erase_if == 202002L);
 #endif
 #else
 #ifdef __cpp_lib_erase_if


### PR DESCRIPTION
# Description

Resolves #555. (oddly coincental that the original is #55)
Opening as draft due to
> presumably to 202002L (we need to double-check).

And where are the existing tests for this? Granted I didn't look very hard but I couldn't find them (assuming they exist).
# Checklist

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [ ] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
