### PR TITLE
Updates to Ranges test machinery

### DIFF
--- a/tests/std/tests/P0896R4_ranges_alg_adjacent_find/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_adjacent_find/test.cpp
@@ -71,4 +71,4 @@ struct instantiator {
     }
 };
 
-template void test_fwd<instantiator>();
+template void test_fwd<instantiator, const int>();

--- a/tests/std/tests/P0896R4_ranges_alg_all_of/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_all_of/test.cpp
@@ -53,4 +53,4 @@ struct instantiator {
     }
 };
 
-template void test_in<instantiator>();
+template void test_in<instantiator, const int>();

--- a/tests/std/tests/P0896R4_ranges_alg_any_of/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_any_of/test.cpp
@@ -51,4 +51,4 @@ struct instantiator {
     }
 };
 
-template void test_in<instantiator>();
+template void test_in<instantiator, const int>();

--- a/tests/std/tests/P0896R4_ranges_alg_binary_search/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_binary_search/test.cpp
@@ -70,11 +70,9 @@ struct lower_bound_instantiator {
 
         for (int i = 0; i < 8; ++i) {
             const P* const target = pairs.data() + i + (i > 3 ? 2 : 0);
-            ASSERT(to_address(ranges::lower_bound(range, i, ranges::less{}, get_first).base()) == target);
-            ASSERT(
-                to_address(
-                    ranges::lower_bound(ranges::begin(range), ranges::end(range), i, ranges::less{}, get_first).base())
-                == target);
+            ASSERT(ranges::lower_bound(range, i, ranges::less{}, get_first).peek() == target);
+            ASSERT(ranges::lower_bound(ranges::begin(range), ranges::end(range), i, ranges::less{}, get_first).peek()
+                   == target);
         }
 
         ASSERT(ranges::lower_bound(range, 8, ranges::less{}, get_first) == ranges::end(range));
@@ -95,11 +93,9 @@ struct upper_bound_instantiator {
         for (int i = 0; i < 8; ++i) {
             const P* const target = pairs.data() + i + 1 + (i >= 3 ? 2 : 0);
 
-            ASSERT(to_address(ranges::upper_bound(range, i, ranges::less{}, get_first).base()) == target);
-            ASSERT(
-                to_address(
-                    ranges::upper_bound(ranges::begin(range), ranges::end(range), i, ranges::less{}, get_first).base())
-                == target);
+            ASSERT(ranges::upper_bound(range, i, ranges::less{}, get_first).peek() == target);
+            ASSERT(ranges::upper_bound(ranges::begin(range), ranges::end(range), i, ranges::less{}, get_first).peek()
+                   == target);
         }
 
         ASSERT(ranges::upper_bound(range, 8, ranges::less{}, get_first) == ranges::end(range));
@@ -130,14 +126,14 @@ struct equal_range_instantiator {
 
             {
                 auto result = ranges::equal_range(range, i, ranges::less{}, get_first);
-                ASSERT(to_address(result.begin().base()) == lo);
-                ASSERT(to_address(result.end().base()) == hi);
+                ASSERT(result.begin().peek() == lo);
+                ASSERT(result.end().peek() == hi);
             }
             {
                 auto result =
                     ranges::equal_range(ranges::begin(range), ranges::end(range), i, ranges::less{}, get_first);
-                ASSERT(to_address(result.begin().base()) == lo);
-                ASSERT(to_address(result.end().base()) == hi);
+                ASSERT(result.begin().peek() == lo);
+                ASSERT(result.end().peek() == hi);
             }
         }
 

--- a/tests/std/tests/P0896R4_ranges_alg_copy/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_copy/test.cpp
@@ -56,4 +56,4 @@ struct instantiator {
     }
 };
 
-template void test_in_write<instantiator>();
+template void test_in_write<instantiator, const int, int>();

--- a/tests/std/tests/P0896R4_ranges_alg_copy_if/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_copy_if/test.cpp
@@ -116,4 +116,4 @@ struct instantiator {
     }
 };
 
-template void test_in_write<instantiator>();
+template void test_in_write<instantiator, const int, int>();

--- a/tests/std/tests/P0896R4_ranges_alg_copy_n/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_copy_n/test.cpp
@@ -33,10 +33,10 @@ int main() {
 }
 
 struct instantiator {
-    template <class In, class, class Out>
+    template <class In, class Out>
     static void call(In in = {}, std::iter_difference_t<In> const count = 42, Out out = {}) {
         (void) ranges::copy_n(std::move(in), count, std::move(out));
     }
 };
 
-template void test_counted_write<instantiator>();
+template void test_read_write<instantiator, const int, int>();

--- a/tests/std/tests/P0896R4_ranges_alg_count/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_count/test.cpp
@@ -50,4 +50,4 @@ struct instantiator {
     }
 };
 
-template void test_in<instantiator>();
+template void test_in<instantiator, const int>();

--- a/tests/std/tests/P0896R4_ranges_alg_count_if/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_count_if/test.cpp
@@ -50,4 +50,4 @@ struct instantiator {
     }
 };
 
-template void test_in<instantiator>();
+template void test_in<instantiator, const int>();

--- a/tests/std/tests/P0896R4_ranges_alg_equal/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_equal/test.cpp
@@ -97,4 +97,4 @@ struct instantiator {
     }
 };
 
-template void test_in_in<instantiator>();
+template void test_in_in<instantiator, const int, const int>();

--- a/tests/std/tests/P0896R4_ranges_alg_fill/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_fill/test.cpp
@@ -35,6 +35,6 @@ struct instantiator {
 };
 
 int main() {
-    STATIC_ASSERT((test_out<instantiator>(), true));
-    test_out<instantiator>();
+    STATIC_ASSERT((test_out<instantiator, int>(), true));
+    test_out<instantiator, int>();
 }

--- a/tests/std/tests/P0896R4_ranges_alg_fill_n/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_fill_n/test.cpp
@@ -40,6 +40,6 @@ struct instantiator {
 };
 
 int main() {
-    STATIC_ASSERT((test_out<instantiator>(), true));
-    test_out<instantiator>();
+    STATIC_ASSERT((test_out<instantiator, int>(), true));
+    test_out<instantiator, int>();
 }

--- a/tests/std/tests/P0896R4_ranges_alg_find/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_find/test.cpp
@@ -69,4 +69,4 @@ struct instantiator {
     }
 };
 
-template void test_in<instantiator>();
+template void test_in<instantiator, const int>();

--- a/tests/std/tests/P0896R4_ranges_alg_find_end/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_find_end/test.cpp
@@ -106,4 +106,4 @@ struct instantiator {
     }
 };
 
-template void test_fwd_fwd<instantiator>();
+template void test_fwd_fwd<instantiator, const int, const int>();

--- a/tests/std/tests/P0896R4_ranges_alg_find_first_of/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_find_first_of/test.cpp
@@ -27,7 +27,7 @@ constexpr void smoke_test() {
         // Validate range overload [found case]
         auto result = find_first_of(basic_borrowed_range{pairs}, good_needle, pred, get_first);
         STATIC_ASSERT(same_as<decltype(result), iterator_t<basic_borrowed_range<const P>>>);
-        assert(to_address(std::move(result).base()) == pairs.data() + 2);
+        assert(result.peek() == pairs.data() + 2);
     }
     {
         // Validate iterator + sentinel overload [found case]
@@ -35,7 +35,7 @@ constexpr void smoke_test() {
         auto result = find_first_of(
             wrapped_pairs.begin(), wrapped_pairs.end(), good_needle.begin(), good_needle.end(), pred, get_first);
         STATIC_ASSERT(same_as<decltype(result), iterator_t<basic_borrowed_range<const P>>>);
-        assert(to_address(std::move(result).base()) == pairs.data() + 2);
+        assert(result.peek() == pairs.data() + 2);
     }
 
     const array bad_needle = {29, 17};
@@ -43,7 +43,7 @@ constexpr void smoke_test() {
         // Validate range overload [not found case]
         auto result = find_first_of(basic_borrowed_range{pairs}, bad_needle, pred, get_first);
         STATIC_ASSERT(same_as<decltype(result), iterator_t<basic_borrowed_range<const P>>>);
-        assert(to_address(std::move(result).base()) == pairs.data() + pairs.size());
+        assert(result.peek() == pairs.data() + pairs.size());
     }
     {
         // Validate iterator + sentinel overload [not found case]
@@ -51,7 +51,7 @@ constexpr void smoke_test() {
         auto result = find_first_of(
             wrapped_pairs.begin(), wrapped_pairs.end(), bad_needle.begin(), bad_needle.end(), pred, get_first);
         STATIC_ASSERT(same_as<decltype(result), iterator_t<basic_borrowed_range<const P>>>);
-        assert(to_address(std::move(result).base()) == pairs.data() + pairs.size());
+        assert(result.peek() == pairs.data() + pairs.size());
     }
 }
 
@@ -90,4 +90,4 @@ struct instantiator {
     }
 };
 
-template void test_in_fwd<instantiator>();
+template void test_in_fwd<instantiator, const int, const int>();

--- a/tests/std/tests/P0896R4_ranges_alg_find_if/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_find_if/test.cpp
@@ -67,4 +67,4 @@ struct instantiator {
     }
 };
 
-template void test_in<instantiator>();
+template void test_in<instantiator, const int>();

--- a/tests/std/tests/P0896R4_ranges_alg_find_if_not/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_find_if_not/test.cpp
@@ -69,4 +69,4 @@ struct instantiator {
     }
 };
 
-template void test_in<instantiator>();
+template void test_in<instantiator, const int>();

--- a/tests/std/tests/P0896R4_ranges_alg_for_each/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_for_each/test.cpp
@@ -72,4 +72,4 @@ struct instantiator {
     }
 };
 
-template void test_in<instantiator>();
+template void test_in<instantiator, const int>();

--- a/tests/std/tests/P0896R4_ranges_alg_for_each_n/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_for_each_n/test.cpp
@@ -39,7 +39,7 @@ int main() {
 }
 
 struct instantiator {
-    template <class In, class, class>
+    template <class In>
     static void call(In in = {}) {
         using std::iter_difference_t;
 
@@ -51,4 +51,4 @@ struct instantiator {
     }
 };
 
-template void test_counted_write<instantiator>();
+template void test_read<instantiator, const int>();

--- a/tests/std/tests/P0896R4_ranges_alg_is_sorted/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_is_sorted/test.cpp
@@ -35,9 +35,9 @@ struct range_overloads {
             assert(ranges::is_sorted(range, ranges::less{}, get_first) == sorted);
 
             const auto addr = elements.data() + (N - offset);
-            assert(to_address(ranges::is_sorted_until(range).base()) == addr);
-            assert(to_address(ranges::is_sorted_until(range, ranges::less{}).base()) == addr);
-            assert(to_address(ranges::is_sorted_until(range, ranges::less{}, get_first).base()) == addr);
+            assert(ranges::is_sorted_until(range).peek() == addr);
+            assert(ranges::is_sorted_until(range, ranges::less{}).peek() == addr);
+            assert(ranges::is_sorted_until(range, ranges::less{}, get_first).peek() == addr);
 
             const auto next = ranges::next(ranges::begin(elements));
             rotate(ranges::begin(elements), next, ranges::end(elements));
@@ -59,10 +59,9 @@ struct iterator_overloads {
             assert(ranges::is_sorted(begin(range), end(range), ranges::less{}, get_first) == sorted);
 
             const auto addr = elements.data() + (N - offset);
-            assert(to_address(ranges::is_sorted_until(begin(range), end(range)).base()) == addr);
-            assert(to_address(ranges::is_sorted_until(begin(range), end(range), ranges::less{}).base()) == addr);
-            assert(to_address(ranges::is_sorted_until(begin(range), end(range), ranges::less{}, get_first).base())
-                   == addr);
+            assert(ranges::is_sorted_until(begin(range), end(range)).peek() == addr);
+            assert(ranges::is_sorted_until(begin(range), end(range), ranges::less{}).peek() == addr);
+            assert(ranges::is_sorted_until(begin(range), end(range), ranges::less{}, get_first).peek() == addr);
 
             const auto next = ranges::next(begin(elements));
             rotate(begin(elements), next, end(elements));

--- a/tests/std/tests/P0896R4_ranges_alg_mismatch/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_mismatch/test.cpp
@@ -102,4 +102,4 @@ struct instantiator {
     }
 };
 
-template void test_in_in<instantiator>();
+template void test_in_in<instantiator, const int, const int>();

--- a/tests/std/tests/P0896R4_ranges_alg_move/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_move/test.cpp
@@ -80,4 +80,4 @@ struct instantiator {
     }
 };
 
-template void test_in_write<instantiator>();
+template void test_in_write<instantiator, const int, int>();

--- a/tests/std/tests/P0896R4_ranges_alg_none_of/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_none_of/test.cpp
@@ -51,4 +51,4 @@ struct instantiator {
     }
 };
 
-template void test_in<instantiator>();
+template void test_in<instantiator, const int>();

--- a/tests/std/tests/P0896R4_ranges_alg_swap_ranges/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_swap_ranges/test.cpp
@@ -63,4 +63,4 @@ struct instantiator {
     }
 };
 
-template void test_in_in<instantiator>();
+template void test_in_in<instantiator, int, int>();


### PR DESCRIPTION
* Replace `base` member of `test::iterator` and `test::sentinel` with `peek`. The point is to break the abstraction and provide access to the internal pointer. There's no reason to mimic the behavior of iterator/sentinel adaptors, it just makes the test tool harder to use.

* `test::range::begin` enforces the restriction that it may be called at most once for a single-pass range. `test::range::_Unchecked_begin` should be subject to the same restriction.

* Remove default template arguments for the element types of ranges in the instantiation helpers (`test_in`, `test_fwd_fwd`, etc.) forcing the element types to be explicitly specified.