### PR TITLE
Atomic CAS with pad (#23, P0528R3)

### DIFF
--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -354,8 +354,18 @@ struct _Atomic_storage {
         _Check_memory_order(_Order);
         const auto _Storage_ptr  = _STD addressof(_Storage);
         const auto _Expected_ptr = _STD addressof(_Expected);
+#if _HAS_CXX20
+        if constexpr (!_STD has_unique_object_representations_v<_Ty>) {
+            __builtin_zero_non_value_bits(_Expected_ptr);
+        }
+#endif
         bool _Result;
         _Lock();
+#if _HAS_CXX20
+        if constexpr (!_STD has_unique_object_representations_v<_Ty>) {
+            __builtin_zero_non_value_bits(_Storage_ptr);
+        }
+#endif
         if (_CSTD memcmp(_Storage_ptr, _Expected_ptr, sizeof(_Ty)) == 0) {
             _CSTD memcpy(_Storage_ptr, _STD addressof(_Desired), sizeof(_Ty));
             _Result = true;
@@ -480,13 +490,37 @@ struct _Atomic_storage<_Ty, 1> { // lock-free using 1-byte intrinsics
 
     bool compare_exchange_strong(_Ty& _Expected, const _Ty _Desired,
         const memory_order _Order = memory_order_seq_cst) noexcept { // CAS with given memory order
-        const char _Expected_bytes = _Atomic_reinterpret_as<char>(_Expected); // read before atomic operation
+        char _Expected_bytes = _Atomic_reinterpret_as<char>(_Expected); // read before atomic operation
         char _Prev_bytes;
-        _ATOMIC_CHOOSE_INTRINSIC(_Order, _Prev_bytes, _InterlockedCompareExchange8, _Atomic_address_as<char>(_Storage),
-            _Atomic_reinterpret_as<char>(_Desired), _Expected_bytes);
-        if (_Prev_bytes == _Expected_bytes) {
-            return true;
+
+#if _HAS_CXX20
+        if constexpr (_STD has_unique_object_representations_v<_Ty>) {
+#endif
+            _ATOMIC_CHOOSE_INTRINSIC(_Order, _Prev_bytes, _InterlockedCompareExchange8,
+                _Atomic_address_as<char>(_Storage), _Atomic_reinterpret_as<char>(_Desired), _Expected_bytes);
+            if (_Prev_bytes == _Expected_bytes) {
+                return true;
+            }
+#if _HAS_CXX20
+        } else {
+            _Ty _Mask;
+            _CSTD memset(&_Mask, 0xff, sizeof(_Ty));
+            __builtin_zero_non_value_bits(_STD addressof(_Mask));
+            const short _Mask_val = _Atomic_reinterpret_as<short>(_Mask);
+
+            for (;;) {
+                _ATOMIC_CHOOSE_INTRINSIC(_Order, _Prev_bytes, _InterlockedCompareExchange8,
+                    _Atomic_address_as<char>(_Storage), _Atomic_reinterpret_as<char>(_Desired), _Expected_bytes);
+                if (_Prev_bytes == _Expected_bytes) {
+                    return true;
+                }
+                if ((_Prev_bytes ^ _Expected_bytes) & _Mask_val) {
+                    break;
+                }
+                _Expected_bytes = (_Expected_bytes & _Mask_val) | (_Prev_bytes & ~_Mask_val);
+            }
         }
+#endif
 
         reinterpret_cast<char&>(_Expected) = _Prev_bytes;
         return false;
@@ -562,13 +596,36 @@ struct _Atomic_storage<_Ty, 2> { // lock-free using 2-byte intrinsics
 
     bool compare_exchange_strong(_Ty& _Expected, const _Ty _Desired,
         const memory_order _Order = memory_order_seq_cst) noexcept { // CAS with given memory order
-        const short _Expected_bytes = _Atomic_reinterpret_as<short>(_Expected); // read before atomic operation
+        short _Expected_bytes = _Atomic_reinterpret_as<short>(_Expected); // read before atomic operation
         short _Prev_bytes;
-        _ATOMIC_CHOOSE_INTRINSIC(_Order, _Prev_bytes, _InterlockedCompareExchange16,
-            _Atomic_address_as<short>(_Storage), _Atomic_reinterpret_as<short>(_Desired), _Expected_bytes);
-        if (_Prev_bytes == _Expected_bytes) {
-            return true;
+#if _HAS_CXX20
+        if constexpr (_STD has_unique_object_representations_v<_Ty>) {
+#endif
+            _ATOMIC_CHOOSE_INTRINSIC(_Order, _Prev_bytes, _InterlockedCompareExchange16,
+                _Atomic_address_as<short>(_Storage), _Atomic_reinterpret_as<short>(_Desired), _Expected_bytes);
+            if (_Prev_bytes == _Expected_bytes) {
+                return true;
+            }
+#if _HAS_CXX20
+        } else {
+            _Ty _Mask;
+            _CSTD memset(&_Mask, 0xff, sizeof(_Ty));
+            __builtin_zero_non_value_bits(_STD addressof(_Mask));
+            const short _Mask_val = _Atomic_reinterpret_as<short>(_Mask);
+
+            for (;;) {
+                _ATOMIC_CHOOSE_INTRINSIC(_Order, _Prev_bytes, _InterlockedCompareExchange16,
+                    _Atomic_address_as<short>(_Storage), _Atomic_reinterpret_as<short>(_Desired), _Expected_bytes);
+                if (_Prev_bytes == _Expected_bytes) {
+                    return true;
+                }
+                if ((_Prev_bytes ^ _Expected_bytes) & _Mask_val) {
+                    break;
+                }
+                _Expected_bytes = (_Expected_bytes & _Mask_val) | (_Prev_bytes & ~_Mask_val);
+            }
         }
+#endif
 
         _CSTD memcpy(_STD addressof(_Expected), &_Prev_bytes, sizeof(_Ty));
         return false;
@@ -642,13 +699,36 @@ struct _Atomic_storage<_Ty, 4> { // lock-free using 4-byte intrinsics
 
     bool compare_exchange_strong(_Ty& _Expected, const _Ty _Desired,
         const memory_order _Order = memory_order_seq_cst) noexcept { // CAS with given memory order
-        const long _Expected_bytes = _Atomic_reinterpret_as<long>(_Expected); // read before atomic operation
+        long _Expected_bytes = _Atomic_reinterpret_as<long>(_Expected); // read before atomic operation
         long _Prev_bytes;
-        _ATOMIC_CHOOSE_INTRINSIC(_Order, _Prev_bytes, _InterlockedCompareExchange, _Atomic_address_as<long>(_Storage),
-            _Atomic_reinterpret_as<long>(_Desired), _Expected_bytes);
-        if (_Prev_bytes == _Expected_bytes) {
-            return true;
+#if _HAS_CXX20
+        if constexpr (_STD has_unique_object_representations_v<_Ty>) {
+#endif
+            _ATOMIC_CHOOSE_INTRINSIC(_Order, _Prev_bytes, _InterlockedCompareExchange,
+                _Atomic_address_as<long>(_Storage), _Atomic_reinterpret_as<long>(_Desired), _Expected_bytes);
+            if (_Prev_bytes == _Expected_bytes) {
+                return true;
+            }
+#if _HAS_CXX20
+        } else {
+            _Ty _Mask;
+            _CSTD memset(&_Mask, 0xff, sizeof(_Ty));
+            __builtin_zero_non_value_bits(_STD addressof(_Mask));
+            const long _Mask_val = _Atomic_reinterpret_as<long>(_Mask);
+
+            for (;;) {
+                _ATOMIC_CHOOSE_INTRINSIC(_Order, _Prev_bytes, _InterlockedCompareExchange,
+                    _Atomic_address_as<long>(_Storage), _Atomic_reinterpret_as<long>(_Desired), _Expected_bytes);
+                if (_Prev_bytes == _Expected_bytes) {
+                    return true;
+                }
+                if ((_Prev_bytes ^ _Expected_bytes) & _Mask_val) {
+                    break;
+                }
+                _Expected_bytes = (_Expected_bytes & _Mask_val) | (_Prev_bytes & ~_Mask_val);
+            }
         }
+#endif
 
         _CSTD memcpy(_STD addressof(_Expected), &_Prev_bytes, sizeof(_Ty));
         return false;
@@ -749,13 +829,38 @@ struct _Atomic_storage<_Ty, 8> { // lock-free using 8-byte intrinsics
 
     bool compare_exchange_strong(_Ty& _Expected, const _Ty _Desired,
         const memory_order _Order = memory_order_seq_cst) noexcept { // CAS with given memory order
-        const long long _Expected_bytes = _Atomic_reinterpret_as<long long>(_Expected); // read before atomic operation
+        long long _Expected_bytes = _Atomic_reinterpret_as<long long>(_Expected); // read before atomic operation
         long long _Prev_bytes;
-        _ATOMIC_CHOOSE_INTRINSIC(_Order, _Prev_bytes, _InterlockedCompareExchange64,
-            _Atomic_address_as<long long>(_Storage), _Atomic_reinterpret_as<long long>(_Desired), _Expected_bytes);
-        if (_Prev_bytes == _Expected_bytes) {
-            return true;
+
+#if _HAS_CXX20
+        if constexpr (_STD has_unique_object_representations_v<_Ty>) {
+#endif
+            _ATOMIC_CHOOSE_INTRINSIC(_Order, _Prev_bytes, _InterlockedCompareExchange64,
+                _Atomic_address_as<long long>(_Storage), _Atomic_reinterpret_as<long long>(_Desired), _Expected_bytes);
+            if (_Prev_bytes == _Expected_bytes) {
+                return true;
+            }
+#if _HAS_CXX20
+        } else {
+            _Ty _Mask;
+            _CSTD memset(&_Mask, 0xff, sizeof(_Ty));
+            __builtin_zero_non_value_bits(_STD addressof(_Mask));
+            const long long _Mask_val = _Atomic_reinterpret_as<long long>(_Mask);
+
+            for (;;) {
+                _ATOMIC_CHOOSE_INTRINSIC(_Order, _Prev_bytes, _InterlockedCompareExchange64,
+                    _Atomic_address_as<long long>(_Storage), _Atomic_reinterpret_as<long long>(_Desired),
+                    _Expected_bytes);
+                if (_Prev_bytes == _Expected_bytes) {
+                    return true;
+                }
+                if ((_Prev_bytes ^ _Expected_bytes) & _Mask_val) {
+                    break;
+                }
+                _Expected_bytes = (_Expected_bytes & _Mask_val) | (_Prev_bytes & ~_Mask_val);
+            }
         }
+#endif
 
         _CSTD memcpy(_STD addressof(_Expected), &_Prev_bytes, sizeof(_Ty));
         return false;

--- a/tests/std/test.lst
+++ b/tests/std/test.lst
@@ -219,6 +219,7 @@ tests\P0433R2_deduction_guides
 tests\P0476R2_bit_cast
 tests\P0487R1_fixing_operator_shl_basic_istream_char_pointer
 tests\P0513R0_poisoning_the_hash
+tests\P0528R3_cmpxchg_pad
 tests\P0553R4_bit_rotating_and_counting_functions
 tests\P0556R3_bit_integral_power_of_two_operations
 tests\P0586R2_integer_comparison

--- a/tests/std/tests/P0528R3_cmpxchg_pad/env.lst
+++ b/tests/std/tests/P0528R3_cmpxchg_pad/env.lst
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+RUNALL_INCLUDE ..\usual_latest_matrix.lst

--- a/tests/std/tests/P0528R3_cmpxchg_pad/test.cpp
+++ b/tests/std/tests/P0528R3_cmpxchg_pad/test.cpp
@@ -1,0 +1,138 @@
+#include <atomic>
+#include <cassert>
+
+struct X1 {
+    char x : 6;
+
+    void set(char v) {
+        x = v;
+    }
+};
+
+struct X2 {
+    short x : 9;
+
+    void set(char v) {
+        x = v;
+    }
+};
+
+#pragma pack(push,1)
+struct X3 {
+    char x : 4;
+    char : 2;
+    char y : 1;
+    short z;
+
+    void set(char v) {
+        x = v;
+        y = 0;
+        z = 0;
+    }
+};
+#pragma pack(pop)
+
+#pragma warning(push)
+#pragma warning(disable:4324) // '%s': structure was padded due to alignment specifier
+struct alignas(4) X4 {
+    char x;
+
+    void set(char v) {
+        x = v;
+    }
+};
+#pragma warning(pop)
+
+struct X8 {
+    char x;
+    long y;
+
+    void set(char v) {
+        x = v;
+        y = 0;
+    }
+};
+
+struct X16 {
+    long x;
+    char y;
+    long long z;
+
+    void set(char v) {
+        x = v;
+        y = 0;
+        z = 0;
+    }
+};
+
+struct X20 {
+    long x;
+    long y[3];
+    char z;
+
+    void set(char v) {
+        x = v;
+        memset(&y, 0, sizeof(y));
+        z = 0;
+    }
+};
+
+
+template<class X, std::size_t S>
+void test() {
+    static_assert(sizeof(X) == S, "Unexpected size");
+    X x2;
+    X x3;
+    X x4;
+    X x1;
+    memset(&x1, 0x00, sizeof(x1));
+    memset(&x2, 0xff, sizeof(x1));
+    memset(&x3, 0xff, sizeof(x1));
+    x1.set(5);
+    x2.set(5);
+    x3.set(6);
+    x4.set(7);
+
+    std::atomic<X> v;
+    v.store(x1);
+    X x;
+    memcpy(&x, &x3, sizeof(x));
+    assert(!v.compare_exchange_strong(x, x4));
+    assert(v.load().x == 5);
+
+    v.store(x1);
+    for (int retry = 0; retry != 10; ++retry) {
+        X xw;
+        memcpy(&xw, &x3, sizeof(x));
+        assert(!v.compare_exchange_weak(xw, x4));
+        assert(v.load().x == 5);
+    }
+
+    v.store(x1);
+    memcpy(&x, &x2, sizeof(x));
+    assert(v.compare_exchange_strong(x, x3));
+    assert(v.load().x == 6);
+
+    v.store(x1);
+    for (;;) {
+        X xw;
+        memcpy(&xw, &x2, sizeof(x));
+        if (v.compare_exchange_weak(xw, x3))
+            break;
+    }
+    assert(v.load().x == 6);
+}
+
+
+
+int main()
+{
+    test<X1, 1>();
+    test<X2, 2>();
+    test<X3, 3>();
+    test<X4, 4>();
+    test<X8, 8>();
+    test<X16, 16>();
+    test<X20, 20>();
+    return 0;
+}


### PR DESCRIPTION
- Only use `__builtin_zero_non_value_bits` in `compare_exchange_strong`:
  - Using in constructor will not work properly for `atomic_ref`
  - Using in constructor will force to use it in `store` and `exchange` which is sub-optiomal
  - Computing mask in CAS might be useful for LL/SC implementation, if masked CAS is exposed as intrinsic
- Only expose the feature for C++20