### PR TITLE
<filesystem>: create_directories() throw for empty paths

### DIFF
--- a/stl/inc/filesystem
+++ b/stl/inc/filesystem
@@ -3751,7 +3751,8 @@ namespace filesystem {
     // FUNCTION create_directories
     inline bool create_directories(const path& _Path, error_code& _Ec) {
         if (_Path.empty()) {
-            _Throw_fs_error("create_directories", _Make_ec(__std_win_error::_Invalid_parameter), _Path);
+            _Ec = _Make_ec(__std_win_error::_Path_not_found);
+            return false;
         }
 
         _Ec.clear(); // for exception safety

--- a/stl/inc/filesystem
+++ b/stl/inc/filesystem
@@ -3750,6 +3750,10 @@ namespace filesystem {
 
     // FUNCTION create_directories
     inline bool create_directories(const path& _Path, error_code& _Ec) {
+        if (_Path.empty()) {
+            _Throw_fs_error("create_directories", _Make_ec(__std_win_error::_Invalid_parameter), _Path);
+        }
+
         _Ec.clear(); // for exception safety
         const wstring& _Text = _Path.native();
         wstring _Tmp;

--- a/tests/std/tests/P0218R1_filesystem/test.cpp
+++ b/tests/std/tests/P0218R1_filesystem/test.cpp
@@ -3570,6 +3570,7 @@ void test_temp_directory_path() {
 void test_create_directory() {
     const test_temp_directory tempDir("create_directory"sv);
     const path p = tempDir.directoryPath / L"__std.c++17.filesystem.create_directory"sv;
+    const path emptyPath{};
 
     // test happy
     {
@@ -3605,6 +3606,17 @@ void test_create_directory() {
             EXPECT(bad(ec));
 
             EXPECT(throws_filesystem_error([&] { create_directory(nonexistent); }, "create_directory", nonexistent));
+        }
+    }
+
+    // test empty path
+    {
+        try {
+            // create_directory should throw for empty paths
+            create_directories(emptyPath);
+            assert(false);
+        } catch (const filesystem_error&) {
+            assert(true);
         }
     }
 

--- a/tests/std/tests/P0218R1_filesystem/test.cpp
+++ b/tests/std/tests/P0218R1_filesystem/test.cpp
@@ -3570,7 +3570,6 @@ void test_temp_directory_path() {
 void test_create_directory() {
     const test_temp_directory tempDir("create_directory"sv);
     const path p = tempDir.directoryPath / L"__std.c++17.filesystem.create_directory"sv;
-    const path emptyPath{};
 
     // test happy
     {
@@ -3606,17 +3605,6 @@ void test_create_directory() {
             EXPECT(bad(ec));
 
             EXPECT(throws_filesystem_error([&] { create_directory(nonexistent); }, "create_directory", nonexistent));
-        }
-    }
-
-    // test empty path
-    {
-        try {
-            // create_directory should throw for empty paths
-            create_directories(emptyPath);
-            assert(false);
-        } catch (const filesystem_error&) {
-            assert(true);
         }
     }
 
@@ -3680,6 +3668,11 @@ void test_create_dirs_and_remove_all() {
     remove_all(badPath); // we ignore invalid paths as in remove
     remove_all(badPath, ec);
     EXPECT(good(ec));
+
+    // test GH-1283 create_directories() should throw for empty paths
+    EXPECT(throws_filesystem_error([] { create_directories(path{}); }, "create_directories", path{}));
+    EXPECT(create_directories(path{}, ec) == false);
+    EXPECT(bad(ec));
 
     // test that normalization isn't done first
     auto dots = r / L"a/../b/../c"sv;


### PR DESCRIPTION
Fixes #1283 