### PR TITLE
_NODISCARD for function objects

### DIFF
--- a/stl/inc/compare
+++ b/stl/inc/compare
@@ -333,7 +333,7 @@ struct compare_three_way_result<_Ty1, _Ty2> {
 struct compare_three_way {
     template <class _Ty1, class _Ty2>
         requires three_way_comparable_with<_Ty1, _Ty2> // TRANSITION, GH-489
-    constexpr auto operator()(_Ty1&& _Left, _Ty2&& _Right) const
+    _NODISCARD constexpr auto operator()(_Ty1&& _Left, _Ty2&& _Right) const
         noexcept(noexcept(_STD forward<_Ty1>(_Left) <=> _STD forward<_Ty2>(_Right))) /* strengthened */ {
         return _STD forward<_Ty1>(_Left) <=> _STD forward<_Ty2>(_Right);
     }

--- a/stl/inc/functional
+++ b/stl/inc/functional
@@ -45,7 +45,7 @@ struct divides {
     _CXX17_DEPRECATE_ADAPTOR_TYPEDEFS typedef _Ty _SECOND_ARGUMENT_TYPE_NAME;
     _CXX17_DEPRECATE_ADAPTOR_TYPEDEFS typedef _Ty _RESULT_TYPE_NAME;
 
-    constexpr _Ty operator()(const _Ty& _Left, const _Ty& _Right) const {
+    _NODISCARD constexpr _Ty operator()(const _Ty& _Left, const _Ty& _Right) const {
         return _Left / _Right;
     }
 };
@@ -57,7 +57,7 @@ struct modulus {
     _CXX17_DEPRECATE_ADAPTOR_TYPEDEFS typedef _Ty _SECOND_ARGUMENT_TYPE_NAME;
     _CXX17_DEPRECATE_ADAPTOR_TYPEDEFS typedef _Ty _RESULT_TYPE_NAME;
 
-    constexpr _Ty operator()(const _Ty& _Left, const _Ty& _Right) const {
+    _NODISCARD constexpr _Ty operator()(const _Ty& _Left, const _Ty& _Right) const {
         return _Left % _Right;
     }
 };
@@ -68,7 +68,7 @@ struct negate {
     _CXX17_DEPRECATE_ADAPTOR_TYPEDEFS typedef _Ty _ARGUMENT_TYPE_NAME;
     _CXX17_DEPRECATE_ADAPTOR_TYPEDEFS typedef _Ty _RESULT_TYPE_NAME;
 
-    constexpr _Ty operator()(const _Ty& _Left) const {
+    _NODISCARD constexpr _Ty operator()(const _Ty& _Left) const {
         return -_Left;
     }
 };
@@ -98,7 +98,7 @@ struct logical_and {
     _CXX17_DEPRECATE_ADAPTOR_TYPEDEFS typedef _Ty _SECOND_ARGUMENT_TYPE_NAME;
     _CXX17_DEPRECATE_ADAPTOR_TYPEDEFS typedef bool _RESULT_TYPE_NAME;
 
-    constexpr bool operator()(const _Ty& _Left, const _Ty& _Right) const {
+    _NODISCARD constexpr bool operator()(const _Ty& _Left, const _Ty& _Right) const {
         return _Left && _Right;
     }
 };
@@ -110,7 +110,7 @@ struct logical_or {
     _CXX17_DEPRECATE_ADAPTOR_TYPEDEFS typedef _Ty _SECOND_ARGUMENT_TYPE_NAME;
     _CXX17_DEPRECATE_ADAPTOR_TYPEDEFS typedef bool _RESULT_TYPE_NAME;
 
-    constexpr bool operator()(const _Ty& _Left, const _Ty& _Right) const {
+    _NODISCARD constexpr bool operator()(const _Ty& _Left, const _Ty& _Right) const {
         return _Left || _Right;
     }
 };
@@ -121,7 +121,7 @@ struct logical_not {
     _CXX17_DEPRECATE_ADAPTOR_TYPEDEFS typedef _Ty _ARGUMENT_TYPE_NAME;
     _CXX17_DEPRECATE_ADAPTOR_TYPEDEFS typedef bool _RESULT_TYPE_NAME;
 
-    constexpr bool operator()(const _Ty& _Left) const {
+    _NODISCARD constexpr bool operator()(const _Ty& _Left) const {
         return !_Left;
     }
 };
@@ -133,7 +133,7 @@ struct bit_and {
     _CXX17_DEPRECATE_ADAPTOR_TYPEDEFS typedef _Ty _SECOND_ARGUMENT_TYPE_NAME;
     _CXX17_DEPRECATE_ADAPTOR_TYPEDEFS typedef _Ty _RESULT_TYPE_NAME;
 
-    constexpr _Ty operator()(const _Ty& _Left, const _Ty& _Right) const {
+    _NODISCARD constexpr _Ty operator()(const _Ty& _Left, const _Ty& _Right) const {
         return _Left & _Right;
     }
 };
@@ -145,7 +145,7 @@ struct bit_or {
     _CXX17_DEPRECATE_ADAPTOR_TYPEDEFS typedef _Ty _SECOND_ARGUMENT_TYPE_NAME;
     _CXX17_DEPRECATE_ADAPTOR_TYPEDEFS typedef _Ty _RESULT_TYPE_NAME;
 
-    constexpr _Ty operator()(const _Ty& _Left, const _Ty& _Right) const {
+    _NODISCARD constexpr _Ty operator()(const _Ty& _Left, const _Ty& _Right) const {
         return _Left | _Right;
     }
 };
@@ -157,7 +157,7 @@ struct bit_xor {
     _CXX17_DEPRECATE_ADAPTOR_TYPEDEFS typedef _Ty _SECOND_ARGUMENT_TYPE_NAME;
     _CXX17_DEPRECATE_ADAPTOR_TYPEDEFS typedef _Ty _RESULT_TYPE_NAME;
 
-    constexpr _Ty operator()(const _Ty& _Left, const _Ty& _Right) const {
+    _NODISCARD constexpr _Ty operator()(const _Ty& _Left, const _Ty& _Right) const {
         return _Left ^ _Right;
     }
 };
@@ -168,7 +168,7 @@ struct bit_not {
     _CXX17_DEPRECATE_ADAPTOR_TYPEDEFS typedef _Ty _ARGUMENT_TYPE_NAME;
     _CXX17_DEPRECATE_ADAPTOR_TYPEDEFS typedef _Ty _RESULT_TYPE_NAME;
 
-    constexpr _Ty operator()(const _Ty& _Left) const {
+    _NODISCARD constexpr _Ty operator()(const _Ty& _Left) const {
         return ~_Left;
     }
 };
@@ -186,7 +186,7 @@ struct bit_not {
 template <>
 struct divides<void> {
     template <class _Ty1, class _Ty2>
-    constexpr auto operator()(_Ty1&& _Left, _Ty2&& _Right) const
+    _NODISCARD constexpr auto operator()(_Ty1&& _Left, _Ty2&& _Right) const
         -> decltype(_STD forward<_Ty1>(_Left) / _STD forward<_Ty2>(_Right)) {
         return _STD forward<_Ty1>(_Left) / _STD forward<_Ty2>(_Right);
     }
@@ -198,7 +198,7 @@ struct divides<void> {
 template <>
 struct modulus<void> {
     template <class _Ty1, class _Ty2>
-    constexpr auto operator()(_Ty1&& _Left, _Ty2&& _Right) const
+    _NODISCARD constexpr auto operator()(_Ty1&& _Left, _Ty2&& _Right) const
         -> decltype(_STD forward<_Ty1>(_Left) % _STD forward<_Ty2>(_Right)) {
         return _STD forward<_Ty1>(_Left) % _STD forward<_Ty2>(_Right);
     }
@@ -210,7 +210,7 @@ struct modulus<void> {
 template <>
 struct negate<void> {
     template <class _Ty>
-    constexpr auto operator()(_Ty&& _Left) const -> decltype(-_STD forward<_Ty>(_Left)) {
+    _NODISCARD constexpr auto operator()(_Ty&& _Left) const -> decltype(-_STD forward<_Ty>(_Left)) {
         return -_STD forward<_Ty>(_Left);
     }
 
@@ -239,7 +239,7 @@ struct negate<void> {
 template <>
 struct logical_and<void> {
     template <class _Ty1, class _Ty2>
-    constexpr auto operator()(_Ty1&& _Left, _Ty2&& _Right) const
+    _NODISCARD constexpr auto operator()(_Ty1&& _Left, _Ty2&& _Right) const
         -> decltype(_STD forward<_Ty1>(_Left) && _STD forward<_Ty2>(_Right)) {
         return _STD forward<_Ty1>(_Left) && _STD forward<_Ty2>(_Right);
     }
@@ -251,7 +251,7 @@ struct logical_and<void> {
 template <>
 struct logical_or<void> {
     template <class _Ty1, class _Ty2>
-    constexpr auto operator()(_Ty1&& _Left, _Ty2&& _Right) const
+    _NODISCARD constexpr auto operator()(_Ty1&& _Left, _Ty2&& _Right) const
         -> decltype(_STD forward<_Ty1>(_Left) || _STD forward<_Ty2>(_Right)) {
         return _STD forward<_Ty1>(_Left) || _STD forward<_Ty2>(_Right);
     }
@@ -263,7 +263,7 @@ struct logical_or<void> {
 template <>
 struct logical_not<void> {
     template <class _Ty>
-    constexpr auto operator()(_Ty&& _Left) const -> decltype(!_STD forward<_Ty>(_Left)) {
+    _NODISCARD constexpr auto operator()(_Ty&& _Left) const -> decltype(!_STD forward<_Ty>(_Left)) {
         return !_STD forward<_Ty>(_Left);
     }
 
@@ -274,7 +274,7 @@ struct logical_not<void> {
 template <>
 struct bit_and<void> {
     template <class _Ty1, class _Ty2>
-    constexpr auto operator()(_Ty1&& _Left, _Ty2&& _Right) const
+    _NODISCARD constexpr auto operator()(_Ty1&& _Left, _Ty2&& _Right) const
         -> decltype(_STD forward<_Ty1>(_Left) & _STD forward<_Ty2>(_Right)) {
         return _STD forward<_Ty1>(_Left) & _STD forward<_Ty2>(_Right);
     }
@@ -286,7 +286,7 @@ struct bit_and<void> {
 template <>
 struct bit_or<void> {
     template <class _Ty1, class _Ty2>
-    constexpr auto operator()(_Ty1&& _Left, _Ty2&& _Right) const
+    _NODISCARD constexpr auto operator()(_Ty1&& _Left, _Ty2&& _Right) const
         -> decltype(_STD forward<_Ty1>(_Left) | _STD forward<_Ty2>(_Right)) {
         return _STD forward<_Ty1>(_Left) | _STD forward<_Ty2>(_Right);
     }
@@ -298,7 +298,7 @@ struct bit_or<void> {
 template <>
 struct bit_xor<void> {
     template <class _Ty1, class _Ty2>
-    constexpr auto operator()(_Ty1&& _Left, _Ty2&& _Right) const
+    _NODISCARD constexpr auto operator()(_Ty1&& _Left, _Ty2&& _Right) const
         -> decltype(_STD forward<_Ty1>(_Left) ^ _STD forward<_Ty2>(_Right)) {
         return _STD forward<_Ty1>(_Left) ^ _STD forward<_Ty2>(_Right);
     }
@@ -310,7 +310,7 @@ struct bit_xor<void> {
 template <>
 struct bit_not<void> {
     template <class _Ty>
-    constexpr auto operator()(_Ty&& _Left) const -> decltype(~_STD forward<_Ty>(_Left)) {
+    _NODISCARD constexpr auto operator()(_Ty&& _Left) const -> decltype(~_STD forward<_Ty>(_Left)) {
         return ~_STD forward<_Ty>(_Left);
     }
 
@@ -328,7 +328,7 @@ public:
 
     constexpr explicit unary_negate(const _Fn& _Func) : _Functor(_Func) {}
 
-    constexpr bool operator()(const argument_type& _Left) const {
+    _NODISCARD constexpr bool operator()(const argument_type& _Left) const {
         return !_Functor(_Left);
     }
 
@@ -352,7 +352,7 @@ public:
 
     constexpr explicit binary_negate(const _Fn& _Func) : _Functor(_Func) {}
 
-    constexpr bool operator()(const first_argument_type& _Left, const second_argument_type& _Right) const {
+    _NODISCARD constexpr bool operator()(const first_argument_type& _Left, const second_argument_type& _Right) const {
         return !_Functor(_Left, _Right);
     }
 

--- a/stl/inc/xstddef
+++ b/stl/inc/xstddef
@@ -51,7 +51,7 @@ struct plus {
     _CXX17_DEPRECATE_ADAPTOR_TYPEDEFS typedef _Ty _SECOND_ARGUMENT_TYPE_NAME;
     _CXX17_DEPRECATE_ADAPTOR_TYPEDEFS typedef _Ty _RESULT_TYPE_NAME;
 
-    constexpr _Ty operator()(const _Ty& _Left, const _Ty& _Right) const {
+    _NODISCARD constexpr _Ty operator()(const _Ty& _Left, const _Ty& _Right) const {
         return _Left + _Right;
     }
 };
@@ -63,7 +63,7 @@ struct minus {
     _CXX17_DEPRECATE_ADAPTOR_TYPEDEFS typedef _Ty _SECOND_ARGUMENT_TYPE_NAME;
     _CXX17_DEPRECATE_ADAPTOR_TYPEDEFS typedef _Ty _RESULT_TYPE_NAME;
 
-    constexpr _Ty operator()(const _Ty& _Left, const _Ty& _Right) const {
+    _NODISCARD constexpr _Ty operator()(const _Ty& _Left, const _Ty& _Right) const {
         return _Left - _Right;
     }
 };
@@ -75,7 +75,7 @@ struct multiplies {
     _CXX17_DEPRECATE_ADAPTOR_TYPEDEFS typedef _Ty _SECOND_ARGUMENT_TYPE_NAME;
     _CXX17_DEPRECATE_ADAPTOR_TYPEDEFS typedef _Ty _RESULT_TYPE_NAME;
 
-    constexpr _Ty operator()(const _Ty& _Left, const _Ty& _Right) const {
+    _NODISCARD constexpr _Ty operator()(const _Ty& _Left, const _Ty& _Right) const {
         return _Left * _Right;
     }
 };
@@ -87,7 +87,7 @@ struct equal_to {
     _CXX17_DEPRECATE_ADAPTOR_TYPEDEFS typedef _Ty _SECOND_ARGUMENT_TYPE_NAME;
     _CXX17_DEPRECATE_ADAPTOR_TYPEDEFS typedef bool _RESULT_TYPE_NAME;
 
-    constexpr bool operator()(const _Ty& _Left, const _Ty& _Right) const {
+    _NODISCARD constexpr bool operator()(const _Ty& _Left, const _Ty& _Right) const {
         return _Left == _Right;
     }
 };
@@ -99,7 +99,7 @@ struct not_equal_to {
     _CXX17_DEPRECATE_ADAPTOR_TYPEDEFS typedef _Ty _SECOND_ARGUMENT_TYPE_NAME;
     _CXX17_DEPRECATE_ADAPTOR_TYPEDEFS typedef bool _RESULT_TYPE_NAME;
 
-    constexpr bool operator()(const _Ty& _Left, const _Ty& _Right) const {
+    _NODISCARD constexpr bool operator()(const _Ty& _Left, const _Ty& _Right) const {
         return _Left != _Right;
     }
 };
@@ -111,7 +111,7 @@ struct greater {
     _CXX17_DEPRECATE_ADAPTOR_TYPEDEFS typedef _Ty _SECOND_ARGUMENT_TYPE_NAME;
     _CXX17_DEPRECATE_ADAPTOR_TYPEDEFS typedef bool _RESULT_TYPE_NAME;
 
-    constexpr bool operator()(const _Ty& _Left, const _Ty& _Right) const {
+    _NODISCARD constexpr bool operator()(const _Ty& _Left, const _Ty& _Right) const {
         return _Left > _Right;
     }
 };
@@ -123,7 +123,7 @@ struct less {
     _CXX17_DEPRECATE_ADAPTOR_TYPEDEFS typedef _Ty _SECOND_ARGUMENT_TYPE_NAME;
     _CXX17_DEPRECATE_ADAPTOR_TYPEDEFS typedef bool _RESULT_TYPE_NAME;
 
-    constexpr bool operator()(const _Ty& _Left, const _Ty& _Right) const {
+    _NODISCARD constexpr bool operator()(const _Ty& _Left, const _Ty& _Right) const {
         return _Left < _Right;
     }
 };
@@ -135,7 +135,7 @@ struct greater_equal {
     _CXX17_DEPRECATE_ADAPTOR_TYPEDEFS typedef _Ty _SECOND_ARGUMENT_TYPE_NAME;
     _CXX17_DEPRECATE_ADAPTOR_TYPEDEFS typedef bool _RESULT_TYPE_NAME;
 
-    constexpr bool operator()(const _Ty& _Left, const _Ty& _Right) const {
+    _NODISCARD constexpr bool operator()(const _Ty& _Left, const _Ty& _Right) const {
         return _Left >= _Right;
     }
 };
@@ -147,7 +147,7 @@ struct less_equal {
     _CXX17_DEPRECATE_ADAPTOR_TYPEDEFS typedef _Ty _SECOND_ARGUMENT_TYPE_NAME;
     _CXX17_DEPRECATE_ADAPTOR_TYPEDEFS typedef bool _RESULT_TYPE_NAME;
 
-    constexpr bool operator()(const _Ty& _Left, const _Ty& _Right) const {
+    _NODISCARD constexpr bool operator()(const _Ty& _Left, const _Ty& _Right) const {
         return _Left <= _Right;
     }
 };
@@ -156,7 +156,7 @@ struct less_equal {
 template <>
 struct plus<void> {
     template <class _Ty1, class _Ty2>
-    constexpr auto operator()(_Ty1&& _Left, _Ty2&& _Right) const
+    _NODISCARD constexpr auto operator()(_Ty1&& _Left, _Ty2&& _Right) const
         noexcept(noexcept(static_cast<_Ty1&&>(_Left) + static_cast<_Ty2&&>(_Right))) // strengthened
         -> decltype(static_cast<_Ty1&&>(_Left) + static_cast<_Ty2&&>(_Right)) {
         return static_cast<_Ty1&&>(_Left) + static_cast<_Ty2&&>(_Right);
@@ -169,7 +169,7 @@ struct plus<void> {
 template <>
 struct minus<void> {
     template <class _Ty1, class _Ty2>
-    constexpr auto operator()(_Ty1&& _Left, _Ty2&& _Right) const
+    _NODISCARD constexpr auto operator()(_Ty1&& _Left, _Ty2&& _Right) const
         noexcept(noexcept(static_cast<_Ty1&&>(_Left) - static_cast<_Ty2&&>(_Right))) // strengthened
         -> decltype(static_cast<_Ty1&&>(_Left) - static_cast<_Ty2&&>(_Right)) {
         return static_cast<_Ty1&&>(_Left) - static_cast<_Ty2&&>(_Right);
@@ -182,7 +182,7 @@ struct minus<void> {
 template <>
 struct multiplies<void> {
     template <class _Ty1, class _Ty2>
-    constexpr auto operator()(_Ty1&& _Left, _Ty2&& _Right) const
+    _NODISCARD constexpr auto operator()(_Ty1&& _Left, _Ty2&& _Right) const
         noexcept(noexcept(static_cast<_Ty1&&>(_Left) * static_cast<_Ty2&&>(_Right))) // strengthened
         -> decltype(static_cast<_Ty1&&>(_Left) * static_cast<_Ty2&&>(_Right)) {
         return static_cast<_Ty1&&>(_Left) * static_cast<_Ty2&&>(_Right);
@@ -195,7 +195,7 @@ struct multiplies<void> {
 template <>
 struct equal_to<void> {
     template <class _Ty1, class _Ty2>
-    constexpr auto operator()(_Ty1&& _Left, _Ty2&& _Right) const
+    _NODISCARD constexpr auto operator()(_Ty1&& _Left, _Ty2&& _Right) const
         noexcept(noexcept(static_cast<_Ty1&&>(_Left) == static_cast<_Ty2&&>(_Right))) // strengthened
         -> decltype(static_cast<_Ty1&&>(_Left) == static_cast<_Ty2&&>(_Right)) {
         return static_cast<_Ty1&&>(_Left) == static_cast<_Ty2&&>(_Right);
@@ -208,7 +208,7 @@ struct equal_to<void> {
 template <>
 struct not_equal_to<void> {
     template <class _Ty1, class _Ty2>
-    constexpr auto operator()(_Ty1&& _Left, _Ty2&& _Right) const
+    _NODISCARD constexpr auto operator()(_Ty1&& _Left, _Ty2&& _Right) const
         noexcept(noexcept(static_cast<_Ty1&&>(_Left) != static_cast<_Ty2&&>(_Right))) // strengthened
         -> decltype(static_cast<_Ty1&&>(_Left) != static_cast<_Ty2&&>(_Right)) {
         return static_cast<_Ty1&&>(_Left) != static_cast<_Ty2&&>(_Right);
@@ -221,7 +221,7 @@ struct not_equal_to<void> {
 template <>
 struct greater<void> {
     template <class _Ty1, class _Ty2>
-    constexpr auto operator()(_Ty1&& _Left, _Ty2&& _Right) const
+    _NODISCARD constexpr auto operator()(_Ty1&& _Left, _Ty2&& _Right) const
         noexcept(noexcept(static_cast<_Ty1&&>(_Left) > static_cast<_Ty2&&>(_Right))) // strengthened
         -> decltype(static_cast<_Ty1&&>(_Left) > static_cast<_Ty2&&>(_Right)) {
         return static_cast<_Ty1&&>(_Left) > static_cast<_Ty2&&>(_Right);
@@ -234,7 +234,7 @@ struct greater<void> {
 template <>
 struct less<void> {
     template <class _Ty1, class _Ty2>
-    constexpr auto operator()(_Ty1&& _Left, _Ty2&& _Right) const
+    _NODISCARD constexpr auto operator()(_Ty1&& _Left, _Ty2&& _Right) const
         noexcept(noexcept(static_cast<_Ty1&&>(_Left) < static_cast<_Ty2&&>(_Right))) // strengthened
         -> decltype(static_cast<_Ty1&&>(_Left) < static_cast<_Ty2&&>(_Right)) {
         return static_cast<_Ty1&&>(_Left) < static_cast<_Ty2&&>(_Right);
@@ -247,7 +247,7 @@ struct less<void> {
 template <>
 struct greater_equal<void> {
     template <class _Ty1, class _Ty2>
-    constexpr auto operator()(_Ty1&& _Left, _Ty2&& _Right) const
+    _NODISCARD constexpr auto operator()(_Ty1&& _Left, _Ty2&& _Right) const
         noexcept(noexcept(static_cast<_Ty1&&>(_Left) >= static_cast<_Ty2&&>(_Right))) // strengthened
         -> decltype(static_cast<_Ty1&&>(_Left) >= static_cast<_Ty2&&>(_Right)) {
         return static_cast<_Ty1&&>(_Left) >= static_cast<_Ty2&&>(_Right);
@@ -260,7 +260,7 @@ struct greater_equal<void> {
 template <>
 struct less_equal<void> {
     template <class _Ty1, class _Ty2>
-    constexpr auto operator()(_Ty1&& _Left, _Ty2&& _Right) const
+    _NODISCARD constexpr auto operator()(_Ty1&& _Left, _Ty2&& _Right) const
         noexcept(noexcept(static_cast<_Ty1&&>(_Left) <= static_cast<_Ty2&&>(_Right))) // strengthened
         -> decltype(static_cast<_Ty1&&>(_Left) <= static_cast<_Ty2&&>(_Right)) {
         return static_cast<_Ty1&&>(_Left) <= static_cast<_Ty2&&>(_Right);

--- a/tests/std/tests/VSO_0000000_instantiate_iterators_misc/test.compile.pass.cpp
+++ b/tests/std/tests/VSO_0000000_instantiate_iterators_misc/test.compile.pass.cpp
@@ -1628,26 +1628,26 @@ void typeindex_test() {
 template <typename FunctorArg, typename Arg>
 void functors_test_impl(Arg val) {
     // Following from <xstddef>:
-    plus<FunctorArg>()(val, val);
-    minus<FunctorArg>()(val, val);
-    multiplies<FunctorArg>()(val, val);
-    equal_to<FunctorArg>()(val, val);
-    less<FunctorArg>()(val, val);
+    (void) plus<FunctorArg>()(val, val);
+    (void) minus<FunctorArg>()(val, val);
+    (void) multiplies<FunctorArg>()(val, val);
+    (void) equal_to<FunctorArg>()(val, val);
+    (void) less<FunctorArg>()(val, val);
 
-    divides<FunctorArg>()(val, val);
-    modulus<FunctorArg>()(val, val);
-    negate<FunctorArg>()(val);
-    not_equal_to<FunctorArg>()(val, val);
-    greater<FunctorArg>()(val, val);
-    greater_equal<FunctorArg>()(val, val);
-    less_equal<FunctorArg>()(val, val);
-    logical_and<FunctorArg>()(val, val);
-    logical_or<FunctorArg>()(val, val);
-    logical_not<FunctorArg>()(val);
-    bit_and<FunctorArg>()(val, val);
-    bit_or<FunctorArg>()(val, val);
-    bit_xor<FunctorArg>()(val, val);
-    bit_not<FunctorArg>()(val);
+    (void) divides<FunctorArg>()(val, val);
+    (void) modulus<FunctorArg>()(val, val);
+    (void) negate<FunctorArg>()(val);
+    (void) not_equal_to<FunctorArg>()(val, val);
+    (void) greater<FunctorArg>()(val, val);
+    (void) greater_equal<FunctorArg>()(val, val);
+    (void) less_equal<FunctorArg>()(val, val);
+    (void) logical_and<FunctorArg>()(val, val);
+    (void) logical_or<FunctorArg>()(val, val);
+    (void) logical_not<FunctorArg>()(val);
+    (void) bit_and<FunctorArg>()(val, val);
+    (void) bit_or<FunctorArg>()(val, val);
+    (void) bit_xor<FunctorArg>()(val, val);
+    (void) bit_not<FunctorArg>()(val);
 }
 
 int real_unary_function(int) {
@@ -1661,8 +1661,8 @@ int real_binary_function(int, int) {
 void xfunctional_test() {
     functors_test_impl<int>(5);
     functors_test_impl<void>(5);
-    not1(negate<int>())(5); // not1 requires T::second_argument_type
-    not2(less_equal<int>())(5, 5); // not2 requires T::second_argument_type
+    (void) not1(negate<int>())(5); // not1 requires T::second_argument_type
+    (void) not2(less_equal<int>())(5, 5); // not2 requires T::second_argument_type
 
 #if _HAS_AUTO_PTR_ETC
     auto b1 = bind1st(plus<int>(), 1);


### PR DESCRIPTION
<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->

***Very likely*** partially addresses #206.

Note: `_NODISCARD` is already present for `ranges` function objects.