### PR TITLE
Add _CONTAINER_DEBUG_LEVEL checks for optional

### DIFF
--- a/stl/inc/optional
+++ b/stl/inc/optional
@@ -338,22 +338,40 @@ public:
 
     // observers [optional.object.observe]
     _NODISCARD constexpr const _Ty* operator->() const {
+#if _CONTAINER_DEBUG_LEVEL > 0
+        _STL_VERIFY(this->_Has_value, "Cannot access value of empty optional");
+#endif // _CONTAINER_DEBUG_LEVEL > 0
         return _STD addressof(this->_Value);
     }
     _NODISCARD constexpr _Ty* operator->() {
+#if _CONTAINER_DEBUG_LEVEL > 0
+        _STL_VERIFY(this->_Has_value, "Cannot access value of empty optional");
+#endif // _CONTAINER_DEBUG_LEVEL > 0
         return _STD addressof(this->_Value);
     }
 
     _NODISCARD constexpr const _Ty& operator*() const& {
+#if _CONTAINER_DEBUG_LEVEL > 0
+        _STL_VERIFY(this->_Has_value, "Cannot access value of empty optional");
+#endif // _CONTAINER_DEBUG_LEVEL > 0
         return this->_Value;
     }
     _NODISCARD constexpr _Ty& operator*() & {
+#if _CONTAINER_DEBUG_LEVEL > 0
+        _STL_VERIFY(this->_Has_value, "Cannot access value of empty optional");
+#endif // _CONTAINER_DEBUG_LEVEL > 0
         return this->_Value;
     }
     _NODISCARD constexpr _Ty&& operator*() && {
+#if _CONTAINER_DEBUG_LEVEL > 0
+        _STL_VERIFY(this->_Has_value, "Cannot access value of empty optional");
+#endif // _CONTAINER_DEBUG_LEVEL > 0
         return _STD move(this->_Value);
     }
     _NODISCARD constexpr const _Ty&& operator*() const&& {
+#if _CONTAINER_DEBUG_LEVEL > 0
+        _STL_VERIFY(this->_Has_value, "Cannot access value of empty optional");
+#endif // _CONTAINER_DEBUG_LEVEL > 0
         return _STD move(this->_Value);
     }
 

--- a/tests/std/include/test_death.hpp
+++ b/tests/std/include/test_death.hpp
@@ -12,7 +12,6 @@
 #include <test_windows.hpp>
 
 namespace std_testing {
-
     constexpr int internal_failure = 103;
     using normal_function_t        = void (*)();
     using death_function_t         = void (*)();
@@ -22,7 +21,6 @@ namespace std_testing {
         printf("%s failed; LastError: 0x%08X\n", api_name, last_error);
         abort();
     }
-
 
     class death_test_executive {
         const normal_function_t run_normal_tests;
@@ -98,9 +96,10 @@ namespace std_testing {
         }
 
     public:
+        death_test_executive() : run_normal_tests(nullptr) {}
+
         explicit death_test_executive(const normal_function_t normal_tests_function)
             : run_normal_tests(normal_tests_function) {}
-
 
         template <size_t TestsCount>
         void add_death_tests(const death_function_t (&tests)[TestsCount]) {
@@ -111,7 +110,9 @@ namespace std_testing {
             if (argc == 1) {
                 // first pass, run normal tests and sub-process loop
                 printf("running normal tests...");
-                run_normal_tests();
+                if (run_normal_tests != nullptr) {
+                    run_normal_tests();
+                }
                 puts(" passed!");
 
                 ::SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX);

--- a/tests/std/test.lst
+++ b/tests/std/test.lst
@@ -215,6 +215,7 @@ tests\P0202R3_constexpr_algorithm_and_exchange
 tests\P0218R1_filesystem
 tests\P0220R1_any
 tests\P0220R1_optional
+tests\P0220R1_optional_death
 tests\P0220R1_polymorphic_memory_resources
 tests\P0220R1_sample
 tests\P0220R1_searchers

--- a/tests/std/tests/P0220R1_optional_death/env.lst
+++ b/tests/std/tests/P0220R1_optional_death/env.lst
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+RUNALL_INCLUDE ..\usual_17_winsdk_matrix.lst

--- a/tests/std/tests/P0220R1_optional_death/test.cpp
+++ b/tests/std/tests/P0220R1_optional_death/test.cpp
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#define _CONTAINER_DEBUG_LEVEL 1
+
+#include <optional>
+
+#include <test_death.hpp>
+
+using namespace std;
+
+struct S {
+    int value;
+};
+
+void test_nullopt_operator_arrow() {
+    optional<S> o;
+    (void) o->value;
+}
+
+void test_nullopt_operator_arrow_const() {
+    const optional<S> o;
+    (void) o->value;
+}
+
+void test_nullopt_operator_star_lvalue() {
+    optional<S> o;
+    (void) *o;
+}
+
+void test_nullopt_operator_star_const_lvalue() {
+    const optional<S> o;
+    (void) *o;
+}
+
+void test_nullopt_operator_star_rvalue() {
+    optional<S> o;
+    (void) *move(o);
+}
+
+void test_nullopt_operator_star_const_rvalue() {
+    const optional<S> o;
+    (void) *move(o);
+}
+
+int main(int argc, char* argv[]) {
+    std_testing::death_test_executive exec;
+
+    exec.add_death_tests({
+        test_nullopt_operator_arrow,
+        test_nullopt_operator_arrow_const,
+        test_nullopt_operator_star_lvalue,
+        test_nullopt_operator_star_const_lvalue,
+        test_nullopt_operator_star_rvalue,
+        test_nullopt_operator_star_const_rvalue,
+    });
+
+    return exec.run(argc, argv);
+}

--- a/tests/std/tests/P0220R1_optional_death/test.cpp
+++ b/tests/std/tests/P0220R1_optional_death/test.cpp
@@ -4,6 +4,7 @@
 #define _CONTAINER_DEBUG_LEVEL 1
 
 #include <optional>
+#include <utility>
 
 #include <test_death.hpp>
 

--- a/tests/std/tests/P0660R10_stop_token_death/test.cpp
+++ b/tests/std/tests/P0660R10_stop_token_death/test.cpp
@@ -36,7 +36,7 @@ void test_case_throw_during_request_stop() {
 }
 
 int main(int argc, char* argv[]) {
-    std_testing::death_test_executive exec([] {});
+    std_testing::death_test_executive exec;
 
     exec.add_death_tests({
         test_case_throw_during_request_stop,

--- a/tests/std/tests/P0896R4_common_iterator_death/test.cpp
+++ b/tests/std/tests/P0896R4_common_iterator_death/test.cpp
@@ -156,7 +156,7 @@ void test_case_iter_swap_sentinel_right_valueless() {
 }
 
 int main(int argc, char* argv[]) {
-    std_testing::death_test_executive exec([] {});
+    std_testing::death_test_executive exec;
 
 #if _ITERATOR_DEBUG_LEVEL != 0
     exec.add_death_tests({

--- a/tests/std/tests/P0896R4_counted_iterator_death/test.cpp
+++ b/tests/std/tests/P0896R4_counted_iterator_death/test.cpp
@@ -206,7 +206,7 @@ void test_case_operator_spaceship_incompatible_value_initialized() {
 }
 
 int main(int argc, char* argv[]) {
-    std_testing::death_test_executive exec([] {});
+    std_testing::death_test_executive exec;
 
 #if _ITERATOR_DEBUG_LEVEL != 0
     exec.add_death_tests({

--- a/tests/std/tests/P0896R4_views_filter_death/test.cpp
+++ b/tests/std/tests/P0896R4_views_filter_death/test.cpp
@@ -131,7 +131,7 @@ void test_iter_swap_value_initialized_iterator_right() {
 }
 
 int main(int argc, char* argv[]) {
-    std_testing::death_test_executive exec([] {});
+    std_testing::death_test_executive exec;
 
 #if _ITERATOR_DEBUG_LEVEL != 0
     exec.add_death_tests({

--- a/tests/std/tests/P0896R4_views_transform_death/test.cpp
+++ b/tests/std/tests/P0896R4_views_transform_death/test.cpp
@@ -334,7 +334,7 @@ void test_flipped_sentinel_difference_value_initialized() {
 }
 
 int main(int argc, char* argv[]) {
-    std_testing::death_test_executive exec([] {});
+    std_testing::death_test_executive exec;
 
 #if _ITERATOR_DEBUG_LEVEL != 0
     exec.add_death_tests({


### PR DESCRIPTION
When `_CONTAINER_DEBUG_LEVEL` is `1` (which is implied by `_ITERATOR_DEBUG_LEVEL != 0`) `optional::operator*` and `optional::operator->` verify the precondition that the `optional` is not empty.

Drive-by: Add a default constructor to `death_test_executive` so we need not construct with a do-nothing function when there are no "normal" tests.


Partially addresses #1359.