### PR TITLE
Add initial launch.json and task.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,29 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "clang-cl Launch",
+            "type": "cppvsdbg",
+            "request": "launch",
+            "program": "${fileBasenameNoExtension}.exe",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}/out",
+            "environment": [],
+            "externalConsole": false,
+            "preLaunchTask": "C/C++: build active file with clang-cl"
+        },
+        {
+            "name": "cl Launch",
+            "type": "cppvsdbg",
+            "request": "launch",
+            "program": "${fileBasenameNoExtension}.exe",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}/out",
+            "environment": [],
+            "externalConsole": false,
+            "preLaunchTask": "C/C++: build active file with cl"
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,102 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "cppbuild",
+			"label": "C/C++: build active file with cl",
+			"command": "cl.exe",
+			"args": [
+				"/ID:${workspaceFolder}/out/build/x64/out/inc",
+				"/IC:${workspaceFolder}/tests/std/include",
+				"/LIBPATH:${workspaceFolder}/out/build/x64/out/lib/amd64",
+				"/FIforce_include.hpp",
+				"/nologo",
+				"/EHsc",
+				"/W4",
+				"/WX",
+				"/Od",
+				"/w14061",
+				"/w14242",
+				"/w14265",
+				"/w14365",
+				"/w14582",
+				"/w14583",
+				"/w14587",
+				"/w14588",
+				"/w14749",
+				"/w14841",
+				"/w14842",
+				"/w15038",
+				"/w15214",
+				"/w15215",
+				"/w15216",
+				"/w15217",
+				"/MTd",
+				"/std:c++latest",
+				"/I",
+				"${workspaceFolder}/tests/std/include",
+				"${file}"
+			],
+			"options": {
+				"cwd": "${workspaceFolder}/out"
+			},
+			"problemMatcher": [
+				"$msCompile"
+			],
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			},
+			"detail": "compiler: cl.exe"
+		},
+		{
+			"type": "cppbuild",
+			"label": "C/C++: build active file with clang-cl",
+			"command": "clang-cl.exe",
+			"args": [
+				"/ID:${workspaceFolder}\\out\\build\\x64\\out\\inc",
+				"/IC:${workspaceFolder}\\tests\\std\\include",
+				"/FIforce_include.hpp",
+				"/nologo",
+				"/EHsc",
+				"/W4",
+				"/WX",
+				"/Od",
+				"/w14061",
+				"/w14242",
+				"/w14265",
+				"/w14365",
+				"/w14582",
+				"/w14583",
+				"/w14587",
+				"/w14588",
+				"/w14749",
+				"/w14841",
+				"/w14842",
+				"/w15038",
+				"/w15214",
+				"/w15215",
+				"/w15216",
+				"/w15217",
+				"/MTd",
+				"/std:c++latest",
+				"-fno-ms-compatibility",
+				"-fno-delayed-template-parsing",
+				"/I",
+				"${workspaceFolder}/tests/std/include",
+				"${file}"
+			],
+			"options": {
+				"cwd": "${workspaceFolder}/out"
+			},
+			"problemMatcher": [
+				"$msCompile"
+			],
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			},
+			"detail": "compiler: clang-cl.exe"
+		}
+	]
+}


### PR DESCRIPTION
This is a WIP to get some feedback on how to integrate tasks and debugging into the repo (See #484).

For now there are many questions open:

1. I believe we should add some cmake_kits to enabling building via the cmake tools extension
2. There should be a way to get the current configuration of the cmake tools and reuse it in the task
3. All those settings / language modes from the test matrix are hell
4. All those settings / language modes from the test matrix are hell
5. There are some bugs lying around, for example clang-cl does not build with the libpath input albeit cl does!?