### PR TITLE
Change VMs to Standard_D16as_v4

### DIFF
--- a/azure-devops/create-vmss.ps1
+++ b/azure-devops/create-vmss.ps1
@@ -17,7 +17,7 @@ or are running from Azure Cloud Shell.
 
 $Location = 'westus2'
 $Prefix = 'StlBuild-' + (Get-Date -Format 'yyyy-MM-dd')
-$VMSize = 'Standard_F16s_v2'
+$VMSize = 'Standard_D16as_v4'
 $ProtoVMName = 'PROTOTYPE'
 $LiveVMPrefix = 'BUILD'
 $WindowsServerSku = '2019-Datacenter'

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -296,7 +296,6 @@ Add-MpPreference -ExclusionProcess clang-cl.exe
 Add-MpPreference -ExclusionProcess cl.exe
 Add-MpPreference -ExclusionProcess link.exe
 Add-MpPreference -ExclusionProcess python.exe
-Add-MpPreference -ExclusionProcess test.exe
 
 InstallPython $PythonUrl
 InstallVisualStudio -Workloads $Workloads -BootstrapperUrl $VisualStudioBootstrapperUrl

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,7 @@
 # Build STL targeting x86, x64, arm, arm64
 
 variables:
-  agentPool: 'StlBuild-2020-08-07'
+  agentPool: 'StlBuild-2020-08-11'
   tmpDir: 'D:\Temp'
 
 stages:


### PR DESCRIPTION
Use [Standard_D16as_v4](https://docs.microsoft.com/en-us/azure/virtual-machines/dav4-dasv4-series#dasv4-series). These VMs have 64 GB of RAM and 230-260 ACU. ([Standard_F16s_v2](https://docs.microsoft.com/en-us/azure/virtual-machines/fsv2-series) had 32 GB and 195-210 ACU.) Might alleviate #1181.

Remove the `test.exe` exclusion added by #1153; our test executables aren't named that.