### PR TITLE
Make several improvements to the way the CI runs the tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ under a category in libcxx, or running a single test in `std` and `tr1`.
 
 C:\STL\build>ctest -V
 
-:: This command will also run all of the testsuites
+:: This command will also run all of the testsuites.
 
 C:\STL\build>python tests\utils\stl-lit\stl-lit.py ..\llvm-project\libcxx\test ..\tests\std ..\tests\tr1
 
@@ -271,7 +271,7 @@ C:\STL\build>python tests\utils\stl-lit\stl-lit.py ..\llvm-project\libcxx\test\s
 
 ### CTest
 
-When running the tests via CTest all of the testsuites are considered to be a single test. If any single test in a
+When running the tests via CTest, all of the testsuites are considered to be a single test. If any single test in a
 testsuite fails, CTest will simply report that the `stl` test failed.
 
 Example:

--- a/README.md
+++ b/README.md
@@ -248,11 +248,11 @@ under a category in libcxx, or running a single test in `std` and `tr1`.
 
 C:\STL\build>ctest -V
 
+:: This command will also run all of the testsuites
+
+C:\STL\build>python tests\utils\stl-lit\stl-lit.py ..\llvm-project\libcxx\test ..\tests\std ..\tests\tr1
+
 :: This command will run all of the std testsuite.
-
-C:\STL\build>ctest -R std
-
-:: This command will also run all of the std testsuite.
 
 C:\STL\build>python tests\utils\stl-lit\stl-lit.py ..\tests\std
 
@@ -271,18 +271,20 @@ C:\STL\build>python tests\utils\stl-lit\stl-lit.py ..\llvm-project\libcxx\test\s
 
 ### CTest
 
-When running the tests via CTest each of the testsuites is considered to be a single test. If any single test in a
-testsuite fails, CTest will report the test which represents that testsuite as failed.
+When running the tests via CTest all of the testsuites are considered to be a single test. If any single test in a
+testsuite fails, CTest will simply report that the `stl` test failed.
 
 Example:
 ```
-67% tests passed, 1 tests failed out of 3
+0% tests passed, 1 tests failed out of 1
 
 Total Test time (real) = 2441.55 sec
 
 The following tests FAILED:
-      1 - libcxx (Failed)
+      1 - stl (Failed)
 ```
+
+The primary utility of CTest in this case is to conveniently invoke `stl-lit.py` with the correct set of arguments.
 
 CTest will output everything that was sent to stderr for each of the failed testsuites, which can be used to identify
 which individual test within the testsuite failed. It can sometimes be helpful to run CTest with the `-V` option in

--- a/azure-devops/run-build.yml
+++ b/azure-devops/run-build.yml
@@ -26,7 +26,7 @@ jobs:
       clean: true
       submodules: true
     - task: Cache@2
-      displayName: Restore Cached vcpkg Installed Directory
+      displayName: vcpkg/installed Caching
       timeoutInMinutes: 10
       inputs:
         key: '"${{ parameters.targetPlatform }}" | $(Build.SourcesDirectory)/.git/modules/vcpkg/HEAD | "2020-03-01.01"'

--- a/azure-devops/run-build.yml
+++ b/azure-devops/run-build.yml
@@ -9,7 +9,7 @@ jobs:
 
   variables:
     buildOutputLocation: 'D:\build\${{ parameters.targetPlatform }}'
-    litFlags: '-j$(testParallelism);--timeout=240;--shuffle;--xunit-xml-output=$(buildOutputLocation)/${{ parameters.targetPlatform }}/test-results.xml'
+    litFlags: '-j$(testParallelism);--timeout=240;--shuffle;--xunit-xml-output=$(buildOutputLocation)/test-results.xml'
     vcpkgLocation: '$(Build.SourcesDirectory)/vcpkg'
   steps:
     - script: |
@@ -79,7 +79,7 @@ jobs:
       timeoutInMinutes: 120
       condition: in('${{ parameters.targetPlatform }}', 'x64', 'x86')
       inputs:
-        workingDirectory: $(buildOutputLocation)/${{ parameters.targetPlatform }}
+        workingDirectory: $(buildOutputLocation)
         script: |
           call "%PROGRAMFILES(X86)%\Microsoft Visual Studio\2019\Preview\Common7\Tools\VsDevCmd.bat" ^
           -host_arch=${{ parameters.vsDevCmdArch }} -arch=${{ parameters.vsDevCmdArch }} -no_logo
@@ -90,7 +90,7 @@ jobs:
       timeoutInMinutes: 10
       condition: in('${{ parameters.targetPlatform }}', 'x64', 'x86')
       inputs:
-        searchFolder: $(buildOutputLocation)/${{ parameters.targetPlatform }}
+        searchFolder: $(buildOutputLocation)
         testResultsFormat: JUnit
         testResultsFiles: '**/test-results.xml'
         testRunTitle: 'test-${{ parameters.targetPlatform }}'

--- a/azure-devops/run-build.yml
+++ b/azure-devops/run-build.yml
@@ -10,6 +10,7 @@ jobs:
   variables:
     vcpkgLocation: '$(Build.SourcesDirectory)/vcpkg'
     buildOutputLocation: 'D:/build'
+    litFlags: '-j$[testParallelism];--xunit-xml-output $[buildOutputLocation]/${{ parameters.targetPlatform }}/test-results.xml;--timeout 240;--shuffle'
   steps:
     - script: |
         if exist "$(tmpDir)" (
@@ -61,7 +62,7 @@ jobs:
         buildDirectory: $(buildOutputLocation)/${{ parameters.targetPlatform }}
         useVcpkgToolchainFile: true
         cmakeAppendedArgs: |
-          -G Ninja -DENABLE_XUNIT_OUTPUT=TRUE -DADDITIONAL_LIT_FLAGS=-j$(testParallelism)
+          -G Ninja -DADDITIONAL_LIT_FLAGS="$(litFlags)"
       env: { TMP: $(tmpDir), TEMP: $(tmpDir) }
     - task: CmdLine@2
       displayName: 'Run Tests'
@@ -75,29 +76,11 @@ jobs:
           ctest -V
       env: { TMP: $(tmpDir), TEMP: $(tmpDir) }
     - task: PublishTestResults@2
-      displayName: 'Publish libcxx Tests'
+      displayName: 'Publish Tests'
       timeoutInMinutes: 10
       condition: in('${{ parameters.targetPlatform }}', 'x64', 'x86')
       inputs:
         searchFolder: $(buildOutputLocation)/${{ parameters.targetPlatform }}
         testResultsFormat: JUnit
-        testResultsFiles: '**/libcxx.test.xml'
-        testRunTitle: 'libcxx-${{ parameters.targetPlatform }}'
-    - task: PublishTestResults@2
-      displayName: 'Publish std Tests'
-      timeoutInMinutes: 10
-      condition: in('${{ parameters.targetPlatform }}', 'x64', 'x86')
-      inputs:
-        searchFolder: $(buildOutputLocation)/${{ parameters.targetPlatform }}
-        testResultsFormat: JUnit
-        testResultsFiles: '**/std.test.xml'
-        testRunTitle: 'std-${{ parameters.targetPlatform }}'
-    - task: PublishTestResults@2
-      displayName: 'Publish tr1 Tests'
-      timeoutInMinutes: 10
-      condition: in('${{ parameters.targetPlatform }}', 'x64', 'x86')
-      inputs:
-        searchFolder: $(buildOutputLocation)/${{ parameters.targetPlatform }}
-        testResultsFormat: JUnit
-        testResultsFiles: '**/tr1.test.xml'
-        testRunTitle: 'tr1-${{ parameters.targetPlatform }}'
+        testResultsFiles: '**/test-results.xml'
+        testRunTitle: 'test-${{ parameters.targetPlatform }}'

--- a/azure-devops/run-build.yml
+++ b/azure-devops/run-build.yml
@@ -8,10 +8,14 @@ jobs:
     name: $(agentPool)
 
   variables:
+    buildOutputLocation: 'D:\build\${{ parameters.targetPlatform }}'
+    litFlags: '-j$(testParallelism);--timeout=240;--shuffle;--xunit-xml-output=$(buildOutputLocation)/${{ parameters.targetPlatform }}/test-results.xml'
     vcpkgLocation: '$(Build.SourcesDirectory)/vcpkg'
-    buildOutputLocation: 'D:/build'
-    litFlags: '-j$[testParallelism];--xunit-xml-output $[buildOutputLocation]/${{ parameters.targetPlatform }}/test-results.xml;--timeout 240;--shuffle'
   steps:
+    - script: |
+        python -m pip install --upgrade pip
+        pip install psutil
+      displayName: pip install psutil
     - script: |
         if exist "$(tmpDir)" (
           rmdir /S /Q $(tmpDir)
@@ -22,7 +26,7 @@ jobs:
       clean: true
       submodules: true
     - task: Cache@2
-      displayName: Cache vcpkg
+      displayName: Restore Cached vcpkg Installed Directory
       timeoutInMinutes: 10
       inputs:
         key: '"${{ parameters.targetPlatform }}" | $(Build.SourcesDirectory)/.git/modules/vcpkg/HEAD | "2020-03-01.01"'
@@ -33,14 +37,17 @@ jobs:
       condition: and(ne(variables.CACHE_RESTORED, 'true'), contains('${{ parameters.targetPlatform }}', 'arm'))
       timeoutInMinutes: 10
       inputs:
+        doNotUpdateVcpkg: true
         vcpkgArguments: 'boost-build'
         vcpkgDirectory: '$(vcpkgLocation)'
         vcpkgTriplet: 'x86-windows'
       env: { TMP: $(tmpDir), TEMP: $(tmpDir) }
     - task: run-vcpkg@0
-      displayName: 'Run vcpkg'
+      displayName: 'Run vcpkg to Install boost-math'
+      condition: ne(variables.CACHE_RESTORED, 'true')
       timeoutInMinutes: 10
       inputs:
+        doNotUpdateVcpkg: true
         vcpkgArguments: 'boost-math'
         vcpkgDirectory: '$(vcpkgLocation)'
         vcpkgTriplet: '${{ parameters.targetPlatform }}-windows'
@@ -53,16 +60,19 @@ jobs:
         script: |
           $testParallelism = $env:NUMBER_OF_PROCESSORS - 2
           Write-Output "##vso[task.setvariable variable=testParallelism;]$testParallelism"
-    - task: run-cmake@0
+    - script: |
+        if exist "$(buildOutputLocation)" (
+          rmdir /S /Q "$(buildOutputLocation)"
+        )
+        call "%PROGRAMFILES(X86)%\Microsoft Visual Studio\2019\Preview\Common7\Tools\VsDevCmd.bat" ^
+        -host_arch=amd64 -arch=${{ parameters.vsDevCmdArch }} -no_logo
+        cmake -G Ninja -DCMAKE_TOOLCHAIN_FILE=$(vcpkgLocation)\scripts\buildsystems\vcpkg.cmake ^
+        -DVCPKG_TARGET_TRIPLET=${{ parameters.targetPlatform }}-windows -DCMAKE_CXX_COMPILER=cl ^
+        -DCMAKE_BUILD_TYPE=Release -DADDITIONAL_LIT_FLAGS=$(litFlags) ^
+        -S $(Build.SourcesDirectory) -B $(buildOutputLocation)
+        cmake --build $(buildOutputLocation)
       displayName: 'Build the STL'
       timeoutInMinutes: 10
-      inputs:
-        cmakeListsOrSettingsJson: 'CMakeListsTxtAdvanced'
-        cmakeListsTxtPath: '$(Build.SourcesDirectory)/CMakeLists.txt'
-        buildDirectory: $(buildOutputLocation)/${{ parameters.targetPlatform }}
-        useVcpkgToolchainFile: true
-        cmakeAppendedArgs: |
-          -G Ninja -DADDITIONAL_LIT_FLAGS="$(litFlags)"
       env: { TMP: $(tmpDir), TEMP: $(tmpDir) }
     - task: CmdLine@2
       displayName: 'Run Tests'

--- a/azure-devops/run-build.yml
+++ b/azure-devops/run-build.yml
@@ -68,7 +68,7 @@ jobs:
         -host_arch=amd64 -arch=${{ parameters.vsDevCmdArch }} -no_logo
         cmake -G Ninja -DCMAKE_TOOLCHAIN_FILE=$(vcpkgLocation)\scripts\buildsystems\vcpkg.cmake ^
         -DVCPKG_TARGET_TRIPLET=${{ parameters.targetPlatform }}-windows -DCMAKE_CXX_COMPILER=cl ^
-        -DCMAKE_BUILD_TYPE=Release -DADDITIONAL_LIT_FLAGS=$(litFlags) ^
+        -DCMAKE_BUILD_TYPE=Release -DLIT_FLAGS=$(litFlags) ^
         -S $(Build.SourcesDirectory) -B $(buildOutputLocation)
         cmake --build $(buildOutputLocation)
       displayName: 'Build the STL'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,6 +17,8 @@ stages:
         pool:
           name: $(agentPool)
 
+        variables:
+          buildOutputLocation: 'D:\tools'
         steps:
           - script: |
               if exist "$(tmpDir)" (
@@ -28,14 +30,14 @@ stages:
             clean: true
             submodules: false
           - script: |
-              if exist "D:\tools" (
-                rmdir /S /Q "D:\tools"
+              if exist "$(buildOutputLocation)" (
+                rmdir /S /Q "$(buildOutputLocation)"
               )
               call "%PROGRAMFILES(X86)%\Microsoft Visual Studio\2019\Preview\Common7\Tools\VsDevCmd.bat" ^
               -host_arch=amd64 -arch=amd64 -no_logo
               cmake -G Ninja -DCMAKE_CXX_COMPILER=cl -DCMAKE_BUILD_TYPE=Release ^
-              -S $(Build.SourcesDirectory)\tools -B D:\tools
-              cmake --build D:\tools
+              -S $(Build.SourcesDirectory)\tools -B $(buildOutputLocation)
+              cmake --build $(buildOutputLocation)
             displayName: 'Build Support Tools'
             env: { TMP: $(tmpDir), TEMP: $(tmpDir) }
           - task: BatchScript@1
@@ -44,7 +46,7 @@ stages:
             inputs:
               filename: 'azure-devops/enforce-clang-format.cmd'
               failOnStandardError: true
-              arguments: 'D:/tools/parallelize/parallelize.exe'
+              arguments: '$(buildOutputLocation)/parallelize/parallelize.exe'
             env: { TMP: $(tmpDir), TEMP: $(tmpDir) }
           - task: BatchScript@1
             displayName: 'Validate Files'
@@ -52,7 +54,7 @@ stages:
             inputs:
               filename: 'azure-devops/validate-files.cmd'
               failOnStandardError: true
-              arguments: 'D:/tools/validate/validate.exe'
+              arguments: '$(buildOutputLocation)/validate/validate.exe'
             env: { TMP: $(tmpDir), TEMP: $(tmpDir) }
   - stage: Build_And_Test
     displayName: 'Build and Test'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,12 +28,14 @@ stages:
             clean: true
             submodules: false
           - script: |
+              if exist "D:\tools" (
+                rmdir /S /Q "D:\tools"
+              )
               call "%PROGRAMFILES(X86)%\Microsoft Visual Studio\2019\Preview\Common7\Tools\VsDevCmd.bat" ^
               -host_arch=amd64 -arch=amd64 -no_logo
               cmake -G Ninja -DCMAKE_CXX_COMPILER=cl -DCMAKE_BUILD_TYPE=Release ^
-              -S $(Build.SourcesDirectory)\tools -B $(Build.ArtifactStagingDirectory)\tools
-              cd $(Build.ArtifactStagingDirectory)\tools
-              cmake --build .
+              -S $(Build.SourcesDirectory)\tools -B D:\tools
+              cmake --build D:\tools
             displayName: 'Build Support Tools'
             env: { TMP: $(tmpDir), TEMP: $(tmpDir) }
           - task: BatchScript@1
@@ -42,7 +44,7 @@ stages:
             inputs:
               filename: 'azure-devops/enforce-clang-format.cmd'
               failOnStandardError: true
-              arguments: '$(Build.ArtifactStagingDirectory)/tools/parallelize/parallelize.exe'
+              arguments: 'D:/tools/parallelize/parallelize.exe'
             env: { TMP: $(tmpDir), TEMP: $(tmpDir) }
           - task: BatchScript@1
             displayName: 'Validate Files'
@@ -50,7 +52,7 @@ stages:
             inputs:
               filename: 'azure-devops/validate-files.cmd'
               failOnStandardError: true
-              arguments: '$(Build.ArtifactStagingDirectory)/tools/validate/validate.exe'
+              arguments: 'D:/tools/validate/validate.exe'
             env: { TMP: $(tmpDir), TEMP: $(tmpDir) }
   - stage: Build_And_Test
     displayName: 'Build and Test'

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,9 +21,13 @@ add_subdirectory(utils/stl-lit)
 set(Python_FIND_STRATEGY VERSION)
 find_package(Python3)
 
+if(NOT DEFINED LIT_FLAGS)
+    list(APPEND LIT_FLAGS "-o" "${CMAKE_CURRENT_BINARY_DIR}/test_results.json")
+endif()
+
 get_property(STL_LIT_TEST_DIRS GLOBAL PROPERTY STL_LIT_TEST_DIRS)
 list(APPEND STL_LIT_COMMAND "${STL_LIT_OUTPUT}"
-                            "${ADDITIONAL_LIT_FLAGS}"
+                            "${LIT_FLAGS}"
                             "${STL_LIT_TEST_DIRS}")
 
 add_test(NAME stl COMMAND ${Python3_EXECUTABLE} ${STL_LIT_COMMAND} COMMAND_EXPAND_LISTS)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,20 +9,21 @@ set(STL_TESTED_HEADERS_DIR "${STL_BUILD_ROOT}/inc")
 
 set(LLVM_PROJECT_SOURCE_DIR "${STL_SOURCE_DIR}/llvm-project" CACHE PATH
     "Location of the llvm-project source tree")
-set(LIBCXX_SOURCE_DIR "${LLVM_PROJECT_SOURCE_DIR}/libcxx" CACHE PATH
-    "Location of the libcxx source tree")
-set(LLVM_SOURCE_DIR "${LLVM_PROJECT_SOURCE_DIR}/llvm" CACHE PATH
-    "Location of the llvm source tree")
-
-set(STL_LIT ${CMAKE_CURRENT_BINARY_DIR}/utils/stl-lit/stl-lit.py)
-
-set(Python_FIND_STRATEGY VERSION)
-find_package(Python3)
 
 add_subdirectory(libcxx)
 add_subdirectory(std)
 add_subdirectory(tr1)
 
 # Add the stl-lit subdirectory last so all the test directories have had a
-# chance to add to the config map.
+# chance to add to the config map and test directory global properties.
 add_subdirectory(utils/stl-lit)
+
+set(Python_FIND_STRATEGY VERSION)
+find_package(Python3)
+
+get_property(STL_LIT_TEST_DIRS GLOBAL PROPERTY STL_LIT_TEST_DIRS)
+list(APPEND STL_LIT_COMMAND "${STL_LIT_OUTPUT}"
+                            "${ADDITIONAL_LIT_FLAGS}"
+                            "${STL_LIT_TEST_DIRS}")
+
+add_test(NAME stl COMMAND ${Python3_EXECUTABLE} ${STL_LIT_COMMAND} COMMAND_EXPAND_LISTS)

--- a/tests/libcxx/CMakeLists.txt
+++ b/tests/libcxx/CMakeLists.txt
@@ -3,24 +3,14 @@
 
 set(LIBCXX_ENVLST "${CMAKE_CURRENT_SOURCE_DIR}/usual_matrix.lst")
 set(LIBCXX_EXPECTED_RESULTS "${CMAKE_CURRENT_SOURCE_DIR}/expected_results.txt")
+set(LIBCXX_SOURCE_DIR "${LLVM_PROJECT_SOURCE_DIR}/libcxx" CACHE PATH
+    "Location of the libcxx source tree")
 set(LIBCXX_TEST_OUTPUT_DIR "${STL_TEST_OUTPUT_DIR}/libcxx")
 
 configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.in
   ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg)
 
-get_property(STL_LIT_CONFIG_MAP GLOBAL PROPERTY STL_LIT_CONFIG_MAP)
-string(APPEND STL_LIT_CONFIG_MAP "map_config(\"${LIBCXX_SOURCE_DIR}/test/lit.cfg\", \"${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg\")\n")
-set_property(GLOBAL PROPERTY STL_LIT_CONFIG_MAP ${STL_LIT_CONFIG_MAP})
-
-if(ENABLE_XUNIT_OUTPUT)
-    list(APPEND LIBCXX_ADDITIONAL_LIT_FLAGS "--xunit-xml-output" "${CMAKE_CURRENT_BINARY_DIR}/libcxx.test.xml")
-endif()
-
-list(APPEND LIBCXX_STL_LIT_COMMAND "${STL_LIT}"
-                                   "${ADDITIONAL_LIT_FLAGS}"
-                                   "${LIBCXX_ADDITIONAL_LIT_FLAGS}"
-                                   "${LIBCXX_SOURCE_DIR}/test")
-
-add_test(NAME libcxx COMMAND ${Python3_EXECUTABLE} ${LIBCXX_STL_LIT_COMMAND} COMMAND_EXPAND_LISTS)
-set_tests_properties(libcxx PROPERTIES RUN_SERIAL TRUE)
+set(LIBCXX_LIT_CONFIG_MAP "map_config(\"${LIBCXX_SOURCE_DIR}/test/lit.cfg\", \"${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg\")\n")
+set_property(GLOBAL APPEND_STRING PROPERTY STL_LIT_CONFIG_MAP ${LIBCXX_LIT_CONFIG_MAP})
+set_property(GLOBAL APPEND PROPERTY STL_LIT_TEST_DIRS "${LIBCXX_SOURCE_DIR}/test/std")

--- a/tests/std/CMakeLists.txt
+++ b/tests/std/CMakeLists.txt
@@ -10,18 +10,6 @@ configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.in
   ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg)
 
-get_property(STL_LIT_CONFIG_MAP GLOBAL PROPERTY STL_LIT_CONFIG_MAP)
-string(APPEND STL_LIT_CONFIG_MAP "map_config(\"${CMAKE_CURRENT_SOURCE_DIR}/lit.cfg\", \"${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg\")\n")
-set_property(GLOBAL PROPERTY STL_LIT_CONFIG_MAP ${STL_LIT_CONFIG_MAP})
-
-if(ENABLE_XUNIT_OUTPUT)
-    list(APPEND STD_ADDITIONAL_LIT_FLAGS "--xunit-xml-output" "${CMAKE_CURRENT_BINARY_DIR}/std.test.xml")
-endif()
-
-list(APPEND STD_STL_LIT_COMMAND "${STL_LIT}"
-                                "${ADDITIONAL_LIT_FLAGS}"
-                                "${STD_ADDITIONAL_LIT_FLAGS}"
-                                "${CMAKE_CURRENT_SOURCE_DIR}")
-
-add_test(NAME std COMMAND ${Python3_EXECUTABLE} ${STD_STL_LIT_COMMAND} COMMAND_EXPAND_LISTS)
-set_tests_properties(std PROPERTIES RUN_SERIAL TRUE)
+set(STD_LIT_CONFIG_MAP "map_config(\"${CMAKE_CURRENT_SOURCE_DIR}/lit.cfg\", \"${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg\")\n")
+set_property(GLOBAL APPEND_STRING PROPERTY STL_LIT_CONFIG_MAP ${STD_LIT_CONFIG_MAP})
+set_property(GLOBAL APPEND PROPERTY STL_LIT_TEST_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/tests")

--- a/tests/tr1/CMakeLists.txt
+++ b/tests/tr1/CMakeLists.txt
@@ -10,18 +10,6 @@ configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.in
   ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg)
 
-get_property(STL_LIT_CONFIG_MAP GLOBAL PROPERTY STL_LIT_CONFIG_MAP)
-string(APPEND STL_LIT_CONFIG_MAP "map_config(\"${CMAKE_CURRENT_SOURCE_DIR}/lit.cfg\", \"${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg\")\n")
-set_property(GLOBAL PROPERTY STL_LIT_CONFIG_MAP ${STL_LIT_CONFIG_MAP})
-
-if(ENABLE_XUNIT_OUTPUT)
-    list(APPEND TR1_ADDITIONAL_LIT_FLAGS "--xunit-xml-output" "${CMAKE_CURRENT_BINARY_DIR}/tr1.test.xml")
-endif()
-
-list(APPEND TR1_STL_LIT_COMMAND "${STL_LIT}"
-                                "${ADDITIONAL_LIT_FLAGS}"
-                                "${TR1_ADDITIONAL_LIT_FLAGS}"
-                                "${CMAKE_CURRENT_SOURCE_DIR}")
-
-add_test(NAME tr1 COMMAND ${Python3_EXECUTABLE} ${TR1_STL_LIT_COMMAND} COMMAND_EXPAND_LISTS)
-set_tests_properties(tr1 PROPERTIES RUN_SERIAL TRUE)
+set(TR1_LIT_CONFIG_MAP "map_config(\"${CMAKE_CURRENT_SOURCE_DIR}/lit.cfg\", \"${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg\")\n")
+set_property(GLOBAL APPEND_STRING PROPERTY STL_LIT_CONFIG_MAP ${TR1_LIT_CONFIG_MAP})
+set_property(GLOBAL APPEND PROPERTY STL_LIT_TEST_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/tests")

--- a/tests/utils/stl-lit/CMakeLists.txt
+++ b/tests/utils/stl-lit/CMakeLists.txt
@@ -1,8 +1,13 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+set(LLVM_SOURCE_DIR "${LLVM_PROJECT_SOURCE_DIR}/llvm" CACHE PATH
+    "Location of the llvm source tree")
+
+set(STL_LIT_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/stl-lit.py")
+set(STL_LIT_OUTPUT "${STL_LIT_OUTPUT}" PARENT_SCOPE)
+
 get_property(STL_LIT_CONFIG_MAP GLOBAL PROPERTY STL_LIT_CONFIG_MAP)
 configure_file(
-    ${CMAKE_CURRENT_SOURCE_DIR}/stl-lit.in
-    ${STL_LIT}
-)
+    "${CMAKE_CURRENT_SOURCE_DIR}/stl-lit.in"
+    "${STL_LIT_OUTPUT}")


### PR DESCRIPTION
1. Discover and run all the libcxx, std, and tr1 as a single step.
This minimizes the amount of single threaded time we take to run the
tests.
2. Make the tests have a timeout in the CI. (In order to do this I need
to `pip install psutil`)
3. Shuffle the order the tests are run in the CI.
4. Don't require vcpkg.exe to run the build
5. Move the build output directory of the support tools to be on the
D: drive.
6. A JSON results file will now get created when running the `ctest` command and no other LIT flags are specified.