### PR TITLE
Fix filesystem's handling of nonexistent network paths emitting ERROR_INVALID_NAME

### DIFF
--- a/stl/src/syserror.cpp
+++ b/stl/src/syserror.cpp
@@ -47,7 +47,7 @@ static constexpr _Win_errtab_t _Win_errtab[] = {
     {ERROR_INVALID_DRIVE, errc::no_such_device},
     {ERROR_INVALID_FUNCTION, errc::function_not_supported},
     {ERROR_INVALID_HANDLE, errc::invalid_argument},
-    {ERROR_INVALID_NAME, errc::invalid_argument},
+    {ERROR_INVALID_NAME, errc::no_such_file_or_directory},
     {ERROR_INVALID_PARAMETER, errc::invalid_argument},
     {ERROR_LOCK_VIOLATION, errc::no_lock_available},
     {ERROR_LOCKED, errc::no_lock_available},

--- a/tests/std/tests/P0218R1_filesystem/test.cpp
+++ b/tests/std/tests/P0218R1_filesystem/test.cpp
@@ -2875,8 +2875,9 @@ void test_status() {
         EXPECT(status(nonexistent).type() == file_type::not_found); // should not throw
         EXPECT(status(nonexistent, ec).type() == file_type::not_found);
         EXPECT(ec.category() == system_category());
-        // accept ERROR_FILE_NOT_FOUND (2), ERROR_PATH_NOT_FOUND (3), or ERROR_BAD_NETPATH (53)
-        EXPECT(ec.value() == 2 || ec.value() == 3 || ec.value() == 53);
+        // Accept ERROR_FILE_NOT_FOUND (2), ERROR_PATH_NOT_FOUND (3), ERROR_BAD_NETPATH (53), ERROR_INVALID_NAME (123).
+        // This should match __std_is_file_not_found() in <xfilesystem_abi.h>.
+        EXPECT(ec.value() == 2 || ec.value() == 3 || ec.value() == 53 || ec.value() == 123);
         EXPECT(ec == errc::no_such_file_or_directory);
     }
 


### PR DESCRIPTION
On my machine, `P0218R1_filesystem` was failing whenever it tested nonexistent network paths. (I'm not sure why nobody else has observed this yet; I'm just running a normal Microsoft corpnet installation of Windows 10 Enterprise.)

I debugged into this, and observed that when `__std_fs_get_stats()` calls `GetFileAttributesExW()`, it fails with `ERROR_INVALID_NAME`:
https://github.com/microsoft/STL/blob/65d98ffabab3a95d79255f741daa1230692e8066/stl/src/filesystem.cpp#L919-L921

This is returned unchanged by `_File_size()`:
https://github.com/microsoft/STL/blob/65d98ffabab3a95d79255f741daa1230692e8066/stl/inc/filesystem#L3377-L3388

The test expects `file_size()` to return `bad_file_size`, which it does, but it also expects `ec == errc::no_such_file_or_directory`, which fails:
https://github.com/microsoft/STL/blob/65d98ffabab3a95d79255f741daa1230692e8066/tests/std/tests/P0218R1_filesystem/test.cpp#L2713-L2716

This is because we map `ERROR_INVALID_NAME` to `errc::invalid_argument`:
https://github.com/microsoft/STL/blob/65d98ffabab3a95d79255f741daa1230692e8066/stl/src/syserror.cpp#L50

The [Windows documentation for System Error Codes](https://docs.microsoft.com/en-us/windows/win32/debug/system-error-codes--0-499-) describes `ERROR_INVALID_NAME` as "The filename, directory name, or volume label syntax is incorrect." so this is specific to filesystem operations; it isn't a general error code for invalid arguments.

Additionally, `__std_is_file_not_found()` already considers `__std_win_error::_Invalid_name` (our synonym for `ERROR_INVALID_NAME`) to be a "file not found" error code:
https://github.com/microsoft/STL/blob/65d98ffabab3a95d79255f741daa1230692e8066/stl/inc/xfilesystem_abi.h#L51-L61

The other 3 error codes are already mapped to `errc::no_such_file_or_directory`:

https://github.com/microsoft/STL/blob/65d98ffabab3a95d79255f741daa1230692e8066/stl/src/syserror.cpp#L44
https://github.com/microsoft/STL/blob/65d98ffabab3a95d79255f741daa1230692e8066/stl/src/syserror.cpp#L64
https://github.com/microsoft/STL/blob/65d98ffabab3a95d79255f741daa1230692e8066/stl/src/syserror.cpp#L27

Changing the mapping of `ERROR_INVALID_NAME` (and updating the test's direct inspection of `ec.value()`) fixes this bug.

This is a behavioral change (similar to #406 and #616, although they added new mappings). As this fixes the behavior of `<filesystem>`, I believe it is necessary.