### PR TITLE
Fail if the version of Python found is too old

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,4 +29,4 @@ list(APPEND STL_LIT_COMMAND "${STL_LIT_OUTPUT}"
                             "${LIT_FLAGS}"
                             "${STL_LIT_TEST_DIRS}")
 
-add_test(NAME stl COMMAND ${Python3_EXECUTABLE} ${STL_LIT_COMMAND} COMMAND_EXPAND_LISTS)
+add_test(NAME stl COMMAND ${Python_EXECUTABLE} ${STL_LIT_COMMAND} COMMAND_EXPAND_LISTS)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,6 +19,10 @@ set(STL_LIT ${CMAKE_CURRENT_BINARY_DIR}/utils/stl-lit/stl-lit.py)
 set(Python_FIND_STRATEGY VERSION)
 find_package(Python3)
 
+if(Python_VERSION VERSION_LESS "3.8")
+    message(FATAL_ERROR "Found Python version ${Python_VERSION}. We require at least Python 3.8.")
+endif()
+
 add_subdirectory(libcxx)
 add_subdirectory(std)
 add_subdirectory(tr1)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,12 +16,7 @@ set(LLVM_SOURCE_DIR "${LLVM_PROJECT_SOURCE_DIR}/llvm" CACHE PATH
 
 set(STL_LIT ${CMAKE_CURRENT_BINARY_DIR}/utils/stl-lit/stl-lit.py)
 
-set(Python_FIND_STRATEGY VERSION)
-find_package(Python3)
-
-if(Python_VERSION VERSION_LESS "3.8")
-    message(FATAL_ERROR "Found Python version ${Python_VERSION}. We require at least Python 3.8.")
-endif()
+find_package(Python "3.8" REQUIRED COMPONENTS Interpreter)
 
 add_subdirectory(libcxx)
 add_subdirectory(std)


### PR DESCRIPTION
We require at least Python 3.8.

Partially addresses #806 .