### PR TITLE
Correct member comment for _List_val::_Sort.

### DIFF
--- a/stl/inc/list
+++ b/stl/inc/list
@@ -555,7 +555,7 @@ public:
 
     template <class _Pr2>
     static _Nodeptr _Sort(_Nodeptr& _First, const size_type _Size, _Pr2 _Pred) {
-        // order [_First, _Last), return _First + _Size
+        // order [_First, _First + _Size), return _First + _Size
         switch (_Size) {
         case 0:
             return _First;


### PR DESCRIPTION
Fixing a recent stack overflow answer and adding a link to our actual
implementation I discovered I didn't fix this comment when I last
overhauled this sort.
