### PR TITLE
Avoid triggering GH-1030 in P0896R4_ranges_alg_equal

### DIFF
--- a/tests/std/tests/P0896R4_ranges_alg_equal/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_equal/test.cpp
@@ -97,4 +97,6 @@ struct instantiator {
     }
 };
 
+#ifndef _PREFAST_ // TRANSITION, GH-1030
 template void test_in_in<instantiator, const int, const int>();
+#endif // TRANSITION, GH-1030


### PR DESCRIPTION
This test has been intermittently timing out in MSVC-internal testing due to extreme memory consumption.