### PR TITLE
C++20 reverse_iterator changes

### DIFF
--- a/stl/inc/array
+++ b/stl/inc/array
@@ -272,6 +272,11 @@ private:
         _STL_VERIFY(*this <= _Last, "array iterator range transposed");
     }
 
+    friend constexpr void _Verify_range(
+        const _Array_const_iterator& _First, const _Array_const_iterator& _Last) noexcept {
+        _First._Verify_with(_Last);
+    }
+
     constexpr void _Seek_to(pointer _It) noexcept {
         _Idx = static_cast<size_t>(_It - _Ptr);
     }
@@ -281,15 +286,6 @@ private:
     size_t _Idx; // offset into array
 #endif // _ITERATOR_DEBUG_LEVEL == 0
 };
-
-#if _ITERATOR_DEBUG_LEVEL != 0
-template <class _Ty, size_t _Size>
-constexpr void _Verify_range(
-    const _Array_const_iterator<_Ty, _Size>& _First, const _Array_const_iterator<_Ty, _Size>& _Last) noexcept {
-    // TRANSITION, VSO-612785
-    _First._Verify_with(_Last);
-}
-#endif // _ITERATOR_DEBUG_LEVEL != 0
 
 template <class _Ty, size_t _Size>
 _NODISCARD _CONSTEXPR17 _Array_const_iterator<_Ty, _Size> operator+(

--- a/stl/inc/array
+++ b/stl/inc/array
@@ -272,11 +272,6 @@ private:
         _STL_VERIFY(*this <= _Last, "array iterator range transposed");
     }
 
-    friend constexpr void _Verify_range(
-        const _Array_const_iterator& _First, const _Array_const_iterator& _Last) noexcept {
-        _First._Verify_with(_Last);
-    }
-
     constexpr void _Seek_to(pointer _It) noexcept {
         _Idx = static_cast<size_t>(_It - _Ptr);
     }
@@ -286,6 +281,15 @@ private:
     size_t _Idx; // offset into array
 #endif // _ITERATOR_DEBUG_LEVEL == 0
 };
+
+#if _ITERATOR_DEBUG_LEVEL != 0
+template <class _Ty, size_t _Size>
+constexpr void _Verify_range(
+    const _Array_const_iterator<_Ty, _Size>& _First, const _Array_const_iterator<_Ty, _Size>& _Last) noexcept {
+    // TRANSITION, CUDA
+    _First._Verify_with(_Last);
+}
+#endif // _ITERATOR_DEBUG_LEVEL != 0
 
 template <class _Ty, size_t _Size>
 _NODISCARD _CONSTEXPR17 _Array_const_iterator<_Ty, _Size> operator+(

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -1785,26 +1785,38 @@ _NODISCARD _CONSTEXPR17 _BidIt prev(_BidIt _First, _Iter_diff_t<_BidIt> _Off = 1
 }
 
 // CLASS TEMPLATE reverse_iterator
-template <class _Iterator>
-constexpr _Iterator _Operator_arrow(_Iterator _Target, true_type) { // return operator-> where _Iterator is a pointer
+#if !_HAS_IF_CONSTEXPR
+template <class _Iter>
+constexpr _Iter _Operator_arrow(true_type, _Iter _Target) {
     return _Target;
 }
 
-template <class _Iterator>
-constexpr decltype(auto) _Operator_arrow(_Iterator&& _Target, false_type) {
-    // return operator-> where _Iterator is a class type
-    return _STD forward<_Iterator>(_Target).operator->();
+template <class _Iter>
+constexpr decltype(auto) _Operator_arrow(false_type, _Iter& _Target) {
+    return _Target.operator->();
 }
+#endif // !_HAS_IF_CONSTEXPR
 
 template <class _BidIt>
-class reverse_iterator { // wrap iterator to run it backwards
+class reverse_iterator {
 public:
-    using iterator_type     = _BidIt;
-    using iterator_category = typename iterator_traits<_BidIt>::iterator_category;
-    using value_type        = typename iterator_traits<_BidIt>::value_type;
-    using difference_type   = typename iterator_traits<_BidIt>::difference_type;
-    using pointer           = typename iterator_traits<_BidIt>::pointer;
-    using reference         = typename iterator_traits<_BidIt>::reference;
+    using iterator_type = _BidIt;
+
+#ifdef __cpp_lib_concepts
+    using iterator_concept =
+        conditional_t<random_access_iterator<_BidIt>, random_access_iterator_tag, bidirectional_iterator_tag>;
+    using iterator_category = conditional_t<derived_from<_Iter_cat_t<_BidIt>, random_access_iterator_tag>,
+        random_access_iterator_tag, _Iter_cat_t<_BidIt>>;
+#else // ^^^ __cpp_lib_concepts / !__cpp_lib_concepts vvv
+    using iterator_category = _Iter_cat_t<_BidIt>;
+#endif // __cpp_lib_concepts
+    using value_type      = _Iter_value_t<_BidIt>;
+    using difference_type = _Iter_diff_t<_BidIt>;
+    using pointer         = typename iterator_traits<_BidIt>::pointer;
+    using reference       = _Iter_ref_t<_BidIt>;
+
+    template <class>
+    friend class reverse_iterator;
 
     _CONSTEXPR17 reverse_iterator() = default;
 
@@ -1812,15 +1824,27 @@ public:
         is_nothrow_move_constructible_v<_BidIt>) // strengthened
         : current(_STD move(_Right)) {}
 
+    // clang-format off
     template <class _Other>
-    _CONSTEXPR17 reverse_iterator(const reverse_iterator<_Other>& _Right) : current(_Right.base()) {}
+#ifdef __cpp_lib_concepts
+        // Per LWG-3435
+        requires (!is_same_v<_Other, _BidIt>) && convertible_to<const _Other&, _BidIt>
+#endif // __cpp_lib_concepts
+    _CONSTEXPR17 reverse_iterator(const reverse_iterator<_Other>& _Right) noexcept(
+        is_nothrow_constructible_v<_BidIt, const _Other&>) // strengthened
+        : current(_Right.current) {}
 
     template <class _Other>
+#ifdef __cpp_lib_concepts
+        // Per LWG-3435
+        requires (!is_same_v<_Other, _BidIt>) && convertible_to<const _Other&, _BidIt>
+            && assignable_from<_BidIt&, const _Other&>
+#endif // __cpp_lib_concepts
     _CONSTEXPR17 reverse_iterator& operator=(const reverse_iterator<_Other>& _Right) {
-
-        current = _Right.base();
+        current = _Right.current;
         return *this;
     }
+    // clang-format on
 
     _NODISCARD _CONSTEXPR17 _BidIt base() const {
         return current;
@@ -1831,11 +1855,32 @@ public:
         return *--_Tmp;
     }
 
+#ifdef __cpp_lib_concepts
+    _NODISCARD constexpr pointer operator->() const
+        requires(is_pointer_v<_BidIt> || requires(const _BidIt __i) { __i.operator->(); }) {
+        _BidIt _Tmp = current;
+        --_Tmp;
+        if constexpr (is_pointer_v<_BidIt>) {
+            return _Tmp;
+        } else {
+            return _Tmp.operator->();
+        }
+    }
+#else // ^^^ __cpp_lib_concepts / !__cpp_lib_concepts vvv
     _NODISCARD _CONSTEXPR17 pointer operator->() const {
         _BidIt _Tmp = current;
         --_Tmp;
-        return _Operator_arrow(_Tmp, is_pointer<_BidIt>());
+#if _HAS_IF_CONSTEXPR
+        if constexpr (is_pointer_v<_BidIt>) {
+            return _Tmp;
+        } else {
+            return _Tmp.operator->();
+        }
+#else // ^^^ _HAS_IF_CONSTEXPR / !_HAS_IF_CONSTEXPR vvv
+        return _Operator_arrow(is_pointer<_BidIt>(), _Tmp);
+#endif // _HAS_IF_CONSTEXPR
     }
+#endif // __cpp_lib_concepts
 
     _CONSTEXPR17 reverse_iterator& operator++() {
         --current;
@@ -1859,19 +1904,12 @@ public:
         return _Tmp;
     }
 
-    // N.B. functions valid for random-access iterators only beyond this point
-
-    _CONSTEXPR17 reverse_iterator& operator+=(const difference_type _Off) {
-        current -= _Off;
-        return *this;
-    }
-
     _NODISCARD _CONSTEXPR17 reverse_iterator operator+(const difference_type _Off) const {
         return reverse_iterator(current - _Off);
     }
 
-    _CONSTEXPR17 reverse_iterator& operator-=(const difference_type _Off) {
-        current += _Off;
+    _CONSTEXPR17 reverse_iterator& operator+=(const difference_type _Off) {
+        current -= _Off;
         return *this;
     }
 
@@ -1879,11 +1917,41 @@ public:
         return reverse_iterator(current + _Off);
     }
 
+    _CONSTEXPR17 reverse_iterator& operator-=(const difference_type _Off) {
+        current += _Off;
+        return *this;
+    }
+
     _NODISCARD _CONSTEXPR17 reference operator[](const difference_type _Off) const {
         return current[static_cast<difference_type>(-_Off - 1)];
     }
 
+#ifdef __cpp_lib_concepts
+    _NODISCARD friend constexpr iter_rvalue_reference_t<_BidIt> iter_move(const reverse_iterator& _It) noexcept(
+        is_nothrow_copy_constructible_v<_BidIt>&& noexcept(_RANGES iter_move(--_STD declval<_BidIt&>()))) {
+        auto _Tmp = _It.current;
+        --_Tmp;
+        return _RANGES iter_move(_Tmp);
+    }
+
+    template <indirectly_swappable<_BidIt> _BidIt2>
+    friend constexpr void iter_swap(const reverse_iterator& _Left, const reverse_iterator<_BidIt2>& _Right) noexcept(
+        is_nothrow_copy_constructible_v<_BidIt>&& is_nothrow_copy_constructible_v<_BidIt2>&& noexcept(
+            _RANGES iter_swap(--_STD declval<_BidIt&>(), --_STD declval<_BidIt2&>()))) {
+        auto _LTmp = _Left.current;
+        auto _RTmp = _Right.base();
+        --_LTmp;
+        --_RTmp;
+        _RANGES iter_swap(_LTmp, _RTmp);
+    }
+#endif // __cpp_lib_concepts
+
     using _Prevent_inheriting_unwrap = reverse_iterator;
+
+    template <class _BidIt2, enable_if_t<_Range_verifiable_v<_BidIt, _BidIt2>, int> = 0>
+    friend constexpr void _Verify_range(const reverse_iterator& _First, const reverse_iterator<_BidIt2>& _Last) {
+        _Verify_range(_Last._Get_current(), _First.current); // note reversed parameters
+    }
 
     template <class _BidIt2 = _BidIt, enable_if_t<_Offset_verifiable_v<_BidIt2>, int> = 0>
     constexpr void _Verify_offset(const difference_type _Off) const {
@@ -1898,19 +1966,102 @@ public:
 
     static constexpr bool _Unwrap_when_unverified = _Do_unwrap_when_unverified_v<_BidIt>;
 
-    template <class _Src, enable_if_t<_Wrapped_seekable_v<_BidIt, _Src>, int> = 0>
+    template <class _Src, enable_if_t<_Wrapped_seekable_v<_BidIt, const _Src&>, int> = 0>
     constexpr void _Seek_to(const reverse_iterator<_Src>& _It) {
-        current._Seek_to(_It.base());
+        current._Seek_to(_It.current);
+    }
+
+    constexpr const _BidIt& _Get_current() const noexcept {
+        return current;
     }
 
 protected:
-    _BidIt current{}; // the wrapped iterator
+    _BidIt current{};
 };
 
-template <class _BidIt, class _BidIt2, enable_if_t<_Range_verifiable_v<_BidIt, _BidIt2>, int> = 0>
-constexpr void _Verify_range(const reverse_iterator<_BidIt>& _First, const reverse_iterator<_BidIt2>& _Last) {
-    // TRANSITION, VSO-612785
-    _Verify_range(_Last.base(), _First.base()); // note reversed parameters
+#ifdef __cpp_lib_concepts
+template <class _From, class _To>
+concept _Implicitly_convertible_to = is_convertible_v<_From, _To>;
+#endif // __cpp_lib_concepts
+
+template <class _BidIt1, class _BidIt2>
+_NODISCARD _CONSTEXPR17 bool operator==(const reverse_iterator<_BidIt1>& _Left, const reverse_iterator<_BidIt2>& _Right)
+#ifdef __cpp_lib_concepts
+    // clang-format off
+    requires requires {
+        { _Left._Get_current() == _Right._Get_current() } -> _Implicitly_convertible_to<bool>;
+    }
+// clang-format on
+#endif // __cpp_lib_concepts
+{ return _Left._Get_current() == _Right._Get_current(); }
+
+template <class _BidIt1, class _BidIt2>
+_NODISCARD _CONSTEXPR17 bool operator!=(const reverse_iterator<_BidIt1>& _Left, const reverse_iterator<_BidIt2>& _Right)
+#ifdef __cpp_lib_concepts
+    // clang-format off
+    requires requires {
+        { _Left._Get_current() != _Right._Get_current() } -> _Implicitly_convertible_to<bool>;
+    }
+// clang-format on
+#endif // __cpp_lib_concepts
+{ return _Left._Get_current() != _Right._Get_current(); }
+
+template <class _BidIt1, class _BidIt2>
+_NODISCARD _CONSTEXPR17 bool operator<(const reverse_iterator<_BidIt1>& _Left, const reverse_iterator<_BidIt2>& _Right)
+#ifdef __cpp_lib_concepts
+    // clang-format off
+    requires requires {
+        { _Left._Get_current() > _Right._Get_current() } -> _Implicitly_convertible_to<bool>;
+    }
+// clang-format on
+#endif // __cpp_lib_concepts
+{ return _Left._Get_current() > _Right._Get_current(); }
+
+template <class _BidIt1, class _BidIt2>
+_NODISCARD _CONSTEXPR17 bool operator>(const reverse_iterator<_BidIt1>& _Left, const reverse_iterator<_BidIt2>& _Right)
+#ifdef __cpp_lib_concepts
+    // clang-format off
+    requires requires {
+        { _Left._Get_current() < _Right._Get_current() } -> _Implicitly_convertible_to<bool>;
+    }
+// clang-format on
+#endif // __cpp_lib_concepts
+{ return _Left._Get_current() < _Right._Get_current(); }
+
+template <class _BidIt1, class _BidIt2>
+_NODISCARD _CONSTEXPR17 bool operator<=(const reverse_iterator<_BidIt1>& _Left, const reverse_iterator<_BidIt2>& _Right)
+#ifdef __cpp_lib_concepts
+    // clang-format off
+    requires requires {
+        { _Left._Get_current() >= _Right._Get_current() } -> _Implicitly_convertible_to<bool>;
+    }
+// clang-format on
+#endif // __cpp_lib_concepts
+{ return _Left._Get_current() >= _Right._Get_current(); }
+
+template <class _BidIt1, class _BidIt2>
+_NODISCARD _CONSTEXPR17 bool operator>=(const reverse_iterator<_BidIt1>& _Left, const reverse_iterator<_BidIt2>& _Right)
+#ifdef __cpp_lib_concepts
+    // clang-format off
+    requires requires {
+        { _Left._Get_current() <= _Right._Get_current() } -> _Implicitly_convertible_to<bool>;
+    }
+// clang-format on
+#endif // __cpp_lib_concepts
+{ return _Left._Get_current() <= _Right._Get_current(); }
+
+#if defined(__cpp_impl_three_way_comparison) && defined(__cpp_lib_concepts)
+template <class _BidIt1, three_way_comparable_with<_BidIt1> _BidIt2>
+_NODISCARD constexpr compare_three_way_result_t<_BidIt1, _BidIt2> operator<=>(
+    const reverse_iterator<_BidIt1>& _Left, const reverse_iterator<_BidIt2>& _Right) {
+    return _Right._Get_current() <=> _Left._Get_current();
+}
+#endif // defined(__cpp_impl_three_way_comparison) && defined(__cpp_lib_concepts)
+
+template <class _BidIt1, class _BidIt2>
+_NODISCARD _CONSTEXPR17 auto operator-(const reverse_iterator<_BidIt1>& _Left, const reverse_iterator<_BidIt2>& _Right)
+    -> decltype(_Right._Get_current() - _Left._Get_current()) {
+    return _Right._Get_current() - _Left._Get_current();
 }
 
 template <class _BidIt>
@@ -1919,54 +2070,20 @@ _NODISCARD _CONSTEXPR17 reverse_iterator<_BidIt> operator+(
     return _Right + _Off;
 }
 
-template <class _BidIt1, class _BidIt2>
-_NODISCARD _CONSTEXPR17 auto operator-(const reverse_iterator<_BidIt1>& _Left, const reverse_iterator<_BidIt2>& _Right)
-    -> decltype(_Right.base() - _Left.base()) {
-    return _Right.base() - _Left.base();
-}
-
-template <class _BidIt1, class _BidIt2>
-_NODISCARD _CONSTEXPR17 bool operator==(
-    const reverse_iterator<_BidIt1>& _Left, const reverse_iterator<_BidIt2>& _Right) {
-    return _Left.base() == _Right.base();
-}
-
-template <class _BidIt1, class _BidIt2>
-_NODISCARD _CONSTEXPR17 bool operator!=(
-    const reverse_iterator<_BidIt1>& _Left, const reverse_iterator<_BidIt2>& _Right) {
-    return !(_Left == _Right);
-}
-
-template <class _BidIt1, class _BidIt2>
-_NODISCARD _CONSTEXPR17 bool operator<(
-    const reverse_iterator<_BidIt1>& _Left, const reverse_iterator<_BidIt2>& _Right) {
-    return _Right.base() < _Left.base();
-}
-
-template <class _BidIt1, class _BidIt2>
-_NODISCARD _CONSTEXPR17 bool operator>(
-    const reverse_iterator<_BidIt1>& _Left, const reverse_iterator<_BidIt2>& _Right) {
-    return _Right < _Left;
-}
-
-template <class _BidIt1, class _BidIt2>
-_NODISCARD _CONSTEXPR17 bool operator<=(
-    const reverse_iterator<_BidIt1>& _Left, const reverse_iterator<_BidIt2>& _Right) {
-    return !(_Right < _Left);
-}
-
-template <class _BidIt1, class _BidIt2>
-_NODISCARD _CONSTEXPR17 bool operator>=(
-    const reverse_iterator<_BidIt1>& _Left, const reverse_iterator<_BidIt2>& _Right) {
-    return !(_Left < _Right);
-}
-
 // FUNCTION TEMPLATE make_reverse_iterator
 template <class _BidIt>
 _NODISCARD _CONSTEXPR17 reverse_iterator<_BidIt> make_reverse_iterator(_BidIt _Iter) noexcept(
     is_nothrow_move_constructible_v<_BidIt>) /* strengthened */ {
     return reverse_iterator<_BidIt>(_STD move(_Iter));
 }
+
+#ifdef __cpp_lib_concepts
+// clang-format off
+template <class _BidIt1, class _BidIt2>
+    requires (!sized_sentinel_for<_BidIt1, _BidIt2>)
+inline constexpr bool disable_sized_sentinel_for<reverse_iterator<_BidIt1>, reverse_iterator<_BidIt2>> = true;
+// clang-format on
+#endif // __cpp_lib_concepts
 
 // FUNCTION TEMPLATES begin AND end
 template <class _Container>
@@ -3464,7 +3581,7 @@ namespace ranges {
         }
 
         constexpr subrange& advance(const iter_difference_t<_It> _Count) {
-            // Per LWG issue submitted but not numbered as of 2020-04-21, this has defined behavior when _Count < 0.
+            // Per LWG-3413, this has defined behavior when _Count < 0.
             if constexpr (bidirectional_iterator<_It>) {
                 if (_Count < 0) {
                     _RANGES advance(_First, _Count);

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -1787,12 +1787,12 @@ _NODISCARD _CONSTEXPR17 _BidIt prev(_BidIt _First, _Iter_diff_t<_BidIt> _Off = 1
 // CLASS TEMPLATE reverse_iterator
 #if !_HAS_IF_CONSTEXPR
 template <class _Iter>
-constexpr _Iter _Operator_arrow(true_type, _Iter _Target) {
+_NODISCARD constexpr _Iter _Operator_arrow(true_type, _Iter _Target) {
     return _Target;
 }
 
 template <class _Iter>
-constexpr decltype(auto) _Operator_arrow(false_type, _Iter& _Target) {
+_NODISCARD constexpr decltype(auto) _Operator_arrow(false_type, _Iter& _Target) {
     return _Target.operator->();
 }
 #endif // !_HAS_IF_CONSTEXPR
@@ -1877,7 +1877,7 @@ public:
             return _Tmp.operator->();
         }
 #else // ^^^ _HAS_IF_CONSTEXPR / !_HAS_IF_CONSTEXPR vvv
-        return _Operator_arrow(is_pointer<_BidIt>(), _Tmp);
+        return _Operator_arrow(is_pointer<_BidIt>{}, _Tmp);
 #endif // _HAS_IF_CONSTEXPR
     }
 #endif // __cpp_lib_concepts
@@ -1971,7 +1971,7 @@ public:
         current._Seek_to(_It.current);
     }
 
-    constexpr const _BidIt& _Get_current() const noexcept {
+    _NODISCARD constexpr const _BidIt& _Get_current() const noexcept {
         return current;
     }
 

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -174,22 +174,11 @@ std/input.output/filesystems/fs.op.funcs/fs.op.symlink_status/symlink_status.pas
 std/input.output/filesystems/fs.op.funcs/fs.op.temp_dir_path/temp_directory_path.pass.cpp SKIPPED
 std/input.output/filesystems/fs.op.funcs/fs.op.weakly_canonical/weakly_canonical.pass.cpp SKIPPED
 
-# We need some way to turn on deprecations for tests asking for _LIBCPP_ENABLE_DEPRECATION_WARNINGS
-std/utilities/function.objects/negators/binary_negate.depr_in_cxx17.fail.cpp SKIPPED
-std/utilities/function.objects/negators/unary_negate.depr_in_cxx17.fail.cpp SKIPPED
-
 # generate_feature_test_macro_components.py needs to learn about C1XX
 std/language.support/support.limits/support.limits.general/type_traits.version.pass.cpp SKIPPED
 std/language.support/support.limits/support.limits.general/version.version.pass.cpp SKIPPED
 
 # Contest does not understand .sh tests, which must be run specially
-std/depr/depr.c.headers/stdint_h.sh.cpp SKIPPED
-std/language.support/support.dynamic/new.delete/new.delete.array/new_size_align_nothrow.sh.cpp SKIPPED
-std/language.support/support.dynamic/new.delete/new.delete.array/new_size_align.sh.cpp SKIPPED
-std/language.support/support.dynamic/new.delete/new.delete.array/new_size_nothrow.sh.cpp SKIPPED
-std/language.support/support.dynamic/new.delete/new.delete.array/new_size.sh.cpp SKIPPED
-std/language.support/support.dynamic/new.delete/new.delete.single/new_size_align_nothrow.sh.cpp SKIPPED
-std/language.support/support.dynamic/new.delete/new.delete.single/new_size_align.sh.cpp SKIPPED
 std/thread/thread.condition/thread.condition.condvarany/wait_terminates.sh.cpp SKIPPED
 
 # These tests set an allocator with a max_size() too small to default construct an unordered container
@@ -201,6 +190,55 @@ std/containers/unord/unord.set/max_size.pass.cpp SKIPPED
 
 # Requires too great a template instantiation depth for C1XX.
 std/utilities/tuple/tuple.tuple/tuple.apply/apply_large_arity.pass.cpp SKIPPED
+
+# .verify.cpp tests use clang-verify to validate warnings
+containers\associative\map\map.access\empty.verify.cpp SKIPPED
+containers\associative\multimap\empty.verify.cpp SKIPPED
+containers\associative\multiset\empty.verify.cpp SKIPPED
+containers\associative\set\empty.verify.cpp SKIPPED
+containers\container.adaptors\priority.queue\priqueue.members\empty.verify.cpp SKIPPED
+containers\container.adaptors\queue\queue.defn\empty.verify.cpp SKIPPED
+containers\container.adaptors\stack\stack.defn\empty.verify.cpp SKIPPED
+containers\sequences\array\empty.verify.cpp SKIPPED
+containers\sequences\deque\deque.capacity\empty.verify.cpp SKIPPED
+containers\sequences\forwardlist\empty.verify.cpp SKIPPED
+containers\sequences\list\list.capacity\empty.verify.cpp SKIPPED
+containers\sequences\vector\vector.capacity\empty.verify.cpp SKIPPED
+containers\sequences\vector.bool\empty.verify.cpp SKIPPED
+containers\sequences\vector\vector.cons\copy.move_only.verify.cpp SKIPPED
+containers\unord\unord.map\empty.verify.cpp SKIPPED
+containers\unord\unord.multimap\empty.verify.cpp SKIPPED
+containers\unord\unord.multiset\empty.verify.cpp SKIPPED
+containers\unord\unord.set\empty.verify.cpp SKIPPED
+depr\depr.lib.binders\depr.lib.bind.1st\bind1st.depr_in_cxx11.verify.cpp SKIPPED
+depr\depr.lib.binders\depr.lib.bind.2nd\bind2nd.depr_in_cxx11.verify.cpp SKIPPED
+depr\depr.lib.binders\depr.lib.binder.1st\binder1st.depr_in_cxx11.verify.cpp SKIPPED
+depr\depr.lib.binders\depr.lib.binder.2nd\binder2nd.depr_in_cxx11.verify.cpp SKIPPED
+input.output\filesystems\class.path\path.member\path.decompose\empty.verify.cpp SKIPPED
+iterators\iterator.container\empty.array.verify.cpp SKIPPED
+iterators\iterator.container\empty.container.verify.cpp SKIPPED
+iterators\iterator.container\empty.initializer_list.verify.cpp SKIPPED
+language.support\support.dynamic\new.delete\new.delete.array\new_size.verify.cpp SKIPPED
+language.support\support.dynamic\new.delete\new.delete.array\new_size_align.verify.cpp SKIPPED
+language.support\support.dynamic\new.delete\new.delete.array\new_size_align_nothrow.verify.cpp SKIPPED
+language.support\support.dynamic\new.delete\new.delete.array\new_size_nothrow.verify.cpp SKIPPED
+language.support\support.dynamic\new.delete\new.delete.placement\new_array_ptr.verify.cpp SKIPPED
+language.support\support.dynamic\new.delete\new.delete.placement\new_ptr.verify.cpp SKIPPED
+language.support\support.dynamic\new.delete\new.delete.single\new_size.verify.cpp SKIPPED
+language.support\support.dynamic\new.delete\new.delete.single\new_size_align.verify.cpp SKIPPED
+language.support\support.dynamic\new.delete\new.delete.single\new_size_align_nothrow.verify.cpp SKIPPED
+language.support\support.dynamic\new.delete\new.delete.single\new_size_nothrow.verify.cpp SKIPPED
+language.support\support.dynamic\ptr.launder\launder.nodiscard.verify.cpp SKIPPED
+re\re.results\re.results.size\empty.verify.cpp SKIPPED
+strings\basic.string\string.capacity\empty.verify.cpp SKIPPED
+strings\string.view\string.view.capacity\empty.verify.cpp SKIPPED
+thread\futures\futures.async\async.verify.cpp SKIPPED
+utilities\allocator.adaptor\allocator.adaptor.members\allocate_size.verify.cpp SKIPPED
+utilities\allocator.adaptor\allocator.adaptor.members\allocate_size_hint.verify.cpp SKIPPED
+utilities\function.objects\negators\not1.depr_in_cxx17.verify.cpp SKIPPED
+utilities\function.objects\negators\not2.depr_in_cxx17.verify.cpp SKIPPED
+utilities\memory\allocator.traits\allocator.traits.members\allocate.verify.cpp SKIPPED
+utilities\memory\default.allocator\allocator.members\allocate.verify.cpp SKIPPED
 
 
 # *** MISSING STL FEATURES ***
@@ -555,9 +593,9 @@ std/input.output/file.streams/fstreams/filebuf.virtuals/underflow.pass.cpp FAIL
 std/depr/depr.c.headers/tgmath_h.pass.cpp SKIPPED
 
 # STL bug: Our inheritance implementation is allowing this to compile when it shouldn't.
-std/numerics/complex.number/complex.special/double_long_double_implicit.fail.cpp FAIL
-std/numerics/complex.number/complex.special/float_double_implicit.fail.cpp FAIL
-std/numerics/complex.number/complex.special/float_long_double_implicit.fail.cpp FAIL
+numerics\complex.number\complex.special\double_long_double_implicit.compile.fail.cpp FAIL
+numerics\complex.number\complex.special\float_double_implicit.compile.fail.cpp FAIL
+numerics\complex.number\complex.special\float_long_double_implicit.compile.fail.cpp FAIL
 
 # STL bug: regex_traits::transform() isn't following the Standard.
 std/re/re.traits/transform.pass.cpp FAIL
@@ -637,6 +675,10 @@ std/diagnostics/syserr/syserr.errcat/syserr.errcat.nonvirtuals/default_ctor.pass
 
 # STL Bug: future incorrectly uses copy assignment instead of copy construction in set_value. (Should be fixed in vNext.)
 std/thread/futures/futures.promise/set_value_const.pass.cpp FAIL
+
+# STL bug: GH-757 <xstring>: Too many enabled hash specializations
+strings\basic.string.hash\char_type_hash.fail.cpp FAIL
+strings\string.view\string.view.hash\char_type.hash.fail.cpp FAIL
 
 
 # *** CRT BUGS ***

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -677,8 +677,8 @@ std/diagnostics/syserr/syserr.errcat/syserr.errcat.nonvirtuals/default_ctor.pass
 std/thread/futures/futures.promise/set_value_const.pass.cpp FAIL
 
 # STL bug: GH-757 <xstring>: Too many enabled hash specializations
-strings/basic.string.hash/char_type_hash.fail.cpp FAIL
-strings/string.view/string.view.hash/char_type.hash.fail.cpp FAIL
+std/strings/basic.string.hash/char_type_hash.fail.cpp FAIL
+std/strings/string.view/string.view.hash/char_type.hash.fail.cpp FAIL
 
 
 # *** CRT BUGS ***

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -192,53 +192,53 @@ std/containers/unord/unord.set/max_size.pass.cpp SKIPPED
 std/utilities/tuple/tuple.tuple/tuple.apply/apply_large_arity.pass.cpp SKIPPED
 
 # .verify.cpp tests use clang-verify to validate warnings
-containers\associative\map\map.access\empty.verify.cpp SKIPPED
-containers\associative\multimap\empty.verify.cpp SKIPPED
-containers\associative\multiset\empty.verify.cpp SKIPPED
-containers\associative\set\empty.verify.cpp SKIPPED
-containers\container.adaptors\priority.queue\priqueue.members\empty.verify.cpp SKIPPED
-containers\container.adaptors\queue\queue.defn\empty.verify.cpp SKIPPED
-containers\container.adaptors\stack\stack.defn\empty.verify.cpp SKIPPED
-containers\sequences\array\empty.verify.cpp SKIPPED
-containers\sequences\deque\deque.capacity\empty.verify.cpp SKIPPED
-containers\sequences\forwardlist\empty.verify.cpp SKIPPED
-containers\sequences\list\list.capacity\empty.verify.cpp SKIPPED
-containers\sequences\vector\vector.capacity\empty.verify.cpp SKIPPED
-containers\sequences\vector.bool\empty.verify.cpp SKIPPED
-containers\sequences\vector\vector.cons\copy.move_only.verify.cpp SKIPPED
-containers\unord\unord.map\empty.verify.cpp SKIPPED
-containers\unord\unord.multimap\empty.verify.cpp SKIPPED
-containers\unord\unord.multiset\empty.verify.cpp SKIPPED
-containers\unord\unord.set\empty.verify.cpp SKIPPED
-depr\depr.lib.binders\depr.lib.bind.1st\bind1st.depr_in_cxx11.verify.cpp SKIPPED
-depr\depr.lib.binders\depr.lib.bind.2nd\bind2nd.depr_in_cxx11.verify.cpp SKIPPED
-depr\depr.lib.binders\depr.lib.binder.1st\binder1st.depr_in_cxx11.verify.cpp SKIPPED
-depr\depr.lib.binders\depr.lib.binder.2nd\binder2nd.depr_in_cxx11.verify.cpp SKIPPED
-input.output\filesystems\class.path\path.member\path.decompose\empty.verify.cpp SKIPPED
-iterators\iterator.container\empty.array.verify.cpp SKIPPED
-iterators\iterator.container\empty.container.verify.cpp SKIPPED
-iterators\iterator.container\empty.initializer_list.verify.cpp SKIPPED
-language.support\support.dynamic\new.delete\new.delete.array\new_size.verify.cpp SKIPPED
-language.support\support.dynamic\new.delete\new.delete.array\new_size_align.verify.cpp SKIPPED
-language.support\support.dynamic\new.delete\new.delete.array\new_size_align_nothrow.verify.cpp SKIPPED
-language.support\support.dynamic\new.delete\new.delete.array\new_size_nothrow.verify.cpp SKIPPED
-language.support\support.dynamic\new.delete\new.delete.placement\new_array_ptr.verify.cpp SKIPPED
-language.support\support.dynamic\new.delete\new.delete.placement\new_ptr.verify.cpp SKIPPED
-language.support\support.dynamic\new.delete\new.delete.single\new_size.verify.cpp SKIPPED
-language.support\support.dynamic\new.delete\new.delete.single\new_size_align.verify.cpp SKIPPED
-language.support\support.dynamic\new.delete\new.delete.single\new_size_align_nothrow.verify.cpp SKIPPED
-language.support\support.dynamic\new.delete\new.delete.single\new_size_nothrow.verify.cpp SKIPPED
-language.support\support.dynamic\ptr.launder\launder.nodiscard.verify.cpp SKIPPED
-re\re.results\re.results.size\empty.verify.cpp SKIPPED
-strings\basic.string\string.capacity\empty.verify.cpp SKIPPED
-strings\string.view\string.view.capacity\empty.verify.cpp SKIPPED
-thread\futures\futures.async\async.verify.cpp SKIPPED
-utilities\allocator.adaptor\allocator.adaptor.members\allocate_size.verify.cpp SKIPPED
-utilities\allocator.adaptor\allocator.adaptor.members\allocate_size_hint.verify.cpp SKIPPED
-utilities\function.objects\negators\not1.depr_in_cxx17.verify.cpp SKIPPED
-utilities\function.objects\negators\not2.depr_in_cxx17.verify.cpp SKIPPED
-utilities\memory\allocator.traits\allocator.traits.members\allocate.verify.cpp SKIPPED
-utilities\memory\default.allocator\allocator.members\allocate.verify.cpp SKIPPED
+std/containers/associative/map/map.access/empty.verify.cpp SKIPPED
+std/containers/associative/multimap/empty.verify.cpp SKIPPED
+std/containers/associative/multiset/empty.verify.cpp SKIPPED
+std/containers/associative/set/empty.verify.cpp SKIPPED
+std/containers/container.adaptors/priority.queue/priqueue.members/empty.verify.cpp SKIPPED
+std/containers/container.adaptors/queue/queue.defn/empty.verify.cpp SKIPPED
+std/containers/container.adaptors/stack/stack.defn/empty.verify.cpp SKIPPED
+std/containers/sequences/array/empty.verify.cpp SKIPPED
+std/containers/sequences/deque/deque.capacity/empty.verify.cpp SKIPPED
+std/containers/sequences/forwardlist/empty.verify.cpp SKIPPED
+std/containers/sequences/list/list.capacity/empty.verify.cpp SKIPPED
+std/containers/sequences/vector/vector.capacity/empty.verify.cpp SKIPPED
+std/containers/sequences/vector.bool/empty.verify.cpp SKIPPED
+std/containers/sequences/vector/vector.cons/copy.move_only.verify.cpp SKIPPED
+std/containers/unord/unord.map/empty.verify.cpp SKIPPED
+std/containers/unord/unord.multimap/empty.verify.cpp SKIPPED
+std/containers/unord/unord.multiset/empty.verify.cpp SKIPPED
+std/containers/unord/unord.set/empty.verify.cpp SKIPPED
+std/depr/depr.lib.binders/depr.lib.bind.1st/bind1st.depr_in_cxx11.verify.cpp SKIPPED
+std/depr/depr.lib.binders/depr.lib.bind.2nd/bind2nd.depr_in_cxx11.verify.cpp SKIPPED
+std/depr/depr.lib.binders/depr.lib.binder.1st/binder1st.depr_in_cxx11.verify.cpp SKIPPED
+std/depr/depr.lib.binders/depr.lib.binder.2nd/binder2nd.depr_in_cxx11.verify.cpp SKIPPED
+std/input.output/filesystems/class.path/path.member/path.decompose/empty.verify.cpp SKIPPED
+std/iterators/iterator.container/empty.array.verify.cpp SKIPPED
+std/iterators/iterator.container/empty.container.verify.cpp SKIPPED
+std/iterators/iterator.container/empty.initializer_list.verify.cpp SKIPPED
+std/language.support/support.dynamic/new.delete/new.delete.array/new_size.verify.cpp SKIPPED
+std/language.support/support.dynamic/new.delete/new.delete.array/new_size_align.verify.cpp SKIPPED
+std/language.support/support.dynamic/new.delete/new.delete.array/new_size_align_nothrow.verify.cpp SKIPPED
+std/language.support/support.dynamic/new.delete/new.delete.array/new_size_nothrow.verify.cpp SKIPPED
+std/language.support/support.dynamic/new.delete/new.delete.placement/new_array_ptr.verify.cpp SKIPPED
+std/language.support/support.dynamic/new.delete/new.delete.placement/new_ptr.verify.cpp SKIPPED
+std/language.support/support.dynamic/new.delete/new.delete.single/new_size.verify.cpp SKIPPED
+std/language.support/support.dynamic/new.delete/new.delete.single/new_size_align.verify.cpp SKIPPED
+std/language.support/support.dynamic/new.delete/new.delete.single/new_size_align_nothrow.verify.cpp SKIPPED
+std/language.support/support.dynamic/new.delete/new.delete.single/new_size_nothrow.verify.cpp SKIPPED
+std/language.support/support.dynamic/ptr.launder/launder.nodiscard.verify.cpp SKIPPED
+std/re/re.results/re.results.size/empty.verify.cpp SKIPPED
+std/strings/basic.string/string.capacity/empty.verify.cpp SKIPPED
+std/strings/string.view/string.view.capacity/empty.verify.cpp SKIPPED
+std/thread/futures/futures.async/async.verify.cpp SKIPPED
+std/utilities/allocator.adaptor/allocator.adaptor.members/allocate_size.verify.cpp SKIPPED
+std/utilities/allocator.adaptor/allocator.adaptor.members/allocate_size_hint.verify.cpp SKIPPED
+std/utilities/function.objects/negators/not1.depr_in_cxx17.verify.cpp SKIPPED
+std/utilities/function.objects/negators/not2.depr_in_cxx17.verify.cpp SKIPPED
+std/utilities/memory/allocator.traits/allocator.traits.members/allocate.verify.cpp SKIPPED
+std/utilities/memory/default.allocator/allocator.members/allocate.verify.cpp SKIPPED
 
 
 # *** MISSING STL FEATURES ***
@@ -593,9 +593,9 @@ std/input.output/file.streams/fstreams/filebuf.virtuals/underflow.pass.cpp FAIL
 std/depr/depr.c.headers/tgmath_h.pass.cpp SKIPPED
 
 # STL bug: Our inheritance implementation is allowing this to compile when it shouldn't.
-numerics\complex.number\complex.special\double_long_double_implicit.compile.fail.cpp FAIL
-numerics\complex.number\complex.special\float_double_implicit.compile.fail.cpp FAIL
-numerics\complex.number\complex.special\float_long_double_implicit.compile.fail.cpp FAIL
+std/numerics/complex.number/complex.special/double_long_double_implicit.compile.fail.cpp FAIL
+std/numerics/complex.number/complex.special/float_double_implicit.compile.fail.cpp FAIL
+std/numerics/complex.number/complex.special/float_long_double_implicit.compile.fail.cpp FAIL
 
 # STL bug: regex_traits::transform() isn't following the Standard.
 std/re/re.traits/transform.pass.cpp FAIL
@@ -677,8 +677,8 @@ std/diagnostics/syserr/syserr.errcat/syserr.errcat.nonvirtuals/default_ctor.pass
 std/thread/futures/futures.promise/set_value_const.pass.cpp FAIL
 
 # STL bug: GH-757 <xstring>: Too many enabled hash specializations
-strings\basic.string.hash\char_type_hash.fail.cpp FAIL
-strings\string.view\string.view.hash\char_type.hash.fail.cpp FAIL
+strings/basic.string.hash/char_type_hash.fail.cpp FAIL
+strings/string.view/string.view.hash/char_type.hash.fail.cpp FAIL
 
 
 # *** CRT BUGS ***
@@ -1064,7 +1064,7 @@ std/utilities/tuple/tuple.tuple/tuple.cnstr/deduct.pass.cpp:0 FAIL
 std/localization/locale.categories/category.ctype/locale.codecvt/locale.codecvt.members/utf_sanity_check.pass.cpp FAIL
 
 # Not yet analyzed. Frequent timeouts
-containers\sequences\deque\deque.modifiers\insert_iter_iter.pass.cpp SKIPPED
+std/containers/sequences/deque/deque.modifiers/insert_iter_iter.pass.cpp SKIPPED
 
 
 # *** XFAILs WHICH PASS ***

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -174,22 +174,11 @@ input.output\filesystems\fs.op.funcs\fs.op.symlink_status\symlink_status.pass.cp
 input.output\filesystems\fs.op.funcs\fs.op.temp_dir_path\temp_directory_path.pass.cpp
 input.output\filesystems\fs.op.funcs\fs.op.weakly_canonical\weakly_canonical.pass.cpp
 
-# We need some way to turn on deprecations for tests asking for _LIBCPP_ENABLE_DEPRECATION_WARNINGS
-utilities\function.objects\negators\binary_negate.depr_in_cxx17.fail.cpp
-utilities\function.objects\negators\unary_negate.depr_in_cxx17.fail.cpp
-
 # generate_feature_test_macro_components.py needs to learn about C1XX
 language.support\support.limits\support.limits.general\type_traits.version.pass.cpp
 language.support\support.limits\support.limits.general\version.version.pass.cpp
 
 # Contest does not understand .sh tests, which must be run specially
-depr\depr.c.headers\stdint_h.sh.cpp
-language.support\support.dynamic\new.delete\new.delete.array\new_size_align_nothrow.sh.cpp
-language.support\support.dynamic\new.delete\new.delete.array\new_size_align.sh.cpp
-language.support\support.dynamic\new.delete\new.delete.array\new_size_nothrow.sh.cpp
-language.support\support.dynamic\new.delete\new.delete.array\new_size.sh.cpp
-language.support\support.dynamic\new.delete\new.delete.single\new_size_align_nothrow.sh.cpp
-language.support\support.dynamic\new.delete\new.delete.single\new_size_align.sh.cpp
 thread\thread.condition\thread.condition.condvarany\wait_terminates.sh.cpp
 
 # These tests set an allocator with a max_size() too small to default construct an unordered container
@@ -201,6 +190,55 @@ containers\unord\unord.set\max_size.pass.cpp
 
 # Requires too great a template instantiation depth for C1XX.
 utilities\tuple\tuple.tuple\tuple.apply\apply_large_arity.pass.cpp
+
+# .verify.cpp tests use clang-verify to validate warnings
+containers\associative\map\map.access\empty.verify.cpp
+containers\associative\multimap\empty.verify.cpp
+containers\associative\multiset\empty.verify.cpp
+containers\associative\set\empty.verify.cpp
+containers\container.adaptors\priority.queue\priqueue.members\empty.verify.cpp
+containers\container.adaptors\queue\queue.defn\empty.verify.cpp
+containers\container.adaptors\stack\stack.defn\empty.verify.cpp
+containers\sequences\array\empty.verify.cpp
+containers\sequences\deque\deque.capacity\empty.verify.cpp
+containers\sequences\forwardlist\empty.verify.cpp
+containers\sequences\list\list.capacity\empty.verify.cpp
+containers\sequences\vector\vector.capacity\empty.verify.cpp
+containers\sequences\vector.bool\empty.verify.cpp
+containers\sequences\vector\vector.cons\copy.move_only.verify.cpp
+containers\unord\unord.map\empty.verify.cpp
+containers\unord\unord.multimap\empty.verify.cpp
+containers\unord\unord.multiset\empty.verify.cpp
+containers\unord\unord.set\empty.verify.cpp
+depr\depr.lib.binders\depr.lib.bind.1st\bind1st.depr_in_cxx11.verify.cpp
+depr\depr.lib.binders\depr.lib.bind.2nd\bind2nd.depr_in_cxx11.verify.cpp
+depr\depr.lib.binders\depr.lib.binder.1st\binder1st.depr_in_cxx11.verify.cpp
+depr\depr.lib.binders\depr.lib.binder.2nd\binder2nd.depr_in_cxx11.verify.cpp
+input.output\filesystems\class.path\path.member\path.decompose\empty.verify.cpp
+iterators\iterator.container\empty.array.verify.cpp
+iterators\iterator.container\empty.container.verify.cpp
+iterators\iterator.container\empty.initializer_list.verify.cpp
+language.support\support.dynamic\new.delete\new.delete.array\new_size.verify.cpp
+language.support\support.dynamic\new.delete\new.delete.array\new_size_align.verify.cpp
+language.support\support.dynamic\new.delete\new.delete.array\new_size_align_nothrow.verify.cpp
+language.support\support.dynamic\new.delete\new.delete.array\new_size_nothrow.verify.cpp
+language.support\support.dynamic\new.delete\new.delete.placement\new_array_ptr.verify.cpp
+language.support\support.dynamic\new.delete\new.delete.placement\new_ptr.verify.cpp
+language.support\support.dynamic\new.delete\new.delete.single\new_size.verify.cpp
+language.support\support.dynamic\new.delete\new.delete.single\new_size_align.verify.cpp
+language.support\support.dynamic\new.delete\new.delete.single\new_size_align_nothrow.verify.cpp
+language.support\support.dynamic\new.delete\new.delete.single\new_size_nothrow.verify.cpp
+language.support\support.dynamic\ptr.launder\launder.nodiscard.verify.cpp
+re\re.results\re.results.size\empty.verify.cpp
+strings\basic.string\string.capacity\empty.verify.cpp
+strings\string.view\string.view.capacity\empty.verify.cpp
+thread\futures\futures.async\async.verify.cpp
+utilities\allocator.adaptor\allocator.adaptor.members\allocate_size.verify.cpp
+utilities\allocator.adaptor\allocator.adaptor.members\allocate_size_hint.verify.cpp
+utilities\function.objects\negators\not1.depr_in_cxx17.verify.cpp
+utilities\function.objects\negators\not2.depr_in_cxx17.verify.cpp
+utilities\memory\allocator.traits\allocator.traits.members\allocate.verify.cpp
+utilities\memory\default.allocator\allocator.members\allocate.verify.cpp
 
 
 # *** MISSING STL FEATURES ***
@@ -555,9 +593,9 @@ input.output\file.streams\fstreams\filebuf.virtuals\underflow.pass.cpp
 depr\depr.c.headers\tgmath_h.pass.cpp
 
 # STL bug: Our inheritance implementation is allowing this to compile when it shouldn't.
-numerics\complex.number\complex.special\double_long_double_implicit.fail.cpp
-numerics\complex.number\complex.special\float_double_implicit.fail.cpp
-numerics\complex.number\complex.special\float_long_double_implicit.fail.cpp
+numerics\complex.number\complex.special\double_long_double_implicit.compile.fail.cpp
+numerics\complex.number\complex.special\float_double_implicit.compile.fail.cpp
+numerics\complex.number\complex.special\float_long_double_implicit.compile.fail.cpp
 
 # STL bug: regex_traits::transform() isn't following the Standard.
 re\re.traits\transform.pass.cpp
@@ -637,6 +675,10 @@ diagnostics\syserr\syserr.errcat\syserr.errcat.nonvirtuals\default_ctor.pass.cpp
 
 # STL Bug: future incorrectly uses copy assignment instead of copy construction in set_value. (Should be fixed in vNext.)
 thread\futures\futures.promise\set_value_const.pass.cpp
+
+# STL bug: GH-757 <xstring>: Too many enabled hash specializations
+strings\basic.string.hash\char_type_hash.fail.cpp
+strings\string.view\string.view.hash\char_type.hash.fail.cpp
 
 
 # *** CRT BUGS ***


### PR DESCRIPTION
Changes primarily came from P0896R4 "`<ranges>`", but the `operator<=>` from P1614R1 "Adding Spaceship `<=>` To The Library" is here as well.

I had to patch a pair of libc++ tests for an extension that allows `std::map<int, X>::reverse_iterator` (resp. `std::multimap<int, X>::reverse_iterator`) to be instantiated when `X` is incomplete; this extension is no longer possible in C++20.

Drive-by:
* LWG-3413 has a number now
* ~~Remove workarounds for VSO-612785 which seems not to reproduce with current EDG~~ (Still needed for CUDA 9.2 in our Microsoft-internal test suite.)