### PR TITLE
[type_traits] Add variable templates_Conjunction_v and _Disjunction_v

### DIFF
--- a/stl/inc/bit
+++ b/stl/inc/bit
@@ -25,8 +25,8 @@ _STL_DISABLE_CLANG_WARNINGS
 _STD_BEGIN
 #ifdef __cpp_lib_bit_cast // TRANSITION, VSO-1041044
 template <class _To, class _From,
-    enable_if_t<conjunction_v<bool_constant<sizeof(_To) == sizeof(_From)>, is_trivially_copyable<_To>,
-                    is_trivially_copyable<_From>>,
+    enable_if_t<
+        _Conjunction_v<sizeof(_To) == sizeof(_From), is_trivially_copyable_v<_To>, is_trivially_copyable_v<_From>>,
         int> = 0>
 _NODISCARD constexpr _To bit_cast(const _From& _Val) noexcept {
     return __builtin_bit_cast(_To, _Val);

--- a/stl/inc/deque
+++ b/stl/inc/deque
@@ -1566,7 +1566,7 @@ private:
 
 #if _HAS_CXX17
 template <class _Iter, class _Alloc = allocator<_Iter_value_t<_Iter>>,
-    enable_if_t<conjunction_v<_Is_iterator<_Iter>, _Is_allocator<_Alloc>>, int> = 0>
+    enable_if_t<_Conjunction_v<_Is_iterator_v<_Iter>, _Is_allocator_v<_Alloc>>, int> = 0>
 deque(_Iter, _Iter, _Alloc = _Alloc()) -> deque<_Iter_value_t<_Iter>, _Alloc>;
 #endif // _HAS_CXX17
 

--- a/stl/inc/forward_list
+++ b/stl/inc/forward_list
@@ -1509,7 +1509,7 @@ private:
 
 #if _HAS_CXX17
 template <class _Iter, class _Alloc = allocator<_Iter_value_t<_Iter>>,
-    enable_if_t<conjunction_v<_Is_iterator<_Iter>, _Is_allocator<_Alloc>>, int> = 0>
+    enable_if_t<_Conjunction_v<_Is_iterator_v<_Iter>, _Is_allocator_v<_Alloc>>, int> = 0>
 forward_list(_Iter, _Iter, _Alloc = _Alloc()) -> forward_list<_Iter_value_t<_Iter>, _Alloc>;
 #endif // _HAS_CXX17
 

--- a/stl/inc/list
+++ b/stl/inc/list
@@ -1796,7 +1796,7 @@ private:
 
 #if _HAS_CXX17
 template <class _Iter, class _Alloc = allocator<_Iter_value_t<_Iter>>,
-    enable_if_t<conjunction_v<_Is_iterator<_Iter>, _Is_allocator<_Alloc>>, int> = 0>
+    enable_if_t<_Conjunction_v<_Is_iterator_v<_Iter>, _Is_allocator_v<_Alloc>>, int> = 0>
 list(_Iter, _Iter, _Alloc = _Alloc()) -> list<_Iter_value_t<_Iter>, _Alloc>;
 #endif // _HAS_CXX17
 

--- a/stl/inc/map
+++ b/stl/inc/map
@@ -349,17 +349,18 @@ public:
 
 #if _HAS_CXX17
 template <class _Iter, class _Pr = less<_Guide_key_t<_Iter>>, class _Alloc = allocator<_Guide_pair_t<_Iter>>,
-    enable_if_t<conjunction_v<_Is_iterator<_Iter>, negation<_Is_allocator<_Pr>>, _Is_allocator<_Alloc>>, int> = 0>
+    enable_if_t<_Conjunction_v<_Is_iterator_v<_Iter>, !_Is_allocator_v<_Pr>, _Is_allocator_v<_Alloc>>, int> = 0>
 map(_Iter, _Iter, _Pr = _Pr(), _Alloc = _Alloc()) -> map<_Guide_key_t<_Iter>, _Guide_val_t<_Iter>, _Pr, _Alloc>;
 
 template <class _Kty, class _Ty, class _Pr = less<_Kty>, class _Alloc = allocator<pair<const _Kty, _Ty>>,
-    enable_if_t<conjunction_v<negation<_Is_allocator<_Pr>>, _Is_allocator<_Alloc>>, int> = 0>
+    enable_if_t<_Conjunction_v<!_Is_allocator_v<_Pr>, _Is_allocator_v<_Alloc>>, int> = 0>
 map(initializer_list<pair<_Kty, _Ty>>, _Pr = _Pr(), _Alloc = _Alloc()) -> map<_Kty, _Ty, _Pr, _Alloc>;
 
-template <class _Iter, class _Alloc, enable_if_t<conjunction_v<_Is_iterator<_Iter>, _Is_allocator<_Alloc>>, int> = 0>
+template <class _Iter, class _Alloc,
+    enable_if_t<_Conjunction_v<_Is_iterator_v<_Iter>, _Is_allocator_v<_Alloc>>, int> = 0>
 map(_Iter, _Iter, _Alloc) -> map<_Guide_key_t<_Iter>, _Guide_val_t<_Iter>, less<_Guide_key_t<_Iter>>, _Alloc>;
 
-template <class _Kty, class _Ty, class _Alloc, enable_if_t<_Is_allocator<_Alloc>::value, int> = 0>
+template <class _Kty, class _Ty, class _Alloc, enable_if_t<_Is_allocator_v<_Alloc>, int> = 0>
 map(initializer_list<pair<_Kty, _Ty>>, _Alloc) -> map<_Kty, _Ty, less<_Kty>, _Alloc>;
 #endif // _HAS_CXX17
 
@@ -503,18 +504,19 @@ public:
 
 #if _HAS_CXX17
 template <class _Iter, class _Pr = less<_Guide_key_t<_Iter>>, class _Alloc = allocator<_Guide_pair_t<_Iter>>,
-    enable_if_t<conjunction_v<_Is_iterator<_Iter>, negation<_Is_allocator<_Pr>>, _Is_allocator<_Alloc>>, int> = 0>
+    enable_if_t<_Conjunction_v<_Is_iterator_v<_Iter>, !_Is_allocator_v<_Pr>, _Is_allocator_v<_Alloc>>, int> = 0>
 multimap(_Iter, _Iter, _Pr = _Pr(), _Alloc = _Alloc())
     -> multimap<_Guide_key_t<_Iter>, _Guide_val_t<_Iter>, _Pr, _Alloc>;
 
 template <class _Kty, class _Ty, class _Pr = less<_Kty>, class _Alloc = allocator<pair<const _Kty, _Ty>>,
-    enable_if_t<conjunction_v<negation<_Is_allocator<_Pr>>, _Is_allocator<_Alloc>>, int> = 0>
+    enable_if_t<_Conjunction_v<!_Is_allocator_v<_Pr>, _Is_allocator_v<_Alloc>>, int> = 0>
 multimap(initializer_list<pair<_Kty, _Ty>>, _Pr = _Pr(), _Alloc = _Alloc()) -> multimap<_Kty, _Ty, _Pr, _Alloc>;
 
-template <class _Iter, class _Alloc, enable_if_t<conjunction_v<_Is_iterator<_Iter>, _Is_allocator<_Alloc>>, int> = 0>
+template <class _Iter, class _Alloc,
+    enable_if_t<_Conjunction_v<_Is_iterator_v<_Iter>, _Is_allocator_v<_Alloc>>, int> = 0>
 multimap(_Iter, _Iter, _Alloc) -> multimap<_Guide_key_t<_Iter>, _Guide_val_t<_Iter>, less<_Guide_key_t<_Iter>>, _Alloc>;
 
-template <class _Kty, class _Ty, class _Alloc, enable_if_t<_Is_allocator<_Alloc>::value, int> = 0>
+template <class _Kty, class _Ty, class _Alloc, enable_if_t<_Is_allocator_v<_Alloc>, int> = 0>
 multimap(initializer_list<pair<_Kty, _Ty>>, _Alloc) -> multimap<_Kty, _Ty, less<_Kty>, _Alloc>;
 #endif // _HAS_CXX17
 

--- a/stl/inc/numeric
+++ b/stl/inc/numeric
@@ -49,7 +49,7 @@ _NODISCARD _CONSTEXPR20 _Ty accumulate(const _InIt _First, const _InIt _Last, _T
 #if _STD_VECTORIZE_WITH_FLOAT_CONTROL
 template <class _InIt, class _Ty, class _BinOp>
 inline constexpr bool _Plus_on_arithmetic_ranges_reduction_v =
-    conjunction_v<is_arithmetic<_Ty>, is_arithmetic<remove_pointer_t<_InIt>>, is_same<plus<>, _BinOp>>;
+    _Conjunction_v<is_arithmetic_v<_Ty>, is_arithmetic_v<remove_pointer_t<_InIt>>, is_same_v<plus<>, _BinOp>>;
 
 #pragma float_control(precise, off, push)
 template <class _InIt, class _Ty>
@@ -177,8 +177,8 @@ _NODISCARD _CONSTEXPR20 _Ty inner_product(
 #if _STD_VECTORIZE_WITH_FLOAT_CONTROL
 template <class _InIt1, class _InIt2, class _Ty, class _BinOp1, class _BinOp2>
 inline constexpr bool _Default_ops_transform_reduce_v =
-    conjunction_v<is_arithmetic<_Ty>, is_arithmetic<remove_pointer_t<_InIt1>>, is_arithmetic<remove_pointer_t<_InIt2>>,
-        is_same<plus<>, _BinOp1>, is_same<multiplies<>, _BinOp2>>;
+    _Conjunction_v<is_arithmetic_<_Ty>, is_arithmetic_v<remove_pointer_t<_InIt1>>,
+        is_arithmetic_v<remove_pointer_t<_InIt2>>, is_same_v<plus<>, _BinOp1>, is_same_v<multiplies<>, _BinOp2>>;
 
 #pragma float_control(precise, off, push)
 template <class _InIt1, class _InIt2, class _Ty>

--- a/stl/inc/optional
+++ b/stl/inc/optional
@@ -176,48 +176,48 @@ public:
         : _Mybase(in_place, _Ilist, _STD forward<_Types>(_Args)...) {}
 
     template <class _Ty2>
-    using _AllowDirectConversion = bool_constant<conjunction_v<negation<is_same<_Remove_cvref_t<_Ty2>, optional>>,
-        negation<is_same<_Remove_cvref_t<_Ty2>, in_place_t>>, is_constructible<_Ty, _Ty2>>>;
+    _INLINE_VAR constexpr bool _AllowDirectConversion_v = _Conjunction_v<!is_same_v<_Remove_cvref_t<_Ty2>, optional>,
+        !is_same_v<_Remove_cvref_t<_Ty2>, in_place_t>, is_constructible_v<_Ty, _Ty2>>;
 
 #if _HAS_CONDITIONAL_EXPLICIT
-    template <class _Ty2 = _Ty, enable_if_t<_AllowDirectConversion<_Ty2>::value, int> = 0>
+    template <class _Ty2 = _Ty, enable_if_t<_AllowDirectConversion_v<_Ty2>::value, int> = 0>
     constexpr explicit(!is_convertible_v<_Ty2, _Ty>) optional(_Ty2&& _Right)
         : _Mybase(in_place, _STD forward<_Ty2>(_Right)) {}
 #else // ^^^ _HAS_CONDITIONAL_EXPLICIT ^^^ / vvv !_HAS_CONDITIONAL_EXPLICIT vvv
-    template <class _Ty2                                                                         = _Ty,
-        enable_if_t<conjunction_v<_AllowDirectConversion<_Ty2>, is_convertible<_Ty2, _Ty>>, int> = 0>
+    template <class _Ty2                                                                              = _Ty,
+        enable_if_t<_Conjunction_v<_AllowDirectConversion_v<_Ty2>, is_convertible_v<_Ty2, _Ty>>, int> = 0>
     constexpr optional(_Ty2&& _Right) : _Mybase(in_place, _STD forward<_Ty2>(_Right)) {}
-    template <class _Ty2                                                                                   = _Ty,
-        enable_if_t<conjunction_v<_AllowDirectConversion<_Ty2>, negation<is_convertible<_Ty2, _Ty>>>, int> = 0>
+    template <class _Ty2                                                                               = _Ty,
+        enable_if_t<_Conjunction_v<_AllowDirectConversion_v<_Ty2>, !is_convertible_v<_Ty2, _Ty>>, int> = 0>
     constexpr explicit optional(_Ty2&& _Right) : _Mybase(in_place, _STD forward<_Ty2>(_Right)) {}
 #endif // ^^^ !_HAS_CONDITIONAL_EXPLICIT ^^^
 
     template <class _Ty2>
-    struct _AllowUnwrapping : bool_constant<!disjunction_v<is_same<_Ty, _Ty2>, is_constructible<_Ty, optional<_Ty2>&>,
-                                  is_constructible<_Ty, const optional<_Ty2>&>,
-                                  is_constructible<_Ty, const optional<_Ty2>>, is_constructible<_Ty, optional<_Ty2>>,
-                                  is_convertible<optional<_Ty2>&, _Ty>, is_convertible<const optional<_Ty2>&, _Ty>,
-                                  is_convertible<const optional<_Ty2>, _Ty>, is_convertible<optional<_Ty2>, _Ty>>> {};
+    _INLINE_VAR constexpr bool _AllowUnwrapping_v = !_Disjunction_v<is_same_v<_Ty, _Ty2>,
+        is_constructible_v<_Ty, optional<_Ty2>&>, is_constructible_v<_Ty, const optional<_Ty2>&>,
+        is_constructible_v<_Ty, const optional<_Ty2>>, is_constructible_v<_Ty, optional<_Ty2>>,
+        is_convertible_v<optional<_Ty2>&, _Ty>, is_convertible_v<const optional<_Ty2>&, _Ty>,
+        is_convertible_v<const optional<_Ty2>, _Ty>, is_convertible_v<optional<_Ty2>, _Ty>>;
 
 #if _HAS_CONDITIONAL_EXPLICIT
     template <class _Ty2,
-        enable_if_t<conjunction_v<_AllowUnwrapping<_Ty2>, is_constructible<_Ty, const _Ty2&>>, int> = 0>
+        enable_if_t<_Conjunction_v<_AllowUnwrapping_v<_Ty2>, is_constructible_v<_Ty, const _Ty2&>>, int> = 0>
     explicit(!is_convertible_v<const _Ty2&, _Ty>) optional(const optional<_Ty2>& _Right) {
         if (_Right) {
             this->_Construct(*_Right);
         }
     }
 #else // ^^^ _HAS_CONDITIONAL_EXPLICIT ^^^ / vvv !_HAS_CONDITIONAL_EXPLICIT vvv
-    template <class _Ty2, enable_if_t<conjunction_v<_AllowUnwrapping<_Ty2>, is_constructible<_Ty, const _Ty2&>,
-                                          is_convertible<const _Ty2&, _Ty>>,
+    template <class _Ty2, enable_if_t<_Conjunction_v<_AllowUnwrapping_v<_Ty2>, is_constructible_v<_Ty, const _Ty2&>,
+                                          is_convertible_v<const _Ty2&, _Ty>>,
                               int> = 0>
     optional(const optional<_Ty2>& _Right) {
         if (_Right) {
             this->_Construct(*_Right);
         }
     }
-    template <class _Ty2, enable_if_t<conjunction_v<_AllowUnwrapping<_Ty2>, is_constructible<_Ty, const _Ty2&>,
-                                          negation<is_convertible<const _Ty2&, _Ty>>>,
+    template <class _Ty2, enable_if_t<_Conjunction_v<_AllowUnwrapping_v<_Ty2>, is_constructible_v<_Ty, const _Ty2&>,
+                                          !is_convertible_v<const _Ty2&, _Ty>>,
                               int> = 0>
     explicit optional(const optional<_Ty2>& _Right) {
         if (_Right) {
@@ -227,23 +227,23 @@ public:
 #endif // ^^^ !_HAS_CONDITIONAL_EXPLICIT ^^^
 
 #if _HAS_CONDITIONAL_EXPLICIT
-    template <class _Ty2, enable_if_t<conjunction_v<_AllowUnwrapping<_Ty2>, is_constructible<_Ty, _Ty2>>, int> = 0>
+    template <class _Ty2, enable_if_t<_Conjunction_v<_AllowUnwrapping_v<_Ty2>, is_constructible_v<_Ty, _Ty2>>, int> = 0>
     explicit(!is_convertible_v<_Ty2, _Ty>) optional(optional<_Ty2>&& _Right) {
         if (_Right) {
             this->_Construct(_STD move(*_Right));
         }
     }
 #else // ^^^ _HAS_CONDITIONAL_EXPLICIT ^^^ / vvv !_HAS_CONDITIONAL_EXPLICIT vvv
-    template <class _Ty2,
-        enable_if_t<conjunction_v<_AllowUnwrapping<_Ty2>, is_constructible<_Ty, _Ty2>, is_convertible<_Ty2, _Ty>>,
-            int> = 0>
+    template <class _Ty2, enable_if_t<_Conjunction_v<_AllowUnwrapping_v<_Ty2>, is_constructible_v<_Ty, _Ty2>,
+                                          is_convertible_v<_Ty2, _Ty>>,
+                              int> = 0>
     optional(optional<_Ty2>&& _Right) {
         if (_Right) {
             this->_Construct(_STD move(*_Right));
         }
     }
-    template <class _Ty2, enable_if_t<conjunction_v<_AllowUnwrapping<_Ty2>, is_constructible<_Ty, _Ty2>,
-                                          negation<is_convertible<_Ty2, _Ty>>>,
+    template <class _Ty2, enable_if_t<_Conjunction_v<_AllowUnwrapping_v<_Ty2>, is_constructible_v<_Ty, _Ty2>,
+                                          !is_convertible_v<_Ty2, _Ty>>,
                               int> = 0>
     explicit optional(optional<_Ty2>&& _Right) {
         if (_Right) {
@@ -258,9 +258,9 @@ public:
         return *this;
     }
 
-    template <class _Ty2 = _Ty, enable_if_t<conjunction_v<negation<is_same<optional, _Remove_cvref_t<_Ty2>>>,
-                                                negation<conjunction<is_scalar<_Ty>, is_same<_Ty, decay_t<_Ty2>>>>,
-                                                is_constructible<_Ty, _Ty2>, is_assignable<_Ty&, _Ty2>>,
+    template <class _Ty2 = _Ty, enable_if_t<_Conjunction_v<!is_same_v<optional, _Remove_cvref_t<_Ty2>>,
+                                                !_Conjunction_v<is_scalar_v<_Ty>, is_same_v<_Ty, decay_t<_Ty2>>>,
+                                                is_constructible_v<_Ty, _Ty2>, is_assignable_v<_Ty&, _Ty2>>,
                                     int> = 0>
     optional& operator=(_Ty2&& _Right) {
         this->_Assign(_STD forward<_Ty2>(_Right));
@@ -268,13 +268,12 @@ public:
     }
 
     template <class _Ty2>
-    struct _AllowUnwrappingAssignment
-        : bool_constant<!disjunction_v<is_same<_Ty, _Ty2>, is_assignable<_Ty&, optional<_Ty2>&>,
-              is_assignable<_Ty&, const optional<_Ty2>&>, is_assignable<_Ty&, const optional<_Ty2>>,
-              is_assignable<_Ty&, optional<_Ty2>>>> {};
+    using _AllowUnwrappingAssignment_v = !_Disjunction_v<is_same_v<_Ty, _Ty2>, is_assignable_v<_Ty&, optional<_Ty2>&>,
+        is_assignable_v<_Ty&, const optional<_Ty2>&>, is_assignable_v<_Ty&, const optional<_Ty2>>,
+        is_assignable_v<_Ty&, optional<_Ty2>>>;
 
-    template <class _Ty2, enable_if_t<conjunction_v<_AllowUnwrappingAssignment<_Ty2>,
-                                          is_constructible<_Ty, const _Ty2&>, is_assignable<_Ty&, const _Ty2&>>,
+    template <class _Ty2, enable_if_t<_Conjunction_v<_AllowUnwrappingAssignment_v<_Ty2>,
+                                          is_constructible_v<_Ty, const _Ty2&>, is_assignable_v<_Ty&, const _Ty2&>>,
                               int> = 0>
     optional& operator=(const optional<_Ty2>& _Right) {
         if (_Right) {
@@ -286,8 +285,8 @@ public:
         return *this;
     }
 
-    template <class _Ty2, enable_if_t<conjunction_v<_AllowUnwrappingAssignment<_Ty2>, is_constructible<_Ty, _Ty2>,
-                                          is_assignable<_Ty&, _Ty2>>,
+    template <class _Ty2, enable_if_t<_Conjunction_v<_AllowUnwrappingAssignment_v<_Ty2>, is_constructible_v<_Ty, _Ty2>,
+                                          is_assignable_v<_Ty&, _Ty2>>,
                               int> = 0>
     optional& operator=(optional<_Ty2>&& _Right) {
         if (_Right) {

--- a/stl/inc/queue
+++ b/stl/inc/queue
@@ -155,12 +155,12 @@ protected:
 };
 
 #if _HAS_CXX17
-template <class _Container, enable_if_t<!_Is_allocator<_Container>::value, int> = 0>
+template <class _Container, enable_if_t<!_Is_allocator_v<_Container>, int> = 0>
 queue(_Container) -> queue<typename _Container::value_type, _Container>;
 
 template <class _Container, class _Alloc,
     enable_if_t<
-        conjunction_v<negation<_Is_allocator<_Container>>, _Is_allocator<_Alloc>, uses_allocator<_Container, _Alloc>>,
+        _Conjunction_v<!_Is_allocator_v<_Container>, _Is_allocator_v<_Alloc>, uses_allocator<_Container, _Alloc>>,
         int> = 0>
 queue(_Container, _Alloc) -> queue<typename _Container::value_type, _Container>;
 #endif // _HAS_CXX17
@@ -297,17 +297,16 @@ protected:
 
 #if _HAS_CXX17
 template <class _Pr, class _Container,
-    enable_if_t<conjunction_v<negation<_Is_allocator<_Pr>>, negation<_Is_allocator<_Container>>>, int> = 0>
+    enable_if_t<_Conjunction_v<!_Is_allocator_v<_Pr>, !_Is_allocator_v<_Container>>, int> = 0>
 priority_queue(_Pr, _Container) -> priority_queue<typename _Container::value_type, _Container, _Pr>;
 
 template <class _Iter, class _Pr = less<_Iter_value_t<_Iter>>, class _Container = vector<_Iter_value_t<_Iter>>,
-    enable_if_t<conjunction_v<_Is_iterator<_Iter>, negation<_Is_allocator<_Pr>>, negation<_Is_allocator<_Container>>>,
-        int> = 0>
+    enable_if_t<_Conjunction_v<_Is_iterator_v<_Iter>, !_Is_allocator_v<_Pr>, !_Is_allocator_v<_Container>>, int> = 0>
 priority_queue(_Iter, _Iter, _Pr = _Pr(), _Container = _Container())
     -> priority_queue<_Iter_value_t<_Iter>, _Container, _Pr>;
 
 template <class _Pr, class _Container, class _Alloc,
-    enable_if_t<conjunction_v<negation<_Is_allocator<_Pr>>, negation<_Is_allocator<_Container>>, _Is_allocator<_Alloc>,
+    enable_if_t<_Conjunction_v<!_Is_allocator_v<_Pr>, !_Is_allocator_v<_Container>, _Is_allocator_v<_Alloc>,
                     uses_allocator<_Container, _Alloc>>,
         int> = 0>
 priority_queue(_Pr, _Container, _Alloc) -> priority_queue<typename _Container::value_type, _Container, _Pr>;

--- a/stl/inc/set
+++ b/stl/inc/set
@@ -160,17 +160,18 @@ public:
 
 #if _HAS_CXX17
 template <class _Iter, class _Pr = less<_Iter_value_t<_Iter>>, class _Alloc = allocator<_Iter_value_t<_Iter>>,
-    enable_if_t<conjunction_v<_Is_iterator<_Iter>, negation<_Is_allocator<_Pr>>, _Is_allocator<_Alloc>>, int> = 0>
+    enable_if_t<_Conjunction_v<_Is_iterator_v<_Iter>, !_Is_allocator_v<_Pr>, _Is_allocator_v<_Alloc>>, int> = 0>
 set(_Iter, _Iter, _Pr = _Pr(), _Alloc = _Alloc()) -> set<_Iter_value_t<_Iter>, _Pr, _Alloc>;
 
 template <class _Kty, class _Pr = less<_Kty>, class _Alloc = allocator<_Kty>,
-    enable_if_t<conjunction_v<negation<_Is_allocator<_Pr>>, _Is_allocator<_Alloc>>, int> = 0>
+    enable_if_t<_Conjunction_v<!_Is_allocator_v<_Pr>, _Is_allocator_v<_Alloc>>, int> = 0>
 set(initializer_list<_Kty>, _Pr = _Pr(), _Alloc = _Alloc()) -> set<_Kty, _Pr, _Alloc>;
 
-template <class _Iter, class _Alloc, enable_if_t<conjunction_v<_Is_iterator<_Iter>, _Is_allocator<_Alloc>>, int> = 0>
+template <class _Iter, class _Alloc,
+    enable_if_t<_Conjunction_v<_Is_iterator_v<_Iter>, _Is_allocator_v<_Alloc>>, int> = 0>
 set(_Iter, _Iter, _Alloc) -> set<_Iter_value_t<_Iter>, less<_Iter_value_t<_Iter>>, _Alloc>;
 
-template <class _Kty, class _Alloc, enable_if_t<_Is_allocator<_Alloc>::value, int> = 0>
+template <class _Kty, class _Alloc, enable_if_t<_Is_allocator_v<_Alloc>, int> = 0>
 set(initializer_list<_Kty>, _Alloc) -> set<_Kty, less<_Kty>, _Alloc>;
 #endif // _HAS_CXX17
 
@@ -300,17 +301,18 @@ public:
 
 #if _HAS_CXX17
 template <class _Iter, class _Pr = less<_Iter_value_t<_Iter>>, class _Alloc = allocator<_Iter_value_t<_Iter>>,
-    enable_if_t<conjunction_v<_Is_iterator<_Iter>, negation<_Is_allocator<_Pr>>, _Is_allocator<_Alloc>>, int> = 0>
+    enable_if_t<_Conjunction_v<_Is_iterator_v<_Iter>, !_Is_allocator_v<_Pr>, _Is_allocator_v<_Alloc>>, int> = 0>
 multiset(_Iter, _Iter, _Pr = _Pr(), _Alloc = _Alloc()) -> multiset<_Iter_value_t<_Iter>, _Pr, _Alloc>;
 
 template <class _Kty, class _Pr = less<_Kty>, class _Alloc = allocator<_Kty>,
-    enable_if_t<conjunction_v<negation<_Is_allocator<_Pr>>, _Is_allocator<_Alloc>>, int> = 0>
+    enable_if_t<_Conjunction_v<_Is_allocator_v<_Pr>, _Is_allocator_v<_Alloc>>, int> = 0>
 multiset(initializer_list<_Kty>, _Pr = _Pr(), _Alloc = _Alloc()) -> multiset<_Kty, _Pr, _Alloc>;
 
-template <class _Iter, class _Alloc, enable_if_t<conjunction_v<_Is_iterator<_Iter>, _Is_allocator<_Alloc>>, int> = 0>
+template <class _Iter, class _Alloc,
+    enable_if_t<_Conjunction_v<_Is_iterator_v<_Iter>, _Is_allocator_v<_Alloc>>, int> = 0>
 multiset(_Iter, _Iter, _Alloc) -> multiset<_Iter_value_t<_Iter>, less<_Iter_value_t<_Iter>>, _Alloc>;
 
-template <class _Kty, class _Alloc, enable_if_t<_Is_allocator<_Alloc>::value, int> = 0>
+template <class _Kty, class _Alloc, enable_if_t<_Is_allocator_v<_Alloc>, int> = 0>
 multiset(initializer_list<_Kty>, _Alloc) -> multiset<_Kty, less<_Kty>, _Alloc>;
 #endif // _HAS_CXX17
 

--- a/stl/inc/span
+++ b/stl/inc/span
@@ -257,14 +257,6 @@ class array;
 template <class _Ty, size_t _Extent>
 class span;
 
-#ifdef __cpp_lib_concepts
-namespace ranges {
-    template <class _Ty, size_t _Extent>
-    inline constexpr bool enable_view<span<_Ty, _Extent>> = _Extent == 0 || _Extent == dynamic_extent;
-    template <class _Ty, size_t _Extent>
-    inline constexpr bool enable_borrowed_range<span<_Ty, _Extent>> = true;
-} // namespace ranges
-
 // VARIABLE TEMPLATE _Is_span_v
 template <class>
 inline constexpr bool _Is_span_v = false;
@@ -278,6 +270,14 @@ inline constexpr bool _Is_std_array_v = false;
 
 template <class _Ty, size_t _Size>
 inline constexpr bool _Is_std_array_v<array<_Ty, _Size>> = true;
+
+#ifdef __cpp_lib_concepts
+namespace ranges {
+    template <class _Ty, size_t _Extent>
+    inline constexpr bool enable_view<span<_Ty, _Extent>> = _Extent == 0 || _Extent == dynamic_extent;
+    template <class _Ty, size_t _Extent>
+    inline constexpr bool enable_borrowed_range<span<_Ty, _Extent>> = true;
+} // namespace ranges
 
 // clang-format off
 // CONCEPT _Span_compatible_iterator
@@ -302,41 +302,26 @@ concept _Span_compatible_range =
  && is_convertible_v<remove_reference_t<_RANGES range_reference_t<_Rng>>(*)[], _Ty(*)[]>;
 // clang-format on
 #else // ^^^ __cpp_lib_concepts / !__cpp_lib_concepts vvv
-
-// STRUCT TEMPLATE _Is_span
-template <class>
-struct _Is_span : false_type {};
-
-template <class _Ty, size_t _Extent>
-struct _Is_span<span<_Ty, _Extent>> : true_type {};
-
-// STRUCT TEMPLATE _Is_std_array
-template <class>
-struct _Is_std_array : false_type {};
-
-template <class _Ty, size_t _Size>
-struct _Is_std_array<array<_Ty, _Size>> : true_type {};
-
 // STRUCT TEMPLATE _Is_span_convertible_range
 template <class _Rng, class _Ty>
-struct _Is_span_convertible_range
-    : bool_constant<is_convertible_v<remove_pointer_t<decltype(_STD data(_STD declval<_Rng&>()))> (*)[], _Ty (*)[]>> {};
+inline constexpr bool _Is_span_convertible_range_v =
+    is_convertible_v<remove_pointer_t<decltype(_STD data(_STD declval<_Rng&>()))> (*)[], _Ty (*)[]> > ;
 
 // STRUCT TEMPLATE _Has_container_interface
 template <class, class = void>
-struct _Has_container_interface : false_type {};
+inline constexpr bool _Has_container_interface_v = false;
 
 template <class _Rng>
-struct _Has_container_interface<_Rng,
-    void_t<decltype(_STD data(_STD declval<_Rng&>())), decltype(_STD size(_STD declval<_Rng&>()))>> : true_type {};
+inline constexpr bool _Has_container_interface_v<_Rng,
+    void_t<decltype(_STD data(_STD declval<_Rng&>())), decltype(_STD size(_STD declval<_Rng&>()))>> = true;
 
 // VARIABLE TEMPLATE _Is_span_compatible_range
 // clang-format off
 template <class _Rng, class _Ty>
-inline constexpr bool _Is_span_compatible_range = conjunction_v<
-    negation<is_array<_Rng>>,
-    negation<_Is_span<remove_const_t<_Rng>>>,
-    negation<_Is_std_array<remove_const_t<_Rng>>>,
+inline constexpr bool _Is_span_compatible_range = _Conjunction_v<
+    !is_array_v<_Rng>,
+    !_Is_span_v<remove_const_t<_Rng>>,
+    !_Is_std_array_v<remove_const_t<_Rng>>,
     _Has_container_interface<_Rng>,
     _Is_span_convertible_range<_Rng, _Ty>>;
 // clang-format on
@@ -461,14 +446,14 @@ public:
     constexpr span(element_type (&_Arr)[_Size]) noexcept : _Mybase(_Size), _Mydata(_Arr) {}
 
     template <class _OtherTy, size_t _Size,
-        enable_if_t<conjunction_v<bool_constant<_Extent == dynamic_extent || _Extent == _Size>,
-                        is_convertible<_OtherTy (*)[], element_type (*)[]>>,
+        enable_if_t<_Conjunction_v<_Extent == dynamic_extent || _Extent == _Size,
+                        is_convertible_v<_OtherTy (*)[], element_type (*)[]>>,
             int> = 0>
     constexpr span(array<_OtherTy, _Size>& _Arr) noexcept : _Mybase(_Size), _Mydata(_Arr.data()) {}
 
     template <class _OtherTy, size_t _Size,
-        enable_if_t<conjunction_v<bool_constant<_Extent == dynamic_extent || _Extent == _Size>,
-                        is_convertible<const _OtherTy (*)[], element_type (*)[]>>,
+        enable_if_t<_Conjunction_v<_Extent == dynamic_extent || _Extent == _Size,
+                        is_convertible_v<const _OtherTy (*)[], element_type (*)[]>>,
             int> = 0>
     constexpr span(const array<_OtherTy, _Size>& _Arr) noexcept : _Mybase(_Size), _Mydata(_Arr.data()) {}
 
@@ -495,9 +480,9 @@ public:
     }
 
     template <class _OtherTy, size_t _OtherExtent,
-        enable_if_t<conjunction_v<bool_constant<_Extent == dynamic_extent || _OtherExtent == dynamic_extent
-                                                || _Extent == _OtherExtent>,
-                        is_convertible<_OtherTy (*)[], element_type (*)[]>>,
+        enable_if_t<
+            _Conjunction_v<_Extent == dynamic_extent || _OtherExtent == dynamic_extent || _Extent == _OtherExtent,
+                is_convertible_v<_OtherTy (*)[], element_type (*)[]>>,
             int> = 0>
     constexpr explicit(_Extent != dynamic_extent && _OtherExtent == dynamic_extent)
         span(const span<_OtherTy, _OtherExtent>& _Other) noexcept

--- a/stl/inc/stack
+++ b/stl/inc/stack
@@ -145,12 +145,12 @@ protected:
 };
 
 #if _HAS_CXX17
-template <class _Container, enable_if_t<!_Is_allocator<_Container>::value, int> = 0>
+template <class _Container, enable_if_t<!_Is_allocator_v<_Container>, int> = 0>
 stack(_Container) -> stack<typename _Container::value_type, _Container>;
 
 template <class _Container, class _Alloc,
     enable_if_t<
-        conjunction_v<negation<_Is_allocator<_Container>>, _Is_allocator<_Alloc>, uses_allocator<_Container, _Alloc>>,
+        _Conjunction_v<!_Is_allocator_v<_Container>, _Is_allocator_v<_Alloc>, uses_allocator<_Container, _Alloc>>,
         int> = 0>
 stack(_Container, _Alloc) -> stack<typename _Container::value_type, _Container>;
 #endif // _HAS_CXX17

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -65,6 +65,26 @@ struct conjunction<_First, _Rest...> : _Conjunction<_First::value, _First, _Rest
 template <class... _Traits>
 _INLINE_VAR constexpr bool conjunction_v = conjunction<_Traits...>::value;
 
+// VARIABLE TEMPLATE _Conjunction_v
+template <bool _Arg, bool... _Args>
+_INLINE_VAR constexpr bool _Conjunction_v = _Arg&& _Conjunction_v<_Args...>;
+
+template <bool... _Args>
+_INLINE_VAR constexpr bool _Conjunction_v<false, _Args...> = false;
+
+template <>
+_INLINE_VAR constexpr bool _Conjunction_v<true> = true;
+
+// VARIABLE TEMPLATE _Disjunction_v
+template <bool _Arg, bool... _Args>
+_INLINE_VAR constexpr bool _Disjunction_v = _Arg || _Disjunction_v<_Args...>;
+
+template <bool... _Args>
+_INLINE_VAR constexpr bool _Disjunction_v<true, _Args...> = true;
+
+template <>
+_INLINE_VAR constexpr bool _Disjunction_v<false> = false;
+
 // STRUCT TEMPLATE negation
 template <class _Trait>
 struct negation : bool_constant<!static_cast<bool>(_Trait::value)> {}; // The negated result of _Trait

--- a/stl/inc/unordered_map
+++ b/stl/inc/unordered_map
@@ -410,40 +410,42 @@ public:
 template <class _Iter, class _Hasher = hash<_Guide_key_t<_Iter>>, class _Keyeq = equal_to<_Guide_key_t<_Iter>>,
     class _Alloc = allocator<_Guide_pair_t<_Iter>>,
     enable_if_t<
-        conjunction_v<_Is_iterator<_Iter>, _Is_hasher<_Hasher>, negation<_Is_allocator<_Keyeq>>, _Is_allocator<_Alloc>>,
+        _Conjunction_v<_Is_iterator_v<_Iter>, _Is_hasher_v<_Hasher>, !_Is_allocator_v<_Keyeq>, _Is_allocator_v<_Alloc>>,
         int> = 0>
 unordered_map(_Iter, _Iter, _Guide_size_type_t<_Alloc> = 0, _Hasher = _Hasher(), _Keyeq = _Keyeq(), _Alloc = _Alloc())
     -> unordered_map<_Guide_key_t<_Iter>, _Guide_val_t<_Iter>, _Hasher, _Keyeq, _Alloc>;
 
 template <class _Kty, class _Ty, class _Hasher = hash<_Kty>, class _Keyeq = equal_to<_Kty>,
     class _Alloc = allocator<pair<const _Kty, _Ty>>,
-    enable_if_t<conjunction_v<_Is_hasher<_Hasher>, negation<_Is_allocator<_Keyeq>>, _Is_allocator<_Alloc>>, int> = 0>
+    enable_if_t<_Conjunction_v<_Is_hasher_v<_Hasher>, _Is_allocator_v<_Keyeq>, _Is_allocator_v<_Alloc>>, int> = 0>
 unordered_map(initializer_list<pair<_Kty, _Ty>>, _Guide_size_type_t<_Alloc> = 0, _Hasher = _Hasher(), _Keyeq = _Keyeq(),
     _Alloc = _Alloc()) -> unordered_map<_Kty, _Ty, _Hasher, _Keyeq, _Alloc>;
 
-template <class _Iter, class _Alloc, enable_if_t<conjunction_v<_Is_iterator<_Iter>, _Is_allocator<_Alloc>>, int> = 0>
+template <class _Iter, class _Alloc,
+    enable_if_t<_Conjunction_v<_Is_iterator_v<_Iter>, _Is_allocator_v<_Alloc>>, int> = 0>
 unordered_map(_Iter, _Iter, _Alloc) -> unordered_map<_Guide_key_t<_Iter>, _Guide_val_t<_Iter>,
     hash<_Guide_key_t<_Iter>>, equal_to<_Guide_key_t<_Iter>>, _Alloc>;
 
-template <class _Iter, class _Alloc, enable_if_t<conjunction_v<_Is_iterator<_Iter>, _Is_allocator<_Alloc>>, int> = 0>
+template <class _Iter, class _Alloc,
+    enable_if_t<_Conjunction_v<_Is_iterator_v<_Iter>, _Is_allocator_v<_Alloc>>, int> = 0>
 unordered_map(_Iter, _Iter, _Guide_size_type_t<_Alloc>, _Alloc) -> unordered_map<_Guide_key_t<_Iter>,
     _Guide_val_t<_Iter>, hash<_Guide_key_t<_Iter>>, equal_to<_Guide_key_t<_Iter>>, _Alloc>;
 
 template <class _Iter, class _Hasher, class _Alloc,
-    enable_if_t<conjunction_v<_Is_iterator<_Iter>, _Is_hasher<_Hasher>, _Is_allocator<_Alloc>>, int> = 0>
+    enable_if_t<_Conjunction_v<_Is_iterator_v<_Iter>, _Is_hasher_v<_Hasher>, _Is_allocator_v<_Alloc>>, int> = 0>
 unordered_map(_Iter, _Iter, _Guide_size_type_t<_Alloc>, _Hasher, _Alloc)
     -> unordered_map<_Guide_key_t<_Iter>, _Guide_val_t<_Iter>, _Hasher, equal_to<_Guide_key_t<_Iter>>, _Alloc>;
 
-template <class _Kty, class _Ty, class _Alloc, enable_if_t<_Is_allocator<_Alloc>::value, int> = 0>
+template <class _Kty, class _Ty, class _Alloc, enable_if_t<_Is_allocator_v<_Alloc>, int> = 0>
 unordered_map(initializer_list<pair<_Kty, _Ty>>, _Alloc)
     -> unordered_map<_Kty, _Ty, hash<_Kty>, equal_to<_Kty>, _Alloc>;
 
-template <class _Kty, class _Ty, class _Alloc, enable_if_t<_Is_allocator<_Alloc>::value, int> = 0>
+template <class _Kty, class _Ty, class _Alloc, enable_if_t<_Is_allocator_v<_Alloc>, int> = 0>
 unordered_map(initializer_list<pair<_Kty, _Ty>>, _Guide_size_type_t<_Alloc>, _Alloc)
     -> unordered_map<_Kty, _Ty, hash<_Kty>, equal_to<_Kty>, _Alloc>;
 
 template <class _Kty, class _Ty, class _Hasher, class _Alloc,
-    enable_if_t<conjunction_v<_Is_hasher<_Hasher>, _Is_allocator<_Alloc>>, int> = 0>
+    enable_if_t<_Conjunction_v<_Is_hasher_v<_Hasher>, _Is_allocator_v<_Alloc>>, int> = 0>
 unordered_map(initializer_list<pair<_Kty, _Ty>>, _Guide_size_type_t<_Alloc>, _Hasher, _Alloc)
     -> unordered_map<_Kty, _Ty, _Hasher, equal_to<_Kty>, _Alloc>;
 #endif // _HAS_CXX17
@@ -702,40 +704,42 @@ public:
 template <class _Iter, class _Hasher = hash<_Guide_key_t<_Iter>>, class _Keyeq = equal_to<_Guide_key_t<_Iter>>,
     class _Alloc = allocator<_Guide_pair_t<_Iter>>,
     enable_if_t<
-        conjunction_v<_Is_iterator<_Iter>, _Is_hasher<_Hasher>, negation<_Is_allocator<_Keyeq>>, _Is_allocator<_Alloc>>,
+        _Conjunction_v<_Is_iterator_v<_Iter>, _Is_hasher_v<_Hasher>, !_Is_allocator_v<_Keyeq>, _Is_allocator_v<_Alloc>>,
         int> = 0>
 unordered_multimap(_Iter, _Iter, _Guide_size_type_t<_Alloc> = 0, _Hasher = _Hasher(), _Keyeq = _Keyeq(),
     _Alloc = _Alloc()) -> unordered_multimap<_Guide_key_t<_Iter>, _Guide_val_t<_Iter>, _Hasher, _Keyeq, _Alloc>;
 
 template <class _Kty, class _Ty, class _Hasher = hash<_Kty>, class _Keyeq = equal_to<_Kty>,
     class _Alloc = allocator<pair<const _Kty, _Ty>>,
-    enable_if_t<conjunction_v<_Is_hasher<_Hasher>, negation<_Is_allocator<_Keyeq>>, _Is_allocator<_Alloc>>, int> = 0>
+    enable_if_t<_Conjunction_v<_Is_hasher_v<_Hasher>, !_Is_allocator_v<_Keyeq>, _Is_allocator_v<_Alloc>>, int> = 0>
 unordered_multimap(initializer_list<pair<_Kty, _Ty>>, _Guide_size_type_t<_Alloc> = 0, _Hasher = _Hasher(),
     _Keyeq = _Keyeq(), _Alloc = _Alloc()) -> unordered_multimap<_Kty, _Ty, _Hasher, _Keyeq, _Alloc>;
 
-template <class _Iter, class _Alloc, enable_if_t<conjunction_v<_Is_iterator<_Iter>, _Is_allocator<_Alloc>>, int> = 0>
+template <class _Iter, class _Alloc,
+    enable_if_t<_Conjunction_v<_Is_iterator_v<_Iter>, _Is_allocator_v<_Alloc>>, int> = 0>
 unordered_multimap(_Iter, _Iter, _Alloc) -> unordered_multimap<_Guide_key_t<_Iter>, _Guide_val_t<_Iter>,
     hash<_Guide_key_t<_Iter>>, equal_to<_Guide_key_t<_Iter>>, _Alloc>;
 
-template <class _Iter, class _Alloc, enable_if_t<conjunction_v<_Is_iterator<_Iter>, _Is_allocator<_Alloc>>, int> = 0>
+template <class _Iter, class _Alloc,
+    enable_if_t<_Conjunction_v<_Is_iterator_v<_Iter>, _Is_allocator_v<_Alloc>>, int> = 0>
 unordered_multimap(_Iter, _Iter, _Guide_size_type_t<_Alloc>, _Alloc) -> unordered_multimap<_Guide_key_t<_Iter>,
     _Guide_val_t<_Iter>, hash<_Guide_key_t<_Iter>>, equal_to<_Guide_key_t<_Iter>>, _Alloc>;
 
 template <class _Iter, class _Hasher, class _Alloc,
-    enable_if_t<conjunction_v<_Is_iterator<_Iter>, _Is_hasher<_Hasher>, _Is_allocator<_Alloc>>, int> = 0>
+    enable_if_t<_Conjunction_v<_Is_iterator_v<_Iter>, _Is_hasher_v<_Hasher>, _Is_allocator_v<_Alloc>>, int> = 0>
 unordered_multimap(_Iter, _Iter, _Guide_size_type_t<_Alloc>, _Hasher, _Alloc)
     -> unordered_multimap<_Guide_key_t<_Iter>, _Guide_val_t<_Iter>, _Hasher, equal_to<_Guide_key_t<_Iter>>, _Alloc>;
 
-template <class _Kty, class _Ty, class _Alloc, enable_if_t<_Is_allocator<_Alloc>::value, int> = 0>
+template <class _Kty, class _Ty, class _Alloc, enable_if_t<_Is_allocator_v<_Alloc>, int> = 0>
 unordered_multimap(initializer_list<pair<_Kty, _Ty>>, _Alloc)
     -> unordered_multimap<_Kty, _Ty, hash<_Kty>, equal_to<_Kty>, _Alloc>;
 
-template <class _Kty, class _Ty, class _Alloc, enable_if_t<_Is_allocator<_Alloc>::value, int> = 0>
+template <class _Kty, class _Ty, class _Alloc, enable_if_t<_Is_allocator_v<_Alloc>, int> = 0>
 unordered_multimap(initializer_list<pair<_Kty, _Ty>>, _Guide_size_type_t<_Alloc>, _Alloc)
     -> unordered_multimap<_Kty, _Ty, hash<_Kty>, equal_to<_Kty>, _Alloc>;
 
 template <class _Kty, class _Ty, class _Hasher, class _Alloc,
-    enable_if_t<conjunction_v<_Is_hasher<_Hasher>, _Is_allocator<_Alloc>>, int> = 0>
+    enable_if_t<_Conjunction_v<_Is_hasher_v<_Hasher>, _Is_allocator_v<_Alloc>>, int> = 0>
 unordered_multimap(initializer_list<pair<_Kty, _Ty>>, _Guide_size_type_t<_Alloc>, _Hasher, _Alloc)
     -> unordered_multimap<_Kty, _Ty, _Hasher, equal_to<_Kty>, _Alloc>;
 #endif // _HAS_CXX17

--- a/stl/inc/unordered_set
+++ b/stl/inc/unordered_set
@@ -273,31 +273,32 @@ public:
 template <class _Iter, class _Hasher = hash<_Iter_value_t<_Iter>>, class _Keyeq = equal_to<_Iter_value_t<_Iter>>,
     class _Alloc = allocator<_Iter_value_t<_Iter>>,
     enable_if_t<
-        conjunction_v<_Is_iterator<_Iter>, _Is_hasher<_Hasher>, negation<_Is_allocator<_Keyeq>>, _Is_allocator<_Alloc>>,
+        _Conjunction_v<_Is_iterator_v<_Iter>, _Is_hasher_v<_Hasher>, !_Is_allocator_v<_Keyeq>, _Is_allocator_v<_Alloc>>,
         int> = 0>
 unordered_set(_Iter, _Iter, _Guide_size_type_t<_Alloc> = 0, _Hasher = _Hasher(), _Keyeq = _Keyeq(), _Alloc = _Alloc())
     -> unordered_set<_Iter_value_t<_Iter>, _Hasher, _Keyeq, _Alloc>;
 
 template <class _Kty, class _Hasher = hash<_Kty>, class _Keyeq = equal_to<_Kty>, class _Alloc = allocator<_Kty>,
-    enable_if_t<conjunction_v<_Is_hasher<_Hasher>, negation<_Is_allocator<_Keyeq>>, _Is_allocator<_Alloc>>, int> = 0>
+    enable_if_t<_Conjunction_v<_Is_hasher_v<_Hasher>, !_Is_allocator_v<_Keyeq>, _Is_allocator_v<_Alloc>>, int> = 0>
 unordered_set(initializer_list<_Kty>, _Guide_size_type_t<_Alloc> = 0, _Hasher = _Hasher(), _Keyeq = _Keyeq(),
     _Alloc = _Alloc()) -> unordered_set<_Kty, _Hasher, _Keyeq, _Alloc>;
 
-template <class _Iter, class _Alloc, enable_if_t<conjunction_v<_Is_iterator<_Iter>, _Is_allocator<_Alloc>>, int> = 0>
+template <class _Iter, class _Alloc,
+    enable_if_t<_Conjunction_v<_Is_iterator_v<_Iter>, _Is_allocator_v<_Alloc>>, int> = 0>
 unordered_set(_Iter, _Iter, _Guide_size_type_t<_Alloc>, _Alloc)
     -> unordered_set<_Iter_value_t<_Iter>, hash<_Iter_value_t<_Iter>>, equal_to<_Iter_value_t<_Iter>>, _Alloc>;
 
 template <class _Iter, class _Hasher, class _Alloc,
-    enable_if_t<conjunction_v<_Is_iterator<_Iter>, _Is_hasher<_Hasher>, _Is_allocator<_Alloc>>, int> = 0>
+    enable_if_t<_Conjunction_v<_Is_iterator_v<_Iter>, _Is_hasher_v<_Hasher>, _Is_allocator_v<_Alloc>>, int> = 0>
 unordered_set(_Iter, _Iter, _Guide_size_type_t<_Alloc>, _Hasher, _Alloc)
     -> unordered_set<_Iter_value_t<_Iter>, _Hasher, equal_to<_Iter_value_t<_Iter>>, _Alloc>;
 
-template <class _Kty, class _Alloc, enable_if_t<_Is_allocator<_Alloc>::value, int> = 0>
+template <class _Kty, class _Alloc, enable_if_t<_Is_allocator_v<_Alloc>, int> = 0>
 unordered_set(initializer_list<_Kty>, _Guide_size_type_t<_Alloc>, _Alloc)
     -> unordered_set<_Kty, hash<_Kty>, equal_to<_Kty>, _Alloc>;
 
 template <class _Kty, class _Hasher, class _Alloc,
-    enable_if_t<conjunction_v<_Is_hasher<_Hasher>, _Is_allocator<_Alloc>>, int> = 0>
+    enable_if_t<_Conjunction_v<_Is_hasher_v<_Hasher>, _Is_allocator_v<_Alloc>>, int> = 0>
 unordered_set(initializer_list<_Kty>, _Guide_size_type_t<_Alloc>, _Hasher, _Alloc)
     -> unordered_set<_Kty, _Hasher, equal_to<_Kty>, _Alloc>;
 #endif // _HAS_CXX17
@@ -535,31 +536,32 @@ public:
 template <class _Iter, class _Hasher = hash<_Iter_value_t<_Iter>>, class _Keyeq = equal_to<_Iter_value_t<_Iter>>,
     class _Alloc = allocator<_Iter_value_t<_Iter>>,
     enable_if_t<
-        conjunction_v<_Is_iterator<_Iter>, _Is_hasher<_Hasher>, negation<_Is_allocator<_Keyeq>>, _Is_allocator<_Alloc>>,
+        _Conjunction_v<_Is_iterator_v<_Iter>, _Is_hasher_v<_Hasher>, !_Is_allocator_v<_Keyeq>, _Is_allocator_v<_Alloc>>,
         int> = 0>
 unordered_multiset(_Iter, _Iter, _Guide_size_type_t<_Alloc> = 0, _Hasher = _Hasher(), _Keyeq = _Keyeq(),
     _Alloc = _Alloc()) -> unordered_multiset<_Iter_value_t<_Iter>, _Hasher, _Keyeq, _Alloc>;
 
 template <class _Kty, class _Hasher = hash<_Kty>, class _Keyeq = equal_to<_Kty>, class _Alloc = allocator<_Kty>,
-    enable_if_t<conjunction_v<_Is_hasher<_Hasher>, negation<_Is_allocator<_Keyeq>>, _Is_allocator<_Alloc>>, int> = 0>
+    enable_if_t<_Conjunction_v<_Is_hasher_v<_Hasher>, !_Is_allocator_v<_Keyeq>, _Is_allocator_v<_Alloc>>, int> = 0>
 unordered_multiset(initializer_list<_Kty>, _Guide_size_type_t<_Alloc> = 0, _Hasher = _Hasher(), _Keyeq = _Keyeq(),
     _Alloc = _Alloc()) -> unordered_multiset<_Kty, _Hasher, _Keyeq, _Alloc>;
 
-template <class _Iter, class _Alloc, enable_if_t<conjunction_v<_Is_iterator<_Iter>, _Is_allocator<_Alloc>>, int> = 0>
+template <class _Iter, class _Alloc,
+    enable_if_t<_Conjunction_v<_Is_iterator_v<_Iter>, _Is_allocator_v<_Alloc>>, int> = 0>
 unordered_multiset(_Iter, _Iter, _Guide_size_type_t<_Alloc>, _Alloc)
     -> unordered_multiset<_Iter_value_t<_Iter>, hash<_Iter_value_t<_Iter>>, equal_to<_Iter_value_t<_Iter>>, _Alloc>;
 
 template <class _Iter, class _Hasher, class _Alloc,
-    enable_if_t<conjunction_v<_Is_iterator<_Iter>, _Is_hasher<_Hasher>, _Is_allocator<_Alloc>>, int> = 0>
+    enable_if_t<_Conjunction_v<_Is_iterator_v<_Iter>, _Is_hasher_v<_Hasher>, _Is_allocator_v<_Alloc>>, int> = 0>
 unordered_multiset(_Iter, _Iter, _Guide_size_type_t<_Alloc>, _Hasher, _Alloc)
     -> unordered_multiset<_Iter_value_t<_Iter>, _Hasher, equal_to<_Iter_value_t<_Iter>>, _Alloc>;
 
-template <class _Kty, class _Alloc, enable_if_t<_Is_allocator<_Alloc>::value, int> = 0>
+template <class _Kty, class _Alloc, enable_if_t<_Is_allocator_v<_Alloc>, int> = 0>
 unordered_multiset(initializer_list<_Kty>, _Guide_size_type_t<_Alloc>, _Alloc)
     -> unordered_multiset<_Kty, hash<_Kty>, equal_to<_Kty>, _Alloc>;
 
 template <class _Kty, class _Hasher, class _Alloc,
-    enable_if_t<conjunction_v<_Is_hasher<_Hasher>, _Is_allocator<_Alloc>>, int> = 0>
+    enable_if_t<_Conjunction_v<_Is_hasher_v<_Hasher>, _Is_allocator_v<_Alloc>>, int> = 0>
 unordered_multiset(initializer_list<_Kty>, _Guide_size_type_t<_Alloc>, _Hasher, _Alloc)
     -> unordered_multiset<_Kty, _Hasher, equal_to<_Kty>, _Alloc>;
 #endif // _HAS_CXX17

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -1751,7 +1751,7 @@ private:
 
 #if _HAS_CXX17
 template <class _Iter, class _Alloc = allocator<_Iter_value_t<_Iter>>,
-    enable_if_t<conjunction_v<_Is_iterator<_Iter>, _Is_allocator<_Alloc>>, int> = 0>
+    enable_if_t<_Conjunction_v<_Is_iterator_v<_Iter>, _Is_allocator_v<_Alloc>>, int> = 0>
 vector(_Iter, _Iter, _Alloc = _Alloc()) -> vector<_Iter_value_t<_Iter>, _Alloc>;
 #endif // _HAS_CXX17
 

--- a/stl/inc/xhash
+++ b/stl/inc/xhash
@@ -2086,9 +2086,9 @@ protected:
 };
 
 #if _HAS_CXX17
-// ALIAS TEMPLATE _Is_hasher FOR CONSTRAINING DEDUCTION GUIDES, N4687 26.2.7 [unord.req]/17.3
+// ALIAS TEMPLATE _Is_hasher_v FOR CONSTRAINING DEDUCTION GUIDES, N4687 26.2.7 [unord.req]/17.3
 template <class _Hasher>
-using _Is_hasher = negation<disjunction<is_integral<_Hasher>, _Is_allocator<_Hasher>>>;
+_INLINE_VAR constexpr bool _Is_hasher_v = !_Disjunction_v<is_integral_v<_Hasher>, _Is_allocator_v<_Hasher>>;
 #endif // _HAS_CXX17
 
 #if !_HAS_IF_CONSTEXPR

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -864,7 +864,7 @@ _NODISCARD bool operator!=(const allocator<_Ty>&, const allocator<_Other>&) noex
 // ALIAS TEMPLATE _Guide_size_type_t FOR DEDUCTION GUIDES, N4687 26.5.4.1 [unord.map.overview]/4
 template <class _Alloc>
 using _Guide_size_type_t =
-    typename allocator_traits<conditional_t<_Is_allocator<_Alloc>::value, _Alloc, allocator<int>>>::size_type;
+    typename allocator_traits<conditional_t<_Is_allocator_v<_Alloc>, _Alloc, allocator<int>>>::size_type;
 #endif // _HAS_CXX17
 
 // ALIAS TEMPLATE _Alloc_ptr_t

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -2268,8 +2268,8 @@ private:
 #if _HAS_CXX17
     template <class _StringViewIsh>
     using _Is_string_view_ish =
-        enable_if_t<conjunction_v<is_convertible<const _StringViewIsh&, basic_string_view<_Elem, _Traits>>,
-                        negation<is_convertible<const _StringViewIsh&, const _Elem*>>>,
+        enable_if_t<_Conjunction_v<is_convertible_v<const _StringViewIsh&, basic_string_view<_Elem, _Traits>>,
+                        !is_convertible_v<const _StringViewIsh&, const _Elem*>>,
             int>;
 #endif // _HAS_CXX17
 

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -2346,7 +2346,7 @@ public:
     }
 
 #if _HAS_CXX17
-    template <class _Alloc2 = _Alloc, enable_if_t<_Is_allocator<_Alloc2>::value, int> = 0>
+    template <class _Alloc2 = _Alloc, enable_if_t<_Is_allocator_v<_Alloc2>, int> = 0>
 #endif // _HAS_CXX17
     basic_string(_In_z_ const _Elem* const _Ptr, const _Alloc& _Al) : _Mypair(_One_then_variadic_args_t{}, _Al) {
         auto&& _Alproxy = _GET_PROXY_ALLOCATOR(_Alty, _Getal());
@@ -2366,7 +2366,7 @@ public:
     }
 
 #if _HAS_CXX17
-    template <class _Alloc2 = _Alloc, enable_if_t<_Is_allocator<_Alloc2>::value, int> = 0>
+    template <class _Alloc2 = _Alloc, enable_if_t<_Is_allocator_v<_Alloc2>, int> = 0>
 #endif // _HAS_CXX17
     basic_string(_CRT_GUARDOVERFLOW const size_type _Count, const _Elem _Ch, const _Alloc& _Al)
         : _Mypair(_One_then_variadic_args_t{}, _Al) { // construct from _Count * _Ch with allocator
@@ -4341,17 +4341,15 @@ private:
 
 #if _HAS_CXX17
 template <class _Iter, class _Alloc = allocator<_Iter_value_t<_Iter>>,
-    enable_if_t<conjunction_v<_Is_iterator<_Iter>, _Is_allocator<_Alloc>>, int> = 0>
+    enable_if_t<_Conjunction_v<_Is_iterator_v<_Iter>, _Is_allocator_v<_Alloc>>, int> = 0>
 basic_string(_Iter, _Iter, _Alloc = _Alloc())
     -> basic_string<_Iter_value_t<_Iter>, char_traits<_Iter_value_t<_Iter>>, _Alloc>;
 
-template <class _Elem, class _Traits, class _Alloc = allocator<_Elem>,
-    enable_if_t<_Is_allocator<_Alloc>::value, int> = 0>
+template <class _Elem, class _Traits, class _Alloc = allocator<_Elem>, enable_if_t<_Is_allocator_v<_Alloc>, int> = 0>
 explicit basic_string(basic_string_view<_Elem, _Traits>, const _Alloc& = _Alloc())
     -> basic_string<_Elem, _Traits, _Alloc>;
 
-template <class _Elem, class _Traits, class _Alloc = allocator<_Elem>,
-    enable_if_t<_Is_allocator<_Alloc>::value, int> = 0>
+template <class _Elem, class _Traits, class _Alloc = allocator<_Elem>, enable_if_t<_Is_allocator_v<_Alloc>, int> = 0>
 basic_string(basic_string_view<_Elem, _Traits>, _Guide_size_type_t<_Alloc>, _Guide_size_type_t<_Alloc>,
     const _Alloc& = _Alloc()) -> basic_string<_Elem, _Traits, _Alloc>;
 #endif // _HAS_CXX17

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -1417,16 +1417,14 @@ constexpr void _Seek_wrapped(_Ty*& _It, _Ty* const _UIt) {
 #endif // _HAS_IF_CONSTEXPR
 
 #if _HAS_CXX17
-// STRUCT TEMPLATE _Is_allocator
+// VARIABLE TEMPLATE _Is_allocator_v
 template <class _Ty, class = void>
-struct _Is_allocator : false_type { // selected when _Ty can't possibly be an allocator
-};
+_INLINE_VAR constexpr bool _Is_allocator_v = false;
 
 template <class _Ty>
-struct _Is_allocator<_Ty, void_t<typename _Ty::value_type, decltype(_STD declval<_Ty&>().deallocate(
-                                                               _STD declval<_Ty&>().allocate(size_t{1}), size_t{1}))>>
-    : true_type { // selected when _Ty resembles an allocator, N4687 26.2.1 [container.requirements.general]/17
-};
+_INLINE_VAR constexpr bool _Is_allocator_v<_Ty,
+    void_t<typename _Ty::value_type,
+        decltype(_STD declval<_Ty&>().deallocate(_STD declval<_Ty&>().allocate(size_t{1}), size_t{1}))>> = true;
 
 // ALIAS TEMPLATES FOR DEDUCTION GUIDES, N4687 26.4.1 [associative.general]/2
 template <class _Iter>


### PR DESCRIPTION
This proposal is inspired by recent work of @ericniebler and @lewissbaker on libunifex.

The observation was that `std::conjunction` and `std::disjunction` are rather costly as they do not work on variable templates but rather require the instantiation of types all the time.

With these new variable templates one could move along and transform the rather costly invocations of `conjunction_v` and `disjunction_v` with a variable template.

For example:
```cpp
template <class _Fn>
_INLINE_VAR constexpr bool _Pass_functor_by_value_v = sizeof(_Fn) <= sizeof(void*)
                               && conjunction_v<is_trivially_copy_constructible<_Fn>, 
                                                is_trivially_destructible<_Fn>>;
```

Could be transformed into
```cpp
template <class _Fn>
_INLINE_VAR constexpr bool _Pass_functor_by_value_v = 
    _Conjunction_v<sizeof(_Fn) <= sizeof(void*),
                   is_trivially_copy_constructible_v<_Fn>, 
                   is_trivially_destructible_v<_Fn>>;
```

I did not yet commit any changes as there are some rather involved modifications requires, e.g. `_Is_allocator` directly goes back to `bool_constant` and one would have to create a new `_Is_allocator_v`. 

If this approach is not viable I would rather not invest all the time upfront.