### PR TITLE
Skip /clr tests

### DIFF
--- a/tests/utils/stl/test/tests.py
+++ b/tests/utils/stl/test/tests.py
@@ -34,14 +34,13 @@ class STLTest(Test):
 
         self._configure_cxx(lit_config, envlst_entry, default_cxx)
 
-        # TRANSITION: These configurations should be enabled in the future.
         for flag in chain(self.cxx.flags, self.cxx.compile_flags):
             if flag[1:] == 'clr:pure':
-                self.requires.append('clr_pure')
+                self.requires.append('clr_pure') # TRANSITION, GH-798
             elif flag[1:] == 'clr':
-                self.requires.append('clr')
+                self.requires.append('clr') # TRANSITION, GH-797
             elif flag[1:] == 'BE':
-                self.requires.append('edg')
+                self.requires.append('edg') # TRANSITION, GH-799
 
     def getOutputDir(self):
         return Path(os.path.join(

--- a/tests/utils/stl/test/tests.py
+++ b/tests/utils/stl/test/tests.py
@@ -40,7 +40,7 @@ class STLTest(Test):
             elif flag[1:] == 'clr':
                 self.requires.append('clr') # TRANSITION, GH-797
             elif flag[1:] == 'BE':
-                self.requires.append('edg') # TRANSITION, GH-799
+                self.requires.append('edg') # available for x86, see config.py
 
     def getOutputDir(self):
         return Path(os.path.join(

--- a/tests/utils/stl/test/tests.py
+++ b/tests/utils/stl/test/tests.py
@@ -36,9 +36,11 @@ class STLTest(Test):
 
         # TRANSITION: These configurations should be enabled in the future.
         for flag in chain(self.cxx.flags, self.cxx.compile_flags):
-            if flag.startswith('clr:pure', 1):
+            if flag[1:] == 'clr:pure':
                 self.requires.append('clr_pure')
-            elif flag.startswith('BE', 1):
+            elif flag[1:] == 'clr':
+                self.requires.append('clr')
+            elif flag[1:] == 'BE':
                 self.requires.append('edg')
 
     def getOutputDir(self):


### PR DESCRIPTION
Fixes #788. We don't yet build `/clr` support libraries, so we shouldn't attempt to test them. (This fails on my machine, for some reason; on other machines it tests a Frankenstein combination of STL OSS and released VS code.)

Additionally, this changes the Python logic to use exact matches for compiler options instead of `startswith`. This doesn't make a difference given the current ordering (looking for `clr:pure` first) and our current compiler options, but I believe this is more robust (given the existence of `/clr:meow` variants). As before, we ignore the first character because MSVC supports `-meow` and `/meow` option styles.

This PR resolves an enormous number of test failures on my machine. Now, the test log looks like:

```json
    {
      "code": "UNSUPPORTED",
      "elapsed": 0.0009999275207519531,
      "name": "std :: tests/Dev08_496675_iostream_int_reading:19",
      "output": "Test requires the following unavailable features: clr"
    },
    {
      "code": "UNSUPPORTED",
      "elapsed": 0.0,
      "name": "std :: tests/Dev08_496675_iostream_int_reading:20",
      "output": "Test requires the following unavailable features: clr"
    },
    {
      "code": "UNSUPPORTED",
      "elapsed": 0.0,
      "name": "std :: tests/Dev08_496675_iostream_int_reading:21",
      "output": "Test requires the following unavailable features: clr_pure"
    },
    {
      "code": "UNSUPPORTED",
      "elapsed": 0.0,
      "name": "std :: tests/Dev08_496675_iostream_int_reading:22",
      "output": "Test requires the following unavailable features: clr_pure"
    },
    {
      "code": "UNSUPPORTED",
      "elapsed": 0.0,
      "name": "std :: tests/Dev08_496675_iostream_int_reading:23",
      "output": "Test requires the following unavailable features: edg"
    },
    {
      "code": "UNSUPPORTED",
      "elapsed": 0.0009996891021728516,
      "name": "std :: tests/Dev08_496675_iostream_int_reading:24",
      "output": "Test requires the following unavailable features: edg"
    },
    {
      "code": "UNSUPPORTED",
      "elapsed": 0.0,
      "name": "std :: tests/Dev08_496675_iostream_int_reading:25",
      "output": "Test requires the following unavailable features: edg"
    },
```

I verified that the configuration numbers for `/clr`, `/clr:pure`, and `/BE` correspond to the lines in the test matrix.

I believe this is my first 100% Python PR. 😸 