### PR TITLE
LWG-3464 istream::gcount() can overflow

### DIFF
--- a/stl/inc/istream
+++ b/stl/inc/istream
@@ -600,7 +600,7 @@ public:
     }
 
     _NODISCARD streamsize __CLR_OR_THIS_CALL gcount() const { // get count from last extraction
-        return _Chcount;
+        return _Chcount < 0 ? _STD numeric_limits<streamsize>::max() : _Chcount;
     }
 
     int __CLR_OR_THIS_CALL sync() { // synchronize with input source


### PR DESCRIPTION
[LWG-3464](https://cplusplus.github.io/LWG/issue3464) istream::gcount() can overflow, so in case, if `_Chcount` is negative, return `std::numeric_limits<streamsize>::max()`

Fixes #1480 