### PR TITLE
<atomic>: removing _ENABLE_ATOMIC_ALIGNMENT_FIX

### DIFF
--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -1505,16 +1505,6 @@ public:
         return _Result;
     }
 
-#ifndef _ENABLE_ATOMIC_ALIGNMENT_FIX
-    static_assert(alignof(_Ty) >= sizeof(_Ty) || (sizeof(_Ty) != 2 && sizeof(_Ty) != 4 && sizeof(_Ty) != 8),
-        "You've instantiated std::atomic<T> with sizeof(T) equal to 2/4/8 and alignof(T) < sizeof(T). "
-        "Before VS 2015 Update 2, this would have misbehaved at runtime. "
-        "VS 2015 Update 2 was fixed to handle this correctly, "
-        "but the fix inherently changes layout and breaks binary compatibility. "
-        "Please define _ENABLE_ATOMIC_ALIGNMENT_FIX to acknowledge that you understand this, "
-        "and that everything you're linking has been compiled with VS 2015 Update 2 (or later).");
-#endif // _ENABLE_ATOMIC_ALIGNMENT_FIX
-
 #else // ^^^ don't break ABI / break ABI vvv
 
 #if _HAS_CXX17

--- a/tests/std/tests/Dev11_0863628_atomic_compare_exchange/test.cpp
+++ b/tests/std/tests/Dev11_0863628_atomic_compare_exchange/test.cpp
@@ -6,8 +6,6 @@
 // Regress\intrin\atomic.cpp
 //
 
-#define _ENABLE_ATOMIC_ALIGNMENT_FIX
-
 #include <assert.h>
 #include <atomic>
 #include <limits>

--- a/tests/std/tests/P0024R2_parallel_algorithms_is_sorted/test.cpp
+++ b/tests/std/tests/P0024R2_parallel_algorithms_is_sorted/test.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#define _ENABLE_ATOMIC_ALIGNMENT_FIX
-
 #include <algorithm>
 #include <assert.h>
 #include <deque>

--- a/tests/tr1/tests/atomic/test.cpp
+++ b/tests/tr1/tests/atomic/test.cpp
@@ -4,7 +4,6 @@
 // test <atomic> C++11 header
 #define TEST_NAME "<atomic>"
 
-#define _ENABLE_ATOMIC_ALIGNMENT_FIX
 #define _SILENCE_CXX20_ATOMIC_INIT_DEPRECATION_WARNING
 
 #include "tdefs.h"


### PR DESCRIPTION
<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->

Fixes #717 
There is also a llvm test (`llvm-project/libcxx/test/support/msvc_stdlib_force_include.h`) which defines `_ENABLE_ATOMIC_ALIGNMENT_FIX`. I guess that should be patched within llvm, right?
