### PR TITLE
_Execute_once bug fix.

### DIFF
--- a/stl/src/xonce.cpp
+++ b/stl/src/xonce.cpp
@@ -30,8 +30,7 @@ _CRTIMP2_PURE int __CLRCALL_PURE_OR_CDECL _Execute_once(
         return static_cast<BOOL>(_Trampoline_parameter->_Callback(_InitOnce, _Trampoline_parameter->_Pv, _Context));
     };
 
-    return InitOnceExecuteOnce(reinterpret_cast<PINIT_ONCE>(&_Flag._Opaque), _Xfg_trampoline,
-        static_cast<PVOID>(&_Trampoline_parameter), nullptr);
+    return InitOnceExecuteOnce(reinterpret_cast<PINIT_ONCE>(&_Flag._Opaque), _Xfg_trampoline, &_Trampoline_parameter, nullptr);
 }
 
 [[noreturn]] _CRTIMP2_PURE void __CLRCALL_PURE_OR_CDECL

--- a/stl/src/xonce.cpp
+++ b/stl/src/xonce.cpp
@@ -23,18 +23,15 @@ _CRTIMP2_PURE int __CLRCALL_PURE_OR_CDECL _Execute_once(
     // we introduce _Xfg_trampoline which has PINIT_ONCE_FN's type signature and
     // calls into _Callback as an _Execute_once_fp_t for XFG compatibility.
 
-    _Xfg_trampoline_parameter _Trampoline_parameter = {
-        _Pv,
-        _Callback
-    };
+    _Xfg_trampoline_parameter _Trampoline_parameter = {_Pv, _Callback};
 
     PINIT_ONCE_FN _Xfg_trampoline = [](PINIT_ONCE _InitOnce, PVOID _Parameter, PVOID* _Context) {
         const auto _Trampoline_parameter = static_cast<_Xfg_trampoline_parameter*>(_Parameter);
         return static_cast<BOOL>(_Trampoline_parameter->_Callback(_InitOnce, _Trampoline_parameter->_Pv, _Context));
     };
 
-    return InitOnceExecuteOnce(
-        reinterpret_cast<PINIT_ONCE>(&_Flag._Opaque), _Xfg_trampoline, static_cast<PVOID>(&_Trampoline_parameter), nullptr);
+    return InitOnceExecuteOnce(reinterpret_cast<PINIT_ONCE>(&_Flag._Opaque), _Xfg_trampoline,
+        static_cast<PVOID>(&_Trampoline_parameter), nullptr);
 }
 
 [[noreturn]] _CRTIMP2_PURE void __CLRCALL_PURE_OR_CDECL

--- a/stl/src/xonce.cpp
+++ b/stl/src/xonce.cpp
@@ -30,7 +30,8 @@ _CRTIMP2_PURE int __CLRCALL_PURE_OR_CDECL _Execute_once(
         return static_cast<BOOL>(_Trampoline_parameter->_Callback(_InitOnce, _Trampoline_parameter->_Pv, _Context));
     };
 
-    return InitOnceExecuteOnce(reinterpret_cast<PINIT_ONCE>(&_Flag._Opaque), _Xfg_trampoline, &_Trampoline_parameter, nullptr);
+    return InitOnceExecuteOnce(
+        reinterpret_cast<PINIT_ONCE>(&_Flag._Opaque), _Xfg_trampoline, &_Trampoline_parameter, nullptr);
 }
 
 [[noreturn]] _CRTIMP2_PURE void __CLRCALL_PURE_OR_CDECL

--- a/stl/src/xonce.cpp
+++ b/stl/src/xonce.cpp
@@ -8,6 +8,12 @@
 #include "awint.hpp"
 
 _STD_BEGIN
+
+struct _Xfg_trampoline_parameter {
+    void* _Pv;
+    _Execute_once_fp_t _Callback;
+};
+
 // TRANSITION, ABI
 _CRTIMP2_PURE int __CLRCALL_PURE_OR_CDECL _Execute_once(
     once_flag& _Flag, _Execute_once_fp_t _Callback, void* _Pv) noexcept { // wrap Win32 InitOnceExecuteOnce()
@@ -17,13 +23,18 @@ _CRTIMP2_PURE int __CLRCALL_PURE_OR_CDECL _Execute_once(
     // we introduce _Xfg_trampoline which has PINIT_ONCE_FN's type signature and
     // calls into _Callback as an _Execute_once_fp_t for XFG compatibility.
 
+    _Xfg_trampoline_parameter _Trampoline_parameter = {
+        _Pv,
+        _Callback
+    };
+
     PINIT_ONCE_FN _Xfg_trampoline = [](PINIT_ONCE _InitOnce, PVOID _Parameter, PVOID* _Context) {
-        const auto _Callback = reinterpret_cast<_Execute_once_fp_t>(_Context);
-        return static_cast<BOOL>(_Callback(_InitOnce, _Parameter, nullptr));
+        const auto _Trampoline_parameter = static_cast<_Xfg_trampoline_parameter*>(_Parameter);
+        return static_cast<BOOL>(_Trampoline_parameter->_Callback(_InitOnce, _Trampoline_parameter->_Pv, _Context));
     };
 
     return InitOnceExecuteOnce(
-        reinterpret_cast<PINIT_ONCE>(&_Flag._Opaque), _Xfg_trampoline, _Pv, reinterpret_cast<PVOID*>(_Callback));
+        reinterpret_cast<PINIT_ONCE>(&_Flag._Opaque), _Xfg_trampoline, static_cast<PVOID>(&_Trampoline_parameter), nullptr);
 }
 
 [[noreturn]] _CRTIMP2_PURE void __CLRCALL_PURE_OR_CDECL


### PR DESCRIPTION
The original XFG enlightening for _Execute_once tried to be clever by using Context to pass the final callback to the trampoline. Unfortunately, Context is used by InitOnceExecuteOnce itself and having the wrong bits set can result in an error being returned. This PR addresses this by defining a struct which contains the parameter value and callback pointer to pass those to the trampoline.