### PR TITLE
Update __cpp_lib_coroutine

### DIFF
--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -172,7 +172,6 @@
 //     (partially implemented)
 // P0898R3 Standard Library Concepts
 // P0912R5 Library Support For Coroutines
-//     (partially implemented, missing noop coroutines)
 // P0919R3 Heterogeneous Lookup For Unordered Containers
 // P0966R1 string::reserve() Should Not Shrink
 // P1001R2 execution::unseq
@@ -1169,8 +1168,12 @@
 #define __cpp_lib_constexpr_tuple       201811L
 #define __cpp_lib_constexpr_utility     201811L
 
-#ifdef __cpp_impl_coroutine // TRANSITION, VS 2019 16.8 Preview 3
-#define __cpp_lib_coroutine 197000L
+#ifdef __cpp_impl_coroutine // TRANSITION, Clang and EDG coroutine support
+#if __cpp_impl_coroutine >= 201902L
+#define __cpp_lib_coroutine 201902L
+#else // ^^^ __cpp_impl_coroutine >= 201902L ^^^ / vvv __cpp_impl_coroutine < 201902L vvv
+#define __cpp_lib_coroutine 197000L // TRANSITION, VS 2019 16.8 Preview 4
+#endif // ^^^ __cpp_impl_coroutine < 201902L ^^^
 #endif // __cpp_impl_coroutine
 
 #define __cpp_lib_destroying_delete            201806L

--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.cpp
@@ -481,6 +481,25 @@ STATIC_ASSERT(__cpp_lib_constexpr_utility == 201811L);
 #endif
 #endif
 
+#if _HAS_CXX20 && defined(__cpp_impl_coroutine) // TRANSITION, Clang and EDG coroutine support
+#if __cpp_impl_coroutine >= 201902L
+#define ExpectedCppLibCoroutine 201902L
+#else
+#define ExpectedCppLibCoroutine 197000L // TRANSITION, VS 2019 16.8 Preview 4
+#endif
+#ifndef __cpp_lib_coroutine
+#error __cpp_lib_coroutine is not defined
+#elif __cpp_lib_coroutine != ExpectedCppLibCoroutine
+#error __cpp_lib_coroutine is not ExpectedCppLibCoroutine
+#else
+STATIC_ASSERT(__cpp_lib_coroutine == ExpectedCppLibCoroutine);
+#endif
+#else
+#ifdef __cpp_lib_coroutine
+#error __cpp_lib_coroutine is defined
+#endif
+#endif
+
 #if _HAS_CXX20
 #ifndef __cpp_lib_destroying_delete
 #error __cpp_lib_destroying_delete is not defined


### PR DESCRIPTION
Works towards #40.

Now that Victor Tong has implemented symmetric coroutine transfer for VS 2019 16.8 Preview 3 (Microsoft-internal MSVC-PR-267685), we can activate the library's feature-test macro.

Because Clang and EDG don't define `__cpp_impl_coroutine` yet, I'm structuring this in a cautious way. If we're in C++20 mode, and the compiler defines `__cpp_impl_coroutine` (true for MSVC right now), we'll inspect the value - if it's the Standard value (or newer, just in case), we'll define the library macro to the Standard value (which happens to be the same). If it's a pre-Standard value (true for MSVC as of VS 2019 16.8 Preview 1 right now, will probably be true until VS 2019 16.8 Preview 4), we'll define the library macro to the pre-Standard value of Nulluary 1970.

I'm updating the feature-test macro test accordingly. This adaptive behavior should allow the tests to continue passing as the compilers light up their impl macros. Adaptive behavior has been problematic in the past when we use a feature-test macro internally to activate code, but here it is precisely targeted at the `<coroutine>` header which is currently a pure leaf.

I'm also removing the "partially implemented" comment, since we've merged noop coroutines. However, #40 will remain open until we add end-to-end test coverage for MSVC. (At that time we'll probably spin off separate issues for the remaining checkboxes.)