### PR TITLE
Work around compiler bug in atomic.

### DIFF
--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -857,7 +857,13 @@ struct _Atomic_integral; // not defined
 template <class _Ty>
 struct _Atomic_integral<_Ty, 1> : _Atomic_storage<_Ty> { // atomic integral operations using 1-byte intrinsics
     using _Base = _Atomic_storage<_Ty>;
+
+#ifdef __cplusplus_winrt // TRANSITION, VSO-1083296
+    _Atomic_integral() = default;
+    /* implicit */ constexpr _Atomic_integral(const _Ty _Value) noexcept : _Base(_Value) {}
+#else // ^^^ workaround / no workaround vvv
     using _Base::_Base;
+#endif // ^^^ no workaround ^^^
 
     _Ty fetch_add(const _Ty _Operand, const memory_order _Order = memory_order_seq_cst) noexcept {
         char _Result;
@@ -914,7 +920,13 @@ struct _Atomic_integral<_Ty, 1> : _Atomic_storage<_Ty> { // atomic integral oper
 template <class _Ty>
 struct _Atomic_integral<_Ty, 2> : _Atomic_storage<_Ty> { // atomic integral operations using 2-byte intrinsics
     using _Base = _Atomic_storage<_Ty>;
+
+#ifdef __cplusplus_winrt // TRANSITION, VSO-1083296
+    _Atomic_integral() = default;
+    /* implicit */ constexpr _Atomic_integral(const _Ty _Value) noexcept : _Base(_Value) {}
+#else // ^^^ workaround / no workaround vvv
     using _Base::_Base;
+#endif // ^^^ no workaround ^^^
 
     _Ty fetch_add(const _Ty _Operand, const memory_order _Order = memory_order_seq_cst) noexcept {
         short _Result;
@@ -970,7 +982,13 @@ struct _Atomic_integral<_Ty, 2> : _Atomic_storage<_Ty> { // atomic integral oper
 template <class _Ty>
 struct _Atomic_integral<_Ty, 4> : _Atomic_storage<_Ty> { // atomic integral operations using 4-byte intrinsics
     using _Base = _Atomic_storage<_Ty>;
+
+#ifdef __cplusplus_winrt // TRANSITION, VSO-1083296
+    _Atomic_integral() = default;
+    /* implicit */ constexpr _Atomic_integral(const _Ty _Value) noexcept : _Base(_Value) {}
+#else // ^^^ workaround / no workaround vvv
     using _Base::_Base;
+#endif // ^^^ no workaround ^^^
 
     _Ty fetch_add(const _Ty _Operand, const memory_order _Order = memory_order_seq_cst) noexcept {
         long _Result;
@@ -1026,7 +1044,13 @@ struct _Atomic_integral<_Ty, 4> : _Atomic_storage<_Ty> { // atomic integral oper
 template <class _Ty>
 struct _Atomic_integral<_Ty, 8> : _Atomic_storage<_Ty> { // atomic integral operations using 8-byte intrinsics
     using _Base = _Atomic_storage<_Ty>;
+
+#ifdef __cplusplus_winrt // TRANSITION, VSO-1083296
+    _Atomic_integral() = default;
+    /* implicit */ constexpr _Atomic_integral(const _Ty _Value) noexcept : _Base(_Value) {}
+#else // ^^^ workaround / no workaround vvv
     using _Base::_Base;
+#endif // ^^^ no workaround ^^^
 
 #ifdef _M_IX86
     _Ty fetch_add(const _Ty _Operand, const memory_order _Order = memory_order_seq_cst) noexcept {
@@ -1139,9 +1163,15 @@ struct _Atomic_integral<_Ty, 8> : _Atomic_storage<_Ty> { // atomic integral oper
 template <class _Ty>
 struct _Atomic_integral_facade : _Atomic_integral<_Ty> {
     // provides operator overloads and other support for atomic integral specializations
-    using _Base = _Atomic_integral<_Ty>;
-    using _Base::_Base;
+    using _Base           = _Atomic_integral<_Ty>;
     using difference_type = _Ty;
+
+#ifdef __cplusplus_winrt // TRANSITION, VSO-1083296
+    _Atomic_integral_facade() = default;
+    /* implicit */ constexpr _Atomic_integral_facade(const _Ty _Value) noexcept : _Base(_Value) {}
+#else // ^^^ workaround / no workaround vvv
+    using _Base::_Base;
+#endif // ^^^ no workaround ^^^
 
     // note: const_cast-ing away volatile is safe because all our intrinsics add volatile back on.
     // We make the primary functions non-volatile for better debug codegen, as non-volatile atomics
@@ -1265,9 +1295,15 @@ struct _Atomic_integral_facade : _Atomic_integral<_Ty> {
 template <class _Ty>
 struct _Atomic_floating : _Atomic_storage<_Ty> {
     // provides atomic floating-point operations
-    using _Base = _Atomic_storage<_Ty>;
-    using _Base::_Base;
+    using _Base           = _Atomic_storage<_Ty>;
     using difference_type = _Ty;
+
+#ifdef __cplusplus_winrt // TRANSITION, VSO-1083296
+    _Atomic_floating() = default;
+    /* implicit */ constexpr _Atomic_floating(const _Ty _Value) noexcept : _Base(_Value) {}
+#else // ^^^ workaround / no workaround vvv
+    using _Base::_Base;
+#endif // ^^^ no workaround ^^^
 
     _Ty fetch_add(const _Ty _Operand, const memory_order _Order = memory_order_seq_cst) noexcept {
         _Ty _Temp{this->load(memory_order_relaxed)};
@@ -1317,8 +1353,15 @@ struct _Atomic_floating : _Atomic_storage<_Ty> {
 // STRUCT TEMPLATE _Atomic_pointer
 template <class _Ty>
 struct _Atomic_pointer : _Atomic_storage<_Ty> {
-    using _Atomic_storage<_Ty>::_Atomic_storage;
+    using _Base           = _Atomic_storage<_Ty>;
     using difference_type = ptrdiff_t;
+
+#ifdef __cplusplus_winrt // TRANSITION, VSO-1083296
+    _Atomic_pointer() = default;
+    /* implicit */ constexpr _Atomic_pointer(const _Ty _Value) noexcept : _Base(_Value) {}
+#else // ^^^ workaround / no workaround vvv
+    using _Base::_Base;
+#endif // ^^^ no workaround ^^^
 
     _Ty fetch_add(const ptrdiff_t _Diff, const memory_order _Order = memory_order_seq_cst) noexcept {
         const ptrdiff_t _Shift_bytes =
@@ -1441,7 +1484,11 @@ public:
 
     using value_type = _Ty;
 
+#ifdef __cplusplus_winrt // TRANSITION, VSO-1083296
+    /* implicit */ constexpr atomic(const _Ty _Value) noexcept : _Base(_Value) {}
+#else // ^^^ workaround / no workaround vvv
     using _Base::_Base;
+#endif // ^^^ no workaround ^^^
 
     constexpr atomic() noexcept(is_nothrow_default_constructible_v<_Ty>) : _Base() {}
 
@@ -1887,8 +1934,7 @@ using atomic_char8_t = atomic<char8_t>;
 #endif // __cpp_lib_char8_t
 using atomic_char16_t = atomic<char16_t>;
 using atomic_char32_t = atomic<char32_t>;
-
-using atomic_wchar_t = atomic<wchar_t>;
+using atomic_wchar_t  = atomic<wchar_t>;
 
 using atomic_int8_t   = atomic<int8_t>;
 using atomic_uint8_t  = atomic<uint8_t>;


### PR DESCRIPTION
Description
===========

Work around Microsoft-internal VSO-1083296 in atomic. This is a C++/CX compiler bug affecting `constexpr` and inheriting constructors, so the workaround is guarded to affect C++/CX only. Mirrors Microsoft-internal MSVC-PR-235695.

Checklist
=========

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [x] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
