### PR TITLE
<xutility>: strengthen noexcept for array iterators

### DIFF
--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -3117,97 +3117,97 @@ public:
 
     _CONSTEXPR17 explicit _Array_const_iterator(pointer _Parg, size_t _Off = 0) : _Ptr(_Parg + _Off) {}
 
-    _NODISCARD _CONSTEXPR17 reference operator*() const {
+    _NODISCARD _CONSTEXPR17 reference operator*() const noexcept /* strengthened */ {
         return *_Ptr;
     }
 
-    _NODISCARD _CONSTEXPR17 pointer operator->() const {
+    _NODISCARD _CONSTEXPR17 pointer operator->() const noexcept /* strengthened */ {
         return _Ptr;
     }
 
-    _CONSTEXPR17 _Array_const_iterator& operator++() {
+    _CONSTEXPR17 _Array_const_iterator& operator++() noexcept /* strengthened */ {
         ++_Ptr;
         return *this;
     }
 
-    _CONSTEXPR17 _Array_const_iterator operator++(int) {
+    _CONSTEXPR17 _Array_const_iterator operator++(int) noexcept /* strengthened */ {
         _Array_const_iterator _Tmp = *this;
         ++_Ptr;
         return _Tmp;
     }
 
-    _CONSTEXPR17 _Array_const_iterator& operator--() {
+    _CONSTEXPR17 _Array_const_iterator& operator--() noexcept /* strengthened */ {
         --_Ptr;
         return *this;
     }
 
-    _CONSTEXPR17 _Array_const_iterator operator--(int) {
+    _CONSTEXPR17 _Array_const_iterator operator--(int) noexcept /* strengthened */ {
         _Array_const_iterator _Tmp = *this;
         --_Ptr;
         return _Tmp;
     }
 
-    _CONSTEXPR17 _Array_const_iterator& operator+=(const ptrdiff_t _Off) {
+    _CONSTEXPR17 _Array_const_iterator& operator+=(const ptrdiff_t _Off) noexcept /* strengthened */ {
         _Ptr += _Off;
         return *this;
     }
 
-    _NODISCARD _CONSTEXPR17 _Array_const_iterator operator+(const ptrdiff_t _Off) const {
+    _NODISCARD _CONSTEXPR17 _Array_const_iterator operator+(const ptrdiff_t _Off) const noexcept /* strengthened */ {
         _Array_const_iterator _Tmp = *this;
         return _Tmp += _Off;
     }
 
-    _CONSTEXPR17 _Array_const_iterator& operator-=(const ptrdiff_t _Off) {
+    _CONSTEXPR17 _Array_const_iterator& operator-=(const ptrdiff_t _Off) noexcept /* strengthened */ {
         _Ptr -= _Off;
         return *this;
     }
 
-    _NODISCARD _CONSTEXPR17 _Array_const_iterator operator-(const ptrdiff_t _Off) const {
+    _NODISCARD _CONSTEXPR17 _Array_const_iterator operator-(const ptrdiff_t _Off) const noexcept /* strengthened */ {
         _Array_const_iterator _Tmp = *this;
         return _Tmp -= _Off;
     }
 
-    _NODISCARD _CONSTEXPR17 ptrdiff_t operator-(const _Array_const_iterator& _Right) const {
+    _NODISCARD _CONSTEXPR17 ptrdiff_t operator-(const _Array_const_iterator& _Right) const noexcept /* strengthened */ {
         return _Ptr - _Right._Ptr;
     }
 
-    _NODISCARD _CONSTEXPR17 reference operator[](const ptrdiff_t _Off) const {
+    _NODISCARD _CONSTEXPR17 reference operator[](const ptrdiff_t _Off) const noexcept /* strengthened */ {
         return _Ptr[_Off];
     }
 
-    _NODISCARD _CONSTEXPR17 bool operator==(const _Array_const_iterator& _Right) const {
+    _NODISCARD _CONSTEXPR17 bool operator==(const _Array_const_iterator& _Right) const noexcept /* strengthened */ {
         return _Ptr == _Right._Ptr;
     }
 
-    _NODISCARD _CONSTEXPR17 bool operator!=(const _Array_const_iterator& _Right) const {
+    _NODISCARD _CONSTEXPR17 bool operator!=(const _Array_const_iterator& _Right) const noexcept /* strengthened */ {
         return !(*this == _Right);
     }
 
-    _NODISCARD _CONSTEXPR17 bool operator<(const _Array_const_iterator& _Right) const {
+    _NODISCARD _CONSTEXPR17 bool operator<(const _Array_const_iterator& _Right) const noexcept /* strengthened */ {
         return _Ptr < _Right._Ptr;
     }
 
-    _NODISCARD _CONSTEXPR17 bool operator>(const _Array_const_iterator& _Right) const {
+    _NODISCARD _CONSTEXPR17 bool operator>(const _Array_const_iterator& _Right) const noexcept /* strengthened */ {
         return _Right < *this;
     }
 
-    _NODISCARD _CONSTEXPR17 bool operator<=(const _Array_const_iterator& _Right) const {
+    _NODISCARD _CONSTEXPR17 bool operator<=(const _Array_const_iterator& _Right) const noexcept /* strengthened */ {
         return !(_Right < *this);
     }
 
-    _NODISCARD _CONSTEXPR17 bool operator>=(const _Array_const_iterator& _Right) const {
+    _NODISCARD _CONSTEXPR17 bool operator>=(const _Array_const_iterator& _Right) const noexcept /* strengthened */ {
         return !(*this < _Right);
     }
 
     using _Prevent_inheriting_unwrap = _Array_const_iterator;
 
-    _NODISCARD constexpr pointer _Unwrapped() const {
+    _NODISCARD constexpr pointer _Unwrapped() const noexcept {
         return _Ptr;
     }
 
     static constexpr bool _Unwrap_when_unverified = true;
 
-    constexpr void _Seek_to(pointer _It) {
+    constexpr void _Seek_to(pointer _It) noexcept {
         _Ptr = _It;
     }
 
@@ -3219,37 +3219,37 @@ private:
 
     _CONSTEXPR17 explicit _Array_const_iterator(pointer _Parg, size_t _Off = 0) : _Ptr(_Parg), _Idx(_Off) {}
 
-    _NODISCARD _CONSTEXPR17 reference operator*() const {
+    _NODISCARD _CONSTEXPR17 reference operator*() const noexcept /* strengthened */ {
         return *operator->();
     }
 
-    _NODISCARD _CONSTEXPR17 pointer operator->() const {
+    _NODISCARD _CONSTEXPR17 pointer operator->() const noexcept /* strengthened */ {
         _STL_VERIFY(_Ptr, "cannot dereference value-initialized array iterator");
         _STL_VERIFY(_Idx < _Size, "cannot dereference out of range array iterator");
         return _Ptr + _Idx;
     }
 
-    _CONSTEXPR17 _Array_const_iterator& operator++() {
+    _CONSTEXPR17 _Array_const_iterator& operator++() noexcept /* strengthened */ {
         _STL_VERIFY(_Ptr, "cannot increment value-initialized array iterator");
         _STL_VERIFY(_Idx < _Size, "cannot increment array iterator past end");
         ++_Idx;
         return *this;
     }
 
-    _CONSTEXPR17 _Array_const_iterator operator++(int) {
+    _CONSTEXPR17 _Array_const_iterator operator++(int) noexcept /* strengthened */ {
         _Array_const_iterator _Tmp = *this;
         ++*this;
         return _Tmp;
     }
 
-    _CONSTEXPR17 _Array_const_iterator& operator--() {
+    _CONSTEXPR17 _Array_const_iterator& operator--() noexcept /* strengthened */ {
         _STL_VERIFY(_Ptr, "cannot decrement value-initialized array iterator");
         _STL_VERIFY(_Idx != 0, "cannot decrement array iterator before begin");
         --_Idx;
         return *this;
     }
 
-    _CONSTEXPR17 _Array_const_iterator operator--(int) {
+    _CONSTEXPR17 _Array_const_iterator operator--(int) noexcept /* strengthened */ {
         _Array_const_iterator _Tmp = *this;
         --*this;
         return _Tmp;
@@ -3270,68 +3270,68 @@ private:
         }
     }
 
-    _CONSTEXPR17 _Array_const_iterator& operator+=(const ptrdiff_t _Off) {
+    _CONSTEXPR17 _Array_const_iterator& operator+=(const ptrdiff_t _Off) noexcept /* strengthened */ {
         _Verify_offset(_Off);
         _Idx += _Off;
         return *this;
     }
 
-    _NODISCARD _CONSTEXPR17 _Array_const_iterator operator+(const ptrdiff_t _Off) const {
+    _NODISCARD _CONSTEXPR17 _Array_const_iterator operator+(const ptrdiff_t _Off) const noexcept /* strengthened */ {
         _Array_const_iterator _Tmp = *this;
         return _Tmp += _Off;
     }
 
-    _CONSTEXPR17 _Array_const_iterator& operator-=(const ptrdiff_t _Off) {
+    _CONSTEXPR17 _Array_const_iterator& operator-=(const ptrdiff_t _Off) noexcept /* strengthened */ {
         return *this += -_Off;
     }
 
-    _NODISCARD _CONSTEXPR17 _Array_const_iterator operator-(const ptrdiff_t _Off) const {
+    _NODISCARD _CONSTEXPR17 _Array_const_iterator operator-(const ptrdiff_t _Off) const noexcept /* strengthened */ {
         _Array_const_iterator _Tmp = *this;
         return _Tmp -= _Off;
     }
 
-    _NODISCARD _CONSTEXPR17 ptrdiff_t operator-(const _Array_const_iterator& _Right) const {
+    _NODISCARD _CONSTEXPR17 ptrdiff_t operator-(const _Array_const_iterator& _Right) const noexcept /* strengthened */ {
         _Compat(_Right);
         return static_cast<ptrdiff_t>(_Idx - _Right._Idx);
     }
 
-    _NODISCARD _CONSTEXPR17 reference operator[](const ptrdiff_t _Off) const {
+    _NODISCARD _CONSTEXPR17 reference operator[](const ptrdiff_t _Off) const noexcept /* strengthened */ {
         return *(*this + _Off);
     }
 
-    _NODISCARD _CONSTEXPR17 bool operator==(const _Array_const_iterator& _Right) const {
+    _NODISCARD _CONSTEXPR17 bool operator==(const _Array_const_iterator& _Right) const noexcept /* strengthened */ {
         _Compat(_Right);
         return _Idx == _Right._Idx;
     }
 
-    _NODISCARD _CONSTEXPR17 bool operator!=(const _Array_const_iterator& _Right) const {
+    _NODISCARD _CONSTEXPR17 bool operator!=(const _Array_const_iterator& _Right) const noexcept /* strengthened */ {
         return !(*this == _Right);
     }
 
-    _NODISCARD _CONSTEXPR17 bool operator<(const _Array_const_iterator& _Right) const {
+    _NODISCARD _CONSTEXPR17 bool operator<(const _Array_const_iterator& _Right) const noexcept /* strengthened */ {
         _Compat(_Right);
         return _Idx < _Right._Idx;
     }
 
-    _NODISCARD _CONSTEXPR17 bool operator>(const _Array_const_iterator& _Right) const {
+    _NODISCARD _CONSTEXPR17 bool operator>(const _Array_const_iterator& _Right) const noexcept /* strengthened */ {
         return _Right < *this;
     }
 
-    _NODISCARD _CONSTEXPR17 bool operator<=(const _Array_const_iterator& _Right) const {
+    _NODISCARD _CONSTEXPR17 bool operator<=(const _Array_const_iterator& _Right) const noexcept /* strengthened */ {
         return !(_Right < *this);
     }
 
-    _NODISCARD _CONSTEXPR17 bool operator>=(const _Array_const_iterator& _Right) const {
+    _NODISCARD _CONSTEXPR17 bool operator>=(const _Array_const_iterator& _Right) const noexcept /* strengthened */ {
         return !(*this < _Right);
     }
 
-    _CONSTEXPR17 void _Compat(const _Array_const_iterator& _Right) const { // test for compatible iterator pair
+    _CONSTEXPR17 void _Compat(const _Array_const_iterator& _Right) const noexcept { // test for compatible iterator pair
         _STL_VERIFY(_Ptr == _Right._Ptr, "array iterators incompatible");
     }
 
     using _Prevent_inheriting_unwrap = _Array_const_iterator;
 
-    _NODISCARD constexpr pointer _Unwrapped() const {
+    _NODISCARD constexpr pointer _Unwrapped() const noexcept {
         return _Ptr + _Idx;
     }
 
@@ -3340,7 +3340,7 @@ private:
         _STL_VERIFY(*this <= _Last, "array iterator range transposed");
     }
 
-    constexpr void _Seek_to(pointer _It) {
+    constexpr void _Seek_to(pointer _It) noexcept {
         _Idx = static_cast<size_t>(_It - _Ptr);
     }
 
@@ -3361,7 +3361,7 @@ constexpr void _Verify_range(
 
 template <class _Ty, size_t _Size>
 _NODISCARD _CONSTEXPR17 _Array_const_iterator<_Ty, _Size> operator+(
-    ptrdiff_t _Off, _Array_const_iterator<_Ty, _Size> _Next) {
+    ptrdiff_t _Off, _Array_const_iterator<_Ty, _Size> _Next) noexcept /* strengthened */ {
     return _Next += _Off;
 }
 
@@ -3399,71 +3399,72 @@ public:
 
     _CONSTEXPR17 explicit _Array_iterator(pointer _Parg, size_t _Off = 0) : _Mybase(_Parg, _Off) {}
 
-    _NODISCARD _CONSTEXPR17 reference operator*() const {
+    _NODISCARD _CONSTEXPR17 reference operator*() const noexcept /* strengthened */ {
         return const_cast<reference>(_Mybase::operator*());
     }
 
-    _NODISCARD _CONSTEXPR17 pointer operator->() const {
+    _NODISCARD _CONSTEXPR17 pointer operator->() const noexcept /* strengthened */ {
         return const_cast<pointer>(_Mybase::operator->());
     }
 
-    _CONSTEXPR17 _Array_iterator& operator++() {
+    _CONSTEXPR17 _Array_iterator& operator++() noexcept /* strengthened */ {
         _Mybase::operator++();
         return *this;
     }
 
-    _CONSTEXPR17 _Array_iterator operator++(int) {
+    _CONSTEXPR17 _Array_iterator operator++(int) noexcept /* strengthened */ {
         _Array_iterator _Tmp = *this;
         _Mybase::operator++();
         return _Tmp;
     }
 
-    _CONSTEXPR17 _Array_iterator& operator--() {
+    _CONSTEXPR17 _Array_iterator& operator--() noexcept /* strengthened */ {
         _Mybase::operator--();
         return *this;
     }
 
-    _CONSTEXPR17 _Array_iterator operator--(int) {
+    _CONSTEXPR17 _Array_iterator operator--(int) noexcept /* strengthened */ {
         _Array_iterator _Tmp = *this;
         _Mybase::operator--();
         return _Tmp;
     }
 
-    _CONSTEXPR17 _Array_iterator& operator+=(const ptrdiff_t _Off) {
+    _CONSTEXPR17 _Array_iterator& operator+=(const ptrdiff_t _Off) noexcept /* strengthened */ {
         _Mybase::operator+=(_Off);
         return *this;
     }
 
-    _NODISCARD _CONSTEXPR17 _Array_iterator operator+(const ptrdiff_t _Off) const {
+    _NODISCARD _CONSTEXPR17 _Array_iterator operator+(const ptrdiff_t _Off) const noexcept /* strengthened */ {
         _Array_iterator _Tmp = *this;
         return _Tmp += _Off;
     }
 
-    _CONSTEXPR17 _Array_iterator& operator-=(const ptrdiff_t _Off) {
+    _CONSTEXPR17 _Array_iterator& operator-=(const ptrdiff_t _Off) noexcept /* strengthened */ {
         _Mybase::operator-=(_Off);
         return *this;
     }
 
     using _Mybase::operator-;
 
-    _NODISCARD _CONSTEXPR17 _Array_iterator operator-(const ptrdiff_t _Off) const {
+    _NODISCARD _CONSTEXPR17 _Array_iterator operator-(const ptrdiff_t _Off) const noexcept /* strengthened */ {
         _Array_iterator _Tmp = *this;
         return _Tmp -= _Off;
     }
 
-    _NODISCARD _CONSTEXPR17 reference operator[](const ptrdiff_t _Off) const {
+    _NODISCARD _CONSTEXPR17 reference operator[](const ptrdiff_t _Off) const noexcept /* strengthened */ {
         return const_cast<reference>(_Mybase::operator[](_Off));
     }
 
     using _Prevent_inheriting_unwrap = _Array_iterator;
 
-    _NODISCARD constexpr pointer _Unwrapped() const {
+    _NODISCARD constexpr pointer _Unwrapped() const noexcept {
         return const_cast<pointer>(_Mybase::_Unwrapped());
     }
 };
 
 template <class _Ty, size_t _Size>
-_NODISCARD _CONSTEXPR17 _Array_iterator<_Ty, _Size> operator+(ptrdiff_t _Off, _Array_iterator<_Ty, _Size> _Next) {
+_NODISCARD _CONSTEXPR17 _Array_iterator<_Ty, _Size> operator+(
+    ptrdiff_t _Off, _Array_iterator<_Ty, _Size> _Next) noexcept /* strengthened */ {
     return _Next += _Off;
 }
 

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -3361,7 +3361,7 @@ constexpr void _Verify_range(
 
 template <class _Ty, size_t _Size>
 _NODISCARD _CONSTEXPR17 _Array_const_iterator<_Ty, _Size> operator+(
-    ptrdiff_t _Off, _Array_const_iterator<_Ty, _Size> _Next) noexcept {
+    const ptrdiff_t _Off, _Array_const_iterator<_Ty, _Size> _Next) noexcept {
     return _Next += _Off;
 }
 
@@ -3464,7 +3464,7 @@ public:
 
 template <class _Ty, size_t _Size>
 _NODISCARD _CONSTEXPR17 _Array_iterator<_Ty, _Size> operator+(
-    ptrdiff_t _Off, _Array_iterator<_Ty, _Size> _Next) noexcept {
+    const ptrdiff_t _Off, _Array_iterator<_Ty, _Size> _Next) noexcept {
     return _Next += _Off;
 }
 

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -3113,9 +3113,9 @@ public:
     enum { _EEN_SIZE = _Size }; // helper for expression evaluator
 
 #if _ITERATOR_DEBUG_LEVEL == 0
-    _CONSTEXPR17 _Array_const_iterator() : _Ptr() {}
+    _CONSTEXPR17 _Array_const_iterator() noexcept : _Ptr() {}
 
-    _CONSTEXPR17 explicit _Array_const_iterator(pointer _Parg, size_t _Off = 0) : _Ptr(_Parg + _Off) {}
+    _CONSTEXPR17 explicit _Array_const_iterator(pointer _Parg, size_t _Off = 0) noexcept : _Ptr(_Parg + _Off) {}
 
     _NODISCARD _CONSTEXPR17 reference operator*() const noexcept /* strengthened */ {
         return *_Ptr;
@@ -3215,9 +3215,9 @@ private:
     pointer _Ptr; // beginning of array
 
 #else // ^^^ _ITERATOR_DEBUG_LEVEL == 0 / _ITERATOR_DEBUG_LEVEL != 0 vvv
-    _CONSTEXPR17 _Array_const_iterator() : _Ptr(), _Idx(0) {}
+    _CONSTEXPR17 _Array_const_iterator() noexcept : _Ptr(), _Idx(0) {}
 
-    _CONSTEXPR17 explicit _Array_const_iterator(pointer _Parg, size_t _Off = 0) : _Ptr(_Parg), _Idx(_Off) {}
+    _CONSTEXPR17 explicit _Array_const_iterator(pointer _Parg, size_t _Off = 0) noexcept : _Ptr(_Parg), _Idx(_Off) {}
 
     _NODISCARD _CONSTEXPR17 reference operator*() const noexcept /* strengthened */ {
         return *operator->();
@@ -3397,7 +3397,7 @@ public:
 
     _CONSTEXPR17 _Array_iterator() noexcept {}
 
-    _CONSTEXPR17 explicit _Array_iterator(pointer _Parg, size_t _Off = 0) : _Mybase(_Parg, _Off) {}
+    _CONSTEXPR17 explicit _Array_iterator(pointer _Parg, size_t _Off = 0) noexcept : _Mybase(_Parg, _Off) {}
 
     _NODISCARD _CONSTEXPR17 reference operator*() const noexcept /* strengthened */ {
         return const_cast<reference>(_Mybase::operator*());

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -3117,85 +3117,85 @@ public:
 
     _CONSTEXPR17 explicit _Array_const_iterator(pointer _Parg, size_t _Off = 0) noexcept : _Ptr(_Parg + _Off) {}
 
-    _NODISCARD _CONSTEXPR17 reference operator*() const noexcept /* strengthened */ {
+    _NODISCARD _CONSTEXPR17 reference operator*() const noexcept {
         return *_Ptr;
     }
 
-    _NODISCARD _CONSTEXPR17 pointer operator->() const noexcept /* strengthened */ {
+    _NODISCARD _CONSTEXPR17 pointer operator->() const noexcept {
         return _Ptr;
     }
 
-    _CONSTEXPR17 _Array_const_iterator& operator++() noexcept /* strengthened */ {
+    _CONSTEXPR17 _Array_const_iterator& operator++() noexcept {
         ++_Ptr;
         return *this;
     }
 
-    _CONSTEXPR17 _Array_const_iterator operator++(int) noexcept /* strengthened */ {
+    _CONSTEXPR17 _Array_const_iterator operator++(int) noexcept {
         _Array_const_iterator _Tmp = *this;
         ++_Ptr;
         return _Tmp;
     }
 
-    _CONSTEXPR17 _Array_const_iterator& operator--() noexcept /* strengthened */ {
+    _CONSTEXPR17 _Array_const_iterator& operator--() noexcept {
         --_Ptr;
         return *this;
     }
 
-    _CONSTEXPR17 _Array_const_iterator operator--(int) noexcept /* strengthened */ {
+    _CONSTEXPR17 _Array_const_iterator operator--(int) noexcept {
         _Array_const_iterator _Tmp = *this;
         --_Ptr;
         return _Tmp;
     }
 
-    _CONSTEXPR17 _Array_const_iterator& operator+=(const ptrdiff_t _Off) noexcept /* strengthened */ {
+    _CONSTEXPR17 _Array_const_iterator& operator+=(const ptrdiff_t _Off) noexcept {
         _Ptr += _Off;
         return *this;
     }
 
-    _NODISCARD _CONSTEXPR17 _Array_const_iterator operator+(const ptrdiff_t _Off) const noexcept /* strengthened */ {
+    _NODISCARD _CONSTEXPR17 _Array_const_iterator operator+(const ptrdiff_t _Off) const noexcept {
         _Array_const_iterator _Tmp = *this;
         return _Tmp += _Off;
     }
 
-    _CONSTEXPR17 _Array_const_iterator& operator-=(const ptrdiff_t _Off) noexcept /* strengthened */ {
+    _CONSTEXPR17 _Array_const_iterator& operator-=(const ptrdiff_t _Off) noexcept {
         _Ptr -= _Off;
         return *this;
     }
 
-    _NODISCARD _CONSTEXPR17 _Array_const_iterator operator-(const ptrdiff_t _Off) const noexcept /* strengthened */ {
+    _NODISCARD _CONSTEXPR17 _Array_const_iterator operator-(const ptrdiff_t _Off) const noexcept {
         _Array_const_iterator _Tmp = *this;
         return _Tmp -= _Off;
     }
 
-    _NODISCARD _CONSTEXPR17 ptrdiff_t operator-(const _Array_const_iterator& _Right) const noexcept /* strengthened */ {
+    _NODISCARD _CONSTEXPR17 ptrdiff_t operator-(const _Array_const_iterator& _Right) const noexcept {
         return _Ptr - _Right._Ptr;
     }
 
-    _NODISCARD _CONSTEXPR17 reference operator[](const ptrdiff_t _Off) const noexcept /* strengthened */ {
+    _NODISCARD _CONSTEXPR17 reference operator[](const ptrdiff_t _Off) const noexcept {
         return _Ptr[_Off];
     }
 
-    _NODISCARD _CONSTEXPR17 bool operator==(const _Array_const_iterator& _Right) const noexcept /* strengthened */ {
+    _NODISCARD _CONSTEXPR17 bool operator==(const _Array_const_iterator& _Right) const noexcept {
         return _Ptr == _Right._Ptr;
     }
 
-    _NODISCARD _CONSTEXPR17 bool operator!=(const _Array_const_iterator& _Right) const noexcept /* strengthened */ {
+    _NODISCARD _CONSTEXPR17 bool operator!=(const _Array_const_iterator& _Right) const noexcept {
         return !(*this == _Right);
     }
 
-    _NODISCARD _CONSTEXPR17 bool operator<(const _Array_const_iterator& _Right) const noexcept /* strengthened */ {
+    _NODISCARD _CONSTEXPR17 bool operator<(const _Array_const_iterator& _Right) const noexcept {
         return _Ptr < _Right._Ptr;
     }
 
-    _NODISCARD _CONSTEXPR17 bool operator>(const _Array_const_iterator& _Right) const noexcept /* strengthened */ {
+    _NODISCARD _CONSTEXPR17 bool operator>(const _Array_const_iterator& _Right) const noexcept {
         return _Right < *this;
     }
 
-    _NODISCARD _CONSTEXPR17 bool operator<=(const _Array_const_iterator& _Right) const noexcept /* strengthened */ {
+    _NODISCARD _CONSTEXPR17 bool operator<=(const _Array_const_iterator& _Right) const noexcept {
         return !(_Right < *this);
     }
 
-    _NODISCARD _CONSTEXPR17 bool operator>=(const _Array_const_iterator& _Right) const noexcept /* strengthened */ {
+    _NODISCARD _CONSTEXPR17 bool operator>=(const _Array_const_iterator& _Right) const noexcept {
         return !(*this < _Right);
     }
 
@@ -3219,37 +3219,37 @@ private:
 
     _CONSTEXPR17 explicit _Array_const_iterator(pointer _Parg, size_t _Off = 0) noexcept : _Ptr(_Parg), _Idx(_Off) {}
 
-    _NODISCARD _CONSTEXPR17 reference operator*() const noexcept /* strengthened */ {
+    _NODISCARD _CONSTEXPR17 reference operator*() const noexcept {
         return *operator->();
     }
 
-    _NODISCARD _CONSTEXPR17 pointer operator->() const noexcept /* strengthened */ {
+    _NODISCARD _CONSTEXPR17 pointer operator->() const noexcept {
         _STL_VERIFY(_Ptr, "cannot dereference value-initialized array iterator");
         _STL_VERIFY(_Idx < _Size, "cannot dereference out of range array iterator");
         return _Ptr + _Idx;
     }
 
-    _CONSTEXPR17 _Array_const_iterator& operator++() noexcept /* strengthened */ {
+    _CONSTEXPR17 _Array_const_iterator& operator++() noexcept {
         _STL_VERIFY(_Ptr, "cannot increment value-initialized array iterator");
         _STL_VERIFY(_Idx < _Size, "cannot increment array iterator past end");
         ++_Idx;
         return *this;
     }
 
-    _CONSTEXPR17 _Array_const_iterator operator++(int) noexcept /* strengthened */ {
+    _CONSTEXPR17 _Array_const_iterator operator++(int) noexcept {
         _Array_const_iterator _Tmp = *this;
         ++*this;
         return _Tmp;
     }
 
-    _CONSTEXPR17 _Array_const_iterator& operator--() noexcept /* strengthened */ {
+    _CONSTEXPR17 _Array_const_iterator& operator--() noexcept {
         _STL_VERIFY(_Ptr, "cannot decrement value-initialized array iterator");
         _STL_VERIFY(_Idx != 0, "cannot decrement array iterator before begin");
         --_Idx;
         return *this;
     }
 
-    _CONSTEXPR17 _Array_const_iterator operator--(int) noexcept /* strengthened */ {
+    _CONSTEXPR17 _Array_const_iterator operator--(int) noexcept {
         _Array_const_iterator _Tmp = *this;
         --*this;
         return _Tmp;
@@ -3270,58 +3270,58 @@ private:
         }
     }
 
-    _CONSTEXPR17 _Array_const_iterator& operator+=(const ptrdiff_t _Off) noexcept /* strengthened */ {
+    _CONSTEXPR17 _Array_const_iterator& operator+=(const ptrdiff_t _Off) noexcept {
         _Verify_offset(_Off);
         _Idx += _Off;
         return *this;
     }
 
-    _NODISCARD _CONSTEXPR17 _Array_const_iterator operator+(const ptrdiff_t _Off) const noexcept /* strengthened */ {
+    _NODISCARD _CONSTEXPR17 _Array_const_iterator operator+(const ptrdiff_t _Off) const noexcept {
         _Array_const_iterator _Tmp = *this;
         return _Tmp += _Off;
     }
 
-    _CONSTEXPR17 _Array_const_iterator& operator-=(const ptrdiff_t _Off) noexcept /* strengthened */ {
+    _CONSTEXPR17 _Array_const_iterator& operator-=(const ptrdiff_t _Off) noexcept {
         return *this += -_Off;
     }
 
-    _NODISCARD _CONSTEXPR17 _Array_const_iterator operator-(const ptrdiff_t _Off) const noexcept /* strengthened */ {
+    _NODISCARD _CONSTEXPR17 _Array_const_iterator operator-(const ptrdiff_t _Off) const noexcept {
         _Array_const_iterator _Tmp = *this;
         return _Tmp -= _Off;
     }
 
-    _NODISCARD _CONSTEXPR17 ptrdiff_t operator-(const _Array_const_iterator& _Right) const noexcept /* strengthened */ {
+    _NODISCARD _CONSTEXPR17 ptrdiff_t operator-(const _Array_const_iterator& _Right) const noexcept {
         _Compat(_Right);
         return static_cast<ptrdiff_t>(_Idx - _Right._Idx);
     }
 
-    _NODISCARD _CONSTEXPR17 reference operator[](const ptrdiff_t _Off) const noexcept /* strengthened */ {
+    _NODISCARD _CONSTEXPR17 reference operator[](const ptrdiff_t _Off) const noexcept {
         return *(*this + _Off);
     }
 
-    _NODISCARD _CONSTEXPR17 bool operator==(const _Array_const_iterator& _Right) const noexcept /* strengthened */ {
+    _NODISCARD _CONSTEXPR17 bool operator==(const _Array_const_iterator& _Right) const noexcept {
         _Compat(_Right);
         return _Idx == _Right._Idx;
     }
 
-    _NODISCARD _CONSTEXPR17 bool operator!=(const _Array_const_iterator& _Right) const noexcept /* strengthened */ {
+    _NODISCARD _CONSTEXPR17 bool operator!=(const _Array_const_iterator& _Right) const noexcept {
         return !(*this == _Right);
     }
 
-    _NODISCARD _CONSTEXPR17 bool operator<(const _Array_const_iterator& _Right) const noexcept /* strengthened */ {
+    _NODISCARD _CONSTEXPR17 bool operator<(const _Array_const_iterator& _Right) const noexcept {
         _Compat(_Right);
         return _Idx < _Right._Idx;
     }
 
-    _NODISCARD _CONSTEXPR17 bool operator>(const _Array_const_iterator& _Right) const noexcept /* strengthened */ {
+    _NODISCARD _CONSTEXPR17 bool operator>(const _Array_const_iterator& _Right) const noexcept {
         return _Right < *this;
     }
 
-    _NODISCARD _CONSTEXPR17 bool operator<=(const _Array_const_iterator& _Right) const noexcept /* strengthened */ {
+    _NODISCARD _CONSTEXPR17 bool operator<=(const _Array_const_iterator& _Right) const noexcept {
         return !(_Right < *this);
     }
 
-    _NODISCARD _CONSTEXPR17 bool operator>=(const _Array_const_iterator& _Right) const noexcept /* strengthened */ {
+    _NODISCARD _CONSTEXPR17 bool operator>=(const _Array_const_iterator& _Right) const noexcept {
         return !(*this < _Right);
     }
 
@@ -3361,7 +3361,7 @@ constexpr void _Verify_range(
 
 template <class _Ty, size_t _Size>
 _NODISCARD _CONSTEXPR17 _Array_const_iterator<_Ty, _Size> operator+(
-    ptrdiff_t _Off, _Array_const_iterator<_Ty, _Size> _Next) noexcept /* strengthened */ {
+    ptrdiff_t _Off, _Array_const_iterator<_Ty, _Size> _Next) noexcept {
     return _Next += _Off;
 }
 
@@ -3399,59 +3399,59 @@ public:
 
     _CONSTEXPR17 explicit _Array_iterator(pointer _Parg, size_t _Off = 0) noexcept : _Mybase(_Parg, _Off) {}
 
-    _NODISCARD _CONSTEXPR17 reference operator*() const noexcept /* strengthened */ {
+    _NODISCARD _CONSTEXPR17 reference operator*() const noexcept {
         return const_cast<reference>(_Mybase::operator*());
     }
 
-    _NODISCARD _CONSTEXPR17 pointer operator->() const noexcept /* strengthened */ {
+    _NODISCARD _CONSTEXPR17 pointer operator->() const noexcept {
         return const_cast<pointer>(_Mybase::operator->());
     }
 
-    _CONSTEXPR17 _Array_iterator& operator++() noexcept /* strengthened */ {
+    _CONSTEXPR17 _Array_iterator& operator++() noexcept {
         _Mybase::operator++();
         return *this;
     }
 
-    _CONSTEXPR17 _Array_iterator operator++(int) noexcept /* strengthened */ {
+    _CONSTEXPR17 _Array_iterator operator++(int) noexcept {
         _Array_iterator _Tmp = *this;
         _Mybase::operator++();
         return _Tmp;
     }
 
-    _CONSTEXPR17 _Array_iterator& operator--() noexcept /* strengthened */ {
+    _CONSTEXPR17 _Array_iterator& operator--() noexcept {
         _Mybase::operator--();
         return *this;
     }
 
-    _CONSTEXPR17 _Array_iterator operator--(int) noexcept /* strengthened */ {
+    _CONSTEXPR17 _Array_iterator operator--(int) noexcept {
         _Array_iterator _Tmp = *this;
         _Mybase::operator--();
         return _Tmp;
     }
 
-    _CONSTEXPR17 _Array_iterator& operator+=(const ptrdiff_t _Off) noexcept /* strengthened */ {
+    _CONSTEXPR17 _Array_iterator& operator+=(const ptrdiff_t _Off) noexcept {
         _Mybase::operator+=(_Off);
         return *this;
     }
 
-    _NODISCARD _CONSTEXPR17 _Array_iterator operator+(const ptrdiff_t _Off) const noexcept /* strengthened */ {
+    _NODISCARD _CONSTEXPR17 _Array_iterator operator+(const ptrdiff_t _Off) const noexcept {
         _Array_iterator _Tmp = *this;
         return _Tmp += _Off;
     }
 
-    _CONSTEXPR17 _Array_iterator& operator-=(const ptrdiff_t _Off) noexcept /* strengthened */ {
+    _CONSTEXPR17 _Array_iterator& operator-=(const ptrdiff_t _Off) noexcept {
         _Mybase::operator-=(_Off);
         return *this;
     }
 
     using _Mybase::operator-;
 
-    _NODISCARD _CONSTEXPR17 _Array_iterator operator-(const ptrdiff_t _Off) const noexcept /* strengthened */ {
+    _NODISCARD _CONSTEXPR17 _Array_iterator operator-(const ptrdiff_t _Off) const noexcept {
         _Array_iterator _Tmp = *this;
         return _Tmp -= _Off;
     }
 
-    _NODISCARD _CONSTEXPR17 reference operator[](const ptrdiff_t _Off) const noexcept /* strengthened */ {
+    _NODISCARD _CONSTEXPR17 reference operator[](const ptrdiff_t _Off) const noexcept {
         return const_cast<reference>(_Mybase::operator[](_Off));
     }
 
@@ -3464,7 +3464,7 @@ public:
 
 template <class _Ty, size_t _Size>
 _NODISCARD _CONSTEXPR17 _Array_iterator<_Ty, _Size> operator+(
-    ptrdiff_t _Off, _Array_iterator<_Ty, _Size> _Next) noexcept /* strengthened */ {
+    ptrdiff_t _Off, _Array_iterator<_Ty, _Size> _Next) noexcept {
     return _Next += _Off;
 }
 

--- a/tests/std/tests/P0122R7_span/test.cpp
+++ b/tests/std/tests/P0122R7_span/test.cpp
@@ -377,8 +377,8 @@ constexpr bool test() {
         static_assert(!is_constructible_v<span<int>, Z, C>);
         static_assert(!is_constructible_v<span<int>, Z, Z>);
 
-        static_assert(is_nothrow_constructible_v<span<int, 3>, I, C>); // strengthened
         static_assert(is_nothrow_constructible_v<span<int, 3>, I, I>); // strengthened
+        static_assert(is_nothrow_constructible_v<span<int, 3>, I, C>); // strengthened
         static_assert(!is_constructible_v<span<int, 3>, I, Z>);
         static_assert(!is_constructible_v<span<int, 3>, C, I>);
         static_assert(!is_constructible_v<span<int, 3>, C, C>);

--- a/tests/std/tests/P0122R7_span/test.cpp
+++ b/tests/std/tests/P0122R7_span/test.cpp
@@ -367,33 +367,33 @@ constexpr bool test() {
         using C = array<int, 3>::const_iterator;
         using Z = array<double, 3>::iterator;
 
-        static_assert(is_nothrow_constructible_v<span<int>, I, I>); // strengthened 
-        static_assert(is_nothrow_constructible_v<span<int>, I, C>); // strengthened 
-        static_assert(!is_nothrow_constructible_v<span<int>, I, Z>); // strengthened 
-        static_assert(!is_nothrow_constructible_v<span<int>, C, I>); // strengthened 
-        static_assert(!is_nothrow_constructible_v<span<int>, C, C>); // strengthened 
-        static_assert(!is_nothrow_constructible_v<span<int>, C, Z>); // strengthened 
-        static_assert(!is_nothrow_constructible_v<span<int>, Z, I>); // strengthened 
-        static_assert(!is_nothrow_constructible_v<span<int>, Z, C>); // strengthened 
-        static_assert(!is_nothrow_constructible_v<span<int>, Z, Z>);
+        static_assert(is_nothrow_constructible_v<span<int>, I, I>); // strengthened
+        static_assert(is_nothrow_constructible_v<span<int>, I, C>); // strengthened
+        static_assert(!is_constructible_v<span<int>, I, Z>);
+        static_assert(!is_constructible_v<span<int>, C, I>);
+        static_assert(!is_constructible_v<span<int>, C, C>);
+        static_assert(!is_constructible_v<span<int>, C, Z>);
+        static_assert(!is_constructible_v<span<int>, Z, I>);
+        static_assert(!is_constructible_v<span<int>, Z, C>);
+        static_assert(!is_constructible_v<span<int>, Z, Z>);
 
-        static_assert(is_nothrow_constructible_v<span<int, 3>, I, C>); // strengthened 
-        static_assert(is_nothrow_constructible_v<span<int, 3>, I, I>); // strengthened 
-        static_assert(!is_nothrow_constructible_v<span<int, 3>, I, Z>); // strengthened 
-        static_assert(!is_nothrow_constructible_v<span<int, 3>, C, I>); // strengthened 
-        static_assert(!is_nothrow_constructible_v<span<int, 3>, C, C>); // strengthened 
-        static_assert(!is_nothrow_constructible_v<span<int, 3>, C, Z>); // strengthened 
-        static_assert(!is_nothrow_constructible_v<span<int, 3>, Z, I>); // strengthened 
-        static_assert(!is_nothrow_constructible_v<span<int, 3>, Z, C>); // strengthened 
-        static_assert(!is_nothrow_constructible_v<span<int, 3>, Z, Z>); // strengthened 
+        static_assert(is_nothrow_constructible_v<span<int, 3>, I, C>); // strengthened
+        static_assert(is_nothrow_constructible_v<span<int, 3>, I, I>); // strengthened
+        static_assert(!is_constructible_v<span<int, 3>, I, Z>);
+        static_assert(!is_constructible_v<span<int, 3>, C, I>);
+        static_assert(!is_constructible_v<span<int, 3>, C, C>);
+        static_assert(!is_constructible_v<span<int, 3>, C, Z>);
+        static_assert(!is_constructible_v<span<int, 3>, Z, I>);
+        static_assert(!is_constructible_v<span<int, 3>, Z, C>);
+        static_assert(!is_constructible_v<span<int, 3>, Z, Z>);
 
-        static_assert(is_nothrow_constructible_v<span<const int>, I, I>); // strengthened 
-        static_assert(is_nothrow_constructible_v<span<const int>, I, C>); // strengthened 
-        static_assert(is_nothrow_constructible_v<span<const int>, C, I>); // strengthened 
-        static_assert(is_nothrow_constructible_v<span<const int>, C, C>); // strengthened 
+        static_assert(is_nothrow_constructible_v<span<const int>, I, I>); // strengthened
+        static_assert(is_nothrow_constructible_v<span<const int>, I, C>); // strengthened
+        static_assert(is_nothrow_constructible_v<span<const int>, C, I>); // strengthened
+        static_assert(is_nothrow_constructible_v<span<const int>, C, C>); // strengthened
 
-        static_assert(!is_nothrow_constructible_v<span<int>, I, int*>); // strengthened 
-        static_assert(!is_nothrow_constructible_v<span<int>, int*, I>); // strengthened 
+        static_assert(!is_constructible_v<span<int>, I, int*>);
+        static_assert(!is_constructible_v<span<int>, int*, I>);
 
         static_assert(is_nothrow_constructible_v<span<Base>, Base*, Base*>); // strengthened
         static_assert(is_nothrow_constructible_v<span<Base, 3>, Base*, Base*>); // strengthened
@@ -402,8 +402,8 @@ constexpr bool test() {
 
         using B = array<Base, 3>::iterator;
         using D = array<Derived, 3>::iterator;
-        static_assert(is_constructible_v<span<Base>, B, B>);
-        static_assert(is_constructible_v<span<Base, 3>, B, B>);
+        static_assert(is_nothrow_constructible_v<span<Base>, B, B>); // strengthened
+        static_assert(is_nothrow_constructible_v<span<Base, 3>, B, B>); // strengthened
         static_assert(!is_constructible_v<span<Base>, D, D>);
         static_assert(!is_constructible_v<span<Base, 3>, D, D>);
 

--- a/tests/std/tests/P0122R7_span/test.cpp
+++ b/tests/std/tests/P0122R7_span/test.cpp
@@ -367,35 +367,33 @@ constexpr bool test() {
         using C = array<int, 3>::const_iterator;
         using Z = array<double, 3>::iterator;
 
-        // TRANSITION, GH-427, array iterators haven't strengthened noexcept
+        static_assert(is_nothrow_constructible_v<span<int>, I, I>); // strengthened 
+        static_assert(is_nothrow_constructible_v<span<int>, I, C>); // strengthened 
+        static_assert(!is_nothrow_constructible_v<span<int>, I, Z>); // strengthened 
+        static_assert(!is_nothrow_constructible_v<span<int>, C, I>); // strengthened 
+        static_assert(!is_nothrow_constructible_v<span<int>, C, C>); // strengthened 
+        static_assert(!is_nothrow_constructible_v<span<int>, C, Z>); // strengthened 
+        static_assert(!is_nothrow_constructible_v<span<int>, Z, I>); // strengthened 
+        static_assert(!is_nothrow_constructible_v<span<int>, Z, C>); // strengthened 
+        static_assert(!is_nothrow_constructible_v<span<int>, Z, Z>);
 
-        static_assert(is_constructible_v<span<int>, I, I>);
-        static_assert(is_constructible_v<span<int>, I, C>);
-        static_assert(!is_constructible_v<span<int>, I, Z>);
-        static_assert(!is_constructible_v<span<int>, C, I>);
-        static_assert(!is_constructible_v<span<int>, C, C>);
-        static_assert(!is_constructible_v<span<int>, C, Z>);
-        static_assert(!is_constructible_v<span<int>, Z, I>);
-        static_assert(!is_constructible_v<span<int>, Z, C>);
-        static_assert(!is_constructible_v<span<int>, Z, Z>);
+        static_assert(is_nothrow_constructible_v<span<int, 3>, I, C>); // strengthened 
+        static_assert(is_nothrow_constructible_v<span<int, 3>, I, I>); // strengthened 
+        static_assert(!is_nothrow_constructible_v<span<int, 3>, I, Z>); // strengthened 
+        static_assert(!is_nothrow_constructible_v<span<int, 3>, C, I>); // strengthened 
+        static_assert(!is_nothrow_constructible_v<span<int, 3>, C, C>); // strengthened 
+        static_assert(!is_nothrow_constructible_v<span<int, 3>, C, Z>); // strengthened 
+        static_assert(!is_nothrow_constructible_v<span<int, 3>, Z, I>); // strengthened 
+        static_assert(!is_nothrow_constructible_v<span<int, 3>, Z, C>); // strengthened 
+        static_assert(!is_nothrow_constructible_v<span<int, 3>, Z, Z>); // strengthened 
 
-        static_assert(is_constructible_v<span<int, 3>, I, I>);
-        static_assert(is_constructible_v<span<int, 3>, I, C>);
-        static_assert(!is_constructible_v<span<int, 3>, I, Z>);
-        static_assert(!is_constructible_v<span<int, 3>, C, I>);
-        static_assert(!is_constructible_v<span<int, 3>, C, C>);
-        static_assert(!is_constructible_v<span<int, 3>, C, Z>);
-        static_assert(!is_constructible_v<span<int, 3>, Z, I>);
-        static_assert(!is_constructible_v<span<int, 3>, Z, C>);
-        static_assert(!is_constructible_v<span<int, 3>, Z, Z>);
+        static_assert(is_nothrow_constructible_v<span<const int>, I, I>); // strengthened 
+        static_assert(is_nothrow_constructible_v<span<const int>, I, C>); // strengthened 
+        static_assert(is_nothrow_constructible_v<span<const int>, C, I>); // strengthened 
+        static_assert(is_nothrow_constructible_v<span<const int>, C, C>); // strengthened 
 
-        static_assert(is_constructible_v<span<const int>, I, I>);
-        static_assert(is_constructible_v<span<const int>, I, C>);
-        static_assert(is_constructible_v<span<const int>, C, I>);
-        static_assert(is_constructible_v<span<const int>, C, C>);
-
-        static_assert(!is_constructible_v<span<int>, I, int*>);
-        static_assert(!is_constructible_v<span<int>, int*, I>);
+        static_assert(!is_nothrow_constructible_v<span<int>, I, int*>); // strengthened 
+        static_assert(!is_nothrow_constructible_v<span<int>, int*, I>); // strengthened 
 
         static_assert(is_nothrow_constructible_v<span<Base>, Base*, Base*>); // strengthened
         static_assert(is_nothrow_constructible_v<span<Base, 3>, Base*, Base*>); // strengthened


### PR DESCRIPTION
Description
===========
Closes #427 and part of #363

Checklist
=========

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [ ] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
