### PR TITLE
psx is 0, so don't even bother checking

### DIFF
--- a/stl/src/xfdscale.cpp
+++ b/stl/src/xfdscale.cpp
@@ -37,7 +37,7 @@ short _FDscale(float* px, long lexp) { // scale *px by 2^xexp with checking
             unsigned short psx = 0;
 
             if (xexp <= -16) { // scale by words
-                psx          = ps->_Sh[_F1] | 0;
+                psx          = ps->_Sh[_F1];
                 ps->_Sh[_F1] = ps->_Sh[_F0];
                 ps->_Sh[_F0] = 0;
                 xexp += 16;

--- a/stl/src/xfdscale.cpp
+++ b/stl/src/xfdscale.cpp
@@ -37,7 +37,7 @@ short _FDscale(float* px, long lexp) { // scale *px by 2^xexp with checking
             unsigned short psx = 0;
 
             if (xexp <= -16) { // scale by words
-                psx          = ps->_Sh[_F1] | (psx != 0 ? 1 : 0);
+                psx          = ps->_Sh[_F1] | 0;
                 ps->_Sh[_F1] = ps->_Sh[_F0];
                 ps->_Sh[_F0] = 0;
                 xexp += 16;


### PR DESCRIPTION
Description
===========
In xfdscale, there is a tertiary statement checking if psx is not equal to 0, despite two statements ago assigning psx to 0. Such a statement is a waste.


Checklist
=========

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [x] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
