### PR TITLE
Code cleanup: avoid macro-like identifiers, remove double newlines

### DIFF
--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -915,7 +915,6 @@ struct _Atomic_integral<_Ty, 1> : _Atomic_storage<_Ty> { // atomic integral oper
     }
 };
 
-
 template <class _Ty>
 struct _Atomic_integral<_Ty, 2> : _Atomic_storage<_Ty> { // atomic integral operations using 2-byte intrinsics
     using _Base = _Atomic_storage<_Ty>;

--- a/stl/inc/bitset
+++ b/stl/inc/bitset
@@ -102,11 +102,11 @@ public:
     constexpr bitset(unsigned long long _Val) noexcept : _Array{static_cast<_Ty>(_Need_mask ? _Val & _Mask : _Val)} {}
 
     template <class _Traits, class _Elem>
-    void _Construct(const _Elem* const _Ptr, size_t _Count, const _Elem _E0, const _Elem _E1) {
+    void _Construct(const _Elem* const _Ptr, size_t _Count, const _Elem _Elem0, const _Elem _Elem1) {
         if (_Count > _Bits) {
             for (size_t _Idx = _Bits; _Idx < _Count; ++_Idx) {
                 const auto _Ch = _Ptr[_Idx];
-                if (!_Traits::eq(_E1, _Ch) && !_Traits::eq(_E0, _Ch)) {
+                if (!_Traits::eq(_Elem1, _Ch) && !_Traits::eq(_Elem0, _Ch)) {
                     _Xinv();
                 }
             }
@@ -122,8 +122,8 @@ public:
             do {
                 --_Last;
                 const auto _Ch = *_Last;
-                _This_word |= static_cast<_Ty>(_Traits::eq(_E1, _Ch)) << _Bits_used_in_word;
-                if (!_Traits::eq(_E1, _Ch) && !_Traits::eq(_E0, _Ch)) {
+                _This_word |= static_cast<_Ty>(_Traits::eq(_Elem1, _Ch)) << _Bits_used_in_word;
+                if (!_Traits::eq(_Elem1, _Ch) && !_Traits::eq(_Elem0, _Ch)) {
                     _Xinv();
                 }
 
@@ -150,8 +150,8 @@ public:
     explicit bitset(const basic_string<_Elem, _Traits, _Alloc>& _Str,
         typename basic_string<_Elem, _Traits, _Alloc>::size_type _Pos   = 0,
         typename basic_string<_Elem, _Traits, _Alloc>::size_type _Count = basic_string<_Elem, _Traits, _Alloc>::npos,
-        _Elem _E0                                                       = static_cast<_Elem>('0'),
-        _Elem _E1 = static_cast<_Elem>('1')) { // construct from [_Pos, _Pos + _Count) elements in string
+        _Elem _Elem0 = static_cast<_Elem>('0'), _Elem _Elem1 = static_cast<_Elem>('1')) {
+        // construct from [_Pos, _Pos + _Count) elements in string
         if (_Str.size() < _Pos) {
             _Xran(); // _Pos off end
         }
@@ -160,17 +160,17 @@ public:
             _Count = _Str.size() - _Pos; // trim _Count to size
         }
 
-        _Construct<_Traits>(_Str.data() + _Pos, _Count, _E0, _E1);
+        _Construct<_Traits>(_Str.data() + _Pos, _Count, _Elem0, _Elem1);
     }
 
     template <class _Elem>
     explicit bitset(const _Elem* _Ntcts, typename basic_string<_Elem>::size_type _Count = basic_string<_Elem>::npos,
-        _Elem _E0 = static_cast<_Elem>('0'), _Elem _E1 = static_cast<_Elem>('1')) {
+        _Elem _Elem0 = static_cast<_Elem>('0'), _Elem _Elem1 = static_cast<_Elem>('1')) {
         if (_Count == basic_string<_Elem>::npos) {
             _Count = char_traits<_Elem>::length(_Ntcts);
         }
 
-        _Construct<char_traits<_Elem>>(_Ntcts, _Count, _E0, _E1);
+        _Construct<char_traits<_Elem>>(_Ntcts, _Count, _Elem0, _Elem1);
     }
 
     bitset& operator&=(const bitset& _Right) noexcept {
@@ -323,12 +323,13 @@ public:
 
     template <class _Elem = char, class _Tr = char_traits<_Elem>, class _Alloc = allocator<_Elem>>
     _NODISCARD basic_string<_Elem, _Tr, _Alloc> to_string(
-        _Elem _E0 = static_cast<_Elem>('0'), _Elem _E1 = static_cast<_Elem>('1')) const { // convert bitset to string
+        _Elem _Elem0 = static_cast<_Elem>('0'), _Elem _Elem1 = static_cast<_Elem>('1')) const {
+        // convert bitset to string
         basic_string<_Elem, _Tr, _Alloc> _Str;
         _Str.reserve(_Bits);
 
         for (auto _Pos = _Bits; 0 < _Pos;) {
-            _Str.push_back(_Subscript(--_Pos) ? _E1 : _E0);
+            _Str.push_back(_Subscript(--_Pos) ? _Elem1 : _Elem0);
         }
 
         return _Str;
@@ -490,10 +491,10 @@ template <class _Elem, class _Tr, size_t _Bits>
 basic_ostream<_Elem, _Tr>& operator<<(basic_ostream<_Elem, _Tr>& _Ostr, const bitset<_Bits>& _Right) {
     using _Ctype             = typename basic_ostream<_Elem, _Tr>::_Ctype;
     const _Ctype& _Ctype_fac = _STD use_facet<_Ctype>(_Ostr.getloc());
-    const _Elem _E0          = _Ctype_fac.widen('0');
-    const _Elem _E1          = _Ctype_fac.widen('1');
+    const _Elem _Elem0       = _Ctype_fac.widen('0');
+    const _Elem _Elem1       = _Ctype_fac.widen('1');
 
-    return _Ostr << _Right.template to_string<_Elem, _Tr, allocator<_Elem>>(_E0, _E1);
+    return _Ostr << _Right.template to_string<_Elem, _Tr, allocator<_Elem>>(_Elem0, _Elem1);
 }
 
 // TEMPLATE operator>>
@@ -502,8 +503,8 @@ basic_istream<_Elem, _Tr>& operator>>(basic_istream<_Elem, _Tr>& _Istr, bitset<_
     using _Istr_t                    = basic_istream<_Elem, _Tr>;
     using _Ctype                     = typename _Istr_t::_Ctype;
     const _Ctype& _Ctype_fac         = _STD use_facet<_Ctype>(_Istr.getloc());
-    const _Elem _E0                  = _Ctype_fac.widen('0');
-    const _Elem _E1                  = _Ctype_fac.widen('1');
+    const _Elem _Elem0               = _Ctype_fac.widen('0');
+    const _Elem _Elem1               = _Ctype_fac.widen('1');
     typename _Istr_t::iostate _State = _Istr_t::goodbit;
     bool _Changed                    = false;
     string _Str;
@@ -518,13 +519,13 @@ basic_istream<_Elem, _Tr>& operator>>(basic_istream<_Elem, _Tr>& _Istr, bitset<_
             if (_Tr::eq_int_type(_Tr::eof(), _Meta)) { // end of file, quit
                 _State |= _Istr_t::eofbit;
                 break;
-            } else if ((_Char = _Tr::to_char_type(_Meta)) != _E0 && _Char != _E1) {
+            } else if ((_Char = _Tr::to_char_type(_Meta)) != _Elem0 && _Char != _Elem1) {
                 break; // invalid element
             } else if (_Str.max_size() <= _Str.size()) { // no room in string, give up (unlikely)
                 _State |= _Istr_t::failbit;
                 break;
             } else { // valid, append '0' or '1'
-                _Str.push_back('0' + (_Char == _E1));
+                _Str.push_back('0' + (_Char == _Elem1));
                 _Changed = true;
             }
         }

--- a/stl/inc/charconv
+++ b/stl/inc/charconv
@@ -593,9 +593,9 @@ _NODISCARD inline bool _Add(_Big_integer_flt& _Xval, const uint32_t _Value) noex
     return true;
 }
 
-_NODISCARD inline uint32_t _Add_carry(uint32_t& _U1, const uint32_t _U2, const uint32_t _U_carry) noexcept {
-    const uint64_t _Uu = static_cast<uint64_t>(_U1) + _U2 + _U_carry;
-    _U1                = static_cast<uint32_t>(_Uu);
+_NODISCARD inline uint32_t _Add_carry(uint32_t& _Ux1, const uint32_t _Ux2, const uint32_t _U_carry) noexcept {
+    const uint64_t _Uu = static_cast<uint64_t>(_Ux1) + _Ux2 + _U_carry;
+    _Ux1               = static_cast<uint32_t>(_Uu);
     return static_cast<uint32_t>(_Uu >> 32);
 }
 

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -664,18 +664,18 @@ _NODISCARD bool _To_xtime_10_day_clamped(_CSTD xtime& _Xt, const chrono::duratio
     // Every function calling this one is TRANSITION, ABI
     constexpr chrono::nanoseconds _Ten_days{chrono::hours{24} * 10};
     constexpr chrono::duration<double> _Ten_days_d{_Ten_days};
-    chrono::nanoseconds _T0 = chrono::system_clock::now().time_since_epoch();
-    const bool _Clamped     = _Ten_days_d < _Rel_time;
+    chrono::nanoseconds _Tx0 = chrono::system_clock::now().time_since_epoch();
+    const bool _Clamped      = _Ten_days_d < _Rel_time;
     if (_Clamped) {
-        _T0 += _Ten_days;
+        _Tx0 += _Ten_days;
     } else {
-        _T0 += chrono::duration_cast<chrono::nanoseconds>(_Rel_time);
+        _Tx0 += chrono::duration_cast<chrono::nanoseconds>(_Rel_time);
     }
 
-    const auto _Whole_seconds = chrono::duration_cast<chrono::seconds>(_T0);
+    const auto _Whole_seconds = chrono::duration_cast<chrono::seconds>(_Tx0);
     _Xt.sec                   = _Whole_seconds.count();
-    _T0 -= _Whole_seconds;
-    _Xt.nsec = static_cast<long>(_T0.count());
+    _Tx0 -= _Whole_seconds;
+    _Xt.nsec = static_cast<long>(_Tx0.count());
     return _Clamped;
 }
 

--- a/stl/inc/concepts
+++ b/stl/inc/concepts
@@ -226,7 +226,6 @@ concept equality_comparable_with = equality_comparable<_Ty1> && equality_compara
     && equality_comparable<common_reference_t<const remove_reference_t<_Ty1>&, const remove_reference_t<_Ty2>&>>
     && _Weakly_equality_comparable_with<_Ty1, _Ty2>;
 
-
 // CONCEPT _Partially_ordered_with
 template <class _Ty1, class _Ty2>
 concept _Half_ordered = requires(const remove_reference_t<_Ty1>& __t, const remove_reference_t<_Ty2>& __u) {

--- a/stl/inc/cvt/ebcdic
+++ b/stl/inc/cvt/ebcdic
@@ -20,8 +20,6 @@ _STL_DISABLE_CLANG_WARNINGS
 
 namespace stdext {
     namespace cvt {
-
-
         using _Statype = _CSTD mbstate_t;
 
         // CLASS TEMPLATE codecvt_ebcdic

--- a/stl/inc/cvt/euc_0208
+++ b/stl/inc/cvt/euc_0208
@@ -20,8 +20,6 @@ _STL_DISABLE_CLANG_WARNINGS
 
 namespace stdext {
     namespace cvt {
-
-
         using _Statype = _CSTD mbstate_t;
 
         // CLASS TEMPLATE codecvt_euc_0208

--- a/stl/inc/cvt/jis_0208
+++ b/stl/inc/cvt/jis_0208
@@ -20,8 +20,6 @@ _STL_DISABLE_CLANG_WARNINGS
 
 namespace stdext {
     namespace cvt {
-
-
         using _Statype = _CSTD mbstate_t;
 
 #define _ESC_CODE 0x1b

--- a/stl/inc/cvt/utf16
+++ b/stl/inc/cvt/utf16
@@ -25,8 +25,6 @@ _STL_DISABLE_CLANG_WARNINGS
 
 namespace stdext {
     namespace cvt {
-
-
         using _Statype = _CSTD mbstate_t;
 
         _STL_DISABLE_DEPRECATED_WARNING

--- a/stl/inc/cvt/utf8_utf16
+++ b/stl/inc/cvt/utf8_utf16
@@ -47,7 +47,6 @@ namespace stdext {
 
             explicit codecvt_utf8_utf16(size_t _Refs = 0) : _Mybase(_Refs) {}
 
-
             virtual ~codecvt_utf8_utf16() noexcept {}
 
         protected:

--- a/stl/inc/cvt/wbuffer
+++ b/stl/inc/cvt/wbuffer
@@ -23,7 +23,6 @@ _STL_DISABLE_CLANG_WARNINGS
 // wostream mywcout(&mybuf); // construct wide ostream object
 // mywcout << static_cast<wchar_t>(0x80); // writes 0xc2 0x80
 
-
 namespace stdext {
     namespace cvt {
 

--- a/stl/inc/execution
+++ b/stl/inc/execution
@@ -1312,7 +1312,6 @@ struct _Static_partitioned_find2 {
     }
 };
 
-
 template <class _ExPo, class _FwdIt, class _Find_fx>
 _FwdIt _Find_parallel_unchecked(_ExPo&&, const _FwdIt _First, const _FwdIt _Last, const _Find_fx _Fx) {
     // find first matching _Val, potentially in parallel
@@ -3100,7 +3099,6 @@ _NODISCARD _FwdIt is_sorted_until(_ExPo&&, _FwdIt _First, _FwdIt _Last, _Pr _Pre
             }
         }
     }
-
 
     _Seek_wrapped(_First, _STD is_sorted_until(_UFirst, _ULast, _Pass_fn(_Pred)));
     return _First;

--- a/stl/inc/experimental/filesystem
+++ b/stl/inc/experimental/filesystem
@@ -60,7 +60,6 @@ using _Pchar = wchar_t; // UTF16
 #define _FS_SLASH  L'/'
 #define _FS_BSLASH L'\\'
 
-
 struct _Char8_t; // flag for UTF8
 
 // ENUM file_type
@@ -197,7 +196,6 @@ _FS_DLL int __CLRCALL_PURE_OR_CDECL _Resize(const wchar_t*, uintmax_t);
 _FS_DLL int __CLRCALL_PURE_OR_CDECL _Unlink(const wchar_t*);
 _FS_DLL int __CLRCALL_PURE_OR_CDECL _Copy_file(const wchar_t*, const wchar_t*);
 _FS_DLL int __CLRCALL_PURE_OR_CDECL _Chmod(const wchar_t*, perms);
-
 
 // STRUCT TEMPLATE _Path_cvt
 template <class _Inchar, class _Outchar, class _Outtraits = char_traits<_Outchar>,

--- a/stl/inc/forward_list
+++ b/stl/inc/forward_list
@@ -224,7 +224,6 @@ public:
     }
 };
 
-
 // forward_list TYPE WRAPPERS
 template <class _Value_type, class _Size_type, class _Difference_type, class _Pointer, class _Const_pointer,
     class _Reference, class _Const_reference, class _Nodeptr_type>

--- a/stl/inc/future
+++ b/stl/inc/future
@@ -616,7 +616,6 @@ private:
     function<void(_ArgTypes...)> _Fn;
 };
 
-
 template <class _Ty, class _Alloc>
 _Associated_state<_Ty>* _Make_associated_state(const _Alloc& _Al) {
     // construct an _Associated_state object with an allocator

--- a/stl/inc/iostream
+++ b/stl/inc/iostream
@@ -35,8 +35,6 @@ __PURE_APPDOMAIN_GLOBAL extern wistream* _Ptr_wcin;
 __PURE_APPDOMAIN_GLOBAL extern wostream* _Ptr_wcout;
 __PURE_APPDOMAIN_GLOBAL extern wostream* _Ptr_wcerr;
 __PURE_APPDOMAIN_GLOBAL extern wostream* _Ptr_wclog;
-
-
 #else // _M_CEE_PURE
       // OBJECTS
 __PURE_APPDOMAIN_GLOBAL extern _CRTDATA2_IMPORT istream cin;
@@ -56,7 +54,6 @@ __PURE_APPDOMAIN_GLOBAL extern _CRTDATA2_IMPORT wistream* _Ptr_wcin;
 __PURE_APPDOMAIN_GLOBAL extern _CRTDATA2_IMPORT wostream* _Ptr_wcout;
 __PURE_APPDOMAIN_GLOBAL extern _CRTDATA2_IMPORT wostream* _Ptr_wcerr;
 __PURE_APPDOMAIN_GLOBAL extern _CRTDATA2_IMPORT wostream* _Ptr_wclog;
-
 
 // CLASS _Winit
 class _CRTIMP2_PURE_IMPORT _Winit {

--- a/stl/inc/iterator
+++ b/stl/inc/iterator
@@ -128,7 +128,6 @@ _NODISCARD _CONSTEXPR20 front_insert_iterator<_Container> front_inserter(_Contai
     return front_insert_iterator<_Container>(_Cont);
 }
 
-
 // CLASS TEMPLATE insert_iterator
 template <class _Container>
 class insert_iterator { // wrap inserts into container as output iterator
@@ -298,7 +297,6 @@ _NODISCARD bool operator!=(const istream_iterator<_Ty, _Elem, _Traits, _Diff>& _
     const istream_iterator<_Ty, _Elem, _Traits, _Diff>& _Right) {
     return !(_Left == _Right);
 }
-
 
 // CLASS TEMPLATE ostream_iterator
 template <class _Ty, class _Elem = char, class _Traits = char_traits<_Elem>>

--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -2945,10 +2945,10 @@ inline void* align(size_t _Bound, size_t _Size, void*& _Ptr, size_t& _Space) noe
 }
 
 #if _HAS_CXX20 && 0
-template <size_t _N0, class _Ty>
+template <size_t _Nx, class _Ty>
 _NODISCARD constexpr _Ty* assume_aligned(_Ty* _Ptr) noexcept /* strengthened */ {
-    // this enforces the requirement that _N0 be a power of two
-    __builtin_assume_aligned(_Ptr, _N0);
+    // this enforces the requirement that _Nx be a power of two
+    __builtin_assume_aligned(_Ptr, _Nx);
 
     return _Ptr;
 }

--- a/stl/inc/mutex
+++ b/stl/inc/mutex
@@ -351,7 +351,6 @@ _NODISCARD int try_lock(_Lock0& _Lk0, _Lock1& _Lk1, _LockN&... _LkN) { // try to
     return _Try_lock1(_Lk0, _Lk1, _LkN...);
 }
 
-
 // FUNCTION TEMPLATE lock
 template <class... _LockN>
 int _Lock_attempt(const int _Hard_lock, _LockN&... _LkN) {
@@ -419,7 +418,6 @@ template <class _Lock0, class _Lock1, class... _LockN>
 void lock(_Lock0& _Lk0, _Lock1& _Lk1, _LockN&... _LkN) { // lock multiple locks, without deadlock
     _Lock_nonmember1(_Lk0, _Lk1, _LkN...);
 }
-
 
 // CLASS TEMPLATE lock_guard
 template <class _Mutex>

--- a/stl/inc/ostream
+++ b/stl/inc/ostream
@@ -101,7 +101,6 @@ public:
                 return;
             }
 
-
             _Tied->flush();
             _Ok = _Ostr.good(); // store test only after flushing tie
         }

--- a/stl/inc/random
+++ b/stl/inc/random
@@ -209,23 +209,23 @@ public:
             }
 
             for (_Kx = 0; _Kx < _Mx; ++_Kx) { // scramble and add any vector contributions
-                result_type _R1 =
+                result_type _Rx1 =
                     1664525 * _Xor27(_UFirst[_Kx % _Nx] ^ _UFirst[(_Kx + _Px) % _Nx] ^ _UFirst[(_Kx - 1) % _Nx]);
-                result_type _R2 = static_cast<result_type>(
-                    (_R1 + (_Kx == 0 ? _Sx : _Kx <= _Sx ? _Kx % _Nx + _Myvec[(_Kx - 1) % _Sx] : _Kx % _Nx)) & _Mask);
+                result_type _Rx2 = static_cast<result_type>(
+                    (_Rx1 + (_Kx == 0 ? _Sx : _Kx <= _Sx ? _Kx % _Nx + _Myvec[(_Kx - 1) % _Sx] : _Kx % _Nx)) & _Mask);
 
-                _UFirst[(_Kx + _Px) % _Nx] = (_UFirst[(_Kx + _Px) % _Nx] + _R1) & _Mask;
-                _UFirst[(_Kx + _Qx) % _Nx] = (_UFirst[(_Kx + _Qx) % _Nx] + _R2) & _Mask;
-                _UFirst[_Kx % _Nx]         = _R2;
+                _UFirst[(_Kx + _Px) % _Nx] = (_UFirst[(_Kx + _Px) % _Nx] + _Rx1) & _Mask;
+                _UFirst[(_Kx + _Qx) % _Nx] = (_UFirst[(_Kx + _Qx) % _Nx] + _Rx2) & _Mask;
+                _UFirst[_Kx % _Nx]         = _Rx2;
             }
             for (; _Kx < _Mx + _Nx; ++_Kx) { // rescramble
-                result_type _R3 =
+                result_type _Rx3 =
                     1566083941 * _Xor27(_UFirst[_Kx % _Nx] + _UFirst[(_Kx + _Px) % _Nx] + _UFirst[(_Kx - 1) % _Nx]);
-                result_type _R4 = static_cast<result_type>((_R3 - _Kx % _Nx) & _Mask);
+                result_type _Rx4 = static_cast<result_type>((_Rx3 - _Kx % _Nx) & _Mask);
 
-                _UFirst[(_Kx + _Px) % _Nx] = (_UFirst[(_Kx + _Px) % _Nx] ^ _R3) & _Mask;
-                _UFirst[(_Kx + _Qx) % _Nx] = (_UFirst[(_Kx + _Qx) % _Nx] ^ _R4) & _Mask;
-                _UFirst[_Kx % _Nx]         = _R4;
+                _UFirst[(_Kx + _Px) % _Nx] = (_UFirst[(_Kx + _Px) % _Nx] ^ _Rx3) & _Mask;
+                _UFirst[(_Kx + _Qx) % _Nx] = (_UFirst[(_Kx + _Qx) % _Nx] ^ _Rx4) & _Mask;
+                _UFirst[_Kx % _Nx]         = _Rx4;
             }
         }
     }
@@ -511,15 +511,15 @@ public:
     linear_congruential() noexcept // strengthened
         : _Prev(_Get_linear_congruential_seed<_Uint, _Cx, _Mx>(1u)) {}
 
-    explicit linear_congruential(_Uint _X0) noexcept // strengthened
-        : _Prev(_Get_linear_congruential_seed<_Uint, _Cx, _Mx>(_X0)) {}
+    explicit linear_congruential(_Uint _Xx0) noexcept // strengthened
+        : _Prev(_Get_linear_congruential_seed<_Uint, _Cx, _Mx>(_Xx0)) {}
 
     template <class _Gen, _Enable_if_seed_seq_t<_Gen, linear_congruential> = 0>
     linear_congruential(_Gen& _Seq) : _Prev(_Get_linear_congruential_seed<_Uint, _Cx, _Mx>(_Seq())) {}
 
-    void seed(_Uint _X0 = 1u) noexcept /* strengthened */ {
+    void seed(_Uint _Xx0 = 1u) noexcept /* strengthened */ {
         // reset sequence from numeric value
-        _Prev = _Get_linear_congruential_seed<_Uint, _Cx, _Mx>(_X0);
+        _Prev = _Get_linear_congruential_seed<_Uint, _Cx, _Mx>(_Xx0);
     }
 
     template <class _Gen, _Enable_if_seed_seq_t<_Gen, linear_congruential> = 0>
@@ -614,14 +614,14 @@ struct _Circ_buf { // holds historical values for generators
             _Other = _Right._Ax + _Right._Base();
         }
 
-        ptrdiff_t _N0 = _Nw;
-        while (0 < _N0) { // scan
-                          // note: may need up to three passes; each scan starts at the
-                          // current highest array position and ends at the end of the
-                          // array or the _Idx value, whichever comes first; the
-                          // equality test succeeds only by reaching the _Idx value.
+        ptrdiff_t _Nx0 = _Nw;
+        while (0 < _Nx0) { // scan
+                           // note: may need up to three passes; each scan starts at the
+                           // current highest array position and ends at the end of the
+                           // array or the _Idx value, whichever comes first; the
+                           // equality test succeeds only by reaching the _Idx value.
             const _Ty* _Limit = _First < _Last ? _Last : _Use2 ? _Right._Ax + 2 * _Nw : _Ax + 2 * _Nw;
-            _N0 -= _Limit - _First;
+            _Nx0 -= _Limit - _First;
             while (_First != _Limit) {
                 if (*_First++ != *_Other++) {
                     return false;
@@ -661,8 +661,8 @@ public:
         seed();
     }
 
-    _Swc_base(_Seed_t _X0) {
-        seed(_X0);
+    _Swc_base(_Seed_t _Xx0) {
+        seed(_Xx0);
     }
 
     template <class _Gen, _Enable_if_seed_seq_t<_Gen, _Swc_base> = 0>
@@ -883,7 +883,7 @@ public:
 
     subtract_with_carry() : _Mybase(default_seed) {}
 
-    explicit subtract_with_carry(_Ty _X0) : _Mybase(_X0) {}
+    explicit subtract_with_carry(_Ty _Xx0) : _Mybase(_Xx0) {}
 
     template <class _Gen, _Enable_if_seed_seq_t<_Gen, subtract_with_carry> = 0>
     subtract_with_carry(_Gen& _Gx) : _Mybase(_Gx) {}
@@ -912,7 +912,7 @@ public:
 
     subtract_with_carry_engine() : _Mybase(default_seed) {}
 
-    explicit subtract_with_carry_engine(_Ty _X0) : _Mybase(_X0) {}
+    explicit subtract_with_carry_engine(_Ty _Xx0) : _Mybase(_Xx0) {}
 
     template <class _Seed_seq, _Enable_if_seed_seq_t<_Seed_seq, subtract_with_carry_engine> = 0>
     explicit subtract_with_carry_engine(_Seed_seq& _Seq) : _Mybase() {
@@ -1077,8 +1077,9 @@ public:
         seed(default_seed, static_cast<_Ty>(1812433253));
     }
 
-    explicit mersenne_twister(_Ty _X0, _Ty _Dxarg = _WMSK, _Ty _Fxarg = static_cast<_Ty>(1812433253)) : _Dxval(_Dxarg) {
-        seed(_X0, _Fxarg);
+    explicit mersenne_twister(_Ty _Xx0, _Ty _Dxarg = _WMSK, _Ty _Fxarg = static_cast<_Ty>(1812433253))
+        : _Dxval(_Dxarg) {
+        seed(_Xx0, _Fxarg);
     }
 
     template <class _Gen, _Enable_if_seed_seq_t<_Gen, mersenne_twister> = 0>
@@ -1086,9 +1087,9 @@ public:
         seed(_Gx);
     }
 
-    void seed(_Ty _X0 = default_seed, _Ty _Fx = static_cast<_Ty>(1812433253)) {
+    void seed(_Ty _Xx0 = default_seed, _Ty _Fx = static_cast<_Ty>(1812433253)) {
         // set initial values from specified value
-        _Ty _Prev = this->_Ax[0] = _X0 & _WMSK;
+        _Ty _Prev = this->_Ax[0] = _Xx0 & _WMSK;
         for (size_t _Ix = 1; _Ix < _Nx; ++_Ix) {
             _Prev = this->_Ax[_Ix] = (_Ix + _Fx * (_Prev ^ (_Prev >> (_Wx - 2)))) & _WMSK;
         }
@@ -1241,15 +1242,15 @@ public:
 
     mersenne_twister_engine() : _Mybase(default_seed, _Dx, _Fx) {}
 
-    explicit mersenne_twister_engine(result_type _X0) : _Mybase(_X0, _Dx, _Fx) {}
+    explicit mersenne_twister_engine(result_type _Xx0) : _Mybase(_Xx0, _Dx, _Fx) {}
 
     template <class _Seed_seq, _Enable_if_seed_seq_t<_Seed_seq, mersenne_twister_engine> = 0>
     explicit mersenne_twister_engine(_Seed_seq& _Seq) : _Mybase(default_seed, _Dx, _Fx) {
         seed(_Seq);
     }
 
-    void seed(result_type _X0 = default_seed) { // set initial values from specified value
-        _Mybase::seed(_X0, _Fx);
+    void seed(result_type _Xx0 = default_seed) { // set initial values from specified value
+        _Mybase::seed(_Xx0, _Fx);
     }
 
     template <class _Seed_seq, _Enable_if_seed_seq_t<_Seed_seq, mersenne_twister_engine> = 0>
@@ -1315,8 +1316,8 @@ public:
         _Nx = 0;
     }
 
-    void seed(result_type _X0) { // seed engine from specified value
-        _Eng.seed(_X0);
+    void seed(result_type _Xx0) { // seed engine from specified value
+        _Eng.seed(_Xx0);
         _Nx = 0;
     }
 
@@ -1420,7 +1421,7 @@ public:
 
     explicit discard_block_engine(_Engine&& _Ex) : _Mybase(_STD move(_Ex)) {}
 
-    explicit discard_block_engine(result_type _X0) : _Mybase(_X0) {}
+    explicit discard_block_engine(result_type _Xx0) : _Mybase(_Xx0) {}
 
     template <class _Seed_seq, _Enable_if_seed_seq_t<_Seed_seq, discard_block_engine, _Engine> = 0>
     explicit discard_block_engine(_Seed_seq& _Seq) : _Mybase(_Seq) {}
@@ -1459,7 +1460,7 @@ public:
         _Init();
     }
 
-    explicit independent_bits_engine(result_type _X0) : _Eng(static_cast<_Eres>(_X0)) {
+    explicit independent_bits_engine(result_type _Xx0) : _Eng(static_cast<_Eres>(_Xx0)) {
         _Init();
     }
 
@@ -1472,8 +1473,8 @@ public:
         _Eng.seed();
     }
 
-    void seed(result_type _X0) { // seed engine from specified value
-        _Eng.seed(static_cast<_Eres>(_X0));
+    void seed(result_type _Xx0) { // seed engine from specified value
+        _Eng.seed(static_cast<_Eres>(_Xx0));
     }
 
     template <class _Seed_seq, _Enable_if_seed_seq_t<_Seed_seq, independent_bits_engine> = 0>
@@ -1496,28 +1497,28 @@ public:
     _NODISCARD result_type operator()() {
         size_t _Idx       = 0;
         result_type _Res  = 0;
-        result_type _Mask = ((result_type{1} << (_W0 - 1)) << 1) - 1;
+        result_type _Mask = ((result_type{1} << (_Wx0 - 1)) << 1) - 1;
         _Eres _Val;
 
-        for (; _Idx < _N0; ++_Idx) { // pack _W0-bit values
+        for (; _Idx < _Nx0; ++_Idx) { // pack _Wx0-bit values
             for (;;) { // get a small enough value
                 _Val = _Eng() - (_Engine::min)();
-                if (_Val <= _Y0) {
+                if (_Val <= _Yx0) {
                     break;
                 }
             }
-            _Res = _Res << _W0 | (static_cast<result_type>(_Val) & _Mask);
+            _Res = _Res << _Wx0 | (static_cast<result_type>(_Val) & _Mask);
         }
 
         _Mask = _Mask << 1 | 1;
-        for (; _Idx < _Nx; ++_Idx) { // pack _W0+1-bit values
+        for (; _Idx < _Nx; ++_Idx) { // pack _Wx0+1-bit values
             for (;;) { // get a small enough value
                 _Val = _Eng() - (_Engine::min)();
-                if (_Val <= _Y1) {
+                if (_Val <= _Yx1) {
                     break;
                 }
             }
-            _Res = _Res << (_W0 + 1) | (static_cast<result_type>(_Val) & _Mask);
+            _Res = _Res << (_Wx0 + 1) | (static_cast<result_type>(_Val) & _Mask);
         }
         return _Res;
     }
@@ -1553,25 +1554,25 @@ private:
         }
 
         for (size_t _Nfix = 0;; ++_Nfix) { // compute consistent set of parameters
-            _Nx = (_Wx + _Mx - 1) / _Mx + _Nfix; // trial _Nx
-            _W0 = _Wx / _Nx;
-            _N0 = _Nx - _Wx % _Nx;
-            _Y0 = (_Rx >> _W0) << _W0;
-            _Y1 = (((_Rx >> _W0) >> 1) << _W0) << 1;
-            if (_Nfix == 1 || _Rx - _Y0 <= _Y0 / _Nx) {
+            _Nx  = (_Wx + _Mx - 1) / _Mx + _Nfix; // trial _Nx
+            _Wx0 = _Wx / _Nx;
+            _Nx0 = _Nx - _Wx % _Nx;
+            _Yx0 = (_Rx >> _Wx0) << _Wx0;
+            _Yx1 = (((_Rx >> _Wx0) >> 1) << _Wx0) << 1;
+            if (_Nfix == 1 || _Rx - _Yx0 <= _Yx0 / _Nx) {
                 break; // also works if _Rx == 0 (_Mx == all bits)
             }
         }
-        --_Y0;
-        --_Y1;
+        --_Yx0;
+        --_Yx1;
     }
 
     _Engine _Eng; // the stored engine
-    size_t _N0; // number of smaller packing words
+    size_t _Nx0; // number of smaller packing words
     size_t _Nx; // total number of packing words
-    size_t _W0; // bits per smaller packing word
-    _Eres _Y0; // max value for smaller packing word
-    _Eres _Y1; // max value for larger packing word
+    size_t _Wx0; // bits per smaller packing word
+    _Eres _Yx0; // max value for smaller packing word
+    _Eres _Yx1; // max value for larger packing word
 };
 
 template <class _Engine, size_t _Wx, class _UIntType>
@@ -1621,7 +1622,7 @@ public:
         _Init();
     }
 
-    explicit shuffle_order_engine(result_type _X0) : _Eng(_X0) {
+    explicit shuffle_order_engine(result_type _Xx0) : _Eng(_Xx0) {
         _Init();
     }
 
@@ -1635,8 +1636,8 @@ public:
         _Init();
     }
 
-    void seed(result_type _X0) { // seed engine from specified value
-        _Eng.seed(_X0);
+    void seed(result_type _Xx0) { // seed engine from specified value
+        _Eng.seed(_Xx0);
         _Init();
     }
 
@@ -1941,8 +1942,8 @@ public:
             _Init(0.5);
         }
 
-        explicit param_type(double _P0) {
-            _Init(_P0);
+        explicit param_type(double _Px0) {
+            _Init(_Px0);
         }
 
         _NODISCARD bool operator==(const param_type& _Right) const {
@@ -1957,10 +1958,10 @@ public:
             return _Px;
         }
 
-        void _Init(double _P0) { // set internal state
-            _STL_ASSERT(0.0 <= _P0 && _P0 <= 1.0, "invalid probability argument for bernoulli_distribution");
+        void _Init(double _Px0) { // set internal state
+            _STL_ASSERT(0.0 <= _Px0 && _Px0 <= 1.0, "invalid probability argument for bernoulli_distribution");
 
-            _Px = _P0;
+            _Px = _Px0;
         }
 
         double _Px;
@@ -1968,7 +1969,7 @@ public:
 
     bernoulli_distribution() : _Par(0.5) {}
 
-    explicit bernoulli_distribution(double _P0) : _Par(_P0) {}
+    explicit bernoulli_distribution(double _Px0) : _Par(_Px0) {}
 
     explicit bernoulli_distribution(const param_type& _Par0) : _Par(_Par0) {}
 
@@ -2006,9 +2007,9 @@ public:
 
     template <class _Elem, class _Traits>
     basic_istream<_Elem, _Traits>& _Read(basic_istream<_Elem, _Traits>& _Istr) { // read state from _Istr
-        double _P0;
-        _In(_Istr, _P0);
-        _Par._Init(_P0);
+        double _Px0;
+        _In(_Istr, _Px0);
+        _Par._Init(_Px0);
         return _Istr;
     }
 
@@ -2064,8 +2065,8 @@ public:
             _Init(_Ty1(0.5));
         }
 
-        explicit param_type(_Ty1 _P0) {
-            _Init(_P0);
+        explicit param_type(_Ty1 _Px0) {
+            _Init(_Px0);
         }
 
         _NODISCARD bool operator==(const param_type& _Right) const {
@@ -2080,9 +2081,9 @@ public:
             return _Px;
         }
 
-        void _Init(_Ty1 _P0) { // initialize
-            _STL_ASSERT(0.0 < _P0 && _P0 < 1.0, "invalid probability argument for geometric_distribution");
-            _Px      = _P0;
+        void _Init(_Ty1 _Px0) { // initialize
+            _STL_ASSERT(0.0 < _Px0 && _Px0 < 1.0, "invalid probability argument for geometric_distribution");
+            _Px      = _Px0;
             _Log_1_p = _CSTD log(1 - _Px);
         }
 
@@ -2092,7 +2093,7 @@ public:
 
     geometric_distribution() : _Par(_Ty1(0.5)) {}
 
-    explicit geometric_distribution(_Ty1 _P0) : _Par(_P0) {}
+    explicit geometric_distribution(_Ty1 _Px0) : _Par(_Px0) {}
 
     explicit geometric_distribution(const param_type& _Par0) : _Par(_Par0) {}
 
@@ -2130,9 +2131,9 @@ public:
 
     template <class _Elem, class _Traits>
     basic_istream<_Elem, _Traits>& _Read(basic_istream<_Elem, _Traits>& _Istr) { // read state from _Istr
-        _Ty1 _P0;
-        _In(_Istr, _P0);
-        _Par._Init(_P0);
+        _Ty1 _Px0;
+        _In(_Istr, _Px0);
+        _Par._Init(_Px0);
         return _Istr;
     }
 
@@ -2186,7 +2187,7 @@ public:
         _Ty1 _Val;
         for (_Res = 0, _Val = 1.0;; ++_Res) { // count repetitions
             _Val *= _NRAND(_Eng, _Ty1);
-            if (_Val <= _G0) {
+            if (_Val <= _Gx0) {
                 break;
             }
         }
@@ -2194,11 +2195,11 @@ public:
     }
 
     void _Init(const _Ty1& _Mean0) { // set internal state
-        _G0 = _CSTD exp(-_Mean0);
+        _Gx0 = _CSTD exp(-_Mean0);
     }
 
 private:
-    _Ty1 _G0;
+    _Ty1 _Gx0;
 };
 
 template <class _Ty = int>
@@ -2238,14 +2239,14 @@ public:
             _Mean = _Mean0;
             _Sqrt = _CSTD sqrt(2.0 * _Mean0);
             _Logm = _CSTD log(_Mean0);
-            _G1   = _Mean0 * _Logm - _XLgamma(_Mean0 + 1.0);
+            _Gx1  = _Mean0 * _Logm - _XLgamma(_Mean0 + 1.0);
             _Small._Init(_Mean0);
         }
 
         _Ty1 _Mean;
         _Ty1 _Sqrt;
         _Ty1 _Logm;
-        _Ty1 _G1;
+        _Ty1 _Gx1;
 
         _Small_poisson_distribution<_Ty> _Small;
     };
@@ -2321,7 +2322,7 @@ private:
             }
 
             if (_NRAND(_Eng, _Ty1)
-                <= 0.9 * (1.0 + _Yx * _Yx) * _CSTD exp(_Res * _Par0._Logm - _XLgamma(_Res + 1.0) - _Par0._G1)) {
+                <= 0.9 * (1.0 + _Yx * _Yx) * _CSTD exp(_Res * _Par0._Logm - _XLgamma(_Res + 1.0) - _Par0._Gx1)) {
                 return _Res;
             }
         }
@@ -2370,8 +2371,8 @@ public:
             _Init(1, _Ty1(0.5));
         }
 
-        explicit param_type(_Ty _T0, _Ty1 _P0 = _Ty1(0.5)) {
-            _Init(_T0, _P0);
+        explicit param_type(_Ty _Tx0, _Ty1 _Px0 = _Ty1(0.5)) {
+            _Init(_Tx0, _Px0);
         }
 
         _NODISCARD bool operator==(const param_type& _Right) const {
@@ -2390,14 +2391,14 @@ public:
             return _Px;
         }
 
-        void _Init(_Ty _T0, _Ty1 _P0) { // initialize
-            _STL_ASSERT(0.0 <= _T0, "invalid max argument for binomial_distribution");
-            _STL_ASSERT(0.0 <= _P0 && _P0 <= 1.0, "invalid probability argument for binomial_distribution");
-            _Tx    = _T0;
-            _Px    = _P0;
+        void _Init(_Ty _Tx0, _Ty1 _Px0) { // initialize
+            _STL_ASSERT(0.0 <= _Tx0, "invalid max argument for binomial_distribution");
+            _STL_ASSERT(0.0 <= _Px0 && _Px0 <= 1.0, "invalid probability argument for binomial_distribution");
+            _Tx    = _Tx0;
+            _Px    = _Px0;
             _Pp    = _Px < 0.5 ? _Px : (1.0 - _Px);
             _Mean  = _Tx * _Pp;
-            _G1    = _XLgamma(_Tx + 1.0);
+            _Gx1   = _XLgamma(_Tx + 1.0);
             _Sqrt  = _CSTD sqrt(2 * _Mean * (1 - _Pp));
             _Logp  = _CSTD log(_Pp);
             _Logp1 = _CSTD log(1.0 - _Pp);
@@ -2408,7 +2409,7 @@ public:
         _Ty1 _Px;
         _Ty1 _Pp;
         _Ty1 _Mean;
-        _Ty1 _G1;
+        _Ty1 _Gx1;
         _Ty1 _Sqrt;
         _Ty1 _Logp;
         _Ty1 _Logp1;
@@ -2418,7 +2419,7 @@ public:
 
     binomial_distribution() : _Par(1, _Ty1(0.5)) {}
 
-    explicit binomial_distribution(_Ty _T0, _Ty1 _P0 = _Ty1(0.5)) : _Par(_T0, _P0) {}
+    explicit binomial_distribution(_Ty _Tx0, _Ty1 _Px0 = _Ty1(0.5)) : _Par(_Tx0, _Px0) {}
 
     explicit binomial_distribution(const param_type& _Par0) : _Par(_Par0) {}
 
@@ -2460,11 +2461,11 @@ public:
 
     template <class _Elem, class _Traits>
     basic_istream<_Elem, _Traits>& _Read(basic_istream<_Elem, _Traits>& _Istr) { // read state from _Istr
-        _Ty _T0;
-        _Ty1 _P0;
-        _In(_Istr, _P0);
-        _In(_Istr, _T0);
-        _Par._Init(_T0, _P0);
+        _Ty _Tx0;
+        _Ty1 _Px0;
+        _In(_Istr, _Px0);
+        _In(_Istr, _Tx0);
+        _Par._Init(_Tx0, _Px0);
         return _Istr;
     }
 
@@ -2504,7 +2505,7 @@ private:
                 }
                 if (_NRAND(_Eng, _Ty1)
                     <= 1.2 * _Par0._Sqrt * (1.0 + _Yx * _Yx)
-                           * _CSTD exp(_Par0._G1 - _XLgamma(_Res + 1.0) - _XLgamma(_Par0._Tx - _Res + 1.0)
+                           * _CSTD exp(_Par0._Gx1 - _XLgamma(_Res + 1.0) - _XLgamma(_Par0._Tx - _Res + 1.0)
                                        + _Res * _Par0._Logp + (_Par0._Tx - _Res) * _Par0._Logp1)) {
                     break;
                 }
@@ -2870,11 +2871,11 @@ public:
         _Ty _Sigma;
     };
 
-    normal_distribution() : _Par(0.0, 1.0), _Valid(false), _X2(0) {}
+    normal_distribution() : _Par(0.0, 1.0), _Valid(false), _Xx2(0) {}
 
-    explicit normal_distribution(_Ty _Mean0, _Ty _Sigma0 = 1.0) : _Par(_Mean0, _Sigma0), _Valid(false), _X2(0) {}
+    explicit normal_distribution(_Ty _Mean0, _Ty _Sigma0 = 1.0) : _Par(_Mean0, _Sigma0), _Valid(false), _Xx2(0) {}
 
-    explicit normal_distribution(const param_type& _Par0) : _Par(_Par0), _Valid(false), _X2(0) {}
+    explicit normal_distribution(const param_type& _Par0) : _Par(_Par0), _Valid(false), _Xx2(0) {}
 
     _NODISCARD _Ty mean() const {
         return _Par.mean();
@@ -2929,7 +2930,7 @@ public:
         _Par._Init(_Mean0, _Sigma0);
 
         _Istr >> _Valid;
-        _In(_Istr, _X2);
+        _In(_Istr, _Xx2);
         return _Istr;
     }
 
@@ -2939,7 +2940,7 @@ public:
         _Out(_Ostr, _Par._Sigma);
 
         _Ostr << ' ' << _Valid;
-        _Out(_Ostr, _X2);
+        _Out(_Ostr, _Xx2);
         return _Ostr;
     }
 
@@ -2950,33 +2951,33 @@ private:
                              // Knuth, vol. 2, p. 122, alg. P
         _Ty _Res;
         if (_Keep && _Valid) {
-            _Res   = _X2;
+            _Res   = _Xx2;
             _Valid = false;
         } else { // generate two values, store one, return one
-            _Ty _V1;
-            _Ty _V2;
+            _Ty _Vx1;
+            _Ty _Vx2;
             _Ty _Sx;
             for (;;) { // reject bad values
-                _V1 = 2 * _NRAND(_Eng, _Ty) - 1;
-                _V2 = 2 * _NRAND(_Eng, _Ty) - 1;
-                _Sx = _V1 * _V1 + _V2 * _V2;
+                _Vx1 = 2 * _NRAND(_Eng, _Ty) - 1;
+                _Vx2 = 2 * _NRAND(_Eng, _Ty) - 1;
+                _Sx  = _Vx1 * _Vx1 + _Vx2 * _Vx2;
                 if (_Sx < 1) {
                     break;
                 }
             }
             const auto _Fx = static_cast<_Ty>(_CSTD sqrt(-2.0 * _CSTD log(_Sx) / _Sx));
             if (_Keep) { // save second value for next call
-                _X2    = _Fx * _V2;
+                _Xx2   = _Fx * _Vx2;
                 _Valid = true;
             }
-            _Res = _Fx * _V1;
+            _Res = _Fx * _Vx1;
         }
         return _Res * _Par0._Sigma + _Par0._Mean;
     }
 
     param_type _Par;
     bool _Valid;
-    _Ty _X2;
+    _Ty _Xx2;
 };
 
 template <class _Ty>
@@ -3212,8 +3213,8 @@ public:
             _Init(_Ty{1}, _Ty{1});
         }
 
-        explicit param_type(_Ty _A0, _Ty _B0 = _Ty{1}) {
-            _Init(_A0, _B0);
+        explicit param_type(_Ty _Ax0, _Ty _Bx0 = _Ty{1}) {
+            _Init(_Ax0, _Bx0);
         }
 
         _NODISCARD bool operator==(const param_type& _Right) const {
@@ -3232,11 +3233,11 @@ public:
             return _Bx;
         }
 
-        void _Init(_Ty _A0, _Ty _B0) { // initialize
-            _STL_ASSERT(0.0 < _A0, "invalid a argument for weibull_distribution");
-            _STL_ASSERT(0.0 < _B0, "invalid b argument for weibull_distribution");
-            _Ax = _A0;
-            _Bx = _B0;
+        void _Init(_Ty _Ax0, _Ty _Bx0) { // initialize
+            _STL_ASSERT(0.0 < _Ax0, "invalid a argument for weibull_distribution");
+            _STL_ASSERT(0.0 < _Bx0, "invalid b argument for weibull_distribution");
+            _Ax = _Ax0;
+            _Bx = _Bx0;
         }
 
         _Ty _Ax;
@@ -3245,7 +3246,7 @@ public:
 
     weibull_distribution() : _Par(_Ty{1}, _Ty{1}) {}
 
-    explicit weibull_distribution(_Ty _A0, _Ty _B0 = _Ty{1}) : _Par(_A0, _B0) {}
+    explicit weibull_distribution(_Ty _Ax0, _Ty _Bx0 = _Ty{1}) : _Par(_Ax0, _Bx0) {}
 
     explicit weibull_distribution(const param_type& _Par0) : _Par(_Par0) {}
 
@@ -3287,11 +3288,11 @@ public:
 
     template <class _Elem, class _Traits>
     basic_istream<_Elem, _Traits>& _Read(basic_istream<_Elem, _Traits>& _Istr) { // read state from _Istr
-        _Ty _A0;
-        _Ty _B0;
-        _In(_Istr, _A0);
-        _In(_Istr, _B0);
-        _Par._Init(_A0, _B0);
+        _Ty _Ax0;
+        _Ty _Bx0;
+        _In(_Istr, _Ax0);
+        _In(_Istr, _Bx0);
+        _Par._Init(_Ax0, _Bx0);
         return _Istr;
     }
 
@@ -3349,8 +3350,8 @@ public:
             _Init(_Ty{0}, _Ty{1});
         }
 
-        explicit param_type(_Ty _A0, _Ty _B0 = _Ty{1}) {
-            _Init(_A0, _B0);
+        explicit param_type(_Ty _Ax0, _Ty _Bx0 = _Ty{1}) {
+            _Init(_Ax0, _Bx0);
         }
 
         _NODISCARD bool operator==(const param_type& _Right) const {
@@ -3369,10 +3370,10 @@ public:
             return _Bx;
         }
 
-        void _Init(_Ty _A0, _Ty _B0) { // initialize
-            _STL_ASSERT(0.0 < _B0, "invalid b argument for extreme_value_distribution");
-            _Ax = _A0;
-            _Bx = _B0;
+        void _Init(_Ty _Ax0, _Ty _Bx0) { // initialize
+            _STL_ASSERT(0.0 < _Bx0, "invalid b argument for extreme_value_distribution");
+            _Ax = _Ax0;
+            _Bx = _Bx0;
         }
 
         _Ty _Ax;
@@ -3381,7 +3382,7 @@ public:
 
     extreme_value_distribution() : _Par(_Ty{0}, _Ty{1}) {}
 
-    explicit extreme_value_distribution(_Ty _A0, _Ty _B0 = _Ty{1}) : _Par(_A0, _B0) {}
+    explicit extreme_value_distribution(_Ty _Ax0, _Ty _Bx0 = _Ty{1}) : _Par(_Ax0, _Bx0) {}
 
     explicit extreme_value_distribution(const param_type& _Par0) : _Par(_Par0) {}
 
@@ -3423,11 +3424,11 @@ public:
 
     template <class _Elem, class _Traits>
     basic_istream<_Elem, _Traits>& _Read(basic_istream<_Elem, _Traits>& _Istr) { // read state from _Istr
-        _Ty _A0;
-        _Ty _B0;
-        _In(_Istr, _A0);
-        _In(_Istr, _B0);
-        _Par._Init(_A0, _B0);
+        _Ty _Ax0;
+        _Ty _Bx0;
+        _In(_Istr, _Ax0);
+        _In(_Istr, _Bx0);
+        _Par._Init(_Ax0, _Bx0);
         return _Istr;
     }
 
@@ -3487,8 +3488,8 @@ public:
             _Init(_Ty{0}, _Ty{1});
         }
 
-        explicit param_type(_Ty _M0, _Ty _S0 = _Ty{1}) {
-            _Init(_M0, _S0);
+        explicit param_type(_Ty _Mx0, _Ty _Sx0 = _Ty{1}) {
+            _Init(_Mx0, _Sx0);
         }
 
         _NODISCARD bool operator==(const param_type& _Right) const {
@@ -3507,10 +3508,10 @@ public:
             return _Sx;
         }
 
-        void _Init(_Ty _M0, _Ty _S0) { // initialize
-            _STL_ASSERT(0.0 < _S0, "invalid s argument for lognormal_distribution");
-            _Mx = _M0;
-            _Sx = _S0;
+        void _Init(_Ty _Mx0, _Ty _Sx0) { // initialize
+            _STL_ASSERT(0.0 < _Sx0, "invalid s argument for lognormal_distribution");
+            _Mx = _Mx0;
+            _Sx = _Sx0;
         }
 
         _Ty _Mx;
@@ -3519,7 +3520,7 @@ public:
 
     lognormal_distribution() : _Par(_Ty{0}, _Ty{1}) {}
 
-    explicit lognormal_distribution(_Ty _M0, _Ty _S0 = _Ty{1}) : _Par(_M0, _S0) {}
+    explicit lognormal_distribution(_Ty _Mx0, _Ty _Sx0 = _Ty{1}) : _Par(_Mx0, _Sx0) {}
 
     explicit lognormal_distribution(const param_type& _Par0) : _Par(_Par0) {}
 
@@ -3561,11 +3562,11 @@ public:
 
     template <class _Elem, class _Traits>
     basic_istream<_Elem, _Traits>& _Read(basic_istream<_Elem, _Traits>& _Istr) { // read state from _Istr
-        _Ty _M0;
-        _Ty _S0;
-        _In(_Istr, _M0);
-        _In(_Istr, _S0);
-        _Par._Init(_M0, _S0);
+        _Ty _Mx0;
+        _Ty _Sx0;
+        _In(_Istr, _Mx0);
+        _In(_Istr, _Sx0);
+        _Par._Init(_Mx0, _Sx0);
         return _Istr;
     }
 
@@ -3623,8 +3624,8 @@ public:
             _Init(_Ty{1});
         }
 
-        explicit param_type(_Ty _N0) {
-            _Init(_N0);
+        explicit param_type(_Ty _Nx0) {
+            _Init(_Nx0);
         }
 
         _NODISCARD bool operator==(const param_type& _Right) const {
@@ -3639,9 +3640,9 @@ public:
             return _Nx;
         }
 
-        void _Init(_Ty _N0) { // initialize
-            _STL_ASSERT(0 < _N0, "invalid n argument for chi_squared_distribution");
-            _Nx = _N0;
+        void _Init(_Ty _Nx0) { // initialize
+            _STL_ASSERT(0 < _Nx0, "invalid n argument for chi_squared_distribution");
+            _Nx = _Nx0;
         }
 
         _Ty _Nx;
@@ -3649,7 +3650,7 @@ public:
 
     chi_squared_distribution() : _Par(_Ty{1}) {}
 
-    explicit chi_squared_distribution(_Ty _N0) : _Par(_N0) {}
+    explicit chi_squared_distribution(_Ty _Nx0) : _Par(_Nx0) {}
 
     explicit chi_squared_distribution(const param_type& _Par0) : _Par(_Par0) {}
 
@@ -3687,9 +3688,9 @@ public:
 
     template <class _Elem, class _Traits>
     basic_istream<_Elem, _Traits>& _Read(basic_istream<_Elem, _Traits>& _Istr) { // read state from _Istr
-        _Ty _N0;
-        _Istr >> _N0;
-        _Par._Init(_N0);
+        _Ty _Nx0;
+        _Istr >> _Nx0;
+        _Par._Init(_Nx0);
         return _Istr;
     }
 
@@ -3745,8 +3746,8 @@ public:
             _Init(_Ty{0}, _Ty{1});
         }
 
-        explicit param_type(_Ty _A0, _Ty _B0 = _Ty{1}) {
-            _Init(_A0, _B0);
+        explicit param_type(_Ty _Ax0, _Ty _Bx0 = _Ty{1}) {
+            _Init(_Ax0, _Bx0);
         }
 
         _NODISCARD bool operator==(const param_type& _Right) const {
@@ -3765,10 +3766,10 @@ public:
             return _Bx;
         }
 
-        void _Init(_Ty _A0, _Ty _B0) { // initialize
-            _STL_ASSERT(0.0 < _B0, "invalid b argument for cauchy_distribution");
-            _Ax = _A0;
-            _Bx = _B0;
+        void _Init(_Ty _Ax0, _Ty _Bx0) { // initialize
+            _STL_ASSERT(0.0 < _Bx0, "invalid b argument for cauchy_distribution");
+            _Ax = _Ax0;
+            _Bx = _Bx0;
         }
 
         _Ty _Ax;
@@ -3777,7 +3778,7 @@ public:
 
     cauchy_distribution() : _Par(_Ty{0}, _Ty{1}) {}
 
-    explicit cauchy_distribution(_Ty _A0, _Ty _B0 = _Ty{1}) : _Par(_A0, _B0) {}
+    explicit cauchy_distribution(_Ty _Ax0, _Ty _Bx0 = _Ty{1}) : _Par(_Ax0, _Bx0) {}
 
     explicit cauchy_distribution(const param_type& _Par0) : _Par(_Par0) {}
 
@@ -3819,11 +3820,11 @@ public:
 
     template <class _Elem, class _Traits>
     basic_istream<_Elem, _Traits>& _Read(basic_istream<_Elem, _Traits>& _Istr) { // read state from _Istr
-        _Ty _A0;
-        _Ty _B0;
-        _In(_Istr, _A0);
-        _In(_Istr, _B0);
-        _Par._Init(_A0, _B0);
+        _Ty _Ax0;
+        _Ty _Bx0;
+        _In(_Istr, _Ax0);
+        _In(_Istr, _Bx0);
+        _Par._Init(_Ax0, _Bx0);
         return _Istr;
     }
 
@@ -3872,44 +3873,44 @@ class _Beta_distribution { // beta distribution
 public:
     using result_type = _Ty;
 
-    explicit _Beta_distribution(const _Ty& _A0 = _Ty{1}, const _Ty& _B0 = _Ty{1}) {
-        _Init(_A0, _B0);
+    explicit _Beta_distribution(const _Ty& _Ax0 = _Ty{1}, const _Ty& _Bx0 = _Ty{1}) {
+        _Init(_Ax0, _Bx0);
     }
 
     template <class _Engine>
     _NODISCARD result_type operator()(_Engine& _Eng) const {
         if (_Ax < _Ty{1} && _Bx < _Ty{1}) { // look for a good value
             _Ty _Wx;
-            _Ty _P1;
-            _Ty _P2;
+            _Ty _Px1;
+            _Ty _Px2;
             for (;;) { // reject large values
-                _P1 = _NRAND(_Eng, _Ty);
-                _P2 = _NRAND(_Eng, _Ty);
-                _P1 = _CSTD pow(_P1, _Ty{1} / _Ax);
-                _P2 = _CSTD pow(_P2, _Ty{1} / _Bx);
-                _Wx = _P1 + _P2;
+                _Px1 = _NRAND(_Eng, _Ty);
+                _Px2 = _NRAND(_Eng, _Ty);
+                _Px1 = _CSTD pow(_Px1, _Ty{1} / _Ax);
+                _Px2 = _CSTD pow(_Px2, _Ty{1} / _Bx);
+                _Wx  = _Px1 + _Px2;
                 if (_Wx <= _Ty{1}) {
                     break;
                 }
             }
-            return _P1 / _Wx;
+            return _Px1 / _Wx;
         } else { // use gamma distributions instead
-            _Ty _P1;
-            _Ty _P2;
+            _Ty _Px1;
+            _Ty _Px2;
             gamma_distribution<_Ty> _Dist1(_Ax, 1);
             gamma_distribution<_Ty> _Dist2(_Bx, 1);
-            _P1 = _Dist1(_Eng);
-            _P2 = _Dist2(_Eng);
-            return _P1 / (_P1 + _P2);
+            _Px1 = _Dist1(_Eng);
+            _Px2 = _Dist2(_Eng);
+            return _Px1 / (_Px1 + _Px2);
         }
     }
 
 private:
-    void _Init(_Ty _A0, _Ty _B0) { // initialize
-        _STL_ASSERT(0.0 < _A0, "invalid a argument for _Beta_distribution");
-        _STL_ASSERT(0.0 < _B0, "invalid b argument for _Beta_distribution");
-        _Ax = _A0;
-        _Bx = _B0;
+    void _Init(_Ty _Ax0, _Ty _Bx0) { // initialize
+        _STL_ASSERT(0.0 < _Ax0, "invalid a argument for _Beta_distribution");
+        _STL_ASSERT(0.0 < _Bx0, "invalid b argument for _Beta_distribution");
+        _Ax = _Ax0;
+        _Bx = _Bx0;
     }
 
     _Ty _Ax;
@@ -3931,8 +3932,8 @@ public:
             _Init(_Ty{1}, _Ty{1});
         }
 
-        explicit param_type(_Ty _M0, _Ty _N0 = _Ty{1}) {
-            _Init(_M0, _N0);
+        explicit param_type(_Ty _Mx0, _Ty _Nx0 = _Ty{1}) {
+            _Init(_Mx0, _Nx0);
         }
 
         _NODISCARD bool operator==(const param_type& _Right) const {
@@ -3951,11 +3952,11 @@ public:
             return _Nx;
         }
 
-        void _Init(_Ty _M0, _Ty _N0) { // initialize
-            _STL_ASSERT(0 < _M0, "invalid m argument for fisher_f_distribution");
-            _STL_ASSERT(0 < _N0, "invalid n argument for fisher_f_distribution");
-            _Mx = _M0;
-            _Nx = _N0;
+        void _Init(_Ty _Mx0, _Ty _Nx0) { // initialize
+            _STL_ASSERT(0 < _Mx0, "invalid m argument for fisher_f_distribution");
+            _STL_ASSERT(0 < _Nx0, "invalid n argument for fisher_f_distribution");
+            _Mx = _Mx0;
+            _Nx = _Nx0;
         }
 
         _Ty _Mx;
@@ -3964,7 +3965,7 @@ public:
 
     fisher_f_distribution() : _Par(_Ty{1}, _Ty{1}) {}
 
-    explicit fisher_f_distribution(_Ty _M0, _Ty _N0 = _Ty{1}) : _Par(_M0, _N0) {}
+    explicit fisher_f_distribution(_Ty _Mx0, _Ty _Nx0 = _Ty{1}) : _Par(_Mx0, _Nx0) {}
 
     explicit fisher_f_distribution(const param_type& _Par0) : _Par(_Par0) {}
 
@@ -4006,10 +4007,10 @@ public:
 
     template <class _Elem, class _Traits>
     basic_istream<_Elem, _Traits>& _Read(basic_istream<_Elem, _Traits>& _Istr) { // read state from _Istr
-        _Ty _M0;
-        _Ty _N0;
-        _Istr >> _M0 >> _N0;
-        _Par._Init(_M0, _N0);
+        _Ty _Mx0;
+        _Ty _Nx0;
+        _Istr >> _Mx0 >> _Nx0;
+        _Par._Init(_Mx0, _Nx0);
         return _Istr;
     }
 
@@ -4023,14 +4024,14 @@ private:
     template <class _Engine>
     result_type _Eval(_Engine& _Eng, const param_type& _Par0) const {
         _Ty _Px;
-        _Ty _V1;
-        _Ty _V2;
-        _V1 = static_cast<_Ty>(_Par0._Mx) * static_cast<_Ty>(0.5);
-        _V2 = static_cast<_Ty>(_Par0._Nx) * static_cast<_Ty>(0.5);
-        _Beta_distribution<_Ty> _Dist(_V1, _V2);
+        _Ty _Vx1;
+        _Ty _Vx2;
+        _Vx1 = static_cast<_Ty>(_Par0._Mx) * static_cast<_Ty>(0.5);
+        _Vx2 = static_cast<_Ty>(_Par0._Nx) * static_cast<_Ty>(0.5);
+        _Beta_distribution<_Ty> _Dist(_Vx1, _Vx2);
         _Px = _Dist(_Eng);
 
-        return (_V2 / _V1) * (_Px / (_Ty{1} - _Px));
+        return (_Vx2 / _Vx1) * (_Px / (_Ty{1} - _Px));
     }
 
     param_type _Par;
@@ -4073,8 +4074,8 @@ public:
             _Init(_Ty{1});
         }
 
-        explicit param_type(_Ty _N0) {
-            _Init(_N0);
+        explicit param_type(_Ty _Nx0) {
+            _Init(_Nx0);
         }
 
         _NODISCARD bool operator==(const param_type& _Right) const {
@@ -4089,9 +4090,9 @@ public:
             return _Nx;
         }
 
-        void _Init(_Ty _N0) { // initialize
-            _STL_ASSERT(0 < _N0, "invalid n argument for student_t_distribution");
-            _Nx = _N0;
+        void _Init(_Ty _Nx0) { // initialize
+            _STL_ASSERT(0 < _Nx0, "invalid n argument for student_t_distribution");
+            _Nx = _Nx0;
         }
 
         _Ty _Nx;
@@ -4099,7 +4100,7 @@ public:
 
     student_t_distribution() : _Par(_Ty{1}) {}
 
-    explicit student_t_distribution(_Ty _N0) : _Par(_N0) {}
+    explicit student_t_distribution(_Ty _Nx0) : _Par(_Nx0) {}
 
     explicit student_t_distribution(const param_type& _Par0) : _Par(_Par0) {}
 
@@ -4137,9 +4138,9 @@ public:
 
     template <class _Elem, class _Traits>
     basic_istream<_Elem, _Traits>& _Read(basic_istream<_Elem, _Traits>& _Istr) { // read state from _Istr
-        _Ty _N0;
-        _Istr >> _N0;
-        _Par._Init(_N0);
+        _Ty _Nx0;
+        _Istr >> _Nx0;
+        _Par._Init(_Nx0);
         return _Istr;
     }
 
@@ -4151,23 +4152,23 @@ public:
 private:
     template <class _Engine>
     result_type _Eval(_Engine& _Eng, const param_type& _Par0) const {
-        _Ty _V1;
-        _Ty _V2;
-        _Ty _R0;
+        _Ty _Vx1;
+        _Ty _Vx2;
+        _Ty _Rx0;
         _Ty _Rs;
         uniform_real<_Ty> _Dist(-1, 1);
         for (;;) { // get a point inside unit circle
-            _V1 = _Dist(_Eng);
-            _V2 = _Dist(_Eng);
-            _Rs = _V1 * _V1 + _V2 * _V2;
+            _Vx1 = _Dist(_Eng);
+            _Vx2 = _Dist(_Eng);
+            _Rs  = _Vx1 * _Vx1 + _Vx2 * _Vx2;
 
             if (_Rs < _Ty{1}) {
                 break;
             }
         }
-        _R0 = _CSTD sqrt(_Rs);
+        _Rx0 = _CSTD sqrt(_Rs);
 
-        return _V1 * _CSTD sqrt(_Par0._Nx * (_CSTD pow(_R0, -_Ty{4} / _Par0._Nx) - _Ty{1}) / _Rs);
+        return _Vx1 * _CSTD sqrt(_Par0._Nx * (_CSTD pow(_Rx0, -_Ty{4} / _Par0._Nx) - _Ty{1}) / _Rs);
     }
 
     param_type _Par;
@@ -4210,8 +4211,8 @@ public:
             _Init(1, 0.5);
         }
 
-        explicit param_type(_Ty _K0, double _P0 = 0.5) {
-            _Init(_K0, _P0);
+        explicit param_type(_Ty _Kx0, double _Px0 = 0.5) {
+            _Init(_Kx0, _Px0);
         }
 
         _NODISCARD bool operator==(const param_type& _Right) const {
@@ -4230,13 +4231,13 @@ public:
             return _Px;
         }
 
-        void _Init(_Ty _K0, double _P0) { // initialize
-            _STL_ASSERT(0.0 < _K0, "invalid max argument for "
-                                   "negative_binomial_distribution");
-            _STL_ASSERT(0.0 < _P0 && _P0 <= 1.0, "invalid probability argument for "
-                                                 "negative_binomial_distribution");
-            _Kx = _K0;
-            _Px = _P0;
+        void _Init(_Ty _Kx0, double _Px0) { // initialize
+            _STL_ASSERT(0.0 < _Kx0, "invalid max argument for "
+                                    "negative_binomial_distribution");
+            _STL_ASSERT(0.0 < _Px0 && _Px0 <= 1.0, "invalid probability argument for "
+                                                   "negative_binomial_distribution");
+            _Kx = _Kx0;
+            _Px = _Px0;
         }
 
         _Ty _Kx;
@@ -4245,7 +4246,7 @@ public:
 
     negative_binomial_distribution() : _Par(1, 0.5) {}
 
-    explicit negative_binomial_distribution(_Ty _K0, double _P0 = 0.5) : _Par(_K0, _P0) {}
+    explicit negative_binomial_distribution(_Ty _Kx0, double _Px0 = 0.5) : _Par(_Kx0, _Px0) {}
 
     explicit negative_binomial_distribution(const param_type& _Par0) : _Par(_Par0) {}
 
@@ -4287,11 +4288,11 @@ public:
 
     template <class _Elem, class _Traits>
     basic_istream<_Elem, _Traits>& _Read(basic_istream<_Elem, _Traits>& _Istr) { // read state from _Istr
-        _Ty _K0;
-        double _P0;
-        _In(_Istr, _P0);
-        _In(_Istr, _K0);
-        _Par._Init(_K0, _P0);
+        _Ty _Kx0;
+        double _Px0;
+        _In(_Istr, _Px0);
+        _In(_Istr, _Kx0);
+        _Par._Init(_Kx0, _Px0);
         return _Istr;
     }
 
@@ -4305,11 +4306,11 @@ public:
 private:
     template <class _Engine>
     result_type _Eval(_Engine& _Eng, const param_type& _Par0) const {
-        double _V1;
+        double _Vx1;
         gamma_distribution<double> dist1(
             static_cast<double>(_Par0._Kx), static_cast<double>((_Ty{1} - _Par0._Px) / _Par0._Px));
-        _V1 = dist1(_Eng);
-        poisson_distribution<_Ty> dist2(_V1);
+        _Vx1 = dist1(_Eng);
+        poisson_distribution<_Ty> dist2(_Vx1);
 
         return dist2(_Eng);
     }
@@ -4942,17 +4943,18 @@ public:
 
     template <class _Engine>
     result_type _Eval(_Engine& _Eng, const param_type& _Par0) const {
-        size_t _Px = _Mybase::operator()(_Eng, _Par0);
-        double _P0 = _Par0._Pvec[_Px];
-        double _P1 = _Par0._Pvec[_Px + 1];
+        size_t _Px  = _Mybase::operator()(_Eng, _Par0);
+        double _Px0 = _Par0._Pvec[_Px];
+        double _Px1 = _Par0._Pvec[_Px + 1];
         uniform_real<_Ty> _Dist;
-        result_type _X0 = _Dist(_Eng);
+        result_type _Xx0 = _Dist(_Eng);
 
-        if (_P0 != _P1) {
-            _X0 = static_cast<result_type>((_STD sqrt(_P0 * _P0 * (1.0 - _X0) + _P1 * _P1 * _X0) - _P0) / (_P1 - _P0));
+        if (_Px0 != _Px1) {
+            _Xx0 = static_cast<result_type>(
+                (_STD sqrt(_Px0 * _Px0 * (1.0 - _Xx0) + _Px1 * _Px1 * _Xx0) - _Px0) / (_Px1 - _Px0));
         }
 
-        return _Par0._Bvec[_Px] + _X0 * (_Par0._Bvec[_Px + 1] - _Par0._Bvec[_Px]);
+        return _Par0._Bvec[_Px] + _Xx0 * (_Par0._Bvec[_Px + 1] - _Par0._Bvec[_Px]);
     }
 
     param_type _Par;

--- a/stl/inc/random
+++ b/stl/inc/random
@@ -2174,7 +2174,6 @@ basic_ostream<_Elem, _Traits>& operator<<(basic_ostream<_Elem, _Traits>& _Ostr,
     return _Dist._Write(_Ostr);
 }
 
-
 // CLASS TEMPLATE poisson_distribution AND HELPER
 template <class _Ty = int>
 class _Small_poisson_distribution { // poisson distribution with small mean
@@ -2352,7 +2351,6 @@ basic_ostream<_Elem, _Traits>& operator<<(basic_ostream<_Elem, _Traits>& _Ostr,
     const poisson_distribution<_Ty>& _Dist) { // write state to _Ostr
     return _Dist._Write(_Ostr);
 }
-
 
 // CLASS TEMPLATE binomial_distribution
 template <class _Ty = int>

--- a/stl/inc/ratio
+++ b/stl/inc/ratio
@@ -86,110 +86,111 @@ struct ratio { // holds the ratio of _Nx to _Dx
 template <class _Ty>
 _INLINE_VAR constexpr bool _Is_ratio_v = false; // test for ratio type
 
-template <intmax_t _R1, intmax_t _R2>
-_INLINE_VAR constexpr bool _Is_ratio_v<ratio<_R1, _R2>> = true;
+template <intmax_t _Rx1, intmax_t _Rx2>
+_INLINE_VAR constexpr bool _Is_ratio_v<ratio<_Rx1, _Rx2>> = true;
 
 // ALIAS TEMPLATE ratio_add
-template <class _R1, class _R2>
+template <class _Rx1, class _Rx2>
 struct _Ratio_add { // add two ratios
-    static_assert(_Is_ratio_v<_R1> && _Is_ratio_v<_R2>, "ratio_add<R1, R2> requires R1 and R2 to be ratio<>s.");
+    static_assert(_Is_ratio_v<_Rx1> && _Is_ratio_v<_Rx2>, "ratio_add<R1, R2> requires R1 and R2 to be ratio<>s.");
 
-    static constexpr intmax_t _N1 = _R1::num;
-    static constexpr intmax_t _D1 = _R1::den;
-    static constexpr intmax_t _N2 = _R2::num;
-    static constexpr intmax_t _D2 = _R2::den;
+    static constexpr intmax_t _Nx1 = _Rx1::num;
+    static constexpr intmax_t _Dx1 = _Rx1::den;
+    static constexpr intmax_t _Nx2 = _Rx2::num;
+    static constexpr intmax_t _Dx2 = _Rx2::den;
 
-    static constexpr intmax_t _Gx = _Gcd<_D1, _D2>::value;
+    static constexpr intmax_t _Gx = _Gcd<_Dx1, _Dx2>::value;
 
     // typename ratio<>::type is necessary here
-    using type = typename ratio<_Safe_add<_Safe_mult<_N1, _D2 / _Gx>::value, _Safe_mult<_N2, _D1 / _Gx>::value>::value,
-        _Safe_mult<_D1, _D2 / _Gx>::value>::type;
+    using type =
+        typename ratio<_Safe_add<_Safe_mult<_Nx1, _Dx2 / _Gx>::value, _Safe_mult<_Nx2, _Dx1 / _Gx>::value>::value,
+            _Safe_mult<_Dx1, _Dx2 / _Gx>::value>::type;
 };
 
-template <class _R1, class _R2>
-using ratio_add = typename _Ratio_add<_R1, _R2>::type;
+template <class _Rx1, class _Rx2>
+using ratio_add = typename _Ratio_add<_Rx1, _Rx2>::type;
 
 // ALIAS TEMPLATE ratio_subtract
-template <class _R1, class _R2>
+template <class _Rx1, class _Rx2>
 struct _Ratio_subtract { // subtract two ratios
-    static_assert(_Is_ratio_v<_R1> && _Is_ratio_v<_R2>, "ratio_subtract<R1, R2> requires R1 and R2 to be ratio<>s.");
+    static_assert(_Is_ratio_v<_Rx1> && _Is_ratio_v<_Rx2>, "ratio_subtract<R1, R2> requires R1 and R2 to be ratio<>s.");
 
-    static constexpr intmax_t _N2 = _R2::num;
-    static constexpr intmax_t _D2 = _R2::den;
+    static constexpr intmax_t _Nx2 = _Rx2::num;
+    static constexpr intmax_t _Dx2 = _Rx2::den;
 
-    using type = ratio_add<_R1, ratio<-_N2, _D2>>;
+    using type = ratio_add<_Rx1, ratio<-_Nx2, _Dx2>>;
 };
 
-template <class _R1, class _R2>
-using ratio_subtract = typename _Ratio_subtract<_R1, _R2>::type;
+template <class _Rx1, class _Rx2>
+using ratio_subtract = typename _Ratio_subtract<_Rx1, _Rx2>::type;
 
 // ALIAS TEMPLATE ratio_multiply
-template <class _R1, class _R2>
+template <class _Rx1, class _Rx2>
 struct _Ratio_multiply { // multiply two ratios
-    static_assert(_Is_ratio_v<_R1> && _Is_ratio_v<_R2>, "ratio_multiply<R1, R2> requires R1 and R2 to be ratio<>s.");
+    static_assert(_Is_ratio_v<_Rx1> && _Is_ratio_v<_Rx2>, "ratio_multiply<R1, R2> requires R1 and R2 to be ratio<>s.");
 
-    static constexpr intmax_t _N1 = _R1::num;
-    static constexpr intmax_t _D1 = _R1::den;
-    static constexpr intmax_t _N2 = _R2::num;
-    static constexpr intmax_t _D2 = _R2::den;
+    static constexpr intmax_t _Nx1 = _Rx1::num;
+    static constexpr intmax_t _Dx1 = _Rx1::den;
+    static constexpr intmax_t _Nx2 = _Rx2::num;
+    static constexpr intmax_t _Dx2 = _Rx2::den;
 
-    static constexpr intmax_t _Gx = _Gcd<_N1, _D2>::value;
-    static constexpr intmax_t _Gy = _Gcd<_N2, _D1>::value;
+    static constexpr intmax_t _Gx = _Gcd<_Nx1, _Dx2>::value;
+    static constexpr intmax_t _Gy = _Gcd<_Nx2, _Dx1>::value;
 
-    using _Num = _Safe_mult<_N1 / _Gx, _N2 / _Gy, true>;
-    using _Den = _Safe_mult<_D1 / _Gy, _D2 / _Gx, true>;
+    using _Num = _Safe_mult<_Nx1 / _Gx, _Nx2 / _Gy, true>;
+    using _Den = _Safe_mult<_Dx1 / _Gy, _Dx2 / _Gx, true>;
 };
 
-template <class _R1, class _R2, bool _Sfinae = true, class = void>
+template <class _Rx1, class _Rx2, bool _Sfinae = true, class = void>
 struct _Ratio_multiply_sfinae { // detect overflow during multiplication
     static_assert(_Sfinae, "integer arithmetic overflow");
 };
 
-template <class _R1, class _R2, bool _Sfinae>
-struct _Ratio_multiply_sfinae<_R1, _R2, _Sfinae,
-    void_t<typename _Ratio_multiply<_R1, _R2>::_Num::type,
-        typename _Ratio_multiply<_R1, _R2>::_Den::type>> { // typename ratio<>::type is unnecessary here
-    using type = ratio<_Ratio_multiply<_R1, _R2>::_Num::value, _Ratio_multiply<_R1, _R2>::_Den::value>;
+template <class _Rx1, class _Rx2, bool _Sfinae>
+struct _Ratio_multiply_sfinae<_Rx1, _Rx2, _Sfinae,
+    void_t<typename _Ratio_multiply<_Rx1, _Rx2>::_Num::type,
+        typename _Ratio_multiply<_Rx1, _Rx2>::_Den::type>> { // typename ratio<>::type is unnecessary here
+    using type = ratio<_Ratio_multiply<_Rx1, _Rx2>::_Num::value, _Ratio_multiply<_Rx1, _Rx2>::_Den::value>;
 };
 
-template <class _R1, class _R2>
-using ratio_multiply = typename _Ratio_multiply_sfinae<_R1, _R2, false>::type;
+template <class _Rx1, class _Rx2>
+using ratio_multiply = typename _Ratio_multiply_sfinae<_Rx1, _Rx2, false>::type;
 
 // ALIAS TEMPLATE ratio_divide
-template <class _R1, class _R2>
+template <class _Rx1, class _Rx2>
 struct _Ratio_divide { // divide two ratios
-    static_assert(_Is_ratio_v<_R1> && _Is_ratio_v<_R2>, "ratio_divide<R1, R2> requires R1 and R2 to be ratio<>s.");
+    static_assert(_Is_ratio_v<_Rx1> && _Is_ratio_v<_Rx2>, "ratio_divide<R1, R2> requires R1 and R2 to be ratio<>s.");
 
-    static constexpr intmax_t _N2 = _R2::num;
-    static constexpr intmax_t _D2 = _R2::den;
+    static constexpr intmax_t _Nx2 = _Rx2::num;
+    static constexpr intmax_t _Dx2 = _Rx2::den;
 
-    using _R2_inverse = ratio<_D2, _N2>;
+    using _Rx2_inverse = ratio<_Dx2, _Nx2>;
 };
 
-template <class _R1, class _R2, bool _Sfinae = true>
+template <class _Rx1, class _Rx2, bool _Sfinae = true>
 using _Ratio_divide_sfinae =
-    typename _Ratio_multiply_sfinae<_R1, typename _Ratio_divide<_R1, _R2>::_R2_inverse, _Sfinae>::type;
+    typename _Ratio_multiply_sfinae<_Rx1, typename _Ratio_divide<_Rx1, _Rx2>::_Rx2_inverse, _Sfinae>::type;
 
-template <class _R1, class _R2>
-using ratio_divide = _Ratio_divide_sfinae<_R1, _R2, false>;
+template <class _Rx1, class _Rx2>
+using ratio_divide = _Ratio_divide_sfinae<_Rx1, _Rx2, false>;
 
 // STRUCT TEMPLATE ratio_equal
-template <class _R1, class _R2>
-struct ratio_equal : bool_constant<_R1::num == _R2::num && _R1::den == _R2::den> { // tests if ratio == ratio
-    static_assert(_Is_ratio_v<_R1> && _Is_ratio_v<_R2>, "ratio_equal<R1, R2> requires R1 and R2 to be ratio<>s.");
+template <class _Rx1, class _Rx2>
+struct ratio_equal : bool_constant<_Rx1::num == _Rx2::num && _Rx1::den == _Rx2::den> { // tests if ratio == ratio
+    static_assert(_Is_ratio_v<_Rx1> && _Is_ratio_v<_Rx2>, "ratio_equal<R1, R2> requires R1 and R2 to be ratio<>s.");
 };
 
-template <class _R1, class _R2>
-_INLINE_VAR constexpr bool ratio_equal_v = ratio_equal<_R1, _R2>::value;
+template <class _Rx1, class _Rx2>
+_INLINE_VAR constexpr bool ratio_equal_v = ratio_equal<_Rx1, _Rx2>::value;
 
 // STRUCT TEMPLATE ratio_not_equal
-template <class _R1, class _R2>
-struct ratio_not_equal : bool_constant<!ratio_equal_v<_R1, _R2>> { // tests if ratio != ratio
-    static_assert(_Is_ratio_v<_R1> && _Is_ratio_v<_R2>, "ratio_not_equal<R1, R2> requires R1 and R2 to be ratio<>s.");
+template <class _Rx1, class _Rx2>
+struct ratio_not_equal : bool_constant<!ratio_equal_v<_Rx1, _Rx2>> { // tests if ratio != ratio
+    static_assert(_Is_ratio_v<_Rx1> && _Is_ratio_v<_Rx2>, "ratio_not_equal<R1, R2> requires R1 and R2 to be ratio<>s.");
 };
 
-template <class _R1, class _R2>
-_INLINE_VAR constexpr bool ratio_not_equal_v = ratio_not_equal<_R1, _R2>::value;
+template <class _Rx1, class _Rx2>
+_INLINE_VAR constexpr bool ratio_not_equal_v = ratio_not_equal<_Rx1, _Rx2>::value;
 
 // STRUCT TEMPLATE ratio_less
 struct _Big_uint128 {
@@ -226,55 +227,56 @@ constexpr _Big_uint128 _Big_multiply(const uint64_t _Lfactor,
     return {_Lhigh * _Rhigh + _Mid_upper + _Carry, (_Temp << 32) + _Lower32};
 }
 
-constexpr bool _Ratio_less(const int64_t _N1, const int64_t _D1, const int64_t _N2, const int64_t _D2) noexcept {
-    if (_N1 >= 0 && _N2 >= 0) {
-        return _Big_multiply(static_cast<uint64_t>(_N1), static_cast<uint64_t>(_D2))
-               < _Big_multiply(static_cast<uint64_t>(_N2), static_cast<uint64_t>(_D1));
+constexpr bool _Ratio_less(const int64_t _Nx1, const int64_t _Dx1, const int64_t _Nx2, const int64_t _Dx2) noexcept {
+    if (_Nx1 >= 0 && _Nx2 >= 0) {
+        return _Big_multiply(static_cast<uint64_t>(_Nx1), static_cast<uint64_t>(_Dx2))
+               < _Big_multiply(static_cast<uint64_t>(_Nx2), static_cast<uint64_t>(_Dx1));
     }
 
-    if (_N1 < 0 && _N2 < 0) {
-        return _Big_multiply(static_cast<uint64_t>(-_N2), static_cast<uint64_t>(_D1))
-               < _Big_multiply(static_cast<uint64_t>(-_N1), static_cast<uint64_t>(_D2));
+    if (_Nx1 < 0 && _Nx2 < 0) {
+        return _Big_multiply(static_cast<uint64_t>(-_Nx2), static_cast<uint64_t>(_Dx1))
+               < _Big_multiply(static_cast<uint64_t>(-_Nx1), static_cast<uint64_t>(_Dx2));
     }
 
-    return _N1 < _N2;
+    return _Nx1 < _Nx2;
 }
 
-template <class _R1, class _R2>
-struct ratio_less : bool_constant<_Ratio_less(_R1::num, _R1::den, _R2::num, _R2::den)> { // tests if ratio < ratio
-    static_assert(_Is_ratio_v<_R1> && _Is_ratio_v<_R2>, "ratio_less<R1, R2> requires R1 and R2 to be ratio<>s.");
+template <class _Rx1, class _Rx2>
+struct ratio_less : bool_constant<_Ratio_less(_Rx1::num, _Rx1::den, _Rx2::num, _Rx2::den)> { // tests if ratio < ratio
+    static_assert(_Is_ratio_v<_Rx1> && _Is_ratio_v<_Rx2>, "ratio_less<R1, R2> requires R1 and R2 to be ratio<>s.");
 };
 
-template <class _R1, class _R2>
-_INLINE_VAR constexpr bool ratio_less_v = ratio_less<_R1, _R2>::value;
+template <class _Rx1, class _Rx2>
+_INLINE_VAR constexpr bool ratio_less_v = ratio_less<_Rx1, _Rx2>::value;
 
 // STRUCT TEMPLATE ratio_less_equal
-template <class _R1, class _R2>
-struct ratio_less_equal : bool_constant<!ratio_less_v<_R2, _R1>> { // tests if ratio <= ratio
-    static_assert(_Is_ratio_v<_R1> && _Is_ratio_v<_R2>, "ratio_less_equal<R1, R2> requires R1 and R2 to be ratio<>s.");
+template <class _Rx1, class _Rx2>
+struct ratio_less_equal : bool_constant<!ratio_less_v<_Rx2, _Rx1>> { // tests if ratio <= ratio
+    static_assert(
+        _Is_ratio_v<_Rx1> && _Is_ratio_v<_Rx2>, "ratio_less_equal<R1, R2> requires R1 and R2 to be ratio<>s.");
 };
 
-template <class _R1, class _R2>
-_INLINE_VAR constexpr bool ratio_less_equal_v = ratio_less_equal<_R1, _R2>::value;
+template <class _Rx1, class _Rx2>
+_INLINE_VAR constexpr bool ratio_less_equal_v = ratio_less_equal<_Rx1, _Rx2>::value;
 
 // STRUCT TEMPLATE ratio_greater
-template <class _R1, class _R2>
-struct ratio_greater : ratio_less<_R2, _R1>::type { // tests if ratio > ratio
-    static_assert(_Is_ratio_v<_R1> && _Is_ratio_v<_R2>, "ratio_greater<R1, R2> requires R1 and R2 to be ratio<>s.");
+template <class _Rx1, class _Rx2>
+struct ratio_greater : ratio_less<_Rx2, _Rx1>::type { // tests if ratio > ratio
+    static_assert(_Is_ratio_v<_Rx1> && _Is_ratio_v<_Rx2>, "ratio_greater<R1, R2> requires R1 and R2 to be ratio<>s.");
 };
 
-template <class _R1, class _R2>
-_INLINE_VAR constexpr bool ratio_greater_v = ratio_greater<_R1, _R2>::value;
+template <class _Rx1, class _Rx2>
+_INLINE_VAR constexpr bool ratio_greater_v = ratio_greater<_Rx1, _Rx2>::value;
 
 // STRUCT TEMPLATE ratio_greater_equal
-template <class _R1, class _R2>
-struct ratio_greater_equal : bool_constant<!ratio_less_v<_R1, _R2>> { // tests if ratio >= ratio
+template <class _Rx1, class _Rx2>
+struct ratio_greater_equal : bool_constant<!ratio_less_v<_Rx1, _Rx2>> { // tests if ratio >= ratio
     static_assert(
-        _Is_ratio_v<_R1> && _Is_ratio_v<_R2>, "ratio_greater_equal<R1, R2> requires R1 and R2 to be ratio<>s.");
+        _Is_ratio_v<_Rx1> && _Is_ratio_v<_Rx2>, "ratio_greater_equal<R1, R2> requires R1 and R2 to be ratio<>s.");
 };
 
-template <class _R1, class _R2>
-_INLINE_VAR constexpr bool ratio_greater_equal_v = ratio_greater_equal<_R1, _R2>::value;
+template <class _Rx1, class _Rx2>
+_INLINE_VAR constexpr bool ratio_greater_equal_v = ratio_greater_equal<_Rx1, _Rx2>::value;
 
 // SI TYPEDEFS
 using atto  = ratio<1, 1000000000000000000LL>;

--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -188,8 +188,8 @@ inline const wchar_t* _Cl_names::_Get<wchar_t>() const { // get wide pointer
 template <class _RxTraits>
 struct _Cmp_cs { // functor to compare two character values for equality
     using _Elem = typename _RxTraits::char_type;
-    bool operator()(_Elem _E1, _Elem _E2) {
-        return _E1 == _E2;
+    bool operator()(_Elem _Ex1, _Elem _Ex2) {
+        return _Ex1 == _Ex2;
     }
 };
 
@@ -199,8 +199,8 @@ struct _Cmp_icase { // functor to compare for case-insensitive equality
 
     explicit _Cmp_icase(const _RxTraits& _Tr) : _Traits(_Tr) {}
 
-    bool operator()(_Elem _E1, _Elem _E2) {
-        return _Traits.translate_nocase(_E1) == _Traits.translate_nocase(_E2);
+    bool operator()(_Elem _Ex1, _Elem _Ex2) {
+        return _Traits.translate_nocase(_Ex1) == _Traits.translate_nocase(_Ex2);
     }
 
     const _RxTraits& _Traits;
@@ -214,8 +214,8 @@ struct _Cmp_collate { // functor to compare for locale-specific equality
 
     explicit _Cmp_collate(const _RxTraits& _Tr) : _Traits(_Tr) {}
 
-    bool operator()(_Elem _E1, _Elem _E2) {
-        return _Traits.translate(_E1) == _Traits.translate(_E2);
+    bool operator()(_Elem _Ex1, _Elem _Ex2) {
+        return _Traits.translate(_Ex1) == _Traits.translate(_Ex2);
     }
 
     const _RxTraits& _Traits;
@@ -1475,7 +1475,7 @@ public:
     void _Add_char(_Elem _Ch);
     void _Add_class();
     void _Add_char_to_class(_Elem _Ch);
-    void _Add_range(_Elem _E0, _Elem _E1);
+    void _Add_range(_Elem _Ex0, _Elem _Ex1);
     void _Add_named_class(_Regex_traits_base::char_class_type, bool = false);
     void _Add_equiv(_FwdIt, _FwdIt, _Difft);
     void _Add_coll(_FwdIt, _FwdIt, _Difft);
@@ -2857,36 +2857,36 @@ void _Builder<_FwdIt, _Elem, _RxTraits>::_Add_char_to_class(_Elem _Ch) { // add 
 template <class _FwdIt, class _Elem, class _RxTraits>
 void _Builder<_FwdIt, _Elem, _RxTraits>::_Add_range(_Elem _Arg0, _Elem _Arg1) {
     // add character range to set
-    unsigned int _E0;
-    unsigned int _E1;
+    unsigned int _Ex0;
+    unsigned int _Ex1;
     if (_Flags & regex_constants::icase) { // change to lowercase range
-        _E0 = static_cast<unsigned int>(_Traits.translate_nocase(_Arg0));
-        _E1 = static_cast<unsigned int>(_Traits.translate_nocase(_Arg1));
+        _Ex0 = static_cast<unsigned int>(_Traits.translate_nocase(_Arg0));
+        _Ex1 = static_cast<unsigned int>(_Traits.translate_nocase(_Arg1));
     } else {
-        _E0 = static_cast<typename _RxTraits::_Uelem>(_Arg0);
-        _E1 = static_cast<typename _RxTraits::_Uelem>(_Arg1);
+        _Ex0 = static_cast<typename _RxTraits::_Uelem>(_Arg0);
+        _Ex1 = static_cast<typename _RxTraits::_Uelem>(_Arg1);
     }
 
     _Node_class<_Elem, _RxTraits>* _Node = static_cast<_Node_class<_Elem, _RxTraits>*>(_Current);
-    for (; _E0 <= _E1 && _E1 < _Get_bmax(); ++_E0) { // set a bit
+    for (; _Ex0 <= _Ex1 && _Ex1 < _Get_bmax(); ++_Ex0) { // set a bit
         if (!_Node->_Small) {
             _Node->_Small = new _Bitmap;
         }
 
-        _Node->_Small->_Mark(_E0);
+        _Node->_Small->_Mark(_Ex0);
     }
-    if (_E1 >= _E0) {
-        if (_E1 - _E0 < _Get_tmax()) {
-            for (; _E0 <= _E1; ++_E0) {
-                _Add_char_to_array(static_cast<_Elem>(_E0));
+    if (_Ex1 >= _Ex0) {
+        if (_Ex1 - _Ex0 < _Get_tmax()) {
+            for (; _Ex0 <= _Ex1; ++_Ex0) {
+                _Add_char_to_array(static_cast<_Elem>(_Ex0));
             }
         } else { // store remaining range as pair
             if (!_Node->_Ranges) {
                 _Node->_Ranges = new _Buf<_Elem>;
             }
 
-            _Node->_Ranges->_Insert(static_cast<_Elem>(_E0));
-            _Node->_Ranges->_Insert(static_cast<_Elem>(_E1));
+            _Node->_Ranges->_Insert(static_cast<_Elem>(_Ex0));
+            _Node->_Ranges->_Insert(static_cast<_Elem>(_Ex1));
         }
     }
 }

--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -2855,16 +2855,16 @@ void _Builder<_FwdIt, _Elem, _RxTraits>::_Add_char_to_class(_Elem _Ch) { // add 
 }
 
 template <class _FwdIt, class _Elem, class _RxTraits>
-void _Builder<_FwdIt, _Elem, _RxTraits>::_Add_range(_Elem _E0x, _Elem _E1x) {
+void _Builder<_FwdIt, _Elem, _RxTraits>::_Add_range(_Elem _Arg0, _Elem _Arg1) {
     // add character range to set
     unsigned int _E0;
     unsigned int _E1;
     if (_Flags & regex_constants::icase) { // change to lowercase range
-        _E0 = static_cast<unsigned int>(_Traits.translate_nocase(_E0x));
-        _E1 = static_cast<unsigned int>(_Traits.translate_nocase(_E1x));
+        _E0 = static_cast<unsigned int>(_Traits.translate_nocase(_Arg0));
+        _E1 = static_cast<unsigned int>(_Traits.translate_nocase(_Arg1));
     } else {
-        _E0 = static_cast<typename _RxTraits::_Uelem>(_E0x);
-        _E1 = static_cast<typename _RxTraits::_Uelem>(_E1x);
+        _E0 = static_cast<typename _RxTraits::_Uelem>(_Arg0);
+        _E1 = static_cast<typename _RxTraits::_Uelem>(_Arg1);
     }
 
     _Node_class<_Elem, _RxTraits>* _Node = static_cast<_Node_class<_Elem, _RxTraits>*>(_Current);

--- a/stl/inc/scoped_allocator
+++ b/stl/inc/scoped_allocator
@@ -41,16 +41,13 @@ decltype(auto) _Scoped_outermost(_Alloc& _Al) { // gets the outermost allocator
     return _Scoped_outermost_helper<_Alloc>::_Fn(_Al);
 }
 
-
 // ALIAS TEMPLATE _Scoped_outermost_t
 template <class _Alloc>
 using _Scoped_outermost_t = remove_reference_t<decltype(_Scoped_outermost(_STD declval<_Alloc&>()))>;
 
-
 // ALIAS TEMPLATE _Scoped_outermost_traits
 template <class _Alloc>
 using _Scoped_outermost_traits = allocator_traits<_Scoped_outermost_t<_Alloc>>;
-
 
 // CLASS TEMPLATE _Scoped_base
 template <class _Outer, class... _Inner>

--- a/stl/inc/shared_mutex
+++ b/stl/inc/shared_mutex
@@ -26,7 +26,6 @@ _STL_DISABLE_CLANG_WARNINGS
 #pragma push_macro("new")
 #undef new
 
-
 _STD_BEGIN
 // CLASS shared_mutex
 class shared_mutex { // class for mutual exclusion shared across threads

--- a/stl/inc/string
+++ b/stl/inc/string
@@ -84,7 +84,6 @@ basic_istream<_Elem, _Traits>& getline(basic_istream<_Elem, _Traits>& _Istr,
     return getline(_STD move(_Istr), _Str, _Istr.widen('\n'));
 }
 
-
 // sto* NARROW CONVERSIONS
 inline int stoi(const string& _Str, size_t* _Idx = nullptr, int _Base = 10) {
     // convert string to int

--- a/stl/inc/tuple
+++ b/stl/inc/tuple
@@ -755,7 +755,6 @@ _CONSTEXPR20 void swap(tuple<_Types...>& _Left, tuple<_Types...>& _Right) noexce
     return _Left.swap(_Right);
 }
 
-
 // CLASS _Tuple_element (find element by type)
 template <class _Ty, class _Tuple>
 struct _Tuple_element {}; // backstop _Tuple_element definition

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -119,7 +119,6 @@ struct is_function : _Is_function<_Ty>::_Bool_type {}; // determine whether _Ty 
 template <class _Ty>
 _INLINE_VAR constexpr bool is_function_v = _Is_function<_Ty>::_Bool_type::value;
 
-
 template <class _Ty>
 struct _Is_memfunptr { // base class for member function pointer predicates
     using _Bool_type = false_type; // NB: members are user-visible via _Weak_types
@@ -283,7 +282,6 @@ template <class _Ty>
 struct remove_pointer<_Ty* volatile> {
     using type = _Ty;
 };
-
 
 template <class _Ty>
 struct remove_pointer<_Ty* const volatile> {
@@ -1657,7 +1655,6 @@ struct _Invoker_ret<_Unforced, false> { // selected for _Rx being _Unforced
         return _STD invoke(static_cast<_Valtys&&>(_Vals)...);
     }
 };
-
 
 // TYPE TRAITS FOR invoke()
 #pragma warning(push)

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -51,7 +51,6 @@ _NODISCARD constexpr _Ty(max)(initializer_list<_Ty>, _Pr); // implemented in <al
 template <class _Ty>
 _NODISCARD constexpr _Ty(max)(initializer_list<_Ty>); // implemented in <algorithm>
 
-
 // FUNCTION TEMPLATE min
 template <class _Ty, class _Pr>
 _NODISCARD constexpr const _Ty&(min)(const _Ty& _Left, const _Ty& _Right, _Pr _Pred) noexcept(
@@ -75,7 +74,6 @@ _NODISCARD constexpr _Ty(min)(initializer_list<_Ty>, _Pr); // implemented in <al
 
 template <class _Ty>
 _NODISCARD constexpr _Ty(min)(initializer_list<_Ty>); // implemented in <algorithm>
-
 
 // FUNCTION TEMPLATE iter_swap (from <algorithm>)
 template <class _FwdIt1, class _FwdIt2>
@@ -478,7 +476,6 @@ struct _MSVC_KNOWN_SEMANTICS tuple_element<_Idx, array<_Ty, _Size>> {
 
     using type = _Ty;
 };
-
 
 // TUPLE INTERFACE TO tuple
 template <class... _Types>

--- a/stl/inc/xlocmon
+++ b/stl/inc/xlocmon
@@ -682,12 +682,12 @@ protected:
         }
 
         const ctype<_Elem>& _Ctype_fac = _STD use_facet<ctype<_Elem>>(_Iosbase.getloc());
-        const _Elem _E0                = _Ctype_fac.widen('0');
+        const _Elem _Elem0             = _Ctype_fac.widen('0');
 
         string_type _Val2(static_cast<size_t>(_Count), _Elem{});
         _Ctype_fac.widen(_Buf, _Buf + _Count, &_Val2[0]);
-        _Val2.append(_Exp, _E0); // scale by trailing zeros
-        return _Putmfld(_Dest, _Intl, _Iosbase, _Fill, _Negative, _Val2, _E0);
+        _Val2.append(_Exp, _Elem0); // scale by trailing zeros
+        return _Putmfld(_Dest, _Intl, _Iosbase, _Fill, _Negative, _Val2, _Elem0);
     }
 
     virtual _OutIt __CLR_OR_THIS_CALL do_put(_OutIt _Dest, bool _Intl, ios_base& _Iosbase, _Elem _Fill,
@@ -718,8 +718,9 @@ protected:
     }
 
 private:
-    _OutIt _Putmfld(_OutIt _Dest, bool _Intl, ios_base& _Iosbase, _Elem _Fill, bool _Neg, string_type _Val,
-        _Elem _E0) const { // put string_type with just digits to _Dest
+    _OutIt _Putmfld(
+        _OutIt _Dest, bool _Intl, ios_base& _Iosbase, _Elem _Fill, bool _Neg, string_type _Val, _Elem _Elem0) const {
+        // put string_type with just digits to _Dest
         const _Mpunct<_Elem>* _Ppunct_fac;
         if (_Intl) {
             _Ppunct_fac = _STD addressof(_STD use_facet<_Mypunct1>(_Iosbase.getloc())); // international
@@ -732,7 +733,7 @@ private:
         const auto _Fracdigits = static_cast<unsigned int>(_Ifracdigits < 0 ? -_Ifracdigits : _Ifracdigits);
 
         if (_Val.size() <= _Fracdigits) {
-            _Val.insert(0, _Fracdigits - _Val.size() + 1, _E0);
+            _Val.insert(0, _Fracdigits - _Val.size() + 1, _Elem0);
         } else if (*_Grouping.c_str() != CHAR_MAX && '\0' < *_Grouping.c_str()) {
             // grouping specified, add thousands separators
             const _Elem _Kseparator = _Ppunct_fac->thousands_sep();
@@ -821,20 +822,17 @@ private:
 
             case money_base::value: // put value field
                 if (_Fracdigits == 0) {
-                    _Dest = _Put(_Dest, _Val.begin(),
-                        _Val.size()); // no fraction part
+                    _Dest = _Put(_Dest, _Val.begin(), _Val.size()); // no fraction part
                 } else if (_Val.size() <= _Fracdigits) { // put leading zero, all fraction digits
-                    *_Dest++ = _E0;
+                    *_Dest++ = _Elem0;
                     *_Dest++ = _Ppunct_fac->decimal_point();
-                    _Dest    = _Rep(_Dest, _E0,
-                        _Fracdigits - _Val.size()); // insert zeros
+                    _Dest    = _Rep(_Dest, _Elem0, _Fracdigits - _Val.size()); // insert zeros
                     _Dest    = _Put(_Dest, _Val.begin(), _Val.size());
                 } else { // put both integer and fraction parts
-                    _Dest    = _Put(_Dest, _Val.begin(),
-                        _Val.size() - _Fracdigits); // put integer part
+                    _Dest    = _Put(_Dest, _Val.begin(), _Val.size() - _Fracdigits); // put integer part
                     *_Dest++ = _Ppunct_fac->decimal_point();
-                    _Dest    = _Put(_Dest, _Val.end() - static_cast<ptrdiff_t>(_Fracdigits),
-                        _Fracdigits); // put fraction part
+                    _Dest =
+                        _Put(_Dest, _Val.end() - static_cast<ptrdiff_t>(_Fracdigits), _Fracdigits); // put fraction part
                 }
                 break;
 
@@ -851,16 +849,15 @@ private:
         }
 
         if (1 < _Sign.size()) {
-            _Dest = _Put(_Dest, _Sign.begin() + 1,
-                _Sign.size() - 1); // put remainder of sign
+            _Dest = _Put(_Dest, _Sign.begin() + 1, _Sign.size() - 1); // put remainder of sign
         }
 
         _Iosbase.width(0);
         return _Rep(_Dest, _Fill, _Fillcount); // put trailing fill
     }
 
-    static _OutIt _Put(_OutIt _Dest, typename string_type::const_iterator _Source,
-        size_t _Count) { // put [_Source, _Source + _Count) to _Dest
+    static _OutIt _Put(_OutIt _Dest, typename string_type::const_iterator _Source, size_t _Count) {
+        // put [_Source, _Source + _Count) to _Dest
         for (; 0 < _Count; --_Count, (void) ++_Dest, ++_Source) {
             *_Dest = *_Source;
         }

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -441,7 +441,6 @@ template <class _Alloc, class _Ptr, class... _Args>
 using _Uses_default_construct =
     disjunction<_Is_default_allocator<_Alloc>, _Has_no_allocator_construct<void, _Alloc, _Ptr, _Args...>>;
 
-
 // ALIAS TEMPLATE _Uses_default_destroy AND _Uses_default_destroy_t
 template <class _Alloc, class _Ptr, class = void>
 struct _Has_no_alloc_destroy : true_type {};
@@ -457,7 +456,6 @@ using _Uses_default_destroy = disjunction<_Is_default_allocator<_Alloc>, _Has_no
 
 template <class _Alloc, class _Ptr>
 using _Uses_default_destroy_t = typename _Uses_default_destroy<_Alloc, _Ptr>::type;
-
 
 // STRUCT TEMPLATE _Has_allocate_hint
 template <class _Alloc, class _Size_type, class _Const_void_pointer, class = void>
@@ -486,7 +484,6 @@ struct _Has_select_on_container_copy_construction : false_type {};
 template <class _Alloc>
 struct _Has_select_on_container_copy_construction<_Alloc,
     void_t<decltype(_STD declval<const _Alloc&>().select_on_container_copy_construction())>> : true_type {};
-
 
 // STRUCT TEMPLATE allocator_traits
 template <class _Alloc>
@@ -949,7 +946,6 @@ void _Pocs(_Alloc& _Left, _Alloc& _Right) noexcept {
 }
 #endif // _HAS_IF_CONSTEXPR
 
-
 // FUNCTION TEMPLATE _Destroy_range WITH ALLOC
 template <class _Alloc>
 void _Destroy_range(_Alloc_ptr_t<_Alloc> _First, const _Alloc_ptr_t<_Alloc> _Last, _Alloc& _Al) noexcept {
@@ -962,7 +958,6 @@ void _Destroy_range(_Alloc_ptr_t<_Alloc> _First, const _Alloc_ptr_t<_Alloc> _Las
     }
 }
 
-
 // FUNCTION TEMPLATE _Destroy_range
 template <class _NoThrowFwdIt>
 void _Destroy_range(_NoThrowFwdIt _First, const _NoThrowFwdIt _Last) noexcept {
@@ -973,7 +968,6 @@ void _Destroy_range(_NoThrowFwdIt _First, const _NoThrowFwdIt _Last) noexcept {
         }
     }
 }
-
 
 // FUNCTION TEMPLATE _Convert_size
 template <class _Size_type>
@@ -1237,12 +1231,10 @@ inline void _Container_base12::_Swap_proxy_and_iterators(_Container_base12& _Rig
 #if _ITERATOR_DEBUG_LEVEL == 0
 using _Container_base = _Container_base0;
 using _Iterator_base  = _Iterator_base0;
-
 #else // _ITERATOR_DEBUG_LEVEL == 0
 using _Container_base = _Container_base12;
 using _Iterator_base = _Iterator_base12;
 #endif // _ITERATOR_DEBUG_LEVEL == 0
-
 
 // ALIAS TEMPLATE _Container_proxy_ptr AND SUPPORTING MACHINERY
 struct _Leave_proxy_unbound {

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -1396,30 +1396,30 @@ public:
         return _Traits_compare<_Traits>(_Mydata, _Mysize, _Right._Mydata, _Right._Mysize);
     }
 
-    _NODISCARD constexpr int compare(const size_type _Off, const size_type _N0, const basic_string_view _Right) const {
-        // compare [_Off, _Off + _N0) with _Right
-        return substr(_Off, _N0).compare(_Right);
+    _NODISCARD constexpr int compare(const size_type _Off, const size_type _Nx, const basic_string_view _Right) const {
+        // compare [_Off, _Off + _Nx) with _Right
+        return substr(_Off, _Nx).compare(_Right);
     }
 
-    _NODISCARD constexpr int compare(const size_type _Off, const size_type _N0, const basic_string_view _Right,
+    _NODISCARD constexpr int compare(const size_type _Off, const size_type _Nx, const basic_string_view _Right,
         const size_type _Roff, const size_type _Count) const {
-        // compare [_Off, _Off + _N0) with _Right [_Roff, _Roff + _Count)
-        return substr(_Off, _N0).compare(_Right.substr(_Roff, _Count));
+        // compare [_Off, _Off + _Nx) with _Right [_Roff, _Roff + _Count)
+        return substr(_Off, _Nx).compare(_Right.substr(_Roff, _Count));
     }
 
     _NODISCARD constexpr int compare(_In_z_ const _Elem* const _Ptr) const { // compare [0, _Mysize) with [_Ptr, <null>)
         return compare(basic_string_view(_Ptr));
     }
 
-    _NODISCARD constexpr int compare(const size_type _Off, const size_type _N0, _In_z_ const _Elem* const _Ptr) const {
-        // compare [_Off, _Off + _N0) with [_Ptr, <null>)
-        return substr(_Off, _N0).compare(basic_string_view(_Ptr));
+    _NODISCARD constexpr int compare(const size_type _Off, const size_type _Nx, _In_z_ const _Elem* const _Ptr) const {
+        // compare [_Off, _Off + _Nx) with [_Ptr, <null>)
+        return substr(_Off, _Nx).compare(basic_string_view(_Ptr));
     }
 
-    _NODISCARD constexpr int compare(const size_type _Off, const size_type _N0,
+    _NODISCARD constexpr int compare(const size_type _Off, const size_type _Nx,
         _In_reads_(_Count) const _Elem* const _Ptr, const size_type _Count) const {
-        // compare [_Off, _Off + _N0) with [_Ptr, _Ptr + _Count)
-        return substr(_Off, _N0).compare(basic_string_view(_Ptr, _Count));
+        // compare [_Off, _Off + _Nx) with [_Ptr, _Ptr + _Count)
+        return substr(_Off, _Nx).compare(basic_string_view(_Ptr, _Count));
     }
 
 #if _HAS_CXX20
@@ -3310,63 +3310,63 @@ public:
         _Eos(0);
     }
 
-    basic_string& replace(const size_type _Off, const size_type _N0, const basic_string& _Right) {
-        // replace [_Off, _Off + _N0) with _Right
-        return replace(_Off, _N0, _Right._Mypair._Myval2._Myptr(), _Right._Mypair._Myval2._Mysize);
+    basic_string& replace(const size_type _Off, const size_type _Nx, const basic_string& _Right) {
+        // replace [_Off, _Off + _Nx) with _Right
+        return replace(_Off, _Nx, _Right._Mypair._Myval2._Myptr(), _Right._Mypair._Myval2._Mysize);
     }
 
-    basic_string& replace(const size_type _Off, size_type _N0, const basic_string& _Right, const size_type _Roff,
+    basic_string& replace(const size_type _Off, size_type _Nx, const basic_string& _Right, const size_type _Roff,
         size_type _Count = npos) {
-        // replace [_Off, _Off + _N0) with _Right [_Roff, _Roff + _Count)
+        // replace [_Off, _Off + _Nx) with _Right [_Roff, _Roff + _Count)
         _Right._Mypair._Myval2._Check_offset(_Roff);
         _Count = _Right._Mypair._Myval2._Clamp_suffix_size(_Roff, _Count);
-        return replace(_Off, _N0, _Right._Mypair._Myval2._Myptr() + _Roff, _Count);
+        return replace(_Off, _Nx, _Right._Mypair._Myval2._Myptr() + _Roff, _Count);
     }
 
 #if _HAS_CXX17
     template <class _StringViewIsh, _Is_string_view_ish<_StringViewIsh> = 0>
-    basic_string& replace(const size_type _Off, const size_type _N0, const _StringViewIsh& _Right) {
-        // replace [_Off, _Off + _N0) with _Right
+    basic_string& replace(const size_type _Off, const size_type _Nx, const _StringViewIsh& _Right) {
+        // replace [_Off, _Off + _Nx) with _Right
         basic_string_view<_Elem, _Traits> _As_view = _Right;
-        return replace(_Off, _N0, _As_view.data(), _Convert_size<size_type>(_As_view.size()));
+        return replace(_Off, _Nx, _As_view.data(), _Convert_size<size_type>(_As_view.size()));
     }
 
     template <class _StringViewIsh, _Is_string_view_ish<_StringViewIsh> = 0>
-    basic_string& replace(const size_type _Off, const size_type _N0, const _StringViewIsh& _Right,
+    basic_string& replace(const size_type _Off, const size_type _Nx, const _StringViewIsh& _Right,
         const size_type _Roff, const size_type _Count = npos) {
-        // replace [_Off, _Off + _N0) with _Right [_Roff, _Roff + _Count)
+        // replace [_Off, _Off + _Nx) with _Right [_Roff, _Roff + _Count)
         basic_string_view<_Elem, _Traits> _As_view = _Right;
-        return replace(_Off, _N0, _As_view.substr(_Roff, _Count));
+        return replace(_Off, _Nx, _As_view.substr(_Roff, _Count));
     }
 #endif // _HAS_CXX17
 
     basic_string& replace(
-        const size_type _Off, size_type _N0, _In_reads_(_Count) const _Elem* const _Ptr, const size_type _Count) {
-        // replace [_Off, _Off + _N0) with [_Ptr, _Ptr + _Count)
+        const size_type _Off, size_type _Nx, _In_reads_(_Count) const _Elem* const _Ptr, const size_type _Count) {
+        // replace [_Off, _Off + _Nx) with [_Ptr, _Ptr + _Count)
         _Mypair._Myval2._Check_offset(_Off);
-        _N0 = _Mypair._Myval2._Clamp_suffix_size(_Off, _N0);
-        if (_N0 == _Count) { // size doesn't change, so a single move does the trick
+        _Nx = _Mypair._Myval2._Clamp_suffix_size(_Off, _Nx);
+        if (_Nx == _Count) { // size doesn't change, so a single move does the trick
             _Traits::move(_Mypair._Myval2._Myptr() + _Off, _Ptr, _Count);
             return *this;
         }
 
         const size_type _Old_size    = _Mypair._Myval2._Mysize;
-        const size_type _Suffix_size = _Old_size - _N0 - _Off + 1;
-        if (_Count < _N0) { // suffix shifts backwards; we don't have to move anything out of the way
-            _Mypair._Myval2._Mysize = _Old_size - (_N0 - _Count);
+        const size_type _Suffix_size = _Old_size - _Nx - _Off + 1;
+        if (_Count < _Nx) { // suffix shifts backwards; we don't have to move anything out of the way
+            _Mypair._Myval2._Mysize = _Old_size - (_Nx - _Count);
             _Elem* const _Old_ptr   = _Mypair._Myval2._Myptr();
             _Elem* const _Insert_at = _Old_ptr + _Off;
             _Traits::move(_Insert_at, _Ptr, _Count);
-            _Traits::move(_Insert_at + _Count, _Insert_at + _N0, _Suffix_size);
+            _Traits::move(_Insert_at + _Count, _Insert_at + _Nx, _Suffix_size);
             return *this;
         }
 
-        const size_type _Growth = static_cast<size_type>(_Count - _N0);
+        const size_type _Growth = static_cast<size_type>(_Count - _Nx);
         if (_Growth <= _Mypair._Myval2._Myres - _Old_size) { // growth fits
             _Mypair._Myval2._Mysize = _Old_size + _Growth;
             _Elem* const _Old_ptr   = _Mypair._Myval2._Myptr();
             _Elem* const _Insert_at = _Old_ptr + _Off;
-            _Elem* const _Suffix_at = _Insert_at + _N0;
+            _Elem* const _Suffix_at = _Insert_at + _Nx;
 
             size_type _Ptr_shifted_after; // see rationale in insert
             if (_Ptr + _Count <= _Insert_at || _Ptr > _Old_ptr + _Old_size) {
@@ -3392,49 +3392,49 @@ public:
         return _Reallocate_grow_by(
             _Growth,
             [](_Elem* const _New_ptr, const _Elem* const _Old_ptr, const size_type _Old_size, const size_type _Off,
-                const size_type _N0, const _Elem* const _Ptr, const size_type _Count) {
+                const size_type _Nx, const _Elem* const _Ptr, const size_type _Count) {
                 _Traits::copy(_New_ptr, _Old_ptr, _Off);
                 _Traits::copy(_New_ptr + _Off, _Ptr, _Count);
-                _Traits::copy(_New_ptr + _Off + _Count, _Old_ptr + _Off + _N0, _Old_size - _N0 - _Off + 1);
+                _Traits::copy(_New_ptr + _Off + _Count, _Old_ptr + _Off + _Nx, _Old_size - _Nx - _Off + 1);
             },
-            _Off, _N0, _Ptr, _Count);
+            _Off, _Nx, _Ptr, _Count);
     }
 
-    basic_string& replace(const size_type _Off, const size_type _N0, _In_z_ const _Elem* const _Ptr) {
-        // replace [_Off, _Off + _N0) with [_Ptr, <null>)
-        return replace(_Off, _N0, _Ptr, _Convert_size<size_type>(_Traits::length(_Ptr)));
+    basic_string& replace(const size_type _Off, const size_type _Nx, _In_z_ const _Elem* const _Ptr) {
+        // replace [_Off, _Off + _Nx) with [_Ptr, <null>)
+        return replace(_Off, _Nx, _Ptr, _Convert_size<size_type>(_Traits::length(_Ptr)));
     }
 
-    basic_string& replace(const size_type _Off, size_type _N0, const size_type _Count, const _Elem _Ch) {
-        // replace [_Off, _Off + _N0) with _Count * _Ch
+    basic_string& replace(const size_type _Off, size_type _Nx, const size_type _Count, const _Elem _Ch) {
+        // replace [_Off, _Off + _Nx) with _Count * _Ch
         _Mypair._Myval2._Check_offset(_Off);
-        _N0 = _Mypair._Myval2._Clamp_suffix_size(_Off, _N0);
-        if (_Count == _N0) {
+        _Nx = _Mypair._Myval2._Clamp_suffix_size(_Off, _Nx);
+        if (_Count == _Nx) {
             _Traits::assign(_Mypair._Myval2._Myptr() + _Off, _Count, _Ch);
             return *this;
         }
 
         const size_type _Old_size = _Mypair._Myval2._Mysize;
-        if (_Count < _N0
-            || _Count - _N0 <= _Mypair._Myval2._Myres - _Old_size) { // either we are shrinking, or the growth fits
-            _Mypair._Myval2._Mysize = _Old_size + _Count - _N0; // may temporarily overflow;
+        if (_Count < _Nx
+            || _Count - _Nx <= _Mypair._Myval2._Myres - _Old_size) { // either we are shrinking, or the growth fits
+            _Mypair._Myval2._Mysize = _Old_size + _Count - _Nx; // may temporarily overflow;
                                                                 // OK because size_type must be unsigned
             _Elem* const _Old_ptr   = _Mypair._Myval2._Myptr();
             _Elem* const _Insert_at = _Old_ptr + _Off;
-            _Traits::move(_Insert_at + _Count, _Insert_at + _N0, _Old_size - _N0 - _Off + 1);
+            _Traits::move(_Insert_at + _Count, _Insert_at + _Nx, _Old_size - _Nx - _Off + 1);
             _Traits::assign(_Insert_at, _Count, _Ch);
             return *this;
         }
 
         return _Reallocate_grow_by(
-            _Count - _N0,
+            _Count - _Nx,
             [](_Elem* const _New_ptr, const _Elem* const _Old_ptr, const size_type _Old_size, const size_type _Off,
-                const size_type _N0, const size_type _Count, const _Elem _Ch) {
+                const size_type _Nx, const size_type _Count, const _Elem _Ch) {
                 _Traits::copy(_New_ptr, _Old_ptr, _Off);
                 _Traits::assign(_New_ptr + _Off, _Count, _Ch);
-                _Traits::copy(_New_ptr + _Off + _Count, _Old_ptr + _Off + _N0, _Old_size - _N0 - _Off + 1);
+                _Traits::copy(_New_ptr + _Off + _Count, _Old_ptr + _Off + _Nx, _Old_size - _Nx - _Off + 1);
             },
-            _Off, _N0, _Count, _Ch);
+            _Off, _Nx, _Count, _Ch);
     }
 
     basic_string& replace(const const_iterator _First, const const_iterator _Last, const basic_string& _Right) {
@@ -4168,22 +4168,22 @@ public:
     }
 
     template <class _StringViewIsh, _Is_string_view_ish<_StringViewIsh> = 0>
-    _NODISCARD int compare(const size_type _Off, const size_type _N0, const _StringViewIsh& _Right) const {
-        // compare [_Off, _Off + _N0) with _Right
+    _NODISCARD int compare(const size_type _Off, const size_type _Nx, const _StringViewIsh& _Right) const {
+        // compare [_Off, _Off + _Nx) with _Right
         basic_string_view<_Elem, _Traits> _As_view = _Right;
         _Mypair._Myval2._Check_offset(_Off);
-        return _Traits_compare<_Traits>(_Mypair._Myval2._Myptr() + _Off, _Mypair._Myval2._Clamp_suffix_size(_Off, _N0),
+        return _Traits_compare<_Traits>(_Mypair._Myval2._Myptr() + _Off, _Mypair._Myval2._Clamp_suffix_size(_Off, _Nx),
             _As_view.data(), _As_view.size());
     }
 
     template <class _StringViewIsh, _Is_string_view_ish<_StringViewIsh> = 0>
-    _NODISCARD int compare(const size_type _Off, const size_type _N0, const _StringViewIsh& _Right,
+    _NODISCARD int compare(const size_type _Off, const size_type _Nx, const _StringViewIsh& _Right,
         const size_type _Roff, const size_type _Count = npos) const {
-        // compare [_Off, _Off + _N0) with _Right [_Roff, _Roff + _Count)
+        // compare [_Off, _Off + _Nx) with _Right [_Roff, _Roff + _Count)
         basic_string_view<_Elem, _Traits> _As_view = _Right;
         _Mypair._Myval2._Check_offset(_Off);
         const auto _With_substr = _As_view.substr(_Roff, _Count);
-        return _Traits_compare<_Traits>(_Mypair._Myval2._Myptr() + _Off, _Mypair._Myval2._Clamp_suffix_size(_Off, _N0),
+        return _Traits_compare<_Traits>(_Mypair._Myval2._Myptr() + _Off, _Mypair._Myval2._Clamp_suffix_size(_Off, _Nx),
             _With_substr.data(), _With_substr.size());
     }
 #endif // _HAS_CXX17
@@ -4193,19 +4193,19 @@ public:
             _Right._Mypair._Myval2._Myptr(), _Right._Mypair._Myval2._Mysize);
     }
 
-    _NODISCARD int compare(size_type _Off, size_type _N0, const basic_string& _Right) const {
-        // compare [_Off, _Off + _N0) with _Right
+    _NODISCARD int compare(size_type _Off, size_type _Nx, const basic_string& _Right) const {
+        // compare [_Off, _Off + _Nx) with _Right
         _Mypair._Myval2._Check_offset(_Off);
-        return _Traits_compare<_Traits>(_Mypair._Myval2._Myptr() + _Off, _Mypair._Myval2._Clamp_suffix_size(_Off, _N0),
+        return _Traits_compare<_Traits>(_Mypair._Myval2._Myptr() + _Off, _Mypair._Myval2._Clamp_suffix_size(_Off, _Nx),
             _Right._Mypair._Myval2._Myptr(), _Right._Mypair._Myval2._Mysize);
     }
 
-    _NODISCARD int compare(const size_type _Off, const size_type _N0, const basic_string& _Right, const size_type _Roff,
+    _NODISCARD int compare(const size_type _Off, const size_type _Nx, const basic_string& _Right, const size_type _Roff,
         const size_type _Count = npos) const {
-        // compare [_Off, _Off + _N0) with _Right [_Roff, _Roff + _Count)
+        // compare [_Off, _Off + _Nx) with _Right [_Roff, _Roff + _Count)
         _Mypair._Myval2._Check_offset(_Off);
         _Right._Mypair._Myval2._Check_offset(_Roff);
-        return _Traits_compare<_Traits>(_Mypair._Myval2._Myptr() + _Off, _Mypair._Myval2._Clamp_suffix_size(_Off, _N0),
+        return _Traits_compare<_Traits>(_Mypair._Myval2._Myptr() + _Off, _Mypair._Myval2._Clamp_suffix_size(_Off, _Nx),
             _Right._Mypair._Myval2._Myptr() + _Roff, _Right._Mypair._Myval2._Clamp_suffix_size(_Roff, _Count));
     }
 
@@ -4214,18 +4214,18 @@ public:
         return _Traits_compare<_Traits>(_Mypair._Myval2._Myptr(), _Mypair._Myval2._Mysize, _Ptr, _Traits::length(_Ptr));
     }
 
-    _NODISCARD int compare(const size_type _Off, const size_type _N0, _In_z_ const _Elem* const _Ptr) const {
-        // compare [_Off, _Off + _N0) with [_Ptr, <null>)
+    _NODISCARD int compare(const size_type _Off, const size_type _Nx, _In_z_ const _Elem* const _Ptr) const {
+        // compare [_Off, _Off + _Nx) with [_Ptr, <null>)
         _Mypair._Myval2._Check_offset(_Off);
-        return _Traits_compare<_Traits>(_Mypair._Myval2._Myptr() + _Off, _Mypair._Myval2._Clamp_suffix_size(_Off, _N0),
+        return _Traits_compare<_Traits>(_Mypair._Myval2._Myptr() + _Off, _Mypair._Myval2._Clamp_suffix_size(_Off, _Nx),
             _Ptr, _Traits::length(_Ptr));
     }
 
-    _NODISCARD int compare(const size_type _Off, const size_type _N0, _In_reads_(_Count) const _Elem* const _Ptr,
-        const size_type _Count) const { // compare [_Off, _Off + _N0) with [_Ptr, _Ptr + _Count)
+    _NODISCARD int compare(const size_type _Off, const size_type _Nx, _In_reads_(_Count) const _Elem* const _Ptr,
+        const size_type _Count) const { // compare [_Off, _Off + _Nx) with [_Ptr, _Ptr + _Count)
         _Mypair._Myval2._Check_offset(_Off);
         return _Traits_compare<_Traits>(
-            _Mypair._Myval2._Myptr() + _Off, _Mypair._Myval2._Clamp_suffix_size(_Off, _N0), _Ptr, _Count);
+            _Mypair._Myval2._Myptr() + _Off, _Mypair._Myval2._Clamp_suffix_size(_Off, _Nx), _Ptr, _Count);
     }
 
 #if _HAS_CXX20

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -1214,7 +1214,6 @@ constexpr void _Adl_verify_range(const _Iter& _First, const _Sentinel& _Last) {
 }
 #endif // _HAS_IF_CONSTEXPR
 
-
 // FUNCTION TEMPLATE _Get_unwrapped
 template <class _Iter, class = void>
 _INLINE_VAR constexpr bool _Unwrappable_v = false;
@@ -1508,7 +1507,6 @@ _NODISCARD constexpr auto _Idl_distance(const _Iter& _First, const _Iter& _Last)
     return _Idl_distance1<_Checked>(_First, _Last, _Iter_cat_t<_Iter>());
 }
 #endif // _HAS_IF_CONSTEXPR
-
 
 // STRUCT TEMPLATE _Unwrap_enum AND ALIAS
 template <class _Elem, bool _Is_enum = is_enum_v<_Elem>>


### PR DESCRIPTION
The STL uses `_Ugly` (or `__ugly` in certain situations) identifiers to avoid colliding with users, especially with user macros. While all `_Ugly` identifiers are reserved, we conventionally avoid single-letter names like `_X` because they look too much like macros (being composed entirely of capital letters and underscores). And, notably, `_T` is macroized by `tchar.h`.

In https://github.com/microsoft/STL/issues/47#issuecomment-633809877, @CaseyCarter observed that we still have identifiers like `_N0` which also resemble macros, as they contain no lowercase letters. In the past, `_M1` and `_M2` were specifically problematic:

https://github.com/microsoft/STL/blob/212de15c590010c961c0e7bb4025f6fec89866c8/stl/inc/__msvc_all_public_headers.hpp#L20

We've mostly been avoiding `_[A-Z][0-9]` identifiers in new code. We should clean up all occurrences in the headers, so that they aren't imitated by new changes.

This PR makes the following changes, where the new names aren't currently used in each file (thus avoiding any potential for conflict):

* `bitset`: `_E0`, `_E1` to `_Elem0`, `_Elem1`
* `charconv`: `_U1`, `_U2` to `_Ux1`, `_Ux2`
* `chrono`: `_T0` to `_Tx0`
* `random`: `_R1` to `_Rx1` etc.
* `ratio`: `_R1`, `_R2` to `_Rx1`, `_Rx2` etc.
  + Also `_R2_inverse` to `_Rx2_inverse`, for consistency.
* `regex`: `_E1`, `_E2` to `_Ex1`, `_Ex2`
  + Also `_E0x`, `_E1x` to `_Arg0`, `_Arg1`, to avoid visual confusion.
* `xlocmon`: `_E0` to `_Elem0`
* `xstring`: `_N0` to `_Nx`

In this file, the new name is currently used elsewhere, but not in a conflicting way (totally different scope):

* `memory`: `_N0` to `_Nx`

While we're making widespread superficial changes, this removes many occurrences of double newlines that were inconsistent or unnecessary. It doesn't remove all double newlines in headers; some seemed consistently used (although we could drop all of them and enforce it forever via clang-format if we wanted to).

Finally, this detaches a few comments from braces, and unwraps a few lines (oddly, clang-format was neutral - it accepted either the wrapped or unwrapped lines).