### PR TITLE
Correct naked `if constexpr` in C++14 mode

### DIFF
--- a/stl/inc/limits
+++ b/stl/inc/limits
@@ -1041,7 +1041,6 @@ _NODISCARD constexpr int _Countr_zero_fallback(const _Ty _Val) noexcept {
 }
 
 #if defined(_M_IX86) || defined(_M_X64)
-
 // TRANSITION, VS 2019 16.8 Preview 1, intrin0.h will declare _tzcnt*
 extern "C" {
 extern int __isa_available;
@@ -1068,7 +1067,7 @@ _NODISCARD int _Checked_x86_x64_countr_zero(const _Ty _Val) noexcept {
     }
 #endif // __AVX2__
 
-    if constexpr (_Digits <= 32) {
+    if _CONSTEXPR_IF (_Digits <= 32) {
         // Intended widening to int. This operation means that a narrow 0 will widen
         // to 0xFFFF....FFFF0... instead of 0. We need this to avoid counting all the zeros
         // of the wider type.


### PR DESCRIPTION
Fixes VSO-1152720.
