### PR TITLE
Style cleanup of requires\s*\(

### DIFF
--- a/stl/inc/concepts
+++ b/stl/inc/concepts
@@ -199,7 +199,7 @@ concept _Boolean_testable_impl = convertible_to<_Ty, bool>;
 
 template <class _Ty>
 concept _Boolean_testable = _Boolean_testable_impl<_Ty>
-    && requires (_Ty&& __t) {
+    && requires(_Ty&& __t) {
         { !static_cast<_Ty&&>(__t) } -> _Boolean_testable_impl;
     };
 

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -1909,8 +1909,9 @@ public:
     }
 
 #ifdef __cpp_lib_concepts
+    // clang-format off
     _NODISCARD constexpr pointer operator->() const
-        requires(is_pointer_v<_BidIt> || requires(const _BidIt __i) { __i.operator->(); }) {
+        requires (is_pointer_v<_BidIt> || requires(const _BidIt __i) { __i.operator->(); }) {
         _BidIt _Tmp = current;
         --_Tmp;
         if constexpr (is_pointer_v<_BidIt>) {
@@ -1919,6 +1920,7 @@ public:
             return _Tmp.operator->();
         }
     }
+    // clang-format on
 #else // ^^^ __cpp_lib_concepts / !__cpp_lib_concepts vvv
     _NODISCARD _CONSTEXPR17 pointer operator->() const {
         _BidIt _Tmp = current;

--- a/tests/std/include/range_algorithm_support.hpp
+++ b/tests/std/include/range_algorithm_support.hpp
@@ -109,15 +109,19 @@ namespace test {
 
         using unwrap = sentinel<Element, IsWrapped::no>;
 
-        [[nodiscard]] constexpr auto _Unwrapped() const noexcept requires(to_bool(Wrapped)) {
+        // clang-format off
+        [[nodiscard]] constexpr auto _Unwrapped() const noexcept requires (to_bool(Wrapped)) {
             return unwrap{ptr_};
         }
+        // clang-format on
 
         static constexpr bool _Unwrap_when_unverified = true;
 
-        constexpr void _Seek_to(unwrap const& s) noexcept requires(to_bool(Wrapped)) {
+        // clang-format off
+        constexpr void _Seek_to(unwrap const& s) noexcept requires (to_bool(Wrapped)) {
             ptr_ = s.peek();
         }
+        // clang-format on
     };
 
     // clang-format off

--- a/tests/std/tests/P0896R4_P1614R2_comparisons/test.cpp
+++ b/tests/std/tests/P0896R4_P1614R2_comparisons/test.cpp
@@ -83,19 +83,21 @@ struct three_way_archetype {
     three_way_archetype(three_way_archetype const&) = delete;
     three_way_archetype& operator=(three_way_archetype const&) = delete;
     ~three_way_archetype()                                     = delete;
+    // clang-format off
     // 0: not equality_comparable
-    bool operator==(three_way_archetype const&) const requires(I == 0) = delete;
-    bool operator==(three_way_archetype const&) const requires(I != 0);
+    bool operator==(three_way_archetype const&) const requires (I == 0) = delete;
+    bool operator==(three_way_archetype const&) const requires (I != 0);
     // 1: not totally_ordered
-    bool operator<(three_way_archetype const&) const requires(I == 1) = delete;
-    bool operator<(three_way_archetype const&) const requires(I != 1);
-    bool operator>(three_way_archetype const&) const requires(I != 1);
-    bool operator<=(three_way_archetype const&) const requires(I != 1);
-    bool operator>=(three_way_archetype const&) const requires(I != 1);
+    bool operator<(three_way_archetype const&) const requires (I == 1) = delete;
+    bool operator<(three_way_archetype const&) const requires (I != 1);
+    bool operator>(three_way_archetype const&) const requires (I != 1);
+    bool operator<=(three_way_archetype const&) const requires (I != 1);
+    bool operator>=(three_way_archetype const&) const requires (I != 1);
     // 2: <=> isn't defined
-    Category operator<=>(three_way_archetype const&) const requires(I != 2 && I != 3);
+    Category operator<=>(three_way_archetype const&) const requires (I != 2 && I != 3);
     // 3: <=> doesn't return a comparison category type
-    int operator<=>(three_way_archetype const&) const requires(I == 3);
+    int operator<=>(three_way_archetype const&) const requires (I == 3);
+    // clang-format on
 };
 constexpr int three_way_archetype_max = 4;
 

--- a/tests/std/tests/P0896R4_ranges_algorithm_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_algorithm_machinery/test.cpp
@@ -61,8 +61,9 @@ template <int I, class T = int>
 struct simple_iter_archetype {
     using value_type = T;
 
-    simple_reference<T> operator*() const requires(I != 0); // 0: not indirectly_readable
-
+    // clang-format off
+    simple_reference<T> operator*() const requires (I != 0); // 0: not indirectly_readable
+    // clang-format on
     friend void iter_swap(simple_iter_archetype const&, simple_iter_archetype const&) {}
 };
 STATIC_ASSERT(!std::indirectly_readable<simple_iter_archetype<0>>);
@@ -92,21 +93,23 @@ namespace indirectly_unary_invocable_test {
 
     template <int I>
     struct Fn : base<I> {
+        // clang-format off
         // 1: not invocable<Fn&, iter_value_t<simple_iter_archetype>&>
-        void operator()(int&) const requires(I == 1) = delete;
+        void operator()(int&) const requires (I == 1) = delete;
         // 2: not invocable<Fn&, iter_reference_t<simple_iter_archetype>>
-        void operator()(simple_reference<int>) const requires(I == 2) = delete;
+        void operator()(simple_reference<int>) const requires (I == 2) = delete;
         // 3: not invocable<Fn&, iter_common_reference_t<simple_iter_archetype>>
-        void operator()(simple_common_reference<int>) const requires(I == 3) = delete;
+        void operator()(simple_common_reference<int>) const requires (I == 3) = delete;
 
         // 4 : not common_reference_with<invoke_result_t<Fn&, iter_value_t<simple_iter_archetype>&>,
         //                               invoke_result_t<Fn&, iter_reference_t<simple_iter_archetype>>>;
-        void operator()(int&) const requires(I == 4);
-        int operator()(simple_reference<int>) const requires(I == 4);
+        void operator()(int&) const requires (I == 4);
+        int operator()(simple_reference<int>) const requires (I == 4);
 
-        int operator()(int&) const requires(I != 1 && I != 4);
-        int operator()(simple_reference<int>) const requires(I != 2 && I != 4);
-        int operator()(simple_common_reference<int>) const requires(I != 3 && I != 4);
+        int operator()(int&) const requires (I != 1 && I != 4);
+        int operator()(simple_reference<int>) const requires (I != 2 && I != 4);
+        int operator()(simple_common_reference<int>) const requires (I != 3 && I != 4);
+        // clang-format on
     };
 
     template <class F, class I>
@@ -141,17 +144,19 @@ namespace indirect_unary_predicate_test {
 
     template <int I>
     struct Fn : base<I> {
+        // clang-format off
         // 1: not predicate<Fn&, iter_value_t<simple_iter_archetype>&>
-        void operator()(int&) const requires(I == 1);
+        void operator()(int&) const requires (I == 1);
         // 2: not predicate<Fn&, iter_reference_t<simple_iter_archetype>>
-        void operator()(simple_reference<int>) const requires(I == 2) = delete;
+        void operator()(simple_reference<int>) const requires (I == 2) = delete;
         // 3: not predicate<Fn&, iter_common_reference_t<simple_iter_archetype>>
-        void operator()(simple_common_reference<int>) const requires(I == 3) = delete;
+        void operator()(simple_common_reference<int>) const requires (I == 3) = delete;
 
         // 4: all of the above
-        int operator()(int&) const requires(I != 1 && I != 4);
-        int operator()(simple_reference<int>) const requires(I != 2 && I != 4);
-        int operator()(simple_common_reference<int>) const requires(I != 3 && I != 4);
+        int operator()(int&) const requires (I != 1 && I != 4);
+        int operator()(simple_reference<int>) const requires (I != 2 && I != 4);
+        int operator()(simple_common_reference<int>) const requires (I != 3 && I != 4);
+        // clang-format on
     };
 
     STATIC_ASSERT(!indirect_unary_predicate<Fn<0>, simple_iter_archetype<1>>);
@@ -179,22 +184,24 @@ namespace indirect_binary_predicate_test {
 
     template <int I>
     struct Fn : base<I> {
+        // clang-format off
         // 1: not predicate<Fn&, iter_value_t<simple_iter_archetype>&, iter_value_t<simple_iter_archetype>&>
-        void operator()(int&, int&) const requires(I == 1);
+        void operator()(int&, int&) const requires (I == 1);
         // 2: not predicate<Fn&, iter_value_t<simple_iter_archetype>&, iter_reference_t<simple_iter_archetype>>
-        void operator()(int&, simple_reference<int>) const requires(I == 2);
+        void operator()(int&, simple_reference<int>) const requires (I == 2);
         // 3: not predicate<Fn&, iter_reference_t<simple_iter_archetype>, iter_value_t<simple_iter_archetype>&>
-        void operator()(simple_reference<int>, int&) const requires(I == 3);
+        void operator()(simple_reference<int>, int&) const requires (I == 3);
         // 4: not predicate<Fn&, iter_reference_t<simple_iter_archetype>, iter_reference_t<simple_iter_archetype>>
-        void operator()(simple_reference<int>, simple_reference<int>) const requires(I == 4);
+        void operator()(simple_reference<int>, simple_reference<int>) const requires (I == 4);
         // 5: not predicate<Fn&, iter_common_reference_t</**/>, iter_common_reference_t</**/>>
-        void operator()(simple_common_reference<int>, simple_common_reference<int>) const requires(I == 5);
+        void operator()(simple_common_reference<int>, simple_common_reference<int>) const requires (I == 5);
 
-        bool operator()(int&, int&) const requires(I != 1);
-        int operator()(int&, simple_reference<int>) const requires(I != 2);
-        int* operator()(simple_reference<int>, int&) const requires(I != 3);
-        std::true_type operator()(simple_reference<int>, simple_reference<int>) const requires(I != 4);
-        std::false_type operator()(simple_common_reference<int>, simple_common_reference<int>) const requires(I != 5);
+        bool operator()(int&, int&) const requires (I != 1);
+        int operator()(int&, simple_reference<int>) const requires (I != 2);
+        int* operator()(simple_reference<int>, int&) const requires (I != 3);
+        std::true_type operator()(simple_reference<int>, simple_reference<int>) const requires (I != 4);
+        std::false_type operator()(simple_common_reference<int>, simple_common_reference<int>) const requires (I != 5);
+        // clang-format on
     };
 
     template <int FuncSelector, int IterSelector1, int IterSelector2>
@@ -260,17 +267,19 @@ namespace indirectly_movable_test { // also covers indirectly_movable_storable
 
     template <int I>
     struct value_type {
+        // clang-format off
         value_type()             = default;
         value_type(value_type&&) = default;
-        value_type& operator=(value_type&&) requires(I != 0) = default; // 0: not movable
+        value_type& operator=(value_type&&) requires (I != 0) = default; // 0: not movable
         // 1: not constructible_from<iter_rvalue_reference_t<In>>:
         template <class T>
-        value_type(simple_reference<T>) requires(I == 1) = delete;
+        value_type(simple_reference<T>) requires (I == 1) = delete;
         // 2: not assignable_from<iter_rvalue_reference_t<In>>:
         template <class T>
-        value_type& operator=(simple_reference<T>) requires(I != 2);
+        value_type& operator=(simple_reference<T>) requires (I != 2);
         template <class T>
-        void operator=(simple_reference<T>) requires(I == 2) = delete;
+        void operator=(simple_reference<T>) requires (I == 2) = delete;
+        // clang-format on
     };
     // Ensure specializations of value_type have the intended properties
     STATIC_ASSERT(!movable<value_type<0>>);
@@ -291,11 +300,11 @@ namespace indirectly_movable_test { // also covers indirectly_movable_storable
         // clang-format off
         out_archetype& operator*() const;
         // 0: not indirectly_writable<simple_reference>
-        void operator=(simple_reference<value_type<J>>&&) const requires(I == 0) = delete;
-        void operator=(simple_reference<value_type<J>>&&) const requires(I != 0);
+        void operator=(simple_reference<value_type<J>>&&) const requires (I == 0) = delete;
+        void operator=(simple_reference<value_type<J>>&&) const requires (I != 0);
         // 1: not indirectly_writable<value_type>
-        void operator=(value_type<J>&&) const requires(I == 1) = delete;
-        void operator=(value_type<J>&&) const requires(I != 1);
+        void operator=(value_type<J>&&) const requires (I == 1) = delete;
+        void operator=(value_type<J>&&) const requires (I != 1);
         // clang-format on
     };
     // Ensure specializations of out_archetype have the intended properties
@@ -328,15 +337,17 @@ namespace indirectly_copyable_test { // also covers indirectly_copyable_storable
     struct value_type {
         value_type()                  = default;
         value_type(value_type const&) = default;
-        value_type& operator=(value_type const&) requires(I != 0) = default; // 0: not copyable
+        // clang-format off
+        value_type& operator=(value_type const&) requires (I != 0) = default; // 0: not copyable
         // 1: not constructible_from<iter_reference_t<In>>:
         template <class T>
-        value_type(simple_reference<T>) requires(I == 1) = delete;
+        value_type(simple_reference<T>) requires (I == 1) = delete;
         // 2: not assignable_from<iter_reference_t<In>>:
         template <class T>
-        value_type& operator=(simple_reference<T>) requires(I != 2);
+        value_type& operator=(simple_reference<T>) requires (I != 2);
         template <class T>
-        void operator=(simple_reference<T>) requires(I == 2) = delete;
+        void operator=(simple_reference<T>) requires (I == 2) = delete;
+        // clang-format on
     };
     // Ensure specializations of value_type have the intended properties
     STATIC_ASSERT(!copyable<value_type<0>>);
@@ -357,20 +368,20 @@ namespace indirectly_copyable_test { // also covers indirectly_copyable_storable
         // clang-format off
         out_archetype& operator*() const;
         // 0: not indirectly_writable<simple_reference>
-        void operator=(simple_reference<value_type<J>>&&) const requires(I == 0) = delete;
-        void operator=(simple_reference<value_type<J>>&&) const requires(I != 0);
+        void operator=(simple_reference<value_type<J>>&&) const requires (I == 0) = delete;
+        void operator=(simple_reference<value_type<J>>&&) const requires (I != 0);
         // 1: not indirectly_writable<value_type&>
-        void operator=(value_type<J>&) const requires(I == 1) = delete;
-        void operator=(value_type<J>&) const requires(I != 1);
+        void operator=(value_type<J>&) const requires (I == 1) = delete;
+        void operator=(value_type<J>&) const requires (I != 1);
         // 2: not indirectly_writable<value_type&&>
-        void operator=(value_type<J>&&) const requires(I == 2) = delete;
-        void operator=(value_type<J>&&) const requires(I != 2);
+        void operator=(value_type<J>&&) const requires (I == 2) = delete;
+        void operator=(value_type<J>&&) const requires (I != 2);
         // 3: not indirectly_writable<const value_type&&>
-        void operator=(value_type<J> const&&) const requires(I == 3) = delete;
-        void operator=(value_type<J> const&&) const requires(I != 3);
+        void operator=(value_type<J> const&&) const requires (I == 3) = delete;
+        void operator=(value_type<J> const&&) const requires (I != 3);
         // 4: not indirectly_writable<const value_type&>
-        void operator=(value_type<J> const&) const requires(I == 4) = delete;
-        void operator=(value_type<J> const&) const requires(I != 4);
+        void operator=(value_type<J> const&) const requires (I == 4) = delete;
+        void operator=(value_type<J> const&) const requires (I != 4);
         // clang-format on
     };
     // Ensure specializations of out_archetype have the intended properties
@@ -439,13 +450,13 @@ namespace indirectly_swappable_test {
             operator int() const;
         };
 
-        reference operator*() const noexcept requires(I != 0);
-
-        friend constexpr void iter_swap(archetype const&, archetype const&) requires(I != 1) {}
-
         // clang-format off
+        reference operator*() const noexcept requires (I != 0);
+
+        friend constexpr void iter_swap(archetype const&, archetype const&) requires (I != 1) {}
+
         template <int J>
-            requires(I != J && I != 2 && J != 2)
+            requires (I != J && I != 2 && J != 2)
         friend constexpr void iter_swap(archetype const&, archetype<J> const&) {}
         // clang-format on
     };
@@ -503,9 +514,11 @@ namespace indirectly_comparable_test {
 
     template <int I>
     struct Fn : base<I> {
+        // clang-format off
         // 1: not predicate
-        void operator()(int, int) const requires(I == 1);
-        void* operator()(int, int) const requires(I != 1);
+        void operator()(int, int) const requires (I == 1);
+        void* operator()(int, int) const requires (I != 1);
+        // clang-format on
     };
 
     STATIC_ASSERT(!indirectly_comparable<simple_iter_archetype<1>, simple_iter_archetype<1>, Fn<0>, Proj, Proj>);
@@ -711,7 +724,9 @@ namespace permutable_test {
 
             operator int() const;
             // 1: not indirectly_movable_storable<archetype, archetype>
-            void operator=(int) const requires(I != 1);
+            // clang-format off
+            void operator=(int) const requires (I != 1);
+            // clang-format on
         };
 
         proxy operator*() const;
@@ -719,8 +734,10 @@ namespace permutable_test {
         archetype& operator++();
         archetype operator++(int);
 
+        // clang-format off
         // 0: not forward_iterator (input only)
-        bool operator==(archetype const&) const requires(I != 0) = default;
+        bool operator==(archetype const&) const requires (I != 0) = default;
+        // clang-format on
 
         friend int iter_move(archetype const&) {
             return 42;

--- a/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
@@ -305,13 +305,15 @@ struct destructible_archetype<0> {
 };
 inline constexpr std::size_t destructible_archetype_max = 1;
 
-#define SEMIREGULAR_OPS(prefix)                                                \
-    prefix##_archetype() requires(I != 1);                                     \
-    prefix##_archetype(prefix##_archetype const&) requires(I != 2);            \
-    prefix##_archetype(prefix##_archetype&&) requires(I == 3) = delete;        \
-                                                                               \
-    prefix##_archetype& operator=(prefix##_archetype const&) requires(I != 4); \
-    prefix##_archetype& operator=(prefix##_archetype&&) requires(I == 5) = delete
+// clang-format off
+#define SEMIREGULAR_OPS(prefix)                                                 \
+    prefix##_archetype() requires (I != 1);                                     \
+    prefix##_archetype(prefix##_archetype const&) requires (I != 2);            \
+    prefix##_archetype(prefix##_archetype&&) requires (I == 3) = delete;        \
+                                                                                \
+    prefix##_archetype& operator=(prefix##_archetype const&) requires (I != 4); \
+    prefix##_archetype& operator=(prefix##_archetype&&) requires (I == 5) = delete
+// clang-format on
 
 template <std::size_t I>
 struct semiregular_archetype : destructible_archetype<I> {
@@ -337,22 +339,26 @@ struct weakly_incrementable_archetype_dt<8> {
 
 template <std::size_t I, class Derived, class Post = void>
 struct increment_ops {
-    void operator++() requires(I == 9);
-    Derived operator++() requires(I == 10);
-    Derived& operator++() requires(I < 9 || I >= 11);
-    Post operator++(int) requires(I != 11);
+    // clang-format off
+    void operator++() requires (I == 9);
+    Derived operator++() requires (I == 10);
+    Derived& operator++() requires (I < 9 || I >= 11);
+    Post operator++(int) requires (I != 11);
+    // clang-format on
 };
 
 template <std::size_t I>
 struct weakly_incrementable_archetype : destructible_archetype<I>,
                                         weakly_incrementable_archetype_dt<I>,
                                         increment_ops<I, weakly_incrementable_archetype<I>, void> {
-    weakly_incrementable_archetype() requires(I != 1) {}
+    // clang-format off
+    weakly_incrementable_archetype() requires (I != 1) {}
     weakly_incrementable_archetype(weakly_incrementable_archetype const&)                      = delete;
-    weakly_incrementable_archetype(weakly_incrementable_archetype&&) requires(I < 2 || I >= 4) = default;
+    weakly_incrementable_archetype(weakly_incrementable_archetype&&) requires (I < 2 || I >= 4) = default;
 
     weakly_incrementable_archetype& operator=(weakly_incrementable_archetype const&) = delete;
-    weakly_incrementable_archetype& operator=(weakly_incrementable_archetype&&) requires(I < 4 || I >= 6) = default;
+    weakly_incrementable_archetype& operator=(weakly_incrementable_archetype&&) requires (I < 4 || I >= 6) = default;
+    // clang-format on
 };
 
 inline constexpr std::size_t weakly_incrementable_archetype_max = 12;
@@ -363,9 +369,11 @@ struct incrementable_archetype : weakly_incrementable_archetype<I>,
     SEMIREGULAR_OPS(incrementable);
     using increment_ops<I, incrementable_archetype<I>, incrementable_archetype<I>>::operator++;
 
-    bool operator==(incrementable_archetype const&) const requires(I != weakly_incrementable_archetype_max);
+    // clang-format off
+    bool operator==(incrementable_archetype const&) const requires (I != weakly_incrementable_archetype_max);
     bool operator!=(incrementable_archetype const&) const
-        requires(I == weakly_incrementable_archetype_max + 1) = delete;
+        requires (I == weakly_incrementable_archetype_max + 1) = delete;
+    // clang-format on
 };
 
 inline constexpr std::size_t incrementable_archetype_max = 14;
@@ -374,11 +382,13 @@ template <std::size_t I>
 struct iterator_archetype : weakly_incrementable_archetype<I> {
     SEMIREGULAR_OPS(iterator);
 
-    iterator_archetype& operator++() requires(I > 10);
-    void operator++(int) requires(I != 11);
+    // clang-format off
+    iterator_archetype& operator++() requires (I > 10);
+    void operator++(int) requires (I != 11);
 
-    void operator*() requires(I == 12);
-    int operator*() requires(I != 12);
+    void operator*() requires (I == 12);
+    int operator*() requires (I != 12);
+    // clang-format on
 };
 
 inline constexpr std::size_t iterator_archetype_max = 13;
@@ -432,12 +442,14 @@ struct output_iterator_archetype : iterator_archetype<I>,
     SEMIREGULAR_OPS(output_iterator);
     using increment_ops<I, output_iterator_archetype<I>, output_iterator_archetype<I>&>::operator++;
 
+    // clang-format off
     // dereference ops from iterator_archetype
-    void operator*() requires(I == 12);
-    output_iterator_archetype& operator*() requires(I != 12);
+    void operator*() requires (I == 12);
+    output_iterator_archetype& operator*() requires (I != 12);
 
     // indirectly_writable requirements
-    void operator=(int) requires(I != 13);
+    void operator=(int) requires (I != 13);
+    // clang-format on
 };
 
 inline constexpr std::size_t output_iterator_archetype_max = 14;
@@ -470,9 +482,11 @@ struct input_iterator_archetype : iterator_archetype<I>,
     SEMIREGULAR_OPS(input_iterator);
     using increment_ops<I, input_iterator_archetype<I>, void>::operator++;
 
+    // clang-format off
     // dereference ops from iterator_archetype
-    void operator*() const requires(I == 12);
-    int& operator*() const requires(I != 12);
+    void operator*() const requires (I == 12);
+    int& operator*() const requires (I != 12);
+    // clang-format on
 };
 
 inline constexpr std::size_t input_iterator_archetype_max = 17;
@@ -483,18 +497,22 @@ struct forward_iterator_archetype : input_iterator_archetype<I>,
     SEMIREGULAR_OPS(forward_iterator);
     using increment_ops<I, forward_iterator_archetype<I>, forward_iterator_archetype<I>>::operator++;
 
-    bool operator==(forward_iterator_archetype const&) const requires(I != input_iterator_archetype_max);
-    bool operator!=(forward_iterator_archetype const&) const requires(I == input_iterator_archetype_max + 1) = delete;
+    // clang-format off
+    bool operator==(forward_iterator_archetype const&) const requires (I != input_iterator_archetype_max);
+    bool operator!=(forward_iterator_archetype const&) const requires (I == input_iterator_archetype_max + 1) = delete;
+    // clang-format on
 };
 
 inline constexpr std::size_t forward_iterator_archetype_max = 19;
 
 template <std::size_t I, class Derived>
 struct decrement_ops {
-    void operator--() requires(I == 19);
-    Derived operator--() requires(I == 20);
-    Derived& operator--() requires(I < 19 || I >= 21);
-    Derived operator--(int) requires(I != 21);
+    // clang-format off
+    void operator--() requires (I == 19);
+    Derived operator--() requires (I == 20);
+    Derived& operator--() requires (I < 19 || I >= 21);
+    Derived operator--(int) requires (I != 21);
+    // clang-format on
 };
 
 template <std::size_t I>
@@ -515,20 +533,22 @@ struct random_iterator_archetype : bidi_iterator_archetype<I>,
     using increment_ops<I, random_iterator_archetype<I>, random_iterator_archetype<I>>::operator++;
     using decrement_ops<I, random_iterator_archetype<I>>::operator--;
 
-    std::strong_ordering operator<=>(random_iterator_archetype const&) const requires(I != 22);
+    // clang-format off
+    std::strong_ordering operator<=>(random_iterator_archetype const&) const requires (I != 22);
 
-    int operator-(random_iterator_archetype const&) const requires(I != 6 && I != 23);
+    int operator-(random_iterator_archetype const&) const requires (I != 6 && I != 23);
 
-    random_iterator_archetype& operator+=(int) requires(I != 24);
-    random_iterator_archetype operator+(int) const requires(I != 25);
-    friend random_iterator_archetype operator+(int, random_iterator_archetype const&) requires(I != 26) {}
+    random_iterator_archetype& operator+=(int) requires (I != 24);
+    random_iterator_archetype operator+(int) const requires (I != 25);
+    friend random_iterator_archetype operator+(int, random_iterator_archetype const&) requires (I != 26) {}
 
-    random_iterator_archetype& operator-=(int) requires(I != 27);
-    random_iterator_archetype operator-(int) const requires(I != 28);
+    random_iterator_archetype& operator-=(int) requires (I != 27);
+    random_iterator_archetype operator-(int) const requires (I != 28);
 
-    void operator[](int) const requires(I == 29);
-    int operator[](int) const requires(I == 30);
-    int& operator[](int) const requires(I < 29 || I >= 31);
+    void operator[](int) const requires (I == 29);
+    int operator[](int) const requires (I == 30);
+    int& operator[](int) const requires (I < 29 || I >= 31);
+    // clang-format on
 };
 
 inline constexpr std::size_t random_iterator_archetype_max = 31;
@@ -561,14 +581,16 @@ struct contig_iterator_archetype : increment_ops<I, contig_iterator_archetype<I>
     using increment_ops<I, contig_iterator_archetype<I>, contig_iterator_archetype<I>>::operator++;
     using decrement_ops<I, contig_iterator_archetype<I>>::operator--;
 
-    int operator-(contig_iterator_archetype const&) const requires(I != 6 && I != 23);
+    // clang-format off
+    int operator-(contig_iterator_archetype const&) const requires (I != 6 && I != 23);
 
-    contig_iterator_archetype& operator+=(int) requires(I != 24);
-    contig_iterator_archetype operator+(int) const requires(I != 25);
-    friend contig_iterator_archetype operator+(int, contig_iterator_archetype const&) requires(I != 26) {}
+    contig_iterator_archetype& operator+=(int) requires (I != 24);
+    contig_iterator_archetype operator+(int) const requires (I != 25);
+    friend contig_iterator_archetype operator+(int, contig_iterator_archetype const&) requires (I != 26) {}
 
-    contig_iterator_archetype& operator-=(int) requires(I != 27);
-    contig_iterator_archetype operator-(int) const requires(I != 28);
+    contig_iterator_archetype& operator-=(int) requires (I != 27);
+    contig_iterator_archetype operator-(int) const requires (I != 28);
+    // clang-format on
 };
 
 template <std::size_t I>
@@ -1873,11 +1895,13 @@ namespace iter_ops {
             return *this;
         }
 
-        constexpr trace_iterator& operator=(default_sentinel_t) requires(Assign == assign::yes) {
+        // clang-format off
+        constexpr trace_iterator& operator=(default_sentinel_t) requires (Assign == assign::yes) {
             ++trace_->assignments_;
             pos_ = sentinel_position;
             return *this;
         }
+        // clang-format on
 
         int operator*() const;
 

--- a/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
@@ -353,7 +353,7 @@ struct weakly_incrementable_archetype : destructible_archetype<I>,
                                         increment_ops<I, weakly_incrementable_archetype<I>, void> {
     // clang-format off
     weakly_incrementable_archetype() requires (I != 1) {}
-    weakly_incrementable_archetype(weakly_incrementable_archetype const&)                      = delete;
+    weakly_incrementable_archetype(weakly_incrementable_archetype const&)                       = delete;
     weakly_incrementable_archetype(weakly_incrementable_archetype&&) requires (I < 2 || I >= 4) = default;
 
     weakly_incrementable_archetype& operator=(weakly_incrementable_archetype const&) = delete;

--- a/tests/std/tests/P0896R4_ranges_range_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_range_machinery/test.cpp
@@ -1289,91 +1289,93 @@ constexpr bool test_array_ish() { // An actual runtime test!
 }
 
 namespace nothrow_testing {
+    // clang-format off
     template <unsigned int I, bool NoThrow>
     struct range {
         int elements_[3];
 
         // begin/end are members for I == 0, and non-members otherwise
-        int* begin() noexcept(NoThrow) requires(I == 0) {
+        int* begin() noexcept(NoThrow) requires (I == 0) {
             return elements_;
         }
-        int* end() noexcept(NoThrow) requires(I == 0) {
+        int* end() noexcept(NoThrow) requires (I == 0) {
             return elements_ + 3;
         }
-        int const* begin() const noexcept(NoThrow) requires(I == 0) {
+        int const* begin() const noexcept(NoThrow) requires (I == 0) {
             return elements_;
         }
-        int const* end() const noexcept(NoThrow) requires(I == 0) {
+        int const* end() const noexcept(NoThrow) requires (I == 0) {
             return elements_ + 3;
         }
 
         // rbegin/rend are members for I == 0, not provided for I == 1, and non-members otherwise
         // (Not providing operations allows us to test the library-provided fallback behavior)
-        int* rbegin() noexcept(NoThrow) requires(I == 0) {
+        int* rbegin() noexcept(NoThrow) requires (I == 0) {
             return elements_;
         }
-        int* rend() noexcept(NoThrow) requires(I == 0) {
+        int* rend() noexcept(NoThrow) requires (I == 0) {
             return elements_ + 3;
         }
-        int const* rbegin() const noexcept(NoThrow) requires(I == 0) {
+        int const* rbegin() const noexcept(NoThrow) requires (I == 0) {
             return elements_;
         }
-        int const* rend() const noexcept(NoThrow) requires(I == 0) {
+        int const* rend() const noexcept(NoThrow) requires (I == 0) {
             return elements_ + 3;
         }
 
         // empty is not provided when I == 1
-        bool empty() const noexcept(NoThrow) requires(I != 1) {
+        bool empty() const noexcept(NoThrow) requires (I != 1) {
             return false;
         }
 
         // data is not provided when I == 2
-        int* data() noexcept(NoThrow) requires(I != 2) {
+        int* data() noexcept(NoThrow) requires (I != 2) {
             return elements_;
         }
-        int const* data() const noexcept(NoThrow) requires(I != 2) {
+        int const* data() const noexcept(NoThrow) requires (I != 2) {
             return elements_;
         }
 
         // size is not provided when I == 3
-        std::size_t size() const noexcept(NoThrow) requires(I != 3) {
+        std::size_t size() const noexcept(NoThrow) requires (I != 3) {
             return 3;
         }
     };
 
     template <unsigned int I, bool NoThrow>
-    int* begin(range<I, NoThrow>& a) noexcept(NoThrow) requires(I != 0) {
+    int* begin(range<I, NoThrow>& a) noexcept(NoThrow) requires (I != 0) {
         return a.elements_;
     }
     template <unsigned int I, bool NoThrow>
-    int* end(range<I, NoThrow>& a) noexcept(NoThrow) requires(I != 0) {
+    int* end(range<I, NoThrow>& a) noexcept(NoThrow) requires (I != 0) {
         return a.elements_ + 3;
     }
     template <unsigned int I, bool NoThrow>
-    int const* begin(range<I, NoThrow> const& a) noexcept(NoThrow) requires(I != 0) {
+    int const* begin(range<I, NoThrow> const& a) noexcept(NoThrow) requires (I != 0) {
         return a.elements_;
     }
     template <unsigned int I, bool NoThrow>
-    int const* end(range<I, NoThrow> const& a) noexcept(NoThrow) requires(I != 0) {
+    int const* end(range<I, NoThrow> const& a) noexcept(NoThrow) requires (I != 0) {
         return a.elements_ + 3;
     }
 
     template <unsigned int I, bool NoThrow>
-    int* rbegin(range<I, NoThrow>& a) noexcept(NoThrow) requires(I > 2) {
+    int* rbegin(range<I, NoThrow>& a) noexcept(NoThrow) requires (I > 2) {
         return a.elements_;
     }
     template <unsigned int I, bool NoThrow>
-    int* rend(range<I, NoThrow>& a) noexcept(NoThrow) requires(I > 2) {
+    int* rend(range<I, NoThrow>& a) noexcept(NoThrow) requires (I > 2) {
         return a.elements_ + 3;
     }
     template <unsigned int I, bool NoThrow>
-    int const* rbegin(range<I, NoThrow> const& a) noexcept(NoThrow) requires(I > 2) {
+    int const* rbegin(range<I, NoThrow> const& a) noexcept(NoThrow) requires (I > 2) {
         return a.elements_;
     }
     template <unsigned int I, bool NoThrow>
-    int const* rend(range<I, NoThrow> const& a) noexcept(NoThrow) requires(I > 2) {
+    int const* rend(range<I, NoThrow> const& a) noexcept(NoThrow) requires (I > 2) {
         return a.elements_ + 3;
     }
+    // clang-format on
 
     template <class T, bool Nothrow>
     constexpr bool test() {

--- a/tests/std/tests/P0898R3_concepts/test.cpp
+++ b/tests/std/tests/P0898R3_concepts/test.cpp
@@ -180,7 +180,9 @@ template <class First, class Second = IncompleteClass>
 struct ConvertsFrom {
     ConvertsFrom() = default;
     constexpr ConvertsFrom(First) noexcept {}
-    constexpr ConvertsFrom(Second) noexcept requires(!std::is_same_v<IncompleteClass, Second>) {}
+    // clang-format off
+    constexpr ConvertsFrom(Second) noexcept requires (!std::is_same_v<IncompleteClass, Second>) {}
+    // clang-format on
 };
 
 template <int>


### PR DESCRIPTION
To consistently follow the guidelines established in #982.

Fixes #982.
