### PR TITLE
Fix unnecessary self-move-assignments on calling deque erase(x,x)

### DIFF
--- a/stl/inc/deque
+++ b/stl/inc/deque
@@ -1291,25 +1291,25 @@ public:
         auto _Off   = static_cast<size_type>(_First - begin());
         auto _Count = static_cast<size_type>(_Last - _First);
 #endif // _ITERATOR_DEBUG_LEVEL == 2
-
-        if (_Off < static_cast<size_type>(end() - _Last)) { // closer to front
-            _STD move_backward(begin(), _First, _Last); // copy over hole
-            for (; 0 < _Count; --_Count) {
-                pop_front(); // pop copied elements
-            }
-        } else { // closer to back
-            _STD move(_Last, end(), _First); // copy over hole
-            for (; 0 < _Count; --_Count) {
-                pop_back(); // pop copied elements
-            }
-        }
+		if (_Count > 0){
+			if (_Off < static_cast<size_type>(end() - _Last)) { // closer to front
+				_STD move_backward(begin(), _First, _Last); // copy over hole
+				for (; 0 < _Count; --_Count) {
+					pop_front(); // pop copied elements
+				}
+			} else { // closer to back
+				_STD move(_Last, end(), _First); // copy over hole
+				for (; 0 < _Count; --_Count) {
+					pop_back(); // pop copied elements
+				}
+			}
 
 #if _ITERATOR_DEBUG_LEVEL == 2
-        if (_Moved) {
-            _Orphan_all();
-        }
+			if (_Moved) {
+				_Orphan_all();
+			}
 #endif // _ITERATOR_DEBUG_LEVEL == 2
-
+		}
         return begin() + static_cast<difference_type>(_Off);
     }
 


### PR DESCRIPTION


<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
