### PR TITLE
[tests] Enable span tests now that libc++ has been updated

### DIFF
--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -801,11 +801,6 @@ std/iterators/predef.iterators/insert.iterators/insert.iterator/types.pass.cpp F
 std/numerics/complex.number/cmplx.over/conj.pass.cpp:0 FAIL
 std/numerics/complex.number/cmplx.over/proj.pass.cpp:0 FAIL
 
-# Bogus for various reasons (See https://reviews.llvm.org/D80030)
-std/containers/views/span.cons/stdarray.pass.cpp:0 FAIL
-std/utilities/function.objects/func.wrap/func.wrap.func/func.wrap.func.con/F_assign.pass.cpp FAIL
-std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.const/shared_ptr_pointer.pass.cpp FAIL
-
 
 # *** LIKELY STL BUGS ***
 # Not yet analyzed, likely STL bugs. Assertions and other runtime failures.

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -691,9 +691,6 @@ std/thread/thread.threads/thread.thread.class/thread.thread.member/join.pass.cpp
 std/depr/depr.c.headers/math_h.pass.cpp FAIL
 std/numerics/c.math/cmath.pass.cpp FAIL
 
-# Test needs to be updated for P1976R2 "Explicit Constructors For Fixed-Extent span From Dynamic-Extent Ranges".
-std/containers/views/span.cons/assign.pass.cpp FAIL
-
 # Test bug after LWG-2899 "is_(nothrow_)move_constructible and tuple, optional and unique_ptr" was accepted.
 std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.asgn/move_convert.pass.cpp FAIL
 std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.asgn/move_convert.runtime.pass.cpp FAIL
@@ -702,21 +699,6 @@ std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.asgn/move.pass.cpp
 
 # Test bug after LWG-3257 "Missing feature testing macro update from P0858" was accepted.
 std/language.support/support.limits/support.limits.general/string.version.pass.cpp FAIL
-
-# Test needs to be updated for LWG-3320 removing span::const_iterator.
-std/containers/views/types.pass.cpp FAIL
-std/containers/views/span.iterators/begin.pass.cpp FAIL
-std/containers/views/span.iterators/rbegin.pass.cpp FAIL
-std/containers/views/span.iterators/end.pass.cpp FAIL
-std/containers/views/span.iterators/rend.pass.cpp FAIL
-
-# Test needs to be removed after P2116R0 removed the tuple interface of span
-std/containers/views/span.tuple/get.fail.cpp PASS
-std/containers/views/span.tuple/get.pass.cpp FAIL
-std/containers/views/span.tuple/tuple_element.fail.cpp PASS
-std/containers/views/span.tuple/tuple_element.pass.cpp FAIL
-std/containers/views/span.tuple/tuple_size.fail.cpp PASS
-std/containers/views/span.tuple/tuple_size.pass.cpp FAIL
 
 # Not yet analyzed, likely bogus tests. Appears to be timing assumptions.
 std/thread/futures/futures.async/async.pass.cpp SKIPPED

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -801,6 +801,11 @@ std/iterators/predef.iterators/insert.iterators/insert.iterator/types.pass.cpp F
 std/numerics/complex.number/cmplx.over/conj.pass.cpp:0 FAIL
 std/numerics/complex.number/cmplx.over/proj.pass.cpp:0 FAIL
 
+# Bogus for various reasons (See https://reviews.llvm.org/D80030)
+std/containers/views/span.cons/stdarray.pass.cpp:0 FAIL
+std/utilities/function.objects/func.wrap/func.wrap.func/func.wrap.func.con/F_assign.pass.cpp FAIL
+std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.const/shared_ptr_pointer.pass.cpp FAIL
+
 
 # *** LIKELY STL BUGS ***
 # Not yet analyzed, likely STL bugs. Assertions and other runtime failures.
@@ -1010,9 +1015,6 @@ std/containers/unord/unord.map/unord.map.cnstr/deduct_const.pass.cpp FAIL
 std/containers/unord/unord.multimap/unord.multimap.cnstr/deduct.pass.cpp:0 FAIL
 std/containers/unord/unord.multimap/unord.multimap.cnstr/deduct_const.pass.cpp FAIL
 std/utilities/tuple/tuple.tuple/tuple.cnstr/deduct.pass.cpp:0 FAIL
-
-# Not yet analyzed. Assertion failed: f16_8.out(mbs, c16, c_c16p, c_c16p, c8, c8+4, c8p) == F32_8::ok
-std/localization/locale.categories/category.ctype/locale.codecvt/locale.codecvt.members/utf_sanity_check.pass.cpp FAIL
 
 # Not yet analyzed. Frequent timeouts
 std/containers/sequences/deque/deque.modifiers/insert_iter_iter.pass.cpp SKIPPED

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -801,11 +801,6 @@ iterators\predef.iterators\insert.iterators\insert.iterator\types.pass.cpp
 numerics\complex.number\cmplx.over\conj.pass.cpp
 numerics\complex.number\cmplx.over\proj.pass.cpp
 
-# Bogus for various reasons (See https://reviews.llvm.org/D80030)
-containers\views\span.cons\stdarray.pass.cpp
-utilities\function.objects\func.wrap\func.wrap.func\func.wrap.func.con\F_assign.pass.cpp
-utilities\memory\util.smartptr\util.smartptr.shared\util.smartptr.shared.const\shared_ptr_pointer.pass.cpp
-
 
 # *** LIKELY STL BUGS ***
 # Not yet analyzed, likely STL bugs. Assertions and other runtime failures.

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -691,9 +691,6 @@ thread\thread.threads\thread.thread.class\thread.thread.member\join.pass.cpp
 depr\depr.c.headers\math_h.pass.cpp
 numerics\c.math\cmath.pass.cpp
 
-# Test needs to be updated for P1976R2 "Explicit Constructors For Fixed-Extent span From Dynamic-Extent Ranges".
-containers\views\span.cons\assign.pass.cpp
-
 # Test bug after LWG-2899 "is_(nothrow_)move_constructible and tuple, optional and unique_ptr" was accepted.
 utilities\smartptr\unique.ptr\unique.ptr.class\unique.ptr.asgn\move_convert.pass.cpp
 utilities\smartptr\unique.ptr\unique.ptr.class\unique.ptr.asgn\move_convert.runtime.pass.cpp
@@ -702,21 +699,6 @@ utilities\smartptr\unique.ptr\unique.ptr.class\unique.ptr.asgn\move.pass.cpp
 
 # Test bug after LWG-3257 "Missing feature testing macro update from P0858" was accepted.
 language.support\support.limits\support.limits.general\string.version.pass.cpp
-
-# Test needs to be updated for LWG-3320 removing span::const_iterator.
-containers\views\types.pass.cpp
-containers\views\span.iterators\begin.pass.cpp
-containers\views\span.iterators\rbegin.pass.cpp
-containers\views\span.iterators\end.pass.cpp
-containers\views\span.iterators\rend.pass.cpp
-
-# Test needs to be removed after P2116R0 removed the tuple interface of span
-containers\views\span.tuple\get.fail.cpp
-containers\views\span.tuple\get.pass.cpp
-containers\views\span.tuple\tuple_element.fail.cpp
-containers\views\span.tuple\tuple_element.pass.cpp
-containers\views\span.tuple\tuple_size.fail.cpp
-containers\views\span.tuple\tuple_size.pass.cpp
 
 # Not yet analyzed, likely bogus tests. Appears to be timing assumptions.
 thread\futures\futures.async\async.pass.cpp

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -801,6 +801,11 @@ iterators\predef.iterators\insert.iterators\insert.iterator\types.pass.cpp
 numerics\complex.number\cmplx.over\conj.pass.cpp
 numerics\complex.number\cmplx.over\proj.pass.cpp
 
+# Bogus for various reasons (See https://reviews.llvm.org/D80030)
+containers\views\span.cons\stdarray.pass.cpp
+utilities\function.objects\func.wrap\func.wrap.func\func.wrap.func.con\F_assign.pass.cpp
+utilities\memory\util.smartptr\util.smartptr.shared\util.smartptr.shared.const\shared_ptr_pointer.pass.cpp
+
 
 # *** LIKELY STL BUGS ***
 # Not yet analyzed, likely STL bugs. Assertions and other runtime failures.
@@ -1010,9 +1015,6 @@ containers\unord\unord.map\unord.map.cnstr\deduct_const.pass.cpp
 containers\unord\unord.multimap\unord.multimap.cnstr\deduct.pass.cpp
 containers\unord\unord.multimap\unord.multimap.cnstr\deduct_const.pass.cpp
 utilities\tuple\tuple.tuple\tuple.cnstr\deduct.pass.cpp
-
-# Not yet analyzed. Assertion failed: f16_8.out(mbs, c16, c_c16p, c_c16p, c8, c8+4, c8p) == F32_8::ok
-localization\locale.categories\category.ctype\locale.codecvt\locale.codecvt.members\utf_sanity_check.pass.cpp
 
 # Not yet analyzed. Frequent timeouts
 containers\sequences\deque\deque.modifiers\insert_iter_iter.pass.cpp


### PR DESCRIPTION
It finally happened and the updates to std::span landed in libc++

Consequently we should now be able to use those tests.