### PR TITLE
mark `memory_resource` dtor as `default` to enable constant destruction of `memory_resource`

### DIFF
--- a/stl/inc/xpolymorphic_allocator.h
+++ b/stl/inc/xpolymorphic_allocator.h
@@ -140,7 +140,7 @@ namespace pmr {
     // CLASS memory_resource
     class __declspec(novtable) memory_resource {
     public:
-        virtual ~memory_resource() noexcept {}
+        virtual ~memory_resource() noexcept = default;
 
         _NODISCARD __declspec(allocator) void* allocate(_CRT_GUARDOVERFLOW const size_t _Bytes,
             const size_t _Align = alignof(max_align_t)) { // allocate _Bytes bytes of memory with alignment _Align


### PR DESCRIPTION
[This is a dual of internal [MSVC-PR-276531](https://devdiv.visualstudio.com/DevDiv/_git/msvc/pullrequest/276531)]