### PR TITLE
Allow both ::value_type and ::element_type in indirectly_readable_traits

### DIFF
--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -377,6 +377,13 @@ struct indirectly_readable_traits<_Ty> : _Cond_value_type<typename _Ty::value_ty
 template <_Has_member_element_type _Ty>
 struct indirectly_readable_traits<_Ty> : _Cond_value_type<typename _Ty::element_type> {};
 
+// clang-format off
+template <_Has_member_value_type _Ty> // Per LWG issue submitted but unnumbered as of 2020-05-14
+    requires _Has_member_element_type<_Ty>
+        && same_as<remove_cv_t<typename _Ty::value_type>, remove_cv_t<typename _Ty::element_type>>
+struct indirectly_readable_traits<_Ty> : _Cond_value_type<typename _Ty::value_type> {};
+// clang-format on
+
 // ALIAS TEMPLATE iter_value_t
 template <class _Ty>
 using iter_value_t = typename conditional_t<_Is_from_primary<iterator_traits<remove_cvref_t<_Ty>>>,

--- a/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
@@ -3239,6 +3239,27 @@ namespace lwg3420 {
     STATIC_ASSERT(!has_member_value_type<std::iterator_traits<X>>);
 } // namespace lwg3420
 
+namespace vso1121031 {
+    // Validate that indirectly_readable_traits accepts type arguments with both value_type and element_type nested
+    // types if they are consistent.
+    using std::indirectly_readable_traits, std::same_as;
+
+    template <class Element>
+    struct iterish {
+        using value_type   = int;
+        using element_type = Element;
+    };
+    STATIC_ASSERT(same_as<indirectly_readable_traits<iterish<int>>::value_type, int>);
+    STATIC_ASSERT(same_as<indirectly_readable_traits<iterish<int const>>::value_type, int>);
+    STATIC_ASSERT(same_as<indirectly_readable_traits<iterish<int volatile>>::value_type, int>);
+    STATIC_ASSERT(same_as<indirectly_readable_traits<iterish<int const volatile>>::value_type, int>);
+
+    STATIC_ASSERT(!has_member_value_type<indirectly_readable_traits<iterish<float>>>);
+    STATIC_ASSERT(!has_member_value_type<indirectly_readable_traits<iterish<float const>>>);
+    STATIC_ASSERT(!has_member_value_type<indirectly_readable_traits<iterish<float volatile>>>);
+    STATIC_ASSERT(!has_member_value_type<indirectly_readable_traits<iterish<float const volatile>>>);
+} // namespace vso1121031
+
 int main() {
     iterator_cust_swap_test::test();
     iter_ops::test();


### PR DESCRIPTION
Per [readable.traits], `indirectly_readable_traits<T>::value_type` is the same type as `remove_cv_t<T::value_type>` if it denotes an object type, or `remove_cv_t<T::element_type>` if it denotes an object type. If both `T::value_type` and `T::element_type` denote types, `indirectly_readable_traits<T>::value_type` is ill-formed. This was perhaps not the best design, given that there are iterators in the wild (Boost's unordered containers) that define both nested types. `indirectly_readable_traits` should tolerate iterators that define both nested types consistently.

Fixes VSO-1121031.
