### PR TITLE
Code cleanup: Brace for impact

### DIFF
--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -549,7 +549,7 @@ _NODISCARD _FwdIt adjacent_find(_ExPo&& _Exec, _FwdIt _First, _FwdIt _Last, _Pr 
 template <class _ExPo, class _FwdIt, _Enable_if_execution_policy_t<_ExPo> = 0>
 _NODISCARD _FwdIt adjacent_find(_ExPo&& _Exec, const _FwdIt _First, const _FwdIt _Last) noexcept /* terminates */ {
     // find first matching successor
-    return _STD adjacent_find(_STD forward<_ExPo>(_Exec), _First, _Last, equal_to<>{});
+    return _STD adjacent_find(_STD forward<_ExPo>(_Exec), _First, _Last, equal_to{});
 }
 #endif // _HAS_CXX17
 
@@ -726,7 +726,7 @@ _NODISCARD pair<_FwdIt1, _FwdIt2> mismatch(
     // return [_First1, _Last1)/[_First2, ...) mismatch
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
-    return _STD mismatch(_STD forward<_ExPo>(_Exec), _First1, _Last1, _First2, equal_to<>{});
+    return _STD mismatch(_STD forward<_ExPo>(_Exec), _First1, _Last1, _First2, equal_to{});
 }
 #endif // _HAS_CXX17
 
@@ -818,7 +818,7 @@ _NODISCARD pair<_FwdIt1, _FwdIt2> mismatch(
     // return [_First1, _Last1)/[_First2, _Last2) mismatch
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
-    return _STD mismatch(_STD forward<_ExPo>(_Exec), _First1, _Last1, _First2, _Last2, equal_to<>{});
+    return _STD mismatch(_STD forward<_ExPo>(_Exec), _First1, _Last1, _First2, _Last2, equal_to{});
 }
 #endif // _HAS_CXX17
 
@@ -1936,7 +1936,7 @@ template <class _ExPo, class _FwdItHaystack, class _FwdItPat, _Enable_if_executi
 _NODISCARD _FwdItHaystack search(_ExPo&& _Exec, const _FwdItHaystack _First1, const _FwdItHaystack _Last1,
     const _FwdItPat _First2, const _FwdItPat _Last2) noexcept /* terminates */ {
     // find first [_First2, _Last2) match
-    return _STD search(_STD forward<_ExPo>(_Exec), _First1, _Last1, _First2, _Last2, equal_to<>{});
+    return _STD search(_STD forward<_ExPo>(_Exec), _First1, _Last1, _First2, _Last2, equal_to{});
 }
 #endif // _HAS_CXX17
 
@@ -2269,7 +2269,7 @@ _NODISCARD _CONSTEXPR20 _FwdIt search_n(const _FwdIt _First, const _FwdIt _Last,
 template <class _ExPo, class _FwdIt, class _Diff, class _Ty, _Enable_if_execution_policy_t<_ExPo> = 0>
 _NODISCARD _FwdIt search_n(_ExPo&& _Exec, const _FwdIt _First, const _FwdIt _Last, const _Diff _Count,
     const _Ty& _Val) noexcept /* terminates */ { // find first _Count * _Val match
-    return _STD search_n(_STD forward<_ExPo>(_Exec), _First, _Last, _Count, _Val, equal_to<>{});
+    return _STD search_n(_STD forward<_ExPo>(_Exec), _First, _Last, _Count, _Val, equal_to{});
 }
 #endif // _HAS_CXX17
 
@@ -2624,7 +2624,7 @@ _NODISCARD _FwdIt1 find_end(
 template <class _ExPo, class _FwdIt1, class _FwdIt2, _Enable_if_execution_policy_t<_ExPo> = 0>
 _NODISCARD _FwdIt1 find_end(_ExPo&& _Exec, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2, _FwdIt2 _Last2) noexcept
 /* terminates */ { // find last [_First2, _Last2) match
-    return _STD find_end(_STD forward<_ExPo>(_Exec), _First1, _Last1, _First2, _Last2, equal_to<>{});
+    return _STD find_end(_STD forward<_ExPo>(_Exec), _First1, _Last1, _First2, _Last2, equal_to{});
 }
 #endif // _HAS_CXX17
 
@@ -2832,7 +2832,7 @@ _NODISCARD _FwdIt1 find_first_of(_ExPo&& _Exec, const _FwdIt1 _First1, _FwdIt1 _
 template <class _ExPo, class _FwdIt1, class _FwdIt2, _Enable_if_execution_policy_t<_ExPo> = 0>
 _NODISCARD _FwdIt1 find_first_of(_ExPo&& _Exec, const _FwdIt1 _First1, const _FwdIt1 _Last1, const _FwdIt2 _First2,
     const _FwdIt2 _Last2) noexcept /* terminates */ { // look for one of [_First2, _Last2) that matches element
-    return _STD find_first_of(_STD forward<_ExPo>(_Exec), _First1, _Last1, _First2, _Last2, equal_to<>{});
+    return _STD find_first_of(_STD forward<_ExPo>(_Exec), _First1, _Last1, _First2, _Last2, equal_to{});
 }
 #endif // _HAS_CXX17
 
@@ -5604,7 +5604,7 @@ void sort(_ExPo&& _Exec, _RanIt _First, _RanIt _Last, _Pr _Pred) noexcept; // te
 template <class _ExPo, class _RanIt, _Enable_if_execution_policy_t<_ExPo> = 0>
 void sort(_ExPo&& _Exec, const _RanIt _First, const _RanIt _Last) noexcept /* terminates */ {
     // order [_First, _Last)
-    _STD sort(_STD forward<_ExPo>(_Exec), _First, _Last, less<>{});
+    _STD sort(_STD forward<_ExPo>(_Exec), _First, _Last, less{});
 }
 #endif // _HAS_CXX17
 
@@ -5798,7 +5798,7 @@ void stable_sort(const _BidIt _First, const _BidIt _Last) { // sort preserving o
 template <class _ExPo, class _BidIt, _Enable_if_execution_policy_t<_ExPo> = 0>
 void stable_sort(_ExPo&& _Exec, _BidIt _First, _BidIt _Last) noexcept /* terminates */ {
     // sort preserving order of equivalents
-    _STD stable_sort(_STD forward<_ExPo>(_Exec), _First, _Last, less<>{});
+    _STD stable_sort(_STD forward<_ExPo>(_Exec), _First, _Last, less{});
 }
 #endif // _HAS_CXX17
 

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -539,7 +539,7 @@ _NODISCARD _CONSTEXPR20 _FwdIt adjacent_find(const _FwdIt _First, _FwdIt _Last, 
 
 template <class _FwdIt>
 _NODISCARD _CONSTEXPR20 _FwdIt adjacent_find(const _FwdIt _First, const _FwdIt _Last) { // find first matching successor
-    return _STD adjacent_find(_First, _Last, equal_to<>());
+    return _STD adjacent_find(_First, _Last, equal_to<>{});
 }
 
 #if _HAS_CXX17
@@ -549,7 +549,7 @@ _NODISCARD _FwdIt adjacent_find(_ExPo&& _Exec, _FwdIt _First, _FwdIt _Last, _Pr 
 template <class _ExPo, class _FwdIt, _Enable_if_execution_policy_t<_ExPo> = 0>
 _NODISCARD _FwdIt adjacent_find(_ExPo&& _Exec, const _FwdIt _First, const _FwdIt _Last) noexcept /* terminates */ {
     // find first matching successor
-    return _STD adjacent_find(_STD forward<_ExPo>(_Exec), _First, _Last, equal_to<>());
+    return _STD adjacent_find(_STD forward<_ExPo>(_Exec), _First, _Last, equal_to<>{});
 }
 #endif // _HAS_CXX17
 
@@ -716,7 +716,7 @@ _NODISCARD pair<_FwdIt1, _FwdIt2> mismatch(
 template <class _InIt1, class _InIt2>
 _NODISCARD _CONSTEXPR20 pair<_InIt1, _InIt2> mismatch(const _InIt1 _First1, const _InIt1 _Last1, const _InIt2 _First2) {
     // return [_First1, _Last1)/[_First2, ...) mismatch
-    return _STD mismatch(_First1, _Last1, _First2, equal_to<>());
+    return _STD mismatch(_First1, _Last1, _First2, equal_to<>{});
 }
 
 #if _HAS_CXX17
@@ -726,7 +726,7 @@ _NODISCARD pair<_FwdIt1, _FwdIt2> mismatch(
     // return [_First1, _Last1)/[_First2, ...) mismatch
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
-    return _STD mismatch(_STD forward<_ExPo>(_Exec), _First1, _Last1, _First2, equal_to<>());
+    return _STD mismatch(_STD forward<_ExPo>(_Exec), _First1, _Last1, _First2, equal_to<>{});
 }
 #endif // _HAS_CXX17
 
@@ -808,7 +808,7 @@ _NODISCARD pair<_FwdIt1, _FwdIt2> mismatch(
 template <class _InIt1, class _InIt2>
 _NODISCARD _CONSTEXPR20 pair<_InIt1, _InIt2> mismatch(_InIt1 _First1, _InIt1 _Last1, _InIt2 _First2, _InIt2 _Last2) {
     // return [_First1, _Last1)/[_First2, _Last2) mismatch
-    return _STD mismatch(_First1, _Last1, _First2, _Last2, equal_to<>());
+    return _STD mismatch(_First1, _Last1, _First2, _Last2, equal_to<>{});
 }
 
 #if _HAS_CXX17
@@ -818,7 +818,7 @@ _NODISCARD pair<_FwdIt1, _FwdIt2> mismatch(
     // return [_First1, _Last1)/[_First2, _Last2) mismatch
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
-    return _STD mismatch(_STD forward<_ExPo>(_Exec), _First1, _Last1, _First2, _Last2, equal_to<>());
+    return _STD mismatch(_STD forward<_ExPo>(_Exec), _First1, _Last1, _First2, _Last2, equal_to<>{});
 }
 #endif // _HAS_CXX17
 
@@ -1928,7 +1928,7 @@ template <class _FwdItHaystack, class _FwdItPat>
 _NODISCARD _CONSTEXPR20 _FwdItHaystack search(
     const _FwdItHaystack _First1, const _FwdItHaystack _Last1, const _FwdItPat _First2, const _FwdItPat _Last2) {
     // find first [_First2, _Last2) match
-    return _STD search(_First1, _Last1, _First2, _Last2, equal_to<>());
+    return _STD search(_First1, _Last1, _First2, _Last2, equal_to<>{});
 }
 
 #if _HAS_CXX17
@@ -1936,7 +1936,7 @@ template <class _ExPo, class _FwdItHaystack, class _FwdItPat, _Enable_if_executi
 _NODISCARD _FwdItHaystack search(_ExPo&& _Exec, const _FwdItHaystack _First1, const _FwdItHaystack _Last1,
     const _FwdItPat _First2, const _FwdItPat _Last2) noexcept /* terminates */ {
     // find first [_First2, _Last2) match
-    return _STD search(_STD forward<_ExPo>(_Exec), _First1, _Last1, _First2, _Last2, equal_to<>());
+    return _STD search(_STD forward<_ExPo>(_Exec), _First1, _Last1, _First2, _Last2, equal_to<>{});
 }
 #endif // _HAS_CXX17
 
@@ -2262,14 +2262,14 @@ _NODISCARD _FwdIt search_n(_ExPo&& _Exec, const _FwdIt _First, _FwdIt _Last, con
 template <class _FwdIt, class _Diff, class _Ty>
 _NODISCARD _CONSTEXPR20 _FwdIt search_n(const _FwdIt _First, const _FwdIt _Last, const _Diff _Count, const _Ty& _Val) {
     // find first _Count * _Val match
-    return _STD search_n(_First, _Last, _Count, _Val, equal_to<>());
+    return _STD search_n(_First, _Last, _Count, _Val, equal_to<>{});
 }
 
 #if _HAS_CXX17
 template <class _ExPo, class _FwdIt, class _Diff, class _Ty, _Enable_if_execution_policy_t<_ExPo> = 0>
 _NODISCARD _FwdIt search_n(_ExPo&& _Exec, const _FwdIt _First, const _FwdIt _Last, const _Diff _Count,
     const _Ty& _Val) noexcept /* terminates */ { // find first _Count * _Val match
-    return _STD search_n(_STD forward<_ExPo>(_Exec), _First, _Last, _Count, _Val, equal_to<>());
+    return _STD search_n(_STD forward<_ExPo>(_Exec), _First, _Last, _Count, _Val, equal_to<>{});
 }
 #endif // _HAS_CXX17
 
@@ -2613,7 +2613,7 @@ template <class _FwdIt1, class _FwdIt2>
 _NODISCARD _CONSTEXPR20 _FwdIt1 find_end(
     _FwdIt1 const _First1, const _FwdIt1 _Last1, const _FwdIt2 _First2, const _FwdIt2 _Last2) {
     // find last [_First2, _Last2) match
-    return _STD find_end(_First1, _Last1, _First2, _Last2, equal_to<>());
+    return _STD find_end(_First1, _Last1, _First2, _Last2, equal_to<>{});
 }
 
 #if _HAS_CXX17
@@ -2624,7 +2624,7 @@ _NODISCARD _FwdIt1 find_end(
 template <class _ExPo, class _FwdIt1, class _FwdIt2, _Enable_if_execution_policy_t<_ExPo> = 0>
 _NODISCARD _FwdIt1 find_end(_ExPo&& _Exec, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2, _FwdIt2 _Last2) noexcept
 /* terminates */ { // find last [_First2, _Last2) match
-    return _STD find_end(_STD forward<_ExPo>(_Exec), _First1, _Last1, _First2, _Last2, equal_to<>());
+    return _STD find_end(_STD forward<_ExPo>(_Exec), _First1, _Last1, _First2, _Last2, equal_to<>{});
 }
 #endif // _HAS_CXX17
 
@@ -2821,7 +2821,7 @@ _NODISCARD _CONSTEXPR20 _FwdIt1 find_first_of(
 template <class _FwdIt1, class _FwdIt2>
 _NODISCARD _CONSTEXPR20 _FwdIt1 find_first_of(const _FwdIt1 _First1, const _FwdIt1 _Last1, const _FwdIt2 _First2,
     const _FwdIt2 _Last2) { // look for one of [_First2, _Last2) that matches element
-    return _STD find_first_of(_First1, _Last1, _First2, _Last2, equal_to<>());
+    return _STD find_first_of(_First1, _Last1, _First2, _Last2, equal_to<>{});
 }
 
 #if _HAS_CXX17
@@ -2832,7 +2832,7 @@ _NODISCARD _FwdIt1 find_first_of(_ExPo&& _Exec, const _FwdIt1 _First1, _FwdIt1 _
 template <class _ExPo, class _FwdIt1, class _FwdIt2, _Enable_if_execution_policy_t<_ExPo> = 0>
 _NODISCARD _FwdIt1 find_first_of(_ExPo&& _Exec, const _FwdIt1 _First1, const _FwdIt1 _Last1, const _FwdIt2 _First2,
     const _FwdIt2 _Last2) noexcept /* terminates */ { // look for one of [_First2, _Last2) that matches element
-    return _STD find_first_of(_STD forward<_ExPo>(_Exec), _First1, _Last1, _First2, _Last2, equal_to<>());
+    return _STD find_first_of(_STD forward<_ExPo>(_Exec), _First1, _Last1, _First2, _Last2, equal_to<>{});
 }
 #endif // _HAS_CXX17
 
@@ -3377,7 +3377,7 @@ _NODISCARD _CONSTEXPR20 _FwdIt unique(_FwdIt _First, _FwdIt _Last, _Pr _Pred) {
 
 template <class _FwdIt>
 _NODISCARD _CONSTEXPR20 _FwdIt unique(_FwdIt _First, _FwdIt _Last) { // remove each matching previous
-    return _STD unique(_First, _Last, equal_to<>());
+    return _STD unique(_First, _Last, equal_to<>{});
 }
 
 #if _HAS_CXX17
@@ -3544,7 +3544,7 @@ _OutIt unique_copy(_InIt _First, _InIt _Last, _OutIt _Dest, _Pr _Pred) { // copy
 
 template <class _InIt, class _OutIt>
 _CONSTEXPR20 _OutIt unique_copy(_InIt _First, _InIt _Last, _OutIt _Dest) { // copy compressing pairs that match
-    return _STD unique_copy(_First, _Last, _Dest, equal_to<>());
+    return _STD unique_copy(_First, _Last, _Dest, equal_to<>{});
 }
 
 #if _HAS_CXX17
@@ -4221,7 +4221,7 @@ _CONSTEXPR20 void push_heap(_RanIt _First, _RanIt _Last, _Pr _Pred) {
 template <class _RanIt>
 _CONSTEXPR20 void push_heap(_RanIt _First, _RanIt _Last) {
     // push *(_Last - 1) onto heap at [_First, _Last - 1)
-    _STD push_heap(_First, _Last, less<>());
+    _STD push_heap(_First, _Last, less<>{});
 }
 
 #ifdef __cpp_lib_concepts
@@ -4359,7 +4359,7 @@ _CONSTEXPR20 void pop_heap(_RanIt _First, _RanIt _Last, _Pr _Pred) {
 template <class _RanIt>
 _CONSTEXPR20 void pop_heap(_RanIt _First, _RanIt _Last) {
     // pop *_First to *(_Last - 1) and reheap
-    _STD pop_heap(_First, _Last, less<>());
+    _STD pop_heap(_First, _Last, less<>{});
 }
 
 #ifdef __cpp_lib_concepts
@@ -4486,7 +4486,7 @@ _CONSTEXPR20 void make_heap(_RanIt _First, _RanIt _Last, _Pr _Pred) { // make [_
 
 template <class _RanIt>
 _CONSTEXPR20 void make_heap(_RanIt _First, _RanIt _Last) { // make [_First, _Last) into a heap
-    _STD make_heap(_First, _Last, less<>());
+    _STD make_heap(_First, _Last, less<>{});
 }
 
 #ifdef __cpp_lib_concepts
@@ -4578,12 +4578,12 @@ _NODISCARD _CONSTEXPR20 bool is_heap(_RanIt _First, _RanIt _Last, _Pr _Pred) {
 template <class _RanIt>
 _NODISCARD _CONSTEXPR20 _RanIt is_heap_until(_RanIt _First, _RanIt _Last) {
     // find extent of range that is a heap ordered by operator<
-    return _STD is_heap_until(_First, _Last, less<>());
+    return _STD is_heap_until(_First, _Last, less<>{});
 }
 
 template <class _RanIt>
 _NODISCARD _CONSTEXPR20 bool is_heap(_RanIt _First, _RanIt _Last) { // test if range is a heap ordered by operator<
-    return _STD is_heap(_First, _Last, less<>());
+    return _STD is_heap(_First, _Last, less<>{});
 }
 
 #if _HAS_CXX17
@@ -4719,7 +4719,7 @@ _CONSTEXPR20 void sort_heap(_RanIt _First, _RanIt _Last, _Pr _Pred) { // order h
 
 template <class _RanIt>
 _CONSTEXPR20 void sort_heap(_RanIt _First, _RanIt _Last) { // order heap by repeatedly popping
-    _STD sort_heap(_First, _Last, less<>());
+    _STD sort_heap(_First, _Last, less<>{});
 }
 
 #ifdef __cpp_lib_concepts
@@ -4853,7 +4853,7 @@ _NODISCARD _CONSTEXPR20 _FwdIt upper_bound(_FwdIt _First, _FwdIt _Last, const _T
 template <class _FwdIt, class _Ty>
 _NODISCARD _CONSTEXPR20 _FwdIt upper_bound(_FwdIt _First, _FwdIt _Last, const _Ty& _Val) {
     // find first element that _Val is before
-    return _STD upper_bound(_First, _Last, _Val, less<>());
+    return _STD upper_bound(_First, _Last, _Val, less<>{});
 }
 
 #ifdef __cpp_lib_concepts
@@ -4955,7 +4955,7 @@ _NODISCARD _CONSTEXPR20 pair<_FwdIt, _FwdIt> equal_range(_FwdIt _First, _FwdIt _
 template <class _FwdIt, class _Ty>
 _NODISCARD _CONSTEXPR20 pair<_FwdIt, _FwdIt> equal_range(_FwdIt _First, _FwdIt _Last, const _Ty& _Val) {
     // find range equivalent to _Val
-    return _STD equal_range(_First, _Last, _Val, less<>());
+    return _STD equal_range(_First, _Last, _Val, less<>{});
 }
 
 #ifdef __cpp_lib_concepts
@@ -5036,7 +5036,7 @@ _NODISCARD _CONSTEXPR20 bool binary_search(_FwdIt _First, _FwdIt _Last, const _T
 template <class _FwdIt, class _Ty>
 _NODISCARD _CONSTEXPR20 bool binary_search(_FwdIt _First, _FwdIt _Last, const _Ty& _Val) {
     // test if _Val equivalent to some element
-    return _STD binary_search(_First, _Last, _Val, less<>());
+    return _STD binary_search(_First, _Last, _Val, less<>{});
 }
 
 #ifdef __cpp_lib_concepts
@@ -5137,7 +5137,7 @@ _CONSTEXPR20 _OutIt merge(_InIt1 _First1, _InIt1 _Last1, _InIt2 _First2, _InIt2 
 template <class _InIt1, class _InIt2, class _OutIt>
 _CONSTEXPR20 _OutIt merge(_InIt1 _First1, _InIt1 _Last1, _InIt2 _First2, _InIt2 _Last2, _OutIt _Dest) {
     // copy merging ranges
-    return _STD merge(_First1, _Last1, _First2, _Last2, _Dest, less<>());
+    return _STD merge(_First1, _Last1, _First2, _Last2, _Dest, less<>{});
 }
 
 #if _HAS_CXX17
@@ -5409,7 +5409,7 @@ void inplace_merge(_BidIt _First, _BidIt _Mid, _BidIt _Last, _Pr _Pred) {
 template <class _BidIt>
 void inplace_merge(_BidIt _First, _BidIt _Mid, _BidIt _Last) {
     // merge [_First, _Mid) with [_Mid, _Last)
-    _STD inplace_merge(_First, _Mid, _Last, less<>());
+    _STD inplace_merge(_First, _Mid, _Last, less<>{});
 }
 
 #if _HAS_CXX17
@@ -5594,7 +5594,7 @@ _CONSTEXPR20 void sort(const _RanIt _First, const _RanIt _Last, _Pr _Pred) { // 
 
 template <class _RanIt>
 _CONSTEXPR20 void sort(const _RanIt _First, const _RanIt _Last) { // order [_First, _Last)
-    _STD sort(_First, _Last, less<>());
+    _STD sort(_First, _Last, less<>{});
 }
 
 #if _HAS_CXX17
@@ -5791,14 +5791,14 @@ void stable_sort(_ExPo&& _Exec, const _BidIt _First, const _BidIt _Last, _Pr _Pr
 
 template <class _BidIt>
 void stable_sort(const _BidIt _First, const _BidIt _Last) { // sort preserving order of equivalents
-    _STD stable_sort(_First, _Last, less<>());
+    _STD stable_sort(_First, _Last, less<>{});
 }
 
 #if _HAS_CXX17
 template <class _ExPo, class _BidIt, _Enable_if_execution_policy_t<_ExPo> = 0>
 void stable_sort(_ExPo&& _Exec, _BidIt _First, _BidIt _Last) noexcept /* terminates */ {
     // sort preserving order of equivalents
-    _STD stable_sort(_STD forward<_ExPo>(_Exec), _First, _Last, less<>());
+    _STD stable_sort(_STD forward<_ExPo>(_Exec), _First, _Last, less<>{});
 }
 #endif // _HAS_CXX17
 
@@ -5830,7 +5830,7 @@ _CONSTEXPR20 void partial_sort(_RanIt _First, _RanIt _Mid, _RanIt _Last, _Pr _Pr
 template <class _RanIt>
 _CONSTEXPR20 void partial_sort(_RanIt _First, _RanIt _Mid, _RanIt _Last) {
     // order [_First, _Last) up to _Mid
-    _STD partial_sort(_First, _Mid, _Last, less<>());
+    _STD partial_sort(_First, _Mid, _Last, less<>{});
 }
 
 #if _HAS_CXX17
@@ -5885,7 +5885,7 @@ _CONSTEXPR20 _RanIt partial_sort_copy(_InIt _First1, _InIt _Last1, _RanIt _First
 template <class _InIt, class _RanIt>
 _CONSTEXPR20 _RanIt partial_sort_copy(_InIt _First1, _InIt _Last1, _RanIt _First2, _RanIt _Last2) {
     // copy [_First1, _Last1) into [_First2, _Last2)
-    return _STD partial_sort_copy(_First1, _Last1, _First2, _Last2, less<>());
+    return _STD partial_sort_copy(_First1, _Last1, _First2, _Last2, less<>{});
 }
 
 #if _HAS_CXX17
@@ -5938,7 +5938,7 @@ _CONSTEXPR20 void nth_element(_RanIt _First, _RanIt _Nth, _RanIt _Last, _Pr _Pre
 
 template <class _RanIt>
 _CONSTEXPR20 void nth_element(_RanIt _First, _RanIt _Nth, _RanIt _Last) { // order Nth element
-    _STD nth_element(_First, _Nth, _Last, less<>());
+    _STD nth_element(_First, _Nth, _Last, less<>{});
 }
 
 #if _HAS_CXX17
@@ -5985,7 +5985,7 @@ _NODISCARD _CONSTEXPR20 bool includes(_InIt1 _First1, _InIt1 _Last1, _InIt2 _Fir
 template <class _InIt1, class _InIt2>
 _NODISCARD _CONSTEXPR20 bool includes(_InIt1 _First1, _InIt1 _Last1, _InIt2 _First2, _InIt2 _Last2) {
     // test if every element in sorted [_First2, _Last2) is in sorted [_First1, _Last1)
-    return _STD includes(_First1, _Last1, _First2, _Last2, less<>());
+    return _STD includes(_First1, _Last1, _First2, _Last2, less<>{});
 }
 
 #if _HAS_CXX17
@@ -6046,7 +6046,7 @@ _CONSTEXPR20 _OutIt set_union(_InIt1 _First1, _InIt1 _Last1, _InIt2 _First2, _In
 template <class _InIt1, class _InIt2, class _OutIt>
 _CONSTEXPR20 _OutIt set_union(_InIt1 _First1, _InIt1 _Last1, _InIt2 _First2, _InIt2 _Last2, _OutIt _Dest) {
     // OR sets [_First1, _Last1) and [_First2, _Last2)
-    return _STD set_union(_First1, _Last1, _First2, _Last2, _Dest, less<>());
+    return _STD set_union(_First1, _Last1, _First2, _Last2, _Dest, less<>{});
 }
 
 #if _HAS_CXX17
@@ -6107,7 +6107,7 @@ _CONSTEXPR20 _OutIt set_intersection(
 template <class _InIt1, class _InIt2, class _OutIt>
 _CONSTEXPR20 _OutIt set_intersection(_InIt1 _First1, _InIt1 _Last1, _InIt2 _First2, _InIt2 _Last2, _OutIt _Dest) {
     // AND sets [_First1, _Last1) and [_First2, _Last2)
-    return _STD set_intersection(_First1, _Last1, _First2, _Last2, _Dest, less<>());
+    return _STD set_intersection(_First1, _Last1, _First2, _Last2, _Dest, less<>{});
 }
 
 #if _HAS_CXX17
@@ -6158,7 +6158,7 @@ _CONSTEXPR20 _OutIt set_difference(
 template <class _InIt1, class _InIt2, class _OutIt>
 _CONSTEXPR20 _OutIt set_difference(_InIt1 _First1, _InIt1 _Last1, _InIt2 _First2, _InIt2 _Last2, _OutIt _Dest) {
     // take set [_First2, _Last2) from [_First1, _Last1)
-    return _STD set_difference(_First1, _Last1, _First2, _Last2, _Dest, less<>());
+    return _STD set_difference(_First1, _Last1, _First2, _Last2, _Dest, less<>{});
 }
 
 #if _HAS_CXX17
@@ -6212,7 +6212,7 @@ template <class _InIt1, class _InIt2, class _OutIt>
 _CONSTEXPR20 _OutIt set_symmetric_difference(
     _InIt1 _First1, _InIt1 _Last1, _InIt2 _First2, _InIt2 _Last2, _OutIt _Dest) {
     // XOR sets [_First1, _Last1) and [_First2, _Last2)
-    return _STD set_symmetric_difference(_First1, _Last1, _First2, _Last2, _Dest, less<>());
+    return _STD set_symmetric_difference(_First1, _Last1, _First2, _Last2, _Dest, less<>{});
 }
 
 #if _HAS_CXX17
@@ -6263,7 +6263,7 @@ _NODISCARD constexpr _FwdIt max_element(_FwdIt _First, _FwdIt _Last, _Pr _Pred) 
 
 template <class _FwdIt>
 _NODISCARD constexpr _FwdIt max_element(_FwdIt _First, _FwdIt _Last) { // find largest element
-    return _STD max_element(_First, _Last, less<>());
+    return _STD max_element(_First, _Last, less<>{});
 }
 
 #if _HAS_CXX17
@@ -6356,7 +6356,7 @@ _NODISCARD constexpr _FwdIt min_element(_FwdIt _First, _FwdIt _Last, _Pr _Pred) 
 
 template <class _FwdIt>
 _NODISCARD constexpr _FwdIt min_element(_FwdIt _First, _FwdIt _Last) { // find smallest element
-    return _STD min_element(_First, _Last, less<>());
+    return _STD min_element(_First, _Last, less<>{});
 }
 
 #if _HAS_CXX17
@@ -6477,7 +6477,7 @@ _NODISCARD constexpr pair<_FwdIt, _FwdIt> minmax_element(_FwdIt _First, _FwdIt _
 template <class _FwdIt>
 _NODISCARD constexpr pair<_FwdIt, _FwdIt> minmax_element(_FwdIt _First, _FwdIt _Last) {
     // find smallest and largest elements
-    return _STD minmax_element(_First, _Last, less<>());
+    return _STD minmax_element(_First, _Last, less<>{});
 }
 
 #if _HAS_CXX17
@@ -6598,7 +6598,7 @@ _NODISCARD constexpr _Ty(max)(initializer_list<_Ty> _Ilist, _Pr _Pred) {
 template <class _Ty>
 _NODISCARD constexpr _Ty(max)(initializer_list<_Ty> _Ilist) {
     // return leftmost/largest
-    return (_STD max)(_Ilist, less<>());
+    return (_STD max)(_Ilist, less<>{});
 }
 
 #ifdef __cpp_lib_concepts
@@ -6678,7 +6678,7 @@ _NODISCARD constexpr _Ty(min)(initializer_list<_Ty> _Ilist, _Pr _Pred) {
 template <class _Ty>
 _NODISCARD constexpr _Ty(min)(initializer_list<_Ty> _Ilist) {
     // return leftmost/smallest
-    return (_STD min)(_Ilist, less<>());
+    return (_STD min)(_Ilist, less<>{});
 }
 
 #ifdef __cpp_lib_concepts
@@ -6773,7 +6773,7 @@ _NODISCARD constexpr pair<const _Ty&, const _Ty&> minmax(const _Ty& _Left, const
 template <class _Ty>
 _NODISCARD constexpr pair<_Ty, _Ty> minmax(initializer_list<_Ty> _Ilist) {
     // return {leftmost/smallest, rightmost/largest}
-    return _STD minmax(_Ilist, less<>());
+    return _STD minmax(_Ilist, less<>{});
 }
 
 #ifdef __cpp_lib_concepts
@@ -6907,7 +6907,7 @@ _CONSTEXPR20 bool next_permutation(_BidIt _First, _BidIt _Last, _Pr _Pred) {
 template <class _BidIt>
 _CONSTEXPR20 bool next_permutation(_BidIt _First, _BidIt _Last) {
     // permute and test for pure ascending
-    return _STD next_permutation(_First, _Last, less<>());
+    return _STD next_permutation(_First, _Last, less<>{});
 }
 
 // FUNCTION TEMPLATE prev_permutation
@@ -6945,7 +6945,7 @@ _CONSTEXPR20 bool prev_permutation(_BidIt _First, _BidIt _Last, _Pr _Pred) {
 template <class _BidIt>
 _CONSTEXPR20 bool prev_permutation(_BidIt _First, _BidIt _Last) {
     // reverse permute and test for pure descending
-    return _STD prev_permutation(_First, _Last, less<>());
+    return _STD prev_permutation(_First, _Last, less<>{});
 }
 
 // FUNCTION TEMPLATES is_sorted AND is_sorted_until
@@ -6980,12 +6980,12 @@ _NODISCARD _CONSTEXPR20 bool is_sorted(_FwdIt _First, _FwdIt _Last, _Pr _Pred) {
 template <class _FwdIt>
 _NODISCARD _CONSTEXPR20 _FwdIt is_sorted_until(_FwdIt _First, _FwdIt _Last) {
     // find extent of range that is ordered by operator<
-    return _STD is_sorted_until(_First, _Last, less<>());
+    return _STD is_sorted_until(_First, _Last, less<>{});
 }
 
 template <class _FwdIt>
 _NODISCARD _CONSTEXPR20 bool is_sorted(_FwdIt _First, _FwdIt _Last) { // test if range is ordered by operator<
-    return _STD is_sorted(_First, _Last, less<>());
+    return _STD is_sorted(_First, _Last, less<>{});
 }
 
 #if _HAS_CXX17

--- a/stl/inc/execution
+++ b/stl/inc/execution
@@ -719,7 +719,7 @@ struct _Work_stealing_team { // inter-thread communication for threads working o
 
     _Work_stealing_team(size_t _Threads, _Diff _Total_work)
         : _Queues(_Threads), _Queues_used(0), _Remaining_work(_Total_work), _Available_mutex(),
-          _Available_queues(greater<>{}, _Get_queues(_Threads)) {} // register work with the thread pool
+          _Available_queues(greater{}, _Get_queues(_Threads)) {} // register work with the thread pool
 
     _Work_stealing_membership<_Ty> _Join_team() noexcept {
         size_t _Id;

--- a/stl/inc/forward_list
+++ b/stl/inc/forward_list
@@ -1187,7 +1187,7 @@ public:
     }
 
     auto unique() { // erase each element matching previous
-        return unique(equal_to<>());
+        return unique(equal_to<>{});
     }
 
     template <class _Pr2>
@@ -1217,11 +1217,11 @@ public:
     }
 
     void merge(forward_list& _Right) { // merge in elements from _Right, both ordered by operator<
-        _Merge1(_Right, less<>());
+        _Merge1(_Right, less<>{});
     }
 
     void merge(forward_list&& _Right) { // merge in elements from _Right, both ordered by operator<
-        _Merge1(_Right, less<>());
+        _Merge1(_Right, less<>{});
     }
 
     template <class _Pr2>

--- a/stl/inc/list
+++ b/stl/inc/list
@@ -1626,7 +1626,7 @@ public:
     }
 
     auto unique() { // erase each element matching previous
-        return unique(equal_to<>());
+        return unique(equal_to<>{});
     }
 
     template <class _Pr2>
@@ -1653,11 +1653,11 @@ public:
     }
 
     void merge(list& _Right) { // merge in elements from _Right, both ordered by operator<
-        _Merge1(_Right, less<>());
+        _Merge1(_Right, less<>{});
     }
 
     void merge(list&& _Right) { // merge in elements from _Right, both ordered by operator<
-        _Merge1(_Right, less<>());
+        _Merge1(_Right, less<>{});
     }
 
     template <class _Pr2>
@@ -1707,7 +1707,7 @@ private:
 
 public:
     void sort() { // order sequence
-        sort(less<>());
+        sort(less<>{});
     }
 
     template <class _Pr2>

--- a/stl/inc/numeric
+++ b/stl/inc/numeric
@@ -94,14 +94,14 @@ _NODISCARD _CONSTEXPR20 _Ty reduce(const _InIt _First, const _InIt _Last, _Ty _V
 template <class _InIt, class _Ty>
 _NODISCARD _CONSTEXPR20 _Ty reduce(const _InIt _First, const _InIt _Last, _Ty _Val) {
     // return commutative and associative reduction of _Val and [_First, _Last)
-    return _STD reduce(_First, _Last, _STD move(_Val), plus<>{});
+    return _STD reduce(_First, _Last, _STD move(_Val), plus{});
 }
 
 template <class _InIt>
 _NODISCARD _CONSTEXPR20 _Iter_value_t<_InIt> reduce(const _InIt _First, const _InIt _Last) {
     // return commutative and associative reduction of
     // iterator_traits<_InIt>::value_type{} and [_First, _Last)
-    return _STD reduce(_First, _Last, _Iter_value_t<_InIt>{}, plus<>{});
+    return _STD reduce(_First, _Last, _Iter_value_t<_InIt>{}, plus{});
 }
 
 template <class _ExPo, class _FwdIt, class _Ty, class _BinOp, _Enable_if_execution_policy_t<_ExPo> = 0>
@@ -111,7 +111,7 @@ template <class _ExPo, class _FwdIt, class _Ty, _Enable_if_execution_policy_t<_E
 _NODISCARD _Ty reduce(_ExPo&& _Exec, const _FwdIt _First, const _FwdIt _Last, _Ty _Val) noexcept /* terminates */ {
     // return commutative and associative reduction of _Val and [_First, _Last)
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt);
-    return _STD reduce(_STD forward<_ExPo>(_Exec), _First, _Last, _STD move(_Val), plus<>{});
+    return _STD reduce(_STD forward<_ExPo>(_Exec), _First, _Last, _STD move(_Val), plus{});
 }
 
 template <class _ExPo, class _FwdIt, _Enable_if_execution_policy_t<_ExPo> = 0>
@@ -120,7 +120,7 @@ _NODISCARD _Iter_value_t<_FwdIt> reduce(_ExPo&& _Exec, const _FwdIt _First, cons
     // return commutative and associative reduction of
     // iterator_traits<_FwdIt>::value_type{} and [_First, _Last)
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt);
-    return _STD reduce(_STD forward<_ExPo>(_Exec), _First, _Last, _Iter_value_t<_FwdIt>{}, plus<>{});
+    return _STD reduce(_STD forward<_ExPo>(_Exec), _First, _Last, _Iter_value_t<_FwdIt>{}, plus{});
 }
 #endif // _HAS_CXX17
 
@@ -205,7 +205,7 @@ _NODISCARD _CONSTEXPR20 _Ty transform_reduce(
 template <class _InIt1, class _InIt2, class _Ty>
 _NODISCARD _CONSTEXPR20 _Ty transform_reduce(_InIt1 _First1, _InIt1 _Last1, _InIt2 _First2, _Ty _Val) {
     // return commutative and associative transform-reduction of sequences
-    return _STD transform_reduce(_First1, _Last1, _First2, _STD move(_Val), plus<>{}, multiplies<>{});
+    return _STD transform_reduce(_First1, _Last1, _First2, _STD move(_Val), plus{}, multiplies{});
 }
 
 template <class _InIt, class _Ty, class _BinOp, class _UnaryOp>
@@ -235,7 +235,7 @@ _NODISCARD _Ty transform_reduce(_ExPo&& _Exec, _FwdIt1 _First1, _FwdIt1 _Last1, 
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
     _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
     return _STD transform_reduce(
-        _STD forward<_ExPo>(_Exec), _First1, _Last1, _First2, _STD move(_Val), plus<>{}, multiplies<>{});
+        _STD forward<_ExPo>(_Exec), _First1, _Last1, _First2, _STD move(_Val), plus{}, multiplies{});
 }
 
 template <class _ExPo, class _FwdIt, class _Ty, class _BinOp, class _UnaryOp, _Enable_if_execution_policy_t<_ExPo> = 0>
@@ -309,7 +309,7 @@ _CONSTEXPR20 _OutIt exclusive_scan(const _InIt _First, const _InIt _Last, _OutIt
 template <class _InIt, class _OutIt, class _Ty>
 _CONSTEXPR20 _OutIt exclusive_scan(const _InIt _First, const _InIt _Last, const _OutIt _Dest, _Ty _Val) {
     // set each value in [_Dest, _Dest + (_Last - _First)) to the associative reduction of predecessors and _Val
-    return _STD exclusive_scan(_First, _Last, _Dest, _STD move(_Val), plus<>{});
+    return _STD exclusive_scan(_First, _Last, _Dest, _STD move(_Val), plus{});
 }
 
 template <class _ExPo, class _FwdIt1, class _FwdIt2, class _Ty, class _BinOp, _Enable_if_execution_policy_t<_ExPo> = 0>
@@ -320,7 +320,7 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, class _Ty, _Enable_if_execu
 _FwdIt2 exclusive_scan(_ExPo&& _Exec, const _FwdIt1 _First, const _FwdIt1 _Last, const _FwdIt2 _Dest, _Ty _Val) noexcept
 /* terminates */ {
     // set each value in [_Dest, _Dest + (_Last - _First)) to the associative reduction of predecessors and _Val
-    return _STD exclusive_scan(_STD forward<_ExPo>(_Exec), _First, _Last, _Dest, _STD move(_Val), plus<>{});
+    return _STD exclusive_scan(_STD forward<_ExPo>(_Exec), _First, _Last, _Dest, _STD move(_Val), plus{});
 }
 
 // FUNCTION TEMPLATE inclusive_scan
@@ -369,7 +369,7 @@ _CONSTEXPR20 _OutIt inclusive_scan(const _InIt _First, const _InIt _Last, _OutIt
 template <class _InIt, class _OutIt>
 _CONSTEXPR20 _OutIt inclusive_scan(const _InIt _First, const _InIt _Last, const _OutIt _Dest) {
     // compute partial noncommutative and associative reductions into _Dest
-    return _STD inclusive_scan(_First, _Last, _Dest, plus<>{});
+    return _STD inclusive_scan(_First, _Last, _Dest, plus{});
 }
 
 template <class _ExPo, class _FwdIt1, class _FwdIt2, class _BinOp, class _Ty, _Enable_if_execution_policy_t<_ExPo> = 0>
@@ -384,7 +384,7 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, _Enable_if_execution_policy
 _FwdIt2 inclusive_scan(_ExPo&& _Exec, const _FwdIt1 _First, const _FwdIt1 _Last, const _FwdIt2 _Dest) noexcept
 /* terminates */ {
     // compute partial noncommutative and associative reductions into _Dest
-    return _STD inclusive_scan(_STD forward<_ExPo>(_Exec), _First, _Last, _Dest, plus<>{});
+    return _STD inclusive_scan(_STD forward<_ExPo>(_Exec), _First, _Last, _Dest, plus{});
 }
 
 // FUNCTION TEMPLATE transform_exclusive_scan
@@ -518,7 +518,7 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, _Enable_if_execution_policy
 _FwdIt2 adjacent_difference(_ExPo&& _Exec, const _FwdIt1 _First, const _FwdIt1 _Last, const _FwdIt2 _Dest) noexcept
 /* terminates */ {
     // compute adjacent differences into _Dest
-    return _STD adjacent_difference(_STD forward<_ExPo>(_Exec), _First, _Last, _Dest, minus<>{});
+    return _STD adjacent_difference(_STD forward<_ExPo>(_Exec), _First, _Last, _Dest, minus{});
 }
 #endif // _HAS_CXX17
 

--- a/stl/inc/numeric
+++ b/stl/inc/numeric
@@ -41,7 +41,7 @@ _NODISCARD _CONSTEXPR20 _Ty accumulate(const _InIt _First, const _InIt _Last, _T
 template <class _InIt, class _Ty>
 _NODISCARD _CONSTEXPR20 _Ty accumulate(const _InIt _First, const _InIt _Last, _Ty _Val) {
     // return noncommutative and nonassociative reduction of _Val and all in [_First, _Last)
-    return _STD accumulate(_First, _Last, _Val, plus<>());
+    return _STD accumulate(_First, _Last, _Val, plus<>{});
 }
 
 #if _HAS_CXX17
@@ -148,7 +148,7 @@ _NODISCARD _CONSTEXPR20 _Ty inner_product(
 template <class _InIt1, class _InIt2, class _Ty>
 _NODISCARD _CONSTEXPR20 _Ty inner_product(const _InIt1 _First1, const _InIt1 _Last1, const _InIt2 _First2, _Ty _Val) {
     // return noncommutative and nonassociative transform-reduction of sequences
-    return _STD inner_product(_First1, _Last1, _First2, _STD move(_Val), plus<>(), multiplies<>());
+    return _STD inner_product(_First1, _Last1, _First2, _STD move(_Val), plus<>{}, multiplies<>{});
 }
 
 #if _HAS_CXX17
@@ -276,7 +276,7 @@ _CONSTEXPR20 _OutIt partial_sum(const _InIt _First, const _InIt _Last, _OutIt _D
 template <class _InIt, class _OutIt>
 _CONSTEXPR20 _OutIt partial_sum(_InIt _First, _InIt _Last, _OutIt _Dest) {
     // compute partial noncommutative and nonassociative reductions into _Dest
-    return _STD partial_sum(_First, _Last, _Dest, plus<>());
+    return _STD partial_sum(_First, _Last, _Dest, plus<>{});
 }
 
 #if _HAS_CXX17
@@ -384,7 +384,7 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, _Enable_if_execution_policy
 _FwdIt2 inclusive_scan(_ExPo&& _Exec, const _FwdIt1 _First, const _FwdIt1 _Last, const _FwdIt2 _Dest) noexcept
 /* terminates */ {
     // compute partial noncommutative and associative reductions into _Dest
-    return _STD inclusive_scan(_STD forward<_ExPo>(_Exec), _First, _Last, _Dest, plus<>());
+    return _STD inclusive_scan(_STD forward<_ExPo>(_Exec), _First, _Last, _Dest, plus<>{});
 }
 
 // FUNCTION TEMPLATE transform_exclusive_scan
@@ -506,7 +506,7 @@ _CONSTEXPR20 _OutIt adjacent_difference(const _InIt _First, const _InIt _Last, _
 template <class _InIt, class _OutIt>
 _CONSTEXPR20 _OutIt adjacent_difference(const _InIt _First, const _InIt _Last, const _OutIt _Dest) {
     // compute adjacent differences into _Dest
-    return _STD adjacent_difference(_First, _Last, _Dest, minus<>());
+    return _STD adjacent_difference(_First, _Last, _Dest, minus<>{});
 }
 
 #if _HAS_CXX17
@@ -518,7 +518,7 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, _Enable_if_execution_policy
 _FwdIt2 adjacent_difference(_ExPo&& _Exec, const _FwdIt1 _First, const _FwdIt1 _Last, const _FwdIt2 _Dest) noexcept
 /* terminates */ {
     // compute adjacent differences into _Dest
-    return _STD adjacent_difference(_STD forward<_ExPo>(_Exec), _First, _Last, _Dest, minus<>());
+    return _STD adjacent_difference(_STD forward<_ExPo>(_Exec), _First, _Last, _Dest, minus<>{});
 }
 #endif // _HAS_CXX17
 

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -4989,7 +4989,7 @@ _NODISCARD bool equal(_ExPo&& _Exec, const _FwdIt1 _First1, const _FwdIt1 _Last1
 template <class _InIt1, class _InIt2>
 _NODISCARD _CONSTEXPR20 bool equal(const _InIt1 _First1, const _InIt1 _Last1, const _InIt2 _First2) {
     // compare [_First1, _Last1) to [_First2, ...)
-    return _STD equal(_First1, _Last1, _First2, equal_to<>());
+    return _STD equal(_First1, _Last1, _First2, equal_to<>{});
 }
 
 #if _HAS_CXX17
@@ -4997,7 +4997,7 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, _Enable_if_execution_policy
 _NODISCARD bool equal(_ExPo&& _Exec, const _FwdIt1 _First1, const _FwdIt1 _Last1, const _FwdIt2 _First2) noexcept
 /* terminates */ {
     // compare [_First1, _Last1) to [_First2, ...)
-    return _STD equal(_STD forward<_ExPo>(_Exec), _First1, _Last1, _First2, equal_to<>());
+    return _STD equal(_STD forward<_ExPo>(_Exec), _First1, _Last1, _First2, equal_to<>{});
 }
 #endif // _HAS_CXX17
 
@@ -5091,7 +5091,7 @@ template <class _InIt1, class _InIt2>
 _NODISCARD _CONSTEXPR20 bool equal(
     const _InIt1 _First1, const _InIt1 _Last1, const _InIt2 _First2, const _InIt2 _Last2) {
     // compare [_First1, _Last1) to [_First2, _Last2)
-    return _STD equal(_First1, _Last1, _First2, _Last2, equal_to<>());
+    return _STD equal(_First1, _Last1, _First2, _Last2, equal_to<>{});
 }
 
 #if _HAS_CXX17
@@ -5099,7 +5099,7 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, _Enable_if_execution_policy
 _NODISCARD bool equal(_ExPo&& _Exec, const _FwdIt1 _First1, const _FwdIt1 _Last1, const _FwdIt2 _First2,
     const _FwdIt2 _Last2) noexcept /* terminates */ {
     // compare [_First1, _Last1) to [_First2, _Last2)
-    return _STD equal(_STD forward<_ExPo>(_Exec), _First1, _Last1, _First2, _Last2, equal_to<>());
+    return _STD equal(_STD forward<_ExPo>(_Exec), _First1, _Last1, _First2, _Last2, equal_to<>{});
 }
 #endif // _HAS_CXX17
 
@@ -5206,7 +5206,7 @@ _NODISCARD _CONSTEXPR20 bool lexicographical_compare(
 template <class _InIt1, class _InIt2>
 _NODISCARD _CONSTEXPR20 bool lexicographical_compare(_InIt1 _First1, _InIt1 _Last1, _InIt2 _First2, _InIt2 _Last2) {
     // order [_First1, _Last1) vs. [_First2, _Last2)
-    return _STD lexicographical_compare(_First1, _Last1, _First2, _Last2, less<>());
+    return _STD lexicographical_compare(_First1, _Last1, _First2, _Last2, less<>{});
 }
 
 #if _HAS_CXX17
@@ -5797,7 +5797,7 @@ _NODISCARD _CONSTEXPR20 _FwdIt lower_bound(_FwdIt _First, const _FwdIt _Last, co
 template <class _FwdIt, class _Ty>
 _NODISCARD _CONSTEXPR20 _FwdIt lower_bound(_FwdIt _First, _FwdIt _Last, const _Ty& _Val) {
     // find first element not before _Val
-    return _STD lower_bound(_First, _Last, _Val, less<>());
+    return _STD lower_bound(_First, _Last, _Val, less<>{});
 }
 
 // FUNCTION TEMPLATE _Swap_ranges_unchecked

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -4997,7 +4997,7 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, _Enable_if_execution_policy
 _NODISCARD bool equal(_ExPo&& _Exec, const _FwdIt1 _First1, const _FwdIt1 _Last1, const _FwdIt2 _First2) noexcept
 /* terminates */ {
     // compare [_First1, _Last1) to [_First2, ...)
-    return _STD equal(_STD forward<_ExPo>(_Exec), _First1, _Last1, _First2, equal_to<>{});
+    return _STD equal(_STD forward<_ExPo>(_Exec), _First1, _Last1, _First2, equal_to{});
 }
 #endif // _HAS_CXX17
 
@@ -5099,7 +5099,7 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, _Enable_if_execution_policy
 _NODISCARD bool equal(_ExPo&& _Exec, const _FwdIt1 _First1, const _FwdIt1 _Last1, const _FwdIt2 _First2,
     const _FwdIt2 _Last2) noexcept /* terminates */ {
     // compare [_First1, _Last1) to [_First2, _Last2)
-    return _STD equal(_STD forward<_ExPo>(_Exec), _First1, _Last1, _First2, _Last2, equal_to<>{});
+    return _STD equal(_STD forward<_ExPo>(_Exec), _First1, _Last1, _First2, _Last2, equal_to{});
 }
 #endif // _HAS_CXX17
 


### PR DESCRIPTION
We're increasingly using braces to construct temporary objects in product code. This makes expressions more readable because braces don't look like function calls.

This PR changes all occurrences of `meow<>()` to `meow<>{}` (missed by previous rounds of search-and-replace due to the "diamond"). These are the transparent operator function objects (primarily `equal_to` and `less`, also a few `plus`, `minus`, and `multiplies` in `<numeric>`).

Then, this changes `meow<>{}` to `meow{}` in C++17-and-later code, where Class Template Argument Deduction is available. (We were already using `meow{}` in a few places, so this is increasing consistency. Of course, this creates a difference between C++14 and C++17 styles, but I think it's reasonable to take advantage of CTAD when possible.)
