### PR TITLE
Implement LWG-3420

### DIFF
--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -431,11 +431,13 @@ struct _Iter_traits_difference<false> {
 
 // clang-format off
 template <class _It>
-concept _Cpp17_iterator = copyable<_It> && requires(_It __i) {
-    { *__i } -> _Can_reference;
-    { ++__i } -> same_as<_It&>;
-    { *__i++ } -> _Can_reference;
-};
+concept _Cpp17_iterator =
+    requires(_It __i) {
+        { *__i } -> _Can_reference;
+        { ++__i } -> same_as<_It&>;
+        { *__i++ } -> _Can_reference;
+    }
+    && copyable<_It>;
 
 template <class _It>
 concept _Cpp17_input_iterator = _Cpp17_iterator<_It>

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -431,7 +431,7 @@ struct _Iter_traits_difference<false> {
 
 // clang-format off
 template <class _It>
-concept _Cpp17_iterator =
+concept _Cpp17_iterator = // per LWG-3420
     requires(_It __i) {
         { *__i } -> _Can_reference;
         { ++__i } -> same_as<_It&>;

--- a/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
@@ -2987,7 +2987,7 @@ namespace reverse_iterator_test {
 } // namespace reverse_iterator_test
 
 namespace lwg3420 {
-    // Validate that we can ask for the iterator_traits of a type with no * operator for which checking copyability
+    // Validate that we can ask for the iterator_traits of a type with no operator* for which checking copyability
     // results in constraint recursion.
     struct X {
         X() = default;

--- a/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
@@ -2986,6 +2986,20 @@ namespace reverse_iterator_test {
         !std::sized_sentinel_for<reverse_iterator<simple_no_difference>, reverse_iterator<simple_no_difference>>);
 } // namespace reverse_iterator_test
 
+namespace lwg3420 {
+    // Validate that we can ask for the iterator_traits of a type with no * operator for which checking copyability
+    // results in constraint recursion.
+    struct X {
+        X() = default;
+        template <std::copyable T>
+        X(T const&);
+    };
+    STATIC_ASSERT(!has_member_iter_concept<std::iterator_traits<X>>);
+    STATIC_ASSERT(!has_member_iter_category<std::iterator_traits<X>>);
+    STATIC_ASSERT(!has_member_difference_type<std::iterator_traits<X>>);
+    STATIC_ASSERT(!has_member_value_type<std::iterator_traits<X>>);
+} // namespace lwg3420
+
 int main() {
     iterator_cust_swap_test::test();
     iter_ops::test();


### PR DESCRIPTION
LWG-3420 is a fairly simple reordering of concept requirements that LWG decided was Tentatively Ready about a month ago. Rather than wait for the resolution to be merged into the working draft at the next WG21 meeting - whenever that might be - I'm going to implement it now.