### PR TITLE
LWG-3446 now has a number

### DIFF
--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -378,7 +378,7 @@ template <_Has_member_element_type _Ty>
 struct indirectly_readable_traits<_Ty> : _Cond_value_type<typename _Ty::element_type> {};
 
 // clang-format off
-template <_Has_member_value_type _Ty> // Per LWG issue submitted but unnumbered as of 2020-05-14
+template <_Has_member_value_type _Ty> // Per LWG-3446
     requires _Has_member_element_type<_Ty>
         && same_as<remove_cv_t<typename _Ty::value_type>, remove_cv_t<typename _Ty::element_type>>
 struct indirectly_readable_traits<_Ty> : _Cond_value_type<typename _Ty::value_type> {};


### PR DESCRIPTION
... which we can reference in `<xutility>` to explain why `indirectly_readable_traits` is non-standard.