### PR TITLE
Rework test_range/test_iterator Ranges test machinery

### DIFF
--- a/tests/std/include/range_algorithm_support.hpp
+++ b/tests/std/include/range_algorithm_support.hpp
@@ -47,7 +47,7 @@ struct borrowed { // borrowed<true> is a borrowed_range; borrowed<false> is not
 };
 
 template <>
-inline constexpr bool std::ranges::enable_borrowed_range<borrowed<true>> = true;
+inline constexpr bool ranges::enable_borrowed_range<borrowed<true>> = true;
 
 #ifndef __clang__ // TRANSITION, LLVM-45213
 inline
@@ -63,371 +63,425 @@ inline
     return static_cast<decltype(x)>(x).second;
 };
 
+struct boolish {
+    bool value_ = true;
+
+    constexpr operator bool() const noexcept {
+        return value_;
+    }
+
+    [[nodiscard]] constexpr boolish operator!() const noexcept {
+        return {!value_};
+    }
+};
+
+namespace test {
+    using std::assignable_from, std::copy_constructible, std::conditional_t, std::derived_from, std::exchange,
+        std::ptrdiff_t, std::span;
+
+    using output     = std::output_iterator_tag;
+    using input      = std::input_iterator_tag;
+    using fwd        = std::forward_iterator_tag;
+    using bidi       = std::bidirectional_iterator_tag;
+    using random     = std::random_access_iterator_tag;
+    using contiguous = std::contiguous_iterator_tag;
+
+    template <class T>
+    void operator&(T&&) {
+        STATIC_ASSERT(always_false<T>);
+    }
+
+    template <class T, class U>
+    void operator,(T&&, U&&) {
+        STATIC_ASSERT(always_false<T>);
+    }
+
+    template <class Element, bool Wrapped = true>
+    class sentinel {
+        Element* ptr_ = nullptr;
+
+    public:
+        sentinel() = default;
+        constexpr explicit sentinel(Element* ptr) noexcept : ptr_{ptr} {}
+
+        [[nodiscard]] constexpr Element* base() const noexcept {
+            return ptr_;
+        }
+
+        using _Prevent_inheriting_unwrap = sentinel;
+
+        using unwrap = sentinel<Element, false>;
+
+        [[nodiscard]] constexpr auto _Unwrapped() const noexcept requires Wrapped {
+            return unwrap{ptr_};
+        }
+
+        static constexpr bool _Unwrap_when_unverified = true;
+
+        constexpr void _Seek_to(unwrap const& s) noexcept requires Wrapped {
+            ptr_ = s.base();
+        }
+    };
+
+    // clang-format off
+    template <class Category, class Element,
+        // Model sized_sentinel_for along with sentinel?
+        bool Sized = derived_from<Category, random>,
+        // Model sentinel_for with self (and sized_sentinel_for if Sized; implies copyable)?
+        bool Common = derived_from<Category, fwd>,
+        // Use a proxy reference type (instead of Element&)?
+        bool Proxy = !derived_from<Category, contiguous>,
+        // Interact with the STL's iterator unwrapping machinery?
+        bool Wrapped = true>
+        requires (Common || !derived_from<Category, fwd>)
+            && (!Proxy || !derived_from<Category, contiguous>)
+    class iterator {
+        Element* ptr_;
+
+        using ValueType = std::remove_cv_t<Element>;
+
+        template <class T>
+        static constexpr bool at_least = derived_from<Category, T>;
+
+        class proxy_reference {
+            Element& ref_;
+
+        public:
+            constexpr explicit proxy_reference(Element& ref) : ref_{ref} {}
+
+            constexpr proxy_reference const& operator=(proxy_reference const& that) const
+                requires assignable_from<Element&, Element&> {
+                ref_ = that.ref_;
+                return *this;
+            }
+
+            constexpr operator ValueType() const requires at_least<input> && copy_constructible<ValueType> {
+                return ref_;
+            }
+
+            constexpr void operator=(ValueType const& val) const requires assignable_from<Element&, ValueType const&> {
+                ref_ = val;
+            }
+        };
+
+        using ReferenceType = conditional_t<Proxy, proxy_reference, Element&>;
+
+    public:
+        // output iterator operations
+        iterator() = default;
+
+        constexpr explicit iterator(Element* ptr) noexcept : ptr_{ptr} {}
+
+        iterator(iterator&&) = default;
+        iterator& operator=(iterator&&) = default;
+
+        [[nodiscard]] constexpr Element* base() const& noexcept requires Common {
+            return ptr_;
+        }
+        [[nodiscard]] constexpr Element* base() && noexcept {
+            return exchange(ptr_, nullptr);
+        }
+
+        [[nodiscard]] constexpr ReferenceType operator*() const noexcept {
+            return ReferenceType{*ptr_};
+        }
+
+        [[nodiscard]] constexpr boolish operator==(sentinel<Element, Wrapped> const& s) const noexcept {
+            return boolish{ptr_ == s.base()};
+        }
+        [[nodiscard]] friend constexpr boolish operator==(
+            sentinel<Element, Wrapped> const& s, iterator const& i) noexcept {
+            return i == s;
+        }
+        [[nodiscard]] constexpr boolish operator!=(sentinel<Element, Wrapped> const& s) const noexcept {
+            return !(*this == s);
+        }
+        [[nodiscard]] friend constexpr boolish operator!=(
+            sentinel<Element, Wrapped> const& s, iterator const& i) noexcept {
+            return !(i == s);
+        }
+
+        constexpr iterator& operator++() & noexcept {
+            ++ptr_;
+            return *this;
+        }
+        constexpr iterator operator++(int) & noexcept {
+            auto tmp = *this;
+            ++ptr_;
+            return tmp;
+        }
+
+        auto operator--() & {
+            STATIC_ASSERT(always_false<Category>);
+        }
+        auto operator--(int) & {
+            STATIC_ASSERT(always_false<Category>);
+        }
+
+        friend void iter_swap(iterator const&, iterator const&) {
+            STATIC_ASSERT(always_false<Category>);
+        }
+
+        void operator<(iterator const&) const {
+            STATIC_ASSERT(always_false<Category>);
+        }
+        void operator>(iterator const&) const {
+            STATIC_ASSERT(always_false<Category>);
+        }
+        void operator<=(iterator const&) const {
+            STATIC_ASSERT(always_false<Category>);
+        }
+        void operator>=(iterator const&) const {
+            STATIC_ASSERT(always_false<Category>);
+        }
+
+        // input iterator operations:
+        constexpr void operator++(int) & noexcept requires std::is_same_v<Category, input> {
+            ++ptr_;
+        }
+
+        [[nodiscard]] constexpr friend ValueType iter_move(iterator const& i) requires at_least<input> {
+            return ranges::iter_move(i.ptr_);
+        }
+
+        constexpr friend void iter_swap(iterator const& x, iterator const& y)
+            requires at_least<input> {
+            ranges::iter_swap(x.ptr_, y.ptr_);
+        }
+
+        // sentinel operations (implied by forward iterator):
+        iterator(iterator const&) requires Common = default;
+        iterator& operator=(iterator const&) requires Common = default;
+        [[nodiscard]] constexpr boolish operator==(iterator const& that) const noexcept requires Common {
+            return {ptr_ == that.ptr_};
+        }
+        [[nodiscard]] constexpr boolish operator!=(iterator const& that) const noexcept requires Common {
+            return !(*this == that);
+        }
+
+        // bidi iterator operations:
+        constexpr iterator& operator--() & noexcept requires at_least<bidi> {
+            --ptr_;
+            return *this;
+        }
+        constexpr iterator operator--(int) & noexcept requires at_least<bidi> {
+            auto tmp = *this;
+            --ptr_;
+            return tmp;
+        }
+
+        // random-access iterator operations:
+        [[nodiscard]] constexpr boolish operator<(iterator const& that) const noexcept
+            requires at_least<random> {
+            return {ptr_ < that.ptr_};
+        }
+        [[nodiscard]] constexpr boolish operator>(iterator const& that) const noexcept
+            requires at_least<random> {
+            return that < *this;
+        }
+        [[nodiscard]] constexpr boolish operator<=(iterator const& that) const noexcept
+            requires at_least<random> {
+            return !(that < *this);
+        }
+        [[nodiscard]] constexpr boolish operator>=(iterator const& that) const noexcept
+            requires at_least<random> {
+            return !(*this < that);
+        }
+        [[nodiscard]] constexpr ReferenceType operator[](ptrdiff_t const n) const& noexcept
+            requires at_least<random> {
+            return ReferenceType{ptr_[n]};
+        }
+        constexpr iterator& operator+=(ptrdiff_t const n) & noexcept
+            requires at_least<random> {
+            ptr_ += n;
+            return *this;
+        }
+        constexpr iterator& operator-=(ptrdiff_t const n) & noexcept
+            requires at_least<random> {
+            ptr_ -= n;
+            return *this;
+        }
+        [[nodiscard]] constexpr iterator operator+(ptrdiff_t const n) const noexcept
+            requires at_least<random> {
+            return iterator{ptr_ + n};
+        }
+        [[nodiscard]] friend constexpr iterator operator+(ptrdiff_t const n, iterator const& i) noexcept
+            requires at_least<random> {
+            return i + n;
+        }
+        [[nodiscard]] constexpr iterator operator-(ptrdiff_t const n) const noexcept
+            requires at_least<random> {
+            return iterator{ptr_ - n};
+        }
+
+        // contiguous iterator operations:
+        [[nodiscard]] constexpr Element* operator->() const noexcept requires at_least<contiguous> {
+            return ptr_;
+        }
+
+        // sized_sentinel_for operations:
+        [[nodiscard]] constexpr ptrdiff_t operator-(iterator const& that) const noexcept
+            requires (Sized && Common) || at_least<random> {
+            return ptr_ - that.ptr_;
+        }
+        [[nodiscard]] constexpr ptrdiff_t operator-(sentinel<Element, Wrapped> const& s) const noexcept
+            requires Sized {
+            return ptr_ - s.base();
+        }
+        [[nodiscard]] friend constexpr ptrdiff_t operator-(
+            sentinel<Element, Wrapped> const& s, iterator const& i) noexcept requires Sized {
+            return -(i - s);
+        }
+
+        // iterator unwrapping operations:
+        using _Prevent_inheriting_unwrap = iterator;
+
+        using unwrap = iterator<Category, Element, Sized, Common, Proxy, false>;
+
+        [[nodiscard]] constexpr auto _Unwrapped() const& noexcept requires Wrapped && Common {
+            return unwrap{ptr_};
+        }
+
+        [[nodiscard]] constexpr auto _Unwrapped() && noexcept requires Wrapped {
+            return unwrap{exchange(ptr_, nullptr)};
+        }
+
+        static constexpr bool _Unwrap_when_unverified = true;
+
+        constexpr void _Seek_to(unwrap const& i) noexcept requires Wrapped && Common {
+            ptr_ = i.base();
+        }
+
+        constexpr void _Seek_to(unwrap&& i) noexcept requires Wrapped {
+            ptr_ = std::move(i).base();
+        }
+    };
+    // clang-format on
+} // namespace test
+
+template <class Category, class Element, bool Sized, bool Common, bool Proxy, bool Wrapped>
+struct std::iterator_traits<::test::iterator<Category, Element, Sized, Common, Proxy, Wrapped>> {
+    using iterator_concept  = Category;
+    using iterator_category = conditional_t<derived_from<Category, forward_iterator_tag>, //
+        conditional_t<Proxy, input_iterator_tag, Category>, //
+        conditional_t<Common, Category, void>>; // TRANSITION, LWG-3289
+    using value_type        = remove_cv_t<Element>;
+    using difference_type   = ptrdiff_t;
+    using pointer           = conditional_t<derived_from<Category, contiguous_iterator_tag>, Element*, void>;
+    using reference         = iter_reference_t<::test::iterator<Category, Element, Sized, Common, Proxy, Wrapped>>;
+};
+
+template <class Element, bool Sized, bool Wrapped>
+struct std::pointer_traits<::test::iterator<std::contiguous_iterator_tag, Element, Sized, true, false, Wrapped>> {
+    using pointer         = ::test::iterator<contiguous_iterator_tag, Element, Sized, true, false, Wrapped>;
+    using element_type    = Element;
+    using difference_type = ptrdiff_t;
+
+    [[nodiscard]] static constexpr element_type* to_address(pointer const& x) noexcept {
+        return x.base();
+    }
+};
+
+namespace test {
+    // clang-format off
+    template <class Category, class Element,
+        // Implement member size?
+        bool Sized = false,
+        // iterator and sentinel model sized_sentinel_for (also iterator and iterator if CommonIterators)
+        bool SizedIterators = derived_from<Category, random>,
+        // Model common_range?
+        bool Common = false,
+        // Iterator models sentinel_for with self
+        bool CommonIterators = derived_from<Category, fwd>,
+        // Use a proxy reference type?
+        bool Proxy = !derived_from<Category, contiguous>>
+        requires (!Common || CommonIterators)
+            && (CommonIterators || !derived_from<Category, fwd>)
+            && (!Proxy || !derived_from<Category, contiguous>)
+    class range : ranges::view_base {
+        span<Element> elements_;
+        mutable bool begin_called_ = false;
+
+    public:
+        using I = iterator<Category, Element, SizedIterators, CommonIterators, Proxy, true>;
+        using S = conditional_t<Common, I, sentinel<Element, true>>;
+
+        range() = default;
+        constexpr explicit range(span<Element> elements) noexcept : elements_{elements} {}
+
+        range(const range&) requires derived_from<Category, fwd> = default;
+        range& operator=(const range&) requires derived_from<Category, fwd> = default;
+
+        constexpr range(range&& that) noexcept
+            : elements_{exchange(that.elements_, {})}, begin_called_{that.begin_called_} {}
+
+        constexpr range& operator=(range&& that) noexcept {
+            elements_     = exchange(that.elements_, {});
+            begin_called_ = that.begin_called_;
+            return *this;
+        }
+
+        [[nodiscard]] constexpr I begin() const noexcept {
+            if constexpr (!derived_from<Category, fwd>) {
+                assert(!exchange(begin_called_, true));
+            }
+            return I{elements_.data()};
+        }
+
+        [[nodiscard]] constexpr S end() const noexcept {
+            return S{elements_.data() + elements_.size()};
+        }
+
+        [[nodiscard]] constexpr ptrdiff_t size() const noexcept requires Sized {
+            if constexpr (!derived_from<Category, fwd>) {
+                assert(!begin_called_);
+            }
+            return static_cast<ptrdiff_t>(elements_.size());
+        }
+
+        [[nodiscard]] constexpr Element* data() const noexcept requires derived_from<Category, contiguous> {
+            return elements_.data();
+        }
+
+        using UI = iterator<Category, Element, SizedIterators, CommonIterators, Proxy, false>;
+        using US = conditional_t<Common, I, sentinel<Element, false>>;
+
+        [[nodiscard]] constexpr UI _Unchecked_begin() const noexcept {
+            return UI{elements_.data()};
+        }
+        [[nodiscard]] constexpr US _Unchecked_end() const noexcept {
+            return US{elements_.data() + elements_.size()};
+        }
+
+        void operator&() const {
+            STATIC_ASSERT(always_false<Category>);
+        }
+        template <class T>
+        friend void operator,(range const&, T&&) {
+            STATIC_ASSERT(always_false<Category>);
+        }
+    };
+    // clang-format on
+} // namespace test
+
 template <class T>
-class move_only_range : public ranges::view_base {
-    // Adapts a contiguous range into a move-only view with move-only iterators
-private:
-    using U = std::span<T>;
-    U elements;
-    mutable bool begin_called = false;
-
-    class iterator;
-    class sentinel;
-
+class move_only_range : public test::range<test::input, T, false, false, false, false, false> {
+#if defined(__clang__) || defined(__EDG__) // TRANSITION, VSO-1132704
+    using test::range<test::input, T, false, false, false, false, false>::range;
+#else // ^^^ no workaround / workaround vvv
 public:
-    constexpr explicit move_only_range(U x) : elements{x} {}
-
-    constexpr move_only_range(move_only_range&& that)
-        : elements{std::exchange(that.elements, {})}, begin_called{that.begin_called} {}
-
-    constexpr move_only_range& operator=(move_only_range&& that) {
-        elements     = std::exchange(that.elements, {});
-        begin_called = that.begin_called;
-        return *this;
-    }
-
-    constexpr iterator begin() const {
-        assert(!std::exchange(begin_called, true));
-        return iterator{elements.begin()};
-    }
-
-    constexpr sentinel end() const {
-        return sentinel{elements.end()};
-    }
+    constexpr move_only_range() = default;
+    constexpr explicit move_only_range(std::span<T> elements) noexcept : move_only_range::range{elements} {}
+    constexpr move_only_range(move_only_range&&) = default;
+    constexpr move_only_range& operator=(move_only_range&&) = default;
+#endif // TRANSITION, VSO-1132704
 };
 
 template <ranges::contiguous_range R>
 move_only_range(R&) -> move_only_range<std::remove_reference_t<ranges::range_reference_t<R>>>;
 
 template <class T>
-class move_only_range<T>::iterator {
-private:
-    friend sentinel;
-    ranges::iterator_t<std::span<T>> pos;
-
-public:
-    using iterator_concept  = std::input_iterator_tag;
-    using iterator_category = void; // TRANSITION, LWG-3289
-    using value_type        = std::remove_cv_t<T>;
-    using difference_type   = std::ptrdiff_t;
-    using pointer           = void;
-    using reference         = T&;
-
-    iterator() = default;
-    constexpr explicit iterator(ranges::iterator_t<U> p) : pos{p} {}
-    constexpr iterator(iterator&& that) : pos{std::exchange(that.pos, {})} {}
-
-    constexpr iterator& operator=(iterator&& that) {
-        pos = std::exchange(that.pos, {});
-        return *this;
-    }
-
-    constexpr ranges::iterator_t<U> base() const {
-        return pos;
-    }
-
-    constexpr T& operator*() const {
-        return *pos;
-    }
-    constexpr iterator& operator++() {
-        ++pos;
-        return *this;
-    }
-    constexpr void operator++(int) {
-        ++pos;
-    }
-};
-
-template <class T>
-class move_only_range<T>::sentinel {
-private:
-    ranges::iterator_t<U> pos;
-
-public:
-    sentinel() = default;
-    constexpr explicit sentinel(ranges::iterator_t<U> p) : pos{p} {}
-
-    constexpr ranges::iterator_t<U> base() const {
-        return pos;
-    }
-
-    constexpr bool operator==(iterator const& that) const {
-        return pos == that.pos;
-    }
-};
-
-template <class T>
 inline constexpr bool ranges::enable_borrowed_range<::move_only_range<T>> = true;
-
-struct boolish {
-    operator bool() const {
-        return true;
-    }
-
-    boolish operator!() const {
-        return *this;
-    }
-};
-
-template <class Category, class ValueType, bool Sized = false>
-struct test_iterator {
-    template <class T>
-    static constexpr bool exactly = std::is_same_v<T, Category>;
-    template <class T>
-    static constexpr bool at_least = std::derived_from<Category, T>;
-
-    struct reference {
-        operator ValueType() const requires at_least<std::input_iterator_tag> {
-            return {};
-        }
-        void operator=(ValueType const&) const {}
-    };
-
-    // output iterator operations
-    test_iterator()                = default;
-    test_iterator(test_iterator&&) = default;
-    test_iterator& operator=(test_iterator&&) = default;
-
-    reference operator*() const {
-        return {};
-    }
-    ValueType& operator*() const requires at_least<std::contiguous_iterator_tag> {
-        static ValueType value{};
-        return value;
-    }
-
-    friend boolish operator==(test_iterator const&, std::default_sentinel_t const&) {
-        return {};
-    }
-    friend boolish operator==(std::default_sentinel_t const&, test_iterator const&) {
-        return {};
-    }
-    friend boolish operator!=(test_iterator const&, std::default_sentinel_t const&) {
-        return {};
-    }
-    friend boolish operator!=(std::default_sentinel_t const&, test_iterator const&) {
-        return {};
-    }
-
-    test_iterator& operator++() & {
-        return *this;
-    }
-    test_iterator operator++(int) & {
-        return {};
-    }
-
-    auto operator--() & {
-        STATIC_ASSERT(always_false<Category>);
-    }
-    auto operator--(int) & {
-        STATIC_ASSERT(always_false<Category>);
-    }
-
-    friend void iter_swap(test_iterator const&, test_iterator const&) {
-        STATIC_ASSERT(always_false<Category>);
-    }
-    void operator<(test_iterator const&) const {
-        STATIC_ASSERT(always_false<Category>);
-    }
-    void operator>(test_iterator const&) const {
-        STATIC_ASSERT(always_false<Category>);
-    }
-    void operator<=(test_iterator const&) const {
-        STATIC_ASSERT(always_false<Category>);
-    }
-    void operator>=(test_iterator const&) const {
-        STATIC_ASSERT(always_false<Category>);
-    }
-
-    void operator&() const {
-        STATIC_ASSERT(always_false<Category>);
-    }
-    template <class T>
-    friend void operator,(test_iterator const&, T&&) {
-        STATIC_ASSERT(always_false<Category>);
-    }
-
-    // input iterator operations:
-    void operator++(int) & requires exactly<std::input_iterator_tag> {}
-    friend ValueType iter_move(test_iterator const&) requires at_least<std::input_iterator_tag> {
-        return {};
-    }
-    friend void iter_swap(test_iterator const&, test_iterator const&) requires at_least<std::input_iterator_tag> {}
-
-    // forward iterator operations:
-    test_iterator(test_iterator const&) requires at_least<std::forward_iterator_tag> = default;
-    test_iterator& operator=(test_iterator const&) requires at_least<std::forward_iterator_tag> = default;
-    test_iterator operator++(int) & requires at_least<std::forward_iterator_tag> {}
-    boolish operator==(test_iterator const&) const requires at_least<std::forward_iterator_tag> {
-        return {};
-    }
-    boolish operator!=(test_iterator const&) const requires at_least<std::forward_iterator_tag> {
-        return {};
-    }
-
-    // bidirectional iterator operations:
-    test_iterator& operator--() & requires at_least<std::bidirectional_iterator_tag> {
-        return *this;
-    }
-    test_iterator operator--(int) & requires at_least<std::bidirectional_iterator_tag> {}
-
-    // random-access iterator operations:
-    boolish operator<(test_iterator const&) const requires at_least<std::random_access_iterator_tag> {
-        return {};
-    }
-    boolish operator>(test_iterator const&) const requires at_least<std::random_access_iterator_tag> {
-        return {};
-    }
-    boolish operator<=(test_iterator const&) const requires at_least<std::random_access_iterator_tag> {
-        return {};
-    }
-    boolish operator>=(test_iterator const&) const requires at_least<std::random_access_iterator_tag> {
-        return {};
-    }
-    decltype(auto) operator[](std::ptrdiff_t) const& requires at_least<std::random_access_iterator_tag> {
-        return **this;
-    }
-    test_iterator& operator+=(std::ptrdiff_t) & requires at_least<std::random_access_iterator_tag> {
-        return *this;
-    }
-    test_iterator& operator-=(std::ptrdiff_t) & requires at_least<std::random_access_iterator_tag> {
-        return *this;
-    }
-    test_iterator operator+(std::ptrdiff_t) const requires at_least<std::random_access_iterator_tag> {
-        return *this;
-    }
-    friend test_iterator operator+(
-        std::ptrdiff_t, test_iterator const& i) requires at_least<std::random_access_iterator_tag> {
-        return i;
-    }
-    test_iterator operator-(std::ptrdiff_t) const requires at_least<std::random_access_iterator_tag> {
-        return *this;
-    }
-
-    // sized_sentinel_for operations:
-    std::ptrdiff_t operator-(test_iterator const&) const requires Sized || at_least<std::random_access_iterator_tag> {
-        return 42;
-    }
-    friend std::ptrdiff_t operator-(std::default_sentinel_t, test_iterator const&) requires Sized {
-        return 42;
-    }
-    friend std::ptrdiff_t operator-(test_iterator const&, std::default_sentinel_t) requires Sized {
-        return -42;
-    }
-};
-
-template <class Category, class ValueType, bool Sized>
-struct std::iterator_traits<::test_iterator<Category, ValueType, Sized>> {
-    using iterator_concept  = Category;
-    using iterator_category = Category; // TRANSITION, LWG-3289
-    using value_type        = ValueType;
-    using difference_type   = ptrdiff_t;
-    using pointer           = void;
-    using reference         = iter_reference_t<::test_iterator<Category, ValueType, Sized>>;
-};
-
-template <class ValueType, bool Sized>
-struct std::pointer_traits<::test_iterator<std::contiguous_iterator_tag, ValueType, Sized>> {
-    using pointer         = ::test_iterator<contiguous_iterator_tag, ValueType, Sized>;
-    using element_type    = ValueType;
-    using difference_type = ptrdiff_t;
-
-    [[nodiscard]] static constexpr element_type* to_address(pointer) noexcept {
-        return nullptr;
-    }
-};
-
-STATIC_ASSERT(std::output_iterator<test_iterator<std::output_iterator_tag, int, false>, int>);
-STATIC_ASSERT(std::input_iterator<test_iterator<std::input_iterator_tag, int, false>>);
-STATIC_ASSERT(std::forward_iterator<test_iterator<std::forward_iterator_tag, int, false>>);
-STATIC_ASSERT(std::bidirectional_iterator<test_iterator<std::bidirectional_iterator_tag, int, false>>);
-STATIC_ASSERT(std::random_access_iterator<test_iterator<std::random_access_iterator_tag, int, false>>);
-STATIC_ASSERT(std::contiguous_iterator<test_iterator<std::contiguous_iterator_tag, int, false>>);
-
-STATIC_ASSERT(std::output_iterator<test_iterator<std::output_iterator_tag, int, true>, int>);
-STATIC_ASSERT(std::input_iterator<test_iterator<std::input_iterator_tag, int, true>>);
-STATIC_ASSERT(std::forward_iterator<test_iterator<std::forward_iterator_tag, int, true>>);
-STATIC_ASSERT(std::bidirectional_iterator<test_iterator<std::bidirectional_iterator_tag, int, true>>);
-STATIC_ASSERT(std::random_access_iterator<test_iterator<std::random_access_iterator_tag, int, true>>);
-STATIC_ASSERT(std::contiguous_iterator<test_iterator<std::contiguous_iterator_tag, int, true>>);
-
-STATIC_ASSERT(std::sized_sentinel_for<std::default_sentinel_t, test_iterator<std::output_iterator_tag, int, true>>);
-STATIC_ASSERT(std::sized_sentinel_for<std::default_sentinel_t, test_iterator<std::input_iterator_tag, int, true>>);
-STATIC_ASSERT(std::sized_sentinel_for<std::default_sentinel_t, test_iterator<std::forward_iterator_tag, int, true>>);
-STATIC_ASSERT(
-    std::sized_sentinel_for<std::default_sentinel_t, test_iterator<std::bidirectional_iterator_tag, int, true>>);
-STATIC_ASSERT(
-    std::sized_sentinel_for<std::default_sentinel_t, test_iterator<std::random_access_iterator_tag, int, true>>);
-STATIC_ASSERT(std::sized_sentinel_for<std::default_sentinel_t, test_iterator<std::contiguous_iterator_tag, int, true>>);
-
-STATIC_ASSERT(std::sized_sentinel_for<test_iterator<std::forward_iterator_tag, int, true>,
-    test_iterator<std::forward_iterator_tag, int, true>>);
-STATIC_ASSERT(std::sized_sentinel_for<test_iterator<std::bidirectional_iterator_tag, int, true>,
-    test_iterator<std::bidirectional_iterator_tag, int, true>>);
-STATIC_ASSERT(std::sized_sentinel_for<test_iterator<std::random_access_iterator_tag, int, true>,
-    test_iterator<std::random_access_iterator_tag, int, true>>);
-STATIC_ASSERT(std::sized_sentinel_for<test_iterator<std::contiguous_iterator_tag, int, true>,
-    test_iterator<std::contiguous_iterator_tag, int, true>>);
-
-template <class Category, class ValueType, bool Sized = false, bool Common = false>
-struct test_range {
-    using I = test_iterator<Category, ValueType, Sized>;
-    using S = std::conditional_t<Common && std::derived_from<Category, std::forward_iterator_tag>, I,
-        std::default_sentinel_t>;
-
-    I begin() const {
-        return {};
-    }
-
-    S end() const {
-        return {};
-    }
-
-    std::ptrdiff_t size() const requires Sized {
-        return 42;
-    }
-
-    ValueType* data() const requires std::derived_from<Category, std::contiguous_iterator_tag> {
-        return nullptr;
-    }
-
-    void operator&() const {
-        STATIC_ASSERT(always_false<Category>);
-    }
-    template <class T>
-    friend void operator,(test_range const&, T&&) {
-        STATIC_ASSERT(always_false<Category>);
-    }
-};
-
-STATIC_ASSERT(ranges::output_range<test_range<std::output_iterator_tag, int, false>, int>);
-STATIC_ASSERT(ranges::input_range<test_range<std::input_iterator_tag, int, false>>);
-STATIC_ASSERT(ranges::forward_range<test_range<std::forward_iterator_tag, int, false>>);
-STATIC_ASSERT(ranges::bidirectional_range<test_range<std::bidirectional_iterator_tag, int, false>>);
-STATIC_ASSERT(ranges::random_access_range<test_range<std::random_access_iterator_tag, int, false>>);
-STATIC_ASSERT(ranges::contiguous_range<test_range<std::contiguous_iterator_tag, int, false>>);
-
-STATIC_ASSERT(ranges::output_range<test_range<std::output_iterator_tag, int, true>, int>);
-STATIC_ASSERT(ranges::input_range<test_range<std::input_iterator_tag, int, true>>);
-STATIC_ASSERT(ranges::forward_range<test_range<std::forward_iterator_tag, int, true>>);
-STATIC_ASSERT(ranges::bidirectional_range<test_range<std::bidirectional_iterator_tag, int, true>>);
-STATIC_ASSERT(ranges::random_access_range<test_range<std::random_access_iterator_tag, int, true>>);
-STATIC_ASSERT(ranges::contiguous_range<test_range<std::contiguous_iterator_tag, int, true>>);
-STATIC_ASSERT(ranges::sized_range<test_range<std::output_iterator_tag, int, true>>);
-STATIC_ASSERT(ranges::sized_range<test_range<std::input_iterator_tag, int, true>>);
-STATIC_ASSERT(ranges::sized_range<test_range<std::forward_iterator_tag, int, true>>);
-STATIC_ASSERT(ranges::sized_range<test_range<std::bidirectional_iterator_tag, int, true>>);
-STATIC_ASSERT(ranges::sized_range<test_range<std::random_access_iterator_tag, int, true>>);
-STATIC_ASSERT(ranges::sized_range<test_range<std::contiguous_iterator_tag, int, true>>);
-
-STATIC_ASSERT(ranges::forward_range<test_range<std::forward_iterator_tag, int, true, true>>);
-STATIC_ASSERT(ranges::bidirectional_range<test_range<std::bidirectional_iterator_tag, int, true, true>>);
-STATIC_ASSERT(ranges::random_access_range<test_range<std::random_access_iterator_tag, int, true, true>>);
-STATIC_ASSERT(ranges::contiguous_range<test_range<std::contiguous_iterator_tag, int, true, true>>);
-STATIC_ASSERT(ranges::sized_range<test_range<std::forward_iterator_tag, int, true, true>>);
-STATIC_ASSERT(ranges::sized_range<test_range<std::bidirectional_iterator_tag, int, true, true>>);
-STATIC_ASSERT(ranges::sized_range<test_range<std::random_access_iterator_tag, int, true, true>>);
-STATIC_ASSERT(ranges::sized_range<test_range<std::contiguous_iterator_tag, int, true, true>>);
 
 template <int>
 struct unique_tag {};
@@ -449,17 +503,31 @@ template <class I1, class I2>
 using BinaryPredicateFor = boolish (*)(std::iter_common_reference_t<I1>, std::iter_common_reference_t<I2>);
 
 template <class Continuation>
-struct with_output_iterators {
+struct with_writable_iterators {
     template <class... Args>
     static void call() {
-        Continuation::template call<Args..., test_iterator<std::output_iterator_tag, int>>();
-        Continuation::template call<Args..., test_iterator<std::input_iterator_tag, int>>();
-        Continuation::template call<Args..., test_iterator<std::forward_iterator_tag, int, false>>();
-        Continuation::template call<Args..., test_iterator<std::forward_iterator_tag, int, true>>();
-        Continuation::template call<Args..., test_iterator<std::bidirectional_iterator_tag, int, false>>();
-        Continuation::template call<Args..., test_iterator<std::bidirectional_iterator_tag, int, true>>();
-        Continuation::template call<Args..., test_iterator<std::random_access_iterator_tag, int>>();
-        Continuation::template call<Args..., test_iterator<std::contiguous_iterator_tag, int>>();
+        using namespace test;
+
+        // Sized and Common are not significant for "lone" single-pass iterators, so we can ignore them here.
+        Continuation::template call<Args..., iterator<output, int, false, false, false>>();
+        Continuation::template call<Args..., iterator<output, int, false, false, true>>();
+        Continuation::template call<Args..., iterator<input, int, false, false, false>>();
+        Continuation::template call<Args..., iterator<input, int, false, false, true>>();
+        // For forward and bidi, Common is necessarily true but Sized and Proxy may vary.
+        Continuation::template call<Args..., iterator<fwd, int, false, true, false>>();
+        Continuation::template call<Args..., iterator<fwd, int, false, true, true>>();
+        Continuation::template call<Args..., iterator<fwd, int, true, true, false>>();
+        Continuation::template call<Args..., iterator<fwd, int, true, true, true>>();
+
+        Continuation::template call<Args..., iterator<bidi, int, false, true, false>>();
+        Continuation::template call<Args..., iterator<bidi, int, false, true, true>>();
+        Continuation::template call<Args..., iterator<bidi, int, true, true, false>>();
+        Continuation::template call<Args..., iterator<bidi, int, true, true, true>>();
+        // Random iterators are Sized and Common - only Proxy varies.
+        Continuation::template call<Args..., iterator<random, int, true, true, false>>();
+        Continuation::template call<Args..., iterator<random, int, true, true, true>>();
+        // Contiguous iterators are totally locked down.
+        Continuation::template call<Args..., iterator<contiguous, int>>();
     }
 };
 
@@ -467,24 +535,79 @@ template <class Continuation>
 struct with_input_ranges {
     template <class... Args>
     static void call() {
-        Continuation::template call<Args..., test_range<std::input_iterator_tag, int, false>>();
-        Continuation::template call<Args..., test_range<std::input_iterator_tag, int, true>>();
+        using namespace test;
 
-        Continuation::template call<Args..., test_range<std::forward_iterator_tag, int, false, false>>();
-        Continuation::template call<Args..., test_range<std::forward_iterator_tag, int, false, true>>();
-        Continuation::template call<Args..., test_range<std::forward_iterator_tag, int, true, false>>();
-        Continuation::template call<Args..., test_range<std::forward_iterator_tag, int, true, true>>();
+        // For all ranges, Commmon implies CommonIterators.
+        // For single-pass ranges, CommonIterators is uninteresting without Common (there's only one valid iterator
+        // value at a time, and no reason to compare it with itself for equality).
+        Continuation::template call<Args..., range<input, int, false, false, false, false, false>>();
+        Continuation::template call<Args..., range<input, int, false, false, false, false, true>>();
+        Continuation::template call<Args..., range<input, int, false, false, true, true, false>>();
+        Continuation::template call<Args..., range<input, int, false, false, true, true, true>>();
 
-        Continuation::template call<Args..., test_range<std::bidirectional_iterator_tag, int, false, false>>();
-        Continuation::template call<Args..., test_range<std::bidirectional_iterator_tag, int, false, true>>();
-        Continuation::template call<Args..., test_range<std::bidirectional_iterator_tag, int, true, false>>();
-        Continuation::template call<Args..., test_range<std::bidirectional_iterator_tag, int, true, true>>();
+        Continuation::template call<Args..., range<input, int, false, true, false, false, false>>();
+        Continuation::template call<Args..., range<input, int, false, true, false, false, true>>();
+        Continuation::template call<Args..., range<input, int, false, true, true, true, false>>();
+        Continuation::template call<Args..., range<input, int, false, true, true, true, true>>();
 
-        Continuation::template call<Args..., test_range<std::random_access_iterator_tag, int, true, false>>();
-        Continuation::template call<Args..., test_range<std::random_access_iterator_tag, int, true, true>>();
+        Continuation::template call<Args..., range<input, int, true, false, false, false, false>>();
+        Continuation::template call<Args..., range<input, int, true, false, false, false, true>>();
+        Continuation::template call<Args..., range<input, int, true, false, true, true, false>>();
+        Continuation::template call<Args..., range<input, int, true, false, true, true, true>>();
 
-        Continuation::template call<Args..., test_range<std::contiguous_iterator_tag, int, true, false>>();
-        Continuation::template call<Args..., test_range<std::contiguous_iterator_tag, int, true, true>>();
+        Continuation::template call<Args..., range<input, int, true, true, false, false, false>>();
+        Continuation::template call<Args..., range<input, int, true, true, false, false, true>>();
+        Continuation::template call<Args..., range<input, int, true, true, true, true, false>>();
+        Continuation::template call<Args..., range<input, int, true, true, true, true, true>>();
+
+        // forward always has CommonIterators; !Sized && SizedSentinel is uninteresting (sized_range is sized_range).
+        Continuation::template call<Args..., range<fwd, int, false, false, false, true, false>>();
+        Continuation::template call<Args..., range<fwd, int, false, false, false, true, true>>();
+        Continuation::template call<Args..., range<fwd, int, false, false, true, true, false>>();
+        Continuation::template call<Args..., range<fwd, int, false, false, true, true, true>>();
+        Continuation::template call<Args..., range<fwd, int, true, false, false, true, false>>();
+        Continuation::template call<Args..., range<fwd, int, true, false, false, true, true>>();
+        Continuation::template call<Args..., range<fwd, int, true, false, true, true, false>>();
+        Continuation::template call<Args..., range<fwd, int, true, false, true, true, true>>();
+        Continuation::template call<Args..., range<fwd, int, true, true, false, true, false>>();
+        Continuation::template call<Args..., range<fwd, int, true, true, false, true, true>>();
+        Continuation::template call<Args..., range<fwd, int, true, true, true, true, false>>();
+        Continuation::template call<Args..., range<fwd, int, true, true, true, true, true>>();
+
+        // Ditto always CommonIterators; !Sized && SizedSentinel is uninteresting (ranges::size still works).
+        Continuation::template call<Args..., range<bidi, int, false, false, false, true, false>>();
+        Continuation::template call<Args..., range<bidi, int, false, false, false, true, true>>();
+        Continuation::template call<Args..., range<bidi, int, false, false, true, true, false>>();
+        Continuation::template call<Args..., range<bidi, int, false, false, true, true, true>>();
+        Continuation::template call<Args..., range<bidi, int, true, false, false, true, false>>();
+        Continuation::template call<Args..., range<bidi, int, true, false, false, true, true>>();
+        Continuation::template call<Args..., range<bidi, int, true, false, true, true, false>>();
+        Continuation::template call<Args..., range<bidi, int, true, false, true, true, true>>();
+        Continuation::template call<Args..., range<bidi, int, true, true, false, true, false>>();
+        Continuation::template call<Args..., range<bidi, int, true, true, false, true, true>>();
+        Continuation::template call<Args..., range<bidi, int, true, true, true, true, false>>();
+        Continuation::template call<Args..., range<bidi, int, true, true, true, true, true>>();
+
+        // Ditto always CommonIterators; !Sized && SizedSentinel is uninteresting (ranges::size still works), as is
+        // !Sized && Common.
+        Continuation::template call<Args..., range<random, int, false, false, false, true, false>>();
+        Continuation::template call<Args..., range<random, int, false, false, false, true, true>>();
+        Continuation::template call<Args..., range<random, int, true, false, false, true, false>>();
+        Continuation::template call<Args..., range<random, int, true, false, false, true, true>>();
+        Continuation::template call<Args..., range<random, int, true, false, true, true, false>>();
+        Continuation::template call<Args..., range<random, int, true, false, true, true, true>>();
+        Continuation::template call<Args..., range<random, int, true, true, false, true, false>>();
+        Continuation::template call<Args..., range<random, int, true, true, false, true, true>>();
+        Continuation::template call<Args..., range<random, int, true, true, true, true, false>>();
+        Continuation::template call<Args..., range<random, int, true, true, true, true, true>>();
+
+        // Ditto always CommonIterators; !Sized && SizedSentinel is uninteresting (ranges::size still works), as is
+        // !Sized && Common. contiguous also implies !Proxy.
+        Continuation::template call<Args..., range<contiguous, int, false, false, false, true, false>>();
+        Continuation::template call<Args..., range<contiguous, int, true, false, false, true, false>>();
+        Continuation::template call<Args..., range<contiguous, int, true, false, true, true, false>>();
+        Continuation::template call<Args..., range<contiguous, int, true, true, false, true, false>>();
+        Continuation::template call<Args..., range<contiguous, int, true, true, true, true, false>>();
     }
 };
 
@@ -492,21 +615,56 @@ template <class Continuation>
 struct with_forward_ranges {
     template <class... Args>
     static void call() {
-        Continuation::template call<Args..., test_range<std::forward_iterator_tag, int, false, false>>();
-        Continuation::template call<Args..., test_range<std::forward_iterator_tag, int, false, true>>();
-        Continuation::template call<Args..., test_range<std::forward_iterator_tag, int, true, false>>();
-        Continuation::template call<Args..., test_range<std::forward_iterator_tag, int, true, true>>();
+        using namespace test;
 
-        Continuation::template call<Args..., test_range<std::bidirectional_iterator_tag, int, false, false>>();
-        Continuation::template call<Args..., test_range<std::bidirectional_iterator_tag, int, false, true>>();
-        Continuation::template call<Args..., test_range<std::bidirectional_iterator_tag, int, true, false>>();
-        Continuation::template call<Args..., test_range<std::bidirectional_iterator_tag, int, true, true>>();
+        // forward always has CommonIterators; !Sized && SizedSentinel is uninteresting (sized_range is sized_range).
+        Continuation::template call<Args..., range<fwd, int, false, false, false, true, false>>();
+        Continuation::template call<Args..., range<fwd, int, false, false, false, true, true>>();
+        Continuation::template call<Args..., range<fwd, int, false, false, true, true, false>>();
+        Continuation::template call<Args..., range<fwd, int, false, false, true, true, true>>();
+        Continuation::template call<Args..., range<fwd, int, true, false, false, true, false>>();
+        Continuation::template call<Args..., range<fwd, int, true, false, false, true, true>>();
+        Continuation::template call<Args..., range<fwd, int, true, false, true, true, false>>();
+        Continuation::template call<Args..., range<fwd, int, true, false, true, true, true>>();
+        Continuation::template call<Args..., range<fwd, int, true, true, false, true, false>>();
+        Continuation::template call<Args..., range<fwd, int, true, true, false, true, true>>();
+        Continuation::template call<Args..., range<fwd, int, true, true, true, true, false>>();
+        Continuation::template call<Args..., range<fwd, int, true, true, true, true, true>>();
 
-        Continuation::template call<Args..., test_range<std::random_access_iterator_tag, int, true, false>>();
-        Continuation::template call<Args..., test_range<std::random_access_iterator_tag, int, true, true>>();
+        // Ditto always CommonIterators; !Sized && SizedSentinel is uninteresting (ranges::size still works).
+        Continuation::template call<Args..., range<bidi, int, false, false, false, true, false>>();
+        Continuation::template call<Args..., range<bidi, int, false, false, false, true, true>>();
+        Continuation::template call<Args..., range<bidi, int, false, false, true, true, false>>();
+        Continuation::template call<Args..., range<bidi, int, false, false, true, true, true>>();
+        Continuation::template call<Args..., range<bidi, int, true, false, false, true, false>>();
+        Continuation::template call<Args..., range<bidi, int, true, false, false, true, true>>();
+        Continuation::template call<Args..., range<bidi, int, true, false, true, true, false>>();
+        Continuation::template call<Args..., range<bidi, int, true, false, true, true, true>>();
+        Continuation::template call<Args..., range<bidi, int, true, true, false, true, false>>();
+        Continuation::template call<Args..., range<bidi, int, true, true, false, true, true>>();
+        Continuation::template call<Args..., range<bidi, int, true, true, true, true, false>>();
+        Continuation::template call<Args..., range<bidi, int, true, true, true, true, true>>();
 
-        Continuation::template call<Args..., test_range<std::contiguous_iterator_tag, int, true, false>>();
-        Continuation::template call<Args..., test_range<std::contiguous_iterator_tag, int, true, true>>();
+        // Ditto always CommonIterators; !Sized && SizedSentinel is uninteresting (ranges::size still works), as is
+        // !Sized && Common.
+        Continuation::template call<Args..., range<random, int, false, false, false, true, false>>();
+        Continuation::template call<Args..., range<random, int, false, false, false, true, true>>();
+        Continuation::template call<Args..., range<random, int, true, false, false, true, false>>();
+        Continuation::template call<Args..., range<random, int, true, false, false, true, true>>();
+        Continuation::template call<Args..., range<random, int, true, false, true, true, false>>();
+        Continuation::template call<Args..., range<random, int, true, false, true, true, true>>();
+        Continuation::template call<Args..., range<random, int, true, true, false, true, false>>();
+        Continuation::template call<Args..., range<random, int, true, true, false, true, true>>();
+        Continuation::template call<Args..., range<random, int, true, true, true, true, false>>();
+        Continuation::template call<Args..., range<random, int, true, true, true, true, true>>();
+
+        // Ditto always CommonIterators; !Sized && SizedSentinel is uninteresting (ranges::size still works), as is
+        // !Sized && Common. contiguous also implies !Proxy.
+        Continuation::template call<Args..., range<contiguous, int, false, false, false, true, false>>();
+        Continuation::template call<Args..., range<contiguous, int, true, false, false, true, false>>();
+        Continuation::template call<Args..., range<contiguous, int, true, false, true, true, false>>();
+        Continuation::template call<Args..., range<contiguous, int, true, true, false, true, false>>();
+        Continuation::template call<Args..., range<contiguous, int, true, true, true, true, false>>();
     }
 };
 
@@ -514,13 +672,26 @@ template <class Continuation>
 struct with_input_iterators {
     template <class... Args>
     static void call() {
-        Continuation::template call<Args..., test_iterator<std::input_iterator_tag, int>>();
-        Continuation::template call<Args..., test_iterator<std::forward_iterator_tag, int, false>>();
-        Continuation::template call<Args..., test_iterator<std::forward_iterator_tag, int, true>>();
-        Continuation::template call<Args..., test_iterator<std::bidirectional_iterator_tag, int, false>>();
-        Continuation::template call<Args..., test_iterator<std::bidirectional_iterator_tag, int, true>>();
-        Continuation::template call<Args..., test_iterator<std::random_access_iterator_tag, int>>();
-        Continuation::template call<Args..., test_iterator<std::contiguous_iterator_tag, int>>();
+        using namespace test;
+
+        // Sized and Common are not significant for "lone" single-pass iterators, so we can ignore them here.
+        Continuation::template call<Args..., iterator<input, int, false, false, false>>();
+        Continuation::template call<Args..., iterator<input, int, false, false, true>>();
+        // For forward and bidi, Common is necessarily true but Sized and Proxy may vary.
+        Continuation::template call<Args..., iterator<fwd, int, false, true, false>>();
+        Continuation::template call<Args..., iterator<fwd, int, false, true, true>>();
+        Continuation::template call<Args..., iterator<fwd, int, true, true, false>>();
+        Continuation::template call<Args..., iterator<fwd, int, true, true, true>>();
+
+        Continuation::template call<Args..., iterator<bidi, int, false, true, false>>();
+        Continuation::template call<Args..., iterator<bidi, int, false, true, true>>();
+        Continuation::template call<Args..., iterator<bidi, int, true, true, false>>();
+        Continuation::template call<Args..., iterator<bidi, int, true, true, true>>();
+        // Random iterators are Sized and Common - only Proxy varies.
+        Continuation::template call<Args..., iterator<random, int, true, true, false>>();
+        Continuation::template call<Args..., iterator<random, int, true, true, true>>();
+        // Contiguous iterators are totally locked down.
+        Continuation::template call<Args..., iterator<contiguous, int>>();
     }
 };
 
@@ -531,11 +702,6 @@ struct with_difference {
         Continuation::template call<Iterator, std::iter_difference_t<Iterator>>();
     }
 };
-
-template <class Instantiator>
-void test_out() {
-    with_output_iterators<Instantiator>::call();
-}
 
 template <class Instantiator>
 void test_in() {
@@ -563,11 +729,11 @@ void test_fwd_fwd() {
 }
 
 template <class Instantiator>
-void test_in_out() {
-    with_input_ranges<with_output_iterators<Instantiator>>::call();
+void test_in_write() {
+    with_input_ranges<with_writable_iterators<Instantiator>>::call();
 }
 
 template <class Instantiator>
-void test_counted_out() {
-    with_input_iterators<with_difference<with_output_iterators<Instantiator>>>::call();
+void test_counted_write() {
+    with_input_iterators<with_difference<with_writable_iterators<Instantiator>>>::call();
 }

--- a/tests/std/test.lst
+++ b/tests/std/test.lst
@@ -253,6 +253,7 @@ tests\P0896R4_ranges_alg_none_of
 tests\P0896R4_ranges_iterator_machinery
 tests\P0896R4_ranges_range_machinery
 tests\P0896R4_ranges_subrange
+tests\P0896R4_ranges_test_machinery
 tests\P0896R4_ranges_to_address
 tests\P0898R3_concepts
 tests\P0898R3_identity

--- a/tests/std/tests/P0896R4_ranges_alg_copy/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_copy/test.cpp
@@ -56,4 +56,4 @@ struct instantiator {
     }
 };
 
-template void test_in_out<instantiator>();
+template void test_in_write<instantiator>();

--- a/tests/std/tests/P0896R4_ranges_alg_copy_if/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_copy_if/test.cpp
@@ -17,6 +17,43 @@ struct not_pair {
     U second;
 
     auto operator<=>(const not_pair&) const = default;
+
+    template <std::size_t I>
+    constexpr friend auto&& get(not_pair& np) noexcept {
+        if constexpr (I == 0) {
+            return np.first;
+        } else {
+            STATIC_ASSERT(I == 1);
+            return np.second;
+        }
+    }
+    template <std::size_t I>
+    constexpr friend auto&& get(not_pair const& np) noexcept {
+        if constexpr (I == 0) {
+            return np.first;
+        } else {
+            STATIC_ASSERT(I == 1);
+            return np.second;
+        }
+    }
+    template <std::size_t I>
+    constexpr friend auto&& get(not_pair&& np) noexcept {
+        if constexpr (I == 0) {
+            return std::move(np).first;
+        } else {
+            STATIC_ASSERT(I == 1);
+            return std::move(np).second;
+        }
+    }
+    template <std::size_t I>
+    constexpr friend auto&& get(not_pair const&& np) noexcept {
+        if constexpr (I == 0) {
+            return std::move(np).first;
+        } else {
+            STATIC_ASSERT(I == 1);
+            return std::move(np).second;
+        }
+    }
 };
 
 constexpr void smoke_test() {

--- a/tests/std/tests/P0896R4_ranges_alg_copy_if/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_copy_if/test.cpp
@@ -79,4 +79,4 @@ struct instantiator {
     }
 };
 
-template void test_in_out<instantiator>();
+template void test_in_write<instantiator>();

--- a/tests/std/tests/P0896R4_ranges_alg_copy_n/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_copy_n/test.cpp
@@ -39,4 +39,4 @@ struct instantiator {
     }
 };
 
-template void test_counted_out<instantiator>();
+template void test_counted_write<instantiator>();

--- a/tests/std/tests/P0896R4_ranges_alg_find_first_of/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_find_first_of/test.cpp
@@ -25,33 +25,33 @@ constexpr void smoke_test() {
     const array good_needle = {29, 1};
     {
         // Validate range overload [found case]
-        const auto result = find_first_of(move_only_range{pairs}, good_needle, pred, get_first);
-        STATIC_ASSERT(same_as<decltype(result), const iterator_t<move_only_range<const P>>>);
-        assert(to_address(result.base()) == pairs.data() + 2);
+        auto result = find_first_of(move_only_range{pairs}, good_needle, pred, get_first);
+        STATIC_ASSERT(same_as<decltype(result), iterator_t<move_only_range<const P>>>);
+        assert(to_address(std::move(result).base()) == pairs.data() + 2);
     }
     {
         // Validate iterator + sentinel overload [found case]
         move_only_range wrapped_pairs{pairs};
-        const auto result = find_first_of(
+        auto result = find_first_of(
             wrapped_pairs.begin(), wrapped_pairs.end(), good_needle.begin(), good_needle.end(), pred, get_first);
-        STATIC_ASSERT(same_as<decltype(result), const iterator_t<move_only_range<const P>>>);
-        assert(to_address(result.base()) == pairs.data() + 2);
+        STATIC_ASSERT(same_as<decltype(result), iterator_t<move_only_range<const P>>>);
+        assert(to_address(std::move(result).base()) == pairs.data() + 2);
     }
 
     const array bad_needle = {29, 17};
     {
         // Validate range overload [not found case]
-        const auto result = find_first_of(move_only_range{pairs}, bad_needle, pred, get_first);
-        STATIC_ASSERT(same_as<decltype(result), const iterator_t<move_only_range<const P>>>);
-        assert(to_address(result.base()) == pairs.data() + pairs.size());
+        auto result = find_first_of(move_only_range{pairs}, bad_needle, pred, get_first);
+        STATIC_ASSERT(same_as<decltype(result), iterator_t<move_only_range<const P>>>);
+        assert(to_address(std::move(result).base()) == pairs.data() + pairs.size());
     }
     {
         // Validate iterator + sentinel overload [not found case]
         move_only_range wrapped_pairs{pairs};
-        const auto result = find_first_of(
+        auto result = find_first_of(
             wrapped_pairs.begin(), wrapped_pairs.end(), bad_needle.begin(), bad_needle.end(), pred, get_first);
-        STATIC_ASSERT(same_as<decltype(result), const iterator_t<move_only_range<const P>>>);
-        assert(to_address(result.base()) == pairs.data() + pairs.size());
+        STATIC_ASSERT(same_as<decltype(result), iterator_t<move_only_range<const P>>>);
+        assert(to_address(std::move(result).base()) == pairs.data() + pairs.size());
     }
 }
 

--- a/tests/std/tests/P0896R4_ranges_alg_for_each_n/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_for_each_n/test.cpp
@@ -51,4 +51,4 @@ struct instantiator {
     }
 };
 
-template void test_counted_out<instantiator>();
+template void test_counted_write<instantiator>();

--- a/tests/std/tests/P0896R4_ranges_subrange/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_subrange/test.cpp
@@ -91,22 +91,25 @@ namespace test_view_interface {
         t[42];
     };
 
+    using test::Common, test::CanDifference, test::CanCompare, test::ProxyRef;
+    enum class ConstRange : bool { no, yes };
+
     // clang-format off
-    template <class Cat, bool Common, bool SizedSentinel, bool ConstRange>
-    struct fake_view : ranges::view_interface<fake_view<Cat, Common, SizedSentinel, ConstRange>> {
-        using I = test::iterator<Cat, int, SizedSentinel, true, false>;
-        using S = std::conditional_t<Common, I, test::sentinel<int>>;
+    template <class Cat, Common IsCommon, CanDifference Diff, ConstRange HasConstRange>
+    struct fake_view : ranges::view_interface<fake_view<Cat, IsCommon, Diff, HasConstRange>> {
+        using I = test::iterator<Cat, int, Diff, CanCompare::yes, ProxyRef::no>;
+        using S = std::conditional_t<bool(IsCommon), I, test::sentinel<int>>;
 
         I begin();
-        I begin() const requires ConstRange;
+        I begin() const requires (bool(HasConstRange));
 
         S end();
-        S end() const requires ConstRange;
+        S end() const requires (bool(HasConstRange));
     };
     // clang-format on
 
     namespace output_unsized_onlymutable {
-        using V = fake_view<output_iterator_tag, false, false, false>;
+        using V = fake_view<output_iterator_tag, Common::no, CanDifference::no, ConstRange::no>;
         STATIC_ASSERT(ranges::range<V>);
         STATIC_ASSERT(!ranges::range<V const>);
         STATIC_ASSERT(ranges::view<V>);
@@ -127,7 +130,7 @@ namespace test_view_interface {
     } // namespace output_unsized_onlymutable
 
     namespace output_unsized_allowconst {
-        using V = fake_view<output_iterator_tag, false, false, true>;
+        using V = fake_view<output_iterator_tag, Common::no, CanDifference::no, ConstRange::yes>;
         STATIC_ASSERT(ranges::range<V>);
         STATIC_ASSERT(ranges::range<V const>);
         STATIC_ASSERT(ranges::view<V>);
@@ -148,7 +151,7 @@ namespace test_view_interface {
     } // namespace output_unsized_allowconst
 
     namespace output_sized_onlymutable {
-        using V = fake_view<output_iterator_tag, false, true, false>;
+        using V = fake_view<output_iterator_tag, Common::no, CanDifference::yes, ConstRange::no>;
         STATIC_ASSERT(ranges::range<V>);
         STATIC_ASSERT(!ranges::range<V const>);
         STATIC_ASSERT(ranges::view<V>);
@@ -169,7 +172,7 @@ namespace test_view_interface {
     } // namespace output_sized_onlymutable
 
     namespace output_sized_allowconst {
-        using V = fake_view<output_iterator_tag, false, true, true>;
+        using V = fake_view<output_iterator_tag, Common::no, CanDifference::yes, ConstRange::yes>;
         STATIC_ASSERT(ranges::range<V>);
         STATIC_ASSERT(ranges::range<V const>);
         STATIC_ASSERT(ranges::view<V>);
@@ -190,7 +193,7 @@ namespace test_view_interface {
     } // namespace output_sized_allowconst
 
     namespace input_unsized_onlymutable {
-        using V = fake_view<input_iterator_tag, false, false, false>;
+        using V = fake_view<input_iterator_tag, Common::no, CanDifference::no, ConstRange::no>;
         STATIC_ASSERT(ranges::range<V>);
         STATIC_ASSERT(!ranges::range<V const>);
         STATIC_ASSERT(ranges::view<V>);
@@ -211,7 +214,7 @@ namespace test_view_interface {
     } // namespace input_unsized_onlymutable
 
     namespace input_unsized_allowconst {
-        using V = fake_view<input_iterator_tag, false, false, true>;
+        using V = fake_view<input_iterator_tag, Common::no, CanDifference::no, ConstRange::yes>;
         STATIC_ASSERT(ranges::range<V>);
         STATIC_ASSERT(ranges::range<V const>);
         STATIC_ASSERT(ranges::view<V>);
@@ -232,7 +235,7 @@ namespace test_view_interface {
     } // namespace input_unsized_allowconst
 
     namespace input_sized_onlymutable {
-        using V = fake_view<input_iterator_tag, false, true, false>;
+        using V = fake_view<input_iterator_tag, Common::no, CanDifference::yes, ConstRange::no>;
         STATIC_ASSERT(ranges::range<V>);
         STATIC_ASSERT(!ranges::range<V const>);
         STATIC_ASSERT(ranges::view<V>);
@@ -253,7 +256,7 @@ namespace test_view_interface {
     } // namespace input_sized_onlymutable
 
     namespace input_sized_allowconst {
-        using V = fake_view<input_iterator_tag, false, true, true>;
+        using V = fake_view<input_iterator_tag, Common::no, CanDifference::yes, ConstRange::yes>;
         STATIC_ASSERT(ranges::range<V>);
         STATIC_ASSERT(ranges::range<V const>);
         STATIC_ASSERT(ranges::view<V>);
@@ -274,7 +277,7 @@ namespace test_view_interface {
     } // namespace input_sized_allowconst
 
     namespace forward_uncommon_unsized_onlymutable {
-        using V = fake_view<forward_iterator_tag, false, false, false>;
+        using V = fake_view<forward_iterator_tag, Common::no, CanDifference::no, ConstRange::no>;
         STATIC_ASSERT(ranges::range<V>);
         STATIC_ASSERT(!ranges::range<V const>);
         STATIC_ASSERT(ranges::view<V>);
@@ -295,7 +298,7 @@ namespace test_view_interface {
     } // namespace forward_uncommon_unsized_onlymutable
 
     namespace forward_uncommon_unsized_allowconst {
-        using V = fake_view<forward_iterator_tag, false, false, true>;
+        using V = fake_view<forward_iterator_tag, Common::no, CanDifference::no, ConstRange::yes>;
         STATIC_ASSERT(ranges::range<V>);
         STATIC_ASSERT(ranges::range<V const>);
         STATIC_ASSERT(ranges::view<V>);
@@ -316,7 +319,7 @@ namespace test_view_interface {
     } // namespace forward_uncommon_unsized_allowconst
 
     namespace forward_uncommon_sized_onlymutable {
-        using V = fake_view<forward_iterator_tag, false, true, false>;
+        using V = fake_view<forward_iterator_tag, Common::no, CanDifference::yes, ConstRange::no>;
         STATIC_ASSERT(ranges::range<V>);
         STATIC_ASSERT(!ranges::range<V const>);
         STATIC_ASSERT(ranges::view<V>);
@@ -337,7 +340,7 @@ namespace test_view_interface {
     } // namespace forward_uncommon_sized_onlymutable
 
     namespace forward_uncommon_sized_allowconst {
-        using V = fake_view<forward_iterator_tag, false, true, true>;
+        using V = fake_view<forward_iterator_tag, Common::no, CanDifference::yes, ConstRange::yes>;
         STATIC_ASSERT(ranges::range<V>);
         STATIC_ASSERT(ranges::range<V const>);
         STATIC_ASSERT(ranges::view<V>);
@@ -358,7 +361,7 @@ namespace test_view_interface {
     } // namespace forward_uncommon_sized_allowconst
 
     namespace forward_common_unsized_onlymutable {
-        using V = fake_view<forward_iterator_tag, true, false, false>;
+        using V = fake_view<forward_iterator_tag, Common::yes, CanDifference::no, ConstRange::no>;
         STATIC_ASSERT(ranges::range<V>);
         STATIC_ASSERT(!ranges::range<V const>);
         STATIC_ASSERT(ranges::view<V>);
@@ -379,7 +382,7 @@ namespace test_view_interface {
     } // namespace forward_common_unsized_onlymutable
 
     namespace forward_common_unsized_allowconst {
-        using V = fake_view<forward_iterator_tag, true, false, true>;
+        using V = fake_view<forward_iterator_tag, Common::yes, CanDifference::no, ConstRange::yes>;
         STATIC_ASSERT(ranges::range<V>);
         STATIC_ASSERT(ranges::range<V const>);
         STATIC_ASSERT(ranges::view<V>);
@@ -400,7 +403,7 @@ namespace test_view_interface {
     } // namespace forward_common_unsized_allowconst
 
     namespace forward_common_sized_onlymutable {
-        using V = fake_view<forward_iterator_tag, true, true, false>;
+        using V = fake_view<forward_iterator_tag, Common::yes, CanDifference::yes, ConstRange::no>;
         STATIC_ASSERT(ranges::range<V>);
         STATIC_ASSERT(!ranges::range<V const>);
         STATIC_ASSERT(ranges::view<V>);
@@ -421,7 +424,7 @@ namespace test_view_interface {
     } // namespace forward_common_sized_onlymutable
 
     namespace forward_common_sized_allowconst {
-        using V = fake_view<forward_iterator_tag, true, true, true>;
+        using V = fake_view<forward_iterator_tag, Common::yes, CanDifference::yes, ConstRange::yes>;
         STATIC_ASSERT(ranges::range<V>);
         STATIC_ASSERT(ranges::range<V const>);
         STATIC_ASSERT(ranges::view<V>);
@@ -442,7 +445,7 @@ namespace test_view_interface {
     } // namespace forward_common_sized_allowconst
 
     namespace bidi_uncommon_unsized_onlymutable {
-        using V = fake_view<bidirectional_iterator_tag, false, false, false>;
+        using V = fake_view<bidirectional_iterator_tag, Common::no, CanDifference::no, ConstRange::no>;
         STATIC_ASSERT(ranges::range<V>);
         STATIC_ASSERT(!ranges::range<V const>);
         STATIC_ASSERT(ranges::view<V>);
@@ -463,7 +466,7 @@ namespace test_view_interface {
     } // namespace bidi_uncommon_unsized_onlymutable
 
     namespace bidi_uncommon_unsized_allowconst {
-        using V = fake_view<bidirectional_iterator_tag, false, false, true>;
+        using V = fake_view<bidirectional_iterator_tag, Common::no, CanDifference::no, ConstRange::yes>;
         STATIC_ASSERT(ranges::range<V>);
         STATIC_ASSERT(ranges::range<V const>);
         STATIC_ASSERT(ranges::view<V>);
@@ -484,7 +487,7 @@ namespace test_view_interface {
     } // namespace bidi_uncommon_unsized_allowconst
 
     namespace bidi_uncommon_sized_onlymutable {
-        using V = fake_view<bidirectional_iterator_tag, false, true, false>;
+        using V = fake_view<bidirectional_iterator_tag, Common::no, CanDifference::yes, ConstRange::no>;
         STATIC_ASSERT(ranges::range<V>);
         STATIC_ASSERT(!ranges::range<V const>);
         STATIC_ASSERT(ranges::view<V>);
@@ -505,7 +508,7 @@ namespace test_view_interface {
     } // namespace bidi_uncommon_sized_onlymutable
 
     namespace bidi_uncommon_sized_allowconst {
-        using V = fake_view<bidirectional_iterator_tag, false, true, true>;
+        using V = fake_view<bidirectional_iterator_tag, Common::no, CanDifference::yes, ConstRange::yes>;
         STATIC_ASSERT(ranges::range<V>);
         STATIC_ASSERT(ranges::range<V const>);
         STATIC_ASSERT(ranges::view<V>);
@@ -526,7 +529,7 @@ namespace test_view_interface {
     } // namespace bidi_uncommon_sized_allowconst
 
     namespace bidi_common_unsized_onlymutable {
-        using V = fake_view<bidirectional_iterator_tag, true, false, false>;
+        using V = fake_view<bidirectional_iterator_tag, Common::yes, CanDifference::no, ConstRange::no>;
         STATIC_ASSERT(ranges::range<V>);
         STATIC_ASSERT(!ranges::range<V const>);
         STATIC_ASSERT(ranges::view<V>);
@@ -547,7 +550,7 @@ namespace test_view_interface {
     } // namespace bidi_common_unsized_onlymutable
 
     namespace bidi_common_unsized_allowconst {
-        using V = fake_view<bidirectional_iterator_tag, true, false, true>;
+        using V = fake_view<bidirectional_iterator_tag, Common::yes, CanDifference::no, ConstRange::yes>;
         STATIC_ASSERT(ranges::range<V>);
         STATIC_ASSERT(ranges::range<V const>);
         STATIC_ASSERT(ranges::view<V>);
@@ -568,7 +571,7 @@ namespace test_view_interface {
     } // namespace bidi_common_unsized_allowconst
 
     namespace bidi_common_sized_onlymutable {
-        using V = fake_view<bidirectional_iterator_tag, true, true, false>;
+        using V = fake_view<bidirectional_iterator_tag, Common::yes, CanDifference::yes, ConstRange::no>;
         STATIC_ASSERT(ranges::range<V>);
         STATIC_ASSERT(!ranges::range<V const>);
         STATIC_ASSERT(ranges::view<V>);
@@ -589,7 +592,7 @@ namespace test_view_interface {
     } // namespace bidi_common_sized_onlymutable
 
     namespace bidi_common_sized_allowconst {
-        using V = fake_view<bidirectional_iterator_tag, true, true, true>;
+        using V = fake_view<bidirectional_iterator_tag, Common::yes, CanDifference::yes, ConstRange::yes>;
         STATIC_ASSERT(ranges::range<V>);
         STATIC_ASSERT(ranges::range<V const>);
         STATIC_ASSERT(ranges::view<V>);
@@ -610,7 +613,7 @@ namespace test_view_interface {
     } // namespace bidi_common_sized_allowconst
 
     namespace random_uncommon_sized_onlymutable {
-        using V = fake_view<random_access_iterator_tag, false, true, false>;
+        using V = fake_view<random_access_iterator_tag, Common::no, CanDifference::yes, ConstRange::no>;
         STATIC_ASSERT(ranges::range<V>);
         STATIC_ASSERT(!ranges::range<V const>);
         STATIC_ASSERT(ranges::view<V>);
@@ -631,7 +634,7 @@ namespace test_view_interface {
     } // namespace random_uncommon_sized_onlymutable
 
     namespace random_uncommon_sized_allowconst {
-        using V = fake_view<random_access_iterator_tag, false, true, true>;
+        using V = fake_view<random_access_iterator_tag, Common::no, CanDifference::yes, ConstRange::yes>;
         STATIC_ASSERT(ranges::range<V>);
         STATIC_ASSERT(ranges::range<V const>);
         STATIC_ASSERT(ranges::view<V>);
@@ -652,7 +655,7 @@ namespace test_view_interface {
     } // namespace random_uncommon_sized_allowconst
 
     namespace random_common_sized_onlymutable {
-        using V = fake_view<random_access_iterator_tag, true, true, false>;
+        using V = fake_view<random_access_iterator_tag, Common::yes, CanDifference::yes, ConstRange::no>;
         STATIC_ASSERT(ranges::range<V>);
         STATIC_ASSERT(!ranges::range<V const>);
         STATIC_ASSERT(ranges::view<V>);
@@ -673,7 +676,7 @@ namespace test_view_interface {
     } // namespace random_common_sized_onlymutable
 
     namespace random_common_sized_allowconst {
-        using V = fake_view<random_access_iterator_tag, true, true, true>;
+        using V = fake_view<random_access_iterator_tag, Common::yes, CanDifference::yes, ConstRange::yes>;
         STATIC_ASSERT(ranges::range<V>);
         STATIC_ASSERT(ranges::range<V const>);
         STATIC_ASSERT(ranges::view<V>);
@@ -694,7 +697,7 @@ namespace test_view_interface {
     } // namespace random_common_sized_allowconst
 
     namespace contiguous_uncommon_sized_onlymutable {
-        using V = fake_view<contiguous_iterator_tag, false, true, false>;
+        using V = fake_view<contiguous_iterator_tag, Common::no, CanDifference::yes, ConstRange::no>;
         STATIC_ASSERT(ranges::range<V>);
         STATIC_ASSERT(!ranges::range<V const>);
         STATIC_ASSERT(ranges::view<V>);
@@ -715,7 +718,7 @@ namespace test_view_interface {
     } // namespace contiguous_uncommon_sized_onlymutable
 
     namespace contiguous_uncommon_sized_allowconst {
-        using V = fake_view<contiguous_iterator_tag, false, true, true>;
+        using V = fake_view<contiguous_iterator_tag, Common::no, CanDifference::yes, ConstRange::yes>;
         STATIC_ASSERT(ranges::range<V>);
         STATIC_ASSERT(ranges::range<V const>);
         STATIC_ASSERT(ranges::view<V>);
@@ -736,7 +739,7 @@ namespace test_view_interface {
     } // namespace contiguous_uncommon_sized_allowconst
 
     namespace contiguous_common_sized_onlymutable {
-        using V = fake_view<contiguous_iterator_tag, true, true, false>;
+        using V = fake_view<contiguous_iterator_tag, Common::yes, CanDifference::yes, ConstRange::no>;
         STATIC_ASSERT(ranges::range<V>);
         STATIC_ASSERT(!ranges::range<V const>);
         STATIC_ASSERT(ranges::view<V>);
@@ -757,7 +760,7 @@ namespace test_view_interface {
     } // namespace contiguous_common_sized_onlymutable
 
     namespace contiguous_common_sized_allowconst {
-        using V = fake_view<contiguous_iterator_tag, true, true, true>;
+        using V = fake_view<contiguous_iterator_tag, Common::yes, CanDifference::yes, ConstRange::yes>;
         STATIC_ASSERT(ranges::range<V>);
         STATIC_ASSERT(ranges::range<V const>);
         STATIC_ASSERT(ranges::view<V>);
@@ -883,103 +886,197 @@ namespace test_subrange {
         return true;
     }
 
-    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, false, false, false, false, false>>());
-    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, false, false, false, false, true>>());
-    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, false, false, false, true, false>>());
-    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, false, false, false, true, true>>());
-    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, false, false, true, true, false>>());
-    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, false, false, true, true, true>>());
-    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, false, true, false, false, false>>());
-    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, false, true, false, false, true>>());
-    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, false, true, false, true, false>>());
-    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, false, true, false, true, true>>());
-    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, false, true, true, true, false>>());
-    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, false, true, true, true, true>>());
-    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, true, false, false, false, false>>());
-    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, true, false, false, false, true>>());
-    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, true, false, false, true, false>>());
-    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, true, false, false, true, true>>());
-    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, true, false, true, true, false>>());
-    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, true, false, true, true, true>>());
-    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, true, true, false, false, false>>());
-    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, true, true, false, false, true>>());
-    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, true, true, false, true, false>>());
-    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, true, true, false, true, true>>());
-    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, true, true, true, true, false>>());
-    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, true, true, true, true, true>>());
+    using test::CanCompare, test::CanDifference, test::Common, test::ProxyRef, test::Sized;
 
-    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, false, false, false, false, false>>());
-    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, false, false, false, false, true>>());
-    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, false, false, false, true, false>>());
-    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, false, false, false, true, true>>());
-    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, false, false, true, true, false>>());
-    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, false, false, true, true, true>>());
-    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, false, true, false, false, false>>());
-    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, false, true, false, false, true>>());
-    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, false, true, false, true, false>>());
-    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, false, true, false, true, true>>());
-    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, false, true, true, true, false>>());
-    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, false, true, true, true, true>>());
-    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, true, false, false, false, false>>());
-    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, true, false, false, false, true>>());
-    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, true, false, false, true, false>>());
-    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, true, false, false, true, true>>());
-    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, true, false, true, true, false>>());
-    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, true, false, true, true, true>>());
-    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, true, true, false, false, false>>());
-    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, true, true, false, false, true>>());
-    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, true, true, false, true, false>>());
-    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, true, true, false, true, true>>());
-    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, true, true, true, true, false>>());
-    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, true, true, true, true, true>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, Sized::no, CanDifference::no, Common::no,
+            CanCompare::no, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, Sized::no, CanDifference::no, Common::no,
+            CanCompare::no, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, Sized::no, CanDifference::no, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, Sized::no, CanDifference::no, Common::no,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, Sized::no, CanDifference::no, Common::yes,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, Sized::no, CanDifference::no, Common::yes,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, Sized::no, CanDifference::yes, Common::no,
+            CanCompare::no, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, Sized::no, CanDifference::yes, Common::no,
+            CanCompare::no, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, Sized::no, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, Sized::no, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, Sized::no, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, Sized::no, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, Sized::yes, CanDifference::no, Common::no,
+            CanCompare::no, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, Sized::yes, CanDifference::no, Common::no,
+            CanCompare::no, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, Sized::yes, CanDifference::no, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, Sized::yes, CanDifference::no, Common::no,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, Sized::yes, CanDifference::no, Common::yes,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, Sized::yes, CanDifference::no, Common::yes,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no,
+            CanCompare::no, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no,
+            CanCompare::no, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, Sized::yes, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, Sized::yes, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::yes>>());
 
-    STATIC_ASSERT(test_construction<test::range<forward_iterator_tag, int, false, false, false, true, false>>());
-    STATIC_ASSERT(test_construction<test::range<forward_iterator_tag, int, false, false, false, true, true>>());
-    STATIC_ASSERT(test_construction<test::range<forward_iterator_tag, int, false, false, true, true, false>>());
-    STATIC_ASSERT(test_construction<test::range<forward_iterator_tag, int, false, false, true, true, true>>());
-    STATIC_ASSERT(test_construction<test::range<forward_iterator_tag, int, false, true, false, true, false>>());
-    STATIC_ASSERT(test_construction<test::range<forward_iterator_tag, int, false, true, false, true, true>>());
-    STATIC_ASSERT(test_construction<test::range<forward_iterator_tag, int, false, true, true, true, false>>());
-    STATIC_ASSERT(test_construction<test::range<forward_iterator_tag, int, false, true, true, true, true>>());
-    STATIC_ASSERT(test_construction<test::range<forward_iterator_tag, int, true, false, false, true, false>>());
-    STATIC_ASSERT(test_construction<test::range<forward_iterator_tag, int, true, false, false, true, true>>());
-    STATIC_ASSERT(test_construction<test::range<forward_iterator_tag, int, true, false, true, true, false>>());
-    STATIC_ASSERT(test_construction<test::range<forward_iterator_tag, int, true, false, true, true, true>>());
-    STATIC_ASSERT(test_construction<test::range<forward_iterator_tag, int, true, true, false, true, false>>());
-    STATIC_ASSERT(test_construction<test::range<forward_iterator_tag, int, true, true, false, true, true>>());
-    STATIC_ASSERT(test_construction<test::range<forward_iterator_tag, int, true, true, true, true, false>>());
-    STATIC_ASSERT(test_construction<test::range<forward_iterator_tag, int, true, true, true, true, true>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, Sized::no, CanDifference::no, Common::no,
+            CanCompare::no, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, Sized::no, CanDifference::no, Common::no,
+            CanCompare::no, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, Sized::no, CanDifference::no, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, Sized::no, CanDifference::no, Common::no,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, Sized::no, CanDifference::no, Common::yes,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, Sized::no, CanDifference::no, Common::yes,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, Sized::no, CanDifference::yes, Common::no,
+            CanCompare::no, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, Sized::no, CanDifference::yes, Common::no,
+            CanCompare::no, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, Sized::no, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, Sized::no, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, Sized::no, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, Sized::no, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, Sized::yes, CanDifference::no, Common::no,
+            CanCompare::no, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, Sized::yes, CanDifference::no, Common::no,
+            CanCompare::no, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, Sized::yes, CanDifference::no, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, Sized::yes, CanDifference::no, Common::no,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, Sized::yes, CanDifference::no, Common::yes,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, Sized::yes, CanDifference::no, Common::yes,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no,
+            CanCompare::no, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no,
+            CanCompare::no, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, Sized::yes, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, Sized::yes, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::yes>>());
 
-    STATIC_ASSERT(test_construction<test::range<bidirectional_iterator_tag, int, false, false, false, true, false>>());
-    STATIC_ASSERT(test_construction<test::range<bidirectional_iterator_tag, int, false, false, false, true, true>>());
-    STATIC_ASSERT(test_construction<test::range<bidirectional_iterator_tag, int, false, false, true, true, false>>());
-    STATIC_ASSERT(test_construction<test::range<bidirectional_iterator_tag, int, false, false, true, true, true>>());
-    STATIC_ASSERT(test_construction<test::range<bidirectional_iterator_tag, int, false, true, false, true, false>>());
-    STATIC_ASSERT(test_construction<test::range<bidirectional_iterator_tag, int, false, true, false, true, true>>());
-    STATIC_ASSERT(test_construction<test::range<bidirectional_iterator_tag, int, false, true, true, true, false>>());
-    STATIC_ASSERT(test_construction<test::range<bidirectional_iterator_tag, int, false, true, true, true, true>>());
-    STATIC_ASSERT(test_construction<test::range<bidirectional_iterator_tag, int, true, false, false, true, false>>());
-    STATIC_ASSERT(test_construction<test::range<bidirectional_iterator_tag, int, true, false, false, true, true>>());
-    STATIC_ASSERT(test_construction<test::range<bidirectional_iterator_tag, int, true, false, true, true, false>>());
-    STATIC_ASSERT(test_construction<test::range<bidirectional_iterator_tag, int, true, false, true, true, true>>());
-    STATIC_ASSERT(test_construction<test::range<bidirectional_iterator_tag, int, true, true, false, true, false>>());
-    STATIC_ASSERT(test_construction<test::range<bidirectional_iterator_tag, int, true, true, false, true, true>>());
-    STATIC_ASSERT(test_construction<test::range<bidirectional_iterator_tag, int, true, true, true, true, false>>());
-    STATIC_ASSERT(test_construction<test::range<bidirectional_iterator_tag, int, true, true, true, true, true>>());
+    STATIC_ASSERT(test_construction<test::range<forward_iterator_tag, int, Sized::no, CanDifference::no, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<forward_iterator_tag, int, Sized::no, CanDifference::no, Common::no,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<forward_iterator_tag, int, Sized::no, CanDifference::no, Common::yes,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<forward_iterator_tag, int, Sized::no, CanDifference::no, Common::yes,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<forward_iterator_tag, int, Sized::no, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<forward_iterator_tag, int, Sized::no, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<forward_iterator_tag, int, Sized::no, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<forward_iterator_tag, int, Sized::no, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<forward_iterator_tag, int, Sized::yes, CanDifference::no, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<forward_iterator_tag, int, Sized::yes, CanDifference::no, Common::no,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<forward_iterator_tag, int, Sized::yes, CanDifference::no, Common::yes,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<forward_iterator_tag, int, Sized::yes, CanDifference::no, Common::yes,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<forward_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<forward_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<forward_iterator_tag, int, Sized::yes, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<forward_iterator_tag, int, Sized::yes, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::yes>>());
 
-    STATIC_ASSERT(test_construction<test::range<random_access_iterator_tag, int, false, true, false, true, false>>());
-    STATIC_ASSERT(test_construction<test::range<random_access_iterator_tag, int, false, true, false, true, true>>());
-    STATIC_ASSERT(test_construction<test::range<random_access_iterator_tag, int, false, true, true, true, false>>());
-    STATIC_ASSERT(test_construction<test::range<random_access_iterator_tag, int, false, true, true, true, true>>());
-    STATIC_ASSERT(test_construction<test::range<random_access_iterator_tag, int, true, true, false, true, false>>());
-    STATIC_ASSERT(test_construction<test::range<random_access_iterator_tag, int, true, true, false, true, true>>());
-    STATIC_ASSERT(test_construction<test::range<random_access_iterator_tag, int, true, true, true, true, false>>());
-    STATIC_ASSERT(test_construction<test::range<random_access_iterator_tag, int, true, true, true, true, true>>());
+    STATIC_ASSERT(test_construction<test::range<bidirectional_iterator_tag, int, Sized::no, CanDifference::no,
+            Common::no, CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<bidirectional_iterator_tag, int, Sized::no, CanDifference::no,
+            Common::no, CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<bidirectional_iterator_tag, int, Sized::no, CanDifference::no,
+            Common::yes, CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<bidirectional_iterator_tag, int, Sized::no, CanDifference::no,
+            Common::yes, CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<bidirectional_iterator_tag, int, Sized::no, CanDifference::yes,
+            Common::no, CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<bidirectional_iterator_tag, int, Sized::no, CanDifference::yes,
+            Common::no, CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<bidirectional_iterator_tag, int, Sized::no, CanDifference::yes,
+            Common::yes, CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<bidirectional_iterator_tag, int, Sized::no, CanDifference::yes,
+            Common::yes, CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<bidirectional_iterator_tag, int, Sized::yes, CanDifference::no,
+            Common::no, CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<bidirectional_iterator_tag, int, Sized::yes, CanDifference::no,
+            Common::no, CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<bidirectional_iterator_tag, int, Sized::yes, CanDifference::no,
+            Common::yes, CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<bidirectional_iterator_tag, int, Sized::yes, CanDifference::no,
+            Common::yes, CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<bidirectional_iterator_tag, int, Sized::yes, CanDifference::yes,
+            Common::no, CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<bidirectional_iterator_tag, int, Sized::yes, CanDifference::yes,
+            Common::no, CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<bidirectional_iterator_tag, int, Sized::yes, CanDifference::yes,
+            Common::yes, CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<bidirectional_iterator_tag, int, Sized::yes, CanDifference::yes,
+            Common::yes, CanCompare::yes, ProxyRef::yes>>());
 
-    STATIC_ASSERT(test_construction<test::range<contiguous_iterator_tag, int, false, true, false, true, false>>());
-    STATIC_ASSERT(test_construction<test::range<contiguous_iterator_tag, int, false, true, true, true, false>>());
-    STATIC_ASSERT(test_construction<test::range<contiguous_iterator_tag, int, true, true, false, true, false>>());
-    STATIC_ASSERT(test_construction<test::range<contiguous_iterator_tag, int, true, true, true, true, false>>());
+    STATIC_ASSERT(test_construction<test::range<random_access_iterator_tag, int, Sized::no, CanDifference::yes,
+            Common::no, CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<random_access_iterator_tag, int, Sized::no, CanDifference::yes,
+            Common::no, CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<random_access_iterator_tag, int, Sized::no, CanDifference::yes,
+            Common::yes, CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<random_access_iterator_tag, int, Sized::no, CanDifference::yes,
+            Common::yes, CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<random_access_iterator_tag, int, Sized::yes, CanDifference::yes,
+            Common::no, CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<random_access_iterator_tag, int, Sized::yes, CanDifference::yes,
+            Common::no, CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<random_access_iterator_tag, int, Sized::yes, CanDifference::yes,
+            Common::yes, CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<random_access_iterator_tag, int, Sized::yes, CanDifference::yes,
+            Common::yes, CanCompare::yes, ProxyRef::yes>>());
+
+    STATIC_ASSERT(test_construction<test::range<contiguous_iterator_tag, int, Sized::no, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<contiguous_iterator_tag, int, Sized::no, CanDifference::yes,
+            Common::yes, CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<contiguous_iterator_tag, int, Sized::yes, CanDifference::yes,
+            Common::no, CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<contiguous_iterator_tag, int, Sized::yes, CanDifference::yes,
+            Common::yes, CanCompare::yes, ProxyRef::no>>());
 
     STATIC_ASSERT(test_construction<std::forward_list<int>>());
     STATIC_ASSERT(test_construction<std::list<int>>());
@@ -1113,120 +1210,213 @@ namespace test_subrange {
         return true;
     }
 
-    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, false, false, false, false, false>>());
-    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, false, false, false, false, true>>());
-    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, false, false, false, true, false>>());
-    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, false, false, false, true, true>>());
-    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, false, false, true, true, false>>());
-    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, false, false, true, true, true>>());
-    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, false, true, false, false, false>>());
-    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, false, true, false, false, true>>());
-    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, false, true, false, true, false>>());
-    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, false, true, false, true, true>>());
-    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, false, true, true, true, false>>());
-    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, false, true, true, true, true>>());
-    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, true, false, false, false, false>>());
-    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, true, false, false, false, true>>());
-    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, true, false, false, true, false>>());
-    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, true, false, false, true, true>>());
-    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, true, false, true, true, false>>());
-    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, true, false, true, true, true>>());
-    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, true, true, false, false, false>>());
-    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, true, true, false, false, true>>());
-    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, true, true, false, true, false>>());
-    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, true, true, false, true, true>>());
-    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, true, true, true, true, false>>());
-    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, true, true, true, true, true>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, Sized::no, CanDifference::no, Common::no,
+            CanCompare::no, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, Sized::no, CanDifference::no, Common::no,
+            CanCompare::no, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, Sized::no, CanDifference::no, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, Sized::no, CanDifference::no, Common::no,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, Sized::no, CanDifference::no, Common::yes,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, Sized::no, CanDifference::no, Common::yes,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, Sized::no, CanDifference::yes, Common::no,
+            CanCompare::no, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, Sized::no, CanDifference::yes, Common::no,
+            CanCompare::no, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, Sized::no, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, Sized::no, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, Sized::no, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, Sized::no, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, Sized::yes, CanDifference::no, Common::no,
+            CanCompare::no, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, Sized::yes, CanDifference::no, Common::no,
+            CanCompare::no, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, Sized::yes, CanDifference::no, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, Sized::yes, CanDifference::no, Common::no,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, Sized::yes, CanDifference::no, Common::yes,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, Sized::yes, CanDifference::no, Common::yes,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no,
+            CanCompare::no, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no,
+            CanCompare::no, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, Sized::yes, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, Sized::yes, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::yes>>());
 
-    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, false, false, false, false, false>>());
-    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, false, false, false, false, true>>());
-    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, false, false, false, true, false>>());
-    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, false, false, false, true, true>>());
-    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, false, false, true, true, false>>());
-    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, false, false, true, true, true>>());
-    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, false, true, false, false, false>>());
-    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, false, true, false, false, true>>());
-    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, false, true, false, true, false>>());
-    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, false, true, false, true, true>>());
-    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, false, true, true, true, false>>());
-    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, false, true, true, true, true>>());
-    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, true, false, false, false, false>>());
-    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, true, false, false, false, true>>());
-    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, true, false, false, true, false>>());
-    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, true, false, false, true, true>>());
-    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, true, false, true, true, false>>());
-    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, true, false, true, true, true>>());
-    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, true, true, false, false, false>>());
-    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, true, true, false, false, true>>());
-    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, true, true, false, true, false>>());
-    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, true, true, false, true, true>>());
-    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, true, true, true, true, false>>());
-    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, true, true, true, true, true>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, Sized::no, CanDifference::no, Common::no,
+            CanCompare::no, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, Sized::no, CanDifference::no, Common::no,
+            CanCompare::no, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, Sized::no, CanDifference::no, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, Sized::no, CanDifference::no, Common::no,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, Sized::no, CanDifference::no, Common::yes,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, Sized::no, CanDifference::no, Common::yes,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, Sized::no, CanDifference::yes, Common::no,
+            CanCompare::no, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, Sized::no, CanDifference::yes, Common::no,
+            CanCompare::no, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, Sized::no, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, Sized::no, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, Sized::no, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, Sized::no, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, Sized::yes, CanDifference::no, Common::no,
+            CanCompare::no, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, Sized::yes, CanDifference::no, Common::no,
+            CanCompare::no, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, Sized::yes, CanDifference::no, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, Sized::yes, CanDifference::no, Common::no,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, Sized::yes, CanDifference::no, Common::yes,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, Sized::yes, CanDifference::no, Common::yes,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no,
+            CanCompare::no, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no,
+            CanCompare::no, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, Sized::yes, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, Sized::yes, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::yes>>());
 
-    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, false, false, false, true, false>>());
-    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, false, false, false, true, true>>());
-    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, false, false, true, true, false>>());
-    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, false, false, true, true, true>>());
-    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, false, true, false, true, false>>());
-    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, false, true, false, true, true>>());
-    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, false, true, true, true, false>>());
-    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, false, true, true, true, true>>());
-    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, true, false, false, true, false>>());
-    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, true, false, false, true, true>>());
-    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, true, false, true, true, false>>());
-    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, true, false, true, true, true>>());
-    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, true, true, false, true, false>>());
-    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, true, true, false, true, true>>());
-    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, true, true, true, true, false>>());
-    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, true, true, true, true, true>>());
+    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, Sized::no, CanDifference::no, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, Sized::no, CanDifference::no, Common::no,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, Sized::no, CanDifference::no, Common::yes,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, Sized::no, CanDifference::no, Common::yes,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, Sized::no, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, Sized::no, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, Sized::no, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, Sized::no, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, Sized::yes, CanDifference::no, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, Sized::yes, CanDifference::no, Common::no,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, Sized::yes, CanDifference::no, Common::yes,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, Sized::yes, CanDifference::no, Common::yes,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, Sized::yes, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, Sized::yes, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::yes>>());
 
-    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, false, false, false, true, false>>());
-    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, false, false, false, true, true>>());
-    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, false, false, true, true, false>>());
-    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, false, false, true, true, true>>());
-    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, false, true, false, true, false>>());
-    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, false, true, false, true, true>>());
-    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, false, true, true, true, false>>());
-    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, false, true, true, true, true>>());
-    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, true, false, false, true, false>>());
-    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, true, false, false, true, true>>());
-    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, true, false, true, true, false>>());
-    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, true, false, true, true, true>>());
-    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, true, true, false, true, false>>());
-    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, true, true, false, true, true>>());
-    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, true, true, true, true, false>>());
-    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, true, true, true, true, true>>());
+    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, Sized::no, CanDifference::no, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, Sized::no, CanDifference::no, Common::no,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, Sized::no, CanDifference::no, Common::yes,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, Sized::no, CanDifference::no, Common::yes,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, Sized::no, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, Sized::no, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, Sized::no, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, Sized::no, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, Sized::yes, CanDifference::no, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, Sized::yes, CanDifference::no, Common::no,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, Sized::yes, CanDifference::no, Common::yes,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, Sized::yes, CanDifference::no, Common::yes,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, Sized::yes, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, Sized::yes, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::yes>>());
 
-    STATIC_ASSERT(test_ctad<test::range<random_access_iterator_tag, int, false, true, false, true, false>>());
-    STATIC_ASSERT(test_ctad<test::range<random_access_iterator_tag, int, false, true, false, true, true>>());
-    STATIC_ASSERT(test_ctad<test::range<random_access_iterator_tag, int, false, true, true, true, false>>());
-    STATIC_ASSERT(test_ctad<test::range<random_access_iterator_tag, int, false, true, true, true, true>>());
-    STATIC_ASSERT(test_ctad<test::range<random_access_iterator_tag, int, true, true, false, true, false>>());
-    STATIC_ASSERT(test_ctad<test::range<random_access_iterator_tag, int, true, true, false, true, true>>());
-    STATIC_ASSERT(test_ctad<test::range<random_access_iterator_tag, int, true, true, true, true, false>>());
-    STATIC_ASSERT(test_ctad<test::range<random_access_iterator_tag, int, true, true, true, true, true>>());
+    STATIC_ASSERT(test_ctad<test::range<random_access_iterator_tag, int, Sized::no, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<random_access_iterator_tag, int, Sized::no, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<random_access_iterator_tag, int, Sized::no, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<random_access_iterator_tag, int, Sized::no, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<random_access_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<random_access_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<random_access_iterator_tag, int, Sized::yes, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<random_access_iterator_tag, int, Sized::yes, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::yes>>());
 
-    STATIC_ASSERT(test_ctad<test::range<contiguous_iterator_tag, int, false, true, false, true, false>>());
-    STATIC_ASSERT(test_ctad<test::range<contiguous_iterator_tag, int, false, true, true, true, false>>());
-    STATIC_ASSERT(test_ctad<test::range<contiguous_iterator_tag, int, true, true, false, true, false>>());
-    STATIC_ASSERT(test_ctad<test::range<contiguous_iterator_tag, int, true, true, true, true, false>>());
+    STATIC_ASSERT(test_ctad<test::range<contiguous_iterator_tag, int, Sized::no, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<contiguous_iterator_tag, int, Sized::no, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<contiguous_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<contiguous_iterator_tag, int, Sized::yes, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::no>>());
 
-    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, false, false>>());
-    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, true, false>>());
-    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, false, false>>());
-    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, true, false>>());
-    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, false, false>>());
-    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, false, true>>());
-    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, true, false>>());
-    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, true, true>>());
-    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, false, false>>());
-    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, false, true>>());
-    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, true, false>>());
-    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, true, true>>());
-    STATIC_ASSERT(test_ctad<test::range<random_access_iterator_tag, int, true, false>>());
-    STATIC_ASSERT(test_ctad<test::range<random_access_iterator_tag, int, true, true>>());
-    STATIC_ASSERT(test_ctad<test::range<contiguous_iterator_tag, int, true, false>>());
-    STATIC_ASSERT(test_ctad<test::range<contiguous_iterator_tag, int, true, true>>());
+    STATIC_ASSERT(
+        test_ctad<test::range<output_iterator_tag, int, Sized::no, CanDifference::no>>()); // FIXME: look at these
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, Sized::yes, CanDifference::no>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, Sized::no, CanDifference::no>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, Sized::yes, CanDifference::no>>());
+    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, Sized::no, CanDifference::no>>());
+    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, Sized::no, CanDifference::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, Sized::yes, CanDifference::no>>());
+    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, Sized::yes, CanDifference::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, Sized::no, CanDifference::no>>());
+    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, Sized::no, CanDifference::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, Sized::yes, CanDifference::no>>());
+    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, Sized::yes, CanDifference::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<random_access_iterator_tag, int, Sized::yes, CanDifference::no>>());
+    STATIC_ASSERT(test_ctad<test::range<random_access_iterator_tag, int, Sized::yes, CanDifference::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<contiguous_iterator_tag, int, Sized::yes, CanDifference::no>>());
+    STATIC_ASSERT(test_ctad<test::range<contiguous_iterator_tag, int, Sized::yes, CanDifference::yes>>());
 
     STATIC_ASSERT(test_ctad<std::forward_list<int>>());
     STATIC_ASSERT(test_ctad<std::list<int>>());

--- a/tests/std/tests/P0896R4_ranges_subrange/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_subrange/test.cpp
@@ -91,17 +91,19 @@ namespace test_view_interface {
         t[42];
     };
 
+    // clang-format off
     template <class Cat, bool Common, bool SizedSentinel, bool ConstRange>
     struct fake_view : ranges::view_interface<fake_view<Cat, Common, SizedSentinel, ConstRange>> {
-        using iterator = test_iterator<Cat, int, SizedSentinel>;
-        using sentinel = std::conditional_t<Common, iterator, std::default_sentinel_t>;
+        using I = test::iterator<Cat, int, SizedSentinel, true, false>;
+        using S = std::conditional_t<Common, I, test::sentinel<int>>;
 
-        iterator begin();
-        iterator begin() const requires ConstRange;
+        I begin();
+        I begin() const requires ConstRange;
 
-        sentinel end();
-        sentinel end() const requires ConstRange;
+        S end();
+        S end() const requires ConstRange;
     };
+    // clang-format on
 
     namespace output_unsized_onlymutable {
         using V = fake_view<output_iterator_tag, false, false, false>;
@@ -607,48 +609,6 @@ namespace test_view_interface {
         STATIC_ASSERT(!CanIndex<V const>);
     } // namespace bidi_common_sized_allowconst
 
-    namespace random_uncommon_unsized_onlymutable {
-        using V = fake_view<random_access_iterator_tag, false, false, false>;
-        STATIC_ASSERT(ranges::range<V>);
-        STATIC_ASSERT(!ranges::range<V const>);
-        STATIC_ASSERT(ranges::view<V>);
-        STATIC_ASSERT(CanEmpty<V>);
-        STATIC_ASSERT(!CanEmpty<V const>);
-        STATIC_ASSERT(CanBool<V>);
-        STATIC_ASSERT(!CanBool<V const>);
-        STATIC_ASSERT(!CanData<V>);
-        STATIC_ASSERT(!CanData<V const>);
-        STATIC_ASSERT(!CanSize<V>);
-        STATIC_ASSERT(!CanSize<V const>);
-        STATIC_ASSERT(CanFront<V>);
-        STATIC_ASSERT(!CanFront<V const>);
-        STATIC_ASSERT(!CanBack<V>);
-        STATIC_ASSERT(!CanBack<V const>);
-        STATIC_ASSERT(CanIndex<V>);
-        STATIC_ASSERT(!CanIndex<V const>);
-    } // namespace random_uncommon_unsized_onlymutable
-
-    namespace random_uncommon_unsized_allowconst {
-        using V = fake_view<random_access_iterator_tag, false, false, true>;
-        STATIC_ASSERT(ranges::range<V>);
-        STATIC_ASSERT(ranges::range<V const>);
-        STATIC_ASSERT(ranges::view<V>);
-        STATIC_ASSERT(CanEmpty<V>);
-        STATIC_ASSERT(CanEmpty<V const>);
-        STATIC_ASSERT(CanBool<V>);
-        STATIC_ASSERT(CanBool<V const>);
-        STATIC_ASSERT(!CanData<V>);
-        STATIC_ASSERT(!CanData<V const>);
-        STATIC_ASSERT(!CanSize<V>);
-        STATIC_ASSERT(!CanSize<V const>);
-        STATIC_ASSERT(CanFront<V>);
-        STATIC_ASSERT(CanFront<V const>);
-        STATIC_ASSERT(!CanBack<V>);
-        STATIC_ASSERT(!CanBack<V const>);
-        STATIC_ASSERT(CanIndex<V>);
-        STATIC_ASSERT(CanIndex<V const>);
-    } // namespace random_uncommon_unsized_allowconst
-
     namespace random_uncommon_sized_onlymutable {
         using V = fake_view<random_access_iterator_tag, false, true, false>;
         STATIC_ASSERT(ranges::range<V>);
@@ -732,48 +692,6 @@ namespace test_view_interface {
         STATIC_ASSERT(CanIndex<V>);
         STATIC_ASSERT(CanIndex<V const>);
     } // namespace random_common_sized_allowconst
-
-    namespace contiguous_uncommon_unsized_onlymutable {
-        using V = fake_view<contiguous_iterator_tag, false, false, false>;
-        STATIC_ASSERT(ranges::range<V>);
-        STATIC_ASSERT(!ranges::range<V const>);
-        STATIC_ASSERT(ranges::view<V>);
-        STATIC_ASSERT(CanEmpty<V>);
-        STATIC_ASSERT(!CanEmpty<V const>);
-        STATIC_ASSERT(CanBool<V>);
-        STATIC_ASSERT(!CanBool<V const>);
-        STATIC_ASSERT(CanData<V>);
-        STATIC_ASSERT(!CanData<V const>);
-        STATIC_ASSERT(!CanSize<V>);
-        STATIC_ASSERT(!CanSize<V const>);
-        STATIC_ASSERT(CanFront<V>);
-        STATIC_ASSERT(!CanFront<V const>);
-        STATIC_ASSERT(!CanBack<V>);
-        STATIC_ASSERT(!CanBack<V const>);
-        STATIC_ASSERT(CanIndex<V>);
-        STATIC_ASSERT(!CanIndex<V const>);
-    } // namespace contiguous_uncommon_unsized_onlymutable
-
-    namespace contiguous_uncommon_unsized_allowconst {
-        using V = fake_view<contiguous_iterator_tag, false, false, true>;
-        STATIC_ASSERT(ranges::range<V>);
-        STATIC_ASSERT(ranges::range<V const>);
-        STATIC_ASSERT(ranges::view<V>);
-        STATIC_ASSERT(CanEmpty<V>);
-        STATIC_ASSERT(CanEmpty<V const>);
-        STATIC_ASSERT(CanBool<V>);
-        STATIC_ASSERT(CanBool<V const>);
-        STATIC_ASSERT(CanData<V>);
-        STATIC_ASSERT(CanData<V const>);
-        STATIC_ASSERT(!CanSize<V>);
-        STATIC_ASSERT(!CanSize<V const>);
-        STATIC_ASSERT(CanFront<V>);
-        STATIC_ASSERT(CanFront<V const>);
-        STATIC_ASSERT(!CanBack<V>);
-        STATIC_ASSERT(!CanBack<V const>);
-        STATIC_ASSERT(CanIndex<V>);
-        STATIC_ASSERT(CanIndex<V const>);
-    } // namespace contiguous_uncommon_unsized_allowconst
 
     namespace contiguous_uncommon_sized_onlymutable {
         using V = fake_view<contiguous_iterator_tag, false, true, false>;
@@ -896,9 +814,8 @@ namespace test_subrange {
     STATIC_ASSERT(same_as<subrange<int*>, subrange<int*, int*, subrange_kind::sized>>);
     STATIC_ASSERT(same_as<subrange<int*, std::unreachable_sentinel_t>,
         subrange<int*, std::unreachable_sentinel_t, subrange_kind::unsized>>);
-    STATIC_ASSERT(same_as<subrange<test_iterator<forward_iterator_tag, int>>,
-        subrange<test_iterator<forward_iterator_tag, int>, test_iterator<forward_iterator_tag, int>,
-            subrange_kind::unsized>>);
+    STATIC_ASSERT(same_as<subrange<std::forward_list<int>::iterator>,
+        subrange<std::forward_list<int>::iterator, std::forward_list<int>::iterator, subrange_kind::unsized>>);
 
     // Validate many properties of a specialization of subrange
     template <class>
@@ -965,22 +882,104 @@ namespace test_subrange {
 
         return true;
     }
-    STATIC_ASSERT(test_construction<test_range<output_iterator_tag, int, false, false>>());
-    STATIC_ASSERT(test_construction<test_range<output_iterator_tag, int, true, false>>());
-    STATIC_ASSERT(test_construction<test_range<input_iterator_tag, int, false, false>>());
-    STATIC_ASSERT(test_construction<test_range<input_iterator_tag, int, true, false>>());
-    STATIC_ASSERT(test_construction<test_range<forward_iterator_tag, int, false, false>>());
-    STATIC_ASSERT(test_construction<test_range<forward_iterator_tag, int, false, true>>());
-    STATIC_ASSERT(test_construction<test_range<forward_iterator_tag, int, true, false>>());
-    STATIC_ASSERT(test_construction<test_range<forward_iterator_tag, int, true, true>>());
-    STATIC_ASSERT(test_construction<test_range<bidirectional_iterator_tag, int, false, false>>());
-    STATIC_ASSERT(test_construction<test_range<bidirectional_iterator_tag, int, false, true>>());
-    STATIC_ASSERT(test_construction<test_range<bidirectional_iterator_tag, int, true, false>>());
-    STATIC_ASSERT(test_construction<test_range<bidirectional_iterator_tag, int, true, true>>());
-    STATIC_ASSERT(test_construction<test_range<random_access_iterator_tag, int, true, false>>());
-    STATIC_ASSERT(test_construction<test_range<random_access_iterator_tag, int, true, true>>());
-    STATIC_ASSERT(test_construction<test_range<contiguous_iterator_tag, int, true, false>>());
-    STATIC_ASSERT(test_construction<test_range<contiguous_iterator_tag, int, true, true>>());
+
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, false, false, false, false, false>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, false, false, false, false, true>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, false, false, false, true, false>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, false, false, false, true, true>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, false, false, true, true, false>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, false, false, true, true, true>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, false, true, false, false, false>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, false, true, false, false, true>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, false, true, false, true, false>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, false, true, false, true, true>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, false, true, true, true, false>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, false, true, true, true, true>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, true, false, false, false, false>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, true, false, false, false, true>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, true, false, false, true, false>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, true, false, false, true, true>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, true, false, true, true, false>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, true, false, true, true, true>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, true, true, false, false, false>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, true, true, false, false, true>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, true, true, false, true, false>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, true, true, false, true, true>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, true, true, true, true, false>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, true, true, true, true, true>>());
+
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, false, false, false, false, false>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, false, false, false, false, true>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, false, false, false, true, false>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, false, false, false, true, true>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, false, false, true, true, false>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, false, false, true, true, true>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, false, true, false, false, false>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, false, true, false, false, true>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, false, true, false, true, false>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, false, true, false, true, true>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, false, true, true, true, false>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, false, true, true, true, true>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, true, false, false, false, false>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, true, false, false, false, true>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, true, false, false, true, false>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, true, false, false, true, true>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, true, false, true, true, false>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, true, false, true, true, true>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, true, true, false, false, false>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, true, true, false, false, true>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, true, true, false, true, false>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, true, true, false, true, true>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, true, true, true, true, false>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, true, true, true, true, true>>());
+
+    STATIC_ASSERT(test_construction<test::range<forward_iterator_tag, int, false, false, false, true, false>>());
+    STATIC_ASSERT(test_construction<test::range<forward_iterator_tag, int, false, false, false, true, true>>());
+    STATIC_ASSERT(test_construction<test::range<forward_iterator_tag, int, false, false, true, true, false>>());
+    STATIC_ASSERT(test_construction<test::range<forward_iterator_tag, int, false, false, true, true, true>>());
+    STATIC_ASSERT(test_construction<test::range<forward_iterator_tag, int, false, true, false, true, false>>());
+    STATIC_ASSERT(test_construction<test::range<forward_iterator_tag, int, false, true, false, true, true>>());
+    STATIC_ASSERT(test_construction<test::range<forward_iterator_tag, int, false, true, true, true, false>>());
+    STATIC_ASSERT(test_construction<test::range<forward_iterator_tag, int, false, true, true, true, true>>());
+    STATIC_ASSERT(test_construction<test::range<forward_iterator_tag, int, true, false, false, true, false>>());
+    STATIC_ASSERT(test_construction<test::range<forward_iterator_tag, int, true, false, false, true, true>>());
+    STATIC_ASSERT(test_construction<test::range<forward_iterator_tag, int, true, false, true, true, false>>());
+    STATIC_ASSERT(test_construction<test::range<forward_iterator_tag, int, true, false, true, true, true>>());
+    STATIC_ASSERT(test_construction<test::range<forward_iterator_tag, int, true, true, false, true, false>>());
+    STATIC_ASSERT(test_construction<test::range<forward_iterator_tag, int, true, true, false, true, true>>());
+    STATIC_ASSERT(test_construction<test::range<forward_iterator_tag, int, true, true, true, true, false>>());
+    STATIC_ASSERT(test_construction<test::range<forward_iterator_tag, int, true, true, true, true, true>>());
+
+    STATIC_ASSERT(test_construction<test::range<bidirectional_iterator_tag, int, false, false, false, true, false>>());
+    STATIC_ASSERT(test_construction<test::range<bidirectional_iterator_tag, int, false, false, false, true, true>>());
+    STATIC_ASSERT(test_construction<test::range<bidirectional_iterator_tag, int, false, false, true, true, false>>());
+    STATIC_ASSERT(test_construction<test::range<bidirectional_iterator_tag, int, false, false, true, true, true>>());
+    STATIC_ASSERT(test_construction<test::range<bidirectional_iterator_tag, int, false, true, false, true, false>>());
+    STATIC_ASSERT(test_construction<test::range<bidirectional_iterator_tag, int, false, true, false, true, true>>());
+    STATIC_ASSERT(test_construction<test::range<bidirectional_iterator_tag, int, false, true, true, true, false>>());
+    STATIC_ASSERT(test_construction<test::range<bidirectional_iterator_tag, int, false, true, true, true, true>>());
+    STATIC_ASSERT(test_construction<test::range<bidirectional_iterator_tag, int, true, false, false, true, false>>());
+    STATIC_ASSERT(test_construction<test::range<bidirectional_iterator_tag, int, true, false, false, true, true>>());
+    STATIC_ASSERT(test_construction<test::range<bidirectional_iterator_tag, int, true, false, true, true, false>>());
+    STATIC_ASSERT(test_construction<test::range<bidirectional_iterator_tag, int, true, false, true, true, true>>());
+    STATIC_ASSERT(test_construction<test::range<bidirectional_iterator_tag, int, true, true, false, true, false>>());
+    STATIC_ASSERT(test_construction<test::range<bidirectional_iterator_tag, int, true, true, false, true, true>>());
+    STATIC_ASSERT(test_construction<test::range<bidirectional_iterator_tag, int, true, true, true, true, false>>());
+    STATIC_ASSERT(test_construction<test::range<bidirectional_iterator_tag, int, true, true, true, true, true>>());
+
+    STATIC_ASSERT(test_construction<test::range<random_access_iterator_tag, int, false, true, false, true, false>>());
+    STATIC_ASSERT(test_construction<test::range<random_access_iterator_tag, int, false, true, false, true, true>>());
+    STATIC_ASSERT(test_construction<test::range<random_access_iterator_tag, int, false, true, true, true, false>>());
+    STATIC_ASSERT(test_construction<test::range<random_access_iterator_tag, int, false, true, true, true, true>>());
+    STATIC_ASSERT(test_construction<test::range<random_access_iterator_tag, int, true, true, false, true, false>>());
+    STATIC_ASSERT(test_construction<test::range<random_access_iterator_tag, int, true, true, false, true, true>>());
+    STATIC_ASSERT(test_construction<test::range<random_access_iterator_tag, int, true, true, true, true, false>>());
+    STATIC_ASSERT(test_construction<test::range<random_access_iterator_tag, int, true, true, true, true, true>>());
+
+    STATIC_ASSERT(test_construction<test::range<contiguous_iterator_tag, int, false, true, false, true, false>>());
+    STATIC_ASSERT(test_construction<test::range<contiguous_iterator_tag, int, false, true, true, true, false>>());
+    STATIC_ASSERT(test_construction<test::range<contiguous_iterator_tag, int, true, true, false, true, false>>());
+    STATIC_ASSERT(test_construction<test::range<contiguous_iterator_tag, int, true, true, true, true, false>>());
 
     STATIC_ASSERT(test_construction<std::forward_list<int>>());
     STATIC_ASSERT(test_construction<std::list<int>>());
@@ -1113,22 +1112,121 @@ namespace test_subrange {
 
         return true;
     }
-    STATIC_ASSERT(test_ctad<test_range<output_iterator_tag, int, false, false>>());
-    STATIC_ASSERT(test_ctad<test_range<output_iterator_tag, int, true, false>>());
-    STATIC_ASSERT(test_ctad<test_range<input_iterator_tag, int, false, false>>());
-    STATIC_ASSERT(test_ctad<test_range<input_iterator_tag, int, true, false>>());
-    STATIC_ASSERT(test_ctad<test_range<forward_iterator_tag, int, false, false>>());
-    STATIC_ASSERT(test_ctad<test_range<forward_iterator_tag, int, false, true>>());
-    STATIC_ASSERT(test_ctad<test_range<forward_iterator_tag, int, true, false>>());
-    STATIC_ASSERT(test_ctad<test_range<forward_iterator_tag, int, true, true>>());
-    STATIC_ASSERT(test_ctad<test_range<bidirectional_iterator_tag, int, false, false>>());
-    STATIC_ASSERT(test_ctad<test_range<bidirectional_iterator_tag, int, false, true>>());
-    STATIC_ASSERT(test_ctad<test_range<bidirectional_iterator_tag, int, true, false>>());
-    STATIC_ASSERT(test_ctad<test_range<bidirectional_iterator_tag, int, true, true>>());
-    STATIC_ASSERT(test_ctad<test_range<random_access_iterator_tag, int, true, false>>());
-    STATIC_ASSERT(test_ctad<test_range<random_access_iterator_tag, int, true, true>>());
-    STATIC_ASSERT(test_ctad<test_range<contiguous_iterator_tag, int, true, false>>());
-    STATIC_ASSERT(test_ctad<test_range<contiguous_iterator_tag, int, true, true>>());
+
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, false, false, false, false, false>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, false, false, false, false, true>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, false, false, false, true, false>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, false, false, false, true, true>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, false, false, true, true, false>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, false, false, true, true, true>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, false, true, false, false, false>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, false, true, false, false, true>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, false, true, false, true, false>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, false, true, false, true, true>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, false, true, true, true, false>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, false, true, true, true, true>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, true, false, false, false, false>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, true, false, false, false, true>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, true, false, false, true, false>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, true, false, false, true, true>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, true, false, true, true, false>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, true, false, true, true, true>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, true, true, false, false, false>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, true, true, false, false, true>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, true, true, false, true, false>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, true, true, false, true, true>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, true, true, true, true, false>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, true, true, true, true, true>>());
+
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, false, false, false, false, false>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, false, false, false, false, true>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, false, false, false, true, false>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, false, false, false, true, true>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, false, false, true, true, false>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, false, false, true, true, true>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, false, true, false, false, false>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, false, true, false, false, true>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, false, true, false, true, false>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, false, true, false, true, true>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, false, true, true, true, false>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, false, true, true, true, true>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, true, false, false, false, false>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, true, false, false, false, true>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, true, false, false, true, false>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, true, false, false, true, true>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, true, false, true, true, false>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, true, false, true, true, true>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, true, true, false, false, false>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, true, true, false, false, true>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, true, true, false, true, false>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, true, true, false, true, true>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, true, true, true, true, false>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, true, true, true, true, true>>());
+
+    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, false, false, false, true, false>>());
+    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, false, false, false, true, true>>());
+    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, false, false, true, true, false>>());
+    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, false, false, true, true, true>>());
+    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, false, true, false, true, false>>());
+    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, false, true, false, true, true>>());
+    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, false, true, true, true, false>>());
+    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, false, true, true, true, true>>());
+    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, true, false, false, true, false>>());
+    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, true, false, false, true, true>>());
+    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, true, false, true, true, false>>());
+    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, true, false, true, true, true>>());
+    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, true, true, false, true, false>>());
+    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, true, true, false, true, true>>());
+    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, true, true, true, true, false>>());
+    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, true, true, true, true, true>>());
+
+    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, false, false, false, true, false>>());
+    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, false, false, false, true, true>>());
+    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, false, false, true, true, false>>());
+    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, false, false, true, true, true>>());
+    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, false, true, false, true, false>>());
+    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, false, true, false, true, true>>());
+    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, false, true, true, true, false>>());
+    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, false, true, true, true, true>>());
+    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, true, false, false, true, false>>());
+    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, true, false, false, true, true>>());
+    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, true, false, true, true, false>>());
+    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, true, false, true, true, true>>());
+    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, true, true, false, true, false>>());
+    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, true, true, false, true, true>>());
+    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, true, true, true, true, false>>());
+    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, true, true, true, true, true>>());
+
+    STATIC_ASSERT(test_ctad<test::range<random_access_iterator_tag, int, false, true, false, true, false>>());
+    STATIC_ASSERT(test_ctad<test::range<random_access_iterator_tag, int, false, true, false, true, true>>());
+    STATIC_ASSERT(test_ctad<test::range<random_access_iterator_tag, int, false, true, true, true, false>>());
+    STATIC_ASSERT(test_ctad<test::range<random_access_iterator_tag, int, false, true, true, true, true>>());
+    STATIC_ASSERT(test_ctad<test::range<random_access_iterator_tag, int, true, true, false, true, false>>());
+    STATIC_ASSERT(test_ctad<test::range<random_access_iterator_tag, int, true, true, false, true, true>>());
+    STATIC_ASSERT(test_ctad<test::range<random_access_iterator_tag, int, true, true, true, true, false>>());
+    STATIC_ASSERT(test_ctad<test::range<random_access_iterator_tag, int, true, true, true, true, true>>());
+
+    STATIC_ASSERT(test_ctad<test::range<contiguous_iterator_tag, int, false, true, false, true, false>>());
+    STATIC_ASSERT(test_ctad<test::range<contiguous_iterator_tag, int, false, true, true, true, false>>());
+    STATIC_ASSERT(test_ctad<test::range<contiguous_iterator_tag, int, true, true, false, true, false>>());
+    STATIC_ASSERT(test_ctad<test::range<contiguous_iterator_tag, int, true, true, true, true, false>>());
+
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, false, false>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, true, false>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, false, false>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, true, false>>());
+    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, false, false>>());
+    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, false, true>>());
+    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, true, false>>());
+    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, true, true>>());
+    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, false, false>>());
+    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, false, true>>());
+    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, true, false>>());
+    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, true, true>>());
+    STATIC_ASSERT(test_ctad<test::range<random_access_iterator_tag, int, true, false>>());
+    STATIC_ASSERT(test_ctad<test::range<random_access_iterator_tag, int, true, true>>());
+    STATIC_ASSERT(test_ctad<test::range<contiguous_iterator_tag, int, true, false>>());
+    STATIC_ASSERT(test_ctad<test::range<contiguous_iterator_tag, int, true, true>>());
 
     STATIC_ASSERT(test_ctad<std::forward_list<int>>());
     STATIC_ASSERT(test_ctad<std::list<int>>());

--- a/tests/std/tests/P0896R4_ranges_test_machinery/env.lst
+++ b/tests/std/tests/P0896R4_ranges_test_machinery/env.lst
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+RUNALL_INCLUDE ..\concepts_matrix.lst

--- a/tests/std/tests/P0896R4_ranges_test_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_test_machinery/test.cpp
@@ -12,10 +12,14 @@ using namespace std;
 
 int main() {} // COMPILE-ONLY
 
+using test::CanDifference, test::CanCompare, test::ProxyRef, test::IsWrapped;
+
 // Validate test::iterator and test::sentinel
-template <class Category, class Element, bool Sized, bool Common, bool Proxy, bool Wrapped>
+template <class Category, class Element, CanDifference Diff, CanCompare Eq, ProxyRef Proxy, IsWrapped Wrapped>
 constexpr bool iter_test() {
-    using I = test::iterator<Category, Element, Sized, Common, Proxy, Wrapped>;
+    using test::iterator, test::sentinel;
+
+    using I = iterator<Category, Element, Diff, Eq, Proxy, Wrapped>;
 
     STATIC_ASSERT(default_initializable<I>);
     STATIC_ASSERT(movable<I>);
@@ -33,87 +37,112 @@ constexpr bool iter_test() {
     STATIC_ASSERT(!derived_from<Category, random_access_iterator_tag> || random_access_iterator<I>);
     STATIC_ASSERT(!derived_from<Category, contiguous_iterator_tag> || contiguous_iterator<I>);
 
-    using S = test::sentinel<Element, Wrapped>;
+    using S = sentinel<Element, Wrapped>;
     STATIC_ASSERT(sentinel_for<S, I>);
-    STATIC_ASSERT(!Sized || sized_sentinel_for<S, I>);
-    STATIC_ASSERT(!Common || sentinel_for<I, I>);
-    STATIC_ASSERT(!Common || !Sized || sized_sentinel_for<I, I>);
+    STATIC_ASSERT(!bool(Diff) || sized_sentinel_for<S, I>);
+    STATIC_ASSERT(!bool(Eq) || sentinel_for<I, I>);
+    STATIC_ASSERT(!bool(Eq) || !bool(Diff) || sized_sentinel_for<I, I>);
 
-    if constexpr (Wrapped) {
-        STATIC_ASSERT(same_as<_Unwrapped_t<I>, test::iterator<Category, Element, Sized, Common, Proxy, false>>);
-        STATIC_ASSERT(same_as<_Unwrapped_t<S>, test::sentinel<Element, false>>);
+    if constexpr (bool(Wrapped)) {
+        STATIC_ASSERT(same_as<_Unwrapped_t<I>, iterator<Category, Element, Diff, Eq, Proxy, IsWrapped::no>>);
+        STATIC_ASSERT(same_as<_Unwrapped_t<S>, sentinel<Element, IsWrapped::no>>);
     }
 
     return true;
 }
 
-STATIC_ASSERT(iter_test<output_iterator_tag, int, false, false, false, false>());
-STATIC_ASSERT(iter_test<output_iterator_tag, int, false, false, false, true>());
-STATIC_ASSERT(iter_test<output_iterator_tag, int, false, false, true, false>());
-STATIC_ASSERT(iter_test<output_iterator_tag, int, false, false, true, true>());
-STATIC_ASSERT(iter_test<output_iterator_tag, int, false, true, false, false>());
-STATIC_ASSERT(iter_test<output_iterator_tag, int, false, true, false, true>());
-STATIC_ASSERT(iter_test<output_iterator_tag, int, false, true, true, false>());
-STATIC_ASSERT(iter_test<output_iterator_tag, int, false, true, true, true>());
-STATIC_ASSERT(iter_test<output_iterator_tag, int, true, false, false, false>());
-STATIC_ASSERT(iter_test<output_iterator_tag, int, true, false, false, true>());
-STATIC_ASSERT(iter_test<output_iterator_tag, int, true, false, true, false>());
-STATIC_ASSERT(iter_test<output_iterator_tag, int, true, false, true, true>());
-STATIC_ASSERT(iter_test<output_iterator_tag, int, true, true, false, false>());
-STATIC_ASSERT(iter_test<output_iterator_tag, int, true, true, false, true>());
-STATIC_ASSERT(iter_test<output_iterator_tag, int, true, true, true, false>());
-STATIC_ASSERT(iter_test<output_iterator_tag, int, true, true, true, true>());
+STATIC_ASSERT(iter_test<output_iterator_tag, int, CanDifference::no, CanCompare::no, ProxyRef::no, IsWrapped::no>());
+STATIC_ASSERT(iter_test<output_iterator_tag, int, CanDifference::no, CanCompare::no, ProxyRef::no, IsWrapped::yes>());
+STATIC_ASSERT(iter_test<output_iterator_tag, int, CanDifference::no, CanCompare::no, ProxyRef::yes, IsWrapped::no>());
+STATIC_ASSERT(iter_test<output_iterator_tag, int, CanDifference::no, CanCompare::no, ProxyRef::yes, IsWrapped::yes>());
+STATIC_ASSERT(iter_test<output_iterator_tag, int, CanDifference::no, CanCompare::yes, ProxyRef::no, IsWrapped::no>());
+STATIC_ASSERT(iter_test<output_iterator_tag, int, CanDifference::no, CanCompare::yes, ProxyRef::no, IsWrapped::yes>());
+STATIC_ASSERT(iter_test<output_iterator_tag, int, CanDifference::no, CanCompare::yes, ProxyRef::yes, IsWrapped::no>());
+STATIC_ASSERT(iter_test<output_iterator_tag, int, CanDifference::no, CanCompare::yes, ProxyRef::yes, IsWrapped::yes>());
+STATIC_ASSERT(iter_test<output_iterator_tag, int, CanDifference::yes, CanCompare::no, ProxyRef::no, IsWrapped::no>());
+STATIC_ASSERT(iter_test<output_iterator_tag, int, CanDifference::yes, CanCompare::no, ProxyRef::no, IsWrapped::yes>());
+STATIC_ASSERT(iter_test<output_iterator_tag, int, CanDifference::yes, CanCompare::no, ProxyRef::yes, IsWrapped::no>());
+STATIC_ASSERT(iter_test<output_iterator_tag, int, CanDifference::yes, CanCompare::no, ProxyRef::yes, IsWrapped::yes>());
+STATIC_ASSERT(iter_test<output_iterator_tag, int, CanDifference::yes, CanCompare::yes, ProxyRef::no, IsWrapped::no>());
+STATIC_ASSERT(iter_test<output_iterator_tag, int, CanDifference::yes, CanCompare::yes, ProxyRef::no, IsWrapped::yes>());
+STATIC_ASSERT(iter_test<output_iterator_tag, int, CanDifference::yes, CanCompare::yes, ProxyRef::yes, IsWrapped::no>());
+STATIC_ASSERT(
+    iter_test<output_iterator_tag, int, CanDifference::yes, CanCompare::yes, ProxyRef::yes, IsWrapped::yes>());
 
-STATIC_ASSERT(iter_test<input_iterator_tag, int, false, false, false, false>());
-STATIC_ASSERT(iter_test<input_iterator_tag, int, false, false, false, true>());
-STATIC_ASSERT(iter_test<input_iterator_tag, int, false, false, true, false>());
-STATIC_ASSERT(iter_test<input_iterator_tag, int, false, false, true, true>());
-STATIC_ASSERT(iter_test<input_iterator_tag, int, false, true, false, false>());
-STATIC_ASSERT(iter_test<input_iterator_tag, int, false, true, false, true>());
-STATIC_ASSERT(iter_test<input_iterator_tag, int, false, true, true, false>());
-STATIC_ASSERT(iter_test<input_iterator_tag, int, false, true, true, true>());
-STATIC_ASSERT(iter_test<input_iterator_tag, int, true, false, false, false>());
-STATIC_ASSERT(iter_test<input_iterator_tag, int, true, false, false, true>());
-STATIC_ASSERT(iter_test<input_iterator_tag, int, true, false, true, false>());
-STATIC_ASSERT(iter_test<input_iterator_tag, int, true, false, true, true>());
-STATIC_ASSERT(iter_test<input_iterator_tag, int, true, true, false, false>());
-STATIC_ASSERT(iter_test<input_iterator_tag, int, true, true, false, true>());
-STATIC_ASSERT(iter_test<input_iterator_tag, int, true, true, true, false>());
-STATIC_ASSERT(iter_test<input_iterator_tag, int, true, true, true, true>());
+STATIC_ASSERT(iter_test<input_iterator_tag, int, CanDifference::no, CanCompare::no, ProxyRef::no, IsWrapped::no>());
+STATIC_ASSERT(iter_test<input_iterator_tag, int, CanDifference::no, CanCompare::no, ProxyRef::no, IsWrapped::yes>());
+STATIC_ASSERT(iter_test<input_iterator_tag, int, CanDifference::no, CanCompare::no, ProxyRef::yes, IsWrapped::no>());
+STATIC_ASSERT(iter_test<input_iterator_tag, int, CanDifference::no, CanCompare::no, ProxyRef::yes, IsWrapped::yes>());
+STATIC_ASSERT(iter_test<input_iterator_tag, int, CanDifference::no, CanCompare::yes, ProxyRef::no, IsWrapped::no>());
+STATIC_ASSERT(iter_test<input_iterator_tag, int, CanDifference::no, CanCompare::yes, ProxyRef::no, IsWrapped::yes>());
+STATIC_ASSERT(iter_test<input_iterator_tag, int, CanDifference::no, CanCompare::yes, ProxyRef::yes, IsWrapped::no>());
+STATIC_ASSERT(iter_test<input_iterator_tag, int, CanDifference::no, CanCompare::yes, ProxyRef::yes, IsWrapped::yes>());
+STATIC_ASSERT(iter_test<input_iterator_tag, int, CanDifference::yes, CanCompare::no, ProxyRef::no, IsWrapped::no>());
+STATIC_ASSERT(iter_test<input_iterator_tag, int, CanDifference::yes, CanCompare::no, ProxyRef::no, IsWrapped::yes>());
+STATIC_ASSERT(iter_test<input_iterator_tag, int, CanDifference::yes, CanCompare::no, ProxyRef::yes, IsWrapped::no>());
+STATIC_ASSERT(iter_test<input_iterator_tag, int, CanDifference::yes, CanCompare::no, ProxyRef::yes, IsWrapped::yes>());
+STATIC_ASSERT(iter_test<input_iterator_tag, int, CanDifference::yes, CanCompare::yes, ProxyRef::no, IsWrapped::no>());
+STATIC_ASSERT(iter_test<input_iterator_tag, int, CanDifference::yes, CanCompare::yes, ProxyRef::no, IsWrapped::yes>());
+STATIC_ASSERT(iter_test<input_iterator_tag, int, CanDifference::yes, CanCompare::yes, ProxyRef::yes, IsWrapped::no>());
+STATIC_ASSERT(iter_test<input_iterator_tag, int, CanDifference::yes, CanCompare::yes, ProxyRef::yes, IsWrapped::yes>());
 
-STATIC_ASSERT(iter_test<forward_iterator_tag, int, false, true, false, false>());
-STATIC_ASSERT(iter_test<forward_iterator_tag, int, false, true, false, true>());
-STATIC_ASSERT(iter_test<forward_iterator_tag, int, false, true, true, false>());
-STATIC_ASSERT(iter_test<forward_iterator_tag, int, false, true, true, true>());
-STATIC_ASSERT(iter_test<forward_iterator_tag, int, true, true, false, false>());
-STATIC_ASSERT(iter_test<forward_iterator_tag, int, true, true, false, true>());
-STATIC_ASSERT(iter_test<forward_iterator_tag, int, true, true, true, false>());
-STATIC_ASSERT(iter_test<forward_iterator_tag, int, true, true, true, true>());
+STATIC_ASSERT(iter_test<forward_iterator_tag, int, CanDifference::no, CanCompare::yes, ProxyRef::no, IsWrapped::no>());
+STATIC_ASSERT(iter_test<forward_iterator_tag, int, CanDifference::no, CanCompare::yes, ProxyRef::no, IsWrapped::yes>());
+STATIC_ASSERT(iter_test<forward_iterator_tag, int, CanDifference::no, CanCompare::yes, ProxyRef::yes, IsWrapped::no>());
+STATIC_ASSERT(
+    iter_test<forward_iterator_tag, int, CanDifference::no, CanCompare::yes, ProxyRef::yes, IsWrapped::yes>());
+STATIC_ASSERT(iter_test<forward_iterator_tag, int, CanDifference::yes, CanCompare::yes, ProxyRef::no, IsWrapped::no>());
+STATIC_ASSERT(
+    iter_test<forward_iterator_tag, int, CanDifference::yes, CanCompare::yes, ProxyRef::no, IsWrapped::yes>());
+STATIC_ASSERT(
+    iter_test<forward_iterator_tag, int, CanDifference::yes, CanCompare::yes, ProxyRef::yes, IsWrapped::no>());
+STATIC_ASSERT(
+    iter_test<forward_iterator_tag, int, CanDifference::yes, CanCompare::yes, ProxyRef::yes, IsWrapped::yes>());
 
-STATIC_ASSERT(iter_test<bidirectional_iterator_tag, int, false, true, false, false>());
-STATIC_ASSERT(iter_test<bidirectional_iterator_tag, int, false, true, false, true>());
-STATIC_ASSERT(iter_test<bidirectional_iterator_tag, int, false, true, true, false>());
-STATIC_ASSERT(iter_test<bidirectional_iterator_tag, int, false, true, true, true>());
-STATIC_ASSERT(iter_test<bidirectional_iterator_tag, int, true, true, false, false>());
-STATIC_ASSERT(iter_test<bidirectional_iterator_tag, int, true, true, false, true>());
-STATIC_ASSERT(iter_test<bidirectional_iterator_tag, int, true, true, true, false>());
-STATIC_ASSERT(iter_test<bidirectional_iterator_tag, int, true, true, true, true>());
+STATIC_ASSERT(
+    iter_test<bidirectional_iterator_tag, int, CanDifference::no, CanCompare::yes, ProxyRef::no, IsWrapped::no>());
+STATIC_ASSERT(
+    iter_test<bidirectional_iterator_tag, int, CanDifference::no, CanCompare::yes, ProxyRef::no, IsWrapped::yes>());
+STATIC_ASSERT(
+    iter_test<bidirectional_iterator_tag, int, CanDifference::no, CanCompare::yes, ProxyRef::yes, IsWrapped::no>());
+STATIC_ASSERT(
+    iter_test<bidirectional_iterator_tag, int, CanDifference::no, CanCompare::yes, ProxyRef::yes, IsWrapped::yes>());
+STATIC_ASSERT(
+    iter_test<bidirectional_iterator_tag, int, CanDifference::yes, CanCompare::yes, ProxyRef::no, IsWrapped::no>());
+STATIC_ASSERT(
+    iter_test<bidirectional_iterator_tag, int, CanDifference::yes, CanCompare::yes, ProxyRef::no, IsWrapped::yes>());
+STATIC_ASSERT(
+    iter_test<bidirectional_iterator_tag, int, CanDifference::yes, CanCompare::yes, ProxyRef::yes, IsWrapped::no>());
+STATIC_ASSERT(
+    iter_test<bidirectional_iterator_tag, int, CanDifference::yes, CanCompare::yes, ProxyRef::yes, IsWrapped::yes>());
 
-STATIC_ASSERT(iter_test<random_access_iterator_tag, int, false, true, false, false>());
-STATIC_ASSERT(iter_test<random_access_iterator_tag, int, false, true, false, true>());
-STATIC_ASSERT(iter_test<random_access_iterator_tag, int, false, true, true, false>());
-STATIC_ASSERT(iter_test<random_access_iterator_tag, int, false, true, true, true>());
-STATIC_ASSERT(iter_test<random_access_iterator_tag, int, true, true, false, false>());
-STATIC_ASSERT(iter_test<random_access_iterator_tag, int, true, true, false, true>());
-STATIC_ASSERT(iter_test<random_access_iterator_tag, int, true, true, true, false>());
-STATIC_ASSERT(iter_test<random_access_iterator_tag, int, true, true, true, true>());
+STATIC_ASSERT(
+    iter_test<random_access_iterator_tag, int, CanDifference::no, CanCompare::yes, ProxyRef::no, IsWrapped::no>());
+STATIC_ASSERT(
+    iter_test<random_access_iterator_tag, int, CanDifference::no, CanCompare::yes, ProxyRef::no, IsWrapped::yes>());
+STATIC_ASSERT(
+    iter_test<random_access_iterator_tag, int, CanDifference::no, CanCompare::yes, ProxyRef::yes, IsWrapped::no>());
+STATIC_ASSERT(
+    iter_test<random_access_iterator_tag, int, CanDifference::no, CanCompare::yes, ProxyRef::yes, IsWrapped::yes>());
+STATIC_ASSERT(
+    iter_test<random_access_iterator_tag, int, CanDifference::yes, CanCompare::yes, ProxyRef::no, IsWrapped::no>());
+STATIC_ASSERT(
+    iter_test<random_access_iterator_tag, int, CanDifference::yes, CanCompare::yes, ProxyRef::no, IsWrapped::yes>());
+STATIC_ASSERT(
+    iter_test<random_access_iterator_tag, int, CanDifference::yes, CanCompare::yes, ProxyRef::yes, IsWrapped::no>());
+STATIC_ASSERT(
+    iter_test<random_access_iterator_tag, int, CanDifference::yes, CanCompare::yes, ProxyRef::yes, IsWrapped::yes>());
 
-STATIC_ASSERT(iter_test<contiguous_iterator_tag, int, false, true, false, false>());
-STATIC_ASSERT(iter_test<contiguous_iterator_tag, int, false, true, false, true>());
-STATIC_ASSERT(iter_test<contiguous_iterator_tag, int, true, true, false, false>());
-STATIC_ASSERT(iter_test<contiguous_iterator_tag, int, true, true, false, true>());
+STATIC_ASSERT(
+    iter_test<contiguous_iterator_tag, int, CanDifference::no, CanCompare::yes, ProxyRef::no, IsWrapped::no>());
+STATIC_ASSERT(
+    iter_test<contiguous_iterator_tag, int, CanDifference::no, CanCompare::yes, ProxyRef::no, IsWrapped::yes>());
+STATIC_ASSERT(
+    iter_test<contiguous_iterator_tag, int, CanDifference::yes, CanCompare::yes, ProxyRef::no, IsWrapped::no>());
+STATIC_ASSERT(
+    iter_test<contiguous_iterator_tag, int, CanDifference::yes, CanCompare::yes, ProxyRef::no, IsWrapped::yes>());
 
-STATIC_ASSERT(same_as<_Unwrapped_t<test::sentinel<int, true>>, test::sentinel<int, false>>);
+STATIC_ASSERT(same_as<_Unwrapped_t<test::sentinel<int, IsWrapped::yes>>, test::sentinel<int, IsWrapped::no>>);
 
 // Validate test::range
 // clang-format off
@@ -124,12 +153,15 @@ concept has_member_size = requires(const R& r) {
 };
 // clang-format on
 
-template <class Category, class Element, bool Sized, bool SizedIterators, bool Common, bool CommonIterators, bool Proxy>
+using test::Sized, test::Common;
+
+template <class Category, class Element, Sized IsSized, CanDifference Diff, Common IsCommon, CanCompare Eq,
+    ProxyRef Proxy>
 constexpr bool range_test() {
-    using R = test::range<Category, Element, Sized, SizedIterators, Common, CommonIterators, Proxy>;
+    using R = test::range<Category, Element, IsSized, Diff, IsCommon, Eq, Proxy>;
     using I = ranges::iterator_t<R>;
     using S = ranges::sentinel_t<R>;
-    STATIC_ASSERT(same_as<I, test::iterator<Category, Element, SizedIterators, CommonIterators, Proxy, true>>);
+    STATIC_ASSERT(same_as<I, test::iterator<Category, Element, Diff, Eq, Proxy, IsWrapped::yes>>);
 
     STATIC_ASSERT(!derived_from<Category, output_iterator_tag> || ranges::output_range<R, Element>);
     STATIC_ASSERT(!derived_from<Category, input_iterator_tag> || ranges::input_range<R>);
@@ -138,121 +170,213 @@ constexpr bool range_test() {
     STATIC_ASSERT(!derived_from<Category, random_access_iterator_tag> || ranges::random_access_range<R>);
     STATIC_ASSERT(!derived_from<Category, contiguous_iterator_tag> || ranges::contiguous_range<R>);
 
-    if constexpr (Common) {
-        STATIC_ASSERT(CommonIterators);
+    if constexpr (bool(IsCommon)) {
+        STATIC_ASSERT(bool(Eq));
         STATIC_ASSERT(ranges::common_range<R>);
     } else {
-        STATIC_ASSERT(same_as<S, test::sentinel<Element, true>>);
+        STATIC_ASSERT(same_as<S, test::sentinel<Element, IsWrapped::yes>>);
     }
 
-    STATIC_ASSERT(!CommonIterators || sentinel_for<I, I>);
+    STATIC_ASSERT(!bool(Eq) || sentinel_for<I, I>);
 
-    constexpr bool is_sized = Sized || (SizedIterators && derived_from<Category, forward_iterator_tag>);
+    constexpr bool is_sized = bool(IsSized) || (bool(Diff) && derived_from<Category, forward_iterator_tag>);
     STATIC_ASSERT(ranges::sized_range<R> == is_sized);
-    if constexpr (Sized) {
+    if constexpr (bool(IsSized)) {
         STATIC_ASSERT(has_member_size<R>);
     }
 
     return true;
 }
 
-STATIC_ASSERT(range_test<output_iterator_tag, int, false, false, false, false, false>());
-STATIC_ASSERT(range_test<output_iterator_tag, int, false, false, false, false, true>());
-STATIC_ASSERT(range_test<output_iterator_tag, int, false, false, false, true, false>());
-STATIC_ASSERT(range_test<output_iterator_tag, int, false, false, false, true, true>());
-STATIC_ASSERT(range_test<output_iterator_tag, int, false, false, true, true, false>());
-STATIC_ASSERT(range_test<output_iterator_tag, int, false, false, true, true, true>());
-STATIC_ASSERT(range_test<output_iterator_tag, int, false, true, false, false, false>());
-STATIC_ASSERT(range_test<output_iterator_tag, int, false, true, false, false, true>());
-STATIC_ASSERT(range_test<output_iterator_tag, int, false, true, false, true, false>());
-STATIC_ASSERT(range_test<output_iterator_tag, int, false, true, false, true, true>());
-STATIC_ASSERT(range_test<output_iterator_tag, int, false, true, true, true, false>());
-STATIC_ASSERT(range_test<output_iterator_tag, int, false, true, true, true, true>());
-STATIC_ASSERT(range_test<output_iterator_tag, int, true, false, false, false, false>());
-STATIC_ASSERT(range_test<output_iterator_tag, int, true, false, false, false, true>());
-STATIC_ASSERT(range_test<output_iterator_tag, int, true, false, false, true, false>());
-STATIC_ASSERT(range_test<output_iterator_tag, int, true, false, false, true, true>());
-STATIC_ASSERT(range_test<output_iterator_tag, int, true, false, true, true, false>());
-STATIC_ASSERT(range_test<output_iterator_tag, int, true, false, true, true, true>());
-STATIC_ASSERT(range_test<output_iterator_tag, int, true, true, false, false, false>());
-STATIC_ASSERT(range_test<output_iterator_tag, int, true, true, false, false, true>());
-STATIC_ASSERT(range_test<output_iterator_tag, int, true, true, false, true, false>());
-STATIC_ASSERT(range_test<output_iterator_tag, int, true, true, false, true, true>());
-STATIC_ASSERT(range_test<output_iterator_tag, int, true, true, true, true, false>());
-STATIC_ASSERT(range_test<output_iterator_tag, int, true, true, true, true, true>());
+STATIC_ASSERT(
+    range_test<output_iterator_tag, int, Sized::no, CanDifference::no, Common::no, CanCompare::no, ProxyRef::no>());
+STATIC_ASSERT(
+    range_test<output_iterator_tag, int, Sized::no, CanDifference::no, Common::no, CanCompare::no, ProxyRef::yes>());
+STATIC_ASSERT(
+    range_test<output_iterator_tag, int, Sized::no, CanDifference::no, Common::no, CanCompare::yes, ProxyRef::no>());
+STATIC_ASSERT(
+    range_test<output_iterator_tag, int, Sized::no, CanDifference::no, Common::no, CanCompare::yes, ProxyRef::yes>());
+STATIC_ASSERT(
+    range_test<output_iterator_tag, int, Sized::no, CanDifference::no, Common::yes, CanCompare::yes, ProxyRef::no>());
+STATIC_ASSERT(
+    range_test<output_iterator_tag, int, Sized::no, CanDifference::no, Common::yes, CanCompare::yes, ProxyRef::yes>());
+STATIC_ASSERT(
+    range_test<output_iterator_tag, int, Sized::no, CanDifference::yes, Common::no, CanCompare::no, ProxyRef::no>());
+STATIC_ASSERT(
+    range_test<output_iterator_tag, int, Sized::no, CanDifference::yes, Common::no, CanCompare::no, ProxyRef::yes>());
+STATIC_ASSERT(
+    range_test<output_iterator_tag, int, Sized::no, CanDifference::yes, Common::no, CanCompare::yes, ProxyRef::no>());
+STATIC_ASSERT(
+    range_test<output_iterator_tag, int, Sized::no, CanDifference::yes, Common::no, CanCompare::yes, ProxyRef::yes>());
+STATIC_ASSERT(
+    range_test<output_iterator_tag, int, Sized::no, CanDifference::yes, Common::yes, CanCompare::yes, ProxyRef::no>());
+STATIC_ASSERT(
+    range_test<output_iterator_tag, int, Sized::no, CanDifference::yes, Common::yes, CanCompare::yes, ProxyRef::yes>());
+STATIC_ASSERT(
+    range_test<output_iterator_tag, int, Sized::yes, CanDifference::no, Common::no, CanCompare::no, ProxyRef::no>());
+STATIC_ASSERT(
+    range_test<output_iterator_tag, int, Sized::yes, CanDifference::no, Common::no, CanCompare::no, ProxyRef::yes>());
+STATIC_ASSERT(
+    range_test<output_iterator_tag, int, Sized::yes, CanDifference::no, Common::no, CanCompare::yes, ProxyRef::no>());
+STATIC_ASSERT(
+    range_test<output_iterator_tag, int, Sized::yes, CanDifference::no, Common::no, CanCompare::yes, ProxyRef::yes>());
+STATIC_ASSERT(
+    range_test<output_iterator_tag, int, Sized::yes, CanDifference::no, Common::yes, CanCompare::yes, ProxyRef::no>());
+STATIC_ASSERT(
+    range_test<output_iterator_tag, int, Sized::yes, CanDifference::no, Common::yes, CanCompare::yes, ProxyRef::yes>());
+STATIC_ASSERT(
+    range_test<output_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no, CanCompare::no, ProxyRef::no>());
+STATIC_ASSERT(
+    range_test<output_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no, CanCompare::no, ProxyRef::yes>());
+STATIC_ASSERT(
+    range_test<output_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no, CanCompare::yes, ProxyRef::no>());
+STATIC_ASSERT(
+    range_test<output_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no, CanCompare::yes, ProxyRef::yes>());
+STATIC_ASSERT(
+    range_test<output_iterator_tag, int, Sized::yes, CanDifference::yes, Common::yes, CanCompare::yes, ProxyRef::no>());
+STATIC_ASSERT(range_test<output_iterator_tag, int, Sized::yes, CanDifference::yes, Common::yes, CanCompare::yes,
+    ProxyRef::yes>());
 
-STATIC_ASSERT(range_test<input_iterator_tag, int, false, false, false, false, false>());
-STATIC_ASSERT(range_test<input_iterator_tag, int, false, false, false, false, true>());
-STATIC_ASSERT(range_test<input_iterator_tag, int, false, false, false, true, false>());
-STATIC_ASSERT(range_test<input_iterator_tag, int, false, false, false, true, true>());
-STATIC_ASSERT(range_test<input_iterator_tag, int, false, false, true, true, false>());
-STATIC_ASSERT(range_test<input_iterator_tag, int, false, false, true, true, true>());
-STATIC_ASSERT(range_test<input_iterator_tag, int, false, true, false, false, false>());
-STATIC_ASSERT(range_test<input_iterator_tag, int, false, true, false, false, true>());
-STATIC_ASSERT(range_test<input_iterator_tag, int, false, true, false, true, false>());
-STATIC_ASSERT(range_test<input_iterator_tag, int, false, true, false, true, true>());
-STATIC_ASSERT(range_test<input_iterator_tag, int, false, true, true, true, false>());
-STATIC_ASSERT(range_test<input_iterator_tag, int, false, true, true, true, true>());
-STATIC_ASSERT(range_test<input_iterator_tag, int, true, false, false, false, false>());
-STATIC_ASSERT(range_test<input_iterator_tag, int, true, false, false, false, true>());
-STATIC_ASSERT(range_test<input_iterator_tag, int, true, false, false, true, false>());
-STATIC_ASSERT(range_test<input_iterator_tag, int, true, false, false, true, true>());
-STATIC_ASSERT(range_test<input_iterator_tag, int, true, false, true, true, false>());
-STATIC_ASSERT(range_test<input_iterator_tag, int, true, false, true, true, true>());
-STATIC_ASSERT(range_test<input_iterator_tag, int, true, true, false, false, false>());
-STATIC_ASSERT(range_test<input_iterator_tag, int, true, true, false, false, true>());
-STATIC_ASSERT(range_test<input_iterator_tag, int, true, true, false, true, false>());
-STATIC_ASSERT(range_test<input_iterator_tag, int, true, true, false, true, true>());
-STATIC_ASSERT(range_test<input_iterator_tag, int, true, true, true, true, false>());
-STATIC_ASSERT(range_test<input_iterator_tag, int, true, true, true, true, true>());
+STATIC_ASSERT(
+    range_test<input_iterator_tag, int, Sized::no, CanDifference::no, Common::no, CanCompare::no, ProxyRef::no>());
+STATIC_ASSERT(
+    range_test<input_iterator_tag, int, Sized::no, CanDifference::no, Common::no, CanCompare::no, ProxyRef::yes>());
+STATIC_ASSERT(
+    range_test<input_iterator_tag, int, Sized::no, CanDifference::no, Common::no, CanCompare::yes, ProxyRef::no>());
+STATIC_ASSERT(
+    range_test<input_iterator_tag, int, Sized::no, CanDifference::no, Common::no, CanCompare::yes, ProxyRef::yes>());
+STATIC_ASSERT(
+    range_test<input_iterator_tag, int, Sized::no, CanDifference::no, Common::yes, CanCompare::yes, ProxyRef::no>());
+STATIC_ASSERT(
+    range_test<input_iterator_tag, int, Sized::no, CanDifference::no, Common::yes, CanCompare::yes, ProxyRef::yes>());
+STATIC_ASSERT(
+    range_test<input_iterator_tag, int, Sized::no, CanDifference::yes, Common::no, CanCompare::no, ProxyRef::no>());
+STATIC_ASSERT(
+    range_test<input_iterator_tag, int, Sized::no, CanDifference::yes, Common::no, CanCompare::no, ProxyRef::yes>());
+STATIC_ASSERT(
+    range_test<input_iterator_tag, int, Sized::no, CanDifference::yes, Common::no, CanCompare::yes, ProxyRef::no>());
+STATIC_ASSERT(
+    range_test<input_iterator_tag, int, Sized::no, CanDifference::yes, Common::no, CanCompare::yes, ProxyRef::yes>());
+STATIC_ASSERT(
+    range_test<input_iterator_tag, int, Sized::no, CanDifference::yes, Common::yes, CanCompare::yes, ProxyRef::no>());
+STATIC_ASSERT(
+    range_test<input_iterator_tag, int, Sized::no, CanDifference::yes, Common::yes, CanCompare::yes, ProxyRef::yes>());
+STATIC_ASSERT(
+    range_test<input_iterator_tag, int, Sized::yes, CanDifference::no, Common::no, CanCompare::no, ProxyRef::no>());
+STATIC_ASSERT(
+    range_test<input_iterator_tag, int, Sized::yes, CanDifference::no, Common::no, CanCompare::no, ProxyRef::yes>());
+STATIC_ASSERT(
+    range_test<input_iterator_tag, int, Sized::yes, CanDifference::no, Common::no, CanCompare::yes, ProxyRef::no>());
+STATIC_ASSERT(
+    range_test<input_iterator_tag, int, Sized::yes, CanDifference::no, Common::no, CanCompare::yes, ProxyRef::yes>());
+STATIC_ASSERT(
+    range_test<input_iterator_tag, int, Sized::yes, CanDifference::no, Common::yes, CanCompare::yes, ProxyRef::no>());
+STATIC_ASSERT(
+    range_test<input_iterator_tag, int, Sized::yes, CanDifference::no, Common::yes, CanCompare::yes, ProxyRef::yes>());
+STATIC_ASSERT(
+    range_test<input_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no, CanCompare::no, ProxyRef::no>());
+STATIC_ASSERT(
+    range_test<input_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no, CanCompare::no, ProxyRef::yes>());
+STATIC_ASSERT(
+    range_test<input_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no, CanCompare::yes, ProxyRef::no>());
+STATIC_ASSERT(
+    range_test<input_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no, CanCompare::yes, ProxyRef::yes>());
+STATIC_ASSERT(
+    range_test<input_iterator_tag, int, Sized::yes, CanDifference::yes, Common::yes, CanCompare::yes, ProxyRef::no>());
+STATIC_ASSERT(
+    range_test<input_iterator_tag, int, Sized::yes, CanDifference::yes, Common::yes, CanCompare::yes, ProxyRef::yes>());
 
-STATIC_ASSERT(range_test<forward_iterator_tag, int, false, false, false, true, false>());
-STATIC_ASSERT(range_test<forward_iterator_tag, int, false, false, false, true, true>());
-STATIC_ASSERT(range_test<forward_iterator_tag, int, false, false, true, true, false>());
-STATIC_ASSERT(range_test<forward_iterator_tag, int, false, false, true, true, true>());
-STATIC_ASSERT(range_test<forward_iterator_tag, int, false, true, false, true, false>());
-STATIC_ASSERT(range_test<forward_iterator_tag, int, false, true, false, true, true>());
-STATIC_ASSERT(range_test<forward_iterator_tag, int, false, true, true, true, false>());
-STATIC_ASSERT(range_test<forward_iterator_tag, int, false, true, true, true, true>());
-STATIC_ASSERT(range_test<forward_iterator_tag, int, true, false, false, true, false>());
-STATIC_ASSERT(range_test<forward_iterator_tag, int, true, false, false, true, true>());
-STATIC_ASSERT(range_test<forward_iterator_tag, int, true, false, true, true, false>());
-STATIC_ASSERT(range_test<forward_iterator_tag, int, true, false, true, true, true>());
-STATIC_ASSERT(range_test<forward_iterator_tag, int, true, true, false, true, false>());
-STATIC_ASSERT(range_test<forward_iterator_tag, int, true, true, false, true, true>());
-STATIC_ASSERT(range_test<forward_iterator_tag, int, true, true, true, true, false>());
-STATIC_ASSERT(range_test<forward_iterator_tag, int, true, true, true, true, true>());
+STATIC_ASSERT(
+    range_test<forward_iterator_tag, int, Sized::no, CanDifference::no, Common::no, CanCompare::yes, ProxyRef::no>());
+STATIC_ASSERT(
+    range_test<forward_iterator_tag, int, Sized::no, CanDifference::no, Common::no, CanCompare::yes, ProxyRef::yes>());
+STATIC_ASSERT(
+    range_test<forward_iterator_tag, int, Sized::no, CanDifference::no, Common::yes, CanCompare::yes, ProxyRef::no>());
+STATIC_ASSERT(
+    range_test<forward_iterator_tag, int, Sized::no, CanDifference::no, Common::yes, CanCompare::yes, ProxyRef::yes>());
+STATIC_ASSERT(
+    range_test<forward_iterator_tag, int, Sized::no, CanDifference::yes, Common::no, CanCompare::yes, ProxyRef::no>());
+STATIC_ASSERT(
+    range_test<forward_iterator_tag, int, Sized::no, CanDifference::yes, Common::no, CanCompare::yes, ProxyRef::yes>());
+STATIC_ASSERT(
+    range_test<forward_iterator_tag, int, Sized::no, CanDifference::yes, Common::yes, CanCompare::yes, ProxyRef::no>());
+STATIC_ASSERT(range_test<forward_iterator_tag, int, Sized::no, CanDifference::yes, Common::yes, CanCompare::yes,
+    ProxyRef::yes>());
+STATIC_ASSERT(
+    range_test<forward_iterator_tag, int, Sized::yes, CanDifference::no, Common::no, CanCompare::yes, ProxyRef::no>());
+STATIC_ASSERT(
+    range_test<forward_iterator_tag, int, Sized::yes, CanDifference::no, Common::no, CanCompare::yes, ProxyRef::yes>());
+STATIC_ASSERT(
+    range_test<forward_iterator_tag, int, Sized::yes, CanDifference::no, Common::yes, CanCompare::yes, ProxyRef::no>());
+STATIC_ASSERT(range_test<forward_iterator_tag, int, Sized::yes, CanDifference::no, Common::yes, CanCompare::yes,
+    ProxyRef::yes>());
+STATIC_ASSERT(
+    range_test<forward_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no, CanCompare::yes, ProxyRef::no>());
+STATIC_ASSERT(range_test<forward_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no, CanCompare::yes,
+    ProxyRef::yes>());
+STATIC_ASSERT(range_test<forward_iterator_tag, int, Sized::yes, CanDifference::yes, Common::yes, CanCompare::yes,
+    ProxyRef::no>());
+STATIC_ASSERT(range_test<forward_iterator_tag, int, Sized::yes, CanDifference::yes, Common::yes, CanCompare::yes,
+    ProxyRef::yes>());
 
-STATIC_ASSERT(range_test<bidirectional_iterator_tag, int, false, false, false, true, false>());
-STATIC_ASSERT(range_test<bidirectional_iterator_tag, int, false, false, false, true, true>());
-STATIC_ASSERT(range_test<bidirectional_iterator_tag, int, false, false, true, true, false>());
-STATIC_ASSERT(range_test<bidirectional_iterator_tag, int, false, false, true, true, true>());
-STATIC_ASSERT(range_test<bidirectional_iterator_tag, int, false, true, false, true, false>());
-STATIC_ASSERT(range_test<bidirectional_iterator_tag, int, false, true, false, true, true>());
-STATIC_ASSERT(range_test<bidirectional_iterator_tag, int, false, true, true, true, false>());
-STATIC_ASSERT(range_test<bidirectional_iterator_tag, int, false, true, true, true, true>());
-STATIC_ASSERT(range_test<bidirectional_iterator_tag, int, true, false, false, true, false>());
-STATIC_ASSERT(range_test<bidirectional_iterator_tag, int, true, false, false, true, true>());
-STATIC_ASSERT(range_test<bidirectional_iterator_tag, int, true, false, true, true, false>());
-STATIC_ASSERT(range_test<bidirectional_iterator_tag, int, true, false, true, true, true>());
-STATIC_ASSERT(range_test<bidirectional_iterator_tag, int, true, true, false, true, false>());
-STATIC_ASSERT(range_test<bidirectional_iterator_tag, int, true, true, false, true, true>());
-STATIC_ASSERT(range_test<bidirectional_iterator_tag, int, true, true, true, true, false>());
-STATIC_ASSERT(range_test<bidirectional_iterator_tag, int, true, true, true, true, true>());
+STATIC_ASSERT(range_test<bidirectional_iterator_tag, int, Sized::no, CanDifference::no, Common::no, CanCompare::yes,
+    ProxyRef::no>());
+STATIC_ASSERT(range_test<bidirectional_iterator_tag, int, Sized::no, CanDifference::no, Common::no, CanCompare::yes,
+    ProxyRef::yes>());
+STATIC_ASSERT(range_test<bidirectional_iterator_tag, int, Sized::no, CanDifference::no, Common::yes, CanCompare::yes,
+    ProxyRef::no>());
+STATIC_ASSERT(range_test<bidirectional_iterator_tag, int, Sized::no, CanDifference::no, Common::yes, CanCompare::yes,
+    ProxyRef::yes>());
+STATIC_ASSERT(range_test<bidirectional_iterator_tag, int, Sized::no, CanDifference::yes, Common::no, CanCompare::yes,
+    ProxyRef::no>());
+STATIC_ASSERT(range_test<bidirectional_iterator_tag, int, Sized::no, CanDifference::yes, Common::no, CanCompare::yes,
+    ProxyRef::yes>());
+STATIC_ASSERT(range_test<bidirectional_iterator_tag, int, Sized::no, CanDifference::yes, Common::yes, CanCompare::yes,
+    ProxyRef::no>());
+STATIC_ASSERT(range_test<bidirectional_iterator_tag, int, Sized::no, CanDifference::yes, Common::yes, CanCompare::yes,
+    ProxyRef::yes>());
+STATIC_ASSERT(range_test<bidirectional_iterator_tag, int, Sized::yes, CanDifference::no, Common::no, CanCompare::yes,
+    ProxyRef::no>());
+STATIC_ASSERT(range_test<bidirectional_iterator_tag, int, Sized::yes, CanDifference::no, Common::no, CanCompare::yes,
+    ProxyRef::yes>());
+STATIC_ASSERT(range_test<bidirectional_iterator_tag, int, Sized::yes, CanDifference::no, Common::yes, CanCompare::yes,
+    ProxyRef::no>());
+STATIC_ASSERT(range_test<bidirectional_iterator_tag, int, Sized::yes, CanDifference::no, Common::yes, CanCompare::yes,
+    ProxyRef::yes>());
+STATIC_ASSERT(range_test<bidirectional_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no, CanCompare::yes,
+    ProxyRef::no>());
+STATIC_ASSERT(range_test<bidirectional_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no, CanCompare::yes,
+    ProxyRef::yes>());
+STATIC_ASSERT(range_test<bidirectional_iterator_tag, int, Sized::yes, CanDifference::yes, Common::yes, CanCompare::yes,
+    ProxyRef::no>());
+STATIC_ASSERT(range_test<bidirectional_iterator_tag, int, Sized::yes, CanDifference::yes, Common::yes, CanCompare::yes,
+    ProxyRef::yes>());
 
-STATIC_ASSERT(range_test<random_access_iterator_tag, int, false, true, false, true, false>());
-STATIC_ASSERT(range_test<random_access_iterator_tag, int, false, true, false, true, true>());
-STATIC_ASSERT(range_test<random_access_iterator_tag, int, false, true, true, true, false>());
-STATIC_ASSERT(range_test<random_access_iterator_tag, int, false, true, true, true, true>());
-STATIC_ASSERT(range_test<random_access_iterator_tag, int, true, true, false, true, false>());
-STATIC_ASSERT(range_test<random_access_iterator_tag, int, true, true, false, true, true>());
-STATIC_ASSERT(range_test<random_access_iterator_tag, int, true, true, true, true, false>());
-STATIC_ASSERT(range_test<random_access_iterator_tag, int, true, true, true, true, true>());
+STATIC_ASSERT(range_test<random_access_iterator_tag, int, Sized::no, CanDifference::yes, Common::no, CanCompare::yes,
+    ProxyRef::no>());
+STATIC_ASSERT(range_test<random_access_iterator_tag, int, Sized::no, CanDifference::yes, Common::no, CanCompare::yes,
+    ProxyRef::yes>());
+STATIC_ASSERT(range_test<random_access_iterator_tag, int, Sized::no, CanDifference::yes, Common::yes, CanCompare::yes,
+    ProxyRef::no>());
+STATIC_ASSERT(range_test<random_access_iterator_tag, int, Sized::no, CanDifference::yes, Common::yes, CanCompare::yes,
+    ProxyRef::yes>());
+STATIC_ASSERT(range_test<random_access_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no, CanCompare::yes,
+    ProxyRef::no>());
+STATIC_ASSERT(range_test<random_access_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no, CanCompare::yes,
+    ProxyRef::yes>());
+STATIC_ASSERT(range_test<random_access_iterator_tag, int, Sized::yes, CanDifference::yes, Common::yes, CanCompare::yes,
+    ProxyRef::no>());
+STATIC_ASSERT(range_test<random_access_iterator_tag, int, Sized::yes, CanDifference::yes, Common::yes, CanCompare::yes,
+    ProxyRef::yes>());
 
-STATIC_ASSERT(range_test<contiguous_iterator_tag, int, false, true, false, true, false>());
-STATIC_ASSERT(range_test<contiguous_iterator_tag, int, false, true, true, true, false>());
-STATIC_ASSERT(range_test<contiguous_iterator_tag, int, true, true, false, true, false>());
-STATIC_ASSERT(range_test<contiguous_iterator_tag, int, true, true, true, true, false>());
+STATIC_ASSERT(range_test<contiguous_iterator_tag, int, Sized::no, CanDifference::yes, Common::no, CanCompare::yes,
+    ProxyRef::no>());
+STATIC_ASSERT(range_test<contiguous_iterator_tag, int, Sized::no, CanDifference::yes, Common::yes, CanCompare::yes,
+    ProxyRef::no>());
+STATIC_ASSERT(range_test<contiguous_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no, CanCompare::yes,
+    ProxyRef::no>());
+STATIC_ASSERT(range_test<contiguous_iterator_tag, int, Sized::yes, CanDifference::yes, Common::yes, CanCompare::yes,
+    ProxyRef::no>());
 
 // Validate move_only_range
 STATIC_ASSERT(ranges::input_range<move_only_range<int>>);

--- a/tests/std/tests/P0896R4_ranges_test_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_test_machinery/test.cpp
@@ -259,3 +259,18 @@ STATIC_ASSERT(ranges::input_range<move_only_range<int>>);
 STATIC_ASSERT(!ranges::forward_range<move_only_range<int>>);
 STATIC_ASSERT(movable<move_only_range<int>>);
 STATIC_ASSERT(!copyable<move_only_range<int>>);
+
+struct instantiate {
+    template <class Range1, class Range2>
+    static constexpr void call() {
+        STATIC_ASSERT(ranges::input_range<Range1>);
+        STATIC_ASSERT(same_as<ranges::range_value_t<Range1>, double>);
+        STATIC_ASSERT(indirectly_writable<ranges::iterator_t<Range1>, const double&>);
+
+        STATIC_ASSERT(ranges::input_range<Range2>);
+        STATIC_ASSERT(same_as<ranges::range_value_t<Range2>, void*>);
+        STATIC_ASSERT(!indirectly_writable<ranges::iterator_t<Range2>, void*>);
+    }
+};
+
+template void test_in_in<instantiate, double, void* const>();

--- a/tests/std/tests/P0896R4_ranges_test_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_test_machinery/test.cpp
@@ -1,0 +1,261 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <concepts>
+#include <ranges>
+//
+#include <range_algorithm_support.hpp>
+
+#define STATIC_ASSERT(...) static_assert(__VA_ARGS__, #__VA_ARGS__)
+
+using namespace std;
+
+int main() {} // COMPILE-ONLY
+
+// Validate test::iterator and test::sentinel
+template <class Category, class Element, bool Sized, bool Common, bool Proxy, bool Wrapped>
+constexpr bool iter_test() {
+    using I = test::iterator<Category, Element, Sized, Common, Proxy, Wrapped>;
+
+    STATIC_ASSERT(default_initializable<I>);
+    STATIC_ASSERT(movable<I>);
+
+    STATIC_ASSERT(!movable<Element> || indirectly_writable<I, Element>);
+
+    constexpr bool can_write =
+        derived_from<Category,
+            output_iterator_tag> || (derived_from<Category, forward_iterator_tag> && assignable_from<Element&, Element>);
+    STATIC_ASSERT(!can_write || output_iterator<I, Element>);
+
+    STATIC_ASSERT(!derived_from<Category, input_iterator_tag> || input_iterator<I>);
+    STATIC_ASSERT(!derived_from<Category, forward_iterator_tag> || forward_iterator<I>);
+    STATIC_ASSERT(!derived_from<Category, bidirectional_iterator_tag> || bidirectional_iterator<I>);
+    STATIC_ASSERT(!derived_from<Category, random_access_iterator_tag> || random_access_iterator<I>);
+    STATIC_ASSERT(!derived_from<Category, contiguous_iterator_tag> || contiguous_iterator<I>);
+
+    using S = test::sentinel<Element, Wrapped>;
+    STATIC_ASSERT(sentinel_for<S, I>);
+    STATIC_ASSERT(!Sized || sized_sentinel_for<S, I>);
+    STATIC_ASSERT(!Common || sentinel_for<I, I>);
+    STATIC_ASSERT(!Common || !Sized || sized_sentinel_for<I, I>);
+
+    if constexpr (Wrapped) {
+        STATIC_ASSERT(same_as<_Unwrapped_t<I>, test::iterator<Category, Element, Sized, Common, Proxy, false>>);
+        STATIC_ASSERT(same_as<_Unwrapped_t<S>, test::sentinel<Element, false>>);
+    }
+
+    return true;
+}
+
+STATIC_ASSERT(iter_test<output_iterator_tag, int, false, false, false, false>());
+STATIC_ASSERT(iter_test<output_iterator_tag, int, false, false, false, true>());
+STATIC_ASSERT(iter_test<output_iterator_tag, int, false, false, true, false>());
+STATIC_ASSERT(iter_test<output_iterator_tag, int, false, false, true, true>());
+STATIC_ASSERT(iter_test<output_iterator_tag, int, false, true, false, false>());
+STATIC_ASSERT(iter_test<output_iterator_tag, int, false, true, false, true>());
+STATIC_ASSERT(iter_test<output_iterator_tag, int, false, true, true, false>());
+STATIC_ASSERT(iter_test<output_iterator_tag, int, false, true, true, true>());
+STATIC_ASSERT(iter_test<output_iterator_tag, int, true, false, false, false>());
+STATIC_ASSERT(iter_test<output_iterator_tag, int, true, false, false, true>());
+STATIC_ASSERT(iter_test<output_iterator_tag, int, true, false, true, false>());
+STATIC_ASSERT(iter_test<output_iterator_tag, int, true, false, true, true>());
+STATIC_ASSERT(iter_test<output_iterator_tag, int, true, true, false, false>());
+STATIC_ASSERT(iter_test<output_iterator_tag, int, true, true, false, true>());
+STATIC_ASSERT(iter_test<output_iterator_tag, int, true, true, true, false>());
+STATIC_ASSERT(iter_test<output_iterator_tag, int, true, true, true, true>());
+
+STATIC_ASSERT(iter_test<input_iterator_tag, int, false, false, false, false>());
+STATIC_ASSERT(iter_test<input_iterator_tag, int, false, false, false, true>());
+STATIC_ASSERT(iter_test<input_iterator_tag, int, false, false, true, false>());
+STATIC_ASSERT(iter_test<input_iterator_tag, int, false, false, true, true>());
+STATIC_ASSERT(iter_test<input_iterator_tag, int, false, true, false, false>());
+STATIC_ASSERT(iter_test<input_iterator_tag, int, false, true, false, true>());
+STATIC_ASSERT(iter_test<input_iterator_tag, int, false, true, true, false>());
+STATIC_ASSERT(iter_test<input_iterator_tag, int, false, true, true, true>());
+STATIC_ASSERT(iter_test<input_iterator_tag, int, true, false, false, false>());
+STATIC_ASSERT(iter_test<input_iterator_tag, int, true, false, false, true>());
+STATIC_ASSERT(iter_test<input_iterator_tag, int, true, false, true, false>());
+STATIC_ASSERT(iter_test<input_iterator_tag, int, true, false, true, true>());
+STATIC_ASSERT(iter_test<input_iterator_tag, int, true, true, false, false>());
+STATIC_ASSERT(iter_test<input_iterator_tag, int, true, true, false, true>());
+STATIC_ASSERT(iter_test<input_iterator_tag, int, true, true, true, false>());
+STATIC_ASSERT(iter_test<input_iterator_tag, int, true, true, true, true>());
+
+STATIC_ASSERT(iter_test<forward_iterator_tag, int, false, true, false, false>());
+STATIC_ASSERT(iter_test<forward_iterator_tag, int, false, true, false, true>());
+STATIC_ASSERT(iter_test<forward_iterator_tag, int, false, true, true, false>());
+STATIC_ASSERT(iter_test<forward_iterator_tag, int, false, true, true, true>());
+STATIC_ASSERT(iter_test<forward_iterator_tag, int, true, true, false, false>());
+STATIC_ASSERT(iter_test<forward_iterator_tag, int, true, true, false, true>());
+STATIC_ASSERT(iter_test<forward_iterator_tag, int, true, true, true, false>());
+STATIC_ASSERT(iter_test<forward_iterator_tag, int, true, true, true, true>());
+
+STATIC_ASSERT(iter_test<bidirectional_iterator_tag, int, false, true, false, false>());
+STATIC_ASSERT(iter_test<bidirectional_iterator_tag, int, false, true, false, true>());
+STATIC_ASSERT(iter_test<bidirectional_iterator_tag, int, false, true, true, false>());
+STATIC_ASSERT(iter_test<bidirectional_iterator_tag, int, false, true, true, true>());
+STATIC_ASSERT(iter_test<bidirectional_iterator_tag, int, true, true, false, false>());
+STATIC_ASSERT(iter_test<bidirectional_iterator_tag, int, true, true, false, true>());
+STATIC_ASSERT(iter_test<bidirectional_iterator_tag, int, true, true, true, false>());
+STATIC_ASSERT(iter_test<bidirectional_iterator_tag, int, true, true, true, true>());
+
+STATIC_ASSERT(iter_test<random_access_iterator_tag, int, false, true, false, false>());
+STATIC_ASSERT(iter_test<random_access_iterator_tag, int, false, true, false, true>());
+STATIC_ASSERT(iter_test<random_access_iterator_tag, int, false, true, true, false>());
+STATIC_ASSERT(iter_test<random_access_iterator_tag, int, false, true, true, true>());
+STATIC_ASSERT(iter_test<random_access_iterator_tag, int, true, true, false, false>());
+STATIC_ASSERT(iter_test<random_access_iterator_tag, int, true, true, false, true>());
+STATIC_ASSERT(iter_test<random_access_iterator_tag, int, true, true, true, false>());
+STATIC_ASSERT(iter_test<random_access_iterator_tag, int, true, true, true, true>());
+
+STATIC_ASSERT(iter_test<contiguous_iterator_tag, int, false, true, false, false>());
+STATIC_ASSERT(iter_test<contiguous_iterator_tag, int, false, true, false, true>());
+STATIC_ASSERT(iter_test<contiguous_iterator_tag, int, true, true, false, false>());
+STATIC_ASSERT(iter_test<contiguous_iterator_tag, int, true, true, false, true>());
+
+STATIC_ASSERT(same_as<_Unwrapped_t<test::sentinel<int, true>>, test::sentinel<int, false>>);
+
+// Validate test::range
+// clang-format off
+template <class R>
+concept has_member_size = requires(const R& r) {
+    typename ranges::range_size_t<R>;
+    { r.size() } -> same_as<ranges::range_size_t<R>>;
+};
+// clang-format on
+
+template <class Category, class Element, bool Sized, bool SizedIterators, bool Common, bool CommonIterators, bool Proxy>
+constexpr bool range_test() {
+    using R = test::range<Category, Element, Sized, SizedIterators, Common, CommonIterators, Proxy>;
+    using I = ranges::iterator_t<R>;
+    using S = ranges::sentinel_t<R>;
+    STATIC_ASSERT(same_as<I, test::iterator<Category, Element, SizedIterators, CommonIterators, Proxy, true>>);
+
+    STATIC_ASSERT(!derived_from<Category, output_iterator_tag> || ranges::output_range<R, Element>);
+    STATIC_ASSERT(!derived_from<Category, input_iterator_tag> || ranges::input_range<R>);
+    STATIC_ASSERT(!derived_from<Category, forward_iterator_tag> || ranges::forward_range<R>);
+    STATIC_ASSERT(!derived_from<Category, bidirectional_iterator_tag> || ranges::bidirectional_range<R>);
+    STATIC_ASSERT(!derived_from<Category, random_access_iterator_tag> || ranges::random_access_range<R>);
+    STATIC_ASSERT(!derived_from<Category, contiguous_iterator_tag> || ranges::contiguous_range<R>);
+
+    if constexpr (Common) {
+        STATIC_ASSERT(CommonIterators);
+        STATIC_ASSERT(ranges::common_range<R>);
+    } else {
+        STATIC_ASSERT(same_as<S, test::sentinel<Element, true>>);
+    }
+
+    STATIC_ASSERT(!CommonIterators || sentinel_for<I, I>);
+
+    constexpr bool is_sized = Sized || (SizedIterators && derived_from<Category, forward_iterator_tag>);
+    STATIC_ASSERT(ranges::sized_range<R> == is_sized);
+    if constexpr (Sized) {
+        STATIC_ASSERT(has_member_size<R>);
+    }
+
+    return true;
+}
+
+STATIC_ASSERT(range_test<output_iterator_tag, int, false, false, false, false, false>());
+STATIC_ASSERT(range_test<output_iterator_tag, int, false, false, false, false, true>());
+STATIC_ASSERT(range_test<output_iterator_tag, int, false, false, false, true, false>());
+STATIC_ASSERT(range_test<output_iterator_tag, int, false, false, false, true, true>());
+STATIC_ASSERT(range_test<output_iterator_tag, int, false, false, true, true, false>());
+STATIC_ASSERT(range_test<output_iterator_tag, int, false, false, true, true, true>());
+STATIC_ASSERT(range_test<output_iterator_tag, int, false, true, false, false, false>());
+STATIC_ASSERT(range_test<output_iterator_tag, int, false, true, false, false, true>());
+STATIC_ASSERT(range_test<output_iterator_tag, int, false, true, false, true, false>());
+STATIC_ASSERT(range_test<output_iterator_tag, int, false, true, false, true, true>());
+STATIC_ASSERT(range_test<output_iterator_tag, int, false, true, true, true, false>());
+STATIC_ASSERT(range_test<output_iterator_tag, int, false, true, true, true, true>());
+STATIC_ASSERT(range_test<output_iterator_tag, int, true, false, false, false, false>());
+STATIC_ASSERT(range_test<output_iterator_tag, int, true, false, false, false, true>());
+STATIC_ASSERT(range_test<output_iterator_tag, int, true, false, false, true, false>());
+STATIC_ASSERT(range_test<output_iterator_tag, int, true, false, false, true, true>());
+STATIC_ASSERT(range_test<output_iterator_tag, int, true, false, true, true, false>());
+STATIC_ASSERT(range_test<output_iterator_tag, int, true, false, true, true, true>());
+STATIC_ASSERT(range_test<output_iterator_tag, int, true, true, false, false, false>());
+STATIC_ASSERT(range_test<output_iterator_tag, int, true, true, false, false, true>());
+STATIC_ASSERT(range_test<output_iterator_tag, int, true, true, false, true, false>());
+STATIC_ASSERT(range_test<output_iterator_tag, int, true, true, false, true, true>());
+STATIC_ASSERT(range_test<output_iterator_tag, int, true, true, true, true, false>());
+STATIC_ASSERT(range_test<output_iterator_tag, int, true, true, true, true, true>());
+
+STATIC_ASSERT(range_test<input_iterator_tag, int, false, false, false, false, false>());
+STATIC_ASSERT(range_test<input_iterator_tag, int, false, false, false, false, true>());
+STATIC_ASSERT(range_test<input_iterator_tag, int, false, false, false, true, false>());
+STATIC_ASSERT(range_test<input_iterator_tag, int, false, false, false, true, true>());
+STATIC_ASSERT(range_test<input_iterator_tag, int, false, false, true, true, false>());
+STATIC_ASSERT(range_test<input_iterator_tag, int, false, false, true, true, true>());
+STATIC_ASSERT(range_test<input_iterator_tag, int, false, true, false, false, false>());
+STATIC_ASSERT(range_test<input_iterator_tag, int, false, true, false, false, true>());
+STATIC_ASSERT(range_test<input_iterator_tag, int, false, true, false, true, false>());
+STATIC_ASSERT(range_test<input_iterator_tag, int, false, true, false, true, true>());
+STATIC_ASSERT(range_test<input_iterator_tag, int, false, true, true, true, false>());
+STATIC_ASSERT(range_test<input_iterator_tag, int, false, true, true, true, true>());
+STATIC_ASSERT(range_test<input_iterator_tag, int, true, false, false, false, false>());
+STATIC_ASSERT(range_test<input_iterator_tag, int, true, false, false, false, true>());
+STATIC_ASSERT(range_test<input_iterator_tag, int, true, false, false, true, false>());
+STATIC_ASSERT(range_test<input_iterator_tag, int, true, false, false, true, true>());
+STATIC_ASSERT(range_test<input_iterator_tag, int, true, false, true, true, false>());
+STATIC_ASSERT(range_test<input_iterator_tag, int, true, false, true, true, true>());
+STATIC_ASSERT(range_test<input_iterator_tag, int, true, true, false, false, false>());
+STATIC_ASSERT(range_test<input_iterator_tag, int, true, true, false, false, true>());
+STATIC_ASSERT(range_test<input_iterator_tag, int, true, true, false, true, false>());
+STATIC_ASSERT(range_test<input_iterator_tag, int, true, true, false, true, true>());
+STATIC_ASSERT(range_test<input_iterator_tag, int, true, true, true, true, false>());
+STATIC_ASSERT(range_test<input_iterator_tag, int, true, true, true, true, true>());
+
+STATIC_ASSERT(range_test<forward_iterator_tag, int, false, false, false, true, false>());
+STATIC_ASSERT(range_test<forward_iterator_tag, int, false, false, false, true, true>());
+STATIC_ASSERT(range_test<forward_iterator_tag, int, false, false, true, true, false>());
+STATIC_ASSERT(range_test<forward_iterator_tag, int, false, false, true, true, true>());
+STATIC_ASSERT(range_test<forward_iterator_tag, int, false, true, false, true, false>());
+STATIC_ASSERT(range_test<forward_iterator_tag, int, false, true, false, true, true>());
+STATIC_ASSERT(range_test<forward_iterator_tag, int, false, true, true, true, false>());
+STATIC_ASSERT(range_test<forward_iterator_tag, int, false, true, true, true, true>());
+STATIC_ASSERT(range_test<forward_iterator_tag, int, true, false, false, true, false>());
+STATIC_ASSERT(range_test<forward_iterator_tag, int, true, false, false, true, true>());
+STATIC_ASSERT(range_test<forward_iterator_tag, int, true, false, true, true, false>());
+STATIC_ASSERT(range_test<forward_iterator_tag, int, true, false, true, true, true>());
+STATIC_ASSERT(range_test<forward_iterator_tag, int, true, true, false, true, false>());
+STATIC_ASSERT(range_test<forward_iterator_tag, int, true, true, false, true, true>());
+STATIC_ASSERT(range_test<forward_iterator_tag, int, true, true, true, true, false>());
+STATIC_ASSERT(range_test<forward_iterator_tag, int, true, true, true, true, true>());
+
+STATIC_ASSERT(range_test<bidirectional_iterator_tag, int, false, false, false, true, false>());
+STATIC_ASSERT(range_test<bidirectional_iterator_tag, int, false, false, false, true, true>());
+STATIC_ASSERT(range_test<bidirectional_iterator_tag, int, false, false, true, true, false>());
+STATIC_ASSERT(range_test<bidirectional_iterator_tag, int, false, false, true, true, true>());
+STATIC_ASSERT(range_test<bidirectional_iterator_tag, int, false, true, false, true, false>());
+STATIC_ASSERT(range_test<bidirectional_iterator_tag, int, false, true, false, true, true>());
+STATIC_ASSERT(range_test<bidirectional_iterator_tag, int, false, true, true, true, false>());
+STATIC_ASSERT(range_test<bidirectional_iterator_tag, int, false, true, true, true, true>());
+STATIC_ASSERT(range_test<bidirectional_iterator_tag, int, true, false, false, true, false>());
+STATIC_ASSERT(range_test<bidirectional_iterator_tag, int, true, false, false, true, true>());
+STATIC_ASSERT(range_test<bidirectional_iterator_tag, int, true, false, true, true, false>());
+STATIC_ASSERT(range_test<bidirectional_iterator_tag, int, true, false, true, true, true>());
+STATIC_ASSERT(range_test<bidirectional_iterator_tag, int, true, true, false, true, false>());
+STATIC_ASSERT(range_test<bidirectional_iterator_tag, int, true, true, false, true, true>());
+STATIC_ASSERT(range_test<bidirectional_iterator_tag, int, true, true, true, true, false>());
+STATIC_ASSERT(range_test<bidirectional_iterator_tag, int, true, true, true, true, true>());
+
+STATIC_ASSERT(range_test<random_access_iterator_tag, int, false, true, false, true, false>());
+STATIC_ASSERT(range_test<random_access_iterator_tag, int, false, true, false, true, true>());
+STATIC_ASSERT(range_test<random_access_iterator_tag, int, false, true, true, true, false>());
+STATIC_ASSERT(range_test<random_access_iterator_tag, int, false, true, true, true, true>());
+STATIC_ASSERT(range_test<random_access_iterator_tag, int, true, true, false, true, false>());
+STATIC_ASSERT(range_test<random_access_iterator_tag, int, true, true, false, true, true>());
+STATIC_ASSERT(range_test<random_access_iterator_tag, int, true, true, true, true, false>());
+STATIC_ASSERT(range_test<random_access_iterator_tag, int, true, true, true, true, true>());
+
+STATIC_ASSERT(range_test<contiguous_iterator_tag, int, false, true, false, true, false>());
+STATIC_ASSERT(range_test<contiguous_iterator_tag, int, false, true, true, true, false>());
+STATIC_ASSERT(range_test<contiguous_iterator_tag, int, true, true, false, true, false>());
+STATIC_ASSERT(range_test<contiguous_iterator_tag, int, true, true, true, true, false>());
+
+// Validate move_only_range
+STATIC_ASSERT(ranges::input_range<move_only_range<int>>);
+STATIC_ASSERT(!ranges::forward_range<move_only_range<int>>);
+STATIC_ASSERT(movable<move_only_range<int>>);
+STATIC_ASSERT(!copyable<move_only_range<int>>);


### PR DESCRIPTION
These were previously compile-only tools intended for instantiation tests, but they can now adapt a contiguous sequence of elements into a range with specified properties for runtime testing. Nest in namespace `test` as `test::range` and `test::iterator`. Add `test::sentinel` to use with `test::iterator` to make non-`common_range`s. `test::iterator` and `test::range` now enforce valid combinations of parameters instead of silently ignoring inconsistencies. `test::iterator`/`test::sentinel` now have "wrapped" and "unwrapped" variations to test use of unwrapping machinery in the Range algorithms. `move_only_range` is now a special case of `test::range`. Adds new test `std/P0896R4_ranges_test_machinery` for this stuff since it's getting complicated.
