### PR TITLE
Fix counted_iterator unwrapping bug

### DIFF
--- a/stl/inc/iterator
+++ b/stl/inc/iterator
@@ -770,11 +770,11 @@ public:
 
     _NODISCARD constexpr counted_iterator<_Unwrapped_t<const _Iter&>>
         _Unwrapped() const& requires _Unwrappable_v<const _Iter&> {
-        return static_cast<counted_iterator<_Unwrapped_t<const _Iter&>>>(_Current._Unwrapped());
+        return counted_iterator<_Unwrapped_t<const _Iter&>>{_Current._Unwrapped(), _Length};
     }
 
-    _NODISCARD constexpr counted_iterator<_Unwrapped_t<_Iter>> _Unwrapped() && requires _Unwrappable_v<const _Iter&> {
-        return static_cast<counted_iterator<_Unwrapped_t<_Iter>>>(_STD move(_Current)._Unwrapped());
+    _NODISCARD constexpr counted_iterator<_Unwrapped_t<_Iter>> _Unwrapped() && requires _Unwrappable_v<_Iter> {
+        return counted_iterator<_Unwrapped_t<_Iter>>{_STD move(_Current)._Unwrapped(), _Length};
     }
 
     static constexpr bool _Unwrap_when_unverified = _Do_unwrap_when_unverified_v<_Iter>;

--- a/tests/std/tests/P0896R4_counted_iterator/test.cpp
+++ b/tests/std/tests/P0896R4_counted_iterator/test.cpp
@@ -4,6 +4,7 @@
 #include <cassert>
 #include <concepts>
 #include <iterator>
+#include <list>
 #include <memory>
 #include <type_traits>
 
@@ -304,4 +305,13 @@ struct instantiator {
 int main() {
     STATIC_ASSERT((with_writable_iterators<instantiator, int>::call(), true));
     with_writable_iterators<instantiator, int>::call();
+
+    { // Validate unwrapping
+        list<int> lst{0, 1, 2};
+        counted_iterator ci{lst.begin(), 2};
+        same_as<counted_iterator<_Unwrapped_t<list<int>::iterator>>> auto uci = _Get_unwrapped(ci);
+        ++uci;
+        _Seek_wrapped(ci, uci);
+        assert((ci == counted_iterator{ranges::next(lst.begin()), 1}));
+    }
 }


### PR DESCRIPTION
As @BillyONeal always says, "If there are no tests the feature is broken." This apparently applies even to things we merged maybe a week ago.