### PR TITLE
Unsigned changed to unsigned int due to convention

### DIFF
--- a/tests/std/tests/P0088R3_variant/test.cpp
+++ b/tests/std/tests/P0088R3_variant/test.cpp
@@ -6617,10 +6617,10 @@ namespace msvc {
         //
         //===----------------------------------------------------------------------===//
 
-        enum CallType : unsigned { CT_None, CT_NonConst = 1, CT_Const = 2, CT_LValue = 4, CT_RValue = 8 };
+        enum CallType : unsigned int { CT_None, CT_NonConst = 1, CT_Const = 2, CT_LValue = 4, CT_RValue = 8 };
 
         constexpr CallType operator|(CallType LHS, CallType RHS) {
-            return static_cast<CallType>(static_cast<unsigned>(LHS) | static_cast<unsigned>(RHS));
+            return static_cast<CallType>(static_cast<unsigned int>(LHS) | static_cast<unsigned int>(RHS));
         }
 
         struct ForwardingCallObject {

--- a/tests/std/tests/P0088R3_variant/test.cpp
+++ b/tests/std/tests/P0088R3_variant/test.cpp
@@ -2135,7 +2135,7 @@ void test_copy_assignment_same_index() {
     assert(std::get<0>(v1) == 42);
   }
   {
-    using V = std::variant<int, long, unsigned>;
+    using V = std::variant<int, long, unsigned int>;
     V v1(43l);
     V v2(42l);
     V &vref = (v1 = v2);
@@ -2144,7 +2144,7 @@ void test_copy_assignment_same_index() {
     assert(std::get<1>(v1) == 42);
   }
   {
-    using V = std::variant<int, CopyAssign, unsigned>;
+    using V = std::variant<int, CopyAssign, unsigned int>;
     V v1(std::in_place_type<CopyAssign>, 43);
     V v2(std::in_place_type<CopyAssign>, 42);
     CopyAssign::reset();
@@ -2192,7 +2192,7 @@ void test_copy_assignment_same_index() {
   {
     struct {
       constexpr Result<long> operator()() const {
-        using V = std::variant<int, long, unsigned>;
+        using V = std::variant<int, long, unsigned int>;
         V v(43l);
         V v2(42l);
         v = v2;
@@ -2206,7 +2206,7 @@ void test_copy_assignment_same_index() {
   {
     struct {
       constexpr Result<int> operator()() const {
-        using V = std::variant<int, TCopyAssign, unsigned>;
+        using V = std::variant<int, TCopyAssign, unsigned int>;
         V v(std::in_place_type<TCopyAssign>, 43);
         V v2(std::in_place_type<TCopyAssign>, 42);
         v = v2;
@@ -2220,7 +2220,7 @@ void test_copy_assignment_same_index() {
   {
     struct {
       constexpr Result<int> operator()() const {
-        using V = std::variant<int, TCopyAssignNTMoveAssign, unsigned>;
+        using V = std::variant<int, TCopyAssignNTMoveAssign, unsigned int>;
         V v(std::in_place_type<TCopyAssignNTMoveAssign>, 43);
         V v2(std::in_place_type<TCopyAssignNTMoveAssign>, 42);
         v = v2;
@@ -2236,7 +2236,7 @@ void test_copy_assignment_same_index() {
 
 void test_copy_assignment_different_index() {
   {
-    using V = std::variant<int, long, unsigned>;
+    using V = std::variant<int, long, unsigned int>;
     V v1(43);
     V v2(42l);
     V &vref = (v1 = v2);
@@ -2245,9 +2245,9 @@ void test_copy_assignment_different_index() {
     assert(std::get<1>(v1) == 42);
   }
   {
-    using V = std::variant<int, CopyAssign, unsigned>;
+    using V = std::variant<int, CopyAssign, unsigned int>;
     CopyAssign::reset();
-    V v1(std::in_place_type<unsigned>, 43u);
+    V v1(std::in_place_type<unsigned int>, 43u);
     V v2(std::in_place_type<CopyAssign>, 42);
     assert(CopyAssign::copy_construct == 0);
     assert(CopyAssign::move_construct == 0);
@@ -2326,7 +2326,7 @@ void test_copy_assignment_different_index() {
   {
     struct {
       constexpr Result<long> operator()() const {
-        using V = std::variant<int, long, unsigned>;
+        using V = std::variant<int, long, unsigned int>;
         V v(43);
         V v2(42l);
         v = v2;
@@ -2340,8 +2340,8 @@ void test_copy_assignment_different_index() {
   {
     struct {
       constexpr Result<int> operator()() const {
-        using V = std::variant<int, TCopyAssign, unsigned>;
-        V v(std::in_place_type<unsigned>, 43u);
+        using V = std::variant<int, TCopyAssign, unsigned int>;
+        V v(std::in_place_type<unsigned int>, 43u);
         V v2(std::in_place_type<TCopyAssign>, 42);
         v = v2;
         return {v.index(), std::get<1>(v).value};
@@ -2707,7 +2707,7 @@ void test_move_assignment_same_index() {
     assert(std::get<0>(v1) == 42);
   }
   {
-    using V = std::variant<int, long, unsigned>;
+    using V = std::variant<int, long, unsigned int>;
     V v1(43l);
     V v2(42l);
     V &vref = (v1 = std::move(v2));
@@ -2716,7 +2716,7 @@ void test_move_assignment_same_index() {
     assert(std::get<1>(v1) == 42);
   }
   {
-    using V = std::variant<int, MoveAssign, unsigned>;
+    using V = std::variant<int, MoveAssign, unsigned int>;
     V v1(std::in_place_type<MoveAssign>, 43);
     V v2(std::in_place_type<MoveAssign>, 42);
     MoveAssign::reset();
@@ -2763,7 +2763,7 @@ void test_move_assignment_same_index() {
   {
     struct {
       constexpr Result<long> operator()() const {
-        using V = std::variant<int, long, unsigned>;
+        using V = std::variant<int, long, unsigned int>;
         V v(43l);
         V v2(42l);
         v = std::move(v2);
@@ -2777,7 +2777,7 @@ void test_move_assignment_same_index() {
   {
     struct {
       constexpr Result<int> operator()() const {
-        using V = std::variant<int, TMoveAssign, unsigned>;
+        using V = std::variant<int, TMoveAssign, unsigned int>;
         V v(std::in_place_type<TMoveAssign>, 43);
         V v2(std::in_place_type<TMoveAssign>, 42);
         v = std::move(v2);
@@ -2793,7 +2793,7 @@ void test_move_assignment_same_index() {
 
 void test_move_assignment_different_index() {
   {
-    using V = std::variant<int, long, unsigned>;
+    using V = std::variant<int, long, unsigned int>;
     V v1(43);
     V v2(42l);
     V &vref = (v1 = std::move(v2));
@@ -2802,8 +2802,8 @@ void test_move_assignment_different_index() {
     assert(std::get<1>(v1) == 42);
   }
   {
-    using V = std::variant<int, MoveAssign, unsigned>;
-    V v1(std::in_place_type<unsigned>, 43u);
+    using V = std::variant<int, MoveAssign, unsigned int>;
+    V v1(std::in_place_type<unsigned int>, 43u);
     V v2(std::in_place_type<MoveAssign>, 42);
     MoveAssign::reset();
     V &vref = (v1 = std::move(v2));
@@ -2843,7 +2843,7 @@ void test_move_assignment_different_index() {
   {
     struct {
       constexpr Result<long> operator()() const {
-        using V = std::variant<int, long, unsigned>;
+        using V = std::variant<int, long, unsigned int>;
         V v(43);
         V v2(42l);
         v = std::move(v2);
@@ -2857,8 +2857,8 @@ void test_move_assignment_different_index() {
   {
     struct {
       constexpr Result<long> operator()() const {
-        using V = std::variant<int, TMoveAssign, unsigned>;
-        V v(std::in_place_type<unsigned>, 43u);
+        using V = std::variant<int, TMoveAssign, unsigned int>;
+        V v(std::in_place_type<unsigned int>, 43u);
         V v2(std::in_place_type<TMoveAssign>, 42);
         v = std::move(v2);
         return {v.index(), std::get<1>(v).value};
@@ -3107,7 +3107,7 @@ void test_T_assignment_basic() {
 #if 0 // TRANSITION, P0608
 #ifndef TEST_VARIANT_ALLOWS_NARROWING_CONVERSIONS
   {
-    std::variant<unsigned, long> v;
+    std::variant<unsigned int, long> v;
     v = 42;
     assert(v.index() == 1);
     assert(std::get<1>(v) == 42);
@@ -4632,7 +4632,7 @@ void test_T_ctor_basic() {
 #if 0 // TRANSITION, P0608
 #ifndef TEST_VARIANT_ALLOWS_NARROWING_CONVERSIONS
   {
-    constexpr std::variant<unsigned, long> v(42);
+    constexpr std::variant<unsigned int, long> v(42);
     static_assert(v.index() == 1, "");
     static_assert(std::get<1>(v) == 42, "");
   }
@@ -6073,7 +6073,7 @@ int run_test() {
 #include "variant_test_helpers.h"
 
 namespace visit {
-enum CallType : unsigned {
+enum CallType : unsigned int {
   CT_None,
   CT_NonConst = 1,
   CT_Const = 2,
@@ -6082,8 +6082,8 @@ enum CallType : unsigned {
 };
 
 inline constexpr CallType operator|(CallType LHS, CallType RHS) {
-  return static_cast<CallType>(static_cast<unsigned>(LHS) |
-                               static_cast<unsigned>(RHS));
+  return static_cast<CallType>(static_cast<unsigned int>(LHS) |
+                               static_cast<unsigned int>(RHS));
 }
 
 struct ForwardingCallObject {
@@ -6617,10 +6617,10 @@ namespace msvc {
         //
         //===----------------------------------------------------------------------===//
 
-        enum CallType : unsigned { CT_None, CT_NonConst = 1, CT_Const = 2, CT_LValue = 4, CT_RValue = 8 };
+        enum CallType : unsigned int { CT_None, CT_NonConst = 1, CT_Const = 2, CT_LValue = 4, CT_RValue = 8 };
 
         constexpr CallType operator|(CallType LHS, CallType RHS) {
-            return static_cast<CallType>(static_cast<unsigned>(LHS) | static_cast<unsigned>(RHS));
+            return static_cast<CallType>(static_cast<unsigned int>(LHS) | static_cast<unsigned int>(RHS));
         }
 
         struct ForwardingCallObject {

--- a/tests/std/tests/P0088R3_variant/test.cpp
+++ b/tests/std/tests/P0088R3_variant/test.cpp
@@ -2135,7 +2135,7 @@ void test_copy_assignment_same_index() {
     assert(std::get<0>(v1) == 42);
   }
   {
-    using V = std::variant<int, long, unsigned int>;
+    using V = std::variant<int, long, unsigned>;
     V v1(43l);
     V v2(42l);
     V &vref = (v1 = v2);
@@ -2144,7 +2144,7 @@ void test_copy_assignment_same_index() {
     assert(std::get<1>(v1) == 42);
   }
   {
-    using V = std::variant<int, CopyAssign, unsigned int>;
+    using V = std::variant<int, CopyAssign, unsigned>;
     V v1(std::in_place_type<CopyAssign>, 43);
     V v2(std::in_place_type<CopyAssign>, 42);
     CopyAssign::reset();
@@ -2192,7 +2192,7 @@ void test_copy_assignment_same_index() {
   {
     struct {
       constexpr Result<long> operator()() const {
-        using V = std::variant<int, long, unsigned int>;
+        using V = std::variant<int, long, unsigned>;
         V v(43l);
         V v2(42l);
         v = v2;
@@ -2206,7 +2206,7 @@ void test_copy_assignment_same_index() {
   {
     struct {
       constexpr Result<int> operator()() const {
-        using V = std::variant<int, TCopyAssign, unsigned int>;
+        using V = std::variant<int, TCopyAssign, unsigned>;
         V v(std::in_place_type<TCopyAssign>, 43);
         V v2(std::in_place_type<TCopyAssign>, 42);
         v = v2;
@@ -2220,7 +2220,7 @@ void test_copy_assignment_same_index() {
   {
     struct {
       constexpr Result<int> operator()() const {
-        using V = std::variant<int, TCopyAssignNTMoveAssign, unsigned int>;
+        using V = std::variant<int, TCopyAssignNTMoveAssign, unsigned>;
         V v(std::in_place_type<TCopyAssignNTMoveAssign>, 43);
         V v2(std::in_place_type<TCopyAssignNTMoveAssign>, 42);
         v = v2;
@@ -2236,7 +2236,7 @@ void test_copy_assignment_same_index() {
 
 void test_copy_assignment_different_index() {
   {
-    using V = std::variant<int, long, unsigned int>;
+    using V = std::variant<int, long, unsigned>;
     V v1(43);
     V v2(42l);
     V &vref = (v1 = v2);
@@ -2245,9 +2245,9 @@ void test_copy_assignment_different_index() {
     assert(std::get<1>(v1) == 42);
   }
   {
-    using V = std::variant<int, CopyAssign, unsigned int>;
+    using V = std::variant<int, CopyAssign, unsigned>;
     CopyAssign::reset();
-    V v1(std::in_place_type<unsigned int>, 43u);
+    V v1(std::in_place_type<unsigned>, 43u);
     V v2(std::in_place_type<CopyAssign>, 42);
     assert(CopyAssign::copy_construct == 0);
     assert(CopyAssign::move_construct == 0);
@@ -2326,7 +2326,7 @@ void test_copy_assignment_different_index() {
   {
     struct {
       constexpr Result<long> operator()() const {
-        using V = std::variant<int, long, unsigned int>;
+        using V = std::variant<int, long, unsigned>;
         V v(43);
         V v2(42l);
         v = v2;
@@ -2340,8 +2340,8 @@ void test_copy_assignment_different_index() {
   {
     struct {
       constexpr Result<int> operator()() const {
-        using V = std::variant<int, TCopyAssign, unsigned int>;
-        V v(std::in_place_type<unsigned int>, 43u);
+        using V = std::variant<int, TCopyAssign, unsigned>;
+        V v(std::in_place_type<unsigned>, 43u);
         V v2(std::in_place_type<TCopyAssign>, 42);
         v = v2;
         return {v.index(), std::get<1>(v).value};
@@ -2707,7 +2707,7 @@ void test_move_assignment_same_index() {
     assert(std::get<0>(v1) == 42);
   }
   {
-    using V = std::variant<int, long, unsigned int>;
+    using V = std::variant<int, long, unsigned>;
     V v1(43l);
     V v2(42l);
     V &vref = (v1 = std::move(v2));
@@ -2716,7 +2716,7 @@ void test_move_assignment_same_index() {
     assert(std::get<1>(v1) == 42);
   }
   {
-    using V = std::variant<int, MoveAssign, unsigned int>;
+    using V = std::variant<int, MoveAssign, unsigned>;
     V v1(std::in_place_type<MoveAssign>, 43);
     V v2(std::in_place_type<MoveAssign>, 42);
     MoveAssign::reset();
@@ -2763,7 +2763,7 @@ void test_move_assignment_same_index() {
   {
     struct {
       constexpr Result<long> operator()() const {
-        using V = std::variant<int, long, unsigned int>;
+        using V = std::variant<int, long, unsigned>;
         V v(43l);
         V v2(42l);
         v = std::move(v2);
@@ -2777,7 +2777,7 @@ void test_move_assignment_same_index() {
   {
     struct {
       constexpr Result<int> operator()() const {
-        using V = std::variant<int, TMoveAssign, unsigned int>;
+        using V = std::variant<int, TMoveAssign, unsigned>;
         V v(std::in_place_type<TMoveAssign>, 43);
         V v2(std::in_place_type<TMoveAssign>, 42);
         v = std::move(v2);
@@ -2793,7 +2793,7 @@ void test_move_assignment_same_index() {
 
 void test_move_assignment_different_index() {
   {
-    using V = std::variant<int, long, unsigned int>;
+    using V = std::variant<int, long, unsigned>;
     V v1(43);
     V v2(42l);
     V &vref = (v1 = std::move(v2));
@@ -2802,8 +2802,8 @@ void test_move_assignment_different_index() {
     assert(std::get<1>(v1) == 42);
   }
   {
-    using V = std::variant<int, MoveAssign, unsigned int>;
-    V v1(std::in_place_type<unsigned int>, 43u);
+    using V = std::variant<int, MoveAssign, unsigned>;
+    V v1(std::in_place_type<unsigned>, 43u);
     V v2(std::in_place_type<MoveAssign>, 42);
     MoveAssign::reset();
     V &vref = (v1 = std::move(v2));
@@ -2843,7 +2843,7 @@ void test_move_assignment_different_index() {
   {
     struct {
       constexpr Result<long> operator()() const {
-        using V = std::variant<int, long, unsigned int>;
+        using V = std::variant<int, long, unsigned>;
         V v(43);
         V v2(42l);
         v = std::move(v2);
@@ -2857,8 +2857,8 @@ void test_move_assignment_different_index() {
   {
     struct {
       constexpr Result<long> operator()() const {
-        using V = std::variant<int, TMoveAssign, unsigned int>;
-        V v(std::in_place_type<unsigned int>, 43u);
+        using V = std::variant<int, TMoveAssign, unsigned>;
+        V v(std::in_place_type<unsigned>, 43u);
         V v2(std::in_place_type<TMoveAssign>, 42);
         v = std::move(v2);
         return {v.index(), std::get<1>(v).value};
@@ -3107,7 +3107,7 @@ void test_T_assignment_basic() {
 #if 0 // TRANSITION, P0608
 #ifndef TEST_VARIANT_ALLOWS_NARROWING_CONVERSIONS
   {
-    std::variant<unsigned int, long> v;
+    std::variant<unsigned, long> v;
     v = 42;
     assert(v.index() == 1);
     assert(std::get<1>(v) == 42);
@@ -4632,7 +4632,7 @@ void test_T_ctor_basic() {
 #if 0 // TRANSITION, P0608
 #ifndef TEST_VARIANT_ALLOWS_NARROWING_CONVERSIONS
   {
-    constexpr std::variant<unsigned int, long> v(42);
+    constexpr std::variant<unsigned, long> v(42);
     static_assert(v.index() == 1, "");
     static_assert(std::get<1>(v) == 42, "");
   }
@@ -6073,7 +6073,7 @@ int run_test() {
 #include "variant_test_helpers.h"
 
 namespace visit {
-enum CallType : unsigned int {
+enum CallType : unsigned {
   CT_None,
   CT_NonConst = 1,
   CT_Const = 2,
@@ -6082,8 +6082,8 @@ enum CallType : unsigned int {
 };
 
 inline constexpr CallType operator|(CallType LHS, CallType RHS) {
-  return static_cast<CallType>(static_cast<unsigned int>(LHS) |
-                               static_cast<unsigned int>(RHS));
+  return static_cast<CallType>(static_cast<unsigned>(LHS) |
+                               static_cast<unsigned>(RHS));
 }
 
 struct ForwardingCallObject {
@@ -6617,10 +6617,10 @@ namespace msvc {
         //
         //===----------------------------------------------------------------------===//
 
-        enum CallType : unsigned int { CT_None, CT_NonConst = 1, CT_Const = 2, CT_LValue = 4, CT_RValue = 8 };
+        enum CallType : unsigned { CT_None, CT_NonConst = 1, CT_Const = 2, CT_LValue = 4, CT_RValue = 8 };
 
         constexpr CallType operator|(CallType LHS, CallType RHS) {
-            return static_cast<CallType>(static_cast<unsigned int>(LHS) | static_cast<unsigned int>(RHS));
+            return static_cast<CallType>(static_cast<unsigned>(LHS) | static_cast<unsigned>(RHS));
         }
 
         struct ForwardingCallObject {

--- a/tests/std/tests/P0220R1_optional/test.cpp
+++ b/tests/std/tests/P0220R1_optional/test.cpp
@@ -5718,7 +5718,7 @@ class X
 {
     int i_;
 public:
-    static unsigned int dtor_called;
+    static unsigned dtor_called;
     X(int i) : i_(i) {}
     X(X&& x) = default;
     X& operator=(X&&) = default;
@@ -5727,13 +5727,13 @@ public:
     friend bool operator==(const X& x, const X& y) {return x.i_ == y.i_;}
 };
 
-unsigned int X::dtor_called = 0;
+unsigned X::dtor_called = 0;
 
 class Y
 {
     int i_;
 public:
-    static unsigned int dtor_called;
+    static unsigned dtor_called;
     Y(int i) : i_(i) {}
     Y(Y&&) = default;
     ~Y() {++dtor_called;}
@@ -5742,7 +5742,7 @@ public:
     friend void swap(Y& x, Y& y) {std::swap(x.i_, y.i_);}
 };
 
-unsigned int Y::dtor_called = 0;
+unsigned Y::dtor_called = 0;
 
 class Z
 {
@@ -6955,7 +6955,7 @@ class X
 {
     int i_;
 public:
-    static unsigned int dtor_called;
+    static unsigned dtor_called;
     X(int i) : i_(i) {}
     X(X&& x) = default;
     X& operator=(X&&) = default;
@@ -6964,13 +6964,13 @@ public:
     friend bool operator==(const X& x, const X& y) {return x.i_ == y.i_;}
 };
 
-unsigned int X::dtor_called = 0;
+unsigned X::dtor_called = 0;
 
 class Y
 {
     int i_;
 public:
-    static unsigned int dtor_called;
+    static unsigned dtor_called;
     Y(int i) : i_(i) {}
     Y(Y&&) = default;
     ~Y() {++dtor_called;}
@@ -6979,7 +6979,7 @@ public:
     friend void swap(Y& x, Y& y) {std::swap(x.i_, y.i_);}
 };
 
-unsigned int Y::dtor_called = 0;
+unsigned Y::dtor_called = 0;
 
 class Z
 {

--- a/tests/std/tests/P0220R1_optional/test.cpp
+++ b/tests/std/tests/P0220R1_optional/test.cpp
@@ -5718,7 +5718,7 @@ class X
 {
     int i_;
 public:
-    static unsigned dtor_called;
+    static unsigned int dtor_called;
     X(int i) : i_(i) {}
     X(X&& x) = default;
     X& operator=(X&&) = default;
@@ -5727,13 +5727,13 @@ public:
     friend bool operator==(const X& x, const X& y) {return x.i_ == y.i_;}
 };
 
-unsigned X::dtor_called = 0;
+unsigned int X::dtor_called = 0;
 
 class Y
 {
     int i_;
 public:
-    static unsigned dtor_called;
+    static unsigned int dtor_called;
     Y(int i) : i_(i) {}
     Y(Y&&) = default;
     ~Y() {++dtor_called;}
@@ -5742,7 +5742,7 @@ public:
     friend void swap(Y& x, Y& y) {std::swap(x.i_, y.i_);}
 };
 
-unsigned Y::dtor_called = 0;
+unsigned int Y::dtor_called = 0;
 
 class Z
 {
@@ -6955,7 +6955,7 @@ class X
 {
     int i_;
 public:
-    static unsigned dtor_called;
+    static unsigned int dtor_called;
     X(int i) : i_(i) {}
     X(X&& x) = default;
     X& operator=(X&&) = default;
@@ -6964,13 +6964,13 @@ public:
     friend bool operator==(const X& x, const X& y) {return x.i_ == y.i_;}
 };
 
-unsigned X::dtor_called = 0;
+unsigned int X::dtor_called = 0;
 
 class Y
 {
     int i_;
 public:
-    static unsigned dtor_called;
+    static unsigned int dtor_called;
     Y(int i) : i_(i) {}
     Y(Y&&) = default;
     ~Y() {++dtor_called;}
@@ -6979,7 +6979,7 @@ public:
     friend void swap(Y& x, Y& y) {std::swap(x.i_, y.i_);}
 };
 
-unsigned Y::dtor_called = 0;
+unsigned int Y::dtor_called = 0;
 
 class Z
 {

--- a/tests/std/tests/P0898R3_concepts/test.cpp
+++ b/tests/std/tests/P0898R3_concepts/test.cpp
@@ -876,7 +876,7 @@ namespace test_integral_concepts {
 
     STATIC_ASSERT(test_integral<unsigned char, is_signed::no>());
     STATIC_ASSERT(test_integral<unsigned short, is_signed::no>());
-    STATIC_ASSERT(test_integral<unsigned, is_signed::no>());
+    STATIC_ASSERT(test_integral<unsigned int, is_signed::no>());
     STATIC_ASSERT(test_integral<unsigned long, is_signed::no>());
     STATIC_ASSERT(test_integral<unsigned long long, is_signed::no>());
 
@@ -934,7 +934,7 @@ namespace test_floating_point {
 
     STATIC_ASSERT(!test_floating_point<unsigned char>());
     STATIC_ASSERT(!test_floating_point<unsigned short>());
-    STATIC_ASSERT(!test_floating_point<unsigned>());
+    STATIC_ASSERT(!test_floating_point<unsigned int>());
     STATIC_ASSERT(!test_floating_point<unsigned long>());
     STATIC_ASSERT(!test_floating_point<unsigned long long>());
 
@@ -2403,7 +2403,7 @@ namespace test_boolean_testable {
     };
     STATIC_ASSERT(_Boolean_testable<MutatingBoolConversion>);
 
-    template <unsigned Select> // values in [0, Archetype_max) select a requirement to violate
+    template <unsigned int Select> // values in [0, Archetype_max) select a requirement to violate
     struct Archetype {
         // clang-format off
         operator bool() const requires (Select != 0); // Archetype<0> is not implicitly convertible to bool
@@ -2448,14 +2448,14 @@ namespace test_equality_comparable {
 
     STATIC_ASSERT(!test<EmptyClass>());
 
-    template <unsigned> // selects one requirement to violate
+    template <unsigned int> // selects one requirement to violate
     struct Archetype {};
 
-    template <unsigned Select>
+    template <unsigned int Select>
     bool operator==(Archetype<Select> const&, Archetype<Select> const&);
     void operator==(Archetype<0> const&, Archetype<0> const&); // Archetype<0> == Archetype<0> is not _Boolean_testable
 
-    template <unsigned Select>
+    template <unsigned int Select>
     bool operator!=(Archetype<Select> const&, Archetype<Select> const&);
     void operator!=(Archetype<1> const&, Archetype<1> const&); // Archetype<1> != Archetype<1> is not _Boolean_testable
 
@@ -2605,31 +2605,31 @@ namespace test_totally_ordered {
     STATIC_ASSERT(!test<std::nullptr_t>());
     STATIC_ASSERT(!test<EmptyClass>());
 
-    constexpr unsigned Archetype_max = 6;
-    template <unsigned> // values in [0, Archetype_max) select a requirement to violate
+    constexpr unsigned int Archetype_max = 6;
+    template <unsigned int> // values in [0, Archetype_max) select a requirement to violate
     struct Archetype {};
 
-    template <unsigned Select>
+    template <unsigned int Select>
     bool operator==(Archetype<Select> const&, Archetype<Select> const&);
     void operator==(Archetype<0> const&, Archetype<0> const&);
 
-    template <unsigned Select>
+    template <unsigned int Select>
     bool operator!=(Archetype<Select> const&, Archetype<Select> const&);
     void operator!=(Archetype<1> const&, Archetype<1> const&);
 
-    template <unsigned Select>
+    template <unsigned int Select>
     bool operator<(Archetype<Select> const&, Archetype<Select> const&);
     void operator<(Archetype<2> const&, Archetype<2> const&);
 
-    template <unsigned Select>
+    template <unsigned int Select>
     bool operator>(Archetype<Select> const&, Archetype<Select> const&);
     void operator>(Archetype<3> const&, Archetype<3> const&);
 
-    template <unsigned Select>
+    template <unsigned int Select>
     bool operator<=(Archetype<Select> const&, Archetype<Select> const&);
     void operator<=(Archetype<4> const&, Archetype<4> const&);
 
-    template <unsigned Select>
+    template <unsigned int Select>
     bool operator>=(Archetype<Select> const&, Archetype<Select> const&);
     void operator>=(Archetype<5> const&, Archetype<5> const&);
 
@@ -3334,29 +3334,29 @@ namespace test_relation {
         operator bool() const;
     };
 
-    template <unsigned>
+    template <unsigned int>
     struct A {};
     // clang-format off
-    template <unsigned U>
+    template <unsigned int U>
         requires (0 < U)
     Bool operator==(A<U>, A<U>); // A<0> == A<0> is invalid
     // clang-format on
     STATIC_ASSERT(!test<Equivalent, A<0>>());
     STATIC_ASSERT(test<Equivalent, A<1>>());
 
-    template <unsigned>
+    template <unsigned int>
     struct B {};
     void operator==(B<1>, B<1>); // B<1> == B<1> does not model _Boolean_testable
-    template <unsigned U>
+    template <unsigned int U>
     bool operator==(B<U>, B<U>);
     STATIC_ASSERT(test<Equivalent, B<0>>());
     STATIC_ASSERT(!test<Equivalent, B<1>>());
 
     // clang-format off
-    template <unsigned I>
+    template <unsigned int I>
         requires (2 != I)
     bool operator==(A<I>, B<I>); // A<2> == B<2> rewrites to B<2> == A<2>
-    template <unsigned I>
+    template <unsigned int I>
         requires (3 != I)
     bool operator==(B<I>, A<I>); // B<3> == A<3> rewrites to A<3> == B<3>
     // clang-format on
@@ -3367,12 +3367,12 @@ namespace test_relation {
     STATIC_ASSERT(test<Equivalent, A<3>, B<3>>());
     STATIC_ASSERT(test<Equivalent, A<4>, B<4>>());
 
-    template <unsigned I>
+    template <unsigned int I>
     struct C {};
     enum E : bool { No, Yes };
     E operator==(C<0>&, C<0>&); // const C<0> == const C<0> is invalid
     // clang-format off
-    template <unsigned I>
+    template <unsigned int I>
         requires (0 != I)
     E operator==(C<I>, C<I>);
     // clang-format on
@@ -3397,23 +3397,23 @@ namespace test_uniform_random_bit_generator {
     STATIC_ASSERT(uniform_random_bit_generator<std::random_device>);
 
     struct NoCall {
-        static constexpr unsigned min() {
+        static constexpr unsigned int min() {
             return 0;
         }
-        static constexpr unsigned max() {
+        static constexpr unsigned int max() {
             return 42;
         }
     };
     STATIC_ASSERT(!uniform_random_bit_generator<NoCall>);
 
     struct NoLvalueCall {
-        static constexpr unsigned min() {
+        static constexpr unsigned int min() {
             return 0;
         }
-        static constexpr unsigned max() {
+        static constexpr unsigned int max() {
             return 42;
         }
-        unsigned operator()() &&;
+        unsigned int operator()() &&;
     };
     STATIC_ASSERT(!uniform_random_bit_generator<NoLvalueCall>);
 
@@ -3429,21 +3429,21 @@ namespace test_uniform_random_bit_generator {
     STATIC_ASSERT(!uniform_random_bit_generator<SignedValue>);
 
     struct NoMin {
-        static constexpr unsigned max() {
+        static constexpr unsigned int max() {
             return 42;
         }
-        unsigned operator()();
+        unsigned int operator()();
     };
     STATIC_ASSERT(!uniform_random_bit_generator<NoMin>);
 
     struct NonConstexprMin {
-        static unsigned min() {
+        static unsigned int min() {
             return 0;
         }
-        static constexpr unsigned max() {
+        static constexpr unsigned int max() {
             return 42;
         }
-        unsigned operator()();
+        unsigned int operator()();
     };
     STATIC_ASSERT(!uniform_random_bit_generator<NonConstexprMin>);
 
@@ -3451,85 +3451,85 @@ namespace test_uniform_random_bit_generator {
         static constexpr int min() {
             return 0;
         }
-        static constexpr unsigned max() {
+        static constexpr unsigned int max() {
             return 42;
         }
-        unsigned operator()();
+        unsigned int operator()();
     };
     STATIC_ASSERT(!uniform_random_bit_generator<BadMin>);
 
     struct NoMax {
-        static constexpr unsigned min() {
+        static constexpr unsigned int min() {
             return 0;
         }
-        unsigned operator()();
+        unsigned int operator()();
     };
     STATIC_ASSERT(!uniform_random_bit_generator<NoMax>);
 
     struct NonConstexprMax {
-        static constexpr unsigned min() {
+        static constexpr unsigned int min() {
             return 0;
         }
-        static unsigned max() {
+        static unsigned int max() {
             return 42;
         }
-        unsigned operator()();
+        unsigned int operator()();
     };
     STATIC_ASSERT(!uniform_random_bit_generator<NonConstexprMax>);
 
     struct BadMax {
-        static constexpr unsigned min() {
+        static constexpr unsigned int min() {
             return 0;
         }
         static constexpr int max() {
             return 42;
         }
-        unsigned operator()();
+        unsigned int operator()();
     };
     STATIC_ASSERT(!uniform_random_bit_generator<BadMax>);
 
     struct EmptyRange {
-        static constexpr unsigned min() {
+        static constexpr unsigned int min() {
             return 0;
         }
-        static constexpr unsigned max() {
+        static constexpr unsigned int max() {
             return 0;
         }
-        unsigned operator()();
+        unsigned int operator()();
     };
     STATIC_ASSERT(!uniform_random_bit_generator<EmptyRange>);
 
     struct ReversedRange {
-        static constexpr unsigned min() {
+        static constexpr unsigned int min() {
             return 42;
         }
-        static constexpr unsigned max() {
+        static constexpr unsigned int max() {
             return 0;
         }
-        unsigned operator()();
+        unsigned int operator()();
     };
     STATIC_ASSERT(!uniform_random_bit_generator<ReversedRange>);
 
     struct URBG {
-        static constexpr unsigned min() {
+        static constexpr unsigned int min() {
             return 0;
         }
-        static constexpr unsigned max() {
+        static constexpr unsigned int max() {
             return 42;
         }
-        unsigned operator()();
+        unsigned int operator()();
     };
     STATIC_ASSERT(uniform_random_bit_generator<URBG>);
     STATIC_ASSERT(!uniform_random_bit_generator<const URBG>);
 
     struct ConstURBG {
-        static constexpr unsigned min() {
+        static constexpr unsigned int min() {
             return 0;
         }
-        static constexpr unsigned max() {
+        static constexpr unsigned int max() {
             return 42;
         }
-        unsigned operator()() const;
+        unsigned int operator()() const;
     };
     STATIC_ASSERT(uniform_random_bit_generator<ConstURBG>);
     STATIC_ASSERT(uniform_random_bit_generator<const ConstURBG>);


### PR DESCRIPTION
Using of unsigned changed to unsigned int according to [convention (comment)](https://github.com/microsoft/STL/pull/1159#discussion_r498709286)

Fixes #1389 