### PR TITLE
Remove noexcept from coroutine_handle<>::resume and operator()

### DIFF
--- a/stl/inc/coroutine
+++ b/stl/inc/coroutine
@@ -76,11 +76,11 @@ struct coroutine_handle<void> {
         return __builtin_coro_done(_Ptr);
     }
 
-    void operator()() const noexcept { // strengthened
+    void operator()() const {
         __builtin_coro_resume(_Ptr);
     }
 
-    void resume() const noexcept { // strengthened
+    void resume() const {
         __builtin_coro_resume(_Ptr);
     }
 

--- a/stl/inc/experimental/coroutine
+++ b/stl/inc/experimental/coroutine
@@ -95,7 +95,7 @@ namespace experimental {
             return _Ptr;
         }
 
-        void operator()() const noexcept {
+        void operator()() const {
             resume();
         }
 


### PR DESCRIPTION
With the adoption of [coroutine issue 25](http://open-std.org/JTC1/SC22/WG21/docs/papers/2018/p0664r6.html#25)
it is no longer undefined behavior for an exception to escape the body
of a coroutine, e.g. by rethrowing from `unhandled_exception`. Compiler
support for handling such an exception was introduced to MSVC with
version 16.7, and with this support it is now well-defined for `resume`
to exit with an exception. This PR removes the strengthened noexcept
specifiers from both `resume` and `operator()` which previously trapped
the undefined behavior.

<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
