### PR TITLE
Update the <ranges> header unit test

### DIFF
--- a/tests/std/tests/P1502R1_standard_library_header_units/test.cpp
+++ b/tests/std/tests/P1502R1_standard_library_header_units/test.cpp
@@ -607,7 +607,7 @@ int main() {
 #if 0 // TRANSITION, VSO-1088552 (deduction guides)
         assert(ranges::distance(views::filter(arr, [](int x) { return x == 0; })) == 4);
         static_assert(ranges::distance(views::filter(arr, [](int x) { return x != 0; })) == 5);
-#elif 0 // TRANSITION, VSO-1237145 (trailing requires clause)
+#elif defined(MSVC_INTERNAL_TESTING) // TRANSITION, VSO-1237145 (trailing requires clause)
         auto is_zero                  = [](int x) { return x == 0; };
         using FV1                     = ranges::filter_view<ranges::ref_view<decltype(arr)>, decltype(is_zero)>;
         assert(ranges::distance(FV1{arr, is_zero}) == 4);


### PR DESCRIPTION
The Microsoft-internal compiler bug VSO-1237145 "Standard Library Header Units: bogus error C7599: `'std::ranges::operator =='`: a trailing `requires` clause is only allowed on a templated function" has been fixed, so we can activate the `<ranges>` header unit test for the MSVC-internal development build, preventing regressions. We'll be able to completely activate this when VS 2019 16.9 Preview 2 is available.

This is an isolated PR to make the compiler devs' lives easier; internal MSVC-PR-283648.