### PR TITLE
Add recurse_submodules to git clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ acquire this dependency.
 6. Run `.\vcpkg.exe integrate install` which tells Visual Studio which vcpkg instance you wish to use. If you have never
    done this before, you may be prompted to elevate.
 7. Open Visual Studio, and choose the "Clone or check out code" option. Enter the URL to this
-   repository, typically `https://github.com/microsoft/STL`
+   repository, typically `https://github.com/microsoft/STL`. Make sure that submodules are also checked out.
 8. Choose the architecture you wish to build in the IDE, and build as you would any other project. All necessary CMake
    settings are set by `CMakeSettings.json` and `vcpkg integrate`
 
@@ -166,7 +166,7 @@ architectures.
 5. Invoke `.\vcpkg.exe install boost-math:x64-windows` to install the boost-math dependency.
 6. Open an "x64 Native Tools Command Prompt for VS 2019".
 7. Change directories to a location where you'd like a clone of this STL repository.
-8. Invoke `git clone https://github.com/microsoft/STL`
+8. Invoke `git clone --recurse-submodules https://github.com/microsoft/STL`
 9. Invoke `cd STL`
 10. Invoke `cmake -G Ninja -DCMAKE_TOOLCHAIN_FILE={where your vcpkg clone is located}\scripts\buildsystems\vcpkg.cmake
 -S . -B {wherever you want binaries}` to configure the project. For example,


### PR DESCRIPTION
Without cloning submodules, build process as outlined fails. Amend README to add `recurse_submodules` to `git clone`.

Description
===========



Checklist
=========

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [ ] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [ ] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [ ] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [ ] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
