### PR TITLE
Finish P0811R3 midpoint and lerp

### DIFF
--- a/stl/inc/cmath
+++ b/stl/inc/cmath
@@ -1288,7 +1288,7 @@ _NODISCARD constexpr _Ty _Common_lerp(const _Ty _ArgA, const _Ty _ArgB, const _T
             return _ArgT;
         }
     } else {
-        // raise FE_INVALID if at least one of _ArgA, _ArgB and _ArgT is signaling NaN
+        // raise FE_INVALID if at least one of _ArgA, _ArgB, and _ArgT is signaling NaN
         if (_STD _Is_nan(_ArgA) || _STD _Is_nan(_ArgB)) {
             return (_ArgA + _ArgB) + _ArgT;
         }

--- a/stl/inc/cmath
+++ b/stl/inc/cmath
@@ -12,6 +12,10 @@
 #include <cstdlib>
 #include <xtr1common>
 
+#if _HAS_CXX20
+#include <xutility>
+#endif // _HAS_CXX20
+
 #pragma pack(push, _CRT_PACKING)
 #pragma warning(push, _STL_WARNING_LEVEL)
 #pragma warning(disable : _STL_DISABLED_WARNINGS)
@@ -1238,13 +1242,12 @@ _NODISCARD auto hypot(const _Ty1 _Dx, const _Ty2 _Dy, const _Ty3 _Dz) {
 
 #if _HAS_CXX20
 // FUNCTION lerp
-// TRANSITION, P0553: lerp is not yet constexpr
 template <class _Ty>
-_NODISCARD /* constexpr */ _Ty _Common_lerp(const _Ty _ArgA, const _Ty _ArgB, const _Ty _ArgT) noexcept {
+_NODISCARD constexpr _Ty _Common_lerp(const _Ty _ArgA, const _Ty _ArgB, const _Ty _ArgT) noexcept {
     // on a line intersecting {(0.0, _ArgA), (1.0, _ArgB)}, return the Y value for X == _ArgT
 
-    const int _Finite_mask = (int{isfinite(_ArgA)} << 2) | (int{isfinite(_ArgB)} << 1) | int{isfinite(_ArgT)};
-    if (_Finite_mask == 0b111) {
+    const bool _T_is_finite = _STD _Is_finite(_ArgT);
+    if (_T_is_finite && _STD _Is_finite(_ArgA) && _STD _Is_finite(_ArgB)) {
         // 99% case, put it first; this block comes from P0811R3
         if ((_ArgA <= 0 && _ArgB >= 0) || (_ArgA >= 0 && _ArgB <= 0)) {
             // exact, monotonic, bounded, determinate, and (for _ArgA == _ArgB == 0) consistent:
@@ -1272,96 +1275,64 @@ _NODISCARD /* constexpr */ _Ty _Common_lerp(const _Ty _ArgA, const _Ty _ArgB, co
         return _Candidate;
     }
 
-    if (isnan(_ArgA)) {
-        return _ArgA;
-    }
-
-    if (isnan(_ArgB)) {
-        return _ArgB;
-    }
-
-    if (isnan(_ArgT)) {
-        return _ArgT;
-    }
-
-    switch (_Finite_mask) {
-    case 0b000:
-        // All values are infinities
-        if (_ArgT >= 1) {
-            return _ArgB;
-        }
-
-        return _ArgA;
-    case 0b010:
-    case 0b100:
-    case 0b110:
-        // _ArgT is an infinity; return infinity in the "direction" of _ArgA and _ArgB
-        return _ArgT * (_ArgB - _ArgA);
-    case 0b001:
-        // Here _ArgA and _ArgB are infinities
-        if (_ArgA == _ArgB) {
-            // same sign, so T doesn't matter
+    if (_STD is_constant_evaluated()) {
+        if (_STD _Is_nan(_ArgA)) {
             return _ArgA;
         }
 
-        // Opposite signs, choose the "infinity direction" according to T if it makes sense.
-        if (_ArgT <= 0) {
-            return _ArgA;
-        }
-
-        if (_ArgT >= 1) {
+        if (_STD _Is_nan(_ArgB)) {
             return _ArgB;
         }
 
-        // Interpolating between infinities of opposite signs doesn't make sense, NaN
-        if constexpr (sizeof(_Ty) == sizeof(float)) {
-            return __builtin_nanf("0");
+        if (_STD _Is_nan(_ArgT)) {
+            return _ArgT;
+        }
+    } else {
+        if (_STD _Is_nan(_ArgA)) {
+            if (_STD _Is_nan(_ArgB) || _STD _Is_nan(_ArgT)) {
+                (void) (_ArgB + _ArgT);
+            }
+
+            return _ArgA + _ArgA;
+        }
+
+        if (_STD _Is_nan(_ArgB) || _STD _Is_nan(_ArgT)) {
+            return _ArgB + _ArgT;
+        }
+    }
+
+    if (_T_is_finite) {
+        // _ArgT is finite, _ArgA and/or _ArgB is infinity
+        if (_ArgT < 0) {
+            // if _ArgT < 0:     return infinity in the "direction" of _ArgA if that exists, NaN otherwise
+            return _ArgA - _ArgB;
+        } else if (_ArgT <= 1) {
+            // if _ArgT == 0:    return _ArgA (infinity) if _ArgB is finite, NaN otherwise
+            // if 0 < _ArgT < 1: return infinity "between" _ArgA and _ArgB if that exists, NaN otherwise
+            // if _ArgT == 1:    return _ArgB (infinity) if _ArgA is finite, NaN otherwise
+            return _ArgT * _ArgB + (1 - _ArgT) * _ArgA;
         } else {
-            return __builtin_nan("0");
+            // if _ArgT > 1:     return infinity in the "direction" of _ArgB if that exists, NaN otherwise
+            return _ArgB - _ArgA;
         }
-    case 0b011:
-        // _ArgA is an infinity but _ArgB is not
-        if (_ArgT == 1) {
-            return _ArgB;
-        }
-
-        if (_ArgT < 1) {
-            // towards the infinity, return it
-            return _ArgA;
-        }
-
-        // away from the infinity
-        return -_ArgA;
-    case 0b101:
-        // _ArgA is finite and _ArgB is an infinity
-        if (_ArgT == 0) {
-            return _ArgA;
-        }
-
-        if (_ArgT > 0) {
-            // toward the infinity
-            return _ArgB;
-        }
-
-        return -_ArgB;
-    case 0b111: // impossible; handled in fast path
-    default:
-        _CSTD abort();
+    } else {
+        // _ArgT is an infinity; return infinity in the "direction" of _ArgA and _ArgB if that exists, NaN otherwise
+        return _ArgT * (_ArgB - _ArgA);
     }
 }
 
 // As of 2019-06-17 it is unclear whether the "sufficient additional overloads" clause is intended to target lerp;
 // LWG-3223 is pending.
 
-_NODISCARD /* constexpr */ inline float lerp(const float _ArgA, const float _ArgB, const float _ArgT) noexcept {
+_NODISCARD constexpr inline float lerp(const float _ArgA, const float _ArgB, const float _ArgT) noexcept {
     return _Common_lerp(_ArgA, _ArgB, _ArgT);
 }
 
-_NODISCARD /* constexpr */ inline double lerp(const double _ArgA, const double _ArgB, const double _ArgT) noexcept {
+_NODISCARD constexpr inline double lerp(const double _ArgA, const double _ArgB, const double _ArgT) noexcept {
     return _Common_lerp(_ArgA, _ArgB, _ArgT);
 }
 
-_NODISCARD /* constexpr */ inline long double lerp(
+_NODISCARD constexpr inline long double lerp(
     const long double _ArgA, const long double _ArgB, const long double _ArgT) noexcept {
     return _Common_lerp(_ArgA, _ArgB, _ArgT);
 }

--- a/stl/inc/cmath
+++ b/stl/inc/cmath
@@ -1288,19 +1288,13 @@ _NODISCARD constexpr _Ty _Common_lerp(const _Ty _ArgA, const _Ty _ArgB, const _T
             return _ArgT;
         }
     } else {
-        if (_STD _Is_nan(_ArgA)) {
-            // raise FE_INVALID if at least one of _ArgA, _ArgB and _ArgT is signaling NaN
-            _Ty _Tmp = _ArgA;
-
-            if (_STD _Is_nan(_ArgB) || _STD _Is_nan(_ArgT)) {
-                _Tmp = _ArgB + _ArgT;
-            }
-
-            return _ArgA + _Tmp;
+        // raise FE_INVALID if at least one of _ArgA, _ArgB and _ArgT is signaling NaN
+        if (_STD _Is_nan(_ArgA) || _STD _Is_nan(_ArgB)) {
+            return (_ArgA + _ArgB) + _ArgT;
         }
 
-        if (_STD _Is_nan(_ArgB) || _STD _Is_nan(_ArgT)) {
-            return _ArgB + _ArgT;
+        if (_STD _Is_nan(_ArgT)) {
+            return _ArgT + _ArgT;
         }
     }
 

--- a/stl/inc/cmath
+++ b/stl/inc/cmath
@@ -1290,12 +1290,13 @@ _NODISCARD constexpr _Ty _Common_lerp(const _Ty _ArgA, const _Ty _ArgB, const _T
     } else {
         if (_STD _Is_nan(_ArgA)) {
             // raise FE_INVALID if at least one of _ArgA, _ArgB and _ArgT is signaling NaN
+            _Ty _Tmp = _ArgA;
 
             if (_STD _Is_nan(_ArgB) || _STD _Is_nan(_ArgT)) {
-                (void) (_ArgB + _ArgT);
+                _Tmp = _ArgB + _ArgT;
             }
 
-            return _ArgA + _ArgA;
+            return _ArgA + _Tmp;
         }
 
         if (_STD _Is_nan(_ArgB) || _STD _Is_nan(_ArgT)) {

--- a/stl/inc/cmath
+++ b/stl/inc/cmath
@@ -1289,6 +1289,8 @@ _NODISCARD constexpr _Ty _Common_lerp(const _Ty _ArgA, const _Ty _ArgB, const _T
         }
     } else {
         if (_STD _Is_nan(_ArgA)) {
+            // raise FE_INVALID if at least one of _ArgA, _ArgB and _ArgT is signaling NaN
+
             if (_STD _Is_nan(_ArgB) || _STD _Is_nan(_ArgT)) {
                 (void) (_ArgB + _ArgT);
             }

--- a/stl/inc/numeric
+++ b/stl/inc/numeric
@@ -540,14 +540,9 @@ template <class _Arithmetic>
 _NODISCARD constexpr auto _Abs_u(const _Arithmetic _Val) noexcept {
     // computes absolute value of _Val (converting to an unsigned integer type if necessary to avoid overflow
     // representing the negation of the minimum value)
-    if constexpr (is_floating_point_v<_Arithmetic>) {
-        // TRANSITION, P0553: this mishandles NaNs
-        if (_Val < 0) {
-            return -_Val;
-        }
+    static_assert(is_integral_v<_Arithmetic>);
 
-        return _Val;
-    } else if constexpr (is_signed_v<_Arithmetic>) {
+    if constexpr (is_signed_v<_Arithmetic>) {
         using _Unsigned = make_unsigned_t<_Arithmetic>;
         if (_Val < 0) {
             // note static_cast to _Unsigned such that _Arithmetic == short returns unsigned short rather than int
@@ -619,9 +614,23 @@ _NODISCARD constexpr common_type_t<_Mt, _Nt> lcm(const _Mt _Mx, const _Nt _Nx) n
 template <class _Ty, enable_if_t<is_arithmetic_v<_Ty> && !is_same_v<remove_cv_t<_Ty>, bool>, int> = 0>
 _NODISCARD constexpr _Ty midpoint(const _Ty _Val1, const _Ty _Val2) noexcept {
     if constexpr (is_floating_point_v<_Ty>) {
+        if (_STD is_constant_evaluated()) {
+            if (_STD _Is_nan(_Val1)) {
+                return _Val1;
+            }
+
+            if (_STD _Is_nan(_Val2)) {
+                return _Val2;
+            }
+        } else {
+            if (_STD _Is_nan(_Val1) || _STD _Is_nan(_Val2)) {
+                return _Val1 + _Val2;
+            }
+        }
+
         constexpr _Ty _High_limit = (numeric_limits<_Ty>::max)() / 2;
-        const auto _Val1_a        = _Abs_u(_Val1);
-        const auto _Val2_a        = _Abs_u(_Val2);
+        const auto _Val1_a        = _Float_abs(_Val1);
+        const auto _Val2_a        = _Float_abs(_Val2);
         if (_Val1_a <= _High_limit && _Val2_a <= _High_limit) {
             // _Val1 and _Val2 are small enough that _Val1 + _Val2 won't overflow
 
@@ -635,16 +644,6 @@ _NODISCARD constexpr _Ty midpoint(const _Ty _Val1, const _Ty _Val2) noexcept {
             // be finer than 2^-1074 and addition/subtraction can't create smaller steps.
 
             return (_Val1 + _Val2) / 2;
-        }
-
-        // TRANSITION, P0553: the next two branches handle NaNs but don't produce correct behavior under /fp:fast or
-        // -fassociative-math
-        if (_Val1 != _Val1) {
-            return _Val1;
-        }
-
-        if (_Val2 != _Val2) {
-            return _Val2;
         }
 
         // Here at least one of {_Val1, _Val2} has large magnitude.

--- a/stl/inc/numeric
+++ b/stl/inc/numeric
@@ -536,16 +536,16 @@ _CONSTEXPR20 void iota(_FwdIt _First, _FwdIt _Last, _Ty _Val) {
 
 #if _HAS_CXX17
 // FUNCTION TEMPLATE _Abs_u
-template <class _Arithmetic>
-_NODISCARD constexpr auto _Abs_u(const _Arithmetic _Val) noexcept {
+template <class _Integral>
+_NODISCARD constexpr auto _Abs_u(const _Integral _Val) noexcept {
     // computes absolute value of _Val (converting to an unsigned integer type if necessary to avoid overflow
     // representing the negation of the minimum value)
-    static_assert(is_integral_v<_Arithmetic>);
+    static_assert(is_integral_v<_Integral>);
 
-    if constexpr (is_signed_v<_Arithmetic>) {
-        using _Unsigned = make_unsigned_t<_Arithmetic>;
+    if constexpr (is_signed_v<_Integral>) {
+        using _Unsigned = make_unsigned_t<_Integral>;
         if (_Val < 0) {
-            // note static_cast to _Unsigned such that _Arithmetic == short returns unsigned short rather than int
+            // note static_cast to _Unsigned such that _Integral == short returns unsigned short rather than int
             return static_cast<_Unsigned>(_Unsigned{0} - static_cast<_Unsigned>(_Val));
         }
 

--- a/stl/inc/numeric
+++ b/stl/inc/numeric
@@ -624,6 +624,7 @@ _NODISCARD constexpr _Ty midpoint(const _Ty _Val1, const _Ty _Val2) noexcept {
             }
         } else {
             if (_STD _Is_nan(_Val1) || _STD _Is_nan(_Val2)) {
+                // raise FE_INVALID if at least one of _Val1 and _Val2 is signaling NaN
                 return _Val1 + _Val2;
             }
         }
@@ -651,7 +652,7 @@ _NODISCARD constexpr _Ty midpoint(const _Ty _Val1, const _Ty _Val2) noexcept {
         // one ULP of the result, so we can add it directly without the potentially inexact division by 2.
 
         // In the default rounding mode this less than one ULP difference will always be rounded away, so under
-        // /fp:precise or /fp:fast we could avoid these tests if we had some means of detecting it in the caller.
+        // /fp:fast we could avoid these tests if we had some means of detecting it in the caller.
         constexpr _Ty _Low_limit = (numeric_limits<_Ty>::min)() * 2;
         if (_Val1_a < _Low_limit) {
             return _Val1 + _Val2 / 2;

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -5942,73 +5942,49 @@ struct _CXX17_DEPRECATE_ITERATOR_BASE_CLASS iterator { // base type for iterator
     using reference         = _Reference;
 };
 
-// STRUCT TEMPLATE _Float_bits
+// STRUCT TEMPLATE _Float_traits
 template <class _Ty>
-struct _Float_bits {
-    static_assert(_Always_false<_Ty>, "_Float_bits<NonFloatingPoint> is invalid");
-};
+struct _Float_traits {
+    static_assert(is_floating_point_v<_Ty>, "_Float_traits<NonFloatingPoint> is invalid");
 
-template <>
-struct _Float_bits<float> {
-    using type = unsigned int;
-};
-
-template <>
-struct _Float_bits<double> {
+    // traits for double and long double:
     using type = unsigned long long;
+
+    static constexpr type _Magnitude_mask = 0x7fff'ffff'ffff'ffffULL;
+    static constexpr type _Exponent_mask  = 0x7ff0'0000'0000'0000ULL;
 };
 
 template <>
-struct _Float_bits<long double> {
-    using type = _Float_bits<double>::type;
+struct _Float_traits<float> {
+    using type = unsigned int;
+
+    static constexpr type _Magnitude_mask = 0x7fff'ffffU;
+    static constexpr type _Exponent_mask  = 0x7f80'0000U;
 };
-
-template <class _Ty>
-using _Float_bits_t = typename _Float_bits<_Ty>::type;
-
-template <class _Ty>
-_INLINE_VAR constexpr _Float_bits_t<_Ty> _Float_magnitude_mask{};
-template <class _Ty>
-_INLINE_VAR constexpr _Float_bits_t<_Ty> _Float_exponent_mask{};
-
-template <>
-_INLINE_VAR constexpr _Float_bits_t<float> _Float_magnitude_mask<float> = 0x7fff'ffffU;
-template <>
-_INLINE_VAR constexpr _Float_bits_t<float> _Float_exponent_mask<float> = 0x7f80'0000U;
-
-template <>
-_INLINE_VAR constexpr _Float_bits_t<double> _Float_magnitude_mask<double> = 0x7fff'ffff'ffff'ffffULL;
-template <>
-_INLINE_VAR constexpr _Float_bits_t<double> _Float_exponent_mask<double> = 0x7ff0'0000'0000'0000ULL;
-
-template <>
-_INLINE_VAR constexpr _Float_bits_t<long double> _Float_magnitude_mask<long double> = _Float_magnitude_mask<double>;
-template <>
-_INLINE_VAR constexpr _Float_bits_t<long double> _Float_exponent_mask<long double> = _Float_exponent_mask<double>;
 
 // FUNCTION TEMPLATE _Float_abs_bits
-template <class _Ty, enable_if_t<is_floating_point<_Ty>::value, int> = 0>
+template <class _Ty, enable_if_t<is_floating_point_v<_Ty>, int> = 0>
 _NODISCARD _CONSTEXPR_BIT_CAST auto _Float_abs_bits(const _Ty& _Xx) {
-    const auto _Bits = _Bit_cast<_Float_bits_t<_Ty>>(_Xx);
-    return static_cast<_Float_bits_t<_Ty>>(_Bits & _Float_magnitude_mask<_Ty>);
+    const auto _Bits = _Bit_cast<typename _Float_traits<_Ty>::type>(_Xx);
+    return _Bits & _Float_traits<_Ty>::_Magnitude_mask;
 }
 
 // FUNCTION TEMPLATE _Float_abs
-template <class _Ty, enable_if_t<is_floating_point<_Ty>::value, int> = 0>
+template <class _Ty, enable_if_t<is_floating_point_v<_Ty>, int> = 0>
 _NODISCARD _CONSTEXPR_BIT_CAST _Ty _Float_abs(const _Ty _Xx) { // constexpr floating point abs()
     return _Bit_cast<_Ty>(_Float_abs_bits(_Xx));
 }
 
 // FUNCTION TEMPLATE _Is_nan
-template <class _Ty, enable_if_t<is_floating_point<_Ty>::value, int> = 0>
+template <class _Ty, enable_if_t<is_floating_point_v<_Ty>, int> = 0>
 _NODISCARD _CONSTEXPR_BIT_CAST bool _Is_nan(const _Ty _Xx) { // constexpr isnan()
-    return _Float_abs_bits(_Xx) > _Float_exponent_mask<_Ty>;
+    return _Float_abs_bits(_Xx) > _Float_traits<_Ty>::_Exponent_mask;
 }
 
 // FUNCTION TEMPLATE _Is_finite
-template <class _Ty, enable_if_t<is_floating_point<_Ty>::value, int> = 0>
+template <class _Ty, enable_if_t<is_floating_point_v<_Ty>, int> = 0>
 _NODISCARD _CONSTEXPR_BIT_CAST bool _Is_finite(const _Ty _Xx) { // constexpr isfinite()
-    return _Float_abs_bits(_Xx) < _Float_exponent_mask<_Ty>;
+    return _Float_abs_bits(_Xx) < _Float_traits<_Ty>::_Exponent_mask;
 }
 _STD_END
 #undef _CONSTEXPR_BIT_CAST

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -1139,19 +1139,19 @@ struct _Iterator_traits_base<_Iter,
         typename _Iter::pointer, typename _Iter::reference>> {
     // defined if _Iter::* types exist
     using iterator_category = typename _Iter::iterator_category;
-    using value_type        = typename _Iter::value_type;
-    using difference_type   = typename _Iter::difference_type;
-    using pointer           = typename _Iter::pointer;
-    using reference         = typename _Iter::reference;
+    using value_type = typename _Iter::value_type;
+    using difference_type = typename _Iter::difference_type;
+    using pointer = typename _Iter::pointer;
+    using reference = typename _Iter::reference;
 };
 
 template <class _Ty, bool = is_object_v<_Ty>>
 struct _Iterator_traits_pointer_base { // iterator properties for pointers to object
     using iterator_category = random_access_iterator_tag;
-    using value_type        = remove_cv_t<_Ty>;
-    using difference_type   = ptrdiff_t;
-    using pointer           = _Ty*;
-    using reference         = _Ty&;
+    using value_type = remove_cv_t<_Ty>;
+    using difference_type = ptrdiff_t;
+    using pointer = _Ty*;
+    using reference = _Ty&;
 };
 
 template <class _Ty>
@@ -1411,8 +1411,8 @@ _NODISCARD constexpr decltype(auto) _Get_unwrapped_n(_Iter&& _It, const _Diff _O
 template <class _Iter, class _Diff, enable_if_t<_Unwrappable_for_offset_v<_Iter> && is_integral_v<_Diff>, int> = 0>
 _NODISCARD constexpr decltype(auto) _Get_unwrapped_n(_Iter&& _It, const _Diff _Off) {
     // ask an iterator to assert that the iterator moved _Off positions is valid, and unwrap
-    using _IDiff     = _Iter_diff_t<_Remove_cvref_t<_Iter>>;
-    using _CDiff     = common_type_t<_Diff, _IDiff>;
+    using _IDiff = _Iter_diff_t<_Remove_cvref_t<_Iter>>;
+    using _CDiff = common_type_t<_Diff, _IDiff>;
     const auto _COff = static_cast<_CDiff>(_Off);
 
     _STL_ASSERT(_COff <= static_cast<_CDiff>(_Max_possible_v<_IDiff>)
@@ -1721,7 +1721,7 @@ _CONSTEXPR17 void _Advance1(_InIt& _Where, _Diff _Off, input_iterator_tag) {
     // increment iterator by offset, input iterators
     _STL_ASSERT(_Off >= 0, "negative advance of non-bidirectional iterator");
 
-    decltype(auto) _UWhere      = _Get_unwrapped_n(_STD move(_Where), _Off);
+    decltype(auto) _UWhere = _Get_unwrapped_n(_STD move(_Where), _Off);
     constexpr bool _Need_rewrap = !is_reference_v<decltype(_Get_unwrapped_n(_STD move(_Where), _Off))>;
 
     for (; 0 < _Off; --_Off) {
@@ -1736,7 +1736,7 @@ _CONSTEXPR17 void _Advance1(_InIt& _Where, _Diff _Off, input_iterator_tag) {
 template <class _BidIt, class _Diff>
 _CONSTEXPR17 void _Advance1(_BidIt& _Where, _Diff _Off, bidirectional_iterator_tag) {
     // increment iterator by offset, bidirectional iterators
-    decltype(auto) _UWhere      = _Get_unwrapped_n(_STD move(_Where), _Off);
+    decltype(auto) _UWhere = _Get_unwrapped_n(_STD move(_Where), _Off);
     constexpr bool _Need_rewrap = !is_reference_v<decltype(_Get_unwrapped_n(_STD move(_Where), _Off))>;
 
     for (; 0 < _Off; --_Off) {
@@ -1789,8 +1789,8 @@ template <class _InIt>
 _CONSTEXPR17 _Iter_diff_t<_InIt> _Distance1(_InIt _First, _InIt _Last, input_iterator_tag) {
     // return distance between iterators; input
     _Adl_verify_range(_First, _Last);
-    auto _UFirst             = _Get_unwrapped(_First);
-    const auto _ULast        = _Get_unwrapped(_Last);
+    auto _UFirst = _Get_unwrapped(_First);
+    const auto _ULast = _Get_unwrapped(_Last);
     _Iter_diff_t<_InIt> _Off = 0;
     for (; _UFirst != _ULast; ++_UFirst) {
         ++_Off;
@@ -4436,7 +4436,7 @@ _OutIt copy_n(_InIt _First, _Diff _Count_raw, _OutIt _Dest) { // copy [_First, _
     const _Algorithm_int_t<_Diff> _Count = _Count_raw;
     if (0 < _Count) {
         auto _UFirst = _Get_unwrapped_n(_First, _Count);
-        auto _UDest  = _Get_unwrapped_n(_Dest, _Count);
+        auto _UDest = _Get_unwrapped_n(_Dest, _Count);
         _Seek_wrapped(
             _Dest, _Copy_n_unchecked4(_UFirst, _Count, _UDest,
                        bool_constant<_Ptr_copy_cat<decltype(_UFirst), decltype(_UDest)>::_Trivially_copyable>{}));
@@ -4518,9 +4518,9 @@ _BidIt2 _Copy_backward_unchecked(_BidIt1 _First, _BidIt1 _Last, _BidIt2 _Dest, t
 template <class _BidIt1, class _BidIt2>
 _BidIt2 copy_backward(_BidIt1 _First, _BidIt1 _Last, _BidIt2 _Dest) { // copy [_First, _Last) backwards to [..., _Dest)
     _Adl_verify_range(_First, _Last);
-    auto _UFirst      = _Get_unwrapped(_First);
+    auto _UFirst = _Get_unwrapped(_First);
     const auto _ULast = _Get_unwrapped(_Last);
-    auto _UDest       = _Get_unwrapped_n(_Dest, -_Idl_distance<_BidIt1>(_UFirst, _ULast));
+    auto _UDest = _Get_unwrapped_n(_Dest, -_Idl_distance<_BidIt1>(_UFirst, _ULast));
     _Seek_wrapped(_Dest, _Copy_backward_unchecked(_UFirst, _ULast, _UDest,
                              bool_constant<_Ptr_copy_cat<decltype(_UFirst), decltype(_UDest)>::_Trivially_copyable>{}));
     return _Dest;
@@ -4969,7 +4969,7 @@ bool _Equal_unchecked(const _InIt1 _First1, const _InIt1 _Last1, const _InIt2 _F
     // compare [_First1, _Last1) to [_First2, ...), memcmp optimization
     const auto _First1_ch = reinterpret_cast<const char*>(_First1);
     const auto _First2_ch = reinterpret_cast<const char*>(_First2);
-    const auto _Count     = static_cast<size_t>(reinterpret_cast<const char*>(_Last1) - _First1_ch);
+    const auto _Count = static_cast<size_t>(reinterpret_cast<const char*>(_Last1) - _First1_ch);
     return _CSTD memcmp(_First1_ch, _First2_ch, _Count) == 0;
 }
 
@@ -4978,7 +4978,7 @@ _NODISCARD bool equal(const _InIt1 _First1, const _InIt1 _Last1, const _InIt2 _F
     // compare [_First1, _Last1) to [_First2, ...)
     _Adl_verify_range(_First1, _Last1);
     const auto _UFirst1 = _Get_unwrapped(_First1);
-    const auto _ULast1  = _Get_unwrapped(_Last1);
+    const auto _ULast1 = _Get_unwrapped(_Last1);
     const auto _UFirst2 = _Get_unwrapped_n(_First2, _Idl_distance<_InIt1>(_UFirst1, _ULast1));
     return _Equal_unchecked(_UFirst1, _ULast1, _UFirst2, _Pass_fn(_Pred));
 }

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -27,6 +27,12 @@ _STL_DISABLE_CLANG_WARNINGS
 #define _USE_STD_VECTOR_ALGORITHMS 0
 #endif
 
+#ifdef __CUDACC__
+#define _CONSTEXPR_BIT_CAST inline
+#else // ^^^ workaround ^^^ / vvv no workaround vvv
+#define _CONSTEXPR_BIT_CAST constexpr
+#endif // ^^^ no workaround ^^^
+
 #if _USE_STD_VECTOR_ALGORITHMS
 _EXTERN_C
 // The "noalias" attribute tells the compiler optimizer that pointers going into these hand-vectorized algorithms
@@ -52,17 +58,15 @@ template <class _To, class _From,
     enable_if_t<conjunction_v<bool_constant<sizeof(_To) == sizeof(_From)>, is_trivially_copyable<_To>,
                     is_trivially_copyable<_From>>,
         int> = 0>
+_NODISCARD _CONSTEXPR_BIT_CAST _To _Bit_cast(const _From& _Val) noexcept {
 #ifdef __CUDACC__
-_NODISCARD _To _Bit_cast(const _From& _Val) noexcept {
     _To _To_obj; // assumes default-init
     _CSTD memcpy(_STD addressof(_To_obj), _STD addressof(_Val), sizeof(_To));
     return _To_obj;
-}
 #else // ^^^ workaround ^^^ / vvv no workaround vvv
-_NODISCARD constexpr _To _Bit_cast(const _From& _Val) noexcept {
     return __builtin_bit_cast(_To, _Val);
-}
 #endif // ^^^ no workaround ^^^
+}
 
 // STRUCT TEMPLATE _Get_first_parameter
 template <class _Ty>
@@ -5937,7 +5941,74 @@ struct _CXX17_DEPRECATE_ITERATOR_BASE_CLASS iterator { // base type for iterator
     using pointer           = _Pointer;
     using reference         = _Reference;
 };
+
+// STRUCT TEMPLATE _Float_bit_traits
+template <class _Ty>
+struct _Float_bit_traits;
+
+template <>
+struct _Float_bit_traits<float> {
+    using _Float_type = float;
+    using _Bit_type   = unsigned int;
+
+    static constexpr _Bit_type _Magnitude_mask = 0x7fff'ffffU;
+    static constexpr _Bit_type _Exponent_mask  = 0x7f80'0000U;
+};
+
+template <>
+struct _Float_bit_traits<double> {
+    using _Float_type = double;
+    using _Bit_type   = unsigned long long;
+
+    static constexpr _Bit_type _Magnitude_mask = 0x7fff'ffff'ffff'ffffULL;
+    static constexpr _Bit_type _Exponent_mask  = 0x7ff0'0000'0000'0000ULL;
+};
+
+template <>
+struct _Float_bit_traits<long double> {
+    using _Float_type = long double;
+    using _Bit_type   = unsigned long long;
+
+    static constexpr _Bit_type _Magnitude_mask = 0x7fff'ffff'ffff'ffffULL;
+    static constexpr _Bit_type _Exponent_mask  = 0x7ff0'0000'0000'0000ULL;
+};
+
+template <class _Ty>
+struct _Float_bit_traits<const _Ty> : public _Float_bit_traits<_Ty> {};
+
+template <class _Ty>
+struct _Float_bit_traits<volatile _Ty> : public _Float_bit_traits<_Ty> {};
+
+template <class _Ty>
+struct _Float_bit_traits<const volatile _Ty> : public _Float_bit_traits<_Ty> {};
+
+// FUNCTION TEMPLATE _Float_abs_bits
+template <class _Ty, enable_if_t<is_floating_point<_Ty>::value, int> = 0>
+_NODISCARD _CONSTEXPR_BIT_CAST auto _Float_abs_bits(const _Ty& _Xx) {
+    using _Bit_type  = typename _Float_bit_traits<_Ty>::_Bit_type;
+    const auto _Bits = _Bit_cast<_Bit_type>(_Xx);
+    return static_cast<_Bit_type>(_Bits & _Float_bit_traits<_Ty>::_Magnitude_mask);
+}
+
+// FUNCTION TEMPLATE _Float_abs
+template <class _Ty, enable_if_t<is_floating_point<_Ty>::value, int> = 0>
+_NODISCARD _CONSTEXPR_BIT_CAST _Ty _Float_abs(const _Ty _Xx) { // constexpr floating point abs()
+    return _Bit_cast<_Ty>(_Float_abs_bits(_Xx));
+}
+
+// FUNCTION TEMPLATE _Is_nan
+template <class _Ty, enable_if_t<is_floating_point<_Ty>::value, int> = 0>
+_NODISCARD _CONSTEXPR_BIT_CAST bool _Is_nan(const _Ty _Xx) { // constexpr isnan()
+    return _Float_abs_bits(_Xx) > _Float_bit_traits<_Ty>::_Exponent_mask;
+}
+
+// FUNCTION TEMPLATE _Is_finite
+template <class _Ty, enable_if_t<is_floating_point<_Ty>::value, int> = 0>
+_NODISCARD _CONSTEXPR_BIT_CAST bool _Is_finite(const _Ty _Xx) { // constexpr isfinite()
+    return _Float_abs_bits(_Xx) < _Float_bit_traits<_Ty>::_Exponent_mask;
+}
 _STD_END
+#undef _CONSTEXPR_BIT_CAST
 #pragma pop_macro("new")
 _STL_RESTORE_CLANG_WARNINGS
 #pragma warning(pop)

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -5942,52 +5942,55 @@ struct _CXX17_DEPRECATE_ITERATOR_BASE_CLASS iterator { // base type for iterator
     using reference         = _Reference;
 };
 
-// STRUCT TEMPLATE _Float_bit_traits
+// STRUCT TEMPLATE _Float_bits
 template <class _Ty>
-struct _Float_bit_traits;
-
-template <>
-struct _Float_bit_traits<float> {
-    using _Float_type = float;
-    using _Bit_type   = unsigned int;
-
-    static constexpr _Bit_type _Magnitude_mask = 0x7fff'ffffU;
-    static constexpr _Bit_type _Exponent_mask  = 0x7f80'0000U;
+struct _Float_bits {
+    static_assert(_Always_false<_Ty>, "_Float_bits<NonFloatingPoint> is invalid");
 };
 
 template <>
-struct _Float_bit_traits<double> {
-    using _Float_type = double;
-    using _Bit_type   = unsigned long long;
-
-    static constexpr _Bit_type _Magnitude_mask = 0x7fff'ffff'ffff'ffffULL;
-    static constexpr _Bit_type _Exponent_mask  = 0x7ff0'0000'0000'0000ULL;
+struct _Float_bits<float> {
+    using type = unsigned int;
 };
 
 template <>
-struct _Float_bit_traits<long double> {
-    using _Float_type = long double;
-    using _Bit_type   = unsigned long long;
+struct _Float_bits<double> {
+    using type = unsigned long long;
+};
 
-    static constexpr _Bit_type _Magnitude_mask = 0x7fff'ffff'ffff'ffffULL;
-    static constexpr _Bit_type _Exponent_mask  = 0x7ff0'0000'0000'0000ULL;
+template <>
+struct _Float_bits<long double> {
+    using type = _Float_bits<double>::type;
 };
 
 template <class _Ty>
-struct _Float_bit_traits<const _Ty> : public _Float_bit_traits<_Ty> {};
+using _Float_bits_t = typename _Float_bits<_Ty>::type;
 
 template <class _Ty>
-struct _Float_bit_traits<volatile _Ty> : public _Float_bit_traits<_Ty> {};
-
+_INLINE_VAR constexpr _Float_bits_t<_Ty> _Float_magnitude_mask{};
 template <class _Ty>
-struct _Float_bit_traits<const volatile _Ty> : public _Float_bit_traits<_Ty> {};
+_INLINE_VAR constexpr _Float_bits_t<_Ty> _Float_exponent_mask{};
+
+template <>
+_INLINE_VAR constexpr _Float_bits_t<float> _Float_magnitude_mask<float> = 0x7fff'ffffU;
+template <>
+_INLINE_VAR constexpr _Float_bits_t<float> _Float_exponent_mask<float> = 0x7f80'0000U;
+
+template <>
+_INLINE_VAR constexpr _Float_bits_t<double> _Float_magnitude_mask<double> = 0x7fff'ffff'ffff'ffffULL;
+template <>
+_INLINE_VAR constexpr _Float_bits_t<double> _Float_exponent_mask<double> = 0x7ff0'0000'0000'0000ULL;
+
+template <>
+_INLINE_VAR constexpr _Float_bits_t<long double> _Float_magnitude_mask<long double> = _Float_magnitude_mask<double>;
+template <>
+_INLINE_VAR constexpr _Float_bits_t<long double> _Float_exponent_mask<long double> = _Float_exponent_mask<double>;
 
 // FUNCTION TEMPLATE _Float_abs_bits
 template <class _Ty, enable_if_t<is_floating_point<_Ty>::value, int> = 0>
 _NODISCARD _CONSTEXPR_BIT_CAST auto _Float_abs_bits(const _Ty& _Xx) {
-    using _Bit_type  = typename _Float_bit_traits<_Ty>::_Bit_type;
-    const auto _Bits = _Bit_cast<_Bit_type>(_Xx);
-    return static_cast<_Bit_type>(_Bits & _Float_bit_traits<_Ty>::_Magnitude_mask);
+    const auto _Bits = _Bit_cast<_Float_bits_t<_Ty>>(_Xx);
+    return static_cast<_Float_bits_t<_Ty>>(_Bits & _Float_magnitude_mask<_Ty>);
 }
 
 // FUNCTION TEMPLATE _Float_abs
@@ -5999,13 +6002,13 @@ _NODISCARD _CONSTEXPR_BIT_CAST _Ty _Float_abs(const _Ty _Xx) { // constexpr floa
 // FUNCTION TEMPLATE _Is_nan
 template <class _Ty, enable_if_t<is_floating_point<_Ty>::value, int> = 0>
 _NODISCARD _CONSTEXPR_BIT_CAST bool _Is_nan(const _Ty _Xx) { // constexpr isnan()
-    return _Float_abs_bits(_Xx) > _Float_bit_traits<_Ty>::_Exponent_mask;
+    return _Float_abs_bits(_Xx) > _Float_exponent_mask<_Ty>;
 }
 
 // FUNCTION TEMPLATE _Is_finite
 template <class _Ty, enable_if_t<is_floating_point<_Ty>::value, int> = 0>
 _NODISCARD _CONSTEXPR_BIT_CAST bool _Is_finite(const _Ty _Xx) { // constexpr isfinite()
-    return _Float_abs_bits(_Xx) < _Float_bit_traits<_Ty>::_Exponent_mask;
+    return _Float_abs_bits(_Xx) < _Float_exponent_mask<_Ty>;
 }
 _STD_END
 #undef _CONSTEXPR_BIT_CAST

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -164,7 +164,6 @@
 //     (partially implemented)
 // P0769R2 shift_left(), shift_right()
 // P0811R3 midpoint(), lerp()
-//     (partially implemented, lerp() not yet constexpr)
 // P0879R0 constexpr For Swapping Functions
 // P0887R1 type_identity
 // P0896R4 Ranges
@@ -1169,6 +1168,7 @@
 #define __cpp_lib_generic_unordered_lookup     201811L
 #define __cpp_lib_int_pow2                     202002L
 #define __cpp_lib_integer_comparison_functions 202002L
+#define __cpp_lib_interpolate                  201902L
 #define __cpp_lib_is_constant_evaluated        201811L
 #define __cpp_lib_is_nothrow_convertible       201806L
 #define __cpp_lib_list_remove_return_type      201806L

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -465,10 +465,6 @@ std/utilities/variant/variant.variant/variant.ctor/T.pass.cpp FAIL
 # C++20 P0768R1 "Library Support for the Spaceship (Comparison) Operator"
 std/language.support/support.limits/support.limits.general/compare.version.pass.cpp FAIL
 
-# C++20 P0811R2 "midpoint(), lerp()"
-std/language.support/support.limits/support.limits.general/numeric.version.pass.cpp FAIL
-std/numerics/c.math/c.math.lerp/c.math.lerp.pass.cpp FAIL
-
 # C++20 P0896R4 "<ranges>"
 std/language.support/support.limits/support.limits.general/algorithm.version.pass.cpp FAIL
 std/language.support/support.limits/support.limits.general/functional.version.pass.cpp FAIL
@@ -778,6 +774,11 @@ std/iterators/predef.iterators/insert.iterators/insert.iterator/types.pass.cpp F
 # Tests emit warning C4244: 'argument': conversion from 'T' to 'const std::complex<double>::_Ty', possible loss of data
 std/numerics/complex.number/cmplx.over/conj.pass.cpp:0 FAIL
 std/numerics/complex.number/cmplx.over/proj.pass.cpp:0 FAIL
+
+# Assertion failed: (std::lerp(T(2.3), T(2.3), inf) == T(2.3))
+# Asserts `(std::lerp(T(2.3), T(2.3), inf) == T(2.3))` and `std::isnan(std::lerp(T( 0), T( 0), inf))`
+# They shouldn't behave differently. Both of them should probably return NaN.
+std/numerics/c.math/c.math.lerp/c.math.lerp.pass.cpp FAIL
 
 
 # *** LIKELY STL BUGS ***

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -465,10 +465,6 @@ utilities\variant\variant.variant\variant.ctor\T.pass.cpp
 # C++20 P0768R1 "Library Support for the Spaceship (Comparison) Operator"
 language.support\support.limits\support.limits.general\compare.version.pass.cpp
 
-# C++20 P0811R2 "midpoint(), lerp()"
-language.support\support.limits\support.limits.general\numeric.version.pass.cpp
-numerics\c.math\c.math.lerp\c.math.lerp.pass.cpp
-
 # C++20 P0896R4 "<ranges>"
 language.support\support.limits\support.limits.general\algorithm.version.pass.cpp
 language.support\support.limits\support.limits.general\functional.version.pass.cpp
@@ -778,6 +774,11 @@ iterators\predef.iterators\insert.iterators\insert.iterator\types.pass.cpp
 # Tests emit warning C4244: 'argument': conversion from 'T' to 'const std::complex<double>::_Ty', possible loss of data
 numerics\complex.number\cmplx.over\conj.pass.cpp
 numerics\complex.number\cmplx.over\proj.pass.cpp
+
+# Assertion failed: (std::lerp(T(2.3), T(2.3), inf) == T(2.3))
+# Asserts `(std::lerp(T(2.3), T(2.3), inf) == T(2.3))` and `std::isnan(std::lerp(T( 0), T( 0), inf))`
+# They shouldn't behave differently. Both of them should probably return NaN.
+numerics\c.math\c.math.lerp\c.math.lerp.pass.cpp
 
 
 # *** LIKELY STL BUGS ***

--- a/tests/std/tests/P0811R3_midpoint_lerp/env.lst
+++ b/tests/std/tests/P0811R3_midpoint_lerp/env.lst
@@ -2,3 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 RUNALL_INCLUDE ..\usual_latest_matrix.lst
+RUNALL_CROSSLIST
+PM_CL="/Od"
+PM_CL="/O2"

--- a/tests/std/tests/P0811R3_midpoint_lerp/test.cpp
+++ b/tests/std/tests/P0811R3_midpoint_lerp/test.cpp
@@ -839,23 +839,19 @@ bool test_lerp() {
     STATIC_ASSERT(is_signed_v<Ty>);
     STATIC_ASSERT(noexcept(lerp(Ty(), Ty(), Ty())));
 
-    const auto test_lerp_constexpr = [] {
+    constexpr auto test_lerp_constexpr = [] {
         using bit_type = conditional_t<sizeof(Ty) == 4, unsigned int, unsigned long long>;
 
         for (const auto& testCase : LerpCases<Ty>::lerpTestCases) {
             const auto answer = lerp(testCase.x, testCase.y, testCase.t);
-            if (bit_cast<bit_type>(answer) != bit_cast<bit_type>(testCase.expected)) {
-                return false;
-            }
+            assert(bit_cast<bit_type>(answer) == bit_cast<bit_type>(testCase.expected));
         }
 
         for (auto&& testCase : LerpCases<Ty>::lerpNaNTestCases) {
             const auto answer = lerp(testCase.x, testCase.y, testCase.t);
-            if (none_of(begin(testCase.expected_list), end(testCase.expected_list), [&](const auto& expected) {
-                    return expected.has_value() && bit_cast<bit_type>(answer) == bit_cast<bit_type>(expected.value());
-                })) {
-                return false;
-            }
+            assert(any_of(begin(testCase.expected_list), end(testCase.expected_list), [&](const auto& expected) {
+                return expected.has_value() && bit_cast<bit_type>(answer) == bit_cast<bit_type>(expected.value());
+            }));
         }
 
         return true;

--- a/tests/std/tests/P0811R3_midpoint_lerp/test.cpp
+++ b/tests/std/tests/P0811R3_midpoint_lerp/test.cpp
@@ -89,7 +89,6 @@ private:
 bool check_feexcept(const int expected_excepts, const int except_mask = fe_major_except) {
     return fetestexcept(except_mask) == (expected_excepts & except_mask);
 }
-
 #else // ^^^ defined(_M_FP_STRICT) / !defined(_M_FP_STRICT) vvv
 class ExceptGuard {
 public:
@@ -968,7 +967,7 @@ bool test_lerp() {
     for (auto&& testCase : LerpCases<Ty>::lerpOverflowTestCases) {
         ExceptGuard except;
         const auto answer = lerp(testCase.x, testCase.y, testCase.t);
-        if (!check_feexcept(FE_OVERFLOW, fe_major_except) || memcmp(&answer, &testCase.expected, sizeof(Ty)) != 0) {
+        if (!check_feexcept(FE_OVERFLOW) || memcmp(&answer, &testCase.expected, sizeof(Ty)) != 0) {
             print_lerp_result(testCase, answer);
             abort();
         }

--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.cpp
@@ -685,6 +685,20 @@ STATIC_ASSERT(__cpp_lib_integer_sequence == 201304L);
 STATIC_ASSERT(__cpp_lib_integral_constant_callable == 201304L);
 #endif
 
+#if _HAS_CXX20
+#ifndef __cpp_lib_interpolate
+#error __cpp_lib_interpolate is not defined
+#elif __cpp_lib_interpolate != 201902L
+#error __cpp_lib_interpolate is not 201902L
+#else
+STATIC_ASSERT(__cpp_lib_interpolate == 201902L);
+#endif
+#else
+#ifdef __cpp_lib_interpolate
+#error __cpp_lib_interpolate is defined
+#endif
+#endif
+
 #ifndef __cpp_lib_invoke
 #error __cpp_lib_invoke is not defined
 #elif __cpp_lib_invoke != 201411L


### PR DESCRIPTION
* Removes workaround for missing `bit_cast()` and mark `lerp()` constexpr.

* Changes how `lerp()` handles infinity inputs according to https://github.com/microsoft/STL/issues/65#issuecomment-563811523 and https://github.com/microsoft/STL/issues/65#issuecomment-564102550.

* Adds constexpr tests for `lerp()`, and updates test cases for infinity inputs according to the new behavior.

Resolves #65.

<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
