### PR TITLE
tests: Note unsupported locales, but don't warn.

### DIFF
--- a/tests/utils/stl/test/target_info.py
+++ b/tests/utils/stl/test/target_info.py
@@ -40,6 +40,6 @@ class WindowsLocalTI:
             if _test_locale(loc_name):
                 self.features.add('locale.{0}'.format(loc_id))
             else:
-                lit_config.warning('The locale {0} is not supported by '
-                                   'your platform. Some tests will be '
-                                   'unsupported.'.format(loc_name))
+                lit_config.note('The locale {0} is not supported by '
+                                'your platform. Some tests will be '
+                                'unsupported.'.format(loc_name))


### PR DESCRIPTION
Fixes #855.

Before:

```
S:\GitHub\STL\out\build\x86>python tests\utils\stl-lit\stl-lit.py ..\..\..\tests\std\tests\Dev11_0272959_make_signed
stl-lit.py: S:\GitHub\STL\tests\utils\stl\test\target_info.py:43: warning: The locale Czech_Czech Republic.1250 is not supported by your platform. Some tests will be unsupported.
-- Testing: 29 tests, 12 workers --
[...]
PASS: std :: tests/Dev11_0272959_make_signed:16 (29 of 29)

Testing Time: 2.68s
  Unsupported Tests:  4
  Expected Passes  : 25

1 warning(s) in tests
```

After:

```
S:\GitHub\STL\out\build\x86>python tests\utils\stl-lit\stl-lit.py ..\..\..\tests\std\tests\Dev11_0272959_make_signed
stl-lit.py: S:\GitHub\STL\tests\utils\stl\test\target_info.py:43: note: The locale Czech_Czech Republic.1250 is not supported by your platform. Some tests will be unsupported.
-- Testing: 29 tests, 12 workers --
[...]
PASS: std :: tests/Dev11_0272959_make_signed:16 (29 of 29)

Testing Time: 2.59s
  Unsupported Tests:  4
  Expected Passes  : 25
```

I considered dropping this entirely, but it seems reasonable to emit a note. The important thing is that the summary no longer prints `1 warning(s) in tests`.