### PR TITLE
fix using *_Prev_iter(it) instead of *(it - 1)

### DIFF
--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -4745,8 +4745,8 @@ _CONSTEXPR20 bool next_permutation(_BidIt _First, _BidIt _Last, _Pr _Pred) {
 
     for (;;) { // find rightmost element smaller than successor
         auto _UNext1 = _UNext;
-        if (_DEBUG_LT_PRED(
-                _Pred, *_Prev_iter(_UNext), *_UNext1)) { // swap with rightmost element that's smaller, flip suffix
+        if (_DEBUG_LT_PRED(_Pred, *_Prev_iter(_UNext), *_UNext1)) { 
+            // swap with rightmost element that's smaller, flip suffix
             auto _UMid = _ULast;
             do {
                 --_UMid;
@@ -4784,8 +4784,8 @@ _CONSTEXPR20 bool prev_permutation(_BidIt _First, _BidIt _Last, _Pr _Pred) {
 
     for (;;) { // find rightmost element not smaller than successor
         auto _UNext1 = _UNext;
-        if (_DEBUG_LT_PRED(
-                _Pred, *_UNext1, *_Prev_iter(_UNext))) { // swap with rightmost element that's not smaller, flip suffix
+        if (_DEBUG_LT_PRED(_Pred, *_UNext1, *_Prev_iter(_UNext))) { 
+            // swap with rightmost element that's not smaller, flip suffix
             auto _UMid = _ULast;
             do {
                 --_UMid;

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -2424,7 +2424,7 @@ _CONSTEXPR20 _OutIt reverse_copy(_BidIt _First, _BidIt _Last, _OutIt _Dest) {
     auto _ULast        = _Get_unwrapped(_Last);
     auto _UDest        = _Get_unwrapped_n(_Dest, _Idl_distance<_BidIt>(_UFirst, _ULast));
     for (; _UFirst != _ULast; ++_UDest) {
-      *_UDest = *_Prev_iter(_ULast);
+        *_UDest = *_Prev_iter(_ULast);
     }
 
     _Seek_wrapped(_Dest, _UDest);
@@ -4745,7 +4745,8 @@ _CONSTEXPR20 bool next_permutation(_BidIt _First, _BidIt _Last, _Pr _Pred) {
 
     for (;;) { // find rightmost element smaller than successor
         auto _UNext1 = _UNext;
-        if (_DEBUG_LT_PRED(_Pred, *_Prev_iter(_UNext), *_UNext1)) { // swap with rightmost element that's smaller, flip suffix
+        if (_DEBUG_LT_PRED(
+                _Pred, *_Prev_iter(_UNext), *_UNext1)) { // swap with rightmost element that's smaller, flip suffix
             auto _UMid = _ULast;
             do {
                 --_UMid;
@@ -4783,7 +4784,8 @@ _CONSTEXPR20 bool prev_permutation(_BidIt _First, _BidIt _Last, _Pr _Pred) {
 
     for (;;) { // find rightmost element not smaller than successor
         auto _UNext1 = _UNext;
-        if (_DEBUG_LT_PRED(_Pred, *_UNext1, *_Prev_iter(_UNext))) { // swap with rightmost element that's not smaller, flip suffix
+        if (_DEBUG_LT_PRED(
+                _Pred, *_UNext1, *_Prev_iter(_UNext))) { // swap with rightmost element that's not smaller, flip suffix
             auto _UMid = _ULast;
             do {
                 --_UMid;

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -1606,7 +1606,7 @@ _FwdIt _Search_n_unchecked1(_FwdIt _First, const _FwdIt _Last, const _Diff _Coun
             _Iter_diff_t<_FwdIt> _Count1 = _Count_diff;
             _FwdIt _Mid                  = _First;
 
-            while (_Old_first != _First && _Pred(*(_First - 1), _Val)) {
+            while (_Old_first != _First && _Pred(*_Prev_iter(_First), _Val)) {
                 --_Count1; // back up over any skipped prefix
                 --_First;
             }

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -4745,7 +4745,7 @@ _CONSTEXPR20 bool next_permutation(_BidIt _First, _BidIt _Last, _Pr _Pred) {
 
     for (;;) { // find rightmost element smaller than successor
         auto _UNext1 = _UNext;
-        if (_DEBUG_LT_PRED(_Pred, *_Prev_iter(_UNext), *_UNext1)) { 
+        if (_DEBUG_LT_PRED(_Pred, *_Prev_iter(_UNext), *_UNext1)) {
             // swap with rightmost element that's smaller, flip suffix
             auto _UMid = _ULast;
             do {
@@ -4784,7 +4784,7 @@ _CONSTEXPR20 bool prev_permutation(_BidIt _First, _BidIt _Last, _Pr _Pred) {
 
     for (;;) { // find rightmost element not smaller than successor
         auto _UNext1 = _UNext;
-        if (_DEBUG_LT_PRED(_Pred, *_UNext1, *_Prev_iter(_UNext))) { 
+        if (_DEBUG_LT_PRED(_Pred, *_UNext1, *_Prev_iter(_UNext))) {
             // swap with rightmost element that's not smaller, flip suffix
             auto _UMid = _ULast;
             do {

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -2424,7 +2424,7 @@ _CONSTEXPR20 _OutIt reverse_copy(_BidIt _First, _BidIt _Last, _OutIt _Dest) {
     auto _ULast        = _Get_unwrapped(_Last);
     auto _UDest        = _Get_unwrapped_n(_Dest, _Idl_distance<_BidIt>(_UFirst, _ULast));
     for (; _UFirst != _ULast; ++_UDest) {
-        *_UDest = *--_ULast;
+      *_UDest = *_Prev_iter(_ULast);
     }
 
     _Seek_wrapped(_Dest, _UDest);
@@ -4745,7 +4745,7 @@ _CONSTEXPR20 bool next_permutation(_BidIt _First, _BidIt _Last, _Pr _Pred) {
 
     for (;;) { // find rightmost element smaller than successor
         auto _UNext1 = _UNext;
-        if (_DEBUG_LT_PRED(_Pred, *--_UNext, *_UNext1)) { // swap with rightmost element that's smaller, flip suffix
+        if (_DEBUG_LT_PRED(_Pred, *_Prev_iter(_UNext), *_UNext1)) { // swap with rightmost element that's smaller, flip suffix
             auto _UMid = _ULast;
             do {
                 --_UMid;
@@ -4783,7 +4783,7 @@ _CONSTEXPR20 bool prev_permutation(_BidIt _First, _BidIt _Last, _Pr _Pred) {
 
     for (;;) { // find rightmost element not smaller than successor
         auto _UNext1 = _UNext;
-        if (_DEBUG_LT_PRED(_Pred, *_UNext1, *--_UNext)) { // swap with rightmost element that's not smaller, flip suffix
+        if (_DEBUG_LT_PRED(_Pred, *_UNext1, *_Prev_iter(_UNext))) { // swap with rightmost element that's not smaller, flip suffix
             auto _UMid = _ULast;
             do {
                 --_UMid;

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -1525,7 +1525,7 @@ _NODISCARD _CONSTEXPR20 _FwdIt search_n(
                 _Iter_diff_t<_FwdIt> _Count1 = _Count_diff;
                 auto _UMid                   = _UFirst;
 
-                while (_UOld_first != _UFirst && _Pred(*(_UFirst - 1), _Val)) { // back up over any skipped prefix
+                while (_UOld_first != _UFirst && _Pred(*_Prev_iter(_UFirst), _Val)) { // back up over any skipped prefix
                     --_Count1;
                     --_UFirst;
                 }
@@ -2424,7 +2424,7 @@ _CONSTEXPR20 _OutIt reverse_copy(_BidIt _First, _BidIt _Last, _OutIt _Dest) {
     auto _ULast        = _Get_unwrapped(_Last);
     auto _UDest        = _Get_unwrapped_n(_Dest, _Idl_distance<_BidIt>(_UFirst, _ULast));
     for (; _UFirst != _ULast; ++_UDest) {
-        *_UDest = *_Prev_iter(_ULast);
+        *_UDest = *--_ULast;
     }
 
     _Seek_wrapped(_Dest, _UDest);
@@ -3764,7 +3764,8 @@ _CONSTEXPR20 pair<_RanIt, _RanIt> _Partition_by_median_guess_unchecked(_RanIt _F
     _RanIt _Pfirst = _Mid;
     _RanIt _Plast  = _Pfirst + 1;
 
-    while (_First < _Pfirst && !_DEBUG_LT_PRED(_Pred, *(_Pfirst - 1), *_Pfirst) && !_Pred(*_Pfirst, *(_Pfirst - 1))) {
+    while (_First < _Pfirst && !_DEBUG_LT_PRED(_Pred, *_Prev_iter(_Pfirst), *_Pfirst)
+           && !_Pred(*_Pfirst, *_Prev_iter(_Pfirst))) {
         --_Pfirst;
     }
 
@@ -3789,8 +3790,8 @@ _CONSTEXPR20 pair<_RanIt, _RanIt> _Partition_by_median_guess_unchecked(_RanIt _F
         }
 
         for (; _First < _Glast; --_Glast) {
-            if (_DEBUG_LT_PRED(_Pred, *(_Glast - 1), *_Pfirst)) {
-            } else if (_Pred(*_Pfirst, *(_Glast - 1))) {
+            if (_DEBUG_LT_PRED(_Pred, *_Prev_iter(_Glast), *_Pfirst)) {
+            } else if (_Pred(*_Pfirst, *_Prev_iter(_Glast))) {
                 break;
             } else if (--_Pfirst != _Glast - 1) {
                 _STD iter_swap(_Pfirst, _Glast - 1);
@@ -4745,8 +4746,7 @@ _CONSTEXPR20 bool next_permutation(_BidIt _First, _BidIt _Last, _Pr _Pred) {
 
     for (;;) { // find rightmost element smaller than successor
         auto _UNext1 = _UNext;
-        if (_DEBUG_LT_PRED(_Pred, *_Prev_iter(_UNext), *_UNext1)) {
-            // swap with rightmost element that's smaller, flip suffix
+        if (_DEBUG_LT_PRED(_Pred, *--_UNext, *_UNext1)) { // swap with rightmost element that's smaller, flip suffix
             auto _UMid = _ULast;
             do {
                 --_UMid;
@@ -4784,8 +4784,7 @@ _CONSTEXPR20 bool prev_permutation(_BidIt _First, _BidIt _Last, _Pr _Pred) {
 
     for (;;) { // find rightmost element not smaller than successor
         auto _UNext1 = _UNext;
-        if (_DEBUG_LT_PRED(_Pred, *_UNext1, *_Prev_iter(_UNext))) {
-            // swap with rightmost element that's not smaller, flip suffix
+        if (_DEBUG_LT_PRED(_Pred, *_UNext1, *--_UNext)) { // swap with rightmost element that's not smaller, flip suffix
             auto _UMid = _ULast;
             do {
                 --_UMid;


### PR DESCRIPTION
# Description

Fixes #465 

# Checklist

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [x] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [ ] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
