### PR TITLE
Add static_assert to is_sorted() for the lookup tables in validate.cpp

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -4,7 +4,7 @@
 cmake_minimum_required(VERSION 3.15)
 project(msvc_standard_libraries_tools LANGUAGES CXX)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 

--- a/tools/validate/validate.cpp
+++ b/tools/validate/validate.cpp
@@ -172,10 +172,9 @@ int main() {
         ".gitmodules"sv,
     };
 
-    // TRANSITION, P0202R3, use constexpr is_sorted()
-    assert(is_sorted(skipped_directories.begin(), skipped_directories.end()));
-    assert(is_sorted(skipped_extensions.begin(), skipped_extensions.end()));
-    assert(is_sorted(tabby_filenames.begin(), tabby_filenames.end()));
+    static_assert(is_sorted(skipped_directories.begin(), skipped_directories.end()));
+    static_assert(is_sorted(skipped_extensions.begin(), skipped_extensions.end()));
+    static_assert(is_sorted(tabby_filenames.begin(), tabby_filenames.end()));
 
     vector<unsigned char> buffer; // reused for performance
 


### PR DESCRIPTION
Description
===========
With VS 2019 16.6 Preview 1 available, shipping toolset supports `constexpr is_sorted()` which means we can `static_assert` `is_sorted` in `validate.cpp`. This PR makes that change and closes #455.


Checklist
=========

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [x] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
