### PR TITLE
enforce "non-array trivial standard-layout" for string and string_view

### DIFF
--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -1209,6 +1209,10 @@ public:
         "Bad char_traits for basic_string_view; "
         "N4659 24.4.2 [string.view.template]/1 \"the type traits::char_type shall name the same type as charT.\"");
 
+    static_assert(!is_array_v<_Elem> && is_trivial_v<_Elem> && is_standard_layout_v<_Elem>,
+        "The character type of basic_string_view must be a non-array trivial standard-layout type. See N4861 "
+        "[strings.general]/1.");
+
     using traits_type            = _Traits;
     using value_type             = _Elem;
     using pointer                = _Elem*;
@@ -2277,6 +2281,10 @@ private:
     static_assert(is_same_v<_Elem, typename _Traits::char_type>,
         "N4659 24.3.2.1 [string.require]/3 requires that the supplied "
         "char_traits character type match the string's character type.");
+
+    static_assert(!is_array_v<_Elem> && is_trivial_v<_Elem> && is_standard_layout_v<_Elem>,
+        "The character type of basic_string must be a non-array trivial standard-layout type. See N4861 "
+        "[strings.general]/1.");
 
 public:
     using traits_type    = _Traits;

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -551,9 +551,6 @@ std/containers/sequences/array/array.data/data_const.pass.cpp FAIL
 std/containers/sequences/array/array.data/data.pass.cpp FAIL
 std/containers/sequences/array/iterators.pass.cpp FAIL
 
-# STL bug: string_view doesn't enforce "non-array trivial standard-layout", related to LWG-3034.
-std/strings/string.view/char.bad.fail.cpp:0 FAIL
-
 # Predicate count assertions - IDL2 is slightly bending the Standard's rules here.
 std/algorithms/alg.sorting/alg.heap.operations/make.heap/make_heap_comp.pass.cpp FAIL
 std/algorithms/alg.sorting/alg.merge/inplace_merge_comp.pass.cpp FAIL

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -551,9 +551,6 @@ containers\sequences\array\array.data\data_const.pass.cpp
 containers\sequences\array\array.data\data.pass.cpp
 containers\sequences\array\iterators.pass.cpp
 
-# STL bug: string_view doesn't enforce "non-array trivial standard-layout", related to LWG-3034.
-strings\string.view\char.bad.fail.cpp
-
 # Predicate count assertions - IDL2 is slightly bending the Standard's rules here.
 algorithms\alg.sorting\alg.heap.operations\make.heap\make_heap_comp.pass.cpp
 algorithms\alg.sorting\alg.merge\inplace_merge_comp.pass.cpp


### PR DESCRIPTION
Fixes #1261

I think libc++ tests the static_asserts: https://github.com/llvm/llvm-project/blob/master/libcxx/test/std/strings/basic.string/char.bad.fail.cpp and https://github.com/llvm/llvm-project/blob/master/libcxx/test/std/strings/string.view/char.bad.fail.cpp

How can I enable basic.string/char.bad.fail.cpp ? I did not find it among SKIPPED