### PR TITLE
_Node_handle: destroy with value_type allocator

### DIFF
--- a/stl/inc/xnode_handle.h
+++ b/stl/inc/xnode_handle.h
@@ -80,21 +80,21 @@ private:
     aligned_union_t<0, _Alloc> _Alloc_storage; // Invariant: contains a live _Alloc iff _Ptr != nullptr
 
     void _Clear() noexcept { // destroy any contained node and return to the empty state
-        if (_Ptr) {
+        if (_Ptr != nullptr) {
             _Alloc& _Al = _Getal();
             _Alnode _Node_alloc{_Al};
-            _Alnode_traits::destroy(_Node_alloc, _STD addressof(_Ptr->_Myval));
+            _Alty_traits::destroy(_Al, _STD addressof(_Ptr->_Myval));
             _Node::_Freenode0(_Node_alloc, _Ptr);
             _Destroy_in_place(_Al);
             _Ptr = nullptr;
         }
     }
 
-    _Node_handle(const _Nodeptr _My_ptr, const _Alloc& _My_alloc) noexcept
-        : _Ptr{_My_ptr} { // Initialize a _Node_handle that holds the specified node
-                          // pre: _My_ptr != nullptr
-                          // pre: _Alloc can release _Ptr
-        _Construct_in_place(_Getal(), _My_alloc);
+    _Node_handle(const _Nodeptr _Ptr_, const _Alloc& _Al) noexcept
+        : _Ptr{_Ptr_} { // Initialize a _Node_handle that holds the specified node
+                        // pre: _Alloc can release _Ptr
+        _STL_INTERNAL_CHECK(_Ptr_ != nullptr);
+        _Construct_in_place(_Getal(), _Al);
     }
 
 public:
@@ -105,7 +105,7 @@ public:
     }
 
     _Node_handle(_Node_handle&& _That) noexcept : _Ptr{_That._Ptr} { // steal node and allocator (if any) from _That
-        if (_Ptr) {
+        if (_Ptr != nullptr) {
             _That._Ptr       = nullptr;
             _Alloc& _That_al = _That._Getal();
             _Construct_in_place(_Getal(), _STD move(_That_al));
@@ -115,8 +115,8 @@ public:
 
     _Node_handle& operator=(_Node_handle&& _That) noexcept /* strengthened */ {
         // steal state from _That
-        if (!_Ptr) {
-            if (_That._Ptr) {
+        if (_Ptr == nullptr) {
+            if (_That._Ptr != nullptr) {
                 _Alloc& _That_al = _That._Getal();
                 _Construct_in_place(_Getal(), _STD move(_That_al));
                 _Destroy_in_place(_That_al);
@@ -126,14 +126,14 @@ public:
             return *this;
         }
 
-        if (!_That._Ptr || this == _STD addressof(_That)) {
+        if (_That._Ptr == nullptr || this == _STD addressof(_That)) {
             _Clear();
             return *this;
         }
 
         _Alloc& _Al = _Getal();
         _Alnode _Node_alloc{_Al};
-        _Alnode_traits::destroy(_Node_alloc, _STD addressof(_Ptr->_Myval));
+        _Alty_traits::destroy(_Al, _STD addressof(_Ptr->_Myval));
         _Alnode_traits::deallocate(_Node_alloc, _Ptr, 1);
 
         _Alloc& _That_al = _That._Getal();
@@ -148,15 +148,16 @@ public:
         return _Ptr;
     }
 
-    _Alloc& _Getal() noexcept { // pre: !empty()
+    _Alloc& _Getal() noexcept {
         return reinterpret_cast<_Alloc&>(_Alloc_storage);
     }
-    const _Alloc& _Getal() const noexcept { // pre: !empty()
+    const _Alloc& _Getal() const noexcept {
+        _STL_INTERNAL_CHECK(!empty());
         return reinterpret_cast<const _Alloc&>(_Alloc_storage);
     }
 
     _NODISCARD allocator_type get_allocator() const noexcept /* strengthened */ {
-        // pre: !empty()
+        _STL_INTERNAL_CHECK(!empty());
         return _Getal();
     }
 
@@ -169,14 +170,14 @@ public:
     }
 
     _Nodeptr _Release() noexcept { // extract the node from *this
-                                   // pre: !empty()
+        _STL_INTERNAL_CHECK(!empty());
         _Destroy_in_place(_Getal());
         return _STD exchange(_Ptr, nullptr);
     }
 
     void swap(_Node_handle& _That) noexcept /* strengthened */ {
-        if (_Ptr) {
-            if (_That._Ptr) {
+        if (_Ptr != nullptr) {
+            if (_That._Ptr != nullptr) {
                 _Pocs(_Getal(), _That._Getal());
             } else {
                 _Alloc& _Al = _Getal();
@@ -184,7 +185,7 @@ public:
                 _Destroy_in_place(_Al);
             }
         } else {
-            if (!_That._Ptr) {
+            if (_That._Ptr == nullptr) {
                 return;
             }
 
@@ -200,8 +201,8 @@ public:
 
     static _Node_handle _Make(const _Nodeptr _Ptr, const allocator_type& _Al) {
         // initialize a _Node_handle that holds _Ptr and _Al
-        // pre: _Ptr != nullptr
         // pre: _Al can release _Ptr
+        _STL_INTERNAL_CHECK(_Ptr != nullptr);
         return _Node_handle{_Ptr, _Al};
     }
 };

--- a/stl/inc/xnode_handle.h
+++ b/stl/inc/xnode_handle.h
@@ -82,8 +82,8 @@ private:
     void _Clear() noexcept { // destroy any contained node and return to the empty state
         if (_Ptr != nullptr) {
             _Alloc& _Al = _Getal();
-            _Alnode _Node_alloc{_Al};
             _Alty_traits::destroy(_Al, _STD addressof(_Ptr->_Myval));
+            _Alnode _Node_alloc{_Al};
             _Node::_Freenode0(_Node_alloc, _Ptr);
             _Destroy_in_place(_Al);
             _Ptr = nullptr;
@@ -132,8 +132,8 @@ public:
         }
 
         _Alloc& _Al = _Getal();
-        _Alnode _Node_alloc{_Al};
         _Alty_traits::destroy(_Al, _STD addressof(_Ptr->_Myval));
+        _Alnode _Node_alloc{_Al};
         _Alnode_traits::deallocate(_Node_alloc, _Ptr, 1);
 
         _Alloc& _That_al = _That._Getal();

--- a/tests/std/tests/P0083R3_splicing_maps_and_sets/test.cpp
+++ b/tests/std/tests/P0083R3_splicing_maps_and_sets/test.cpp
@@ -502,7 +502,7 @@ void test_set() {
     {
         using S = Set<int, std::less<>, tracked_allocator<int>>;
         allocation_guard guard{true};
-        S s{{0, 1}};
+        S s{0, 1};
         allocation_allowed = false;
 
         auto nh1 = test_extract(s, 42, 0);
@@ -611,7 +611,7 @@ void test_unordered_set() {
     {
         using S = Set<int, std::hash<int>, std::equal_to<>, tracked_allocator<int>>;
         allocation_guard guard{true};
-        S s{{0, 1}};
+        S s{0, 1};
         allocation_allowed = false;
 
         auto nh1 = test_extract(s, 42, 0);
@@ -662,11 +662,12 @@ void test_gh1309() {
     // Guard against regression of GH-1309, in which node handles were incorrectly destroying the user value with a node
     // allocator rather than a value_type allocator as the Standard requires.
 
+    allocation_guard guard{true};
+
     {
         using A  = tracked_allocator<std::pair<int const, char>>;
         using M  = std::map<int, char, std::less<>, A>;
-        using NH = decltype(std::declval<M&>().extract(42));
-        allocation_guard guard{true};
+        using NH = M::node_type;
         NH nh1;
         NH nh2;
         {
@@ -682,8 +683,7 @@ void test_gh1309() {
     {
         using A  = tracked_allocator<std::pair<int const, char>>;
         using M  = std::multimap<int, char, std::less<>, A>;
-        using NH = decltype(std::declval<M&>().extract(42));
-        allocation_guard guard{true};
+        using NH = M::node_type;
         NH nh1;
         NH nh2;
         {
@@ -698,12 +698,11 @@ void test_gh1309() {
 
     {
         using S  = std::set<int, std::less<>, tracked_allocator<int>>;
-        using NH = decltype(std::declval<S&>().extract(42));
-        allocation_guard guard{true};
+        using NH = S::node_type;
         NH nh1;
         NH nh2;
         {
-            S s{{0, 1}};
+            S s{0, 1};
             nh1 = s.extract(0);
             nh2 = s.extract(s.begin());
         }
@@ -714,12 +713,11 @@ void test_gh1309() {
 
     {
         using S  = std::multiset<int, std::less<>, tracked_allocator<int>>;
-        using NH = decltype(std::declval<S&>().extract(42));
-        allocation_guard guard{true};
+        using NH = S::node_type;
         NH nh1;
         NH nh2;
         {
-            S s{{0, 0}};
+            S s{0, 0};
             nh1 = s.extract(0);
             nh2 = s.extract(s.begin());
         }
@@ -731,8 +729,7 @@ void test_gh1309() {
     {
         using A  = tracked_allocator<std::pair<int const, char>>;
         using M  = std::unordered_map<int, char, std::hash<int>, std::equal_to<>, A>;
-        using NH = decltype(std::declval<M&>().extract(42));
-        allocation_guard guard{true};
+        using NH = M::node_type;
         NH nh1;
         NH nh2;
         {
@@ -748,8 +745,7 @@ void test_gh1309() {
     {
         using A  = tracked_allocator<std::pair<int const, char>>;
         using M  = std::unordered_multimap<int, char, std::hash<int>, std::equal_to<>, A>;
-        using NH = decltype(std::declval<M&>().extract(42));
-        allocation_guard guard{true};
+        using NH = M::node_type;
         NH nh1;
         NH nh2;
         {
@@ -764,12 +760,11 @@ void test_gh1309() {
 
     {
         using S  = std::unordered_set<int, std::hash<int>, std::equal_to<>, tracked_allocator<int>>;
-        using NH = decltype(std::declval<S&>().extract(42));
-        allocation_guard guard{true};
+        using NH = S::node_type;
         NH nh1;
         NH nh2;
         {
-            S s{{0, 1}};
+            S s{0, 1};
             nh1 = s.extract(0);
             nh2 = s.extract(s.begin());
         }
@@ -780,12 +775,11 @@ void test_gh1309() {
 
     {
         using S  = std::unordered_multiset<int, std::hash<int>, std::equal_to<>, tracked_allocator<int>>;
-        using NH = decltype(std::declval<S&>().extract(42));
-        allocation_guard guard{true};
+        using NH = S::node_type;
         NH nh1;
         NH nh2;
         {
-            S s{{0, 0}};
+            S s{0, 0};
             nh1 = s.extract(0);
             nh2 = s.extract(s.begin());
         }


### PR DESCRIPTION
Drive-by cleanup:
* explicitly compare pointers  with `nullptr` in preference to `if (ptr)` and `if (!ptr)`
* `_STL_INTERNAL_CHECK` checkable preconditions
* Use `constinit` when available to verify `constexpr` constructor

Fixes #1309.
