### PR TITLE
Minimal changes to support constexpr allocation in MSVC

### DIFF
--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -284,26 +284,86 @@ _NoThrowFwdIt uninitialized_fill_n(_NoThrowFwdIt _First, const _Diff _Count_raw,
 }
 #endif // _HAS_IF_CONSTEXPR
 
+// FUNCTION TEMPLATE construct_at
 #if _HAS_CXX20
 template <class _Ty, class... _Types>
-auto construct_at(_Ty* const _Location, _Types&&... _Args) noexcept(noexcept(::new (const_cast<void*>(
-    static_cast<const volatile void*>(_Location))) _Ty(_STD forward<_Types>(_Args)...))) // strengthened
+_CONSTEXPR20_DYNALLOC auto construct_at(_Ty* const _Location, _Types&&... _Args) noexcept(
+    noexcept(::new (const_cast<void*>(static_cast<const volatile void*>(_Location)))
+            _Ty(_STD forward<_Types>(_Args)...))) // strengthened
     -> decltype(
         ::new (const_cast<void*>(static_cast<const volatile void*>(_Location))) _Ty(_STD forward<_Types>(_Args)...)) {
     return ::new (const_cast<void*>(static_cast<const volatile void*>(_Location))) _Ty(_STD forward<_Types>(_Args)...);
 }
 
+#ifdef __cpp_lib_concepts
 namespace ranges {
-    using _STD construct_at;
+    // VARIABLE ranges::construct_at
+    class _Construct_at_fn : private _Not_quite_object {
+    public:
+        using _Not_quite_object::_Not_quite_object;
+
+        // clang-format off
+        template <class _Ty, class... _Types>
+        _CONSTEXPR20_DYNALLOC _Ty* operator()(_Ty* _Location, _Types&&... _Args) const
+            noexcept(noexcept(::new (const_cast<void*>(static_cast<const volatile void*>(_Location)))
+                    _Ty(_STD forward<_Types>(_Args)...))) // strengthened
+            requires requires {
+                ::new (const_cast<void*>(static_cast<const volatile void*>(_Location)))
+                    _Ty(_STD forward<_Types>(_Args)...);
+            } {
+            // clang-format on
+            return ::new (const_cast<void*>(static_cast<const volatile void*>(_Location)))
+                _Ty(_STD forward<_Types>(_Args)...);
+        }
+    };
+
+    inline constexpr _Construct_at_fn construct_at{_Not_quite_object::_Construct_tag{}};
 } // namespace ranges
+#endif // __cpp_lib_concepts
 #endif // _HAS_CXX20
 
 #if _HAS_CXX17
 // FUNCTION TEMPLATE destroy_at
 template <class _Ty>
-void destroy_at(_Ty* const _Location) noexcept /* strengthened */ {
-    _Location->~_Ty();
+_CONSTEXPR20_DYNALLOC void destroy_at(_Ty* const _Location) noexcept /* strengthened */ {
+#if _HAS_CXX20
+    if constexpr (is_array_v<_Ty>) {
+        _Destroy_range(_STD begin(*_Location), _STD end(*_Location));
+    } else
+#endif // _HAS_CXX20
+    {
+        _Location->~_Ty();
+    }
 }
+
+#ifdef __cpp_lib_concepts
+namespace ranges {
+    // VARIABLE ranges::destroy_at
+    // clang-format off
+    template <_No_throw_input_iterator _It, _No_throw_sentinel_for<_It> _Se>
+        requires destructible<iter_value_t<_It>>
+    _NODISCARD _CONSTEXPR20_DYNALLOC _It _Destroy_unchecked(_It _First, _Se _Last) noexcept;
+    // clang-format on
+
+    class _Destroy_at_fn : private _Not_quite_object {
+    public:
+        using _Not_quite_object::_Not_quite_object;
+
+        // clang-format off
+        template <destructible _Ty>
+        _CONSTEXPR20_DYNALLOC void operator()(_Ty* const _Location) const noexcept {
+            // clang-format on
+            if constexpr (is_array_v<_Ty>) {
+                (void) _RANGES _Destroy_unchecked(_RANGES begin(*_Location), _RANGES end(*_Location));
+            } else {
+                _Location->~_Ty();
+            }
+        }
+    };
+
+    inline constexpr _Destroy_at_fn destroy_at{_Not_quite_object::_Construct_tag{}};
+} // namespace ranges
+#endif // __cpp_lib_concepts
 
 // FUNCTION TEMPLATE destroy
 template <class _NoThrowFwdIt>
@@ -311,6 +371,51 @@ void destroy(const _NoThrowFwdIt _First, const _NoThrowFwdIt _Last) { // destroy
     _Adl_verify_range(_First, _Last);
     _Destroy_range(_Get_unwrapped(_First), _Get_unwrapped(_Last));
 }
+
+#ifdef __cpp_lib_concepts
+namespace ranges {
+    // VARIABLE ranges::destroy
+    // clang-format off
+    template <_No_throw_input_iterator _It, _No_throw_sentinel_for<_It> _Se>
+        requires destructible<iter_value_t<_It>>
+    _NODISCARD _CONSTEXPR20_DYNALLOC _It _Destroy_unchecked(_It _First, const _Se _Last) noexcept {
+        // clang-format on
+        for (; _First != _Last; ++_First) {
+            _RANGES destroy_at(_STD addressof(*_First));
+        }
+
+        return _First;
+    }
+
+    class _Destroy_fn : private _Not_quite_object {
+    public:
+        using _Not_quite_object::_Not_quite_object;
+
+        // clang-format off
+        template <_No_throw_input_iterator _It, _No_throw_sentinel_for<_It> _Se>
+            requires destructible<iter_value_t<_It>>
+        /* _CONSTEXPR20_DYNALLOC */ _It operator()(_It _First, _Se _Last) const noexcept {
+            // clang-format on
+            _Adl_verify_range(_First, _Last);
+            _Seek_wrapped(_First,
+                _RANGES _Destroy_unchecked(_Get_unwrapped(_STD move(_First)), _Get_unwrapped(_STD move(_Last))));
+            return _First;
+        }
+
+        // clang-format off
+        template <_No_throw_input_range _Rng>
+            requires destructible<range_value_t<_Rng>>
+        /* _CONSTEXPR20_DYNALLOC */ borrowed_iterator_t<_Rng> operator()(_Rng&& _Range) const noexcept {
+            // clang-format on
+            auto _First = _RANGES begin(_Range);
+            _Seek_wrapped(_First, _RANGES _Destroy_unchecked(_Get_unwrapped(_STD move(_First)), _Uend(_Range)));
+            return _First;
+        }
+    };
+
+    inline constexpr _Destroy_fn destroy{_Not_quite_object::_Construct_tag{}};
+} // namespace ranges
+#endif // __cpp_lib_concepts
 
 // FUNCTION TEMPLATE destroy_n
 template <class _NoThrowFwdIt, class _Diff>
@@ -334,6 +439,36 @@ _NoThrowFwdIt destroy_n(_NoThrowFwdIt _First, const _Diff _Count_raw) {
 
     return _First;
 }
+
+#ifdef __cpp_lib_concepts
+namespace ranges {
+    // VARIABLE ranges::destroy_n
+    class _Destroy_n_fn : private _Not_quite_object {
+    public:
+        using _Not_quite_object::_Not_quite_object;
+
+        // clang-format off
+        template <_No_throw_input_iterator _It>
+            requires destructible<iter_value_t<_It>>
+        /* _CONSTEXPR20_DYNALLOC */ _It operator()(_It _First, const iter_difference_t<_It> _Count) const noexcept {
+            // clang-format on
+            if (_Count <= 0) {
+                return _First;
+            }
+
+            auto _UFirst = _Get_unwrapped_n(_STD move(_First));
+            for (; _Count-- > 0; ++_UFirst) {
+                _RANGES destroy_at(_STD addressof(*_UFirst));
+            }
+
+            _Seek_wrapped(_First, _STD move(_UFirst));
+            return _First;
+        }
+    };
+
+    inline constexpr _Destroy_n_fn destroy_n{_Not_quite_object::_Construct_tag{}};
+} // namespace ranges
+#endif // __cpp_lib_concepts
 
 // FUNCTION TEMPLATE uninitialized_default_construct
 template <class _NoThrowFwdIt>

--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -304,13 +304,12 @@ namespace ranges {
 
         // clang-format off
         template <class _Ty, class... _Types>
+            requires requires(void* _Void_ptr, _Types&&... _Args) {
+                ::new (_Void_ptr) _Ty(static_cast<_Types&&>(_Args)...);
+            }
         _CONSTEXPR20_DYNALLOC _Ty* operator()(_Ty* _Location, _Types&&... _Args) const
             noexcept(noexcept(::new (const_cast<void*>(static_cast<const volatile void*>(_Location)))
-                    _Ty(_STD forward<_Types>(_Args)...))) // strengthened
-            requires requires {
-                ::new (const_cast<void*>(static_cast<const volatile void*>(_Location)))
-                    _Ty(_STD forward<_Types>(_Args)...);
-            } {
+                    _Ty(_STD forward<_Types>(_Args)...))) /* strengthened */ {
             // clang-format on
             return ::new (const_cast<void*>(static_cast<const volatile void*>(_Location)))
                 _Ty(_STD forward<_Types>(_Args)...);
@@ -349,10 +348,8 @@ namespace ranges {
     public:
         using _Not_quite_object::_Not_quite_object;
 
-        // clang-format off
         template <destructible _Ty>
         _CONSTEXPR20_DYNALLOC void operator()(_Ty* const _Location) const noexcept {
-            // clang-format on
             if constexpr (is_array_v<_Ty>) {
                 (void) _RANGES _Destroy_unchecked(_RANGES begin(*_Location), _RANGES end(*_Location));
             } else {
@@ -456,9 +453,15 @@ namespace ranges {
                 return _First;
             }
 
-            auto _UFirst = _Get_unwrapped_n(_STD move(_First));
-            for (; _Count-- > 0; ++_UFirst) {
-                _RANGES destroy_at(_STD addressof(*_UFirst));
+            auto _UFirst = _Get_unwrapped_n(_STD move(_First), _Count);
+            if constexpr (is_trivially_destructible_v<iter_value_t<_It>>) {
+                _RANGES advance(_UFirst, _Count);
+            } else {
+                do {
+                    _RANGES destroy_at(_STD addressof(*_UFirst));
+                    ++_UFirst;
+                    --_Count;
+                } while (_Count > 0);
             }
 
             _Seek_wrapped(_First, _STD move(_UFirst));

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -257,10 +257,10 @@ _Pointer _Refancy(_Pointer _Ptr) noexcept {
 
 // FUNCTION TEMPLATE _Destroy_in_place
 template <class _NoThrowFwdIt, class _NoThrowSentinel>
-/* _CONSTEXPR20_DYNALLOC */ void _Destroy_range(_NoThrowFwdIt _First, _NoThrowSentinel _Last) noexcept;
+_CONSTEXPR20_DYNALLOC void _Destroy_range(_NoThrowFwdIt _First, _NoThrowSentinel _Last) noexcept;
 
 template <class _Ty>
-/* _CONSTEXPR20_DYNALLOC */ void _Destroy_in_place(_Ty& _Obj) noexcept {
+_CONSTEXPR20_DYNALLOC void _Destroy_in_place(_Ty& _Obj) noexcept {
 #if _HAS_IF_CONSTEXPR
     if constexpr (is_array_v<_Ty>) {
         _Destroy_range(_Obj, _Obj + extent_v<_Ty>);
@@ -964,7 +964,7 @@ template <class _Alloc>
 
 // FUNCTION TEMPLATE _Destroy_range
 template <class _NoThrowFwdIt, class _NoThrowSentinel>
-/* _CONSTEXPR20_DYNALLOC */ void _Destroy_range(_NoThrowFwdIt _First, const _NoThrowSentinel _Last) noexcept {
+_CONSTEXPR20_DYNALLOC void _Destroy_range(_NoThrowFwdIt _First, const _NoThrowSentinel _Last) noexcept {
     // note that this is an optimization for debug mode codegen; in release mode the BE removes all of this
     if _CONSTEXPR_IF (!is_trivially_destructible_v<_Iter_value_t<_NoThrowFwdIt>>) {
         for (; _First != _Last; ++_First) {

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -951,8 +951,7 @@ void _Pocs(_Alloc& _Left, _Alloc& _Right) noexcept {
 
 // FUNCTION TEMPLATE _Destroy_range WITH ALLOC
 template <class _Alloc>
-/* _CONSTEXPR20_DYNALLOC */ void _Destroy_range(
-    _Alloc_ptr_t<_Alloc> _First, const _Alloc_ptr_t<_Alloc> _Last, _Alloc& _Al) noexcept {
+void _Destroy_range(_Alloc_ptr_t<_Alloc> _First, const _Alloc_ptr_t<_Alloc> _Last, _Alloc& _Al) noexcept {
     // note that this is an optimization for debug mode codegen; in release mode the BE removes all of this
     using _Ty = typename _Alloc::value_type;
     if _CONSTEXPR_IF (!conjunction_v<is_trivially_destructible<_Ty>, _Uses_default_destroy<_Alloc, _Ty*>>) {
@@ -1425,18 +1424,18 @@ struct _Uninitialized_backout { // struct to undo partially constructed ranges i
     _Uninitialized_backout(const _Uninitialized_backout&) = delete;
     _Uninitialized_backout& operator=(const _Uninitialized_backout&) = delete;
 
-    /* _CONSTEXPR20_DYNALLOC */ ~_Uninitialized_backout() {
+    ~_Uninitialized_backout() {
         _Destroy_range(_First, _Last);
     }
 
     template <class... _Types>
-    /* _CONSTEXPR20_DYNALLOC */ void _Emplace_back(_Types&&... _Vals) {
+    void _Emplace_back(_Types&&... _Vals) {
         // construct a new element at *_Last and increment
         _Construct_in_place(*_Last, _STD forward<_Types>(_Vals)...);
         ++_Last;
     }
 
-    /* _CONSTEXPR20_DYNALLOC */ _NoThrowFwdIt _Release() { // suppress any exception handling backout and return _Last
+    _NoThrowFwdIt _Release() { // suppress any exception handling backout and return _Last
         _First = _Last;
         return _Last;
     }

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -541,6 +541,13 @@
 #define _CONSTEXPR20 inline
 #endif // ^^^ inline (not constexpr) in C++17 and earlier ^^^
 
+// Functions that became constexpr in C++20 via P0784R7
+#if _HAS_CXX20 && defined(__cpp_constexpr_dynamic_alloc)
+#define _CONSTEXPR20_DYNALLOC constexpr
+#else
+#define _CONSTEXPR20_DYNALLOC inline
+#endif
+
 // P0607R0 Inline Variables For The STL
 #if _HAS_CXX17
 #define _INLINE_VAR inline

--- a/tests/std/tests/P0784R7_library_support_for_more_constexpr_containers/test.cpp
+++ b/tests/std/tests/P0784R7_library_support_for_more_constexpr_containers/test.cpp
@@ -9,6 +9,9 @@
 #include <type_traits>
 #include <utility>
 
+#pragma warning(disable : 4582) // '%s': constructor is not implicitly called
+#pragma warning(disable : 4583) // '%s': destructor is not implicitly called
+
 using namespace std;
 
 #ifdef __cpp_lib_concepts

--- a/tests/std/tests/P0784R7_library_support_for_more_constexpr_containers/test.cpp
+++ b/tests/std/tests/P0784R7_library_support_for_more_constexpr_containers/test.cpp
@@ -11,6 +11,45 @@
 
 using namespace std;
 
+#ifdef __cpp_lib_concepts
+template <class Ty, class... Types>
+concept can_std_construct_at = requires(Ty* ptr, Types&&... args) {
+    construct_at(ptr, forward<Types>(args)...);
+};
+
+template <class Ty, class... Types>
+concept can_ranges_construct_at = requires(Ty* ptr, Types&&... args) {
+    ranges::construct_at(ptr, forward<Types>(args)...);
+};
+
+template <class Ty>
+concept can_ranges_destroy_at = requires(Ty* ptr) {
+    ranges::destroy_at(ptr);
+};
+
+template <class Ty, class... Types>
+inline constexpr bool can_construct_at = [] {
+    constexpr bool result = can_std_construct_at<Ty, Types...>;
+    static_assert(can_ranges_construct_at<Ty, Types...> == result);
+    return result;
+}();
+
+template <class T, class... Args>
+constexpr bool construct_at_noexcept() {
+    constexpr bool result = noexcept(construct_at(declval<T*>(), declval<Args>()...));
+    static_assert(noexcept(ranges::construct_at(declval<T*>(), declval<Args>()...)) == result);
+    return result;
+}
+
+template <class T>
+constexpr bool destroy_at_noexcept() {
+    static_assert(noexcept(destroy_at(declval<T*>())));
+    if constexpr (can_ranges_destroy_at<T>) {
+        static_assert(noexcept(ranges::destroy_at(declval<T*>())));
+    }
+    return true;
+}
+#else // ^^^ Concepts and Ranges / No Concepts or Ranges vvv
 template <class Void, class Ty, class... Types>
 inline constexpr bool can_construct_at_impl = false;
 
@@ -20,6 +59,17 @@ inline constexpr bool
 
 template <class Ty, class... Types>
 inline constexpr bool can_construct_at = can_construct_at_impl<void, Ty, Types...>;
+
+template <class T, class... Args>
+constexpr bool construct_at_noexcept() {
+    return noexcept(construct_at(declval<T*>(), declval<Args>()...));
+}
+
+template <class T>
+constexpr bool destroy_at_noexcept() {
+    return noexcept(destroy_at(declval<T*>()));
+}
+#endif // __cpp_lib_concepts
 
 static_assert(can_construct_at<int>);
 static_assert(can_construct_at<const int>);
@@ -70,52 +120,156 @@ static_assert(!can_construct_at<string, X>);
 // The following static_asserts test our strengthening of noexcept
 
 #ifndef __EDG__ // TRANSITION, VSO-1075296
-static_assert(noexcept(construct_at(declval<int*>(), 42)));
-static_assert(noexcept(construct_at(declval<const int*>(), 42)));
-static_assert(noexcept(construct_at(declval<volatile int*>(), 42)));
-static_assert(noexcept(construct_at(declval<const volatile int*>(), 42)));
+static_assert(construct_at_noexcept<int, int>());
+static_assert(construct_at_noexcept<const int, int>());
+static_assert(construct_at_noexcept<volatile int, int>());
+static_assert(construct_at_noexcept<const volatile int, int>());
 #endif // __EDG__
 
-static_assert(!noexcept(construct_at(declval<string*>(), "hello")));
-static_assert(!noexcept(construct_at(declval<const string*>(), "hello")));
-static_assert(!noexcept(construct_at(declval<volatile string*>(), "hello")));
-static_assert(!noexcept(construct_at(declval<const volatile string*>(), "hello")));
+static_assert(!construct_at_noexcept<string, const char (&)[6]>());
+static_assert(!construct_at_noexcept<const string, const char (&)[6]>());
+static_assert(!construct_at_noexcept<volatile string, const char (&)[6]>());
+static_assert(!construct_at_noexcept<const volatile string, const char (&)[6]>());
 
-static_assert(noexcept(destroy_at(declval<int*>())));
-static_assert(noexcept(destroy_at(declval<string*>())));
-static_assert(noexcept(destroy_at(declval<const int*>())));
-static_assert(noexcept(destroy_at(declval<const string*>())));
-static_assert(noexcept(destroy_at(declval<volatile int*>())));
-static_assert(noexcept(destroy_at(declval<volatile string*>())));
-static_assert(noexcept(destroy_at(declval<const volatile int*>())));
-static_assert(noexcept(destroy_at(declval<const volatile string*>())));
+static_assert(destroy_at_noexcept<int>());
+static_assert(destroy_at_noexcept<string>());
+static_assert(destroy_at_noexcept<const int>());
+static_assert(destroy_at_noexcept<const string>());
+static_assert(destroy_at_noexcept<volatile int>());
+static_assert(destroy_at_noexcept<volatile string>());
+static_assert(destroy_at_noexcept<const volatile int>());
+static_assert(destroy_at_noexcept<const volatile string>());
+
+#if _HAS_CXX20
+static_assert(destroy_at_noexcept<int[42]>());
+static_assert(destroy_at_noexcept<string[42]>());
+static_assert(destroy_at_noexcept<const int[42]>());
+static_assert(destroy_at_noexcept<const string[42]>());
+static_assert(destroy_at_noexcept<volatile int[42]>());
+static_assert(destroy_at_noexcept<volatile string[42]>());
+static_assert(destroy_at_noexcept<const volatile int[42]>());
+static_assert(destroy_at_noexcept<const volatile string[42]>());
+#endif // _HAS_CXX20
 
 struct throwing_dtor {
     ~throwing_dtor() noexcept(false) {}
 };
 
-static_assert(noexcept(destroy_at(declval<throwing_dtor*>())));
+static_assert(destroy_at_noexcept<throwing_dtor>());
+#if _HAS_CXX20
+static_assert(destroy_at_noexcept<throwing_dtor[42]>());
+#endif // _HAS_CXX20
+
+#ifdef __cpp_lib_concepts
+static_assert(!can_ranges_destroy_at<throwing_dtor>);
+static_assert(!can_ranges_destroy_at<throwing_dtor[42]>);
+#endif // __cpp_lib_concepts
 
 template <class Ty>
 void test_runtime(const Ty& val) {
     alignas(Ty) unsigned char storage[sizeof(Ty)];
-    memset(storage, 42, sizeof(Ty));
     const auto asPtrTy = reinterpret_cast<Ty*>(&storage);
+    memset(storage, 42, sizeof(Ty));
     assert(asPtrTy == construct_at(asPtrTy, val));
     assert(*asPtrTy == val);
     destroy_at(asPtrTy);
 
+#ifdef __cpp_lib_concepts
     // test ranges:
+    memset(storage, 42, sizeof(Ty));
     assert(asPtrTy == ranges::construct_at(asPtrTy, val));
     assert(*asPtrTy == val);
-    destroy_at(asPtrTy);
+    ranges::destroy_at(asPtrTy);
+#endif // __cpp_lib_concepts
 
     // test voidify:
     const auto asCv = static_cast<const volatile Ty*>(asPtrTy);
+    memset(storage, 42, sizeof(Ty));
     assert(asPtrTy == construct_at(asCv, val));
     assert(const_cast<const Ty&>(*asCv) == val);
     destroy_at(asCv);
+
+#ifdef __cpp_lib_concepts
+    memset(storage, 42, sizeof(Ty));
+    assert(asPtrTy == ranges::construct_at(asCv, val));
+    assert(const_cast<const Ty&>(*asCv) == val);
+    ranges::destroy_at(asCv);
+#endif // __cpp_lib_concepts
 }
+
+template <class T>
+void test_array(const T& val) {
+    constexpr int N = 42;
+    (void) val;
+
+#if _HAS_CXX20
+    alignas(T) unsigned char storage[sizeof(T) * N];
+    using U        = conditional_t<is_scalar_v<T>, const volatile T, T>;
+    const auto ptr = reinterpret_cast<U*>(storage);
+
+    for (auto i = 0; i < N; ++i) {
+        construct_at(ptr + i, val);
+    }
+
+    destroy_at(reinterpret_cast<U(*)[N]>(ptr));
+
+#ifdef __cpp_lib_concepts
+    for (auto i = 0; i < N; ++i) {
+        ranges::construct_at(ptr + i, val);
+    }
+
+#if defined(__clang__) || defined(__EDG__) // TRANSITION, VSO-1049320
+    ranges::destroy_at(reinterpret_cast<U(*)[N]>(ptr));
+#else // ^^^ no workaround / workaround vvv
+    ranges::destroy_at(reinterpret_cast<T(*)[N]>(const_cast<T*>(ptr)));
+#endif // TRANSITION, VSO-1049320
+#endif // __cpp_lib_concepts
+#endif // _HAS_CXX20
+}
+
+#if _HAS_CXX20 && defined(__cpp_constexpr_dynamic_alloc)
+template <class T>
+struct storage_for {
+    union {
+        T object;
+    };
+
+    constexpr storage_for() noexcept {}
+    constexpr ~storage_for() {}
+};
+
+constexpr void test_compiletime() {
+    {
+        storage_for<int> s;
+        construct_at(&s.object, 42);
+        assert(s.object == 42);
+        destroy_at(&s.object);
+
+        ranges::construct_at(&s.object, 1729);
+        assert(s.object == 1729);
+        ranges::destroy_at(&s.object);
+    }
+
+    struct nontrivial {
+        constexpr nontrivial(int i = 42) noexcept : x{i} {}
+        constexpr ~nontrivial() {}
+
+        int x = 42;
+    };
+
+    {
+        storage_for<nontrivial> s;
+        construct_at(&s.object, 42);
+        assert(s.object.x == 42);
+        destroy_at(&s.object);
+
+        ranges::construct_at(&s.object, 1729);
+        assert(s.object.x == 1729);
+        ranges::destroy_at(&s.object);
+    }
+}
+static_assert((test_compiletime(), true));
+#endif // _HAS_CXX20 && defined(__cpp_constexpr_dynamic_alloc)
 
 int main() {
     test_runtime(1234);
@@ -127,5 +281,14 @@ int main() {
         const auto ptr = reinterpret_cast<indestructible*>(storage);
         construct_at(ptr);
         ptr->destroy();
+
+#ifdef __cpp_lib_concepts
+        ranges::construct_at(ptr);
+        ptr->destroy();
+#endif // __cpp_lib_concepts
     }
+
+    test_array(1234);
+    test_array(string("hello world"));
+    test_array(string("hello to some really long world that certainly doesn't fit in SSO"));
 }

--- a/tests/std/tests/P0896R4_ranges_alg_uninitialized_move/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_uninitialized_move/test.cpp
@@ -80,21 +80,14 @@ struct holder {
     }
 };
 
-template <class R>
-void not_ranges_destroy(R&& r) { // TRANSITION, ranges::destroy
-    for (auto& e : r) {
-        destroy_at(&e);
-    }
-}
-
 struct instantiator {
     static constexpr int expected_output[] = {13, 55, 12345};
     static constexpr int expected_input[]  = {-1, -1, -1};
 
     template <ranges::input_range R, ranges::forward_range W>
     static void call() {
-        using ranges::uninitialized_move, ranges::uninitialized_move_result, ranges::equal, ranges::equal_to,
-            ranges::iterator_t;
+        using ranges::uninitialized_move, ranges::uninitialized_move_result, ranges::destroy, ranges::equal,
+            ranges::equal_to, ranges::iterator_t;
 
         { // Validate range overload
             int_wrapper input[3] = {13, 55, 12345};
@@ -111,7 +104,7 @@ struct instantiator {
             assert(result.out == wrapped_output.end());
             assert(equal(wrapped_output, expected_output, equal_to{}, &int_wrapper::val));
             assert(equal(input, expected_input, equal_to{}, &int_wrapper::val));
-            not_ranges_destroy(wrapped_output);
+            destroy(wrapped_output);
             assert(int_wrapper::constructions == 3);
             assert(int_wrapper::destructions == 3);
         }
@@ -131,7 +124,7 @@ struct instantiator {
             assert(result.out == wrapped_output.end());
             assert(equal(wrapped_output, expected_output, equal_to{}, &int_wrapper::val));
             assert(equal(input, expected_input, equal_to{}, &int_wrapper::val));
-            not_ranges_destroy(wrapped_output);
+            destroy(wrapped_output);
             assert(int_wrapper::constructions == 3);
             assert(int_wrapper::destructions == 3);
         }


### PR DESCRIPTION
* Define `_CONSTEXPR20_DYNALLOC` macro to `constexpr` when the compiler defines `__cpp_constexpr_dynamic_alloc` and `inline` otherwise.
* Implement and test `ranges::construct_at` and `ranges::destroy_at`, mark them (and `std` flavors) `_CONSTEXPR20_DYNALLOC`.
* Implement `ranges::destroy` and `ranges::destroy_n` which share machinery with `ranges::destroy_at` with minimal test coverage. (More to follow.)

[This is a dual of internal MSVC-PR-275909.]

Partially implements #37 and #39.
