### PR TITLE
Use constexpr is_sorted, add charconv tests, update comments

### DIFF
--- a/stl/inc/execution
+++ b/stl/inc/execution
@@ -1091,8 +1091,7 @@ struct _Static_partitioned_all_of_family2 { // all_of/any_of/none_of task schedu
         if (!_Key) {
             return _Cancellation_status::_Canceled;
         }
-        // Once _Key is obtained, the amount of work should not be discarded; see GH-818.
-        // GH-818: https://github.com/microsoft/STL/issues/818
+        // Once _Key is obtained, the amount of work should not be discarded (see GH-818).
 
         const auto _Range = _Basis._Get_chunk(_Key);
         for (auto _First = _Range._First; _First != _Range._Last; ++_First) {
@@ -1326,7 +1325,7 @@ struct _Static_partitioned_find2 {
         if (!_Key) {
             return _Cancellation_status::_Canceled;
         }
-        // Once _Key is obtained, the amount of work should not be discarded; see GH-818.
+        // Once _Key is obtained, the amount of work should not be discarded (see GH-818).
 
         const auto _Range     = _Basis._Get_chunk(_Key);
         const auto _This_find = _Fx(_Range._First, _Range._Last);
@@ -1531,7 +1530,7 @@ struct _Static_partitioned_find_end_backward2 {
         if (!_Key) {
             return _Cancellation_status::_Canceled;
         }
-        // Once _Key is obtained, the amount of work should not be discarded; see GH-818.
+        // Once _Key is obtained, the amount of work should not be discarded (see GH-818).
 
         const auto _Chunk_number = _Key._Chunk_number;
         const auto _Range        = _Basis._Get_chunk(_Key);
@@ -1652,7 +1651,7 @@ struct _Static_partitioned_adjacent_find2 {
         if (!_Key) {
             return _Cancellation_status::_Canceled;
         }
-        // Once _Key is obtained, the amount of work should not be discarded; see GH-818.
+        // Once _Key is obtained, the amount of work should not be discarded (see GH-818).
 
         const auto _Chunk_number = _Key._Chunk_number;
         const auto _Range        = _Basis._Get_chunk(_Key);
@@ -1868,7 +1867,7 @@ struct _Static_partitioned_mismatch2 {
         if (!_Key) {
             return _Cancellation_status::_Canceled;
         }
-        // Once _Key is obtained, the amount of work should not be discarded; see GH-818.
+        // Once _Key is obtained, the amount of work should not be discarded (see GH-818).
 
         const auto _Chunk_number = _Key._Chunk_number;
         const auto _Range1       = _Basis1._Get_chunk(_Key);
@@ -2000,7 +1999,7 @@ struct _Static_partitioned_equal2 {
         if (!_Key) {
             return _Cancellation_status::_Canceled;
         }
-        // Once _Key is obtained, the amount of work should not be discarded; see GH-818.
+        // Once _Key is obtained, the amount of work should not be discarded (see GH-818).
 
         const auto _Range1       = _Basis1._Get_chunk(_Key);
         const auto _Range2_first = _Basis2._Get_chunk(_Key)._First;
@@ -2119,7 +2118,7 @@ struct _Static_partitioned_search2 {
         if (!_Key) {
             return _Cancellation_status::_Canceled;
         }
-        // Once _Key is obtained, the amount of work should not be discarded; see GH-818.
+        // Once _Key is obtained, the amount of work should not be discarded (see GH-818).
 
         const auto _Range = _Basis._Get_chunk(_Key);
         for (auto _Candidate = _Range._First; _Candidate != _Range._Last; ++_Candidate) {
@@ -2238,7 +2237,7 @@ struct _Static_partitioned_search_n2 {
         if (!_Key) {
             return _Cancellation_status::_Canceled;
         }
-        // Once _Key is obtained, the amount of work should not be discarded; see GH-818.
+        // Once _Key is obtained, the amount of work should not be discarded (see GH-818).
 
         const auto _Range = _Basis._Get_chunk(_Key);
 
@@ -3069,7 +3068,7 @@ struct _Static_partitioned_is_sorted_until {
         if (!_Key) {
             return _Cancellation_status::_Canceled;
         }
-        // Once _Key is obtained, the amount of work should not be discarded; see GH-818.
+        // Once _Key is obtained, the amount of work should not be discarded (see GH-818).
 
         auto _Range = _Basis._Get_chunk(_Key);
         auto _Next  = _Range._First;
@@ -3184,7 +3183,7 @@ struct _Static_partitioned_is_partitioned {
         if (!_Key) {
             return _Cancellation_status::_Canceled;
         }
-        // Once _Key is obtained, the amount of work should not be discarded; see GH-818.
+        // Once _Key is obtained, the amount of work should not be discarded (see GH-818).
 
         // looking at chunks from either end, moving in towards the middle
         auto _Target_chunk_number = _Key._Chunk_number >> 1;
@@ -3297,7 +3296,7 @@ struct _Static_partitioned_is_heap_until {
         if (!_Key) {
             return _Cancellation_status::_Canceled;
         }
-        // Once _Key is obtained, the amount of work should not be discarded; see GH-818.
+        // Once _Key is obtained, the amount of work should not be discarded (see GH-818).
 
         const auto _Chunk_range_size = _Key._Size;
         const auto _Chunk_offset     = _Key._Start_at;

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -520,10 +520,10 @@ std/language.support/support.limits/limits/numeric.limits.members/traps.pass.cpp
 
 
 # *** STL BUGS ***
-# GH-1112 "<locale>: the enum value of std::money_base is not correct[libcxx]"
+# GH-1112 <locale>: the enum value of std::money_base is not correct
 std/localization/locale.categories/category.monetary/locale.moneypunct/money_base.pass.cpp FAIL
 
-# GH-1113 <fstream> basic_filebuf doesn't comply with setbuf(0,0) requirement in the standard
+# GH-1113 <fstream>: basic_filebuf doesn't comply with setbuf(0,0) requirement in the standard
 std/input.output/file.streams/fstreams/filebuf.virtuals/overflow.pass.cpp FAIL
 std/input.output/file.streams/fstreams/filebuf.virtuals/underflow.pass.cpp FAIL
 
@@ -532,37 +532,38 @@ std/numerics/complex.number/complex.special/double_long_double_implicit.compile.
 std/numerics/complex.number/complex.special/float_double_implicit.compile.fail.cpp FAIL
 std/numerics/complex.number/complex.special/float_long_double_implicit.compile.fail.cpp FAIL
 
-# GH-1004 regex_traits::transform() isn't following the Standard.
+# GH-1004 <regex>: Error C2664 in std::regex_traits::transform
 std/re/re.traits/transform.pass.cpp FAIL
 
-# GH-1260 Incorrect return types.
+# GH-1260 <complex>: pow, incorrect type conversion
 std/numerics/complex.number/cmplx.over/pow.pass.cpp FAIL
 
 # GH-1295 <array>: array<const T, 0> allows fill() and swap()
 std/containers/sequences/array/array.fill/fill.fail.cpp FAIL
 std/containers/sequences/array/array.swap/swap.fail.cpp FAIL
 
-# GH-942 We reject array<NoDefault, 0>.
+# GH-942 <array>: std::array<T,0> doesn't compile - when type is not default constructible
 std/containers/sequences/array/array.cons/implicit_copy.pass.cpp FAIL
 std/containers/sequences/array/array.cons/initialization.pass.cpp FAIL
 std/containers/sequences/array/array.data/data_const.pass.cpp FAIL
 std/containers/sequences/array/array.data/data.pass.cpp FAIL
 std/containers/sequences/array/iterators.pass.cpp FAIL
 
-# GH-1006 Predicate count assertions - IDL2 is slightly bending the Standard's rules here.
+# GH-1006 <algorithm>: debug checks for predicates are observable
 std/algorithms/alg.sorting/alg.heap.operations/make.heap/make_heap_comp.pass.cpp FAIL
 std/algorithms/alg.sorting/alg.merge/inplace_merge_comp.pass.cpp FAIL
 std/algorithms/alg.sorting/alg.min.max/minmax_init_list_comp.pass.cpp FAIL
 
-# GH-1259 We don't match strtod / strtof when doing field extraction for hexfloats, or special cases like inf
+# GH-1259 <locale>: wrong field extraction for hexfloats, or special cases like inf
 std/localization/locale.categories/category.numeric/locale.num.get/facet.num.get.members/get_double.pass.cpp FAIL
 std/localization/locale.categories/category.numeric/locale.num.get/facet.num.get.members/get_float.pass.cpp FAIL
 std/localization/locale.categories/category.numeric/locale.num.get/facet.num.get.members/get_long_double.pass.cpp FAIL
 
-# GH-1277 We don't match numpunct groups correctly in do_get
+# GH-1277 <xlocnum>: We don't match numpunct groups correctly in do_get
 std/localization/locale.categories/category.numeric/locale.num.get/facet.num.get.members/get_long.pass.cpp FAIL
 
-# GH-1275 We don't have the locale names libcxx wants specialized in platform_support.hpp
+# GH-1275 <locale>: missing some locale names
+# We don't have the locale names libcxx wants specialized in platform_support.hpp
 # More bugs may be uncovered when the locale names are present.
 # move.pass.cpp can crash.
 std/input.output/iostreams.base/ios/basic.ios.members/move.pass.cpp SKIPPED
@@ -594,13 +595,13 @@ std/localization/locale.categories/category.time/locale.time.put.byname/put1.pas
 std/localization/locale.categories/facet.numpunct/locale.numpunct.byname/grouping.pass.cpp FAIL
 std/localization/locale.categories/facet.numpunct/locale.numpunct.byname/thousands_sep.pass.cpp FAIL
 
-# GH-1264 Our wbuffer_convert does not implement seek. [depr.conversions.buffer] is completely underspecified.
+# GH-1264 <locale>: wbuffer_convert does not implement seek
 std/localization/locales/locale.convenience/conversions/conversions.buffer/seekoff.pass.cpp FAIL
 
-# GH-1116 error_category's default ctor isn't constexpr. (Should be fixed in vNext.)
+# GH-1116 <system_error>: error_category's default ctor isn't constexpr.
 std/diagnostics/syserr/syserr.errcat/syserr.errcat.nonvirtuals/default_ctor.pass.cpp:1 FAIL
 
-# GH-1190 future incorrectly uses copy assignment instead of copy construction in set_value. (Should be fixed in vNext.)
+# GH-1190 <future>: incorrectly used copy assignment instead of copy construction in set_value
 std/thread/futures/futures.promise/set_value_const.pass.cpp FAIL
 
 # GH-757 <xstring>: Too many enabled hash specializations

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -520,10 +520,10 @@ std/language.support/support.limits/limits/numeric.limits.members/traps.pass.cpp
 
 
 # *** STL BUGS ***
-# GH-1112 VSO-121977 "<locale>: the enum value of std::money_base is not correct[libcxx]"
+# GH-1112 "<locale>: the enum value of std::money_base is not correct[libcxx]"
 std/localization/locale.categories/category.monetary/locale.moneypunct/money_base.pass.cpp FAIL
 
-# GH-1113 VSO-595631 <fstream> basic_filebuf doesn't comply with setbuf(0,0) requirement in the standard
+# GH-1113 <fstream> basic_filebuf doesn't comply with setbuf(0,0) requirement in the standard
 std/input.output/file.streams/fstreams/filebuf.virtuals/overflow.pass.cpp FAIL
 std/input.output/file.streams/fstreams/filebuf.virtuals/underflow.pass.cpp FAIL
 
@@ -542,7 +542,7 @@ std/numerics/complex.number/cmplx.over/pow.pass.cpp FAIL
 std/containers/sequences/array/array.fill/fill.fail.cpp FAIL
 std/containers/sequences/array/array.swap/swap.fail.cpp FAIL
 
-# GH-942 VSO-207715 We reject array<NoDefault, 0>.
+# GH-942 We reject array<NoDefault, 0>.
 std/containers/sequences/array/array.cons/implicit_copy.pass.cpp FAIL
 std/containers/sequences/array/array.cons/initialization.pass.cpp FAIL
 std/containers/sequences/array/array.data/data_const.pass.cpp FAIL

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -66,6 +66,7 @@ std/numerics/bit/bit.pow.two/log2p1.pass.cpp FAIL
 # test emits warning C4310: cast truncates constant value
 std/numerics/bit/bitops.rot/rotl.pass.cpp:0 FAIL
 
+
 # *** INTERACTIONS WITH CONTEST / C1XX THAT UPSTREAM LIKELY WON'T FIX ***
 # Tracked by VSO-593630 "<filesystem> Enable libcxx filesystem tests"
 # rapid-cxx-test.hpp uses pragma system_header
@@ -486,10 +487,10 @@ std/thread/futures/futures.task/futures.task.members/make_ready_at_thread_exit.p
 
 
 # *** C1XX COMPILER BUGS ***
-# Compiler bug: DevCom-409222 "Constructing rvalue reference from non-reference-related lvalue reference"
+# DevCom-409222 "Constructing rvalue reference from non-reference-related lvalue reference"
 std/utilities/meta/meta.unary/meta.unary.prop/is_constructible.pass.cpp:0 FAIL
 
-# Compiler bug: DevCom-876860 "conditional operator errors" blocks readable<volatile int*>.
+# DevCom-876860 "conditional operator errors" blocks readable<volatile int*>.
 std/containers/views/span.cons/ptr_len.pass.cpp:0 FAIL
 std/containers/views/span.cons/ptr_ptr.pass.cpp:0 FAIL
 
@@ -519,49 +520,49 @@ std/language.support/support.limits/limits/numeric.limits.members/traps.pass.cpp
 
 
 # *** STL BUGS ***
-# STL bug: GH-1112 VSO-121977 "<locale>: the enum value of std::money_base is not correct[libcxx]"
+# GH-1112 VSO-121977 "<locale>: the enum value of std::money_base is not correct[libcxx]"
 std/localization/locale.categories/category.monetary/locale.moneypunct/money_base.pass.cpp FAIL
 
-# STL bug: GH-1113 VSO-595631 <fstream> basic_filebuf doesn't comply with setbuf(0,0) requirement in the standard
+# GH-1113 VSO-595631 <fstream> basic_filebuf doesn't comply with setbuf(0,0) requirement in the standard
 std/input.output/file.streams/fstreams/filebuf.virtuals/overflow.pass.cpp FAIL
 std/input.output/file.streams/fstreams/filebuf.virtuals/underflow.pass.cpp FAIL
 
-# STL bug: GH-1256 Our inheritance implementation is allowing this to compile when it shouldn't.
+# GH-1256 Our inheritance implementation is allowing this to compile when it shouldn't.
 std/numerics/complex.number/complex.special/double_long_double_implicit.compile.fail.cpp FAIL
 std/numerics/complex.number/complex.special/float_double_implicit.compile.fail.cpp FAIL
 std/numerics/complex.number/complex.special/float_long_double_implicit.compile.fail.cpp FAIL
 
-# STL bug: GH-1004 regex_traits::transform() isn't following the Standard.
+# GH-1004 regex_traits::transform() isn't following the Standard.
 std/re/re.traits/transform.pass.cpp FAIL
 
-# STL bug: GH-1260 Incorrect return types.
+# GH-1260 Incorrect return types.
 std/numerics/complex.number/cmplx.over/pow.pass.cpp FAIL
 
-# STL bug: GH-942 We allow fill() and swap() for array<const T, 0>.
+# GH-942 We allow fill() and swap() for array<const T, 0>.
 std/containers/sequences/array/array.fill/fill.fail.cpp FAIL
 std/containers/sequences/array/array.swap/swap.fail.cpp FAIL
 
-# STL bug: GH-942 VSO-207715 We reject array<NoDefault, 0>.
+# GH-942 VSO-207715 We reject array<NoDefault, 0>.
 std/containers/sequences/array/array.cons/implicit_copy.pass.cpp FAIL
 std/containers/sequences/array/array.cons/initialization.pass.cpp FAIL
 std/containers/sequences/array/array.data/data_const.pass.cpp FAIL
 std/containers/sequences/array/array.data/data.pass.cpp FAIL
 std/containers/sequences/array/iterators.pass.cpp FAIL
 
-# STL bug: GH-1006 Predicate count assertions - IDL2 is slightly bending the Standard's rules here.
+# GH-1006 Predicate count assertions - IDL2 is slightly bending the Standard's rules here.
 std/algorithms/alg.sorting/alg.heap.operations/make.heap/make_heap_comp.pass.cpp FAIL
 std/algorithms/alg.sorting/alg.merge/inplace_merge_comp.pass.cpp FAIL
 std/algorithms/alg.sorting/alg.min.max/minmax_init_list_comp.pass.cpp FAIL
 
-# STL bug: GH-1259 We don't match strtod / strtof when doing field extraction for hexfloats, or special cases like inf
+# GH-1259 We don't match strtod / strtof when doing field extraction for hexfloats, or special cases like inf
 std/localization/locale.categories/category.numeric/locale.num.get/facet.num.get.members/get_double.pass.cpp FAIL
 std/localization/locale.categories/category.numeric/locale.num.get/facet.num.get.members/get_float.pass.cpp FAIL
 std/localization/locale.categories/category.numeric/locale.num.get/facet.num.get.members/get_long_double.pass.cpp FAIL
 
-# STL bug: GH-1277 We don't match numpunct groups correctly in do_get
+# GH-1277 We don't match numpunct groups correctly in do_get
 std/localization/locale.categories/category.numeric/locale.num.get/facet.num.get.members/get_long.pass.cpp FAIL
 
-# STL test bug: GH-1275 We don't have the locale names libcxx wants specialized in platform_support.hpp
+# GH-1275 We don't have the locale names libcxx wants specialized in platform_support.hpp
 # More bugs may be uncovered when the locale names are present.
 # move.pass.cpp can crash.
 std/input.output/iostreams.base/ios/basic.ios.members/move.pass.cpp SKIPPED
@@ -593,21 +594,25 @@ std/localization/locale.categories/category.time/locale.time.put.byname/put1.pas
 std/localization/locale.categories/facet.numpunct/locale.numpunct.byname/grouping.pass.cpp FAIL
 std/localization/locale.categories/facet.numpunct/locale.numpunct.byname/thousands_sep.pass.cpp FAIL
 
-# STL bug? GH-1264 Our wbuffer_convert does not implement seek. [depr.conversions.buffer] is completely underspecified.
+# GH-1264 Our wbuffer_convert does not implement seek. [depr.conversions.buffer] is completely underspecified.
 std/localization/locales/locale.convenience/conversions/conversions.buffer/seekoff.pass.cpp FAIL
 
-# STL bug: GH-1116 error_category's default ctor isn't constexpr. (Should be fixed in vNext.)
+# GH-1116 error_category's default ctor isn't constexpr. (Should be fixed in vNext.)
 std/diagnostics/syserr/syserr.errcat/syserr.errcat.nonvirtuals/default_ctor.pass.cpp:1 FAIL
 
-# STL bug: GH-1190 future incorrectly uses copy assignment instead of copy construction in set_value. (Should be fixed in vNext.)
+# GH-1190 future incorrectly uses copy assignment instead of copy construction in set_value. (Should be fixed in vNext.)
 std/thread/futures/futures.promise/set_value_const.pass.cpp FAIL
 
-# STL bug: GH-757 <xstring>: Too many enabled hash specializations
+# GH-757 <xstring>: Too many enabled hash specializations
 std/strings/basic.string.hash/char_type_hash.fail.cpp FAIL
 std/strings/string.view/string.view.hash/char_type.hash.fail.cpp FAIL
 
-# STL bug: GH-784 <type_traits>: aligned_storage has incorrect alignment defaults
+# GH-784 <type_traits>: aligned_storage has incorrect alignment defaults
 std/utilities/meta/meta.trans/meta.trans.other/aligned_storage.pass.cpp FAIL
+
+# GH-519 <cmath>: signbit() misses overloads for integer types
+std/depr/depr.c.headers/math_h.pass.cpp FAIL
+std/numerics/c.math/cmath.pass.cpp FAIL
 
 
 # *** CRT BUGS ***
@@ -633,10 +638,6 @@ std/thread/thread.semaphore/try_acquire.pass.cpp FAIL
 # pass lambda without noexcept to barrier
 std/thread/thread.barrier/completion.pass.cpp FAIL
 std/thread/thread.barrier/max.pass.cpp FAIL
-
-# Test bug/LEWG issue or STL bug. See GH-519 "<cmath>: signbit() misses overloads for integer types".
-std/depr/depr.c.headers/math_h.pass.cpp FAIL
-std/numerics/c.math/cmath.pass.cpp FAIL
 
 # Test bug after LWG-2899 "is_(nothrow_)move_constructible and tuple, optional and unique_ptr" was accepted.
 std/utilities/smartptr/unique.ptr/unique.ptr.class/unique.ptr.asgn/move_convert.pass.cpp FAIL

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -519,49 +519,49 @@ std/language.support/support.limits/limits/numeric.limits.members/traps.pass.cpp
 
 
 # *** STL BUGS ***
-# STL bug: VSO-121977 "<locale>: the enum value of std::money_base is not correct[libcxx]"
+# STL bug: GH-1112 VSO-121977 "<locale>: the enum value of std::money_base is not correct[libcxx]"
 std/localization/locale.categories/category.monetary/locale.moneypunct/money_base.pass.cpp FAIL
 
-# STL Bug: VSO-595631 <fstream> basic_filebuf doesn't comply with setbuf(0,0) requirement in the standard
+# STL bug: GH-1113 VSO-595631 <fstream> basic_filebuf doesn't comply with setbuf(0,0) requirement in the standard
 std/input.output/file.streams/fstreams/filebuf.virtuals/overflow.pass.cpp FAIL
 std/input.output/file.streams/fstreams/filebuf.virtuals/underflow.pass.cpp FAIL
 
-# STL bug: Our inheritance implementation is allowing this to compile when it shouldn't.
+# STL bug: GH-1256 Our inheritance implementation is allowing this to compile when it shouldn't.
 std/numerics/complex.number/complex.special/double_long_double_implicit.compile.fail.cpp FAIL
 std/numerics/complex.number/complex.special/float_double_implicit.compile.fail.cpp FAIL
 std/numerics/complex.number/complex.special/float_long_double_implicit.compile.fail.cpp FAIL
 
-# STL bug: regex_traits::transform() isn't following the Standard.
+# STL bug: GH-1004 regex_traits::transform() isn't following the Standard.
 std/re/re.traits/transform.pass.cpp FAIL
 
-# STL bug: Incorrect return types.
+# STL bug: GH-1260 Incorrect return types.
 std/numerics/complex.number/cmplx.over/pow.pass.cpp FAIL
 
-# STL bug: We allow fill() and swap() for array<const T, 0>.
+# STL bug: GH-942 We allow fill() and swap() for array<const T, 0>.
 std/containers/sequences/array/array.fill/fill.fail.cpp FAIL
 std/containers/sequences/array/array.swap/swap.fail.cpp FAIL
 
-# STL bug: VSO-207715 We reject array<NoDefault, 0>.
+# STL bug: GH-942 VSO-207715 We reject array<NoDefault, 0>.
 std/containers/sequences/array/array.cons/implicit_copy.pass.cpp FAIL
 std/containers/sequences/array/array.cons/initialization.pass.cpp FAIL
 std/containers/sequences/array/array.data/data_const.pass.cpp FAIL
 std/containers/sequences/array/array.data/data.pass.cpp FAIL
 std/containers/sequences/array/iterators.pass.cpp FAIL
 
-# Predicate count assertions - IDL2 is slightly bending the Standard's rules here.
+# STL bug: GH-1006 Predicate count assertions - IDL2 is slightly bending the Standard's rules here.
 std/algorithms/alg.sorting/alg.heap.operations/make.heap/make_heap_comp.pass.cpp FAIL
 std/algorithms/alg.sorting/alg.merge/inplace_merge_comp.pass.cpp FAIL
 std/algorithms/alg.sorting/alg.min.max/minmax_init_list_comp.pass.cpp FAIL
 
-# STL bug: We don't match strtod / strtof when doing field extraction for hexfloats, or special cases like inf
+# STL bug: GH-1259 We don't match strtod / strtof when doing field extraction for hexfloats, or special cases like inf
 std/localization/locale.categories/category.numeric/locale.num.get/facet.num.get.members/get_double.pass.cpp FAIL
 std/localization/locale.categories/category.numeric/locale.num.get/facet.num.get.members/get_float.pass.cpp FAIL
 std/localization/locale.categories/category.numeric/locale.num.get/facet.num.get.members/get_long_double.pass.cpp FAIL
 
-# STL bug: We don't match numpunct groups correctly in do_get
+# STL bug: GH-1277 We don't match numpunct groups correctly in do_get
 std/localization/locale.categories/category.numeric/locale.num.get/facet.num.get.members/get_long.pass.cpp FAIL
 
-# STL test bug: We don't have the locale names libcxx wants specialized in platform_support.hpp
+# STL test bug: GH-1275 We don't have the locale names libcxx wants specialized in platform_support.hpp
 # More bugs may be uncovered when the locale names are present.
 # move.pass.cpp can crash.
 std/input.output/iostreams.base/ios/basic.ios.members/move.pass.cpp SKIPPED
@@ -593,13 +593,13 @@ std/localization/locale.categories/category.time/locale.time.put.byname/put1.pas
 std/localization/locale.categories/facet.numpunct/locale.numpunct.byname/grouping.pass.cpp FAIL
 std/localization/locale.categories/facet.numpunct/locale.numpunct.byname/thousands_sep.pass.cpp FAIL
 
-# STL Bug? Our wbuffer_convert does not implement seek. [depr.conversions.buffer] is completely underspecified.
+# STL bug? GH-1264 Our wbuffer_convert does not implement seek. [depr.conversions.buffer] is completely underspecified.
 std/localization/locales/locale.convenience/conversions/conversions.buffer/seekoff.pass.cpp FAIL
 
-# STL Bug: error_category's default ctor isn't constexpr. (Should be fixed in vNext.)
+# STL bug: GH-1116 error_category's default ctor isn't constexpr. (Should be fixed in vNext.)
 std/diagnostics/syserr/syserr.errcat/syserr.errcat.nonvirtuals/default_ctor.pass.cpp:1 FAIL
 
-# STL Bug: future incorrectly uses copy assignment instead of copy construction in set_value. (Should be fixed in vNext.)
+# STL bug: GH-1190 future incorrectly uses copy assignment instead of copy construction in set_value. (Should be fixed in vNext.)
 std/thread/futures/futures.promise/set_value_const.pass.cpp FAIL
 
 # STL bug: GH-757 <xstring>: Too many enabled hash specializations

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -527,7 +527,7 @@ std/localization/locale.categories/category.monetary/locale.moneypunct/money_bas
 std/input.output/file.streams/fstreams/filebuf.virtuals/overflow.pass.cpp FAIL
 std/input.output/file.streams/fstreams/filebuf.virtuals/underflow.pass.cpp FAIL
 
-# GH-1256 Our inheritance implementation is allowing this to compile when it shouldn't.
+# STL bug: Our inheritance implementation is allowing this to compile when it shouldn't.
 std/numerics/complex.number/complex.special/double_long_double_implicit.compile.fail.cpp FAIL
 std/numerics/complex.number/complex.special/float_double_implicit.compile.fail.cpp FAIL
 std/numerics/complex.number/complex.special/float_long_double_implicit.compile.fail.cpp FAIL

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -538,7 +538,7 @@ std/re/re.traits/transform.pass.cpp FAIL
 # GH-1260 Incorrect return types.
 std/numerics/complex.number/cmplx.over/pow.pass.cpp FAIL
 
-# GH-942 We allow fill() and swap() for array<const T, 0>.
+# GH-1295 <array>: array<const T, 0> allows fill() and swap()
 std/containers/sequences/array/array.fill/fill.fail.cpp FAIL
 std/containers/sequences/array/array.swap/swap.fail.cpp FAIL
 

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -527,7 +527,7 @@ localization\locale.categories\category.monetary\locale.moneypunct\money_base.pa
 input.output\file.streams\fstreams\filebuf.virtuals\overflow.pass.cpp
 input.output\file.streams\fstreams\filebuf.virtuals\underflow.pass.cpp
 
-# GH-1256 Our inheritance implementation is allowing this to compile when it shouldn't.
+# STL bug: Our inheritance implementation is allowing this to compile when it shouldn't.
 numerics\complex.number\complex.special\double_long_double_implicit.compile.fail.cpp
 numerics\complex.number\complex.special\float_double_implicit.compile.fail.cpp
 numerics\complex.number\complex.special\float_long_double_implicit.compile.fail.cpp

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -520,10 +520,10 @@ language.support\support.limits\limits\numeric.limits.members\traps.pass.cpp
 
 
 # *** STL BUGS ***
-# GH-1112 "<locale>: the enum value of std::money_base is not correct[libcxx]"
+# GH-1112 <locale>: the enum value of std::money_base is not correct
 localization\locale.categories\category.monetary\locale.moneypunct\money_base.pass.cpp
 
-# GH-1113 <fstream> basic_filebuf doesn't comply with setbuf(0,0) requirement in the standard
+# GH-1113 <fstream>: basic_filebuf doesn't comply with setbuf(0,0) requirement in the standard
 input.output\file.streams\fstreams\filebuf.virtuals\overflow.pass.cpp
 input.output\file.streams\fstreams\filebuf.virtuals\underflow.pass.cpp
 
@@ -532,37 +532,38 @@ numerics\complex.number\complex.special\double_long_double_implicit.compile.fail
 numerics\complex.number\complex.special\float_double_implicit.compile.fail.cpp
 numerics\complex.number\complex.special\float_long_double_implicit.compile.fail.cpp
 
-# GH-1004 regex_traits::transform() isn't following the Standard.
+# GH-1004 <regex>: Error C2664 in std::regex_traits::transform
 re\re.traits\transform.pass.cpp
 
-# GH-1260 Incorrect return types.
+# GH-1260 <complex>: pow, incorrect type conversion
 numerics\complex.number\cmplx.over\pow.pass.cpp
 
 # GH-1295 <array>: array<const T, 0> allows fill() and swap()
 containers\sequences\array\array.fill\fill.fail.cpp
 containers\sequences\array\array.swap\swap.fail.cpp
 
-# GH-942 We reject array<NoDefault, 0>.
+# GH-942 <array>: std::array<T,0> doesn't compile - when type is not default constructible
 containers\sequences\array\array.cons\implicit_copy.pass.cpp
 containers\sequences\array\array.cons\initialization.pass.cpp
 containers\sequences\array\array.data\data_const.pass.cpp
 containers\sequences\array\array.data\data.pass.cpp
 containers\sequences\array\iterators.pass.cpp
 
-# GH-1006 Predicate count assertions - IDL2 is slightly bending the Standard's rules here.
+# GH-1006 <algorithm>: debug checks for predicates are observable
 algorithms\alg.sorting\alg.heap.operations\make.heap\make_heap_comp.pass.cpp
 algorithms\alg.sorting\alg.merge\inplace_merge_comp.pass.cpp
 algorithms\alg.sorting\alg.min.max\minmax_init_list_comp.pass.cpp
 
-# GH-1259 We don't match strtod / strtof when doing field extraction for hexfloats, or special cases like inf
+# GH-1259 <locale>: wrong field extraction for hexfloats, or special cases like inf
 localization\locale.categories\category.numeric\locale.num.get\facet.num.get.members\get_double.pass.cpp
 localization\locale.categories\category.numeric\locale.num.get\facet.num.get.members\get_float.pass.cpp
 localization\locale.categories\category.numeric\locale.num.get\facet.num.get.members\get_long_double.pass.cpp
 
-# GH-1277 We don't match numpunct groups correctly in do_get
+# GH-1277 <xlocnum>: We don't match numpunct groups correctly in do_get
 localization\locale.categories\category.numeric\locale.num.get\facet.num.get.members\get_long.pass.cpp
 
-# GH-1275 We don't have the locale names libcxx wants specialized in platform_support.hpp
+# GH-1275 <locale>: missing some locale names
+# We don't have the locale names libcxx wants specialized in platform_support.hpp
 # More bugs may be uncovered when the locale names are present.
 # move.pass.cpp can crash.
 input.output\iostreams.base\ios\basic.ios.members\move.pass.cpp
@@ -594,13 +595,13 @@ localization\locale.categories\category.time\locale.time.put.byname\put1.pass.cp
 localization\locale.categories\facet.numpunct\locale.numpunct.byname\grouping.pass.cpp
 localization\locale.categories\facet.numpunct\locale.numpunct.byname\thousands_sep.pass.cpp
 
-# GH-1264 Our wbuffer_convert does not implement seek. [depr.conversions.buffer] is completely underspecified.
+# GH-1264 <locale>: wbuffer_convert does not implement seek
 localization\locales\locale.convenience\conversions\conversions.buffer\seekoff.pass.cpp
 
-# GH-1116 error_category's default ctor isn't constexpr. (Should be fixed in vNext.)
+# GH-1116 <system_error>: error_category's default ctor isn't constexpr.
 diagnostics\syserr\syserr.errcat\syserr.errcat.nonvirtuals\default_ctor.pass.cpp
 
-# GH-1190 future incorrectly uses copy assignment instead of copy construction in set_value. (Should be fixed in vNext.)
+# GH-1190 <future>: incorrectly used copy assignment instead of copy construction in set_value
 thread\futures\futures.promise\set_value_const.pass.cpp
 
 # GH-757 <xstring>: Too many enabled hash specializations

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -520,10 +520,10 @@ language.support\support.limits\limits\numeric.limits.members\traps.pass.cpp
 
 
 # *** STL BUGS ***
-# GH-1112 VSO-121977 "<locale>: the enum value of std::money_base is not correct[libcxx]"
+# GH-1112 "<locale>: the enum value of std::money_base is not correct[libcxx]"
 localization\locale.categories\category.monetary\locale.moneypunct\money_base.pass.cpp
 
-# GH-1113 VSO-595631 <fstream> basic_filebuf doesn't comply with setbuf(0,0) requirement in the standard
+# GH-1113 <fstream> basic_filebuf doesn't comply with setbuf(0,0) requirement in the standard
 input.output\file.streams\fstreams\filebuf.virtuals\overflow.pass.cpp
 input.output\file.streams\fstreams\filebuf.virtuals\underflow.pass.cpp
 
@@ -542,7 +542,7 @@ numerics\complex.number\cmplx.over\pow.pass.cpp
 containers\sequences\array\array.fill\fill.fail.cpp
 containers\sequences\array\array.swap\swap.fail.cpp
 
-# GH-942 VSO-207715 We reject array<NoDefault, 0>.
+# GH-942 We reject array<NoDefault, 0>.
 containers\sequences\array\array.cons\implicit_copy.pass.cpp
 containers\sequences\array\array.cons\initialization.pass.cpp
 containers\sequences\array\array.data\data_const.pass.cpp

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -538,7 +538,7 @@ re\re.traits\transform.pass.cpp
 # GH-1260 Incorrect return types.
 numerics\complex.number\cmplx.over\pow.pass.cpp
 
-# GH-942 We allow fill() and swap() for array<const T, 0>.
+# GH-1295 <array>: array<const T, 0> allows fill() and swap()
 containers\sequences\array\array.fill\fill.fail.cpp
 containers\sequences\array\array.swap\swap.fail.cpp
 

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -519,49 +519,49 @@ language.support\support.limits\limits\numeric.limits.members\traps.pass.cpp
 
 
 # *** STL BUGS ***
-# STL bug: VSO-121977 "<locale>: the enum value of std::money_base is not correct[libcxx]"
+# STL bug: GH-1112 VSO-121977 "<locale>: the enum value of std::money_base is not correct[libcxx]"
 localization\locale.categories\category.monetary\locale.moneypunct\money_base.pass.cpp
 
-# STL Bug: VSO-595631 <fstream> basic_filebuf doesn't comply with setbuf(0,0) requirement in the standard
+# STL bug: GH-1113 VSO-595631 <fstream> basic_filebuf doesn't comply with setbuf(0,0) requirement in the standard
 input.output\file.streams\fstreams\filebuf.virtuals\overflow.pass.cpp
 input.output\file.streams\fstreams\filebuf.virtuals\underflow.pass.cpp
 
-# STL bug: Our inheritance implementation is allowing this to compile when it shouldn't.
+# STL bug: GH-1256 Our inheritance implementation is allowing this to compile when it shouldn't.
 numerics\complex.number\complex.special\double_long_double_implicit.compile.fail.cpp
 numerics\complex.number\complex.special\float_double_implicit.compile.fail.cpp
 numerics\complex.number\complex.special\float_long_double_implicit.compile.fail.cpp
 
-# STL bug: regex_traits::transform() isn't following the Standard.
+# STL bug: GH-1004 regex_traits::transform() isn't following the Standard.
 re\re.traits\transform.pass.cpp
 
-# STL bug: Incorrect return types.
+# STL bug: GH-1260 Incorrect return types.
 numerics\complex.number\cmplx.over\pow.pass.cpp
 
-# STL bug: We allow fill() and swap() for array<const T, 0>.
+# STL bug: GH-942 We allow fill() and swap() for array<const T, 0>.
 containers\sequences\array\array.fill\fill.fail.cpp
 containers\sequences\array\array.swap\swap.fail.cpp
 
-# STL bug: VSO-207715 We reject array<NoDefault, 0>.
+# STL bug: GH-942 VSO-207715 We reject array<NoDefault, 0>.
 containers\sequences\array\array.cons\implicit_copy.pass.cpp
 containers\sequences\array\array.cons\initialization.pass.cpp
 containers\sequences\array\array.data\data_const.pass.cpp
 containers\sequences\array\array.data\data.pass.cpp
 containers\sequences\array\iterators.pass.cpp
 
-# Predicate count assertions - IDL2 is slightly bending the Standard's rules here.
+# STL bug: GH-1006 Predicate count assertions - IDL2 is slightly bending the Standard's rules here.
 algorithms\alg.sorting\alg.heap.operations\make.heap\make_heap_comp.pass.cpp
 algorithms\alg.sorting\alg.merge\inplace_merge_comp.pass.cpp
 algorithms\alg.sorting\alg.min.max\minmax_init_list_comp.pass.cpp
 
-# STL bug: We don't match strtod / strtof when doing field extraction for hexfloats, or special cases like inf
+# STL bug: GH-1259 We don't match strtod / strtof when doing field extraction for hexfloats, or special cases like inf
 localization\locale.categories\category.numeric\locale.num.get\facet.num.get.members\get_double.pass.cpp
 localization\locale.categories\category.numeric\locale.num.get\facet.num.get.members\get_float.pass.cpp
 localization\locale.categories\category.numeric\locale.num.get\facet.num.get.members\get_long_double.pass.cpp
 
-# STL bug: We don't match numpunct groups correctly in do_get
+# STL bug: GH-1277 We don't match numpunct groups correctly in do_get
 localization\locale.categories\category.numeric\locale.num.get\facet.num.get.members\get_long.pass.cpp
 
-# STL test bug: We don't have the locale names libcxx wants specialized in platform_support.hpp
+# STL test bug: GH-1275 We don't have the locale names libcxx wants specialized in platform_support.hpp
 # More bugs may be uncovered when the locale names are present.
 # move.pass.cpp can crash.
 input.output\iostreams.base\ios\basic.ios.members\move.pass.cpp
@@ -593,13 +593,13 @@ localization\locale.categories\category.time\locale.time.put.byname\put1.pass.cp
 localization\locale.categories\facet.numpunct\locale.numpunct.byname\grouping.pass.cpp
 localization\locale.categories\facet.numpunct\locale.numpunct.byname\thousands_sep.pass.cpp
 
-# STL Bug? Our wbuffer_convert does not implement seek. [depr.conversions.buffer] is completely underspecified.
+# STL bug? GH-1264 Our wbuffer_convert does not implement seek. [depr.conversions.buffer] is completely underspecified.
 localization\locales\locale.convenience\conversions\conversions.buffer\seekoff.pass.cpp
 
-# STL Bug: error_category's default ctor isn't constexpr. (Should be fixed in vNext.)
+# STL bug: GH-1116 error_category's default ctor isn't constexpr. (Should be fixed in vNext.)
 diagnostics\syserr\syserr.errcat\syserr.errcat.nonvirtuals\default_ctor.pass.cpp
 
-# STL Bug: future incorrectly uses copy assignment instead of copy construction in set_value. (Should be fixed in vNext.)
+# STL bug: GH-1190 future incorrectly uses copy assignment instead of copy construction in set_value. (Should be fixed in vNext.)
 thread\futures\futures.promise\set_value_const.pass.cpp
 
 # STL bug: GH-757 <xstring>: Too many enabled hash specializations

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -66,6 +66,7 @@ numerics\bit\bit.pow.two\log2p1.pass.cpp
 # test emits warning C4310: cast truncates constant value
 numerics\bit\bitops.rot\rotl.pass.cpp
 
+
 # *** INTERACTIONS WITH CONTEST / C1XX THAT UPSTREAM LIKELY WON'T FIX ***
 # Tracked by VSO-593630 "<filesystem> Enable libcxx filesystem tests"
 # rapid-cxx-test.hpp uses pragma system_header
@@ -486,10 +487,10 @@ thread\futures\futures.task\futures.task.members\make_ready_at_thread_exit.pass.
 
 
 # *** C1XX COMPILER BUGS ***
-# Compiler bug: DevCom-409222 "Constructing rvalue reference from non-reference-related lvalue reference"
+# DevCom-409222 "Constructing rvalue reference from non-reference-related lvalue reference"
 utilities\meta\meta.unary\meta.unary.prop\is_constructible.pass.cpp
 
-# Compiler bug: DevCom-876860 "conditional operator errors" blocks readable<volatile int*>.
+# DevCom-876860 "conditional operator errors" blocks readable<volatile int*>.
 containers\views\span.cons\ptr_len.pass.cpp
 containers\views\span.cons\ptr_ptr.pass.cpp
 
@@ -519,49 +520,49 @@ language.support\support.limits\limits\numeric.limits.members\traps.pass.cpp
 
 
 # *** STL BUGS ***
-# STL bug: GH-1112 VSO-121977 "<locale>: the enum value of std::money_base is not correct[libcxx]"
+# GH-1112 VSO-121977 "<locale>: the enum value of std::money_base is not correct[libcxx]"
 localization\locale.categories\category.monetary\locale.moneypunct\money_base.pass.cpp
 
-# STL bug: GH-1113 VSO-595631 <fstream> basic_filebuf doesn't comply with setbuf(0,0) requirement in the standard
+# GH-1113 VSO-595631 <fstream> basic_filebuf doesn't comply with setbuf(0,0) requirement in the standard
 input.output\file.streams\fstreams\filebuf.virtuals\overflow.pass.cpp
 input.output\file.streams\fstreams\filebuf.virtuals\underflow.pass.cpp
 
-# STL bug: GH-1256 Our inheritance implementation is allowing this to compile when it shouldn't.
+# GH-1256 Our inheritance implementation is allowing this to compile when it shouldn't.
 numerics\complex.number\complex.special\double_long_double_implicit.compile.fail.cpp
 numerics\complex.number\complex.special\float_double_implicit.compile.fail.cpp
 numerics\complex.number\complex.special\float_long_double_implicit.compile.fail.cpp
 
-# STL bug: GH-1004 regex_traits::transform() isn't following the Standard.
+# GH-1004 regex_traits::transform() isn't following the Standard.
 re\re.traits\transform.pass.cpp
 
-# STL bug: GH-1260 Incorrect return types.
+# GH-1260 Incorrect return types.
 numerics\complex.number\cmplx.over\pow.pass.cpp
 
-# STL bug: GH-942 We allow fill() and swap() for array<const T, 0>.
+# GH-942 We allow fill() and swap() for array<const T, 0>.
 containers\sequences\array\array.fill\fill.fail.cpp
 containers\sequences\array\array.swap\swap.fail.cpp
 
-# STL bug: GH-942 VSO-207715 We reject array<NoDefault, 0>.
+# GH-942 VSO-207715 We reject array<NoDefault, 0>.
 containers\sequences\array\array.cons\implicit_copy.pass.cpp
 containers\sequences\array\array.cons\initialization.pass.cpp
 containers\sequences\array\array.data\data_const.pass.cpp
 containers\sequences\array\array.data\data.pass.cpp
 containers\sequences\array\iterators.pass.cpp
 
-# STL bug: GH-1006 Predicate count assertions - IDL2 is slightly bending the Standard's rules here.
+# GH-1006 Predicate count assertions - IDL2 is slightly bending the Standard's rules here.
 algorithms\alg.sorting\alg.heap.operations\make.heap\make_heap_comp.pass.cpp
 algorithms\alg.sorting\alg.merge\inplace_merge_comp.pass.cpp
 algorithms\alg.sorting\alg.min.max\minmax_init_list_comp.pass.cpp
 
-# STL bug: GH-1259 We don't match strtod / strtof when doing field extraction for hexfloats, or special cases like inf
+# GH-1259 We don't match strtod / strtof when doing field extraction for hexfloats, or special cases like inf
 localization\locale.categories\category.numeric\locale.num.get\facet.num.get.members\get_double.pass.cpp
 localization\locale.categories\category.numeric\locale.num.get\facet.num.get.members\get_float.pass.cpp
 localization\locale.categories\category.numeric\locale.num.get\facet.num.get.members\get_long_double.pass.cpp
 
-# STL bug: GH-1277 We don't match numpunct groups correctly in do_get
+# GH-1277 We don't match numpunct groups correctly in do_get
 localization\locale.categories\category.numeric\locale.num.get\facet.num.get.members\get_long.pass.cpp
 
-# STL test bug: GH-1275 We don't have the locale names libcxx wants specialized in platform_support.hpp
+# GH-1275 We don't have the locale names libcxx wants specialized in platform_support.hpp
 # More bugs may be uncovered when the locale names are present.
 # move.pass.cpp can crash.
 input.output\iostreams.base\ios\basic.ios.members\move.pass.cpp
@@ -593,21 +594,25 @@ localization\locale.categories\category.time\locale.time.put.byname\put1.pass.cp
 localization\locale.categories\facet.numpunct\locale.numpunct.byname\grouping.pass.cpp
 localization\locale.categories\facet.numpunct\locale.numpunct.byname\thousands_sep.pass.cpp
 
-# STL bug? GH-1264 Our wbuffer_convert does not implement seek. [depr.conversions.buffer] is completely underspecified.
+# GH-1264 Our wbuffer_convert does not implement seek. [depr.conversions.buffer] is completely underspecified.
 localization\locales\locale.convenience\conversions\conversions.buffer\seekoff.pass.cpp
 
-# STL bug: GH-1116 error_category's default ctor isn't constexpr. (Should be fixed in vNext.)
+# GH-1116 error_category's default ctor isn't constexpr. (Should be fixed in vNext.)
 diagnostics\syserr\syserr.errcat\syserr.errcat.nonvirtuals\default_ctor.pass.cpp
 
-# STL bug: GH-1190 future incorrectly uses copy assignment instead of copy construction in set_value. (Should be fixed in vNext.)
+# GH-1190 future incorrectly uses copy assignment instead of copy construction in set_value. (Should be fixed in vNext.)
 thread\futures\futures.promise\set_value_const.pass.cpp
 
-# STL bug: GH-757 <xstring>: Too many enabled hash specializations
+# GH-757 <xstring>: Too many enabled hash specializations
 strings\basic.string.hash\char_type_hash.fail.cpp
 strings\string.view\string.view.hash\char_type.hash.fail.cpp
 
-# STL bug: GH-784 <type_traits>: aligned_storage has incorrect alignment defaults
+# GH-784 <type_traits>: aligned_storage has incorrect alignment defaults
 utilities\meta\meta.trans\meta.trans.other\aligned_storage.pass.cpp
+
+# GH-519 <cmath>: signbit() misses overloads for integer types
+depr\depr.c.headers\math_h.pass.cpp
+numerics\c.math\cmath.pass.cpp
 
 
 # *** CRT BUGS ***
@@ -633,10 +638,6 @@ thread\thread.semaphore\try_acquire.pass.cpp
 # pass lambda without noexcept to barrier
 thread\thread.barrier\completion.pass.cpp
 thread\thread.barrier\max.pass.cpp
-
-# Test bug/LEWG issue or STL bug. See GH-519 "<cmath>: signbit() misses overloads for integer types".
-depr\depr.c.headers\math_h.pass.cpp
-numerics\c.math\cmath.pass.cpp
 
 # Test bug after LWG-2899 "is_(nothrow_)move_constructible and tuple, optional and unique_ptr" was accepted.
 utilities\smartptr\unique.ptr\unique.ptr.class\unique.ptr.asgn\move_convert.pass.cpp

--- a/tests/std/tests/P0067R5_charconv/double_general_precision_to_chars_test_cases.hpp
+++ b/tests/std/tests/P0067R5_charconv/double_general_precision_to_chars_test_cases.hpp
@@ -5049,4 +5049,12 @@ inline constexpr DoublePrecisionToCharsTestCase double_general_precision_to_char
     {0x1.88e2d605edc3dp+345, chars_format::general, 3, "1.1e+104"},
     {0x1.88e2d605edc3dp+345, chars_format::general, 2, "1.1e+104"},
     {0x1.88e2d605edc3dp+345, chars_format::general, 1, "1e+104"},
+
+    // More cases that the UCRT had trouble with (e.g. DevCom-1093399).
+    {0x1.8p+62, chars_format::general, 17, "6.9175290276410819e+18"},
+    {0x1.0a2742p+17, chars_format::general, 6, "136271"},
+    {0x1.f8b0f962cdffbp+205, chars_format::general, 14, "1.0137595739223e+62"},
+    {0x1.f8b0f962cdffbp+205, chars_format::general, 17, "1.0137595739222531e+62"},
+    {0x1.f8b0f962cdffbp+205, chars_format::general, 51, "1.01375957392225305727423222620636224221808910954041e+62"},
+    {0x1.f8b0f962cdffbp+205, chars_format::general, 55, "1.013759573922253057274232226206362242218089109540405973e+62"},
 };

--- a/tests/std/tests/P0067R5_charconv/double_scientific_precision_to_chars_test_cases_1.hpp
+++ b/tests/std/tests/P0067R5_charconv/double_scientific_precision_to_chars_test_cases_1.hpp
@@ -312,4 +312,13 @@ inline constexpr DoublePrecisionToCharsTestCase double_scientific_precision_to_c
     {0x1.88e2d605edc3dp+345, chars_format::scientific, 2, "1.10e+104"},
     {0x1.88e2d605edc3dp+345, chars_format::scientific, 1, "1.1e+104"},
     {0x1.88e2d605edc3dp+345, chars_format::scientific, 0, "1e+104"},
+
+    // More cases that the UCRT had trouble with (e.g. DevCom-1093399).
+    {0x1.8p+62, chars_format::scientific, 16, "6.9175290276410819e+18"},
+    {0x1.0a2742p+17, chars_format::scientific, 5, "1.36271e+05"},
+    {0x1.f8b0f962cdffbp+205, chars_format::scientific, 13, "1.0137595739223e+62"},
+    {0x1.f8b0f962cdffbp+205, chars_format::scientific, 16, "1.0137595739222531e+62"},
+    {0x1.f8b0f962cdffbp+205, chars_format::scientific, 50, "1.01375957392225305727423222620636224221808910954041e+62"},
+    {0x1.f8b0f962cdffbp+205, chars_format::scientific, 54,
+        "1.013759573922253057274232226206362242218089109540405973e+62"},
 };

--- a/tools/parallelize/parallelize.cpp
+++ b/tools/parallelize/parallelize.cpp
@@ -158,8 +158,7 @@ extern "C" int wmain(int argc, wchar_t* argv[]) {
             L".hpp"sv,
         };
 
-        // TRANSITION, P0202R3, use constexpr is_sorted()
-        assert(std::is_sorted(accepted_extensions.begin(), accepted_extensions.end()));
+        static_assert(std::is_sorted(accepted_extensions.begin(), accepted_extensions.end()));
 
         if (argc < 3) {
             puts("Usage: parallelize.exe commandPrefix pathRoot0 [... pathRootN]\n"


### PR DESCRIPTION
These are unrelated small changes to separate files - they could be split into separate PRs but I don't believe that would add any value.

* Use `constexpr is_sorted()` in `tools/parallelize/parallelize.cpp`. It's been available for a while, we just forgot about this occurrence.
* Adjust `<execution>` comments to take advantage of hover cards in the GitHub Pull Requests And Issues extension for VSCode. (microsoft/vscode-pull-request-github#2085 has been fixed, but is not yet released.)
* Update the libcxx skip lists now that @fsb4000 and @AlexGuteniev have filed issues for the various STL bugs mentioned. :heart_eyes_cat:
  + Remove redundant "compiler bug" and "STL bug" comments.
    - Note that #1290 is about to be merged and will remove the skip for VSO-1035737 "constexpr pointers-by-reference"; to avoid a merge conflict I have simply not updated that line.
    - Similarly, @Arzaghi submitted #1294 for GH-1256; I have chosen to revert the changes to this line to avoid a pointless merge conflict (I am confident we can merge this fix in the near future).
  + Group GH-519 with the STL bugs.
  + Filed GH-1295 separately from GH-942. (Notably, we should be able to fix the former without breaking ABI.)
  + Remove VSO citations when we have GH issues (which are linked).
* Add test cases for floating-point numbers that UCRT `printf()` has trouble with; `<charconv>` was never affected but let's test these just in case.