### PR TITLE
<bitset>: Make bitset::all work like bitset::any

### DIFF
--- a/stl/inc/bitset
+++ b/stl/inc/bitset
@@ -411,7 +411,7 @@ public:
         if _CONSTEXPR_IF ((_Bits % _Bitsperword) == 0) {
             return ~_Array[_Words] == 0;
         }
-        return _Array[_Words] == (static_cast<_Ty>(1) << (_Bits % _Bitsperword))-1;
+        return _Array[_Words] == (static_cast<_Ty>(1) << (_Bits % _Bitsperword)) - 1;
     }
 
     _NODISCARD bitset operator<<(size_t _Pos) const noexcept {

--- a/stl/inc/bitset
+++ b/stl/inc/bitset
@@ -409,7 +409,7 @@ public:
                 return false;
             }
         }
-        if _CONSTEXPR_IF ((_Bits % _Bitsperword) == 0) {
+        if _CONSTEXPR_IF (_Bits % _Bitsperword == 0) {
             return _Array[_Words] == ~static_cast<_Ty>(0);
         }
         return _Array[_Words] == (static_cast<_Ty>(1) << (_Bits % _Bitsperword)) - 1;

--- a/stl/inc/bitset
+++ b/stl/inc/bitset
@@ -404,12 +404,12 @@ public:
             return true;
         }
         for (size_t _Wpos = 0; _Wpos < _Words; ++_Wpos) {
-            if (~_Array[_Wpos] != 0) {
+            if (_Array[_Wpos] != ~static_cast<_Ty>(0)) {
                 return false;
             }
         }
         if _CONSTEXPR_IF ((_Bits % _Bitsperword) == 0) {
-            return ~_Array[_Words] == 0;
+            return _Array[_Words] == ~static_cast<_Ty>(0);
         }
         return _Array[_Words] == (static_cast<_Ty>(1) << (_Bits % _Bitsperword)) - 1;
     }

--- a/stl/inc/bitset
+++ b/stl/inc/bitset
@@ -411,6 +411,7 @@ public:
                 return false;
             }
         }
+
         return _No_padding || _Array[_Words] == (static_cast<_Ty>(1) << (_Bits % _Bitsperword)) - 1;
     }
 

--- a/stl/inc/bitset
+++ b/stl/inc/bitset
@@ -411,7 +411,7 @@ public:
                 return false;
             }
         }
-        return _No_padding ? true : _Array[_Words] == (static_cast<_Ty>(1) << (_Bits % _Bitsperword)) - 1;
+        return _No_padding || _Array[_Words] == (static_cast<_Ty>(1) << (_Bits % _Bitsperword)) - 1;
     }
 
     _NODISCARD bitset operator<<(size_t _Pos) const noexcept {

--- a/stl/inc/bitset
+++ b/stl/inc/bitset
@@ -20,7 +20,6 @@ _STL_DISABLE_CLANG_WARNINGS
 
 #pragma warning(disable : 6294) // Ill-defined for-loop:
                                 // initial condition does not satisfy test.  Loop body not executed.
-#pragma warning(disable : 4127) // conditional expression is constant
 
 _STD_BEGIN
 // CLASS TEMPLATE bitset
@@ -401,18 +400,18 @@ public:
     }
 
     _NODISCARD bool all() const noexcept {
-        if _CONSTEXPR_IF (_Bits == 0) {
-            return true;
+        constexpr bool _Zero_length = _Bits == 0;
+        if _CONSTEXPR_IF (_Zero_length) { // must test for this, otherwise would count one full word
+            return true; 
         }
-        for (size_t _Wpos = 0; _Wpos < _Words; ++_Wpos) {
+
+        constexpr bool _No_padding = _Bits % _Bitsperword == 0;
+        for (size_t _Wpos = 0; _Wpos < _Words + _No_padding; ++_Wpos) {
             if (_Array[_Wpos] != ~static_cast<_Ty>(0)) {
                 return false;
             }
         }
-        if _CONSTEXPR_IF (_Bits % _Bitsperword == 0) {
-            return _Array[_Words] == ~static_cast<_Ty>(0);
-        }
-        return _Array[_Words] == (static_cast<_Ty>(1) << (_Bits % _Bitsperword)) - 1;
+        return _No_padding ? 0 : _Array[_Words] == (static_cast<_Ty>(1) << (_Bits % _Bitsperword)) - 1;
     }
 
     _NODISCARD bitset operator<<(size_t _Pos) const noexcept {

--- a/stl/inc/bitset
+++ b/stl/inc/bitset
@@ -402,7 +402,7 @@ public:
     _NODISCARD bool all() const noexcept {
         constexpr bool _Zero_length = _Bits == 0;
         if _CONSTEXPR_IF (_Zero_length) { // must test for this, otherwise would count one full word
-            return true; 
+            return true;
         }
 
         constexpr bool _No_padding = _Bits % _Bitsperword == 0;

--- a/stl/inc/bitset
+++ b/stl/inc/bitset
@@ -20,6 +20,7 @@ _STL_DISABLE_CLANG_WARNINGS
 
 #pragma warning(disable : 6294) // Ill-defined for-loop:
                                 // initial condition does not satisfy test.  Loop body not executed.
+#pragma warning(disable : 4127) // conditional expression is constant
 
 _STD_BEGIN
 // CLASS TEMPLATE bitset

--- a/stl/inc/bitset
+++ b/stl/inc/bitset
@@ -400,7 +400,18 @@ public:
     }
 
     _NODISCARD bool all() const noexcept {
-        return count() == size();
+        if _CONSTEXPR_IF (_Bits == 0) {
+            return true;
+        }
+        for (size_t _Wpos = 0; _Wpos < _Words; ++_Wpos) {
+            if (~_Array[_Wpos] != 0) {
+                return false;
+            }
+        }
+        if _CONSTEXPR_IF ((_Bits % _Bitsperword) == 0) {
+            return ~_Array[_Words] == 0;
+        }
+        return _Array[_Words] == (static_cast<_Ty>(1) << (_Bits % _Bitsperword))-1;
     }
 
     _NODISCARD bitset operator<<(size_t _Pos) const noexcept {

--- a/stl/inc/bitset
+++ b/stl/inc/bitset
@@ -411,7 +411,7 @@ public:
                 return false;
             }
         }
-        return _No_padding ? 0 : _Array[_Words] == (static_cast<_Ty>(1) << (_Bits % _Bitsperword)) - 1;
+        return _No_padding ? true : _Array[_Words] == (static_cast<_Ty>(1) << (_Bits % _Bitsperword)) - 1;
     }
 
     _NODISCARD bitset operator<<(size_t _Pos) const noexcept {


### PR DESCRIPTION
Description
===========

Fix #669

Checklist
=========

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [x] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [x] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
