### PR TITLE
Silence Clang -Wc++20-extensions

### DIFF
--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -427,6 +427,7 @@
 #endif // _STL_DISABLED_WARNINGS
 
 // warning: constexpr if is a C++17 extension [-Wc++17-extensions]
+// warning: explicit(bool) is a C++20 extension [-Wc++20-extensions]
 // warning: ignoring __declspec(allocator) because the function return type '%s' is not a pointer or reference type
 //     [-Wignored-attributes]
 // warning: user-defined literal suffixes not starting with '_' are reserved [-Wuser-defined-literals]
@@ -437,6 +438,7 @@
 #define _STL_DISABLE_CLANG_WARNINGS                                 \
     _Pragma("clang diagnostic push")                                \
     _Pragma("clang diagnostic ignored \"-Wc++17-extensions\"")      \
+    _Pragma("clang diagnostic ignored \"-Wc++20-extensions\"")      \
     _Pragma("clang diagnostic ignored \"-Wignored-attributes\"")    \
     _Pragma("clang diagnostic ignored \"-Wuser-defined-literals\"") \
     _Pragma("clang diagnostic ignored \"-Wunknown-pragmas\"")


### PR DESCRIPTION
In `pair`, `tuple`, and `optional`, we use C++20 conditional `explicit` (aka `explicit(bool)`) to simplify constructors and improve compiler throughput, when compiler support is available:

https://github.com/microsoft/STL/blob/0cbd1b2470412909b3681902ce0470609d7ae86e/stl/inc/optional#L182-L193

Like C++17 `if constexpr`, MSVC supports C++20 `explicit(bool)` in older Standard modes, with a suppressible warning. (This is because the feature requires novel syntax, so it can't be accidentally used, and it's extremely useful to library developers.) We suppress both warnings in STL headers:

https://github.com/microsoft/STL/blob/0cbd1b2470412909b3681902ce0470609d7ae86e/stl/inc/yvals_core.h#L368-L380

Clang 9 supported `explicit(bool)` in C++20 mode, while Clang 10 added "downlevel" support similar to MSVC. When #708 changed the STL to require Clang 10, it also began using Clang 10's downlevel support for `explicit(bool)`.

@cbezault discovered that we forgot to suppress the warning that Clang emits for `explicit(bool)` in older Standard modes. We missed this because Clang (unlike MSVC) ordinarily suppresses warnings from "system headers". (`-Wsystem-headers` activates warnings in system headers, although this is rarely used because users are rarely interested in such warnings, and UCRT/WinSDK headers are still being cleaned up.)

This is a practical issue because anything on the `INCLUDE` path is considered to be a system header for warning purposes, while `/I` directories aren't (despite `#include <meow>` searching both `INCLUDE` and `/I`). During STL development, it is very convenient to be able to compile with `/I S:\GitHub\STL\stl\inc` and immediately consume updated STL headers without rebuilding (this is not possible when separately compiled changes are involved, of course), which will emit Clang warnings.

After this lengthy backstory, the fix is delightfully simple.