### PR TITLE
<random>: Fix discrete_distribution result out of range

### DIFF
--- a/stl/inc/random
+++ b/stl/inc/random
@@ -4507,7 +4507,7 @@ private:
     result_type _Eval(_Engine& _Eng, const param_type& _Par0) const {
         double _Px           = _NRAND(_Eng, double);
         const auto _First    = _Par0._Pcdf.begin();
-        const auto _Position = _STD lower_bound(_First, _STD prev(_Par0._Pcdf.end()), _Px);
+        const auto _Position = _STD lower_bound(_First, _Prev_iter(_Par0._Pcdf.end()), _Px);
         return static_cast<result_type>(_Position - _First);
     }
 

--- a/stl/inc/random
+++ b/stl/inc/random
@@ -4507,7 +4507,7 @@ private:
     result_type _Eval(_Engine& _Eng, const param_type& _Par0) const {
         double _Px           = _NRAND(_Eng, double);
         const auto _First    = _Par0._Pcdf.begin();
-        const auto _Position = _STD lower_bound(_First, _Par0._Pcdf.end(), _Px);
+        const auto _Position = _STD lower_bound(_First, _STD prev(_Par0._Pcdf.end()), _Px);
         return static_cast<result_type>(_Position - _First);
     }
 

--- a/tests/std/include/bad_random_engine.hpp
+++ b/tests/std/include/bad_random_engine.hpp
@@ -1,0 +1,158 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <type_traits>
+
+namespace detail {
+    template <typename UInt, int Width = std::numeric_limits<UInt>::digits>
+    class bad_rng_bit_generator { // generates bit patterns for bad_random_engine
+    public:
+        using result_type = UInt;
+
+        static constexpr result_type top_bit    = result_type{1} << (Width - 1);
+        static constexpr result_type lower_bits = top_bit - 1;
+        static constexpr result_type mask_bits  = top_bit | lower_bits;
+        static constexpr int final_bit_count    = (Width - 1) / 2 + 1;
+
+        constexpr result_type current_value() const noexcept { // gets the current pattern
+            return current_value_;
+        }
+
+        constexpr bool generate_next() noexcept { // generates the next pattern, returns false if back to all 0's
+            current_value_ = (current_value_ & lower_bits) << 1 | (current_value_ & top_bit) >> (Width - 1);
+
+            if (current_shift < Width - 1 && current_bit_count != 0 && current_bit_count != Width) {
+                ++current_shift;
+                return true;
+            }
+
+            current_shift = 0;
+
+            if (current_bit_count < final_bit_count) { // n 1's -> n 0's
+                current_bit_count = Width - current_bit_count;
+                current_value_ ^= mask_bits;
+                return true;
+            } else if (current_bit_count > final_bit_count) { // n 0's -> (n+1) 1's
+                current_bit_count = Width - current_bit_count + 1;
+                current_value_    = (current_value_ ^ mask_bits) << 1 | result_type{1};
+                return true;
+            } else { // all bit patterns have been generated, back to all 0's
+                current_bit_count = 0;
+                current_value_    = result_type{0};
+                return false;
+            }
+        }
+
+        friend constexpr bool operator==(const bad_rng_bit_generator& a, const bad_rng_bit_generator& b) noexcept {
+            return a.current_value() == b.current_value();
+        }
+
+        friend constexpr bool operator!=(const bad_rng_bit_generator& a, const bad_rng_bit_generator& b) noexcept {
+            return !(a == b);
+        }
+
+    private:
+        result_type current_value_ = 0;
+        int current_bit_count      = 0;
+        int current_shift          = 0;
+    };
+} // namespace detail
+
+template <typename UInt, int Width = std::numeric_limits<UInt>::digits, int Dimension = 1>
+class bad_random_engine {
+    // Generates bit patterns with at most two transitions between 0's and 1's.
+    // (e.g. 00000000, 11111111, 00001111, 11110000, 00011000, 11100111)
+    // When its output is grouped into subsequences of length Dimension, it cycles through all possible subsequences
+    // containing only such bit patterns. Bit patterns with few 1's or few 0's are be generated first, starting from
+    // all 0's and all 1's.
+
+    static_assert(std::is_integral<UInt>::value, "bad_random_engine: UInt should be unsigned integeral type");
+    static_assert(std::is_unsigned<UInt>::value, "bad_random_engine: UInt should be unsigned integeral type");
+    static_assert(Width > 0, "bad_random_engine: invalid value for Width");
+    static_assert(Width <= std::numeric_limits<UInt>::digits, "bad_random_engine: invalid value for Width");
+    static_assert(Dimension > 0, "bad_random_engine: invalid value for Dimension");
+
+
+public:
+    using result_type = UInt;
+
+    static constexpr result_type(min)() noexcept {
+        return result_type{0};
+    }
+    static constexpr result_type(max)() noexcept {
+        return generator::mask_bits;
+    }
+
+    constexpr result_type operator()() noexcept {
+        const result_type result = generators[current_dimension].current_value();
+
+        if (current_dimension < Dimension - 1) {
+            ++current_dimension;
+        } else {
+            current_dimension = 0;
+
+            if (!generate_next()) {
+                has_cycled_through_ = true;
+            }
+        }
+
+        return result;
+    }
+
+    constexpr bool has_cycled_through() const noexcept { // have we finished a full cycle?
+        return has_cycled_through_;
+    }
+
+private:
+    using generator = detail::bad_rng_bit_generator<UInt, Width>;
+
+    constexpr bool generate_next() noexcept { // generates the next subsequence, returns false if back to all 0's
+        if (limit_value != generator{}) {
+            for (int i = 0; i < limit_dimension; ++i) {
+                if (generators[i] != limit_value) {
+                    generators[i].generate_next();
+                    return true;
+                } else {
+                    generators[i] = generator{};
+                }
+            }
+
+            for (int i = limit_dimension + 1; i < Dimension; ++i) {
+                generators[i].generate_next();
+                if (generators[i] != limit_value) {
+                    return true;
+                } else {
+                    generators[i] = generator{};
+                }
+            }
+
+            __analysis_assume(limit_dimension < Dimension);
+            generators[limit_dimension] = generator{};
+
+            if (limit_dimension < Dimension - 1) {
+                ++limit_dimension;
+                generators[limit_dimension] = limit_value;
+                return true;
+            }
+        }
+
+        limit_dimension   = 0;
+        const bool result = limit_value.generate_next();
+        generators[0]     = limit_value;
+        return result;
+    }
+
+    generator generators[Dimension] = {};
+    generator limit_value{};
+    int limit_dimension      = 0;
+    int current_dimension    = 0;
+    bool has_cycled_through_ = false;
+};
+
+// the cycle length of bad_random_generator is 32 546 312
+using bad_random_generator = bad_random_engine<std::uint64_t, 64, 2>;

--- a/tests/std/include/bad_random_engine.hpp
+++ b/tests/std/include/bad_random_engine.hpp
@@ -5,6 +5,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <iterator>
 #include <limits>
 #include <type_traits>
 
@@ -110,7 +111,6 @@ class bad_random_engine {
     static_assert(Width > 0, "bad_random_engine: invalid value for Width");
     static_assert(Width <= std::numeric_limits<UInt>::digits, "bad_random_engine: invalid value for Width");
     static_assert(Dimension > 0, "bad_random_engine: invalid value for Dimension");
-
 
 public:
     using result_type = UInt;

--- a/tests/std/include/bad_random_engine.hpp
+++ b/tests/std/include/bad_random_engine.hpp
@@ -102,8 +102,8 @@ class bad_random_engine {
     // Generates bit patterns with at most two transitions between 0's and 1's.
     // (e.g. 00000000, 11111111, 00001111, 11110000, 00011000, 11100111)
     // When its output is grouped into subsequences of length Dimension, it cycles through all possible subsequences
-    // containing only such bit patterns. Bit patterns with few 1's or few 0's are be generated first, starting from
-    // all 0's and all 1's.
+    // containing only such bit patterns. Bit patterns with few 1's or few 0's are generated first, starting from all
+    // 0's and all 1's.
 
     static_assert(std::is_integral<UInt>::value, "bad_random_engine: UInt should be unsigned integeral type");
     static_assert(std::is_unsigned<UInt>::value, "bad_random_engine: UInt should be unsigned integeral type");

--- a/tests/std/test.lst
+++ b/tests/std/test.lst
@@ -160,6 +160,7 @@ tests\GH_000545_include_compare
 tests\GH_000685_condition_variable_any
 tests\GH_000690_overaligned_function
 tests\GH_000890_pow_template
+tests\GH_001017_discrete_distribution_out_of_range
 tests\LWG2597_complex_branch_cut
 tests\LWG3018_shared_ptr_function
 tests\P0024R2_parallel_algorithms_adjacent_difference

--- a/tests/std/tests/GH_001017_discrete_distribution_out_of_range/bad_random_engine.hpp
+++ b/tests/std/tests/GH_001017_discrete_distribution_out_of_range/bad_random_engine.hpp
@@ -74,8 +74,7 @@ namespace detail {
             return !(a == b);
         }
 
-        friend constexpr bool operator==(const my_iter& iter, const my_sentinel sentinel) noexcept {
-            (void) sentinel;
+        friend constexpr bool operator==(const my_iter& iter, my_sentinel) noexcept {
             return *iter == 0;
         }
 
@@ -106,8 +105,8 @@ class bad_random_engine {
     // containing only such bit patterns. Bit patterns with few 1's or few 0's are generated first, starting from all
     // 0's and all 1's.
 
-    static_assert(std::is_integral<UInt>::value, "bad_random_engine: UInt should be unsigned integeral type");
-    static_assert(std::is_unsigned<UInt>::value, "bad_random_engine: UInt should be unsigned integeral type");
+    static_assert(std::is_integral_v<UInt>, "bad_random_engine: UInt should be unsigned integral type");
+    static_assert(std::is_unsigned_v<UInt>, "bad_random_engine: UInt should be unsigned integral type");
     static_assert(Width > 0, "bad_random_engine: invalid value for Width");
     static_assert(Width <= std::numeric_limits<UInt>::digits, "bad_random_engine: invalid value for Width");
     static_assert(Dimension > 0, "bad_random_engine: invalid value for Dimension");

--- a/tests/std/tests/GH_001017_discrete_distribution_out_of_range/env.lst
+++ b/tests/std/tests/GH_001017_discrete_distribution_out_of_range/env.lst
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+RUNALL_INCLUDE ..\usual_matrix.lst

--- a/tests/std/tests/GH_001017_discrete_distribution_out_of_range/test.cpp
+++ b/tests/std/tests/GH_001017_discrete_distribution_out_of_range/test.cpp
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <cassert>
+#include <random>
+
+#include <bad_random_engine.hpp>
+
+int main() {
+    std::discrete_distribution<int> dist{1, 1, 1, 1, 1, 1};
+    bad_random_generator rng;
+
+    while (!rng.has_cycled_through()) {
+        const auto rand_value = dist(rng);
+        assert(0 <= rand_value && rand_value < 6);
+    }
+}

--- a/tests/std/tests/GH_001017_discrete_distribution_out_of_range/test.cpp
+++ b/tests/std/tests/GH_001017_discrete_distribution_out_of_range/test.cpp
@@ -4,7 +4,7 @@
 #include <cassert>
 #include <random>
 
-#include <bad_random_engine.hpp>
+#include "bad_random_engine.hpp"
 
 int main() {
     std::discrete_distribution<int> dist{1, 1, 1, 1, 1, 1};


### PR DESCRIPTION
Fix #1017.

Mathematically, `_Par0._Pcdf.back()` should be one. However, when it is actually slightly smaller than one due to rounding error, there is a small probability that `_Px > _Par0._Pcdf.back()`, and the original code returns the invalid value of `_Par0._Pcdf.size()`.

<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
