### PR TITLE
Always remove_cvref_t the argument to enable_borrowed_range

### DIFF
--- a/tests/std/tests/P0896R4_views_all/test.cpp
+++ b/tests/std/tests/P0896R4_views_all/test.cpp
@@ -95,7 +95,7 @@ constexpr bool test_one(Rng&& rng) {
 
         static_assert(same_as<decltype(move(rng) | pipeline), V>);
         static_assert(noexcept(move(rng) | pipeline) == is_noexcept);
-    } else if constexpr (ranges::enable_borrowed_range<Rng>) {
+    } else if constexpr (ranges::enable_borrowed_range<remove_cvref_t<Rng>>) {
         using S                    = decltype(ranges::subrange{declval<Rng>()});
         constexpr bool is_noexcept = noexcept(S{declval<Rng>()});
 
@@ -131,7 +131,7 @@ constexpr bool test_one(Rng&& rng) {
 
         static_assert(same_as<decltype(move(as_const(rng)) | pipeline), V>);
         static_assert(noexcept(move(as_const(rng)) | pipeline) == is_noexcept);
-    } else if constexpr (!is_view && ranges::enable_borrowed_range<const remove_cvref_t<Rng>>) {
+    } else if constexpr (!is_view && ranges::enable_borrowed_range<remove_cvref_t<Rng>>) {
         using S                    = decltype(ranges::subrange{declval<const remove_cvref_t<Rng>>()});
         constexpr bool is_noexcept = noexcept(S{declval<const remove_cvref_t<Rng>>()});
 

--- a/tests/std/tests/P0896R4_views_reverse/test.cpp
+++ b/tests/std/tests/P0896R4_views_reverse/test.cpp
@@ -106,7 +106,7 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
 
         static_assert(same_as<decltype(move(rng) | pipeline), R>);
         static_assert(noexcept(move(rng) | pipeline) == is_noexcept);
-    } else if constexpr (enable_borrowed_range<Rng>) {
+    } else if constexpr (enable_borrowed_range<remove_cvref_t<Rng>>) {
         using S                    = decltype(ranges::subrange{declval<Rng>()});
         using RS                   = reverse_view<S>;
         constexpr bool is_noexcept = noexcept(S{declval<Rng>()});
@@ -141,7 +141,7 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
 
         static_assert(same_as<decltype(move(as_const(rng)) | pipeline), R>);
         static_assert(noexcept(move(as_const(rng)) | pipeline) == is_noexcept);
-    } else if constexpr (!is_view && enable_borrowed_range<const remove_cvref_t<Rng>>) {
+    } else if constexpr (!is_view && enable_borrowed_range<remove_cvref_t<Rng>>) {
         using S                    = decltype(ranges::subrange{declval<const remove_cvref_t<Rng>>()});
         using RS                   = reverse_view<S>;
         constexpr bool is_noexcept = noexcept(S{declval<const remove_cvref_t<Rng>>()});


### PR DESCRIPTION
... especially in these view tests.

Found during review at https://github.com/microsoft/STL/pull/1305#discussion_r510524571.

<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
