### PR TITLE
remove EDG related workaround related to bit_cast

### DIFF
--- a/stl/inc/bit
+++ b/stl/inc/bit
@@ -23,7 +23,6 @@ _STL_DISABLE_CLANG_WARNINGS
 #undef new
 
 _STD_BEGIN
-#ifdef __cpp_lib_bit_cast // TRANSITION, VSO-1041044
 template <class _To, class _From,
     enable_if_t<conjunction_v<bool_constant<sizeof(_To) == sizeof(_From)>, is_trivially_copyable<_To>,
                     is_trivially_copyable<_From>>,
@@ -31,7 +30,6 @@ template <class _To, class _From,
 _NODISCARD constexpr _To bit_cast(const _From& _Val) noexcept {
     return __builtin_bit_cast(_To, _Val);
 }
-#endif // TRANSITION, VSO-1041044
 
 #ifdef __cpp_lib_bitops // TRANSITION, VSO-1020212
 template <class _Ty, enable_if_t<_Is_standard_unsigned_integer<_Ty>, int> = 0>

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -1104,10 +1104,7 @@
 #define __cpp_lib_atomic_float      201711L
 #define __cpp_lib_atomic_shared_ptr 201711L
 #define __cpp_lib_bind_front        201907L
-
-#ifndef __EDG__ // TRANSITION, VSO-1041044
-#define __cpp_lib_bit_cast 201806L
-#endif // __EDG__
+#define __cpp_lib_bit_cast          201806L
 
 #ifdef __clang__ // TRANSITION, VSO-1020212
 // a future MSVC update will embed CPU feature detection into <bit> intrinsics

--- a/tests/std/tests/P0476R2_bit_cast/test.cpp
+++ b/tests/std/tests/P0476R2_bit_cast/test.cpp
@@ -1,10 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifdef __EDG__ // TRANSITION, VSO-1041044
-int main() {}
-#else // __EDG__ ^^^ / vvv !__EDG__
-
 #include <assert.h>
 #include <bit>
 #include <cmath>
@@ -263,4 +259,3 @@ int main() {
     assert(test_float());
     static_assert(test_float());
 }
-#endif // __EDG__

--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.cpp
@@ -816,7 +816,7 @@ STATIC_ASSERT(__cpp_lib_bind_front == 201907L);
 #endif
 #endif
 
-#if _HAS_CXX20 && !defined(__EDG__) // TRANSITION, VSO-1041044
+#if _HAS_CXX20
 #ifndef __cpp_lib_bit_cast
 #error __cpp_lib_bit_cast is not defined
 #elif __cpp_lib_bit_cast != 201806L


### PR DESCRIPTION
We were working around VSO-1041044 (essentially edg not supporting our __builtin_bit_cast) now it does and it appears that's landed in 16.6 preview 2 so we can remove the workaround!

I'd like to see the CI pass in both github and VSO before merging into either, due to really needing EDG coverage.