### PR TITLE
Limit line length to 120 columns

### DIFF
--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -142,7 +142,8 @@ namespace ranges {
         using _Not_quite_object::_Not_quite_object;
 
         // clang-format off
-        template <input_iterator _It1, sentinel_for<_It1> _Se1, _No_throw_forward_iterator _It2, _No_throw_sentinel_for<_It2> _Se2>
+        template <input_iterator _It1, sentinel_for<_It1> _Se1, _No_throw_forward_iterator _It2,
+            _No_throw_sentinel_for<_It2> _Se2>
             requires constructible_from<iter_value_t<_It2>, iter_rvalue_reference_t<_It1>>
         uninitialized_move_result<_It1, _It2> operator()(_It1 _First1, _Se1 _Last1, _It2 _First2, _Se2 _Last2) const {
             // clang-format on

--- a/tests/std/tests/Dev11_0437519_container_requirements/test.cpp
+++ b/tests/std/tests/Dev11_0437519_container_requirements/test.cpp
@@ -329,42 +329,43 @@ struct emplace_argument {
 
 // clang-format off
 
-#define DEFINE_TYPE(name, dtor, default_ctor, copy_ctor, move_ctor, emplace_ctor, copy_assign, move_assign, emplace_assign) \
-    class name {                                                                                                            \
-    public:                 name(key) { }                                                                                   \
-    private: dtor           ~name() { }                                                                                     \
-    private: default_ctor   name() { }                                                                                      \
-    private: copy_ctor      name(name const&) { }                                                                           \
-    private: move_ctor      name(name&&) { }                                                                                \
-    private: emplace_ctor   name(emplace_argument&&) { }                                                                    \
-    private: emplace_ctor   name(emplace_argument&&, emplace_argument&&) { }                                                \
-    private: emplace_ctor   name(emplace_argument&&, emplace_argument&&, emplace_argument&&) { }                            \
-    private: copy_assign    name& operator=(name const&) { return *this; }                                                  \
-    private: move_assign    name& operator=(name&&) noexcept { return *this; }                                              \
-    private: emplace_assign name& operator=(emplace_argument&&) { return *this; }                                           \
+#define DEFINE_TYPE(name, dtor, def_ctor, copy_ctor, move_ctor, emp_ctor, copy_assign, move_assign, emp_assign) \
+    class name {                                                                                                \
+    public:              name(key) { }                                                                          \
+    private: dtor        ~name() { }                                                                            \
+    private: def_ctor    name() { }                                                                             \
+    private: copy_ctor   name(name const&) { }                                                                  \
+    private: move_ctor   name(name&&) { }                                                                       \
+    private: emp_ctor    name(emp_argument&&) { }                                                               \
+    private: emp_ctor    name(emp_argument&&, emp_argument&&) { }                                               \
+    private: emp_ctor    name(emp_argument&&, emp_argument&&, emp_argument&&) { }                               \
+    private: copy_assign name& operator=(name const&) { return *this; }                                         \
+    private: move_assign name& operator=(name&&) noexcept { return *this; }                                     \
+    private: emp_assign  name& operator=(emp_argument&&) { return *this; }                                      \
     }
 
 #define YES public:
 
-//                                 dtor          default ctor  copy ctor     move ctor     emplace ctor  copy assign   move assign   emplace assign
-DEFINE_TYPE(erasable             , YES         ,             ,             ,             ,             ,             ,             ,             );
-DEFINE_TYPE(default_constructible, YES         , YES         ,             ,             ,             ,             ,             ,             );
-DEFINE_TYPE(copy_insertable      , YES         ,             , YES         , YES         ,             ,             ,             ,             );
-DEFINE_TYPE(move_insertable      , YES         ,             ,             , YES         ,             ,             ,             ,             );
-DEFINE_TYPE(emplace_constructible, YES         ,             ,             ,             , YES         ,             ,             ,             );
-DEFINE_TYPE(copy_assignable      , YES         ,             ,             ,             ,             , YES         , YES         ,             );
-DEFINE_TYPE(move_assignable      , YES         ,             ,             ,             ,             ,             , YES         ,             );
-DEFINE_TYPE(equality_comparable  , YES         ,             ,             ,             ,             ,             ,             ,             );
-DEFINE_TYPE(less_comparable      , YES         ,             ,             ,             ,             ,             ,             ,             );
+//                                        default   copy   move   emplace    copy     move    emplace
+//                                 dtor    ctor     ctor   ctor    ctor     assign   assign   assign
+DEFINE_TYPE(erasable             , YES  ,         ,      ,      ,         ,        ,        ,         );
+DEFINE_TYPE(default_constructible, YES  , YES     ,      ,      ,         ,        ,        ,         );
+DEFINE_TYPE(copy_insertable      , YES  ,         , YES  , YES  ,         ,        ,        ,         );
+DEFINE_TYPE(move_insertable      , YES  ,         ,      , YES  ,         ,        ,        ,         );
+DEFINE_TYPE(emplace_constructible, YES  ,         ,      ,      , YES     ,        ,        ,         );
+DEFINE_TYPE(copy_assignable      , YES  ,         ,      ,      ,         , YES    , YES    ,         );
+DEFINE_TYPE(move_assignable      , YES  ,         ,      ,      ,         ,        , YES    ,         );
+DEFINE_TYPE(equality_comparable  , YES  ,         ,      ,      ,         ,        ,        ,         );
+DEFINE_TYPE(less_comparable      , YES  ,         ,      ,      ,         ,        ,        ,         );
 
-DEFINE_TYPE(ca_ci                , YES         ,             , YES         , YES         ,             , YES         , YES         ,             );
-DEFINE_TYPE(ci_ma                , YES         ,             , YES         , YES         ,             ,             , YES         ,             );
-DEFINE_TYPE(dc_mi                , YES         , YES         ,             , YES         ,             ,             ,             ,             );
-DEFINE_TYPE(ec_ma_mi             , YES         ,             ,             , YES         , YES         ,             , YES         ,             );
-DEFINE_TYPE(ec_mi                , YES         ,             ,             , YES         , YES         ,             ,             ,             );
-DEFINE_TYPE(ma_mi                , YES         ,             ,             , YES         ,             ,             , YES         ,             );
-DEFINE_TYPE(ec_ea                , YES         ,             ,             ,             , YES         ,             ,             , YES         );
-DEFINE_TYPE(ec_ea_mi             , YES         ,             ,             , YES         , YES         ,             ,             , YES         );
+DEFINE_TYPE(ca_ci                , YES  ,         , YES  , YES  ,         , YES    , YES    ,         );
+DEFINE_TYPE(ci_ma                , YES  ,         , YES  , YES  ,         ,        , YES    ,         );
+DEFINE_TYPE(dc_mi                , YES  , YES     ,      , YES  ,         ,        ,        ,         );
+DEFINE_TYPE(ec_ma_mi             , YES  ,         ,      , YES  , YES     ,        , YES    ,         );
+DEFINE_TYPE(ec_mi                , YES  ,         ,      , YES  , YES     ,        ,        ,         );
+DEFINE_TYPE(ma_mi                , YES  ,         ,      , YES  ,         ,        , YES    ,         );
+DEFINE_TYPE(ec_ea                , YES  ,         ,      ,      , YES     ,        ,        , YES     );
+DEFINE_TYPE(ec_ea_mi             , YES  ,         ,      , YES  , YES     ,        ,        , YES     );
 
 #undef YES
 

--- a/tests/std/tests/P0088R3_variant/test.cpp
+++ b/tests/std/tests/P0088R3_variant/test.cpp
@@ -1771,8 +1771,10 @@ int run_test()
 #if 0 // TRANSITION, P0608
   static_assert(std::is_assignable<std::variant<char>, int>::value == VariantAllowsNarrowingConversions, "");
 
-  static_assert(std::is_assignable<std::variant<std::string, float>, int>::value == VariantAllowsNarrowingConversions, "");
-  static_assert(std::is_assignable<std::variant<std::string, double>, int>::value == VariantAllowsNarrowingConversions, "");
+  static_assert(std::is_assignable<std::variant<std::string, float>, int>::value
+    == VariantAllowsNarrowingConversions, "");
+  static_assert(std::is_assignable<std::variant<std::string, double>, int>::value
+    == VariantAllowsNarrowingConversions, "");
   static_assert(!std::is_assignable<std::variant<std::string, bool>, int>::value, "");
 
   static_assert(!std::is_assignable<std::variant<int, bool>, decltype("meow")>::value, "");
@@ -3267,8 +3269,10 @@ int run_test()
 #if 0 // TRANSITION, P0608
   static_assert(std::is_constructible<std::variant<char>, int>::value == VariantAllowsNarrowingConversions, "");
 
-  static_assert(std::is_constructible<std::variant<std::string, float>, int>::value == VariantAllowsNarrowingConversions, "");
-  static_assert(std::is_constructible<std::variant<std::string, double>, int>::value == VariantAllowsNarrowingConversions, "");
+  static_assert(std::is_constructible<std::variant<std::string, float>, int>::value
+    == VariantAllowsNarrowingConversions, "");
+  static_assert(std::is_constructible<std::variant<std::string, double>, int>::value
+    == VariantAllowsNarrowingConversions, "");
   static_assert(!std::is_constructible<std::variant<std::string, bool>, int>::value, "");
 
   static_assert(!std::is_constructible<std::variant<int, bool>, decltype("meow")>::value, "");

--- a/tests/std/tests/VSO_0191296_allocator_construct/test.cpp
+++ b/tests/std/tests/VSO_0191296_allocator_construct/test.cpp
@@ -217,44 +217,45 @@ struct emplace_argument {
 
 // clang-format off
 
-#define DEFINE_TYPE(name, default_ctor, copy_ctor, move_ctor, emplace_ctor, swappable, copy_assign, move_assign, emplace_assign) \
-    class name {                                                                                                                 \
-    public:                 name(key) { }                                                                                        \
-    public:                 ~name() { }                                                                                          \
-    private: default_ctor   name(alloc_key) { }                                                                                  \
-    private: copy_ctor      name(alloc_key, name const&) { }                                                                     \
-    private: move_ctor      name(alloc_key, name&&) { }                                                                          \
-    private: emplace_ctor   name(alloc_key, emplace_argument&&) { }                                                              \
-    private: emplace_ctor   name(alloc_key, emplace_argument&&, emplace_argument&&) { }                                          \
-    private: emplace_ctor   name(alloc_key, emplace_argument&&, emplace_argument&&, emplace_argument&&) { }                      \
-    private: swappable      friend void swap(name&, name&) {}                                                                    \
-    private: copy_assign    name& operator=(name const&) { return *this; }                                                       \
-    private: move_assign    name& operator=(name&&) { return *this; }                                                            \
-    private: emplace_assign name& operator=(emplace_argument&&) { return *this; }                                                \
-    private: name() {}                                                                                                           \
-    private: name(const name&) {}                                                                                                \
+#define DEFINE_TYPE(name, def_ctor, copy_ctor, move_ctor, emp_ctor, swappable, copy_assign, move_assign, emp_assign) \
+    class name {                                                                                                     \
+    public:              name(key) { }                                                                               \
+    public:              ~name() { }                                                                                 \
+    private: def_ctor    name(alloc_key) { }                                                                         \
+    private: copy_ctor   name(alloc_key, name const&) { }                                                            \
+    private: move_ctor   name(alloc_key, name&&) { }                                                                 \
+    private: emp_ctor    name(alloc_key, emp_argument&&) { }                                                         \
+    private: emp_ctor    name(alloc_key, emp_argument&&, emp_argument&&) { }                                         \
+    private: emp_ctor    name(alloc_key, emp_argument&&, emp_argument&&, emp_argument&&) { }                         \
+    private: swappable   friend void swap(name&, name&) {}                                                           \
+    private: copy_assign name& operator=(name const&) { return *this; }                                              \
+    private: move_assign name& operator=(name&&) { return *this; }                                                   \
+    private: emp_assign  name& operator=(emp_argument&&) { return *this; }                                           \
+    private:             name() {}                                                                                   \
+    private:             name(const name&) {}                                                                        \
     }
 
 #define YES public:
 
-//                                 default ctor  copy ctor     move ctor     emplace ctor   swappable   copy assign   move assign   emplace assign
-DEFINE_TYPE(erasable             ,             ,             ,             ,             ,             ,             ,             ,             );
-DEFINE_TYPE(default_constructible, YES         ,             ,             ,             ,             ,             ,             ,             );
-DEFINE_TYPE(copy_insertable      ,             , YES         , YES         ,             ,             ,             ,             ,             );
-DEFINE_TYPE(move_insertable      ,             ,             , YES         ,             ,             ,             ,             ,             );
-DEFINE_TYPE(emplace_constructible,             ,             ,             , YES         ,             ,             ,             ,             );
-DEFINE_TYPE(copy_assignable      ,             ,             ,             ,             , YES         , YES         , YES         ,             );
-DEFINE_TYPE(move_assignable      ,             ,             ,             ,             , YES         ,             , YES         ,             );
-DEFINE_TYPE(equality_comparable  ,             ,             ,             ,             ,             ,             ,             ,             );
-DEFINE_TYPE(less_comparable      ,             ,             ,             ,             ,             ,             ,             ,             );
-DEFINE_TYPE(ca_ci                ,             , YES         , YES         ,             , YES         , YES         , YES         ,             );
-DEFINE_TYPE(ci_ma                ,             , YES         , YES         ,             , YES         ,             , YES         ,             );
-DEFINE_TYPE(dc_mi                , YES         ,             , YES         ,             ,             ,             ,             ,             );
-DEFINE_TYPE(ec_ma_mi             ,             ,             , YES         , YES         , YES         ,             , YES         ,             );
-DEFINE_TYPE(ec_mi                ,             ,             , YES         , YES         ,             ,             ,             ,             );
-DEFINE_TYPE(ma_mi                ,             ,             , YES         ,             , YES         ,             , YES         ,             );
-DEFINE_TYPE(ec_ea                ,             ,             ,             , YES         ,             ,             ,             , YES         );
-DEFINE_TYPE(ec_ea_mi             ,             ,             , YES         , YES         ,             ,             ,             , YES         );
+//                                 default   copy   move   emplace                copy     move    emplace
+//                                  ctor     ctor   ctor    ctor     swappable   assign   assign   assign
+DEFINE_TYPE(erasable             ,         ,      ,      ,         ,           ,        ,        ,             );
+DEFINE_TYPE(default_constructible, YES     ,      ,      ,         ,           ,        ,        ,             );
+DEFINE_TYPE(copy_insertable      ,         , YES  , YES  ,         ,           ,        ,        ,             );
+DEFINE_TYPE(move_insertable      ,         ,      , YES  ,         ,           ,        ,        ,             );
+DEFINE_TYPE(emplace_constructible,         ,      ,      , YES     ,           ,        ,        ,             );
+DEFINE_TYPE(copy_assignable      ,         ,      ,      ,         , YES       , YES    , YES    ,             );
+DEFINE_TYPE(move_assignable      ,         ,      ,      ,         , YES       ,        , YES    ,             );
+DEFINE_TYPE(equality_comparable  ,         ,      ,      ,         ,           ,        ,        ,             );
+DEFINE_TYPE(less_comparable      ,         ,      ,      ,         ,           ,        ,        ,             );
+DEFINE_TYPE(ca_ci                ,         , YES  , YES  ,         , YES       , YES    , YES    ,             );
+DEFINE_TYPE(ci_ma                ,         , YES  , YES  ,         , YES       ,        , YES    ,             );
+DEFINE_TYPE(dc_mi                , YES     ,      , YES  ,         ,           ,        ,        ,             );
+DEFINE_TYPE(ec_ma_mi             ,         ,      , YES  , YES     , YES       ,        , YES    ,             );
+DEFINE_TYPE(ec_mi                ,         ,      , YES  , YES     ,           ,        ,        ,             );
+DEFINE_TYPE(ma_mi                ,         ,      , YES  ,         , YES       ,        , YES    ,             );
+DEFINE_TYPE(ec_ea                ,         ,      ,      , YES     ,           ,        ,        , YES         );
+DEFINE_TYPE(ec_ea_mi             ,         ,      , YES  , YES     ,           ,        ,        , YES         );
 
 #undef YES
 
@@ -1429,8 +1430,9 @@ DEFINE_TEST(test_specific_unordered_associative_constructors,
 
         copy_constructible_hash<erasable> const hf((key()));
         copy_constructible_compare<erasable> const eq((key()));
-        (container_type(0, hf, eq, construct_applying_allocator<typename Traits::template bind_value<erasable>::type>()));
-        container_type a(0, hf, eq, construct_applying_allocator<typename Traits::template bind_value<erasable>::type>());
+        using T = typename Traits::template bind_value<erasable>::type
+        (container_type(0, hf, eq, construct_applying_allocator<T>()));
+        container_type a(0, hf, eq, construct_applying_allocator<T>());
 }
 
 // X(i, j, n, hf, eq, allocator)


### PR DESCRIPTION
Teach validate.cpp to complain if there are more than 120 code units between line endings in files with particular extensions. Fix the files that it complains about.
