### PR TITLE
Run format validation as its own stage and enable /BE

### DIFF
--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -50,10 +50,11 @@ if (-not [string]::IsNullOrEmpty($AdminUserPassword)) {
 
 $Workloads = @(
   'Microsoft.VisualStudio.Component.VC.CLI.Support',
-  'Microsoft.VisualStudio.Component.VC.Tools.x86.x64 ',
-  'Microsoft.VisualStudio.Component.VC.Tools.ARM64 ',
-  'Microsoft.VisualStudio.Component.VC.Tools.ARM ',
-  'Microsoft.VisualStudio.Component.Windows10SDK.18362 '
+  'Microsoft.VisualStudio.Component.VC.CoreIde',
+  'Microsoft.VisualStudio.Component.VC.Tools.x86.x64',
+  'Microsoft.VisualStudio.Component.VC.Tools.ARM64',
+  'Microsoft.VisualStudio.Component.VC.Tools.ARM',
+  'Microsoft.VisualStudio.Component.Windows10SDK.18362'
 )
 
 $ReleaseInPath = 'Preview'

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -64,7 +64,7 @@ $LlvmUrl = 'https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.
 $NinjaUrl = 'https://github.com/ninja-build/ninja/releases/download/v1.10.0/ninja-win.zip'
 $PythonUrl = 'https://www.python.org/ftp/python/3.8.2/python-3.8.2-amd64.exe'
 
-$CudaUrl = 'https://developer.nvidia.com/compute/cuda/10.1/Prod/local_installers/cuda_10.1.105_418.96_win10.exe'
+$CudaUrl = 'https://developer.download.nvidia.com/compute/cuda/10.1/Prod/local_installers/cuda_10.1.243_426.00_win10.exe'
 $CudaFeatures = 'nvcc_10.1 cuobjdump_10.1 nvprune_10.1 cupti_10.1 gpu_library_advisor_10.1 memcheck_10.1 ' + `
   'nvdisasm_10.1 nvprof_10.1 visual_profiler_10.1 visual_studio_integration_10.1 cublas_10.1 cublas_dev_10.1 ' + `
   'cudart_10.1 cufft_10.1 cufft_dev_10.1 curand_10.1 curand_dev_10.1 cusolver_10.1 cusolver_dev_10.1 cusparse_10.1 ' + `

--- a/azure-devops/run-build.yml
+++ b/azure-devops/run-build.yml
@@ -61,7 +61,7 @@ jobs:
         workingDirectory: $(Build.ArtifactStagingDirectory)/${{ parameters.targetPlatform }}
         script: |
           call "%PROGRAMFILES(X86)%\Microsoft Visual Studio\2019\Preview\Common7\Tools\VsDevCmd.bat" ^
-          -arch=${{ parameters.vsDevCmdArch }} -host_arch=${{ parameters.vsDevCmdArch }} -no_logo
+          -host_arch=${{ parameters.vsDevCmdArch }} -arch=${{ parameters.vsDevCmdArch }} -no_logo
           ctest -V
     - task: PublishTestResults@2
       displayName: 'Publish libcxx Tests'

--- a/azure-devops/run-build.yml
+++ b/azure-devops/run-build.yml
@@ -12,7 +12,7 @@ jobs:
   steps:
     - checkout: self
       clean: true
-      submodules: recursive
+      submodules: true
     - task: Cache@2
       displayName: Cache vcpkg
       timeoutInMinutes: 10
@@ -35,31 +35,6 @@ jobs:
         vcpkgArguments: 'boost-math'
         vcpkgDirectory: '$(vcpkgLocation)'
         vcpkgTriplet: '${{ parameters.targetPlatform }}-windows'
-    - task: run-cmake@0
-      displayName: 'Build Support Tools'
-      timeoutInMinutes: 2
-      condition: eq('${{ parameters.targetPlatform }}', 'x64')
-      inputs:
-        cmakeListsTxtPath: 'tools/CMakeSettings.json'
-        useVcpkgToolchainFile: true
-        configurationRegexFilter: '.*x64-Release.*'
-        buildDirectory: $(Build.ArtifactStagingDirectory)/tools
-    - task: BatchScript@1
-      displayName: 'Enforce clang-format'
-      timeoutInMinutes: 60
-      condition: eq('${{ parameters.targetPlatform }}', 'x64')
-      inputs:
-        filename: 'azure-devops/enforce-clang-format.cmd'
-        failOnStandardError: true
-        arguments: '$(Build.ArtifactStagingDirectory)/tools/parallelize/parallelize.exe'
-    - task: BatchScript@1
-      displayName: 'Validate Files'
-      timeoutInMinutes: 2
-      condition: eq('${{ parameters.targetPlatform }}', 'x64')
-      inputs:
-        filename: 'azure-devops/validate-files.cmd'
-        failOnStandardError: true
-        arguments: '$(Build.ArtifactStagingDirectory)/tools/validate/validate.exe'
     - task: PowerShell@2
       displayName: 'Get Test Parallelism'
       timeoutInMinutes: 2

--- a/azure-devops/run-build.yml
+++ b/azure-devops/run-build.yml
@@ -5,7 +5,7 @@ jobs:
 - job: ${{ parameters.targetPlatform }}
   timeoutInMinutes: 360
   pool:
-    name: StlBuild-2020-03-28
+    name: $(agentPool)
 
   variables:
     vcpkgLocation: '$(Build.SourcesDirectory)/vcpkg'

--- a/azure-devops/run-build.yml
+++ b/azure-devops/run-build.yml
@@ -53,20 +53,16 @@ jobs:
         useVcpkgToolchainFile: true
         cmakeAppendedArgs: |
           -G Ninja -DBUILD_TESTING=TRUE -DENABLE_XUNIT_OUTPUT=TRUE -DADDITIONAL_LIT_FLAGS=-j$(testParallelism)
-    - task: PowerShell@2
+    - task: CmdLine@2
       displayName: 'Run Tests'
       timeoutInMinutes: 120
       condition: in('${{ parameters.targetPlatform }}', 'x64', 'x86')
       inputs:
         workingDirectory: $(Build.ArtifactStagingDirectory)/${{ parameters.targetPlatform }}
-        targetType: inline
         script: |
-          Add-Content -Path ./run-tests.cmd -Value "set PATH=$(split-path (get-command ctest).source);%PATH%"
-          Add-Content -Path ./run-tests.cmd -Value "set PATH=$(split-path (get-command clang-cl).source);%PATH%"
-          $currentDir = "$((Get-Item -Path "./").FullName)"
-          Add-Content -Path ./run-tests.cmd -Value "cd $currentDir"
-          Add-Content -Path ./run-tests.cmd -Value "ctest -V"
-          $(vcpkgLocation)/vcpkg.exe env --triplet ${{ parameters.targetPlatform }}-windows "$currentDir/run-tests.cmd"
+          call "%PROGRAMFILES(X86)%\Microsoft Visual Studio\2019\Preview\Common7\Tools\VsDevCmd.bat" ^
+          -arch=${{ parameters.vsDevCmdArch }} -host_arch=${{ parameters.vsDevCmdArch }} -no_logo
+          ctest -V
     - task: PublishTestResults@2
       displayName: 'Publish libcxx Tests'
       timeoutInMinutes: 10

--- a/azure-devops/sysprep.ps1
+++ b/azure-devops/sysprep.ps1
@@ -1,0 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+Write-Output 'Running sysprep'
+& C:\Windows\system32\sysprep\sysprep.exe /oobe /generalize /shutdown

--- a/azure-devops/sysprep.ps1
+++ b/azure-devops/sysprep.ps1
@@ -1,6 +1,5 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-#
 
 Write-Output 'Running sysprep'
 & C:\Windows\system32\sysprep\sysprep.exe /oobe /generalize /shutdown

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,7 @@
 # Build STL targeting x86, x64, arm, arm64
 
 variables:
-  agentPool: 'StlBuild-2020-04-03-2'
+  agentPool: 'StlBuild-2020-04-04-2'
 
 stages:
   - stage: Code_Format
@@ -23,6 +23,12 @@ stages:
           - script: |
               call "%PROGRAMFILES(X86)%\Microsoft Visual Studio\2019\Preview\Common7\Tools\VsDevCmd.bat" ^
               -arch=amd64 -host_arch=amd64 -no_logo
+              set
+              where cpfe.dll
+              dir "%PROGRAMFILES(X86)%\Microsoft Visual Studio\2019\Preview\Common7"
+              dir "%PROGRAMFILES(X86)%\Microsoft Visual Studio\2019\Preview\Common7\IDE"
+              dir "%PROGRAMFILES(X86)%\Microsoft Visual Studio\2019\Preview\Common7\IDE\VC"
+              dir "%PROGRAMFILES(X86)%\Microsoft Visual Studio\2019\Preview\Common7\IDE\VC\VCPackages"
               cmake -G Ninja -DCMAKE_CXX_COMPILER=cl -DCMAKE_BUILD_TYPE=Release ^
               -S $(Build.SourcesDirectory)\tools -B $(Build.ArtifactStagingDirectory)\tools
               cd $(Build.ArtifactStagingDirectory)\tools

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,9 +4,10 @@
 # Build STL targeting x86, x64, arm, arm64
 
 stages:
-  variables:
+  variables: {
     agentPool: 'StlBuild-2020-03-28'
     vcpkgLocation: '$(Build.SourcesDirectory)/vcpkg'
+  }
 
   - stage: Code_Format_Validation
     displayName: "Code Format Validation"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,12 +3,11 @@
 
 # Build STL targeting x86, x64, arm, arm64
 
-stages:
-  variables: {
-    agentPool: 'StlBuild-2020-03-28'
-    vcpkgLocation: '$(Build.SourcesDirectory)/vcpkg'
-  }
+variables:
+  agentPool: 'StlBuild-2020-03-28'
+  vcpkgLocation: '$(Build.SourcesDirectory)/vcpkg'
 
+stages:
   - stage: Code_Format_Validation
     displayName: "Code Format Validation"
     jobs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,12 +23,6 @@ stages:
           - script: |
               call "%PROGRAMFILES(X86)%\Microsoft Visual Studio\2019\Preview\Common7\Tools\VsDevCmd.bat" ^
               -arch=amd64 -host_arch=amd64 -no_logo
-              set
-              where cpfe.dll
-              dir "%PROGRAMFILES(X86)%\Microsoft Visual Studio\2019\Preview\Common7"
-              dir "%PROGRAMFILES(X86)%\Microsoft Visual Studio\2019\Preview\Common7\IDE"
-              dir "%PROGRAMFILES(X86)%\Microsoft Visual Studio\2019\Preview\Common7\IDE\VC"
-              dir "%PROGRAMFILES(X86)%\Microsoft Visual Studio\2019\Preview\Common7\IDE\VC\VCPackages"
               cmake -G Ninja -DCMAKE_CXX_COMPILER=cl -DCMAKE_BUILD_TYPE=Release ^
               -S $(Build.SourcesDirectory)\tools -B $(Build.ArtifactStagingDirectory)\tools
               cd $(Build.ArtifactStagingDirectory)\tools

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,19 +3,67 @@
 
 # Build STL targeting x86, x64, arm, arm64
 
-jobs:
-- template: azure-devops/run-build.yml
-  parameters:
-    targetPlatform: x86
+stages:
+  - stage: Code_Format_Validation
+    displayName: "Code Format Validation"
+    jobs:
+      - job: Run_Code_Format_Validation
+        timeoutInMinutes: 90
+        displayName: "Run Code Format Validation"
+        pool:
+          name: StlBuild-2020-03-28
 
-- template: azure-devops/run-build.yml
-  parameters:
-    targetPlatform: x64
+        variables:
+          vcpkgLocation: '$(Build.SourcesDirectory)/vcpkg'
+        steps:
+          - checkout: self
+            clean: true
+            submodules: true
+          - task: run-vcpkg@0
+            displayName: 'Setup environment variables for run-cmake'
+            timeoutInMinutes: 10
+            inputs:
+              setupOnly: true
+              vcpkgArguments: 'boost-build'
+              vcpkgDirectory: '$(vcpkgLocation)'
+              vcpkgTriplet: 'x64-windows'
+          - task: run-cmake@0
+            displayName: 'Build Support Tools'
+            timeoutInMinutes: 2
+            inputs:
+              cmakeListsTxtPath: 'tools/CMakeSettings.json'
+              useVcpkgToolchainFile: true
+              configurationRegexFilter: '.*x64-Release.*'
+              buildDirectory: $(Build.ArtifactStagingDirectory)/tools
+          - task: BatchScript@1
+            displayName: 'Enforce clang-format'
+            timeoutInMinutes: 60
+            inputs:
+              filename: 'azure-devops/enforce-clang-format.cmd'
+              failOnStandardError: true
+              arguments: '$(Build.ArtifactStagingDirectory)/tools/parallelize/parallelize.exe'
+          - task: BatchScript@1
+            displayName: 'Validate Files'
+            timeoutInMinutes: 2
+            inputs:
+              filename: 'azure-devops/validate-files.cmd'
+              failOnStandardError: true
+              arguments: '$(Build.ArtifactStagingDirectory)/tools/validate/validate.exe'
+  - stage: Build_And_Test
+    displayName: "Build and Test the STL"
+    jobs:
+      - template: azure-devops/run-build.yml
+        parameters:
+          targetPlatform: x86
 
-- template: azure-devops/run-build.yml
-  parameters:
-    targetPlatform: arm
+      - template: azure-devops/run-build.yml
+        parameters:
+          targetPlatform: x64
 
-- template: azure-devops/run-build.yml
-  parameters:
-    targetPlatform: arm64
+      - template: azure-devops/run-build.yml
+        parameters:
+          targetPlatform: arm
+
+      - template: azure-devops/run-build.yml
+        parameters:
+          targetPlatform: arm64

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,7 +22,7 @@ stages:
             submodules: false
           - script: |
               call "%PROGRAMFILES(X86)%\Microsoft Visual Studio\2019\Preview\Common7\Tools\VsDevCmd.bat" ^
-              -arch=amd64 -host_arch=amd64 -no_logo
+              -host_arch=amd64 -arch=amd64 -no_logo
               cmake -G Ninja -DCMAKE_CXX_COMPILER=cl -DCMAKE_BUILD_TYPE=Release ^
               -S $(Build.SourcesDirectory)\tools -B $(Build.ArtifactStagingDirectory)\tools
               cd $(Build.ArtifactStagingDirectory)\tools

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,21 +4,25 @@
 # Build STL targeting x86, x64, arm, arm64
 
 stages:
+  variables:
+    agentPool: StlBuild-2020-03-28
+    vcpkgLocation: '$(Build.SourcesDirectory)/vcpkg'
+
   - stage: Code_Format_Validation
     displayName: "Code Format Validation"
     jobs:
       - job: Run_Code_Format_Validation
         timeoutInMinutes: 90
-        displayName: "Run Code Format Validation"
+        displayName: "Run"
         pool:
-          name: StlBuild-2020-03-28
+          name: $(agentPool)
 
-        variables:
-          vcpkgLocation: '$(Build.SourcesDirectory)/vcpkg'
         steps:
           - checkout: self
             clean: true
             submodules: true
+          # TRANSITION: Once issue #19 or #33 is resolved on https://github.com/lukka/CppBuildTasks we can drop
+          # building boost-build here.
           - task: run-vcpkg@0
             displayName: 'Setup environment variables for run-cmake'
             timeoutInMinutes: 10

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,7 @@ stages:
     jobs:
       - job: Run_Code_Format_Validation
         timeoutInMinutes: 90
-        displayName: "Run"
+        displayName: "Run Validation"
         pool:
           name: $(agentPool)
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,7 +19,7 @@ stages:
         steps:
           - checkout: self
             clean: true
-            submodules: true
+            submodules: false
           - script: |
               call "%PROGRAMFILES(X86)%\Microsoft Visual Studio\2019\Preview\Common7\Tools\VsDevCmd.bat" ^
               -arch=amd64 -host_arch=amd64 -no_logo

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,15 +5,14 @@
 
 variables:
   agentPool: 'StlBuild-2020-03-28'
-  vcpkgLocation: '$(Build.SourcesDirectory)/vcpkg'
 
 stages:
   - stage: Code_Format_Validation
-    displayName: "Code Format Validation"
+    displayName: 'Code Format Validation'
     jobs:
       - job: Run_Code_Format_Validation
         timeoutInMinutes: 90
-        displayName: "Run Validation"
+        displayName: 'Run Validation'
         pool:
           name: $(agentPool)
 
@@ -21,24 +20,14 @@ stages:
           - checkout: self
             clean: true
             submodules: true
-          # TRANSITION: Once issue #19 or #33 is resolved on https://github.com/lukka/CppBuildTasks we can drop
-          # building boost-build here.
-          - task: run-vcpkg@0
-            displayName: 'Setup environment variables for run-cmake'
-            timeoutInMinutes: 10
-            inputs:
-              setupOnly: true
-              vcpkgArguments: 'boost-build'
-              vcpkgDirectory: '$(vcpkgLocation)'
-              vcpkgTriplet: 'x64-windows'
-          - task: run-cmake@0
+          - script: |
+              call "%PROGRAMFILES(X86)%\Microsoft Visual Studio\2019\Preview\Common7\Tools\VsDevCmd.bat" ^
+              -arch=amd64 -host_arch=amd64 -no_logo
+              cmake -G Ninja -DCMAKE_CXX_COMPILER=cl -DCMAKE_BUILD_TYPE=Release ^
+              -S $(Build.SourcesDirectory)\tools -B $(Build.ArtifactStagingDirectory)\tools
+              cd $(Build.ArtifactStagingDirectory)\tools
+              cmake --build .
             displayName: 'Build Support Tools'
-            timeoutInMinutes: 2
-            inputs:
-              cmakeListsTxtPath: 'tools/CMakeSettings.json'
-              useVcpkgToolchainFile: true
-              configurationRegexFilter: '.*x64-Release.*'
-              buildDirectory: $(Build.ArtifactStagingDirectory)/tools
           - task: BatchScript@1
             displayName: 'Enforce clang-format'
             timeoutInMinutes: 60
@@ -54,20 +43,24 @@ stages:
               failOnStandardError: true
               arguments: '$(Build.ArtifactStagingDirectory)/tools/validate/validate.exe'
   - stage: Build_And_Test
-    displayName: "Build and Test the STL"
+    displayName: 'Build and Test'
     jobs:
       - template: azure-devops/run-build.yml
         parameters:
           targetPlatform: x86
+          vsDevCmdArch: x86
 
       - template: azure-devops/run-build.yml
         parameters:
           targetPlatform: x64
+          vsDevCmdArch: amd64
 
       - template: azure-devops/run-build.yml
         parameters:
           targetPlatform: arm
+          vsDevCmdArch: arm
 
       - template: azure-devops/run-build.yml
         parameters:
           targetPlatform: arm64
+          vsDevCmdArch: arm64

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,15 +4,15 @@
 # Build STL targeting x86, x64, arm, arm64
 
 variables:
-  agentPool: 'StlBuild-2020-03-28'
+  agentPool: 'StlBuild-2020-04-03-2'
 
 stages:
-  - stage: Code_Format_Validation
-    displayName: 'Code Format Validation'
+  - stage: Code_Format
+    displayName: 'Code Format'
     jobs:
-      - job: Run_Code_Format_Validation
+      - job: Code_Format_Validation
         timeoutInMinutes: 90
-        displayName: 'Run Validation'
+        displayName: 'Validation'
         pool:
           name: $(agentPool)
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,7 @@
 # Build STL targeting x86, x64, arm, arm64
 
 variables:
-  agentPool: 'StlBuild-2020-04-04-2'
+  agentPool: 'StlBuild-2020-04-04-3'
 
 stages:
   - stage: Code_Format

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,7 +5,7 @@
 
 stages:
   variables:
-    agentPool: StlBuild-2020-03-28
+    agentPool: 'StlBuild-2020-03-28'
     vcpkgLocation: '$(Build.SourcesDirectory)/vcpkg'
 
   - stage: Code_Format_Validation

--- a/tests/std/expected_results.txt
+++ b/tests/std/expected_results.txt
@@ -1,5 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-# TRANSITION: This test causes the compiler to either hang forever or ICE
+# TRANSITION: These tests cause the compiler to either hang forever or ICE
+tests/GH_000545_include_compare:15 SKIP
 tests/GH_000545_include_compare:16 SKIP

--- a/tests/std/expected_results.txt
+++ b/tests/std/expected_results.txt
@@ -1,2 +1,5 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# TRANSITION: This test causes the compiler to either hang forever or ICE
+tests/GH_000545_include_compare:16 SKIP

--- a/tests/std/expected_results.txt
+++ b/tests/std/expected_results.txt
@@ -1,6 +1,13 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-# TRANSITION: These tests cause the compiler to either hang forever or ICE
+# TRANSITION, VSO-1093670 "Memory corruption in EDG when processing multiple TUs"
 tests/GH_000545_include_compare:15 SKIP
 tests/GH_000545_include_compare:16 SKIP
+tests/P0607R0_inline_variables:19 SKIP
+tests/P0607R0_inline_variables:20 SKIP
+tests/P0607R0_inline_variables:21 SKIP
+
+# TRANSITION, GH-697 "We should have means of collecting compiler and test crash dumps"
+# The ICE we are skipping this test because of is not easily reproducible we need to collect dumps
+tests/VSO_0000000_string_view_idl:15 SKIP

--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.cpp
@@ -51,7 +51,7 @@ int main() {} // COMPILE-ONLY
 #endif
 #endif
 
-#if defined(__EDG__) || (defined(__clang__) && __clang_major__ < 10) // Clang 9 and EDG don't yet implement P1771R1
+#if defined(__clang__) && __clang_major__ < 10 // Clang 9 doesn't yet implement P1771R1
 #if __has_cpp_attribute(nodiscard) != 201603L
 #error __has_cpp_attribute(nodiscard) is not 201603L
 #endif
@@ -160,7 +160,8 @@ STATIC_ASSERT(__cpp_conditional_explicit == 201806L);
 
 #ifndef __cpp_constexpr
 #error __cpp_constexpr is not defined
-#elif _HAS_CXX20 && defined(__clang__) && __clang_major__ >= 10 // TRANSITION, VSO-951133 and VSO-951142
+#elif _HAS_CXX20 \
+    && ((defined(__clang__) && __clang_major__ >= 10) || defined(__EDG__)) // TRANSITION, VSO-951133 and VSO-951142
 #if __cpp_constexpr != 201907L
 #error __cpp_constexpr is not 201907L
 #else
@@ -263,7 +264,7 @@ STATIC_ASSERT(__cpp_fold_expressions == 201603L);
 
 #ifndef __cpp_generic_lambdas
 #error __cpp_generic_lambdas is not defined
-#elif _HAS_CXX20 && defined(__clang__) && __clang_major__ >= 10 // TRANSITION, VSO-951133 and EDG
+#elif _HAS_CXX20 && ((defined(__clang__) && __clang_major__ >= 10) || defined(__EDG__)) // TRANSITION, VSO-951133
 #if __cpp_generic_lambdas != 201707L
 #error __cpp_generic_lambdas is not 201707L
 #else
@@ -333,15 +334,9 @@ STATIC_ASSERT(__cpp_impl_destroying_delete == 201806L);
 #endif
 #endif
 
-#if _HAS_CXX20 && (!defined(__clang__) || __clang_major__ >= 10)
+#if _HAS_CXX20 && ((!defined(__clang__) || __clang_major__ >= 10) || defined(__EDG__))
 #ifndef __cpp_impl_three_way_comparison
 #error __cpp_impl_three_way_comparison is not defined
-#elif defined(__EDG__) // EDG does not yet implement P1630R1 or P1186R3 so they still report the old value.
-#if __cpp_impl_three_way_comparison != 201711L
-#error __cpp_impl_three_way_comparison is not 201711L
-#else
-STATIC_ASSERT(__cpp_impl_three_way_comparison == 201711L);
-#endif
 #else
 #if __cpp_impl_three_way_comparison != 201907L
 #error __cpp_impl_three_way_comparison is not 201907L
@@ -734,7 +729,7 @@ STATIC_ASSERT(__cpp_lib_apply == 201603L);
 #endif
 #endif
 
-#if _HAS_CXX20
+#if _HAS_CXX20 && !defined(__EDG__)
 #ifndef __cpp_lib_array_constexpr
 #error __cpp_lib_array_constexpr is not defined
 #elif __cpp_lib_array_constexpr != 201806L
@@ -1045,12 +1040,22 @@ STATIC_ASSERT(__cpp_lib_endian == 201907L);
 #endif
 
 #if _HAS_CXX20
+#ifdef __EDG__
+#ifndef __cpp_lib_erase_if
+#error __cpp_lib_erase_if is not defined
+#elif __cpp_lib_erase_if != 201811L
+#error __cpp_lib_erase_if is not 201811L
+#else
+STATIC_ASSERT(__cpp_lib_erase_if == 201811L);
+#endif
+#else // ^^^ EDG / Clang and MSVC vvv
 #ifndef __cpp_lib_erase_if
 #error __cpp_lib_erase_if is not defined
 #elif __cpp_lib_erase_if != 202002L
 #error __cpp_lib_erase_if is not 202002L
 #else
 STATIC_ASSERT(__cpp_lib_erase_if == 202002L);
+#endif
 #endif
 #else
 #ifdef __cpp_lib_erase_if
@@ -1197,12 +1202,22 @@ STATIC_ASSERT(__cpp_lib_incomplete_container_elements == 201505L);
 #endif
 
 #if _HAS_CXX20
+#ifdef __EDG__
+#ifndef __cpp_lib_int_pow2
+#error __cpp_lib_int_pow2 is not defined
+#elif __cpp_lib_int_pow2 != 201806L
+#error __cpp_lib_int_pow2 is not 201806L
+#else
+STATIC_ASSERT(__cpp_lib_int_pow2 == 201806L);
+#endif
+#else // ^^^ EDG / Clang and MSVC vvv
 #ifndef __cpp_lib_int_pow2
 #error __cpp_lib_int_pow2 is not defined
 #elif __cpp_lib_int_pow2 != 202002L
 #error __cpp_lib_int_pow2 is not 202002L
 #else
 STATIC_ASSERT(__cpp_lib_int_pow2 == 202002L);
+#endif
 #endif
 #else
 #ifdef __cpp_lib_int_pow2
@@ -1655,12 +1670,22 @@ STATIC_ASSERT(__cpp_lib_shift == 201806L);
 #endif
 
 #if _HAS_CXX20
+#ifdef __EDG__
+#ifndef __cpp_lib_span
+#error __cpp_lib_span is not defined
+#elif __cpp_lib_span != 201902L
+#error __cpp_lib_span is not 201902L
+#else
+STATIC_ASSERT(__cpp_lib_span == 201902L);
+#endif
+#else // ^^^ EDG / Clang and MSVC vvv
 #ifndef __cpp_lib_span
 #error __cpp_lib_span is not defined
 #elif __cpp_lib_span != 202002L
 #error __cpp_lib_span is not 202002L
 #else
 STATIC_ASSERT(__cpp_lib_span == 202002L);
+#endif
 #endif
 #else
 #ifdef __cpp_lib_span

--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.cpp
@@ -160,7 +160,8 @@ STATIC_ASSERT(__cpp_conditional_explicit == 201806L);
 
 #ifndef __cpp_constexpr
 #error __cpp_constexpr is not defined
-#elif _HAS_CXX20 && (defined(__clang__) && __clang_major__ >= 10 || defined(__EDG__)) // TRANSITION, VSO-951133 and VSO-951142
+#elif _HAS_CXX20 \
+    && (defined(__clang__) && __clang_major__ >= 10 || defined(__EDG__)) // TRANSITION, VSO-951133 and VSO-951142
 #if __cpp_constexpr != 201907L
 #error __cpp_constexpr is not 201907L
 #else

--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.cpp
@@ -51,7 +51,7 @@ int main() {} // COMPILE-ONLY
 #endif
 #endif
 
-#if defined(__EDG__) || (defined(__clang__) && __clang_major__ < 10) // Clang 9 and EDG don't yet implement P1771R1
+#if defined(__clang__) && __clang_major__ < 10 // Clang 9 doesn't yet implement P1771R1
 #if __has_cpp_attribute(nodiscard) != 201603L
 #error __has_cpp_attribute(nodiscard) is not 201603L
 #endif
@@ -160,7 +160,7 @@ STATIC_ASSERT(__cpp_conditional_explicit == 201806L);
 
 #ifndef __cpp_constexpr
 #error __cpp_constexpr is not defined
-#elif _HAS_CXX20 && defined(__clang__) && __clang_major__ >= 10 // TRANSITION, VSO-951133 and VSO-951142
+#elif _HAS_CXX20 && (defined(__clang__) && __clang_major__ >= 10 || defined(__EDG__)) // TRANSITION, VSO-951133 and VSO-951142
 #if __cpp_constexpr != 201907L
 #error __cpp_constexpr is not 201907L
 #else
@@ -263,7 +263,7 @@ STATIC_ASSERT(__cpp_fold_expressions == 201603L);
 
 #ifndef __cpp_generic_lambdas
 #error __cpp_generic_lambdas is not defined
-#elif _HAS_CXX20 && defined(__clang__) && __clang_major__ >= 10 // TRANSITION, VSO-951133 and EDG
+#elif _HAS_CXX20 && ((defined(__clang__) && __clang_major__ >= 10) || defined(__EDG__)) // TRANSITION, VSO-951133
 #if __cpp_generic_lambdas != 201707L
 #error __cpp_generic_lambdas is not 201707L
 #else
@@ -352,12 +352,6 @@ STATIC_ASSERT(__cpp_impl_destroying_delete == 201806L);
 #if _HAS_CXX20 && (!defined(__clang__) || __clang_major__ >= 10)
 #ifndef __cpp_impl_three_way_comparison
 #error __cpp_impl_three_way_comparison is not defined
-#elif defined(__EDG__) // EDG does not yet implement P1630R1 or P1186R3 so they still report the old value.
-#if __cpp_impl_three_way_comparison != 201711L
-#error __cpp_impl_three_way_comparison is not 201711L
-#else
-STATIC_ASSERT(__cpp_impl_three_way_comparison == 201711L);
-#endif
 #else
 #if __cpp_impl_three_way_comparison != 201907L
 #error __cpp_impl_three_way_comparison is not 201907L

--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.cpp
@@ -51,7 +51,7 @@ int main() {} // COMPILE-ONLY
 #endif
 #endif
 
-#if defined(__clang__) && __clang_major__ < 10 // Clang 9 doesn't yet implement P1771R1
+#if defined(__EDG__) || (defined(__clang__) && __clang_major__ < 10) // Clang 9 and EDG don't yet implement P1771R1
 #if __has_cpp_attribute(nodiscard) != 201603L
 #error __has_cpp_attribute(nodiscard) is not 201603L
 #endif
@@ -160,8 +160,7 @@ STATIC_ASSERT(__cpp_conditional_explicit == 201806L);
 
 #ifndef __cpp_constexpr
 #error __cpp_constexpr is not defined
-#elif _HAS_CXX20 \
-    && ((defined(__clang__) && __clang_major__ >= 10) || defined(__EDG__)) // TRANSITION, VSO-951133 and VSO-951142
+#elif _HAS_CXX20 && defined(__clang__) && __clang_major__ >= 10 // TRANSITION, VSO-951133 and VSO-951142
 #if __cpp_constexpr != 201907L
 #error __cpp_constexpr is not 201907L
 #else
@@ -264,7 +263,7 @@ STATIC_ASSERT(__cpp_fold_expressions == 201603L);
 
 #ifndef __cpp_generic_lambdas
 #error __cpp_generic_lambdas is not defined
-#elif _HAS_CXX20 && ((defined(__clang__) && __clang_major__ >= 10) || defined(__EDG__)) // TRANSITION, VSO-951133
+#elif _HAS_CXX20 && defined(__clang__) && __clang_major__ >= 10 // TRANSITION, VSO-951133 and EDG
 #if __cpp_generic_lambdas != 201707L
 #error __cpp_generic_lambdas is not 201707L
 #else
@@ -334,9 +333,31 @@ STATIC_ASSERT(__cpp_impl_destroying_delete == 201806L);
 #endif
 #endif
 
-#if _HAS_CXX20 && ((!defined(__clang__) || __clang_major__ >= 10) || defined(__EDG__))
+#if defined(__clang__) || defined(__EDG__) // TRANSITION, VS 2019 16.7p1
+#if defined(__clang__) || _HAS_CXX20 && !defined(__EDG__) // TRANSITION, EDG
+#ifndef __cpp_impl_destroying_delete
+#error __cpp_impl_destroying_delete is not defined
+#elif __cpp_impl_destroying_delete != 201806L
+#error __cpp_impl_destroying_delete is not 201806L
+#else
+STATIC_ASSERT(__cpp_impl_destroying_delete == 201806L);
+#endif
+#else
+#ifdef __cpp_impl_destroying_delete
+#error __cpp_impl_destroying_delete is defined
+#endif
+#endif
+#endif
+
+#if _HAS_CXX20 && (!defined(__clang__) || __clang_major__ >= 10)
 #ifndef __cpp_impl_three_way_comparison
 #error __cpp_impl_three_way_comparison is not defined
+#elif defined(__EDG__) // EDG does not yet implement P1630R1 or P1186R3 so they still report the old value.
+#if __cpp_impl_three_way_comparison != 201711L
+#error __cpp_impl_three_way_comparison is not 201711L
+#else
+STATIC_ASSERT(__cpp_impl_three_way_comparison == 201711L);
+#endif
 #else
 #if __cpp_impl_three_way_comparison != 201907L
 #error __cpp_impl_three_way_comparison is not 201907L
@@ -729,7 +750,7 @@ STATIC_ASSERT(__cpp_lib_apply == 201603L);
 #endif
 #endif
 
-#if _HAS_CXX20 && !defined(__EDG__)
+#if _HAS_CXX20
 #ifndef __cpp_lib_array_constexpr
 #error __cpp_lib_array_constexpr is not defined
 #elif __cpp_lib_array_constexpr != 201806L
@@ -1017,6 +1038,20 @@ STATIC_ASSERT(__cpp_lib_destroying_delete == 201806L);
 #endif
 #endif
 
+#if _HAS_CXX20 && defined(__cpp_impl_destroying_delete) // TRANSITION, EDG and VS 2019 16.7p1
+#ifndef __cpp_lib_destroying_delete
+#error __cpp_lib_destroying_delete is not defined
+#elif __cpp_lib_destroying_delete != 201806L
+#error __cpp_lib_destroying_delete is not 201806L
+#else
+STATIC_ASSERT(__cpp_lib_destroying_delete == 201806L);
+#endif
+#else
+#ifdef __cpp_lib_destroying_delete
+#error __cpp_lib_destroying_delete is defined
+#endif
+#endif
+
 #ifndef __cpp_lib_enable_shared_from_this
 #error __cpp_lib_enable_shared_from_this is not defined
 #elif __cpp_lib_enable_shared_from_this != 201603L
@@ -1040,22 +1075,12 @@ STATIC_ASSERT(__cpp_lib_endian == 201907L);
 #endif
 
 #if _HAS_CXX20
-#ifdef __EDG__
-#ifndef __cpp_lib_erase_if
-#error __cpp_lib_erase_if is not defined
-#elif __cpp_lib_erase_if != 201811L
-#error __cpp_lib_erase_if is not 201811L
-#else
-STATIC_ASSERT(__cpp_lib_erase_if == 201811L);
-#endif
-#else // ^^^ EDG / Clang and MSVC vvv
 #ifndef __cpp_lib_erase_if
 #error __cpp_lib_erase_if is not defined
 #elif __cpp_lib_erase_if != 202002L
 #error __cpp_lib_erase_if is not 202002L
 #else
 STATIC_ASSERT(__cpp_lib_erase_if == 202002L);
-#endif
 #endif
 #else
 #ifdef __cpp_lib_erase_if
@@ -1202,22 +1227,12 @@ STATIC_ASSERT(__cpp_lib_incomplete_container_elements == 201505L);
 #endif
 
 #if _HAS_CXX20
-#ifdef __EDG__
-#ifndef __cpp_lib_int_pow2
-#error __cpp_lib_int_pow2 is not defined
-#elif __cpp_lib_int_pow2 != 201806L
-#error __cpp_lib_int_pow2 is not 201806L
-#else
-STATIC_ASSERT(__cpp_lib_int_pow2 == 201806L);
-#endif
-#else // ^^^ EDG / Clang and MSVC vvv
 #ifndef __cpp_lib_int_pow2
 #error __cpp_lib_int_pow2 is not defined
 #elif __cpp_lib_int_pow2 != 202002L
 #error __cpp_lib_int_pow2 is not 202002L
 #else
 STATIC_ASSERT(__cpp_lib_int_pow2 == 202002L);
-#endif
 #endif
 #else
 #ifdef __cpp_lib_int_pow2
@@ -1670,22 +1685,12 @@ STATIC_ASSERT(__cpp_lib_shift == 201806L);
 #endif
 
 #if _HAS_CXX20
-#ifdef __EDG__
-#ifndef __cpp_lib_span
-#error __cpp_lib_span is not defined
-#elif __cpp_lib_span != 201902L
-#error __cpp_lib_span is not 201902L
-#else
-STATIC_ASSERT(__cpp_lib_span == 201902L);
-#endif
-#else // ^^^ EDG / Clang and MSVC vvv
 #ifndef __cpp_lib_span
 #error __cpp_lib_span is not defined
 #elif __cpp_lib_span != 202002L
 #error __cpp_lib_span is not 202002L
 #else
 STATIC_ASSERT(__cpp_lib_span == 202002L);
-#endif
 #endif
 #else
 #ifdef __cpp_lib_span

--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.cpp
@@ -334,22 +334,6 @@ STATIC_ASSERT(__cpp_impl_destroying_delete == 201806L);
 #endif
 #endif
 
-#if defined(__clang__) || defined(__EDG__) // TRANSITION, VS 2019 16.7p1
-#if defined(__clang__) || _HAS_CXX20 && !defined(__EDG__) // TRANSITION, EDG
-#ifndef __cpp_impl_destroying_delete
-#error __cpp_impl_destroying_delete is not defined
-#elif __cpp_impl_destroying_delete != 201806L
-#error __cpp_impl_destroying_delete is not 201806L
-#else
-STATIC_ASSERT(__cpp_impl_destroying_delete == 201806L);
-#endif
-#else
-#ifdef __cpp_impl_destroying_delete
-#error __cpp_impl_destroying_delete is defined
-#endif
-#endif
-#endif
-
 #if _HAS_CXX20 && (!defined(__clang__) || __clang_major__ >= 10)
 #ifndef __cpp_impl_three_way_comparison
 #error __cpp_impl_three_way_comparison is not defined
@@ -1016,20 +1000,6 @@ STATIC_ASSERT(__cpp_lib_constexpr_numeric == 201911L);
 #else
 #ifdef __cpp_lib_constexpr_numeric
 #error __cpp_lib_constexpr_numeric is defined
-#endif
-#endif
-
-#if _HAS_CXX20 && defined(__cpp_impl_destroying_delete) // TRANSITION, EDG and VS 2019 16.7p1
-#ifndef __cpp_lib_destroying_delete
-#error __cpp_lib_destroying_delete is not defined
-#elif __cpp_lib_destroying_delete != 201806L
-#error __cpp_lib_destroying_delete is not 201806L
-#else
-STATIC_ASSERT(__cpp_lib_destroying_delete == 201806L);
-#endif
-#else
-#ifdef __cpp_lib_destroying_delete
-#error __cpp_lib_destroying_delete is defined
 #endif
 #endif
 

--- a/tests/utils/stl/test/config.py
+++ b/tests/utils/stl/test/config.py
@@ -126,6 +126,12 @@ class Configuration:
         self.config.available_features.add('msvc')
         self.config.available_features.update(self.target_info.features)
 
+        if self.target_arch is None:
+            self.configure_target_architecture()
+
+        if self.target_arch == 'x86':
+            self.config.available_features.add('edg')
+
     def configure_test_source_root(self):
         test_source_root = self.get_lit_conf('test_source_root', None)
 

--- a/tests/utils/stl/util.py
+++ b/tests/utils/stl/util.py
@@ -43,7 +43,7 @@ def nullContext(value):
 
 
 def makeReport(cmd, out, err, rc):
-    report = "Command: %s\n" % ' '.join(cmd)
+    report = "Command: \"%s\"\n" % "\" \"".join(cmd)
     report += "Exit Code: %d\n" % rc
     if out:
         report += "Standard Output:\n--\n%s--\n" % out


### PR DESCRIPTION
We have decided that it is worth gating any builds and test runs behind a successful format validation step.

Also since doing this needed me to figure out how to set up a dev environment without vcpkg's help do a drive-by and enable the /BE testing.

In order to get /BE working I also need to update the VMs.