### PR TITLE
LWG-3036 polymorphic_allocator::destroy is extraneous

### DIFF
--- a/stl/inc/xpolymorphic_allocator.h
+++ b/stl/inc/xpolymorphic_allocator.h
@@ -136,7 +136,6 @@ void _Uses_allocator_construct(
 
 #if _HAS_CXX17
 namespace pmr {
-
     // CLASS memory_resource
     class __declspec(novtable) memory_resource {
     public:
@@ -274,6 +273,11 @@ namespace pmr {
             _Uses_allocator_construct(_Ptr, _Al, *this, _STD forward<_Types>(_Args)...);
         }
 
+        template <class _Uty>
+        _CXX20_DEPRECATE_POLYMORPHIC_ALLOCATOR_DESTROY void destroy(_Uty* const _Ptr) noexcept /* strengthened */ {
+            _Destroy_in_place(*_Ptr);
+        }
+
         _NODISCARD polymorphic_allocator select_on_container_copy_construction() const noexcept /* strengthened */ {
             // don't propagate on copy
             return {};
@@ -302,6 +306,12 @@ namespace pmr {
     }
 
 } // namespace pmr
+
+template <class _Ty, class _Ptr>
+struct _Has_no_alloc_destroy<pmr::polymorphic_allocator<_Ty>, _Ptr, void> : true_type {
+    // polymorphic_allocator technically _does_ have a destroy member, but it's equivalent to the
+    // default implementation in allocator_traits so we can optimize it away.
+};
 
 #endif // _HAS_CXX17
 

--- a/stl/inc/xpolymorphic_allocator.h
+++ b/stl/inc/xpolymorphic_allocator.h
@@ -274,7 +274,7 @@ namespace pmr {
         }
 
         template <class _Uty>
-        _CXX20_DEPRECATE_POLYMORPHIC_ALLOCATOR_DESTROY void destroy(_Uty* const _Ptr) noexcept /* strengthened */ {
+        _CXX17_DEPRECATE_POLYMORPHIC_ALLOCATOR_DESTROY void destroy(_Uty* const _Ptr) noexcept /* strengthened */ {
             _Destroy_in_place(*_Ptr);
         }
 

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -1007,7 +1007,19 @@
 #define _CXX20_DEPRECATE_MOVE_ITERATOR_ARROW
 #endif // ^^^ warning disabled ^^^
 
-// next warning number: STL4032
+#if _HAS_CXX20 && !defined(_SILENCE_CXX20_POLYMORPHIC_ALLOCATOR_DESTROY_DEPRECATION_WARNING) \
+    && !defined(_SILENCE_ALL_CXX20_DEPRECATION_WARNINGS)
+#define _CXX20_DEPRECATE_POLYMORPHIC_ALLOCATOR_DESTROY                                              \
+    [[deprecated("warning STL4032: "                                                                \
+                 "std::pmr::polymorphic_allocator::destroy() is deprecated by C++20. "              \
+                 "Prefer std::destroy_at or std::allocator_traits<polymorphic_allocator>::destroy." \
+                 "You can define _SILENCE_CXX20_POLYMORPHIC_ALLOCATOR_DESTROY_DEPRECATION_WARNING " \
+                 "or _SILENCE_ALL_CXX20_DEPRECATION_WARNINGS to acknowledge that you have received this warning.")]]
+#else // ^^^ warning enabled / warning disabled vvv
+#define _CXX20_DEPRECATE_POLYMORPHIC_ALLOCATOR_DESTROY
+#endif // ^^^ warning disabled ^^^
+
+// next warning number: STL4033
 
 // P0619R4 Removing C++17-Deprecated Features
 #ifndef _HAS_FEATURES_REMOVED_IN_CXX20

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -1007,7 +1007,8 @@
 #define _CXX20_DEPRECATE_MOVE_ITERATOR_ARROW
 #endif // ^^^ warning disabled ^^^
 
-#if _HAS_CXX20 && !defined(_SILENCE_CXX20_POLYMORPHIC_ALLOCATOR_DESTROY_DEPRECATION_WARNING) \
+// Yes, this is intentionally _HAS_CXX17: we're retroactively deprecating in C++17 mode as well.
+#if _HAS_CXX17 && !defined(_SILENCE_CXX20_POLYMORPHIC_ALLOCATOR_DESTROY_DEPRECATION_WARNING) \
     && !defined(_SILENCE_ALL_CXX20_DEPRECATION_WARNINGS)
 #define _CXX20_DEPRECATE_POLYMORPHIC_ALLOCATOR_DESTROY                                              \
     [[deprecated("warning STL4032: "                                                                \

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -878,7 +878,7 @@
     [[deprecated("warning STL4021: "                                                                                 \
                  "The std::filesystem::u8path() overloads are deprecated in C++20. "                                 \
                  "The constructors of std::filesystem::path provide equivalent functionality via construction from " \
-                 "u8string, u8string_view, or iterators with value_type char8_t."                                    \
+                 "u8string, u8string_view, or iterators with value_type char8_t. "                                   \
                  "You can define _SILENCE_CXX20_U8PATH_DEPRECATION_WARNING "                                         \
                  "or _SILENCE_ALL_CXX20_DEPRECATION_WARNINGS to acknowledge that you have received this warning.")]]
 #else // ^^^ warning enabled / warning disabled vvv
@@ -1007,17 +1007,16 @@
 #define _CXX20_DEPRECATE_MOVE_ITERATOR_ARROW
 #endif // ^^^ warning disabled ^^^
 
-// Yes, this is intentionally _HAS_CXX17: we're retroactively deprecating in C++17 mode as well.
-#if _HAS_CXX17 && !defined(_SILENCE_CXX20_POLYMORPHIC_ALLOCATOR_DESTROY_DEPRECATION_WARNING) \
-    && !defined(_SILENCE_ALL_CXX20_DEPRECATION_WARNINGS)
-#define _CXX20_DEPRECATE_POLYMORPHIC_ALLOCATOR_DESTROY                                              \
-    [[deprecated("warning STL4032: "                                                                \
-                 "std::pmr::polymorphic_allocator::destroy() is deprecated by C++20. "              \
-                 "Prefer std::destroy_at or std::allocator_traits<polymorphic_allocator>::destroy." \
-                 "You can define _SILENCE_CXX20_POLYMORPHIC_ALLOCATOR_DESTROY_DEPRECATION_WARNING " \
-                 "or _SILENCE_ALL_CXX20_DEPRECATION_WARNINGS to acknowledge that you have received this warning.")]]
+#if _HAS_CXX17 && !defined(_SILENCE_CXX17_POLYMORPHIC_ALLOCATOR_DESTROY_DEPRECATION_WARNING) \
+    && !defined(_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS)
+#define _CXX17_DEPRECATE_POLYMORPHIC_ALLOCATOR_DESTROY                                                   \
+    [[deprecated("warning STL4032: "                                                                     \
+                 "std::pmr::polymorphic_allocator::destroy() is deprecated in C++17 by LWG-3036. "       \
+                 "Prefer std::destroy_at() or std::allocator_traits<polymorphic_allocator>::destroy(). " \
+                 "You can define _SILENCE_CXX17_POLYMORPHIC_ALLOCATOR_DESTROY_DEPRECATION_WARNING "      \
+                 "or _SILENCE_ALL_CXX17_DEPRECATION_WARNINGS to acknowledge that you have received this warning.")]]
 #else // ^^^ warning enabled / warning disabled vvv
-#define _CXX20_DEPRECATE_POLYMORPHIC_ALLOCATOR_DESTROY
+#define _CXX17_DEPRECATE_POLYMORPHIC_ALLOCATOR_DESTROY
 #endif // ^^^ warning disabled ^^^
 
 // next warning number: STL4033

--- a/tests/std/tests/P0220R1_polymorphic_memory_resources/test.cpp
+++ b/tests/std/tests/P0220R1_polymorphic_memory_resources/test.cpp
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#define _SILENCE_CXX20_POLYMORPHIC_ALLOCATOR_DESTROY_DEPRECATION_WARNING
+
 #include <algorithm>
 #include <cmath>
 #include <cstdio>
@@ -942,6 +944,29 @@ namespace {
                 CHECK(a != c);
             }
         } // namespace eq
+
+        namespace destroy {
+            void test() {
+                bool destroyed = false;
+                struct S {
+                    bool& destroy_ref;
+
+                    S(bool& _destroy_ref_) : destroy_ref{_destroy_ref_} {}
+                    ~S() {
+                        destroy_ref = true;
+                    }
+                    S(const S&) = delete;
+                    S& operator=(const S&) = delete;
+                };
+                std::pmr::polymorphic_allocator<S> a{};
+                S* ptr = a.allocate(1);
+                a.construct(ptr, destroyed);
+                CHECK(destroyed == false);
+                a.destroy(ptr);
+                CHECK(destroyed == true);
+                a.deallocate(ptr, 1);
+            }
+        } // namespace destroy
     } // namespace polymorphic_allocator
 
     namespace monotonic {
@@ -1450,6 +1475,7 @@ int main() {
     polymorphic_allocator::mem::select_on_container_copy_construction::test();
     polymorphic_allocator::mem::resource::test();
     polymorphic_allocator::eq::test();
+    polymorphic_allocator::destroy::test();
 
     monotonic::ctor::buffer_upstream::test();
     monotonic::ctor::size_upstream::test();

--- a/tests/std/tests/P0220R1_polymorphic_memory_resources/test.cpp
+++ b/tests/std/tests/P0220R1_polymorphic_memory_resources/test.cpp
@@ -951,7 +951,7 @@ namespace {
                 struct S {
                     bool& destroy_ref;
 
-                    S(bool& _destroy_ref_) : destroy_ref{_destroy_ref_} {}
+                    explicit S(bool& _destroy_ref_) : destroy_ref{_destroy_ref_} {}
                     ~S() {
                         destroy_ref = true;
                     }

--- a/tests/std/tests/P0220R1_polymorphic_memory_resources/test.cpp
+++ b/tests/std/tests/P0220R1_polymorphic_memory_resources/test.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#define _SILENCE_CXX20_POLYMORPHIC_ALLOCATOR_DESTROY_DEPRECATION_WARNING
+#define _SILENCE_CXX17_POLYMORPHIC_ALLOCATOR_DESTROY_DEPRECATION_WARNING
 
 #include <algorithm>
 #include <cmath>


### PR DESCRIPTION
By defining `polymorphic_allocator::destroy` - despite that it's equivalent to the default in `allocator_traits` - as deprecated. Also hack up the internal `_Has_no_alloc_destroy` trait so our optimization that avoids calling `destroy` on trivially destructible types keeps working with `polymorphic_allocator`.

Fixes #1454 and fixes #753.
