### PR TITLE
Modernize ranges::for_each

### DIFF
--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -336,21 +336,40 @@ namespace ranges {
             indirectly_unary_invocable<projected<_It, _Pj>> _Fn>
         constexpr for_each_result<_It, _Fn> operator()(_It _First, _Se _Last, _Fn _Func, _Pj _Proj = {}) const {
             _Adl_verify_range(_First, _Last);
-            auto _UFirst      = _Get_unwrapped(_STD move(_First));
-            const auto _ULast = _Get_unwrapped(_STD move(_Last));
-            for (; _UFirst != _ULast; ++_UFirst) {
-                _STD invoke(_Func, _STD invoke(_Proj, *_UFirst));
-            }
 
-            _Seek_wrapped(_First, _STD move(_UFirst));
-            return {_STD move(_First), _STD move(_Func)};
+            auto _UResult = _For_each_unchecked(
+                _Get_unwrapped(_STD move(_First)), _Get_unwrapped(_STD move(_Last)), _STD move(_Func), _Pass_fn(_Proj));
+
+            _Seek_wrapped(_First, _STD move(_UResult.in));
+            return {_STD move(_First), _STD move(_UResult.fun)};
         }
 
         template <input_range _Rng, class _Pj = identity,
             indirectly_unary_invocable<projected<iterator_t<_Rng>, _Pj>> _Fn>
         constexpr for_each_result<borrowed_iterator_t<_Rng>, _Fn> operator()(
             _Rng&& _Range, _Fn _Func, _Pj _Proj = {}) const {
-            return (*this)(_RANGES begin(_Range), _RANGES end(_Range), _STD move(_Func), _Pass_fn(_Proj));
+            auto _First = _RANGES begin(_Range);
+
+            auto _UResult = _For_each_unchecked(
+                _Get_unwrapped(_STD move(_First)), _Uend(_Range), _STD move(_Func), _Pass_fn(_Proj));
+
+            _Seek_wrapped(_First, _STD move(_UResult.in));
+            return {_STD move(_First), _STD move(_UResult.fun)};
+        }
+
+    private:
+        template <class _It, class _Se, class _Pj, class _Fn>
+        _NODISCARD static constexpr for_each_result<_It, _Fn> _For_each_unchecked(
+            _It _First, const _Se _Last, _Fn _Func, _Pj _Proj) {
+            _STL_INTERNAL_STATIC_ASSERT(input_iterator<_It>);
+            _STL_INTERNAL_STATIC_ASSERT(sentinel_for<_Se, _It>);
+            _STL_INTERNAL_STATIC_ASSERT(indirectly_unary_invocable<_Fn, projected<_It, _Pj>>);
+
+            for (; _First != _Last; ++_First) {
+                _STD invoke(_Func, _STD invoke(_Proj, *_First));
+            }
+
+            return {_STD move(_First), _STD move(_Func)};
         }
     };
 

--- a/tests/std/tests/P0896R4_ranges_alg_for_each/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_for_each/test.cpp
@@ -12,6 +12,8 @@
 using namespace std;
 using P = pair<int, int>;
 
+constexpr auto incr = [](auto& y) { ++y; };
+
 // Validate that for_each_result aliases in_fun_result
 STATIC_ASSERT(same_as<ranges::for_each_result<int, double>, ranges::in_fun_result<int, double>>);
 
@@ -26,8 +28,7 @@ struct instantiator {
 
     template <ranges::input_range ReadWrite>
     static constexpr void call() {
-        using ranges::for_each, ranges::for_each_result, ranges::in_fun_result, ranges::iterator_t;
-        auto incr = [](auto& y) { ++y; };
+        using ranges::for_each, ranges::for_each_result, ranges::iterator_t;
 
         { // Validate iterator + sentinel overload
             P input[3] = {{0, 42}, {2, 42}, {4, 42}};

--- a/tests/std/tests/P0896R4_ranges_alg_for_each/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_for_each/test.cpp
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include <algorithm>
-#include <array>
 #include <cassert>
 #include <concepts>
 #include <functional>
@@ -10,66 +9,56 @@
 #include <utility>
 
 #include <range_algorithm_support.hpp>
+using namespace std;
+using P = pair<int, int>;
 
-constexpr void smoke_test() {
-    using ranges::for_each, ranges::for_each_result, ranges::in_fun_result, ranges::iterator_t;
-    using std::identity, std::same_as;
-    using P = std::pair<int, int>;
-    using R = std::array<P, 3>;
+// Validate that for_each_result aliases in_fun_result
+STATIC_ASSERT(same_as<ranges::for_each_result<int, double>, ranges::in_fun_result<int, double>>);
 
-    // Validate that for_each_result aliases in_fun_result
-    STATIC_ASSERT(same_as<for_each_result<int, double>, in_fun_result<int, double>>);
-
-    // Validate dangling story
-    STATIC_ASSERT(
-        same_as<decltype(for_each(borrowed<false>{}, identity{})), for_each_result<ranges::dangling, identity>>);
-    STATIC_ASSERT(same_as<decltype(for_each(borrowed<true>{}, identity{})), for_each_result<int*, identity>>);
-
-    R const values = {{{0, 42}, {2, 42}, {4, 42}}};
-    auto incr      = [](auto& y) { ++y; };
-
-    {
-        auto pairs  = values;
-        auto result = for_each(basic_borrowed_range{pairs}, incr, get_first);
-        STATIC_ASSERT(same_as<decltype(result), for_each_result<iterator_t<basic_borrowed_range<P>>, decltype(incr)>>);
-        assert(result.in == basic_borrowed_range{pairs}.end());
-        int some_value = 1729;
-        result.fun(some_value);
-        assert(some_value == 1730);
-        R const expected = {{{1, 42}, {3, 42}, {5, 42}}};
-        assert(ranges::equal(pairs, expected));
-    }
-    {
-        auto pairs = values;
-        basic_borrowed_range wrapped_pairs{pairs};
-        auto result = for_each(wrapped_pairs.begin(), wrapped_pairs.end(), incr, get_second);
-        STATIC_ASSERT(same_as<decltype(result), for_each_result<iterator_t<basic_borrowed_range<P>>, decltype(incr)>>);
-        assert(result.in == wrapped_pairs.end());
-        int some_value = 1729;
-        result.fun(some_value);
-        assert(some_value == 1730);
-        R const expected = {{{0, 43}, {2, 43}, {4, 43}}};
-        assert(ranges::equal(pairs, expected));
-    }
-}
-
-int main() {
-    STATIC_ASSERT((smoke_test(), true));
-    smoke_test();
-}
+// Validate dangling story
+STATIC_ASSERT(same_as<decltype(ranges::for_each(borrowed<false>{}, identity{})),
+    ranges::for_each_result<ranges::dangling, identity>>);
+STATIC_ASSERT(
+    same_as<decltype(ranges::for_each(borrowed<true>{}, identity{})), ranges::for_each_result<int*, identity>>);
 
 struct instantiator {
-    template <class In>
-    static void call(In&& in = {}) {
-        using I   = ranges::iterator_t<In>;
-        using Fun = void (*)(std::iter_common_reference_t<I>);
-        ranges::for_each(in, Fun{});
-        ranges::for_each(ranges::begin(in), ranges::end(in), Fun{});
+    static constexpr P expected[3] = {{1, 42}, {3, 42}, {5, 42}};
 
-        using ProjFun = void (*)(unique_tag<0>);
-        ranges::for_each(in, ProjFun{}, ProjectionFor<I>{});
-        ranges::for_each(ranges::begin(in), ranges::end(in), ProjFun{}, ProjectionFor<I>{});
+    template <ranges::input_range ReadWrite>
+    static constexpr void call() {
+        using ranges::for_each, ranges::for_each_result, ranges::in_fun_result, ranges::iterator_t;
+        auto incr = [](auto& y) { ++y; };
+
+        { // Validate iterator + sentinel overload
+            P input[3] = {{0, 42}, {2, 42}, {4, 42}};
+            ReadWrite wrapped_input{input};
+
+            auto result = for_each(wrapped_input.begin(), wrapped_input.end(), incr, get_first);
+            STATIC_ASSERT(same_as<decltype(result), for_each_result<iterator_t<ReadWrite>, decltype(incr)>>);
+            assert(result.in == wrapped_input.end());
+            assert(ranges::equal(expected, input));
+
+            int some_value = 1729;
+            result.fun(some_value);
+            assert(some_value == 1730);
+        }
+        { // Validate range overload
+            P input[3] = {{0, 42}, {2, 42}, {4, 42}};
+            ReadWrite wrapped_input{input};
+
+            auto result = for_each(wrapped_input, incr, get_first);
+            STATIC_ASSERT(same_as<decltype(result), for_each_result<iterator_t<ReadWrite>, decltype(incr)>>);
+            assert(result.in == wrapped_input.end());
+            assert(ranges::equal(expected, input));
+
+            int some_value = 1729;
+            result.fun(some_value);
+            assert(some_value == 1730);
+        }
     }
 };
 
-template void test_in<instantiator, const int>();
+int main() {
+    STATIC_ASSERT((test_in<instantiator, P>(), true));
+    test_in<instantiator, P>();
+}

--- a/tests/std/tests/P0896R4_ranges_alg_for_each/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_for_each/test.cpp
@@ -35,7 +35,8 @@ struct instantiator {
             ReadWrite wrapped_input{input};
 
             auto result = for_each(wrapped_input.begin(), wrapped_input.end(), incr, get_first);
-            STATIC_ASSERT(same_as<decltype(result), for_each_result<iterator_t<ReadWrite>, decltype(incr)>>);
+            STATIC_ASSERT(
+                same_as<decltype(result), for_each_result<iterator_t<ReadWrite>, remove_const_t<decltype(incr)>>>);
             assert(result.in == wrapped_input.end());
             assert(ranges::equal(expected, input));
 
@@ -48,7 +49,8 @@ struct instantiator {
             ReadWrite wrapped_input{input};
 
             auto result = for_each(wrapped_input, incr, get_first);
-            STATIC_ASSERT(same_as<decltype(result), for_each_result<iterator_t<ReadWrite>, decltype(incr)>>);
+            STATIC_ASSERT(
+                same_as<decltype(result), for_each_result<iterator_t<ReadWrite>, remove_const_t<decltype(incr)>>>);
             assert(result.in == wrapped_input.end());
             assert(ranges::equal(expected, input));
 

--- a/tests/std/tests/P0896R4_ranges_alg_for_each_n/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_for_each_n/test.cpp
@@ -22,18 +22,16 @@ struct instantiator {
     template <indirectly_writable<P> ReadWrite>
     static constexpr void call() {
         using ranges::for_each_n, ranges::for_each_n_result, ranges::iterator_t, ranges::distance;
-        { // Validate iterator + sentinel overload
-            P input[3] = {{0, 42}, {2, 42}, {4, 42}};
+        P input[3] = {{0, 42}, {2, 42}, {4, 42}};
 
-            auto result = for_each_n(ReadWrite{input}, distance(input), incr, get_first);
-            STATIC_ASSERT(same_as<decltype(result), for_each_n_result<ReadWrite, remove_const_t<decltype(incr)>>>);
-            assert(result.in.peek() == end(input));
-            assert(ranges::equal(expected, input));
+        auto result = for_each_n(ReadWrite{input}, distance(input), incr, get_first);
+        STATIC_ASSERT(same_as<decltype(result), for_each_n_result<ReadWrite, remove_const_t<decltype(incr)>>>);
+        assert(result.in.peek() == end(input));
+        assert(ranges::equal(expected, input));
 
-            int some_value = 1729;
-            result.fun(some_value);
-            assert(some_value == 1730);
-        }
+        int some_value = 1729;
+        result.fun(some_value);
+        assert(some_value == 1730);
     }
 };
 

--- a/tests/std/tests/P0896R4_ranges_alg_for_each_n/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_for_each_n/test.cpp
@@ -2,53 +2,42 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include <algorithm>
-#include <array>
 #include <cassert>
 #include <concepts>
 #include <ranges>
 #include <utility>
 
 #include <range_algorithm_support.hpp>
+using namespace std;
+using P = pair<int, int>;
 
-constexpr void smoke_test() {
-    using ranges::for_each_n, ranges::for_each_n_result, ranges::in_fun_result, ranges::iterator_t;
-    using std::same_as;
-    using P = std::pair<int, int>;
-    using R = std::array<P, 3>;
-
-    // Validate that for_each_n_result aliases in_fun_result
-    STATIC_ASSERT(same_as<for_each_n_result<int, double>, in_fun_result<int, double>>);
-
-    R pairs   = {{{0, 42}, {2, 42}, {4, 42}}};
-    auto incr = [](auto& y) { ++y; };
-
-    basic_borrowed_range wrapped_pairs{pairs};
-    auto result = for_each_n(wrapped_pairs.begin(), ranges::distance(pairs), incr, get_first);
-    STATIC_ASSERT(same_as<decltype(result), for_each_n_result<iterator_t<basic_borrowed_range<P>>, decltype(incr)>>);
-    assert(result.in == wrapped_pairs.end());
-    int some_value = 1729;
-    result.fun(some_value);
-    assert(some_value == 1730);
-    R const expected = {{{1, 42}, {3, 42}, {5, 42}}};
-    assert(ranges::equal(pairs, expected));
-}
-
-int main() {
-    STATIC_ASSERT((smoke_test(), true));
-    smoke_test();
-}
+// Validate that for_each_n_result aliases in_fun_result
+STATIC_ASSERT(same_as<ranges::for_each_n_result<int, double>, ranges::in_fun_result<int, double>>);
 
 struct instantiator {
-    template <class In>
-    static void call(In in = {}) {
-        using std::iter_difference_t;
+    static constexpr P expected[3] = {{1, 42}, {3, 42}, {5, 42}};
 
-        using Fun = void (*)(std::iter_common_reference_t<In>);
-        ranges::for_each_n(std::move(in), iter_difference_t<In>{}, Fun{});
+    template <indirectly_writable<P> ReadWrite>
+    static constexpr void call() {
+        using ranges::for_each_n, ranges::for_each_n_result, ranges::iterator_t, ranges::distance;
+        auto incr = [](auto& y) { ++y; };
 
-        using ProjFun = void (*)(unique_tag<0>);
-        ranges::for_each_n(std::move(in), iter_difference_t<In>{}, ProjFun{}, ProjectionFor<In>{});
+        { // Validate iterator + sentinel overload
+            P input[3] = {{0, 42}, {2, 42}, {4, 42}};
+
+            auto result = for_each_n(ReadWrite{input}, distance(input), incr, get_first);
+            STATIC_ASSERT(same_as<decltype(result), for_each_n_result<ReadWrite, decltype(incr)>>);
+            assert(result.in.peek() == end(input));
+            assert(ranges::equal(expected, input));
+
+            int some_value = 1729;
+            result.fun(some_value);
+            assert(some_value == 1730);
+        }
     }
 };
 
-template void test_read<instantiator, const int>();
+int main() {
+    STATIC_ASSERT((test_read<instantiator, P>(), true));
+    test_read<instantiator, P>();
+}

--- a/tests/std/tests/P0896R4_ranges_alg_for_each_n/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_for_each_n/test.cpp
@@ -11,6 +11,8 @@
 using namespace std;
 using P = pair<int, int>;
 
+constexpr auto incr = [](auto& y) { ++y; };
+
 // Validate that for_each_n_result aliases in_fun_result
 STATIC_ASSERT(same_as<ranges::for_each_n_result<int, double>, ranges::in_fun_result<int, double>>);
 
@@ -20,8 +22,6 @@ struct instantiator {
     template <indirectly_writable<P> ReadWrite>
     static constexpr void call() {
         using ranges::for_each_n, ranges::for_each_n_result, ranges::iterator_t, ranges::distance;
-        auto incr = [](auto& y) { ++y; };
-
         { // Validate iterator + sentinel overload
             P input[3] = {{0, 42}, {2, 42}, {4, 42}};
 

--- a/tests/std/tests/P0896R4_ranges_alg_for_each_n/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_for_each_n/test.cpp
@@ -26,7 +26,7 @@ struct instantiator {
             P input[3] = {{0, 42}, {2, 42}, {4, 42}};
 
             auto result = for_each_n(ReadWrite{input}, distance(input), incr, get_first);
-            STATIC_ASSERT(same_as<decltype(result), for_each_n_result<ReadWrite, decltype(incr)>>);
+            STATIC_ASSERT(same_as<decltype(result), for_each_n_result<ReadWrite, remove_const_t<decltype(incr)>>>);
             assert(result.in.peek() == end(input));
             assert(ranges::equal(expected, input));
 


### PR DESCRIPTION
This modernizes `ranges::for_each` and `ranges::for_each_n` to the current state of the art