### PR TITLE
Upgrade toolset to VS 2019 16.8 Preview 1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,13 +5,13 @@ if (NOT DEFINED CMAKE_TOOLCHAIN_FILE AND EXISTS "${CMAKE_CURRENT_LIST_DIR}/vcpkg
     set(CMAKE_TOOLCHAIN_FILE "${CMAKE_CURRENT_LIST_DIR}/vcpkg/scripts/buildsystems/vcpkg.cmake")
 endif()
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.17)
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 project(msvc_standard_libraries LANGUAGES CXX)
 
 find_package(Boost REQUIRED)
 
-set(VCLIBS_MIN_BOOST_VERSION 1.70.0)
+set(VCLIBS_MIN_BOOST_VERSION 1.73.0)
 if("${Boost_VERSION}" VERSION_LESS "${VCLIBS_MIN_BOOST_VERSION}")
     message(FATAL_ERROR "Detected Boost version is too old (older than ${VCLIBS_MIN_BOOST_VERSION}).")
 endif()

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 The STL uses boost-math headers to provide P0226R1 Mathematical Special Functions. We recommend using [vcpkg][] to
 acquire this dependency.
 
-1. Install Visual Studio 2019 16.7 Preview 3 or later.
+1. Install Visual Studio 2019 16.8 Preview 1 or later.
 2. Invoke `git clone https://github.com/microsoft/vcpkg`
 3. Invoke `cd vcpkg`
 4. Invoke `.\bootstrap-vcpkg.bat`
@@ -159,7 +159,10 @@ acquire this dependency.
 These instructions assume you're targeting `x64-windows`; you can change this constant below to target other
 architectures.
 
-1. Install [CMake][] 3.16.5 or later, [Ninja][] 1.10.0 or later, and Visual Studio 2019 16.7 Preview 3 or later.
+1. Install Visual Studio 2019 16.8 Preview 1 or later.
+    * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
+    This will ensure that you're using supported versions of CMake and Ninja.
+    * Otherwise, install [CMake][] 3.17 or later, and [Ninja][] 1.8.2 or later.
 2. Open an "x64 Native Tools Command Prompt for VS 2019".
 3. Change directories to a location where you'd like a clone of this STL repository.
 4. Invoke `git clone https://github.com/microsoft/STL`
@@ -222,8 +225,10 @@ C:\Users\bion\Desktop>dumpbin /IMPORTS .\example.exe | findstr msvcp
 1. Follow either [How To Build With A Native Tools Command Prompt][] or [How To Build With The Visual Studio IDE][].
 2. Invoke `git submodule update --init llvm-project` at the root of the STL source tree.
 3. Acquire [Python][] 3.8 or newer and have it on the `PATH` (or run it directly using its absolute or relative path).
-4. Have LLVM's `bin` directory on the `PATH`. Simply using [LLVM's installer][] and choosing to add LLVM to your `PATH`
-during installation is the easiest way to get LLVM's `bin` directory on your `PATH`.
+4. Have LLVM's `bin` directory on the `PATH` (so `clang-cl.exe` is available).
+    * We recommend selecting "C++ Clang tools for Windows" in the VS Installer. This will automatically add LLVM to the
+    `PATH` of the x86 and x64 Native Tools Command Prompts, and will ensure that you're using a supported version.
+    * Otherwise, use [LLVM's installer][] and choose to add LLVM to your `PATH` during installation.
 5. Follow the instructions below.
 
 ## Running All The Tests

--- a/azure-devops/create-vmss.ps1
+++ b/azure-devops/create-vmss.ps1
@@ -11,7 +11,7 @@ system. See https://docs.microsoft.com/en-us/azure/virtual-machine-scale-sets/ov
 for more information.
 
 This script assumes you have installed Azure tools into PowerShell by following the instructions
-at https://docs.microsoft.com/en-us/powershell/azure/install-az-ps?view=azps-3.6.1
+at https://docs.microsoft.com/en-us/powershell/azure/install-az-ps
 or are running from Azure Cloud Shell.
 #>
 
@@ -211,20 +211,20 @@ $denyEverythingElse = New-AzNetworkSecurityRuleConfig `
   -DestinationAddressPrefix * `
   -DestinationPortRange *
 
-$NetworkSecurityGroupName = $ResourceGroupName + 'NetworkSecurity'
+$NetworkSecurityGroupName = $ResourceGroupName + '-NetworkSecurity'
 $NetworkSecurityGroup = New-AzNetworkSecurityGroup `
   -Name $NetworkSecurityGroupName `
   -ResourceGroupName $ResourceGroupName `
   -Location $Location `
   -SecurityRules @($allowHttp, $allowDns, $denyEverythingElse)
 
-$SubnetName = $ResourceGroupName + 'Subnet'
+$SubnetName = $ResourceGroupName + '-Subnet'
 $Subnet = New-AzVirtualNetworkSubnetConfig `
   -Name $SubnetName `
   -AddressPrefix "10.0.0.0/16" `
   -NetworkSecurityGroup $NetworkSecurityGroup
 
-$VirtualNetworkName = $ResourceGroupName + 'Network'
+$VirtualNetworkName = $ResourceGroupName + '-Network'
 $VirtualNetwork = New-AzVirtualNetwork `
   -Name $VirtualNetworkName `
   -ResourceGroupName $ResourceGroupName `
@@ -237,7 +237,7 @@ Write-Progress `
   -Activity 'Creating prototype VM' `
   -PercentComplete (100 / $TotalProgress * $CurrentProgress++)
 
-$NicName = $ResourceGroupName + 'NIC'
+$NicName = $ResourceGroupName + '-NIC'
 $Nic = New-AzNetworkInterface `
   -Name $NicName `
   -ResourceGroupName $ResourceGroupName `
@@ -272,12 +272,14 @@ Write-Progress `
   -Status 'Running provisioning script provision-image.ps1 in VM' `
   -PercentComplete (100 / $TotalProgress * $CurrentProgress++)
 
-Invoke-AzVMRunCommand `
+$ProvisionImageResult = Invoke-AzVMRunCommand `
   -ResourceGroupName $ResourceGroupName `
   -VMName $ProtoVMName `
   -CommandId 'RunPowerShellScript' `
   -ScriptPath "$PSScriptRoot\provision-image.ps1" `
   -Parameter @{AdminUserPassword = $AdminPW }
+
+Write-Host "provision-image.ps1 output: $($ProvisionImageResult.value.Message)"
 
 ####################################################################################################
 Write-Progress `
@@ -343,9 +345,9 @@ Write-Progress `
   -Status 'Creating scale set' `
   -PercentComplete (100 / $TotalProgress * $CurrentProgress++)
 
-$VmssIpConfigName = $ResourceGroupName + 'VmssIpConfig'
+$VmssIpConfigName = $ResourceGroupName + '-VmssIpConfig'
 $VmssIpConfig = New-AzVmssIpConfig -SubnetId $Nic.IpConfigurations[0].Subnet.Id -Primary -Name $VmssIpConfigName
-$VmssName = $ResourceGroupName + 'Vmss'
+$VmssName = $ResourceGroupName + '-Vmss'
 $Vmss = New-AzVmssConfig `
   -Location $Location `
   -SkuCapacity 0 `

--- a/azure-devops/enforce-clang-format.cmd
+++ b/azure-devops/enforce-clang-format.cmd
@@ -1,5 +1,7 @@
 :: Copyright (c) Microsoft Corporation.
 :: SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+call "%PROGRAMFILES(X86)%\Microsoft Visual Studio\2019\Preview\Common7\Tools\VsDevCmd.bat" ^
+-host_arch=amd64 -arch=amd64 -no_logo
 "%1" "clang-format.exe -style=file -i" ^
 stl/inc ^
 stl/src ^

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -50,10 +50,14 @@ Function Get-TempFilePath {
   return Join-Path $tempPath $tempName
 }
 
-if (-not [string]::IsNullOrEmpty($AdminUserPassword)) {
-  Write-Host "AdminUser password supplied; switching to AdminUser"
+$TranscriptPath = 'C:\provision-image-transcript.txt'
+
+if ([string]::IsNullOrEmpty($AdminUserPassword)) {
+  Start-Transcript -Path $TranscriptPath
+} else {
+  Write-Host 'AdminUser password supplied; switching to AdminUser.'
   $PsExecPath = Get-TempFilePath -Extension 'exe'
-  Write-Host "Downloading psexec to $PsExecPath"
+  Write-Host "Downloading psexec to: $PsExecPath"
   & curl.exe -L -o $PsExecPath -s -S https://live.sysinternals.com/PsExec64.exe
   $PsExecArgs = @(
     '-u',
@@ -69,9 +73,11 @@ if (-not [string]::IsNullOrEmpty($AdminUserPassword)) {
     $PSCommandPath
   )
 
-  Write-Host "Executing $PsExecPath " + @PsExecArgs
+  Write-Host "Executing: $PsExecPath $PsExecArgs"
 
   $proc = Start-Process -FilePath $PsExecPath -ArgumentList $PsExecArgs -Wait -PassThru
+  Write-Host 'Reading transcript...'
+  Get-Content -Path $TranscriptPath
   Write-Host 'Cleaning up...'
   Remove-Item $PsExecPath
   exit $proc.ExitCode
@@ -79,20 +85,19 @@ if (-not [string]::IsNullOrEmpty($AdminUserPassword)) {
 
 $Workloads = @(
   'Microsoft.VisualStudio.Component.VC.CLI.Support',
+  'Microsoft.VisualStudio.Component.VC.CMake.Project',
   'Microsoft.VisualStudio.Component.VC.CoreIde',
-  'Microsoft.VisualStudio.Component.VC.Tools.x86.x64',
-  'Microsoft.VisualStudio.Component.VC.Tools.ARM64',
+  'Microsoft.VisualStudio.Component.VC.Llvm.Clang',
   'Microsoft.VisualStudio.Component.VC.Tools.ARM',
-  'Microsoft.VisualStudio.Component.Windows10SDK.18362'
+  'Microsoft.VisualStudio.Component.VC.Tools.ARM64',
+  'Microsoft.VisualStudio.Component.VC.Tools.x86.x64',
+  'Microsoft.VisualStudio.Component.Windows10SDK.19041'
 )
 
 $ReleaseInPath = 'Preview'
 $Sku = 'Enterprise'
 $VisualStudioBootstrapperUrl = 'https://aka.ms/vs/16/pre/vs_enterprise.exe'
-$CMakeUrl = 'https://github.com/Kitware/CMake/releases/download/v3.16.5/cmake-3.16.5-win64-x64.msi'
-$LlvmUrl = 'https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/LLVM-10.0.0-win64.exe'
-$NinjaUrl = 'https://github.com/ninja-build/ninja/releases/download/v1.10.0/ninja-win.zip'
-$PythonUrl = 'https://www.python.org/ftp/python/3.8.2/python-3.8.2-amd64.exe'
+$PythonUrl = 'https://www.python.org/ftp/python/3.8.5/python-3.8.5-amd64.exe'
 
 $CudaUrl = 'https://developer.download.nvidia.com/compute/cuda/10.1/Prod/local_installers/cuda_10.1.243_426.00_win10.exe'
 $CudaFeatures = 'nvcc_10.1 cuobjdump_10.1 nvprune_10.1 cupti_10.1 gpu_library_advisor_10.1 memcheck_10.1 ' + `
@@ -162,7 +167,7 @@ Function InstallVisualStudio {
     Write-Host 'Downloading Visual Studio...'
     [string]$bootstrapperExe = Get-TempFilePath -Extension 'exe'
     curl.exe -L -o $bootstrapperExe -s -S $BootstrapperUrl
-    Write-Host "Installing Visual Studio..."
+    Write-Host 'Installing Visual Studio...'
     $args = @('/c', $bootstrapperExe, '--quiet', '--norestart', '--wait', '--nocache')
     foreach ($workload in $Workloads) {
       $args += '--add'
@@ -184,103 +189,6 @@ Function InstallVisualStudio {
   }
   catch {
     Write-Error "Failed to install Visual Studio! $($_.Exception.Message)"
-  }
-}
-
-<#
-.SYNOPSIS
-Install an .msi file.
-
-.DESCRIPTION
-InstallMSI takes a URL where an .msi lives, and installs that .msi to the system.
-
-.PARAMETER Name
-The name of the thing to install.
-
-.PARAMETER Url
-The URL at which the .msi lives.
-#>
-Function InstallMSI {
-  Param(
-    [String]$Name,
-    [String]$Url
-  )
-
-  try {
-    Write-Host "Downloading $Name..."
-    [string]$msiPath = Get-TempFilePath -Extension 'msi'
-    curl.exe -L -o $msiPath -s -S $Url
-    Write-Host "Installing $Name..."
-    $args = @('/i', $msiPath, '/norestart', '/quiet', '/qn')
-    $proc = Start-Process -FilePath 'msiexec.exe' -ArgumentList $args -Wait -PassThru
-    PrintMsiExitCodeMessage $proc.ExitCode
-  }
-  catch {
-    Write-Error "Failed to install $Name! $($_.Exception.Message)"
-  }
-}
-
-<#
-.SYNOPSIS
-Unpacks a zip file to $Dir.
-
-.DESCRIPTION
-InstallZip takes a URL of a zip file, and unpacks the zip file to the directory
-$Dir.
-
-.PARAMETER Name
-The name of the tool being installed.
-
-.PARAMETER Url
-The URL of the zip file to unpack.
-
-.PARAMETER Dir
-The directory to unpack the zip file to.
-#>
-Function InstallZip {
-  Param(
-    [String]$Name,
-    [String]$Url,
-    [String]$Dir
-  )
-
-  try {
-    Write-Host "Downloading $Name..."
-    [string]$zipPath = Get-TempFilePath -Extension 'zip'
-    curl.exe -L -o $zipPath -s -S $Url
-    Write-Host "Installing $Name..."
-    Expand-Archive -Path $zipPath -DestinationPath $Dir -Force
-  }
-  catch {
-    Write-Error "Failed to install $Name! $($_.Exception.Message)"
-  }
-}
-
-<#
-.SYNOPSIS
-Installs LLVM.
-
-.DESCRIPTION
-InstallLLVM installs LLVM from the supplied URL.
-
-.PARAMETER Url
-The URL of the LLVM installer.
-#>
-Function InstallLLVM {
-  Param(
-    [String]$Url
-  )
-
-  try {
-    Write-Host 'Downloading LLVM...'
-    [string]$installerPath = Get-TempFilePath -Extension 'exe'
-    curl.exe -L -o $installerPath -s -S $Url
-    Write-Host 'Installing LLVM...'
-    $proc = Start-Process -FilePath $installerPath -ArgumentList @('/S') -NoNewWindow -Wait -PassThru
-    PrintMsiExitCodeMessage $proc.ExitCode
-  }
-  catch {
-    Write-Error "Failed to install LLVM! $($_.Exception.Message)"
   }
 }
 
@@ -369,16 +277,16 @@ Function PipInstall {
   )
 
   try {
-    Write-Host 'Installing or upgrading $Package...'
+    Write-Host "Installing or upgrading $Package..."
     python.exe -m pip install --upgrade $Package
-    Write-Host 'Done installing or upgrading $Package'
+    Write-Host "Done installing or upgrading $Package."
   }
   catch {
-    Write-Error "Failed to install or upgrade $Package"
+    Write-Error "Failed to install or upgrade $Package."
   }
 }
 
-Write-Host "AdminUser password not supplied; assuming already running as AdminUser"
+Write-Host 'AdminUser password not supplied; assuming already running as AdminUser.'
 
 Write-Host 'Configuring AntiVirus exclusions...'
 Add-MpPreference -ExclusionPath C:\agent
@@ -388,20 +296,28 @@ Add-MpPreference -ExclusionProcess clang-cl.exe
 Add-MpPreference -ExclusionProcess cl.exe
 Add-MpPreference -ExclusionProcess link.exe
 Add-MpPreference -ExclusionProcess python.exe
+Add-MpPreference -ExclusionProcess test.exe
 
-InstallMSI 'CMake' $CMakeUrl
-InstallZip 'Ninja' $NinjaUrl 'C:\Program Files\CMake\bin'
-InstallLLVM $LlvmUrl
 InstallPython $PythonUrl
 InstallVisualStudio -Workloads $Workloads -BootstrapperUrl $VisualStudioBootstrapperUrl
 InstallCuda -Url $CudaUrl -Features $CudaFeatures
 
 Write-Host 'Updating PATH...'
+
+# Step 1: Read the system path, which was just updated by installing Python.
 $environmentKey = Get-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment' -Name Path
-$Env:PATH="$($environmentKey.Path);C:\Program Files\CMake\bin;C:\Program Files\LLVM\bin"
+
+# Step 2: Update the local path (for this running script), so PipInstall can run python.exe.
+# Additional directories can be added here (e.g. if we extracted a zip file
+# or installed something that didn't update the system path).
+$Env:PATH="$($environmentKey.Path)"
+
+# Step 3: Update the system path, permanently recording any additional directories that were added in the previous step.
 Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment' `
   -Name Path `
   -Value "$Env:PATH"
+
+Write-Host 'Finished updating PATH!'
 
 PipInstall pip
 PipInstall psutil

--- a/azure-devops/sysprep.ps1
+++ b/azure-devops/sysprep.ps1
@@ -3,4 +3,4 @@
 
 $ErrorActionPreference = 'Stop'
 Write-Host 'Running sysprep'
-& C:\Windows\system32\sysprep\sysprep.exe /oobe /generalize /shutdown
+& C:\Windows\system32\sysprep\sysprep.exe /oobe /generalize /mode:vm /shutdown

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,7 @@
 # Build STL targeting x86, x64, arm, arm64
 
 variables:
-  agentPool: 'StlBuild-2020-07-08-2'
+  agentPool: 'StlBuild-2020-08-07'
   tmpDir: 'D:\Temp'
 
 stages:

--- a/stl/inc/bit
+++ b/stl/inc/bit
@@ -115,14 +115,7 @@ _NODISCARD constexpr int _Popcount_fallback(_Ty _Val) noexcept {
 
 #if defined(_M_IX86) || defined(_M_X64)
 
-// TRANSITION, VS 2019 16.8 Preview 1, intrin0.h will declare __lzcnt* and __popcnt*
 extern "C" {
-__MACHINEX86_X64(unsigned int __lzcnt(unsigned int))
-__MACHINEX86_X64(unsigned short __lzcnt16(unsigned short))
-__MACHINEX64(unsigned __int64 __lzcnt64(unsigned __int64))
-__MACHINEX86_X64(unsigned int __popcnt(unsigned int))
-__MACHINEX86_X64(unsigned short __popcnt16(unsigned short))
-__MACHINEX64(unsigned __int64 __popcnt64(unsigned __int64))
 extern int __isa_available;
 }
 

--- a/stl/inc/experimental/coroutine
+++ b/stl/inc/experimental/coroutine
@@ -32,10 +32,10 @@ support Clang. You can define _SILENCE_CLANG_COROUTINE_MESSAGE to silence this m
 unsupported.
 #endif // defined(__clang__) && !defined(_SILENCE_CLANG_COROUTINE_MESSAGE)
 
-#if defined(_MSC_VER) && defined(__cpp_impl_coroutine)
+#ifdef __cpp_impl_coroutine
 #error The <experimental/coroutine> and <experimental/resumable> headers are only supported \
 with /await and implement pre-C++20 coroutine support. Use <coroutine> for standard C++20 coroutines.
-#endif // defined(_MSC_VER) && defined(__cpp_impl_coroutine)
+#endif // __cpp_impl_coroutine
 
 // intrinsics used in implementation of coroutine_handle
 extern "C" size_t _coro_resume(void*);

--- a/stl/inc/experimental/resumable
+++ b/stl/inc/experimental/resumable
@@ -30,7 +30,7 @@ _STD_BEGIN
 
 namespace experimental {
 
-#if !defined(__EDG__) && _MSC_VER >= 1928
+#ifndef __EDG__
     // STRUCT noop_coroutine_promise
     struct noop_coroutine_promise {};
 
@@ -75,7 +75,7 @@ namespace experimental {
         // Returns a handle to a coroutine that has no observable effects when resumed or destroyed.
         return noop_coroutine_handle{};
     }
-#endif // !defined(__EDG__) && _MSC_VER >= 1928
+#endif // __EDG__
 } // namespace experimental
 
 _STD_END

--- a/stl/inc/experimental/resumable
+++ b/stl/inc/experimental/resumable
@@ -75,7 +75,7 @@ namespace experimental {
         // Returns a handle to a coroutine that has no observable effects when resumed or destroyed.
         return noop_coroutine_handle{};
     }
-#endif // __EDG__
+#endif // ^^^ !defined(__EDG__) ^^^
 } // namespace experimental
 
 _STD_END

--- a/stl/inc/limits
+++ b/stl/inc/limits
@@ -1041,15 +1041,12 @@ _NODISCARD constexpr int _Countr_zero_fallback(const _Ty _Val) noexcept {
 }
 
 #if defined(_M_IX86) || defined(_M_X64)
-// TRANSITION, VS 2019 16.8 Preview 1, intrin0.h will declare _tzcnt*
 extern "C" {
 extern int __isa_available;
 #ifdef __clang__
 #define _TZCNT_U32 __builtin_ia32_tzcnt_u32
 #define _TZCNT_U64 __builtin_ia32_tzcnt_u64
 #else // ^^^ __clang__ / !__clang__ vvv
-__MACHINEX86_X64(unsigned int _tzcnt_u32(unsigned int))
-__MACHINEX64(unsigned __int64 _tzcnt_u64(unsigned __int64));
 #define _TZCNT_U32 _tzcnt_u32
 #define _TZCNT_U64 _tzcnt_u64
 #endif // __clang__

--- a/stl/inc/system_error
+++ b/stl/inc/system_error
@@ -513,7 +513,6 @@ public:
     }
 };
 
-// TRANSITION, Visual Studio 2019 version 16.8
 // _Immortalize_memcpy_image is used to provide a nonstandard guarantee.
 // Specifically, we want the error category objects returned from things like std::system_category() to always
 //   be available, even during DLL unload (otherwise, <system_error> would be a huge regression vs. legacy error codes).
@@ -556,7 +555,13 @@ _NODISCARD const _Ty& _Immortalize_memcpy_image() noexcept {
     static constexpr _Ty _Static;
     return _Static;
 }
-#elif defined(_MSC_VER) && _MSC_VER > 1927 && !defined(_M_CEE) // _M_CEE test is TRANSITION, VSO-1153256
+#elif defined(__clang__)
+template <class _Ty>
+_NODISCARD const _Ty& _Immortalize_memcpy_image() noexcept {
+    [[clang::require_constant_initialization]] static _Ty _Static;
+    return _Static;
+}
+#elif !defined(_M_CEE) // TRANSITION, VSO-1153256
 template <class _Ty>
 struct _Constexpr_immortalize_impl {
     union {
@@ -578,7 +583,7 @@ _NODISCARD const _Ty& _Immortalize_memcpy_image() noexcept {
     static _Constexpr_immortalize_impl<_Ty> _Static;
     return _Static._Storage;
 }
-#else // choose immortalize strategy
+#else // ^^^ no workaround / workaround vvv
 template <class _Ty>
 _NODISCARD const _Ty& _Immortalize_memcpy_image() noexcept {
     // return reference to a memcpy'd default-initialized _Ty

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -336,7 +336,7 @@ template <>
 struct char_traits<unsigned short> : _WChar_traits<unsigned short> {};
 #endif // _NATIVE_WCHAR_T_DEFINED
 
-#if defined(__cpp_char8_t) && defined(_MSC_VER) && !defined(__EDG__) && !defined(__clang__)
+#if defined(__cpp_char8_t) && !defined(__EDG__) && !defined(__clang__)
 #define _HAS_U8_INTRINSICS 1
 #else // ^^^ Use intrinsics for char8_t / don't use said intrinsics vvv
 #define _HAS_U8_INTRINSICS 0

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -500,8 +500,8 @@
 #error STL1000: Unexpected compiler version, expected Clang 10.0.0 or newer.
 #endif // ^^^ old Clang ^^^
 #elif defined(_MSC_VER)
-#if _MSC_VER < 1927 // Coarse-grained, not inspecting _MSC_FULL_VER
-#error STL1001: Unexpected compiler version, expected MSVC 19.27 or newer.
+#if _MSC_VER < 1928 // Coarse-grained, not inspecting _MSC_FULL_VER
+#error STL1001: Unexpected compiler version, expected MSVC 19.28 or newer.
 #endif // ^^^ old MSVC ^^^
 #else // vvv other compilers vvv
 // not attempting to detect other compilers
@@ -1148,9 +1148,9 @@
 #define __cpp_lib_char8_t 201907L
 #endif // __cpp_char8_t
 
-#if defined(__cpp_concepts) && __cpp_concepts > 201507L
+#ifndef __EDG__ // TRANSITION, EDG concepts support
 #define __cpp_lib_concepts 201907L
-#endif // defined(__cpp_concepts) && __cpp_concepts > 201507L
+#endif // __EDG__
 
 #define __cpp_lib_constexpr_algorithms  201806L
 #define __cpp_lib_constexpr_complex     201711L
@@ -1162,7 +1162,7 @@
 #define __cpp_lib_constexpr_tuple       201811L
 #define __cpp_lib_constexpr_utility     201811L
 
-#ifdef __cpp_impl_coroutine // TRANSITION, VS 2019 16.8 Preview 1
+#ifdef __cpp_impl_coroutine // TRANSITION, VS 2019 16.8 Preview 3
 #define __cpp_lib_coroutine 197000L
 #endif // __cpp_impl_coroutine
 

--- a/stl/src/excptptr.cpp
+++ b/stl/src/excptptr.cpp
@@ -43,7 +43,7 @@ namespace {
         /* MAGIC */ static _Immortalizer_impl<_Ty> _Static;
         return reinterpret_cast<_Ty&>(_Static._Storage);
     }
-#elif _MSC_VER > 1927 && !defined(_M_CEE) // _M_CEE test is TRANSITION, VSO-1153256
+#elif !defined(_M_CEE) // _M_CEE test is TRANSITION, VSO-1153256
     template <class _Ty>
     struct _Constexpr_excptptr_immortalize_impl {
         union {

--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.cpp
@@ -327,7 +327,7 @@ STATIC_ASSERT(__cpp_lib_clamp == 201603L);
 STATIC_ASSERT(__cpp_lib_complex_udls == 201309L);
 #endif
 
-#if _HAS_CXX20 && defined(__cpp_concepts)
+#if _HAS_CXX20 && !defined(__EDG__) // TRANSITION, EDG concepts support
 #ifndef __cpp_lib_concepts
 #error __cpp_lib_concepts is not defined
 #elif __cpp_lib_concepts != 201907L

--- a/tests/std/tests/VSO_0971246_legacy_await_headers/env.lst
+++ b/tests/std/tests/VSO_0971246_legacy_await_headers/env.lst
@@ -3,7 +3,7 @@
 
 RUNALL_INCLUDE ..\prefix.lst
 RUNALL_CROSSLIST
-# PM_CL="/EHsc /MT /std:c++latest" # TRANSITION, VS 2019 16.8 Preview 1
+PM_CL="/EHsc /MT /std:c++latest"
 PM_CL="/EHsc /MT /await /std:c++latest"
 PM_CL="/BE /c /EHsc /MD /await /std:c++latest /permissive-"
 PM_CL="/BE /c /EHsc /MD /await /std:c++latest"


### PR DESCRIPTION
Fixes #1051.

Infrastructure
===
* `azure-devops/create-vmss.ps1`
  + Link to the always-latest version of the Azure PowerShell docs, currently 4.5.0.
  + Add an extra dash to resource names for clarity, changing 'StlBuild-2020-08-07Vmss' to 'StlBuild-2020-08-07-Vmss'.
  + Print `$ProvisionImageResult.value.Message`, allowing us to see what's happening during VM setup.
* `azure-devops/provision-image.ps1`
  + This script is started as `NT AUTHORITY\SYSTEM`, and then runs itself as an AdminUser (because `SYSTEM` can't be used to install MSIs). To capture output from the nested invocation, we can use PowerShell's `Start-Transcript` feature. The AdminUser invocation will save this to a fixed location, `C:\provision-image-transcript.txt`, so the original invocation can print it out. (This is what's sent to `create-vmss.ps1`.)
  + Adjust punctuation in messages. Use `'single quote strings'` when we don't need to expand variables.
  + Fix `Write-Host "Executing $PsExecPath " + @PsExecArgs` which was printing a spurious `+`.
  + Sort the VS workloads for style.
  + Install CMake (including Ninja) and Clang/LLVM via VS.
  + Upgrade the Win10 SDK from 18362 to the latest 19041.
  + Don't manually install CMake 3.16.5; VS installs a customized version of 3.17.
  + Don't manually install LLVM 10.0.0; VS installs this.
  + Don't manually install Ninja 1.10.0; VS installs 1.8.2.
  + Upgrade Python from 3.8.2 to 3.8.5.
  + We don't need the `InstallMSI`, `InstallZip`, `InstallLLVM` functions anymore. (They can always be restored from history if they're ever needed again.)
  + In `PipInstall`, we need to use `"double quote strings to expand $Package"`.
  + Exclude `test.exe` from Windows Defender, hoping that this will make test runs faster (it probably won't).
  + Add comments to the PATH update machinery, explaining why it's necessary.
  + Don't add CMake and LLVM to the system-wide PATH; they're available in VS command prompts.
* `azure-devops/enforce-clang-format.cmd`
  + Now that LLVM is no longer on the system-wide PATH, use an x64-native VS Dev Command Prompt
  so we can run `clang-format.exe` here.
* `CMakeLists.txt`
  + Increase our required CMake version to 3.17.
  + Increase our required Boost version to 1.73.0 (after the recent vcpkg submodule update).
* `azure-devops/sysprep.ps1`
  + Add the `/mode:vm` option, documented by https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/sysprep-command-line-options . This reportedly skips a lot of hardware detection, making it faster to boot up the sysprepped image. It also appears to make the sysprep step much faster (I timed it at 31 seconds; before this change, it seemed to take an eternity).
* `azure-pipelines.yml`
  + Use the new Agent Pool.

Documentation
===
* `README.md`
  + VS 2019 16.8 Preview 1 is now required.
  + Update the instructions to recommend installing CMake/Ninja and Clang/LLVM via VS.

Product Code
===
* `stl/inc/bit`
* `stl/inc/limits`
  + `intrin0.h` now declares these intrinsics.
* `stl/inc/experimental/coroutine`
* `stl/inc/xstring`
  + Testing `defined(_MSC_VER)` is unnecessary; everyone pretends to be MSVC.
* `stl/inc/experimental/resumable`
  + `_MSC_VER >= 1928` is now always true.
* `stl/inc/system_error`
  + `_MSC_VER > 1927` is now always true.
  + Provide a new codepath for Clang, which doesn't understand `[[msvc::noop_dtor]]`. Instead, we can use a
  non-`constexpr` variable that's `static`, marked with `[[clang::require_constant_initialization]]`.
* `stl/src/excptptr.cpp`
  + `_MSC_VER > 1927` is now always true.
* `stl/inc/yvals_core.h`
  + Require MSVC 19.28.
  + Provide a simpler form of #1158. In `_HAS_CXX20` mode, we no longer need to inspect `__cpp_concepts`, as both MSVC and Clang will pass that test.
  + `__cpp_lib_coroutine` can't be defined to its final value yet. This might be possible (but isn't guaranteed) for VS 2019 16.8 Preview 3.

Test Code
===
* `tests/std/tests/VSO_0157762_feature_test_macros/test.cpp`
  + Update the `__cpp_lib_concepts` test accordingly. (#1158 didn't need to do this, because it was still being built with VS 2019 16.7.)
* `tests/std/tests/VSO_0971246_legacy_await_headers/env.lst`
  + This workaround is no longer needed.
