### PR TITLE
Update libcxx expected_results.txt, skipped_tests.txt

### DIFF
--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -29,10 +29,11 @@ std/input.output/file.streams/fstreams/ofstream.members/open_path.pass.cpp FAIL
 std/iterators/iterator.primitives/iterator.operations/prev.pass.cpp FAIL
 
 # Itanium ABI assumptions that current_exception and rethrow_exception don't copy the exception object
+# rethrow_if_nested.pass.cpp can crash.
 std/language.support/support.exception/propagation/current_exception.pass.cpp FAIL
 std/language.support/support.exception/propagation/make_exception_ptr.pass.cpp FAIL
 std/language.support/support.exception/propagation/rethrow_exception.pass.cpp FAIL
-std/language.support/support.exception/except.nested/rethrow_if_nested.pass.cpp FAIL
+std/language.support/support.exception/except.nested/rethrow_if_nested.pass.cpp SKIPPED
 
 # Testing nonstandard behavior
 std/utilities/template.bitset/bitset.cons/string_ctor.pass.cpp FAIL
@@ -194,7 +195,7 @@ std/containers/unord/unord.multimap/max_size.pass.cpp FAIL
 std/containers/unord/unord.multiset/max_size.pass.cpp FAIL
 std/containers/unord/unord.set/max_size.pass.cpp FAIL
 
-# Requires too great a template instantiation depth for C1XX.
+# Extreme compiler memory consumption.
 std/utilities/tuple/tuple.tuple/tuple.apply/apply_large_arity.pass.cpp SKIPPED
 
 # .verify.cpp tests use clang-verify to validate warnings
@@ -629,7 +630,8 @@ std/localization/locale.categories/category.numeric/locale.num.get/facet.num.get
 
 # STL test bug: We don't have the locale names libcxx wants specialized in platform_support.hpp
 # More bugs may be uncovered when the locale names are present.
-std/input.output/iostreams.base/ios/basic.ios.members/move.pass.cpp FAIL
+# move.pass.cpp can crash.
+std/input.output/iostreams.base/ios/basic.ios.members/move.pass.cpp SKIPPED
 std/localization/locale.categories/category.collate/locale.collate.byname/compare.pass.cpp FAIL
 std/localization/locale.categories/category.ctype/locale.ctype.byname/is_1.pass.cpp FAIL
 std/localization/locale.categories/category.ctype/locale.ctype.byname/is_many.pass.cpp FAIL
@@ -677,8 +679,8 @@ std/utilities/meta/meta.trans/meta.trans.other/aligned_storage.pass.cpp FAIL
 
 # *** CRT BUGS ***
 # We're permanently missing aligned_alloc().
-std/depr/depr.c.headers/stdlib_h.pass.cpp SKIPPED
-std/language.support/support.runtime/cstdlib.pass.cpp SKIPPED
+std/depr/depr.c.headers/stdlib_h.pass.cpp FAIL
+std/language.support/support.runtime/cstdlib.pass.cpp FAIL
 
 # OS-11107628 "_Exit allows cleanup in other DLLs"
 std/thread/thread.threads/thread.thread.class/thread.thread.assign/move2.pass.cpp SKIPPED
@@ -686,7 +688,7 @@ std/thread/thread.threads/thread.thread.class/thread.thread.member/join.pass.cpp
 
 
 # *** LIKELY BOGUS TESTS ***
-# Test bug. See VSO-521345 "<cmath> We're missing integral overloads for some math.h functions, including isfinite"
+# Test bug/LEWG issue or STL bug. See GH-519 "<cmath>: signbit() misses overloads for integer types".
 std/depr/depr.c.headers/math_h.pass.cpp FAIL
 std/numerics/c.math/cmath.pass.cpp FAIL
 
@@ -779,22 +781,22 @@ std/thread/thread.threads/thread.thread.class/thread.thread.member/detach.pass.c
 std/thread/thread.threads/thread.thread.this/sleep_until.pass.cpp SKIPPED
 
 # Not yet analyzed, likely bogus tests. Various assertions, probably POSIX assumptions.
-std/diagnostics/syserr/syserr.compare/eq_error_code_error_code.pass.cpp SKIPPED
-std/diagnostics/syserr/syserr.errcat/syserr.errcat.derived/message.pass.cpp SKIPPED
-std/diagnostics/syserr/syserr.errcat/syserr.errcat.objects/system_category.pass.cpp SKIPPED
-std/diagnostics/syserr/syserr.syserr/syserr.syserr.members/ctor_error_code_const_char_pointer.pass.cpp SKIPPED
-std/diagnostics/syserr/syserr.syserr/syserr.syserr.members/ctor_error_code_string.pass.cpp SKIPPED
-std/diagnostics/syserr/syserr.syserr/syserr.syserr.members/ctor_error_code.pass.cpp SKIPPED
-std/diagnostics/syserr/syserr.syserr/syserr.syserr.members/ctor_int_error_category_const_char_pointer.pass.cpp SKIPPED
-std/diagnostics/syserr/syserr.syserr/syserr.syserr.members/ctor_int_error_category_string.pass.cpp SKIPPED
-std/diagnostics/syserr/syserr.syserr/syserr.syserr.members/ctor_int_error_category.pass.cpp SKIPPED
+std/diagnostics/syserr/syserr.compare/eq_error_code_error_code.pass.cpp FAIL
+std/diagnostics/syserr/syserr.errcat/syserr.errcat.derived/message.pass.cpp FAIL
+std/diagnostics/syserr/syserr.errcat/syserr.errcat.objects/system_category.pass.cpp FAIL
+std/diagnostics/syserr/syserr.syserr/syserr.syserr.members/ctor_error_code_const_char_pointer.pass.cpp FAIL
+std/diagnostics/syserr/syserr.syserr/syserr.syserr.members/ctor_error_code_string.pass.cpp FAIL
+std/diagnostics/syserr/syserr.syserr/syserr.syserr.members/ctor_error_code.pass.cpp FAIL
+std/diagnostics/syserr/syserr.syserr/syserr.syserr.members/ctor_int_error_category_const_char_pointer.pass.cpp FAIL
+std/diagnostics/syserr/syserr.syserr/syserr.syserr.members/ctor_int_error_category_string.pass.cpp FAIL
+std/diagnostics/syserr/syserr.syserr/syserr.syserr.members/ctor_int_error_category.pass.cpp FAIL
 
 # libc++ disagrees with libstdc++ and MSVC on whether setstate calls during I/O that throw set failbit; see open issue LWG-2349
 std/input.output/iostream.format/input.streams/istream.unformatted/get_pointer_size_chart.pass.cpp FAIL
 std/input.output/iostream.format/input.streams/istream.unformatted/get_pointer_size.pass.cpp FAIL
 
 # Sensitive to implementation details. Assertion failed: test_alloc_base::count == expected_num_allocs
-std/containers/container.requirements/container.requirements.general/allocator_move.pass.cpp SKIPPED
+std/containers/container.requirements/container.requirements.general/allocator_move.pass.cpp FAIL
 
 # Tests std::weak_equality/strong_equality which were removed by P1959R0
 std/language.support/cmp/cmp.common/common_comparison_category.pass.cpp FAIL

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -29,6 +29,7 @@ input.output\file.streams\fstreams\ofstream.members\open_path.pass.cpp
 iterators\iterator.primitives\iterator.operations\prev.pass.cpp
 
 # Itanium ABI assumptions that current_exception and rethrow_exception don't copy the exception object
+# rethrow_if_nested.pass.cpp can crash.
 language.support\support.exception\propagation\current_exception.pass.cpp
 language.support\support.exception\propagation\make_exception_ptr.pass.cpp
 language.support\support.exception\propagation\rethrow_exception.pass.cpp
@@ -194,7 +195,7 @@ containers\unord\unord.multimap\max_size.pass.cpp
 containers\unord\unord.multiset\max_size.pass.cpp
 containers\unord\unord.set\max_size.pass.cpp
 
-# Requires too great a template instantiation depth for C1XX.
+# Extreme compiler memory consumption.
 utilities\tuple\tuple.tuple\tuple.apply\apply_large_arity.pass.cpp
 
 # .verify.cpp tests use clang-verify to validate warnings
@@ -629,6 +630,7 @@ localization\locale.categories\category.numeric\locale.num.get\facet.num.get.mem
 
 # STL test bug: We don't have the locale names libcxx wants specialized in platform_support.hpp
 # More bugs may be uncovered when the locale names are present.
+# move.pass.cpp can crash.
 input.output\iostreams.base\ios\basic.ios.members\move.pass.cpp
 localization\locale.categories\category.collate\locale.collate.byname\compare.pass.cpp
 localization\locale.categories\category.ctype\locale.ctype.byname\is_1.pass.cpp
@@ -686,7 +688,7 @@ thread\thread.threads\thread.thread.class\thread.thread.member\join.pass.cpp
 
 
 # *** LIKELY BOGUS TESTS ***
-# Test bug. See VSO-521345 "<cmath> We're missing integral overloads for some math.h functions, including isfinite"
+# Test bug/LEWG issue or STL bug. See GH-519 "<cmath>: signbit() misses overloads for integer types".
 depr\depr.c.headers\math_h.pass.cpp
 numerics\c.math\cmath.pass.cpp
 


### PR DESCRIPTION
* `except.nested/rethrow_if_nested.pass.cpp` crashes on my machine, displaying a dialog box that isn't subject to the `AssertionDialogAvoider`. Accordingly, it should be `SKIPPED` instead of marked as known `FAIL`.
* `tuple.apply/apply_large_arity.pass.cpp` actually compiles on my new machine, but it consumes an astounding 18 GB of memory. This should continue to be `SKIPPED`, but I'm updating the recorded reason.
* `basic.ios.members/move.pass.cpp` is also crashing for me, so change `FAIL` to `SKIPPED`.
* The tests that need `aligned_alloc()` are reliably failing to compile, and it's possible that this will be implemented in the next hundred years, so change `SKIPPED` to `FAIL`.
* Update the explanation and bug citation for GH-519 (the longstanding issue about integral overloads of `<cmath>` classification functions).
* The `system_error` tests assuming POSIX error codes are failing reliably. Change `SKIPPED` to `FAIL` so if they're fixed upstream, we'll notice.
* `container.requirements.general/allocator_move.pass.cpp` is also asserting reliably; change `SKIPPED` to `FAIL`.
* Update the comments in `skipped_tests.txt` to match.

I checked with @CaseyCarter about the rationales for all other `SKIPPED` tests. They are:

* `ios.base.storage/iword.pass.cpp` etc. running 50M loops takes forever, so we want to skip that.
* `futures.task.members/dtor.pass.cpp` triggers undefined behavior, so we should skip potential crashes.
* `directory_entry.cons/copy.pass.cpp` and the other `<filesystem>` tests might have side effects; we haven't analyzed them to see if they're safe to run (instead of, for example, recursively deleting directory trees that they shouldn't).
* `thread.condition.condvarany/wait_terminates.sh.cpp` needs to be run specially; there's no point in trying to run it otherwise.
* `MEOW.verify.cpp` tests need `clang-verify`; our infrastructure doesn't do that.
* The tests for C++20 P0722R3 are `SKIPPED` so we can run the tests with the current development compiler in addition to the public VS Preview; this will vanish in the near future when VS 2019 16.7 Preview 1 is available.
* The `_Exit` bug blocking `thread.thread.assign/move2.pass.cpp` etc. leads to runtime misbehavior which is best `SKIPPED`.
* Bogus timing assumptions are bogus.
* `deque.modifiers/insert_iter_iter.pass.cpp` timeouts (not yet analyzed) indicate that the test is taking forever, which should be `SKIPPED` until we understand the root cause.