### PR TITLE
Revert "Replace __pragma with _Pragma (#662)"

### DIFF
--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -455,8 +455,8 @@
     _Pragma("clang diagnostic ignored \"-Wdeprecated-declarations\"")
 #else // __clang__
 #define _STL_DISABLE_DEPRECATED_WARNING \
-    _Pragma("warning(push)")            \
-    _Pragma("warning(disable : 4996)") // was declared deprecated
+    __pragma(warning(push))             \
+    __pragma(warning(disable : 4996)) // was declared deprecated
 #endif // __clang__
 #endif // _STL_DISABLE_DEPRECATED_WARNING
 // clang-format on
@@ -465,7 +465,7 @@
 #ifdef __clang__
 #define _STL_RESTORE_DEPRECATED_WARNING _Pragma("clang diagnostic pop")
 #else // __clang__
-#define _STL_RESTORE_DEPRECATED_WARNING _Pragma("warning(pop)")
+#define _STL_RESTORE_DEPRECATED_WARNING __pragma(warning(pop))
 #endif // __clang__
 #endif // _STL_RESTORE_DEPRECATED_WARNING
 


### PR DESCRIPTION
This reverts commit 42d5df07d025f1e635ee16f45b6c688394634947.

Reverting due to a bug in how /Zc:preprocessor handles _Pragma
see VSO-1091758 for more details

<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
