### PR TITLE
Fix inconsistencies in range adaptor tests

### DIFF
--- a/tests/std/tests/P0896R4_views_all/test.cpp
+++ b/tests/std/tests/P0896R4_views_all/test.cpp
@@ -121,10 +121,10 @@ constexpr bool test_one(Rng&& rng) {
 
         static_assert(same_as<views::all_t<const remove_cvref_t<Rng>>, V>);
         static_assert(same_as<decltype(views::all(move(as_const(rng)))), V>);
-        static_assert(noexcept(views::all(as_const(rng))) == is_noexcept);
+        static_assert(noexcept(views::all(move(as_const(rng)))) == is_noexcept);
 
         static_assert(same_as<decltype(move(as_const(rng)) | views::all), V>);
-        static_assert(noexcept(as_const(rng) | views::all) == is_noexcept);
+        static_assert(noexcept(move(as_const(rng)) | views::all) == is_noexcept);
 
         static_assert(same_as<decltype(move(as_const(rng)) | views::all | views::all | views::all), V>);
         static_assert(noexcept(move(as_const(rng)) | views::all | views::all | views::all) == is_noexcept);

--- a/tests/std/tests/P0896R4_views_drop/test.cpp
+++ b/tests/std/tests/P0896R4_views_drop/test.cpp
@@ -159,10 +159,10 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
         constexpr bool is_noexcept = is_nothrow_copy_constructible_v<V> && !is_subrange<V>;
 
         STATIC_ASSERT(same_as<decltype(views::drop(move(as_const(rng)), 4)), M>);
-        STATIC_ASSERT(noexcept(views::drop(as_const(rng), 4)) == is_noexcept);
+        STATIC_ASSERT(noexcept(views::drop(move(as_const(rng)), 4)) == is_noexcept);
 
         STATIC_ASSERT(same_as<decltype(move(as_const(rng)) | drop_four), M>);
-        STATIC_ASSERT(noexcept(as_const(rng) | drop_four) == is_noexcept);
+        STATIC_ASSERT(noexcept(move(as_const(rng)) | drop_four) == is_noexcept);
 
         STATIC_ASSERT(same_as<decltype(move(as_const(rng)) | pipeline), pipeline_t<const remove_reference_t<Rng>>>);
         STATIC_ASSERT(noexcept(move(as_const(rng)) | pipeline) == is_noexcept);

--- a/tests/std/tests/P0896R4_views_filter/test.cpp
+++ b/tests/std/tests/P0896R4_views_filter/test.cpp
@@ -126,10 +126,10 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
         constexpr bool is_noexcept = is_nothrow_copy_constructible_v<V>;
 
         STATIC_ASSERT(same_as<decltype(views::filter(move(as_const(rng)), is_even)), F>);
-        STATIC_ASSERT(noexcept(views::filter(as_const(rng), is_even)) == is_noexcept);
+        STATIC_ASSERT(noexcept(views::filter(move(as_const(rng)), is_even)) == is_noexcept);
 
         STATIC_ASSERT(same_as<decltype(move(as_const(rng)) | filter_even), F>);
-        STATIC_ASSERT(noexcept(as_const(rng) | filter_even) == is_noexcept);
+        STATIC_ASSERT(noexcept(move(as_const(rng)) | filter_even) == is_noexcept);
 
         STATIC_ASSERT(same_as<decltype(move(as_const(rng)) | pipeline), pipeline_t<const remove_reference_t<Rng>>>);
         STATIC_ASSERT(noexcept(move(as_const(rng)) | pipeline) == is_noexcept);

--- a/tests/std/tests/P0896R4_views_reverse/test.cpp
+++ b/tests/std/tests/P0896R4_views_reverse/test.cpp
@@ -131,10 +131,10 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
         constexpr bool is_noexcept = is_nothrow_copy_constructible_v<V>;
 
         static_assert(same_as<decltype(views::reverse(move(as_const(rng)))), R>);
-        static_assert(noexcept(views::reverse(as_const(rng))) == is_nothrow_copy_constructible_v<R>);
+        static_assert(noexcept(views::reverse(move(as_const(rng)))) == is_nothrow_copy_constructible_v<R>);
 
         static_assert(same_as<decltype(move(as_const(rng)) | views::reverse), R>);
-        static_assert(noexcept(as_const(rng) | views::reverse) == is_nothrow_copy_constructible_v<R>);
+        static_assert(noexcept(move(as_const(rng)) | views::reverse) == is_nothrow_copy_constructible_v<R>);
 
         static_assert(same_as<decltype(move(as_const(rng)) | views::reverse | views::reverse | views::reverse), R>);
         static_assert(noexcept(move(as_const(rng)) | views::reverse | views::reverse | views::reverse) == is_noexcept);

--- a/tests/std/tests/P0896R4_views_take/test.cpp
+++ b/tests/std/tests/P0896R4_views_take/test.cpp
@@ -158,10 +158,10 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
         constexpr bool is_noexcept = is_nothrow_copy_constructible_v<V> && !is_subrange<V>;
 
         STATIC_ASSERT(same_as<decltype(views::take(move(as_const(rng)), 4)), M>);
-        STATIC_ASSERT(noexcept(views::take(as_const(rng), 4)) == is_noexcept);
+        STATIC_ASSERT(noexcept(views::take(move(as_const(rng)), 4)) == is_noexcept);
 
         STATIC_ASSERT(same_as<decltype(move(as_const(rng)) | take_four), M>);
-        STATIC_ASSERT(noexcept(as_const(rng) | take_four) == is_noexcept);
+        STATIC_ASSERT(noexcept(move(as_const(rng)) | take_four) == is_noexcept);
 
         STATIC_ASSERT(same_as<decltype(move(as_const(rng)) | pipeline), pipeline_t<const remove_reference_t<Rng>>>);
         STATIC_ASSERT(noexcept(move(as_const(rng)) | pipeline) == is_noexcept);

--- a/tests/std/tests/P0896R4_views_transform/test.cpp
+++ b/tests/std/tests/P0896R4_views_transform/test.cpp
@@ -134,10 +134,10 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
         constexpr bool is_noexcept = is_nothrow_copy_constructible_v<V>;
 
         STATIC_ASSERT(same_as<decltype(views::transform(move(as_const(rng)), add8)), TV>);
-        STATIC_ASSERT(noexcept(views::transform(as_const(rng), add8)) == is_noexcept);
+        STATIC_ASSERT(noexcept(views::transform(move(as_const(rng)), add8)) == is_noexcept);
 
         STATIC_ASSERT(same_as<decltype(move(as_const(rng)) | transform_incr), TV>);
-        STATIC_ASSERT(noexcept(as_const(rng) | transform_incr) == is_noexcept);
+        STATIC_ASSERT(noexcept(move(as_const(rng)) | transform_incr) == is_noexcept);
 
         STATIC_ASSERT(same_as<decltype(move(as_const(rng)) | pipeline), pipeline_t<const remove_reference_t<Rng>>>);
         STATIC_ASSERT(noexcept(move(as_const(rng)) | pipeline) == is_noexcept);


### PR DESCRIPTION
Stephan noticed a `move` missing from a line of code that meant to `move(as_const(rng))` while reviewing `common_view`. This bug (and for the most part, another similar bug nearby) came from the `views::all` test and propagated through _all_ of the range adaptor tests.
