### PR TITLE
<locale>: std::ctype<char>::blank should return true only for space and tab

### DIFF
--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -298,11 +298,13 @@ public:
     }
 
     bool isctype(_Elem _Ch, char_class_type _Fx) const {
-        if (_Fx != static_cast<char_class_type>(-1)) {
-            return _Getctype()->is(_Fx, _Ch);
-        } else {
+        if (_Fx == static_cast<char_class_type>(_Ch_blank)) {
+            return _Getctype()->is(_SP, _Ch) || _Getctype()->is(_CN, _Ch);
+        } else if (_Fx == static_cast<char_class_type>(-1)) {
             return _Ch == '_' // assumes L'_' == '_'
                    || _Getctype()->is(_Ch_alnum, _Ch);
+        } else {
+            return _Getctype()->is(_Fx, _Ch);
         }
     }
 

--- a/stl/inc/xlocale
+++ b/stl/inc/xlocale
@@ -2611,6 +2611,9 @@ public:
     using char_type = _Elem;
 
     bool __CLR_OR_THIS_CALL is(mask _Maskval, _Elem _Ch) const { // test if element fits any mask classifications
+        if (_Maskval == blank) {
+            return _isblank_l(_Ch, _get_current_locale()) != 0;
+        }
         return (_Ctype._Table[static_cast<unsigned char>(_Ch)] & _Maskval) != 0;
     }
 


### PR DESCRIPTION
Fixes #1121 
It's a very simple and probably a temporary solution to this issue. The actual fix should be in the UCRT(I think) and it also needs some modifications in character classification flags. According to [This Table](http://www.cplusplus.com/reference/cctype/),  `_Ctype._Table[static_cast<unsigned char>('\t')]` should be 104 (0x68). But now it returns 40 (0x28) just like the other white-space control codes ('\f','\v','\n','\r').  So, I think there is no direct way to distinguish them without touching the UCRT.
In this fix, I've tried to treat blank as a special case. But some test cases [failed](https://github.com/microsoft/STL/runs/1162703066) in Regex test cases. So, I've made some modifications to the `<regex>` too.