### PR TITLE
Fix errors in hyperbolic function crossover

### DIFF
--- a/stl/src/xfvalues.cpp
+++ b/stl/src/xfvalues.cpp
@@ -28,6 +28,6 @@ extern /* const */ _Dconst _FNan    = {INIT((_FMAX << _FOFF) | (1 << (_FOFF - 1)
 extern /* const */ _Dconst _FSnan   = {INIT2(_FMAX << _FOFF, 1)};
 extern const _Dconst _FRteps        = {INIT((_FBIAS - NBITS / 2) << _FOFF)};
 
-extern const float _FXbig = (NBITS + 1) * 347L / 1000;
+extern const float _FXbig = (NBITS + 2) * 0.347f;
 
 _END_EXTERN_C_UNLESS_PURE

--- a/stl/src/xlvalues.cpp
+++ b/stl/src/xlvalues.cpp
@@ -26,4 +26,4 @@ extern /* const */ _Dconst _LNan    = {INIT((_DMAX << _DOFF) | (1 << (_DOFF - 1)
 extern /* const */ _Dconst _LSnan   = {INIT2(_DMAX << _DOFF, 1)};
 extern const _Dconst _LRteps        = {INIT((_DBIAS - NBITS / 2) << _DOFF)};
 
-extern const long double _LXbig = (NBITS + 1) * 347L / 1000;
+extern const long double _LXbig = (NBITS + 2) * 0.347L;

--- a/stl/src/xvalues.cpp
+++ b/stl/src/xvalues.cpp
@@ -28,4 +28,4 @@ extern /* const */ _Dconst _Nan     = {INIT((_DMAX << _DOFF) | (1 << (_DOFF - 1)
 extern /* const */ _Dconst _Snan    = {INIT2(_DMAX << _DOFF, 1)};
 extern const _Dconst _Rteps         = {INIT((_DBIAS - NBITS / 2) << _DOFF)};
 
-extern const double _Xbig = (NBITS + 1) * 347L / 1000;
+extern const double _Xbig = (NBITS + 2) * 0.347;

--- a/tests/std/test.lst
+++ b/tests/std/test.lst
@@ -164,6 +164,7 @@ tests\GH_000890_pow_template
 tests\GH_000940_missing_valarray_copy
 tests\GH_001010_filesystem_error_encoding
 tests\GH_001017_discrete_distribution_out_of_range
+tests\GH_001059_hyperbolic_truncation
 tests\GH_001086_partial_sort_copy
 tests\GH_001103_countl_zero_correctness
 tests\LWG2597_complex_branch_cut

--- a/tests/std/tests/GH_001059_hyperbolic_truncation/env.lst
+++ b/tests/std/tests/GH_001059_hyperbolic_truncation/env.lst
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+RUNALL_INCLUDE ..\usual_matrix.lst

--- a/tests/std/tests/GH_001059_hyperbolic_truncation/test.cpp
+++ b/tests/std/tests/GH_001059_hyperbolic_truncation/test.cpp
@@ -18,26 +18,26 @@ using namespace std;
 
 template <class T>
 void Test(T x) {
-    const complex<T> z{x};
-    const T exp_over_2 = T{0.5} * real(exp(z));
+    const complex<T> z{ x };
+    const T exp_over_2 = T{ 0.5 } *real(exp(z));
 
-    const T cosh_expected = exp_over_2 + T{0.25} / exp_over_2;
-    const T cosh_calc     = real(cosh(z));
+    const T cosh_expected = exp_over_2 + T{ 0.25 } / exp_over_2;
+    const T cosh_calc = real(cosh(z));
     if (cosh_expected != cosh_calc) {
         cout.precision(numeric_limits<T>::digits10 + 2);
         cout << "x = " << x << '\n'
-         << "cosh (expected)   = " << cosh_expected << '\n'
-         << "cosh (calculated) = " << cosh_calc << endl;
+            << "cosh (expected)   = " << cosh_expected << '\n'
+            << "cosh (calculated) = " << cosh_calc << endl;
         assert(cosh_expected == cosh_calc);
     }
 
-    const T sinh_expected = exp_over_2 - T{0.25} / exp_over_2;
-    const T sinh_calc     = real(sinh(z));
+    const T sinh_expected = exp_over_2 - T{ 0.25 } / exp_over_2;
+    const T sinh_calc = real(sinh(z));
     if (sinh_expected != sinh_calc) {
         cout.precision(numeric_limits<T>::digits10 + 2);
         cout << "x = " << x << '\n'
-             << "sinh (expected)   = " << sinh_expected << '\n'
-             << "sinh (calculated) = " << sinh_calc << endl;
+            << "sinh (expected)   = " << sinh_expected << '\n'
+            << "sinh (calculated) = " << sinh_calc << endl;
         assert(sinh_expected == sinh_calc);
     }
 }
@@ -46,15 +46,15 @@ template <class T>
 constexpr array<T, 3> GenerateValues() {
     // {old crossover, difference ~ 1 ulp, difference ~ ulp/2}
     constexpr int DIG = numeric_limits<T>::digits;
-    return {DIG * 347L / 1000L, DIG * static_cast<T>(0.347), (DIG + 1) * static_cast<T>(0.347)};
+    return { DIG * 347L / 1000L, DIG * static_cast<T>(0.347), (DIG + 1) * static_cast<T>(0.347) };
 }
 
 int main() {
-    constexpr auto fValues{GenerateValues<float>()};
+    constexpr auto fValues{ GenerateValues<float>() };
     for (auto x : fValues)
         Test<float>(x);
 
-    constexpr auto dValues{GenerateValues<double>()};
+    constexpr auto dValues{ GenerateValues<double>() };
     for (auto x : dValues)
         Test<double>(x);
 

--- a/tests/std/tests/GH_001059_hyperbolic_truncation/test.cpp
+++ b/tests/std/tests/GH_001059_hyperbolic_truncation/test.cpp
@@ -18,26 +18,26 @@ using namespace std;
 
 template <class T>
 void Test(T x) {
-    const complex<T> z{ x };
-    const T exp_over_2 = T{ 0.5 } *real(exp(z));
+    const complex<T> z{x};
+    const T exp_over_2 = T{0.5} * real(exp(z));
 
-    const T cosh_expected = exp_over_2 + T{ 0.25 } / exp_over_2;
-    const T cosh_calc = real(cosh(z));
+    const T cosh_expected = exp_over_2 + T{0.25} / exp_over_2;
+    const T cosh_calc     = real(cosh(z));
     if (cosh_expected != cosh_calc) {
         cout.precision(numeric_limits<T>::digits10 + 2);
         cout << "x = " << x << '\n'
-            << "cosh (expected)   = " << cosh_expected << '\n'
-            << "cosh (calculated) = " << cosh_calc << endl;
+             << "cosh (expected)   = " << cosh_expected << '\n'
+             << "cosh (calculated) = " << cosh_calc << endl;
         assert(cosh_expected == cosh_calc);
     }
 
-    const T sinh_expected = exp_over_2 - T{ 0.25 } / exp_over_2;
-    const T sinh_calc = real(sinh(z));
+    const T sinh_expected = exp_over_2 - T{0.25} / exp_over_2;
+    const T sinh_calc     = real(sinh(z));
     if (sinh_expected != sinh_calc) {
         cout.precision(numeric_limits<T>::digits10 + 2);
         cout << "x = " << x << '\n'
-            << "sinh (expected)   = " << sinh_expected << '\n'
-            << "sinh (calculated) = " << sinh_calc << endl;
+             << "sinh (expected)   = " << sinh_expected << '\n'
+             << "sinh (calculated) = " << sinh_calc << endl;
         assert(sinh_expected == sinh_calc);
     }
 }
@@ -46,15 +46,15 @@ template <class T>
 constexpr array<T, 3> GenerateValues() {
     // {old crossover, difference ~ 1 ulp, difference ~ ulp/2}
     constexpr int DIG = numeric_limits<T>::digits;
-    return { DIG * 347L / 1000L, DIG * static_cast<T>(0.347), (DIG + 1) * static_cast<T>(0.347) };
+    return {DIG * 347L / 1000L, DIG * static_cast<T>(0.347), (DIG + 1) * static_cast<T>(0.347)};
 }
 
 int main() {
-    constexpr auto fValues{ GenerateValues<float>() };
+    constexpr auto fValues{GenerateValues<float>()};
     for (auto x : fValues)
         Test<float>(x);
 
-    constexpr auto dValues{ GenerateValues<double>() };
+    constexpr auto dValues{GenerateValues<double>()};
     for (auto x : dValues)
         Test<double>(x);
 

--- a/tests/std/tests/GH_001059_hyperbolic_truncation/test.cpp
+++ b/tests/std/tests/GH_001059_hyperbolic_truncation/test.cpp
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// GH-1059: "Incorrect const float values in xvalues.cpp files"
+// The _Xbig constants, used to determine when the exp(-x) terms in
+// cosh and sinh can be ignored, have off-by-one and integer
+// truncation errors.
+
+#include <array>
+#include <cassert>
+#include <cmath>
+#include <complex>
+#include <iostream>
+#include <limits>
+#include <thread>
+
+using namespace std;
+
+template <class T>
+void Test(T x) {
+    const complex<T> z{x};
+    const T exp_over_2 = T{0.5} * real(exp(z));
+
+    const T cosh_expected = exp_over_2 + T{0.25} / exp_over_2;
+    const T cosh_calc     = real(cosh(z));
+    if (cosh_expected != cosh_calc) {
+        cout.precision(numeric_limits<T>::digits10 + 2);
+        cout << "x = " << x << '\n'
+         << "cosh (expected)   = " << cosh_expected << '\n'
+         << "cosh (calculated) = " << cosh_calc << endl;
+        assert(cosh_expected == cosh_calc);
+    }
+
+    const T sinh_expected = exp_over_2 - T{0.25} / exp_over_2;
+    const T sinh_calc     = real(sinh(z));
+    if (sinh_expected != sinh_calc) {
+        cout.precision(numeric_limits<T>::digits10 + 2);
+        cout << "x = " << x << '\n'
+             << "sinh (expected)   = " << sinh_expected << '\n'
+             << "sinh (calculated) = " << sinh_calc << endl;
+        assert(sinh_expected == sinh_calc);
+    }
+}
+
+template <class T>
+constexpr array<T, 3> GenerateValues() {
+    // {old crossover, difference ~ 1 ulp, difference ~ ulp/2}
+    constexpr int DIG = numeric_limits<T>::digits;
+    return {DIG * 347L / 1000L, DIG * static_cast<T>(0.347), (DIG + 1) * static_cast<T>(0.347)};
+}
+
+int main() {
+    constexpr auto fValues{GenerateValues<float>()};
+    for (auto x : fValues)
+        Test<float>(x);
+
+    constexpr auto dValues{GenerateValues<double>()};
+    for (auto x : dValues)
+        Test<double>(x);
+
+    return 0;
+}


### PR DESCRIPTION
Fixes #1059.

 - Need to introduce a floating point to avoid integer truncation.
 - The exp(-x) term needs to be smaller than ULP/2, which requires x > (p+1)*ln(2)/2. But `NBITS` is the number of physical, not effective, bits, so `(NBITS+2)` is needed. Could also use `numeric_limits<T>::digits+1`.