### PR TITLE
Code cleanups: remove workarounds, use braces

### DIFF
--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -792,7 +792,7 @@ _NODISCARD pair<_InIt1, _InIt2> mismatch(_InIt1 _First1, _InIt1 _Last1, _InIt2 _
     _Adl_verify_range(_First1, _Last1);
     _Adl_verify_range(_First2, _Last2);
     const auto _Result = _Mismatch_unchecked(_Get_unwrapped(_First1), _Get_unwrapped(_Last1), _Get_unwrapped(_First2),
-        _Get_unwrapped(_Last2), _Pass_fn(_Pred), _Iter_cat_t<_InIt1>(), _Iter_cat_t<_InIt2>());
+        _Get_unwrapped(_Last2), _Pass_fn(_Pred), _Iter_cat_t<_InIt1>{}, _Iter_cat_t<_InIt2>{});
     _Seek_wrapped(_First2, _Result.second);
     _Seek_wrapped(_First1, _Result.first);
     return {_First1, _First2};
@@ -1913,7 +1913,7 @@ _NODISCARD _FwdItHaystack search(_FwdItHaystack _First1, const _FwdItHaystack _L
     _Adl_verify_range(_First2, _Last2);
     _Seek_wrapped(
         _First1, _Search_unchecked(_Get_unwrapped(_First1), _Get_unwrapped(_Last1), _Get_unwrapped(_First2),
-                     _Get_unwrapped(_Last2), _Pass_fn(_Pred), _Iter_cat_t<_FwdItHaystack>(), _Iter_cat_t<_FwdItPat>()));
+                     _Get_unwrapped(_Last2), _Pass_fn(_Pred), _Iter_cat_t<_FwdItHaystack>{}, _Iter_cat_t<_FwdItPat>{}));
     return _First1;
 }
 #endif // _HAS_IF_CONSTEXPR
@@ -2247,7 +2247,7 @@ _NODISCARD _FwdIt search_n(_FwdIt _First, const _FwdIt _Last, const _Diff _Count
 
     _Adl_verify_range(_First, _Last);
     _Seek_wrapped(_First, _Search_n_unchecked1(_Get_unwrapped(_First), _Get_unwrapped(_Last), _Count, _Val,
-                              _Pass_fn(_Pred), _Iter_cat_t<_FwdIt>()));
+                              _Pass_fn(_Pred), _Iter_cat_t<_FwdIt>{}));
 
     return _First;
 }
@@ -2603,7 +2603,7 @@ _NODISCARD _FwdIt1 find_end(_FwdIt1 _First1, const _FwdIt1 _Last1, const _FwdIt2
     _Adl_verify_range(_First2, _Last2);
     _Seek_wrapped(
         _First1, _Find_end_unchecked(_Get_unwrapped(_First1), _Get_unwrapped(_Last1), _Get_unwrapped(_First2),
-                     _Get_unwrapped(_Last2), _Pass_fn(_Pred), _Iter_cat_t<_FwdIt1>(), _Iter_cat_t<_FwdIt2>()));
+                     _Get_unwrapped(_Last2), _Pass_fn(_Pred), _Iter_cat_t<_FwdIt1>{}, _Iter_cat_t<_FwdIt2>{}));
 
     return _First1;
 }
@@ -3639,7 +3639,7 @@ _SampleIt sample(_PopIt _First, _PopIt _Last, _SampleIt _Dest, _Diff _Count,
     _Adl_verify_range(_First, _Last);
     if (0 < _Count) {
         _Rng_from_urng<_Iter_diff_t<_PopIt>, remove_reference_t<_Urng>> _RngFunc(_Func);
-        _Dest = _Sample1(_Get_unwrapped(_First), _Get_unwrapped(_Last), _Dest, _Count, _RngFunc, _Iter_cat_t<_PopIt>());
+        _Dest = _Sample1(_Get_unwrapped(_First), _Get_unwrapped(_Last), _Dest, _Count, _RngFunc, _Iter_cat_t<_PopIt>{});
     }
 
     return _Dest;
@@ -3949,7 +3949,7 @@ _FwdIt partition(_FwdIt _First, const _FwdIt _Last, _Pr _Pred) {
     // move elements satisfying _Pred to beginning of sequence
     _Adl_verify_range(_First, _Last);
     _Seek_wrapped(_First,
-        _Partition_unchecked(_Get_unwrapped(_First), _Get_unwrapped(_Last), _Pass_fn(_Pred), _Iter_cat_t<_FwdIt>()));
+        _Partition_unchecked(_Get_unwrapped(_First), _Get_unwrapped(_Last), _Pass_fn(_Pred), _Iter_cat_t<_FwdIt>{}));
 
     return _First;
 }

--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -1386,7 +1386,7 @@ _NODISCARD shared_ptr<_Ty1> dynamic_pointer_cast(const shared_ptr<_Ty2>& _Other)
         return shared_ptr<_Ty1>(_Other, _Ptr);
     }
 
-    return shared_ptr<_Ty1>();
+    return {};
 }
 
 template <class _Ty1, class _Ty2>
@@ -1398,7 +1398,7 @@ _NODISCARD shared_ptr<_Ty1> dynamic_pointer_cast(shared_ptr<_Ty2>&& _Other) noex
         return shared_ptr<_Ty1>(_STD move(_Other), _Ptr);
     }
 
-    return shared_ptr<_Ty1>();
+    return {};
 }
 #else // _CPPRTTI
 template <class _Ty1, class _Ty2>
@@ -2730,7 +2730,7 @@ _NODISCARD bool operator<(const unique_ptr<_Ty1, _Dx1>& _Left, const unique_ptr<
     using _Ptr1   = typename unique_ptr<_Ty1, _Dx1>::pointer;
     using _Ptr2   = typename unique_ptr<_Ty2, _Dx2>::pointer;
     using _Common = common_type_t<_Ptr1, _Ptr2>;
-    return less<_Common>()(_Left.get(), _Right.get());
+    return less<_Common>{}(_Left.get(), _Right.get());
 }
 
 template <class _Ty1, class _Dx1, class _Ty2, class _Dx2>
@@ -2771,13 +2771,13 @@ _NODISCARD bool operator!=(nullptr_t _Left, const unique_ptr<_Ty, _Dx>& _Right) 
 template <class _Ty, class _Dx>
 _NODISCARD bool operator<(const unique_ptr<_Ty, _Dx>& _Left, nullptr_t _Right) {
     using _Ptr = typename unique_ptr<_Ty, _Dx>::pointer;
-    return less<_Ptr>()(_Left.get(), _Right);
+    return less<_Ptr>{}(_Left.get(), _Right);
 }
 
 template <class _Ty, class _Dx>
 _NODISCARD bool operator<(nullptr_t _Left, const unique_ptr<_Ty, _Dx>& _Right) {
     using _Ptr = typename unique_ptr<_Ty, _Dx>::pointer;
-    return less<_Ptr>()(_Left, _Right.get());
+    return less<_Ptr>{}(_Left, _Right.get());
 }
 
 template <class _Ty, class _Dx>

--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -1822,13 +1822,13 @@ public:
     template <class _InIt>
     basic_regex(_InIt _First, _InIt _Last, flag_type _Flags) : _Rep(nullptr) {
         _Adl_verify_range(_First, _Last);
-        _Reset(_Get_unwrapped(_First), _Get_unwrapped(_Last), _Flags, _Iter_cat_t<_InIt>());
+        _Reset(_Get_unwrapped(_First), _Get_unwrapped(_Last), _Flags, _Iter_cat_t<_InIt>{});
     }
 
     template <class _InIt>
     basic_regex(_InIt _First, _InIt _Last) : _Rep(nullptr) {
         _Adl_verify_range(_First, _Last);
-        _Reset(_Get_unwrapped(_First), _Get_unwrapped(_Last), regex_constants::ECMAScript, _Iter_cat_t<_InIt>());
+        _Reset(_Get_unwrapped(_First), _Get_unwrapped(_Last), regex_constants::ECMAScript, _Iter_cat_t<_InIt>{});
     }
 
     basic_regex(const basic_regex& _Right)
@@ -1939,7 +1939,7 @@ public:
     template <class _InIt>
     basic_regex& assign(_InIt _First, _InIt _Last, flag_type _Flags = regex_constants::ECMAScript) {
         _Adl_verify_range(_First, _Last);
-        _Reset(_Get_unwrapped(_First), _Get_unwrapped(_Last), _Flags, _Iter_cat_t<_InIt>());
+        _Reset(_Get_unwrapped(_First), _Get_unwrapped(_Last), _Flags, _Iter_cat_t<_InIt>{});
         return *this;
     }
 

--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -336,7 +336,7 @@ public:
         unsigned int _Ix = 0;
         for (; _Names[_Ix]._Get<_Elem>(); ++_Ix) {
             if (_STD equal(_Get_unwrapped(_First), _Get_unwrapped(_Last), _Names[_Ix]._Get<_Elem>(),
-                    _Names[_Ix]._Get<_Elem>() + _Names[_Ix]._Len, _Cmp_icase<_Regex_traits<_Elem>>(*this))) {
+                    _Names[_Ix]._Get<_Elem>() + _Names[_Ix]._Len, _Cmp_icase<_Regex_traits<_Elem>>{*this})) {
                 break;
             }
         }
@@ -3292,11 +3292,11 @@ _BidIt1 _Compare(_BidIt1 _Begin1, _BidIt1 _End1, _BidIt2 _Begin2, _BidIt2 _End2,
     regex_constants::syntax_option_type _Sflags) { // compare character ranges
     _BidIt1 _Res = _End1;
     if (_Sflags & regex_constants::icase) {
-        _Res = _Cmp_chrange(_Begin1, _End1, _Begin2, _End2, _Cmp_icase<_RxTraits>(_Traits));
+        _Res = _Cmp_chrange(_Begin1, _End1, _Begin2, _End2, _Cmp_icase<_RxTraits>{_Traits});
     } else if (_Sflags & regex_constants::collate) {
-        _Res = _Cmp_chrange(_Begin1, _End1, _Begin2, _End2, _Cmp_collate<_RxTraits>(_Traits));
+        _Res = _Cmp_chrange(_Begin1, _End1, _Begin2, _End2, _Cmp_collate<_RxTraits>{_Traits});
     } else {
-        _Res = _Cmp_chrange(_Begin1, _End1, _Begin2, _End2, _Cmp_cs<_RxTraits>());
+        _Res = _Cmp_chrange(_Begin1, _End1, _Begin2, _End2, _Cmp_cs<_RxTraits>{});
     }
 
     return _Res;

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -522,7 +522,7 @@ template <size_t _Idx, class _Ty1, class _Ty2>
 _NODISCARD constexpr tuple_element_t<_Idx, pair<_Ty1, _Ty2>>& get(
     pair<_Ty1, _Ty2>& _Pr) noexcept { // get reference to element at _Idx in pair _Pr
     using _Rtype = tuple_element_t<_Idx, pair<_Ty1, _Ty2>>&;
-    return _Pair_get<_Rtype>(_Pr, integral_constant<size_t, _Idx>());
+    return _Pair_get<_Rtype>(_Pr, integral_constant<size_t, _Idx>{});
 }
 
 template <class _Ty1, class _Ty2>
@@ -539,7 +539,7 @@ template <size_t _Idx, class _Ty1, class _Ty2>
 _NODISCARD constexpr const tuple_element_t<_Idx, pair<_Ty1, _Ty2>>& get(
     const pair<_Ty1, _Ty2>& _Pr) noexcept { // get const reference to element at _Idx in pair _Pr
     using _Ctype = const tuple_element_t<_Idx, pair<_Ty1, _Ty2>>&;
-    return _Pair_get<_Ctype>(_Pr, integral_constant<size_t, _Idx>());
+    return _Pair_get<_Ctype>(_Pr, integral_constant<size_t, _Idx>{});
 }
 
 template <class _Ty1, class _Ty2>

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -2668,7 +2668,7 @@ public:
     template <class _Iter, enable_if_t<_Is_iterator_v<_Iter>, int> = 0>
     iterator insert(const_iterator _Where, _Iter _First, _Iter _Last) {
         difference_type _Off = _Where - begin();
-        _Insert(_Where, _First, _Last, _Iter_cat_t<_Iter>());
+        _Insert(_Where, _First, _Last, _Iter_cat_t<_Iter>{});
         return begin() + _Off;
     }
 

--- a/stl/inc/xpolymorphic_allocator.h
+++ b/stl/inc/xpolymorphic_allocator.h
@@ -63,7 +63,7 @@ template <class _Ty, class _Outer_alloc, class _Inner_alloc, class... _Types,
     enable_if_t<!_Is_specialization_v<_Ty, pair>, int> = 0>
 void _Uses_allocator_construct(_Ty* const _Ptr, _Outer_alloc& _Outer, _Inner_alloc& _Inner, _Types&&... _Args) {
     // uses-allocator construction of *_Ptr by alloc _Outer propagating alloc _Inner, non-pair case
-    _Uses_allocator_construct1(uses_allocator<_Ty, _Inner_alloc>(), _Ptr, _Outer, _Inner,
+    _Uses_allocator_construct1(uses_allocator<_Ty, _Inner_alloc>{}, _Ptr, _Outer, _Inner,
         _STD forward<_Types>(_Args)...); // TRANSITION, if constexpr
 }
 
@@ -93,8 +93,8 @@ void _Uses_allocator_construct_pair(pair<_Ty1, _Ty2>* const _Ptr, _Outer_alloc& 
     tuple<_Types1...>&& _Val1, tuple<_Types2...>&& _Val2) {
     // uses-allocator construction of pair from _Val1 and _Val2 by alloc _Outer propagating alloc _Inner
     allocator_traits<_Outer_alloc>::construct(_Outer, _Ptr, piecewise_construct,
-        _Uses_allocator_piecewise<_Ty1>(uses_allocator<_Ty1, _Inner_alloc>(), _Inner, _STD move(_Val1)),
-        _Uses_allocator_piecewise<_Ty2>(uses_allocator<_Ty2, _Inner_alloc>(), _Inner, _STD move(_Val2)));
+        _Uses_allocator_piecewise<_Ty1>(uses_allocator<_Ty1, _Inner_alloc>{}, _Inner, _STD move(_Val1)),
+        _Uses_allocator_piecewise<_Ty2>(uses_allocator<_Ty2, _Inner_alloc>{}, _Inner, _STD move(_Val2)));
 }
 
 template <class _Ty1, class _Ty2, class _Outer_alloc, class _Inner_alloc, class... _Types1, class... _Types2>

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -2436,7 +2436,7 @@ public:
         _Container_proxy_ptr<_Alty> _Proxy(_Alproxy, _Mypair._Myval2);
         _Tidy_init();
         _Adl_verify_range(_First, _Last);
-        _Construct(_Get_unwrapped(_First), _Get_unwrapped(_Last), _Iter_cat_t<_Iter>());
+        _Construct(_Get_unwrapped(_First), _Get_unwrapped(_Last), _Iter_cat_t<_Iter>{});
         _Proxy._Release();
     }
 

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -1552,7 +1552,7 @@ _NODISCARD constexpr _Iter_diff_t<_Checked> _Idl_distance1(
 template <class _Checked, class _Iter>
 _NODISCARD constexpr auto _Idl_distance(const _Iter& _First, const _Iter& _Last) {
     // tries to get the distance between _First and _Last if they are random-access iterators
-    return _Idl_distance1<_Checked>(_First, _Last, _Iter_cat_t<_Iter>());
+    return _Idl_distance1<_Checked>(_First, _Last, _Iter_cat_t<_Iter>{});
 }
 #endif // _HAS_IF_CONSTEXPR
 
@@ -1636,7 +1636,7 @@ constexpr void _Debug_order_unchecked2(_FwdIt _First, _Sentinel _Last, _Pr& _Pre
 template <class _InIt, class _Sentinel, class _Pr>
 constexpr void _Debug_order_unchecked(_InIt _First, _Sentinel _Last, _Pr&& _Pred) {
     // test if range is ordered by predicate
-    _Debug_order_unchecked2(_First, _Last, _Pred, _Iter_cat_t<_InIt>());
+    _Debug_order_unchecked2(_First, _Last, _Pred, _Iter_cat_t<_InIt>{});
 }
 #endif // _HAS_IF_CONSTEXPR
 
@@ -1675,7 +1675,7 @@ constexpr void _Debug_order_set_unchecked2(
 template <class _OtherIt, class _InIt, class _Pr>
 constexpr void _Debug_order_set_unchecked(_InIt _First, _InIt _Last, _Pr&& _Pred) {
     // test if range is ordered by predicate
-    _Debug_order_set_unchecked2(_First, _Last, _Pred, _Iter_cat_t<_InIt>(),
+    _Debug_order_set_unchecked2(_First, _Last, _Pred, _Iter_cat_t<_InIt>{},
         _Priority_tag<is_same_v<_Iter_value_t<_OtherIt>, _Iter_value_t<_InIt>>>());
 }
 #endif // _HAS_IF_CONSTEXPR
@@ -1758,7 +1758,7 @@ template <class _InIt, class _Diff>
 _CONSTEXPR17 void advance(_InIt& _Where, _Diff _Off) {
     // increment iterator by offset, arbitrary iterators
     // we remove_const_t before _Iter_cat_t for better diagnostics if the user passes an iterator that is const
-    _Advance1(_Where, _Off, _Iter_cat_t<remove_const_t<_InIt>>());
+    _Advance1(_Where, _Off, _Iter_cat_t<remove_const_t<_InIt>>{});
 }
 #endif // _HAS_IF_CONSTEXPR
 
@@ -1803,7 +1803,7 @@ _CONSTEXPR17 _Iter_diff_t<_RanIt> _Distance1(_RanIt _First, _RanIt _Last, random
 
 template <class _InIt>
 _NODISCARD _CONSTEXPR17 _Iter_diff_t<_InIt> distance(_InIt _First, _InIt _Last) {
-    return _Distance1(_First, _Last, _Iter_cat_t<_InIt>());
+    return _Distance1(_First, _Last, _Iter_cat_t<_InIt>{});
 }
 #endif // _HAS_IF_CONSTEXPR
 
@@ -5075,7 +5075,7 @@ _NODISCARD bool equal(const _InIt1 _First1, const _InIt1 _Last1, const _InIt2 _F
     _Adl_verify_range(_First1, _Last1);
     _Adl_verify_range(_First2, _Last2);
     return _Equal_unchecked(_Get_unwrapped(_First1), _Get_unwrapped(_Last1), _Get_unwrapped(_First2),
-        _Get_unwrapped(_Last2), _Pass_fn(_Pred), _Iter_cat_t<_InIt1>(), _Iter_cat_t<_InIt2>());
+        _Get_unwrapped(_Last2), _Pass_fn(_Pred), _Iter_cat_t<_InIt1>{}, _Iter_cat_t<_InIt2>{});
 }
 #endif // _HAS_IF_CONSTEXPR
 
@@ -5468,7 +5468,7 @@ _NODISCARD _CONSTEXPR20 bool _Check_match_counts(
         ++_Last2;
     }
 #else // ^^^ _HAS_IF_CONSTEXPR // !_HAS_IF_CONSTEXPR vvv
-    _Trim_matching_suffixes(_Last1, _Last2, _Pred, _Iter_cat_t<_FwdIt1>(), _Iter_cat_t<_FwdIt2>());
+    _Trim_matching_suffixes(_Last1, _Last2, _Pred, _Iter_cat_t<_FwdIt1>{}, _Iter_cat_t<_FwdIt2>{});
 #endif // _HAS_IF_CONSTEXPR
     for (_FwdIt1 _Next1 = _First1; _Next1 != _Last1; ++_Next1) {
         if (_Next1 == _Find_pr(_First1, _Next1, *_Next1, _Pred)) { // new value, compare match counts
@@ -5729,7 +5729,7 @@ _FwdIt _Rotate_unchecked(_FwdIt _First, _FwdIt _Mid, _FwdIt _Last) {
         return _First;
     }
 
-    return _Rotate_unchecked1(_First, _Mid, _Last, _Iter_cat_t<_FwdIt>());
+    return _Rotate_unchecked1(_First, _Mid, _Last, _Iter_cat_t<_FwdIt>{});
 }
 
 template <class _FwdIt>

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -1676,7 +1676,7 @@ template <class _OtherIt, class _InIt, class _Pr>
 constexpr void _Debug_order_set_unchecked(_InIt _First, _InIt _Last, _Pr&& _Pred) {
     // test if range is ordered by predicate
     _Debug_order_set_unchecked2(_First, _Last, _Pred, _Iter_cat_t<_InIt>{},
-        _Priority_tag<is_same_v<_Iter_value_t<_OtherIt>, _Iter_value_t<_InIt>>>());
+        _Priority_tag<is_same_v<_Iter_value_t<_OtherIt>, _Iter_value_t<_InIt>>>{});
 }
 #endif // _HAS_IF_CONSTEXPR
 #endif // _ITERATOR_DEBUG_LEVEL < 2

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -1167,10 +1167,7 @@
 #define __cpp_lib_coroutine 197000L
 #endif // __cpp_impl_coroutine
 
-#ifdef __cpp_impl_destroying_delete
-#define __cpp_lib_destroying_delete 201806L
-#endif // __cpp_impl_destroying_delete
-
+#define __cpp_lib_destroying_delete            201806L
 #define __cpp_lib_endian                       201907L
 #define __cpp_lib_erase_if                     202002L
 #define __cpp_lib_generic_unordered_lookup     201811L

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -396,12 +396,8 @@
 // warning C4412: function signature contains type 'meow'; C++ objects are unsafe to pass between pure code
 //                and mixed or native. (/Wall)
 // warning C4455: literal suffix identifiers that do not start with an underscore are reserved
-// warning C4472: 'meow' is a native enum: add an access specifier (private/public)
-//                to declare a managed enum (/Wall)
 // warning C4494: Ignoring __declspec(allocator) because the function return type is not a pointer or reference
 // warning C4514: unreferenced inline function has been removed (/Wall)
-// warning C4571: Informational: catch(...) semantics changed since Visual C++ 7.1;
-//                structured exceptions (SEH) are no longer caught (/Wall)
 // warning C4574: 'MACRO' is defined to be '0': did you mean to use '#if MACRO'? (/Wall)
 // warning C4582: 'union': constructor is not implicitly called (/Wall)
 // warning C4583: 'union': destructor is not implicitly called (/Wall)
@@ -425,9 +421,9 @@
 #ifndef _STL_DISABLED_WARNINGS
 // clang-format off
 #define _STL_DISABLED_WARNINGS                        \
-    4180 4412 4455 4472 4494 4514 4571 4574 4582 4583 \
-    4587 4588 4619 4623 4625 4626 4643 4648 4702 4793 \
-    4820 4988 5026 5027 5045 6294                     \
+    4180 4412 4455 4494 4514 4574 4582 4583 4587 4588 \
+    4619 4623 4625 4626 4643 4648 4702 4793 4820 4988 \
+    5026 5027 5045 6294                               \
     _STL_DISABLED_WARNING_C4577                       \
     _STL_DISABLED_WARNING_C4984                       \
     _STL_DISABLED_WARNING_C5053                       \

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -498,9 +498,7 @@ std/thread/thread.semaphore/version.pass.cpp FAIL
 
 
 # *** MISSING COMPILER FEATURES ***
-# C++20 P0722R3 "Efficient sized delete for variable sized classes" // TRANSITION, VS2019 16.7p1
-std/language.support/support.dynamic/destroying_delete_t_declaration.pass.cpp:0 SKIPPED
-std/language.support/support.dynamic/destroying_delete_t.pass.cpp:0 SKIPPED
+# Nothing here! :-)
 
 
 # *** MISSING LWG ISSUE RESOLUTIONS ***

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -498,9 +498,7 @@ thread\thread.semaphore\version.pass.cpp
 
 
 # *** MISSING COMPILER FEATURES ***
-# C++20 P0722R3 "Efficient sized delete for variable sized classes" // TRANSITION, VS2019 16.7p1
-language.support\support.dynamic\destroying_delete_t_declaration.pass.cpp
-language.support\support.dynamic\destroying_delete_t.pass.cpp
+# Nothing here! :-)
 
 
 # *** MISSING LWG ISSUE RESOLUTIONS ***

--- a/tests/std/tests/P0898R3_concepts/test.cpp
+++ b/tests/std/tests/P0898R3_concepts/test.cpp
@@ -1433,9 +1433,7 @@ namespace test_constructible_from {
     };
     STATIC_ASSERT(!test<Multiparameter>());
     STATIC_ASSERT(test<Multiparameter, int>());
-#if defined(__clang__) || defined(__EDG__) || _MSC_VER >= 1927 // TRANSITION, VS 2019 16.7 Preview 1
     STATIC_ASSERT(!test<Multiparameter, long>() || is_permissive);
-#endif // TRANSITION, VS 2019 16.7 Preview 1
     STATIC_ASSERT(!test<Multiparameter, double>());
     STATIC_ASSERT(!test<Multiparameter, char>());
     STATIC_ASSERT(!test<Multiparameter, void>());

--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.cpp
@@ -453,7 +453,7 @@ STATIC_ASSERT(__cpp_lib_constexpr_utility == 201811L);
 #endif
 #endif
 
-#if _HAS_CXX20 && defined(__cpp_impl_destroying_delete) // TRANSITION, EDG and VS 2019 16.7p1
+#if _HAS_CXX20
 #ifndef __cpp_lib_destroying_delete
 #error __cpp_lib_destroying_delete is not defined
 #elif __cpp_lib_destroying_delete != 201806L


### PR DESCRIPTION
* Fix #433: Warnings C4472 and C4571 were removed in VS 2019 16.6.
* Fix #693: Remove workarounds now that we require VS 2019 16.7.
* Use braces to construct tags (especially `_Iter_cat_t`), function objects, and empty `shared_ptr`s.

In the libcxx skip lists, we'll inevitably need the "missing compiler features" sections again, so they're preserved here.