### PR TITLE
Modernize the ranges::find family

### DIFF
--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -620,12 +620,9 @@ namespace ranges {
             indirect_binary_predicate<projected<iterator_t<_Rng>, _Pj>, projected<iterator_t<_Rng>, _Pj>> _Pr =
                 ranges::equal_to>
         _NODISCARD constexpr borrowed_iterator_t<_Rng> operator()(_Rng&& _Range, _Pr _Pred = {}, _Pj _Proj = {}) const {
-            auto _First = _RANGES begin(_Range);
-
             auto _UResult = _Adjacent_find_unchecked(_Ubegin(_Range), _Uend(_Range), _Pass_fn(_Pred), _Pass_fn(_Proj));
 
-            _Seek_wrapped(_First, _STD move(_UResult));
-            return _First;
+            return _Rewrap_iterator(_Range, _STD move(_UResult));
         }
 
     private:

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -640,7 +640,7 @@ namespace ranges {
                 return _First;
             }
 
-            for (auto _Next = _First;; _First = _Next) {
+            for (auto _Next = _First;; ++_First) {
                 if (++_Next == _Last) {
                     return _Next;
                 }

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -520,22 +520,40 @@ namespace ranges {
             indirect_unary_predicate<projected<_It, _Pj>> _Pr>
         _NODISCARD constexpr _It operator()(_It _First, _Se _Last, _Pr _Pred, _Pj _Proj = {}) const {
             _Adl_verify_range(_First, _Last);
-            auto _UFirst      = _Get_unwrapped(_STD move(_First));
-            const auto _ULast = _Get_unwrapped(_STD move(_Last));
-            for (; _UFirst != _ULast; ++_UFirst) {
-                if (!_STD invoke(_Pred, _STD invoke(_Proj, *_UFirst))) {
-                    break;
-                }
-            }
 
-            _Seek_wrapped(_First, _STD move(_UFirst));
+            auto _UResult = _Find_if_not_unchecked(
+                _Get_unwrapped(_STD move(_First)), _Get_unwrapped(_STD move(_Last)), _Pass_fn(_Pred), _Pass_fn(_Proj));
+
+            _Seek_wrapped(_First, _STD move(_UResult));
             return _First;
         }
 
         template <input_range _Rng, class _Pj = identity,
             indirect_unary_predicate<projected<iterator_t<_Rng>, _Pj>> _Pr>
         _NODISCARD constexpr borrowed_iterator_t<_Rng> operator()(_Rng&& _Range, _Pr _Pred, _Pj _Proj = {}) const {
-            return (*this)(_RANGES begin(_Range), _RANGES end(_Range), _Pass_fn(_Pred), _Pass_fn(_Proj));
+            auto _First = _RANGES begin(_Range);
+
+            auto _UResult = _Find_if_not_unchecked(
+                _Get_unwrapped(_STD move(_First)), _Uend(_Range), _Pass_fn(_Pred), _Pass_fn(_Proj));
+
+            _Seek_wrapped(_First, _STD move(_UResult));
+            return _First;
+        }
+
+    private:
+        template <class _It, class _Se, class _Pj, class _Pr>
+        _NODISCARD static constexpr _It _Find_if_not_unchecked(_It _First, const _Se _Last, _Pr _Pred, _Pj _Proj) {
+            _STL_INTERNAL_STATIC_ASSERT(input_iterator<_It>);
+            _STL_INTERNAL_STATIC_ASSERT(sentinel_for<_Se, _It>);
+            _STL_INTERNAL_STATIC_ASSERT(indirect_unary_predicate<_Pr, projected<_It, _Pj>>);
+
+            for (; _First != _Last; ++_First) {
+                if (!_STD invoke(_Pred, _STD invoke(_Proj, *_First))) {
+                    break;
+                }
+            }
+
+            return _First;
         }
     };
 
@@ -589,33 +607,48 @@ namespace ranges {
         template <forward_iterator _It, sentinel_for<_It> _Se, class _Pj = identity,
             indirect_binary_predicate<projected<_It, _Pj>, projected<_It, _Pj>> _Pr = ranges::equal_to>
         _NODISCARD constexpr _It operator()(_It _First, const _Se _Last, _Pr _Pred = {}, _Pj _Proj = {}) const {
-            // find first satisfying _Pred with successor
             _Adl_verify_range(_First, _Last);
-            auto _UFirst      = _Get_unwrapped(_First);
-            const auto _ULast = _Get_unwrapped(_Last);
 
-            if (_UFirst == _ULast) {
-                return _First;
-            }
+            auto _UResult = _Adjacent_find_unchecked(
+                _Get_unwrapped(_STD move(_First)), _Get_unwrapped(_STD move(_Last)), _Pass_fn(_Pred), _Pass_fn(_Proj));
 
-            for (auto _UNext = _UFirst;; _UFirst = _UNext) {
-                if (++_UNext == _ULast) {
-                    _Seek_wrapped(_First, _UNext);
-                    return _First;
-                }
-
-                if (_STD invoke(_Pred, _STD invoke(_Proj, *_UFirst), _STD invoke(_Proj, *_UNext))) {
-                    _Seek_wrapped(_First, _UFirst);
-                    return _First;
-                }
-            }
+            _Seek_wrapped(_First, _STD move(_UResult));
+            return _First;
         }
 
         template <forward_range _Rng, class _Pj = identity,
             indirect_binary_predicate<projected<iterator_t<_Rng>, _Pj>, projected<iterator_t<_Rng>, _Pj>> _Pr =
                 ranges::equal_to>
         _NODISCARD constexpr borrowed_iterator_t<_Rng> operator()(_Rng&& _Range, _Pr _Pred = {}, _Pj _Proj = {}) const {
-            return (*this)(_RANGES begin(_Range), _RANGES end(_Range), _Pass_fn(_Pred), _Pass_fn(_Proj));
+            auto _First = _RANGES begin(_Range);
+
+            auto _UResult = _Adjacent_find_unchecked(_Ubegin(_Range), _Uend(_Range), _Pass_fn(_Pred), _Pass_fn(_Proj));
+
+            _Seek_wrapped(_First, _STD move(_UResult));
+            return _First;
+        }
+
+    private:
+        template <class _It, class _Se, class _Pj, class _Pr>
+        _NODISCARD static constexpr _It _Adjacent_find_unchecked(_It _First, const _Se _Last, _Pr _Pred, _Pj _Proj) {
+            // find first satisfying _Pred with successor
+            _STL_INTERNAL_STATIC_ASSERT(forward_iterator<_It>);
+            _STL_INTERNAL_STATIC_ASSERT(sentinel_for<_Se, _It>);
+            _STL_INTERNAL_STATIC_ASSERT(indirect_binary_predicate<_Pr, projected<_It, _Pj>, projected<_It, _Pj>>);
+
+            if (_First == _Last) {
+                return _First;
+            }
+
+            for (auto _Next = _First;; _First = _Next) {
+                if (++_Next == _Last) {
+                    return _Next;
+                }
+
+                if (_STD invoke(_Pred, _STD invoke(_Proj, *_First), _STD invoke(_Proj, *_Next))) {
+                    return _First;
+                }
+            }
         }
     };
 
@@ -3184,24 +3217,16 @@ namespace ranges {
         template <input_iterator _It1, sentinel_for<_It1> _Se1, forward_iterator _It2, sentinel_for<_It2> _Se2,
             class _Pr = ranges::equal_to, class _Pj1 = identity, class _Pj2 = identity>
             requires indirectly_comparable<_It1, _It2, _Pr, _Pj1, _Pj2>
-        _NODISCARD constexpr _It1 operator()(_It1 _First1, const _Se1 _Last1, const _It2 _First2, const _Se2 _Last2,
-            _Pr _Pred = {}, _Pj1 _Proj1 = {}, _Pj2 _Proj2 = {}) const {
+        _NODISCARD constexpr _It1 operator()(_It1 _First1, _Se1 _Last1, _It2 _First2, _Se2 _Last2, _Pr _Pred = {},
+            _Pj1 _Proj1 = {}, _Pj2 _Proj2 = {}) const {
             _Adl_verify_range(_First1, _Last1);
             _Adl_verify_range(_First2, _Last2);
-            auto _UFirst1       = _Get_unwrapped(_STD move(_First1));
-            const auto _ULast1  = _Get_unwrapped(_Last1);
-            const auto _UFirst2 = _Get_unwrapped(_First2);
-            const auto _ULast2  = _Get_unwrapped(_Last2);
-            for (; _UFirst1 != _ULast1; ++_UFirst1) {
-                for (auto _UMid2 = _UFirst2; _UMid2 != _ULast2; ++_UMid2) {
-                    if (_STD invoke(_Pred, _STD invoke(_Proj1, *_UFirst1), _STD invoke(_Proj2, *_UMid2))) {
-                        _Seek_wrapped(_First1, _STD move(_UFirst1));
-                        return _First1;
-                    }
-                }
-            }
 
-            _Seek_wrapped(_First1, _STD move(_UFirst1));
+            auto _UResult = _Find_first_of_unchecked(_Get_unwrapped(_STD move(_First1)),
+                _Get_unwrapped(_STD move(_Last1)), _Get_unwrapped(_STD move(_First2)),
+                _Get_unwrapped(_STD move(_Last2)), _Pass_fn(_Pred), _Pass_fn(_Proj1), _Pass_fn(_Proj2));
+
+            _Seek_wrapped(_First1, _STD move(_UResult));
             return _First1;
         }
 
@@ -3210,10 +3235,35 @@ namespace ranges {
             requires indirectly_comparable<iterator_t<_Rng1>, iterator_t<_Rng2>, _Pr, _Pj1, _Pj2>
         _NODISCARD constexpr borrowed_iterator_t<_Rng1> operator()(
             _Rng1&& _Range1, _Rng2&& _Range2, _Pr _Pred = {}, _Pj1 _Proj1 = {}, _Pj2 _Proj2 = {}) const {
-            return (*this)(_RANGES begin(_Range1), _RANGES end(_Range1), _RANGES begin(_Range2), _RANGES end(_Range2),
-                _Pass_fn(_Pred), _Pass_fn(_Proj1), _Pass_fn(_Proj2));
+            auto _First1 = _RANGES begin(_Range1);
+
+            auto _UResult = _Find_first_of_unchecked(_Get_unwrapped(_STD move(_First1)), _Uend(_Range1),
+                _Ubegin(_Range2), _Uend(_Range2), _Pass_fn(_Pred), _Pass_fn(_Proj1), _Pass_fn(_Proj2));
+
+            _Seek_wrapped(_First1, _STD move(_UResult));
+            return _First1;
         }
         // clang-format on
+    private:
+        template <class _It1, class _Se1, class _It2, class _Se2, class _Pr, class _Pj1, class _Pj2>
+        _NODISCARD static constexpr _It1 _Find_first_of_unchecked(_It1 _First1, const _Se1 _Last1, const _It2 _First2,
+            const _Se2 _Last2, _Pr _Pred, _Pj1 _Proj1, _Pj2 _Proj2) {
+            _STL_INTERNAL_STATIC_ASSERT(input_iterator<_It1>);
+            _STL_INTERNAL_STATIC_ASSERT(sentinel_for<_Se1, _It1>);
+            _STL_INTERNAL_STATIC_ASSERT(forward_iterator<_It2>);
+            _STL_INTERNAL_STATIC_ASSERT(sentinel_for<_Se2, _It2>);
+            _STL_INTERNAL_STATIC_ASSERT(indirectly_comparable<_It1, _It2, _Pr, _Pj1, _Pj2>);
+
+            for (; _First1 != _Last1; ++_First1) {
+                for (auto _Mid2 = _First2; _Mid2 != _Last2; ++_Mid2) {
+                    if (_STD invoke(_Pred, _STD invoke(_Proj1, *_First1), _STD invoke(_Proj2, *_Mid2))) {
+                        return _First1;
+                    }
+                }
+            }
+
+            return _First1;
+        }
     };
 
     inline constexpr _Find_first_of_fn find_first_of{_Not_quite_object::_Construct_tag{}};

--- a/tests/std/tests/P0896R4_ranges_alg_find/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_find/test.cpp
@@ -9,7 +9,7 @@
 
 #include <range_algorithm_support.hpp>
 using namespace std;
-using P = std::pair<int, int>;
+using P = pair<int, int>;
 
 // Validate dangling story
 STATIC_ASSERT(same_as<decltype(ranges::find(borrowed<false>{}, 42)), ranges::dangling>);
@@ -22,7 +22,7 @@ struct instantiator {
     static constexpr void call() {
         using ranges::find, ranges::iterator_t;
 
-        for (auto [value, _] : haystack) {
+        for (const auto& [value, _] : haystack) {
             { // Validate range overload [found case]
                 Read wrapped_input{haystack};
                 auto result = find(wrapped_input, value, get_first);

--- a/tests/std/tests/P0896R4_ranges_alg_find/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_find/test.cpp
@@ -2,71 +2,56 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include <algorithm>
-#include <array>
 #include <cassert>
 #include <concepts>
 #include <ranges>
 #include <utility>
 
 #include <range_algorithm_support.hpp>
+using namespace std;
+using P = std::pair<int, int>;
 
-constexpr void smoke_test() {
-    using ranges::find, ranges::iterator_t, std::same_as;
-    using P = std::pair<int, int>;
-
-    // Validate dangling story
-    STATIC_ASSERT(same_as<decltype(find(borrowed<false>{}, 42)), ranges::dangling>);
-    STATIC_ASSERT(same_as<decltype(find(borrowed<true>{}, 42)), int*>);
-
-    std::array<P, 3> const pairs = {{{0, 42}, {2, 42}, {4, 42}}};
-
-    for (auto [value, _] : pairs) {
-        {
-            // Validate range overload [found case]
-            auto result = find(basic_borrowed_range{pairs}, value, get_first);
-            STATIC_ASSERT(same_as<decltype(result), iterator_t<basic_borrowed_range<P const>>>);
-            assert((*result).first == value);
-        }
-        {
-            // Validate iterator + sentinel overload [found case]
-            basic_borrowed_range wrapped_pairs{pairs};
-            auto result = find(wrapped_pairs.begin(), wrapped_pairs.end(), value, get_first);
-            STATIC_ASSERT(same_as<decltype(result), iterator_t<basic_borrowed_range<P const>>>);
-            assert((*result).first == value);
-        }
-    }
-    {
-        // Validate range overload [not found case]
-        auto result = find(basic_borrowed_range{pairs}, 42, get_first);
-        STATIC_ASSERT(same_as<decltype(result), iterator_t<basic_borrowed_range<P const>>>);
-        assert(result == basic_borrowed_range{pairs}.end());
-    }
-    {
-        // Validate iterator + sentinel overload [not found case]
-        basic_borrowed_range wrapped_pairs{pairs};
-        auto result = find(wrapped_pairs.begin(), wrapped_pairs.end(), 42, get_first);
-        STATIC_ASSERT(same_as<decltype(result), iterator_t<basic_borrowed_range<P const>>>);
-        assert(result == wrapped_pairs.end());
-    }
-}
-
-int main() {
-    STATIC_ASSERT((smoke_test(), true));
-    smoke_test();
-}
+// Validate dangling story
+STATIC_ASSERT(same_as<decltype(ranges::find(borrowed<false>{}, 42)), ranges::dangling>);
+STATIC_ASSERT(same_as<decltype(ranges::find(borrowed<true>{}, 42)), int*>);
 
 struct instantiator {
-    template <class In>
-    static void call(In&& in = {}) {
-        ranges::range_value_t<In> const value{};
-        (void) ranges::find(in, value);
+    static constexpr P haystack[3] = {{0, 42}, {2, 42}, {4, 42}};
 
-        struct type {
-            bool operator==(type const&) const = default;
-        };
-        using Projection = type (*)(std::iter_common_reference_t<ranges::iterator_t<In>>);
-        (void) ranges::find(in, type{}, Projection{});
+    template <ranges::input_range Read>
+    static constexpr void call() {
+        using ranges::find, ranges::iterator_t;
+
+        for (auto [value, _] : haystack) {
+            { // Validate range overload [found case]
+                Read wrapped_input{haystack};
+                auto result = find(wrapped_input, value, get_first);
+                STATIC_ASSERT(same_as<decltype(result), iterator_t<Read>>);
+                assert(result.peek()->first == value);
+            }
+            { // Validate iterator + sentinel overload [found case]
+                Read wrapped_input{haystack};
+                auto result = find(wrapped_input.begin(), wrapped_input.end(), value, get_first);
+                STATIC_ASSERT(same_as<decltype(result), iterator_t<Read>>);
+                assert(result.peek()->first == value);
+            }
+        }
+        { // Validate range overload [not found case]
+            Read wrapped_input{haystack};
+            auto result = find(wrapped_input, 42, get_first);
+            STATIC_ASSERT(same_as<decltype(result), iterator_t<Read>>);
+            assert(result == wrapped_input.end());
+        }
+        { // Validate iterator + sentinel overload [not found case]
+            Read wrapped_input{haystack};
+            auto result = find(wrapped_input.begin(), wrapped_input.end(), 42, get_first);
+            STATIC_ASSERT(same_as<decltype(result), iterator_t<Read>>);
+            assert(result == wrapped_input.end());
+        }
     }
 };
 
-template void test_in<instantiator, const int>();
+int main() {
+    STATIC_ASSERT((test_in<instantiator, const P>(), true));
+    test_in<instantiator, const P>();
+}

--- a/tests/std/tests/P0896R4_ranges_alg_find_first_of/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_find_first_of/test.cpp
@@ -9,7 +9,7 @@
 
 #include <range_algorithm_support.hpp>
 using namespace std;
-using P = std::pair<int, int>;
+using P = pair<int, int>;
 
 constexpr auto pred = [](const int x, const int y) { return x == y + 1; };
 

--- a/tests/std/tests/P0896R4_ranges_alg_find_first_of/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_find_first_of/test.cpp
@@ -2,92 +2,86 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include <algorithm>
-#include <array>
 #include <cassert>
 #include <concepts>
 #include <ranges>
 #include <utility>
 
 #include <range_algorithm_support.hpp>
+using namespace std;
+using P = std::pair<int, int>;
 
-constexpr void smoke_test() {
-    using ranges::find_first_of, ranges::iterator_t, std::array, std::same_as, std::to_address;
-    using P = std::pair<int, int>;
-
-    // Validate dangling story
-    STATIC_ASSERT(same_as<decltype(find_first_of(borrowed<false>{}, array<int, 42>{})), ranges::dangling>);
-    STATIC_ASSERT(same_as<decltype(find_first_of(borrowed<true>{}, array<int, 42>{})), int*>);
-
-    const array pairs = {P{0, 42}, P{1, 42}, P{2, 42}, P{3, 42}, P{4, 42}, P{5, 42}, P{6, 42}};
-
-    const auto pred = [](const int x, const int y) { return x == y + 1; };
-
-    const array good_needle = {29, 1};
-    {
-        // Validate range overload [found case]
-        auto result = find_first_of(basic_borrowed_range{pairs}, good_needle, pred, get_first);
-        STATIC_ASSERT(same_as<decltype(result), iterator_t<basic_borrowed_range<const P>>>);
-        assert(result.peek() == pairs.data() + 2);
-    }
-    {
-        // Validate iterator + sentinel overload [found case]
-        basic_borrowed_range wrapped_pairs{pairs};
-        auto result = find_first_of(
-            wrapped_pairs.begin(), wrapped_pairs.end(), good_needle.begin(), good_needle.end(), pred, get_first);
-        STATIC_ASSERT(same_as<decltype(result), iterator_t<basic_borrowed_range<const P>>>);
-        assert(result.peek() == pairs.data() + 2);
-    }
-
-    const array bad_needle = {29, 17};
-    {
-        // Validate range overload [not found case]
-        auto result = find_first_of(basic_borrowed_range{pairs}, bad_needle, pred, get_first);
-        STATIC_ASSERT(same_as<decltype(result), iterator_t<basic_borrowed_range<const P>>>);
-        assert(result.peek() == pairs.data() + pairs.size());
-    }
-    {
-        // Validate iterator + sentinel overload [not found case]
-        basic_borrowed_range wrapped_pairs{pairs};
-        auto result = find_first_of(
-            wrapped_pairs.begin(), wrapped_pairs.end(), bad_needle.begin(), bad_needle.end(), pred, get_first);
-        STATIC_ASSERT(same_as<decltype(result), iterator_t<basic_borrowed_range<const P>>>);
-        assert(result.peek() == pairs.data() + pairs.size());
-    }
-}
-
-int main() {
-    STATIC_ASSERT((smoke_test(), true));
-    smoke_test();
-}
+// Validate dangling story
+STATIC_ASSERT(same_as<decltype(ranges::find_first_of(borrowed<false>{}, borrowed<true>{})), ranges::dangling>);
+STATIC_ASSERT(same_as<decltype(ranges::find_first_of(borrowed<true>{}, borrowed<true>{})), int*>);
 
 struct instantiator {
-    template <class In1, class Fwd2>
-    static void call(In1&& in1 = {}, Fwd2&& fwd2 = {}) {
-        if constexpr (!is_permissive) { // These fail to compile in C1XX's permissive mode due to VSO-566808
-            using ranges::iterator_t;
+    static constexpr P haystack[7]      = {{0, 42}, {1, 42}, {2, 42}, {3, 42}, {4, 42}, {5, 42}, {6, 42}};
+    static constexpr int good_needle[2] = {29, 1};
+    static constexpr int bad_needle[2]  = {29, 17};
 
-            (void) ranges::find_first_of(in1, fwd2);
-            (void) ranges::find_first_of(ranges::begin(in1), ranges::end(in1), ranges::begin(fwd2), ranges::end(fwd2));
+    template <ranges::input_range Read1, ranges::forward_range Read2>
+    static constexpr void call() {
+        using ranges::find_first_of, ranges::iterator_t;
+        const auto pred = [](const int x, const int y) { return x == y + 1; };
 
-            BinaryPredicateFor<iterator_t<In1>, iterator_t<Fwd2>> pred{};
-            (void) ranges::find_first_of(in1, fwd2, pred);
-            (void) ranges::find_first_of(
-                ranges::begin(in1), ranges::end(in1), ranges::begin(fwd2), ranges::end(fwd2), pred);
+        { // Validate range overload [found case]
+            Read1 wrapped_haystack{haystack};
+            Read2 wrapped_needle{good_needle};
 
-            HalfProjectedBinaryPredicateFor<iterator_t<Fwd2>> halfpred{};
-            ProjectionFor<iterator_t<In1>> halfproj{};
-            (void) ranges::find_first_of(in1, fwd2, halfpred, halfproj);
-            (void) ranges::find_first_of(
-                ranges::begin(in1), ranges::end(in1), ranges::begin(fwd2), ranges::end(fwd2), halfpred, halfproj);
+            auto result = find_first_of(wrapped_haystack, wrapped_needle, pred, get_first);
+            STATIC_ASSERT(same_as<decltype(result), iterator_t<Read1>>);
+            assert(result.peek() == begin(haystack) + 2);
+        }
+        { // Validate iterator + sentinel overload [found case]
+            Read1 wrapped_haystack{haystack};
+            Read2 wrapped_needle{good_needle};
 
-            ProjectedBinaryPredicate<0, 1> projpred{};
-            ProjectionFor<iterator_t<In1>, 0> proj1{};
-            ProjectionFor<iterator_t<Fwd2>, 1> proj2{};
-            (void) ranges::find_first_of(in1, fwd2, projpred, proj1, proj2);
-            (void) ranges::find_first_of(
-                ranges::begin(in1), ranges::end(in1), ranges::begin(fwd2), ranges::end(fwd2), projpred, proj1, proj2);
+            auto result = find_first_of(wrapped_haystack.begin(), wrapped_haystack.end(), wrapped_needle.begin(),
+                wrapped_needle.end(), pred, get_first);
+            STATIC_ASSERT(same_as<decltype(result), iterator_t<Read1>>);
+            assert(result.peek() == begin(haystack) + 2);
+        }
+
+        { // Validate range overload [not found case]
+            Read1 wrapped_haystack{haystack};
+            Read2 wrapped_needle{bad_needle};
+
+            auto result = find_first_of(wrapped_haystack, wrapped_needle, pred, get_first);
+            STATIC_ASSERT(same_as<decltype(result), iterator_t<Read1>>);
+            assert(result.peek() == end(haystack));
+        }
+        {
+            // Validate iterator + sentinel overload [not found case]
+            Read1 wrapped_haystack{haystack};
+            Read2 wrapped_needle{bad_needle};
+
+            auto result = find_first_of(wrapped_haystack.begin(), wrapped_haystack.end(), wrapped_needle.begin(),
+                wrapped_needle.end(), pred, get_first);
+            STATIC_ASSERT(same_as<decltype(result), iterator_t<Read1>>);
+            assert(result.peek() == end(haystack));
         }
     }
 };
 
-template void test_in_fwd<instantiator, const int, const int>();
+#ifdef TEST_EVERYTHING
+int main() {
+    STATIC_ASSERT((test_in_fwd<instantiator, const P, const int>(), true));
+    test_in_fwd<instantiator, const P, const int>();
+}
+#else // ^^^ test all range combinations // test only interesting range combos vvv
+using in_test_range  = test::range<input_iterator_tag, const P, test::Sized::no, test::CanDifference::no,
+    test::Common::no, test::CanCompare::no, test::ProxyRef::yes>;
+using fwd_test_range = test::range<forward_iterator_tag, const int, test::Sized::no, test::CanDifference::no,
+    test::Common::no, test::CanCompare::yes, test::ProxyRef::yes>;
+
+constexpr bool run_tests() {
+    instantiator::call<in_test_range, fwd_test_range>();
+    return true;
+}
+
+int main() {
+    STATIC_ASSERT(run_tests());
+    run_tests();
+}
+#endif // TEST_EVERYTHING

--- a/tests/std/tests/P0896R4_ranges_alg_find_if/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_find_if/test.cpp
@@ -2,69 +2,59 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include <algorithm>
-#include <array>
 #include <cassert>
 #include <concepts>
 #include <ranges>
 #include <utility>
 
 #include <range_algorithm_support.hpp>
+using namespace std;
+using P = std::pair<int, int>;
 
-constexpr void smoke_test() {
-    using ranges::find_if, ranges::iterator_t, std::same_as;
-    using P = std::pair<int, int>;
+auto matches = [](const int x) { return x == 42; };
 
-    std::array<P, 3> const pairs = {{{0, 42}, {2, 42}, {4, 42}}};
-    constexpr auto equals        = [](auto x) { return [x](auto&& y) { return y == x; }; };
-
-    // Validate dangling story
-    STATIC_ASSERT(same_as<decltype(find_if(borrowed<false>{}, equals(42))), ranges::dangling>);
-    STATIC_ASSERT(same_as<decltype(find_if(borrowed<true>{}, equals(42))), int*>);
-
-    for (auto [value, _] : pairs) {
-        {
-            // Validate range overload [found case]
-            auto result = find_if(basic_borrowed_range{pairs}, equals(value), get_first);
-            STATIC_ASSERT(same_as<decltype(result), iterator_t<basic_borrowed_range<P const>>>);
-            assert((*result).first == value);
-        }
-        {
-            // Validate iterator + sentinel overload [found case]
-            basic_borrowed_range wrapped_pairs{pairs};
-            auto result = find_if(wrapped_pairs.begin(), wrapped_pairs.end(), equals(value), get_first);
-            STATIC_ASSERT(same_as<decltype(result), iterator_t<basic_borrowed_range<P const>>>);
-            assert((*result).first == value);
-        }
-    }
-    {
-        // Validate range overload [not found case]
-        auto result = find_if(basic_borrowed_range{pairs}, equals(42), get_first);
-        STATIC_ASSERT(same_as<decltype(result), iterator_t<basic_borrowed_range<P const>>>);
-        assert(result == basic_borrowed_range{pairs}.end());
-    }
-    {
-        // Validate iterator + sentinel overload [not found case]
-        basic_borrowed_range wrapped_pairs{pairs};
-        auto result = find_if(wrapped_pairs.begin(), wrapped_pairs.end(), equals(42), get_first);
-        STATIC_ASSERT(same_as<decltype(result), iterator_t<basic_borrowed_range<P const>>>);
-        assert(result == wrapped_pairs.end());
-    }
-}
-
-int main() {
-    STATIC_ASSERT((smoke_test(), true));
-    smoke_test();
-}
+// Validate dangling story
+STATIC_ASSERT(same_as<decltype(ranges::find_if(borrowed<false>{}, matches)), ranges::dangling>);
+STATIC_ASSERT(same_as<decltype(ranges::find_if(borrowed<true>{}, matches)), int*>);
 
 struct instantiator {
-    template <class In>
-    static void call(In&& in = {}) {
-        using ranges::iterator_t;
-        using I = iterator_t<In>;
+    static constexpr P haystack[3] = {{0, 42}, {2, 42}, {4, 42}};
 
-        (void) ranges::find_if(in, UnaryPredicateFor<I>{});
-        (void) ranges::find_if(in, ProjectedUnaryPredicate<>{}, ProjectionFor<I>{});
+    template <ranges::input_range Read>
+    static constexpr void call() {
+        using ranges::find_if, ranges::iterator_t;
+        auto equals = [](auto x) { return [x](auto&& y) { return y == x; }; };
+
+        for (auto [value, _] : haystack) {
+            { // Validate range overload [found case]
+                Read wrapped_input{haystack};
+                auto result = find_if(wrapped_input, equals(value), get_first);
+                STATIC_ASSERT(same_as<decltype(result), iterator_t<Read>>);
+                assert(result.peek()->first == value);
+            }
+            { // Validate iterator + sentinel overload [found case]
+                Read wrapped_input{haystack};
+                auto result = find_if(wrapped_input.begin(), wrapped_input.end(), equals(value), get_first);
+                STATIC_ASSERT(same_as<decltype(result), iterator_t<Read>>);
+                assert(result.peek()->first == value);
+            }
+        }
+        { // Validate range overload [not found case]
+            Read wrapped_input{haystack};
+            auto result = find_if(wrapped_input, equals(42), get_first);
+            STATIC_ASSERT(same_as<decltype(result), iterator_t<Read>>);
+            assert(result == wrapped_input.end());
+        }
+        { // Validate iterator + sentinel overload [not found case]
+            Read wrapped_input{haystack};
+            auto result = find_if(wrapped_input.begin(), wrapped_input.end(), equals(42), get_first);
+            STATIC_ASSERT(same_as<decltype(result), iterator_t<Read>>);
+            assert(result == wrapped_input.end());
+        }
     }
 };
 
-template void test_in<instantiator, const int>();
+int main() {
+    STATIC_ASSERT((test_in<instantiator, const P>(), true));
+    test_in<instantiator, const P>();
+}

--- a/tests/std/tests/P0896R4_ranges_alg_find_if/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_find_if/test.cpp
@@ -11,7 +11,7 @@
 using namespace std;
 using P = std::pair<int, int>;
 
-auto matches = [](const int x) { return x == 42; };
+constexpr auto matches = [](const int val) { return val == 42; };
 
 // Validate dangling story
 STATIC_ASSERT(same_as<decltype(ranges::find_if(borrowed<false>{}, matches)), ranges::dangling>);

--- a/tests/std/tests/P0896R4_ranges_alg_find_if/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_find_if/test.cpp
@@ -9,7 +9,7 @@
 
 #include <range_algorithm_support.hpp>
 using namespace std;
-using P = std::pair<int, int>;
+using P = pair<int, int>;
 
 constexpr auto matches = [](const int val) { return val == 42; };
 constexpr auto equals  = [](auto x) { return [x](auto&& y) { return y == x; }; };
@@ -25,7 +25,7 @@ struct instantiator {
     static constexpr void call() {
         using ranges::find_if, ranges::iterator_t;
 
-        for (auto [value, _] : haystack) {
+        for (const auto& [value, _] : haystack) {
             { // Validate range overload [found case]
                 Read wrapped_input{haystack};
                 auto result = find_if(wrapped_input, equals(value), get_first);

--- a/tests/std/tests/P0896R4_ranges_alg_find_if/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_find_if/test.cpp
@@ -12,6 +12,7 @@ using namespace std;
 using P = std::pair<int, int>;
 
 constexpr auto matches = [](const int val) { return val == 42; };
+constexpr auto equals  = [](auto x) { return [x](auto&& y) { return y == x; }; };
 
 // Validate dangling story
 STATIC_ASSERT(same_as<decltype(ranges::find_if(borrowed<false>{}, matches)), ranges::dangling>);
@@ -23,7 +24,6 @@ struct instantiator {
     template <ranges::input_range Read>
     static constexpr void call() {
         using ranges::find_if, ranges::iterator_t;
-        auto equals = [](auto x) { return [x](auto&& y) { return y == x; }; };
 
         for (auto [value, _] : haystack) {
             { // Validate range overload [found case]

--- a/tests/std/tests/P0896R4_ranges_alg_find_if_not/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_find_if_not/test.cpp
@@ -9,64 +9,53 @@
 #include <utility>
 
 #include <range_algorithm_support.hpp>
+using namespace std;
+using P = std::pair<int, int>;
 
-constexpr void smoke_test() {
-    using ranges::find_if_not, ranges::iterator_t, std::same_as;
-    using P = std::pair<int, int>;
+auto matches = [](const int x) { return x == 42; };
 
-    std::array<P, 3> pairs = {{{0, 13}, {0, 13}, {0, 13}}};
-    constexpr auto equals  = [](auto x) { return [x](auto&& y) { return y == x; }; };
-
-    // Validate dangling story
-    STATIC_ASSERT(same_as<decltype(find_if_not(borrowed<false>{}, equals(42))), ranges::dangling>);
-    STATIC_ASSERT(same_as<decltype(find_if_not(borrowed<true>{}, equals(42))), int*>);
-
-    for (auto& [value, _] : pairs) {
-        value = 42;
-        {
-            // Validate range overload [found case]
-            auto result = find_if_not(basic_borrowed_range{pairs}, equals(0), get_first);
-            STATIC_ASSERT(same_as<decltype(result), iterator_t<basic_borrowed_range<P>>>);
-            assert((*result).first == 42);
-        }
-        {
-            // Validate iterator + sentinel overload [found case]
-            basic_borrowed_range wrapped_pairs{pairs};
-            auto result = find_if_not(wrapped_pairs.begin(), wrapped_pairs.end(), equals(0), get_first);
-            STATIC_ASSERT(same_as<decltype(result), iterator_t<basic_borrowed_range<P>>>);
-            assert((*result).first == 42);
-        }
-        value = 0;
-    }
-    {
-        // Validate range overload [not found case]
-        auto result = find_if_not(basic_borrowed_range{pairs}, equals(0), get_first);
-        STATIC_ASSERT(same_as<decltype(result), iterator_t<basic_borrowed_range<P>>>);
-        assert(result == basic_borrowed_range{pairs}.end());
-    }
-    {
-        // Validate iterator + sentinel overload [not found case]
-        basic_borrowed_range wrapped_pairs{pairs};
-        auto result = find_if_not(wrapped_pairs.begin(), wrapped_pairs.end(), equals(0), get_first);
-        STATIC_ASSERT(same_as<decltype(result), iterator_t<basic_borrowed_range<P>>>);
-        assert(result == wrapped_pairs.end());
-    }
-}
-
-int main() {
-    STATIC_ASSERT((smoke_test(), true));
-    smoke_test();
-}
+// Validate dangling story
+STATIC_ASSERT(same_as<decltype(ranges::find_if_not(borrowed<false>{}, matches)), ranges::dangling>);
+STATIC_ASSERT(same_as<decltype(ranges::find_if_not(borrowed<true>{}, matches)), int*>);
 
 struct instantiator {
-    template <class In>
-    static void call(In&& in = {}) {
-        using ranges::iterator_t;
-        using I = iterator_t<In>;
+    static constexpr P haystack[3] = {{1, 13}, {2, 13}, {3, 13}};
 
-        (void) ranges::find_if_not(in, UnaryPredicateFor<I>{});
-        (void) ranges::find_if_not(in, ProjectedUnaryPredicate<>{}, ProjectionFor<I>{});
+    template <ranges::input_range Read>
+    static constexpr void call() {
+        using ranges::find_if_not, ranges::iterator_t;
+        auto equals = [](auto x) { return [x](auto&& y) { return y == x; }; };
+
+        for (auto& [value, _] : haystack) {
+            { // Validate range overload [found case]
+                Read wrapped_input{haystack};
+                auto result = find_if_not(wrapped_input, equals(4), get_first);
+                STATIC_ASSERT(same_as<decltype(result), iterator_t<Read>>);
+                assert(result.peek()->first == 1);
+            }
+            { // Validate iterator + sentinel overload [found case]
+                Read wrapped_input{haystack};
+                auto result = find_if_not(wrapped_input.begin(), wrapped_input.end(), equals(0), get_first);
+                STATIC_ASSERT(same_as<decltype(result), iterator_t<Read>>);
+                assert(result.peek()->first == 1);
+            }
+        }
+        { // Validate range overload [not found case]
+            Read wrapped_input{haystack};
+            auto result = find_if_not(wrapped_input, equals(13), get_second);
+            STATIC_ASSERT(same_as<decltype(result), iterator_t<Read>>);
+            assert(result == wrapped_input.end());
+        }
+        { // Validate iterator + sentinel overload [not found case]
+            Read wrapped_input{haystack};
+            auto result = find_if_not(wrapped_input.begin(), wrapped_input.end(), equals(13), get_second);
+            STATIC_ASSERT(same_as<decltype(result), iterator_t<Read>>);
+            assert(result == wrapped_input.end());
+        }
     }
 };
 
-template void test_in<instantiator, const int>();
+int main() {
+    STATIC_ASSERT((test_in<instantiator, const P>(), true));
+    test_in<instantiator, const P>();
+}

--- a/tests/std/tests/P0896R4_ranges_alg_find_if_not/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_find_if_not/test.cpp
@@ -12,33 +12,34 @@
 using namespace std;
 using P = std::pair<int, int>;
 
-auto matches = [](const int x) { return x == 42; };
+constexpr auto matches = [](const int val) { return val == 42; };
 
 // Validate dangling story
 STATIC_ASSERT(same_as<decltype(ranges::find_if_not(borrowed<false>{}, matches)), ranges::dangling>);
 STATIC_ASSERT(same_as<decltype(ranges::find_if_not(borrowed<true>{}, matches)), int*>);
 
 struct instantiator {
-    static constexpr P haystack[3] = {{1, 13}, {2, 13}, {3, 13}};
-
     template <ranges::input_range Read>
     static constexpr void call() {
         using ranges::find_if_not, ranges::iterator_t;
-        auto equals = [](auto x) { return [x](auto&& y) { return y == x; }; };
+        auto equals   = [](auto x) { return [x](auto&& y) { return y == x; }; };
+        P haystack[3] = {{0, 13}, {0, 13}, {0, 13}};
 
         for (auto& [value, _] : haystack) {
+            value = 42;
             { // Validate range overload [found case]
                 Read wrapped_input{haystack};
-                auto result = find_if_not(wrapped_input, equals(4), get_first);
+                auto result = find_if_not(wrapped_input, equals(0), get_first);
                 STATIC_ASSERT(same_as<decltype(result), iterator_t<Read>>);
-                assert(result.peek()->first == 1);
+                assert(result.peek()->first == 42);
             }
             { // Validate iterator + sentinel overload [found case]
                 Read wrapped_input{haystack};
                 auto result = find_if_not(wrapped_input.begin(), wrapped_input.end(), equals(0), get_first);
                 STATIC_ASSERT(same_as<decltype(result), iterator_t<Read>>);
-                assert(result.peek()->first == 1);
+                assert(result.peek()->first == 42);
             }
+            value = 0;
         }
         { // Validate range overload [not found case]
             Read wrapped_input{haystack};

--- a/tests/std/tests/P0896R4_ranges_alg_find_if_not/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_find_if_not/test.cpp
@@ -10,7 +10,7 @@
 
 #include <range_algorithm_support.hpp>
 using namespace std;
-using P = std::pair<int, int>;
+using P = pair<int, int>;
 
 constexpr auto matches = [](const int val) { return val == 42; };
 constexpr auto equals  = [](auto x) { return [x](auto&& y) { return y == x; }; };

--- a/tests/std/tests/P0896R4_ranges_alg_find_if_not/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_find_if_not/test.cpp
@@ -13,6 +13,7 @@ using namespace std;
 using P = std::pair<int, int>;
 
 constexpr auto matches = [](const int val) { return val == 42; };
+constexpr auto equals  = [](auto x) { return [x](auto&& y) { return y == x; }; };
 
 // Validate dangling story
 STATIC_ASSERT(same_as<decltype(ranges::find_if_not(borrowed<false>{}, matches)), ranges::dangling>);
@@ -22,7 +23,6 @@ struct instantiator {
     template <ranges::input_range Read>
     static constexpr void call() {
         using ranges::find_if_not, ranges::iterator_t;
-        auto equals   = [](auto x) { return [x](auto&& y) { return y == x; }; };
         P haystack[3] = {{0, 13}, {0, 13}, {0, 13}};
 
         for (auto& [value, _] : haystack) {


### PR DESCRIPTION
This updates the `ranges::find*` algorithms to the latest way of implementing the algorithms.
It also updates all tests except `find_end` as there was a strange issue I need to understand.