### PR TITLE
Use memset and memcmp in a bit more cases

### DIFF
--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -3993,9 +3993,7 @@ namespace ranges {
 #endif // __cpp_lib_is_constant_evaluated
                 {
                     const auto _Distance = static_cast<size_t>(_ULast - _UFirst);
-                    using _DestTy        = _Iter_value_t<decltype(_UFirst)>;
-                    // first cast _Value to _DestTy in case _DestTy is bool
-                    _CSTD memset(_UFirst, static_cast<unsigned char>(static_cast<_DestTy>(_Value)), _Distance);
+                    _Fill_memset(_UFirst, _Value, _Distance);
                     _UFirst += _Distance;
                     _Seek_wrapped(_First, _UFirst);
                     return _First;
@@ -4034,10 +4032,7 @@ namespace ranges {
                     if (!_STD is_constant_evaluated())
 #endif // __cpp_lib_is_constant_evaluated
                     {
-                        using _DestTy = _Iter_value_t<decltype(_UFirst)>;
-                        // first cast _Value to _DestTy in case _DestTy is bool
-                        _CSTD memset(_UFirst, static_cast<unsigned char>(static_cast<_DestTy>(_Value)),
-                            static_cast<size_t>(_Count));
+                        _Fill_memset(_UFirst, _Value, static_cast<size_t>(_Count));
                         _UFirst += _Count;
                         _Seek_wrapped(_First, _UFirst); // no need to move since _UFirst is a pointer
                         return _First;

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -3993,7 +3993,9 @@ namespace ranges {
 #endif // __cpp_lib_is_constant_evaluated
                 {
                     const auto _Distance = static_cast<size_t>(_ULast - _UFirst);
-                    _CSTD memset(_UFirst, static_cast<unsigned char>(_Value), _Distance);
+                    using _DestTy        = _Iter_value_t<decltype(_UFirst)>;
+                    // first cast _Value to _DestTy in case _DestTy is bool
+                    _CSTD memset(_UFirst, static_cast<unsigned char>(static_cast<_DestTy>(_Value)), _Distance);
                     _UFirst += _Distance;
                     _Seek_wrapped(_First, _UFirst);
                     return _First;
@@ -4032,7 +4034,9 @@ namespace ranges {
                     if (!_STD is_constant_evaluated())
 #endif // __cpp_lib_is_constant_evaluated
                     {
-                        _CSTD memset(_UFirst, static_cast<unsigned char>(_Value), static_cast<size_t>(_Count));
+                        using _DestTy = _Iter_value_t<decltype(_UFirst)>;
+                        // first cast _Value to _DestTy in case _DestTy is bool
+                        _CSTD memset(_UFirst, static_cast<unsigned char>(static_cast<_DestTy>(_Value)), static_cast<size_t>(_Count));
                         _UFirst += _Count;
                         _Seek_wrapped(_First, _UFirst); // no need to move since _UFirst is a pointer
                         return _First;

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -4036,7 +4036,8 @@ namespace ranges {
                     {
                         using _DestTy = _Iter_value_t<decltype(_UFirst)>;
                         // first cast _Value to _DestTy in case _DestTy is bool
-                        _CSTD memset(_UFirst, static_cast<unsigned char>(static_cast<_DestTy>(_Value)), static_cast<size_t>(_Count));
+                        _CSTD memset(_UFirst, static_cast<unsigned char>(static_cast<_DestTy>(_Value)),
+                            static_cast<size_t>(_Count));
                         _UFirst += _Count;
                         _Seek_wrapped(_First, _UFirst); // no need to move since _UFirst is a pointer
                         return _First;

--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -134,7 +134,9 @@ _NoThrowFwdIt uninitialized_fill_n(_NoThrowFwdIt _First, const _Diff _Count_raw,
     if (0 < _Count) {
         auto _UFirst = _Get_unwrapped_n(_First, _Count);
         if constexpr (_Fill_memset_is_safe<_Unwrapped_n_t<const _NoThrowFwdIt&>, _Tval>) {
-            _CSTD memset(_UFirst, static_cast<unsigned char>(_Val), _Count);
+            using _DestTy = _Iter_value_t<_Unwrapped_n_t<const _NoThrowFwdIt&>>;
+            // first cast _Val to _DestTy in case _DestTy is bool
+            _CSTD memset(_UFirst, static_cast<unsigned char>(static_cast<_DestTy>(_Val)), _Count);
             _UFirst += _Count;
         } else {
             _Uninitialized_backout<_Unwrapped_n_t<const _NoThrowFwdIt&>> _Backout{_UFirst};
@@ -167,7 +169,9 @@ template <class _NoThrowFwdIt, class _Diff, class _Tval>
 _NoThrowFwdIt _Uninitialized_fill_n_unchecked1(
     const _NoThrowFwdIt _First, const _Diff _Count, const _Tval& _Val, true_type) {
     // copy _Count copies of _Val to raw _First, memset optimization
-    _CSTD memset(_First, static_cast<unsigned char>(_Val), _Count);
+    using _DestTy = _Iter_value_t<_NoThrowFwdIt>;
+    // first cast _Val to _DestTy in case _DestTy is bool
+    _CSTD memset(_First, static_cast<unsigned char>(static_cast<_DestTy>(_Val)), _Count);
     return _First + _Count;
 }
 

--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -134,9 +134,7 @@ _NoThrowFwdIt uninitialized_fill_n(_NoThrowFwdIt _First, const _Diff _Count_raw,
     if (0 < _Count) {
         auto _UFirst = _Get_unwrapped_n(_First, _Count);
         if constexpr (_Fill_memset_is_safe<_Unwrapped_n_t<const _NoThrowFwdIt&>, _Tval>) {
-            using _DestTy = _Iter_value_t<_Unwrapped_n_t<const _NoThrowFwdIt&>>;
-            // first cast _Val to _DestTy in case _DestTy is bool
-            _CSTD memset(_UFirst, static_cast<unsigned char>(static_cast<_DestTy>(_Val)), _Count);
+            _Fill_memset(_UFirst, _Val, _Count);
             _UFirst += _Count;
         } else {
             _Uninitialized_backout<_Unwrapped_n_t<const _NoThrowFwdIt&>> _Backout{_UFirst};
@@ -169,9 +167,7 @@ template <class _NoThrowFwdIt, class _Diff, class _Tval>
 _NoThrowFwdIt _Uninitialized_fill_n_unchecked1(
     const _NoThrowFwdIt _First, const _Diff _Count, const _Tval& _Val, true_type) {
     // copy _Count copies of _Val to raw _First, memset optimization
-    using _DestTy = _Iter_value_t<_NoThrowFwdIt>;
-    // first cast _Val to _DestTy in case _DestTy is bool
-    _CSTD memset(_First, static_cast<unsigned char>(static_cast<_DestTy>(_Val)), _Count);
+    _Fill_memset(_First, _Val, _Count);
     return _First + _Count;
 }
 
@@ -1657,7 +1653,7 @@ void _Uninitialized_fill_multidimensional_n(_Ty* const _Out, const size_t _Size,
         }
         _Guard._Target = nullptr;
     } else if constexpr (_Fill_memset_is_safe<_Ty*, _Ty>) {
-        _CSTD memset(_Out, static_cast<unsigned char>(_Val), _Size);
+        _Fill_memset(_Out, _Val, _Size);
     } else {
         _Uninitialized_rev_destroying_backout _Backout{_Out};
         for (size_t _Idx = 0; _Idx < _Size; ++_Idx) {
@@ -1980,7 +1976,7 @@ void _Uninitialized_fill_multidimensional_n_al(_Ty* const _Out, const size_t _Si
         }
         _Guard._Target = nullptr;
     } else if constexpr (_Fill_memset_is_safe<_Ty*, _Ty> && _Uses_default_construct<_Alloc, _Ty*, const _Ty&>::value) {
-        _CSTD memset(_Out, static_cast<unsigned char>(_Val), _Size);
+        _Fill_memset(_Out, _Val, _Size);
     } else {
         _Uninitialized_rev_destroying_backout_al _Backout{_Out, _Al};
         for (size_t _Idx = 0; _Idx < _Size; ++_Idx) {

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -1756,7 +1756,9 @@ void uninitialized_fill(const _NoThrowFwdIt _First, const _NoThrowFwdIt _Last, c
     auto _UFirst      = _Get_unwrapped(_First);
     const auto _ULast = _Get_unwrapped(_Last);
     if constexpr (_Fill_memset_is_safe<_Unwrapped_t<const _NoThrowFwdIt&>, _Tval>) {
-        _CSTD memset(_UFirst, static_cast<unsigned char>(_Val), static_cast<size_t>(_ULast - _UFirst));
+        using _DestTy = _Iter_value_t<_Unwrapped_t<const _NoThrowFwdIt&>>;
+        // first cast _Val to _DestTy in case _DestTy is bool
+        _CSTD memset(_UFirst, static_cast<unsigned char>(static_cast<_DestTy>(_Val)), static_cast<size_t>(_ULast - _UFirst));
     } else {
         _Uninitialized_backout<_Unwrapped_t<const _NoThrowFwdIt&>> _Backout{_UFirst};
         while (_Backout._Last != _ULast) {
@@ -1783,7 +1785,9 @@ template <class _NoThrowFwdIt, class _Tval>
 void _Uninitialized_fill_unchecked(
     const _NoThrowFwdIt _First, const _NoThrowFwdIt _Last, const _Tval& _Val, true_type) {
     // copy _Val throughout raw [_First, _Last), memset optimization
-    _CSTD memset(_First, static_cast<unsigned char>(_Val), static_cast<size_t>(_Last - _First));
+    using _DestTy = _Iter_value_t<_NoThrowFwdIt>;
+    // first cast _Val to _DestTy in case _DestTy is bool
+    _CSTD memset(_First, static_cast<unsigned char>(static_cast<_DestTy>(_Val)), static_cast<size_t>(_Last - _First));
 }
 
 template <class _NoThrowFwdIt, class _Tval>

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -1758,7 +1758,8 @@ void uninitialized_fill(const _NoThrowFwdIt _First, const _NoThrowFwdIt _Last, c
     if constexpr (_Fill_memset_is_safe<_Unwrapped_t<const _NoThrowFwdIt&>, _Tval>) {
         using _DestTy = _Iter_value_t<_Unwrapped_t<const _NoThrowFwdIt&>>;
         // first cast _Val to _DestTy in case _DestTy is bool
-        _CSTD memset(_UFirst, static_cast<unsigned char>(static_cast<_DestTy>(_Val)), static_cast<size_t>(_ULast - _UFirst));
+        _CSTD memset(
+            _UFirst, static_cast<unsigned char>(static_cast<_DestTy>(_Val)), static_cast<size_t>(_ULast - _UFirst));
     } else {
         _Uninitialized_backout<_Unwrapped_t<const _NoThrowFwdIt&>> _Backout{_UFirst};
         while (_Backout._Last != _ULast) {

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -1705,7 +1705,7 @@ _Alloc_ptr_t<_Alloc> _Uninitialized_fill_n(
     // copy _Count copies of _Val to raw _First, using _Al
     using _Ty = typename _Alloc::value_type;
     if constexpr (_Fill_memset_is_safe<_Ty*, _Ty> && _Uses_default_construct<_Alloc, _Ty*, _Ty>::value) {
-        _CSTD memset(_Unfancy(_First), static_cast<unsigned char>(_Val), static_cast<size_t>(_Count));
+        _Fill_memset(_Unfancy(_First), _Val, static_cast<size_t>(_Count));
         return _First + _Count;
     } else {
         _Uninitialized_backout_al<_Alloc> _Backout{_First, _Al};
@@ -1733,7 +1733,7 @@ template <class _Alloc>
 _Alloc_ptr_t<_Alloc> _Uninit_alloc_fill_n1(_Alloc_ptr_t<_Alloc> _First, _Alloc_size_t<_Alloc> _Count,
     const typename _Alloc::value_type& _Val, _Alloc&, true_type) {
     // copy _Count copies of _Val to raw _First, using default _Alloc construct, memset optimization
-    _CSTD memset(_Unfancy(_First), static_cast<unsigned char>(_Val), _Count);
+    _Fill_memset(_Unfancy(_First), _Val, _Count);
     return _First + _Count;
 }
 
@@ -1756,10 +1756,7 @@ void uninitialized_fill(const _NoThrowFwdIt _First, const _NoThrowFwdIt _Last, c
     auto _UFirst      = _Get_unwrapped(_First);
     const auto _ULast = _Get_unwrapped(_Last);
     if constexpr (_Fill_memset_is_safe<_Unwrapped_t<const _NoThrowFwdIt&>, _Tval>) {
-        using _DestTy = _Iter_value_t<_Unwrapped_t<const _NoThrowFwdIt&>>;
-        // first cast _Val to _DestTy in case _DestTy is bool
-        _CSTD memset(
-            _UFirst, static_cast<unsigned char>(static_cast<_DestTy>(_Val)), static_cast<size_t>(_ULast - _UFirst));
+        _Fill_memset(_UFirst, _Val, static_cast<size_t>(_ULast - _UFirst));
     } else {
         _Uninitialized_backout<_Unwrapped_t<const _NoThrowFwdIt&>> _Backout{_UFirst};
         while (_Backout._Last != _ULast) {
@@ -1786,9 +1783,7 @@ template <class _NoThrowFwdIt, class _Tval>
 void _Uninitialized_fill_unchecked(
     const _NoThrowFwdIt _First, const _NoThrowFwdIt _Last, const _Tval& _Val, true_type) {
     // copy _Val throughout raw [_First, _Last), memset optimization
-    using _DestTy = _Iter_value_t<_NoThrowFwdIt>;
-    // first cast _Val to _DestTy in case _DestTy is bool
-    _CSTD memset(_First, static_cast<unsigned char>(static_cast<_DestTy>(_Val)), static_cast<size_t>(_Last - _First));
+    _Fill_memset(_First, _Val, static_cast<size_t>(_Last - _First));
 }
 
 template <class _NoThrowFwdIt, class _Tval>

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -4912,9 +4912,6 @@ template <class _Elem1, class _Elem2,
            && _Is_nonbool_integral<_Elem2> && !is_volatile_v<_Elem2>>
 _INLINE_VAR constexpr bool _Can_memcmp_elements = static_cast<_Elem1>(-1) == static_cast<_Elem2>(-1);
 
-template <bool _False>
-_INLINE_VAR constexpr bool _Can_memcmp_elements<bool, bool, _False> = true;
-
 #ifdef __cpp_lib_byte
 // Allow memcmping std::byte.
 // inline is required here as explicit specializations of variable templates are problematic in C++14.
@@ -4930,7 +4927,7 @@ template <class _Ty1, class _Ty2>
 _INLINE_VAR constexpr bool _Can_memcmp_elements<_Ty1*, _Ty2*, false> = is_same_v<remove_cv_t<_Ty1>, remove_cv_t<_Ty2>>;
 
 template <class _Elem1, class _Elem2>
-_INLINE_VAR constexpr bool _Can_memcmp_elements<_Elem1, _Elem2, false> = false;
+_INLINE_VAR constexpr bool _Can_memcmp_elements<_Elem1, _Elem2, false> = is_same_v<_Elem1, bool> && is_same_v<_Elem2, bool>;
 
 // _Pred_is_consistent_with_memcmp<_Elem1, _Elem2, _Pr> reports whether `_Pr(_Elem1, _Elem2)` returns
 // `_Elem1 == _Elem2` without performing any type conversions that could affect the memcmp optimization.

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -4927,7 +4927,8 @@ template <class _Ty1, class _Ty2>
 _INLINE_VAR constexpr bool _Can_memcmp_elements<_Ty1*, _Ty2*, false> = is_same_v<remove_cv_t<_Ty1>, remove_cv_t<_Ty2>>;
 
 template <class _Elem1, class _Elem2>
-_INLINE_VAR constexpr bool _Can_memcmp_elements<_Elem1, _Elem2, false> = is_same_v<_Elem1, bool> && is_same_v<_Elem2, bool>;
+_INLINE_VAR constexpr bool _Can_memcmp_elements<_Elem1, _Elem2, false> =
+    is_same_v<_Elem1, bool>&& is_same_v<_Elem2, bool>;
 
 // _Pred_is_consistent_with_memcmp<_Elem1, _Elem2, _Pr> reports whether `_Pr(_Elem1, _Elem2)` returns
 // `_Elem1 == _Elem2` without performing any type conversions that could affect the memcmp optimization.

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -4903,14 +4903,13 @@ _FwdIt fill_n(_ExPo&&, _FwdIt _Dest, _Diff _Count_raw, const _Ty& _Val) noexcept
 
 // Integral types are eligible for memcmp in very specific cases.
 // * They must be the same size. (`int == long` is eligible; `int == long long` isn't.)
-// * They can't be bool. (Not even `bool == bool`; we're concerned about representations other than 0 and 1.)
 // * They can't be volatile.
 // * Finally, the usual arithmetic conversions must preserve bit patterns. (This is true for `int == unsigned int`,
 //   but false for `short == unsigned short`.)
 template <class _Elem1, class _Elem2,
     bool = sizeof(_Elem1) == sizeof(_Elem2) //
-           && _Is_nonbool_integral<_Elem1> && !is_volatile_v<_Elem1> //
-           && _Is_nonbool_integral<_Elem2> && !is_volatile_v<_Elem2>>
+           && is_integral_v<_Elem1> && !is_volatile_v<_Elem1> //
+           && is_integral_v<_Elem2> && !is_volatile_v<_Elem2>>
 _INLINE_VAR constexpr bool _Can_memcmp_elements = static_cast<_Elem1>(-1) == static_cast<_Elem2>(-1);
 
 #ifdef __cpp_lib_byte

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -4913,7 +4913,7 @@ template <class _Elem1, class _Elem2,
 _INLINE_VAR constexpr bool _Can_memcmp_elements = static_cast<_Elem1>(-1) == static_cast<_Elem2>(-1);
 
 template <>
-inline constexpr bool _Can_memcmp_elements<bool, bool, false> = true;
+_INLINE_VAR constexpr bool _Can_memcmp_elements<bool, bool, false> = true;
 
 #ifdef __cpp_lib_byte
 // Allow memcmping std::byte.

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -4908,9 +4908,12 @@ _FwdIt fill_n(_ExPo&&, _FwdIt _Dest, _Diff _Count_raw, const _Ty& _Val) noexcept
 //   but false for `short == unsigned short`.)
 template <class _Elem1, class _Elem2,
     bool = sizeof(_Elem1) == sizeof(_Elem2) //
-           && is_integral_v<_Elem1> && !is_volatile_v<_Elem1> //
-           && is_integral_v<_Elem2> && !is_volatile_v<_Elem2>>
+           && _Is_nonbool_integral<_Elem1> && !is_volatile_v<_Elem1> //
+           && _Is_nonbool_integral<_Elem2> && !is_volatile_v<_Elem2>>
 _INLINE_VAR constexpr bool _Can_memcmp_elements = static_cast<_Elem1>(-1) == static_cast<_Elem2>(-1);
+
+template <>
+inline constexpr bool _Can_memcmp_elements<bool, bool, false> = true;
 
 #ifdef __cpp_lib_byte
 // Allow memcmping std::byte.

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -4732,20 +4732,21 @@ struct _Is_character<char8_t> : true_type {}; // UTF-8 code units are sort-of ch
 #endif // __cpp_char8_t
 
 template <class _Ty>
-struct _Is_character_or_byte : _Is_character<_Ty>::type {};
+struct _Is_character_or_byte_or_bool : _Is_character<_Ty>::type {};
 
 #ifdef __cpp_lib_byte
 template <>
-struct _Is_character_or_byte<byte> : true_type {};
+struct _Is_character_or_byte_or_bool<byte> : true_type {};
 #endif // __cpp_lib_byte
+
+template <>
+struct _Is_character_or_byte_or_bool<bool> : true_type {};
 
 // _Fill_memset_is_safe determines if _FwdIt and _Ty are eligible for memset optimization in fill
 template <class _FwdIt, class _Ty, bool = is_pointer_v<_FwdIt>>
-_INLINE_VAR constexpr bool _Fill_memset_is_safe = conjunction_v<
-    disjunction<conjunction<_Is_character_or_byte<_Unwrap_enum_t<_Ty>>,
-                    _Is_character_or_byte<_Unwrap_enum_t<_Iter_value_t<_FwdIt>>>>,
-        conjunction<is_same<bool, _Unwrap_enum_t<_Ty>>, is_same<bool, _Unwrap_enum_t<_Iter_value_t<_FwdIt>>>>>,
-    is_assignable<_Iter_ref_t<_FwdIt>, const _Ty&>>;
+_INLINE_VAR constexpr bool _Fill_memset_is_safe =
+    conjunction_v<is_scalar<_Ty>, _Is_character_or_byte_or_bool<_Unwrap_enum_t<_Iter_value_t<_FwdIt>>>,
+        is_assignable<_Iter_ref_t<_FwdIt>, const _Ty&>>;
 
 template <class _FwdIt, class _Ty>
 _INLINE_VAR constexpr bool _Fill_memset_is_safe<_FwdIt, _Ty, false> = false;
@@ -4765,7 +4766,10 @@ _CONSTEXPR20 void fill(const _FwdIt _First, const _FwdIt _Last, const _Ty& _Val)
             if (!_STD is_constant_evaluated())
 #endif // __cpp_lib_is_constant_evaluated
             {
-                _CSTD memset(_UFirst, static_cast<unsigned char>(_Val), static_cast<size_t>(_ULast - _UFirst));
+                using _DestTy = _Iter_value_t<decltype(_UFirst)>;
+                // first cast _Val to _DestTy in case _DestTy is bool
+                _CSTD memset(_UFirst, static_cast<unsigned char>(static_cast<_DestTy>(_Val)),
+                    static_cast<size_t>(_ULast - _UFirst));
                 return;
             }
         }
@@ -4787,7 +4791,9 @@ void _Fill_unchecked1(_FwdIt _First, _FwdIt _Last, const _Ty& _Val, false_type) 
 template <class _FwdIt, class _Ty>
 void _Fill_unchecked1(_FwdIt _First, _FwdIt _Last, const _Ty& _Val, true_type) {
     // copy _Val through [_First, _Last), memset optimization
-    _CSTD memset(_First, static_cast<unsigned char>(_Val), static_cast<size_t>(_Last - _First));
+    using _DestTy = _Iter_value_t<_FwdIt>;
+    // first cast _Val to _DestTy in case _DestTy is bool
+    _CSTD memset(_First, static_cast<unsigned char>(static_cast<_DestTy>(_Val)), static_cast<size_t>(_Last - _First));
 }
 
 template <class _FwdIt, class _Ty>
@@ -4826,7 +4832,10 @@ _CONSTEXPR20 _OutIt fill_n(_OutIt _Dest, const _Diff _Count_raw, const _Ty& _Val
                 if (!_STD is_constant_evaluated())
 #endif // __cpp_lib_is_constant_evaluated
                 {
-                    _CSTD memset(_UDest, static_cast<unsigned char>(_Val), static_cast<size_t>(_Count));
+                    using _DestTy = _Iter_value_t<decltype(_UDest)>;
+                    // first cast _Val to _DestTy in case _DestTy is bool
+                    _CSTD memset(
+                        _UDest, static_cast<unsigned char>(static_cast<_DestTy>(_Val)), static_cast<size_t>(_Count));
                     _UDest += _Count;
                     _Seek_wrapped(_Dest, _UDest);
                     return _Dest;
@@ -4857,7 +4866,9 @@ _OutIt _Fill_n_unchecked2(_OutIt _Dest, _Diff _Count, const _Ty& _Val, false_typ
 template <class _OutIt, class _Diff, class _Ty>
 _OutIt _Fill_n_unchecked2(_OutIt _Dest, _Diff _Count, const _Ty& _Val, true_type) {
     // copy _Val _Count times through [_Dest, ...), memset optimization
-    _CSTD memset(_Dest, static_cast<unsigned char>(_Val), static_cast<size_t>(_Count));
+    using _DestTy = _Iter_value_t<_OutIt>;
+    // first cast _Val to _DestTy in case _DestTy is bool
+    _CSTD memset(_Dest, static_cast<unsigned char>(static_cast<_DestTy>(_Val)), static_cast<size_t>(_Count));
     return _Dest + _Count;
 }
 

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -4904,9 +4904,10 @@ _FwdIt fill_n(_ExPo&&, _FwdIt _Dest, _Diff _Count_raw, const _Ty& _Val) noexcept
 //   but false for `short == unsigned short`.)
 template <class _Elem1, class _Elem2,
     bool = sizeof(_Elem1) == sizeof(_Elem2) //
-           && _Is_nonbool_integral<_Elem1> && !is_volatile_v<_Elem1> //
-           && _Is_nonbool_integral<_Elem2> && !is_volatile_v<_Elem2>>
-_INLINE_VAR constexpr bool _Can_memcmp_elements = static_cast<_Elem1>(-1) == static_cast<_Elem2>(-1);
+           && is_integral_v<_Elem1> && !is_volatile_v<_Elem1> //
+           && is_integral_v<_Elem2> && !is_volatile_v<_Elem2>>
+_INLINE_VAR constexpr bool _Can_memcmp_elements =
+    is_same_v<_Elem1, bool> || is_same_v<_Elem2, bool> || static_cast<_Elem1>(-1) == static_cast<_Elem2>(-1);
 
 #ifdef __cpp_lib_byte
 // Allow memcmping std::byte.
@@ -4923,8 +4924,7 @@ template <class _Ty1, class _Ty2>
 _INLINE_VAR constexpr bool _Can_memcmp_elements<_Ty1*, _Ty2*, false> = is_same_v<remove_cv_t<_Ty1>, remove_cv_t<_Ty2>>;
 
 template <class _Elem1, class _Elem2>
-_INLINE_VAR constexpr bool _Can_memcmp_elements<_Elem1, _Elem2, false> =
-    is_same_v<_Elem1, bool>&& is_same_v<_Elem2, bool>;
+_INLINE_VAR constexpr bool _Can_memcmp_elements<_Elem1, _Elem2, false> = false;
 
 // _Pred_is_consistent_with_memcmp<_Elem1, _Elem2, _Pr> reports whether `_Pr(_Elem1, _Elem2)` returns
 // `_Elem1 == _Elem2` without performing any type conversions that could affect the memcmp optimization.

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -4752,7 +4752,7 @@ template <class _FwdIt, class _Ty>
 _INLINE_VAR constexpr bool _Fill_memset_is_safe<_FwdIt, _Ty, false> = false;
 
 template <class _DestTy, class _Ty>
-void _Fill_memset(_DestTy* const _Dest, const _Ty& _Val, size_t _Count) {
+void _Fill_memset(_DestTy* const _Dest, const _Ty _Val, const size_t _Count) {
     // first cast _Val to _DestTy in case _DestTy is bool
     _CSTD memset(_Dest, static_cast<unsigned char>(static_cast<_DestTy>(_Val)), _Count);
 }

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -4744,9 +4744,9 @@ struct _Is_character_or_byte_or_bool<bool> : true_type {};
 
 // _Fill_memset_is_safe determines if _FwdIt and _Ty are eligible for memset optimization in fill
 template <class _FwdIt, class _Ty, bool = is_pointer_v<_FwdIt>>
-_INLINE_VAR constexpr bool _Fill_memset_is_safe =
-    conjunction_v<is_scalar<_Ty>, _Is_character_or_byte_or_bool<_Unwrap_enum_t<_Iter_value_t<_FwdIt>>>,
-        is_assignable<_Iter_ref_t<_FwdIt>, const _Ty&>>;
+_INLINE_VAR constexpr bool _Fill_memset_is_safe = conjunction_v<is_scalar<_Ty>,
+    _Is_character_or_byte_or_bool<_Unwrap_enum_t<remove_reference_t<_Iter_ref_t<_FwdIt>>>>,
+    is_assignable<_Iter_ref_t<_FwdIt>, const _Ty&>>;
 
 template <class _FwdIt, class _Ty>
 _INLINE_VAR constexpr bool _Fill_memset_is_safe<_FwdIt, _Ty, false> = false;

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -4912,8 +4912,8 @@ template <class _Elem1, class _Elem2,
            && _Is_nonbool_integral<_Elem2> && !is_volatile_v<_Elem2>>
 _INLINE_VAR constexpr bool _Can_memcmp_elements = static_cast<_Elem1>(-1) == static_cast<_Elem2>(-1);
 
-template <>
-_INLINE_VAR constexpr bool _Can_memcmp_elements<bool, bool, false> = true;
+template <bool _False>
+_INLINE_VAR constexpr bool _Can_memcmp_elements<bool, bool, _False> = true;
 
 #ifdef __cpp_lib_byte
 // Allow memcmping std::byte.

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -4751,6 +4751,12 @@ _INLINE_VAR constexpr bool _Fill_memset_is_safe =
 template <class _FwdIt, class _Ty>
 _INLINE_VAR constexpr bool _Fill_memset_is_safe<_FwdIt, _Ty, false> = false;
 
+template <class _DestTy, class _Ty>
+void _Fill_memset(_DestTy* const _Dest, const _Ty& _Val, size_t _Count) {
+    // first cast _Val to _DestTy in case _DestTy is bool
+    _CSTD memset(_Dest, static_cast<unsigned char>(static_cast<_DestTy>(_Val)), _Count);
+}
+
 #if _HAS_IF_CONSTEXPR
 template <class _FwdIt, class _Ty>
 _CONSTEXPR20 void fill(const _FwdIt _First, const _FwdIt _Last, const _Ty& _Val) {
@@ -4766,10 +4772,7 @@ _CONSTEXPR20 void fill(const _FwdIt _First, const _FwdIt _Last, const _Ty& _Val)
             if (!_STD is_constant_evaluated())
 #endif // __cpp_lib_is_constant_evaluated
             {
-                using _DestTy = _Iter_value_t<decltype(_UFirst)>;
-                // first cast _Val to _DestTy in case _DestTy is bool
-                _CSTD memset(_UFirst, static_cast<unsigned char>(static_cast<_DestTy>(_Val)),
-                    static_cast<size_t>(_ULast - _UFirst));
+                _Fill_memset(_UFirst, _Val, static_cast<size_t>(_ULast - _UFirst));
                 return;
             }
         }
@@ -4791,9 +4794,7 @@ void _Fill_unchecked1(_FwdIt _First, _FwdIt _Last, const _Ty& _Val, false_type) 
 template <class _FwdIt, class _Ty>
 void _Fill_unchecked1(_FwdIt _First, _FwdIt _Last, const _Ty& _Val, true_type) {
     // copy _Val through [_First, _Last), memset optimization
-    using _DestTy = _Iter_value_t<_FwdIt>;
-    // first cast _Val to _DestTy in case _DestTy is bool
-    _CSTD memset(_First, static_cast<unsigned char>(static_cast<_DestTy>(_Val)), static_cast<size_t>(_Last - _First));
+    _Fill_memset(_First, _Val, static_cast<size_t>(_Last - _First));
 }
 
 template <class _FwdIt, class _Ty>
@@ -4832,10 +4833,7 @@ _CONSTEXPR20 _OutIt fill_n(_OutIt _Dest, const _Diff _Count_raw, const _Ty& _Val
                 if (!_STD is_constant_evaluated())
 #endif // __cpp_lib_is_constant_evaluated
                 {
-                    using _DestTy = _Iter_value_t<decltype(_UDest)>;
-                    // first cast _Val to _DestTy in case _DestTy is bool
-                    _CSTD memset(
-                        _UDest, static_cast<unsigned char>(static_cast<_DestTy>(_Val)), static_cast<size_t>(_Count));
+                    _Fill_memset(_UDest, _Val, static_cast<size_t>(_Count));
                     _UDest += _Count;
                     _Seek_wrapped(_Dest, _UDest);
                     return _Dest;
@@ -4866,9 +4864,7 @@ _OutIt _Fill_n_unchecked2(_OutIt _Dest, _Diff _Count, const _Ty& _Val, false_typ
 template <class _OutIt, class _Diff, class _Ty>
 _OutIt _Fill_n_unchecked2(_OutIt _Dest, _Diff _Count, const _Ty& _Val, true_type) {
     // copy _Val _Count times through [_Dest, ...), memset optimization
-    using _DestTy = _Iter_value_t<_OutIt>;
-    // first cast _Val to _DestTy in case _DestTy is bool
-    _CSTD memset(_Dest, static_cast<unsigned char>(static_cast<_DestTy>(_Val)), static_cast<size_t>(_Count));
+    _Fill_memset(_Dest, _Val, static_cast<size_t>(_Count));
     return _Dest + _Count;
 }
 

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -4902,12 +4902,15 @@ _FwdIt fill_n(_ExPo&&, _FwdIt _Dest, _Diff _Count_raw, const _Ty& _Val) noexcept
 // * They can't be volatile.
 // * Finally, the usual arithmetic conversions must preserve bit patterns. (This is true for `int == unsigned int`,
 //   but false for `short == unsigned short`.)
+#pragma warning(push)
+#pragma warning(disable : 4806) // no value of type 'bool' promoted to type 'char' can equal the given constant
 template <class _Elem1, class _Elem2,
     bool = sizeof(_Elem1) == sizeof(_Elem2) //
            && is_integral_v<_Elem1> && !is_volatile_v<_Elem1> //
            && is_integral_v<_Elem2> && !is_volatile_v<_Elem2>>
 _INLINE_VAR constexpr bool _Can_memcmp_elements =
     is_same_v<_Elem1, bool> || is_same_v<_Elem2, bool> || static_cast<_Elem1>(-1) == static_cast<_Elem2>(-1);
+#pragma warning(pop)
 
 #ifdef __cpp_lib_byte
 // Allow memcmping std::byte.

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -4753,8 +4753,8 @@ _INLINE_VAR constexpr bool _Fill_memset_is_safe<_FwdIt, _Ty, false> = false;
 
 template <class _DestTy, class _Ty>
 void _Fill_memset(_DestTy* const _Dest, const _Ty _Val, const size_t _Count) {
-    // first cast _Val to _DestTy in case _DestTy is bool
-    _CSTD memset(_Dest, static_cast<unsigned char>(static_cast<_DestTy>(_Val)), _Count);
+    _DestTy _Dest_val = _Val; // implicitly convert (a cast would suppress warnings); also handles _DestTy being bool
+    _CSTD memset(_Dest, static_cast<unsigned char>(_Dest_val), _Count);
 }
 
 #if _HAS_IF_CONSTEXPR

--- a/tests/std/tests/P0896R4_ranges_alg_fill/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_fill/test.cpp
@@ -34,7 +34,7 @@ struct instantiator {
         { // Validate int is properly converted to bool
             bool output[] = {false, true, false};
             fill(ranges::begin(output), ranges::end(output), 5);
-            for (bool elem : output) {
+            for (const bool &elem : output) {
                 assert(elem == true);
             }
         }

--- a/tests/std/tests/P0896R4_ranges_alg_fill/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_fill/test.cpp
@@ -34,7 +34,7 @@ struct instantiator {
         { // Validate int is properly converted to bool
             bool output[] = {false, true, false};
             fill(ranges::begin(output), ranges::end(output), 5);
-            for (const bool &elem : output) {
+            for (const bool& elem : output) {
                 assert(elem == true);
             }
         }

--- a/tests/std/tests/P0896R4_ranges_alg_fill/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_fill/test.cpp
@@ -31,6 +31,13 @@ struct instantiator {
             }
             assert(result == ranges::end(output));
         }
+        { // Validate int is properly converted to bool
+            bool output[] = {false, true, false};
+            fill(ranges::begin(output), ranges::end(output), 5);
+            for (bool elem : output) {
+                assert(elem == true);
+            }
+        }
     }
 };
 

--- a/tests/std/tests/P0896R4_ranges_alg_fill_n/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_fill_n/test.cpp
@@ -36,6 +36,13 @@ struct instantiator {
             assert(ranges::equal(output, expected_output));
             assert(result == ranges::begin(output));
         }
+        { // Validate int is properly converted to bool
+            bool output[] = { false, true, false };
+            fill_n(ranges::begin(output), ranges::distance(output), 5);
+            for (bool elem : output) {
+                assert(elem == true);
+            }
+        }
     }
 };
 

--- a/tests/std/tests/P0896R4_ranges_alg_fill_n/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_fill_n/test.cpp
@@ -39,7 +39,7 @@ struct instantiator {
         { // Validate int is properly converted to bool
             bool output[] = {false, true, false};
             fill_n(ranges::begin(output), ranges::distance(output), 5);
-            for (bool elem : output) {
+            for (const bool &elem : output) {
                 assert(elem == true);
             }
         }

--- a/tests/std/tests/P0896R4_ranges_alg_fill_n/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_fill_n/test.cpp
@@ -37,7 +37,7 @@ struct instantiator {
             assert(result == ranges::begin(output));
         }
         { // Validate int is properly converted to bool
-            bool output[] = { false, true, false };
+            bool output[] = {false, true, false};
             fill_n(ranges::begin(output), ranges::distance(output), 5);
             for (bool elem : output) {
                 assert(elem == true);

--- a/tests/std/tests/P0896R4_ranges_alg_fill_n/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_fill_n/test.cpp
@@ -39,7 +39,7 @@ struct instantiator {
         { // Validate int is properly converted to bool
             bool output[] = {false, true, false};
             fill_n(ranges::begin(output), ranges::distance(output), 5);
-            for (const bool &elem : output) {
+            for (const bool& elem : output) {
                 assert(elem == true);
             }
         }

--- a/tests/std/tests/VSO_0180469_fill_family/test.cpp
+++ b/tests/std/tests/VSO_0180469_fill_family/test.cpp
@@ -19,7 +19,7 @@ using namespace std;
 
 // This thing is a workaround for C4309 "truncation of constant value"
 template <typename T, typename U>
-T cast(U i) {
+remove_volatile_t<T> cast(U i) {
     return static_cast<remove_volatile_t<T>>(i);
 }
 
@@ -131,7 +131,7 @@ int main() {
     test_fill<int, char>();
     test_fill<char, int>();
 
-    test_fill<volatile char, volatile char>();
+    test_fill<volatile char, char>();
 
     test_uninitialized_fill(
         [](count_copies* buff, size_t n, const count_copies& src) { uninitialized_fill(buff, buff + n, src); });

--- a/tests/std/tests/VSO_0180469_fill_family/test.cpp
+++ b/tests/std/tests/VSO_0180469_fill_family/test.cpp
@@ -20,7 +20,7 @@ using namespace std;
 // This thing is a workaround for C4309 "truncation of constant value"
 template <typename T, typename U>
 T cast(U i) {
-    return static_cast<T>(i);
+    return static_cast<remove_volatile_t<T>>(i);
 }
 
 // Tests that `fillCall`(buffer, value, startIndex, endIndex) fills [startIndex, endIndex) with `value`
@@ -130,6 +130,8 @@ int main() {
     test_fill<int, int>();
     test_fill<int, char>();
     test_fill<char, int>();
+
+    test_fill<volatile char, volatile char>();
 
     test_uninitialized_fill(
         [](count_copies* buff, size_t n, const count_copies& src) { uninitialized_fill(buff, buff + n, src); });

--- a/tests/std/tests/VSO_0180469_fill_family/test.cpp
+++ b/tests/std/tests/VSO_0180469_fill_family/test.cpp
@@ -136,4 +136,34 @@ int main() {
 
     test_uninitialized_fill(
         [](count_copies* buff, size_t n, const count_copies& src) { uninitialized_fill_n(buff, n, src); });
+
+    // Validate int is properly converted to bool
+    {
+        bool output[] = {false, true, false};
+        fill(output, output + 3, 5);
+        for (bool elem : output) {
+            assert(elem == true);
+        }
+    }
+    {
+        bool output[] = {false, true, false};
+        fill_n(output, 3, 5);
+        for (bool elem : output) {
+            assert(elem == true);
+        }
+    }
+    {
+        bool output[] = {false, true, false};
+        uninitialized_fill(output, output + 3, 5);
+        for (bool elem : output) {
+            assert(elem == true);
+        }
+    }
+    {
+        bool output[] = {false, true, false};
+        uninitialized_fill_n(output, 3, 5);
+        for (bool elem : output) {
+            assert(elem == true);
+        }
+    }
 }

--- a/tests/std/tests/VSO_0180469_fill_family/test.cpp
+++ b/tests/std/tests/VSO_0180469_fill_family/test.cpp
@@ -143,28 +143,28 @@ int main() {
     {
         bool output[] = {false, true, false};
         fill(output, output + 3, 5);
-        for (const bool &elem : output) {
+        for (const bool& elem : output) {
             assert(elem == true);
         }
     }
     {
         bool output[] = {false, true, false};
         fill_n(output, 3, 5);
-        for (const bool &elem : output) {
+        for (const bool& elem : output) {
             assert(elem == true);
         }
     }
     {
         bool output[] = {false, true, false};
         uninitialized_fill(output, output + 3, 5);
-        for (const bool &elem : output) {
+        for (const bool& elem : output) {
             assert(elem == true);
         }
     }
     {
         bool output[] = {false, true, false};
         uninitialized_fill_n(output, 3, 5);
-        for (const bool &elem : output) {
+        for (const bool& elem : output) {
             assert(elem == true);
         }
     }

--- a/tests/std/tests/VSO_0180469_fill_family/test.cpp
+++ b/tests/std/tests/VSO_0180469_fill_family/test.cpp
@@ -131,7 +131,7 @@ int main() {
     test_fill<int, char>();
     test_fill<char, int>();
 
-    test_fill<volatile char, char>();
+    test_fill<volatile char, char>(); // Test GH-1183
 
     test_uninitialized_fill(
         [](count_copies* buff, size_t n, const count_copies& src) { uninitialized_fill(buff, buff + n, src); });
@@ -143,28 +143,28 @@ int main() {
     {
         bool output[] = {false, true, false};
         fill(output, output + 3, 5);
-        for (bool elem : output) {
+        for (const bool &elem : output) {
             assert(elem == true);
         }
     }
     {
         bool output[] = {false, true, false};
         fill_n(output, 3, 5);
-        for (bool elem : output) {
+        for (const bool &elem : output) {
             assert(elem == true);
         }
     }
     {
         bool output[] = {false, true, false};
         uninitialized_fill(output, output + 3, 5);
-        for (bool elem : output) {
+        for (const bool &elem : output) {
             assert(elem == true);
         }
     }
     {
         bool output[] = {false, true, false};
         uninitialized_fill_n(output, 3, 5);
-        for (bool elem : output) {
+        for (const bool &elem : output) {
             assert(elem == true);
         }
     }

--- a/tests/std/tests/VSO_0180469_ptr_cat/test.cpp
+++ b/tests/std/tests/VSO_0180469_ptr_cat/test.cpp
@@ -388,9 +388,13 @@ void equal_safe_test_cases() {
     test_case_Equal_memcmp_is_safe<sizeof(int) == sizeof(long), unsigned long, unsigned int>();
     test_case_Equal_memcmp_is_safe<true, long long, unsigned long long>();
     test_case_Equal_memcmp_is_safe<true, unsigned long long, long long>();
-    // memcmp is not safe between bool and other integral types
-    test_case_Equal_memcmp_is_safe<false, bool, char>();
-    test_case_Equal_memcmp_is_safe<false, char, bool>();
+#pragma warning(push)
+#pragma warning(disable : 4806) // no value of type '_Elem1' promoted to type '_Elem2' can equal the given constant
+    // memcmp is safe between bool and other integral types with the same size because we don't care about
+    // representations other than 0 and 1
+    test_case_Equal_memcmp_is_safe<true, bool, char>();
+    test_case_Equal_memcmp_is_safe<true, char, bool>();
+#pragma warning(pop)
     // No enums
     test_case_Equal_memcmp_is_safe<false, bool_enum, bool>();
     test_case_Equal_memcmp_is_safe<false, bool, bool_enum>();

--- a/tests/std/tests/VSO_0180469_ptr_cat/test.cpp
+++ b/tests/std/tests/VSO_0180469_ptr_cat/test.cpp
@@ -257,23 +257,31 @@ void test_case_Equal_memcmp_is_safe_comparator() {
 
 #ifdef __cpp_lib_concepts
     // contiguous iterators should not change the answer
-    STATIC_ASSERT(
-        _Equal_memcmp_is_safe<typename vector<Elem1>::iterator, typename vector<Elem2>::iterator, Pr> == Expected);
-    STATIC_ASSERT(_Equal_memcmp_is_safe<typename vector<Elem1>::const_iterator, typename vector<Elem2>::const_iterator,
-                      Pr> == Expected);
+    if constexpr (!is_same_v<Elem1, bool> && !is_same_v<Elem2, bool>) { // vector<bool>::iterator is not contiguous
+        STATIC_ASSERT(
+            _Equal_memcmp_is_safe<typename vector<Elem1>::iterator, typename vector<Elem2>::iterator, Pr> == Expected);
+        STATIC_ASSERT(_Equal_memcmp_is_safe<typename vector<Elem1>::const_iterator,
+                          typename vector<Elem2>::const_iterator, Pr> == Expected);
+    }
     STATIC_ASSERT(
         _Equal_memcmp_is_safe<typename array<Elem1, 1>::iterator, typename array<Elem2, 1>::iterator, Pr> == Expected);
     STATIC_ASSERT(_Equal_memcmp_is_safe<typename array<Elem1, 1>::const_iterator,
                       typename array<Elem2, 1>::const_iterator, Pr> == Expected);
     // Mixing contiguous iterators should not change the answer
-    STATIC_ASSERT(_Equal_memcmp_is_safe<typename vector<Elem1>::iterator, typename vector<Elem2>::const_iterator,
-                      Pr> == Expected);
-    STATIC_ASSERT(_Equal_memcmp_is_safe<typename array<Elem1, 1>::const_iterator,
-                      typename vector<Elem2>::const_iterator, Pr> == Expected);
-    STATIC_ASSERT(
-        _Equal_memcmp_is_safe<typename vector<Elem1>::iterator, typename array<Elem2, 1>::iterator, Pr> == Expected);
-    STATIC_ASSERT(_Equal_memcmp_is_safe<typename vector<Elem1>::iterator, typename array<Elem2, 1>::const_iterator,
-                      Pr> == Expected);
+    if constexpr (!is_same_v<Elem1, bool> && !is_same_v<Elem2, bool>) {
+        STATIC_ASSERT(_Equal_memcmp_is_safe<typename vector<Elem1>::iterator, typename vector<Elem2>::const_iterator,
+                          Pr> == Expected);
+    }
+    if constexpr (!is_same_v<Elem2, bool>) {
+        STATIC_ASSERT(_Equal_memcmp_is_safe<typename array<Elem1, 1>::const_iterator,
+                          typename vector<Elem2>::const_iterator, Pr> == Expected);
+    }
+    if constexpr (!is_same_v<Elem1, bool>) {
+        STATIC_ASSERT(_Equal_memcmp_is_safe<typename vector<Elem1>::iterator, typename array<Elem2, 1>::iterator,
+                          Pr> == Expected);
+        STATIC_ASSERT(_Equal_memcmp_is_safe<typename vector<Elem1>::iterator, typename array<Elem2, 1>::const_iterator,
+                          Pr> == Expected);
+    }
     // span iterators are contiguous
     STATIC_ASSERT(
         _Equal_memcmp_is_safe<typename span<Elem1>::iterator, typename span<Elem2>::iterator, Pr> == Expected);
@@ -335,7 +343,8 @@ void test_case_Equal_memcmp_is_safe() {
 }
 
 void equal_safe_test_cases() {
-    // memcmp is safe for non-bool integral types
+    // memcmp is safe for integral types
+    test_case_Equal_memcmp_is_safe<true, bool, bool>();
     test_case_Equal_memcmp_is_safe<true, char, char>();
     test_case_Equal_memcmp_is_safe<true, signed char, signed char>();
     test_case_Equal_memcmp_is_safe<true, unsigned char, unsigned char>();
@@ -377,8 +386,7 @@ void equal_safe_test_cases() {
     test_case_Equal_memcmp_is_safe<sizeof(int) == sizeof(long), unsigned long, unsigned int>();
     test_case_Equal_memcmp_is_safe<true, long long, unsigned long long>();
     test_case_Equal_memcmp_is_safe<true, unsigned long long, long long>();
-    // memcmp is not safe for bool types
-    test_case_Equal_memcmp_is_safe<false, bool, bool>();
+    // memcmp is not safe between bool and other integral types
     test_case_Equal_memcmp_is_safe<false, bool, char>();
     test_case_Equal_memcmp_is_safe<false, char, bool>();
     // No enums

--- a/tests/std/tests/VSO_0180469_ptr_cat/test.cpp
+++ b/tests/std/tests/VSO_0180469_ptr_cat/test.cpp
@@ -388,13 +388,10 @@ void equal_safe_test_cases() {
     test_case_Equal_memcmp_is_safe<sizeof(int) == sizeof(long), unsigned long, unsigned int>();
     test_case_Equal_memcmp_is_safe<true, long long, unsigned long long>();
     test_case_Equal_memcmp_is_safe<true, unsigned long long, long long>();
-#pragma warning(push)
-#pragma warning(disable : 4806) // no value of type '_Elem1' promoted to type '_Elem2' can equal the given constant
     // memcmp is safe between bool and other integral types with the same size because we don't care about
     // representations other than 0 and 1
     test_case_Equal_memcmp_is_safe<true, bool, char>();
     test_case_Equal_memcmp_is_safe<true, char, bool>();
-#pragma warning(pop)
     // No enums
     test_case_Equal_memcmp_is_safe<false, bool_enum, bool>();
     test_case_Equal_memcmp_is_safe<false, bool, bool_enum>();

--- a/tests/std/tests/VSO_0180469_ptr_cat/test.cpp
+++ b/tests/std/tests/VSO_0180469_ptr_cat/test.cpp
@@ -272,10 +272,12 @@ void test_case_Equal_memcmp_is_safe_comparator() {
         STATIC_ASSERT(_Equal_memcmp_is_safe<typename vector<Elem1>::iterator, typename vector<Elem2>::const_iterator,
                           Pr> == Expected);
     }
+
     if constexpr (!is_same_v<Elem2, bool>) {
         STATIC_ASSERT(_Equal_memcmp_is_safe<typename array<Elem1, 1>::const_iterator,
                           typename vector<Elem2>::const_iterator, Pr> == Expected);
     }
+
     if constexpr (!is_same_v<Elem1, bool>) {
         STATIC_ASSERT(_Equal_memcmp_is_safe<typename vector<Elem1>::iterator, typename array<Elem2, 1>::iterator,
                           Pr> == Expected);


### PR DESCRIPTION
A small PR to optimize `(ranges::)(uninitialized_)fill(_n)` when filling ranges of `bool` or `(signed|unsigned)char(8_t)` with other scalar types. Part of #431.

EDIT: Fixes #1183.