### PR TITLE
Suppress C5219 in the STL

### DIFF
--- a/stl/inc/xhash
+++ b/stl/inc/xhash
@@ -1057,7 +1057,7 @@ public:
     }
 
     void reserve(size_type _Maxcount) { // rebuild table with room for _Maxcount elements
-        rehash(static_cast<size_type>(static_cast<float>(_Maxcount / max_load_factor() + 0.5F)));
+        rehash(static_cast<size_type>(static_cast<float>(_Maxcount) / max_load_factor() + 0.5F));
     }
 
     conditional_t<_Multi, iterator, pair<iterator, bool>> insert(const value_type& _Val) {
@@ -1768,7 +1768,7 @@ protected:
 
     _NODISCARD size_type _Min_load_factor_buckets(const size_type _For_size) const noexcept {
         // returns the minimum number of buckets necessary for the elements in _List
-        return static_cast<size_type>(_CSTD ceilf(_For_size / max_load_factor()));
+        return static_cast<size_type>(_CSTD ceilf(static_cast<float>(_For_size) / max_load_factor()));
     }
 
     _NODISCARD size_type _Desired_grow_bucket_count(const size_type _For_size) const noexcept {

--- a/stl/src/special_math.cpp
+++ b/stl/src/special_math.cpp
@@ -8,10 +8,10 @@
 #include <utility>
 
 #pragma warning(push)
-#pragma warning(disable : 4244) // 'type cast': conversion from '%s' to '%s', possible loss of data
 #pragma warning(disable : 4619) // #pragma warning: there is no warning number '%d'
 #pragma warning(disable : 4643) // Forward declaring '%s' in namespace std is not permitted by the C++ Standard
 #pragma warning(disable : 4702) // unreachable code
+#pragma warning(disable : 5219) // implicit conversion from '%s' to '%s', possible loss of data
 
 #define BOOST_CHRONO_HEADER_ONLY
 #define BOOST_CONFIG_SUPPRESS_OUTDATED_MESSAGE

--- a/stl/src/special_math.cpp
+++ b/stl/src/special_math.cpp
@@ -8,6 +8,7 @@
 #include <utility>
 
 #pragma warning(push)
+#pragma warning(disable : 4244) // 'type cast': conversion from '%s' to '%s', possible loss of data
 #pragma warning(disable : 4619) // #pragma warning: there is no warning number '%d'
 #pragma warning(disable : 4643) // Forward declaring '%s' in namespace std is not permitted by the C++ Standard
 #pragma warning(disable : 4702) // unreachable code

--- a/tests/std/tests/VSO_0792651_unordered_set_rehash_invalidates_key/test.cpp
+++ b/tests/std/tests/VSO_0792651_unordered_set_rehash_invalidates_key/test.cpp
@@ -36,7 +36,7 @@ int main() {
     // insert nullptr because that's the moved from state; the bug made this element get returned:
     uut.insert(unique_ptr<int>{});
     // insert enough elements to be on the edge of a rehash:
-    while ((static_cast<float>(uut.size() + 1) / uut.bucket_count()) <= 0.5f) {
+    while ((static_cast<float>(uut.size() + 1) / static_cast<float>(uut.bucket_count())) <= 0.5f) {
         uut.insert(make_unique<int>(i++));
     }
 

--- a/tests/tr1/include/tdefs.h
+++ b/tests/tr1/include/tdefs.h
@@ -362,7 +362,7 @@ int approx2(Float_type d1, Float_type d2, Float_type sensitivity) { // test for 
         if (err < (Float_type) 0)
             err = -err;
 
-        sensitivity += ulp;
+        sensitivity += static_cast<Float_type>(ulp);
         if (err <= sensitivity * eps0) { // close enough, maybe display then succeed
             if (verbose)
                 CSTD printf("difference is %.2g ulp (<= %.2g ulp)"

--- a/tests/tr1/tests/unordered_map/test.cpp
+++ b/tests/tr1/tests/unordered_map/test.cpp
@@ -232,7 +232,7 @@ void test_unordered_map() { // test unordered_map
         CHECK_INT(v10.size(), 3);
         CHECK_INT(v10.count('a'), 1);
 
-        v10.reserve((Mycont::size_type)(nbuckets * v10.max_load_factor() + 0.5));
+        v10.reserve((Mycont::size_type)(static_cast<float>(nbuckets) * v10.max_load_factor() + 0.5));
         CHECK_INT(v10.size(), 3);
         CHECK_INT(v10.count('a'), 1);
     }

--- a/tests/tr1/tests/unordered_set/test.cpp
+++ b/tests/tr1/tests/unordered_set/test.cpp
@@ -212,7 +212,7 @@ void test_unordered_set() { // test unordered_set
         CHECK_INT(v10.size(), 3);
         CHECK_INT(v10.count('a'), 1);
 
-        v10.reserve((Mycont::size_type)(nbuckets * v10.max_load_factor() + 0.5));
+        v10.reserve((Mycont::size_type)(static_cast<float>(nbuckets) * v10.max_load_factor() + 0.5));
         CHECK_INT(v10.size(), 3);
         CHECK_INT(v10.count('a'), 1);
     }


### PR DESCRIPTION
C1XX now emits C5219 `implicit conversion from '%s' to '%s', possible loss of data` to warn about potentially lossy implicit conversions, e.g., from integer types to floating-point types. These changes avoid emission of the new warning from the internals and tests of the STL.

[This is a dual of internal MSVC-PR-243026.]