### PR TITLE
Integrate P1391 into views::take and views::drop

### DIFF
--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -1655,7 +1655,7 @@ namespace ranges {
         template <class _Rng>
         concept _Reconstructible_range = random_access_range<_Rng> && sized_range<_Rng>
             && (_Is_dynamic_span<remove_cvref_t<_Rng>>
-                // || _Is_specialization_v<remove_cvref_t<_Rng>, basic_string_view> // TRANSITION, P1391R4
+                || _Is_specialization_v<remove_cvref_t<_Rng>, basic_string_view>
                 // || _Is_specialization_v<remove_cvref_t<_Rng>, iota_view> // TRANSITION, iota_view
                 || _Is_subrange<remove_cvref_t<_Rng>>);
 

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -193,6 +193,7 @@
 //     (partially implemented)
 // P1248R1 Fixing Relations
 // P1357R1 is_bounded_array, is_unbounded_array
+// P1391R4 Range Constructor For string_view
 // P1394R4 Range Constructor For span
 // P1423R3 char8_t Backward Compatibility Remediation
 // P1456R1 Move-Only Views
@@ -202,6 +203,8 @@
 // P1651R0 bind_front() Should Not Unwrap reference_wrapper
 // P1690R1 Refining Heterogeneous Lookup For Unordered Containers
 // P1716R3 Range Comparison Algorithms Are Over-Constrained
+// P1739R4 Avoiding Template Bloat For Ranges
+//     (partially implemented)
 // P1754R1 Rename Concepts To standard_case
 // P1865R1 Adding max() To latch And barrier
 // P1870R1 Rename forwarding-range To borrowed_range (Was safe_range before LWG-3379)

--- a/tests/std/tests/P0896R4_views_drop/test.cpp
+++ b/tests/std/tests/P0896R4_views_drop/test.cpp
@@ -45,7 +45,7 @@ concept reconstructible = ranges::random_access_range<V>
     && ranges::sized_range<V>
     && (is_empty_view<V>
         || is_dynamic_span<V>
-     // || is_string_view<V> // TRANSITION, P1391R4
+        || is_string_view<V>
      // || is_iota_view<V> // TRANSITION, iota_view
         || is_subrange<V>);
 // clang-format on
@@ -469,9 +469,8 @@ int main() {
         STATIC_ASSERT(test_one(views::empty<int>, span<const int, 0>{}));
         test_one(views::empty<int>, span<const int, 0>{});
 
-        // TRANSITION, P1391R4
-        // STATIC_ASSERT(test_one(basic_string_view{some_ints}, only_four_ints));
-        // test_one(basic_string_view{some_ints}, only_four_ints);
+        STATIC_ASSERT(test_one(basic_string_view{ranges::begin(some_ints), ranges::end(some_ints)}, only_four_ints));
+        test_one(basic_string_view{ranges::begin(some_ints), ranges::end(some_ints)}, only_four_ints);
 
         // TRANSITION, iota_view
         // STATIC_ASSERT(test_one(ranges::iota_view{0, 8}, only_four_ints));

--- a/tests/std/tests/P0896R4_views_take/test.cpp
+++ b/tests/std/tests/P0896R4_views_take/test.cpp
@@ -45,7 +45,7 @@ concept reconstructible = ranges::random_access_range<V>
     && ranges::sized_range<V>
     && (is_empty_view<V>
         || is_dynamic_span<V>
-     // || is_string_view<V> // TRANSITION, P1391R4
+        || is_string_view<V>
      // || is_iota_view<V> // TRANSITION, iota_view
         || is_subrange<V>);
 // clang-format on
@@ -492,9 +492,8 @@ int main() {
         STATIC_ASSERT(test_one(views::empty<int>, span<const int, 0>{}));
         test_one(views::empty<int>, span<const int, 0>{});
 
-        // TRANSITION, P1391R4
-        // STATIC_ASSERT(test_one(basic_string_view{some_ints}, only_four_ints));
-        // test_one(basic_string_view{some_ints}, only_four_ints);
+        STATIC_ASSERT(test_one(basic_string_view{ranges::begin(some_ints), ranges::end(some_ints)}, only_four_ints));
+        test_one(basic_string_view{ranges::begin(some_ints), ranges::end(some_ints)}, only_four_ints);
 
         // TRANSITION, iota_view
         // STATIC_ASSERT(test_one(ranges::iota_view{0, 8}, only_four_ints));


### PR DESCRIPTION
Completes a bit more of WG21-P1739 "Avoiding Template Bloat For Ranges".

Annotate implementation of P1391R4 and partial implementation of P1739R4 in `<yvals_core.h>`.

Partially addresses #39.
