### PR TITLE
initializer_lists constructed using values

### DIFF
--- a/tests/tr1/tests/algorithm/test.cpp
+++ b/tests/tr1/tests/algorithm/test.cpp
@@ -33,10 +33,9 @@ void test_single(char* first, char*) { // test single-element template functions
     CHECK_INT(STD minmax('0', '2', lessf).first, '0');
     CHECK_INT(STD minmax('0', '2', lessf).second, '2');
 
-    char arr[] = {"012"};
-    STD initializer_list<char> ilist1{arr[0]};
-    STD initializer_list<char> ilist2{arr[1], arr[2]};
-    STD initializer_list<char> ilist3{arr[0], arr[1], arr[2]};
+    STD initializer_list<char> ilist1{'0'};
+    STD initializer_list<char> ilist2{'1', '2'};
+    STD initializer_list<char> ilist3{'0', '1', '2'};
 
     CHECK_INT(STD max(ilist1), '0');
     CHECK_INT(STD max(ilist3), '2');

--- a/tests/tr1/tests/algorithm/test.cpp
+++ b/tests/tr1/tests/algorithm/test.cpp
@@ -34,9 +34,9 @@ void test_single(char* first, char*) { // test single-element template functions
     CHECK_INT(STD minmax('0', '2', lessf).second, '2');
 
     char arr[] = {"012"};
-    STD initializer_list<char> ilist1 {arr[0]};
-    STD initializer_list<char> ilist2 {arr[1], arr[2]};
-    STD initializer_list<char> ilist3 {arr[0], arr[1], arr[2]};
+    STD initializer_list<char> ilist1{arr[0]};
+    STD initializer_list<char> ilist2{arr[1], arr[2]};
+    STD initializer_list<char> ilist3{arr[0], arr[1], arr[2]};
 
     CHECK_INT(STD max(ilist1), '0');
     CHECK_INT(STD max(ilist3), '2');

--- a/tests/tr1/tests/algorithm/test.cpp
+++ b/tests/tr1/tests/algorithm/test.cpp
@@ -34,9 +34,9 @@ void test_single(char* first, char*) { // test single-element template functions
     CHECK_INT(STD minmax('0', '2', lessf).second, '2');
 
     char arr[] = {"012"};
-    STD initializer_list<char> ilist1(&arr[0], &arr[1]);
-    STD initializer_list<char> ilist2(&arr[1], &arr[3]);
-    STD initializer_list<char> ilist3(&arr[0], &arr[3]);
+    STD initializer_list<char> ilist1 {arr[0]};
+    STD initializer_list<char> ilist2 {arr[1], arr[2]};
+    STD initializer_list<char> ilist3 {arr[0], arr[1], arr[2]};
 
     CHECK_INT(STD max(ilist1), '0');
     CHECK_INT(STD max(ilist3), '2');

--- a/tests/tr1/tests/deque/test.cpp
+++ b/tests/tr1/tests/deque/test.cpp
@@ -277,7 +277,7 @@ void test_main() { // test basic workings of deque definitions
     }
 
     {
-        STD initializer_list<char> init {'a', 'b', 'c'};
+        STD initializer_list<char> init{'a', 'b', 'c'};
         Mycont v11(init);
         CHECK_INT(v11.size(), 3);
         CHECK_INT(v11[2], 'c');

--- a/tests/tr1/tests/deque/test.cpp
+++ b/tests/tr1/tests/deque/test.cpp
@@ -277,8 +277,7 @@ void test_main() { // test basic workings of deque definitions
     }
 
     {
-        const char* data = "abc";
-        STD initializer_list<char> init(data, data + CSTD strlen(data));
+        STD initializer_list<char> init {'a', 'b', 'c'};
         Mycont v11(init);
         CHECK_INT(v11.size(), 3);
         CHECK_INT(v11[2], 'c');
@@ -288,7 +287,7 @@ void test_main() { // test basic workings of deque definitions
         CHECK_INT(v11.size(), 3);
         CHECK_INT(v11[2], 'c');
 
-        CHECK_INT(*v11.insert(v11.begin() + 1, init), data[0]);
+        CHECK_INT(*v11.insert(v11.begin() + 1, init), *init.begin());
         CHECK_INT(v11.size(), 6);
         CHECK_INT(v11[2], 'b');
 

--- a/tests/tr1/tests/forward_list/test.cpp
+++ b/tests/tr1/tests/forward_list/test.cpp
@@ -334,7 +334,7 @@ void test_main() { // test basic workings of forward_list definitions
 
     {
 
-        STD initializer_list<char> init {'a', 'b', 'c'};
+        STD initializer_list<char> init{'a', 'b', 'c'};
         Mycont v11(init);
         CHECK_INT(size(v11), 3);
         CHECK_INT(v11.front(), 'a');

--- a/tests/tr1/tests/forward_list/test.cpp
+++ b/tests/tr1/tests/forward_list/test.cpp
@@ -333,8 +333,8 @@ void test_main() { // test basic workings of forward_list definitions
     CHECK_INT(v0.front(), 'b');
 
     {
-        const char* data = "abc";
-        STD initializer_list<char> init(data, data + CSTD strlen(data));
+
+        STD initializer_list<char> init {'a', 'b', 'c'};
         Mycont v11(init);
         CHECK_INT(size(v11), 3);
         CHECK_INT(v11.front(), 'a');

--- a/tests/tr1/tests/forward_list/test.cpp
+++ b/tests/tr1/tests/forward_list/test.cpp
@@ -333,7 +333,6 @@ void test_main() { // test basic workings of forward_list definitions
     CHECK_INT(v0.front(), 'b');
 
     {
-
         STD initializer_list<char> init{'a', 'b', 'c'};
         Mycont v11(init);
         CHECK_INT(size(v11), 3);

--- a/tests/tr1/tests/hash_map/test.cpp
+++ b/tests/tr1/tests/hash_map/test.cpp
@@ -295,7 +295,7 @@ void test_hash_map() { // test hash_map
     }
 
     {
-        STD initializer_list<Myval> init(xarr, xarr + 3);
+        STD initializer_list<Myval> init {xarr[0], xarr[1], xarr[2]};
         Mycont v11(init);
         CHECK_INT(v11.size(), 3);
         CHECK_INT(v11.find('a')->second, 1);
@@ -583,7 +583,7 @@ void test_hash_multimap() { // test hash_multimap
     }
 
     {
-        STD initializer_list<Myval> init(xarr, xarr + 3);
+        STD initializer_list<Myval> init {xarr[0], xarr[1], xarr[2]};
         Mycont v11(init);
         CHECK_INT(v11.size(), 3);
         CHECK_INT(v11.begin()->first, 'a');

--- a/tests/tr1/tests/hash_map/test.cpp
+++ b/tests/tr1/tests/hash_map/test.cpp
@@ -295,7 +295,7 @@ void test_hash_map() { // test hash_map
     }
 
     {
-        STD initializer_list<Myval> init {xarr[0], xarr[1], xarr[2]};
+        STD initializer_list<Myval> init{xarr[0], xarr[1], xarr[2]};
         Mycont v11(init);
         CHECK_INT(v11.size(), 3);
         CHECK_INT(v11.find('a')->second, 1);
@@ -583,7 +583,7 @@ void test_hash_multimap() { // test hash_multimap
     }
 
     {
-        STD initializer_list<Myval> init {xarr[0], xarr[1], xarr[2]};
+        STD initializer_list<Myval> init{xarr[0], xarr[1], xarr[2]};
         Mycont v11(init);
         CHECK_INT(v11.size(), 3);
         CHECK_INT(v11.begin()->first, 'a');

--- a/tests/tr1/tests/hash_set/test.cpp
+++ b/tests/tr1/tests/hash_set/test.cpp
@@ -292,7 +292,7 @@ void test_hash_set() { // test hash_set
     }
 
     {
-        STD initializer_list<char> init(carr, carr + 3);
+        STD initializer_list<char> init {carr[0], carr[1], carr[2]};
         Mycont v11(init);
         CHECK_INT(v11.size(), 3);
         CHECK_INT(*v11.find('a'), 'a');
@@ -589,7 +589,7 @@ void test_hash_multiset() { // test hash_multiset
     }
 
     {
-        STD initializer_list<char> init(carr, carr + 3);
+        STD initializer_list<char> init {carr[0], carr[1], carr[2]};
         Mycont v11(init);
         CHECK_INT(v11.size(), 3);
         CHECK_INT(*v11.find('a'), 'a');

--- a/tests/tr1/tests/hash_set/test.cpp
+++ b/tests/tr1/tests/hash_set/test.cpp
@@ -292,7 +292,7 @@ void test_hash_set() { // test hash_set
     }
 
     {
-        STD initializer_list<char> init {carr[0], carr[1], carr[2]};
+        STD initializer_list<char> init{carr[0], carr[1], carr[2]};
         Mycont v11(init);
         CHECK_INT(v11.size(), 3);
         CHECK_INT(*v11.find('a'), 'a');
@@ -589,7 +589,7 @@ void test_hash_multiset() { // test hash_multiset
     }
 
     {
-        STD initializer_list<char> init {carr[0], carr[1], carr[2]};
+        STD initializer_list<char> init{carr[0], carr[1], carr[2]};
         Mycont v11(init);
         CHECK_INT(v11.size(), 3);
         CHECK_INT(*v11.find('a'), 'a');

--- a/tests/tr1/tests/iterator/test.cpp
+++ b/tests/tr1/tests/iterator/test.cpp
@@ -444,7 +444,7 @@ void test_size_data() { // test size/empty/data
     CHECK(!STD empty(c0));
     CHECK_PTR(STD data(c0), c0.data());
 
-    STD initializer_list<char> ilist {c0[0], c0[1], c0[2]};
+    STD initializer_list<char> ilist{c0[0], c0[1], c0[2]};
     CHECK_INT(STD size(ilist), 3);
     CHECK_PTR(STD data(ilist), ilist.begin());
 }

--- a/tests/tr1/tests/iterator/test.cpp
+++ b/tests/tr1/tests/iterator/test.cpp
@@ -444,7 +444,7 @@ void test_size_data() { // test size/empty/data
     CHECK(!STD empty(c0));
     CHECK_PTR(STD data(c0), c0.data());
 
-    STD initializer_list<char> ilist(c0.data(), c0.data() + 3);
+    STD initializer_list<char> ilist {c0[0], c0[1], c0[2]};
     CHECK_INT(STD size(ilist), 3);
     CHECK_PTR(STD data(ilist), ilist.begin());
 }

--- a/tests/tr1/tests/list/test.cpp
+++ b/tests/tr1/tests/list/test.cpp
@@ -346,7 +346,7 @@ void test_main() { // test basic workings of list definitions
 
     {
         const char* data = "abc";
-        STD initializer_list<char> init(data, data + CSTD strlen(data));
+        STD initializer_list<char> init {'a', 'b', 'c'};
         Mycont v11(init);
         CHECK_INT(v11.size(), 3);
         CHECK_INT(v11.back(), 'c');

--- a/tests/tr1/tests/list/test.cpp
+++ b/tests/tr1/tests/list/test.cpp
@@ -345,8 +345,7 @@ void test_main() { // test basic workings of list definitions
     CHECK_INT(v0.front(), 'b');
 
     {
-        const char* data = "abc";
-        STD initializer_list<char> init {'a', 'b', 'c'};
+        STD initializer_list<char> init{'a', 'b', 'c'};
         Mycont v11(init);
         CHECK_INT(v11.size(), 3);
         CHECK_INT(v11.back(), 'c');
@@ -356,7 +355,7 @@ void test_main() { // test basic workings of list definitions
         CHECK_INT(v11.size(), 3);
         CHECK_INT(v11.back(), 'c');
 
-        CHECK_INT(*v11.insert(++v11.begin(), init), data[0]);
+        CHECK_INT(*v11.insert(++v11.begin(), init), *init.begin());
         CHECK_INT(v11.size(), 6);
         CHECK_INT(*++v11.begin(), 'a');
 

--- a/tests/tr1/tests/map/test.cpp
+++ b/tests/tr1/tests/map/test.cpp
@@ -320,7 +320,7 @@ void test_map() { // test map
     }
 
     {
-        STD initializer_list<Myval> init {xarr[0], xarr[1], xarr[2]};
+        STD initializer_list<Myval> init{xarr[0], xarr[1], xarr[2]};
         Mycont v11(init);
         CHECK_INT(v11.size(), 3);
         CHECK_INT(v11.begin()->first, 'a');
@@ -590,7 +590,7 @@ void test_multimap() { // test multimap
     }
 
     {
-        STD initializer_list<Myval> init {xarr[0], xarr[1], xarr[2]};
+        STD initializer_list<Myval> init{xarr[0], xarr[1], xarr[2]};
         Mycont v11(init);
         CHECK_INT(v11.size(), 3);
         CHECK_INT(v11.begin()->first, 'a');

--- a/tests/tr1/tests/map/test.cpp
+++ b/tests/tr1/tests/map/test.cpp
@@ -320,7 +320,7 @@ void test_map() { // test map
     }
 
     {
-        STD initializer_list<Myval> init(xarr, xarr + 3);
+        STD initializer_list<Myval> init {xarr[0], xarr[1], xarr[2]};
         Mycont v11(init);
         CHECK_INT(v11.size(), 3);
         CHECK_INT(v11.begin()->first, 'a');
@@ -590,7 +590,7 @@ void test_multimap() { // test multimap
     }
 
     {
-        STD initializer_list<Myval> init(xarr, xarr + 3);
+        STD initializer_list<Myval> init {xarr[0], xarr[1], xarr[2]};
         Mycont v11(init);
         CHECK_INT(v11.size(), 3);
         CHECK_INT(v11.begin()->first, 'a');

--- a/tests/tr1/tests/random4/test.cpp
+++ b/tests/tr1/tests/random4/test.cpp
@@ -57,7 +57,7 @@ static void tseed_seq() { // test class seed_seq
     seq1.generate(&arr2[0], &arr2[4]);
     CHECK_INT(arr2[3], 3734116661U);
 
-    STD seed_seq seq2(STD initializer_list<Uint32> {arr1[0], arr1[1], arr1[2], arr1[3], arr1[4]});
+    STD seed_seq seq2({arr1[0], arr1[1], arr1[2], arr1[3], arr1[4]});
     CHECK_INT(seq2.size(), 5);
     seq2.param(&arr2[0]);
     CHECK_INT(arr2[0], 'a');

--- a/tests/tr1/tests/random4/test.cpp
+++ b/tests/tr1/tests/random4/test.cpp
@@ -57,7 +57,7 @@ static void tseed_seq() { // test class seed_seq
     seq1.generate(&arr2[0], &arr2[4]);
     CHECK_INT(arr2[3], 3734116661U);
 
-    STD seed_seq seq2(STD initializer_list<Uint32>(&arr1[0], &arr1[5]));
+    STD seed_seq seq2(STD initializer_list<Uint32> {arr1[0], arr1[1], arr1[2], arr1[3], arr1[4]});
     CHECK_INT(seq2.size(), 5);
     seq2.param(&arr2[0]);
     CHECK_INT(arr2[0], 'a');

--- a/tests/tr1/tests/random5/test.cpp
+++ b/tests/tr1/tests/random5/test.cpp
@@ -499,7 +499,7 @@ static void tpiecewise_constant() {
     dist_t dist2(10, 1.0, 2.0, myfn);
     CHECK_INT(dist2.densities().size(), 10);
 
-	STD initializer_list<double> ilist {1.0, 1.5, 2.0, 3.0, 4.0};
+	STD initializer_list<double> ilist{1.0, 1.5, 2.0, 3.0, 4.0};
     dist_t dist3(ilist, myfn);
     CHECK_INT(dist3.densities().size(), 4);
     CHECK_DOUBLE(dist3.densities()[0], 0.2777777777777778);
@@ -573,7 +573,7 @@ static void tpiecewise_linear() {
     dist_t dist2(10, 1.0, 2.0, myfn);
     CHECK_INT(dist2.densities().size(), 11);
 
-    STD initializer_list<double> ilist {1.0, 1.5, 2.0, 3.0, 4.0};
+    STD initializer_list<double> ilist{1.0, 1.5, 2.0, 3.0, 4.0};
     dist_t dist3(ilist, myfn);
     CHECK_INT(dist3.densities().size(), 5);
     CHECK_DOUBLE(dist3.densities()[0], 0.13333333333333333);

--- a/tests/tr1/tests/random5/test.cpp
+++ b/tests/tr1/tests/random5/test.cpp
@@ -426,7 +426,7 @@ static void tdiscrete() {
 
     STD vector<double> vec(4, 1.0);
 
-    dist_t dist1(STD initializer_list<double>(vec.data(), vec.data() + vec.size()));
+    dist_t dist1 {vec[0], vec[1], vec[2], vec[3]};
 
     CHECK_INT(dist1.probabilities().size(), 4);
     STD stringstream str;
@@ -443,7 +443,7 @@ static void tdiscrete() {
     CHECK(dist0.probabilities() == par0.probabilities());
     vec = par0.probabilities();
 
-    CHECK(par0 == dist_t::param_type(STD initializer_list<double>(vec.data(), vec.data() + vec.size())));
+    CHECK(par0 == dist_t::param_type({vec[0], vec[1], vec[2], vec[3]}));
 
     typedef STD ranlux24 rng_t;
     rng_t rng;
@@ -499,8 +499,8 @@ static void tpiecewise_constant() {
     dist_t dist2(10, 1.0, 2.0, myfn);
     CHECK_INT(dist2.densities().size(), 10);
 
-    double arr[] = {1.0, 1.5, 2.0, 3.0, 4.0};
-    dist_t dist3(STD initializer_list<double>(&arr[0], &arr[5]), myfn);
+	STD initializer_list<double> ilist {1.0, 1.5, 2.0, 3.0, 4.0};
+    dist_t dist3(ilist, myfn);
     CHECK_INT(dist3.densities().size(), 4);
     CHECK_DOUBLE(dist3.densities()[0], 0.2777777777777778);
 
@@ -516,7 +516,7 @@ static void tpiecewise_constant() {
 
     CHECK(dist2.param() == dist_t::param_type(10, 1.0, 2.0, myfn));
 
-    CHECK(dist3.param() == dist_t::param_type(STD initializer_list<double>(&arr[0], &arr[5]), myfn));
+    CHECK(dist3.param() == dist_t::param_type(ilist, myfn));
 
     typedef STD ranlux24 rng_t;
     rng_t rng;
@@ -573,8 +573,8 @@ static void tpiecewise_linear() {
     dist_t dist2(10, 1.0, 2.0, myfn);
     CHECK_INT(dist2.densities().size(), 11);
 
-    double arr[] = {1.0, 1.5, 2.0, 3.0, 4.0};
-    dist_t dist3(STD initializer_list<double>(&arr[0], &arr[5]), myfn);
+    STD initializer_list<double> ilist {1.0, 1.5, 2.0, 3.0, 4.0};
+    dist_t dist3(ilist, myfn);
     CHECK_INT(dist3.densities().size(), 5);
     CHECK_DOUBLE(dist3.densities()[0], 0.13333333333333333);
 
@@ -590,7 +590,7 @@ static void tpiecewise_linear() {
 
     CHECK(dist2.param() == dist_t::param_type(10, 1.0, 2.0, myfn));
 
-    CHECK(dist3.param() == dist_t::param_type(STD initializer_list<double>(&arr[0], &arr[5]), myfn));
+    CHECK(dist3.param() == dist_t::param_type(ilist, myfn));
 
     typedef STD ranlux24 rng_t;
     rng_t rng;

--- a/tests/tr1/tests/random5/test.cpp
+++ b/tests/tr1/tests/random5/test.cpp
@@ -426,7 +426,7 @@ static void tdiscrete() {
 
     STD vector<double> vec(4, 1.0);
 
-    dist_t dist1(vec.begin(), vec.end());
+    dist_t dist1{1.0, 1.0, 1.0, 1.0};
 
     CHECK_INT(dist1.probabilities().size(), 4);
     STD stringstream str;

--- a/tests/tr1/tests/random5/test.cpp
+++ b/tests/tr1/tests/random5/test.cpp
@@ -426,7 +426,7 @@ static void tdiscrete() {
 
     STD vector<double> vec(4, 1.0);
 
-    dist_t dist1 {vec[0], vec[1], vec[2], vec[3]};
+    dist_t dist1(vec.begin(), vec.end());
 
     CHECK_INT(dist1.probabilities().size(), 4);
     STD stringstream str;
@@ -443,7 +443,7 @@ static void tdiscrete() {
     CHECK(dist0.probabilities() == par0.probabilities());
     vec = par0.probabilities();
 
-    CHECK(par0 == dist_t::param_type({vec[0], vec[1], vec[2], vec[3]}));
+    CHECK(par0 == dist_t::param_type(vec.begin(), vec.end()));
 
     typedef STD ranlux24 rng_t;
     rng_t rng;
@@ -499,7 +499,7 @@ static void tpiecewise_constant() {
     dist_t dist2(10, 1.0, 2.0, myfn);
     CHECK_INT(dist2.densities().size(), 10);
 
-	STD initializer_list<double> ilist{1.0, 1.5, 2.0, 3.0, 4.0};
+    STD initializer_list<double> ilist{1.0, 1.5, 2.0, 3.0, 4.0};
     dist_t dist3(ilist, myfn);
     CHECK_INT(dist3.densities().size(), 4);
     CHECK_DOUBLE(dist3.densities()[0], 0.2777777777777778);

--- a/tests/tr1/tests/regex1/test.cpp
+++ b/tests/tr1/tests/regex1/test.cpp
@@ -443,12 +443,12 @@ static void test_regex() { // test template basic_regex
     CHECK_INT(r2.mark_count(), 1);
 
     {
-        STD initializer_list<CHR> init {'(', '(', 'd', '(', 'e', ')', ')', 'f', ')'};
+        STD initializer_list<CHR> init{'(', '(', 'd', '(', 'e', ')', ')', 'f', ')'};
         MyRgx r11(init, (MyRgx::flag_type)(MyRgx::icase | MyRgx::extended));
         CHECK_INT(r11.flags(), MyRgx::icase | MyRgx::extended);
         CHECK_INT(r11.mark_count(), 3);
 
-        STD initializer_list<CHR> init2 {'(', 'b', ')'};
+        STD initializer_list<CHR> init2{'(', 'b', ')'};
         r11.assign(init2, MyRgx::awk);
         CHECK_INT(r11.flags(), MyRgx::awk);
         CHECK_INT(r11.mark_count(), 1);

--- a/tests/tr1/tests/regex1/test.cpp
+++ b/tests/tr1/tests/regex1/test.cpp
@@ -443,14 +443,12 @@ static void test_regex() { // test template basic_regex
     CHECK_INT(r2.mark_count(), 1);
 
     {
-        const CHR* data = T("((d(e))f)");
-        STD initializer_list<CHR> init(data, data + xlen(data));
+        STD initializer_list<CHR> init {'(', '(', 'd', '(', 'e', ')', ')', 'f', ')'};
         MyRgx r11(init, (MyRgx::flag_type)(MyRgx::icase | MyRgx::extended));
         CHECK_INT(r11.flags(), MyRgx::icase | MyRgx::extended);
         CHECK_INT(r11.mark_count(), 3);
 
-        const CHR* data2 = T("(b)");
-        STD initializer_list<CHR> init2(data2, data2 + xlen(data2));
+        STD initializer_list<CHR> init2 {'(', 'b', ')'};
         r11.assign(init2, MyRgx::awk);
         CHECK_INT(r11.flags(), MyRgx::awk);
         CHECK_INT(r11.mark_count(), 1);
@@ -789,7 +787,7 @@ static void test_regex_token_iterator() { // test template regex_token_iterator
     }
 
     { // test initializer list
-        STD initializer_list<int> ilist(init, init + 3);
+        STD initializer_list<int> ilist{init[0], init[1], init[2]};
         MyTokIter iter3(begin, end, re, ilist);
 
         CHECK(iter3 != end_it);

--- a/tests/tr1/tests/set/test.cpp
+++ b/tests/tr1/tests/set/test.cpp
@@ -288,7 +288,7 @@ void test_set() { // test set
     }
 
     {
-        STD initializer_list<char> init(carr, carr + 3);
+        STD initializer_list<char> init {carr[0], carr[1], carr[2]};
         Mycont v11(init);
         CHECK_INT(v11.size(), 3);
         CHECK_INT(*v11.begin(), 'a');
@@ -564,7 +564,7 @@ void test_multiset() { // test multiset
     }
 
     {
-        STD initializer_list<char> init(carr, carr + 3);
+        STD initializer_list<char> init{carr[0], carr[1], carr[2]};
         Mycont v11(init);
         CHECK_INT(v11.size(), 3);
         CHECK_INT(*v11.begin(), 'a');

--- a/tests/tr1/tests/set/test.cpp
+++ b/tests/tr1/tests/set/test.cpp
@@ -288,7 +288,7 @@ void test_set() { // test set
     }
 
     {
-        STD initializer_list<char> init {carr[0], carr[1], carr[2]};
+        STD initializer_list<char> init{carr[0], carr[1], carr[2]};
         Mycont v11(init);
         CHECK_INT(v11.size(), 3);
         CHECK_INT(*v11.begin(), 'a');

--- a/tests/tr1/tests/string1/test.cpp
+++ b/tests/tr1/tests/string1/test.cpp
@@ -558,7 +558,7 @@ void test_main() { // test basic workings of string definitions
 
     {
 
-        STD initializer_list<char> init {'a', 'b', 'c'};
+        STD initializer_list<char> init{'a', 'b', 'c'};
         STD string s11(init);
         CHECK_SIZE_T(s11.size(), 3);
         CHECK_INT(s11[2], 'c');

--- a/tests/tr1/tests/string1/test.cpp
+++ b/tests/tr1/tests/string1/test.cpp
@@ -557,8 +557,8 @@ void test_main() { // test basic workings of string definitions
     }
 
     {
-        const char* data = "abc";
-        STD initializer_list<char> init(data, data + CSTD strlen(data));
+
+        STD initializer_list<char> init {'a', 'b', 'c'};
         STD string s11(init);
         CHECK_SIZE_T(s11.size(), 3);
         CHECK_INT(s11[2], 'c');
@@ -583,7 +583,7 @@ void test_main() { // test basic workings of string definitions
         CHECK_SIZE_T(s11.size(), 3);
         CHECK_INT(s11[2], 'c');
 
-        CHECK_INT(*s11.insert(s11.begin() + 1, init), data[0]);
+        CHECK_INT(*s11.insert(s11.begin() + 1, init), *init.begin());
         CHECK_SIZE_T(s11.size(), 6);
         CHECK_INT(s11[2], 'b');
 

--- a/tests/tr1/tests/string1/test.cpp
+++ b/tests/tr1/tests/string1/test.cpp
@@ -557,7 +557,6 @@ void test_main() { // test basic workings of string definitions
     }
 
     {
-
         STD initializer_list<char> init{'a', 'b', 'c'};
         STD string s11(init);
         CHECK_SIZE_T(s11.size(), 3);

--- a/tests/tr1/tests/string2/test.cpp
+++ b/tests/tr1/tests/string2/test.cpp
@@ -528,7 +528,7 @@ void test_main() { // test basic workings of string definitions
     }
 
     {
-        STD initializer_list<wchar_t> init {L'a', L'b', L'c'};
+        STD initializer_list<wchar_t> init{L'a', L'b', L'c'};
         STD wstring s11(init);
         CHECK_SIZE_T(s11.size(), 3);
         CHECK_INT(s11[2], L'c');

--- a/tests/tr1/tests/string2/test.cpp
+++ b/tests/tr1/tests/string2/test.cpp
@@ -528,8 +528,7 @@ void test_main() { // test basic workings of string definitions
     }
 
     {
-        const wchar_t* data = L"abc";
-        STD initializer_list<wchar_t> init(data, data + CSTD wcslen(data));
+        STD initializer_list<wchar_t> init {L'a', L'b', L'c'};
         STD wstring s11(init);
         CHECK_SIZE_T(s11.size(), 3);
         CHECK_INT(s11[2], L'c');
@@ -554,7 +553,7 @@ void test_main() { // test basic workings of string definitions
         CHECK_SIZE_T(s11.size(), 3);
         CHECK_INT(s11[2], L'c');
 
-        CHECK_INT(*s11.insert(s11.begin() + 1, init), data[0]);
+        CHECK_INT(*s11.insert(s11.begin() + 1, init), *init.begin());
         CHECK_SIZE_T(s11.size(), 6);
         CHECK_INT(s11[2], L'b');
 

--- a/tests/tr1/tests/unordered_map/test.cpp
+++ b/tests/tr1/tests/unordered_map/test.cpp
@@ -347,7 +347,7 @@ void test_unordered_map() { // test unordered_map
     }
 
     {
-        STD initializer_list<Myval> init(xarr, xarr + 3);
+        STD initializer_list<Myval> init {xarr[0], xarr[1], xarr[2]};
         Mycont v11(init);
         CHECK_INT(v11.size(), 3);
         CHECK_INT(v11.find('a')->second, 1);
@@ -635,7 +635,7 @@ void test_unordered_multimap() { // test unordered_multimap
     }
 
     {
-        STD initializer_list<Myval> init(xarr, xarr + 3);
+        STD initializer_list<Myval> init{xarr[0], xarr[1], xarr[2]};
         Mycont v11(init);
         CHECK_INT(v11.size(), 3);
         CHECK_INT(v11.find('a')->second, 1);

--- a/tests/tr1/tests/unordered_map/test.cpp
+++ b/tests/tr1/tests/unordered_map/test.cpp
@@ -347,7 +347,7 @@ void test_unordered_map() { // test unordered_map
     }
 
     {
-        STD initializer_list<Myval> init {xarr[0], xarr[1], xarr[2]};
+        STD initializer_list<Myval> init{xarr[0], xarr[1], xarr[2]};
         Mycont v11(init);
         CHECK_INT(v11.size(), 3);
         CHECK_INT(v11.find('a')->second, 1);

--- a/tests/tr1/tests/unordered_set/test.cpp
+++ b/tests/tr1/tests/unordered_set/test.cpp
@@ -315,7 +315,7 @@ void test_unordered_set() { // test unordered_set
     }
 
     {
-        STD initializer_list<char> init(carr, carr + 3);
+        STD initializer_list<char> init {'a', 'b', 'c'};
         Mycont v11(init);
         CHECK_INT(v11.size(), 3);
         CHECK_INT(*v11.find('a'), 'a');
@@ -615,7 +615,7 @@ void test_unordered_multiset() { // test unordered_multiset
     }
 
     {
-        STD initializer_list<char> init(carr, carr + 3);
+        STD initializer_list<char> init{'a', 'b', 'c'};
         Mycont v11(init);
         CHECK_INT(v11.size(), 3);
         CHECK_INT(*v11.find('a'), 'a');

--- a/tests/tr1/tests/unordered_set/test.cpp
+++ b/tests/tr1/tests/unordered_set/test.cpp
@@ -315,7 +315,7 @@ void test_unordered_set() { // test unordered_set
     }
 
     {
-        STD initializer_list<char> init {'a', 'b', 'c'};
+        STD initializer_list<char> init{'a', 'b', 'c'};
         Mycont v11(init);
         CHECK_INT(v11.size(), 3);
         CHECK_INT(*v11.find('a'), 'a');

--- a/tests/tr1/tests/valarray/test.cpp
+++ b/tests/tr1/tests/valarray/test.cpp
@@ -166,8 +166,7 @@ void test_main() { // test basic workings of valarray definitions
     }
 
     {
-        const char* data = "abc";
-        STD initializer_list<char> init(data, data + CSTD strlen(data));
+        STD initializer_list<char> init {'a', 'b', 'c'};
         Mycont v11(init);
         CHECK_INT(v11.size(), 3);
         CHECK_INT(v11[2], 'c');

--- a/tests/tr1/tests/valarray/test.cpp
+++ b/tests/tr1/tests/valarray/test.cpp
@@ -166,7 +166,7 @@ void test_main() { // test basic workings of valarray definitions
     }
 
     {
-        STD initializer_list<char> init {'a', 'b', 'c'};
+        STD initializer_list<char> init{'a', 'b', 'c'};
         Mycont v11(init);
         CHECK_INT(v11.size(), 3);
         CHECK_INT(v11[2], 'c');

--- a/tests/tr1/tests/vector/test.cpp
+++ b/tests/tr1/tests/vector/test.cpp
@@ -251,7 +251,7 @@ void test_main() { // test basic workings of vector definitions
     }
 
     {
-        STD initializer_list<char> init {'a', 'b', 'c'};
+        STD initializer_list<char> init{'a', 'b', 'c'};
         Mycont v11(init);
         CHECK_INT(v11.size(), 3);
         CHECK_INT(v11[2], 'c');
@@ -349,7 +349,7 @@ void test_main() { // test basic workings of vector definitions
         }
 
         {
-            STD initializer_list<bool> init = {false, true, false};
+            STD initializer_list<bool> init{false, true, false};
             Bvector bv11(init);
             CHECK_INT(bv11.size(), 3);
             CHECK_INT(bv11[2], false);

--- a/tests/tr1/tests/vector/test.cpp
+++ b/tests/tr1/tests/vector/test.cpp
@@ -251,8 +251,7 @@ void test_main() { // test basic workings of vector definitions
     }
 
     {
-        const char* data = "abc";
-        STD initializer_list<char> init(data, data + CSTD strlen(data));
+        STD initializer_list<char> init {'a', 'b', 'c'};
         Mycont v11(init);
         CHECK_INT(v11.size(), 3);
         CHECK_INT(v11[2], 'c');
@@ -350,8 +349,7 @@ void test_main() { // test basic workings of vector definitions
         }
 
         {
-            bool data[] = {false, true, false};
-            STD initializer_list<bool> init(data + 0, data + 3);
+            STD initializer_list<bool> init = {false, true, false};
             Bvector bv11(init);
             CHECK_INT(bv11.size(), 3);
             CHECK_INT(bv11[2], false);


### PR DESCRIPTION
I searched occurences of using `initializer_list` according to issue #1184. In most cases `initializer_list` is used for testing `initializer_list` constructors or it is required for constructing other object, so I just filled initializer_lists manually, in pair of cases I replaced them

Fixes #1184
