### PR TITLE
Update .clang-format for Clang 10

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -5,50 +5,36 @@
 
 ---
 # Language:        Cpp
-
 BasedOnStyle:  LLVM
-
 # AccessModifierOffset: -2
 AccessModifierOffset: -4
-
 # AlignAfterOpenBracket: Align
 AlignAfterOpenBracket: DontAlign
-
 # AlignConsecutiveMacros: false
 AlignConsecutiveMacros: true
-
 # AlignConsecutiveAssignments: false
 AlignConsecutiveAssignments: true
-
 # AlignConsecutiveDeclarations: false
-
 # AlignEscapedNewlines: Right
 AlignEscapedNewlines: Left
-
 # AlignOperands:   true
-
 # AlignTrailingComments: true
 AlignTrailingComments: false
-
 # AllowAllArgumentsOnNextLine: true
 # AllowAllConstructorInitializersOnNextLine: true
 # AllowAllParametersOfDeclarationOnNextLine: true
 # AllowShortBlocksOnASingleLine: Never
 # AllowShortCaseLabelsOnASingleLine: false
-
 # AllowShortFunctionsOnASingleLine: All
 AllowShortFunctionsOnASingleLine: Empty
-
 # AllowShortLambdasOnASingleLine: All
 # AllowShortIfStatementsOnASingleLine: Never
 # AllowShortLoopsOnASingleLine: false
 # AlwaysBreakAfterDefinitionReturnType: None
 # AlwaysBreakAfterReturnType: None
 # AlwaysBreakBeforeMultilineStrings: false
-
 # AlwaysBreakTemplateDeclarations: MultiLine
 AlwaysBreakTemplateDeclarations: Yes
-
 # BinPackArguments: true
 # BinPackParameters: true
 # BraceWrapping:
@@ -68,10 +54,8 @@ AlwaysBreakTemplateDeclarations: Yes
 #   SplitEmptyFunction: true
 #   SplitEmptyRecord: true
 #   SplitEmptyNamespace: true
-
 # BreakBeforeBinaryOperators: None
 BreakBeforeBinaryOperators: NonAssignment
-
 # BreakBeforeBraces: Attach
 # BreakBeforeInheritanceComma: false
 # BreakInheritanceList: BeforeColon
@@ -80,20 +64,16 @@ BreakBeforeBinaryOperators: NonAssignment
 # BreakConstructorInitializers: BeforeColon
 # BreakAfterJavaFieldAnnotations: false
 # BreakStringLiterals: true
-
 # ColumnLimit:     80
 ColumnLimit:     120
-
 # CommentPragmas:  '^ IWYU pragma:'
 # CompactNamespaces: false
 # ConstructorInitializerAllOnOneLineOrOnePerLine: false
 # ConstructorInitializerIndentWidth: 4
 # ContinuationIndentWidth: 4
 # Cpp11BracedListStyle: true
-
 # DeriveLineEnding: true
 DeriveLineEnding: false
-
 # DerivePointerAlignment: false
 # DisableFormat:   false
 # ExperimentalAutoDetectBinPacking: false
@@ -102,10 +82,8 @@ DeriveLineEnding: false
 #   - foreach
 #   - Q_FOREACH
 #   - BOOST_FOREACH
-
 # IncludeBlocks:   Preserve
 IncludeBlocks:   Regroup
-
 # IncludeCategories:
 #   - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
 #     Priority:        2
@@ -131,33 +109,25 @@ IncludeCategories:
     Priority:        5
   - Regex:           '.*'
     Priority:        2
-
 # IncludeIsMainRegex: '(Test)?$'
 # IncludeIsMainSourceRegex: ''
 # IndentCaseLabels: false
 # IndentGotoLabels: true
 # IndentPPDirectives: None
-
 # IndentWidth:     2
 IndentWidth:     4
-
 # IndentWrappedFunctionNames: false
 IndentWrappedFunctionNames: true
-
 # JavaScriptQuotes: Leave
 # JavaScriptWrapImports: true
 # KeepEmptyLinesAtTheStartOfBlocks: true
-
 # NOTE: MacroBlockBegin/MacroBlockEnd don't work with _CATCH_ALL.
 # MacroBlockBegin: ''
 # MacroBlockEnd:   ''
-
 # MaxEmptyLinesToKeep: 1
 MaxEmptyLinesToKeep: 2
-
 # NamespaceIndentation: None
 NamespaceIndentation: All
-
 # ObjCBinPackProtocolList: Auto
 # ObjCBlockIndentWidth: 2
 # ObjCSpaceAfterProperty: false
@@ -170,17 +140,13 @@ NamespaceIndentation: All
 # PenaltyBreakTemplateDeclaration: 10
 # PenaltyExcessCharacter: 1000000
 # PenaltyReturnTypeOnItsOwnLine: 60
-
 # PointerAlignment: Right
 PointerAlignment: Left
-
 # ReflowComments:  true
 # SortIncludes:    true
 # SortUsingDeclarations: true
-
 # SpaceAfterCStyleCast: false
 SpaceAfterCStyleCast: true
-
 # SpaceAfterLogicalNot: false
 # SpaceAfterTemplateKeyword: true
 # SpaceBeforeAssignmentOperators: true
@@ -200,12 +166,11 @@ SpaceAfterCStyleCast: true
 # SpacesInSquareBrackets: false
 # SpaceBeforeSquareBrackets: false
 # Standard:        Latest
-
-# NOTE: _STD_BEGIN, _STD_END, etc. aren't macros for complete statements, but telling clang-format that they are
-# produces the behavior that we want (with no block indentation).
 # StatementMacros:
 #   - Q_UNUSED
 #   - QT_REQUIRE_VERSION
+# NOTE: _STD_BEGIN, _STD_END, etc. aren't macros for complete statements, but telling
+# clang-format that they are produces the behavior that we want (with no block indentation).
 StatementMacros:
   - _STD_BEGIN
   - _STD_END
@@ -215,11 +180,8 @@ StatementMacros:
   - _END_EXTERN_C
   - _EXTERN_C_UNLESS_PURE
   - _END_EXTERN_C_UNLESS_PURE
-
 # TabWidth:        8
-
 # UseCRLF:         false
 UseCRLF:         true
-
 # UseTab:          Never
 ...

--- a/.clang-format
+++ b/.clang-format
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-# https://releases.llvm.org/9.0.0/tools/clang/docs/ClangFormatStyleOptions.html
+# https://releases.llvm.org/10.0.0/tools/clang/docs/ClangFormatStyleOptions.html
 
 ---
 # Language:        Cpp
@@ -33,7 +33,7 @@ AlignTrailingComments: false
 # AllowAllArgumentsOnNextLine: true
 # AllowAllConstructorInitializersOnNextLine: true
 # AllowAllParametersOfDeclarationOnNextLine: true
-# AllowShortBlocksOnASingleLine: false
+# AllowShortBlocksOnASingleLine: Never
 # AllowShortCaseLabelsOnASingleLine: false
 
 # AllowShortFunctionsOnASingleLine: All
@@ -90,6 +90,10 @@ ColumnLimit:     120
 # ConstructorInitializerIndentWidth: 4
 # ContinuationIndentWidth: 4
 # Cpp11BracedListStyle: true
+
+# DeriveLineEnding: true
+DeriveLineEnding: false
+
 # DerivePointerAlignment: false
 # DisableFormat:   false
 # ExperimentalAutoDetectBinPacking: false
@@ -105,17 +109,22 @@ IncludeBlocks:   Regroup
 # IncludeCategories:
 #   - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
 #     Priority:        2
+#     SortPriority:    0
 #   - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
 #     Priority:        3
+#     SortPriority:    0
 #   - Regex:           '.*'
 #     Priority:        1
+#     SortPriority:    0
 IncludeCategories:
   - Regex:           '^<yvals(_core)?\.h>$'
     Priority:        1
   - Regex:           '^<(Windows|userenv)\.h>$'
     Priority:        3
+    SortPriority:    3
   - Regex:           '^<WinIoCtl\.h>$'
-    Priority:        4
+    Priority:        3
+    SortPriority:    4
   - Regex:           '^<__.*\.hpp>$'
     Priority:        2
   - Regex:           '\.hpp[>"]$'
@@ -124,7 +133,9 @@ IncludeCategories:
     Priority:        2
 
 # IncludeIsMainRegex: '(Test)?$'
+# IncludeIsMainSourceRegex: ''
 # IndentCaseLabels: false
+# IndentGotoLabels: true
 # IndentPPDirectives: None
 
 # IndentWidth:     2
@@ -178,14 +189,17 @@ SpaceAfterCStyleCast: true
 # SpaceBeforeInheritanceColon: true
 # SpaceBeforeParens: ControlStatements
 # SpaceBeforeRangeBasedForLoopColon: true
+# SpaceInEmptyBlock: false
 # SpaceInEmptyParentheses: false
 # SpacesBeforeTrailingComments: 1
 # SpacesInAngles:  false
+# SpacesInConditionalStatement: false
 # SpacesInContainerLiterals: true
 # SpacesInCStyleCastParentheses: false
 # SpacesInParentheses: false
 # SpacesInSquareBrackets: false
-# Standard:        Cpp11
+# SpaceBeforeSquareBrackets: false
+# Standard:        Latest
 
 # NOTE: _STD_BEGIN, _STD_END, etc. aren't macros for complete statements, but telling clang-format that they are
 # produces the behavior that we want (with no block indentation).
@@ -203,5 +217,9 @@ StatementMacros:
   - _END_EXTERN_C_UNLESS_PURE
 
 # TabWidth:        8
+
+# UseCRLF:         false
+UseCRLF:         true
+
 # UseTab:          Never
 ...

--- a/stl/src/filesystem.cpp
+++ b/stl/src/filesystem.cpp
@@ -18,7 +18,6 @@
 #include <xfilesystem_abi.h>
 
 #include <Windows.h>
-
 #include <WinIoCtl.h>
 
 // We have several switches that do not have case statements for every possible enum value.

--- a/tests/std/tests/P0896R4_ranges_alg_is_permutation/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_is_permutation/test.cpp
@@ -8,7 +8,7 @@
 #include <ranges>
 #include <span>
 #include <utility>
-//
+
 #include <range_algorithm_support.hpp>
 
 using namespace std;

--- a/tests/std/tests/P0896R4_ranges_alg_search/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_search/test.cpp
@@ -8,7 +8,7 @@
 #include <ranges>
 #include <span>
 #include <utility>
-//
+
 #include <range_algorithm_support.hpp>
 
 using namespace std;

--- a/tests/std/tests/P0896R4_ranges_range_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_range_machinery/test.cpp
@@ -25,7 +25,7 @@
 #include <utility>
 #include <valarray>
 #include <vector>
-//
+
 #include <range_algorithm_support.hpp>
 
 // Note that many tests herein assume:

--- a/tools/inc/stljobs.h
+++ b/tools/inc/stljobs.h
@@ -501,7 +501,7 @@ public:
     thread_proc_attribute_list& operator=(thread_proc_attribute_list&&) = default;
 
     explicit thread_proc_attribute_list(const unsigned long attributeCount) {
-        size_t size;
+        SIZE_T size;
         if (InitializeProcThreadAttributeList(nullptr, attributeCount, 0, &size)) {
             fputs("First call to InitializeProcThreadAttributeList should not succeed.", stderr);
             abort();


### PR DESCRIPTION
* Remove unnecessary comments in ranges tests.
  + We taught clang-format how to sort like this automatically. :smile_cat:
* Fix x86 compiler error in `stljobs.h`.
  + This never compiled for x86 where `size_t` and `SIZE_T` are different types. :scream_cat:
* Update `.clang-format` for Clang 10.
  + AllowShortBlocksOnASingleLine changed from false/true to Never/Empty/Always. We still want the default of Never, as Empty appears to misbehave.
  + DeriveLineEnding was added, defaulting to true. We want to disable line ending auto-detection.
  + SortPriority was added. Its documentation is difficult to understand, but it can be used to group includes together while modifying their otherwise-lexicographic ordering. Here, I'm using it to group WinSDK includes together, while still sorting `WinIoCtl.h` last.
  + IncludeIsMainSourceRegex was added. This doesn't appear to be relevant to us.
  + IndentGotoLabels was added. We've avoided goto.
  + SpaceInEmptyBlock was added. We prefer the default of no space.
  + SpacesInConditionalStatement was added. We definitely prefer the default of no space.
  + SpaceBeforeSquareBrackets was added. Again, we definitely prefer the default of no space.
  + The Standard option was overhauled. Previously, Cpp11 meant "use the latest supported standard". That was confusing, so it has been deprecated in favor of Latest.
  + UseCRLF was added. We currently use CRLF for all files. (Previously, `validate.cpp` would detect LF files, but clang-format wouldn't fix them.)
* In `.clang-format`, delete empty lines and move comment.
  + The empty lines were intended to make it easier to see customized options, but they were actually making it harder to diff the default config against our config.
  + Move the StatementMacros comment next to our customized settings, and rewrap it.
* Reformat `filesystem.cpp`.