### PR TITLE
Correct issues from investigation of VSO-938163

### DIFF
--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -5118,7 +5118,9 @@ namespace ranges {
 
                     return {_STD move(_First), _STD move(_Final)};
                 } else {
-                    auto [_Mid_first, _Mid_last] = _Reverse_until_mid_unchecked(_STD move(_First), _Mid, _Final);
+                    const auto _Result = _Reverse_until_mid_unchecked(_STD move(_First), _Mid, _Final);
+                    auto _Mid_first    = _Result.begin();
+                    auto _Mid_last     = _Result.end();
                     _Reverse_common(_Mid_first, _Mid_last);
 
                     if (_Mid_first == _Mid) {

--- a/tests/std/tests/P0896R4_P1614R2_comparisons/test.cpp
+++ b/tests/std/tests/P0896R4_P1614R2_comparisons/test.cpp
@@ -433,9 +433,9 @@ constexpr void ordering_test_cases() {
 
     derived const some_deriveds[2] = {};
     test_strongly_ordered(&some_deriveds[0], &some_deriveds[1]);
-#if !defined(__clang__) && !defined(__EDG__) // TRANSITION, VSO-938163
+#if !defined(__clang__) && !defined(__EDG__) // TRANSITION, VSO-1168721
     if (!std::is_constant_evaluated())
-#endif // TRANSITION, VSO-938163
+#endif // TRANSITION, VSO-1168721
     {
         test_strongly_ordered(static_cast<base const*>(&some_deriveds[0]), &some_deriveds[1]);
         test_strongly_ordered(&some_deriveds[0], static_cast<base const*>(&some_deriveds[1]));

--- a/tests/std/tests/P0896R4_ranges_alg_partition/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_partition/test.cpp
@@ -63,15 +63,17 @@ struct partition_test {
         using ranges::is_partitioned, ranges::partition, ranges::partition_point, ranges::is_permutation,
             ranges::subrange;
 
-        auto pairs = elements;
+        { // Validate is_partitioned
+            auto pairs = elements;
 
-        {
-            Range range{pairs};
-            ASSERT(!is_partitioned(range, is_even, get_first));
-        }
-        {
-            Range range{pairs};
-            ASSERT(!is_partitioned(range.begin(), range.end(), is_even, get_first));
+            {
+                Range range{pairs};
+                ASSERT(!is_partitioned(range, is_even, get_first));
+            }
+            {
+                Range range{pairs};
+                ASSERT(!is_partitioned(range.begin(), range.end(), is_even, get_first));
+            }
         }
 
 #if !defined(__clang__) && !defined(__EDG__) // TRANSITION, VSO-938163
@@ -79,28 +81,37 @@ struct partition_test {
 #endif // TRANSITION, VSO-938163
         {
             if constexpr (ranges::forward_range<Range>) {
-                const Range range{pairs};
-                const auto mid = ranges::next(range.begin(), 4);
+                { // Validate range overloads of partition, is_partitioned, partition_point
+                    auto pairs = elements;
+                    const Range range{pairs};
+                    const auto mid = ranges::next(range.begin(), 4);
 
-                {
-                    auto result = partition(range, is_even, get_first);
-                    ASSERT(result.begin() == mid);
-                    ASSERT(result.end() == range.end());
+                    {
+                        auto result = partition(range, is_even, get_first);
+                        ASSERT(result.begin() == mid);
+                        ASSERT(result.end() == range.end());
+                    }
+                    ASSERT(
+                        is_permutation(subrange{range.begin(), mid}, array{0, 2, 4, 6}, ranges::equal_to{}, get_first));
+                    ASSERT(is_partitioned(range, is_even, get_first));
+                    ASSERT(partition_point(range, is_even, get_first) == mid);
                 }
-                ASSERT(is_permutation(subrange{range.begin(), mid}, array{0, 2, 4, 6}, ranges::equal_to{}, get_first));
-                ASSERT(is_partitioned(range, is_even, get_first));
-                ASSERT(partition_point(range, is_even, get_first) == mid);
 
-                pairs = elements;
+                { // Validate iterator overloads of partition, is_partitioned, partition_point
+                    auto pairs = elements;
+                    const Range range{pairs};
+                    const auto mid = ranges::next(range.begin(), 4);
 
-                {
-                    auto result = partition(range.begin(), range.end(), is_even, get_first);
-                    ASSERT(result.begin() == mid);
-                    ASSERT(result.end() == range.end());
+                    {
+                        auto result = partition(range.begin(), range.end(), is_even, get_first);
+                        ASSERT(result.begin() == mid);
+                        ASSERT(result.end() == range.end());
+                    }
+                    ASSERT(
+                        is_permutation(subrange{range.begin(), mid}, array{0, 2, 4, 6}, ranges::equal_to{}, get_first));
+                    ASSERT(is_partitioned(range.begin(), range.end(), is_even, get_first));
+                    ASSERT(partition_point(range.begin(), range.end(), is_even, get_first) == mid);
                 }
-                ASSERT(is_permutation(subrange{range.begin(), mid}, array{0, 2, 4, 6}, ranges::equal_to{}, get_first));
-                ASSERT(is_partitioned(range.begin(), range.end(), is_even, get_first));
-                ASSERT(partition_point(range.begin(), range.end(), is_even, get_first) == mid);
             }
         }
     }

--- a/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
@@ -1173,7 +1173,7 @@ namespace iterator_cust_swap_test {
         STATIC_ASSERT(noexcept(ranges::iter_swap(&i0, &i1)));
         return true;
     }
-#ifdef __clang__ // TRANSITION, VSO-938163
+#if defined(__clang__) || defined(__EDG__) // TRANSITION, VSO-938163
     STATIC_ASSERT(test());
 #endif // TRANSITION, VSO-938163
 


### PR DESCRIPTION
I've been helping the MSVC compiler team's `constexpr` specialist investigate VSO-938163 (which we'll call "`constexpr` hates `ranges::iter_swap`") and its interactions with our Ranges tests. She discovered there are really two different bugs that we've been calling VSO-938163, and fixed them both. In the process we found some miscategorization and other problems hidden behind VSO-938163.

* `<algorithm>`: Applied perma-workaround for VSO-1141368 ("`constexpr` hates lifetime extension") by avoiding structured binding and the consequent lifetime extension of temporaries implicitly bound to references.

* `tests/std/tests/P0896R4_P1614R2_comparisons`: This test triggers a different bug for which I filed VSO-1168721 with a minimal repro:
   ```c++
   struct B {};
   struct D : B {};

   constexpr bool test() {
       D some_deriveds[2] = {};

       return &some_deriveds[0] < static_cast<B *>(&some_deriveds[1]);
   }
   static_assert(test(), "FAIL");
   ```
   I've changed the TRANSITION comment appropriately.

* `tests/std/tests/P0896R4_ranges_alg_partition`: In addition to VSO-938163, this triggers VSO-1168723 in which `std::array<std::pair<int, int>, N>`'s implicit copy assignment operator is incorrectly not considered `constexpr` despite that `std::pair<int, int>` can be copy assigned in a constant expression. I've applied a perma-workaround to avoid VSO-1168723.

* `tests/std/tests/P0896R4_ranges_iterator_machinery`: Change `#ifdef __clang__` guard to `#if defined(__clang__) || defined(__EDG__)` for consistency.

I've verified that the tests will all pass with the fixed compiler after applying these changes and removing all remaining workarounds for VSO-938163, which we'll be able to do after the fixed compiler ships.