### PR TITLE
Remove unneeded case in uninitialized_default_construct_n

### DIFF
--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -858,14 +858,6 @@ namespace ranges {
             using _Ty = remove_reference_t<iter_reference_t<_It>>;
             if constexpr (is_trivially_default_constructible_v<_Ty>) {
                 _RANGES advance(_First, _Count);
-            } else if constexpr (is_nothrow_default_constructible_v<_Ty>) {
-                auto _UFirst = _Get_unwrapped_n(_STD move(_First), _Count);
-
-                for (; _Count > 0; --_Count, (void) ++_UFirst) {
-                    ::new (_Voidify_iter(_UFirst)) _Ty;
-                }
-
-                _Seek_wrapped(_First, _STD move(_UFirst));
             } else {
                 _Uninitialized_backout _Backout{_Get_unwrapped_n(_STD move(_First), _Count)};
 


### PR DESCRIPTION
There was a leftover from #1164 where I forgot to remove the unneeded specialization from `uninitialized_default_construct_n`