### PR TITLE
Add "/build/" to the .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 
 .vs/
 .vscode/
+/build/
 /out/
 /tools/out/


### PR DESCRIPTION
What the title says. 
I assume most people who aren't using Visual Studio would use `build` instead of `out`.