### PR TITLE
Implement ranges::subrange and ranges::view_interface

### DIFF
--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -509,15 +509,6 @@ struct _MSVC_KNOWN_SEMANTICS tuple_element<_Index, tuple<_This, _Rest...>>
     : tuple_element<_Index - 1, tuple<_Rest...>> { // recursive tuple_element definition
 };
 
-template <size_t _Index, class... _Types>
-_NODISCARD constexpr tuple_element_t<_Index, tuple<_Types...>>& get(tuple<_Types...>& _Tuple) noexcept;
-template <size_t _Index, class... _Types>
-_NODISCARD constexpr const tuple_element_t<_Index, tuple<_Types...>>& get(const tuple<_Types...>& _Tuple) noexcept;
-template <size_t _Index, class... _Types>
-_NODISCARD constexpr tuple_element_t<_Index, tuple<_Types...>>&& get(tuple<_Types...>&& _Tuple) noexcept;
-template <size_t _Index, class... _Types>
-_NODISCARD constexpr const tuple_element_t<_Index, tuple<_Types...>>&& get(const tuple<_Types...>&& _Tuple) noexcept;
-
 // TUPLE INTERFACE TO pair
 template <class _Ty1, class _Ty2>
 struct tuple_size<pair<_Ty1, _Ty2>> : integral_constant<size_t, 2> { // size of pair

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -509,6 +509,15 @@ struct _MSVC_KNOWN_SEMANTICS tuple_element<_Index, tuple<_This, _Rest...>>
     : tuple_element<_Index - 1, tuple<_Rest...>> { // recursive tuple_element definition
 };
 
+template <size_t _Index, class... _Types>
+_NODISCARD constexpr tuple_element_t<_Index, tuple<_Types...>>& get(tuple<_Types...>& _Tuple) noexcept;
+template <size_t _Index, class... _Types>
+_NODISCARD constexpr const tuple_element_t<_Index, tuple<_Types...>>& get(const tuple<_Types...>& _Tuple) noexcept;
+template <size_t _Index, class... _Types>
+_NODISCARD constexpr tuple_element_t<_Index, tuple<_Types...>>&& get(tuple<_Types...>&& _Tuple) noexcept;
+template <size_t _Index, class... _Types>
+_NODISCARD constexpr const tuple_element_t<_Index, tuple<_Types...>>&& get(const tuple<_Types...>&& _Tuple) noexcept;
+
 // TUPLE INTERFACE TO pair
 template <class _Ty1, class _Ty2>
 struct tuple_size<pair<_Ty1, _Ty2>> : integral_constant<size_t, 2> { // size of pair

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -981,7 +981,7 @@ namespace ranges {
                 if constexpr (_Has_ADL<_Ty1, _Ty2>) {
                     return {_St::_Custom, noexcept(iter_swap(_STD declval<_Ty1>(), _STD declval<_Ty2>()))};
                 } else if constexpr (_Can_swap_references<_Ty1, _Ty2>) {
-                    return {_St::_Swap, noexcept(swap(*_STD declval<_Ty1>(), *_STD declval<_Ty2>()))};
+                    return {_St::_Swap, noexcept(_RANGES swap(*_STD declval<_Ty1>(), *_STD declval<_Ty2>()))};
                 } else if constexpr (indirectly_movable_storable<remove_reference_t<_Ty1>, remove_reference_t<_Ty2>>
                     && indirectly_movable_storable<remove_reference_t<_Ty2>, remove_reference_t<_Ty1>>) {
                     constexpr auto _Nothrow = noexcept(
@@ -1002,7 +1002,7 @@ namespace ranges {
                 if constexpr (_Choice<_Ty1, _Ty2>._Strategy == _St::_Custom) {
                     iter_swap(static_cast<_Ty1&&>(_Val1), static_cast<_Ty2&&>(_Val2));
                 } else if constexpr (_Choice<_Ty1, _Ty2>._Strategy == _St::_Swap) {
-                    swap(*static_cast<_Ty1&&>(_Val1), *static_cast<_Ty2&&>(_Val2));
+                    _RANGES swap(*static_cast<_Ty1&&>(_Val1), *static_cast<_Ty2&&>(_Val2));
                 } else if constexpr (_Choice<_Ty1, _Ty2>._Strategy == _St::_Exchange) {
                     *static_cast<_Ty1&&>(_Val1) =
                         _Iter_exchange_move(static_cast<_Ty1&&>(_Val1), static_cast<_Ty2&&>(_Val2));

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -3063,8 +3063,477 @@ namespace ranges {
     template <class _Rng>
     concept common_range = range<_Rng>
         && same_as<iterator_t<_Rng>, sentinel_t<_Rng>>;
+
+    // CLASS TEMPLATE ranges::view_interface
+    template <class _Ty>
+    concept _Can_empty = requires(_Ty __t) { _RANGES empty(__t); };
+
+    template <class _Derived>
+        requires is_class_v<_Derived> && same_as<_Derived, remove_cv_t<_Derived>>
+    class view_interface : public view_base {
+    private:
+        _NODISCARD constexpr _Derived& _Cast() noexcept {
+            static_assert(derived_from<_Derived, view_interface>,
+                "view_interface's template argument T must derive from view_interface<T> (N4849 [view.interface]/2).");
+            static_assert(view<_Derived>,
+                "view_interface's template argument must model the view concept (N4849 [view.interface]/2).");
+            return static_cast<_Derived&>(*this);
+        }
+        _NODISCARD constexpr const _Derived& _Cast() const noexcept {
+            static_assert(derived_from<_Derived, view_interface>,
+                "view_interface's template argument T must derive from view_interface<T> (N4849 [view.interface]/2).");
+            static_assert(view<_Derived>,
+                "view_interface's template argument must model the view concept (N4849 [view.interface]/2).");
+            return static_cast<const _Derived&>(*this);
+        }
+
+    public:
+#ifdef __clang__ // TRANSITION, LLVM-44833
+        template <class _Dx = _Derived>
+        _NODISCARD constexpr bool empty() requires forward_range<_Dx>
+#else // ^^^ workaround / no workaround vvv
+        _NODISCARD constexpr bool empty() requires forward_range<_Derived>
+#endif // TRANSITION, LLVM-44833
+        {
+            auto& _Self = _Cast();
+            return _RANGES begin(_Self) == _RANGES end(_Self);
+        }
+
+#ifdef __clang__ // TRANSITION, LLVM-44833
+        template <class _Dx = _Derived>
+        _NODISCARD constexpr bool empty() const requires forward_range<const _Dx>
+#else // ^^^ workaround / no workaround vvv
+        _NODISCARD constexpr bool empty() const requires forward_range<const _Derived>
+#endif // TRANSITION, LLVM-44833
+        {
+            auto& _Self = _Cast();
+            return _RANGES begin(_Self) == _RANGES end(_Self);
+        }
+
+#ifdef __clang__ // TRANSITION, LLVM-44833
+        template <class _Dx = _Derived>
+        constexpr explicit operator bool() requires _Can_empty<_Dx>
+#else // ^^^ workaround / no workaround vvv
+        constexpr explicit operator bool() requires _Can_empty<_Derived>
+#endif // TRANSITION, LLVM-44833
+        {
+            return !_RANGES empty(_Cast());
+        }
+
+#ifdef __clang__ // TRANSITION, LLVM-44833
+        template <class _Dx = _Derived>
+        constexpr explicit operator bool() const requires _Can_empty<const _Dx>
+#else // ^^^ workaround / no workaround vvv
+        constexpr explicit operator bool() const requires _Can_empty<const _Derived>
+#endif // TRANSITION, LLVM-44833
+        {
+            return !_RANGES empty(_Cast());
+        }
+
+#ifdef __clang__ // TRANSITION, LLVM-44833
+        template <class _Dx = _Derived>
+        _NODISCARD constexpr auto data() requires contiguous_iterator<iterator_t<_Dx>>
+#else // ^^^ workaround / no workaround vvv
+        _NODISCARD constexpr auto data() requires contiguous_iterator<iterator_t<_Derived>>
+#endif // TRANSITION, LLVM-44833
+        {
+            return _STD to_address(_RANGES begin(_Cast()));
+        }
+#ifdef __clang__ // TRANSITION, LLVM-44833
+        template <class _Dx = _Derived>
+        _NODISCARD constexpr auto data() const
+            requires range<const _Dx> && contiguous_iterator<iterator_t<const _Dx>>
+#else // ^^^ workaround / no workaround vvv
+        _NODISCARD constexpr auto data() const
+            requires range<const _Derived> && contiguous_iterator<iterator_t<const _Derived>>
+#endif // TRANSITION, LLVM-44833
+        {
+            return _STD to_address(_RANGES begin(_Cast()));
+        }
+
+#ifdef __clang__ // TRANSITION, LLVM-44833
+        template <class _Dx = _Derived>
+        _NODISCARD constexpr auto size()
+            requires forward_range<_Dx> && sized_sentinel_for<sentinel_t<_Dx>, iterator_t<_Dx>>
+#else // ^^^ workaround / no workaround vvv
+        _NODISCARD constexpr auto size()
+            requires forward_range<_Derived> && sized_sentinel_for<sentinel_t<_Derived>, iterator_t<_Derived>>
+#endif // TRANSITION, LLVM-44833
+        {
+            auto& _Self = _Cast();
+            return _RANGES end(_Self) - _RANGES begin(_Self);
+        }
+
+#ifdef __clang__ // TRANSITION, LLVM-44833
+        template <class _Dx = _Derived>
+        _NODISCARD constexpr auto size() const requires forward_range<const _Dx>
+            && sized_sentinel_for<sentinel_t<const _Dx>, iterator_t<const _Dx>>
+#else // ^^^ workaround / no workaround vvv
+        _NODISCARD constexpr auto size() const requires forward_range<const _Derived>
+            && sized_sentinel_for<sentinel_t<const _Derived>, iterator_t<const _Derived>>
+#endif // TRANSITION, LLVM-44833
+        {
+            auto& _Self = _Cast();
+            return _RANGES end(_Self) - _RANGES begin(_Self);
+        }
+
+#ifdef __clang__ // TRANSITION, LLVM-44833
+        template <class _Dx = _Derived>
+        _NODISCARD constexpr decltype(auto) front() requires forward_range<_Dx>
+#else // ^^^ workaround / no workaround vvv
+        _NODISCARD constexpr decltype(auto) front() requires forward_range<_Derived>
+#endif // TRANSITION, LLVM-44833
+        {
+            auto& _Self = _Cast();
+#if _CONTAINER_DEBUG_LEVEL > 0
+            _STL_VERIFY(!_RANGES empty(_Self), "front called on empty view_interface");
+#endif // _CONTAINER_DEBUG_LEVEL > 0
+            return *_RANGES begin(_Self);
+        }
+
+#ifdef __clang__ // TRANSITION, LLVM-44833
+        template <class _Dx = _Derived>
+        _NODISCARD constexpr decltype(auto) front() const requires forward_range<const _Dx>
+#else // ^^^ workaround / no workaround vvv
+        _NODISCARD constexpr decltype(auto) front() const requires forward_range<const _Derived>
+#endif // TRANSITION, LLVM-44833
+        {
+            auto& _Self = _Cast();
+#if _CONTAINER_DEBUG_LEVEL > 0
+            _STL_VERIFY(!_RANGES empty(_Self), "front called on empty view_interface");
+#endif // _CONTAINER_DEBUG_LEVEL > 0
+            return *_RANGES begin(_Self);
+        }
+
+#ifdef __clang__ // TRANSITION, LLVM-44833
+        template <class _Dx = _Derived>
+        _NODISCARD constexpr decltype(auto) back() requires bidirectional_range<_Dx> && common_range<_Dx>
+#else // ^^^ workaround / no workaround vvv
+        _NODISCARD constexpr decltype(auto) back() requires bidirectional_range<_Derived> && common_range<_Derived>
+#endif // TRANSITION, LLVM-44833
+        {
+            auto& _Self = _Cast();
+#if _CONTAINER_DEBUG_LEVEL > 0
+            _STL_VERIFY(!_RANGES empty(_Self), "back called on empty view_interface");
+#endif // _CONTAINER_DEBUG_LEVEL > 0
+            auto _Last = _RANGES end(_Self);
+            return *--_Last;
+        }
+
+#ifdef __clang__ // TRANSITION, LLVM-44833
+        template <class _Dx = _Derived>
+        _NODISCARD constexpr decltype(auto) back() const
+            requires bidirectional_range<const _Dx> && common_range<const _Dx>
+#else // ^^^ workaround / no workaround vvv
+        _NODISCARD constexpr decltype(auto) back() const
+            requires bidirectional_range<const _Derived> && common_range<const _Derived>
+#endif // TRANSITION, LLVM-44833
+        {
+            auto& _Self = _Cast();
+#if _CONTAINER_DEBUG_LEVEL > 0
+            _STL_VERIFY(!_RANGES empty(_Self), "back called on empty view_interface");
+#endif // _CONTAINER_DEBUG_LEVEL > 0
+            auto _Last = _RANGES end(_Self);
+            return *--_Last;
+        }
+
+        template <random_access_range _Rng = _Derived>
+        _NODISCARD constexpr decltype(auto) operator[](const range_difference_t<_Rng> _Idx) {
+            auto& _Self = _Cast();
+#if _CONTAINER_DEBUG_LEVEL > 0
+            if constexpr (sized_range<_Derived>) {
+                _STL_VERIFY(_Idx < _RANGES size(_Self), "index out of range for view_interface");
+            }
+#endif // _CONTAINER_DEBUG_LEVEL > 0
+            return _RANGES begin(_Self)[_Idx];
+        }
+        template <random_access_range _Rng = const _Derived>
+        _NODISCARD constexpr decltype(auto) operator[](const range_difference_t<_Rng> _Idx) const {
+            auto& _Self = _Cast();
+#if _CONTAINER_DEBUG_LEVEL > 0
+            if constexpr (sized_range<_Derived>) {
+                _STL_VERIFY(_Idx < _RANGES size(_Self), "index out of range for view_interface");
+            }
+#endif // _CONTAINER_DEBUG_LEVEL > 0
+            return _RANGES begin(_Self)[_Idx];
+        }
+    };
     // clang-format on
 
+    // ENUM ranges::subrange_kind
+    enum class subrange_kind : bool { unsized, sized };
+
+    // CLASS TEMPLATE ranges::subrange
+    // clang-format off
+    template <class _From, class _To>
+    concept _Convertible_to_non_slicing = convertible_to<_From, _To>
+        && !(is_pointer_v<decay_t<_From>>
+            && is_pointer_v<decay_t<_To>>
+            && _Not_same_as<remove_pointer_t<decay_t<_From>>, remove_pointer_t<decay_t<_To>>>);
+
+    template <class _Ty>
+    concept _Pair_like =
+        !is_reference_v<_Ty> && requires(_Ty __t) {
+        typename tuple_size<_Ty>::type;
+        requires derived_from<tuple_size<_Ty>, integral_constant<size_t, 2>>;
+        typename tuple_element_t<0, remove_const_t<_Ty>>;
+        typename tuple_element_t<1, remove_const_t<_Ty>>;
+        { _STD get<0>(__t) } -> convertible_to<const tuple_element_t<0, _Ty>&>;
+        { _STD get<1>(__t) } -> convertible_to<const tuple_element_t<1, _Ty>&>;
+    };
+
+    template <class _Ty, class _First, class _Second>
+    concept _Pair_like_convertible_from = !range<_Ty> && _Pair_like<_Ty>
+        && constructible_from<_Ty, _First, _Second>
+        && _Convertible_to_non_slicing<_First, tuple_element_t<0, _Ty>>
+        && convertible_to<_Second, tuple_element_t<1, _Ty>>;
+
+    template <input_or_output_iterator _It, sentinel_for<_It> _Se = _It,
+        subrange_kind _Ki = sized_sentinel_for<_Se, _It> ? subrange_kind::sized : subrange_kind::unsized>
+        requires (_Ki == subrange_kind::sized || !sized_sentinel_for<_Se, _It>)
+    class subrange;
+    // clang-format on
+
+    template <class _It, class _Se, subrange_kind _Ki,
+        bool _Store = _Ki == subrange_kind::sized && !sized_sentinel_for<_Se, _It>>
+    class _Subrange_base : public view_interface<subrange<_It, _Se, _Ki>> { // TRANSITION, [[no_unique_address]]
+    protected:
+        using _Size_type = _Make_unsigned_like_t<iter_difference_t<_It>>;
+
+        static constexpr bool _Store_size = true;
+        _Size_type _Size                  = 0;
+
+    public:
+        _Subrange_base() = default;
+        constexpr _Subrange_base(const _Size_type& _Size_) noexcept : _Size(_Size_) {}
+    };
+
+    template <class _It, class _Se, subrange_kind _Ki>
+    class _Subrange_base<_It, _Se, _Ki, false> : public view_interface<subrange<_It, _Se, _Ki>> {
+    protected:
+        using _Size_type = _Make_unsigned_like_t<iter_difference_t<_It>>;
+
+        static constexpr bool _Store_size = false;
+
+    public:
+        _Subrange_base() = default;
+        constexpr _Subrange_base(const _Size_type&) noexcept {}
+    };
+
+    // clang-format off
+    template <input_or_output_iterator _It, sentinel_for<_It> _Se, subrange_kind _Ki>
+        requires (_Ki == subrange_kind::sized || !sized_sentinel_for<_Se, _It>)
+    class subrange : public _Subrange_base<_It, _Se, _Ki> {
+    private:
+        using _Mybase = _Subrange_base<_It, _Se, _Ki>;
+        using typename _Mybase::_Size_type;
+        using _Mybase::_Store_size;
+
+        // TRANSITION, [[no_unique_address]]:
+        /* [[no_unique_address]] */ _It _First{};
+        /* [[no_unique_address]] */ _Se _Last{};
+        // [[no_unique_address]] conditional_t<_Store_size, _Size_type, _Nil> _Size{};
+
+        template <class _Rng>
+        constexpr subrange(true_type, _Rng&& _Val) : subrange{_STD forward<_Rng>(_Val), _RANGES size(_Val)} {
+            // delegation target for subrange(_Rng&&) when _Rng models sized_range
+        }
+        template <class _Rng>
+        constexpr subrange(false_type, _Rng&& _Val) : subrange{_RANGES begin(_Val), _RANGES end(_Val)} {
+            // delegation target for subrange(_Rng&&) when _Rng does not model sized_range
+        }
+
+    public:
+        subrange() = default;
+
+        template <_Convertible_to_non_slicing<_It> _It2>
+        constexpr subrange(_It2 _First_, _Se _Last_) requires (!_Store_size)
+            : _First(_STD move(_First_)), _Last(_STD move(_Last_)) {}
+
+        template <_Convertible_to_non_slicing<_It> _It2>
+        constexpr subrange(_It2 _First_, _Se _Last_, const _Size_type _Size_) requires (_Ki == subrange_kind::sized)
+            : _Mybase(_Size_), _First(_STD move(_First_)), _Last(_STD move(_Last_)) {
+            if constexpr(sized_sentinel_for<_Se, _It>) {
+                _STL_ASSERT(_Size_ == static_cast<_Size_type>(_Last - _First),
+                    "This constructor's third argument should equal the distance "
+                    "between the first and second arguments (N4849 [range.subrange.ctor]/3).");
+            }
+        }
+
+        template <_Not_same_as<subrange> _Rng>
+            requires borrowed_range<_Rng>
+                && _Convertible_to_non_slicing<iterator_t<_Rng>, _It>
+                && convertible_to<sentinel_t<_Rng>, _Se>
+        constexpr subrange(_Rng&& _Val) requires (!_Store_size || sized_range<_Rng>)
+            : subrange{bool_constant<_Store_size>{}, _STD forward<_Rng>(_Val)} {}
+
+        template <borrowed_range _Rng>
+            requires _Convertible_to_non_slicing<iterator_t<_Rng>, _It> && convertible_to<sentinel_t<_Rng>, _Se>
+        constexpr subrange(_Rng&& _Val, const _Size_type n) requires (_Ki == subrange_kind::sized)
+            : subrange{_RANGES begin(_Val), _RANGES end(_Val), n} {}
+
+        template <_Not_same_as<subrange> _Pair_like>
+            requires _Pair_like_convertible_from<_Pair_like, const _It&, const _Se&>
+        constexpr operator _Pair_like() const {
+            return _Pair_like(_First, _Last);
+        }
+
+        _NODISCARD constexpr _It begin() const requires copyable<_It> {
+            return _First;
+        }
+        _NODISCARD constexpr _It begin() requires (!copyable<_It>) {
+            return _STD move(_First);
+        }
+
+        _NODISCARD constexpr _Se end() const {
+            return _Last;
+        }
+
+        _NODISCARD constexpr bool empty() const {
+            return _First == _Last;
+        }
+
+        _NODISCARD constexpr _Size_type size() const requires (_Ki == subrange_kind::sized) {
+            if constexpr (_Store_size) {
+                return this->_Size;
+            } else {
+                return static_cast<_Size_type>(_Last - _First);
+            }
+        }
+
+        _NODISCARD constexpr subrange next() const & requires forward_iterator<_It> {
+            auto _Tmp = *this;
+            if (_Tmp._First != _Tmp._Last) {
+                ++_Tmp._First;
+                if constexpr (_Store_size) {
+                    --_Tmp._Size;
+                }
+            }
+            return _Tmp;
+        }
+        _NODISCARD constexpr subrange next(const iter_difference_t<_It> _Count) const & requires forward_iterator<_It> {
+            auto _Tmp = *this;
+            _Tmp.advance(_Count);
+            return _Tmp;
+        }
+
+        _NODISCARD constexpr subrange next() && {
+            if (_First != _Last) {
+                ++_First;
+                if constexpr (_Store_size) {
+                    --this->_Size;
+                }
+            }
+            return _STD move(*this);
+        }
+        _NODISCARD constexpr subrange next(const iter_difference_t<_It> _Count) && {
+            advance(_Count);
+            return _STD move(*this);
+        }
+
+        _NODISCARD constexpr subrange prev() const requires bidirectional_iterator<_It> {
+            auto _Tmp = *this;
+            --_Tmp._First;
+            if constexpr (_Store_size) {
+                ++_Tmp._Size;
+            }
+            return _Tmp;
+        }
+        _NODISCARD constexpr subrange prev(const iter_difference_t<_It> _Count) const
+            requires bidirectional_iterator<_It> {
+            auto _Tmp = *this;
+            _Tmp.advance(-_Count);
+            return _Tmp;
+        }
+
+        constexpr subrange& advance(const iter_difference_t<_It> _Count) {
+            // Per as-yet-unnumbered LWG issue, this actually has defined behavior when _Count < 0.
+            if constexpr (bidirectional_iterator<_It>) {
+                if (_Count < 0) {
+                    _RANGES advance(_First, _Count);
+                    if constexpr (_Store_size) {
+                        this->_Size += static_cast<_Size_type>(-_Count);
+                    }
+                    return *this;
+                }
+            }
+
+            const auto _Remainder = _RANGES advance(_First, _Count, _Last);
+            if constexpr (_Store_size) {
+                this->_Size -= static_cast<_Size_type>(_Count - _Remainder);
+            }
+            return *this;
+        }
+    };
+    // clang-format on
+
+    template <input_or_output_iterator _It, sentinel_for<_It> _Se>
+    subrange(_It, _Se) -> subrange<_It, _Se>;
+
+    template <input_or_output_iterator _It, sentinel_for<_It> _Se>
+    subrange(_It, _Se, _Make_unsigned_like_t<iter_difference_t<_It>>) -> subrange<_It, _Se, subrange_kind::sized>;
+
+    template <borrowed_range _Rng>
+    subrange(_Rng &&) -> subrange<iterator_t<_Rng>, sentinel_t<_Rng>,
+        (sized_range<_Rng> || sized_sentinel_for<sentinel_t<_Rng>, iterator_t<_Rng>>) ? subrange_kind::sized
+                                                                                      : subrange_kind::unsized>;
+
+    template <borrowed_range _Rng>
+    subrange(_Rng&&, _Make_unsigned_like_t<range_difference_t<_Rng>>)
+        -> subrange<iterator_t<_Rng>, sentinel_t<_Rng>, subrange_kind::sized>;
+
+    template <class _It, class _Se, subrange_kind _Ki>
+    inline constexpr bool enable_borrowed_range<subrange<_It, _Se, _Ki>> = true;
+
+    // clang-format off
+    template <size_t _Idx, class _It, class _Se, subrange_kind _Ki>
+        requires (_Idx < 2)
+    constexpr auto get(const subrange<_It, _Se, _Ki>& _Val) {
+        if constexpr (_Idx == 0) {
+            return _Val.begin();
+        } else {
+            return _Val.end();
+        }
+    }
+
+    template <size_t _Idx, class _It, class _Se, subrange_kind _Ki>
+        requires (_Idx < 2)
+    constexpr auto get(subrange<_It, _Se, _Ki>&& _Val) {
+        if constexpr (_Idx == 0) {
+            return _Val.begin();
+        } else {
+            return _Val.end();
+        }
+    }
+    // clang-format on
+} // namespace ranges
+
+using ranges::get;
+
+template <class _It, class _Se, ranges::subrange_kind _Ki>
+struct tuple_size<ranges::subrange<_It, _Se, _Ki>> : integral_constant<size_t, 2> {};
+
+template <class _It, class _Se, ranges::subrange_kind _Ki>
+struct tuple_element<0, ranges::subrange<_It, _Se, _Ki>> {
+    using type = _It;
+};
+
+template <class _It, class _Se, ranges::subrange_kind _Ki>
+struct tuple_element<1, ranges::subrange<_It, _Se, _Ki>> {
+    using type = _Se;
+};
+
+template <class _It, class _Se, ranges::subrange_kind _Ki>
+struct tuple_element<0, const ranges::subrange<_It, _Se, _Ki>> {
+    using type = _It;
+};
+
+template <class _It, class _Se, ranges::subrange_kind _Ki>
+struct tuple_element<1, const ranges::subrange<_It, _Se, _Ki>> {
+    using type = _Se;
+};
+
+namespace ranges {
     // STRUCT ranges::dangling
     struct dangling {
         constexpr dangling() noexcept = default;
@@ -3075,6 +3544,10 @@ namespace ranges {
     // ALIAS TEMPLATE ranges::borrowed_iterator_t
     template <range _Rng>
     using borrowed_iterator_t = conditional_t<borrowed_range<_Rng>, iterator_t<_Rng>, dangling>;
+
+    // ALIAS TEMPLATE ranges::borrowed_subrange_t
+    template <range _Rng>
+    using borrowed_subrange_t = conditional_t<borrowed_range<_Rng>, subrange<iterator_t<_Rng>>, dangling>;
 } // namespace ranges
 #endif // __cpp_lib_concepts
 

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -3074,7 +3074,7 @@ namespace ranges {
     private:
         _NODISCARD constexpr _Derived& _Cast() noexcept {
             static_assert(derived_from<_Derived, view_interface>,
-                "view_interface's template argument T must derive from view_interface<T> (N4849 [view.interface]/2).");
+                "view_interface's template argument D must derive from view_interface<D> (N4849 [view.interface]/2).");
             static_assert(view<_Derived>,
                 "view_interface's template argument must model the view concept (N4849 [view.interface]/2).");
             return static_cast<_Derived&>(*this);
@@ -3082,7 +3082,7 @@ namespace ranges {
 
         _NODISCARD constexpr const _Derived& _Cast() const noexcept {
             static_assert(derived_from<_Derived, view_interface>,
-                "view_interface's template argument T must derive from view_interface<T> (N4849 [view.interface]/2).");
+                "view_interface's template argument D must derive from view_interface<D> (N4849 [view.interface]/2).");
             static_assert(view<_Derived>,
                 "view_interface's template argument must model the view concept (N4849 [view.interface]/2).");
             return static_cast<const _Derived&>(*this);
@@ -3267,8 +3267,8 @@ namespace ranges {
     // clang-format on
 } // namespace ranges
 
-// These declarations must be visible to unqualified name lookup for _STD get in _Pair_like below, even if
-// <tuple> hasn't yet been included.
+// These declarations must be visible to qualified name lookup for _STD get in _Pair_like below, even if <tuple> hasn't
+// yet been included.
 template <size_t _Index, class... _Types>
 _NODISCARD constexpr tuple_element_t<_Index, tuple<_Types...>>& get(tuple<_Types...>& _Tuple) noexcept;
 template <size_t _Index, class... _Types>
@@ -3288,8 +3288,7 @@ namespace ranges {
             && _Not_same_as<remove_pointer_t<decay_t<_From>>, remove_pointer_t<decay_t<_To>>>);
 
     template <class _Ty>
-    concept _Pair_like =
-        !is_reference_v<_Ty> && requires(_Ty __t) {
+    concept _Pair_like = !is_reference_v<_Ty> && requires(_Ty __t) {
         typename tuple_size<_Ty>::type;
         requires derived_from<tuple_size<_Ty>, integral_constant<size_t, 2>>;
         typename tuple_element_t<0, remove_const_t<_Ty>>;

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -3079,6 +3079,7 @@ namespace ranges {
                 "view_interface's template argument must model the view concept (N4849 [view.interface]/2).");
             return static_cast<_Derived&>(*this);
         }
+
         _NODISCARD constexpr const _Derived& _Cast() const noexcept {
             static_assert(derived_from<_Derived, view_interface>,
                 "view_interface's template argument T must derive from view_interface<T> (N4849 [view.interface]/2).");
@@ -3139,6 +3140,7 @@ namespace ranges {
         {
             return _STD to_address(_RANGES begin(_Cast()));
         }
+
 #ifdef __clang__ // TRANSITION, LLVM-44833
         template <class _Dx = _Derived>
         _NODISCARD constexpr auto data() const
@@ -3247,6 +3249,7 @@ namespace ranges {
 #endif // _CONTAINER_DEBUG_LEVEL > 0
             return _RANGES begin(_Self)[_Idx];
         }
+
         template <random_access_range _Rng = const _Derived>
         _NODISCARD constexpr decltype(auto) operator[](const range_difference_t<_Rng> _Idx) const {
             auto& _Self = _Cast();
@@ -3258,13 +3261,26 @@ namespace ranges {
             return _RANGES begin(_Self)[_Idx];
         }
     };
-    // clang-format on
 
-    // ENUM ranges::subrange_kind
+    // ENUM CLASS ranges::subrange_kind
     enum class subrange_kind : bool { unsized, sized };
+    // clang-format on
+} // namespace ranges
 
-    // CLASS TEMPLATE ranges::subrange
+// These declarations must be visible to unqualified name lookup for _STD get in _Pair_like below, even if
+// <tuple> hasn't yet been included.
+template <size_t _Index, class... _Types>
+_NODISCARD constexpr tuple_element_t<_Index, tuple<_Types...>>& get(tuple<_Types...>& _Tuple) noexcept;
+template <size_t _Index, class... _Types>
+_NODISCARD constexpr const tuple_element_t<_Index, tuple<_Types...>>& get(const tuple<_Types...>& _Tuple) noexcept;
+template <size_t _Index, class... _Types>
+_NODISCARD constexpr tuple_element_t<_Index, tuple<_Types...>>&& get(tuple<_Types...>&& _Tuple) noexcept;
+template <size_t _Index, class... _Types>
+_NODISCARD constexpr const tuple_element_t<_Index, tuple<_Types...>>&& get(const tuple<_Types...>&& _Tuple) noexcept;
+
+namespace ranges {
     // clang-format off
+    // CLASS TEMPLATE ranges::subrange
     template <class _From, class _To>
     concept _Convertible_to_non_slicing = convertible_to<_From, _To>
         && !(is_pointer_v<decay_t<_From>>
@@ -3298,26 +3314,25 @@ namespace ranges {
         bool _Store = _Ki == subrange_kind::sized && !sized_sentinel_for<_Se, _It>>
     class _Subrange_base : public view_interface<subrange<_It, _Se, _Ki>> { // TRANSITION, [[no_unique_address]]
     protected:
-        using _Size_type = _Make_unsigned_like_t<iter_difference_t<_It>>;
-
+        using _Size_type                  = _Make_unsigned_like_t<iter_difference_t<_It>>;
         static constexpr bool _Store_size = true;
-        _Size_type _Size                  = 0;
+
+        _Size_type _Size = 0;
 
     public:
         _Subrange_base() = default;
-        constexpr _Subrange_base(const _Size_type& _Size_) noexcept : _Size(_Size_) {}
+        explicit constexpr _Subrange_base(const _Size_type& _Size_) noexcept : _Size(_Size_) {}
     };
 
     template <class _It, class _Se, subrange_kind _Ki>
     class _Subrange_base<_It, _Se, _Ki, false> : public view_interface<subrange<_It, _Se, _Ki>> {
     protected:
-        using _Size_type = _Make_unsigned_like_t<iter_difference_t<_It>>;
-
+        using _Size_type                  = _Make_unsigned_like_t<iter_difference_t<_It>>;
         static constexpr bool _Store_size = false;
 
     public:
         _Subrange_base() = default;
-        constexpr _Subrange_base(const _Size_type&) noexcept {}
+        explicit constexpr _Subrange_base(const _Size_type&) noexcept {}
     };
 
     // clang-format off
@@ -3336,11 +3351,14 @@ namespace ranges {
 
         template <class _Rng>
         constexpr subrange(true_type, _Rng&& _Val) : subrange{_STD forward<_Rng>(_Val), _RANGES size(_Val)} {
-            // delegation target for subrange(_Rng&&) when _Rng models sized_range
+            // delegation target for subrange(_Rng&&) when we must store the range size
+            _STL_INTERNAL_STATIC_ASSERT(_Store_size);
         }
+
         template <class _Rng>
         constexpr subrange(false_type, _Rng&& _Val) : subrange{_RANGES begin(_Val), _RANGES end(_Val)} {
-            // delegation target for subrange(_Rng&&) when _Rng does not model sized_range
+            // delegation target for subrange(_Rng&&) when we need not store the range size
+            _STL_INTERNAL_STATIC_ASSERT(!_Store_size);
         }
 
     public:
@@ -3353,9 +3371,9 @@ namespace ranges {
         template <_Convertible_to_non_slicing<_It> _It2>
         constexpr subrange(_It2 _First_, _Se _Last_, const _Size_type _Size_) requires (_Ki == subrange_kind::sized)
             : _Mybase(_Size_), _First(_STD move(_First_)), _Last(_STD move(_Last_)) {
-            if constexpr(sized_sentinel_for<_Se, _It>) {
+            if constexpr (sized_sentinel_for<_Se, _It>) {
                 _STL_ASSERT(_Size_ == static_cast<_Size_type>(_Last - _First),
-                    "This constructor's third argument should equal the distance "
+                    "This constructor's third argument should be equal to the distance "
                     "between the first and second arguments (N4849 [range.subrange.ctor]/3).");
             }
         }
@@ -3369,8 +3387,8 @@ namespace ranges {
 
         template <borrowed_range _Rng>
             requires _Convertible_to_non_slicing<iterator_t<_Rng>, _It> && convertible_to<sentinel_t<_Rng>, _Se>
-        constexpr subrange(_Rng&& _Val, const _Size_type n) requires (_Ki == subrange_kind::sized)
-            : subrange{_RANGES begin(_Val), _RANGES end(_Val), n} {}
+        constexpr subrange(_Rng&& _Val, const _Size_type _Count) requires (_Ki == subrange_kind::sized)
+            : subrange{_RANGES begin(_Val), _RANGES end(_Val), _Count} {}
 
         template <_Not_same_as<subrange> _Pair_like>
             requires _Pair_like_convertible_from<_Pair_like, const _It&, const _Se&>
@@ -3447,7 +3465,7 @@ namespace ranges {
         }
 
         constexpr subrange& advance(const iter_difference_t<_It> _Count) {
-            // Per as-yet-unnumbered LWG issue, this actually has defined behavior when _Count < 0.
+            // Per LWG issue submitted but not numbered as of 2020-04-21, this has defined behavior when _Count < 0.
             if constexpr (bidirectional_iterator<_It>) {
                 if (_Count < 0) {
                     _RANGES advance(_First, _Count);
@@ -3488,7 +3506,7 @@ namespace ranges {
     // clang-format off
     template <size_t _Idx, class _It, class _Se, subrange_kind _Ki>
         requires (_Idx < 2)
-    constexpr auto get(const subrange<_It, _Se, _Ki>& _Val) {
+    _NODISCARD constexpr auto get(const subrange<_It, _Se, _Ki>& _Val) {
         if constexpr (_Idx == 0) {
             return _Val.begin();
         } else {
@@ -3498,7 +3516,7 @@ namespace ranges {
 
     template <size_t _Idx, class _It, class _Se, subrange_kind _Ki>
         requires (_Idx < 2)
-    constexpr auto get(subrange<_It, _Se, _Ki>&& _Val) {
+    _NODISCARD constexpr auto get(subrange<_It, _Se, _Ki>&& _Val) {
         if constexpr (_Idx == 0) {
             return _Val.begin();
         } else {

--- a/tests/std/include/range_algorithm_support.hpp
+++ b/tests/std/include/range_algorithm_support.hpp
@@ -222,9 +222,6 @@ struct test_iterator {
         STATIC_ASSERT(always_false<Category>);
     }
 
-    friend void iter_move(test_iterator const&) {
-        STATIC_ASSERT(always_false<Category>);
-    }
     friend void iter_swap(test_iterator const&, test_iterator const&) {
         STATIC_ASSERT(always_false<Category>);
     }

--- a/tests/std/include/range_algorithm_support.hpp
+++ b/tests/std/include/range_algorithm_support.hpp
@@ -106,7 +106,7 @@ private:
 
 public:
     using iterator_concept  = std::input_iterator_tag;
-    using iterator_category = std::output_iterator_tag;
+    using iterator_category = void; // TRANSITION, LWG-3289
     using value_type        = std::remove_cv_t<T>;
     using difference_type   = std::ptrdiff_t;
     using pointer           = void;

--- a/tests/std/test.lst
+++ b/tests/std/test.lst
@@ -245,6 +245,7 @@ tests\P0896R4_ranges_alg_mismatch
 tests\P0896R4_ranges_alg_none_of
 tests\P0896R4_ranges_iterator_machinery
 tests\P0896R4_ranges_range_machinery
+tests\P0896R4_ranges_subrange
 tests\P0896R4_ranges_to_address
 tests\P0898R3_concepts
 tests\P0898R3_identity

--- a/tests/std/tests/P0896R4_ranges_algorithm_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_algorithm_machinery/test.cpp
@@ -348,7 +348,7 @@ namespace indirectly_comparable_test {
 
 namespace dangling_test {
     // Also test borrowed_iterator_t and borrowed_subrange_t
-    using ranges::dangling, ranges::borrowed_iterator_t;
+    using ranges::dangling, ranges::borrowed_iterator_t, ranges::borrowed_subrange_t;
     using std::is_nothrow_constructible_v, std::same_as;
 
     STATIC_ASSERT(std::is_class_v<dangling>);
@@ -367,10 +367,8 @@ namespace dangling_test {
     STATIC_ASSERT(same_as<borrowed_iterator_t<borrowed<false>>, dangling>);
     STATIC_ASSERT(same_as<borrowed_iterator_t<borrowed<true>>, int*>);
 
-#if 0 // TRANSITION, subrange
     STATIC_ASSERT(same_as<borrowed_subrange_t<borrowed<false>>, dangling>);
     STATIC_ASSERT(same_as<borrowed_subrange_t<borrowed<true>>, ranges::subrange<int*>>);
-#endif // TRANSITION, subrange
 } // namespace dangling_test
 
 namespace result_test {

--- a/tests/std/tests/P0896R4_ranges_range_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_range_machinery/test.cpp
@@ -1503,9 +1503,7 @@ namespace borrowed_range_testing {
     STATIC_ASSERT(test_borrowed_range<std::wstring_view, std::wstring_view::iterator>());
     STATIC_ASSERT(test_borrowed_range<std::span<int>, std::span<int>::iterator>());
     STATIC_ASSERT(test_borrowed_range<std::span<int, 42>, std::span<int, 42>::iterator>());
-#if 0 // TRANSITION, subrange
     STATIC_ASSERT(test_borrowed_range<ranges::subrange<int*, int*>, int*>());
-#endif // TRANSITION, subrange
 #if 0 // TRANSITION, future
     STATIC_ASSERT(test_borrowed_range<ranges::ref_view<int[42]>, int*>());
     STATIC_ASSERT(test_borrowed_range<ranges::iota_view<int, int>, ...>());

--- a/tests/std/tests/P0896R4_ranges_subrange/env.lst
+++ b/tests/std/tests/P0896R4_ranges_subrange/env.lst
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+RUNALL_INCLUDE ..\concepts_matrix.lst

--- a/tests/std/tests/P0896R4_ranges_subrange/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_subrange/test.cpp
@@ -41,6 +41,7 @@ namespace test_view_interface {
             STATIC_ASSERT(!CanViewInterface<T volatile>);
             STATIC_ASSERT(!CanViewInterface<T const volatile>);
         }
+
         if constexpr (!std::is_void_v<T>) {
             STATIC_ASSERT(!CanViewInterface<T&>);
             STATIC_ASSERT(!CanViewInterface<T&&>);
@@ -998,7 +999,7 @@ namespace test_subrange {
         template <bool IsConst>
         struct iterator {
             using iterator_concept  = input_iterator_tag;
-            using iterator_category = output_iterator_tag;
+            using iterator_category = void; // TRANSITION, LWG-3289
             using value_type        = int;
             using difference_type   = int;
             using pointer           = void;

--- a/tests/std/tests/P0896R4_ranges_subrange/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_subrange/test.cpp
@@ -1,0 +1,1223 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Covers ranges::view_interface and ranges::subrange
+
+#include <cassert>
+#include <concepts>
+#include <forward_list>
+#include <list>
+#include <ranges>
+#include <string_view>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+#include <vector>
+//
+#include "range_algorithm_support.hpp"
+
+#define ASSERT(...) assert((__VA_ARGS__))
+
+using std::output_iterator_tag, std::input_iterator_tag, std::forward_iterator_tag, std::bidirectional_iterator_tag,
+    std::random_access_iterator_tag, std::contiguous_iterator_tag;
+
+int main() {} // COMPILE-ONLY
+
+struct empty {};
+
+namespace test_view_interface {
+    template <class T>
+    concept CanViewInterface = requires {
+        typename ranges::view_interface<T>;
+    };
+
+    template <class T>
+    constexpr bool test_template_id() {
+        // view_interface<T> is a valid template-id only if T is a cv-unqualified class type
+        STATIC_ASSERT(std::is_same_v<T, std::remove_cvref_t<T>>);
+        STATIC_ASSERT(CanViewInterface<T> == std::is_class_v<T>);
+        if constexpr (!std::is_function_v<T>) {
+            STATIC_ASSERT(!CanViewInterface<T const>);
+            STATIC_ASSERT(!CanViewInterface<T volatile>);
+            STATIC_ASSERT(!CanViewInterface<T const volatile>);
+        }
+        if constexpr (!std::is_void_v<T>) {
+            STATIC_ASSERT(!CanViewInterface<T&>);
+            STATIC_ASSERT(!CanViewInterface<T&&>);
+            if constexpr (!std::is_function_v<T>) {
+                STATIC_ASSERT(!CanViewInterface<T const&>);
+                STATIC_ASSERT(!CanViewInterface<T volatile&>);
+                STATIC_ASSERT(!CanViewInterface<T const volatile&>);
+                STATIC_ASSERT(!CanViewInterface<T const&&>);
+                STATIC_ASSERT(!CanViewInterface<T volatile&&>);
+                STATIC_ASSERT(!CanViewInterface<T const volatile&&>);
+            }
+        }
+        return true;
+    }
+
+    STATIC_ASSERT(test_template_id<int>());
+    STATIC_ASSERT(test_template_id<void>());
+    STATIC_ASSERT(test_template_id<int()>());
+    STATIC_ASSERT(test_template_id<empty>());
+
+    template <class T>
+    concept CanEmpty = requires(T& t) {
+        ranges::empty(t);
+    };
+    template <class T>
+    concept CanBool = requires(T& t) {
+        static_cast<bool>(t);
+    };
+    template <class T>
+    concept CanData = requires(T& t) {
+        ranges::data(t);
+    };
+    template <class T>
+    concept CanSize = requires(T& t) {
+        ranges::size(t);
+    };
+    template <class T>
+    concept CanFront = requires(T& t) {
+        t.front();
+    };
+    template <class T>
+    concept CanBack = requires(T& t) {
+        t.back();
+    };
+    template <class T>
+    concept CanIndex = requires(T& t) {
+        t[42];
+    };
+
+    template <class Cat, bool Common, bool SizedSentinel, bool ConstRange>
+    struct fake_view : ranges::view_interface<fake_view<Cat, Common, SizedSentinel, ConstRange>> {
+        using iterator = test_iterator<Cat, int, SizedSentinel>;
+        using sentinel = std::conditional_t<Common, iterator, std::default_sentinel_t>;
+
+        iterator begin();
+        iterator begin() const requires ConstRange;
+
+        sentinel end();
+        sentinel end() const requires ConstRange;
+    };
+
+    namespace output_unsized_onlymutable {
+        using V = fake_view<output_iterator_tag, false, false, false>;
+        STATIC_ASSERT(ranges::range<V>);
+        STATIC_ASSERT(!ranges::range<V const>);
+        STATIC_ASSERT(ranges::view<V>);
+        STATIC_ASSERT(!CanEmpty<V>);
+        STATIC_ASSERT(!CanEmpty<V const>);
+        STATIC_ASSERT(!CanBool<V>);
+        STATIC_ASSERT(!CanBool<V const>);
+        STATIC_ASSERT(!CanData<V>);
+        STATIC_ASSERT(!CanData<V const>);
+        STATIC_ASSERT(!CanSize<V>);
+        STATIC_ASSERT(!CanSize<V const>);
+        STATIC_ASSERT(!CanFront<V>);
+        STATIC_ASSERT(!CanFront<V const>);
+        STATIC_ASSERT(!CanBack<V>);
+        STATIC_ASSERT(!CanBack<V const>);
+        STATIC_ASSERT(!CanIndex<V>);
+        STATIC_ASSERT(!CanIndex<V const>);
+    } // namespace output_unsized_onlymutable
+
+    namespace output_unsized_allowconst {
+        using V = fake_view<output_iterator_tag, false, false, true>;
+        STATIC_ASSERT(ranges::range<V>);
+        STATIC_ASSERT(ranges::range<V const>);
+        STATIC_ASSERT(ranges::view<V>);
+        STATIC_ASSERT(!CanEmpty<V>);
+        STATIC_ASSERT(!CanEmpty<V const>);
+        STATIC_ASSERT(!CanBool<V>);
+        STATIC_ASSERT(!CanBool<V const>);
+        STATIC_ASSERT(!CanData<V>);
+        STATIC_ASSERT(!CanData<V const>);
+        STATIC_ASSERT(!CanSize<V>);
+        STATIC_ASSERT(!CanSize<V const>);
+        STATIC_ASSERT(!CanFront<V>);
+        STATIC_ASSERT(!CanFront<V const>);
+        STATIC_ASSERT(!CanBack<V>);
+        STATIC_ASSERT(!CanBack<V const>);
+        STATIC_ASSERT(!CanIndex<V>);
+        STATIC_ASSERT(!CanIndex<V const>);
+    } // namespace output_unsized_allowconst
+
+    namespace output_sized_onlymutable {
+        using V = fake_view<output_iterator_tag, false, true, false>;
+        STATIC_ASSERT(ranges::range<V>);
+        STATIC_ASSERT(!ranges::range<V const>);
+        STATIC_ASSERT(ranges::view<V>);
+        STATIC_ASSERT(!CanEmpty<V>);
+        STATIC_ASSERT(!CanEmpty<V const>);
+        STATIC_ASSERT(!CanBool<V>);
+        STATIC_ASSERT(!CanBool<V const>);
+        STATIC_ASSERT(!CanData<V>);
+        STATIC_ASSERT(!CanData<V const>);
+        STATIC_ASSERT(!CanSize<V>);
+        STATIC_ASSERT(!CanSize<V const>);
+        STATIC_ASSERT(!CanFront<V>);
+        STATIC_ASSERT(!CanFront<V const>);
+        STATIC_ASSERT(!CanBack<V>);
+        STATIC_ASSERT(!CanBack<V const>);
+        STATIC_ASSERT(!CanIndex<V>);
+        STATIC_ASSERT(!CanIndex<V const>);
+    } // namespace output_sized_onlymutable
+
+    namespace output_sized_allowconst {
+        using V = fake_view<output_iterator_tag, false, true, true>;
+        STATIC_ASSERT(ranges::range<V>);
+        STATIC_ASSERT(ranges::range<V const>);
+        STATIC_ASSERT(ranges::view<V>);
+        STATIC_ASSERT(!CanEmpty<V>);
+        STATIC_ASSERT(!CanEmpty<V const>);
+        STATIC_ASSERT(!CanBool<V>);
+        STATIC_ASSERT(!CanBool<V const>);
+        STATIC_ASSERT(!CanData<V>);
+        STATIC_ASSERT(!CanData<V const>);
+        STATIC_ASSERT(!CanSize<V>);
+        STATIC_ASSERT(!CanSize<V const>);
+        STATIC_ASSERT(!CanFront<V>);
+        STATIC_ASSERT(!CanFront<V const>);
+        STATIC_ASSERT(!CanBack<V>);
+        STATIC_ASSERT(!CanBack<V const>);
+        STATIC_ASSERT(!CanIndex<V>);
+        STATIC_ASSERT(!CanIndex<V const>);
+    } // namespace output_sized_allowconst
+
+    namespace input_unsized_onlymutable {
+        using V = fake_view<input_iterator_tag, false, false, false>;
+        STATIC_ASSERT(ranges::range<V>);
+        STATIC_ASSERT(!ranges::range<V const>);
+        STATIC_ASSERT(ranges::view<V>);
+        STATIC_ASSERT(!CanEmpty<V>);
+        STATIC_ASSERT(!CanEmpty<V const>);
+        STATIC_ASSERT(!CanBool<V>);
+        STATIC_ASSERT(!CanBool<V const>);
+        STATIC_ASSERT(!CanData<V>);
+        STATIC_ASSERT(!CanData<V const>);
+        STATIC_ASSERT(!CanSize<V>);
+        STATIC_ASSERT(!CanSize<V const>);
+        STATIC_ASSERT(!CanFront<V>);
+        STATIC_ASSERT(!CanFront<V const>);
+        STATIC_ASSERT(!CanBack<V>);
+        STATIC_ASSERT(!CanBack<V const>);
+        STATIC_ASSERT(!CanIndex<V>);
+        STATIC_ASSERT(!CanIndex<V const>);
+    } // namespace input_unsized_onlymutable
+
+    namespace input_unsized_allowconst {
+        using V = fake_view<input_iterator_tag, false, false, true>;
+        STATIC_ASSERT(ranges::range<V>);
+        STATIC_ASSERT(ranges::range<V const>);
+        STATIC_ASSERT(ranges::view<V>);
+        STATIC_ASSERT(!CanEmpty<V>);
+        STATIC_ASSERT(!CanEmpty<V const>);
+        STATIC_ASSERT(!CanBool<V>);
+        STATIC_ASSERT(!CanBool<V const>);
+        STATIC_ASSERT(!CanData<V>);
+        STATIC_ASSERT(!CanData<V const>);
+        STATIC_ASSERT(!CanSize<V>);
+        STATIC_ASSERT(!CanSize<V const>);
+        STATIC_ASSERT(!CanFront<V>);
+        STATIC_ASSERT(!CanFront<V const>);
+        STATIC_ASSERT(!CanBack<V>);
+        STATIC_ASSERT(!CanBack<V const>);
+        STATIC_ASSERT(!CanIndex<V>);
+        STATIC_ASSERT(!CanIndex<V const>);
+    } // namespace input_unsized_allowconst
+
+    namespace input_sized_onlymutable {
+        using V = fake_view<input_iterator_tag, false, true, false>;
+        STATIC_ASSERT(ranges::range<V>);
+        STATIC_ASSERT(!ranges::range<V const>);
+        STATIC_ASSERT(ranges::view<V>);
+        STATIC_ASSERT(!CanEmpty<V>);
+        STATIC_ASSERT(!CanEmpty<V const>);
+        STATIC_ASSERT(!CanBool<V>);
+        STATIC_ASSERT(!CanBool<V const>);
+        STATIC_ASSERT(!CanData<V>);
+        STATIC_ASSERT(!CanData<V const>);
+        STATIC_ASSERT(!CanSize<V>);
+        STATIC_ASSERT(!CanSize<V const>);
+        STATIC_ASSERT(!CanFront<V>);
+        STATIC_ASSERT(!CanFront<V const>);
+        STATIC_ASSERT(!CanBack<V>);
+        STATIC_ASSERT(!CanBack<V const>);
+        STATIC_ASSERT(!CanIndex<V>);
+        STATIC_ASSERT(!CanIndex<V const>);
+    } // namespace input_sized_onlymutable
+
+    namespace input_sized_allowconst {
+        using V = fake_view<input_iterator_tag, false, true, true>;
+        STATIC_ASSERT(ranges::range<V>);
+        STATIC_ASSERT(ranges::range<V const>);
+        STATIC_ASSERT(ranges::view<V>);
+        STATIC_ASSERT(!CanEmpty<V>);
+        STATIC_ASSERT(!CanEmpty<V const>);
+        STATIC_ASSERT(!CanBool<V>);
+        STATIC_ASSERT(!CanBool<V const>);
+        STATIC_ASSERT(!CanData<V>);
+        STATIC_ASSERT(!CanData<V const>);
+        STATIC_ASSERT(!CanSize<V>);
+        STATIC_ASSERT(!CanSize<V const>);
+        STATIC_ASSERT(!CanFront<V>);
+        STATIC_ASSERT(!CanFront<V const>);
+        STATIC_ASSERT(!CanBack<V>);
+        STATIC_ASSERT(!CanBack<V const>);
+        STATIC_ASSERT(!CanIndex<V>);
+        STATIC_ASSERT(!CanIndex<V const>);
+    } // namespace input_sized_allowconst
+
+    namespace forward_uncommon_unsized_onlymutable {
+        using V = fake_view<forward_iterator_tag, false, false, false>;
+        STATIC_ASSERT(ranges::range<V>);
+        STATIC_ASSERT(!ranges::range<V const>);
+        STATIC_ASSERT(ranges::view<V>);
+        STATIC_ASSERT(CanEmpty<V>);
+        STATIC_ASSERT(!CanEmpty<V const>);
+        STATIC_ASSERT(CanBool<V>);
+        STATIC_ASSERT(!CanBool<V const>);
+        STATIC_ASSERT(!CanData<V>);
+        STATIC_ASSERT(!CanData<V const>);
+        STATIC_ASSERT(!CanSize<V>);
+        STATIC_ASSERT(!CanSize<V const>);
+        STATIC_ASSERT(CanFront<V>);
+        STATIC_ASSERT(!CanFront<V const>);
+        STATIC_ASSERT(!CanBack<V>);
+        STATIC_ASSERT(!CanBack<V const>);
+        STATIC_ASSERT(!CanIndex<V>);
+        STATIC_ASSERT(!CanIndex<V const>);
+    } // namespace forward_uncommon_unsized_onlymutable
+
+    namespace forward_uncommon_unsized_allowconst {
+        using V = fake_view<forward_iterator_tag, false, false, true>;
+        STATIC_ASSERT(ranges::range<V>);
+        STATIC_ASSERT(ranges::range<V const>);
+        STATIC_ASSERT(ranges::view<V>);
+        STATIC_ASSERT(CanEmpty<V>);
+        STATIC_ASSERT(CanEmpty<V const>);
+        STATIC_ASSERT(CanBool<V>);
+        STATIC_ASSERT(CanBool<V const>);
+        STATIC_ASSERT(!CanData<V>);
+        STATIC_ASSERT(!CanData<V const>);
+        STATIC_ASSERT(!CanSize<V>);
+        STATIC_ASSERT(!CanSize<V const>);
+        STATIC_ASSERT(CanFront<V>);
+        STATIC_ASSERT(CanFront<V const>);
+        STATIC_ASSERT(!CanBack<V>);
+        STATIC_ASSERT(!CanBack<V const>);
+        STATIC_ASSERT(!CanIndex<V>);
+        STATIC_ASSERT(!CanIndex<V const>);
+    } // namespace forward_uncommon_unsized_allowconst
+
+    namespace forward_uncommon_sized_onlymutable {
+        using V = fake_view<forward_iterator_tag, false, true, false>;
+        STATIC_ASSERT(ranges::range<V>);
+        STATIC_ASSERT(!ranges::range<V const>);
+        STATIC_ASSERT(ranges::view<V>);
+        STATIC_ASSERT(CanEmpty<V>);
+        STATIC_ASSERT(!CanEmpty<V const>);
+        STATIC_ASSERT(CanBool<V>);
+        STATIC_ASSERT(!CanBool<V const>);
+        STATIC_ASSERT(!CanData<V>);
+        STATIC_ASSERT(!CanData<V const>);
+        STATIC_ASSERT(CanSize<V>);
+        STATIC_ASSERT(!CanSize<V const>);
+        STATIC_ASSERT(CanFront<V>);
+        STATIC_ASSERT(!CanFront<V const>);
+        STATIC_ASSERT(!CanBack<V>);
+        STATIC_ASSERT(!CanBack<V const>);
+        STATIC_ASSERT(!CanIndex<V>);
+        STATIC_ASSERT(!CanIndex<V const>);
+    } // namespace forward_uncommon_sized_onlymutable
+
+    namespace forward_uncommon_sized_allowconst {
+        using V = fake_view<forward_iterator_tag, false, true, true>;
+        STATIC_ASSERT(ranges::range<V>);
+        STATIC_ASSERT(ranges::range<V const>);
+        STATIC_ASSERT(ranges::view<V>);
+        STATIC_ASSERT(CanEmpty<V>);
+        STATIC_ASSERT(CanEmpty<V const>);
+        STATIC_ASSERT(CanBool<V>);
+        STATIC_ASSERT(CanBool<V const>);
+        STATIC_ASSERT(!CanData<V>);
+        STATIC_ASSERT(!CanData<V const>);
+        STATIC_ASSERT(CanSize<V>);
+        STATIC_ASSERT(CanSize<V const>);
+        STATIC_ASSERT(CanFront<V>);
+        STATIC_ASSERT(CanFront<V const>);
+        STATIC_ASSERT(!CanBack<V>);
+        STATIC_ASSERT(!CanBack<V const>);
+        STATIC_ASSERT(!CanIndex<V>);
+        STATIC_ASSERT(!CanIndex<V const>);
+    } // namespace forward_uncommon_sized_allowconst
+
+    namespace forward_common_unsized_onlymutable {
+        using V = fake_view<forward_iterator_tag, true, false, false>;
+        STATIC_ASSERT(ranges::range<V>);
+        STATIC_ASSERT(!ranges::range<V const>);
+        STATIC_ASSERT(ranges::view<V>);
+        STATIC_ASSERT(CanEmpty<V>);
+        STATIC_ASSERT(!CanEmpty<V const>);
+        STATIC_ASSERT(CanBool<V>);
+        STATIC_ASSERT(!CanBool<V const>);
+        STATIC_ASSERT(!CanData<V>);
+        STATIC_ASSERT(!CanData<V const>);
+        STATIC_ASSERT(!CanSize<V>);
+        STATIC_ASSERT(!CanSize<V const>);
+        STATIC_ASSERT(CanFront<V>);
+        STATIC_ASSERT(!CanFront<V const>);
+        STATIC_ASSERT(!CanBack<V>);
+        STATIC_ASSERT(!CanBack<V const>);
+        STATIC_ASSERT(!CanIndex<V>);
+        STATIC_ASSERT(!CanIndex<V const>);
+    } // namespace forward_common_unsized_onlymutable
+
+    namespace forward_common_unsized_allowconst {
+        using V = fake_view<forward_iterator_tag, true, false, true>;
+        STATIC_ASSERT(ranges::range<V>);
+        STATIC_ASSERT(ranges::range<V const>);
+        STATIC_ASSERT(ranges::view<V>);
+        STATIC_ASSERT(CanEmpty<V>);
+        STATIC_ASSERT(CanEmpty<V const>);
+        STATIC_ASSERT(CanBool<V>);
+        STATIC_ASSERT(CanBool<V const>);
+        STATIC_ASSERT(!CanData<V>);
+        STATIC_ASSERT(!CanData<V const>);
+        STATIC_ASSERT(!CanSize<V>);
+        STATIC_ASSERT(!CanSize<V const>);
+        STATIC_ASSERT(CanFront<V>);
+        STATIC_ASSERT(CanFront<V const>);
+        STATIC_ASSERT(!CanBack<V>);
+        STATIC_ASSERT(!CanBack<V const>);
+        STATIC_ASSERT(!CanIndex<V>);
+        STATIC_ASSERT(!CanIndex<V const>);
+    } // namespace forward_common_unsized_allowconst
+
+    namespace forward_common_sized_onlymutable {
+        using V = fake_view<forward_iterator_tag, true, true, false>;
+        STATIC_ASSERT(ranges::range<V>);
+        STATIC_ASSERT(!ranges::range<V const>);
+        STATIC_ASSERT(ranges::view<V>);
+        STATIC_ASSERT(CanEmpty<V>);
+        STATIC_ASSERT(!CanEmpty<V const>);
+        STATIC_ASSERT(CanBool<V>);
+        STATIC_ASSERT(!CanBool<V const>);
+        STATIC_ASSERT(!CanData<V>);
+        STATIC_ASSERT(!CanData<V const>);
+        STATIC_ASSERT(CanSize<V>);
+        STATIC_ASSERT(!CanSize<V const>);
+        STATIC_ASSERT(CanFront<V>);
+        STATIC_ASSERT(!CanFront<V const>);
+        STATIC_ASSERT(!CanBack<V>);
+        STATIC_ASSERT(!CanBack<V const>);
+        STATIC_ASSERT(!CanIndex<V>);
+        STATIC_ASSERT(!CanIndex<V const>);
+    } // namespace forward_common_sized_onlymutable
+
+    namespace forward_common_sized_allowconst {
+        using V = fake_view<forward_iterator_tag, true, true, true>;
+        STATIC_ASSERT(ranges::range<V>);
+        STATIC_ASSERT(ranges::range<V const>);
+        STATIC_ASSERT(ranges::view<V>);
+        STATIC_ASSERT(CanEmpty<V>);
+        STATIC_ASSERT(CanEmpty<V const>);
+        STATIC_ASSERT(CanBool<V>);
+        STATIC_ASSERT(CanBool<V const>);
+        STATIC_ASSERT(!CanData<V>);
+        STATIC_ASSERT(!CanData<V const>);
+        STATIC_ASSERT(CanSize<V>);
+        STATIC_ASSERT(CanSize<V const>);
+        STATIC_ASSERT(CanFront<V>);
+        STATIC_ASSERT(CanFront<V const>);
+        STATIC_ASSERT(!CanBack<V>);
+        STATIC_ASSERT(!CanBack<V const>);
+        STATIC_ASSERT(!CanIndex<V>);
+        STATIC_ASSERT(!CanIndex<V const>);
+    } // namespace forward_common_sized_allowconst
+
+    namespace bidi_uncommon_unsized_onlymutable {
+        using V = fake_view<bidirectional_iterator_tag, false, false, false>;
+        STATIC_ASSERT(ranges::range<V>);
+        STATIC_ASSERT(!ranges::range<V const>);
+        STATIC_ASSERT(ranges::view<V>);
+        STATIC_ASSERT(CanEmpty<V>);
+        STATIC_ASSERT(!CanEmpty<V const>);
+        STATIC_ASSERT(CanBool<V>);
+        STATIC_ASSERT(!CanBool<V const>);
+        STATIC_ASSERT(!CanData<V>);
+        STATIC_ASSERT(!CanData<V const>);
+        STATIC_ASSERT(!CanSize<V>);
+        STATIC_ASSERT(!CanSize<V const>);
+        STATIC_ASSERT(CanFront<V>);
+        STATIC_ASSERT(!CanFront<V const>);
+        STATIC_ASSERT(!CanBack<V>);
+        STATIC_ASSERT(!CanBack<V const>);
+        STATIC_ASSERT(!CanIndex<V>);
+        STATIC_ASSERT(!CanIndex<V const>);
+    } // namespace bidi_uncommon_unsized_onlymutable
+
+    namespace bidi_uncommon_unsized_allowconst {
+        using V = fake_view<bidirectional_iterator_tag, false, false, true>;
+        STATIC_ASSERT(ranges::range<V>);
+        STATIC_ASSERT(ranges::range<V const>);
+        STATIC_ASSERT(ranges::view<V>);
+        STATIC_ASSERT(CanEmpty<V>);
+        STATIC_ASSERT(CanEmpty<V const>);
+        STATIC_ASSERT(CanBool<V>);
+        STATIC_ASSERT(CanBool<V const>);
+        STATIC_ASSERT(!CanData<V>);
+        STATIC_ASSERT(!CanData<V const>);
+        STATIC_ASSERT(!CanSize<V>);
+        STATIC_ASSERT(!CanSize<V const>);
+        STATIC_ASSERT(CanFront<V>);
+        STATIC_ASSERT(CanFront<V const>);
+        STATIC_ASSERT(!CanBack<V>);
+        STATIC_ASSERT(!CanBack<V const>);
+        STATIC_ASSERT(!CanIndex<V>);
+        STATIC_ASSERT(!CanIndex<V const>);
+    } // namespace bidi_uncommon_unsized_allowconst
+
+    namespace bidi_uncommon_sized_onlymutable {
+        using V = fake_view<bidirectional_iterator_tag, false, true, false>;
+        STATIC_ASSERT(ranges::range<V>);
+        STATIC_ASSERT(!ranges::range<V const>);
+        STATIC_ASSERT(ranges::view<V>);
+        STATIC_ASSERT(CanEmpty<V>);
+        STATIC_ASSERT(!CanEmpty<V const>);
+        STATIC_ASSERT(CanBool<V>);
+        STATIC_ASSERT(!CanBool<V const>);
+        STATIC_ASSERT(!CanData<V>);
+        STATIC_ASSERT(!CanData<V const>);
+        STATIC_ASSERT(CanSize<V>);
+        STATIC_ASSERT(!CanSize<V const>);
+        STATIC_ASSERT(CanFront<V>);
+        STATIC_ASSERT(!CanFront<V const>);
+        STATIC_ASSERT(!CanBack<V>);
+        STATIC_ASSERT(!CanBack<V const>);
+        STATIC_ASSERT(!CanIndex<V>);
+        STATIC_ASSERT(!CanIndex<V const>);
+    } // namespace bidi_uncommon_sized_onlymutable
+
+    namespace bidi_uncommon_sized_allowconst {
+        using V = fake_view<bidirectional_iterator_tag, false, true, true>;
+        STATIC_ASSERT(ranges::range<V>);
+        STATIC_ASSERT(ranges::range<V const>);
+        STATIC_ASSERT(ranges::view<V>);
+        STATIC_ASSERT(CanEmpty<V>);
+        STATIC_ASSERT(CanEmpty<V const>);
+        STATIC_ASSERT(CanBool<V>);
+        STATIC_ASSERT(CanBool<V const>);
+        STATIC_ASSERT(!CanData<V>);
+        STATIC_ASSERT(!CanData<V const>);
+        STATIC_ASSERT(CanSize<V>);
+        STATIC_ASSERT(CanSize<V const>);
+        STATIC_ASSERT(CanFront<V>);
+        STATIC_ASSERT(CanFront<V const>);
+        STATIC_ASSERT(!CanBack<V>);
+        STATIC_ASSERT(!CanBack<V const>);
+        STATIC_ASSERT(!CanIndex<V>);
+        STATIC_ASSERT(!CanIndex<V const>);
+    } // namespace bidi_uncommon_sized_allowconst
+
+    namespace bidi_common_unsized_onlymutable {
+        using V = fake_view<bidirectional_iterator_tag, true, false, false>;
+        STATIC_ASSERT(ranges::range<V>);
+        STATIC_ASSERT(!ranges::range<V const>);
+        STATIC_ASSERT(ranges::view<V>);
+        STATIC_ASSERT(CanEmpty<V>);
+        STATIC_ASSERT(!CanEmpty<V const>);
+        STATIC_ASSERT(CanBool<V>);
+        STATIC_ASSERT(!CanBool<V const>);
+        STATIC_ASSERT(!CanData<V>);
+        STATIC_ASSERT(!CanData<V const>);
+        STATIC_ASSERT(!CanSize<V>);
+        STATIC_ASSERT(!CanSize<V const>);
+        STATIC_ASSERT(CanFront<V>);
+        STATIC_ASSERT(!CanFront<V const>);
+        STATIC_ASSERT(CanBack<V>);
+        STATIC_ASSERT(!CanBack<V const>);
+        STATIC_ASSERT(!CanIndex<V>);
+        STATIC_ASSERT(!CanIndex<V const>);
+    } // namespace bidi_common_unsized_onlymutable
+
+    namespace bidi_common_unsized_allowconst {
+        using V = fake_view<bidirectional_iterator_tag, true, false, true>;
+        STATIC_ASSERT(ranges::range<V>);
+        STATIC_ASSERT(ranges::range<V const>);
+        STATIC_ASSERT(ranges::view<V>);
+        STATIC_ASSERT(CanEmpty<V>);
+        STATIC_ASSERT(CanEmpty<V const>);
+        STATIC_ASSERT(CanBool<V>);
+        STATIC_ASSERT(CanBool<V const>);
+        STATIC_ASSERT(!CanData<V>);
+        STATIC_ASSERT(!CanData<V const>);
+        STATIC_ASSERT(!CanSize<V>);
+        STATIC_ASSERT(!CanSize<V const>);
+        STATIC_ASSERT(CanFront<V>);
+        STATIC_ASSERT(CanFront<V const>);
+        STATIC_ASSERT(CanBack<V>);
+        STATIC_ASSERT(CanBack<V const>);
+        STATIC_ASSERT(!CanIndex<V>);
+        STATIC_ASSERT(!CanIndex<V const>);
+    } // namespace bidi_common_unsized_allowconst
+
+    namespace bidi_common_sized_onlymutable {
+        using V = fake_view<bidirectional_iterator_tag, true, true, false>;
+        STATIC_ASSERT(ranges::range<V>);
+        STATIC_ASSERT(!ranges::range<V const>);
+        STATIC_ASSERT(ranges::view<V>);
+        STATIC_ASSERT(CanEmpty<V>);
+        STATIC_ASSERT(!CanEmpty<V const>);
+        STATIC_ASSERT(CanBool<V>);
+        STATIC_ASSERT(!CanBool<V const>);
+        STATIC_ASSERT(!CanData<V>);
+        STATIC_ASSERT(!CanData<V const>);
+        STATIC_ASSERT(CanSize<V>);
+        STATIC_ASSERT(!CanSize<V const>);
+        STATIC_ASSERT(CanFront<V>);
+        STATIC_ASSERT(!CanFront<V const>);
+        STATIC_ASSERT(CanBack<V>);
+        STATIC_ASSERT(!CanBack<V const>);
+        STATIC_ASSERT(!CanIndex<V>);
+        STATIC_ASSERT(!CanIndex<V const>);
+    } // namespace bidi_common_sized_onlymutable
+
+    namespace bidi_common_sized_allowconst {
+        using V = fake_view<bidirectional_iterator_tag, true, true, true>;
+        STATIC_ASSERT(ranges::range<V>);
+        STATIC_ASSERT(ranges::range<V const>);
+        STATIC_ASSERT(ranges::view<V>);
+        STATIC_ASSERT(CanEmpty<V>);
+        STATIC_ASSERT(CanEmpty<V const>);
+        STATIC_ASSERT(CanBool<V>);
+        STATIC_ASSERT(CanBool<V const>);
+        STATIC_ASSERT(!CanData<V>);
+        STATIC_ASSERT(!CanData<V const>);
+        STATIC_ASSERT(CanSize<V>);
+        STATIC_ASSERT(CanSize<V const>);
+        STATIC_ASSERT(CanFront<V>);
+        STATIC_ASSERT(CanFront<V const>);
+        STATIC_ASSERT(CanBack<V>);
+        STATIC_ASSERT(CanBack<V const>);
+        STATIC_ASSERT(!CanIndex<V>);
+        STATIC_ASSERT(!CanIndex<V const>);
+    } // namespace bidi_common_sized_allowconst
+
+    namespace random_uncommon_unsized_onlymutable {
+        using V = fake_view<random_access_iterator_tag, false, false, false>;
+        STATIC_ASSERT(ranges::range<V>);
+        STATIC_ASSERT(!ranges::range<V const>);
+        STATIC_ASSERT(ranges::view<V>);
+        STATIC_ASSERT(CanEmpty<V>);
+        STATIC_ASSERT(!CanEmpty<V const>);
+        STATIC_ASSERT(CanBool<V>);
+        STATIC_ASSERT(!CanBool<V const>);
+        STATIC_ASSERT(!CanData<V>);
+        STATIC_ASSERT(!CanData<V const>);
+        STATIC_ASSERT(!CanSize<V>);
+        STATIC_ASSERT(!CanSize<V const>);
+        STATIC_ASSERT(CanFront<V>);
+        STATIC_ASSERT(!CanFront<V const>);
+        STATIC_ASSERT(!CanBack<V>);
+        STATIC_ASSERT(!CanBack<V const>);
+        STATIC_ASSERT(CanIndex<V>);
+        STATIC_ASSERT(!CanIndex<V const>);
+    } // namespace random_uncommon_unsized_onlymutable
+
+    namespace random_uncommon_unsized_allowconst {
+        using V = fake_view<random_access_iterator_tag, false, false, true>;
+        STATIC_ASSERT(ranges::range<V>);
+        STATIC_ASSERT(ranges::range<V const>);
+        STATIC_ASSERT(ranges::view<V>);
+        STATIC_ASSERT(CanEmpty<V>);
+        STATIC_ASSERT(CanEmpty<V const>);
+        STATIC_ASSERT(CanBool<V>);
+        STATIC_ASSERT(CanBool<V const>);
+        STATIC_ASSERT(!CanData<V>);
+        STATIC_ASSERT(!CanData<V const>);
+        STATIC_ASSERT(!CanSize<V>);
+        STATIC_ASSERT(!CanSize<V const>);
+        STATIC_ASSERT(CanFront<V>);
+        STATIC_ASSERT(CanFront<V const>);
+        STATIC_ASSERT(!CanBack<V>);
+        STATIC_ASSERT(!CanBack<V const>);
+        STATIC_ASSERT(CanIndex<V>);
+        STATIC_ASSERT(CanIndex<V const>);
+    } // namespace random_uncommon_unsized_allowconst
+
+    namespace random_uncommon_sized_onlymutable {
+        using V = fake_view<random_access_iterator_tag, false, true, false>;
+        STATIC_ASSERT(ranges::range<V>);
+        STATIC_ASSERT(!ranges::range<V const>);
+        STATIC_ASSERT(ranges::view<V>);
+        STATIC_ASSERT(CanEmpty<V>);
+        STATIC_ASSERT(!CanEmpty<V const>);
+        STATIC_ASSERT(CanBool<V>);
+        STATIC_ASSERT(!CanBool<V const>);
+        STATIC_ASSERT(!CanData<V>);
+        STATIC_ASSERT(!CanData<V const>);
+        STATIC_ASSERT(CanSize<V>);
+        STATIC_ASSERT(!CanSize<V const>);
+        STATIC_ASSERT(CanFront<V>);
+        STATIC_ASSERT(!CanFront<V const>);
+        STATIC_ASSERT(!CanBack<V>);
+        STATIC_ASSERT(!CanBack<V const>);
+        STATIC_ASSERT(CanIndex<V>);
+        STATIC_ASSERT(!CanIndex<V const>);
+    } // namespace random_uncommon_sized_onlymutable
+
+    namespace random_uncommon_sized_allowconst {
+        using V = fake_view<random_access_iterator_tag, false, true, true>;
+        STATIC_ASSERT(ranges::range<V>);
+        STATIC_ASSERT(ranges::range<V const>);
+        STATIC_ASSERT(ranges::view<V>);
+        STATIC_ASSERT(CanEmpty<V>);
+        STATIC_ASSERT(CanEmpty<V const>);
+        STATIC_ASSERT(CanBool<V>);
+        STATIC_ASSERT(CanBool<V const>);
+        STATIC_ASSERT(!CanData<V>);
+        STATIC_ASSERT(!CanData<V const>);
+        STATIC_ASSERT(CanSize<V>);
+        STATIC_ASSERT(CanSize<V const>);
+        STATIC_ASSERT(CanFront<V>);
+        STATIC_ASSERT(CanFront<V const>);
+        STATIC_ASSERT(!CanBack<V>);
+        STATIC_ASSERT(!CanBack<V const>);
+        STATIC_ASSERT(CanIndex<V>);
+        STATIC_ASSERT(CanIndex<V const>);
+    } // namespace random_uncommon_sized_allowconst
+
+    namespace random_common_sized_onlymutable {
+        using V = fake_view<random_access_iterator_tag, true, true, false>;
+        STATIC_ASSERT(ranges::range<V>);
+        STATIC_ASSERT(!ranges::range<V const>);
+        STATIC_ASSERT(ranges::view<V>);
+        STATIC_ASSERT(CanEmpty<V>);
+        STATIC_ASSERT(!CanEmpty<V const>);
+        STATIC_ASSERT(CanBool<V>);
+        STATIC_ASSERT(!CanBool<V const>);
+        STATIC_ASSERT(!CanData<V>);
+        STATIC_ASSERT(!CanData<V const>);
+        STATIC_ASSERT(CanSize<V>);
+        STATIC_ASSERT(!CanSize<V const>);
+        STATIC_ASSERT(CanFront<V>);
+        STATIC_ASSERT(!CanFront<V const>);
+        STATIC_ASSERT(CanBack<V>);
+        STATIC_ASSERT(!CanBack<V const>);
+        STATIC_ASSERT(CanIndex<V>);
+        STATIC_ASSERT(!CanIndex<V const>);
+    } // namespace random_common_sized_onlymutable
+
+    namespace random_common_sized_allowconst {
+        using V = fake_view<random_access_iterator_tag, true, true, true>;
+        STATIC_ASSERT(ranges::range<V>);
+        STATIC_ASSERT(ranges::range<V const>);
+        STATIC_ASSERT(ranges::view<V>);
+        STATIC_ASSERT(CanEmpty<V>);
+        STATIC_ASSERT(CanEmpty<V const>);
+        STATIC_ASSERT(CanBool<V>);
+        STATIC_ASSERT(CanBool<V const>);
+        STATIC_ASSERT(!CanData<V>);
+        STATIC_ASSERT(!CanData<V const>);
+        STATIC_ASSERT(CanSize<V>);
+        STATIC_ASSERT(CanSize<V const>);
+        STATIC_ASSERT(CanFront<V>);
+        STATIC_ASSERT(CanFront<V const>);
+        STATIC_ASSERT(CanBack<V>);
+        STATIC_ASSERT(CanBack<V const>);
+        STATIC_ASSERT(CanIndex<V>);
+        STATIC_ASSERT(CanIndex<V const>);
+    } // namespace random_common_sized_allowconst
+
+    namespace contiguous_uncommon_unsized_onlymutable {
+        using V = fake_view<contiguous_iterator_tag, false, false, false>;
+        STATIC_ASSERT(ranges::range<V>);
+        STATIC_ASSERT(!ranges::range<V const>);
+        STATIC_ASSERT(ranges::view<V>);
+        STATIC_ASSERT(CanEmpty<V>);
+        STATIC_ASSERT(!CanEmpty<V const>);
+        STATIC_ASSERT(CanBool<V>);
+        STATIC_ASSERT(!CanBool<V const>);
+        STATIC_ASSERT(CanData<V>);
+        STATIC_ASSERT(!CanData<V const>);
+        STATIC_ASSERT(!CanSize<V>);
+        STATIC_ASSERT(!CanSize<V const>);
+        STATIC_ASSERT(CanFront<V>);
+        STATIC_ASSERT(!CanFront<V const>);
+        STATIC_ASSERT(!CanBack<V>);
+        STATIC_ASSERT(!CanBack<V const>);
+        STATIC_ASSERT(CanIndex<V>);
+        STATIC_ASSERT(!CanIndex<V const>);
+    } // namespace contiguous_uncommon_unsized_onlymutable
+
+    namespace contiguous_uncommon_unsized_allowconst {
+        using V = fake_view<contiguous_iterator_tag, false, false, true>;
+        STATIC_ASSERT(ranges::range<V>);
+        STATIC_ASSERT(ranges::range<V const>);
+        STATIC_ASSERT(ranges::view<V>);
+        STATIC_ASSERT(CanEmpty<V>);
+        STATIC_ASSERT(CanEmpty<V const>);
+        STATIC_ASSERT(CanBool<V>);
+        STATIC_ASSERT(CanBool<V const>);
+        STATIC_ASSERT(CanData<V>);
+        STATIC_ASSERT(CanData<V const>);
+        STATIC_ASSERT(!CanSize<V>);
+        STATIC_ASSERT(!CanSize<V const>);
+        STATIC_ASSERT(CanFront<V>);
+        STATIC_ASSERT(CanFront<V const>);
+        STATIC_ASSERT(!CanBack<V>);
+        STATIC_ASSERT(!CanBack<V const>);
+        STATIC_ASSERT(CanIndex<V>);
+        STATIC_ASSERT(CanIndex<V const>);
+    } // namespace contiguous_uncommon_unsized_allowconst
+
+    namespace contiguous_uncommon_sized_onlymutable {
+        using V = fake_view<contiguous_iterator_tag, false, true, false>;
+        STATIC_ASSERT(ranges::range<V>);
+        STATIC_ASSERT(!ranges::range<V const>);
+        STATIC_ASSERT(ranges::view<V>);
+        STATIC_ASSERT(CanEmpty<V>);
+        STATIC_ASSERT(!CanEmpty<V const>);
+        STATIC_ASSERT(CanBool<V>);
+        STATIC_ASSERT(!CanBool<V const>);
+        STATIC_ASSERT(CanData<V>);
+        STATIC_ASSERT(!CanData<V const>);
+        STATIC_ASSERT(CanSize<V>);
+        STATIC_ASSERT(!CanSize<V const>);
+        STATIC_ASSERT(CanFront<V>);
+        STATIC_ASSERT(!CanFront<V const>);
+        STATIC_ASSERT(!CanBack<V>);
+        STATIC_ASSERT(!CanBack<V const>);
+        STATIC_ASSERT(CanIndex<V>);
+        STATIC_ASSERT(!CanIndex<V const>);
+    } // namespace contiguous_uncommon_sized_onlymutable
+
+    namespace contiguous_uncommon_sized_allowconst {
+        using V = fake_view<contiguous_iterator_tag, false, true, true>;
+        STATIC_ASSERT(ranges::range<V>);
+        STATIC_ASSERT(ranges::range<V const>);
+        STATIC_ASSERT(ranges::view<V>);
+        STATIC_ASSERT(CanEmpty<V>);
+        STATIC_ASSERT(CanEmpty<V const>);
+        STATIC_ASSERT(CanBool<V>);
+        STATIC_ASSERT(CanBool<V const>);
+        STATIC_ASSERT(CanData<V>);
+        STATIC_ASSERT(CanData<V const>);
+        STATIC_ASSERT(CanSize<V>);
+        STATIC_ASSERT(CanSize<V const>);
+        STATIC_ASSERT(CanFront<V>);
+        STATIC_ASSERT(CanFront<V const>);
+        STATIC_ASSERT(!CanBack<V>);
+        STATIC_ASSERT(!CanBack<V const>);
+        STATIC_ASSERT(CanIndex<V>);
+        STATIC_ASSERT(CanIndex<V const>);
+    } // namespace contiguous_uncommon_sized_allowconst
+
+    namespace contiguous_common_sized_onlymutable {
+        using V = fake_view<contiguous_iterator_tag, true, true, false>;
+        STATIC_ASSERT(ranges::range<V>);
+        STATIC_ASSERT(!ranges::range<V const>);
+        STATIC_ASSERT(ranges::view<V>);
+        STATIC_ASSERT(CanEmpty<V>);
+        STATIC_ASSERT(!CanEmpty<V const>);
+        STATIC_ASSERT(CanBool<V>);
+        STATIC_ASSERT(!CanBool<V const>);
+        STATIC_ASSERT(CanData<V>);
+        STATIC_ASSERT(!CanData<V const>);
+        STATIC_ASSERT(CanSize<V>);
+        STATIC_ASSERT(!CanSize<V const>);
+        STATIC_ASSERT(CanFront<V>);
+        STATIC_ASSERT(!CanFront<V const>);
+        STATIC_ASSERT(CanBack<V>);
+        STATIC_ASSERT(!CanBack<V const>);
+        STATIC_ASSERT(CanIndex<V>);
+        STATIC_ASSERT(!CanIndex<V const>);
+    } // namespace contiguous_common_sized_onlymutable
+
+    namespace contiguous_common_sized_allowconst {
+        using V = fake_view<contiguous_iterator_tag, true, true, true>;
+        STATIC_ASSERT(ranges::range<V>);
+        STATIC_ASSERT(ranges::range<V const>);
+        STATIC_ASSERT(ranges::view<V>);
+        STATIC_ASSERT(CanEmpty<V>);
+        STATIC_ASSERT(CanEmpty<V const>);
+        STATIC_ASSERT(CanBool<V>);
+        STATIC_ASSERT(CanBool<V const>);
+        STATIC_ASSERT(CanData<V>);
+        STATIC_ASSERT(CanData<V const>);
+        STATIC_ASSERT(CanSize<V>);
+        STATIC_ASSERT(CanSize<V const>);
+        STATIC_ASSERT(CanFront<V>);
+        STATIC_ASSERT(CanFront<V const>);
+        STATIC_ASSERT(CanBack<V>);
+        STATIC_ASSERT(CanBack<V const>);
+        STATIC_ASSERT(CanIndex<V>);
+        STATIC_ASSERT(CanIndex<V const>);
+    } // namespace contiguous_common_sized_allowconst
+} // namespace test_view_interface
+
+namespace test_subrange {
+    using ranges::borrowed_range, ranges::range, ranges::sized_range, ranges::subrange, ranges::subrange_kind;
+    using std::constructible_from, std::copyable, std::default_initializable, std::movable, std::same_as,
+        std::sized_sentinel_for;
+
+    // * template-id: subrange<I, S, K> is a valid template-id iff I models input_or_output_iterator, S models
+    // sentinel_for<I>, and sized_sentinel_for<S, I> implies K == sized.
+    template <class I, class S, ranges::subrange_kind K>
+    concept CanSubrange = requires {
+        typename subrange<I, S, K>;
+    };
+    STATIC_ASSERT(CanSubrange<int*, int*, subrange_kind::sized>);
+    STATIC_ASSERT(!CanSubrange<int*, int*, subrange_kind::unsized>);
+    STATIC_ASSERT(!CanSubrange<int*, void, subrange_kind::unsized>);
+    STATIC_ASSERT(!CanSubrange<void, int*, subrange_kind::unsized>);
+    STATIC_ASSERT(CanSubrange<int*, std::unreachable_sentinel_t, subrange_kind::unsized>);
+    STATIC_ASSERT(!CanSubrange<std::unreachable_sentinel_t, int*, subrange_kind::unsized>);
+    STATIC_ASSERT(CanSubrange<int*, std::unreachable_sentinel_t, subrange_kind::sized>);
+
+    // clang-format off
+    template <class R>
+    concept HasMemberEmpty = requires(std::remove_reference_t<R> const r) {
+        { r.empty() } -> same_as<bool>;
+    };
+
+    template <class R>
+    concept HasMemberSize = requires(std::remove_reference_t<R> const r) {
+        { r.size() } -> std::integral;
+    };
+    // clang-format on
+
+    // Validate default template arguments: second defaults to first, and third defaults to subrange_kind::sized iff
+    // sized_sentinel_for<second, first>.
+    STATIC_ASSERT(same_as<subrange<int*>, subrange<int*, int*, subrange_kind::sized>>);
+    STATIC_ASSERT(same_as<subrange<int*, std::unreachable_sentinel_t>,
+        subrange<int*, std::unreachable_sentinel_t, subrange_kind::unsized>>);
+    STATIC_ASSERT(same_as<subrange<test_iterator<forward_iterator_tag, int>>,
+        subrange<test_iterator<forward_iterator_tag, int>, test_iterator<forward_iterator_tag, int>,
+            subrange_kind::unsized>>);
+
+    // Validate many properties of a specialization of subrange
+    template <class>
+    inline constexpr bool is_subrange = false;
+    template <class I, class S, subrange_kind K>
+    inline constexpr bool is_subrange<subrange<I, S, K>> = true;
+
+    template <class T>
+    inline constexpr auto kind_of = illformed<T>();
+    template <class I, class S, subrange_kind K>
+    inline constexpr auto kind_of<subrange<I, S, K>> = K;
+
+    template <class Subrange, class Rng>
+    constexpr bool test_subrange() {
+        STATIC_ASSERT(same_as<Subrange, std::remove_cvref_t<Subrange>>);
+        STATIC_ASSERT(is_subrange<Subrange>);
+
+        using I              = ranges::iterator_t<Subrange>;
+        using S              = ranges::sentinel_t<Subrange>;
+        constexpr bool sized = kind_of<Subrange> == subrange_kind::sized;
+        static_assert(
+            std::integral<std::iter_difference_t<I>>, "make_unsigned_t below needs to be make-unsigned-like-t");
+        using size_type = std::make_unsigned_t<std::iter_difference_t<I>>;
+
+        // Validate SMFs
+        STATIC_ASSERT(default_initializable<Subrange>);
+        STATIC_ASSERT(movable<Subrange>);
+        STATIC_ASSERT(!copyable<I> || copyable<Subrange>);
+
+        STATIC_ASSERT(constructible_from<Subrange, I, S> == (!sized || sized_sentinel_for<S, I>) );
+        STATIC_ASSERT(
+            constructible_from<Subrange, I const&, S const&> == (copyable<I> && (!sized || sized_sentinel_for<S, I>) ));
+        STATIC_ASSERT(constructible_from<Subrange, I, S, size_type> == sized);
+        STATIC_ASSERT(constructible_from<Subrange, I const&, S const&, size_type> == (copyable<I> && sized));
+
+        STATIC_ASSERT(constructible_from<Subrange, Rng&> == (!sized || sized_range<Rng> || sized_sentinel_for<S, I>) );
+        STATIC_ASSERT(constructible_from<Subrange, Rng&, size_type> == sized);
+        STATIC_ASSERT(constructible_from<Subrange,
+                          Rng> == (borrowed_range<Rng> && (!sized || sized_range<Rng> || sized_sentinel_for<S, I>) ));
+        STATIC_ASSERT(constructible_from<Subrange, Rng, size_type> == (sized && borrowed_range<Rng>) );
+
+        // Validate begin/end/empty
+        STATIC_ASSERT(range<Subrange>);
+        STATIC_ASSERT(HasMemberEmpty<Subrange const>);
+        STATIC_ASSERT(!copyable<I> || range<Subrange const&>);
+
+        // Validate size
+        STATIC_ASSERT(sized == HasMemberSize<Subrange>);
+
+        return true;
+    }
+
+    template <class Rng>
+    constexpr bool test_construction() {
+        STATIC_ASSERT(same_as<Rng, std::remove_cvref_t<Rng>>);
+
+        using I = ranges::iterator_t<Rng>;
+        using S = ranges::sentinel_t<Rng>;
+
+        STATIC_ASSERT(test_subrange<subrange<I, S, subrange_kind::sized>, Rng>());
+        if constexpr (!sized_sentinel_for<S, I>) {
+            STATIC_ASSERT(test_subrange<subrange<I, S, subrange_kind::unsized>, Rng>());
+        }
+
+        return true;
+    }
+    STATIC_ASSERT(test_construction<test_range<output_iterator_tag, int, false, false>>());
+    STATIC_ASSERT(test_construction<test_range<output_iterator_tag, int, true, false>>());
+    STATIC_ASSERT(test_construction<test_range<input_iterator_tag, int, false, false>>());
+    STATIC_ASSERT(test_construction<test_range<input_iterator_tag, int, true, false>>());
+    STATIC_ASSERT(test_construction<test_range<forward_iterator_tag, int, false, false>>());
+    STATIC_ASSERT(test_construction<test_range<forward_iterator_tag, int, false, true>>());
+    STATIC_ASSERT(test_construction<test_range<forward_iterator_tag, int, true, false>>());
+    STATIC_ASSERT(test_construction<test_range<forward_iterator_tag, int, true, true>>());
+    STATIC_ASSERT(test_construction<test_range<bidirectional_iterator_tag, int, false, false>>());
+    STATIC_ASSERT(test_construction<test_range<bidirectional_iterator_tag, int, false, true>>());
+    STATIC_ASSERT(test_construction<test_range<bidirectional_iterator_tag, int, true, false>>());
+    STATIC_ASSERT(test_construction<test_range<bidirectional_iterator_tag, int, true, true>>());
+    STATIC_ASSERT(test_construction<test_range<random_access_iterator_tag, int, true, false>>());
+    STATIC_ASSERT(test_construction<test_range<random_access_iterator_tag, int, true, true>>());
+    STATIC_ASSERT(test_construction<test_range<contiguous_iterator_tag, int, true, false>>());
+    STATIC_ASSERT(test_construction<test_range<contiguous_iterator_tag, int, true, true>>());
+
+    STATIC_ASSERT(test_construction<std::forward_list<int>>());
+    STATIC_ASSERT(test_construction<std::list<int>>());
+    STATIC_ASSERT(test_construction<std::vector<int>>());
+    STATIC_ASSERT(test_construction<std::string_view>());
+
+    // Validate that slicing conversions are forbidden
+    struct Base {};
+    struct Derived : Base {};
+    STATIC_ASSERT(!std::constructible_from<subrange<Base*>, Derived*, Derived*>);
+    STATIC_ASSERT(!std::constructible_from<subrange<Base*>, Derived*, Derived*, std::make_unsigned_t<std::ptrdiff_t>>);
+    STATIC_ASSERT(!std::constructible_from<subrange<Base*>, subrange<Derived*>>);
+    STATIC_ASSERT(!std::constructible_from<subrange<Base*>, subrange<Derived*>, std::make_unsigned_t<std::ptrdiff_t>>);
+
+    struct with_converting_iterators {
+        template <bool IsConst>
+        struct iterator {
+            using iterator_concept  = input_iterator_tag;
+            using iterator_category = output_iterator_tag;
+            using value_type        = int;
+            using difference_type   = int;
+            using pointer           = void;
+            using reference         = int;
+
+            iterator() = default;
+            iterator(iterator<!IsConst>) requires IsConst;
+
+            iterator(iterator&&) = default;
+            iterator& operator=(iterator&&) = default;
+
+            int operator*() const;
+            iterator& operator++();
+            void operator++(int);
+        };
+
+        template <bool IsConst>
+        struct sentinel {
+            sentinel() = default;
+            sentinel(sentinel<!IsConst>) requires IsConst;
+
+            bool operator==(iterator<IsConst> const&) const;
+        };
+
+        iterator<false> begin();
+        sentinel<false> end();
+        iterator<true> begin() const;
+        sentinel<true> end() const;
+    };
+
+    void test_non_slicing_conversions() {
+        // and non-slicing conversions are ok
+        using LI = std::list<int>::iterator;
+        STATIC_ASSERT(std::constructible_from<subrange<std::list<int>::const_iterator>, LI const&, LI const&>);
+        STATIC_ASSERT(std::constructible_from<subrange<std::list<int>::const_iterator>, LI, LI>);
+
+        using I  = ranges::iterator_t<with_converting_iterators>;
+        using S  = ranges::sentinel_t<with_converting_iterators>;
+        using CI = ranges::iterator_t<with_converting_iterators const>;
+        using CS = ranges::sentinel_t<with_converting_iterators const>;
+
+        using SizedSubrange = subrange<CI, CS, subrange_kind::sized>;
+        STATIC_ASSERT(test_subrange<SizedSubrange, with_converting_iterators>());
+
+        STATIC_ASSERT(!constructible_from<SizedSubrange, I&, S&>); // lvalues are not convertible
+        STATIC_ASSERT(!constructible_from<SizedSubrange, I&, S&, unsigned int>); // ditto
+        STATIC_ASSERT(!constructible_from<SizedSubrange, I, S>); // missing size
+        STATIC_ASSERT(constructible_from<SizedSubrange, I, S, unsigned int>);
+
+        using UnsizedSubrange = subrange<CI, CS, subrange_kind::unsized>;
+        STATIC_ASSERT(test_subrange<UnsizedSubrange, with_converting_iterators>());
+
+        STATIC_ASSERT(!constructible_from<UnsizedSubrange, I&, S&>); // lvalues are not convertible
+        STATIC_ASSERT(!constructible_from<UnsizedSubrange, I&, S&, unsigned int>); // ditto
+        STATIC_ASSERT(constructible_from<UnsizedSubrange, I, S>); // but rvalues are
+        STATIC_ASSERT(!constructible_from<UnsizedSubrange, I, S, unsigned int>); // !sized
+    }
+
+    // Validate deduction guides
+    template <class Rng>
+    constexpr bool test_ctad() {
+        using I             = ranges::iterator_t<Rng>;
+        using S             = ranges::sentinel_t<Rng>;
+        constexpr bool diff = sized_sentinel_for<S, I>;
+
+        {
+            using T = decltype(subrange(std::declval<I>(), std::declval<S>()));
+            STATIC_ASSERT(same_as<T, subrange<I, S, subrange_kind{diff}>>);
+
+            STATIC_ASSERT(range<T>);
+            STATIC_ASSERT(!copyable<I> || range<T const&>);
+        }
+
+        static_assert(
+            std::integral<std::iter_difference_t<I>>, "make_unsigned_t below needs to be make-unsigned-like-t");
+        using size_type = std::make_unsigned_t<std::iter_difference_t<I>>;
+        {
+            using T = decltype(subrange(std::declval<I>(), std::declval<S>(), std::declval<size_type>()));
+            STATIC_ASSERT(same_as<T, subrange<I, S, subrange_kind::sized>>);
+
+            STATIC_ASSERT(range<T>);
+            STATIC_ASSERT(!copyable<I> || range<T const&>);
+        }
+
+        constexpr bool is_sized = diff | sized_range<Rng>;
+        {
+            using T = decltype(subrange(std::declval<Rng&>()));
+            STATIC_ASSERT(same_as<T, subrange<I, S, subrange_kind{is_sized}>>);
+
+            STATIC_ASSERT(range<T>);
+            STATIC_ASSERT(!copyable<I> || range<T const&>);
+
+            if constexpr (borrowed_range<Rng>) {
+                using U = decltype(subrange(std::declval<Rng>()));
+                STATIC_ASSERT(same_as<U, T>);
+            }
+        }
+
+        {
+            using T = decltype(subrange(std::declval<Rng&>(), std::declval<size_type>()));
+            STATIC_ASSERT(same_as<T, subrange<I, S, subrange_kind::sized>>);
+
+            STATIC_ASSERT(range<T>);
+            STATIC_ASSERT(!copyable<I> || range<T const&>);
+
+            if constexpr (borrowed_range<Rng>) {
+                using U = decltype(subrange(std::declval<Rng>(), std::declval<size_type>()));
+                STATIC_ASSERT(same_as<U, T>);
+            }
+        }
+
+        return true;
+    }
+    STATIC_ASSERT(test_ctad<test_range<output_iterator_tag, int, false, false>>());
+    STATIC_ASSERT(test_ctad<test_range<output_iterator_tag, int, true, false>>());
+    STATIC_ASSERT(test_ctad<test_range<input_iterator_tag, int, false, false>>());
+    STATIC_ASSERT(test_ctad<test_range<input_iterator_tag, int, true, false>>());
+    STATIC_ASSERT(test_ctad<test_range<forward_iterator_tag, int, false, false>>());
+    STATIC_ASSERT(test_ctad<test_range<forward_iterator_tag, int, false, true>>());
+    STATIC_ASSERT(test_ctad<test_range<forward_iterator_tag, int, true, false>>());
+    STATIC_ASSERT(test_ctad<test_range<forward_iterator_tag, int, true, true>>());
+    STATIC_ASSERT(test_ctad<test_range<bidirectional_iterator_tag, int, false, false>>());
+    STATIC_ASSERT(test_ctad<test_range<bidirectional_iterator_tag, int, false, true>>());
+    STATIC_ASSERT(test_ctad<test_range<bidirectional_iterator_tag, int, true, false>>());
+    STATIC_ASSERT(test_ctad<test_range<bidirectional_iterator_tag, int, true, true>>());
+    STATIC_ASSERT(test_ctad<test_range<random_access_iterator_tag, int, true, false>>());
+    STATIC_ASSERT(test_ctad<test_range<random_access_iterator_tag, int, true, true>>());
+    STATIC_ASSERT(test_ctad<test_range<contiguous_iterator_tag, int, true, false>>());
+    STATIC_ASSERT(test_ctad<test_range<contiguous_iterator_tag, int, true, true>>());
+
+    STATIC_ASSERT(test_ctad<std::forward_list<int>>());
+    STATIC_ASSERT(test_ctad<std::list<int>>());
+    STATIC_ASSERT(test_ctad<std::vector<int>>());
+    STATIC_ASSERT(test_ctad<std::string_view>());
+
+    // Validate conversion to PairLike
+    STATIC_ASSERT(std::is_convertible_v<subrange<int*>, std::pair<int*, int*>>);
+    STATIC_ASSERT(!std::is_convertible_v<subrange<int const*>, std::pair<int*, int*>>);
+    STATIC_ASSERT(std::is_convertible_v<subrange<int*>, std::pair<int const*, int const*>>);
+    STATIC_ASSERT(std::is_convertible_v<subrange<int const*>, std::pair<int const*, int const*>>);
+    STATIC_ASSERT(std::is_convertible_v<subrange<int*>, std::tuple<int*, int*>>);
+    STATIC_ASSERT(!std::is_convertible_v<subrange<int const*>, std::tuple<int*, int*>>);
+    STATIC_ASSERT(std::is_convertible_v<subrange<int*>, std::tuple<int const*, int const*>>);
+    STATIC_ASSERT(std::is_convertible_v<subrange<int const*>, std::tuple<int const*, int const*>>);
+
+    constexpr bool test_advance_next_prev() {
+        // Validate advance/next/prev
+        int const some_ints[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+        auto const first      = ranges::begin(some_ints);
+        auto const last       = ranges::end(some_ints);
+
+        ASSERT(subrange{some_ints}.begin() == first);
+        ASSERT(subrange{some_ints}.end() == last);
+
+        ASSERT(subrange{some_ints}.next().begin() == first + 1);
+        ASSERT(subrange{some_ints}.next().end() == last);
+
+        ASSERT(subrange{first + 1, last}.prev().begin() == first);
+        ASSERT(subrange{first + 1, last}.prev().end() == last);
+
+        for (std::ptrdiff_t i = 0; i <= last - first; ++i) {
+            ASSERT(subrange{some_ints}.next(i).begin() == first + i);
+            ASSERT(subrange{some_ints}.next(i).end() == last);
+
+            subrange s0{some_ints};
+            s0.advance(i);
+            ASSERT(s0.begin() == first + i);
+            ASSERT(s0.end() == last);
+
+            ASSERT(subrange{first + i, last}.prev(i).begin() == first);
+            ASSERT(subrange{first + i, last}.prev(i).end() == last);
+
+            subrange s1{first + i, last};
+            s1.advance(-i);
+            ASSERT(s1.begin() == first);
+            ASSERT(s1.end() == last);
+        }
+
+        return true;
+    }
+    STATIC_ASSERT(test_advance_next_prev());
+
+    // Validate tuple interface
+    template <class Subrange>
+    constexpr bool test_tuple() {
+        using std::declval, std::tuple_element_t, std::tuple_size_v;
+
+        using I = ranges::iterator_t<Subrange>;
+        using S = ranges::sentinel_t<Subrange>;
+
+        STATIC_ASSERT(tuple_size_v<Subrange> == 2);
+        STATIC_ASSERT(tuple_size_v<Subrange const> == 2);
+
+        STATIC_ASSERT(same_as<tuple_element_t<0, Subrange>, I>);
+        STATIC_ASSERT(same_as<tuple_element_t<0, Subrange const>, I>);
+        STATIC_ASSERT(same_as<tuple_element_t<1, Subrange>, S>);
+        STATIC_ASSERT(same_as<tuple_element_t<1, Subrange const>, S>);
+
+        STATIC_ASSERT(same_as<decltype(ranges::get<0>(declval<Subrange>())), I>);
+        STATIC_ASSERT(same_as<decltype(ranges::get<0>(declval<Subrange&>())), I>);
+        STATIC_ASSERT(same_as<decltype(ranges::get<0>(declval<Subrange const>())), I>);
+        STATIC_ASSERT(same_as<decltype(ranges::get<0>(declval<Subrange const&>())), I>);
+        STATIC_ASSERT(same_as<decltype(std::get<0>(declval<Subrange>())), I>);
+        STATIC_ASSERT(same_as<decltype(std::get<0>(declval<Subrange&>())), I>);
+        STATIC_ASSERT(same_as<decltype(std::get<0>(declval<Subrange const>())), I>);
+        STATIC_ASSERT(same_as<decltype(std::get<0>(declval<Subrange const&>())), I>);
+
+        STATIC_ASSERT(same_as<decltype(ranges::get<1>(declval<Subrange>())), S>);
+        STATIC_ASSERT(same_as<decltype(ranges::get<1>(declval<Subrange&>())), S>);
+        STATIC_ASSERT(same_as<decltype(ranges::get<1>(declval<Subrange const>())), S>);
+        STATIC_ASSERT(same_as<decltype(ranges::get<1>(declval<Subrange const&>())), S>);
+        STATIC_ASSERT(same_as<decltype(std::get<1>(declval<Subrange>())), S>);
+        STATIC_ASSERT(same_as<decltype(std::get<1>(declval<Subrange&>())), S>);
+        STATIC_ASSERT(same_as<decltype(std::get<1>(declval<Subrange const>())), S>);
+        STATIC_ASSERT(same_as<decltype(std::get<1>(declval<Subrange const&>())), S>);
+
+        return true;
+    }
+    STATIC_ASSERT(test_tuple<subrange<int*>>());
+    STATIC_ASSERT(test_tuple<subrange<int*, std::unreachable_sentinel_t, subrange_kind::sized>>());
+    STATIC_ASSERT(test_tuple<subrange<int*, std::unreachable_sentinel_t, subrange_kind::unsized>>());
+} // namespace test_subrange


### PR DESCRIPTION
Product changes:
`<xutility>`: Implementations of `subrange`, `view_interface`, and `borrowed_subrange_t`.

Test changes:
`std/include/range_algorithm_support.hpp`: Remove `iter_move` overload landmine for non-`indirectly_readable` `test_iterator`s that hampers detection.
`std/tests/P0896R4_ranges_algorithm_machinery`: Enable `borrowed_subrange_t` smoke test.
`std/tests/P0896R4_ranges_range_machinery`: Validate that `subrange` is a `borrowed_range`.
`std/tests/P0896R4_ranges_subrange`: New test to cover `subrange` and `view_interface`.
