### PR TITLE
Update cgmanifest for 16.8

### DIFF
--- a/docs/cgmanifest.json
+++ b/docs/cgmanifest.json
@@ -14,7 +14,7 @@
                 "type": "git",
                 "git": {
                     "repositoryUrl": "https://github.com/microsoft/STL.git",
-                    "commitHash": "81d88bd8e40b2b229776a9602c8bf5f49c128a9b"
+                    "commitHash": "c70b7a830eda523a69934ba949ac700da2c0dfd2"
                 }
             }
         },


### PR DESCRIPTION
c70b7a830eda523a69934ba949ac700da2c0dfd2 corresponds to #1316 "Accept 80-bit `long double` in `<complex>`," which was ported into a late 16.8 preview. This will almost certainly be our last commit for 16.8.

Not that not every preceding commit is in 16.8. This is fine: we need all shipping commits to be covered by the cgmanifest, it's ok to also cover some commits that won't ship until the next release.
