### PR TITLE
Noop Coroutine Implementation

### DIFF
--- a/stl/inc/coroutine
+++ b/stl/inc/coroutine
@@ -176,6 +176,7 @@ _NODISCARD inline noop_coroutine_handle noop_coroutine() noexcept {
     // Returns a handle to a coroutine that has no observable effects when resumed or destroyed.
     return noop_coroutine_handle{};
 }
+
 // STRUCT suspend_never
 struct suspend_never {
     _NODISCARD constexpr bool await_ready() const noexcept {

--- a/stl/inc/coroutine
+++ b/stl/inc/coroutine
@@ -176,7 +176,6 @@ _NODISCARD inline noop_coroutine_handle noop_coroutine() noexcept {
     // Returns a handle to a coroutine that has no observable effects when resumed or destroyed.
     return noop_coroutine_handle{};
 }
-
 // STRUCT suspend_never
 struct suspend_never {
     _NODISCARD constexpr bool await_ready() const noexcept {

--- a/stl/inc/experimental/coroutine
+++ b/stl/inc/experimental/coroutine
@@ -90,8 +90,8 @@ namespace experimental {
             return _Ptr;
         }
 
-        __declspec(
-            deprecated("is deprecated. Use coroutine_handle::address() instead")) void* to_address() const noexcept {
+        __declspec(deprecated("is deprecated. Use coroutine_handle::address() instead")) void* to_address() const
+            noexcept {
             return _Ptr;
         }
 


### PR DESCRIPTION
Dexcription:

Added framework and implementation for noop coroutines following the TS guidelines: http://open-std.org/JTC1/SC22/WG21/docs/papers/2020/n4861.pdf  section 17.2.4. With the new addition to the header, users can now have noop coroutines that essentially acts as a coroutine that does nothing.

Features: 

- Supports legacy and standard ABI.
- Follows the clang implementation by using the intrinsic in Await.cpp call builtin_coro_noop().

Possible breaking changes:

- In the header we check for if EDG isn't defined and if _MSC_VER >= 1928 in order to include noop coroutine code to pass intellisense tests.
