### PR TITLE
Improve type traits usage

### DIFF
--- a/stl/inc/random
+++ b/stl/inc/random
@@ -1839,21 +1839,17 @@ private:
     }
 
     static _Uty _Adjust(_Uty _Uval) { // convert signed ranges to unsigned ranges and vice versa
-        return _Adjust(_Uval, is_signed<_Ty>{});
-    }
+        if _CONSTEXPR_IF (is_signed_v<_Ty>) {
+            const _Uty _Adjuster = (static_cast<_Uty>(-1) >> 1) + 1; // 2^(N-1)
 
-    static _Uty _Adjust(_Uty _Uval, true_type) { // convert signed ranges to unsigned ranges and vice versa
-        const _Uty _Adjuster = (static_cast<_Uty>(-1) >> 1) + 1; // 2^(N-1)
-
-        if (_Uval < _Adjuster) {
-            return static_cast<_Uty>(_Uval + _Adjuster);
-        } else {
-            return static_cast<_Uty>(_Uval - _Adjuster);
+            if (_Uval < _Adjuster) {
+                return static_cast<_Uty>(_Uval + _Adjuster);
+            } else {
+                return static_cast<_Uty>(_Uval - _Adjuster);
+            }
+        } else { // _Ty is already unsigned, do nothing
+            return _Uval;
         }
-    }
-
-    static _Uty _Adjust(_Uty _Uval, false_type) { // _Ty is already unsigned, do nothing
-        return _Uval;
     }
 
     param_type _Par;

--- a/stl/inc/random
+++ b/stl/inc/random
@@ -1824,12 +1824,12 @@ private:
     result_type _Eval(_Engine& _Eng, _Ty _Min, _Ty _Max) const { // compute next value in range [_Min, _Max]
         _Rng_from_urng<_Uty, _Engine> _Generator(_Eng);
 
-        const _Uty _Umin = _Adjust(_Uty(_Min));
-        const _Uty _Umax = _Adjust(_Uty(_Max));
+        const _Uty _Umin = _Adjust(static_cast<_Uty>(_Min));
+        const _Uty _Umax = _Adjust(static_cast<_Uty>(_Max));
 
         _Uty _Uret;
 
-        if (_Umax - _Umin == _Uty(-1)) {
+        if (_Umax - _Umin == static_cast<_Uty>(-1)) {
             _Uret = static_cast<_Uty>(_Generator._Get_all_bits());
         } else {
             _Uret = static_cast<_Uty>(_Generator(static_cast<_Uty>(_Umax - _Umin + 1)));
@@ -1843,7 +1843,7 @@ private:
     }
 
     static _Uty _Adjust(_Uty _Uval, true_type) { // convert signed ranges to unsigned ranges and vice versa
-        const _Uty _Adjuster = (_Uty(-1) >> 1) + 1; // 2^(N-1)
+        const _Uty _Adjuster = (static_cast<_Uty>(-1) >> 1) + 1; // 2^(N-1)
 
         if (_Uval < _Adjuster) {
             return static_cast<_Uty>(_Uval + _Adjuster);

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -397,7 +397,7 @@ struct _Get_propagate_on_container_swap<_Ty, void_t<typename _Ty::propagate_on_c
 // STRUCT TEMPLATE _Get_is_always_equal
 template <class _Ty, class = void>
 struct _Get_is_always_equal {
-    using type = typename is_empty<_Ty>::type;
+    using type = bool_constant<is_empty_v<_Ty>>;
 };
 
 template <class _Ty>

--- a/stl/inc/xtree
+++ b/stl/inc/xtree
@@ -1759,7 +1759,7 @@ protected:
         _Nodeptr _Newroot = _Scary->_Myhead; // point at nil node
 
         if (!_Rootnode->_Isnil) { // copy or move a node, then any subtrees
-            typename is_same<key_type, value_type>::type _Is_set;
+            bool_constant<is_same_v<key_type, value_type>> _Is_set;
             _Nodeptr _Pnode = _Copy_or_move(_Rootnode->_Myval, _Movefl, _Is_set);
             _Pnode->_Parent = _Wherenode;
             _Pnode->_Color  = _Rootnode->_Color;

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -5466,7 +5466,8 @@ _NODISCARD constexpr bool _Within_limits(const _Ty& _Val, false_type, false_type
 template <class _InIt, class _Ty>
 _NODISCARD constexpr bool _Within_limits(_InIt, const _Ty& _Val) { // check whether _Val is within the limits of _Elem
     using _Elem = remove_pointer_t<_InIt>;
-    return _Within_limits(_Val, is_signed<_Elem>{}, is_signed<_Ty>{}, bool_constant<-1 == static_cast<_Ty>(-1)>{});
+    return _Within_limits(_Val, bool_constant<is_signed_v<_Elem>>{}, bool_constant<is_signed_v<_Ty>>{},
+        bool_constant<-1 == static_cast<_Ty>(-1)>{});
 }
 
 template <class _InIt>


### PR DESCRIPTION
Fixes MS-internal VSO-1240399 / [AB#1240399](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1240399) reported by @xiangfan-ms.

* `<random>`
  + Cleanup: change `_Uty(MEOW)`, which is a functional-syntax C-semantics cast, to `static_cast<_Uty>(MEOW)`.
  + Replace `is_signed` tag dispatch with `if _CONSTEXPR_IF` `is_signed_v`. This improves throughput twice (first because `is_signed_v` is silently optimized by MSVC, second because `if constexpr` is much cheaper than tag dispatch). Note that even when `if constexpr` is unavailable, both sides of the branch will compile just fine.
* `<xmemory>`
  + Instead of "smashing" `is_empty` to `bool_constant` via `typename MEOW::type`, wrap `is_empty_v` in `bool_constant` because MSVC silently optimizes `is_empty_v`.
* `<xtree>`
  + Similarly change this tag to `bool_constant<is_same_v<MEOW>>`.
* `<xutility>`
  + Here, we were directly dispatching with `is_signed` converted to `true_type` or `false_type` during overload resolution. Again, it's faster to say `bool_constant<is_signed_v<MEOW>>`. (This logic should be refactored into `if constexpr` later, and/or it should use the C++20 `in_range` technique; I am deliberately not pursuing those larger changes now.)