### PR TITLE
Use _Next_iter(it) and _Prev_iter(it) instead of it + 1 and it - 1

### DIFF
--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -3468,7 +3468,7 @@ void _Inplace_merge_buffer_left(_BidIt _First, _BidIt _Mid, _BidIt _Last, _Iter_
     using _Ptr_ty = _Iter_value_t<_BidIt>*;
     _Uninitialized_backout<_Ptr_ty> _Backout{_Temp_ptr, _Uninitialized_move_unchecked(_First, _Mid, _Temp_ptr)};
     _Ptr_ty _Left_first      = _Temp_ptr;
-    const _Ptr_ty _Left_last = _Backout._Last - 1; // avoid a compare with the highest element
+    const _Ptr_ty _Left_last = _Prev_iter(_Backout._Last); // avoid a compare with the highest element
     *_First                  = _STD move(*_Mid); // the lowest element is now in position
     ++_First;
     ++_Mid;
@@ -3503,7 +3503,7 @@ void _Inplace_merge_buffer_right(
     _Uninitialized_backout<_Ptr_ty> _Backout{_Temp_ptr, _Uninitialized_move_unchecked(_Mid, _Last, _Temp_ptr)};
     *--_Last                   = _STD move(*--_Mid); // move the highest element into position
     const _Ptr_ty _Right_first = _Temp_ptr;
-    _Ptr_ty _Right_last        = _Backout._Last - 1;
+    _Ptr_ty _Right_last        = _Prev_iter(_Backout._Last);
     --_Mid;
     for (;;) {
         if (_Pred(*_Right_last, *_Mid)) { // merge from the left partition

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -3468,7 +3468,7 @@ void _Inplace_merge_buffer_left(_BidIt _First, _BidIt _Mid, _BidIt _Last, _Iter_
     using _Ptr_ty = _Iter_value_t<_BidIt>*;
     _Uninitialized_backout<_Ptr_ty> _Backout{_Temp_ptr, _Uninitialized_move_unchecked(_First, _Mid, _Temp_ptr)};
     _Ptr_ty _Left_first      = _Temp_ptr;
-    const _Ptr_ty _Left_last = _Prev_iter(_Backout._Last); // avoid a compare with the highest element
+    const _Ptr_ty _Left_last = _Backout._Last - 1; // avoid a compare with the highest element
     *_First                  = _STD move(*_Mid); // the lowest element is now in position
     ++_First;
     ++_Mid;
@@ -3503,7 +3503,7 @@ void _Inplace_merge_buffer_right(
     _Uninitialized_backout<_Ptr_ty> _Backout{_Temp_ptr, _Uninitialized_move_unchecked(_Mid, _Last, _Temp_ptr)};
     *--_Last                   = _STD move(*--_Mid); // move the highest element into position
     const _Ptr_ty _Right_first = _Temp_ptr;
-    _Ptr_ty _Right_last        = _Prev_iter(_Backout._Last);
+    _Ptr_ty _Right_last        = _Backout._Last - 1;
     --_Mid;
     for (;;) {
         if (_Pred(*_Right_last, *_Mid)) { // merge from the left partition

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -1543,7 +1543,7 @@ _NODISCARD _CONSTEXPR20 _FwdIt search_n(
                 _UOld_first = ++_UMid; // failed match, take small jump
                 _Inc        = 0;
             } else { // no match, take big jump and back up as needed
-                _UOld_first = _UFirst + 1;
+                _UOld_first = _Next_iter(_UFirst);
                 _Inc        = _Count_diff - 1;
             }
         }
@@ -1623,7 +1623,7 @@ _FwdIt _Search_n_unchecked1(_FwdIt _First, const _FwdIt _Last, const _Diff _Coun
             _Old_first = ++_Mid; // failed match, take small jump
             _Inc       = 0;
         } else { // no match, take big jump and back up as needed
-            _Old_first = _First + 1;
+            _Old_first = _Next_iter(_First);
             _Inc       = _Count_diff - 1;
         }
     }
@@ -3760,9 +3760,9 @@ template <class _RanIt, class _Pr>
 _CONSTEXPR20 pair<_RanIt, _RanIt> _Partition_by_median_guess_unchecked(_RanIt _First, _RanIt _Last, _Pr _Pred) {
     // partition [_First, _Last), using _Pred
     _RanIt _Mid = _First + ((_Last - _First) >> 1); // shift for codegen
-    _Guess_median_unchecked(_First, _Mid, _Last - 1, _Pred);
+    _Guess_median_unchecked(_First, _Mid, _Prev_iter(_Last), _Pred);
     _RanIt _Pfirst = _Mid;
-    _RanIt _Plast  = _Pfirst + 1;
+    _RanIt _Plast  = _Next_iter(_Pfirst);
 
     while (_First < _Pfirst && !_DEBUG_LT_PRED(_Pred, *(_Pfirst - 1), *_Pfirst) && !_Pred(*_Pfirst, *(_Pfirst - 1))) {
         --_Pfirst;
@@ -3792,8 +3792,8 @@ _CONSTEXPR20 pair<_RanIt, _RanIt> _Partition_by_median_guess_unchecked(_RanIt _F
             if (_DEBUG_LT_PRED(_Pred, *(_Glast - 1), *_Pfirst)) {
             } else if (_Pred(*_Pfirst, *(_Glast - 1))) {
                 break;
-            } else if (--_Pfirst != _Glast - 1) {
-                _STD iter_swap(_Pfirst, _Glast - 1);
+            } else if (--_Pfirst != _Prev_iter(_Glast)) {
+                _STD iter_swap(_Pfirst, _Prev_iter(_Glast));
             }
         }
 

--- a/stl/inc/deque
+++ b/stl/inc/deque
@@ -1271,7 +1271,7 @@ public:
     }
 
     iterator erase(const_iterator _Where) noexcept(is_nothrow_move_assignable_v<value_type>) /* strengthened */ {
-        return erase(_Where, _Where + 1);
+        return erase(_Where, _Next_iter(_Where));
     }
 
     iterator erase(const_iterator _First_arg, const_iterator _Last_arg) noexcept(

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -2695,11 +2695,11 @@ public:
 
 #if _ITERATOR_DEBUG_LEVEL == 2
         _STL_VERIFY(end() > _Where, "vector<bool> erase iterator outside range");
-        _STD copy(_Where + 1, end(), _Where);
+        _STD copy(_Next_iter(_Where), end(), _Where);
         _Orphan_range(static_cast<size_type>(_Off), this->_Mysize);
 
 #else // _ITERATOR_DEBUG_LEVEL == 2
-        _STD copy(_Where + 1, end(), _Where);
+        _STD copy(_Next_iter(_Where), end(), _Where);
 #endif // _ITERATOR_DEBUG_LEVEL == 2
 
         _Trim(this->_Mysize - 1);


### PR DESCRIPTION
# Description

Fixes #802  

# Checklist

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [x] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [x] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [ ] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [x] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
