### PR TITLE
Coroutine promise types _must_ have member unhandled_exception in C++20

### DIFF
--- a/stl/inc/experimental/generator
+++ b/stl/inc/experimental/generator
@@ -38,10 +38,11 @@ namespace experimental {
     struct generator {
         struct promise_type {
             _Ty const* _CurrentValue;
+#if 1 // TRANSITION, VSO-1172852
 #ifdef _CPPUNWIND
-            // TRANSITION, VSO-967814
             exception_ptr _Eptr;
 #endif // _CPPUNWIND
+#endif // TRANSITION, VSO-1172852
 
             auto get_return_object() {
                 return generator{*this};
@@ -55,14 +56,21 @@ namespace experimental {
                 return {};
             }
 
+#if defined(_CPPUNWIND) || defined(__cpp_impl_coroutine)
             void unhandled_exception() noexcept {
+#if 1 // TRANSITION, VSO-1172852
 #ifdef _CPPUNWIND
                 _Eptr = _STD current_exception();
 #else // ^^^ _CPPUNWIND / !_CPPUNWIND vvv
                 abort();
 #endif // _CPPUNWIND
+#else // ^^^ workaround / no workaround
+                throw;
+#endif // TRANSITION, VSO-1172852
             }
+#endif // defined(_CPPUNWIND) || defined(__cpp_impl_coroutine)
 
+#if 1 // TRANSITION, VSO-1172852
             void _Rethrow_if_exception() {
 #ifdef _CPPUNWIND
                 if (_Eptr) {
@@ -70,6 +78,7 @@ namespace experimental {
                 }
 #endif // _CPPUNWIND
             }
+#endif // TRANSITION, VSO-1172852
 
             auto yield_value(_Ty const& _Value) {
                 _CurrentValue = _STD addressof(_Value);
@@ -119,7 +128,11 @@ namespace experimental {
             iterator& operator++() {
                 _Coro.resume();
                 if (_Coro.done()) {
+#if 1 // TRANSITION, VSO-1172852
                     _STD exchange(_Coro, {}).promise()._Rethrow_if_exception();
+#else // ^^^ workaround / no workaround
+                    _Coro = nullptr;
+#endif // TRANSITION, VSO-1172852
                 }
 
                 return *this;
@@ -152,7 +165,9 @@ namespace experimental {
             if (_Coro) {
                 _Coro.resume();
                 if (_Coro.done()) {
+#if 1 // TRANSITION, VSO-1172852
                     _Coro.promise()._Rethrow_if_exception();
+#endif // TRANSITION, VSO-1172852
                     return {nullptr};
                 }
             }
@@ -166,10 +181,8 @@ namespace experimental {
 
         explicit generator(promise_type& _Prom) : _Coro(coroutine_handle<promise_type>::from_promise(_Prom)) {}
 
-        generator() = default;
-
+        generator()                 = default;
         generator(generator const&) = delete;
-
         generator& operator=(generator const&) = delete;
 
         generator(generator&& _Right) : _Coro(_Right._Coro) {

--- a/stl/inc/experimental/generator
+++ b/stl/inc/experimental/generator
@@ -55,11 +55,13 @@ namespace experimental {
                 return {};
             }
 
-#ifdef _CPPUNWIND
             void unhandled_exception() noexcept {
+#ifdef _CPPUNWIND
                 _Eptr = _STD current_exception();
-            }
+#else // ^^^ _CPPUNWIND / !_CPPUNWIND vvv
+                abort();
 #endif // _CPPUNWIND
+            }
 
             void _Rethrow_if_exception() {
 #ifdef _CPPUNWIND

--- a/stl/inc/experimental/generator
+++ b/stl/inc/experimental/generator
@@ -64,7 +64,7 @@ namespace experimental {
 #else // ^^^ _CPPUNWIND / !_CPPUNWIND vvv
                 abort();
 #endif // _CPPUNWIND
-#else // ^^^ workaround / no workaround
+#else // ^^^ workaround / no workaround vvv
                 throw;
 #endif // TRANSITION, VSO-1172852
             }
@@ -130,7 +130,7 @@ namespace experimental {
                 if (_Coro.done()) {
 #if 1 // TRANSITION, VSO-1172852
                     _STD exchange(_Coro, {}).promise()._Rethrow_if_exception();
-#else // ^^^ workaround / no workaround
+#else // ^^^ workaround / no workaround vvv
                     _Coro = nullptr;
 #endif // TRANSITION, VSO-1172852
                 }


### PR DESCRIPTION
... even when `_CPPUNWIND` is not defined.

