### PR TITLE
Replace `_STATIC_UNLESS_PURE` with `static`.

### DIFF
--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -309,8 +309,9 @@ public:
     template <class _Iter>
     char_class_type lookup_classname(_Iter _First, _Iter _Last, bool _Icase = false) const {
         // map [_First, _Last) to character class mask value
-#define _REGEX_CHAR_CLASS_NAME(n, c) {n, L##n, sizeof(n) / sizeof(n[0]) - 1, c}
-        _STATIC_UNLESS_PURE constexpr _Cl_names _Names[] = {
+#define _REGEX_CHAR_CLASS_NAME(n, c) \
+    { n, L##n, sizeof(n) / sizeof(n[0]) - 1, c }
+        static constexpr _Cl_names _Names[] = {
             // map class names to numeric constants
             _REGEX_CHAR_CLASS_NAME("alnum", _Ch_alnum),
             _REGEX_CHAR_CLASS_NAME("alpha", _Ch_alpha),
@@ -563,7 +564,7 @@ int _Iter_compare(_FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2, _FwdIt2 _Las
 // FUNCTION TEMPLATE _Is_word
 inline bool _Is_word(unsigned char _UCh) {
     // special casing char to avoid branches for std::regex in this path
-    _STATIC_UNLESS_PURE constexpr bool _Is_word_table[(numeric_limits<unsigned char>::max)() + 1] = {
+    static constexpr bool _Is_word_table[(numeric_limits<unsigned char>::max)() + 1] = {
         //        X0 X1 X2 X3 X4 X5 X6 X7 X8 X9 XA XB XC XD XE XF
         /* 0X */ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         /* 1X */ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -3828,10 +3829,9 @@ bool _Parser<_FwdIt, _Elem, _RxTraits>::_Is_esc() const { // assumes _Pat != _En
 
 template <class _FwdIt, class _Elem, class _RxTraits>
 void _Parser<_FwdIt, _Elem, _RxTraits>::_Trans() { // map character to meta-character
-    _STATIC_UNLESS_PURE constexpr char _Meta_map[] = {_Meta_lpar, _Meta_rpar, _Meta_dlr, _Meta_caret, _Meta_dot,
-        _Meta_star, _Meta_plus, _Meta_query, _Meta_lsq, _Meta_rsq, _Meta_bar, _Meta_esc, _Meta_dash, _Meta_lbr,
-        _Meta_rbr, _Meta_comma, _Meta_colon, _Meta_equal, _Meta_exc, _Meta_nl, _Meta_cr, _Meta_bsp,
-        0}; // array of meta chars
+    static constexpr char _Meta_map[] = {_Meta_lpar, _Meta_rpar, _Meta_dlr, _Meta_caret, _Meta_dot, _Meta_star,
+        _Meta_plus, _Meta_query, _Meta_lsq, _Meta_rsq, _Meta_bar, _Meta_esc, _Meta_dash, _Meta_lbr, _Meta_rbr,
+        _Meta_comma, _Meta_colon, _Meta_equal, _Meta_exc, _Meta_nl, _Meta_cr, _Meta_bsp, 0}; // array of meta chars
 
     if (_Pat == _End) {
         _Mchar = _Meta_eos;

--- a/stl/inc/xlocmon
+++ b/stl/inc/xlocmon
@@ -431,8 +431,8 @@ private:
         const money_base::pattern _Pattern = _Ppunct_fac->neg_format();
         string _Val;
         size_t _Idx;
-        _STATIC_UNLESS_PURE constexpr char _Src[] = "0123456789-";
-        const ctype<_Elem>& _Ctype_fac            = _STD use_facet<ctype<_Elem>>(_Iosbase.getloc());
+        static constexpr char _Src[]   = "0123456789-";
+        const ctype<_Elem>& _Ctype_fac = _STD use_facet<ctype<_Elem>>(_Iosbase.getloc());
         _Ctype_fac.widen(&_Src[0], &_Src[sizeof(_Src)], _Atoms);
 
         for (size_t _Off = 0; !_Bad && _Off < 4; ++_Off) {
@@ -697,7 +697,7 @@ protected:
 
     virtual _OutIt __CLR_OR_THIS_CALL do_put(_OutIt _Dest, bool _Intl, ios_base& _Iosbase, _Elem _Fill,
         const string_type& _Val) const { // put string_type to _Dest
-        _STATIC_UNLESS_PURE constexpr char _Src[] = "0123456789-";
+        static constexpr char _Src[] = "0123456789-";
         _Elem _Atoms[sizeof(_Src)];
         const ctype<_Elem>& _Ctype_fac = _STD use_facet<ctype<_Elem>>(_Iosbase.getloc());
         _Ctype_fac.widen(&_Src[0], &_Src[sizeof(_Src)], _Atoms);

--- a/stl/inc/xlocnum
+++ b/stl/inc/xlocnum
@@ -670,9 +670,9 @@ private:
         const string _Grouping  = _Punct_fac.grouping();
         const _Elem _Kseparator = _Grouping.size() == 0 ? _Elem{} : _Punct_fac.thousands_sep();
 
-        constexpr int _Numget_signoff             = 22;
-        constexpr int _Numget_xoff                = 24;
-        _STATIC_UNLESS_PURE constexpr char _Src[] = "0123456789ABCDEFabcdef-+Xx";
+        constexpr int _Numget_signoff = 22;
+        constexpr int _Numget_xoff    = 24;
+        static constexpr char _Src[]  = "0123456789ABCDEFabcdef-+Xx";
         _Elem _Atoms[sizeof(_Src)];
         const ctype<_Elem>& _Ctype_fac = _STD use_facet<ctype<_Elem>>(_Loc);
         _Ctype_fac.widen(&_Src[0], &_Src[sizeof(_Src)], _Atoms);
@@ -783,9 +783,9 @@ private:
         bool _Bad              = false;
         bool _Sticky           = false;
 
-        constexpr int _Numget_signoff             = 10;
-        constexpr int _Numget_eoff                = 12;
-        _STATIC_UNLESS_PURE constexpr char _Src[] = "0123456789-+Ee";
+        constexpr int _Numget_signoff = 10;
+        constexpr int _Numget_eoff    = 12;
+        static constexpr char _Src[]  = "0123456789-+Ee";
         _Elem _Atoms[sizeof(_Src)];
         const ctype<_Elem>& _Ctype_fac = _STD use_facet<ctype<_Elem>>(_Iosbase.getloc());
         _Ctype_fac.widen(&_Src[0], &_Src[sizeof(_Src)], _Atoms);
@@ -964,10 +964,10 @@ private:
         const auto& _Punct_fac = _STD use_facet<numpunct<_Elem>>(_Iosbase.getloc());
         const string _Grouping = _Punct_fac.grouping();
 
-        constexpr int _Numget_signoff             = 22;
-        constexpr int _Numget_xoff                = 24;
-        constexpr int _Numget_poff                = 26;
-        _STATIC_UNLESS_PURE constexpr char _Src[] = "0123456789ABCDEFabcdef-+XxPp";
+        constexpr int _Numget_signoff = 22;
+        constexpr int _Numget_xoff    = 24;
+        constexpr int _Numget_poff    = 26;
+        static constexpr char _Src[]  = "0123456789ABCDEFabcdef-+XxPp";
         _Elem _Atoms[sizeof(_Src)];
         const ctype<_Elem>& _Ctype_fac = _STD use_facet<ctype<_Elem>>(_Iosbase.getloc());
         _Ctype_fac.widen(&_Src[0], &_Src[sizeof(_Src)], _Atoms);

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -1160,11 +1160,9 @@ compiler option, or define _ALLOW_RTCc_IN_STL to acknowledge that you have recei
 #ifdef _M_CEE_PURE
 #define _EXTERN_C_UNLESS_PURE
 #define _END_EXTERN_C_UNLESS_PURE
-#define _STATIC_UNLESS_PURE // Avoid warning C4640: construction of local static object is not thread-safe (/Wall)
 #else // ^^^ _M_CEE_PURE / !_M_CEE_PURE vvv
 #define _EXTERN_C_UNLESS_PURE     _EXTERN_C
 #define _END_EXTERN_C_UNLESS_PURE _END_EXTERN_C
-#define _STATIC_UNLESS_PURE       static
 #endif // _M_CEE_PURE
 
 #if defined(MRTDLL) && !defined(_CRTBLD)


### PR DESCRIPTION
# Description

This was a workaround for a compiler bug (in constexpr initialization)
that has been fixed.

This is Microsoft-internal MSVC-PR-233145.

# Checklist

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [ ] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
