### PR TITLE
Change most libc++ SKIPs to FAILs

### DIFF
--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -4,7 +4,7 @@
 # *** ISSUES REPORTED/KNOWN UPSTREAM ***
 # Non-Standard regex behavior.
 # "It seems likely that the test is still non-conforming due to how libc++ handles the 'w' character class."
-std/re/re.traits/lookup_classname.pass.cpp SKIPPED
+std/re/re.traits/lookup_classname.pass.cpp FAIL
 
 # These tests are extremely slow, taking over 23 minutes to execute (in debug mode, non-optimized).
 # They contain 10K^2 / 2 == 50M loops.
@@ -12,47 +12,53 @@ std/input.output/iostreams.base/ios.base/ios.base.storage/iword.pass.cpp SKIPPED
 std/input.output/iostreams.base/ios.base/ios.base.storage/pword.pass.cpp SKIPPED
 
 # "The behavior demonstrated in this test is not meant to be standard"
-std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/null.pass.cpp SKIPPED
+std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.ctor/null.pass.cpp FAIL
 
 # allocator<const T>.
-std/utilities/memory/default.allocator/allocator.ctor.pass.cpp SKIPPED
+std/utilities/memory/default.allocator/allocator.ctor.pass.cpp FAIL
 
 # path::value_type is char assumptions
-std/input.output/file.streams/fstreams/filebuf.members/open_path.pass.cpp SKIPPED
-std/input.output/file.streams/fstreams/fstream.cons/path.pass.cpp SKIPPED
-std/input.output/file.streams/fstreams/fstream.members/open_path.pass.cpp SKIPPED
-std/input.output/file.streams/fstreams/ofstream.cons/path.pass.cpp SKIPPED
-std/input.output/file.streams/fstreams/ofstream.members/open_path.pass.cpp SKIPPED
+std/input.output/file.streams/fstreams/filebuf.members/open_path.pass.cpp FAIL
+std/input.output/file.streams/fstreams/fstream.cons/path.pass.cpp FAIL
+std/input.output/file.streams/fstreams/fstream.members/open_path.pass.cpp FAIL
+std/input.output/file.streams/fstreams/ofstream.cons/path.pass.cpp FAIL
+std/input.output/file.streams/fstreams/ofstream.members/open_path.pass.cpp FAIL
 
 # This test is passing non-BidirectionalIterators to std::prev.
 # LWG-3197 "std::prev should not require BidirectionalIterator" (New)
-std/iterators/iterator.primitives/iterator.operations/prev.pass.cpp SKIPPED
+std/iterators/iterator.primitives/iterator.operations/prev.pass.cpp FAIL
 
 # Itanium ABI assumptions that current_exception and rethrow_exception don't copy the exception object
-std/language.support/support.exception/propagation/current_exception.pass.cpp SKIPPED
-std/language.support/support.exception/propagation/make_exception_ptr.pass.cpp SKIPPED
-std/language.support/support.exception/propagation/rethrow_exception.pass.cpp SKIPPED
-std/language.support/support.exception/except.nested/rethrow_if_nested.pass.cpp SKIPPED
+std/language.support/support.exception/propagation/current_exception.pass.cpp FAIL
+std/language.support/support.exception/propagation/make_exception_ptr.pass.cpp FAIL
+std/language.support/support.exception/propagation/rethrow_exception.pass.cpp FAIL
+std/language.support/support.exception/except.nested/rethrow_if_nested.pass.cpp FAIL
 
 # Testing nonstandard behavior
-std/utilities/template.bitset/bitset.cons/string_ctor.pass.cpp SKIPPED
+std/utilities/template.bitset/bitset.cons/string_ctor.pass.cpp FAIL
 
 # This test has undefined behavior under N4842 [basic.start.term]/6
 std/thread/futures/futures.task/futures.task.members/dtor.pass.cpp SKIPPED
 
 # libcxx is incorrect on what the type passed to allocator construct should be
 # See https://reviews.llvm.org/D61364
-std/containers/associative/map/map.modifiers/insert_and_emplace_allocator_requirements.pass.cpp SKIPPED
-std/containers/associative/set/insert_and_emplace_allocator_requirements.pass.cpp SKIPPED
-std/containers/unord/unord.map/unord.map.modifiers/insert_and_emplace_allocator_requirements.pass.cpp SKIPPED
-std/containers/unord/unord.set/insert_and_emplace_allocator_requirements.pass.cpp SKIPPED
+std/containers/associative/map/map.modifiers/insert_and_emplace_allocator_requirements.pass.cpp FAIL
+std/containers/associative/set/insert_and_emplace_allocator_requirements.pass.cpp FAIL
+std/containers/unord/unord.map/unord.map.modifiers/insert_and_emplace_allocator_requirements.pass.cpp FAIL
+std/containers/unord/unord.set/insert_and_emplace_allocator_requirements.pass.cpp FAIL
 
-# libcxx doesn't yet implement P1423R3, so it expects an "old" value for __cpp_lib_char8_t
-std/language.support/support.limits/support.limits.general/filesystem.version.pass.cpp SKIPPED
-std/language.support/support.limits/support.limits.general/istream.version.pass.cpp SKIPPED
-std/language.support/support.limits/support.limits.general/limits.version.pass.cpp SKIPPED
-std/language.support/support.limits/support.limits.general/locale.version.pass.cpp SKIPPED
-std/language.support/support.limits/support.limits.general/ostream.version.pass.cpp SKIPPED
+# libc++ doesn't yet implement P1423R3, so it expects an old value for `__cpp_lib_char8_t`
+std/language.support/support.limits/support.limits.general/filesystem.version.pass.cpp FAIL
+std/language.support/support.limits/support.limits.general/istream.version.pass.cpp FAIL
+std/language.support/support.limits/support.limits.general/limits.version.pass.cpp FAIL
+std/language.support/support.limits/support.limits.general/locale.version.pass.cpp FAIL
+std/language.support/support.limits/support.limits.general/ostream.version.pass.cpp FAIL
+
+# libc++ doesn't yet implement P1956R1, so it expects the old names `ispow2`, `ceil2`, `floor2`, and `log2p1`
+std/numerics/bit/bit.pow.two/ceil2.pass.cpp FAIL
+std/numerics/bit/bit.pow.two/floor2.pass.cpp FAIL
+std/numerics/bit/bit.pow.two/ispow2.pass.cpp FAIL
+std/numerics/bit/bit.pow.two/log2p1.pass.cpp FAIL
 
 
 # *** INTERACTIONS WITH CONTEST / C1XX THAT UPSTREAM LIKELY WON'T FIX ***
@@ -175,18 +181,18 @@ std/input.output/filesystems/fs.op.funcs/fs.op.temp_dir_path/temp_directory_path
 std/input.output/filesystems/fs.op.funcs/fs.op.weakly_canonical/weakly_canonical.pass.cpp SKIPPED
 
 # generate_feature_test_macro_components.py needs to learn about C1XX
-std/language.support/support.limits/support.limits.general/type_traits.version.pass.cpp SKIPPED
-std/language.support/support.limits/support.limits.general/version.version.pass.cpp SKIPPED
+std/language.support/support.limits/support.limits.general/type_traits.version.pass.cpp:0 FAIL
+std/language.support/support.limits/support.limits.general/version.version.pass.cpp FAIL
 
 # Contest does not understand .sh tests, which must be run specially
 std/thread/thread.condition/thread.condition.condvarany/wait_terminates.sh.cpp SKIPPED
 
 # These tests set an allocator with a max_size() too small to default construct an unordered container
 # (due to our minimum bucket size).
-std/containers/unord/unord.map/max_size.pass.cpp SKIPPED
-std/containers/unord/unord.multimap/max_size.pass.cpp SKIPPED
-std/containers/unord/unord.multiset/max_size.pass.cpp SKIPPED
-std/containers/unord/unord.set/max_size.pass.cpp SKIPPED
+std/containers/unord/unord.map/max_size.pass.cpp FAIL
+std/containers/unord/unord.multimap/max_size.pass.cpp FAIL
+std/containers/unord/unord.multiset/max_size.pass.cpp FAIL
+std/containers/unord/unord.set/max_size.pass.cpp FAIL
 
 # Requires too great a template instantiation depth for C1XX.
 std/utilities/tuple/tuple.tuple/tuple.apply/apply_large_arity.pass.cpp SKIPPED
@@ -243,290 +249,281 @@ std/utilities/memory/default.allocator/allocator.members/allocate.verify.cpp SKI
 
 # *** MISSING STL FEATURES ***
 # C++20 P0019R8 "atomic_ref"
-std/language.support/support.limits/support.limits.general/atomic.version.pass.cpp SKIPPED
+std/language.support/support.limits/support.limits.general/atomic.version.pass.cpp FAIL
 
 # C++20 P0355R7 "<chrono> Calendars And Time Zones"
-std/utilities/time/days.pass.cpp SKIPPED
-std/utilities/time/months.pass.cpp SKIPPED
-std/utilities/time/weeks.pass.cpp SKIPPED
-std/utilities/time/years.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.day/types.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.day/time.cal.day.members/ctor.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.day/time.cal.day.members/decrement.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.day/time.cal.day.members/increment.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.day/time.cal.day.members/ok.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.day/time.cal.day.members/plus_minus_equal.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.day/time.cal.day.nonmembers/comparisons.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.day/time.cal.day.nonmembers/literals.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.day/time.cal.day.nonmembers/minus.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.day/time.cal.day.nonmembers/plus.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.day/time.cal.day.nonmembers/streaming.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.last/types.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.md/types.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.md/time.cal.md.members/ctor.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.md/time.cal.md.members/day.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.md/time.cal.md.members/month.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.md/time.cal.md.members/ok.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.md/time.cal.md.nonmembers/comparisons.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.md/time.cal.md.nonmembers/streaming.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.mdlast/comparisons.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.mdlast/ctor.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.mdlast/month.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.mdlast/ok.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.mdlast/streaming.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.mdlast/types.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.month/types.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.month/time.cal.month.members/ctor.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.month/time.cal.month.members/decrement.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.month/time.cal.month.members/increment.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.month/time.cal.month.members/ok.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.month/time.cal.month.members/plus_minus_equal.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.month/time.cal.month.nonmembers/comparisons.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.month/time.cal.month.nonmembers/literals.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.month/time.cal.month.nonmembers/minus.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.month/time.cal.month.nonmembers/plus.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.month/time.cal.month.nonmembers/streaming.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.mwd/types.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.mwd/time.cal.mwd.members/ctor.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.mwd/time.cal.mwd.members/month.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.mwd/time.cal.mwd.members/ok.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.mwd/time.cal.mwd.members/weekday_indexed.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.mwd/time.cal.mwd.nonmembers/comparisons.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.mwd/time.cal.mwd.nonmembers/streaming.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.mwdlast/types.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.mwdlast/time.cal.mwdlast.members/ctor.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.mwdlast/time.cal.mwdlast.members/month.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.mwdlast/time.cal.mwdlast.members/ok.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.mwdlast/time.cal.mwdlast.members/weekday_last.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.mwdlast/time.cal.mwdlast.nonmembers/comparisons.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.mwdlast/time.cal.mwdlast.nonmembers/streaming.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.operators/month_day.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.operators/month_day_last.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.operators/month_weekday.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.operators/month_weekday_last.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.operators/year_month.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.operators/year_month_day.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.operators/year_month_day_last.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.operators/year_month_weekday.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.operators/year_month_weekday_last.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.wdidx/types.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.wdidx/time.cal.wdidx.members/ctor.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.wdidx/time.cal.wdidx.members/index.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.wdidx/time.cal.wdidx.members/ok.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.wdidx/time.cal.wdidx.members/weekday.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.wdidx/time.cal.wdidx.nonmembers/comparisons.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.wdidx/time.cal.wdidx.nonmembers/streaming.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.wdlast/types.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.wdlast/time.cal.wdlast.members/ctor.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.wdlast/time.cal.wdlast.members/ok.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.wdlast/time.cal.wdlast.members/weekday.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.wdlast/time.cal.wdlast.nonmembers/comparisons.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.wdlast/time.cal.wdlast.nonmembers/streaming.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.weekday/types.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.members/c_encoding.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.members/ctor.local_days.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.members/ctor.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.members/ctor.sys_days.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.members/decrement.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.members/increment.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.members/iso_encoding.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.members/ok.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.members/operator[].pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.members/plus_minus_equal.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.nonmembers/comparisons.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.nonmembers/literals.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.nonmembers/minus.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.nonmembers/plus.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.nonmembers/streaming.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.year/types.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.year/time.cal.year.members/ctor.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.year/time.cal.year.members/decrement.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.year/time.cal.year.members/increment.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.year/time.cal.year.members/is_leap.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.year/time.cal.year.members/ok.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.year/time.cal.year.members/plus_minus.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.year/time.cal.year.members/plus_minus_equal.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.year/time.cal.year.nonmembers/comparisons.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.year/time.cal.year.nonmembers/literals.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.year/time.cal.year.nonmembers/minus.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.year/time.cal.year.nonmembers/plus.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.year/time.cal.year.nonmembers/streaming.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ym/types.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ym/time.cal.ym.members/ctor.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ym/time.cal.ym.members/month.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ym/time.cal.ym.members/ok.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ym/time.cal.ym.members/plus_minus_equal_month.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ym/time.cal.ym.members/plus_minus_equal_year.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ym/time.cal.ym.members/year.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ym/time.cal.ym.nonmembers/comparisons.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ym/time.cal.ym.nonmembers/minus.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ym/time.cal.ym.nonmembers/plus.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ym/time.cal.ym.nonmembers/streaming.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ymd/types.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.members/ctor.local_days.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.members/ctor.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.members/ctor.sys_days.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.members/ctor.year_month_day_last.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.members/day.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.members/month.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.members/ok.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.members/op.local_days.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.members/op.sys_days.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.members/plus_minus_equal_month.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.members/plus_minus_equal_year.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.members/year.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.nonmembers/comparisons.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.nonmembers/minus.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.nonmembers/plus.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.nonmembers/streaming.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.members/ctor.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.members/day.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.members/month.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.members/month_day_last.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.members/ok.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.members/op_local_days.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.members/op_sys_days.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.members/plus_minus_equal_month.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.members/plus_minus_equal_year.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.members/year.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.nonmembers/comparisons.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.nonmembers/minus.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.nonmembers/plus.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.nonmembers/streaming.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ymwd/types.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/ctor.local_days.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/ctor.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/ctor.sys_days.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/index.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/month.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/ok.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/op.local_days.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/op.sys_days.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/plus_minus_equal_month.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/plus_minus_equal_year.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/weekday.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/weekday_indexed.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/year.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.nonmembers/comparisons.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.nonmembers/minus.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.nonmembers/plus.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.nonmembers/streaming.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ymwdlast/types.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.members/ctor.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.members/month.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.members/ok.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.members/op_local_days.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.members/op_sys_days.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.members/plus_minus_equal_month.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.members/plus_minus_equal_year.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.members/weekday.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.members/year.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.nonmembers/comparisons.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.nonmembers/minus.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.nonmembers/plus.pass.cpp SKIPPED
-std/utilities/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.nonmembers/streaming.pass.cpp SKIPPED
-std/utilities/time/time.clock/time.clock.file/consistency.pass.cpp SKIPPED
-std/utilities/time/time.clock/time.clock.file/file_time.pass.cpp SKIPPED
-std/utilities/time/time.clock/time.clock.file/now.pass.cpp SKIPPED
-std/utilities/time/time.clock/time.clock.file/rep_signed.pass.cpp SKIPPED
-std/utilities/time/time.clock/time.clock.system/local_time.types.pass.cpp SKIPPED
-std/utilities/time/time.clock/time.clock.system/sys.time.types.pass.cpp SKIPPED
-std/utilities/time/time.duration/time.duration.literals/literals1.pass.cpp SKIPPED
-std/utilities/time/time.hms/time.12/is_am.pass.cpp SKIPPED
-std/utilities/time/time.hms/time.12/is_pm.pass.cpp SKIPPED
-std/utilities/time/time.hms/time.12/make12.pass.cpp SKIPPED
-std/utilities/time/time.hms/time.12/make24.pass.cpp SKIPPED
-std/utilities/time/time.hms/time.hms.members/hours.pass.cpp SKIPPED
-std/utilities/time/time.hms/time.hms.members/is_negative.pass.cpp SKIPPED
-std/utilities/time/time.hms/time.hms.members/minutes.pass.cpp SKIPPED
-std/utilities/time/time.hms/time.hms.members/precision.pass.cpp SKIPPED
-std/utilities/time/time.hms/time.hms.members/precision_type.pass.cpp SKIPPED
-std/utilities/time/time.hms/time.hms.members/seconds.pass.cpp SKIPPED
-std/utilities/time/time.hms/time.hms.members/subseconds.pass.cpp SKIPPED
-std/utilities/time/time.hms/time.hms.members/to_duration.pass.cpp SKIPPED
-std/utilities/time/time.hms/time.hms.members/width.pass.cpp SKIPPED
-
-# C++20 P0476R2 "<bit> bit_cast"
-std/language.support/support.limits/support.limits.general/bit.version.pass.cpp SKIPPED
+std/utilities/time/days.pass.cpp FAIL
+std/utilities/time/months.pass.cpp FAIL
+std/utilities/time/weeks.pass.cpp FAIL
+std/utilities/time/years.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.day/types.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.day/time.cal.day.members/ctor.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.day/time.cal.day.members/decrement.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.day/time.cal.day.members/increment.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.day/time.cal.day.members/ok.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.day/time.cal.day.members/plus_minus_equal.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.day/time.cal.day.nonmembers/comparisons.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.day/time.cal.day.nonmembers/literals.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.day/time.cal.day.nonmembers/minus.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.day/time.cal.day.nonmembers/plus.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.day/time.cal.day.nonmembers/streaming.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.last/types.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.md/types.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.md/time.cal.md.members/ctor.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.md/time.cal.md.members/day.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.md/time.cal.md.members/month.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.md/time.cal.md.members/ok.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.md/time.cal.md.nonmembers/comparisons.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.md/time.cal.md.nonmembers/streaming.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.mdlast/comparisons.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.mdlast/ctor.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.mdlast/month.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.mdlast/ok.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.mdlast/streaming.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.mdlast/types.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.month/types.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.month/time.cal.month.members/ctor.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.month/time.cal.month.members/decrement.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.month/time.cal.month.members/increment.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.month/time.cal.month.members/ok.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.month/time.cal.month.members/plus_minus_equal.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.month/time.cal.month.nonmembers/comparisons.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.month/time.cal.month.nonmembers/literals.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.month/time.cal.month.nonmembers/minus.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.month/time.cal.month.nonmembers/plus.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.month/time.cal.month.nonmembers/streaming.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.mwd/types.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.mwd/time.cal.mwd.members/ctor.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.mwd/time.cal.mwd.members/month.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.mwd/time.cal.mwd.members/ok.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.mwd/time.cal.mwd.members/weekday_indexed.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.mwd/time.cal.mwd.nonmembers/comparisons.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.mwd/time.cal.mwd.nonmembers/streaming.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.mwdlast/types.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.mwdlast/time.cal.mwdlast.members/ctor.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.mwdlast/time.cal.mwdlast.members/month.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.mwdlast/time.cal.mwdlast.members/ok.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.mwdlast/time.cal.mwdlast.members/weekday_last.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.mwdlast/time.cal.mwdlast.nonmembers/comparisons.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.mwdlast/time.cal.mwdlast.nonmembers/streaming.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.operators/month_day.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.operators/month_day_last.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.operators/month_weekday.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.operators/month_weekday_last.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.operators/year_month.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.operators/year_month_day.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.operators/year_month_day_last.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.operators/year_month_weekday.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.operators/year_month_weekday_last.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.wdidx/types.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.wdidx/time.cal.wdidx.members/ctor.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.wdidx/time.cal.wdidx.members/index.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.wdidx/time.cal.wdidx.members/ok.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.wdidx/time.cal.wdidx.members/weekday.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.wdidx/time.cal.wdidx.nonmembers/comparisons.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.wdidx/time.cal.wdidx.nonmembers/streaming.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.wdlast/types.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.wdlast/time.cal.wdlast.members/ctor.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.wdlast/time.cal.wdlast.members/ok.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.wdlast/time.cal.wdlast.members/weekday.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.wdlast/time.cal.wdlast.nonmembers/comparisons.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.wdlast/time.cal.wdlast.nonmembers/streaming.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.weekday/types.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.members/c_encoding.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.members/ctor.local_days.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.members/ctor.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.members/ctor.sys_days.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.members/decrement.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.members/increment.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.members/iso_encoding.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.members/ok.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.members/operator[].pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.members/plus_minus_equal.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.nonmembers/comparisons.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.nonmembers/literals.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.nonmembers/minus.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.nonmembers/plus.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.nonmembers/streaming.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.year/types.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.year/time.cal.year.members/ctor.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.year/time.cal.year.members/decrement.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.year/time.cal.year.members/increment.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.year/time.cal.year.members/is_leap.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.year/time.cal.year.members/ok.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.year/time.cal.year.members/plus_minus.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.year/time.cal.year.members/plus_minus_equal.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.year/time.cal.year.nonmembers/comparisons.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.year/time.cal.year.nonmembers/literals.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.year/time.cal.year.nonmembers/minus.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.year/time.cal.year.nonmembers/plus.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.year/time.cal.year.nonmembers/streaming.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ym/types.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ym/time.cal.ym.members/ctor.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ym/time.cal.ym.members/month.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ym/time.cal.ym.members/ok.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ym/time.cal.ym.members/plus_minus_equal_month.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ym/time.cal.ym.members/plus_minus_equal_year.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ym/time.cal.ym.members/year.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ym/time.cal.ym.nonmembers/comparisons.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ym/time.cal.ym.nonmembers/minus.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ym/time.cal.ym.nonmembers/plus.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ym/time.cal.ym.nonmembers/streaming.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ymd/types.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.members/ctor.local_days.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.members/ctor.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.members/ctor.sys_days.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.members/ctor.year_month_day_last.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.members/day.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.members/month.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.members/ok.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.members/op.local_days.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.members/op.sys_days.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.members/plus_minus_equal_month.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.members/plus_minus_equal_year.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.members/year.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.nonmembers/comparisons.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.nonmembers/minus.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.nonmembers/plus.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.nonmembers/streaming.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.members/ctor.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.members/day.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.members/month.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.members/month_day_last.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.members/ok.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.members/op_local_days.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.members/op_sys_days.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.members/plus_minus_equal_month.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.members/plus_minus_equal_year.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.members/year.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.nonmembers/comparisons.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.nonmembers/minus.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.nonmembers/plus.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.nonmembers/streaming.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ymwd/types.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/ctor.local_days.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/ctor.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/ctor.sys_days.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/index.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/month.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/ok.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/op.local_days.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/op.sys_days.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/plus_minus_equal_month.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/plus_minus_equal_year.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/weekday.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/weekday_indexed.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.members/year.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.nonmembers/comparisons.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.nonmembers/minus.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.nonmembers/plus.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.nonmembers/streaming.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ymwdlast/types.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.members/ctor.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.members/month.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.members/ok.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.members/op_local_days.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.members/op_sys_days.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.members/plus_minus_equal_month.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.members/plus_minus_equal_year.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.members/weekday.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.members/year.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.nonmembers/comparisons.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.nonmembers/minus.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.nonmembers/plus.pass.cpp FAIL
+std/utilities/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.nonmembers/streaming.pass.cpp FAIL
+std/utilities/time/time.clock/time.clock.file/consistency.pass.cpp FAIL
+std/utilities/time/time.clock/time.clock.file/file_time.pass.cpp FAIL
+std/utilities/time/time.clock/time.clock.file/now.pass.cpp FAIL
+std/utilities/time/time.clock/time.clock.file/rep_signed.pass.cpp FAIL
+std/utilities/time/time.clock/time.clock.system/local_time.types.pass.cpp FAIL
+std/utilities/time/time.clock/time.clock.system/sys.time.types.pass.cpp FAIL
+std/utilities/time/time.duration/time.duration.literals/literals1.pass.cpp FAIL
+std/utilities/time/time.hms/time.12/is_am.pass.cpp FAIL
+std/utilities/time/time.hms/time.12/is_pm.pass.cpp FAIL
+std/utilities/time/time.hms/time.12/make12.pass.cpp FAIL
+std/utilities/time/time.hms/time.12/make24.pass.cpp FAIL
+std/utilities/time/time.hms/time.hms.members/hours.pass.cpp FAIL
+std/utilities/time/time.hms/time.hms.members/is_negative.pass.cpp FAIL
+std/utilities/time/time.hms/time.hms.members/minutes.pass.cpp FAIL
+std/utilities/time/time.hms/time.hms.members/precision.pass.cpp FAIL
+std/utilities/time/time.hms/time.hms.members/precision_type.pass.cpp FAIL
+std/utilities/time/time.hms/time.hms.members/seconds.pass.cpp FAIL
+std/utilities/time/time.hms/time.hms.members/subseconds.pass.cpp FAIL
+std/utilities/time/time.hms/time.hms.members/to_duration.pass.cpp FAIL
+std/utilities/time/time.hms/time.hms.members/width.pass.cpp FAIL
 
 # C++20 P0553R4 "<bit> Rotating And Counting Functions"
-std/numerics/bit/bitops.count/countl_one.pass.cpp SKIPPED
-std/numerics/bit/bitops.count/countl_zero.pass.cpp SKIPPED
-std/numerics/bit/bitops.count/countr_one.pass.cpp SKIPPED
-std/numerics/bit/bitops.count/countr_zero.pass.cpp SKIPPED
-std/numerics/bit/bitops.count/popcount.pass.cpp SKIPPED
-std/numerics/bit/bitops.rot/rotl.pass.cpp SKIPPED
-std/numerics/bit/bitops.rot/rotr.pass.cpp SKIPPED
-
-# C++20 P0556R3 "<bit> ispow2(), ceil2(), floor2(), log2p1()"
-std/numerics/bit/bit.pow.two/ceil2.pass.cpp SKIPPED
-std/numerics/bit/bit.pow.two/floor2.pass.cpp SKIPPED
-std/numerics/bit/bit.pow.two/ispow2.pass.cpp SKIPPED
-std/numerics/bit/bit.pow.two/log2p1.pass.cpp SKIPPED
+std/numerics/bit/bitops.count/countl_one.pass.cpp:0 FAIL
+std/numerics/bit/bitops.count/countl_zero.pass.cpp:0 FAIL
+std/numerics/bit/bitops.count/countr_one.pass.cpp:0 FAIL
+std/numerics/bit/bitops.count/countr_zero.pass.cpp:0 FAIL
+std/numerics/bit/bitops.count/popcount.pass.cpp:0 FAIL
+std/numerics/bit/bitops.rot/rotl.pass.cpp:0 FAIL
+std/numerics/bit/bitops.rot/rotr.pass.cpp:0 FAIL
 
 # C++20 P0608R3 "Improving variant's Converting Constructor/Assignment"
-std/utilities/variant/variant.variant/variant.assign/conv.pass.cpp SKIPPED
-std/utilities/variant/variant.variant/variant.assign/T.pass.cpp SKIPPED
-std/utilities/variant/variant.variant/variant.ctor/conv.pass.cpp SKIPPED
-std/utilities/variant/variant.variant/variant.ctor/T.pass.cpp SKIPPED
+std/utilities/variant/variant.variant/variant.assign/conv.pass.cpp FAIL
+std/utilities/variant/variant.variant/variant.assign/T.pass.cpp FAIL
+std/utilities/variant/variant.variant/variant.ctor/conv.pass.cpp FAIL
+std/utilities/variant/variant.variant/variant.ctor/T.pass.cpp FAIL
 
 # C++20 P0768R1 "Library Support for the Spaceship (Comparison) Operator"
-std/language.support/support.limits/support.limits.general/compare.version.pass.cpp SKIPPED
+std/language.support/support.limits/support.limits.general/compare.version.pass.cpp FAIL
 
 # C++20 P0811R2 "midpoint(), lerp()"
-std/language.support/support.limits/support.limits.general/numeric.version.pass.cpp SKIPPED
-std/numerics/c.math/c.math.lerp/c.math.lerp.pass.cpp SKIPPED
+std/language.support/support.limits/support.limits.general/numeric.version.pass.cpp FAIL
+std/numerics/c.math/c.math.lerp/c.math.lerp.pass.cpp FAIL
 
 # C++20 P0896R4 "<ranges>"
-std/language.support/support.limits/support.limits.general/algorithm.version.pass.cpp SKIPPED
-std/language.support/support.limits/support.limits.general/functional.version.pass.cpp SKIPPED
-std/language.support/support.limits/support.limits.general/iterator.version.pass.cpp SKIPPED
-std/language.support/support.limits/support.limits.general/memory.version.pass.cpp SKIPPED
+std/language.support/support.limits/support.limits.general/algorithm.version.pass.cpp FAIL
+std/language.support/support.limits/support.limits.general/functional.version.pass.cpp FAIL
+std/language.support/support.limits/support.limits.general/iterator.version.pass.cpp FAIL
+std/language.support/support.limits/support.limits.general/memory.version.pass.cpp FAIL
 
 # C++20 P1032R1 "Miscellaneous constexpr"
-std/language.support/support.limits/support.limits.general/array.version.pass.cpp SKIPPED
-std/language.support/support.limits/support.limits.general/functional.version.pass.cpp SKIPPED
-std/language.support/support.limits/support.limits.general/iterator.version.pass.cpp SKIPPED
-std/language.support/support.limits/support.limits.general/string_view.version.pass.cpp SKIPPED
-std/language.support/support.limits/support.limits.general/tuple.version.pass.cpp SKIPPED
-std/language.support/support.limits/support.limits.general/utility.version.pass.cpp SKIPPED
-std/strings/char.traits/char.traits.specializations/char.traits.specializations.char/assign3.pass.cpp SKIPPED
-std/strings/char.traits/char.traits.specializations/char.traits.specializations.char/copy.pass.cpp SKIPPED
-std/strings/char.traits/char.traits.specializations/char.traits.specializations.char/move.pass.cpp SKIPPED
-std/strings/char.traits/char.traits.specializations/char.traits.specializations.char16_t/assign3.pass.cpp SKIPPED
-std/strings/char.traits/char.traits.specializations/char.traits.specializations.char16_t/copy.pass.cpp SKIPPED
-std/strings/char.traits/char.traits.specializations/char.traits.specializations.char16_t/move.pass.cpp SKIPPED
-std/strings/char.traits/char.traits.specializations/char.traits.specializations.char32_t/assign3.pass.cpp SKIPPED
-std/strings/char.traits/char.traits.specializations/char.traits.specializations.char32_t/copy.pass.cpp SKIPPED
-std/strings/char.traits/char.traits.specializations/char.traits.specializations.char32_t/move.pass.cpp SKIPPED
-std/strings/char.traits/char.traits.specializations/char.traits.specializations.char8_t/assign3.pass.cpp SKIPPED
-std/strings/char.traits/char.traits.specializations/char.traits.specializations.char8_t/copy.pass.cpp SKIPPED
-std/strings/char.traits/char.traits.specializations/char.traits.specializations.char8_t/move.pass.cpp SKIPPED
-std/strings/char.traits/char.traits.specializations/char.traits.specializations.wchar.t/assign3.pass.cpp SKIPPED
-std/strings/char.traits/char.traits.specializations/char.traits.specializations.wchar.t/copy.pass.cpp SKIPPED
-std/strings/char.traits/char.traits.specializations/char.traits.specializations.wchar.t/move.pass.cpp SKIPPED
+std/language.support/support.limits/support.limits.general/array.version.pass.cpp FAIL
+std/language.support/support.limits/support.limits.general/functional.version.pass.cpp FAIL
+std/language.support/support.limits/support.limits.general/iterator.version.pass.cpp FAIL
+std/language.support/support.limits/support.limits.general/string_view.version.pass.cpp FAIL
+std/language.support/support.limits/support.limits.general/tuple.version.pass.cpp FAIL
+std/language.support/support.limits/support.limits.general/utility.version.pass.cpp FAIL
+std/strings/char.traits/char.traits.specializations/char.traits.specializations.char/assign3.pass.cpp FAIL
+std/strings/char.traits/char.traits.specializations/char.traits.specializations.char/copy.pass.cpp FAIL
+std/strings/char.traits/char.traits.specializations/char.traits.specializations.char/move.pass.cpp FAIL
+std/strings/char.traits/char.traits.specializations/char.traits.specializations.char16_t/assign3.pass.cpp FAIL
+std/strings/char.traits/char.traits.specializations/char.traits.specializations.char16_t/copy.pass.cpp FAIL
+std/strings/char.traits/char.traits.specializations/char.traits.specializations.char16_t/move.pass.cpp FAIL
+std/strings/char.traits/char.traits.specializations/char.traits.specializations.char32_t/assign3.pass.cpp FAIL
+std/strings/char.traits/char.traits.specializations/char.traits.specializations.char32_t/copy.pass.cpp FAIL
+std/strings/char.traits/char.traits.specializations/char.traits.specializations.char32_t/move.pass.cpp FAIL
+std/strings/char.traits/char.traits.specializations/char.traits.specializations.char8_t/assign3.pass.cpp FAIL
+std/strings/char.traits/char.traits.specializations/char.traits.specializations.char8_t/copy.pass.cpp FAIL
+std/strings/char.traits/char.traits.specializations/char.traits.specializations.char8_t/move.pass.cpp FAIL
+std/strings/char.traits/char.traits.specializations/char.traits.specializations.wchar.t/assign3.pass.cpp FAIL
+std/strings/char.traits/char.traits.specializations/char.traits.specializations.wchar.t/copy.pass.cpp FAIL
+std/strings/char.traits/char.traits.specializations/char.traits.specializations.wchar.t/move.pass.cpp FAIL
 
 # C++20 P1135R6 "The C++20 Synchronization Library"
-std/atomics/types.pass.cpp SKIPPED
-std/atomics/atomics.types.operations/atomics.types.operations.wait/atomic_wait.pass.cpp SKIPPED
-std/thread/thread.barrier/arrive.pass.cpp SKIPPED
-std/thread/thread.barrier/arrive_and_drop.pass.cpp SKIPPED
-std/thread/thread.barrier/arrive_and_wait.pass.cpp SKIPPED
-std/thread/thread.barrier/completion.pass.cpp SKIPPED
-std/thread/thread.barrier/max.pass.cpp SKIPPED
-std/thread/thread.barrier/version.pass.cpp SKIPPED
-std/thread/thread.latch/arrive_and_wait.pass.cpp SKIPPED
-std/thread/thread.latch/count_down.pass.cpp SKIPPED
-std/thread/thread.latch/max.pass.cpp SKIPPED
-std/thread/thread.latch/try_wait.pass.cpp SKIPPED
-std/thread/thread.latch/version.pass.cpp SKIPPED
-std/thread/thread.semaphore/acquire.pass.cpp SKIPPED
-std/thread/thread.semaphore/binary.pass.cpp SKIPPED
-std/thread/thread.semaphore/max.pass.cpp SKIPPED
-std/thread/thread.semaphore/release.pass.cpp SKIPPED
-std/thread/thread.semaphore/timed.pass.cpp SKIPPED
-std/thread/thread.semaphore/try_acquire.pass.cpp SKIPPED
-std/thread/thread.semaphore/version.pass.cpp SKIPPED
+std/atomics/types.pass.cpp FAIL
+std/atomics/atomics.types.operations/atomics.types.operations.wait/atomic_wait.pass.cpp FAIL
+std/thread/thread.barrier/arrive.pass.cpp FAIL
+std/thread/thread.barrier/arrive_and_drop.pass.cpp FAIL
+std/thread/thread.barrier/arrive_and_wait.pass.cpp FAIL
+std/thread/thread.barrier/completion.pass.cpp FAIL
+std/thread/thread.barrier/max.pass.cpp FAIL
+std/thread/thread.barrier/version.pass.cpp FAIL
+std/thread/thread.latch/arrive_and_wait.pass.cpp FAIL
+std/thread/thread.latch/count_down.pass.cpp FAIL
+std/thread/thread.latch/max.pass.cpp FAIL
+std/thread/thread.latch/try_wait.pass.cpp FAIL
+std/thread/thread.latch/version.pass.cpp FAIL
+std/thread/thread.semaphore/acquire.pass.cpp FAIL
+std/thread/thread.semaphore/binary.pass.cpp FAIL
+std/thread/thread.semaphore/max.pass.cpp FAIL
+std/thread/thread.semaphore/release.pass.cpp FAIL
+std/thread/thread.semaphore/timed.pass.cpp FAIL
+std/thread/thread.semaphore/try_acquire.pass.cpp FAIL
+std/thread/thread.semaphore/version.pass.cpp FAIL
 
 
 # *** MISSING COMPILER FEATURES ***
@@ -538,43 +535,43 @@ std/language.support/support.dynamic/destroying_delete_t.pass.cpp:0 SKIPPED
 # *** MISSING LWG ISSUE RESOLUTIONS ***
 # LWG-2532 "Satisfying a promise at thread exit" (Open)
 # WCFB02 implements the proposed resolution for this issue
-std/thread/futures/futures.promise/set_exception_at_thread_exit.pass.cpp SKIPPED
-std/thread/futures/futures.promise/set_lvalue_at_thread_exit.pass.cpp SKIPPED
-std/thread/futures/futures.promise/set_rvalue_at_thread_exit.pass.cpp SKIPPED
-std/thread/futures/futures.promise/set_value_at_thread_exit_const.pass.cpp SKIPPED
-std/thread/futures/futures.promise/set_value_at_thread_exit_void.pass.cpp SKIPPED
-std/thread/futures/futures.task/futures.task.members/make_ready_at_thread_exit.pass.cpp SKIPPED
+std/thread/futures/futures.promise/set_exception_at_thread_exit.pass.cpp FAIL
+std/thread/futures/futures.promise/set_lvalue_at_thread_exit.pass.cpp FAIL
+std/thread/futures/futures.promise/set_rvalue_at_thread_exit.pass.cpp FAIL
+std/thread/futures/futures.promise/set_value_at_thread_exit_const.pass.cpp FAIL
+std/thread/futures/futures.promise/set_value_at_thread_exit_void.pass.cpp FAIL
+std/thread/futures/futures.task/futures.task.members/make_ready_at_thread_exit.pass.cpp FAIL
 
 
 # *** C1XX COMPILER BUGS ***
-# Compiler bug: VSO-120957 "alignas by-value parameters should be permitted"
-std/utilities/meta/meta.trans/meta.trans.other/aligned_storage.pass.cpp SKIPPED
-
 # Compiler bug: VSO-106654 "error C2580 "multiple versions of a defaulted special member functions are not allowed" is bogus and ungrammatical"
-std/utilities/tuple/tuple.tuple/tuple.cnstr/test_lazy_sfinae.pass.cpp:0 SKIPPED
+std/utilities/tuple/tuple.tuple/tuple.cnstr/test_lazy_sfinae.pass.cpp:0 FAIL
 
 # Compiler bug: DevCom-409222 "Constructing rvalue reference from non-reference-related lvalue reference"
-std/utilities/meta/meta.unary/meta.unary.prop/is_constructible.pass.cpp:0 SKIPPED
+std/utilities/meta/meta.unary/meta.unary.prop/is_constructible.pass.cpp:0 FAIL
 
 # Compiler bug: DevCom-876860 "conditional operator errors" blocks readable<volatile int*>.
-std/containers/views/span.cons/ptr_len.pass.cpp:0 SKIPPED
-std/containers/views/span.cons/ptr_ptr.pass.cpp:0 SKIPPED
+std/containers/views/span.cons/ptr_len.pass.cpp:0 FAIL
+std/containers/views/span.cons/ptr_ptr.pass.cpp:0 FAIL
 
 
 # *** CLANG COMPILER BUGS ***
 # LLVM-33230 "Clang on Windows should define __STDCPP_THREADS__ to be 1"
-std/thread/macro.pass.cpp:1 SKIPPED
+std/thread/macro.pass.cpp:1 FAIL
+
+# Clang's tgmath.h interferes with the UCRT's tgmath.h
+std/depr/depr.c.headers/tgmath_h.pass.cpp:1 FAIL
 
 
 # *** CLANG ISSUES, NOT YET ANALYZED ***
 # Clang doesn't enable sized deallocation by default. Should we add -fsized-deallocation or do something else?
-std/language.support/support.dynamic/new.delete/new.delete.array/sized_delete_array_fsizeddeallocation.pass.cpp SKIPPED
-std/language.support/support.dynamic/new.delete/new.delete.array/sized_delete_array14.pass.cpp SKIPPED
-std/language.support/support.dynamic/new.delete/new.delete.single/sized_delete_fsizeddeallocation.pass.cpp SKIPPED
-std/language.support/support.dynamic/new.delete/new.delete.single/sized_delete14.pass.cpp SKIPPED
+std/language.support/support.dynamic/new.delete/new.delete.array/sized_delete_array_fsizeddeallocation.pass.cpp:1 FAIL
+std/language.support/support.dynamic/new.delete/new.delete.array/sized_delete_array14.pass.cpp:1 FAIL
+std/language.support/support.dynamic/new.delete/new.delete.single/sized_delete_fsizeddeallocation.pass.cpp:1 FAIL
+std/language.support/support.dynamic/new.delete/new.delete.single/sized_delete14.pass.cpp:1 FAIL
 
 # Not yet analyzed. Clang apparently defines platform macros differently from C1XX.
-std/language.support/support.limits/limits/numeric.limits.members/traps.pass.cpp SKIPPED
+std/language.support/support.limits/limits/numeric.limits.members/traps.pass.cpp:1 FAIL
 
 
 # *** STL BUGS ***
@@ -584,9 +581,6 @@ std/localization/locale.categories/category.monetary/locale.moneypunct/money_bas
 # STL Bug: VSO-595631 <fstream> basic_filebuf doesn't comply with setbuf(0,0) requirement in the standard
 std/input.output/file.streams/fstreams/filebuf.virtuals/overflow.pass.cpp FAIL
 std/input.output/file.streams/fstreams/filebuf.virtuals/underflow.pass.cpp FAIL
-
-# STL bug: We don't have tgmath.h.
-std/depr/depr.c.headers/tgmath_h.pass.cpp SKIPPED
 
 # STL bug: Our inheritance implementation is allowing this to compile when it shouldn't.
 std/numerics/complex.number/complex.special/double_long_double_implicit.compile.fail.cpp FAIL
@@ -676,6 +670,9 @@ std/thread/futures/futures.promise/set_value_const.pass.cpp FAIL
 std/strings/basic.string.hash/char_type_hash.fail.cpp FAIL
 std/strings/string.view/string.view.hash/char_type.hash.fail.cpp FAIL
 
+# STL bug: GH-784 <type_traits>: aligned_storage has incorrect alignment defaults
+std/utilities/meta/meta.trans/meta.trans.other/aligned_storage.pass.cpp FAIL
+
 
 # *** CRT BUGS ***
 # We're permanently missing aligned_alloc().
@@ -689,66 +686,35 @@ std/thread/thread.threads/thread.thread.class/thread.thread.member/join.pass.cpp
 
 # *** LIKELY BOGUS TESTS ***
 # Test bug. See VSO-521345 "<cmath> We're missing integral overloads for some math.h functions, including isfinite"
-std/depr/depr.c.headers/math_h.pass.cpp SKIPPED
-std/numerics/c.math/cmath.pass.cpp SKIPPED
-
-# Tests need to be updated for P1115R3 "erase()/erase_if() Return size_type".
-std/containers/associative/map/map.erasure/erase_if.pass.cpp SKIPPED
-std/containers/associative/multimap/multimap.erasure/erase_if.pass.cpp SKIPPED
-std/containers/associative/multiset/multiset.erasure/erase_if.pass.cpp SKIPPED
-std/containers/associative/set/set.erasure/erase_if.pass.cpp SKIPPED
-std/containers/sequences/deque/deque.erasure/erase_if.pass.cpp SKIPPED
-std/containers/sequences/deque/deque.erasure/erase.pass.cpp SKIPPED
-std/containers/sequences/forwardlist/forwardlist.erasure/erase_if.pass.cpp SKIPPED
-std/containers/sequences/forwardlist/forwardlist.erasure/erase.pass.cpp SKIPPED
-std/containers/sequences/list/list.erasure/erase_if.pass.cpp SKIPPED
-std/containers/sequences/list/list.erasure/erase.pass.cpp SKIPPED
-std/containers/sequences/vector/vector.erasure/erase_if.pass.cpp SKIPPED
-std/containers/sequences/vector/vector.erasure/erase.pass.cpp SKIPPED
-std/containers/unord/unord.map/erase_if.pass.cpp SKIPPED
-std/containers/unord/unord.multimap/erase_if.pass.cpp SKIPPED
-std/containers/unord/unord.multiset/erase_if.pass.cpp SKIPPED
-std/containers/unord/unord.set/erase_if.pass.cpp SKIPPED
-std/language.support/support.limits/support.limits.general/deque.version.pass.cpp SKIPPED
-std/language.support/support.limits/support.limits.general/forward_list.version.pass.cpp SKIPPED
-std/language.support/support.limits/support.limits.general/list.version.pass.cpp SKIPPED
-std/language.support/support.limits/support.limits.general/map.version.pass.cpp SKIPPED
-std/language.support/support.limits/support.limits.general/set.version.pass.cpp SKIPPED
-std/language.support/support.limits/support.limits.general/unordered_map.version.pass.cpp SKIPPED
-std/language.support/support.limits/support.limits.general/unordered_set.version.pass.cpp SKIPPED
-std/language.support/support.limits/support.limits.general/vector.version.pass.cpp SKIPPED
-std/strings/strings.erasure/erase_if.pass.cpp SKIPPED
-std/strings/strings.erasure/erase.pass.cpp SKIPPED
+std/depr/depr.c.headers/math_h.pass.cpp FAIL
+std/numerics/c.math/cmath.pass.cpp FAIL
 
 # Test needs to be updated for P1976R2 "Explicit Constructors For Fixed-Extent span From Dynamic-Extent Ranges".
-std/containers/views/span.cons/assign.pass.cpp SKIPPED
+std/containers/views/span.cons/assign.pass.cpp FAIL
 
 # Test bug after LWG-2899 "is_(nothrow_)move_constructible and tuple, optional and unique_ptr" was accepted.
-std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.asgn/move_convert.pass.cpp SKIPPED
-std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.asgn/move_convert.runtime.pass.cpp SKIPPED
-std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.asgn/move_convert.single.pass.cpp SKIPPED
-std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.asgn/move.pass.cpp SKIPPED
+std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.asgn/move_convert.pass.cpp FAIL
+std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.asgn/move_convert.runtime.pass.cpp FAIL
+std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.asgn/move_convert.single.pass.cpp FAIL
+std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.asgn/move.pass.cpp FAIL
 
 # Test bug after LWG-3257 "Missing feature testing macro update from P0858" was accepted.
-std/language.support/support.limits/support.limits.general/string.version.pass.cpp SKIPPED
+std/language.support/support.limits/support.limits.general/string.version.pass.cpp FAIL
 
 # Test needs to be updated for LWG-3320 removing span::const_iterator.
-std/containers/views/types.pass.cpp SKIPPED
-std/containers/views/span.iterators/begin.pass.cpp SKIPPED
-std/containers/views/span.iterators/rbegin.pass.cpp SKIPPED
-std/containers/views/span.iterators/end.pass.cpp SKIPPED
-std/containers/views/span.iterators/rend.pass.cpp SKIPPED
+std/containers/views/types.pass.cpp FAIL
+std/containers/views/span.iterators/begin.pass.cpp FAIL
+std/containers/views/span.iterators/rbegin.pass.cpp FAIL
+std/containers/views/span.iterators/end.pass.cpp FAIL
+std/containers/views/span.iterators/rend.pass.cpp FAIL
 
-# Test needs to be updated for P2116R0 removing the tuple interface of span
-std/containers/views/span.tuple/get.fail.cpp SKIPPED
-std/containers/views/span.tuple/get.pass.cpp SKIPPED
-std/containers/views/span.tuple/tuple_element.fail.cpp SKIPPED
-std/containers/views/span.tuple/tuple_element.pass.cpp SKIPPED
-std/containers/views/span.tuple/tuple_size.fail.cpp SKIPPED
-std/containers/views/span.tuple/tuple_size.pass.cpp SKIPPED
-
-# Test bug. See LWG-3099 "is_assignable<Incomplete&, Incomplete&>"
-std/utilities/utility/pairs/pairs.pair/assign_pair.pass.cpp SKIPPED
+# Test needs to be removed after P2116R0 removed the tuple interface of span
+std/containers/views/span.tuple/get.fail.cpp PASS
+std/containers/views/span.tuple/get.pass.cpp FAIL
+std/containers/views/span.tuple/tuple_element.fail.cpp PASS
+std/containers/views/span.tuple/tuple_element.pass.cpp FAIL
+std/containers/views/span.tuple/tuple_size.fail.cpp PASS
+std/containers/views/span.tuple/tuple_size.pass.cpp FAIL
 
 # Not yet analyzed, likely bogus tests. Appears to be timing assumptions.
 std/thread/futures/futures.async/async.pass.cpp SKIPPED
@@ -822,29 +788,29 @@ std/diagnostics/syserr/syserr.syserr/syserr.syserr.members/ctor_int_error_catego
 std/diagnostics/syserr/syserr.syserr/syserr.syserr.members/ctor_int_error_category.pass.cpp SKIPPED
 
 # libc++ disagrees with libstdc++ and MSVC on whether setstate calls during I/O that throw set failbit; see open issue LWG-2349
-std/input.output/iostream.format/input.streams/istream.unformatted/get_pointer_size_chart.pass.cpp SKIPPED
-std/input.output/iostream.format/input.streams/istream.unformatted/get_pointer_size.pass.cpp SKIPPED
+std/input.output/iostream.format/input.streams/istream.unformatted/get_pointer_size_chart.pass.cpp FAIL
+std/input.output/iostream.format/input.streams/istream.unformatted/get_pointer_size.pass.cpp FAIL
 
 # Sensitive to implementation details. Assertion failed: test_alloc_base::count == expected_num_allocs
 std/containers/container.requirements/container.requirements.general/allocator_move.pass.cpp SKIPPED
 
 # Tests std::weak_equality/strong_equality which were removed by P1959R0
-std/language.support/cmp/cmp.common/common_comparison_category.pass.cpp SKIPPED
-std/language.support/cmp/cmp.partialord/partialord.pass.cpp SKIPPED
-std/language.support/cmp/cmp.strongeq/cmp.strongeq.pass.cpp SKIPPED
-std/language.support/cmp/cmp.strongord/strongord.pass.cpp SKIPPED
-std/language.support/cmp/cmp.weakeq/cmp.weakeq.pass.cpp SKIPPED
-std/language.support/cmp/cmp.weakord/weakord.pass.cpp SKIPPED
+std/language.support/cmp/cmp.common/common_comparison_category.pass.cpp FAIL
+std/language.support/cmp/cmp.partialord/partialord.pass.cpp FAIL
+std/language.support/cmp/cmp.strongeq/cmp.strongeq.pass.cpp FAIL
+std/language.support/cmp/cmp.strongord/strongord.pass.cpp FAIL
+std/language.support/cmp/cmp.weakeq/cmp.weakeq.pass.cpp FAIL
+std/language.support/cmp/cmp.weakord/weakord.pass.cpp FAIL
 
 # Comment: "Test C99 compound literal."
 # Code: `(int[]){3, 4}`
 # error C4576: a parenthesized type followed by an initializer list is a non-standard explicit type conversion syntax
-std/containers/sequences/array/array.creation/to_array.pass.cpp SKIPPED
+std/containers/sequences/array/array.creation/to_array.pass.cpp:0 FAIL
 
 # Tests that need to learn that insert iterators have non-void difference type in C++20
-std/iterators/predef.iterators/insert.iterators/back.insert.iterator/types.pass.cpp SKIPPED
-std/iterators/predef.iterators/insert.iterators/front.insert.iterator/types.pass.cpp SKIPPED
-std/iterators/predef.iterators/insert.iterators/insert.iterator/types.pass.cpp SKIPPED
+std/iterators/predef.iterators/insert.iterators/back.insert.iterator/types.pass.cpp FAIL
+std/iterators/predef.iterators/insert.iterators/front.insert.iterator/types.pass.cpp FAIL
+std/iterators/predef.iterators/insert.iterators/insert.iterator/types.pass.cpp FAIL
 
 
 # *** LIKELY STL BUGS ***
@@ -1061,6 +1027,9 @@ std/localization/locale.categories/category.ctype/locale.codecvt/locale.codecvt.
 
 # Not yet analyzed. Frequent timeouts
 std/containers/sequences/deque/deque.modifiers/insert_iter_iter.pass.cpp SKIPPED
+
+# Not yet analyzed. Failing after https://reviews.llvm.org/D75622.
+std/re/re.const/re.matchflag/match_prev_avail.pass.cpp FAIL
 
 
 # *** XFAILs WHICH PASS ***

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -47,12 +47,18 @@ containers\associative\set\insert_and_emplace_allocator_requirements.pass.cpp
 containers\unord\unord.map\unord.map.modifiers\insert_and_emplace_allocator_requirements.pass.cpp
 containers\unord\unord.set\insert_and_emplace_allocator_requirements.pass.cpp
 
-# libcxx doesn't yet implement P1423R3, so it expects an "old" value for __cpp_lib_char8_t
+# libc++ doesn't yet implement P1423R3, so it expects an old value for `__cpp_lib_char8_t`
 language.support\support.limits\support.limits.general\filesystem.version.pass.cpp
 language.support\support.limits\support.limits.general\istream.version.pass.cpp
 language.support\support.limits\support.limits.general\limits.version.pass.cpp
 language.support\support.limits\support.limits.general\locale.version.pass.cpp
 language.support\support.limits\support.limits.general\ostream.version.pass.cpp
+
+# libc++ doesn't yet implement P1956R1, so it expects the old names `ispow2`, `ceil2`, `floor2`, and `log2p1`
+numerics\bit\bit.pow.two\ceil2.pass.cpp
+numerics\bit\bit.pow.two\floor2.pass.cpp
+numerics\bit\bit.pow.two\ispow2.pass.cpp
+numerics\bit\bit.pow.two\log2p1.pass.cpp
 
 
 # *** INTERACTIONS WITH CONTEST / C1XX THAT UPSTREAM LIKELY WON'T FIX ***
@@ -446,9 +452,6 @@ utilities\time\time.hms\time.hms.members\subseconds.pass.cpp
 utilities\time\time.hms\time.hms.members\to_duration.pass.cpp
 utilities\time\time.hms\time.hms.members\width.pass.cpp
 
-# C++20 P0476R2 "<bit> bit_cast"
-language.support\support.limits\support.limits.general\bit.version.pass.cpp
-
 # C++20 P0553R4 "<bit> Rotating And Counting Functions"
 numerics\bit\bitops.count\countl_one.pass.cpp
 numerics\bit\bitops.count\countl_zero.pass.cpp
@@ -457,12 +460,6 @@ numerics\bit\bitops.count\countr_zero.pass.cpp
 numerics\bit\bitops.count\popcount.pass.cpp
 numerics\bit\bitops.rot\rotl.pass.cpp
 numerics\bit\bitops.rot\rotr.pass.cpp
-
-# C++20 P0556R3 "<bit> ispow2(), ceil2(), floor2(), log2p1()"
-numerics\bit\bit.pow.two\ceil2.pass.cpp
-numerics\bit\bit.pow.two\floor2.pass.cpp
-numerics\bit\bit.pow.two\ispow2.pass.cpp
-numerics\bit\bit.pow.two\log2p1.pass.cpp
 
 # C++20 P0608R3 "Improving variant's Converting Constructor/Assignment"
 utilities\variant\variant.variant\variant.assign\conv.pass.cpp
@@ -547,9 +544,6 @@ thread\futures\futures.task\futures.task.members\make_ready_at_thread_exit.pass.
 
 
 # *** C1XX COMPILER BUGS ***
-# Compiler bug: VSO-120957 "alignas by-value parameters should be permitted"
-utilities\meta\meta.trans\meta.trans.other\aligned_storage.pass.cpp
-
 # Compiler bug: VSO-106654 "error C2580 "multiple versions of a defaulted special member functions are not allowed" is bogus and ungrammatical"
 utilities\tuple\tuple.tuple\tuple.cnstr\test_lazy_sfinae.pass.cpp
 
@@ -564,6 +558,9 @@ containers\views\span.cons\ptr_ptr.pass.cpp
 # *** CLANG COMPILER BUGS ***
 # LLVM-33230 "Clang on Windows should define __STDCPP_THREADS__ to be 1"
 thread\macro.pass.cpp
+
+# Clang's tgmath.h interferes with the UCRT's tgmath.h
+depr\depr.c.headers\tgmath_h.pass.cpp
 
 
 # *** CLANG ISSUES, NOT YET ANALYZED ***
@@ -584,9 +581,6 @@ localization\locale.categories\category.monetary\locale.moneypunct\money_base.pa
 # STL Bug: VSO-595631 <fstream> basic_filebuf doesn't comply with setbuf(0,0) requirement in the standard
 input.output\file.streams\fstreams\filebuf.virtuals\overflow.pass.cpp
 input.output\file.streams\fstreams\filebuf.virtuals\underflow.pass.cpp
-
-# STL bug: We don't have tgmath.h.
-depr\depr.c.headers\tgmath_h.pass.cpp
 
 # STL bug: Our inheritance implementation is allowing this to compile when it shouldn't.
 numerics\complex.number\complex.special\double_long_double_implicit.compile.fail.cpp
@@ -676,6 +670,9 @@ thread\futures\futures.promise\set_value_const.pass.cpp
 strings\basic.string.hash\char_type_hash.fail.cpp
 strings\string.view\string.view.hash\char_type.hash.fail.cpp
 
+# STL bug: GH-784 <type_traits>: aligned_storage has incorrect alignment defaults
+utilities\meta\meta.trans\meta.trans.other\aligned_storage.pass.cpp
+
 
 # *** CRT BUGS ***
 # We're permanently missing aligned_alloc().
@@ -691,34 +688,6 @@ thread\thread.threads\thread.thread.class\thread.thread.member\join.pass.cpp
 # Test bug. See VSO-521345 "<cmath> We're missing integral overloads for some math.h functions, including isfinite"
 depr\depr.c.headers\math_h.pass.cpp
 numerics\c.math\cmath.pass.cpp
-
-# Tests need to be updated for P1115R3 "erase()/erase_if() Return size_type".
-containers\associative\map\map.erasure\erase_if.pass.cpp
-containers\associative\multimap\multimap.erasure\erase_if.pass.cpp
-containers\associative\multiset\multiset.erasure\erase_if.pass.cpp
-containers\associative\set\set.erasure\erase_if.pass.cpp
-containers\sequences\deque\deque.erasure\erase_if.pass.cpp
-containers\sequences\deque\deque.erasure\erase.pass.cpp
-containers\sequences\forwardlist\forwardlist.erasure\erase_if.pass.cpp
-containers\sequences\forwardlist\forwardlist.erasure\erase.pass.cpp
-containers\sequences\list\list.erasure\erase_if.pass.cpp
-containers\sequences\list\list.erasure\erase.pass.cpp
-containers\sequences\vector\vector.erasure\erase_if.pass.cpp
-containers\sequences\vector\vector.erasure\erase.pass.cpp
-containers\unord\unord.map\erase_if.pass.cpp
-containers\unord\unord.multimap\erase_if.pass.cpp
-containers\unord\unord.multiset\erase_if.pass.cpp
-containers\unord\unord.set\erase_if.pass.cpp
-language.support\support.limits\support.limits.general\deque.version.pass.cpp
-language.support\support.limits\support.limits.general\forward_list.version.pass.cpp
-language.support\support.limits\support.limits.general\list.version.pass.cpp
-language.support\support.limits\support.limits.general\map.version.pass.cpp
-language.support\support.limits\support.limits.general\set.version.pass.cpp
-language.support\support.limits\support.limits.general\unordered_map.version.pass.cpp
-language.support\support.limits\support.limits.general\unordered_set.version.pass.cpp
-language.support\support.limits\support.limits.general\vector.version.pass.cpp
-strings\strings.erasure\erase_if.pass.cpp
-strings\strings.erasure\erase.pass.cpp
 
 # Test needs to be updated for P1976R2 "Explicit Constructors For Fixed-Extent span From Dynamic-Extent Ranges".
 containers\views\span.cons\assign.pass.cpp
@@ -739,16 +708,13 @@ containers\views\span.iterators\rbegin.pass.cpp
 containers\views\span.iterators\end.pass.cpp
 containers\views\span.iterators\rend.pass.cpp
 
-# Test needs to be updated for P2116R0 removing the tuple interface of span
+# Test needs to be removed after P2116R0 removed the tuple interface of span
 containers\views\span.tuple\get.fail.cpp
 containers\views\span.tuple\get.pass.cpp
 containers\views\span.tuple\tuple_element.fail.cpp
 containers\views\span.tuple\tuple_element.pass.cpp
 containers\views\span.tuple\tuple_size.fail.cpp
 containers\views\span.tuple\tuple_size.pass.cpp
-
-# Test bug. See LWG-3099 "is_assignable<Incomplete&, Incomplete&>"
-utilities\utility\pairs\pairs.pair\assign_pair.pass.cpp
 
 # Not yet analyzed, likely bogus tests. Appears to be timing assumptions.
 thread\futures\futures.async\async.pass.cpp
@@ -1061,3 +1027,6 @@ localization\locale.categories\category.ctype\locale.codecvt\locale.codecvt.memb
 
 # Not yet analyzed. Frequent timeouts
 containers\sequences\deque\deque.modifiers\insert_iter_iter.pass.cpp
+
+# Not yet analyzed. Failing after https://reviews.llvm.org/D75622.
+re\re.const\re.matchflag\match_prev_avail.pass.cpp

--- a/tests/std/tests/prefix.lst
+++ b/tests/std/tests/prefix.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-PM_CL="/nologo /Od /W4 /w14061 /w14242 /w14265 /w14365 /w14582 /w14583 /w14587 /w14588 /w14749 /w14841 /w14842 /w15038 /w15214 /w15215 /w15216 /w15217 /sdl /WX /Zc:strictStrings /D_ENABLE_STL_INTERNAL_CHECK /D_ENFORCE_FACET_SPECIALIZATIONS=1 /bigobj"
+PM_CL="/nologo /Od /W4 /w14061 /w14242 /w14265 /w14365 /w14582 /w14583 /w14587 /w14588 /w14749 /w14841 /w14842 /w15038 /w15214 /w15215 /w15216 /w15217 /sdl /WX /Zc:strictStrings /D_ENABLE_STL_INTERNAL_CHECK /D_ENFORCE_FACET_SPECIALIZATIONS /bigobj"

--- a/tests/std/tests/prefix.lst
+++ b/tests/std/tests/prefix.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-PM_CL="/nologo /Od /W4 /w14061 /w14242 /w14265 /w14365 /w14582 /w14583 /w14587 /w14588 /w14749 /w14841 /w14842 /w15038 /w15214 /w15215 /w15216 /w15217 /sdl /WX /Zc:strictStrings /D_ENABLE_STL_INTERNAL_CHECK /D_ENFORCE_FACET_SPECIALIZATIONS /bigobj"
+PM_CL="/nologo /Od /W4 /w14061 /w14242 /w14265 /w14365 /w14582 /w14583 /w14587 /w14588 /w14749 /w14841 /w14842 /w15038 /w15214 /w15215 /w15216 /w15217 /sdl /WX /Zc:strictStrings /D_ENABLE_STL_INTERNAL_CHECK /D_ENFORCE_FACET_SPECIALIZATIONS=1 /bigobj"

--- a/tests/tr1/prefix.lst
+++ b/tests/tr1/prefix.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-PM_CL="/nologo /Od /W4 /w14061 /w14242 /w14265 /w14749 /w14841 /w14842 /w15038 /sdl /WX /Zc:strictStrings /D_ENABLE_STL_INTERNAL_CHECK /D_ENFORCE_FACET_SPECIALIZATIONS=1 /D_CRT_SECURE_NO_WARNINGS /bigobj"
+PM_CL="/nologo /Od /W4 /w14061 /w14242 /w14265 /w14749 /w14841 /w14842 /w15038 /sdl /WX /Zc:strictStrings /D_ENABLE_STL_INTERNAL_CHECK /D_ENFORCE_FACET_SPECIALIZATIONS /D_CRT_SECURE_NO_WARNINGS /bigobj"

--- a/tests/tr1/prefix.lst
+++ b/tests/tr1/prefix.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-PM_CL="/nologo /Od /W4 /w14061 /w14242 /w14265 /w14749 /w14841 /w14842 /w15038 /sdl /WX /Zc:strictStrings /D_ENABLE_STL_INTERNAL_CHECK /D_ENFORCE_FACET_SPECIALIZATIONS /D_CRT_SECURE_NO_WARNINGS /bigobj"
+PM_CL="/nologo /Od /W4 /w14061 /w14242 /w14265 /w14749 /w14841 /w14842 /w15038 /sdl /WX /Zc:strictStrings /D_ENABLE_STL_INTERNAL_CHECK /D_ENFORCE_FACET_SPECIALIZATIONS=1 /D_CRT_SECURE_NO_WARNINGS /bigobj"


### PR DESCRIPTION
... to more closely reflect expectations. This ensures that we'll find out immediately when a bug that was causing a test to fail is fixed, or when a bad test is fixed.