### PR TITLE
Spelling

### DIFF
--- a/stl/inc/experimental/filesystem
+++ b/stl/inc/experimental/filesystem
@@ -94,7 +94,7 @@ enum class copy_options { // names for copy options
 
 _BITMASK_OPS(copy_options)
 
-// ENUM dirctory_options
+// ENUM directory_options
 enum class directory_options { // names for directory options
     none = 0,
     follow_directory_symlink

--- a/stl/src/xmbtowc.cpp
+++ b/stl/src/xmbtowc.cpp
@@ -102,7 +102,7 @@ _MRTIMP2 int __cdecl _Mbrtowc(wchar_t* pwc, const char* s, size_t n, mbstate_t* 
     case 4: // UTF-8
         _ASSERTE(ploc->_Page == CP_UTF8);
         trailingUtf8Units = _Utf8_trailing_byte_count(&wch, ch);
-        if (trailingUtf8Units == 0) { // optimistic ASCII passsthrough
+        if (trailingUtf8Units == 0) { // optimistic ASCII passthrough
             *pwc = static_cast<wchar_t>(ch);
             return 1;
         }

--- a/tests/std/tests/Dev08_496675_iostream_int_reading/test.cpp
+++ b/tests/std/tests/Dev08_496675_iostream_int_reading/test.cpp
@@ -14,7 +14,7 @@ int main() {
         // separator.
         ss << "2,";
 
-        // imbueing the "C" locale workaround the problem
+        // imbuing the "C" locale workaround the problem
         // ss.imbue(std::locale("C"));
 
         // reading from the stream should not fail

--- a/tests/std/tests/Dev11_0000000_user_defined_literals/test.cpp
+++ b/tests/std/tests/Dev11_0000000_user_defined_literals/test.cpp
@@ -402,9 +402,9 @@ int main() {
         std::experimental::erase_if(str1, is_vowel{});
         assert(str1 == "ct flffy kttns");
 
-        std::string str2{"visual studio"};
-        std::experimental::erase(str2, 'u');
-        assert(str2 == "visal stdio");
+        std::string str2{"broad anticausotic"};
+        std::experimental::erase(str2, 'o');
+        assert(str2 == "brad anticaustic");
 
         struct is_odd : no_copy {
             bool operator()(const int i) const {
@@ -560,9 +560,9 @@ int main() {
         assert(str1 == "ct flffy kttns");
         assert(str1_removed == 5);
 
-        std::string str2{"visual studio"};
-        const auto str2_removed = std::erase(str2, 'u');
-        assert(str2 == "visal stdio");
+        std::string str2{"broad anticaustic"};
+        const auto str2_removed = std::erase(str2, 'o');
+        assert(str2 == "brad anticaustic");
         assert(str2_removed == 2);
 
         struct is_odd : no_copy {

--- a/tests/std/tests/Dev11_0000000_user_defined_literals/test.cpp
+++ b/tests/std/tests/Dev11_0000000_user_defined_literals/test.cpp
@@ -402,9 +402,9 @@ int main() {
         std::experimental::erase_if(str1, is_vowel{});
         assert(str1 == "ct flffy kttns");
 
-        std::string str2{"broad anticausotic"};
-        std::experimental::erase(str2, 'o');
-        assert(str2 == "brad anticaustic");
+        std::string str2{"asynchronous beat"};
+        std::experimental::erase(str2, 'a');
+        assert(str2 == "synchronous bet");
 
         struct is_odd : no_copy {
             bool operator()(const int i) const {
@@ -560,9 +560,9 @@ int main() {
         assert(str1 == "ct flffy kttns");
         assert(str1_removed == 5);
 
-        std::string str2{"broad anticaustic"};
-        const auto str2_removed = std::erase(str2, 'o');
-        assert(str2 == "brad anticaustic");
+        std::string str2{"asynchronous beat"};
+        const auto str2_removed = std::erase(str2, 'a');
+        assert(str2 == "synchronous bet");
         assert(str2_removed == 2);
 
         struct is_odd : no_copy {

--- a/tests/std/tests/P0220R1_optional/test.cpp
+++ b/tests/std/tests/P0220R1_optional/test.cpp
@@ -1497,7 +1497,7 @@ void test_with_test_type() {
     assert(T::alive == 0);
 }
 
-void test_ambigious_assign() {
+void test_ambiguous_assign() {
     using OptInt = std::optional<int>;
     {
         using T = AssignableFrom<OptInt const&>;
@@ -1553,7 +1553,7 @@ void test_ambigious_assign() {
 int run_test()
 {
     test_with_test_type();
-    test_ambigious_assign();
+    test_ambiguous_assign();
     {
         optional<int> opt;
         constexpr optional<short> opt2;
@@ -2557,7 +2557,7 @@ void test_with_test_type() {
 }
 
 
-void test_ambigious_assign() {
+void test_ambiguous_assign() {
     using OptInt = std::optional<int>;
     {
         using T = AssignableFrom<OptInt&&>;
@@ -2613,7 +2613,7 @@ void test_ambigious_assign() {
 int run_test()
 {
     test_with_test_type();
-    test_ambigious_assign();
+    test_ambiguous_assign();
     {
         optional<int> opt;
         optional<short> opt2;

--- a/tests/std/tests/P0898R3_concepts/test.cpp
+++ b/tests/std/tests/P0898R3_concepts/test.cpp
@@ -2352,7 +2352,7 @@ namespace test_object_concepts {
     STATIC_ASSERT(!test_semiregular<ExplicitMoveAbomination>());
     STATIC_ASSERT(!test_semiregular<ExplicitCopyAbomination>());
     STATIC_ASSERT(!test_semiregular<CopyOnlyAbomination>());
-    STATIC_ASSERT(test_semiregular<SemiregularType>()); // Who would have guessed?
+    STATIC_ASSERT(test_semiregular<SemiregularType>());
     STATIC_ASSERT(test_semiregular<RegularType>());
 
     STATIC_ASSERT(!test_regular<void>());

--- a/tests/std/tests/P0898R3_concepts/test.cpp
+++ b/tests/std/tests/P0898R3_concepts/test.cpp
@@ -2633,14 +2633,14 @@ namespace test_totally_ordered {
     void operator>=(Archetype<5> const&, Archetype<5> const&);
 
     template <std::size_t I>
-    constexpr void test_archeype_single() {
+    constexpr void test_archetype_single() {
         STATIC_ASSERT(!test<Archetype<I>>());
     }
 
     template <std::size_t... Is>
     constexpr bool test_Archetype(std::index_sequence<Is...>) {
         STATIC_ASSERT(std::is_same_v<std::index_sequence<Is...>, std::make_index_sequence<Archetype_max>>);
-        (test_archeype_single<Is>(), ...);
+        (test_archetype_single<Is>(), ...);
         STATIC_ASSERT(test<Archetype<Archetype_max>>());
         return true;
     }

--- a/tests/std/tests/P0898R3_concepts/test.cpp
+++ b/tests/std/tests/P0898R3_concepts/test.cpp
@@ -2352,7 +2352,7 @@ namespace test_object_concepts {
     STATIC_ASSERT(!test_semiregular<ExplicitMoveAbomination>());
     STATIC_ASSERT(!test_semiregular<ExplicitCopyAbomination>());
     STATIC_ASSERT(!test_semiregular<CopyOnlyAbomination>());
-    STATIC_ASSERT(test_semiregular<SemiregularType>()); // Who woulda guessed?
+    STATIC_ASSERT(test_semiregular<SemiregularType>()); // Who would have guessed?
     STATIC_ASSERT(test_semiregular<RegularType>());
 
     STATIC_ASSERT(!test_regular<void>());

--- a/tests/std/tests/VSO_0000000_type_traits/test.cpp
+++ b/tests/std/tests/VSO_0000000_type_traits/test.cpp
@@ -568,7 +568,7 @@ STATIC_ASSERT(!is_pod_v<Wrap<TrivialExceptConstruct>>);
 
 // VSO-152213 "<type_traits>: is_function does not match qualified function types"
 // VSO-154500 "<type_traits>: [Feedback]std::is_function returns false for cv/ref qualified functions"
-// C++14 LWG-2196 "Specification of is_*[copy/move]_[constructible/assignable] unclear for non-referencable types"
+// C++14 LWG-2196 "Specification of is_*[copy/move]_[constructible/assignable] unclear for non-referenceable types"
 // C++17 LWG-2101 "Some transformation types can produce impossible types"
 
 template <typename T>

--- a/tests/utils/stl/test/config.py
+++ b/tests/utils/stl/test/config.py
@@ -358,7 +358,7 @@ class Configuration:
         # Configure extra flags
         self.default_compiler.compile_flags += \
             self.get_lit_conf('compile_flags', [])
-        additional_flags_str = self.get_lit_conf('addtional_compiler_flags')
+        additional_flags_str = self.get_lit_conf('additional_compiler_flags')
         if additional_flags_str:
             self.default_compiler.compile_flags += \
                 shlex.split(additional_flags_str)


### PR DESCRIPTION
Most of these changes are to tests.

* [tests/utils/stl/test/config.py](https://github.com/jsoref/STL/blob/bee3b91f7ae2a857f8256f636f9b19abaedcc3f4/tests/utils/stl/test/config.py) is a cli api change

I'm happy to drop/adjust commits.

The `visual studio` change is probably the one most likely to be controversial. I know people like being cute and using product names, but in many projects, product names are often misspelled, so it's best to avoid whitelisting misspellings of product names. (I liked the meow and or 🐈 references.)

This PR was developed using my [check-spelling](https://github.com/marketplace/actions/check-spelling) action.

Validation for the changes can be seen in the ✔ in [spell-check](https://github.com/jsoref/STL/tree/spell-check).

The check-spelling configuration is derived from the version I worked on with @DHowett-MSFT and friends for https://github.com/microsoft/terminal.

