### PR TITLE
Fix noexcept(noexcept(is_nothrow_v))

### DIFF
--- a/stl/inc/iterator
+++ b/stl/inc/iterator
@@ -602,7 +602,7 @@ public:
 #endif // TRANSITION, VSO-1225825
 
     _Variantish(const _Variantish& _That) noexcept(
-        noexcept(is_nothrow_copy_constructible_v<_It>&& is_nothrow_copy_constructible_v<_Se>))
+        is_nothrow_copy_constructible_v<_It>&& is_nothrow_copy_constructible_v<_Se>)
         : _Contains{_That._Contains} {
         switch (_Contains) {
         case _Variantish_state::_Holds_iter:

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -1187,7 +1187,7 @@ namespace ranges {
             _Iterator() = default;
 
             constexpr _Iterator(_Parent_t& _Parent_, iterator_t<_Base> _Current_) noexcept(
-                noexcept(is_nothrow_move_constructible_v<iterator_t<_Base>>)) // strengthened
+                is_nothrow_move_constructible_v<iterator_t<_Base>>) // strengthened
                 : _Current{_STD move(_Current_)}, _Parent{_STD addressof(_Parent_)} {
 #if _ITERATOR_DEBUG_LEVEL != 0
                 _Adl_verify_range(_Current, _RANGES end(_Parent_._Range));


### PR DESCRIPTION
Noticed while reviewing #1406.

`noexcept(noexcept(is_nothrow_v))` is a mistake (it's always `noexcept(true)`). We intended `noexcept(is_nothrow_v)` here.

These appear to be the only occurrences that we've accumulated so far; I searched with all of my regex powers.

(It's unfortunate that the language repurposes the keyword with a different meaning here, and it's unfortunate that neither MSVC nor Clang warn about this.)