### PR TITLE
Cleanup feature_test_macros/test.cpp

### DIFF
--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.cpp
@@ -8,49 +8,49 @@ int main() {} // COMPILE-ONLY
 // Always defined to varying values (C++14 versus C++17-and-newer mode).
 
 #ifndef __cpp_constexpr
-#error BOOM
+#error Expected __cpp_constexpr to be defined.
 #elif _HAS_CXX17
 #if __cpp_constexpr != 201603L
-#error BOOM
+#error Expected cpp_constexpr to equal 201603L.
 #else
 STATIC_ASSERT(__cpp_constexpr == 201603L);
 #endif
 #else
 #if __cpp_constexpr != 201304L
-#error BOOM
+#error Expected cpp_constexpr to equal 201304L.
 #else
 STATIC_ASSERT(__cpp_constexpr == 201304L);
 #endif
 #endif
 
 #ifndef __cpp_inheriting_constructors
-#error BOOM
+#error Expected __cpp_inheriting_constructors to be defined.
 #elif (_HAS_CXX17 || defined(__clang__)) && !defined(__EDG__) // Clang implemented this C++17 feature unconditionally.
                                                               // TRANSITION, VSO-610203
 #if __cpp_inheriting_constructors != 201511L
-#error BOOM
+#error Expected cpp_inheriting_constructors to equal 201511L.
 #else
 STATIC_ASSERT(__cpp_inheriting_constructors == 201511L);
 #endif
 #else
 #if __cpp_inheriting_constructors != 200802L
-#error BOOM
+#error Expected cpp_inheriting_constructors to equal 200802L.
 #else
 STATIC_ASSERT(__cpp_inheriting_constructors == 200802L);
 #endif
 #endif
 
 #ifndef __cpp_static_assert
-#error BOOM
+#error Expected __cpp_static_assert to be defined.
 #elif _HAS_CXX17
 #if __cpp_static_assert != 201411L
-#error BOOM
+#error Expected cpp_static_assert to equal 201411L.
 #else
 STATIC_ASSERT(__cpp_static_assert == 201411L);
 #endif
 #else
 #if __cpp_static_assert != 200410L
-#error BOOM
+#error Expected cpp_static_assert to equal 200410L.
 #else
 STATIC_ASSERT(__cpp_static_assert == 200410L);
 #endif
@@ -60,213 +60,213 @@ STATIC_ASSERT(__cpp_static_assert == 200410L);
 // Always defined to specific values.
 
 #ifndef __cpp_aggregate_nsdmi
-#error BOOM
+#error Expected __cpp_aggregate_nsdmi to be defined.
 #elif __cpp_aggregate_nsdmi != 201304L
-#error BOOM
+#error Expected cpp_aggregate_nsdmi to equal 201304L.
 #else
 STATIC_ASSERT(__cpp_aggregate_nsdmi == 201304L);
 #endif
 
 #ifndef __cpp_alias_templates
-#error BOOM
+#error Expected __cpp_alias_templates to be defined.
 #elif __cpp_alias_templates != 200704L
-#error BOOM
+#error Expected cpp_alias_templates to equal 200704L.
 #else
 STATIC_ASSERT(__cpp_alias_templates == 200704L);
 #endif
 
 #ifndef __cpp_attributes
-#error BOOM
+#error Expected __cpp_attributes to be defined.
 #elif __cpp_attributes != 200809L
-#error BOOM
+#error Expected cpp_attributes to equal 200809L.
 #else
 STATIC_ASSERT(__cpp_attributes == 200809L);
 #endif
 
 #ifndef __cpp_binary_literals
-#error BOOM
+#error Expected __cpp_binary_literals to be defined.
 #elif __cpp_binary_literals != 201304L
-#error BOOM
+#error Expected cpp_binary_literals to equal 201304L.
 #else
 STATIC_ASSERT(__cpp_binary_literals == 201304L);
 #endif
 
 #ifndef __cpp_decltype
-#error BOOM
+#error Expected __cpp_decltype to be defined.
 #elif __cpp_decltype != 200707L
-#error BOOM
+#error Expected cpp_decltype to equal 200707L.
 #else
 STATIC_ASSERT(__cpp_decltype == 200707L);
 #endif
 
 #ifndef __cpp_decltype_auto
-#error BOOM
+#error Expected __cpp_decltype_auto to be defined.
 #elif __cpp_decltype_auto != 201304L
-#error BOOM
+#error Expected cpp_decltype_auto to equal 201304L.
 #else
 STATIC_ASSERT(__cpp_decltype_auto == 201304L);
 #endif
 
 #ifndef __cpp_delegating_constructors
-#error BOOM
+#error Expected __cpp_delegating_constructors to be defined.
 #elif __cpp_delegating_constructors != 200604L
-#error BOOM
+#error Expected cpp_delegating_constructors to equal 200604L.
 #else
 STATIC_ASSERT(__cpp_delegating_constructors == 200604L);
 #endif
 
 #if !defined(__clang__) || _HAS_CXX17 // C1XX implemented this C++17 feature unconditionally.
 #ifndef __cpp_enumerator_attributes
-#error BOOM
+#error Expected __cpp_enumerator_attributes to be defined.
 #elif __cpp_enumerator_attributes != 201411L
-#error BOOM
+#error Expected cpp_enumerator_attributes to equal 201411L.
 #else
 STATIC_ASSERT(__cpp_enumerator_attributes == 201411L);
 #endif
 #else
 #ifdef __cpp_enumerator_attributes
-#error BOOM
+#error Expected __cpp_enumerator_attributes to NOT be defined.
 #endif
 #endif
 
 #ifndef __cpp_generic_lambdas
-#error BOOM
+#error Expected __cpp_generic_lambdas to be defined.
 #elif __cpp_generic_lambdas != 201304L
-#error BOOM
+#error Expected cpp_generic_lambdas to equal 201304L.
 #else
 STATIC_ASSERT(__cpp_generic_lambdas == 201304L);
 #endif
 
 #ifndef __cpp_init_captures
-#error BOOM
+#error Expected __cpp_init_captures to be defined.
 #elif __cpp_init_captures != 201304L
-#error BOOM
+#error Expected cpp_init_captures to equal 201304L.
 #else
 STATIC_ASSERT(__cpp_init_captures == 201304L);
 #endif
 
 #ifndef __cpp_initializer_lists
-#error BOOM
+#error Expected __cpp_initializer_lists to be defined.
 #elif __cpp_initializer_lists != 200806L
-#error BOOM
+#error Expected cpp_initializer_lists to equal 200806L.
 #else
 STATIC_ASSERT(__cpp_initializer_lists == 200806L);
 #endif
 
 #ifndef __cpp_lambdas
-#error BOOM
+#error Expected __cpp_lambdas to be defined.
 #elif __cpp_lambdas != 200907L
-#error BOOM
+#error Expected cpp_lambdas to equal 200907L.
 #else
 STATIC_ASSERT(__cpp_lambdas == 200907L);
 #endif
 
 #if !defined(__clang__) || _HAS_CXX17 // C1XX implemented this C++17 feature unconditionally.
 #ifndef __cpp_namespace_attributes
-#error BOOM
+#error Expected __cpp_namespace_attributes to be defined.
 #elif __cpp_namespace_attributes != 201411L
-#error BOOM
+#error Expected cpp_namespace_attributes to equal 201411L.
 #else
 STATIC_ASSERT(__cpp_namespace_attributes == 201411L);
 #endif
 #else
 #ifdef __cpp_namespace_attributes
-#error BOOM
+#error Expected __cpp_namespace_attributes to NOT be defined.
 #endif
 #endif
 
 #ifndef __cpp_nsdmi
-#error BOOM
+#error Expected __cpp_nsdmi to be defined.
 #elif __cpp_nsdmi != 200809L
-#error BOOM
+#error Expected cpp_nsdmi to equal 200809L.
 #else
 STATIC_ASSERT(__cpp_nsdmi == 200809L);
 #endif
 
 #ifndef __cpp_range_based_for
-#error BOOM
+#error Expected __cpp_range_based_for to be defined.
 #elif !defined(__clang__) || _HAS_CXX17 // C1XX implemented this C++17 feature unconditionally.
 #if __cpp_range_based_for != 201603L
-#error BOOM
+#error Expected cpp_range_based_for to equal 201603L.
 #else
 STATIC_ASSERT(__cpp_range_based_for == 201603L);
 #endif
 #else
 #if __cpp_range_based_for != 200907L
-#error BOOM
+#error Expected cpp_range_based_for to equal 200907L.
 #else
 STATIC_ASSERT(__cpp_range_based_for == 200907L);
 #endif
 #endif
 
 #ifndef __cpp_raw_strings
-#error BOOM
+#error Expected __cpp_raw_strings to be defined.
 #elif __cpp_raw_strings != 200710L
-#error BOOM
+#error Expected cpp_raw_strings to equal 200710L.
 #else
 STATIC_ASSERT(__cpp_raw_strings == 200710L);
 #endif
 
 #ifndef __cpp_ref_qualifiers
-#error BOOM
+#error Expected __cpp_ref_qualifiers to be defined.
 #elif __cpp_ref_qualifiers != 200710L
-#error BOOM
+#error Expected cpp_ref_qualifiers to equal 200710L.
 #else
 STATIC_ASSERT(__cpp_ref_qualifiers == 200710L);
 #endif
 
 #ifndef __cpp_return_type_deduction
-#error BOOM
+#error Expected __cpp_return_type_deduction to be defined.
 #elif __cpp_return_type_deduction != 201304L
-#error BOOM
+#error Expected cpp_return_type_deduction to equal 201304L.
 #else
 STATIC_ASSERT(__cpp_return_type_deduction == 201304L);
 #endif
 
 #ifndef __cpp_rvalue_references
-#error BOOM
+#error Expected __cpp_rvalue_references to be defined.
 #elif __cpp_rvalue_references != 200610L
-#error BOOM
+#error Expected cpp_rvalue_references to equal 200610L.
 #else
 STATIC_ASSERT(__cpp_rvalue_references == 200610L);
 #endif
 
 #ifndef __cpp_unicode_characters
-#error BOOM
+#error Expected __cpp_unicode_characters to be defined.
 #elif __cpp_unicode_characters != 200704L
-#error BOOM
+#error Expected cpp_unicode_characters to equal 200704L.
 #else
 STATIC_ASSERT(__cpp_unicode_characters == 200704L);
 #endif
 
 #ifndef __cpp_unicode_literals
-#error BOOM
+#error Expected __cpp_unicode_literals to be defined.
 #elif __cpp_unicode_literals != 200710L
-#error BOOM
+#error Expected cpp_unicode_literals to equal 200710L.
 #else
 STATIC_ASSERT(__cpp_unicode_literals == 200710L);
 #endif
 
 #ifndef __cpp_user_defined_literals
-#error BOOM
+#error Expected __cpp_user_defined_literals to be defined.
 #elif __cpp_user_defined_literals != 200809L
-#error BOOM
+#error Expected cpp_user_defined_literals to equal 200809L.
 #else
 STATIC_ASSERT(__cpp_user_defined_literals == 200809L);
 #endif
 
 #ifndef __cpp_variable_templates
-#error BOOM
+#error Expected __cpp_variable_templates to be defined.
 #elif __cpp_variable_templates != 201304L
-#error BOOM
+#error Expected cpp_variable_templates to equal 201304L.
 #else
 STATIC_ASSERT(__cpp_variable_templates == 201304L);
 #endif
 
 #ifndef __cpp_variadic_templates
-#error BOOM
+#error Expected __cpp_variadic_templates to be defined.
 #elif __cpp_variadic_templates != 200704L
-#error BOOM
+#error Expected cpp_variadic_templates to equal 200704L.
 #else
 STATIC_ASSERT(__cpp_variadic_templates == 200704L);
 #endif
@@ -276,163 +276,163 @@ STATIC_ASSERT(__cpp_variadic_templates == 200704L);
 
 #if _HAS_CXX17
 #ifndef __cpp_aggregate_bases
-#error BOOM
+#error Expected __cpp_aggregate_bases to be defined.
 #elif __cpp_aggregate_bases != 201603L
-#error BOOM
+#error Expected cpp_aggregate_bases to equal 201603L.
 #else
 STATIC_ASSERT(__cpp_aggregate_bases == 201603L);
 #endif
 #else
 #ifdef __cpp_aggregate_bases
-#error BOOM
+#error Expected __cpp_aggregate_bases to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_capture_star_this
-#error BOOM
+#error Expected __cpp_capture_star_this to be defined.
 #elif __cpp_capture_star_this != 201603L
-#error BOOM
+#error Expected cpp_capture_star_this to equal 201603L.
 #else
 STATIC_ASSERT(__cpp_capture_star_this == 201603L);
 #endif
 #else
 #ifdef __cpp_capture_star_this
-#error BOOM
+#error Expected __cpp_capture_star_this to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_deduction_guides
-#error BOOM
+#error Expected __cpp_deduction_guides to be defined.
 #elif __cpp_deduction_guides != 201703L
-#error BOOM
+#error Expected cpp_deduction_guides to equal 201703L.
 #else
 STATIC_ASSERT(__cpp_deduction_guides == 201703L);
 #endif
 #else
 #ifdef __cpp_deduction_guides
-#error BOOM
+#error Expected __cpp_deduction_guides to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_fold_expressions
-#error BOOM
+#error Expected __cpp_fold_expressions to be defined.
 #elif __cpp_fold_expressions != 201603L
-#error BOOM
+#error Expected cpp_fold_expressions to equal 201603L.
 #else
 STATIC_ASSERT(__cpp_fold_expressions == 201603L);
 #endif
 #else
 #ifdef __cpp_fold_expressions
-#error BOOM
+#error Expected __cpp_fold_expressions to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_guaranteed_copy_elision
-#error BOOM
+#error Expected __cpp_guaranteed_copy_elision to be defined.
 #elif __cpp_guaranteed_copy_elision != 201606L
-#error BOOM
+#error Expected cpp_guaranteed_copy_elision to equal 201606L.
 #else
 STATIC_ASSERT(__cpp_guaranteed_copy_elision == 201606L);
 #endif
 #else
 #ifdef __cpp_guaranteed_copy_elision
-#error BOOM
+#error Expected __cpp_guaranteed_copy_elision to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX17 || defined(__EDG__) // EDG unconditionally reports hex floats as being available.
 #ifndef __cpp_hex_float
-#error BOOM
+#error Expected __cpp_hex_float to be defined.
 #elif __cpp_hex_float != 201603L
-#error BOOM
+#error Expected cpp_hex_float to equal 201603L.
 #else
 STATIC_ASSERT(__cpp_hex_float == 201603L);
 #endif
 #else
 #ifdef __cpp_hex_float
-#error BOOM
+#error Expected __cpp_hex_float to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX17 || defined(__EDG__) // EDG unconditionally reports "if constexpr" as being available.
 #ifndef __cpp_if_constexpr
-#error BOOM
+#error Expected __cpp_if_constexpr to be defined.
 #elif __cpp_if_constexpr != 201606L
-#error BOOM
+#error Expected cpp_if_constexpr to equal 201606L.
 #else
 STATIC_ASSERT(__cpp_if_constexpr == 201606L);
 #endif
 #else
 #ifdef __cpp_if_constexpr
-#error BOOM
+#error Expected __cpp_if_constexpr to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_inline_variables
-#error BOOM
+#error Expected __cpp_inline_variables to be defined.
 #elif __cpp_inline_variables != 201606L
-#error BOOM
+#error Expected cpp_inline_variables to equal 201606L.
 #else
 STATIC_ASSERT(__cpp_inline_variables == 201606L);
 #endif
 #else
 #ifdef __cpp_inline_variables
-#error BOOM
+#error Expected __cpp_inline_variables to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX20 && !defined(__clang__) && !defined(__EDG__)
 #ifndef __cpp_nontype_template_args
-#error BOOM
+#error Expected __cpp_nontype_template_args to be defined.
 #elif __cpp_nontype_template_args != 201911L
-#error BOOM
+#error Expected cpp_nontype_template_args to equal 201911L.
 #else
 STATIC_ASSERT(__cpp_nontype_template_args == 201911L);
 #endif
 #elif _HAS_CXX17
 #ifndef __cpp_nontype_template_args
-#error BOOM
+#error Expected __cpp_nontype_template_args to be defined.
 #elif __cpp_nontype_template_args != 201411L
-#error BOOM
+#error Expected cpp_nontype_template_args to equal 201411L.
 #else
 STATIC_ASSERT(__cpp_nontype_template_args == 201411L);
 #endif
 #else
 #ifdef __cpp_nontype_template_args
-#error BOOM
+#error Expected __cpp_nontype_template_args to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_nontype_template_parameter_auto
-#error BOOM
+#error Expected __cpp_nontype_template_parameter_auto to be defined.
 #elif __cpp_nontype_template_parameter_auto != 201606L
-#error BOOM
+#error Expected cpp_nontype_template_parameter_auto to equal 201606L.
 #else
 STATIC_ASSERT(__cpp_nontype_template_parameter_auto == 201606L);
 #endif
 #else
 #ifdef __cpp_nontype_template_parameter_auto
-#error BOOM
+#error Expected __cpp_nontype_template_parameter_auto to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_structured_bindings
-#error BOOM
+#error Expected __cpp_structured_bindings to be defined.
 #elif __cpp_structured_bindings != 201606L
-#error BOOM
+#error Expected cpp_structured_bindings to equal 201606L.
 #else
 STATIC_ASSERT(__cpp_structured_bindings == 201606L);
 #endif
 #else
 #ifdef __cpp_structured_bindings
-#error BOOM
+#error Expected __cpp_structured_bindings to NOT be defined.
 #endif
 #endif
 
@@ -445,29 +445,29 @@ STATIC_ASSERT(__cpp_structured_bindings == 201606L);
 // ambiguity errors for reasonable and previously-valid code. This issue is
 // expected to be rectified soon."
 #ifndef __cpp_template_template_args
-#error BOOM
+#error Expected __cpp_template_template_args to be defined.
 #elif __cpp_template_template_args != 201611L
-#error BOOM
+#error Expected cpp_template_template_args to equal 201611L.
 #else
 STATIC_ASSERT(__cpp_template_template_args == 201611L);
 #endif
 #else
 #ifdef __cpp_template_template_args
-#error BOOM
+#error Expected __cpp_template_template_args to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_variadic_using
-#error BOOM
+#error Expected __cpp_variadic_using to be defined.
 #elif __cpp_variadic_using != 201611L
-#error BOOM
+#error Expected cpp_variadic_using to equal 201611L.
 #else
 STATIC_ASSERT(__cpp_variadic_using == 201611L);
 #endif
 #else
 #ifdef __cpp_variadic_using
-#error BOOM
+#error Expected __cpp_variadic_using to NOT be defined.
 #endif
 #endif
 
@@ -476,38 +476,38 @@ STATIC_ASSERT(__cpp_variadic_using == 201611L);
 #if _HAS_CXX20 || defined(__EDG__)
 // EDG unconditionally reports "explicit(bool)" as being available.
 #ifndef __cpp_conditional_explicit
-#error BOOM
+#error Expected __cpp_conditional_explicit to be defined.
 #elif __cpp_conditional_explicit != 201806L
-#error BOOM
+#error Expected cpp_conditional_explicit to equal 201806L.
 #else
 STATIC_ASSERT(__cpp_conditional_explicit == 201806L);
 #endif
 #else
 #ifdef __cpp_conditional_explicit
-#error BOOM
+#error Expected __cpp_conditional_explicit to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX20 && !defined(__clang__)
 // Clang only has partial support for <=> but that does not include the feature test macro.
 #ifndef __cpp_impl_three_way_comparison
-#error BOOM
+#error Expected __cpp_impl_three_way_comparison to be defined.
 #elif defined(__EDG__) // EDG does not yet implement P1630R1 or P1186R3 so they still report the old value.
 #if __cpp_impl_three_way_comparison != 201711L
-#error BOOM
+#error Expected cpp_impl_three_way_comparison to equal 201711L.
 #else
 STATIC_ASSERT(__cpp_impl_three_way_comparison == 201711L);
 #endif
 #else
 #if __cpp_impl_three_way_comparison != 201907L
-#error BOOM
+#error Expected cpp_impl_three_way_comparison to equal 201907L.
 #else
 STATIC_ASSERT(__cpp_impl_three_way_comparison == 201907L);
 #endif
 #endif
 #else
 #ifdef __cpp_impl_three_way_comparison
-#error BOOM
+#error Expected __cpp_impl_three_way_comparison to NOT be defined.
 #endif
 #endif
 
@@ -516,13 +516,13 @@ STATIC_ASSERT(__cpp_impl_three_way_comparison == 201907L);
 // C++17, /Zc:alignedNew[-]
 #if !_HAS_CXX17 || defined(TEST_DISABLED_ALIGNED_NEW)
 #ifdef __cpp_aligned_new
-#error BOOM
+#error Expected __cpp_aligned_new to NOT be defined.
 #endif
 #else
 #ifndef __cpp_aligned_new
-#error BOOM
+#error Expected __cpp_aligned_new to be defined.
 #elif __cpp_aligned_new != 201606L
-#error BOOM
+#error Expected cpp_aligned_new to equal 201606L.
 #else
 STATIC_ASSERT(__cpp_aligned_new == 201606L);
 #endif
@@ -531,13 +531,13 @@ STATIC_ASSERT(__cpp_aligned_new == 201606L);
 // C++98, /EHs[-]
 #ifdef TEST_DISABLED_EXCEPTIONS
 #ifdef __cpp_exceptions
-#error BOOM
+#error Expected __cpp_exceptions to NOT be defined.
 #endif
 #else
 #ifndef __cpp_exceptions
-#error BOOM
+#error Expected __cpp_exceptions to be defined.
 #elif __cpp_exceptions != 199711L
-#error BOOM
+#error Expected cpp_exceptions to equal 199711L.
 #else
 STATIC_ASSERT(__cpp_exceptions == 199711L);
 #endif
@@ -546,13 +546,13 @@ STATIC_ASSERT(__cpp_exceptions == 199711L);
 // C++17, /Zc:noexceptTypes[-]
 #if !_HAS_CXX17 || defined(TEST_DISABLED_NOEXCEPT_FUNCTION_TYPE)
 #ifdef __cpp_noexcept_function_type
-#error BOOM
+#error Expected __cpp_noexcept_function_type to NOT be defined.
 #endif
 #else
 #ifndef __cpp_noexcept_function_type
-#error BOOM
+#error Expected __cpp_noexcept_function_type to be defined.
 #elif __cpp_noexcept_function_type != 201510L
-#error BOOM
+#error Expected cpp_noexcept_function_type to equal 201510L.
 #else
 STATIC_ASSERT(__cpp_noexcept_function_type == 201510L);
 #endif
@@ -561,13 +561,13 @@ STATIC_ASSERT(__cpp_noexcept_function_type == 201510L);
 // C++98, /GR[-]
 #ifdef TEST_DISABLED_RTTI
 #ifdef __cpp_rtti
-#error BOOM
+#error Expected __cpp_rtti to NOT be defined.
 #endif
 #else
 #ifndef __cpp_rtti
-#error BOOM
+#error Expected __cpp_rtti to be defined.
 #elif __cpp_rtti != 199711L
-#error BOOM
+#error Expected cpp_rtti to equal 199711L.
 #else
 STATIC_ASSERT(__cpp_rtti == 199711L);
 #endif
@@ -576,13 +576,13 @@ STATIC_ASSERT(__cpp_rtti == 199711L);
 // C++14, /Zc:sizedDealloc[-]
 #if defined(TEST_DISABLED_SIZED_DEALLOCATION) || defined(__clang__) // Clang disables sized deallocation by default.
 #ifdef __cpp_sized_deallocation
-#error BOOM
+#error Expected __cpp_sized_deallocation to NOT be defined.
 #endif
 #else
 #ifndef __cpp_sized_deallocation
-#error BOOM
+#error Expected __cpp_sized_deallocation to be defined.
 #elif __cpp_sized_deallocation != 201309L
-#error BOOM
+#error Expected cpp_sized_deallocation to equal 201309L.
 #else
 STATIC_ASSERT(__cpp_sized_deallocation == 201309L);
 #endif
@@ -591,13 +591,13 @@ STATIC_ASSERT(__cpp_sized_deallocation == 201309L);
 // C++11, /Zc:threadSafeInit[-]
 #if defined(_M_CEE_PURE) || defined(TEST_DISABLED_THREADSAFE_STATIC_INIT)
 #ifdef __cpp_threadsafe_static_init
-#error BOOM
+#error Expected __cpp_threadsafe_static_init to NOT be defined.
 #endif
 #else
 #ifndef __cpp_threadsafe_static_init
-#error BOOM
+#error Expected __cpp_threadsafe_static_init to be defined.
 #elif __cpp_threadsafe_static_init != 200806L
-#error BOOM
+#error Expected cpp_threadsafe_static_init to equal 200806L.
 #else
 STATIC_ASSERT(__cpp_threadsafe_static_init == 200806L);
 #endif
@@ -609,42 +609,42 @@ STATIC_ASSERT(__cpp_threadsafe_static_init == 200806L);
 #ifdef __has_cpp_attribute
 // Good.
 #else
-#error BOOM
+#error Expected __has_cpp_attribute to be defined.
 #endif
 
 #if defined(__has_cpp_attribute)
 // Good.
 #else
-#error BOOM
+#error Expected __has_cpp_attribute to be defined.
 #endif
 
 #ifndef __has_cpp_attribute
-#error BOOM
+#error Expected __has_cpp_attribute to be defined.
 #endif
 
 
 // Always defined to specific values.
 
 #if __has_cpp_attribute(carries_dependency) != 200809L
-#error BOOM
+#error Expected has_cpp_attribute(carries_dependency) to equal 200809L.
 #endif
 
 #if __has_cpp_attribute(deprecated) != 201309L
-#error BOOM
+#error Expected has_cpp_attribute(deprecated) to equal 201309L.
 #endif
 
 #if defined(__clang__) || defined(__EDG__) // clang and EDG don't yet implement P1771R1
 #if __has_cpp_attribute(nodiscard) != 201603L
-#error BOOM
+#error Expected has_cpp_attribute(nodiscard) to equal 201603L.
 #endif
 #else
 #if __has_cpp_attribute(nodiscard) != 201907L
-#error BOOM
+#error Expected has_cpp_attribute(nodiscard) to equal 201907L.
 #endif
 #endif
 
 #if __has_cpp_attribute(noreturn) != 200809L
-#error BOOM
+#error Expected has_cpp_attribute(noreturn) to equal 200809L.
 #endif
 
 
@@ -652,21 +652,21 @@ STATIC_ASSERT(__cpp_threadsafe_static_init == 200806L);
 
 #if _HAS_CXX17 || defined(__clang__) || defined(__EDG__) // Clang and EDG provide this in C++14 mode.
 #if __has_cpp_attribute(fallthrough) != 201603L
-#error BOOM
+#error Expected has_cpp_attribute(fallthrough) to equal 201603L.
 #endif
 #else
 #if __has_cpp_attribute(fallthrough) != 0
-#error BOOM
+#error Expected has_cpp_attribute(fallthrough) to equal 0.
 #endif
 #endif
 
 #if _HAS_CXX17 || defined(__clang__) || defined(__EDG__) // Clang and EDG provide this in C++14 mode.
 #if __has_cpp_attribute(maybe_unused) != 201603L
-#error BOOM
+#error Expected has_cpp_attribute(maybe_unused) to equal 201603L.
 #endif
 #else
 #if __has_cpp_attribute(maybe_unused) != 0
-#error BOOM
+#error Expected has_cpp_attribute(maybe_unused) to equal 0.
 #endif
 #endif
 
@@ -679,16 +679,16 @@ STATIC_ASSERT(__cpp_threadsafe_static_init == 200806L);
 // Always defined to varying values (C++14 versus C++17-and-newer mode).
 
 #ifndef __cpp_lib_chrono
-#error BOOM
+#error Expected __cpp_lib_chrono to be defined.
 #elif _HAS_CXX17
 #if __cpp_lib_chrono != 201611L
-#error BOOM
+#error Expected cpp_lib_chrono to equal 201611L.
 #else
 STATIC_ASSERT(__cpp_lib_chrono == 201611L);
 #endif
 #else
 #if __cpp_lib_chrono != 201510L
-#error BOOM
+#error Expected cpp_lib_chrono to equal 201510L.
 #else
 STATIC_ASSERT(__cpp_lib_chrono == 201510L);
 #endif
@@ -698,319 +698,319 @@ STATIC_ASSERT(__cpp_lib_chrono == 201510L);
 // Always defined to specific values.
 
 #ifndef __cpp_lib_addressof_constexpr
-#error BOOM
+#error Expected __cpp_lib_addressof_constexpr to be defined.
 #elif __cpp_lib_addressof_constexpr != 201603L
-#error BOOM
+#error Expected cpp_lib_addressof_constexpr to equal 201603L.
 #else
 STATIC_ASSERT(__cpp_lib_addressof_constexpr == 201603L);
 #endif
 
 #ifndef __cpp_lib_allocator_traits_is_always_equal
-#error BOOM
+#error Expected __cpp_lib_allocator_traits_is_always_equal to be defined.
 #elif __cpp_lib_allocator_traits_is_always_equal != 201411L
-#error BOOM
+#error Expected cpp_lib_allocator_traits_is_always_equal to equal 201411L.
 #else
 STATIC_ASSERT(__cpp_lib_allocator_traits_is_always_equal == 201411L);
 #endif
 
 #ifndef __cpp_lib_as_const
-#error BOOM
+#error Expected __cpp_lib_as_const to be defined.
 #elif __cpp_lib_as_const != 201510L
-#error BOOM
+#error Expected cpp_lib_as_const to equal 201510L.
 #else
 STATIC_ASSERT(__cpp_lib_as_const == 201510L);
 #endif
 
 #ifndef __cpp_lib_atomic_value_initialization
-#error BOOM
+#error Expected __cpp_lib_atomic_value_initialization to be defined.
 #elif __cpp_lib_atomic_value_initialization != 201911L
-#error BOOM
+#error Expected cpp_lib_atomic_value_initialization to equal 201911L.
 #else
 STATIC_ASSERT(__cpp_lib_atomic_value_initialization == 201911L);
 #endif
 
 #ifndef __cpp_lib_bool_constant
-#error BOOM
+#error Expected __cpp_lib_bool_constant to be defined.
 #elif __cpp_lib_bool_constant != 201505L
-#error BOOM
+#error Expected cpp_lib_bool_constant to equal 201505L.
 #else
 STATIC_ASSERT(__cpp_lib_bool_constant == 201505L);
 #endif
 
 #ifndef __cpp_lib_chrono_udls
-#error BOOM
+#error Expected __cpp_lib_chrono_udls to be defined.
 #elif __cpp_lib_chrono_udls != 201304L
-#error BOOM
+#error Expected cpp_lib_chrono_udls to equal 201304L.
 #else
 STATIC_ASSERT(__cpp_lib_chrono_udls == 201304L);
 #endif
 
 #ifndef __cpp_lib_complex_udls
-#error BOOM
+#error Expected __cpp_lib_complex_udls to be defined.
 #elif __cpp_lib_complex_udls != 201309L
-#error BOOM
+#error Expected cpp_lib_complex_udls to equal 201309L.
 #else
 STATIC_ASSERT(__cpp_lib_complex_udls == 201309L);
 #endif
 
 #ifndef __cpp_lib_enable_shared_from_this
-#error BOOM
+#error Expected __cpp_lib_enable_shared_from_this to be defined.
 #elif __cpp_lib_enable_shared_from_this != 201603L
-#error BOOM
+#error Expected cpp_lib_enable_shared_from_this to equal 201603L.
 #else
 STATIC_ASSERT(__cpp_lib_enable_shared_from_this == 201603L);
 #endif
 
 #ifndef __cpp_lib_exchange_function
-#error BOOM
+#error Expected __cpp_lib_exchange_function to be defined.
 #elif __cpp_lib_exchange_function != 201304L
-#error BOOM
+#error Expected cpp_lib_exchange_function to equal 201304L.
 #else
 STATIC_ASSERT(__cpp_lib_exchange_function == 201304L);
 #endif
 
 #ifndef __cpp_lib_experimental_erase_if
-#error BOOM
+#error Expected __cpp_lib_experimental_erase_if to be defined.
 #elif __cpp_lib_experimental_erase_if != 201411L
-#error BOOM
+#error Expected cpp_lib_experimental_erase_if to equal 201411L.
 #else
 STATIC_ASSERT(__cpp_lib_experimental_erase_if == 201411L);
 #endif
 
 #ifndef __cpp_lib_experimental_filesystem
-#error BOOM
+#error Expected __cpp_lib_experimental_filesystem to be defined.
 #elif __cpp_lib_experimental_filesystem != 201406L
-#error BOOM
+#error Expected cpp_lib_experimental_filesystem to equal 201406L.
 #else
 STATIC_ASSERT(__cpp_lib_experimental_filesystem == 201406L);
 #endif
 
 #ifndef __cpp_lib_generic_associative_lookup
-#error BOOM
+#error Expected __cpp_lib_generic_associative_lookup to be defined.
 #elif __cpp_lib_generic_associative_lookup != 201304L
-#error BOOM
+#error Expected cpp_lib_generic_associative_lookup to equal 201304L.
 #else
 STATIC_ASSERT(__cpp_lib_generic_associative_lookup == 201304L);
 #endif
 
 #ifndef __cpp_lib_incomplete_container_elements
-#error BOOM
+#error Expected __cpp_lib_incomplete_container_elements to be defined.
 #elif __cpp_lib_incomplete_container_elements != 201505L
-#error BOOM
+#error Expected cpp_lib_incomplete_container_elements to equal 201505L.
 #else
 STATIC_ASSERT(__cpp_lib_incomplete_container_elements == 201505L);
 #endif
 
 #ifndef __cpp_lib_integer_sequence
-#error BOOM
+#error Expected __cpp_lib_integer_sequence to be defined.
 #elif __cpp_lib_integer_sequence != 201304L
-#error BOOM
+#error Expected cpp_lib_integer_sequence to equal 201304L.
 #else
 STATIC_ASSERT(__cpp_lib_integer_sequence == 201304L);
 #endif
 
 #ifndef __cpp_lib_integral_constant_callable
-#error BOOM
+#error Expected __cpp_lib_integral_constant_callable to be defined.
 #elif __cpp_lib_integral_constant_callable != 201304L
-#error BOOM
+#error Expected cpp_lib_integral_constant_callable to equal 201304L.
 #else
 STATIC_ASSERT(__cpp_lib_integral_constant_callable == 201304L);
 #endif
 
 #ifndef __cpp_lib_invoke
-#error BOOM
+#error Expected __cpp_lib_invoke to be defined.
 #elif __cpp_lib_invoke != 201411L
-#error BOOM
+#error Expected cpp_lib_invoke to equal 201411L.
 #else
 STATIC_ASSERT(__cpp_lib_invoke == 201411L);
 #endif
 
 #ifndef __cpp_lib_is_final
-#error BOOM
+#error Expected __cpp_lib_is_final to be defined.
 #elif __cpp_lib_is_final != 201402L
-#error BOOM
+#error Expected cpp_lib_is_final to equal 201402L.
 #else
 STATIC_ASSERT(__cpp_lib_is_final == 201402L);
 #endif
 
 #ifndef __cpp_lib_is_null_pointer
-#error BOOM
+#error Expected __cpp_lib_is_null_pointer to be defined.
 #elif __cpp_lib_is_null_pointer != 201309L
-#error BOOM
+#error Expected cpp_lib_is_null_pointer to equal 201309L.
 #else
 STATIC_ASSERT(__cpp_lib_is_null_pointer == 201309L);
 #endif
 
 #ifndef __cpp_lib_logical_traits
-#error BOOM
+#error Expected __cpp_lib_logical_traits to be defined.
 #elif __cpp_lib_logical_traits != 201510L
-#error BOOM
+#error Expected cpp_lib_logical_traits to equal 201510L.
 #else
 STATIC_ASSERT(__cpp_lib_logical_traits == 201510L);
 #endif
 
 #ifndef __cpp_lib_make_reverse_iterator
-#error BOOM
+#error Expected __cpp_lib_make_reverse_iterator to be defined.
 #elif __cpp_lib_make_reverse_iterator != 201402L
-#error BOOM
+#error Expected cpp_lib_make_reverse_iterator to equal 201402L.
 #else
 STATIC_ASSERT(__cpp_lib_make_reverse_iterator == 201402L);
 #endif
 
 #ifndef __cpp_lib_make_unique
-#error BOOM
+#error Expected __cpp_lib_make_unique to be defined.
 #elif __cpp_lib_make_unique != 201304L
-#error BOOM
+#error Expected cpp_lib_make_unique to equal 201304L.
 #else
 STATIC_ASSERT(__cpp_lib_make_unique == 201304L);
 #endif
 
 #ifndef __cpp_lib_map_try_emplace
-#error BOOM
+#error Expected __cpp_lib_map_try_emplace to be defined.
 #elif __cpp_lib_map_try_emplace != 201411L
-#error BOOM
+#error Expected cpp_lib_map_try_emplace to equal 201411L.
 #else
 STATIC_ASSERT(__cpp_lib_map_try_emplace == 201411L);
 #endif
 
 #ifndef __cpp_lib_nonmember_container_access
-#error BOOM
+#error Expected __cpp_lib_nonmember_container_access to be defined.
 #elif __cpp_lib_nonmember_container_access != 201411L
-#error BOOM
+#error Expected cpp_lib_nonmember_container_access to equal 201411L.
 #else
 STATIC_ASSERT(__cpp_lib_nonmember_container_access == 201411L);
 #endif
 
 #ifndef __cpp_lib_null_iterators
-#error BOOM
+#error Expected __cpp_lib_null_iterators to be defined.
 #elif __cpp_lib_null_iterators != 201304L
-#error BOOM
+#error Expected cpp_lib_null_iterators to equal 201304L.
 #else
 STATIC_ASSERT(__cpp_lib_null_iterators == 201304L);
 #endif
 
 #ifndef __cpp_lib_quoted_string_io
-#error BOOM
+#error Expected __cpp_lib_quoted_string_io to be defined.
 #elif __cpp_lib_quoted_string_io != 201304L
-#error BOOM
+#error Expected cpp_lib_quoted_string_io to equal 201304L.
 #else
 STATIC_ASSERT(__cpp_lib_quoted_string_io == 201304L);
 #endif
 
 #ifndef __cpp_lib_result_of_sfinae
-#error BOOM
+#error Expected __cpp_lib_result_of_sfinae to be defined.
 #elif __cpp_lib_result_of_sfinae != 201210L
-#error BOOM
+#error Expected cpp_lib_result_of_sfinae to equal 201210L.
 #else
 STATIC_ASSERT(__cpp_lib_result_of_sfinae == 201210L);
 #endif
 
 #ifndef __cpp_lib_robust_nonmodifying_seq_ops
-#error BOOM
+#error Expected __cpp_lib_robust_nonmodifying_seq_ops to be defined.
 #elif __cpp_lib_robust_nonmodifying_seq_ops != 201304L
-#error BOOM
+#error Expected cpp_lib_robust_nonmodifying_seq_ops to equal 201304L.
 #else
 STATIC_ASSERT(__cpp_lib_robust_nonmodifying_seq_ops == 201304L);
 #endif
 
 #ifndef __cpp_lib_shared_mutex
-#error BOOM
+#error Expected __cpp_lib_shared_mutex to be defined.
 #elif __cpp_lib_shared_mutex != 201505L
-#error BOOM
+#error Expected cpp_lib_shared_mutex to equal 201505L.
 #else
 STATIC_ASSERT(__cpp_lib_shared_mutex == 201505L);
 #endif
 
 #ifndef __cpp_lib_shared_ptr_arrays
-#error BOOM
+#error Expected __cpp_lib_shared_ptr_arrays to be defined.
 #elif __cpp_lib_shared_ptr_arrays != 201611L
-#error BOOM
+#error Expected cpp_lib_shared_ptr_arrays to equal 201611L.
 #else
 STATIC_ASSERT(__cpp_lib_shared_ptr_arrays == 201611L);
 #endif
 
 #ifdef _M_CEE
 #ifdef __cpp_lib_shared_timed_mutex
-#error BOOM
+#error Expected __cpp_lib_shared_timed_mutex to NOT be defined.
 #endif
 #else // ^^^ _M_CEE ^^^ // vvv !_M_CEE vvv
 #ifndef __cpp_lib_shared_timed_mutex
-#error BOOM
+#error Expected __cpp_lib_shared_timed_mutex to be defined.
 #elif __cpp_lib_shared_timed_mutex != 201402L
-#error BOOM
+#error Expected cpp_lib_shared_timed_mutex to equal 201402L.
 #else
 STATIC_ASSERT(__cpp_lib_shared_timed_mutex == 201402L);
 #endif
 #endif // _M_CEE
 
 #ifndef __cpp_lib_string_udls
-#error BOOM
+#error Expected __cpp_lib_string_udls to be defined.
 #elif __cpp_lib_string_udls != 201304L
-#error BOOM
+#error Expected cpp_lib_string_udls to equal 201304L.
 #else
 STATIC_ASSERT(__cpp_lib_string_udls == 201304L);
 #endif
 
 #ifndef __cpp_lib_transformation_trait_aliases
-#error BOOM
+#error Expected __cpp_lib_transformation_trait_aliases to be defined.
 #elif __cpp_lib_transformation_trait_aliases != 201304L
-#error BOOM
+#error Expected cpp_lib_transformation_trait_aliases to equal 201304L.
 #else
 STATIC_ASSERT(__cpp_lib_transformation_trait_aliases == 201304L);
 #endif
 
 #ifndef __cpp_lib_transparent_operators
-#error BOOM
+#error Expected __cpp_lib_transparent_operators to be defined.
 #elif __cpp_lib_transparent_operators != 201510L
-#error BOOM
+#error Expected cpp_lib_transparent_operators to equal 201510L.
 #else
 STATIC_ASSERT(__cpp_lib_transparent_operators == 201510L);
 #endif
 
 #ifndef __cpp_lib_tuple_element_t
-#error BOOM
+#error Expected __cpp_lib_tuple_element_t to be defined.
 #elif __cpp_lib_tuple_element_t != 201402L
-#error BOOM
+#error Expected cpp_lib_tuple_element_t to equal 201402L.
 #else
 STATIC_ASSERT(__cpp_lib_tuple_element_t == 201402L);
 #endif
 
 #ifndef __cpp_lib_tuples_by_type
-#error BOOM
+#error Expected __cpp_lib_tuples_by_type to be defined.
 #elif __cpp_lib_tuples_by_type != 201304L
-#error BOOM
+#error Expected cpp_lib_tuples_by_type to equal 201304L.
 #else
 STATIC_ASSERT(__cpp_lib_tuples_by_type == 201304L);
 #endif
 
 #ifndef __cpp_lib_type_trait_variable_templates
-#error BOOM
+#error Expected __cpp_lib_type_trait_variable_templates to be defined.
 #elif __cpp_lib_type_trait_variable_templates != 201510L
-#error BOOM
+#error Expected cpp_lib_type_trait_variable_templates to equal 201510L.
 #else
 STATIC_ASSERT(__cpp_lib_type_trait_variable_templates == 201510L);
 #endif
 
 #ifndef __cpp_lib_uncaught_exceptions
-#error BOOM
+#error Expected __cpp_lib_uncaught_exceptions to be defined.
 #elif __cpp_lib_uncaught_exceptions != 201411L
-#error BOOM
+#error Expected cpp_lib_uncaught_exceptions to equal 201411L.
 #else
 STATIC_ASSERT(__cpp_lib_uncaught_exceptions == 201411L);
 #endif
 
 #ifndef __cpp_lib_unordered_map_try_emplace
-#error BOOM
+#error Expected __cpp_lib_unordered_map_try_emplace to be defined.
 #elif __cpp_lib_unordered_map_try_emplace != 201411L
-#error BOOM
+#error Expected cpp_lib_unordered_map_try_emplace to equal 201411L.
 #else
 STATIC_ASSERT(__cpp_lib_unordered_map_try_emplace == 201411L);
 #endif
 
 #ifndef __cpp_lib_void_t
-#error BOOM
+#error Expected __cpp_lib_void_t to be defined.
 #elif __cpp_lib_void_t != 201411L
-#error BOOM
+#error Expected cpp_lib_void_t to equal 201411L.
 #else
 STATIC_ASSERT(__cpp_lib_void_t == 201411L);
 #endif
@@ -1020,421 +1020,421 @@ STATIC_ASSERT(__cpp_lib_void_t == 201411L);
 
 #if _HAS_CXX17
 #ifndef __cpp_lib_any
-#error BOOM
+#error Expected __cpp_lib_any to be defined.
 #elif __cpp_lib_any != 201606L
-#error BOOM
+#error Expected cpp_lib_any to equal 201606L.
 #else
 STATIC_ASSERT(__cpp_lib_any == 201606L);
 #endif
 #else
 #ifdef __cpp_lib_any
-#error BOOM
+#error Expected __cpp_lib_any to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_lib_apply
-#error BOOM
+#error Expected __cpp_lib_apply to be defined.
 #elif __cpp_lib_apply != 201603L
-#error BOOM
+#error Expected cpp_lib_apply to equal 201603L.
 #else
 STATIC_ASSERT(__cpp_lib_apply == 201603L);
 #endif
 #else
 #ifdef __cpp_lib_apply
-#error BOOM
+#error Expected __cpp_lib_apply to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_lib_array_constexpr
-#error BOOM
+#error Expected __cpp_lib_array_constexpr to be defined.
 #elif __cpp_lib_array_constexpr != 201803L
-#error BOOM
+#error Expected cpp_lib_array_constexpr to equal 201803L.
 #else
 STATIC_ASSERT(__cpp_lib_array_constexpr == 201803L);
 #endif
 #else
 #ifdef __cpp_lib_array_constexpr
-#error BOOM
+#error Expected __cpp_lib_array_constexpr to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_lib_atomic_is_always_lock_free
-#error BOOM
+#error Expected __cpp_lib_atomic_is_always_lock_free to be defined.
 #elif __cpp_lib_atomic_is_always_lock_free != 201603L
-#error BOOM
+#error Expected cpp_lib_atomic_is_always_lock_free to equal 201603L.
 #else
 STATIC_ASSERT(__cpp_lib_atomic_is_always_lock_free == 201603L);
 #endif
 #else
 #ifdef __cpp_lib_atomic_is_always_lock_free
-#error BOOM
+#error Expected __cpp_lib_atomic_is_always_lock_free to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_lib_boyer_moore_searcher
-#error BOOM
+#error Expected __cpp_lib_boyer_moore_searcher to be defined.
 #elif __cpp_lib_boyer_moore_searcher != 201603L
-#error BOOM
+#error Expected cpp_lib_boyer_moore_searcher to equal 201603L.
 #else
 STATIC_ASSERT(__cpp_lib_boyer_moore_searcher == 201603L);
 #endif
 #else
 #ifdef __cpp_lib_boyer_moore_searcher
-#error BOOM
+#error Expected __cpp_lib_boyer_moore_searcher to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_lib_clamp
-#error BOOM
+#error Expected __cpp_lib_clamp to be defined.
 #elif __cpp_lib_clamp != 201603L
-#error BOOM
+#error Expected cpp_lib_clamp to equal 201603L.
 #else
 STATIC_ASSERT(__cpp_lib_clamp == 201603L);
 #endif
 #else
 #ifdef __cpp_lib_clamp
-#error BOOM
+#error Expected __cpp_lib_clamp to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX17 && !defined(_M_CEE)
 #ifndef __cpp_lib_execution
-#error BOOM
+#error Expected __cpp_lib_execution to be defined.
 #elif __cpp_lib_execution != 201603L
-#error BOOM
+#error Expected cpp_lib_execution to equal 201603L.
 #else
 STATIC_ASSERT(__cpp_lib_execution == 201603L);
 #endif
 #else
 #ifdef __cpp_lib_execution
-#error BOOM
+#error Expected __cpp_lib_execution to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_lib_filesystem
-#error BOOM
+#error Expected __cpp_lib_filesystem to be defined.
 #elif __cpp_lib_filesystem != 201703L
-#error BOOM
+#error Expected cpp_lib_filesystem to equal 201703L.
 #else
 STATIC_ASSERT(__cpp_lib_filesystem == 201703L);
 #endif
 #else
 #ifdef __cpp_lib_filesystem
-#error BOOM
+#error Expected __cpp_lib_filesystem to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_lib_gcd_lcm
-#error BOOM
+#error Expected __cpp_lib_gcd_lcm to be defined.
 #elif __cpp_lib_gcd_lcm != 201606L
-#error BOOM
+#error Expected cpp_lib_gcd_lcm to equal 201606L.
 #else
 STATIC_ASSERT(__cpp_lib_gcd_lcm == 201606L);
 #endif
 #else
 #ifdef __cpp_lib_gcd_lcm
-#error BOOM
+#error Expected __cpp_lib_gcd_lcm to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_lib_hardware_interference_size
-#error BOOM
+#error Expected __cpp_lib_hardware_interference_size to be defined.
 #elif __cpp_lib_hardware_interference_size != 201703L
-#error BOOM
+#error Expected cpp_lib_hardware_interference_size to equal 201703L.
 #else
 STATIC_ASSERT(__cpp_lib_hardware_interference_size == 201703L);
 #endif
 #else
 #ifdef __cpp_lib_hardware_interference_size
-#error BOOM
+#error Expected __cpp_lib_hardware_interference_size to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_lib_has_unique_object_representations
-#error BOOM
+#error Expected __cpp_lib_has_unique_object_representations to be defined.
 #elif __cpp_lib_has_unique_object_representations != 201606L
-#error BOOM
+#error Expected cpp_lib_has_unique_object_representations to equal 201606L.
 #else
 STATIC_ASSERT(__cpp_lib_has_unique_object_representations == 201606L);
 #endif
 #else
 #ifdef __cpp_lib_has_unique_object_representations
-#error BOOM
+#error Expected __cpp_lib_has_unique_object_representations to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_lib_hypot
-#error BOOM
+#error Expected __cpp_lib_hypot to be defined.
 #elif __cpp_lib_hypot != 201603L
-#error BOOM
+#error Expected cpp_lib_hypot to equal 201603L.
 #else
 STATIC_ASSERT(__cpp_lib_hypot == 201603L);
 #endif
 #else
 #ifdef __cpp_lib_hypot
-#error BOOM
+#error Expected __cpp_lib_hypot to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_lib_is_aggregate
-#error BOOM
+#error Expected __cpp_lib_is_aggregate to be defined.
 #elif __cpp_lib_is_aggregate != 201703L
-#error BOOM
+#error Expected cpp_lib_is_aggregate to equal 201703L.
 #else
 STATIC_ASSERT(__cpp_lib_is_aggregate == 201703L);
 #endif
 #else
 #ifdef __cpp_lib_is_aggregate
-#error BOOM
+#error Expected __cpp_lib_is_aggregate to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_lib_is_invocable
-#error BOOM
+#error Expected __cpp_lib_is_invocable to be defined.
 #elif __cpp_lib_is_invocable != 201703L
-#error BOOM
+#error Expected cpp_lib_is_invocable to equal 201703L.
 #else
 STATIC_ASSERT(__cpp_lib_is_invocable == 201703L);
 #endif
 #else
 #ifdef __cpp_lib_is_invocable
-#error BOOM
+#error Expected __cpp_lib_is_invocable to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_lib_is_swappable
-#error BOOM
+#error Expected __cpp_lib_is_swappable to be defined.
 #elif __cpp_lib_is_swappable != 201603L
-#error BOOM
+#error Expected cpp_lib_is_swappable to equal 201603L.
 #else
 STATIC_ASSERT(__cpp_lib_is_swappable == 201603L);
 #endif
 #else
 #ifdef __cpp_lib_is_swappable
-#error BOOM
+#error Expected __cpp_lib_is_swappable to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_lib_launder
-#error BOOM
+#error Expected __cpp_lib_launder to be defined.
 #elif __cpp_lib_launder != 201606L
-#error BOOM
+#error Expected cpp_lib_launder to equal 201606L.
 #else
 STATIC_ASSERT(__cpp_lib_launder == 201606L);
 #endif
 #else
 #ifdef __cpp_lib_launder
-#error BOOM
+#error Expected __cpp_lib_launder to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_lib_make_from_tuple
-#error BOOM
+#error Expected __cpp_lib_make_from_tuple to be defined.
 #elif __cpp_lib_make_from_tuple != 201606L
-#error BOOM
+#error Expected cpp_lib_make_from_tuple to equal 201606L.
 #else
 STATIC_ASSERT(__cpp_lib_make_from_tuple == 201606L);
 #endif
 #else
 #ifdef __cpp_lib_make_from_tuple
-#error BOOM
+#error Expected __cpp_lib_make_from_tuple to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_lib_math_special_functions
-#error BOOM
+#error Expected __cpp_lib_math_special_functions to be defined.
 #elif __cpp_lib_math_special_functions != 201603L
-#error BOOM
+#error Expected cpp_lib_math_special_functions to equal 201603L.
 #else
 STATIC_ASSERT(__cpp_lib_math_special_functions == 201603L);
 #endif
 #else
 #ifdef __cpp_lib_math_special_functions
-#error BOOM
+#error Expected __cpp_lib_math_special_functions to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_lib_memory_resource
-#error BOOM
+#error Expected __cpp_lib_memory_resource to be defined.
 #elif __cpp_lib_memory_resource != 201603L
-#error BOOM
+#error Expected cpp_lib_memory_resource to equal 201603L.
 #else
 STATIC_ASSERT(__cpp_lib_memory_resource == 201603L);
 #endif
 #else
 #ifdef __cpp_lib_memory_resource
-#error BOOM
+#error Expected __cpp_lib_memory_resource to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_lib_node_extract
-#error BOOM
+#error Expected __cpp_lib_node_extract to be defined.
 #elif __cpp_lib_node_extract != 201606L
-#error BOOM
+#error Expected cpp_lib_node_extract to equal 201606L.
 #else
 STATIC_ASSERT(__cpp_lib_node_extract == 201606L);
 #endif
 #else
 #ifdef __cpp_lib_node_extract
-#error BOOM
+#error Expected __cpp_lib_node_extract to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_lib_not_fn
-#error BOOM
+#error Expected __cpp_lib_not_fn to be defined.
 #elif __cpp_lib_not_fn != 201603L
-#error BOOM
+#error Expected cpp_lib_not_fn to equal 201603L.
 #else
 STATIC_ASSERT(__cpp_lib_not_fn == 201603L);
 #endif
 #else
 #ifdef __cpp_lib_not_fn
-#error BOOM
+#error Expected __cpp_lib_not_fn to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_lib_optional
-#error BOOM
+#error Expected __cpp_lib_optional to be defined.
 #elif __cpp_lib_optional != 201606L
-#error BOOM
+#error Expected cpp_lib_optional to equal 201606L.
 #else
 STATIC_ASSERT(__cpp_lib_optional == 201606L);
 #endif
 #else
 #ifdef __cpp_lib_optional
-#error BOOM
+#error Expected __cpp_lib_optional to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX17 && !defined(_M_CEE)
 #ifndef __cpp_lib_parallel_algorithm
-#error BOOM
+#error Expected __cpp_lib_parallel_algorithm to be defined.
 #elif __cpp_lib_parallel_algorithm != 201603L
-#error BOOM
+#error Expected cpp_lib_parallel_algorithm to equal 201603L.
 #else
 STATIC_ASSERT(__cpp_lib_parallel_algorithm == 201603L);
 #endif
 #else
 #ifdef __cpp_lib_parallel_algorithm
-#error BOOM
+#error Expected __cpp_lib_parallel_algorithm to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_lib_raw_memory_algorithms
-#error BOOM
+#error Expected __cpp_lib_raw_memory_algorithms to be defined.
 #elif __cpp_lib_raw_memory_algorithms != 201606L
-#error BOOM
+#error Expected cpp_lib_raw_memory_algorithms to equal 201606L.
 #else
 STATIC_ASSERT(__cpp_lib_raw_memory_algorithms == 201606L);
 #endif
 #else
 #ifdef __cpp_lib_raw_memory_algorithms
-#error BOOM
+#error Expected __cpp_lib_raw_memory_algorithms to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_lib_sample
-#error BOOM
+#error Expected __cpp_lib_sample to be defined.
 #elif __cpp_lib_sample != 201603L
-#error BOOM
+#error Expected cpp_lib_sample to equal 201603L.
 #else
 STATIC_ASSERT(__cpp_lib_sample == 201603L);
 #endif
 #else
 #ifdef __cpp_lib_sample
-#error BOOM
+#error Expected __cpp_lib_sample to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_lib_scoped_lock
-#error BOOM
+#error Expected __cpp_lib_scoped_lock to be defined.
 #elif __cpp_lib_scoped_lock != 201703L
-#error BOOM
+#error Expected cpp_lib_scoped_lock to equal 201703L.
 #else
 STATIC_ASSERT(__cpp_lib_scoped_lock == 201703L);
 #endif
 #else
 #ifdef __cpp_lib_scoped_lock
-#error BOOM
+#error Expected __cpp_lib_scoped_lock to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_lib_shared_ptr_weak_type
-#error BOOM
+#error Expected __cpp_lib_shared_ptr_weak_type to be defined.
 #elif __cpp_lib_shared_ptr_weak_type != 201606L
-#error BOOM
+#error Expected cpp_lib_shared_ptr_weak_type to equal 201606L.
 #else
 STATIC_ASSERT(__cpp_lib_shared_ptr_weak_type == 201606L);
 #endif
 #else
 #ifdef __cpp_lib_shared_ptr_weak_type
-#error BOOM
+#error Expected __cpp_lib_shared_ptr_weak_type to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_lib_string_view
-#error BOOM
+#error Expected __cpp_lib_string_view to be defined.
 #elif __cpp_lib_string_view != 201803L
-#error BOOM
+#error Expected cpp_lib_string_view to equal 201803L.
 #else
 STATIC_ASSERT(__cpp_lib_string_view == 201803L);
 #endif
 #else
 #ifdef __cpp_lib_string_view
-#error BOOM
+#error Expected __cpp_lib_string_view to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_lib_to_chars
-#error BOOM
+#error Expected __cpp_lib_to_chars to be defined.
 #elif __cpp_lib_to_chars != 201611L
-#error BOOM
+#error Expected cpp_lib_to_chars to equal 201611L.
 #else
 STATIC_ASSERT(__cpp_lib_to_chars == 201611L);
 #endif
 #else
 #ifdef __cpp_lib_to_chars
-#error BOOM
+#error Expected __cpp_lib_to_chars to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_lib_variant
-#error BOOM
+#error Expected __cpp_lib_variant to be defined.
 #elif __cpp_lib_variant != 201606L
-#error BOOM
+#error Expected cpp_lib_variant to equal 201606L.
 #else
 STATIC_ASSERT(__cpp_lib_variant == 201606L);
 #endif
 #else
 #ifdef __cpp_lib_variant
-#error BOOM
+#error Expected __cpp_lib_variant to NOT be defined.
 #endif
 #endif
 
@@ -1443,15 +1443,15 @@ STATIC_ASSERT(__cpp_lib_variant == 201606L);
 
 #if _HAS_STD_BYTE
 #ifndef __cpp_lib_byte
-#error BOOM
+#error Expected __cpp_lib_byte to be defined.
 #elif __cpp_lib_byte != 201603L
-#error BOOM
+#error Expected cpp_lib_byte to equal 201603L.
 #else
 STATIC_ASSERT(__cpp_lib_byte == 201603L);
 #endif
 #else
 #ifdef __cpp_lib_byte
-#error BOOM
+#error Expected __cpp_lib_byte to NOT be defined.
 #endif
 #endif
 
@@ -1460,351 +1460,351 @@ STATIC_ASSERT(__cpp_lib_byte == 201603L);
 
 #if _HAS_CXX20
 #ifndef __cpp_lib_atomic_float
-#error BOOM
+#error Expected __cpp_lib_atomic_float to be defined.
 #elif __cpp_lib_atomic_float != 201711L
-#error BOOM
+#error Expected cpp_lib_atomic_float to equal 201711L.
 #else
 STATIC_ASSERT(__cpp_lib_atomic_float == 201711L);
 #endif
 #else
 #ifdef __cpp_lib_atomic_float
-#error BOOM
+#error Expected __cpp_lib_atomic_float to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX20
 #ifndef __cpp_lib_bind_front
-#error BOOM
+#error Expected __cpp_lib_bind_front to be defined.
 #elif __cpp_lib_bind_front != 201907L
-#error BOOM
+#error Expected cpp_lib_bind_front to equal 201907L.
 #else
 STATIC_ASSERT(__cpp_lib_bind_front == 201907L);
 #endif
 #else
 #ifdef __cpp_lib_bind_front
-#error BOOM
+#error Expected __cpp_lib_bind_front to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX20 && !defined(__EDG__) // TRANSITION, VSO-1041044
 #ifndef __cpp_lib_bit_cast
-#error BOOM
+#error Expected __cpp_lib_bit_cast to be defined.
 #elif __cpp_lib_bit_cast != 201806L
-#error BOOM
+#error Expected cpp_lib_bit_cast to equal 201806L.
 #else
 STATIC_ASSERT(__cpp_lib_bit_cast == 201806L);
 #endif
 #else
 #ifdef __cpp_lib_bit_cast
-#error BOOM
+#error Expected __cpp_lib_bit_cast to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX20 && (defined(__clang__) || defined(__EDG__)) // TRANSITION, VSO-1020212
 #ifndef __cpp_lib_bitops
-#error BOOM
+#error Expected __cpp_lib_bitops to be defined.
 #elif __cpp_lib_bitops != 201907L
-#error BOOM
+#error Expected cpp_lib_bitops to equal 201907L.
 #else
 STATIC_ASSERT(__cpp_lib_bitops == 201907L);
 #endif
 #else
 #ifdef __cpp_lib_bitops
-#error BOOM
+#error Expected __cpp_lib_bitops to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX20
 #ifndef __cpp_lib_bounded_array_traits
-#error BOOM
+#error Expected __cpp_lib_bounded_array_traits to be defined.
 #elif __cpp_lib_bounded_array_traits != 201902L
-#error BOOM
+#error Expected cpp_lib_bounded_array_traits to equal 201902L.
 #else
 STATIC_ASSERT(__cpp_lib_bounded_array_traits == 201902L);
 #endif
 #else
 #ifdef __cpp_lib_bounded_array_traits
-#error BOOM
+#error Expected __cpp_lib_bounded_array_traits to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX20
 #ifndef __cpp_lib_constexpr_algorithms
-#error BOOM
+#error Expected __cpp_lib_constexpr_algorithms to be defined.
 #elif __cpp_lib_constexpr_algorithms != 201806L
-#error BOOM
+#error Expected cpp_lib_constexpr_algorithms to equal 201806L.
 #else
 STATIC_ASSERT(__cpp_lib_constexpr_algorithms == 201806L);
 #endif
 #else
 #ifdef __cpp_lib_constexpr_algorithms
-#error BOOM
+#error Expected __cpp_lib_constexpr_algorithms to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX20
 #ifndef __cpp_lib_constexpr_memory
-#error BOOM
+#error Expected __cpp_lib_constexpr_memory to be defined.
 #elif __cpp_lib_constexpr_memory != 201811L
-#error BOOM
+#error Expected cpp_lib_constexpr_memory to equal 201811L.
 #else
 STATIC_ASSERT(__cpp_lib_constexpr_memory == 201811L);
 #endif
 #else
 #ifdef __cpp_lib_constexpr_memory
-#error BOOM
+#error Expected __cpp_lib_constexpr_memory to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX20
 #ifndef __cpp_lib_constexpr_numeric
-#error BOOM
+#error Expected __cpp_lib_constexpr_numeric to be defined.
 #elif __cpp_lib_constexpr_numeric != 201911L
-#error BOOM
+#error Expected cpp_lib_constexpr_numeric to equal 201911L.
 #else
 STATIC_ASSERT(__cpp_lib_constexpr_numeric == 201911L);
 #endif
 #else
 #ifdef __cpp_lib_constexpr_numeric
-#error BOOM
+#error Expected __cpp_lib_constexpr_numeric to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX20
 #ifndef __cpp_lib_endian
-#error BOOM
+#error Expected __cpp_lib_endian to be defined.
 #elif __cpp_lib_endian != 201907L
-#error BOOM
+#error Expected cpp_lib_endian to equal 201907L.
 #else
 STATIC_ASSERT(__cpp_lib_endian == 201907L);
 #endif
 #else
 #ifdef __cpp_lib_endian
-#error BOOM
+#error Expected __cpp_lib_endian to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX20
 #ifndef __cpp_lib_erase_if
-#error BOOM
+#error Expected __cpp_lib_erase_if to be defined.
 #elif __cpp_lib_erase_if != 202002L
-#error BOOM
+#error Expected cpp_lib_erase_if to equal 202002L.
 #else
 STATIC_ASSERT(__cpp_lib_erase_if == 202002L);
 #endif
 #else
 #ifdef __cpp_lib_erase_if
-#error BOOM
+#error Expected __cpp_lib_erase_if to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX20
 #ifndef __cpp_lib_generic_unordered_lookup
-#error BOOM
+#error Expected __cpp_lib_generic_unordered_lookup to be defined.
 #elif __cpp_lib_generic_unordered_lookup != 201811L
-#error BOOM
+#error Expected cpp_lib_generic_unordered_lookup to equal 201811L.
 #else
 STATIC_ASSERT(__cpp_lib_generic_unordered_lookup == 201811L);
 #endif
 #else
 #ifdef __cpp_lib_generic_unordered_lookup
-#error BOOM
+#error Expected __cpp_lib_generic_unordered_lookup to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX20
 #ifndef __cpp_lib_int_pow2
-#error BOOM
+#error Expected __cpp_lib_int_pow2 to be defined.
 #elif __cpp_lib_int_pow2 != 202002L
-#error BOOM
+#error Expected cpp_lib_int_pow2 to equal 202002L.
 #else
 STATIC_ASSERT(__cpp_lib_int_pow2 == 202002L);
 #endif
 #else
 #ifdef __cpp_lib_int_pow2
-#error BOOM
+#error Expected __cpp_lib_int_pow2 to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX20
 #ifndef __cpp_lib_is_constant_evaluated
-#error BOOM
+#error Expected __cpp_lib_is_constant_evaluated to be defined.
 #elif __cpp_lib_is_constant_evaluated != 201811L
-#error BOOM
+#error Expected cpp_lib_is_constant_evaluated to equal 201811L.
 #else
 STATIC_ASSERT(__cpp_lib_is_constant_evaluated == 201811L);
 #endif
 #else
 #ifdef __cpp_lib_is_constant_evaluated
-#error BOOM
+#error Expected __cpp_lib_is_constant_evaluated to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX20
 #ifndef __cpp_lib_is_nothrow_convertible
-#error BOOM
+#error Expected __cpp_lib_is_nothrow_convertible to be defined.
 #elif __cpp_lib_is_nothrow_convertible != 201806L
-#error BOOM
+#error Expected cpp_lib_is_nothrow_convertible to equal 201806L.
 #else
 STATIC_ASSERT(__cpp_lib_is_nothrow_convertible == 201806L);
 #endif
 #else
 #ifdef __cpp_lib_is_nothrow_convertible
-#error BOOM
+#error Expected __cpp_lib_is_nothrow_convertible to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX20
 #ifndef __cpp_lib_list_remove_return_type
-#error BOOM
+#error Expected __cpp_lib_list_remove_return_type to be defined.
 #elif __cpp_lib_list_remove_return_type != 201806L
-#error BOOM
+#error Expected cpp_lib_list_remove_return_type to equal 201806L.
 #else
 STATIC_ASSERT(__cpp_lib_list_remove_return_type == 201806L);
 #endif
 #else
 #ifdef __cpp_lib_list_remove_return_type
-#error BOOM
+#error Expected __cpp_lib_list_remove_return_type to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX20
 #ifndef __cpp_lib_math_constants
-#error BOOM
+#error Expected __cpp_lib_math_constants to be defined.
 #elif __cpp_lib_math_constants != 201907L
-#error BOOM
+#error Expected cpp_lib_math_constants to equal 201907L.
 #else
 STATIC_ASSERT(__cpp_lib_math_constants == 201907L);
 #endif
 #else
 #ifdef __cpp_lib_math_constants
-#error BOOM
+#error Expected __cpp_lib_math_constants to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX20
 #ifndef __cpp_lib_remove_cvref
-#error BOOM
+#error Expected __cpp_lib_remove_cvref to be defined.
 #elif __cpp_lib_remove_cvref != 201711L
-#error BOOM
+#error Expected cpp_lib_remove_cvref to equal 201711L.
 #else
 STATIC_ASSERT(__cpp_lib_remove_cvref == 201711L);
 #endif
 #else
 #ifdef __cpp_lib_remove_cvref
-#error BOOM
+#error Expected __cpp_lib_remove_cvref to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX20
 #ifndef __cpp_lib_shift
-#error BOOM
+#error Expected __cpp_lib_shift to be defined.
 #elif __cpp_lib_shift != 201806L
-#error BOOM
+#error Expected cpp_lib_shift to equal 201806L.
 #else
 STATIC_ASSERT(__cpp_lib_shift == 201806L);
 #endif
 #else
 #ifdef __cpp_lib_shift
-#error BOOM
+#error Expected __cpp_lib_shift to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX20
 #ifndef __cpp_lib_span
-#error BOOM
+#error Expected __cpp_lib_span to be defined.
 #elif __cpp_lib_span != 202002L
-#error BOOM
+#error Expected cpp_lib_span to equal 202002L.
 #else
 STATIC_ASSERT(__cpp_lib_span == 202002L);
 #endif
 #else
 #ifdef __cpp_lib_span
-#error BOOM
+#error Expected __cpp_lib_span to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX20
 #ifndef __cpp_lib_ssize
-#error BOOM
+#error Expected __cpp_lib_ssize to be defined.
 #elif __cpp_lib_ssize != 201902L
-#error BOOM
+#error Expected cpp_lib_ssize to equal 201902L.
 #else
 STATIC_ASSERT(__cpp_lib_ssize == 201902L);
 #endif
 #else
 #ifdef __cpp_lib_ssize
-#error BOOM
+#error Expected __cpp_lib_ssize to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX20
 #ifndef __cpp_lib_starts_ends_with
-#error BOOM
+#error Expected __cpp_lib_starts_ends_with to be defined.
 #elif __cpp_lib_starts_ends_with != 201711L
-#error BOOM
+#error Expected cpp_lib_starts_ends_with to equal 201711L.
 #else
 STATIC_ASSERT(__cpp_lib_starts_ends_with == 201711L);
 #endif
 #else
 #ifdef __cpp_lib_starts_ends_with
-#error BOOM
+#error Expected __cpp_lib_starts_ends_with to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX20
 #ifndef __cpp_lib_to_address
-#error BOOM
+#error Expected __cpp_lib_to_address to be defined.
 #elif __cpp_lib_to_address != 201711L
-#error BOOM
+#error Expected cpp_lib_to_address to equal 201711L.
 #else
 STATIC_ASSERT(__cpp_lib_to_address == 201711L);
 #endif
 #else
 #ifdef __cpp_lib_to_address
-#error BOOM
+#error Expected __cpp_lib_to_address to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX20
 #ifndef __cpp_lib_to_array
-#error BOOM
+#error Expected __cpp_lib_to_array to be defined.
 #elif __cpp_lib_to_array != 201907L
-#error BOOM
+#error Expected cpp_lib_to_array to equal 201907L.
 #else
 STATIC_ASSERT(__cpp_lib_to_array == 201907L);
 #endif
 #else
 #ifdef __cpp_lib_to_array
-#error BOOM
+#error Expected __cpp_lib_to_array to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX20
 #ifndef __cpp_lib_type_identity
-#error BOOM
+#error Expected __cpp_lib_type_identity to be defined.
 #elif __cpp_lib_type_identity != 201806L
-#error BOOM
+#error Expected cpp_lib_type_identity to equal 201806L.
 #else
 STATIC_ASSERT(__cpp_lib_type_identity == 201806L);
 #endif
 #else
 #ifdef __cpp_lib_type_identity
-#error BOOM
+#error Expected __cpp_lib_type_identity to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX20
 #ifndef __cpp_lib_unwrap_ref
-#error BOOM
+#error Expected __cpp_lib_unwrap_ref to be defined.
 #elif __cpp_lib_unwrap_ref != 201811L
-#error BOOM
+#error Expected cpp_lib_unwrap_ref to equal 201811L.
 #else
 STATIC_ASSERT(__cpp_lib_unwrap_ref == 201811L);
 #endif
 #else
 #ifdef __cpp_lib_unwrap_ref
-#error BOOM
+#error Expected __cpp_lib_unwrap_ref to NOT be defined.
 #endif
 #endif
 
@@ -1813,28 +1813,28 @@ STATIC_ASSERT(__cpp_lib_unwrap_ref == 201811L);
 
 #if _HAS_CXX20 && defined(__cpp_char8_t)
 #ifndef __cpp_lib_char8_t
-#error BOOM
+#error Expected __cpp_lib_char8_t to be defined.
 #elif __cpp_lib_char8_t != 201907L
-#error BOOM
+#error Expected cpp_lib_char8_t to equal 201907L.
 #else
 STATIC_ASSERT(__cpp_lib_char8_t == 201907L);
 #endif
 #else
 #ifdef __cpp_lib_char8_t
-#error BOOM
+#error Expected __cpp_lib_char8_t to NOT be defined.
 #endif
 #endif
 
 #if _HAS_CXX20 && defined(__cpp_concepts)
 #ifndef __cpp_lib_concepts
-#error BOOM
+#error Expected __cpp_lib_concepts to be defined.
 #elif __cpp_lib_concepts != 201907L
-#error BOOM
+#error Expected cpp_lib_concepts to equal 201907L.
 #else
 STATIC_ASSERT(__cpp_lib_concepts == 201907L);
 #endif
 #else
 #ifdef __cpp_lib_concepts
-#error BOOM
+#error Expected __cpp_lib_concepts to NOT be defined.
 #endif
 #endif

--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.cpp
@@ -5,59 +5,44 @@
 
 int main() {} // COMPILE-ONLY
 
-// Always defined to varying values (C++14 versus C++17-and-newer mode).
+// ATTRIBUTES.
 
-#ifndef __cpp_constexpr
-#error Expected __cpp_constexpr to be defined.
-#elif _HAS_CXX17
-#if __cpp_constexpr != 201603L
-#error Expected cpp_constexpr to equal 201603L.
+#ifdef __has_cpp_attribute
+// Good.
 #else
-STATIC_ASSERT(__cpp_constexpr == 201603L);
+#error Expected __has_cpp_attribute to be defined.
 #endif
+#if defined(__has_cpp_attribute)
+// Good.
 #else
-#if __cpp_constexpr != 201304L
-#error Expected cpp_constexpr to equal 201304L.
-#else
-STATIC_ASSERT(__cpp_constexpr == 201304L);
+#error Expected __has_cpp_attribute to be defined.
 #endif
+#ifndef __has_cpp_attribute
+#error Expected __has_cpp_attribute to be defined.
 #endif
 
-#ifndef __cpp_inheriting_constructors
-#error Expected __cpp_inheriting_constructors to be defined.
-#elif (_HAS_CXX17 || defined(__clang__)) && !defined(__EDG__) // Clang implemented this C++17 feature unconditionally.
-                                                              // TRANSITION, VSO-610203
-#if __cpp_inheriting_constructors != 201511L
-#error Expected cpp_inheriting_constructors to equal 201511L.
-#else
-STATIC_ASSERT(__cpp_inheriting_constructors == 201511L);
+#if __has_cpp_attribute(carries_dependency) != 200809L
+#error Expected has_cpp_attribute(carries_dependency) to equal 200809L.
+#endif
+#if __has_cpp_attribute(deprecated) != 201309L
+#error Expected has_cpp_attribute(deprecated) to equal 201309L.
+#endif
+
+#if defined(__clang__) || defined(__EDG__) // clang and EDG don't yet implement P1771R1
+#if __has_cpp_attribute(nodiscard) != 201603L
+#error Expected has_cpp_attribute(nodiscard) to equal 201603L.
 #endif
 #else
-#if __cpp_inheriting_constructors != 200802L
-#error Expected cpp_inheriting_constructors to equal 200802L.
-#else
-STATIC_ASSERT(__cpp_inheriting_constructors == 200802L);
+#if __has_cpp_attribute(nodiscard) != 201907L
+#error Expected has_cpp_attribute(nodiscard) to equal 201907L.
 #endif
 #endif
 
-#ifndef __cpp_static_assert
-#error Expected __cpp_static_assert to be defined.
-#elif _HAS_CXX17
-#if __cpp_static_assert != 201411L
-#error Expected cpp_static_assert to equal 201411L.
-#else
-STATIC_ASSERT(__cpp_static_assert == 201411L);
-#endif
-#else
-#if __cpp_static_assert != 200410L
-#error Expected cpp_static_assert to equal 200410L.
-#else
-STATIC_ASSERT(__cpp_static_assert == 200410L);
-#endif
+#if __has_cpp_attribute(noreturn) != 200809L
+#error Expected has_cpp_attribute(noreturn) to equal 200809L.
 #endif
 
-
-// Always defined to specific values.
+//// LANGUAGE FEATURE-TEST MACROS
 
 #ifndef __cpp_aggregate_nsdmi
 #error Expected __cpp_aggregate_nsdmi to be defined.
@@ -91,6 +76,22 @@ STATIC_ASSERT(__cpp_attributes == 200809L);
 STATIC_ASSERT(__cpp_binary_literals == 201304L);
 #endif
 
+#ifndef __cpp_constexpr
+#error Expected __cpp_constexpr to be defined.
+#elif _HAS_CXX17
+#if __cpp_constexpr != 201603L
+#error Expected cpp_constexpr to equal 201603L.
+#else
+STATIC_ASSERT(__cpp_constexpr == 201603L);
+#endif
+#else
+#if __cpp_constexpr != 201304L
+#error Expected cpp_constexpr to equal 201304L.
+#else
+STATIC_ASSERT(__cpp_constexpr == 201304L);
+#endif
+#endif
+
 #ifndef __cpp_decltype
 #error Expected __cpp_decltype to be defined.
 #elif __cpp_decltype != 200707L
@@ -115,26 +116,29 @@ STATIC_ASSERT(__cpp_decltype_auto == 201304L);
 STATIC_ASSERT(__cpp_delegating_constructors == 200604L);
 #endif
 
-#if !defined(__clang__) || _HAS_CXX17 // C1XX implemented this C++17 feature unconditionally.
-#ifndef __cpp_enumerator_attributes
-#error Expected __cpp_enumerator_attributes to be defined.
-#elif __cpp_enumerator_attributes != 201411L
-#error Expected cpp_enumerator_attributes to equal 201411L.
-#else
-STATIC_ASSERT(__cpp_enumerator_attributes == 201411L);
-#endif
-#else
-#ifdef __cpp_enumerator_attributes
-#error Expected __cpp_enumerator_attributes to NOT be defined.
-#endif
-#endif
-
 #ifndef __cpp_generic_lambdas
 #error Expected __cpp_generic_lambdas to be defined.
 #elif __cpp_generic_lambdas != 201304L
 #error Expected cpp_generic_lambdas to equal 201304L.
 #else
 STATIC_ASSERT(__cpp_generic_lambdas == 201304L);
+#endif
+
+#ifndef __cpp_inheriting_constructors
+#error Expected __cpp_inheriting_constructors to be defined.
+#elif (_HAS_CXX17 || defined(__clang__)) && !defined(__EDG__) // Clang implemented this C++17 feature unconditionally.
+                                                              // TRANSITION, VSO-610203
+#if __cpp_inheriting_constructors != 201511L
+#error Expected cpp_inheriting_constructors to equal 201511L.
+#else
+STATIC_ASSERT(__cpp_inheriting_constructors == 201511L);
+#endif
+#else
+#if __cpp_inheriting_constructors != 200802L
+#error Expected cpp_inheriting_constructors to equal 200802L.
+#else
+STATIC_ASSERT(__cpp_inheriting_constructors == 200802L);
+#endif
 #endif
 
 #ifndef __cpp_init_captures
@@ -159,20 +163,6 @@ STATIC_ASSERT(__cpp_initializer_lists == 200806L);
 #error Expected cpp_lambdas to equal 200907L.
 #else
 STATIC_ASSERT(__cpp_lambdas == 200907L);
-#endif
-
-#if !defined(__clang__) || _HAS_CXX17 // C1XX implemented this C++17 feature unconditionally.
-#ifndef __cpp_namespace_attributes
-#error Expected __cpp_namespace_attributes to be defined.
-#elif __cpp_namespace_attributes != 201411L
-#error Expected cpp_namespace_attributes to equal 201411L.
-#else
-STATIC_ASSERT(__cpp_namespace_attributes == 201411L);
-#endif
-#else
-#ifdef __cpp_namespace_attributes
-#error Expected __cpp_namespace_attributes to NOT be defined.
-#endif
 #endif
 
 #ifndef __cpp_nsdmi
@@ -231,6 +221,22 @@ STATIC_ASSERT(__cpp_return_type_deduction == 201304L);
 STATIC_ASSERT(__cpp_rvalue_references == 200610L);
 #endif
 
+#ifndef __cpp_static_assert
+#error Expected __cpp_static_assert to be defined.
+#elif _HAS_CXX17
+#if __cpp_static_assert != 201411L
+#error Expected cpp_static_assert to equal 201411L.
+#else
+STATIC_ASSERT(__cpp_static_assert == 201411L);
+#endif
+#else
+#if __cpp_static_assert != 200410L
+#error Expected cpp_static_assert to equal 200410L.
+#else
+STATIC_ASSERT(__cpp_static_assert == 200410L);
+#endif
+#endif
+
 #ifndef __cpp_unicode_characters
 #error Expected __cpp_unicode_characters to be defined.
 #elif __cpp_unicode_characters != 200704L
@@ -271,8 +277,95 @@ STATIC_ASSERT(__cpp_variable_templates == 201304L);
 STATIC_ASSERT(__cpp_variadic_templates == 200704L);
 #endif
 
+// C++98, /GR[-]
+#ifdef TEST_DISABLED_RTTI
+#ifdef __cpp_rtti
+#error Expected __cpp_rtti to NOT be defined.
+#endif
+#else
+#ifndef __cpp_rtti
+#error Expected __cpp_rtti to be defined.
+#elif __cpp_rtti != 199711L
+#error Expected cpp_rtti to equal 199711L.
+#else
+STATIC_ASSERT(__cpp_rtti == 199711L);
+#endif
+#endif
 
-// Defined in C++17-and-newer mode to specific values.
+// C++11, /Zc:threadSafeInit[-]
+#if defined(_M_CEE_PURE) || defined(TEST_DISABLED_THREADSAFE_STATIC_INIT)
+#ifdef __cpp_threadsafe_static_init
+#error Expected __cpp_threadsafe_static_init to NOT be defined.
+#endif
+#else
+#ifndef __cpp_threadsafe_static_init
+#error Expected __cpp_threadsafe_static_init to be defined.
+#elif __cpp_threadsafe_static_init != 200806L
+#error Expected cpp_threadsafe_static_init to equal 200806L.
+#else
+STATIC_ASSERT(__cpp_threadsafe_static_init == 200806L);
+#endif
+#endif
+
+// C++14, /Zc:sizedDealloc[-]
+#if defined(TEST_DISABLED_SIZED_DEALLOCATION) || defined(__clang__) // Clang disables sized deallocation by default.
+#ifdef __cpp_sized_deallocation
+#error Expected __cpp_sized_deallocation to NOT be defined.
+#endif
+#else
+#ifndef __cpp_sized_deallocation
+#error Expected __cpp_sized_deallocation to be defined.
+#elif __cpp_sized_deallocation != 201309L
+#error Expected cpp_sized_deallocation to equal 201309L.
+#else
+STATIC_ASSERT(__cpp_sized_deallocation == 201309L);
+#endif
+#endif
+
+// C++17, /Zc:alignedNew[-]
+#if !_HAS_CXX17 || defined(TEST_DISABLED_ALIGNED_NEW)
+#ifdef __cpp_aligned_new
+#error Expected __cpp_aligned_new to NOT be defined.
+#endif
+#else
+#ifndef __cpp_aligned_new
+#error Expected __cpp_aligned_new to be defined.
+#elif __cpp_aligned_new != 201606L
+#error Expected cpp_aligned_new to equal 201606L.
+#else
+STATIC_ASSERT(__cpp_aligned_new == 201606L);
+#endif
+#endif
+
+// C++17, /Zc:noexceptTypes[-]
+#if !_HAS_CXX17 || defined(TEST_DISABLED_NOEXCEPT_FUNCTION_TYPE)
+#ifdef __cpp_noexcept_function_type
+#error Expected __cpp_noexcept_function_type to NOT be defined.
+#endif
+#else
+#ifndef __cpp_noexcept_function_type
+#error Expected __cpp_noexcept_function_type to be defined.
+#elif __cpp_noexcept_function_type != 201510L
+#error Expected cpp_noexcept_function_type to equal 201510L.
+#else
+STATIC_ASSERT(__cpp_noexcept_function_type == 201510L);
+#endif
+#endif
+
+// C++98, /EHs[-]
+#ifdef TEST_DISABLED_EXCEPTIONS
+#ifdef __cpp_exceptions
+#error Expected __cpp_exceptions to NOT be defined.
+#endif
+#else
+#ifndef __cpp_exceptions
+#error Expected __cpp_exceptions to be defined.
+#elif __cpp_exceptions != 199711L
+#error Expected cpp_exceptions to equal 199711L.
+#else
+STATIC_ASSERT(__cpp_exceptions == 199711L);
+#endif
+#endif
 
 #if _HAS_CXX17
 #ifndef __cpp_aggregate_bases
@@ -344,34 +437,6 @@ STATIC_ASSERT(__cpp_guaranteed_copy_elision == 201606L);
 #endif
 #endif
 
-#if _HAS_CXX17 || defined(__EDG__) // EDG unconditionally reports hex floats as being available.
-#ifndef __cpp_hex_float
-#error Expected __cpp_hex_float to be defined.
-#elif __cpp_hex_float != 201603L
-#error Expected cpp_hex_float to equal 201603L.
-#else
-STATIC_ASSERT(__cpp_hex_float == 201603L);
-#endif
-#else
-#ifdef __cpp_hex_float
-#error Expected __cpp_hex_float to NOT be defined.
-#endif
-#endif
-
-#if _HAS_CXX17 || defined(__EDG__) // EDG unconditionally reports "if constexpr" as being available.
-#ifndef __cpp_if_constexpr
-#error Expected __cpp_if_constexpr to be defined.
-#elif __cpp_if_constexpr != 201606L
-#error Expected cpp_if_constexpr to equal 201606L.
-#else
-STATIC_ASSERT(__cpp_if_constexpr == 201606L);
-#endif
-#else
-#ifdef __cpp_if_constexpr
-#error Expected __cpp_if_constexpr to NOT be defined.
-#endif
-#endif
-
 #if _HAS_CXX17
 #ifndef __cpp_inline_variables
 #error Expected __cpp_inline_variables to be defined.
@@ -383,28 +448,6 @@ STATIC_ASSERT(__cpp_inline_variables == 201606L);
 #else
 #ifdef __cpp_inline_variables
 #error Expected __cpp_inline_variables to NOT be defined.
-#endif
-#endif
-
-#if _HAS_CXX20 && !defined(__clang__) && !defined(__EDG__)
-#ifndef __cpp_nontype_template_args
-#error Expected __cpp_nontype_template_args to be defined.
-#elif __cpp_nontype_template_args != 201911L
-#error Expected cpp_nontype_template_args to equal 201911L.
-#else
-STATIC_ASSERT(__cpp_nontype_template_args == 201911L);
-#endif
-#elif _HAS_CXX17
-#ifndef __cpp_nontype_template_args
-#error Expected __cpp_nontype_template_args to be defined.
-#elif __cpp_nontype_template_args != 201411L
-#error Expected cpp_nontype_template_args to equal 201411L.
-#else
-STATIC_ASSERT(__cpp_nontype_template_args == 201411L);
-#endif
-#else
-#ifdef __cpp_nontype_template_args
-#error Expected __cpp_nontype_template_args to NOT be defined.
 #endif
 #endif
 
@@ -436,6 +479,20 @@ STATIC_ASSERT(__cpp_structured_bindings == 201606L);
 #endif
 #endif
 
+#if _HAS_CXX17
+#ifndef __cpp_variadic_using
+#error Expected __cpp_variadic_using to be defined.
+#elif __cpp_variadic_using != 201611L
+#error Expected cpp_variadic_using to equal 201611L.
+#else
+STATIC_ASSERT(__cpp_variadic_using == 201611L);
+#endif
+#else
+#ifdef __cpp_variadic_using
+#error Expected __cpp_variadic_using to NOT be defined.
+#endif
+#endif
+
 #if _HAS_CXX17 && !defined(__clang__)
 // https://clang.llvm.org/cxx_status.html says P0522R0 is Partial, "Despite being
 // the resolution to a Defect Report, this feature is disabled by default in all
@@ -457,34 +514,59 @@ STATIC_ASSERT(__cpp_template_template_args == 201611L);
 #endif
 #endif
 
-#if _HAS_CXX17
-#ifndef __cpp_variadic_using
-#error Expected __cpp_variadic_using to be defined.
-#elif __cpp_variadic_using != 201611L
-#error Expected cpp_variadic_using to equal 201611L.
+#if _HAS_CXX17 || !defined(__clang__) // C1XX implemented this C++17 feature unconditionally.
+#ifndef __cpp_namespace_attributes
+#error Expected __cpp_namespace_attributes to be defined.
+#elif __cpp_namespace_attributes != 201411L
+#error Expected cpp_namespace_attributes to equal 201411L.
 #else
-STATIC_ASSERT(__cpp_variadic_using == 201611L);
+STATIC_ASSERT(__cpp_namespace_attributes == 201411L);
 #endif
 #else
-#ifdef __cpp_variadic_using
-#error Expected __cpp_variadic_using to NOT be defined.
+#ifdef __cpp_namespace_attributes
+#error Expected __cpp_namespace_attributes to NOT be defined.
 #endif
 #endif
 
-// Defined in C++20-and-newer mode to specific values.
-
-#if _HAS_CXX20 || defined(__EDG__)
-// EDG unconditionally reports "explicit(bool)" as being available.
-#ifndef __cpp_conditional_explicit
-#error Expected __cpp_conditional_explicit to be defined.
-#elif __cpp_conditional_explicit != 201806L
-#error Expected cpp_conditional_explicit to equal 201806L.
+#if _HAS_CXX17 || !defined(__clang__) // C1XX implemented this C++17 feature unconditionally.
+#ifndef __cpp_enumerator_attributes
+#error Expected __cpp_enumerator_attributes to be defined.
+#elif __cpp_enumerator_attributes != 201411L
+#error Expected cpp_enumerator_attributes to equal 201411L.
 #else
-STATIC_ASSERT(__cpp_conditional_explicit == 201806L);
+STATIC_ASSERT(__cpp_enumerator_attributes == 201411L);
 #endif
 #else
-#ifdef __cpp_conditional_explicit
-#error Expected __cpp_conditional_explicit to NOT be defined.
+#ifdef __cpp_enumerator_attributes
+#error Expected __cpp_enumerator_attributes to NOT be defined.
+#endif
+#endif
+
+#if _HAS_CXX17 || defined(__EDG__) // EDG unconditionally reports "if constexpr" as being available.
+#ifndef __cpp_if_constexpr
+#error Expected __cpp_if_constexpr to be defined.
+#elif __cpp_if_constexpr != 201606L
+#error Expected cpp_if_constexpr to equal 201606L.
+#else
+STATIC_ASSERT(__cpp_if_constexpr == 201606L);
+#endif
+#else
+#ifdef __cpp_if_constexpr
+#error Expected __cpp_if_constexpr to NOT be defined.
+#endif
+#endif
+
+#if _HAS_CXX17 || defined(__EDG__) // EDG unconditionally reports hex floats as being available.
+#ifndef __cpp_hex_float
+#error Expected __cpp_hex_float to be defined.
+#elif __cpp_hex_float != 201603L
+#error Expected cpp_hex_float to equal 201603L.
+#else
+STATIC_ASSERT(__cpp_hex_float == 201603L);
+#endif
+#else
+#ifdef __cpp_hex_float
+#error Expected __cpp_hex_float to NOT be defined.
 #endif
 #endif
 
@@ -511,191 +593,45 @@ STATIC_ASSERT(__cpp_impl_three_way_comparison == 201907L);
 #endif
 #endif
 
-// Conditionally defined (various compiler options) to specific values.
-
-// C++17, /Zc:alignedNew[-]
-#if !_HAS_CXX17 || defined(TEST_DISABLED_ALIGNED_NEW)
-#ifdef __cpp_aligned_new
-#error Expected __cpp_aligned_new to NOT be defined.
+#if _HAS_CXX20 && !defined(__clang__) && !defined(__EDG__)
+#ifndef __cpp_nontype_template_args
+#error Expected __cpp_nontype_template_args to be defined.
+#elif __cpp_nontype_template_args != 201911L
+#error Expected cpp_nontype_template_args to equal 201911L.
+#else
+STATIC_ASSERT(__cpp_nontype_template_args == 201911L);
+#endif
+#elif _HAS_CXX17
+#ifndef __cpp_nontype_template_args
+#error Expected __cpp_nontype_template_args to be defined.
+#elif __cpp_nontype_template_args != 201411L
+#error Expected cpp_nontype_template_args to equal 201411L.
+#else
+STATIC_ASSERT(__cpp_nontype_template_args == 201411L);
 #endif
 #else
-#ifndef __cpp_aligned_new
-#error Expected __cpp_aligned_new to be defined.
-#elif __cpp_aligned_new != 201606L
-#error Expected cpp_aligned_new to equal 201606L.
-#else
-STATIC_ASSERT(__cpp_aligned_new == 201606L);
+#ifdef __cpp_nontype_template_args
+#error Expected __cpp_nontype_template_args to NOT be defined.
 #endif
 #endif
 
-// C++98, /EHs[-]
-#ifdef TEST_DISABLED_EXCEPTIONS
-#ifdef __cpp_exceptions
-#error Expected __cpp_exceptions to NOT be defined.
-#endif
+#if _HAS_CXX20 || defined(__EDG__)
+// EDG unconditionally reports "explicit(bool)" as being available.
+#ifndef __cpp_conditional_explicit
+#error Expected __cpp_conditional_explicit to be defined.
+#elif __cpp_conditional_explicit != 201806L
+#error Expected cpp_conditional_explicit to equal 201806L.
 #else
-#ifndef __cpp_exceptions
-#error Expected __cpp_exceptions to be defined.
-#elif __cpp_exceptions != 199711L
-#error Expected cpp_exceptions to equal 199711L.
-#else
-STATIC_ASSERT(__cpp_exceptions == 199711L);
-#endif
-#endif
-
-// C++17, /Zc:noexceptTypes[-]
-#if !_HAS_CXX17 || defined(TEST_DISABLED_NOEXCEPT_FUNCTION_TYPE)
-#ifdef __cpp_noexcept_function_type
-#error Expected __cpp_noexcept_function_type to NOT be defined.
+STATIC_ASSERT(__cpp_conditional_explicit == 201806L);
 #endif
 #else
-#ifndef __cpp_noexcept_function_type
-#error Expected __cpp_noexcept_function_type to be defined.
-#elif __cpp_noexcept_function_type != 201510L
-#error Expected cpp_noexcept_function_type to equal 201510L.
-#else
-STATIC_ASSERT(__cpp_noexcept_function_type == 201510L);
+#ifdef __cpp_conditional_explicit
+#error Expected __cpp_conditional_explicit to NOT be defined.
 #endif
 #endif
-
-// C++98, /GR[-]
-#ifdef TEST_DISABLED_RTTI
-#ifdef __cpp_rtti
-#error Expected __cpp_rtti to NOT be defined.
-#endif
-#else
-#ifndef __cpp_rtti
-#error Expected __cpp_rtti to be defined.
-#elif __cpp_rtti != 199711L
-#error Expected cpp_rtti to equal 199711L.
-#else
-STATIC_ASSERT(__cpp_rtti == 199711L);
-#endif
-#endif
-
-// C++14, /Zc:sizedDealloc[-]
-#if defined(TEST_DISABLED_SIZED_DEALLOCATION) || defined(__clang__) // Clang disables sized deallocation by default.
-#ifdef __cpp_sized_deallocation
-#error Expected __cpp_sized_deallocation to NOT be defined.
-#endif
-#else
-#ifndef __cpp_sized_deallocation
-#error Expected __cpp_sized_deallocation to be defined.
-#elif __cpp_sized_deallocation != 201309L
-#error Expected cpp_sized_deallocation to equal 201309L.
-#else
-STATIC_ASSERT(__cpp_sized_deallocation == 201309L);
-#endif
-#endif
-
-// C++11, /Zc:threadSafeInit[-]
-#if defined(_M_CEE_PURE) || defined(TEST_DISABLED_THREADSAFE_STATIC_INIT)
-#ifdef __cpp_threadsafe_static_init
-#error Expected __cpp_threadsafe_static_init to NOT be defined.
-#endif
-#else
-#ifndef __cpp_threadsafe_static_init
-#error Expected __cpp_threadsafe_static_init to be defined.
-#elif __cpp_threadsafe_static_init != 200806L
-#error Expected cpp_threadsafe_static_init to equal 200806L.
-#else
-STATIC_ASSERT(__cpp_threadsafe_static_init == 200806L);
-#endif
-#endif
-
-
-// Attributes.
-
-#ifdef __has_cpp_attribute
-// Good.
-#else
-#error Expected __has_cpp_attribute to be defined.
-#endif
-
-#if defined(__has_cpp_attribute)
-// Good.
-#else
-#error Expected __has_cpp_attribute to be defined.
-#endif
-
-#ifndef __has_cpp_attribute
-#error Expected __has_cpp_attribute to be defined.
-#endif
-
-
-// Always defined to specific values.
-
-#if __has_cpp_attribute(carries_dependency) != 200809L
-#error Expected has_cpp_attribute(carries_dependency) to equal 200809L.
-#endif
-
-#if __has_cpp_attribute(deprecated) != 201309L
-#error Expected has_cpp_attribute(deprecated) to equal 201309L.
-#endif
-
-#if defined(__clang__) || defined(__EDG__) // clang and EDG don't yet implement P1771R1
-#if __has_cpp_attribute(nodiscard) != 201603L
-#error Expected has_cpp_attribute(nodiscard) to equal 201603L.
-#endif
-#else
-#if __has_cpp_attribute(nodiscard) != 201907L
-#error Expected has_cpp_attribute(nodiscard) to equal 201907L.
-#endif
-#endif
-
-#if __has_cpp_attribute(noreturn) != 200809L
-#error Expected has_cpp_attribute(noreturn) to equal 200809L.
-#endif
-
-
-// Always defined to varying values (C++14 versus C++17-and-newer mode).
-
-#if _HAS_CXX17 || defined(__clang__) || defined(__EDG__) // Clang and EDG provide this in C++14 mode.
-#if __has_cpp_attribute(fallthrough) != 201603L
-#error Expected has_cpp_attribute(fallthrough) to equal 201603L.
-#endif
-#else
-#if __has_cpp_attribute(fallthrough) != 0
-#error Expected has_cpp_attribute(fallthrough) to equal 0.
-#endif
-#endif
-
-#if _HAS_CXX17 || defined(__clang__) || defined(__EDG__) // Clang and EDG provide this in C++14 mode.
-#if __has_cpp_attribute(maybe_unused) != 201603L
-#error Expected has_cpp_attribute(maybe_unused) to equal 201603L.
-#endif
-#else
-#if __has_cpp_attribute(maybe_unused) != 0
-#error Expected has_cpp_attribute(maybe_unused) to equal 0.
-#endif
-#endif
-
 
 // LIBRARY FEATURE-TEST MACROS
-
 #include <version>
-
-
-// Always defined to varying values (C++14 versus C++17-and-newer mode).
-
-#ifndef __cpp_lib_chrono
-#error Expected __cpp_lib_chrono to be defined.
-#elif _HAS_CXX17
-#if __cpp_lib_chrono != 201611L
-#error Expected cpp_lib_chrono to equal 201611L.
-#else
-STATIC_ASSERT(__cpp_lib_chrono == 201611L);
-#endif
-#else
-#if __cpp_lib_chrono != 201510L
-#error Expected cpp_lib_chrono to equal 201510L.
-#else
-STATIC_ASSERT(__cpp_lib_chrono == 201510L);
-#endif
-#endif
-
-
-// Always defined to specific values.
 
 #ifndef __cpp_lib_addressof_constexpr
 #error Expected __cpp_lib_addressof_constexpr to be defined.
@@ -735,6 +671,22 @@ STATIC_ASSERT(__cpp_lib_atomic_value_initialization == 201911L);
 #error Expected cpp_lib_bool_constant to equal 201505L.
 #else
 STATIC_ASSERT(__cpp_lib_bool_constant == 201505L);
+#endif
+
+#ifndef __cpp_lib_chrono
+#error Expected __cpp_lib_chrono to be defined.
+#elif _HAS_CXX17
+#if __cpp_lib_chrono != 201611L
+#error Expected cpp_lib_chrono to equal 201611L.
+#else
+STATIC_ASSERT(__cpp_lib_chrono == 201611L);
+#endif
+#else
+#if __cpp_lib_chrono != 201510L
+#error Expected cpp_lib_chrono to equal 201510L.
+#else
+STATIC_ASSERT(__cpp_lib_chrono == 201510L);
+#endif
 #endif
 
 #ifndef __cpp_lib_chrono_udls
@@ -929,20 +881,6 @@ STATIC_ASSERT(__cpp_lib_shared_mutex == 201505L);
 STATIC_ASSERT(__cpp_lib_shared_ptr_arrays == 201611L);
 #endif
 
-#ifdef _M_CEE
-#ifdef __cpp_lib_shared_timed_mutex
-#error Expected __cpp_lib_shared_timed_mutex to NOT be defined.
-#endif
-#else // ^^^ _M_CEE ^^^ // vvv !_M_CEE vvv
-#ifndef __cpp_lib_shared_timed_mutex
-#error Expected __cpp_lib_shared_timed_mutex to be defined.
-#elif __cpp_lib_shared_timed_mutex != 201402L
-#error Expected cpp_lib_shared_timed_mutex to equal 201402L.
-#else
-STATIC_ASSERT(__cpp_lib_shared_timed_mutex == 201402L);
-#endif
-#endif // _M_CEE
-
 #ifndef __cpp_lib_string_udls
 #error Expected __cpp_lib_string_udls to be defined.
 #elif __cpp_lib_string_udls != 201304L
@@ -1014,9 +952,6 @@ STATIC_ASSERT(__cpp_lib_unordered_map_try_emplace == 201411L);
 #else
 STATIC_ASSERT(__cpp_lib_void_t == 201411L);
 #endif
-
-
-// Defined in C++17-and-newer mode to specific values.
 
 #if _HAS_CXX17
 #ifndef __cpp_lib_any
@@ -1099,20 +1034,6 @@ STATIC_ASSERT(__cpp_lib_clamp == 201603L);
 #else
 #ifdef __cpp_lib_clamp
 #error Expected __cpp_lib_clamp to NOT be defined.
-#endif
-#endif
-
-#if _HAS_CXX17 && !defined(_M_CEE)
-#ifndef __cpp_lib_execution
-#error Expected __cpp_lib_execution to be defined.
-#elif __cpp_lib_execution != 201603L
-#error Expected cpp_lib_execution to equal 201603L.
-#else
-STATIC_ASSERT(__cpp_lib_execution == 201603L);
-#endif
-#else
-#ifdef __cpp_lib_execution
-#error Expected __cpp_lib_execution to NOT be defined.
 #endif
 #endif
 
@@ -1326,20 +1247,6 @@ STATIC_ASSERT(__cpp_lib_optional == 201606L);
 #endif
 #endif
 
-#if _HAS_CXX17 && !defined(_M_CEE)
-#ifndef __cpp_lib_parallel_algorithm
-#error Expected __cpp_lib_parallel_algorithm to be defined.
-#elif __cpp_lib_parallel_algorithm != 201603L
-#error Expected cpp_lib_parallel_algorithm to equal 201603L.
-#else
-STATIC_ASSERT(__cpp_lib_parallel_algorithm == 201603L);
-#endif
-#else
-#ifdef __cpp_lib_parallel_algorithm
-#error Expected __cpp_lib_parallel_algorithm to NOT be defined.
-#endif
-#endif
-
 #if _HAS_CXX17
 #ifndef __cpp_lib_raw_memory_algorithms
 #error Expected __cpp_lib_raw_memory_algorithms to be defined.
@@ -1438,25 +1345,33 @@ STATIC_ASSERT(__cpp_lib_variant == 201606L);
 #endif
 #endif
 
-
-// Conditionally defined in C++17-and-newer mode to specific values.
-
-#if _HAS_STD_BYTE
-#ifndef __cpp_lib_byte
-#error Expected __cpp_lib_byte to be defined.
-#elif __cpp_lib_byte != 201603L
-#error Expected cpp_lib_byte to equal 201603L.
+#if _HAS_CXX17 && !defined(_M_CEE)
+#ifndef __cpp_lib_execution
+#error Expected __cpp_lib_execution to be defined.
+#elif __cpp_lib_execution != 201603L
+#error Expected cpp_lib_execution to equal 201603L.
 #else
-STATIC_ASSERT(__cpp_lib_byte == 201603L);
+STATIC_ASSERT(__cpp_lib_execution == 201603L);
 #endif
 #else
-#ifdef __cpp_lib_byte
-#error Expected __cpp_lib_byte to NOT be defined.
+#ifdef __cpp_lib_execution
+#error Expected __cpp_lib_execution to NOT be defined.
 #endif
 #endif
 
-
-// Defined in C++20-and-newer mode to specific values.
+#if _HAS_CXX17 && !defined(_M_CEE)
+#ifndef __cpp_lib_parallel_algorithm
+#error Expected __cpp_lib_parallel_algorithm to be defined.
+#elif __cpp_lib_parallel_algorithm != 201603L
+#error Expected cpp_lib_parallel_algorithm to equal 201603L.
+#else
+STATIC_ASSERT(__cpp_lib_parallel_algorithm == 201603L);
+#endif
+#else
+#ifdef __cpp_lib_parallel_algorithm
+#error Expected __cpp_lib_parallel_algorithm to NOT be defined.
+#endif
+#endif
 
 #if _HAS_CXX20
 #ifndef __cpp_lib_atomic_float
@@ -1483,34 +1398,6 @@ STATIC_ASSERT(__cpp_lib_bind_front == 201907L);
 #else
 #ifdef __cpp_lib_bind_front
 #error Expected __cpp_lib_bind_front to NOT be defined.
-#endif
-#endif
-
-#if _HAS_CXX20 && !defined(__EDG__) // TRANSITION, VSO-1041044
-#ifndef __cpp_lib_bit_cast
-#error Expected __cpp_lib_bit_cast to be defined.
-#elif __cpp_lib_bit_cast != 201806L
-#error Expected cpp_lib_bit_cast to equal 201806L.
-#else
-STATIC_ASSERT(__cpp_lib_bit_cast == 201806L);
-#endif
-#else
-#ifdef __cpp_lib_bit_cast
-#error Expected __cpp_lib_bit_cast to NOT be defined.
-#endif
-#endif
-
-#if _HAS_CXX20 && (defined(__clang__) || defined(__EDG__)) // TRANSITION, VSO-1020212
-#ifndef __cpp_lib_bitops
-#error Expected __cpp_lib_bitops to be defined.
-#elif __cpp_lib_bitops != 201907L
-#error Expected cpp_lib_bitops to equal 201907L.
-#else
-STATIC_ASSERT(__cpp_lib_bitops == 201907L);
-#endif
-#else
-#ifdef __cpp_lib_bitops
-#error Expected __cpp_lib_bitops to NOT be defined.
 #endif
 #endif
 
@@ -1808,8 +1695,33 @@ STATIC_ASSERT(__cpp_lib_unwrap_ref == 201811L);
 #endif
 #endif
 
+#if _HAS_CXX20 && !defined(__EDG__) // TRANSITION, VSO-1041044
+#ifndef __cpp_lib_bit_cast
+#error Expected __cpp_lib_bit_cast to be defined.
+#elif __cpp_lib_bit_cast != 201806L
+#error Expected cpp_lib_bit_cast to equal 201806L.
+#else
+STATIC_ASSERT(__cpp_lib_bit_cast == 201806L);
+#endif
+#else
+#ifdef __cpp_lib_bit_cast
+#error Expected __cpp_lib_bit_cast to NOT be defined.
+#endif
+#endif
 
-// Conditionally defined in C++20-and-newer mode to specific values.
+#if _HAS_CXX20 && (defined(__clang__) || defined(__EDG__)) // TRANSITION, VSO-1020212
+#ifndef __cpp_lib_bitops
+#error Expected __cpp_lib_bitops to be defined.
+#elif __cpp_lib_bitops != 201907L
+#error Expected cpp_lib_bitops to equal 201907L.
+#else
+STATIC_ASSERT(__cpp_lib_bitops == 201907L);
+#endif
+#else
+#ifdef __cpp_lib_bitops
+#error Expected __cpp_lib_bitops to NOT be defined.
+#endif
+#endif
 
 #if _HAS_CXX20 && defined(__cpp_char8_t)
 #ifndef __cpp_lib_char8_t
@@ -1838,3 +1750,31 @@ STATIC_ASSERT(__cpp_lib_concepts == 201907L);
 #error Expected __cpp_lib_concepts to NOT be defined.
 #endif
 #endif
+
+#if _HAS_STD_BYTE
+#ifndef __cpp_lib_byte
+#error Expected __cpp_lib_byte to be defined.
+#elif __cpp_lib_byte != 201603L
+#error Expected cpp_lib_byte to equal 201603L.
+#else
+STATIC_ASSERT(__cpp_lib_byte == 201603L);
+#endif
+#else
+#ifdef __cpp_lib_byte
+#error Expected __cpp_lib_byte to NOT be defined.
+#endif
+#endif
+
+#ifdef _M_CEE
+#ifdef __cpp_lib_shared_timed_mutex
+#error Expected __cpp_lib_shared_timed_mutex to NOT be defined.
+#endif
+#else // ^^^ _M_CEE ^^^ // vvv !_M_CEE vvv
+#ifndef __cpp_lib_shared_timed_mutex
+#error Expected __cpp_lib_shared_timed_mutex to be defined.
+#elif __cpp_lib_shared_timed_mutex != 201402L
+#error Expected cpp_lib_shared_timed_mutex to equal 201402L.
+#else
+STATIC_ASSERT(__cpp_lib_shared_timed_mutex == 201402L);
+#endif
+#endif // _M_CEE

--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.cpp
@@ -22,49 +22,49 @@ int main() {} // COMPILE-ONLY
 #endif
 
 #if __has_cpp_attribute(carries_dependency) != 200809L
-#error has_cpp_attribute(carries_dependency) is not 200809L
+#error __has_cpp_attribute(carries_dependency) is not 200809L
 #endif
 
 #if __has_cpp_attribute(deprecated) != 201309L
-#error has_cpp_attribute(deprecated) is not 201309L
+#error __has_cpp_attribute(deprecated) is not 201309L
 #endif
 
 #if __has_cpp_attribute(noreturn) != 200809L
-#error has_cpp_attribute(noreturn) is not 200809L
+#error __has_cpp_attribute(noreturn) is not 200809L
 #endif
 
 #if defined(__clang__) || defined(__EDG__) // clang and EDG don't yet implement P1771R1
 #if __has_cpp_attribute(nodiscard) != 201603L
-#error has_cpp_attribute(nodiscard) is not 201603L
+#error __has_cpp_attribute(nodiscard) is not 201603L
 #endif
 #else
 #if __has_cpp_attribute(nodiscard) != 201907L
-#error has_cpp_attribute(nodiscard) is not 201907L
+#error __has_cpp_attribute(nodiscard) is not 201907L
 #endif
 #endif
 
 #if _HAS_CXX17 || defined(__clang__) || defined(__EDG__) // Clang and EDG provide this in C++14 mode.
 #if __has_cpp_attribute(fallthrough) != 201603L
-#error has_cpp_attribute(fallthrough) is not 201603L
+#error __has_cpp_attribute(fallthrough) is not 201603L
 #endif
 #else
 #if __has_cpp_attribute(fallthrough) != 0
-#error has_cpp_attribute(fallthrough) is not 0
+#error __has_cpp_attribute(fallthrough) is not 0
 #endif
 #endif
 
 #if _HAS_CXX17 || defined(__clang__) || defined(__EDG__) // Clang and EDG provide this in C++14 mode.
 #if __has_cpp_attribute(maybe_unused) != 201603L
-#error has_cpp_attribute(maybe_unused) is not 201603L
+#error __has_cpp_attribute(maybe_unused) is not 201603L
 #endif
 #else
 #if __has_cpp_attribute(maybe_unused) != 0
-#error has_cpp_attribute(maybe_unused) is not 0
+#error __has_cpp_attribute(maybe_unused) is not 0
 #endif
 #endif
 
 #if __has_cpp_attribute(noreturn) != 200809L
-#error has_cpp_attribute(noreturn) is not 200809L
+#error __has_cpp_attribute(noreturn) is not 200809L
 #endif
 
 
@@ -73,7 +73,7 @@ int main() {} // COMPILE-ONLY
 #ifndef __cpp_aggregate_nsdmi
 #error __cpp_aggregate_nsdmi is not defined
 #elif __cpp_aggregate_nsdmi != 201304L
-#error cpp_aggregate_nsdmi is not 201304L
+#error __cpp_aggregate_nsdmi is not 201304L
 #else
 STATIC_ASSERT(__cpp_aggregate_nsdmi == 201304L);
 #endif
@@ -81,7 +81,7 @@ STATIC_ASSERT(__cpp_aggregate_nsdmi == 201304L);
 #ifndef __cpp_alias_templates
 #error __cpp_alias_templates is not defined
 #elif __cpp_alias_templates != 200704L
-#error cpp_alias_templates is not 200704L
+#error __cpp_alias_templates is not 200704L
 #else
 STATIC_ASSERT(__cpp_alias_templates == 200704L);
 #endif
@@ -89,7 +89,7 @@ STATIC_ASSERT(__cpp_alias_templates == 200704L);
 #ifndef __cpp_attributes
 #error __cpp_attributes is not defined
 #elif __cpp_attributes != 200809L
-#error cpp_attributes is not 200809L
+#error __cpp_attributes is not 200809L
 #else
 STATIC_ASSERT(__cpp_attributes == 200809L);
 #endif
@@ -97,7 +97,7 @@ STATIC_ASSERT(__cpp_attributes == 200809L);
 #ifndef __cpp_binary_literals
 #error __cpp_binary_literals is not defined
 #elif __cpp_binary_literals != 201304L
-#error cpp_binary_literals is not 201304L
+#error __cpp_binary_literals is not 201304L
 #else
 STATIC_ASSERT(__cpp_binary_literals == 201304L);
 #endif
@@ -106,13 +106,13 @@ STATIC_ASSERT(__cpp_binary_literals == 201304L);
 #error __cpp_constexpr is not defined
 #elif _HAS_CXX17
 #if __cpp_constexpr != 201603L
-#error cpp_constexpr is not 201603L
+#error __cpp_constexpr is not 201603L
 #else
 STATIC_ASSERT(__cpp_constexpr == 201603L);
 #endif
 #else
 #if __cpp_constexpr != 201304L
-#error cpp_constexpr is not 201304L
+#error __cpp_constexpr is not 201304L
 #else
 STATIC_ASSERT(__cpp_constexpr == 201304L);
 #endif
@@ -121,7 +121,7 @@ STATIC_ASSERT(__cpp_constexpr == 201304L);
 #ifndef __cpp_decltype
 #error __cpp_decltype is not defined
 #elif __cpp_decltype != 200707L
-#error cpp_decltype is not 200707L
+#error __cpp_decltype is not 200707L
 #else
 STATIC_ASSERT(__cpp_decltype == 200707L);
 #endif
@@ -129,7 +129,7 @@ STATIC_ASSERT(__cpp_decltype == 200707L);
 #ifndef __cpp_decltype_auto
 #error __cpp_decltype_auto is not defined
 #elif __cpp_decltype_auto != 201304L
-#error cpp_decltype_auto is not 201304L
+#error __cpp_decltype_auto is not 201304L
 #else
 STATIC_ASSERT(__cpp_decltype_auto == 201304L);
 #endif
@@ -137,7 +137,7 @@ STATIC_ASSERT(__cpp_decltype_auto == 201304L);
 #ifndef __cpp_delegating_constructors
 #error __cpp_delegating_constructors is not defined
 #elif __cpp_delegating_constructors != 200604L
-#error cpp_delegating_constructors is not 200604L
+#error __cpp_delegating_constructors is not 200604L
 #else
 STATIC_ASSERT(__cpp_delegating_constructors == 200604L);
 #endif
@@ -145,7 +145,7 @@ STATIC_ASSERT(__cpp_delegating_constructors == 200604L);
 #ifndef __cpp_generic_lambdas
 #error __cpp_generic_lambdas is not defined
 #elif __cpp_generic_lambdas != 201304L
-#error cpp_generic_lambdas is not 201304L
+#error __cpp_generic_lambdas is not 201304L
 #else
 STATIC_ASSERT(__cpp_generic_lambdas == 201304L);
 #endif
@@ -155,13 +155,13 @@ STATIC_ASSERT(__cpp_generic_lambdas == 201304L);
 #elif (_HAS_CXX17 || defined(__clang__)) && !defined(__EDG__) // Clang implemented this C++17 feature unconditionally.
                                                               // TRANSITION, VSO-610203
 #if __cpp_inheriting_constructors != 201511L
-#error cpp_inheriting_constructors is not 201511L
+#error __cpp_inheriting_constructors is not 201511L
 #else
 STATIC_ASSERT(__cpp_inheriting_constructors == 201511L);
 #endif
 #else
 #if __cpp_inheriting_constructors != 200802L
-#error cpp_inheriting_constructors is not 200802L
+#error __cpp_inheriting_constructors is not 200802L
 #else
 STATIC_ASSERT(__cpp_inheriting_constructors == 200802L);
 #endif
@@ -170,7 +170,7 @@ STATIC_ASSERT(__cpp_inheriting_constructors == 200802L);
 #ifndef __cpp_init_captures
 #error __cpp_init_captures is not defined
 #elif __cpp_init_captures != 201304L
-#error cpp_init_captures is not 201304L
+#error __cpp_init_captures is not 201304L
 #else
 STATIC_ASSERT(__cpp_init_captures == 201304L);
 #endif
@@ -178,7 +178,7 @@ STATIC_ASSERT(__cpp_init_captures == 201304L);
 #ifndef __cpp_initializer_lists
 #error __cpp_initializer_lists is not defined
 #elif __cpp_initializer_lists != 200806L
-#error cpp_initializer_lists is not 200806L
+#error __cpp_initializer_lists is not 200806L
 #else
 STATIC_ASSERT(__cpp_initializer_lists == 200806L);
 #endif
@@ -186,7 +186,7 @@ STATIC_ASSERT(__cpp_initializer_lists == 200806L);
 #ifndef __cpp_lambdas
 #error __cpp_lambdas is not defined
 #elif __cpp_lambdas != 200907L
-#error cpp_lambdas is not 200907L
+#error __cpp_lambdas is not 200907L
 #else
 STATIC_ASSERT(__cpp_lambdas == 200907L);
 #endif
@@ -194,7 +194,7 @@ STATIC_ASSERT(__cpp_lambdas == 200907L);
 #ifndef __cpp_nsdmi
 #error __cpp_nsdmi is not defined
 #elif __cpp_nsdmi != 200809L
-#error cpp_nsdmi is not 200809L
+#error __cpp_nsdmi is not 200809L
 #else
 STATIC_ASSERT(__cpp_nsdmi == 200809L);
 #endif
@@ -203,13 +203,13 @@ STATIC_ASSERT(__cpp_nsdmi == 200809L);
 #error __cpp_range_based_for is not defined
 #elif !defined(__clang__) || _HAS_CXX17 // C1XX implemented this C++17 feature unconditionally.
 #if __cpp_range_based_for != 201603L
-#error cpp_range_based_for is not 201603L
+#error __cpp_range_based_for is not 201603L
 #else
 STATIC_ASSERT(__cpp_range_based_for == 201603L);
 #endif
 #else
 #if __cpp_range_based_for != 200907L
-#error cpp_range_based_for is not 200907L
+#error __cpp_range_based_for is not 200907L
 #else
 STATIC_ASSERT(__cpp_range_based_for == 200907L);
 #endif
@@ -218,7 +218,7 @@ STATIC_ASSERT(__cpp_range_based_for == 200907L);
 #ifndef __cpp_raw_strings
 #error __cpp_raw_strings is not defined
 #elif __cpp_raw_strings != 200710L
-#error cpp_raw_strings is not 200710L
+#error __cpp_raw_strings is not 200710L
 #else
 STATIC_ASSERT(__cpp_raw_strings == 200710L);
 #endif
@@ -226,7 +226,7 @@ STATIC_ASSERT(__cpp_raw_strings == 200710L);
 #ifndef __cpp_ref_qualifiers
 #error __cpp_ref_qualifiers is not defined
 #elif __cpp_ref_qualifiers != 200710L
-#error cpp_ref_qualifiers is not 200710L
+#error __cpp_ref_qualifiers is not 200710L
 #else
 STATIC_ASSERT(__cpp_ref_qualifiers == 200710L);
 #endif
@@ -234,7 +234,7 @@ STATIC_ASSERT(__cpp_ref_qualifiers == 200710L);
 #ifndef __cpp_return_type_deduction
 #error __cpp_return_type_deduction is not defined
 #elif __cpp_return_type_deduction != 201304L
-#error cpp_return_type_deduction is not 201304L
+#error __cpp_return_type_deduction is not 201304L
 #else
 STATIC_ASSERT(__cpp_return_type_deduction == 201304L);
 #endif
@@ -242,7 +242,7 @@ STATIC_ASSERT(__cpp_return_type_deduction == 201304L);
 #ifndef __cpp_rvalue_references
 #error __cpp_rvalue_references is not defined
 #elif __cpp_rvalue_references != 200610L
-#error cpp_rvalue_references is not 200610L
+#error __cpp_rvalue_references is not 200610L
 #else
 STATIC_ASSERT(__cpp_rvalue_references == 200610L);
 #endif
@@ -251,13 +251,13 @@ STATIC_ASSERT(__cpp_rvalue_references == 200610L);
 #error __cpp_static_assert is not defined
 #elif _HAS_CXX17
 #if __cpp_static_assert != 201411L
-#error cpp_static_assert is not 201411L
+#error __cpp_static_assert is not 201411L
 #else
 STATIC_ASSERT(__cpp_static_assert == 201411L);
 #endif
 #else
 #if __cpp_static_assert != 200410L
-#error cpp_static_assert is not 200410L
+#error __cpp_static_assert is not 200410L
 #else
 STATIC_ASSERT(__cpp_static_assert == 200410L);
 #endif
@@ -266,7 +266,7 @@ STATIC_ASSERT(__cpp_static_assert == 200410L);
 #ifndef __cpp_unicode_characters
 #error __cpp_unicode_characters is not defined
 #elif __cpp_unicode_characters != 200704L
-#error cpp_unicode_characters is not 200704L
+#error __cpp_unicode_characters is not 200704L
 #else
 STATIC_ASSERT(__cpp_unicode_characters == 200704L);
 #endif
@@ -274,7 +274,7 @@ STATIC_ASSERT(__cpp_unicode_characters == 200704L);
 #ifndef __cpp_unicode_literals
 #error __cpp_unicode_literals is not defined
 #elif __cpp_unicode_literals != 200710L
-#error cpp_unicode_literals is not 200710L
+#error __cpp_unicode_literals is not 200710L
 #else
 STATIC_ASSERT(__cpp_unicode_literals == 200710L);
 #endif
@@ -282,7 +282,7 @@ STATIC_ASSERT(__cpp_unicode_literals == 200710L);
 #ifndef __cpp_user_defined_literals
 #error __cpp_user_defined_literals is not defined
 #elif __cpp_user_defined_literals != 200809L
-#error cpp_user_defined_literals is not 200809L
+#error __cpp_user_defined_literals is not 200809L
 #else
 STATIC_ASSERT(__cpp_user_defined_literals == 200809L);
 #endif
@@ -290,7 +290,7 @@ STATIC_ASSERT(__cpp_user_defined_literals == 200809L);
 #ifndef __cpp_variable_templates
 #error __cpp_variable_templates is not defined
 #elif __cpp_variable_templates != 201304L
-#error cpp_variable_templates is not 201304L
+#error __cpp_variable_templates is not 201304L
 #else
 STATIC_ASSERT(__cpp_variable_templates == 201304L);
 #endif
@@ -298,7 +298,7 @@ STATIC_ASSERT(__cpp_variable_templates == 201304L);
 #ifndef __cpp_variadic_templates
 #error __cpp_variadic_templates is not defined
 #elif __cpp_variadic_templates != 200704L
-#error cpp_variadic_templates is not 200704L
+#error __cpp_variadic_templates is not 200704L
 #else
 STATIC_ASSERT(__cpp_variadic_templates == 200704L);
 #endif
@@ -307,7 +307,7 @@ STATIC_ASSERT(__cpp_variadic_templates == 200704L);
 #ifndef __cpp_aggregate_bases
 #error __cpp_aggregate_bases is not defined
 #elif __cpp_aggregate_bases != 201603L
-#error cpp_aggregate_bases is not 201603L
+#error __cpp_aggregate_bases is not 201603L
 #else
 STATIC_ASSERT(__cpp_aggregate_bases == 201603L);
 #endif
@@ -321,7 +321,7 @@ STATIC_ASSERT(__cpp_aggregate_bases == 201603L);
 #ifndef __cpp_capture_star_this
 #error __cpp_capture_star_this is not defined
 #elif __cpp_capture_star_this != 201603L
-#error cpp_capture_star_this is not 201603L
+#error __cpp_capture_star_this is not 201603L
 #else
 STATIC_ASSERT(__cpp_capture_star_this == 201603L);
 #endif
@@ -335,7 +335,7 @@ STATIC_ASSERT(__cpp_capture_star_this == 201603L);
 #ifndef __cpp_deduction_guides
 #error __cpp_deduction_guides is not defined
 #elif __cpp_deduction_guides != 201703L
-#error cpp_deduction_guides is not 201703L
+#error __cpp_deduction_guides is not 201703L
 #else
 STATIC_ASSERT(__cpp_deduction_guides == 201703L);
 #endif
@@ -349,7 +349,7 @@ STATIC_ASSERT(__cpp_deduction_guides == 201703L);
 #ifndef __cpp_fold_expressions
 #error __cpp_fold_expressions is not defined
 #elif __cpp_fold_expressions != 201603L
-#error cpp_fold_expressions is not 201603L
+#error __cpp_fold_expressions is not 201603L
 #else
 STATIC_ASSERT(__cpp_fold_expressions == 201603L);
 #endif
@@ -363,7 +363,7 @@ STATIC_ASSERT(__cpp_fold_expressions == 201603L);
 #ifndef __cpp_guaranteed_copy_elision
 #error __cpp_guaranteed_copy_elision is not defined
 #elif __cpp_guaranteed_copy_elision != 201606L
-#error cpp_guaranteed_copy_elision is not 201606L
+#error __cpp_guaranteed_copy_elision is not 201606L
 #else
 STATIC_ASSERT(__cpp_guaranteed_copy_elision == 201606L);
 #endif
@@ -377,7 +377,7 @@ STATIC_ASSERT(__cpp_guaranteed_copy_elision == 201606L);
 #ifndef __cpp_inline_variables
 #error __cpp_inline_variables is not defined
 #elif __cpp_inline_variables != 201606L
-#error cpp_inline_variables is not 201606L
+#error __cpp_inline_variables is not 201606L
 #else
 STATIC_ASSERT(__cpp_inline_variables == 201606L);
 #endif
@@ -391,7 +391,7 @@ STATIC_ASSERT(__cpp_inline_variables == 201606L);
 #ifndef __cpp_nontype_template_parameter_auto
 #error __cpp_nontype_template_parameter_auto is not defined
 #elif __cpp_nontype_template_parameter_auto != 201606L
-#error cpp_nontype_template_parameter_auto is not 201606L
+#error __cpp_nontype_template_parameter_auto is not 201606L
 #else
 STATIC_ASSERT(__cpp_nontype_template_parameter_auto == 201606L);
 #endif
@@ -405,7 +405,7 @@ STATIC_ASSERT(__cpp_nontype_template_parameter_auto == 201606L);
 #ifndef __cpp_structured_bindings
 #error __cpp_structured_bindings is not defined
 #elif __cpp_structured_bindings != 201606L
-#error cpp_structured_bindings is not 201606L
+#error __cpp_structured_bindings is not 201606L
 #else
 STATIC_ASSERT(__cpp_structured_bindings == 201606L);
 #endif
@@ -419,7 +419,7 @@ STATIC_ASSERT(__cpp_structured_bindings == 201606L);
 #ifndef __cpp_variadic_using
 #error __cpp_variadic_using is not defined
 #elif __cpp_variadic_using != 201611L
-#error cpp_variadic_using is not 201611L
+#error __cpp_variadic_using is not 201611L
 #else
 STATIC_ASSERT(__cpp_variadic_using == 201611L);
 #endif
@@ -440,7 +440,7 @@ STATIC_ASSERT(__cpp_variadic_using == 201611L);
 #ifndef __cpp_template_template_args
 #error __cpp_template_template_args is not defined
 #elif __cpp_template_template_args != 201611L
-#error cpp_template_template_args is not 201611L
+#error __cpp_template_template_args is not 201611L
 #else
 STATIC_ASSERT(__cpp_template_template_args == 201611L);
 #endif
@@ -454,7 +454,7 @@ STATIC_ASSERT(__cpp_template_template_args == 201611L);
 #ifndef __cpp_enumerator_attributes
 #error __cpp_enumerator_attributes is not defined
 #elif __cpp_enumerator_attributes != 201411L
-#error cpp_enumerator_attributes is not 201411L
+#error __cpp_enumerator_attributes is not 201411L
 #else
 STATIC_ASSERT(__cpp_enumerator_attributes == 201411L);
 #endif
@@ -468,7 +468,7 @@ STATIC_ASSERT(__cpp_enumerator_attributes == 201411L);
 #ifndef __cpp_namespace_attributes
 #error __cpp_namespace_attributes is not defined
 #elif __cpp_namespace_attributes != 201411L
-#error cpp_namespace_attributes is not 201411L
+#error __cpp_namespace_attributes is not 201411L
 #else
 STATIC_ASSERT(__cpp_namespace_attributes == 201411L);
 #endif
@@ -482,7 +482,7 @@ STATIC_ASSERT(__cpp_namespace_attributes == 201411L);
 #ifndef __cpp_if_constexpr
 #error __cpp_if_constexpr is not defined
 #elif __cpp_if_constexpr != 201606L
-#error cpp_if_constexpr is not 201606L
+#error __cpp_if_constexpr is not 201606L
 #else
 STATIC_ASSERT(__cpp_if_constexpr == 201606L);
 #endif
@@ -496,7 +496,7 @@ STATIC_ASSERT(__cpp_if_constexpr == 201606L);
 #ifndef __cpp_hex_float
 #error __cpp_hex_float is not defined
 #elif __cpp_hex_float != 201603L
-#error cpp_hex_float is not 201603L
+#error __cpp_hex_float is not 201603L
 #else
 STATIC_ASSERT(__cpp_hex_float == 201603L);
 #endif
@@ -512,13 +512,13 @@ STATIC_ASSERT(__cpp_hex_float == 201603L);
 #error __cpp_impl_three_way_comparison is not defined
 #elif defined(__EDG__) // EDG does not yet implement P1630R1 or P1186R3 so they still report the old value.
 #if __cpp_impl_three_way_comparison != 201711L
-#error cpp_impl_three_way_comparison is not 201711L
+#error __cpp_impl_three_way_comparison is not 201711L
 #else
 STATIC_ASSERT(__cpp_impl_three_way_comparison == 201711L);
 #endif
 #else
 #if __cpp_impl_three_way_comparison != 201907L
-#error cpp_impl_three_way_comparison is not 201907L
+#error __cpp_impl_three_way_comparison is not 201907L
 #else
 STATIC_ASSERT(__cpp_impl_three_way_comparison == 201907L);
 #endif
@@ -533,7 +533,7 @@ STATIC_ASSERT(__cpp_impl_three_way_comparison == 201907L);
 #ifndef __cpp_nontype_template_args
 #error __cpp_nontype_template_args is not defined
 #elif __cpp_nontype_template_args != 201911L
-#error cpp_nontype_template_args is not 201911L
+#error __cpp_nontype_template_args is not 201911L
 #else
 STATIC_ASSERT(__cpp_nontype_template_args == 201911L);
 #endif
@@ -541,7 +541,7 @@ STATIC_ASSERT(__cpp_nontype_template_args == 201911L);
 #ifndef __cpp_nontype_template_args
 #error __cpp_nontype_template_args is not defined
 #elif __cpp_nontype_template_args != 201411L
-#error cpp_nontype_template_args is not 201411L
+#error __cpp_nontype_template_args is not 201411L
 #else
 STATIC_ASSERT(__cpp_nontype_template_args == 201411L);
 #endif
@@ -556,7 +556,7 @@ STATIC_ASSERT(__cpp_nontype_template_args == 201411L);
 #ifndef __cpp_conditional_explicit
 #error __cpp_conditional_explicit is not defined
 #elif __cpp_conditional_explicit != 201806L
-#error cpp_conditional_explicit is not 201806L
+#error __cpp_conditional_explicit is not 201806L
 #else
 STATIC_ASSERT(__cpp_conditional_explicit == 201806L);
 #endif
@@ -575,7 +575,7 @@ STATIC_ASSERT(__cpp_conditional_explicit == 201806L);
 #ifndef __cpp_exceptions
 #error __cpp_exceptions is not defined
 #elif __cpp_exceptions != 199711L
-#error cpp_exceptions is not 199711L
+#error __cpp_exceptions is not 199711L
 #else
 STATIC_ASSERT(__cpp_exceptions == 199711L);
 #endif
@@ -601,7 +601,7 @@ STATIC_ASSERT(__cpp_exceptions == 199711L);
 #ifndef __cpp_threadsafe_static_init
 #error __cpp_threadsafe_static_init is not defined
 #elif __cpp_threadsafe_static_init != 200806L
-#error cpp_threadsafe_static_init is not 200806L
+#error __cpp_threadsafe_static_init is not 200806L
 #else
 STATIC_ASSERT(__cpp_threadsafe_static_init == 200806L);
 #endif
@@ -616,7 +616,7 @@ STATIC_ASSERT(__cpp_threadsafe_static_init == 200806L);
 #ifndef __cpp_sized_deallocation
 #error __cpp_sized_deallocation is not defined
 #elif __cpp_sized_deallocation != 201309L
-#error cpp_sized_deallocation is not 201309L
+#error __cpp_sized_deallocation is not 201309L
 #else
 STATIC_ASSERT(__cpp_sized_deallocation == 201309L);
 #endif
@@ -631,7 +631,7 @@ STATIC_ASSERT(__cpp_sized_deallocation == 201309L);
 #ifndef __cpp_aligned_new
 #error __cpp_aligned_new is not defined
 #elif __cpp_aligned_new != 201606L
-#error cpp_aligned_new is not 201606L
+#error __cpp_aligned_new is not 201606L
 #else
 STATIC_ASSERT(__cpp_aligned_new == 201606L);
 #endif
@@ -646,7 +646,7 @@ STATIC_ASSERT(__cpp_aligned_new == 201606L);
 #ifndef __cpp_noexcept_function_type
 #error __cpp_noexcept_function_type is not defined
 #elif __cpp_noexcept_function_type != 201510L
-#error cpp_noexcept_function_type is not 201510L
+#error __cpp_noexcept_function_type is not 201510L
 #else
 STATIC_ASSERT(__cpp_noexcept_function_type == 201510L);
 #endif
@@ -659,7 +659,7 @@ STATIC_ASSERT(__cpp_noexcept_function_type == 201510L);
 #ifndef __cpp_lib_addressof_constexpr
 #error __cpp_lib_addressof_constexpr is not defined
 #elif __cpp_lib_addressof_constexpr != 201603L
-#error cpp_lib_addressof_constexpr is not 201603L
+#error __cpp_lib_addressof_constexpr is not 201603L
 #else
 STATIC_ASSERT(__cpp_lib_addressof_constexpr == 201603L);
 #endif
@@ -667,7 +667,7 @@ STATIC_ASSERT(__cpp_lib_addressof_constexpr == 201603L);
 #ifndef __cpp_lib_allocator_traits_is_always_equal
 #error __cpp_lib_allocator_traits_is_always_equal is not defined
 #elif __cpp_lib_allocator_traits_is_always_equal != 201411L
-#error cpp_lib_allocator_traits_is_always_equal is not 201411L
+#error __cpp_lib_allocator_traits_is_always_equal is not 201411L
 #else
 STATIC_ASSERT(__cpp_lib_allocator_traits_is_always_equal == 201411L);
 #endif
@@ -675,7 +675,7 @@ STATIC_ASSERT(__cpp_lib_allocator_traits_is_always_equal == 201411L);
 #ifndef __cpp_lib_as_const
 #error __cpp_lib_as_const is not defined
 #elif __cpp_lib_as_const != 201510L
-#error cpp_lib_as_const is not 201510L
+#error __cpp_lib_as_const is not 201510L
 #else
 STATIC_ASSERT(__cpp_lib_as_const == 201510L);
 #endif
@@ -683,7 +683,7 @@ STATIC_ASSERT(__cpp_lib_as_const == 201510L);
 #ifndef __cpp_lib_atomic_value_initialization
 #error __cpp_lib_atomic_value_initialization is not defined
 #elif __cpp_lib_atomic_value_initialization != 201911L
-#error cpp_lib_atomic_value_initialization is not 201911L
+#error __cpp_lib_atomic_value_initialization is not 201911L
 #else
 STATIC_ASSERT(__cpp_lib_atomic_value_initialization == 201911L);
 #endif
@@ -691,7 +691,7 @@ STATIC_ASSERT(__cpp_lib_atomic_value_initialization == 201911L);
 #ifndef __cpp_lib_bool_constant
 #error __cpp_lib_bool_constant is not defined
 #elif __cpp_lib_bool_constant != 201505L
-#error cpp_lib_bool_constant is not 201505L
+#error __cpp_lib_bool_constant is not 201505L
 #else
 STATIC_ASSERT(__cpp_lib_bool_constant == 201505L);
 #endif
@@ -700,13 +700,13 @@ STATIC_ASSERT(__cpp_lib_bool_constant == 201505L);
 #error __cpp_lib_chrono is not defined
 #elif _HAS_CXX17
 #if __cpp_lib_chrono != 201611L
-#error cpp_lib_chrono is not 201611L
+#error __cpp_lib_chrono is not 201611L
 #else
 STATIC_ASSERT(__cpp_lib_chrono == 201611L);
 #endif
 #else
 #if __cpp_lib_chrono != 201510L
-#error cpp_lib_chrono is not 201510L
+#error __cpp_lib_chrono is not 201510L
 #else
 STATIC_ASSERT(__cpp_lib_chrono == 201510L);
 #endif
@@ -715,7 +715,7 @@ STATIC_ASSERT(__cpp_lib_chrono == 201510L);
 #ifndef __cpp_lib_chrono_udls
 #error __cpp_lib_chrono_udls is not defined
 #elif __cpp_lib_chrono_udls != 201304L
-#error cpp_lib_chrono_udls is not 201304L
+#error __cpp_lib_chrono_udls is not 201304L
 #else
 STATIC_ASSERT(__cpp_lib_chrono_udls == 201304L);
 #endif
@@ -723,7 +723,7 @@ STATIC_ASSERT(__cpp_lib_chrono_udls == 201304L);
 #ifndef __cpp_lib_complex_udls
 #error __cpp_lib_complex_udls is not defined
 #elif __cpp_lib_complex_udls != 201309L
-#error cpp_lib_complex_udls is not 201309L
+#error __cpp_lib_complex_udls is not 201309L
 #else
 STATIC_ASSERT(__cpp_lib_complex_udls == 201309L);
 #endif
@@ -731,7 +731,7 @@ STATIC_ASSERT(__cpp_lib_complex_udls == 201309L);
 #ifndef __cpp_lib_enable_shared_from_this
 #error __cpp_lib_enable_shared_from_this is not defined
 #elif __cpp_lib_enable_shared_from_this != 201603L
-#error cpp_lib_enable_shared_from_this is not 201603L
+#error __cpp_lib_enable_shared_from_this is not 201603L
 #else
 STATIC_ASSERT(__cpp_lib_enable_shared_from_this == 201603L);
 #endif
@@ -739,7 +739,7 @@ STATIC_ASSERT(__cpp_lib_enable_shared_from_this == 201603L);
 #ifndef __cpp_lib_exchange_function
 #error __cpp_lib_exchange_function is not defined
 #elif __cpp_lib_exchange_function != 201304L
-#error cpp_lib_exchange_function is not 201304L
+#error __cpp_lib_exchange_function is not 201304L
 #else
 STATIC_ASSERT(__cpp_lib_exchange_function == 201304L);
 #endif
@@ -747,7 +747,7 @@ STATIC_ASSERT(__cpp_lib_exchange_function == 201304L);
 #ifndef __cpp_lib_experimental_erase_if
 #error __cpp_lib_experimental_erase_if is not defined
 #elif __cpp_lib_experimental_erase_if != 201411L
-#error cpp_lib_experimental_erase_if is not 201411L
+#error __cpp_lib_experimental_erase_if is not 201411L
 #else
 STATIC_ASSERT(__cpp_lib_experimental_erase_if == 201411L);
 #endif
@@ -755,7 +755,7 @@ STATIC_ASSERT(__cpp_lib_experimental_erase_if == 201411L);
 #ifndef __cpp_lib_experimental_filesystem
 #error __cpp_lib_experimental_filesystem is not defined
 #elif __cpp_lib_experimental_filesystem != 201406L
-#error cpp_lib_experimental_filesystem is not 201406L
+#error __cpp_lib_experimental_filesystem is not 201406L
 #else
 STATIC_ASSERT(__cpp_lib_experimental_filesystem == 201406L);
 #endif
@@ -763,7 +763,7 @@ STATIC_ASSERT(__cpp_lib_experimental_filesystem == 201406L);
 #ifndef __cpp_lib_generic_associative_lookup
 #error __cpp_lib_generic_associative_lookup is not defined
 #elif __cpp_lib_generic_associative_lookup != 201304L
-#error cpp_lib_generic_associative_lookup is not 201304L
+#error __cpp_lib_generic_associative_lookup is not 201304L
 #else
 STATIC_ASSERT(__cpp_lib_generic_associative_lookup == 201304L);
 #endif
@@ -771,7 +771,7 @@ STATIC_ASSERT(__cpp_lib_generic_associative_lookup == 201304L);
 #ifndef __cpp_lib_incomplete_container_elements
 #error __cpp_lib_incomplete_container_elements is not defined
 #elif __cpp_lib_incomplete_container_elements != 201505L
-#error cpp_lib_incomplete_container_elements is not 201505L
+#error __cpp_lib_incomplete_container_elements is not 201505L
 #else
 STATIC_ASSERT(__cpp_lib_incomplete_container_elements == 201505L);
 #endif
@@ -779,7 +779,7 @@ STATIC_ASSERT(__cpp_lib_incomplete_container_elements == 201505L);
 #ifndef __cpp_lib_integer_sequence
 #error __cpp_lib_integer_sequence is not defined
 #elif __cpp_lib_integer_sequence != 201304L
-#error cpp_lib_integer_sequence is not 201304L
+#error __cpp_lib_integer_sequence is not 201304L
 #else
 STATIC_ASSERT(__cpp_lib_integer_sequence == 201304L);
 #endif
@@ -787,7 +787,7 @@ STATIC_ASSERT(__cpp_lib_integer_sequence == 201304L);
 #ifndef __cpp_lib_integral_constant_callable
 #error __cpp_lib_integral_constant_callable is not defined
 #elif __cpp_lib_integral_constant_callable != 201304L
-#error cpp_lib_integral_constant_callable is not 201304L
+#error __cpp_lib_integral_constant_callable is not 201304L
 #else
 STATIC_ASSERT(__cpp_lib_integral_constant_callable == 201304L);
 #endif
@@ -795,7 +795,7 @@ STATIC_ASSERT(__cpp_lib_integral_constant_callable == 201304L);
 #ifndef __cpp_lib_invoke
 #error __cpp_lib_invoke is not defined
 #elif __cpp_lib_invoke != 201411L
-#error cpp_lib_invoke is not 201411L
+#error __cpp_lib_invoke is not 201411L
 #else
 STATIC_ASSERT(__cpp_lib_invoke == 201411L);
 #endif
@@ -803,7 +803,7 @@ STATIC_ASSERT(__cpp_lib_invoke == 201411L);
 #ifndef __cpp_lib_is_final
 #error __cpp_lib_is_final is not defined
 #elif __cpp_lib_is_final != 201402L
-#error cpp_lib_is_final is not 201402L
+#error __cpp_lib_is_final is not 201402L
 #else
 STATIC_ASSERT(__cpp_lib_is_final == 201402L);
 #endif
@@ -811,7 +811,7 @@ STATIC_ASSERT(__cpp_lib_is_final == 201402L);
 #ifndef __cpp_lib_is_null_pointer
 #error __cpp_lib_is_null_pointer is not defined
 #elif __cpp_lib_is_null_pointer != 201309L
-#error cpp_lib_is_null_pointer is not 201309L
+#error __cpp_lib_is_null_pointer is not 201309L
 #else
 STATIC_ASSERT(__cpp_lib_is_null_pointer == 201309L);
 #endif
@@ -819,7 +819,7 @@ STATIC_ASSERT(__cpp_lib_is_null_pointer == 201309L);
 #ifndef __cpp_lib_logical_traits
 #error __cpp_lib_logical_traits is not defined
 #elif __cpp_lib_logical_traits != 201510L
-#error cpp_lib_logical_traits is not 201510L
+#error __cpp_lib_logical_traits is not 201510L
 #else
 STATIC_ASSERT(__cpp_lib_logical_traits == 201510L);
 #endif
@@ -827,7 +827,7 @@ STATIC_ASSERT(__cpp_lib_logical_traits == 201510L);
 #ifndef __cpp_lib_make_reverse_iterator
 #error __cpp_lib_make_reverse_iterator is not defined
 #elif __cpp_lib_make_reverse_iterator != 201402L
-#error cpp_lib_make_reverse_iterator is not 201402L
+#error __cpp_lib_make_reverse_iterator is not 201402L
 #else
 STATIC_ASSERT(__cpp_lib_make_reverse_iterator == 201402L);
 #endif
@@ -835,7 +835,7 @@ STATIC_ASSERT(__cpp_lib_make_reverse_iterator == 201402L);
 #ifndef __cpp_lib_make_unique
 #error __cpp_lib_make_unique is not defined
 #elif __cpp_lib_make_unique != 201304L
-#error cpp_lib_make_unique is not 201304L
+#error __cpp_lib_make_unique is not 201304L
 #else
 STATIC_ASSERT(__cpp_lib_make_unique == 201304L);
 #endif
@@ -843,7 +843,7 @@ STATIC_ASSERT(__cpp_lib_make_unique == 201304L);
 #ifndef __cpp_lib_map_try_emplace
 #error __cpp_lib_map_try_emplace is not defined
 #elif __cpp_lib_map_try_emplace != 201411L
-#error cpp_lib_map_try_emplace is not 201411L
+#error __cpp_lib_map_try_emplace is not 201411L
 #else
 STATIC_ASSERT(__cpp_lib_map_try_emplace == 201411L);
 #endif
@@ -851,7 +851,7 @@ STATIC_ASSERT(__cpp_lib_map_try_emplace == 201411L);
 #ifndef __cpp_lib_nonmember_container_access
 #error __cpp_lib_nonmember_container_access is not defined
 #elif __cpp_lib_nonmember_container_access != 201411L
-#error cpp_lib_nonmember_container_access is not 201411L
+#error __cpp_lib_nonmember_container_access is not 201411L
 #else
 STATIC_ASSERT(__cpp_lib_nonmember_container_access == 201411L);
 #endif
@@ -859,7 +859,7 @@ STATIC_ASSERT(__cpp_lib_nonmember_container_access == 201411L);
 #ifndef __cpp_lib_null_iterators
 #error __cpp_lib_null_iterators is not defined
 #elif __cpp_lib_null_iterators != 201304L
-#error cpp_lib_null_iterators is not 201304L
+#error __cpp_lib_null_iterators is not 201304L
 #else
 STATIC_ASSERT(__cpp_lib_null_iterators == 201304L);
 #endif
@@ -867,7 +867,7 @@ STATIC_ASSERT(__cpp_lib_null_iterators == 201304L);
 #ifndef __cpp_lib_quoted_string_io
 #error __cpp_lib_quoted_string_io is not defined
 #elif __cpp_lib_quoted_string_io != 201304L
-#error cpp_lib_quoted_string_io is not 201304L
+#error __cpp_lib_quoted_string_io is not 201304L
 #else
 STATIC_ASSERT(__cpp_lib_quoted_string_io == 201304L);
 #endif
@@ -875,7 +875,7 @@ STATIC_ASSERT(__cpp_lib_quoted_string_io == 201304L);
 #ifndef __cpp_lib_result_of_sfinae
 #error __cpp_lib_result_of_sfinae is not defined
 #elif __cpp_lib_result_of_sfinae != 201210L
-#error cpp_lib_result_of_sfinae is not 201210L
+#error __cpp_lib_result_of_sfinae is not 201210L
 #else
 STATIC_ASSERT(__cpp_lib_result_of_sfinae == 201210L);
 #endif
@@ -883,7 +883,7 @@ STATIC_ASSERT(__cpp_lib_result_of_sfinae == 201210L);
 #ifndef __cpp_lib_robust_nonmodifying_seq_ops
 #error __cpp_lib_robust_nonmodifying_seq_ops is not defined
 #elif __cpp_lib_robust_nonmodifying_seq_ops != 201304L
-#error cpp_lib_robust_nonmodifying_seq_ops is not 201304L
+#error __cpp_lib_robust_nonmodifying_seq_ops is not 201304L
 #else
 STATIC_ASSERT(__cpp_lib_robust_nonmodifying_seq_ops == 201304L);
 #endif
@@ -891,7 +891,7 @@ STATIC_ASSERT(__cpp_lib_robust_nonmodifying_seq_ops == 201304L);
 #ifndef __cpp_lib_shared_mutex
 #error __cpp_lib_shared_mutex is not defined
 #elif __cpp_lib_shared_mutex != 201505L
-#error cpp_lib_shared_mutex is not 201505L
+#error __cpp_lib_shared_mutex is not 201505L
 #else
 STATIC_ASSERT(__cpp_lib_shared_mutex == 201505L);
 #endif
@@ -899,7 +899,7 @@ STATIC_ASSERT(__cpp_lib_shared_mutex == 201505L);
 #ifndef __cpp_lib_shared_ptr_arrays
 #error __cpp_lib_shared_ptr_arrays is not defined
 #elif __cpp_lib_shared_ptr_arrays != 201611L
-#error cpp_lib_shared_ptr_arrays is not 201611L
+#error __cpp_lib_shared_ptr_arrays is not 201611L
 #else
 STATIC_ASSERT(__cpp_lib_shared_ptr_arrays == 201611L);
 #endif
@@ -907,7 +907,7 @@ STATIC_ASSERT(__cpp_lib_shared_ptr_arrays == 201611L);
 #ifndef __cpp_lib_string_udls
 #error __cpp_lib_string_udls is not defined
 #elif __cpp_lib_string_udls != 201304L
-#error cpp_lib_string_udls is not 201304L
+#error __cpp_lib_string_udls is not 201304L
 #else
 STATIC_ASSERT(__cpp_lib_string_udls == 201304L);
 #endif
@@ -915,7 +915,7 @@ STATIC_ASSERT(__cpp_lib_string_udls == 201304L);
 #ifndef __cpp_lib_transformation_trait_aliases
 #error __cpp_lib_transformation_trait_aliases is not defined
 #elif __cpp_lib_transformation_trait_aliases != 201304L
-#error cpp_lib_transformation_trait_aliases is not 201304L
+#error __cpp_lib_transformation_trait_aliases is not 201304L
 #else
 STATIC_ASSERT(__cpp_lib_transformation_trait_aliases == 201304L);
 #endif
@@ -923,7 +923,7 @@ STATIC_ASSERT(__cpp_lib_transformation_trait_aliases == 201304L);
 #ifndef __cpp_lib_transparent_operators
 #error __cpp_lib_transparent_operators is not defined
 #elif __cpp_lib_transparent_operators != 201510L
-#error cpp_lib_transparent_operators is not 201510L
+#error __cpp_lib_transparent_operators is not 201510L
 #else
 STATIC_ASSERT(__cpp_lib_transparent_operators == 201510L);
 #endif
@@ -931,7 +931,7 @@ STATIC_ASSERT(__cpp_lib_transparent_operators == 201510L);
 #ifndef __cpp_lib_tuple_element_t
 #error __cpp_lib_tuple_element_t is not defined
 #elif __cpp_lib_tuple_element_t != 201402L
-#error cpp_lib_tuple_element_t is not 201402L
+#error __cpp_lib_tuple_element_t is not 201402L
 #else
 STATIC_ASSERT(__cpp_lib_tuple_element_t == 201402L);
 #endif
@@ -939,7 +939,7 @@ STATIC_ASSERT(__cpp_lib_tuple_element_t == 201402L);
 #ifndef __cpp_lib_tuples_by_type
 #error __cpp_lib_tuples_by_type is not defined
 #elif __cpp_lib_tuples_by_type != 201304L
-#error cpp_lib_tuples_by_type is not 201304L
+#error __cpp_lib_tuples_by_type is not 201304L
 #else
 STATIC_ASSERT(__cpp_lib_tuples_by_type == 201304L);
 #endif
@@ -947,7 +947,7 @@ STATIC_ASSERT(__cpp_lib_tuples_by_type == 201304L);
 #ifndef __cpp_lib_type_trait_variable_templates
 #error __cpp_lib_type_trait_variable_templates is not defined
 #elif __cpp_lib_type_trait_variable_templates != 201510L
-#error cpp_lib_type_trait_variable_templates is not 201510L
+#error __cpp_lib_type_trait_variable_templates is not 201510L
 #else
 STATIC_ASSERT(__cpp_lib_type_trait_variable_templates == 201510L);
 #endif
@@ -955,7 +955,7 @@ STATIC_ASSERT(__cpp_lib_type_trait_variable_templates == 201510L);
 #ifndef __cpp_lib_uncaught_exceptions
 #error __cpp_lib_uncaught_exceptions is not defined
 #elif __cpp_lib_uncaught_exceptions != 201411L
-#error cpp_lib_uncaught_exceptions is not 201411L
+#error __cpp_lib_uncaught_exceptions is not 201411L
 #else
 STATIC_ASSERT(__cpp_lib_uncaught_exceptions == 201411L);
 #endif
@@ -963,7 +963,7 @@ STATIC_ASSERT(__cpp_lib_uncaught_exceptions == 201411L);
 #ifndef __cpp_lib_unordered_map_try_emplace
 #error __cpp_lib_unordered_map_try_emplace is not defined
 #elif __cpp_lib_unordered_map_try_emplace != 201411L
-#error cpp_lib_unordered_map_try_emplace is not 201411L
+#error __cpp_lib_unordered_map_try_emplace is not 201411L
 #else
 STATIC_ASSERT(__cpp_lib_unordered_map_try_emplace == 201411L);
 #endif
@@ -971,7 +971,7 @@ STATIC_ASSERT(__cpp_lib_unordered_map_try_emplace == 201411L);
 #ifndef __cpp_lib_void_t
 #error __cpp_lib_void_t is not defined
 #elif __cpp_lib_void_t != 201411L
-#error cpp_lib_void_t is not 201411L
+#error __cpp_lib_void_t is not 201411L
 #else
 STATIC_ASSERT(__cpp_lib_void_t == 201411L);
 #endif
@@ -980,7 +980,7 @@ STATIC_ASSERT(__cpp_lib_void_t == 201411L);
 #ifndef __cpp_lib_any
 #error __cpp_lib_any is not defined
 #elif __cpp_lib_any != 201606L
-#error cpp_lib_any is not 201606L
+#error __cpp_lib_any is not 201606L
 #else
 STATIC_ASSERT(__cpp_lib_any == 201606L);
 #endif
@@ -994,7 +994,7 @@ STATIC_ASSERT(__cpp_lib_any == 201606L);
 #ifndef __cpp_lib_apply
 #error __cpp_lib_apply is not defined
 #elif __cpp_lib_apply != 201603L
-#error cpp_lib_apply is not 201603L
+#error __cpp_lib_apply is not 201603L
 #else
 STATIC_ASSERT(__cpp_lib_apply == 201603L);
 #endif
@@ -1008,7 +1008,7 @@ STATIC_ASSERT(__cpp_lib_apply == 201603L);
 #ifndef __cpp_lib_array_constexpr
 #error __cpp_lib_array_constexpr is not defined
 #elif __cpp_lib_array_constexpr != 201803L
-#error cpp_lib_array_constexpr is not 201803L
+#error __cpp_lib_array_constexpr is not 201803L
 #else
 STATIC_ASSERT(__cpp_lib_array_constexpr == 201803L);
 #endif
@@ -1022,7 +1022,7 @@ STATIC_ASSERT(__cpp_lib_array_constexpr == 201803L);
 #ifndef __cpp_lib_atomic_is_always_lock_free
 #error __cpp_lib_atomic_is_always_lock_free is not defined
 #elif __cpp_lib_atomic_is_always_lock_free != 201603L
-#error cpp_lib_atomic_is_always_lock_free is not 201603L
+#error __cpp_lib_atomic_is_always_lock_free is not 201603L
 #else
 STATIC_ASSERT(__cpp_lib_atomic_is_always_lock_free == 201603L);
 #endif
@@ -1036,7 +1036,7 @@ STATIC_ASSERT(__cpp_lib_atomic_is_always_lock_free == 201603L);
 #ifndef __cpp_lib_boyer_moore_searcher
 #error __cpp_lib_boyer_moore_searcher is not defined
 #elif __cpp_lib_boyer_moore_searcher != 201603L
-#error cpp_lib_boyer_moore_searcher is not 201603L
+#error __cpp_lib_boyer_moore_searcher is not 201603L
 #else
 STATIC_ASSERT(__cpp_lib_boyer_moore_searcher == 201603L);
 #endif
@@ -1050,7 +1050,7 @@ STATIC_ASSERT(__cpp_lib_boyer_moore_searcher == 201603L);
 #ifndef __cpp_lib_clamp
 #error __cpp_lib_clamp is not defined
 #elif __cpp_lib_clamp != 201603L
-#error cpp_lib_clamp is not 201603L
+#error __cpp_lib_clamp is not 201603L
 #else
 STATIC_ASSERT(__cpp_lib_clamp == 201603L);
 #endif
@@ -1064,7 +1064,7 @@ STATIC_ASSERT(__cpp_lib_clamp == 201603L);
 #ifndef __cpp_lib_filesystem
 #error __cpp_lib_filesystem is not defined
 #elif __cpp_lib_filesystem != 201703L
-#error cpp_lib_filesystem is not 201703L
+#error __cpp_lib_filesystem is not 201703L
 #else
 STATIC_ASSERT(__cpp_lib_filesystem == 201703L);
 #endif
@@ -1078,7 +1078,7 @@ STATIC_ASSERT(__cpp_lib_filesystem == 201703L);
 #ifndef __cpp_lib_gcd_lcm
 #error __cpp_lib_gcd_lcm is not defined
 #elif __cpp_lib_gcd_lcm != 201606L
-#error cpp_lib_gcd_lcm is not 201606L
+#error __cpp_lib_gcd_lcm is not 201606L
 #else
 STATIC_ASSERT(__cpp_lib_gcd_lcm == 201606L);
 #endif
@@ -1092,7 +1092,7 @@ STATIC_ASSERT(__cpp_lib_gcd_lcm == 201606L);
 #ifndef __cpp_lib_hardware_interference_size
 #error __cpp_lib_hardware_interference_size is not defined
 #elif __cpp_lib_hardware_interference_size != 201703L
-#error cpp_lib_hardware_interference_size is not 201703L
+#error __cpp_lib_hardware_interference_size is not 201703L
 #else
 STATIC_ASSERT(__cpp_lib_hardware_interference_size == 201703L);
 #endif
@@ -1106,7 +1106,7 @@ STATIC_ASSERT(__cpp_lib_hardware_interference_size == 201703L);
 #ifndef __cpp_lib_has_unique_object_representations
 #error __cpp_lib_has_unique_object_representations is not defined
 #elif __cpp_lib_has_unique_object_representations != 201606L
-#error cpp_lib_has_unique_object_representations is not 201606L
+#error __cpp_lib_has_unique_object_representations is not 201606L
 #else
 STATIC_ASSERT(__cpp_lib_has_unique_object_representations == 201606L);
 #endif
@@ -1120,7 +1120,7 @@ STATIC_ASSERT(__cpp_lib_has_unique_object_representations == 201606L);
 #ifndef __cpp_lib_hypot
 #error __cpp_lib_hypot is not defined
 #elif __cpp_lib_hypot != 201603L
-#error cpp_lib_hypot is not 201603L
+#error __cpp_lib_hypot is not 201603L
 #else
 STATIC_ASSERT(__cpp_lib_hypot == 201603L);
 #endif
@@ -1134,7 +1134,7 @@ STATIC_ASSERT(__cpp_lib_hypot == 201603L);
 #ifndef __cpp_lib_is_aggregate
 #error __cpp_lib_is_aggregate is not defined
 #elif __cpp_lib_is_aggregate != 201703L
-#error cpp_lib_is_aggregate is not 201703L
+#error __cpp_lib_is_aggregate is not 201703L
 #else
 STATIC_ASSERT(__cpp_lib_is_aggregate == 201703L);
 #endif
@@ -1148,7 +1148,7 @@ STATIC_ASSERT(__cpp_lib_is_aggregate == 201703L);
 #ifndef __cpp_lib_is_invocable
 #error __cpp_lib_is_invocable is not defined
 #elif __cpp_lib_is_invocable != 201703L
-#error cpp_lib_is_invocable is not 201703L
+#error __cpp_lib_is_invocable is not 201703L
 #else
 STATIC_ASSERT(__cpp_lib_is_invocable == 201703L);
 #endif
@@ -1162,7 +1162,7 @@ STATIC_ASSERT(__cpp_lib_is_invocable == 201703L);
 #ifndef __cpp_lib_is_swappable
 #error __cpp_lib_is_swappable is not defined
 #elif __cpp_lib_is_swappable != 201603L
-#error cpp_lib_is_swappable is not 201603L
+#error __cpp_lib_is_swappable is not 201603L
 #else
 STATIC_ASSERT(__cpp_lib_is_swappable == 201603L);
 #endif
@@ -1176,7 +1176,7 @@ STATIC_ASSERT(__cpp_lib_is_swappable == 201603L);
 #ifndef __cpp_lib_launder
 #error __cpp_lib_launder is not defined
 #elif __cpp_lib_launder != 201606L
-#error cpp_lib_launder is not 201606L
+#error __cpp_lib_launder is not 201606L
 #else
 STATIC_ASSERT(__cpp_lib_launder == 201606L);
 #endif
@@ -1190,7 +1190,7 @@ STATIC_ASSERT(__cpp_lib_launder == 201606L);
 #ifndef __cpp_lib_make_from_tuple
 #error __cpp_lib_make_from_tuple is not defined
 #elif __cpp_lib_make_from_tuple != 201606L
-#error cpp_lib_make_from_tuple is not 201606L
+#error __cpp_lib_make_from_tuple is not 201606L
 #else
 STATIC_ASSERT(__cpp_lib_make_from_tuple == 201606L);
 #endif
@@ -1204,7 +1204,7 @@ STATIC_ASSERT(__cpp_lib_make_from_tuple == 201606L);
 #ifndef __cpp_lib_math_special_functions
 #error __cpp_lib_math_special_functions is not defined
 #elif __cpp_lib_math_special_functions != 201603L
-#error cpp_lib_math_special_functions is not 201603L
+#error __cpp_lib_math_special_functions is not 201603L
 #else
 STATIC_ASSERT(__cpp_lib_math_special_functions == 201603L);
 #endif
@@ -1218,7 +1218,7 @@ STATIC_ASSERT(__cpp_lib_math_special_functions == 201603L);
 #ifndef __cpp_lib_memory_resource
 #error __cpp_lib_memory_resource is not defined
 #elif __cpp_lib_memory_resource != 201603L
-#error cpp_lib_memory_resource is not 201603L
+#error __cpp_lib_memory_resource is not 201603L
 #else
 STATIC_ASSERT(__cpp_lib_memory_resource == 201603L);
 #endif
@@ -1232,7 +1232,7 @@ STATIC_ASSERT(__cpp_lib_memory_resource == 201603L);
 #ifndef __cpp_lib_node_extract
 #error __cpp_lib_node_extract is not defined
 #elif __cpp_lib_node_extract != 201606L
-#error cpp_lib_node_extract is not 201606L
+#error __cpp_lib_node_extract is not 201606L
 #else
 STATIC_ASSERT(__cpp_lib_node_extract == 201606L);
 #endif
@@ -1246,7 +1246,7 @@ STATIC_ASSERT(__cpp_lib_node_extract == 201606L);
 #ifndef __cpp_lib_not_fn
 #error __cpp_lib_not_fn is not defined
 #elif __cpp_lib_not_fn != 201603L
-#error cpp_lib_not_fn is not 201603L
+#error __cpp_lib_not_fn is not 201603L
 #else
 STATIC_ASSERT(__cpp_lib_not_fn == 201603L);
 #endif
@@ -1260,7 +1260,7 @@ STATIC_ASSERT(__cpp_lib_not_fn == 201603L);
 #ifndef __cpp_lib_optional
 #error __cpp_lib_optional is not defined
 #elif __cpp_lib_optional != 201606L
-#error cpp_lib_optional is not 201606L
+#error __cpp_lib_optional is not 201606L
 #else
 STATIC_ASSERT(__cpp_lib_optional == 201606L);
 #endif
@@ -1274,7 +1274,7 @@ STATIC_ASSERT(__cpp_lib_optional == 201606L);
 #ifndef __cpp_lib_raw_memory_algorithms
 #error __cpp_lib_raw_memory_algorithms is not defined
 #elif __cpp_lib_raw_memory_algorithms != 201606L
-#error cpp_lib_raw_memory_algorithms is not 201606L
+#error __cpp_lib_raw_memory_algorithms is not 201606L
 #else
 STATIC_ASSERT(__cpp_lib_raw_memory_algorithms == 201606L);
 #endif
@@ -1288,7 +1288,7 @@ STATIC_ASSERT(__cpp_lib_raw_memory_algorithms == 201606L);
 #ifndef __cpp_lib_sample
 #error __cpp_lib_sample is not defined
 #elif __cpp_lib_sample != 201603L
-#error cpp_lib_sample is not 201603L
+#error __cpp_lib_sample is not 201603L
 #else
 STATIC_ASSERT(__cpp_lib_sample == 201603L);
 #endif
@@ -1302,7 +1302,7 @@ STATIC_ASSERT(__cpp_lib_sample == 201603L);
 #ifndef __cpp_lib_scoped_lock
 #error __cpp_lib_scoped_lock is not defined
 #elif __cpp_lib_scoped_lock != 201703L
-#error cpp_lib_scoped_lock is not 201703L
+#error __cpp_lib_scoped_lock is not 201703L
 #else
 STATIC_ASSERT(__cpp_lib_scoped_lock == 201703L);
 #endif
@@ -1316,7 +1316,7 @@ STATIC_ASSERT(__cpp_lib_scoped_lock == 201703L);
 #ifndef __cpp_lib_shared_ptr_weak_type
 #error __cpp_lib_shared_ptr_weak_type is not defined
 #elif __cpp_lib_shared_ptr_weak_type != 201606L
-#error cpp_lib_shared_ptr_weak_type is not 201606L
+#error __cpp_lib_shared_ptr_weak_type is not 201606L
 #else
 STATIC_ASSERT(__cpp_lib_shared_ptr_weak_type == 201606L);
 #endif
@@ -1330,7 +1330,7 @@ STATIC_ASSERT(__cpp_lib_shared_ptr_weak_type == 201606L);
 #ifndef __cpp_lib_string_view
 #error __cpp_lib_string_view is not defined
 #elif __cpp_lib_string_view != 201803L
-#error cpp_lib_string_view is not 201803L
+#error __cpp_lib_string_view is not 201803L
 #else
 STATIC_ASSERT(__cpp_lib_string_view == 201803L);
 #endif
@@ -1344,7 +1344,7 @@ STATIC_ASSERT(__cpp_lib_string_view == 201803L);
 #ifndef __cpp_lib_to_chars
 #error __cpp_lib_to_chars is not defined
 #elif __cpp_lib_to_chars != 201611L
-#error cpp_lib_to_chars is not 201611L
+#error __cpp_lib_to_chars is not 201611L
 #else
 STATIC_ASSERT(__cpp_lib_to_chars == 201611L);
 #endif
@@ -1358,7 +1358,7 @@ STATIC_ASSERT(__cpp_lib_to_chars == 201611L);
 #ifndef __cpp_lib_variant
 #error __cpp_lib_variant is not defined
 #elif __cpp_lib_variant != 201606L
-#error cpp_lib_variant is not 201606L
+#error __cpp_lib_variant is not 201606L
 #else
 STATIC_ASSERT(__cpp_lib_variant == 201606L);
 #endif
@@ -1372,7 +1372,7 @@ STATIC_ASSERT(__cpp_lib_variant == 201606L);
 #ifndef __cpp_lib_execution
 #error __cpp_lib_execution is not defined
 #elif __cpp_lib_execution != 201603L
-#error cpp_lib_execution is not 201603L
+#error __cpp_lib_execution is not 201603L
 #else
 STATIC_ASSERT(__cpp_lib_execution == 201603L);
 #endif
@@ -1386,7 +1386,7 @@ STATIC_ASSERT(__cpp_lib_execution == 201603L);
 #ifndef __cpp_lib_parallel_algorithm
 #error __cpp_lib_parallel_algorithm is not defined
 #elif __cpp_lib_parallel_algorithm != 201603L
-#error cpp_lib_parallel_algorithm is not 201603L
+#error __cpp_lib_parallel_algorithm is not 201603L
 #else
 STATIC_ASSERT(__cpp_lib_parallel_algorithm == 201603L);
 #endif
@@ -1400,7 +1400,7 @@ STATIC_ASSERT(__cpp_lib_parallel_algorithm == 201603L);
 #ifndef __cpp_lib_atomic_float
 #error __cpp_lib_atomic_float is not defined
 #elif __cpp_lib_atomic_float != 201711L
-#error cpp_lib_atomic_float is not 201711L
+#error __cpp_lib_atomic_float is not 201711L
 #else
 STATIC_ASSERT(__cpp_lib_atomic_float == 201711L);
 #endif
@@ -1414,7 +1414,7 @@ STATIC_ASSERT(__cpp_lib_atomic_float == 201711L);
 #ifndef __cpp_lib_bind_front
 #error __cpp_lib_bind_front is not defined
 #elif __cpp_lib_bind_front != 201907L
-#error cpp_lib_bind_front is not 201907L
+#error __cpp_lib_bind_front is not 201907L
 #else
 STATIC_ASSERT(__cpp_lib_bind_front == 201907L);
 #endif
@@ -1428,7 +1428,7 @@ STATIC_ASSERT(__cpp_lib_bind_front == 201907L);
 #ifndef __cpp_lib_bounded_array_traits
 #error __cpp_lib_bounded_array_traits is not defined
 #elif __cpp_lib_bounded_array_traits != 201902L
-#error cpp_lib_bounded_array_traits is not 201902L
+#error __cpp_lib_bounded_array_traits is not 201902L
 #else
 STATIC_ASSERT(__cpp_lib_bounded_array_traits == 201902L);
 #endif
@@ -1442,7 +1442,7 @@ STATIC_ASSERT(__cpp_lib_bounded_array_traits == 201902L);
 #ifndef __cpp_lib_constexpr_algorithms
 #error __cpp_lib_constexpr_algorithms is not defined
 #elif __cpp_lib_constexpr_algorithms != 201806L
-#error cpp_lib_constexpr_algorithms is not 201806L
+#error __cpp_lib_constexpr_algorithms is not 201806L
 #else
 STATIC_ASSERT(__cpp_lib_constexpr_algorithms == 201806L);
 #endif
@@ -1456,7 +1456,7 @@ STATIC_ASSERT(__cpp_lib_constexpr_algorithms == 201806L);
 #ifndef __cpp_lib_constexpr_memory
 #error __cpp_lib_constexpr_memory is not defined
 #elif __cpp_lib_constexpr_memory != 201811L
-#error cpp_lib_constexpr_memory is not 201811L
+#error __cpp_lib_constexpr_memory is not 201811L
 #else
 STATIC_ASSERT(__cpp_lib_constexpr_memory == 201811L);
 #endif
@@ -1470,7 +1470,7 @@ STATIC_ASSERT(__cpp_lib_constexpr_memory == 201811L);
 #ifndef __cpp_lib_constexpr_numeric
 #error __cpp_lib_constexpr_numeric is not defined
 #elif __cpp_lib_constexpr_numeric != 201911L
-#error cpp_lib_constexpr_numeric is not 201911L
+#error __cpp_lib_constexpr_numeric is not 201911L
 #else
 STATIC_ASSERT(__cpp_lib_constexpr_numeric == 201911L);
 #endif
@@ -1484,7 +1484,7 @@ STATIC_ASSERT(__cpp_lib_constexpr_numeric == 201911L);
 #ifndef __cpp_lib_endian
 #error __cpp_lib_endian is not defined
 #elif __cpp_lib_endian != 201907L
-#error cpp_lib_endian is not 201907L
+#error __cpp_lib_endian is not 201907L
 #else
 STATIC_ASSERT(__cpp_lib_endian == 201907L);
 #endif
@@ -1498,7 +1498,7 @@ STATIC_ASSERT(__cpp_lib_endian == 201907L);
 #ifndef __cpp_lib_erase_if
 #error __cpp_lib_erase_if is not defined
 #elif __cpp_lib_erase_if != 202002L
-#error cpp_lib_erase_if is not 202002L
+#error __cpp_lib_erase_if is not 202002L
 #else
 STATIC_ASSERT(__cpp_lib_erase_if == 202002L);
 #endif
@@ -1512,7 +1512,7 @@ STATIC_ASSERT(__cpp_lib_erase_if == 202002L);
 #ifndef __cpp_lib_generic_unordered_lookup
 #error __cpp_lib_generic_unordered_lookup is not defined
 #elif __cpp_lib_generic_unordered_lookup != 201811L
-#error cpp_lib_generic_unordered_lookup is not 201811L
+#error __cpp_lib_generic_unordered_lookup is not 201811L
 #else
 STATIC_ASSERT(__cpp_lib_generic_unordered_lookup == 201811L);
 #endif
@@ -1526,7 +1526,7 @@ STATIC_ASSERT(__cpp_lib_generic_unordered_lookup == 201811L);
 #ifndef __cpp_lib_int_pow2
 #error __cpp_lib_int_pow2 is not defined
 #elif __cpp_lib_int_pow2 != 202002L
-#error cpp_lib_int_pow2 is not 202002L
+#error __cpp_lib_int_pow2 is not 202002L
 #else
 STATIC_ASSERT(__cpp_lib_int_pow2 == 202002L);
 #endif
@@ -1540,7 +1540,7 @@ STATIC_ASSERT(__cpp_lib_int_pow2 == 202002L);
 #ifndef __cpp_lib_is_constant_evaluated
 #error __cpp_lib_is_constant_evaluated is not defined
 #elif __cpp_lib_is_constant_evaluated != 201811L
-#error cpp_lib_is_constant_evaluated is not 201811L
+#error __cpp_lib_is_constant_evaluated is not 201811L
 #else
 STATIC_ASSERT(__cpp_lib_is_constant_evaluated == 201811L);
 #endif
@@ -1554,7 +1554,7 @@ STATIC_ASSERT(__cpp_lib_is_constant_evaluated == 201811L);
 #ifndef __cpp_lib_is_nothrow_convertible
 #error __cpp_lib_is_nothrow_convertible is not defined
 #elif __cpp_lib_is_nothrow_convertible != 201806L
-#error cpp_lib_is_nothrow_convertible is not 201806L
+#error __cpp_lib_is_nothrow_convertible is not 201806L
 #else
 STATIC_ASSERT(__cpp_lib_is_nothrow_convertible == 201806L);
 #endif
@@ -1568,7 +1568,7 @@ STATIC_ASSERT(__cpp_lib_is_nothrow_convertible == 201806L);
 #ifndef __cpp_lib_list_remove_return_type
 #error __cpp_lib_list_remove_return_type is not defined
 #elif __cpp_lib_list_remove_return_type != 201806L
-#error cpp_lib_list_remove_return_type is not 201806L
+#error __cpp_lib_list_remove_return_type is not 201806L
 #else
 STATIC_ASSERT(__cpp_lib_list_remove_return_type == 201806L);
 #endif
@@ -1582,7 +1582,7 @@ STATIC_ASSERT(__cpp_lib_list_remove_return_type == 201806L);
 #ifndef __cpp_lib_math_constants
 #error __cpp_lib_math_constants is not defined
 #elif __cpp_lib_math_constants != 201907L
-#error cpp_lib_math_constants is not 201907L
+#error __cpp_lib_math_constants is not 201907L
 #else
 STATIC_ASSERT(__cpp_lib_math_constants == 201907L);
 #endif
@@ -1596,7 +1596,7 @@ STATIC_ASSERT(__cpp_lib_math_constants == 201907L);
 #ifndef __cpp_lib_remove_cvref
 #error __cpp_lib_remove_cvref is not defined
 #elif __cpp_lib_remove_cvref != 201711L
-#error cpp_lib_remove_cvref is not 201711L
+#error __cpp_lib_remove_cvref is not 201711L
 #else
 STATIC_ASSERT(__cpp_lib_remove_cvref == 201711L);
 #endif
@@ -1610,7 +1610,7 @@ STATIC_ASSERT(__cpp_lib_remove_cvref == 201711L);
 #ifndef __cpp_lib_shift
 #error __cpp_lib_shift is not defined
 #elif __cpp_lib_shift != 201806L
-#error cpp_lib_shift is not 201806L
+#error __cpp_lib_shift is not 201806L
 #else
 STATIC_ASSERT(__cpp_lib_shift == 201806L);
 #endif
@@ -1624,7 +1624,7 @@ STATIC_ASSERT(__cpp_lib_shift == 201806L);
 #ifndef __cpp_lib_span
 #error __cpp_lib_span is not defined
 #elif __cpp_lib_span != 202002L
-#error cpp_lib_span is not 202002L
+#error __cpp_lib_span is not 202002L
 #else
 STATIC_ASSERT(__cpp_lib_span == 202002L);
 #endif
@@ -1638,7 +1638,7 @@ STATIC_ASSERT(__cpp_lib_span == 202002L);
 #ifndef __cpp_lib_ssize
 #error __cpp_lib_ssize is not defined
 #elif __cpp_lib_ssize != 201902L
-#error cpp_lib_ssize is not 201902L
+#error __cpp_lib_ssize is not 201902L
 #else
 STATIC_ASSERT(__cpp_lib_ssize == 201902L);
 #endif
@@ -1652,7 +1652,7 @@ STATIC_ASSERT(__cpp_lib_ssize == 201902L);
 #ifndef __cpp_lib_starts_ends_with
 #error __cpp_lib_starts_ends_with is not defined
 #elif __cpp_lib_starts_ends_with != 201711L
-#error cpp_lib_starts_ends_with is not 201711L
+#error __cpp_lib_starts_ends_with is not 201711L
 #else
 STATIC_ASSERT(__cpp_lib_starts_ends_with == 201711L);
 #endif
@@ -1666,7 +1666,7 @@ STATIC_ASSERT(__cpp_lib_starts_ends_with == 201711L);
 #ifndef __cpp_lib_to_address
 #error __cpp_lib_to_address is not defined
 #elif __cpp_lib_to_address != 201711L
-#error cpp_lib_to_address is not 201711L
+#error __cpp_lib_to_address is not 201711L
 #else
 STATIC_ASSERT(__cpp_lib_to_address == 201711L);
 #endif
@@ -1680,7 +1680,7 @@ STATIC_ASSERT(__cpp_lib_to_address == 201711L);
 #ifndef __cpp_lib_to_array
 #error __cpp_lib_to_array is not defined
 #elif __cpp_lib_to_array != 201907L
-#error cpp_lib_to_array is not 201907L
+#error __cpp_lib_to_array is not 201907L
 #else
 STATIC_ASSERT(__cpp_lib_to_array == 201907L);
 #endif
@@ -1694,7 +1694,7 @@ STATIC_ASSERT(__cpp_lib_to_array == 201907L);
 #ifndef __cpp_lib_type_identity
 #error __cpp_lib_type_identity is not defined
 #elif __cpp_lib_type_identity != 201806L
-#error cpp_lib_type_identity is not 201806L
+#error __cpp_lib_type_identity is not 201806L
 #else
 STATIC_ASSERT(__cpp_lib_type_identity == 201806L);
 #endif
@@ -1708,7 +1708,7 @@ STATIC_ASSERT(__cpp_lib_type_identity == 201806L);
 #ifndef __cpp_lib_unwrap_ref
 #error __cpp_lib_unwrap_ref is not defined
 #elif __cpp_lib_unwrap_ref != 201811L
-#error cpp_lib_unwrap_ref is not 201811L
+#error __cpp_lib_unwrap_ref is not 201811L
 #else
 STATIC_ASSERT(__cpp_lib_unwrap_ref == 201811L);
 #endif
@@ -1722,7 +1722,7 @@ STATIC_ASSERT(__cpp_lib_unwrap_ref == 201811L);
 #ifndef __cpp_lib_bit_cast
 #error __cpp_lib_bit_cast is not defined
 #elif __cpp_lib_bit_cast != 201806L
-#error cpp_lib_bit_cast is not 201806L
+#error __cpp_lib_bit_cast is not 201806L
 #else
 STATIC_ASSERT(__cpp_lib_bit_cast == 201806L);
 #endif
@@ -1736,7 +1736,7 @@ STATIC_ASSERT(__cpp_lib_bit_cast == 201806L);
 #ifndef __cpp_lib_bitops
 #error __cpp_lib_bitops is not defined
 #elif __cpp_lib_bitops != 201907L
-#error cpp_lib_bitops is not 201907L
+#error __cpp_lib_bitops is not 201907L
 #else
 STATIC_ASSERT(__cpp_lib_bitops == 201907L);
 #endif
@@ -1750,7 +1750,7 @@ STATIC_ASSERT(__cpp_lib_bitops == 201907L);
 #ifndef __cpp_lib_char8_t
 #error __cpp_lib_char8_t is not defined
 #elif __cpp_lib_char8_t != 201907L
-#error cpp_lib_char8_t is not 201907L
+#error __cpp_lib_char8_t is not 201907L
 #else
 STATIC_ASSERT(__cpp_lib_char8_t == 201907L);
 #endif
@@ -1764,7 +1764,7 @@ STATIC_ASSERT(__cpp_lib_char8_t == 201907L);
 #ifndef __cpp_lib_concepts
 #error __cpp_lib_concepts is not defined
 #elif __cpp_lib_concepts != 201907L
-#error cpp_lib_concepts is not 201907L
+#error __cpp_lib_concepts is not 201907L
 #else
 STATIC_ASSERT(__cpp_lib_concepts == 201907L);
 #endif
@@ -1778,7 +1778,7 @@ STATIC_ASSERT(__cpp_lib_concepts == 201907L);
 #ifndef __cpp_lib_byte
 #error __cpp_lib_byte is not defined
 #elif __cpp_lib_byte != 201603L
-#error cpp_lib_byte is not 201603L
+#error __cpp_lib_byte is not 201603L
 #else
 STATIC_ASSERT(__cpp_lib_byte == 201603L);
 #endif
@@ -1796,7 +1796,7 @@ STATIC_ASSERT(__cpp_lib_byte == 201603L);
 #ifndef __cpp_lib_shared_timed_mutex
 #error __cpp_lib_shared_timed_mutex is not defined
 #elif __cpp_lib_shared_timed_mutex != 201402L
-#error cpp_lib_shared_timed_mutex is not 201402L
+#error __cpp_lib_shared_timed_mutex is not 201402L
 #else
 STATIC_ASSERT(__cpp_lib_shared_timed_mutex == 201402L);
 #endif

--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.cpp
@@ -5,15 +5,15 @@
 
 int main() {} // COMPILE-ONLY
 
-// ATTRIBUTE FEATURE-TEST MACROS.
+// ATTRIBUTE FEATURE-TEST MACROS
 
 #ifdef __has_cpp_attribute
-// Good.
+// Good
 #else
 #error Expected __has_cpp_attribute to be defined.
 #endif
 #if defined(__has_cpp_attribute)
-// Good.
+// Good
 #else
 #error Expected __has_cpp_attribute to be defined.
 #endif
@@ -68,7 +68,7 @@ int main() {} // COMPILE-ONLY
 #endif
 
 
-// COMPILER FEATURE-TEST MACROS
+// CORE LANGUAGE FEATURE-TEST MACROS
 
 #ifndef __cpp_aggregate_nsdmi
 #error Expected __cpp_aggregate_nsdmi to be defined.

--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.cpp
@@ -67,6 +67,20 @@ int main() {} // COMPILE-ONLY
 
 // CORE LANGUAGE FEATURE-TEST MACROS
 
+#if _HAS_CXX17
+#ifndef __cpp_aggregate_bases
+#error __cpp_aggregate_bases is not defined
+#elif __cpp_aggregate_bases != 201603L
+#error __cpp_aggregate_bases is not 201603L
+#else
+STATIC_ASSERT(__cpp_aggregate_bases == 201603L);
+#endif
+#else
+#ifdef __cpp_aggregate_bases
+#error __cpp_aggregate_bases is defined
+#endif
+#endif
+
 #ifndef __cpp_aggregate_nsdmi
 #error __cpp_aggregate_nsdmi is not defined
 #elif __cpp_aggregate_nsdmi != 201304L
@@ -83,6 +97,21 @@ STATIC_ASSERT(__cpp_aggregate_nsdmi == 201304L);
 STATIC_ASSERT(__cpp_alias_templates == 200704L);
 #endif
 
+// C++17, /Zc:alignedNew[-]
+#if !_HAS_CXX17 || defined(TEST_DISABLED_ALIGNED_NEW)
+#ifdef __cpp_aligned_new
+#error __cpp_aligned_new is defined
+#endif
+#else
+#ifndef __cpp_aligned_new
+#error __cpp_aligned_new is not defined
+#elif __cpp_aligned_new != 201606L
+#error __cpp_aligned_new is not 201606L
+#else
+STATIC_ASSERT(__cpp_aligned_new == 201606L);
+#endif
+#endif
+
 #ifndef __cpp_attributes
 #error __cpp_attributes is not defined
 #elif __cpp_attributes != 200809L
@@ -97,6 +126,35 @@ STATIC_ASSERT(__cpp_attributes == 200809L);
 #error __cpp_binary_literals is not 201304L
 #else
 STATIC_ASSERT(__cpp_binary_literals == 201304L);
+#endif
+
+#if _HAS_CXX17
+#ifndef __cpp_capture_star_this
+#error __cpp_capture_star_this is not defined
+#elif __cpp_capture_star_this != 201603L
+#error __cpp_capture_star_this is not 201603L
+#else
+STATIC_ASSERT(__cpp_capture_star_this == 201603L);
+#endif
+#else
+#ifdef __cpp_capture_star_this
+#error __cpp_capture_star_this is defined
+#endif
+#endif
+
+#if _HAS_CXX20 || defined(__EDG__)
+// EDG unconditionally reports "explicit(bool)" as being available.
+#ifndef __cpp_conditional_explicit
+#error __cpp_conditional_explicit is not defined
+#elif __cpp_conditional_explicit != 201806L
+#error __cpp_conditional_explicit is not 201806L
+#else
+STATIC_ASSERT(__cpp_conditional_explicit == 201806L);
+#endif
+#else
+#ifdef __cpp_conditional_explicit
+#error __cpp_conditional_explicit is defined
+#endif
 #endif
 
 #ifndef __cpp_constexpr
@@ -131,6 +189,20 @@ STATIC_ASSERT(__cpp_decltype == 200707L);
 STATIC_ASSERT(__cpp_decltype_auto == 201304L);
 #endif
 
+#if _HAS_CXX17
+#ifndef __cpp_deduction_guides
+#error __cpp_deduction_guides is not defined
+#elif __cpp_deduction_guides != 201703L
+#error __cpp_deduction_guides is not 201703L
+#else
+STATIC_ASSERT(__cpp_deduction_guides == 201703L);
+#endif
+#else
+#ifdef __cpp_deduction_guides
+#error __cpp_deduction_guides is defined
+#endif
+#endif
+
 #ifndef __cpp_delegating_constructors
 #error __cpp_delegating_constructors is not defined
 #elif __cpp_delegating_constructors != 200604L
@@ -139,12 +211,120 @@ STATIC_ASSERT(__cpp_decltype_auto == 201304L);
 STATIC_ASSERT(__cpp_delegating_constructors == 200604L);
 #endif
 
+#if _HAS_CXX17 || !defined(__clang__) // C1XX implemented this C++17 feature unconditionally.
+#ifndef __cpp_enumerator_attributes
+#error __cpp_enumerator_attributes is not defined
+#elif __cpp_enumerator_attributes != 201411L
+#error __cpp_enumerator_attributes is not 201411L
+#else
+STATIC_ASSERT(__cpp_enumerator_attributes == 201411L);
+#endif
+#else
+#ifdef __cpp_enumerator_attributes
+#error __cpp_enumerator_attributes is defined
+#endif
+#endif
+
+// C++98, /EHs[-]
+#ifdef TEST_DISABLED_EXCEPTIONS
+#ifdef __cpp_exceptions
+#error __cpp_exceptions is defined
+#endif
+#else
+#ifndef __cpp_exceptions
+#error __cpp_exceptions is not defined
+#elif __cpp_exceptions != 199711L
+#error __cpp_exceptions is not 199711L
+#else
+STATIC_ASSERT(__cpp_exceptions == 199711L);
+#endif
+#endif
+
+#if _HAS_CXX17
+#ifndef __cpp_fold_expressions
+#error __cpp_fold_expressions is not defined
+#elif __cpp_fold_expressions != 201603L
+#error __cpp_fold_expressions is not 201603L
+#else
+STATIC_ASSERT(__cpp_fold_expressions == 201603L);
+#endif
+#else
+#ifdef __cpp_fold_expressions
+#error __cpp_fold_expressions is defined
+#endif
+#endif
+
 #ifndef __cpp_generic_lambdas
 #error __cpp_generic_lambdas is not defined
 #elif __cpp_generic_lambdas != 201304L
 #error __cpp_generic_lambdas is not 201304L
 #else
 STATIC_ASSERT(__cpp_generic_lambdas == 201304L);
+#endif
+
+#if _HAS_CXX17
+#ifndef __cpp_guaranteed_copy_elision
+#error __cpp_guaranteed_copy_elision is not defined
+#elif __cpp_guaranteed_copy_elision != 201606L
+#error __cpp_guaranteed_copy_elision is not 201606L
+#else
+STATIC_ASSERT(__cpp_guaranteed_copy_elision == 201606L);
+#endif
+#else
+#ifdef __cpp_guaranteed_copy_elision
+#error __cpp_guaranteed_copy_elision is defined
+#endif
+#endif
+
+#if _HAS_CXX17 || defined(__EDG__) // EDG unconditionally reports hex floats as being available.
+#ifndef __cpp_hex_float
+#error __cpp_hex_float is not defined
+#elif __cpp_hex_float != 201603L
+#error __cpp_hex_float is not 201603L
+#else
+STATIC_ASSERT(__cpp_hex_float == 201603L);
+#endif
+#else
+#ifdef __cpp_hex_float
+#error __cpp_hex_float is defined
+#endif
+#endif
+
+#if _HAS_CXX17 || defined(__EDG__) // EDG unconditionally reports "if constexpr" as being available.
+#ifndef __cpp_if_constexpr
+#error __cpp_if_constexpr is not defined
+#elif __cpp_if_constexpr != 201606L
+#error __cpp_if_constexpr is not 201606L
+#else
+STATIC_ASSERT(__cpp_if_constexpr == 201606L);
+#endif
+#else
+#ifdef __cpp_if_constexpr
+#error __cpp_if_constexpr is defined
+#endif
+#endif
+
+#if _HAS_CXX20 && !defined(__clang__)
+// Clang only has partial support for <=> but that does not include the feature test macro.
+#ifndef __cpp_impl_three_way_comparison
+#error __cpp_impl_three_way_comparison is not defined
+#elif defined(__EDG__) // EDG does not yet implement P1630R1 or P1186R3 so they still report the old value.
+#if __cpp_impl_three_way_comparison != 201711L
+#error __cpp_impl_three_way_comparison is not 201711L
+#else
+STATIC_ASSERT(__cpp_impl_three_way_comparison == 201711L);
+#endif
+#else
+#if __cpp_impl_three_way_comparison != 201907L
+#error __cpp_impl_three_way_comparison is not 201907L
+#else
+STATIC_ASSERT(__cpp_impl_three_way_comparison == 201907L);
+#endif
+#endif
+#else
+#ifdef __cpp_impl_three_way_comparison
+#error __cpp_impl_three_way_comparison is defined
+#endif
 #endif
 
 #ifndef __cpp_inheriting_constructors
@@ -164,14 +344,6 @@ STATIC_ASSERT(__cpp_inheriting_constructors == 200802L);
 #endif
 #endif
 
-#ifndef __cpp_init_captures
-#error __cpp_init_captures is not defined
-#elif __cpp_init_captures != 201304L
-#error __cpp_init_captures is not 201304L
-#else
-STATIC_ASSERT(__cpp_init_captures == 201304L);
-#endif
-
 #ifndef __cpp_initializer_lists
 #error __cpp_initializer_lists is not defined
 #elif __cpp_initializer_lists != 200806L
@@ -180,12 +352,99 @@ STATIC_ASSERT(__cpp_init_captures == 201304L);
 STATIC_ASSERT(__cpp_initializer_lists == 200806L);
 #endif
 
+#ifndef __cpp_init_captures
+#error __cpp_init_captures is not defined
+#elif __cpp_init_captures != 201304L
+#error __cpp_init_captures is not 201304L
+#else
+STATIC_ASSERT(__cpp_init_captures == 201304L);
+#endif
+
+#if _HAS_CXX17
+#ifndef __cpp_inline_variables
+#error __cpp_inline_variables is not defined
+#elif __cpp_inline_variables != 201606L
+#error __cpp_inline_variables is not 201606L
+#else
+STATIC_ASSERT(__cpp_inline_variables == 201606L);
+#endif
+#else
+#ifdef __cpp_inline_variables
+#error __cpp_inline_variables is defined
+#endif
+#endif
+
 #ifndef __cpp_lambdas
 #error __cpp_lambdas is not defined
 #elif __cpp_lambdas != 200907L
 #error __cpp_lambdas is not 200907L
 #else
 STATIC_ASSERT(__cpp_lambdas == 200907L);
+#endif
+
+#if _HAS_CXX17 || !defined(__clang__) // C1XX implemented this C++17 feature unconditionally.
+#ifndef __cpp_namespace_attributes
+#error __cpp_namespace_attributes is not defined
+#elif __cpp_namespace_attributes != 201411L
+#error __cpp_namespace_attributes is not 201411L
+#else
+STATIC_ASSERT(__cpp_namespace_attributes == 201411L);
+#endif
+#else
+#ifdef __cpp_namespace_attributes
+#error __cpp_namespace_attributes is defined
+#endif
+#endif
+
+// C++17, /Zc:noexceptTypes[-]
+#if !_HAS_CXX17 || defined(TEST_DISABLED_NOEXCEPT_FUNCTION_TYPE)
+#ifdef __cpp_noexcept_function_type
+#error __cpp_noexcept_function_type is defined
+#endif
+#else
+#ifndef __cpp_noexcept_function_type
+#error __cpp_noexcept_function_type is not defined
+#elif __cpp_noexcept_function_type != 201510L
+#error __cpp_noexcept_function_type is not 201510L
+#else
+STATIC_ASSERT(__cpp_noexcept_function_type == 201510L);
+#endif
+#endif
+
+#if _HAS_CXX20 && !defined(__clang__) && !defined(__EDG__)
+#ifndef __cpp_nontype_template_args
+#error __cpp_nontype_template_args is not defined
+#elif __cpp_nontype_template_args != 201911L
+#error __cpp_nontype_template_args is not 201911L
+#else
+STATIC_ASSERT(__cpp_nontype_template_args == 201911L);
+#endif
+#elif _HAS_CXX17
+#ifndef __cpp_nontype_template_args
+#error __cpp_nontype_template_args is not defined
+#elif __cpp_nontype_template_args != 201411L
+#error __cpp_nontype_template_args is not 201411L
+#else
+STATIC_ASSERT(__cpp_nontype_template_args == 201411L);
+#endif
+#else
+#ifdef __cpp_nontype_template_args
+#error __cpp_nontype_template_args is defined
+#endif
+#endif
+
+#if _HAS_CXX17
+#ifndef __cpp_nontype_template_parameter_auto
+#error __cpp_nontype_template_parameter_auto is not defined
+#elif __cpp_nontype_template_parameter_auto != 201606L
+#error __cpp_nontype_template_parameter_auto is not 201606L
+#else
+STATIC_ASSERT(__cpp_nontype_template_parameter_auto == 201606L);
+#endif
+#else
+#ifdef __cpp_nontype_template_parameter_auto
+#error __cpp_nontype_template_parameter_auto is defined
+#endif
 #endif
 
 #ifndef __cpp_nsdmi
@@ -236,12 +495,38 @@ STATIC_ASSERT(__cpp_ref_qualifiers == 200710L);
 STATIC_ASSERT(__cpp_return_type_deduction == 201304L);
 #endif
 
+// C++98, /GR[-]
+#ifdef TEST_DISABLED_RTTI
+#ifdef __cpp_rtti
+#error __cpp_rtti is defined
+#endif
+#else
+#ifdef __cpp_namespace_attributes
+#error __cpp_namespace_attributes is defined
+#endif
+#endif
+
 #ifndef __cpp_rvalue_references
 #error __cpp_rvalue_references is not defined
 #elif __cpp_rvalue_references != 200610L
 #error __cpp_rvalue_references is not 200610L
 #else
 STATIC_ASSERT(__cpp_rvalue_references == 200610L);
+#endif
+
+// C++14, /Zc:sizedDealloc[-]
+#if defined(TEST_DISABLED_SIZED_DEALLOCATION) || defined(__clang__) // Clang disables sized deallocation by default.
+#ifdef __cpp_sized_deallocation
+#error __cpp_sized_deallocation is defined
+#endif
+#else
+#ifndef __cpp_sized_deallocation
+#error __cpp_sized_deallocation is not defined
+#elif __cpp_sized_deallocation != 201309L
+#error __cpp_sized_deallocation is not 201309L
+#else
+STATIC_ASSERT(__cpp_sized_deallocation == 201309L);
+#endif
 #endif
 
 #ifndef __cpp_static_assert
@@ -257,6 +542,56 @@ STATIC_ASSERT(__cpp_static_assert == 201411L);
 #error __cpp_static_assert is not 200410L
 #else
 STATIC_ASSERT(__cpp_static_assert == 200410L);
+#endif
+#endif
+
+#if _HAS_CXX17
+#ifndef __cpp_structured_bindings
+#error __cpp_structured_bindings is not defined
+#elif __cpp_structured_bindings != 201606L
+#error __cpp_structured_bindings is not 201606L
+#else
+STATIC_ASSERT(__cpp_structured_bindings == 201606L);
+#endif
+#else
+#ifdef __cpp_structured_bindings
+#error __cpp_structured_bindings is defined
+#endif
+#endif
+
+#if _HAS_CXX17 && !defined(__clang__)
+// https://clang.llvm.org/cxx_status.html says P0522R0 is Partial, "Despite being
+// the resolution to a Defect Report, this feature is disabled by default in all
+// language versions, and can be enabled explicitly with the flag
+// -frelaxed-template-template-args in Clang 4 onwards. The change to the standard
+// lacks a corresponding change for template partial ordering, resulting in
+// ambiguity errors for reasonable and previously-valid code. This issue is
+// expected to be rectified soon."
+#ifndef __cpp_template_template_args
+#error __cpp_template_template_args is not defined
+#elif __cpp_template_template_args != 201611L
+#error __cpp_template_template_args is not 201611L
+#else
+STATIC_ASSERT(__cpp_template_template_args == 201611L);
+#endif
+#else
+#ifdef __cpp_template_template_args
+#error __cpp_template_template_args is defined
+#endif
+#endif
+
+// C++11, /Zc:threadSafeInit[-]
+#if defined(_M_CEE_PURE) || defined(TEST_DISABLED_THREADSAFE_STATIC_INIT)
+#ifdef __cpp_threadsafe_static_init
+#error __cpp_threadsafe_static_init is defined
+#endif
+#else
+#ifndef __cpp_threadsafe_static_init
+#error __cpp_threadsafe_static_init is not defined
+#elif __cpp_threadsafe_static_init != 200806L
+#error __cpp_threadsafe_static_init is not 200806L
+#else
+STATIC_ASSERT(__cpp_threadsafe_static_init == 200806L);
 #endif
 #endif
 
@@ -301,118 +636,6 @@ STATIC_ASSERT(__cpp_variadic_templates == 200704L);
 #endif
 
 #if _HAS_CXX17
-#ifndef __cpp_aggregate_bases
-#error __cpp_aggregate_bases is not defined
-#elif __cpp_aggregate_bases != 201603L
-#error __cpp_aggregate_bases is not 201603L
-#else
-STATIC_ASSERT(__cpp_aggregate_bases == 201603L);
-#endif
-#else
-#ifdef __cpp_aggregate_bases
-#error __cpp_aggregate_bases is defined
-#endif
-#endif
-
-#if _HAS_CXX17
-#ifndef __cpp_capture_star_this
-#error __cpp_capture_star_this is not defined
-#elif __cpp_capture_star_this != 201603L
-#error __cpp_capture_star_this is not 201603L
-#else
-STATIC_ASSERT(__cpp_capture_star_this == 201603L);
-#endif
-#else
-#ifdef __cpp_capture_star_this
-#error __cpp_capture_star_this is defined
-#endif
-#endif
-
-#if _HAS_CXX17
-#ifndef __cpp_deduction_guides
-#error __cpp_deduction_guides is not defined
-#elif __cpp_deduction_guides != 201703L
-#error __cpp_deduction_guides is not 201703L
-#else
-STATIC_ASSERT(__cpp_deduction_guides == 201703L);
-#endif
-#else
-#ifdef __cpp_deduction_guides
-#error __cpp_deduction_guides is defined
-#endif
-#endif
-
-#if _HAS_CXX17
-#ifndef __cpp_fold_expressions
-#error __cpp_fold_expressions is not defined
-#elif __cpp_fold_expressions != 201603L
-#error __cpp_fold_expressions is not 201603L
-#else
-STATIC_ASSERT(__cpp_fold_expressions == 201603L);
-#endif
-#else
-#ifdef __cpp_fold_expressions
-#error __cpp_fold_expressions is defined
-#endif
-#endif
-
-#if _HAS_CXX17
-#ifndef __cpp_guaranteed_copy_elision
-#error __cpp_guaranteed_copy_elision is not defined
-#elif __cpp_guaranteed_copy_elision != 201606L
-#error __cpp_guaranteed_copy_elision is not 201606L
-#else
-STATIC_ASSERT(__cpp_guaranteed_copy_elision == 201606L);
-#endif
-#else
-#ifdef __cpp_guaranteed_copy_elision
-#error __cpp_guaranteed_copy_elision is defined
-#endif
-#endif
-
-#if _HAS_CXX17
-#ifndef __cpp_inline_variables
-#error __cpp_inline_variables is not defined
-#elif __cpp_inline_variables != 201606L
-#error __cpp_inline_variables is not 201606L
-#else
-STATIC_ASSERT(__cpp_inline_variables == 201606L);
-#endif
-#else
-#ifdef __cpp_inline_variables
-#error __cpp_inline_variables is defined
-#endif
-#endif
-
-#if _HAS_CXX17
-#ifndef __cpp_nontype_template_parameter_auto
-#error __cpp_nontype_template_parameter_auto is not defined
-#elif __cpp_nontype_template_parameter_auto != 201606L
-#error __cpp_nontype_template_parameter_auto is not 201606L
-#else
-STATIC_ASSERT(__cpp_nontype_template_parameter_auto == 201606L);
-#endif
-#else
-#ifdef __cpp_nontype_template_parameter_auto
-#error __cpp_nontype_template_parameter_auto is defined
-#endif
-#endif
-
-#if _HAS_CXX17
-#ifndef __cpp_structured_bindings
-#error __cpp_structured_bindings is not defined
-#elif __cpp_structured_bindings != 201606L
-#error __cpp_structured_bindings is not 201606L
-#else
-STATIC_ASSERT(__cpp_structured_bindings == 201606L);
-#endif
-#else
-#ifdef __cpp_structured_bindings
-#error __cpp_structured_bindings is defined
-#endif
-#endif
-
-#if _HAS_CXX17
 #ifndef __cpp_variadic_using
 #error __cpp_variadic_using is not defined
 #elif __cpp_variadic_using != 201611L
@@ -423,229 +646,6 @@ STATIC_ASSERT(__cpp_variadic_using == 201611L);
 #else
 #ifdef __cpp_variadic_using
 #error __cpp_variadic_using is defined
-#endif
-#endif
-
-#if _HAS_CXX17 && !defined(__clang__)
-// https://clang.llvm.org/cxx_status.html says P0522R0 is Partial, "Despite being
-// the resolution to a Defect Report, this feature is disabled by default in all
-// language versions, and can be enabled explicitly with the flag
-// -frelaxed-template-template-args in Clang 4 onwards. The change to the standard
-// lacks a corresponding change for template partial ordering, resulting in
-// ambiguity errors for reasonable and previously-valid code. This issue is
-// expected to be rectified soon."
-#ifndef __cpp_template_template_args
-#error __cpp_template_template_args is not defined
-#elif __cpp_template_template_args != 201611L
-#error __cpp_template_template_args is not 201611L
-#else
-STATIC_ASSERT(__cpp_template_template_args == 201611L);
-#endif
-#else
-#ifdef __cpp_template_template_args
-#error __cpp_template_template_args is defined
-#endif
-#endif
-
-#if _HAS_CXX17 || !defined(__clang__) // C1XX implemented this C++17 feature unconditionally.
-#ifndef __cpp_enumerator_attributes
-#error __cpp_enumerator_attributes is not defined
-#elif __cpp_enumerator_attributes != 201411L
-#error __cpp_enumerator_attributes is not 201411L
-#else
-STATIC_ASSERT(__cpp_enumerator_attributes == 201411L);
-#endif
-#else
-#ifdef __cpp_enumerator_attributes
-#error __cpp_enumerator_attributes is defined
-#endif
-#endif
-
-#if _HAS_CXX17 || !defined(__clang__) // C1XX implemented this C++17 feature unconditionally.
-#ifndef __cpp_namespace_attributes
-#error __cpp_namespace_attributes is not defined
-#elif __cpp_namespace_attributes != 201411L
-#error __cpp_namespace_attributes is not 201411L
-#else
-STATIC_ASSERT(__cpp_namespace_attributes == 201411L);
-#endif
-#else
-#ifdef __cpp_namespace_attributes
-#error __cpp_namespace_attributes is defined
-#endif
-#endif
-
-#if _HAS_CXX17 || defined(__EDG__) // EDG unconditionally reports "if constexpr" as being available.
-#ifndef __cpp_if_constexpr
-#error __cpp_if_constexpr is not defined
-#elif __cpp_if_constexpr != 201606L
-#error __cpp_if_constexpr is not 201606L
-#else
-STATIC_ASSERT(__cpp_if_constexpr == 201606L);
-#endif
-#else
-#ifdef __cpp_if_constexpr
-#error __cpp_if_constexpr is defined
-#endif
-#endif
-
-#if _HAS_CXX17 || defined(__EDG__) // EDG unconditionally reports hex floats as being available.
-#ifndef __cpp_hex_float
-#error __cpp_hex_float is not defined
-#elif __cpp_hex_float != 201603L
-#error __cpp_hex_float is not 201603L
-#else
-STATIC_ASSERT(__cpp_hex_float == 201603L);
-#endif
-#else
-#ifdef __cpp_hex_float
-#error __cpp_hex_float is defined
-#endif
-#endif
-
-#if _HAS_CXX20 && !defined(__clang__)
-// Clang only has partial support for <=> but that does not include the feature test macro.
-#ifndef __cpp_impl_three_way_comparison
-#error __cpp_impl_three_way_comparison is not defined
-#elif defined(__EDG__) // EDG does not yet implement P1630R1 or P1186R3 so they still report the old value.
-#if __cpp_impl_three_way_comparison != 201711L
-#error __cpp_impl_three_way_comparison is not 201711L
-#else
-STATIC_ASSERT(__cpp_impl_three_way_comparison == 201711L);
-#endif
-#else
-#if __cpp_impl_three_way_comparison != 201907L
-#error __cpp_impl_three_way_comparison is not 201907L
-#else
-STATIC_ASSERT(__cpp_impl_three_way_comparison == 201907L);
-#endif
-#endif
-#else
-#ifdef __cpp_impl_three_way_comparison
-#error __cpp_impl_three_way_comparison is defined
-#endif
-#endif
-
-#if _HAS_CXX20 && !defined(__clang__) && !defined(__EDG__)
-#ifndef __cpp_nontype_template_args
-#error __cpp_nontype_template_args is not defined
-#elif __cpp_nontype_template_args != 201911L
-#error __cpp_nontype_template_args is not 201911L
-#else
-STATIC_ASSERT(__cpp_nontype_template_args == 201911L);
-#endif
-#elif _HAS_CXX17
-#ifndef __cpp_nontype_template_args
-#error __cpp_nontype_template_args is not defined
-#elif __cpp_nontype_template_args != 201411L
-#error __cpp_nontype_template_args is not 201411L
-#else
-STATIC_ASSERT(__cpp_nontype_template_args == 201411L);
-#endif
-#else
-#ifdef __cpp_nontype_template_args
-#error __cpp_nontype_template_args is defined
-#endif
-#endif
-
-#if _HAS_CXX20 || defined(__EDG__)
-// EDG unconditionally reports "explicit(bool)" as being available.
-#ifndef __cpp_conditional_explicit
-#error __cpp_conditional_explicit is not defined
-#elif __cpp_conditional_explicit != 201806L
-#error __cpp_conditional_explicit is not 201806L
-#else
-STATIC_ASSERT(__cpp_conditional_explicit == 201806L);
-#endif
-#else
-#ifdef __cpp_conditional_explicit
-#error __cpp_conditional_explicit is defined
-#endif
-#endif
-
-// C++98, /EHs[-]
-#ifdef TEST_DISABLED_EXCEPTIONS
-#ifdef __cpp_exceptions
-#error __cpp_exceptions is defined
-#endif
-#else
-#ifndef __cpp_exceptions
-#error __cpp_exceptions is not defined
-#elif __cpp_exceptions != 199711L
-#error __cpp_exceptions is not 199711L
-#else
-STATIC_ASSERT(__cpp_exceptions == 199711L);
-#endif
-#endif
-
-// C++98, /GR[-]
-#ifdef TEST_DISABLED_RTTI
-#ifdef __cpp_rtti
-#error __cpp_rtti is defined
-#endif
-#else
-#ifdef __cpp_namespace_attributes
-#error __cpp_namespace_attributes is defined
-#endif
-#endif
-
-// C++11, /Zc:threadSafeInit[-]
-#if defined(_M_CEE_PURE) || defined(TEST_DISABLED_THREADSAFE_STATIC_INIT)
-#ifdef __cpp_threadsafe_static_init
-#error __cpp_threadsafe_static_init is defined
-#endif
-#else
-#ifndef __cpp_threadsafe_static_init
-#error __cpp_threadsafe_static_init is not defined
-#elif __cpp_threadsafe_static_init != 200806L
-#error __cpp_threadsafe_static_init is not 200806L
-#else
-STATIC_ASSERT(__cpp_threadsafe_static_init == 200806L);
-#endif
-#endif
-
-// C++14, /Zc:sizedDealloc[-]
-#if defined(TEST_DISABLED_SIZED_DEALLOCATION) || defined(__clang__) // Clang disables sized deallocation by default.
-#ifdef __cpp_sized_deallocation
-#error __cpp_sized_deallocation is defined
-#endif
-#else
-#ifndef __cpp_sized_deallocation
-#error __cpp_sized_deallocation is not defined
-#elif __cpp_sized_deallocation != 201309L
-#error __cpp_sized_deallocation is not 201309L
-#else
-STATIC_ASSERT(__cpp_sized_deallocation == 201309L);
-#endif
-#endif
-
-// C++17, /Zc:alignedNew[-]
-#if !_HAS_CXX17 || defined(TEST_DISABLED_ALIGNED_NEW)
-#ifdef __cpp_aligned_new
-#error __cpp_aligned_new is defined
-#endif
-#else
-#ifndef __cpp_aligned_new
-#error __cpp_aligned_new is not defined
-#elif __cpp_aligned_new != 201606L
-#error __cpp_aligned_new is not 201606L
-#else
-STATIC_ASSERT(__cpp_aligned_new == 201606L);
-#endif
-#endif
-
-// C++17, /Zc:noexceptTypes[-]
-#if !_HAS_CXX17 || defined(TEST_DISABLED_NOEXCEPT_FUNCTION_TYPE)
-#ifdef __cpp_noexcept_function_type
-#error __cpp_noexcept_function_type is defined
-#endif
-#else
-#ifndef __cpp_noexcept_function_type
-#error __cpp_noexcept_function_type is not defined
-#elif __cpp_noexcept_function_type != 201510L
-#error __cpp_noexcept_function_type is not 201510L
-#else
-STATIC_ASSERT(__cpp_noexcept_function_type == 201510L);
 #endif
 #endif
 

--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.cpp
@@ -29,20 +29,6 @@ int main() {} // COMPILE-ONLY
 #error __has_cpp_attribute(deprecated) is not 201309L
 #endif
 
-#if __has_cpp_attribute(noreturn) != 200809L
-#error __has_cpp_attribute(noreturn) is not 200809L
-#endif
-
-#if defined(__clang__) || defined(__EDG__) // clang and EDG don't yet implement P1771R1
-#if __has_cpp_attribute(nodiscard) != 201603L
-#error __has_cpp_attribute(nodiscard) is not 201603L
-#endif
-#else
-#if __has_cpp_attribute(nodiscard) != 201907L
-#error __has_cpp_attribute(nodiscard) is not 201907L
-#endif
-#endif
-
 #if _HAS_CXX17 || defined(__clang__) || defined(__EDG__) // Clang and EDG provide this in C++14 mode.
 #if __has_cpp_attribute(fallthrough) != 201603L
 #error __has_cpp_attribute(fallthrough) is not 201603L
@@ -62,6 +48,17 @@ int main() {} // COMPILE-ONLY
 #error __has_cpp_attribute(maybe_unused) is not 0
 #endif
 #endif
+
+#if defined(__clang__) || defined(__EDG__) // clang and EDG don't yet implement P1771R1
+#if __has_cpp_attribute(nodiscard) != 201603L
+#error __has_cpp_attribute(nodiscard) is not 201603L
+#endif
+#else
+#if __has_cpp_attribute(nodiscard) != 201907L
+#error __has_cpp_attribute(nodiscard) is not 201907L
+#endif
+#endif
+
 
 #if __has_cpp_attribute(noreturn) != 200809L
 #error __has_cpp_attribute(noreturn) is not 200809L

--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.cpp
@@ -5,38 +5,11 @@
 
 int main() {} // COMPILE-ONLY
 
-// COMPILER FEATURE-TEST MACROS
-
-#ifdef _MSVC_LANG
-#if _MSVC_LANG > 201703L
-#define CXX17_MODE 1
-#define CXX20_MODE 1
-#elif _MSVC_LANG > 201402L
-#define CXX17_MODE 1
-#define CXX20_MODE 0
-#else
-#define CXX17_MODE 0
-#define CXX20_MODE 0
-#endif
-#else
-#if __cplusplus > 201703L
-#define CXX17_MODE 1
-#define CXX20_MODE 1
-#elif __cplusplus > 201402L
-#define CXX17_MODE 1
-#define CXX20_MODE 0
-#else
-#define CXX17_MODE 0
-#define CXX20_MODE 0
-#endif
-#endif
-
-
 // Always defined to varying values (C++14 versus C++17-and-newer mode).
 
 #ifndef __cpp_constexpr
 #error BOOM
-#elif CXX17_MODE
+#elif _HAS_CXX17
 #if __cpp_constexpr != 201603L
 #error BOOM
 #else
@@ -52,7 +25,7 @@ STATIC_ASSERT(__cpp_constexpr == 201304L);
 
 #ifndef __cpp_inheriting_constructors
 #error BOOM
-#elif (CXX17_MODE || defined(__clang__)) && !defined(__EDG__) // Clang implemented this C++17 feature unconditionally.
+#elif (_HAS_CXX17 || defined(__clang__)) && !defined(__EDG__) // Clang implemented this C++17 feature unconditionally.
                                                               // TRANSITION, VSO-610203
 #if __cpp_inheriting_constructors != 201511L
 #error BOOM
@@ -69,7 +42,7 @@ STATIC_ASSERT(__cpp_inheriting_constructors == 200802L);
 
 #ifndef __cpp_static_assert
 #error BOOM
-#elif CXX17_MODE
+#elif _HAS_CXX17
 #if __cpp_static_assert != 201411L
 #error BOOM
 #else
@@ -142,7 +115,7 @@ STATIC_ASSERT(__cpp_decltype_auto == 201304L);
 STATIC_ASSERT(__cpp_delegating_constructors == 200604L);
 #endif
 
-#if !defined(__clang__) || CXX17_MODE // C1XX implemented this C++17 feature unconditionally.
+#if !defined(__clang__) || _HAS_CXX17 // C1XX implemented this C++17 feature unconditionally.
 #ifndef __cpp_enumerator_attributes
 #error BOOM
 #elif __cpp_enumerator_attributes != 201411L
@@ -188,7 +161,7 @@ STATIC_ASSERT(__cpp_initializer_lists == 200806L);
 STATIC_ASSERT(__cpp_lambdas == 200907L);
 #endif
 
-#if !defined(__clang__) || CXX17_MODE // C1XX implemented this C++17 feature unconditionally.
+#if !defined(__clang__) || _HAS_CXX17 // C1XX implemented this C++17 feature unconditionally.
 #ifndef __cpp_namespace_attributes
 #error BOOM
 #elif __cpp_namespace_attributes != 201411L
@@ -212,7 +185,7 @@ STATIC_ASSERT(__cpp_nsdmi == 200809L);
 
 #ifndef __cpp_range_based_for
 #error BOOM
-#elif !defined(__clang__) || CXX17_MODE // C1XX implemented this C++17 feature unconditionally.
+#elif !defined(__clang__) || _HAS_CXX17 // C1XX implemented this C++17 feature unconditionally.
 #if __cpp_range_based_for != 201603L
 #error BOOM
 #else
@@ -301,7 +274,7 @@ STATIC_ASSERT(__cpp_variadic_templates == 200704L);
 
 // Defined in C++17-and-newer mode to specific values.
 
-#if CXX17_MODE
+#if _HAS_CXX17
 #ifndef __cpp_aggregate_bases
 #error BOOM
 #elif __cpp_aggregate_bases != 201603L
@@ -315,7 +288,7 @@ STATIC_ASSERT(__cpp_aggregate_bases == 201603L);
 #endif
 #endif
 
-#if CXX17_MODE
+#if _HAS_CXX17
 #ifndef __cpp_capture_star_this
 #error BOOM
 #elif __cpp_capture_star_this != 201603L
@@ -329,7 +302,7 @@ STATIC_ASSERT(__cpp_capture_star_this == 201603L);
 #endif
 #endif
 
-#if CXX17_MODE
+#if _HAS_CXX17
 #ifndef __cpp_deduction_guides
 #error BOOM
 #elif __cpp_deduction_guides != 201703L
@@ -343,7 +316,7 @@ STATIC_ASSERT(__cpp_deduction_guides == 201703L);
 #endif
 #endif
 
-#if CXX17_MODE
+#if _HAS_CXX17
 #ifndef __cpp_fold_expressions
 #error BOOM
 #elif __cpp_fold_expressions != 201603L
@@ -357,7 +330,7 @@ STATIC_ASSERT(__cpp_fold_expressions == 201603L);
 #endif
 #endif
 
-#if CXX17_MODE
+#if _HAS_CXX17
 #ifndef __cpp_guaranteed_copy_elision
 #error BOOM
 #elif __cpp_guaranteed_copy_elision != 201606L
@@ -371,7 +344,7 @@ STATIC_ASSERT(__cpp_guaranteed_copy_elision == 201606L);
 #endif
 #endif
 
-#if CXX17_MODE || defined(__EDG__) // EDG unconditionally reports hex floats as being available.
+#if _HAS_CXX17 || defined(__EDG__) // EDG unconditionally reports hex floats as being available.
 #ifndef __cpp_hex_float
 #error BOOM
 #elif __cpp_hex_float != 201603L
@@ -385,7 +358,7 @@ STATIC_ASSERT(__cpp_hex_float == 201603L);
 #endif
 #endif
 
-#if CXX17_MODE || defined(__EDG__) // EDG unconditionally reports "if constexpr" as being available.
+#if _HAS_CXX17 || defined(__EDG__) // EDG unconditionally reports "if constexpr" as being available.
 #ifndef __cpp_if_constexpr
 #error BOOM
 #elif __cpp_if_constexpr != 201606L
@@ -399,7 +372,7 @@ STATIC_ASSERT(__cpp_if_constexpr == 201606L);
 #endif
 #endif
 
-#if CXX17_MODE
+#if _HAS_CXX17
 #ifndef __cpp_inline_variables
 #error BOOM
 #elif __cpp_inline_variables != 201606L
@@ -413,7 +386,7 @@ STATIC_ASSERT(__cpp_inline_variables == 201606L);
 #endif
 #endif
 
-#if CXX20_MODE && !defined(__clang__) && !defined(__EDG__)
+#if _HAS_CXX20 && !defined(__clang__) && !defined(__EDG__)
 #ifndef __cpp_nontype_template_args
 #error BOOM
 #elif __cpp_nontype_template_args != 201911L
@@ -421,7 +394,7 @@ STATIC_ASSERT(__cpp_inline_variables == 201606L);
 #else
 STATIC_ASSERT(__cpp_nontype_template_args == 201911L);
 #endif
-#elif CXX17_MODE
+#elif _HAS_CXX17
 #ifndef __cpp_nontype_template_args
 #error BOOM
 #elif __cpp_nontype_template_args != 201411L
@@ -435,7 +408,7 @@ STATIC_ASSERT(__cpp_nontype_template_args == 201411L);
 #endif
 #endif
 
-#if CXX17_MODE
+#if _HAS_CXX17
 #ifndef __cpp_nontype_template_parameter_auto
 #error BOOM
 #elif __cpp_nontype_template_parameter_auto != 201606L
@@ -449,7 +422,7 @@ STATIC_ASSERT(__cpp_nontype_template_parameter_auto == 201606L);
 #endif
 #endif
 
-#if CXX17_MODE
+#if _HAS_CXX17
 #ifndef __cpp_structured_bindings
 #error BOOM
 #elif __cpp_structured_bindings != 201606L
@@ -463,7 +436,7 @@ STATIC_ASSERT(__cpp_structured_bindings == 201606L);
 #endif
 #endif
 
-#if CXX17_MODE && !defined(__clang__)
+#if _HAS_CXX17 && !defined(__clang__)
 // https://clang.llvm.org/cxx_status.html says P0522R0 is Partial, "Despite being
 // the resolution to a Defect Report, this feature is disabled by default in all
 // language versions, and can be enabled explicitly with the flag
@@ -484,7 +457,7 @@ STATIC_ASSERT(__cpp_template_template_args == 201611L);
 #endif
 #endif
 
-#if CXX17_MODE
+#if _HAS_CXX17
 #ifndef __cpp_variadic_using
 #error BOOM
 #elif __cpp_variadic_using != 201611L
@@ -500,7 +473,7 @@ STATIC_ASSERT(__cpp_variadic_using == 201611L);
 
 // Defined in C++20-and-newer mode to specific values.
 
-#if CXX20_MODE || defined(__EDG__)
+#if _HAS_CXX20 || defined(__EDG__)
 // EDG unconditionally reports "explicit(bool)" as being available.
 #ifndef __cpp_conditional_explicit
 #error BOOM
@@ -515,7 +488,7 @@ STATIC_ASSERT(__cpp_conditional_explicit == 201806L);
 #endif
 #endif
 
-#if CXX20_MODE && !defined(__clang__)
+#if _HAS_CXX20 && !defined(__clang__)
 // Clang only has partial support for <=> but that does not include the feature test macro.
 #ifndef __cpp_impl_three_way_comparison
 #error BOOM
@@ -541,7 +514,7 @@ STATIC_ASSERT(__cpp_impl_three_way_comparison == 201907L);
 // Conditionally defined (various compiler options) to specific values.
 
 // C++17, /Zc:alignedNew[-]
-#if !CXX17_MODE || defined(TEST_DISABLED_ALIGNED_NEW)
+#if !_HAS_CXX17 || defined(TEST_DISABLED_ALIGNED_NEW)
 #ifdef __cpp_aligned_new
 #error BOOM
 #endif
@@ -571,7 +544,7 @@ STATIC_ASSERT(__cpp_exceptions == 199711L);
 #endif
 
 // C++17, /Zc:noexceptTypes[-]
-#if !CXX17_MODE || defined(TEST_DISABLED_NOEXCEPT_FUNCTION_TYPE)
+#if !_HAS_CXX17 || defined(TEST_DISABLED_NOEXCEPT_FUNCTION_TYPE)
 #ifdef __cpp_noexcept_function_type
 #error BOOM
 #endif
@@ -677,7 +650,7 @@ STATIC_ASSERT(__cpp_threadsafe_static_init == 200806L);
 
 // Always defined to varying values (C++14 versus C++17-and-newer mode).
 
-#if CXX17_MODE || defined(__clang__) || defined(__EDG__) // Clang and EDG provide this in C++14 mode.
+#if _HAS_CXX17 || defined(__clang__) || defined(__EDG__) // Clang and EDG provide this in C++14 mode.
 #if __has_cpp_attribute(fallthrough) != 201603L
 #error BOOM
 #endif
@@ -687,7 +660,7 @@ STATIC_ASSERT(__cpp_threadsafe_static_init == 200806L);
 #endif
 #endif
 
-#if CXX17_MODE || defined(__clang__) || defined(__EDG__) // Clang and EDG provide this in C++14 mode.
+#if _HAS_CXX17 || defined(__clang__) || defined(__EDG__) // Clang and EDG provide this in C++14 mode.
 #if __has_cpp_attribute(maybe_unused) != 201603L
 #error BOOM
 #endif
@@ -707,7 +680,7 @@ STATIC_ASSERT(__cpp_threadsafe_static_init == 200806L);
 
 #ifndef __cpp_lib_chrono
 #error BOOM
-#elif CXX17_MODE
+#elif _HAS_CXX17
 #if __cpp_lib_chrono != 201611L
 #error BOOM
 #else
@@ -1045,7 +1018,7 @@ STATIC_ASSERT(__cpp_lib_void_t == 201411L);
 
 // Defined in C++17-and-newer mode to specific values.
 
-#if CXX17_MODE
+#if _HAS_CXX17
 #ifndef __cpp_lib_any
 #error BOOM
 #elif __cpp_lib_any != 201606L
@@ -1059,7 +1032,7 @@ STATIC_ASSERT(__cpp_lib_any == 201606L);
 #endif
 #endif
 
-#if CXX17_MODE
+#if _HAS_CXX17
 #ifndef __cpp_lib_apply
 #error BOOM
 #elif __cpp_lib_apply != 201603L
@@ -1073,7 +1046,7 @@ STATIC_ASSERT(__cpp_lib_apply == 201603L);
 #endif
 #endif
 
-#if CXX17_MODE
+#if _HAS_CXX17
 #ifndef __cpp_lib_array_constexpr
 #error BOOM
 #elif __cpp_lib_array_constexpr != 201803L
@@ -1087,7 +1060,7 @@ STATIC_ASSERT(__cpp_lib_array_constexpr == 201803L);
 #endif
 #endif
 
-#if CXX17_MODE
+#if _HAS_CXX17
 #ifndef __cpp_lib_atomic_is_always_lock_free
 #error BOOM
 #elif __cpp_lib_atomic_is_always_lock_free != 201603L
@@ -1101,7 +1074,7 @@ STATIC_ASSERT(__cpp_lib_atomic_is_always_lock_free == 201603L);
 #endif
 #endif
 
-#if CXX17_MODE
+#if _HAS_CXX17
 #ifndef __cpp_lib_boyer_moore_searcher
 #error BOOM
 #elif __cpp_lib_boyer_moore_searcher != 201603L
@@ -1115,7 +1088,7 @@ STATIC_ASSERT(__cpp_lib_boyer_moore_searcher == 201603L);
 #endif
 #endif
 
-#if CXX17_MODE
+#if _HAS_CXX17
 #ifndef __cpp_lib_clamp
 #error BOOM
 #elif __cpp_lib_clamp != 201603L
@@ -1129,7 +1102,7 @@ STATIC_ASSERT(__cpp_lib_clamp == 201603L);
 #endif
 #endif
 
-#if CXX17_MODE && !defined(_M_CEE)
+#if _HAS_CXX17 && !defined(_M_CEE)
 #ifndef __cpp_lib_execution
 #error BOOM
 #elif __cpp_lib_execution != 201603L
@@ -1143,7 +1116,7 @@ STATIC_ASSERT(__cpp_lib_execution == 201603L);
 #endif
 #endif
 
-#if CXX17_MODE
+#if _HAS_CXX17
 #ifndef __cpp_lib_filesystem
 #error BOOM
 #elif __cpp_lib_filesystem != 201703L
@@ -1157,7 +1130,7 @@ STATIC_ASSERT(__cpp_lib_filesystem == 201703L);
 #endif
 #endif
 
-#if CXX17_MODE
+#if _HAS_CXX17
 #ifndef __cpp_lib_gcd_lcm
 #error BOOM
 #elif __cpp_lib_gcd_lcm != 201606L
@@ -1171,7 +1144,7 @@ STATIC_ASSERT(__cpp_lib_gcd_lcm == 201606L);
 #endif
 #endif
 
-#if CXX17_MODE
+#if _HAS_CXX17
 #ifndef __cpp_lib_hardware_interference_size
 #error BOOM
 #elif __cpp_lib_hardware_interference_size != 201703L
@@ -1185,7 +1158,7 @@ STATIC_ASSERT(__cpp_lib_hardware_interference_size == 201703L);
 #endif
 #endif
 
-#if CXX17_MODE
+#if _HAS_CXX17
 #ifndef __cpp_lib_has_unique_object_representations
 #error BOOM
 #elif __cpp_lib_has_unique_object_representations != 201606L
@@ -1199,7 +1172,7 @@ STATIC_ASSERT(__cpp_lib_has_unique_object_representations == 201606L);
 #endif
 #endif
 
-#if CXX17_MODE
+#if _HAS_CXX17
 #ifndef __cpp_lib_hypot
 #error BOOM
 #elif __cpp_lib_hypot != 201603L
@@ -1213,7 +1186,7 @@ STATIC_ASSERT(__cpp_lib_hypot == 201603L);
 #endif
 #endif
 
-#if CXX17_MODE
+#if _HAS_CXX17
 #ifndef __cpp_lib_is_aggregate
 #error BOOM
 #elif __cpp_lib_is_aggregate != 201703L
@@ -1227,7 +1200,7 @@ STATIC_ASSERT(__cpp_lib_is_aggregate == 201703L);
 #endif
 #endif
 
-#if CXX17_MODE
+#if _HAS_CXX17
 #ifndef __cpp_lib_is_invocable
 #error BOOM
 #elif __cpp_lib_is_invocable != 201703L
@@ -1241,7 +1214,7 @@ STATIC_ASSERT(__cpp_lib_is_invocable == 201703L);
 #endif
 #endif
 
-#if CXX17_MODE
+#if _HAS_CXX17
 #ifndef __cpp_lib_is_swappable
 #error BOOM
 #elif __cpp_lib_is_swappable != 201603L
@@ -1255,7 +1228,7 @@ STATIC_ASSERT(__cpp_lib_is_swappable == 201603L);
 #endif
 #endif
 
-#if CXX17_MODE
+#if _HAS_CXX17
 #ifndef __cpp_lib_launder
 #error BOOM
 #elif __cpp_lib_launder != 201606L
@@ -1269,7 +1242,7 @@ STATIC_ASSERT(__cpp_lib_launder == 201606L);
 #endif
 #endif
 
-#if CXX17_MODE
+#if _HAS_CXX17
 #ifndef __cpp_lib_make_from_tuple
 #error BOOM
 #elif __cpp_lib_make_from_tuple != 201606L
@@ -1283,7 +1256,7 @@ STATIC_ASSERT(__cpp_lib_make_from_tuple == 201606L);
 #endif
 #endif
 
-#if CXX17_MODE
+#if _HAS_CXX17
 #ifndef __cpp_lib_math_special_functions
 #error BOOM
 #elif __cpp_lib_math_special_functions != 201603L
@@ -1297,7 +1270,7 @@ STATIC_ASSERT(__cpp_lib_math_special_functions == 201603L);
 #endif
 #endif
 
-#if CXX17_MODE
+#if _HAS_CXX17
 #ifndef __cpp_lib_memory_resource
 #error BOOM
 #elif __cpp_lib_memory_resource != 201603L
@@ -1311,7 +1284,7 @@ STATIC_ASSERT(__cpp_lib_memory_resource == 201603L);
 #endif
 #endif
 
-#if CXX17_MODE
+#if _HAS_CXX17
 #ifndef __cpp_lib_node_extract
 #error BOOM
 #elif __cpp_lib_node_extract != 201606L
@@ -1325,7 +1298,7 @@ STATIC_ASSERT(__cpp_lib_node_extract == 201606L);
 #endif
 #endif
 
-#if CXX17_MODE
+#if _HAS_CXX17
 #ifndef __cpp_lib_not_fn
 #error BOOM
 #elif __cpp_lib_not_fn != 201603L
@@ -1339,7 +1312,7 @@ STATIC_ASSERT(__cpp_lib_not_fn == 201603L);
 #endif
 #endif
 
-#if CXX17_MODE
+#if _HAS_CXX17
 #ifndef __cpp_lib_optional
 #error BOOM
 #elif __cpp_lib_optional != 201606L
@@ -1353,7 +1326,7 @@ STATIC_ASSERT(__cpp_lib_optional == 201606L);
 #endif
 #endif
 
-#if CXX17_MODE && !defined(_M_CEE)
+#if _HAS_CXX17 && !defined(_M_CEE)
 #ifndef __cpp_lib_parallel_algorithm
 #error BOOM
 #elif __cpp_lib_parallel_algorithm != 201603L
@@ -1367,7 +1340,7 @@ STATIC_ASSERT(__cpp_lib_parallel_algorithm == 201603L);
 #endif
 #endif
 
-#if CXX17_MODE
+#if _HAS_CXX17
 #ifndef __cpp_lib_raw_memory_algorithms
 #error BOOM
 #elif __cpp_lib_raw_memory_algorithms != 201606L
@@ -1381,7 +1354,7 @@ STATIC_ASSERT(__cpp_lib_raw_memory_algorithms == 201606L);
 #endif
 #endif
 
-#if CXX17_MODE
+#if _HAS_CXX17
 #ifndef __cpp_lib_sample
 #error BOOM
 #elif __cpp_lib_sample != 201603L
@@ -1395,7 +1368,7 @@ STATIC_ASSERT(__cpp_lib_sample == 201603L);
 #endif
 #endif
 
-#if CXX17_MODE
+#if _HAS_CXX17
 #ifndef __cpp_lib_scoped_lock
 #error BOOM
 #elif __cpp_lib_scoped_lock != 201703L
@@ -1409,7 +1382,7 @@ STATIC_ASSERT(__cpp_lib_scoped_lock == 201703L);
 #endif
 #endif
 
-#if CXX17_MODE
+#if _HAS_CXX17
 #ifndef __cpp_lib_shared_ptr_weak_type
 #error BOOM
 #elif __cpp_lib_shared_ptr_weak_type != 201606L
@@ -1423,7 +1396,7 @@ STATIC_ASSERT(__cpp_lib_shared_ptr_weak_type == 201606L);
 #endif
 #endif
 
-#if CXX17_MODE
+#if _HAS_CXX17
 #ifndef __cpp_lib_string_view
 #error BOOM
 #elif __cpp_lib_string_view != 201803L
@@ -1437,7 +1410,7 @@ STATIC_ASSERT(__cpp_lib_string_view == 201803L);
 #endif
 #endif
 
-#if CXX17_MODE
+#if _HAS_CXX17
 #ifndef __cpp_lib_to_chars
 #error BOOM
 #elif __cpp_lib_to_chars != 201611L
@@ -1451,7 +1424,7 @@ STATIC_ASSERT(__cpp_lib_to_chars == 201611L);
 #endif
 #endif
 
-#if CXX17_MODE
+#if _HAS_CXX17
 #ifndef __cpp_lib_variant
 #error BOOM
 #elif __cpp_lib_variant != 201606L
@@ -1485,7 +1458,7 @@ STATIC_ASSERT(__cpp_lib_byte == 201603L);
 
 // Defined in C++20-and-newer mode to specific values.
 
-#if CXX20_MODE
+#if _HAS_CXX20
 #ifndef __cpp_lib_atomic_float
 #error BOOM
 #elif __cpp_lib_atomic_float != 201711L
@@ -1499,7 +1472,7 @@ STATIC_ASSERT(__cpp_lib_atomic_float == 201711L);
 #endif
 #endif
 
-#if CXX20_MODE
+#if _HAS_CXX20
 #ifndef __cpp_lib_bind_front
 #error BOOM
 #elif __cpp_lib_bind_front != 201907L
@@ -1513,7 +1486,7 @@ STATIC_ASSERT(__cpp_lib_bind_front == 201907L);
 #endif
 #endif
 
-#if CXX20_MODE && !defined(__EDG__) // TRANSITION, VSO-1041044
+#if _HAS_CXX20 && !defined(__EDG__) // TRANSITION, VSO-1041044
 #ifndef __cpp_lib_bit_cast
 #error BOOM
 #elif __cpp_lib_bit_cast != 201806L
@@ -1527,7 +1500,7 @@ STATIC_ASSERT(__cpp_lib_bit_cast == 201806L);
 #endif
 #endif
 
-#if CXX20_MODE && (defined(__clang__) || defined(__EDG__)) // TRANSITION, VSO-1020212
+#if _HAS_CXX20 && (defined(__clang__) || defined(__EDG__)) // TRANSITION, VSO-1020212
 #ifndef __cpp_lib_bitops
 #error BOOM
 #elif __cpp_lib_bitops != 201907L
@@ -1541,7 +1514,7 @@ STATIC_ASSERT(__cpp_lib_bitops == 201907L);
 #endif
 #endif
 
-#if CXX20_MODE
+#if _HAS_CXX20
 #ifndef __cpp_lib_bounded_array_traits
 #error BOOM
 #elif __cpp_lib_bounded_array_traits != 201902L
@@ -1555,7 +1528,7 @@ STATIC_ASSERT(__cpp_lib_bounded_array_traits == 201902L);
 #endif
 #endif
 
-#if CXX20_MODE
+#if _HAS_CXX20
 #ifndef __cpp_lib_constexpr_algorithms
 #error BOOM
 #elif __cpp_lib_constexpr_algorithms != 201806L
@@ -1569,7 +1542,7 @@ STATIC_ASSERT(__cpp_lib_constexpr_algorithms == 201806L);
 #endif
 #endif
 
-#if CXX20_MODE
+#if _HAS_CXX20
 #ifndef __cpp_lib_constexpr_memory
 #error BOOM
 #elif __cpp_lib_constexpr_memory != 201811L
@@ -1583,7 +1556,7 @@ STATIC_ASSERT(__cpp_lib_constexpr_memory == 201811L);
 #endif
 #endif
 
-#if CXX20_MODE
+#if _HAS_CXX20
 #ifndef __cpp_lib_constexpr_numeric
 #error BOOM
 #elif __cpp_lib_constexpr_numeric != 201911L
@@ -1597,7 +1570,7 @@ STATIC_ASSERT(__cpp_lib_constexpr_numeric == 201911L);
 #endif
 #endif
 
-#if CXX20_MODE
+#if _HAS_CXX20
 #ifndef __cpp_lib_endian
 #error BOOM
 #elif __cpp_lib_endian != 201907L
@@ -1611,7 +1584,7 @@ STATIC_ASSERT(__cpp_lib_endian == 201907L);
 #endif
 #endif
 
-#if CXX20_MODE
+#if _HAS_CXX20
 #ifndef __cpp_lib_erase_if
 #error BOOM
 #elif __cpp_lib_erase_if != 202002L
@@ -1625,7 +1598,7 @@ STATIC_ASSERT(__cpp_lib_erase_if == 202002L);
 #endif
 #endif
 
-#if CXX20_MODE
+#if _HAS_CXX20
 #ifndef __cpp_lib_generic_unordered_lookup
 #error BOOM
 #elif __cpp_lib_generic_unordered_lookup != 201811L
@@ -1639,7 +1612,7 @@ STATIC_ASSERT(__cpp_lib_generic_unordered_lookup == 201811L);
 #endif
 #endif
 
-#if CXX20_MODE
+#if _HAS_CXX20
 #ifndef __cpp_lib_int_pow2
 #error BOOM
 #elif __cpp_lib_int_pow2 != 202002L
@@ -1653,7 +1626,7 @@ STATIC_ASSERT(__cpp_lib_int_pow2 == 202002L);
 #endif
 #endif
 
-#if CXX20_MODE
+#if _HAS_CXX20
 #ifndef __cpp_lib_is_constant_evaluated
 #error BOOM
 #elif __cpp_lib_is_constant_evaluated != 201811L
@@ -1667,7 +1640,7 @@ STATIC_ASSERT(__cpp_lib_is_constant_evaluated == 201811L);
 #endif
 #endif
 
-#if CXX20_MODE
+#if _HAS_CXX20
 #ifndef __cpp_lib_is_nothrow_convertible
 #error BOOM
 #elif __cpp_lib_is_nothrow_convertible != 201806L
@@ -1681,7 +1654,7 @@ STATIC_ASSERT(__cpp_lib_is_nothrow_convertible == 201806L);
 #endif
 #endif
 
-#if CXX20_MODE
+#if _HAS_CXX20
 #ifndef __cpp_lib_list_remove_return_type
 #error BOOM
 #elif __cpp_lib_list_remove_return_type != 201806L
@@ -1695,7 +1668,7 @@ STATIC_ASSERT(__cpp_lib_list_remove_return_type == 201806L);
 #endif
 #endif
 
-#if CXX20_MODE
+#if _HAS_CXX20
 #ifndef __cpp_lib_math_constants
 #error BOOM
 #elif __cpp_lib_math_constants != 201907L
@@ -1709,7 +1682,7 @@ STATIC_ASSERT(__cpp_lib_math_constants == 201907L);
 #endif
 #endif
 
-#if CXX20_MODE
+#if _HAS_CXX20
 #ifndef __cpp_lib_remove_cvref
 #error BOOM
 #elif __cpp_lib_remove_cvref != 201711L
@@ -1723,7 +1696,7 @@ STATIC_ASSERT(__cpp_lib_remove_cvref == 201711L);
 #endif
 #endif
 
-#if CXX20_MODE
+#if _HAS_CXX20
 #ifndef __cpp_lib_shift
 #error BOOM
 #elif __cpp_lib_shift != 201806L
@@ -1737,7 +1710,7 @@ STATIC_ASSERT(__cpp_lib_shift == 201806L);
 #endif
 #endif
 
-#if CXX20_MODE
+#if _HAS_CXX20
 #ifndef __cpp_lib_span
 #error BOOM
 #elif __cpp_lib_span != 202002L
@@ -1751,7 +1724,7 @@ STATIC_ASSERT(__cpp_lib_span == 202002L);
 #endif
 #endif
 
-#if CXX20_MODE
+#if _HAS_CXX20
 #ifndef __cpp_lib_ssize
 #error BOOM
 #elif __cpp_lib_ssize != 201902L
@@ -1765,7 +1738,7 @@ STATIC_ASSERT(__cpp_lib_ssize == 201902L);
 #endif
 #endif
 
-#if CXX20_MODE
+#if _HAS_CXX20
 #ifndef __cpp_lib_starts_ends_with
 #error BOOM
 #elif __cpp_lib_starts_ends_with != 201711L
@@ -1779,7 +1752,7 @@ STATIC_ASSERT(__cpp_lib_starts_ends_with == 201711L);
 #endif
 #endif
 
-#if CXX20_MODE
+#if _HAS_CXX20
 #ifndef __cpp_lib_to_address
 #error BOOM
 #elif __cpp_lib_to_address != 201711L
@@ -1793,7 +1766,7 @@ STATIC_ASSERT(__cpp_lib_to_address == 201711L);
 #endif
 #endif
 
-#if CXX20_MODE
+#if _HAS_CXX20
 #ifndef __cpp_lib_to_array
 #error BOOM
 #elif __cpp_lib_to_array != 201907L
@@ -1807,7 +1780,7 @@ STATIC_ASSERT(__cpp_lib_to_array == 201907L);
 #endif
 #endif
 
-#if CXX20_MODE
+#if _HAS_CXX20
 #ifndef __cpp_lib_type_identity
 #error BOOM
 #elif __cpp_lib_type_identity != 201806L
@@ -1821,7 +1794,7 @@ STATIC_ASSERT(__cpp_lib_type_identity == 201806L);
 #endif
 #endif
 
-#if CXX20_MODE
+#if _HAS_CXX20
 #ifndef __cpp_lib_unwrap_ref
 #error BOOM
 #elif __cpp_lib_unwrap_ref != 201811L
@@ -1838,7 +1811,7 @@ STATIC_ASSERT(__cpp_lib_unwrap_ref == 201811L);
 
 // Conditionally defined in C++20-and-newer mode to specific values.
 
-#if CXX20_MODE && defined(__cpp_char8_t)
+#if _HAS_CXX20 && defined(__cpp_char8_t)
 #ifndef __cpp_lib_char8_t
 #error BOOM
 #elif __cpp_lib_char8_t != 201907L
@@ -1852,7 +1825,7 @@ STATIC_ASSERT(__cpp_lib_char8_t == 201907L);
 #endif
 #endif
 
-#if CXX20_MODE && defined(__cpp_concepts)
+#if _HAS_CXX20 && defined(__cpp_concepts)
 #ifndef __cpp_lib_concepts
 #error BOOM
 #elif __cpp_lib_concepts != 201907L

--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.cpp
@@ -10,422 +10,422 @@ int main() {} // COMPILE-ONLY
 #ifdef __has_cpp_attribute
 // Good
 #else
-#error Expected __has_cpp_attribute to be defined.
+#error __has_cpp_attribute is not defined
 #endif
 #if defined(__has_cpp_attribute)
 // Good
 #else
-#error Expected __has_cpp_attribute to be defined.
+#error __has_cpp_attribute is not defined
 #endif
 #ifndef __has_cpp_attribute
-#error Expected __has_cpp_attribute to be defined.
+#error __has_cpp_attribute is not defined
 #endif
 
 #if __has_cpp_attribute(carries_dependency) != 200809L
-#error Expected has_cpp_attribute(carries_dependency) to equal 200809L.
+#error has_cpp_attribute(carries_dependency) is not 200809L
 #endif
 
 #if __has_cpp_attribute(deprecated) != 201309L
-#error Expected has_cpp_attribute(deprecated) to equal 201309L.
+#error has_cpp_attribute(deprecated) is not 201309L
 #endif
 
 #if __has_cpp_attribute(noreturn) != 200809L
-#error Expected has_cpp_attribute(noreturn) to equal 200809L.
+#error has_cpp_attribute(noreturn) is not 200809L
 #endif
 
 #if defined(__clang__) || defined(__EDG__) // clang and EDG don't yet implement P1771R1
 #if __has_cpp_attribute(nodiscard) != 201603L
-#error Expected has_cpp_attribute(nodiscard) to equal 201603L.
+#error has_cpp_attribute(nodiscard) is not 201603L
 #endif
 #else
 #if __has_cpp_attribute(nodiscard) != 201907L
-#error Expected has_cpp_attribute(nodiscard) to equal 201907L.
+#error has_cpp_attribute(nodiscard) is not 201907L
 #endif
 #endif
 
 #if _HAS_CXX17 || defined(__clang__) || defined(__EDG__) // Clang and EDG provide this in C++14 mode.
 #if __has_cpp_attribute(fallthrough) != 201603L
-#error Expected has_cpp_attribute(fallthrough) to equal 201603L.
+#error has_cpp_attribute(fallthrough) is not 201603L
 #endif
 #else
 #if __has_cpp_attribute(fallthrough) != 0
-#error Expected has_cpp_attribute(fallthrough) to equal 0.
+#error has_cpp_attribute(fallthrough) is not 0
 #endif
 #endif
 
 #if _HAS_CXX17 || defined(__clang__) || defined(__EDG__) // Clang and EDG provide this in C++14 mode.
 #if __has_cpp_attribute(maybe_unused) != 201603L
-#error Expected has_cpp_attribute(maybe_unused) to equal 201603L.
+#error has_cpp_attribute(maybe_unused) is not 201603L
 #endif
 #else
 #if __has_cpp_attribute(maybe_unused) != 0
-#error Expected has_cpp_attribute(maybe_unused) to equal 0.
+#error has_cpp_attribute(maybe_unused) is not 0
 #endif
 #endif
 
 #if __has_cpp_attribute(noreturn) != 200809L
-#error Expected has_cpp_attribute(noreturn) to equal 200809L.
+#error has_cpp_attribute(noreturn) is not 200809L
 #endif
 
 
 // CORE LANGUAGE FEATURE-TEST MACROS
 
 #ifndef __cpp_aggregate_nsdmi
-#error Expected __cpp_aggregate_nsdmi to be defined.
+#error __cpp_aggregate_nsdmi is not defined
 #elif __cpp_aggregate_nsdmi != 201304L
-#error Expected cpp_aggregate_nsdmi to equal 201304L.
+#error cpp_aggregate_nsdmi is not 201304L
 #else
 STATIC_ASSERT(__cpp_aggregate_nsdmi == 201304L);
 #endif
 
 #ifndef __cpp_alias_templates
-#error Expected __cpp_alias_templates to be defined.
+#error __cpp_alias_templates is not defined
 #elif __cpp_alias_templates != 200704L
-#error Expected cpp_alias_templates to equal 200704L.
+#error cpp_alias_templates is not 200704L
 #else
 STATIC_ASSERT(__cpp_alias_templates == 200704L);
 #endif
 
 #ifndef __cpp_attributes
-#error Expected __cpp_attributes to be defined.
+#error __cpp_attributes is not defined
 #elif __cpp_attributes != 200809L
-#error Expected cpp_attributes to equal 200809L.
+#error cpp_attributes is not 200809L
 #else
 STATIC_ASSERT(__cpp_attributes == 200809L);
 #endif
 
 #ifndef __cpp_binary_literals
-#error Expected __cpp_binary_literals to be defined.
+#error __cpp_binary_literals is not defined
 #elif __cpp_binary_literals != 201304L
-#error Expected cpp_binary_literals to equal 201304L.
+#error cpp_binary_literals is not 201304L
 #else
 STATIC_ASSERT(__cpp_binary_literals == 201304L);
 #endif
 
 #ifndef __cpp_constexpr
-#error Expected __cpp_constexpr to be defined.
+#error __cpp_constexpr is not defined
 #elif _HAS_CXX17
 #if __cpp_constexpr != 201603L
-#error Expected cpp_constexpr to equal 201603L.
+#error cpp_constexpr is not 201603L
 #else
 STATIC_ASSERT(__cpp_constexpr == 201603L);
 #endif
 #else
 #if __cpp_constexpr != 201304L
-#error Expected cpp_constexpr to equal 201304L.
+#error cpp_constexpr is not 201304L
 #else
 STATIC_ASSERT(__cpp_constexpr == 201304L);
 #endif
 #endif
 
 #ifndef __cpp_decltype
-#error Expected __cpp_decltype to be defined.
+#error __cpp_decltype is not defined
 #elif __cpp_decltype != 200707L
-#error Expected cpp_decltype to equal 200707L.
+#error cpp_decltype is not 200707L
 #else
 STATIC_ASSERT(__cpp_decltype == 200707L);
 #endif
 
 #ifndef __cpp_decltype_auto
-#error Expected __cpp_decltype_auto to be defined.
+#error __cpp_decltype_auto is not defined
 #elif __cpp_decltype_auto != 201304L
-#error Expected cpp_decltype_auto to equal 201304L.
+#error cpp_decltype_auto is not 201304L
 #else
 STATIC_ASSERT(__cpp_decltype_auto == 201304L);
 #endif
 
 #ifndef __cpp_delegating_constructors
-#error Expected __cpp_delegating_constructors to be defined.
+#error __cpp_delegating_constructors is not defined
 #elif __cpp_delegating_constructors != 200604L
-#error Expected cpp_delegating_constructors to equal 200604L.
+#error cpp_delegating_constructors is not 200604L
 #else
 STATIC_ASSERT(__cpp_delegating_constructors == 200604L);
 #endif
 
 #ifndef __cpp_generic_lambdas
-#error Expected __cpp_generic_lambdas to be defined.
+#error __cpp_generic_lambdas is not defined
 #elif __cpp_generic_lambdas != 201304L
-#error Expected cpp_generic_lambdas to equal 201304L.
+#error cpp_generic_lambdas is not 201304L
 #else
 STATIC_ASSERT(__cpp_generic_lambdas == 201304L);
 #endif
 
 #ifndef __cpp_inheriting_constructors
-#error Expected __cpp_inheriting_constructors to be defined.
+#error __cpp_inheriting_constructors is not defined
 #elif (_HAS_CXX17 || defined(__clang__)) && !defined(__EDG__) // Clang implemented this C++17 feature unconditionally.
                                                               // TRANSITION, VSO-610203
 #if __cpp_inheriting_constructors != 201511L
-#error Expected cpp_inheriting_constructors to equal 201511L.
+#error cpp_inheriting_constructors is not 201511L
 #else
 STATIC_ASSERT(__cpp_inheriting_constructors == 201511L);
 #endif
 #else
 #if __cpp_inheriting_constructors != 200802L
-#error Expected cpp_inheriting_constructors to equal 200802L.
+#error cpp_inheriting_constructors is not 200802L
 #else
 STATIC_ASSERT(__cpp_inheriting_constructors == 200802L);
 #endif
 #endif
 
 #ifndef __cpp_init_captures
-#error Expected __cpp_init_captures to be defined.
+#error __cpp_init_captures is not defined
 #elif __cpp_init_captures != 201304L
-#error Expected cpp_init_captures to equal 201304L.
+#error cpp_init_captures is not 201304L
 #else
 STATIC_ASSERT(__cpp_init_captures == 201304L);
 #endif
 
 #ifndef __cpp_initializer_lists
-#error Expected __cpp_initializer_lists to be defined.
+#error __cpp_initializer_lists is not defined
 #elif __cpp_initializer_lists != 200806L
-#error Expected cpp_initializer_lists to equal 200806L.
+#error cpp_initializer_lists is not 200806L
 #else
 STATIC_ASSERT(__cpp_initializer_lists == 200806L);
 #endif
 
 #ifndef __cpp_lambdas
-#error Expected __cpp_lambdas to be defined.
+#error __cpp_lambdas is not defined
 #elif __cpp_lambdas != 200907L
-#error Expected cpp_lambdas to equal 200907L.
+#error cpp_lambdas is not 200907L
 #else
 STATIC_ASSERT(__cpp_lambdas == 200907L);
 #endif
 
 #ifndef __cpp_nsdmi
-#error Expected __cpp_nsdmi to be defined.
+#error __cpp_nsdmi is not defined
 #elif __cpp_nsdmi != 200809L
-#error Expected cpp_nsdmi to equal 200809L.
+#error cpp_nsdmi is not 200809L
 #else
 STATIC_ASSERT(__cpp_nsdmi == 200809L);
 #endif
 
 #ifndef __cpp_range_based_for
-#error Expected __cpp_range_based_for to be defined.
+#error __cpp_range_based_for is not defined
 #elif !defined(__clang__) || _HAS_CXX17 // C1XX implemented this C++17 feature unconditionally.
 #if __cpp_range_based_for != 201603L
-#error Expected cpp_range_based_for to equal 201603L.
+#error cpp_range_based_for is not 201603L
 #else
 STATIC_ASSERT(__cpp_range_based_for == 201603L);
 #endif
 #else
 #if __cpp_range_based_for != 200907L
-#error Expected cpp_range_based_for to equal 200907L.
+#error cpp_range_based_for is not 200907L
 #else
 STATIC_ASSERT(__cpp_range_based_for == 200907L);
 #endif
 #endif
 
 #ifndef __cpp_raw_strings
-#error Expected __cpp_raw_strings to be defined.
+#error __cpp_raw_strings is not defined
 #elif __cpp_raw_strings != 200710L
-#error Expected cpp_raw_strings to equal 200710L.
+#error cpp_raw_strings is not 200710L
 #else
 STATIC_ASSERT(__cpp_raw_strings == 200710L);
 #endif
 
 #ifndef __cpp_ref_qualifiers
-#error Expected __cpp_ref_qualifiers to be defined.
+#error __cpp_ref_qualifiers is not defined
 #elif __cpp_ref_qualifiers != 200710L
-#error Expected cpp_ref_qualifiers to equal 200710L.
+#error cpp_ref_qualifiers is not 200710L
 #else
 STATIC_ASSERT(__cpp_ref_qualifiers == 200710L);
 #endif
 
 #ifndef __cpp_return_type_deduction
-#error Expected __cpp_return_type_deduction to be defined.
+#error __cpp_return_type_deduction is not defined
 #elif __cpp_return_type_deduction != 201304L
-#error Expected cpp_return_type_deduction to equal 201304L.
+#error cpp_return_type_deduction is not 201304L
 #else
 STATIC_ASSERT(__cpp_return_type_deduction == 201304L);
 #endif
 
 #ifndef __cpp_rvalue_references
-#error Expected __cpp_rvalue_references to be defined.
+#error __cpp_rvalue_references is not defined
 #elif __cpp_rvalue_references != 200610L
-#error Expected cpp_rvalue_references to equal 200610L.
+#error cpp_rvalue_references is not 200610L
 #else
 STATIC_ASSERT(__cpp_rvalue_references == 200610L);
 #endif
 
 #ifndef __cpp_static_assert
-#error Expected __cpp_static_assert to be defined.
+#error __cpp_static_assert is not defined
 #elif _HAS_CXX17
 #if __cpp_static_assert != 201411L
-#error Expected cpp_static_assert to equal 201411L.
+#error cpp_static_assert is not 201411L
 #else
 STATIC_ASSERT(__cpp_static_assert == 201411L);
 #endif
 #else
 #if __cpp_static_assert != 200410L
-#error Expected cpp_static_assert to equal 200410L.
+#error cpp_static_assert is not 200410L
 #else
 STATIC_ASSERT(__cpp_static_assert == 200410L);
 #endif
 #endif
 
 #ifndef __cpp_unicode_characters
-#error Expected __cpp_unicode_characters to be defined.
+#error __cpp_unicode_characters is not defined
 #elif __cpp_unicode_characters != 200704L
-#error Expected cpp_unicode_characters to equal 200704L.
+#error cpp_unicode_characters is not 200704L
 #else
 STATIC_ASSERT(__cpp_unicode_characters == 200704L);
 #endif
 
 #ifndef __cpp_unicode_literals
-#error Expected __cpp_unicode_literals to be defined.
+#error __cpp_unicode_literals is not defined
 #elif __cpp_unicode_literals != 200710L
-#error Expected cpp_unicode_literals to equal 200710L.
+#error cpp_unicode_literals is not 200710L
 #else
 STATIC_ASSERT(__cpp_unicode_literals == 200710L);
 #endif
 
 #ifndef __cpp_user_defined_literals
-#error Expected __cpp_user_defined_literals to be defined.
+#error __cpp_user_defined_literals is not defined
 #elif __cpp_user_defined_literals != 200809L
-#error Expected cpp_user_defined_literals to equal 200809L.
+#error cpp_user_defined_literals is not 200809L
 #else
 STATIC_ASSERT(__cpp_user_defined_literals == 200809L);
 #endif
 
 #ifndef __cpp_variable_templates
-#error Expected __cpp_variable_templates to be defined.
+#error __cpp_variable_templates is not defined
 #elif __cpp_variable_templates != 201304L
-#error Expected cpp_variable_templates to equal 201304L.
+#error cpp_variable_templates is not 201304L
 #else
 STATIC_ASSERT(__cpp_variable_templates == 201304L);
 #endif
 
 #ifndef __cpp_variadic_templates
-#error Expected __cpp_variadic_templates to be defined.
+#error __cpp_variadic_templates is not defined
 #elif __cpp_variadic_templates != 200704L
-#error Expected cpp_variadic_templates to equal 200704L.
+#error cpp_variadic_templates is not 200704L
 #else
 STATIC_ASSERT(__cpp_variadic_templates == 200704L);
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_aggregate_bases
-#error Expected __cpp_aggregate_bases to be defined.
+#error __cpp_aggregate_bases is not defined
 #elif __cpp_aggregate_bases != 201603L
-#error Expected cpp_aggregate_bases to equal 201603L.
+#error cpp_aggregate_bases is not 201603L
 #else
 STATIC_ASSERT(__cpp_aggregate_bases == 201603L);
 #endif
 #else
 #ifdef __cpp_aggregate_bases
-#error Expected __cpp_aggregate_bases to NOT be defined.
+#error __cpp_aggregate_bases is defined
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_capture_star_this
-#error Expected __cpp_capture_star_this to be defined.
+#error __cpp_capture_star_this is not defined
 #elif __cpp_capture_star_this != 201603L
-#error Expected cpp_capture_star_this to equal 201603L.
+#error cpp_capture_star_this is not 201603L
 #else
 STATIC_ASSERT(__cpp_capture_star_this == 201603L);
 #endif
 #else
 #ifdef __cpp_capture_star_this
-#error Expected __cpp_capture_star_this to NOT be defined.
+#error __cpp_capture_star_this is defined
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_deduction_guides
-#error Expected __cpp_deduction_guides to be defined.
+#error __cpp_deduction_guides is not defined
 #elif __cpp_deduction_guides != 201703L
-#error Expected cpp_deduction_guides to equal 201703L.
+#error cpp_deduction_guides is not 201703L
 #else
 STATIC_ASSERT(__cpp_deduction_guides == 201703L);
 #endif
 #else
 #ifdef __cpp_deduction_guides
-#error Expected __cpp_deduction_guides to NOT be defined.
+#error __cpp_deduction_guides is defined
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_fold_expressions
-#error Expected __cpp_fold_expressions to be defined.
+#error __cpp_fold_expressions is not defined
 #elif __cpp_fold_expressions != 201603L
-#error Expected cpp_fold_expressions to equal 201603L.
+#error cpp_fold_expressions is not 201603L
 #else
 STATIC_ASSERT(__cpp_fold_expressions == 201603L);
 #endif
 #else
 #ifdef __cpp_fold_expressions
-#error Expected __cpp_fold_expressions to NOT be defined.
+#error __cpp_fold_expressions is defined
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_guaranteed_copy_elision
-#error Expected __cpp_guaranteed_copy_elision to be defined.
+#error __cpp_guaranteed_copy_elision is not defined
 #elif __cpp_guaranteed_copy_elision != 201606L
-#error Expected cpp_guaranteed_copy_elision to equal 201606L.
+#error cpp_guaranteed_copy_elision is not 201606L
 #else
 STATIC_ASSERT(__cpp_guaranteed_copy_elision == 201606L);
 #endif
 #else
 #ifdef __cpp_guaranteed_copy_elision
-#error Expected __cpp_guaranteed_copy_elision to NOT be defined.
+#error __cpp_guaranteed_copy_elision is defined
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_inline_variables
-#error Expected __cpp_inline_variables to be defined.
+#error __cpp_inline_variables is not defined
 #elif __cpp_inline_variables != 201606L
-#error Expected cpp_inline_variables to equal 201606L.
+#error cpp_inline_variables is not 201606L
 #else
 STATIC_ASSERT(__cpp_inline_variables == 201606L);
 #endif
 #else
 #ifdef __cpp_inline_variables
-#error Expected __cpp_inline_variables to NOT be defined.
+#error __cpp_inline_variables is defined
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_nontype_template_parameter_auto
-#error Expected __cpp_nontype_template_parameter_auto to be defined.
+#error __cpp_nontype_template_parameter_auto is not defined
 #elif __cpp_nontype_template_parameter_auto != 201606L
-#error Expected cpp_nontype_template_parameter_auto to equal 201606L.
+#error cpp_nontype_template_parameter_auto is not 201606L
 #else
 STATIC_ASSERT(__cpp_nontype_template_parameter_auto == 201606L);
 #endif
 #else
 #ifdef __cpp_nontype_template_parameter_auto
-#error Expected __cpp_nontype_template_parameter_auto to NOT be defined.
+#error __cpp_nontype_template_parameter_auto is defined
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_structured_bindings
-#error Expected __cpp_structured_bindings to be defined.
+#error __cpp_structured_bindings is not defined
 #elif __cpp_structured_bindings != 201606L
-#error Expected cpp_structured_bindings to equal 201606L.
+#error cpp_structured_bindings is not 201606L
 #else
 STATIC_ASSERT(__cpp_structured_bindings == 201606L);
 #endif
 #else
 #ifdef __cpp_structured_bindings
-#error Expected __cpp_structured_bindings to NOT be defined.
+#error __cpp_structured_bindings is defined
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_variadic_using
-#error Expected __cpp_variadic_using to be defined.
+#error __cpp_variadic_using is not defined
 #elif __cpp_variadic_using != 201611L
-#error Expected cpp_variadic_using to equal 201611L.
+#error cpp_variadic_using is not 201611L
 #else
 STATIC_ASSERT(__cpp_variadic_using == 201611L);
 #endif
 #else
 #ifdef __cpp_variadic_using
-#error Expected __cpp_variadic_using to NOT be defined.
+#error __cpp_variadic_using is defined
 #endif
 #endif
 
@@ -438,144 +438,144 @@ STATIC_ASSERT(__cpp_variadic_using == 201611L);
 // ambiguity errors for reasonable and previously-valid code. This issue is
 // expected to be rectified soon."
 #ifndef __cpp_template_template_args
-#error Expected __cpp_template_template_args to be defined.
+#error __cpp_template_template_args is not defined
 #elif __cpp_template_template_args != 201611L
-#error Expected cpp_template_template_args to equal 201611L.
+#error cpp_template_template_args is not 201611L
 #else
 STATIC_ASSERT(__cpp_template_template_args == 201611L);
 #endif
 #else
 #ifdef __cpp_template_template_args
-#error Expected __cpp_template_template_args to NOT be defined.
+#error __cpp_template_template_args is defined
 #endif
 #endif
 
 #if _HAS_CXX17 || !defined(__clang__) // C1XX implemented this C++17 feature unconditionally.
 #ifndef __cpp_enumerator_attributes
-#error Expected __cpp_enumerator_attributes to be defined.
+#error __cpp_enumerator_attributes is not defined
 #elif __cpp_enumerator_attributes != 201411L
-#error Expected cpp_enumerator_attributes to equal 201411L.
+#error cpp_enumerator_attributes is not 201411L
 #else
 STATIC_ASSERT(__cpp_enumerator_attributes == 201411L);
 #endif
 #else
 #ifdef __cpp_enumerator_attributes
-#error Expected __cpp_enumerator_attributes to NOT be defined.
+#error __cpp_enumerator_attributes is defined
 #endif
 #endif
 
 #if _HAS_CXX17 || !defined(__clang__) // C1XX implemented this C++17 feature unconditionally.
 #ifndef __cpp_namespace_attributes
-#error Expected __cpp_namespace_attributes to be defined.
+#error __cpp_namespace_attributes is not defined
 #elif __cpp_namespace_attributes != 201411L
-#error Expected cpp_namespace_attributes to equal 201411L.
+#error cpp_namespace_attributes is not 201411L
 #else
 STATIC_ASSERT(__cpp_namespace_attributes == 201411L);
 #endif
 #else
 #ifdef __cpp_namespace_attributes
-#error Expected __cpp_namespace_attributes to NOT be defined.
+#error __cpp_namespace_attributes is defined
 #endif
 #endif
 
 #if _HAS_CXX17 || defined(__EDG__) // EDG unconditionally reports "if constexpr" as being available.
 #ifndef __cpp_if_constexpr
-#error Expected __cpp_if_constexpr to be defined.
+#error __cpp_if_constexpr is not defined
 #elif __cpp_if_constexpr != 201606L
-#error Expected cpp_if_constexpr to equal 201606L.
+#error cpp_if_constexpr is not 201606L
 #else
 STATIC_ASSERT(__cpp_if_constexpr == 201606L);
 #endif
 #else
 #ifdef __cpp_if_constexpr
-#error Expected __cpp_if_constexpr to NOT be defined.
+#error __cpp_if_constexpr is defined
 #endif
 #endif
 
 #if _HAS_CXX17 || defined(__EDG__) // EDG unconditionally reports hex floats as being available.
 #ifndef __cpp_hex_float
-#error Expected __cpp_hex_float to be defined.
+#error __cpp_hex_float is not defined
 #elif __cpp_hex_float != 201603L
-#error Expected cpp_hex_float to equal 201603L.
+#error cpp_hex_float is not 201603L
 #else
 STATIC_ASSERT(__cpp_hex_float == 201603L);
 #endif
 #else
 #ifdef __cpp_hex_float
-#error Expected __cpp_hex_float to NOT be defined.
+#error __cpp_hex_float is defined
 #endif
 #endif
 
 #if _HAS_CXX20 && !defined(__clang__)
 // Clang only has partial support for <=> but that does not include the feature test macro.
 #ifndef __cpp_impl_three_way_comparison
-#error Expected __cpp_impl_three_way_comparison to be defined.
+#error __cpp_impl_three_way_comparison is not defined
 #elif defined(__EDG__) // EDG does not yet implement P1630R1 or P1186R3 so they still report the old value.
 #if __cpp_impl_three_way_comparison != 201711L
-#error Expected cpp_impl_three_way_comparison to equal 201711L.
+#error cpp_impl_three_way_comparison is not 201711L
 #else
 STATIC_ASSERT(__cpp_impl_three_way_comparison == 201711L);
 #endif
 #else
 #if __cpp_impl_three_way_comparison != 201907L
-#error Expected cpp_impl_three_way_comparison to equal 201907L.
+#error cpp_impl_three_way_comparison is not 201907L
 #else
 STATIC_ASSERT(__cpp_impl_three_way_comparison == 201907L);
 #endif
 #endif
 #else
 #ifdef __cpp_impl_three_way_comparison
-#error Expected __cpp_impl_three_way_comparison to NOT be defined.
+#error __cpp_impl_three_way_comparison is defined
 #endif
 #endif
 
 #if _HAS_CXX20 && !defined(__clang__) && !defined(__EDG__)
 #ifndef __cpp_nontype_template_args
-#error Expected __cpp_nontype_template_args to be defined.
+#error __cpp_nontype_template_args is not defined
 #elif __cpp_nontype_template_args != 201911L
-#error Expected cpp_nontype_template_args to equal 201911L.
+#error cpp_nontype_template_args is not 201911L
 #else
 STATIC_ASSERT(__cpp_nontype_template_args == 201911L);
 #endif
 #elif _HAS_CXX17
 #ifndef __cpp_nontype_template_args
-#error Expected __cpp_nontype_template_args to be defined.
+#error __cpp_nontype_template_args is not defined
 #elif __cpp_nontype_template_args != 201411L
-#error Expected cpp_nontype_template_args to equal 201411L.
+#error cpp_nontype_template_args is not 201411L
 #else
 STATIC_ASSERT(__cpp_nontype_template_args == 201411L);
 #endif
 #else
 #ifdef __cpp_nontype_template_args
-#error Expected __cpp_nontype_template_args to NOT be defined.
+#error __cpp_nontype_template_args is defined
 #endif
 #endif
 
 #if _HAS_CXX20 || defined(__EDG__)
 // EDG unconditionally reports "explicit(bool)" as being available.
 #ifndef __cpp_conditional_explicit
-#error Expected __cpp_conditional_explicit to be defined.
+#error __cpp_conditional_explicit is not defined
 #elif __cpp_conditional_explicit != 201806L
-#error Expected cpp_conditional_explicit to equal 201806L.
+#error cpp_conditional_explicit is not 201806L
 #else
 STATIC_ASSERT(__cpp_conditional_explicit == 201806L);
 #endif
 #else
 #ifdef __cpp_conditional_explicit
-#error Expected __cpp_conditional_explicit to NOT be defined.
+#error __cpp_conditional_explicit is defined
 #endif
 #endif
 
 // C++98, /EHs[-]
 #ifdef TEST_DISABLED_EXCEPTIONS
 #ifdef __cpp_exceptions
-#error Expected __cpp_exceptions to NOT be defined.
+#error __cpp_exceptions is defined
 #endif
 #else
 #ifndef __cpp_exceptions
-#error Expected __cpp_exceptions to be defined.
+#error __cpp_exceptions is not defined
 #elif __cpp_exceptions != 199711L
-#error Expected cpp_exceptions to equal 199711L.
+#error cpp_exceptions is not 199711L
 #else
 STATIC_ASSERT(__cpp_exceptions == 199711L);
 #endif
@@ -584,24 +584,24 @@ STATIC_ASSERT(__cpp_exceptions == 199711L);
 // C++98, /GR[-]
 #ifdef TEST_DISABLED_RTTI
 #ifdef __cpp_rtti
-#error Expected __cpp_rtti to NOT be defined.
+#error __cpp_rtti is defined
 #endif
 #else
 #ifdef __cpp_namespace_attributes
-#error Expected __cpp_namespace_attributes to NOT be defined.
+#error __cpp_namespace_attributes is defined
 #endif
 #endif
 
 // C++11, /Zc:threadSafeInit[-]
 #if defined(_M_CEE_PURE) || defined(TEST_DISABLED_THREADSAFE_STATIC_INIT)
 #ifdef __cpp_threadsafe_static_init
-#error Expected __cpp_threadsafe_static_init to NOT be defined.
+#error __cpp_threadsafe_static_init is defined
 #endif
 #else
 #ifndef __cpp_threadsafe_static_init
-#error Expected __cpp_threadsafe_static_init to be defined.
+#error __cpp_threadsafe_static_init is not defined
 #elif __cpp_threadsafe_static_init != 200806L
-#error Expected cpp_threadsafe_static_init to equal 200806L.
+#error cpp_threadsafe_static_init is not 200806L
 #else
 STATIC_ASSERT(__cpp_threadsafe_static_init == 200806L);
 #endif
@@ -610,13 +610,13 @@ STATIC_ASSERT(__cpp_threadsafe_static_init == 200806L);
 // C++14, /Zc:sizedDealloc[-]
 #if defined(TEST_DISABLED_SIZED_DEALLOCATION) || defined(__clang__) // Clang disables sized deallocation by default.
 #ifdef __cpp_sized_deallocation
-#error Expected __cpp_sized_deallocation to NOT be defined.
+#error __cpp_sized_deallocation is defined
 #endif
 #else
 #ifndef __cpp_sized_deallocation
-#error Expected __cpp_sized_deallocation to be defined.
+#error __cpp_sized_deallocation is not defined
 #elif __cpp_sized_deallocation != 201309L
-#error Expected cpp_sized_deallocation to equal 201309L.
+#error cpp_sized_deallocation is not 201309L
 #else
 STATIC_ASSERT(__cpp_sized_deallocation == 201309L);
 #endif
@@ -625,13 +625,13 @@ STATIC_ASSERT(__cpp_sized_deallocation == 201309L);
 // C++17, /Zc:alignedNew[-]
 #if !_HAS_CXX17 || defined(TEST_DISABLED_ALIGNED_NEW)
 #ifdef __cpp_aligned_new
-#error Expected __cpp_aligned_new to NOT be defined.
+#error __cpp_aligned_new is defined
 #endif
 #else
 #ifndef __cpp_aligned_new
-#error Expected __cpp_aligned_new to be defined.
+#error __cpp_aligned_new is not defined
 #elif __cpp_aligned_new != 201606L
-#error Expected cpp_aligned_new to equal 201606L.
+#error cpp_aligned_new is not 201606L
 #else
 STATIC_ASSERT(__cpp_aligned_new == 201606L);
 #endif
@@ -640,13 +640,13 @@ STATIC_ASSERT(__cpp_aligned_new == 201606L);
 // C++17, /Zc:noexceptTypes[-]
 #if !_HAS_CXX17 || defined(TEST_DISABLED_NOEXCEPT_FUNCTION_TYPE)
 #ifdef __cpp_noexcept_function_type
-#error Expected __cpp_noexcept_function_type to NOT be defined.
+#error __cpp_noexcept_function_type is defined
 #endif
 #else
 #ifndef __cpp_noexcept_function_type
-#error Expected __cpp_noexcept_function_type to be defined.
+#error __cpp_noexcept_function_type is not defined
 #elif __cpp_noexcept_function_type != 201510L
-#error Expected cpp_noexcept_function_type to equal 201510L.
+#error cpp_noexcept_function_type is not 201510L
 #else
 STATIC_ASSERT(__cpp_noexcept_function_type == 201510L);
 #endif
@@ -657,1146 +657,1146 @@ STATIC_ASSERT(__cpp_noexcept_function_type == 201510L);
 #include <version>
 
 #ifndef __cpp_lib_addressof_constexpr
-#error Expected __cpp_lib_addressof_constexpr to be defined.
+#error __cpp_lib_addressof_constexpr is not defined
 #elif __cpp_lib_addressof_constexpr != 201603L
-#error Expected cpp_lib_addressof_constexpr to equal 201603L.
+#error cpp_lib_addressof_constexpr is not 201603L
 #else
 STATIC_ASSERT(__cpp_lib_addressof_constexpr == 201603L);
 #endif
 
 #ifndef __cpp_lib_allocator_traits_is_always_equal
-#error Expected __cpp_lib_allocator_traits_is_always_equal to be defined.
+#error __cpp_lib_allocator_traits_is_always_equal is not defined
 #elif __cpp_lib_allocator_traits_is_always_equal != 201411L
-#error Expected cpp_lib_allocator_traits_is_always_equal to equal 201411L.
+#error cpp_lib_allocator_traits_is_always_equal is not 201411L
 #else
 STATIC_ASSERT(__cpp_lib_allocator_traits_is_always_equal == 201411L);
 #endif
 
 #ifndef __cpp_lib_as_const
-#error Expected __cpp_lib_as_const to be defined.
+#error __cpp_lib_as_const is not defined
 #elif __cpp_lib_as_const != 201510L
-#error Expected cpp_lib_as_const to equal 201510L.
+#error cpp_lib_as_const is not 201510L
 #else
 STATIC_ASSERT(__cpp_lib_as_const == 201510L);
 #endif
 
 #ifndef __cpp_lib_atomic_value_initialization
-#error Expected __cpp_lib_atomic_value_initialization to be defined.
+#error __cpp_lib_atomic_value_initialization is not defined
 #elif __cpp_lib_atomic_value_initialization != 201911L
-#error Expected cpp_lib_atomic_value_initialization to equal 201911L.
+#error cpp_lib_atomic_value_initialization is not 201911L
 #else
 STATIC_ASSERT(__cpp_lib_atomic_value_initialization == 201911L);
 #endif
 
 #ifndef __cpp_lib_bool_constant
-#error Expected __cpp_lib_bool_constant to be defined.
+#error __cpp_lib_bool_constant is not defined
 #elif __cpp_lib_bool_constant != 201505L
-#error Expected cpp_lib_bool_constant to equal 201505L.
+#error cpp_lib_bool_constant is not 201505L
 #else
 STATIC_ASSERT(__cpp_lib_bool_constant == 201505L);
 #endif
 
 #ifndef __cpp_lib_chrono
-#error Expected __cpp_lib_chrono to be defined.
+#error __cpp_lib_chrono is not defined
 #elif _HAS_CXX17
 #if __cpp_lib_chrono != 201611L
-#error Expected cpp_lib_chrono to equal 201611L.
+#error cpp_lib_chrono is not 201611L
 #else
 STATIC_ASSERT(__cpp_lib_chrono == 201611L);
 #endif
 #else
 #if __cpp_lib_chrono != 201510L
-#error Expected cpp_lib_chrono to equal 201510L.
+#error cpp_lib_chrono is not 201510L
 #else
 STATIC_ASSERT(__cpp_lib_chrono == 201510L);
 #endif
 #endif
 
 #ifndef __cpp_lib_chrono_udls
-#error Expected __cpp_lib_chrono_udls to be defined.
+#error __cpp_lib_chrono_udls is not defined
 #elif __cpp_lib_chrono_udls != 201304L
-#error Expected cpp_lib_chrono_udls to equal 201304L.
+#error cpp_lib_chrono_udls is not 201304L
 #else
 STATIC_ASSERT(__cpp_lib_chrono_udls == 201304L);
 #endif
 
 #ifndef __cpp_lib_complex_udls
-#error Expected __cpp_lib_complex_udls to be defined.
+#error __cpp_lib_complex_udls is not defined
 #elif __cpp_lib_complex_udls != 201309L
-#error Expected cpp_lib_complex_udls to equal 201309L.
+#error cpp_lib_complex_udls is not 201309L
 #else
 STATIC_ASSERT(__cpp_lib_complex_udls == 201309L);
 #endif
 
 #ifndef __cpp_lib_enable_shared_from_this
-#error Expected __cpp_lib_enable_shared_from_this to be defined.
+#error __cpp_lib_enable_shared_from_this is not defined
 #elif __cpp_lib_enable_shared_from_this != 201603L
-#error Expected cpp_lib_enable_shared_from_this to equal 201603L.
+#error cpp_lib_enable_shared_from_this is not 201603L
 #else
 STATIC_ASSERT(__cpp_lib_enable_shared_from_this == 201603L);
 #endif
 
 #ifndef __cpp_lib_exchange_function
-#error Expected __cpp_lib_exchange_function to be defined.
+#error __cpp_lib_exchange_function is not defined
 #elif __cpp_lib_exchange_function != 201304L
-#error Expected cpp_lib_exchange_function to equal 201304L.
+#error cpp_lib_exchange_function is not 201304L
 #else
 STATIC_ASSERT(__cpp_lib_exchange_function == 201304L);
 #endif
 
 #ifndef __cpp_lib_experimental_erase_if
-#error Expected __cpp_lib_experimental_erase_if to be defined.
+#error __cpp_lib_experimental_erase_if is not defined
 #elif __cpp_lib_experimental_erase_if != 201411L
-#error Expected cpp_lib_experimental_erase_if to equal 201411L.
+#error cpp_lib_experimental_erase_if is not 201411L
 #else
 STATIC_ASSERT(__cpp_lib_experimental_erase_if == 201411L);
 #endif
 
 #ifndef __cpp_lib_experimental_filesystem
-#error Expected __cpp_lib_experimental_filesystem to be defined.
+#error __cpp_lib_experimental_filesystem is not defined
 #elif __cpp_lib_experimental_filesystem != 201406L
-#error Expected cpp_lib_experimental_filesystem to equal 201406L.
+#error cpp_lib_experimental_filesystem is not 201406L
 #else
 STATIC_ASSERT(__cpp_lib_experimental_filesystem == 201406L);
 #endif
 
 #ifndef __cpp_lib_generic_associative_lookup
-#error Expected __cpp_lib_generic_associative_lookup to be defined.
+#error __cpp_lib_generic_associative_lookup is not defined
 #elif __cpp_lib_generic_associative_lookup != 201304L
-#error Expected cpp_lib_generic_associative_lookup to equal 201304L.
+#error cpp_lib_generic_associative_lookup is not 201304L
 #else
 STATIC_ASSERT(__cpp_lib_generic_associative_lookup == 201304L);
 #endif
 
 #ifndef __cpp_lib_incomplete_container_elements
-#error Expected __cpp_lib_incomplete_container_elements to be defined.
+#error __cpp_lib_incomplete_container_elements is not defined
 #elif __cpp_lib_incomplete_container_elements != 201505L
-#error Expected cpp_lib_incomplete_container_elements to equal 201505L.
+#error cpp_lib_incomplete_container_elements is not 201505L
 #else
 STATIC_ASSERT(__cpp_lib_incomplete_container_elements == 201505L);
 #endif
 
 #ifndef __cpp_lib_integer_sequence
-#error Expected __cpp_lib_integer_sequence to be defined.
+#error __cpp_lib_integer_sequence is not defined
 #elif __cpp_lib_integer_sequence != 201304L
-#error Expected cpp_lib_integer_sequence to equal 201304L.
+#error cpp_lib_integer_sequence is not 201304L
 #else
 STATIC_ASSERT(__cpp_lib_integer_sequence == 201304L);
 #endif
 
 #ifndef __cpp_lib_integral_constant_callable
-#error Expected __cpp_lib_integral_constant_callable to be defined.
+#error __cpp_lib_integral_constant_callable is not defined
 #elif __cpp_lib_integral_constant_callable != 201304L
-#error Expected cpp_lib_integral_constant_callable to equal 201304L.
+#error cpp_lib_integral_constant_callable is not 201304L
 #else
 STATIC_ASSERT(__cpp_lib_integral_constant_callable == 201304L);
 #endif
 
 #ifndef __cpp_lib_invoke
-#error Expected __cpp_lib_invoke to be defined.
+#error __cpp_lib_invoke is not defined
 #elif __cpp_lib_invoke != 201411L
-#error Expected cpp_lib_invoke to equal 201411L.
+#error cpp_lib_invoke is not 201411L
 #else
 STATIC_ASSERT(__cpp_lib_invoke == 201411L);
 #endif
 
 #ifndef __cpp_lib_is_final
-#error Expected __cpp_lib_is_final to be defined.
+#error __cpp_lib_is_final is not defined
 #elif __cpp_lib_is_final != 201402L
-#error Expected cpp_lib_is_final to equal 201402L.
+#error cpp_lib_is_final is not 201402L
 #else
 STATIC_ASSERT(__cpp_lib_is_final == 201402L);
 #endif
 
 #ifndef __cpp_lib_is_null_pointer
-#error Expected __cpp_lib_is_null_pointer to be defined.
+#error __cpp_lib_is_null_pointer is not defined
 #elif __cpp_lib_is_null_pointer != 201309L
-#error Expected cpp_lib_is_null_pointer to equal 201309L.
+#error cpp_lib_is_null_pointer is not 201309L
 #else
 STATIC_ASSERT(__cpp_lib_is_null_pointer == 201309L);
 #endif
 
 #ifndef __cpp_lib_logical_traits
-#error Expected __cpp_lib_logical_traits to be defined.
+#error __cpp_lib_logical_traits is not defined
 #elif __cpp_lib_logical_traits != 201510L
-#error Expected cpp_lib_logical_traits to equal 201510L.
+#error cpp_lib_logical_traits is not 201510L
 #else
 STATIC_ASSERT(__cpp_lib_logical_traits == 201510L);
 #endif
 
 #ifndef __cpp_lib_make_reverse_iterator
-#error Expected __cpp_lib_make_reverse_iterator to be defined.
+#error __cpp_lib_make_reverse_iterator is not defined
 #elif __cpp_lib_make_reverse_iterator != 201402L
-#error Expected cpp_lib_make_reverse_iterator to equal 201402L.
+#error cpp_lib_make_reverse_iterator is not 201402L
 #else
 STATIC_ASSERT(__cpp_lib_make_reverse_iterator == 201402L);
 #endif
 
 #ifndef __cpp_lib_make_unique
-#error Expected __cpp_lib_make_unique to be defined.
+#error __cpp_lib_make_unique is not defined
 #elif __cpp_lib_make_unique != 201304L
-#error Expected cpp_lib_make_unique to equal 201304L.
+#error cpp_lib_make_unique is not 201304L
 #else
 STATIC_ASSERT(__cpp_lib_make_unique == 201304L);
 #endif
 
 #ifndef __cpp_lib_map_try_emplace
-#error Expected __cpp_lib_map_try_emplace to be defined.
+#error __cpp_lib_map_try_emplace is not defined
 #elif __cpp_lib_map_try_emplace != 201411L
-#error Expected cpp_lib_map_try_emplace to equal 201411L.
+#error cpp_lib_map_try_emplace is not 201411L
 #else
 STATIC_ASSERT(__cpp_lib_map_try_emplace == 201411L);
 #endif
 
 #ifndef __cpp_lib_nonmember_container_access
-#error Expected __cpp_lib_nonmember_container_access to be defined.
+#error __cpp_lib_nonmember_container_access is not defined
 #elif __cpp_lib_nonmember_container_access != 201411L
-#error Expected cpp_lib_nonmember_container_access to equal 201411L.
+#error cpp_lib_nonmember_container_access is not 201411L
 #else
 STATIC_ASSERT(__cpp_lib_nonmember_container_access == 201411L);
 #endif
 
 #ifndef __cpp_lib_null_iterators
-#error Expected __cpp_lib_null_iterators to be defined.
+#error __cpp_lib_null_iterators is not defined
 #elif __cpp_lib_null_iterators != 201304L
-#error Expected cpp_lib_null_iterators to equal 201304L.
+#error cpp_lib_null_iterators is not 201304L
 #else
 STATIC_ASSERT(__cpp_lib_null_iterators == 201304L);
 #endif
 
 #ifndef __cpp_lib_quoted_string_io
-#error Expected __cpp_lib_quoted_string_io to be defined.
+#error __cpp_lib_quoted_string_io is not defined
 #elif __cpp_lib_quoted_string_io != 201304L
-#error Expected cpp_lib_quoted_string_io to equal 201304L.
+#error cpp_lib_quoted_string_io is not 201304L
 #else
 STATIC_ASSERT(__cpp_lib_quoted_string_io == 201304L);
 #endif
 
 #ifndef __cpp_lib_result_of_sfinae
-#error Expected __cpp_lib_result_of_sfinae to be defined.
+#error __cpp_lib_result_of_sfinae is not defined
 #elif __cpp_lib_result_of_sfinae != 201210L
-#error Expected cpp_lib_result_of_sfinae to equal 201210L.
+#error cpp_lib_result_of_sfinae is not 201210L
 #else
 STATIC_ASSERT(__cpp_lib_result_of_sfinae == 201210L);
 #endif
 
 #ifndef __cpp_lib_robust_nonmodifying_seq_ops
-#error Expected __cpp_lib_robust_nonmodifying_seq_ops to be defined.
+#error __cpp_lib_robust_nonmodifying_seq_ops is not defined
 #elif __cpp_lib_robust_nonmodifying_seq_ops != 201304L
-#error Expected cpp_lib_robust_nonmodifying_seq_ops to equal 201304L.
+#error cpp_lib_robust_nonmodifying_seq_ops is not 201304L
 #else
 STATIC_ASSERT(__cpp_lib_robust_nonmodifying_seq_ops == 201304L);
 #endif
 
 #ifndef __cpp_lib_shared_mutex
-#error Expected __cpp_lib_shared_mutex to be defined.
+#error __cpp_lib_shared_mutex is not defined
 #elif __cpp_lib_shared_mutex != 201505L
-#error Expected cpp_lib_shared_mutex to equal 201505L.
+#error cpp_lib_shared_mutex is not 201505L
 #else
 STATIC_ASSERT(__cpp_lib_shared_mutex == 201505L);
 #endif
 
 #ifndef __cpp_lib_shared_ptr_arrays
-#error Expected __cpp_lib_shared_ptr_arrays to be defined.
+#error __cpp_lib_shared_ptr_arrays is not defined
 #elif __cpp_lib_shared_ptr_arrays != 201611L
-#error Expected cpp_lib_shared_ptr_arrays to equal 201611L.
+#error cpp_lib_shared_ptr_arrays is not 201611L
 #else
 STATIC_ASSERT(__cpp_lib_shared_ptr_arrays == 201611L);
 #endif
 
 #ifndef __cpp_lib_string_udls
-#error Expected __cpp_lib_string_udls to be defined.
+#error __cpp_lib_string_udls is not defined
 #elif __cpp_lib_string_udls != 201304L
-#error Expected cpp_lib_string_udls to equal 201304L.
+#error cpp_lib_string_udls is not 201304L
 #else
 STATIC_ASSERT(__cpp_lib_string_udls == 201304L);
 #endif
 
 #ifndef __cpp_lib_transformation_trait_aliases
-#error Expected __cpp_lib_transformation_trait_aliases to be defined.
+#error __cpp_lib_transformation_trait_aliases is not defined
 #elif __cpp_lib_transformation_trait_aliases != 201304L
-#error Expected cpp_lib_transformation_trait_aliases to equal 201304L.
+#error cpp_lib_transformation_trait_aliases is not 201304L
 #else
 STATIC_ASSERT(__cpp_lib_transformation_trait_aliases == 201304L);
 #endif
 
 #ifndef __cpp_lib_transparent_operators
-#error Expected __cpp_lib_transparent_operators to be defined.
+#error __cpp_lib_transparent_operators is not defined
 #elif __cpp_lib_transparent_operators != 201510L
-#error Expected cpp_lib_transparent_operators to equal 201510L.
+#error cpp_lib_transparent_operators is not 201510L
 #else
 STATIC_ASSERT(__cpp_lib_transparent_operators == 201510L);
 #endif
 
 #ifndef __cpp_lib_tuple_element_t
-#error Expected __cpp_lib_tuple_element_t to be defined.
+#error __cpp_lib_tuple_element_t is not defined
 #elif __cpp_lib_tuple_element_t != 201402L
-#error Expected cpp_lib_tuple_element_t to equal 201402L.
+#error cpp_lib_tuple_element_t is not 201402L
 #else
 STATIC_ASSERT(__cpp_lib_tuple_element_t == 201402L);
 #endif
 
 #ifndef __cpp_lib_tuples_by_type
-#error Expected __cpp_lib_tuples_by_type to be defined.
+#error __cpp_lib_tuples_by_type is not defined
 #elif __cpp_lib_tuples_by_type != 201304L
-#error Expected cpp_lib_tuples_by_type to equal 201304L.
+#error cpp_lib_tuples_by_type is not 201304L
 #else
 STATIC_ASSERT(__cpp_lib_tuples_by_type == 201304L);
 #endif
 
 #ifndef __cpp_lib_type_trait_variable_templates
-#error Expected __cpp_lib_type_trait_variable_templates to be defined.
+#error __cpp_lib_type_trait_variable_templates is not defined
 #elif __cpp_lib_type_trait_variable_templates != 201510L
-#error Expected cpp_lib_type_trait_variable_templates to equal 201510L.
+#error cpp_lib_type_trait_variable_templates is not 201510L
 #else
 STATIC_ASSERT(__cpp_lib_type_trait_variable_templates == 201510L);
 #endif
 
 #ifndef __cpp_lib_uncaught_exceptions
-#error Expected __cpp_lib_uncaught_exceptions to be defined.
+#error __cpp_lib_uncaught_exceptions is not defined
 #elif __cpp_lib_uncaught_exceptions != 201411L
-#error Expected cpp_lib_uncaught_exceptions to equal 201411L.
+#error cpp_lib_uncaught_exceptions is not 201411L
 #else
 STATIC_ASSERT(__cpp_lib_uncaught_exceptions == 201411L);
 #endif
 
 #ifndef __cpp_lib_unordered_map_try_emplace
-#error Expected __cpp_lib_unordered_map_try_emplace to be defined.
+#error __cpp_lib_unordered_map_try_emplace is not defined
 #elif __cpp_lib_unordered_map_try_emplace != 201411L
-#error Expected cpp_lib_unordered_map_try_emplace to equal 201411L.
+#error cpp_lib_unordered_map_try_emplace is not 201411L
 #else
 STATIC_ASSERT(__cpp_lib_unordered_map_try_emplace == 201411L);
 #endif
 
 #ifndef __cpp_lib_void_t
-#error Expected __cpp_lib_void_t to be defined.
+#error __cpp_lib_void_t is not defined
 #elif __cpp_lib_void_t != 201411L
-#error Expected cpp_lib_void_t to equal 201411L.
+#error cpp_lib_void_t is not 201411L
 #else
 STATIC_ASSERT(__cpp_lib_void_t == 201411L);
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_lib_any
-#error Expected __cpp_lib_any to be defined.
+#error __cpp_lib_any is not defined
 #elif __cpp_lib_any != 201606L
-#error Expected cpp_lib_any to equal 201606L.
+#error cpp_lib_any is not 201606L
 #else
 STATIC_ASSERT(__cpp_lib_any == 201606L);
 #endif
 #else
 #ifdef __cpp_lib_any
-#error Expected __cpp_lib_any to NOT be defined.
+#error __cpp_lib_any is defined
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_lib_apply
-#error Expected __cpp_lib_apply to be defined.
+#error __cpp_lib_apply is not defined
 #elif __cpp_lib_apply != 201603L
-#error Expected cpp_lib_apply to equal 201603L.
+#error cpp_lib_apply is not 201603L
 #else
 STATIC_ASSERT(__cpp_lib_apply == 201603L);
 #endif
 #else
 #ifdef __cpp_lib_apply
-#error Expected __cpp_lib_apply to NOT be defined.
+#error __cpp_lib_apply is defined
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_lib_array_constexpr
-#error Expected __cpp_lib_array_constexpr to be defined.
+#error __cpp_lib_array_constexpr is not defined
 #elif __cpp_lib_array_constexpr != 201803L
-#error Expected cpp_lib_array_constexpr to equal 201803L.
+#error cpp_lib_array_constexpr is not 201803L
 #else
 STATIC_ASSERT(__cpp_lib_array_constexpr == 201803L);
 #endif
 #else
 #ifdef __cpp_lib_array_constexpr
-#error Expected __cpp_lib_array_constexpr to NOT be defined.
+#error __cpp_lib_array_constexpr is defined
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_lib_atomic_is_always_lock_free
-#error Expected __cpp_lib_atomic_is_always_lock_free to be defined.
+#error __cpp_lib_atomic_is_always_lock_free is not defined
 #elif __cpp_lib_atomic_is_always_lock_free != 201603L
-#error Expected cpp_lib_atomic_is_always_lock_free to equal 201603L.
+#error cpp_lib_atomic_is_always_lock_free is not 201603L
 #else
 STATIC_ASSERT(__cpp_lib_atomic_is_always_lock_free == 201603L);
 #endif
 #else
 #ifdef __cpp_lib_atomic_is_always_lock_free
-#error Expected __cpp_lib_atomic_is_always_lock_free to NOT be defined.
+#error __cpp_lib_atomic_is_always_lock_free is defined
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_lib_boyer_moore_searcher
-#error Expected __cpp_lib_boyer_moore_searcher to be defined.
+#error __cpp_lib_boyer_moore_searcher is not defined
 #elif __cpp_lib_boyer_moore_searcher != 201603L
-#error Expected cpp_lib_boyer_moore_searcher to equal 201603L.
+#error cpp_lib_boyer_moore_searcher is not 201603L
 #else
 STATIC_ASSERT(__cpp_lib_boyer_moore_searcher == 201603L);
 #endif
 #else
 #ifdef __cpp_lib_boyer_moore_searcher
-#error Expected __cpp_lib_boyer_moore_searcher to NOT be defined.
+#error __cpp_lib_boyer_moore_searcher is defined
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_lib_clamp
-#error Expected __cpp_lib_clamp to be defined.
+#error __cpp_lib_clamp is not defined
 #elif __cpp_lib_clamp != 201603L
-#error Expected cpp_lib_clamp to equal 201603L.
+#error cpp_lib_clamp is not 201603L
 #else
 STATIC_ASSERT(__cpp_lib_clamp == 201603L);
 #endif
 #else
 #ifdef __cpp_lib_clamp
-#error Expected __cpp_lib_clamp to NOT be defined.
+#error __cpp_lib_clamp is defined
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_lib_filesystem
-#error Expected __cpp_lib_filesystem to be defined.
+#error __cpp_lib_filesystem is not defined
 #elif __cpp_lib_filesystem != 201703L
-#error Expected cpp_lib_filesystem to equal 201703L.
+#error cpp_lib_filesystem is not 201703L
 #else
 STATIC_ASSERT(__cpp_lib_filesystem == 201703L);
 #endif
 #else
 #ifdef __cpp_lib_filesystem
-#error Expected __cpp_lib_filesystem to NOT be defined.
+#error __cpp_lib_filesystem is defined
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_lib_gcd_lcm
-#error Expected __cpp_lib_gcd_lcm to be defined.
+#error __cpp_lib_gcd_lcm is not defined
 #elif __cpp_lib_gcd_lcm != 201606L
-#error Expected cpp_lib_gcd_lcm to equal 201606L.
+#error cpp_lib_gcd_lcm is not 201606L
 #else
 STATIC_ASSERT(__cpp_lib_gcd_lcm == 201606L);
 #endif
 #else
 #ifdef __cpp_lib_gcd_lcm
-#error Expected __cpp_lib_gcd_lcm to NOT be defined.
+#error __cpp_lib_gcd_lcm is defined
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_lib_hardware_interference_size
-#error Expected __cpp_lib_hardware_interference_size to be defined.
+#error __cpp_lib_hardware_interference_size is not defined
 #elif __cpp_lib_hardware_interference_size != 201703L
-#error Expected cpp_lib_hardware_interference_size to equal 201703L.
+#error cpp_lib_hardware_interference_size is not 201703L
 #else
 STATIC_ASSERT(__cpp_lib_hardware_interference_size == 201703L);
 #endif
 #else
 #ifdef __cpp_lib_hardware_interference_size
-#error Expected __cpp_lib_hardware_interference_size to NOT be defined.
+#error __cpp_lib_hardware_interference_size is defined
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_lib_has_unique_object_representations
-#error Expected __cpp_lib_has_unique_object_representations to be defined.
+#error __cpp_lib_has_unique_object_representations is not defined
 #elif __cpp_lib_has_unique_object_representations != 201606L
-#error Expected cpp_lib_has_unique_object_representations to equal 201606L.
+#error cpp_lib_has_unique_object_representations is not 201606L
 #else
 STATIC_ASSERT(__cpp_lib_has_unique_object_representations == 201606L);
 #endif
 #else
 #ifdef __cpp_lib_has_unique_object_representations
-#error Expected __cpp_lib_has_unique_object_representations to NOT be defined.
+#error __cpp_lib_has_unique_object_representations is defined
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_lib_hypot
-#error Expected __cpp_lib_hypot to be defined.
+#error __cpp_lib_hypot is not defined
 #elif __cpp_lib_hypot != 201603L
-#error Expected cpp_lib_hypot to equal 201603L.
+#error cpp_lib_hypot is not 201603L
 #else
 STATIC_ASSERT(__cpp_lib_hypot == 201603L);
 #endif
 #else
 #ifdef __cpp_lib_hypot
-#error Expected __cpp_lib_hypot to NOT be defined.
+#error __cpp_lib_hypot is defined
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_lib_is_aggregate
-#error Expected __cpp_lib_is_aggregate to be defined.
+#error __cpp_lib_is_aggregate is not defined
 #elif __cpp_lib_is_aggregate != 201703L
-#error Expected cpp_lib_is_aggregate to equal 201703L.
+#error cpp_lib_is_aggregate is not 201703L
 #else
 STATIC_ASSERT(__cpp_lib_is_aggregate == 201703L);
 #endif
 #else
 #ifdef __cpp_lib_is_aggregate
-#error Expected __cpp_lib_is_aggregate to NOT be defined.
+#error __cpp_lib_is_aggregate is defined
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_lib_is_invocable
-#error Expected __cpp_lib_is_invocable to be defined.
+#error __cpp_lib_is_invocable is not defined
 #elif __cpp_lib_is_invocable != 201703L
-#error Expected cpp_lib_is_invocable to equal 201703L.
+#error cpp_lib_is_invocable is not 201703L
 #else
 STATIC_ASSERT(__cpp_lib_is_invocable == 201703L);
 #endif
 #else
 #ifdef __cpp_lib_is_invocable
-#error Expected __cpp_lib_is_invocable to NOT be defined.
+#error __cpp_lib_is_invocable is defined
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_lib_is_swappable
-#error Expected __cpp_lib_is_swappable to be defined.
+#error __cpp_lib_is_swappable is not defined
 #elif __cpp_lib_is_swappable != 201603L
-#error Expected cpp_lib_is_swappable to equal 201603L.
+#error cpp_lib_is_swappable is not 201603L
 #else
 STATIC_ASSERT(__cpp_lib_is_swappable == 201603L);
 #endif
 #else
 #ifdef __cpp_lib_is_swappable
-#error Expected __cpp_lib_is_swappable to NOT be defined.
+#error __cpp_lib_is_swappable is defined
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_lib_launder
-#error Expected __cpp_lib_launder to be defined.
+#error __cpp_lib_launder is not defined
 #elif __cpp_lib_launder != 201606L
-#error Expected cpp_lib_launder to equal 201606L.
+#error cpp_lib_launder is not 201606L
 #else
 STATIC_ASSERT(__cpp_lib_launder == 201606L);
 #endif
 #else
 #ifdef __cpp_lib_launder
-#error Expected __cpp_lib_launder to NOT be defined.
+#error __cpp_lib_launder is defined
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_lib_make_from_tuple
-#error Expected __cpp_lib_make_from_tuple to be defined.
+#error __cpp_lib_make_from_tuple is not defined
 #elif __cpp_lib_make_from_tuple != 201606L
-#error Expected cpp_lib_make_from_tuple to equal 201606L.
+#error cpp_lib_make_from_tuple is not 201606L
 #else
 STATIC_ASSERT(__cpp_lib_make_from_tuple == 201606L);
 #endif
 #else
 #ifdef __cpp_lib_make_from_tuple
-#error Expected __cpp_lib_make_from_tuple to NOT be defined.
+#error __cpp_lib_make_from_tuple is defined
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_lib_math_special_functions
-#error Expected __cpp_lib_math_special_functions to be defined.
+#error __cpp_lib_math_special_functions is not defined
 #elif __cpp_lib_math_special_functions != 201603L
-#error Expected cpp_lib_math_special_functions to equal 201603L.
+#error cpp_lib_math_special_functions is not 201603L
 #else
 STATIC_ASSERT(__cpp_lib_math_special_functions == 201603L);
 #endif
 #else
 #ifdef __cpp_lib_math_special_functions
-#error Expected __cpp_lib_math_special_functions to NOT be defined.
+#error __cpp_lib_math_special_functions is defined
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_lib_memory_resource
-#error Expected __cpp_lib_memory_resource to be defined.
+#error __cpp_lib_memory_resource is not defined
 #elif __cpp_lib_memory_resource != 201603L
-#error Expected cpp_lib_memory_resource to equal 201603L.
+#error cpp_lib_memory_resource is not 201603L
 #else
 STATIC_ASSERT(__cpp_lib_memory_resource == 201603L);
 #endif
 #else
 #ifdef __cpp_lib_memory_resource
-#error Expected __cpp_lib_memory_resource to NOT be defined.
+#error __cpp_lib_memory_resource is defined
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_lib_node_extract
-#error Expected __cpp_lib_node_extract to be defined.
+#error __cpp_lib_node_extract is not defined
 #elif __cpp_lib_node_extract != 201606L
-#error Expected cpp_lib_node_extract to equal 201606L.
+#error cpp_lib_node_extract is not 201606L
 #else
 STATIC_ASSERT(__cpp_lib_node_extract == 201606L);
 #endif
 #else
 #ifdef __cpp_lib_node_extract
-#error Expected __cpp_lib_node_extract to NOT be defined.
+#error __cpp_lib_node_extract is defined
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_lib_not_fn
-#error Expected __cpp_lib_not_fn to be defined.
+#error __cpp_lib_not_fn is not defined
 #elif __cpp_lib_not_fn != 201603L
-#error Expected cpp_lib_not_fn to equal 201603L.
+#error cpp_lib_not_fn is not 201603L
 #else
 STATIC_ASSERT(__cpp_lib_not_fn == 201603L);
 #endif
 #else
 #ifdef __cpp_lib_not_fn
-#error Expected __cpp_lib_not_fn to NOT be defined.
+#error __cpp_lib_not_fn is defined
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_lib_optional
-#error Expected __cpp_lib_optional to be defined.
+#error __cpp_lib_optional is not defined
 #elif __cpp_lib_optional != 201606L
-#error Expected cpp_lib_optional to equal 201606L.
+#error cpp_lib_optional is not 201606L
 #else
 STATIC_ASSERT(__cpp_lib_optional == 201606L);
 #endif
 #else
 #ifdef __cpp_lib_optional
-#error Expected __cpp_lib_optional to NOT be defined.
+#error __cpp_lib_optional is defined
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_lib_raw_memory_algorithms
-#error Expected __cpp_lib_raw_memory_algorithms to be defined.
+#error __cpp_lib_raw_memory_algorithms is not defined
 #elif __cpp_lib_raw_memory_algorithms != 201606L
-#error Expected cpp_lib_raw_memory_algorithms to equal 201606L.
+#error cpp_lib_raw_memory_algorithms is not 201606L
 #else
 STATIC_ASSERT(__cpp_lib_raw_memory_algorithms == 201606L);
 #endif
 #else
 #ifdef __cpp_lib_raw_memory_algorithms
-#error Expected __cpp_lib_raw_memory_algorithms to NOT be defined.
+#error __cpp_lib_raw_memory_algorithms is defined
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_lib_sample
-#error Expected __cpp_lib_sample to be defined.
+#error __cpp_lib_sample is not defined
 #elif __cpp_lib_sample != 201603L
-#error Expected cpp_lib_sample to equal 201603L.
+#error cpp_lib_sample is not 201603L
 #else
 STATIC_ASSERT(__cpp_lib_sample == 201603L);
 #endif
 #else
 #ifdef __cpp_lib_sample
-#error Expected __cpp_lib_sample to NOT be defined.
+#error __cpp_lib_sample is defined
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_lib_scoped_lock
-#error Expected __cpp_lib_scoped_lock to be defined.
+#error __cpp_lib_scoped_lock is not defined
 #elif __cpp_lib_scoped_lock != 201703L
-#error Expected cpp_lib_scoped_lock to equal 201703L.
+#error cpp_lib_scoped_lock is not 201703L
 #else
 STATIC_ASSERT(__cpp_lib_scoped_lock == 201703L);
 #endif
 #else
 #ifdef __cpp_lib_scoped_lock
-#error Expected __cpp_lib_scoped_lock to NOT be defined.
+#error __cpp_lib_scoped_lock is defined
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_lib_shared_ptr_weak_type
-#error Expected __cpp_lib_shared_ptr_weak_type to be defined.
+#error __cpp_lib_shared_ptr_weak_type is not defined
 #elif __cpp_lib_shared_ptr_weak_type != 201606L
-#error Expected cpp_lib_shared_ptr_weak_type to equal 201606L.
+#error cpp_lib_shared_ptr_weak_type is not 201606L
 #else
 STATIC_ASSERT(__cpp_lib_shared_ptr_weak_type == 201606L);
 #endif
 #else
 #ifdef __cpp_lib_shared_ptr_weak_type
-#error Expected __cpp_lib_shared_ptr_weak_type to NOT be defined.
+#error __cpp_lib_shared_ptr_weak_type is defined
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_lib_string_view
-#error Expected __cpp_lib_string_view to be defined.
+#error __cpp_lib_string_view is not defined
 #elif __cpp_lib_string_view != 201803L
-#error Expected cpp_lib_string_view to equal 201803L.
+#error cpp_lib_string_view is not 201803L
 #else
 STATIC_ASSERT(__cpp_lib_string_view == 201803L);
 #endif
 #else
 #ifdef __cpp_lib_string_view
-#error Expected __cpp_lib_string_view to NOT be defined.
+#error __cpp_lib_string_view is defined
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_lib_to_chars
-#error Expected __cpp_lib_to_chars to be defined.
+#error __cpp_lib_to_chars is not defined
 #elif __cpp_lib_to_chars != 201611L
-#error Expected cpp_lib_to_chars to equal 201611L.
+#error cpp_lib_to_chars is not 201611L
 #else
 STATIC_ASSERT(__cpp_lib_to_chars == 201611L);
 #endif
 #else
 #ifdef __cpp_lib_to_chars
-#error Expected __cpp_lib_to_chars to NOT be defined.
+#error __cpp_lib_to_chars is defined
 #endif
 #endif
 
 #if _HAS_CXX17
 #ifndef __cpp_lib_variant
-#error Expected __cpp_lib_variant to be defined.
+#error __cpp_lib_variant is not defined
 #elif __cpp_lib_variant != 201606L
-#error Expected cpp_lib_variant to equal 201606L.
+#error cpp_lib_variant is not 201606L
 #else
 STATIC_ASSERT(__cpp_lib_variant == 201606L);
 #endif
 #else
 #ifdef __cpp_lib_variant
-#error Expected __cpp_lib_variant to NOT be defined.
+#error __cpp_lib_variant is defined
 #endif
 #endif
 
 #if _HAS_CXX17 && !defined(_M_CEE)
 #ifndef __cpp_lib_execution
-#error Expected __cpp_lib_execution to be defined.
+#error __cpp_lib_execution is not defined
 #elif __cpp_lib_execution != 201603L
-#error Expected cpp_lib_execution to equal 201603L.
+#error cpp_lib_execution is not 201603L
 #else
 STATIC_ASSERT(__cpp_lib_execution == 201603L);
 #endif
 #else
 #ifdef __cpp_lib_execution
-#error Expected __cpp_lib_execution to NOT be defined.
+#error __cpp_lib_execution is defined
 #endif
 #endif
 
 #if _HAS_CXX17 && !defined(_M_CEE)
 #ifndef __cpp_lib_parallel_algorithm
-#error Expected __cpp_lib_parallel_algorithm to be defined.
+#error __cpp_lib_parallel_algorithm is not defined
 #elif __cpp_lib_parallel_algorithm != 201603L
-#error Expected cpp_lib_parallel_algorithm to equal 201603L.
+#error cpp_lib_parallel_algorithm is not 201603L
 #else
 STATIC_ASSERT(__cpp_lib_parallel_algorithm == 201603L);
 #endif
 #else
 #ifdef __cpp_lib_parallel_algorithm
-#error Expected __cpp_lib_parallel_algorithm to NOT be defined.
+#error __cpp_lib_parallel_algorithm is defined
 #endif
 #endif
 
 #if _HAS_CXX20
 #ifndef __cpp_lib_atomic_float
-#error Expected __cpp_lib_atomic_float to be defined.
+#error __cpp_lib_atomic_float is not defined
 #elif __cpp_lib_atomic_float != 201711L
-#error Expected cpp_lib_atomic_float to equal 201711L.
+#error cpp_lib_atomic_float is not 201711L
 #else
 STATIC_ASSERT(__cpp_lib_atomic_float == 201711L);
 #endif
 #else
 #ifdef __cpp_lib_atomic_float
-#error Expected __cpp_lib_atomic_float to NOT be defined.
+#error __cpp_lib_atomic_float is defined
 #endif
 #endif
 
 #if _HAS_CXX20
 #ifndef __cpp_lib_bind_front
-#error Expected __cpp_lib_bind_front to be defined.
+#error __cpp_lib_bind_front is not defined
 #elif __cpp_lib_bind_front != 201907L
-#error Expected cpp_lib_bind_front to equal 201907L.
+#error cpp_lib_bind_front is not 201907L
 #else
 STATIC_ASSERT(__cpp_lib_bind_front == 201907L);
 #endif
 #else
 #ifdef __cpp_lib_bind_front
-#error Expected __cpp_lib_bind_front to NOT be defined.
+#error __cpp_lib_bind_front is defined
 #endif
 #endif
 
 #if _HAS_CXX20
 #ifndef __cpp_lib_bounded_array_traits
-#error Expected __cpp_lib_bounded_array_traits to be defined.
+#error __cpp_lib_bounded_array_traits is not defined
 #elif __cpp_lib_bounded_array_traits != 201902L
-#error Expected cpp_lib_bounded_array_traits to equal 201902L.
+#error cpp_lib_bounded_array_traits is not 201902L
 #else
 STATIC_ASSERT(__cpp_lib_bounded_array_traits == 201902L);
 #endif
 #else
 #ifdef __cpp_lib_bounded_array_traits
-#error Expected __cpp_lib_bounded_array_traits to NOT be defined.
+#error __cpp_lib_bounded_array_traits is defined
 #endif
 #endif
 
 #if _HAS_CXX20
 #ifndef __cpp_lib_constexpr_algorithms
-#error Expected __cpp_lib_constexpr_algorithms to be defined.
+#error __cpp_lib_constexpr_algorithms is not defined
 #elif __cpp_lib_constexpr_algorithms != 201806L
-#error Expected cpp_lib_constexpr_algorithms to equal 201806L.
+#error cpp_lib_constexpr_algorithms is not 201806L
 #else
 STATIC_ASSERT(__cpp_lib_constexpr_algorithms == 201806L);
 #endif
 #else
 #ifdef __cpp_lib_constexpr_algorithms
-#error Expected __cpp_lib_constexpr_algorithms to NOT be defined.
+#error __cpp_lib_constexpr_algorithms is defined
 #endif
 #endif
 
 #if _HAS_CXX20
 #ifndef __cpp_lib_constexpr_memory
-#error Expected __cpp_lib_constexpr_memory to be defined.
+#error __cpp_lib_constexpr_memory is not defined
 #elif __cpp_lib_constexpr_memory != 201811L
-#error Expected cpp_lib_constexpr_memory to equal 201811L.
+#error cpp_lib_constexpr_memory is not 201811L
 #else
 STATIC_ASSERT(__cpp_lib_constexpr_memory == 201811L);
 #endif
 #else
 #ifdef __cpp_lib_constexpr_memory
-#error Expected __cpp_lib_constexpr_memory to NOT be defined.
+#error __cpp_lib_constexpr_memory is defined
 #endif
 #endif
 
 #if _HAS_CXX20
 #ifndef __cpp_lib_constexpr_numeric
-#error Expected __cpp_lib_constexpr_numeric to be defined.
+#error __cpp_lib_constexpr_numeric is not defined
 #elif __cpp_lib_constexpr_numeric != 201911L
-#error Expected cpp_lib_constexpr_numeric to equal 201911L.
+#error cpp_lib_constexpr_numeric is not 201911L
 #else
 STATIC_ASSERT(__cpp_lib_constexpr_numeric == 201911L);
 #endif
 #else
 #ifdef __cpp_lib_constexpr_numeric
-#error Expected __cpp_lib_constexpr_numeric to NOT be defined.
+#error __cpp_lib_constexpr_numeric is defined
 #endif
 #endif
 
 #if _HAS_CXX20
 #ifndef __cpp_lib_endian
-#error Expected __cpp_lib_endian to be defined.
+#error __cpp_lib_endian is not defined
 #elif __cpp_lib_endian != 201907L
-#error Expected cpp_lib_endian to equal 201907L.
+#error cpp_lib_endian is not 201907L
 #else
 STATIC_ASSERT(__cpp_lib_endian == 201907L);
 #endif
 #else
 #ifdef __cpp_lib_endian
-#error Expected __cpp_lib_endian to NOT be defined.
+#error __cpp_lib_endian is defined
 #endif
 #endif
 
 #if _HAS_CXX20
 #ifndef __cpp_lib_erase_if
-#error Expected __cpp_lib_erase_if to be defined.
+#error __cpp_lib_erase_if is not defined
 #elif __cpp_lib_erase_if != 202002L
-#error Expected cpp_lib_erase_if to equal 202002L.
+#error cpp_lib_erase_if is not 202002L
 #else
 STATIC_ASSERT(__cpp_lib_erase_if == 202002L);
 #endif
 #else
 #ifdef __cpp_lib_erase_if
-#error Expected __cpp_lib_erase_if to NOT be defined.
+#error __cpp_lib_erase_if is defined
 #endif
 #endif
 
 #if _HAS_CXX20
 #ifndef __cpp_lib_generic_unordered_lookup
-#error Expected __cpp_lib_generic_unordered_lookup to be defined.
+#error __cpp_lib_generic_unordered_lookup is not defined
 #elif __cpp_lib_generic_unordered_lookup != 201811L
-#error Expected cpp_lib_generic_unordered_lookup to equal 201811L.
+#error cpp_lib_generic_unordered_lookup is not 201811L
 #else
 STATIC_ASSERT(__cpp_lib_generic_unordered_lookup == 201811L);
 #endif
 #else
 #ifdef __cpp_lib_generic_unordered_lookup
-#error Expected __cpp_lib_generic_unordered_lookup to NOT be defined.
+#error __cpp_lib_generic_unordered_lookup is defined
 #endif
 #endif
 
 #if _HAS_CXX20
 #ifndef __cpp_lib_int_pow2
-#error Expected __cpp_lib_int_pow2 to be defined.
+#error __cpp_lib_int_pow2 is not defined
 #elif __cpp_lib_int_pow2 != 202002L
-#error Expected cpp_lib_int_pow2 to equal 202002L.
+#error cpp_lib_int_pow2 is not 202002L
 #else
 STATIC_ASSERT(__cpp_lib_int_pow2 == 202002L);
 #endif
 #else
 #ifdef __cpp_lib_int_pow2
-#error Expected __cpp_lib_int_pow2 to NOT be defined.
+#error __cpp_lib_int_pow2 is defined
 #endif
 #endif
 
 #if _HAS_CXX20
 #ifndef __cpp_lib_is_constant_evaluated
-#error Expected __cpp_lib_is_constant_evaluated to be defined.
+#error __cpp_lib_is_constant_evaluated is not defined
 #elif __cpp_lib_is_constant_evaluated != 201811L
-#error Expected cpp_lib_is_constant_evaluated to equal 201811L.
+#error cpp_lib_is_constant_evaluated is not 201811L
 #else
 STATIC_ASSERT(__cpp_lib_is_constant_evaluated == 201811L);
 #endif
 #else
 #ifdef __cpp_lib_is_constant_evaluated
-#error Expected __cpp_lib_is_constant_evaluated to NOT be defined.
+#error __cpp_lib_is_constant_evaluated is defined
 #endif
 #endif
 
 #if _HAS_CXX20
 #ifndef __cpp_lib_is_nothrow_convertible
-#error Expected __cpp_lib_is_nothrow_convertible to be defined.
+#error __cpp_lib_is_nothrow_convertible is not defined
 #elif __cpp_lib_is_nothrow_convertible != 201806L
-#error Expected cpp_lib_is_nothrow_convertible to equal 201806L.
+#error cpp_lib_is_nothrow_convertible is not 201806L
 #else
 STATIC_ASSERT(__cpp_lib_is_nothrow_convertible == 201806L);
 #endif
 #else
 #ifdef __cpp_lib_is_nothrow_convertible
-#error Expected __cpp_lib_is_nothrow_convertible to NOT be defined.
+#error __cpp_lib_is_nothrow_convertible is defined
 #endif
 #endif
 
 #if _HAS_CXX20
 #ifndef __cpp_lib_list_remove_return_type
-#error Expected __cpp_lib_list_remove_return_type to be defined.
+#error __cpp_lib_list_remove_return_type is not defined
 #elif __cpp_lib_list_remove_return_type != 201806L
-#error Expected cpp_lib_list_remove_return_type to equal 201806L.
+#error cpp_lib_list_remove_return_type is not 201806L
 #else
 STATIC_ASSERT(__cpp_lib_list_remove_return_type == 201806L);
 #endif
 #else
 #ifdef __cpp_lib_list_remove_return_type
-#error Expected __cpp_lib_list_remove_return_type to NOT be defined.
+#error __cpp_lib_list_remove_return_type is defined
 #endif
 #endif
 
 #if _HAS_CXX20
 #ifndef __cpp_lib_math_constants
-#error Expected __cpp_lib_math_constants to be defined.
+#error __cpp_lib_math_constants is not defined
 #elif __cpp_lib_math_constants != 201907L
-#error Expected cpp_lib_math_constants to equal 201907L.
+#error cpp_lib_math_constants is not 201907L
 #else
 STATIC_ASSERT(__cpp_lib_math_constants == 201907L);
 #endif
 #else
 #ifdef __cpp_lib_math_constants
-#error Expected __cpp_lib_math_constants to NOT be defined.
+#error __cpp_lib_math_constants is defined
 #endif
 #endif
 
 #if _HAS_CXX20
 #ifndef __cpp_lib_remove_cvref
-#error Expected __cpp_lib_remove_cvref to be defined.
+#error __cpp_lib_remove_cvref is not defined
 #elif __cpp_lib_remove_cvref != 201711L
-#error Expected cpp_lib_remove_cvref to equal 201711L.
+#error cpp_lib_remove_cvref is not 201711L
 #else
 STATIC_ASSERT(__cpp_lib_remove_cvref == 201711L);
 #endif
 #else
 #ifdef __cpp_lib_remove_cvref
-#error Expected __cpp_lib_remove_cvref to NOT be defined.
+#error __cpp_lib_remove_cvref is defined
 #endif
 #endif
 
 #if _HAS_CXX20
 #ifndef __cpp_lib_shift
-#error Expected __cpp_lib_shift to be defined.
+#error __cpp_lib_shift is not defined
 #elif __cpp_lib_shift != 201806L
-#error Expected cpp_lib_shift to equal 201806L.
+#error cpp_lib_shift is not 201806L
 #else
 STATIC_ASSERT(__cpp_lib_shift == 201806L);
 #endif
 #else
 #ifdef __cpp_lib_shift
-#error Expected __cpp_lib_shift to NOT be defined.
+#error __cpp_lib_shift is defined
 #endif
 #endif
 
 #if _HAS_CXX20
 #ifndef __cpp_lib_span
-#error Expected __cpp_lib_span to be defined.
+#error __cpp_lib_span is not defined
 #elif __cpp_lib_span != 202002L
-#error Expected cpp_lib_span to equal 202002L.
+#error cpp_lib_span is not 202002L
 #else
 STATIC_ASSERT(__cpp_lib_span == 202002L);
 #endif
 #else
 #ifdef __cpp_lib_span
-#error Expected __cpp_lib_span to NOT be defined.
+#error __cpp_lib_span is defined
 #endif
 #endif
 
 #if _HAS_CXX20
 #ifndef __cpp_lib_ssize
-#error Expected __cpp_lib_ssize to be defined.
+#error __cpp_lib_ssize is not defined
 #elif __cpp_lib_ssize != 201902L
-#error Expected cpp_lib_ssize to equal 201902L.
+#error cpp_lib_ssize is not 201902L
 #else
 STATIC_ASSERT(__cpp_lib_ssize == 201902L);
 #endif
 #else
 #ifdef __cpp_lib_ssize
-#error Expected __cpp_lib_ssize to NOT be defined.
+#error __cpp_lib_ssize is defined
 #endif
 #endif
 
 #if _HAS_CXX20
 #ifndef __cpp_lib_starts_ends_with
-#error Expected __cpp_lib_starts_ends_with to be defined.
+#error __cpp_lib_starts_ends_with is not defined
 #elif __cpp_lib_starts_ends_with != 201711L
-#error Expected cpp_lib_starts_ends_with to equal 201711L.
+#error cpp_lib_starts_ends_with is not 201711L
 #else
 STATIC_ASSERT(__cpp_lib_starts_ends_with == 201711L);
 #endif
 #else
 #ifdef __cpp_lib_starts_ends_with
-#error Expected __cpp_lib_starts_ends_with to NOT be defined.
+#error __cpp_lib_starts_ends_with is defined
 #endif
 #endif
 
 #if _HAS_CXX20
 #ifndef __cpp_lib_to_address
-#error Expected __cpp_lib_to_address to be defined.
+#error __cpp_lib_to_address is not defined
 #elif __cpp_lib_to_address != 201711L
-#error Expected cpp_lib_to_address to equal 201711L.
+#error cpp_lib_to_address is not 201711L
 #else
 STATIC_ASSERT(__cpp_lib_to_address == 201711L);
 #endif
 #else
 #ifdef __cpp_lib_to_address
-#error Expected __cpp_lib_to_address to NOT be defined.
+#error __cpp_lib_to_address is defined
 #endif
 #endif
 
 #if _HAS_CXX20
 #ifndef __cpp_lib_to_array
-#error Expected __cpp_lib_to_array to be defined.
+#error __cpp_lib_to_array is not defined
 #elif __cpp_lib_to_array != 201907L
-#error Expected cpp_lib_to_array to equal 201907L.
+#error cpp_lib_to_array is not 201907L
 #else
 STATIC_ASSERT(__cpp_lib_to_array == 201907L);
 #endif
 #else
 #ifdef __cpp_lib_to_array
-#error Expected __cpp_lib_to_array to NOT be defined.
+#error __cpp_lib_to_array is defined
 #endif
 #endif
 
 #if _HAS_CXX20
 #ifndef __cpp_lib_type_identity
-#error Expected __cpp_lib_type_identity to be defined.
+#error __cpp_lib_type_identity is not defined
 #elif __cpp_lib_type_identity != 201806L
-#error Expected cpp_lib_type_identity to equal 201806L.
+#error cpp_lib_type_identity is not 201806L
 #else
 STATIC_ASSERT(__cpp_lib_type_identity == 201806L);
 #endif
 #else
 #ifdef __cpp_lib_type_identity
-#error Expected __cpp_lib_type_identity to NOT be defined.
+#error __cpp_lib_type_identity is defined
 #endif
 #endif
 
 #if _HAS_CXX20
 #ifndef __cpp_lib_unwrap_ref
-#error Expected __cpp_lib_unwrap_ref to be defined.
+#error __cpp_lib_unwrap_ref is not defined
 #elif __cpp_lib_unwrap_ref != 201811L
-#error Expected cpp_lib_unwrap_ref to equal 201811L.
+#error cpp_lib_unwrap_ref is not 201811L
 #else
 STATIC_ASSERT(__cpp_lib_unwrap_ref == 201811L);
 #endif
 #else
 #ifdef __cpp_lib_unwrap_ref
-#error Expected __cpp_lib_unwrap_ref to NOT be defined.
+#error __cpp_lib_unwrap_ref is defined
 #endif
 #endif
 
 #if _HAS_CXX20 && !defined(__EDG__) // TRANSITION, VSO-1041044
 #ifndef __cpp_lib_bit_cast
-#error Expected __cpp_lib_bit_cast to be defined.
+#error __cpp_lib_bit_cast is not defined
 #elif __cpp_lib_bit_cast != 201806L
-#error Expected cpp_lib_bit_cast to equal 201806L.
+#error cpp_lib_bit_cast is not 201806L
 #else
 STATIC_ASSERT(__cpp_lib_bit_cast == 201806L);
 #endif
 #else
 #ifdef __cpp_lib_bit_cast
-#error Expected __cpp_lib_bit_cast to NOT be defined.
+#error __cpp_lib_bit_cast is defined
 #endif
 #endif
 
 #if _HAS_CXX20 && (defined(__clang__) || defined(__EDG__)) // TRANSITION, VSO-1020212
 #ifndef __cpp_lib_bitops
-#error Expected __cpp_lib_bitops to be defined.
+#error __cpp_lib_bitops is not defined
 #elif __cpp_lib_bitops != 201907L
-#error Expected cpp_lib_bitops to equal 201907L.
+#error cpp_lib_bitops is not 201907L
 #else
 STATIC_ASSERT(__cpp_lib_bitops == 201907L);
 #endif
 #else
 #ifdef __cpp_lib_bitops
-#error Expected __cpp_lib_bitops to NOT be defined.
+#error __cpp_lib_bitops is defined
 #endif
 #endif
 
 #if _HAS_CXX20 && defined(__cpp_char8_t)
 #ifndef __cpp_lib_char8_t
-#error Expected __cpp_lib_char8_t to be defined.
+#error __cpp_lib_char8_t is not defined
 #elif __cpp_lib_char8_t != 201907L
-#error Expected cpp_lib_char8_t to equal 201907L.
+#error cpp_lib_char8_t is not 201907L
 #else
 STATIC_ASSERT(__cpp_lib_char8_t == 201907L);
 #endif
 #else
 #ifdef __cpp_lib_char8_t
-#error Expected __cpp_lib_char8_t to NOT be defined.
+#error __cpp_lib_char8_t is defined
 #endif
 #endif
 
 #if _HAS_CXX20 && defined(__cpp_concepts)
 #ifndef __cpp_lib_concepts
-#error Expected __cpp_lib_concepts to be defined.
+#error __cpp_lib_concepts is not defined
 #elif __cpp_lib_concepts != 201907L
-#error Expected cpp_lib_concepts to equal 201907L.
+#error cpp_lib_concepts is not 201907L
 #else
 STATIC_ASSERT(__cpp_lib_concepts == 201907L);
 #endif
 #else
 #ifdef __cpp_lib_concepts
-#error Expected __cpp_lib_concepts to NOT be defined.
+#error __cpp_lib_concepts is defined
 #endif
 #endif
 
 #if _HAS_STD_BYTE
 #ifndef __cpp_lib_byte
-#error Expected __cpp_lib_byte to be defined.
+#error __cpp_lib_byte is not defined
 #elif __cpp_lib_byte != 201603L
-#error Expected cpp_lib_byte to equal 201603L.
+#error cpp_lib_byte is not 201603L
 #else
 STATIC_ASSERT(__cpp_lib_byte == 201603L);
 #endif
 #else
 #ifdef __cpp_lib_byte
-#error Expected __cpp_lib_byte to NOT be defined.
+#error __cpp_lib_byte is defined
 #endif
 #endif
 
 #ifdef _M_CEE
 #ifdef __cpp_lib_shared_timed_mutex
-#error Expected __cpp_lib_shared_timed_mutex to NOT be defined.
+#error __cpp_lib_shared_timed_mutex is defined
 #endif
 #else // ^^^ _M_CEE ^^^ // vvv !_M_CEE vvv
 #ifndef __cpp_lib_shared_timed_mutex
-#error Expected __cpp_lib_shared_timed_mutex to be defined.
+#error __cpp_lib_shared_timed_mutex is not defined
 #elif __cpp_lib_shared_timed_mutex != 201402L
-#error Expected cpp_lib_shared_timed_mutex to equal 201402L.
+#error cpp_lib_shared_timed_mutex is not 201402L
 #else
 STATIC_ASSERT(__cpp_lib_shared_timed_mutex == 201402L);
 #endif

--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.cpp
@@ -669,310 +669,6 @@ STATIC_ASSERT(__cpp_lib_addressof_constexpr == 201603L);
 STATIC_ASSERT(__cpp_lib_allocator_traits_is_always_equal == 201411L);
 #endif
 
-#ifndef __cpp_lib_as_const
-#error __cpp_lib_as_const is not defined
-#elif __cpp_lib_as_const != 201510L
-#error __cpp_lib_as_const is not 201510L
-#else
-STATIC_ASSERT(__cpp_lib_as_const == 201510L);
-#endif
-
-#ifndef __cpp_lib_atomic_value_initialization
-#error __cpp_lib_atomic_value_initialization is not defined
-#elif __cpp_lib_atomic_value_initialization != 201911L
-#error __cpp_lib_atomic_value_initialization is not 201911L
-#else
-STATIC_ASSERT(__cpp_lib_atomic_value_initialization == 201911L);
-#endif
-
-#ifndef __cpp_lib_bool_constant
-#error __cpp_lib_bool_constant is not defined
-#elif __cpp_lib_bool_constant != 201505L
-#error __cpp_lib_bool_constant is not 201505L
-#else
-STATIC_ASSERT(__cpp_lib_bool_constant == 201505L);
-#endif
-
-#ifndef __cpp_lib_chrono
-#error __cpp_lib_chrono is not defined
-#elif _HAS_CXX17
-#if __cpp_lib_chrono != 201611L
-#error __cpp_lib_chrono is not 201611L
-#else
-STATIC_ASSERT(__cpp_lib_chrono == 201611L);
-#endif
-#else
-#if __cpp_lib_chrono != 201510L
-#error __cpp_lib_chrono is not 201510L
-#else
-STATIC_ASSERT(__cpp_lib_chrono == 201510L);
-#endif
-#endif
-
-#ifndef __cpp_lib_chrono_udls
-#error __cpp_lib_chrono_udls is not defined
-#elif __cpp_lib_chrono_udls != 201304L
-#error __cpp_lib_chrono_udls is not 201304L
-#else
-STATIC_ASSERT(__cpp_lib_chrono_udls == 201304L);
-#endif
-
-#ifndef __cpp_lib_complex_udls
-#error __cpp_lib_complex_udls is not defined
-#elif __cpp_lib_complex_udls != 201309L
-#error __cpp_lib_complex_udls is not 201309L
-#else
-STATIC_ASSERT(__cpp_lib_complex_udls == 201309L);
-#endif
-
-#ifndef __cpp_lib_enable_shared_from_this
-#error __cpp_lib_enable_shared_from_this is not defined
-#elif __cpp_lib_enable_shared_from_this != 201603L
-#error __cpp_lib_enable_shared_from_this is not 201603L
-#else
-STATIC_ASSERT(__cpp_lib_enable_shared_from_this == 201603L);
-#endif
-
-#ifndef __cpp_lib_exchange_function
-#error __cpp_lib_exchange_function is not defined
-#elif __cpp_lib_exchange_function != 201304L
-#error __cpp_lib_exchange_function is not 201304L
-#else
-STATIC_ASSERT(__cpp_lib_exchange_function == 201304L);
-#endif
-
-#ifndef __cpp_lib_experimental_erase_if
-#error __cpp_lib_experimental_erase_if is not defined
-#elif __cpp_lib_experimental_erase_if != 201411L
-#error __cpp_lib_experimental_erase_if is not 201411L
-#else
-STATIC_ASSERT(__cpp_lib_experimental_erase_if == 201411L);
-#endif
-
-#ifndef __cpp_lib_experimental_filesystem
-#error __cpp_lib_experimental_filesystem is not defined
-#elif __cpp_lib_experimental_filesystem != 201406L
-#error __cpp_lib_experimental_filesystem is not 201406L
-#else
-STATIC_ASSERT(__cpp_lib_experimental_filesystem == 201406L);
-#endif
-
-#ifndef __cpp_lib_generic_associative_lookup
-#error __cpp_lib_generic_associative_lookup is not defined
-#elif __cpp_lib_generic_associative_lookup != 201304L
-#error __cpp_lib_generic_associative_lookup is not 201304L
-#else
-STATIC_ASSERT(__cpp_lib_generic_associative_lookup == 201304L);
-#endif
-
-#ifndef __cpp_lib_incomplete_container_elements
-#error __cpp_lib_incomplete_container_elements is not defined
-#elif __cpp_lib_incomplete_container_elements != 201505L
-#error __cpp_lib_incomplete_container_elements is not 201505L
-#else
-STATIC_ASSERT(__cpp_lib_incomplete_container_elements == 201505L);
-#endif
-
-#ifndef __cpp_lib_integer_sequence
-#error __cpp_lib_integer_sequence is not defined
-#elif __cpp_lib_integer_sequence != 201304L
-#error __cpp_lib_integer_sequence is not 201304L
-#else
-STATIC_ASSERT(__cpp_lib_integer_sequence == 201304L);
-#endif
-
-#ifndef __cpp_lib_integral_constant_callable
-#error __cpp_lib_integral_constant_callable is not defined
-#elif __cpp_lib_integral_constant_callable != 201304L
-#error __cpp_lib_integral_constant_callable is not 201304L
-#else
-STATIC_ASSERT(__cpp_lib_integral_constant_callable == 201304L);
-#endif
-
-#ifndef __cpp_lib_invoke
-#error __cpp_lib_invoke is not defined
-#elif __cpp_lib_invoke != 201411L
-#error __cpp_lib_invoke is not 201411L
-#else
-STATIC_ASSERT(__cpp_lib_invoke == 201411L);
-#endif
-
-#ifndef __cpp_lib_is_final
-#error __cpp_lib_is_final is not defined
-#elif __cpp_lib_is_final != 201402L
-#error __cpp_lib_is_final is not 201402L
-#else
-STATIC_ASSERT(__cpp_lib_is_final == 201402L);
-#endif
-
-#ifndef __cpp_lib_is_null_pointer
-#error __cpp_lib_is_null_pointer is not defined
-#elif __cpp_lib_is_null_pointer != 201309L
-#error __cpp_lib_is_null_pointer is not 201309L
-#else
-STATIC_ASSERT(__cpp_lib_is_null_pointer == 201309L);
-#endif
-
-#ifndef __cpp_lib_logical_traits
-#error __cpp_lib_logical_traits is not defined
-#elif __cpp_lib_logical_traits != 201510L
-#error __cpp_lib_logical_traits is not 201510L
-#else
-STATIC_ASSERT(__cpp_lib_logical_traits == 201510L);
-#endif
-
-#ifndef __cpp_lib_make_reverse_iterator
-#error __cpp_lib_make_reverse_iterator is not defined
-#elif __cpp_lib_make_reverse_iterator != 201402L
-#error __cpp_lib_make_reverse_iterator is not 201402L
-#else
-STATIC_ASSERT(__cpp_lib_make_reverse_iterator == 201402L);
-#endif
-
-#ifndef __cpp_lib_make_unique
-#error __cpp_lib_make_unique is not defined
-#elif __cpp_lib_make_unique != 201304L
-#error __cpp_lib_make_unique is not 201304L
-#else
-STATIC_ASSERT(__cpp_lib_make_unique == 201304L);
-#endif
-
-#ifndef __cpp_lib_map_try_emplace
-#error __cpp_lib_map_try_emplace is not defined
-#elif __cpp_lib_map_try_emplace != 201411L
-#error __cpp_lib_map_try_emplace is not 201411L
-#else
-STATIC_ASSERT(__cpp_lib_map_try_emplace == 201411L);
-#endif
-
-#ifndef __cpp_lib_nonmember_container_access
-#error __cpp_lib_nonmember_container_access is not defined
-#elif __cpp_lib_nonmember_container_access != 201411L
-#error __cpp_lib_nonmember_container_access is not 201411L
-#else
-STATIC_ASSERT(__cpp_lib_nonmember_container_access == 201411L);
-#endif
-
-#ifndef __cpp_lib_null_iterators
-#error __cpp_lib_null_iterators is not defined
-#elif __cpp_lib_null_iterators != 201304L
-#error __cpp_lib_null_iterators is not 201304L
-#else
-STATIC_ASSERT(__cpp_lib_null_iterators == 201304L);
-#endif
-
-#ifndef __cpp_lib_quoted_string_io
-#error __cpp_lib_quoted_string_io is not defined
-#elif __cpp_lib_quoted_string_io != 201304L
-#error __cpp_lib_quoted_string_io is not 201304L
-#else
-STATIC_ASSERT(__cpp_lib_quoted_string_io == 201304L);
-#endif
-
-#ifndef __cpp_lib_result_of_sfinae
-#error __cpp_lib_result_of_sfinae is not defined
-#elif __cpp_lib_result_of_sfinae != 201210L
-#error __cpp_lib_result_of_sfinae is not 201210L
-#else
-STATIC_ASSERT(__cpp_lib_result_of_sfinae == 201210L);
-#endif
-
-#ifndef __cpp_lib_robust_nonmodifying_seq_ops
-#error __cpp_lib_robust_nonmodifying_seq_ops is not defined
-#elif __cpp_lib_robust_nonmodifying_seq_ops != 201304L
-#error __cpp_lib_robust_nonmodifying_seq_ops is not 201304L
-#else
-STATIC_ASSERT(__cpp_lib_robust_nonmodifying_seq_ops == 201304L);
-#endif
-
-#ifndef __cpp_lib_shared_mutex
-#error __cpp_lib_shared_mutex is not defined
-#elif __cpp_lib_shared_mutex != 201505L
-#error __cpp_lib_shared_mutex is not 201505L
-#else
-STATIC_ASSERT(__cpp_lib_shared_mutex == 201505L);
-#endif
-
-#ifndef __cpp_lib_shared_ptr_arrays
-#error __cpp_lib_shared_ptr_arrays is not defined
-#elif __cpp_lib_shared_ptr_arrays != 201611L
-#error __cpp_lib_shared_ptr_arrays is not 201611L
-#else
-STATIC_ASSERT(__cpp_lib_shared_ptr_arrays == 201611L);
-#endif
-
-#ifndef __cpp_lib_string_udls
-#error __cpp_lib_string_udls is not defined
-#elif __cpp_lib_string_udls != 201304L
-#error __cpp_lib_string_udls is not 201304L
-#else
-STATIC_ASSERT(__cpp_lib_string_udls == 201304L);
-#endif
-
-#ifndef __cpp_lib_transformation_trait_aliases
-#error __cpp_lib_transformation_trait_aliases is not defined
-#elif __cpp_lib_transformation_trait_aliases != 201304L
-#error __cpp_lib_transformation_trait_aliases is not 201304L
-#else
-STATIC_ASSERT(__cpp_lib_transformation_trait_aliases == 201304L);
-#endif
-
-#ifndef __cpp_lib_transparent_operators
-#error __cpp_lib_transparent_operators is not defined
-#elif __cpp_lib_transparent_operators != 201510L
-#error __cpp_lib_transparent_operators is not 201510L
-#else
-STATIC_ASSERT(__cpp_lib_transparent_operators == 201510L);
-#endif
-
-#ifndef __cpp_lib_tuple_element_t
-#error __cpp_lib_tuple_element_t is not defined
-#elif __cpp_lib_tuple_element_t != 201402L
-#error __cpp_lib_tuple_element_t is not 201402L
-#else
-STATIC_ASSERT(__cpp_lib_tuple_element_t == 201402L);
-#endif
-
-#ifndef __cpp_lib_tuples_by_type
-#error __cpp_lib_tuples_by_type is not defined
-#elif __cpp_lib_tuples_by_type != 201304L
-#error __cpp_lib_tuples_by_type is not 201304L
-#else
-STATIC_ASSERT(__cpp_lib_tuples_by_type == 201304L);
-#endif
-
-#ifndef __cpp_lib_type_trait_variable_templates
-#error __cpp_lib_type_trait_variable_templates is not defined
-#elif __cpp_lib_type_trait_variable_templates != 201510L
-#error __cpp_lib_type_trait_variable_templates is not 201510L
-#else
-STATIC_ASSERT(__cpp_lib_type_trait_variable_templates == 201510L);
-#endif
-
-#ifndef __cpp_lib_uncaught_exceptions
-#error __cpp_lib_uncaught_exceptions is not defined
-#elif __cpp_lib_uncaught_exceptions != 201411L
-#error __cpp_lib_uncaught_exceptions is not 201411L
-#else
-STATIC_ASSERT(__cpp_lib_uncaught_exceptions == 201411L);
-#endif
-
-#ifndef __cpp_lib_unordered_map_try_emplace
-#error __cpp_lib_unordered_map_try_emplace is not defined
-#elif __cpp_lib_unordered_map_try_emplace != 201411L
-#error __cpp_lib_unordered_map_try_emplace is not 201411L
-#else
-STATIC_ASSERT(__cpp_lib_unordered_map_try_emplace == 201411L);
-#endif
-
-#ifndef __cpp_lib_void_t
-#error __cpp_lib_void_t is not defined
-#elif __cpp_lib_void_t != 201411L
-#error __cpp_lib_void_t is not 201411L
-#else
-STATIC_ASSERT(__cpp_lib_void_t == 201411L);
-#endif
-
 #if _HAS_CXX17
 #ifndef __cpp_lib_any
 #error __cpp_lib_any is not defined
@@ -1015,6 +711,28 @@ STATIC_ASSERT(__cpp_lib_array_constexpr == 201803L);
 #endif
 #endif
 
+#ifndef __cpp_lib_as_const
+#error __cpp_lib_as_const is not defined
+#elif __cpp_lib_as_const != 201510L
+#error __cpp_lib_as_const is not 201510L
+#else
+STATIC_ASSERT(__cpp_lib_as_const == 201510L);
+#endif
+
+#if _HAS_CXX20
+#ifndef __cpp_lib_atomic_float
+#error __cpp_lib_atomic_float is not defined
+#elif __cpp_lib_atomic_float != 201711L
+#error __cpp_lib_atomic_float is not 201711L
+#else
+STATIC_ASSERT(__cpp_lib_atomic_float == 201711L);
+#endif
+#else
+#ifdef __cpp_lib_atomic_float
+#error __cpp_lib_atomic_float is defined
+#endif
+#endif
+
 #if _HAS_CXX17
 #ifndef __cpp_lib_atomic_is_always_lock_free
 #error __cpp_lib_atomic_is_always_lock_free is not defined
@@ -1026,6 +744,78 @@ STATIC_ASSERT(__cpp_lib_atomic_is_always_lock_free == 201603L);
 #else
 #ifdef __cpp_lib_atomic_is_always_lock_free
 #error __cpp_lib_atomic_is_always_lock_free is defined
+#endif
+#endif
+
+#ifndef __cpp_lib_atomic_value_initialization
+#error __cpp_lib_atomic_value_initialization is not defined
+#elif __cpp_lib_atomic_value_initialization != 201911L
+#error __cpp_lib_atomic_value_initialization is not 201911L
+#else
+STATIC_ASSERT(__cpp_lib_atomic_value_initialization == 201911L);
+#endif
+
+#if _HAS_CXX20
+#ifndef __cpp_lib_bind_front
+#error __cpp_lib_bind_front is not defined
+#elif __cpp_lib_bind_front != 201907L
+#error __cpp_lib_bind_front is not 201907L
+#else
+STATIC_ASSERT(__cpp_lib_bind_front == 201907L);
+#endif
+#else
+#ifdef __cpp_lib_bind_front
+#error __cpp_lib_bind_front is defined
+#endif
+#endif
+
+#if _HAS_CXX20 && (defined(__clang__) || defined(__EDG__)) // TRANSITION, VSO-1020212
+#ifndef __cpp_lib_bitops
+#error __cpp_lib_bitops is not defined
+#elif __cpp_lib_bitops != 201907L
+#error __cpp_lib_bitops is not 201907L
+#else
+STATIC_ASSERT(__cpp_lib_bitops == 201907L);
+#endif
+#else
+#ifdef __cpp_lib_bitops
+#error __cpp_lib_bitops is defined
+#endif
+#endif
+
+#if _HAS_CXX20 && !defined(__EDG__) // TRANSITION, VSO-1041044
+#ifndef __cpp_lib_bit_cast
+#error __cpp_lib_bit_cast is not defined
+#elif __cpp_lib_bit_cast != 201806L
+#error __cpp_lib_bit_cast is not 201806L
+#else
+STATIC_ASSERT(__cpp_lib_bit_cast == 201806L);
+#endif
+#else
+#ifdef __cpp_lib_bit_cast
+#error __cpp_lib_bit_cast is defined
+#endif
+#endif
+
+#ifndef __cpp_lib_bool_constant
+#error __cpp_lib_bool_constant is not defined
+#elif __cpp_lib_bool_constant != 201505L
+#error __cpp_lib_bool_constant is not 201505L
+#else
+STATIC_ASSERT(__cpp_lib_bool_constant == 201505L);
+#endif
+
+#if _HAS_CXX20
+#ifndef __cpp_lib_bounded_array_traits
+#error __cpp_lib_bounded_array_traits is not defined
+#elif __cpp_lib_bounded_array_traits != 201902L
+#error __cpp_lib_bounded_array_traits is not 201902L
+#else
+STATIC_ASSERT(__cpp_lib_bounded_array_traits == 201902L);
+#endif
+#else
+#ifdef __cpp_lib_bounded_array_traits
+#error __cpp_lib_bounded_array_traits is defined
 #endif
 #endif
 
@@ -1043,6 +833,58 @@ STATIC_ASSERT(__cpp_lib_boyer_moore_searcher == 201603L);
 #endif
 #endif
 
+#if _HAS_STD_BYTE
+#ifndef __cpp_lib_byte
+#error __cpp_lib_byte is not defined
+#elif __cpp_lib_byte != 201603L
+#error __cpp_lib_byte is not 201603L
+#else
+STATIC_ASSERT(__cpp_lib_byte == 201603L);
+#endif
+#else
+#ifdef __cpp_lib_byte
+#error __cpp_lib_byte is defined
+#endif
+#endif
+
+#if _HAS_CXX20 && defined(__cpp_char8_t)
+#ifndef __cpp_lib_char8_t
+#error __cpp_lib_char8_t is not defined
+#elif __cpp_lib_char8_t != 201907L
+#error __cpp_lib_char8_t is not 201907L
+#else
+STATIC_ASSERT(__cpp_lib_char8_t == 201907L);
+#endif
+#else
+#ifdef __cpp_lib_char8_t
+#error __cpp_lib_char8_t is defined
+#endif
+#endif
+
+#ifndef __cpp_lib_chrono
+#error __cpp_lib_chrono is not defined
+#elif _HAS_CXX17
+#if __cpp_lib_chrono != 201611L
+#error __cpp_lib_chrono is not 201611L
+#else
+STATIC_ASSERT(__cpp_lib_chrono == 201611L);
+#endif
+#else
+#if __cpp_lib_chrono != 201510L
+#error __cpp_lib_chrono is not 201510L
+#else
+STATIC_ASSERT(__cpp_lib_chrono == 201510L);
+#endif
+#endif
+
+#ifndef __cpp_lib_chrono_udls
+#error __cpp_lib_chrono_udls is not defined
+#elif __cpp_lib_chrono_udls != 201304L
+#error __cpp_lib_chrono_udls is not 201304L
+#else
+STATIC_ASSERT(__cpp_lib_chrono_udls == 201304L);
+#endif
+
 #if _HAS_CXX17
 #ifndef __cpp_lib_clamp
 #error __cpp_lib_clamp is not defined
@@ -1057,381 +899,25 @@ STATIC_ASSERT(__cpp_lib_clamp == 201603L);
 #endif
 #endif
 
-#if _HAS_CXX17
-#ifndef __cpp_lib_filesystem
-#error __cpp_lib_filesystem is not defined
-#elif __cpp_lib_filesystem != 201703L
-#error __cpp_lib_filesystem is not 201703L
+#ifndef __cpp_lib_complex_udls
+#error __cpp_lib_complex_udls is not defined
+#elif __cpp_lib_complex_udls != 201309L
+#error __cpp_lib_complex_udls is not 201309L
 #else
-STATIC_ASSERT(__cpp_lib_filesystem == 201703L);
-#endif
-#else
-#ifdef __cpp_lib_filesystem
-#error __cpp_lib_filesystem is defined
-#endif
+STATIC_ASSERT(__cpp_lib_complex_udls == 201309L);
 #endif
 
-#if _HAS_CXX17
-#ifndef __cpp_lib_gcd_lcm
-#error __cpp_lib_gcd_lcm is not defined
-#elif __cpp_lib_gcd_lcm != 201606L
-#error __cpp_lib_gcd_lcm is not 201606L
+#if _HAS_CXX20 && defined(__cpp_concepts)
+#ifndef __cpp_lib_concepts
+#error __cpp_lib_concepts is not defined
+#elif __cpp_lib_concepts != 201907L
+#error __cpp_lib_concepts is not 201907L
 #else
-STATIC_ASSERT(__cpp_lib_gcd_lcm == 201606L);
-#endif
-#else
-#ifdef __cpp_lib_gcd_lcm
-#error __cpp_lib_gcd_lcm is defined
-#endif
-#endif
-
-#if _HAS_CXX17
-#ifndef __cpp_lib_hardware_interference_size
-#error __cpp_lib_hardware_interference_size is not defined
-#elif __cpp_lib_hardware_interference_size != 201703L
-#error __cpp_lib_hardware_interference_size is not 201703L
-#else
-STATIC_ASSERT(__cpp_lib_hardware_interference_size == 201703L);
+STATIC_ASSERT(__cpp_lib_concepts == 201907L);
 #endif
 #else
-#ifdef __cpp_lib_hardware_interference_size
-#error __cpp_lib_hardware_interference_size is defined
-#endif
-#endif
-
-#if _HAS_CXX17
-#ifndef __cpp_lib_has_unique_object_representations
-#error __cpp_lib_has_unique_object_representations is not defined
-#elif __cpp_lib_has_unique_object_representations != 201606L
-#error __cpp_lib_has_unique_object_representations is not 201606L
-#else
-STATIC_ASSERT(__cpp_lib_has_unique_object_representations == 201606L);
-#endif
-#else
-#ifdef __cpp_lib_has_unique_object_representations
-#error __cpp_lib_has_unique_object_representations is defined
-#endif
-#endif
-
-#if _HAS_CXX17
-#ifndef __cpp_lib_hypot
-#error __cpp_lib_hypot is not defined
-#elif __cpp_lib_hypot != 201603L
-#error __cpp_lib_hypot is not 201603L
-#else
-STATIC_ASSERT(__cpp_lib_hypot == 201603L);
-#endif
-#else
-#ifdef __cpp_lib_hypot
-#error __cpp_lib_hypot is defined
-#endif
-#endif
-
-#if _HAS_CXX17
-#ifndef __cpp_lib_is_aggregate
-#error __cpp_lib_is_aggregate is not defined
-#elif __cpp_lib_is_aggregate != 201703L
-#error __cpp_lib_is_aggregate is not 201703L
-#else
-STATIC_ASSERT(__cpp_lib_is_aggregate == 201703L);
-#endif
-#else
-#ifdef __cpp_lib_is_aggregate
-#error __cpp_lib_is_aggregate is defined
-#endif
-#endif
-
-#if _HAS_CXX17
-#ifndef __cpp_lib_is_invocable
-#error __cpp_lib_is_invocable is not defined
-#elif __cpp_lib_is_invocable != 201703L
-#error __cpp_lib_is_invocable is not 201703L
-#else
-STATIC_ASSERT(__cpp_lib_is_invocable == 201703L);
-#endif
-#else
-#ifdef __cpp_lib_is_invocable
-#error __cpp_lib_is_invocable is defined
-#endif
-#endif
-
-#if _HAS_CXX17
-#ifndef __cpp_lib_is_swappable
-#error __cpp_lib_is_swappable is not defined
-#elif __cpp_lib_is_swappable != 201603L
-#error __cpp_lib_is_swappable is not 201603L
-#else
-STATIC_ASSERT(__cpp_lib_is_swappable == 201603L);
-#endif
-#else
-#ifdef __cpp_lib_is_swappable
-#error __cpp_lib_is_swappable is defined
-#endif
-#endif
-
-#if _HAS_CXX17
-#ifndef __cpp_lib_launder
-#error __cpp_lib_launder is not defined
-#elif __cpp_lib_launder != 201606L
-#error __cpp_lib_launder is not 201606L
-#else
-STATIC_ASSERT(__cpp_lib_launder == 201606L);
-#endif
-#else
-#ifdef __cpp_lib_launder
-#error __cpp_lib_launder is defined
-#endif
-#endif
-
-#if _HAS_CXX17
-#ifndef __cpp_lib_make_from_tuple
-#error __cpp_lib_make_from_tuple is not defined
-#elif __cpp_lib_make_from_tuple != 201606L
-#error __cpp_lib_make_from_tuple is not 201606L
-#else
-STATIC_ASSERT(__cpp_lib_make_from_tuple == 201606L);
-#endif
-#else
-#ifdef __cpp_lib_make_from_tuple
-#error __cpp_lib_make_from_tuple is defined
-#endif
-#endif
-
-#if _HAS_CXX17
-#ifndef __cpp_lib_math_special_functions
-#error __cpp_lib_math_special_functions is not defined
-#elif __cpp_lib_math_special_functions != 201603L
-#error __cpp_lib_math_special_functions is not 201603L
-#else
-STATIC_ASSERT(__cpp_lib_math_special_functions == 201603L);
-#endif
-#else
-#ifdef __cpp_lib_math_special_functions
-#error __cpp_lib_math_special_functions is defined
-#endif
-#endif
-
-#if _HAS_CXX17
-#ifndef __cpp_lib_memory_resource
-#error __cpp_lib_memory_resource is not defined
-#elif __cpp_lib_memory_resource != 201603L
-#error __cpp_lib_memory_resource is not 201603L
-#else
-STATIC_ASSERT(__cpp_lib_memory_resource == 201603L);
-#endif
-#else
-#ifdef __cpp_lib_memory_resource
-#error __cpp_lib_memory_resource is defined
-#endif
-#endif
-
-#if _HAS_CXX17
-#ifndef __cpp_lib_node_extract
-#error __cpp_lib_node_extract is not defined
-#elif __cpp_lib_node_extract != 201606L
-#error __cpp_lib_node_extract is not 201606L
-#else
-STATIC_ASSERT(__cpp_lib_node_extract == 201606L);
-#endif
-#else
-#ifdef __cpp_lib_node_extract
-#error __cpp_lib_node_extract is defined
-#endif
-#endif
-
-#if _HAS_CXX17
-#ifndef __cpp_lib_not_fn
-#error __cpp_lib_not_fn is not defined
-#elif __cpp_lib_not_fn != 201603L
-#error __cpp_lib_not_fn is not 201603L
-#else
-STATIC_ASSERT(__cpp_lib_not_fn == 201603L);
-#endif
-#else
-#ifdef __cpp_lib_not_fn
-#error __cpp_lib_not_fn is defined
-#endif
-#endif
-
-#if _HAS_CXX17
-#ifndef __cpp_lib_optional
-#error __cpp_lib_optional is not defined
-#elif __cpp_lib_optional != 201606L
-#error __cpp_lib_optional is not 201606L
-#else
-STATIC_ASSERT(__cpp_lib_optional == 201606L);
-#endif
-#else
-#ifdef __cpp_lib_optional
-#error __cpp_lib_optional is defined
-#endif
-#endif
-
-#if _HAS_CXX17
-#ifndef __cpp_lib_raw_memory_algorithms
-#error __cpp_lib_raw_memory_algorithms is not defined
-#elif __cpp_lib_raw_memory_algorithms != 201606L
-#error __cpp_lib_raw_memory_algorithms is not 201606L
-#else
-STATIC_ASSERT(__cpp_lib_raw_memory_algorithms == 201606L);
-#endif
-#else
-#ifdef __cpp_lib_raw_memory_algorithms
-#error __cpp_lib_raw_memory_algorithms is defined
-#endif
-#endif
-
-#if _HAS_CXX17
-#ifndef __cpp_lib_sample
-#error __cpp_lib_sample is not defined
-#elif __cpp_lib_sample != 201603L
-#error __cpp_lib_sample is not 201603L
-#else
-STATIC_ASSERT(__cpp_lib_sample == 201603L);
-#endif
-#else
-#ifdef __cpp_lib_sample
-#error __cpp_lib_sample is defined
-#endif
-#endif
-
-#if _HAS_CXX17
-#ifndef __cpp_lib_scoped_lock
-#error __cpp_lib_scoped_lock is not defined
-#elif __cpp_lib_scoped_lock != 201703L
-#error __cpp_lib_scoped_lock is not 201703L
-#else
-STATIC_ASSERT(__cpp_lib_scoped_lock == 201703L);
-#endif
-#else
-#ifdef __cpp_lib_scoped_lock
-#error __cpp_lib_scoped_lock is defined
-#endif
-#endif
-
-#if _HAS_CXX17
-#ifndef __cpp_lib_shared_ptr_weak_type
-#error __cpp_lib_shared_ptr_weak_type is not defined
-#elif __cpp_lib_shared_ptr_weak_type != 201606L
-#error __cpp_lib_shared_ptr_weak_type is not 201606L
-#else
-STATIC_ASSERT(__cpp_lib_shared_ptr_weak_type == 201606L);
-#endif
-#else
-#ifdef __cpp_lib_shared_ptr_weak_type
-#error __cpp_lib_shared_ptr_weak_type is defined
-#endif
-#endif
-
-#if _HAS_CXX17
-#ifndef __cpp_lib_string_view
-#error __cpp_lib_string_view is not defined
-#elif __cpp_lib_string_view != 201803L
-#error __cpp_lib_string_view is not 201803L
-#else
-STATIC_ASSERT(__cpp_lib_string_view == 201803L);
-#endif
-#else
-#ifdef __cpp_lib_string_view
-#error __cpp_lib_string_view is defined
-#endif
-#endif
-
-#if _HAS_CXX17
-#ifndef __cpp_lib_to_chars
-#error __cpp_lib_to_chars is not defined
-#elif __cpp_lib_to_chars != 201611L
-#error __cpp_lib_to_chars is not 201611L
-#else
-STATIC_ASSERT(__cpp_lib_to_chars == 201611L);
-#endif
-#else
-#ifdef __cpp_lib_to_chars
-#error __cpp_lib_to_chars is defined
-#endif
-#endif
-
-#if _HAS_CXX17
-#ifndef __cpp_lib_variant
-#error __cpp_lib_variant is not defined
-#elif __cpp_lib_variant != 201606L
-#error __cpp_lib_variant is not 201606L
-#else
-STATIC_ASSERT(__cpp_lib_variant == 201606L);
-#endif
-#else
-#ifdef __cpp_lib_variant
-#error __cpp_lib_variant is defined
-#endif
-#endif
-
-#if _HAS_CXX17 && !defined(_M_CEE)
-#ifndef __cpp_lib_execution
-#error __cpp_lib_execution is not defined
-#elif __cpp_lib_execution != 201603L
-#error __cpp_lib_execution is not 201603L
-#else
-STATIC_ASSERT(__cpp_lib_execution == 201603L);
-#endif
-#else
-#ifdef __cpp_lib_execution
-#error __cpp_lib_execution is defined
-#endif
-#endif
-
-#if _HAS_CXX17 && !defined(_M_CEE)
-#ifndef __cpp_lib_parallel_algorithm
-#error __cpp_lib_parallel_algorithm is not defined
-#elif __cpp_lib_parallel_algorithm != 201603L
-#error __cpp_lib_parallel_algorithm is not 201603L
-#else
-STATIC_ASSERT(__cpp_lib_parallel_algorithm == 201603L);
-#endif
-#else
-#ifdef __cpp_lib_parallel_algorithm
-#error __cpp_lib_parallel_algorithm is defined
-#endif
-#endif
-
-#if _HAS_CXX20
-#ifndef __cpp_lib_atomic_float
-#error __cpp_lib_atomic_float is not defined
-#elif __cpp_lib_atomic_float != 201711L
-#error __cpp_lib_atomic_float is not 201711L
-#else
-STATIC_ASSERT(__cpp_lib_atomic_float == 201711L);
-#endif
-#else
-#ifdef __cpp_lib_atomic_float
-#error __cpp_lib_atomic_float is defined
-#endif
-#endif
-
-#if _HAS_CXX20
-#ifndef __cpp_lib_bind_front
-#error __cpp_lib_bind_front is not defined
-#elif __cpp_lib_bind_front != 201907L
-#error __cpp_lib_bind_front is not 201907L
-#else
-STATIC_ASSERT(__cpp_lib_bind_front == 201907L);
-#endif
-#else
-#ifdef __cpp_lib_bind_front
-#error __cpp_lib_bind_front is defined
-#endif
-#endif
-
-#if _HAS_CXX20
-#ifndef __cpp_lib_bounded_array_traits
-#error __cpp_lib_bounded_array_traits is not defined
-#elif __cpp_lib_bounded_array_traits != 201902L
-#error __cpp_lib_bounded_array_traits is not 201902L
-#else
-STATIC_ASSERT(__cpp_lib_bounded_array_traits == 201902L);
-#endif
-#else
-#ifdef __cpp_lib_bounded_array_traits
-#error __cpp_lib_bounded_array_traits is defined
+#ifdef __cpp_lib_concepts
+#error __cpp_lib_concepts is defined
 #endif
 #endif
 
@@ -1477,6 +963,14 @@ STATIC_ASSERT(__cpp_lib_constexpr_numeric == 201911L);
 #endif
 #endif
 
+#ifndef __cpp_lib_enable_shared_from_this
+#error __cpp_lib_enable_shared_from_this is not defined
+#elif __cpp_lib_enable_shared_from_this != 201603L
+#error __cpp_lib_enable_shared_from_this is not 201603L
+#else
+STATIC_ASSERT(__cpp_lib_enable_shared_from_this == 201603L);
+#endif
+
 #if _HAS_CXX20
 #ifndef __cpp_lib_endian
 #error __cpp_lib_endian is not defined
@@ -1505,6 +999,80 @@ STATIC_ASSERT(__cpp_lib_erase_if == 202002L);
 #endif
 #endif
 
+#ifndef __cpp_lib_exchange_function
+#error __cpp_lib_exchange_function is not defined
+#elif __cpp_lib_exchange_function != 201304L
+#error __cpp_lib_exchange_function is not 201304L
+#else
+STATIC_ASSERT(__cpp_lib_exchange_function == 201304L);
+#endif
+
+#if _HAS_CXX17 && !defined(_M_CEE)
+#ifndef __cpp_lib_execution
+#error __cpp_lib_execution is not defined
+#elif __cpp_lib_execution != 201603L
+#error __cpp_lib_execution is not 201603L
+#else
+STATIC_ASSERT(__cpp_lib_execution == 201603L);
+#endif
+#else
+#ifdef __cpp_lib_execution
+#error __cpp_lib_execution is defined
+#endif
+#endif
+
+#ifndef __cpp_lib_experimental_erase_if
+#error __cpp_lib_experimental_erase_if is not defined
+#elif __cpp_lib_experimental_erase_if != 201411L
+#error __cpp_lib_experimental_erase_if is not 201411L
+#else
+STATIC_ASSERT(__cpp_lib_experimental_erase_if == 201411L);
+#endif
+
+#ifndef __cpp_lib_experimental_filesystem
+#error __cpp_lib_experimental_filesystem is not defined
+#elif __cpp_lib_experimental_filesystem != 201406L
+#error __cpp_lib_experimental_filesystem is not 201406L
+#else
+STATIC_ASSERT(__cpp_lib_experimental_filesystem == 201406L);
+#endif
+
+#if _HAS_CXX17
+#ifndef __cpp_lib_filesystem
+#error __cpp_lib_filesystem is not defined
+#elif __cpp_lib_filesystem != 201703L
+#error __cpp_lib_filesystem is not 201703L
+#else
+STATIC_ASSERT(__cpp_lib_filesystem == 201703L);
+#endif
+#else
+#ifdef __cpp_lib_filesystem
+#error __cpp_lib_filesystem is defined
+#endif
+#endif
+
+#if _HAS_CXX17
+#ifndef __cpp_lib_gcd_lcm
+#error __cpp_lib_gcd_lcm is not defined
+#elif __cpp_lib_gcd_lcm != 201606L
+#error __cpp_lib_gcd_lcm is not 201606L
+#else
+STATIC_ASSERT(__cpp_lib_gcd_lcm == 201606L);
+#endif
+#else
+#ifdef __cpp_lib_gcd_lcm
+#error __cpp_lib_gcd_lcm is defined
+#endif
+#endif
+
+#ifndef __cpp_lib_generic_associative_lookup
+#error __cpp_lib_generic_associative_lookup is not defined
+#elif __cpp_lib_generic_associative_lookup != 201304L
+#error __cpp_lib_generic_associative_lookup is not 201304L
+#else
+STATIC_ASSERT(__cpp_lib_generic_associative_lookup == 201304L);
+#endif
+
 #if _HAS_CXX20
 #ifndef __cpp_lib_generic_unordered_lookup
 #error __cpp_lib_generic_unordered_lookup is not defined
@@ -1519,6 +1087,72 @@ STATIC_ASSERT(__cpp_lib_generic_unordered_lookup == 201811L);
 #endif
 #endif
 
+#if _HAS_CXX17
+#ifndef __cpp_lib_hardware_interference_size
+#error __cpp_lib_hardware_interference_size is not defined
+#elif __cpp_lib_hardware_interference_size != 201703L
+#error __cpp_lib_hardware_interference_size is not 201703L
+#else
+STATIC_ASSERT(__cpp_lib_hardware_interference_size == 201703L);
+#endif
+#else
+#ifdef __cpp_lib_hardware_interference_size
+#error __cpp_lib_hardware_interference_size is defined
+#endif
+#endif
+
+#if _HAS_CXX17
+#ifndef __cpp_lib_has_unique_object_representations
+#error __cpp_lib_has_unique_object_representations is not defined
+#elif __cpp_lib_has_unique_object_representations != 201606L
+#error __cpp_lib_has_unique_object_representations is not 201606L
+#else
+STATIC_ASSERT(__cpp_lib_has_unique_object_representations == 201606L);
+#endif
+#else
+#ifdef __cpp_lib_has_unique_object_representations
+#error __cpp_lib_has_unique_object_representations is defined
+#endif
+#endif
+
+#if _HAS_CXX17
+#ifndef __cpp_lib_hypot
+#error __cpp_lib_hypot is not defined
+#elif __cpp_lib_hypot != 201603L
+#error __cpp_lib_hypot is not 201603L
+#else
+STATIC_ASSERT(__cpp_lib_hypot == 201603L);
+#endif
+#else
+#ifdef __cpp_lib_hypot
+#error __cpp_lib_hypot is defined
+#endif
+#endif
+
+#ifndef __cpp_lib_incomplete_container_elements
+#error __cpp_lib_incomplete_container_elements is not defined
+#elif __cpp_lib_incomplete_container_elements != 201505L
+#error __cpp_lib_incomplete_container_elements is not 201505L
+#else
+STATIC_ASSERT(__cpp_lib_incomplete_container_elements == 201505L);
+#endif
+
+#ifndef __cpp_lib_integer_sequence
+#error __cpp_lib_integer_sequence is not defined
+#elif __cpp_lib_integer_sequence != 201304L
+#error __cpp_lib_integer_sequence is not 201304L
+#else
+STATIC_ASSERT(__cpp_lib_integer_sequence == 201304L);
+#endif
+
+#ifndef __cpp_lib_integral_constant_callable
+#error __cpp_lib_integral_constant_callable is not defined
+#elif __cpp_lib_integral_constant_callable != 201304L
+#error __cpp_lib_integral_constant_callable is not 201304L
+#else
+STATIC_ASSERT(__cpp_lib_integral_constant_callable == 201304L);
+#endif
+
 #if _HAS_CXX20
 #ifndef __cpp_lib_int_pow2
 #error __cpp_lib_int_pow2 is not defined
@@ -1530,6 +1164,28 @@ STATIC_ASSERT(__cpp_lib_int_pow2 == 202002L);
 #else
 #ifdef __cpp_lib_int_pow2
 #error __cpp_lib_int_pow2 is defined
+#endif
+#endif
+
+#ifndef __cpp_lib_invoke
+#error __cpp_lib_invoke is not defined
+#elif __cpp_lib_invoke != 201411L
+#error __cpp_lib_invoke is not 201411L
+#else
+STATIC_ASSERT(__cpp_lib_invoke == 201411L);
+#endif
+
+#if _HAS_CXX17
+#ifndef __cpp_lib_is_aggregate
+#error __cpp_lib_is_aggregate is not defined
+#elif __cpp_lib_is_aggregate != 201703L
+#error __cpp_lib_is_aggregate is not 201703L
+#else
+STATIC_ASSERT(__cpp_lib_is_aggregate == 201703L);
+#endif
+#else
+#ifdef __cpp_lib_is_aggregate
+#error __cpp_lib_is_aggregate is defined
 #endif
 #endif
 
@@ -1547,6 +1203,28 @@ STATIC_ASSERT(__cpp_lib_is_constant_evaluated == 201811L);
 #endif
 #endif
 
+#ifndef __cpp_lib_is_final
+#error __cpp_lib_is_final is not defined
+#elif __cpp_lib_is_final != 201402L
+#error __cpp_lib_is_final is not 201402L
+#else
+STATIC_ASSERT(__cpp_lib_is_final == 201402L);
+#endif
+
+#if _HAS_CXX17
+#ifndef __cpp_lib_is_invocable
+#error __cpp_lib_is_invocable is not defined
+#elif __cpp_lib_is_invocable != 201703L
+#error __cpp_lib_is_invocable is not 201703L
+#else
+STATIC_ASSERT(__cpp_lib_is_invocable == 201703L);
+#endif
+#else
+#ifdef __cpp_lib_is_invocable
+#error __cpp_lib_is_invocable is defined
+#endif
+#endif
+
 #if _HAS_CXX20
 #ifndef __cpp_lib_is_nothrow_convertible
 #error __cpp_lib_is_nothrow_convertible is not defined
@@ -1558,6 +1236,42 @@ STATIC_ASSERT(__cpp_lib_is_nothrow_convertible == 201806L);
 #else
 #ifdef __cpp_lib_is_nothrow_convertible
 #error __cpp_lib_is_nothrow_convertible is defined
+#endif
+#endif
+
+#ifndef __cpp_lib_is_null_pointer
+#error __cpp_lib_is_null_pointer is not defined
+#elif __cpp_lib_is_null_pointer != 201309L
+#error __cpp_lib_is_null_pointer is not 201309L
+#else
+STATIC_ASSERT(__cpp_lib_is_null_pointer == 201309L);
+#endif
+
+#if _HAS_CXX17
+#ifndef __cpp_lib_is_swappable
+#error __cpp_lib_is_swappable is not defined
+#elif __cpp_lib_is_swappable != 201603L
+#error __cpp_lib_is_swappable is not 201603L
+#else
+STATIC_ASSERT(__cpp_lib_is_swappable == 201603L);
+#endif
+#else
+#ifdef __cpp_lib_is_swappable
+#error __cpp_lib_is_swappable is defined
+#endif
+#endif
+
+#if _HAS_CXX17
+#ifndef __cpp_lib_launder
+#error __cpp_lib_launder is not defined
+#elif __cpp_lib_launder != 201606L
+#error __cpp_lib_launder is not 201606L
+#else
+STATIC_ASSERT(__cpp_lib_launder == 201606L);
+#endif
+#else
+#ifdef __cpp_lib_launder
+#error __cpp_lib_launder is defined
 #endif
 #endif
 
@@ -1575,6 +1289,52 @@ STATIC_ASSERT(__cpp_lib_list_remove_return_type == 201806L);
 #endif
 #endif
 
+#ifndef __cpp_lib_logical_traits
+#error __cpp_lib_logical_traits is not defined
+#elif __cpp_lib_logical_traits != 201510L
+#error __cpp_lib_logical_traits is not 201510L
+#else
+STATIC_ASSERT(__cpp_lib_logical_traits == 201510L);
+#endif
+
+#if _HAS_CXX17
+#ifndef __cpp_lib_make_from_tuple
+#error __cpp_lib_make_from_tuple is not defined
+#elif __cpp_lib_make_from_tuple != 201606L
+#error __cpp_lib_make_from_tuple is not 201606L
+#else
+STATIC_ASSERT(__cpp_lib_make_from_tuple == 201606L);
+#endif
+#else
+#ifdef __cpp_lib_make_from_tuple
+#error __cpp_lib_make_from_tuple is defined
+#endif
+#endif
+
+#ifndef __cpp_lib_make_reverse_iterator
+#error __cpp_lib_make_reverse_iterator is not defined
+#elif __cpp_lib_make_reverse_iterator != 201402L
+#error __cpp_lib_make_reverse_iterator is not 201402L
+#else
+STATIC_ASSERT(__cpp_lib_make_reverse_iterator == 201402L);
+#endif
+
+#ifndef __cpp_lib_make_unique
+#error __cpp_lib_make_unique is not defined
+#elif __cpp_lib_make_unique != 201304L
+#error __cpp_lib_make_unique is not 201304L
+#else
+STATIC_ASSERT(__cpp_lib_make_unique == 201304L);
+#endif
+
+#ifndef __cpp_lib_map_try_emplace
+#error __cpp_lib_map_try_emplace is not defined
+#elif __cpp_lib_map_try_emplace != 201411L
+#error __cpp_lib_map_try_emplace is not 201411L
+#else
+STATIC_ASSERT(__cpp_lib_map_try_emplace == 201411L);
+#endif
+
 #if _HAS_CXX20
 #ifndef __cpp_lib_math_constants
 #error __cpp_lib_math_constants is not defined
@@ -1586,6 +1346,128 @@ STATIC_ASSERT(__cpp_lib_math_constants == 201907L);
 #else
 #ifdef __cpp_lib_math_constants
 #error __cpp_lib_math_constants is defined
+#endif
+#endif
+
+#if _HAS_CXX17
+#ifndef __cpp_lib_math_special_functions
+#error __cpp_lib_math_special_functions is not defined
+#elif __cpp_lib_math_special_functions != 201603L
+#error __cpp_lib_math_special_functions is not 201603L
+#else
+STATIC_ASSERT(__cpp_lib_math_special_functions == 201603L);
+#endif
+#else
+#ifdef __cpp_lib_math_special_functions
+#error __cpp_lib_math_special_functions is defined
+#endif
+#endif
+
+#if _HAS_CXX17
+#ifndef __cpp_lib_memory_resource
+#error __cpp_lib_memory_resource is not defined
+#elif __cpp_lib_memory_resource != 201603L
+#error __cpp_lib_memory_resource is not 201603L
+#else
+STATIC_ASSERT(__cpp_lib_memory_resource == 201603L);
+#endif
+#else
+#ifdef __cpp_lib_memory_resource
+#error __cpp_lib_memory_resource is defined
+#endif
+#endif
+
+#if _HAS_CXX17
+#ifndef __cpp_lib_node_extract
+#error __cpp_lib_node_extract is not defined
+#elif __cpp_lib_node_extract != 201606L
+#error __cpp_lib_node_extract is not 201606L
+#else
+STATIC_ASSERT(__cpp_lib_node_extract == 201606L);
+#endif
+#else
+#ifdef __cpp_lib_node_extract
+#error __cpp_lib_node_extract is defined
+#endif
+#endif
+
+#ifndef __cpp_lib_nonmember_container_access
+#error __cpp_lib_nonmember_container_access is not defined
+#elif __cpp_lib_nonmember_container_access != 201411L
+#error __cpp_lib_nonmember_container_access is not 201411L
+#else
+STATIC_ASSERT(__cpp_lib_nonmember_container_access == 201411L);
+#endif
+
+#if _HAS_CXX17
+#ifndef __cpp_lib_not_fn
+#error __cpp_lib_not_fn is not defined
+#elif __cpp_lib_not_fn != 201603L
+#error __cpp_lib_not_fn is not 201603L
+#else
+STATIC_ASSERT(__cpp_lib_not_fn == 201603L);
+#endif
+#else
+#ifdef __cpp_lib_not_fn
+#error __cpp_lib_not_fn is defined
+#endif
+#endif
+
+#ifndef __cpp_lib_null_iterators
+#error __cpp_lib_null_iterators is not defined
+#elif __cpp_lib_null_iterators != 201304L
+#error __cpp_lib_null_iterators is not 201304L
+#else
+STATIC_ASSERT(__cpp_lib_null_iterators == 201304L);
+#endif
+
+#if _HAS_CXX17
+#ifndef __cpp_lib_optional
+#error __cpp_lib_optional is not defined
+#elif __cpp_lib_optional != 201606L
+#error __cpp_lib_optional is not 201606L
+#else
+STATIC_ASSERT(__cpp_lib_optional == 201606L);
+#endif
+#else
+#ifdef __cpp_lib_optional
+#error __cpp_lib_optional is defined
+#endif
+#endif
+
+#if _HAS_CXX17 && !defined(_M_CEE)
+#ifndef __cpp_lib_parallel_algorithm
+#error __cpp_lib_parallel_algorithm is not defined
+#elif __cpp_lib_parallel_algorithm != 201603L
+#error __cpp_lib_parallel_algorithm is not 201603L
+#else
+STATIC_ASSERT(__cpp_lib_parallel_algorithm == 201603L);
+#endif
+#else
+#ifdef __cpp_lib_parallel_algorithm
+#error __cpp_lib_parallel_algorithm is defined
+#endif
+#endif
+
+#ifndef __cpp_lib_quoted_string_io
+#error __cpp_lib_quoted_string_io is not defined
+#elif __cpp_lib_quoted_string_io != 201304L
+#error __cpp_lib_quoted_string_io is not 201304L
+#else
+STATIC_ASSERT(__cpp_lib_quoted_string_io == 201304L);
+#endif
+
+#if _HAS_CXX17
+#ifndef __cpp_lib_raw_memory_algorithms
+#error __cpp_lib_raw_memory_algorithms is not defined
+#elif __cpp_lib_raw_memory_algorithms != 201606L
+#error __cpp_lib_raw_memory_algorithms is not 201606L
+#else
+STATIC_ASSERT(__cpp_lib_raw_memory_algorithms == 201606L);
+#endif
+#else
+#ifdef __cpp_lib_raw_memory_algorithms
+#error __cpp_lib_raw_memory_algorithms is defined
 #endif
 #endif
 
@@ -1602,6 +1484,94 @@ STATIC_ASSERT(__cpp_lib_remove_cvref == 201711L);
 #error __cpp_lib_remove_cvref is defined
 #endif
 #endif
+
+#ifndef __cpp_lib_result_of_sfinae
+#error __cpp_lib_result_of_sfinae is not defined
+#elif __cpp_lib_result_of_sfinae != 201210L
+#error __cpp_lib_result_of_sfinae is not 201210L
+#else
+STATIC_ASSERT(__cpp_lib_result_of_sfinae == 201210L);
+#endif
+
+#ifndef __cpp_lib_robust_nonmodifying_seq_ops
+#error __cpp_lib_robust_nonmodifying_seq_ops is not defined
+#elif __cpp_lib_robust_nonmodifying_seq_ops != 201304L
+#error __cpp_lib_robust_nonmodifying_seq_ops is not 201304L
+#else
+STATIC_ASSERT(__cpp_lib_robust_nonmodifying_seq_ops == 201304L);
+#endif
+
+#if _HAS_CXX17
+#ifndef __cpp_lib_sample
+#error __cpp_lib_sample is not defined
+#elif __cpp_lib_sample != 201603L
+#error __cpp_lib_sample is not 201603L
+#else
+STATIC_ASSERT(__cpp_lib_sample == 201603L);
+#endif
+#else
+#ifdef __cpp_lib_sample
+#error __cpp_lib_sample is defined
+#endif
+#endif
+
+#if _HAS_CXX17
+#ifndef __cpp_lib_scoped_lock
+#error __cpp_lib_scoped_lock is not defined
+#elif __cpp_lib_scoped_lock != 201703L
+#error __cpp_lib_scoped_lock is not 201703L
+#else
+STATIC_ASSERT(__cpp_lib_scoped_lock == 201703L);
+#endif
+#else
+#ifdef __cpp_lib_scoped_lock
+#error __cpp_lib_scoped_lock is defined
+#endif
+#endif
+
+#ifndef __cpp_lib_shared_mutex
+#error __cpp_lib_shared_mutex is not defined
+#elif __cpp_lib_shared_mutex != 201505L
+#error __cpp_lib_shared_mutex is not 201505L
+#else
+STATIC_ASSERT(__cpp_lib_shared_mutex == 201505L);
+#endif
+
+#ifndef __cpp_lib_shared_ptr_arrays
+#error __cpp_lib_shared_ptr_arrays is not defined
+#elif __cpp_lib_shared_ptr_arrays != 201611L
+#error __cpp_lib_shared_ptr_arrays is not 201611L
+#else
+STATIC_ASSERT(__cpp_lib_shared_ptr_arrays == 201611L);
+#endif
+
+#if _HAS_CXX17
+#ifndef __cpp_lib_shared_ptr_weak_type
+#error __cpp_lib_shared_ptr_weak_type is not defined
+#elif __cpp_lib_shared_ptr_weak_type != 201606L
+#error __cpp_lib_shared_ptr_weak_type is not 201606L
+#else
+STATIC_ASSERT(__cpp_lib_shared_ptr_weak_type == 201606L);
+#endif
+#else
+#ifdef __cpp_lib_shared_ptr_weak_type
+#error __cpp_lib_shared_ptr_weak_type is defined
+#endif
+#endif
+
+#ifdef _M_CEE
+#ifdef __cpp_lib_shared_timed_mutex
+#error __cpp_lib_shared_timed_mutex is defined
+#endif
+#else // ^^^ _M_CEE ^^^ // vvv !_M_CEE vvv
+#ifndef __cpp_lib_shared_timed_mutex
+#error __cpp_lib_shared_timed_mutex is not defined
+#elif __cpp_lib_shared_timed_mutex != 201402L
+#error __cpp_lib_shared_timed_mutex is not 201402L
+#else
+STATIC_ASSERT(__cpp_lib_shared_timed_mutex == 201402L);
+#endif
+#endif // _M_CEE
 
 #if _HAS_CXX20
 #ifndef __cpp_lib_shift
@@ -1659,6 +1629,28 @@ STATIC_ASSERT(__cpp_lib_starts_ends_with == 201711L);
 #endif
 #endif
 
+#ifndef __cpp_lib_string_udls
+#error __cpp_lib_string_udls is not defined
+#elif __cpp_lib_string_udls != 201304L
+#error __cpp_lib_string_udls is not 201304L
+#else
+STATIC_ASSERT(__cpp_lib_string_udls == 201304L);
+#endif
+
+#if _HAS_CXX17
+#ifndef __cpp_lib_string_view
+#error __cpp_lib_string_view is not defined
+#elif __cpp_lib_string_view != 201803L
+#error __cpp_lib_string_view is not 201803L
+#else
+STATIC_ASSERT(__cpp_lib_string_view == 201803L);
+#endif
+#else
+#ifdef __cpp_lib_string_view
+#error __cpp_lib_string_view is defined
+#endif
+#endif
+
 #if _HAS_CXX20
 #ifndef __cpp_lib_to_address
 #error __cpp_lib_to_address is not defined
@@ -1687,6 +1679,52 @@ STATIC_ASSERT(__cpp_lib_to_array == 201907L);
 #endif
 #endif
 
+#if _HAS_CXX17
+#ifndef __cpp_lib_to_chars
+#error __cpp_lib_to_chars is not defined
+#elif __cpp_lib_to_chars != 201611L
+#error __cpp_lib_to_chars is not 201611L
+#else
+STATIC_ASSERT(__cpp_lib_to_chars == 201611L);
+#endif
+#else
+#ifdef __cpp_lib_to_chars
+#error __cpp_lib_to_chars is defined
+#endif
+#endif
+
+#ifndef __cpp_lib_transformation_trait_aliases
+#error __cpp_lib_transformation_trait_aliases is not defined
+#elif __cpp_lib_transformation_trait_aliases != 201304L
+#error __cpp_lib_transformation_trait_aliases is not 201304L
+#else
+STATIC_ASSERT(__cpp_lib_transformation_trait_aliases == 201304L);
+#endif
+
+#ifndef __cpp_lib_transparent_operators
+#error __cpp_lib_transparent_operators is not defined
+#elif __cpp_lib_transparent_operators != 201510L
+#error __cpp_lib_transparent_operators is not 201510L
+#else
+STATIC_ASSERT(__cpp_lib_transparent_operators == 201510L);
+#endif
+
+#ifndef __cpp_lib_tuples_by_type
+#error __cpp_lib_tuples_by_type is not defined
+#elif __cpp_lib_tuples_by_type != 201304L
+#error __cpp_lib_tuples_by_type is not 201304L
+#else
+STATIC_ASSERT(__cpp_lib_tuples_by_type == 201304L);
+#endif
+
+#ifndef __cpp_lib_tuple_element_t
+#error __cpp_lib_tuple_element_t is not defined
+#elif __cpp_lib_tuple_element_t != 201402L
+#error __cpp_lib_tuple_element_t is not 201402L
+#else
+STATIC_ASSERT(__cpp_lib_tuple_element_t == 201402L);
+#endif
+
 #if _HAS_CXX20
 #ifndef __cpp_lib_type_identity
 #error __cpp_lib_type_identity is not defined
@@ -1699,6 +1737,30 @@ STATIC_ASSERT(__cpp_lib_type_identity == 201806L);
 #ifdef __cpp_lib_type_identity
 #error __cpp_lib_type_identity is defined
 #endif
+#endif
+
+#ifndef __cpp_lib_type_trait_variable_templates
+#error __cpp_lib_type_trait_variable_templates is not defined
+#elif __cpp_lib_type_trait_variable_templates != 201510L
+#error __cpp_lib_type_trait_variable_templates is not 201510L
+#else
+STATIC_ASSERT(__cpp_lib_type_trait_variable_templates == 201510L);
+#endif
+
+#ifndef __cpp_lib_uncaught_exceptions
+#error __cpp_lib_uncaught_exceptions is not defined
+#elif __cpp_lib_uncaught_exceptions != 201411L
+#error __cpp_lib_uncaught_exceptions is not 201411L
+#else
+STATIC_ASSERT(__cpp_lib_uncaught_exceptions == 201411L);
+#endif
+
+#ifndef __cpp_lib_unordered_map_try_emplace
+#error __cpp_lib_unordered_map_try_emplace is not defined
+#elif __cpp_lib_unordered_map_try_emplace != 201411L
+#error __cpp_lib_unordered_map_try_emplace is not 201411L
+#else
+STATIC_ASSERT(__cpp_lib_unordered_map_try_emplace == 201411L);
 #endif
 
 #if _HAS_CXX20
@@ -1715,86 +1777,24 @@ STATIC_ASSERT(__cpp_lib_unwrap_ref == 201811L);
 #endif
 #endif
 
-#if _HAS_CXX20 && !defined(__EDG__) // TRANSITION, VSO-1041044
-#ifndef __cpp_lib_bit_cast
-#error __cpp_lib_bit_cast is not defined
-#elif __cpp_lib_bit_cast != 201806L
-#error __cpp_lib_bit_cast is not 201806L
+#if _HAS_CXX17
+#ifndef __cpp_lib_variant
+#error __cpp_lib_variant is not defined
+#elif __cpp_lib_variant != 201606L
+#error __cpp_lib_variant is not 201606L
 #else
-STATIC_ASSERT(__cpp_lib_bit_cast == 201806L);
+STATIC_ASSERT(__cpp_lib_variant == 201606L);
 #endif
 #else
-#ifdef __cpp_lib_bit_cast
-#error __cpp_lib_bit_cast is defined
+#ifdef __cpp_lib_variant
+#error __cpp_lib_variant is defined
 #endif
 #endif
 
-#if _HAS_CXX20 && (defined(__clang__) || defined(__EDG__)) // TRANSITION, VSO-1020212
-#ifndef __cpp_lib_bitops
-#error __cpp_lib_bitops is not defined
-#elif __cpp_lib_bitops != 201907L
-#error __cpp_lib_bitops is not 201907L
+#ifndef __cpp_lib_void_t
+#error __cpp_lib_void_t is not defined
+#elif __cpp_lib_void_t != 201411L
+#error __cpp_lib_void_t is not 201411L
 #else
-STATIC_ASSERT(__cpp_lib_bitops == 201907L);
+STATIC_ASSERT(__cpp_lib_void_t == 201411L);
 #endif
-#else
-#ifdef __cpp_lib_bitops
-#error __cpp_lib_bitops is defined
-#endif
-#endif
-
-#if _HAS_CXX20 && defined(__cpp_char8_t)
-#ifndef __cpp_lib_char8_t
-#error __cpp_lib_char8_t is not defined
-#elif __cpp_lib_char8_t != 201907L
-#error __cpp_lib_char8_t is not 201907L
-#else
-STATIC_ASSERT(__cpp_lib_char8_t == 201907L);
-#endif
-#else
-#ifdef __cpp_lib_char8_t
-#error __cpp_lib_char8_t is defined
-#endif
-#endif
-
-#if _HAS_CXX20 && defined(__cpp_concepts)
-#ifndef __cpp_lib_concepts
-#error __cpp_lib_concepts is not defined
-#elif __cpp_lib_concepts != 201907L
-#error __cpp_lib_concepts is not 201907L
-#else
-STATIC_ASSERT(__cpp_lib_concepts == 201907L);
-#endif
-#else
-#ifdef __cpp_lib_concepts
-#error __cpp_lib_concepts is defined
-#endif
-#endif
-
-#if _HAS_STD_BYTE
-#ifndef __cpp_lib_byte
-#error __cpp_lib_byte is not defined
-#elif __cpp_lib_byte != 201603L
-#error __cpp_lib_byte is not 201603L
-#else
-STATIC_ASSERT(__cpp_lib_byte == 201603L);
-#endif
-#else
-#ifdef __cpp_lib_byte
-#error __cpp_lib_byte is defined
-#endif
-#endif
-
-#ifdef _M_CEE
-#ifdef __cpp_lib_shared_timed_mutex
-#error __cpp_lib_shared_timed_mutex is defined
-#endif
-#else // ^^^ _M_CEE ^^^ // vvv !_M_CEE vvv
-#ifndef __cpp_lib_shared_timed_mutex
-#error __cpp_lib_shared_timed_mutex is not defined
-#elif __cpp_lib_shared_timed_mutex != 201402L
-#error __cpp_lib_shared_timed_mutex is not 201402L
-#else
-STATIC_ASSERT(__cpp_lib_shared_timed_mutex == 201402L);
-#endif
-#endif // _M_CEE

--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.cpp
@@ -5,7 +5,7 @@
 
 int main() {} // COMPILE-ONLY
 
-// ATTRIBUTES.
+// ATTRIBUTE FEATURE-TEST MACROS.
 
 #ifdef __has_cpp_attribute
 // Good.
@@ -24,8 +24,13 @@ int main() {} // COMPILE-ONLY
 #if __has_cpp_attribute(carries_dependency) != 200809L
 #error Expected has_cpp_attribute(carries_dependency) to equal 200809L.
 #endif
+
 #if __has_cpp_attribute(deprecated) != 201309L
 #error Expected has_cpp_attribute(deprecated) to equal 201309L.
+#endif
+
+#if __has_cpp_attribute(noreturn) != 200809L
+#error Expected has_cpp_attribute(noreturn) to equal 200809L.
 #endif
 
 #if defined(__clang__) || defined(__EDG__) // clang and EDG don't yet implement P1771R1
@@ -38,11 +43,32 @@ int main() {} // COMPILE-ONLY
 #endif
 #endif
 
+#if _HAS_CXX17 || defined(__clang__) || defined(__EDG__) // Clang and EDG provide this in C++14 mode.
+#if __has_cpp_attribute(fallthrough) != 201603L
+#error Expected has_cpp_attribute(fallthrough) to equal 201603L.
+#endif
+#else
+#if __has_cpp_attribute(fallthrough) != 0
+#error Expected has_cpp_attribute(fallthrough) to equal 0.
+#endif
+#endif
+
+#if _HAS_CXX17 || defined(__clang__) || defined(__EDG__) // Clang and EDG provide this in C++14 mode.
+#if __has_cpp_attribute(maybe_unused) != 201603L
+#error Expected has_cpp_attribute(maybe_unused) to equal 201603L.
+#endif
+#else
+#if __has_cpp_attribute(maybe_unused) != 0
+#error Expected has_cpp_attribute(maybe_unused) to equal 0.
+#endif
+#endif
+
 #if __has_cpp_attribute(noreturn) != 200809L
 #error Expected has_cpp_attribute(noreturn) to equal 200809L.
 #endif
 
-//// LANGUAGE FEATURE-TEST MACROS
+
+// COMPILER FEATURE-TEST MACROS
 
 #ifndef __cpp_aggregate_nsdmi
 #error Expected __cpp_aggregate_nsdmi to be defined.
@@ -277,96 +303,6 @@ STATIC_ASSERT(__cpp_variable_templates == 201304L);
 STATIC_ASSERT(__cpp_variadic_templates == 200704L);
 #endif
 
-// C++98, /GR[-]
-#ifdef TEST_DISABLED_RTTI
-#ifdef __cpp_rtti
-#error Expected __cpp_rtti to NOT be defined.
-#endif
-#else
-#ifndef __cpp_rtti
-#error Expected __cpp_rtti to be defined.
-#elif __cpp_rtti != 199711L
-#error Expected cpp_rtti to equal 199711L.
-#else
-STATIC_ASSERT(__cpp_rtti == 199711L);
-#endif
-#endif
-
-// C++11, /Zc:threadSafeInit[-]
-#if defined(_M_CEE_PURE) || defined(TEST_DISABLED_THREADSAFE_STATIC_INIT)
-#ifdef __cpp_threadsafe_static_init
-#error Expected __cpp_threadsafe_static_init to NOT be defined.
-#endif
-#else
-#ifndef __cpp_threadsafe_static_init
-#error Expected __cpp_threadsafe_static_init to be defined.
-#elif __cpp_threadsafe_static_init != 200806L
-#error Expected cpp_threadsafe_static_init to equal 200806L.
-#else
-STATIC_ASSERT(__cpp_threadsafe_static_init == 200806L);
-#endif
-#endif
-
-// C++14, /Zc:sizedDealloc[-]
-#if defined(TEST_DISABLED_SIZED_DEALLOCATION) || defined(__clang__) // Clang disables sized deallocation by default.
-#ifdef __cpp_sized_deallocation
-#error Expected __cpp_sized_deallocation to NOT be defined.
-#endif
-#else
-#ifndef __cpp_sized_deallocation
-#error Expected __cpp_sized_deallocation to be defined.
-#elif __cpp_sized_deallocation != 201309L
-#error Expected cpp_sized_deallocation to equal 201309L.
-#else
-STATIC_ASSERT(__cpp_sized_deallocation == 201309L);
-#endif
-#endif
-
-// C++17, /Zc:alignedNew[-]
-#if !_HAS_CXX17 || defined(TEST_DISABLED_ALIGNED_NEW)
-#ifdef __cpp_aligned_new
-#error Expected __cpp_aligned_new to NOT be defined.
-#endif
-#else
-#ifndef __cpp_aligned_new
-#error Expected __cpp_aligned_new to be defined.
-#elif __cpp_aligned_new != 201606L
-#error Expected cpp_aligned_new to equal 201606L.
-#else
-STATIC_ASSERT(__cpp_aligned_new == 201606L);
-#endif
-#endif
-
-// C++17, /Zc:noexceptTypes[-]
-#if !_HAS_CXX17 || defined(TEST_DISABLED_NOEXCEPT_FUNCTION_TYPE)
-#ifdef __cpp_noexcept_function_type
-#error Expected __cpp_noexcept_function_type to NOT be defined.
-#endif
-#else
-#ifndef __cpp_noexcept_function_type
-#error Expected __cpp_noexcept_function_type to be defined.
-#elif __cpp_noexcept_function_type != 201510L
-#error Expected cpp_noexcept_function_type to equal 201510L.
-#else
-STATIC_ASSERT(__cpp_noexcept_function_type == 201510L);
-#endif
-#endif
-
-// C++98, /EHs[-]
-#ifdef TEST_DISABLED_EXCEPTIONS
-#ifdef __cpp_exceptions
-#error Expected __cpp_exceptions to NOT be defined.
-#endif
-#else
-#ifndef __cpp_exceptions
-#error Expected __cpp_exceptions to be defined.
-#elif __cpp_exceptions != 199711L
-#error Expected cpp_exceptions to equal 199711L.
-#else
-STATIC_ASSERT(__cpp_exceptions == 199711L);
-#endif
-#endif
-
 #if _HAS_CXX17
 #ifndef __cpp_aggregate_bases
 #error Expected __cpp_aggregate_bases to be defined.
@@ -515,20 +451,6 @@ STATIC_ASSERT(__cpp_template_template_args == 201611L);
 #endif
 
 #if _HAS_CXX17 || !defined(__clang__) // C1XX implemented this C++17 feature unconditionally.
-#ifndef __cpp_namespace_attributes
-#error Expected __cpp_namespace_attributes to be defined.
-#elif __cpp_namespace_attributes != 201411L
-#error Expected cpp_namespace_attributes to equal 201411L.
-#else
-STATIC_ASSERT(__cpp_namespace_attributes == 201411L);
-#endif
-#else
-#ifdef __cpp_namespace_attributes
-#error Expected __cpp_namespace_attributes to NOT be defined.
-#endif
-#endif
-
-#if _HAS_CXX17 || !defined(__clang__) // C1XX implemented this C++17 feature unconditionally.
 #ifndef __cpp_enumerator_attributes
 #error Expected __cpp_enumerator_attributes to be defined.
 #elif __cpp_enumerator_attributes != 201411L
@@ -539,6 +461,20 @@ STATIC_ASSERT(__cpp_enumerator_attributes == 201411L);
 #else
 #ifdef __cpp_enumerator_attributes
 #error Expected __cpp_enumerator_attributes to NOT be defined.
+#endif
+#endif
+
+#if _HAS_CXX17 || !defined(__clang__) // C1XX implemented this C++17 feature unconditionally.
+#ifndef __cpp_namespace_attributes
+#error Expected __cpp_namespace_attributes to be defined.
+#elif __cpp_namespace_attributes != 201411L
+#error Expected cpp_namespace_attributes to equal 201411L.
+#else
+STATIC_ASSERT(__cpp_namespace_attributes == 201411L);
+#endif
+#else
+#ifdef __cpp_namespace_attributes
+#error Expected __cpp_namespace_attributes to NOT be defined.
 #endif
 #endif
 
@@ -629,6 +565,93 @@ STATIC_ASSERT(__cpp_conditional_explicit == 201806L);
 #error Expected __cpp_conditional_explicit to NOT be defined.
 #endif
 #endif
+
+// C++98, /EHs[-]
+#ifdef TEST_DISABLED_EXCEPTIONS
+#ifdef __cpp_exceptions
+#error Expected __cpp_exceptions to NOT be defined.
+#endif
+#else
+#ifndef __cpp_exceptions
+#error Expected __cpp_exceptions to be defined.
+#elif __cpp_exceptions != 199711L
+#error Expected cpp_exceptions to equal 199711L.
+#else
+STATIC_ASSERT(__cpp_exceptions == 199711L);
+#endif
+#endif
+
+// C++98, /GR[-]
+#ifdef TEST_DISABLED_RTTI
+#ifdef __cpp_rtti
+#error Expected __cpp_rtti to NOT be defined.
+#endif
+#else
+#ifdef __cpp_namespace_attributes
+#error Expected __cpp_namespace_attributes to NOT be defined.
+#endif
+#endif
+
+// C++11, /Zc:threadSafeInit[-]
+#if defined(_M_CEE_PURE) || defined(TEST_DISABLED_THREADSAFE_STATIC_INIT)
+#ifdef __cpp_threadsafe_static_init
+#error Expected __cpp_threadsafe_static_init to NOT be defined.
+#endif
+#else
+#ifndef __cpp_threadsafe_static_init
+#error Expected __cpp_threadsafe_static_init to be defined.
+#elif __cpp_threadsafe_static_init != 200806L
+#error Expected cpp_threadsafe_static_init to equal 200806L.
+#else
+STATIC_ASSERT(__cpp_threadsafe_static_init == 200806L);
+#endif
+#endif
+
+// C++14, /Zc:sizedDealloc[-]
+#if defined(TEST_DISABLED_SIZED_DEALLOCATION) || defined(__clang__) // Clang disables sized deallocation by default.
+#ifdef __cpp_sized_deallocation
+#error Expected __cpp_sized_deallocation to NOT be defined.
+#endif
+#else
+#ifndef __cpp_sized_deallocation
+#error Expected __cpp_sized_deallocation to be defined.
+#elif __cpp_sized_deallocation != 201309L
+#error Expected cpp_sized_deallocation to equal 201309L.
+#else
+STATIC_ASSERT(__cpp_sized_deallocation == 201309L);
+#endif
+#endif
+
+// C++17, /Zc:alignedNew[-]
+#if !_HAS_CXX17 || defined(TEST_DISABLED_ALIGNED_NEW)
+#ifdef __cpp_aligned_new
+#error Expected __cpp_aligned_new to NOT be defined.
+#endif
+#else
+#ifndef __cpp_aligned_new
+#error Expected __cpp_aligned_new to be defined.
+#elif __cpp_aligned_new != 201606L
+#error Expected cpp_aligned_new to equal 201606L.
+#else
+STATIC_ASSERT(__cpp_aligned_new == 201606L);
+#endif
+#endif
+
+// C++17, /Zc:noexceptTypes[-]
+#if !_HAS_CXX17 || defined(TEST_DISABLED_NOEXCEPT_FUNCTION_TYPE)
+#ifdef __cpp_noexcept_function_type
+#error Expected __cpp_noexcept_function_type to NOT be defined.
+#endif
+#else
+#ifndef __cpp_noexcept_function_type
+#error Expected __cpp_noexcept_function_type to be defined.
+#elif __cpp_noexcept_function_type != 201510L
+#error Expected cpp_noexcept_function_type to equal 201510L.
+#else
+STATIC_ASSERT(__cpp_noexcept_function_type == 201510L);
+#endif
+#endif
+
 
 // LIBRARY FEATURE-TEST MACROS
 #include <version>


### PR DESCRIPTION
Description
===========

Fixes #600, _Hopefully_ I haven't messed this up. Reordering was...an experience,

* Used the forms "Expected `foo` to (NOT) be defined." / "Expected `foo` to equal `value`." To replace `BOOM`
* Removed `CXX??_MODE` and replaced with `_HAS_CXX??`
* Swapped the order of `#if !defined(clang) || _HAS_CXX17` for a better sorted order
* Made "Attributes" comment uppercase to follow the library section comment (~~and new language section comment~~ realised it already existed I just accidentally deleted it in the first commit)
* Reordered the tests removing `// Always defined...` sections. Tests are now ordered lexicographically grouped by Attributes, Language, then Library.

Checklist
=========

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [ ] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [ ] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [ ] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [ ] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
