### PR TITLE
<regex> Prevent stack overflow while parsing grouping repetitions

### DIFF
--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -2120,6 +2120,23 @@ _OutIt _Format_sed(const match_results<_BidIt, _Alloc>& _Match, _OutIt _Out, _In
     return _Out;
 }
 
+#ifdef _IS_THERE_A_MACRO_TO_DETECT_EHa_COMPILER_OPTION
+template <typename _TMatcher, typename _TMatchResult>
+bool _Regex_match_helper(_TMatcher& _Mx, _TMatchResult* _Matches, bool _Full) {
+    __try {
+        return _Mx._Match(_Matches, _Full);
+    } __except (GetExceptionCode() == EXCEPTION_STACK_OVERFLOW) {
+        _resetstkoflw();
+        _Xregex_error(regex_constants::error_stack);
+    }
+}
+#else // _IS_THERE_A_MACRO_TO_DETECT_EHa_COMPILER_OPTION
+template <typename _TMatcher, typename _TMatchResult>
+bool _Regex_match_helper(_TMatcher& _Mx, _TMatchResult* _Matches, bool _Full) {
+    return _Mx._Match(_Matches, _Full);
+}
+#endif // _IS_THERE_A_MACRO_TO_DETECT_EHa_COMPILER_OPTION
+
 // FUNCTION TEMPLATE _Regex_match1
 template <class _BidIt, class _Alloc, class _Elem, class _RxTraits, class _It>
 bool _Regex_match1(_It _First, _It _Last, match_results<_BidIt, _Alloc>* _Matches,
@@ -2131,7 +2148,7 @@ bool _Regex_match1(_It _First, _It _Last, match_results<_BidIt, _Alloc>* _Matche
 
     _Matcher<_BidIt, _Elem, _RxTraits, _It> _Mx(
         _First, _Last, _Re._Get_traits(), _Re._Get(), _Re.mark_count() + 1, _Re.flags(), _Flgs);
-    return _Mx._Match(_Matches, _Full);
+    return _Regex_match_helper(_Mx, _Matches, _Full);
 }
 
 // FUNCTION TEMPLATE regex_match

--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -23,6 +23,12 @@
 #include <utility>
 #include <vector>
 
+// clang-format off
+// The order of these includes are important
+#include <Windows.h>
+#include <processthreadsapi.h>
+// clang-format on
+
 #if _HAS_CXX17
 #include <xpolymorphic_allocator.h>
 #endif // _HAS_CXX17
@@ -38,13 +44,9 @@ _STL_DISABLE_CLANG_WARNINGS
 #define _REGEX_MAX_COMPLEXITY_COUNT 10000000L // set to 0 to disable
 #endif // _REGEX_MAX_COMPLEXITY_COUNT
 
-#ifndef _REGEX_MAX_STACK_COUNT
-#ifdef _WIN64
-#define _REGEX_MAX_STACK_COUNT 225L // set to 0 to disable
-#else // _WIN64
-#define _REGEX_MAX_STACK_COUNT 1000L // set to 0 to disable
-#endif // _WIN64
-#endif // _REGEX_MAX_STACK_COUNT
+#ifndef _REGEX_NEEDED_STACK_SIZE
+#define _REGEX_NEEDED_STACK_SIZE 35000L
+#endif // _REGEX_NEEDED_STACK_SIZE
 
 #ifndef _ENHANCED_REGEX_VISUALIZER
 
@@ -1584,7 +1586,6 @@ public:
         _Cap                  = static_cast<bool>(_Matches);
         _Full                 = _Full_match;
         _Max_complexity_count = _REGEX_MAX_COMPLEXITY_COUNT;
-        _Max_stack_count      = _REGEX_MAX_STACK_COUNT;
 
         _Matched = false;
 
@@ -1650,7 +1651,6 @@ private:
     const _RxTraits& _Traits;
     bool _Full;
     long _Max_complexity_count;
-    long _Max_stack_count;
 
 public:
     _Matcher& operator=(const _Matcher&) = delete;
@@ -2120,23 +2120,6 @@ _OutIt _Format_sed(const match_results<_BidIt, _Alloc>& _Match, _OutIt _Out, _In
     return _Out;
 }
 
-#ifdef _IS_THERE_A_MACRO_TO_DETECT_EHa_COMPILER_OPTION
-template <typename _TMatcher, typename _TMatchResult>
-bool _Regex_match_helper(_TMatcher& _Mx, _TMatchResult* _Matches, bool _Full) {
-    __try {
-        return _Mx._Match(_Matches, _Full);
-    } __except (GetExceptionCode() == EXCEPTION_STACK_OVERFLOW) {
-        _resetstkoflw();
-        _Xregex_error(regex_constants::error_stack);
-    }
-}
-#else // _IS_THERE_A_MACRO_TO_DETECT_EHa_COMPILER_OPTION
-template <typename _TMatcher, typename _TMatchResult>
-bool _Regex_match_helper(_TMatcher& _Mx, _TMatchResult* _Matches, bool _Full) {
-    return _Mx._Match(_Matches, _Full);
-}
-#endif // _IS_THERE_A_MACRO_TO_DETECT_EHa_COMPILER_OPTION
-
 // FUNCTION TEMPLATE _Regex_match1
 template <class _BidIt, class _Alloc, class _Elem, class _RxTraits, class _It>
 bool _Regex_match1(_It _First, _It _Last, match_results<_BidIt, _Alloc>* _Matches,
@@ -2148,7 +2131,7 @@ bool _Regex_match1(_It _First, _It _Last, match_results<_BidIt, _Alloc>* _Matche
 
     _Matcher<_BidIt, _Elem, _RxTraits, _It> _Mx(
         _First, _Last, _Re._Get_traits(), _Re._Get(), _Re.mark_count() + 1, _Re.flags(), _Flgs);
-    return _Regex_match_helper(_Mx, _Matches, _Full);
+    return _Mx._Match(_Matches, _Full);
 }
 
 // FUNCTION TEMPLATE regex_match
@@ -3458,9 +3441,21 @@ unsigned int _Matcher<_BidIt, _Elem, _RxTraits, _It>::_Get_ncap() const {
     return static_cast<unsigned int>(_Ncap);
 }
 
+ULONG_PTR _AvailableStackCapacity() {
+
+    ULONG_PTR _StackLowBoundary;
+    ULONG_PTR _StackHighBoundary;
+    GetCurrentThreadStackLimits(&_StackLowBoundary, &_StackHighBoundary);
+
+    char aDummyValue;
+    ULONG_PTR _CurrentStackPointer = reinterpret_cast<ULONG_PTR>(&aDummyValue);
+    ULONG_PTR _AvailableStackSize  = _CurrentStackPointer - _StackLowBoundary;
+    return _AvailableStackSize;
+}
+
 template <class _BidIt, class _Elem, class _RxTraits, class _It>
 bool _Matcher<_BidIt, _Elem, _RxTraits, _It>::_Match_pat(_Node_base* _Nx) { // check for match
-    if (0 < _Max_stack_count && --_Max_stack_count <= 0) {
+    if (_AvailableStackCapacity() < _REGEX_NEEDED_STACK_SIZE) {
         _Xregex_error(regex_constants::error_stack);
     }
 
@@ -3643,10 +3638,6 @@ bool _Matcher<_BidIt, _Elem, _RxTraits, _It>::_Match_pat(_Node_base* _Nx) { // c
         } else if (_Nx) {
             _Nx = _Nx->_Next;
         }
-    }
-
-    if (0 < _Max_stack_count) {
-        ++_Max_stack_count;
     }
 
     return !_Failed;

--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -2120,23 +2120,6 @@ _OutIt _Format_sed(const match_results<_BidIt, _Alloc>& _Match, _OutIt _Out, _In
     return _Out;
 }
 
-#ifdef _IS_THERE_A_MACRO_TO_DETECT_EHa_COMPILER_OPTION
-template <typename _TMatcher, typename _TMatchResult>
-bool _Regex_match_helper(_TMatcher& _Mx, _TMatchResult* _Matches, bool _Full) {
-    __try {
-        return _Mx._Match(_Matches, _Full);
-    } __except (GetExceptionCode() == EXCEPTION_STACK_OVERFLOW) {
-        _resetstkoflw();
-        _Xregex_error(regex_constants::error_stack);
-    }
-}
-#else // _IS_THERE_A_MACRO_TO_DETECT_EHa_COMPILER_OPTION
-template <typename _TMatcher, typename _TMatchResult>
-bool _Regex_match_helper(_TMatcher& _Mx, _TMatchResult* _Matches, bool _Full) {
-    return _Mx._Match(_Matches, _Full);
-}
-#endif // _IS_THERE_A_MACRO_TO_DETECT_EHa_COMPILER_OPTION
-
 // FUNCTION TEMPLATE _Regex_match1
 template <class _BidIt, class _Alloc, class _Elem, class _RxTraits, class _It>
 bool _Regex_match1(_It _First, _It _Last, match_results<_BidIt, _Alloc>* _Matches,
@@ -2148,7 +2131,7 @@ bool _Regex_match1(_It _First, _It _Last, match_results<_BidIt, _Alloc>* _Matche
 
     _Matcher<_BidIt, _Elem, _RxTraits, _It> _Mx(
         _First, _Last, _Re._Get_traits(), _Re._Get(), _Re.mark_count() + 1, _Re.flags(), _Flgs);
-    return _Regex_match_helper(_Mx, _Matches, _Full);
+    return _Mx._Match(_Matches, _Full);
 }
 
 // FUNCTION TEMPLATE regex_match

--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -24,7 +24,7 @@
 #include <vector>
 
 // clang-format off
-// The order of these includes are important
+// The order of these includes is important.
 #include <Windows.h>
 #include <processthreadsapi.h>
 // clang-format on

--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -23,12 +23,6 @@
 #include <utility>
 #include <vector>
 
-// clang-format off
-// The order of these includes is important.
-#include <Windows.h>
-#include <processthreadsapi.h>
-// clang-format on
-
 #if _HAS_CXX17
 #include <xpolymorphic_allocator.h>
 #endif // _HAS_CXX17
@@ -44,9 +38,13 @@ _STL_DISABLE_CLANG_WARNINGS
 #define _REGEX_MAX_COMPLEXITY_COUNT 10000000L // set to 0 to disable
 #endif // _REGEX_MAX_COMPLEXITY_COUNT
 
-#ifndef _REGEX_NEEDED_STACK_SIZE
-#define _REGEX_NEEDED_STACK_SIZE 35000L
-#endif // _REGEX_NEEDED_STACK_SIZE
+#ifndef _REGEX_MAX_STACK_COUNT
+#ifdef _WIN64
+#define _REGEX_MAX_STACK_COUNT 225L // set to 0 to disable
+#else // _WIN64
+#define _REGEX_MAX_STACK_COUNT 1000L // set to 0 to disable
+#endif // _WIN64
+#endif // _REGEX_MAX_STACK_COUNT
 
 #ifndef _ENHANCED_REGEX_VISUALIZER
 
@@ -1586,6 +1584,7 @@ public:
         _Cap                  = static_cast<bool>(_Matches);
         _Full                 = _Full_match;
         _Max_complexity_count = _REGEX_MAX_COMPLEXITY_COUNT;
+        _Max_stack_count      = _REGEX_MAX_STACK_COUNT;
 
         _Matched = false;
 
@@ -1651,6 +1650,7 @@ private:
     const _RxTraits& _Traits;
     bool _Full;
     long _Max_complexity_count;
+    long _Max_stack_count;
 
 public:
     _Matcher& operator=(const _Matcher&) = delete;
@@ -2120,6 +2120,23 @@ _OutIt _Format_sed(const match_results<_BidIt, _Alloc>& _Match, _OutIt _Out, _In
     return _Out;
 }
 
+#ifdef _IS_THERE_A_MACRO_TO_DETECT_EHa_COMPILER_OPTION
+template <typename _TMatcher, typename _TMatchResult>
+bool _Regex_match_helper(_TMatcher& _Mx, _TMatchResult* _Matches, bool _Full) {
+    __try {
+        return _Mx._Match(_Matches, _Full);
+    } __except (GetExceptionCode() == EXCEPTION_STACK_OVERFLOW) {
+        _resetstkoflw();
+        _Xregex_error(regex_constants::error_stack);
+    }
+}
+#else // _IS_THERE_A_MACRO_TO_DETECT_EHa_COMPILER_OPTION
+template <typename _TMatcher, typename _TMatchResult>
+bool _Regex_match_helper(_TMatcher& _Mx, _TMatchResult* _Matches, bool _Full) {
+    return _Mx._Match(_Matches, _Full);
+}
+#endif // _IS_THERE_A_MACRO_TO_DETECT_EHa_COMPILER_OPTION
+
 // FUNCTION TEMPLATE _Regex_match1
 template <class _BidIt, class _Alloc, class _Elem, class _RxTraits, class _It>
 bool _Regex_match1(_It _First, _It _Last, match_results<_BidIt, _Alloc>* _Matches,
@@ -2131,7 +2148,7 @@ bool _Regex_match1(_It _First, _It _Last, match_results<_BidIt, _Alloc>* _Matche
 
     _Matcher<_BidIt, _Elem, _RxTraits, _It> _Mx(
         _First, _Last, _Re._Get_traits(), _Re._Get(), _Re.mark_count() + 1, _Re.flags(), _Flgs);
-    return _Mx._Match(_Matches, _Full);
+    return _Regex_match_helper(_Mx, _Matches, _Full);
 }
 
 // FUNCTION TEMPLATE regex_match
@@ -3441,21 +3458,9 @@ unsigned int _Matcher<_BidIt, _Elem, _RxTraits, _It>::_Get_ncap() const {
     return static_cast<unsigned int>(_Ncap);
 }
 
-ULONG_PTR _AvailableStackCapacity() {
-
-    ULONG_PTR _StackLowBoundary;
-    ULONG_PTR _StackHighBoundary;
-    GetCurrentThreadStackLimits(&_StackLowBoundary, &_StackHighBoundary);
-
-    char aDummyValue;
-    ULONG_PTR _CurrentStackPointer = reinterpret_cast<ULONG_PTR>(&aDummyValue);
-    ULONG_PTR _AvailableStackSize  = _CurrentStackPointer - _StackLowBoundary;
-    return _AvailableStackSize;
-}
-
 template <class _BidIt, class _Elem, class _RxTraits, class _It>
 bool _Matcher<_BidIt, _Elem, _RxTraits, _It>::_Match_pat(_Node_base* _Nx) { // check for match
-    if (_AvailableStackCapacity() < _REGEX_NEEDED_STACK_SIZE) {
+    if (0 < _Max_stack_count && --_Max_stack_count <= 0) {
         _Xregex_error(regex_constants::error_stack);
     }
 
@@ -3638,6 +3643,10 @@ bool _Matcher<_BidIt, _Elem, _RxTraits, _It>::_Match_pat(_Node_base* _Nx) { // c
         } else if (_Nx) {
             _Nx = _Nx->_Next;
         }
+    }
+
+    if (0 < _Max_stack_count) {
+        ++_Max_stack_count;
     }
 
     return !_Failed;

--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -40,7 +40,7 @@ _STL_DISABLE_CLANG_WARNINGS
 
 #ifndef _REGEX_MAX_STACK_COUNT
 #ifdef _WIN64
-#define _REGEX_MAX_STACK_COUNT 600L // set to 0 to disable
+#define _REGEX_MAX_STACK_COUNT 225L // set to 0 to disable
 #else // _WIN64
 #define _REGEX_MAX_STACK_COUNT 1000L // set to 0 to disable
 #endif // _WIN64

--- a/tests/std/include/test_regex_support.hpp
+++ b/tests/std/include/test_regex_support.hpp
@@ -176,6 +176,22 @@ public:
             }
         }
     }
+
+    void should_not_crash(
+        const std::string& subject, const std::string& pattern, const std::regex_constants::error_type expectedCode) {
+        try {
+            const std::regex r(pattern);
+            std::smatch m;
+            std::regex_match(subject, m, r);
+        } catch (const std::regex_error& e) {
+            if (e.code() != expectedCode) {
+                printf(R"(regex r("%s") threw 0x%X; expected 0x%X)"
+                       "\n",
+                    pattern.c_str(), static_cast<unsigned int>(e.code()), static_cast<unsigned int>(expectedCode));
+                fail_regex();
+            }
+        }
+    }
 };
 
 class test_regex {

--- a/tests/std/tests/Dev10_814245_regex_character_class_crash/test.cpp
+++ b/tests/std/tests/Dev10_814245_regex_character_class_crash/test.cpp
@@ -111,25 +111,12 @@ void test_VSO_984741_splitting_a_string_with_a_regex() {
     assert(equal(i, sregex_token_iterator{}, begin(tokens), end(tokens)));
 }
 
-void test_GH_997_grouping_repetition_should_not_crash() {
-    // This case should match successfully or throw a C++ exception but should not crash with stack overflow
-    try {
-        std::string str(1000, 'a');
-        std::smatch match{};
-        std::regex_match(str, match, std::regex{"(?:a)+"});
-        assert(true);
-    } catch (std::exception&) {
-        assert(true);
-    }
-}
-
 int main() {
     init_character_strings();
     test_dev10_814245_character_class_should_not_crash();
     test_dev10_723057_normal_to_high_bit_ranges_should_not_throw_error_range();
     test_VSO_153556_singular_classes_can_have_high_bit_set();
     test_VSO_984741_splitting_a_string_with_a_regex();
-    test_GH_997_grouping_repetition_should_not_crash();
 
     return g_regexTester.result();
 }

--- a/tests/std/tests/Dev10_814245_regex_character_class_crash/test.cpp
+++ b/tests/std/tests/Dev10_814245_regex_character_class_crash/test.cpp
@@ -111,12 +111,25 @@ void test_VSO_984741_splitting_a_string_with_a_regex() {
     assert(equal(i, sregex_token_iterator{}, begin(tokens), end(tokens)));
 }
 
+void test_GH_997_grouping_repetition_should_not_crash() {
+    // This case should match successfully or throw a C++ exception but should not crash with stack overflow
+    try {
+        std::string str(1000, 'a');
+        std::smatch match{};
+        std::regex_match(str, match, std::regex{"(?:a)+"});
+        assert(true);
+    } catch (std::exception&) {
+        assert(true);
+    }
+}
+
 int main() {
     init_character_strings();
     test_dev10_814245_character_class_should_not_crash();
     test_dev10_723057_normal_to_high_bit_ranges_should_not_throw_error_range();
     test_VSO_153556_singular_classes_can_have_high_bit_set();
     test_VSO_984741_splitting_a_string_with_a_regex();
+    test_GH_997_grouping_repetition_should_not_crash();
 
     return g_regexTester.result();
 }

--- a/tests/std/tests/VSO_0000000_regex_use/test.cpp
+++ b/tests/std/tests/VSO_0000000_regex_use/test.cpp
@@ -546,6 +546,11 @@ void test_VSO_226914_word_boundaries() {
     aWordAny.should_search_fail("aa", match_not_bow | match_not_eow);
 }
 
+void test_GH_997_regex_should_throw_regex_error_on_stack_overflow() {
+    // This case should match successfully or throw a regex error but should not crash on stack overflow
+    g_regexTester.should_not_crash(std::string(2000, 'a'), R"((?:a)+)", error_stack);
+}
+
 int main() {
     test_dev10_449367_case_insensitivity_should_work();
     test_dev11_462743_regex_collate_should_not_disable_regex_icase();
@@ -572,6 +577,7 @@ int main() {
     test_VSO_225160_match_bol_flag();
     test_VSO_225160_match_eol_flag();
     test_VSO_226914_word_boundaries();
+    test_GH_997_regex_should_throw_regex_error_on_stack_overflow();
 
     return g_regexTester.result();
 }


### PR DESCRIPTION
Fixes #997 
I've investigated this issue. The problem occurs because the algorithm is recursive and reaches max call stack.
I tried to fix the issue by using `GetCurrentThreadStackLimits` to avoid the stack overflow problem.
However, this solution needs `<windows.h>`, and therefore some of the tests can not be passed when `/Za` or `/Zc:preprocessor` is enabled.
The first and second commit of this PR contains other solutions to fix this issue. 
1) Simply reducing the `MAX_STACK_COUNT`. It works. But I'm not sure is it the desirable solution by the maintainers?
2) Using structured exception handling(`__try/__except`). Boost uses this solution but it works only when `/EHa` is enabled.

If it is correct I prefer the 4th commit. But this commit doesn't work with `/Za` nor `/Zc:preprocessor`.
Any thought/suggestion on these? 🤔 