### PR TITLE
use build_testing option to toggle tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ if("${Boost_VERSION}" VERSION_LESS "${VCLIBS_MIN_BOOST_VERSION}")
     message(FATAL_ERROR "Detected Boost version is too old (older than ${VCLIBS_MIN_BOOST_VERSION}).")
 endif()
 
+option(BUILD_TESTING "Enable testing" OFF)
 set(VCLIBS_SUFFIX "_oss" CACHE STRING "suffix for built DLL names to avoid conflicts with distributed DLLs")
 
 if(NOT DEFINED VCLIBS_TARGET_ARCHITECTURE)
@@ -88,7 +89,7 @@ set(TOOLSET_LIB "${TOOLSET_ROOT_DIR}/lib/${VCLIBS_X86_OR_X64}")
 
 add_subdirectory(stl)
 
-if(ENABLE_TESTS)
+if(BUILD_TESTING)
     enable_testing()
     add_subdirectory(tests)
 endif()

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ C:\Users\bion\Desktop>dumpbin /IMPORTS .\example.exe | findstr msvcp
 1. Follow steps 1-9 of [How To Build With A Native Tools Command Prompt][].
 2. Invoke `git submodule update --init llvm-project`
 3. Invoke `cmake -G Ninja -DCMAKE_TOOLCHAIN_FILE={where your vcpkg clone is located}\scripts\buildsystems\vcpkg.cmake
--DENABLE_TESTS=TRUE -S . -B {wherever you want binaries}`. This differs from above only in `-DENABLE_TESTS=TRUE`.
+-DBUILD_TESTING=TRUE -S . -B {wherever you want binaries}`. This differs from above only in `-DBUILD_TESTING=TRUE`.
 4. If you have already followed the steps from [How To Build With A Native Tools Command Prompt][], and have not
 changed the value of `{wherever you want binaries}` in step 4, then there is no need to rebuild to run the tests.
 Otherwise, invoke `ninja -C {wherever you want binaries}` to build the project.
@@ -252,7 +252,7 @@ a category in libcxx, or running a single test in `std` and `tr1`.
 :: already installed boost. It also assumes you have inited and updated the llvm-project submodule.
 
 C:\STL\build>cmake -GNinja -DCMAKE_CXX_COMPILER=cl -DCMAKE_TOOLCHAIN_FILE=..\vcpkg\scripts\buildsystems\vcpkg.cmake ^
--DENABLE_TESTS=TRUE ..
+-DBUILD_TESTING=TRUE ..
 
 :: As stated above, this step is only strictly necessary if you have yet to build the STL or if you have changed the
 :: output directory of the binaries. Any changes or additions in any of the existing testsuites do not require

--- a/azure-devops/run-build.yml
+++ b/azure-devops/run-build.yml
@@ -77,7 +77,7 @@ jobs:
         buildDirectory: $(Build.ArtifactStagingDirectory)/${{ parameters.targetPlatform }}
         useVcpkgToolchainFile: true
         cmakeAppendedArgs: |
-          -G Ninja -DENABLE_TESTS=TRUE -DENABLE_XUNIT_OUTPUT=TRUE -DADDITIONAL_LIT_FLAGS=-j$(testParallelism)
+          -G Ninja -DBUILD_TESTING=TRUE -DENABLE_XUNIT_OUTPUT=TRUE -DADDITIONAL_LIT_FLAGS=-j$(testParallelism)
     - task: PowerShell@2
       displayName: 'Run Tests'
       timeoutInMinutes: 120


### PR DESCRIPTION
Also add it as an option() so it shows up in the cache
and in cache editors such as cmake-gui.

Description
===========
Previously we were using ENABLE_TESTS to toggle testing on or off. I suppose this is a little more true to what it does than BUILD_TESTING, but BUILD_TESTING is the "standard" cmake option used for this kind of stuff by many projects.

Additionally we never added ENABLE_TESTS to the cache so it didn't show up in programs like cmake-gui, so I added it to the cache with a default value of "OFF" using the option() cmake command.

Also I updated the pipelines files and the readme to reflect the new option name.


Checklist
=========

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [ ] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
