### PR TITLE
<iomanip>: std::get_time should not fail when format is longer than the stream

### DIFF
--- a/stl/inc/xloctime
+++ b/stl/inc/xloctime
@@ -134,7 +134,7 @@ public:
                 _First = do_get(_First, _Last, _Iosbase, _State, _Pt, _Specifier, _Modifier); // convert a single field
 
                 if (_State != ios_base::goodbit) {
-                    // Failed to convert the field. Do not proceed to the next fields. Return with failed _State.
+                    // _State is fail, eof or bad. Do not proceed to the next fields. Return with current _State.
                     break;
                 }
             }

--- a/stl/inc/xloctime
+++ b/stl/inc/xloctime
@@ -134,7 +134,7 @@ public:
                 _First = do_get(_First, _Last, _Iosbase, _State, _Pt, _Specifier, _Modifier); // convert a single field
 
                 if (_State != ios_base::goodbit) {
-                    // _State is fail, eof or bad. Do not proceed to the next fields. Return with current _State.
+                    // _State is fail, eof, or bad. Do not proceed to the next fields. Return with current _State.
                     break;
                 }
             }

--- a/tests/std/tests/Dev11_0836436_get_time/test.cpp
+++ b/tests/std/tests/Dev11_0836436_get_time/test.cpp
@@ -309,6 +309,47 @@ void test_990695() {
             iss >> get_time(&t, fmt.c_str());
             assert(iss.fail());
         }
+
+
+        {
+            // GH-1071 should not fail when format is longer than the stream
+            istringstream iss("2020");
+            ios_base::iostate err = Bit;
+            tm t{};
+            const string fmt("%Y%m%d");
+            use_facet<time_get<char>>(iss.getloc())
+                .get(Iter(iss.rdbuf()), Iter(), iss, err, &t, fmt.c_str(), fmt.c_str() + fmt.size());
+            assert(err == ios_base::eofbit);
+            assert(t.tm_mon == 0);
+            assert(t.tm_mday == 0);
+            assert(t.tm_year == 120);
+        }
+
+        {
+            // GH-1071 should not fail when format is longer than the stream
+            istringstream iss("2020-sep");
+            tm t = {};
+            const string fmt("%Y-%b-%d");
+            iss >> get_time(&t, fmt.c_str());
+            assert(!iss.fail());
+            assert(iss.eof());
+            assert(t.tm_mon == 8);
+            assert(t.tm_mday == 0);
+            assert(t.tm_year == 120);
+        }
+
+        {
+            // GH-1071 should not fail when format is longer than the stream
+            istringstream iss("Current time is 3:8");
+            tm t = {};
+            const string fmt("Current time is %H:%M:%S");
+            iss >> get_time(&t, fmt.c_str());
+            assert(!iss.fail());
+            assert(iss.eof());
+            assert(t.tm_hour == 3);
+            assert(t.tm_min == 8);
+            assert(t.tm_sec == 0);
+        }
     }
 }
 

--- a/tests/std/tests/Dev11_0836436_get_time/test.cpp
+++ b/tests/std/tests/Dev11_0836436_get_time/test.cpp
@@ -310,7 +310,6 @@ void test_990695() {
             assert(iss.fail());
         }
 
-
         {
             // GH-1071 should not fail when format is longer than the stream
             istringstream iss("2020");


### PR DESCRIPTION
Closes #1071 
The issue has been fixed indirectly by #1168 
I've added some tests to cover the issue.
