### PR TITLE
Upgrade CI to 32-core VMs and VS 2019 16.8 Preview 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 The STL uses boost-math headers to provide P0226R1 Mathematical Special Functions. We recommend using [vcpkg][] to
 acquire this dependency.
 
-1. Install Visual Studio 2019 16.8 Preview 4 or later.
+1. Install Visual Studio 2019 16.8 Preview 5 or later.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
     * Otherwise, install [CMake][] 3.17 or later, and [Ninja][] 1.8.2 or later.
@@ -158,7 +158,7 @@ acquire this dependency.
 
 # How To Build With A Native Tools Command Prompt
 
-1. Install Visual Studio 2019 16.8 Preview 4 or later.
+1. Install Visual Studio 2019 16.8 Preview 5 or later.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
     * Otherwise, install [CMake][] 3.17 or later, and [Ninja][] 1.8.2 or later.

--- a/azure-devops/create-vmss.ps1
+++ b/azure-devops/create-vmss.ps1
@@ -19,7 +19,7 @@ $ErrorActionPreference = 'Stop'
 
 $Location = 'westus2'
 $Prefix = 'StlBuild-' + (Get-Date -Format 'yyyy-MM-dd')
-$VMSize = 'Standard_D16as_v4'
+$VMSize = 'Standard_D32as_v4'
 $ProtoVMName = 'PROTOTYPE'
 $LiveVMPrefix = 'BUILD'
 $WindowsServerSku = '2019-Datacenter'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,7 @@
 variables:
   tmpDir: 'D:\Temp'
 
-pool: 'StlBuild-2020-10-13'
+pool: 'StlBuild-2020-10-23'
 
 stages:
   - stage: Code_Format


### PR DESCRIPTION
Thanks to @cbezault, our VM quota has been increased to 480 cores. This PR takes advantage of that, using a Virtual Machine Scale Set with 14 VMs of the larger Standard_D32as_v4 size. I've updated the [wiki checklist](https://github.com/microsoft/STL/wiki/Checklist-for-Updating-Toolset-and-or-Dependencies) accordingly; this leaves room for exactly 1 more VM during the update process, because (14 + 1) * 32 = 480.

Regenerating the VMSS also updates our toolset to 16.8 Preview 5; I've updated the README accordingly.