### PR TITLE
Fix for ambiguous symbol on sort function call.

### DIFF
--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -78,7 +78,7 @@ _NODISCARD constexpr _Ty(min)(initializer_list<_Ty>); // implemented in <algorit
 // FUNCTION TEMPLATE iter_swap (from <algorithm>)
 template <class _FwdIt1, class _FwdIt2>
 _CONSTEXPR20 void iter_swap(_FwdIt1 _Left, _FwdIt2 _Right) { // swap *_Left and *_Right
-    swap(*_Left, *_Right);
+    _STD swap(*_Left, *_Right);
 }
 
 // FUNCTION TEMPLATE swap


### PR DESCRIPTION
Fix for bug where there is an ambiguous call to `swap`. To reproduce, implement a `swap` method in another namespace (not `std`), then sort a container.  To fix, I added a designation that `swap` inside the sort should use the std::swap function.