### PR TITLE
_M_ARM64EC cleanups, v5

### DIFF
--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -21,7 +21,7 @@ _STL_DISABLE_CLANG_WARNINGS
 #pragma push_macro("new")
 #undef new
 
-#if (defined(_M_IX86) || defined(_M_X64) && !defined(_M_ARM64EC)) && !defined(_M_CEE_PURE) && !defined(_M_HYBRID)
+#if (defined(_M_IX86) || defined(_M_X64)) && !defined(_M_CEE_PURE) && !defined(_M_HYBRID) && !defined(_M_ARM64EC)
 #define _USE_STD_VECTOR_ALGORITHMS 1
 #else
 #define _USE_STD_VECTOR_ALGORITHMS 0

--- a/stl/msbuild/stl_atomic_wait/stl_atomic_wait.files.settings.targets
+++ b/stl/msbuild/stl_atomic_wait/stl_atomic_wait.files.settings.targets
@@ -28,8 +28,8 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
     <ItemGroup Condition="'$(Arm64X)' == 'true' and '$(TargetNetFx)' != 'true'">
         <!-- Add EC symbols to import lib -->
-        <ImportLib Include="$(ECObjs);" />
-        <Link Include="$(ECObjs);"/>
+        <ImportLib Include="$(ECObjs)" />
+        <Link Include="$(ECObjs)"/>
         <Link Condition="'$(CrtBuildModelIsDll)' == 'true'" Include="
         $(IntermediateOutputDirectoryEC)\dllmain_satellite.obj;
         "/>

--- a/stl/msbuild/stl_base/msvcp.settings.targets
+++ b/stl/msbuild/stl_base/msvcp.settings.targets
@@ -213,7 +213,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
             $(IntermediateOutputDirectoryEC)\xthrow.obj;
             $(IntermediateOutputDirectoryEC)\winapisupp.obj;
             $(IntermediateOutputDirectoryEC)\dllmain.obj;
-            $(IntermediateOutputDirectoryEC)\instances.obj
+            $(IntermediateOutputDirectoryEC)\instances.obj;
        </ECImportLibObjs>
         <!-- OBJs that need to get added to msvcprt[d].lib and msvcprt_base[d].lib. -->
         <!-- They get added to both through msvcprt_base.exp -->
@@ -223,16 +223,16 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
             $(IntermediateOutputDirectoryEC)\nothrow.obj;
             $(IntermediateOutputDirectoryEC)\parallel_algorithms.obj;
             $(IntermediateOutputDirectoryEC)\sharedmutex.obj;
-            $(IntermediateOutputDirectoryEC)\vector_algorithms.obj
+            $(IntermediateOutputDirectoryEC)\vector_algorithms.obj;
         </ECLibObjs>
     </PropertyGroup>
 
     <!-- OBJs for msvcprt_base.lib -->
     <ItemGroup Condition="'$(Arm64X)' == 'true'">
         <!-- Add EC symbols to import lib -->
-        <ImportLib Include="$(ECImportLibObjs);" />
+        <ImportLib Include="$(ECImportLibObjs)" />
         <!-- Add these EC OBJs to import lib -->
-        <ImportLib Include="$(ECLibObjs);">
+        <ImportLib Include="$(ECLibObjs)">
             <IncludeInLink>false</IncludeInLink>
             <IncludeInImportLib>true</IncludeInImportLib>
         </ImportLib>

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -5,7 +5,12 @@
 // injected into the msvcprt.lib and msvcprtd.lib import libraries.
 // Do not include or define anything else here.
 // In particular, basic_string must not be included here.
-#if (defined(_M_IX86) || defined(_M_X64) && !defined(_M_ARM64EC)) && !defined(_M_CEE_PURE)
+
+#ifdef _M_CEE_PURE
+#error _M_CEE_PURE should not be defined when compiling vector_algorithms.cpp.
+#endif
+
+#if (defined(_M_IX86) || defined(_M_X64)) && !defined(_M_ARM64EC)
 
 #include <emmintrin.h>
 #include <immintrin.h>
@@ -418,4 +423,4 @@ __declspec(noalias) void __cdecl __std_reverse_copy_trivially_copyable_8(
 
 } // extern "C"
 
-#endif // (defined(_M_IX86) || defined(_M_X64) && !defined(_M_ARM64EC)) && !defined(_M_CEE_PURE)
+#endif // (defined(_M_IX86) || defined(_M_X64)) && !defined(_M_ARM64EC)


### PR DESCRIPTION
Followups to GH-1344 requested by @cbezault.

* `xutility`
  + Extract `&& !defined(_M_ARM64EC)` to the end for clarity. There's no behavioral change here (`_M_ARM64EC` can be defined only when `_M_X64` is defined), it just separates the major architectures where we want to enable the vectorized algorithms (x86, x64) from the flavors where they should be excluded due to intrinsic unavailability.
* `stl/msbuild/stl_base/msvcp.settings.targets`
* `stl/msbuild/stl_atomic_wait/stl_atomic_wait.files.settings.targets`
  + Add and remove semicolons for consistency.
* `vector_algorithms.cpp`
  + Adjust preprocessor guards. We never build this for `/clr:pure`, so that can be a hard `#error`. However, we do need to make this file a no-op for `_M_ARM64EC`. Extract that, like `xutility` above.

I tested this with MSVC-internal builds of x86, x64, arm, arm64, and chpe (there is no dedicated arm64ec build).

(Recreated yet again, hopefully Azure Pipelines will work now.)