### PR TITLE
Code cleanups: Unify _Float_traits and _Floating_type_traits

### DIFF
--- a/stl/inc/complex
+++ b/stl/inc/complex
@@ -1877,7 +1877,7 @@ _Ty _Fabs(const complex<_Ty>& _Left, int* _Pexp) { // Used by sqrt(), return mag
             _Bv    = _Bv * static_cast<_Ty>(0.0625);
         } else {
             constexpr _Ty _Flt_eps = _Ctraits<_Ty>::_Flt_eps();
-            // TRANSITION, workaround for non floating-point _Ty
+            // TRANSITION, workaround for non-floating-point _Ty
             constexpr _Ty _Leg_tiny = _Flt_eps == 0 ? _Ty{0} : 2 * _Ctraits<_Ty>::_Flt_norm_min() / _Flt_eps;
 
             if (_Av < _Leg_tiny) {
@@ -1914,7 +1914,7 @@ _Ty _Fabs(const complex<_Ty>& _Left, int* _Pexp) { // Used by sqrt(), return mag
 
 // FUNCTION TEMPLATE log
 template <class _Ty>
-_NODISCARD _Ty _Log_abs(const complex<_Ty>& _Left) noexcept { // for double, long double, and non floating-point types
+_NODISCARD _Ty _Log_abs(const complex<_Ty>& _Left) noexcept { // for double, long double, and non-floating-point types
     return static_cast<_Ty>(
         _Math_algorithms::_Log_hypot(static_cast<double>(_STD real(_Left)), static_cast<double>(_STD imag(_Left))));
 }

--- a/stl/inc/complex
+++ b/stl/inc/complex
@@ -60,10 +60,10 @@ struct _C_ldouble_complex {
 
 _STD_BEGIN
 
-// implements multi-precision floating point arithmetic for numerical algorithms
+// implements multi-precision floating-point arithmetic for numerical algorithms
 #pragma float_control(precise, on, push)
 namespace _Float_multi_prec {
-    // multi-precision floating point types
+    // multi-precision floating-point types
     template <class _Ty, int _Prec>
     struct _Fmp_t;
 
@@ -1877,7 +1877,7 @@ _Ty _Fabs(const complex<_Ty>& _Left, int* _Pexp) { // Used by sqrt(), return mag
             _Bv    = _Bv * static_cast<_Ty>(0.0625);
         } else {
             constexpr _Ty _Flt_eps = _Ctraits<_Ty>::_Flt_eps();
-            // TRANSITION, workaround for non floating point _Ty
+            // TRANSITION, workaround for non floating-point _Ty
             constexpr _Ty _Leg_tiny = _Flt_eps == 0 ? _Ty{0} : 2 * _Ctraits<_Ty>::_Flt_norm_min() / _Flt_eps;
 
             if (_Av < _Leg_tiny) {
@@ -1914,7 +1914,7 @@ _Ty _Fabs(const complex<_Ty>& _Left, int* _Pexp) { // Used by sqrt(), return mag
 
 // FUNCTION TEMPLATE log
 template <class _Ty>
-_NODISCARD _Ty _Log_abs(const complex<_Ty>& _Left) noexcept { // for double, long double, and non floating point types
+_NODISCARD _Ty _Log_abs(const complex<_Ty>& _Left) noexcept { // for double, long double, and non floating-point types
     return static_cast<_Ty>(
         _Math_algorithms::_Log_hypot(static_cast<double>(_STD real(_Left)), static_cast<double>(_STD imag(_Left))));
 }

--- a/stl/inc/strstream
+++ b/stl/inc/strstream
@@ -193,7 +193,7 @@ protected:
         if (_Old_gptr && eback() < _Old_gptr) { // if the input sequence has a putback position available
             if (_Meta == EOF) {
                 _Meta = 0; // a value other than EOF
-            } else if (!(_Strmode & _Constant)) { // non constant, overwrite no matter what
+            } else if (!(_Strmode & _Constant)) { // non-constant, overwrite no matter what
                 _Old_gptr[-1] = static_cast<char>(_Meta);
             } else if (_Old_gptr[-1] != static_cast<char>(_Meta)) { // constant, unequal, can't put it back
                 return EOF;

--- a/stl/inc/typeinfo
+++ b/stl/inc/typeinfo
@@ -55,7 +55,7 @@ protected:
     }
 };
 
-class _CRTIMP2_IMPORT __non_rtti_object : public bad_typeid { // report a non RTTI object
+class _CRTIMP2_IMPORT __non_rtti_object : public bad_typeid { // report a non-RTTI object
 public:
     __non_rtti_object(const char* _Message) : bad_typeid(_Message) {}
 };

--- a/stl/inc/xlocnum
+++ b/stl/inc/xlocnum
@@ -898,7 +898,7 @@ private:
         if (_Sticky) { // increment ls digit in memory of those lost
             char* _Px = _Ptr;
             while (--_Px != _Leading) { // add in carry
-                if (*_Px != localeconv()->decimal_point[0]) { // non decimal point
+                if (*_Px != localeconv()->decimal_point[0]) { // not decimal point
                     if (*_Px != '9') { // carry stops here
                         ++*_Px;
                         break;

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -4116,7 +4116,7 @@ public:
 
     _NODISCARD size_type find_first_not_of(const _Elem _Ch, const size_type _Off = 0) const noexcept
     /* strengthened */ {
-        // look for non _Ch at or after _Off
+        // look for non-_Ch at or after _Off
         return static_cast<size_type>(
             _Traits_find_not_ch<_Traits>(_Mypair._Myval2._Myptr(), _Mypair._Myval2._Mysize, _Off, _Ch));
     }
@@ -4155,7 +4155,7 @@ public:
 
     _NODISCARD size_type find_last_not_of(const _Elem _Ch, const size_type _Off = npos) const noexcept
     /* strengthened */ {
-        // look for non _Ch before _Off
+        // look for non-_Ch before _Off
         return static_cast<size_type>(
             _Traits_rfind_not_ch<_Traits>(_Mypair._Myval2._Myptr(), _Mypair._Myval2._Mysize, _Off, _Ch));
     }

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -6123,35 +6123,13 @@ struct _CXX17_DEPRECATE_ITERATOR_BASE_CLASS iterator { // base type for iterator
     using reference         = _Reference;
 };
 
-// STRUCT TEMPLATE _Float_traits
-template <class _Ty>
-struct _Float_traits {
-    static_assert(is_floating_point_v<_Ty>, "_Float_traits<NonFloatingPoint> is invalid");
-
-    // traits for double and long double:
-    using type = unsigned long long;
-
-    static constexpr type _Sign_mask      = 0x8000'0000'0000'0000ULL;
-    static constexpr type _Magnitude_mask = 0x7fff'ffff'ffff'ffffULL;
-    static constexpr type _Exponent_mask  = 0x7ff0'0000'0000'0000ULL;
-    static constexpr type _Quiet_nan_mask = 0x0008'0000'0000'0000ULL;
-};
-
-template <>
-struct _Float_traits<float> {
-    using type = unsigned int;
-
-    static constexpr type _Sign_mask      = 0x8000'0000U;
-    static constexpr type _Magnitude_mask = 0x7fff'ffffU;
-    static constexpr type _Exponent_mask  = 0x7f80'0000U;
-    static constexpr type _Quiet_nan_mask = 0x0040'0000U;
-};
-
 // FUNCTION TEMPLATE _Float_abs_bits
 template <class _Ty, enable_if_t<is_floating_point_v<_Ty>, int> = 0>
 _NODISCARD _CONSTEXPR_BIT_CAST auto _Float_abs_bits(const _Ty& _Xx) {
-    const auto _Bits = _Bit_cast<typename _Float_traits<_Ty>::type>(_Xx);
-    return _Bits & _Float_traits<_Ty>::_Magnitude_mask;
+    using _Traits    = _Floating_type_traits<_Ty>;
+    using _Uint_type = typename _Traits::_Uint_type;
+    const auto _Bits = _Bit_cast<_Uint_type>(_Xx);
+    return _Bits & ~_Traits::_Shifted_sign_mask;
 }
 
 // FUNCTION TEMPLATE _Float_abs
@@ -6163,14 +6141,17 @@ _NODISCARD _CONSTEXPR_BIT_CAST _Ty _Float_abs(const _Ty _Xx) { // constexpr floa
 // FUNCTION TEMPLATE _Float_copysign
 template <class _Ty, enable_if_t<is_floating_point_v<_Ty>, int> = 0>
 _NODISCARD _CONSTEXPR_BIT_CAST _Ty _Float_copysign(const _Ty _Magnitude, const _Ty _Sign) { // constexpr copysign()
-    const auto _Signbit = _Bit_cast<typename _Float_traits<_Ty>::type>(_Sign) & _Float_traits<_Ty>::_Sign_mask;
+    using _Traits       = _Floating_type_traits<_Ty>;
+    using _Uint_type    = typename _Traits::_Uint_type;
+    const auto _Signbit = _Bit_cast<_Uint_type>(_Sign) & _Traits::_Shifted_sign_mask;
     return _Bit_cast<_Ty>(_Float_abs_bits(_Magnitude) | _Signbit);
 }
 
 // FUNCTION TEMPLATE _Is_nan
 template <class _Ty, enable_if_t<is_floating_point_v<_Ty>, int> = 0>
 _NODISCARD _CONSTEXPR_BIT_CAST bool _Is_nan(const _Ty _Xx) { // constexpr isnan()
-    return _Float_abs_bits(_Xx) > _Float_traits<_Ty>::_Exponent_mask;
+    using _Traits = _Floating_type_traits<_Ty>;
+    return _Float_abs_bits(_Xx) > _Traits::_Shifted_exponent_mask;
 }
 
 // FUNCTION TEMPLATE _Is_signaling_nan
@@ -6180,20 +6161,23 @@ _NODISCARD _CONSTEXPR_BIT_CAST bool _Is_nan(const _Ty _Xx) { // constexpr isnan(
 // and turns it into a quiet NaN. This behavior is undesirable if we want to test for signaling NaNs.
 template <class _Ty, enable_if_t<is_floating_point_v<_Ty>, int> = 0>
 _NODISCARD _CONSTEXPR_BIT_CAST bool _Is_signaling_nan(const _Ty& _Xx) { // returns true if input is a signaling NaN
+    using _Traits        = _Floating_type_traits<_Ty>;
     const auto _Abs_bits = _Float_abs_bits(_Xx);
-    return _Abs_bits > _Float_traits<_Ty>::_Exponent_mask && ((_Abs_bits & _Float_traits<_Ty>::_Quiet_nan_mask) == 0);
+    return _Abs_bits > _Traits::_Shifted_exponent_mask && ((_Abs_bits & _Traits::_Special_nan_mantissa_mask) == 0);
 }
 
 // FUNCTION TEMPLATE _Is_inf
 template <class _Ty, enable_if_t<is_floating_point_v<_Ty>, int> = 0>
 _NODISCARD _CONSTEXPR_BIT_CAST bool _Is_inf(const _Ty _Xx) { // constexpr isinf()
-    return _Float_abs_bits(_Xx) == _Float_traits<_Ty>::_Exponent_mask;
+    using _Traits = _Floating_type_traits<_Ty>;
+    return _Float_abs_bits(_Xx) == _Traits::_Shifted_exponent_mask;
 }
 
 // FUNCTION TEMPLATE _Is_finite
 template <class _Ty, enable_if_t<is_floating_point_v<_Ty>, int> = 0>
 _NODISCARD _CONSTEXPR_BIT_CAST bool _Is_finite(const _Ty _Xx) { // constexpr isfinite()
-    return _Float_abs_bits(_Xx) < _Float_traits<_Ty>::_Exponent_mask;
+    using _Traits = _Floating_type_traits<_Ty>;
+    return _Float_abs_bits(_Xx) < _Traits::_Shifted_exponent_mask;
 }
 
 // STRUCT _Nontrivial_dummy_type

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -6156,7 +6156,7 @@ _NODISCARD _CONSTEXPR_BIT_CAST auto _Float_abs_bits(const _Ty& _Xx) {
 
 // FUNCTION TEMPLATE _Float_abs
 template <class _Ty, enable_if_t<is_floating_point_v<_Ty>, int> = 0>
-_NODISCARD _CONSTEXPR_BIT_CAST _Ty _Float_abs(const _Ty _Xx) { // constexpr floating point abs()
+_NODISCARD _CONSTEXPR_BIT_CAST _Ty _Float_abs(const _Ty _Xx) { // constexpr floating-point abs()
     return _Bit_cast<_Ty>(_Float_abs_bits(_Xx));
 }
 
@@ -6175,7 +6175,7 @@ _NODISCARD _CONSTEXPR_BIT_CAST bool _Is_nan(const _Ty _Xx) { // constexpr isnan(
 
 // FUNCTION TEMPLATE _Is_signaling_nan
 // TRANSITION, workaround x86 ABI
-// On x86 ABI, floating point by-value arguments and return values are passed in 80-bit x87 registers.
+// On x86 ABI, floating-point by-value arguments and return values are passed in 80-bit x87 registers.
 // When the value is a 32-bit or 64-bit signaling NaN, the conversion to/from 80-bit raises FE_INVALID
 // and turns it into a quiet NaN. This behavior is undesirable if we want to test for signaling NaNs.
 template <class _Ty, enable_if_t<is_floating_point_v<_Ty>, int> = 0>

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -653,7 +653,7 @@
 #ifndef _STD_VECTORIZE_WITH_FLOAT_CONTROL
 #ifdef _M_FP_EXCEPT
 #define _STD_VECTORIZE_WITH_FLOAT_CONTROL 0
-#else // ^^^ floating point exceptions enabled / floating point exceptions disabled (default) vvv
+#else // ^^^ floating-point exceptions enabled / floating-point exceptions disabled (default) vvv
 #define _STD_VECTORIZE_WITH_FLOAT_CONTROL 1
 #endif // _M_FP_EXCEPT
 #endif // _STD_VECTORIZE_WITH_FLOAT_CONTROL

--- a/stl/src/cond.cpp
+++ b/stl/src/cond.cpp
@@ -23,8 +23,8 @@ struct _Cnd_internal_imp_t { // condition variable implementation for ConcRT
 };
 
 static_assert(sizeof(_Cnd_internal_imp_t) <= _Cnd_internal_imp_size, "incorrect _Cnd_internal_imp_size");
-static_assert(std::alignment_of<_Cnd_internal_imp_t>::value <= _Cnd_internal_imp_alignment,
-    "incorrect _Cnd_internal_imp_alignment");
+static_assert(
+    std::alignment_of_v<_Cnd_internal_imp_t> <= _Cnd_internal_imp_alignment, "incorrect _Cnd_internal_imp_alignment");
 
 void _Cnd_init_in_situ(const _Cnd_t cond) { // initialize condition variable in situ
     Concurrency::details::create_stl_condition_variable(cond->_get_cv());

--- a/stl/src/cond.cpp
+++ b/stl/src/cond.cpp
@@ -23,8 +23,7 @@ struct _Cnd_internal_imp_t { // condition variable implementation for ConcRT
 };
 
 static_assert(sizeof(_Cnd_internal_imp_t) <= _Cnd_internal_imp_size, "incorrect _Cnd_internal_imp_size");
-static_assert(
-    std::alignment_of_v<_Cnd_internal_imp_t> <= _Cnd_internal_imp_alignment, "incorrect _Cnd_internal_imp_alignment");
+static_assert(alignof(_Cnd_internal_imp_t) <= _Cnd_internal_imp_alignment, "incorrect _Cnd_internal_imp_alignment");
 
 void _Cnd_init_in_situ(const _Cnd_t cond) { // initialize condition variable in situ
     Concurrency::details::create_stl_condition_variable(cond->_get_cv());

--- a/stl/src/mutex.cpp
+++ b/stl/src/mutex.cpp
@@ -51,8 +51,7 @@ struct _Mtx_internal_imp_t { // ConcRT mutex
 };
 
 static_assert(sizeof(_Mtx_internal_imp_t) <= _Mtx_internal_imp_size, "incorrect _Mtx_internal_imp_size");
-static_assert(
-    std::alignment_of_v<_Mtx_internal_imp_t> <= _Mtx_internal_imp_alignment, "incorrect _Mtx_internal_imp_alignment");
+static_assert(alignof(_Mtx_internal_imp_t) <= _Mtx_internal_imp_alignment, "incorrect _Mtx_internal_imp_alignment");
 
 void _Mtx_init_in_situ(_Mtx_t mtx, int type) { // initialize mutex in situ
     Concurrency::details::create_stl_critical_section(mtx->_get_cs());

--- a/stl/src/mutex.cpp
+++ b/stl/src/mutex.cpp
@@ -51,8 +51,8 @@ struct _Mtx_internal_imp_t { // ConcRT mutex
 };
 
 static_assert(sizeof(_Mtx_internal_imp_t) <= _Mtx_internal_imp_size, "incorrect _Mtx_internal_imp_size");
-static_assert(std::alignment_of<_Mtx_internal_imp_t>::value <= _Mtx_internal_imp_alignment,
-    "incorrect _Mtx_internal_imp_alignment");
+static_assert(
+    std::alignment_of_v<_Mtx_internal_imp_t> <= _Mtx_internal_imp_alignment, "incorrect _Mtx_internal_imp_alignment");
 
 void _Mtx_init_in_situ(_Mtx_t mtx, int type) { // initialize mutex in situ
     Concurrency::details::create_stl_critical_section(mtx->_get_cs());

--- a/tests/std/tests/GH_000935_complex_numerical_accuracy/floating_point_utils.hpp
+++ b/tests/std/tests/GH_000935_complex_numerical_accuracy/floating_point_utils.hpp
@@ -12,19 +12,19 @@
 
 namespace fputil {
     template <typename T>
-    using float_bits_t = typename _STD _Float_traits<T>::type;
+    using float_bits_t = typename _STD _Floating_type_traits<T>::_Uint_type;
 
     template <typename T>
-    _INLINE_VAR constexpr float_bits_t<T> magnitude_mask_v = _STD _Float_traits<T>::_Magnitude_mask;
+    _INLINE_VAR constexpr float_bits_t<T> sign_mask_v = _STD _Floating_type_traits<T>::_Shifted_sign_mask;
 
     template <typename T>
-    _INLINE_VAR constexpr float_bits_t<T> exponent_mask_v = _STD _Float_traits<T>::_Exponent_mask;
+    _INLINE_VAR constexpr float_bits_t<T> magnitude_mask_v = ~sign_mask_v<T>;
+
+    template <typename T>
+    _INLINE_VAR constexpr float_bits_t<T> exponent_mask_v = _STD _Floating_type_traits<T>::_Shifted_exponent_mask;
 
     template <typename T>
     _INLINE_VAR constexpr float_bits_t<T> significand_mask_v = magnitude_mask_v<T> & ~exponent_mask_v<T>;
-
-    template <typename T>
-    _INLINE_VAR constexpr float_bits_t<T> sign_mask_v = _STD _Float_traits<T>::_Sign_mask;
 
     template <typename T>
     _INLINE_VAR constexpr float_bits_t<T> norm_min_bits_v = significand_mask_v<T> + 1U;

--- a/tests/std/tests/P0092R1_polishing_chrono/test.cpp
+++ b/tests/std/tests/P0092R1_polishing_chrono/test.cpp
@@ -208,7 +208,7 @@ int main() {
     assert(duration_cast<duration<long long>>(d).count() == 17);
 
 
-    // DevDiv-742944 "non conforming return value for std::chrono::duration::operator%()"
+    // DevDiv-742944 "non-conforming return value for std::chrono::duration::operator%()"
     assert((milliseconds(1050) % seconds(1)).count() == 50);
 
     assert((milliseconds(1729) / 10).count() == 172);

--- a/tests/std/tests/P0513R0_poisoning_the_hash/test.cpp
+++ b/tests/std/tests/P0513R0_poisoning_the_hash/test.cpp
@@ -105,11 +105,11 @@ namespace std {
 
     template <>
     struct hash<Hashable> {
-        hash() { // non trivial
+        hash() { // non-trivial
         }
-        hash(const hash&) { // non trivial
+        hash(const hash&) { // non-trivial
         }
-        hash& operator=(const hash&) { // non trivial
+        hash& operator=(const hash&) { // non-trivial
             return *this;
         }
         size_t operator()(Hashable) {

--- a/tests/std/tests/P0896R4_istream_view/test.cpp
+++ b/tests/std/tests/P0896R4_istream_view/test.cpp
@@ -71,7 +71,7 @@ void test_one_type() {
     static_assert(noexcept(default_constructed.end()));
     static_assert(noexcept(ranges::end(default_constructed)));
 
-    // Non existing member functions
+    // Nonexistent member functions
     static_assert(!CanMemberSize<R>);
     static_assert(!CanMemberData<R>);
     static_assert(!CanMemberEmpty<R>);

--- a/tests/std/tests/P0896R4_views_take_while/test.cpp
+++ b/tests/std/tests/P0896R4_views_take_while/test.cpp
@@ -246,7 +246,7 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
         same_as<ranges::sentinel_t<const R>> auto sc = as_const(r).end();
 
         if (forward_range<V>) { // intentionally not if constexpr
-            // Compare with const / non const iterators
+            // Compare with const / non-const iterators
             assert(s != r.begin());
             assert(s != as_const(r).begin());
             assert(sc != r.begin());

--- a/tests/std/tests/VSO_0000000_type_traits/test.cpp
+++ b/tests/std/tests/VSO_0000000_type_traits/test.cpp
@@ -493,7 +493,7 @@ VERIFY_BASE_CHARACTERISTIC(is_void<int>, conjunction<is_void<int>, void>);
 VERIFY_BASE_CHARACTERISTIC(is_volatile<int>, conjunction<is_const<const int>, is_volatile<int>, void>);
 VERIFY_BASE_CHARACTERISTIC(is_const<int>, conjunction<is_const<int>, void, void>);
 VERIFY_BASE_CHARACTERISTIC(is_const<int>, conjunction<is_const<int>, void, void, void>);
-// non integral_constant family
+// non-integral_constant family
 VERIFY_BASE_CHARACTERISTIC_V(fake_bool<true>, conjunction<fake_bool<true>>);
 VERIFY_BASE_CHARACTERISTIC_V(fake_bool<true>, conjunction<fake_bool<true>, fake_bool<true>>);
 VERIFY_BASE_CHARACTERISTIC_V(fake_bool<true>, conjunction<fake_bool<true>, fake_bool<true>, fake_bool<true>>);
@@ -530,7 +530,7 @@ VERIFY_BASE_CHARACTERISTIC(is_void<void>, disjunction<is_void<void>, void>);
 VERIFY_BASE_CHARACTERISTIC(is_void<void>, disjunction<is_const<int>, is_void<void>, void>);
 VERIFY_BASE_CHARACTERISTIC(is_void<void>, disjunction<is_void<void>, void, void>);
 VERIFY_BASE_CHARACTERISTIC(is_void<void>, disjunction<is_void<void>, void, void, void>);
-// non integral_constant family
+// non-integral_constant family
 VERIFY_BASE_CHARACTERISTIC_V(fake_bool<false>, disjunction<fake_bool<false>>);
 VERIFY_BASE_CHARACTERISTIC_V(fake_bool<false>, disjunction<fake_bool<false>, fake_bool<false>>);
 VERIFY_BASE_CHARACTERISTIC_V(fake_bool<false>, disjunction<fake_bool<false>, fake_bool<false>, fake_bool<false>>);

--- a/tests/std/tests/VSO_0180469_ptr_cat/test.compile.pass.cpp
+++ b/tests/std/tests/VSO_0180469_ptr_cat/test.compile.pass.cpp
@@ -334,7 +334,7 @@ void test_case_Equal_memcmp_is_safe() {
 
     // equal_to< some other T > should explode
     STATIC_ASSERT(_Equal_memcmp_is_safe<Elem1*, Elem2*, equal_to<list<int>>> == false);
-    // Non equal_to comparison functions should explode
+    // Non-equal_to comparison functions should explode
     auto lambda = [](Elem1*, Elem2*) { return false; };
     STATIC_ASSERT(_Equal_memcmp_is_safe<Elem1*, Elem2*, decltype(lambda)> == false);
     // equal_to<T> should not explode

--- a/tests/tr1/tests/filesystem1/test.cpp
+++ b/tests/tr1/tests/filesystem1/test.cpp
@@ -19,13 +19,6 @@
 #define GAMMA16 01623
 #define GAMMA8  "\316\223"
 
-#ifdef _HAS_WINDOWS_FILESYSTEM
-#elif defined(_WIN32)
-#define _HAS_WINDOWS_FILESYSTEM 1
-#else // defined(_WIN32)
-#define _HAS_WINDOWS_FILESYSTEM 0
-#endif // defined(_WIN32)
-
 #define ALT(x, y)           y
 #define NEVER_HAS_ROOT_NAME false
 #define ROOT_NAME           "c:"


### PR DESCRIPTION
* `tr1`: `_HAS_WINDOWS_FILESYSTEM` is unused.
  + We don't usually clean up `tr1`, but this was polluting my search for `#ifdef _HAS`.
* `cond.cpp`, `mutex.cpp`: Use `alignof`.
* Hyphenate floating-point in comments.
* Fix "non meow" comments (usually to say "non-meow", sometimes rephrasing differently).
* Replace `_Float_traits` usage with `_Floating_type_traits` from `<type_traits>`.
  + While @statementreply was working on #935 which added `_Float_traits` to `<xutility>`, #1370 moved `_Floating_type_traits` up from `<charconv>` to `<type_traits>`. We should de-duplicate this machinery now. `_Floating_type_traits` has all of this content and more (under different names), except for `_Float_traits::_Magnitude_mask`. This is used only once in product code (`_Float_abs_bits`), where I believe it's simpler to refer to `~_Floating_type_traits::_Shifted_sign_mask` (as we're clearly masking away the sign bit), instead of adding `_Magnitude_mask` to `_Floating_type_traits`.
  + I verified with `static_assert` that the values are identical.
  + Note that there is a terminology difference: `_Floating_type_traits` has `_Shifted_exponent_mask` (which we want; it's been "shifted" into the proper position for single-precision or double-precision) and `_Exponent_mask` (which we do not want). I double-checked that all uses of `_Float_traits::_Exponent_mask` were properly converted to `_Floating_type_traits::_Shifted_exponent_mask`.
  + This extracts `_Traits` and `_Uint_type` typedefs for readability.
  + This also updates the test code's definition of `magnitude_mask_v`; the constants need to be re-ordered which is why the diff looks complicated.
