### PR TITLE
Status Chart: Weekly update

### DIFF
--- a/daily_table.js
+++ b/daily_table.js
@@ -407,5 +407,12 @@ const daily_table = [
     { date: '2020-10-10', merged: 42.28, pr: 32, cxx20: 19, lwg: 1, issue: 292, bug: 93, avg_age: 70.65, avg_wait: 51.20, sum_age: 75.36, sum_wait: 54.62, },
     { date: '2020-10-11', merged: 41.38, pr: 32, cxx20: 19, lwg: 1, issue: 293, bug: 93, avg_age: 71.65, avg_wait: 52.20, sum_age: 76.43, sum_wait: 55.68, },
     { date: '2020-10-12', merged: 41.38, pr: 31, cxx20: 19, lwg: 1, issue: 292, bug: 93, avg_age: 74.87, avg_wait: 54.09, sum_age: 77.36, sum_wait: 55.89, },
+    { date: '2020-10-13', merged: 40.03, pr: 34, cxx20: 19, lwg: 1, issue: 293, bug: 94, avg_age: 69.21, avg_wait: 49.36, sum_age: 78.43, sum_wait: 55.94, },
+    { date: '2020-10-14', merged: 38.90, pr: 37, cxx20: 19, lwg: 1, issue: 293, bug: 94, avg_age: 64.57, avg_wait: 46.33, sum_age: 79.64, sum_wait: 57.15, },
+    { date: '2020-10-15', merged: 38.01, pr: 38, cxx20: 19, lwg: 1, issue: 293, bug: 94, avg_age: 63.87, avg_wait: 46.06, sum_age: 80.90, sum_wait: 58.34, },
+    { date: '2020-10-16', merged: 37.91, pr: 39, cxx20: 19, lwg: 1, issue: 294, bug: 94, avg_age: 62.84, avg_wait: 45.60, sum_age: 81.69, sum_wait: 59.28, },
+    { date: '2020-10-17', merged: 40.81, pr: 35, cxx20: 18, lwg: 1, issue: 293, bug: 92, avg_age: 70.20, avg_wait: 51.62, sum_age: 81.90, sum_wait: 60.22, },
+    { date: '2020-10-18', merged: 39.71, pr: 35, cxx20: 18, lwg: 1, issue: 291, bug: 92, avg_age: 71.20, avg_wait: 52.62, sum_age: 83.06, sum_wait: 61.39, },
+    { date: '2020-10-19', merged: 38.66, pr: 35, cxx20: 18, lwg: 1, issue: 292, bug: 92, avg_age: 72.20, avg_wait: 53.62, sum_age: 84.23, sum_wait: 62.55, },
 ];
 // Generated file - DO NOT EDIT manually!

--- a/index.html
+++ b/index.html
@@ -26,8 +26,8 @@
             font-weight: bold;
         }
     </style>
-    <script src="https://cdn.jsdelivr.net/npm/chart.js@2.9.3/dist/Chart.min.js"
-        integrity="sha256-R4pqcOYV8lt7snxMQO/HSbVCFRPMdrhAFMH+vr9giYI=" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@2.9.4/dist/Chart.min.js"
+        integrity="sha256-t9UJPrESBeG2ojKTIcFLPGF7nHi2vEc7f5A2KpH/UBU=" crossorigin="anonymous"></script>
     <script
         src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns@1.0.0/dist/chartjs-adapter-date-fns.bundle.min.js"
         integrity="sha256-OrN9od558nPowCwU4e475a5CCwTfCwSrk7TF7KYUoXk=" crossorigin="anonymous"></script>

--- a/index.html
+++ b/index.html
@@ -278,7 +278,7 @@
                         },
                         ticks: {
                             min: 0,
-                            max: 80,
+                            max: 100,
                             stepSize: 10,
                         },
                     },
@@ -293,7 +293,7 @@
                         },
                         ticks: {
                             min: 0,
-                            max: 80,
+                            max: 100,
                             stepSize: 10,
                         },
                     },

--- a/weekly_table.js
+++ b/weekly_table.js
@@ -175,4 +175,5 @@ const weekly_table = [
     { date: '2020-09-25', vso: 148, libcxx: 535 },
     { date: '2020-10-02', vso: 148, libcxx: 535 },
     { date: '2020-10-09', vso: 147, libcxx: 537 },
+    { date: '2020-10-16', vso: 148, libcxx: 537 },
 ];


### PR DESCRIPTION
Update chart.js to 2.9.4, a bugfix release.

Increase the max PR age from 80 to 100.

Live preview: [stephantlavavej.github.io/STL/](https://stephantlavavej.github.io/STL/)
===