### PR TITLE
Apply a new attribute '[[msvc::known_semantics]]'

### DIFF
--- a/stl/inc/span
+++ b/stl/inc/span
@@ -681,7 +681,7 @@ struct tuple_size<span<_Ty, dynamic_extent>>;
 #endif // !__cpp_lib_concepts
 
 template <size_t _Index, class _Ty, size_t _Extent>
-struct tuple_element<_Index, span<_Ty, _Extent>> {
+struct _MSVC_KNOWN_SEMANTICS tuple_element<_Index, span<_Ty, _Extent>> {
     static_assert(dynamic_extent != _Extent, "std::span<T, dynamic_extent> is not tuple-like");
     static_assert(_Index < _Extent, "Index out of bounds for a std::span of this extent");
     using type = _Ty;

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -495,7 +495,7 @@ struct _MSVC_KNOWN_SEMANTICS tuple_element<_Index, tuple<>> { // enforce bounds 
 
 template <class _This, class... _Rest>
 struct _MSVC_KNOWN_SEMANTICS tuple_element<0, tuple<_This, _Rest...>> { // select first element
-    using type   = _This;
+    using type = _This;
     // MSVC assumes the meaning of _Ttype; remove or rename, but do not change semantics
     using _Ttype = tuple<_This, _Rest...>;
 };

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -446,20 +446,19 @@ template <size_t _Index, class _Tuple>
 struct tuple_element;
 
 template <size_t _Index, class _Tuple>
-struct tuple_element<_Index, const _Tuple> : tuple_element<_Index, _Tuple> { // tuple_element for const
+struct _MSVC_KNOWN_SEMANTICS tuple_element<_Index, const _Tuple> : tuple_element<_Index, _Tuple> {
     using _Mybase = tuple_element<_Index, _Tuple>;
     using type    = add_const_t<typename _Mybase::type>;
 };
 
 template <size_t _Index, class _Tuple>
-struct tuple_element<_Index, volatile _Tuple> : tuple_element<_Index, _Tuple> { // tuple_element for volatile
+struct _MSVC_KNOWN_SEMANTICS tuple_element<_Index, volatile _Tuple> : tuple_element<_Index, _Tuple> {
     using _Mybase = tuple_element<_Index, _Tuple>;
     using type    = add_volatile_t<typename _Mybase::type>;
 };
 
 template <size_t _Index, class _Tuple>
-struct tuple_element<_Index, const volatile _Tuple>
-    : tuple_element<_Index, _Tuple> { // tuple_element for const volatile
+struct _MSVC_KNOWN_SEMANTICS tuple_element<_Index, const volatile _Tuple> : tuple_element<_Index, _Tuple> {
     using _Mybase = tuple_element<_Index, _Tuple>;
     using type    = add_cv_t<typename _Mybase::type>;
 };
@@ -477,7 +476,7 @@ struct tuple_size<array<_Ty, _Size>>
 };
 
 template <size_t _Idx, class _Ty, size_t _Size>
-struct tuple_element<_Idx, array<_Ty, _Size>> { // struct to determine type of element _Idx in array
+struct _MSVC_KNOWN_SEMANTICS tuple_element<_Idx, array<_Ty, _Size>> {
     static_assert(_Idx < _Size, "array index out of bounds");
 
     using type = _Ty;
@@ -490,18 +489,19 @@ struct tuple_size<tuple<_Types...>> : integral_constant<size_t, sizeof...(_Types
 };
 
 template <size_t _Index>
-struct tuple_element<_Index, tuple<>> { // enforce bounds checking
+struct _MSVC_KNOWN_SEMANTICS tuple_element<_Index, tuple<>> { // enforce bounds checking
     static_assert(_Always_false<integral_constant<size_t, _Index>>, "tuple index out of bounds");
 };
 
 template <class _This, class... _Rest>
-struct tuple_element<0, tuple<_This, _Rest...>> { // select first element
+struct _MSVC_KNOWN_SEMANTICS tuple_element<0, tuple<_This, _Rest...>> { // select first element
     using type   = _This;
+    // MSVC assumes the meaning of _Ttype; remove or rename, but do not change semantics
     using _Ttype = tuple<_This, _Rest...>;
 };
 
 template <size_t _Index, class _This, class... _Rest>
-struct tuple_element<_Index, tuple<_This, _Rest...>>
+struct _MSVC_KNOWN_SEMANTICS tuple_element<_Index, tuple<_This, _Rest...>>
     : tuple_element<_Index - 1, tuple<_Rest...>> { // recursive tuple_element definition
 };
 
@@ -511,7 +511,7 @@ struct tuple_size<pair<_Ty1, _Ty2>> : integral_constant<size_t, 2> { // size of 
 };
 
 template <size_t _Idx, class _Ty1, class _Ty2>
-struct tuple_element<_Idx, pair<_Ty1, _Ty2>> { // struct to determine type of element _Idx in pair
+struct _MSVC_KNOWN_SEMANTICS tuple_element<_Idx, pair<_Ty1, _Ty2>> {
     static_assert(_Idx < 2, "pair index out of bounds");
 
     using type = conditional_t<_Idx == 0, _Ty1, _Ty2>;

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -306,6 +306,16 @@
 // _HAS_NODISCARD (in vcruntime.h) controls:
 // [[nodiscard]] attributes on STL functions
 
+// Determine if we should use [[msvc::known_semantics]] to communicate to the compiler
+// that certain type trait specializations have the standard-mandated semantics
+#ifndef __has_cpp_attribute
+#define _MSVC_KNOWN_SEMANTICS
+#elif __has_cpp_attribute(msvc::known_semantics)
+#define _MSVC_KNOWN_SEMANTICS [[msvc::known_semantics]]
+#else
+#define _MSVC_KNOWN_SEMANTICS
+#endif
+
 // Controls whether the STL uses "if constexpr" internally
 #ifndef _HAS_IF_CONSTEXPR
 #ifdef __CUDACC__


### PR DESCRIPTION
Apply a new attribute '[[msvc::known_semantics]]' to communicate to the compiler that certain type trait specializations have the standard-mandated semantics

# Description



# Checklist

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [x] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
