### PR TITLE
Disable a libcxx test due to the impact of P0960R3

### DIFF
--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -532,7 +532,7 @@ std/depr/depr.c.headers/tgmath_h.pass.cpp:1 FAIL
 
 # *** CLANG FEATURES NOT YET IMPLEMENTED ***
 # P0960R3 "Allow initializing aggregates from a parenthesized list of values"
-utilities/tuple/tuple.tuple/tuple.creation/tuple_cat.pass.cpp SKIP # TRANSITION, VS 2019 16.8 p3
+std/utilities/tuple/tuple.tuple/tuple.creation/tuple_cat.pass.cpp SKIP # TRANSITION, VS 2019 16.8 p3
 
 
 # *** CLANG ISSUES, NOT YET ANALYZED ***

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -530,6 +530,11 @@ std/thread/macro.pass.cpp:1 FAIL
 std/depr/depr.c.headers/tgmath_h.pass.cpp:1 FAIL
 
 
+# *** CLANG FEATURES NOT YET IMPLEMENTED ***
+# P0960R3 "Allow initializing aggregates from a parenthesized list of values"
+utilities/tuple/tuple.tuple/tuple.creation/tuple_cat.pass.cpp SKIP # TRANSITION, VS 2019 16.8 p3
+
+
 # *** CLANG ISSUES, NOT YET ANALYZED ***
 # Clang doesn't enable sized deallocation by default. Should we add -fsized-deallocation or do something else?
 std/language.support/support.dynamic/new.delete/new.delete.array/sized_delete_array_fsizeddeallocation.pass.cpp:1 FAIL

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -532,7 +532,7 @@ std/depr/depr.c.headers/tgmath_h.pass.cpp:1 FAIL
 
 # *** CLANG FEATURES NOT YET IMPLEMENTED ***
 # P0960R3 "Allow initializing aggregates from a parenthesized list of values"
-std/utilities/tuple/tuple.tuple/tuple.creation/tuple_cat.pass.cpp SKIP # TRANSITION, VS 2019 16.8 p3
+std/utilities/tuple/tuple.tuple/tuple.creation/tuple_cat.pass.cpp SKIPPED # TRANSITION, VS 2019 16.8 p3
 
 
 # *** CLANG ISSUES, NOT YET ANALYZED ***

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -530,6 +530,11 @@ thread\macro.pass.cpp
 depr\depr.c.headers\tgmath_h.pass.cpp
 
 
+# *** CLANG FEATURES NOT YET IMPLEMENTED ***
+# P0960R3 "Allow initializing aggregates from a parenthesized list of values"
+utilities\tuple\tuple.tuple\tuple.creation\tuple_cat.pass.cpp
+
+
 # *** CLANG ISSUES, NOT YET ANALYZED ***
 # Clang doesn't enable sized deallocation by default. Should we add -fsized-deallocation or do something else?
 language.support\support.dynamic\new.delete\new.delete.array\sized_delete_array_fsizeddeallocation.pass.cpp


### PR DESCRIPTION
The adoption of P0960R3 (Allow initializing aggregates from a parenthesized list of values) has caused code like the following to change behavior:
~~~cpp
#include <tuple>
struct S {
   int i;
};

std::tuple<S> t({ 1 });
~~~
This code used to be accepted but because P0960R3 changes the value of `std::is_constructible_v<S, int>` from `false` to `true` the compiler ends up choosing a different tuple constructor and, eventually, emits an error message:
~~~
xxx.cpp
xxx.cpp(14): error C2664: 'std::tuple<S>::tuple(std::tuple<S> &&)': cannot convert argument 1 from 'initializer list' to 'std::tuple<S> &&'
xxx.cpp(14): note: copy-list-initialization of 'std::tuple<S>' cannot use an explicit constructor
~~~
It was suggested, by Casey Carter, that I disable this test until std::tuple can be updated to handle the new C++20 rules.