### PR TITLE
constexpr for std::array Comparisons

### DIFF
--- a/stl/inc/array
+++ b/stl/inc/array
@@ -150,8 +150,7 @@ public:
         return _Elems[_Pos];
     }
 
-    _NODISCARD constexpr const_reference operator[](_In_range_(0, _Size - 1) size_type _Pos) const noexcept
-    /* strengthened */ {
+    _NODISCARD constexpr const_reference operator[](_In_range_(0, _Size - 1) size_type _Pos) const noexcept /* strengthened */ {
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(_Pos < _Size, "array subscript out of range");
 #endif // _CONTAINER_DEBUG_LEVEL > 0
@@ -200,7 +199,7 @@ struct _Enforce_same {
 };
 
 template <class _First, class... _Rest>
-array(_First, _Rest...) -> array<typename _Enforce_same<_First, _Rest...>::type, 1 + sizeof...(_Rest)>;
+array(_First, _Rest...)->array<typename _Enforce_same<_First, _Rest...>::type, 1 + sizeof...(_Rest)>;
 #endif // _HAS_CXX17
 
 template <class _Ty>

--- a/stl/inc/array
+++ b/stl/inc/array
@@ -150,7 +150,8 @@ public:
         return _Elems[_Pos];
     }
 
-    _NODISCARD constexpr const_reference operator[](_In_range_(0, _Size - 1) size_type _Pos) const noexcept /* strengthened */ {
+    _NODISCARD constexpr const_reference operator[](_In_range_(0, _Size - 1) size_type _Pos) const
+        noexcept /* strengthened */ {
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(_Pos < _Size, "array subscript out of range");
 #endif // _CONTAINER_DEBUG_LEVEL > 0

--- a/stl/inc/array
+++ b/stl/inc/array
@@ -150,8 +150,8 @@ public:
         return _Elems[_Pos];
     }
 
-    _NODISCARD constexpr const_reference operator[](_In_range_(0, _Size - 1) size_type _Pos) const
-        noexcept /* strengthened */ {
+    _NODISCARD constexpr const_reference operator[](_In_range_(0, _Size - 1) size_type _Pos) const noexcept
+    /* strengthened */ {
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(_Pos < _Size, "array subscript out of range");
 #endif // _CONTAINER_DEBUG_LEVEL > 0
@@ -200,7 +200,7 @@ struct _Enforce_same {
 };
 
 template <class _First, class... _Rest>
-array(_First, _Rest...)->array<typename _Enforce_same<_First, _Rest...>::type, 1 + sizeof...(_Rest)>;
+array(_First, _Rest...) -> array<typename _Enforce_same<_First, _Rest...>::type, 1 + sizeof...(_Rest)>;
 #endif // _HAS_CXX17
 
 template <class _Ty>

--- a/stl/inc/array
+++ b/stl/inc/array
@@ -380,32 +380,32 @@ void swap(array<_Ty, _Size>& _Left, array<_Ty, _Size>& _Right) noexcept(noexcept
 }
 
 template <class _Ty, size_t _Size>
-_NODISCARD bool operator==(const array<_Ty, _Size>& _Left, const array<_Ty, _Size>& _Right) {
+_NODISCARD _CONSTEXPR20 bool operator==(const array<_Ty, _Size>& _Left, const array<_Ty, _Size>& _Right) {
     return _STD equal(_Left.begin(), _Left.end(), _Right.begin());
 }
 
 template <class _Ty, size_t _Size>
-_NODISCARD bool operator!=(const array<_Ty, _Size>& _Left, const array<_Ty, _Size>& _Right) {
+_NODISCARD _CONSTEXPR20 bool operator!=(const array<_Ty, _Size>& _Left, const array<_Ty, _Size>& _Right) {
     return !(_Left == _Right);
 }
 
 template <class _Ty, size_t _Size>
-_NODISCARD bool operator<(const array<_Ty, _Size>& _Left, const array<_Ty, _Size>& _Right) {
+_NODISCARD _CONSTEXPR20 bool operator<(const array<_Ty, _Size>& _Left, const array<_Ty, _Size>& _Right) {
     return _STD lexicographical_compare(_Left.begin(), _Left.end(), _Right.begin(), _Right.end());
 }
 
 template <class _Ty, size_t _Size>
-_NODISCARD bool operator>(const array<_Ty, _Size>& _Left, const array<_Ty, _Size>& _Right) {
+_NODISCARD _CONSTEXPR20 bool operator>(const array<_Ty, _Size>& _Left, const array<_Ty, _Size>& _Right) {
     return _Right < _Left;
 }
 
 template <class _Ty, size_t _Size>
-_NODISCARD bool operator<=(const array<_Ty, _Size>& _Left, const array<_Ty, _Size>& _Right) {
+_NODISCARD _CONSTEXPR20 bool operator<=(const array<_Ty, _Size>& _Left, const array<_Ty, _Size>& _Right) {
     return !(_Right < _Left);
 }
 
 template <class _Ty, size_t _Size>
-_NODISCARD bool operator>=(const array<_Ty, _Size>& _Left, const array<_Ty, _Size>& _Right) {
+_NODISCARD _CONSTEXPR20 bool operator>=(const array<_Ty, _Size>& _Left, const array<_Ty, _Size>& _Right) {
     return !(_Left < _Right);
 }
 

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -169,6 +169,7 @@
 // P0919R3 Heterogeneous Lookup For Unordered Containers
 // P0966R1 string::reserve() Should Not Shrink
 // P1006R1 constexpr For pointer_traits<T*>::pointer_to()
+// P1023R0 constexpr For std::array Comparisons
 // P1024R3 Enhancing span Usability
 // P1085R2 Removing span Comparisons
 // P1115R3 erase()/erase_if() Return size_type
@@ -1037,7 +1038,6 @@
 #if _HAS_CXX17
 #define __cpp_lib_any                        201606L
 #define __cpp_lib_apply                      201603L
-#define __cpp_lib_array_constexpr            201803L
 #define __cpp_lib_atomic_is_always_lock_free 201603L
 #define __cpp_lib_boyer_moore_searcher       201603L
 #if _HAS_STD_BYTE
@@ -1126,6 +1126,13 @@
 #define __cpp_lib_type_identity            201806L
 #define __cpp_lib_unwrap_ref               201811L
 #endif // _HAS_CXX20
+
+#if _HAS_CXX20
+#define __cpp_lib_array_constexpr          201811L // P1023R0 constexpr For std::array Comparisons
+// ^^^ _HAS_CXX20 / _HAS_CXX17 vvv
+#elif _HAS_CXX17
+#define __cpp_lib_array_constexpr          201803L
+#endif // _HAS_CXX17
 
 // EXPERIMENTAL
 #define __cpp_lib_experimental_erase_if   201411L

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -1128,10 +1128,9 @@
 #endif // _HAS_CXX20
 
 #if _HAS_CXX20
-#define __cpp_lib_array_constexpr          201811L // P1023R0 constexpr For std::array Comparisons
-// ^^^ _HAS_CXX20 / _HAS_CXX17 vvv
-#elif _HAS_CXX17
-#define __cpp_lib_array_constexpr          201803L
+#define __cpp_lib_array_constexpr 201811L // P1023R0 constexpr For std::array Comparisons
+#elif _HAS_CXX17 // ^^^ _HAS_CXX20 / _HAS_CXX17 vvv
+#define __cpp_lib_array_constexpr 201803L
 #endif // _HAS_CXX17
 
 // EXPERIMENTAL

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -1128,7 +1128,7 @@
 #endif // _HAS_CXX20
 
 #if _HAS_CXX20
-#define __cpp_lib_array_constexpr 201811L // P1023R0 constexpr For std::array Comparisons
+#define __cpp_lib_array_constexpr 201806L // P1023R0 constexpr For std::array Comparisons
 #elif _HAS_CXX17 // ^^^ _HAS_CXX20 / _HAS_CXX17 vvv
 #define __cpp_lib_array_constexpr 201803L
 #endif // _HAS_CXX17

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -452,9 +452,6 @@ std/language.support/support.limits/support.limits.general/functional.version.pa
 std/language.support/support.limits/support.limits.general/iterator.version.pass.cpp SKIP
 std/language.support/support.limits/support.limits.general/memory.version.pass.cpp SKIP
 
-# C++20 P1023R0 "constexpr For std::array Comparisons"
-std/containers/sequences/array/compare.pass.cpp SKIP
-
 # C++20 P1032R1 "Miscellaneous constexpr"
 std/language.support/support.limits/support.limits.general/array.version.pass.cpp SKIP
 std/language.support/support.limits/support.limits.general/functional.version.pass.cpp SKIP

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -452,9 +452,6 @@ language.support\support.limits\support.limits.general\functional.version.pass.c
 language.support\support.limits\support.limits.general\iterator.version.pass.cpp
 language.support\support.limits\support.limits.general\memory.version.pass.cpp
 
-# C++20 P1023R0 "constexpr For std::array Comparisons"
-containers\sequences\array\compare.pass.cpp
-
 # C++20 P1032R1 "Miscellaneous constexpr"
 language.support\support.limits\support.limits.general\array.version.pass.cpp
 language.support\support.limits\support.limits.general\functional.version.pass.cpp

--- a/tests/std/test.lst
+++ b/tests/std/test.lst
@@ -249,6 +249,7 @@ tests\P0898R3_concepts
 tests\P0898R3_identity
 tests\P0919R3_heterogeneous_unordered_lookup
 tests\P0966R1_string_reserve_should_not_shrink
+tests\P1023R0_constexpr_for_array_comparisons
 tests\P1165R1_consistently_propagating_stateful_allocators
 tests\P1423R3_char8_t_remediation
 tests\P1645R1_constexpr_numeric

--- a/tests/std/tests/P1023R0_constexpr_for_array_comparisons/env.lst
+++ b/tests/std/tests/P1023R0_constexpr_for_array_comparisons/env.lst
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+RUNALL_INCLUDE ..\usual_latest_matrix.lst

--- a/tests/std/tests/P1023R0_constexpr_for_array_comparisons/test.cpp
+++ b/tests/std/tests/P1023R0_constexpr_for_array_comparisons/test.cpp
@@ -23,7 +23,7 @@ constexpr bool test_operator_eq() {
 constexpr bool test_operator_neq() {
     assert(!(a0 != a0));
     assert(!(a1 != a1));
-    assert(!(a0 != a2));
+    assert((a0 != a2));
     assert(!(a3 != a3));
 
     return true;
@@ -50,7 +50,6 @@ constexpr bool test_operator_gt() {
 
 constexpr bool test_operator_leq() {
     assert(a0 <= a0);
-    assert(a0 <= a0);
     assert(a1 <= a1);
     assert(a2 <= a0);
     assert(a3 <= a3);
@@ -70,8 +69,7 @@ constexpr bool test_operator_geq() {
 
 constexpr bool test() {
     // clang-format off
-    return
-        test_operator_eq()
+    return test_operator_eq()
         && test_operator_neq()
         && test_operator_lt()
         && test_operator_gt()

--- a/tests/std/tests/P1023R0_constexpr_for_array_comparisons/test.cpp
+++ b/tests/std/tests/P1023R0_constexpr_for_array_comparisons/test.cpp
@@ -48,7 +48,8 @@ constexpr bool test_operator_gt() {
 }
 
 
-constexpr bool test_operator_leq() {assert(a0 <= a0);
+constexpr bool test_operator_leq() {
+    assert(a0 <= a0);
     assert(a0 <= a0);
     assert(a1 <= a1);
     assert(a2 <= a0);

--- a/tests/std/tests/P1023R0_constexpr_for_array_comparisons/test.cpp
+++ b/tests/std/tests/P1023R0_constexpr_for_array_comparisons/test.cpp
@@ -6,9 +6,9 @@
 
 using namespace std;
 
-constexpr array<int, 5> a0{2, 8, 9, 1, 9};
-constexpr array<int, 3> a1{2, 8, 9};
-constexpr array<int, 5> a2{2, 8, 9, 1, 8};
+constexpr array<int, 5> a0{{2, 8, 9, 1, 9}};
+constexpr array<int, 3> a1{{2, 8, 9}};
+constexpr array<int, 5> a2{{2, 8, 9, 1, 8}};
 constexpr array<int, 0> a3{};
 
 constexpr bool test_operator_eq() {

--- a/tests/std/tests/P1023R0_constexpr_for_array_comparisons/test.cpp
+++ b/tests/std/tests/P1023R0_constexpr_for_array_comparisons/test.cpp
@@ -1,0 +1,145 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <cassert>
+#include <array>
+
+using namespace std;
+
+constexpr bool test_operator_eq() {
+    array<int, 5> a0{2,8,9,1,9};
+    array<int, 3> a1{2,8,9};
+    array<int, 5> a2{2,8,9,1,8};
+    array<int, 0> a3({});
+
+    assert(a0 == a0);
+    assert(a1 == a1);
+    assert(! (a0 == a2));
+    assert(a3 == a3);
+
+    #ifdef __cpp_lib_to_array
+    assert(a0 == to_array({2,8,9,1,9}));
+    assert(! (a0 == to_array({2,8,9,1,8})));
+    #endif //__cpp_lib_to_array
+
+    return true;
+}
+
+constexpr bool test_operator_neq() {
+    array<int, 5> a0{2,8,9,1,9};
+    array<int, 3> a1{2,8,9};
+    array<int, 5> a2{2,8,9,1,8};
+    array<int, 0> a3({});
+
+    assert(! (a0 != a0));
+    assert(! (a1 != a1));
+    assert(! (a0 == a2));
+    assert(! (a3 != a3));
+
+    #ifdef __cpp_lib_to_array
+    assert(! (a0 != to_array({2,8,9,1,9})));
+    assert(a0 != to_array({2,8,9,1,8}));
+    #endif //__cpp_lib_to_array
+
+    return true;
+}
+
+constexpr bool test_operator_lt() {
+    array<int, 5> a0{2,8,9,1,9};
+    array<int, 3> a1{2,8,9};
+    array<int, 5> a2{2,8,9,1,8};
+    array<int, 0> a3({});
+
+
+    assert(! (a0 < a0));
+    assert(! (a1 < a1));
+    assert(a2 < a0);
+    assert(! (a3 < a3));
+
+    #ifdef __cpp_lib_to_array
+    assert(! (a0 < to_array({2,8,9,1,9})));
+    assert(a0 < to_array({2,8,9,1,10}));
+    #endif //__cpp_lib_to_array
+
+    return true;
+}
+
+constexpr bool test_operator_gt() {
+    array<int, 5> a0{2,8,9,1,9};
+    array<int, 3> a1{2,8,9};
+    array<int, 5> a2{2,8,9,1,8};
+    array<int, 0> a3({});
+
+
+    assert(! (a0 > a0));
+    assert(! (a1 > a1));
+    assert(a0 > a2);
+    assert(! (a3 > a3));
+
+    #ifdef __cpp_lib_to_array
+    assert(! (a0 > to_array({2,8,9,1,9})));
+    assert(a0 > to_array({2,8,9,1,0}));
+    #endif //__cpp_lib_to_array
+
+    return true;
+}
+
+
+constexpr bool test_operator_leq() {
+    array<int, 5> a0{2,8,9,1,9};
+    array<int, 3> a1{2,8,9};
+    array<int, 5> a2{2,8,9,1,8};
+    array<int, 0> a3({});
+
+
+    assert(a0 <= a0);
+    assert(a1 <= a1);
+    assert(a2 <= a0);
+    assert(a3 <= a3);
+
+    #ifdef __cpp_lib_to_array
+    assert(a0 <= to_array({2,8,9,1,9}));
+    assert(a0 <= to_array({2,8,9,1,10}));
+    #endif //__cpp_lib_to_array
+
+    return true;
+}
+
+
+constexpr bool test_operator_geq() {
+    array<int, 5> a0{2,8,9,1,9};
+    array<int, 3> a1{2,8,9};
+    array<int, 5> a2{2,8,9,1,8};
+    array<int, 0> a3({});
+
+
+    assert(a0 >= a0);
+    assert(a1 >= a1);
+    assert(a0 >= a2);
+    assert(a3 >= a3);
+
+    #ifdef __cpp_lib_to_array
+    assert(a0 >= to_array({2,8,9,1,9}));
+    assert(a0 >= to_array({2,8,9,1,0}));
+    #endif //__cpp_lib_to_array
+
+    return true;
+}
+
+constexpr bool test() {
+    // clang-format off
+    return
+        test_operator_eq()
+        && test_operator_neq()
+        && test_operator_lt()
+        && test_operator_gt()
+        && test_operator_leq()
+        && test_operator_geq()
+        ;
+    // clang-format on
+}
+
+int main() {
+    test();
+    static_assert(test());
+}

--- a/tests/std/tests/P1023R0_constexpr_for_array_comparisons/test.cpp
+++ b/tests/std/tests/P1023R0_constexpr_for_array_comparisons/test.cpp
@@ -6,122 +6,63 @@
 
 using namespace std;
 
-constexpr bool test_operator_eq() {
-    array<int, 5> a0{2, 8, 9, 1, 9};
-    array<int, 3> a1{2, 8, 9};
-    array<int, 5> a2{2, 8, 9, 1, 8};
-    array<int, 0> a3{};
+const array<int, 5> a0{2, 8, 9, 1, 9};
+const array<int, 3> a1{2, 8, 9};
+const array<int, 5> a2{2, 8, 9, 1, 8};
+const array<int, 0> a3{};
 
+constexpr bool test_operator_eq() {
     assert(a0 == a0);
     assert(a1 == a1);
     assert(!(a0 == a2));
     assert(a3 == a3);
 
-#ifdef __cpp_lib_to_array
-    assert(a0 == to_array({2, 8, 9, 1, 9}));
-    assert(!(a0 == to_array({2, 8, 9, 1, 8})));
-#endif //__cpp_lib_to_array
-
     return true;
 }
 
 constexpr bool test_operator_neq() {
-    array<int, 5> a0{2, 8, 9, 1, 9};
-    array<int, 3> a1{2, 8, 9};
-    array<int, 5> a2{2, 8, 9, 1, 8};
-    array<int, 0> a3{};
-
     assert(!(a0 != a0));
     assert(!(a1 != a1));
-    assert(!(a0 == a2));
+    assert(!(a0 != a2));
     assert(!(a3 != a3));
-
-#ifdef __cpp_lib_to_array
-    assert(!(a0 != to_array({2, 8, 9, 1, 9})));
-    assert(a0 != to_array({2, 8, 9, 1, 8}));
-#endif //__cpp_lib_to_array
 
     return true;
 }
 
 constexpr bool test_operator_lt() {
-    array<int, 5> a0{2, 8, 9, 1, 9};
-    array<int, 3> a1{2, 8, 9};
-    array<int, 5> a2{2, 8, 9, 1, 8};
-    array<int, 0> a3{};
-
-
     assert(!(a0 < a0));
     assert(!(a1 < a1));
     assert(a2 < a0);
     assert(!(a3 < a3));
 
-#ifdef __cpp_lib_to_array
-    assert(!(a0 < to_array({2, 8, 9, 1, 9})));
-    assert(a0 < to_array({2, 8, 9, 1, 10}));
-#endif //__cpp_lib_to_array
-
     return true;
 }
 
 constexpr bool test_operator_gt() {
-    array<int, 5> a0{2, 8, 9, 1, 9};
-    array<int, 3> a1{2, 8, 9};
-    array<int, 5> a2{2, 8, 9, 1, 8};
-    array<int, 0> a3{};
-
-
     assert(!(a0 > a0));
     assert(!(a1 > a1));
     assert(a0 > a2);
     assert(!(a3 > a3));
 
-#ifdef __cpp_lib_to_array
-    assert(!(a0 > to_array({2, 8, 9, 1, 9})));
-    assert(a0 > to_array({2, 8, 9, 1, 0}));
-#endif //__cpp_lib_to_array
-
     return true;
 }
 
 
-constexpr bool test_operator_leq() {
-    array<int, 5> a0{2, 8, 9, 1, 9};
-    array<int, 3> a1{2, 8, 9};
-    array<int, 5> a2{2, 8, 9, 1, 8};
-    array<int, 0> a3{};
-
-
+constexpr bool test_operator_leq() {assert(a0 <= a0);
     assert(a0 <= a0);
     assert(a1 <= a1);
     assert(a2 <= a0);
     assert(a3 <= a3);
-
-#ifdef __cpp_lib_to_array
-    assert(a0 <= to_array({2, 8, 9, 1, 9}));
-    assert(a0 <= to_array({2, 8, 9, 1, 10}));
-#endif //__cpp_lib_to_array
 
     return true;
 }
 
 
 constexpr bool test_operator_geq() {
-    array<int, 5> a0{2, 8, 9, 1, 9};
-    array<int, 3> a1{2, 8, 9};
-    array<int, 5> a2{2, 8, 9, 1, 8};
-    array<int, 0> a3{};
-
-
     assert(a0 >= a0);
     assert(a1 >= a1);
     assert(a0 >= a2);
     assert(a3 >= a3);
-
-#ifdef __cpp_lib_to_array
-    assert(a0 >= to_array({2, 8, 9, 1, 9}));
-    assert(a0 >= to_array({2, 8, 9, 1, 0}));
-#endif //__cpp_lib_to_array
 
     return true;
 }

--- a/tests/std/tests/P1023R0_constexpr_for_array_comparisons/test.cpp
+++ b/tests/std/tests/P1023R0_constexpr_for_array_comparisons/test.cpp
@@ -1,94 +1,94 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include <cassert>
 #include <array>
+#include <cassert>
 
 using namespace std;
 
 constexpr bool test_operator_eq() {
-    array<int, 5> a0{2,8,9,1,9};
-    array<int, 3> a1{2,8,9};
-    array<int, 5> a2{2,8,9,1,8};
+    array<int, 5> a0{2, 8, 9, 1, 9};
+    array<int, 3> a1{2, 8, 9};
+    array<int, 5> a2{2, 8, 9, 1, 8};
     array<int, 0> a3({});
 
     assert(a0 == a0);
     assert(a1 == a1);
-    assert(! (a0 == a2));
+    assert(!(a0 == a2));
     assert(a3 == a3);
 
-    #ifdef __cpp_lib_to_array
-    assert(a0 == to_array({2,8,9,1,9}));
-    assert(! (a0 == to_array({2,8,9,1,8})));
-    #endif //__cpp_lib_to_array
+#ifdef __cpp_lib_to_array
+    assert(a0 == to_array({2, 8, 9, 1, 9}));
+    assert(!(a0 == to_array({2, 8, 9, 1, 8})));
+#endif //__cpp_lib_to_array
 
     return true;
 }
 
 constexpr bool test_operator_neq() {
-    array<int, 5> a0{2,8,9,1,9};
-    array<int, 3> a1{2,8,9};
-    array<int, 5> a2{2,8,9,1,8};
+    array<int, 5> a0{2, 8, 9, 1, 9};
+    array<int, 3> a1{2, 8, 9};
+    array<int, 5> a2{2, 8, 9, 1, 8};
     array<int, 0> a3({});
 
-    assert(! (a0 != a0));
-    assert(! (a1 != a1));
-    assert(! (a0 == a2));
-    assert(! (a3 != a3));
+    assert(!(a0 != a0));
+    assert(!(a1 != a1));
+    assert(!(a0 == a2));
+    assert(!(a3 != a3));
 
-    #ifdef __cpp_lib_to_array
-    assert(! (a0 != to_array({2,8,9,1,9})));
-    assert(a0 != to_array({2,8,9,1,8}));
-    #endif //__cpp_lib_to_array
+#ifdef __cpp_lib_to_array
+    assert(!(a0 != to_array({2, 8, 9, 1, 9})));
+    assert(a0 != to_array({2, 8, 9, 1, 8}));
+#endif //__cpp_lib_to_array
 
     return true;
 }
 
 constexpr bool test_operator_lt() {
-    array<int, 5> a0{2,8,9,1,9};
-    array<int, 3> a1{2,8,9};
-    array<int, 5> a2{2,8,9,1,8};
+    array<int, 5> a0{2, 8, 9, 1, 9};
+    array<int, 3> a1{2, 8, 9};
+    array<int, 5> a2{2, 8, 9, 1, 8};
     array<int, 0> a3({});
 
 
-    assert(! (a0 < a0));
-    assert(! (a1 < a1));
+    assert(!(a0 < a0));
+    assert(!(a1 < a1));
     assert(a2 < a0);
-    assert(! (a3 < a3));
+    assert(!(a3 < a3));
 
-    #ifdef __cpp_lib_to_array
-    assert(! (a0 < to_array({2,8,9,1,9})));
-    assert(a0 < to_array({2,8,9,1,10}));
-    #endif //__cpp_lib_to_array
+#ifdef __cpp_lib_to_array
+    assert(!(a0 < to_array({2, 8, 9, 1, 9})));
+    assert(a0 < to_array({2, 8, 9, 1, 10}));
+#endif //__cpp_lib_to_array
 
     return true;
 }
 
 constexpr bool test_operator_gt() {
-    array<int, 5> a0{2,8,9,1,9};
-    array<int, 3> a1{2,8,9};
-    array<int, 5> a2{2,8,9,1,8};
+    array<int, 5> a0{2, 8, 9, 1, 9};
+    array<int, 3> a1{2, 8, 9};
+    array<int, 5> a2{2, 8, 9, 1, 8};
     array<int, 0> a3({});
 
 
-    assert(! (a0 > a0));
-    assert(! (a1 > a1));
+    assert(!(a0 > a0));
+    assert(!(a1 > a1));
     assert(a0 > a2);
-    assert(! (a3 > a3));
+    assert(!(a3 > a3));
 
-    #ifdef __cpp_lib_to_array
-    assert(! (a0 > to_array({2,8,9,1,9})));
-    assert(a0 > to_array({2,8,9,1,0}));
-    #endif //__cpp_lib_to_array
+#ifdef __cpp_lib_to_array
+    assert(!(a0 > to_array({2, 8, 9, 1, 9})));
+    assert(a0 > to_array({2, 8, 9, 1, 0}));
+#endif //__cpp_lib_to_array
 
     return true;
 }
 
 
 constexpr bool test_operator_leq() {
-    array<int, 5> a0{2,8,9,1,9};
-    array<int, 3> a1{2,8,9};
-    array<int, 5> a2{2,8,9,1,8};
+    array<int, 5> a0{2, 8, 9, 1, 9};
+    array<int, 3> a1{2, 8, 9};
+    array<int, 5> a2{2, 8, 9, 1, 8};
     array<int, 0> a3({});
 
 
@@ -97,19 +97,19 @@ constexpr bool test_operator_leq() {
     assert(a2 <= a0);
     assert(a3 <= a3);
 
-    #ifdef __cpp_lib_to_array
-    assert(a0 <= to_array({2,8,9,1,9}));
-    assert(a0 <= to_array({2,8,9,1,10}));
-    #endif //__cpp_lib_to_array
+#ifdef __cpp_lib_to_array
+    assert(a0 <= to_array({2, 8, 9, 1, 9}));
+    assert(a0 <= to_array({2, 8, 9, 1, 10}));
+#endif //__cpp_lib_to_array
 
     return true;
 }
 
 
 constexpr bool test_operator_geq() {
-    array<int, 5> a0{2,8,9,1,9};
-    array<int, 3> a1{2,8,9};
-    array<int, 5> a2{2,8,9,1,8};
+    array<int, 5> a0{2, 8, 9, 1, 9};
+    array<int, 3> a1{2, 8, 9};
+    array<int, 5> a2{2, 8, 9, 1, 8};
     array<int, 0> a3({});
 
 
@@ -118,10 +118,10 @@ constexpr bool test_operator_geq() {
     assert(a0 >= a2);
     assert(a3 >= a3);
 
-    #ifdef __cpp_lib_to_array
-    assert(a0 >= to_array({2,8,9,1,9}));
-    assert(a0 >= to_array({2,8,9,1,0}));
-    #endif //__cpp_lib_to_array
+#ifdef __cpp_lib_to_array
+    assert(a0 >= to_array({2, 8, 9, 1, 9}));
+    assert(a0 >= to_array({2, 8, 9, 1, 0}));
+#endif //__cpp_lib_to_array
 
     return true;
 }

--- a/tests/std/tests/P1023R0_constexpr_for_array_comparisons/test.cpp
+++ b/tests/std/tests/P1023R0_constexpr_for_array_comparisons/test.cpp
@@ -10,7 +10,7 @@ constexpr bool test_operator_eq() {
     array<int, 5> a0{2, 8, 9, 1, 9};
     array<int, 3> a1{2, 8, 9};
     array<int, 5> a2{2, 8, 9, 1, 8};
-    array<int, 0> a3({});
+    array<int, 0> a3{};
 
     assert(a0 == a0);
     assert(a1 == a1);
@@ -29,7 +29,7 @@ constexpr bool test_operator_neq() {
     array<int, 5> a0{2, 8, 9, 1, 9};
     array<int, 3> a1{2, 8, 9};
     array<int, 5> a2{2, 8, 9, 1, 8};
-    array<int, 0> a3({});
+    array<int, 0> a3{};
 
     assert(!(a0 != a0));
     assert(!(a1 != a1));
@@ -48,7 +48,7 @@ constexpr bool test_operator_lt() {
     array<int, 5> a0{2, 8, 9, 1, 9};
     array<int, 3> a1{2, 8, 9};
     array<int, 5> a2{2, 8, 9, 1, 8};
-    array<int, 0> a3({});
+    array<int, 0> a3{};
 
 
     assert(!(a0 < a0));
@@ -68,7 +68,7 @@ constexpr bool test_operator_gt() {
     array<int, 5> a0{2, 8, 9, 1, 9};
     array<int, 3> a1{2, 8, 9};
     array<int, 5> a2{2, 8, 9, 1, 8};
-    array<int, 0> a3({});
+    array<int, 0> a3{};
 
 
     assert(!(a0 > a0));
@@ -89,7 +89,7 @@ constexpr bool test_operator_leq() {
     array<int, 5> a0{2, 8, 9, 1, 9};
     array<int, 3> a1{2, 8, 9};
     array<int, 5> a2{2, 8, 9, 1, 8};
-    array<int, 0> a3({});
+    array<int, 0> a3{};
 
 
     assert(a0 <= a0);
@@ -110,7 +110,7 @@ constexpr bool test_operator_geq() {
     array<int, 5> a0{2, 8, 9, 1, 9};
     array<int, 3> a1{2, 8, 9};
     array<int, 5> a2{2, 8, 9, 1, 8};
-    array<int, 0> a3({});
+    array<int, 0> a3{};
 
 
     assert(a0 >= a0);

--- a/tests/std/tests/P1023R0_constexpr_for_array_comparisons/test.cpp
+++ b/tests/std/tests/P1023R0_constexpr_for_array_comparisons/test.cpp
@@ -23,7 +23,7 @@ constexpr bool test_operator_eq() {
 constexpr bool test_operator_neq() {
     assert(!(a0 != a0));
     assert(!(a1 != a1));
-    assert((a0 != a2));
+    assert(a0 != a2);
     assert(!(a3 != a3));
 
     return true;

--- a/tests/std/tests/P1023R0_constexpr_for_array_comparisons/test.cpp
+++ b/tests/std/tests/P1023R0_constexpr_for_array_comparisons/test.cpp
@@ -6,10 +6,10 @@
 
 using namespace std;
 
-const array<int, 5> a0{2, 8, 9, 1, 9};
-const array<int, 3> a1{2, 8, 9};
-const array<int, 5> a2{2, 8, 9, 1, 8};
-const array<int, 0> a3{};
+constexpr array<int, 5> a0{2, 8, 9, 1, 9};
+constexpr array<int, 3> a1{2, 8, 9};
+constexpr array<int, 5> a2{2, 8, 9, 1, 8};
+constexpr array<int, 0> a3{};
 
 constexpr bool test_operator_eq() {
     assert(a0 == a0);

--- a/tests/std/tests/P1023R0_constexpr_for_array_comparisons/test.cpp
+++ b/tests/std/tests/P1023R0_constexpr_for_array_comparisons/test.cpp
@@ -11,72 +11,58 @@ constexpr array<int, 3> a1{{2, 8, 9}};
 constexpr array<int, 5> a2{{2, 8, 9, 1, 8}};
 constexpr array<int, 0> a3{};
 
-constexpr bool test_operator_eq() {
+constexpr void test_operator_eq() {
     assert(a0 == a0);
     assert(a1 == a1);
     assert(!(a0 == a2));
     assert(a3 == a3);
-
-    return true;
 }
 
-constexpr bool test_operator_neq() {
+constexpr void test_operator_neq() {
     assert(!(a0 != a0));
     assert(!(a1 != a1));
     assert(a0 != a2);
     assert(!(a3 != a3));
-
-    return true;
 }
 
-constexpr bool test_operator_lt() {
+constexpr void test_operator_lt() {
     assert(!(a0 < a0));
     assert(!(a1 < a1));
     assert(a2 < a0);
     assert(!(a3 < a3));
-
-    return true;
 }
 
-constexpr bool test_operator_gt() {
+constexpr void test_operator_gt() {
     assert(!(a0 > a0));
     assert(!(a1 > a1));
     assert(a0 > a2);
     assert(!(a3 > a3));
-
-    return true;
 }
 
 
-constexpr bool test_operator_leq() {
+constexpr void test_operator_leq() {
     assert(a0 <= a0);
     assert(a1 <= a1);
     assert(a2 <= a0);
     assert(a3 <= a3);
-
-    return true;
 }
 
 
-constexpr bool test_operator_geq() {
+constexpr void test_operator_geq() {
     assert(a0 >= a0);
     assert(a1 >= a1);
     assert(a0 >= a2);
     assert(a3 >= a3);
-
-    return true;
 }
 
 constexpr bool test() {
-    // clang-format off
-    return test_operator_eq()
-        && test_operator_neq()
-        && test_operator_lt()
-        && test_operator_gt()
-        && test_operator_leq()
-        && test_operator_geq()
-        ;
-    // clang-format on
+    test_operator_eq();
+    test_operator_neq();
+    test_operator_lt();
+    test_operator_gt();
+    test_operator_leq();
+    test_operator_geq();
+    return true;
 }
 
 int main() {

--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.cpp
@@ -718,7 +718,15 @@ STATIC_ASSERT(__cpp_lib_apply == 201603L);
 #endif
 #endif
 
-#if _HAS_CXX17
+#if _HAS_CXX20
+#ifndef __cpp_lib_array_constexpr
+#error __cpp_lib_array_constexpr is not defined
+#elif __cpp_lib_array_constexpr != 201806L
+#error __cpp_lib_array_constexpr is not 201806L
+#else
+STATIC_ASSERT(__cpp_lib_array_constexpr == 201806L);
+#endif
+#elif _HAS_CXX17
 #ifndef __cpp_lib_array_constexpr
 #error __cpp_lib_array_constexpr is not defined
 #elif __cpp_lib_array_constexpr != 201803L


### PR DESCRIPTION
Description
===========
Resolves #49.

- `stl/inc/array`: The functions where `constexpr` needed to be added just called other functions which are now `constexpr`, so only `_CONSTEXPR20` was added.

- `stl/inc/yvals_core.h`: Modified the definition of the feature test macro `__cpp_lib_array_constexpr` for cxx20 mode.

- `tests/std/tests/VSO_0157762_feature_test_macros/test.cpp`: Added test coverage for `__cpp_lib_array_constexpr` in cxx20 mode.

Checklist
=========

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [x] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
