### PR TITLE
VS 2019 16.8 Preview 2 toolset upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 The STL uses boost-math headers to provide P0226R1 Mathematical Special Functions. We recommend using [vcpkg][] to
 acquire this dependency.
 
-1. Install Visual Studio 2019 16.8 Preview 1 or later.
+1. Install Visual Studio 2019 16.8 Preview 2 or later.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
     * Otherwise, install [CMake][] 3.17 or later, and [Ninja][] 1.8.2 or later.
@@ -158,7 +158,7 @@ acquire this dependency.
 
 # How To Build With A Native Tools Command Prompt
 
-1. Install Visual Studio 2019 16.8 Preview 1 or later.
+1. Install Visual Studio 2019 16.8 Preview 2 or later.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
     * Otherwise, install [CMake][] 3.17 or later, and [Ninja][] 1.8.2 or later.

--- a/azure-devops/create-vmss.ps1
+++ b/azure-devops/create-vmss.ps1
@@ -15,6 +15,8 @@ at https://docs.microsoft.com/en-us/powershell/azure/install-az-ps
 or are running from Azure Cloud Shell.
 #>
 
+$ErrorActionPreference = 'Stop'
+
 $Location = 'westus2'
 $Prefix = 'StlBuild-' + (Get-Date -Format 'yyyy-MM-dd')
 $VMSize = 'Standard_D16as_v4'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,7 @@
 # Build STL targeting x86, x64, arm, arm64
 
 variables:
-  agentPool: 'StlBuild-2020-08-11'
+  agentPool: 'StlBuild-2020-08-26'
   tmpDir: 'D:\Temp'
 
 stages:

--- a/stl/inc/xatomic.h
+++ b/stl/inc/xatomic.h
@@ -11,7 +11,7 @@
 
 #include <intrin0.h>
 #include <type_traits>
-#if defined(_WIN64) && (_MSC_FULL_VER <= 192829203) // TRANSITION
+#if defined(_WIN64) && (_MSC_FULL_VER <= 192829213) // TRANSITION
 #include <intrin.h> // Visual Studio 2019 to define 128-bit CAS in <intrin0.h>
 #endif // defined(_WIN64) && (_MSC_FULL_VER < 192829203), TRANSITION
 

--- a/stl/inc/xatomic.h
+++ b/stl/inc/xatomic.h
@@ -11,7 +11,7 @@
 
 #include <intrin0.h>
 #include <type_traits>
-#if defined(_WIN64) && (_MSC_FULL_VER < 192829203) // TRANSITION
+#if defined(_WIN64) && (_MSC_FULL_VER <= 192829203) // TRANSITION
 #include <intrin.h> // Visual Studio 2019 to define 128-bit CAS in <intrin0.h>
 #endif // defined(_WIN64) && (_MSC_FULL_VER < 192829203), TRANSITION
 

--- a/stl/inc/xatomic.h
+++ b/stl/inc/xatomic.h
@@ -13,7 +13,7 @@
 #include <type_traits>
 #if defined(_WIN64) && (_MSC_FULL_VER <= 192829213) // TRANSITION
 #include <intrin.h> // Visual Studio 2019 to define 128-bit CAS in <intrin0.h>
-#endif // defined(_WIN64) && (_MSC_FULL_VER < 192829203), TRANSITION
+#endif // defined(_WIN64) && (_MSC_FULL_VER <= 192829213), TRANSITION
 
 #pragma pack(push, _CRT_PACKING)
 #pragma warning(push, _STL_WARNING_LEVEL)

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -506,9 +506,6 @@ std/thread/futures/futures.task/futures.task.members/make_ready_at_thread_exit.p
 
 
 # *** C1XX COMPILER BUGS ***
-# Compiler bug: VSO-106654 "error C2580 "multiple versions of a defaulted special member functions are not allowed" is bogus and ungrammatical"
-std/utilities/tuple/tuple.tuple/tuple.cnstr/test_lazy_sfinae.pass.cpp:0 FAIL
-
 # Compiler bug: DevCom-409222 "Constructing rvalue reference from non-reference-related lvalue reference"
 std/utilities/meta/meta.unary/meta.unary.prop/is_constructible.pass.cpp:0 FAIL
 

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -506,9 +506,6 @@ thread\futures\futures.task\futures.task.members\make_ready_at_thread_exit.pass.
 
 
 # *** C1XX COMPILER BUGS ***
-# Compiler bug: VSO-106654 "error C2580 "multiple versions of a defaulted special member functions are not allowed" is bogus and ungrammatical"
-utilities\tuple\tuple.tuple\tuple.cnstr\test_lazy_sfinae.pass.cpp
-
 # Compiler bug: DevCom-409222 "Constructing rvalue reference from non-reference-related lvalue reference"
 utilities\meta\meta.unary\meta.unary.prop\is_constructible.pass.cpp
 


### PR DESCRIPTION
This additionally changes `create-vmss.ps1` to stop on errors. (When I attempt to update the VMSS while all of our cores are busy processing PR/CI builds, the script fails - now it immediately exits after encountering the quota limit, instead of proceeding and getting confused as to why it can't shut down a nonexistent VM.)

