### PR TITLE
Test <coroutine>

### DIFF
--- a/tests/std/test.lst
+++ b/tests/std/test.lst
@@ -317,6 +317,7 @@ tests\P0896R4_ranges_test_machinery
 tests\P0896R4_ranges_to_address
 tests\P0898R3_concepts
 tests\P0898R3_identity
+tests\P0912R5_coroutine
 tests\P0919R3_heterogeneous_unordered_lookup
 tests\P0966R1_string_reserve_should_not_shrink
 tests\P1023R0_constexpr_for_array_comparisons

--- a/tests/std/tests/P0912R5_coroutine/env.lst
+++ b/tests/std/tests/P0912R5_coroutine/env.lst
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+RUNALL_INCLUDE ..\usual_latest_matrix.lst

--- a/tests/std/tests/P0912R5_coroutine/test.cpp
+++ b/tests/std/tests/P0912R5_coroutine/test.cpp
@@ -25,7 +25,7 @@ struct Task {
                 void await_resume() noexcept {}
 
                 coroutine_handle<> await_suspend(coroutine_handle<Promise> h) {
-                    // If there is no previous coroutine to resume we've reached the outermost coroutine.
+                    // If there is no previous coroutine to resume, we've reached the outermost coroutine.
                     // Return a noop coroutine to allow control to return back to the caller.
                     if (!h.promise().previous) {
                         return noop_coroutine();
@@ -59,7 +59,7 @@ struct Task {
 
     auto await_suspend(coroutine_handle<> enclosing) {
         coro.promise().previous = enclosing;
-        return coro; // resume ourselves.
+        return coro; // resume ourselves
     }
 
     Task(Task&& rhs) noexcept : coro(rhs.coro) {

--- a/tests/std/tests/P0912R5_coroutine/test.cpp
+++ b/tests/std/tests/P0912R5_coroutine/test.cpp
@@ -25,13 +25,13 @@ struct Task {
                 void await_resume() noexcept {}
 
                 coroutine_handle<> await_suspend(coroutine_handle<Promise> h) {
-                    // If there is no previous coroutine to resume, we've reached the outermost coroutine.
-                    // Return a noop coroutine to allow control to return back to the caller.
-                    if (!h.promise().previous) {
-                        return noop_coroutine();
+                    if (auto& p = h.promise().previous; p) {
+                        return p; // resume awaiting coroutine
                     }
 
-                    return h.promise().previous; // resume awaiting coroutine
+                    // If there is no previous coroutine to resume, we've reached the outermost coroutine.
+                    // Return a noop coroutine to allow control to return back to the caller.
+                    return noop_coroutine();
                 }
             };
 

--- a/tests/std/tests/P0912R5_coroutine/test.cpp
+++ b/tests/std/tests/P0912R5_coroutine/test.cpp
@@ -1,0 +1,90 @@
+
+#include <coroutine>
+#include <exception>
+
+struct task
+{
+    struct promise_type
+    {
+        int result;
+        std::coroutine_handle<> prev;
+
+        task get_return_object()
+        {
+            return {*this};
+        }
+
+        std::suspend_always initial_suspend() { return {}; }
+
+        auto final_suspend() noexcept
+        {
+            struct Awaiter
+            {
+                bool await_ready() noexcept { return false; }
+                void await_resume() noexcept {}
+                std::coroutine_handle<> await_suspend(std::coroutine_handle<promise_type> h)
+                {
+                    // If there is no previous coroutine to resume we've reached the outermost coroutine.
+                    // Return a noop coroutine to allow control to return back to the caller.
+                    if (!h.promise().prev)
+                        return std::noop_coroutine();
+                    return h.promise().prev; // resume awaiting coroutine
+                }
+            };
+            return Awaiter{};
+        }
+        void return_value(const int v) { result = v; }
+        void unhandled_exception() noexcept { std::terminate(); }
+    };
+
+    bool await_ready() const noexcept { return false; }
+    int await_resume() { return coro.promise().result; }
+    auto await_suspend(std::coroutine_handle<> enclosing)
+    {
+        coro.promise().prev = enclosing;
+        return coro; // resume ourselves.
+    }
+
+    task(task&& rhs) noexcept : coro(rhs.coro) { rhs.coro = nullptr; }
+    task(task const&) = delete;
+    task(promise_type& p) : coro(std::coroutine_handle<promise_type>::from_promise(p)) {}
+
+    ~task()
+    {
+        if (coro)
+            coro.destroy();
+    }
+
+    std::coroutine_handle<promise_type> coro;
+};
+
+task f(int n)
+{
+    if (n == 0)
+        co_return 0;
+
+    co_return 1 + co_await f(n - 1);
+}
+
+int main()
+{
+    task t = f(10);
+    std::coroutine_handle<> h = t.coro;
+    if (h != t.coro)
+    {
+        return 1;
+    }
+    if (!h || h.done())
+    {
+        return 1;
+    }
+
+    h();
+
+    int val = t.coro.promise().result;
+
+    if (val != 10)
+    {
+        return 1;
+    }
+}

--- a/tests/std/tests/P0912R5_coroutine/test.cpp
+++ b/tests/std/tests/P0912R5_coroutine/test.cpp
@@ -77,7 +77,7 @@ struct Task {
     coroutine_handle<Promise> coro;
 };
 
-Task f(int n) {
+Task f(const int n) {
     if (n == 0) {
         co_return 0;
     }
@@ -95,7 +95,7 @@ int main() {
 
     h();
 
-    int val = t.coro.promise().result;
+    const int val = t.coro.promise().result;
 
     assert(val == 10);
 }

--- a/tests/std/tests/P0912R5_coroutine/test.cpp
+++ b/tests/std/tests/P0912R5_coroutine/test.cpp
@@ -66,8 +66,6 @@ struct Task {
         rhs.coro = nullptr;
     }
 
-    Task(Task const&) = delete;
-
     Task(Promise& p) : coro(coroutine_handle<Promise>::from_promise(p)) {}
 
     ~Task() {

--- a/tests/std/tests/P0912R5_coroutine/test.cpp
+++ b/tests/std/tests/P0912R5_coroutine/test.cpp
@@ -5,7 +5,7 @@ using namespace std;
 
 struct Task {
     struct Promise {
-        int result;
+        int result{-1000};
         coroutine_handle<> previous;
 
         Task get_return_object() {
@@ -25,8 +25,8 @@ struct Task {
                 void await_resume() noexcept {}
 
                 coroutine_handle<> await_suspend(coroutine_handle<Promise> h) {
-                    if (auto& p = h.promise().previous; p) {
-                        return p; // resume awaiting coroutine
+                    if (auto& pre = h.promise().previous; pre) {
+                        return pre; // resume awaiting coroutine
                     }
 
                     // If there is no previous coroutine to resume, we've reached the outermost coroutine.
@@ -94,6 +94,10 @@ int main() {
     assert(!h.done());
 
     h();
+
+    assert(h == t.coro);
+    assert(h);
+    assert(h.done());
 
     const int val = t.coro.promise().result;
 

--- a/tests/std/tests/P0912R5_coroutine/test.cpp
+++ b/tests/std/tests/P0912R5_coroutine/test.cpp
@@ -1,3 +1,9 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <version> // TRANSITION, P0912R5 Library Support For Coroutines
+#if defined(__cpp_lib_coroutine) && __cpp_lib_coroutine >= 201902L // TRANSITION, P0912R5 Library Support For Coroutines
+
 #include <assert.h>
 #include <coroutine>
 #include <exception>
@@ -115,3 +121,7 @@ int main() {
 
     assert(g_tasks_destroyed == 11); // triangular_number() called for [0, 10]
 }
+
+#else // ^^^ test <coroutine> ^^^ / vvv don't test <coroutine> vvv
+int main() {}
+#endif // TRANSITION, P0912R5 Library Support For Coroutines

--- a/tests/std/tests/P0912R5_coroutine/test.cpp
+++ b/tests/std/tests/P0912R5_coroutine/test.cpp
@@ -19,20 +19,27 @@ struct task {
                 bool await_ready() noexcept {
                     return false;
                 }
+
                 void await_resume() noexcept {}
+
                 std::coroutine_handle<> await_suspend(std::coroutine_handle<promise_type> h) {
                     // If there is no previous coroutine to resume we've reached the outermost coroutine.
                     // Return a noop coroutine to allow control to return back to the caller.
-                    if (!h.promise().prev)
+                    if (!h.promise().prev) {
                         return std::noop_coroutine();
+                    }
+
                     return h.promise().prev; // resume awaiting coroutine
                 }
             };
+
             return Awaiter{};
         }
+
         void return_value(const int v) {
             result = v;
         }
+
         void unhandled_exception() noexcept {
             std::terminate();
         }
@@ -41,9 +48,11 @@ struct task {
     bool await_ready() const noexcept {
         return false;
     }
+
     int await_resume() {
         return coro.promise().result;
     }
+
     auto await_suspend(std::coroutine_handle<> enclosing) {
         coro.promise().prev = enclosing;
         return coro; // resume ourselves.
@@ -52,20 +61,24 @@ struct task {
     task(task&& rhs) noexcept : coro(rhs.coro) {
         rhs.coro = nullptr;
     }
+
     task(task const&) = delete;
+
     task(promise_type& p) : coro(std::coroutine_handle<promise_type>::from_promise(p)) {}
 
     ~task() {
-        if (coro)
+        if (coro) {
             coro.destroy();
+        }
     }
 
     std::coroutine_handle<promise_type> coro;
 };
 
 task f(int n) {
-    if (n == 0)
+    if (n == 0) {
         co_return 0;
+    }
 
     co_return 1 + co_await f(n - 1);
 }
@@ -73,9 +86,11 @@ task f(int n) {
 int main() {
     task t                    = f(10);
     std::coroutine_handle<> h = t.coro;
+
     if (h != t.coro) {
         return 1;
     }
+
     if (!h || h.done()) {
         return 1;
     }

--- a/tests/std/tests/P0912R5_coroutine/test.cpp
+++ b/tests/std/tests/P0912R5_coroutine/test.cpp
@@ -1,29 +1,26 @@
-
 #include <coroutine>
 #include <exception>
 
-struct task
-{
-    struct promise_type
-    {
+struct task {
+    struct promise_type {
         int result;
         std::coroutine_handle<> prev;
 
-        task get_return_object()
-        {
+        task get_return_object() {
             return {*this};
         }
 
-        std::suspend_always initial_suspend() { return {}; }
+        std::suspend_always initial_suspend() {
+            return {};
+        }
 
-        auto final_suspend() noexcept
-        {
-            struct Awaiter
-            {
-                bool await_ready() noexcept { return false; }
+        auto final_suspend() noexcept {
+            struct Awaiter {
+                bool await_ready() noexcept {
+                    return false;
+                }
                 void await_resume() noexcept {}
-                std::coroutine_handle<> await_suspend(std::coroutine_handle<promise_type> h)
-                {
+                std::coroutine_handle<> await_suspend(std::coroutine_handle<promise_type> h) {
                     // If there is no previous coroutine to resume we've reached the outermost coroutine.
                     // Return a noop coroutine to allow control to return back to the caller.
                     if (!h.promise().prev)
@@ -33,24 +30,32 @@ struct task
             };
             return Awaiter{};
         }
-        void return_value(const int v) { result = v; }
-        void unhandled_exception() noexcept { std::terminate(); }
+        void return_value(const int v) {
+            result = v;
+        }
+        void unhandled_exception() noexcept {
+            std::terminate();
+        }
     };
 
-    bool await_ready() const noexcept { return false; }
-    int await_resume() { return coro.promise().result; }
-    auto await_suspend(std::coroutine_handle<> enclosing)
-    {
+    bool await_ready() const noexcept {
+        return false;
+    }
+    int await_resume() {
+        return coro.promise().result;
+    }
+    auto await_suspend(std::coroutine_handle<> enclosing) {
         coro.promise().prev = enclosing;
         return coro; // resume ourselves.
     }
 
-    task(task&& rhs) noexcept : coro(rhs.coro) { rhs.coro = nullptr; }
+    task(task&& rhs) noexcept : coro(rhs.coro) {
+        rhs.coro = nullptr;
+    }
     task(task const&) = delete;
     task(promise_type& p) : coro(std::coroutine_handle<promise_type>::from_promise(p)) {}
 
-    ~task()
-    {
+    ~task() {
         if (coro)
             coro.destroy();
     }
@@ -58,24 +63,20 @@ struct task
     std::coroutine_handle<promise_type> coro;
 };
 
-task f(int n)
-{
+task f(int n) {
     if (n == 0)
         co_return 0;
 
     co_return 1 + co_await f(n - 1);
 }
 
-int main()
-{
-    task t = f(10);
+int main() {
+    task t                    = f(10);
     std::coroutine_handle<> h = t.coro;
-    if (h != t.coro)
-    {
+    if (h != t.coro) {
         return 1;
     }
-    if (!h || h.done())
-    {
+    if (!h || h.done()) {
         return 1;
     }
 
@@ -83,8 +84,7 @@ int main()
 
     int val = t.coro.promise().result;
 
-    if (val != 10)
-    {
+    if (val != 10) {
         return 1;
     }
 }

--- a/tests/std/tests/P0912R5_coroutine/test.cpp
+++ b/tests/std/tests/P0912R5_coroutine/test.cpp
@@ -77,16 +77,16 @@ struct Task {
     coroutine_handle<Promise> coro;
 };
 
-Task f(const int n) {
+Task triangular_number(const int n) {
     if (n == 0) {
         co_return 0;
     }
 
-    co_return 1 + co_await f(n - 1);
+    co_return n + co_await triangular_number(n - 1);
 }
 
 int main() {
-    Task t               = f(10);
+    Task t               = triangular_number(10);
     coroutine_handle<> h = t.coro;
 
     assert(h == t.coro);
@@ -97,5 +97,5 @@ int main() {
 
     const int val = t.coro.promise().result;
 
-    assert(val == 10);
+    assert(val == 55);
 }

--- a/tests/std/tests/P0912R5_coroutine/test.cpp
+++ b/tests/std/tests/P0912R5_coroutine/test.cpp
@@ -1,16 +1,17 @@
 #include <coroutine>
 #include <exception>
+using namespace std;
 
 struct Task {
     struct Promise {
         int result;
-        std::coroutine_handle<> previous;
+        coroutine_handle<> previous;
 
         Task get_return_object() {
             return {*this};
         }
 
-        std::suspend_always initial_suspend() {
+        suspend_always initial_suspend() {
             return {};
         }
 
@@ -22,11 +23,11 @@ struct Task {
 
                 void await_resume() noexcept {}
 
-                std::coroutine_handle<> await_suspend(std::coroutine_handle<Promise> h) {
+                coroutine_handle<> await_suspend(coroutine_handle<Promise> h) {
                     // If there is no previous coroutine to resume we've reached the outermost coroutine.
                     // Return a noop coroutine to allow control to return back to the caller.
                     if (!h.promise().previous) {
-                        return std::noop_coroutine();
+                        return noop_coroutine();
                     }
 
                     return h.promise().previous; // resume awaiting coroutine
@@ -41,7 +42,7 @@ struct Task {
         }
 
         void unhandled_exception() noexcept {
-            std::terminate();
+            terminate();
         }
     };
 
@@ -55,7 +56,7 @@ struct Task {
         return coro.promise().result;
     }
 
-    auto await_suspend(std::coroutine_handle<> enclosing) {
+    auto await_suspend(coroutine_handle<> enclosing) {
         coro.promise().previous = enclosing;
         return coro; // resume ourselves.
     }
@@ -66,7 +67,7 @@ struct Task {
 
     Task(Task const&) = delete;
 
-    Task(Promise& p) : coro(std::coroutine_handle<Promise>::from_promise(p)) {}
+    Task(Promise& p) : coro(coroutine_handle<Promise>::from_promise(p)) {}
 
     ~Task() {
         if (coro) {
@@ -74,7 +75,7 @@ struct Task {
         }
     }
 
-    std::coroutine_handle<Promise> coro;
+    coroutine_handle<Promise> coro;
 };
 
 Task f(int n) {
@@ -86,8 +87,8 @@ Task f(int n) {
 }
 
 int main() {
-    Task t                    = f(10);
-    std::coroutine_handle<> h = t.coro;
+    Task t               = f(10);
+    coroutine_handle<> h = t.coro;
 
     if (h != t.coro) {
         return 1;

--- a/tests/std/tests/P0912R5_coroutine/test.cpp
+++ b/tests/std/tests/P0912R5_coroutine/test.cpp
@@ -4,7 +4,7 @@
 struct Task {
     struct Promise {
         int result;
-        std::coroutine_handle<> prev;
+        std::coroutine_handle<> previous;
 
         Task get_return_object() {
             return {*this};
@@ -25,11 +25,11 @@ struct Task {
                 std::coroutine_handle<> await_suspend(std::coroutine_handle<Promise> h) {
                     // If there is no previous coroutine to resume we've reached the outermost coroutine.
                     // Return a noop coroutine to allow control to return back to the caller.
-                    if (!h.promise().prev) {
+                    if (!h.promise().previous) {
                         return std::noop_coroutine();
                     }
 
-                    return h.promise().prev; // resume awaiting coroutine
+                    return h.promise().previous; // resume awaiting coroutine
                 }
             };
 
@@ -56,7 +56,7 @@ struct Task {
     }
 
     auto await_suspend(std::coroutine_handle<> enclosing) {
-        coro.promise().prev = enclosing;
+        coro.promise().previous = enclosing;
         return coro; // resume ourselves.
     }
 

--- a/tests/std/tests/P0912R5_coroutine/test.cpp
+++ b/tests/std/tests/P0912R5_coroutine/test.cpp
@@ -1,3 +1,4 @@
+#include <assert.h>
 #include <coroutine>
 #include <exception>
 using namespace std;
@@ -90,19 +91,13 @@ int main() {
     Task t               = f(10);
     coroutine_handle<> h = t.coro;
 
-    if (h != t.coro) {
-        return 1;
-    }
-
-    if (!h || h.done()) {
-        return 1;
-    }
+    assert(h == t.coro);
+    assert(h);
+    assert(!h.done());
 
     h();
 
     int val = t.coro.promise().result;
 
-    if (val != 10) {
-        return 1;
-    }
+    assert(val == 10);
 }


### PR DESCRIPTION
Works towards #40.

This test was contributed by @joemmett. It requires symmetric transfer, implemented by Victor Tong for VS 2019 16.8 Preview 3. 

After verifying that the test compiles cleanly and passes with our current development build of the compiler, I guarded it with `__cpp_lib_coroutine >= 201902L`. This will be activated when MSVC updates the compiler macro `__cpp_impl_coroutine` (expected in VS 2019 16.8 Preview 3/4) and similarly for Clang/EDG.

This test is incompatible with `/await`, but #1207 is removing that from the `usual_latest_matrix.lst`.