### PR TITLE
Remove invalid overload of ranges::copy_n

### DIFF
--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -1557,12 +1557,6 @@ namespace ranges {
             _Seek_wrapped(_First, _STD move(_UFirst));
             return {_STD move(_First), _STD move(_Result)};
         }
-
-        template <input_range _Rng, weakly_incrementable _Out>
-            requires indirectly_copyable<iterator_t<_Rng>, _Out>
-        constexpr copy_n_result<borrowed_iterator_t<_Rng>, _Out> operator()(_Rng&& _Range, _Out _Result) const {
-            return (*this)(_RANGES begin(_Range), _RANGES end(_Range), _STD move(_Result));
-        }
         // clang-format on
     };
 

--- a/tests/std/tests/P0896R4_ranges_alg_copy_n/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_copy_n/test.cpp
@@ -16,14 +16,15 @@ STATIC_ASSERT(same_as<ranges::copy_n_result<int, double>, ranges::in_out_result<
 
 struct instantiator {
     static constexpr int input[3] = {13, 42, 1729};
-    template <class Read, class, class Write>
+
+    template <ranges::input_range Read, indirectly_writable<ranges::range_reference_t<Read>> Write>
     static constexpr void call() {
         using ranges::copy_n, ranges::copy_n_result, ranges::iterator_t;
         int output[3] = {-1, -1, -1};
         Read wrapped_input{input};
 
-        auto result = copy_n(wrapped_input, ranges::distance(input), Write{output});
-        STATIC_ASSERT(same_as<decltype(result), copy_n_result<Read, Write>>);
+        auto result = copy_n(wrapped_input.begin(), ranges::distance(wrapped_input), Write{output});
+        STATIC_ASSERT(same_as<decltype(result), copy_n_result<iterator_t<Read>, Write>>);
         assert(result.in == wrapped_input.end());
         assert(result.out.peek() == output + 3);
         assert(ranges::equal(output, input));
@@ -31,6 +32,6 @@ struct instantiator {
 };
 
 int main() {
-    STATIC_ASSERT((test_counted_write<instantiator, const int, int>(), true));
-    test_counted_write<instantiator, const int, int>();
+    STATIC_ASSERT((test_read_write<instantiator, int const, int>(), true));
+    test_read_write<instantiator, int const, int>();
 }

--- a/tests/std/tests/P0896R4_ranges_alg_copy_n/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_copy_n/test.cpp
@@ -32,6 +32,6 @@ struct instantiator {
 };
 
 int main() {
-    STATIC_ASSERT((test_read_write<instantiator, int const, int>(), true));
-    test_read_write<instantiator, int const, int>();
+    STATIC_ASSERT((test_in_write<instantiator, int const, int>(), true));
+    test_in_write<instantiator, int const, int>();
 }

--- a/tests/std/tests/P0896R4_ranges_alg_copy_n/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_copy_n/test.cpp
@@ -23,9 +23,7 @@ struct instantiator {
         auto result   = copy_n(In{input}, ranges::distance(input), Write{output});
         STATIC_ASSERT(same_as<decltype(result), copy_n_result<In, Write>>);
         assert(result.in.base() == input + 3);
-        if constexpr (std::equality_comparable<Write>) {
-            assert(result.out == Write{output + 3});
-        }
+        assert(result.out.base() == output + 3);
         assert(ranges::equal(output, input));
     }
 };

--- a/tests/std/tests/P0896R4_ranges_alg_copy_n/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_copy_n/test.cpp
@@ -9,8 +9,9 @@
 
 #include <range_algorithm_support.hpp>
 
+using namespace std;
+using same_as;
 using ranges::copy_n, ranges::copy_n_result, ranges::iterator_t;
-using std::same_as;
 
 // Validate that copy_n_result aliases in_out_result
 STATIC_ASSERT(same_as<copy_n_result<int, double>, ranges::in_out_result<int, double>>);
@@ -29,6 +30,6 @@ struct instantiator {
 };
 
 int main() {
-    STATIC_ASSERT((test_counted_write<instantiator>(), true));
-    test_counted_write<instantiator>();
+    STATIC_ASSERT((test_counted_write<instantiator, const int, int>(), true));
+    test_counted_write<instantiator, const int, int>();
 }

--- a/tests/std/tests/P0896R4_ranges_alg_copy_n/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_copy_n/test.cpp
@@ -10,21 +10,22 @@
 #include <range_algorithm_support.hpp>
 
 using namespace std;
-using same_as;
-using ranges::copy_n, ranges::copy_n_result, ranges::iterator_t;
 
 // Validate that copy_n_result aliases in_out_result
-STATIC_ASSERT(same_as<copy_n_result<int, double>, ranges::in_out_result<int, double>>);
+STATIC_ASSERT(same_as<ranges::copy_n_result<int, double>, ranges::in_out_result<int, double>>);
 
 struct instantiator {
     static constexpr int input[3] = {13, 42, 1729};
-    template <class In, class, class Write>
+    template <class Read, class, class Write>
     static constexpr void call() {
+        using ranges::copy_n, ranges::copy_n_result, ranges::iterator_t;
         int output[3] = {-1, -1, -1};
-        auto result   = copy_n(In{input}, ranges::distance(input), Write{output});
-        STATIC_ASSERT(same_as<decltype(result), copy_n_result<In, Write>>);
-        assert(result.in.base() == input + 3);
-        assert(result.out.base() == output + 3);
+        Read wrapped_input{input};
+
+        auto result = copy_n(wrapped_input, ranges::distance(input), Write{output});
+        STATIC_ASSERT(same_as<decltype(result), copy_n_result<Read, Write>>);
+        assert(result.in == wrapped_input.end());
+        assert(result.out.peek() == output + 3);
         assert(ranges::equal(output, input));
     }
 };

--- a/tests/std/tests/P0896R4_ranges_alg_copy_n/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_copy_n/test.cpp
@@ -22,9 +22,7 @@ struct instantiator {
         int output[3] = {-1, -1, -1};
         auto result   = copy_n(In{input}, ranges::distance(input), Write{output});
         STATIC_ASSERT(same_as<decltype(result), copy_n_result<In, Write>>);
-        if constexpr (std::equality_comparable<In>) {
-            assert(result.in == In{input + 3});
-        }
+        assert(result.in.base() == input + 3);
         if constexpr (std::equality_comparable<Write>) {
             assert(result.out == Write{output + 3});
         }

--- a/tests/std/tests/P0896R4_ranges_alg_copy_n/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_copy_n/test.cpp
@@ -32,6 +32,6 @@ struct instantiator {
 };
 
 int main() {
-    STATIC_ASSERT((test_in_write<instantiator, int const, int>(), true));
-    test_in_write<instantiator, int const, int>();
+    STATIC_ASSERT((test_in_write<instantiator, const int, int>(), true));
+    test_in_write<instantiator, const int, int>();
 }

--- a/tests/std/tests/P0896R4_ranges_alg_copy_n/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_copy_n/test.cpp
@@ -23,7 +23,7 @@ struct instantiator {
         int output[3] = {-1, -1, -1};
         Read wrapped_input{input};
 
-        auto result = copy_n(wrapped_input.begin(), ranges::distance(wrapped_input), Write{output});
+        auto result = copy_n(wrapped_input.begin(), 3, Write{output});
         STATIC_ASSERT(same_as<decltype(result), copy_n_result<iterator_t<Read>, Write>>);
         assert(result.in == wrapped_input.end());
         assert(result.out.peek() == output + 3);


### PR DESCRIPTION
When modernizing the tests I found that there is a copy & paste  error with a second overload that would not even compile if it was called.

Modernize the tests and remove the invalid overload.

I also changed the default type of the `test_counted_write` range to const int as we generally should avoid modifying the input range.