### PR TITLE
Improve build instructions and cleanup code

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,8 +170,8 @@ architectures.
 9. Invoke `cd STL`
 10. Invoke `cmake -G Ninja -DCMAKE_TOOLCHAIN_FILE={where your vcpkg clone is located}\scripts\buildsystems\vcpkg.cmake
 -S . -B {wherever you want binaries}` to configure the project. For example, `cmake -G Ninja
--DCMAKE_TOOLCHAIN_FILE=C:\Dev\vcpkg\scripts\buildsystems\vcpkg.cmake -S . -B build.x64`
-11. Invoke `ninja -C {wherever you want binaries}` to build the project. For example, `ninja -C build.x64`
+-DCMAKE_TOOLCHAIN_FILE=C:\Dev\vcpkg\scripts\buildsystems\vcpkg.cmake -S . -B out\build\x64`
+11. Invoke `ninja -C {wherever you want binaries}` to build the project. For example, `ninja -C out\build\x64`
 
 # How To Consume
 

--- a/stl/inc/experimental/filesystem
+++ b/stl/inc/experimental/filesystem
@@ -1370,14 +1370,12 @@ private:
     path _Mypval1;
     path _Mypval2;
 
-#if _HAS_EXCEPTIONS
-
-#else // _HAS_EXCEPTIONS
+#if !_HAS_EXCEPTIONS
 protected:
     virtual __CLR_OR_THIS_CALL void _Doraise() const override { // perform class-specific exception handling
         _RAISE(*this);
     }
-#endif // _HAS_EXCEPTIONS
+#endif // !_HAS_EXCEPTIONS
 };
 
 [[noreturn]] inline void _Throw_filesystem_error(const char* const _Message) {

--- a/stl/inc/filesystem
+++ b/stl/inc/filesystem
@@ -1794,14 +1794,12 @@ namespace filesystem {
         path _Path2;
         string _What;
 
-#if _HAS_EXCEPTIONS
-
-#else // _HAS_EXCEPTIONS
+#if !_HAS_EXCEPTIONS
     protected:
         virtual void _Doraise() const override { // perform class-specific exception handling
             _RAISE(*this);
         }
-#endif // _HAS_EXCEPTIONS
+#endif // !_HAS_EXCEPTIONS
     };
 
     [[noreturn]] inline void _Throw_fs_error(const char* _Op, __std_win_error _Error) {

--- a/stl/inc/functional
+++ b/stl/inc/functional
@@ -1366,9 +1366,9 @@ struct _Select_fixer<_Cv_TiD, false, true, 0> { // nested bind fixer
 #pragma warning(pop)
 
     template <class _Untuple>
-    static auto _Fix(_Cv_TiD& _Tid, _Untuple&& _Ut) -> decltype(_Apply(_Tid, _STD move(_Ut),
-        make_index_sequence<tuple_size_v<_Untuple>>())) { // call a nested bind expression
-        return _Apply(_Tid, _STD move(_Ut), make_index_sequence<tuple_size_v<_Untuple>>());
+    static auto _Fix(_Cv_TiD& _Tid, _Untuple&& _Ut) -> decltype(
+        _Apply(_Tid, _STD move(_Ut), make_index_sequence<tuple_size_v<_Untuple>>{})) { // call a nested bind expression
+        return _Apply(_Tid, _STD move(_Ut), make_index_sequence<tuple_size_v<_Untuple>>{});
     }
 };
 
@@ -1439,9 +1439,9 @@ public:
 
 #define _BINDER_OPERATOR(CONST_OPT)                                                                           \
     template <class... _Unbound>                                                                              \
-    auto operator()(_Unbound&&... _Unbargs) CONST_OPT->decltype(_Call_binder(_Invoker_ret<_Ret>(), _Seq(),    \
+    auto operator()(_Unbound&&... _Unbargs) CONST_OPT->decltype(_Call_binder(_Invoker_ret<_Ret>(), _Seq{},    \
         _Mypair._Get_first(), _Mypair._Myval2, _STD forward_as_tuple(_STD forward<_Unbound>(_Unbargs)...))) { \
-        return _Call_binder(_Invoker_ret<_Ret>(), _Seq(), _Mypair._Get_first(), _Mypair._Myval2,              \
+        return _Call_binder(_Invoker_ret<_Ret>(), _Seq{}, _Mypair._Get_first(), _Mypair._Myval2,              \
             _STD forward_as_tuple(_STD forward<_Unbound>(_Unbargs)...));                                      \
     }
 

--- a/stl/inc/future
+++ b/stl/inc/future
@@ -139,14 +139,12 @@ public:
         return _Future_error_map(_Mycode.value());
     }
 
-#if _HAS_EXCEPTIONS
-
-#else // _HAS_EXCEPTIONS
+#if !_HAS_EXCEPTIONS
 protected:
     virtual void _Doraise() const override { // perform class-specific exception handling
         _RAISE(*this);
     }
-#endif // _HAS_EXCEPTIONS
+#endif // !_HAS_EXCEPTIONS
 
 private:
     error_code _Mycode; // the stored error code

--- a/stl/inc/mutex
+++ b/stl/inc/mutex
@@ -518,8 +518,8 @@ auto _Invoke_stored_explicit(tuple<_Types...>&& _Tuple, index_sequence<_Indices.
 // FUNCTION TEMPLATE _Invoke_stored
 template <class... _Types>
 auto _Invoke_stored(tuple<_Types...>&& _Tuple)
-    -> decltype(_Invoke_stored_explicit(_STD move(_Tuple), index_sequence_for<_Types...>())) { // invoke() a tuple
-    return _Invoke_stored_explicit(_STD move(_Tuple), index_sequence_for<_Types...>());
+    -> decltype(_Invoke_stored_explicit(_STD move(_Tuple), index_sequence_for<_Types...>{})) { // invoke() a tuple
+    return _Invoke_stored_explicit(_STD move(_Tuple), index_sequence_for<_Types...>{});
 }
 
 // FUNCTION TEMPLATE call_once
@@ -530,9 +530,9 @@ int __stdcall _Callback_once(void*, void* _Pv, void**) { // adapt call_once() to
     _Tuple* _Ptup = static_cast<_Tuple*>(_Pv);
 
     _TRY_BEGIN
-    // Note explicit _Seq() selects every element from *_Ptup except the last,
+    // Note explicit _Seq{} selects every element from *_Ptup except the last,
     // which contains call_once's exception_ptr.
-    _Invoke_stored_explicit(_STD move(*_Ptup), _Seq());
+    _Invoke_stored_explicit(_STD move(*_Ptup), _Seq{});
     _CATCH_ALL
     auto& _Ref = _STD get<_Idx>(*_Ptup);
     _Ref       = _STD current_exception();

--- a/stl/inc/stdexcept
+++ b/stl/inc/stdexcept
@@ -27,14 +27,12 @@ public:
 
     explicit logic_error(const char* _Message) : _Mybase(_Message) {}
 
-#if _HAS_EXCEPTIONS
-
-#else // _HAS_EXCEPTIONS
+#if !_HAS_EXCEPTIONS
 protected:
     virtual void _Doraise() const override { // perform class-specific exception handling
         _RAISE(*this);
     }
-#endif // _HAS_EXCEPTIONS
+#endif // !_HAS_EXCEPTIONS
 };
 
 // CLASS domain_error
@@ -46,14 +44,12 @@ public:
 
     explicit domain_error(const char* _Message) : _Mybase(_Message) {}
 
-#if _HAS_EXCEPTIONS
-
-#else // _HAS_EXCEPTIONS
+#if !_HAS_EXCEPTIONS
 protected:
     virtual void _Doraise() const override { // perform class-specific exception handling
         _RAISE(*this);
     }
-#endif // _HAS_EXCEPTIONS
+#endif // !_HAS_EXCEPTIONS
 };
 
 // CLASS invalid_argument
@@ -65,14 +61,12 @@ public:
 
     explicit invalid_argument(const char* _Message) : _Mybase(_Message) {}
 
-#if _HAS_EXCEPTIONS
-
-#else // _HAS_EXCEPTIONS
+#if !_HAS_EXCEPTIONS
 protected:
     virtual void _Doraise() const override { // perform class-specific exception handling
         _RAISE(*this);
     }
-#endif // _HAS_EXCEPTIONS
+#endif // !_HAS_EXCEPTIONS
 };
 
 // CLASS length_error
@@ -84,14 +78,12 @@ public:
 
     explicit length_error(const char* _Message) : _Mybase(_Message) {}
 
-#if _HAS_EXCEPTIONS
-
-#else // _HAS_EXCEPTIONS
+#if !_HAS_EXCEPTIONS
 protected:
     virtual void _Doraise() const override { // perform class-specific exception handling
         _RAISE(*this);
     }
-#endif // _HAS_EXCEPTIONS
+#endif // !_HAS_EXCEPTIONS
 };
 
 // CLASS out_of_range
@@ -103,14 +95,12 @@ public:
 
     explicit out_of_range(const char* _Message) : _Mybase(_Message) {}
 
-#if _HAS_EXCEPTIONS
-
-#else // _HAS_EXCEPTIONS
+#if !_HAS_EXCEPTIONS
 protected:
     virtual void _Doraise() const override { // perform class-specific exception handling
         _RAISE(*this);
     }
-#endif // _HAS_EXCEPTIONS
+#endif // !_HAS_EXCEPTIONS
 };
 
 // CLASS runtime_error
@@ -122,14 +112,12 @@ public:
 
     explicit runtime_error(const char* _Message) : _Mybase(_Message) {}
 
-#if _HAS_EXCEPTIONS
-
-#else // _HAS_EXCEPTIONS
+#if !_HAS_EXCEPTIONS
 protected:
     virtual void _Doraise() const override { // perform class-specific exception handling
         _RAISE(*this);
     }
-#endif // _HAS_EXCEPTIONS
+#endif // !_HAS_EXCEPTIONS
 };
 
 // CLASS overflow_error
@@ -141,14 +129,12 @@ public:
 
     explicit overflow_error(const char* _Message) : _Mybase(_Message) {}
 
-#if _HAS_EXCEPTIONS
-
-#else // _HAS_EXCEPTIONS
+#if !_HAS_EXCEPTIONS
 protected:
     virtual void _Doraise() const override { // perform class-specific exception handling
         _RAISE(*this);
     }
-#endif // _HAS_EXCEPTIONS
+#endif // !_HAS_EXCEPTIONS
 };
 
 // CLASS underflow_error
@@ -160,14 +146,12 @@ public:
 
     explicit underflow_error(const char* _Message) : _Mybase(_Message) {}
 
-#if _HAS_EXCEPTIONS
-
-#else // _HAS_EXCEPTIONS
+#if !_HAS_EXCEPTIONS
 protected:
     virtual void _Doraise() const override { // perform class-specific exception handling
         _RAISE(*this);
     }
-#endif // _HAS_EXCEPTIONS
+#endif // !_HAS_EXCEPTIONS
 };
 
 // CLASS range_error
@@ -179,14 +163,12 @@ public:
 
     explicit range_error(const char* _Message) : _Mybase(_Message) {}
 
-#if _HAS_EXCEPTIONS
-
-#else // _HAS_EXCEPTIONS
+#if !_HAS_EXCEPTIONS
 protected:
     virtual void _Doraise() const override { // perform class-specific exception handling
         _RAISE(*this);
     }
-#endif // _HAS_EXCEPTIONS
+#endif // !_HAS_EXCEPTIONS
 };
 
 [[noreturn]] inline void _Throw_range_error(const char* const _Message) {

--- a/stl/inc/system_error
+++ b/stl/inc/system_error
@@ -425,14 +425,12 @@ public:
         return _Mycode;
     }
 
-#if _HAS_EXCEPTIONS
-
-#else // _HAS_EXCEPTIONS
+#if !_HAS_EXCEPTIONS
 protected:
     virtual void _Doraise() const override { // perform class-specific exception handling
         _RAISE(*this);
     }
-#endif // _HAS_EXCEPTIONS
+#endif // !_HAS_EXCEPTIONS
 };
 
 [[noreturn]] inline void _Throw_system_error(const errc _Errno) {

--- a/stl/inc/tuple
+++ b/stl/inc/tuple
@@ -1004,7 +1004,7 @@ pair<_Ty1, _Ty2>::pair(_Tuple1& _Val1, _Tuple2& _Val2, index_sequence<_Indexes1.
 template <class _Ty1, class _Ty2>
 template <class... _Types1, class... _Types2>
 pair<_Ty1, _Ty2>::pair(piecewise_construct_t, tuple<_Types1...> _Val1, tuple<_Types2...> _Val2)
-    : pair(_Val1, _Val2, index_sequence_for<_Types1...>(), index_sequence_for<_Types2...>()) {}
+    : pair(_Val1, _Val2, index_sequence_for<_Types1...>{}, index_sequence_for<_Types2...>{}) {}
 
 // STRUCT TEMPLATE uses_allocator
 template <class... _Types, class _Alloc>

--- a/stl/inc/typeinfo
+++ b/stl/inc/typeinfo
@@ -27,7 +27,7 @@ _STD_BEGIN
 // size in pointers of std::function and std::any (roughly 3 pointers larger than std::string when building debug)
 constexpr int _Small_object_num_ptrs = 6 + 16 / sizeof(void*);
 
-#if !(_HAS_EXCEPTIONS)
+#if !_HAS_EXCEPTIONS
 
 // CLASS bad_cast
 class _CRTIMP2_IMPORT bad_cast : public exception { // base of all bad cast exceptions
@@ -59,7 +59,7 @@ class _CRTIMP2_IMPORT __non_rtti_object : public bad_typeid { // report a non RT
 public:
     __non_rtti_object(const char* _Message) : bad_typeid(_Message) {}
 };
-#endif // _HAS_EXCEPTIONS
+#endif // !_HAS_EXCEPTIONS
 
 [[noreturn]] inline void _Throw_bad_cast() {
     _THROW(bad_cast{});

--- a/stl/inc/xiosbase
+++ b/stl/inc/xiosbase
@@ -206,14 +206,12 @@ public:
             : system_error(_Errcode, _Message) { // construct with message
         }
 
-#if _HAS_EXCEPTIONS
-
-#else // _HAS_EXCEPTIONS
+#if !_HAS_EXCEPTIONS
     protected:
         virtual void _Doraise() const override { // report the exception
             _RAISE(*this);
         }
-#endif // _HAS_EXCEPTIONS
+#endif // !_HAS_EXCEPTIONS
     };
 
     // CLASS Init

--- a/stl/inc/yvals.h
+++ b/stl/inc/yvals.h
@@ -441,7 +441,6 @@ private:
     catch (...) {
 #define _CATCH_END }
 
-#define _RAISE(x) throw x
 #define _RERAISE  throw
 #define _THROW(x) throw x
 

--- a/stl/src/_tolower.cpp
+++ b/stl/src/_tolower.cpp
@@ -83,9 +83,10 @@ _CRTIMP2_PURE int __CLRCALL_PURE_OR_CDECL _Tolower(int c, const _Ctypevec* ploc)
     }
 
     // convert wide char to lowercase
-    if (0
-        == (size = __crtLCMapStringA(
-                locale_name, LCMAP_LOWERCASE, (const char*) inbuffer, size, (char*) outbuffer, 3, codepage, TRUE))) {
+    size = __crtLCMapStringA(locale_name, LCMAP_LOWERCASE, reinterpret_cast<const char*>(inbuffer), size,
+        reinterpret_cast<char*>(outbuffer), 3, codepage, TRUE);
+
+    if (size == 0) {
         return c;
     }
 

--- a/stl/src/_tolower.cpp
+++ b/stl/src/_tolower.cpp
@@ -41,7 +41,7 @@ _CRTIMP2_PURE int __CLRCALL_PURE_OR_CDECL _Tolower(int c, const _Ctypevec* ploc)
     UINT codepage;
     const wchar_t* locale_name;
 
-    if (ploc == 0) {
+    if (ploc == nullptr) {
         locale_name = ___lc_locale_name_func()[LC_CTYPE];
         codepage    = ___lc_codepage_func();
     } else {
@@ -59,7 +59,7 @@ _CRTIMP2_PURE int __CLRCALL_PURE_OR_CDECL _Tolower(int c, const _Ctypevec* ploc)
 
     // if checking case of c does not require API call, do it
     if (static_cast<unsigned int>(c) < 256) {
-        if (ploc == 0) {
+        if (ploc == nullptr) {
             if (!isupper(c)) {
                 return c;
             }
@@ -71,7 +71,7 @@ _CRTIMP2_PURE int __CLRCALL_PURE_OR_CDECL _Tolower(int c, const _Ctypevec* ploc)
     }
 
     // convert int c to multibyte string
-    if (ploc == 0 ? _cpp_isleadbyte((c >> 8) & 0xff) : (ploc->_Table[(c >> 8) & 0xff] & _LEADBYTE) != 0) {
+    if (ploc == nullptr ? _cpp_isleadbyte((c >> 8) & 0xff) : (ploc->_Table[(c >> 8) & 0xff] & _LEADBYTE) != 0) {
         inbuffer[0] = (c >> 8 & 0xff);
         inbuffer[1] = (unsigned char) c;
         inbuffer[2] = 0;

--- a/stl/src/_tolower.cpp
+++ b/stl/src/_tolower.cpp
@@ -58,7 +58,7 @@ _CRTIMP2_PURE int __CLRCALL_PURE_OR_CDECL _Tolower(int c, const _Ctypevec* ploc)
     }
 
     // if checking case of c does not require API call, do it
-    if ((unsigned) c < 256) {
+    if (static_cast<unsigned int>(c) < 256) {
         if (ploc == 0) {
             if (!isupper(c)) {
                 return c;

--- a/stl/src/_toupper.cpp
+++ b/stl/src/_toupper.cpp
@@ -39,7 +39,7 @@ _CRTIMP2_PURE int __CLRCALL_PURE_OR_CDECL _Toupper(int c, const _Ctypevec* ploc)
     const wchar_t* locale_name;
     UINT codepage;
 
-    if (ploc == 0) {
+    if (ploc == nullptr) {
         locale_name = ___lc_locale_name_func()[LC_CTYPE];
         codepage    = ___lc_codepage_func();
     } else {
@@ -57,7 +57,7 @@ _CRTIMP2_PURE int __CLRCALL_PURE_OR_CDECL _Toupper(int c, const _Ctypevec* ploc)
 
     // if checking case of c does not require API call, do it
     if (static_cast<unsigned int>(c) < 256) {
-        if (ploc == 0) {
+        if (ploc == nullptr) {
             if (!islower(c)) {
                 return c;
             }
@@ -69,7 +69,7 @@ _CRTIMP2_PURE int __CLRCALL_PURE_OR_CDECL _Toupper(int c, const _Ctypevec* ploc)
     }
 
     // convert int c to multibyte string
-    if (ploc == 0 ? _cpp_isleadbyte((c >> 8) & 0xff) : (ploc->_Table[(c >> 8) & 0xff] & _LEADBYTE) != 0) {
+    if (ploc == nullptr ? _cpp_isleadbyte((c >> 8) & 0xff) : (ploc->_Table[(c >> 8) & 0xff] & _LEADBYTE) != 0) {
         inbuffer[0] = (c >> 8 & 0xff);
         inbuffer[1] = (unsigned char) c;
         inbuffer[2] = 0;

--- a/stl/src/_toupper.cpp
+++ b/stl/src/_toupper.cpp
@@ -81,9 +81,10 @@ _CRTIMP2_PURE int __CLRCALL_PURE_OR_CDECL _Toupper(int c, const _Ctypevec* ploc)
     }
 
     // convert wide char to uppercase
-    if (0
-        == (size = __crtLCMapStringA(
-                locale_name, LCMAP_UPPERCASE, (const char*) inbuffer, size, (char*) outbuffer, 3, codepage, TRUE))) {
+    size = __crtLCMapStringA(locale_name, LCMAP_UPPERCASE, reinterpret_cast<const char*>(inbuffer), size,
+        reinterpret_cast<char*>(outbuffer), 3, codepage, TRUE);
+
+    if (size == 0) {
         return c;
     }
 

--- a/stl/src/_toupper.cpp
+++ b/stl/src/_toupper.cpp
@@ -56,7 +56,7 @@ _CRTIMP2_PURE int __CLRCALL_PURE_OR_CDECL _Toupper(int c, const _Ctypevec* ploc)
     }
 
     // if checking case of c does not require API call, do it
-    if ((unsigned) c < 256) {
+    if (static_cast<unsigned int>(c) < 256) {
         if (ploc == 0) {
             if (!islower(c)) {
                 return c;

--- a/stl/src/cthread.cpp
+++ b/stl/src/cthread.cpp
@@ -47,8 +47,8 @@ _CRTIMP2_PURE void _Thrd_exit(int res) { // terminate execution of calling threa
 
 // TRANSITION, ABI: _Thrd_start() is preserved for binary compatibility
 _CRTIMP2_PURE int _Thrd_start(_Thrd_t* thr, _Thrd_callback_t func, void* b) { // start a thread
-    return (thr->_Hnd = reinterpret_cast<HANDLE>(_beginthreadex(0, 0, func, b, 0, &thr->_Id))) == 0 ? _Thrd_error
-                                                                                                    : _Thrd_success;
+    thr->_Hnd = reinterpret_cast<HANDLE>(_beginthreadex(0, 0, func, b, 0, &thr->_Id));
+    return thr->_Hnd == 0 ? _Thrd_error : _Thrd_success;
 }
 
 int _Thrd_join(_Thrd_t thr, int* code) { // return exit code when thread terminates

--- a/stl/src/dllmain.cpp
+++ b/stl/src/dllmain.cpp
@@ -9,17 +9,15 @@
 #if defined(_CRT_APP)
 // free static resource used by causality
 extern "C" void __cdecl __crtCleanupCausalityStaticFactories();
-#endif
+#endif // defined(_CRT_APP)
 
-extern "C" BOOL APIENTRY DllMain(HMODULE /* hModule */, DWORD ul_reason_for_call, LPVOID lpReserved) {
+extern "C" BOOL APIENTRY DllMain(HMODULE /* hModule */, DWORD ul_reason_for_call, [[maybe_unused]] LPVOID lpReserved) {
     if (ul_reason_for_call == DLL_PROCESS_DETACH) {
 #if defined(_CRT_APP)
         if (lpReserved == nullptr) { // only when the process is not terminating
             __crtCleanupCausalityStaticFactories();
         }
-#else
-        (void) (lpReserved);
-#endif
+#endif // defined(_CRT_APP)
     }
     return TRUE;
 }

--- a/stl/src/dllmain.cpp
+++ b/stl/src/dllmain.cpp
@@ -6,18 +6,18 @@
 
 #include <Windows.h>
 
-#if defined(_CRT_APP)
+#ifdef _CRT_APP
 // free static resource used by causality
 extern "C" void __cdecl __crtCleanupCausalityStaticFactories();
-#endif // defined(_CRT_APP)
+#endif // _CRT_APP
 
 extern "C" BOOL APIENTRY DllMain(HMODULE /* hModule */, DWORD ul_reason_for_call, [[maybe_unused]] LPVOID lpReserved) {
     if (ul_reason_for_call == DLL_PROCESS_DETACH) {
-#if defined(_CRT_APP)
+#ifdef _CRT_APP
         if (lpReserved == nullptr) { // only when the process is not terminating
             __crtCleanupCausalityStaticFactories();
         }
-#endif // defined(_CRT_APP)
+#endif // _CRT_APP
     }
     return TRUE;
 }

--- a/stl/src/filesys.cpp
+++ b/stl/src/filesys.cpp
@@ -43,17 +43,17 @@ static wchar_t* _Strcpy(wchar_t (&_Dest)[_MAX_FILESYS_NAME], const wchar_t* _Src
 }
 
 static HANDLE _FilesysOpenFile(const wchar_t* _Fname, DWORD _Desired_access, DWORD _Flags) {
-#if defined(_CRT_APP)
+#ifdef _CRT_APP
     CREATEFILE2_EXTENDED_PARAMETERS _Create_file_parameters = {};
     _Create_file_parameters.dwSize                          = sizeof(_Create_file_parameters);
     _Create_file_parameters.dwFileFlags                     = _Flags;
 
     return CreateFile2(_Fname, _Desired_access, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, OPEN_EXISTING,
         &_Create_file_parameters);
-#else // defined(_CRT_APP)
+#else // _CRT_APP
     return CreateFileW(
         _Fname, _Desired_access, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, 0, OPEN_EXISTING, _Flags, 0);
-#endif // defined(_CRT_APP)
+#endif // _CRT_APP
 }
 
 _FS_DLL wchar_t* __CLRCALL_PURE_OR_CDECL _Read_dir(
@@ -141,21 +141,21 @@ _FS_DLL void* __CLRCALL_PURE_OR_CDECL _Open_dir(
 _FS_DLL bool __CLRCALL_PURE_OR_CDECL _Current_get(wchar_t (&_Dest)[_MAX_FILESYS_NAME]) {
     // get current working directory
     _Strcpy(_Dest, L"");
-#if defined(_CRT_APP)
+#ifdef _CRT_APP
     return false; // no support
-#else // defined(_CRT_APP)
+#else // _CRT_APP
     return _wgetcwd(_Dest, _MAX_FILESYS_NAME) != 0;
-#endif // defined(_CRT_APP)
+#endif // _CRT_APP
 }
 
 _FS_DLL bool __CLRCALL_PURE_OR_CDECL _Current_set(const wchar_t* _Dirname) {
     // set current working directory
-#if defined(_CRT_APP)
+#ifdef _CRT_APP
     (void) _Dirname;
     return false; // no support
-#else // defined(_CRT_APP)
+#else // _CRT_APP
     return _wchdir(_Dirname) == 0;
-#endif // defined(_CRT_APP)
+#endif // _CRT_APP
 }
 
 _FS_DLL wchar_t* __CLRCALL_PURE_OR_CDECL _Symlink_get(wchar_t (&_Dest)[_MAX_FILESYS_NAME], const wchar_t*) {
@@ -226,7 +226,7 @@ _FS_DLL unsigned long long __CLRCALL_PURE_OR_CDECL _Hard_links(const wchar_t* _F
     // get hard link count
     HANDLE _Handle = _FilesysOpenFile(_Fname, FILE_READ_ATTRIBUTES, FILE_FLAG_BACKUP_SEMANTICS);
 
-#if defined(_CRT_APP)
+#ifdef _CRT_APP
     FILE_STANDARD_INFO _Info = {0};
     bool _Ok                 = false;
 
@@ -235,7 +235,7 @@ _FS_DLL unsigned long long __CLRCALL_PURE_OR_CDECL _Hard_links(const wchar_t* _F
         CloseHandle(_Handle);
     }
     return _Ok ? _Info.NumberOfLinks : static_cast<unsigned long long>(-1);
-#else // defined(_CRT_APP)
+#else // _CRT_APP
     BY_HANDLE_FILE_INFORMATION _Info = {0};
     bool _Ok                         = false;
 
@@ -244,7 +244,7 @@ _FS_DLL unsigned long long __CLRCALL_PURE_OR_CDECL _Hard_links(const wchar_t* _F
         CloseHandle(_Handle);
     }
     return _Ok ? _Info.nNumberOfLinks : static_cast<unsigned long long>(-1);
-#endif // defined(_CRT_APP)
+#endif // _CRT_APP
 }
 
 
@@ -329,7 +329,7 @@ _FS_DLL space_info __CLRCALL_PURE_OR_CDECL _Statvfs(const wchar_t* _Fname) {
 
 _FS_DLL int __CLRCALL_PURE_OR_CDECL _Equivalent(
     const wchar_t* _Fname1, const wchar_t* _Fname2) { // test for equivalent file names
-#if defined(_CRT_APP)
+#ifdef _CRT_APP
     _FILE_ID_INFO _Info1 = {0};
     _FILE_ID_INFO _Info2 = {0};
     bool _Ok1            = false;
@@ -357,7 +357,7 @@ _FS_DLL int __CLRCALL_PURE_OR_CDECL _Equivalent(
                    ? 0
                    : 1;
     }
-#else // defined(_CRT_APP)
+#else // _CRT_APP
     BY_HANDLE_FILE_INFORMATION _Info1 = {0};
     BY_HANDLE_FILE_INFORMATION _Info2 = {0};
     bool _Ok1                         = false;
@@ -385,31 +385,31 @@ _FS_DLL int __CLRCALL_PURE_OR_CDECL _Equivalent(
                    ? 0
                    : 1;
     }
-#endif // defined(_CRT_APP)
+#endif // _CRT_APP
 }
 
 
 // FILE LINKAGE FUNCTIONS
 _FS_DLL int __CLRCALL_PURE_OR_CDECL _Link(const wchar_t* _Fname1, const wchar_t* _Fname2) {
     // link _Fname2 to _Fname1
-#if defined(_CRT_APP)
+#ifdef _CRT_APP
     (void) _Fname1;
     (void) _Fname2;
     return errno = EDOM; // hardlinks not supported
-#else // defined(_CRT_APP)
+#else // _CRT_APP
     return CreateHardLinkW(_Fname2, _Fname1, 0) != 0 ? 0 : GetLastError();
-#endif // defined(_CRT_APP)
+#endif // _CRT_APP
 }
 
 _FS_DLL int __CLRCALL_PURE_OR_CDECL _Symlink(const wchar_t* _Fname1, const wchar_t* _Fname2) {
     // link _Fname2 to _Fname1
-#if defined(_CRT_APP)
+#ifdef _CRT_APP
     (void) _Fname1;
     (void) _Fname2;
     return errno = EDOM; // symlinks not supported
-#else // defined(_CRT_APP)
+#else // _CRT_APP
     return __crtCreateSymbolicLinkW(_Fname2, _Fname1, 0) != 0 ? 0 : GetLastError();
-#endif // defined(_CRT_APP)
+#endif // _CRT_APP
 }
 
 _FS_DLL int __CLRCALL_PURE_OR_CDECL _Rename(const wchar_t* _Fname1, const wchar_t* _Fname2) {

--- a/stl/src/ppltasks.cpp
+++ b/stl/src/ppltasks.cpp
@@ -131,11 +131,11 @@ namespace Concurrency {
         const GUID PPLTaskCausalityPlatformID = {
             0x7A76B220, 0xA758, 0x4E6E, 0xB0, 0xE0, 0xD7, 0xC6, 0xD7, 0x4A, 0x88, 0xFE};
 
-        _CRTIMP2 void __thiscall _TaskEventLogger::_LogScheduleTask(bool _isContinuation) {
+        _CRTIMP2 void __thiscall _TaskEventLogger::_LogScheduleTask(bool _IsContinuation) {
             if (asyncCausalityTracer.isCausalitySupported()) {
                 asyncCausalityTracer.get()->TraceOperationCreation(CausalityTraceLevel_Required,
                     CausalitySource_Library, PPLTaskCausalityPlatformID, reinterpret_cast<unsigned long long>(_M_task),
-                    HStringReference(_isContinuation ? L"Concurrency::PPLTask::ScheduleContinuationTask"
+                    HStringReference(_IsContinuation ? L"Concurrency::PPLTask::ScheduleContinuationTask"
                                                      : L"Concurrency::PPLTask::ScheduleTask")
                         .Get(),
                     0);

--- a/stl/src/xstrcoll.cpp
+++ b/stl/src/xstrcoll.cpp
@@ -54,11 +54,12 @@ _CRTIMP2_PURE int __CLRCALL_PURE_OR_CDECL _Strcoll(
     }
 
     if (locale_name == nullptr) {
-        int ans;
-        ans = memcmp(string1, string2, n1 < n2 ? n1 : n2);
-        ret = (ans != 0 || n1 == n2 ? ans : n1 < n2 ? -1 : +1);
+        int ans = memcmp(string1, string2, n1 < n2 ? n1 : n2);
+        ret     = (ans != 0 || n1 == n2 ? ans : n1 < n2 ? -1 : +1);
     } else {
-        if (0 == (ret = __crtCompareStringA(locale_name, SORT_STRINGSORT, string1, n1, string2, n2, codepage))) {
+        ret = __crtCompareStringA(locale_name, SORT_STRINGSORT, string1, n1, string2, n2, codepage);
+
+        if (ret == 0) {
             errno = EINVAL;
             ret   = _NLSCMPERROR;
         } else {

--- a/stl/src/xstrcoll.cpp
+++ b/stl/src/xstrcoll.cpp
@@ -23,10 +23,10 @@ _EXTERN_C_UNLESS_PURE
 //     In the C locale, strcoll() simply resolves to strcmp().
 //
 // Entry:
-//     const char* _string1 = pointer to beginning of the first string
-//     const char* _end1    = pointer past end of the first string
-//     const char* _string2 = pointer to beginning of the second string
-//     const char* _end2    = pointer past end of the second string
+//     const char* string1  = pointer to beginning of the first string
+//     const char* end1     = pointer past end of the first string
+//     const char* string2  = pointer to beginning of the second string
+//     const char* end2     = pointer past end of the second string
 //     const _Collvec* ploc = pointer to locale info
 //
 // Exit:
@@ -38,11 +38,11 @@ _EXTERN_C_UNLESS_PURE
 //     _NLSCMPERROR = error
 //     errno = EINVAL
 _CRTIMP2_PURE int __CLRCALL_PURE_OR_CDECL _Strcoll(
-    const char* _string1, const char* _end1, const char* _string2, const char* _end2, const _Collvec* ploc) {
+    const char* string1, const char* end1, const char* string2, const char* end2, const _Collvec* ploc) {
     int ret = 0;
     UINT codepage;
-    int n1 = (int) (_end1 - _string1);
-    int n2 = (int) (_end2 - _string2);
+    int n1 = (int) (end1 - string1);
+    int n2 = (int) (end2 - string2);
     const wchar_t* locale_name;
 
     if (ploc == nullptr) {
@@ -55,10 +55,10 @@ _CRTIMP2_PURE int __CLRCALL_PURE_OR_CDECL _Strcoll(
 
     if (locale_name == nullptr) {
         int ans;
-        ans = memcmp(_string1, _string2, n1 < n2 ? n1 : n2);
+        ans = memcmp(string1, string2, n1 < n2 ? n1 : n2);
         ret = (ans != 0 || n1 == n2 ? ans : n1 < n2 ? -1 : +1);
     } else {
-        if (0 == (ret = __crtCompareStringA(locale_name, SORT_STRINGSORT, _string1, n1, _string2, n2, codepage))) {
+        if (0 == (ret = __crtCompareStringA(locale_name, SORT_STRINGSORT, string1, n1, string2, n2, codepage))) {
             errno = EINVAL;
             ret   = _NLSCMPERROR;
         } else {

--- a/stl/src/xstrcoll.cpp
+++ b/stl/src/xstrcoll.cpp
@@ -45,7 +45,7 @@ _CRTIMP2_PURE int __CLRCALL_PURE_OR_CDECL _Strcoll(
     int n2 = (int) (_end2 - _string2);
     const wchar_t* locale_name;
 
-    if (ploc == 0) {
+    if (ploc == nullptr) {
         locale_name = ___lc_locale_name_func()[LC_COLLATE];
         codepage    = ___lc_collate_cp_func();
     } else {

--- a/stl/src/xstrcoll.cpp
+++ b/stl/src/xstrcoll.cpp
@@ -41,8 +41,8 @@ _CRTIMP2_PURE int __CLRCALL_PURE_OR_CDECL _Strcoll(
     const char* string1, const char* end1, const char* string2, const char* end2, const _Collvec* ploc) {
     int ret = 0;
     UINT codepage;
-    int n1 = (int) (end1 - string1);
-    int n2 = (int) (end2 - string2);
+    int n1 = static_cast<int>(end1 - string1);
+    int n2 = static_cast<int>(end2 - string2);
     const wchar_t* locale_name;
 
     if (ploc == nullptr) {

--- a/stl/src/xstrxfrm.cpp
+++ b/stl/src/xstrxfrm.cpp
@@ -59,7 +59,7 @@ _CRTIMP2_PURE size_t __CLRCALL_PURE_OR_CDECL _Strxfrm(
     UINT codepage;
     const wchar_t* locale_name;
 
-    if (ploc == 0) {
+    if (ploc == nullptr) {
         locale_name = ___lc_locale_name_func()[LC_COLLATE];
         codepage    = ___lc_collate_cp_func();
     } else {

--- a/stl/src/xstrxfrm.cpp
+++ b/stl/src/xstrxfrm.cpp
@@ -53,10 +53,9 @@ _EXTERN_C_UNLESS_PURE
 //     Non-standard: if OM/API error, return INT_MAX.
 _CRTIMP2_PURE size_t __CLRCALL_PURE_OR_CDECL _Strxfrm(
     char* _string1, char* _end1, const char* _string2, const char* _end2, const _Collvec* ploc) {
-    size_t _n1 = _end1 - _string1;
-    size_t _n2 = _end2 - _string2;
-    int dstlen;
-    size_t retval = (size_t) -1; // NON-ANSI: default if OM or API error
+    size_t _n1    = _end1 - _string1;
+    size_t _n2    = _end2 - _string2;
+    size_t retval = static_cast<size_t>(-1); // NON-ANSI: default if OM or API error
     UINT codepage;
     const wchar_t* locale_name;
 
@@ -68,22 +67,24 @@ _CRTIMP2_PURE size_t __CLRCALL_PURE_OR_CDECL _Strxfrm(
         codepage    = ploc->_Page;
     }
 
-    if ((locale_name == nullptr) && (codepage == CP_ACP)) {
+    if (locale_name == nullptr && codepage == CP_ACP) {
         if (_n2 <= _n1) {
             memcpy(_string1, _string2, _n2);
         }
         retval = _n2;
     } else {
         // Inquire size of dst string in BYTES
-        if (0
-            != (dstlen =
-                    __crtLCMapStringA(locale_name, LCMAP_SORTKEY, _string2, (int) _n2, nullptr, 0, codepage, TRUE))) {
+        const int dstlen =
+            __crtLCMapStringA(locale_name, LCMAP_SORTKEY, _string2, static_cast<int>(_n2), nullptr, 0, codepage, TRUE);
+
+        if (dstlen != 0) {
             retval = dstlen;
 
             // if not enough room, return amount needed
-            if (dstlen <= (int) (_n1)) {
+            if (dstlen <= static_cast<int>(_n1)) {
                 // Map src string to dst string
-                __crtLCMapStringA(locale_name, LCMAP_SORTKEY, _string2, (int) _n2, _string1, (int) _n1, codepage, TRUE);
+                __crtLCMapStringA(locale_name, LCMAP_SORTKEY, _string2, static_cast<int>(_n2), _string1,
+                    static_cast<int>(_n1), codepage, TRUE);
             }
         }
     }

--- a/stl/src/xstrxfrm.cpp
+++ b/stl/src/xstrxfrm.cpp
@@ -18,9 +18,9 @@ _EXTERN_C_UNLESS_PURE
 // size_t _Strxfrm() - Transform a string using locale information
 //
 // Purpose:
-//     Transform the string pointed to by _string2 and place the
-//     resulting string into the array pointed to by _string1.
-//     No more than _end1 - _string1 characters are placed into the
+//     Transform the string pointed to by string2 and place the
+//     resulting string into the array pointed to by string1.
+//     No more than end1 - string1 characters are placed into the
 //     resulting string (including the null).
 //
 //     The transformation is such that if strcmp() is applied to
@@ -38,23 +38,23 @@ _EXTERN_C_UNLESS_PURE
 //     In the "C" locale, _Strxfrm() simply resolves to strncpy()/strlen().
 //
 // Entry:
-//     char* _string1       = pointer to beginning of result string
-//     char* _end1          = pointer past end of result string
-//     const char* _string2 = pointer to beginning of source string
-//     const char* _end2    = pointer past end of source string
+//     char* string1        = pointer to beginning of result string
+//     char* end1           = pointer past end of result string
+//     const char* string2  = pointer to beginning of source string
+//     const char* end2     = pointer past end of source string
 //     const _Collvec* ploc = pointer to locale info
 //
 // Exit:
 //     Length of the transformed string.
 //     If the value returned is too big, the contents of the
-//     _string1 array are indeterminate.
+//     string1 array are indeterminate.
 //
 // Exceptions:
 //     Non-standard: if OM/API error, return INT_MAX.
 _CRTIMP2_PURE size_t __CLRCALL_PURE_OR_CDECL _Strxfrm(
-    char* _string1, char* _end1, const char* _string2, const char* _end2, const _Collvec* ploc) {
-    size_t _n1    = _end1 - _string1;
-    size_t _n2    = _end2 - _string2;
+    char* string1, char* end1, const char* string2, const char* end2, const _Collvec* ploc) {
+    size_t n1     = end1 - string1;
+    size_t n2     = end2 - string2;
     size_t retval = static_cast<size_t>(-1); // NON-ANSI: default if OM or API error
     UINT codepage;
     const wchar_t* locale_name;
@@ -68,23 +68,23 @@ _CRTIMP2_PURE size_t __CLRCALL_PURE_OR_CDECL _Strxfrm(
     }
 
     if (locale_name == nullptr && codepage == CP_ACP) {
-        if (_n2 <= _n1) {
-            memcpy(_string1, _string2, _n2);
+        if (n2 <= n1) {
+            memcpy(string1, string2, n2);
         }
-        retval = _n2;
+        retval = n2;
     } else {
         // Inquire size of dst string in BYTES
         const int dstlen =
-            __crtLCMapStringA(locale_name, LCMAP_SORTKEY, _string2, static_cast<int>(_n2), nullptr, 0, codepage, TRUE);
+            __crtLCMapStringA(locale_name, LCMAP_SORTKEY, string2, static_cast<int>(n2), nullptr, 0, codepage, TRUE);
 
         if (dstlen != 0) {
             retval = dstlen;
 
             // if not enough room, return amount needed
-            if (dstlen <= static_cast<int>(_n1)) {
+            if (dstlen <= static_cast<int>(n1)) {
                 // Map src string to dst string
-                __crtLCMapStringA(locale_name, LCMAP_SORTKEY, _string2, static_cast<int>(_n2), _string1,
-                    static_cast<int>(_n1), codepage, TRUE);
+                __crtLCMapStringA(locale_name, LCMAP_SORTKEY, string2, static_cast<int>(n2), string1,
+                    static_cast<int>(n1), codepage, TRUE);
             }
         }
     }

--- a/stl/src/xwcscoll.cpp
+++ b/stl/src/xwcscoll.cpp
@@ -41,7 +41,7 @@ _CRTIMP2_PURE int __CLRCALL_PURE_OR_CDECL _Wcscoll(const wchar_t* _string1, cons
     int ret = 0;
     const wchar_t* locale_name;
 
-    if (ploc == 0) {
+    if (ploc == nullptr) {
         locale_name = ___lc_locale_name_func()[LC_COLLATE];
     } else {
         locale_name = ploc->_LocaleName;

--- a/stl/src/xwcscoll.cpp
+++ b/stl/src/xwcscoll.cpp
@@ -19,10 +19,10 @@ _EXTERN_C_UNLESS_PURE
 //     In the C locale, wcscmp() is used to make the comparison.
 //
 // Entry:
-//     const wchar_t* _string1 = pointer to beginning of the first string
-//     const wchar_t* _end1    = pointer past end of the first string
-//     const wchar_t* _string2 = pointer to beginning of the second string
-//     const wchar_t* _end2    = pointer past end of the second string
+//     const wchar_t* string1  = pointer to beginning of the first string
+//     const wchar_t* end1     = pointer past end of the first string
+//     const wchar_t* string2  = pointer to beginning of the second string
+//     const wchar_t* end2     = pointer past end of the second string
 //     const _Collvec* ploc    = pointer to locale info
 //
 // Exit:
@@ -34,10 +34,10 @@ _EXTERN_C_UNLESS_PURE
 // Exceptions:
 //     _NLSCMPERROR = error
 //     errno = EINVAL
-_CRTIMP2_PURE int __CLRCALL_PURE_OR_CDECL _Wcscoll(const wchar_t* _string1, const wchar_t* _end1,
-    const wchar_t* _string2, const wchar_t* _end2, const _Collvec* ploc) {
-    int n1  = (int) (_end1 - _string1);
-    int n2  = (int) (_end2 - _string2);
+_CRTIMP2_PURE int __CLRCALL_PURE_OR_CDECL _Wcscoll(
+    const wchar_t* string1, const wchar_t* end1, const wchar_t* string2, const wchar_t* end2, const _Collvec* ploc) {
+    int n1  = (int) (end1 - string1);
+    int n2  = (int) (end2 - string2);
     int ret = 0;
     const wchar_t* locale_name;
 
@@ -48,10 +48,10 @@ _CRTIMP2_PURE int __CLRCALL_PURE_OR_CDECL _Wcscoll(const wchar_t* _string1, cons
     }
 
     if (locale_name == nullptr) {
-        int ans = wmemcmp(_string1, _string2, n1 < n2 ? n1 : n2);
+        int ans = wmemcmp(string1, string2, n1 < n2 ? n1 : n2);
         ret     = (ans != 0 || n1 == n2 ? ans : n1 < n2 ? -1 : +1);
     } else {
-        if (0 == (ret = __crtCompareStringW(locale_name, SORT_STRINGSORT, _string1, n1, _string2, n2))) {
+        if (0 == (ret = __crtCompareStringW(locale_name, SORT_STRINGSORT, string1, n1, string2, n2))) {
             errno = EINVAL;
             ret   = _NLSCMPERROR;
         } else {
@@ -63,10 +63,10 @@ _CRTIMP2_PURE int __CLRCALL_PURE_OR_CDECL _Wcscoll(const wchar_t* _string1, cons
 }
 
 #ifdef MRTDLL
-_CRTIMP2_PURE int __CLRCALL_PURE_OR_CDECL _Wcscoll(const unsigned short* _string1, const unsigned short* _end1,
-    const unsigned short* _string2, const unsigned short* _end2, const _Collvec* ploc) {
+_CRTIMP2_PURE int __CLRCALL_PURE_OR_CDECL _Wcscoll(const unsigned short* string1, const unsigned short* end1,
+    const unsigned short* string2, const unsigned short* end2, const _Collvec* ploc) {
     return _Wcscoll(
-        (const wchar_t*) _string1, (const wchar_t*) _end1, (const wchar_t*) _string2, (const wchar_t*) _end2, ploc);
+        (const wchar_t*) string1, (const wchar_t*) end1, (const wchar_t*) string2, (const wchar_t*) end2, ploc);
 }
 #endif // MRTDLL
 

--- a/stl/src/xwcscoll.cpp
+++ b/stl/src/xwcscoll.cpp
@@ -36,8 +36,8 @@ _EXTERN_C_UNLESS_PURE
 //     errno = EINVAL
 _CRTIMP2_PURE int __CLRCALL_PURE_OR_CDECL _Wcscoll(
     const wchar_t* string1, const wchar_t* end1, const wchar_t* string2, const wchar_t* end2, const _Collvec* ploc) {
-    int n1  = (int) (end1 - string1);
-    int n2  = (int) (end2 - string2);
+    int n1  = static_cast<int>(end1 - string1);
+    int n2  = static_cast<int>(end2 - string2);
     int ret = 0;
     const wchar_t* locale_name;
 
@@ -67,8 +67,8 @@ _CRTIMP2_PURE int __CLRCALL_PURE_OR_CDECL _Wcscoll(
 #ifdef MRTDLL
 _CRTIMP2_PURE int __CLRCALL_PURE_OR_CDECL _Wcscoll(const unsigned short* string1, const unsigned short* end1,
     const unsigned short* string2, const unsigned short* end2, const _Collvec* ploc) {
-    return _Wcscoll(
-        (const wchar_t*) string1, (const wchar_t*) end1, (const wchar_t*) string2, (const wchar_t*) end2, ploc);
+    return _Wcscoll(reinterpret_cast<const wchar_t*>(string1), reinterpret_cast<const wchar_t*>(end1),
+        reinterpret_cast<const wchar_t*>(string2), reinterpret_cast<const wchar_t*>(end2), ploc);
 }
 #endif // MRTDLL
 

--- a/stl/src/xwcscoll.cpp
+++ b/stl/src/xwcscoll.cpp
@@ -51,7 +51,9 @@ _CRTIMP2_PURE int __CLRCALL_PURE_OR_CDECL _Wcscoll(
         int ans = wmemcmp(string1, string2, n1 < n2 ? n1 : n2);
         ret     = (ans != 0 || n1 == n2 ? ans : n1 < n2 ? -1 : +1);
     } else {
-        if (0 == (ret = __crtCompareStringW(locale_name, SORT_STRINGSORT, string1, n1, string2, n2))) {
+        ret = __crtCompareStringW(locale_name, SORT_STRINGSORT, string1, n1, string2, n2);
+
+        if (ret == 0) {
             errno = EINVAL;
             ret   = _NLSCMPERROR;
         } else {

--- a/stl/src/xwcsxfrm.cpp
+++ b/stl/src/xwcsxfrm.cpp
@@ -16,9 +16,9 @@ _EXTERN_C_UNLESS_PURE
 // size_t _Wcsxfrm() - Transform a string using locale information
 //
 // Purpose:
-//     Transform the wide string pointed to by _string2 and place the
-//     resulting wide string into the array pointed to by _string1.
-//     No more than _end1 - _string1 wide characters are placed into the
+//     Transform the wide string pointed to by string2 and place the
+//     resulting wide string into the array pointed to by string1.
+//     No more than end1 - string1 wide characters are placed into the
 //     resulting string (including the null).
 //
 //     The transformation is such that if wcscmp() is applied to
@@ -30,23 +30,23 @@ _EXTERN_C_UNLESS_PURE
 //     In the C locale, wcsxfrm() simply resolves to wcsncpy()/wcslen().
 //
 // Entry:
-//     wchar_t* _string1       = pointer to beginning of result string
-//     wchar_t* _end1          = pointer past end of result string
-//     const wchar_t* _string2 = pointer to beginning of source string
-//     const wchar_t* _end2    = pointer past end of source string
+//     wchar_t* string1        = pointer to beginning of result string
+//     wchar_t* end1           = pointer past end of result string
+//     const wchar_t* string2  = pointer to beginning of source string
+//     const wchar_t* end2     = pointer past end of source string
 //     const _Collvec* ploc    = pointer to locale info
 //
 // Exit:
 //     Length of the transformed string.
 //     If the value returned is too big, the contents of the
-//     _string1 array are indeterminate.
+//     string1 array are indeterminate.
 //
 // Exceptions:
 //     Non-standard: if OM/API error, return INT_MAX.
 _CRTIMP2_PURE size_t __CLRCALL_PURE_OR_CDECL _Wcsxfrm(
-    wchar_t* _string1, wchar_t* _end1, const wchar_t* _string2, const wchar_t* _end2, const _Collvec* ploc) {
-    size_t _n1             = _end1 - _string1;
-    size_t _n2             = _end2 - _string2;
+    wchar_t* string1, wchar_t* end1, const wchar_t* string2, const wchar_t* end2, const _Collvec* ploc) {
+    size_t n1              = end1 - string1;
+    size_t n2              = end2 - string2;
     size_t size            = (size_t) -1;
     unsigned char* bbuffer = nullptr;
     const wchar_t* locale_name;
@@ -58,25 +58,25 @@ _CRTIMP2_PURE size_t __CLRCALL_PURE_OR_CDECL _Wcsxfrm(
     }
 
     if (locale_name == nullptr) {
-        if (_n2 <= _n1) {
-            memcpy(_string1, _string2, _n2 * sizeof(wchar_t));
+        if (n2 <= n1) {
+            memcpy(string1, string2, n2 * sizeof(wchar_t));
         }
-        size = _n2;
+        size = n2;
     } else {
 
         // When using LCMAP_SORTKEY, LCMapStringW handles BYTES not wide
         // chars. We use a byte buffer to hold bytes and then convert the
         // byte string to a wide char string and return this so it can be
-        // compared using wcscmp(). User's buffer is _n1 wide chars, so
-        // use an internal buffer of _n1 bytes.
+        // compared using wcscmp(). User's buffer is n1 wide chars, so
+        // use an internal buffer of n1 bytes.
 
-        if (nullptr != (bbuffer = (unsigned char*) _malloc_crt(_n1))) {
+        if (nullptr != (bbuffer = (unsigned char*) _malloc_crt(n1))) {
             if (0
                 == (size = __crtLCMapStringW(
-                        locale_name, LCMAP_SORTKEY, _string2, (int) _n2, (wchar_t*) bbuffer, (int) _n1))) {
+                        locale_name, LCMAP_SORTKEY, string2, (int) n2, (wchar_t*) bbuffer, (int) n1))) {
                 // buffer not big enough, get size required.
 
-                if (0 == (size = __crtLCMapStringW(locale_name, LCMAP_SORTKEY, _string2, (int) _n2, nullptr, 0))) {
+                if (0 == (size = __crtLCMapStringW(locale_name, LCMAP_SORTKEY, string2, (int) n2, nullptr, 0))) {
                     size = INT_MAX; // default error
                 }
             } else {
@@ -84,7 +84,7 @@ _CRTIMP2_PURE size_t __CLRCALL_PURE_OR_CDECL _Wcsxfrm(
                 // string successfully mapped, convert to wide char
 
                 for (i = 0; i < size; i++) {
-                    _string1[i] = (wchar_t) bbuffer[i];
+                    string1[i] = (wchar_t) bbuffer[i];
                 }
             }
         }
@@ -98,9 +98,9 @@ _CRTIMP2_PURE size_t __CLRCALL_PURE_OR_CDECL _Wcsxfrm(
 }
 
 #ifdef MRTDLL
-_CRTIMP2_PURE size_t __CLRCALL_PURE_OR_CDECL _Wcsxfrm(unsigned short* _string1, unsigned short* _end1,
-    const unsigned short* _string2, const unsigned short* _end2, const _Collvec* ploc) {
-    return _Wcsxfrm((wchar_t*) _string1, (wchar_t*) _end1, (const wchar_t*) _string2, (const wchar_t*) _end2, ploc);
+_CRTIMP2_PURE size_t __CLRCALL_PURE_OR_CDECL _Wcsxfrm(unsigned short* string1, unsigned short* end1,
+    const unsigned short* string2, const unsigned short* end2, const _Collvec* ploc) {
+    return _Wcsxfrm((wchar_t*) string1, (wchar_t*) end1, (const wchar_t*) string2, (const wchar_t*) end2, ploc);
 }
 #endif // MRTDLL
 

--- a/stl/src/xwcsxfrm.cpp
+++ b/stl/src/xwcsxfrm.cpp
@@ -51,7 +51,7 @@ _CRTIMP2_PURE size_t __CLRCALL_PURE_OR_CDECL _Wcsxfrm(
     unsigned char* bbuffer = nullptr;
     const wchar_t* locale_name;
 
-    if (ploc == 0) {
+    if (ploc == nullptr) {
         locale_name = ___lc_locale_name_func()[LC_COLLATE];
     } else {
         locale_name = ploc->_LocaleName;

--- a/stl/src/xwcsxfrm.cpp
+++ b/stl/src/xwcsxfrm.cpp
@@ -47,7 +47,7 @@ _CRTIMP2_PURE size_t __CLRCALL_PURE_OR_CDECL _Wcsxfrm(
     wchar_t* string1, wchar_t* end1, const wchar_t* string2, const wchar_t* end2, const _Collvec* ploc) {
     size_t n1              = end1 - string1;
     size_t n2              = end2 - string2;
-    size_t size            = (size_t) -1;
+    size_t size            = static_cast<size_t>(-1);
     unsigned char* bbuffer = nullptr;
     const wchar_t* locale_name;
 
@@ -70,14 +70,15 @@ _CRTIMP2_PURE size_t __CLRCALL_PURE_OR_CDECL _Wcsxfrm(
         // compared using wcscmp(). User's buffer is n1 wide chars, so
         // use an internal buffer of n1 bytes.
 
-        bbuffer = (unsigned char*) _malloc_crt(n1);
+        bbuffer = static_cast<unsigned char*>(_malloc_crt(n1));
 
         if (bbuffer != nullptr) {
-            size = __crtLCMapStringW(locale_name, LCMAP_SORTKEY, string2, (int) n2, (wchar_t*) bbuffer, (int) n1);
+            size = __crtLCMapStringW(locale_name, LCMAP_SORTKEY, string2, static_cast<int>(n2),
+                reinterpret_cast<wchar_t*>(bbuffer), static_cast<int>(n1));
 
             if (size == 0) {
                 // buffer not big enough, get size required.
-                size = __crtLCMapStringW(locale_name, LCMAP_SORTKEY, string2, (int) n2, nullptr, 0);
+                size = __crtLCMapStringW(locale_name, LCMAP_SORTKEY, string2, static_cast<int>(n2), nullptr, 0);
 
                 if (size == 0) {
                     size = INT_MAX; // default error
@@ -86,7 +87,7 @@ _CRTIMP2_PURE size_t __CLRCALL_PURE_OR_CDECL _Wcsxfrm(
                 // string successfully mapped, convert to wide char
 
                 for (size_t i = 0; i < size; ++i) {
-                    string1[i] = (wchar_t) bbuffer[i];
+                    string1[i] = static_cast<wchar_t>(bbuffer[i]);
                 }
             }
         }
@@ -102,7 +103,8 @@ _CRTIMP2_PURE size_t __CLRCALL_PURE_OR_CDECL _Wcsxfrm(
 #ifdef MRTDLL
 _CRTIMP2_PURE size_t __CLRCALL_PURE_OR_CDECL _Wcsxfrm(unsigned short* string1, unsigned short* end1,
     const unsigned short* string2, const unsigned short* end2, const _Collvec* ploc) {
-    return _Wcsxfrm((wchar_t*) string1, (wchar_t*) end1, (const wchar_t*) string2, (const wchar_t*) end2, ploc);
+    return _Wcsxfrm(reinterpret_cast<wchar_t*>(string1), reinterpret_cast<wchar_t*>(end1),
+        reinterpret_cast<const wchar_t*>(string2), reinterpret_cast<const wchar_t*>(end2), ploc);
 }
 #endif // MRTDLL
 

--- a/stl/src/xwcsxfrm.cpp
+++ b/stl/src/xwcsxfrm.cpp
@@ -70,20 +70,22 @@ _CRTIMP2_PURE size_t __CLRCALL_PURE_OR_CDECL _Wcsxfrm(
         // compared using wcscmp(). User's buffer is n1 wide chars, so
         // use an internal buffer of n1 bytes.
 
-        if (nullptr != (bbuffer = (unsigned char*) _malloc_crt(n1))) {
-            if (0
-                == (size = __crtLCMapStringW(
-                        locale_name, LCMAP_SORTKEY, string2, (int) n2, (wchar_t*) bbuffer, (int) n1))) {
-                // buffer not big enough, get size required.
+        bbuffer = (unsigned char*) _malloc_crt(n1);
 
-                if (0 == (size = __crtLCMapStringW(locale_name, LCMAP_SORTKEY, string2, (int) n2, nullptr, 0))) {
+        if (bbuffer != nullptr) {
+            size = __crtLCMapStringW(locale_name, LCMAP_SORTKEY, string2, (int) n2, (wchar_t*) bbuffer, (int) n1);
+
+            if (size == 0) {
+                // buffer not big enough, get size required.
+                size = __crtLCMapStringW(locale_name, LCMAP_SORTKEY, string2, (int) n2, nullptr, 0);
+
+                if (size == 0) {
                     size = INT_MAX; // default error
                 }
             } else {
-                size_t i;
                 // string successfully mapped, convert to wide char
 
-                for (i = 0; i < size; i++) {
+                for (size_t i = 0; i < size; ++i) {
                     string1[i] = (wchar_t) bbuffer[i];
                 }
             }

--- a/stl/src/xwctomb.cpp
+++ b/stl/src/xwctomb.cpp
@@ -56,7 +56,7 @@ _CRTIMP2_PURE int __CLRCALL_PURE_OR_CDECL _Wcrtomb(char* s, wchar_t wchar, mbsta
         BOOL defused = 0;
         _Cvtvec cvtvec;
 
-        if (ploc == 0) {
+        if (ploc == nullptr) {
             cvtvec = _Getcvt();
             ploc   = &cvtvec;
         }

--- a/tests/std/tests/Dev11_0437519_container_behavior/test.cpp
+++ b/tests/std/tests/Dev11_0437519_container_behavior/test.cpp
@@ -22,7 +22,7 @@ void assert_forward_list_resize_empty() {
 // argument is a reference to an element in the list that will be removed.
 
 struct A {
-    A(unsigned value) : _value(value) {}
+    A(unsigned int value) : _value(value) {}
     ~A() {
         _value = 0;
     }
@@ -33,7 +33,7 @@ struct A {
     }
 
 private:
-    unsigned _value;
+    unsigned int _value;
 };
 
 void assert_list_remove_element_in_sequence() {

--- a/tests/tr1/tests/chrono/test.cpp
+++ b/tests/tr1/tests/chrono/test.cpp
@@ -37,7 +37,7 @@ namespace {
     void t_treat_as_floating_point() {
         CHECK_INT(STD chrono::treat_as_floating_point<char>::value, false);
         CHECK_INT(STD chrono::treat_as_floating_point<short>::value, false);
-        CHECK_INT(STD chrono::treat_as_floating_point<unsigned>::value, false);
+        CHECK_INT(STD chrono::treat_as_floating_point<unsigned int>::value, false);
         CHECK_INT(STD chrono::treat_as_floating_point<int>::value, false);
         CHECK_INT(STD chrono::treat_as_floating_point<long>::value, false);
         CHECK_INT(STD chrono::treat_as_floating_point<unsigned long>::value, false);

--- a/tests/tr1/tests/random1/test.cpp
+++ b/tests/tr1/tests/random1/test.cpp
@@ -18,7 +18,7 @@ typedef unsigned int Uint32;
 template <class T>
 class generator {
 public:
-    void reset(const T* ptr0, unsigned n0) { // establish new sequence
+    void reset(const T* ptr0, unsigned int n0) { // establish new sequence
         ptr = ptr0;
         n   = n0;
         i   = 0;
@@ -28,14 +28,14 @@ public:
         return ptr[i++];
     }
 
-    unsigned index() const { // return index into sequence
+    unsigned int index() const { // return index into sequence
         return i;
     }
 
 private:
     const T* ptr;
-    unsigned n;
-    unsigned i;
+    unsigned int n;
+    unsigned int i;
 };
 
 template <class Eng>

--- a/tools/validate/validate.cpp
+++ b/tools/validate/validate.cpp
@@ -157,6 +157,7 @@ int main() {
         L".vs"sv,
         L".vscode"sv,
         L"__pycache__"sv,
+        L"build"sv,
         L"llvm-project"sv,
         L"out"sv,
         L"vcpkg"sv,


### PR DESCRIPTION
* Change `build.x64` to `out\build\x64`, fixing #518.
  - This significantly improves usability as `.gitignore` lists `/out/`.
* Add `"build"` to `skipped_directories` in `validate.cpp`.
  - This essentially replicates the information in `.gitignore`, where `/build/` was added by #581.
* Consistently test `#if !_HAS_EXCEPTIONS`.
  - This still isn't a supported mode.
* `_RAISE` was never used for real exceptions.
* Change `unsigned` to `unsigned int`.
  - There were a few cases (outside of LLVM-derived tests) where we weren't following our usual convention. I'm cleaning them up, even within tr1.
  - Additionally, change a couple of C casts to `static_cast`s, slowly working towards #184.
* Use `{}` for `make_index_sequence` and `index_sequence_for`.
  - In new code, we prefer using `{}` to construct tags, because `()` resembles a function call. See #468.
* cthread.cpp: Simplify a lengthy conditional operator.
* Extract `__crtLCMapStringA` calls and use C++ casts.
  - xstrxfrm.cpp: `dstlen` can be `const`.
  - Remove unnecessary parentheses (equality has well-known higher precedence than logical AND).
* Change `ploc == 0` to `ploc == nullptr`.
* dllmain.cpp: `[[maybe_unused]]`, preprocessor comments.
* Use `#ifdef _CRT_APP` for simplicity.
* Avoid `_underscore_lowercase` parameter names.
* Extract more assignments before comparisons.
  - Also scope `size_t i` to a for-loop and use preincrement.
  - Immediately initialize `ans`.
* More C++ casts.
