### PR TITLE
GitHub: Document "broken" links

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ libraries.)
 includes C++20 features, [LWG issues][], conformance bugs, performance improvements, and other todos. There are
 approximately 200 active bugs in the STL's Microsoft-internal database; we need to manually replicate all of them to
 GitHub issues. Currently, the [cxx20 tag][] and [LWG tag][] are done; every remaining work item is tracked by a GitHub
-issue. The [bug tag][] and [enhancement tag][] are being populated.
+issue. The [bug tag][] and [enhancement tag][] are being populated.  
+*Note: Issues that link to a paper with `wg21.link/` may not work as that means they aren't publicly available at the time. Once they become public the links will then work.*
 
 * Plans: **In progress.** We're writing up our [Roadmap][] and [Iteration Plans][].
 


### PR DESCRIPTION
# Description

Was just browsing the issues and got a "broken" link and thought it would be worth documenting.

*Note: I'm no wordsmith.*

Also this will fail ~~clang-format~~ validation due to the double space on the end of this line to put the notice on a new line.
https://github.com/microsoft/STL/pull/582/files#diff-04c6e90faac2675aa89e2176d2eec7d8R50