### PR TITLE
Implement ranges::uninitialized_move

### DIFF
--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -94,10 +94,6 @@ struct _Optimistic_temporary_buffer { // temporary storage with _alloca-like att
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    // CONCEPT _Convertible_from
-    template <class _To, class _From>
-    concept _Convertible_from = convertible_to<_From, _To>;
-
 #ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunknown-attributes"
@@ -134,23 +130,6 @@ namespace ranges {
         template <_Convertible_from<_In1> _IIn1, _Convertible_from<_In2> _IIn2>
         constexpr operator in_in_result<_IIn1, _IIn2>() && {
             return {_STD move(in1), _STD move(in2)};
-        }
-    };
-
-    // STRUCT TEMPLATE in_out_result
-    template <class _In, class _Out>
-    struct in_out_result {
-        [[no_unique_address]] _In in;
-        [[no_unique_address]] _Out out;
-
-        template <_Convertible_from<const _In&> _IIn, _Convertible_from<const _Out&> _OOut>
-        constexpr operator in_out_result<_IIn, _OOut>() const& {
-            return {in, out};
-        }
-
-        template <_Convertible_from<_In> _IIn, _Convertible_from<_Out> _OOut>
-        constexpr operator in_out_result<_IIn, _OOut>() && {
-            return {_STD move(in), _STD move(out)};
         }
     };
 

--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -120,8 +120,7 @@ namespace ranges {
         // clang-format off
         template <input_iterator _It1, sentinel_for<_It1> _Se1, _No_throw_forward_iterator _It2, _No_throw_sentinel_for<_It2> _Se2>
             requires constructible_from<iter_value_t<_It2>, iter_rvalue_reference_t<_It1>>
-        /* _CONSTEXPR20_DYNALLOC */ uninitialized_move_result<_It1, _It2> operator()(
-            _It1 _First1, _Se1 _Last1, _It2 _First2, _Se2 _Last2) const {
+        uninitialized_move_result<_It1, _It2> operator()(_It1 _First1, _Se1 _Last1, _It2 _First2, _Se2 _Last2) const {
             // clang-format on
             _Adl_verify_range(_First1, _Last1);
             _Adl_verify_range(_First2, _Last2);
@@ -137,8 +136,8 @@ namespace ranges {
         // clang-format off
         template <input_range _Rng1, _No_throw_forward_range _Rng2>
             requires constructible_from<range_value_t<_Rng2>, range_rvalue_reference_t<_Rng1>>
-        /* _CONSTEXPR20_DYNALLOC */ uninitialized_move_result<borrowed_iterator_t<_Rng1>, borrowed_iterator_t<_Rng2>>
-            operator()(_Rng1&& _Range1, _Rng2&& _Range2) const {
+        uninitialized_move_result<borrowed_iterator_t<_Rng1>, borrowed_iterator_t<_Rng2>> operator()(
+            _Rng1&& _Range1, _Rng2&& _Range2) const {
             // clang-format on
             auto _First1  = _RANGES begin(_Range1);
             auto _UResult = _RANGES _Uninitialized_move_unchecked(

--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -187,9 +187,7 @@ namespace ranges {
                 _Backout._Emplace_back(_RANGES iter_move(_IFirst));
             }
 
-            _OFirst = _STD move(_Backout._Last);
-            _Backout._Release();
-            return {_STD move(_IFirst), _STD move(_OFirst)};
+            return {_STD move(_IFirst), _Backout._Release()};
         }
     };
 

--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -97,6 +97,62 @@ _NoThrowFwdIt uninitialized_move(const _InIt _First, const _InIt _Last, _NoThrow
     return _Dest;
 }
 
+#ifdef __cpp_lib_concepts
+namespace ranges {
+    // clang-format off
+    // CONCEPT _No_throw_input_range
+    template <class _Rng>
+    concept _No_throw_input_range = range<_Rng>
+        && _No_throw_input_iterator<iterator_t<_Rng>>
+        && _No_throw_sentinel_for<sentinel_t<_Rng>, iterator_t<_Rng>>;
+
+    // CONCEPT _No_throw_forward_range
+    template <class _Rng>
+    concept _No_throw_forward_range = _No_throw_input_range<_Rng>
+        && _No_throw_forward_iterator<iterator_t<_Rng>>;
+    // clang-format on
+
+    // VARIABLE ranges::uninitialized_move
+    class _Uninitialized_move_fn : private _Not_quite_object {
+    public:
+        using _Not_quite_object::_Not_quite_object;
+
+        // clang-format off
+        template <input_iterator _It1, sentinel_for<_It1> _Se1, _No_throw_forward_iterator _It2, _No_throw_sentinel_for<_It2> _Se2>
+            requires constructible_from<iter_value_t<_It2>, iter_rvalue_reference_t<_It1>>
+        /* _CONSTEXPR20_DYNALLOC */ uninitialized_move_result<_It1, _It2> operator()(
+            _It1 _First1, _Se1 _Last1, _It2 _First2, _Se2 _Last2) const {
+            // clang-format on
+            _Adl_verify_range(_First1, _Last1);
+            _Adl_verify_range(_First2, _Last2);
+            auto _UResult = _RANGES _Uninitialized_move_unchecked(_Get_unwrapped(_STD move(_First1)),
+                _Get_unwrapped(_STD move(_Last1)), _Get_unwrapped(_STD move(_First2)),
+                _Get_unwrapped(_STD move(_Last2)));
+
+            _Seek_wrapped(_First1, _STD move(_UResult.in));
+            _Seek_wrapped(_First2, _STD move(_UResult.out));
+            return {_STD move(_First1), _STD move(_First2)};
+        }
+
+        // clang-format off
+        template <input_range _Rng1, _No_throw_forward_range _Rng2>
+            requires constructible_from<range_value_t<_Rng2>, range_rvalue_reference_t<_Rng1>>
+        /* _CONSTEXPR20_DYNALLOC */ uninitialized_move_result<borrowed_iterator_t<_Rng1>, borrowed_iterator_t<_Rng2>>
+            operator()(_Rng1&& _Range1, _Rng2&& _Range2) const {
+            // clang-format on
+            auto _First1  = _RANGES begin(_Range1);
+            auto _UResult = _RANGES _Uninitialized_move_unchecked(
+                _Get_unwrapped(_STD move(_First1)), _Uend(_Range1), _Ubegin(_Range2), _Uend(_Range2));
+
+            _Seek_wrapped(_First1, _STD move(_UResult.in));
+            return {_STD move(_First1), _Rewrap_iterator(_Range2, _STD move(_UResult.out))};
+        }
+    };
+
+    inline constexpr _Uninitialized_move_fn uninitialized_move{_Not_quite_object::_Construct_tag{}};
+} // namespace ranges
+#endif // __cpp_lib_concepts
+
 // FUNCTION TEMPLATE uninitialized_move_n
 template <class _InIt, class _Diff, class _NoThrowFwdIt>
 pair<_InIt, _NoThrowFwdIt> uninitialized_move_n(_InIt _First, const _Diff _Count_raw, _NoThrowFwdIt _Dest) {

--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -26,6 +26,39 @@ _STL_DISABLE_CLANG_WARNINGS
 #undef new
 
 _STD_BEGIN
+#ifdef __cpp_lib_concepts
+namespace ranges {
+    // clang-format off
+    // CONCEPT _No_throw_input_iterator
+    template <class _It>
+    concept _No_throw_input_iterator = input_iterator<_It>
+        && is_lvalue_reference_v<iter_reference_t<_It>>
+        && same_as<remove_cvref_t<iter_reference_t<_It>>, iter_value_t<_It>>;
+
+    // CONCEPT _No_throw_sentinel_for
+    template <class _Se, class _It>
+    concept _No_throw_sentinel_for = sentinel_for<_Se, _It>;
+
+    // CONCEPT _No_throw_forward_iterator
+    template <class _It>
+    concept _No_throw_forward_iterator = _No_throw_input_iterator<_It>
+        && forward_iterator<_It>
+        && _No_throw_sentinel_for<_It, _It>;
+
+    // CONCEPT _No_throw_input_range
+    template <class _Rng>
+    concept _No_throw_input_range = range<_Rng>
+        && _No_throw_input_iterator<iterator_t<_Rng>>
+        && _No_throw_sentinel_for<sentinel_t<_Rng>, iterator_t<_Rng>>;
+
+    // CONCEPT _No_throw_forward_range
+    template <class _Rng>
+    concept _No_throw_forward_range = _No_throw_input_range<_Rng>
+        && _No_throw_forward_iterator<iterator_t<_Rng>>;
+    // clang-format on
+} // namespace ranges
+#endif // __cpp_lib_concepts
+
 // FUNCTION TEMPLATE uninitialized_copy_n
 #if _HAS_IF_CONSTEXPR
 template <class _InIt, class _Diff, class _NoThrowFwdIt>
@@ -99,18 +132,9 @@ _NoThrowFwdIt uninitialized_move(const _InIt _First, const _InIt _Last, _NoThrow
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    // clang-format off
-    // CONCEPT _No_throw_input_range
-    template <class _Rng>
-    concept _No_throw_input_range = range<_Rng>
-        && _No_throw_input_iterator<iterator_t<_Rng>>
-        && _No_throw_sentinel_for<sentinel_t<_Rng>, iterator_t<_Rng>>;
-
-    // CONCEPT _No_throw_forward_range
-    template <class _Rng>
-    concept _No_throw_forward_range = _No_throw_input_range<_Rng>
-        && _No_throw_forward_iterator<iterator_t<_Rng>>;
-    // clang-format on
+    // ALIAS TEMPLATE uninitialized_move_result
+    template <class _In, class _Out>
+    using uninitialized_move_result = in_out_result<_In, _Out>;
 
     // VARIABLE ranges::uninitialized_move
     class _Uninitialized_move_fn : private _Not_quite_object {
@@ -124,9 +148,9 @@ namespace ranges {
             // clang-format on
             _Adl_verify_range(_First1, _Last1);
             _Adl_verify_range(_First2, _Last2);
-            auto _UResult = _RANGES _Uninitialized_move_unchecked(_Get_unwrapped(_STD move(_First1)),
-                _Get_unwrapped(_STD move(_Last1)), _Get_unwrapped(_STD move(_First2)),
-                _Get_unwrapped(_STD move(_Last2)));
+            auto _UResult =
+                _Uninitialized_move_unchecked(_Get_unwrapped(_STD move(_First1)), _Get_unwrapped(_STD move(_Last1)),
+                    _Get_unwrapped(_STD move(_First2)), _Get_unwrapped(_STD move(_Last2)));
 
             _Seek_wrapped(_First1, _STD move(_UResult.in));
             _Seek_wrapped(_First2, _STD move(_UResult.out));
@@ -140,11 +164,32 @@ namespace ranges {
             _Rng1&& _Range1, _Rng2&& _Range2) const {
             // clang-format on
             auto _First1  = _RANGES begin(_Range1);
-            auto _UResult = _RANGES _Uninitialized_move_unchecked(
+            auto _UResult = _Uninitialized_move_unchecked(
                 _Get_unwrapped(_STD move(_First1)), _Uend(_Range1), _Ubegin(_Range2), _Uend(_Range2));
 
             _Seek_wrapped(_First1, _STD move(_UResult.in));
             return {_STD move(_First1), _Rewrap_iterator(_Range2, _STD move(_UResult.out))};
+        }
+
+    private:
+        template <class _It1, class _Se1, class _It2, class _Se2>
+        _NODISCARD static uninitialized_move_result<_It1, _It2> _Uninitialized_move_unchecked(
+            _It1 _IFirst, const _Se1 _ILast, _It2 _OFirst, const _Se2 _OLast) {
+            _STL_INTERNAL_STATIC_ASSERT(input_iterator<_It1>);
+            _STL_INTERNAL_STATIC_ASSERT(sentinel_for<_Se1, _It1>);
+            _STL_INTERNAL_STATIC_ASSERT(_No_throw_forward_iterator<_It2>);
+            _STL_INTERNAL_STATIC_ASSERT(_No_throw_sentinel_for<_Se2, _It2>);
+            _STL_INTERNAL_STATIC_ASSERT(constructible_from<iter_value_t<_It2>, iter_rvalue_reference_t<_It1>>);
+
+            _Uninitialized_backout _Backout{_STD move(_OFirst)};
+
+            for (; _IFirst != _ILast && _Backout._Last != _OLast; ++_IFirst) {
+                _Backout._Emplace_back(_RANGES iter_move(_IFirst));
+            }
+
+            _OFirst = _STD move(_Backout._Last);
+            _Backout._Release();
+            return {_STD move(_IFirst), _STD move(_OFirst)};
         }
     };
 

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -263,9 +263,19 @@ _Pointer _Refancy(_Pointer _Ptr) noexcept {
 }
 
 // FUNCTION TEMPLATE _Destroy_in_place
+template <class _NoThrowFwdIt, class _NoThrowSentinel>
+/* _CONSTEXPR20_DYNALLOC */ void _Destroy_range(_NoThrowFwdIt _First, const _NoThrowSentinel _Last) noexcept;
+
 template <class _Ty>
-void _Destroy_in_place(_Ty& _Obj) noexcept {
-    _Obj.~_Ty();
+/* _CONSTEXPR20_DYNALLOC */ void _Destroy_in_place(_Ty& _Obj) noexcept {
+#if _HAS_IF_CONSTEXPR
+    if constexpr (is_array_v<_Ty>) {
+        _Destroy_range(_Obj, _Obj + extent_v<_Ty>);
+    } else
+#endif // _HAS_IF_CONSTEXPR
+    {
+        _Obj.~_Ty();
+    }
 }
 
 // FUNCTION TEMPLATE _Const_cast
@@ -948,7 +958,8 @@ void _Pocs(_Alloc& _Left, _Alloc& _Right) noexcept {
 
 // FUNCTION TEMPLATE _Destroy_range WITH ALLOC
 template <class _Alloc>
-void _Destroy_range(_Alloc_ptr_t<_Alloc> _First, const _Alloc_ptr_t<_Alloc> _Last, _Alloc& _Al) noexcept {
+/* _CONSTEXPR20_DYNALLOC */ void _Destroy_range(
+    _Alloc_ptr_t<_Alloc> _First, const _Alloc_ptr_t<_Alloc> _Last, _Alloc& _Al) noexcept {
     // note that this is an optimization for debug mode codegen; in release mode the BE removes all of this
     using _Ty = typename _Alloc::value_type;
     if _CONSTEXPR_IF (!conjunction_v<is_trivially_destructible<_Ty>, _Uses_default_destroy<_Alloc, _Ty*>>) {
@@ -959,8 +970,8 @@ void _Destroy_range(_Alloc_ptr_t<_Alloc> _First, const _Alloc_ptr_t<_Alloc> _Las
 }
 
 // FUNCTION TEMPLATE _Destroy_range
-template <class _NoThrowFwdIt>
-void _Destroy_range(_NoThrowFwdIt _First, const _NoThrowFwdIt _Last) noexcept {
+template <class _NoThrowFwdIt, class _NoThrowSentinel>
+/* _CONSTEXPR20_DYNALLOC */ void _Destroy_range(_NoThrowFwdIt _First, const _NoThrowSentinel _Last) noexcept {
     // note that this is an optimization for debug mode codegen; in release mode the BE removes all of this
     if _CONSTEXPR_IF (!is_trivially_destructible_v<_Iter_value_t<_NoThrowFwdIt>>) {
         for (; _First != _Last; ++_First) {
@@ -1414,24 +1425,25 @@ struct _Uninitialized_backout { // struct to undo partially constructed ranges i
     _NoThrowFwdIt _First;
     _NoThrowFwdIt _Last;
 
-    explicit _Uninitialized_backout(_NoThrowFwdIt _Dest) : _First(_Dest), _Last(_Dest) {}
+    constexpr explicit _Uninitialized_backout(_NoThrowFwdIt _Dest) : _First(_Dest), _Last(_Dest) {}
 
-    _Uninitialized_backout(_NoThrowFwdIt _First_, _NoThrowFwdIt _Last_) : _First(_First_), _Last(_Last_) {}
+    constexpr _Uninitialized_backout(_NoThrowFwdIt _First_, _NoThrowFwdIt _Last_) : _First(_First_), _Last(_Last_) {}
 
     _Uninitialized_backout(const _Uninitialized_backout&) = delete;
     _Uninitialized_backout& operator=(const _Uninitialized_backout&) = delete;
 
-    ~_Uninitialized_backout() {
+    /* _CONSTEXPR20_DYNALLOC */ ~_Uninitialized_backout() {
         _Destroy_range(_First, _Last);
     }
 
     template <class... _Types>
-    void _Emplace_back(_Types&&... _Vals) { // construct a new element at *_Last and increment
+    /* _CONSTEXPR20_DYNALLOC */ void _Emplace_back(_Types&&... _Vals) {
+        // construct a new element at *_Last and increment
         _Construct_in_place(*_Last, _STD forward<_Types>(_Vals)...);
         ++_Last;
     }
 
-    _NoThrowFwdIt _Release() { // suppress any exception handling backout and return _Last
+    /* _CONSTEXPR20_DYNALLOC */ _NoThrowFwdIt _Release() { // suppress any exception handling backout and return _Last
         _First = _Last;
         return _Last;
     }
@@ -1479,6 +1491,81 @@ _NoThrowFwdIt _Uninitialized_move_unchecked(_InIt _First, const _InIt _Last, _No
         _First, _Last, _Dest, bool_constant<_Ptr_move_cat<_InIt, _NoThrowFwdIt>::_Really_trivial>{});
 }
 #endif // _HAS_IF_CONSTEXPR
+
+#ifdef __cpp_lib_concepts
+namespace ranges {
+    // CONCEPT _Convertible_from
+    template <class _To, class _From>
+    concept _Convertible_from = convertible_to<_From, _To>;
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunknown-attributes"
+#endif // __clang__
+
+    // STRUCT TEMPLATE in_out_result
+    template <class _In, class _Out>
+    struct in_out_result {
+        [[no_unique_address]] _In in;
+        [[no_unique_address]] _Out out;
+
+        template <_Convertible_from<const _In&> _IIn, _Convertible_from<const _Out&> _OOut>
+        constexpr operator in_out_result<_IIn, _OOut>() const& {
+            return {in, out};
+        }
+
+        template <_Convertible_from<_In> _IIn, _Convertible_from<_Out> _OOut>
+        constexpr operator in_out_result<_IIn, _OOut>() && {
+            return {_STD move(in), _STD move(out)};
+        }
+    };
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif // __clang__
+
+    // clang-format off
+    // CONCEPT _No_throw_input_iterator
+    template <class _It>
+    concept _No_throw_input_iterator = input_iterator<_It>
+        && is_lvalue_reference_v<iter_reference_t<_It>>
+        && same_as<remove_cvref_t<iter_reference_t<_It>>, iter_value_t<_It>>;
+
+    // CONCEPT _No_throw_sentinel_for
+    template <class _Se, class _It>
+    concept _No_throw_sentinel_for = sentinel_for<_Se, _It>;
+
+    // CONCEPT _No_throw_forward_iterator
+    template <class _It>
+    concept _No_throw_forward_iterator = _No_throw_input_iterator<_It>
+        && forward_iterator<_It>
+        && _No_throw_sentinel_for<_It, _It>;
+    // clang-format on
+
+    // ALIAS TEMPLATE uninitialized_move_result
+    template <class _In, class _Out>
+    using uninitialized_move_result = in_out_result<_In, _Out>;
+
+    // FUNCTION TEMPLATE ranges::_Uninitialized_move_unchecked
+    // clang-format off
+    template <input_iterator _It1, sentinel_for<_It1> _Se1, _No_throw_forward_iterator _It2,
+        _No_throw_sentinel_for<_It2> _Se2>
+        requires constructible_from<iter_value_t<_It2>, iter_rvalue_reference_t<_It1>>
+    _NODISCARD /* _CONSTEXPR20_DYNALLOC */ uninitialized_move_result<_It1, _It2> _Uninitialized_move_unchecked(
+        _It1 _IFirst, const _Se1 _ILast, _It2 _OFirst, const _Se2 _OLast) {
+        // clang-format on
+        _Uninitialized_backout _Backout{_STD move(_OFirst)};
+
+        for (; _IFirst != _ILast && _Backout._Last != _OLast; ++_IFirst) {
+            _Backout._Emplace_back(_RANGES iter_move(_IFirst));
+        }
+
+        _OFirst = _STD move(_Backout._Last);
+        _Backout._Release();
+        return {_STD move(_IFirst), _STD move(_OFirst)};
+    }
+} // namespace ranges
+#endif // __cpp_lib_concepts
 
 // STRUCT TEMPLATE _Uninitialized_backout_al
 template <class _Alloc>

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -264,7 +264,7 @@ _Pointer _Refancy(_Pointer _Ptr) noexcept {
 
 // FUNCTION TEMPLATE _Destroy_in_place
 template <class _NoThrowFwdIt, class _NoThrowSentinel>
-/* _CONSTEXPR20_DYNALLOC */ void _Destroy_range(_NoThrowFwdIt _First, const _NoThrowSentinel _Last) noexcept;
+/* _CONSTEXPR20_DYNALLOC */ void _Destroy_range(_NoThrowFwdIt _First, _NoThrowSentinel _Last) noexcept;
 
 template <class _Ty>
 /* _CONSTEXPR20_DYNALLOC */ void _Destroy_in_place(_Ty& _Obj) noexcept {

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -1449,6 +1449,40 @@ struct _Uninitialized_backout { // struct to undo partially constructed ranges i
     }
 };
 
+#ifdef __cpp_lib_concepts
+namespace ranges {
+    // CONCEPT _Convertible_from
+    template <class _To, class _From>
+    concept _Convertible_from = convertible_to<_From, _To>;
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunknown-attributes"
+#endif // __clang__
+
+    // STRUCT TEMPLATE in_out_result
+    template <class _In, class _Out>
+    struct in_out_result {
+        [[no_unique_address]] _In in;
+        [[no_unique_address]] _Out out;
+
+        template <_Convertible_from<const _In&> _IIn, _Convertible_from<const _Out&> _OOut>
+        constexpr operator in_out_result<_IIn, _OOut>() const& {
+            return {in, out};
+        }
+
+        template <_Convertible_from<_In> _IIn, _Convertible_from<_Out> _OOut>
+        constexpr operator in_out_result<_IIn, _OOut>() && {
+            return {_STD move(in), _STD move(out)};
+        }
+    };
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif // __clang__
+} // namespace ranges
+#endif // __cpp_lib_concepts
+
 // FUNCTION TEMPLATE _Uninitialized_move_unchecked
 #if _HAS_IF_CONSTEXPR
 template <class _InIt, class _NoThrowFwdIt>
@@ -1491,40 +1525,6 @@ _NoThrowFwdIt _Uninitialized_move_unchecked(_InIt _First, const _InIt _Last, _No
         _First, _Last, _Dest, bool_constant<_Ptr_move_cat<_InIt, _NoThrowFwdIt>::_Really_trivial>{});
 }
 #endif // _HAS_IF_CONSTEXPR
-
-#ifdef __cpp_lib_concepts
-namespace ranges {
-    // CONCEPT _Convertible_from
-    template <class _To, class _From>
-    concept _Convertible_from = convertible_to<_From, _To>;
-
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunknown-attributes"
-#endif // __clang__
-
-    // STRUCT TEMPLATE in_out_result
-    template <class _In, class _Out>
-    struct in_out_result {
-        [[no_unique_address]] _In in;
-        [[no_unique_address]] _Out out;
-
-        template <_Convertible_from<const _In&> _IIn, _Convertible_from<const _Out&> _OOut>
-        constexpr operator in_out_result<_IIn, _OOut>() const& {
-            return {in, out};
-        }
-
-        template <_Convertible_from<_In> _IIn, _Convertible_from<_Out> _OOut>
-        constexpr operator in_out_result<_IIn, _OOut>() && {
-            return {_STD move(in), _STD move(out)};
-        }
-    };
-
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif // __clang__
-} // namespace ranges
-#endif // __cpp_lib_concepts
 
 // STRUCT TEMPLATE _Uninitialized_backout_al
 template <class _Alloc>

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -1523,47 +1523,6 @@ namespace ranges {
 #ifdef __clang__
 #pragma clang diagnostic pop
 #endif // __clang__
-
-    // clang-format off
-    // CONCEPT _No_throw_input_iterator
-    template <class _It>
-    concept _No_throw_input_iterator = input_iterator<_It>
-        && is_lvalue_reference_v<iter_reference_t<_It>>
-        && same_as<remove_cvref_t<iter_reference_t<_It>>, iter_value_t<_It>>;
-
-    // CONCEPT _No_throw_sentinel_for
-    template <class _Se, class _It>
-    concept _No_throw_sentinel_for = sentinel_for<_Se, _It>;
-
-    // CONCEPT _No_throw_forward_iterator
-    template <class _It>
-    concept _No_throw_forward_iterator = _No_throw_input_iterator<_It>
-        && forward_iterator<_It>
-        && _No_throw_sentinel_for<_It, _It>;
-    // clang-format on
-
-    // ALIAS TEMPLATE uninitialized_move_result
-    template <class _In, class _Out>
-    using uninitialized_move_result = in_out_result<_In, _Out>;
-
-    // FUNCTION TEMPLATE ranges::_Uninitialized_move_unchecked
-    // clang-format off
-    template <input_iterator _It1, sentinel_for<_It1> _Se1, _No_throw_forward_iterator _It2,
-        _No_throw_sentinel_for<_It2> _Se2>
-        requires constructible_from<iter_value_t<_It2>, iter_rvalue_reference_t<_It1>>
-    _NODISCARD /* _CONSTEXPR20_DYNALLOC */ uninitialized_move_result<_It1, _It2> _Uninitialized_move_unchecked(
-        _It1 _IFirst, const _Se1 _ILast, _It2 _OFirst, const _Se2 _OLast) {
-        // clang-format on
-        _Uninitialized_backout _Backout{_STD move(_OFirst)};
-
-        for (; _IFirst != _ILast && _Backout._Last != _OLast; ++_IFirst) {
-            _Backout._Emplace_back(_RANGES iter_move(_IFirst));
-        }
-
-        _OFirst = _STD move(_Backout._Last);
-        _Backout._Release();
-        return {_STD move(_IFirst), _STD move(_OFirst)};
-    }
 } // namespace ranges
 #endif // __cpp_lib_concepts
 

--- a/tests/std/include/range_algorithm_support.hpp
+++ b/tests/std/include/range_algorithm_support.hpp
@@ -415,8 +415,7 @@ namespace test {
             ++ptr_;
         }
 
-        [[nodiscard]] constexpr friend std::remove_cv_t<Element> iter_move(iterator const& i)
-            requires at_least<input> && std::constructible_from<std::remove_cv_t<Element>, Element> {
+        [[nodiscard]] constexpr friend Element&& iter_move(iterator const& i) requires at_least<input> {
             return std::move(*i.ptr_);
         }
 

--- a/tests/std/test.lst
+++ b/tests/std/test.lst
@@ -297,6 +297,7 @@ tests\P0896R4_ranges_alg_shuffle
 tests\P0896R4_ranges_alg_swap_ranges
 tests\P0896R4_ranges_alg_transform_binary
 tests\P0896R4_ranges_alg_transform_unary
+tests\P0896R4_ranges_alg_uninitialized_move
 tests\P0896R4_ranges_alg_unique
 tests\P0896R4_ranges_alg_unique_copy
 tests\P0896R4_ranges_iterator_machinery

--- a/tests/std/tests/P0896R4_ranges_alg_uninitialized_move/env.lst
+++ b/tests/std/tests/P0896R4_ranges_alg_uninitialized_move/env.lst
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+RUNALL_INCLUDE ..\concepts_matrix.lst

--- a/tests/std/tests/P0896R4_ranges_alg_uninitialized_move/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_uninitialized_move/test.cpp
@@ -1,0 +1,211 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <algorithm>
+#include <cassert>
+#include <concepts>
+#include <memory>
+#include <ranges>
+#include <span>
+#include <utility>
+
+#include <range_algorithm_support.hpp>
+
+using namespace std;
+
+#ifndef _CONSTEXPR20_DYNALLOC // TRANSITION, P0784
+#define _CONSTEXPR20_DYNALLOC
+#endif
+
+// Validate that uninitialized_move_result aliases in_out_result
+STATIC_ASSERT(same_as<ranges::uninitialized_move_result<int, double>, ranges::in_out_result<int, double>>);
+
+// Validate dangling story
+STATIC_ASSERT(same_as<decltype(ranges::uninitialized_move(borrowed<false>{}, borrowed<false>{})),
+    ranges::uninitialized_move_result<ranges::dangling, ranges::dangling>>);
+STATIC_ASSERT(same_as<decltype(ranges::uninitialized_move(borrowed<false>{}, borrowed<true>{})),
+    ranges::uninitialized_move_result<ranges::dangling, int*>>);
+STATIC_ASSERT(same_as<decltype(ranges::uninitialized_move(borrowed<true>{}, borrowed<false>{})),
+    ranges::uninitialized_move_result<int*, ranges::dangling>>);
+STATIC_ASSERT(same_as<decltype(ranges::uninitialized_move(borrowed<true>{}, borrowed<true>{})),
+    ranges::uninitialized_move_result<int*, int*>>);
+
+struct int_wrapper {
+    inline static int constructions = 0;
+    inline static int destructions  = 0;
+
+    static constexpr void clear_counts() {
+        if (!is_constant_evaluated()) {
+            constructions = destructions = 0;
+        }
+    }
+
+    static constexpr int magic_throwing_val = 29;
+    int val                                 = 10;
+
+    constexpr int_wrapper() {
+        if (!is_constant_evaluated()) {
+            ++constructions;
+        }
+    }
+    constexpr int_wrapper(int x) : val{x} {
+        if (!is_constant_evaluated()) {
+            ++constructions;
+        }
+    }
+    constexpr int_wrapper(int_wrapper&& that) {
+        if (that.val == magic_throwing_val) {
+            throw magic_throwing_val;
+        }
+
+        val = exchange(that.val, -1);
+        if (!is_constant_evaluated()) {
+            ++constructions;
+        }
+    }
+
+    _CONSTEXPR20_DYNALLOC ~int_wrapper() {
+        if (!is_constant_evaluated()) {
+            ++destructions;
+        }
+    }
+
+    constexpr int_wrapper& operator=(int_wrapper&& that) {
+        if (that.val == magic_throwing_val) {
+            throw magic_throwing_val;
+        }
+        val = exchange(that.val, -1);
+        return *this;
+    }
+
+    auto operator<=>(const int_wrapper&) const = default;
+};
+STATIC_ASSERT(movable<int_wrapper> && !copyable<int_wrapper>);
+
+template <class T, size_t N>
+struct holder {
+    T* ptr = allocator<T>{}.allocate(N);
+
+    holder()              = default;
+    holder(const holder&) = delete;
+    holder& operator=(const holder&) = delete;
+
+    _CONSTEXPR20_DYNALLOC ~holder() {
+        allocator<T>{}.deallocate(ptr, N);
+    }
+
+    constexpr auto as_span() const noexcept {
+        return span<T, N>{ptr, N};
+    }
+};
+
+struct instantiator {
+    static constexpr int expected_output[] = {13, 55, 12345};
+    static constexpr int expected_input[]  = {-1, -1, -1};
+
+    template <ranges::input_range R, ranges::forward_range W>
+    static _CONSTEXPR20_DYNALLOC void call() {
+        using ranges::uninitialized_move, ranges::uninitialized_move_result, ranges::equal, ranges::iterator_t;
+
+        { // Validate range overload
+            int_wrapper input[3] = {13, 55, 12345};
+            int_wrapper::clear_counts();
+            R wrapped_input{input};
+            holder<int_wrapper, 3> mem;
+            W wrapped_output{mem.as_span()};
+
+            const same_as<uninitialized_move_result<iterator_t<R>, iterator_t<W>>> auto result =
+                uninitialized_move(wrapped_input, wrapped_output);
+            if (!is_constant_evaluated()) {
+                assert(int_wrapper::constructions == 3);
+                assert(int_wrapper::destructions == 0);
+            }
+            assert(result.in == wrapped_input.end());
+            assert(result.out == wrapped_output.end());
+            assert(equal(wrapped_output, expected_output, ranges::equal_to{}, &int_wrapper::val));
+            assert(equal(input, expected_input, ranges::equal_to{}, &int_wrapper::val));
+            ranges::destroy(wrapped_output);
+            if (!is_constant_evaluated()) {
+                assert(int_wrapper::constructions == 3);
+                assert(int_wrapper::destructions == 3);
+            }
+        }
+
+        { // Validate iterator overload
+            int_wrapper input[3] = {13, 55, 12345};
+            int_wrapper::clear_counts();
+            R wrapped_input{input};
+            holder<int_wrapper, 3> mem;
+            W wrapped_output{mem.as_span()};
+
+            const same_as<uninitialized_move_result<iterator_t<R>, iterator_t<W>>> auto result = uninitialized_move(
+                wrapped_input.begin(), wrapped_input.end(), wrapped_output.begin(), wrapped_output.end());
+            if (!is_constant_evaluated()) {
+                assert(int_wrapper::constructions == 3);
+                assert(int_wrapper::destructions == 0);
+            }
+            assert(result.in == wrapped_input.end());
+            assert(result.out == wrapped_output.end());
+            assert(equal(wrapped_output, expected_output, ranges::equal_to{}, &int_wrapper::val));
+            assert(equal(input, expected_input, ranges::equal_to{}, &int_wrapper::val));
+            ranges::destroy(wrapped_output);
+            if (!is_constant_evaluated()) {
+                assert(int_wrapper::constructions == 3);
+                assert(int_wrapper::destructions == 3);
+            }
+        }
+    }
+};
+
+struct throwing_test {
+    static constexpr int expected_input[] = {-1, -1, int_wrapper::magic_throwing_val, 12345};
+
+    template <ranges::input_range R, ranges::forward_range W>
+    static void call() {
+        using ranges::uninitialized_move, ranges::uninitialized_move_result, ranges::equal, ranges::iterator_t;
+        // Validate only range overload (one is plenty since they are backends)
+        int_wrapper input[] = {13, 55, int_wrapper::magic_throwing_val, 12345};
+        int_wrapper::clear_counts();
+        R wrapped_input{input};
+        holder<int_wrapper, 4> mem;
+        W wrapped_output{mem.as_span()};
+
+        try {
+            (void) uninitialized_move(wrapped_input, wrapped_output);
+            assert(false);
+        } catch (int i) {
+            assert(i == int_wrapper::magic_throwing_val);
+        } catch (...) {
+            assert(false);
+        }
+        assert(int_wrapper::constructions == 2);
+        assert(int_wrapper::destructions == 2);
+        assert(equal(input, expected_input, ranges::equal_to{}, &int_wrapper::val));
+    }
+};
+
+template <test::ProxyRef IsProxy>
+using test_input  = test::range<test::input, int_wrapper, test::Sized::no, test::CanDifference::no, test::Common::no,
+    test::CanCompare::yes, IsProxy>;
+using test_output = test::range<test::fwd, int_wrapper, test::Sized::no, test::CanDifference::no, test::Common::no,
+    test::CanCompare::yes, test::ProxyRef::no>;
+
+constexpr void run_tests() {
+    // The algorithm is oblivious to non-required category, size, difference, and requires non-proxy references for the
+    // output range.
+
+    if (!is_constant_evaluated()) { // TRANSITION, P0784
+        instantiator::call<test_input<test::ProxyRef::no>, test_output>();
+        instantiator::call<test_input<test::ProxyRef::yes>, test_output>();
+    }
+
+    if (!is_constant_evaluated()) {
+        throwing_test::call<test_input<test::ProxyRef::no>, test_output>();
+        throwing_test::call<test_input<test::ProxyRef::yes>, test_output>();
+    }
+}
+
+int main() {
+    STATIC_ASSERT((run_tests(), true));
+    run_tests();
+}

--- a/tests/std/tests/P0896R4_ranges_alg_uninitialized_move/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_uninitialized_move/test.cpp
@@ -81,7 +81,7 @@ struct holder {
 };
 
 template <class R>
-void not_ranges_destroy(R&& r) {
+void not_ranges_destroy(R&& r) { // TRANSITION, ranges::destroy
     for (auto& e : r) {
         destroy_at(&e);
     }

--- a/tests/std/tests/P0896R4_ranges_alg_uninitialized_move/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_uninitialized_move/test.cpp
@@ -172,7 +172,7 @@ using test_output = test::range<test::fwd, int_wrapper, test::Sized::no, test::C
 
 int main() {
     // The algorithm is oblivious to non-required category, size, difference, and "proxyness" of the input range. It
-    // _is_ sensitive to proxiness in that it requires non-proxy references for the output range.
+    // _is_ sensitive to proxyness in that it requires non-proxy references for the output range.
 
     instantiator::call<test_input<test::ProxyRef::no>, test_output>();
     instantiator::call<test_input<test::ProxyRef::yes>, test_output>();

--- a/tests/std/tests/P0896R4_ranges_algorithm_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_algorithm_machinery/test.cpp
@@ -6,6 +6,7 @@
 #include <concepts>
 #include <cstddef>
 #include <iterator>
+#include <memory>
 #include <ranges>
 #include <type_traits>
 #include <utility>
@@ -983,3 +984,128 @@ namespace gh_1089 {
         }
     }
 } // namespace gh_1089
+
+namespace special_memory_concepts {
+    // Validate the concepts from [special.mem.concepts] used to constrain the specialized memory algorithms
+    // NB: Non-portable tests of internal machinery
+    using ranges::_No_throw_input_iterator, ranges::_No_throw_sentinel_for, ranges::_No_throw_input_range,
+        ranges::_No_throw_forward_iterator, ranges::_No_throw_forward_range;
+    using std::forward_iterator, std::input_iterator, std::sentinel_for;
+
+    enum class iterator_status : int { not_input, not_lvalue_reference, different_reference_and_value, input, forward };
+
+    template <iterator_status I>
+    struct iterator_archetype {
+        using iterator_concept = std::conditional_t<I == iterator_status::not_input, std::output_iterator_tag,
+            std::conditional_t<I == iterator_status::forward, std::forward_iterator_tag, std::input_iterator_tag>>;
+        using difference_type  = int;
+        using value_type       = std::conditional_t<I == iterator_status::different_reference_and_value, long, int>;
+
+        // clang-format off
+        int operator*() const requires (I == iterator_status::not_lvalue_reference);
+        int& operator*() const requires (I != iterator_status::not_lvalue_reference);
+
+        iterator_archetype& operator++();
+        void operator++(int) requires (I != iterator_status::forward);
+        iterator_archetype operator++(int) requires (I == iterator_status::forward);
+
+        bool operator==(std::default_sentinel_t) const;
+        bool operator==(iterator_archetype const&) const requires (I == iterator_status::forward);
+        // clang-format on
+    };
+    // Verify iterator_archetype
+    STATIC_ASSERT(!input_iterator<iterator_archetype<iterator_status::not_input>>);
+    STATIC_ASSERT(input_iterator<iterator_archetype<iterator_status::not_lvalue_reference>>);
+    STATIC_ASSERT(input_iterator<iterator_archetype<iterator_status::different_reference_and_value>>);
+    STATIC_ASSERT(input_iterator<iterator_archetype<iterator_status::input>>);
+    STATIC_ASSERT(!forward_iterator<iterator_archetype<iterator_status::input>>);
+    STATIC_ASSERT(forward_iterator<iterator_archetype<iterator_status::forward>>);
+
+    template <class I>
+    inline constexpr bool has_lvalue_reference = std::is_lvalue_reference_v<std::iter_reference_t<I>>;
+    STATIC_ASSERT(has_lvalue_reference<iterator_archetype<iterator_status::not_input>>);
+    STATIC_ASSERT(!has_lvalue_reference<iterator_archetype<iterator_status::not_lvalue_reference>>);
+    STATIC_ASSERT(has_lvalue_reference<iterator_archetype<iterator_status::different_reference_and_value>>);
+    STATIC_ASSERT(has_lvalue_reference<iterator_archetype<iterator_status::input>>);
+    STATIC_ASSERT(has_lvalue_reference<iterator_archetype<iterator_status::forward>>);
+
+    template <class I>
+    inline constexpr bool same_reference_value =
+        std::same_as<std::remove_cvref_t<std::iter_reference_t<I>>, std::iter_value_t<I>>;
+    STATIC_ASSERT(same_reference_value<iterator_archetype<iterator_status::not_input>>);
+    STATIC_ASSERT(same_reference_value<iterator_archetype<iterator_status::not_lvalue_reference>>);
+    STATIC_ASSERT(!same_reference_value<iterator_archetype<iterator_status::different_reference_and_value>>);
+    STATIC_ASSERT(same_reference_value<iterator_archetype<iterator_status::input>>);
+    STATIC_ASSERT(same_reference_value<iterator_archetype<iterator_status::forward>>);
+
+    // Validate _No_throw_input_iterator
+    STATIC_ASSERT(!_No_throw_input_iterator<iterator_archetype<iterator_status::not_input>>);
+    STATIC_ASSERT(!_No_throw_input_iterator<iterator_archetype<iterator_status::not_lvalue_reference>>);
+    STATIC_ASSERT(!_No_throw_input_iterator<iterator_archetype<iterator_status::different_reference_and_value>>);
+    STATIC_ASSERT(_No_throw_input_iterator<iterator_archetype<iterator_status::input>>);
+    STATIC_ASSERT(_No_throw_input_iterator<iterator_archetype<iterator_status::forward>>);
+
+    enum class sentinel_status : int { not_sentinel, good };
+
+    template <sentinel_status I>
+    struct sentinel_archetype {
+        // clang-format off
+        template <iterator_status S>
+        bool operator==(iterator_archetype<S> const&) const requires (I != sentinel_status::not_sentinel);
+        // clang-format on
+    };
+    // Verify sentinel_archetype
+    STATIC_ASSERT(
+        !sentinel_for<sentinel_archetype<sentinel_status::not_sentinel>, iterator_archetype<iterator_status::input>>);
+    STATIC_ASSERT(sentinel_for<sentinel_archetype<sentinel_status::good>, iterator_archetype<iterator_status::input>>);
+
+    // Validate _No_throw_sentinel_for
+    STATIC_ASSERT(!_No_throw_sentinel_for<sentinel_archetype<sentinel_status::not_sentinel>,
+                  iterator_archetype<iterator_status::input>>);
+    STATIC_ASSERT(
+        _No_throw_sentinel_for<sentinel_archetype<sentinel_status::good>, iterator_archetype<iterator_status::input>>);
+    STATIC_ASSERT(!_No_throw_sentinel_for<iterator_archetype<iterator_status::input>,
+                  iterator_archetype<iterator_status::input>>);
+    STATIC_ASSERT(_No_throw_sentinel_for<iterator_archetype<iterator_status::forward>,
+        iterator_archetype<iterator_status::forward>>);
+
+    // Validate _No_throw_forward_iterator
+    STATIC_ASSERT(!_No_throw_forward_iterator<iterator_archetype<iterator_status::not_input>>);
+    STATIC_ASSERT(!_No_throw_forward_iterator<iterator_archetype<iterator_status::not_lvalue_reference>>);
+    STATIC_ASSERT(!_No_throw_forward_iterator<iterator_archetype<iterator_status::different_reference_and_value>>);
+    STATIC_ASSERT(!_No_throw_forward_iterator<iterator_archetype<iterator_status::input>>);
+    STATIC_ASSERT(_No_throw_forward_iterator<iterator_archetype<iterator_status::forward>>);
+
+    enum class range_status : int { not_range, not_input, input, forward };
+
+    template <range_status I>
+    struct range_archetype {
+        using It = std::conditional_t<I == range_status::not_range, void,
+            std::conditional_t<I == range_status::not_input, iterator_archetype<iterator_status::not_input>,
+                std::conditional_t<I == range_status::forward, iterator_archetype<iterator_status::forward>,
+                    iterator_archetype<iterator_status::input>>>>;
+        using Se = std::conditional_t<I == range_status::not_range, void,
+            std::conditional_t<I == range_status::forward, iterator_archetype<iterator_status::forward>,
+                std::default_sentinel_t>>;
+
+        It begin() const;
+        Se end() const;
+    };
+    // Verify range_archetype
+    STATIC_ASSERT(!ranges::range<range_archetype<range_status::not_range>>);
+    STATIC_ASSERT(ranges::range<range_archetype<range_status::not_input>>);
+    STATIC_ASSERT(ranges::range<range_archetype<range_status::input>>);
+    STATIC_ASSERT(ranges::range<range_archetype<range_status::forward>>);
+
+    // Validate _No_throw_input_range; note that the distinction betweeen range<R> and
+    // no-throw-sentinel-for<sentinel_t<R>, iterator_t<R>> is purely semantic, so we can't test them separately.
+    STATIC_ASSERT(!_No_throw_input_range<range_archetype<range_status::not_range>>);
+    STATIC_ASSERT(!_No_throw_input_range<range_archetype<range_status::not_input>>);
+    STATIC_ASSERT(_No_throw_input_range<range_archetype<range_status::input>>);
+    STATIC_ASSERT(_No_throw_input_range<range_archetype<range_status::forward>>);
+
+    STATIC_ASSERT(!_No_throw_forward_range<range_archetype<range_status::not_range>>);
+    STATIC_ASSERT(!_No_throw_forward_range<range_archetype<range_status::not_input>>);
+    STATIC_ASSERT(!_No_throw_forward_range<range_archetype<range_status::input>>);
+    STATIC_ASSERT(_No_throw_forward_range<range_archetype<range_status::forward>>);
+} // namespace special_memory_concepts

--- a/tests/std/tests/P0896R4_ranges_algorithm_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_algorithm_machinery/test.cpp
@@ -1045,25 +1045,24 @@ namespace special_memory_concepts {
     STATIC_ASSERT(_No_throw_input_iterator<iterator_archetype<iterator_status::input>>);
     STATIC_ASSERT(_No_throw_input_iterator<iterator_archetype<iterator_status::forward>>);
 
-    enum class sentinel_status : int { not_sentinel, good };
+    enum class sentinel_status : int { no, yes };
 
     template <sentinel_status I>
     struct sentinel_archetype {
         // clang-format off
         template <iterator_status S>
-        bool operator==(iterator_archetype<S> const&) const requires (I != sentinel_status::not_sentinel);
+        bool operator==(iterator_archetype<S> const&) const requires (I != sentinel_status::no);
         // clang-format on
     };
     // Verify sentinel_archetype
-    STATIC_ASSERT(
-        !sentinel_for<sentinel_archetype<sentinel_status::not_sentinel>, iterator_archetype<iterator_status::input>>);
-    STATIC_ASSERT(sentinel_for<sentinel_archetype<sentinel_status::good>, iterator_archetype<iterator_status::input>>);
+    STATIC_ASSERT(!sentinel_for<sentinel_archetype<sentinel_status::no>, iterator_archetype<iterator_status::input>>);
+    STATIC_ASSERT(sentinel_for<sentinel_archetype<sentinel_status::yes>, iterator_archetype<iterator_status::input>>);
 
     // Validate _No_throw_sentinel_for
-    STATIC_ASSERT(!_No_throw_sentinel_for<sentinel_archetype<sentinel_status::not_sentinel>,
-                  iterator_archetype<iterator_status::input>>);
     STATIC_ASSERT(
-        _No_throw_sentinel_for<sentinel_archetype<sentinel_status::good>, iterator_archetype<iterator_status::input>>);
+        !_No_throw_sentinel_for<sentinel_archetype<sentinel_status::no>, iterator_archetype<iterator_status::input>>);
+    STATIC_ASSERT(
+        _No_throw_sentinel_for<sentinel_archetype<sentinel_status::yes>, iterator_archetype<iterator_status::input>>);
     STATIC_ASSERT(!_No_throw_sentinel_for<iterator_archetype<iterator_status::input>,
                   iterator_archetype<iterator_status::input>>);
     STATIC_ASSERT(_No_throw_sentinel_for<iterator_archetype<iterator_status::forward>,
@@ -1104,6 +1103,7 @@ namespace special_memory_concepts {
     STATIC_ASSERT(_No_throw_input_range<range_archetype<range_status::input>>);
     STATIC_ASSERT(_No_throw_input_range<range_archetype<range_status::forward>>);
 
+    // Validate _No_throw_forward_range
     STATIC_ASSERT(!_No_throw_forward_range<range_archetype<range_status::not_range>>);
     STATIC_ASSERT(!_No_throw_forward_range<range_archetype<range_status::not_input>>);
     STATIC_ASSERT(!_No_throw_forward_range<range_archetype<range_status::input>>);

--- a/tests/std/tests/P0896R4_ranges_subrange/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_subrange/test.cpp
@@ -14,7 +14,7 @@
 #include <utility>
 #include <vector>
 
-#include "range_algorithm_support.hpp"
+#include <range_algorithm_support.hpp>
 
 #define ASSERT(...) assert((__VA_ARGS__))
 


### PR DESCRIPTION
`<algorithm>`
* Promote `_Convertible_from` and `in_out_result` to `<xmemory>` for use by the specialized memory algorithms in`<memory>`, (notably including `ranges::uninitialized_move`).

`<xmemory>`
* Teach `_Destroy_in_place` to destroy arrays.
* Teach `_Destroy_range` to accept different sentinel types.

`<memory>`
* Implement exposition-only concepts `_No_throw_input_iterator`, `_No_throw_sentinel_for`, `_No_throw_forward_iterator`, `_No_throw_input_range`, and `_No_throw_forward_range` (with test coverage in `tests/std/tests/P0896R4_ranges_algorithm_machinery`).
* Implement `ranges::uninitialized_move` (with test `tests/std/tests/P0896R4_ranges_alg_uninitialized_move`).

`tests/std/include/range_algorithm_support.hpp`
* `test::iterator`'s `iter_move` should yield an xvalue instead of a prvalue to eliminate the redundant extra move in `*x = iter_move(y)`.
