### PR TITLE
Cleanup `using _Pred` and `using operator<` comments

### DIFF
--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -4163,7 +4163,7 @@ _CONSTEXPR20 void push_heap(_RanIt _First, _RanIt _Last, _Pr _Pred) {
 
 template <class _RanIt>
 _CONSTEXPR20 void push_heap(_RanIt _First, _RanIt _Last) {
-    // push *(_Last - 1) onto heap at [_First, _Last - 1), using operator<
+    // push *(_Last - 1) onto heap at [_First, _Last - 1)
     _STD push_heap(_First, _Last, less<>());
 }
 
@@ -4301,7 +4301,7 @@ _CONSTEXPR20 void pop_heap(_RanIt _First, _RanIt _Last, _Pr _Pred) {
 
 template <class _RanIt>
 _CONSTEXPR20 void pop_heap(_RanIt _First, _RanIt _Last) {
-    // pop *_First to *(_Last - 1) and reheap, using operator<
+    // pop *_First to *(_Last - 1) and reheap
     _STD pop_heap(_First, _Last, less<>());
 }
 
@@ -4428,7 +4428,7 @@ _CONSTEXPR20 void make_heap(_RanIt _First, _RanIt _Last, _Pr _Pred) { // make [_
 }
 
 template <class _RanIt>
-_CONSTEXPR20 void make_heap(_RanIt _First, _RanIt _Last) { // make [_First, _Last) into a heap, using operator<
+_CONSTEXPR20 void make_heap(_RanIt _First, _RanIt _Last) { // make [_First, _Last) into a heap
     _STD make_heap(_First, _Last, less<>());
 }
 
@@ -4661,7 +4661,7 @@ _CONSTEXPR20 void sort_heap(_RanIt _First, _RanIt _Last, _Pr _Pred) { // order h
 }
 
 template <class _RanIt>
-_CONSTEXPR20 void sort_heap(_RanIt _First, _RanIt _Last) { // order heap by repeatedly popping, using operator<
+_CONSTEXPR20 void sort_heap(_RanIt _First, _RanIt _Last) { // order heap by repeatedly popping
     _STD sort_heap(_First, _Last, less<>());
 }
 
@@ -4795,7 +4795,7 @@ _NODISCARD _CONSTEXPR20 _FwdIt upper_bound(_FwdIt _First, _FwdIt _Last, const _T
 
 template <class _FwdIt, class _Ty>
 _NODISCARD _CONSTEXPR20 _FwdIt upper_bound(_FwdIt _First, _FwdIt _Last, const _Ty& _Val) {
-    // find first element that _Val is before, using operator<
+    // find first element that _Val is before
     return _STD upper_bound(_First, _Last, _Val, less<>());
 }
 
@@ -4897,7 +4897,7 @@ _NODISCARD _CONSTEXPR20 pair<_FwdIt, _FwdIt> equal_range(_FwdIt _First, _FwdIt _
 
 template <class _FwdIt, class _Ty>
 _NODISCARD _CONSTEXPR20 pair<_FwdIt, _FwdIt> equal_range(_FwdIt _First, _FwdIt _Last, const _Ty& _Val) {
-    // find range equivalent to _Val, using operator<
+    // find range equivalent to _Val
     return _STD equal_range(_First, _Last, _Val, less<>());
 }
 
@@ -4978,7 +4978,7 @@ _NODISCARD _CONSTEXPR20 bool binary_search(_FwdIt _First, _FwdIt _Last, const _T
 
 template <class _FwdIt, class _Ty>
 _NODISCARD _CONSTEXPR20 bool binary_search(_FwdIt _First, _FwdIt _Last, const _Ty& _Val) {
-    // test if _Val equivalent to some element, using operator<
+    // test if _Val equivalent to some element
     return _STD binary_search(_First, _Last, _Val, less<>());
 }
 
@@ -5079,7 +5079,7 @@ _CONSTEXPR20 _OutIt merge(_InIt1 _First1, _InIt1 _Last1, _InIt2 _First2, _InIt2 
 
 template <class _InIt1, class _InIt2, class _OutIt>
 _CONSTEXPR20 _OutIt merge(_InIt1 _First1, _InIt1 _Last1, _InIt2 _First2, _InIt2 _Last2, _OutIt _Dest) {
-    // copy merging ranges, both using operator<
+    // copy merging ranges, both
     return _STD merge(_First1, _Last1, _First2, _Last2, _Dest, less<>());
 }
 
@@ -5098,7 +5098,7 @@ _FwdIt3 merge(_ExPo&&, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2, _FwdIt2
 template <class _ExPo, class _FwdIt1, class _FwdIt2, class _FwdIt3, _Enable_if_execution_policy_t<_ExPo> = 0>
 _FwdIt3 merge(_ExPo&&, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2, _FwdIt2 _Last2, _FwdIt3 _Dest) noexcept
 /* terminates */ {
-    // copy merging ranges, both using operator<
+    // copy merging ranges
     // not parallelized at present, parallelism expected to be feasible in a future release
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
@@ -5351,7 +5351,7 @@ void inplace_merge(_BidIt _First, _BidIt _Mid, _BidIt _Last, _Pr _Pred) {
 
 template <class _BidIt>
 void inplace_merge(_BidIt _First, _BidIt _Mid, _BidIt _Last) {
-    // merge [_First, _Mid) with [_Mid, _Last), using operator<
+    // merge [_First, _Mid) with [_Mid, _Last)
     _STD inplace_merge(_First, _Mid, _Last, less<>());
 }
 
@@ -5365,7 +5365,7 @@ void inplace_merge(_ExPo&&, _BidIt _First, _BidIt _Mid, _BidIt _Last, _Pr _Pred)
 
 template <class _ExPo, class _BidIt, _Enable_if_execution_policy_t<_ExPo> = 0>
 void inplace_merge(_ExPo&&, _BidIt _First, _BidIt _Mid, _BidIt _Last) noexcept /* terminates */ {
-    // merge [_First, _Mid) with [_Mid, _Last), using operator<
+    // merge [_First, _Mid) with [_Mid, _Last)
     // not parallelized at present, parallelism expected to be feasible in a future release
     _STD inplace_merge(_First, _Mid, _Last);
 }
@@ -5536,7 +5536,7 @@ _CONSTEXPR20 void sort(const _RanIt _First, const _RanIt _Last, _Pr _Pred) { // 
 }
 
 template <class _RanIt>
-_CONSTEXPR20 void sort(const _RanIt _First, const _RanIt _Last) { // order [_First, _Last), using operator<
+_CONSTEXPR20 void sort(const _RanIt _First, const _RanIt _Last) { // order [_First, _Last)
     _STD sort(_First, _Last, less<>());
 }
 
@@ -5546,7 +5546,7 @@ void sort(_ExPo&& _Exec, _RanIt _First, _RanIt _Last, _Pr _Pred) noexcept; // te
 
 template <class _ExPo, class _RanIt, _Enable_if_execution_policy_t<_ExPo> = 0>
 void sort(_ExPo&& _Exec, const _RanIt _First, const _RanIt _Last) noexcept /* terminates */ {
-    // order [_First, _Last), using operator<
+    // order [_First, _Last)
     _STD sort(_STD forward<_ExPo>(_Exec), _First, _Last, less<>{});
 }
 #endif // _HAS_CXX17
@@ -5733,14 +5733,14 @@ void stable_sort(_ExPo&& _Exec, const _BidIt _First, const _BidIt _Last, _Pr _Pr
 #endif // _HAS_CXX17
 
 template <class _BidIt>
-void stable_sort(const _BidIt _First, const _BidIt _Last) { // sort preserving order of equivalents, using operator<
+void stable_sort(const _BidIt _First, const _BidIt _Last) { // sort preserving order of equivalents
     _STD stable_sort(_First, _Last, less<>());
 }
 
 #if _HAS_CXX17
 template <class _ExPo, class _BidIt, _Enable_if_execution_policy_t<_ExPo> = 0>
 void stable_sort(_ExPo&& _Exec, _BidIt _First, _BidIt _Last) noexcept /* terminates */ {
-    // sort preserving order of equivalents, using operator<
+    // sort preserving order of equivalents
     _STD stable_sort(_STD forward<_ExPo>(_Exec), _First, _Last, less<>());
 }
 #endif // _HAS_CXX17
@@ -5772,7 +5772,7 @@ _CONSTEXPR20 void partial_sort(_RanIt _First, _RanIt _Mid, _RanIt _Last, _Pr _Pr
 
 template <class _RanIt>
 _CONSTEXPR20 void partial_sort(_RanIt _First, _RanIt _Mid, _RanIt _Last) {
-    // order [_First, _Last) up to _Mid, using operator<
+    // order [_First, _Last) up to _Mid
     _STD partial_sort(_First, _Mid, _Last, less<>());
 }
 
@@ -5786,7 +5786,7 @@ void partial_sort(_ExPo&&, _RanIt _First, _RanIt _Mid, _RanIt _Last, _Pr _Pred) 
 
 template <class _ExPo, class _RanIt, _Enable_if_execution_policy_t<_ExPo> = 0>
 void partial_sort(_ExPo&&, _RanIt _First, _RanIt _Mid, _RanIt _Last) noexcept /* terminates */ {
-    // order [_First, _Last) up to _Mid, using operator<
+    // order [_First, _Last) up to _Mid
     // parallelism suspected to be infeasible
     return _STD partial_sort(_First, _Mid, _Last);
 }
@@ -5827,7 +5827,7 @@ _CONSTEXPR20 _RanIt partial_sort_copy(_InIt _First1, _InIt _Last1, _RanIt _First
 
 template <class _InIt, class _RanIt>
 _CONSTEXPR20 _RanIt partial_sort_copy(_InIt _First1, _InIt _Last1, _RanIt _First2, _RanIt _Last2) {
-    // copy [_First1, _Last1) into [_First2, _Last2), using operator<
+    // copy [_First1, _Last1) into [_First2, _Last2)
     return _STD partial_sort_copy(_First1, _Last1, _First2, _Last2, less<>());
 }
 
@@ -5844,7 +5844,7 @@ _RanIt partial_sort_copy(_ExPo&&, _FwdIt _First1, _FwdIt _Last1, _RanIt _First2,
 template <class _ExPo, class _FwdIt, class _RanIt, _Enable_if_execution_policy_t<_ExPo> = 0>
 _RanIt partial_sort_copy(_ExPo&&, _FwdIt _First1, _FwdIt _Last1, _RanIt _First2, _RanIt _Last2) noexcept
 /* terminates */ {
-    // copy [_First1, _Last1) into [_First2, _Last2), using operator<
+    // copy [_First1, _Last1) into [_First2, _Last2)
     // parallelism suspected to be infeasible
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt);
     return _STD partial_sort_copy(_First1, _Last1, _First2, _Last2);
@@ -5880,7 +5880,7 @@ _CONSTEXPR20 void nth_element(_RanIt _First, _RanIt _Nth, _RanIt _Last, _Pr _Pre
 }
 
 template <class _RanIt>
-_CONSTEXPR20 void nth_element(_RanIt _First, _RanIt _Nth, _RanIt _Last) { // order Nth element, using operator<
+_CONSTEXPR20 void nth_element(_RanIt _First, _RanIt _Nth, _RanIt _Last) { // order Nth element
     _STD nth_element(_First, _Nth, _Last, less<>());
 }
 
@@ -5894,7 +5894,7 @@ void nth_element(_ExPo&&, _RanIt _First, _RanIt _Nth, _RanIt _Last, _Pr _Pred) n
 
 template <class _ExPo, class _RanIt, _Enable_if_execution_policy_t<_ExPo> = 0>
 void nth_element(_ExPo&&, _RanIt _First, _RanIt _Nth, _RanIt _Last) noexcept /* terminates */ {
-    // order Nth element, using operator<
+    // order Nth element
     // not parallelized at present, parallelism expected to be feasible in a future release
     _STD nth_element(_First, _Nth, _Last);
 }
@@ -5927,7 +5927,7 @@ _NODISCARD _CONSTEXPR20 bool includes(_InIt1 _First1, _InIt1 _Last1, _InIt2 _Fir
 
 template <class _InIt1, class _InIt2>
 _NODISCARD _CONSTEXPR20 bool includes(_InIt1 _First1, _InIt1 _Last1, _InIt2 _First2, _InIt2 _Last2) {
-    // test if every element in sorted [_First2, _Last2) is in sorted [_First1, _Last1), using operator<
+    // test if every element in sorted [_First2, _Last2) is in sorted [_First1, _Last1)
     return _STD includes(_First1, _Last1, _First2, _Last2, less<>());
 }
 
@@ -5946,7 +5946,7 @@ _NODISCARD bool includes(_ExPo&&, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _Firs
 template <class _ExPo, class _FwdIt1, class _FwdIt2, _Enable_if_execution_policy_t<_ExPo> = 0>
 _NODISCARD bool includes(_ExPo&&, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2, _FwdIt2 _Last2) noexcept
 /* terminates */ {
-    // test if every element in sorted [_First2, _Last2) is in sorted [_First1, _Last1), using operator<
+    // test if every element in sorted [_First2, _Last2) is in sorted [_First1, _Last1)
     // not parallelized at present, parallelism expected to be feasible in a future release
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
@@ -5988,7 +5988,7 @@ _CONSTEXPR20 _OutIt set_union(_InIt1 _First1, _InIt1 _Last1, _InIt2 _First2, _In
 
 template <class _InIt1, class _InIt2, class _OutIt>
 _CONSTEXPR20 _OutIt set_union(_InIt1 _First1, _InIt1 _Last1, _InIt2 _First2, _InIt2 _Last2, _OutIt _Dest) {
-    // OR sets [_First1, _Last1) and [_First2, _Last2), using operator<
+    // OR sets [_First1, _Last1) and [_First2, _Last2)
     return _STD set_union(_First1, _Last1, _First2, _Last2, _Dest, less<>());
 }
 
@@ -6007,7 +6007,7 @@ _FwdIt3 set_union(_ExPo&&, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2, _Fw
 template <class _ExPo, class _FwdIt1, class _FwdIt2, class _FwdIt3, _Enable_if_execution_policy_t<_ExPo> = 0>
 _FwdIt3 set_union(_ExPo&&, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2, _FwdIt2 _Last2, _FwdIt3 _Dest) noexcept
 /* terminates */ {
-    // OR sets [_First1, _Last1) and [_First2, _Last2), using operator<
+    // OR sets [_First1, _Last1) and [_First2, _Last2)
     // not parallelized at present, parallelism expected to be feasible in a future release
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
@@ -6049,7 +6049,7 @@ _CONSTEXPR20 _OutIt set_intersection(
 
 template <class _InIt1, class _InIt2, class _OutIt>
 _CONSTEXPR20 _OutIt set_intersection(_InIt1 _First1, _InIt1 _Last1, _InIt2 _First2, _InIt2 _Last2, _OutIt _Dest) {
-    // AND sets [_First1, _Last1) and [_First2, _Last2), using operator<
+    // AND sets [_First1, _Last1) and [_First2, _Last2)
     return _STD set_intersection(_First1, _Last1, _First2, _Last2, _Dest, less<>());
 }
 
@@ -6061,7 +6061,7 @@ _FwdIt3 set_intersection(_ExPo&&, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _Firs
 template <class _ExPo, class _FwdIt1, class _FwdIt2, class _FwdIt3, _Enable_if_execution_policy_t<_ExPo> = 0>
 _FwdIt3 set_intersection(_ExPo&& _Exec, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2, _FwdIt2 _Last2,
     _FwdIt3 _Dest) noexcept /* terminates */ {
-    // AND sets [_First1, _Last1) and [_First2, _Last2), using operator<
+    // AND sets [_First1, _Last1) and [_First2, _Last2)
     return _STD set_intersection(_STD forward<_ExPo>(_Exec), _First1, _Last1, _First2, _Last2, _Dest, less{});
 }
 #endif // _HAS_CXX17
@@ -6100,7 +6100,7 @@ _CONSTEXPR20 _OutIt set_difference(
 
 template <class _InIt1, class _InIt2, class _OutIt>
 _CONSTEXPR20 _OutIt set_difference(_InIt1 _First1, _InIt1 _Last1, _InIt2 _First2, _InIt2 _Last2, _OutIt _Dest) {
-    // take set [_First2, _Last2) from [_First1, _Last1), using operator<
+    // take set [_First2, _Last2) from [_First1, _Last1)
     return _STD set_difference(_First1, _Last1, _First2, _Last2, _Dest, less<>());
 }
 
@@ -6112,7 +6112,7 @@ _FwdIt3 set_difference(_ExPo&&, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2
 template <class _ExPo, class _FwdIt1, class _FwdIt2, class _FwdIt3, _Enable_if_execution_policy_t<_ExPo> = 0>
 _FwdIt3 set_difference(_ExPo&& _Exec, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2, _FwdIt2 _Last2,
     _FwdIt3 _Dest) noexcept /* terminates */ {
-    // take set [_First2, _Last2) from [_First1, _Last1), using operator<
+    // take set [_First2, _Last2) from [_First1, _Last1)
     return _STD set_difference(_STD forward<_ExPo>(_Exec), _First1, _Last1, _First2, _Last2, _Dest, less{});
 }
 #endif // _HAS_CXX17
@@ -6154,7 +6154,7 @@ _CONSTEXPR20 _OutIt set_symmetric_difference(
 template <class _InIt1, class _InIt2, class _OutIt>
 _CONSTEXPR20 _OutIt set_symmetric_difference(
     _InIt1 _First1, _InIt1 _Last1, _InIt2 _First2, _InIt2 _Last2, _OutIt _Dest) {
-    // XOR sets [_First1, _Last1) and [_First2, _Last2), using operator<
+    // XOR sets [_First1, _Last1) and [_First2, _Last2)
     return _STD set_symmetric_difference(_First1, _Last1, _First2, _Last2, _Dest, less<>());
 }
 
@@ -6173,7 +6173,7 @@ _FwdIt3 set_symmetric_difference(_ExPo&&, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdI
 template <class _ExPo, class _FwdIt1, class _FwdIt2, class _FwdIt3, _Enable_if_execution_policy_t<_ExPo> = 0>
 _FwdIt3 set_symmetric_difference(_ExPo&&, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2, _FwdIt2 _Last2,
     _FwdIt3 _Dest) noexcept /* terminates */ {
-    // XOR sets [_First1, _Last1) and [_First2, _Last2), using operator<
+    // XOR sets [_First1, _Last1) and [_First2, _Last2)
     // not parallelized at present, parallelism expected to be feasible in a future release
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
@@ -6205,7 +6205,7 @@ _NODISCARD constexpr _FwdIt max_element(_FwdIt _First, _FwdIt _Last, _Pr _Pred) 
 }
 
 template <class _FwdIt>
-_NODISCARD constexpr _FwdIt max_element(_FwdIt _First, _FwdIt _Last) { // find largest element, using operator<
+_NODISCARD constexpr _FwdIt max_element(_FwdIt _First, _FwdIt _Last) { // find largest element
     return _STD max_element(_First, _Last, less<>());
 }
 
@@ -6219,7 +6219,7 @@ _NODISCARD _FwdIt max_element(_ExPo&&, _FwdIt _First, _FwdIt _Last, _Pr _Pred) n
 
 template <class _ExPo, class _FwdIt, _Enable_if_execution_policy_t<_ExPo> = 0>
 _NODISCARD _FwdIt max_element(_ExPo&&, _FwdIt _First, _FwdIt _Last) noexcept /* terminates */ {
-    // find largest element, using operator<
+    // find largest element
     // not parallelized at present, parallelism expected to be feasible in a future release
     return _STD max_element(_First, _Last);
 }
@@ -6298,7 +6298,7 @@ _NODISCARD constexpr _FwdIt min_element(_FwdIt _First, _FwdIt _Last, _Pr _Pred) 
 }
 
 template <class _FwdIt>
-_NODISCARD constexpr _FwdIt min_element(_FwdIt _First, _FwdIt _Last) { // find smallest element, using operator<
+_NODISCARD constexpr _FwdIt min_element(_FwdIt _First, _FwdIt _Last) { // find smallest element
     return _STD min_element(_First, _Last, less<>());
 }
 
@@ -6312,7 +6312,7 @@ _NODISCARD _FwdIt min_element(_ExPo&&, _FwdIt _First, _FwdIt _Last, _Pr _Pred) n
 
 template <class _ExPo, class _FwdIt, _Enable_if_execution_policy_t<_ExPo> = 0>
 _NODISCARD _FwdIt min_element(_ExPo&&, _FwdIt _First, _FwdIt _Last) noexcept /* terminates */ {
-    // find smallest element, using operator<
+    // find smallest element
     // not parallelized at present, parallelism expected to be feasible in a future release
     return _STD min_element(_First, _Last);
 }
@@ -6419,7 +6419,7 @@ _NODISCARD constexpr pair<_FwdIt, _FwdIt> minmax_element(_FwdIt _First, _FwdIt _
 
 template <class _FwdIt>
 _NODISCARD constexpr pair<_FwdIt, _FwdIt> minmax_element(_FwdIt _First, _FwdIt _Last) {
-    // find smallest and largest elements, using operator<
+    // find smallest and largest elements
     return _STD minmax_element(_First, _Last, less<>());
 }
 
@@ -6434,7 +6434,7 @@ _NODISCARD pair<_FwdIt, _FwdIt> minmax_element(_ExPo&&, _FwdIt _First, _FwdIt _L
 
 template <class _ExPo, class _FwdIt, _Enable_if_execution_policy_t<_ExPo> = 0>
 _NODISCARD pair<_FwdIt, _FwdIt> minmax_element(_ExPo&&, _FwdIt _First, _FwdIt _Last) noexcept /* terminates */ {
-    // find smallest and largest elements, using operator<
+    // find smallest and largest elements
     // not parallelized at present, parallelism expected to be feasible in a future release
     return _STD minmax_element(_First, _Last);
 }
@@ -6849,7 +6849,7 @@ _CONSTEXPR20 bool next_permutation(_BidIt _First, _BidIt _Last, _Pr _Pred) {
 
 template <class _BidIt>
 _CONSTEXPR20 bool next_permutation(_BidIt _First, _BidIt _Last) {
-    // permute and test for pure ascending, using operator<
+    // permute and test for pure ascending
     return _STD next_permutation(_First, _Last, less<>());
 }
 
@@ -6887,7 +6887,7 @@ _CONSTEXPR20 bool prev_permutation(_BidIt _First, _BidIt _Last, _Pr _Pred) {
 
 template <class _BidIt>
 _CONSTEXPR20 bool prev_permutation(_BidIt _First, _BidIt _Last) {
-    // reverse permute and test for pure descending, using operator<
+    // reverse permute and test for pure descending
     return _STD prev_permutation(_First, _Last, less<>());
 }
 

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -5079,7 +5079,7 @@ _CONSTEXPR20 _OutIt merge(_InIt1 _First1, _InIt1 _Last1, _InIt2 _First2, _InIt2 
 
 template <class _InIt1, class _InIt2, class _OutIt>
 _CONSTEXPR20 _OutIt merge(_InIt1 _First1, _InIt1 _Last1, _InIt2 _First2, _InIt2 _Last2, _OutIt _Dest) {
-    // copy merging ranges, both
+    // copy merging ranges
     return _STD merge(_First1, _Last1, _First2, _Last2, _Dest, less<>());
 }
 

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -692,7 +692,7 @@ namespace ranges {
 // FUNCTION TEMPLATE mismatch
 template <class _InIt1, class _InIt2, class _Pr>
 _NODISCARD _CONSTEXPR20 pair<_InIt1, _InIt2> mismatch(_InIt1 _First1, const _InIt1 _Last1, _InIt2 _First2, _Pr _Pred) {
-    // return [_First1, _Last1)/[_First2, ...) mismatch using _Pred
+    // return [_First1, _Last1)/[_First2, ...) mismatch
     _Adl_verify_range(_First1, _Last1);
     auto _UFirst1      = _Get_unwrapped(_First1);
     const auto _ULast1 = _Get_unwrapped(_Last1);
@@ -734,7 +734,7 @@ _NODISCARD pair<_FwdIt1, _FwdIt2> mismatch(
 template <class _InIt1, class _InIt2, class _Pr>
 _NODISCARD _CONSTEXPR20 pair<_InIt1, _InIt2> mismatch(
     _InIt1 _First1, _InIt1 _Last1, _InIt2 _First2, _InIt2 _Last2, _Pr _Pred) {
-    // return [_First1, _Last1)/[_First2, _Last2) mismatch using _Pred
+    // return [_First1, _Last1)/[_First2, _Last2) mismatch
     _Adl_verify_range(_First1, _Last1);
     _Adl_verify_range(_First2, _Last2);
     auto _UFirst1      = _Get_unwrapped(_First1);
@@ -766,7 +766,7 @@ _NODISCARD _CONSTEXPR20 pair<_InIt1, _InIt2> mismatch(
 template <class _InIt1, class _InIt2, class _Pr>
 pair<_InIt1, _InIt2> _Mismatch_unchecked(_InIt1 _First1, const _InIt1 _Last1, _InIt2 _First2, const _InIt2 _Last2,
     _Pr _Pred, input_iterator_tag, input_iterator_tag) {
-    // return [_First1, _Last1)/[_First2, _Last2) mismatch using _Pred, no special optimization
+    // return [_First1, _Last1)/[_First2, _Last2) mismatch, no special optimization
     while (_First1 != _Last1 && _First2 != _Last2 && _Pred(*_First1, *_First2)) {
         ++_First1;
         ++_First2;
@@ -778,7 +778,7 @@ pair<_InIt1, _InIt2> _Mismatch_unchecked(_InIt1 _First1, const _InIt1 _Last1, _I
 template <class _InIt1, class _InIt2, class _Pr>
 pair<_InIt1, _InIt2> _Mismatch_unchecked(const _InIt1 _First1, const _InIt1 _Last1, const _InIt2 _First2,
     const _InIt2 _Last2, _Pr _Pred, random_access_iterator_tag, random_access_iterator_tag) {
-    // return [_First1, _Last1)/[_First2, _Last2) mismatch using _Pred, random-access iterators
+    // return [_First1, _Last1)/[_First2, _Last2) mismatch, random-access iterators
     using _CT         = _Common_diff_t<_InIt1, _InIt2>;
     const _CT _Count1 = _Last1 - _First1;
     const _CT _Count2 = _Last2 - _First2;
@@ -788,7 +788,7 @@ pair<_InIt1, _InIt2> _Mismatch_unchecked(const _InIt1 _First1, const _InIt1 _Las
 
 template <class _InIt1, class _InIt2, class _Pr>
 _NODISCARD pair<_InIt1, _InIt2> mismatch(_InIt1 _First1, _InIt1 _Last1, _InIt2 _First2, _InIt2 _Last2, _Pr _Pred) {
-    // return [_First1, _Last1)/[_First2, _Last2) mismatch using _Pred
+    // return [_First1, _Last1)/[_First2, _Last2) mismatch
     _Adl_verify_range(_First1, _Last1);
     _Adl_verify_range(_First2, _Last2);
     const auto _Result = _Mismatch_unchecked(_Get_unwrapped(_First1), _Get_unwrapped(_Last1), _Get_unwrapped(_First2),
@@ -1012,7 +1012,7 @@ namespace ranges {
 // FUNCTION TEMPLATE is_permutation
 template <class _FwdIt1, class _FwdIt2, class _Pr>
 _NODISCARD _CONSTEXPR20 bool is_permutation(_FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2, _Pr _Pred) {
-    // test if [_First1, _Last1) == permuted [_First2, ...), using _Pred
+    // test if [_First1, _Last1) == permuted [_First2, ...)
     _Adl_verify_range(_First1, _Last1);
     auto _UFirst1      = _Get_unwrapped(_First1);
     const auto _ULast1 = _Get_unwrapped(_Last1);
@@ -1043,7 +1043,7 @@ _NODISCARD _CONSTEXPR20 bool is_permutation(_FwdIt1 _First1, _FwdIt1 _Last1, _Fw
 template <class _FwdIt1, class _FwdIt2, class _Pr>
 _CONSTEXPR20 bool _Is_permutation_unchecked(_FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2, _FwdIt2 _Last2, _Pr _Pred,
     forward_iterator_tag, forward_iterator_tag) {
-    // test if [_First1, _Last1) == permuted [_First2, _Last2), using _Pred, arbitrary iterators
+    // test if [_First1, _Last1) == permuted [_First2, _Last2), arbitrary iterators
     for (;; ++_First1, (void) ++_First2) { // trim matching prefix
         if (_First1 == _Last1) {
             return _First2 == _Last2;
@@ -1078,7 +1078,7 @@ _CONSTEXPR20 bool _Is_permutation_unchecked(_FwdIt1 _First1, _FwdIt1 _Last1, _Fw
 template <class _FwdIt1, class _FwdIt2, class _Pr>
 _CONSTEXPR20 bool _Is_permutation_unchecked(_FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2, _FwdIt2 _Last2, _Pr _Pred,
     random_access_iterator_tag, random_access_iterator_tag) {
-    // test if [_First1, _Last1) == permuted [_First2, _Last2), using _Pred, random-access iterators
+    // test if [_First1, _Last1) == permuted [_First2, _Last2), random-access iterators
     if (_Last1 - _First1 != _Last2 - _First2) {
         return false;
     }
@@ -1096,7 +1096,7 @@ _CONSTEXPR20 bool _Is_permutation_unchecked(_FwdIt1 _First1, _FwdIt1 _Last1, _Fw
 template <class _FwdIt1, class _FwdIt2, class _Pr>
 _NODISCARD _CONSTEXPR20 bool is_permutation(
     _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2, _FwdIt2 _Last2, _Pr _Pred) {
-    // test if [_First1, _Last1) == permuted [_First2, _Last2), using _Pred
+    // test if [_First1, _Last1) == permuted [_First2, _Last2)
     _Adl_verify_range(_First1, _Last1);
     _Adl_verify_range(_First2, _Last2);
     return _Is_permutation_unchecked(_Get_unwrapped(_First1), _Get_unwrapped(_Last1), _Get_unwrapped(_First2),
@@ -1778,7 +1778,7 @@ _NODISCARD _CONSTEXPR20 _FwdIt partition_point(_FwdIt _First, _FwdIt _Last, _Pr 
 #if _HAS_IF_CONSTEXPR
 template <class _InIt1, class _InIt2, class _Pr>
 _NODISCARD _CONSTEXPR20 bool _Equal_rev_pred_unchecked(_InIt1 _First1, _InIt2 _First2, const _InIt2 _Last2, _Pr _Pred) {
-    // compare [_First1, ...) to [_First2, _Last2) using _Pred
+    // compare [_First1, ...) to [_First2, _Last2)
     if constexpr (_Equal_memcmp_is_safe<_InIt1, _InIt2, _Pr>) {
 #ifdef __cpp_lib_is_constant_evaluated
         if (!_STD is_constant_evaluated())
@@ -1802,7 +1802,7 @@ _NODISCARD _CONSTEXPR20 bool _Equal_rev_pred_unchecked(_InIt1 _First1, _InIt2 _F
 #else // ^^^ _HAS_IF_CONSTEXPR ^^^ // vvv !_HAS_IF_CONSTEXPR vvv
 template <class _InIt1, class _InIt2, class _Pr, enable_if_t<!_Equal_memcmp_is_safe<_InIt1, _InIt2, _Pr>, int> = 0>
 bool _Equal_rev_pred_unchecked(_InIt1 _First1, _InIt2 _First2, const _InIt2 _Last2, _Pr _Pred) {
-    // compare [_First1, ...) to [_First2, _Last2) using _Pred, no special optimization
+    // compare [_First1, ...) to [_First2, _Last2), no special optimization
     for (; _First2 != _Last2; ++_First1, (void) ++_First2) {
         if (!_Pred(*_First1, *_First2)) {
             return false;
@@ -4082,7 +4082,7 @@ pair<_BidIt, _Iter_diff_t<_BidIt>> _Stable_partition_unchecked1(_BidIt _First, _
 
 template <class _BidIt, class _Pr>
 _BidIt _Stable_partition_unchecked(_BidIt _First, _BidIt _Last, _Pr _Pred) {
-    // partition preserving order of equivalents, using _Pred
+    // partition preserving order of equivalents
     for (;;) {
         if (_First == _Last) { // the input range range is true (already partitioned)
             return _First;
@@ -4115,7 +4115,7 @@ _BidIt _Stable_partition_unchecked(_BidIt _First, _BidIt _Last, _Pr _Pred) {
 
 template <class _BidIt, class _Pr>
 _BidIt stable_partition(_BidIt _First, _BidIt _Last, _Pr _Pred) {
-    // partition preserving order of equivalents, using _Pred
+    // partition preserving order of equivalents
     _Adl_verify_range(_First, _Last);
     _Seek_wrapped(_First, _Stable_partition_unchecked(_Get_unwrapped(_First), _Get_unwrapped(_Last), _Pass_fn(_Pred)));
     return _First;
@@ -4124,7 +4124,7 @@ _BidIt stable_partition(_BidIt _First, _BidIt _Last, _Pr _Pred) {
 #if _HAS_CXX17
 template <class _ExPo, class _BidIt, class _Pr, _Enable_if_execution_policy_t<_ExPo> = 0>
 _BidIt stable_partition(_ExPo&&, _BidIt _First, _BidIt _Last, _Pr _Pred) noexcept /* terminates */ {
-    // partition preserving order of equivalents, using _Pred
+    // partition preserving order of equivalents
     // not parallelized at present, parallelism expected to be feasible in a future release
     return _STD stable_partition(_First, _Last, _Pass_fn(_Pred));
 }
@@ -4134,7 +4134,7 @@ _BidIt stable_partition(_ExPo&&, _BidIt _First, _BidIt _Last, _Pr _Pred) noexcep
 template <class _RanIt, class _Ty, class _Pr>
 _CONSTEXPR20 void _Push_heap_by_index(
     _RanIt _First, _Iter_diff_t<_RanIt> _Hole, _Iter_diff_t<_RanIt> _Top, _Ty&& _Val, _Pr _Pred) {
-    // percolate _Hole to _Top or where _Val belongs, using _Pred
+    // percolate _Hole to _Top or where _Val belongs
     using _Diff = _Iter_diff_t<_RanIt>;
     for (_Diff _Idx = (_Hole - 1) >> 1; // shift for codegen
          _Top < _Hole && _DEBUG_LT_PRED(_Pred, *(_First + _Idx), _Val); //
@@ -4149,7 +4149,7 @@ _CONSTEXPR20 void _Push_heap_by_index(
 
 template <class _RanIt, class _Pr>
 _CONSTEXPR20 void push_heap(_RanIt _First, _RanIt _Last, _Pr _Pred) {
-    // push *(_Last - 1) onto heap at [_First, _Last - 1), using _Pred
+    // push *(_Last - 1) onto heap at [_First, _Last - 1)
     _Adl_verify_range(_First, _Last);
     const auto _UFirst = _Get_unwrapped(_First);
     auto _ULast        = _Get_unwrapped(_Last);
@@ -4173,7 +4173,7 @@ namespace ranges {
     template <class _It, class _Pr, class _Pj>
     constexpr void _Push_heap_by_index(const _It _First, iter_difference_t<_It> _Hole,
         const iter_difference_t<_It> _Top, iter_value_t<_It>&& _Val, _Pr _Pred, _Pj _Proj) {
-        // percolate _Hole to _Top or where _Val belongs, using _Pred and _Proj
+        // percolate _Hole to _Top or where _Val belongs
         _STL_INTERNAL_STATIC_ASSERT(random_access_iterator<_It>);
         _STL_INTERNAL_STATIC_ASSERT(sortable<_It, _Pr, _Pj>);
 
@@ -4245,7 +4245,7 @@ namespace ranges {
 template <class _RanIt, class _Ty, class _Pr>
 _CONSTEXPR20 void _Pop_heap_hole_by_index(
     _RanIt _First, _Iter_diff_t<_RanIt> _Hole, _Iter_diff_t<_RanIt> _Bottom, _Ty&& _Val, _Pr _Pred) {
-    // percolate _Hole to _Bottom, then push _Val, using _Pred
+    // percolate _Hole to _Bottom, then push _Val
     _STL_INTERNAL_CHECK(_Bottom > 0);
 
     using _Diff      = _Iter_diff_t<_RanIt>;
@@ -4274,7 +4274,7 @@ _CONSTEXPR20 void _Pop_heap_hole_by_index(
 
 template <class _RanIt, class _Ty, class _Pr>
 _CONSTEXPR20 void _Pop_heap_hole_unchecked(_RanIt _First, _RanIt _Last, _RanIt _Dest, _Ty&& _Val, _Pr _Pred) {
-    // pop *_First to *_Dest and reheap, using _Pred
+    // pop *_First to *_Dest and reheap
     // precondition: _First != _Last
     // precondition: _First != _Dest
     *_Dest      = _STD move(*_First);
@@ -4284,7 +4284,7 @@ _CONSTEXPR20 void _Pop_heap_hole_unchecked(_RanIt _First, _RanIt _Last, _RanIt _
 
 template <class _RanIt, class _Pr>
 _CONSTEXPR20 void _Pop_heap_unchecked(_RanIt _First, _RanIt _Last, _Pr _Pred) {
-    // pop *_First to *(_Last - 1) and reheap, using _Pred
+    // pop *_First to *(_Last - 1) and reheap
     if (2 <= _Last - _First) {
         --_Last;
         _Iter_value_t<_RanIt> _Val = _STD move(*_Last);
@@ -4294,7 +4294,7 @@ _CONSTEXPR20 void _Pop_heap_unchecked(_RanIt _First, _RanIt _Last, _Pr _Pred) {
 
 template <class _RanIt, class _Pr>
 _CONSTEXPR20 void pop_heap(_RanIt _First, _RanIt _Last, _Pr _Pred) {
-    // pop *_First to *(_Last - 1) and reheap, using _Pred
+    // pop *_First to *(_Last - 1) and reheap
     _Adl_verify_range(_First, _Last);
     _Pop_heap_unchecked(_Get_unwrapped(_First), _Get_unwrapped(_Last), _Pass_fn(_Pred));
 }
@@ -4311,7 +4311,7 @@ namespace ranges {
     template <class _It, class _Pr, class _Pj>
     constexpr void _Pop_heap_hole_by_index(_It _First, iter_difference_t<_It> _Hole,
         const iter_difference_t<_It> _Bottom, iter_value_t<_It>&& _Val, _Pr _Pred, _Pj _Proj) {
-        // percolate _Hole to _Bottom, then push _Val, using _Pred and _Proj
+        // percolate _Hole to _Bottom, then push _Val
         _STL_INTERNAL_STATIC_ASSERT(random_access_iterator<_It>);
         _STL_INTERNAL_STATIC_ASSERT(sortable<_It, _Pr, _Pj>);
         _STL_INTERNAL_CHECK(_Hole >= 0);
@@ -4346,7 +4346,7 @@ namespace ranges {
     template <class _It, class _Pr, class _Pj>
     constexpr void _Pop_heap_hole_unchecked(
         _It _First, const _It _Last, const _It _Dest, iter_value_t<_It>&& _Val, _Pr _Pred, _Pj _Proj) {
-        // pop *_First to *_Dest and reheap, using _Pred and _Proj
+        // pop *_First to *_Dest and reheap
         _STL_INTERNAL_STATIC_ASSERT(random_access_iterator<_It>);
         _STL_INTERNAL_STATIC_ASSERT(sortable<_It, _Pr, _Pj>);
         _STL_INTERNAL_CHECK(_First != _Last);
@@ -4359,7 +4359,7 @@ namespace ranges {
 
     template <class _It, class _Pr, class _Pj>
     constexpr void _Pop_heap_unchecked(_It _First, _It _Last, _Pr _Pred, _Pj _Proj) {
-        // pop *_First to *(_Last - 1) and reheap, using _Pred and _Proj
+        // pop *_First to *(_Last - 1) and reheap
         _STL_INTERNAL_STATIC_ASSERT(random_access_iterator<_It>);
         _STL_INTERNAL_STATIC_ASSERT(sortable<_It, _Pr, _Pj>);
 
@@ -4410,7 +4410,7 @@ namespace ranges {
 // FUNCTION TEMPLATE make_heap
 template <class _RanIt, class _Pr>
 _CONSTEXPR20 void _Make_heap_unchecked(_RanIt _First, _RanIt _Last, _Pr _Pred) {
-    // make nontrivial [_First, _Last) into a heap, using _Pred
+    // make nontrivial [_First, _Last) into a heap
     using _Diff   = _Iter_diff_t<_RanIt>;
     _Diff _Bottom = _Last - _First;
     for (_Diff _Hole = _Bottom >> 1; _Hole > 0;) { // shift for codegen
@@ -4422,7 +4422,7 @@ _CONSTEXPR20 void _Make_heap_unchecked(_RanIt _First, _RanIt _Last, _Pr _Pred) {
 }
 
 template <class _RanIt, class _Pr>
-_CONSTEXPR20 void make_heap(_RanIt _First, _RanIt _Last, _Pr _Pred) { // make [_First, _Last) into a heap, using _Pred
+_CONSTEXPR20 void make_heap(_RanIt _First, _RanIt _Last, _Pr _Pred) { // make [_First, _Last) into a heap
     _Adl_verify_range(_First, _Last);
     _Make_heap_unchecked(_Get_unwrapped(_First), _Get_unwrapped(_Last), _Pass_fn(_Pred));
 }
@@ -4467,7 +4467,7 @@ namespace ranges {
     private:
         template <class _It, class _Pr, class _Pj>
         static constexpr void _Make_heap_unchecked(_It _First, _It _Last, _Pr _Pred, _Pj _Proj) {
-            // make nontrivial [_First, _Last) into a heap, using _Pred and _Proj
+            // make nontrivial [_First, _Last) into a heap
             _STL_INTERNAL_STATIC_ASSERT(random_access_iterator<_It>);
             _STL_INTERNAL_STATIC_ASSERT(sortable<_It, _Pr, _Pj>);
 
@@ -4489,7 +4489,7 @@ namespace ranges {
 // FUNCTION TEMPLATES is_heap AND is_heap_until
 template <class _RanIt, class _Pr>
 _CONSTEXPR20 _RanIt _Is_heap_until_unchecked(_RanIt _First, _RanIt _Last, _Pr _Pred) {
-    // find extent of range that is a heap ordered by _Pred
+    // find extent of range that is a heap
     using _Diff       = _Iter_diff_t<_RanIt>;
     const _Diff _Size = _Last - _First;
     for (_Diff _Off = 1; _Off < _Size; ++_Off) {
@@ -4503,7 +4503,7 @@ _CONSTEXPR20 _RanIt _Is_heap_until_unchecked(_RanIt _First, _RanIt _Last, _Pr _P
 
 template <class _RanIt, class _Pr>
 _NODISCARD _CONSTEXPR20 _RanIt is_heap_until(_RanIt _First, _RanIt _Last, _Pr _Pred) {
-    // find extent of range that is a heap ordered by _Pred
+    // find extent of range that is a heap
     _Adl_verify_range(_First, _Last);
     _Seek_wrapped(_First, _Is_heap_until_unchecked(_Get_unwrapped(_First), _Get_unwrapped(_Last), _Pass_fn(_Pred)));
     return _First;
@@ -4511,7 +4511,7 @@ _NODISCARD _CONSTEXPR20 _RanIt is_heap_until(_RanIt _First, _RanIt _Last, _Pr _P
 
 template <class _RanIt, class _Pr>
 _NODISCARD _CONSTEXPR20 bool is_heap(_RanIt _First, _RanIt _Last, _Pr _Pred) {
-    // test if range is a heap ordered by _Pred
+    // test if range is a heap
     _Adl_verify_range(_First, _Last);
     const auto _UFirst = _Get_unwrapped(_First);
     const auto _ULast  = _Get_unwrapped(_Last);
@@ -4535,7 +4535,7 @@ _NODISCARD _RanIt is_heap_until(_ExPo&& _Exec, _RanIt _First, _RanIt _Last, _Pr 
 
 template <class _ExPo, class _RanIt, class _Pr, _Enable_if_execution_policy_t<_ExPo> = 0>
 _NODISCARD bool is_heap(_ExPo&& _Exec, _RanIt _First, _RanIt _Last, _Pr _Pred) noexcept /* terminates */ {
-    // test if range is a heap ordered by _Pred
+    // test if range is a heap
     return _STD is_heap_until(_STD forward<_ExPo>(_Exec), _First, _Last, _Pass_fn(_Pred)) == _Last;
 }
 
@@ -4557,7 +4557,7 @@ namespace ranges {
     template <class _It, class _Pr, class _Pj>
     _NODISCARD constexpr _It _Is_heap_until_unchecked(
         _It _First, const iter_difference_t<_It> _Size, _Pr _Pred, _Pj _Proj) {
-        // find extent of counted range that is a heap ordered with respect to _Pred and _Proj
+        // find extent of counted range that is a heap
         _STL_INTERNAL_STATIC_ASSERT(random_access_iterator<_It>);
         _STL_INTERNAL_STATIC_ASSERT(indirect_strict_weak_order<_Pr, projected<_It, _Pj>>);
 
@@ -4640,14 +4640,14 @@ namespace ranges {
 // FUNCTION TEMPLATE sort_heap
 template <class _RanIt, class _Pr>
 _CONSTEXPR20 void _Sort_heap_unchecked(_RanIt _First, _RanIt _Last, _Pr _Pred) {
-    // order heap by repeatedly popping, using _Pred
+    // order heap by repeatedly popping
     for (; _Last - _First >= 2; --_Last) {
         _Pop_heap_unchecked(_First, _Last, _Pred);
     }
 }
 
 template <class _RanIt, class _Pr>
-_CONSTEXPR20 void sort_heap(_RanIt _First, _RanIt _Last, _Pr _Pred) { // order heap by repeatedly popping, using _Pred
+_CONSTEXPR20 void sort_heap(_RanIt _First, _RanIt _Last, _Pr _Pred) { // order heap by repeatedly popping
     _Adl_verify_range(_First, _Last);
     const auto _UFirst = _Get_unwrapped(_First);
     const auto _ULast  = _Get_unwrapped(_Last);
@@ -4700,7 +4700,7 @@ namespace ranges {
     private:
         template <class _It, class _Pr, class _Pj>
         static constexpr void _Sort_heap_unchecked(const _It _First, _It _Last, _Pr _Pred, _Pj _Proj) {
-            // order heap by repeatedly popping, using _Pred and _Proj
+            // order heap by repeatedly popping
             _STL_INTERNAL_STATIC_ASSERT(random_access_iterator<_It>);
             _STL_INTERNAL_STATIC_ASSERT(sortable<_It, _Pr, _Pj>);
 
@@ -4773,7 +4773,7 @@ namespace ranges {
 // FUNCTION TEMPLATE upper_bound
 template <class _FwdIt, class _Ty, class _Pr>
 _NODISCARD _CONSTEXPR20 _FwdIt upper_bound(_FwdIt _First, _FwdIt _Last, const _Ty& _Val, _Pr _Pred) {
-    // find first element that _Val is before, using _Pred
+    // find first element that _Val is before
     _Adl_verify_range(_First, _Last);
     auto _UFirst                = _Get_unwrapped(_First);
     _Iter_diff_t<_FwdIt> _Count = _STD distance(_UFirst, _Get_unwrapped(_Last));
@@ -4860,7 +4860,7 @@ namespace ranges {
 // FUNCTION TEMPLATE equal_range
 template <class _FwdIt, class _Ty, class _Pr>
 _NODISCARD _CONSTEXPR20 pair<_FwdIt, _FwdIt> equal_range(_FwdIt _First, _FwdIt _Last, const _Ty& _Val, _Pr _Pred) {
-    // find range equivalent to _Val, using _Pred
+    // find range equivalent to _Val
     _Adl_verify_range(_First, _Last);
     auto _UFirst      = _Get_unwrapped(_First);
     const auto _ULast = _Get_unwrapped(_Last);
@@ -4968,7 +4968,7 @@ namespace ranges {
 // FUNCTION TEMPLATE binary_search
 template <class _FwdIt, class _Ty, class _Pr>
 _NODISCARD _CONSTEXPR20 bool binary_search(_FwdIt _First, _FwdIt _Last, const _Ty& _Val, _Pr _Pred) {
-    // test if _Val equivalent to some element, using _Pred
+    // test if _Val equivalent to some element
     _Adl_verify_range(_First, _Last);
     auto _UFirst      = _Get_unwrapped(_First);
     const auto _ULast = _Get_unwrapped(_Last);
@@ -5038,7 +5038,7 @@ _NODISCARD constexpr auto _Idl_dist_add(_Diff1 _Lhs, _Diff2 _Rhs) {
 
 template <class _InIt1, class _InIt2, class _OutIt, class _Pr>
 _CONSTEXPR20 _OutIt merge(_InIt1 _First1, _InIt1 _Last1, _InIt2 _First2, _InIt2 _Last2, _OutIt _Dest, _Pr _Pred) {
-    // copy merging ranges, both using _Pred
+    // copy merging ranges
     _Adl_verify_range(_First1, _Last1);
     _Adl_verify_range(_First2, _Last2);
     auto _UFirst1      = _Get_unwrapped(_First1);
@@ -5087,7 +5087,7 @@ _CONSTEXPR20 _OutIt merge(_InIt1 _First1, _InIt1 _Last1, _InIt2 _First2, _InIt2 
 template <class _ExPo, class _FwdIt1, class _FwdIt2, class _FwdIt3, class _Pr, _Enable_if_execution_policy_t<_ExPo> = 0>
 _FwdIt3 merge(_ExPo&&, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2, _FwdIt2 _Last2, _FwdIt3 _Dest,
     _Pr _Pred) noexcept /* terminates */ {
-    // copy merging ranges, both using _Pred
+    // copy merging ranges
     // not parallelized at present, parallelism expected to be feasible in a future release
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
@@ -5134,9 +5134,10 @@ void _Rotate_one_left(_BidIt _First, _BidIt _Mid, _BidIt _Last) {
 }
 
 template <class _BidIt, class _Pr>
-void _Inplace_merge_buffer_left(_BidIt _First, _BidIt _Mid, _BidIt _Last, _Iter_value_t<_BidIt>* const _Temp_ptr,
-    _Pr _Pred) { // move the range [_First, _Mid) to _Temp_ptr, and merge it with [_Mid, _Last) to _First, using _Pred
-                 // usual invariants apply
+void _Inplace_merge_buffer_left(
+    _BidIt _First, _BidIt _Mid, _BidIt _Last, _Iter_value_t<_BidIt>* const _Temp_ptr, _Pr _Pred) {
+    // move the range [_First, _Mid) to _Temp_ptr, and merge it with [_Mid, _Last) to _First
+    // usual invariants apply
     using _Ptr_ty = _Iter_value_t<_BidIt>*;
     _Uninitialized_backout<_Ptr_ty> _Backout{_Temp_ptr, _Uninitialized_move_unchecked(_First, _Mid, _Temp_ptr)};
     _Ptr_ty _Left_first      = _Temp_ptr;
@@ -5169,7 +5170,7 @@ void _Inplace_merge_buffer_left(_BidIt _First, _BidIt _Mid, _BidIt _Last, _Iter_
 template <class _BidIt, class _Pr>
 void _Inplace_merge_buffer_right(
     _BidIt _First, _BidIt _Mid, _BidIt _Last, _Iter_value_t<_BidIt>* const _Temp_ptr, _Pr _Pred) {
-    // move the range [_Mid, _Last) to _Temp_ptr, and merge it with [_First, _Mid) to _Last, using _Pred
+    // move the range [_Mid, _Last) to _Temp_ptr, and merge it with [_First, _Mid) to _Last
     // usual invariants apply
     using _Ptr_ty = _Iter_value_t<_BidIt>*;
     _Uninitialized_backout<_Ptr_ty> _Backout{_Temp_ptr, _Uninitialized_move_unchecked(_Mid, _Last, _Temp_ptr)};
@@ -5221,7 +5222,7 @@ void _Buffered_inplace_merge_divide_and_conquer2(_BidIt _First, _BidIt _Mid, _Bi
 template <class _BidIt, class _Pr>
 void _Buffered_inplace_merge_divide_and_conquer(_BidIt _First, _BidIt _Mid, _BidIt _Last, _Iter_diff_t<_BidIt> _Count1,
     _Iter_diff_t<_BidIt> _Count2, _Iter_value_t<_BidIt>* const _Temp_ptr, const ptrdiff_t _Capacity, _Pr _Pred) {
-    // merge sorted [_First, _Mid) with sorted [_Mid, _Last), using _Pred
+    // merge sorted [_First, _Mid) with sorted [_Mid, _Last)
     // usual invariants apply
     using _Diff = _Iter_diff_t<_BidIt>;
     if (_Count1 <= _Count2) {
@@ -5242,7 +5243,7 @@ void _Buffered_inplace_merge_divide_and_conquer(_BidIt _First, _BidIt _Mid, _Bid
 template <class _BidIt, class _Pr>
 void _Buffered_inplace_merge_unchecked_impl(_BidIt _First, _BidIt _Mid, _BidIt _Last, _Iter_diff_t<_BidIt> _Count1,
     _Iter_diff_t<_BidIt> _Count2, _Iter_value_t<_BidIt>* const _Temp_ptr, const ptrdiff_t _Capacity, _Pr _Pred) {
-    // merge sorted [_First, _Mid) with sorted [_Mid, _Last), using _Pred
+    // merge sorted [_First, _Mid) with sorted [_Mid, _Last)
     // usual invariants apply
     if (_Count1 <= _Count2 && _Count1 <= _Capacity) {
         _Inplace_merge_buffer_left(_First, _Mid, _Last, _Temp_ptr, _Pred);
@@ -5256,7 +5257,7 @@ void _Buffered_inplace_merge_unchecked_impl(_BidIt _First, _BidIt _Mid, _BidIt _
 template <class _BidIt, class _Pr>
 void _Buffered_inplace_merge_unchecked(_BidIt _First, _BidIt _Mid, _BidIt _Last, _Iter_diff_t<_BidIt> _Count1,
     _Iter_diff_t<_BidIt> _Count2, _Iter_value_t<_BidIt>* const _Temp_ptr, const ptrdiff_t _Capacity, _Pr _Pred) {
-    // merge sorted [_First, _Mid) with sorted [_Mid, _Last), using _Pred
+    // merge sorted [_First, _Mid) with sorted [_Mid, _Last)
     // usual invariants *do not* apply; only sortedness applies
     // establish the usual invariants (explained in inplace_merge)
     if (_Mid == _Last) {
@@ -5299,7 +5300,7 @@ void _Buffered_inplace_merge_unchecked(_BidIt _First, _BidIt _Mid, _BidIt _Last,
 
 template <class _BidIt, class _Pr>
 void inplace_merge(_BidIt _First, _BidIt _Mid, _BidIt _Last, _Pr _Pred) {
-    // merge [_First, _Mid) with [_Mid, _Last), using _Pred
+    // merge [_First, _Mid) with [_Mid, _Last)
     _Adl_verify_range(_First, _Mid);
     _Adl_verify_range(_Mid, _Last);
     auto _UFirst = _Get_unwrapped(_First);
@@ -5357,7 +5358,7 @@ void inplace_merge(_BidIt _First, _BidIt _Mid, _BidIt _Last) {
 #if _HAS_CXX17
 template <class _ExPo, class _BidIt, class _Pr, _Enable_if_execution_policy_t<_ExPo> = 0>
 void inplace_merge(_ExPo&&, _BidIt _First, _BidIt _Mid, _BidIt _Last, _Pr _Pred) noexcept /* terminates */ {
-    // merge [_First, _Mid) with [_Mid, _Last), using _Pred
+    // merge [_First, _Mid) with [_Mid, _Last)
     // not parallelized at present, parallelism expected to be feasible in a future release
     _STD inplace_merge(_First, _Mid, _Last, _Pass_fn(_Pred));
 }
@@ -5373,7 +5374,7 @@ void inplace_merge(_ExPo&&, _BidIt _First, _BidIt _Mid, _BidIt _Last) noexcept /
 // FUNCTION TEMPLATE sort
 template <class _BidIt, class _Pr>
 _CONSTEXPR20 _BidIt _Insertion_sort_unchecked(_BidIt _First, const _BidIt _Last, _Pr _Pred) {
-    // insertion sort [_First, _Last), using _Pred
+    // insertion sort [_First, _Last)
     if (_First != _Last) {
         for (_BidIt _Next = _First; ++_Next != _Last;) { // order next element
             _BidIt _Next1              = _Next;
@@ -5430,7 +5431,7 @@ _CONSTEXPR20 void _Guess_median_unchecked(_RanIt _First, _RanIt _Mid, _RanIt _La
 
 template <class _RanIt, class _Pr>
 _CONSTEXPR20 pair<_RanIt, _RanIt> _Partition_by_median_guess_unchecked(_RanIt _First, _RanIt _Last, _Pr _Pred) {
-    // partition [_First, _Last), using _Pred
+    // partition [_First, _Last)
     _RanIt _Mid = _First + ((_Last - _First) >> 1); // shift for codegen
     _Guess_median_unchecked(_First, _Mid, _Prev_iter(_Last), _Pred);
     _RanIt _Pfirst = _Mid;
@@ -5498,7 +5499,7 @@ _CONSTEXPR20 pair<_RanIt, _RanIt> _Partition_by_median_guess_unchecked(_RanIt _F
 
 template <class _RanIt, class _Pr>
 _CONSTEXPR20 void _Sort_unchecked(_RanIt _First, _RanIt _Last, _Iter_diff_t<_RanIt> _Ideal, _Pr _Pred) {
-    // order [_First, _Last), using _Pred
+    // order [_First, _Last)
     for (;;) {
         if (_Last - _First <= _ISORT_MAX) { // small
             _Insertion_sort_unchecked(_First, _Last, _Pred);
@@ -5527,7 +5528,7 @@ _CONSTEXPR20 void _Sort_unchecked(_RanIt _First, _RanIt _Last, _Iter_diff_t<_Ran
 }
 
 template <class _RanIt, class _Pr>
-_CONSTEXPR20 void sort(const _RanIt _First, const _RanIt _Last, _Pr _Pred) { // order [_First, _Last), using _Pred
+_CONSTEXPR20 void sort(const _RanIt _First, const _RanIt _Last, _Pr _Pred) { // order [_First, _Last)
     _Adl_verify_range(_First, _Last);
     const auto _UFirst = _Get_unwrapped(_First);
     const auto _ULast  = _Get_unwrapped(_Last);
@@ -5553,7 +5554,7 @@ void sort(_ExPo&& _Exec, const _RanIt _First, const _RanIt _Last) noexcept /* te
 // FUNCTION TEMPLATE stable_sort
 template <class _FwdIt, class _Ty, class _Pr>
 _Ty* _Uninitialized_merge_move(_FwdIt _First, const _FwdIt _Mid, const _FwdIt _Last, _Ty* const _Dest, _Pr _Pred) {
-    // move merging ranges to uninitialized storage, both using _Pred
+    // move merging ranges to uninitialized storage
     // pre: _First != _Mid && _Mid != _Last
     _Uninitialized_backout<_Ty*> _Backout{_Dest};
     _FwdIt _Next = _Mid;
@@ -5580,7 +5581,7 @@ _Ty* _Uninitialized_merge_move(_FwdIt _First, const _FwdIt _Mid, const _FwdIt _L
 
 template <class _InIt, class _OutIt, class _Pr>
 _OutIt _Merge_move(_InIt _First, const _InIt _Mid, const _InIt _Last, _OutIt _Dest, _Pr _Pred) {
-    // move merging adjacent ranges [_First, _Mid) and [_Mid, _Last) to _Dest, both using _Pred
+    // move merging adjacent ranges [_First, _Mid) and [_Mid, _Last) to _Dest
     // pre: _First != _Mid && _Mid != _Last
     _InIt _Next = _Mid;
     for (;;) {
@@ -5607,7 +5608,7 @@ _OutIt _Merge_move(_InIt _First, const _InIt _Mid, const _InIt _Last, _OutIt _De
 template <class _BidIt, class _Ty, class _Pr>
 void _Uninitialized_chunked_merge_unchecked(_BidIt _First, const _BidIt _Last, _Ty* _Dest,
     const _Iter_diff_t<_BidIt> _Chunk, _Iter_diff_t<_BidIt> _Count, _Pr _Pred) {
-    // move to uninitialized merging adjacent chunks of distance _Chunk, using _Pred
+    // move to uninitialized merging adjacent chunks of distance _Chunk
     // pre: _Count == distance(_First, _Last)
     // pre: _Chunk > 0
     _Uninitialized_backout<_Ty*> _Backout{_Dest};
@@ -5628,7 +5629,7 @@ void _Uninitialized_chunked_merge_unchecked(_BidIt _First, const _BidIt _Last, _
 template <class _BidIt, class _OutIt, class _Pr>
 void _Chunked_merge_unchecked(_BidIt _First, const _BidIt _Last, _OutIt _Dest, const _Iter_diff_t<_BidIt> _Chunk,
     _Iter_diff_t<_BidIt> _Count, _Pr _Pred) {
-    // move merging adjacent chunks of distance _Chunk, using _Pred
+    // move merging adjacent chunks of distance _Chunk
     // pre: _Count == distance(_First, _Last)
     // pre: _Chunk > 0
     while (_Chunk < _Count) {
@@ -5658,7 +5659,7 @@ void _Insertion_sort_isort_max_chunks(_BidIt _First, const _BidIt _Last, _Iter_d
 template <class _BidIt, class _Pr>
 void _Buffered_merge_sort_unchecked(const _BidIt _First, const _BidIt _Last, const _Iter_diff_t<_BidIt> _Count,
     _Iter_value_t<_BidIt>* const _Temp_ptr, _Pr _Pred) {
-    // sort using temp buffer for merges, using _Pred
+    // sort using temp buffer for merges
     // pre: _Last - _First == _Count
     // pre: _Count <= capacity of buffer at _Temp_ptr; also allows safe narrowing to ptrdiff_t
     _Insertion_sort_isort_max_chunks(_First, _Last, _Count, _Pred);
@@ -5689,7 +5690,7 @@ void _Buffered_merge_sort_unchecked(const _BidIt _First, const _BidIt _Last, con
 template <class _BidIt, class _Pr>
 void _Stable_sort_unchecked(const _BidIt _First, const _BidIt _Last, const _Iter_diff_t<_BidIt> _Count,
     _Iter_value_t<_BidIt>* const _Temp_ptr, const ptrdiff_t _Capacity, _Pr _Pred) {
-    // sort preserving order of equivalents, using _Pred
+    // sort preserving order of equivalents
     using _Diff = _Iter_diff_t<_BidIt>;
     if (_Count <= _ISORT_MAX) {
         _Insertion_sort_unchecked(_First, _Last, _Pred); // small
@@ -5712,7 +5713,7 @@ void _Stable_sort_unchecked(const _BidIt _First, const _BidIt _Last, const _Iter
 
 template <class _BidIt, class _Pr>
 void stable_sort(const _BidIt _First, const _BidIt _Last, _Pr _Pred) {
-    // sort preserving order of equivalents, using _Pred
+    // sort preserving order of equivalents
     _Adl_verify_range(_First, _Last);
     const auto _UFirst = _Get_unwrapped(_First);
     const auto _ULast  = _Get_unwrapped(_Last);
@@ -5747,7 +5748,7 @@ void stable_sort(_ExPo&& _Exec, _BidIt _First, _BidIt _Last) noexcept /* termina
 // FUNCTION TEMPLATE partial_sort
 template <class _RanIt, class _Pr>
 _CONSTEXPR20 void partial_sort(_RanIt _First, _RanIt _Mid, _RanIt _Last, _Pr _Pred) {
-    // order [_First, _Last) up to _Mid, using _Pred
+    // order [_First, _Last) up to _Mid
     _Adl_verify_range(_First, _Mid);
     _Adl_verify_range(_Mid, _Last);
     auto _UFirst      = _Get_unwrapped(_First);
@@ -5778,7 +5779,7 @@ _CONSTEXPR20 void partial_sort(_RanIt _First, _RanIt _Mid, _RanIt _Last) {
 #if _HAS_CXX17
 template <class _ExPo, class _RanIt, class _Pr, _Enable_if_execution_policy_t<_ExPo> = 0>
 void partial_sort(_ExPo&&, _RanIt _First, _RanIt _Mid, _RanIt _Last, _Pr _Pred) noexcept /* terminates */ {
-    // order [_First, _Last) up to _Mid, using _Pred
+    // order [_First, _Last) up to _Mid
     // parallelism suspected to be infeasible
     return _STD partial_sort(_First, _Mid, _Last, _Pass_fn(_Pred));
 }
@@ -5794,7 +5795,7 @@ void partial_sort(_ExPo&&, _RanIt _First, _RanIt _Mid, _RanIt _Last) noexcept /*
 // FUNCTION TEMPLATE partial_sort_copy
 template <class _InIt, class _RanIt, class _Pr>
 _CONSTEXPR20 _RanIt partial_sort_copy(_InIt _First1, _InIt _Last1, _RanIt _First2, _RanIt _Last2, _Pr _Pred) {
-    // copy [_First1, _Last1) into [_First2, _Last2) using _Pred
+    // copy [_First1, _Last1) into [_First2, _Last2)
     _Adl_verify_range(_First1, _Last1);
     _Adl_verify_range(_First2, _Last2);
     auto _UFirst1      = _Get_unwrapped(_First1);
@@ -5834,7 +5835,7 @@ _CONSTEXPR20 _RanIt partial_sort_copy(_InIt _First1, _InIt _Last1, _RanIt _First
 template <class _ExPo, class _FwdIt, class _RanIt, class _Pr, _Enable_if_execution_policy_t<_ExPo> = 0>
 _RanIt partial_sort_copy(_ExPo&&, _FwdIt _First1, _FwdIt _Last1, _RanIt _First2, _RanIt _Last2, _Pr _Pred) noexcept
 /* terminates */ {
-    // copy [_First1, _Last1) into [_First2, _Last2) using _Pred
+    // copy [_First1, _Last1) into [_First2, _Last2)
     // parallelism suspected to be infeasible
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt);
     return _STD partial_sort_copy(_First1, _Last1, _First2, _Last2, _Pass_fn(_Pred));
@@ -5853,7 +5854,7 @@ _RanIt partial_sort_copy(_ExPo&&, _FwdIt _First1, _FwdIt _Last1, _RanIt _First2,
 // FUNCTION TEMPLATE nth_element
 template <class _RanIt, class _Pr>
 _CONSTEXPR20 void nth_element(_RanIt _First, _RanIt _Nth, _RanIt _Last, _Pr _Pred) {
-    // order Nth element, using _Pred
+    // order Nth element
     _Adl_verify_range(_First, _Nth);
     _Adl_verify_range(_Nth, _Last);
     auto _UFirst     = _Get_unwrapped(_First);
@@ -5886,7 +5887,7 @@ _CONSTEXPR20 void nth_element(_RanIt _First, _RanIt _Nth, _RanIt _Last) { // ord
 #if _HAS_CXX17
 template <class _ExPo, class _RanIt, class _Pr, _Enable_if_execution_policy_t<_ExPo> = 0>
 void nth_element(_ExPo&&, _RanIt _First, _RanIt _Nth, _RanIt _Last, _Pr _Pred) noexcept /* terminates */ {
-    // order Nth element, using _Pred
+    // order Nth element
     // not parallelized at present, parallelism expected to be feasible in a future release
     _STD nth_element(_First, _Nth, _Last, _Pass_fn(_Pred));
 }
@@ -5902,7 +5903,7 @@ void nth_element(_ExPo&&, _RanIt _First, _RanIt _Nth, _RanIt _Last) noexcept /* 
 // FUNCTION TEMPLATE includes
 template <class _InIt1, class _InIt2, class _Pr>
 _NODISCARD _CONSTEXPR20 bool includes(_InIt1 _First1, _InIt1 _Last1, _InIt2 _First2, _InIt2 _Last2, _Pr _Pred) {
-    // test if every element in sorted [_First2, _Last2) is in sorted [_First1, _Last1), using _Pred
+    // test if every element in sorted [_First2, _Last2) is in sorted [_First1, _Last1)
     _Adl_verify_range(_First1, _Last1);
     _Adl_verify_range(_First2, _Last2);
     auto _UFirst1      = _Get_unwrapped(_First1);
@@ -5935,7 +5936,7 @@ _NODISCARD _CONSTEXPR20 bool includes(_InIt1 _First1, _InIt1 _Last1, _InIt2 _Fir
 template <class _ExPo, class _FwdIt1, class _FwdIt2, class _Pr, _Enable_if_execution_policy_t<_ExPo> = 0>
 _NODISCARD bool includes(_ExPo&&, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2, _FwdIt2 _Last2, _Pr _Pred) noexcept
 /* terminates */ {
-    // test if every element in sorted [_First2, _Last2) is in sorted [_First1, _Last1), using _Pred
+    // test if every element in sorted [_First2, _Last2) is in sorted [_First1, _Last1)
     // not parallelized at present, parallelism expected to be feasible in a future release
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
@@ -5956,7 +5957,7 @@ _NODISCARD bool includes(_ExPo&&, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _Firs
 // FUNCTION TEMPLATE set_union
 template <class _InIt1, class _InIt2, class _OutIt, class _Pr>
 _CONSTEXPR20 _OutIt set_union(_InIt1 _First1, _InIt1 _Last1, _InIt2 _First2, _InIt2 _Last2, _OutIt _Dest, _Pr _Pred) {
-    // OR sets [_First1, _Last1) and [_First2, _Last2), using _Pred
+    // OR sets [_First1, _Last1) and [_First2, _Last2)
     _Adl_verify_range(_First1, _Last1);
     _Adl_verify_range(_First2, _Last2);
     auto _UFirst1      = _Get_unwrapped(_First1);
@@ -5995,7 +5996,7 @@ _CONSTEXPR20 _OutIt set_union(_InIt1 _First1, _InIt1 _Last1, _InIt2 _First2, _In
 template <class _ExPo, class _FwdIt1, class _FwdIt2, class _FwdIt3, class _Pr, _Enable_if_execution_policy_t<_ExPo> = 0>
 _FwdIt3 set_union(_ExPo&&, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2, _FwdIt2 _Last2, _FwdIt3 _Dest,
     _Pr _Pred) noexcept /* terminates */ {
-    // OR sets [_First1, _Last1) and [_First2, _Last2), using _Pred
+    // OR sets [_First1, _Last1) and [_First2, _Last2)
     // not parallelized at present, parallelism expected to be feasible in a future release
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
@@ -6019,7 +6020,7 @@ _FwdIt3 set_union(_ExPo&&, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2, _Fw
 template <class _InIt1, class _InIt2, class _OutIt, class _Pr>
 _CONSTEXPR20 _OutIt set_intersection(
     _InIt1 _First1, _InIt1 _Last1, _InIt2 _First2, _InIt2 _Last2, _OutIt _Dest, _Pr _Pred) {
-    // AND sets [_First1, _Last1) and [_First2, _Last2), using _Pred
+    // AND sets [_First1, _Last1) and [_First2, _Last2)
     _Adl_verify_range(_First1, _Last1);
     _Adl_verify_range(_First2, _Last2);
     auto _UFirst1      = _Get_unwrapped(_First1);
@@ -6069,7 +6070,7 @@ _FwdIt3 set_intersection(_ExPo&& _Exec, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2
 template <class _InIt1, class _InIt2, class _OutIt, class _Pr>
 _CONSTEXPR20 _OutIt set_difference(
     _InIt1 _First1, _InIt1 _Last1, _InIt2 _First2, _InIt2 _Last2, _OutIt _Dest, _Pr _Pred) {
-    // take set [_First2, _Last2) from [_First1, _Last1), using _Pred
+    // take set [_First2, _Last2) from [_First1, _Last1)
     _Adl_verify_range(_First1, _Last1);
     _Adl_verify_range(_First2, _Last2);
     auto _UFirst1      = _Get_unwrapped(_First1);
@@ -6120,7 +6121,7 @@ _FwdIt3 set_difference(_ExPo&& _Exec, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _
 template <class _InIt1, class _InIt2, class _OutIt, class _Pr>
 _CONSTEXPR20 _OutIt set_symmetric_difference(
     _InIt1 _First1, _InIt1 _Last1, _InIt2 _First2, _InIt2 _Last2, _OutIt _Dest, _Pr _Pred) {
-    // XOR sets [_First1, _Last1) and [_First2, _Last2), using _Pred
+    // XOR sets [_First1, _Last1) and [_First2, _Last2)
     _Adl_verify_range(_First1, _Last1);
     _Adl_verify_range(_First2, _Last2);
     auto _UFirst1      = _Get_unwrapped(_First1);
@@ -6161,7 +6162,7 @@ _CONSTEXPR20 _OutIt set_symmetric_difference(
 template <class _ExPo, class _FwdIt1, class _FwdIt2, class _FwdIt3, class _Pr, _Enable_if_execution_policy_t<_ExPo> = 0>
 _FwdIt3 set_symmetric_difference(_ExPo&&, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2, _FwdIt2 _Last2,
     _FwdIt3 _Dest, _Pr _Pred) noexcept /* terminates */ {
-    // XOR sets [_First1, _Last1) and [_First2, _Last2), using _Pred
+    // XOR sets [_First1, _Last1) and [_First2, _Last2)
     // not parallelized at present, parallelism expected to be feasible in a future release
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
@@ -6183,7 +6184,7 @@ _FwdIt3 set_symmetric_difference(_ExPo&&, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdI
 
 // FUNCTION TEMPLATE max_element
 template <class _FwdIt, class _Pr>
-constexpr _FwdIt _Max_element_unchecked(_FwdIt _First, _FwdIt _Last, _Pr _Pred) { // find largest element, using _Pred
+constexpr _FwdIt _Max_element_unchecked(_FwdIt _First, _FwdIt _Last, _Pr _Pred) { // find largest element
     _FwdIt _Found = _First;
     if (_First != _Last) {
         while (++_First != _Last) {
@@ -6197,7 +6198,7 @@ constexpr _FwdIt _Max_element_unchecked(_FwdIt _First, _FwdIt _Last, _Pr _Pred) 
 }
 
 template <class _FwdIt, class _Pr>
-_NODISCARD constexpr _FwdIt max_element(_FwdIt _First, _FwdIt _Last, _Pr _Pred) { // find largest element, using _Pred
+_NODISCARD constexpr _FwdIt max_element(_FwdIt _First, _FwdIt _Last, _Pr _Pred) { // find largest element
     _Adl_verify_range(_First, _Last);
     _Seek_wrapped(_First, _Max_element_unchecked(_Get_unwrapped(_First), _Get_unwrapped(_Last), _Pass_fn(_Pred)));
     return _First;
@@ -6211,7 +6212,7 @@ _NODISCARD constexpr _FwdIt max_element(_FwdIt _First, _FwdIt _Last) { // find l
 #if _HAS_CXX17
 template <class _ExPo, class _FwdIt, class _Pr, _Enable_if_execution_policy_t<_ExPo> = 0>
 _NODISCARD _FwdIt max_element(_ExPo&&, _FwdIt _First, _FwdIt _Last, _Pr _Pred) noexcept /* terminates */ {
-    // find largest element, using _Pred
+    // find largest element
     // not parallelized at present, parallelism expected to be feasible in a future release
     return _STD max_element(_First, _Last, _Pass_fn(_Pred));
 }
@@ -6276,7 +6277,7 @@ namespace ranges {
 
 // FUNCTION TEMPLATE min_element
 template <class _FwdIt, class _Pr>
-constexpr _FwdIt _Min_element_unchecked(_FwdIt _First, _FwdIt _Last, _Pr _Pred) { // find smallest element, using _Pred
+constexpr _FwdIt _Min_element_unchecked(_FwdIt _First, _FwdIt _Last, _Pr _Pred) { // find smallest element
     _FwdIt _Found = _First;
     if (_First != _Last) {
         while (++_First != _Last) {
@@ -6290,7 +6291,7 @@ constexpr _FwdIt _Min_element_unchecked(_FwdIt _First, _FwdIt _Last, _Pr _Pred) 
 }
 
 template <class _FwdIt, class _Pr>
-_NODISCARD constexpr _FwdIt min_element(_FwdIt _First, _FwdIt _Last, _Pr _Pred) { // find smallest element, using _Pred
+_NODISCARD constexpr _FwdIt min_element(_FwdIt _First, _FwdIt _Last, _Pr _Pred) { // find smallest element
     _Adl_verify_range(_First, _Last);
     _Seek_wrapped(_First, _Min_element_unchecked(_Get_unwrapped(_First), _Get_unwrapped(_Last), _Pass_fn(_Pred)));
     return _First;
@@ -6304,7 +6305,7 @@ _NODISCARD constexpr _FwdIt min_element(_FwdIt _First, _FwdIt _Last) { // find s
 #if _HAS_CXX17
 template <class _ExPo, class _FwdIt, class _Pr, _Enable_if_execution_policy_t<_ExPo> = 0>
 _NODISCARD _FwdIt min_element(_ExPo&&, _FwdIt _First, _FwdIt _Last, _Pr _Pred) noexcept /* terminates */ {
-    // find smallest element, using _Pred
+    // find smallest element
     // not parallelized at present, parallelism expected to be feasible in a future release
     return _STD min_element(_First, _Last, _Pass_fn(_Pred));
 }
@@ -6370,7 +6371,7 @@ namespace ranges {
 // FUNCTION TEMPLATE minmax_element
 template <class _FwdIt, class _Pr>
 constexpr pair<_FwdIt, _FwdIt> _Minmax_element_unchecked(_FwdIt _First, _FwdIt _Last, _Pr _Pred) {
-    // find smallest and largest elements, using _Pred
+    // find smallest and largest elements
     pair<_FwdIt, _FwdIt> _Found(_First, _First);
 
     if (_First != _Last) {
@@ -6408,7 +6409,7 @@ constexpr pair<_FwdIt, _FwdIt> _Minmax_element_unchecked(_FwdIt _First, _FwdIt _
 
 template <class _FwdIt, class _Pr>
 _NODISCARD constexpr pair<_FwdIt, _FwdIt> minmax_element(_FwdIt _First, _FwdIt _Last, _Pr _Pred) {
-    // find smallest and largest elements, using _Pred
+    // find smallest and largest elements
     _Adl_verify_range(_First, _Last);
     const auto _Result = _Minmax_element_unchecked(_Get_unwrapped(_First), _Get_unwrapped(_Last), _Pass_fn(_Pred));
     _Seek_wrapped(_Last, _Result.second);
@@ -6426,7 +6427,7 @@ _NODISCARD constexpr pair<_FwdIt, _FwdIt> minmax_element(_FwdIt _First, _FwdIt _
 template <class _ExPo, class _FwdIt, class _Pr, _Enable_if_execution_policy_t<_ExPo> = 0>
 _NODISCARD pair<_FwdIt, _FwdIt> minmax_element(_ExPo&&, _FwdIt _First, _FwdIt _Last, _Pr _Pred) noexcept
 /* terminates */ {
-    // find smallest and largest elements, using _Pred
+    // find smallest and largest elements
     // not parallelized at present, parallelism expected to be feasible in a future release
     return _STD minmax_element(_First, _Last, _Pass_fn(_Pred));
 }
@@ -6817,7 +6818,7 @@ namespace ranges {
 // FUNCTION TEMPLATE next_permutation
 template <class _BidIt, class _Pr>
 _CONSTEXPR20 bool next_permutation(_BidIt _First, _BidIt _Last, _Pr _Pred) {
-    // permute and test for pure ascending, using _Pred
+    // permute and test for pure ascending
     _Adl_verify_range(_First, _Last);
     auto _UFirst      = _Get_unwrapped(_First);
     const auto _ULast = _Get_unwrapped(_Last);
@@ -6855,7 +6856,7 @@ _CONSTEXPR20 bool next_permutation(_BidIt _First, _BidIt _Last) {
 // FUNCTION TEMPLATE prev_permutation
 template <class _BidIt, class _Pr>
 _CONSTEXPR20 bool prev_permutation(_BidIt _First, _BidIt _Last, _Pr _Pred) {
-    // reverse permute and test for pure descending, using _Pred
+    // reverse permute and test for pure descending
     _Adl_verify_range(_First, _Last);
     auto _UFirst      = _Get_unwrapped(_First);
     const auto _ULast = _Get_unwrapped(_Last);
@@ -7033,7 +7034,7 @@ namespace ranges {
 // FUNCTION TEMPLATE clamp
 template <class _Ty, class _Pr>
 _NODISCARD constexpr const _Ty& clamp(const _Ty& _Val, const _Ty& _Min_val, const _Ty& _Max_val, _Pr _Pred) {
-    // returns _Val constrained to [_Min_val, _Max_val] ordered by _Pred
+    // returns _Val constrained to [_Min_val, _Max_val]
 #if _ITERATOR_DEBUG_LEVEL == 2
     if (_DEBUG_LT_PRED(_Pred, _Max_val, _Min_val)) {
         _STL_REPORT_ERROR("invalid bounds arguments passed to std::clamp");

--- a/stl/inc/execution
+++ b/stl/inc/execution
@@ -1871,7 +1871,7 @@ struct _Static_partitioned_mismatch2 {
 template <class _ExPo, class _FwdIt1, class _FwdIt2, class _Pr, _Enable_if_execution_policy_t<_ExPo> /* = 0 */>
 _NODISCARD pair<_FwdIt1, _FwdIt2> mismatch(
     _ExPo&&, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2, _Pr _Pred) noexcept /* terminates */ {
-    // return [_First1, _Last1)/[_First2, ...) mismatch using _Pred
+    // return [_First1, _Last1)/[_First2, ...) mismatch
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
     _Adl_verify_range(_First1, _Last1);
@@ -1913,7 +1913,7 @@ _NODISCARD pair<_FwdIt1, _FwdIt2> mismatch(
 template <class _ExPo, class _FwdIt1, class _FwdIt2, class _Pr, _Enable_if_execution_policy_t<_ExPo> /* = 0 */>
 _NODISCARD pair<_FwdIt1, _FwdIt2> mismatch(
     _ExPo&&, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2, _FwdIt2 _Last2, _Pr _Pred) noexcept /* terminates */ {
-    // return [_First1, _Last1)/[_First2, _Last2) mismatch using _Pred
+    // return [_First1, _Last1)/[_First2, _Last2) mismatch
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
     _Adl_verify_range(_First1, _Last1);
@@ -1991,7 +1991,7 @@ struct _Static_partitioned_equal2 {
 template <class _ExPo, class _FwdIt1, class _FwdIt2, class _Pr, _Enable_if_execution_policy_t<_ExPo> /* = 0 */>
 _NODISCARD bool equal(_ExPo&&, const _FwdIt1 _First1, const _FwdIt1 _Last1, const _FwdIt2 _First2, _Pr _Pred) noexcept
 /* terminates */ {
-    // compare [_First1, _Last1) to [_First2, ...) using _Pred
+    // compare [_First1, _Last1) to [_First2, ...)
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
     _Adl_verify_range(_First1, _Last1);
@@ -2024,7 +2024,7 @@ _NODISCARD bool equal(_ExPo&&, const _FwdIt1 _First1, const _FwdIt1 _Last1, cons
 template <class _ExPo, class _FwdIt1, class _FwdIt2, class _Pr, _Enable_if_execution_policy_t<_ExPo> /* = 0 */>
 _NODISCARD bool equal(_ExPo&&, const _FwdIt1 _First1, const _FwdIt1 _Last1, const _FwdIt2 _First2, const _FwdIt2 _Last2,
     _Pr _Pred) noexcept /* terminates */ {
-    // compare [_First1, _Last1) to [_First2, _Last2) using _Pred
+    // compare [_First1, _Last1) to [_First2, _Last2)
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
     _Adl_verify_range(_First1, _Last1);
@@ -2740,7 +2740,7 @@ struct _Sort_operation { // context for background threads
 
 template <class _ExPo, class _RanIt, class _Pr, _Enable_if_execution_policy_t<_ExPo> /* = 0 */>
 void sort(_ExPo&&, const _RanIt _First, const _RanIt _Last, _Pr _Pred) noexcept /* terminates */ {
-    // order [_First, _Last), using _Pred
+    // order [_First, _Last)
     _Adl_verify_range(_First, _Last);
     const auto _UFirst                = _Get_unwrapped(_First);
     const auto _ULast                 = _Get_unwrapped(_Last);
@@ -2998,7 +2998,7 @@ struct _Static_partitioned_stable_sort3 {
 
 template <class _ExPo, class _BidIt, class _Pr, _Enable_if_execution_policy_t<_ExPo> /* = 0 */>
 void stable_sort(_ExPo&&, const _BidIt _First, const _BidIt _Last, _Pr _Pred) noexcept /* terminates */ {
-    // sort preserving order of equivalents, using _Pred
+    // sort preserving order of equivalents
     _Adl_verify_range(_First, _Last);
     const auto _UFirst = _Get_unwrapped(_First);
     const auto _ULast  = _Get_unwrapped(_Last);
@@ -3314,7 +3314,7 @@ struct _Static_partitioned_is_heap_until {
 
 template <class _ExPo, class _RanIt, class _Pr, _Enable_if_execution_policy_t<_ExPo> /* = 0 */>
 _NODISCARD _RanIt is_heap_until(_ExPo&&, _RanIt _First, _RanIt _Last, _Pr _Pred) noexcept /* terminates */ {
-    // find extent of range that is a heap ordered by _Pred
+    // find extent of range that is a heap
     _REQUIRE_PARALLEL_ITERATOR(_RanIt);
     _Adl_verify_range(_First, _Last);
     const auto _UFirst = _Get_unwrapped(_First);
@@ -3910,7 +3910,7 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, class _FwdIt3, class _Pr,
     _Enable_if_execution_policy_t<_ExPo> /* = 0 */>
 _FwdIt3 set_intersection(_ExPo&&, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2, _FwdIt2 _Last2, _FwdIt3 _Dest,
     _Pr _Pred) noexcept /* terminates */ {
-    // AND sets [_First1, _Last1) and [_First2, _Last2), using _Pred
+    // AND sets [_First1, _Last1) and [_First2, _Last2)
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt3);
@@ -4001,7 +4001,7 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, class _FwdIt3, class _Pr,
     _Enable_if_execution_policy_t<_ExPo> /* = 0 */>
 _FwdIt3 set_difference(_ExPo&&, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2, _FwdIt2 _Last2, _FwdIt3 _Dest,
     _Pr _Pred) noexcept /* terminates */ {
-    // take set [_First2, _Last2) from [_First1, _Last1), using _Pred
+    // take set [_First2, _Last2) from [_First1, _Last1)
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt3);

--- a/stl/inc/forward_list
+++ b/stl/inc/forward_list
@@ -1342,7 +1342,7 @@ private:
     }
 
 public:
-    void sort() { // order sequence, using operator<
+    void sort() { // order sequence
         _Scary_val::_Sort(_Mypair._Myval2._Before_head(), less<>{});
     }
 

--- a/stl/inc/forward_list
+++ b/stl/inc/forward_list
@@ -1347,7 +1347,7 @@ public:
     }
 
     template <class _Pr2>
-    void sort(_Pr2 _Pred) { // order sequence, using _Pred
+    void sort(_Pr2 _Pred) { // order sequence
         _Scary_val::_Sort(_Mypair._Myval2._Before_head(), _Pass_fn(_Pred));
     }
 

--- a/stl/inc/list
+++ b/stl/inc/list
@@ -555,7 +555,7 @@ public:
 
     template <class _Pr2>
     static _Nodeptr _Sort(_Nodeptr& _First, const size_type _Size, _Pr2 _Pred) {
-        // order [_First, _Last), using _Pred, return _First + _Size
+        // order [_First, _Last), return _First + _Size
         switch (_Size) {
         case 0:
             return _First;
@@ -1711,7 +1711,7 @@ public:
     }
 
     template <class _Pr2>
-    void sort(_Pr2 _Pred) { // order sequence, using _Pred
+    void sort(_Pr2 _Pred) { // order sequence
         auto& _My_data = _Mypair._Myval2;
         _Scary_val::_Sort(_My_data._Myhead->_Next, _My_data._Mysize, _Pass_fn(_Pred));
     }

--- a/stl/inc/list
+++ b/stl/inc/list
@@ -1706,7 +1706,7 @@ private:
     }
 
 public:
-    void sort() { // order sequence, using operator<
+    void sort() { // order sequence
         sort(less<>());
     }
 

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -31,7 +31,7 @@ _STD_BEGIN
 template <class _Ty, class _Pr>
 _NODISCARD constexpr const _Ty&(max)(const _Ty& _Left, const _Ty& _Right, _Pr _Pred) noexcept(
     noexcept(_Pred(_Left, _Right))) /* strengthened */ {
-    // return larger of _Left and _Right using _Pred
+    // return larger of _Left and _Right
     return _Pred(_Left, _Right) ? _Right : _Left;
 }
 
@@ -55,7 +55,7 @@ _NODISCARD constexpr _Ty(max)(initializer_list<_Ty>); // implemented in <algorit
 template <class _Ty, class _Pr>
 _NODISCARD constexpr const _Ty&(min)(const _Ty& _Left, const _Ty& _Right, _Pr _Pred) noexcept(
     noexcept(_Pred(_Right, _Left))) /* strengthened */ {
-    // return smaller of _Left and _Right using _Pred
+    // return smaller of _Left and _Right
     return _Pred(_Right, _Left) ? _Right : _Left;
 }
 

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -5794,7 +5794,7 @@ _NODISCARD _CONSTEXPR20 _FwdIt lower_bound(_FwdIt _First, const _FwdIt _Last, co
 
 template <class _FwdIt, class _Ty>
 _NODISCARD _CONSTEXPR20 _FwdIt lower_bound(_FwdIt _First, _FwdIt _Last, const _Ty& _Val) {
-    // find first element not before _Val, using operator<
+    // find first element not before _Val
     return _STD lower_bound(_First, _Last, _Val, less<>());
 }
 

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -4920,7 +4920,7 @@ _INLINE_VAR constexpr bool _Equal_memcmp_is_safe =
 #if _HAS_IF_CONSTEXPR
 template <class _InIt1, class _InIt2, class _Pr>
 _NODISCARD _CONSTEXPR20 bool equal(const _InIt1 _First1, const _InIt1 _Last1, const _InIt2 _First2, _Pr _Pred) {
-    // compare [_First1, _Last1) to [_First2, ...) using _Pred
+    // compare [_First1, _Last1) to [_First2, ...)
     _Adl_verify_range(_First1, _Last1);
     auto _UFirst1      = _Get_unwrapped(_First1);
     const auto _ULast1 = _Get_unwrapped(_Last1);
@@ -4948,7 +4948,7 @@ _NODISCARD _CONSTEXPR20 bool equal(const _InIt1 _First1, const _InIt1 _Last1, co
 #else // ^^^ _HAS_IF_CONSTEXPR / !_HAS_IF_CONSTEXPR vvv
 template <class _InIt1, class _InIt2, class _Pr, enable_if_t<!_Equal_memcmp_is_safe<_InIt1, _InIt2, _Pr>, int> = 0>
 bool _Equal_unchecked(_InIt1 _First1, const _InIt1 _Last1, _InIt2 _First2, _Pr _Pred) {
-    // compare [_First1, _Last1) to [_First2, ...) using _Pred, no special optimization
+    // compare [_First1, _Last1) to [_First2, ...), no special optimization
     for (; _First1 != _Last1; ++_First1, (void) ++_First2) {
         if (!_Pred(*_First1, *_First2)) {
             return false;
@@ -4969,7 +4969,7 @@ bool _Equal_unchecked(const _InIt1 _First1, const _InIt1 _Last1, const _InIt2 _F
 
 template <class _InIt1, class _InIt2, class _Pr>
 _NODISCARD bool equal(const _InIt1 _First1, const _InIt1 _Last1, const _InIt2 _First2, _Pr _Pred) {
-    // compare [_First1, _Last1) to [_First2, ...) using _Pred
+    // compare [_First1, _Last1) to [_First2, ...)
     _Adl_verify_range(_First1, _Last1);
     const auto _UFirst1 = _Get_unwrapped(_First1);
     const auto _ULast1  = _Get_unwrapped(_Last1);
@@ -5003,7 +5003,7 @@ _NODISCARD bool equal(_ExPo&& _Exec, const _FwdIt1 _First1, const _FwdIt1 _Last1
 template <class _InIt1, class _InIt2, class _Pr>
 _NODISCARD _CONSTEXPR20 bool equal(
     const _InIt1 _First1, const _InIt1 _Last1, const _InIt2 _First2, const _InIt2 _Last2, _Pr _Pred) {
-    // compare [_First1, _Last1) to [_First2, _Last2) using _Pred
+    // compare [_First1, _Last1) to [_First2, _Last2)
     _Adl_verify_range(_First1, _Last1);
     _Adl_verify_range(_First2, _Last2);
     auto _UFirst1      = _Get_unwrapped(_First1);
@@ -5039,7 +5039,7 @@ _NODISCARD _CONSTEXPR20 bool equal(
 template <class _InIt1, class _InIt2, class _Pr>
 bool _Equal_unchecked(_InIt1 _First1, const _InIt1 _Last1, _InIt2 _First2, const _InIt2 _Last2, _Pr _Pred,
     input_iterator_tag, input_iterator_tag) {
-    // compare [_First1, _Last1) to [_First2, _Last2) using _Pred, arbitrary iterators
+    // compare [_First1, _Last1) to [_First2, _Last2), arbitrary iterators
     for (;;) {
         if (_First1 == _Last1) {
             return _First2 == _Last2;
@@ -5061,7 +5061,7 @@ bool _Equal_unchecked(_InIt1 _First1, const _InIt1 _Last1, _InIt2 _First2, const
 template <class _InIt1, class _InIt2, class _Pr>
 bool _Equal_unchecked(const _InIt1 _First1, const _InIt1 _Last1, const _InIt2 _First2, const _InIt2 _Last2, _Pr _Pred,
     random_access_iterator_tag, random_access_iterator_tag) {
-    // compare [_First1, _Last1) to [_First2, _Last2) using _Pred, random-access iterators
+    // compare [_First1, _Last1) to [_First2, _Last2), random-access iterators
     if (_Last1 - _First1 != _Last2 - _First2) {
         return false;
     }
@@ -5071,7 +5071,7 @@ bool _Equal_unchecked(const _InIt1 _First1, const _InIt1 _Last1, const _InIt2 _F
 
 template <class _InIt1, class _InIt2, class _Pr>
 _NODISCARD bool equal(const _InIt1 _First1, const _InIt1 _Last1, const _InIt2 _First2, const _InIt2 _Last2, _Pr _Pred) {
-    // compare [_First1, _Last1) to [_First2, _Last2) using _Pred
+    // compare [_First1, _Last1) to [_First2, _Last2)
     _Adl_verify_range(_First1, _Last1);
     _Adl_verify_range(_First2, _Last2);
     return _Equal_unchecked(_Get_unwrapped(_First1), _Get_unwrapped(_Last1), _Get_unwrapped(_First2),
@@ -5159,7 +5159,7 @@ constexpr auto _Lex_compare_memcmp_classify(_Obj1* const&, _Obj2* const&, const 
 template <class _InIt1, class _InIt2, class _Pr>
 _NODISCARD constexpr bool _Lex_compare_unchecked(
     _InIt1 _First1, _InIt1 _Last1, _InIt2 _First2, _InIt2 _Last2, _Pr _Pred, _Lex_compare_optimize<void>) {
-    // order [_First1, _Last1) vs. [_First2, _Last2) using _Pred, no special optimization
+    // order [_First1, _Last1) vs. [_First2, _Last2), no special optimization
     for (; _First1 != _Last1 && _First2 != _Last2; ++_First1, (void) ++_First2) { // something to compare, do it
         if (_DEBUG_LT_PRED(_Pred, *_First1, *_First2)) {
             return true;
@@ -5190,7 +5190,7 @@ _NODISCARD _CONSTEXPR20 bool _Lex_compare_unchecked(
 template <class _InIt1, class _InIt2, class _Pr>
 _NODISCARD _CONSTEXPR20 bool lexicographical_compare(
     _InIt1 _First1, _InIt1 _Last1, _InIt2 _First2, _InIt2 _Last2, _Pr _Pred) {
-    // order [_First1, _Last1) vs. [_First2, _Last2) using _Pred
+    // order [_First1, _Last1) vs. [_First2, _Last2)
     _Adl_verify_range(_First1, _Last1);
     _Adl_verify_range(_First2, _Last2);
     const auto _UFirst1 = _Get_unwrapped(_First1);
@@ -5211,7 +5211,7 @@ _NODISCARD _CONSTEXPR20 bool lexicographical_compare(_InIt1 _First1, _InIt1 _Las
 template <class _ExPo, class _FwdIt1, class _FwdIt2, class _Pr, _Enable_if_execution_policy_t<_ExPo> = 0>
 _NODISCARD bool lexicographical_compare(
     _ExPo&&, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2, _FwdIt2 _Last2, _Pr _Pred) noexcept /* terminates */ {
-    // order [_First1, _Last1) vs. [_First2, _Last2) using _Pred
+    // order [_First1, _Last1) vs. [_First2, _Last2)
     // not parallelized at present, parallelism expected to be feasible in a future release
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
@@ -5772,7 +5772,7 @@ _NODISCARD _CONSTEXPR20 _InIt find_if(_InIt _First, const _InIt _Last, _Pr _Pred
 // FUNCTION TEMPLATE lower_bound
 template <class _FwdIt, class _Ty, class _Pr>
 _NODISCARD _CONSTEXPR20 _FwdIt lower_bound(_FwdIt _First, const _FwdIt _Last, const _Ty& _Val, _Pr _Pred) {
-    // find first element not before _Val, using _Pred
+    // find first element not before _Val
     _Adl_verify_range(_First, _Last);
     auto _UFirst                = _Get_unwrapped(_First);
     _Iter_diff_t<_FwdIt> _Count = _STD distance(_UFirst, _Get_unwrapped(_Last));


### PR DESCRIPTION
As promised in the discussion starting at https://github.com/microsoft/STL/pull/930#discussion_r447328975, this PR removes variations of `using _Pred` and `using operator<` from comments since they are, for the most part, painfully obvious.