### PR TITLE
Fix missing SFINAE in operator/ and operator% for std::chrono::duration

### DIFF
--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -284,18 +284,17 @@ namespace chrono {
     struct _Duration_div_mod1<_CR, _Period1, _Rep2, false> { // no return type
     };
 
-    template <class _Rep1, class _Period1, class _Rep2, bool = _Is_duration_v<_Rep2>>
+    template <class _CR, class _Period1, class _Rep2, bool = _Is_duration_v<_Rep2>>
     struct _Duration_div_mod { // no return type
     };
 
-    template <class _Rep1, class _Period1, class _Rep2>
-    struct _Duration_div_mod<_Rep1, _Period1, _Rep2, false>
-        : _Duration_div_mod1<common_type_t<_Rep1, _Rep2>, _Period1, _Rep2> {
+    template <class _CR, class _Period1, class _Rep2>
+    struct _Duration_div_mod<_CR, _Period1, _Rep2, false> : _Duration_div_mod1<_CR, _Period1, _Rep2> {
         // return type for duration / rep and duration % rep
     };
 
     template <class _Rep1, class _Period1, class _Rep2>
-    _NODISCARD constexpr typename _Duration_div_mod<_Rep1, _Period1, _Rep2>::type operator/(
+    _NODISCARD constexpr typename _Duration_div_mod<common_type_t<_Rep1, _Rep2>, _Period1, _Rep2>::type operator/(
         const duration<_Rep1, _Period1>& _Left,
         const _Rep2& _Right) noexcept(is_arithmetic_v<_Rep1>&& is_arithmetic_v<_Rep2>) /* strengthened */ {
         using _CR = common_type_t<_Rep1, _Rep2>;
@@ -312,7 +311,7 @@ namespace chrono {
     }
 
     template <class _Rep1, class _Period1, class _Rep2>
-    _NODISCARD constexpr typename _Duration_div_mod<_Rep1, _Period1, _Rep2>::type operator%(
+    _NODISCARD constexpr typename _Duration_div_mod<common_type_t<_Rep1, _Rep2>, _Period1, _Rep2>::type operator%(
         const duration<_Rep1, _Period1>& _Left,
         const _Rep2& _Right) noexcept(is_arithmetic_v<_Rep1>&& is_arithmetic_v<_Rep2>) /* strengthened */ {
         using _CR = common_type_t<_Rep1, _Rep2>;

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -627,11 +627,6 @@ localization\locale.categories\facet.numpunct\locale.numpunct.byname\thousands_s
 # STL Bug? Our wbuffer_convert does not implement seek. [depr.conversions.buffer] is completely underspecified.
 localization\locales\locale.convenience\conversions\conversions.buffer\seekoff.pass.cpp
 
-# STL Bug: We aren't properly SFINAEing chrono operators
-# https://github.com/llvm/llvm-project/commit/efa6d803c624f9251d0ab7881122501bb9d27368
-utilities\time\time.duration\time.duration.nonmember\op_divide_rep.pass.cpp
-utilities\time\time.duration\time.duration.nonmember\op_mod_rep.pass.cpp
-
 # STL Bug: error_category's default ctor isn't constexpr. (Should be fixed in vNext.)
 diagnostics\syserr\syserr.errcat\syserr.errcat.nonvirtuals\default_ctor.pass.cpp
 


### PR DESCRIPTION
# Description

## Problem
`operator/` and `operator%` for `std::chrono::duration` and non-duration types do not properly SFINAE-out when second parameter `Rep2` and `Rep1` in `duration<Rep1, Period>` of first parameter do not have `common_type_t<Rep1, Rep2>`.

## Technical details

`operator/` and `operator%` is declared as follows in standard:
* from `[time.duration.nonmember]` in `N4741`
```cpp
// operator/ (1)
template<class Rep1, class Period, class Rep2>
constexpr duration<common_type_t<Rep1, Rep2>, Period> operator/(const duration<Rep1, Period>& d, const Rep2& s);
// operator% (1)
template<class Rep1, class Period, class Rep2>
constexpr duration<common_type_t<Rep1, Rep2>, Period>operator%(const duration<Rep1, Period>& d, const Rep2& s);
```
And both functions have extra remark on them:
+ `Remarks: This operator shall not participate in overload resolution unless Rep2 is implicitly convertible to common_type_t<Rep1, Rep2> and Rep2 is not a specialization of duration.`

To conform standard wording, current `operator/` and `operator%` has proxy return type to SFINAE out on invalid conditions:

```cpp
template <class _Rep1, class _Period1, class _Rep2>
_NODISCARD constexpr typename _Duration_div_mod<_Rep1, _Period1, _Rep2>::type operator/(
    const duration<_Rep1, _Period1>& _Left,
    const _Rep2& _Right)
```

And `_Duration_div_mod` is deriving from `_Duration_div_mod1` for further check:
```cpp
    template <class _Rep1, class _Period1, class _Rep2>
    struct _Duration_div_mod<_Rep1, _Period1, _Rep2, false>
        : _Duration_div_mod1<common_type_t<_Rep1, _Rep2>, _Period1, _Rep2> {
        // return type for duration / rep and duration % rep
    };
```
 
Notice `common_type_t<_Rep1, _Rep2>` is called in template parameter of base class.
This means when `common_type_t<_Rep1, _Rep2>` is not defined (i.e. no common type found), this causes compile error instead of discarding overload even when other operator overload is still valid.

## Test code
```cpp
#include <chrono>
#include <iostream>

template <class Rep, class Period>
constexpr bool operator/(const std::chrono::duration<Rep, Period>& d, std::ostream&) {
    return true;
}

int main() {
    std::chrono::milliseconds mil;
    static_assert(mil / std::cout);
}
```
[Godbolt link](https://godbolt.org/z/6xQTNQ)

## Solution

Instead of calling `common_type_t` inside of proxy return type, calling it from return type of `operator/` and `operator%` should properly discard them from candidates on fail.

# Checklist

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [ ] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
