### PR TITLE
<numeric> Optimize gcd to use builtins

### DIFF
--- a/stl/inc/bit
+++ b/stl/inc/bit
@@ -23,8 +23,6 @@ _STL_DISABLE_CLANG_WARNINGS
 #undef new
 
 _STD_BEGIN
-enum class endian { little = 0, big = 1, native = little };
-
 #ifdef __cpp_lib_bit_cast // TRANSITION, VSO-1041044
 template <class _To, class _From,
     enable_if_t<conjunction_v<bool_constant<sizeof(_To) == sizeof(_From)>, is_trivially_copyable<_To>,
@@ -37,9 +35,7 @@ _NODISCARD constexpr _To bit_cast(const _From& _Val) noexcept {
 
 #ifdef __cpp_lib_bitops // TRANSITION, VSO-1020212
 template <class _Ty, enable_if_t<_Is_standard_unsigned_integer<_Ty>, int> = 0>
-_NODISCARD constexpr int countl_zero(_Ty _Val) noexcept {
-    return _Countl_zero(_Val);
-}
+_NODISCARD constexpr int countl_zero(_Ty _Val) noexcept;
 
 template <class _Ty, enable_if_t<_Is_standard_unsigned_integer<_Ty>, int> = 0>
 _NODISCARD constexpr bool has_single_bit(const _Ty _Val) noexcept {
@@ -52,7 +48,7 @@ _NODISCARD constexpr _Ty bit_ceil(const _Ty _Val) noexcept /* strengthened */ {
         return 1;
     }
 
-    return static_cast<_Ty>(_Ty{1} << (numeric_limits<_Ty>::digits - _Countl_zero(static_cast<_Ty>(_Val - 1))));
+    return static_cast<_Ty>(_Ty{1} << (numeric_limits<_Ty>::digits - _STD countl_zero(static_cast<_Ty>(_Val - 1))));
 }
 
 template <class _Ty, enable_if_t<_Is_standard_unsigned_integer<_Ty>, int> = 0>
@@ -61,12 +57,12 @@ _NODISCARD constexpr _Ty bit_floor(const _Ty _Val) noexcept {
         return 0;
     }
 
-    return static_cast<_Ty>(_Ty{1} << (numeric_limits<_Ty>::digits - 1 - _Countl_zero(_Val)));
+    return static_cast<_Ty>(_Ty{1} << (numeric_limits<_Ty>::digits - 1 - _STD countl_zero(_Val)));
 }
 
 template <class _Ty, enable_if_t<_Is_standard_unsigned_integer<_Ty>, int> = 0>
 _NODISCARD constexpr _Ty bit_width(const _Ty _Val) noexcept {
-    return static_cast<_Ty>(numeric_limits<_Ty>::digits - _Countl_zero(_Val));
+    return static_cast<_Ty>(numeric_limits<_Ty>::digits - _STD countl_zero(_Val));
 }
 
 template <class _Ty, enable_if_t<_Is_standard_unsigned_integer<_Ty>, int> = 0>
@@ -100,27 +96,33 @@ _NODISCARD constexpr _Ty rotr(const _Ty _Val, const int _Rotation) noexcept {
     }
 }
 
+template <class _Ty, enable_if_t<_Is_standard_unsigned_integer<_Ty>, int> _Enabled>
+_NODISCARD constexpr int countl_zero(const _Ty _Val) noexcept {
+    constexpr int _Digits = numeric_limits<_Ty>::digits;
+    if (_Val == 0) {
+        return _Digits;
+    }
+
+    if constexpr (sizeof(_Ty) <= sizeof(unsigned int)) {
+        return __builtin_clz(_Val) - (numeric_limits<unsigned int>::digits - _Digits);
+    } else {
+        return __builtin_clzll(_Val) - (numeric_limits<unsigned long long>::digits - _Digits);
+    }
+}
+
 template <class _Ty, enable_if_t<_Is_standard_unsigned_integer<_Ty>, int> = 0>
 _NODISCARD constexpr int countl_one(const _Ty _Val) noexcept {
-    return _Countl_zero(static_cast<_Ty>(~_Val));
+    return _STD countl_zero(static_cast<_Ty>(~_Val));
 }
 
 template <class _Ty, enable_if_t<_Is_standard_unsigned_integer<_Ty>, int> = 0>
 _NODISCARD constexpr int countr_zero(const _Ty _Val) noexcept {
-    if (_Val == 0) {
-        return numeric_limits<_Ty>::digits;
-    }
-
-    if constexpr (sizeof(_Ty) <= sizeof(unsigned int)) {
-        return __builtin_ctz(_Val);
-    } else {
-        return __builtin_ctzll(_Val);
-    }
+    return _Countr_zero(_Val);
 }
 
 template <class _Ty, enable_if_t<_Is_standard_unsigned_integer<_Ty>, int> _Enabled = 0>
 _NODISCARD constexpr int countr_one(const _Ty _Val) noexcept {
-    return _STD countr_zero(static_cast<_Ty>(~_Val));
+    return _Countr_zero(static_cast<_Ty>(~_Val));
 }
 
 template <class _Ty, enable_if_t<_Is_standard_unsigned_integer<_Ty>, int> _Enabled = 0>
@@ -133,6 +135,7 @@ _NODISCARD constexpr int popcount(const _Ty _Val) noexcept {
 }
 #endif // __cpp_lib_bitops
 
+enum class endian { little = 0, big = 1, native = little };
 _STD_END
 
 #pragma pop_macro("new")

--- a/stl/inc/bit
+++ b/stl/inc/bit
@@ -36,13 +36,10 @@ _NODISCARD constexpr _To bit_cast(const _From& _Val) noexcept {
 #endif // TRANSITION, VSO-1041044
 
 #ifdef __cpp_lib_bitops // TRANSITION, VSO-1020212
-template <class _Ty>
-inline constexpr bool _Is_standard_unsigned_integer =
-    _Is_any_of_v<remove_cv_t<_Ty>, unsigned char, unsigned short, unsigned int, unsigned long, unsigned long long>;
-
-
 template <class _Ty, enable_if_t<_Is_standard_unsigned_integer<_Ty>, int> = 0>
-_NODISCARD constexpr int countl_zero(_Ty _Val) noexcept;
+_NODISCARD constexpr int countl_zero(_Ty _Val) noexcept {
+    return _Countl_zero(_Val);
+}
 
 template <class _Ty, enable_if_t<_Is_standard_unsigned_integer<_Ty>, int> = 0>
 _NODISCARD constexpr bool has_single_bit(const _Ty _Val) noexcept {
@@ -55,7 +52,7 @@ _NODISCARD constexpr _Ty bit_ceil(const _Ty _Val) noexcept /* strengthened */ {
         return 1;
     }
 
-    return static_cast<_Ty>(_Ty{1} << (numeric_limits<_Ty>::digits - _STD countl_zero(static_cast<_Ty>(_Val - 1))));
+    return static_cast<_Ty>(_Ty{1} << (numeric_limits<_Ty>::digits - _Countl_zero(static_cast<_Ty>(_Val - 1))));
 }
 
 template <class _Ty, enable_if_t<_Is_standard_unsigned_integer<_Ty>, int> = 0>
@@ -64,12 +61,12 @@ _NODISCARD constexpr _Ty bit_floor(const _Ty _Val) noexcept {
         return 0;
     }
 
-    return static_cast<_Ty>(_Ty{1} << (numeric_limits<_Ty>::digits - 1 - _STD countl_zero(_Val)));
+    return static_cast<_Ty>(_Ty{1} << (numeric_limits<_Ty>::digits - 1 - _Countl_zero(_Val)));
 }
 
 template <class _Ty, enable_if_t<_Is_standard_unsigned_integer<_Ty>, int> = 0>
 _NODISCARD constexpr _Ty bit_width(const _Ty _Val) noexcept {
-    return static_cast<_Ty>(numeric_limits<_Ty>::digits - _STD countl_zero(_Val));
+    return static_cast<_Ty>(numeric_limits<_Ty>::digits - _Countl_zero(_Val));
 }
 
 template <class _Ty, enable_if_t<_Is_standard_unsigned_integer<_Ty>, int> = 0>
@@ -103,23 +100,9 @@ _NODISCARD constexpr _Ty rotr(const _Ty _Val, const int _Rotation) noexcept {
     }
 }
 
-template <class _Ty, enable_if_t<_Is_standard_unsigned_integer<_Ty>, int> _Enabled>
-_NODISCARD constexpr int countl_zero(const _Ty _Val) noexcept {
-    constexpr int _Digits = numeric_limits<_Ty>::digits;
-    if (_Val == 0) {
-        return _Digits;
-    }
-
-    if constexpr (sizeof(_Ty) <= sizeof(unsigned int)) {
-        return __builtin_clz(_Val) - (numeric_limits<unsigned int>::digits - _Digits);
-    } else {
-        return __builtin_clzll(_Val) - (numeric_limits<unsigned long long>::digits - _Digits);
-    }
-}
-
 template <class _Ty, enable_if_t<_Is_standard_unsigned_integer<_Ty>, int> = 0>
 _NODISCARD constexpr int countl_one(const _Ty _Val) noexcept {
-    return _STD countl_zero(static_cast<_Ty>(~_Val));
+    return _Countl_zero(static_cast<_Ty>(~_Val));
 }
 
 template <class _Ty, enable_if_t<_Is_standard_unsigned_integer<_Ty>, int> = 0>

--- a/stl/inc/limits
+++ b/stl/inc/limits
@@ -1018,16 +1018,15 @@ inline constexpr bool _Is_standard_unsigned_integer =
     _Is_any_of_v<remove_cv_t<_Ty>, unsigned char, unsigned short, unsigned int, unsigned long, unsigned long long>;
 
 template <class _Ty, enable_if_t<_Is_standard_unsigned_integer<_Ty>, int> = 0>
-_NODISCARD constexpr int _Countl_zero(const _Ty _Val) noexcept {
-    constexpr int _Digits = numeric_limits<_Ty>::digits;
+_NODISCARD constexpr int _Countr_zero(const _Ty _Val) noexcept {
     if (_Val == 0) {
-        return _Digits;
+        return numeric_limits<_Ty>::digits;
     }
 
     if constexpr (sizeof(_Ty) <= sizeof(unsigned int)) {
-        return __builtin_clz(_Val) - (numeric_limits<unsigned int>::digits - _Digits);
+        return __builtin_ctz(_Val);
     } else {
-        return __builtin_clzll(_Val) - (numeric_limits<unsigned long long>::digits - _Digits);
+        return __builtin_ctzll(_Val);
     }
 }
 #endif // __cpp_lib_bitops

--- a/stl/inc/limits
+++ b/stl/inc/limits
@@ -1011,6 +1011,27 @@ public:
     static constexpr int min_exponent   = LDBL_MIN_EXP;
     static constexpr int min_exponent10 = LDBL_MIN_10_EXP;
 };
+
+#ifdef __cpp_lib_bitops // TRANSITION, VSO-1020212
+template <class _Ty>
+inline constexpr bool _Is_standard_unsigned_integer =
+    _Is_any_of_v<remove_cv_t<_Ty>, unsigned char, unsigned short, unsigned int, unsigned long, unsigned long long>;
+
+template <class _Ty, enable_if_t<_Is_standard_unsigned_integer<_Ty>, int> = 0>
+_NODISCARD constexpr int _Countl_zero(const _Ty _Val) noexcept {
+    constexpr int _Digits = numeric_limits<_Ty>::digits;
+    if (_Val == 0) {
+        return _Digits;
+    }
+
+    if constexpr (sizeof(_Ty) <= sizeof(unsigned int)) {
+        return __builtin_clz(_Val) - (numeric_limits<unsigned int>::digits - _Digits);
+    } else {
+        return __builtin_clzll(_Val) - (numeric_limits<unsigned long long>::digits - _Digits);
+    }
+}
+#endif // __cpp_lib_bitops
+
 _STD_END
 #pragma pop_macro("new")
 _STL_RESTORE_CLANG_WARNINGS

--- a/stl/inc/numeric
+++ b/stl/inc/numeric
@@ -862,7 +862,6 @@ template <class _Unsigned>
 _NODISCARD constexpr unsigned long _Stl_bitscan_forward(_Unsigned _Mask) noexcept {
 #ifdef __cpp_lib_bitops // TRANSITION, VSO-1020212
     return static_cast<unsigned long>(_Countl_zero(static_cast<_Unsigned>(~_Mask)));
-
 #else // ^^^ __cpp_lib_bitops / !__cpp_lib_bitops vvv
     // find the index of the least significant set bit (_BitScanForward isn't constexpr... yet :))
     static_assert(is_unsigned_v<_Unsigned>, "Bitscan only works on bits");

--- a/stl/inc/numeric
+++ b/stl/inc/numeric
@@ -859,7 +859,10 @@ _NODISCARD constexpr auto _Abs_u(const _Arithmetic _Val) noexcept {
 
 // FUNCTION TEMPLATE _Stl_bitscan_forward
 template <class _Unsigned>
-constexpr unsigned long _Stl_bitscan_forward(_Unsigned _Mask) noexcept {
+_NODISCARD constexpr unsigned long _Stl_bitscan_forward(_Unsigned _Mask) noexcept {
+#ifdef __cpp_lib_bitops // TRANSITION, VSO-1020212
+    return static_cast<unsigned long>(_Countl_zero(~_Mask));
+#else // ^^^ __cpp_lib_bitops / !__cpp_lib_bitops vvv
     // find the index of the least significant set bit (_BitScanForward isn't constexpr... yet :))
     static_assert(is_unsigned_v<_Unsigned>, "Bitscan only works on bits");
     unsigned long _Count = 0;
@@ -871,6 +874,7 @@ constexpr unsigned long _Stl_bitscan_forward(_Unsigned _Mask) noexcept {
     }
 
     return _Count;
+#endif // !__cpp_lib_bitops
 }
 
 // FUNCTION TEMPLATE gcd

--- a/stl/inc/numeric
+++ b/stl/inc/numeric
@@ -861,7 +861,7 @@ _NODISCARD constexpr auto _Abs_u(const _Arithmetic _Val) noexcept {
 template <class _Unsigned>
 _NODISCARD constexpr unsigned long _Stl_bitscan_forward(_Unsigned _Mask) noexcept {
 #ifdef __cpp_lib_bitops // TRANSITION, VSO-1020212
-    return static_cast<unsigned long>(_Countl_zero(static_cast<_Unsigned>(~_Mask)));
+    return static_cast<unsigned long>(_Countr_zero(_Mask));
 #else // ^^^ __cpp_lib_bitops / !__cpp_lib_bitops vvv
     // find the index of the least significant set bit (_BitScanForward isn't constexpr... yet :))
     static_assert(is_unsigned_v<_Unsigned>, "Bitscan only works on bits");

--- a/stl/inc/numeric
+++ b/stl/inc/numeric
@@ -861,7 +861,7 @@ _NODISCARD constexpr auto _Abs_u(const _Arithmetic _Val) noexcept {
 template <class _Unsigned>
 _NODISCARD constexpr unsigned long _Stl_bitscan_forward(_Unsigned _Mask) noexcept {
 #ifdef __cpp_lib_bitops // TRANSITION, VSO-1020212
-    return static_cast<unsigned long>(_Countl_zero(~_Mask));
+    return static_cast<unsigned long>(_Countl_zero<_Unsigned>(~_Mask));
 #else // ^^^ __cpp_lib_bitops / !__cpp_lib_bitops vvv
     // find the index of the least significant set bit (_BitScanForward isn't constexpr... yet :))
     static_assert(is_unsigned_v<_Unsigned>, "Bitscan only works on bits");

--- a/stl/inc/numeric
+++ b/stl/inc/numeric
@@ -861,7 +861,7 @@ _NODISCARD constexpr auto _Abs_u(const _Arithmetic _Val) noexcept {
 template <class _Unsigned>
 _NODISCARD constexpr unsigned long _Stl_bitscan_forward(_Unsigned _Mask) noexcept {
 #ifdef __cpp_lib_bitops // TRANSITION, VSO-1020212
-    return static_cast<unsigned long>(_Countl_zero(static_cast<_Unsigned>(~_Mask));
+    return static_cast<unsigned long>(_Countl_zero(static_cast<_Unsigned>(~_Mask)));
 
 #else // ^^^ __cpp_lib_bitops / !__cpp_lib_bitops vvv
     // find the index of the least significant set bit (_BitScanForward isn't constexpr... yet :))

--- a/stl/inc/numeric
+++ b/stl/inc/numeric
@@ -861,7 +861,8 @@ _NODISCARD constexpr auto _Abs_u(const _Arithmetic _Val) noexcept {
 template <class _Unsigned>
 _NODISCARD constexpr unsigned long _Stl_bitscan_forward(_Unsigned _Mask) noexcept {
 #ifdef __cpp_lib_bitops // TRANSITION, VSO-1020212
-    return static_cast<unsigned long>(_Countl_zero<_Unsigned>(~_Mask));
+    return static_cast<unsigned long>(_Countl_zero(static_cast<_Unsigned>(~_Mask));
+
 #else // ^^^ __cpp_lib_bitops / !__cpp_lib_bitops vvv
     // find the index of the least significant set bit (_BitScanForward isn't constexpr... yet :))
     static_assert(is_unsigned_v<_Unsigned>, "Bitscan only works on bits");


### PR DESCRIPTION
Description
===========
This fixes #298 by moving the meat of the bitscan implementation to the limits header.

This seems unfortunate but is the smallest common denominator of `<numeric>` and `<bit>`

Also we cannot go without limits anyway because the implementation needs it.


Checklist
=========

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [x] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
