### PR TITLE
Try to run with fewer workers to avoid overwhelming the VM

### DIFF
--- a/azure-devops/run-build.yml
+++ b/azure-devops/run-build.yml
@@ -68,7 +68,7 @@ jobs:
         cmakeListsTxtPath: '$(Build.SourcesDirectory)/CMakeLists.txt'
         buildDirectory: $(Build.ArtifactStagingDirectory)/${{ parameters.targetPlatform }}
         useVcpkgToolchainFile: true
-        cmakeAppendedArgs: '-G Ninja -DENABLE_XUNIT_OUTPUT=TRUE'
+        cmakeAppendedArgs: '-G Ninja -DENABLE_XUNIT_OUTPUT=TRUE -DADDITIONAL_LIT_FLAGS=-j14'
     - task: PowerShell@2
       displayName: 'Run Tests'
       timeoutInMinutes: 120

--- a/azure-devops/run-build.yml
+++ b/azure-devops/run-build.yml
@@ -60,6 +60,14 @@ jobs:
         filename: 'azure-devops/validate-files.cmd'
         failOnStandardError: true
         arguments: '$(Build.ArtifactStagingDirectory)/tools/validate/validate.exe'
+    - task: PowerShell@2
+      displayName: 'Get Test Parallelsim'
+      timeoutInMinutes: 2
+      inputs:
+        targetType: inline
+        script: |
+          $number_of_parallel_tests = $env:NUMBER_OF_PROCESSORS - 2
+          Write-Output "##vso[task.setvariable variable=NUMBER_OF_PROCESSORS;]$number_of_parallel_tests"
     - task: run-cmake@0
       displayName: 'Build the STL'
       timeoutInMinutes: 10
@@ -68,7 +76,7 @@ jobs:
         cmakeListsTxtPath: '$(Build.SourcesDirectory)/CMakeLists.txt'
         buildDirectory: $(Build.ArtifactStagingDirectory)/${{ parameters.targetPlatform }}
         useVcpkgToolchainFile: true
-        cmakeAppendedArgs: '-G Ninja -DENABLE_XUNIT_OUTPUT=TRUE -DADDITIONAL_LIT_FLAGS=-j14'
+        cmakeAppendedArgs: '-G Ninja -DENABLE_XUNIT_OUTPUT=TRUE -DADDITIONAL_LIT_FLAGS=$(NUMBER_OF_PROCESSORS)'
     - task: PowerShell@2
       displayName: 'Run Tests'
       timeoutInMinutes: 120

--- a/azure-devops/run-build.yml
+++ b/azure-devops/run-build.yml
@@ -76,7 +76,7 @@ jobs:
         cmakeListsTxtPath: '$(Build.SourcesDirectory)/CMakeLists.txt'
         buildDirectory: $(Build.ArtifactStagingDirectory)/${{ parameters.targetPlatform }}
         useVcpkgToolchainFile: true
-        cmakeAppendedArgs: '-G Ninja -DENABLE_XUNIT_OUTPUT=TRUE -DADDITIONAL_LIT_FLAGS=$(NUMBER_OF_PROCESSORS)'
+        cmakeAppendedArgs: '-G Ninja -DENABLE_XUNIT_OUTPUT=TRUE -DADDITIONAL_LIT_FLAGS=-j$(NUMBER_OF_PROCESSORS)'
     - task: PowerShell@2
       displayName: 'Run Tests'
       timeoutInMinutes: 120

--- a/azure-devops/run-build.yml
+++ b/azure-devops/run-build.yml
@@ -61,7 +61,7 @@ jobs:
         failOnStandardError: true
         arguments: '$(Build.ArtifactStagingDirectory)/tools/validate/validate.exe'
     - task: PowerShell@2
-      displayName: 'Get Test Parallelsim'
+      displayName: 'Get Test Parallelism'
       timeoutInMinutes: 2
       inputs:
         targetType: inline

--- a/azure-devops/run-build.yml
+++ b/azure-devops/run-build.yml
@@ -66,8 +66,8 @@ jobs:
       inputs:
         targetType: inline
         script: |
-          $number_of_parallel_tests = $env:NUMBER_OF_PROCESSORS - 2
-          Write-Output "##vso[task.setvariable variable=NUMBER_OF_PROCESSORS;]$number_of_parallel_tests"
+          $testParallelism = $env:NUMBER_OF_PROCESSORS - 2
+          Write-Output "##vso[task.setvariable variable=testParallelism;]$testParallelism"
     - task: run-cmake@0
       displayName: 'Build the STL'
       timeoutInMinutes: 10
@@ -76,7 +76,7 @@ jobs:
         cmakeListsTxtPath: '$(Build.SourcesDirectory)/CMakeLists.txt'
         buildDirectory: $(Build.ArtifactStagingDirectory)/${{ parameters.targetPlatform }}
         useVcpkgToolchainFile: true
-        cmakeAppendedArgs: '-G Ninja -DENABLE_XUNIT_OUTPUT=TRUE -DADDITIONAL_LIT_FLAGS=-j$(NUMBER_OF_PROCESSORS)'
+        cmakeAppendedArgs: '-G Ninja -DENABLE_XUNIT_OUTPUT=TRUE -DADDITIONAL_LIT_FLAGS=-j$(testParallelism)'
     - task: PowerShell@2
       displayName: 'Run Tests'
       timeoutInMinutes: 120


### PR DESCRIPTION
Description
===========
Try decreasing the worker count to avoid overwhelming the VMs.


Checklist
=========
- [ ] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [ ] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [ ] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [ ] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
