### PR TITLE
VS 2019 16.9 Preview 1 toolset update

### DIFF
--- a/.github/ISSUE_TEMPLATE/cxx23-feature.md
+++ b/.github/ISSUE_TEMPLATE/cxx23-feature.md
@@ -1,8 +1,8 @@
 ---
-name: cxx20 Feature
+name: cxx23 Feature
 about: For STL maintainers only
 title: PAPER_NUMBER PAPER_TITLE
-labels: cxx20
+labels: cxx23
 assignees: ''
 
 ---
@@ -22,3 +22,8 @@ the https://wg21.link redirector will start working.
 
 Feature-test macro:
 `#define MACRO_NAME MACRO_VALUE`
+
+Note: We're still working on finishing C++20. Until we're done
+with that (and the compiler implements distinct `/std:c++20` and
+`/std:c++latest` options), we won't be able to review PRs for
+C++23 features.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if (NOT DEFINED CMAKE_TOOLCHAIN_FILE AND EXISTS "${CMAKE_CURRENT_LIST_DIR}/vcpkg
     set(CMAKE_TOOLCHAIN_FILE "${CMAKE_CURRENT_LIST_DIR}/vcpkg/scripts/buildsystems/vcpkg.cmake")
 endif()
 
-cmake_minimum_required(VERSION 3.17)
+cmake_minimum_required(VERSION 3.18)
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 project(msvc_standard_libraries LANGUAGES CXX)
 

--- a/README.md
+++ b/README.md
@@ -143,10 +143,10 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 The STL uses boost-math headers to provide P0226R1 Mathematical Special Functions. We recommend using [vcpkg][] to
 acquire this dependency.
 
-1. Install Visual Studio 2019 16.8 Preview 5 or later.
+1. Install Visual Studio 2019 16.9 Preview 1 or later.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
-    * Otherwise, install [CMake][] 3.17 or later, and [Ninja][] 1.8.2 or later.
+    * Otherwise, install [CMake][] 3.18 or later, and [Ninja][] 1.8.2 or later.
 2. Open Visual Studio, and choose the "Clone or check out code" option. Enter the URL of this repository,
    `https://github.com/microsoft/STL`.
 3. Open a terminal in the IDE with `` Ctrl + ` `` (by default) or press on "View" in the top bar, and then "Terminal".
@@ -158,10 +158,10 @@ acquire this dependency.
 
 # How To Build With A Native Tools Command Prompt
 
-1. Install Visual Studio 2019 16.8 Preview 5 or later.
+1. Install Visual Studio 2019 16.9 Preview 1 or later.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
-    * Otherwise, install [CMake][] 3.17 or later, and [Ninja][] 1.8.2 or later.
+    * Otherwise, install [CMake][] 3.18 or later, and [Ninja][] 1.8.2 or later.
 2. Open a command prompt.
 3. Change directories to a location where you'd like a clone of this STL repository.
 4. `git clone https://github.com/microsoft/STL`

--- a/azure-devops/create-vmss.ps1
+++ b/azure-devops/create-vmss.ps1
@@ -25,7 +25,7 @@ $LiveVMPrefix = 'BUILD'
 $WindowsServerSku = '2019-Datacenter'
 
 $ProgressActivity = 'Creating Scale Set'
-$TotalProgress = 11
+$TotalProgress = 12
 $CurrentProgress = 1
 
 <#
@@ -158,6 +158,14 @@ function Wait-Shutdown {
   }
 }
 
+
+####################################################################################################
+Write-Progress `
+  -Activity $ProgressActivity `
+  -Status 'Setting the subscription context' `
+  -PercentComplete (100 / $TotalProgress * $CurrentProgress++)
+
+Set-AzContext -SubscriptionName CPP_STL_GitHub
 
 ####################################################################################################
 Write-Progress `

--- a/azure-devops/create-vmss.ps1
+++ b/azure-devops/create-vmss.ps1
@@ -391,6 +391,4 @@ New-AzVmss `
 Write-Progress -Activity $ProgressActivity -Completed
 Write-Host "Location: $Location"
 Write-Host "Resource group name: $ResourceGroupName"
-Write-Host "User name: AdminUser"
-Write-Host "Using generated password: $AdminPW"
 Write-Host 'Finished!'

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -88,6 +88,9 @@ $Workloads = @(
   'Microsoft.VisualStudio.Component.VC.CMake.Project',
   'Microsoft.VisualStudio.Component.VC.CoreIde',
   'Microsoft.VisualStudio.Component.VC.Llvm.Clang',
+  'Microsoft.VisualStudio.Component.VC.Runtimes.ARM.Spectre',
+  'Microsoft.VisualStudio.Component.VC.Runtimes.ARM64.Spectre',
+  'Microsoft.VisualStudio.Component.VC.Runtimes.x86.x64.Spectre',
   'Microsoft.VisualStudio.Component.VC.Tools.ARM',
   'Microsoft.VisualStudio.Component.VC.Tools.ARM64',
   'Microsoft.VisualStudio.Component.VC.Tools.x86.x64',
@@ -98,6 +101,9 @@ $ReleaseInPath = 'Preview'
 $Sku = 'Enterprise'
 $VisualStudioBootstrapperUrl = 'https://aka.ms/vs/16/pre/vs_enterprise.exe'
 $PythonUrl = 'https://www.python.org/ftp/python/3.9.0/python-3.9.0-amd64.exe'
+
+# https://docs.microsoft.com/en-us/windows-hardware/drivers/download-the-wdk
+$WindowsDriverKitUrl = 'https://go.microsoft.com/fwlink/?linkid=2128854'
 
 $CudaUrl = `
   'https://developer.download.nvidia.com/compute/cuda/10.1/Prod/local_installers/cuda_10.1.243_426.00_win10.exe'
@@ -225,6 +231,36 @@ Function InstallPython {
 
 <#
 .SYNOPSIS
+Installs the Windows Driver Kit.
+
+.DESCRIPTION
+InstallWindowsDriverKit installs the Windows Driver Kit from the supplied URL.
+
+.PARAMETER Url
+The URL of the Windows Driver Kit installer.
+#>
+Function InstallWindowsDriverKit {
+  Param(
+    [String]$Url
+  )
+
+  Write-Host 'Downloading the Windows Driver Kit...'
+  [string]$installerPath = Get-TempFilePath -Extension 'exe'
+  curl.exe -L -o $installerPath -s -S $Url
+  Write-Host 'Installing the Windows Driver Kit...'
+  $proc = Start-Process -FilePath $installerPath -ArgumentList `
+  @('/quiet', '/features', 'OptionId.WindowsDriverKitComplete') -Wait -PassThru
+  $exitCode = $proc.ExitCode
+  if ($exitCode -eq 0) {
+    Write-Host 'Installation successful!'
+  }
+  else {
+    Write-Error "Installation failed! Exited with $exitCode."
+  }
+}
+
+<#
+.SYNOPSIS
 Installs NVIDIA's CUDA Toolkit.
 
 .DESCRIPTION
@@ -300,6 +336,7 @@ Add-MpPreference -ExclusionProcess python.exe
 
 InstallPython $PythonUrl
 InstallVisualStudio -Workloads $Workloads -BootstrapperUrl $VisualStudioBootstrapperUrl
+InstallWindowsDriverKit $WindowsDriverKitUrl
 InstallCuda -Url $CudaUrl -Features $CudaFeatures
 
 Write-Host 'Updating PATH...'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,7 @@
 variables:
   tmpDir: 'D:\Temp'
 
-pool: 'StlBuild-2020-10-23'
+pool: 'StlBuild-2020-11-10'
 
 stages:
   - stage: Code_Format

--- a/stl/inc/filesystem
+++ b/stl/inc/filesystem
@@ -622,7 +622,6 @@ namespace filesystem {
 
     _NODISCARD inline bool _Is_drive_prefix_with_slash_slash_question(const wstring_view _Text) {
         // test if _Text starts with a \\?\X: prefix
-        using namespace _STD string_view_literals; // TRANSITION, VSO-571749
         return _Text.size() >= 6 && _Text._Starts_with(LR"(\\?\)"sv) && _Is_drive_prefix(_Text.data() + 4);
     }
 
@@ -1250,8 +1249,6 @@ namespace filesystem {
         }
 
         _NODISCARD path lexically_normal() const {
-            using namespace _STD string_view_literals; // TRANSITION, VSO-571749
-
             constexpr wstring_view _Dot     = L"."sv;
             constexpr wstring_view _Dot_dot = L".."sv;
 
@@ -1686,8 +1683,6 @@ namespace filesystem {
     }
 
     _NODISCARD inline path path::lexically_relative(const path& _Base) const {
-        using namespace _STD string_view_literals; // TRANSITION, VSO-571749
-
         constexpr wstring_view _Dot     = L"."sv;
         constexpr wstring_view _Dot_dot = L".."sv;
 
@@ -1810,7 +1805,6 @@ namespace filesystem {
 
     private:
         static string _Pretty_message(const string_view _Op, const path& _Path1, const path& _Path2 = {}) {
-            using namespace _STD string_view_literals; // TRANSITION, VSO-571749
             string _Result;
             // Convert the paths to narrow encoding in a way that gracefully handles non-encodable characters
             const auto _Code_page   = __std_fs_code_page();
@@ -2550,7 +2544,6 @@ namespace filesystem {
 
         _NODISCARD static __std_win_error _Open_dir(
             path& _Path, const directory_options _Options_arg, _Find_file_handle& _Dir, __std_fs_find_data& _Data) {
-            using namespace _STD string_view_literals; // TRANSITION, VSO-571749
             const size_t _Null_term_len = _CSTD wcslen(_Path.c_str());
             if (_Null_term_len == 0 || _Null_term_len != _Path.native().size()) {
                 return __std_win_error::_File_not_found;
@@ -3021,7 +3014,6 @@ namespace filesystem {
 
     // FUNCTION canonical
     _NODISCARD inline __std_win_error _Canonical(path& _Result, const wstring& _Text) { // pre: _Result.empty()
-        using namespace _STD string_view_literals; // TRANSITION, VSO-571749
         if (_Text.empty()) {
             return __std_win_error::_Success;
         }

--- a/stl/inc/memory_resource
+++ b/stl/inc/memory_resource
@@ -661,7 +661,7 @@ namespace pmr {
         }
 
     protected:
-        virtual void* do_allocate(size_t _Bytes, size_t _Align) override { // TRANSITION, DevCom-1159869
+        virtual void* do_allocate(const size_t _Bytes, const size_t _Align) override {
             // allocate from the current buffer or a new larger buffer from upstream
             if (!_STD align(_Align, _Bytes, _Current_buffer, _Space_available)) {
                 _Increase_capacity(_Bytes, _Align);

--- a/stl/inc/tuple
+++ b/stl/inc/tuple
@@ -684,6 +684,9 @@ public:
     template <size_t _Index, class... _Types>
     friend constexpr const tuple_element_t<_Index, tuple<_Types...>>&& get(const tuple<_Types...>&& _Tuple) noexcept;
 
+    template <size_t _Index, class... _Types>
+    friend constexpr tuple_element_t<_Index, tuple<_Types...>>&& _Tuple_get(tuple<_Types...>&& _Tuple) noexcept;
+
     template <class _Ty, class... _Types>
     friend constexpr _Ty& get(tuple<_Types...>& _Tuple) noexcept;
 
@@ -752,6 +755,81 @@ _NODISCARD constexpr bool operator<=(const tuple<_Types1...>& _Left, const tuple
 template <class... _Types, enable_if_t<conjunction_v<_Is_swappable<_Types>...>, int> = 0>
 _CONSTEXPR20 void swap(tuple<_Types...>& _Left, tuple<_Types...>& _Right) noexcept(noexcept(_Left.swap(_Right))) {
     return _Left.swap(_Right);
+}
+
+// CLASS _Tuple_element (find element by type)
+template <class _Ty, class _Tuple>
+struct _Tuple_element {}; // backstop _Tuple_element definition
+
+template <class _This, class... _Rest>
+struct _Tuple_element<_This, tuple<_This, _Rest...>> { // select first element
+    static_assert(!_Is_any_of_v<_This, _Rest...>, "duplicate type T in get<T>(tuple)");
+    using _Ttype = tuple<_This, _Rest...>;
+};
+
+template <class _Ty, class _This, class... _Rest>
+struct _Tuple_element<_Ty, tuple<_This, _Rest...>> { // recursive _Tuple_element definition
+    using _Ttype = typename _Tuple_element<_Ty, tuple<_Rest...>>::_Ttype;
+};
+
+// FUNCTION TEMPLATE get (by index)
+template <size_t _Index, class... _Types>
+_NODISCARD constexpr tuple_element_t<_Index, tuple<_Types...>>& get(tuple<_Types...>& _Tuple) noexcept {
+    using _Ttype = typename tuple_element<_Index, tuple<_Types...>>::_Ttype;
+    return static_cast<_Ttype&>(_Tuple)._Myfirst._Val;
+}
+
+template <size_t _Index, class... _Types>
+_NODISCARD constexpr const tuple_element_t<_Index, tuple<_Types...>>& get(const tuple<_Types...>& _Tuple) noexcept {
+    using _Ttype = typename tuple_element<_Index, tuple<_Types...>>::_Ttype;
+    return static_cast<const _Ttype&>(_Tuple)._Myfirst._Val;
+}
+
+template <size_t _Index, class... _Types>
+_NODISCARD constexpr tuple_element_t<_Index, tuple<_Types...>>&& get(tuple<_Types...>&& _Tuple) noexcept {
+    using _Ty    = tuple_element_t<_Index, tuple<_Types...>>;
+    using _Ttype = typename tuple_element<_Index, tuple<_Types...>>::_Ttype;
+    return static_cast<_Ty&&>(static_cast<_Ttype&>(_Tuple)._Myfirst._Val);
+}
+
+template <size_t _Index, class... _Types>
+_NODISCARD constexpr const tuple_element_t<_Index, tuple<_Types...>>&& get(const tuple<_Types...>&& _Tuple) noexcept {
+    using _Ty    = tuple_element_t<_Index, tuple<_Types...>>;
+    using _Ttype = typename tuple_element<_Index, tuple<_Types...>>::_Ttype;
+    return static_cast<const _Ty&&>(static_cast<const _Ttype&>(_Tuple)._Myfirst._Val);
+}
+
+template <size_t _Index, class... _Types>
+_NODISCARD constexpr tuple_element_t<_Index, tuple<_Types...>>&& _Tuple_get(tuple<_Types...>&& _Tuple) noexcept {
+    // used by pair's piecewise constructor
+    using _Ty    = tuple_element_t<_Index, tuple<_Types...>>;
+    using _Ttype = typename tuple_element<_Index, tuple<_Types...>>::_Ttype;
+    return static_cast<_Ty&&>(static_cast<_Ttype&>(_Tuple)._Myfirst._Val);
+}
+
+// FUNCTION TEMPLATE get (by type)
+template <class _Ty, class... _Types>
+_NODISCARD constexpr _Ty& get(tuple<_Types...>& _Tuple) noexcept {
+    using _Ttype = typename _Tuple_element<_Ty, tuple<_Types...>>::_Ttype;
+    return static_cast<_Ttype&>(_Tuple)._Myfirst._Val;
+}
+
+template <class _Ty, class... _Types>
+_NODISCARD constexpr const _Ty& get(const tuple<_Types...>& _Tuple) noexcept {
+    using _Ttype = typename _Tuple_element<_Ty, tuple<_Types...>>::_Ttype;
+    return static_cast<const _Ttype&>(_Tuple)._Myfirst._Val;
+}
+
+template <class _Ty, class... _Types>
+_NODISCARD constexpr _Ty&& get(tuple<_Types...>&& _Tuple) noexcept {
+    using _Ttype = typename _Tuple_element<_Ty, tuple<_Types...>>::_Ttype;
+    return static_cast<_Ty&&>(static_cast<_Ttype&>(_Tuple)._Myfirst._Val);
+}
+
+template <class _Ty, class... _Types>
+_NODISCARD constexpr const _Ty&& get(const tuple<_Types...>&& _Tuple) noexcept {
+    using _Ttype = typename _Tuple_element<_Ty, tuple<_Types...>>::_Ttype;
+    return static_cast<const _Ty&&>(static_cast<const _Ttype&>(_Tuple)._Myfirst._Val);
 }
 
 // CONSTRUCTOR TEMPLATES FOR tuple

--- a/stl/inc/tuple
+++ b/stl/inc/tuple
@@ -685,7 +685,7 @@ public:
     friend constexpr const tuple_element_t<_Index, tuple<_Types...>>&& get(const tuple<_Types...>&& _Tuple) noexcept;
 
     template <size_t _Index, class... _Types>
-    friend constexpr tuple_element_t<_Index, tuple<_Types...>>&& _Tuple_get(tuple<_Types...>&& _Tuple) noexcept;
+    friend constexpr decltype(auto) _Tuple_get(tuple<_Types...>&& _Tuple) noexcept;
 
     template <class _Ty, class... _Types>
     friend constexpr _Ty& get(tuple<_Types...>& _Tuple) noexcept;
@@ -800,7 +800,7 @@ _NODISCARD constexpr const tuple_element_t<_Index, tuple<_Types...>>&& get(const
 }
 
 template <size_t _Index, class... _Types>
-_NODISCARD constexpr tuple_element_t<_Index, tuple<_Types...>>&& _Tuple_get(tuple<_Types...>&& _Tuple) noexcept {
+_NODISCARD constexpr decltype(auto) _Tuple_get(tuple<_Types...>&& _Tuple) noexcept {
     // used by pair's piecewise constructor
     using _Ty    = tuple_element_t<_Index, tuple<_Types...>>;
     using _Ttype = typename tuple_element<_Index, tuple<_Types...>>::_Ttype;

--- a/stl/inc/tuple
+++ b/stl/inc/tuple
@@ -685,7 +685,7 @@ public:
     friend constexpr const tuple_element_t<_Index, tuple<_Types...>>&& get(const tuple<_Types...>&& _Tuple) noexcept;
 
     template <size_t _Index, class... _Types>
-    friend constexpr auto&& _Tuple_get(tuple<_Types...>&& _Tuple) noexcept;
+    friend constexpr decltype(auto) _Tuple_get(tuple<_Types...>&& _Tuple) noexcept;
 
     template <class _Ty, class... _Types>
     friend constexpr _Ty& get(tuple<_Types...>& _Tuple) noexcept;
@@ -800,7 +800,7 @@ _NODISCARD constexpr const tuple_element_t<_Index, tuple<_Types...>>&& get(const
 }
 
 template <size_t _Index, class... _Types>
-_NODISCARD constexpr auto&& _Tuple_get(tuple<_Types...>&& _Tuple) noexcept {
+_NODISCARD constexpr decltype(auto) _Tuple_get(tuple<_Types...>&& _Tuple) noexcept {
     // used by pair's piecewise constructor
     using _Ty    = tuple_element_t<_Index, tuple<_Types...>>;
     using _Ttype = typename tuple_element<_Index, tuple<_Types...>>::_Ttype;

--- a/stl/inc/tuple
+++ b/stl/inc/tuple
@@ -754,73 +754,6 @@ _CONSTEXPR20 void swap(tuple<_Types...>& _Left, tuple<_Types...>& _Right) noexce
     return _Left.swap(_Right);
 }
 
-// CLASS _Tuple_element (find element by type)
-template <class _Ty, class _Tuple>
-struct _Tuple_element {}; // backstop _Tuple_element definition
-
-template <class _This, class... _Rest>
-struct _Tuple_element<_This, tuple<_This, _Rest...>> { // select first element
-    static_assert(!_Is_any_of_v<_This, _Rest...>, "duplicate type T in get<T>(tuple)");
-    using _Ttype = tuple<_This, _Rest...>;
-};
-
-template <class _Ty, class _This, class... _Rest>
-struct _Tuple_element<_Ty, tuple<_This, _Rest...>> { // recursive _Tuple_element definition
-    using _Ttype = typename _Tuple_element<_Ty, tuple<_Rest...>>::_Ttype;
-};
-
-// FUNCTION TEMPLATE get (by index)
-template <size_t _Index, class... _Types>
-_NODISCARD constexpr tuple_element_t<_Index, tuple<_Types...>>& get(tuple<_Types...>& _Tuple) noexcept {
-    using _Ttype = typename tuple_element<_Index, tuple<_Types...>>::_Ttype;
-    return static_cast<_Ttype&>(_Tuple)._Myfirst._Val;
-}
-
-template <size_t _Index, class... _Types>
-_NODISCARD constexpr const tuple_element_t<_Index, tuple<_Types...>>& get(const tuple<_Types...>& _Tuple) noexcept {
-    using _Ttype = typename tuple_element<_Index, tuple<_Types...>>::_Ttype;
-    return static_cast<const _Ttype&>(_Tuple)._Myfirst._Val;
-}
-
-template <size_t _Index, class... _Types>
-_NODISCARD constexpr tuple_element_t<_Index, tuple<_Types...>>&& get(tuple<_Types...>&& _Tuple) noexcept {
-    using _Ty    = tuple_element_t<_Index, tuple<_Types...>>;
-    using _Ttype = typename tuple_element<_Index, tuple<_Types...>>::_Ttype;
-    return static_cast<_Ty&&>(static_cast<_Ttype&>(_Tuple)._Myfirst._Val);
-}
-
-template <size_t _Index, class... _Types>
-_NODISCARD constexpr const tuple_element_t<_Index, tuple<_Types...>>&& get(const tuple<_Types...>&& _Tuple) noexcept {
-    using _Ty    = tuple_element_t<_Index, tuple<_Types...>>;
-    using _Ttype = typename tuple_element<_Index, tuple<_Types...>>::_Ttype;
-    return static_cast<const _Ty&&>(static_cast<const _Ttype&>(_Tuple)._Myfirst._Val);
-}
-
-// FUNCTION TEMPLATE get (by type)
-template <class _Ty, class... _Types>
-_NODISCARD constexpr _Ty& get(tuple<_Types...>& _Tuple) noexcept {
-    using _Ttype = typename _Tuple_element<_Ty, tuple<_Types...>>::_Ttype;
-    return static_cast<_Ttype&>(_Tuple)._Myfirst._Val;
-}
-
-template <class _Ty, class... _Types>
-_NODISCARD constexpr const _Ty& get(const tuple<_Types...>& _Tuple) noexcept {
-    using _Ttype = typename _Tuple_element<_Ty, tuple<_Types...>>::_Ttype;
-    return static_cast<const _Ttype&>(_Tuple)._Myfirst._Val;
-}
-
-template <class _Ty, class... _Types>
-_NODISCARD constexpr _Ty&& get(tuple<_Types...>&& _Tuple) noexcept {
-    using _Ttype = typename _Tuple_element<_Ty, tuple<_Types...>>::_Ttype;
-    return static_cast<_Ty&&>(static_cast<_Ttype&>(_Tuple)._Myfirst._Val);
-}
-
-template <class _Ty, class... _Types>
-_NODISCARD constexpr const _Ty&& get(const tuple<_Types...>&& _Tuple) noexcept {
-    using _Ttype = typename _Tuple_element<_Ty, tuple<_Types...>>::_Ttype;
-    return static_cast<const _Ty&&>(static_cast<const _Ttype&>(_Tuple)._Myfirst._Val);
-}
-
 // CONSTRUCTOR TEMPLATES FOR tuple
 template <class _This, class... _Rest>
 template <class _Tag, class _Tpl, size_t... _Indices, enable_if_t<is_same_v<_Tag, _Unpack_tuple_t>, int>>
@@ -970,19 +903,6 @@ _NODISCARD constexpr _Ty make_from_tuple(_Tuple&& _Tpl) { // construct _Ty from 
         _STD forward<_Tuple>(_Tpl), make_index_sequence<tuple_size_v<remove_reference_t<_Tuple>>>{});
 }
 #endif // _HAS_CXX17
-
-// TEMPLATE CONSTRUCTOR pair::pair(tuple, tuple, sequence, sequence)
-template <class _Ty1, class _Ty2>
-template <class _Tuple1, class _Tuple2, size_t... _Indexes1, size_t... _Indexes2>
-constexpr pair<_Ty1, _Ty2>::pair(
-    _Tuple1& _Val1, _Tuple2& _Val2, index_sequence<_Indexes1...>, index_sequence<_Indexes2...>)
-    : first(_STD get<_Indexes1>(_STD move(_Val1))...), second(_STD get<_Indexes2>(_STD move(_Val2))...) {}
-
-// TEMPLATE CONSTRUCTOR pair::pair(piecewise_construct_t, tuple, tuple)
-template <class _Ty1, class _Ty2>
-template <class... _Types1, class... _Types2>
-_CONSTEXPR20 pair<_Ty1, _Ty2>::pair(piecewise_construct_t, tuple<_Types1...> _Val1, tuple<_Types2...> _Val2)
-    : pair(_Val1, _Val2, index_sequence_for<_Types1...>{}, index_sequence_for<_Types2...>{}) {}
 
 // STRUCT TEMPLATE uses_allocator
 template <class... _Types, class _Alloc>

--- a/stl/inc/tuple
+++ b/stl/inc/tuple
@@ -685,7 +685,7 @@ public:
     friend constexpr const tuple_element_t<_Index, tuple<_Types...>>&& get(const tuple<_Types...>&& _Tuple) noexcept;
 
     template <size_t _Index, class... _Types>
-    friend constexpr decltype(auto) _Tuple_get(tuple<_Types...>&& _Tuple) noexcept;
+    friend constexpr auto&& _Tuple_get(tuple<_Types...>&& _Tuple) noexcept;
 
     template <class _Ty, class... _Types>
     friend constexpr _Ty& get(tuple<_Types...>& _Tuple) noexcept;
@@ -800,7 +800,7 @@ _NODISCARD constexpr const tuple_element_t<_Index, tuple<_Types...>>&& get(const
 }
 
 template <size_t _Index, class... _Types>
-_NODISCARD constexpr decltype(auto) _Tuple_get(tuple<_Types...>&& _Tuple) noexcept {
+_NODISCARD constexpr auto&& _Tuple_get(tuple<_Types...>&& _Tuple) noexcept {
     // used by pair's piecewise constructor
     using _Ty    = tuple_element_t<_Index, tuple<_Types...>>;
     using _Ttype = typename tuple_element<_Index, tuple<_Types...>>::_Ttype;

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -498,73 +498,6 @@ template <size_t _Index, class _This, class... _Rest>
 struct _MSVC_KNOWN_SEMANTICS tuple_element<_Index, tuple<_This, _Rest...>>
     : tuple_element<_Index - 1, tuple<_Rest...>> {}; // recursive tuple_element definition
 
-// FUNCTION TEMPLATE get (by index)
-template <size_t _Index, class... _Types>
-_NODISCARD constexpr tuple_element_t<_Index, tuple<_Types...>>& get(tuple<_Types...>& _Tuple) noexcept {
-    using _Ttype = typename tuple_element<_Index, tuple<_Types...>>::_Ttype;
-    return static_cast<_Ttype&>(_Tuple)._Myfirst._Val;
-}
-
-template <size_t _Index, class... _Types>
-_NODISCARD constexpr const tuple_element_t<_Index, tuple<_Types...>>& get(const tuple<_Types...>& _Tuple) noexcept {
-    using _Ttype = typename tuple_element<_Index, tuple<_Types...>>::_Ttype;
-    return static_cast<const _Ttype&>(_Tuple)._Myfirst._Val;
-}
-
-template <size_t _Index, class... _Types>
-_NODISCARD constexpr tuple_element_t<_Index, tuple<_Types...>>&& get(tuple<_Types...>&& _Tuple) noexcept {
-    using _Ty    = tuple_element_t<_Index, tuple<_Types...>>;
-    using _Ttype = typename tuple_element<_Index, tuple<_Types...>>::_Ttype;
-    return static_cast<_Ty&&>(static_cast<_Ttype&>(_Tuple)._Myfirst._Val);
-}
-
-template <size_t _Index, class... _Types>
-_NODISCARD constexpr const tuple_element_t<_Index, tuple<_Types...>>&& get(const tuple<_Types...>&& _Tuple) noexcept {
-    using _Ty    = tuple_element_t<_Index, tuple<_Types...>>;
-    using _Ttype = typename tuple_element<_Index, tuple<_Types...>>::_Ttype;
-    return static_cast<const _Ty&&>(static_cast<const _Ttype&>(_Tuple)._Myfirst._Val);
-}
-
-// CLASS _Tuple_element (find element by type)
-template <class _Ty, class _Tuple>
-struct _Tuple_element {}; // backstop _Tuple_element definition
-
-template <class _This, class... _Rest>
-struct _Tuple_element<_This, tuple<_This, _Rest...>> { // select first element
-    static_assert(!_Is_any_of_v<_This, _Rest...>, "duplicate type T in get<T>(tuple)");
-    using _Ttype = tuple<_This, _Rest...>;
-};
-
-template <class _Ty, class _This, class... _Rest>
-struct _Tuple_element<_Ty, tuple<_This, _Rest...>> { // recursive _Tuple_element definition
-    using _Ttype = typename _Tuple_element<_Ty, tuple<_Rest...>>::_Ttype;
-};
-
-// FUNCTION TEMPLATE get (by type)
-template <class _Ty, class... _Types>
-_NODISCARD constexpr _Ty& get(tuple<_Types...>& _Tuple) noexcept {
-    using _Ttype = typename _Tuple_element<_Ty, tuple<_Types...>>::_Ttype;
-    return static_cast<_Ttype&>(_Tuple)._Myfirst._Val;
-}
-
-template <class _Ty, class... _Types>
-_NODISCARD constexpr const _Ty& get(const tuple<_Types...>& _Tuple) noexcept {
-    using _Ttype = typename _Tuple_element<_Ty, tuple<_Types...>>::_Ttype;
-    return static_cast<const _Ttype&>(_Tuple)._Myfirst._Val;
-}
-
-template <class _Ty, class... _Types>
-_NODISCARD constexpr _Ty&& get(tuple<_Types...>&& _Tuple) noexcept {
-    using _Ttype = typename _Tuple_element<_Ty, tuple<_Types...>>::_Ttype;
-    return static_cast<_Ty&&>(static_cast<_Ttype&>(_Tuple)._Myfirst._Val);
-}
-
-template <class _Ty, class... _Types>
-_NODISCARD constexpr const _Ty&& get(const tuple<_Types...>&& _Tuple) noexcept {
-    using _Ttype = typename _Tuple_element<_Ty, tuple<_Types...>>::_Ttype;
-    return static_cast<const _Ty&&>(static_cast<const _Ttype&>(_Tuple)._Myfirst._Val);
-}
-
 // TUPLE INTERFACE TO pair
 template <class _Ty1, class _Ty2>
 struct tuple_size<pair<_Ty1, _Ty2>> : integral_constant<size_t, 2> {}; // size of pair
@@ -659,11 +592,14 @@ _NODISCARD constexpr const _Ty2&& get(
 }
 
 // TEMPLATE CONSTRUCTOR pair::pair(tuple, tuple, sequence, sequence)
+template <size_t _Index, class... _Types>
+_NODISCARD constexpr tuple_element_t<_Index, tuple<_Types...>>&& _Tuple_get(tuple<_Types...>&& _Tuple) noexcept;
+
 template <class _Ty1, class _Ty2>
 template <class _Tuple1, class _Tuple2, size_t... _Indexes1, size_t... _Indexes2>
 constexpr pair<_Ty1, _Ty2>::pair(
     _Tuple1& _Val1, _Tuple2& _Val2, index_sequence<_Indexes1...>, index_sequence<_Indexes2...>)
-    : first(_STD get<_Indexes1>(_STD move(_Val1))...), second(_STD get<_Indexes2>(_STD move(_Val2))...) {}
+    : first(_Tuple_get<_Indexes1>(_STD move(_Val1))...), second(_Tuple_get<_Indexes2>(_STD move(_Val2))...) {}
 
 // FUNCTION TEMPLATE exchange
 template <class _Ty, class _Other = _Ty>

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -123,6 +123,9 @@ _INLINE_VAR constexpr piecewise_construct_t piecewise_construct{};
 template <class...>
 class tuple;
 
+template <size_t _Index, class... _Types>
+_NODISCARD constexpr decltype(auto) _Tuple_get(tuple<_Types...>&& _Tuple) noexcept;
+
 template <class _Ty1, class _Ty2>
 struct pair { // store a pair of values
     using first_type  = _Ty1;
@@ -263,7 +266,8 @@ struct pair { // store a pair of values
 #endif // ^^^ !_HAS_CONDITIONAL_EXPLICIT ^^^
 
     template <class _Tuple1, class _Tuple2, size_t... _Indexes1, size_t... _Indexes2>
-    constexpr pair(_Tuple1& _Val1, _Tuple2& _Val2, index_sequence<_Indexes1...>, index_sequence<_Indexes2...>);
+    constexpr pair(_Tuple1& _Val1, _Tuple2& _Val2, index_sequence<_Indexes1...>, index_sequence<_Indexes2...>)
+        : first(_Tuple_get<_Indexes1>(_STD move(_Val1))...), second(_Tuple_get<_Indexes2>(_STD move(_Val2))...) {}
 
     template <class... _Types1, class... _Types2>
     _CONSTEXPR20 pair(piecewise_construct_t, tuple<_Types1...> _Val1, tuple<_Types2...> _Val2)
@@ -590,16 +594,6 @@ _NODISCARD constexpr const _Ty2&& get(
     const pair<_Ty1, _Ty2>&& _Pr) noexcept { // get const rvalue reference to element _Ty2 in pair _Pr
     return _STD get<1>(_STD move(_Pr));
 }
-
-// TEMPLATE CONSTRUCTOR pair::pair(tuple, tuple, sequence, sequence)
-template <size_t _Index, class... _Types>
-_NODISCARD constexpr tuple_element_t<_Index, tuple<_Types...>>&& _Tuple_get(tuple<_Types...>&& _Tuple) noexcept;
-
-template <class _Ty1, class _Ty2>
-template <class _Tuple1, class _Tuple2, size_t... _Indexes1, size_t... _Indexes2>
-constexpr pair<_Ty1, _Ty2>::pair(
-    _Tuple1& _Val1, _Tuple2& _Val2, index_sequence<_Indexes1...>, index_sequence<_Indexes2...>)
-    : first(_Tuple_get<_Indexes1>(_STD move(_Val1))...), second(_Tuple_get<_Indexes2>(_STD move(_Val2))...) {}
 
 // FUNCTION TEMPLATE exchange
 template <class _Ty, class _Other = _Ty>

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -124,7 +124,7 @@ template <class...>
 class tuple;
 
 template <size_t _Index, class... _Types>
-_NODISCARD constexpr decltype(auto) _Tuple_get(tuple<_Types...>&& _Tuple) noexcept;
+_NODISCARD constexpr auto&& _Tuple_get(tuple<_Types...>&& _Tuple) noexcept;
 
 template <class _Ty1, class _Ty2>
 struct pair { // store a pair of values

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -266,7 +266,8 @@ struct pair { // store a pair of values
     constexpr pair(_Tuple1& _Val1, _Tuple2& _Val2, index_sequence<_Indexes1...>, index_sequence<_Indexes2...>);
 
     template <class... _Types1, class... _Types2>
-    _CONSTEXPR20 pair(piecewise_construct_t, tuple<_Types1...> _Val1, tuple<_Types2...> _Val2);
+    _CONSTEXPR20 pair(piecewise_construct_t, tuple<_Types1...> _Val1, tuple<_Types2...> _Val2)
+        : pair(_Val1, _Val2, index_sequence_for<_Types1...>{}, index_sequence_for<_Types2...>{}) {}
 
     pair& operator=(const volatile pair&) = delete;
 
@@ -497,6 +498,73 @@ template <size_t _Index, class _This, class... _Rest>
 struct _MSVC_KNOWN_SEMANTICS tuple_element<_Index, tuple<_This, _Rest...>>
     : tuple_element<_Index - 1, tuple<_Rest...>> {}; // recursive tuple_element definition
 
+// FUNCTION TEMPLATE get (by index)
+template <size_t _Index, class... _Types>
+_NODISCARD constexpr tuple_element_t<_Index, tuple<_Types...>>& get(tuple<_Types...>& _Tuple) noexcept {
+    using _Ttype = typename tuple_element<_Index, tuple<_Types...>>::_Ttype;
+    return static_cast<_Ttype&>(_Tuple)._Myfirst._Val;
+}
+
+template <size_t _Index, class... _Types>
+_NODISCARD constexpr const tuple_element_t<_Index, tuple<_Types...>>& get(const tuple<_Types...>& _Tuple) noexcept {
+    using _Ttype = typename tuple_element<_Index, tuple<_Types...>>::_Ttype;
+    return static_cast<const _Ttype&>(_Tuple)._Myfirst._Val;
+}
+
+template <size_t _Index, class... _Types>
+_NODISCARD constexpr tuple_element_t<_Index, tuple<_Types...>>&& get(tuple<_Types...>&& _Tuple) noexcept {
+    using _Ty    = tuple_element_t<_Index, tuple<_Types...>>;
+    using _Ttype = typename tuple_element<_Index, tuple<_Types...>>::_Ttype;
+    return static_cast<_Ty&&>(static_cast<_Ttype&>(_Tuple)._Myfirst._Val);
+}
+
+template <size_t _Index, class... _Types>
+_NODISCARD constexpr const tuple_element_t<_Index, tuple<_Types...>>&& get(const tuple<_Types...>&& _Tuple) noexcept {
+    using _Ty    = tuple_element_t<_Index, tuple<_Types...>>;
+    using _Ttype = typename tuple_element<_Index, tuple<_Types...>>::_Ttype;
+    return static_cast<const _Ty&&>(static_cast<const _Ttype&>(_Tuple)._Myfirst._Val);
+}
+
+// CLASS _Tuple_element (find element by type)
+template <class _Ty, class _Tuple>
+struct _Tuple_element {}; // backstop _Tuple_element definition
+
+template <class _This, class... _Rest>
+struct _Tuple_element<_This, tuple<_This, _Rest...>> { // select first element
+    static_assert(!_Is_any_of_v<_This, _Rest...>, "duplicate type T in get<T>(tuple)");
+    using _Ttype = tuple<_This, _Rest...>;
+};
+
+template <class _Ty, class _This, class... _Rest>
+struct _Tuple_element<_Ty, tuple<_This, _Rest...>> { // recursive _Tuple_element definition
+    using _Ttype = typename _Tuple_element<_Ty, tuple<_Rest...>>::_Ttype;
+};
+
+// FUNCTION TEMPLATE get (by type)
+template <class _Ty, class... _Types>
+_NODISCARD constexpr _Ty& get(tuple<_Types...>& _Tuple) noexcept {
+    using _Ttype = typename _Tuple_element<_Ty, tuple<_Types...>>::_Ttype;
+    return static_cast<_Ttype&>(_Tuple)._Myfirst._Val;
+}
+
+template <class _Ty, class... _Types>
+_NODISCARD constexpr const _Ty& get(const tuple<_Types...>& _Tuple) noexcept {
+    using _Ttype = typename _Tuple_element<_Ty, tuple<_Types...>>::_Ttype;
+    return static_cast<const _Ttype&>(_Tuple)._Myfirst._Val;
+}
+
+template <class _Ty, class... _Types>
+_NODISCARD constexpr _Ty&& get(tuple<_Types...>&& _Tuple) noexcept {
+    using _Ttype = typename _Tuple_element<_Ty, tuple<_Types...>>::_Ttype;
+    return static_cast<_Ty&&>(static_cast<_Ttype&>(_Tuple)._Myfirst._Val);
+}
+
+template <class _Ty, class... _Types>
+_NODISCARD constexpr const _Ty&& get(const tuple<_Types...>&& _Tuple) noexcept {
+    using _Ttype = typename _Tuple_element<_Ty, tuple<_Types...>>::_Ttype;
+    return static_cast<const _Ty&&>(static_cast<const _Ttype&>(_Tuple)._Myfirst._Val);
+}
+
 // TUPLE INTERFACE TO pair
 template <class _Ty1, class _Ty2>
 struct tuple_size<pair<_Ty1, _Ty2>> : integral_constant<size_t, 2> {}; // size of pair
@@ -589,6 +657,13 @@ _NODISCARD constexpr const _Ty2&& get(
     const pair<_Ty1, _Ty2>&& _Pr) noexcept { // get const rvalue reference to element _Ty2 in pair _Pr
     return _STD get<1>(_STD move(_Pr));
 }
+
+// TEMPLATE CONSTRUCTOR pair::pair(tuple, tuple, sequence, sequence)
+template <class _Ty1, class _Ty2>
+template <class _Tuple1, class _Tuple2, size_t... _Indexes1, size_t... _Indexes2>
+constexpr pair<_Ty1, _Ty2>::pair(
+    _Tuple1& _Val1, _Tuple2& _Val2, index_sequence<_Indexes1...>, index_sequence<_Indexes2...>)
+    : first(_STD get<_Indexes1>(_STD move(_Val1))...), second(_STD get<_Indexes2>(_STD move(_Val2))...) {}
 
 // FUNCTION TEMPLATE exchange
 template <class _Ty, class _Other = _Ty>

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -124,7 +124,7 @@ template <class...>
 class tuple;
 
 template <size_t _Index, class... _Types>
-_NODISCARD constexpr auto&& _Tuple_get(tuple<_Types...>&& _Tuple) noexcept;
+_NODISCARD constexpr decltype(auto) _Tuple_get(tuple<_Types...>&& _Tuple) noexcept;
 
 template <class _Ty1, class _Ty2>
 struct pair { // store a pair of values

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -1184,12 +1184,8 @@
 #define __cpp_lib_constexpr_tuple       201811L
 #define __cpp_lib_constexpr_utility     201811L
 
-#ifdef __cpp_impl_coroutine // TRANSITION, Clang and EDG coroutine support
-#if __cpp_impl_coroutine >= 201902L
+#ifdef __cpp_impl_coroutine // TRANSITION, Clang coroutine support
 #define __cpp_lib_coroutine 201902L
-#else // ^^^ __cpp_impl_coroutine >= 201902L ^^^ / vvv __cpp_impl_coroutine < 201902L vvv
-#define __cpp_lib_coroutine 197000L // TRANSITION, VS 2019 16.8 Preview 4
-#endif // ^^^ __cpp_impl_coroutine < 201902L ^^^
 #endif // __cpp_impl_coroutine
 
 #define __cpp_lib_destroying_delete            201806L

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -501,7 +501,7 @@ std/utilities/memory/allocator.traits/allocator.traits.members/destroy.pass.cpp 
 std/utilities/memory/allocator.traits/allocator.traits.members/max_size.pass.cpp FAIL
 std/utilities/memory/allocator.traits/allocator.traits.members/select_on_container_copy_construction.pass.cpp FAIL
 std/utilities/memory/default.allocator/allocator.globals/eq.pass.cpp FAIL
-std/utilities/memory/default.allocator/allocator.members/allocate.pass.cpp FAIL
+std/utilities/memory/default.allocator/allocator.members/allocate.pass.cpp:1 FAIL
 std/utilities/memory/specialized.algorithms/specialized.construct/construct_at.pass.cpp FAIL
 std/utilities/memory/specialized.algorithms/specialized.destroy/destroy.pass.cpp FAIL
 std/utilities/memory/specialized.algorithms/specialized.destroy/destroy_at.pass.cpp FAIL

--- a/tests/std/tests/P0433R2_deduction_guides/test.cpp
+++ b/tests/std/tests/P0433R2_deduction_guides/test.cpp
@@ -91,14 +91,12 @@ long add(short x, int y) {
     return x + y;
 }
 
-struct UniqueTagCanDeduceFrom {}; // TRANSITION, VSO-587956
-
 template <typename Void, template <typename...> class ClassTemplate, typename... CtorArgs>
 struct CanDeduceFromHelper : false_type {};
 
 template <template <typename...> class ClassTemplate, typename... CtorArgs>
-struct CanDeduceFromHelper<void_t<UniqueTagCanDeduceFrom, decltype(ClassTemplate(declval<CtorArgs>()...))>,
-    ClassTemplate, CtorArgs...> : true_type {};
+struct CanDeduceFromHelper<void_t<decltype(ClassTemplate(declval<CtorArgs>()...))>, ClassTemplate, CtorArgs...>
+    : true_type {};
 
 template <template <typename...> class ClassTemplate, typename... CtorArgs>
 constexpr bool CanDeduceFrom = CanDeduceFromHelper<void, ClassTemplate, CtorArgs...>::value;

--- a/tests/std/tests/P0896R4_ranges_range_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_range_machinery/test.cpp
@@ -1498,8 +1498,8 @@ namespace borrowed_range_testing {
     STATIC_ASSERT(test_borrowed_range<std::span<int>, std::span<int>::iterator>());
     STATIC_ASSERT(test_borrowed_range<std::span<int, 42>, std::span<int, 42>::iterator>());
     STATIC_ASSERT(test_borrowed_range<ranges::subrange<int*, int*>, int*>());
-#if 0 // TRANSITION, future
     STATIC_ASSERT(test_borrowed_range<ranges::ref_view<int[42]>, int*>());
+#if 0 // TRANSITION, future
     STATIC_ASSERT(test_borrowed_range<ranges::iota_view<int, int>, ...>());
 #endif // TRANSITION, future
 

--- a/tests/std/tests/P0896R4_views_common/test.cpp
+++ b/tests/std/tests/P0896R4_views_common/test.cpp
@@ -357,9 +357,6 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
         }
 
         // Validate common_view::base() && (NB: do this last since it leaves r moved-from)
-#if !defined(__clang__) && !defined(__EDG__) // TRANSITION, DevCom-1159442
-        (void) 42;
-#endif // TRANSITION, DevCom-1159442
         same_as<V> auto b2 = move(r).base();
         static_assert(noexcept(move(r).base()) == is_nothrow_move_constructible_v<V>);
         if (!is_empty) {

--- a/tests/std/tests/P0896R4_views_drop_while/test.cpp
+++ b/tests/std/tests/P0896R4_views_drop_while/test.cpp
@@ -152,9 +152,6 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
     }
 
     // Validate deduction guide
-#if !defined(__clang__) && !defined(__EDG__) // TRANSITION, DevCom-1159442
-    (void) 42;
-#endif // TRANSITION, DevCom-1159442
     same_as<R> auto r = drop_while_view{forward<Rng>(rng), is_less_than<3>};
     assert(ranges::equal(r, expected));
     if constexpr (forward_range<V>) {

--- a/tests/std/tests/P0896R4_views_filter/test.cpp
+++ b/tests/std/tests/P0896R4_views_filter/test.cpp
@@ -149,9 +149,6 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
     }
 
     // Validate deduction guide
-#if !defined(__clang__) && !defined(__EDG__) // TRANSITION, DevCom-1159442
-    (void) 42;
-#endif // TRANSITION, DevCom-1159442
     same_as<F> auto r = filter_view{forward<Rng>(rng), is_even};
     assert(ranges::equal(r, expected));
     if constexpr (forward_range<V>) {
@@ -263,9 +260,6 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
     }
 
     // Validate filter_view::base() && (NB: do this last since it leaves r moved-from)
-#if !defined(__clang__) && !defined(__EDG__) // TRANSITION, DevCom-1159442
-    (void) 42;
-#endif // TRANSITION, DevCom-1159442
     if (forward_range<V>) { // intentionally not if constexpr
         same_as<V> auto b2 = move(r).base();
         STATIC_ASSERT(noexcept(move(r).base()) == is_nothrow_move_constructible_v<V>);

--- a/tests/std/tests/P0896R4_views_reverse/test.cpp
+++ b/tests/std/tests/P0896R4_views_reverse/test.cpp
@@ -160,9 +160,6 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
     }
 
     // Validate deduction guide
-#if !defined(__clang__) && !defined(__EDG__) // TRANSITION, DevCom-1159442
-    (void) 42;
-#endif // TRANSITION, DevCom-1159442
     same_as<R> auto r = reverse_view{forward<Rng>(rng)};
     assert(ranges::equal(r, expected));
 
@@ -294,9 +291,6 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
     }
 
     // Validate reverse_view::base() && (NB: do this last since it leaves r moved-from)
-#if !defined(__clang__) && !defined(__EDG__) // TRANSITION, DevCom-1159442
-    (void) 42;
-#endif // TRANSITION, DevCom-1159442
     same_as<V> auto b2 = move(r).base();
     static_assert(noexcept(move(r).base()) == is_nothrow_move_constructible_v<V>);
     if (!is_empty) {

--- a/tests/std/tests/P0896R4_views_take_while/test.cpp
+++ b/tests/std/tests/P0896R4_views_take_while/test.cpp
@@ -154,9 +154,6 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
     }
 
     // Validate deduction guide
-#if !defined(__clang__) && !defined(__EDG__) // TRANSITION, DevCom-1159442
-    (void) 42;
-#endif // TRANSITION, DevCom-1159442
     same_as<R> auto r = take_while_view{forward<Rng>(rng), is_less_than<3>};
     assert(ranges::equal(r, expected));
 

--- a/tests/std/tests/P0896R4_views_transform/test.cpp
+++ b/tests/std/tests/P0896R4_views_transform/test.cpp
@@ -311,9 +311,6 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
     }
 
     // Validate transform_view::base() && (NB: do this last since it leaves r moved-from)
-#if !defined(__clang__) && !defined(__EDG__) // TRANSITION, DevCom-1159442
-    (void) 42;
-#endif // TRANSITION, DevCom-1159442
     if (forward_range<V>) { // intentionally not if constexpr
         same_as<V> auto b2 = move(r).base();
         STATIC_ASSERT(noexcept(move(r).base()) == is_nothrow_move_constructible_v<V>);

--- a/tests/std/tests/P1502R1_standard_library_header_units/test.cpp
+++ b/tests/std/tests/P1502R1_standard_library_header_units/test.cpp
@@ -186,18 +186,14 @@ int main() {
 
     {
         puts("Testing <chrono>.");
-#ifdef MSVC_INTERNAL_TESTING // TRANSITION, DevCom-1159995 (UDLs)
         constexpr chrono::seconds dur = 3min;
-#else // ^^^ no workaround / workaround vvv
-        constexpr chrono::seconds dur = chrono::minutes{3};
-#endif // ^^^ workaround ^^^
         assert(dur.count() == 180);
         static_assert(dur.count() == 180);
     }
 
     {
         puts("Testing <codecvt>.");
-#ifdef MSVC_INTERNAL_TESTING // TRANSITION, DevCom-1161187 (access control), VSO-1236034 (error LNK2005: _Yarn)
+#ifdef MSVC_INTERNAL_TESTING // TRANSITION, VSO-1236034 (error LNK2005: _Yarn)
         const string utf8_koshka_cat{"\xD0\xBA\xD0\xBE\xD1\x88\xD0\xBA\xD0\xB0_\xF0\x9F\x90\x88"};
         const wstring utf16_koshka_cat{L"\x043A\x043E\x0448\x043A\x0430_\xD83D\xDC08"};
         wstring_convert<codecvt_utf8_utf16<wchar_t>> conv;
@@ -275,10 +271,8 @@ int main() {
 
     {
         puts("Testing <deque>.");
-#ifdef MSVC_INTERNAL_TESTING // TRANSITION, DevCom-1160260 (partial specialization)
         const deque<int> d{10, 20, 30, 40, 50};
         assert(d[2] == 30);
-#endif // ^^^ no workaround ^^^
     }
 
     {
@@ -313,10 +307,8 @@ int main() {
 
     {
         puts("Testing <forward_list>.");
-#ifdef MSVC_INTERNAL_TESTING // TRANSITION, DevCom-1160260 (partial specialization)
         const forward_list<int> fl{10, 20, 30, 40, 50};
         assert(*next(fl.begin(), 2) == 30);
-#endif // ^^^ no workaround ^^^
     }
 
     {
@@ -436,10 +428,8 @@ int main() {
 
     {
         puts("Testing <list>.");
-#ifdef MSVC_INTERNAL_TESTING // TRANSITION, DevCom-1160260 (partial specialization)
         const list<int> l{10, 20, 30, 40, 50};
         assert(*next(l.begin(), 2) == 30);
-#endif // ^^^ no workaround ^^^
     }
 
     {
@@ -453,10 +443,8 @@ int main() {
 
     {
         puts("Testing <map>.");
-#ifdef MSVC_INTERNAL_TESTING // TRANSITION, DevCom-1160260 (partial specialization)
         map<int, int> m{{10, 11}, {20, 22}, {30, 33}, {40, 44}, {50, 55}};
         assert(m[30] == 33);
-#endif // ^^^ no workaround ^^^
     }
 
     {
@@ -558,7 +546,6 @@ int main() {
 
     {
         puts("Testing <queue>.");
-#ifdef MSVC_INTERNAL_TESTING // TRANSITION, DevCom-1160260 (partial specialization)
         queue<int> q;
         q.push(10);
         q.push(20);
@@ -587,7 +574,6 @@ int main() {
         assert(pq.top() == 10);
         pq.pop();
         assert(pq.empty());
-#endif // ^^^ no workaround ^^^
     }
 
     {
@@ -608,8 +594,8 @@ int main() {
         assert(ranges::distance(views::filter(arr, [](int x) { return x == 0; })) == 4);
         static_assert(ranges::distance(views::filter(arr, [](int x) { return x != 0; })) == 5);
 #elif defined(MSVC_INTERNAL_TESTING) // TRANSITION, VSO-1237145 (trailing requires clause)
-        auto is_zero                  = [](int x) { return x == 0; };
-        using FV1                     = ranges::filter_view<ranges::ref_view<decltype(arr)>, decltype(is_zero)>;
+        auto is_zero = [](int x) { return x == 0; };
+        using FV1    = ranges::filter_view<ranges::ref_view<decltype(arr)>, decltype(is_zero)>;
         assert(ranges::distance(FV1{arr, is_zero}) == 4);
         constexpr auto not_zero = [](int x) { return x != 0; };
         using FV2 = ranges::filter_view<ranges::ref_view<decltype(arr)>, remove_const_t<decltype(not_zero)>>;
@@ -640,14 +626,12 @@ int main() {
 
     {
         puts("Testing <scoped_allocator>.");
-#ifdef MSVC_INTERNAL_TESTING // TRANSITION, DevCom-1162644 (deprecated warning)
         vector<int, scoped_allocator_adaptor<allocator<int>>> v;
         v.push_back(11);
         v.push_back(22);
         v.push_back(33);
         constexpr int expected[]{11, 22, 33};
         assert(equal(v.begin(), v.end(), begin(expected), end(expected)));
-#endif // ^^^ no workaround ^^^
     }
 
     {
@@ -678,14 +662,12 @@ int main() {
 
     {
         puts("Testing <set>.");
-#ifdef MSVC_INTERNAL_TESTING // TRANSITION, DevCom-1160260 (partial specialization)
         const set<int> s{10, 20, 30, 40, 50};
         assert(*next(s.begin(), 2) == 30);
 
         const multiset<int> ms{10, 20, 20, 30, 30, 30, 40, 40, 40, 40};
         const auto p = ms.equal_range(30);
         assert(distance(p.first, p.second) == 3);
-#endif // ^^^ no workaround ^^^
     }
 
     {
@@ -748,7 +730,6 @@ int main() {
 
     {
         puts("Testing <stack>.");
-#ifdef MSVC_INTERNAL_TESTING // TRANSITION, DevCom-1160260 (partial specialization)
         stack<int> s;
         s.push(10);
         s.push(20);
@@ -761,7 +742,6 @@ int main() {
         assert(s.top() == 10);
         s.pop();
         assert(s.empty());
-#endif // ^^^ no workaround ^^^
     }
 
     {
@@ -802,11 +782,7 @@ int main() {
                 }
                 l.count_down(); // tell main() that we're done
                 while (!token.stop_requested()) {
-#ifdef MSVC_INTERNAL_TESTING // TRANSITION, DevCom-1159995 (UDLs)
                     this_thread::sleep_for(10ms); // not a timing assumption; avoids spinning furiously
-#else // ^^^ no workaround / workaround vvv
-                    this_thread::sleep_for(chrono::milliseconds{10}); // not a timing assumption
-#endif // ^^^ workaround ^^^
                 }
                 vec.push_back(-1000); // indicate that token.stop_requested() returned true
             }};
@@ -818,14 +794,7 @@ int main() {
             1079, 3238, 1619, 4858, 2429, 7288, 3644, 1822, 911, 2734, 1367, 4102, 2051, 6154, 3077, 9232, 4616, 2308,
             1154, 577, 1732, 866, 433, 1300, 650, 325, 976, 488, 244, 122, 61, 184, 92, 46, 23, 70, 35, 106, 53, 160,
             80, 40, 20, 10, 5, 16, 8, 4, 2, 1, -1000};
-#ifdef MSVC_INTERNAL_TESTING // TRANSITION, DevCom-1160260 (partial specialization)
         assert(equal(vec.begin(), vec.end(), begin(expected), end(expected)));
-#else // ^^^ no workaround / workaround vvv
-        assert(vec.size() == size(expected));
-        for (size_t i = 0; i < vec.size(); ++i) {
-            assert(vec[i] == expected[i]);
-        }
-#endif // ^^^ workaround ^^^
     }
 
     {
@@ -936,22 +905,18 @@ int main() {
 
     {
         puts("Testing <unordered_map>.");
-#ifdef MSVC_INTERNAL_TESTING // TRANSITION, DevCom-1160260 (partial specialization)
         unordered_map<int, int> um{{1, 1}, {2, 4}, {3, 9}, {4, 16}, {5, 25}};
         for (const auto& p : um) {
             assert(p.first * p.first == p.second);
         }
-#endif // ^^^ no workaround ^^^
     }
 
     {
         puts("Testing <unordered_set>.");
-#ifdef MSVC_INTERNAL_TESTING // TRANSITION, DevCom-1160260 (partial specialization)
         unordered_set<int> us{10, 20, 30, 40, 50};
         for (const auto& elem : us) {
             assert(elem % 10 == 0);
         }
-#endif // ^^^ no workaround ^^^
     }
 
     {

--- a/tests/std/tests/P1502R1_standard_library_header_units/test.cpp
+++ b/tests/std/tests/P1502R1_standard_library_header_units/test.cpp
@@ -972,10 +972,8 @@ int main() {
         const vector<int> v{10, 20, 30, 40, 50};
         assert(v[2] == 30);
 
-#ifdef MSVC_INTERNAL_TESTING // TRANSITION, should work with VS 2019 16.9 Preview 1
         const vector<bool> vb{true, true, false, true};
         assert(vb[0] && vb[1] && !vb[2] && vb[3]);
-#endif // ^^^ no workaround ^^^
     }
 
     {

--- a/tests/std/tests/P1502R1_standard_library_header_units/test.cpp
+++ b/tests/std/tests/P1502R1_standard_library_header_units/test.cpp
@@ -453,7 +453,7 @@ int main() {
 
     {
         puts("Testing <map>.");
-#if 0 // TRANSITION, DevCom-1160260 (partial specialization), VSO-1236041 (error LNK2019 pair piecewise_construct_t)
+#ifdef MSVC_INTERNAL_TESTING // TRANSITION, DevCom-1160260 (partial specialization)
         map<int, int> m{{10, 11}, {20, 22}, {30, 33}, {40, 44}, {50, 55}};
         assert(m[30] == 33);
 #endif // ^^^ no workaround ^^^

--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
@@ -509,18 +509,13 @@ STATIC_ASSERT(__cpp_lib_constexpr_utility == 201811L);
 #endif
 #endif
 
-#if _HAS_CXX20 && defined(__cpp_impl_coroutine) // TRANSITION, Clang and EDG coroutine support
-#if __cpp_impl_coroutine >= 201902L
-#define ExpectedCppLibCoroutine 201902L
-#else
-#define ExpectedCppLibCoroutine 197000L // TRANSITION, VS 2019 16.8 Preview 4
-#endif
+#if _HAS_CXX20 && defined(__cpp_impl_coroutine) // TRANSITION, Clang coroutine support
 #ifndef __cpp_lib_coroutine
 #error __cpp_lib_coroutine is not defined
-#elif __cpp_lib_coroutine != ExpectedCppLibCoroutine
-#error __cpp_lib_coroutine is not ExpectedCppLibCoroutine
+#elif __cpp_lib_coroutine != 201902L
+#error __cpp_lib_coroutine is not 201902L
 #else
-STATIC_ASSERT(__cpp_lib_coroutine == ExpectedCppLibCoroutine);
+STATIC_ASSERT(__cpp_lib_coroutine == 201902L);
 #endif
 #else
 #ifdef __cpp_lib_coroutine


### PR DESCRIPTION
This updates the toolset to VS 2019 16.9 Preview 1 and removes a bunch of compiler bug workarounds.

* `.github/ISSUE_TEMPLATE/cxx23-feature.md`
  + Transform the issue template for C++20 features to C++23. This adds a note that we aren't ready to begin work on C++23.
* `CMakeLists.txt`
  + VS 2019 16.9 Preview 1 ships CMake 3.18; make that our minimum required version.
* `README.md`
  + Mention the new VS and CMake versions.
* `azure-devops/create-vmss.ps1`
  + Increase `$TotalProgress` and add an initial step to `Set-AzContext -SubscriptionName CPP_STL_GitHub`. (For unknown reasons, I now have access to a bunch of subscriptions, and `Connect-AzAccount` selects the first one, which isn't `CPP_STL_GitHub`. This `Set-AzContext` step allows the following steps to work, and should have no harmful effects if a maintainer has access to only `CPP_STL_GitHub`.)
  + When the script is done, don't print `AdminUser` and `$AdminPW`. We don't need these credentials.
* `azure-devops/provision-image.ps1`
  + Install the Spectre-mitigated libraries and the Windows Driver Kit, for later PRs addressing GH-1289.
* `azure-pipelines.yml`
  + Use the new Virtual Machine Scale Set pool.
* `stl/inc/filesystem`
  + Remove the workaround for the internal compiler bug VSO-571749.
* `stl/inc/memory_resource`
  + Remove the workaround for the compiler bug DevCom-1159869 that affected Standard Library Header Units.
* `stl/inc/tuple`
* `stl/inc/utility`
  + Work around the internal compiler bug VSO-1236041 affecting `pair`'s piecewise constructor with Standard Library Header Units, by defining that constructor in `<utility>` instead of `<tuple>`. To do so, we need to define an internal `_Tuple_get` helper for modifiable rvalues only. This mitigates the throughput impact for `<utility>`, and should avoid disrupting conformance tests that are overly sensitive to the order of `get` declarations. As a bonus, we can now define `pair`'s constructors entirely within the class definition.
* `stl/inc/yvals_core.h`
  + MSVC and EDG now define `__cpp_impl_coroutine` to its C++20 value, so we don't need the `197000L` workaround. (We still need `#ifdef __cpp_impl_coroutine` for Clang.)
* `tests/libcxx/expected_results.txt`
  + The MSVC configuration of `allocator.members/allocate.pass.cpp` now passes, so mark it as `FAIL` for Clang only. (No change to `skipped_tests.txt`.)
* `tests/std/tests/P0433R2_deduction_guides/test.cpp`
  + Remove the workaround for the internal compiler bug VSO-587956.
* `tests/std/tests/P0896R4_ranges_range_machinery/test.cpp`
  + Unrelated to the toolset update, I noticed that GH-1132 implemented `ref_view` so we can `test_borrowed_range` here.
* `tests/std/tests/P0896R4_views_common/test.cpp`
* `tests/std/tests/P0896R4_views_drop_while/test.cpp`
* `tests/std/tests/P0896R4_views_filter/test.cpp`
* `tests/std/tests/P0896R4_views_reverse/test.cpp`
* `tests/std/tests/P0896R4_views_take_while/test.cpp`
* `tests/std/tests/P0896R4_views_transform/test.cpp`
  + Remove the (hilariously bizarre :zany_face:) workaround for the compiler bug DevCom-1159442.
* `tests/std/tests/P1502R1_standard_library_header_units/test.cpp`
  + Remove many compiler bug workarounds.
* `tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp`
  + Remove the `__cpp_impl_coroutine` `197000L` workaround; see `yvals_core.h` above.

---

Note: The `_MSC_VER` check is **not** changing, as its value will remain `1928` for 16.9 (due to running out of one's digits). The difference is detectable through `_MSC_FULL_VER`, but this check doesn't need to be strict - it merely diagnoses egregious compiler version mismatch.
https://github.com/microsoft/STL/blob/9959929c77b18e25b6dfbc8886e311b913321925/stl/inc/yvals_core.h#L515-L516
