### PR TITLE
LWG-3464 istream::gcount() can overflow

### DIFF
--- a/stl/inc/istream
+++ b/stl/inc/istream
@@ -206,6 +206,7 @@ private:
         return *this;
     }
 
+    template <class = void>
     void _Increment_gcount() {
         if (_Chcount != (numeric_limits<streamsize>::max)()) {
             ++_Chcount;
@@ -347,7 +348,7 @@ public:
                 _State |= ios_base::eofbit | ios_base::failbit; // end of file
             } else { // got a character, count it
                 _Myios::rdbuf()->sbumpc();
-                _Increment_gcount();
+                _Chcount = 1;
             }
             _CATCH_IO_END
         }
@@ -517,11 +518,7 @@ public:
         if (_Ok && 0 < _Count) { // state okay, use facet to extract
             _TRY_IO_BEGIN
             const streamsize _Num = _Myios::rdbuf()->sgetn(_Str, _Count);
-            if (_Chcount <= (numeric_limits<streamsize>::max)() - _Num) {
-                _Chcount += _Num;
-            } else { // overflow
-                _Chcount = (numeric_limits<streamsize>::max)();
-            }
+            _Chcount              = _Num;
 
             if (_Num != _Count) {
                 _State |= ios_base::eofbit | ios_base::failbit; // short read

--- a/stl/inc/istream
+++ b/stl/inc/istream
@@ -206,6 +206,12 @@ private:
         return *this;
     }
 
+    void _Increment_gcount() {
+        if (_Chcount != (numeric_limits<streamsize>::max)()) {
+            ++_Chcount;
+        }
+    }
+
 public:
     basic_istream& __CLR_OR_THIS_CALL operator>>(bool& _Val) { // extract a boolean
         return _Common_extract_with_num_get(_Val);
@@ -312,7 +318,7 @@ public:
                 break;
                 _CATCH_END
 
-                ++_Chcount;
+                _Increment_gcount();
             }
             _CATCH_IO_END
         }
@@ -341,7 +347,7 @@ public:
                 _State |= ios_base::eofbit | ios_base::failbit; // end of file
             } else { // got a character, count it
                 _Myios::rdbuf()->sbumpc();
-                ++_Chcount;
+                _Increment_gcount();
             }
             _CATCH_IO_END
         }
@@ -372,7 +378,7 @@ public:
                     break; // got a delimiter, quit
                 } else { // got a character, add it to string
                     *_Str++ = _Traits::to_char_type(_Meta);
-                    ++_Chcount;
+                    _Increment_gcount();
                 }
             }
             _CATCH_IO_END
@@ -419,7 +425,7 @@ public:
                     _CATCH_ALL
                     break;
                     _CATCH_END
-                    ++_Chcount;
+                    _Increment_gcount();
                 }
             }
             _CATCH_IO_END
@@ -454,7 +460,7 @@ public:
                     _State |= ios_base::eofbit;
                     break;
                 } else if (_Meta == _Metadelim) { // got a delimiter, discard it and quit
-                    ++_Chcount;
+                    _Increment_gcount();
                     _Myios::rdbuf()->sbumpc();
                     break;
                 } else if (--_Count <= 0) { // buffer full, quit
@@ -462,7 +468,7 @@ public:
                     break;
                 } else { // got a character, add it to string
                     *_Str++ = _Traits::to_char_type(_Meta);
-                    ++_Chcount;
+                    _Increment_gcount();
                 }
             }
             _CATCH_IO_END
@@ -490,7 +496,7 @@ public:
                     _State |= ios_base::eofbit;
                     break;
                 } else { // got a character, count it
-                    ++_Chcount;
+                    _Increment_gcount();
                     if (_Meta == _Metadelim) {
                         break; // got a delimiter, quit
                     }
@@ -511,7 +517,12 @@ public:
         if (_Ok && 0 < _Count) { // state okay, use facet to extract
             _TRY_IO_BEGIN
             const streamsize _Num = _Myios::rdbuf()->sgetn(_Str, _Count);
-            _Chcount += _Num;
+            if (_Chcount <= (numeric_limits<streamsize>::max)() - _Num) {
+                _Chcount += _Num;
+            } else { // overflow
+                _Chcount = (numeric_limits<streamsize>::max)();
+            }
+
             if (_Num != _Count) {
                 _State |= ios_base::eofbit | ios_base::failbit; // short read
             }
@@ -600,7 +611,7 @@ public:
     }
 
     _NODISCARD streamsize __CLR_OR_THIS_CALL gcount() const { // get count from last extraction
-        return _Chcount < 0 ? (numeric_limits<streamsize>::max)() : _Chcount;
+        return _Chcount;
     }
 
     int __CLR_OR_THIS_CALL sync() { // synchronize with input source

--- a/stl/inc/istream
+++ b/stl/inc/istream
@@ -600,7 +600,7 @@ public:
     }
 
     _NODISCARD streamsize __CLR_OR_THIS_CALL gcount() const { // get count from last extraction
-        return _Chcount;
+        return _Chcount < 0 ? (numeric_limits<streamsize>::max)() : _Chcount;
     }
 
     int __CLR_OR_THIS_CALL sync() { // synchronize with input source


### PR DESCRIPTION
[LWG-3464](https://cplusplus.github.io/LWG/issue3464) `istream::gcount()` can overflow, so in case, if `_Chcount` is negative, return `std::numeric_limits<streamsize>::max()`

Fixes #1480