### PR TITLE
Fix boyer_moore_searcher with the Rytter correction

### DIFF
--- a/stl/inc/functional
+++ b/stl/inc/functional
@@ -1768,31 +1768,57 @@ private:
 
 // FUNCTION TEMPLATE _Build_boyer_moore_delta_2_table
 template <class _RanItPat, class _Pred_eq>
-void _Build_boyer_moore_delta_2_table(_Iter_diff_t<_RanItPat>* _Shifts, const _RanItPat _Pat_first,
-    const _Iter_diff_t<_RanItPat> _Pat_size, _Pred_eq& _Eq) {
-    // builds Boyer-Moore's delta_2 table from a pattern [_Pat_first, _Pat_first + _Pat_size)
-    // pre: _Shifts is a pointer to _Pat_size _Iter_diff_t<_RanIt>s
-    if (_Pat_size == 0) {
+void _Build_boyer_moore_delta_2_table(_Iter_diff_t<_RanItPat>* const _Shifts, const _RanItPat _Pat_first,
+    const _Iter_diff_t<_RanItPat> _Mx, _Pred_eq& _Eq) {
+    // Builds Boyer-Moore's delta_2 table from a pattern [_Pat_first, _Pat_first + _Mx).
+    // pre: _Shifts is a pointer to _Mx _Iter_diff_t<_RanItPat>s.
+    // This is the `dd'` algorithm from "Fast Pattern Matching In Strings" by Knuth, Morris, and Pratt (1977).
+    // Note that the published algorithm used 1-based indexing!
+    // This contains the "Rytter correction" from "Algorithms For String Searching: A Survey" by Baeza-Yates (1989),
+    // originally from "A Correct Preprocessing Algorithm For Boyer-Moore String-Searching" by Rytter (1980).
+
+    if (_Mx == 0) {
         return;
     }
 
     using _Diff = _Iter_diff_t<_RanItPat>;
-    unique_ptr<_Diff[]> _Suffix_fn{::new _Diff[static_cast<size_t>(_Pat_size)]};
-    for (_Diff _Idx = 0; _Idx < _Pat_size; ++_Idx) {
-        _Shifts[_Idx] = 2 * _Pat_size - _Idx - 1;
+
+    const unique_ptr<_Diff[]> _Fx{new _Diff[static_cast<size_t>(_Mx)]};
+
+    for (_Diff _Kx = 1; _Kx <= _Mx; ++_Kx) {
+        _Shifts[_Kx - 1] = 2 * _Mx - _Kx;
     }
 
-    _Diff _Suffix = _Pat_size;
-    for (_Diff _Idx = _Pat_size; _Idx > 0; --_Idx, (void) --_Suffix) {
-        _Suffix_fn[static_cast<size_t>(_Idx - 1)] = _Suffix;
-        while (_Suffix < _Pat_size && !_Eq(_Pat_first[_Idx - 1], _Pat_first[_Suffix])) {
-            _Shifts[_Suffix] = (_STD min)(_Shifts[_Suffix], _Pat_size - _Idx);
-            _Suffix          = _Suffix_fn[static_cast<size_t>(_Suffix)];
+    _Diff _Tx = _Mx + 1;
+    for (_Diff _Jx = _Mx; _Jx > 0; --_Jx, (void) --_Tx) {
+        _Fx[static_cast<size_t>(_Jx - 1)] = _Tx;
+        while (_Tx <= _Mx && !_Eq(_Pat_first[_Jx - 1], _Pat_first[_Tx - 1])) {
+            _Shifts[_Tx - 1] = (_STD min)(_Shifts[_Tx - 1], _Mx - _Jx);
+            _Tx              = _Fx[static_cast<size_t>(_Tx - 1)];
         }
     }
 
-    for (_Diff _Idx = 0; _Idx <= _Suffix; ++_Idx) {
-        _Shifts[_Idx] = (_STD min)(_Shifts[_Idx], _Pat_size + _Suffix - _Idx);
+    // Rytter correction
+    _Diff _Qx = _Tx;
+    _Tx       = _Mx + 1 - _Qx;
+    for (_Diff _Jx = 1, _Tx1 = 0; _Jx <= _Tx; ++_Tx1, (void) ++_Jx) {
+        _Fx[static_cast<size_t>(_Jx - 1)] = _Tx1;
+        while (_Tx1 >= 1 && !_Eq(_Pat_first[_Jx - 1], _Pat_first[_Tx1 - 1])) {
+            _Tx1 = _Fx[static_cast<size_t>(_Tx1 - 1)];
+        }
+    }
+
+    _Diff _Qx1 = 1;
+    while (_Qx < _Mx) {
+        for (_Diff _Kx = _Qx1; _Kx <= _Qx; ++_Kx) {
+            _Shifts[_Kx - 1] = (_STD min)(_Shifts[_Kx - 1], _Mx + _Qx - _Kx);
+        }
+        _Qx1 = _Qx + 1;
+
+        const _Diff _Temp = _Fx[static_cast<size_t>(_Tx - 1)];
+
+        _Qx = _Qx + _Tx - _Temp;
+        _Tx = _Temp;
     }
 }
 

--- a/stl/inc/functional
+++ b/stl/inc/functional
@@ -1784,7 +1784,7 @@ void _Build_boyer_moore_delta_2_table(_Iter_diff_t<_RanItPat>* const _Shifts, co
         _Xlength_error("Boyer-Moore pattern is too long");
     }
 
-    const size_t _Mx = static_cast<size_t>(_Pat_size);
+    const auto _Mx = static_cast<size_t>(_Pat_size);
 
     const unique_ptr<size_t[]> _Fx{new size_t[_Mx]};
 

--- a/stl/inc/functional
+++ b/stl/inc/functional
@@ -1774,8 +1774,6 @@ void _Build_boyer_moore_delta_2_table(_Iter_diff_t<_RanItPat>* const _Shifts, co
     // pre: _Shifts is a pointer to _Mx _Iter_diff_t<_RanItPat>s.
     // This is the `dd'` algorithm from "Fast Pattern Matching In Strings" by Knuth, Morris, and Pratt (1977).
     // Note that the published algorithm used 1-based indexing!
-    // This contains the "Rytter correction" from "Algorithms For String Searching: A Survey" by Baeza-Yates (1989),
-    // originally from "A Correct Preprocessing Algorithm For Boyer-Moore String-Searching" by Rytter (1980).
 
     if (_Mx == 0) {
         return;
@@ -1798,7 +1796,9 @@ void _Build_boyer_moore_delta_2_table(_Iter_diff_t<_RanItPat>* const _Shifts, co
         }
     }
 
-    // Rytter correction
+    // The code below is the "Rytter correction" from "Algorithms For String Searching: A Survey" by Baeza-Yates (1989),
+    // originally from "A Correct Preprocessing Algorithm For Boyer-Moore String-Searching" by Rytter (1980).
+
     _Diff _Qx = _Tx;
     _Tx       = _Mx + 1 - _Qx;
     for (_Diff _Jx = 1, _Tx1 = 0; _Jx <= _Tx; ++_Tx1, (void) ++_Jx) {

--- a/stl/inc/functional
+++ b/stl/inc/functional
@@ -1769,53 +1769,58 @@ private:
 // FUNCTION TEMPLATE _Build_boyer_moore_delta_2_table
 template <class _RanItPat, class _Pred_eq>
 void _Build_boyer_moore_delta_2_table(_Iter_diff_t<_RanItPat>* const _Shifts, const _RanItPat _Pat_first,
-    const _Iter_diff_t<_RanItPat> _Mx, _Pred_eq& _Eq) {
-    // Builds Boyer-Moore's delta_2 table from a pattern [_Pat_first, _Pat_first + _Mx).
-    // pre: _Shifts is a pointer to _Mx _Iter_diff_t<_RanItPat>s.
+    const _Iter_diff_t<_RanItPat> _Pat_size, _Pred_eq& _Eq) {
+    // Builds Boyer-Moore's delta_2 table from a pattern [_Pat_first, _Pat_first + _Pat_size).
+    // pre: _Shifts is a pointer to _Pat_size _Iter_diff_t<_RanItPat>s.
     // This is the `dd'` algorithm from "Fast Pattern Matching In Strings" by Knuth, Morris, and Pratt (1977).
     // Note that the published algorithm used 1-based indexing!
+    using _Diff = _Iter_diff_t<_RanItPat>;
 
-    if (_Mx == 0) {
+    if (_Pat_size == 0) {
         return;
     }
 
-    using _Diff = _Iter_diff_t<_RanItPat>;
-
-    const unique_ptr<_Diff[]> _Fx{new _Diff[static_cast<size_t>(_Mx)]};
-
-    for (_Diff _Kx = 1; _Kx <= _Mx; ++_Kx) {
-        _Shifts[_Kx - 1] = 2 * _Mx - _Kx;
+    if ((numeric_limits<_Diff>::max)() - _Pat_size < _Pat_size) {
+        _Xlength_error("Boyer-Moore pattern is too long");
     }
 
-    _Diff _Tx = _Mx + 1;
-    for (_Diff _Jx = _Mx; _Jx > 0; --_Jx, (void) --_Tx) {
-        _Fx[static_cast<size_t>(_Jx - 1)] = _Tx;
+    const size_t _Mx = static_cast<size_t>(_Pat_size);
+
+    const unique_ptr<size_t[]> _Fx{new size_t[_Mx]};
+
+    for (size_t _Kx = 1; _Kx <= _Mx; ++_Kx) {
+        _Shifts[_Kx - 1] = static_cast<_Diff>(2 * _Mx - _Kx);
+    }
+
+    size_t _Tx = _Mx + 1;
+    for (size_t _Jx = _Mx; _Jx > 0; --_Jx, --_Tx) {
+        _Fx[_Jx - 1] = _Tx;
         while (_Tx <= _Mx && !_Eq(_Pat_first[_Jx - 1], _Pat_first[_Tx - 1])) {
-            _Shifts[_Tx - 1] = (_STD min)(_Shifts[_Tx - 1], _Mx - _Jx);
-            _Tx              = _Fx[static_cast<size_t>(_Tx - 1)];
+            _Shifts[_Tx - 1] = (_STD min)(_Shifts[_Tx - 1], static_cast<_Diff>(_Mx - _Jx));
+            _Tx              = _Fx[_Tx - 1];
         }
     }
 
     // The code below is the "Rytter correction" from "Algorithms For String Searching: A Survey" by Baeza-Yates (1989),
     // originally from "A Correct Preprocessing Algorithm For Boyer-Moore String-Searching" by Rytter (1980).
 
-    _Diff _Qx = _Tx;
-    _Tx       = _Mx + 1 - _Qx;
-    for (_Diff _Jx = 1, _Tx1 = 0; _Jx <= _Tx; ++_Tx1, (void) ++_Jx) {
-        _Fx[static_cast<size_t>(_Jx - 1)] = _Tx1;
+    size_t _Qx = _Tx;
+    _Tx        = _Mx + 1 - _Qx;
+    for (size_t _Jx = 1, _Tx1 = 0; _Jx <= _Tx; ++_Tx1, ++_Jx) {
+        _Fx[_Jx - 1] = _Tx1;
         while (_Tx1 >= 1 && !_Eq(_Pat_first[_Jx - 1], _Pat_first[_Tx1 - 1])) {
-            _Tx1 = _Fx[static_cast<size_t>(_Tx1 - 1)];
+            _Tx1 = _Fx[_Tx1 - 1];
         }
     }
 
-    _Diff _Qx1 = 1;
+    size_t _Qx1 = 1;
     while (_Qx < _Mx) {
-        for (_Diff _Kx = _Qx1; _Kx <= _Qx; ++_Kx) {
-            _Shifts[_Kx - 1] = (_STD min)(_Shifts[_Kx - 1], _Mx + _Qx - _Kx);
+        for (size_t _Kx = _Qx1; _Kx <= _Qx; ++_Kx) {
+            _Shifts[_Kx - 1] = (_STD min)(_Shifts[_Kx - 1], static_cast<_Diff>(_Mx + _Qx - _Kx));
         }
         _Qx1 = _Qx + 1;
 
-        const _Diff _Temp = _Fx[static_cast<size_t>(_Tx - 1)];
+        const size_t _Temp = _Fx[_Tx - 1];
 
         _Qx = _Qx + _Tx - _Temp;
         _Tx = _Temp;

--- a/tests/std/tests/P0220R1_searchers/test.cpp
+++ b/tests/std/tests/P0220R1_searchers/test.cpp
@@ -3,10 +3,16 @@
 
 #include <algorithm>
 #include <assert.h>
+#include <chrono>
 #include <forward_list>
 #include <functional>
 #include <initializer_list>
+#include <iostream>
 #include <iterator>
+#include <random>
+#include <stddef.h>
+#include <stdint.h>
+#include <string>
 #include <string_view>
 #include <utility>
 #include <vector>
@@ -38,9 +44,41 @@ void test_boyer_moore_table2_construction() {
     // Test cases from Boyer and Moore's original 1977 paper on page 4:
     test_case_boyer_moore_table2_construction("abcxxxabc", {14, 13, 12, 11, 10, 9, 11, 10, 1});
     test_case_boyer_moore_table2_construction("abyxcdeyx", {17, 16, 15, 14, 13, 12, 7, 10, 1});
+
     // Test case from Knuth, Morris, and Pratt's updated 1977 paper, from which our delta2
     // construction algorithm is derived, on page 20:
     test_case_boyer_moore_table2_construction("badbacbacba", {19, 18, 17, 16, 15, 8, 13, 12, 8, 12, 1});
+
+    // Test cases from Rytter's 1980 paper:
+    test_case_boyer_moore_table2_construction("aaaaaaaaaa", {10, 10, 10, 10, 10, 10, 10, 10, 10, 10});
+    test_case_boyer_moore_table2_construction("abaabaabaa", {12, 11, 10, 12, 11, 10, 12, 11, 2, 2});
+
+    // More test cases (made from scratch) exercising the Rytter correction:
+    test_case_boyer_moore_table2_construction("a", {1});
+    test_case_boyer_moore_table2_construction("aa", {2, 2});
+    test_case_boyer_moore_table2_construction("aaa", {3, 3, 3});
+    test_case_boyer_moore_table2_construction("aaaa", {4, 4, 4, 4});
+    test_case_boyer_moore_table2_construction("aaaaa", {5, 5, 5, 5, 5});
+    test_case_boyer_moore_table2_construction("aaaaaa", {6, 6, 6, 6, 6, 6});
+    test_case_boyer_moore_table2_construction("aaaaaaa", {7, 7, 7, 7, 7, 7, 7});
+    test_case_boyer_moore_table2_construction("aaaaaaaa", {8, 8, 8, 8, 8, 8, 8, 8});
+    test_case_boyer_moore_table2_construction("aaaaaaaaa", {9, 9, 9, 9, 9, 9, 9, 9, 9});
+    test_case_boyer_moore_table2_construction("ab", {3, 1});
+    test_case_boyer_moore_table2_construction("aba", {4, 3, 1});
+    test_case_boyer_moore_table2_construction("abab", {5, 4, 5, 1});
+    test_case_boyer_moore_table2_construction("ababa", {6, 5, 6, 5, 1});
+    test_case_boyer_moore_table2_construction("ababab", {7, 6, 7, 6, 7, 1});
+    test_case_boyer_moore_table2_construction("abababa", {8, 7, 8, 7, 8, 7, 1});
+    test_case_boyer_moore_table2_construction("abababab", {9, 8, 9, 8, 9, 8, 9, 1});
+    test_case_boyer_moore_table2_construction("ababababa", {10, 9, 10, 9, 10, 9, 10, 9, 1});
+    test_case_boyer_moore_table2_construction("ababababab", {11, 10, 11, 10, 11, 10, 11, 10, 11, 1});
+    test_case_boyer_moore_table2_construction("abc", {5, 4, 1});
+    test_case_boyer_moore_table2_construction("abca", {6, 5, 4, 1});
+    test_case_boyer_moore_table2_construction("abcab", {7, 6, 5, 6, 1});
+    test_case_boyer_moore_table2_construction("abcabc", {8, 7, 6, 8, 7, 1});
+    test_case_boyer_moore_table2_construction("abcabca", {9, 8, 7, 9, 8, 7, 1});
+    test_case_boyer_moore_table2_construction("abcabcab", {10, 9, 8, 10, 9, 8, 9, 1});
+    test_case_boyer_moore_table2_construction("abcabcabc", {11, 10, 9, 11, 10, 9, 11, 10, 1});
 }
 
 template <typename Searcher, typename Result, typename... Args>
@@ -92,6 +130,35 @@ void test_case_searcher(const Args... args) {
 
     test_case_searcher_found<Searcher>("abcd", "ddddabcd", 4, args...);
     test_case_searcher_not_found<Searcher>("abcd", "ddddxbcd", args...);
+
+    // GH-713 "<functional>: boyer_moore_searcher produces incorrect results"
+    test_case_searcher_found<Searcher>("aaa",
+        "fbdhhihagdjcdibfdfdgbbhjcdifffdjdaighiaaaehigjegecjffcaecagcbiaeadhebggbijfdeihiceajbcjcjghhbjfcebge", 38,
+        args...);
+    // More test cases for GH-713 discovered through randomized testing:
+    test_case_searcher_found<Searcher>("bbbb",
+        "aaaaaaabaaabaaabbabbabaaaaabaababbabaabaaaababbbaaaabbaaababbaaabbbbabaaabbaabbaaabbbabababbbb", 64, args...);
+    test_case_searcher_found<Searcher>("ababa", "babbaabbbbbabbbbabaaaaaabbabababaabba", 26, args...);
+    test_case_searcher_found<Searcher>("bababbab",
+        "bbaaaaaaabbbabaaababaaabaaababaababbabbbbabaaabbaabbbababbbaaaabbbabbbbaaaabababbabbaaaabbbbab", 75, args...);
+    test_case_searcher_found<Searcher>("abaaba",
+        "abaaabbaabababbbbbbaabbbbbaabaaababbaaabaaaaaabbbaaaaabbbbabaababaababbbbaaaabbabbaabaaabaabaaabaaba", 58,
+        args...);
+    test_case_searcher_found<Searcher>("babbabba",
+        "bbbbbbbaabbbbbbbababababaabaababbbbbaabbbbbaaababaabbabbbaabaaababbbaabaabbbbabbabbaabbabaa", 76, args...);
+    test_case_searcher_found<Searcher>("aabaaaaba", "aabaaabbaabaaaabaabbabaabaab", 8, args...);
+    test_case_searcher_found<Searcher>(
+        "babaabbaba", "abbaabbaaababbbbaabbbaababaabbabaaabbaababbbbbbabbbbbbaaaaba", 23, args...);
+    test_case_searcher_found<Searcher>(
+        "babbabbab", "aaabaabbbabaaabaaababbababbbababbabbabaaaaababbabbabab", 29, args...);
+    test_case_searcher_found<Searcher>(
+        "babcbab", "acaabcaaacccacabbaaacbbbcbbaaaaccbbbacabcbabaacbbcbcaababcbabccbccbaababcacacbbc", 54, args...);
+    test_case_searcher_found<Searcher>("cbcacbc", "abcbabcbcacbcaabbbacabbbccbccaaababbaabaabccacbaa", 6, args...);
+    test_case_searcher_found<Searcher>(
+        "cbaccbac", "babccaaaccccbcbacccacbaaccaaabbacabbacababacaccccbcccbccacbaccbacaaacaaacac", 57, args...);
+    test_case_searcher_found<Searcher>("abcabca",
+        "abbababbaccbaacbaabacccbaabbbbccbccacbbabcababbabcabcaabbaabaabbcaaaaaabaccbbbacbaabcacbcbbbaca", 47, args...);
+    test_case_searcher_found<Searcher>("bacbbacb", "cbcacbbaaaabccbacbbacbcacacbcbabcbccbacabbacbabacb", 14, args...);
 }
 
 struct FancyHash {
@@ -290,6 +357,89 @@ void test_case_BM_unicode32() {
     assert_equal(slowSlow, slowHaystack.begin(), 147, static_cast<ptrdiff_t>(slowPattern.size()));
 }
 
+void report_randomized_failure(const string_view searcher, const string_view needle, const string_view haystack) {
+    cout << searcher << " failed for needle \"" << needle << "\" and haystack \"" << haystack << "\".\n";
+    cout << "This is a randomized test.\n";
+    cout << "DO NOT IGNORE/RERUN THIS FAILURE.\n";
+    cout << "You must report it to the STL maintainers.\n";
+    assert(false);
+}
+
+void initialize_randomness(mt19937& mt) {
+    constexpr size_t n = mt19937::state_size;
+    constexpr size_t w = mt19937::word_size;
+    static_assert(w % 32 == 0);
+    constexpr size_t k = w / 32;
+
+    vector<uint32_t> vec(n * k);
+    random_device rd;
+    generate(vec.begin(), vec.end(), ref(rd));
+    seed_seq seq(vec.cbegin(), vec.cend());
+    mt.seed(seq);
+}
+
+void test_case_randomized_cases() {
+    const auto start = chrono::steady_clock::now();
+
+    mt19937 mt;
+    initialize_randomness(mt);
+
+    constexpr int Needles   = 150;
+    constexpr int Haystacks = 150;
+
+    constexpr size_t MaxNeedleLength = 10;
+    uniform_int_distribution<size_t> needle_length(1, MaxNeedleLength);
+    string needle(MaxNeedleLength, '?');
+    const auto needle_first = needle.c_str();
+
+    constexpr size_t MaxHaystackLength = 100;
+    uniform_int_distribution<size_t> haystack_length(1, MaxHaystackLength);
+    string haystack(MaxHaystackLength, '?');
+    const auto haystack_first = haystack.c_str();
+
+    for (int max_char = 'b'; max_char <= 'f'; ++max_char) {
+        uniform_int_distribution<int> characters('a', max_char);
+
+        for (int n = 0; n < Needles; ++n) {
+            needle.resize(needle_length(mt));
+            for (auto& ch : needle) {
+                ch = static_cast<char>(characters(mt));
+            }
+            const auto needle_last = needle_first + needle.size();
+
+            const default_searcher ds{needle_first, needle_last};
+            const boyer_moore_searcher bms{needle_first, needle_last};
+            const boyer_moore_horspool_searcher bmhs{needle_first, needle_last};
+
+            for (int h = 0; h < Haystacks; ++h) {
+                haystack.resize(haystack_length(mt));
+                for (auto& ch : haystack) {
+                    ch = static_cast<char>(characters(mt));
+                }
+                const auto haystack_last = haystack_first + haystack.size();
+
+                const auto correct = ds(haystack_first, haystack_last);
+
+                if (bms(haystack_first, haystack_last) != correct) {
+                    report_randomized_failure("boyer_moore_searcher", needle, haystack);
+                }
+
+                if (bmhs(haystack_first, haystack_last) != correct) {
+                    report_randomized_failure("boyer_moore_horspool_searcher", needle, haystack);
+                }
+            }
+        }
+    }
+
+    const auto finish = chrono::steady_clock::now();
+    const auto ms     = chrono::duration_cast<chrono::milliseconds>(finish - start);
+
+    if (ms.count() > 10'000) {
+        cout << "test_case_randomized_cases() took " << ms.count() << " ms.\n";
+        cout << "Consider retuning Needles and Haystacks.\n";
+    }
+}
+
 int main() {
     test_boyer_moore_table2_construction();
 
@@ -315,4 +465,6 @@ int main() {
 
     test_case_BM_unicode32<boyer_moore_searcher>();
     test_case_BM_unicode32<boyer_moore_horspool_searcher>();
+
+    test_case_randomized_cases();
 }

--- a/tests/std/tests/P0220R1_searchers/test.cpp
+++ b/tests/std/tests/P0220R1_searchers/test.cpp
@@ -366,12 +366,8 @@ void report_randomized_failure(const string_view searcher, const string_view nee
 }
 
 void initialize_randomness(mt19937& mt) {
-    constexpr size_t n = mt19937::state_size;
-    constexpr size_t w = mt19937::word_size;
-    static_assert(w % 32 == 0);
-    constexpr size_t k = w / 32;
-
-    vector<uint32_t> vec(n * k);
+    static_assert(mt19937::word_size == 32);
+    vector<uint32_t> vec(mt19937::state_size);
     random_device rd;
     generate(vec.begin(), vec.end(), ref(rd));
     seed_seq seq(vec.cbegin(), vec.cend());
@@ -379,7 +375,9 @@ void initialize_randomness(mt19937& mt) {
 }
 
 void test_case_randomized_cases() {
-    const auto start = chrono::steady_clock::now();
+    using namespace std::chrono;
+
+    const auto start = steady_clock::now();
 
     mt19937 mt;
     initialize_randomness(mt);
@@ -431,11 +429,10 @@ void test_case_randomized_cases() {
         }
     }
 
-    const auto finish = chrono::steady_clock::now();
-    const auto ms     = chrono::duration_cast<chrono::milliseconds>(finish - start);
+    const auto elapsed = steady_clock::now() - start;
 
-    if (ms.count() > 10'000) {
-        cout << "test_case_randomized_cases() took " << ms.count() << " ms.\n";
+    if (elapsed > 10s) {
+        cout << "test_case_randomized_cases() took " << duration_cast<milliseconds>(elapsed).count() << " ms.\n";
         cout << "Consider retuning Needles and Haystacks.\n";
     }
 }


### PR DESCRIPTION
This fixes #713, silent bad codegen in an important C++17 feature.

The Boyer-Moore algorithm (published 1977) relies on a "delta2" table, but that paper didn't explain how to generate the table. Another paper by Knuth, Morris, and Pratt (also 1977) provided the algorithm for the delta2 table. Actually, it provided two algorithms producing tables compatible with the usage of delta2: a basic algorithm `dd` and an improved algorithm `dd'`. We implemented the latter, and properly translated it from 1-based indexing to 0-based indexing.

However, the published algorithm for `dd'` was incorrect! This was discovered and fixed by Rytter in 1980, which we weren't aware of until we received a bug report. While the "Rytter correction" was known in the computer science literature, I find it very curious that it isn't constantly mentioned when explaining Boyer-Moore (e.g. Wikipedia's page currently makes no mention of this).

This PR applies this 40-year-old bugfix and significantly expands our test coverage.

* `<functional>`
  * Add top-level `const` to `_Shifts`. (This is the `dd'` output array; I kept the name.)
  * Rename `_Pat_size` to `_Mx` to follow the naming in the published algorithms.
  * Fix comment typo: `_RanIt` doesn't exist, it's `_RanItPat`.
  * Add comments about the history for future programmer-archaeologists.
  * Rename `_Suffix_fn` to `_Fx`, again following the papers. Note that in the usage below, there is a semantic change: `_Suffix_fn` stored 0-based values, while `_Fx` stores 1-based values. This undoes a micro-optimization (`_Suffix_fn` avoided unnecessarily translating between the 0-based and 1-based domains), but with the increased usage of `f` in the Rytter correction, I wanted greater correspondence with the published algorithms in order to verify the implementation.
  * `_Fx` can be top-level `const` (we don't reassign/reset the `unique_ptr`).
  * Obscure bugfix: `unique_ptr<T[]>` uses `default_delete<T[]>` which uses `delete[]`, so we should use `new[]` to match, not `::new[]`. (This makes a difference only for pathologically fancy `_Diff` types.)
  * Change 0-based `_Idx` to 1-based `_Kx`.
  * Change 0-based `_Suffix` to 1-based `_Tx`.
  * Rename 1-based `_Idx` to 1-based `_Jx`. (While the code was correct, I found it confusing that `_Idx` was 0-based in other loops but 1-based in this loop.)
  * Note that after these changes, the code closely corresponds to the published algorithms, except that subscripting needs to adjust from 1-based to 0-based indexing.
  * Implement the Rytter correction, which replaces the final loop of the KMP77 algorithm.
  * For clarity and debug codegen, I extracted a repeated array access into `_Temp` after verifying that this doesn't disturb the algorithm.
* `P0220R1_searchers/test.cpp`
  * Add test cases to `test_boyer_moore_table2_construction()` from Rytter's paper, and other repetitive patterns where the Rytter correction produces different results. Those patterns were "made from scratch" but for the results, I just used the output of the implementation and manually verified selected answers for the AB and ABC categories against my understanding of delta2's meaning (including the unused last entry, see #714; I was able to understand why it's 10 for `"aaaaaaaaaa"`, 2 for `"abaabaabaa"`, and why it should be 1 for `"ababababab"` and `"abcabcabc"`).
  * Add the test case from #713, plus hand-selected test cases from the randomized testing below (selected for interesting-looking patterns).
  * Add randomized test coverage for both Boyer-Moore and Boyer-Moore-Horspool (the latter is not known to have any bugs). This uses a fully-seeded `mt19937` (for speed, instead of directly using `random_device`). It prints out the needle/haystack for any failures, so we don't need the seed printing/reload machinery from `P0067R5_charconv/test.cpp`. (I'm using `mt19937` for 32-bit performance, since we don't need 64-bit values.) The randomized coverage uses alphabets from `[a-b]` to `[a-f]`; the former finds more examples of the bug being fixed here (as it's more likely to create highly repetitive patterns). Expanding the alphabet makes repetition unlikely, which is why I stop at `[a-f]`. The test does a few things to improve non-optimized debug performance (reusing `needle` and `haystack` to avoid repeated allocations, using `const char *` to avoid iterator overhead), although I didn't pursue this to the ultimate limit (e.g. `uniform_int_distribution` is somewhat costly and could be avoided at the expense of some bias). Finally, as with the other randomized coverage, I print out timing statistics if it takes a long time; on my i7-8700 it's tuned to take ~400 ms which seems reasonable (given the number of configurations, the performance of VMs, and the time needed for compilation).

While this changes the behavior of a function, it is ABI-safe. This doesn't require coordinated changes across functions - the rest of the Boyer-Moore machinery is unchanged, and the layout of the delta2 table is unchanged. We're simply filling it with different values. In the event of mismatch, the linker will either pick the correct or incorrect algorithm, so this can't make things any worse.