### PR TITLE
Code cleanups

### DIFF
--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -754,8 +754,7 @@ struct _Atomic_storage<_Ty, 16> { // lock-free using 16-byte intrinsics
     _Atomic_storage() = default;
 
     /* implicit */ constexpr _Atomic_storage(const _Ty _Value) noexcept
-        : _Storage{_Value} { // non-atomically initialize this atomic
-    }
+        : _Storage{_Value} {} // non-atomically initialize this atomic
 
     void store(const _Ty _Value) noexcept { // store with sequential consistency
         (void) exchange(_Value);

--- a/stl/inc/bitset
+++ b/stl/inc/bitset
@@ -33,8 +33,7 @@ public:
         friend bitset<_Bits>;
 
     public:
-        ~reference() noexcept { // TRANSITION, ABI
-        }
+        ~reference() noexcept {} // TRANSITION, ABI
 
         reference& operator=(bool _Val) noexcept {
             _Pbitset->_Set_unchecked(_Mypos, _Val);

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -25,8 +25,7 @@ _STD_BEGIN
 namespace chrono {
     // STRUCT TEMPLATE treat_as_floating_point
     template <class _Rep>
-    struct treat_as_floating_point : is_floating_point<_Rep> { // tests for floating-point type
-    };
+    struct treat_as_floating_point : is_floating_point<_Rep> {}; // tests for floating-point type
 
     template <class _Rep>
     _INLINE_VAR constexpr bool treat_as_floating_point_v = treat_as_floating_point<_Rep>::value;
@@ -221,9 +220,7 @@ namespace chrono {
 
 // STRUCT TEMPLATE _Lcm (LEAST COMMON MULTIPLE)
 template <intmax_t _Ax, intmax_t _Bx>
-struct _Lcm
-    : integral_constant<intmax_t, (_Ax / _Gcd<_Ax, _Bx>::value) * _Bx> { // compute least common multiple of _Ax and _Bx
-};
+struct _Lcm : integral_constant<intmax_t, (_Ax / _Gcd<_Ax, _Bx>::value) * _Bx> {}; // compute LCM of _Ax and _Bx
 
 // STRUCT TEMPLATE common_type SPECIALIZATIONS
 template <class _Rep1, class _Period1, class _Rep2, class _Period2>
@@ -281,12 +278,10 @@ namespace chrono {
     };
 
     template <class _CR, class _Period1, class _Rep2>
-    struct _Duration_div_mod1<_CR, _Period1, _Rep2, false> { // no return type
-    };
+    struct _Duration_div_mod1<_CR, _Period1, _Rep2, false> {}; // no return type
 
     template <class _CR, class _Period1, class _Rep2, bool = _Is_duration_v<_Rep2>>
-    struct _Duration_div_mod { // no return type
-    };
+    struct _Duration_div_mod {}; // no return type
 
     template <class _CR, class _Period1, class _Rep2>
     struct _Duration_div_mod<_CR, _Period1, _Rep2, false> : _Duration_div_mod1<_CR, _Period1, _Rep2> {

--- a/stl/inc/exception
+++ b/stl/inc/exception
@@ -113,8 +113,7 @@ public:
     }
 
 protected:
-    virtual void __CLR_OR_THIS_CALL _Doraise() const { // perform class-specific exception handling
-    }
+    virtual void __CLR_OR_THIS_CALL _Doraise() const {} // perform class-specific exception handling
 
 protected:
     const char* _Ptr; // the message pointer
@@ -137,8 +136,7 @@ protected:
 class bad_alloc : public exception { // base of all bad allocation exceptions
 public:
     __CLR_OR_THIS_CALL bad_alloc() noexcept
-        : exception("bad allocation", 1) { // construct from message string with no memory allocation
-    }
+        : exception("bad allocation", 1) {} // construct from message string with no memory allocation
 
     virtual __CLR_OR_THIS_CALL ~bad_alloc() noexcept {}
 
@@ -146,8 +144,7 @@ private:
     friend class bad_array_new_length;
 
     __CLR_OR_THIS_CALL bad_alloc(const char* _Message) noexcept
-        : exception(_Message, 1) { // construct from message string with no memory allocation
-    }
+        : exception(_Message, 1) {} // construct from message string with no memory allocation
 
 protected:
     virtual void __CLR_OR_THIS_CALL _Doraise() const override { // perform class-specific exception handling
@@ -185,8 +182,7 @@ inline unexpected_handler __CRTDECL set_unexpected(unexpected_handler) noexcept 
     return nullptr;
 }
 
-inline void __CRTDECL unexpected() { // handle unexpected exception
-}
+inline void __CRTDECL unexpected() {} // handle unexpected exception
 
 _NODISCARD inline unexpected_handler __CRTDECL get_unexpected() noexcept { // get current unexpected handler
     return nullptr;
@@ -354,8 +350,7 @@ private:
 template <class _Ty, class _Uty>
 struct _With_nested : _Uty, nested_exception { // glue user exception to nested_exception
     explicit _With_nested(_Ty&& _Arg)
-        : _Uty(_STD forward<_Ty>(_Arg)), nested_exception() { // store user exception and current_exception()
-    }
+        : _Uty(_STD forward<_Ty>(_Arg)), nested_exception() {} // store user exception and current_exception()
 };
 
 #if _HAS_IF_CONSTEXPR
@@ -408,8 +403,7 @@ void _Rethrow_if_nested(const _Ty* _Ptr, true_type) { // use dynamic_cast
 }
 
 template <class _Ty>
-void _Rethrow_if_nested(const _Ty*, false_type) { // can't use dynamic_cast
-}
+void _Rethrow_if_nested(const _Ty*, false_type) {} // can't use dynamic_cast
 
 template <class _Ty>
 void rethrow_if_nested(const _Ty& _Arg) { // detect nested_exception inheritance

--- a/stl/inc/exception
+++ b/stl/inc/exception
@@ -93,7 +93,6 @@ public:
     __CLR_OR_THIS_CALL exception(const exception& _Right) noexcept : _Ptr(_Right._Ptr) {}
 
     exception& __CLR_OR_THIS_CALL operator=(const exception& _Right) noexcept {
-
         _Ptr = _Right._Ptr;
         return *this;
     }

--- a/stl/inc/execution
+++ b/stl/inc/execution
@@ -335,7 +335,8 @@ struct _Generalized_sum_drop { // drop off point for GENERALIZED_SUM intermediat
 // VARIABLE TEMPLATE _Use_atomic_iterator
 template <class _Ty>
 struct _Atomic_is_usually_lock_free : bool_constant<atomic<_Ty>::is_always_lock_free> {
-}; // deferred evaluation of atomic::is_always_lock_free
+    // deferred evaluation of atomic::is_always_lock_free
+};
 
 template <class _FwdIt>
 inline constexpr bool _Use_atomic_iterator = conjunction_v<bool_constant<_Is_random_iter_v<_FwdIt>>,

--- a/stl/inc/execution
+++ b/stl/inc/execution
@@ -334,9 +334,8 @@ struct _Generalized_sum_drop { // drop off point for GENERALIZED_SUM intermediat
 
 // VARIABLE TEMPLATE _Use_atomic_iterator
 template <class _Ty>
-struct _Atomic_is_usually_lock_free
-    : bool_constant<atomic<_Ty>::is_always_lock_free> { // deferred evaluation of atomic::is_always_lock_free
-};
+struct _Atomic_is_usually_lock_free : bool_constant<atomic<_Ty>::is_always_lock_free> {
+}; // deferred evaluation of atomic::is_always_lock_free
 
 template <class _FwdIt>
 inline constexpr bool _Use_atomic_iterator = conjunction_v<bool_constant<_Is_random_iter_v<_FwdIt>>,
@@ -719,8 +718,7 @@ struct _Work_stealing_team { // inter-thread communication for threads working o
 
     _Work_stealing_team(size_t _Threads, _Diff _Total_work)
         : _Queues(_Threads), _Queues_used(0), _Remaining_work(_Total_work), _Available_mutex(),
-          _Available_queues(greater<>{}, _Get_queues(_Threads)) { // register work with the thread pool
-    }
+          _Available_queues(greater<>{}, _Get_queues(_Threads)) {} // register work with the thread pool
 
     _Work_stealing_membership<_Ty> _Join_team() noexcept {
         size_t _Id;

--- a/stl/inc/experimental/filesystem
+++ b/stl/inc/experimental/filesystem
@@ -975,7 +975,7 @@ public:
         return *this;
     }
 
-    path& replace_extension(const path& _Newext = path{}) { // replace extension with _Newext
+    path& replace_extension(const path& _Newext = {}) { // replace extension with _Newext
         if (_Newext.empty() || _Newext.c_str()[0] == _FS_PERIOD) {
             *this = parent_path() / path((stem().native() + _Newext.native()));
         } else {
@@ -1111,7 +1111,7 @@ public:
         if (_Idx < _Mystr.size() && _FS_ISSEP(_Mystr[_Idx])) {
             return path(string_type(1, _FS_PREF));
         } else {
-            return path{};
+            return {};
         }
     }
 
@@ -1788,12 +1788,12 @@ inline path _Absolute(const path& _Path, const path& _Base,
 
     path _Current = current_path(_Code);
     if (_Code) {
-        return path{};
+        return {};
     }
 
     path _Abs_base = _Absolute(_Base, _Current, _Code);
     if (_Code) {
-        return path{};
+        return {};
     }
 
     if (_Path_has_root_name) { // insert _Base
@@ -1867,7 +1867,7 @@ _NODISCARD inline path canonical(const path& _Path,
     error_code& _Code) { // make absolute path from _Path with no ., .., or symlink
     path _Current = current_path(_Code);
     if (_Code) {
-        return path{};
+        return {};
     }
 
     return canonical(_Path, _Current, _Code);
@@ -2196,7 +2196,7 @@ _NODISCARD inline path current_path(error_code& _Code) {
     _Pchar _Dest[_MAX_FILESYS_NAME];
     if (!_Current_get(_Dest)) { // report error
         _Code = make_error_code(errc::operation_not_permitted);
-        return path{};
+        return {};
     }
     return path(_Dest);
 }
@@ -2497,7 +2497,7 @@ _NODISCARD inline path read_symlink(const path& _Path,
     _Code.clear();
     if (!is_symlink(_Path)) { // report error
         _Code = make_error_code(errc::no_such_file_or_directory);
-        return path{};
+        return {};
     }
     _Pchar _Dest[_MAX_FILESYS_NAME];
     return path(_Symlink_get(_Dest, _Path.c_str()));
@@ -2701,7 +2701,7 @@ _NODISCARD inline path system_complete(const path& _Path, error_code& _Code) {
     _Ans = system_complete(_Path);
     _CATCH_ALL
     _Code = make_error_code(errc::operation_not_permitted);
-    return path{};
+    return {};
     _CATCH_END
 
     return _Ans;
@@ -2725,7 +2725,7 @@ _NODISCARD inline path temp_directory_path(error_code& _Code) {
     _Code.clear();
     if (!exists(_Ans) || !is_directory(_Ans)) { // report error
         _Code = make_error_code(errc::no_such_file_or_directory);
-        return path{};
+        return {};
     }
     return _Ans;
 }

--- a/stl/inc/experimental/filesystem
+++ b/stl/inc/experimental/filesystem
@@ -1427,7 +1427,7 @@ public:
     }
 
     _NODISCARD file_status status(error_code& _Code) const noexcept {
-        _Code = error_code();
+        _Code.clear();
         if (!status_known(_Mystat)) {
             if (status_known(_Mysymstat) && !is_symlink(_Mysymstat)) {
                 _Mystat = _Mysymstat;
@@ -1445,7 +1445,7 @@ public:
     }
 
     _NODISCARD file_status symlink_status(error_code& _Code) const noexcept {
-        _Code = error_code();
+        _Code.clear();
         if (!status_known(_Mysymstat)) {
             _Mysymstat = _FSPFX symlink_status(_Mypval, _Code);
         }
@@ -1548,7 +1548,7 @@ public:
     }
 
     _Directory_iterator& increment(error_code& _Code) noexcept {
-        _Code = error_code();
+        _Code.clear();
         if (_Mypdir && *_Mypdir) {
             _Get();
         } else {
@@ -1655,13 +1655,13 @@ public:
 
     recursive_directory_iterator(const path& _Path, directory_options _Opts, error_code& _Code) noexcept
         : _Mylist(1, _Mypair(_Myiter(_Path), _Path)), _Myentry(), _No_push(false), _Options(_Opts) {
-        _Code = error_code();
+        _Code.clear();
         _Get();
     }
 
     recursive_directory_iterator(const path& _Path, error_code& _Code) noexcept
         : _Mylist(1, _Mypair(_Myiter(_Path), _Path)), _Myentry(), _No_push(false), _Options(directory_options::none) {
-        _Code = error_code();
+        _Code.clear();
         _Get();
     }
 
@@ -1729,7 +1729,7 @@ public:
     }
 
     recursive_directory_iterator& increment(error_code& _Code) noexcept {
-        _Code = error_code();
+        _Code.clear();
         if (_Mylist.front().first == _Myiter()) {
             _Code = make_error_code(errc::operation_not_permitted);
         } else {
@@ -1784,7 +1784,7 @@ _NODISCARD inline recursive_directory_iterator end(const recursive_directory_ite
 // OPERATIONAL FUNCTIONS
 inline path _Absolute(const path& _Path, const path& _Base,
     error_code& _Code) { // make absolute path from _Path and directory _Base; errors in _Code
-    _Code                               = error_code();
+    _Code.clear();
     const bool _Path_has_root_name      = _Path.has_root_name();
     const bool _Path_has_root_directory = _Path.has_root_directory();
     if (_Path_has_root_name && _Path_has_root_directory) {
@@ -1880,7 +1880,7 @@ _NODISCARD inline path canonical(const path& _Path,
 
 _NODISCARD inline path canonical(const path& _Path, const path& _Base,
     error_code& _Code) { // make absolute path from _Path, _Base with no ".", "..", symlink
-    _Code = error_code();
+    _Code.clear();
     path _Canon_path; // NRVO this variable
     path _Abs_path = _Absolute(_Path, _Base, _Code);
     if (_Code != error_code()) {
@@ -1941,7 +1941,7 @@ inline void copy(const path& _Oldpval, const path& _Newpval, copy_options _Opts,
     file_status _Newstat;
     error_code _Code2;
 
-    _Code = error_code();
+    _Code.clear();
     if ((_Opts & copy_options::create_symlinks) != copy_options::none
         || (_Opts & copy_options::skip_symlinks) != copy_options::none) { // get symlink status
         _Oldstat = symlink_status(_Oldpval);
@@ -2008,7 +2008,7 @@ inline bool copy_file(const path& _Oldpval, const path& _Newpval, copy_options _
     file_time_type _Oldtime;
     file_time_type _Newtime;
 
-    _Code = error_code();
+    _Code.clear();
     if (_Exists && (_Opt == copy_options::none || equivalent(_Oldpval, _Newpval, _Code))) {
         _Code = make_error_code(errc::file_exists);
         return false;
@@ -2062,7 +2062,7 @@ inline bool create_directories(const path& _Path) { // create directories chain
 
 inline bool create_directories(const path& _Path,
     error_code& _Code) noexcept { // create directory chain
-    _Code = error_code();
+    _Code.clear();
     if (_Path.empty()) {
         return false;
     } else if (!exists(_Path)) { // recursively create parent directories, then current
@@ -2100,7 +2100,7 @@ inline bool create_directory(const path& _Path,
     error_code& _Code) noexcept { // create a directory
     const int _Ans = _Make_dir(_Path.c_str(), nullptr);
 
-    _Code = error_code();
+    _Code.clear();
     if (_Ans < 0) {
         _Code = make_error_code(errc::operation_not_permitted);
     }
@@ -2123,7 +2123,7 @@ inline bool create_directory(const path& _Path, const path& _Attrs,
     error_code& _Code) noexcept { // create a directory, copying attributes
     const int _Ans = _Make_dir(_Path.c_str(), _Attrs.c_str());
 
-    _Code = error_code();
+    _Code.clear();
     if (_Ans < 0) {
         _Code = make_error_code(errc::operation_not_permitted);
     }
@@ -2144,7 +2144,7 @@ inline void create_directory_symlink(const path& _Oldpval, const path& _Newpval,
     error_code& _Code) noexcept { // symlink directory_Newpval to _Oldpval (NB: SAME AS FILE)
     const int _Ans = _Symlink(_Oldpval.c_str(), _Newpval.c_str());
 
-    _Code = error_code();
+    _Code.clear();
     if (_Ans != 0) {
         _Code = error_code(_Ans, _STD system_category());
     }
@@ -2162,7 +2162,7 @@ inline void create_hard_link(const path& _Oldpval, const path& _Newpval,
     error_code& _Code) noexcept { // hard link _Newpval to _Oldpval
     const int _Ans = _Link(_Oldpval.c_str(), _Newpval.c_str());
 
-    _Code = error_code();
+    _Code.clear();
     if (_Ans != 0) {
         _Code = error_code(_Ans, _STD system_category());
     }
@@ -2180,7 +2180,7 @@ inline void create_symlink(const path& _Oldpval, const path& _Newpval,
     error_code& _Code) noexcept { // symlink _Newpval to _Oldpval
     const int _Ans = _Symlink(_Oldpval.c_str(), _Newpval.c_str());
 
-    _Code = error_code();
+    _Code.clear();
     if (_Ans != 0) {
         _Code = error_code(_Ans, _STD system_category());
     }
@@ -2197,7 +2197,7 @@ _NODISCARD inline path current_path() {
 }
 
 _NODISCARD inline path current_path(error_code& _Code) {
-    _Code = error_code();
+    _Code.clear();
     _Pchar _Dest[_MAX_FILESYS_NAME];
     if (!_Current_get(_Dest)) { // report error
         _Code = make_error_code(errc::operation_not_permitted);
@@ -2214,7 +2214,7 @@ inline void current_path(const path& _Path) { // set current working directory
 
 inline void current_path(const path& _Path,
     error_code& _Code) noexcept { // set current working directory
-    _Code = error_code();
+    _Code.clear();
     if (!_Current_set(_Path.c_str())) {
         _Code = make_error_code(errc::no_such_file_or_directory);
     }
@@ -2234,7 +2234,7 @@ _NODISCARD inline bool equivalent(const path& _Path1, const path& _Path2) {
 _NODISCARD inline bool equivalent(const path& _Path1, const path& _Path2, error_code& _Code) noexcept {
     const int _Ans = _Equivalent(_Path1.c_str(), _Path2.c_str());
 
-    _Code = error_code();
+    _Code.clear();
     if (_Ans < 0) {
         _Code = make_error_code(errc::operation_not_permitted);
     }
@@ -2251,7 +2251,7 @@ _NODISCARD inline bool exists(const path& _Path) {
 }
 
 _NODISCARD inline bool exists(const path& _Path, error_code& _Code) noexcept {
-    _Code = error_code();
+    _Code.clear();
     return exists(status(_Path));
 }
 
@@ -2269,7 +2269,7 @@ _NODISCARD inline uintmax_t file_size(const path& _Path, error_code& _Code) noex
     uintmax_t _Ans          = static_cast<uintmax_t>(-1);
     const file_status _Stat = status(_Path);
 
-    _Code = error_code();
+    _Code.clear();
     if (exists(_Stat) && is_regular_file(_Stat)) {
         _Ans = _File_size(_Path.c_str());
     }
@@ -2292,7 +2292,7 @@ _NODISCARD inline uintmax_t hard_link_count(const path& _Path) {
 }
 
 _NODISCARD inline uintmax_t hard_link_count(const path& _Path, error_code& _Code) noexcept {
-    _Code                = error_code();
+    _Code.clear();
     const uintmax_t _Ans = _Hard_links(_Path.c_str());
     if (_Ans == static_cast<uintmax_t>(-1)) {
         _Code = make_error_code(errc::operation_not_permitted);
@@ -2350,7 +2350,7 @@ _NODISCARD inline bool is_empty(const path& _Path) {
 _NODISCARD inline bool is_empty(const path& _Path, error_code& _Code) noexcept {
     const file_status _Stat = status(_Path);
 
-    _Code = error_code();
+    _Code.clear();
     if (is_directory(_Stat)) {
         return directory_iterator(_Path) == directory_iterator();
     } else {
@@ -2431,7 +2431,7 @@ _NODISCARD inline file_time_type last_write_time(const path& _Path) {
 _NODISCARD inline file_time_type last_write_time(const path& _Path, error_code& _Code) noexcept {
     const int64_t _Ticks = _Last_write_time(_Path.c_str());
 
-    _Code = error_code();
+    _Code.clear();
     if (_Ticks == -1) { // report error
         _Code = make_error_code(errc::operation_not_permitted);
         return (file_time_type::min)();
@@ -2449,7 +2449,7 @@ inline void last_write_time(const path& _Path, file_time_type _Newtime) { // set
 
 inline void last_write_time(const path& _Path, file_time_type _Newtime,
     error_code& _Code) noexcept { // set last write time
-    _Code = error_code();
+    _Code.clear();
     if (_Set_last_write_time(_Path.c_str(), _Newtime.time_since_epoch().count()) == 0) {
         _Code = make_error_code(errc::operation_not_permitted);
     }
@@ -2469,7 +2469,7 @@ inline void permissions(const path& _Path, perms _Mask,
     _Mask             = _Mask & perms::mask;
     bool _Ok          = true;
 
-    _Code = error_code();
+    _Code.clear();
     if ((_Todo & perms::add_perms) == perms::none) {
         if ((_Todo & perms::remove_perms) != perms::none) {
             _Mask = status(_Path).permissions() & ~_Mask;
@@ -2499,7 +2499,7 @@ _NODISCARD inline path read_symlink(const path& _Path) { // read symbolic link
 
 _NODISCARD inline path read_symlink(const path& _Path,
     error_code& _Code) { // read symbolic link
-    _Code = error_code();
+    _Code.clear();
     if (!is_symlink(_Path)) { // report error
         _Code = make_error_code(errc::no_such_file_or_directory);
         return path{};
@@ -2521,7 +2521,7 @@ inline bool remove(const path& _Path) { // remove a file
 
 inline bool remove(const path& _Path,
     error_code& _Code) noexcept { // remove a file
-    _Code = error_code();
+    _Code.clear();
     if (!exists(symlink_status(_Path))) {
         return false;
     } else if (is_directory(_Path, _Code)) {
@@ -2543,7 +2543,7 @@ inline bool remove(const path& _Path,
 
 inline bool _Remove_all(const path& _Path, uintmax_t& _Ans,
     error_code& _Code) noexcept { // recursively remove a file or directory, count removed files
-    _Code = error_code();
+    _Code.clear();
     if (is_directory(_Path)) { // empty and remove a directory
         using _Myit = _Directory_iterator<false_type>;
         _Myit _Last;
@@ -2603,7 +2603,7 @@ inline void rename(const path& _Oldpval, const path& _Newpval) { // rename _Oldp
 
 inline void rename(const path& _Oldpval, const path& _Newpval,
     error_code& _Code) noexcept { // rename _Oldpval as _Newpval
-    _Code = error_code();
+    _Code.clear();
 
     if (!exists(_Oldpval)) { // fail immediately without modifying the filesystem
         _Code = make_error_code(errc::operation_not_permitted);
@@ -2637,7 +2637,7 @@ inline void resize_file(const path& _Path, uintmax_t _Newsize,
     error_code& _Code) noexcept { // change file size
     const int _Errno = _Resize(_Path.c_str(), _Newsize);
 
-    _Code = error_code();
+    _Code.clear();
     if (_Errno != 0) {
         _Code = error_code(_Errno, _STD system_category());
     }
@@ -2648,7 +2648,7 @@ _NODISCARD inline space_info space(const path& _Path) {
 }
 
 _NODISCARD inline space_info space(const path& _Path, error_code& _Code) noexcept {
-    _Code = error_code();
+    _Code.clear();
     return _Statvfs(_Path.c_str());
 }
 
@@ -2658,7 +2658,7 @@ _NODISCARD inline file_status status(const path& _Path) {
 }
 
 _NODISCARD inline file_status status(const path& _Path, error_code& _Code) noexcept {
-    _Code = error_code();
+    _Code.clear();
     perms _Mode;
     const file_type _Ftype = _Stat(_Path.c_str(), &_Mode);
     return file_status(_Ftype, _Mode);
@@ -2677,7 +2677,7 @@ _NODISCARD inline file_status symlink_status(const path& _Path, error_code& _Cod
     perms _Mode;
     const file_type _Ftype = _Lstat(_Path.c_str(), &_Mode);
 
-    _Code = error_code();
+    _Code.clear();
     return file_status(_Ftype, _Mode);
 }
 
@@ -2698,7 +2698,7 @@ _NODISCARD inline path system_complete(const path& _Path) {
 }
 
 _NODISCARD inline path system_complete(const path& _Path, error_code& _Code) {
-    _Code = error_code();
+    _Code.clear();
 
     path _Ans;
 
@@ -2727,7 +2727,7 @@ _NODISCARD inline path temp_directory_path(error_code& _Code) {
     _Temp_get(_Dest);
     path _Ans(_Dest);
 
-    _Code = error_code();
+    _Code.clear();
     if (!exists(_Ans) || !is_directory(_Ans)) { // report error
         _Code = make_error_code(errc::no_such_file_or_directory);
         return path{};

--- a/stl/inc/experimental/filesystem
+++ b/stl/inc/experimental/filesystem
@@ -1792,12 +1792,12 @@ inline path _Absolute(const path& _Path, const path& _Base,
     }
 
     path _Current = current_path(_Code);
-    if (_Code != error_code()) {
+    if (_Code) {
         return path{};
     }
 
     path _Abs_base = _Absolute(_Base, _Current, _Code);
-    if (_Code != error_code()) {
+    if (_Code) {
         return path{};
     }
 
@@ -1814,7 +1814,7 @@ _NODISCARD inline path absolute(const path& _Path,
     const path& _Base = current_path()) { // make absolute path from _Path and directory _Base
     error_code _Code;
     path _Result = _Absolute(_Path, _Base, _Code);
-    if (_Code != error_code()) {
+    if (_Code) {
         _Throw_filesystem_error("absolute(p1, p2): current_path() couldn't get current working directory");
     }
 
@@ -1861,7 +1861,7 @@ _NODISCARD inline path canonical(const path& _Path,
     error_code _Code;
     path _Ans = canonical(_Path, _Base, _Code);
 
-    if (_Code != error_code()) {
+    if (_Code) {
         _Throw_filesystem_error("canonical(p1, p2): invalid arguments");
     }
 
@@ -1871,7 +1871,7 @@ _NODISCARD inline path canonical(const path& _Path,
 _NODISCARD inline path canonical(const path& _Path,
     error_code& _Code) { // make absolute path from _Path with no ., .., or symlink
     path _Current = current_path(_Code);
-    if (_Code != error_code()) {
+    if (_Code) {
         return path{};
     }
 
@@ -1883,7 +1883,7 @@ _NODISCARD inline path canonical(const path& _Path, const path& _Base,
     _Code.clear();
     path _Canon_path; // NRVO this variable
     path _Abs_path = _Absolute(_Path, _Base, _Code);
-    if (_Code != error_code()) {
+    if (_Code) {
         return _Canon_path;
     }
 
@@ -1915,7 +1915,7 @@ inline void copy(const path& _Oldpval, const path& _Newpval) { // copy _Oldpval 
     error_code _Code;
 
     copy(_Oldpval, _Newpval, copy_options::none, _Code);
-    if (_Code != error_code()) {
+    if (_Code) {
         _Throw_filesystem_error("copy(p1, p2): invalid arguments");
     }
 }
@@ -1930,7 +1930,7 @@ inline void copy(const path& _Oldpval, const path& _Newpval,
     error_code _Code;
 
     copy(_Oldpval, _Newpval, _Opts, _Code);
-    if (_Code != error_code()) {
+    if (_Code) {
         _Throw_filesystem_error("copy(p1, p2, options): invalid arguments");
     }
 }
@@ -1989,7 +1989,7 @@ inline bool copy_file(const path& _Oldpval, const path& _Newpval,
     copy_options _Opt /* = copy_options::none */) { // copy _Oldpval to _Newpval
     error_code _Code;
     const bool _Ans = copy_file(_Oldpval, _Newpval, _Opt, _Code);
-    if (_Code != error_code()) {
+    if (_Code) {
         _Throw_filesystem_error("copy_file(p1, p2, options): invalid arguments");
     }
 
@@ -2036,7 +2036,7 @@ inline bool copy_file(const path& _Oldpval, const path& _Newpval, copy_options _
 inline void copy_symlink(const path& _Oldpval, const path& _Newpval) { // copy symlink, file or directory
     error_code _Code;
     copy_symlink(_Oldpval, _Newpval, _Code);
-    if (_Code != error_code()) {
+    if (_Code) {
         _Throw_filesystem_error("copy_symlink(p1, p2): invalid arguments");
     }
 }
@@ -2053,7 +2053,7 @@ inline void copy_symlink(const path& _Oldpval, const path& _Newpval,
 inline bool create_directories(const path& _Path) { // create directories chain
     error_code _Code;
     const bool _Ans = create_directories(_Path, _Code);
-    if (_Code != error_code()) {
+    if (_Code) {
         _Throw_filesystem_error("create_directories(p): invalid argument");
     }
 
@@ -2089,7 +2089,7 @@ inline bool create_directory(const path& _Path) { // create a directory
     error_code _Code;
     const bool _Ans = create_directory(_Path, _Code);
 
-    if (_Code != error_code()) {
+    if (_Code) {
         _Throw_filesystem_error("create_directory(p): invalid argument");
     }
 
@@ -2112,7 +2112,7 @@ inline bool create_directory(const path& _Path, const path& _Attrs) { // create 
     error_code _Code;
     const bool _Ans = create_directory(_Path, _Attrs, _Code);
 
-    if (_Code != error_code()) {
+    if (_Code) {
         _Throw_filesystem_error("create_directory(p1, p2): invalid arguments");
     }
 
@@ -2135,7 +2135,7 @@ inline void create_directory_symlink(const path& _Oldpval,
     const path& _Newpval) { // symlink directory _Newpval to _Oldpval
     error_code _Code;
     create_directory_symlink(_Oldpval, _Newpval, _Code);
-    if (_Code != error_code()) {
+    if (_Code) {
         _Throw_filesystem_error("create_directory_symlink(p1, p2): invalid arguments");
     }
 }
@@ -2153,7 +2153,7 @@ inline void create_directory_symlink(const path& _Oldpval, const path& _Newpval,
 inline void create_hard_link(const path& _Oldpval, const path& _Newpval) { // hard link _Newpval to _Oldpval
     error_code _Code;
     create_hard_link(_Oldpval, _Newpval, _Code);
-    if (_Code != error_code()) {
+    if (_Code) {
         _Throw_filesystem_error("create_hard_link(p1, p2): invalid arguments");
     }
 }
@@ -2171,7 +2171,7 @@ inline void create_hard_link(const path& _Oldpval, const path& _Newpval,
 inline void create_symlink(const path& _Oldpval, const path& _Newpval) { // symlink _Newpval to _Oldpval
     error_code _Code;
     create_symlink(_Oldpval, _Newpval, _Code);
-    if (_Code != error_code()) {
+    if (_Code) {
         _Throw_filesystem_error("create_symlink(p1, p2): invalid arguments");
     }
 }
@@ -2189,7 +2189,7 @@ inline void create_symlink(const path& _Oldpval, const path& _Newpval,
 _NODISCARD inline path current_path() {
     error_code _Code;
     path _Ans = current_path(_Code);
-    if (_Code != error_code()) {
+    if (_Code) {
         _Throw_filesystem_error("current_path(): can't get current working directory");
     }
 
@@ -2224,7 +2224,7 @@ _NODISCARD inline bool equivalent(const path& _Path1, const path& _Path2) {
     error_code _Code;
     const int _Ans = equivalent(_Path1, _Path2, _Code);
 
-    if (_Code != error_code()) {
+    if (_Code) {
         _Throw_filesystem_error("equivalent(p1, p2): invalid arguments");
     }
 
@@ -2258,7 +2258,7 @@ _NODISCARD inline bool exists(const path& _Path, error_code& _Code) noexcept {
 _NODISCARD inline uintmax_t file_size(const path& _Path) {
     error_code _Code;
     const uintmax_t _Ans = file_size(_Path, _Code);
-    if (_Code != error_code()) {
+    if (_Code) {
         _Throw_filesystem_error("file_size(p): invalid argument");
     }
 
@@ -2284,7 +2284,7 @@ _NODISCARD inline uintmax_t file_size(const path& _Path, error_code& _Code) noex
 _NODISCARD inline uintmax_t hard_link_count(const path& _Path) {
     error_code _Code;
     const uintmax_t _Ans = hard_link_count(_Path, _Code);
-    if (_Code != error_code()) {
+    if (_Code) {
         _Throw_filesystem_error("hard_link_count(p): invalid argument");
     }
 
@@ -2340,7 +2340,7 @@ _NODISCARD inline bool is_directory(const path& _Path, error_code& _Code) noexce
 _NODISCARD inline bool is_empty(const path& _Path) {
     error_code _Code;
     const bool _Ans = _FSPFX is_empty(_Path, _Code);
-    if (_Code != error_code()) {
+    if (_Code) {
         _Throw_filesystem_error("is_empty(p): invalid argument");
     }
 
@@ -2421,7 +2421,7 @@ _NODISCARD inline bool is_symlink(const path& _Path, error_code& _Code) noexcept
 _NODISCARD inline file_time_type last_write_time(const path& _Path) {
     error_code _Code;
     file_time_type _Ans = last_write_time(_Path, _Code);
-    if (_Code != error_code()) {
+    if (_Code) {
         _Throw_filesystem_error("last_write_time(p): invalid argument");
     }
 
@@ -2442,7 +2442,7 @@ _NODISCARD inline file_time_type last_write_time(const path& _Path, error_code& 
 inline void last_write_time(const path& _Path, file_time_type _Newtime) { // set last write time
     error_code _Code;
     last_write_time(_Path, _Newtime, _Code);
-    if (_Code != error_code()) {
+    if (_Code) {
         _Throw_filesystem_error("last_write_time(p, new_time): invalid arguments");
     }
 }
@@ -2458,7 +2458,7 @@ inline void last_write_time(const path& _Path, file_time_type _Newtime,
 inline void permissions(const path& _Path, perms _Mask) { // set access permissions
     error_code _Code;
     permissions(_Path, _Mask, _Code);
-    if (_Code != error_code()) {
+    if (_Code) {
         _Throw_filesystem_error("permissions(p, prms): can't set permissions");
     }
 }
@@ -2490,7 +2490,7 @@ inline void permissions(const path& _Path, perms _Mask,
 _NODISCARD inline path read_symlink(const path& _Path) { // read symbolic link
     error_code _Code;
     path _Sympath = read_symlink(_Path, _Code);
-    if (_Code != error_code()) {
+    if (_Code) {
         _Throw_filesystem_error("read_symlink(p): can't read symbolic link");
     }
 
@@ -2512,7 +2512,7 @@ inline bool remove(const path& _Path) { // remove a file
     error_code _Code;
     const bool _Ans = remove(_Path, _Code);
 
-    if (_Code != error_code()) {
+    if (_Code) {
         _Throw_filesystem_error("remove(p): invalid argument");
     }
 
@@ -2575,7 +2575,7 @@ inline bool _Remove_all(const path& _Path, uintmax_t& _Ans,
 inline uintmax_t remove_all(const path& _Path) { // recursively remove a directory
     error_code _Code;
     const uintmax_t _Ans = remove_all(_Path, _Code);
-    if (_Code != error_code()) {
+    if (_Code) {
         _Throw_filesystem_error("remove_all(p): invalid argument");
     }
 
@@ -2596,7 +2596,7 @@ inline uintmax_t remove_all(const path& _Path,
 inline void rename(const path& _Oldpval, const path& _Newpval) { // rename _Oldpval as _Newpval
     error_code _Code;
     rename(_Oldpval, _Newpval, _Code);
-    if (_Code != error_code()) {
+    if (_Code) {
         _Throw_filesystem_error("rename(p1, p2): invalid arguments");
     }
 }
@@ -2628,7 +2628,7 @@ inline void rename(const path& _Oldpval, const path& _Newpval,
 inline void resize_file(const path& _Path, uintmax_t _Newsize) { // change file size
     error_code _Code;
     resize_file(_Path, _Newsize, _Code);
-    if (_Code != error_code()) {
+    if (_Code) {
         _Throw_filesystem_error("resize_file(p, n): invalid arguments");
     }
 };
@@ -2715,7 +2715,7 @@ _NODISCARD inline path system_complete(const path& _Path, error_code& _Code) {
 _NODISCARD inline path temp_directory_path() {
     error_code _Code;
     path _Ans = temp_directory_path(_Code);
-    if (_Code != error_code()) {
+    if (_Code) {
         _Throw_filesystem_error("temp_directory_path(): can't find temp directory");
     }
 

--- a/stl/inc/experimental/filesystem
+++ b/stl/inc/experimental/filesystem
@@ -1978,7 +1978,7 @@ inline void copy(const path& _Oldpval, const path& _Newpval, copy_options _Opts,
             _Code = make_error_code(errc::operation_not_permitted);
         }
 
-        for (directory_iterator _Next(_Oldpval), _End; _Code == error_code() && _Next != _End; ++_Next) {
+        for (directory_iterator _Next(_Oldpval), _End; !_Code && _Next != _End; ++_Next) {
             copy(_Next->path(), _Newpval / _Next->path().filename(),
                 _Opts | copy_options::_Unspecified_recursion_prevention_tag, _Code);
         }

--- a/stl/inc/experimental/filesystem
+++ b/stl/inc/experimental/filesystem
@@ -980,7 +980,7 @@ public:
         return *this;
     }
 
-    path& replace_extension(const path& _Newext = path()) { // replace extension with _Newext
+    path& replace_extension(const path& _Newext = path{}) { // replace extension with _Newext
         if (_Newext.empty() || _Newext.c_str()[0] == _FS_PERIOD) {
             *this = parent_path() / path((stem().native() + _Newext.native()));
         } else {
@@ -1116,7 +1116,7 @@ public:
         if (_Idx < _Mystr.size() && _FS_ISSEP(_Mystr[_Idx])) {
             return path(string_type(1, _FS_PREF));
         } else {
-            return path();
+            return path{};
         }
     }
 
@@ -1145,7 +1145,7 @@ public:
     }
 
     _NODISCARD path filename() const {
-        return empty() ? path() : path(*--end());
+        return empty() ? path{} : path(*--end());
     }
 
     _NODISCARD path stem() const { // pick off stem (basename) in filename (leaf) before dot
@@ -1161,7 +1161,7 @@ public:
         return _Idx == string_type::npos // no .
                        || _Str.size() == 1 // only .
                        || (_Str.size() == 2 && _Str[0] == _FS_PERIOD && _Str[1] == _FS_PERIOD) // only ..
-                   ? path()
+                   ? path{}
                    : path(_Str.substr(_Idx));
     }
 
@@ -1396,18 +1396,18 @@ public:
     directory_entry& operator=(directory_entry&&) = default;
 
     explicit directory_entry(
-        const _FSPFX path& _Path, file_status _Statarg = file_status(), file_status _Symstatarg = file_status())
+        const _FSPFX path& _Path, file_status _Statarg = file_status{}, file_status _Symstatarg = file_status{})
         : _Mypval(_Path), _Mystat(_Statarg), _Mysymstat(_Symstatarg) {}
 
     void assign(
-        const _FSPFX path& _Path, file_status _Statarg = file_status(), file_status _Symstatarg = file_status()) {
+        const _FSPFX path& _Path, file_status _Statarg = file_status{}, file_status _Symstatarg = file_status{}) {
         _Mypval    = _Path;
         _Mystat    = _Statarg;
         _Mysymstat = _Symstatarg;
     }
 
-    void replace_filename(const _FSPFX path& _Path, file_status _Statarg = file_status(),
-        file_status _Symstatarg = file_status()) { // replace filename and assign status
+    void replace_filename(const _FSPFX path& _Path, file_status _Statarg = file_status{},
+        file_status _Symstatarg = file_status{}) { // replace filename and assign status
         _Mypval    = _Mypval.parent_path() / _Path;
         _Mystat    = _Statarg;
         _Mysymstat = _Symstatarg;
@@ -1623,14 +1623,12 @@ _NODISCARD bool operator!=(
 
 using directory_iterator = _Directory_iterator<true_type>;
 
-_NODISCARD inline const directory_iterator& begin(
-    const directory_iterator& _Iter) noexcept { // return begin directory_iterator for range-based for
+_NODISCARD inline const directory_iterator& begin(const directory_iterator& _Iter) noexcept {
     return _Iter;
 }
 
-_NODISCARD inline directory_iterator end(
-    const directory_iterator&) noexcept { // return end directory_iterator for range-based for
-    return directory_iterator();
+_NODISCARD inline directory_iterator end(const directory_iterator&) noexcept {
+    return {};
 }
 
 // CLASS recursive_directory_iterator
@@ -1775,15 +1773,12 @@ _NODISCARD inline bool operator!=(
     return !(_Left == _Right);
 }
 
-_NODISCARD inline const recursive_directory_iterator& begin(const recursive_directory_iterator&
-        _Iter) noexcept { // return begin recursive_directory_iterator for range-based for
+_NODISCARD inline const recursive_directory_iterator& begin(const recursive_directory_iterator& _Iter) noexcept {
     return _Iter;
 }
 
-_NODISCARD inline recursive_directory_iterator end(
-    const recursive_directory_iterator&) noexcept { // return end recursive_directory_iterator for
-                                                    // range-based for
-    return recursive_directory_iterator();
+_NODISCARD inline recursive_directory_iterator end(const recursive_directory_iterator&) noexcept {
+    return {};
 }
 
 // OPERATIONAL FUNCTIONS
@@ -1798,12 +1793,12 @@ inline path _Absolute(const path& _Path, const path& _Base,
 
     path _Current = current_path(_Code);
     if (_Code != error_code()) {
-        return path();
+        return path{};
     }
 
     path _Abs_base = _Absolute(_Base, _Current, _Code);
     if (_Code != error_code()) {
-        return path();
+        return path{};
     }
 
     if (_Path_has_root_name) { // insert _Base
@@ -1877,7 +1872,7 @@ _NODISCARD inline path canonical(const path& _Path,
     error_code& _Code) { // make absolute path from _Path with no ., .., or symlink
     path _Current = current_path(_Code);
     if (_Code != error_code()) {
-        return path();
+        return path{};
     }
 
     return canonical(_Path, _Current, _Code);
@@ -2206,7 +2201,7 @@ _NODISCARD inline path current_path(error_code& _Code) {
     _Pchar _Dest[_MAX_FILESYS_NAME];
     if (!_Current_get(_Dest)) { // report error
         _Code = make_error_code(errc::operation_not_permitted);
-        return path();
+        return path{};
     }
     return path(_Dest);
 }
@@ -2507,7 +2502,7 @@ _NODISCARD inline path read_symlink(const path& _Path,
     _Code = error_code();
     if (!is_symlink(_Path)) { // report error
         _Code = make_error_code(errc::no_such_file_or_directory);
-        return path();
+        return path{};
     }
     _Pchar _Dest[_MAX_FILESYS_NAME];
     return path(_Symlink_get(_Dest, _Path.c_str()));
@@ -2711,7 +2706,7 @@ _NODISCARD inline path system_complete(const path& _Path, error_code& _Code) {
     _Ans = system_complete(_Path);
     _CATCH_ALL
     _Code = make_error_code(errc::operation_not_permitted);
-    return path();
+    return path{};
     _CATCH_END
 
     return _Ans;
@@ -2735,7 +2730,7 @@ _NODISCARD inline path temp_directory_path(error_code& _Code) {
     _Code = error_code();
     if (!exists(_Ans) || !is_directory(_Ans)) { // report error
         _Code = make_error_code(errc::no_such_file_or_directory);
-        return path();
+        return path{};
     }
     return _Ans;
 }

--- a/stl/inc/experimental/filesystem
+++ b/stl/inc/experimental/filesystem
@@ -596,7 +596,6 @@ public:
         : _Myptr(_Right._Myptr), _Myelem(_Right._Myelem), _Myoff(_Right._Myoff) {}
 
     _Path_iterator& operator=(const _Path_iterator& _Right) {
-
         _Myptr  = _Right._Myptr;
         _Myelem = _Right._Myelem;
         _Myoff  = _Right._Myoff;
@@ -607,7 +606,6 @@ public:
         : _Myptr(_Right._Myptr), _Myelem(_STD move(_Right._Myelem)), _Myoff(_Right._Myoff) {}
 
     _Path_iterator& operator=(_Path_iterator&& _Right) noexcept {
-
         _Myptr  = _Right._Myptr;
         _Myelem = _STD move(_Right._Myelem);
         _Myoff  = _Right._Myoff;
@@ -806,7 +804,6 @@ public:
     path(path&& _Right) noexcept : _Mystr(_STD move(_Right._Mystr)) {}
 
     path& operator=(path&& _Right) noexcept {
-
         _Mystr = _STD move(_Right._Mystr);
         return *this;
     }
@@ -815,14 +812,12 @@ public:
 
     // ARBITRARY SOURCE ASSIGN
     path& operator=(const path& _Right) {
-
         _Mystr = _Right._Mystr;
         return *this;
     }
 
     template <class _InIt>
     path& operator=(_InIt _First) {
-
         return *this = path(_First);
     }
 

--- a/stl/inc/experimental/filesystem
+++ b/stl/inc/experimental/filesystem
@@ -2611,7 +2611,7 @@ inline void rename(const path& _Oldpval, const path& _Newpval,
     }
 
     if (exists(_Newpval)) { // both exist; there can be only one
-        if (equivalent(_Oldpval, _Newpval, _Code) || _Code != error_code()) {
+        if (equivalent(_Oldpval, _Newpval, _Code) || _Code) {
             return; // successful no-op, or report equivalent() failure
         }
 

--- a/stl/inc/filesystem
+++ b/stl/inc/filesystem
@@ -921,7 +921,7 @@ namespace filesystem {
             return operator/=(_Replacement);
         }
 
-        path& replace_extension(/* const path& _Replacement = path() */) noexcept /* strengthened */ {
+        path& replace_extension(/* const path& _Replacement = path{} */) noexcept /* strengthened */ {
             // remove any extension() (and alternate data stream references) from *this's filename()
             const wchar_t* _First = _Text.data();
             const auto _Last      = _First + _Text.size();
@@ -4036,7 +4036,7 @@ namespace filesystem {
 
             if (!__std_is_file_not_found(_Err)) {
                 _Ec = _Make_ec(_Err);
-                return path();
+                return path{};
             }
         }
 
@@ -4062,7 +4062,7 @@ namespace filesystem {
                     _Call_canonical = false;
                 } else {
                     _Ec = _Make_ec(_Err);
-                    return path();
+                    return path{};
                 }
             }
         }
@@ -4096,13 +4096,13 @@ namespace filesystem {
         const path _Weakly_canonical_path = _STD filesystem::weakly_canonical(_Path, _Ec);
 
         if (_Ec) {
-            return path();
+            return path{};
         }
 
         const path _Weakly_canonical_base = _STD filesystem::weakly_canonical(_Base, _Ec);
 
         if (_Ec) {
-            return path();
+            return path{};
         }
 
         return _Weakly_canonical_path.lexically_proximate(_Weakly_canonical_base);
@@ -4113,7 +4113,7 @@ namespace filesystem {
         const path _Base = _STD filesystem::current_path(_Ec);
         // N4810 29.11.14.27 [fs.op.proximate]/1 incorrectly calls current_path()
         if (_Ec) {
-            return path();
+            return path{};
         }
 
         return _STD filesystem::proximate(_Path, _Base, _Ec);
@@ -4132,13 +4132,13 @@ namespace filesystem {
         const path _Weakly_canonical_path = _STD filesystem::weakly_canonical(_Path, _Ec);
 
         if (_Ec) {
-            return path();
+            return path{};
         }
 
         const path _Weakly_canonical_base = _STD filesystem::weakly_canonical(_Base, _Ec);
 
         if (_Ec) {
-            return path();
+            return path{};
         }
 
         return _Weakly_canonical_path.lexically_relative(_Weakly_canonical_base);
@@ -4149,7 +4149,7 @@ namespace filesystem {
         const path _Base = _STD filesystem::current_path(_Ec);
         // N4810 29.11.14.29 [fs.op.relative]/1 incorrectly calls current_path()
         if (_Ec) {
-            return path();
+            return path{};
         }
 
         return _STD filesystem::relative(_Path, _Base, _Ec);

--- a/stl/inc/filesystem
+++ b/stl/inc/filesystem
@@ -921,7 +921,7 @@ namespace filesystem {
             return operator/=(_Replacement);
         }
 
-        path& replace_extension(/* const path& _Replacement = path{} */) noexcept /* strengthened */ {
+        path& replace_extension(/* const path& _Replacement = {} */) noexcept /* strengthened */ {
             // remove any extension() (and alternate data stream references) from *this's filename()
             const wchar_t* _First = _Text.data();
             const auto _Last      = _First + _Text.size();
@@ -4036,7 +4036,7 @@ namespace filesystem {
 
             if (!__std_is_file_not_found(_Err)) {
                 _Ec = _Make_ec(_Err);
-                return path{};
+                return {};
             }
         }
 
@@ -4062,7 +4062,7 @@ namespace filesystem {
                     _Call_canonical = false;
                 } else {
                     _Ec = _Make_ec(_Err);
-                    return path{};
+                    return {};
                 }
             }
         }
@@ -4096,13 +4096,13 @@ namespace filesystem {
         const path _Weakly_canonical_path = _STD filesystem::weakly_canonical(_Path, _Ec);
 
         if (_Ec) {
-            return path{};
+            return {};
         }
 
         const path _Weakly_canonical_base = _STD filesystem::weakly_canonical(_Base, _Ec);
 
         if (_Ec) {
-            return path{};
+            return {};
         }
 
         return _Weakly_canonical_path.lexically_proximate(_Weakly_canonical_base);
@@ -4113,7 +4113,7 @@ namespace filesystem {
         const path _Base = _STD filesystem::current_path(_Ec);
         // N4810 29.11.14.27 [fs.op.proximate]/1 incorrectly calls current_path()
         if (_Ec) {
-            return path{};
+            return {};
         }
 
         return _STD filesystem::proximate(_Path, _Base, _Ec);
@@ -4132,13 +4132,13 @@ namespace filesystem {
         const path _Weakly_canonical_path = _STD filesystem::weakly_canonical(_Path, _Ec);
 
         if (_Ec) {
-            return path{};
+            return {};
         }
 
         const path _Weakly_canonical_base = _STD filesystem::weakly_canonical(_Base, _Ec);
 
         if (_Ec) {
-            return path{};
+            return {};
         }
 
         return _Weakly_canonical_path.lexically_relative(_Weakly_canonical_base);
@@ -4149,7 +4149,7 @@ namespace filesystem {
         const path _Base = _STD filesystem::current_path(_Ec);
         // N4810 29.11.14.29 [fs.op.relative]/1 incorrectly calls current_path()
         if (_Ec) {
-            return path{};
+            return {};
         }
 
         return _STD filesystem::relative(_Path, _Base, _Ec);

--- a/stl/inc/forward_list
+++ b/stl/inc/forward_list
@@ -276,8 +276,7 @@ public:
     using reference       = value_type&;
     using const_reference = const value_type&;
 
-    _Flist_val() noexcept : _Myhead() { // initialize data
-    }
+    _Flist_val() noexcept : _Myhead() {} // initialize data
 
     _Nodeptr _Before_head() const noexcept { // return pointer to the "before begin" pseudo node
         return pointer_traits<_Nodeptr>::pointer_to(reinterpret_cast<_Node&>(const_cast<_Nodeptr&>(_Myhead)));

--- a/stl/inc/functional
+++ b/stl/inc/functional
@@ -1281,13 +1281,15 @@ _NODISCARD bool operator!=(nullptr_t, const function<_Fty>& _Other) noexcept {
 
 // PLACEHOLDERS
 template <int _Nx>
-struct _Ph {}; // placeholder
+struct _Ph { // placeholder
+    static_assert(_Nx > 0, "invalid placeholder index");
+};
 
 template <class _Tx>
 struct is_placeholder : integral_constant<int, 0> {}; // _Tx is not a placeholder
 
 template <int _Nx>
-struct is_placeholder<_Ph<_Nx>> : integral_constant<int, _Nx> {}; // _Ph<_Nx> is a placeholder
+struct is_placeholder<_Ph<_Nx>> : integral_constant<int, _Nx> {}; // _Ph is a placeholder
 
 template <class _Tx>
 struct is_placeholder<const _Tx> : is_placeholder<_Tx>::type {}; // ignore cv-qualifiers

--- a/stl/inc/functional
+++ b/stl/inc/functional
@@ -672,8 +672,7 @@ private:
 public:
     template <class _Callable, class _Tag, enable_if_t<is_same_v<_Tag, _Not_fn_tag>, int> = 0>
     explicit _Not_fn(_Callable&& _Obj, _Tag) noexcept(is_nothrow_constructible_v<_Decayed, _Callable>) // strengthened
-        : _Mybase(_STD forward<_Callable>(_Obj)) { // store a callable object
-    }
+        : _Mybase(_STD forward<_Callable>(_Obj)) {} // store a callable object
 
     _Not_fn(const _Not_fn&) = default;
     _Not_fn(_Not_fn&&)      = default;
@@ -1282,29 +1281,22 @@ _NODISCARD bool operator!=(nullptr_t, const function<_Fty>& _Other) noexcept {
 
 // PLACEHOLDERS
 template <int _Nx>
-struct _Ph { // placeholder
-};
+struct _Ph {}; // placeholder
 
 template <class _Tx>
-struct is_placeholder : integral_constant<int, 0> { // template to indicate that _Tx is not a placeholder
-};
+struct is_placeholder : integral_constant<int, 0> {}; // _Tx is not a placeholder
 
 template <int _Nx>
-struct is_placeholder<_Ph<_Nx>>
-    : integral_constant<int, _Nx> { // template specialization to indicate that _Ph<_Nx> is a placeholder
-};
+struct is_placeholder<_Ph<_Nx>> : integral_constant<int, _Nx> {}; // _Ph<_Nx> is a placeholder
 
 template <class _Tx>
-struct is_placeholder<const _Tx> : is_placeholder<_Tx>::type { // ignore cv-qualifiers
-};
+struct is_placeholder<const _Tx> : is_placeholder<_Tx>::type {}; // ignore cv-qualifiers
 
 template <class _Tx>
-struct is_placeholder<volatile _Tx> : is_placeholder<_Tx>::type { // ignore cv-qualifiers
-};
+struct is_placeholder<volatile _Tx> : is_placeholder<_Tx>::type {}; // ignore cv-qualifiers
 
 template <class _Tx>
-struct is_placeholder<const volatile _Tx> : is_placeholder<_Tx>::type { // ignore cv-qualifiers
-};
+struct is_placeholder<const volatile _Tx> : is_placeholder<_Tx>::type {}; // ignore cv-qualifiers
 
 template <class _Ty>
 _INLINE_VAR constexpr int is_placeholder_v = is_placeholder<_Ty>::value;
@@ -1315,25 +1307,19 @@ class _Binder;
 
 // STRUCT TEMPLATE is_bind_expression
 template <class _Tx>
-struct is_bind_expression : false_type { // template to indicate that _Tx is not a bind expression
-};
+struct is_bind_expression : false_type {}; // _Tx is not a bind expression
 
 template <class _Ret, class _Fx, class... _Types>
-struct is_bind_expression<_Binder<_Ret, _Fx, _Types...>> : true_type {
-    // template specialization to indicate a bind expression
-};
+struct is_bind_expression<_Binder<_Ret, _Fx, _Types...>> : true_type {}; // _Binder is a bind expression
 
 template <class _Tx>
-struct is_bind_expression<const _Tx> : is_bind_expression<_Tx>::type { // ignore cv-qualifiers
-};
+struct is_bind_expression<const _Tx> : is_bind_expression<_Tx>::type {}; // ignore cv-qualifiers
 
 template <class _Tx>
-struct is_bind_expression<volatile _Tx> : is_bind_expression<_Tx>::type { // ignore cv-qualifiers
-};
+struct is_bind_expression<volatile _Tx> : is_bind_expression<_Tx>::type {}; // ignore cv-qualifiers
 
 template <class _Tx>
-struct is_bind_expression<const volatile _Tx> : is_bind_expression<_Tx>::type { // ignore cv-qualifiers
-};
+struct is_bind_expression<const volatile _Tx> : is_bind_expression<_Tx>::type {}; // ignore cv-qualifiers
 
 template <class _Ty>
 _INLINE_VAR constexpr bool is_bind_expression_v = is_bind_expression<_Ty>::value;
@@ -1556,8 +1542,7 @@ _NODISCARD constexpr auto bind_front(_Fx&& _Func, _Types&&... _Args) {
 #if _HAS_FUNCTION_ALLOCATOR_SUPPORT
 // STRUCT TEMPLATE uses_allocator
 template <class _Fty, class _Alloc>
-struct uses_allocator<function<_Fty>, _Alloc> : true_type { // true_type if container allocator enabled
-};
+struct uses_allocator<function<_Fty>, _Alloc> : true_type {}; // true_type if container allocator enabled
 #endif // _HAS_FUNCTION_ALLOCATOR_SUPPORT
 
 #if _HAS_CXX17

--- a/stl/inc/future
+++ b/stl/inc/future
@@ -97,11 +97,11 @@ struct is_error_code_enum<future_errc> : true_type {};
 _NODISCARD const error_category& future_category() noexcept;
 
 _NODISCARD inline error_code make_error_code(future_errc _Errno) noexcept {
-    return error_code(static_cast<int>(_Errno), future_category());
+    return error_code(static_cast<int>(_Errno), _STD future_category());
 }
 
 _NODISCARD inline error_condition make_error_condition(future_errc _Errno) noexcept {
-    return error_condition(static_cast<int>(_Errno), future_category());
+    return error_condition(static_cast<int>(_Errno), _STD future_category());
 }
 
 // CLASS future_error

--- a/stl/inc/future
+++ b/stl/inc/future
@@ -60,8 +60,7 @@ _NODISCARD _Unique_ptr_alloc<_Alloc> _Make_unique_alloc(_Alloc& _Al, _Args&&... 
 }
 
 // STRUCT _Nil
-struct _Nil { // empty struct, for unused argument types
-};
+struct _Nil {}; // empty struct, for unused argument types
 
 // ENUM future_errc
 enum class future_errc { // names for futures errors
@@ -409,8 +408,7 @@ private:
         return false;
     }
 
-    virtual void _Run_deferred_function(unique_lock<mutex>&) { // do nothing
-    }
+    virtual void _Run_deferred_function(unique_lock<mutex>&) {} // do nothing
 
     virtual void _Do_notify(unique_lock<mutex>* _Lock, bool _At_thread_exit) { // notify waiting threads
         // TRANSITION, ABI: This is virtual, but never overridden.

--- a/stl/inc/istream
+++ b/stl/inc/istream
@@ -156,8 +156,7 @@ public:
     }
 
     // TRANSITION, ABI: non-Standard isfx() is preserved for binary compatibility
-    void __CLR_OR_THIS_CALL isfx() { // perform any wrapup
-    }
+    void __CLR_OR_THIS_CALL isfx() {} // perform any wrapup
 
 #ifdef _M_CEE_PURE
     basic_istream& __CLR_OR_THIS_CALL operator>>(basic_istream&(__clrcall* _Pfn)(basic_istream&) ) {

--- a/stl/inc/limits
+++ b/stl/inc/limits
@@ -106,16 +106,13 @@ public:
 };
 
 template <class _Ty>
-class numeric_limits<const _Ty> : public numeric_limits<_Ty> { // numeric limits for const types
-};
+class numeric_limits<const _Ty> : public numeric_limits<_Ty> {}; // numeric limits for const types
 
 template <class _Ty>
-class numeric_limits<volatile _Ty> : public numeric_limits<_Ty> { // numeric limits for volatile types
-};
+class numeric_limits<volatile _Ty> : public numeric_limits<_Ty> {}; // numeric limits for volatile types
 
 template <class _Ty>
-class numeric_limits<const volatile _Ty> : public numeric_limits<_Ty> { // numeric limits for const volatile types
-};
+class numeric_limits<const volatile _Ty> : public numeric_limits<_Ty> {}; // numeric limits for const volatile types
 
 // STRUCT _Num_int_base
 struct _Num_int_base : _Num_base { // base for integer types

--- a/stl/inc/locale
+++ b/stl/inc/locale
@@ -148,12 +148,10 @@ public:
     static_assert(!_ENFORCE_FACET_SPECIALIZATIONS || _Is_any_of_v<_Elem, char, wchar_t>, _FACET_SPECIALIZATION_MESSAGE);
 
     explicit collate_byname(const char* _Locname, size_t _Refs = 0)
-        : collate<_Elem>(_Locname, _Refs) { // construct for named locale
-    }
+        : collate<_Elem>(_Locname, _Refs) {} // construct for named locale
 
     explicit collate_byname(const string& _Str, size_t _Refs = 0)
-        : collate<_Elem>(_Locinfo(_Str.c_str()), _Refs) { // construct for named locale
-    }
+        : collate<_Elem>(_Locinfo(_Str.c_str()), _Refs) {} // construct for named locale
 
 protected:
     virtual __CLR_OR_THIS_CALL ~collate_byname() noexcept {}

--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -2311,7 +2311,7 @@ public:
     }
 
     void reset() noexcept { // release resource, convert to null weak_ptr object
-        weak_ptr().swap(*this);
+        weak_ptr{}.swap(*this);
     }
 
     void swap(weak_ptr& _Other) noexcept {

--- a/stl/inc/memory_resource
+++ b/stl/inc/memory_resource
@@ -418,8 +418,8 @@ namespace pmr {
             static_assert(_Default_next_capacity > 1);
 
             explicit _Pool(const size_t _Log_of_size_) noexcept
-                : _Block_size{size_t{1} << _Log_of_size_},
-                  _Log_of_size{_Log_of_size_} { // initialize a pool that manages blocks of the indicated size
+                : _Block_size{size_t{1} << _Log_of_size_}, _Log_of_size{_Log_of_size_} {
+                // initialize a pool that manages blocks of the indicated size
             }
 
             _Pool(_Pool&& _That) noexcept
@@ -601,31 +601,29 @@ namespace pmr {
     class monotonic_buffer_resource : public _Identity_equal_resource {
     public:
         explicit monotonic_buffer_resource(memory_resource* const _Upstream) noexcept // strengthened
-            : _Resource{_Upstream} { // initialize this resource with upstream
-        }
+            : _Resource{_Upstream} {} // initialize this resource with upstream
 
         monotonic_buffer_resource(const size_t _Initial_size, memory_resource* const _Upstream) noexcept // strengthened
-            : _Next_buffer_size(_Round(_Initial_size)),
-              _Resource{_Upstream} { // initialize this resource with upstream and initial allocation size
+            : _Next_buffer_size(_Round(_Initial_size)), _Resource{_Upstream} {
+            // initialize this resource with upstream and initial allocation size
         }
 
         monotonic_buffer_resource(void* const _Buffer, const size_t _Buffer_size,
             memory_resource* const _Upstream) noexcept // strengthened
             : _Current_buffer(_Buffer), _Space_available(_Buffer_size),
-              _Next_buffer_size(_Buffer_size ? _Scale(_Buffer_size) : _Min_allocation),
-              _Resource{_Upstream} { // initialize this resource with upstream and initial buffer
+              _Next_buffer_size(_Buffer_size ? _Scale(_Buffer_size) : _Min_allocation), _Resource{_Upstream} {
+            // initialize this resource with upstream and initial buffer
         }
 
         monotonic_buffer_resource() = default;
 
         explicit monotonic_buffer_resource(const size_t _Initial_size) noexcept // strengthened
-            : _Next_buffer_size(_Round(_Initial_size)) { // initialize this resource with initial allocation size
-        }
+            : _Next_buffer_size(_Round(_Initial_size)) {} // initialize this resource with initial allocation size
 
         monotonic_buffer_resource(void* const _Buffer, const size_t _Buffer_size) noexcept // strengthened
             : _Current_buffer(_Buffer), _Space_available(_Buffer_size),
-              _Next_buffer_size(_Buffer_size ? _Scale(_Buffer_size)
-                                             : _Min_allocation) { // initialize this resource with initial buffer
+              _Next_buffer_size(_Buffer_size ? _Scale(_Buffer_size) : _Min_allocation) {
+            // initialize this resource with initial buffer
         }
 
         virtual ~monotonic_buffer_resource() noexcept override {
@@ -675,8 +673,7 @@ namespace pmr {
             return _Result;
         }
 
-        virtual void do_deallocate(void*, size_t, size_t) override { // nothing to do
-        }
+        virtual void do_deallocate(void*, size_t, size_t) override {} // nothing to do
 
     private:
         struct _Header : _Single_link<> { // track the size and alignment of an allocation from upstream

--- a/stl/inc/mutex
+++ b/stl/inc/mutex
@@ -138,26 +138,21 @@ public:
     }
 
     unique_lock(_Mutex& _Mtx, adopt_lock_t)
-        : _Pmtx(_STD addressof(_Mtx)), _Owns(true) { // construct and assume already locked
-    }
+        : _Pmtx(_STD addressof(_Mtx)), _Owns(true) {} // construct and assume already locked
 
     unique_lock(_Mutex& _Mtx, defer_lock_t) noexcept
-        : _Pmtx(_STD addressof(_Mtx)), _Owns(false) { // construct but don't lock
-    }
+        : _Pmtx(_STD addressof(_Mtx)), _Owns(false) {} // construct but don't lock
 
     unique_lock(_Mutex& _Mtx, try_to_lock_t)
-        : _Pmtx(_STD addressof(_Mtx)), _Owns(_Pmtx->try_lock()) { // construct and try to lock
-    }
+        : _Pmtx(_STD addressof(_Mtx)), _Owns(_Pmtx->try_lock()) {} // construct and try to lock
 
     template <class _Rep, class _Period>
     unique_lock(_Mutex& _Mtx, const chrono::duration<_Rep, _Period>& _Rel_time)
-        : _Pmtx(_STD addressof(_Mtx)), _Owns(_Pmtx->try_lock_for(_Rel_time)) { // construct and lock with timeout
-    }
+        : _Pmtx(_STD addressof(_Mtx)), _Owns(_Pmtx->try_lock_for(_Rel_time)) {} // construct and lock with timeout
 
     template <class _Clock, class _Duration>
     unique_lock(_Mutex& _Mtx, const chrono::time_point<_Clock, _Duration>& _Abs_time)
-        : _Pmtx(_STD addressof(_Mtx)), _Owns(_Pmtx->try_lock_until(_Abs_time)) { // construct and lock with timeout
-    }
+        : _Pmtx(_STD addressof(_Mtx)), _Owns(_Pmtx->try_lock_until(_Abs_time)) {} // construct and lock with timeout
 
     unique_lock(_Mutex& _Mtx, const xtime* _Abs_time)
         : _Pmtx(_STD addressof(_Mtx)), _Owns(false) { // try to lock until _Abs_time
@@ -436,8 +431,7 @@ public:
         _MyMutex.lock();
     }
 
-    lock_guard(_Mutex& _Mtx, adopt_lock_t) : _MyMutex(_Mtx) { // construct but don't lock
-    }
+    lock_guard(_Mutex& _Mtx, adopt_lock_t) : _MyMutex(_Mtx) {} // construct but don't lock
 
     ~lock_guard() noexcept {
         _MyMutex.unlock();
@@ -459,8 +453,7 @@ public:
         _STD lock(_Mtxes...);
     }
 
-    explicit scoped_lock(adopt_lock_t, _Mutexes&... _Mtxes) : _MyMutexes(_Mtxes...) { // construct but don't lock
-    }
+    explicit scoped_lock(adopt_lock_t, _Mutexes&... _Mtxes) : _MyMutexes(_Mtxes...) {} // construct but don't lock
 
     ~scoped_lock() noexcept {
         _STD apply([](_Mutexes&... _Mtxes) { (..., (void) _Mtxes.unlock()); }, _MyMutexes);
@@ -482,8 +475,7 @@ public:
         _MyMutex.lock();
     }
 
-    explicit scoped_lock(adopt_lock_t, _Mutex& _Mtx) : _MyMutex(_Mtx) { // construct but don't lock
-    }
+    explicit scoped_lock(adopt_lock_t, _Mutex& _Mtx) : _MyMutex(_Mtx) {} // construct but don't lock
 
     ~scoped_lock() noexcept {
         _MyMutex.unlock();

--- a/stl/inc/random
+++ b/stl/inc/random
@@ -671,12 +671,12 @@ public:
     }
 
     void seed(_Seed_t _Value = default_seed) { // set initial values from specified seed value
-        _Seed(_Value, false, true_type());
+        _Seed(_Value, false, true_type{});
     }
 
     template <class _Gen>
     void seed(_Gen& _Gx, bool _Readcy = false) { // set initial values from range
-        _Seed(_Gx, _Readcy, is_arithmetic<_Gen>());
+        _Seed(_Gx, _Readcy, is_arithmetic<_Gen>{});
     }
 
     _NODISCARD result_type(min)() const {
@@ -920,7 +920,7 @@ public:
     }
 
     void seed(_Ty _Value = default_seed) { // set initial values from specified seed value
-        this->_Seed(_Value, false, true_type());
+        this->_Seed(_Value, false, true_type{});
     }
 
     static constexpr int _Kx = (8 * sizeof(_Ty) + 31) / 32;
@@ -1860,7 +1860,7 @@ private:
     }
 
     static _Uty _Adjust(_Uty _Uval) { // convert signed ranges to unsigned ranges and vice versa
-        return _Adjust(_Uval, is_signed<_Ty>());
+        return _Adjust(_Uval, is_signed<_Ty>{});
     }
 
     static _Uty _Adjust(_Uty _Uval, true_type) { // convert signed ranges to unsigned ranges and vice versa

--- a/stl/inc/random
+++ b/stl/inc/random
@@ -1806,8 +1806,7 @@ public:
         return _Par._Max;
     }
 
-    void reset() { // clear internal state
-    }
+    void reset() {} // clear internal state
 
     template <class _Engine>
     _NODISCARD result_type operator()(_Engine& _Eng) const {
@@ -1993,8 +1992,7 @@ public:
         return true;
     }
 
-    void reset() { // clear internal state
-    }
+    void reset() {} // clear internal state
 
     template <class _Engine>
     _NODISCARD result_type operator()(_Engine& _Eng) const {
@@ -2118,8 +2116,7 @@ public:
         return (numeric_limits<result_type>::max)();
     }
 
-    void reset() { // clear internal state
-    }
+    void reset() {} // clear internal state
 
     template <class _Engine>
     _NODISCARD result_type operator()(_Engine& _Eng) const {
@@ -2279,8 +2276,7 @@ public:
         return (numeric_limits<result_type>::max)();
     }
 
-    void reset() { // clear internal state
-    }
+    void reset() {} // clear internal state
 
     template <class _Engine>
     _NODISCARD result_type operator()(_Engine& _Eng) const {
@@ -2450,8 +2446,7 @@ public:
         return _Par.t();
     }
 
-    void reset() { // clear internal state
-    }
+    void reset() {} // clear internal state
 
     template <class _Engine>
     _NODISCARD result_type operator()(_Engine& _Eng) const {
@@ -2617,8 +2612,7 @@ public:
         return _Par._Max;
     }
 
-    void reset() { // clear internal state
-    }
+    void reset() {} // clear internal state
 
     template <class _Engine>
     _NODISCARD result_type operator()(_Engine& _Eng) const {
@@ -2770,8 +2764,7 @@ public:
         return (numeric_limits<result_type>::max)();
     }
 
-    void reset() { // clear internal state
-    }
+    void reset() {} // clear internal state
 
     template <class _Engine>
     _NODISCARD result_type operator()(_Engine& _Eng) const {
@@ -3089,8 +3082,7 @@ public:
         return (numeric_limits<result_type>::max)();
     }
 
-    void reset() { // clear internal state
-    }
+    void reset() {} // clear internal state
 
     template <class _Engine>
     _NODISCARD result_type operator()(_Engine& _Eng) const {
@@ -3281,8 +3273,7 @@ public:
         return (numeric_limits<result_type>::max)();
     }
 
-    void reset() { // clear internal state
-    }
+    void reset() {} // clear internal state
 
     template <class _Engine>
     _NODISCARD result_type operator()(_Engine& _Eng) const {
@@ -3418,8 +3409,7 @@ public:
         return (numeric_limits<result_type>::max)();
     }
 
-    void reset() { // clear internal state
-    }
+    void reset() {} // clear internal state
 
     template <class _Engine>
     _NODISCARD result_type operator()(_Engine& _Eng) const {
@@ -3557,8 +3547,7 @@ public:
         return (numeric_limits<result_type>::max)();
     }
 
-    void reset() { // clear internal state
-    }
+    void reset() {} // clear internal state
 
     template <class _Engine>
     _NODISCARD result_type operator()(_Engine& _Eng) const {
@@ -3684,8 +3673,7 @@ public:
         return (numeric_limits<result_type>::max)();
     }
 
-    void reset() { // clear internal state
-    }
+    void reset() {} // clear internal state
 
     template <class _Engine>
     _NODISCARD result_type operator()(_Engine& _Eng) const {
@@ -3817,8 +3805,7 @@ public:
         return (numeric_limits<result_type>::max)();
     }
 
-    void reset() { // clear internal state
-    }
+    void reset() {} // clear internal state
 
     template <class _Engine>
     _NODISCARD result_type operator()(_Engine& _Eng) const {
@@ -4005,8 +3992,7 @@ public:
         return (numeric_limits<result_type>::max)();
     }
 
-    void reset() { // clear internal state
-    }
+    void reset() {} // clear internal state
 
     template <class _Engine>
     _NODISCARD result_type operator()(_Engine& _Eng) const {
@@ -4137,8 +4123,7 @@ public:
         return (numeric_limits<result_type>::max)();
     }
 
-    void reset() { // clear internal state
-    }
+    void reset() {} // clear internal state
 
     template <class _Engine>
     _NODISCARD result_type operator()(_Engine& _Eng) const {
@@ -4288,8 +4273,7 @@ public:
         return (numeric_limits<result_type>::max)();
     }
 
-    void reset() { // clear internal state
-    }
+    void reset() {} // clear internal state
 
     template <class _Engine>
     _NODISCARD result_type operator()(_Engine& _Eng) const {
@@ -4369,8 +4353,7 @@ public:
     struct param_type { // parameter package
         using distribution_type = discrete_distribution;
 
-        param_type(_Uninitialized) { // do-nothing constructor for derived classes
-        }
+        param_type(_Uninitialized) {} // do-nothing constructor for derived classes
 
         param_type() {
             _Init();
@@ -4480,8 +4463,7 @@ public:
         return static_cast<result_type>(_Par._Pvec.size() - 1);
     }
 
-    void reset() { // clear internal state
-    }
+    void reset() {} // clear internal state
 
     template <class _Engine>
     _NODISCARD result_type operator()(_Engine& _Eng) const {
@@ -4686,8 +4668,7 @@ public:
         return _Par._Bvec.back();
     }
 
-    void reset() { // clear internal state
-    }
+    void reset() {} // clear internal state
 
     template <class _Engine>
     _NODISCARD result_type operator()(_Engine& _Eng) const {
@@ -4914,8 +4895,7 @@ public:
         return _Par._Bvec.back();
     }
 
-    void reset() { // clear internal state
-    }
+    void reset() {} // clear internal state
 
     template <class _Engine>
     _NODISCARD result_type operator()(_Engine& _Eng) const {

--- a/stl/inc/ratio
+++ b/stl/inc/ratio
@@ -21,14 +21,12 @@ _STL_DISABLE_CLANG_WARNINGS
 _STD_BEGIN
 // STRUCT TEMPLATE _Abs
 template <intmax_t _Val>
-struct _Abs : integral_constant<intmax_t, (_Val < 0 ? -_Val : _Val)> { // computes absolute value of _Val
-};
+struct _Abs : integral_constant<intmax_t, (_Val < 0 ? -_Val : _Val)> {}; // computes absolute value of _Val
 
 // STRUCT TEMPLATE _Safe_mult
 template <intmax_t _Ax, intmax_t _Bx, bool _Sfinae = false,
     bool _Good = (_Abs<_Ax>::value <= INTMAX_MAX / (_Bx == 0 ? 1 : _Abs<_Bx>::value))>
-struct _Safe_mult : integral_constant<intmax_t, _Ax * _Bx> { // computes _Ax * _Bx without overflow
-};
+struct _Safe_mult : integral_constant<intmax_t, _Ax * _Bx> {}; // computes _Ax * _Bx without overflow
 
 template <intmax_t _Ax, intmax_t _Bx, bool _Sfinae>
 struct _Safe_mult<_Ax, _Bx, _Sfinae, false> { // _Ax * _Bx would overflow
@@ -37,13 +35,11 @@ struct _Safe_mult<_Ax, _Bx, _Sfinae, false> { // _Ax * _Bx would overflow
 
 // STRUCT TEMPLATE _Sign_of
 template <intmax_t _Val>
-struct _Sign_of : integral_constant<intmax_t, (_Val < 0 ? -1 : 1)> { // computes sign of _Val
-};
+struct _Sign_of : integral_constant<intmax_t, (_Val < 0 ? -1 : 1)> {}; // computes sign of _Val
 
 // STRUCT TEMPLATE _Safe_add
 template <intmax_t _Ax, intmax_t _Bx, bool _Good, bool _Also_good>
-struct _Safe_addX : integral_constant<intmax_t, _Ax + _Bx> { // computes _Ax + _Bx without overflow
-};
+struct _Safe_addX : integral_constant<intmax_t, _Ax + _Bx> {}; // computes _Ax + _Bx without overflow
 
 template <intmax_t _Ax, intmax_t _Bx>
 struct _Safe_addX<_Ax, _Bx, false, false> { // _Ax + _Bx would overflow
@@ -51,28 +47,24 @@ struct _Safe_addX<_Ax, _Bx, false, false> { // _Ax + _Bx would overflow
 };
 
 template <intmax_t _Ax, intmax_t _Bx>
-struct _Safe_add
-    : _Safe_addX<_Ax, _Bx, _Sign_of<_Ax>::value != _Sign_of<_Bx>::value,
-          (_Abs<_Ax>::value <= INTMAX_MAX - _Abs<_Bx>::value)>::type { // computes _Ax + _Bx, forbids overflow
+struct _Safe_add : _Safe_addX<_Ax, _Bx, _Sign_of<_Ax>::value != _Sign_of<_Bx>::value,
+                       (_Abs<_Ax>::value <= INTMAX_MAX - _Abs<_Bx>::value)>::type {
+    // computes _Ax + _Bx, forbids overflow
 };
 
 // STRUCT TEMPLATE _Gcd
 template <intmax_t _Ax, intmax_t _Bx>
-struct _GcdX : _GcdX<_Bx, _Ax % _Bx>::type { // computes greatest common divisor of _Ax and _Bx
-};
+struct _GcdX : _GcdX<_Bx, _Ax % _Bx>::type {}; // computes GCD of _Ax and _Bx
 
 template <intmax_t _Ax>
-struct _GcdX<_Ax, 0> : integral_constant<intmax_t, _Ax> { // computes greatest common divisor of _Ax and 0
-};
+struct _GcdX<_Ax, 0> : integral_constant<intmax_t, _Ax> {}; // computes GCD of _Ax and 0
 
 template <intmax_t _Ax, intmax_t _Bx>
-struct _Gcd
-    : _GcdX<_Abs<_Ax>::value, _Abs<_Bx>::value>::type { // computes greatest common divisor of abs(_Ax) and abs(_Bx)
-};
+struct _Gcd : _GcdX<_Abs<_Ax>::value, _Abs<_Bx>::value>::type {}; // computes GCD of abs(_Ax) and abs(_Bx)
 
 template <>
-struct _Gcd<0, 0> : integral_constant<intmax_t, 1> // contrary to mathematical convention
-{ // avoids division by 0 in ratio_less
+struct _Gcd<0, 0> : integral_constant<intmax_t, 1> {
+    // contrary to mathematical convention; avoids division by 0 in ratio_less
 };
 
 // STRUCT TEMPLATE ratio

--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -4534,21 +4534,19 @@ _Parser<_FwdIt, _Elem, _RxTraits>::_Parser(
 
     constexpr unsigned int _Egrep_flags = _Extended_flags | _L_alt_nl | _L_no_nl;
 
-    using namespace regex_constants;
+    const regex_constants::syntax_option_type _Masked = _Flags & regex_constants::_Gmask;
 
-    const syntax_option_type _Masked = _Flags & _Gmask;
-
-    if (_Masked == ECMAScript || _Masked == 0) {
+    if (_Masked == regex_constants::ECMAScript || _Masked == 0) {
         _L_flags = _ECMA_flags;
-    } else if (_Masked == basic) {
+    } else if (_Masked == regex_constants::basic) {
         _L_flags = _Basic_flags;
-    } else if (_Masked == extended) {
+    } else if (_Masked == regex_constants::extended) {
         _L_flags = _Extended_flags;
-    } else if (_Masked == awk) {
+    } else if (_Masked == regex_constants::awk) {
         _L_flags = _Awk_flags;
-    } else if (_Masked == grep) {
+    } else if (_Masked == regex_constants::grep) {
         _L_flags = _Grep_flags;
-    } else if (_Masked == egrep) {
+    } else if (_Masked == regex_constants::egrep) {
         _L_flags = _Egrep_flags;
     } else {
         _L_flags = 0;

--- a/stl/inc/scoped_allocator
+++ b/stl/inc/scoped_allocator
@@ -78,8 +78,7 @@ struct _Scoped_base<_Outer, _Inner0, _Inner...> : _Outer { // nest of allocators
         return _Inner_obj;
     }
 
-    _Scoped_base() : _Outer(), _Inner_obj() { // value-initialize Outer and Inner
-    }
+    _Scoped_base() : _Outer(), _Inner_obj() {} // value-initialize Outer and Inner
 
     template <class _Other1, class... _Other2,
         enable_if_t<sizeof...(_Other2) != 0 || !is_base_of_v<_Scoped_base, decay_t<_Other1>>, int> = 0>
@@ -113,13 +112,10 @@ struct _Scoped_base<_Outer> : _Outer { // nest of allocators, one deep
         return _Self;
     }
 
-    _Scoped_base() : _Outer() { // value-initialize
-    }
+    _Scoped_base() : _Outer() {} // value-initialize
 
     template <class _Other1, enable_if_t<!is_base_of_v<_Scoped_base, decay_t<_Other1>>, int> = 0>
-    _Scoped_base(_Other1&& _Outer_arg) : _Outer(_STD forward<_Other1>(_Outer_arg)) {
-        // also handles rebinding
-    }
+    _Scoped_base(_Other1&& _Outer_arg) : _Outer(_STD forward<_Other1>(_Outer_arg)) {} // also handles rebinding
 
     _Scoped_base(const _Scoped_base&) = default;
     _Scoped_base(_Scoped_base&&)      = default;

--- a/stl/inc/shared_mutex
+++ b/stl/inc/shared_mutex
@@ -240,27 +240,24 @@ public:
     }
 
     shared_lock(mutex_type& _Mtx, defer_lock_t) noexcept
-        : _Pmtx(_STD addressof(_Mtx)), _Owns(false) { // construct with unlocked mutex
-    }
+        : _Pmtx(_STD addressof(_Mtx)), _Owns(false) {} // construct with unlocked mutex
 
     shared_lock(mutex_type& _Mtx, try_to_lock_t)
-        : _Pmtx(_STD addressof(_Mtx)), _Owns(_Mtx.try_lock_shared()) { // construct with mutex and try to lock shared
-    }
+        : _Pmtx(_STD addressof(_Mtx)), _Owns(_Mtx.try_lock_shared()) {} // construct with mutex and try to lock shared
 
     shared_lock(mutex_type& _Mtx, adopt_lock_t)
-        : _Pmtx(_STD addressof(_Mtx)), _Owns(true) { // construct with mutex and adopt ownership
-    }
+        : _Pmtx(_STD addressof(_Mtx)), _Owns(true) {} // construct with mutex and adopt ownership
 
     template <class _Rep, class _Period>
     shared_lock(mutex_type& _Mtx, const chrono::duration<_Rep, _Period>& _Rel_time)
-        : _Pmtx(_STD addressof(_Mtx)),
-          _Owns(_Mtx.try_lock_shared_for(_Rel_time)) { // construct with mutex and try to lock for relative time
+        : _Pmtx(_STD addressof(_Mtx)), _Owns(_Mtx.try_lock_shared_for(_Rel_time)) {
+        // construct with mutex and try to lock for relative time
     }
 
     template <class _Clock, class _Duration>
     shared_lock(mutex_type& _Mtx, const chrono::time_point<_Clock, _Duration>& _Abs_time)
-        : _Pmtx(_STD addressof(_Mtx)),
-          _Owns(_Mtx.try_lock_shared_until(_Abs_time)) { // construct with mutex and try to lock until absolute time
+        : _Pmtx(_STD addressof(_Mtx)), _Owns(_Mtx.try_lock_shared_until(_Abs_time)) {
+        // construct with mutex and try to lock until absolute time
     }
 
     ~shared_lock() noexcept {

--- a/stl/inc/streambuf
+++ b/stl/inc/streambuf
@@ -172,11 +172,9 @@ public:
         return xsputn(_Ptr, _Count);
     }
 
-    virtual void __CLR_OR_THIS_CALL _Lock() { // set the thread lock (overridden by basic_filebuf)
-    }
+    virtual void __CLR_OR_THIS_CALL _Lock() {} // set the thread lock (overridden by basic_filebuf)
 
-    virtual void __CLR_OR_THIS_CALL _Unlock() { // clear the thread lock (overridden by basic_filebuf)
-    }
+    virtual void __CLR_OR_THIS_CALL _Unlock() {} // clear the thread lock (overridden by basic_filebuf)
 
 protected:
     _Elem* __CLR_OR_THIS_CALL eback() const {
@@ -376,8 +374,7 @@ protected:
         return 0;
     }
 
-    virtual void __CLR_OR_THIS_CALL imbue(const locale&) { // set locale to argument (do nothing)
-    }
+    virtual void __CLR_OR_THIS_CALL imbue(const locale&) {} // set locale to argument (do nothing)
 
 private:
     _Elem* _Gfirst; // beginning of read buffer

--- a/stl/inc/system_error
+++ b/stl/inc/system_error
@@ -121,7 +121,7 @@ _NODISCARD inline bool _System_error_equal(const error_code&, const error_condit
 // CLASS error_code
 class error_code { // store an implementation-specific error code and category
 public:
-    error_code() noexcept : _Myval(0), _Mycat(&system_category()) { // construct non-error
+    error_code() noexcept : _Myval(0), _Mycat(&_STD system_category()) { // construct non-error
     }
 
     error_code(int _Val, const error_category& _Cat) noexcept : _Myval(_Val), _Mycat(&_Cat) {}
@@ -145,7 +145,7 @@ public:
 
     void clear() noexcept {
         _Myval = 0;
-        _Mycat = &system_category();
+        _Mycat = &_STD system_category();
     }
 
     _NODISCARD int value() const noexcept {
@@ -205,7 +205,7 @@ private:
 // CLASS error_condition
 class error_condition { // store an abstract error code and category
 public:
-    error_condition() noexcept : _Myval(0), _Mycat(&generic_category()) { // construct non-error
+    error_condition() noexcept : _Myval(0), _Mycat(&_STD generic_category()) { // construct non-error
     }
 
     error_condition(int _Val, const error_category& _Cat) noexcept : _Myval(_Val), _Mycat(&_Cat) {}
@@ -229,7 +229,7 @@ public:
 
     void clear() noexcept {
         _Myval = 0;
-        _Mycat = &generic_category();
+        _Mycat = &_STD generic_category();
     }
 
     _NODISCARD int value() const noexcept {
@@ -346,20 +346,20 @@ _NODISCARD inline error_condition error_code::default_error_condition() const no
 
 // FUNCTION make_error_code
 _NODISCARD inline error_code make_error_code(errc _Errno) noexcept {
-    return error_code(static_cast<int>(_Errno), generic_category());
+    return error_code(static_cast<int>(_Errno), _STD generic_category());
 }
 
 _NODISCARD inline error_code make_error_code(io_errc _Errno) noexcept {
-    return error_code(static_cast<int>(_Errno), iostream_category());
+    return error_code(static_cast<int>(_Errno), _STD iostream_category());
 }
 
 // FUNCTION make_error_condition
 _NODISCARD inline error_condition make_error_condition(errc _Errno) noexcept {
-    return error_condition(static_cast<int>(_Errno), generic_category());
+    return error_condition(static_cast<int>(_Errno), _STD generic_category());
 }
 
 _NODISCARD inline error_condition make_error_condition(io_errc _Errno) noexcept {
-    return error_condition(static_cast<int>(_Errno), iostream_category());
+    return error_condition(static_cast<int>(_Errno), _STD iostream_category());
 }
 
 // STRUCT TEMPLATE SPECIALIZATION hash
@@ -510,9 +510,9 @@ public:
         // make error_condition for error code (generic if possible)
         const int _Posv = _Winerror_map(_Errval);
         if (_Posv == 0) {
-            return error_condition(_Errval, system_category());
+            return error_condition(_Errval, _STD system_category());
         } else {
-            return error_condition(_Posv, generic_category());
+            return error_condition(_Posv, _STD generic_category());
         }
     }
 };

--- a/stl/inc/system_error
+++ b/stl/inc/system_error
@@ -121,8 +121,7 @@ _NODISCARD inline bool _System_error_equal(const error_code&, const error_condit
 // CLASS error_code
 class error_code { // store an implementation-specific error code and category
 public:
-    error_code() noexcept : _Myval(0), _Mycat(&_STD system_category()) { // construct non-error
-    }
+    error_code() noexcept : _Myval(0), _Mycat(&_STD system_category()) {} // construct non-error
 
     error_code(int _Val, const error_category& _Cat) noexcept : _Myval(_Val), _Mycat(&_Cat) {}
 
@@ -204,8 +203,7 @@ private:
 // CLASS error_condition
 class error_condition { // store an abstract error code and category
 public:
-    error_condition() noexcept : _Myval(0), _Mycat(&_STD generic_category()) { // construct non-error
-    }
+    error_condition() noexcept : _Myval(0), _Mycat(&_STD generic_category()) {} // construct non-error
 
     error_condition(int _Val, const error_category& _Cat) noexcept : _Myval(_Val), _Mycat(&_Cat) {}
 

--- a/stl/inc/system_error
+++ b/stl/inc/system_error
@@ -138,7 +138,6 @@ public:
 
     template <class _Enum, enable_if_t<is_error_code_enum_v<_Enum>, int> = 0>
     error_code& operator=(_Enum _Errcode) noexcept {
-
         *this = make_error_code(_Errcode); // using ADL
         return *this;
     }
@@ -222,7 +221,6 @@ public:
 
     template <class _Enum, enable_if_t<is_error_condition_enum_v<_Enum>, int> = 0>
     error_condition& operator=(_Enum _Errcode) noexcept {
-
         *this = make_error_condition(_Errcode); // using ADL
         return *this;
     }

--- a/stl/inc/thread
+++ b/stl/inc/thread
@@ -173,8 +173,7 @@ namespace this_thread {
 
 class thread::id { // thread id
 public:
-    id() noexcept : _Id(0) { // id for no thread
-    }
+    id() noexcept : _Id(0) {} // id for no thread
 
 private:
     id(_Thrd_id_t _Other_id) : _Id(_Other_id) {}

--- a/stl/inc/tuple
+++ b/stl/inc/tuple
@@ -904,8 +904,7 @@ struct _View_as_tuple<array<_Ty, _Size>, _Types...>
 
 // STRUCT TEMPLATE _Repeat_for
 template <size_t _Nx, class _Ty>
-struct _Repeat_for : integral_constant<size_t, _Nx> { // repeats _Nx for each _Ty in a parameter pack
-};
+struct _Repeat_for : integral_constant<size_t, _Nx> {}; // repeats _Nx for each _Ty in a parameter pack
 
 // FUNCTION TEMPLATE tuple_cat
 template <class _Ret, class _Kx_arg, class _Ix_arg, size_t _Ix_next, class... _Tuples>
@@ -983,8 +982,7 @@ pair<_Ty1, _Ty2>::pair(piecewise_construct_t, tuple<_Types1...> _Val1, tuple<_Ty
 
 // STRUCT TEMPLATE uses_allocator
 template <class... _Types, class _Alloc>
-struct uses_allocator<tuple<_Types...>, _Alloc> : true_type { // true_type if container allocator enabled
-};
+struct uses_allocator<tuple<_Types...>, _Alloc> : true_type {}; // true_type if container allocator enabled
 
 #if _HAS_TR1_NAMESPACE
 namespace _DEPRECATE_TR1_NAMESPACE tr1 {

--- a/stl/inc/unordered_map
+++ b/stl/inc/unordered_map
@@ -511,12 +511,10 @@ public:
     using local_iterator       = typename _Mybase::iterator;
     using const_local_iterator = typename _Mybase::const_iterator;
 
-    unordered_multimap() : _Mybase(_Key_compare(), allocator_type()) { // construct empty map from defaults
-    }
+    unordered_multimap() : _Mybase(_Key_compare(), allocator_type()) {} // construct empty map from defaults
 
     explicit unordered_multimap(const allocator_type& _Al)
-        : _Mybase(_Key_compare(), _Al) { // construct empty map from defaults, allocator
-    }
+        : _Mybase(_Key_compare(), _Al) {} // construct empty map from defaults, allocator
 
     unordered_multimap(const unordered_multimap& _Right)
         : _Mybase(_Right, _Alnode_traits::select_on_container_copy_construction(_Right._Getal())) {}

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -278,7 +278,6 @@ struct pair { // store a pair of values
             int>            = 0>
     pair& operator=(_Identity_t<const _Myself&> _Right) noexcept(
         conjunction_v<is_nothrow_copy_assignable<_Ty1>, is_nothrow_copy_assignable<_Ty2>>) /* strengthened */ {
-
         first  = _Right.first;
         second = _Right.second;
         return *this;
@@ -290,7 +289,6 @@ struct pair { // store a pair of values
             int>            = 0>
     pair& operator=(_Identity_t<_Myself&&> _Right) noexcept(
         conjunction_v<is_nothrow_move_assignable<_Ty1>, is_nothrow_move_assignable<_Ty2>>) /* strengthened */ {
-
         first  = _STD forward<_Ty1>(_Right.first);
         second = _STD forward<_Ty2>(_Right.second);
         return *this;
@@ -302,7 +300,6 @@ struct pair { // store a pair of values
             int> = 0>
     pair& operator=(const pair<_Other1, _Other2>& _Right) noexcept(is_nothrow_assignable_v<_Ty1&, const _Other1&>&&
             is_nothrow_assignable_v<_Ty2&, const _Other2&>) /* strengthened */ {
-
         first  = _Right.first;
         second = _Right.second;
         return *this;
@@ -314,7 +311,6 @@ struct pair { // store a pair of values
             int> = 0>
     pair& operator=(pair<_Other1, _Other2>&& _Right) noexcept(
         is_nothrow_assignable_v<_Ty1&, _Other1>&& is_nothrow_assignable_v<_Ty2&, _Other2>) /* strengthened */ {
-
         first  = _STD forward<_Other1>(_Right.first);
         second = _STD forward<_Other2>(_Right.second);
         return *this;

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -426,14 +426,13 @@ struct _Tuple_size_sfinae<_Tuple, void_t<decltype(tuple_size<_Tuple>::value)>>
     : integral_constant<size_t, tuple_size<_Tuple>::value> {}; // selected when tuple_size<_Tuple>::value is well-formed
 
 template <class _Tuple>
-struct tuple_size<const _Tuple> : _Tuple_size_sfinae<_Tuple> {}; // size of const tuple
+struct tuple_size<const _Tuple> : _Tuple_size_sfinae<_Tuple> {}; // ignore cv
 
 template <class _Tuple>
-struct _CXX20_DEPRECATE_VOLATILE tuple_size<volatile _Tuple> : _Tuple_size_sfinae<_Tuple> {}; // size of volatile tuple
+struct _CXX20_DEPRECATE_VOLATILE tuple_size<volatile _Tuple> : _Tuple_size_sfinae<_Tuple> {}; // ignore cv
 
 template <class _Tuple>
-struct _CXX20_DEPRECATE_VOLATILE tuple_size<const volatile _Tuple> : _Tuple_size_sfinae<_Tuple> {
-}; // size of const volatile tuple
+struct _CXX20_DEPRECATE_VOLATILE tuple_size<const volatile _Tuple> : _Tuple_size_sfinae<_Tuple> {}; // ignore cv
 
 template <class _Ty>
 _INLINE_VAR constexpr size_t tuple_size_v = tuple_size<_Ty>::value;

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -419,26 +419,21 @@ template <class _Tuple>
 struct tuple_size;
 
 template <class _Tuple, class = void>
-struct _Tuple_size_sfinae { // selected when tuple_size<_Tuple>::value isn't well-formed
-};
+struct _Tuple_size_sfinae {}; // selected when tuple_size<_Tuple>::value isn't well-formed
 
 template <class _Tuple>
 struct _Tuple_size_sfinae<_Tuple, void_t<decltype(tuple_size<_Tuple>::value)>>
-    : integral_constant<size_t, tuple_size<_Tuple>::value> { // selected when tuple_size<_Tuple>::value is well-formed
-};
+    : integral_constant<size_t, tuple_size<_Tuple>::value> {}; // selected when tuple_size<_Tuple>::value is well-formed
 
 template <class _Tuple>
-struct tuple_size<const _Tuple> : _Tuple_size_sfinae<_Tuple> { // size of const tuple
-};
+struct tuple_size<const _Tuple> : _Tuple_size_sfinae<_Tuple> {}; // size of const tuple
 
 template <class _Tuple>
-struct _CXX20_DEPRECATE_VOLATILE tuple_size<volatile _Tuple> : _Tuple_size_sfinae<_Tuple> { // size of volatile tuple
-};
+struct _CXX20_DEPRECATE_VOLATILE tuple_size<volatile _Tuple> : _Tuple_size_sfinae<_Tuple> {}; // size of volatile tuple
 
 template <class _Tuple>
-struct _CXX20_DEPRECATE_VOLATILE tuple_size<const volatile _Tuple>
-    : _Tuple_size_sfinae<_Tuple> { // size of const volatile tuple
-};
+struct _CXX20_DEPRECATE_VOLATILE tuple_size<const volatile _Tuple> : _Tuple_size_sfinae<_Tuple> {
+}; // size of const volatile tuple
 
 template <class _Ty>
 _INLINE_VAR constexpr size_t tuple_size_v = tuple_size<_Ty>::value;
@@ -474,9 +469,7 @@ template <class _Ty, size_t _Size>
 class array;
 
 template <class _Ty, size_t _Size>
-struct tuple_size<array<_Ty, _Size>>
-    : integral_constant<size_t, _Size> { // struct to determine number of elements in array
-};
+struct tuple_size<array<_Ty, _Size>> : integral_constant<size_t, _Size> {}; // size of array
 
 template <size_t _Idx, class _Ty, size_t _Size>
 struct _MSVC_KNOWN_SEMANTICS tuple_element<_Idx, array<_Ty, _Size>> {
@@ -488,8 +481,7 @@ struct _MSVC_KNOWN_SEMANTICS tuple_element<_Idx, array<_Ty, _Size>> {
 
 // TUPLE INTERFACE TO tuple
 template <class... _Types>
-struct tuple_size<tuple<_Types...>> : integral_constant<size_t, sizeof...(_Types)> { // size of tuple
-};
+struct tuple_size<tuple<_Types...>> : integral_constant<size_t, sizeof...(_Types)> {}; // size of tuple
 
 template <size_t _Index>
 struct _MSVC_KNOWN_SEMANTICS tuple_element<_Index, tuple<>> { // enforce bounds checking
@@ -505,13 +497,11 @@ struct _MSVC_KNOWN_SEMANTICS tuple_element<0, tuple<_This, _Rest...>> { // selec
 
 template <size_t _Index, class _This, class... _Rest>
 struct _MSVC_KNOWN_SEMANTICS tuple_element<_Index, tuple<_This, _Rest...>>
-    : tuple_element<_Index - 1, tuple<_Rest...>> { // recursive tuple_element definition
-};
+    : tuple_element<_Index - 1, tuple<_Rest...>> {}; // recursive tuple_element definition
 
 // TUPLE INTERFACE TO pair
 template <class _Ty1, class _Ty2>
-struct tuple_size<pair<_Ty1, _Ty2>> : integral_constant<size_t, 2> { // size of pair
-};
+struct tuple_size<pair<_Ty1, _Ty2>> : integral_constant<size_t, 2> {}; // size of pair
 
 template <size_t _Idx, class _Ty1, class _Ty2>
 struct _MSVC_KNOWN_SEMANTICS tuple_element<_Idx, pair<_Ty1, _Ty2>> {

--- a/stl/inc/valarray
+++ b/stl/inc/valarray
@@ -1315,7 +1315,6 @@ _NODISCARD gslice_array<_Ty> valarray<_Ty>::operator[](const gslice& _Gslicearr)
 
 template <class _Ty>
 valarray<_Ty>& valarray<_Ty>::operator=(const mask_array<_Ty>& _Maskarr) {
-
     _Tidy_deallocate();
     _Grow(_Maskarr._Totlen());
     size_t _Count = 0;

--- a/stl/inc/valarray
+++ b/stl/inc/valarray
@@ -953,8 +953,7 @@ private:
 // CLASS gslice
 class gslice { // define a generalized (multidimensional) slice of a valarray
 public:
-    gslice() : _Start(0) { // construct with all zeros
-    }
+    gslice() : _Start(0) {} // construct with all zeros
 
     gslice(size_t _Off, const _Sizarray& _Lenarr, const _Sizarray& _Incarr)
         : _Start(_Off), _Len(_Lenarr), _Stride(_Incarr) {}

--- a/stl/inc/variant
+++ b/stl/inc/variant
@@ -442,8 +442,7 @@ protected:
 }
 
 template <bool _TrivialDestruction, class... _Types>
-class _Variant_storage_ { // empty storage (empty "_Types" case)
-};
+class _Variant_storage_ {}; // empty storage (empty "_Types" case)
 
 // ALIAS TEMPLATE _Variant_storage
 template <class... _Types>
@@ -458,19 +457,17 @@ public:
         _Variant_storage<_Rest...> _Tail;
     };
 
-    _Variant_storage_() noexcept { // no initialization (no active member)
-    }
+    _Variant_storage_() noexcept {} // no initialization (no active member)
 
     template <class... _Types>
     constexpr explicit _Variant_storage_(integral_constant<size_t, 0>, _Types&&... _Args) noexcept(
         is_nothrow_constructible_v<_First, _Types...>)
-        : _Head(static_cast<_Types&&>(_Args)...) { // initialize _Head with _Args...
-    }
+        : _Head(static_cast<_Types&&>(_Args)...) {} // initialize _Head with _Args...
+
     template <size_t _Idx, class... _Types, enable_if_t<(_Idx > 0), int> = 0>
     constexpr explicit _Variant_storage_(integral_constant<size_t, _Idx>, _Types&&... _Args) noexcept(
         is_nothrow_constructible_v<_Variant_storage<_Rest...>, integral_constant<size_t, _Idx - 1>, _Types...>)
-        : _Tail(integral_constant<size_t, _Idx - 1>{}, static_cast<_Types&&>(_Args)...) { // initialize _Tail (recurse)
-    }
+        : _Tail(integral_constant<size_t, _Idx - 1>{}, static_cast<_Types&&>(_Args)...) {} // initialize _Tail (recurse)
 
     _NODISCARD constexpr _First& _Get() & noexcept {
         return _Head;
@@ -499,19 +496,17 @@ public:
                                     // since the class has a variant member with a non-trivial destructor)
     }
 
-    _Variant_storage_() noexcept { // no initialization (no active member)
-    }
+    _Variant_storage_() noexcept {} // no initialization (no active member)
 
     template <class... _Types>
     constexpr explicit _Variant_storage_(integral_constant<size_t, 0>, _Types&&... _Args) noexcept(
         is_nothrow_constructible_v<_First, _Types...>)
-        : _Head(static_cast<_Types&&>(_Args)...) { // initialize _Head with _Args...
-    }
+        : _Head(static_cast<_Types&&>(_Args)...) {} // initialize _Head with _Args...
+
     template <size_t _Idx, class... _Types, enable_if_t<(_Idx > 0), int> = 0>
     constexpr explicit _Variant_storage_(integral_constant<size_t, _Idx>, _Types&&... _Args) noexcept(
         is_nothrow_constructible_v<_Variant_storage<_Rest...>, integral_constant<size_t, _Idx - 1>, _Types...>)
-        : _Tail(integral_constant<size_t, _Idx - 1>{}, static_cast<_Types&&>(_Args)...) { // initialize _Tail (recurse)
-    }
+        : _Tail(integral_constant<size_t, _Idx - 1>{}, static_cast<_Types&&>(_Args)...) {} // initialize _Tail (recurse)
 
     _Variant_storage_(_Variant_storage_&&)      = default;
     _Variant_storage_(const _Variant_storage_&) = default;
@@ -557,19 +552,17 @@ public:
                                     // since the class has a variant member with a non-trivial destructor)
     }
 
-    _Variant_storage_() noexcept { // no initialization (no active member)
-    }
+    _Variant_storage_() noexcept {} // no initialization (no active member)
 
     template <class... _Types>
     constexpr explicit _Variant_storage_(integral_constant<size_t, 0>, _Types&&... _Args) noexcept(
         is_nothrow_constructible_v<_First ^, _Types...>)
-        : _Head(static_cast<_Types&&>(_Args)...) { // initialize _Head with _Args...
-    }
+        : _Head(static_cast<_Types&&>(_Args)...) {} // initialize _Head with _Args...
+
     template <size_t _Idx, class... _Types, enable_if_t<(_Idx > 0), int> = 0>
     constexpr explicit _Variant_storage_(integral_constant<size_t, _Idx>, _Types&&... _Args) noexcept(
         is_nothrow_constructible_v<_Variant_storage<_Rest...>, integral_constant<size_t, _Idx - 1>, _Types...>)
-        : _Tail(integral_constant<size_t, _Idx - 1>{}, static_cast<_Types&&>(_Args)...) { // initialize _Tail (recurse)
-    }
+        : _Tail(integral_constant<size_t, _Idx - 1>{}, static_cast<_Types&&>(_Args)...) {} // initialize _Tail (recurse)
 
     _Variant_storage_(_Variant_storage_&&)      = default;
     _Variant_storage_(const _Variant_storage_&) = default;
@@ -862,8 +855,7 @@ public:
         return _STD move(*this);
     }
 
-    _Variant_base() noexcept : _Storage_t{}, _Which{_Invalid_index} { // initialize to the value-less state
-    }
+    _Variant_base() noexcept : _Storage_t{}, _Which{_Invalid_index} {} // initialize to the value-less state
 
     template <size_t _Idx, class... _UTypes,
         enable_if_t<is_constructible_v<_Meta_at_c<variant<_Types...>, _Idx>, _UTypes...>, int> = 0>
@@ -994,8 +986,7 @@ template <class... _Types>
 using _Variant_init_overload_set = _Variant_init_overload_set_<index_sequence_for<_Types...>, _Types...>;
 
 template <class Enable, class _Ty, class... _Types>
-struct _Variant_init_helper { // failure case (has no member "type")
-};
+struct _Variant_init_helper {}; // failure case (has no member "type")
 
 template <class _Ty, class... _Types>
 struct _Variant_init_helper<void_t<decltype(_Variant_init_overload_set<_Types...>{}(_STD declval<_Ty>()))>, _Ty,
@@ -1029,8 +1020,7 @@ public:
     // constructors [variant.ctor]
     template <class _First = _Meta_front<variant>, enable_if_t<is_default_constructible_v<_First>, int> = 0>
     constexpr variant() noexcept(is_nothrow_default_constructible_v<_First>)
-        : _Mybase(in_place_index<0>) { // value-initialize alternative 0
-    }
+        : _Mybase(in_place_index<0>) {} // value-initialize alternative 0
 
     template <class _Ty,
         enable_if_t<sizeof...(_Types) != 0 //
@@ -1064,7 +1054,8 @@ public:
         enable_if_t<is_constructible_v<_Meta_at_c<variant, _Idx>, _UTypes...>, int> = 0>
     constexpr explicit variant(in_place_index_t<_Idx>, _UTypes&&... _Args) noexcept(
         is_nothrow_constructible_v<_Meta_at_c<variant, _Idx>, _UTypes...>) // strengthened
-        : _Mybase(in_place_index<_Idx>, static_cast<_UTypes&&>(_Args)...) { // initialize alternative _Idx from _Args...
+        : _Mybase(in_place_index<_Idx>, static_cast<_UTypes&&>(_Args)...) {
+        // initialize alternative _Idx from _Args...
     }
     template <size_t _Idx, class _Elem, class... _UTypes,
         enable_if_t<is_constructible_v<_Meta_at_c<variant, _Idx>, initializer_list<_Elem>&, _UTypes...>, int> = 0>

--- a/stl/inc/xfacet
+++ b/stl/inc/xfacet
@@ -25,8 +25,7 @@ _STD_BEGIN
 // CLASS _Facet_base
 class _CRTIMP2_PURE_IMPORT _Facet_base { // code for reference counting a facet
 public:
-    virtual __CLR_OR_THIS_CALL ~_Facet_base() noexcept { // ensure that derived classes can be destroyed properly
-    }
+    virtual __CLR_OR_THIS_CALL ~_Facet_base() noexcept {} // ensure that derived classes can be destroyed properly
 
     // increment use count
     virtual void __CLR_OR_THIS_CALL _Incref() noexcept = 0;

--- a/stl/inc/xiosbase
+++ b/stl/inc/xiosbase
@@ -199,12 +199,10 @@ public:
     class failure : public system_error { // base of all iostreams exceptions
     public:
         explicit failure(const string& _Message, const error_code& _Errcode = make_error_code(io_errc::stream))
-            : system_error(_Errcode, _Message) { // construct with message
-        }
+            : system_error(_Errcode, _Message) {} // construct with message
 
         explicit failure(const char* _Message, const error_code& _Errcode = make_error_code(io_errc::stream))
-            : system_error(_Errcode, _Message) { // construct with message
-        }
+            : system_error(_Errcode, _Message) {} // construct with message
 
 #if !_HAS_EXCEPTIONS
     protected:
@@ -479,8 +477,7 @@ private:
     struct _Iosarray : _Crt_new_delete { // list element for open-ended sparse array of longs/pointers
     public:
         __CLR_OR_THIS_CALL _Iosarray(int _Idx, _Iosarray* _Link)
-            : _Next(_Link), _Index(_Idx), _Lo(0), _Vp(nullptr) { // construct node for index _Idx and link it in
-        }
+            : _Next(_Link), _Index(_Idx), _Lo(0), _Vp(nullptr) {} // construct node for index _Idx and link it in
 
         _Iosarray* _Next; // pointer to next node
         int _Index; // index of this node
@@ -491,8 +488,7 @@ private:
     // STRUCT _Fnarray
     struct _Fnarray : _Crt_new_delete { // list element for open-ended sparse array of event handlers
         __CLR_OR_THIS_CALL _Fnarray(int _Idx, event_callback _Pnew, _Fnarray* _Link)
-            : _Next(_Link), _Index(_Idx), _Pfn(_Pnew) { // construct node for index _Idx and link it in
-        }
+            : _Next(_Link), _Index(_Idx), _Pfn(_Pnew) {} // construct node for index _Idx and link it in
 
         _Fnarray* _Next; // pointer to next node
         int _Index; // index of this node

--- a/stl/inc/xlocale
+++ b/stl/inc/xlocale
@@ -85,8 +85,7 @@ struct _CRTIMP2_PURE_IMPORT _Crt_new_delete { // base class for marking allocati
         return _Ptr;
     }
 
-    void __CLRCALL_OR_CDECL operator delete(void*, void*) noexcept { // imitate True Placement Delete
-    }
+    void __CLRCALL_OR_CDECL operator delete(void*, void*) noexcept {} // imitate True Placement Delete
 #endif // _DEBUG
 };
 
@@ -3255,12 +3254,10 @@ public:
     static_assert(!_ENFORCE_FACET_SPECIALIZATIONS || _Is_any_of_v<_Elem, char, wchar_t>, _FACET_SPECIALIZATION_MESSAGE);
 
     explicit __CLR_OR_THIS_CALL ctype_byname(const char* _Locname, size_t _Refs = 0)
-        : ctype<_Elem>(_Locinfo(_Locname), _Refs) { // construct for named locale
-    }
+        : ctype<_Elem>(_Locinfo(_Locname), _Refs) {} // construct for named locale
 
     explicit __CLR_OR_THIS_CALL ctype_byname(const string& _Str, size_t _Refs = 0)
-        : ctype<_Elem>(_Locinfo(_Str.c_str()), _Refs) { // construct for named locale
-    }
+        : ctype<_Elem>(_Locinfo(_Str.c_str()), _Refs) {} // construct for named locale
 
 protected:
     virtual __CLR_OR_THIS_CALL ~ctype_byname() noexcept {}

--- a/stl/inc/xlocmes
+++ b/stl/inc/xlocmes
@@ -78,8 +78,7 @@ protected:
 
     virtual __CLR_OR_THIS_CALL ~messages() noexcept {}
 
-    void _Init(const _Locinfo&) { // initialize from _Locinfo object (do nothing)
-    }
+    void _Init(const _Locinfo&) {} // initialize from _Locinfo object (do nothing)
 
     virtual catalog __CLR_OR_THIS_CALL do_open(const string&, const locale&) const { // open catalog (do nothing)
         return -1;
@@ -90,8 +89,7 @@ protected:
         return _Dflt;
     }
 
-    virtual void __CLR_OR_THIS_CALL do_close(catalog) const { // close catalog (do nothing)
-    }
+    virtual void __CLR_OR_THIS_CALL do_close(catalog) const {} // close catalog (do nothing)
 };
 
 // STATIC messages::id OBJECT
@@ -114,12 +112,10 @@ public:
     static_assert(!_ENFORCE_FACET_SPECIALIZATIONS || _Is_any_of_v<_Elem, char, wchar_t>, _FACET_SPECIALIZATION_MESSAGE);
 
     explicit messages_byname(const char* _Locname, size_t _Refs = 0)
-        : messages<_Elem>(_Locname, _Refs) { // construct for named locale
-    }
+        : messages<_Elem>(_Locname, _Refs) {} // construct for named locale
 
     explicit messages_byname(const string& _Str, size_t _Refs = 0)
-        : messages<_Elem>(_Str.c_str(), _Refs) { // construct for named locale
-    }
+        : messages<_Elem>(_Str.c_str(), _Refs) {} // construct for named locale
 
 protected:
     virtual __CLR_OR_THIS_CALL ~messages_byname() noexcept {}

--- a/stl/inc/xlocmon
+++ b/stl/inc/xlocmon
@@ -254,8 +254,7 @@ public:
     _PGLOBAL _CRTIMP2_PURE_IMPORT static const bool intl; // true if international
     __PURE_APPDOMAIN_GLOBAL _CRTIMP2_PURE_IMPORT static locale::id id; // unique facet id
 
-    explicit moneypunct(size_t _Refs = 0) : _Mpunct<_Elem>(_Refs, _Intl) { // construct from current locale
-    }
+    explicit moneypunct(size_t _Refs = 0) : _Mpunct<_Elem>(_Refs, _Intl) {} // construct from current locale
 
     moneypunct(const _Locinfo& _Lobj, size_t _Refs = 0, bool _Isdef = false)
         : _Mpunct<_Elem>(_Lobj, _Refs, _Intl, _Isdef) {}
@@ -299,12 +298,10 @@ public:
     static_assert(!_ENFORCE_FACET_SPECIALIZATIONS || _Is_any_of_v<_Elem, char, wchar_t>, _FACET_SPECIALIZATION_MESSAGE);
 
     explicit moneypunct_byname(const char* _Locname, size_t _Refs = 0)
-        : moneypunct<_Elem, _Intl>(_Locname, _Refs) { // construct for named locale
-    }
+        : moneypunct<_Elem, _Intl>(_Locname, _Refs) {} // construct for named locale
 
     explicit moneypunct_byname(const string& _Str, size_t _Refs = 0)
-        : moneypunct<_Elem, _Intl>(_Str.c_str(), _Refs) { // construct for named locale
-    }
+        : moneypunct<_Elem, _Intl>(_Str.c_str(), _Refs) {} // construct for named locale
 
 protected:
     virtual __CLR_OR_THIS_CALL ~moneypunct_byname() noexcept {}
@@ -358,8 +355,7 @@ public:
 protected:
     virtual __CLR_OR_THIS_CALL ~money_get() noexcept {}
 
-    void _Init(const _Locinfo&) { // initialize from _Locinfo object
-    }
+    void _Init(const _Locinfo&) {} // initialize from _Locinfo object
 
     virtual _InIt __CLR_OR_THIS_CALL do_get(_InIt _First, _InIt _Last, bool _Intl, ios_base& _Iosbase,
         ios_base::iostate& _State,
@@ -661,8 +657,7 @@ public:
 protected:
     virtual __CLR_OR_THIS_CALL ~money_put() noexcept {}
 
-    void _Init(const _Locinfo&) { // initialize from _Locinfo object
-    }
+    void _Init(const _Locinfo&) {} // initialize from _Locinfo object
 
     virtual _OutIt __CLR_OR_THIS_CALL do_put(_OutIt _Dest, bool _Intl, ios_base& _Iosbase, _Elem _Fill,
         long double _Val) const { // put long double to _Dest

--- a/stl/inc/xlocnum
+++ b/stl/inc/xlocnum
@@ -243,12 +243,10 @@ public:
     static_assert(!_ENFORCE_FACET_SPECIALIZATIONS || _Is_any_of_v<_Elem, char, wchar_t>, _FACET_SPECIALIZATION_MESSAGE);
 
     explicit numpunct_byname(const char* _Locname, size_t _Refs = 0)
-        : numpunct<_Elem>(_Locname, _Refs) { // construct for named locale
-    }
+        : numpunct<_Elem>(_Locname, _Refs) {} // construct for named locale
 
     explicit numpunct_byname(const string& _Str, size_t _Refs = 0)
-        : numpunct<_Elem>(_Str.c_str(), _Refs) { // construct for named locale
-    }
+        : numpunct<_Elem>(_Str.c_str(), _Refs) {} // construct for named locale
 
 protected:
     virtual __CLR_OR_THIS_CALL ~numpunct_byname() noexcept {}
@@ -290,8 +288,7 @@ public:
 protected:
     virtual __CLR_OR_THIS_CALL ~num_get() noexcept {}
 
-    void _Init(const _Locinfo&) { // initialize from _Locinfo object
-    }
+    void _Init(const _Locinfo&) {} // initialize from _Locinfo object
 
 public:
     explicit __CLR_OR_THIS_CALL num_get(size_t _Refs = 0) : locale::facet(_Refs) { // construct from current locale
@@ -1170,8 +1167,7 @@ public:
 protected:
     virtual __CLR_OR_THIS_CALL ~num_put() noexcept {}
 
-    void __CLR_OR_THIS_CALL _Init(const _Locinfo&) { // initialize from _Locinfo object
-    }
+    void __CLR_OR_THIS_CALL _Init(const _Locinfo&) {} // initialize from _Locinfo object
 
 public:
     explicit __CLR_OR_THIS_CALL num_put(size_t _Refs = 0) : locale::facet(_Refs) { // construct from current locale

--- a/stl/inc/xloctime
+++ b/stl/inc/xloctime
@@ -622,12 +622,10 @@ public:
     static_assert(!_ENFORCE_FACET_SPECIALIZATIONS || _Is_any_of_v<_Elem, char, wchar_t>, _FACET_SPECIALIZATION_MESSAGE);
 
     explicit time_get_byname(const char* _Locname, size_t _Refs = 0)
-        : time_get<_Elem, _InIt>(_Locname, _Refs) { // construct for named locale
-    }
+        : time_get<_Elem, _InIt>(_Locname, _Refs) {} // construct for named locale
 
     explicit time_get_byname(const string& _Str, size_t _Refs = 0)
-        : time_get<_Elem, _InIt>(_Locinfo(_Str.c_str()), _Refs) { // construct for named locale
-    }
+        : time_get<_Elem, _InIt>(_Locinfo(_Str.c_str()), _Refs) {} // construct for named locale
 
 protected:
     virtual __CLR_OR_THIS_CALL ~time_get_byname() noexcept {}
@@ -1010,12 +1008,10 @@ public:
     static_assert(!_ENFORCE_FACET_SPECIALIZATIONS || _Is_any_of_v<_Elem, char, wchar_t>, _FACET_SPECIALIZATION_MESSAGE);
 
     explicit time_put_byname(const char* _Locname, size_t _Refs = 0)
-        : time_put<_Elem, _OutIt>(_Locname, _Refs) { // construct for named locale
-    }
+        : time_put<_Elem, _OutIt>(_Locname, _Refs) {} // construct for named locale
 
     explicit time_put_byname(const string& _Str, size_t _Refs = 0)
-        : time_put<_Elem, _OutIt>(_Str.c_str(), _Refs) { // construct for named locale
-    }
+        : time_put<_Elem, _OutIt>(_Str.c_str(), _Refs) {} // construct for named locale
 
 protected:
     virtual __CLR_OR_THIS_CALL ~time_put_byname() noexcept {}

--- a/stl/inc/xpolymorphic_allocator.h
+++ b/stl/inc/xpolymorphic_allocator.h
@@ -206,8 +206,7 @@ namespace pmr {
 
         template <class _Uty>
         polymorphic_allocator(const polymorphic_allocator<_Uty>& _That) noexcept
-            : _Resource{_That._Resource} { // initialize with _That's resource
-        }
+            : _Resource{_That._Resource} {} // initialize with _That's resource
 
         polymorphic_allocator& operator=(const polymorphic_allocator&) = delete;
 

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -250,28 +250,24 @@ struct char_traits : _Char_traits<_Elem, long> {}; // properties of a string or 
 
 // STRUCT char_traits<char16_t>
 template <>
-struct char_traits<char16_t> : _WChar_traits<char16_t> {}; // properties of a string or stream char16_t element
+struct char_traits<char16_t> : _WChar_traits<char16_t> {};
 
 using u16streampos = streampos;
 
 // STRUCT char_traits<char32_t>
 template <>
-struct char_traits<char32_t>
-    : _Char_traits<char32_t, unsigned int> { // properties of a string or stream char32_t element
-};
+struct char_traits<char32_t> : _Char_traits<char32_t, unsigned int> {};
 
 using u32streampos = streampos;
 
 // STRUCT char_traits<wchar_t>
 template <>
-struct char_traits<wchar_t> : _WChar_traits<wchar_t> {}; // properties of a string or stream wchar_t element
+struct char_traits<wchar_t> : _WChar_traits<wchar_t> {};
 
 #ifdef _NATIVE_WCHAR_T_DEFINED
 // STRUCT char_traits<unsigned short>
 template <>
-struct char_traits<unsigned short> : _WChar_traits<unsigned short> {
-    // properties of a string or stream unsigned short element
-};
+struct char_traits<unsigned short> : _WChar_traits<unsigned short> {};
 #endif // _NATIVE_WCHAR_T_DEFINED
 
 #if defined(__cpp_char8_t) && defined(_MSC_VER) && !defined(__EDG__) && !defined(__clang__)
@@ -493,8 +489,7 @@ struct _Char_traits_lt {
 
 template <class _Elem>
 struct _Equal_memcmp_is_safe_helper<_Elem, _Elem, _Char_traits_eq<char_traits<_Elem>>>
-    : _Equal_memcmp_is_safe_helper<_Elem, _Elem, equal_to<>>::type { // builtin char_traits::eq behaves like equal_to<>
-};
+    : _Equal_memcmp_is_safe_helper<_Elem, _Elem, equal_to<>>::type {}; // builtin char_traits::eq acts like equal_to<>
 
 template <class _Traits>
 using _Traits_ch_t = typename _Traits::char_type;

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -5817,7 +5817,8 @@ _INLINE_VAR constexpr allocator_arg_t allocator_arg{};
 // STRUCT TEMPLATE uses_allocator
 template <class _Ty, class _Alloc>
 struct uses_allocator : _Has_allocator_type<_Ty, _Alloc>::type {
-}; // determine whether _Ty has an allocator_type member type
+    // determine whether _Ty has an allocator_type member type
+};
 
 template <class _Ty, class _Alloc>
 _INLINE_VAR constexpr bool uses_allocator_v = uses_allocator<_Ty, _Alloc>::value;

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -1434,14 +1434,12 @@ constexpr void _Seek_wrapped(_Ty*& _It, _Ty* const _UIt) {
 #if _HAS_CXX17
 // STRUCT TEMPLATE _Is_allocator
 template <class _Ty, class = void>
-struct _Is_allocator : false_type { // selected when _Ty can't possibly be an allocator
-};
+struct _Is_allocator : false_type {}; // selected when _Ty can't possibly be an allocator
 
 template <class _Ty>
 struct _Is_allocator<_Ty, void_t<typename _Ty::value_type, decltype(_STD declval<_Ty&>().deallocate(
                                                                _STD declval<_Ty&>().allocate(size_t{1}), size_t{1}))>>
-    : true_type { // selected when _Ty resembles an allocator, N4687 26.2.1 [container.requirements.general]/17
-};
+    : true_type {}; // selected when _Ty resembles an allocator, N4687 26.2.1 [container.requirements.general]/17
 
 // ALIAS TEMPLATES FOR DEDUCTION GUIDES, N4687 26.4.1 [associative.general]/2
 template <class _Iter>
@@ -1610,8 +1608,8 @@ struct _Priority_tag<0> { // base case priority tag for tag dispatch
 };
 
 template <class _InIt, class _Pr>
-void _Debug_order_set_unchecked2(_InIt, _InIt, _Pr&, input_iterator_tag,
-    _Priority_tag<0>) { // (don't) test if range is ordered by predicate, input iterators or different types
+void _Debug_order_set_unchecked2(_InIt, _InIt, _Pr&, input_iterator_tag, _Priority_tag<0>) {
+    // (don't) test if range is ordered by predicate, input iterators or different types
 }
 
 template <class _FwdIt, class _Pr>
@@ -5796,13 +5794,11 @@ private:
 
 // STRUCT TEMPLATE _Has_allocator_type
 template <class _Ty, class _Alloc, class = void>
-struct _Has_allocator_type : false_type { // tests for suitable _Ty::allocator_type
-};
+struct _Has_allocator_type : false_type {}; // tests for suitable _Ty::allocator_type
 
 template <class _Ty, class _Alloc>
 struct _Has_allocator_type<_Ty, _Alloc, void_t<typename _Ty::allocator_type>>
-    : is_convertible<_Alloc, typename _Ty::allocator_type>::type { // tests for suitable _Ty::allocator_type
-};
+    : is_convertible<_Alloc, typename _Ty::allocator_type>::type {}; // tests for suitable _Ty::allocator_type
 
 // STRUCT allocator_arg_t
 struct allocator_arg_t { // tag type for added allocator argument
@@ -5820,9 +5816,8 @@ _INLINE_VAR constexpr allocator_arg_t allocator_arg{};
 
 // STRUCT TEMPLATE uses_allocator
 template <class _Ty, class _Alloc>
-struct uses_allocator
-    : _Has_allocator_type<_Ty, _Alloc>::type { // determine whether _Ty has an allocator_type member type
-};
+struct uses_allocator : _Has_allocator_type<_Ty, _Alloc>::type {
+}; // determine whether _Ty has an allocator_type member type
 
 template <class _Ty, class _Alloc>
 _INLINE_VAR constexpr bool uses_allocator_v = uses_allocator<_Ty, _Alloc>::value;

--- a/stl/src/locale0.cpp
+++ b/stl/src/locale0.cpp
@@ -22,8 +22,7 @@ _STD_BEGIN
 
 struct _Fac_node { // node for lazy facet recording
     _Fac_node(_Fac_node* _Nextarg, _Facet_base* _Facptrarg)
-        : _Next(_Nextarg), _Facptr(_Facptrarg) { // construct a node with value
-    }
+        : _Next(_Nextarg), _Facptr(_Facptrarg) {} // construct a node with value
 
     ~_Fac_node() noexcept { // destroy a facet
         delete _Facptr->_Decref();

--- a/stl/src/memory_resource.cpp
+++ b/stl/src/memory_resource.cpp
@@ -64,8 +64,7 @@ namespace pmr {
             virtual void* do_allocate(size_t, size_t) override { // Sorry, OOM!
                 _Xbad_alloc();
             }
-            virtual void do_deallocate(void*, size_t, size_t) override { // Nothing to do
-            }
+            virtual void do_deallocate(void*, size_t, size_t) override {} // Nothing to do
         };
 
         return &const_cast<_Null_resource&>(_Immortalize_memcpy_image<_Null_resource>());


### PR DESCRIPTION
* Use empty braces to construct objects.
  + Note that all of these are our types, not user-defined types.
  + `<experimental/filesystem>`
    - Use `file_status{}` and `{}` for `path`.
    - Drop unnecessary comments for `begin()` and `end()`.
    - Return `{}` for `directory_iterator` and `recursive_directory_iterator` `end()`. (This is what Standard `<filesystem>` does.)
  + `<filesystem>`
    - Use `{}` for `path`.
  + `<memory>`
    - Use `weak_ptr{}`.
  + `<random>`
    - Use `true_type{}`, `is_arithmetic<_Gen>{}`, and `is_signed<_Ty>{}`.
* Add `_STD` qualification.
  + We conventionally qualify all non-`_Ugly` non-member function calls, even those with zero arguments (and therefore zero risk of ADL hijacking). However, many calls to `future_category()`, `generic_category()`, `iostream_category()`, and `system_category()` were missing `_STD`.
* Call `_Code.clear()`.
  + This has the same effect as `_Code = error_code();`, but with better throughput (avoiding `operator=` SFINAE) and increased consistency with Standard `<filesystem>`.
* Change `if (_Code != error_code())` to `if (_Code)`.
  + This is more efficient (because it avoids calling `system_category()`) and consistent with Standard `<filesystem>`. There's a slight semantic difference, which I believe is either irrelevant here or is an improvement: `error_code` equality considers both `value()` and `category()`, so an `error_code` with `value() == 0` but `generic_category()` would compare non-equal with `error_code()`, yet it would test as `false`. I believe that this is irrelevant because the `<experimental/filesystem>` machinery will never construct such an `error_code`.
* Change another test of `_Code != error_code()` to `_Code`.
* Change a test of `_Code == error_code()` to `!_Code`.
* Remove unnecessary empty lines.
  + The empty lines at the beginning of pair's verbose assignment operators were debatable, but I decided to remove them.
* Remove using-directive in `<regex>`.
  + This was the only occurrence of a "convenient" using-directive in the entire STL's product code. (The others are doing necessary work, or working around compiler bugs.)
  + While this was function-local and didn't create correctness issues, I felt that it was inconsistent with our usual conventions, and wasn't even saving significant verbosity. (Long ago, this was an enormously nested conditional expression, where the using-directive indeed helped. That was changed by Microsoft-internal MSVC-PR-182277, to the current chain of if-statements.)
* Adjust braces and comments.