### PR TITLE
Build ARM/ARM64 tests

### DIFF
--- a/azure-devops/run-build.yml
+++ b/azure-devops/run-build.yml
@@ -77,12 +77,11 @@ jobs:
     - task: CmdLine@2
       displayName: 'Run Tests'
       timeoutInMinutes: 120
-      condition: in('${{ parameters.targetPlatform }}', 'x64', 'x86')
       inputs:
         workingDirectory: $(buildOutputLocation)
         script: |
           call "%PROGRAMFILES(X86)%\Microsoft Visual Studio\2019\Preview\Common7\Tools\VsDevCmd.bat" ^
-          -host_arch=${{ parameters.vsDevCmdArch }} -arch=${{ parameters.vsDevCmdArch }} -no_logo
+          -host_arch=${{ parameters.vsDevCmdHostArch }} -arch=${{ parameters.vsDevCmdTargetArch }} -no_logo
           ctest -V
       env: { TMP: $(tmpDir), TEMP: $(tmpDir) }
     - task: PublishTestResults@2

--- a/azure-devops/run-build.yml
+++ b/azure-devops/run-build.yml
@@ -87,7 +87,6 @@ jobs:
     - task: PublishTestResults@2
       displayName: 'Publish Tests'
       timeoutInMinutes: 10
-      condition: in('${{ parameters.targetPlatform }}', 'x64', 'x86')
       inputs:
         searchFolder: $(buildOutputLocation)
         testResultsFormat: JUnit

--- a/azure-devops/run-build.yml
+++ b/azure-devops/run-build.yml
@@ -65,7 +65,7 @@ jobs:
           rmdir /S /Q "$(buildOutputLocation)"
         )
         call "%PROGRAMFILES(X86)%\Microsoft Visual Studio\2019\Preview\Common7\Tools\VsDevCmd.bat" ^
-        -host_arch=amd64 -arch=${{ parameters.vsDevCmdArch }} -no_logo
+        -host_arch=amd64 -arch=${{ parameters.vsDevCmdTargetArch }} -no_logo
         cmake -G Ninja -DCMAKE_TOOLCHAIN_FILE=$(vcpkgLocation)\scripts\buildsystems\vcpkg.cmake ^
         -DVCPKG_TARGET_TRIPLET=${{ parameters.targetPlatform }}-windows -DCMAKE_CXX_COMPILER=cl ^
         -DCMAKE_BUILD_TYPE=Release -DLIT_FLAGS=$(litFlags) ^

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,19 +62,23 @@ stages:
       - template: azure-devops/run-build.yml
         parameters:
           targetPlatform: x86
-          vsDevCmdArch: x86
+          vsDevCmdHostArch: x86
+          vsDevCmdTargetArch: x86
 
       - template: azure-devops/run-build.yml
         parameters:
           targetPlatform: x64
-          vsDevCmdArch: amd64
+          vsDevCmdHostArch: amd64
+          vsDevCmdTargetArch: amd64
 
       - template: azure-devops/run-build.yml
         parameters:
           targetPlatform: arm
-          vsDevCmdArch: arm
+          vsDevCmdHostArch: amd64
+          vsDevCmdTargetArch: arm
 
       - template: azure-devops/run-build.yml
         parameters:
           targetPlatform: arm64
-          vsDevCmdArch: arm64
+          vsDevCmdHostArch: amd64
+          vsDevCmdTargetArch: arm64

--- a/tests/utils/stl/test/format.py
+++ b/tests/utils/stl/test/format.py
@@ -234,8 +234,10 @@ class STLTestFormat:
             exec_dir: os.PathLike = field(default_factory=Path)
 
         shared = SharedState()
-        return self.getBuildSteps(test, lit_config, shared), \
+        buildSteps = self.getBuildSteps(test, lit_config, shared)
+        testSteps = [] if test.build_only else \
             self.getTestSteps(test, lit_config, shared)
+        return buildSteps, testSteps
 
     def getBuildSteps(self, test, lit_config, shared):
         if not test.path_in_suite[-1].endswith('.fail.cpp'):

--- a/tests/utils/stl/test/tests.py
+++ b/tests/utils/stl/test/tests.py
@@ -34,9 +34,10 @@ class STLTest(Test):
         self.skipped = False
         Test.__init__(self, suite, path_in_suite, test_config, file_path)
 
-        self._configure_expected_result(suite, path_in_suite, lit_config,
-                                        test_config, env_num)
-        if self.skipped:
+        self._configure_test_type(suite, path_in_suite, lit_config,
+                                  test_config, env_num)
+        if self.test_type is TestType.SKIPPED:
+            self.script_result = (SKIPPED, 'Test was marked as skipped')
             return
 
         self._configure_cxx(lit_config, envlst_entry, default_cxx)
@@ -51,6 +52,9 @@ class STLTest(Test):
 
         if test_config.target_arch.startswith('arm'):
             self.build_only = True  # TRANSITION, GH-820
+
+    def getIntegratedScriptResult(self):
+        pass
 
     def getOutputDir(self):
         return Path(os.path.join(


### PR DESCRIPTION
Enable the building of tests on `ARM`/`ARM64` using the MSVC x64_arm64 toolchain.

We also disable the `clang-cl` tests when targeting `ARM`/`ARM64` as the pre-built `llvm` binaries do not have the appropriate backend built into them.