### PR TITLE
Implement ranges::is_sorted and ranges::is_sorted_until

### DIFF
--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -5673,7 +5673,7 @@ namespace ranges {
 
         template <forward_range _Rng, class _Pj = identity,
             indirect_strict_weak_order<projected<iterator_t<_Rng>, _Pj>> _Pr = ranges::less>
-        _NODISCARD constexpr bool operator()(_Rng _Range, _Pr _Pred = {}, _Pj _Proj = {}) const {
+        _NODISCARD constexpr bool operator()(_Rng&& _Range, _Pr _Pred = {}, _Pj _Proj = {}) const {
             const auto _ULast  = _Uend(_Range);
             const auto _UFirst = _Is_sorted_until_unchecked(_Ubegin(_Range), _ULast, _Pass_fn(_Pred), _Pass_fn(_Proj));
             return _UFirst == _ULast;

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -5643,11 +5643,13 @@ namespace ranges {
         _STL_INTERNAL_STATIC_ASSERT(sentinel_for<_Se, _It>);
         _STL_INTERNAL_STATIC_ASSERT(indirect_strict_weak_order<_Pr, projected<_It, _Pj>>);
 
-        if (_First != _Last) {
-            for (auto _Prev = _First; ++_First != _Last; ++_Prev) {
-                if (_STD invoke(_Pred, _STD invoke(_Proj, *_First), _STD invoke(_Proj, *_Prev))) {
-                    break;
-                }
+        if (_First == _Last) {
+            return _First;
+        }
+
+        for (auto _Prev = _First; ++_First != _Last; ++_Prev) {
+            if (_STD invoke(_Pred, _STD invoke(_Proj, *_First), _STD invoke(_Proj, *_Prev))) {
+                break;
             }
         }
 

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -5634,9 +5634,82 @@ _NODISCARD bool is_sorted(_ExPo&& _Exec, _FwdIt _First, _FwdIt _Last) noexcept /
     return _STD is_sorted(_STD forward<_ExPo>(_Exec), _First, _Last, less{});
 }
 
-#endif // _HAS_CXX17
+#ifdef __cpp_lib_concepts
+namespace ranges {
+    // FUNCTION TEMPLATE _Is_sorted_until_unchecked
+    template <class _It, class _Se, class _Pr, class _Pj>
+    _NODISCARD constexpr _It _Is_sorted_until_unchecked(_It _First, const _Se _Last, _Pr _Pred, _Pj _Proj) {
+        _STL_INTERNAL_STATIC_ASSERT(forward_iterator<_It>);
+        _STL_INTERNAL_STATIC_ASSERT(sentinel_for<_Se, _It>);
+        _STL_INTERNAL_STATIC_ASSERT(indirect_strict_weak_order<_Pr, projected<_It, _Pj>>);
 
-#if _HAS_CXX17
+        if (_First != _Last) {
+            for (auto _Prev = _First; ++_First != _Last; ++_Prev) {
+                if (_STD invoke(_Pred, _STD invoke(_Proj, *_First), _STD invoke(_Proj, *_Prev))) {
+                    break;
+                }
+            }
+        }
+
+        return _First;
+    }
+
+    // VARIABLE ranges::is_sorted
+    class _Is_sorted_fn : private _Not_quite_object {
+    public:
+        using _Not_quite_object::_Not_quite_object;
+
+        template <forward_iterator _It, sentinel_for<_It> _Se, class _Pj = identity,
+            indirect_strict_weak_order<projected<_It, _Pj>> _Pr = ranges::less>
+        _NODISCARD constexpr bool operator()(_It _First, _Se _Last, _Pr _Pred = {}, _Pj _Proj = {}) const {
+            _Adl_verify_range(_First, _Last);
+            const auto _ULast = _Get_unwrapped(_STD move(_Last));
+            const auto _UFirst =
+                _Is_sorted_until_unchecked(_Get_unwrapped(_STD move(_First)), _ULast, _Pass_fn(_Pred), _Pass_fn(_Proj));
+            return _UFirst == _ULast;
+        }
+
+        template <forward_range _Rng, class _Pj = identity,
+            indirect_strict_weak_order<projected<iterator_t<_Rng>, _Pj>> _Pr = ranges::less>
+        _NODISCARD constexpr bool operator()(_Rng _Range, _Pr _Pred = {}, _Pj _Proj = {}) const {
+            const auto _ULast  = _Uend(_Range);
+            const auto _UFirst = _Is_sorted_until_unchecked(_Ubegin(_Range), _ULast, _Pass_fn(_Pred), _Pass_fn(_Proj));
+            return _UFirst == _ULast;
+        }
+    };
+
+    inline constexpr _Is_sorted_fn is_sorted{_Not_quite_object::_Construct_tag{}};
+
+    // VARIABLE ranges::is_sorted_until
+    class _Is_sorted_until_fn : private _Not_quite_object {
+    public:
+        using _Not_quite_object::_Not_quite_object;
+
+        template <forward_iterator _It, sentinel_for<_It> _Se, class _Pj = identity,
+            indirect_strict_weak_order<projected<_It, _Pj>> _Pr = ranges::less>
+        _NODISCARD constexpr _It operator()(_It _First, _Se _Last, _Pr _Pred = {}, _Pj _Proj = {}) const {
+            _Adl_verify_range(_First, _Last);
+            auto _UFirst = _Is_sorted_until_unchecked(
+                _Get_unwrapped(_STD move(_First)), _Get_unwrapped(_STD move(_Last)), _Pass_fn(_Pred), _Pass_fn(_Proj));
+            _Seek_wrapped(_First, _STD move(_UFirst));
+            return _First;
+        }
+
+        template <forward_range _Rng, class _Pj = identity,
+            indirect_strict_weak_order<projected<iterator_t<_Rng>, _Pj>> _Pr = ranges::less>
+        _NODISCARD constexpr borrowed_iterator_t<_Rng> operator()(_Rng&& _Range, _Pr _Pred = {}, _Pj _Proj = {}) const {
+            auto _First = _RANGES begin(_Range);
+            auto _UFirst =
+                _Is_sorted_until_unchecked(_Get_unwrapped(_First), _Uend(_Range), _Pass_fn(_Pred), _Pass_fn(_Proj));
+            _Seek_wrapped(_First, _STD move(_UFirst));
+            return _First;
+        }
+    };
+
+    inline constexpr _Is_sorted_until_fn is_sorted_until{_Not_quite_object::_Construct_tag{}};
+} // namespace ranges
+#endif // __cpp_lib_concepts
+
 // FUNCTION TEMPLATE clamp
 template <class _Ty, class _Pr>
 _NODISCARD constexpr const _Ty& clamp(const _Ty& _Val, const _Ty& _Min_val, const _Ty& _Max_val, _Pr _Pred) {

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -3148,7 +3148,7 @@ namespace ranges {
                 }
 
                 if constexpr (_Need_rewrap) {
-                    _Seek_wrapped(_Where, static_cast<_It&&>(_UWhere));
+                    _Seek_wrapped(_Where, _STD move(_UWhere));
                 }
             }
         }

--- a/tests/std/include/range_algorithm_support.hpp
+++ b/tests/std/include/range_algorithm_support.hpp
@@ -499,7 +499,7 @@ namespace test {
         requires (!to_bool(IsCommon) || to_bool(Eq))
             && (to_bool(Eq) || !derived_from<Category, fwd>)
             && (!to_bool(Proxy) || !derived_from<Category, contiguous>)
-    class range : ranges::view_base {
+    class range {
         span<Element> elements_;
         mutable bool begin_called_ = false;
 
@@ -510,17 +510,8 @@ namespace test {
         range() = default;
         constexpr explicit range(span<Element> elements) noexcept : elements_{elements} {}
 
-        range(const range&) requires derived_from<Category, fwd> = default;
-        range& operator=(const range&) requires derived_from<Category, fwd> = default;
-
-        constexpr range(range&& that) noexcept
-            : elements_{exchange(that.elements_, {})}, begin_called_{that.begin_called_} {}
-
-        constexpr range& operator=(range&& that) noexcept {
-            elements_     = exchange(that.elements_, {});
-            begin_called_ = that.begin_called_;
-            return *this;
-        }
+        range(const range&) = delete;
+        range& operator=(const range&) = delete;
 
         [[nodiscard]] constexpr I begin() const noexcept {
             if constexpr (!derived_from<Category, fwd>) {
@@ -566,25 +557,17 @@ namespace test {
 } // namespace test
 
 template <class T>
-class move_only_range : public test::range<test::input, T, test::Sized::no, test::CanDifference::no, test::Common::no,
-                            test::CanCompare::no, test::ProxyRef::no> {
-#if defined(__clang__) || defined(__EDG__) // TRANSITION, VSO-1132704
+class basic_borrowed_range : public test::range<test::input, T, test::Sized::no, test::CanDifference::no,
+                                 test::Common::no, test::CanCompare::no, test::ProxyRef::no> {
     using test::range<test::input, T, test::Sized::no, test::CanDifference::no, test::Common::no, test::CanCompare::no,
         test::ProxyRef::no>::range;
-#else // ^^^ no workaround / workaround vvv
-public:
-    constexpr move_only_range() = default;
-    constexpr explicit move_only_range(std::span<T> elements) noexcept : move_only_range::range{elements} {}
-    constexpr move_only_range(move_only_range&&) = default;
-    constexpr move_only_range& operator=(move_only_range&&) = default;
-#endif // TRANSITION, VSO-1132704
 };
 
 template <ranges::contiguous_range R>
-move_only_range(R&) -> move_only_range<std::remove_reference_t<ranges::range_reference_t<R>>>;
+basic_borrowed_range(R&) -> basic_borrowed_range<std::remove_reference_t<ranges::range_reference_t<R>>>;
 
 template <class T>
-inline constexpr bool ranges::enable_borrowed_range<::move_only_range<T>> = true;
+inline constexpr bool ranges::enable_borrowed_range<::basic_borrowed_range<T>> = true;
 
 template <int>
 struct unique_tag {};
@@ -610,6 +593,7 @@ struct with_writable_iterators {
     template <class... Args>
     static constexpr void call() {
         using namespace test;
+        using test::iterator; // Hello, one-phase legacy name lookup!
 
         // Diff and Eq are not significant for "lone" single-pass iterators, so we can ignore them here.
         Continuation::template call<Args...,

--- a/tests/std/include/range_algorithm_support.hpp
+++ b/tests/std/include/range_algorithm_support.hpp
@@ -510,8 +510,8 @@ namespace test {
         range() = default;
         constexpr explicit range(span<Element> elements) noexcept : elements_{elements} {}
 
-        range(const range&) = delete;
-        range& operator=(const range&) = delete;
+        range(range const&) = delete;
+        range& operator=(range const&) = delete;
 
         [[nodiscard]] constexpr I begin() const noexcept {
             if constexpr (!derived_from<Category, fwd>) {
@@ -593,7 +593,7 @@ struct with_writable_iterators {
     template <class... Args>
     static constexpr void call() {
         using namespace test;
-        using test::iterator; // Hello, one-phase legacy name lookup!
+        using test::iterator;
 
         // Diff and Eq are not significant for "lone" single-pass iterators, so we can ignore them here.
         Continuation::template call<Args...,

--- a/tests/std/test.lst
+++ b/tests/std/test.lst
@@ -251,6 +251,7 @@ tests\P0896R4_ranges_alg_find_if_not
 tests\P0896R4_ranges_alg_for_each
 tests\P0896R4_ranges_alg_for_each_n
 tests\P0896R4_ranges_alg_is_permutation
+tests\P0896R4_ranges_alg_is_sorted
 tests\P0896R4_ranges_alg_mismatch
 tests\P0896R4_ranges_alg_move
 tests\P0896R4_ranges_alg_none_of

--- a/tests/std/tests/P0896R4_ranges_alg_all_of/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_all_of/test.cpp
@@ -18,24 +18,24 @@ constexpr void smoke_test() {
     using ranges::all_of;
     constexpr R pairs = {{{0, 13}, {2, 13}, {4, 13}}};
 
-    assert(all_of(move_only_range{pairs}, is_even, get_first));
-    assert(!all_of(move_only_range{pairs}, is_even, get_second));
-    assert(!all_of(move_only_range{pairs}, is_odd, get_first));
-    assert(all_of(move_only_range{pairs}, is_odd, get_second));
+    assert(all_of(basic_borrowed_range{pairs}, is_even, get_first));
+    assert(!all_of(basic_borrowed_range{pairs}, is_even, get_second));
+    assert(!all_of(basic_borrowed_range{pairs}, is_odd, get_first));
+    assert(all_of(basic_borrowed_range{pairs}, is_odd, get_second));
     {
-        move_only_range wrapped_pairs{pairs};
+        basic_borrowed_range wrapped_pairs{pairs};
         assert(all_of(wrapped_pairs.begin(), wrapped_pairs.end(), is_even, get_first));
     }
     {
-        move_only_range wrapped_pairs{pairs};
+        basic_borrowed_range wrapped_pairs{pairs};
         assert(!all_of(wrapped_pairs.begin(), wrapped_pairs.end(), is_even, get_second));
     }
     {
-        move_only_range wrapped_pairs{pairs};
+        basic_borrowed_range wrapped_pairs{pairs};
         assert(!all_of(wrapped_pairs.begin(), wrapped_pairs.end(), is_odd, get_first));
     }
     {
-        move_only_range wrapped_pairs{pairs};
+        basic_borrowed_range wrapped_pairs{pairs};
         assert(all_of(wrapped_pairs.begin(), wrapped_pairs.end(), is_odd, get_second));
     }
 }

--- a/tests/std/tests/P0896R4_ranges_alg_any_of/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_any_of/test.cpp
@@ -16,24 +16,24 @@ constexpr void smoke_test() {
     using ranges::any_of;
     constexpr std::array<std::pair<int, int>, 3> pairs = {{{0, 13}, {7, 13}, {4, 13}}};
 
-    assert(any_of(move_only_range{pairs}, is_even, get_first));
-    assert(!any_of(move_only_range{pairs}, is_even, get_second));
-    assert(any_of(move_only_range{pairs}, is_odd, get_first));
-    assert(any_of(move_only_range{pairs}, is_odd, get_second));
+    assert(any_of(basic_borrowed_range{pairs}, is_even, get_first));
+    assert(!any_of(basic_borrowed_range{pairs}, is_even, get_second));
+    assert(any_of(basic_borrowed_range{pairs}, is_odd, get_first));
+    assert(any_of(basic_borrowed_range{pairs}, is_odd, get_second));
     {
-        move_only_range wrapped_pairs{pairs};
+        basic_borrowed_range wrapped_pairs{pairs};
         assert(any_of(wrapped_pairs.begin(), wrapped_pairs.end(), is_even, get_first));
     }
     {
-        move_only_range wrapped_pairs{pairs};
+        basic_borrowed_range wrapped_pairs{pairs};
         assert(!any_of(wrapped_pairs.begin(), wrapped_pairs.end(), is_even, get_second));
     }
     {
-        move_only_range wrapped_pairs{pairs};
+        basic_borrowed_range wrapped_pairs{pairs};
         assert(any_of(wrapped_pairs.begin(), wrapped_pairs.end(), is_odd, get_first));
     }
     {
-        move_only_range wrapped_pairs{pairs};
+        basic_borrowed_range wrapped_pairs{pairs};
         assert(any_of(wrapped_pairs.begin(), wrapped_pairs.end(), is_odd, get_second));
     }
 }

--- a/tests/std/tests/P0896R4_ranges_alg_copy/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_copy/test.cpp
@@ -24,21 +24,21 @@ constexpr void smoke_test() {
     int const input[] = {13, 42, 1729};
     { // Validate range overload
         int output[] = {-1, -1, -1};
-        auto result  = copy(move_only_range{input}, move_only_range{output}.begin());
+        auto result  = copy(basic_borrowed_range{input}, basic_borrowed_range{output}.begin());
         STATIC_ASSERT(same_as<decltype(result),
-            copy_result<iterator_t<move_only_range<int const>>, iterator_t<move_only_range<int>>>>);
-        assert(result.in == move_only_range{input}.end());
-        assert(result.out == move_only_range{output}.end());
+            copy_result<iterator_t<basic_borrowed_range<int const>>, iterator_t<basic_borrowed_range<int>>>>);
+        assert(result.in == basic_borrowed_range{input}.end());
+        assert(result.out == basic_borrowed_range{output}.end());
         assert(ranges::equal(output, input));
     }
     { // Validate iterator + sentinel overload
         int output[] = {-1, -1, -1};
-        move_only_range wrapped_input{input};
-        auto result = copy(wrapped_input.begin(), wrapped_input.end(), move_only_range{output}.begin());
+        basic_borrowed_range wrapped_input{input};
+        auto result = copy(wrapped_input.begin(), wrapped_input.end(), basic_borrowed_range{output}.begin());
         STATIC_ASSERT(same_as<decltype(result),
-            copy_result<iterator_t<move_only_range<int const>>, iterator_t<move_only_range<int>>>>);
+            copy_result<iterator_t<basic_borrowed_range<int const>>, iterator_t<basic_borrowed_range<int>>>>);
         assert(result.in == wrapped_input.end());
-        assert(result.out == move_only_range{output}.end());
+        assert(result.out == basic_borrowed_range{output}.end());
         assert(ranges::equal(output, input));
     }
 }

--- a/tests/std/tests/P0896R4_ranges_alg_copy_if/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_copy_if/test.cpp
@@ -74,24 +74,24 @@ constexpr void smoke_test() {
 
     std::array<P, 3> const input    = {{{1, 99}, {4, 98}, {5, 97}}};
     std::array<P, 2> const expected = {{{1, 99}, {5, 97}}};
-    using I                         = iterator_t<move_only_range<P const>>;
-    using O                         = iterator_t<move_only_range<P>>;
+    using I                         = iterator_t<basic_borrowed_range<P const>>;
+    using O                         = iterator_t<basic_borrowed_range<P>>;
     { // Validate range overload
         std::array<P, 2> output = {};
-        auto result             = copy_if(move_only_range{input}, move_only_range{output}.begin(), is_odd, get_first);
+        auto result = copy_if(basic_borrowed_range{input}, basic_borrowed_range{output}.begin(), is_odd, get_first);
         STATIC_ASSERT(same_as<decltype(result), copy_if_result<I, O>>);
-        assert(result.in == move_only_range{input}.end());
-        assert(result.out == move_only_range{output}.end());
+        assert(result.in == basic_borrowed_range{input}.end());
+        assert(result.out == basic_borrowed_range{output}.end());
         assert(ranges::equal(output, expected));
     }
     { // Validate iterator + sentinel overload
         std::array<P, 2> output = {};
-        move_only_range wrapped_input{input};
-        auto result =
-            copy_if(wrapped_input.begin(), wrapped_input.end(), move_only_range{output}.begin(), is_odd, get_first);
+        basic_borrowed_range wrapped_input{input};
+        auto result = copy_if(
+            wrapped_input.begin(), wrapped_input.end(), basic_borrowed_range{output}.begin(), is_odd, get_first);
         STATIC_ASSERT(same_as<decltype(result), copy_if_result<I, O>>);
         assert(result.in == wrapped_input.end());
-        assert(result.out == move_only_range{output}.end());
+        assert(result.out == basic_borrowed_range{output}.end());
         assert(ranges::equal(output, expected));
     }
 }

--- a/tests/std/tests/P0896R4_ranges_alg_copy_n/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_copy_n/test.cpp
@@ -18,12 +18,12 @@ constexpr void smoke_test() {
 
     int const input[] = {13, 42, 1729};
     int output[]      = {-1, -1, -1};
-    move_only_range wrapped_input{input};
-    auto result = copy_n(wrapped_input.begin(), ranges::distance(input), move_only_range{output}.begin());
+    basic_borrowed_range wrapped_input{input};
+    auto result = copy_n(wrapped_input.begin(), ranges::distance(input), basic_borrowed_range{output}.begin());
     STATIC_ASSERT(same_as<decltype(result),
-        copy_n_result<iterator_t<move_only_range<int const>>, iterator_t<move_only_range<int>>>>);
+        copy_n_result<iterator_t<basic_borrowed_range<int const>>, iterator_t<basic_borrowed_range<int>>>>);
     assert(result.in == wrapped_input.end());
-    assert(result.out == move_only_range{output}.end());
+    assert(result.out == basic_borrowed_range{output}.end());
     assert(ranges::equal(output, input));
 }
 

--- a/tests/std/tests/P0896R4_ranges_alg_count/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_count/test.cpp
@@ -14,17 +14,17 @@ constexpr void smoke_test() {
     using ranges::count;
     using P                  = std::pair<int, int>;
     std::array<P, 5> const x = {{{0, 99}, {1, 47}, {2, 99}, {3, 47}, {4, 99}}};
-    using D                  = ranges::range_difference_t<move_only_range<P const>>;
+    using D                  = ranges::range_difference_t<basic_borrowed_range<P const>>;
 
     {
         // Validate range overload
-        auto result = count(move_only_range{x}, 99, get_second);
+        auto result = count(basic_borrowed_range{x}, 99, get_second);
         STATIC_ASSERT(std::same_as<decltype(result), D>);
         assert(result == 3);
     }
     {
         // Validate iterator + sentinel overload
-        move_only_range wrapped_x{x};
+        basic_borrowed_range wrapped_x{x};
         auto result = count(wrapped_x.begin(), wrapped_x.end(), 47, get_second);
         STATIC_ASSERT(std::same_as<decltype(result), D>);
         assert(result == 2);

--- a/tests/std/tests/P0896R4_ranges_alg_count_if/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_count_if/test.cpp
@@ -17,17 +17,17 @@ constexpr void smoke_test() {
     using ranges::count_if;
     using P                  = std::pair<int, int>;
     std::array<P, 5> const x = {{{0, 47}, {1, 99}, {2, 99}, {3, 47}, {4, 99}}};
-    using D                  = ranges::range_difference_t<move_only_range<P const>>;
+    using D                  = ranges::range_difference_t<basic_borrowed_range<P const>>;
 
     {
         // Validate range overload
-        auto result = count_if(move_only_range{x}, is_even, get_first);
+        auto result = count_if(basic_borrowed_range{x}, is_even, get_first);
         STATIC_ASSERT(std::same_as<decltype(result), D>);
         assert(result == 3);
     }
     {
         // Validate iterator + sentinel overload
-        move_only_range wrapped_x{x};
+        basic_borrowed_range wrapped_x{x};
         auto result = count_if(wrapped_x.begin(), wrapped_x.end(), is_odd, get_first);
         STATIC_ASSERT(std::same_as<decltype(result), D>);
         assert(result == 2);

--- a/tests/std/tests/P0896R4_ranges_alg_equal/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_equal/test.cpp
@@ -28,10 +28,10 @@ constexpr void smoke_test() {
     }
     {
         // Validate non-sized ranges
-        auto result = equal(move_only_range{x}, move_only_range{y}, cmp, get_first, get_second);
+        auto result = equal(basic_borrowed_range{x}, basic_borrowed_range{y}, cmp, get_first, get_second);
         STATIC_ASSERT(same_as<decltype(result), bool>);
         assert(result);
-        assert(!equal(move_only_range{x}, move_only_range{y}, cmp, get_first, get_first));
+        assert(!equal(basic_borrowed_range{x}, basic_borrowed_range{y}, cmp, get_first, get_first));
     }
     {
         // Validate sized iterator + sentinel pairs
@@ -42,14 +42,16 @@ constexpr void smoke_test() {
     }
     {
         // Validate non-sized iterator + sentinel pairs
-        move_only_range wrapped_x{x};
-        move_only_range wrapped_y{y};
+        basic_borrowed_range wrapped_x{x};
+        basic_borrowed_range wrapped_y{y};
         auto result =
             equal(wrapped_x.begin(), wrapped_x.end(), wrapped_y.begin(), wrapped_y.end(), cmp, get_first, get_second);
         STATIC_ASSERT(same_as<decltype(result), bool>);
         assert(result);
-        wrapped_x = move_only_range{x};
-        wrapped_y = move_only_range{y};
+    }
+    {
+        basic_borrowed_range wrapped_x{x};
+        basic_borrowed_range wrapped_y{y};
         assert(
             !equal(wrapped_x.begin(), wrapped_x.end(), wrapped_y.begin(), wrapped_y.end(), cmp, get_first, get_first));
     }

--- a/tests/std/tests/P0896R4_ranges_alg_find/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_find/test.cpp
@@ -23,29 +23,29 @@ constexpr void smoke_test() {
     for (auto [value, _] : pairs) {
         {
             // Validate range overload [found case]
-            auto result = find(move_only_range{pairs}, value, get_first);
-            STATIC_ASSERT(same_as<decltype(result), iterator_t<move_only_range<P const>>>);
+            auto result = find(basic_borrowed_range{pairs}, value, get_first);
+            STATIC_ASSERT(same_as<decltype(result), iterator_t<basic_borrowed_range<P const>>>);
             assert((*result).first == value);
         }
         {
             // Validate iterator + sentinel overload [found case]
-            move_only_range wrapped_pairs{pairs};
+            basic_borrowed_range wrapped_pairs{pairs};
             auto result = find(wrapped_pairs.begin(), wrapped_pairs.end(), value, get_first);
-            STATIC_ASSERT(same_as<decltype(result), iterator_t<move_only_range<P const>>>);
+            STATIC_ASSERT(same_as<decltype(result), iterator_t<basic_borrowed_range<P const>>>);
             assert((*result).first == value);
         }
     }
     {
         // Validate range overload [not found case]
-        auto result = find(move_only_range{pairs}, 42, get_first);
-        STATIC_ASSERT(same_as<decltype(result), iterator_t<move_only_range<P const>>>);
-        assert(result == move_only_range{pairs}.end());
+        auto result = find(basic_borrowed_range{pairs}, 42, get_first);
+        STATIC_ASSERT(same_as<decltype(result), iterator_t<basic_borrowed_range<P const>>>);
+        assert(result == basic_borrowed_range{pairs}.end());
     }
     {
         // Validate iterator + sentinel overload [not found case]
-        move_only_range wrapped_pairs{pairs};
+        basic_borrowed_range wrapped_pairs{pairs};
         auto result = find(wrapped_pairs.begin(), wrapped_pairs.end(), 42, get_first);
-        STATIC_ASSERT(same_as<decltype(result), iterator_t<move_only_range<P const>>>);
+        STATIC_ASSERT(same_as<decltype(result), iterator_t<basic_borrowed_range<P const>>>);
         assert(result == wrapped_pairs.end());
     }
 }

--- a/tests/std/tests/P0896R4_ranges_alg_find_first_of/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_find_first_of/test.cpp
@@ -25,32 +25,32 @@ constexpr void smoke_test() {
     const array good_needle = {29, 1};
     {
         // Validate range overload [found case]
-        auto result = find_first_of(move_only_range{pairs}, good_needle, pred, get_first);
-        STATIC_ASSERT(same_as<decltype(result), iterator_t<move_only_range<const P>>>);
+        auto result = find_first_of(basic_borrowed_range{pairs}, good_needle, pred, get_first);
+        STATIC_ASSERT(same_as<decltype(result), iterator_t<basic_borrowed_range<const P>>>);
         assert(to_address(std::move(result).base()) == pairs.data() + 2);
     }
     {
         // Validate iterator + sentinel overload [found case]
-        move_only_range wrapped_pairs{pairs};
+        basic_borrowed_range wrapped_pairs{pairs};
         auto result = find_first_of(
             wrapped_pairs.begin(), wrapped_pairs.end(), good_needle.begin(), good_needle.end(), pred, get_first);
-        STATIC_ASSERT(same_as<decltype(result), iterator_t<move_only_range<const P>>>);
+        STATIC_ASSERT(same_as<decltype(result), iterator_t<basic_borrowed_range<const P>>>);
         assert(to_address(std::move(result).base()) == pairs.data() + 2);
     }
 
     const array bad_needle = {29, 17};
     {
         // Validate range overload [not found case]
-        auto result = find_first_of(move_only_range{pairs}, bad_needle, pred, get_first);
-        STATIC_ASSERT(same_as<decltype(result), iterator_t<move_only_range<const P>>>);
+        auto result = find_first_of(basic_borrowed_range{pairs}, bad_needle, pred, get_first);
+        STATIC_ASSERT(same_as<decltype(result), iterator_t<basic_borrowed_range<const P>>>);
         assert(to_address(std::move(result).base()) == pairs.data() + pairs.size());
     }
     {
         // Validate iterator + sentinel overload [not found case]
-        move_only_range wrapped_pairs{pairs};
+        basic_borrowed_range wrapped_pairs{pairs};
         auto result = find_first_of(
             wrapped_pairs.begin(), wrapped_pairs.end(), bad_needle.begin(), bad_needle.end(), pred, get_first);
-        STATIC_ASSERT(same_as<decltype(result), iterator_t<move_only_range<const P>>>);
+        STATIC_ASSERT(same_as<decltype(result), iterator_t<basic_borrowed_range<const P>>>);
         assert(to_address(std::move(result).base()) == pairs.data() + pairs.size());
     }
 }

--- a/tests/std/tests/P0896R4_ranges_alg_find_if/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_find_if/test.cpp
@@ -24,29 +24,29 @@ constexpr void smoke_test() {
     for (auto [value, _] : pairs) {
         {
             // Validate range overload [found case]
-            auto result = find_if(move_only_range{pairs}, equals(value), get_first);
-            STATIC_ASSERT(same_as<decltype(result), iterator_t<move_only_range<P const>>>);
+            auto result = find_if(basic_borrowed_range{pairs}, equals(value), get_first);
+            STATIC_ASSERT(same_as<decltype(result), iterator_t<basic_borrowed_range<P const>>>);
             assert((*result).first == value);
         }
         {
             // Validate iterator + sentinel overload [found case]
-            move_only_range wrapped_pairs{pairs};
+            basic_borrowed_range wrapped_pairs{pairs};
             auto result = find_if(wrapped_pairs.begin(), wrapped_pairs.end(), equals(value), get_first);
-            STATIC_ASSERT(same_as<decltype(result), iterator_t<move_only_range<P const>>>);
+            STATIC_ASSERT(same_as<decltype(result), iterator_t<basic_borrowed_range<P const>>>);
             assert((*result).first == value);
         }
     }
     {
         // Validate range overload [not found case]
-        auto result = find_if(move_only_range{pairs}, equals(42), get_first);
-        STATIC_ASSERT(same_as<decltype(result), iterator_t<move_only_range<P const>>>);
-        assert(result == move_only_range{pairs}.end());
+        auto result = find_if(basic_borrowed_range{pairs}, equals(42), get_first);
+        STATIC_ASSERT(same_as<decltype(result), iterator_t<basic_borrowed_range<P const>>>);
+        assert(result == basic_borrowed_range{pairs}.end());
     }
     {
         // Validate iterator + sentinel overload [not found case]
-        move_only_range wrapped_pairs{pairs};
+        basic_borrowed_range wrapped_pairs{pairs};
         auto result = find_if(wrapped_pairs.begin(), wrapped_pairs.end(), equals(42), get_first);
-        STATIC_ASSERT(same_as<decltype(result), iterator_t<move_only_range<P const>>>);
+        STATIC_ASSERT(same_as<decltype(result), iterator_t<basic_borrowed_range<P const>>>);
         assert(result == wrapped_pairs.end());
     }
 }

--- a/tests/std/tests/P0896R4_ranges_alg_find_if_not/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_find_if_not/test.cpp
@@ -25,30 +25,30 @@ constexpr void smoke_test() {
         value = 42;
         {
             // Validate range overload [found case]
-            auto result = find_if_not(move_only_range{pairs}, equals(0), get_first);
-            STATIC_ASSERT(same_as<decltype(result), iterator_t<move_only_range<P>>>);
+            auto result = find_if_not(basic_borrowed_range{pairs}, equals(0), get_first);
+            STATIC_ASSERT(same_as<decltype(result), iterator_t<basic_borrowed_range<P>>>);
             assert((*result).first == 42);
         }
         {
             // Validate iterator + sentinel overload [found case]
-            move_only_range wrapped_pairs{pairs};
+            basic_borrowed_range wrapped_pairs{pairs};
             auto result = find_if_not(wrapped_pairs.begin(), wrapped_pairs.end(), equals(0), get_first);
-            STATIC_ASSERT(same_as<decltype(result), iterator_t<move_only_range<P>>>);
+            STATIC_ASSERT(same_as<decltype(result), iterator_t<basic_borrowed_range<P>>>);
             assert((*result).first == 42);
         }
         value = 0;
     }
     {
         // Validate range overload [not found case]
-        auto result = find_if_not(move_only_range{pairs}, equals(0), get_first);
-        STATIC_ASSERT(same_as<decltype(result), iterator_t<move_only_range<P>>>);
-        assert(result == move_only_range{pairs}.end());
+        auto result = find_if_not(basic_borrowed_range{pairs}, equals(0), get_first);
+        STATIC_ASSERT(same_as<decltype(result), iterator_t<basic_borrowed_range<P>>>);
+        assert(result == basic_borrowed_range{pairs}.end());
     }
     {
         // Validate iterator + sentinel overload [not found case]
-        move_only_range wrapped_pairs{pairs};
+        basic_borrowed_range wrapped_pairs{pairs};
         auto result = find_if_not(wrapped_pairs.begin(), wrapped_pairs.end(), equals(0), get_first);
-        STATIC_ASSERT(same_as<decltype(result), iterator_t<move_only_range<P>>>);
+        STATIC_ASSERT(same_as<decltype(result), iterator_t<basic_borrowed_range<P>>>);
         assert(result == wrapped_pairs.end());
     }
 }

--- a/tests/std/tests/P0896R4_ranges_alg_for_each/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_for_each/test.cpp
@@ -30,9 +30,9 @@ constexpr void smoke_test() {
 
     {
         auto pairs  = values;
-        auto result = for_each(move_only_range{pairs}, incr, get_first);
-        STATIC_ASSERT(same_as<decltype(result), for_each_result<iterator_t<move_only_range<P>>, decltype(incr)>>);
-        assert(result.in == move_only_range{pairs}.end());
+        auto result = for_each(basic_borrowed_range{pairs}, incr, get_first);
+        STATIC_ASSERT(same_as<decltype(result), for_each_result<iterator_t<basic_borrowed_range<P>>, decltype(incr)>>);
+        assert(result.in == basic_borrowed_range{pairs}.end());
         int some_value = 1729;
         result.fun(some_value);
         assert(some_value == 1730);
@@ -41,9 +41,9 @@ constexpr void smoke_test() {
     }
     {
         auto pairs = values;
-        move_only_range wrapped_pairs{pairs};
+        basic_borrowed_range wrapped_pairs{pairs};
         auto result = for_each(wrapped_pairs.begin(), wrapped_pairs.end(), incr, get_second);
-        STATIC_ASSERT(same_as<decltype(result), for_each_result<iterator_t<move_only_range<P>>, decltype(incr)>>);
+        STATIC_ASSERT(same_as<decltype(result), for_each_result<iterator_t<basic_borrowed_range<P>>, decltype(incr)>>);
         assert(result.in == wrapped_pairs.end());
         int some_value = 1729;
         result.fun(some_value);

--- a/tests/std/tests/P0896R4_ranges_alg_for_each_n/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_for_each_n/test.cpp
@@ -22,9 +22,9 @@ constexpr void smoke_test() {
     R pairs   = {{{0, 42}, {2, 42}, {4, 42}}};
     auto incr = [](auto& y) { ++y; };
 
-    move_only_range wrapped_pairs{pairs};
+    basic_borrowed_range wrapped_pairs{pairs};
     auto result = for_each_n(wrapped_pairs.begin(), ranges::distance(pairs), incr, get_first);
-    STATIC_ASSERT(same_as<decltype(result), for_each_n_result<iterator_t<move_only_range<P>>, decltype(incr)>>);
+    STATIC_ASSERT(same_as<decltype(result), for_each_n_result<iterator_t<basic_borrowed_range<P>>, decltype(incr)>>);
     assert(result.in == wrapped_pairs.end());
     int some_value = 1729;
     result.fun(some_value);

--- a/tests/std/tests/P0896R4_ranges_alg_is_sorted/env.lst
+++ b/tests/std/tests/P0896R4_ranges_alg_is_sorted/env.lst
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+RUNALL_INCLUDE ..\concepts_matrix.lst

--- a/tests/std/tests/P0896R4_ranges_alg_is_sorted/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_is_sorted/test.cpp
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Covers both ranges::is_sorted and ranges::is_sorted_until
+
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <concepts>
+#include <ranges>
+#include <utility>
+//
+#include <range_algorithm_support.hpp>
+
+using namespace std;
+
+// Validate dangling story
+STATIC_ASSERT(same_as<decltype(ranges::is_sorted_until(borrowed<false>{})), ranges::dangling>);
+STATIC_ASSERT(same_as<decltype(ranges::is_sorted_until(borrowed<true>{})), int*>);
+
+using P = pair<int, int>;
+
+struct instantiator {
+    static constexpr array<P, 8> pairs = {
+        P{0, 80}, P{1, 70}, P{2, 60}, P{3, 50}, P{4, 40}, P{5, 30}, P{6, 20}, P{7, 10}};
+
+    template <class Fwd>
+    static constexpr void call() {
+        constexpr auto N = static_cast<int>(pairs.size());
+        auto elements    = pairs;
+        const Fwd range{elements};
+        for (int offset = 0; offset < N; ++offset) {
+            const bool sorted = offset == 0;
+            assert(ranges::is_sorted(range) == sorted);
+            assert(ranges::is_sorted(range, ranges::less{}) == sorted);
+            assert(ranges::is_sorted(range, ranges::less{}, get_first) == sorted);
+
+            const auto addr = elements.data() + (N - offset);
+            assert(to_address(ranges::is_sorted_until(range).base()) == addr);
+            assert(to_address(ranges::is_sorted_until(range, ranges::less{}).base()) == addr);
+            assert(to_address(ranges::is_sorted_until(range, ranges::less{}, get_first).base()) == addr);
+
+            const auto next = ranges::next(ranges::begin(elements));
+            rotate(ranges::begin(elements), next, ranges::end(elements));
+        }
+    }
+};
+
+int main() {
+    STATIC_ASSERT((test_fwd<instantiator, const P>(), true));
+    test_fwd<instantiator, const P>();
+}

--- a/tests/std/tests/P0896R4_ranges_alg_is_sorted/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_is_sorted/test.cpp
@@ -9,7 +9,7 @@
 #include <concepts>
 #include <ranges>
 #include <utility>
-//
+
 #include <range_algorithm_support.hpp>
 
 using namespace std;

--- a/tests/std/tests/P0896R4_ranges_alg_is_sorted/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_is_sorted/test.cpp
@@ -20,10 +20,9 @@ STATIC_ASSERT(same_as<decltype(ranges::is_sorted_until(borrowed<true>{})), int*>
 
 using P = pair<int, int>;
 
-struct instantiator {
-    static constexpr array<P, 8> pairs = {
-        P{0, 80}, P{1, 70}, P{2, 60}, P{3, 50}, P{4, 40}, P{5, 30}, P{6, 20}, P{7, 10}};
+static constexpr array<P, 8> pairs = {P{0, 80}, P{1, 70}, P{2, 60}, P{3, 50}, P{4, 40}, P{5, 30}, P{6, 20}, P{7, 10}};
 
+struct range_overloads {
     template <class Fwd>
     static constexpr void call() {
         constexpr auto N = static_cast<int>(pairs.size());
@@ -46,7 +45,35 @@ struct instantiator {
     }
 };
 
+struct iterator_overloads {
+    template <class Fwd>
+    static constexpr void call() {
+        using ranges::begin, ranges::end;
+        constexpr auto N = static_cast<int>(pairs.size());
+        auto elements    = pairs;
+        const Fwd range{elements};
+        for (int offset = 0; offset < N; ++offset) {
+            const bool sorted = offset == 0;
+            assert(ranges::is_sorted(begin(range), end(range)) == sorted);
+            assert(ranges::is_sorted(begin(range), end(range), ranges::less{}) == sorted);
+            assert(ranges::is_sorted(begin(range), end(range), ranges::less{}, get_first) == sorted);
+
+            const auto addr = elements.data() + (N - offset);
+            assert(to_address(ranges::is_sorted_until(begin(range), end(range)).base()) == addr);
+            assert(to_address(ranges::is_sorted_until(begin(range), end(range), ranges::less{}).base()) == addr);
+            assert(to_address(ranges::is_sorted_until(begin(range), end(range), ranges::less{}, get_first).base())
+                   == addr);
+
+            const auto next = ranges::next(begin(elements));
+            rotate(begin(elements), next, end(elements));
+        }
+    }
+};
+
 int main() {
-    STATIC_ASSERT((test_fwd<instantiator, const P>(), true));
-    test_fwd<instantiator, const P>();
+    STATIC_ASSERT((test_fwd<range_overloads, const P>(), true));
+    test_fwd<range_overloads, const P>();
+
+    STATIC_ASSERT((test_fwd<iterator_overloads, const P>(), true));
+    test_fwd<iterator_overloads, const P>();
 }

--- a/tests/std/tests/P0896R4_ranges_alg_mismatch/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_mismatch/test.cpp
@@ -40,9 +40,9 @@ constexpr void smoke_test() {
     }
     {
         // Validate non-sized ranges
-        auto result = mismatch(move_only_range{x}, move_only_range{y}, equal_to{}, get_first, get_second);
-        using I1    = iterator_t<move_only_range<P const>>;
-        using I2    = iterator_t<move_only_range<std::pair<long, long> const>>;
+        auto result = mismatch(basic_borrowed_range{x}, basic_borrowed_range{y}, equal_to{}, get_first, get_second);
+        using I1    = iterator_t<basic_borrowed_range<P const>>;
+        using I2    = iterator_t<basic_borrowed_range<std::pair<long, long> const>>;
         STATIC_ASSERT(same_as<decltype(result), mismatch_result<I1, I2>>);
         assert((*result.in1 == P{4, 42}));
         assert((*result.in2 == std::pair<long, long>{13, 5}));
@@ -58,8 +58,8 @@ constexpr void smoke_test() {
     }
     {
         // Validate non-sized iterator + sentinel pairs
-        move_only_range wrapped_x{x};
-        move_only_range wrapped_y{y};
+        basic_borrowed_range wrapped_x{x};
+        basic_borrowed_range wrapped_y{y};
         auto result = mismatch(
             wrapped_x.begin(), wrapped_x.end(), wrapped_y.begin(), wrapped_y.end(), equal_to{}, get_first, get_second);
         using I1 = iterator_t<decltype(wrapped_x)>;

--- a/tests/std/tests/P0896R4_ranges_alg_move/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_move/test.cpp
@@ -35,31 +35,31 @@ constexpr void smoke_test() {
     int const input[] = {13, 53, 12435};
     {
         int output[] = {-2, -2, -2};
-        auto result  = move(move_only_range{input}, move_only_range{output}.begin());
+        auto result  = move(basic_borrowed_range{input}, basic_borrowed_range{output}.begin());
         STATIC_ASSERT(same_as<decltype(result),
-            move_result<iterator_t<move_only_range<int const>>, iterator_t<move_only_range<int>>>>);
-        assert(result.in == move_only_range{input}.end());
-        assert(result.out == move_only_range{output}.end());
+            move_result<iterator_t<basic_borrowed_range<int const>>, iterator_t<basic_borrowed_range<int>>>>);
+        assert(result.in == basic_borrowed_range{input}.end());
+        assert(result.out == basic_borrowed_range{output}.end());
         assert(ranges::equal(output, input));
     }
     {
         int output[] = {-2, -2, -2};
-        move_only_range wrapped_input{input};
-        auto result = move(wrapped_input.begin(), wrapped_input.end(), move_only_range{output}.begin());
+        basic_borrowed_range wrapped_input{input};
+        auto result = move(wrapped_input.begin(), wrapped_input.end(), basic_borrowed_range{output}.begin());
         STATIC_ASSERT(same_as<decltype(result),
-            move_result<iterator_t<move_only_range<int const>>, iterator_t<move_only_range<int>>>>);
+            move_result<iterator_t<basic_borrowed_range<int const>>, iterator_t<basic_borrowed_range<int>>>>);
         assert(result.in == wrapped_input.end());
-        assert(result.out == move_only_range{output}.end());
+        assert(result.out == basic_borrowed_range{output}.end());
         assert(ranges::equal(output, input));
     }
     {
         int_wrapper input1[3]        = {13, 55, 1234};
         int const expected_output[3] = {13, 55, 1234};
         int_wrapper actual_output[3] = {-2, -2, -2};
-        move_only_range wrapped_input{input1};
-        auto result = move(wrapped_input.begin(), wrapped_input.end(), move_only_range{actual_output}.begin());
+        basic_borrowed_range wrapped_input{input1};
+        auto result = move(wrapped_input.begin(), wrapped_input.end(), basic_borrowed_range{actual_output}.begin());
         assert(result.in == wrapped_input.end());
-        assert(result.out == move_only_range{actual_output}.end());
+        assert(result.out == basic_borrowed_range{actual_output}.end());
         for (int i = 0; i < 3; ++i) {
             assert(input1[i].val == -1);
             assert(actual_output[i].val == expected_output[i]);

--- a/tests/std/tests/P0896R4_ranges_alg_none_of/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_none_of/test.cpp
@@ -16,24 +16,24 @@ constexpr void smoke_test() {
     using ranges::none_of;
     constexpr std::array<std::pair<int, int>, 3> pairs = {{{0, 13}, {7, 13}, {4, 13}}};
 
-    assert(!none_of(move_only_range{pairs}, is_even, get_first));
-    assert(none_of(move_only_range{pairs}, is_even, get_second));
-    assert(!none_of(move_only_range{pairs}, is_odd, get_first));
-    assert(!none_of(move_only_range{pairs}, is_odd, get_second));
+    assert(!none_of(basic_borrowed_range{pairs}, is_even, get_first));
+    assert(none_of(basic_borrowed_range{pairs}, is_even, get_second));
+    assert(!none_of(basic_borrowed_range{pairs}, is_odd, get_first));
+    assert(!none_of(basic_borrowed_range{pairs}, is_odd, get_second));
     {
-        move_only_range wrapped_pairs{pairs};
+        basic_borrowed_range wrapped_pairs{pairs};
         assert(!none_of(wrapped_pairs.begin(), wrapped_pairs.end(), is_even, get_first));
     }
     {
-        move_only_range wrapped_pairs{pairs};
+        basic_borrowed_range wrapped_pairs{pairs};
         assert(none_of(wrapped_pairs.begin(), wrapped_pairs.end(), is_even, get_second));
     }
     {
-        move_only_range wrapped_pairs{pairs};
+        basic_borrowed_range wrapped_pairs{pairs};
         assert(!none_of(wrapped_pairs.begin(), wrapped_pairs.end(), is_odd, get_first));
     }
     {
-        move_only_range wrapped_pairs{pairs};
+        basic_borrowed_range wrapped_pairs{pairs};
         assert(!none_of(wrapped_pairs.begin(), wrapped_pairs.end(), is_odd, get_second));
     }
 }

--- a/tests/std/tests/P0896R4_ranges_test_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_test_machinery/test.cpp
@@ -378,11 +378,10 @@ STATIC_ASSERT(range_test<contiguous_iterator_tag, int, Sized::yes, CanDifference
 STATIC_ASSERT(range_test<contiguous_iterator_tag, int, Sized::yes, CanDifference::yes, Common::yes, CanCompare::yes,
     ProxyRef::no>());
 
-// Validate move_only_range
-STATIC_ASSERT(ranges::input_range<move_only_range<int>>);
-STATIC_ASSERT(!ranges::forward_range<move_only_range<int>>);
-STATIC_ASSERT(movable<move_only_range<int>>);
-STATIC_ASSERT(!copyable<move_only_range<int>>);
+// Validate basic_borrowed_range
+STATIC_ASSERT(ranges::input_range<basic_borrowed_range<int>>);
+STATIC_ASSERT(!ranges::forward_range<basic_borrowed_range<int>>);
+STATIC_ASSERT(!movable<basic_borrowed_range<int>>);
 
 struct instantiate {
     template <class Range1, class Range2>


### PR DESCRIPTION
Partially addresses #39.

(Note: #914, #915, and #916 contain identical changes to `<range_algorithm_support.hpp>`.)