### PR TITLE
XFG: made _Execute_once XFG-compatible.

### DIFF
--- a/stl/src/xonce.cpp
+++ b/stl/src/xonce.cpp
@@ -13,8 +13,17 @@ _CRTIMP2_PURE int __CLRCALL_PURE_OR_CDECL _Execute_once(
     once_flag& _Flag, _Execute_once_fp_t _Callback, void* _Pv) noexcept { // wrap Win32 InitOnceExecuteOnce()
     static_assert(sizeof(_Flag._Opaque) == sizeof(INIT_ONCE), "invalid size");
 
+    // _Execute_once_fp_t and PINIT_ONCE_FN differ in type signature, therefore
+    // we introduce _Xfg_trampoline which has PINIT_ONCE_FN's type signature and
+    // calls into _Callback as an _Execute_once_fp_t for XFG compatibility.
+
+    PINIT_ONCE_FN _Xfg_trampoline = [](PINIT_ONCE _InitOnce, PVOID _Parameter, PVOID* _Context) {
+        const auto _Callback = reinterpret_cast<_Execute_once_fp_t>(_Context);
+        return static_cast<BOOL>(_Callback(_InitOnce, _Parameter, nullptr));
+    };
+
     return __crtInitOnceExecuteOnce(
-        reinterpret_cast<PINIT_ONCE>(&_Flag._Opaque), reinterpret_cast<PINIT_ONCE_FN>(_Callback), _Pv, nullptr);
+        reinterpret_cast<PINIT_ONCE>(&_Flag._Opaque), _Xfg_trampoline, _Pv, reinterpret_cast<PVOID*>(_Callback));
 }
 
 [[noreturn]] _CRTIMP2_PURE void __CLRCALL_PURE_OR_CDECL


### PR DESCRIPTION
<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->

_Execute_once_fp_t and PINIT_ONCE_FN differ in type signature, therefore we introduce _Xfg_trampoline which has PINIT_ONCE_FN's type signature and calls into _Callback as an _Execute_once_fp_t for XFG compatibility.