### PR TITLE
Fix CUDA warnings/errors, _Noinit shadowing, other cleanups

### DIFF
--- a/stl/inc/istream
+++ b/stl/inc/istream
@@ -31,8 +31,8 @@ public:
     using _Nget  = num_get<_Elem, _Iter>;
 
 #if defined(__FORCE_INSTANCE)
-    explicit __CLR_OR_THIS_CALL basic_istream(_Mysb* _Strbuf, bool _Isstd, bool _Noinit) : _Chcount(0) {
-        if (!_Noinit) {
+    explicit __CLR_OR_THIS_CALL basic_istream(_Mysb* _Strbuf, bool _Isstd, bool _Skip_init) : _Chcount(0) {
+        if (!_Skip_init) {
             _Myios::init(_Strbuf, _Isstd);
         }
     }

--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -1789,8 +1789,7 @@ protected:
 
 // CLASS TEMPLATE _Ref_count_obj_alloc3
 template <class _Ty, class _Alloc>
-class __declspec(empty_bases) _Ref_count_obj_alloc3 : public _Ebco_base<_Rebind_alloc_t<_Alloc, _Ty>>,
-                                                      public _Ref_count_base {
+class _Ref_count_obj_alloc3 : public _Ebco_base<_Rebind_alloc_t<_Alloc, _Ty>>, public _Ref_count_base {
     // handle reference counting for object in control block, allocator
 private:
     static_assert(is_same_v<_Ty, remove_cv_t<_Ty>>, "allocate_shared should remove_cv_t");
@@ -1952,9 +1951,8 @@ void _Uninitialized_fill_multidimensional_n_al(_Ty* const _Out, const size_t _Si
 
 // CLASS TEMPLATE _Ref_count_unbounded_array_alloc
 template <class _Ty, class _Alloc>
-class __declspec(empty_bases) _Ref_count_unbounded_array_alloc
-    : public _Ebco_base<_Rebind_alloc_t<_Alloc, remove_all_extents_t<_Ty>>>,
-      public _Ref_count_base {
+class _Ref_count_unbounded_array_alloc : public _Ebco_base<_Rebind_alloc_t<_Alloc, remove_all_extents_t<_Ty>>>,
+                                         public _Ref_count_base {
     // handle reference counting for unbounded array in control block, allocator
 private:
     static_assert(is_unbounded_array_v<_Ty>);
@@ -2016,9 +2014,8 @@ private:
 
 // CLASS TEMPLATE _Ref_count_bounded_array_alloc
 template <class _Ty, class _Alloc>
-class __declspec(empty_bases) _Ref_count_bounded_array_alloc
-    : public _Ebco_base<_Rebind_alloc_t<_Alloc, remove_all_extents_t<_Ty>>>,
-      public _Ref_count_base {
+class _Ref_count_bounded_array_alloc : public _Ebco_base<_Rebind_alloc_t<_Alloc, remove_all_extents_t<_Ty>>>,
+                                       public _Ref_count_base {
     // handle reference counting for bounded array in control block, allocator
 private:
     static_assert(is_bounded_array_v<_Ty>);

--- a/stl/inc/random
+++ b/stl/inc/random
@@ -4368,10 +4368,8 @@ public:
 
     struct param_type { // parameter package
         using distribution_type = discrete_distribution;
-        struct _Noinit { // placeholder to suppress initialization
-        };
 
-        param_type(_Noinit) { // do-nothing constructor for derived classes
+        param_type(_Uninitialized) { // do-nothing constructor for derived classes
         }
 
         param_type() {
@@ -4567,7 +4565,6 @@ public:
 
     using _Mybase     = discrete_distribution<size_t>;
     using _Mypbase    = typename _Mybase::param_type;
-    using _Noinit     = typename _Mypbase::_Noinit;
     using result_type = _Ty;
 
     struct param_type : _Mypbase { // parameter package
@@ -4579,7 +4576,7 @@ public:
         }
 
         template <class _InIt1, class _InIt2>
-        param_type(_InIt1 _First1, _InIt1 _Last1, _InIt2 _First2) : _Mypbase(_Noinit()), _Bvec(_First1, _Last1) {
+        param_type(_InIt1 _First1, _InIt1 _Last1, _InIt2 _First2) : _Mypbase(_Noinit), _Bvec(_First1, _Last1) {
             if (2 <= _Bvec.size()) {
                 for (size_t _Idx = 0; _Idx < _Bvec.size() - 1; ++_Idx) {
                     this->_Pvec.push_back(static_cast<double>(*_First2++));
@@ -4590,7 +4587,7 @@ public:
         }
 
         template <class _Fn>
-        param_type(initializer_list<_Ty> _Ilist, _Fn _Func) : _Mypbase(_Noinit()) {
+        param_type(initializer_list<_Ty> _Ilist, _Fn _Func) : _Mypbase(_Noinit) {
             if (2 <= _Ilist.size()) {
                 _Bvec.assign(_Ilist);
             } else { // default construct
@@ -4769,7 +4766,6 @@ public:
 
     using _Mybase     = discrete_distribution<size_t>;
     using _Mypbase    = typename _Mybase::param_type;
-    using _Noinit     = typename _Mypbase::_Noinit;
     using result_type = _Ty;
 
     struct param_type : _Mypbase { // parameter package
@@ -4781,7 +4777,7 @@ public:
         }
 
         template <class _InIt1, class _InIt2>
-        param_type(_InIt1 _First1, _InIt1 _Last1, _InIt2 _First2) : _Mypbase(_Noinit()), _Bvec(_First1, _Last1) {
+        param_type(_InIt1 _First1, _InIt1 _Last1, _InIt2 _First2) : _Mypbase(_Noinit), _Bvec(_First1, _Last1) {
             if (2 <= _Bvec.size()) {
                 for (size_t _Idx = 0; _Idx < _Bvec.size(); ++_Idx) {
                     this->_Pvec.push_back(static_cast<double>(*_First2++));
@@ -4792,7 +4788,7 @@ public:
         }
 
         template <class _Fn>
-        param_type(initializer_list<_Ty> _Ilist, _Fn _Func) : _Mypbase(_Noinit()) {
+        param_type(initializer_list<_Ty> _Ilist, _Fn _Func) : _Mypbase(_Noinit) {
             if (2 <= _Ilist.size()) {
                 _Bvec.assign(_Ilist);
             } else { // default construct
@@ -4813,7 +4809,7 @@ public:
         }
 
         template <class _Fn>
-        param_type(size_t _Count, _Ty _Low, _Ty _High, _Fn _Func) : _Mypbase(_Noinit()) {
+        param_type(size_t _Count, _Ty _Low, _Ty _High, _Fn _Func) : _Mypbase(_Noinit) {
             _Ty _Range = _High - _Low;
             _STL_ASSERT(_Ty{0} < _Range, "invalid range for piecewise_linear_distribution");
             if (_Count < 2) {

--- a/stl/inc/string
+++ b/stl/inc/string
@@ -499,13 +499,24 @@ basic_string<_Elem> _Integral_to_string(const _Ty _Val) { // convert _Val to str
     return basic_string<_Elem>(_RNext, _Buff_end);
 }
 
+// TRANSITION, CUDA - warning: pointless comparison of unsigned integer with zero
+template <class _Elem, class _Ty>
+basic_string<_Elem> _UIntegral_to_string(const _Ty _Val) { // convert _Val to string
+    static_assert(is_integral_v<_Ty>, "_Ty must be integral");
+    static_assert(is_unsigned_v<_Ty>, "_Ty must be unsigned");
+    _Elem _Buff[21]; // can hold 2^64 - 1, plus NUL
+    _Elem* const _Buff_end = _STD end(_Buff);
+    _Elem* const _RNext    = _UIntegral_to_buff(_Buff_end, _Val);
+    return basic_string<_Elem>(_RNext, _Buff_end);
+}
+
 // to_string NARROW CONVERSIONS
 _NODISCARD inline string to_string(int _Val) { // convert int to string
     return _Integral_to_string<char>(_Val);
 }
 
 _NODISCARD inline string to_string(unsigned int _Val) { // convert unsigned int to string
-    return _Integral_to_string<char>(_Val);
+    return _UIntegral_to_string<char>(_Val);
 }
 
 _NODISCARD inline string to_string(long _Val) { // convert long to string
@@ -513,7 +524,7 @@ _NODISCARD inline string to_string(long _Val) { // convert long to string
 }
 
 _NODISCARD inline string to_string(unsigned long _Val) { // convert unsigned long to string
-    return _Integral_to_string<char>(_Val);
+    return _UIntegral_to_string<char>(_Val);
 }
 
 _NODISCARD inline string to_string(long long _Val) { // convert long long to string
@@ -521,7 +532,7 @@ _NODISCARD inline string to_string(long long _Val) { // convert long long to str
 }
 
 _NODISCARD inline string to_string(unsigned long long _Val) { // convert unsigned long long to string
-    return _Integral_to_string<char>(_Val);
+    return _UIntegral_to_string<char>(_Val);
 }
 
 _NODISCARD inline string to_string(double _Val) { // convert double to string
@@ -545,7 +556,7 @@ _NODISCARD inline wstring to_wstring(int _Val) { // convert int to wstring
 }
 
 _NODISCARD inline wstring to_wstring(unsigned int _Val) { // convert unsigned int to wstring
-    return _Integral_to_string<wchar_t>(_Val);
+    return _UIntegral_to_string<wchar_t>(_Val);
 }
 
 _NODISCARD inline wstring to_wstring(long _Val) { // convert long to wstring
@@ -553,7 +564,7 @@ _NODISCARD inline wstring to_wstring(long _Val) { // convert long to wstring
 }
 
 _NODISCARD inline wstring to_wstring(unsigned long _Val) { // convert unsigned long to wstring
-    return _Integral_to_string<wchar_t>(_Val);
+    return _UIntegral_to_string<wchar_t>(_Val);
 }
 
 _NODISCARD inline wstring to_wstring(long long _Val) { // convert long long to wstring
@@ -561,7 +572,7 @@ _NODISCARD inline wstring to_wstring(long long _Val) { // convert long long to w
 }
 
 _NODISCARD inline wstring to_wstring(unsigned long long _Val) { // convert unsigned long long to wstring
-    return _Integral_to_string<wchar_t>(_Val);
+    return _UIntegral_to_string<wchar_t>(_Val);
 }
 
 _NODISCARD inline wstring to_wstring(double _Val) { // convert double to wstring

--- a/stl/inc/xlocmon
+++ b/stl/inc/xlocmon
@@ -433,7 +433,7 @@ private:
         size_t _Idx;
         static constexpr char _Src[]   = "0123456789-";
         const ctype<_Elem>& _Ctype_fac = _STD use_facet<ctype<_Elem>>(_Iosbase.getloc());
-        _Ctype_fac.widen(&_Src[0], &_Src[sizeof(_Src)], _Atoms);
+        _Ctype_fac.widen(_STD begin(_Src), _STD end(_Src), _Atoms);
 
         for (size_t _Off = 0; !_Bad && _Off < 4; ++_Off) {
             switch (_Pattern.field[_Off]) { // parse a format component
@@ -690,7 +690,7 @@ protected:
         const _Elem _E0                = _Ctype_fac.widen('0');
 
         string_type _Val2(static_cast<size_t>(_Count), _Elem{});
-        _Ctype_fac.widen(&_Buf[0], &_Buf[_Count], &_Val2[0]);
+        _Ctype_fac.widen(_Buf, _Buf + _Count, &_Val2[0]);
         _Val2.append(_Exp, _E0); // scale by trailing zeros
         return _Putmfld(_Dest, _Intl, _Iosbase, _Fill, _Negative, _Val2, _E0);
     }
@@ -700,7 +700,7 @@ protected:
         static constexpr char _Src[] = "0123456789-";
         _Elem _Atoms[sizeof(_Src)];
         const ctype<_Elem>& _Ctype_fac = _STD use_facet<ctype<_Elem>>(_Iosbase.getloc());
-        _Ctype_fac.widen(&_Src[0], &_Src[sizeof(_Src)], _Atoms);
+        _Ctype_fac.widen(_STD begin(_Src), _STD end(_Src), _Atoms);
 
         bool _Negative = false;
         size_t _Idx0   = 0;

--- a/stl/inc/xlocmon
+++ b/stl/inc/xlocmon
@@ -680,7 +680,7 @@ protected:
         char _Buf[40];
 
         // convert to chars:
-        const auto _Count = static_cast<size_t>(_CSTD sprintf_s(_Buf, sizeof(_Buf), "%.0Lf", _Val));
+        const int _Count = _CSTD sprintf_s(_Buf, sizeof(_Buf), "%.0Lf", _Val);
 
         if (_Count < 0) {
             return _Dest; // bad conversion, give up
@@ -689,7 +689,7 @@ protected:
         const ctype<_Elem>& _Ctype_fac = _STD use_facet<ctype<_Elem>>(_Iosbase.getloc());
         const _Elem _E0                = _Ctype_fac.widen('0');
 
-        string_type _Val2(_Count, _Elem{});
+        string_type _Val2(static_cast<size_t>(_Count), _Elem{});
         _Ctype_fac.widen(&_Buf[0], &_Buf[_Count], &_Val2[0]);
         _Val2.append(_Exp, _E0); // scale by trailing zeros
         return _Putmfld(_Dest, _Intl, _Iosbase, _Fill, _Negative, _Val2, _E0);

--- a/stl/inc/xlocnum
+++ b/stl/inc/xlocnum
@@ -675,7 +675,7 @@ private:
         static constexpr char _Src[]  = "0123456789ABCDEFabcdef-+Xx";
         _Elem _Atoms[sizeof(_Src)];
         const ctype<_Elem>& _Ctype_fac = _STD use_facet<ctype<_Elem>>(_Loc);
-        _Ctype_fac.widen(&_Src[0], &_Src[sizeof(_Src)], _Atoms);
+        _Ctype_fac.widen(_STD begin(_Src), _STD end(_Src), _Atoms);
 
         char* _Ptr = _Ac;
 
@@ -788,7 +788,7 @@ private:
         static constexpr char _Src[]  = "0123456789-+Ee";
         _Elem _Atoms[sizeof(_Src)];
         const ctype<_Elem>& _Ctype_fac = _STD use_facet<ctype<_Elem>>(_Iosbase.getloc());
-        _Ctype_fac.widen(&_Src[0], &_Src[sizeof(_Src)], _Atoms);
+        _Ctype_fac.widen(_STD begin(_Src), _STD end(_Src), _Atoms);
 
         if (_First != _Last) {
             if (*_First == _Atoms[_Numget_signoff + 1]) { // gather plus sign
@@ -970,7 +970,7 @@ private:
         static constexpr char _Src[]  = "0123456789ABCDEFabcdef-+XxPp";
         _Elem _Atoms[sizeof(_Src)];
         const ctype<_Elem>& _Ctype_fac = _STD use_facet<ctype<_Elem>>(_Iosbase.getloc());
-        _Ctype_fac.widen(&_Src[0], &_Src[sizeof(_Src)], _Atoms);
+        _Ctype_fac.widen(_STD begin(_Src), _STD end(_Src), _Atoms);
 
         char* _Ptr = _Ac;
         bool _Bad  = false;
@@ -1410,7 +1410,7 @@ private:
 
         const ctype<_Elem>& _Ctype_fac = _STD use_facet<ctype<_Elem>>(_Iosbase.getloc());
         basic_string<_Elem> _Groupstring(_Count, _Elem(0)); // reserve space
-        _Ctype_fac.widen(&_Buf[0], &_Buf[_Count], &_Groupstring[0]);
+        _Ctype_fac.widen(_Buf, _Buf + _Count, &_Groupstring[0]);
 
         const auto& _Punct_fac  = _STD use_facet<numpunct<_Elem>>(_Iosbase.getloc());
         const string _Grouping  = _Punct_fac.grouping();
@@ -1496,7 +1496,7 @@ private:
 
         const ctype<_Elem>& _Ctype_fac = _STD use_facet<ctype<_Elem>>(_Iosbase.getloc());
         basic_string<_Elem> _Groupstring(_Count, _Elem(0)); // reserve space
-        _Ctype_fac.widen(&_Buf[0], &_Buf[_Count], &_Groupstring[0]);
+        _Ctype_fac.widen(_Buf, _Buf + _Count, &_Groupstring[0]);
 
         const auto& _Punct_fac = _STD use_facet<numpunct<_Elem>>(_Iosbase.getloc());
         const string _Grouping = _Punct_fac.grouping();

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -4297,8 +4297,7 @@ private:
     void _Tidy_init() noexcept { // initialize basic_string data members
         _Mypair._Myval2._Mysize = 0;
         _Mypair._Myval2._Myres  = _BUF_SIZE - 1;
-        // the _Traits::assign is last so the codegen doesn't think the char
-        // write can alias this
+        // the _Traits::assign is last so the codegen doesn't think the char write can alias this
         _Traits::assign(_Mypair._Myval2._Bx._Buf[0], _Elem());
     }
 
@@ -4313,8 +4312,7 @@ private:
 
         _Mypair._Myval2._Mysize = 0;
         _Mypair._Myval2._Myres  = _BUF_SIZE - 1;
-        // the _Traits::assign is last so the codegen doesn't think the char
-        // write can alias this
+        // the _Traits::assign is last so the codegen doesn't think the char write can alias this
         _Traits::assign(_Mypair._Myval2._Bx._Buf[0], _Elem());
     }
 

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -5580,18 +5580,17 @@ template <class _Ty, enable_if_t<_Is_trivially_swappable_v<_Ty>, int> = 0>
 _CONSTEXPR20 _Ty* _Swap_ranges_unchecked(_Ty* _First1, _Ty* const _Last1, _Ty* _First2) {
     // swap [_First1, _Last1) with [_First2, ...), trivially swappable optimization
 #ifdef __cpp_lib_is_constant_evaluated
-    if (!_STD is_constant_evaluated())
+    if (_STD is_constant_evaluated()) {
+        for (; _First1 != _Last1; ++_First1, (void) ++_First2) {
+            _STD iter_swap(_First1, _First2);
+        }
+
+        return _First2;
+    }
 #endif // __cpp_lib_is_constant_evaluated
-    {
-        __std_swap_ranges_trivially_swappable_noalias(_First1, _Last1, _First2);
-        return _First2 + (_Last1 - _First1);
-    }
 
-    for (; _First1 != _Last1; ++_First1, (void) ++_First2) {
-        _STD iter_swap(_First1, _First2);
-    }
-
-    return _First2;
+    __std_swap_ranges_trivially_swappable_noalias(_First1, _Last1, _First2);
+    return _First2 + (_Last1 - _First1);
 }
 #endif // _USE_STD_VECTOR_ALGORITHMS
 

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -332,6 +332,8 @@
 // that certain type trait specializations have the standard-mandated semantics
 #ifndef __has_cpp_attribute
 #define _MSVC_KNOWN_SEMANTICS
+#elif defined(__CUDACC__) // TRANSITION, CUDA - warning: attribute namespace "msvc" is unrecognized
+#define _MSVC_KNOWN_SEMANTICS
 #elif __has_cpp_attribute(msvc::known_semantics)
 #define _MSVC_KNOWN_SEMANTICS [[msvc::known_semantics]]
 #else


### PR DESCRIPTION
`<random>`
This was defining a doubly-nested `struct _Noinit`, shadowing the STL-wide machinery that we should have been using:
https://github.com/microsoft/STL/blob/f0f0b55d57e2c9b9da5206b7dbdd71f17e7a0ee3/stl/inc/yvals.h#L311-L313

`<istream>`
Rename `bool _Noinit` to `_Skip_init`, avoiding more shadowing.

`<yvals_core.h>`
CUDA 9.2 was activating `__has_cpp_attribute(msvc::known_semantics)` yet emitting `warning: attribute namespace "msvc" is unrecognized`. I've added a TRANSITION workaround.

`<memory>`
We were unconditionally using `__declspec(empty_bases)`, causing CUDA 9.2 to emit `error: unknown attribute "empty_bases"`. @CaseyCarter noticed that this had no effect (only one base can possibly be empty here), so we can simply remove `__declspec(empty_bases)`. (These control blocks are new to VS 2019 16.7, so this is extra safe.)

`<string>`
CUDA 9.2 was emitting a valid `warning: pointless comparison of unsigned integer with zero`. Because it doesn't support `if constexpr`, I've added a separate function, marked TRANSITION. Note for the perceptive: I left `// can hold -2^63 and 2^64 - 1, plus NUL` unchanged in the original function so we can restore it easily.

`<xlocmon>`
CUDA 9.2 noticed bogus code here - we `static_cast<size_t>` the `int` return value of `sprintf_s`, so `if (_Count < 0)` was always false!

`<xutility>`
CUDA 9.2 correctly complained about unreachable code here. I've adjusted the preprocessor/control flow to be simpler. This is a permanent improvement, not TRANSITION.

`<xstring>`
Unwrap two comments.

`<xlocmon>`
`<xlocnum>`
Avoid `&_Src[sizeof(_Src)]` and `&_Buf[_Count]`. (The former technically performs a forbidden dereferencing; the latter can too, depending on the value of `_Count`.) I considered using `_Src, _Src + sizeof(_Src)`, but figured the throughput/debug codegen of `begin/end` was acceptable in iostreams.