### PR TITLE
Status Chart improvements

### DIFF
--- a/index.html
+++ b/index.html
@@ -186,46 +186,39 @@
             return table.filter(row => row[key] !== undefined).map(row => ({ x: row.date, y: row[key] }));
         }
 
-        const date_values = table.map(row => row.date);
-        const cxx17_values = get_values('cxx17');
-        const cxx20_values = get_values('cxx20');
-        const lwg_values = get_values('lwg');
-        const bugs_values = get_values('bugs');
-        const libcxx_values = get_values('libcxx');
-
         const chart_data = {
-            labels: date_values,
+            labels: table.map(row => row.date),
             datasets: [
                 {
-                    data: cxx17_values,
+                    data: get_values('cxx17'),
                     label: 'C++17 Features',
                     borderColor: '#00B050',
                     backgroundColor: '#00B050',
                     yAxisID: 'small-axis',
                 },
                 {
-                    data: cxx20_values,
+                    data: get_values('cxx20'),
                     label: 'C++20 Features',
                     borderColor: '#7030A0',
                     backgroundColor: '#7030A0',
                     yAxisID: 'small-axis',
                 },
                 {
-                    data: lwg_values,
+                    data: get_values('lwg'),
                     label: 'LWG Issues',
                     borderColor: '#0070C0',
                     backgroundColor: '#0070C0',
                     yAxisID: 'small-axis',
                 },
                 {
-                    data: bugs_values,
+                    data: get_values('bugs'),
                     label: 'Bugs',
                     borderColor: '#FF0000',
                     backgroundColor: '#FF0000',
                     yAxisID: 'large-axis',
                 },
                 {
-                    data: libcxx_values,
+                    data: get_values('libcxx'),
                     label: 'Libcxx Skips',
                     borderColor: '#FFC000',
                     backgroundColor: '#FFC000',
@@ -322,8 +315,7 @@
         };
 
         window.onload = function () {
-            const ctx = 'statusChart';
-            window.status_chart = new Chart(ctx, {
+            window.status_chart = new Chart('statusChart', {
                 type: 'line',
                 data: chart_data,
                 options: chart_options,

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
     <canvas id="statusChart"></canvas>
     <button id="toggleTimeframe">Toggle Timeframe: All/GitHub</button>
     <script>
-        let table = [
+        const table = [
             { date: '2017-06-09', cxx17: 17, lwg: 44, bugs: 247, libcxx: 526 },
             { date: '2017-06-16', cxx17: 17, lwg: 43, bugs: 246, libcxx: 526 },
             { date: '2017-06-23', cxx17: 17, lwg: 43, bugs: 249, libcxx: 517 },
@@ -186,14 +186,14 @@
             return table.filter(row => row[key] != null).map(row => ({ x: row.date, y: row[key] }));
         }
 
-        let date_values = table.map(row => row.date);
-        let cxx17_values = get_values('cxx17');
-        let cxx20_values = get_values('cxx20');
-        let lwg_values = get_values('lwg');
-        let bugs_values = get_values('bugs');
-        let libcxx_values = get_values('libcxx');
+        const date_values = table.map(row => row.date);
+        const cxx17_values = get_values('cxx17');
+        const cxx20_values = get_values('cxx20');
+        const lwg_values = get_values('lwg');
+        const bugs_values = get_values('bugs');
+        const libcxx_values = get_values('libcxx');
 
-        let chart_data = {
+        const chart_data = {
             labels: date_values,
             datasets: [
                 {
@@ -235,7 +235,7 @@
         };
 
         let timeframe_idx = 0;
-        let timeframes = [
+        const timeframes = [
             {
                 ticks: { min: '2017-06-09' },
                 time: { unit: 'quarter' },
@@ -246,7 +246,7 @@
             },
         ];
 
-        let chart_options = {
+        const chart_options = {
             title: {
                 display: true,
                 fontSize: 24,
@@ -322,7 +322,7 @@
         };
 
         window.onload = function () {
-            let ctx = 'statusChart';
+            const ctx = 'statusChart';
             window.status_chart = new Chart(ctx, {
                 type: 'line',
                 data: chart_data,
@@ -333,8 +333,8 @@
         document.getElementById('toggleTimeframe').addEventListener('click', function () {
             timeframe_idx = (timeframe_idx + 1) % timeframes.length;
 
-            let xAxis = window.status_chart.options.scales.xAxes[0];
-            let new_timeframe = timeframes[timeframe_idx];
+            const xAxis = window.status_chart.options.scales.xAxes[0];
+            const new_timeframe = timeframes[timeframe_idx];
 
             xAxis.ticks.min = new_timeframe.ticks.min;
             xAxis.time.unit = new_timeframe.time.unit;

--- a/index.html
+++ b/index.html
@@ -205,7 +205,7 @@
                 },
                 {
                     data: get_values('lwg'),
-                    label: 'LWG Issues',
+                    label: 'LWG Resolutions',
                     borderColor: '#0070C0',
                     backgroundColor: '#0070C0',
                     yAxisID: 'small-axis',
@@ -219,7 +219,7 @@
                 },
                 {
                     data: get_values('libcxx'),
-                    label: 'Libcxx Skips',
+                    label: 'Skipped Libcxx Tests',
                     borderColor: '#FFC000',
                     backgroundColor: '#FFC000',
                     yAxisID: 'large-axis',
@@ -287,7 +287,7 @@
                         position: 'left',
                         scaleLabel: {
                             display: true,
-                            labelString: 'Bugs, Skips',
+                            labelString: 'Bugs, Skipped Libcxx Tests',
                         },
                         ticks: {
                             min: 0,
@@ -302,7 +302,7 @@
                         position: 'right',
                         scaleLabel: {
                             display: true,
-                            labelString: 'Features, Issues',
+                            labelString: 'Features, LWG Resolutions',
                         },
                         ticks: {
                             min: 0,

--- a/index.html
+++ b/index.html
@@ -183,7 +183,7 @@
         ];
 
         function get_values(key) {
-            return table.filter(row => row[key] != null).map(row => ({ x: row.date, y: row[key] }));
+            return table.filter(row => row[key] !== undefined).map(row => ({ x: row.date, y: row[key] }));
         }
 
         const date_values = table.map(row => row.date);


### PR DESCRIPTION
* Use `const` for all variables except `timeframe_idx`.
  + This is like top-level `const` in C++, in that it means "won't be rebound" instead of "deeply immutable". Preferring this by default appears to be a modern practice.
* Change `row[key] != null` to `row[key] !== undefined`.
  + Non-existent properties are `undefined`. We should use the `!==` operator to look for exactly this. The `!=` operator performs confusing conversions, which is why the code "worked" before.
* Avoid unnecessary named variables.
  + These were being referred to exactly once, and weren't providing any significant clarity.
* Rephrase data and axis labels to "LWG Resolutions" and "Skipped Libcxx Tests".
  + This avoids referring to LWG "Issues", in preparation for tracking GitHub Issues eventually. Also, "Skips" was overly terse.

Live preview: [stephantlavavej.github.io/STL/](https://stephantlavavej.github.io/STL/)
