### PR TITLE
Revert 64-bit interlocked intrinsics on x86

### DIFF
--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -1058,7 +1058,7 @@ struct _Atomic_storage<_Ty, 8> { // lock-free using 8-byte intrinsics
         return reinterpret_cast<_TVal&>(_As_bytes);
     }
 
-#if defined(_M_IX86) && defined(__clang__) // TRANSITION, LLVM-46595
+#ifdef _M_IX86
     _TVal exchange(const _TVal _Value, const memory_order _Order = memory_order_seq_cst) noexcept {
         // exchange with (effectively) sequential consistency
         _TVal _Temp{load()};
@@ -1067,7 +1067,7 @@ struct _Atomic_storage<_Ty, 8> { // lock-free using 8-byte intrinsics
 
         return _Temp;
     }
-#else // ^^^ defined(_M_IX86) && defined(__clang__), LLVM-46595 / !defined(_M_IX86) || !defined(__clang__) vvv
+#else // ^^^ _M_IX86 / !_M_IX86 vvv
     _TVal exchange(const _TVal _Value, const memory_order _Order = memory_order_seq_cst) noexcept {
         // exchange with given memory order
         long long _As_bytes;
@@ -1075,7 +1075,7 @@ struct _Atomic_storage<_Ty, 8> { // lock-free using 8-byte intrinsics
             _Atomic_reinterpret_as<long long>(_Value));
         return reinterpret_cast<_TVal&>(_As_bytes);
     }
-#endif // ^^^ !defined(_M_IX86) || !defined(__clang__) ^^^
+#endif // _M_IX86
 
     bool compare_exchange_strong(_TVal& _Expected, const _TVal _Desired,
         const memory_order _Order = memory_order_seq_cst) noexcept { // CAS with given memory order
@@ -1517,7 +1517,7 @@ struct _Atomic_integral<_Ty, 8> : _Atomic_storage<_Ty> { // atomic integral oper
     using _Base::_Base;
 #endif // ^^^ no workaround ^^^
 
-#if defined(_M_IX86) && defined(__clang__) // TRANSITION, LLVM-46595
+#ifdef _M_IX86
     _TVal fetch_add(const _TVal _Operand, const memory_order _Order = memory_order_seq_cst) noexcept {
         // effectively sequential consistency
         _TVal _Temp{this->load()};
@@ -1570,7 +1570,7 @@ struct _Atomic_integral<_Ty, 8> : _Atomic_storage<_Ty> { // atomic integral oper
         return fetch_add(static_cast<_TVal>(-1)) - static_cast<_TVal>(1);
     }
 
-#else // ^^^ defined(_M_IX86) && defined(__clang__), LLVM-46595 / !defined(_M_IX86) || !defined(__clang__) vvv
+#else // ^^^ _M_IX86 / !_M_IX86 vvv
     _TVal fetch_add(const _TVal _Operand, const memory_order _Order = memory_order_seq_cst) noexcept {
         long long _Result;
         _ATOMIC_CHOOSE_INTRINSIC(_Order, _Result, _InterlockedExchangeAdd64,
@@ -1620,7 +1620,7 @@ struct _Atomic_integral<_Ty, 8> : _Atomic_storage<_Ty> { // atomic integral oper
     _TVal operator--() noexcept {
         return static_cast<_TVal>(_InterlockedDecrement64(_Atomic_address_as<long long>(this->_Storage)));
     }
-#endif // ^^^ !defined(_M_IX86) || !defined(__clang__) ^^^
+#endif // _M_IX86
 };
 
 #if 1 // TRANSITION, ABI


### PR DESCRIPTION
This ports MSVC-PR-269581, reverting GH-986 / MSVC-PR-240462.

According to John Morgan:

> We recently discovered a conflict between the 64-bit Interlocked
> intrinsic functions newly implemented for x86 and the Windows 8.1 SDK.
> To resolve the conflict we are reverting the change. We may later
> implement an alternative solution to support these functions on x86.
