### PR TITLE
Update FixNamespaceComments to true in various clang-format files

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -94,9 +94,7 @@ ColumnLimit:     120
 # DisableFormat:   false
 # ExperimentalAutoDetectBinPacking: false
 
-# TRANSITION, LLVM-39247, fixed in clang-format 10.
-# FixNamespaceComments: true
-FixNamespaceComments: false
+FixNamespaceComments: true
 
 # ForEachMacros:
 #   - foreach

--- a/.clang-format
+++ b/.clang-format
@@ -93,9 +93,7 @@ ColumnLimit:     120
 # DerivePointerAlignment: false
 # DisableFormat:   false
 # ExperimentalAutoDetectBinPacking: false
-
-FixNamespaceComments: true
-
+# FixNamespaceComments: true
 # ForEachMacros:
 #   - foreach
 #   - Q_FOREACH

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -669,7 +669,7 @@ namespace ranges {
             }
         };
         // clang-format on
-    }
+    } // namespace _Iter_move
 
     inline namespace _Cpos {
         inline constexpr _Iter_move::_Cpo iter_move;

--- a/stl/src/excptptr.cpp
+++ b/stl/src/excptptr.cpp
@@ -163,7 +163,7 @@ namespace {
 #endif // _M_CEE_PURE
         }
     }
-}
+} // unnamed namespace
 
 // All exception_ptr implementations are out-of-line because <memory> depends on <exception>,
 // which means <exception> cannot include <memory> -- and shared_ptr is defined in <memory>.
@@ -396,7 +396,7 @@ namespace {
             _Exception_ptr_access::_Set_ptr_rep(_Dest, &_Rx->_ExRecord, _Rx);
         }
     }
-}
+} // unnamed namespace
 
 _CRTIMP2_PURE void __CLRCALL_PURE_OR_CDECL __ExceptionPtrCreate(void* _Ptr) noexcept {
     ::new (_Ptr) shared_ptr<const _EXCEPTION_RECORD>();

--- a/stl/src/winapisupp.cpp
+++ b/stl/src/winapisupp.cpp
@@ -57,7 +57,7 @@ namespace {
     };
 
     typedef Microsoft::WRL::Wrappers::HandleT<HMODULETraits> HMODULEHandle;
-}
+} // unnamed namespace
 
 extern "C" int __crt_IsPackagedAppHelper() {
     static wchar_t const* const possible_apisets[] = {

--- a/tests/std/include/input_iterator.hpp
+++ b/tests/std/include/input_iterator.hpp
@@ -201,6 +201,6 @@ namespace std_testing {
 
         std::vector<impl_value> m_val;
     };
-}
+} // namespace std_testing
 
 #undef STATIC_ASSERT

--- a/tests/std/include/instantiate_algorithms.hpp
+++ b/tests/std/include/instantiate_algorithms.hpp
@@ -127,7 +127,7 @@ namespace std_testing {
         // Check for op,()
         template <typename T, typename U>
         void operator,(const T&, const U&) = delete;
-    }
+    } // namespace dummy_functors
 
 
     template <typename ValueType, typename InIt, typename FwdIt, typename BidIt, typename RanIt, typename OutIt,

--- a/tests/std/include/range_algorithm_support.hpp
+++ b/tests/std/include/range_algorithm_support.hpp
@@ -36,7 +36,7 @@ namespace detail {
             return permissive();
         }
     };
-}
+} // namespace detail
 constexpr bool is_permissive = detail::Derived<int>::test();
 
 template <bool>

--- a/tests/std/tests/Dev11_0483851_vector_debug_allocator_use/test.cpp
+++ b/tests/std/tests/Dev11_0483851_vector_debug_allocator_use/test.cpp
@@ -105,4 +105,4 @@ namespace std {
     // vector<bool>
     template class vector<bool, simple_allocator<bool, empty_base>>;
     template class vector<bool, simple_allocator<bool, nonempty_base>>;
-}
+} // namespace std

--- a/tests/std/tests/Dev11_0535636_functional_overhaul/test.cpp
+++ b/tests/std/tests/Dev11_0535636_functional_overhaul/test.cpp
@@ -1989,7 +1989,7 @@ struct UserTwo {};
 namespace std {
     template <>
     struct is_placeholder<UserTwo> : integral_constant<int, 2> {};
-}
+} // namespace std
 
 struct UserBind {
     template <typename T>
@@ -2001,7 +2001,7 @@ struct UserBind {
 namespace std {
     template <>
     struct is_bind_expression<UserBind> : true_type {};
-}
+} // namespace std
 
 template <typename... Types>
 struct Pack {};

--- a/tests/std/tests/P0088R3_variant/test.cpp
+++ b/tests/std/tests/P0088R3_variant/test.cpp
@@ -7029,7 +7029,7 @@ namespace msvc {
             static_assert(sizeof(S::member) == sizeof(std::variant<std::function<S()>>));
             static_assert(sizeof(S) >= sizeof(S::member));
         }
-    }
+    } // namespace vso468746
 
     namespace vso492097 {
         // Defend against regression of VSO-492097
@@ -7066,7 +7066,7 @@ namespace msvc {
             static_assert(!std::is_copy_constructible_v<std::variant<volatile S>>);
         }
     } // namespace vso508126
-} // unnamed namespace
+} // namespace msvc
 
 int main() {
     bad_variant_access::run_test();

--- a/tests/std/tests/P0092R1_polishing_chrono/test.cpp
+++ b/tests/std/tests/P0092R1_polishing_chrono/test.cpp
@@ -28,7 +28,7 @@ namespace ties_to_even_towards_zero_positive {
     constexpr double_ms d2(2500.0);
     STATIC_ASSERT(floor<double_s>(d2).count() == 2.5);
     STATIC_ASSERT(ceil<double_s>(d2).count() == 2.5);
-}
+} // namespace ties_to_even_towards_zero_positive
 
 namespace rounds_away_from_zero_positive {
     constexpr milliseconds d1(1729);
@@ -38,7 +38,7 @@ namespace rounds_away_from_zero_positive {
     constexpr double_ms d2(1875.0);
     STATIC_ASSERT(floor<double_s>(d2).count() == 1.875);
     STATIC_ASSERT(ceil<double_s>(d2).count() == 1.875);
-}
+} // namespace rounds_away_from_zero_positive
 
 namespace ties_to_even_away_from_zero_positive {
     constexpr milliseconds d1(1500);
@@ -48,7 +48,7 @@ namespace ties_to_even_away_from_zero_positive {
     constexpr double_ms d2(1500.0);
     STATIC_ASSERT(floor<double_s>(d2).count() == 1.5);
     STATIC_ASSERT(ceil<double_s>(d2).count() == 1.5);
-}
+} // namespace ties_to_even_away_from_zero_positive
 
 namespace rounds_toward_zero_positive {
     constexpr milliseconds d1(1229);
@@ -58,7 +58,7 @@ namespace rounds_toward_zero_positive {
     constexpr double_ms d2(1250.0);
     STATIC_ASSERT(floor<double_s>(d2).count() == 1.250);
     STATIC_ASSERT(ceil<double_s>(d2).count() == 1.250);
-}
+} // namespace rounds_toward_zero_positive
 
 namespace exact_positive {
     constexpr milliseconds d1(1000);
@@ -68,7 +68,7 @@ namespace exact_positive {
     constexpr double_ms d2(1000.0);
     STATIC_ASSERT(floor<double_s>(d2).count() == 1.0);
     STATIC_ASSERT(ceil<double_s>(d2).count() == 1.0);
-}
+} // namespace exact_positive
 
 namespace zero {
     constexpr milliseconds d1(0);
@@ -78,7 +78,7 @@ namespace zero {
     constexpr double_ms d2(0.0);
     STATIC_ASSERT(floor<double_s>(d2).count() == 0.0);
     STATIC_ASSERT(ceil<double_s>(d2).count() == 0.0);
-}
+} // namespace zero
 
 namespace exact_negative {
     constexpr milliseconds d1(-1000);
@@ -88,7 +88,7 @@ namespace exact_negative {
     constexpr double_ms d2(-1000.0);
     STATIC_ASSERT(floor<double_s>(d2).count() == -1.0);
     STATIC_ASSERT(ceil<double_s>(d2).count() == -1.0);
-}
+} // namespace exact_negative
 
 namespace rounds_toward_zero_negative {
     constexpr milliseconds d1(-1229);
@@ -98,7 +98,7 @@ namespace rounds_toward_zero_negative {
     constexpr double_ms d2(-1250.0);
     STATIC_ASSERT(floor<double_s>(d2).count() == -1.250);
     STATIC_ASSERT(ceil<double_s>(d2).count() == -1.250);
-}
+} // namespace rounds_toward_zero_negative
 
 namespace ties_to_even_away_from_zero_negative {
     constexpr milliseconds d1(-1500);
@@ -108,7 +108,7 @@ namespace ties_to_even_away_from_zero_negative {
     constexpr double_ms d2(-1500.0);
     STATIC_ASSERT(floor<double_s>(d2).count() == -1.5);
     STATIC_ASSERT(ceil<double_s>(d2).count() == -1.5);
-}
+} // namespace ties_to_even_away_from_zero_negative
 
 namespace rounds_away_from_zero_negative {
     constexpr milliseconds d1(-1729);
@@ -118,7 +118,7 @@ namespace rounds_away_from_zero_negative {
     constexpr double_ms d2(-1875.0);
     STATIC_ASSERT(floor<double_s>(d2).count() == -1.875);
     STATIC_ASSERT(ceil<double_s>(d2).count() == -1.875);
-}
+} // namespace rounds_away_from_zero_negative
 
 namespace ties_to_even_towards_zero_negative {
     constexpr milliseconds d1(-2500);
@@ -128,7 +128,7 @@ namespace ties_to_even_towards_zero_negative {
     constexpr double_ms d2(-2500.0);
     STATIC_ASSERT(floor<double_s>(d2).count() == -2.5);
     STATIC_ASSERT(ceil<double_s>(d2).count() == -2.5);
-}
+} // namespace ties_to_even_towards_zero_negative
 
 namespace identical_types {
     constexpr milliseconds d1(-2500);
@@ -138,7 +138,7 @@ namespace identical_types {
     constexpr double_ms d2(-2500.0);
     STATIC_ASSERT(floor<double_ms>(d2).count() == -2500.0);
     STATIC_ASSERT(ceil<double_ms>(d2).count() == -2500.0);
-}
+} // namespace identical_types
 
 namespace increasing_precision {
     constexpr seconds d1(2);
@@ -148,7 +148,7 @@ namespace increasing_precision {
     constexpr double_s d2(2.0);
     STATIC_ASSERT(floor<double_ms>(d2).count() == 2000.0);
     STATIC_ASSERT(ceil<double_ms>(d2).count() == 2000.0);
-}
+} // namespace increasing_precision
 
 namespace floating_point_conversions {
     // double -> integral
@@ -161,7 +161,7 @@ namespace floating_point_conversions {
     STATIC_ASSERT(floor<seconds>(d2).count() == 1);
     STATIC_ASSERT(ceil<seconds>(d2).count() == 2);
     STATIC_ASSERT(round<seconds>(d2).count() == 1);
-}
+} // namespace floating_point_conversions
 
 // Make sure round() handles cases where taking half the divisor itself
 // truncates.

--- a/tests/std/tests/P0220R1_any/test.cpp
+++ b/tests/std/tests/P0220R1_any/test.cpp
@@ -2595,7 +2595,7 @@ namespace msvc {
                 any a{std::in_place_type<bad_new_type>};
             }
         } // namespace value
-    } // namespace cons
+    } // namespace ctor
 
     namespace assign {
         namespace emplace {
@@ -2606,7 +2606,7 @@ namespace msvc {
 
                 std::any{}.emplace<S>({1, 2, 3});
             }
-        } // namespace in_place
+        } // namespace emplace
 
         namespace move {
 #ifdef __clang__

--- a/tests/std/tests/P0220R1_sample/adapterator.hpp
+++ b/tests/std/tests/P0220R1_sample/adapterator.hpp
@@ -29,7 +29,7 @@ namespace impl {
         };
         template <class T>
         using second = _t<second_<T>>;
-    }
+    } // namespace meta
 
     template <class I, class Cat>
     struct associated_types : std::iterator_traits<I> {
@@ -173,7 +173,7 @@ namespace impl {
             return !(x < y);
         }
     };
-}
+} // namespace impl
 
 template <class I, class C>
 struct adapterator : impl::output<adapterator<I, C>> {

--- a/tests/std/tests/P0220R1_sample/test.cpp
+++ b/tests/std/tests/P0220R1_sample/test.cpp
@@ -72,7 +72,7 @@ namespace {
         test_source_dest<SourceCategory, bidirectional_iterator_tag>(gen);
         test_source_dest<SourceCategory, random_access_iterator_tag>(gen);
     }
-}
+} // unnamed namespace
 
 int main() {
     iota(begin(source), end(source), 0);

--- a/tests/std/tests/P0896R4_ranges_algorithm_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_algorithm_machinery/test.cpp
@@ -34,7 +34,7 @@ namespace detail {
             return permissive();
         }
     };
-}
+} // namespace detail
 constexpr bool is_permissive = detail::Derived<int>::test();
 
 template <bool>

--- a/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
@@ -1007,7 +1007,7 @@ namespace iterator_cust_swap_test {
         concept bullet1 = requires(T&& t, U&& u) {
             iter_swap(std::forward<T>(t), std::forward<U>(u));
         };
-    }
+    } // namespace adl_barrier
     using adl_barrier::bullet1;
 
     struct friend_hook {
@@ -1661,7 +1661,7 @@ namespace unreachable_sentinel_test {
 
         using std_type = std::default_sentinel_t;
         STATIC_ASSERT(evil<std_type>{} != evil<std_type>{});
-    } // regress_1029409
+    } // namespace regress_1029409
 } // namespace unreachable_sentinel_test
 
 namespace unwrap_move_only {

--- a/tests/std/tests/P0898R3_concepts/test.cpp
+++ b/tests/std/tests/P0898R3_concepts/test.cpp
@@ -50,7 +50,7 @@ namespace detail {
             return permissive();
         }
     };
-}
+} // namespace detail
 constexpr bool is_permissive = detail::Derived<int>::test();
 
 struct IncompleteClass;
@@ -821,7 +821,7 @@ namespace test_integral_concepts {
             return true;
         }
         STATIC_ASSERT(test_subsumption());
-    }
+    } // namespace subsumption
 
 #pragma warning(push)
 #pragma warning(disable : 4180) // qualifier applied to function type has no meaning; ignored
@@ -3009,7 +3009,7 @@ namespace test_predicate {
         STATIC_ASSERT(predicate<Fn, tag>);
         STATIC_ASSERT(!predicate<Fn, int>);
     }
-}
+} // namespace test_predicate
 
 { // function object
     STATIC_ASSERT(predicate<S, int>);

--- a/tests/std/tests/VSO_0000000_fancy_pointers/test.cpp
+++ b/tests/std/tests/VSO_0000000_fancy_pointers/test.cpp
@@ -273,7 +273,7 @@ namespace std {
         typedef Val& reference;
         typedef fancy_pointer<Val> pointer;
     };
-}
+} // namespace std
 
 template <typename T>
 struct always_false : std::false_type {};

--- a/tests/std/tests/VSO_0000000_instantiate_containers/test.cpp
+++ b/tests/std/tests/VSO_0000000_instantiate_containers/test.cpp
@@ -699,7 +699,7 @@ namespace std {
     inline const T* cbegin(valarray<T>& arr) {
         return begin(arr); // unqualified
     }
-}
+} // namespace std
 
 void valarray_test() {
     valarray<int> value{};

--- a/tests/std/tests/VSO_0000000_instantiate_type_traits/test.cpp
+++ b/tests/std/tests/VSO_0000000_instantiate_type_traits/test.cpp
@@ -46,7 +46,7 @@ namespace detail {
     constexpr bool test = false;
     template <typename T>
     constexpr bool test<T, std::void_t<decltype(evil(T{}))>> = true;
-}
+} // namespace detail
 
 constexpr bool has_evil_extension = detail::test<>;
 #endif // _HAS_CXX17

--- a/tests/std/tests/VSO_0000000_type_traits/test.cpp
+++ b/tests/std/tests/VSO_0000000_type_traits/test.cpp
@@ -842,7 +842,7 @@ struct Immovable {
 namespace std {
     template <>
     void swap(Immovable&, Immovable&) {}
-}
+} // namespace std
 
 #endif // _HAS_CXX17
 
@@ -1270,7 +1270,7 @@ namespace {
                 return permissive();
             }
         };
-    }
+    } // namespace detail
     constexpr bool is_permissive = detail::Derived<int>::test();
 
     struct move_only {

--- a/tests/std/tests/VSO_0121440_is_iterator_iterator_traits/test.cpp
+++ b/tests/std/tests/VSO_0121440_is_iterator_iterator_traits/test.cpp
@@ -52,7 +52,7 @@ namespace std {
         using pointer           = int*;
         using reference         = int&;
     };
-}
+} // namespace std
 
 // Also test that forming iterator_traits<void *> does not cause a hard, not SFINAE-able, error
 template <class Ty, enable_if_t<is_same_v<Ty, void*>, int> = 0>

--- a/tests/std/tests/VSO_0180466_algorithm_overhauls/test.cpp
+++ b/tests/std/tests/VSO_0180466_algorithm_overhauls/test.cpp
@@ -139,7 +139,7 @@ namespace test_std_equal {
         equal_should_respect_pred();
         test_all_numeric_types<test_equal_should_return_correct_numeric_result>();
     }
-}
+} // namespace test_std_equal
 
 namespace test_lexicographical_compare {
     // examples in sort order
@@ -341,7 +341,7 @@ namespace test_lexicographical_compare {
         test_changing_pred_does_not_change_length_behavior();
         test_all_numeric_types<test_lex_compare_should_return_correct_numeric_result>();
     }
-}
+} // namespace test_lexicographical_compare
 
 namespace test_std_copy {
     void test() {
@@ -350,7 +350,7 @@ namespace test_std_copy {
         copy(input.begin(), input.end(), target.begin() + 1);
         assert((target == array<int, 4>{{42, 1729, 1730, 45}}));
     }
-}
+} // namespace test_std_copy
 
 namespace test_std_move {
     void test() {
@@ -359,7 +359,7 @@ namespace test_std_move {
         move(input.begin(), input.end(), target.begin() + 1);
         assert((target == array<move_only, 4>{{{42}, {1729}, {1730}, {45}}}));
     }
-}
+} // namespace test_std_move
 
 namespace test_std_copy_backward {
     void test() {
@@ -368,7 +368,7 @@ namespace test_std_copy_backward {
         copy_backward(input.begin(), input.end(), target.end());
         assert((target == array<int, 4>{{42, 43, 1729, 1730}}));
     }
-}
+} // namespace test_std_copy_backward
 
 namespace test_std_move_backward {
     void test() {
@@ -377,7 +377,7 @@ namespace test_std_move_backward {
         move_backward(input.begin(), input.end(), target.end());
         assert((target == array<move_only, 4>{{{42}, {43}, {1729}, {1730}}}));
     }
-}
+} // namespace test_std_move_backward
 
 int main() {
     test_std_equal::test();

--- a/tests/std/tests/VSO_0224478_scoped_allocator/test.cpp
+++ b/tests/std/tests/VSO_0224478_scoped_allocator/test.cpp
@@ -149,7 +149,7 @@ namespace test_LWG_2782 {
     STATIC_ASSERT(!is_constructible_v<SA, SM>);
     STATIC_ASSERT(is_constructible_v<SAA, scoped_allocator_adaptor<allocator<float>, allocator<int>>>);
     STATIC_ASSERT(!is_constructible_v<SAA, SMA>);
-}
+} // namespace test_LWG_2782
 
 int main() {
     test_case_VSO_129349_non_default_constructible_allocators();

--- a/tests/std/tests/VSO_0961751_hash_range_erase/test.cpp
+++ b/tests/std/tests/VSO_0961751_hash_range_erase/test.cpp
@@ -283,7 +283,7 @@ namespace std {
             return e.memoized_hash;
         }
     };
-}
+} // namespace std
 
 struct erase_bucket_consistency_fixture {
     struct liveness_empty_asserter {


### PR DESCRIPTION
Now that LLVM-39247 has been fixed in Clang 10, we can enable this setting again. This PR does so in several Libs clang-format files which had a LLVM-39247 comment.

I've changed the end comments on unnamed namespaces from `// namespace`, which clang-format adds automatically, to `// unnamed namespace` which more clearly indicates that someone didn't simply forget to finish typing the comment.

[This is a dual of internal MSVC-PR-239549.]

<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
