### PR TITLE
<vector>: prevent move ctor initializes members twice

### DIFF
--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -3281,10 +3281,10 @@ public:
     }
 
     pointer release() noexcept {
-        return _STD exchange(_Mypair._Myval2, pointer());
+        return _STD exchange(_Mypair._Myval2, nullptr);
     }
 
-    void reset(pointer _Ptr = pointer()) noexcept {
+    void reset(pointer _Ptr = nullptr) noexcept {
         pointer _Old = _STD exchange(_Mypair._Myval2, _Ptr);
         if (_Old) {
             _Mypair._Get_first()(_Old);
@@ -3413,7 +3413,7 @@ public:
     }
 
     pointer release() noexcept {
-        return _STD exchange(_Mypair._Myval2, pointer());
+        return _STD exchange(_Mypair._Myval2, nullptr);
     }
 
     template <class _Uty, class = _Enable_ctor_reset<_Uty, false_type>>

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -372,7 +372,10 @@ public:
     using reference       = value_type&;
     using const_reference = const value_type&;
 
-    _Vector_val() noexcept : _Myfirst(), _Mylast(), _Myend() {}
+    _Vector_val() noexcept : _Myfirst{}, _Mylast{}, _Myend{} {}
+
+    _Vector_val(pointer _First, pointer _Last, pointer _End) noexcept
+        : _Myfirst{_First}, _Mylast{_Last}, _Myend{_End} {}
 
     void _Swap_val(_Vector_val& _Right) noexcept {
         this->_Swap_proxy_and_iterators(_Right);
@@ -578,9 +581,15 @@ private:
     }
 
 public:
-    vector(vector&& _Right) noexcept : _Mypair(_One_then_variadic_args_t{}, _STD move(_Right._Getal())) {
+    vector(vector&& _Right) noexcept
+        : _Mypair(_One_then_variadic_args_t{}, _STD move(_Right._Getal()), _Right._Mypair._Myval2._Myfirst,
+            _Right._Mypair._Myval2._Mylast, _Right._Mypair._Myval2._Myend) {
         _Mypair._Myval2._Alloc_proxy(_GET_PROXY_ALLOCATOR(_Alty, _Getal()));
-        _Move_construct(_Right, true_type{});
+        _Mypair._Myval2._Swap_proxy_and_iterators(_Right._Mypair._Myval2);
+
+        _Right._Mypair._Myval2._Myfirst = pointer();
+        _Right._Mypair._Myval2._Mylast  = pointer();
+        _Right._Mypair._Myval2._Myend   = pointer();
     }
 
     vector(vector&& _Right, const _Alloc& _Al) noexcept(_Alty_traits::is_always_equal::value) // strengthened

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -582,14 +582,12 @@ private:
 
 public:
     vector(vector&& _Right) noexcept
-        : _Mypair(_One_then_variadic_args_t{}, _STD move(_Right._Getal()), _Right._Mypair._Myval2._Myfirst,
-            _Right._Mypair._Myval2._Mylast, _Right._Mypair._Myval2._Myend) {
+        : _Mypair(_One_then_variadic_args_t{}, _STD move(_Right._Getal()),
+            _STD exchange(_Right._Mypair._Myval2._Myfirst, nullptr),
+            _STD exchange(_Right._Mypair._Myval2._Mylast, nullptr),
+            _STD exchange(_Right._Mypair._Myval2._Myend, nullptr)) {
         _Mypair._Myval2._Alloc_proxy(_GET_PROXY_ALLOCATOR(_Alty, _Getal()));
         _Mypair._Myval2._Swap_proxy_and_iterators(_Right._Mypair._Myval2);
-
-        _Right._Mypair._Myval2._Myfirst = nullptr;
-        _Right._Mypair._Myval2._Mylast  = nullptr;
-        _Right._Mypair._Myval2._Myend   = nullptr;
     }
 
     vector(vector&& _Right, const _Alloc& _Al) noexcept(_Alty_traits::is_always_equal::value) // strengthened

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -390,9 +390,9 @@ public:
         _Mylast  = _Right._Mylast;
         _Myend   = _Right._Myend;
 
-        _Right._Myfirst = pointer();
-        _Right._Mylast  = pointer();
-        _Right._Myend   = pointer();
+        _Right._Myfirst = nullptr;
+        _Right._Mylast  = nullptr;
+        _Right._Myend   = nullptr;
     }
 
     pointer _Myfirst; // pointer to beginning of array
@@ -587,9 +587,9 @@ public:
         _Mypair._Myval2._Alloc_proxy(_GET_PROXY_ALLOCATOR(_Alty, _Getal()));
         _Mypair._Myval2._Swap_proxy_and_iterators(_Right._Mypair._Myval2);
 
-        _Right._Mypair._Myval2._Myfirst = pointer();
-        _Right._Mypair._Myval2._Mylast  = pointer();
-        _Right._Mypair._Myval2._Myend   = pointer();
+        _Right._Mypair._Myval2._Myfirst = nullptr;
+        _Right._Mypair._Myval2._Mylast  = nullptr;
+        _Right._Mypair._Myval2._Myend   = nullptr;
     }
 
     vector(vector&& _Right, const _Alloc& _Al) noexcept(_Alty_traits::is_always_equal::value) // strengthened
@@ -1301,9 +1301,9 @@ private:
             _Destroy(_Myfirst, _Mylast);
             _Getal().deallocate(_Myfirst, static_cast<size_type>(_Myend - _Myfirst));
 
-            _Myfirst = pointer();
-            _Mylast  = pointer();
-            _Myend   = pointer();
+            _Myfirst = nullptr;
+            _Mylast  = nullptr;
+            _Myend   = nullptr;
         }
 
         _Buy_raw(_Newcapacity);
@@ -1704,9 +1704,9 @@ private:
             _Destroy(_Myfirst, _Mylast);
             _Getal().deallocate(_Myfirst, static_cast<size_type>(_Myend - _Myfirst));
 
-            _Myfirst = pointer();
-            _Mylast  = pointer();
-            _Myend   = pointer();
+            _Myfirst = nullptr;
+            _Mylast  = nullptr;
+            _Myend   = nullptr;
         }
     }
 

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -372,10 +372,10 @@ public:
     using reference       = value_type&;
     using const_reference = const value_type&;
 
-    _Vector_val() noexcept : _Myfirst{}, _Mylast{}, _Myend{} {}
+    _Vector_val() noexcept : _Myfirst(), _Mylast(), _Myend() {}
 
     _Vector_val(pointer _First, pointer _Last, pointer _End) noexcept
-        : _Myfirst{_First}, _Mylast{_Last}, _Myend{_End} {}
+        : _Myfirst(_First), _Mylast(_Last), _Myend(_End) {}
 
     void _Swap_val(_Vector_val& _Right) noexcept {
         this->_Swap_proxy_and_iterators(_Right);

--- a/stl/inc/xhash
+++ b/stl/inc/xhash
@@ -319,9 +319,9 @@ struct _Hash_vec {
     void _Tidy() noexcept {
         _Destroy_range(_Mypair._Myval2._Myfirst, _Mypair._Myval2._Mylast);
         _Mypair._Get_first().deallocate(_Mypair._Myval2._Myfirst, size());
-        _Mypair._Myval2._Myfirst = pointer();
-        _Mypair._Myval2._Mylast  = pointer();
-        _Mypair._Myval2._Myend   = pointer();
+        _Mypair._Myval2._Myfirst = nullptr;
+        _Mypair._Myval2._Mylast  = nullptr;
+        _Mypair._Myval2._Myend   = nullptr;
     }
 
     ~_Hash_vec() {
@@ -472,7 +472,7 @@ private:
         _Min_buckets_construct_ptr(const _Min_buckets_construct_ptr&) = delete;
         _NODISCARD pointer _Release(_Unchecked_iterator _Newend) noexcept {
             _STD uninitialized_fill(_Base, _Base + _Min_buckets * 2, _Newend);
-            return _STD exchange(_Base, pointer());
+            return _STD exchange(_Base, nullptr);
         }
         ~_Min_buckets_construct_ptr() {
             if (_Base) {

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -2713,7 +2713,7 @@ private:
         auto& _Right_data = _Right._Mypair._Myval2;
         if (_Right_data._Large_string_engaged()) { // steal buffer
             _Construct_in_place(_My_data._Bx._Ptr, _Right_data._Bx._Ptr);
-            _Right_data._Bx._Ptr = pointer();
+            _Right_data._Bx._Ptr = nullptr;
             _Swap_proxy_and_iterators(_Right);
         } else { // copy small string buffer
             _Traits::copy(_My_data._Bx._Buf, _Right_data._Bx._Buf, _Right_data._Mysize + 1);

--- a/tests/std/tests/Dev10_722102_shared_ptr_nullptr/test.cpp
+++ b/tests/std/tests/Dev10_722102_shared_ptr_nullptr/test.cpp
@@ -4,12 +4,12 @@
 //  Dev10-722102 "STL: Get nullptr overloads"
 // DevDiv-520681 "Faulty implementation of shared_ptr(nullptr_t) constructor"
 
-#include <assert.h>
+#include <cassert>
+#include <cstddef>
+#include <cstdlib>
 #include <functional>
 #include <memory>
 #include <new>
-#include <stddef.h>
-#include <stdlib.h>
 #include <type_traits>
 #include <utility>
 
@@ -159,10 +159,42 @@ namespace unique_ptr_ {
 
     template <class T>
     struct fancy_pointer {
-        T* ptr_;
+        T* ptr_{nullptr};
 
         fancy_pointer() = default;
+
         explicit fancy_pointer(secret_tag, T* ptr) : ptr_{ptr} {}
+
+        fancy_pointer(nullptr_t) {}
+
+        fancy_pointer& operator=(nullptr_t) {
+            ptr_ = nullptr;
+            return *this;
+        }
+
+        friend bool operator==(const fancy_pointer& left, const fancy_pointer& right) {
+            return left.ptr_ == right.ptr_;
+        }
+
+        friend bool operator!=(const fancy_pointer& left, const fancy_pointer& right) {
+            return left.ptr_ != right.ptr_;
+        }
+
+        friend bool operator==(const fancy_pointer& left, nullptr_t) {
+            return left.ptr_ == nullptr;
+        }
+
+        friend bool operator!=(const fancy_pointer& left, nullptr_t) {
+            return left.ptr_ != nullptr;
+        }
+
+        friend bool operator==(nullptr_t, const fancy_pointer& right) {
+            return nullptr == right.ptr_;
+        }
+
+        friend bool operator!=(nullptr_t, const fancy_pointer& right) {
+            return nullptr != right.ptr_;
+        }
 
         operator T*() const {
             return ptr_;


### PR DESCRIPTION
Fixes #1324 