### PR TITLE
LWG-1203 More useful rvalue stream insertion

### DIFF
--- a/stl/inc/istream
+++ b/stl/inc/istream
@@ -876,9 +876,7 @@ template <class _Istr, class _Ty>
 struct _Can_stream_in<_Istr, _Ty, void_t<decltype(_STD declval<_Istr&>() >> _STD declval<_Ty>())>> : true_type {};
 
 template <class _Istr, class _Ty,
-    enable_if_t<conjunction_v< // avoid infinite recursion
-                    negation<is_lvalue_reference<_Istr>>, is_base_of<ios_base, _Istr>, _Can_stream_in<_Istr, _Ty>>,
-        int> = 0>
+    enable_if_t<conjunction_v<is_convertible<_Istr*, ios_base*>, _Can_stream_in<_Istr, _Ty>>, int> = 0>
 _Istr&& operator>>(_Istr&& _Is, _Ty&& _Val) { // extract from rvalue stream
     _Is >> _STD forward<_Ty>(_Val);
     return _STD move(_Is);

--- a/stl/inc/ostream
+++ b/stl/inc/ostream
@@ -966,9 +966,7 @@ struct _Can_stream_out<_Ostr, _Ty, void_t<decltype(_STD declval<_Ostr&>() << _ST
 };
 
 template <class _Ostr, class _Ty,
-    enable_if_t<conjunction_v< // prevent infinite recursion
-                    negation<is_lvalue_reference<_Ostr>>, is_base_of<ios_base, _Ostr>, _Can_stream_out<_Ostr, _Ty>>,
-        int> = 0>
+    enable_if_t<conjunction_v<is_convertible<_Ostr*, ios_base*>, _Can_stream_out<_Ostr, _Ty>>, int> = 0>
 _Ostr&& operator<<(_Ostr&& _Os, const _Ty& _Val) { // insert to rvalue stream
     _Os << _Val;
     return _STD move(_Os);

--- a/tests/std/tests/VSO_0000000_nullptr_stream_out/test.cpp
+++ b/tests/std/tests/VSO_0000000_nullptr_stream_out/test.cpp
@@ -2,10 +2,34 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include <assert.h>
+#include <iosfwd>
+#include <istream>
+#include <ostream>
 #include <sstream>
 #include <string>
-
+#include <type_traits>
+#include <utility>
 using namespace std;
+
+#define STATIC_ASSERT(...) static_assert(__VA_ARGS__, #__VA_ARGS__)
+
+template <typename Istream, typename T, typename = void>
+constexpr bool IstreamExtractable = false;
+template <typename Istream, typename T>
+constexpr bool IstreamExtractable<Istream, T, void_t<decltype(declval<Istream>() >> declval<T>())>> = true;
+
+class PublicIstream : public istream {};
+class PrivateIstream : private istream {};
+PrivateIstream& operator>>(PrivateIstream&, int&); // highly artificial test code, see below
+
+template <typename Ostream, typename T, typename = void>
+constexpr bool OstreamInsertable = false;
+template <typename Ostream, typename T>
+constexpr bool OstreamInsertable<Ostream, T, void_t<decltype(declval<Ostream>() << declval<T>())>> = true;
+
+class PublicOstream : public ostream {};
+class PrivateOstream : private ostream {};
+PrivateOstream& operator<<(PrivateOstream&, int); // highly artificial test code, see below
 
 int main() {
 #if _HAS_CXX17
@@ -23,4 +47,21 @@ int main() {
     int x;
     assert((istringstream("42 1729") >> x).str() == "42 1729");
     assert(x == 42);
+
+    // Test GH-538 by verifying that LWG-1203 is constrained by "publicly and unambiguously derived".
+    // The "highly artificial" operator overloads above are ensuring that the streaming expressions are well-formed
+    // for lvalue PrivateIstream/PrivateOstream, so we can specifically test the inheritance constraint.
+    STATIC_ASSERT(IstreamExtractable<istream&, int&>);
+    STATIC_ASSERT(IstreamExtractable<istream, int&>);
+    STATIC_ASSERT(IstreamExtractable<PublicIstream&, int&>);
+    STATIC_ASSERT(IstreamExtractable<PublicIstream, int&>);
+    STATIC_ASSERT(IstreamExtractable<PrivateIstream&, int&>);
+    STATIC_ASSERT(!IstreamExtractable<PrivateIstream, int&>);
+
+    STATIC_ASSERT(OstreamInsertable<ostream&, int>);
+    STATIC_ASSERT(OstreamInsertable<ostream, int>);
+    STATIC_ASSERT(OstreamInsertable<PublicOstream&, int>);
+    STATIC_ASSERT(OstreamInsertable<PublicOstream, int>);
+    STATIC_ASSERT(OstreamInsertable<PrivateOstream&, int>);
+    STATIC_ASSERT(!OstreamInsertable<PrivateOstream, int>);
 }


### PR DESCRIPTION
Fixes #538 by completing LWG-1203 "More useful rvalue stream insertion".

We had already implemented most of this LWG issue resolution, so only the constraints needed to be adjusted. Replacing `is_base_of<ios_base, Stream>` with `is_convertible<Stream*, ios_base*>` implements the "publicly and unambiguously derived" wording in WG21-N4861 [[istream.rvalue]/1](https://eel.is/c++draft/istream.rvalue#1) and [[ostream.rvalue]/1](https://eel.is/c++draft/ostream.rvalue#1) thanks to [[conv.ptr]/3](https://eel.is/c++draft/conv.ptr#3). As a bonus, it also allows us to remove the "avoid infinite recursion" constraint `negation<is_lvalue_reference<Stream>>`, because attempting to form a pointer to a reference will SFINAE due to [[dcl.ptr]/4](https://eel.is/c++draft/dcl.ptr#4) and [[dcl.ref]/5](https://eel.is/c++draft/dcl.ref#5).

Finally, I crafted a test that fails without this change and passes with it.