### PR TITLE
Account for C++17 deferred temporary materialization in invocable_r

### DIFF
--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -1679,11 +1679,8 @@ struct _Invocable_r_zero_nonvoid<void_t<decltype(_Implicitly_convert_to<_Rx>(_ST
     _Callable> : true_type {};
 
 template <class _Rx, class _Callable>
-struct _Is_nothrow_invocable_r_zero_impl
+struct _Is_nothrow_invocable_r_zero_nonvoid
     : bool_constant<noexcept(_Implicitly_convert_to<_Rx>(_STD declval<_Callable>()()))> {};
-
-template <class _Callable>
-struct _Is_nothrow_invocable_r_zero_impl<void, _Callable> : bool_constant<noexcept(_STD declval<_Callable>()())> {};
 
 template <class _Callable>
 struct _Invoke_traits_zero<void_t<_Decltype_invoke_zero<_Callable>>, _Callable> {
@@ -1694,8 +1691,8 @@ struct _Invoke_traits_zero<void_t<_Decltype_invoke_zero<_Callable>>, _Callable> 
     template <class _Rx>
     using _Is_invocable_r = bool_constant<disjunction_v<is_void<_Rx>, _Invocable_r_zero_nonvoid<void, _Rx, _Callable>>>;
     template <class _Rx>
-    using _Is_nothrow_invocable_r =
-        bool_constant<conjunction_v<_Is_invocable_r<_Rx>, _Is_nothrow_invocable_r_zero_impl<_Rx, _Callable>>>;
+    using _Is_nothrow_invocable_r = bool_constant<conjunction_v<_Is_invocable_r<_Rx>,
+        conditional_t<is_void_v<_Rx>, _Is_nothrow_invocable, _Is_nothrow_invocable_r_zero_nonvoid<_Rx, _Callable>>>>;
 };
 
 template <class _Void, class... _Types>
@@ -1722,14 +1719,9 @@ struct _Invocable_r_nonzero_nonvoid<void_t<decltype(_Implicitly_convert_to<_Rx>(
     _Rx, _Callable, _Ty1, _Types2...> : true_type {};
 
 template <class _Rx, class _Callable, class _Ty1, class... _Types2>
-struct _Is_nothrow_invocable_r_nonzero_impl
+struct _Is_nothrow_invocable_r_nonzero_nonvoid
     : bool_constant<noexcept(_Implicitly_convert_to<_Rx>(_Invoker1<_Callable, _Ty1>::_Call(
           _STD declval<_Callable>(), _STD declval<_Ty1>(), _STD declval<_Types2>()...)))> {};
-
-template <class _Callable, class _Ty1, class... _Types2>
-struct _Is_nothrow_invocable_r_nonzero_impl<void, _Callable, _Ty1, _Types2...>
-    : bool_constant<noexcept(_Invoker1<_Callable, _Ty1>::_Call(
-          _STD declval<_Callable>(), _STD declval<_Ty1>(), _STD declval<_Types2>()...))> {};
 
 template <class _Callable, class _Ty1, class... _Types2>
 struct _Invoke_traits_nonzero<void_t<_Decltype_invoke_nonzero<_Callable, _Ty1, _Types2...>>, _Callable, _Ty1,
@@ -1740,10 +1732,12 @@ struct _Invoke_traits_nonzero<void_t<_Decltype_invoke_nonzero<_Callable, _Ty1, _
     using _Is_nothrow_invocable = bool_constant<noexcept(_Invoker1<_Callable, _Ty1>::_Call(
         _STD declval<_Callable>(), _STD declval<_Ty1>(), _STD declval<_Types2>()...))>;
     template <class _Rx>
-    using _Is_invocable_r = _Invocable_r_nonzero_nonvoid<void, _Rx, _Callable, _Ty1, _Types2...>;
+    using _Is_invocable_r = bool_constant<
+        disjunction_v<is_void<_Rx>, _Invocable_r_nonzero_nonvoid<void, _Rx, _Callable, _Ty1, _Types2...>>>;
     template <class _Rx>
-    using _Is_nothrow_invocable_r = bool_constant<
-        conjunction_v<_Is_invocable_r<_Rx>, _Is_nothrow_invocable_r_nonzero_impl<_Rx, _Callable, _Ty1, _Types2...>>>;
+    using _Is_nothrow_invocable_r = bool_constant<conjunction_v<_Is_invocable_r<_Rx>,
+        conditional_t<is_void_v<_Rx>, _Is_nothrow_invocable,
+            _Is_nothrow_invocable_r_nonzero_nonvoid<_Rx, _Callable, _Ty1, _Types2...>>>>;
 };
 
 template <class _Callable, class... _Args>

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -1657,6 +1657,32 @@ template <class _From, class _To>
 using is_nothrow_convertible = _Is_nothrow_convertible<_From, _To>;
 #endif // _HAS_CXX20
 
+template <class _Ty>
+_Ty _Returns_exactly() noexcept; // not defined
+
+template <class _From, class _To, class = void>
+struct _Invoke_convertible : false_type {};
+
+template <class _From, class _To>
+struct _Invoke_convertible<_From, _To, void_t<decltype(_Implicitly_convert_to<_To>(_Returns_exactly<_From>()))>>
+    : true_type {};
+
+template <class _From, class _To>
+struct _Invoke_nothrow_convertible : bool_constant<noexcept(_Implicitly_convert_to<_To>(_Returns_exactly<_From>()))> {};
+
+template <class _Result, bool _Nothrow>
+struct _Invoke_traits_common {
+    using type                  = _Result;
+    using _Is_invocable         = true_type;
+    using _Is_nothrow_invocable = bool_constant<_Nothrow>;
+    template <class _Rx>
+    using _Is_invocable_r = bool_constant<disjunction_v<is_void<_Rx>, _Invoke_convertible<type, _Rx>>>;
+    template <class _Rx>
+    using _Is_nothrow_invocable_r = bool_constant<conjunction_v<_Is_nothrow_invocable,
+        disjunction<is_void<_Rx>,
+            conjunction<_Invoke_convertible<type, _Rx>, _Invoke_nothrow_convertible<type, _Rx>>>>>;
+};
+
 template <class _Void, class _Callable>
 struct _Invoke_traits_zero {
     // selected when _Callable isn't callable with zero _Args
@@ -1671,33 +1697,9 @@ struct _Invoke_traits_zero {
 template <class _Callable>
 using _Decltype_invoke_zero = decltype(_STD declval<_Callable>()());
 
-template <class _Void, class _Rx, class _Result>
-struct _Invocable_r_nonvoid : false_type {};
-
-template <class _Ty>
-_Ty _Returns_exactly() noexcept; // not defined
-
-template <class _Rx, class _Result>
-struct _Invocable_r_nonvoid<void_t<decltype(_Implicitly_convert_to<_Rx>(_Returns_exactly<_Result>()))>, _Rx, _Result>
-    : true_type {};
-
-template <class _Rx, class _Result>
-struct _Is_nothrow_invocable_r_nonvoid
-    : bool_constant<noexcept(_Implicitly_convert_to<_Rx>(_Returns_exactly<_Result>()))> {};
-
 template <class _Callable>
-struct _Invoke_traits_zero<void_t<_Decltype_invoke_zero<_Callable>>, _Callable> {
-    // selected when _Callable is callable with zero _Args
-    using type                  = _Decltype_invoke_zero<_Callable>;
-    using _Is_invocable         = true_type;
-    using _Is_nothrow_invocable = bool_constant<noexcept(_STD declval<_Callable>()())>;
-    template <class _Rx>
-    using _Is_invocable_r = bool_constant<disjunction_v<is_void<_Rx>, _Invocable_r_nonvoid<void, _Rx, type>>>;
-    template <class _Rx>
-    using _Is_nothrow_invocable_r = bool_constant<conjunction_v<_Is_nothrow_invocable,
-        disjunction<is_void<_Rx>,
-            conjunction<_Invocable_r_nonvoid<void, _Rx, type>, _Is_nothrow_invocable_r_nonvoid<_Rx, type>>>>>;
-};
+struct _Invoke_traits_zero<void_t<_Decltype_invoke_zero<_Callable>>, _Callable>
+    : _Invoke_traits_common<_Decltype_invoke_zero<_Callable>, noexcept(_STD declval<_Callable>()())> {};
 
 template <class _Void, class... _Types>
 struct _Invoke_traits_nonzero {
@@ -1716,18 +1718,9 @@ using _Decltype_invoke_nonzero = decltype(
 
 template <class _Callable, class _Ty1, class... _Types2>
 struct _Invoke_traits_nonzero<void_t<_Decltype_invoke_nonzero<_Callable, _Ty1, _Types2...>>, _Callable, _Ty1,
-    _Types2...> {
-    // selected when _Callable is callable with nonzero _Args
-    using type                  = _Decltype_invoke_nonzero<_Callable, _Ty1, _Types2...>;
-    using _Is_invocable         = true_type;
-    using _Is_nothrow_invocable = bool_constant<noexcept(_Invoker1<_Callable, _Ty1>::_Call(
-        _STD declval<_Callable>(), _STD declval<_Ty1>(), _STD declval<_Types2>()...))>;
-    template <class _Rx>
-    using _Is_invocable_r = bool_constant<disjunction_v<is_void<_Rx>, _Invocable_r_nonvoid<void, _Rx, type>>>;
-    template <class _Rx>
-    using _Is_nothrow_invocable_r = bool_constant<conjunction_v<_Is_nothrow_invocable,
-        disjunction<is_void<_Rx>, conjunction<_Is_invocable_r<_Rx>, _Is_nothrow_invocable_r_nonvoid<_Rx, type>>>>>;
-};
+    _Types2...> : _Invoke_traits_common<_Decltype_invoke_nonzero<_Callable, _Ty1, _Types2...>,
+                      noexcept(_Invoker1<_Callable, _Ty1>::_Call(
+                          _STD declval<_Callable>(), _STD declval<_Ty1>(), _STD declval<_Types2>()...))> {};
 
 template <class _Callable, class... _Args>
 using _Select_invoke_traits = conditional_t<sizeof...(_Args) == 0, _Invoke_traits_zero<void, _Callable>,

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -1675,14 +1675,15 @@ template <class _Void, class _Rx, class _Result>
 struct _Invocable_r_nonvoid : false_type {};
 
 template <class _Ty>
-_NODISCARD _Ty _Returns() noexcept; // not defined
+_Ty _Returns_exactly() noexcept; // not defined
 
 template <class _Rx, class _Result>
-struct _Invocable_r_nonvoid<void_t<decltype(_Implicitly_convert_to<_Rx>(_Returns<_Result>()))>, _Rx, _Result>
+struct _Invocable_r_nonvoid<void_t<decltype(_Implicitly_convert_to<_Rx>(_Returns_exactly<_Result>()))>, _Rx, _Result>
     : true_type {};
 
 template <class _Rx, class _Result>
-struct _Is_nothrow_invocable_r_nonvoid : bool_constant<noexcept(_Implicitly_convert_to<_Rx>(_Returns<_Result>()))> {};
+struct _Is_nothrow_invocable_r_nonvoid
+    : bool_constant<noexcept(_Implicitly_convert_to<_Rx>(_Returns_exactly<_Result>()))> {};
 
 template <class _Callable>
 struct _Invoke_traits_zero<void_t<_Decltype_invoke_zero<_Callable>>, _Callable> {

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -1671,6 +1671,18 @@ struct _Invoke_traits_zero {
 template <class _Callable>
 using _Decltype_invoke_zero = decltype(_STD declval<_Callable>()());
 
+template <class _Void, class _Rx, class _Callable, class... _Args>
+struct _Invocable_r_nonvoid : false_type {};
+
+template <class _Rx, class _Callable, class... _Args>
+struct _Invocable_r_nonvoid<
+    void_t<decltype(_Implicitly_convert_to<_Rx>(_STD invoke(_STD declval<_Callable>(), _STD declval<_Args>()...)))>,
+    _Rx, _Callable, _Args...> : true_type {};
+
+template <class _Rx, class _Callable, class... _Args>
+struct _Is_nothrow_invocable_r_nonvoid : bool_constant<noexcept(_Implicitly_convert_to<_Rx>(
+                                             _STD invoke(_STD declval<_Callable>(), _STD declval<_Args>()...)))> {};
+
 template <class _Callable>
 struct _Invoke_traits_zero<void_t<_Decltype_invoke_zero<_Callable>>, _Callable> {
     // selected when _Callable is callable with zero _Args
@@ -1678,10 +1690,10 @@ struct _Invoke_traits_zero<void_t<_Decltype_invoke_zero<_Callable>>, _Callable> 
     using _Is_invocable         = true_type;
     using _Is_nothrow_invocable = bool_constant<noexcept(_STD declval<_Callable>()())>;
     template <class _Rx>
-    using _Is_invocable_r = bool_constant<disjunction_v<is_void<_Rx>, is_convertible<type, _Rx>>>;
+    using _Is_invocable_r = bool_constant<disjunction_v<is_void<_Rx>, _Invocable_r_nonvoid<void, _Rx, _Callable>>>;
     template <class _Rx>
-    using _Is_nothrow_invocable_r = bool_constant<
-        conjunction_v<_Is_nothrow_invocable, disjunction<is_void<_Rx>, _Is_nothrow_convertible<type, _Rx>>>>;
+    using _Is_nothrow_invocable_r = bool_constant<conjunction_v<_Is_invocable_r<_Rx>,
+        disjunction<is_void<_Rx>, _Is_nothrow_invocable_r_nonvoid<_Rx, _Callable>>>>;
 };
 
 template <class _Void, class... _Types>
@@ -1708,10 +1720,11 @@ struct _Invoke_traits_nonzero<void_t<_Decltype_invoke_nonzero<_Callable, _Ty1, _
     using _Is_nothrow_invocable = bool_constant<noexcept(_Invoker1<_Callable, _Ty1>::_Call(
         _STD declval<_Callable>(), _STD declval<_Ty1>(), _STD declval<_Types2>()...))>;
     template <class _Rx>
-    using _Is_invocable_r = bool_constant<disjunction_v<is_void<_Rx>, is_convertible<type, _Rx>>>;
+    using _Is_invocable_r =
+        bool_constant<disjunction_v<is_void<_Rx>, _Invocable_r_nonvoid<void, _Rx, _Callable, _Ty1, _Types2...>>>;
     template <class _Rx>
-    using _Is_nothrow_invocable_r = bool_constant<
-        conjunction_v<_Is_nothrow_invocable, disjunction<is_void<_Rx>, _Is_nothrow_convertible<type, _Rx>>>>;
+    using _Is_nothrow_invocable_r = bool_constant<conjunction_v<_Is_invocable_r<_Rx>,
+        disjunction<is_void<_Rx>, _Is_nothrow_invocable_r_nonvoid<_Rx, _Callable, _Ty1, _Types2...>>>>;
 };
 
 template <class _Callable, class... _Args>

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -1671,16 +1671,18 @@ struct _Invoke_traits_zero {
 template <class _Callable>
 using _Decltype_invoke_zero = decltype(_STD declval<_Callable>()());
 
-template <class _Void, class _Rx, class _Callable>
-struct _Invocable_r_zero_nonvoid : false_type {};
+template <class _Void, class _Rx, class _Result>
+struct _Invocable_r_nonvoid : false_type {};
 
-template <class _Rx, class _Callable>
-struct _Invocable_r_zero_nonvoid<void_t<decltype(_Implicitly_convert_to<_Rx>(_STD declval<_Callable>()()))>, _Rx,
-    _Callable> : true_type {};
+template <class _Ty>
+_NODISCARD _Ty _Returns() noexcept; // not defined
 
-template <class _Rx, class _Callable>
-struct _Is_nothrow_invocable_r_zero_nonvoid
-    : bool_constant<noexcept(_Implicitly_convert_to<_Rx>(_STD declval<_Callable>()()))> {};
+template <class _Rx, class _Result>
+struct _Invocable_r_nonvoid<void_t<decltype(_Implicitly_convert_to<_Rx>(_Returns<_Result>()))>, _Rx, _Result>
+    : true_type {};
+
+template <class _Rx, class _Result>
+struct _Is_nothrow_invocable_r_nonvoid : bool_constant<noexcept(_Implicitly_convert_to<_Rx>(_Returns<_Result>()))> {};
 
 template <class _Callable>
 struct _Invoke_traits_zero<void_t<_Decltype_invoke_zero<_Callable>>, _Callable> {
@@ -1689,10 +1691,11 @@ struct _Invoke_traits_zero<void_t<_Decltype_invoke_zero<_Callable>>, _Callable> 
     using _Is_invocable         = true_type;
     using _Is_nothrow_invocable = bool_constant<noexcept(_STD declval<_Callable>()())>;
     template <class _Rx>
-    using _Is_invocable_r = bool_constant<disjunction_v<is_void<_Rx>, _Invocable_r_zero_nonvoid<void, _Rx, _Callable>>>;
+    using _Is_invocable_r = bool_constant<disjunction_v<is_void<_Rx>, _Invocable_r_nonvoid<void, _Rx, type>>>;
     template <class _Rx>
-    using _Is_nothrow_invocable_r = bool_constant<conjunction_v<_Is_invocable_r<_Rx>,
-        conditional_t<is_void_v<_Rx>, _Is_nothrow_invocable, _Is_nothrow_invocable_r_zero_nonvoid<_Rx, _Callable>>>>;
+    using _Is_nothrow_invocable_r = bool_constant<conjunction_v<_Is_nothrow_invocable,
+        disjunction<is_void<_Rx>,
+            conjunction<_Invocable_r_nonvoid<void, _Rx, type>, _Is_nothrow_invocable_r_nonvoid<_Rx, type>>>>>;
 };
 
 template <class _Void, class... _Types>
@@ -1710,19 +1713,6 @@ template <class _Callable, class _Ty1, class... _Types2>
 using _Decltype_invoke_nonzero = decltype(
     _Invoker1<_Callable, _Ty1>::_Call(_STD declval<_Callable>(), _STD declval<_Ty1>(), _STD declval<_Types2>()...));
 
-template <class _Void, class _Rx, class _Callable, class _Ty1, class... _Types2>
-struct _Invocable_r_nonzero_nonvoid : false_type {};
-
-template <class _Rx, class _Callable, class _Ty1, class... _Types2>
-struct _Invocable_r_nonzero_nonvoid<void_t<decltype(_Implicitly_convert_to<_Rx>(_Invoker1<_Callable, _Ty1>::_Call(
-                                        _STD declval<_Callable>(), _STD declval<_Ty1>(), _STD declval<_Types2>()...)))>,
-    _Rx, _Callable, _Ty1, _Types2...> : true_type {};
-
-template <class _Rx, class _Callable, class _Ty1, class... _Types2>
-struct _Is_nothrow_invocable_r_nonzero_nonvoid
-    : bool_constant<noexcept(_Implicitly_convert_to<_Rx>(_Invoker1<_Callable, _Ty1>::_Call(
-          _STD declval<_Callable>(), _STD declval<_Ty1>(), _STD declval<_Types2>()...)))> {};
-
 template <class _Callable, class _Ty1, class... _Types2>
 struct _Invoke_traits_nonzero<void_t<_Decltype_invoke_nonzero<_Callable, _Ty1, _Types2...>>, _Callable, _Ty1,
     _Types2...> {
@@ -1732,12 +1722,10 @@ struct _Invoke_traits_nonzero<void_t<_Decltype_invoke_nonzero<_Callable, _Ty1, _
     using _Is_nothrow_invocable = bool_constant<noexcept(_Invoker1<_Callable, _Ty1>::_Call(
         _STD declval<_Callable>(), _STD declval<_Ty1>(), _STD declval<_Types2>()...))>;
     template <class _Rx>
-    using _Is_invocable_r = bool_constant<
-        disjunction_v<is_void<_Rx>, _Invocable_r_nonzero_nonvoid<void, _Rx, _Callable, _Ty1, _Types2...>>>;
+    using _Is_invocable_r = bool_constant<disjunction_v<is_void<_Rx>, _Invocable_r_nonvoid<void, _Rx, type>>>;
     template <class _Rx>
-    using _Is_nothrow_invocable_r = bool_constant<conjunction_v<_Is_invocable_r<_Rx>,
-        conditional_t<is_void_v<_Rx>, _Is_nothrow_invocable,
-            _Is_nothrow_invocable_r_nonzero_nonvoid<_Rx, _Callable, _Ty1, _Types2...>>>>;
+    using _Is_nothrow_invocable_r = bool_constant<conjunction_v<_Is_nothrow_invocable,
+        disjunction<is_void<_Rx>, conjunction<_Is_invocable_r<_Rx>, _Is_nothrow_invocable_r_nonvoid<_Rx, type>>>>>;
 };
 
 template <class _Callable, class... _Args>

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -1671,17 +1671,19 @@ struct _Invoke_traits_zero {
 template <class _Callable>
 using _Decltype_invoke_zero = decltype(_STD declval<_Callable>()());
 
-template <class _Void, class _Rx, class _Callable, class... _Args>
-struct _Invocable_r_nonvoid : false_type {};
+template <class _Void, class _Rx, class _Callable>
+struct _Invocable_r_zero_nonvoid : false_type {};
 
-template <class _Rx, class _Callable, class... _Args>
-struct _Invocable_r_nonvoid<
-    void_t<decltype(_Implicitly_convert_to<_Rx>(_STD invoke(_STD declval<_Callable>(), _STD declval<_Args>()...)))>,
-    _Rx, _Callable, _Args...> : true_type {};
+template <class _Rx, class _Callable>
+struct _Invocable_r_zero_nonvoid<void_t<decltype(_Implicitly_convert_to<_Rx>(_STD declval<_Callable>()()))>, _Rx,
+    _Callable> : true_type {};
 
-template <class _Rx, class _Callable, class... _Args>
-struct _Is_nothrow_invocable_r_nonvoid : bool_constant<noexcept(_Implicitly_convert_to<_Rx>(
-                                             _STD invoke(_STD declval<_Callable>(), _STD declval<_Args>()...)))> {};
+template <class _Rx, class _Callable>
+struct _Is_nothrow_invocable_r_zero_impl
+    : bool_constant<noexcept(_Implicitly_convert_to<_Rx>(_STD declval<_Callable>()()))> {};
+
+template <class _Callable>
+struct _Is_nothrow_invocable_r_zero_impl<void, _Callable> : bool_constant<noexcept(_STD declval<_Callable>()())> {};
 
 template <class _Callable>
 struct _Invoke_traits_zero<void_t<_Decltype_invoke_zero<_Callable>>, _Callable> {
@@ -1690,10 +1692,10 @@ struct _Invoke_traits_zero<void_t<_Decltype_invoke_zero<_Callable>>, _Callable> 
     using _Is_invocable         = true_type;
     using _Is_nothrow_invocable = bool_constant<noexcept(_STD declval<_Callable>()())>;
     template <class _Rx>
-    using _Is_invocable_r = bool_constant<disjunction_v<is_void<_Rx>, _Invocable_r_nonvoid<void, _Rx, _Callable>>>;
+    using _Is_invocable_r = bool_constant<disjunction_v<is_void<_Rx>, _Invocable_r_zero_nonvoid<void, _Rx, _Callable>>>;
     template <class _Rx>
-    using _Is_nothrow_invocable_r = bool_constant<conjunction_v<_Is_invocable_r<_Rx>,
-        disjunction<is_void<_Rx>, _Is_nothrow_invocable_r_nonvoid<_Rx, _Callable>>>>;
+    using _Is_nothrow_invocable_r =
+        bool_constant<conjunction_v<_Is_invocable_r<_Rx>, _Is_nothrow_invocable_r_zero_impl<_Rx, _Callable>>>;
 };
 
 template <class _Void, class... _Types>
@@ -1711,6 +1713,24 @@ template <class _Callable, class _Ty1, class... _Types2>
 using _Decltype_invoke_nonzero = decltype(
     _Invoker1<_Callable, _Ty1>::_Call(_STD declval<_Callable>(), _STD declval<_Ty1>(), _STD declval<_Types2>()...));
 
+template <class _Void, class _Rx, class _Callable, class _Ty1, class... _Types2>
+struct _Invocable_r_nonzero_nonvoid : false_type {};
+
+template <class _Rx, class _Callable, class _Ty1, class... _Types2>
+struct _Invocable_r_nonzero_nonvoid<void_t<decltype(_Implicitly_convert_to<_Rx>(_Invoker1<_Callable, _Ty1>::_Call(
+                                        _STD declval<_Callable>(), _STD declval<_Ty1>(), _STD declval<_Types2>()...)))>,
+    _Rx, _Callable, _Ty1, _Types2...> : true_type {};
+
+template <class _Rx, class _Callable, class _Ty1, class... _Types2>
+struct _Is_nothrow_invocable_r_nonzero_impl
+    : bool_constant<noexcept(_Implicitly_convert_to<_Rx>(_Invoker1<_Callable, _Ty1>::_Call(
+          _STD declval<_Callable>(), _STD declval<_Ty1>(), _STD declval<_Types2>()...)))> {};
+
+template <class _Callable, class _Ty1, class... _Types2>
+struct _Is_nothrow_invocable_r_nonzero_impl<void, _Callable, _Ty1, _Types2...>
+    : bool_constant<noexcept(_Invoker1<_Callable, _Ty1>::_Call(
+          _STD declval<_Callable>(), _STD declval<_Ty1>(), _STD declval<_Types2>()...))> {};
+
 template <class _Callable, class _Ty1, class... _Types2>
 struct _Invoke_traits_nonzero<void_t<_Decltype_invoke_nonzero<_Callable, _Ty1, _Types2...>>, _Callable, _Ty1,
     _Types2...> {
@@ -1720,11 +1740,10 @@ struct _Invoke_traits_nonzero<void_t<_Decltype_invoke_nonzero<_Callable, _Ty1, _
     using _Is_nothrow_invocable = bool_constant<noexcept(_Invoker1<_Callable, _Ty1>::_Call(
         _STD declval<_Callable>(), _STD declval<_Ty1>(), _STD declval<_Types2>()...))>;
     template <class _Rx>
-    using _Is_invocable_r =
-        bool_constant<disjunction_v<is_void<_Rx>, _Invocable_r_nonvoid<void, _Rx, _Callable, _Ty1, _Types2...>>>;
+    using _Is_invocable_r = _Invocable_r_nonzero_nonvoid<void, _Rx, _Callable, _Ty1, _Types2...>;
     template <class _Rx>
-    using _Is_nothrow_invocable_r = bool_constant<conjunction_v<_Is_invocable_r<_Rx>,
-        disjunction<is_void<_Rx>, _Is_nothrow_invocable_r_nonvoid<_Rx, _Callable, _Ty1, _Types2...>>>>;
+    using _Is_nothrow_invocable_r = bool_constant<
+        conjunction_v<_Is_invocable_r<_Rx>, _Is_nothrow_invocable_r_nonzero_impl<_Rx, _Callable, _Ty1, _Types2...>>>;
 };
 
 template <class _Callable, class... _Args>

--- a/tests/std/tests/VSO_0105317_expression_sfinae/test.cpp
+++ b/tests/std/tests/VSO_0105317_expression_sfinae/test.cpp
@@ -627,8 +627,6 @@ STATIC_ASSERT(is_invocable_r_v<NonMovable, decltype(&getNonMovable<false>)>);
 STATIC_ASSERT(is_invocable_r_v<NonMovable, decltype(&getNonMovable<true>)>);
 STATIC_ASSERT(!is_nothrow_invocable_r_v<NonMovable, decltype(&getNonMovable<false>)>);
 STATIC_ASSERT(is_nothrow_invocable_r_v<NonMovable, decltype(&getNonMovable<true>)>);
-STATIC_ASSERT(!is_nothrow_invocable_r_v<NonMovable, decltype(&getNonMovable<false>)>);
-STATIC_ASSERT(is_nothrow_invocable_r_v<NonMovable, decltype(&getNonMovable<true>)>);
 
 template <bool Nothrow>
 struct ConvertsToNonMovable {

--- a/tests/std/tests/VSO_0105317_expression_sfinae/test.cpp
+++ b/tests/std/tests/VSO_0105317_expression_sfinae/test.cpp
@@ -605,6 +605,40 @@ STATIC_ASSERT(is_nothrow_invocable_r_v<Puppy, Kitty, int>);
 STATIC_ASSERT(is_invocable_r_v<Zebra, Kitty, int>);
 STATIC_ASSERT(!is_nothrow_invocable_r_v<Zebra, Kitty, int>);
 
+#if defined(__clang__) || defined(__EDG__) // TRANSITION, VSO-1026729
+// Defend against regression of VSO-963790, in which is_invocable_r mis-handles non-movable return types
+struct NonMovable {
+    NonMovable(NonMovable&&)      = delete;
+    NonMovable(const NonMovable&) = delete;
+};
+
+template <bool Nothrow>
+NonMovable getNonMovable() noexcept(Nothrow);
+
+STATIC_ASSERT(is_invocable_r_v<NonMovable, decltype(&getNonMovable<false>)>);
+STATIC_ASSERT(is_invocable_r_v<NonMovable, decltype(&getNonMovable<true>)>);
+STATIC_ASSERT(!is_nothrow_invocable_r_v<NonMovable, decltype(&getNonMovable<false>)>);
+STATIC_ASSERT(is_nothrow_invocable_r_v<NonMovable, decltype(&getNonMovable<true>)>);
+STATIC_ASSERT(!is_nothrow_invocable_r_v<NonMovable, decltype(&getNonMovable<false>)>);
+STATIC_ASSERT(is_nothrow_invocable_r_v<NonMovable, decltype(&getNonMovable<true>)>);
+
+template <bool Nothrow>
+struct ConvertsToNonMovable {
+    operator NonMovable() const noexcept(Nothrow);
+};
+
+template <bool Nothrow, bool NothrowReturn>
+ConvertsToNonMovable<NothrowReturn> getConvertsToNonMovable() noexcept(Nothrow);
+
+STATIC_ASSERT(is_invocable_r_v<NonMovable, decltype(&getConvertsToNonMovable<false, false>)>);
+STATIC_ASSERT(is_invocable_r_v<NonMovable, decltype(&getConvertsToNonMovable<false, true>)>);
+STATIC_ASSERT(is_invocable_r_v<NonMovable, decltype(&getConvertsToNonMovable<true, false>)>);
+STATIC_ASSERT(is_invocable_r_v<NonMovable, decltype(&getConvertsToNonMovable<true, true>)>);
+STATIC_ASSERT(!is_nothrow_invocable_r_v<NonMovable, decltype(&getConvertsToNonMovable<false, false>)>);
+STATIC_ASSERT(!is_nothrow_invocable_r_v<NonMovable, decltype(&getConvertsToNonMovable<false, true>)>);
+STATIC_ASSERT(!is_nothrow_invocable_r_v<NonMovable, decltype(&getConvertsToNonMovable<true, false>)>);
+STATIC_ASSERT(is_nothrow_invocable_r_v<NonMovable, decltype(&getConvertsToNonMovable<true, true>)>);
+#endif // TRANSITION, VSO-1026729
 #endif // _HAS_CXX17
 
 

--- a/tests/std/tests/VSO_0105317_expression_sfinae/test.cpp
+++ b/tests/std/tests/VSO_0105317_expression_sfinae/test.cpp
@@ -19,14 +19,16 @@ using namespace std;
 #if _HAS_CXX17
 template <typename Void, typename Callable, typename... Args>
 struct HasInvokeResultT : false_type {
-
     STATIC_ASSERT(!is_invocable_v<Callable, Args...>);
+    STATIC_ASSERT(!is_nothrow_invocable_v<Callable, Args...>);
+    STATIC_ASSERT(!is_invocable_r_v<void, Callable, Args...>);
+    STATIC_ASSERT(!is_nothrow_invocable_r_v<void, Callable, Args...>);
 };
 
 template <typename Callable, typename... Args>
 struct HasInvokeResultT<void_t<invoke_result_t<Callable, Args...>>, Callable, Args...> : true_type {
-
     STATIC_ASSERT(is_invocable_v<Callable, Args...>);
+    STATIC_ASSERT(is_invocable_r_v<void, Callable, Args...>);
 };
 
 template <typename A>
@@ -584,6 +586,12 @@ STATIC_ASSERT(is_nothrow_invocable_r_v<long, Kitty, int>);
 STATIC_ASSERT(is_invocable_r_v<long, Kitty, int, int>);
 STATIC_ASSERT(!is_nothrow_invocable_r_v<long, Kitty, int, int>);
 
+// When the return type is void, does the invocation throw?
+STATIC_ASSERT(is_invocable_r_v<void, Kitty, int>);
+STATIC_ASSERT(is_nothrow_invocable_r_v<void, Kitty, int>);
+STATIC_ASSERT(is_invocable_r_v<void, Kitty, int, int>);
+STATIC_ASSERT(!is_nothrow_invocable_r_v<void, Kitty, int, int>);
+
 struct Puppy {
     explicit Puppy(int);
     Puppy(long) noexcept;
@@ -606,7 +614,7 @@ STATIC_ASSERT(is_invocable_r_v<Zebra, Kitty, int>);
 STATIC_ASSERT(!is_nothrow_invocable_r_v<Zebra, Kitty, int>);
 
 #if defined(__clang__) || defined(__EDG__) // TRANSITION, VSO-1026729
-// Defend against regression of VSO-963790, in which is_invocable_r mis-handles non-movable return types
+// Defend against regression of VSO-963790, in which is_invocable_r mishandles non-movable return types
 struct NonMovable {
     NonMovable(NonMovable&&)      = delete;
     NonMovable(const NonMovable&) = delete;


### PR DESCRIPTION
...and `is_invocable_r_v`, as required to be able to initialize `std::function<non_movable_type(args...)>` (see DevCom-676429). This
fixes DevCom-676429 for Clang, but not MSVC due to a guaranteed copy elision bug VSO-1026729.
