### PR TITLE
P1871R1 disable_sized_sentinel_for

### DIFF
--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -744,17 +744,20 @@ concept input_or_output_iterator = requires(_It __i) {
 
 // CONCEPT sentinel_for
 template <class _Se, class _It>
-concept sentinel_for = semiregular<_Se> && input_or_output_iterator<_It> && _Weakly_equality_comparable_with<_Se, _It>;
+concept sentinel_for = semiregular<_Se>
+    && input_or_output_iterator<_It>
+    && _Weakly_equality_comparable_with<_Se, _It>;
 // clang-format on
 
-// VARIABLE TEMPLATE disable_sized_sentinel
+// VARIABLE TEMPLATE disable_sized_sentinel_for
 template <class _Se, class _It>
-inline constexpr bool disable_sized_sentinel = false;
+inline constexpr bool disable_sized_sentinel_for = false;
 
 // CONCEPT sized_sentinel_for
 // clang-format off
 template <class _Se, class _It>
-concept sized_sentinel_for = sentinel_for<_Se, _It> && !disable_sized_sentinel<remove_cv_t<_Se>, remove_cv_t<_It>>
+concept sized_sentinel_for = sentinel_for<_Se, _It>
+    && !disable_sized_sentinel_for<remove_cv_t<_Se>, remove_cv_t<_It>>
     && requires(const _It& __i, const _Se& __s) {
         { __s - __i } -> same_as<iter_difference_t<_It>>;
         { __i - __s } -> same_as<iter_difference_t<_It>>;

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -191,6 +191,7 @@
 // P1716R3 Range Comparison Algorithms Are Over-Constrained
 // P1754R1 Rename Concepts To standard_case
 // P1870R1 Rename forwarding-range To borrowed_range (Was safe_range before LWG-3379)
+// P1871R1 disable_sized_sentinel_for
 // P1872R0 span Should Have size_type, Not index_type
 // P1878R1 Constraining Readable Types
 // P1956R1 <bit> has_single_bit(), bit_ceil(), bit_floor(), bit_width()

--- a/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
@@ -228,7 +228,7 @@ std::iter_difference_t<iterator_archetype<J>> operator-(
 // clang-format on
 
 template <class I>
-inline constexpr bool std::disable_sized_sentinel<sized_sentinel_archetype<11>, I> = true;
+inline constexpr bool std::disable_sized_sentinel_for<sized_sentinel_archetype<11>, I> = true;
 
 inline constexpr std::size_t sized_sentinel_archetype_max = 12;
 


### PR DESCRIPTION
Description
===========

Rename the variable template `disable_sized_sentinel` to `disable_sized_sentinel_for` for consistency with the name of the associated concept `sized_sentinel_for`.

Addresses #39.

[This is a dual of internal MSVC-PR-235461.]

Checklist
=========

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [ ] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
