### PR TITLE
Move from rvalue range adaptor closures

### DIFF
--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -987,14 +987,18 @@ namespace ranges {
                 /* [[no_unique_address]] */ _Semiregular_box<_Pr> _Pred;
 
                 template <viewable_range _Rng>
-                _NODISCARD constexpr auto operator()(_Rng&& _Range) const
-                    noexcept(noexcept(filter_view{_STD forward<_Rng>(_Range), _STD move(*_Pred)})) requires requires {
+                _NODISCARD constexpr auto operator()(_Rng&& _Range) const& noexcept(
+                    noexcept(filter_view{_STD forward<_Rng>(_Range), *_Pred})) requires requires {
+                    filter_view{static_cast<_Rng&&>(_Range), *_Pred};
+                }
+                { return filter_view{_STD forward<_Rng>(_Range), *_Pred}; }
+
+                template <viewable_range _Rng>
+                _NODISCARD constexpr auto operator()(_Rng&& _Range) && noexcept(
+                    noexcept(filter_view{_STD forward<_Rng>(_Range), _STD move(*_Pred)})) requires requires {
                     filter_view{static_cast<_Rng&&>(_Range), _STD move(*_Pred)};
                 }
-                {
-                    // clang-format on
-                    return filter_view{_STD forward<_Rng>(_Range), _STD move(*_Pred)};
-                }
+                { return filter_view{_STD forward<_Rng>(_Range), _STD move(*_Pred)}; }
             };
 
         public:
@@ -1470,15 +1474,19 @@ namespace ranges {
             struct _Partial : _Pipe::_Base<_Partial<_Fn>> {
                 /* [[no_unique_address]] */ _Semiregular_box<_Fn> _Fun;
 
-                // clang-format off
                 template <viewable_range _Rng>
-                _NODISCARD constexpr auto operator()(_Rng&& _Range) const noexcept(noexcept(
-                    transform_view{_STD forward<_Rng>(_Range), _STD move(*_Fun)})) requires requires {
-                    transform_view{static_cast<_Rng&&>(_Range), _STD move(*_Fun)};
-                } {
-                    // clang-format on
-                    return transform_view{_STD forward<_Rng>(_Range), _STD move(*_Fun)};
+                _NODISCARD constexpr auto operator()(_Rng&& _Range) const& noexcept(
+                    noexcept(transform_view{_STD forward<_Rng>(_Range), *_Fun})) requires requires {
+                    transform_view{static_cast<_Rng&&>(_Range), *_Fun};
                 }
+                { return transform_view{_STD forward<_Rng>(_Range), *_Fun}; }
+
+                template <viewable_range _Rng>
+                _NODISCARD constexpr auto operator()(_Rng&& _Range) && noexcept(
+                    noexcept(transform_view{_STD forward<_Rng>(_Range), _STD move(*_Fun)})) requires requires {
+                    transform_view{static_cast<_Rng&&>(_Range), _STD move(*_Fun)};
+                }
+                { return transform_view{_STD forward<_Rng>(_Range), _STD move(*_Fun)}; }
             };
 
         public:

--- a/tests/std/tests/P0896R4_views_filter/test.cpp
+++ b/tests/std/tests/P0896R4_views_filter/test.cpp
@@ -390,7 +390,8 @@ int main() {
                 assert(false);
             }
             Fn& operator=(Fn&&) = default;
-            Fn& operator        =(const Fn&) {
+
+            Fn& operator=(const Fn&) {
                 assert(false);
                 return *this;
             }

--- a/tests/std/tests/P0896R4_views_filter/test.cpp
+++ b/tests/std/tests/P0896R4_views_filter/test.cpp
@@ -380,4 +380,26 @@ int main() {
 
     STATIC_ASSERT((instantiation_test(), true));
     instantiation_test();
+
+    { // Validate **non-standard guarantee** that predicates are moved into the range adaptor closure, and into the view
+      // object from an rvalue closure
+        struct Fn {
+            Fn()     = default;
+            Fn(Fn&&) = default;
+            Fn(const Fn&) {
+                assert(false);
+            }
+            Fn& operator=(Fn&&) = default;
+            Fn& operator        =(const Fn&) {
+                assert(false);
+                return *this;
+            }
+
+            bool operator()(int) const {
+                return true;
+            }
+        };
+
+        (void) views::filter(Fn{})(span<int>{});
+    }
 }

--- a/tests/std/tests/P0896R4_views_transform/test.cpp
+++ b/tests/std/tests/P0896R4_views_transform/test.cpp
@@ -710,4 +710,26 @@ int main() {
 
     STATIC_ASSERT((iterator_instantiation_test(), true));
     iterator_instantiation_test();
+
+    { // Validate **non-standard guarantee** that predicates are moved into the range adaptor closure, and into the view
+      // object from an rvalue closure
+        struct Fn {
+            Fn()     = default;
+            Fn(Fn&&) = default;
+            Fn(const Fn&) {
+                assert(false);
+            }
+            Fn& operator=(Fn&&) = default;
+            Fn& operator        =(const Fn&) {
+                assert(false);
+                return *this;
+            }
+
+            bool operator()(int) const {
+                return true;
+            }
+        };
+
+        (void) views::transform(Fn{})(span<int>{});
+    }
 }

--- a/tests/std/tests/P0896R4_views_transform/test.cpp
+++ b/tests/std/tests/P0896R4_views_transform/test.cpp
@@ -720,7 +720,8 @@ int main() {
                 assert(false);
             }
             Fn& operator=(Fn&&) = default;
-            Fn& operator        =(const Fn&) {
+
+            Fn& operator=(const Fn&) {
                 assert(false);
                 return *this;
             }


### PR DESCRIPTION
We currently have `const`-qualified member functions that attempt to move from member variables, which is at the very least confusing. This change splits the `operator() const` of `views::filter` and `views::transform`'s corresponding range adaptor closure objects into `const&`-qualified and `&&`-qualified overloads that copy and move from, respectively, the stashed function object.
