### PR TITLE
 Fix unnecessary self-move-assignments on calling deque erase(x,x)

### DIFF
--- a/stl/inc/deque
+++ b/stl/inc/deque
@@ -1291,25 +1291,27 @@ public:
         auto _Off   = static_cast<size_type>(_First - begin());
         auto _Count = static_cast<size_type>(_Last - _First);
 #endif // _ITERATOR_DEBUG_LEVEL == 2
-	if (_Count > 0){
-		if (_Off < static_cast<size_type>(end() - _Last)) { // closer to front
-			_STD move_backward(begin(), _First, _Last); // copy over hole
-			for (; 0 < _Count; --_Count) {
-				pop_front(); // pop copied elements
-			}
-		} else { // closer to back
-			_STD move(_Last, end(), _First); // copy over hole
-			for (; 0 < _Count; --_Count) {
-				pop_back(); // pop copied elements
-			}
-		}
+
+        if (_Count == 0)
+		    return _First;
+        if (_Off < static_cast<size_type>(end() - _Last)) { // closer to front
+            _STD move_backward(begin(), _First, _Last); // copy over hole
+            for (; 0 < _Count; --_Count) {
+                pop_front(); // pop copied elements
+            }
+        } else { // closer to back
+            _STD move(_Last, end(), _First); // copy over hole
+            for (; 0 < _Count; --_Count) {
+                pop_back(); // pop copied elements
+            }
+        }
 
 #if _ITERATOR_DEBUG_LEVEL == 2
-		if (_Moved) {
-			_Orphan_all();
-		}
+        if (_Moved) {
+            _Orphan_all();
+        }
 #endif // _ITERATOR_DEBUG_LEVEL == 2
-	}
+
         return begin() + static_cast<difference_type>(_Off);
     }
 

--- a/stl/inc/deque
+++ b/stl/inc/deque
@@ -1293,7 +1293,7 @@ public:
 #endif // _ITERATOR_DEBUG_LEVEL == 2
 
         if (_Count == 0)
-	    return _First;
+            return _First;
         if (_Off < static_cast<size_type>(end() - _Last)) { // closer to front
             _STD move_backward(begin(), _First, _Last); // copy over hole
             for (; 0 < _Count; --_Count) {

--- a/stl/inc/deque
+++ b/stl/inc/deque
@@ -1293,7 +1293,7 @@ public:
 #endif // _ITERATOR_DEBUG_LEVEL == 2
 
         if (_Count == 0)
-		    return _First;
+	    return _First;
         if (_Off < static_cast<size_type>(end() - _Last)) { // closer to front
             _STD move_backward(begin(), _First, _Last); // copy over hole
             for (; 0 < _Count; --_Count) {

--- a/stl/inc/deque
+++ b/stl/inc/deque
@@ -1295,7 +1295,7 @@ public:
         if (_Count == 0) {
             return _First;
         }
-        
+
         if (_Off < static_cast<size_type>(end() - _Last)) { // closer to front
             _STD move_backward(begin(), _First, _Last); // copy over hole
             for (; 0 < _Count; --_Count) {

--- a/stl/inc/deque
+++ b/stl/inc/deque
@@ -1291,25 +1291,25 @@ public:
         auto _Off   = static_cast<size_type>(_First - begin());
         auto _Count = static_cast<size_type>(_Last - _First);
 #endif // _ITERATOR_DEBUG_LEVEL == 2
-
-        if (_Off < static_cast<size_type>(end() - _Last)) { // closer to front
-            _STD move_backward(begin(), _First, _Last); // copy over hole
-            for (; 0 < _Count; --_Count) {
-                pop_front(); // pop copied elements
-            }
-        } else { // closer to back
-            _STD move(_Last, end(), _First); // copy over hole
-            for (; 0 < _Count; --_Count) {
-                pop_back(); // pop copied elements
-            }
-        }
+		if (_Count > 0){
+			if (_Off < static_cast<size_type>(end() - _Last)) { // closer to front
+				_STD move_backward(begin(), _First, _Last); // copy over hole
+				for (; 0 < _Count; --_Count) {
+					pop_front(); // pop copied elements
+				}
+			} else { // closer to back
+				_STD move(_Last, end(), _First); // copy over hole
+				for (; 0 < _Count; --_Count) {
+					pop_back(); // pop copied elements
+				}
+			}
 
 #if _ITERATOR_DEBUG_LEVEL == 2
-        if (_Moved) {
-            _Orphan_all();
-        }
+			if (_Moved) {
+				_Orphan_all();
+			}
 #endif // _ITERATOR_DEBUG_LEVEL == 2
-
+		}
         return begin() + static_cast<difference_type>(_Off);
     }
 

--- a/stl/inc/deque
+++ b/stl/inc/deque
@@ -1291,25 +1291,25 @@ public:
         auto _Off   = static_cast<size_type>(_First - begin());
         auto _Count = static_cast<size_type>(_Last - _First);
 #endif // _ITERATOR_DEBUG_LEVEL == 2
-		if (_Count > 0){
-			if (_Off < static_cast<size_type>(end() - _Last)) { // closer to front
-				_STD move_backward(begin(), _First, _Last); // copy over hole
-				for (; 0 < _Count; --_Count) {
-					pop_front(); // pop copied elements
-				}
-			} else { // closer to back
-				_STD move(_Last, end(), _First); // copy over hole
-				for (; 0 < _Count; --_Count) {
-					pop_back(); // pop copied elements
-				}
+	if (_Count > 0){
+		if (_Off < static_cast<size_type>(end() - _Last)) { // closer to front
+			_STD move_backward(begin(), _First, _Last); // copy over hole
+			for (; 0 < _Count; --_Count) {
+				pop_front(); // pop copied elements
 			}
+		} else { // closer to back
+			_STD move(_Last, end(), _First); // copy over hole
+			for (; 0 < _Count; --_Count) {
+				pop_back(); // pop copied elements
+			}
+		}
 
 #if _ITERATOR_DEBUG_LEVEL == 2
-			if (_Moved) {
-				_Orphan_all();
-			}
-#endif // _ITERATOR_DEBUG_LEVEL == 2
+		if (_Moved) {
+			_Orphan_all();
 		}
+#endif // _ITERATOR_DEBUG_LEVEL == 2
+	}
         return begin() + static_cast<difference_type>(_Off);
     }
 

--- a/stl/inc/deque
+++ b/stl/inc/deque
@@ -1292,8 +1292,10 @@ public:
         auto _Count = static_cast<size_type>(_Last - _First);
 #endif // _ITERATOR_DEBUG_LEVEL == 2
 
-        if (_Count == 0)
+        if (_Count == 0) {
             return _First;
+        }
+        
         if (_Off < static_cast<size_type>(end() - _Last)) { // closer to front
             _STD move_backward(begin(), _First, _Last); // copy over hole
             for (; 0 < _Count; --_Count) {


### PR DESCRIPTION
Fixes issue #1118 
I think it's the simplest method to solve the issue. however, it adds a little bit overhead to the library with an additional IF.
Any better idea?
