### PR TITLE
Use the temp disk

### DIFF
--- a/azure-devops/run-build.yml
+++ b/azure-devops/run-build.yml
@@ -9,6 +9,7 @@ jobs:
 
   variables:
     vcpkgLocation: '$(Build.SourcesDirectory)/vcpkg'
+    buildOutputLocation: 'D:/build'
   steps:
     - checkout: self
       clean: true
@@ -49,7 +50,7 @@ jobs:
       inputs:
         cmakeListsOrSettingsJson: 'CMakeListsTxtAdvanced'
         cmakeListsTxtPath: '$(Build.SourcesDirectory)/CMakeLists.txt'
-        buildDirectory: D:/build/${{ parameters.targetPlatform }}
+        buildDirectory: $(buildOutputLocation)/${{ parameters.targetPlatform }}
         useVcpkgToolchainFile: true
         cmakeAppendedArgs: |
           -G Ninja -DBUILD_TESTING=TRUE -DENABLE_XUNIT_OUTPUT=TRUE -DADDITIONAL_LIT_FLAGS=-j$(testParallelism)
@@ -58,7 +59,7 @@ jobs:
       timeoutInMinutes: 120
       condition: in('${{ parameters.targetPlatform }}', 'x64', 'x86')
       inputs:
-        workingDirectory: D:/build/${{ parameters.targetPlatform }}
+        workingDirectory: $(buildOutputLocation)/${{ parameters.targetPlatform }}
         script: |
           call "%PROGRAMFILES(X86)%\Microsoft Visual Studio\2019\Preview\Common7\Tools\VsDevCmd.bat" ^
           -host_arch=${{ parameters.vsDevCmdArch }} -arch=${{ parameters.vsDevCmdArch }} -no_logo
@@ -68,7 +69,7 @@ jobs:
       timeoutInMinutes: 10
       condition: in('${{ parameters.targetPlatform }}', 'x64', 'x86')
       inputs:
-        searchFolder: D:/build/${{ parameters.targetPlatform }}
+        searchFolder: $(buildOutputLocation)/${{ parameters.targetPlatform }}
         testResultsFormat: JUnit
         testResultsFiles: '**/libcxx.test.xml'
         testRunTitle: 'libcxx-${{ parameters.targetPlatform }}'
@@ -77,7 +78,7 @@ jobs:
       timeoutInMinutes: 10
       condition: in('${{ parameters.targetPlatform }}', 'x64', 'x86')
       inputs:
-        searchFolder: D:/build/${{ parameters.targetPlatform }}
+        searchFolder: $(buildOutputLocation)/${{ parameters.targetPlatform }}
         testResultsFormat: JUnit
         testResultsFiles: '**/std.test.xml'
         testRunTitle: 'std-${{ parameters.targetPlatform }}'
@@ -86,7 +87,7 @@ jobs:
       timeoutInMinutes: 10
       condition: in('${{ parameters.targetPlatform }}', 'x64', 'x86')
       inputs:
-        searchFolder: D:/build/${{ parameters.targetPlatform }}
+        searchFolder: $(buildOutputLocation)/${{ parameters.targetPlatform }}
         testResultsFormat: JUnit
         testResultsFiles: '**/tr1.test.xml'
         testRunTitle: 'tr1-${{ parameters.targetPlatform }}'

--- a/azure-devops/run-build.yml
+++ b/azure-devops/run-build.yml
@@ -49,7 +49,7 @@ jobs:
       inputs:
         cmakeListsOrSettingsJson: 'CMakeListsTxtAdvanced'
         cmakeListsTxtPath: '$(Build.SourcesDirectory)/CMakeLists.txt'
-        buildDirectory: $(Build.ArtifactStagingDirectory)/${{ parameters.targetPlatform }}
+        buildDirectory: D:/build/${{ parameters.targetPlatform }}
         useVcpkgToolchainFile: true
         cmakeAppendedArgs: |
           -G Ninja -DBUILD_TESTING=TRUE -DENABLE_XUNIT_OUTPUT=TRUE -DADDITIONAL_LIT_FLAGS=-j$(testParallelism)
@@ -58,7 +58,7 @@ jobs:
       timeoutInMinutes: 120
       condition: in('${{ parameters.targetPlatform }}', 'x64', 'x86')
       inputs:
-        workingDirectory: $(Build.ArtifactStagingDirectory)/${{ parameters.targetPlatform }}
+        workingDirectory: D:/build/${{ parameters.targetPlatform }}
         script: |
           call "%PROGRAMFILES(X86)%\Microsoft Visual Studio\2019\Preview\Common7\Tools\VsDevCmd.bat" ^
           -host_arch=${{ parameters.vsDevCmdArch }} -arch=${{ parameters.vsDevCmdArch }} -no_logo
@@ -68,7 +68,7 @@ jobs:
       timeoutInMinutes: 10
       condition: in('${{ parameters.targetPlatform }}', 'x64', 'x86')
       inputs:
-        searchFolder: $(Build.ArtifactStagingDirectory)/${{ parameters.targetPlatform }}
+        searchFolder: D:/build/${{ parameters.targetPlatform }}
         testResultsFormat: JUnit
         testResultsFiles: '**/libcxx.test.xml'
         testRunTitle: 'libcxx-${{ parameters.targetPlatform }}'
@@ -77,7 +77,7 @@ jobs:
       timeoutInMinutes: 10
       condition: in('${{ parameters.targetPlatform }}', 'x64', 'x86')
       inputs:
-        searchFolder: $(Build.ArtifactStagingDirectory)/${{ parameters.targetPlatform }}
+        searchFolder: D:/build/${{ parameters.targetPlatform }}
         testResultsFormat: JUnit
         testResultsFiles: '**/std.test.xml'
         testRunTitle: 'std-${{ parameters.targetPlatform }}'
@@ -86,7 +86,7 @@ jobs:
       timeoutInMinutes: 10
       condition: in('${{ parameters.targetPlatform }}', 'x64', 'x86')
       inputs:
-        searchFolder: $(Build.ArtifactStagingDirectory)/${{ parameters.targetPlatform }}
+        searchFolder: D:/build/${{ parameters.targetPlatform }}
         testResultsFormat: JUnit
         testResultsFiles: '**/tr1.test.xml'
         testRunTitle: 'tr1-${{ parameters.targetPlatform }}'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,8 +24,8 @@ stages:
               call "%PROGRAMFILES(X86)%\Microsoft Visual Studio\2019\Preview\Common7\Tools\VsDevCmd.bat" ^
               -host_arch=amd64 -arch=amd64 -no_logo
               cmake -G Ninja -DCMAKE_CXX_COMPILER=cl -DCMAKE_BUILD_TYPE=Release ^
-              -S $(Build.SourcesDirectory)\tools -B $(Build.ArtifactStagingDirectory)\tools
-              cd $(Build.ArtifactStagingDirectory)\tools
+              -S $(Build.SourcesDirectory)\tools -B D:\build\tools
+              cd D:\build\tools
               cmake --build .
             displayName: 'Build Support Tools'
           - task: BatchScript@1
@@ -34,14 +34,14 @@ stages:
             inputs:
               filename: 'azure-devops/enforce-clang-format.cmd'
               failOnStandardError: true
-              arguments: '$(Build.ArtifactStagingDirectory)/tools/parallelize/parallelize.exe'
+              arguments: 'D:/build/tools/parallelize/parallelize.exe'
           - task: BatchScript@1
             displayName: 'Validate Files'
             timeoutInMinutes: 2
             inputs:
               filename: 'azure-devops/validate-files.cmd'
               failOnStandardError: true
-              arguments: '$(Build.ArtifactStagingDirectory)/tools/validate/validate.exe'
+              arguments: 'D:/build/tools/validate/validate.exe'
   - stage: Build_And_Test
     displayName: 'Build and Test'
     jobs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,12 +21,11 @@ stages:
             clean: true
             submodules: false
           - script: |
-              rd /S /Q D:\build\tools
               call "%PROGRAMFILES(X86)%\Microsoft Visual Studio\2019\Preview\Common7\Tools\VsDevCmd.bat" ^
               -host_arch=amd64 -arch=amd64 -no_logo
               cmake -G Ninja -DCMAKE_CXX_COMPILER=cl -DCMAKE_BUILD_TYPE=Release ^
-              -S $(Build.SourcesDirectory)\tools -B D:\build\tools
-              cd D:\build\tools
+              -S $(Build.SourcesDirectory)\tools -B $(Build.ArtifactStagingDirectory)\tools
+              cd $(Build.ArtifactStagingDirectory)\tools
               cmake --build .
             displayName: 'Build Support Tools'
           - task: BatchScript@1
@@ -35,14 +34,14 @@ stages:
             inputs:
               filename: 'azure-devops/enforce-clang-format.cmd'
               failOnStandardError: true
-              arguments: 'D:/build/tools/parallelize/parallelize.exe'
+              arguments: '$(Build.ArtifactStagingDirectory)/tools/parallelize/parallelize.exe'
           - task: BatchScript@1
             displayName: 'Validate Files'
             timeoutInMinutes: 2
             inputs:
               filename: 'azure-devops/validate-files.cmd'
               failOnStandardError: true
-              arguments: 'D:/build/tools/validate/validate.exe'
+              arguments: '$(Build.ArtifactStagingDirectory)/tools/validate/validate.exe'
   - stage: Build_And_Test
     displayName: 'Build and Test'
     jobs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,6 +21,7 @@ stages:
             clean: true
             submodules: false
           - script: |
+              rd /S /Q D:\build\tools
               call "%PROGRAMFILES(X86)%\Microsoft Visual Studio\2019\Preview\Common7\Tools\VsDevCmd.bat" ^
               -host_arch=amd64 -arch=amd64 -no_logo
               cmake -G Ninja -DCMAKE_CXX_COMPILER=cl -DCMAKE_BUILD_TYPE=Release ^

--- a/tests/utils/stl/test/format.py
+++ b/tests/utils/stl/test/format.py
@@ -121,7 +121,7 @@ class STLTestFormat:
         # on the .dat files the test requires.
         for path in source_dir.iterdir():
             if path.is_file() and path.name.endswith('.dat'):
-                os.link(path, exec_dir / path.name)
+                shutil.copy2(path, exec_dir / path.name)
 
     def cleanup(self, test):
         shutil.rmtree(test.getExecDir(), ignore_errors=True)


### PR DESCRIPTION
Use the vm's local temporary drives. This may improve performance and will decrease our Azure costs.
Also make the testing scripts capable of straddling two drives.