### PR TITLE
Improve vector growth performance near max_size

### DIFF
--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -1615,9 +1615,10 @@ private:
     size_type _Calculate_growth(const size_type _Newsize) const {
         // given _Oldcapacity and _Newsize, calculate geometric growth
         const size_type _Oldcapacity = capacity();
+        const auto _Max              = max_size();
 
-        if (_Oldcapacity > max_size() - _Oldcapacity / 2) {
-            return max_size(); // geometric growth would overflow
+        if (_Oldcapacity > _Max - _Oldcapacity / 2) {
+            return _Max; // geometric growth would overflow
         }
 
         const size_type _Geometric = _Oldcapacity + _Oldcapacity / 2;

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -1617,7 +1617,7 @@ private:
         const size_type _Oldcapacity = capacity();
 
         if (_Oldcapacity > max_size() - _Oldcapacity / 2) {
-            return _Newsize; // geometric growth would overflow
+            return max_size(); // geometric growth would overflow
         }
 
         const size_type _Geometric = _Oldcapacity + _Oldcapacity / 2;


### PR DESCRIPTION
Fixes #1217

As @BillyONeal suggested [here](https://github.com/microsoft/STL/issues/1217#issue-683249208) I think in the described situation, it is more reasonable to grow the vector to the maximum possible size according to the geometric growth speed.
Furthermore, if someone repeatedly increases vector size it is more likely that he/she wants to increase the size even more. So it is better to have the maximum preallocation space that prevents huge relocating data.
So I've changed it to `max_size()`