### PR TITLE
Fix the interaction between _Pass_fn and invoke

### DIFF
--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -197,9 +197,8 @@ struct _Ref_fn { // pass function object by value as a reference
 };
 
 template <class _Fn>
-_INLINE_VAR constexpr bool
-    _Pass_functor_by_value_v = sizeof(_Fn) <= sizeof(void*)
-                               && conjunction_v<is_trivially_copy_constructible<_Fn>, is_trivially_destructible<_Fn>>;
+_INLINE_VAR constexpr bool _Pass_functor_by_value_v = conjunction_v<bool_constant<sizeof(_Fn) <= 4 * sizeof(void*)>,
+    is_trivially_copy_constructible<_Fn>, is_trivially_destructible<_Fn>>;
 
 template <class _Fn, enable_if_t<_Pass_functor_by_value_v<_Fn>, int> = 0> // TRANSITION, if constexpr
 constexpr _Fn _Pass_fn(_Fn _Val) { // pass functor by value

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -190,14 +190,21 @@ template <class _Fx>
 struct _Ref_fn { // pass function object by value as a reference
     template <class... _Args>
     constexpr decltype(auto) operator()(_Args&&... _Vals) { // forward function call operator
-        return _Fn(_STD forward<_Args>(_Vals)...);
+#if _HAS_IF_CONSTEXPR
+        if constexpr (is_member_pointer_v<_Fx>) {
+            return _STD invoke(_Fn, _STD forward<_Args>(_Vals)...);
+        } else
+#endif // _HAS_IF_CONSTEXPR
+        {
+            return _Fn(_STD forward<_Args>(_Vals)...);
+        }
     }
 
     _Fx& _Fn;
 };
 
 template <class _Fn>
-_INLINE_VAR constexpr bool _Pass_functor_by_value_v = conjunction_v<bool_constant<sizeof(_Fn) <= 4 * sizeof(void*)>,
+_INLINE_VAR constexpr bool _Pass_functor_by_value_v = conjunction_v<bool_constant<sizeof(_Fn) <= sizeof(void*)>,
     is_trivially_copy_constructible<_Fn>, is_trivially_destructible<_Fn>>;
 
 template <class _Fn, enable_if_t<_Pass_functor_by_value_v<_Fn>, int> = 0> // TRANSITION, if constexpr

--- a/tests/std/tests/P0896R4_ranges_algorithm_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_algorithm_machinery/test.cpp
@@ -807,31 +807,50 @@ namespace gh_1089 {
     // could call with `()` and not a pointer-to-member that requires the `invoke` protocol.
 
     void test() {
-        struct Base {
-            virtual int purr() = 0;
-        };
+        {
+            struct Base {
+                virtual int purr() = 0;
+            };
 
-        struct Derived1 : virtual Base {
-            int purr() override {
-                return 1729;
-            }
-        };
+            struct Derived1 : virtual Base {
+                int purr() override {
+                    return 1729;
+                }
+            };
 
-        struct Derived2 : virtual Base {};
+            struct Derived2 : virtual Base {};
 
-        struct MostDerived : Derived1, Derived2 {
-            int purr() override {
-                return 2020;
-            }
-        };
+            struct MostDerived : Derived1, Derived2 {
+                int purr() override {
+                    return 2020;
+                }
+            };
 
-        STATIC_ASSERT(sizeof(&Derived1::purr) == 3 * sizeof(void*)); // NB: relies on non-portable platform properties
 
-        Derived1 a[2];
-        MostDerived b[3];
-        Derived1* pointers[] = {&b[0], &a[0], &b[1], &a[1], &b[2]};
+            STATIC_ASSERT(sizeof(&Derived1::purr) > sizeof(void*)); // NB: relies on non-portable platform properties
 
-        (void) ranges::count(pointers, 1729, &Derived1::purr);
-        (void) ranges::count(pointers, 2020, &Derived1::purr);
+            Derived1 a[2];
+            MostDerived b[3];
+            Derived1* pointers[] = {&b[0], &a[0], &b[1], &a[1], &b[2]};
+
+            (void) ranges::count(pointers, 2020, &Derived1::purr);
+        }
+        {
+            struct Cat;
+
+            using PMD_Cat = int Cat::*;
+            // Quantum effects: we must observe the size before defining Cat or it will become smaller.
+            STATIC_ASSERT(sizeof(PMD_Cat) > sizeof(void*));
+
+            struct Cat {
+                int x = 42;
+            };
+
+            STATIC_ASSERT(sizeof(&Cat::x) > sizeof(void*)); // NB: relies on non-portable platform properties
+
+            Cat cats[42];
+
+            (void) ranges::count(cats, 42, &Cat::x);
+        }
     }
 } // namespace gh_1089


### PR DESCRIPTION
`_Pass_fn` returns a copy of arguments no larger than `void*`, and a call-forwarding reference-wrapper-alike `_Ref_fn` for larger function objects. This became a problem when Ranges started throwing pointers-to-member at `_Pass_fn` with the expectation that they would eventually be `invoke`d: pointers-to-member can be larger than `void*`, but `_Ref_fn` doesn't speak the `invoke` protocol.

There are two relatively obvious possible fixes:
1. Teach `_Pass_fn` to always return copies of pointers-to-member regardless of size
2. Teach `_Ref_fn` to obey the `invoke` protocol

(1) results in "large" pointers-to-member that can't be enregistered being copied and passed by hidden reference resulting in larger codesize than (2), but with no corresponding performance benefits. We therefore implement (2) by teaching `_Ref_fn` to call-forward through `invoke` when it wraps a pointer-to-member.

Fixes GH-1089.
