### PR TITLE
<filesystem> Treat ERROR_BAD_NETPATH as file not found.

### DIFF
--- a/stl/inc/filesystem
+++ b/stl/inc/filesystem
@@ -1826,12 +1826,6 @@ namespace filesystem {
         _THROW(filesystem_error(_Op, _Path1, _Path2, _Error));
     }
 
-    // FUNCTION _Is_file_not_found
-    _NODISCARD inline bool _Is_file_not_found(const __std_win_error _Error) noexcept {
-        return _Error == __std_win_error::_File_not_found || _Error == __std_win_error::_Path_not_found
-               || _Error == __std_win_error::_Invalid_name;
-    }
-
     // ENUM CLASS file_type
     enum class file_type {
         none,
@@ -1975,7 +1969,7 @@ namespace filesystem {
             }
 
             this->permissions(perms::unknown);
-            this->type(_Is_file_not_found(_Error) ? file_type::not_found : file_type::none);
+            this->type(__std_is_file_not_found(_Error) ? file_type::not_found : file_type::none);
         }
 
     private:
@@ -2724,7 +2718,7 @@ namespace filesystem {
                         if (_Error == __std_win_error::_Success) {
                             _Should_recurse =
                                 _Bitmask_includes(_Target_stats._Attributes, __std_fs_file_attr::_Directory);
-                        } else if (_Is_file_not_found(_Error)
+                        } else if (__std_is_file_not_found(_Error)
                                    || (_Error == __std_win_error::_Access_denied
                                        && _Bitmask_includes(_Options, directory_options::skip_permission_denied))) {
                             // skip broken symlinks and permission denied (when configured)
@@ -3757,7 +3751,7 @@ namespace filesystem {
             _Error                    = _Create_result._Error;
             _Created_last             = _Create_result._Created;
             _Error                    = _Create_result._Error;
-            if (_Error != __std_win_error::_Success && !_Is_file_not_found(_Error)) {
+            if (_Error != __std_win_error::_Success && !__std_is_file_not_found(_Error)) {
                 _Most_recent_not_file_not_found = _Error;
             }
 
@@ -3790,7 +3784,7 @@ namespace filesystem {
         for (directory_iterator _It(_Path, _Ec);; _It.increment(_Ec)) { // remove nonempty directory contents
             if (_Ec) {
                 if (_Ec.category() != _STD system_category()
-                    || !_Is_file_not_found(static_cast<__std_win_error>(_Ec.value()))) {
+                    || !__std_is_file_not_found(static_cast<__std_win_error>(_Ec.value()))) {
                     return;
                 }
 
@@ -4042,7 +4036,7 @@ namespace filesystem {
                 return _Temp;
             }
 
-            if (!_Is_file_not_found(_Err)) {
+            if (!__std_is_file_not_found(_Err)) {
                 _Ec = _Make_ec(_Err);
                 return path();
             }
@@ -4066,7 +4060,7 @@ namespace filesystem {
 
                 if (_Err == __std_win_error::_Success) {
                     _Result = _STD move(_Temp);
-                } else if (_Is_file_not_found(_Err)) {
+                } else if (__std_is_file_not_found(_Err)) {
                     _Call_canonical = false;
                 } else {
                     _Ec = _Make_ec(_Err);

--- a/stl/inc/xfilesystem_abi.h
+++ b/stl/inc/xfilesystem_abi.h
@@ -33,6 +33,7 @@ enum class __std_win_error : unsigned long {
     _No_more_files             = 18, // #define ERROR_NO_MORE_FILES              18L
     _Sharing_violation         = 32, // #define ERROR_SHARING_VIOLATION          32L
     _Not_supported             = 50, // #define ERROR_NOT_SUPPORTED              50L
+    _Error_bad_netpath         = 53, // #define ERROR_BAD_NETPATH                53L
     _File_exists               = 80, // #define ERROR_FILE_EXISTS                80L
     _Invalid_parameter         = 87, // #define ERROR_INVALID_PARAMETER          87L
     _Insufficient_buffer       = 122, // #define ERROR_INSUFFICIENT_BUFFER        122L
@@ -43,6 +44,22 @@ enum class __std_win_error : unsigned long {
     _Directory_name_is_invalid = 267, // #define ERROR_DIRECTORY                  267L
     _Max                       = ~0UL // sentinel not used by Win32
 };
+
+// FUNCTION __std_is_file_not_found
+#pragma warning(push)
+#pragma warning(disable: 4061) // enumerator not explicitly handled by switch label
+_NODISCARD inline bool __std_is_file_not_found(const __std_win_error _Error) noexcept {
+    switch (_Error) {
+    case __std_win_error::_File_not_found:
+    case __std_win_error::_Path_not_found:
+    case __std_win_error::_Invalid_name:
+    case __std_win_error::_Error_bad_netpath:
+        return true;
+    default:
+        return false;
+    }
+}
+#pragma warning(pop)
 
 enum class __std_fs_dir_handle : intptr_t { _Invalid = -1 };
 

--- a/stl/inc/xfilesystem_abi.h
+++ b/stl/inc/xfilesystem_abi.h
@@ -52,8 +52,8 @@ _NODISCARD inline bool __std_is_file_not_found(const __std_win_error _Error) noe
     switch (_Error) {
     case __std_win_error::_File_not_found:
     case __std_win_error::_Path_not_found:
-    case __std_win_error::_Invalid_name:
     case __std_win_error::_Error_bad_netpath:
+    case __std_win_error::_Invalid_name:
         return true;
     default:
         return false;

--- a/stl/inc/xfilesystem_abi.h
+++ b/stl/inc/xfilesystem_abi.h
@@ -47,7 +47,7 @@ enum class __std_win_error : unsigned long {
 
 // FUNCTION __std_is_file_not_found
 #pragma warning(push)
-#pragma warning(disable: 4061) // enumerator not explicitly handled by switch label
+#pragma warning(disable : 4061) // enumerator not explicitly handled by switch label
 _NODISCARD inline bool __std_is_file_not_found(const __std_win_error _Error) noexcept {
     switch (_Error) {
     case __std_win_error::_File_not_found:

--- a/stl/src/filesystem.cpp
+++ b/stl/src/filesystem.cpp
@@ -224,13 +224,11 @@ namespace {
     }
 
     [[nodiscard]] __std_win_error __stdcall _Translate_not_found_to_success(const __std_win_error _Err) noexcept {
-        switch (_Err) {
-        case __std_win_error::_File_not_found:
-        case __std_win_error::_Path_not_found:
+        if (__std_is_file_not_found(_Err)) {
             return __std_win_error::_Success;
-        default:
-            return _Err;
         }
+
+        return _Err;
     }
 
     [[nodiscard]] __std_win_error __stdcall _Get_last_write_time_by_handle(

--- a/stl/src/syserror.cpp
+++ b/stl/src/syserror.cpp
@@ -24,8 +24,8 @@ static constexpr _Win_errtab_t _Win_errtab[] = {
     // table of Windows/Posix pairs
     {ERROR_ACCESS_DENIED, errc::permission_denied},
     {ERROR_ALREADY_EXISTS, errc::file_exists},
-    {ERROR_BAD_UNIT, errc::no_such_device},
     {ERROR_BAD_NETPATH, errc::no_such_file_or_directory},
+    {ERROR_BAD_UNIT, errc::no_such_device},
     {ERROR_BROKEN_PIPE, errc::broken_pipe},
     {ERROR_BUFFER_OVERFLOW, errc::filename_too_long},
     {ERROR_BUSY, errc::device_or_resource_busy},

--- a/stl/src/syserror.cpp
+++ b/stl/src/syserror.cpp
@@ -25,6 +25,7 @@ static constexpr _Win_errtab_t _Win_errtab[] = {
     {ERROR_ACCESS_DENIED, errc::permission_denied},
     {ERROR_ALREADY_EXISTS, errc::file_exists},
     {ERROR_BAD_UNIT, errc::no_such_device},
+    {ERROR_BAD_NETPATH, errc::no_such_file_or_directory},
     {ERROR_BROKEN_PIPE, errc::broken_pipe},
     {ERROR_BUFFER_OVERFLOW, errc::filename_too_long},
     {ERROR_BUSY, errc::device_or_resource_busy},

--- a/tests/std/tests/P0218R1_filesystem/test.cpp
+++ b/tests/std/tests/P0218R1_filesystem/test.cpp
@@ -33,9 +33,9 @@ using namespace std::chrono;
 using namespace std::filesystem;
 
 constexpr wstring_view badPath = L"// ?? ?? ///// ?? ?? ? ////"sv;
-path nonexistentPaths[]        = {
+const path nonexistentPaths[]  = {
     L"C:/This/Path/Should/Not/Exist"sv,
-    L"//this_path_does_not_exist_on_the_network_e9da301701f70ead24c65bd30f600d15//docs"sv,
+    L"//this_path_does_not_exist_on_the_network_e9da301701f70ead24c65bd30f600d15/docs"sv,
 };
 constexpr wstring_view longSuffix =
     LR"(really\long\path\longer\than\max_path\goes\here\and it just goes)"
@@ -2875,6 +2875,7 @@ void test_status() {
         EXPECT(status(nonexistent).type() == file_type::not_found); // should not throw
         EXPECT(status(nonexistent, ec).type() == file_type::not_found);
         EXPECT(ec.category() == system_category());
+        // accept ERROR_FILE_NOT_FOUND (2), ERROR_PATH_NOT_FOUND (3), or ERROR_BAD_NETPATH (53)
         EXPECT(ec.value() == 2 || ec.value() == 3 || ec.value() == 53);
         EXPECT(ec == errc::no_such_file_or_directory);
     }
@@ -3297,8 +3298,8 @@ void test_remove() {
     EXPECT(!exists(dirname, ec));
     EXPECT(good(ec));
 
-    remove(badPath); // we ignore bogus invalid paths
-    remove(badPath, ec); // bogus invalid path
+    remove(badPath); // we ignore invalid paths
+    remove(badPath, ec);
     EXPECT(good(ec));
 }
 
@@ -3588,7 +3589,7 @@ void test_create_directory() {
         remove(p);
     }
 
-    // test bogus path
+    // test invalid path
     {
         error_code ec;
         for (auto&& nonexistent : nonexistentPaths) {
@@ -3656,7 +3657,7 @@ void test_create_dirs_and_remove_all() {
     create_directories(badPath, ec);
     EXPECT(bad(ec));
 
-    remove_all(badPath); // we ignore bogus invalid paths to remove
+    remove_all(badPath); // we ignore invalid paths as in remove
     remove_all(badPath, ec);
     EXPECT(good(ec));
 


### PR DESCRIPTION
Resolves GH-615 / DevCom-950424.

* Extract _Is_file_not_found to <xfilesystem_abi.h> as __std_is_file_not_found because we also need that in filesystem.cpp.
* Add ERROR_BAD_NETPATH to __std_is_file_not_found.
* Map ERROR_BAD_NETPATH to errc::no_such_file_or_directory.
* Change filesystem tests that look for file not exists behavior to also test bad network paths.

Checklist
=========

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [x] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
