### PR TITLE
Implement std::permutable and std::sortable

### DIFF
--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -1088,6 +1088,17 @@ concept indirectly_comparable =
     indirect_binary_predicate<_Rel,
         projected<_It1, _Proj1>,
         projected<_It2, _Proj2>>;
+
+// CONCEPT permutable
+template <class _It>
+concept permutable = forward_iterator<_It>
+    && indirectly_movable_storable<_It, _It>
+    && indirectly_swappable<_It, _It>;
+
+// CONCEPT sortable
+namespace ranges { struct less; }
+template <class _It, class _Pr = ranges::less, class _Proj = identity>
+concept sortable = permutable<_It> && indirect_strict_weak_order<_Pr, projected<_It, _Proj>>;
 // clang-format on
 
 // ALIAS TEMPLATE _Iter_ref_t

--- a/tests/std/tests/P0896R4_ranges_algorithm_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_algorithm_machinery/test.cpp
@@ -592,30 +592,32 @@ namespace sortable_test {
     using ranges::less;
     using std::identity, std::indirect_strict_weak_order, std::permutable, std::projected, std::sortable;
 
-    {
-        using I = int const*; // not permutable
-        using C = less;
-        using P = identity;
-        STATIC_ASSERT(!permutable<I>);
-        STATIC_ASSERT(indirect_strict_weak_order<C, projected<I, P>>);
-        STATIC_ASSERT(!sortable<I, C, P>);
-    }
+    void test() {
+        {
+            using I = int const*; // not permutable
+            using C = less;
+            using P = identity;
+            STATIC_ASSERT(!permutable<I>);
+            STATIC_ASSERT(indirect_strict_weak_order<C, projected<I, P>>);
+            STATIC_ASSERT(!sortable<I, C, P>);
+        }
 
-    {
-        using I = int*;
-        using C = void; // not an indirect_strict_weak_order
-        using P = identity;
-        STATIC_ASSERT(permutable<I>);
-        STATIC_ASSERT(!indirect_strict_weak_order<C, projected<I, P>>);
-        STATIC_ASSERT(!sortable<I, C, P>);
-    }
+        {
+            using I = int*;
+            using C = void; // not an indirect_strict_weak_order
+            using P = identity;
+            STATIC_ASSERT(permutable<I>);
+            STATIC_ASSERT(!indirect_strict_weak_order<C, projected<I, P>>);
+            STATIC_ASSERT(!sortable<I, C, P>);
+        }
 
-    {
-        using I = int*;
-        using C = less;
-        using P = identity;
-        STATIC_ASSERT(permutable<I>);
-        STATIC_ASSERT(indirect_strict_weak_order<C, projected<I, P>>);
-        STATIC_ASSERT(sortable<I, C, P>);
+        {
+            using I = int*;
+            using C = less;
+            using P = identity;
+            STATIC_ASSERT(permutable<I>);
+            STATIC_ASSERT(indirect_strict_weak_order<C, projected<I, P>>);
+            STATIC_ASSERT(sortable<I, C, P>);
+        }
     }
 } // namespace sortable_test

--- a/tests/std/tests/P0896R4_ranges_algorithm_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_algorithm_machinery/test.cpp
@@ -533,3 +533,76 @@ namespace result_test {
     STATIC_ASSERT(test_convertible_3<in_in_out_result>());
     STATIC_ASSERT(test_convertible_3<in_out_out_result>());
 } // namespace result_test
+
+namespace permutable_test {
+    using std::forward_iterator, std::indirectly_movable_storable, std::indirectly_swappable, std::permutable;
+
+    template <int I>
+    struct archetype {
+        using value_type      = int;
+        using difference_type = int;
+
+        struct proxy {
+            proxy()             = default;
+            proxy(proxy const&) = delete;
+            proxy& operator=(proxy const&) = delete;
+
+            operator int() const;
+            // 1: not reflexively indirectly_movable_storable
+            void operator=(int) const requires(I != 1);
+        };
+
+        proxy operator*() const;
+
+        archetype& operator++();
+        archetype operator++(int);
+
+        // 0: not forward_iterator (input only)
+        bool operator==(archetype const&) const requires(I != 0) = default;
+
+        friend int iter_move(archetype const&) {
+            return 42;
+        }
+        friend void iter_swap(archetype const&, archetype const&) {}
+
+        // Ideally we'd have a "not reflexively indirectly_swappable" case as well, but there's no way for a class to
+        // satisfy indirectly_movable_storable<T, T> without satisfying indirectly_swappable<T, T> thanks to N4861
+        // [iterator.cust.swap]/4.3. permutable requires indirectly_swappable<T, T> only to ensure that a user type
+        // doesn't define an iter_swap overload that doesn't meet the semantic requirements.
+    };
+    STATIC_ASSERT(std::input_iterator<archetype<0>>);
+    STATIC_ASSERT(!std::forward_iterator<archetype<0>>);
+    STATIC_ASSERT(indirectly_movable_storable<archetype<0>, archetype<0>>);
+    STATIC_ASSERT(indirectly_swappable<archetype<0>, archetype<0>>);
+
+    STATIC_ASSERT(std::forward_iterator<archetype<1>>);
+    STATIC_ASSERT(!indirectly_movable_storable<archetype<1>, archetype<1>>);
+    STATIC_ASSERT(indirectly_swappable<archetype<1>, archetype<1>>);
+
+    STATIC_ASSERT(std::forward_iterator<archetype<2>>);
+    STATIC_ASSERT(indirectly_movable_storable<archetype<2>, archetype<2>>);
+    STATIC_ASSERT(indirectly_swappable<archetype<2>, archetype<2>>);
+
+    STATIC_ASSERT(!permutable<archetype<0>>);
+    STATIC_ASSERT(!permutable<archetype<1>>);
+    STATIC_ASSERT(permutable<archetype<2>>);
+} // namespace permutable_test
+
+namespace sortable_test {
+    using ranges::less;
+    using std::identity, std::indirect_strict_weak_order, std::permutable, std::projected, std::sortable;
+
+    // not permutable
+    STATIC_ASSERT(!permutable<int const*>);
+    STATIC_ASSERT(indirect_strict_weak_order<less, projected<int const*, identity>>);
+    STATIC_ASSERT(!sortable<int const*, less, identity>);
+
+    // not indirect_strict_weak_order
+    STATIC_ASSERT(permutable<int*>);
+    STATIC_ASSERT(!indirect_strict_weak_order<void, projected<int const*, identity>>);
+    STATIC_ASSERT(!sortable<int*, int, identity>);
+
+    STATIC_ASSERT(permutable<int*>);
+    STATIC_ASSERT(indirect_strict_weak_order<less, projected<int*, identity>>);
+    STATIC_ASSERT(sortable<int*, less, identity>);
+} // namespace sortable_test

--- a/tests/std/tests/P0896R4_ranges_algorithm_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_algorithm_machinery/test.cpp
@@ -535,7 +535,8 @@ namespace result_test {
 } // namespace result_test
 
 namespace permutable_test {
-    using std::forward_iterator, std::indirectly_movable_storable, std::indirectly_swappable, std::permutable;
+    using std::forward_iterator, std::input_iterator, std::indirectly_movable_storable, std::indirectly_swappable,
+        std::permutable;
 
     template <int I>
     struct archetype {
@@ -548,7 +549,7 @@ namespace permutable_test {
             proxy& operator=(proxy const&) = delete;
 
             operator int() const;
-            // 1: not reflexively indirectly_movable_storable
+            // 1: not indirectly_movable_storable<archetype, archetype>
             void operator=(int) const requires(I != 1);
         };
 
@@ -567,19 +568,19 @@ namespace permutable_test {
 
         // Ideally we'd have a "not reflexively indirectly_swappable" case as well, but there's no way for a class to
         // satisfy indirectly_movable_storable<T, T> without satisfying indirectly_swappable<T, T> thanks to N4861
-        // [iterator.cust.swap]/4.3. permutable requires indirectly_swappable<T, T> only to forbid a user type to define
-        // an iter_swap overload that doesn't meet the semantic requirements.
+        // [iterator.cust.swap]/4.3. permutable requires indirectly_swappable<T, T> only to forbid a user type from
+        // defining an iter_swap overload that doesn't meet the semantic requirements.
     };
-    STATIC_ASSERT(std::input_iterator<archetype<0>>);
-    STATIC_ASSERT(!std::forward_iterator<archetype<0>>);
+    STATIC_ASSERT(input_iterator<archetype<0>>);
+    STATIC_ASSERT(!forward_iterator<archetype<0>>);
     STATIC_ASSERT(indirectly_movable_storable<archetype<0>, archetype<0>>);
     STATIC_ASSERT(indirectly_swappable<archetype<0>, archetype<0>>);
 
-    STATIC_ASSERT(std::forward_iterator<archetype<1>>);
+    STATIC_ASSERT(forward_iterator<archetype<1>>);
     STATIC_ASSERT(!indirectly_movable_storable<archetype<1>, archetype<1>>);
     STATIC_ASSERT(indirectly_swappable<archetype<1>, archetype<1>>);
 
-    STATIC_ASSERT(std::forward_iterator<archetype<2>>);
+    STATIC_ASSERT(forward_iterator<archetype<2>>);
     STATIC_ASSERT(indirectly_movable_storable<archetype<2>, archetype<2>>);
     STATIC_ASSERT(indirectly_swappable<archetype<2>, archetype<2>>);
 

--- a/tests/std/tests/P0896R4_ranges_algorithm_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_algorithm_machinery/test.cpp
@@ -567,8 +567,8 @@ namespace permutable_test {
 
         // Ideally we'd have a "not reflexively indirectly_swappable" case as well, but there's no way for a class to
         // satisfy indirectly_movable_storable<T, T> without satisfying indirectly_swappable<T, T> thanks to N4861
-        // [iterator.cust.swap]/4.3. permutable requires indirectly_swappable<T, T> only to ensure that a user type
-        // doesn't define an iter_swap overload that doesn't meet the semantic requirements.
+        // [iterator.cust.swap]/4.3. permutable requires indirectly_swappable<T, T> only to forbid a user type to define
+        // an iter_swap overload that doesn't meet the semantic requirements.
     };
     STATIC_ASSERT(std::input_iterator<archetype<0>>);
     STATIC_ASSERT(!std::forward_iterator<archetype<0>>);
@@ -592,17 +592,30 @@ namespace sortable_test {
     using ranges::less;
     using std::identity, std::indirect_strict_weak_order, std::permutable, std::projected, std::sortable;
 
-    // not permutable
-    STATIC_ASSERT(!permutable<int const*>);
-    STATIC_ASSERT(indirect_strict_weak_order<less, projected<int const*, identity>>);
-    STATIC_ASSERT(!sortable<int const*, less, identity>);
+    {
+        using I = int const*; // not permutable
+        using C = less;
+        using P = identity;
+        STATIC_ASSERT(!permutable<I>);
+        STATIC_ASSERT(indirect_strict_weak_order<C, projected<I, P>>);
+        STATIC_ASSERT(!sortable<I, C, P>);
+    }
 
-    // not indirect_strict_weak_order
-    STATIC_ASSERT(permutable<int*>);
-    STATIC_ASSERT(!indirect_strict_weak_order<void, projected<int const*, identity>>);
-    STATIC_ASSERT(!sortable<int*, int, identity>);
+    {
+        using I = int*;
+        using C = void; // not an indirect_strict_weak_order
+        using P = identity;
+        STATIC_ASSERT(permutable<I>);
+        STATIC_ASSERT(!indirect_strict_weak_order<C, projected<I, P>>);
+        STATIC_ASSERT(!sortable<I, C, P>);
+    }
 
-    STATIC_ASSERT(permutable<int*>);
-    STATIC_ASSERT(indirect_strict_weak_order<less, projected<int*, identity>>);
-    STATIC_ASSERT(sortable<int*, less, identity>);
+    {
+        using I = int*;
+        using C = less;
+        using P = identity;
+        STATIC_ASSERT(permutable<I>);
+        STATIC_ASSERT(indirect_strict_weak_order<C, projected<I, P>>);
+        STATIC_ASSERT(sortable<I, C, P>);
+    }
 } // namespace sortable_test


### PR DESCRIPTION
Yanked from my heap algorithm branch to merge quickly and unblock ahana's work on `reverse`.