### PR TITLE
[feature/format] parse format specs

### DIFF
--- a/stl/inc/format
+++ b/stl/inc/format
@@ -51,7 +51,7 @@ concept _Parse_spec_callbacks = requires(_Ty _At, basic_string_view<_CharT> _Sv,
     { _At._On_precision(_STD declval<int>()) } -> same_as<void>;
     { _At._On_dynamic_precision(_STD declval<int>()) } -> same_as<void>;
     { _At._On_dynamic_precision(_STD declval<_Auto_id_tag>()) } -> same_as<void>;
-    { _At._O_sign(_Sgn) } -> same_as<void>;
+    { _At._On_sign(_Sgn) } -> same_as<void>;
     { _At._On_hash() } -> same_as<void>;
     { _At._On_zero() } -> same_as<void>;
     { _At._On_type(_STD declval<_CharT>()) } -> same_as<void>;

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -220,7 +220,6 @@ constexpr const _CharT* _Parse_precision(const _CharT* _Begin, const _CharT* _En
     if (_Begin != _End) {
         _Ch = *_Begin;
     }
-
     if ('0' <= _Ch && _Ch <= '9') {
         int _Precision = 0;
         _Begin         = _Parse_nonnegative_integer(_Begin, _End, _Precision);

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -296,7 +296,7 @@ constexpr const _CharT* _Parse_format_specs(const _CharT* _Begin, const _CharT* 
     }
 
     // Parse precision
-    if (*_Begin == '*') {
+    if (*_Begin == '.') {
         _Begin = _Parse_precision(_Begin, _End, _Callbacks);
     }
 

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -36,11 +36,13 @@ class format_error : public runtime_error {
 
 enum class _Align { _None, _Left, _Right, _Center };
 
+enum class _Sign { _None, _Plus, _Minus, _Space };
+
 struct _Auto_id_tag {};
 
 // clang-format off
 template <class _Ty, class _CharT>
-concept _Parse_spec_callbacks = requires(_Ty _At, basic_string_view<_CharT> _Sv, _Align _Aln) {
+concept _Parse_spec_callbacks = requires(_Ty _At, basic_string_view<_CharT> _Sv, _Align _Aln, _Sign _Sgn) {
     { _At._On_align(_Aln) } -> same_as<void>;
     { _At._On_fill(_Sv) } -> same_as<void>;
     { _At._On_width(_STD declval<int>()) } -> same_as<void>;
@@ -49,8 +51,10 @@ concept _Parse_spec_callbacks = requires(_Ty _At, basic_string_view<_CharT> _Sv,
     { _At._On_precision(_STD declval<int>()) } -> same_as<void>;
     { _At._On_dynamic_precision(_STD declval<int>()) } -> same_as<void>;
     { _At._On_dynamic_precision(_STD declval<_Auto_id_tag>()) } -> same_as<void>;
-
-    /* { _At._On_type(_STD declval<_CharT>()) } -> same_as<void>; */
+    { _At._O_sign(_Sgn) } -> same_as<void>;
+    { _At._On_hash() } -> same_as<void>;
+    { _At._On_zero() } -> same_as<void>;
+    { _At._On_type(_STD declval<_CharT>()) } -> same_as<void>;
 };
 template <class _Ty, class _CharT>
 concept _Parse_arg_id_callbacks = requires(_Ty _At) {
@@ -236,6 +240,69 @@ constexpr const _CharT* _Parse_precision(const _CharT* _Begin, const _CharT* _En
         }
     } else {
         throw format_error("Missing precision specifier.");
+    }
+    return _Begin;
+}
+
+template <class _CharT, _Parse_spec_callbacks<_CharT> _Callbacks_type>
+constexpr const _CharT* _Parse_format_specs(const _CharT* _Begin, const _CharT* _End, _Callbacks_type&& _Callbacks) {
+    if (_Begin == _End || *_Begin == '}') {
+        return _Begin;
+    }
+
+    _Begin = _Parse_align(_Begin, _End, _Callbacks);
+    if (_Begin == _End) {
+        return _Begin;
+    }
+
+    switch (*_Begin) {
+    case '+':
+        _Callbacks._On_sign(_Sign::_Plus);
+        ++_Begin;
+        break;
+    case '-':
+        _Callbacks._On_sign(_Sign::_Minus);
+        ++_Begin;
+        break;
+    case ' ':
+        _Callbacks._On_sign(_Sign::_Space);
+        ++_Begin;
+        break;
+    }
+
+    if (_Begin == _End) {
+        return _Begin;
+    }
+
+    // Parse hash.
+    if (*_Begin == '#') {
+        _Callbacks._On_hash();
+        if (++_Begin == _End) {
+            return _Begin;
+        }
+    }
+
+    // Parse zero flag
+    if (*_Begin == '0') {
+        _Callbacks._On_zero();
+        if (++_Begin == _End) {
+            return _Begin;
+        }
+    }
+
+    _Begin = _Parse_width(_Begin, _End, _Callbacks);
+    if (_Begin == _End) {
+        return _Begin;
+    }
+
+    // Parse precision
+    if (*_Begin == '*') {
+        _Begin == _Parse_precision(_Begin, _End, _Callbacks);
+    }
+
+    // Parse type
+    if (_Begin != _End && _Begin != '}') {
+        _Callbacks._On_type(*_Begin++);
     }
     return _Begin;
 }

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -122,8 +122,7 @@ constexpr const _CharT* _Parse_arg_id(const _CharT* _Begin, const _CharT* _End, 
 
 template <class _CharT, _Parse_spec_callbacks<_CharT> _Callbacks_type>
 constexpr const _CharT* _Parse_align(const _CharT* _Begin, const _CharT* _End, _Callbacks_type&& _Callbacks) {
-    // Preconditions: _Begin != _End && *_Begin != '}'
-
+    _STL_INTERNAL_CHECK(_Begin != _End && *_Begin != '}');
     // align and fill
     auto _Parsed_align = _Align::_None;
     auto _Align_pt     = _Begin + 1;

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -220,6 +220,7 @@ constexpr const _CharT* _Parse_precision(const _CharT* _Begin, const _CharT* _En
     if (_Begin != _End) {
         _Ch = *_Begin;
     }
+
     if ('0' <= _Ch && _Ch <= '9') {
         int _Precision = 0;
         _Begin         = _Parse_nonnegative_integer(_Begin, _End, _Precision);

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -297,11 +297,11 @@ constexpr const _CharT* _Parse_format_specs(const _CharT* _Begin, const _CharT* 
 
     // Parse precision
     if (*_Begin == '*') {
-        _Begin == _Parse_precision(_Begin, _End, _Callbacks);
+        _Begin = _Parse_precision(_Begin, _End, _Callbacks);
     }
 
     // Parse type
-    if (_Begin != _End && _Begin != '}') {
+    if (_Begin != _End && *_Begin != '}') {
         _Callbacks._On_type(*_Begin++);
     }
     return _Begin;

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -274,7 +274,6 @@ constexpr const _CharT* _Parse_format_specs(const _CharT* _Begin, const _CharT* 
         return _Begin;
     }
 
-    // Parse hash.
     if (*_Begin == '#') {
         _Callbacks._On_hash();
         if (++_Begin == _End) {
@@ -282,7 +281,6 @@ constexpr const _CharT* _Parse_format_specs(const _CharT* _Begin, const _CharT* 
         }
     }
 
-    // Parse zero flag
     if (*_Begin == '0') {
         _Callbacks._On_zero();
         if (++_Begin == _End) {
@@ -295,12 +293,11 @@ constexpr const _CharT* _Parse_format_specs(const _CharT* _Begin, const _CharT* 
         return _Begin;
     }
 
-    // Parse precision
     if (*_Begin == '.') {
         _Begin = _Parse_precision(_Begin, _End, _Callbacks);
     }
 
-    // Parse type
+    // If there's anything remaining we assume it's a type.
     if (_Begin != _End && *_Begin != '}') {
         _Callbacks._On_type(*_Begin++);
     }

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -122,10 +122,7 @@ constexpr const _CharT* _Parse_arg_id(const _CharT* _Begin, const _CharT* _End, 
 
 template <class _CharT, _Parse_spec_callbacks<_CharT> _Callbacks_type>
 constexpr const _CharT* _Parse_align(const _CharT* _Begin, const _CharT* _End, _Callbacks_type&& _Callbacks) {
-    // done with parsing, or reached the end of a replacement field.
-    if (_Begin == _End || *_Begin == '}') {
-        return _Begin;
-    }
+    // Preconditions: _Begin != _End && *_Begin != '}'
 
     // align and fill
     auto _Parsed_align = _Align::_None;
@@ -267,6 +264,8 @@ constexpr const _CharT* _Parse_format_specs(const _CharT* _Begin, const _CharT* 
     case ' ':
         _Callbacks._On_sign(_Sign::_Space);
         ++_Begin;
+        break;
+    default:
         break;
     }
 

--- a/tests/std/tests/P0645R10_text_formatting_parsing/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_parsing/test.cpp
@@ -266,23 +266,29 @@ constexpr bool test_parse_format_specs() {
 
 int main() {
     test_parse_align<char>();
+    test_parse_align<wchar_t>();
+    static_assert(test_parse_align<char>());
+    static_assert(test_parse_align<wchar_t>());
+
+    test_parse_arg_id<char>();
+    test_parse_arg_id<wchar_t>();
     static_assert(test_parse_arg_id<char>());
     static_assert(test_parse_arg_id<wchar_t>());
+
     test_parse_width<char>();
     test_parse_width<wchar_t>();
     static_assert(test_parse_width<char>());
     static_assert(test_parse_width<wchar_t>());
+
     test_parse_precision<char>();
     test_parse_precision<wchar_t>();
     static_assert(test_parse_precision<char>());
     static_assert(test_parse_precision<wchar_t>());
-    test_parse_precision<char>();
-    test_parse_precision<wchar_t>();
-    static_assert(test_parse_precision<char>());
-    static_assert(test_parse_precision<wchar_t>());
+
     test_parse_format_specs<char>();
     test_parse_format_specs<wchar_t>();
     static_assert(test_parse_format_specs<char>());
     static_assert(test_parse_format_specs<wchar_t>());
+
     return 0;
 }

--- a/tests/std/tests/P0645R10_text_formatting_parsing/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_parsing/test.cpp
@@ -229,6 +229,8 @@ constexpr bool test_parse_format_specs() {
     view_typ s2(TYPED_LITERAL(CharT, "*>6}"));
     view_typ s3(TYPED_LITERAL(CharT, "*^6}"));
     view_typ s4(TYPED_LITERAL(CharT, "6d}"));
+    view_typ s5(TYPED_LITERAL(CharT, "*^+4.4a}"));
+    view_typ s6(TYPED_LITERAL(CharT, "*^+#04.4a}"));
     test_parse_helper(parse_format_specs_fn, s0, false, s0.size() - 1, {.expected_width = 6});
     test_parse_helper(parse_format_specs_fn, s1, false, s1.size(),
         {.expected_alignment = _Align::_Left,
@@ -243,6 +245,22 @@ constexpr bool test_parse_format_specs() {
             .expected_fill   = view_typ(TYPED_LITERAL(CharT, "*")),
             .expected_width  = 6});
     test_parse_helper(parse_format_specs_fn, s4, false, s4.size() - 1, {.expected_width = 6, .expected_type = 'd'});
+    test_parse_helper(parse_format_specs_fn, s5, false, s5.size() - 1,
+        {.expected_alignment    = _Align::_Center,
+            .expected_sign      = _Sign::_Plus,
+            .expected_fill      = view_typ(TYPED_LITERAL(CharT, "*")),
+            .expected_width     = 4,
+            .expected_precision = 4,
+            .expected_type      = 'a'});
+    test_parse_helper(parse_format_specs_fn, s6, false, s6.size() - 1,
+        {.expected_alignment    = _Align::_Center,
+            .expected_sign      = _Sign::_Plus,
+            .expected_fill      = view_typ(TYPED_LITERAL(CharT, "*")),
+            .expected_width     = 4,
+            .expected_precision = 4,
+            .expected_hash      = true,
+            .expected_zero      = true,
+            .expected_type      = 'a'});
     return true;
 }
 

--- a/tests/std/tests/P0645R10_text_formatting_parsing/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_parsing/test.cpp
@@ -224,21 +224,25 @@ constexpr bool test_parse_format_specs() {
     auto parse_format_specs_fn = _Parse_format_specs<CharT, testing_callbacks<CharT>>;
     using view_typ             = basic_string_view<CharT>;
 
-    auto s0 = view_typ(TYPED_LITERAL(CharT, "{:6}"));
-    auto s1 = view_typ(TYPED_LITERAL(CharT, "{:*<6}"));
-    auto s2 = view_typ(TYPED_LITERAL(CharT, "{:*>6}"));
-    auto s3 = view_typ(TYPED_LITERAL(CharT, "{:*^6}"));
-    auto s4 = view_typ(TYPED_LITERAL(CharT, "{:6d}"));
-
-    test_parse_helper(parse_format_specs_fn, s0, view_typ::npos, {.expected_width = 6});
-    test_parse_helper(parse_format_specs_fn, s1, view_typ::npos,
-        {.expected_fill = view_typ(TYPED_LITERAL(CharT, '*')), .expected_align = _Align::_Left, .expected_width = 6});
-    test_parse_helper(parse_format_specs_fn, s2, view_typ::npos,
-        {.expected_fill = view_typ(TYPED_LITERAL(CharT, '*')), .expected_align = _Align::_Right, .expected_width = 6});
-    test_parse_helper(parse_format_specs_fn, s3, view_typ::npos,
-        {.expected_fill = view_typ(TYPED_LITERAL(CharT, '*')), .expected_align = _Align::_Center, .expected_width = 6});
-    test_parse_helper(parse_format_specs_fn, s4, view_typ::npos, {.expected_width = 6, .expected_type = 'd'});
-
+    view_typ s0(TYPED_LITERAL(CharT, "6}"));
+    view_typ s1(TYPED_LITERAL(CharT, "*<6}"));
+    view_typ s2(TYPED_LITERAL(CharT, "*>6}"));
+    view_typ s3(TYPED_LITERAL(CharT, "*^6}"));
+    view_typ s4(TYPED_LITERAL(CharT, "6d}"));
+    test_parse_helper(parse_format_specs_fn, s0, false, view_typ::npos, {.expected_width = 6});
+    test_parse_helper(parse_format_specs_fn, s1, false, view_typ::npos,
+        {.expected_alignment = _Align::_Left,
+            .expected_fill   = view_typ(TYPED_LITERAL(CharT, "*")),
+            .expected_width  = 6});
+    test_parse_helper(parse_format_specs_fn, s2, false, view_typ::npos,
+        {.expected_alignment = _Align::_Right,
+            .expected_fill   = view_typ(TYPED_LITERAL(CharT, "*")),
+            .expected_width  = 6});
+    test_parse_helper(parse_format_specs_fn, s3, false, view_typ::npos,
+        {.expected_alignment = _Align::_Center,
+            .expected_fill   = view_typ(TYPED_LITERAL(CharT, "*")),
+            .expected_width  = 6});
+    test_parse_helper(parse_format_specs_fn, s4, false, view_typ::npos, {.expected_width = 6, .expected_type = 'd'});
     return true;
 }
 

--- a/tests/std/tests/P0645R10_text_formatting_parsing/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_parsing/test.cpp
@@ -202,11 +202,6 @@ constexpr bool test_parse_precision() {
 
 int main() {
     test_parse_align<char>();
-    test_parse_align<wchar_t>();
-    static_assert(test_parse_align<char>());
-    static_assert(test_parse_align<wchar_t>());
-    test_parse_arg_id<char>();
-    test_parse_arg_id<wchar_t>();
     static_assert(test_parse_arg_id<char>());
     static_assert(test_parse_arg_id<wchar_t>());
     test_parse_width<char>();

--- a/tests/std/tests/P0645R10_text_formatting_parsing/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_parsing/test.cpp
@@ -4,6 +4,7 @@
 #include <assert.h>
 #include <concepts>
 #include <format>
+#include <optional>
 #include <stdio.h>
 #include <string_view>
 
@@ -32,6 +33,7 @@ struct choose_literal<wchar_t> {
 template <typename CharT>
 struct testing_callbacks {
     _Align expected_alignment = _Align::_None;
+    _Sign expected_sign       = _Sign::_None;
     basic_string_view<CharT> expected_fill;
     int expected_width                   = -1;
     int expected_dynamic_width           = -1;
@@ -39,6 +41,9 @@ struct testing_callbacks {
     int expected_precision               = -1;
     int expected_dynamic_precision       = -1;
     bool expected_auto_dynamic_precision = false;
+    bool expected_hash                   = false;
+    bool expected_zero                   = false;
+    char expected_type                   = '\0';
     constexpr void _On_align(_Align aln) {
         assert(aln == expected_alignment);
     }
@@ -62,6 +67,18 @@ struct testing_callbacks {
     }
     constexpr void _On_dynamic_precision(_Auto_id_tag) {
         assert(expected_auto_dynamic_precision);
+    }
+    constexpr void _On_sign(_Sign sgn) {
+        assert(sgn = expected_sign);
+    }
+    constexpr void _On_hash() {
+        assert(expected_hash);
+    }
+    constexpr void _On_zero() {
+        assert(expected_zero);
+    }
+    constexpr void _On_type(CharT type) {
+        assert(type = expected_type);
     }
 };
 template <typename CharT>

--- a/tests/std/tests/P0645R10_text_formatting_parsing/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_parsing/test.cpp
@@ -110,12 +110,10 @@ constexpr bool test_parse_align() {
     auto parse_align_fn = _Parse_align<CharT, testing_callbacks<CharT>>;
     using view_typ      = basic_string_view<CharT>;
 
-    view_typ s0(TYPED_LITERAL(CharT, ""));
     view_typ s1(TYPED_LITERAL(CharT, "*<"));
     view_typ s2(TYPED_LITERAL(CharT, "*>"));
     view_typ s3(TYPED_LITERAL(CharT, "*^"));
 
-    test_parse_helper(parse_align_fn, s0, false, view_typ::npos, {.expected_fill = view_typ(TYPED_LITERAL(CharT, ""))});
     test_parse_helper(parse_align_fn, s1, false, view_typ::npos,
         {.expected_alignment = _Align::_Left, .expected_fill = view_typ(TYPED_LITERAL(CharT, "*"))});
     test_parse_helper(parse_align_fn, s2, false, view_typ::npos,

--- a/tests/std/tests/P0645R10_text_formatting_parsing/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_parsing/test.cpp
@@ -225,24 +225,24 @@ constexpr bool test_parse_format_specs() {
     using view_typ             = basic_string_view<CharT>;
 
     view_typ s0(TYPED_LITERAL(CharT, "6}"));
-    view_typ s1(TYPED_LITERAL(CharT, "*<6}"));
+    view_typ s1(TYPED_LITERAL(CharT, "*<6"));
     view_typ s2(TYPED_LITERAL(CharT, "*>6}"));
     view_typ s3(TYPED_LITERAL(CharT, "*^6}"));
     view_typ s4(TYPED_LITERAL(CharT, "6d}"));
-    test_parse_helper(parse_format_specs_fn, s0, false, view_typ::npos, {.expected_width = 6});
-    test_parse_helper(parse_format_specs_fn, s1, false, view_typ::npos,
+    test_parse_helper(parse_format_specs_fn, s0, false, s0.size() - 1, {.expected_width = 6});
+    test_parse_helper(parse_format_specs_fn, s1, false, s1.size(),
         {.expected_alignment = _Align::_Left,
             .expected_fill   = view_typ(TYPED_LITERAL(CharT, "*")),
             .expected_width  = 6});
-    test_parse_helper(parse_format_specs_fn, s2, false, view_typ::npos,
+    test_parse_helper(parse_format_specs_fn, s2, false, s2.size() - 1,
         {.expected_alignment = _Align::_Right,
             .expected_fill   = view_typ(TYPED_LITERAL(CharT, "*")),
             .expected_width  = 6});
-    test_parse_helper(parse_format_specs_fn, s3, false, view_typ::npos,
+    test_parse_helper(parse_format_specs_fn, s3, false, s3.size() - 1,
         {.expected_alignment = _Align::_Center,
             .expected_fill   = view_typ(TYPED_LITERAL(CharT, "*")),
             .expected_width  = 6});
-    test_parse_helper(parse_format_specs_fn, s4, false, view_typ::npos, {.expected_width = 6, .expected_type = 'd'});
+    test_parse_helper(parse_format_specs_fn, s4, false, s4.size() - 1, {.expected_width = 6, .expected_type = 'd'});
     return true;
 }
 

--- a/tests/std/tests/P0645R10_text_formatting_parsing/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_parsing/test.cpp
@@ -258,5 +258,9 @@ int main() {
     test_parse_precision<wchar_t>();
     static_assert(test_parse_precision<char>());
     static_assert(test_parse_precision<wchar_t>());
+    test_parse_format_specs<char>();
+    test_parse_format_specs<wchar_t>();
+    static_assert(test_parse_format_specs<char>());
+    static_assert(test_parse_format_specs<wchar_t>());
     return 0;
 }


### PR DESCRIPTION
* adds parse_format_specs, which implements the parsing of [format.string.std]

* adds some tests for this, although there's some work that really needs to happen on the testing code (I'd like testing_callbacks to actually check if the thing was called, not just that it was called with the right value).