### PR TITLE
Modernize ranges::copy

### DIFF
--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -1525,8 +1525,10 @@ namespace ranges {
         template <input_range _Rng, weakly_incrementable _Out>
             requires indirectly_copyable<iterator_t<_Rng>, _Out>
         constexpr copy_result<borrowed_iterator_t<_Rng>, _Out> operator()(_Rng&& _Range, _Out _Result) const {
-            auto _UResult = _Copy_unchecked(_Ubegin(_Range), _Uend(_Range), _STD move(_Result));
-            return {_Rewrap_iterator(_Range, _STD move(_UResult.in)), _STD move(_UResult.out)};
+            auto _First   = _RANGES begin(_Range);
+            auto _UResult = _Copy_unchecked(_Get_unwrapped(_STD move(_First)), _Uend(_Range), _STD move(_Result));
+            _Seek_wrapped(_First, _STD move(_UResult.in));
+            return {_STD move(_First), _STD move(_UResult.out)};
         }
         // clang-format on
 

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -1523,10 +1523,10 @@ namespace ranges {
         }
 
         template <input_range _Rng, weakly_incrementable _Out>
-        //    requires indirectly_copyable<iterator_t<_Rng>, _Out>
+            requires indirectly_copyable<iterator_t<_Rng>, _Out>
         constexpr copy_result<borrowed_iterator_t<_Rng>, _Out> operator()(_Rng&& _Range, _Out _Result) const {
-            auto _UResult = _Copy_unchecked(_Ubegin(_Range), _Uend(_Range), _STD move(_Result));
             auto _First   = _RANGES begin(_Range);
+            auto _UResult = _Copy_unchecked(_Ubegin(_Range), _Uend(_Range), _STD move(_Result));
             _Seek_wrapped(_First, _STD move(_UResult.in));
             return {_STD move(_First), _STD move(_UResult.out)};
         }

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -1508,7 +1508,7 @@ namespace ranges {
 
     // VARIABLE ranges::copy
     // clang-format off
-    template <input_iterator _It, sentinel_for<It> _Se, weakly_incrementable _Out>
+    template <input_iterator _It, sentinel_for<_It> _Se, weakly_incrementable _Out>
         requires indirectly_copyable<_It, _Out>
     _NODISCARD constexpr copy_result<_It, _Out> _Copy_unchecked(_It _First, const _Se _Last, _Out _Result) {
         for (; _First != _Last; ++_First, (void) ++_Result) {

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -1525,10 +1525,8 @@ namespace ranges {
         template <input_range _Rng, weakly_incrementable _Out>
             requires indirectly_copyable<iterator_t<_Rng>, _Out>
         constexpr copy_result<borrowed_iterator_t<_Rng>, _Out> operator()(_Rng&& _Range, _Out _Result) const {
-            auto _First   = _RANGES begin(_Range);
             auto _UResult = _Copy_unchecked(_Ubegin(_Range), _Uend(_Range), _STD move(_Result));
-            _Seek_wrapped(_First, _STD move(_UResult.in));
-            return {_STD move(_First), _STD move(_UResult.out)};
+            return {_Rewrap_iterator(_Range, _STD move(_UResult.in)), _STD move(_UResult.out)};
         }
         // clang-format on
 

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -1516,23 +1516,25 @@ namespace ranges {
             requires indirectly_copyable<_It, _Out>
         constexpr copy_result<_It, _Out> operator()(_It _First, _Se _Last, _Out _Result) const {
             _Adl_verify_range(_First, _Last);
-            auto _Res = _Copy_unchecked(_Get_unwrapped(_STD move(_First)), _Get_unwrapped(_STD move(_Last)), _STD move(_Result));
-            _Seek_wrapped(_First, _STD move(_Res.in));
-            return {_STD move(_First), _STD move(_Res.out)};
+            auto _UResult = _Copy_unchecked(
+                _Get_unwrapped(_STD move(_First)), _Get_unwrapped(_STD move(_Last)), _STD move(_Result));
+            _Seek_wrapped(_First, _STD move(_UResult.in));
+            return {_STD move(_First), _STD move(_UResult.out)};
         }
 
         template <input_range _Rng, weakly_incrementable _Out>
-            requires indirectly_copyable<iterator_t<_Rng>, _Out>
+        //    requires indirectly_copyable<iterator_t<_Rng>, _Out>
         constexpr copy_result<borrowed_iterator_t<_Rng>, _Out> operator()(_Rng&& _Range, _Out _Result) const {
-            auto _Res = _Copy_unchecked(_Ubegin(_Range), _Uend(_Range), _STD move(_Result));
-            auto _First = _RANGES begin(_Range);
-            _Seek_wrapped(_First, _STD move(_Res.in));
-            return {_STD move(_First), _STD move(_Res.out)};
+            auto _UResult = _Copy_unchecked(_Ubegin(_Range), _Uend(_Range), _STD move(_Result));
+            auto _First   = _RANGES begin(_Range);
+            _Seek_wrapped(_First, _STD move(_UResult.in));
+            return {_STD move(_First), _STD move(_UResult.out)};
         }
         // clang-format on
+
     private:
         template <class _It, class _Se, class _Out>
-        _NODISCARD constexpr copy_result<_It, _Out> _Copy_unchecked(_It _First, _Se _Last, _Out _Result) const {
+        _NODISCARD static constexpr copy_result<_It, _Out> _Copy_unchecked(_It _First, const _Se _Last, _Out _Result) {
             _STL_INTERNAL_STATIC_ASSERT(input_iterator<_It>);
             _STL_INTERNAL_STATIC_ASSERT(sentinel_for<_Se, _It>);
             _STL_INTERNAL_STATIC_ASSERT(weakly_incrementable<_Out>);
@@ -1541,6 +1543,7 @@ namespace ranges {
             for (; _First != _Last; ++_First, (void) ++_Result) {
                 *_Result = *_First;
             }
+
             return {_STD move(_First), _STD move(_Result)};
         }
     };

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -1533,6 +1533,11 @@ namespace ranges {
     private:
         template <class _It, class _Se, class _Out>
         _NODISCARD constexpr copy_result<_It, _Out> _Copy_unchecked(_It _First, _Se _Last, _Out _Result) const {
+            _STL_INTERNAL_STATIC_ASSERT(input_iterator<_It>);
+            _STL_INTERNAL_STATIC_ASSERT(sentinel_for<_Se, _It>);
+            _STL_INTERNAL_STATIC_ASSERT(weakly_incrementable<_Out>);
+            _STL_INTERNAL_STATIC_ASSERT(indirectly_copyable<_It, _Out>);
+
             for (; _First != _Last; ++_First, (void) ++_Result) {
                 *_Result = *_First;
             }

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -1507,6 +1507,18 @@ namespace ranges {
     using copy_result = in_out_result<_In, _Out>;
 
     // VARIABLE ranges::copy
+    // clang-format off
+    template <input_iterator _It, sentinel_for<It> _Se, weakly_incrementable _Out>
+        requires indirectly_copyable<_It, _Out>
+    _NODISCARD constexpr copy_result<_It, _Out> _Copy_unchecked(_It _First, const _Se _Last, _Out _Result) {
+        for (; _First != _Last; ++_First, (void) ++_Result) {
+            *_Result = *_First;
+        }
+
+        return {_STD move(_First), _STD move(_Result)};
+    }
+    // clang-format on
+
     class _Copy_fn : private _Not_quite_object {
     public:
         using _Not_quite_object::_Not_quite_object;
@@ -1516,7 +1528,7 @@ namespace ranges {
             requires indirectly_copyable<_It, _Out>
         constexpr copy_result<_It, _Out> operator()(_It _First, _Se _Last, _Out _Result) const {
             _Adl_verify_range(_First, _Last);
-            auto _UResult = _Copy_unchecked(
+            auto _UResult = _RANGES _Copy_unchecked(
                 _Get_unwrapped(_STD move(_First)), _Get_unwrapped(_STD move(_Last)), _STD move(_Result));
             _Seek_wrapped(_First, _STD move(_UResult.in));
             return {_STD move(_First), _STD move(_UResult.out)};
@@ -1526,26 +1538,11 @@ namespace ranges {
             requires indirectly_copyable<iterator_t<_Rng>, _Out>
         constexpr copy_result<borrowed_iterator_t<_Rng>, _Out> operator()(_Rng&& _Range, _Out _Result) const {
             auto _First   = _RANGES begin(_Range);
-            auto _UResult = _Copy_unchecked(_Get_unwrapped(_STD move(_First)), _Uend(_Range), _STD move(_Result));
+            auto _UResult = _RANGES _Copy_unchecked(_Get_unwrapped(_STD move(_First)), _Uend(_Range), _STD move(_Result));
             _Seek_wrapped(_First, _STD move(_UResult.in));
             return {_STD move(_First), _STD move(_UResult.out)};
         }
         // clang-format on
-
-    private:
-        template <class _It, class _Se, class _Out>
-        _NODISCARD static constexpr copy_result<_It, _Out> _Copy_unchecked(_It _First, const _Se _Last, _Out _Result) {
-            _STL_INTERNAL_STATIC_ASSERT(input_iterator<_It>);
-            _STL_INTERNAL_STATIC_ASSERT(sentinel_for<_Se, _It>);
-            _STL_INTERNAL_STATIC_ASSERT(weakly_incrementable<_Out>);
-            _STL_INTERNAL_STATIC_ASSERT(indirectly_copyable<_It, _Out>);
-
-            for (; _First != _Last; ++_First, (void) ++_Result) {
-                *_Result = *_First;
-            }
-
-            return {_STD move(_First), _STD move(_Result)};
-        }
     };
 
     inline constexpr _Copy_fn copy{_Not_quite_object::_Construct_tag{}};

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -1516,22 +1516,28 @@ namespace ranges {
             requires indirectly_copyable<_It, _Out>
         constexpr copy_result<_It, _Out> operator()(_It _First, _Se _Last, _Out _Result) const {
             _Adl_verify_range(_First, _Last);
-            auto _UFirst      = _Get_unwrapped(_STD move(_First));
-            const auto _ULast = _Get_unwrapped(_STD move(_Last));
-            for (; _UFirst != _ULast; ++_UFirst, (void) ++_Result) {
-                *_Result = *_UFirst;
-            }
-
-            _Seek_wrapped(_First, _STD move(_UFirst));
-            return {_STD move(_First), _STD move(_Result)};
+            auto _Res = _Copy_unchecked(_Get_unwrapped(_STD move(_First)), _Get_unwrapped(_STD move(_Last)), _STD move(_Result));
+            _Seek_wrapped(_First, _STD move(_Res.in));
+            return {_STD move(_First), _STD move(_Res.out)};
         }
 
         template <input_range _Rng, weakly_incrementable _Out>
             requires indirectly_copyable<iterator_t<_Rng>, _Out>
         constexpr copy_result<borrowed_iterator_t<_Rng>, _Out> operator()(_Rng&& _Range, _Out _Result) const {
-            return (*this)(_RANGES begin(_Range), _RANGES end(_Range), _STD move(_Result));
+            auto _Res = _Copy_unchecked(_Ubegin(_Range), _Uend(_Range), _STD move(_Result));
+            auto _First = _RANGES begin(_Range);
+            _Seek_wrapped(_First, _STD move(_Res.in));
+            return {_STD move(_First), _STD move(_Res.out)};
         }
         // clang-format on
+    private:
+        template <class _It, class _Se, class _Out>
+        _NODISCARD constexpr copy_result<_It, _Out> _Copy_unchecked(_It _First, _Se _Last, _Out _Result) const {
+            for (; _First != _Last; ++_First, (void) ++_Result) {
+                *_Result = *_First;
+            }
+            return {_STD move(_First), _STD move(_Result)};
+        }
     };
 
     inline constexpr _Copy_fn copy{_Not_quite_object::_Construct_tag{}};

--- a/tests/std/tests/P0896R4_ranges_alg_copy/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_copy/test.cpp
@@ -9,8 +9,9 @@
 
 #include <range_algorithm_support.hpp>
 
+using namespace std;
+using same_as;
 using ranges::copy, ranges::copy_result, ranges::iterator_t;
-using std::same_as;
 
 // Validate that copy_result aliases in_out_result
 STATIC_ASSERT(same_as<copy_result<int, double>, ranges::in_out_result<int, double>>);
@@ -40,15 +41,13 @@ struct instantiator {
             auto result = copy(wrapped_input, Write{output});
             STATIC_ASSERT(same_as<decltype(result), copy_result<iterator_t<In>, Write>>);
             assert(result.in == wrapped_input.end());
-            if constexpr (std::equality_comparable<Write>) {
-                assert(result.out == Write{output + 3});
-            }
+            assert(result.out.base() == output + 3);
             assert(ranges::equal(output, input));
         }
     }
 };
 
 int main() {
-    STATIC_ASSERT((test_in_write<instantiator, const int, int>(), true));
-    test_in_write<instantiator, const int, int>();
+    STATIC_ASSERT((test_in_write<instantiator, int const, int>(), true));
+    test_in_write<instantiator, int const, int>();
 }

--- a/tests/std/tests/P0896R4_ranges_alg_copy/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_copy/test.cpp
@@ -22,6 +22,7 @@ STATIC_ASSERT(same_as<decltype(copy(borrowed<true>{}, static_cast<int*>(nullptr)
 
 struct instantiator {
     static constexpr int input[3] = {13, 42, 1729};
+
     template <class In, class Write>
     static constexpr void call() {
         { // Validate iterator + sentinel overload

--- a/tests/std/tests/P0896R4_ranges_alg_copy/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_copy/test.cpp
@@ -9,51 +9,47 @@
 
 #include <range_algorithm_support.hpp>
 
-constexpr void smoke_test() {
-    using ranges::copy, ranges::copy_result, ranges::iterator_t;
-    using std::same_as;
+using ranges::copy, ranges::copy_result, ranges::iterator_t;
+using std::same_as;
 
-    // Validate that copy_result aliases in_out_result
-    STATIC_ASSERT(same_as<copy_result<int, double>, ranges::in_out_result<int, double>>);
+// Validate that copy_result aliases in_out_result
+STATIC_ASSERT(same_as<copy_result<int, double>, ranges::in_out_result<int, double>>);
 
-    // Validate dangling story
-    STATIC_ASSERT(
-        same_as<decltype(copy(borrowed<false>{}, static_cast<int*>(nullptr))), copy_result<ranges::dangling, int*>>);
-    STATIC_ASSERT(same_as<decltype(copy(borrowed<true>{}, static_cast<int*>(nullptr))), copy_result<int*, int*>>);
-
-    int const input[] = {13, 42, 1729};
-    { // Validate range overload
-        int output[] = {-1, -1, -1};
-        auto result  = copy(basic_borrowed_range{input}, basic_borrowed_range{output}.begin());
-        STATIC_ASSERT(same_as<decltype(result),
-            copy_result<iterator_t<basic_borrowed_range<int const>>, iterator_t<basic_borrowed_range<int>>>>);
-        assert(result.in == basic_borrowed_range{input}.end());
-        assert(result.out == basic_borrowed_range{output}.end());
-        assert(ranges::equal(output, input));
-    }
-    { // Validate iterator + sentinel overload
-        int output[] = {-1, -1, -1};
-        basic_borrowed_range wrapped_input{input};
-        auto result = copy(wrapped_input.begin(), wrapped_input.end(), basic_borrowed_range{output}.begin());
-        STATIC_ASSERT(same_as<decltype(result),
-            copy_result<iterator_t<basic_borrowed_range<int const>>, iterator_t<basic_borrowed_range<int>>>>);
-        assert(result.in == wrapped_input.end());
-        assert(result.out == basic_borrowed_range{output}.end());
-        assert(ranges::equal(output, input));
-    }
-}
-
-int main() {
-    STATIC_ASSERT((smoke_test(), true));
-    smoke_test();
-}
+// Validate dangling story
+STATIC_ASSERT(
+    same_as<decltype(copy(borrowed<false>{}, static_cast<int*>(nullptr))), copy_result<ranges::dangling, int*>>);
+STATIC_ASSERT(same_as<decltype(copy(borrowed<true>{}, static_cast<int*>(nullptr))), copy_result<int*, int*>>);
 
 struct instantiator {
-    template <class In, class Out>
-    static void call(In&& in = {}, Out out = {}) {
-        (void) ranges::copy(in, std::move(out));
-        (void) ranges::copy(ranges::begin(in), ranges::end(in), std::move(out));
+    static constexpr int input[3] = {13, 42, 1729};
+    template <class In, class Write>
+    static constexpr void call() {
+        { // Validate iterator + sentinel overload
+            int output[3] = {-1, -1, -1};
+            In wrapped_input{input};
+            auto result = copy(wrapped_input.begin(), wrapped_input.end(), Write{output});
+            STATIC_ASSERT(same_as<decltype(result), copy_result<iterator_t<In>, Write>>);
+            assert(result.in == wrapped_input.end());
+            if constexpr (std::equality_comparable<Write>) {
+                assert(result.out == Write{output + 3});
+            }
+            assert(ranges::equal(output, input));
+        }
+        { // Validate range overload
+            int output[3] = {-1, -1, -1};
+            In wrapped_input{input};
+            auto result = copy(wrapped_input, Write{output});
+            STATIC_ASSERT(same_as<decltype(result), copy_result<iterator_t<In>, Write>>);
+            assert(result.in == wrapped_input.end());
+            if constexpr (std::equality_comparable<Write>) {
+                assert(result.out == Write{output + 3});
+            }
+            assert(ranges::equal(output, input));
+        }
     }
 };
 
-template void test_in_write<instantiator, const int, int>();
+int main() {
+    STATIC_ASSERT((test_in_write<instantiator, const int, int>(), true));
+    test_in_write<instantiator, const int, int>();
+}

--- a/tests/std/tests/P0896R4_ranges_alg_copy/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_copy/test.cpp
@@ -31,9 +31,7 @@ struct instantiator {
             auto result = copy(wrapped_input.begin(), wrapped_input.end(), Write{output});
             STATIC_ASSERT(same_as<decltype(result), copy_result<iterator_t<In>, Write>>);
             assert(result.in == wrapped_input.end());
-            if constexpr (std::equality_comparable<Write>) {
-                assert(result.out == Write{output + 3});
-            }
+            assert(result.out.base() == output + 3);
             assert(ranges::equal(output, input));
         }
         { // Validate range overload

--- a/tests/std/tests/P0896R4_ranges_alg_copy/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_copy/test.cpp
@@ -12,18 +12,18 @@
 using namespace std;
 
 // Validate that copy_result aliases in_out_result
-STATIC_ASSERT(same_as<copy_result<int, double>, ranges::in_out_result<int, double>>);
+STATIC_ASSERT(same_as<ranges::copy_result<int, double>, ranges::in_out_result<int, double>>);
 
 // Validate dangling story
 STATIC_ASSERT(same_as<decltype(ranges::copy(borrowed<false>{}, static_cast<int*>(nullptr))),
     ranges::copy_result<ranges::dangling, int*>>);
 STATIC_ASSERT(
-    same_as<decltype(cranges::opy(borrowed<true>{}, static_cast<int*>(nullptr))), ranges::copy_result<int*, int*>>);
+    same_as<decltype(ranges::copy(borrowed<true>{}, static_cast<int*>(nullptr))), ranges::copy_result<int*, int*>>);
 
 struct instantiator {
     static constexpr int input[3] = {13, 42, 1729};
 
-    template <class Read, class Write>
+    template <ranges::input_range Read, indirectly_writable<ranges::range_reference_t<Read>> Write>
     static constexpr void call() {
         using ranges::copy, ranges::copy_result, ranges::iterator_t;
         { // Validate iterator + sentinel overload

--- a/tests/std/tests/P0896R4_ranges_alg_copy/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_copy/test.cpp
@@ -10,38 +10,40 @@
 #include <range_algorithm_support.hpp>
 
 using namespace std;
-using same_as;
-using ranges::copy, ranges::copy_result, ranges::iterator_t;
 
 // Validate that copy_result aliases in_out_result
 STATIC_ASSERT(same_as<copy_result<int, double>, ranges::in_out_result<int, double>>);
 
 // Validate dangling story
+STATIC_ASSERT(same_as<decltype(ranges::copy(borrowed<false>{}, static_cast<int*>(nullptr))),
+    ranges::copy_result<ranges::dangling, int*>>);
 STATIC_ASSERT(
-    same_as<decltype(copy(borrowed<false>{}, static_cast<int*>(nullptr))), copy_result<ranges::dangling, int*>>);
-STATIC_ASSERT(same_as<decltype(copy(borrowed<true>{}, static_cast<int*>(nullptr))), copy_result<int*, int*>>);
+    same_as<decltype(cranges::opy(borrowed<true>{}, static_cast<int*>(nullptr))), ranges::copy_result<int*, int*>>);
 
 struct instantiator {
     static constexpr int input[3] = {13, 42, 1729};
 
-    template <class In, class Write>
+    template <class Read, class Write>
     static constexpr void call() {
+        using ranges::copy, ranges::copy_result, ranges::iterator_t;
         { // Validate iterator + sentinel overload
             int output[3] = {-1, -1, -1};
-            In wrapped_input{input};
+            Read wrapped_input{input};
+
             auto result = copy(wrapped_input.begin(), wrapped_input.end(), Write{output});
-            STATIC_ASSERT(same_as<decltype(result), copy_result<iterator_t<In>, Write>>);
+            STATIC_ASSERT(same_as<decltype(result), copy_result<iterator_t<Read>, Write>>);
             assert(result.in == wrapped_input.end());
-            assert(result.out.base() == output + 3);
+            assert(result.out.peek() == output + 3);
             assert(ranges::equal(output, input));
         }
         { // Validate range overload
             int output[3] = {-1, -1, -1};
-            In wrapped_input{input};
+            Read wrapped_input{input};
+
             auto result = copy(wrapped_input, Write{output});
-            STATIC_ASSERT(same_as<decltype(result), copy_result<iterator_t<In>, Write>>);
+            STATIC_ASSERT(same_as<decltype(result), copy_result<iterator_t<Read>, Write>>);
             assert(result.in == wrapped_input.end());
-            assert(result.out.base() == output + 3);
+            assert(result.out.peek() == output + 3);
             assert(ranges::equal(output, input));
         }
     }


### PR DESCRIPTION
This moves ranges::copy to the new way of handling both the CPOs and the tests