### PR TITLE
Status Chart: Add README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,90 @@
+# STL Status Chart
+
+This branch generates the STL's [Status Chart][].
+
+# Getting Started: Repo
+
+1. Install [Node.js][] 14.9.0 or newer.
+    + You can accept all of the installer's default options.
+2. Open a new Command Prompt.
+    + You can run `node --version` to verify that Node.js was successfully installed.
+3. Change to a directory where you'd like a clone of this branch.
+4. `git clone --branch gh-pages --config push.default=upstream https://github.com/microsoft/STL.git chart`
+    + This will clone into a subdirectory named `chart`; you can choose a different name.
+    + `--config push.default=upstream` sets a repository-local option, which will prevent `git push` from failing with
+    "fatal: The upstream branch of your current branch does not match the name of your current branch."
+5. `cd chart`
+6. Replace `octocat` with your GitHub username: `set GH_USER=octocat`
+    + This is just to simplify the following instructions.
+7. `git remote add --fetch %GH_USER% https://github.com/%GH_USER%/STL.git`
+    + This will add your fork as a remote, and then fetch from it.
+8. `git push %GH_USER% gh-pages`
+    + If you created your fork before the Status Chart was added, this will copy the `gh-pages` branch into your fork.
+    + If you created your fork after the Status Chart was added, this will update the `gh-pages` branch in your fork.
+9. `git checkout -b my-pages --track %GH_USER%/gh-pages`
+    + This will create a branch named `my-pages`; you can choose a different name.
+    + You can run `git branch -vv` to see what this has achieved. The remote branches (in the official repo and your
+    fork) need to be named `gh-pages` in order to be published via GitHub Pages. Your local `gh-pages` branch tracks
+    the official repo, while your local `my-pages` branch tracks your fork.
+10. `npm ci`
+    + This will download the dependencies listed in `package.json` and locally install them to a `node_modules`
+    subdirectory.
+
+# Getting Started: Personal Access Token
+
+GitHub's GraphQL API requires authentication:
+
+1. Go to your [Personal Access Tokens][] on GitHub.
+2. Click "Generate new token".
+3. Name it "STL Status Chart" or anything else you'd like.
+4. Select `repo` scope.
+5. Click "Generate token". Keep this page open.
+6. In your `chart` repo, create a file named `.env` containing:
+    ```
+    SECRET_GITHUB_PERSONAL_ACCESS_TOKEN=12ab34cd
+    ```
+7. Replace `12ab34cd` with the hexadecimal personal access token that you just generated.
+    + The token is unique, so it's used without your username.
+8. Save the `.env` file.
+9. Close the page displaying your personal access token.
+10. Clear your clipboard.
+11. Verify that `git status` reports "nothing to commit, working tree clean".
+    + This indicates that `.env` is being properly ignored.
+
+**The `.env` file now contains a password-equivalent secret - treat it with respect.**
+
+# Updating The Chart
+
+* Run `npm update` to check for updated dependencies. If it finds any, it'll download and locally install them, and
+it'll update `package.json` and `package-lock.json` accordingly. `git add` and `git commit` those changes.
+* Update `weekly_table.js` by adding a new row.
+    + We update it every Friday, although nothing bad will happen if we skip a week or update it on a different day.
+    + `vso` is the number of Active work items under the STL's Area Path.
+    + `libcxx` is the number of skipped tests in `tests/libcxx/skipped_tests.txt`, excluding "Missing STL Features".
+    To determine this number:
+        1. Copy the file's contents.
+        2. Delete the "Missing STL Features" section.
+        3. Sort the remaining lines.
+        4. Find the last occurrence of `#`, so you can delete all of the empty lines and comments.
+        5. Count the remaining lines.
+* Run `node gather_stats.js` to regenerate `daily_table.js` and `monthly_table.js`.
+    + This regenerates the files from scratch, but the diff should be small because the data is stable and the process
+    is deterministic.
+    + It's possible for previous values to change, e.g. if an issue is relabeled, but dramatic changes without
+    corresponding generator changes should be investigated.
+* Open `index.html` to preview your changes locally.
+    + If you've changed how the Status Chart uses Chart.js, open F12 Developer Tools, click on the Console tab, and
+    refresh the page to verify that no warnings/errors are displayed.
+* After pushing your `my-pages` branch, wait a moment for GitHub Pages to publish, then you can view your changes at
+    `https://%GH_USER%.github.io/STL/`.
+    + When creating a PR, it's helpful to include that as a "live preview" link.
+
+# License
+
+Copyright (c) Microsoft Corporation.
+
+SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+[Node.js]: https://nodejs.org/en/
+[Personal Access Tokens]: https://github.com/settings/tokens
+[Status Chart]: https://microsoft.github.io/STL/

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This branch generates the STL's [Status Chart][].
 
 # Getting Started: Repo
 
-1. Install [Node.js][] 14.9.0 or newer.
+1. Install [Node.js][] 14.10.0 or newer.
     + You can accept all of the installer's default options.
 2. Open a new Command Prompt.
     + You can run `node --version` to verify that Node.js was successfully installed.
@@ -14,7 +14,8 @@ This branch generates the STL's [Status Chart][].
     + `--config push.default=upstream` sets a repository-local option, which will prevent `git push` from failing with
     "fatal: The upstream branch of your current branch does not match the name of your current branch."
 5. `cd chart`
-6. set the environment variable `GH_USER` to your GitHub username: `set GH_USER=octocat` (Replace `octocat` with your GitHub username)
+6. Set the environment variable `GH_USER` to your GitHub username: `set GH_USER=octocat` (Replace `octocat` with your
+    GitHub username.)
     + This is just to simplify the following instructions.
 7. `git remote add --fetch %GH_USER% https://github.com/%GH_USER%/STL.git`
     + This will add your fork as a remote, and then fetch from it.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This branch generates the STL's [Status Chart][].
     + `--config push.default=upstream` sets a repository-local option, which will prevent `git push` from failing with
     "fatal: The upstream branch of your current branch does not match the name of your current branch."
 5. `cd chart`
-6. Replace `octocat` with your GitHub username: `set GH_USER=octocat`
+6. set the environment variable `GH_USER` to your GitHub username: `set GH_USER=octocat` (Replace `octocat` with your GitHub username)
     + This is just to simplify the following instructions.
 7. `git remote add --fetch %GH_USER% https://github.com/%GH_USER%/STL.git`
     + This will add your fork as a remote, and then fetch from it.

--- a/daily_table.js
+++ b/daily_table.js
@@ -368,5 +368,6 @@ const daily_table = [
     { date: '2020-09-01', merged: 66.02, pr: 32, cxx20: 23, lwg: 1, issue: 292, bug: 94, avg_age: 58.82, avg_wait: 43.07, sum_age: 62.74, sum_wait: 45.94, },
     { date: '2020-09-02', merged: 65.19, pr: 31, cxx20: 23, lwg: 1, issue: 293, bug: 94, avg_age: 60.91, avg_wait: 43.18, sum_age: 62.94, sum_wait: 44.62, },
     { date: '2020-09-03', merged: 62.29, pr: 32, cxx20: 23, lwg: 1, issue: 296, bug: 97, avg_age: 60.00, avg_wait: 41.56, sum_age: 64.00, sum_wait: 44.33, },
+    { date: '2020-09-04', merged: 70.29, pr: 24, cxx20: 23, lwg: 1, issue: 296, bug: 95, avg_age: 76.53, avg_wait: 55.16, sum_age: 61.23, sum_wait: 44.13, },
 ];
 // Generated file - DO NOT EDIT manually!

--- a/daily_table.js
+++ b/daily_table.js
@@ -365,6 +365,8 @@ const daily_table = [
     { date: '2020-08-29', merged: 71.34, pr: 29, cxx20: 24, lwg: 1, issue: 290, bug: 92, avg_age: 63.58, avg_wait: 46.85, sum_age: 61.46, sum_wait: 45.29, },
     { date: '2020-08-30', merged: 69.02, pr: 30, cxx20: 24, lwg: 1, issue: 290, bug: 92, avg_age: 62.45, avg_wait: 46.27, sum_age: 62.45, sum_wait: 46.27, },
     { date: '2020-08-31', merged: 68.61, pr: 29, cxx20: 23, lwg: 1, issue: 290, bug: 92, avg_age: 63.83, avg_wait: 46.74, sum_age: 61.70, sum_wait: 45.18, },
-    { date: '2020-09-01', merged: 66.02, pr: 32, cxx20: 23, lwg: 1, issue: 293, bug: 93, avg_age: 58.82, avg_wait: 43.07, sum_age: 62.74, sum_wait: 45.94, },
+    { date: '2020-09-01', merged: 66.02, pr: 32, cxx20: 23, lwg: 1, issue: 292, bug: 94, avg_age: 58.82, avg_wait: 43.07, sum_age: 62.74, sum_wait: 45.94, },
+    { date: '2020-09-02', merged: 65.19, pr: 31, cxx20: 23, lwg: 1, issue: 293, bug: 94, avg_age: 60.91, avg_wait: 43.18, sum_age: 62.94, sum_wait: 44.62, },
+    { date: '2020-09-03', merged: 62.29, pr: 32, cxx20: 23, lwg: 1, issue: 296, bug: 97, avg_age: 60.00, avg_wait: 41.56, sum_age: 64.00, sum_wait: 44.33, },
 ];
 // Generated file - DO NOT EDIT manually!

--- a/daily_table.js
+++ b/daily_table.js
@@ -365,5 +365,6 @@ const daily_table = [
     { date: '2020-08-29', merged: 71.34, pr: 29, cxx20: 24, lwg: 1, issue: 290, bug: 92, avg_age: 63.58, avg_wait: 46.85, sum_age: 61.46, sum_wait: 45.29, },
     { date: '2020-08-30', merged: 69.02, pr: 30, cxx20: 24, lwg: 1, issue: 290, bug: 92, avg_age: 62.45, avg_wait: 46.27, sum_age: 62.45, sum_wait: 46.27, },
     { date: '2020-08-31', merged: 68.61, pr: 29, cxx20: 23, lwg: 1, issue: 290, bug: 92, avg_age: 63.83, avg_wait: 46.74, sum_age: 61.70, sum_wait: 45.18, },
+    { date: '2020-09-01', merged: 66.02, pr: 32, cxx20: 23, lwg: 1, issue: 293, bug: 93, avg_age: 58.82, avg_wait: 43.07, sum_age: 62.74, sum_wait: 45.94, },
 ];
 // Generated file - DO NOT EDIT manually!

--- a/daily_table.js
+++ b/daily_table.js
@@ -369,5 +369,9 @@ const daily_table = [
     { date: '2020-09-02', merged: 65.19, pr: 31, cxx20: 23, lwg: 1, issue: 293, bug: 94, avg_age: 60.91, avg_wait: 43.18, sum_age: 62.94, sum_wait: 44.62, },
     { date: '2020-09-03', merged: 62.29, pr: 32, cxx20: 23, lwg: 1, issue: 296, bug: 97, avg_age: 60.00, avg_wait: 41.56, sum_age: 64.00, sum_wait: 44.33, },
     { date: '2020-09-04', merged: 70.29, pr: 24, cxx20: 23, lwg: 1, issue: 296, bug: 95, avg_age: 76.53, avg_wait: 55.16, sum_age: 61.23, sum_wait: 44.13, },
+    { date: '2020-09-05', merged: 67.53, pr: 26, cxx20: 23, lwg: 1, issue: 296, bug: 95, avg_age: 71.63, avg_wait: 51.91, sum_age: 62.08, sum_wait: 44.99, },
+    { date: '2020-09-06', merged: 65.09, pr: 26, cxx20: 23, lwg: 1, issue: 297, bug: 95, avg_age: 72.63, avg_wait: 52.91, sum_age: 62.95, sum_wait: 45.85, },
+    { date: '2020-09-07', merged: 62.62, pr: 27, cxx20: 23, lwg: 1, issue: 298, bug: 96, avg_age: 70.91, avg_wait: 51.91, sum_age: 63.82, sum_wait: 46.72, },
+    { date: '2020-09-08', merged: 60.31, pr: 28, cxx20: 23, lwg: 1, issue: 298, bug: 96, avg_age: 69.35, avg_wait: 51.04, sum_age: 64.73, sum_wait: 47.63, },
 ];
 // Generated file - DO NOT EDIT manually!

--- a/daily_table.js
+++ b/daily_table.js
@@ -362,5 +362,8 @@ const daily_table = [
     { date: '2020-08-26', merged: 76.11, pr: 26, cxx20: 24, lwg: 1, issue: 287, bug: 92, avg_age: 67.77, avg_wait: 49.50, sum_age: 58.74, sum_wait: 42.90, },
     { date: '2020-08-27', merged: 75.86, pr: 26, cxx20: 24, lwg: 1, issue: 288, bug: 92, avg_age: 68.77, avg_wait: 50.43, sum_age: 59.60, sum_wait: 43.71, },
     { date: '2020-08-28', merged: 73.61, pr: 28, cxx20: 24, lwg: 1, issue: 290, bug: 92, avg_age: 64.83, avg_wait: 47.53, sum_age: 60.51, sum_wait: 44.37, },
+    { date: '2020-08-29', merged: 71.34, pr: 29, cxx20: 24, lwg: 1, issue: 290, bug: 92, avg_age: 63.58, avg_wait: 46.85, sum_age: 61.46, sum_wait: 45.29, },
+    { date: '2020-08-30', merged: 69.02, pr: 30, cxx20: 24, lwg: 1, issue: 290, bug: 92, avg_age: 62.45, avg_wait: 46.27, sum_age: 62.45, sum_wait: 46.27, },
+    { date: '2020-08-31', merged: 68.61, pr: 29, cxx20: 23, lwg: 1, issue: 290, bug: 92, avg_age: 63.83, avg_wait: 46.74, sum_age: 61.70, sum_wait: 45.18, },
 ];
 // Generated file - DO NOT EDIT manually!

--- a/monthly_table.js
+++ b/monthly_table.js
@@ -13,5 +13,6 @@ const monthly_table = [
     { date: '2020-05-16', merge_bar: 43, },
     { date: '2020-06-16', merge_bar: 29, },
     { date: '2020-07-16', merge_bar: 62, },
+    { date: '2020-08-16', merge_bar: 73, },
 ];
 // Generated file - DO NOT EDIT manually!

--- a/weekly_table.js
+++ b/weekly_table.js
@@ -169,4 +169,5 @@ const weekly_table = [
     { date: '2020-08-14', vso: 159, libcxx: 534 },
     { date: '2020-08-21', vso: 153, libcxx: 534 },
     { date: '2020-08-28', vso: 142, libcxx: 533 },
+    { date: '2020-09-04', vso: 145, libcxx: 539 },
 ];


### PR DESCRIPTION
I wrote up the (surprisingly detailed) process for updating the Status Chart. I've attempted to test these instructions - they assume zero familiarity with JavaScript, but basic familiarity with git. (For example, I explain that `npm update` will change `package.json` and `package-lock.json`, which you need to `git add` and `git commit`, but I considered it obvious that manually updating `weekly_table.js` and automatically regenerating `daily_table.js` and `monthly_table.js` also imply `git add` etc. - I could explicitly state that if wanted.)

I believe the following scenarios should work, but haven't tested them:

* You created your fork *before* the `gh-pages` branch was added, so you need to gain such a branch
* You created your fork *after* the `gh-pages` branch was added, but it is presumably out of date (and needs to be fast-forwarded)

Also I haven't tested the following:

* After setting up an appropriately updated `gh-pages` branch in your fork, do you need to enable GitHub Pages in your fork's Settings? This appears on the main settings page (scroll down near the bottom), but I can't remember whether I had to explicitly enable this. This is technically not needed to submit PRs, but it enables the "live preview" technique.

Since the Status Chart is easy to update, I felt that it made sense to keep this in the `gh-pages` branch instead of a wiki page.

Also, regen the table because we're down to 23 C++20 features! :tada:

Live preview: [stephantlavavej.github.io/STL/](https://stephantlavavej.github.io/STL/)
===