### PR TITLE
VS 2019 16.8 Preview 4, Python 3.9.0, absolute time fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 The STL uses boost-math headers to provide P0226R1 Mathematical Special Functions. We recommend using [vcpkg][] to
 acquire this dependency.
 
-1. Install Visual Studio 2019 16.8 Preview 3 or later.
+1. Install Visual Studio 2019 16.8 Preview 4 or later.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
     * Otherwise, install [CMake][] 3.17 or later, and [Ninja][] 1.8.2 or later.
@@ -158,7 +158,7 @@ acquire this dependency.
 
 # How To Build With A Native Tools Command Prompt
 
-1. Install Visual Studio 2019 16.8 Preview 3 or later.
+1. Install Visual Studio 2019 16.8 Preview 4 or later.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
     * Otherwise, install [CMake][] 3.17 or later, and [Ninja][] 1.8.2 or later.
@@ -235,7 +235,7 @@ C:\Users\username\Desktop>dumpbin /IMPORTS .\example.exe | findstr msvcp
 
 1. Follow either [How To Build With A Native Tools Command Prompt][] or [How To Build With The Visual Studio IDE][].
 2. Invoke `git submodule update --init llvm-project` at the root of the STL source tree.
-3. Acquire [Python][] 3.8 or newer and have it on the `PATH` (or run it directly using its absolute or relative path).
+3. Acquire [Python][] 3.9 or newer and have it on the `PATH` (or run it directly using its absolute or relative path).
 4. Have LLVM's `bin` directory on the `PATH` (so `clang-cl.exe` is available).
     * We recommend selecting "C++ Clang tools for Windows" in the VS Installer. This will automatically add LLVM to the
     `PATH` of the x86 and x64 Native Tools Command Prompts, and will ensure that you're using a supported version.

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -97,7 +97,7 @@ $Workloads = @(
 $ReleaseInPath = 'Preview'
 $Sku = 'Enterprise'
 $VisualStudioBootstrapperUrl = 'https://aka.ms/vs/16/pre/vs_enterprise.exe'
-$PythonUrl = 'https://www.python.org/ftp/python/3.8.5/python-3.8.5-amd64.exe'
+$PythonUrl = 'https://www.python.org/ftp/python/3.9.0/python-3.9.0-amd64.exe'
 
 $CudaUrl = `
   'https://developer.download.nvidia.com/compute/cuda/10.1/Prod/local_installers/cuda_10.1.243_426.00_win10.exe'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,7 @@
 variables:
   tmpDir: 'D:\Temp'
 
-pool: 'StlBuild-2020-09-14'
+pool: 'StlBuild-2020-10-13'
 
 stages:
   - stage: Code_Format

--- a/stl/inc/condition_variable
+++ b/stl/inc/condition_variable
@@ -130,7 +130,7 @@ public:
     template <class _Lock, class _Rep, class _Period, class _Predicate>
     bool wait_for(_Lock& _Lck, const chrono::duration<_Rep, _Period>& _Rel_time, _Predicate _Pred) {
         // wait for signal with timeout and check predicate
-        return wait_until(_Lck, chrono::steady_clock::now() + _Rel_time, _STD move(_Pred));
+        return wait_until(_Lck, _To_absolute_time(_Rel_time), _STD move(_Pred));
     }
 
     template <class _Lock>
@@ -232,7 +232,7 @@ public:
 
     template <class _Lock, class _Rep, class _Period, class _Predicate>
     bool wait_for(_Lock& _Lck, stop_token _Stoken, const chrono::duration<_Rep, _Period>& _Rel_time, _Predicate _Pred) {
-        return wait_until(_Lck, _STD move(_Stoken), chrono::steady_clock::now() + _Rel_time, _STD move(_Pred));
+        return wait_until(_Lck, _STD move(_Stoken), _To_absolute_time(_Rel_time), _STD move(_Pred));
     }
 #endif // _HAS_CXX20
 

--- a/stl/inc/mutex
+++ b/stl/inc/mutex
@@ -564,22 +564,6 @@ void(call_once)(once_flag& _Once, _Fn&& _Fx, _Args&&... _Ax) noexcept(
 #undef _WINDOWS_API
 #undef _RENAME_WINDOWS_API
 
-template <class _Rep, class _Period>
-_NODISCARD chrono::steady_clock::time_point _To_absolute_time(
-    const chrono::duration<_Rep, _Period>& _Rel_time) noexcept {
-    auto _Abs_time       = chrono::steady_clock::now();
-    constexpr auto _Zero = chrono::duration<_Rep, _Period>::zero();
-    if (_Rel_time > _Zero) {
-        constexpr auto _Forever = (chrono::steady_clock::time_point::max)();
-        if (_Abs_time < _Forever - _Rel_time) {
-            _Abs_time += _Rel_time;
-        } else {
-            _Abs_time = _Forever;
-        }
-    }
-    return _Abs_time;
-}
-
 // condition_variable, timed_mutex, and recursive_timed_mutex are not supported under /clr
 #ifndef _M_CEE
 enum class cv_status { // names for wait returns

--- a/stl/inc/mutex
+++ b/stl/inc/mutex
@@ -564,6 +564,21 @@ void(call_once)(once_flag& _Once, _Fn&& _Fx, _Args&&... _Ax) noexcept(
 #undef _WINDOWS_API
 #undef _RENAME_WINDOWS_API
 
+template <class _Rep, class _Period>
+_NODISCARD inline chrono::steady_clock::time_point _To_absolute_time(
+    const chrono::duration<_Rep, _Period>& _Rel_time) noexcept {
+    chrono::steady_clock::time_point _Abs_time = chrono::steady_clock::now();
+    if (_Rel_time > chrono::duration<_Rep, _Period>::zero()) {
+        const auto _Forever = chrono::steady_clock::time_point::max();
+        if (_Abs_time < _Forever - _Rel_time) {
+            _Abs_time += _Rel_time;
+        } else {
+            _Abs_time = _Forever;
+        }
+    }
+    return _Abs_time;
+}
+
 // condition_variable, timed_mutex, and recursive_timed_mutex are not supported under /clr
 #ifndef _M_CEE
 enum class cv_status { // names for wait returns
@@ -628,7 +643,7 @@ public:
     template <class _Rep, class _Period, class _Predicate>
     bool wait_for(unique_lock<mutex>& _Lck, const chrono::duration<_Rep, _Period>& _Rel_time, _Predicate _Pred) {
         // wait for signal with timeout and check predicate
-        return _Wait_until1(_Lck, chrono::steady_clock::now() + _Rel_time, _Pred);
+        return _Wait_until1(_Lck, _To_absolute_time(_Rel_time), _Pred);
     }
 
     template <class _Clock, class _Duration>
@@ -776,7 +791,7 @@ public:
 
     template <class _Rep, class _Period>
     _NODISCARD bool try_lock_for(const chrono::duration<_Rep, _Period>& _Rel_time) { // try to lock for duration
-        return try_lock_until(chrono::steady_clock::now() + _Rel_time);
+        return try_lock_until(_To_absolute_time(_Rel_time));
     }
 
     template <class _Time>
@@ -875,7 +890,7 @@ public:
 
     template <class _Rep, class _Period>
     _NODISCARD bool try_lock_for(const chrono::duration<_Rep, _Period>& _Rel_time) { // try to lock for duration
-        return try_lock_until(chrono::steady_clock::now() + _Rel_time);
+        return try_lock_until(_To_absolute_time(_Rel_time));
     }
 
     template <class _Time>

--- a/stl/inc/mutex
+++ b/stl/inc/mutex
@@ -565,11 +565,12 @@ void(call_once)(once_flag& _Once, _Fn&& _Fx, _Args&&... _Ax) noexcept(
 #undef _RENAME_WINDOWS_API
 
 template <class _Rep, class _Period>
-_NODISCARD inline chrono::steady_clock::time_point _To_absolute_time(
+_NODISCARD chrono::steady_clock::time_point _To_absolute_time(
     const chrono::duration<_Rep, _Period>& _Rel_time) noexcept {
-    chrono::steady_clock::time_point _Abs_time = chrono::steady_clock::now();
-    if (_Rel_time > chrono::duration<_Rep, _Period>::zero()) {
-        const auto _Forever = (chrono::steady_clock::time_point::max)();
+    auto _Abs_time       = chrono::steady_clock::now();
+    constexpr auto _Zero = chrono::duration<_Rep, _Period>::zero();
+    if (_Rel_time > _Zero) {
+        constexpr auto _Forever = (chrono::steady_clock::time_point::max)();
         if (_Abs_time < _Forever - _Rel_time) {
             _Abs_time += _Rel_time;
         } else {

--- a/stl/inc/mutex
+++ b/stl/inc/mutex
@@ -569,7 +569,7 @@ _NODISCARD inline chrono::steady_clock::time_point _To_absolute_time(
     const chrono::duration<_Rep, _Period>& _Rel_time) noexcept {
     chrono::steady_clock::time_point _Abs_time = chrono::steady_clock::now();
     if (_Rel_time > chrono::duration<_Rep, _Period>::zero()) {
-        const auto _Forever = chrono::steady_clock::time_point::max();
+        const auto _Forever = (chrono::steady_clock::time_point::max)();
         if (_Abs_time < _Forever - _Rel_time) {
             _Abs_time += _Rel_time;
         } else {

--- a/stl/inc/shared_mutex
+++ b/stl/inc/shared_mutex
@@ -110,7 +110,7 @@ public:
 
     template <class _Rep, class _Period>
     _NODISCARD bool try_lock_for(const chrono::duration<_Rep, _Period>& _Rel_time) { // try to lock for duration
-        return try_lock_until(chrono::steady_clock::now() + _Rel_time);
+        return try_lock_until(_To_absolute_time(_Rel_time));
     }
 
     template <class _Clock, class _Duration>
@@ -168,7 +168,7 @@ public:
     template <class _Rep, class _Period>
     _NODISCARD bool try_lock_shared_for(
         const chrono::duration<_Rep, _Period>& _Rel_time) { // try to lock non-exclusive for relative time
-        return try_lock_shared_until(_Rel_time + chrono::steady_clock::now());
+        return try_lock_shared_until(_To_absolute_time(_Rel_time));
     }
 
     template <class _Time>

--- a/stl/inc/thread
+++ b/stl/inc/thread
@@ -157,10 +157,10 @@ private:
 };
 
 template <class _Rep, class _Period>
-_NODISCARD chrono::steady_clock::time_point _To_absolute_time(
-    const chrono::duration<_Rep, _Period>& _Rel_time) noexcept {
-    auto _Abs_time       = chrono::steady_clock::now();
-    constexpr auto _Zero = chrono::duration<_Rep, _Period>::zero();
+_NODISCARD auto _To_absolute_time(const chrono::duration<_Rep, _Period>& _Rel_time) noexcept {
+    constexpr auto _Zero                 = chrono::duration<_Rep, _Period>::zero();
+    const auto _Now                      = chrono::steady_clock::now();
+    decltype(_Now + _Rel_time) _Abs_time = _Now; // return common type
     if (_Rel_time > _Zero) {
         constexpr auto _Forever = (chrono::steady_clock::time_point::max)();
         if (_Abs_time < _Forever - _Rel_time) {

--- a/stl/inc/thread
+++ b/stl/inc/thread
@@ -156,6 +156,22 @@ private:
     _Thrd_t _Thr;
 };
 
+template <class _Rep, class _Period>
+_NODISCARD chrono::steady_clock::time_point _To_absolute_time(
+    const chrono::duration<_Rep, _Period>& _Rel_time) noexcept {
+    auto _Abs_time       = chrono::steady_clock::now();
+    constexpr auto _Zero = chrono::duration<_Rep, _Period>::zero();
+    if (_Rel_time > _Zero) {
+        constexpr auto _Forever = (chrono::steady_clock::time_point::max)();
+        if (_Abs_time < _Forever - _Rel_time) {
+            _Abs_time += _Rel_time;
+        } else {
+            _Abs_time = _Forever;
+        }
+    }
+    return _Abs_time;
+}
+
 namespace this_thread {
     _NODISCARD thread::id get_id() noexcept;
 
@@ -183,7 +199,7 @@ namespace this_thread {
 
     template <class _Rep, class _Period>
     void sleep_for(const chrono::duration<_Rep, _Period>& _Rel_time) {
-        sleep_until(chrono::steady_clock::now() + _Rel_time);
+        sleep_until(_To_absolute_time(_Rel_time));
     }
 } // namespace this_thread
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,7 +18,7 @@ add_subdirectory(tr1)
 # chance to add to the config map and test directory global properties.
 add_subdirectory(utils/stl-lit)
 
-find_package(Python "3.8" REQUIRED COMPONENTS Interpreter)
+find_package(Python "3.9" REQUIRED COMPONENTS Interpreter)
 
 if(NOT DEFINED LIT_FLAGS)
     list(APPEND LIT_FLAGS "-o" "${CMAKE_CURRENT_BINARY_DIR}/test_results.json")

--- a/tests/std/tests/P0660R10_jthread_and_cv_any/test.cpp
+++ b/tests/std/tests/P0660R10_jthread_and_cv_any/test.cpp
@@ -180,7 +180,7 @@ int main() {
         jthread worker([&](stop_token token) {
             unique_lock lck{m};
             assert(cv.wait(lck, move(token), [] { return true; }) == true);
-            assert(cv.wait(lck, move(token), [&] { return b; }) == true);
+            assert(cv.wait(lck, move(token), [&] { return b; }) == true); // Intentionally uses moved-from token
         });
 
         {
@@ -198,7 +198,7 @@ int main() {
         jthread worker([&](stop_token token) {
             unique_lock lck{m};
             assert(cv.wait_until(lck, move(token), infinity, [] { return true; }) == true);
-            assert(cv.wait_until(lck, move(token), infinity, [&] { return b; }) == true);
+            assert(cv.wait_until(lck, move(token), infinity, [&] { return b; }) == true); // Intentionally uses moved-from token
         });
 
         {
@@ -216,7 +216,7 @@ int main() {
         jthread worker([&](stop_token token) {
             unique_lock lck{m};
             assert(cv.wait_for(lck, move(token), forever, [] { return true; }) == true);
-            assert(cv.wait_for(lck, move(token), forever, [&] { return b; }) == true);
+            assert(cv.wait_for(lck, move(token), forever, [&] { return b; }) == true); // Intentionally uses moved-from token
         });
 
         {

--- a/tests/std/tests/P0660R10_jthread_and_cv_any/test.cpp
+++ b/tests/std/tests/P0660R10_jthread_and_cv_any/test.cpp
@@ -198,7 +198,8 @@ int main() {
         jthread worker([&](stop_token token) {
             unique_lock lck{m};
             assert(cv.wait_until(lck, move(token), infinity, [] { return true; }) == true);
-            assert(cv.wait_until(lck, move(token), infinity, [&] { return b; }) == true); // Intentionally uses moved-from token
+            assert(cv.wait_until(lck, move(token), infinity, [&] { return b; })
+                   == true); // Intentionally uses moved-from token
         });
 
         {
@@ -216,7 +217,8 @@ int main() {
         jthread worker([&](stop_token token) {
             unique_lock lck{m};
             assert(cv.wait_for(lck, move(token), forever, [] { return true; }) == true);
-            assert(cv.wait_for(lck, move(token), forever, [&] { return b; }) == true); // Intentionally uses moved-from token
+            assert(cv.wait_for(lck, move(token), forever, [&] { return b; })
+                   == true); // Intentionally uses moved-from token
         });
 
         {


### PR DESCRIPTION
This updates the CI infrastructure to VS 2019 16.8 Preview 4 and Python 3.9.0.

This also fixes #1365, a sporadic test failure that I encountered after upgrading my local machine to Python 3.9.0. (I'm still not sure if they're actually related, but I've bundled these changes together since they affect different files and are relatively small.) @MattStephanson found the root cause and @CaseyCarter developed a fix: convert relative time to absolute time, clamped between now and forever. I then made the following changes:

* Move `_To_absolute_time` up to `<thread>` so we can fix 3 more lines (in `<thread>` and `<shared_mutex>`).
* `_To_absolute_time` is a `template`, so we don't need `inline`.
* The return type needs special attention - we want to return the same type as `now() + _Rel_time` (the expression we're replacing and clamping). For example, this makes a difference when `_Rel_time` has a `double` representation.
* Extract `constexpr _Zero` to avoid a function call in debug mode.
* Similarly, upgrade `_Forever` to `constexpr`.
