### PR TITLE
cleaning up the MRTDLL macro

### DIFF
--- a/stl/inc/xlocale
+++ b/stl/inc/xlocale
@@ -270,7 +270,6 @@ public:
 
     locale() noexcept : _Ptr(_Init(true)) {}
 
-#if !defined(MRTDLL) || !defined(_CRTBLD)
     locale(const locale& _Loc, const locale& _Other, category _Cat) : _Ptr(_Locimp::_New_Locimp(*_Loc._Ptr)) {
         // construct a locale by copying named facets
         if (_Cat != none) { // worth adding, do it
@@ -345,7 +344,6 @@ public:
         // construct a locale by copying, replacing named facets
         _Construct(_Str, _Cat);
     }
-#endif // !MRTDLL || !_CRTBLD
 
     ~locale() noexcept {
         if (_Ptr) {

--- a/stl/inc/yvals.h
+++ b/stl/inc/yvals.h
@@ -19,17 +19,7 @@ _STL_DISABLE_CLANG_WARNINGS
 #pragma push_macro("new")
 #undef new
 
-#if defined(MRTDLL) && defined(_CRTBLD)
-// process-global is the default for code built with /clr or /clr:oldSyntax.
-// appdomain-global is the default for code built with /clr:pure.
-// Code in MSVCM is built with /clr, but is used by user code built with /clr:pure
-// so it must conform to the expectations of /clr:pure clients.
-// Use __PURE_APPDOMAIN_GLOBAL when a global needs to be appdomain-global for pure
-// clients and process-global for mixed clients.
-#define __PURE_APPDOMAIN_GLOBAL __declspec(appdomain)
-#else
 #define __PURE_APPDOMAIN_GLOBAL
-#endif
 
 // CURRENT DLL NAMES
 #ifndef _CRT_MSVCP_CURRENT
@@ -300,11 +290,7 @@ _STL_DISABLE_CLANG_WARNINGS
 #endif // _CRTIMP2_PURE_IMPORT_UNLESS_CODECVT_ID_SATELLITE
 
 #ifndef _CRTDATA2_IMPORT
-#if defined(MRTDLL) && defined(_CRTBLD)
-#define _CRTDATA2_IMPORT
-#else
 #define _CRTDATA2_IMPORT _CRTIMP2_IMPORT
-#endif
 #endif // _CRTDATA2_IMPORT
 
 // INTEGER PROPERTIES

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -1283,14 +1283,6 @@ compiler option, or define _ALLOW_RTCc_IN_STL to acknowledge that you have recei
 #define _END_EXTERN_C_UNLESS_PURE _END_EXTERN_C
 #endif // _M_CEE_PURE
 
-#if defined(MRTDLL) && !defined(_CRTBLD)
-#error In yvals_core.h, defined(MRTDLL) implies defined(_CRTBLD); !defined(_CRTBLD) implies !defined(MRTDLL)
-#endif // defined(MRTDLL) && !defined(_CRTBLD)
-
-#if defined(MRTDLL) && !defined(_M_CEE_PURE)
-#error In yvals_core.h, defined(MRTDLL) implies defined(_M_CEE_PURE); !defined(_M_CEE_PURE) implies !defined(MRTDLL)
-#endif // defined(MRTDLL) && !defined(_M_CEE_PURE)
-
 #define _STL_WIN32_WINNT_WINXP   0x0501 // _WIN32_WINNT_WINXP from sdkddkver.h
 #define _STL_WIN32_WINNT_VISTA   0x0600 // _WIN32_WINNT_VISTA from sdkddkver.h
 #define _STL_WIN32_WINNT_WIN8    0x0602 // _WIN32_WINNT_WIN8 from sdkddkver.h

--- a/stl/src/clog.cpp
+++ b/stl/src/clog.cpp
@@ -6,11 +6,9 @@
 #include <fstream>
 #include <iostream>
 
-#ifndef MRTDLL
 #pragma warning(disable : 4074)
 #pragma init_seg(compiler)
 static std::_Init_locks initlocks;
-#endif // MRTDLL
 
 _STD_BEGIN
 // OBJECT DECLARATIONS

--- a/stl/src/locale0_implib.cpp
+++ b/stl/src/locale0_implib.cpp
@@ -6,10 +6,6 @@
 #undef CRTDLL2
 #endif
 
-#ifdef MRTDLL
-#undef MRTDLL
-#endif
-
 #define STDCPP_IMPLIB 1
 
 // When building for msvcmrt.lib, inject a dependency to the msvcp DLL.

--- a/stl/src/mexcptptr.cpp
+++ b/stl/src/mexcptptr.cpp
@@ -6,10 +6,6 @@
 #undef CRTDLL
 #endif
 
-#ifdef MRTDLL
-#undef MRTDLL
-#endif
-
 #ifndef _DLL
 #define _DLL
 #endif

--- a/stl/src/nothrow.cpp
+++ b/stl/src/nothrow.cpp
@@ -7,10 +7,6 @@
 #undef CRTDLL2
 #endif
 
-#ifdef MRTDLL
-#undef MRTDLL
-#endif
-
 #include <new>
 _STD_BEGIN
 

--- a/stl/src/xfvalues.cpp
+++ b/stl/src/xfvalues.cpp
@@ -3,12 +3,6 @@
 
 // values used by math functions -- IEEE 754 float version
 
-#if defined(_M_CEE_PURE)
-#if defined(MRTDLL)
-#undef MRTDLL
-#endif
-#endif
-
 #include "xmath.hpp"
 // macros
 #define NBITS (16 + _FOFF)

--- a/stl/src/xgetwctype.cpp
+++ b/stl/src/xgetwctype.cpp
@@ -26,16 +26,4 @@ _CRTIMP2_PURE const wchar_t* __CLRCALL_PURE_OR_CDECL _Getwctypes(const wchar_t* 
     return _Last;
 }
 
-#ifdef MRTDLL
-_CRTIMP2_PURE short __CLRCALL_PURE_OR_CDECL _Getwctype(unsigned short _Ch, const _Ctypevec* _Ctype) {
-    return _Getwctype(static_cast<wchar_t>(_Ch), _Ctype);
-}
-
-_CRTIMP2_PURE const unsigned short* __CLRCALL_PURE_OR_CDECL _Getwctypes(
-    const unsigned short* _First, const unsigned short* _Last, short* _Dest, const _Ctypevec* _Ctype) {
-    return reinterpret_cast<const unsigned short*>(
-        _Getwctypes(reinterpret_cast<const wchar_t*>(_First), reinterpret_cast<const wchar_t*>(_Last), _Dest, _Ctype));
-}
-#endif
-
 _END_EXTERN_C_UNLESS_PURE

--- a/stl/src/xlock.cpp
+++ b/stl/src/xlock.cpp
@@ -20,8 +20,6 @@ constexpr int _Max_lock = 8; // must be power of two
 static _Rmtx mtx[_Max_lock];
 static long init = -1;
 
-#if !defined(MRTDLL)
-
 __thiscall _Init_locks::_Init_locks() noexcept { // initialize locks
     if (InterlockedIncrement(&init) == 0) {
         for (auto& elem : mtx) {
@@ -37,8 +35,6 @@ __thiscall _Init_locks::~_Init_locks() noexcept { // clean up locks
         }
     }
 }
-
-#endif
 
 void __cdecl _Init_locks::_Init_locks_ctor(_Init_locks*) noexcept { // initialize locks
     if (InterlockedIncrement(&init) == 0) {
@@ -57,8 +53,6 @@ void __cdecl _Init_locks::_Init_locks_dtor(_Init_locks*) noexcept { // clean up 
 }
 
 static _Init_locks initlocks;
-
-#if !defined(MRTDLL)
 
 __thiscall _Lockit::_Lockit() noexcept : _Locktype(0) { // lock default mutex
     if (_Locktype == _LOCK_LOCALE) {
@@ -83,8 +77,6 @@ __thiscall _Lockit::~_Lockit() noexcept { // unlock the mutex
         _Mtxunlock(&mtx[_Locktype]);
     }
 }
-
-#endif
 
 void __cdecl _Lockit::_Lockit_ctor(_Lockit*) noexcept { // lock default mutex
     _Mtxlock(&mtx[0]);

--- a/stl/src/xlvalues.cpp
+++ b/stl/src/xlvalues.cpp
@@ -3,12 +3,6 @@
 
 // values used by math functions -- IEEE 754 long version
 
-#if defined(_M_CEE_PURE)
-#if defined(MRTDLL)
-#undef MRTDLL
-#endif
-#endif
-
 #include "xmath.hpp"
 // macros -- 64-bit
 #define NBITS (48 + _DOFF)

--- a/stl/src/xmbtowc.cpp
+++ b/stl/src/xmbtowc.cpp
@@ -152,10 +152,4 @@ _MRTIMP2 _Success_(return >= 0) int __cdecl _Mbrtowc(
     }
 }
 
-#ifdef MRTDLL
-_MRTIMP2 int __cdecl _Mbrtowc(unsigned short* pwc, const char* s, size_t n, mbstate_t* pst, const _Cvtvec* ploc) {
-    return _Mbrtowc(reinterpret_cast<wchar_t*>(pwc), s, n, pst, ploc);
-}
-#endif // MRTDLL
-
 _END_EXTERN_C_UNLESS_PURE

--- a/stl/src/xtowlower.cpp
+++ b/stl/src/xtowlower.cpp
@@ -26,10 +26,4 @@ _CRTIMP2_PURE wchar_t __CLRCALL_PURE_OR_CDECL _Towlower(
     return _Res;
 }
 
-#ifdef MRTDLL
-_CRTIMP2_PURE unsigned short __CLRCALL_PURE_OR_CDECL _Towlower(unsigned short _Ch, const _Ctypevec* _Ctype) {
-    return _Towlower(static_cast<wchar_t>(_Ch), _Ctype);
-}
-#endif
-
 _END_EXTERN_C_UNLESS_PURE

--- a/stl/src/xtowupper.cpp
+++ b/stl/src/xtowupper.cpp
@@ -26,10 +26,4 @@ _CRTIMP2_PURE wchar_t __CLRCALL_PURE_OR_CDECL _Towupper(
     return _Res;
 }
 
-#ifdef MRTDLL
-_CRTIMP2_PURE unsigned short __CLRCALL_PURE_OR_CDECL _Towupper(unsigned short _Ch, const _Ctypevec* _Ctype) {
-    return _Towupper(static_cast<wchar_t>(_Ch), _Ctype);
-}
-#endif
-
 _END_EXTERN_C_UNLESS_PURE

--- a/stl/src/xvalues.cpp
+++ b/stl/src/xvalues.cpp
@@ -3,12 +3,6 @@
 
 // values used by math functions -- IEEE 754 version
 
-#if defined(_M_CEE_PURE)
-#if defined(MRTDLL)
-#undef MRTDLL
-#endif
-#endif
-
 #include "xmath.hpp"
 
 // macros

--- a/stl/src/xwcscoll.cpp
+++ b/stl/src/xwcscoll.cpp
@@ -65,12 +65,4 @@ _CRTIMP2_PURE int __CLRCALL_PURE_OR_CDECL _Wcscoll(
     return ret;
 }
 
-#ifdef MRTDLL
-_CRTIMP2_PURE int __CLRCALL_PURE_OR_CDECL _Wcscoll(const unsigned short* string1, const unsigned short* end1,
-    const unsigned short* string2, const unsigned short* end2, const _Collvec* ploc) {
-    return _Wcscoll(reinterpret_cast<const wchar_t*>(string1), reinterpret_cast<const wchar_t*>(end1),
-        reinterpret_cast<const wchar_t*>(string2), reinterpret_cast<const wchar_t*>(end2), ploc);
-}
-#endif // MRTDLL
-
 _END_EXTERN_C_UNLESS_PURE

--- a/stl/src/xwcsxfrm.cpp
+++ b/stl/src/xwcsxfrm.cpp
@@ -98,12 +98,4 @@ _CRTIMP2_PURE size_t __CLRCALL_PURE_OR_CDECL _Wcsxfrm(_Out_writes_(end1 - string
     return size;
 }
 
-#ifdef MRTDLL
-_CRTIMP2_PURE size_t __CLRCALL_PURE_OR_CDECL _Wcsxfrm(unsigned short* string1, unsigned short* end1,
-    const unsigned short* string2, const unsigned short* end2, const _Collvec* ploc) {
-    return _Wcsxfrm(reinterpret_cast<wchar_t*>(string1), reinterpret_cast<wchar_t*>(end1),
-        reinterpret_cast<const wchar_t*>(string2), reinterpret_cast<const wchar_t*>(end2), ploc);
-}
-#endif // MRTDLL
-
 _END_EXTERN_C_UNLESS_PURE

--- a/stl/src/xwctomb.cpp
+++ b/stl/src/xwctomb.cpp
@@ -69,12 +69,6 @@ _CRTIMP2_PURE _Success_(return != -1) int __CLRCALL_PURE_OR_CDECL
     }
 }
 
-#ifdef MRTDLL
-_CRTIMP2_PURE int __CLRCALL_PURE_OR_CDECL _Wcrtomb(char* s, unsigned short wchar, mbstate_t* pst, const _Cvtvec* ploc) {
-    return _Wcrtomb(s, static_cast<wchar_t>(wchar), pst, ploc);
-}
-#endif // MRTDLL
-
 _CRTIMP2_PURE _Cvtvec __CLRCALL_PURE_OR_CDECL _Getcvt() { // get conversion info for current locale
     _Cvtvec _Cvt = {0};
 

--- a/stl/src/xxxdtent.hpp
+++ b/stl/src/xxxdtent.hpp
@@ -5,9 +5,7 @@
 
 #include "xmath.hpp"
 
-#if !defined(MRTDLL)
 _EXTERN_C
-#endif // defined(MRTDLL)
 
 // macros
 #define ACSIZE 4 // size of extended-precision accumulators
@@ -87,6 +85,5 @@ FTYPE FNAME(Dtento)(FTYPE* xpx, long n, int* perr) { // compute *px * 10**n
     }
     return x;
 }
-#if !defined(MRTDLL)
+
 _END_EXTERN_C
-#endif // !defined(MRTDLL)

--- a/stl/src/xxxprec.hpp
+++ b/stl/src/xxxprec.hpp
@@ -10,9 +10,7 @@
 #pragma warning(push)
 #pragma warning(disable : _STL_DISABLED_WARNINGS)
 
-#if !defined(MRTDLL)
 _EXTERN_C
-#endif // defined(MRTDLL)
 
 #define BIG_EXP   (2 * FMAXEXP) // very large, as exponents go
 #define BITS_WORD (FBITS / 2) // all words same for now
@@ -428,8 +426,7 @@ FTYPE* FNAME(Xp_sqrtx)(FTYPE* p, int n, FTYPE* ptemp4) {
 
     return p;
 }
-#if !defined(MRTDLL)
+
 _END_EXTERN_C
-#endif // !defined(MRTDLL)
 
 #pragma warning(pop)


### PR DESCRIPTION
Closes #185
I've removed all the `MRTDLL` macro usages by assuming that it's not defined by the build system.
I searched the entire solution using Visual Studio and also the entire solution folder using Windows Search Indexer. It seems there is no more usage of this macro.
