### PR TITLE
__cpp_consteval indicates support for consteval

### DIFF
--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -613,7 +613,7 @@
 #define _CONSTEXPR_IF
 #endif // _HAS_IF_CONSTEXPR
 
-#if defined(__cpp_consteval) || defined(__clang__) // TRANSITION, LLVM-45745 and VSO-778944
+#ifdef __cpp_consteval
 #define _CONSTEVAL consteval
 #else // ^^^ supports consteval / no consteval vvv
 #define _CONSTEVAL constexpr

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -613,7 +613,7 @@
 #define _CONSTEXPR_IF
 #endif // _HAS_IF_CONSTEXPR
 
-#ifdef __clang__
+#if defined(__cpp_consteval) || defined(__clang__) // TRANSITION, LLVM-45745 and VSO-778944
 #define _CONSTEVAL consteval
 #else // ^^^ supports consteval / no consteval vvv
 #define _CONSTEVAL constexpr


### PR DESCRIPTION
Per Clang developers (https://bugs.llvm.org/show_bug.cgi?id=45745#c1), the `consteval` support in clang 10 / trunk is partial and we should not rely on it until they define the feature-test macro.