### PR TITLE
<yvals_core.h>: Fix <bit> feature-test macros

### DIFF
--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -1089,12 +1089,10 @@
 #define __cpp_lib_bit_cast 201806L
 #endif // __EDG__
 
-#if defined(__clang__) || defined(__EDG__)
-#define __cpp_lib_bitops 201907L
-#else // ^^^ Clang and EDG / MSVC vvv
+#ifdef __clang__ // TRANSITION, VSO-1020212
 // a future MSVC update will embed CPU feature detection into <bit> intrinsics
-// TRANSITION, VSO-1020212
-#endif // defined(__clang__) || defined(__EDG__)
+#define __cpp_lib_bitops 201907L
+#endif // __clang__
 
 #define __cpp_lib_bounded_array_traits 201902L
 
@@ -1112,20 +1110,24 @@
 #define __cpp_lib_endian                   201907L
 #define __cpp_lib_erase_if                 202002L
 #define __cpp_lib_generic_unordered_lookup 201811L
-#define __cpp_lib_int_pow2                 202002L
-#define __cpp_lib_is_constant_evaluated    201811L
-#define __cpp_lib_is_nothrow_convertible   201806L
-#define __cpp_lib_list_remove_return_type  201806L
-#define __cpp_lib_math_constants           201907L
-#define __cpp_lib_remove_cvref             201711L
-#define __cpp_lib_shift                    201806L
-#define __cpp_lib_span                     202002L
-#define __cpp_lib_ssize                    201902L
-#define __cpp_lib_starts_ends_with         201711L
-#define __cpp_lib_to_address               201711L
-#define __cpp_lib_to_array                 201907L
-#define __cpp_lib_type_identity            201806L
-#define __cpp_lib_unwrap_ref               201811L
+
+#ifdef __cpp_lib_bitops // TRANSITION, VSO-1020212
+#define __cpp_lib_int_pow2 202002L
+#endif
+
+#define __cpp_lib_is_constant_evaluated   201811L
+#define __cpp_lib_is_nothrow_convertible  201806L
+#define __cpp_lib_list_remove_return_type 201806L
+#define __cpp_lib_math_constants          201907L
+#define __cpp_lib_remove_cvref            201711L
+#define __cpp_lib_shift                   201806L
+#define __cpp_lib_span                    202002L
+#define __cpp_lib_ssize                   201902L
+#define __cpp_lib_starts_ends_with        201711L
+#define __cpp_lib_to_address              201711L
+#define __cpp_lib_to_array                201907L
+#define __cpp_lib_type_identity           201806L
+#define __cpp_lib_unwrap_ref              201811L
 #endif // _HAS_CXX20
 
 #if _HAS_CXX20

--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.cpp
@@ -812,7 +812,7 @@ STATIC_ASSERT(__cpp_lib_bit_cast == 201806L);
 #endif
 #endif
 
-#if _HAS_CXX20 && (defined(__clang__) || defined(__EDG__)) // TRANSITION, VSO-1020212
+#if _HAS_CXX20 && defined(__clang__) // TRANSITION, VSO-1020212
 #ifndef __cpp_lib_bitops
 #error __cpp_lib_bitops is not defined
 #elif __cpp_lib_bitops != 201907L
@@ -1166,7 +1166,7 @@ STATIC_ASSERT(__cpp_lib_hypot == 201603L);
 STATIC_ASSERT(__cpp_lib_incomplete_container_elements == 201505L);
 #endif
 
-#if _HAS_CXX20
+#if _HAS_CXX20 && defined(__clang__) // TRANSITION, VSO-1020212
 #ifndef __cpp_lib_int_pow2
 #error __cpp_lib_int_pow2 is not defined
 #elif __cpp_lib_int_pow2 != 202002L


### PR DESCRIPTION
* Don't define `__cpp_lib_bitops` when `__EDG__`, so IntelliSense is consistent with MSVC
* Don't define `__cpp_lib_int_pow2` when `__cpp_lib_bitops` isn't defined since the facilities that correspond with `__cpp_lib_int_pow2` are only provided when `__cpp_lib_bitops` is defined.

(See discussion starting at https://github.com/microsoft/STL/issues/313#issuecomment-585127653.)
