### PR TITLE
Changes to support the compiler portion of P1152R4 "deprecating volatile"

### DIFF
--- a/stl/inc/any
+++ b/stl/inc/any
@@ -401,7 +401,7 @@ _NODISCARD _ValueType* any_cast(any* const _Any) noexcept {
 }
 
 template <class _Ty>
-_NODISCARD _Ty any_cast(const any& _Any) { // retrieve _Any's contained value as _Ty
+_NODISCARD remove_cv_t<_Ty> any_cast(const any& _Any) {
     static_assert(is_constructible_v<_Ty, const _Remove_cvref_t<_Ty>&>,
         "any_cast<T>(const any&) requires T to be constructible from const remove_cv_t<remove_reference_t<T>>&");
 
@@ -410,10 +410,10 @@ _NODISCARD _Ty any_cast(const any& _Any) { // retrieve _Any's contained value as
         _Throw_bad_any_cast();
     }
 
-    return static_cast<_Ty>(*_Ptr);
+    return static_cast<remove_cv_t<_Ty>>(*_Ptr);
 }
 template <class _Ty>
-_NODISCARD _Ty any_cast(any& _Any) { // retrieve _Any's contained value as _Ty
+_NODISCARD remove_cv_t<_Ty> any_cast(any& _Any) {
     static_assert(is_constructible_v<_Ty, _Remove_cvref_t<_Ty>&>,
         "any_cast<T>(any&) requires T to be constructible from remove_cv_t<remove_reference_t<T>>&");
 
@@ -422,10 +422,10 @@ _NODISCARD _Ty any_cast(any& _Any) { // retrieve _Any's contained value as _Ty
         _Throw_bad_any_cast();
     }
 
-    return static_cast<_Ty>(*_Ptr);
+    return static_cast<remove_cv_t<_Ty>>(*_Ptr);
 }
 template <class _Ty>
-_NODISCARD _Ty any_cast(any&& _Any) { // retrieve _Any's contained value as _Ty
+_NODISCARD remove_cv_t<_Ty> any_cast(any&& _Any) {
     static_assert(is_constructible_v<_Ty, _Remove_cvref_t<_Ty>>,
         "any_cast<T>(any&&) requires T to be constructible from remove_cv_t<remove_reference_t<T>>");
 
@@ -434,7 +434,7 @@ _NODISCARD _Ty any_cast(any&& _Any) { // retrieve _Any's contained value as _Ty
         _Throw_bad_any_cast();
     }
 
-    return static_cast<_Ty>(_STD move(*_Ptr));
+    return static_cast<remove_cv_t<_Ty>>(_STD move(*_Ptr));
 }
 
 _STD_END

--- a/stl/inc/any
+++ b/stl/inc/any
@@ -402,8 +402,9 @@ _NODISCARD _ValueType* any_cast(any* const _Any) noexcept {
 
 template <class _Ty>
 _NODISCARD remove_cv_t<_Ty> any_cast(const any& _Any) {
-    static_assert(is_constructible_v<_Ty, const _Remove_cvref_t<_Ty>&>,
-        "any_cast<T>(const any&) requires T to be constructible from const remove_cv_t<remove_reference_t<T>>&");
+    static_assert(is_constructible_v<remove_cv_t<_Ty>, const _Remove_cvref_t<_Ty>&>,
+        "any_cast<T>(const any&) requires remove_cv_t<T> to be constructible from "
+        "const remove_cv_t<remove_reference_t<T>>&");
 
     const auto _Ptr = _STD any_cast<_Remove_cvref_t<_Ty>>(&_Any);
     if (!_Ptr) {
@@ -414,8 +415,8 @@ _NODISCARD remove_cv_t<_Ty> any_cast(const any& _Any) {
 }
 template <class _Ty>
 _NODISCARD remove_cv_t<_Ty> any_cast(any& _Any) {
-    static_assert(is_constructible_v<_Ty, _Remove_cvref_t<_Ty>&>,
-        "any_cast<T>(any&) requires T to be constructible from remove_cv_t<remove_reference_t<T>>&");
+    static_assert(is_constructible_v<remove_cv_t<_Ty>, _Remove_cvref_t<_Ty>&>,
+        "any_cast<T>(any&) requires remove_cv_t<T> to be constructible from remove_cv_t<remove_reference_t<T>>&");
 
     const auto _Ptr = _STD any_cast<_Remove_cvref_t<_Ty>>(&_Any);
     if (!_Ptr) {
@@ -426,8 +427,8 @@ _NODISCARD remove_cv_t<_Ty> any_cast(any& _Any) {
 }
 template <class _Ty>
 _NODISCARD remove_cv_t<_Ty> any_cast(any&& _Any) {
-    static_assert(is_constructible_v<_Ty, _Remove_cvref_t<_Ty>>,
-        "any_cast<T>(any&&) requires T to be constructible from remove_cv_t<remove_reference_t<T>>");
+    static_assert(is_constructible_v<remove_cv_t<_Ty>, _Remove_cvref_t<_Ty>>,
+        "any_cast<T>(any&&) requires remove_cv_t<T> to be constructible from remove_cv_t<remove_reference_t<T>>");
 
     const auto _Ptr = _STD any_cast<_Remove_cvref_t<_Ty>>(&_Any);
     if (!_Ptr) {

--- a/stl/inc/optional
+++ b/stl/inc/optional
@@ -395,9 +395,9 @@ public:
 
     template <class _Ty2>
     _NODISCARD constexpr remove_cv_t<_Ty> value_or(_Ty2&& _Right) const& {
-        static_assert(is_copy_constructible_v<_Ty>,
-            "The const overload of optional<T>::value_or requires T to be copy constructible "
-            "(N4828 [optional.observe]/18).");
+        static_assert(is_convertible_v<const _Ty&, remove_cv_t<_Ty>>,
+            "The const overload of optional<T>::value_or requires const T& to be convertible to remove_cv_t<T> "
+            "([optional.observe]/18 as modified by LWG-XXXX).");
         static_assert(is_convertible_v<_Ty2, _Ty>,
             "optional<T>::value_or(U) requires U to be convertible to T (N4828 [optional.observe]/18).");
 
@@ -409,9 +409,9 @@ public:
     }
     template <class _Ty2>
     _NODISCARD constexpr remove_cv_t<_Ty> value_or(_Ty2&& _Right) && {
-        static_assert(is_move_constructible_v<_Ty>,
-            "The rvalue overload of optional<T>::value_or requires T to be move constructible "
-            "(N4828 [optional.observe]/20).");
+        static_assert(is_convertible_v<_Ty, remove_cv_t<_Ty>>,
+            "The rvalue overload of optional<T>::value_or requires T to be convertible to remove_cv_t<T> "
+            "([optional.observe]/20 as modified by LWG-XXXX).");
         static_assert(is_convertible_v<_Ty2, _Ty>,
             "optional<T>::value_or(U) requires U to be convertible to T (N4828 [optional.observe]/20).");
 

--- a/stl/inc/optional
+++ b/stl/inc/optional
@@ -394,7 +394,7 @@ public:
     }
 
     template <class _Ty2>
-    _NODISCARD constexpr _Ty value_or(_Ty2&& _Right) const& {
+    _NODISCARD constexpr remove_cv_t<_Ty> value_or(_Ty2&& _Right) const& {
         static_assert(is_copy_constructible_v<_Ty>,
             "The const overload of optional<T>::value_or requires T to be copy constructible "
             "(N4828 [optional.observe]/18).");
@@ -405,10 +405,10 @@ public:
             return this->_Value;
         }
 
-        return static_cast<_Ty>(_STD forward<_Ty2>(_Right));
+        return static_cast<remove_cv_t<_Ty>>(_STD forward<_Ty2>(_Right));
     }
     template <class _Ty2>
-    _NODISCARD constexpr _Ty value_or(_Ty2&& _Right) && {
+    _NODISCARD constexpr remove_cv_t<_Ty> value_or(_Ty2&& _Right) && {
         static_assert(is_move_constructible_v<_Ty>,
             "The rvalue overload of optional<T>::value_or requires T to be move constructible "
             "(N4828 [optional.observe]/20).");
@@ -419,7 +419,7 @@ public:
             return _STD move(this->_Value);
         }
 
-        return static_cast<_Ty>(_STD forward<_Ty2>(_Right));
+        return static_cast<remove_cv_t<_Ty>>(_STD forward<_Ty2>(_Right));
     }
 
     // modifiers [optional.object.mod]

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -1660,13 +1660,14 @@ struct _Invoker_ret<_Unforced, false> { // selected for _Rx being _Unforced
 
 
 // TYPE TRAITS FOR invoke()
-template <class _To>
-void _Implicitly_convert_to(_To) noexcept; // not defined
-
 #pragma warning(push)
 #pragma warning(disable : 4242) // 'identifier': conversion from '_From' to '_To', possible loss of data (/Wall)
 #pragma warning(disable : 4244) // 'argument': conversion from '_From' to '_To', possible loss of data
 #pragma warning(disable : 4365) // 'argument': conversion from '_From' to '_To', signed/unsigned mismatch (/Wall)
+#pragma warning(disable : 5215) // '%s' a function parameter with a volatile qualified type is deprecated in C++20
+template <class _To>
+void _Implicitly_convert_to(_To) noexcept; // not defined
+
 template <class _From, class _To, bool = is_convertible_v<_From, _To>, bool = is_void_v<_To>>
 _INLINE_VAR constexpr bool _Is_nothrow_convertible_v = noexcept(_Implicitly_convert_to<_To>(_STD declval<_From>()));
 #pragma warning(pop)

--- a/stl/inc/variant
+++ b/stl/inc/variant
@@ -966,11 +966,23 @@ using _Variant_destroy_layer = conditional_t<conjunction_v<is_trivially_destruct
     _Variant_base<_Types...>, _Variant_destroy_layer_<_Types...>>;
 
 // CLASS TEMPLATE variant
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-volatile"
+#else // ^^^ Clang / not Clang vvv
+#pragma warning(push)
+#pragma warning(disable : 5215) // '%s' a function parameter with volatile qualified type is deprecated in C++20
+#endif // __clang__
 template <size_t _Idx, class _Ty>
 struct _Variant_init_single_overload {
     using _FTy = _Meta_list<integral_constant<size_t, _Idx>, _Ty> (*)(_Ty);
     operator _FTy();
 };
+#ifdef __clang__
+#pragma clang diagnostic pop
+#else // ^^^ Clang / not Clang vvv
+#pragma warning(pop)
+#endif // __clang__
 
 template <class _Indices, class... _Types>
 struct _Variant_init_overload_set_;

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -189,10 +189,8 @@ std/language.support/support.dynamic/new.delete/new.delete.array/new_size_align_
 std/language.support/support.dynamic/new.delete/new.delete.array/new_size_align.sh.cpp SKIP
 std/language.support/support.dynamic/new.delete/new.delete.array/new_size_nothrow.sh.cpp SKIP
 std/language.support/support.dynamic/new.delete/new.delete.array/new_size.sh.cpp SKIP
-std/language.support/support.dynamic/new.delete/new.delete.array/sized_delete_array_fsizeddeallocation.sh.cpp SKIP
 std/language.support/support.dynamic/new.delete/new.delete.single/new_size_align_nothrow.sh.cpp SKIP
 std/language.support/support.dynamic/new.delete/new.delete.single/new_size_align.sh.cpp SKIP
-std/language.support/support.dynamic/new.delete/new.delete.single/sized_delete_fsizeddeallocation.sh.cpp SKIP
 std/thread/thread.condition/thread.condition.condvarany/wait_terminates.sh.cpp SKIP
 
 # These tests set an allocator with a max_size() too small to default construct an unordered container
@@ -547,9 +545,9 @@ std/containers/views/span.iterators/rend.pass.cpp SKIP
 
 # *** CLANG ISSUES, NOT YET ANALYZED ***
 # Clang doesn't enable sized deallocation by default. Should we add -fsized-deallocation or do something else?
-std/language.support/support.dynamic/new.delete/new.delete.array/sized_delete_array_fsizeddeallocation.sh.cpp SKIP
+std/language.support/support.dynamic/new.delete/new.delete.array/sized_delete_array_fsizeddeallocation.pass.cpp SKIP
 std/language.support/support.dynamic/new.delete/new.delete.array/sized_delete_array14.pass.cpp SKIP
-std/language.support/support.dynamic/new.delete/new.delete.single/sized_delete_fsizeddeallocation.sh.cpp SKIP
+std/language.support/support.dynamic/new.delete/new.delete.single/sized_delete_fsizeddeallocation.pass.cpp SKIP
 std/language.support/support.dynamic/new.delete/new.delete.single/sized_delete14.pass.cpp SKIP
 
 # Not yet analyzed. Clang apparently defines platform macros differently from C1XX.
@@ -1033,6 +1031,9 @@ std/utilities/tuple/tuple.tuple/tuple.cnstr/deduct.pass.cpp:0 FAIL
 
 # Not yet analyzed. Assertion failed: f16_8.out(mbs, c16, c_c16p, c_c16p, c8, c8+4, c8p) == F32_8::ok
 std/localization/locale.categories/category.ctype/locale.codecvt/locale.codecvt.members/utf_sanity_check.pass.cpp FAIL
+
+# Not yet analyzed. Frequent timeouts
+containers\sequences\deque\deque.modifiers\insert_iter_iter.pass.cpp SKIP
 
 
 # *** XFAILs WHICH PASS ***

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -189,10 +189,8 @@ language.support\support.dynamic\new.delete\new.delete.array\new_size_align_noth
 language.support\support.dynamic\new.delete\new.delete.array\new_size_align.sh.cpp
 language.support\support.dynamic\new.delete\new.delete.array\new_size_nothrow.sh.cpp
 language.support\support.dynamic\new.delete\new.delete.array\new_size.sh.cpp
-language.support\support.dynamic\new.delete\new.delete.array\sized_delete_array_fsizeddeallocation.sh.cpp
 language.support\support.dynamic\new.delete\new.delete.single\new_size_align_nothrow.sh.cpp
 language.support\support.dynamic\new.delete\new.delete.single\new_size_align.sh.cpp
-language.support\support.dynamic\new.delete\new.delete.single\sized_delete_fsizeddeallocation.sh.cpp
 thread\thread.condition\thread.condition.condvarany\wait_terminates.sh.cpp
 
 # These tests set an allocator with a max_size() too small to default construct an unordered container
@@ -547,9 +545,9 @@ containers\views\span.iterators\rend.pass.cpp
 
 # *** CLANG ISSUES, NOT YET ANALYZED ***
 # Clang doesn't enable sized deallocation by default. Should we add -fsized-deallocation or do something else?
-language.support\support.dynamic\new.delete\new.delete.array\sized_delete_array_fsizeddeallocation.sh.cpp
+language.support\support.dynamic\new.delete\new.delete.array\sized_delete_array_fsizeddeallocation.pass.cpp
 language.support\support.dynamic\new.delete\new.delete.array\sized_delete_array14.pass.cpp
-language.support\support.dynamic\new.delete\new.delete.single\sized_delete_fsizeddeallocation.sh.cpp
+language.support\support.dynamic\new.delete\new.delete.single\sized_delete_fsizeddeallocation.pass.cpp
 language.support\support.dynamic\new.delete\new.delete.single\sized_delete14.pass.cpp
 
 # Not yet analyzed. Clang apparently defines platform macros differently from C1XX.
@@ -1033,3 +1031,6 @@ utilities\tuple\tuple.tuple\tuple.cnstr\deduct.pass.cpp
 
 # Not yet analyzed. Assertion failed: f16_8.out(mbs, c16, c_c16p, c_c16p, c8, c8+4, c8p) == F32_8::ok
 localization\locale.categories\category.ctype\locale.codecvt\locale.codecvt.members\utf_sanity_check.pass.cpp
+
+# Not yet analyzed. Frequent timeouts
+containers\sequences\deque\deque.modifiers\insert_iter_iter.pass.cpp

--- a/tests/libcxx/usual_matrix.lst
+++ b/tests/libcxx/usual_matrix.lst
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-PM_CL="/nologo /Od /W4 /w14061 /w14242 /w14582 /w14583 /w14587 /w14588 /w14265 /w14749 /w14841 /w14842 /w15038 /wd4643 /sdl /WX /Zc:strictStrings /D_ENABLE_STL_INTERNAL_CHECK /bigobj /FImsvc_stdlib_force_include.h /permissive-"
+PM_CL="/nologo /Od /W4 /w14061 /w14242 /w14265 /w14582 /w14583 /w14587 /w14588 /wd4643 /w14749 /w14841 /w14842 /w15038 /w15214 /w15215 /w15216 /w15217 /sdl /WX /Zc:strictStrings /D_ENABLE_STL_INTERNAL_CHECK /bigobj /FImsvc_stdlib_force_include.h /permissive-"
 RUNALL_CROSSLIST
 PM_CL="/EHsc /MTd /D_ITERATOR_DEBUG_LEVEL=2 /std:c++latest /analyze"
 PM_COMPILER="clang-cl" PM_CL="-fno-ms-compatibility -fno-delayed-template-parsing /EHsc /MTd /std:c++latest"

--- a/tests/std/tests/prefix.lst
+++ b/tests/std/tests/prefix.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-PM_CL="/nologo /Od /W4 /w14061 /w14242 /w14582 /w14583 /w14587 /w14588 /w14265 /w14365 /w14749 /w14841 /w14842 /w15038 /sdl /WX /Zc:strictStrings /D_ENABLE_STL_INTERNAL_CHECK /D_ENFORCE_FACET_SPECIALIZATIONS=1 /bigobj"
+PM_CL="/nologo /Od /W4 /w14061 /w14242 /w14265 /w14365 /w14582 /w14583 /w14587 /w14588 /w14749 /w14841 /w14842 /w15038 /w15214 /w15215 /w15216 /w15217 /sdl /WX /Zc:strictStrings /D_ENABLE_STL_INTERNAL_CHECK /D_ENFORCE_FACET_SPECIALIZATIONS=1 /bigobj"

--- a/tests/tr1/include/tfuns.h
+++ b/tests/tr1/include/tfuns.h
@@ -3,6 +3,9 @@
 
 // common header for functional?.cpp
 
+#pragma warning(push)
+#pragma warning(disable : 5215) // '%s' a function parameter with volatile qualified type is deprecated in C++20
+
 struct funobj;
 static int f0();
 static int f1(const volatile funobj);
@@ -131,20 +134,19 @@ struct funobj { // general purpose function object
     int cf6(int i1, int i2, int i3, int i4, int i5) const { // const member function with five arguments
         return ::f6(*this, i1, i2, i3, i4, i5);
     }
-    int cf7(int i1, int i2, int i3, int i4, int i5,
-        int i6) const { // const member function with six arguments
+    int cf7(int i1, int i2, int i3, int i4, int i5, int i6) const { // const member function with six arguments
         return ::f7(*this, i1, i2, i3, i4, i5, i6);
     }
-    int cf8(
-        int i1, int i2, int i3, int i4, int i5, int i6, int i7) const { // const member function with seven arguments
+    int cf8(int i1, int i2, int i3, int i4, int i5, int i6, int i7) const {
+        // const member function with seven arguments
         return ::f8(*this, i1, i2, i3, i4, i5, i6, i7);
     }
-    int cf9(int i1, int i2, int i3, int i4, int i5, int i6, int i7,
-        int i8) const { // const member function with eight arguments
+    int cf9(int i1, int i2, int i3, int i4, int i5, int i6, int i7, int i8) const {
+        // const member function with eight arguments
         return ::f9(*this, i1, i2, i3, i4, i5, i6, i7, i8);
     }
-    int cf10(int i1, int i2, int i3, int i4, int i5, int i6, int i7, int i8,
-        int i9) const { // const member function with nine arguments
+    int cf10(int i1, int i2, int i3, int i4, int i5, int i6, int i7, int i8, int i9) const {
+        // const member function with nine arguments
         return ::f10(*this, i1, i2, i3, i4, i5, i6, i7, i8, i9);
     }
 
@@ -166,20 +168,19 @@ struct funobj { // general purpose function object
     int vf6(int i1, int i2, int i3, int i4, int i5) volatile { // volatile member function with five arguments
         return ::f6(*this, i1, i2, i3, i4, i5);
     }
-    int vf7(int i1, int i2, int i3, int i4, int i5,
-        int i6) volatile { // volatile member function with six arguments
+    int vf7(int i1, int i2, int i3, int i4, int i5, int i6) volatile { // volatile member function with six arguments
         return ::f7(*this, i1, i2, i3, i4, i5, i6);
     }
-    int vf8(int i1, int i2, int i3, int i4, int i5, int i6,
-        int i7) volatile { // volatile member function with seven arguments
+    int vf8(int i1, int i2, int i3, int i4, int i5, int i6, int i7) volatile {
+        // volatile member function with seven arguments
         return ::f8(*this, i1, i2, i3, i4, i5, i6, i7);
     }
-    int vf9(int i1, int i2, int i3, int i4, int i5, int i6, int i7,
-        int i8) volatile { // volatile member function with eight arguments
+    int vf9(int i1, int i2, int i3, int i4, int i5, int i6, int i7, int i8) volatile {
+        // volatile member function with eight arguments
         return ::f9(*this, i1, i2, i3, i4, i5, i6, i7, i8);
     }
-    int vf10(int i1, int i2, int i3, int i4, int i5, int i6, int i7, int i8,
-        int i9) volatile { // volatile member function with nine arguments
+    int vf10(int i1, int i2, int i3, int i4, int i5, int i6, int i7, int i8, int i9) volatile {
+        // volatile member function with nine arguments
         return ::f10(*this, i1, i2, i3, i4, i5, i6, i7, i8, i9);
     }
 
@@ -198,24 +199,24 @@ struct funobj { // general purpose function object
     int cvf5(int i1, int i2, int i3, int i4) const volatile { // const volatile member function with four arguments
         return ::f5(*this, i1, i2, i3, i4);
     }
-    int cvf6(int i1, int i2, int i3, int i4, int i5) const
-        volatile { // const volatile member function with five arguments
+    int cvf6(int i1, int i2, int i3, int i4, int i5) const volatile {
+        // const volatile member function with five arguments
         return ::f6(*this, i1, i2, i3, i4, i5);
     }
-    int cvf7(int i1, int i2, int i3, int i4, int i5,
-        int i6) const volatile { // const volatile member function with six arguments
+    int cvf7(int i1, int i2, int i3, int i4, int i5, int i6) const volatile {
+        // const volatile member function with six arguments
         return ::f7(*this, i1, i2, i3, i4, i5, i6);
     }
-    int cvf8(int i1, int i2, int i3, int i4, int i5, int i6, int i7) const
-        volatile { // const volatile member function with seven arguments
+    int cvf8(int i1, int i2, int i3, int i4, int i5, int i6, int i7) const volatile {
+        // const volatile member function with seven arguments
         return ::f8(*this, i1, i2, i3, i4, i5, i6, i7);
     }
-    int cvf9(int i1, int i2, int i3, int i4, int i5, int i6, int i7, int i8) const
-        volatile { // const volatile member function with eight arguments
+    int cvf9(int i1, int i2, int i3, int i4, int i5, int i6, int i7, int i8) const volatile {
+        // const volatile member function with eight arguments
         return ::f9(*this, i1, i2, i3, i4, i5, i6, i7, i8);
     }
-    int cvf10(int i1, int i2, int i3, int i4, int i5, int i6, int i7, int i8, int i9) const
-        volatile { // const volatile member function with nine arguments
+    int cvf10(int i1, int i2, int i3, int i4, int i5, int i6, int i7, int i8, int i9) const volatile {
+        // const volatile member function with nine arguments
         return ::f10(*this, i1, i2, i3, i4, i5, i6, i7, i8, i9);
     }
     int i0;
@@ -626,3 +627,5 @@ const T& fake_lvalue(const T&& t) { // C++11 12.2 [class.temporary]/5: "A tempor
                                     // of the full-expression containing the call."
     return t;
 }
+
+#pragma warning(pop)

--- a/tests/tr1/tests/functional4/test.cpp
+++ b/tests/tr1/tests/functional4/test.cpp
@@ -4,6 +4,8 @@
 // test <functional>, part 4
 #define TEST_NAME "<functional>, part 4"
 
+#pragma warning(disable : 5215) // '%s' a function parameter with a volatile qualified type is deprecated in C++20
+
 #include "tdefs.h"
 #include "tfuns.h"
 #include <functional>

--- a/tests/utils/stl/test/format.py
+++ b/tests/utils/stl/test/format.py
@@ -286,3 +286,9 @@ class LibcxxTestFormat(STLTestFormat):
                             litConfig, localConfig, test_class=LibcxxTest):
         return super().getTestsInDirectory(testSuite, path_in_suite, litConfig,
                                            localConfig, test_class)
+
+    def addCompilerFlags(self, *args):
+        # For now, this is necessary to discard the value of
+        # `LIBCXX_FILESYSTEM_STATIC_TEST_ROOT` which we don't care about;
+        # eventually it will probably need to be made meaningful.
+        pass

--- a/tests/utils/stl/test/format.py
+++ b/tests/utils/stl/test/format.py
@@ -287,7 +287,7 @@ class LibcxxTestFormat(STLTestFormat):
         return super().getTestsInDirectory(testSuite, path_in_suite, litConfig,
                                            localConfig, test_class)
 
-    def addCompilerFlags(self, *args):
+    def addCompileFlags(self, *args):
         # For now, this is necessary to discard the value of
         # `LIBCXX_FILESYSTEM_STATIC_TEST_ROOT` which we don't care about;
         # eventually it will probably need to be made meaningful.


### PR DESCRIPTION
* Add the new warning C5215 "'%s' a function parameter with volatile qualified type is deprecated in C++20" to libc++'s "suppress deprecation warnings" macro and update llvm submodule reference.
* Skip libc++ test `containers/sequences/deque/deque.modifiers/insert_iter_iter.pass.cpp` after seeing one timeout too many in Contest logs.
* Suppress C5215 in `tr1/include/tfuns.h` which uses volatile function parameters.
* Update skips for two libc++ tests that changed suffixes from `.sh.cpp` to `.pass.cpp`.
* Enable C5214-C5217 (which are off-by-default) in libc++ and std test suites

[This is a dual of internal MSVC-PR-239335.]