### PR TITLE
Provide comparison operators for map/set/etc. instead of _Tree

### DIFF
--- a/stl/inc/map
+++ b/stl/inc/map
@@ -364,6 +364,38 @@ map(initializer_list<pair<_Kty, _Ty>>, _Alloc) -> map<_Kty, _Ty, less<_Kty>, _Al
 #endif // _HAS_CXX17
 
 template <class _Kty, class _Ty, class _Pr, class _Alloc>
+_NODISCARD bool operator==(const map<_Kty, _Ty, _Pr, _Alloc>& _Left, const map<_Kty, _Ty, _Pr, _Alloc>& _Right) {
+    return _Left.size() == _Right.size()
+           && _STD equal(_Left._Unchecked_begin(), _Left._Unchecked_end_iter(), _Right._Unchecked_begin());
+}
+
+template <class _Kty, class _Ty, class _Pr, class _Alloc>
+_NODISCARD bool operator!=(const map<_Kty, _Ty, _Pr, _Alloc>& _Left, const map<_Kty, _Ty, _Pr, _Alloc>& _Right) {
+    return !(_Left == _Right);
+}
+
+template <class _Kty, class _Ty, class _Pr, class _Alloc>
+_NODISCARD bool operator<(const map<_Kty, _Ty, _Pr, _Alloc>& _Left, const map<_Kty, _Ty, _Pr, _Alloc>& _Right) {
+    return _STD lexicographical_compare(
+        _Left._Unchecked_begin(), _Left._Unchecked_end_iter(), _Right._Unchecked_begin(), _Right._Unchecked_end_iter());
+}
+
+template <class _Kty, class _Ty, class _Pr, class _Alloc>
+_NODISCARD bool operator>(const map<_Kty, _Ty, _Pr, _Alloc>& _Left, const map<_Kty, _Ty, _Pr, _Alloc>& _Right) {
+    return _Right < _Left;
+}
+
+template <class _Kty, class _Ty, class _Pr, class _Alloc>
+_NODISCARD bool operator<=(const map<_Kty, _Ty, _Pr, _Alloc>& _Left, const map<_Kty, _Ty, _Pr, _Alloc>& _Right) {
+    return !(_Right < _Left);
+}
+
+template <class _Kty, class _Ty, class _Pr, class _Alloc>
+_NODISCARD bool operator>=(const map<_Kty, _Ty, _Pr, _Alloc>& _Left, const map<_Kty, _Ty, _Pr, _Alloc>& _Right) {
+    return !(_Left < _Right);
+}
+
+template <class _Kty, class _Ty, class _Pr, class _Alloc>
 void swap(map<_Kty, _Ty, _Pr, _Alloc>& _Left, map<_Kty, _Ty, _Pr, _Alloc>& _Right) noexcept(
     noexcept(_Left.swap(_Right))) {
     _Left.swap(_Right);
@@ -517,6 +549,44 @@ multimap(_Iter, _Iter, _Alloc) -> multimap<_Guide_key_t<_Iter>, _Guide_val_t<_It
 template <class _Kty, class _Ty, class _Alloc, enable_if_t<_Is_allocator<_Alloc>::value, int> = 0>
 multimap(initializer_list<pair<_Kty, _Ty>>, _Alloc) -> multimap<_Kty, _Ty, less<_Kty>, _Alloc>;
 #endif // _HAS_CXX17
+
+template <class _Kty, class _Ty, class _Pr, class _Alloc>
+_NODISCARD bool operator==(
+    const multimap<_Kty, _Ty, _Pr, _Alloc>& _Left, const multimap<_Kty, _Ty, _Pr, _Alloc>& _Right) {
+    return _Left.size() == _Right.size()
+           && _STD equal(_Left._Unchecked_begin(), _Left._Unchecked_end_iter(), _Right._Unchecked_begin());
+}
+
+template <class _Kty, class _Ty, class _Pr, class _Alloc>
+_NODISCARD bool operator!=(
+    const multimap<_Kty, _Ty, _Pr, _Alloc>& _Left, const multimap<_Kty, _Ty, _Pr, _Alloc>& _Right) {
+    return !(_Left == _Right);
+}
+
+template <class _Kty, class _Ty, class _Pr, class _Alloc>
+_NODISCARD bool operator<(
+    const multimap<_Kty, _Ty, _Pr, _Alloc>& _Left, const multimap<_Kty, _Ty, _Pr, _Alloc>& _Right) {
+    return _STD lexicographical_compare(
+        _Left._Unchecked_begin(), _Left._Unchecked_end_iter(), _Right._Unchecked_begin(), _Right._Unchecked_end_iter());
+}
+
+template <class _Kty, class _Ty, class _Pr, class _Alloc>
+_NODISCARD bool operator>(
+    const multimap<_Kty, _Ty, _Pr, _Alloc>& _Left, const multimap<_Kty, _Ty, _Pr, _Alloc>& _Right) {
+    return _Right < _Left;
+}
+
+template <class _Kty, class _Ty, class _Pr, class _Alloc>
+_NODISCARD bool operator<=(
+    const multimap<_Kty, _Ty, _Pr, _Alloc>& _Left, const multimap<_Kty, _Ty, _Pr, _Alloc>& _Right) {
+    return !(_Right < _Left);
+}
+
+template <class _Kty, class _Ty, class _Pr, class _Alloc>
+_NODISCARD bool operator>=(
+    const multimap<_Kty, _Ty, _Pr, _Alloc>& _Left, const multimap<_Kty, _Ty, _Pr, _Alloc>& _Right) {
+    return !(_Left < _Right);
+}
 
 template <class _Kty, class _Ty, class _Pr, class _Alloc>
 void swap(multimap<_Kty, _Ty, _Pr, _Alloc>& _Left, multimap<_Kty, _Ty, _Pr, _Alloc>& _Right) noexcept(

--- a/stl/inc/set
+++ b/stl/inc/set
@@ -175,6 +175,38 @@ set(initializer_list<_Kty>, _Alloc) -> set<_Kty, less<_Kty>, _Alloc>;
 #endif // _HAS_CXX17
 
 template <class _Kty, class _Pr, class _Alloc>
+_NODISCARD bool operator==(const set<_Kty, _Pr, _Alloc>& _Left, const set<_Kty, _Pr, _Alloc>& _Right) {
+    return _Left.size() == _Right.size()
+           && _STD equal(_Left._Unchecked_begin(), _Left._Unchecked_end_iter(), _Right._Unchecked_begin());
+}
+
+template <class _Kty, class _Pr, class _Alloc>
+_NODISCARD bool operator!=(const set<_Kty, _Pr, _Alloc>& _Left, const set<_Kty, _Pr, _Alloc>& _Right) {
+    return !(_Left == _Right);
+}
+
+template <class _Kty, class _Pr, class _Alloc>
+_NODISCARD bool operator<(const set<_Kty, _Pr, _Alloc>& _Left, const set<_Kty, _Pr, _Alloc>& _Right) {
+    return _STD lexicographical_compare(
+        _Left._Unchecked_begin(), _Left._Unchecked_end_iter(), _Right._Unchecked_begin(), _Right._Unchecked_end_iter());
+}
+
+template <class _Kty, class _Pr, class _Alloc>
+_NODISCARD bool operator>(const set<_Kty, _Pr, _Alloc>& _Left, const set<_Kty, _Pr, _Alloc>& _Right) {
+    return _Right < _Left;
+}
+
+template <class _Kty, class _Pr, class _Alloc>
+_NODISCARD bool operator<=(const set<_Kty, _Pr, _Alloc>& _Left, const set<_Kty, _Pr, _Alloc>& _Right) {
+    return !(_Right < _Left);
+}
+
+template <class _Kty, class _Pr, class _Alloc>
+_NODISCARD bool operator>=(const set<_Kty, _Pr, _Alloc>& _Left, const set<_Kty, _Pr, _Alloc>& _Right) {
+    return !(_Left < _Right);
+}
+
+template <class _Kty, class _Pr, class _Alloc>
 void swap(set<_Kty, _Pr, _Alloc>& _Left, set<_Kty, _Pr, _Alloc>& _Right) noexcept(noexcept(_Left.swap(_Right))) {
     _Left.swap(_Right);
 }
@@ -313,6 +345,38 @@ multiset(_Iter, _Iter, _Alloc) -> multiset<_Iter_value_t<_Iter>, less<_Iter_valu
 template <class _Kty, class _Alloc, enable_if_t<_Is_allocator<_Alloc>::value, int> = 0>
 multiset(initializer_list<_Kty>, _Alloc) -> multiset<_Kty, less<_Kty>, _Alloc>;
 #endif // _HAS_CXX17
+
+template <class _Kty, class _Pr, class _Alloc>
+_NODISCARD bool operator==(const multiset<_Kty, _Pr, _Alloc>& _Left, const multiset<_Kty, _Pr, _Alloc>& _Right) {
+    return _Left.size() == _Right.size()
+           && _STD equal(_Left._Unchecked_begin(), _Left._Unchecked_end_iter(), _Right._Unchecked_begin());
+}
+
+template <class _Kty, class _Pr, class _Alloc>
+_NODISCARD bool operator!=(const multiset<_Kty, _Pr, _Alloc>& _Left, const multiset<_Kty, _Pr, _Alloc>& _Right) {
+    return !(_Left == _Right);
+}
+
+template <class _Kty, class _Pr, class _Alloc>
+_NODISCARD bool operator<(const multiset<_Kty, _Pr, _Alloc>& _Left, const multiset<_Kty, _Pr, _Alloc>& _Right) {
+    return _STD lexicographical_compare(
+        _Left._Unchecked_begin(), _Left._Unchecked_end_iter(), _Right._Unchecked_begin(), _Right._Unchecked_end_iter());
+}
+
+template <class _Kty, class _Pr, class _Alloc>
+_NODISCARD bool operator>(const multiset<_Kty, _Pr, _Alloc>& _Left, const multiset<_Kty, _Pr, _Alloc>& _Right) {
+    return _Right < _Left;
+}
+
+template <class _Kty, class _Pr, class _Alloc>
+_NODISCARD bool operator<=(const multiset<_Kty, _Pr, _Alloc>& _Left, const multiset<_Kty, _Pr, _Alloc>& _Right) {
+    return !(_Right < _Left);
+}
+
+template <class _Kty, class _Pr, class _Alloc>
+_NODISCARD bool operator>=(const multiset<_Kty, _Pr, _Alloc>& _Left, const multiset<_Kty, _Pr, _Alloc>& _Right) {
+    return !(_Left < _Right);
+}
 
 template <class _Kty, class _Pr, class _Alloc>
 void swap(multiset<_Kty, _Pr, _Alloc>& _Left, multiset<_Kty, _Pr, _Alloc>& _Right) noexcept(

--- a/stl/inc/xtree
+++ b/stl/inc/xtree
@@ -2054,38 +2054,6 @@ protected:
 private:
     _Compressed_pair<key_compare, _Compressed_pair<_Alnode, _Scary_val>> _Mypair;
 };
-
-template <class _Traits>
-_NODISCARD bool operator==(const _Tree<_Traits>& _Left, const _Tree<_Traits>& _Right) {
-    return _Left.size() == _Right.size()
-           && _STD equal(_Left._Unchecked_begin(), _Left._Unchecked_end_iter(), _Right._Unchecked_begin());
-}
-
-template <class _Traits>
-_NODISCARD bool operator!=(const _Tree<_Traits>& _Left, const _Tree<_Traits>& _Right) {
-    return !(_Left == _Right);
-}
-
-template <class _Traits>
-_NODISCARD bool operator<(const _Tree<_Traits>& _Left, const _Tree<_Traits>& _Right) {
-    return _STD lexicographical_compare(
-        _Left._Unchecked_begin(), _Left._Unchecked_end_iter(), _Right._Unchecked_begin(), _Right._Unchecked_end_iter());
-}
-
-template <class _Traits>
-_NODISCARD bool operator>(const _Tree<_Traits>& _Left, const _Tree<_Traits>& _Right) {
-    return _Right < _Left;
-}
-
-template <class _Traits>
-_NODISCARD bool operator<=(const _Tree<_Traits>& _Left, const _Tree<_Traits>& _Right) {
-    return !(_Right < _Left);
-}
-
-template <class _Traits>
-_NODISCARD bool operator>=(const _Tree<_Traits>& _Left, const _Tree<_Traits>& _Right) {
-    return !(_Left < _Right);
-}
 _STD_END
 
 #pragma pop_macro("new")


### PR DESCRIPTION
Fixes #215. I am not actually sure whether this is observable in C++20, but doing what the Standard depicts is generally a good idea, and will make it easier to develop and validate the spaceship operator changes.

Test coverage is provided by `std`:

https://github.com/microsoft/STL/blob/550713eba27c5803addb6f615d3526400cb2df37/tests/std/include/instantiate_containers_iterators_common.hpp#L70-L83
https://github.com/microsoft/STL/blob/550713eba27c5803addb6f615d3526400cb2df37/tests/std/tests/VSO_0000000_instantiate_containers/test.cpp#L442-L446

and the `tr1` legacy test suite:

https://github.com/microsoft/STL/blob/550713eba27c5803addb6f615d3526400cb2df37/tests/tr1/tests/map/test.cpp#L195-L200

(Curiously, I was unable to find where `libcxx` tests the container comparisons, but I didn't search very intensively.)