### PR TITLE
Implement ranges::ref_view

### DIFF
--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -29,6 +29,69 @@ namespace ranges {
     template <class _Rng>
     concept viewable_range = range<_Rng>
         && (borrowed_range<_Rng> || view<remove_cvref_t<_Rng>>);
+
+
+    // CLASS ranges::ref_view
+    // clang-format off
+    template <range _Rng>
+        requires is_object_v<_Rng>
+    class ref_view : public view_interface<ref_view<_Rng>> {
+        // clang-format on
+        void _Rvalue_poison(_Rng&);
+        void _Rvalue_poison(_Rng&&) = delete;
+
+    public:
+        constexpr ref_view() noexcept = default;
+
+        // clang-format off
+        template <_Not_same_as<ref_view> _OtherRng>
+        //     requires convertible_to<_OtherRng, _Rng&> && requires { _Rvalue_poison(declval<_OtherRng>()); }
+        constexpr ref_view(_OtherRng&& _Range)
+            // clang-format on
+            : _Myrange(_STD addressof(static_cast<_Rng&>(_STD forward<_OtherRng>(_Range)))) {}
+
+        constexpr _Rng& base() const {
+            return *_Myrange;
+        }
+
+        constexpr iterator_t<_Rng> begin() const {
+            return _RANGES begin(*_Myrange);
+        }
+
+        constexpr sentinel_t<_Rng> end() const {
+            return _RANGES end(*_Myrange);
+        }
+
+        // clang-format off
+        constexpr bool empty() const
+            requires _Can_empty<_Rng>
+        {
+            // clang-format on
+            return _RANGES empty(*_Myrange);
+        }
+
+        // clang-format off
+        constexpr auto size() const
+            requires sized_range<_Rng>
+        // clang-format on
+        {
+            return _RANGES size(*_Myrange);
+        }
+
+        // clang-format off
+        constexpr auto data() const
+            requires contiguous_range<_Rng>
+        // clang-format on
+        {
+            return _RANGES data(*_Myrange);
+        }
+
+    private:
+        _Rng* _Myrange = nullptr;
+    };
+
+    template <class _Rng>
+    ref_view(_Rng&) -> ref_view<_Rng>;
 } // namespace ranges
 
 _STD_END

--- a/tests/std/test.lst
+++ b/tests/std/test.lst
@@ -301,6 +301,7 @@ tests\P0896R4_ranges_alg_unique
 tests\P0896R4_ranges_alg_unique_copy
 tests\P0896R4_ranges_iterator_machinery
 tests\P0896R4_ranges_range_machinery
+tests\P0896R4_ranges_ref_view
 tests\P0896R4_ranges_subrange
 tests\P0896R4_ranges_test_machinery
 tests\P0896R4_ranges_to_address

--- a/tests/std/tests/P0896R4_ranges_ref_view/env.lst
+++ b/tests/std/tests/P0896R4_ranges_ref_view/env.lst
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+RUNALL_INCLUDE ..\concepts_matrix.lst

--- a/tests/std/tests/P0896R4_ranges_ref_view/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_ref_view/test.cpp
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <concepts>
+#include <ranges>
+#include <span>
+
+#include <range_algorithm_support.hpp>
+using namespace std;
+
+struct instantiator {
+    static constexpr int input[3] = {0, 1, 2};
+
+    template <ranges::input_range Read>
+    static constexpr void call() {
+        using ranges::ref_view, ranges::iterator_t, ranges::sentinel_t, ranges::equal, ranges::begin, ranges::end;
+
+        { // constructors
+            [[maybe_unused]] ref_view<Read> default_constructed{};
+
+            Read wrapped_input{input};
+            [[maybe_unused]] ref_view<Read> same_range{wrapped_input};
+        }
+
+        { // access
+            Read wrapped_input{input};
+            ref_view<Read> test_view{wrapped_input};
+            auto& base_range = test_view.base();
+            STATIC_ASSERT(same_as<decltype(base_range), Read&>);
+            if constexpr (ranges::forward_range<Read>) {
+                assert(equal(base_range, wrapped_input));
+            }
+        }
+
+        { // iterators
+            Read wrapped_input{input};
+            ref_view<Read> test_view{wrapped_input};
+            const same_as<iterator_t<Read>> auto begin_iterator = test_view.begin();
+            if constexpr (ranges::forward_range<Read>) {
+                assert(begin_iterator == begin(wrapped_input));
+            }
+
+            const same_as<sentinel_t<Read>> auto end_iterator = test_view.end();
+            if constexpr (ranges::forward_range<Read>) {
+                assert(end_iterator.peek() == end(wrapped_input).peek());
+            }
+        }
+
+        { // state
+            if constexpr (ranges::sized_range<Read>) {
+                Read wrapped_input{input};
+                ref_view<Read> test_view{wrapped_input};
+
+                const same_as<ranges::range_size_t<Read>> auto ref_size = test_view.size();
+                assert(ref_size == size(wrapped_input));
+            }
+
+            if constexpr (ranges::contiguous_range<Read>) {
+                Read wrapped_input{input};
+                ref_view<Read> test_view{wrapped_input};
+
+                const same_as<const int*> auto ref_data = test_view.data();
+                assert(ref_data == input);
+            }
+
+            span<const int, 3> spanInput{input};
+            ref_view span_view{spanInput};
+
+            const same_as<bool> auto ref_empty = span_view.empty();
+            assert(!ref_empty);
+        }
+    }
+};
+
+int main() {
+    STATIC_ASSERT((test_in<instantiator, const int>(), true));
+    test_in<instantiator, const int>();
+}


### PR DESCRIPTION
This implements `ranges::ref_view` which is a precursor for most other range adaptors.

NOTE: I need to come up with a reasonably simple test for the converting onstructor from a different range.

@CaseyCarter: Should we add `empty` to `test::range`?