### PR TITLE
Strengthen noexcept specification for container iterators

### DIFF
--- a/stl/inc/deque
+++ b/stl/inc/deque
@@ -51,91 +51,91 @@ public:
     _Deque_unchecked_const_iterator(_Size_type _Off, const _Container_base12* _Pdeque) noexcept
         : _Mycont(static_cast<const _Mydeque*>(_Pdeque)), _Myoff(_Off) {}
 
-    _NODISCARD reference operator*() const {
+    _NODISCARD reference operator*() const noexcept {
         _Size_type _Block = _Mycont->_Getblock(_Myoff);
         _Size_type _Off   = _Myoff % _DEQUESIZ;
         return _Mycont->_Map[_Block][_Off];
     }
 
-    _NODISCARD pointer operator->() const {
+    _NODISCARD pointer operator->() const noexcept {
         return pointer_traits<pointer>::pointer_to(**this);
     }
 
-    _Deque_unchecked_const_iterator& operator++() {
+    _Deque_unchecked_const_iterator& operator++() noexcept {
         ++_Myoff;
         return *this;
     }
 
-    _Deque_unchecked_const_iterator operator++(int) {
+    _Deque_unchecked_const_iterator operator++(int) noexcept {
         _Deque_unchecked_const_iterator _Tmp = *this;
         ++_Myoff;
         return _Tmp;
     }
 
-    _Deque_unchecked_const_iterator& operator--() {
+    _Deque_unchecked_const_iterator& operator--() noexcept {
         --_Myoff;
         return *this;
     }
 
-    _Deque_unchecked_const_iterator operator--(int) {
+    _Deque_unchecked_const_iterator operator--(int) noexcept {
         _Deque_unchecked_const_iterator _Tmp = *this;
         --_Myoff;
         return _Tmp;
     }
 
-    _Deque_unchecked_const_iterator& operator+=(const difference_type _Off) {
+    _Deque_unchecked_const_iterator& operator+=(const difference_type _Off) noexcept {
         _Myoff += _Off;
         return *this;
     }
 
-    _NODISCARD _Deque_unchecked_const_iterator operator+(const difference_type _Off) const {
+    _NODISCARD _Deque_unchecked_const_iterator operator+(const difference_type _Off) const noexcept {
         _Deque_unchecked_const_iterator _Tmp = *this;
         return _Tmp += _Off;
     }
 
-    _Deque_unchecked_const_iterator& operator-=(const difference_type _Off) {
+    _Deque_unchecked_const_iterator& operator-=(const difference_type _Off) noexcept {
         _Myoff -= _Off;
         return *this;
     }
 
-    _NODISCARD _Deque_unchecked_const_iterator operator-(const difference_type _Off) const {
+    _NODISCARD _Deque_unchecked_const_iterator operator-(const difference_type _Off) const noexcept {
         _Deque_unchecked_const_iterator _Tmp = *this;
         return _Tmp -= _Off;
     }
 
-    _NODISCARD difference_type operator-(const _Deque_unchecked_const_iterator& _Right) const {
+    _NODISCARD difference_type operator-(const _Deque_unchecked_const_iterator& _Right) const noexcept {
         return static_cast<difference_type>(_Myoff - _Right._Myoff);
     }
 
-    _NODISCARD reference operator[](const difference_type _Off) const {
+    _NODISCARD reference operator[](const difference_type _Off) const noexcept {
         return *(*this + _Off);
     }
 
-    _NODISCARD bool operator==(const _Deque_unchecked_const_iterator& _Right) const {
+    _NODISCARD bool operator==(const _Deque_unchecked_const_iterator& _Right) const noexcept {
         return _Myoff == _Right._Myoff;
     }
 
-    _NODISCARD bool operator!=(const _Deque_unchecked_const_iterator& _Right) const {
+    _NODISCARD bool operator!=(const _Deque_unchecked_const_iterator& _Right) const noexcept {
         return !(*this == _Right);
     }
 
-    _NODISCARD bool operator<(const _Deque_unchecked_const_iterator& _Right) const {
+    _NODISCARD bool operator<(const _Deque_unchecked_const_iterator& _Right) const noexcept {
         return _Myoff < _Right._Myoff;
     }
 
-    _NODISCARD bool operator>(const _Deque_unchecked_const_iterator& _Right) const {
+    _NODISCARD bool operator>(const _Deque_unchecked_const_iterator& _Right) const noexcept {
         return _Right < *this;
     }
 
-    _NODISCARD bool operator<=(const _Deque_unchecked_const_iterator& _Right) const {
+    _NODISCARD bool operator<=(const _Deque_unchecked_const_iterator& _Right) const noexcept {
         return !(_Right < *this);
     }
 
-    _NODISCARD bool operator>=(const _Deque_unchecked_const_iterator& _Right) const {
+    _NODISCARD bool operator>=(const _Deque_unchecked_const_iterator& _Right) const noexcept {
         return !(*this < _Right);
     }
 
-    const _Container_base12* _Getcont() const { // get container pointer
+    const _Container_base12* _Getcont() const noexcept { // get container pointer
         return _Mycont;
     }
 
@@ -146,7 +146,7 @@ public:
 template <class _Mydeque>
 _NODISCARD _Deque_unchecked_const_iterator<_Mydeque> operator+(
     typename _Deque_unchecked_const_iterator<_Mydeque>::difference_type _Off,
-    _Deque_unchecked_const_iterator<_Mydeque> _Next) {
+    _Deque_unchecked_const_iterator<_Mydeque> _Next) noexcept {
     return _Next += _Off;
 }
 
@@ -167,68 +167,69 @@ public:
 
     using _Mybase::_Mybase;
 
-    _NODISCARD reference operator*() const {
+    _NODISCARD reference operator*() const noexcept {
         return const_cast<reference>(_Mybase::operator*());
     }
 
-    _NODISCARD pointer operator->() const {
+    _NODISCARD pointer operator->() const noexcept {
         return pointer_traits<pointer>::pointer_to(**this);
     }
 
-    _Deque_unchecked_iterator& operator++() {
+    _Deque_unchecked_iterator& operator++() noexcept {
         _Mybase::operator++();
         return *this;
     }
 
-    _Deque_unchecked_iterator operator++(int) {
+    _Deque_unchecked_iterator operator++(int) noexcept {
         _Deque_unchecked_iterator _Tmp = *this;
         _Mybase::operator++();
         return _Tmp;
     }
 
-    _Deque_unchecked_iterator& operator--() {
+    _Deque_unchecked_iterator& operator--() noexcept {
         _Mybase::operator--();
         return *this;
     }
 
-    _Deque_unchecked_iterator operator--(int) {
+    _Deque_unchecked_iterator operator--(int) noexcept {
         _Deque_unchecked_iterator _Tmp = *this;
         _Mybase::operator--();
         return _Tmp;
     }
 
-    _Deque_unchecked_iterator& operator+=(const difference_type _Off) {
+    _Deque_unchecked_iterator& operator+=(const difference_type _Off) noexcept {
         _Mybase::operator+=(_Off);
         return *this;
     }
 
-    _NODISCARD _Deque_unchecked_iterator operator+(const difference_type _Off) const {
+    _NODISCARD _Deque_unchecked_iterator operator+(const difference_type _Off) const noexcept {
         _Deque_unchecked_iterator _Tmp = *this;
         return _Tmp += _Off;
     }
 
-    _Deque_unchecked_iterator& operator-=(const difference_type _Off) {
+    _Deque_unchecked_iterator& operator-=(const difference_type _Off) noexcept {
         _Mybase::operator-=(_Off);
         return *this;
     }
 
-    _NODISCARD _Deque_unchecked_iterator operator-(const difference_type _Off) const {
+    _NODISCARD _Deque_unchecked_iterator operator-(const difference_type _Off) const noexcept {
         _Deque_unchecked_iterator _Tmp = *this;
         return _Tmp -= _Off;
     }
 
-    _NODISCARD difference_type operator-(const _Mybase& _Right) const {
+    _NODISCARD difference_type operator-(const _Mybase& _Right) const noexcept {
         return _Mybase::operator-(_Right);
     }
 
-    _NODISCARD reference operator[](const difference_type _Off) const {
+    _NODISCARD reference operator[](const difference_type _Off) const noexcept {
         return const_cast<reference>(_Mybase::operator[](_Off));
     }
 };
 
 template <class _Mydeque>
 _NODISCARD _Deque_unchecked_iterator<_Mydeque> operator+(
-    typename _Deque_unchecked_iterator<_Mydeque>::difference_type _Off, _Deque_unchecked_iterator<_Mydeque> _Next) {
+    typename _Deque_unchecked_iterator<_Mydeque>::difference_type _Off,
+    _Deque_unchecked_iterator<_Mydeque> _Next) noexcept {
     return _Next += _Off;
 }
 
@@ -256,7 +257,7 @@ public:
         _Setcont(static_cast<const _Mydeque*>(_Pdeque));
     }
 
-    _NODISCARD reference operator*() const {
+    _NODISCARD reference operator*() const noexcept {
         const auto _Mycont = static_cast<const _Mydeque*>(this->_Getcont());
 #if _ITERATOR_DEBUG_LEVEL != 0
         _STL_VERIFY(_Mycont, "cannot dereference value-initialized deque iterator");
@@ -269,11 +270,11 @@ public:
         return _Mycont->_Map[_Block][_Off];
     }
 
-    _NODISCARD pointer operator->() const {
+    _NODISCARD pointer operator->() const noexcept {
         return pointer_traits<pointer>::pointer_to(**this);
     }
 
-    _Deque_const_iterator& operator++() {
+    _Deque_const_iterator& operator++() noexcept {
 #if _ITERATOR_DEBUG_LEVEL != 0
         const auto _Mycont = static_cast<const _Mydeque*>(this->_Getcont());
         _STL_VERIFY(_Mycont, "cannot increment value-initialized deque iterator");
@@ -284,13 +285,13 @@ public:
         return *this;
     }
 
-    _Deque_const_iterator operator++(int) {
+    _Deque_const_iterator operator++(int) noexcept {
         _Deque_const_iterator _Tmp = *this;
         ++*this;
         return _Tmp;
     }
 
-    _Deque_const_iterator& operator--() {
+    _Deque_const_iterator& operator--() noexcept {
 #if _ITERATOR_DEBUG_LEVEL != 0
         const auto _Mycont = static_cast<const _Mydeque*>(this->_Getcont());
         _STL_VERIFY(_Mycont, "cannot decrement value-initialized deque iterator");
@@ -301,13 +302,13 @@ public:
         return *this;
     }
 
-    _Deque_const_iterator operator--(int) {
+    _Deque_const_iterator operator--(int) noexcept {
         _Deque_const_iterator _Tmp = *this;
         --*this;
         return _Tmp;
     }
 
-    _Deque_const_iterator& operator+=(const difference_type _Off) {
+    _Deque_const_iterator& operator+=(const difference_type _Off) noexcept {
 #if _ITERATOR_DEBUG_LEVEL != 0
         if (_Off != 0) {
             const auto _Mycont = static_cast<const _Mydeque*>(this->_Getcont());
@@ -322,56 +323,56 @@ public:
         return *this;
     }
 
-    _NODISCARD _Deque_const_iterator operator+(const difference_type _Off) const {
+    _NODISCARD _Deque_const_iterator operator+(const difference_type _Off) const noexcept {
         _Deque_const_iterator _Tmp = *this;
         return _Tmp += _Off;
     }
 
-    _Deque_const_iterator& operator-=(const difference_type _Off) {
+    _Deque_const_iterator& operator-=(const difference_type _Off) noexcept {
         return *this += -_Off;
     }
 
-    _NODISCARD _Deque_const_iterator operator-(const difference_type _Off) const {
+    _NODISCARD _Deque_const_iterator operator-(const difference_type _Off) const noexcept {
         _Deque_const_iterator _Tmp = *this;
         return _Tmp -= _Off;
     }
 
-    _NODISCARD difference_type operator-(const _Deque_const_iterator& _Right) const {
+    _NODISCARD difference_type operator-(const _Deque_const_iterator& _Right) const noexcept {
         _Compat(_Right);
         return static_cast<difference_type>(this->_Myoff - _Right._Myoff);
     }
 
-    _NODISCARD reference operator[](const difference_type _Off) const {
+    _NODISCARD reference operator[](const difference_type _Off) const noexcept {
         return *(*this + _Off);
     }
 
-    _NODISCARD bool operator==(const _Deque_const_iterator& _Right) const {
+    _NODISCARD bool operator==(const _Deque_const_iterator& _Right) const noexcept {
         _Compat(_Right);
         return this->_Myoff == _Right._Myoff;
     }
 
-    _NODISCARD bool operator!=(const _Deque_const_iterator& _Right) const {
+    _NODISCARD bool operator!=(const _Deque_const_iterator& _Right) const noexcept {
         return !(*this == _Right);
     }
 
-    _NODISCARD bool operator<(const _Deque_const_iterator& _Right) const {
+    _NODISCARD bool operator<(const _Deque_const_iterator& _Right) const noexcept {
         _Compat(_Right);
         return this->_Myoff < _Right._Myoff;
     }
 
-    _NODISCARD bool operator>(const _Deque_const_iterator& _Right) const {
+    _NODISCARD bool operator>(const _Deque_const_iterator& _Right) const noexcept {
         return _Right < *this;
     }
 
-    _NODISCARD bool operator<=(const _Deque_const_iterator& _Right) const {
+    _NODISCARD bool operator<=(const _Deque_const_iterator& _Right) const noexcept {
         return !(_Right < *this);
     }
 
-    _NODISCARD bool operator>=(const _Deque_const_iterator& _Right) const {
+    _NODISCARD bool operator>=(const _Deque_const_iterator& _Right) const noexcept {
         return !(*this < _Right);
     }
 
-    void _Compat(const _Deque_const_iterator& _Right) const { // test for compatible iterator pair
+    void _Compat(const _Deque_const_iterator& _Right) const noexcept { // test for compatible iterator pair
 #if _ITERATOR_DEBUG_LEVEL == 0
         (void) _Right;
 #else // _ITERATOR_DEBUG_LEVEL == 0
@@ -379,13 +380,13 @@ public:
 #endif // _ITERATOR_DEBUG_LEVEL == 0
     }
 
-    void _Setcont(const _Mydeque* _Pdeque) { // set container pointer
+    void _Setcont(const _Mydeque* _Pdeque) noexcept { // set container pointer
         this->_Adopt(_Pdeque);
     }
 
     using _Prevent_inheriting_unwrap = _Deque_const_iterator;
 
-    _NODISCARD _Deque_unchecked_const_iterator<_Mydeque> _Unwrapped() const {
+    _NODISCARD _Deque_unchecked_const_iterator<_Mydeque> _Unwrapped() const noexcept {
         return {this->_Myoff, this->_Getcont()};
     }
 
@@ -404,13 +405,13 @@ public:
     }
 
 #if _ITERATOR_DEBUG_LEVEL != 0
-    friend void _Verify_range(const _Deque_const_iterator& _First, const _Deque_const_iterator& _Last) {
+    friend void _Verify_range(const _Deque_const_iterator& _First, const _Deque_const_iterator& _Last) noexcept {
         // note _Compat check inside operator<=
         _STL_VERIFY(_First <= _Last, "deque iterators transposed");
     }
 #endif // _ITERATOR_DEBUG_LEVEL != 0
 
-    void _Seek_to(const _Deque_unchecked_const_iterator<_Mydeque>& _UIt) {
+    void _Seek_to(const _Deque_unchecked_const_iterator<_Mydeque>& _UIt) noexcept {
         _Myoff = _UIt._Myoff;
     }
 
@@ -419,7 +420,7 @@ public:
 
 template <class _Mydeque>
 _NODISCARD _Deque_const_iterator<_Mydeque> operator+(
-    typename _Deque_const_iterator<_Mydeque>::difference_type _Off, _Deque_const_iterator<_Mydeque> _Next) {
+    typename _Deque_const_iterator<_Mydeque>::difference_type _Off, _Deque_const_iterator<_Mydeque> _Next) noexcept {
     return _Next += _Off;
 }
 
@@ -441,72 +442,72 @@ public:
 
     using _Mybase::_Mybase;
 
-    _NODISCARD reference operator*() const {
+    _NODISCARD reference operator*() const noexcept {
         return const_cast<reference>(_Mybase::operator*());
     }
 
-    _NODISCARD pointer operator->() const {
+    _NODISCARD pointer operator->() const noexcept {
         return pointer_traits<pointer>::pointer_to(**this);
     }
 
-    _Deque_iterator& operator++() {
+    _Deque_iterator& operator++() noexcept {
         _Mybase::operator++();
         return *this;
     }
 
-    _Deque_iterator operator++(int) {
+    _Deque_iterator operator++(int) noexcept {
         _Deque_iterator _Tmp = *this;
         _Mybase::operator++();
         return _Tmp;
     }
 
-    _Deque_iterator& operator--() {
+    _Deque_iterator& operator--() noexcept {
         _Mybase::operator--();
         return *this;
     }
 
-    _Deque_iterator operator--(int) {
+    _Deque_iterator operator--(int) noexcept {
         _Deque_iterator _Tmp = *this;
         _Mybase::operator--();
         return _Tmp;
     }
 
-    _Deque_iterator& operator+=(const difference_type _Off) {
+    _Deque_iterator& operator+=(const difference_type _Off) noexcept {
         _Mybase::operator+=(_Off);
         return *this;
     }
 
-    _NODISCARD _Deque_iterator operator+(const difference_type _Off) const {
+    _NODISCARD _Deque_iterator operator+(const difference_type _Off) const noexcept {
         _Deque_iterator _Tmp = *this;
         return _Tmp += _Off;
     }
 
-    _Deque_iterator& operator-=(const difference_type _Off) {
+    _Deque_iterator& operator-=(const difference_type _Off) noexcept {
         _Mybase::operator-=(_Off);
         return *this;
     }
 
     using _Mybase::operator-;
 
-    _NODISCARD _Deque_iterator operator-(const difference_type _Off) const {
+    _NODISCARD _Deque_iterator operator-(const difference_type _Off) const noexcept {
         _Deque_iterator _Tmp = *this;
         return _Tmp -= _Off;
     }
 
-    _NODISCARD reference operator[](const difference_type _Off) const {
+    _NODISCARD reference operator[](const difference_type _Off) const noexcept {
         return const_cast<reference>(_Mybase::operator[](_Off));
     }
 
     using _Prevent_inheriting_unwrap = _Deque_iterator;
 
-    _NODISCARD _Deque_unchecked_iterator<_Mydeque> _Unwrapped() const {
+    _NODISCARD _Deque_unchecked_iterator<_Mydeque> _Unwrapped() const noexcept {
         return {this->_Myoff, this->_Getcont()};
     }
 };
 
 template <class _Mydeque>
 _NODISCARD _Deque_iterator<_Mydeque> operator+(
-    typename _Deque_iterator<_Mydeque>::difference_type _Off, _Deque_iterator<_Mydeque> _Next) {
+    typename _Deque_iterator<_Mydeque>::difference_type _Off, _Deque_iterator<_Mydeque> _Next) noexcept {
     return _Next += _Off;
 }
 

--- a/stl/inc/forward_list
+++ b/stl/inc/forward_list
@@ -40,30 +40,30 @@ public:
         this->_Adopt(_Plist);
     }
 
-    _NODISCARD reference operator*() const {
+    _NODISCARD reference operator*() const noexcept {
         return _Ptr->_Myval;
     }
 
-    _NODISCARD pointer operator->() const {
+    _NODISCARD pointer operator->() const noexcept {
         return pointer_traits<pointer>::pointer_to(**this);
     }
 
-    _Flist_unchecked_const_iterator& operator++() {
+    _Flist_unchecked_const_iterator& operator++() noexcept {
         _Ptr = _Ptr->_Next;
         return *this;
     }
 
-    _Flist_unchecked_const_iterator operator++(int) {
+    _Flist_unchecked_const_iterator operator++(int) noexcept {
         _Flist_unchecked_const_iterator _Tmp = *this;
         _Ptr                                 = _Ptr->_Next;
         return _Tmp;
     }
 
-    _NODISCARD bool operator==(const _Flist_unchecked_const_iterator& _Right) const {
+    _NODISCARD bool operator==(const _Flist_unchecked_const_iterator& _Right) const noexcept {
         return _Ptr == _Right._Ptr;
     }
 
-    _NODISCARD bool operator!=(const _Flist_unchecked_const_iterator& _Right) const {
+    _NODISCARD bool operator!=(const _Flist_unchecked_const_iterator& _Right) const noexcept {
         return !(*this == _Right);
     }
 
@@ -93,20 +93,20 @@ public:
 
     using _Mybase::_Mybase;
 
-    _NODISCARD reference operator*() const {
+    _NODISCARD reference operator*() const noexcept {
         return const_cast<reference>(_Mybase::operator*());
     }
 
-    _NODISCARD pointer operator->() const {
+    _NODISCARD pointer operator->() const noexcept {
         return pointer_traits<pointer>::pointer_to(**this);
     }
 
-    _Flist_unchecked_iterator& operator++() {
+    _Flist_unchecked_iterator& operator++() noexcept {
         _Mybase::operator++();
         return *this;
     }
 
-    _Flist_unchecked_iterator operator++(int) {
+    _Flist_unchecked_iterator operator++(int) noexcept {
         _Flist_unchecked_iterator _Tmp = *this;
         _Mybase::operator++();
         return _Tmp;
@@ -128,7 +128,7 @@ public:
 
     using _Mybase::_Mybase;
 
-    _NODISCARD reference operator*() const {
+    _NODISCARD reference operator*() const noexcept {
 #if _ITERATOR_DEBUG_LEVEL == 2
         const auto _Mycont = static_cast<const _Mylist*>(this->_Getcont());
         _STL_ASSERT(_Mycont, "cannot dereference value-initialized forward_list iterator");
@@ -138,7 +138,7 @@ public:
         return this->_Ptr->_Myval;
     }
 
-    _Flist_const_iterator& operator++() {
+    _Flist_const_iterator& operator++() noexcept {
 #if _ITERATOR_DEBUG_LEVEL == 2
         _STL_VERIFY(this->_Getcont(), "forward_list iterator not incrementable");
 #endif // _ITERATOR_DEBUG_LEVEL == 2
@@ -147,13 +147,13 @@ public:
         return *this;
     }
 
-    _Flist_const_iterator operator++(int) {
+    _Flist_const_iterator operator++(int) noexcept {
         _Flist_const_iterator _Tmp = *this;
         this->_Ptr                 = this->_Ptr->_Next;
         return _Tmp;
     }
 
-    _NODISCARD bool operator==(const _Flist_const_iterator& _Right) const {
+    _NODISCARD bool operator==(const _Flist_const_iterator& _Right) const noexcept {
 #if _ITERATOR_DEBUG_LEVEL == 2
         _STL_VERIFY(this->_Getcont() == _Right._Getcont(), "forward_list iterators incompatible");
 #endif // _ITERATOR_DEBUG_LEVEL == 2
@@ -161,12 +161,12 @@ public:
         return this->_Ptr == _Right._Ptr;
     }
 
-    _NODISCARD bool operator!=(const _Flist_const_iterator& _Right) const {
+    _NODISCARD bool operator!=(const _Flist_const_iterator& _Right) const noexcept {
         return !(*this == _Right);
     }
 
 #if _ITERATOR_DEBUG_LEVEL == 2
-    friend void _Verify_range(const _Flist_const_iterator& _First, const _Flist_const_iterator& _Last) {
+    friend void _Verify_range(const _Flist_const_iterator& _First, const _Flist_const_iterator& _Last) noexcept {
         _STL_VERIFY(
             _First._Getcont() == _Last._Getcont(), "forward_list iterators in range are from different containers");
     }
@@ -178,7 +178,7 @@ public:
         return _Flist_unchecked_const_iterator<_Mylist>(this->_Ptr, static_cast<const _Mylist*>(this->_Getcont()));
     }
 
-    void _Seek_to(const _Flist_unchecked_const_iterator<_Mylist> _It) {
+    void _Seek_to(const _Flist_unchecked_const_iterator<_Mylist> _It) noexcept {
         this->_Ptr = _It._Ptr;
     }
 };
@@ -198,20 +198,20 @@ public:
 
     using _Mybase::_Mybase;
 
-    _NODISCARD reference operator*() const {
+    _NODISCARD reference operator*() const noexcept {
         return const_cast<reference>(_Mybase::operator*());
     }
 
-    _NODISCARD pointer operator->() const {
+    _NODISCARD pointer operator->() const noexcept {
         return pointer_traits<pointer>::pointer_to(**this);
     }
 
-    _Flist_iterator& operator++() {
+    _Flist_iterator& operator++() noexcept {
         _Mybase::operator++();
         return *this;
     }
 
-    _Flist_iterator operator++(int) {
+    _Flist_iterator operator++(int) noexcept {
         _Flist_iterator _Tmp = *this;
         _Mybase::operator++();
         return _Tmp;

--- a/stl/inc/list
+++ b/stl/inc/list
@@ -40,41 +40,41 @@ public:
         this->_Adopt(_Plist);
     }
 
-    _NODISCARD reference operator*() const {
+    _NODISCARD reference operator*() const noexcept {
         return _Ptr->_Myval;
     }
 
-    _NODISCARD pointer operator->() const {
+    _NODISCARD pointer operator->() const noexcept {
         return pointer_traits<pointer>::pointer_to(**this);
     }
 
-    _List_unchecked_const_iterator& operator++() {
+    _List_unchecked_const_iterator& operator++() noexcept {
         _Ptr = _Ptr->_Next;
         return *this;
     }
 
-    _List_unchecked_const_iterator operator++(int) {
+    _List_unchecked_const_iterator operator++(int) noexcept {
         _List_unchecked_const_iterator _Tmp = *this;
         _Ptr                                = _Ptr->_Next;
         return _Tmp;
     }
 
-    _List_unchecked_const_iterator& operator--() {
+    _List_unchecked_const_iterator& operator--() noexcept {
         _Ptr = _Ptr->_Prev;
         return *this;
     }
 
-    _List_unchecked_const_iterator operator--(int) {
+    _List_unchecked_const_iterator operator--(int) noexcept {
         _List_unchecked_const_iterator _Tmp = *this;
         _Ptr                                = _Ptr->_Prev;
         return _Tmp;
     }
 
-    _NODISCARD bool operator==(const _List_unchecked_const_iterator& _Right) const {
+    _NODISCARD bool operator==(const _List_unchecked_const_iterator& _Right) const noexcept {
         return _Ptr == _Right._Ptr;
     }
 
-    _NODISCARD bool operator!=(const _List_unchecked_const_iterator& _Right) const {
+    _NODISCARD bool operator!=(const _List_unchecked_const_iterator& _Right) const noexcept {
         return !(*this == _Right);
     }
 
@@ -96,31 +96,31 @@ public:
 
     using _Mybase::_Mybase;
 
-    _NODISCARD reference operator*() const {
+    _NODISCARD reference operator*() const noexcept {
         return const_cast<reference>(_Mybase::operator*());
     }
 
-    _NODISCARD pointer operator->() const {
+    _NODISCARD pointer operator->() const noexcept {
         return pointer_traits<pointer>::pointer_to(**this);
     }
 
-    _List_unchecked_iterator& operator++() {
+    _List_unchecked_iterator& operator++() noexcept {
         _Mybase::operator++();
         return *this;
     }
 
-    _List_unchecked_iterator operator++(int) {
+    _List_unchecked_iterator operator++(int) noexcept {
         _List_unchecked_iterator _Tmp = *this;
         _Mybase::operator++();
         return _Tmp;
     }
 
-    _List_unchecked_iterator& operator--() {
+    _List_unchecked_iterator& operator--() noexcept {
         _Mybase::operator--();
         return *this;
     }
 
-    _List_unchecked_iterator operator--(int) {
+    _List_unchecked_iterator operator--(int) noexcept {
         _List_unchecked_iterator _Tmp = *this;
         _Mybase::operator--();
         return _Tmp;
@@ -142,7 +142,7 @@ public:
 
     using _Mybase::_Mybase;
 
-    _NODISCARD reference operator*() const {
+    _NODISCARD reference operator*() const noexcept {
 #if _ITERATOR_DEBUG_LEVEL == 2
         const auto _Mycont = static_cast<const _Mylist*>(this->_Getcont());
         _STL_ASSERT(_Mycont, "cannot dereference value-initialized list iterator");
@@ -152,11 +152,11 @@ public:
         return this->_Ptr->_Myval;
     }
 
-    _NODISCARD pointer operator->() const {
+    _NODISCARD pointer operator->() const noexcept {
         return pointer_traits<pointer>::pointer_to(**this);
     }
 
-    _List_const_iterator& operator++() {
+    _List_const_iterator& operator++() noexcept {
 #if _ITERATOR_DEBUG_LEVEL == 2
         const auto _Mycont = static_cast<const _Mylist*>(this->_Getcont());
         _STL_ASSERT(_Mycont, "cannot increment value-initialized list iterator");
@@ -167,13 +167,13 @@ public:
         return *this;
     }
 
-    _List_const_iterator operator++(int) {
+    _List_const_iterator operator++(int) noexcept {
         _List_const_iterator _Tmp = *this;
         ++*this;
         return _Tmp;
     }
 
-    _List_const_iterator& operator--() {
+    _List_const_iterator& operator--() noexcept {
         const auto _New_ptr = this->_Ptr->_Prev;
 #if _ITERATOR_DEBUG_LEVEL == 2
         const auto _Mycont = static_cast<const _Mylist*>(this->_Getcont());
@@ -185,13 +185,13 @@ public:
         return *this;
     }
 
-    _List_const_iterator operator--(int) {
+    _List_const_iterator operator--(int) noexcept {
         _List_const_iterator _Tmp = *this;
         --*this;
         return _Tmp;
     }
 
-    _NODISCARD bool operator==(const _List_const_iterator& _Right) const {
+    _NODISCARD bool operator==(const _List_const_iterator& _Right) const noexcept {
 #if _ITERATOR_DEBUG_LEVEL == 2
         _STL_VERIFY(this->_Getcont() == _Right._Getcont(), "list iterators incompatible");
 #endif // _ITERATOR_DEBUG_LEVEL == 2
@@ -199,19 +199,19 @@ public:
         return this->_Ptr == _Right._Ptr;
     }
 
-    _NODISCARD bool operator!=(const _List_const_iterator& _Right) const {
+    _NODISCARD bool operator!=(const _List_const_iterator& _Right) const noexcept {
         return !(*this == _Right);
     }
 
 #if _ITERATOR_DEBUG_LEVEL == 2
-    friend void _Verify_range(const _List_const_iterator& _First, const _List_const_iterator& _Last) {
+    friend void _Verify_range(const _List_const_iterator& _First, const _List_const_iterator& _Last) noexcept {
         _STL_VERIFY(_First._Getcont() == _Last._Getcont(), "list iterators in range are from different containers");
     }
 #endif // _ITERATOR_DEBUG_LEVEL == 2
 
     using _Prevent_inheriting_unwrap = _List_const_iterator;
 
-    _NODISCARD _List_unchecked_const_iterator<_Mylist> _Unwrapped() const {
+    _NODISCARD _List_unchecked_const_iterator<_Mylist> _Unwrapped() const noexcept {
         return _List_unchecked_const_iterator<_Mylist>(this->_Ptr, static_cast<const _Mylist*>(this->_Getcont()));
     }
 
@@ -235,31 +235,31 @@ public:
 
     using _Mybase::_Mybase;
 
-    _NODISCARD reference operator*() const {
+    _NODISCARD reference operator*() const noexcept {
         return const_cast<reference>(_Mybase::operator*());
     }
 
-    _NODISCARD pointer operator->() const {
+    _NODISCARD pointer operator->() const noexcept {
         return pointer_traits<pointer>::pointer_to(**this);
     }
 
-    _List_iterator& operator++() {
+    _List_iterator& operator++() noexcept {
         _Mybase::operator++();
         return *this;
     }
 
-    _List_iterator operator++(int) {
+    _List_iterator operator++(int) noexcept {
         _List_iterator _Tmp = *this;
         _Mybase::operator++();
         return _Tmp;
     }
 
-    _List_iterator& operator--() {
+    _List_iterator& operator--() noexcept {
         _Mybase::operator--();
         return *this;
     }
 
-    _List_iterator operator--(int) {
+    _List_iterator operator--(int) noexcept {
         _List_iterator _Tmp = *this;
         _Mybase::operator--();
         return _Tmp;
@@ -267,7 +267,7 @@ public:
 
     using _Prevent_inheriting_unwrap = _List_iterator;
 
-    _NODISCARD _List_unchecked_iterator<_Mylist> _Unwrapped() const {
+    _NODISCARD _List_unchecked_iterator<_Mylist> _Unwrapped() const noexcept {
         return _List_unchecked_iterator<_Mylist>(this->_Ptr, static_cast<const _Mylist*>(this->_Getcont()));
     }
 };

--- a/stl/inc/list
+++ b/stl/inc/list
@@ -215,7 +215,7 @@ public:
         return _List_unchecked_const_iterator<_Mylist>(this->_Ptr, static_cast<const _Mylist*>(this->_Getcont()));
     }
 
-    void _Seek_to(const _List_unchecked_const_iterator<_Mylist> _It) {
+    void _Seek_to(const _List_unchecked_const_iterator<_Mylist> _It) noexcept {
         this->_Ptr = _It._Ptr;
     }
 };

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -43,7 +43,7 @@ public:
         this->_Adopt(_Pvector);
     }
 
-    _NODISCARD reference operator*() const {
+    _NODISCARD reference operator*() const noexcept {
 #if _ITERATOR_DEBUG_LEVEL != 0
         const auto _Mycont = static_cast<const _Myvec*>(this->_Getcont());
         _STL_VERIFY(_Ptr, "can't dereference value-initialized vector iterator");
@@ -54,7 +54,7 @@ public:
         return *_Ptr;
     }
 
-    _NODISCARD pointer operator->() const {
+    _NODISCARD pointer operator->() const noexcept {
 #if _ITERATOR_DEBUG_LEVEL != 0
         const auto _Mycont = static_cast<const _Myvec*>(this->_Getcont());
         _STL_VERIFY(_Ptr, "can't dereference value-initialized vector iterator");
@@ -65,7 +65,7 @@ public:
         return _Ptr;
     }
 
-    _Vector_const_iterator& operator++() {
+    _Vector_const_iterator& operator++() noexcept {
 #if _ITERATOR_DEBUG_LEVEL != 0
         const auto _Mycont = static_cast<const _Myvec*>(this->_Getcont());
         _STL_VERIFY(_Ptr, "can't increment value-initialized vector iterator");
@@ -76,13 +76,13 @@ public:
         return *this;
     }
 
-    _Vector_const_iterator operator++(int) {
+    _Vector_const_iterator operator++(int) noexcept {
         _Vector_const_iterator _Tmp = *this;
         ++*this;
         return _Tmp;
     }
 
-    _Vector_const_iterator& operator--() {
+    _Vector_const_iterator& operator--() noexcept {
 #if _ITERATOR_DEBUG_LEVEL != 0
         const auto _Mycont = static_cast<const _Myvec*>(this->_Getcont());
         _STL_VERIFY(_Ptr, "can't decrement value-initialized vector iterator");
@@ -93,13 +93,13 @@ public:
         return *this;
     }
 
-    _Vector_const_iterator operator--(int) {
+    _Vector_const_iterator operator--(int) noexcept {
         _Vector_const_iterator _Tmp = *this;
         --*this;
         return _Tmp;
     }
 
-    void _Verify_offset(const difference_type _Off) const {
+    void _Verify_offset(const difference_type _Off) const noexcept {
 #if _ITERATOR_DEBUG_LEVEL == 0
         (void) _Off;
 #else // ^^^ _ITERATOR_DEBUG_LEVEL == 0 ^^^ // vvv _ITERATOR_DEBUG_LEVEL != 0 vvv
@@ -115,62 +115,62 @@ public:
 #endif // _ITERATOR_DEBUG_LEVEL == 0
     }
 
-    _Vector_const_iterator& operator+=(const difference_type _Off) {
+    _Vector_const_iterator& operator+=(const difference_type _Off) noexcept {
         _Verify_offset(_Off);
         _Ptr += _Off;
         return *this;
     }
 
-    _NODISCARD _Vector_const_iterator operator+(const difference_type _Off) const {
+    _NODISCARD _Vector_const_iterator operator+(const difference_type _Off) const noexcept {
         _Vector_const_iterator _Tmp = *this;
         return _Tmp += _Off;
     }
 
-    _Vector_const_iterator& operator-=(const difference_type _Off) {
+    _Vector_const_iterator& operator-=(const difference_type _Off) noexcept {
         return *this += -_Off;
     }
 
-    _NODISCARD _Vector_const_iterator operator-(const difference_type _Off) const {
+    _NODISCARD _Vector_const_iterator operator-(const difference_type _Off) const noexcept {
         _Vector_const_iterator _Tmp = *this;
         return _Tmp -= _Off;
     }
 
-    _NODISCARD difference_type operator-(const _Vector_const_iterator& _Right) const {
+    _NODISCARD difference_type operator-(const _Vector_const_iterator& _Right) const noexcept {
         _Compat(_Right);
         return _Ptr - _Right._Ptr;
     }
 
-    _NODISCARD reference operator[](const difference_type _Off) const {
+    _NODISCARD reference operator[](const difference_type _Off) const noexcept {
         return *(*this + _Off);
     }
 
-    _NODISCARD bool operator==(const _Vector_const_iterator& _Right) const {
+    _NODISCARD bool operator==(const _Vector_const_iterator& _Right) const noexcept {
         _Compat(_Right);
         return _Ptr == _Right._Ptr;
     }
 
-    _NODISCARD bool operator!=(const _Vector_const_iterator& _Right) const {
+    _NODISCARD bool operator!=(const _Vector_const_iterator& _Right) const noexcept {
         return !(*this == _Right);
     }
 
-    _NODISCARD bool operator<(const _Vector_const_iterator& _Right) const {
+    _NODISCARD bool operator<(const _Vector_const_iterator& _Right) const noexcept {
         _Compat(_Right);
         return _Ptr < _Right._Ptr;
     }
 
-    _NODISCARD bool operator>(const _Vector_const_iterator& _Right) const {
+    _NODISCARD bool operator>(const _Vector_const_iterator& _Right) const noexcept {
         return _Right < *this;
     }
 
-    _NODISCARD bool operator<=(const _Vector_const_iterator& _Right) const {
+    _NODISCARD bool operator<=(const _Vector_const_iterator& _Right) const noexcept {
         return !(_Right < *this);
     }
 
-    _NODISCARD bool operator>=(const _Vector_const_iterator& _Right) const {
+    _NODISCARD bool operator>=(const _Vector_const_iterator& _Right) const noexcept {
         return !(*this < _Right);
     }
 
-    void _Compat(const _Vector_const_iterator& _Right) const { // test for compatible iterator pair
+    void _Compat(const _Vector_const_iterator& _Right) const noexcept { // test for compatible iterator pair
 #if _ITERATOR_DEBUG_LEVEL == 0
         (void) _Right;
 #else // ^^^ _ITERATOR_DEBUG_LEVEL == 0 ^^^ // vvv _ITERATOR_DEBUG_LEVEL != 0 vvv
@@ -179,7 +179,7 @@ public:
     }
 
 #if _ITERATOR_DEBUG_LEVEL != 0
-    friend void _Verify_range(const _Vector_const_iterator& _First, const _Vector_const_iterator& _Last) {
+    friend void _Verify_range(const _Vector_const_iterator& _First, const _Vector_const_iterator& _Last) noexcept {
         _STL_VERIFY(_First._Getcont() == _Last._Getcont(), "vector iterators in range are from different containers");
         _STL_VERIFY(_First._Ptr <= _Last._Ptr, "vector iterator range transposed");
     }
@@ -187,11 +187,11 @@ public:
 
     using _Prevent_inheriting_unwrap = _Vector_const_iterator;
 
-    _NODISCARD const value_type* _Unwrapped() const {
+    _NODISCARD const value_type* _Unwrapped() const noexcept {
         return _Unfancy(_Ptr);
     }
 
-    void _Seek_to(const value_type* _It) {
+    void _Seek_to(const value_type* _It) noexcept {
         _Ptr = _Refancy<_Tptr>(const_cast<value_type*>(_It));
     }
 
@@ -200,7 +200,7 @@ public:
 
 template <class _Myvec>
 _NODISCARD _Vector_const_iterator<_Myvec> operator+(
-    typename _Vector_const_iterator<_Myvec>::difference_type _Off, _Vector_const_iterator<_Myvec> _Next) {
+    typename _Vector_const_iterator<_Myvec>::difference_type _Off, _Vector_const_iterator<_Myvec> _Next) noexcept {
     return _Next += _Off;
 }
 
@@ -248,72 +248,72 @@ public:
 
     using _Mybase::_Mybase;
 
-    _NODISCARD reference operator*() const {
+    _NODISCARD reference operator*() const noexcept {
         return const_cast<reference>(_Mybase::operator*());
     }
 
-    _NODISCARD pointer operator->() const {
+    _NODISCARD pointer operator->() const noexcept {
         return _Const_cast(_Mybase::operator->());
     }
 
-    _Vector_iterator& operator++() {
+    _Vector_iterator& operator++() noexcept {
         _Mybase::operator++();
         return *this;
     }
 
-    _Vector_iterator operator++(int) {
+    _Vector_iterator operator++(int) noexcept {
         _Vector_iterator _Tmp = *this;
         _Mybase::operator++();
         return _Tmp;
     }
 
-    _Vector_iterator& operator--() {
+    _Vector_iterator& operator--() noexcept {
         _Mybase::operator--();
         return *this;
     }
 
-    _Vector_iterator operator--(int) {
+    _Vector_iterator operator--(int) noexcept {
         _Vector_iterator _Tmp = *this;
         _Mybase::operator--();
         return _Tmp;
     }
 
-    _Vector_iterator& operator+=(const difference_type _Off) {
+    _Vector_iterator& operator+=(const difference_type _Off) noexcept {
         _Mybase::operator+=(_Off);
         return *this;
     }
 
-    _NODISCARD _Vector_iterator operator+(const difference_type _Off) const {
+    _NODISCARD _Vector_iterator operator+(const difference_type _Off) const noexcept {
         _Vector_iterator _Tmp = *this;
         return _Tmp += _Off;
     }
 
-    _Vector_iterator& operator-=(const difference_type _Off) {
+    _Vector_iterator& operator-=(const difference_type _Off) noexcept {
         _Mybase::operator-=(_Off);
         return *this;
     }
 
     using _Mybase::operator-;
 
-    _NODISCARD _Vector_iterator operator-(const difference_type _Off) const {
+    _NODISCARD _Vector_iterator operator-(const difference_type _Off) const noexcept {
         _Vector_iterator _Tmp = *this;
         return _Tmp -= _Off;
     }
 
-    _NODISCARD reference operator[](const difference_type _Off) const {
+    _NODISCARD reference operator[](const difference_type _Off) const noexcept {
         return const_cast<reference>(_Mybase::operator[](_Off));
     }
 
     using _Prevent_inheriting_unwrap = _Vector_iterator;
 
-    _NODISCARD value_type* _Unwrapped() const {
+    _NODISCARD value_type* _Unwrapped() const noexcept {
         return _Unfancy(this->_Ptr);
     }
 };
 
 template <class _Myvec>
 _NODISCARD _Vector_iterator<_Myvec> operator+(
-    typename _Vector_iterator<_Myvec>::difference_type _Off, _Vector_iterator<_Myvec> _Next) {
+    typename _Vector_iterator<_Myvec>::difference_type _Off, _Vector_iterator<_Myvec> _Next) noexcept {
     return _Next += _Off;
 }
 
@@ -399,12 +399,12 @@ public:
 
 // FUNCTION TEMPLATE _Unfancy_maybe_null
 template <class _Ptrty>
-auto _Unfancy_maybe_null(_Ptrty _Ptr) { // converts from a (potentially null) fancy pointer to a plain pointer
+auto _Unfancy_maybe_null(_Ptrty _Ptr) noexcept { // converts from a (potentially null) fancy pointer to a plain pointer
     return _Ptr ? _STD addressof(*_Ptr) : nullptr;
 }
 
 template <class _Ty>
-_Ty* _Unfancy_maybe_null(_Ty* _Ptr) { // do nothing for plain pointers
+_Ty* _Unfancy_maybe_null(_Ty* _Ptr) noexcept { // do nothing for plain pointers
     return _Ptr;
 }
 
@@ -1818,14 +1818,14 @@ public:
         this->_Adopt(_Mypvbool);
     }
 
-    void _Advance(_Size_type _Off) {
+    void _Advance(_Size_type _Off) noexcept {
         _Myoff += _Off;
         _Myptr += _Myoff / _VBITS;
         _Myoff %= _VBITS;
     }
 
 #if _ITERATOR_DEBUG_LEVEL != 0
-    _Difference_type _Total_off(const _Mycont* _Cont) const {
+    _Difference_type _Total_off(const _Mycont* _Cont) const noexcept {
         return static_cast<_Difference_type>(_VBITS * (_Myptr - _Cont->_Myvec.data()) + _Myoff);
     }
 #endif // _ITERATOR_DEBUG_LEVEL != 0
@@ -1872,7 +1872,7 @@ public:
         return (*_Getptr() & _Mask()) != 0;
     }
 
-    const _Vbase* _Getptr() const {
+    const _Vbase* _Getptr() const noexcept {
 #if _ITERATOR_DEBUG_LEVEL != 0
         const auto _Cont = static_cast<const _Mycont*>(this->_Getcont());
         _STL_VERIFY(_Cont, "cannot dereference value-initialized vector<bool> iterator");
@@ -1890,7 +1890,7 @@ public:
     }
 
 protected:
-    _Vbase _Mask() const {
+    _Vbase _Mask() const noexcept {
         return static_cast<_Vbase>(1) << this->_Myoff;
     }
 };
@@ -1918,7 +1918,7 @@ public:
 
     _Vb_const_iterator(const _Vbase* _Ptr, const _Container_base* _Mypvbool) noexcept : _Mybase(_Ptr, 0, _Mypvbool) {}
 
-    _NODISCARD const_reference operator*() const {
+    _NODISCARD const_reference operator*() const noexcept {
 #if _ITERATOR_DEBUG_LEVEL != 0
         const auto _Cont = static_cast<const _Mycont*>(this->_Getcont());
         _STL_VERIFY(_Cont, "cannot dereference value-initialized vector<bool> iterator");
@@ -1929,29 +1929,29 @@ public:
         return _Reft(*this);
     }
 
-    _Vb_const_iterator& operator++() {
+    _Vb_const_iterator& operator++() noexcept {
         _Inc();
         return *this;
     }
 
-    _Vb_const_iterator operator++(int) {
+    _Vb_const_iterator operator++(int) noexcept {
         _Vb_const_iterator _Tmp = *this;
         _Inc();
         return _Tmp;
     }
 
-    _Vb_const_iterator& operator--() {
+    _Vb_const_iterator& operator--() noexcept {
         _Dec();
         return *this;
     }
 
-    _Vb_const_iterator operator--(int) {
+    _Vb_const_iterator operator--(int) noexcept {
         _Vb_const_iterator _Tmp = *this;
         _Dec();
         return _Tmp;
     }
 
-    _Vb_const_iterator& operator+=(const difference_type _Off) {
+    _Vb_const_iterator& operator+=(const difference_type _Off) noexcept {
 #if _ITERATOR_DEBUG_LEVEL != 0
         if (_Off != 0) {
             const auto _Cont = static_cast<const _Mycont*>(this->_Getcont());
@@ -1978,57 +1978,57 @@ public:
         return *this;
     }
 
-    _NODISCARD _Vb_const_iterator operator+(const difference_type _Off) const {
+    _NODISCARD _Vb_const_iterator operator+(const difference_type _Off) const noexcept {
         _Vb_const_iterator _Tmp = *this;
         return _Tmp += _Off;
     }
 
-    _Vb_const_iterator& operator-=(const difference_type _Off) {
+    _Vb_const_iterator& operator-=(const difference_type _Off) noexcept {
         return *this += -_Off;
     }
 
-    _NODISCARD _Vb_const_iterator operator-(const difference_type _Off) const {
+    _NODISCARD _Vb_const_iterator operator-(const difference_type _Off) const noexcept {
         _Vb_const_iterator _Tmp = *this;
         return _Tmp -= _Off;
     }
 
-    _NODISCARD difference_type operator-(const _Vb_const_iterator& _Right) const {
+    _NODISCARD difference_type operator-(const _Vb_const_iterator& _Right) const noexcept {
         _Compat(_Right);
         return static_cast<difference_type>(_VBITS * (this->_Myptr - _Right._Myptr))
                + static_cast<difference_type>(this->_Myoff) - static_cast<difference_type>(_Right._Myoff);
     }
 
-    _NODISCARD const_reference operator[](const difference_type _Off) const {
+    _NODISCARD const_reference operator[](const difference_type _Off) const noexcept {
         return *(*this + _Off);
     }
 
-    _NODISCARD bool operator==(const _Vb_const_iterator& _Right) const {
+    _NODISCARD bool operator==(const _Vb_const_iterator& _Right) const noexcept {
         _Compat(_Right);
         return this->_Myptr == _Right._Myptr && this->_Myoff == _Right._Myoff;
     }
 
-    _NODISCARD bool operator!=(const _Vb_const_iterator& _Right) const {
+    _NODISCARD bool operator!=(const _Vb_const_iterator& _Right) const noexcept {
         return !(*this == _Right);
     }
 
-    _NODISCARD bool operator<(const _Vb_const_iterator& _Right) const {
+    _NODISCARD bool operator<(const _Vb_const_iterator& _Right) const noexcept {
         _Compat(_Right);
         return this->_Myptr < _Right._Myptr || (this->_Myptr == _Right._Myptr && this->_Myoff < _Right._Myoff);
     }
 
-    _NODISCARD bool operator>(const _Vb_const_iterator& _Right) const {
+    _NODISCARD bool operator>(const _Vb_const_iterator& _Right) const noexcept {
         return _Right < *this;
     }
 
-    _NODISCARD bool operator<=(const _Vb_const_iterator& _Right) const {
+    _NODISCARD bool operator<=(const _Vb_const_iterator& _Right) const noexcept {
         return !(_Right < *this);
     }
 
-    _NODISCARD bool operator>=(const _Vb_const_iterator& _Right) const {
+    _NODISCARD bool operator>=(const _Vb_const_iterator& _Right) const noexcept {
         return !(*this < _Right);
     }
 
-    void _Compat(const _Vb_const_iterator& _Right) const { // test for compatible iterator pair
+    void _Compat(const _Vb_const_iterator& _Right) const noexcept { // test for compatible iterator pair
 #if _ITERATOR_DEBUG_LEVEL == 0
         (void) _Right;
 #else // _ITERATOR_DEBUG_LEVEL == 0
@@ -2039,13 +2039,13 @@ public:
 #if _ITERATOR_DEBUG_LEVEL != 0
     using _Prevent_inheriting_unwrap = _Vb_const_iterator;
 
-    friend void _Verify_range(const _Vb_const_iterator& _First, const _Vb_const_iterator& _Last) {
+    friend void _Verify_range(const _Vb_const_iterator& _First, const _Vb_const_iterator& _Last) noexcept {
         // note _Compat check inside <=
         _STL_VERIFY(_First <= _Last, "vector<bool> iterator range transposed");
     }
 #endif // _ITERATOR_DEBUG_LEVEL != 0
 
-    void _Dec() { // decrement bit position
+    void _Dec() noexcept { // decrement bit position
 #if _ITERATOR_DEBUG_LEVEL != 0
         const auto _Cont = static_cast<const _Mycont*>(this->_Getcont());
         _STL_VERIFY(_Cont, "cannot decrement value-initialized vector<bool> iterator");
@@ -2060,7 +2060,7 @@ public:
         }
     }
 
-    void _Inc() { // increment bit position
+    void _Inc() noexcept { // increment bit position
 #if _ITERATOR_DEBUG_LEVEL != 0
         const auto _Cont = static_cast<const _Mycont*>(this->_Getcont());
         _STL_VERIFY(_Cont, "cannot increment value-initialized vector<bool> iterator");
@@ -2079,7 +2079,8 @@ public:
 
 template <class _Alvbase_wrapped>
 _NODISCARD _Vb_const_iterator<_Alvbase_wrapped> operator+(
-    typename _Vb_const_iterator<_Alvbase_wrapped>::difference_type _Off, _Vb_const_iterator<_Alvbase_wrapped> _Right) {
+    typename _Vb_const_iterator<_Alvbase_wrapped>::difference_type _Off,
+    _Vb_const_iterator<_Alvbase_wrapped> _Right) noexcept {
     return _Right += _Off;
 }
 
@@ -2102,7 +2103,7 @@ public:
 
     using _Mybase::_Mybase;
 
-    _NODISCARD reference operator*() const {
+    _NODISCARD reference operator*() const noexcept {
 #if _ITERATOR_DEBUG_LEVEL != 0
         const auto _Cont = static_cast<const _Mycont*>(this->_Getcont());
         _STL_VERIFY(_Cont, "cannot dereference value-initialized vector<bool> iterator");
@@ -2113,51 +2114,51 @@ public:
         return _Reft(*this);
     }
 
-    _Vb_iterator& operator++() {
+    _Vb_iterator& operator++() noexcept {
         _Mybase::operator++();
         return *this;
     }
 
-    _Vb_iterator operator++(int) {
+    _Vb_iterator operator++(int) noexcept {
         _Vb_iterator _Tmp = *this;
         _Mybase::operator++();
         return _Tmp;
     }
 
-    _Vb_iterator& operator--() {
+    _Vb_iterator& operator--() noexcept {
         _Mybase::operator--();
         return *this;
     }
 
-    _Vb_iterator operator--(int) {
+    _Vb_iterator operator--(int) noexcept {
         _Vb_iterator _Tmp = *this;
         _Mybase::operator--();
         return _Tmp;
     }
 
-    _Vb_iterator& operator+=(const difference_type _Off) {
+    _Vb_iterator& operator+=(const difference_type _Off) noexcept {
         _Mybase::operator+=(_Off);
         return *this;
     }
 
-    _NODISCARD _Vb_iterator operator+(const difference_type _Off) const {
+    _NODISCARD _Vb_iterator operator+(const difference_type _Off) const noexcept {
         _Vb_iterator _Tmp = *this;
         return _Tmp += _Off;
     }
 
-    _Vb_iterator& operator-=(const difference_type _Off) {
+    _Vb_iterator& operator-=(const difference_type _Off) noexcept {
         _Mybase::operator-=(_Off);
         return *this;
     }
 
     using _Mybase::operator-;
 
-    _NODISCARD _Vb_iterator operator-(const difference_type _Off) const {
+    _NODISCARD _Vb_iterator operator-(const difference_type _Off) const noexcept {
         _Vb_iterator _Tmp = *this;
         return _Tmp -= _Off;
     }
 
-    _NODISCARD reference operator[](const difference_type _Off) const {
+    _NODISCARD reference operator[](const difference_type _Off) const noexcept {
         return *(*this + _Off);
     }
 
@@ -2166,7 +2167,7 @@ public:
 
 template <class _Alvbase_wrapped>
 _NODISCARD _Vb_iterator<_Alvbase_wrapped> operator+(
-    typename _Vb_iterator<_Alvbase_wrapped>::difference_type _Off, _Vb_iterator<_Alvbase_wrapped> _Right) {
+    typename _Vb_iterator<_Alvbase_wrapped>::difference_type _Off, _Vb_iterator<_Alvbase_wrapped> _Right) noexcept {
     return _Right += _Off;
 }
 
@@ -2238,7 +2239,7 @@ public:
         return _Myvec._Getal();
     }
 
-    static size_type _Nw(size_type _Count) {
+    static size_type _Nw(size_type _Count) noexcept {
         return (_Count + _VBITS - 1) / _VBITS;
     }
 

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -2004,7 +2004,7 @@ public:
 
 template <class _Mystr>
 _NODISCARD _String_const_iterator<_Mystr> operator+(
-    typename _String_const_iterator<_Mystr>::difference_type _Off, _String_const_iterator<_Mystr> _Next) {
+    typename _String_const_iterator<_Mystr>::difference_type _Off, _String_const_iterator<_Mystr> _Next) noexcept {
     return _Next += _Off;
 }
 
@@ -3283,7 +3283,7 @@ private:
     }
 
 public:
-    basic_string& erase(const size_type _Off, size_type _Count) { // erase elements [_Off, _Off + _Count)
+    basic_string& erase(const size_type _Off, const size_type _Count) { // erase elements [_Off, _Off + _Count)
         _Mypair._Myval2._Check_offset(_Off);
         return _Erase_noexcept(_Off, _Count);
     }

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -1831,7 +1831,7 @@ public:
         this->_Adopt(_Pstring);
     }
 
-    _NODISCARD reference operator*() const {
+    _NODISCARD reference operator*() const noexcept {
 #if _ITERATOR_DEBUG_LEVEL >= 1
         _STL_VERIFY(_Ptr, "cannot dereference value-initialized string iterator");
         const auto _Mycont = static_cast<const _Mystr*>(this->_Getcont());
@@ -1847,11 +1847,11 @@ public:
         return *_Ptr;
     }
 
-    _NODISCARD pointer operator->() const {
+    _NODISCARD pointer operator->() const noexcept {
         return pointer_traits<pointer>::pointer_to(**this);
     }
 
-    _String_const_iterator& operator++() {
+    _String_const_iterator& operator++() noexcept {
 #if _ITERATOR_DEBUG_LEVEL >= 1
         _STL_VERIFY(_Ptr, "cannot increment value-initialized string iterator");
         const auto _Mycont = static_cast<const _Mystr*>(this->_Getcont());
@@ -1864,13 +1864,13 @@ public:
         return *this;
     }
 
-    _String_const_iterator operator++(int) {
+    _String_const_iterator operator++(int) noexcept {
         _String_const_iterator _Tmp = *this;
         ++*this;
         return _Tmp;
     }
 
-    _String_const_iterator& operator--() {
+    _String_const_iterator& operator--() noexcept {
 #if _ITERATOR_DEBUG_LEVEL >= 1
         _STL_VERIFY(_Ptr, "cannot decrement value-initialized string iterator");
         const auto _Mycont = static_cast<const _Mystr*>(this->_Getcont());
@@ -1883,7 +1883,7 @@ public:
         return *this;
     }
 
-    _String_const_iterator operator--(int) {
+    _String_const_iterator operator--(int) noexcept {
         _String_const_iterator _Tmp = *this;
         --*this;
         return _Tmp;
@@ -1916,7 +1916,7 @@ public:
 #endif // _ITERATOR_DEBUG_LEVEL >= 1
     }
 
-    _String_const_iterator& operator+=(const difference_type _Off) {
+    _String_const_iterator& operator+=(const difference_type _Off) noexcept {
 #if _ITERATOR_DEBUG_LEVEL >= 1
         _Verify_offset(_Off);
 #endif // _ITERATOR_DEBUG_LEVEL >= 1
@@ -1924,56 +1924,56 @@ public:
         return *this;
     }
 
-    _NODISCARD _String_const_iterator operator+(const difference_type _Off) const {
+    _NODISCARD _String_const_iterator operator+(const difference_type _Off) const noexcept {
         _String_const_iterator _Tmp = *this;
         return _Tmp += _Off;
     }
 
-    _String_const_iterator& operator-=(const difference_type _Off) {
+    _String_const_iterator& operator-=(const difference_type _Off) noexcept {
         return *this += -_Off;
     }
 
-    _NODISCARD _String_const_iterator operator-(const difference_type _Off) const {
+    _NODISCARD _String_const_iterator operator-(const difference_type _Off) const noexcept {
         _String_const_iterator _Tmp = *this;
         return _Tmp -= _Off;
     }
 
-    _NODISCARD difference_type operator-(const _String_const_iterator& _Right) const {
+    _NODISCARD difference_type operator-(const _String_const_iterator& _Right) const noexcept {
         _Compat(_Right);
         return _Ptr - _Right._Ptr;
     }
 
-    _NODISCARD reference operator[](const difference_type _Off) const {
+    _NODISCARD reference operator[](const difference_type _Off) const noexcept {
         return *(*this + _Off);
     }
 
-    _NODISCARD bool operator==(const _String_const_iterator& _Right) const {
+    _NODISCARD bool operator==(const _String_const_iterator& _Right) const noexcept {
         _Compat(_Right);
         return _Ptr == _Right._Ptr;
     }
 
-    _NODISCARD bool operator!=(const _String_const_iterator& _Right) const {
+    _NODISCARD bool operator!=(const _String_const_iterator& _Right) const noexcept {
         return !(*this == _Right);
     }
 
-    _NODISCARD bool operator<(const _String_const_iterator& _Right) const {
+    _NODISCARD bool operator<(const _String_const_iterator& _Right) const noexcept {
         _Compat(_Right);
         return _Ptr < _Right._Ptr;
     }
 
-    _NODISCARD bool operator>(const _String_const_iterator& _Right) const {
+    _NODISCARD bool operator>(const _String_const_iterator& _Right) const noexcept {
         return _Right < *this;
     }
 
-    _NODISCARD bool operator<=(const _String_const_iterator& _Right) const {
+    _NODISCARD bool operator<=(const _String_const_iterator& _Right) const noexcept {
         return !(_Right < *this);
     }
 
-    _NODISCARD bool operator>=(const _String_const_iterator& _Right) const {
+    _NODISCARD bool operator>=(const _String_const_iterator& _Right) const noexcept {
         return !(*this < _Right);
     }
 
-    void _Compat(const _String_const_iterator& _Right) const { // test for compatible iterator pair
+    void _Compat(const _String_const_iterator& _Right) const noexcept { // test for compatible iterator pair
 #if _ITERATOR_DEBUG_LEVEL >= 1
         _STL_VERIFY(this->_Getcont() == _Right._Getcont(), "string iterators incompatible (e.g."
                                                            " point to different string instances)");
@@ -1983,7 +1983,7 @@ public:
     }
 
 #if _ITERATOR_DEBUG_LEVEL >= 1
-    friend void _Verify_range(const _String_const_iterator& _First, const _String_const_iterator& _Last) {
+    friend void _Verify_range(const _String_const_iterator& _First, const _String_const_iterator& _Last) noexcept {
         _STL_VERIFY(_First._Getcont() == _Last._Getcont(), "string iterators in range are from different containers");
         _STL_VERIFY(_First._Ptr <= _Last._Ptr, "string iterator range transposed");
     }
@@ -1991,11 +1991,11 @@ public:
 
     using _Prevent_inheriting_unwrap = _String_const_iterator;
 
-    _NODISCARD const value_type* _Unwrapped() const {
+    _NODISCARD const value_type* _Unwrapped() const noexcept {
         return _Unfancy(_Ptr);
     }
 
-    void _Seek_to(const value_type* _It) {
+    void _Seek_to(const value_type* _It) noexcept {
         _Ptr = _Refancy<pointer>(const_cast<value_type*>(_It));
     }
 
@@ -2056,72 +2056,72 @@ public:
 
     using _Mybase::_Mybase;
 
-    _NODISCARD reference operator*() const {
+    _NODISCARD reference operator*() const noexcept {
         return const_cast<reference>(_Mybase::operator*());
     }
 
-    _NODISCARD pointer operator->() const {
+    _NODISCARD pointer operator->() const noexcept {
         return pointer_traits<pointer>::pointer_to(**this);
     }
 
-    _String_iterator& operator++() {
+    _String_iterator& operator++() noexcept {
         _Mybase::operator++();
         return *this;
     }
 
-    _String_iterator operator++(int) {
+    _String_iterator operator++(int) noexcept {
         _String_iterator _Tmp = *this;
         _Mybase::operator++();
         return _Tmp;
     }
 
-    _String_iterator& operator--() {
+    _String_iterator& operator--() noexcept {
         _Mybase::operator--();
         return *this;
     }
 
-    _String_iterator operator--(int) {
+    _String_iterator operator--(int) noexcept {
         _String_iterator _Tmp = *this;
         _Mybase::operator--();
         return _Tmp;
     }
 
-    _String_iterator& operator+=(const difference_type _Off) {
+    _String_iterator& operator+=(const difference_type _Off) noexcept {
         _Mybase::operator+=(_Off);
         return *this;
     }
 
-    _NODISCARD _String_iterator operator+(const difference_type _Off) const {
+    _NODISCARD _String_iterator operator+(const difference_type _Off) const noexcept {
         _String_iterator _Tmp = *this;
         return _Tmp += _Off;
     }
 
-    _String_iterator& operator-=(const difference_type _Off) {
+    _String_iterator& operator-=(const difference_type _Off) noexcept {
         _Mybase::operator-=(_Off);
         return *this;
     }
 
     using _Mybase::operator-;
 
-    _NODISCARD _String_iterator operator-(const difference_type _Off) const {
+    _NODISCARD _String_iterator operator-(const difference_type _Off) const noexcept {
         _String_iterator _Tmp = *this;
         return _Tmp -= _Off;
     }
 
-    _NODISCARD reference operator[](const difference_type _Off) const {
+    _NODISCARD reference operator[](const difference_type _Off) const noexcept {
         return const_cast<reference>(_Mybase::operator[](_Off));
     }
 
     using _Prevent_inheriting_unwrap = _String_iterator;
 
-    _NODISCARD value_type* _Unwrapped() const {
+    _NODISCARD value_type* _Unwrapped() const noexcept {
         return const_cast<value_type*>(_Unfancy(this->_Ptr));
     }
 };
 
 template <class _Mystr>
 _NODISCARD _String_iterator<_Mystr> operator+(
-    typename _String_iterator<_Mystr>::difference_type _Off, _String_iterator<_Mystr> _Next) {
+    typename _String_iterator<_Mystr>::difference_type _Off, _String_iterator<_Mystr> _Next) noexcept {
     return _Next += _Off;
 }
 
@@ -2179,7 +2179,7 @@ public:
     using reference       = value_type&;
     using const_reference = const value_type&;
 
-    _String_val() : _Bx(), _Mysize(0), _Myres(0) {}
+    _String_val() noexcept : _Bx(), _Mysize(0), _Myres(0) {}
 
     // length of internal buffer, [1, 16]:
     static constexpr size_type _BUF_SIZE = 16 / sizeof(value_type) < 1 ? 1 : 16 / sizeof(value_type);
@@ -2233,7 +2233,7 @@ public:
     }
 
     union _Bxty { // storage for small buffer or pointer to larger one
-        _Bxty() {} // user-provided, for fancy pointers
+        _Bxty() noexcept {} // user-provided, for fancy pointers
 
         ~_Bxty() noexcept {} // user-provided, for fancy pointers
 
@@ -3270,8 +3270,8 @@ public:
         return *this;
     }
 
-    basic_string& erase(const size_type _Off, size_type _Count) { // erase elements [_Off, _Off + _Count)
-        _Mypair._Myval2._Check_offset(_Off);
+private:
+    basic_string& _Erase_noexcept(const size_type _Off, size_type _Count) noexcept {
         _Count                    = _Mypair._Myval2._Clamp_suffix_size(_Off, _Count);
         const size_type _Old_size = _Mypair._Myval2._Mysize;
         _Elem* const _My_ptr      = _Mypair._Myval2._Myptr();
@@ -3282,12 +3282,18 @@ public:
         return *this;
     }
 
+public:
+    basic_string& erase(const size_type _Off, size_type _Count) { // erase elements [_Off, _Off + _Count)
+        _Mypair._Myval2._Check_offset(_Off);
+        return _Erase_noexcept(_Off, _Count);
+    }
+
     iterator erase(const const_iterator _Where) noexcept /* strengthened */ {
 #if _ITERATOR_DEBUG_LEVEL != 0
         _STL_VERIFY(_Where._Getcont() == _STD addressof(_Mypair._Myval2), "string iterator incompatible");
 #endif // _ITERATOR_DEBUG_LEVEL != 0
         const auto _Off = static_cast<size_type>(_Unfancy(_Where._Ptr) - _Mypair._Myval2._Myptr());
-        erase(_Off, 1);
+        _Erase_noexcept(_Off, 1);
         return begin() + static_cast<difference_type>(_Off);
     }
 
@@ -3297,7 +3303,7 @@ public:
         _STL_VERIFY(_First._Getcont() == _STD addressof(_Mypair._Myval2), "string iterators incompatible");
 #endif // _ITERATOR_DEBUG_LEVEL != 0
         const auto _Off = static_cast<size_type>(_Unfancy(_First._Ptr) - _Mypair._Myval2._Myptr());
-        erase(_Off, static_cast<size_type>(_Last._Ptr - _First._Ptr));
+        _Erase_noexcept(_Off, static_cast<size_type>(_Last._Ptr - _First._Ptr));
         return begin() + static_cast<difference_type>(_Off);
     }
 

--- a/stl/inc/xtree
+++ b/stl/inc/xtree
@@ -248,7 +248,7 @@ public:
         return _Tree_unchecked_const_iterator<_Mytree>(this->_Ptr, static_cast<const _Mytree*>(this->_Getcont()));
     }
 
-    void _Seek_to(const _Tree_unchecked_const_iterator<_Mytree> _It) {
+    void _Seek_to(const _Tree_unchecked_const_iterator<_Mytree> _It) noexcept {
         this->_Ptr = _It._Ptr;
     }
 };

--- a/stl/inc/xtree
+++ b/stl/inc/xtree
@@ -40,15 +40,15 @@ public:
         this->_Adopt(_Plist);
     }
 
-    _NODISCARD reference operator*() const {
+    _NODISCARD reference operator*() const noexcept {
         return _Ptr->_Myval;
     }
 
-    _NODISCARD pointer operator->() const {
+    _NODISCARD pointer operator->() const noexcept {
         return pointer_traits<pointer>::pointer_to(**this);
     }
 
-    _Tree_unchecked_const_iterator& operator++() {
+    _Tree_unchecked_const_iterator& operator++() noexcept {
         if (_Ptr->_Right->_Isnil) { // climb looking for right subtree
             _Nodeptr _Pnode;
             while (!(_Pnode = _Ptr->_Parent)->_Isnil && _Ptr == _Pnode->_Right) {
@@ -63,13 +63,13 @@ public:
         return *this;
     }
 
-    _Tree_unchecked_const_iterator operator++(int) {
+    _Tree_unchecked_const_iterator operator++(int) noexcept {
         _Tree_unchecked_const_iterator _Tmp = *this;
         ++*this;
         return _Tmp;
     }
 
-    _Tree_unchecked_const_iterator& operator--() {
+    _Tree_unchecked_const_iterator& operator--() noexcept {
         if (_Ptr->_Isnil) {
             _Ptr = _Ptr->_Right; // end() ==> rightmost
         } else if (_Ptr->_Left->_Isnil) { // climb looking for left subtree
@@ -88,17 +88,17 @@ public:
         return *this;
     }
 
-    _Tree_unchecked_const_iterator operator--(int) {
+    _Tree_unchecked_const_iterator operator--(int) noexcept {
         _Tree_unchecked_const_iterator _Tmp = *this;
         --*this;
         return _Tmp;
     }
 
-    _NODISCARD bool operator==(const _Tree_unchecked_const_iterator& _Right) const {
+    _NODISCARD bool operator==(const _Tree_unchecked_const_iterator& _Right) const noexcept {
         return _Ptr == _Right._Ptr;
     }
 
-    _NODISCARD bool operator!=(const _Tree_unchecked_const_iterator& _Right) const {
+    _NODISCARD bool operator!=(const _Tree_unchecked_const_iterator& _Right) const noexcept {
         return !(*this == _Right);
     }
 
@@ -129,31 +129,31 @@ public:
 
     using _Mybase::_Mybase;
 
-    _NODISCARD reference operator*() const {
+    _NODISCARD reference operator*() const noexcept {
         return const_cast<reference>(_Mybase::operator*());
     }
 
-    _NODISCARD pointer operator->() const {
+    _NODISCARD pointer operator->() const noexcept {
         return pointer_traits<pointer>::pointer_to(**this);
     }
 
-    _Tree_unchecked_iterator& operator++() {
+    _Tree_unchecked_iterator& operator++() noexcept {
         _Mybase::operator++();
         return *this;
     }
 
-    _Tree_unchecked_iterator operator++(int) {
+    _Tree_unchecked_iterator operator++(int) noexcept {
         _Tree_unchecked_iterator _Tmp = *this;
         _Mybase::operator++();
         return _Tmp;
     }
 
-    _Tree_unchecked_iterator& operator--() {
+    _Tree_unchecked_iterator& operator--() noexcept {
         _Mybase::operator--();
         return *this;
     }
 
-    _Tree_unchecked_iterator operator--(int) {
+    _Tree_unchecked_iterator operator--(int) noexcept {
         _Tree_unchecked_iterator _Tmp = *this;
         _Mybase::operator--();
         return _Tmp;
@@ -175,7 +175,7 @@ public:
 
     using _Mybase::_Mybase;
 
-    _NODISCARD reference operator*() const {
+    _NODISCARD reference operator*() const noexcept {
 #if _ITERATOR_DEBUG_LEVEL == 2
         const auto _Mycont = static_cast<const _Mytree*>(this->_Getcont());
         _STL_ASSERT(_Mycont, "cannot dereference value-initialized map/set iterator");
@@ -185,11 +185,11 @@ public:
         return this->_Ptr->_Myval;
     }
 
-    _NODISCARD pointer operator->() const {
+    _NODISCARD pointer operator->() const noexcept {
         return pointer_traits<pointer>::pointer_to(**this);
     }
 
-    _Tree_const_iterator& operator++() {
+    _Tree_const_iterator& operator++() noexcept {
 #if _ITERATOR_DEBUG_LEVEL == 2
         _STL_VERIFY(this->_Getcont(), "cannot increment value-initialized map/set iterator");
         _STL_VERIFY(!this->_Ptr->_Isnil, "cannot increment end map/set iterator");
@@ -199,13 +199,13 @@ public:
         return *this;
     }
 
-    _Tree_const_iterator operator++(int) {
+    _Tree_const_iterator operator++(int) noexcept {
         _Tree_const_iterator _Tmp = *this;
         ++*this;
         return _Tmp;
     }
 
-    _Tree_const_iterator& operator--() {
+    _Tree_const_iterator& operator--() noexcept {
 #if _ITERATOR_DEBUG_LEVEL == 2
         _STL_ASSERT(this->_Getcont(), "cannot decrement value-initialized map/set iterator");
         _Nodeptr _Ptrsav = this->_Ptr;
@@ -218,13 +218,13 @@ public:
         return *this;
     }
 
-    _Tree_const_iterator operator--(int) {
+    _Tree_const_iterator operator--(int) noexcept {
         _Tree_const_iterator _Tmp = *this;
         --*this;
         return _Tmp;
     }
 
-    _NODISCARD bool operator==(const _Tree_const_iterator& _Right) const {
+    _NODISCARD bool operator==(const _Tree_const_iterator& _Right) const noexcept {
 #if _ITERATOR_DEBUG_LEVEL == 2
         _STL_VERIFY(this->_Getcont() == _Right._Getcont(), "map/set iterators incompatible");
 #endif // _ITERATOR_DEBUG_LEVEL == 2
@@ -232,19 +232,19 @@ public:
         return this->_Ptr == _Right._Ptr;
     }
 
-    _NODISCARD bool operator!=(const _Tree_const_iterator& _Right) const {
+    _NODISCARD bool operator!=(const _Tree_const_iterator& _Right) const noexcept {
         return !(*this == _Right);
     }
 
 #if _ITERATOR_DEBUG_LEVEL == 2
-    friend void _Verify_range(const _Tree_const_iterator& _First, const _Tree_const_iterator& _Last) {
+    friend void _Verify_range(const _Tree_const_iterator& _First, const _Tree_const_iterator& _Last) noexcept {
         _STL_VERIFY(_First._Getcont() == _Last._Getcont(), "map/set iterators in range are from different containers");
     }
 #endif // _ITERATOR_DEBUG_LEVEL == 2
 
     using _Prevent_inheriting_unwrap = _Tree_const_iterator;
 
-    _NODISCARD _Tree_unchecked_const_iterator<_Mytree> _Unwrapped() const {
+    _NODISCARD _Tree_unchecked_const_iterator<_Mytree> _Unwrapped() const noexcept {
         return _Tree_unchecked_const_iterator<_Mytree>(this->_Ptr, static_cast<const _Mytree*>(this->_Getcont()));
     }
 
@@ -269,31 +269,31 @@ public:
 
     using _Mybase::_Mybase;
 
-    _NODISCARD reference operator*() const {
+    _NODISCARD reference operator*() const noexcept {
         return const_cast<reference>(_Mybase::operator*());
     }
 
-    _NODISCARD pointer operator->() const {
+    _NODISCARD pointer operator->() const noexcept {
         return pointer_traits<pointer>::pointer_to(**this);
     }
 
-    _Tree_iterator& operator++() {
+    _Tree_iterator& operator++() noexcept {
         _Mybase::operator++();
         return *this;
     }
 
-    _Tree_iterator operator++(int) {
+    _Tree_iterator operator++(int) noexcept {
         _Tree_iterator _Tmp = *this;
         _Mybase::operator++();
         return _Tmp;
     }
 
-    _Tree_iterator& operator--() {
+    _Tree_iterator& operator--() noexcept {
         _Mybase::operator--();
         return *this;
     }
 
-    _Tree_iterator operator--(int) {
+    _Tree_iterator operator--(int) noexcept {
         _Tree_iterator _Tmp = *this;
         _Mybase::operator--();
         return _Tmp;
@@ -301,7 +301,7 @@ public:
 
     using _Prevent_inheriting_unwrap = _Tree_iterator;
 
-    _NODISCARD _Tree_unchecked_iterator<_Mytree> _Unwrapped() const {
+    _NODISCARD _Tree_unchecked_iterator<_Mytree> _Unwrapped() const noexcept {
         return _Tree_unchecked_iterator<_Mytree>(this->_Ptr, static_cast<const _Mytree*>(this->_Getcont()));
     }
 };


### PR DESCRIPTION
This is a part of the changes from Billy's noexcept work, which should be easily mergeable given that it solely strengthens internal STL iterators.