### PR TITLE
Support upstream EDG in the std test suite

### DIFF
--- a/tests/utils/stl/compiler.py
+++ b/tests/utils/stl/compiler.py
@@ -22,7 +22,7 @@ class CXXCompiler:
     CM_Analyze = 4
 
     def __init__(self, path, flags=None, compile_flags=None,
-                 link_flags=None, compile_env=None):
+                 link_flags=None, compile_env=None, edg_drop=None):
         self.path = path
         if path is not None:
             self.name = os.path.basename(path).split('.')[0]
@@ -34,6 +34,7 @@ class CXXCompiler:
         self.link_flags = link_flags or []
 
         self.compile_env = compile_env
+        self.edg_drop = edg_drop
 
     def _basicCmd(self, source_files: List[Path], out: Path,
                   mode=CM_Default, flags=[], compile_flags=[], link_flags=[],

--- a/tests/utils/stl/test/config.py
+++ b/tests/utils/stl/test/config.py
@@ -298,6 +298,10 @@ class Configuration:
 
         self.default_compiler.compile_env = self.config.environment
 
+        env_var = 'STL_EDG_DROP'
+        if env_var in os.environ and os.environ[env_var] is not None:
+            self.default_compiler.edg_drop = os.environ[env_var]
+
     # TRANSITION: Investigate using SSHExecutor for ARM
     def configure_executors(self):
         self.build_executor = LocalExecutor()

--- a/tests/utils/stl/test/tests.py
+++ b/tests/utils/stl/test/tests.py
@@ -34,6 +34,7 @@ class STLTest(Test):
 
         self._configure_cxx(lit_config, envlst_entry, default_cxx)
 
+        use_edg = False
         for flag in chain(self.cxx.flags, self.cxx.compile_flags):
             if flag[1:] == 'clr:pure':
                 self.requires.append('clr_pure') # TRANSITION, GH-798
@@ -41,6 +42,10 @@ class STLTest(Test):
                 self.requires.append('clr') # TRANSITION, GH-797
             elif flag[1:] == 'BE':
                 self.requires.append('edg') # available for x86, see config.py
+                use_edg = True
+
+        if not use_edg and self.cxx.edg_drop is not None:
+            self.skipped = True
 
     def getOutputDir(self):
         return Path(os.path.join(
@@ -142,7 +147,7 @@ class STLTest(Test):
                 compile_flags.append('-m32')
 
         self.cxx = CXXCompiler(cxx, flags, compile_flags, link_flags,
-                               default_cxx.compile_env)
+                               default_cxx.compile_env, default_cxx.edg_drop)
 
     # This is partially lifted from lit's Test class. The changes here are to
     # handle skipped tests, our env.lst format, and different naming schemes.


### PR DESCRIPTION
When the `STL_EDG_DROP` environment variable contains the path of an EDG
frontend binary, lit forwards `cl /BE` invocations to that binary, and
skips all remaining test cases.