### PR TITLE
<variant>: silence useless warning

### DIFF
--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -1658,12 +1658,11 @@ struct _Invoker_ret<_Unforced, false> { // selected for _Rx being _Unforced
     }
 };
 
-
 // TYPE TRAITS FOR invoke()
 #pragma warning(push)
-#pragma warning(disable : 4242) // 'identifier': conversion from '_From' to '_To', possible loss of data (/Wall)
-#pragma warning(disable : 4244) // 'argument': conversion from '_From' to '_To', possible loss of data
-#pragma warning(disable : 4365) // 'argument': conversion from '_From' to '_To', signed/unsigned mismatch (/Wall)
+#pragma warning(disable : 4242) // '%s': conversion from '%s' to '%s', possible loss of data (/Wall)
+#pragma warning(disable : 4244) // '%s': conversion from '%s' to '%s', possible loss of data (Yes, duplicated message.)
+#pragma warning(disable : 4365) // '%s': conversion from '%s' to '%s', signed/unsigned mismatch (/Wall)
 #pragma warning(disable : 5215) // '%s' a function parameter with a volatile qualified type is deprecated in C++20
 
 #ifdef __clang__

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -1658,6 +1658,7 @@ struct _Invoker_ret<_Unforced, false> { // selected for _Rx being _Unforced
     }
 };
 
+
 // TYPE TRAITS FOR invoke()
 #pragma warning(push)
 #pragma warning(disable : 4242) // '%s': conversion from '%s' to '%s', possible loss of data (/Wall)

--- a/stl/inc/variant
+++ b/stl/inc/variant
@@ -962,6 +962,7 @@ using _Variant_destroy_layer = conditional_t<conjunction_v<is_trivially_destruct
 #pragma clang diagnostic ignored "-Wdeprecated-volatile"
 #else // ^^^ Clang / not Clang vvv
 #pragma warning(push)
+#pragma warning(disable : 4242) // '%s': conversion from '%s' to '%s', possible loss of data
 #pragma warning(disable : 4244) // '%s': conversion from '%s' to '%s', possible loss of data
 #pragma warning(disable : 4365) // '%s': conversion from '%s' to '%s', signed/unsigned mismatch
 #pragma warning(disable : 5215) // '%s' a function parameter with volatile qualified type is deprecated in C++20

--- a/stl/inc/variant
+++ b/stl/inc/variant
@@ -963,7 +963,7 @@ using _Variant_destroy_layer = conditional_t<conjunction_v<is_trivially_destruct
 #else // ^^^ Clang / not Clang vvv
 #pragma warning(push)
 #pragma warning(disable : 4242) // '%s': conversion from '%s' to '%s', possible loss of data
-#pragma warning(disable : 4244) // '%s': conversion from '%s' to '%s', possible loss of data
+#pragma warning(disable : 4244) // '%s': conversion from '%s' to '%s', possible loss of data (Yes, duplicated message.)
 #pragma warning(disable : 4365) // '%s': conversion from '%s' to '%s', signed/unsigned mismatch
 #pragma warning(disable : 5215) // '%s' a function parameter with volatile qualified type is deprecated in C++20
 #endif // __clang__

--- a/stl/inc/variant
+++ b/stl/inc/variant
@@ -962,6 +962,7 @@ using _Variant_destroy_layer = conditional_t<conjunction_v<is_trivially_destruct
 #pragma clang diagnostic ignored "-Wdeprecated-volatile"
 #else // ^^^ Clang / not Clang vvv
 #pragma warning(push)
+#pragma warning(disable : 4244) // '%s': conversion from '%s' to '%s', possible loss of data
 #pragma warning(disable : 5215) // '%s' a function parameter with volatile qualified type is deprecated in C++20
 #endif // __clang__
 template <size_t _Idx, class _Ty>
@@ -969,11 +970,6 @@ struct _Variant_init_single_overload {
     using _FTy = _Meta_list<integral_constant<size_t, _Idx>, _Ty> (*)(_Ty);
     operator _FTy();
 };
-#ifdef __clang__
-#pragma clang diagnostic pop
-#else // ^^^ Clang / not Clang vvv
-#pragma warning(pop)
-#endif // __clang__
 
 template <class _Indices, class... _Types>
 struct _Variant_init_overload_set_;
@@ -1001,11 +997,16 @@ using _Variant_init_type = _Meta_front<_Meta_pop_front<typename _Variant_init_he
 
 template <class _Ty, class... _Types> // extract the index from _Variant_init_helper
 using _Variant_init_index = _Meta_front<typename _Variant_init_helper<void, _Ty, _Types...>::type>;
+#ifdef __clang__
+#pragma clang diagnostic pop
+#else // ^^^ Clang / not Clang vvv
+#pragma warning(pop)
+#endif // __clang__
 
 template <class>
-struct _Is_in_place_index_specialization : false_type {};
+inline constexpr bool _Is_in_place_index_specialization = false;
 template <size_t _Idx>
-struct _Is_in_place_index_specialization<in_place_index_t<_Idx>> : true_type {};
+inline constexpr bool _Is_in_place_index_specialization<in_place_index_t<_Idx>> = true;
 
 template <class... _Types>
 class variant : private _SMF_control<_Variant_destroy_layer<_Types...>, _Types...> { // discriminated union
@@ -1026,7 +1027,7 @@ public:
         enable_if_t<sizeof...(_Types) != 0 //
                         && !is_same_v<_Remove_cvref_t<_Ty>, variant> //
                         && !_Is_specialization_v<_Remove_cvref_t<_Ty>, in_place_type_t> //
-                        && !_Is_in_place_index_specialization<_Remove_cvref_t<_Ty>>::value //
+                        && !_Is_in_place_index_specialization<_Remove_cvref_t<_Ty>> //
                         && is_constructible_v<_Variant_init_type<_Ty, _Types...>, _Ty>, //
             int> = 0>
     constexpr variant(_Ty&& _Obj) noexcept(is_nothrow_constructible_v<_Variant_init_type<_Ty, _Types...>, _Ty>)

--- a/stl/inc/variant
+++ b/stl/inc/variant
@@ -963,6 +963,7 @@ using _Variant_destroy_layer = conditional_t<conjunction_v<is_trivially_destruct
 #else // ^^^ Clang / not Clang vvv
 #pragma warning(push)
 #pragma warning(disable : 4244) // '%s': conversion from '%s' to '%s', possible loss of data
+#pragma warning(disable : 4365) // '%s': conversion from '%s' to '%s', signed/unsigned mismatch
 #pragma warning(disable : 5215) // '%s' a function parameter with volatile qualified type is deprecated in C++20
 #endif // __clang__
 template <size_t _Idx, class _Ty>

--- a/tests/std/tests/P0088R3_variant/test.cpp
+++ b/tests/std/tests/P0088R3_variant/test.cpp
@@ -7069,11 +7069,16 @@ namespace msvc {
     } // namespace vso508126
 
     namespace DevCom1031281 {
-        void Overload(unsigned long long) {}
+        // Compilers may warn when initializing a variant from a "weird" argument, e.g., std::variant<short>{some_int}
+        // is potentially narrowing. Compilers should not, however, emit such diagnostics from the metaprogramming that
+        // determines which alternative a variant initialization would activate. We don't want to emit warnings when
+        // determining implicit conversion sequences early in overload resolution.
+
+        void Overload(int) {}
         void Overload(std::variant<unsigned short>) {}
 
         void run_test() {
-            Overload(42ULL);
+            Overload(42);
         }
     } // namespace DevCom1031281
 } // namespace msvc

--- a/tests/std/tests/P0088R3_variant/test.cpp
+++ b/tests/std/tests/P0088R3_variant/test.cpp
@@ -7067,6 +7067,15 @@ namespace msvc {
             static_assert(!std::is_copy_constructible_v<std::variant<volatile S>>);
         }
     } // namespace vso508126
+
+    namespace DevCom1031281 {
+        void Overload(unsigned long long) {}
+        void Overload(std::variant<unsigned short>) {}
+
+        void run_test() {
+            Overload(42ULL);
+        }
+    } // namespace DevCom1031281
 } // namespace msvc
 
 int main() {
@@ -7128,4 +7137,5 @@ int main() {
     msvc::vso468746::run_test();
     msvc::vso508126::run_test();
     msvc::vso492097::run_test();
+    msvc::DevCom1031281::run_test();
 }

--- a/tests/std/tests/VSO_0180469_fill_family/test.cpp
+++ b/tests/std/tests/VSO_0180469_fill_family/test.cpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #pragma warning(disable : 4242) // conversion from 'X' to 'Y', possible loss of data
-#pragma warning(disable : 4244) // conversion from 'X' to 'Y', possible loss of data
+#pragma warning(disable : 4244) // conversion from 'X' to 'Y', possible loss of data (Yes, duplicated message.)
 // Note that this test *should* trigger 4242 and 4244 inside STL headers, because it
 // calls std::fill and std::uninitialized_fill with (small type*, small type*, big type)
 #pragma warning(disable : 4365) // conversion from 'X' to 'Y', signed/unsigned mismatch

--- a/tests/tr1/tests/functional1/test.cpp
+++ b/tests/tr1/tests/functional1/test.cpp
@@ -10,7 +10,7 @@
 #define _SILENCE_CXX17_NEGATORS_DEPRECATION_WARNING
 
 #pragma warning(disable : 4242) // conversion from 'X' to 'Y', possible loss of data
-#pragma warning(disable : 4244) // conversion from 'X' to 'Y', possible loss of data
+#pragma warning(disable : 4244) // conversion from 'X' to 'Y', possible loss of data (Yes, duplicated message.)
 
 #include "tdefs.h"
 #include <algorithm>


### PR DESCRIPTION
We don't want narrowing (or any other, for that matter) conversion warnings in the machinery that determines which variant alternative to activate given an initializer. The actual initialization code should certainly emit these warnings, but emitting them from the metaprogramming machinery can produce warnings early in overload resolution while determining conversion sequences for overloads that might not be selected.

Fixes DevCom-1031281.

Drive-by: convert `_Is_in_place_index` into a variable template.
