### PR TITLE
P0896R4 changes to insert iterators

### DIFF
--- a/stl/inc/iterator
+++ b/stl/inc/iterator
@@ -176,7 +176,7 @@ public:
     }
 
 protected:
-    _Container* container              = nullptr;
+    _Container* container = nullptr;
     typename _Container::iterator iter{};
 };
 

--- a/stl/inc/iterator
+++ b/stl/inc/iterator
@@ -25,11 +25,17 @@ class back_insert_iterator { // wrap pushes to back of container as output itera
 public:
     using iterator_category = output_iterator_tag;
     using value_type        = void;
-    using difference_type   = void;
     using pointer           = void;
     using reference         = void;
 
     using container_type = _Container;
+
+#ifdef __cpp_lib_concepts
+    using difference_type                     = ptrdiff_t;
+    constexpr back_insert_iterator() noexcept = default;
+#else // ^^^ __cpp_lib_concepts / !__cpp_lib_concepts vvv
+    using difference_type = void;
+#endif // __cpp_lib_concepts
 
     explicit back_insert_iterator(_Container& _Cont) noexcept /* strengthened */ : container(_STD addressof(_Cont)) {}
 
@@ -56,7 +62,7 @@ public:
     }
 
 protected:
-    _Container* container; // pointer to container
+    _Container* container = nullptr;
 };
 
 // FUNCTION TEMPLATE back_inserter
@@ -72,11 +78,17 @@ class front_insert_iterator { // wrap pushes to front of container as output ite
 public:
     using iterator_category = output_iterator_tag;
     using value_type        = void;
-    using difference_type   = void;
     using pointer           = void;
     using reference         = void;
 
     using container_type = _Container;
+
+#ifdef __cpp_lib_concepts
+    using difference_type                      = ptrdiff_t;
+    constexpr front_insert_iterator() noexcept = default;
+#else // ^^^ __cpp_lib_concepts / !__cpp_lib_concepts vvv
+    using difference_type = void;
+#endif // __cpp_lib_concepts
 
     explicit front_insert_iterator(_Container& _Cont) : container(_STD addressof(_Cont)) {}
 
@@ -103,7 +115,7 @@ public:
     }
 
 protected:
-    _Container* container; // pointer to container
+    _Container* container = nullptr;
 };
 
 // FUNCTION TEMPLATE front_inserter
@@ -119,24 +131,28 @@ class insert_iterator { // wrap inserts into container as output iterator
 public:
     using iterator_category = output_iterator_tag;
     using value_type        = void;
-    using difference_type   = void;
     using pointer           = void;
     using reference         = void;
+    using container_type    = _Container;
 
-    using container_type = _Container;
+#ifdef __cpp_lib_concepts
+    using difference_type = ptrdiff_t;
+    insert_iterator()     = default;
+#else // ^^^ __cpp_lib_concepts / !__cpp_lib_concepts vvv
+    using difference_type = void;
+#endif // __cpp_lib_concepts
 
     insert_iterator(_Container& _Cont, typename _Container::iterator _Where)
         : container(_STD addressof(_Cont)), iter(_Where) {}
 
-    insert_iterator& operator=(
-        const typename _Container::value_type& _Val) { // insert into container and increment stored iterator
+    insert_iterator& operator=(const typename _Container::value_type& _Val) {
+        // insert into container and increment stored iterator
         iter = container->insert(iter, _Val);
         ++iter;
         return *this;
     }
 
     insert_iterator& operator=(typename _Container::value_type&& _Val) { // push value into container
-
         iter = container->insert(iter, _STD move(_Val));
         ++iter;
         return *this;
@@ -155,8 +171,8 @@ public:
     }
 
 protected:
-    _Container* container; // pointer to container
-    typename _Container::iterator iter; // iterator into container
+    _Container* container              = nullptr;
+    typename _Container::iterator iter = typename _Container::iterator();
 };
 
 // FUNCTION TEMPLATE inserter

--- a/stl/inc/iterator
+++ b/stl/inc/iterator
@@ -177,7 +177,7 @@ public:
 
 protected:
     _Container* container              = nullptr;
-    typename _Container::iterator iter = {};
+    typename _Container::iterator iter{};
 };
 
 // FUNCTION TEMPLATE inserter

--- a/stl/inc/iterator
+++ b/stl/inc/iterator
@@ -149,14 +149,15 @@ public:
     insert_iterator(_Container& _Cont, typename _Container::iterator _Where)
         : container(_STD addressof(_Cont)), iter(_Where) {}
 
-    insert_iterator& operator=(const typename _Container::value_type& _Val) {
-        // insert into container and increment stored iterator
+    insert_iterator& operator=(
+        const typename _Container::value_type& _Val) { // insert into container and increment stored iterator
         iter = container->insert(iter, _Val);
         ++iter;
         return *this;
     }
 
     insert_iterator& operator=(typename _Container::value_type&& _Val) { // push value into container
+
         iter = container->insert(iter, _STD move(_Val));
         ++iter;
         return *this;

--- a/stl/inc/iterator
+++ b/stl/inc/iterator
@@ -31,7 +31,8 @@ public:
     using container_type = _Container;
 
 #ifdef __cpp_lib_concepts
-    using difference_type                     = ptrdiff_t;
+    using difference_type = ptrdiff_t;
+
     constexpr back_insert_iterator() noexcept = default;
 #else // ^^^ __cpp_lib_concepts / !__cpp_lib_concepts vvv
     using difference_type = void;
@@ -84,7 +85,8 @@ public:
     using container_type = _Container;
 
 #ifdef __cpp_lib_concepts
-    using difference_type                      = ptrdiff_t;
+    using difference_type = ptrdiff_t;
+
     constexpr front_insert_iterator() noexcept = default;
 #else // ^^^ __cpp_lib_concepts / !__cpp_lib_concepts vvv
     using difference_type = void;
@@ -133,11 +135,13 @@ public:
     using value_type        = void;
     using pointer           = void;
     using reference         = void;
-    using container_type    = _Container;
+
+    using container_type = _Container;
 
 #ifdef __cpp_lib_concepts
     using difference_type = ptrdiff_t;
-    insert_iterator()     = default;
+
+    insert_iterator() = default;
 #else // ^^^ __cpp_lib_concepts / !__cpp_lib_concepts vvv
     using difference_type = void;
 #endif // __cpp_lib_concepts
@@ -172,7 +176,7 @@ public:
 
 protected:
     _Container* container              = nullptr;
-    typename _Container::iterator iter = typename _Container::iterator();
+    typename _Container::iterator iter = {};
 };
 
 // FUNCTION TEMPLATE inserter

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -779,6 +779,11 @@ language.support\cmp\cmp.weakord\weakord.pass.cpp
 # error C4576: a parenthesized type followed by an initializer list is a non-standard explicit type conversion syntax
 containers\sequences\array\array.creation\to_array.pass.cpp
 
+# Tests that need to learn that insert iterators have non-void difference type in C++20
+iterators\predef.iterators\insert.iterators\back.insert.iterator\types.pass.cpp
+iterators\predef.iterators\insert.iterators\front.insert.iterator\types.pass.cpp
+iterators\predef.iterators\insert.iterators\insert.iterator\types.pass.cpp
+
 
 # *** LIKELY STL BUGS ***
 # Not yet analyzed, likely STL bugs. Assertions and other runtime failures.

--- a/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
@@ -5,8 +5,10 @@
 #include <compare>
 #include <concepts>
 #include <iterator>
+#include <list>
 #include <type_traits>
 #include <utility>
+#include <vector>
 
 #define STATIC_ASSERT(...) static_assert(__VA_ARGS__, #__VA_ARGS__)
 
@@ -2769,6 +2771,26 @@ namespace iter_ops {
         test_distance();
     }
 } // namespace iter_ops
+
+namespace insert_iterators {
+    template <class Container>
+    constexpr bool test() {
+        using std::back_insert_iterator, std::front_insert_iterator, std::insert_iterator;
+        using std::default_initializable, std::iter_difference_t, std::ptrdiff_t, std::same_as;
+
+        STATIC_ASSERT(default_initializable<back_insert_iterator<Container>>);
+        STATIC_ASSERT(default_initializable<front_insert_iterator<Container>>);
+        STATIC_ASSERT(default_initializable<insert_iterator<Container>>);
+        STATIC_ASSERT(same_as<iter_difference_t<back_insert_iterator<Container>>, ptrdiff_t>);
+        STATIC_ASSERT(same_as<iter_difference_t<front_insert_iterator<Container>>, ptrdiff_t>);
+        STATIC_ASSERT(same_as<iter_difference_t<insert_iterator<Container>>, ptrdiff_t>);
+
+        return true;
+    }
+
+    STATIC_ASSERT(test<std::list<double>>());
+    STATIC_ASSERT(test<std::vector<int>>());
+} // namespace insert_iterators
 
 int main() {
     iterator_cust_swap_test::test();

--- a/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
@@ -2776,10 +2776,13 @@ namespace insert_iterators {
     template <class Container>
     constexpr bool test() {
         using std::back_insert_iterator, std::front_insert_iterator, std::insert_iterator;
-        using std::default_initializable, std::iter_difference_t, std::ptrdiff_t, std::same_as;
+        using std::default_initializable, std::is_nothrow_default_constructible_v, std::iter_difference_t,
+            std::ptrdiff_t, std::same_as;
 
         STATIC_ASSERT(default_initializable<back_insert_iterator<Container>>);
+        STATIC_ASSERT(is_nothrow_default_constructible_v<back_insert_iterator<Container>>);
         STATIC_ASSERT(default_initializable<front_insert_iterator<Container>>);
+        STATIC_ASSERT(is_nothrow_default_constructible_v<front_insert_iterator<Container>>);
         STATIC_ASSERT(default_initializable<insert_iterator<Container>>);
         STATIC_ASSERT(same_as<iter_difference_t<back_insert_iterator<Container>>, ptrdiff_t>);
         STATIC_ASSERT(same_as<iter_difference_t<front_insert_iterator<Container>>, ptrdiff_t>);


### PR DESCRIPTION
# Description

When `defined(__cpp_lib_concepts)`, `(back_|front_|)insert_iterator` are default constructible, and have `ptrdiff_t` as difference type.

# Checklist

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [x] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
