### PR TITLE
Status Chart: Post-CppCon update

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This branch generates the STL's [Status Chart][].
 
 # Getting Started: Repo
 
-1. Install [Node.js][] 14.10.0 or newer.
+1. Install [Node.js][] 14.11.0 or newer.
     + You can accept all of the installer's default options.
 2. Open a new Command Prompt.
     + You can run `node --version` to verify that Node.js was successfully installed.

--- a/daily_table.js
+++ b/daily_table.js
@@ -373,5 +373,15 @@ const daily_table = [
     { date: '2020-09-06', merged: 65.09, pr: 26, cxx20: 23, lwg: 1, issue: 297, bug: 95, avg_age: 72.63, avg_wait: 52.91, sum_age: 62.95, sum_wait: 45.85, },
     { date: '2020-09-07', merged: 62.62, pr: 27, cxx20: 23, lwg: 1, issue: 298, bug: 96, avg_age: 70.91, avg_wait: 51.91, sum_age: 63.82, sum_wait: 46.72, },
     { date: '2020-09-08', merged: 60.31, pr: 28, cxx20: 23, lwg: 1, issue: 298, bug: 96, avg_age: 69.35, avg_wait: 51.04, sum_age: 64.73, sum_wait: 47.63, },
+    { date: '2020-09-09', merged: 58.96, pr: 29, cxx20: 23, lwg: 1, issue: 299, bug: 97, avg_age: 67.67, avg_wait: 49.39, sum_age: 65.41, sum_wait: 47.74, },
+    { date: '2020-09-10', merged: 57.67, pr: 31, cxx20: 23, lwg: 1, issue: 299, bug: 97, avg_age: 64.26, avg_wait: 47.16, sum_age: 66.40, sum_wait: 48.73, },
+    { date: '2020-09-11', merged: 55.37, pr: 31, cxx20: 23, lwg: 1, issue: 300, bug: 98, avg_age: 65.26, avg_wait: 48.16, sum_age: 67.43, sum_wait: 49.77, },
+    { date: '2020-09-12', merged: 53.12, pr: 31, cxx20: 23, lwg: 1, issue: 301, bug: 98, avg_age: 66.26, avg_wait: 49.16, sum_age: 68.47, sum_wait: 50.80, },
+    { date: '2020-09-13', merged: 50.97, pr: 31, cxx20: 23, lwg: 1, issue: 301, bug: 98, avg_age: 67.26, avg_wait: 50.16, sum_age: 69.50, sum_wait: 51.83, },
+    { date: '2020-09-14', merged: 49.08, pr: 32, cxx20: 23, lwg: 1, issue: 301, bug: 98, avg_age: 66.13, avg_wait: 49.56, sum_age: 70.54, sum_wait: 52.87, },
+    { date: '2020-09-15', merged: 49.70, pr: 32, cxx20: 23, lwg: 1, issue: 302, bug: 100, avg_age: 66.46, avg_wait: 49.89, sum_age: 70.89, sum_wait: 53.22, },
+    { date: '2020-09-16', merged: 47.25, pr: 33, cxx20: 23, lwg: 1, issue: 303, bug: 101, avg_age: 65.43, avg_wait: 49.33, sum_age: 71.98, sum_wait: 54.26, },
+    { date: '2020-09-17', merged: 44.70, pr: 36, cxx20: 23, lwg: 1, issue: 303, bug: 101, avg_age: 60.95, avg_wait: 44.17, sum_age: 73.15, sum_wait: 53.00, },
+    { date: '2020-09-18', merged: 42.24, pr: 38, cxx20: 23, lwg: 1, issue: 303, bug: 101, avg_age: 58.71, avg_wait: 42.08, sum_age: 74.36, sum_wait: 53.30, },
 ];
 // Generated file - DO NOT EDIT manually!

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,19 +5,19 @@
   "requires": true,
   "dependencies": {
     "@octokit/endpoint": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.5.tgz",
-      "integrity": "sha512-70K5u6zd45ItOny6aHQAsea8HHQjlQq85yqOMe+Aj8dkhN2qSJ9T+Q3YjUjEYfPRBcuUWNgMn62DQnP/4LAIiQ==",
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.6.tgz",
+      "integrity": "sha512-7Cc8olaCoL/mtquB7j/HTbPM+sY6Ebr4k2X2y4JoXpVKQ7r5xB4iGQE0IoO58wIPsUk4AzoT65AMEpymSbWTgQ==",
       "requires": {
         "@octokit/types": "^5.0.0",
-        "is-plain-object": "^4.0.0",
+        "is-plain-object": "^5.0.0",
         "universal-user-agent": "^6.0.0"
       }
     },
     "@octokit/graphql": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.5.4.tgz",
-      "integrity": "sha512-ITpZ+dQc0cXAW1FmDkHJJM+8Lb6anUnin0VB5hLBilnYVdLC0ICFU/KIvT7OXfW9S81DE3U4Vx2EypDG1OYaPA==",
+      "version": "4.5.6",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.5.6.tgz",
+      "integrity": "sha512-Rry+unqKTa3svswT2ZAuqenpLrzJd+JTv89LTeVa5UM/5OX8o4KTkPL7/1ABq4f/ZkELb0XEK/2IEoYwykcLXg==",
       "requires": {
         "@octokit/request": "^5.3.0",
         "@octokit/types": "^5.0.0",
@@ -25,15 +25,15 @@
       }
     },
     "@octokit/request": {
-      "version": "5.4.7",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.7.tgz",
-      "integrity": "sha512-FN22xUDP0i0uF38YMbOfx6TotpcENP5W8yJM1e/LieGXn6IoRxDMnBf7tx5RKSW4xuUZ/1P04NFZy5iY3Rax1A==",
+      "version": "5.4.8",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.8.tgz",
+      "integrity": "sha512-mWbxjsARJzAq5xp+ZrQfotc+MHFz3/Am2qATJwflv4PZ1TjhgIJnr60PCVdZT9Z/tl+uPXooaVgeviy1KkDlLQ==",
       "requires": {
         "@octokit/endpoint": "^6.0.1",
         "@octokit/request-error": "^2.0.0",
         "@octokit/types": "^5.0.0",
         "deprecation": "^2.0.0",
-        "is-plain-object": "^4.0.0",
+        "is-plain-object": "^5.0.0",
         "node-fetch": "^2.3.0",
         "once": "^1.4.0",
         "universal-user-agent": "^6.0.0"
@@ -50,17 +50,17 @@
       }
     },
     "@octokit/types": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-5.4.0.tgz",
-      "integrity": "sha512-D/uotqF69M50OIlwMqgyIg9PuLT2daOiBAYF0P40I2ekFA2ESwwBY5dxZe/UhXdPvIbNKDzuZmQrO7rMpuFbcg==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-5.4.1.tgz",
+      "integrity": "sha512-OlMlSySBJoJ6uozkr/i03nO5dlYQyE05vmQNZhAh9MyO4DPBP88QlwsDVLmVjIMFssvIZB6WO0ctIGMRG+xsJQ==",
       "requires": {
         "@types/node": ">= 8"
       }
     },
     "@types/node": {
-      "version": "14.0.27",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.27.tgz",
-      "integrity": "sha512-kVrqXhbclHNHGu9ztnAwSncIgJv/FaxmzXJvGXNdcCpV1b8u1/Mi6z6m0vwy0LzKeXFTPLH0NzwmoJ3fNCIq0g=="
+      "version": "14.10.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.10.1.tgz",
+      "integrity": "sha512-aYNbO+FZ/3KGeQCEkNhHFRIzBOUgc7QvcVNKXbfnhDkSfwUv91JsQQa10rDgKSTSLkXZ1UIyPe4FJJNVgw1xWQ=="
     },
     "ansi-regex": {
       "version": "5.0.0",
@@ -102,9 +102,9 @@
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
     },
     "is-plain-object": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-4.1.1.tgz",
-      "integrity": "sha512-5Aw8LLVsDlZsETVMhoMXzqsXwQqr/0vlnBYzIXJbYo2F4yYlhLHs+Ez7Bod7IIQKWkJbJfxrWD7pA1Dw1TKrwA=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
     },
     "luxon": {
       "version": "1.25.0",
@@ -112,9 +112,9 @@
       "integrity": "sha512-hEgLurSH8kQRjY6i4YLey+mcKVAWXbDNlZRmM6AgWDJ1cY3atl8Ztf5wEY7VBReFbmGnwQPz7KYJblL8B2k0jQ=="
     },
     "node-fetch": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "once": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/microsoft/STL/tree/gh-pages#readme",
   "dependencies": {
-    "@octokit/graphql": "^4.5.4",
+    "@octokit/graphql": "^4.5.6",
     "cli-progress": "^3.8.2",
     "dotenv": "^8.2.0",
     "luxon": "^1.25.0"

--- a/weekly_table.js
+++ b/weekly_table.js
@@ -170,4 +170,6 @@ const weekly_table = [
     { date: '2020-08-21', vso: 153, libcxx: 534 },
     { date: '2020-08-28', vso: 142, libcxx: 533 },
     { date: '2020-09-04', vso: 145, libcxx: 539 },
+    { date: '2020-09-11', vso: 145, libcxx: 539 },
+    { date: '2020-09-18', vso: 146, libcxx: 538 },
 ];


### PR DESCRIPTION
This shows how PR throughput has decreased during CppCon, as expected :scream_cat:

Node.js has received a security update (that doesn't affect us); I've updated the README's stated version accordingly.

Live Preview: [stephantlavavej.github.io/STL/](https://stephantlavavej.github.io/STL/)
===