### PR TITLE
<filesystem>: Fix damage caused by redefinition of _Iter_value_t to iter_value_t in concepts mode

### DIFF
--- a/stl/inc/filesystem
+++ b/stl/inc/filesystem
@@ -196,18 +196,12 @@ namespace filesystem {
     template <>
     inline constexpr bool _Is_EcharT<char32_t> = true;
 
-#ifdef __cpp_lib_concepts
-    // clang-format off
-    template <class _Ty>
-    concept _Is_Source_impl = input_iterator<_Ty> && _Is_EcharT<iter_value_t<_Ty>>;
-    // clang-format on
-#else // ^^^ Concepts / no concepts vvv
     template <class _Ty, class = void>
     inline constexpr bool _Is_Source_impl = false;
 
     template <class _Ty>
-    inline constexpr bool _Is_Source_impl<_Ty, void_t<_Iter_value_t<_Ty>>> = _Is_EcharT<_Iter_value_t<_Ty>>;
-#endif // __cpp_lib_concepts
+    inline constexpr bool _Is_Source_impl<_Ty, void_t<typename iterator_traits<_Ty>::value_type>> =
+        _Is_EcharT<typename iterator_traits<_Ty>::value_type>;
 
     template <class _Ty>
     inline constexpr bool _Is_Source = _Is_Source_impl<decay_t<_Ty>>;

--- a/stl/inc/filesystem
+++ b/stl/inc/filesystem
@@ -196,15 +196,21 @@ namespace filesystem {
     template <>
     inline constexpr bool _Is_EcharT<char32_t> = true;
 
+#ifdef __cpp_lib_concepts
+    // clang-format off
+    template <class _Ty>
+    concept _Is_Source_impl = input_iterator<_Ty> && _Is_EcharT<iter_value_t<_Ty>>;
+    // clang-format on
+#else // ^^^ Concepts / no concepts vvv
     template <class _Ty, class = void>
-    inline constexpr bool _Is_Source2 = false;
+    inline constexpr bool _Is_Source_impl = false;
 
     template <class _Ty>
-    inline constexpr bool _Is_Source2<_Ty, void_t<_Iter_value_t<decay_t<_Ty>>>> =
-        _Is_EcharT<_Iter_value_t<decay_t<_Ty>>>;
+    inline constexpr bool _Is_Source_impl<_Ty, void_t<_Iter_value_t<_Ty>>> = _Is_EcharT<_Iter_value_t<_Ty>>;
+#endif // __cpp_lib_concepts
 
     template <class _Ty>
-    inline constexpr bool _Is_Source = _Is_Source2<_Ty>;
+    inline constexpr bool _Is_Source = _Is_Source_impl<decay_t<_Ty>>;
 
     class path;
 

--- a/tests/std/tests/P0218R1_filesystem/test.cpp
+++ b/tests/std/tests/P0218R1_filesystem/test.cpp
@@ -3903,6 +3903,14 @@ void run_interactive_tests(int argc, wchar_t* argv[]) {
     }
 }
 
+// Also test DevCom-953628, which witnessed a failure of filesystem::path's "Source" constructor to SFINAE away when
+// given a non-iterator argument for which iter_value_t is valid when defining _Iter_value_t to iter_value_t in concepts
+// mode.
+void test_devcom_953628() { // COMPILE-ONLY
+    struct S : wstring {};
+    path{S{}};
+}
+
 int wmain(int argc, wchar_t* argv[]) {
     error_code ec;
 


### PR DESCRIPTION
Description
===========

`iter_value_t` doesn't detour through `iterator_traits`, so it can be valid for non-iterator types. This breaks `_Is_Source2`, however, which expects `_Iter_value_t` to filter out non-iterator types.

Drive-by: rename `_Is_Source2` to `_Is_Source_impl` to be consistent with how we name trait helpers elsewhere.

Fixes DevCom-953628.

[This is a dual of internal MSVC-PR-237115.]

Checklist
=========

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [x] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
