### PR TITLE
[vNext] Modernize array iterators

### DIFF
--- a/stl/inc/array
+++ b/stl/inc/array
@@ -20,7 +20,7 @@ _STL_DISABLE_CLANG_WARNINGS
 _STD_BEGIN
 
 // CLASS TEMPLATE _Array_iterator
-template <class _Ty, bool _Const, bool _Checked>
+template <class _Ty, _ConstIter _Const, _CheckedIter _Checked>
 class _Array_iterator {
 public:
 #ifdef __cpp_lib_concepts
@@ -29,8 +29,8 @@ public:
     using iterator_category = random_access_iterator_tag;
     using value_type        = _Ty;
     using difference_type   = ptrdiff_t;
-    using pointer           = _Maybe_const<_Const, _Ty>*;
-    using reference         = _Maybe_const<_Const, _Ty>&;
+    using pointer           = _Maybe_const<_Const == _ConstIter::_Yes, _Ty>*;
+    using reference         = _Maybe_const<_Const == _ConstIter::_Yes, _Ty>&;
 
     _CONSTEXPR17 _Array_iterator() noexcept = default;
 
@@ -42,15 +42,15 @@ public:
     }
 #else // ^^^ _ITERATOR_DEBUG_LEVEL == 0 / _ITERATOR_DEBUG_LEVEL != 0 vvv
         : _Ptr(_Ptr_), _Begin(_Begin_), _End(_End_) {
-        if constexpr (_Checked) {
+        if constexpr (_Checked == _CheckedIter::_Yes) {
             _STL_VERIFY(_Begin <= _Ptr, "cannot create array iterator outside of bounds");
             _STL_VERIFY(_Ptr <= _End, "cannot create array iterator outside of bounds");
         }
     }
 #endif // _ITERATOR_DEBUG_LEVEL != 0
 
-    template <bool _IsConst = _Const, enable_if_t<_IsConst, int> = 0>
-    _CONSTEXPR17 _Array_iterator(const _Array_iterator<_Ty, !_IsConst, _Checked>& _It) noexcept
+    template <_ConstIter _IsConst = _Const, enable_if_t<_IsConst == _ConstIter::_Yes, int> = 0>
+    _CONSTEXPR17 _Array_iterator(const _Array_iterator<_Ty, _ConstIter::_No, _Checked>& _It) noexcept
 #if _ITERATOR_DEBUG_LEVEL == 0
         : _Ptr(_It._Ptr) {
     }
@@ -61,7 +61,7 @@ public:
 
     _NODISCARD _CONSTEXPR17 reference operator*() const noexcept {
 #if _ITERATOR_DEBUG_LEVEL != 0
-        if constexpr (_Checked) {
+        if constexpr (_Checked == _CheckedIter::_Yes) {
             _STL_VERIFY(_Ptr, "cannot dereference value-initialized array iterator");
             _STL_VERIFY(_Begin <= _Ptr && _Ptr < _End, "cannot dereference out of range array iterator");
         }
@@ -71,7 +71,7 @@ public:
 
     _NODISCARD _CONSTEXPR17 pointer operator->() const noexcept {
 #if _ITERATOR_DEBUG_LEVEL != 0
-        if constexpr (_Checked) {
+        if constexpr (_Checked == _CheckedIter::_Yes) {
             _STL_VERIFY(_Ptr, "cannot dereference value-initialized array iterator");
             _STL_VERIFY(_Begin <= _Ptr && _Ptr < _End, "cannot dereference out of range array iterator");
         }
@@ -79,9 +79,9 @@ public:
         return _Ptr;
     }
 
-    _NODISCARD _CONSTEXPR17 reference operator[](const ptrdiff_t _Off) const noexcept {
+    _NODISCARD _CONSTEXPR17 reference operator[](const difference_type _Off) const noexcept {
 #if _ITERATOR_DEBUG_LEVEL != 0
-        if constexpr (_Checked) {
+        if constexpr (_Checked == _CheckedIter::_Yes) {
             _Verify_offset(_Off);
         }
 #endif // _ITERATOR_DEBUG_LEVEL != 0
@@ -90,7 +90,7 @@ public:
 
     _CONSTEXPR17 _Array_iterator& operator++() noexcept {
 #if _ITERATOR_DEBUG_LEVEL != 0
-        if constexpr (_Checked) {
+        if constexpr (_Checked == _CheckedIter::_Yes) {
             _STL_VERIFY(_Ptr, "cannot increment value-initialized array iterator");
             _STL_VERIFY(_Ptr < _End, "cannot increment array iterator past end");
         }
@@ -101,7 +101,7 @@ public:
 
     _CONSTEXPR17 _Array_iterator operator++(int) noexcept {
 #if _ITERATOR_DEBUG_LEVEL != 0
-        if constexpr (_Checked) {
+        if constexpr (_Checked == _CheckedIter::_Yes) {
             _STL_VERIFY(_Ptr, "cannot increment value-initialized array iterator");
             _STL_VERIFY(_Ptr < _End, "cannot increment array iterator past end");
         }
@@ -113,7 +113,7 @@ public:
 
     _CONSTEXPR17 _Array_iterator& operator--() noexcept {
 #if _ITERATOR_DEBUG_LEVEL != 0
-        if constexpr (_Checked) {
+        if constexpr (_Checked == _CheckedIter::_Yes) {
             _STL_VERIFY(_Ptr, "cannot decrement value-initialized array iterator");
             _STL_VERIFY(_Begin < _Ptr, "cannot decrement array iterator before begin");
         }
@@ -124,7 +124,7 @@ public:
 
     _CONSTEXPR17 _Array_iterator operator--(int) noexcept {
 #if _ITERATOR_DEBUG_LEVEL != 0
-        if constexpr (_Checked) {
+        if constexpr (_Checked == _CheckedIter::_Yes) {
             _STL_VERIFY(_Ptr, "cannot decrement value-initialized array iterator");
             _STL_VERIFY(_Begin < _Ptr, "cannot decrement array iterator before begin");
         }
@@ -134,9 +134,9 @@ public:
         return _Tmp;
     }
 
-    _CONSTEXPR17 _Array_iterator& operator+=(const ptrdiff_t _Off) noexcept {
+    _CONSTEXPR17 _Array_iterator& operator+=(const difference_type _Off) noexcept {
 #if _ITERATOR_DEBUG_LEVEL != 0
-        if constexpr (_Checked) {
+        if constexpr (_Checked == _CheckedIter::_Yes) {
             _Verify_offset(_Off);
         }
 #endif // _ITERATOR_DEBUG_LEVEL != 0
@@ -144,14 +144,14 @@ public:
         return *this;
     }
 
-    _NODISCARD _CONSTEXPR17 _Array_iterator operator+(const ptrdiff_t _Off) const noexcept {
+    _NODISCARD _CONSTEXPR17 _Array_iterator operator+(const difference_type _Off) const noexcept {
         _Array_iterator _Tmp = *this;
         return _Tmp += _Off;
     }
 
-    _CONSTEXPR17 _Array_iterator& operator-=(const ptrdiff_t _Off) noexcept {
+    _CONSTEXPR17 _Array_iterator& operator-=(const difference_type _Off) noexcept {
 #if _ITERATOR_DEBUG_LEVEL != 0
-        if constexpr (_Checked) {
+        if constexpr (_Checked == _CheckedIter::_Yes) {
             _Verify_offset(-_Off);
         }
 #endif // _ITERATOR_DEBUG_LEVEL != 0
@@ -159,30 +159,31 @@ public:
         return *this;
     }
 
-    _NODISCARD _CONSTEXPR17 _Array_iterator operator-(const ptrdiff_t _Off) const noexcept {
+    _NODISCARD _CONSTEXPR17 _Array_iterator operator-(const difference_type _Off) const noexcept {
         _Array_iterator _Tmp = *this;
         return _Tmp -= _Off;
     }
 
-    _NODISCARD _CONSTEXPR17 friend _Array_iterator operator+(const ptrdiff_t _Off, _Array_iterator _Next) noexcept {
+    _NODISCARD _CONSTEXPR17 friend _Array_iterator operator+(
+        const difference_type _Off, _Array_iterator _Next) noexcept {
         return _Next += _Off;
     }
 
-    template <bool _OtherConst>
+    template <_ConstIter _OtherConst>
     _NODISCARD _CONSTEXPR17 ptrdiff_t operator-(
         const _Array_iterator<_Ty, _OtherConst, _Checked>& _Right) const noexcept {
 #if _ITERATOR_DEBUG_LEVEL != 0
-        if constexpr (_Checked) {
+        if constexpr (_Checked == _CheckedIter::_Yes) {
             _STL_VERIFY(_Begin == _Right._Begin, "array iterators incompatible");
         }
 #endif // _ITERATOR_DEBUG_LEVEL != 0
         return _Ptr - _Right._Ptr;
     }
 
-    template <bool _OtherConst>
+    template <_ConstIter _OtherConst>
     _NODISCARD _CONSTEXPR17 bool operator==(const _Array_iterator<_Ty, _OtherConst, _Checked>& _Right) const noexcept {
 #if _ITERATOR_DEBUG_LEVEL != 0
-        if constexpr (_Checked) {
+        if constexpr (_Checked == _CheckedIter::_Yes) {
             _STL_VERIFY(_Begin == _Right._Begin, "array iterators incompatible");
         }
 #endif // _ITERATOR_DEBUG_LEVEL != 0
@@ -190,11 +191,11 @@ public:
     }
 
 #if _HAS_CXX20
-    template <bool _OtherConst>
+    template <_ConstIter _OtherConst>
     _NODISCARD constexpr strong_ordering operator<=>(
         const _Array_iterator<_Ty, _OtherConst, _Checked>& _Right) const noexcept {
 #if _ITERATOR_DEBUG_LEVEL != 0
-        if constexpr (_Checked) {
+        if constexpr (_Checked == _CheckedIter::_Yes) {
             _STL_VERIFY(_Begin == _Right._Begin, "array iterators incompatible");
         }
 #endif // _ITERATOR_DEBUG_LEVEL != 0
@@ -203,40 +204,40 @@ public:
 
 #else // ^^^ _HAS_CXX20 ^^^ / vvv !_HAS_CXX20 vvv
 
-    template <bool _OtherConst>
+    template <_ConstIter _OtherConst>
     _NODISCARD _CONSTEXPR17 bool operator!=(const _Array_iterator<_Ty, _OtherConst, _Checked>& _Right) const noexcept {
         return !(*this == _Right);
     }
 
-    template <bool _OtherConst>
+    template <_ConstIter _OtherConst>
     _NODISCARD _CONSTEXPR17 bool operator<(const _Array_iterator<_Ty, _OtherConst, _Checked>& _Right) const noexcept {
 #if _ITERATOR_DEBUG_LEVEL != 0
-        if constexpr (_Checked) {
+        if constexpr (_Checked == _CheckedIter::_Yes) {
             _STL_VERIFY(_Begin == _Right._Begin, "array iterators incompatible");
         }
 #endif // _ITERATOR_DEBUG_LEVEL != 0
         return _Ptr < _Right._Ptr;
     }
 
-    template <bool _OtherConst>
+    template <_ConstIter _OtherConst>
     _NODISCARD _CONSTEXPR17 bool operator>(const _Array_iterator<_Ty, _OtherConst, _Checked>& _Right) const noexcept {
         return _Right < *this;
     }
 
-    template <bool _OtherConst>
+    template <_ConstIter _OtherConst>
     _NODISCARD _CONSTEXPR17 bool operator<=(const _Array_iterator<_Ty, _OtherConst, _Checked>& _Right) const noexcept {
         return !(_Right < *this);
     }
 
-    template <bool _OtherConst>
+    template <_ConstIter _OtherConst>
     _NODISCARD _CONSTEXPR17 bool operator>=(const _Array_iterator<_Ty, _OtherConst, _Checked>& _Right) const noexcept {
         return !(*this < _Right);
     }
 #endif // !_HAS_CXX20
 
 #if _ITERATOR_DEBUG_LEVEL != 0
-    constexpr void _Verify_offset(const ptrdiff_t _Off) const noexcept {
-        if constexpr (_Checked) {
+    constexpr void _Verify_offset(const difference_type _Off) const noexcept {
+        if constexpr (_Checked == _CheckedIter::_Yes) {
             if (_Off != 0) {
                 _STL_VERIFY(_Ptr, "cannot seek value-initialized array iterator");
             }
@@ -251,10 +252,10 @@ public:
         }
     }
 
-    template <bool _OtherConst>
+    template <_ConstIter _OtherConst>
     friend constexpr void _Verify_range(
         const _Array_iterator& _First, const _Array_iterator<_Ty, _OtherConst, _Checked>& _Last) noexcept {
-        if constexpr (_Checked) {
+        if constexpr (_Checked == _CheckedIter::_Yes) {
             _STL_VERIFY(_First <= _Last, "array iterator range transposed");
         }
     }
@@ -273,7 +274,7 @@ public:
     }
 
 private:
-    template <class, bool, bool>
+    template <class, _ConstIter, _CheckedIter>
     friend class _Array_iterator;
 
     pointer _Ptr{}; // current position in array
@@ -284,10 +285,10 @@ private:
 };
 
 #if _HAS_CXX20
-template <class _Ty, bool _Const, bool _Checked>
+template <class _Ty, _ConstIter _Const, _CheckedIter _Checked>
 struct pointer_traits<_Array_iterator<_Ty, _Const, _Checked>> {
     using pointer         = _Array_iterator<_Ty, _Const, _Checked>;
-    using element_type    = _Maybe_const<_Const, _Ty>;
+    using element_type    = _Maybe_const<_Const == _ConstIter::_Yes, _Ty>;
     using difference_type = ptrdiff_t;
 
     _NODISCARD static constexpr element_type* to_address(const pointer _Iter) noexcept {
@@ -308,8 +309,8 @@ public:
     using reference       = _Ty&;
     using const_reference = const _Ty&;
 
-    using iterator       = _Array_iterator<_Ty, false, true>;
-    using const_iterator = _Array_iterator<_Ty, true, true>;
+    using iterator       = _Array_iterator<_Ty, _ConstIter::_No, _CheckedIter::_Yes>;
+    using const_iterator = _Array_iterator<_Ty, _ConstIter::_Yes, _CheckedIter::_Yes>;
 
     using reverse_iterator       = _STD reverse_iterator<iterator>;
     using const_reverse_iterator = _STD reverse_iterator<const_iterator>;
@@ -490,8 +491,8 @@ public:
     using reference       = _Ty&;
     using const_reference = const _Ty&;
 
-    using iterator               = _Array_iterator<_Ty, false, true>;
-    using const_iterator         = _Array_iterator<_Ty, true, true>;
+    using iterator               = _Array_iterator<_Ty, _ConstIter::_No, _CheckedIter::_Yes>;
+    using const_iterator         = _Array_iterator<_Ty, _ConstIter::_Yes, _CheckedIter::_Yes>;
     using reverse_iterator       = _STD reverse_iterator<iterator>;
     using const_reverse_iterator = _STD reverse_iterator<const_iterator>;
 

--- a/stl/inc/array
+++ b/stl/inc/array
@@ -18,20 +18,10 @@ _STL_DISABLE_CLANG_WARNINGS
 #undef new
 
 _STD_BEGIN
-// CLASS TEMPLATE _Array_const_iterator
-#if _ITERATOR_DEBUG_LEVEL != 0
-struct _Iterator_base12_compatible { // TRANSITION, for binary compatibility
-    _Container_proxy* _Myproxy{};
-    _Iterator_base12* _Mynextiter{};
-};
-#endif // _ITERATOR_DEBUG_LEVEL != 0
 
-template <class _Ty, size_t _Size>
-class _Array_const_iterator
-#if _ITERATOR_DEBUG_LEVEL != 0
-    : private _Iterator_base12_compatible
-#endif // _ITERATOR_DEBUG_LEVEL != 0
-{
+// CLASS TEMPLATE _Array_iterator
+template <class _Ty, bool _Const, bool _Checked>
+class _Array_iterator {
 public:
 #ifdef __cpp_lib_concepts
     using iterator_concept = contiguous_iterator_tag;
@@ -39,329 +29,118 @@ public:
     using iterator_category = random_access_iterator_tag;
     using value_type        = _Ty;
     using difference_type   = ptrdiff_t;
-    using pointer           = const _Ty*;
-    using reference         = const _Ty&;
+    using pointer           = _Maybe_const<_Const, _Ty>*;
+    using reference         = _Maybe_const<_Const, _Ty>&;
 
-    enum { _EEN_SIZE = _Size }; // helper for expression evaluator
+    _CONSTEXPR17 _Array_iterator() noexcept = default;
 
+    _CONSTEXPR17 explicit _Array_iterator(pointer _Ptr_, pointer _Begin_ = nullptr, pointer _End_ = nullptr) noexcept
 #if _ITERATOR_DEBUG_LEVEL == 0
-    _CONSTEXPR17 _Array_const_iterator() noexcept : _Ptr() {}
+        : _Ptr(_Ptr_) {
+        (void) _Begin_;
+        (void) _End_;
+    }
+#else // ^^^ _ITERATOR_DEBUG_LEVEL == 0 / _ITERATOR_DEBUG_LEVEL != 0 vvv
+        : _Ptr(_Ptr_), _Begin(_Begin_), _End(_End_) {
+        if constexpr (_Checked) {
+            _STL_VERIFY(_Begin <= _Ptr, "cannot create array iterator outside of bounds");
+            _STL_VERIFY(_Ptr <= _End, "cannot create array iterator outside of bounds");
+        }
+    }
+#endif // _ITERATOR_DEBUG_LEVEL != 0
 
-    _CONSTEXPR17 explicit _Array_const_iterator(pointer _Parg, size_t _Off = 0) noexcept : _Ptr(_Parg + _Off) {}
+    template <bool _IsConst = _Const, enable_if_t<_IsConst, int> = 0>
+    _CONSTEXPR17 _Array_iterator(const _Array_iterator<_Ty, !_IsConst, _Checked>& _It) noexcept
+#if _ITERATOR_DEBUG_LEVEL == 0
+        : _Ptr(_It._Ptr) {
+    }
+#else // ^^^ _ITERATOR_DEBUG_LEVEL == 0 / _ITERATOR_DEBUG_LEVEL != 0 vvv
+        : _Ptr(_It._Ptr), _Begin(_It._Begin), _End(_It._End) {
+    }
+#endif // _ITERATOR_DEBUG_LEVEL != 0
 
     _NODISCARD _CONSTEXPR17 reference operator*() const noexcept {
+#if _ITERATOR_DEBUG_LEVEL != 0
+        if constexpr (_Checked) {
+            _STL_VERIFY(_Ptr, "cannot dereference value-initialized array iterator");
+            _STL_VERIFY(_Begin <= _Ptr && _Ptr < _End, "cannot dereference out of range array iterator");
+        }
+#endif // _ITERATOR_DEBUG_LEVEL != 0
         return *_Ptr;
     }
 
     _NODISCARD _CONSTEXPR17 pointer operator->() const noexcept {
+#if _ITERATOR_DEBUG_LEVEL != 0
+        if constexpr (_Checked) {
+            _STL_VERIFY(_Ptr, "cannot dereference value-initialized array iterator");
+            _STL_VERIFY(_Begin <= _Ptr && _Ptr < _End, "cannot dereference out of range array iterator");
+        }
+#endif // _ITERATOR_DEBUG_LEVEL != 0
         return _Ptr;
     }
 
-    _CONSTEXPR17 _Array_const_iterator& operator++() noexcept {
-        ++_Ptr;
-        return *this;
-    }
-
-    _CONSTEXPR17 _Array_const_iterator operator++(int) noexcept {
-        _Array_const_iterator _Tmp = *this;
-        ++_Ptr;
-        return _Tmp;
-    }
-
-    _CONSTEXPR17 _Array_const_iterator& operator--() noexcept {
-        --_Ptr;
-        return *this;
-    }
-
-    _CONSTEXPR17 _Array_const_iterator operator--(int) noexcept {
-        _Array_const_iterator _Tmp = *this;
-        --_Ptr;
-        return _Tmp;
-    }
-
-    _CONSTEXPR17 _Array_const_iterator& operator+=(const ptrdiff_t _Off) noexcept {
-        _Ptr += _Off;
-        return *this;
-    }
-
-    _NODISCARD _CONSTEXPR17 _Array_const_iterator operator+(const ptrdiff_t _Off) const noexcept {
-        _Array_const_iterator _Tmp = *this;
-        return _Tmp += _Off;
-    }
-
-    _CONSTEXPR17 _Array_const_iterator& operator-=(const ptrdiff_t _Off) noexcept {
-        _Ptr -= _Off;
-        return *this;
-    }
-
-    _NODISCARD _CONSTEXPR17 _Array_const_iterator operator-(const ptrdiff_t _Off) const noexcept {
-        _Array_const_iterator _Tmp = *this;
-        return _Tmp -= _Off;
-    }
-
-    _NODISCARD _CONSTEXPR17 ptrdiff_t operator-(const _Array_const_iterator& _Right) const noexcept {
-        return _Ptr - _Right._Ptr;
-    }
-
     _NODISCARD _CONSTEXPR17 reference operator[](const ptrdiff_t _Off) const noexcept {
+#if _ITERATOR_DEBUG_LEVEL != 0
+        if constexpr (_Checked) {
+            _Verify_offset(_Off);
+        }
+#endif // _ITERATOR_DEBUG_LEVEL != 0
         return _Ptr[_Off];
     }
 
-    _NODISCARD _CONSTEXPR17 bool operator==(const _Array_const_iterator& _Right) const noexcept {
-        return _Ptr == _Right._Ptr;
-    }
-
-    _NODISCARD _CONSTEXPR17 bool operator!=(const _Array_const_iterator& _Right) const noexcept {
-        return !(*this == _Right);
-    }
-
-    _NODISCARD _CONSTEXPR17 bool operator<(const _Array_const_iterator& _Right) const noexcept {
-        return _Ptr < _Right._Ptr;
-    }
-
-    _NODISCARD _CONSTEXPR17 bool operator>(const _Array_const_iterator& _Right) const noexcept {
-        return _Right < *this;
-    }
-
-    _NODISCARD _CONSTEXPR17 bool operator<=(const _Array_const_iterator& _Right) const noexcept {
-        return !(_Right < *this);
-    }
-
-    _NODISCARD _CONSTEXPR17 bool operator>=(const _Array_const_iterator& _Right) const noexcept {
-        return !(*this < _Right);
-    }
-
-    using _Prevent_inheriting_unwrap = _Array_const_iterator;
-
-    _NODISCARD constexpr pointer _Unwrapped() const noexcept {
-        return _Ptr;
-    }
-
-    static constexpr bool _Unwrap_when_unverified = true;
-
-    constexpr void _Seek_to(pointer _It) noexcept {
-        _Ptr = _It;
-    }
-
-private:
-    pointer _Ptr; // beginning of array
-
-#else // ^^^ _ITERATOR_DEBUG_LEVEL == 0 / _ITERATOR_DEBUG_LEVEL != 0 vvv
-    _CONSTEXPR17 _Array_const_iterator() noexcept : _Ptr(), _Idx(0) {}
-
-    _CONSTEXPR17 explicit _Array_const_iterator(pointer _Parg, size_t _Off = 0) noexcept : _Ptr(_Parg), _Idx(_Off) {}
-
-    _NODISCARD _CONSTEXPR17 reference operator*() const noexcept {
-        return *operator->();
-    }
-
-    _NODISCARD _CONSTEXPR17 pointer operator->() const noexcept {
-        _STL_VERIFY(_Ptr, "cannot dereference value-initialized array iterator");
-        _STL_VERIFY(_Idx < _Size, "cannot dereference out of range array iterator");
-        return _Ptr + _Idx;
-    }
-
-    _CONSTEXPR17 _Array_const_iterator& operator++() noexcept {
-        _STL_VERIFY(_Ptr, "cannot increment value-initialized array iterator");
-        _STL_VERIFY(_Idx < _Size, "cannot increment array iterator past end");
-        ++_Idx;
-        return *this;
-    }
-
-    _CONSTEXPR17 _Array_const_iterator operator++(int) noexcept {
-        _Array_const_iterator _Tmp = *this;
-        ++*this;
-        return _Tmp;
-    }
-
-    _CONSTEXPR17 _Array_const_iterator& operator--() noexcept {
-        _STL_VERIFY(_Ptr, "cannot decrement value-initialized array iterator");
-        _STL_VERIFY(_Idx != 0, "cannot decrement array iterator before begin");
-        --_Idx;
-        return *this;
-    }
-
-    _CONSTEXPR17 _Array_const_iterator operator--(int) noexcept {
-        _Array_const_iterator _Tmp = *this;
-        --*this;
-        return _Tmp;
-    }
-
-    constexpr void _Verify_offset(const ptrdiff_t _Off) const noexcept {
-        if (_Off != 0) {
-            _STL_VERIFY(_Ptr, "cannot seek value-initialized array iterator");
-        }
-
-        if (_Off < 0) {
-            _STL_VERIFY(_Idx >= size_t{0} - static_cast<size_t>(_Off), "cannot seek array iterator before begin");
-        }
-
-        if (_Off > 0) {
-            _STL_VERIFY(_Size - _Idx >= static_cast<size_t>(_Off), "cannot seek array iterator after end");
-        }
-    }
-
-    _CONSTEXPR17 _Array_const_iterator& operator+=(const ptrdiff_t _Off) noexcept {
-        _Verify_offset(_Off);
-        _Idx += static_cast<size_t>(_Off);
-        return *this;
-    }
-
-    _NODISCARD _CONSTEXPR17 _Array_const_iterator operator+(const ptrdiff_t _Off) const noexcept {
-        _Array_const_iterator _Tmp = *this;
-        return _Tmp += _Off;
-    }
-
-    _CONSTEXPR17 _Array_const_iterator& operator-=(const ptrdiff_t _Off) noexcept {
-        return *this += -_Off;
-    }
-
-    _NODISCARD _CONSTEXPR17 _Array_const_iterator operator-(const ptrdiff_t _Off) const noexcept {
-        _Array_const_iterator _Tmp = *this;
-        return _Tmp -= _Off;
-    }
-
-    _NODISCARD _CONSTEXPR17 ptrdiff_t operator-(const _Array_const_iterator& _Right) const noexcept {
-        _Compat(_Right);
-        return static_cast<ptrdiff_t>(_Idx - _Right._Idx);
-    }
-
-    _NODISCARD _CONSTEXPR17 reference operator[](const ptrdiff_t _Off) const noexcept {
-        return *(*this + _Off);
-    }
-
-    _NODISCARD _CONSTEXPR17 bool operator==(const _Array_const_iterator& _Right) const noexcept {
-        _Compat(_Right);
-        return _Idx == _Right._Idx;
-    }
-
-    _NODISCARD _CONSTEXPR17 bool operator!=(const _Array_const_iterator& _Right) const noexcept {
-        return !(*this == _Right);
-    }
-
-    _NODISCARD _CONSTEXPR17 bool operator<(const _Array_const_iterator& _Right) const noexcept {
-        _Compat(_Right);
-        return _Idx < _Right._Idx;
-    }
-
-    _NODISCARD _CONSTEXPR17 bool operator>(const _Array_const_iterator& _Right) const noexcept {
-        return _Right < *this;
-    }
-
-    _NODISCARD _CONSTEXPR17 bool operator<=(const _Array_const_iterator& _Right) const noexcept {
-        return !(_Right < *this);
-    }
-
-    _NODISCARD _CONSTEXPR17 bool operator>=(const _Array_const_iterator& _Right) const noexcept {
-        return !(*this < _Right);
-    }
-
-    _CONSTEXPR17 void _Compat(const _Array_const_iterator& _Right) const noexcept { // test for compatible iterator pair
-        _STL_VERIFY(_Ptr == _Right._Ptr, "array iterators incompatible");
-    }
-
-    using _Prevent_inheriting_unwrap = _Array_const_iterator;
-
-    _NODISCARD constexpr pointer _Unwrapped() const noexcept {
-        return _Ptr + _Idx;
-    }
-
-    constexpr void _Verify_with(const _Array_const_iterator& _Last) const noexcept {
-        // note _Compat check inside operator<=
-        _STL_VERIFY(*this <= _Last, "array iterator range transposed");
-    }
-
-    constexpr void _Seek_to(pointer _It) noexcept {
-        _Idx = static_cast<size_t>(_It - _Ptr);
-    }
-
-private:
-    pointer _Ptr; // beginning of array
-    size_t _Idx; // offset into array
-#endif // _ITERATOR_DEBUG_LEVEL == 0
-};
-
-#if _ITERATOR_DEBUG_LEVEL != 0
-template <class _Ty, size_t _Size>
-constexpr void _Verify_range(
-    const _Array_const_iterator<_Ty, _Size>& _First, const _Array_const_iterator<_Ty, _Size>& _Last) noexcept {
-    // TRANSITION, CUDA
-    _First._Verify_with(_Last);
-}
-#endif // _ITERATOR_DEBUG_LEVEL != 0
-
-template <class _Ty, size_t _Size>
-_NODISCARD _CONSTEXPR17 _Array_const_iterator<_Ty, _Size> operator+(
-    const ptrdiff_t _Off, _Array_const_iterator<_Ty, _Size> _Next) noexcept {
-    return _Next += _Off;
-}
-
-#if _HAS_CXX20
-template <class _Ty, size_t _Size>
-struct pointer_traits<_Array_const_iterator<_Ty, _Size>> {
-    using pointer         = _Array_const_iterator<_Ty, _Size>;
-    using element_type    = const _Ty;
-    using difference_type = ptrdiff_t;
-
-    _NODISCARD static constexpr element_type* to_address(const pointer _Iter) noexcept {
-        return _Iter._Unwrapped();
-    }
-};
-#endif // _HAS_CXX20
-
-// CLASS TEMPLATE _Array_iterator
-template <class _Ty, size_t _Size>
-class _Array_iterator : public _Array_const_iterator<_Ty, _Size> {
-public:
-    using _Mybase = _Array_const_iterator<_Ty, _Size>;
-
-#ifdef __cpp_lib_concepts
-    using iterator_concept = contiguous_iterator_tag;
-#endif // __cpp_lib_concepts
-    using iterator_category = random_access_iterator_tag;
-    using value_type        = _Ty;
-    using difference_type   = ptrdiff_t;
-    using pointer           = _Ty*;
-    using reference         = _Ty&;
-
-    enum { _EEN_SIZE = _Size }; // helper for expression evaluator
-
-    _CONSTEXPR17 _Array_iterator() noexcept {}
-
-    _CONSTEXPR17 explicit _Array_iterator(pointer _Parg, size_t _Off = 0) noexcept : _Mybase(_Parg, _Off) {}
-
-    _NODISCARD _CONSTEXPR17 reference operator*() const noexcept {
-        return const_cast<reference>(_Mybase::operator*());
-    }
-
-    _NODISCARD _CONSTEXPR17 pointer operator->() const noexcept {
-        return const_cast<pointer>(_Mybase::operator->());
-    }
-
     _CONSTEXPR17 _Array_iterator& operator++() noexcept {
-        _Mybase::operator++();
+#if _ITERATOR_DEBUG_LEVEL != 0
+        if constexpr (_Checked) {
+            _STL_VERIFY(_Ptr, "cannot increment value-initialized array iterator");
+            _STL_VERIFY(_Ptr < _End, "cannot increment array iterator past end");
+        }
+#endif // _ITERATOR_DEBUG_LEVEL != 0
+        ++_Ptr;
         return *this;
     }
 
     _CONSTEXPR17 _Array_iterator operator++(int) noexcept {
+#if _ITERATOR_DEBUG_LEVEL != 0
+        if constexpr (_Checked) {
+            _STL_VERIFY(_Ptr, "cannot increment value-initialized array iterator");
+            _STL_VERIFY(_Ptr < _End, "cannot increment array iterator past end");
+        }
+#endif // _ITERATOR_DEBUG_LEVEL != 0
         _Array_iterator _Tmp = *this;
-        _Mybase::operator++();
+        ++_Ptr;
         return _Tmp;
     }
 
     _CONSTEXPR17 _Array_iterator& operator--() noexcept {
-        _Mybase::operator--();
+#if _ITERATOR_DEBUG_LEVEL != 0
+        if constexpr (_Checked) {
+            _STL_VERIFY(_Ptr, "cannot decrement value-initialized array iterator");
+            _STL_VERIFY(_Begin < _Ptr, "cannot decrement array iterator before begin");
+        }
+#endif // _ITERATOR_DEBUG_LEVEL != 0
+        --_Ptr;
         return *this;
     }
 
     _CONSTEXPR17 _Array_iterator operator--(int) noexcept {
+#if _ITERATOR_DEBUG_LEVEL != 0
+        if constexpr (_Checked) {
+            _STL_VERIFY(_Ptr, "cannot decrement value-initialized array iterator");
+            _STL_VERIFY(_Begin < _Ptr, "cannot decrement array iterator before begin");
+        }
+#endif // _ITERATOR_DEBUG_LEVEL != 0
         _Array_iterator _Tmp = *this;
-        _Mybase::operator--();
+        --_Ptr;
         return _Tmp;
     }
 
     _CONSTEXPR17 _Array_iterator& operator+=(const ptrdiff_t _Off) noexcept {
-        _Mybase::operator+=(_Off);
+#if _ITERATOR_DEBUG_LEVEL != 0
+        if constexpr (_Checked) {
+            _Verify_offset(_Off);
+        }
+#endif // _ITERATOR_DEBUG_LEVEL != 0
+        _Ptr += _Off;
         return *this;
     }
 
@@ -371,39 +150,144 @@ public:
     }
 
     _CONSTEXPR17 _Array_iterator& operator-=(const ptrdiff_t _Off) noexcept {
-        _Mybase::operator-=(_Off);
+#if _ITERATOR_DEBUG_LEVEL != 0
+        if constexpr (_Checked) {
+            _Verify_offset(-_Off);
+        }
+#endif // _ITERATOR_DEBUG_LEVEL != 0
+        _Ptr -= _Off;
         return *this;
     }
-
-    using _Mybase::operator-;
 
     _NODISCARD _CONSTEXPR17 _Array_iterator operator-(const ptrdiff_t _Off) const noexcept {
         _Array_iterator _Tmp = *this;
         return _Tmp -= _Off;
     }
 
-    _NODISCARD _CONSTEXPR17 reference operator[](const ptrdiff_t _Off) const noexcept {
-        return const_cast<reference>(_Mybase::operator[](_Off));
+    _NODISCARD _CONSTEXPR17 friend _Array_iterator operator+(const ptrdiff_t _Off, _Array_iterator _Next) noexcept {
+        return _Next += _Off;
     }
+
+    template <bool _OtherConst>
+    _NODISCARD _CONSTEXPR17 ptrdiff_t operator-(
+        const _Array_iterator<_Ty, _OtherConst, _Checked>& _Right) const noexcept {
+#if _ITERATOR_DEBUG_LEVEL != 0
+        if constexpr (_Checked) {
+            _STL_VERIFY(_Begin == _Right._Begin, "array iterators incompatible");
+        }
+#endif // _ITERATOR_DEBUG_LEVEL != 0
+        return _Ptr - _Right._Ptr;
+    }
+
+    template <bool _OtherConst>
+    _NODISCARD _CONSTEXPR17 bool operator==(const _Array_iterator<_Ty, _OtherConst, _Checked>& _Right) const noexcept {
+#if _ITERATOR_DEBUG_LEVEL != 0
+        if constexpr (_Checked) {
+            _STL_VERIFY(_Begin == _Right._Begin, "array iterators incompatible");
+        }
+#endif // _ITERATOR_DEBUG_LEVEL != 0
+        return _Ptr == _Right._Ptr;
+    }
+
+#if _HAS_CXX20
+    template <bool _OtherConst>
+    _NODISCARD constexpr strong_ordering operator<=>(
+        const _Array_iterator<_Ty, _OtherConst, _Checked>& _Right) const noexcept {
+#if _ITERATOR_DEBUG_LEVEL != 0
+        if constexpr (_Checked) {
+            _STL_VERIFY(_Begin == _Right._Begin, "array iterators incompatible");
+        }
+#endif // _ITERATOR_DEBUG_LEVEL != 0
+        return _Ptr <=> _Right._Ptr;
+    }
+
+#else // ^^^ _HAS_CXX20 ^^^ / vvv !_HAS_CXX20 vvv
+
+    template <bool _OtherConst>
+    _NODISCARD _CONSTEXPR17 bool operator!=(const _Array_iterator<_Ty, _OtherConst, _Checked>& _Right) const noexcept {
+        return !(*this == _Right);
+    }
+
+    template <bool _OtherConst>
+    _NODISCARD _CONSTEXPR17 bool operator<(const _Array_iterator<_Ty, _OtherConst, _Checked>& _Right) const noexcept {
+#if _ITERATOR_DEBUG_LEVEL != 0
+        if constexpr (_Checked) {
+            _STL_VERIFY(_Begin == _Right._Begin, "array iterators incompatible");
+        }
+#endif // _ITERATOR_DEBUG_LEVEL != 0
+        return _Ptr < _Right._Ptr;
+    }
+
+    template <bool _OtherConst>
+    _NODISCARD _CONSTEXPR17 bool operator>(const _Array_iterator<_Ty, _OtherConst, _Checked>& _Right) const noexcept {
+        return _Right < *this;
+    }
+
+    template <bool _OtherConst>
+    _NODISCARD _CONSTEXPR17 bool operator<=(const _Array_iterator<_Ty, _OtherConst, _Checked>& _Right) const noexcept {
+        return !(_Right < *this);
+    }
+
+    template <bool _OtherConst>
+    _NODISCARD _CONSTEXPR17 bool operator>=(const _Array_iterator<_Ty, _OtherConst, _Checked>& _Right) const noexcept {
+        return !(*this < _Right);
+    }
+#endif // !_HAS_CXX20
+
+#if _ITERATOR_DEBUG_LEVEL != 0
+    constexpr void _Verify_offset(const ptrdiff_t _Off) const noexcept {
+        if constexpr (_Checked) {
+            if (_Off != 0) {
+                _STL_VERIFY(_Ptr, "cannot seek value-initialized array iterator");
+            }
+
+            if (_Off < 0) {
+                _STL_VERIFY(_Ptr - _Begin >= -_Off, "cannot seek array iterator before begin");
+            }
+
+            if (_Off > 0) {
+                _STL_VERIFY(_End - _Ptr >= _Off, "cannot seek array iterator after end");
+            }
+        }
+    }
+
+    template <bool _OtherConst>
+    friend constexpr void _Verify_range(
+        const _Array_iterator& _First, const _Array_iterator<_Ty, _OtherConst, _Checked>& _Last) noexcept {
+        if constexpr (_Checked) {
+            _STL_VERIFY(_First <= _Last, "array iterator range transposed");
+        }
+    }
+#endif // _ITERATOR_DEBUG_LEVEL != 0
 
     using _Prevent_inheriting_unwrap = _Array_iterator;
 
     _NODISCARD constexpr pointer _Unwrapped() const noexcept {
-        return const_cast<pointer>(_Mybase::_Unwrapped());
+        return _Ptr;
     }
+
+    static constexpr bool _Unwrap_when_unverified = _ITERATOR_DEBUG_LEVEL == 0;
+
+    constexpr void _Seek_to(pointer _It) noexcept {
+        _Ptr = _It;
+    }
+
+private:
+    template <class, bool, bool>
+    friend class _Array_iterator;
+
+    pointer _Ptr{}; // current position in array
+#if _ITERATOR_DEBUG_LEVEL != 0
+    pointer _Begin{}; // beginning of array
+    pointer _End{}; // end of array
+#endif // _ITERATOR_DEBUG_LEVEL != 0
 };
 
-template <class _Ty, size_t _Size>
-_NODISCARD _CONSTEXPR17 _Array_iterator<_Ty, _Size> operator+(
-    const ptrdiff_t _Off, _Array_iterator<_Ty, _Size> _Next) noexcept {
-    return _Next += _Off;
-}
-
 #if _HAS_CXX20
-template <class _Ty, size_t _Size>
-struct pointer_traits<_Array_iterator<_Ty, _Size>> {
-    using pointer         = _Array_iterator<_Ty, _Size>;
-    using element_type    = _Ty;
+template <class _Ty, bool _Const, bool _Checked>
+struct pointer_traits<_Array_iterator<_Ty, _Const, _Checked>> {
+    using pointer         = _Array_iterator<_Ty, _Const, _Checked>;
+    using element_type    = _Maybe_const<_Const, _Ty>;
     using difference_type = ptrdiff_t;
 
     _NODISCARD static constexpr element_type* to_address(const pointer _Iter) noexcept {
@@ -414,7 +298,7 @@ struct pointer_traits<_Array_iterator<_Ty, _Size>> {
 
 // CLASS TEMPLATE array
 template <class _Ty, size_t _Size>
-class array { // fixed size array of values
+class array {
 public:
     using value_type      = _Ty;
     using size_type       = size_t;
@@ -424,8 +308,8 @@ public:
     using reference       = _Ty&;
     using const_reference = const _Ty&;
 
-    using iterator       = _Array_iterator<_Ty, _Size>;
-    using const_iterator = _Array_const_iterator<_Ty, _Size>;
+    using iterator       = _Array_iterator<_Ty, false, true>;
+    using const_iterator = _Array_iterator<_Ty, true, true>;
 
     using reverse_iterator       = _STD reverse_iterator<iterator>;
     using const_reverse_iterator = _STD reverse_iterator<const_iterator>;
@@ -445,51 +329,51 @@ public:
     }
 
     _NODISCARD _CONSTEXPR17 iterator begin() noexcept {
-        return iterator(_Elems, 0);
+        return iterator{_Elems, _Elems, _Elems + _Size};
     }
 
     _NODISCARD _CONSTEXPR17 const_iterator begin() const noexcept {
-        return const_iterator(_Elems, 0);
+        return const_iterator{_Elems, _Elems, _Elems + _Size};
     }
 
     _NODISCARD _CONSTEXPR17 iterator end() noexcept {
-        return iterator(_Elems, _Size);
+        return iterator{_Elems + _Size, _Elems, _Elems + _Size};
     }
 
     _NODISCARD _CONSTEXPR17 const_iterator end() const noexcept {
-        return const_iterator(_Elems, _Size);
+        return const_iterator{_Elems + _Size, _Elems, _Elems + _Size};
     }
 
     _NODISCARD _CONSTEXPR17 reverse_iterator rbegin() noexcept {
-        return reverse_iterator(end());
+        return reverse_iterator(iterator{_Elems + _Size, _Elems, _Elems + _Size});
     }
 
     _NODISCARD _CONSTEXPR17 const_reverse_iterator rbegin() const noexcept {
-        return const_reverse_iterator(end());
+        return const_reverse_iterator(const_iterator{_Elems + _Size, _Elems, _Elems + _Size});
     }
 
     _NODISCARD _CONSTEXPR17 reverse_iterator rend() noexcept {
-        return reverse_iterator(begin());
+        return reverse_iterator(iterator{_Elems, _Elems, _Elems + _Size});
     }
 
     _NODISCARD _CONSTEXPR17 const_reverse_iterator rend() const noexcept {
-        return const_reverse_iterator(begin());
+        return const_reverse_iterator(const_iterator{_Elems, _Elems, _Elems + _Size});
     }
 
     _NODISCARD _CONSTEXPR17 const_iterator cbegin() const noexcept {
-        return begin();
+        return const_iterator{_Elems, _Elems, _Elems + _Size};
     }
 
     _NODISCARD _CONSTEXPR17 const_iterator cend() const noexcept {
-        return end();
+        return const_iterator{_Elems + _Size, _Elems, _Elems + _Size};
     }
 
     _NODISCARD _CONSTEXPR17 const_reverse_iterator crbegin() const noexcept {
-        return rbegin();
+        return const_reverse_iterator(const_iterator{_Elems + _Size, _Elems, _Elems + _Size});
     }
 
     _NODISCARD _CONSTEXPR17 const_reverse_iterator crend() const noexcept {
-        return rend();
+        return const_reverse_iterator(const_iterator{_Elems, _Elems, _Elems + _Size});
     }
 
     _CONSTEXPR17 _Ty* _Unchecked_begin() noexcept {
@@ -540,7 +424,6 @@ public:
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(_Pos < _Size, "array subscript out of range");
 #endif // _CONTAINER_DEBUG_LEVEL > 0
-
         return _Elems[_Pos];
     }
 
@@ -549,7 +432,6 @@ public:
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(_Pos < _Size, "array subscript out of range");
 #endif // _CONTAINER_DEBUG_LEVEL > 0
-
         return _Elems[_Pos];
     }
 
@@ -608,8 +490,8 @@ public:
     using reference       = _Ty&;
     using const_reference = const _Ty&;
 
-    using iterator               = _Array_iterator<_Ty, 0>;
-    using const_iterator         = _Array_const_iterator<_Ty, 0>;
+    using iterator               = _Array_iterator<_Ty, false, true>;
+    using const_iterator         = _Array_iterator<_Ty, true, true>;
     using reverse_iterator       = _STD reverse_iterator<iterator>;
     using const_reverse_iterator = _STD reverse_iterator<const_iterator>;
 
@@ -638,35 +520,35 @@ public:
     }
 
     _NODISCARD _CONSTEXPR17 reverse_iterator rbegin() noexcept {
-        return reverse_iterator(end());
+        return reverse_iterator{iterator{}};
     }
 
     _NODISCARD _CONSTEXPR17 const_reverse_iterator rbegin() const noexcept {
-        return const_reverse_iterator(end());
+        return const_reverse_iterator{const_iterator{}};
     }
 
     _NODISCARD _CONSTEXPR17 reverse_iterator rend() noexcept {
-        return reverse_iterator(begin());
+        return reverse_iterator{iterator{}};
     }
 
     _NODISCARD _CONSTEXPR17 const_reverse_iterator rend() const noexcept {
-        return const_reverse_iterator(begin());
+        return const_reverse_iterator{const_iterator{}};
     }
 
     _NODISCARD _CONSTEXPR17 const_iterator cbegin() const noexcept {
-        return begin();
+        return const_iterator{};
     }
 
     _NODISCARD _CONSTEXPR17 const_iterator cend() const noexcept {
-        return end();
+        return const_iterator{};
     }
 
     _NODISCARD _CONSTEXPR17 const_reverse_iterator crbegin() const noexcept {
-        return rbegin();
+        return const_reverse_iterator{const_iterator{}};
     }
 
     _NODISCARD _CONSTEXPR17 const_reverse_iterator crend() const noexcept {
-        return rend();
+        return const_reverse_iterator{const_iterator{}};
     }
 
     _CONSTEXPR17 _Ty* _Unchecked_begin() noexcept {
@@ -709,7 +591,6 @@ public:
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_REPORT_ERROR("array subscript out of range");
 #endif // _CONTAINER_DEBUG_LEVEL > 0
-
         return _Elems[0];
     }
 
@@ -717,7 +598,6 @@ public:
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_REPORT_ERROR("array subscript out of range");
 #endif // _CONTAINER_DEBUG_LEVEL > 0
-
         return _Elems[0];
     }
 
@@ -725,7 +605,6 @@ public:
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_REPORT_ERROR("array<T, 0>::front() invalid");
 #endif // _CONTAINER_DEBUG_LEVEL > 0
-
         return _Elems[0];
     }
 
@@ -733,7 +612,6 @@ public:
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_REPORT_ERROR("array<T, 0>::front() invalid");
 #endif // _CONTAINER_DEBUG_LEVEL > 0
-
         return _Elems[0];
     }
 
@@ -741,7 +619,6 @@ public:
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_REPORT_ERROR("array<T, 0>::back() invalid");
 #endif // _CONTAINER_DEBUG_LEVEL > 0
-
         return _Elems[0];
     }
 
@@ -749,7 +626,6 @@ public:
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_REPORT_ERROR("array<T, 0>::back() invalid");
 #endif // _CONTAINER_DEBUG_LEVEL > 0
-
         return _Elems[0];
     }
 

--- a/stl/inc/deque
+++ b/stl/inc/deque
@@ -23,10 +23,10 @@ _STL_DISABLE_CLANG_WARNINGS
 
 _STD_BEGIN
 // CLASS TEMPLATE _Deque_iterator
-template <class _Mydeque, bool _Const, bool _Checked>
+template <class _Mydeque, _ConstIter _Const, _CheckedIter _Checked>
 class _Deque_iterator : public _Iterator_base12 {
 private:
-    template <class, bool, bool>
+    template <class, _ConstIter, _CheckedIter>
     friend class _Deque_iterator;
 
     using _Size_type = typename _Mydeque::size_type;
@@ -42,8 +42,9 @@ public:
     using iterator_category = random_access_iterator_tag;
     using value_type        = typename _Mydeque::value_type;
     using difference_type   = typename _Mydeque::difference_type;
-    using pointer           = conditional_t<_Const, typename _Mydeque::const_pointer, typename _Mydeque::pointer>;
-    using reference         = _Maybe_const<_Const, value_type>&;
+    using pointer =
+        conditional_t<_Const == _ConstIter::_Yes, typename _Mydeque::const_pointer, typename _Mydeque::pointer>;
+    using reference = _Maybe_const<_Const == _ConstIter::_Yes, value_type>&;
 
     using _Mydeque_t = _Mydeque; // helper for expression evaluator
     enum { _EEN_DS = _Block_size }; // helper for expression evaluator
@@ -51,7 +52,7 @@ public:
     _Deque_iterator() noexcept = default;
 
     explicit _Deque_iterator(_Size_type _Off, const _Container_base12* _Cont) noexcept : _Myoff(_Off) {
-        if constexpr (_Checked) {
+        if constexpr (_Checked == _CheckedIter::_Yes) {
             const auto _Cont_ = static_cast<const _Mydeque*>(_Cont);
             _STL_VERIFY(_Cont_, "Construct deque iterator without container");
             _STL_VERIFY(_Cont_->_Myoff <= _Myoff && _Myoff <= _Cont_->_Myoff + _Cont_->_Mysize,
@@ -60,14 +61,14 @@ public:
         this->_Adopt(_Cont);
     }
 
-    template <bool _IsConst = _Const, enable_if_t<_IsConst, int> = 0>
-    _Deque_iterator(const _Deque_iterator<_Mydeque, !_IsConst, _Checked>& _It) noexcept : _Myoff(_It._Myoff) {
+    template <_ConstIter _IsConst = _Const, enable_if_t<_IsConst == _ConstIter::_Yes, int> = 0>
+    _Deque_iterator(const _Deque_iterator<_Mydeque, _ConstIter::_No, _Checked>& _It) noexcept : _Myoff(_It._Myoff) {
         this->_Adopt(_It._Getcont());
     }
 
     _NODISCARD reference operator*() const noexcept {
         const auto _Cont = static_cast<const _Mydeque*>(this->_Getcont());
-        if constexpr (_Checked) {
+        if constexpr (_Checked == _CheckedIter::_Yes) {
             _STL_VERIFY(_Cont, "cannot dereference value-initialized deque iterator");
             _STL_VERIFY(_Cont->_Myoff <= _Myoff && _Myoff < _Cont->_Myoff + _Cont->_Mysize,
                 "cannot deference out of range deque iterator");
@@ -84,7 +85,7 @@ public:
     _NODISCARD reference operator[](const difference_type _Off_) const noexcept {
         const auto _Cont    = static_cast<const _Mydeque*>(this->_Getcont());
         const auto _New_pos = _Myoff + _Off_;
-        if constexpr (_Checked) {
+        if constexpr (_Checked == _CheckedIter::_Yes) {
             _STL_VERIFY(_Cont, "cannot subscript value-initialized deque iterator");
             _STL_VERIFY(_Cont->_Myoff <= _New_pos && _New_pos < _Cont->_Myoff + _Cont->_Mysize,
                 "cannot subscript out of range deque iterator");
@@ -95,7 +96,7 @@ public:
     }
 
     _Deque_iterator& operator++() noexcept {
-        if constexpr (_Checked) {
+        if constexpr (_Checked == _CheckedIter::_Yes) {
             const auto _Cont = static_cast<const _Mydeque*>(this->_Getcont());
             _STL_VERIFY(_Cont, "cannot increment value-initialized deque iterator");
             _STL_VERIFY(_Myoff < _Cont->_Myoff + _Cont->_Mysize, "cannot increment deque iterator past end");
@@ -105,7 +106,7 @@ public:
     }
 
     _Deque_iterator operator++(int) noexcept {
-        if constexpr (_Checked) {
+        if constexpr (_Checked == _CheckedIter::_Yes) {
             const auto _Cont = static_cast<const _Mydeque*>(this->_Getcont());
             _STL_VERIFY(_Cont, "cannot increment value-initialized deque iterator");
             _STL_VERIFY(_Myoff < _Cont->_Myoff + _Cont->_Mysize, "cannot increment deque iterator past end");
@@ -116,7 +117,7 @@ public:
     }
 
     _Deque_iterator& operator--() noexcept {
-        if constexpr (_Checked) {
+        if constexpr (_Checked == _CheckedIter::_Yes) {
             const auto _Cont = static_cast<const _Mydeque*>(this->_Getcont());
             _STL_VERIFY(_Cont, "cannot decrement value-initialized deque iterator");
             _STL_VERIFY(_Cont->_Myoff < _Myoff, "cannot decrement deque iterator past end");
@@ -126,7 +127,7 @@ public:
     }
 
     _Deque_iterator operator--(int) noexcept {
-        if constexpr (_Checked) {
+        if constexpr (_Checked == _CheckedIter::_Yes) {
             const auto _Cont = static_cast<const _Mydeque*>(this->_Getcont());
             _STL_VERIFY(_Cont, "cannot decrement value-initialized deque iterator");
             _STL_VERIFY(_Cont->_Myoff < _Myoff, "cannot decrement deque iterator past end");
@@ -137,7 +138,7 @@ public:
     }
 
     _Deque_iterator& operator+=(const difference_type _Off) noexcept {
-        if constexpr (_Checked) {
+        if constexpr (_Checked == _CheckedIter::_Yes) {
             if (_Off != 0) {
                 const auto _Cont = static_cast<const _Mydeque*>(this->_Getcont());
                 _STL_VERIFY(_Cont, "cannot seek value-initialized deque iterator");
@@ -155,7 +156,7 @@ public:
     }
 
     _Deque_iterator& operator-=(const difference_type _Off) noexcept {
-        if constexpr (_Checked) {
+        if constexpr (_Checked == _CheckedIter::_Yes) {
             if (_Off != 0) {
                 const auto _Cont = static_cast<const _Mydeque*>(this->_Getcont());
                 _STL_VERIFY(_Cont, "cannot seek value-initialized deque iterator");
@@ -176,28 +177,28 @@ public:
         return _Next += _Off;
     }
 
-    template <bool _OtherConst>
+    template <_ConstIter _OtherConst>
     _NODISCARD difference_type operator-(
         const _Deque_iterator<_Mydeque, _OtherConst, _Checked>& _Right) const noexcept {
-        if constexpr (_Checked) {
+        if constexpr (_Checked == _CheckedIter::_Yes) {
             _STL_VERIFY(this->_Getcont() == _Right._Getcont(), "deque iterators incompatible");
         }
         return static_cast<difference_type>(_Myoff - _Right._Myoff);
     }
 
-    template <bool _OtherConst>
+    template <_ConstIter _OtherConst>
     _NODISCARD bool operator==(const _Deque_iterator<_Mydeque, _OtherConst, _Checked>& _Right) const noexcept {
-        if constexpr (_Checked) {
+        if constexpr (_Checked == _CheckedIter::_Yes) {
             _STL_VERIFY(this->_Getcont() == _Right._Getcont(), "deque iterators incompatible");
         }
         return _Myoff == _Right._Myoff;
     }
 
 #if _HAS_CXX20
-    template <bool _OtherConst>
+    template <_ConstIter _OtherConst>
     _NODISCARD constexpr strong_ordering operator<=>(
         const _Deque_iterator<_Mydeque, _OtherConst, _Checked>& _Right) const noexcept {
-        if constexpr (_Checked) {
+        if constexpr (_Checked == _CheckedIter::_Yes) {
             _STL_VERIFY(this->_Getcont() == _Right._Getcont(), "deque iterators incompatible");
         }
         return _Myoff <=> _Right._Myoff;
@@ -205,42 +206,42 @@ public:
 
 #else // ^^^ _HAS_CXX20 ^^^ / vvv !_HAS_CXX20 vvv
 
-    template <bool _OtherConst>
+    template <_ConstIter _OtherConst>
     _NODISCARD bool operator!=(const _Deque_iterator<_Mydeque, _OtherConst, _Checked>& _Right) const noexcept {
         return !(*this == _Right);
     }
 
-    template <bool _OtherConst>
+    template <_ConstIter _OtherConst>
     _NODISCARD bool operator<(const _Deque_iterator<_Mydeque, _OtherConst, _Checked>& _Right) const noexcept {
-        if constexpr (_Checked) {
+        if constexpr (_Checked == _CheckedIter::_Yes) {
             _STL_VERIFY(this->_Getcont() == _Right._Getcont(), "deque iterators incompatible");
         }
         return _Myoff < _Right._Myoff;
     }
 
-    template <bool _OtherConst>
+    template <_ConstIter _OtherConst>
     _NODISCARD bool operator>(const _Deque_iterator<_Mydeque, _OtherConst, _Checked>& _Right) const noexcept {
         return _Right < *this;
     }
 
-    template <bool _OtherConst>
+    template <_ConstIter _OtherConst>
     _NODISCARD bool operator<=(const _Deque_iterator<_Mydeque, _OtherConst, _Checked>& _Right) const noexcept {
         return !(_Right < *this);
     }
 
-    template <bool _OtherConst>
+    template <_ConstIter _OtherConst>
     _NODISCARD bool operator>=(const _Deque_iterator<_Mydeque, _OtherConst, _Checked>& _Right) const noexcept {
         return !(*this < _Right);
     }
 #endif // !_HAS_CXX20
 
 #if _ITERATOR_DEBUG_LEVEL == 0
-    template <bool _IsChecked = _Checked, enable_if_t<_IsChecked, int> = 0>
+    template <_CheckedIter _IsChecked = _Checked, enable_if_t<_IsChecked == _CheckedIter::_Yes, int> = 0>
     void _Verify_offset(const difference_type) const noexcept {}
 
 #else // ^^^ _ITERATOR_DEBUG_LEVEL == 0 ^^^ / vvv _ITERATOR_DEBUG_LEVEL != 0 vvv
 
-    template <bool _IsChecked = _Checked, enable_if_t<_IsChecked, int> = 0>
+    template <_CheckedIter _IsChecked = _Checked, enable_if_t<_IsChecked == _CheckedIter::_Yes, int> = 0>
     void _Verify_offset(const difference_type _Off) const noexcept {
         if (_Off != 0) {
             const auto _Mycont = static_cast<const _Mydeque*>(this->_Getcont());
@@ -250,24 +251,25 @@ public:
         }
     }
 
-    template <bool _OtherConst>
+    template <_ConstIter _OtherConst>
     friend constexpr void _Verify_range(
         const _Deque_iterator& _First, const _Deque_iterator<_Mydeque, _OtherConst, _Checked>& _Last) noexcept {
-        if constexpr (_Checked) {
+        if constexpr (_Checked == _CheckedIter::_Yes) {
             _STL_VERIFY(_First <= _Last, "array iterator range transposed");
         }
     }
 #endif // _ITERATOR_DEBUG_LEVEL != 0
 
-    using _Prevent_inheriting_unwrap = _Deque_iterator<_Mydeque, _Const, true>;
+    using _Prevent_inheriting_unwrap = _Deque_iterator<_Mydeque, _Const, _CheckedIter::_Yes>;
 
-    template <bool _IsChecked = _Checked, enable_if_t<_IsChecked, int> = 0>
+    template <_CheckedIter _IsChecked = _Checked, enable_if_t<_IsChecked == _CheckedIter::_Yes, int> = 0>
     _NODISCARD constexpr auto _Unwrapped() const noexcept {
-        return _Deque_iterator<_Mydeque, _Const, false>{_Myoff, static_cast<const _Mydeque*>(this->_Getcont())};
+        return _Deque_iterator<_Mydeque, _Const, _CheckedIter::_No>{
+            _Myoff, static_cast<const _Mydeque*>(this->_Getcont())};
     }
 
-    template <bool _IsChecked = _Checked, enable_if_t<_IsChecked, int> = 0>
-    constexpr void _Seek_to(const _Deque_iterator<_Mydeque, _Const, false>& _It) noexcept {
+    template <_CheckedIter _IsChecked = _Checked, enable_if_t<_IsChecked == _CheckedIter::_Yes, int> = 0>
+    constexpr void _Seek_to(const _Deque_iterator<_Mydeque, _Const, _CheckedIter::_No>& _It) noexcept {
         _Myoff = _It._Myoff;
     }
 };
@@ -356,10 +358,10 @@ public:
     using reference       = _Ty&;
     using const_reference = const _Ty&;
 
-    using iterator                  = _Deque_iterator<_Scary_val, false, true>;
-    using const_iterator            = _Deque_iterator<_Scary_val, true, true>;
-    using _Unchecked_iterator       = _Deque_iterator<_Scary_val, false, false>;
-    using _Unchecked_const_iterator = _Deque_iterator<_Scary_val, true, false>;
+    using iterator                  = _Deque_iterator<_Scary_val, _ConstIter::_No, _CheckedIter::_Yes>;
+    using const_iterator            = _Deque_iterator<_Scary_val, _ConstIter::_Yes, _CheckedIter::_Yes>;
+    using _Unchecked_iterator       = _Deque_iterator<_Scary_val, _ConstIter::_No, _CheckedIter::_No>;
+    using _Unchecked_const_iterator = _Deque_iterator<_Scary_val, _ConstIter::_Yes, _CheckedIter::_No>;
 
     using reverse_iterator       = _STD reverse_iterator<iterator>;
     using const_reverse_iterator = _STD reverse_iterator<const_iterator>;

--- a/stl/inc/deque
+++ b/stl/inc/deque
@@ -22,452 +22,130 @@ _STL_DISABLE_CLANG_WARNINGS
 #undef new
 
 _STD_BEGIN
-// CLASS TEMPLATE _Deque_unchecked_const_iterator
-template <class _Mydeque>
-class _Deque_unchecked_const_iterator {
+// CLASS TEMPLATE _Deque_iterator
+template <class _Mydeque, bool _Const, bool _Checked>
+class _Deque_iterator : public _Iterator_base12 {
 private:
+    template <class, bool, bool>
+    friend class _Deque_iterator;
+
     using _Size_type = typename _Mydeque::size_type;
 
     static constexpr int _Block_size = _Mydeque::_Block_size;
 
 public:
+    _Size_type _Myoff = 0; // offset of element in deque
+
+#ifdef __cpp_lib_concepts
+    using iterator_concept = random_access_iterator_tag;
+#endif // __cpp_lib_concepts
     using iterator_category = random_access_iterator_tag;
-
-    using value_type      = typename _Mydeque::value_type;
-    using difference_type = typename _Mydeque::difference_type;
-    using pointer         = typename _Mydeque::const_pointer;
-    using reference       = const value_type&;
-
-    _Deque_unchecked_const_iterator() noexcept : _Mycont(), _Myoff(0) {}
-
-    _Deque_unchecked_const_iterator(_Size_type _Off, const _Container_base12* _Pdeque) noexcept
-        : _Mycont(static_cast<const _Mydeque*>(_Pdeque)), _Myoff(_Off) {}
-
-    _NODISCARD reference operator*() const noexcept {
-        _Size_type _Block = _Mycont->_Getblock(_Myoff);
-        _Size_type _Off   = _Myoff % _Block_size;
-        return _Mycont->_Map[_Block][_Off];
-    }
-
-    _NODISCARD pointer operator->() const noexcept {
-        return pointer_traits<pointer>::pointer_to(**this);
-    }
-
-    _Deque_unchecked_const_iterator& operator++() noexcept {
-        ++_Myoff;
-        return *this;
-    }
-
-    _Deque_unchecked_const_iterator operator++(int) noexcept {
-        _Deque_unchecked_const_iterator _Tmp = *this;
-        ++_Myoff;
-        return _Tmp;
-    }
-
-    _Deque_unchecked_const_iterator& operator--() noexcept {
-        --_Myoff;
-        return *this;
-    }
-
-    _Deque_unchecked_const_iterator operator--(int) noexcept {
-        _Deque_unchecked_const_iterator _Tmp = *this;
-        --_Myoff;
-        return _Tmp;
-    }
-
-    _Deque_unchecked_const_iterator& operator+=(const difference_type _Off) noexcept {
-        _Myoff += _Off;
-        return *this;
-    }
-
-    _NODISCARD _Deque_unchecked_const_iterator operator+(const difference_type _Off) const noexcept {
-        _Deque_unchecked_const_iterator _Tmp = *this;
-        return _Tmp += _Off;
-    }
-
-    _Deque_unchecked_const_iterator& operator-=(const difference_type _Off) noexcept {
-        _Myoff -= _Off;
-        return *this;
-    }
-
-    _NODISCARD _Deque_unchecked_const_iterator operator-(const difference_type _Off) const noexcept {
-        _Deque_unchecked_const_iterator _Tmp = *this;
-        return _Tmp -= _Off;
-    }
-
-    _NODISCARD difference_type operator-(const _Deque_unchecked_const_iterator& _Right) const noexcept {
-        return static_cast<difference_type>(_Myoff - _Right._Myoff);
-    }
-
-    _NODISCARD reference operator[](const difference_type _Off) const noexcept {
-        return *(*this + _Off);
-    }
-
-    _NODISCARD bool operator==(const _Deque_unchecked_const_iterator& _Right) const noexcept {
-        return _Myoff == _Right._Myoff;
-    }
-
-    _NODISCARD bool operator!=(const _Deque_unchecked_const_iterator& _Right) const noexcept {
-        return !(*this == _Right);
-    }
-
-    _NODISCARD bool operator<(const _Deque_unchecked_const_iterator& _Right) const noexcept {
-        return _Myoff < _Right._Myoff;
-    }
-
-    _NODISCARD bool operator>(const _Deque_unchecked_const_iterator& _Right) const noexcept {
-        return _Right < *this;
-    }
-
-    _NODISCARD bool operator<=(const _Deque_unchecked_const_iterator& _Right) const noexcept {
-        return !(_Right < *this);
-    }
-
-    _NODISCARD bool operator>=(const _Deque_unchecked_const_iterator& _Right) const noexcept {
-        return !(*this < _Right);
-    }
-
-    const _Container_base12* _Getcont() const noexcept { // get container pointer
-        return _Mycont;
-    }
-
-    const _Mydeque* _Mycont;
-    _Size_type _Myoff; // offset of element in deque
-};
-
-template <class _Mydeque>
-_NODISCARD _Deque_unchecked_const_iterator<_Mydeque> operator+(
-    typename _Deque_unchecked_const_iterator<_Mydeque>::difference_type _Off,
-    _Deque_unchecked_const_iterator<_Mydeque> _Next) noexcept {
-    return _Next += _Off;
-}
-
-// CLASS TEMPLATE _Deque_unchecked_iterator
-template <class _Mydeque>
-class _Deque_unchecked_iterator : public _Deque_unchecked_const_iterator<_Mydeque> {
-private:
-    using _Size_type = typename _Mydeque::size_type;
-    using _Mybase    = _Deque_unchecked_const_iterator<_Mydeque>;
-
-public:
-    using iterator_category = random_access_iterator_tag;
-
-    using value_type      = typename _Mydeque::value_type;
-    using difference_type = typename _Mydeque::difference_type;
-    using pointer         = typename _Mydeque::pointer;
-    using reference       = value_type&;
-
-    using _Mybase::_Mybase;
-
-    _NODISCARD reference operator*() const noexcept {
-        return const_cast<reference>(_Mybase::operator*());
-    }
-
-    _NODISCARD pointer operator->() const noexcept {
-        return pointer_traits<pointer>::pointer_to(**this);
-    }
-
-    _Deque_unchecked_iterator& operator++() noexcept {
-        _Mybase::operator++();
-        return *this;
-    }
-
-    _Deque_unchecked_iterator operator++(int) noexcept {
-        _Deque_unchecked_iterator _Tmp = *this;
-        _Mybase::operator++();
-        return _Tmp;
-    }
-
-    _Deque_unchecked_iterator& operator--() noexcept {
-        _Mybase::operator--();
-        return *this;
-    }
-
-    _Deque_unchecked_iterator operator--(int) noexcept {
-        _Deque_unchecked_iterator _Tmp = *this;
-        _Mybase::operator--();
-        return _Tmp;
-    }
-
-    _Deque_unchecked_iterator& operator+=(const difference_type _Off) noexcept {
-        _Mybase::operator+=(_Off);
-        return *this;
-    }
-
-    _NODISCARD _Deque_unchecked_iterator operator+(const difference_type _Off) const noexcept {
-        _Deque_unchecked_iterator _Tmp = *this;
-        return _Tmp += _Off;
-    }
-
-    _Deque_unchecked_iterator& operator-=(const difference_type _Off) noexcept {
-        _Mybase::operator-=(_Off);
-        return *this;
-    }
-
-    _NODISCARD _Deque_unchecked_iterator operator-(const difference_type _Off) const noexcept {
-        _Deque_unchecked_iterator _Tmp = *this;
-        return _Tmp -= _Off;
-    }
-
-    _NODISCARD difference_type operator-(const _Mybase& _Right) const noexcept {
-        return _Mybase::operator-(_Right);
-    }
-
-    _NODISCARD reference operator[](const difference_type _Off) const noexcept {
-        return const_cast<reference>(_Mybase::operator[](_Off));
-    }
-};
-
-template <class _Mydeque>
-_NODISCARD _Deque_unchecked_iterator<_Mydeque> operator+(
-    typename _Deque_unchecked_iterator<_Mydeque>::difference_type _Off,
-    _Deque_unchecked_iterator<_Mydeque> _Next) noexcept {
-    return _Next += _Off;
-}
-
-// CLASS TEMPLATE _Deque_const_iterator
-template <class _Mydeque>
-class _Deque_const_iterator : public _Iterator_base12 {
-private:
-    using _Size_type = typename _Mydeque::size_type;
-
-    static constexpr int _Block_size = _Mydeque::_Block_size;
-
-public:
-    using iterator_category = random_access_iterator_tag;
-
-    using value_type      = typename _Mydeque::value_type;
-    using difference_type = typename _Mydeque::difference_type;
-    using pointer         = typename _Mydeque::const_pointer;
-    using reference       = const value_type&;
+    using value_type        = typename _Mydeque::value_type;
+    using difference_type   = typename _Mydeque::difference_type;
+    using pointer           = conditional_t<_Const, typename _Mydeque::const_pointer, typename _Mydeque::pointer>;
+    using reference         = _Maybe_const<_Const, value_type>&;
 
     using _Mydeque_t = _Mydeque; // helper for expression evaluator
     enum { _EEN_DS = _Block_size }; // helper for expression evaluator
-    _Deque_const_iterator() noexcept : _Myoff(0) {
-        _Setcont(nullptr);
+
+    _Deque_iterator() noexcept = default;
+
+    explicit _Deque_iterator(_Size_type _Off, const _Container_base12* _Cont) noexcept : _Myoff(_Off) {
+        if constexpr (_Checked) {
+            const auto _Cont_ = static_cast<const _Mydeque*>(_Cont);
+            _STL_VERIFY(_Cont_, "Construct deque iterator without container");
+            _STL_VERIFY(_Cont_->_Myoff <= _Myoff && _Myoff <= _Cont_->_Myoff + _Cont_->_Mysize,
+                "Construct out of range deque iterator");
+        }
+        this->_Adopt(_Cont);
     }
 
-    _Deque_const_iterator(_Size_type _Off, const _Container_base12* _Pdeque) noexcept : _Myoff(_Off) {
-        _Setcont(static_cast<const _Mydeque*>(_Pdeque));
+    template <bool _IsConst = _Const, enable_if_t<_IsConst, int> = 0>
+    _Deque_iterator(const _Deque_iterator<_Mydeque, !_IsConst, _Checked>& _It) noexcept : _Myoff(_It._Myoff) {
+        this->_Adopt(_It._Getcont());
     }
 
     _NODISCARD reference operator*() const noexcept {
-        const auto _Mycont = static_cast<const _Mydeque*>(this->_Getcont());
-#if _ITERATOR_DEBUG_LEVEL != 0
-        _STL_VERIFY(_Mycont, "cannot dereference value-initialized deque iterator");
-        _STL_VERIFY(_Mycont->_Myoff <= this->_Myoff && this->_Myoff < _Mycont->_Myoff + _Mycont->_Mysize,
-            "cannot deference out of range deque iterator");
-#endif // _ITERATOR_DEBUG_LEVEL != 0
-
-        _Size_type _Block = _Mycont->_Getblock(_Myoff);
-        _Size_type _Off   = _Myoff % _Block_size;
-        return _Mycont->_Map[_Block][_Off];
+        const auto _Cont = static_cast<const _Mydeque*>(this->_Getcont());
+        if constexpr (_Checked) {
+            _STL_VERIFY(_Cont, "cannot dereference value-initialized deque iterator");
+            _STL_VERIFY(_Cont->_Myoff <= _Myoff && _Myoff < _Cont->_Myoff + _Cont->_Mysize,
+                "cannot deference out of range deque iterator");
+        }
+        const _Size_type _Block = _Cont->_Getblock(_Myoff);
+        const _Size_type _Off   = _Myoff % _Block_size;
+        return _Cont->_Map[_Block][_Off];
     }
 
     _NODISCARD pointer operator->() const noexcept {
         return pointer_traits<pointer>::pointer_to(**this);
     }
 
-    _Deque_const_iterator& operator++() noexcept {
-#if _ITERATOR_DEBUG_LEVEL != 0
-        const auto _Mycont = static_cast<const _Mydeque*>(this->_Getcont());
-        _STL_VERIFY(_Mycont, "cannot increment value-initialized deque iterator");
-        _STL_VERIFY(this->_Myoff < _Mycont->_Myoff + _Mycont->_Mysize, "cannot increment deque iterator past end");
-#endif // _ITERATOR_DEBUG_LEVEL != 0
-
-        ++_Myoff;
-        return *this;
-    }
-
-    _Deque_const_iterator operator++(int) noexcept {
-        _Deque_const_iterator _Tmp = *this;
-        ++*this;
-        return _Tmp;
-    }
-
-    _Deque_const_iterator& operator--() noexcept {
-#if _ITERATOR_DEBUG_LEVEL != 0
-        const auto _Mycont = static_cast<const _Mydeque*>(this->_Getcont());
-        _STL_VERIFY(_Mycont, "cannot decrement value-initialized deque iterator");
-        _STL_VERIFY(_Mycont->_Myoff < this->_Myoff, "cannot decrement deque iterator before begin");
-#endif // _ITERATOR_DEBUG_LEVEL != 0
-
-        --_Myoff;
-        return *this;
-    }
-
-    _Deque_const_iterator operator--(int) noexcept {
-        _Deque_const_iterator _Tmp = *this;
-        --*this;
-        return _Tmp;
-    }
-
-    _Deque_const_iterator& operator+=(const difference_type _Off) noexcept {
-#if _ITERATOR_DEBUG_LEVEL != 0
-        if (_Off != 0) {
-            const auto _Mycont = static_cast<const _Mydeque*>(this->_Getcont());
-            _STL_VERIFY(_Mycont, "cannot seek value-initialized deque iterator");
-            _STL_VERIFY(
-                _Mycont->_Myoff <= this->_Myoff + _Off && this->_Myoff + _Off <= _Mycont->_Myoff + _Mycont->_Mysize,
-                "cannot seek deque iterator out of range");
+    _NODISCARD reference operator[](const difference_type _Off_) const noexcept {
+        const auto _Cont    = static_cast<const _Mydeque*>(this->_Getcont());
+        const auto _New_pos = _Myoff + _Off_;
+        if constexpr (_Checked) {
+            _STL_VERIFY(_Cont, "cannot subscript value-initialized deque iterator");
+            _STL_VERIFY(_Cont->_Myoff <= _New_pos && _New_pos < _Cont->_Myoff + _Cont->_Mysize,
+                "cannot subscript out of range deque iterator");
         }
-#endif // _ITERATOR_DEBUG_LEVEL != 0
-
-        _Myoff += _Off;
-        return *this;
-    }
-
-    _NODISCARD _Deque_const_iterator operator+(const difference_type _Off) const noexcept {
-        _Deque_const_iterator _Tmp = *this;
-        return _Tmp += _Off;
-    }
-
-    _Deque_const_iterator& operator-=(const difference_type _Off) noexcept {
-        return *this += -_Off;
-    }
-
-    _NODISCARD _Deque_const_iterator operator-(const difference_type _Off) const noexcept {
-        _Deque_const_iterator _Tmp = *this;
-        return _Tmp -= _Off;
-    }
-
-    _NODISCARD difference_type operator-(const _Deque_const_iterator& _Right) const noexcept {
-        _Compat(_Right);
-        return static_cast<difference_type>(this->_Myoff - _Right._Myoff);
-    }
-
-    _NODISCARD reference operator[](const difference_type _Off) const noexcept {
-        return *(*this + _Off);
-    }
-
-    _NODISCARD bool operator==(const _Deque_const_iterator& _Right) const noexcept {
-        _Compat(_Right);
-        return this->_Myoff == _Right._Myoff;
-    }
-
-    _NODISCARD bool operator!=(const _Deque_const_iterator& _Right) const noexcept {
-        return !(*this == _Right);
-    }
-
-    _NODISCARD bool operator<(const _Deque_const_iterator& _Right) const noexcept {
-        _Compat(_Right);
-        return this->_Myoff < _Right._Myoff;
-    }
-
-    _NODISCARD bool operator>(const _Deque_const_iterator& _Right) const noexcept {
-        return _Right < *this;
-    }
-
-    _NODISCARD bool operator<=(const _Deque_const_iterator& _Right) const noexcept {
-        return !(_Right < *this);
-    }
-
-    _NODISCARD bool operator>=(const _Deque_const_iterator& _Right) const noexcept {
-        return !(*this < _Right);
-    }
-
-    void _Compat(const _Deque_const_iterator& _Right) const noexcept { // test for compatible iterator pair
-#if _ITERATOR_DEBUG_LEVEL == 0
-        (void) _Right;
-#else // _ITERATOR_DEBUG_LEVEL == 0
-        _STL_VERIFY(this->_Getcont() == _Right._Getcont(), "deque iterators incompatible");
-#endif // _ITERATOR_DEBUG_LEVEL == 0
-    }
-
-    void _Setcont(const _Mydeque* _Pdeque) noexcept { // set container pointer
-        this->_Adopt(_Pdeque);
-    }
-
-    using _Prevent_inheriting_unwrap = _Deque_const_iterator;
-
-    _NODISCARD _Deque_unchecked_const_iterator<_Mydeque> _Unwrapped() const noexcept {
-        return {this->_Myoff, this->_Getcont()};
-    }
-
-    void _Verify_offset(const difference_type _Off) const noexcept {
-#if _ITERATOR_DEBUG_LEVEL == 0
-        (void) _Off;
-#else // ^^^ _ITERATOR_DEBUG_LEVEL == 0 ^^^ // vvv _ITERATOR_DEBUG_LEVEL != 0 vvv
-        if (_Off != 0) {
-            const auto _Mycont = static_cast<const _Mydeque*>(this->_Getcont());
-            _STL_VERIFY(_Mycont, "cannot use value-initialized deque iterator");
-            _STL_VERIFY(
-                _Mycont->_Myoff <= this->_Myoff + _Off && this->_Myoff + _Off <= _Mycont->_Myoff + _Mycont->_Mysize,
-                "cannot seek deque iterator out of range");
-        }
-#endif // _ITERATOR_DEBUG_LEVEL == 0
-    }
-
-#if _ITERATOR_DEBUG_LEVEL != 0
-    friend void _Verify_range(const _Deque_const_iterator& _First, const _Deque_const_iterator& _Last) noexcept {
-        // note _Compat check inside operator<=
-        _STL_VERIFY(_First <= _Last, "deque iterators transposed");
-    }
-#endif // _ITERATOR_DEBUG_LEVEL != 0
-
-    void _Seek_to(const _Deque_unchecked_const_iterator<_Mydeque>& _UIt) noexcept {
-        _Myoff = _UIt._Myoff;
-    }
-
-    _Size_type _Myoff; // offset of element in deque
-};
-
-template <class _Mydeque>
-_NODISCARD _Deque_const_iterator<_Mydeque> operator+(
-    typename _Deque_const_iterator<_Mydeque>::difference_type _Off, _Deque_const_iterator<_Mydeque> _Next) noexcept {
-    return _Next += _Off;
-}
-
-// CLASS TEMPLATE _Deque_iterator
-template <class _Mydeque>
-class _Deque_iterator : public _Deque_const_iterator<_Mydeque> {
-private:
-    using _Size_type = typename _Mydeque::size_type;
-    using _Mybase    = _Deque_const_iterator<_Mydeque>;
-
-public:
-    using _Deque_unchecked_type = _Deque_unchecked_iterator<_Mydeque>;
-    using iterator_category     = random_access_iterator_tag;
-
-    using value_type      = typename _Mydeque::value_type;
-    using difference_type = typename _Mydeque::difference_type;
-    using pointer         = typename _Mydeque::pointer;
-    using reference       = value_type&;
-
-    using _Mybase::_Mybase;
-
-    _NODISCARD reference operator*() const noexcept {
-        return const_cast<reference>(_Mybase::operator*());
-    }
-
-    _NODISCARD pointer operator->() const noexcept {
-        return pointer_traits<pointer>::pointer_to(**this);
+        const _Size_type _Block = _Cont->_Getblock(_New_pos);
+        const _Size_type _Off   = _New_pos % _Block_size;
+        return _Cont->_Map[_Block][_Off];
     }
 
     _Deque_iterator& operator++() noexcept {
-        _Mybase::operator++();
+        if constexpr (_Checked) {
+            const auto _Cont = static_cast<const _Mydeque*>(this->_Getcont());
+            _STL_VERIFY(_Cont, "cannot increment value-initialized deque iterator");
+            _STL_VERIFY(_Myoff < _Cont->_Myoff + _Cont->_Mysize, "cannot increment deque iterator past end");
+        }
+        ++_Myoff;
         return *this;
     }
 
     _Deque_iterator operator++(int) noexcept {
+        if constexpr (_Checked) {
+            const auto _Cont = static_cast<const _Mydeque*>(this->_Getcont());
+            _STL_VERIFY(_Cont, "cannot increment value-initialized deque iterator");
+            _STL_VERIFY(_Myoff < _Cont->_Myoff + _Cont->_Mysize, "cannot increment deque iterator past end");
+        }
         _Deque_iterator _Tmp = *this;
-        _Mybase::operator++();
+        ++_Myoff;
         return _Tmp;
     }
 
     _Deque_iterator& operator--() noexcept {
-        _Mybase::operator--();
+        if constexpr (_Checked) {
+            const auto _Cont = static_cast<const _Mydeque*>(this->_Getcont());
+            _STL_VERIFY(_Cont, "cannot decrement value-initialized deque iterator");
+            _STL_VERIFY(_Cont->_Myoff < _Myoff, "cannot decrement deque iterator past end");
+        }
+        --_Myoff;
         return *this;
     }
 
     _Deque_iterator operator--(int) noexcept {
+        if constexpr (_Checked) {
+            const auto _Cont = static_cast<const _Mydeque*>(this->_Getcont());
+            _STL_VERIFY(_Cont, "cannot decrement value-initialized deque iterator");
+            _STL_VERIFY(_Cont->_Myoff < _Myoff, "cannot decrement deque iterator past end");
+        }
         _Deque_iterator _Tmp = *this;
-        _Mybase::operator--();
+        --_Myoff;
         return _Tmp;
     }
 
     _Deque_iterator& operator+=(const difference_type _Off) noexcept {
-        _Mybase::operator+=(_Off);
+        if constexpr (_Checked) {
+            if (_Off != 0) {
+                const auto _Cont = static_cast<const _Mydeque*>(this->_Getcont());
+                _STL_VERIFY(_Cont, "cannot seek value-initialized deque iterator");
+                _STL_VERIFY(_Cont->_Myoff <= _Myoff + _Off && _Myoff + _Off <= _Cont->_Myoff + _Cont->_Mysize,
+                    "cannot seek deque iterator out of range");
+            }
+        }
+        _Myoff += _Off;
         return *this;
     }
 
@@ -477,43 +155,131 @@ public:
     }
 
     _Deque_iterator& operator-=(const difference_type _Off) noexcept {
-        _Mybase::operator-=(_Off);
+        if constexpr (_Checked) {
+            if (_Off != 0) {
+                const auto _Cont = static_cast<const _Mydeque*>(this->_Getcont());
+                _STL_VERIFY(_Cont, "cannot seek value-initialized deque iterator");
+                _STL_VERIFY(_Cont->_Myoff <= _Myoff - _Off && _Myoff - _Off <= _Cont->_Myoff + _Cont->_Mysize,
+                    "cannot seek deque iterator out of range");
+            }
+        }
+        _Myoff -= _Off;
         return *this;
     }
-
-    using _Mybase::operator-;
 
     _NODISCARD _Deque_iterator operator-(const difference_type _Off) const noexcept {
         _Deque_iterator _Tmp = *this;
         return _Tmp -= _Off;
     }
 
-    _NODISCARD reference operator[](const difference_type _Off) const noexcept {
-        return const_cast<reference>(_Mybase::operator[](_Off));
+    _NODISCARD friend _Deque_iterator operator+(const difference_type _Off, _Deque_iterator _Next) noexcept {
+        return _Next += _Off;
     }
 
-    using _Prevent_inheriting_unwrap = _Deque_iterator;
+    template <bool _OtherConst>
+    _NODISCARD difference_type operator-(
+        const _Deque_iterator<_Mydeque, _OtherConst, _Checked>& _Right) const noexcept {
+        if constexpr (_Checked) {
+            _STL_VERIFY(this->_Getcont() == _Right._Getcont(), "deque iterators incompatible");
+        }
+        return static_cast<difference_type>(_Myoff - _Right._Myoff);
+    }
 
-    _NODISCARD _Deque_unchecked_iterator<_Mydeque> _Unwrapped() const noexcept {
-        return {this->_Myoff, this->_Getcont()};
+    template <bool _OtherConst>
+    _NODISCARD bool operator==(const _Deque_iterator<_Mydeque, _OtherConst, _Checked>& _Right) const noexcept {
+        if constexpr (_Checked) {
+            _STL_VERIFY(this->_Getcont() == _Right._Getcont(), "deque iterators incompatible");
+        }
+        return _Myoff == _Right._Myoff;
+    }
+
+#if _HAS_CXX20
+    template <bool _OtherConst>
+    _NODISCARD constexpr strong_ordering operator<=>(
+        const _Deque_iterator<_Mydeque, _OtherConst, _Checked>& _Right) const noexcept {
+        if constexpr (_Checked) {
+            _STL_VERIFY(this->_Getcont() == _Right._Getcont(), "deque iterators incompatible");
+        }
+        return _Myoff <=> _Right._Myoff;
+    }
+
+#else // ^^^ _HAS_CXX20 ^^^ / vvv !_HAS_CXX20 vvv
+
+    template <bool _OtherConst>
+    _NODISCARD bool operator!=(const _Deque_iterator<_Mydeque, _OtherConst, _Checked>& _Right) const noexcept {
+        return !(*this == _Right);
+    }
+
+    template <bool _OtherConst>
+    _NODISCARD bool operator<(const _Deque_iterator<_Mydeque, _OtherConst, _Checked>& _Right) const noexcept {
+        if constexpr (_Checked) {
+            _STL_VERIFY(this->_Getcont() == _Right._Getcont(), "deque iterators incompatible");
+        }
+        return _Myoff < _Right._Myoff;
+    }
+
+    template <bool _OtherConst>
+    _NODISCARD bool operator>(const _Deque_iterator<_Mydeque, _OtherConst, _Checked>& _Right) const noexcept {
+        return _Right < *this;
+    }
+
+    template <bool _OtherConst>
+    _NODISCARD bool operator<=(const _Deque_iterator<_Mydeque, _OtherConst, _Checked>& _Right) const noexcept {
+        return !(_Right < *this);
+    }
+
+    template <bool _OtherConst>
+    _NODISCARD bool operator>=(const _Deque_iterator<_Mydeque, _OtherConst, _Checked>& _Right) const noexcept {
+        return !(*this < _Right);
+    }
+#endif // !_HAS_CXX20
+
+#if _ITERATOR_DEBUG_LEVEL == 0
+    template <bool _IsChecked = _Checked, enable_if_t<_IsChecked, int> = 0>
+    void _Verify_offset(const difference_type) const noexcept {}
+
+#else // ^^^ _ITERATOR_DEBUG_LEVEL == 0 ^^^ / vvv _ITERATOR_DEBUG_LEVEL != 0 vvv
+
+    template <bool _IsChecked = _Checked, enable_if_t<_IsChecked, int> = 0>
+    void _Verify_offset(const difference_type _Off) const noexcept {
+        if (_Off != 0) {
+            const auto _Mycont = static_cast<const _Mydeque*>(this->_Getcont());
+            _STL_VERIFY(_Mycont, "cannot use value-initialized deque iterator");
+            _STL_VERIFY(_Mycont->_Myoff <= _Myoff + _Off && _Myoff + _Off <= _Mycont->_Myoff + _Mycont->_Mysize,
+                "cannot seek deque iterator out of range");
+        }
+    }
+
+    template <bool _OtherConst>
+    friend constexpr void _Verify_range(
+        const _Deque_iterator& _First, const _Deque_iterator<_Mydeque, _OtherConst, _Checked>& _Last) noexcept {
+        if constexpr (_Checked) {
+            _STL_VERIFY(_First <= _Last, "array iterator range transposed");
+        }
+    }
+#endif // _ITERATOR_DEBUG_LEVEL != 0
+
+    using _Prevent_inheriting_unwrap = _Deque_iterator<_Mydeque, _Const, true>;
+
+    template <bool _IsChecked = _Checked, enable_if_t<_IsChecked, int> = 0>
+    _NODISCARD constexpr auto _Unwrapped() const noexcept {
+        return _Deque_iterator<_Mydeque, _Const, false>{_Myoff, static_cast<const _Mydeque*>(this->_Getcont())};
+    }
+
+    template <bool _IsChecked = _Checked, enable_if_t<_IsChecked, int> = 0>
+    constexpr void _Seek_to(const _Deque_iterator<_Mydeque, _Const, false>& _It) noexcept {
+        _Myoff = _It._Myoff;
     }
 };
 
-template <class _Mydeque>
-_NODISCARD _Deque_iterator<_Mydeque> operator+(
-    typename _Deque_iterator<_Mydeque>::difference_type _Off, _Deque_iterator<_Mydeque> _Next) noexcept {
-    return _Next += _Off;
-}
-
 // deque TYPE WRAPPERS
-template <class _Value_type, class _Size_type, class _Difference_type, class _Pointer, class _Const_pointer,
-    class _Reference, class _Const_reference, class _Mapptr_type>
+template <class _Value_type, class _Alty_traits, class _Mapptr_type>
 struct _Deque_iter_types {
     using value_type      = _Value_type;
-    using size_type       = _Size_type;
-    using difference_type = _Difference_type;
-    using pointer         = _Pointer;
-    using const_pointer   = _Const_pointer;
+    using size_type       = typename _Alty_traits::size_type;
+    using difference_type = typename _Alty_traits::difference_type;
+    using pointer         = typename _Alty_traits::pointer;
+    using const_pointer   = typename _Alty_traits::const_pointer;
     using _Mapptr         = _Mapptr_type;
 };
 
@@ -575,8 +341,7 @@ private:
     using _Alproxy_traits = allocator_traits<_Alproxy_ty>;
 
     using _Scary_val = _Deque_val<conditional_t<_Is_simple_alloc_v<_Alty>, _Deque_simple_types<_Ty>,
-        _Deque_iter_types<_Ty, typename _Alty_traits::size_type, typename _Alty_traits::difference_type,
-            typename _Alty_traits::pointer, typename _Alty_traits::const_pointer, _Ty&, const _Ty&, _Mapptr>>>;
+        _Deque_iter_types<_Ty, _Alty_traits, _Mapptr>>>;
 
     static constexpr int _Minimum_map_size = 8;
     static constexpr int _Block_size       = _Scary_val::_Block_size;
@@ -591,10 +356,10 @@ public:
     using reference       = _Ty&;
     using const_reference = const _Ty&;
 
-    using iterator                  = _Deque_iterator<_Scary_val>;
-    using const_iterator            = _Deque_const_iterator<_Scary_val>;
-    using _Unchecked_iterator       = _Deque_unchecked_iterator<_Scary_val>;
-    using _Unchecked_const_iterator = _Deque_unchecked_const_iterator<_Scary_val>;
+    using iterator                  = _Deque_iterator<_Scary_val, false, true>;
+    using const_iterator            = _Deque_iterator<_Scary_val, true, true>;
+    using _Unchecked_iterator       = _Deque_iterator<_Scary_val, false, false>;
+    using _Unchecked_const_iterator = _Deque_iterator<_Scary_val, true, false>;
 
     using reverse_iterator       = _STD reverse_iterator<iterator>;
     using const_reverse_iterator = _STD reverse_iterator<const_iterator>;

--- a/stl/inc/forward_list
+++ b/stl/inc/forward_list
@@ -22,25 +22,46 @@ _STL_DISABLE_CLANG_WARNINGS
 #undef new
 
 _STD_BEGIN
-// CLASS TEMPLATE _Flist_unchecked_const_iterator
-template <class _Mylist, class _Base = _Iterator_base0>
-class _Flist_unchecked_const_iterator : public _Base {
+// CLASS TEMPLATE _Flist_iterator
+template <class _Mylist, bool _Const, bool _Checked>
+class _Flist_iterator : public _Iterator_base {
+private:
+    template <class, bool, bool>
+    friend class _Flist_iterator;
+
+    using _Nodeptr = typename _Mylist::_Nodeptr;
+
 public:
+    _Nodeptr _Ptr = _Nodeptr(); // offset of element in forward_list
+
+#ifdef __cpp_lib_concepts
+    using iterator_concept = forward_iterator_tag;
+#endif // __cpp_lib_concepts
     using iterator_category = forward_iterator_tag;
+    using value_type        = typename _Mylist::value_type;
+    using difference_type   = typename _Mylist::difference_type;
+    using pointer           = conditional_t<_Const, typename _Mylist::const_pointer, typename _Mylist::pointer>;
+    using reference         = _Maybe_const<_Const, value_type>&;
 
-    using _Nodeptr        = typename _Mylist::_Nodeptr;
-    using value_type      = typename _Mylist::value_type;
-    using difference_type = typename _Mylist::difference_type;
-    using pointer         = typename _Mylist::const_pointer;
-    using reference       = const value_type&;
+    _Flist_iterator() noexcept = default;
 
-    _Flist_unchecked_const_iterator() noexcept : _Ptr() {}
-
-    _Flist_unchecked_const_iterator(_Nodeptr _Pnode, const _Mylist* _Plist) noexcept : _Ptr(_Pnode) {
+    explicit _Flist_iterator(_Nodeptr _Pnode, const _Mylist* _Plist) noexcept : _Ptr(_Pnode) {
         this->_Adopt(_Plist);
     }
 
+    template <bool _IsConst = _Const, enable_if_t<_IsConst, int> = 0>
+    _Flist_iterator(const _Flist_iterator<_Mylist, !_IsConst, _Checked>& _It) noexcept : _Ptr(_It._Ptr) {
+        this->_Adopt(_It._Getcont());
+    }
+
     _NODISCARD reference operator*() const noexcept {
+#if _ITERATOR_DEBUG_LEVEL == 2
+        if constexpr (_Checked) {
+            const auto _Cont = static_cast<const _Mylist*>(this->_Getcont());
+            _STL_ASSERT(_Cont, "cannot dereference value-initialized forward_list iterator");
+            _STL_VERIFY(_Ptr != _Cont->_Before_head(), "cannot dereference forward_list before_begin");
+        }
+#endif // _ITERATOR_DEBUG_LEVEL == 2
         return _Ptr->_Myval;
     }
 
@@ -48,191 +69,89 @@ public:
         return pointer_traits<pointer>::pointer_to(**this);
     }
 
-    _Flist_unchecked_const_iterator& operator++() noexcept {
+    _Flist_iterator& operator++() noexcept {
+#if _ITERATOR_DEBUG_LEVEL == 2
+        if constexpr (_Checked) {
+            _STL_VERIFY(this->_Getcont(), "value-initialized forward_list iterator not incrementable");
+        }
+#endif // _ITERATOR_DEBUG_LEVEL == 2
         _Ptr = _Ptr->_Next;
         return *this;
     }
 
-    _Flist_unchecked_const_iterator operator++(int) noexcept {
-        _Flist_unchecked_const_iterator _Tmp = *this;
-        _Ptr                                 = _Ptr->_Next;
+    _Flist_iterator operator++(int) noexcept {
+#if _ITERATOR_DEBUG_LEVEL == 2
+        if constexpr (_Checked) {
+            _STL_VERIFY(this->_Getcont(), "value-initialized forward_list iterator not incrementable");
+        }
+#endif // _ITERATOR_DEBUG_LEVEL == 2
+        _Flist_iterator _Tmp = *this;
+        _Ptr                 = _Ptr->_Next;
         return _Tmp;
     }
 
-    _NODISCARD bool operator==(const _Flist_unchecked_const_iterator& _Right) const noexcept {
+    template <bool _OtherConst>
+    _NODISCARD bool operator==(const _Flist_iterator<_Mylist, _OtherConst, _Checked>& _Right) const noexcept {
+#if _ITERATOR_DEBUG_LEVEL == 2
+        if constexpr (_Checked) {
+            _STL_VERIFY(this->_Getcont() == _Right._Getcont(), "forward_list iterators incompatible");
+        }
+#endif // _ITERATOR_DEBUG_LEVEL == 2
         return _Ptr == _Right._Ptr;
-    }
-
-    _NODISCARD bool operator!=(const _Flist_unchecked_const_iterator& _Right) const noexcept {
-        return !(*this == _Right);
     }
 
     _NODISCARD bool operator==(_Default_sentinel) const noexcept {
         return _Ptr == nullptr;
     }
 
+#if !_HAS_CXX20
+    template <bool _OtherConst>
+    _NODISCARD bool operator!=(const _Flist_iterator<_Mylist, _OtherConst, _Checked>& _Right) const noexcept {
+#if _ITERATOR_DEBUG_LEVEL == 2
+        if constexpr (_Checked) {
+            _STL_VERIFY(this->_Getcont() == _Right._Getcont(), "forward_list iterators incompatible");
+        }
+#endif // _ITERATOR_DEBUG_LEVEL == 2
+        return _Ptr != _Right._Ptr;
+    }
+
     _NODISCARD bool operator!=(_Default_sentinel) const noexcept {
         return _Ptr != nullptr;
     }
-
-    _Nodeptr _Ptr; // pointer to node
-};
-
-// CLASS TEMPLATE _Flist_unchecked_iterator
-template <class _Mylist>
-class _Flist_unchecked_iterator : public _Flist_unchecked_const_iterator<_Mylist> {
-public:
-    using _Mybase           = _Flist_unchecked_const_iterator<_Mylist>;
-    using iterator_category = forward_iterator_tag;
-
-    using _Nodeptr        = typename _Mylist::_Nodeptr;
-    using value_type      = typename _Mylist::value_type;
-    using difference_type = typename _Mylist::difference_type;
-    using pointer         = typename _Mylist::pointer;
-    using reference       = value_type&;
-
-    using _Mybase::_Mybase;
-
-    _NODISCARD reference operator*() const noexcept {
-        return const_cast<reference>(_Mybase::operator*());
-    }
-
-    _NODISCARD pointer operator->() const noexcept {
-        return pointer_traits<pointer>::pointer_to(**this);
-    }
-
-    _Flist_unchecked_iterator& operator++() noexcept {
-        _Mybase::operator++();
-        return *this;
-    }
-
-    _Flist_unchecked_iterator operator++(int) noexcept {
-        _Flist_unchecked_iterator _Tmp = *this;
-        _Mybase::operator++();
-        return _Tmp;
-    }
-};
-
-// CLASS TEMPLATE _Flist_const_iterator
-template <class _Mylist>
-class _Flist_const_iterator : public _Flist_unchecked_const_iterator<_Mylist, _Iterator_base> {
-public:
-    using _Mybase           = _Flist_unchecked_const_iterator<_Mylist, _Iterator_base>;
-    using iterator_category = forward_iterator_tag;
-
-    using _Nodeptr        = typename _Mylist::_Nodeptr;
-    using value_type      = typename _Mylist::value_type;
-    using difference_type = typename _Mylist::difference_type;
-    using pointer         = typename _Mylist::const_pointer;
-    using reference       = const value_type&;
-
-    using _Mybase::_Mybase;
-
-    _NODISCARD reference operator*() const noexcept {
-#if _ITERATOR_DEBUG_LEVEL == 2
-        const auto _Mycont = static_cast<const _Mylist*>(this->_Getcont());
-        _STL_ASSERT(_Mycont, "cannot dereference value-initialized forward_list iterator");
-        _STL_VERIFY(this->_Ptr != _Mycont->_Before_head(), "cannot dereference forward_list before_begin");
-#endif // _ITERATOR_DEBUG_LEVEL == 2
-
-        return this->_Ptr->_Myval;
-    }
-
-    _Flist_const_iterator& operator++() noexcept {
-#if _ITERATOR_DEBUG_LEVEL == 2
-        _STL_VERIFY(this->_Getcont(), "forward_list iterator not incrementable");
-#endif // _ITERATOR_DEBUG_LEVEL == 2
-
-        this->_Ptr = this->_Ptr->_Next;
-        return *this;
-    }
-
-    _Flist_const_iterator operator++(int) noexcept {
-        _Flist_const_iterator _Tmp = *this;
-        this->_Ptr                 = this->_Ptr->_Next;
-        return _Tmp;
-    }
-
-    _NODISCARD bool operator==(const _Flist_const_iterator& _Right) const noexcept {
-#if _ITERATOR_DEBUG_LEVEL == 2
-        _STL_VERIFY(this->_Getcont() == _Right._Getcont(), "forward_list iterators incompatible");
-#endif // _ITERATOR_DEBUG_LEVEL == 2
-
-        return this->_Ptr == _Right._Ptr;
-    }
-
-    _NODISCARD bool operator!=(const _Flist_const_iterator& _Right) const noexcept {
-        return !(*this == _Right);
-    }
+#endif // !_HAS_CXX20
 
 #if _ITERATOR_DEBUG_LEVEL == 2
-    friend void _Verify_range(const _Flist_const_iterator& _First, const _Flist_const_iterator& _Last) noexcept {
-        _STL_VERIFY(
-            _First._Getcont() == _Last._Getcont(), "forward_list iterators in range are from different containers");
+    template <bool _OtherConst>
+    friend constexpr void _Verify_range(
+        const _Flist_iterator& _First, const _Flist_iterator<_Mylist, _OtherConst, _Checked>& _Last) noexcept {
+        if constexpr (_Checked) {
+            _STL_VERIFY(
+                _First._Getcont() == _Last._Getcont(), "forward_list iterators in range are from different containers");
+        }
     }
 #endif // _ITERATOR_DEBUG_LEVEL == 2
 
-    using _Prevent_inheriting_unwrap = _Flist_const_iterator;
+    using _Prevent_inheriting_unwrap = _Flist_iterator<_Mylist, _Const, true>;
 
-    _NODISCARD _Flist_unchecked_const_iterator<_Mylist> _Unwrapped() const noexcept {
-        return _Flist_unchecked_const_iterator<_Mylist>(this->_Ptr, static_cast<const _Mylist*>(this->_Getcont()));
+    template <bool _IsChecked = _Checked, enable_if_t<_IsChecked, int> = 0>
+    _NODISCARD constexpr auto _Unwrapped() const noexcept {
+        return _Flist_iterator<_Mylist, _Const, false>{_Ptr, static_cast<const _Mylist*>(this->_Getcont())};
     }
 
-    void _Seek_to(const _Flist_unchecked_const_iterator<_Mylist> _It) noexcept {
-        this->_Ptr = _It._Ptr;
-    }
-};
-
-// CLASS TEMPLATE _Flist_iterator
-template <class _Mylist>
-class _Flist_iterator : public _Flist_const_iterator<_Mylist> {
-public:
-    using _Mybase           = _Flist_const_iterator<_Mylist>;
-    using iterator_category = forward_iterator_tag;
-
-    using _Nodeptr        = typename _Mylist::_Nodeptr;
-    using value_type      = typename _Mylist::value_type;
-    using difference_type = typename _Mylist::difference_type;
-    using pointer         = typename _Mylist::pointer;
-    using reference       = value_type&;
-
-    using _Mybase::_Mybase;
-
-    _NODISCARD reference operator*() const noexcept {
-        return const_cast<reference>(_Mybase::operator*());
-    }
-
-    _NODISCARD pointer operator->() const noexcept {
-        return pointer_traits<pointer>::pointer_to(**this);
-    }
-
-    _Flist_iterator& operator++() noexcept {
-        _Mybase::operator++();
-        return *this;
-    }
-
-    _Flist_iterator operator++(int) noexcept {
-        _Flist_iterator _Tmp = *this;
-        _Mybase::operator++();
-        return _Tmp;
-    }
-
-    using _Prevent_inheriting_unwrap = _Flist_iterator;
-
-    _NODISCARD _Flist_unchecked_iterator<_Mylist> _Unwrapped() const noexcept {
-        return _Flist_unchecked_iterator<_Mylist>(this->_Ptr, static_cast<const _Mylist*>(this->_Getcont()));
+    template <bool _IsChecked = _Checked, enable_if_t<_IsChecked, int> = 0>
+    constexpr void _Seek_to(const _Flist_iterator<_Mylist, _Const, false>& _It) noexcept {
+        _Ptr = _It._Ptr;
     }
 };
 
 // forward_list TYPE WRAPPERS
-template <class _Value_type, class _Size_type, class _Difference_type, class _Pointer, class _Const_pointer,
-    class _Reference, class _Const_reference, class _Nodeptr_type>
+template <class _Value_type, class _Alty_traits, class _Nodeptr_type>
 struct _Flist_iter_types {
     using value_type      = _Value_type;
-    using size_type       = _Size_type;
-    using difference_type = _Difference_type;
-    using pointer         = _Pointer;
-    using const_pointer   = _Const_pointer;
+    using size_type       = typename _Alty_traits::size_type;
+    using difference_type = typename _Alty_traits::difference_type;
+    using pointer         = typename _Alty_traits::pointer;
+    using const_pointer   = typename _Alty_traits::const_pointer;
     using _Nodeptr        = _Nodeptr_type;
 };
 
@@ -287,7 +206,7 @@ public:
         _Lockit _Lock(_LOCK_DEBUG);
         _Iterator_base12** _Pnext = &this->_Myproxy->_Myfirstiter;
         while (*_Pnext) {
-            const auto _Pnextptr = static_cast<_Flist_const_iterator<_Flist_val>&>(**_Pnext)._Ptr;
+            const auto _Pnextptr = static_cast<_Flist_iterator<_Flist_val, true, true>&>(**_Pnext)._Ptr;
             if (_Pnextptr == _BHead || (_Ptr != nullptr && _Pnextptr != _Ptr)) {
                 _Pnext = &(*_Pnext)->_Mynextiter;
             } else { // orphan the iterator
@@ -521,8 +440,7 @@ private:
         _MISMATCHED_ALLOCATOR_MESSAGE("forward_list<T, Allocator>", "T"));
 
     using _Scary_val = _Flist_val<conditional_t<_Is_simple_alloc_v<_Alnode>, _Flist_simple_types<_Ty>,
-        _Flist_iter_types<_Ty, typename _Alty_traits::size_type, typename _Alty_traits::difference_type,
-            typename _Alty_traits::pointer, typename _Alty_traits::const_pointer, _Ty&, const _Ty&, _Nodeptr>>>;
+        _Flist_iter_types<_Ty, _Alty_traits, _Nodeptr>>>;
 
 public:
     using value_type      = _Ty;
@@ -534,10 +452,10 @@ public:
     using reference       = value_type&;
     using const_reference = const value_type&;
 
-    using iterator                  = _Flist_iterator<_Scary_val>;
-    using const_iterator            = _Flist_const_iterator<_Scary_val>;
-    using _Unchecked_iterator       = _Flist_unchecked_iterator<_Scary_val>;
-    using _Unchecked_const_iterator = _Flist_unchecked_const_iterator<_Scary_val>;
+    using iterator                  = _Flist_iterator<_Scary_val, false, true>;
+    using const_iterator            = _Flist_iterator<_Scary_val, true, true>;
+    using _Unchecked_iterator       = _Flist_iterator<_Scary_val, false, false>;
+    using _Unchecked_const_iterator = _Flist_iterator<_Scary_val, true, false>;
 
     forward_list() noexcept(is_nothrow_default_constructible_v<_Alnode>) // strengthened
         : _Mypair(_Zero_then_variadic_args_t{}) {

--- a/stl/inc/forward_list
+++ b/stl/inc/forward_list
@@ -23,10 +23,10 @@ _STL_DISABLE_CLANG_WARNINGS
 
 _STD_BEGIN
 // CLASS TEMPLATE _Flist_iterator
-template <class _Mylist, bool _Const, bool _Checked>
+template <class _Mylist, _ConstIter _Const, _CheckedIter _Checked>
 class _Flist_iterator : public _Iterator_base {
 private:
-    template <class, bool, bool>
+    template <class, _ConstIter, _CheckedIter>
     friend class _Flist_iterator;
 
     using _Nodeptr = typename _Mylist::_Nodeptr;
@@ -40,8 +40,9 @@ public:
     using iterator_category = forward_iterator_tag;
     using value_type        = typename _Mylist::value_type;
     using difference_type   = typename _Mylist::difference_type;
-    using pointer           = conditional_t<_Const, typename _Mylist::const_pointer, typename _Mylist::pointer>;
-    using reference         = _Maybe_const<_Const, value_type>&;
+    using pointer =
+        conditional_t<_Const == _ConstIter::_Yes, typename _Mylist::const_pointer, typename _Mylist::pointer>;
+    using reference = _Maybe_const<_Const == _ConstIter::_Yes, value_type>&;
 
     _Flist_iterator() noexcept = default;
 
@@ -49,14 +50,14 @@ public:
         this->_Adopt(_Plist);
     }
 
-    template <bool _IsConst = _Const, enable_if_t<_IsConst, int> = 0>
-    _Flist_iterator(const _Flist_iterator<_Mylist, !_IsConst, _Checked>& _It) noexcept : _Ptr(_It._Ptr) {
+    template <_ConstIter _IsConst = _Const, enable_if_t<_IsConst == _ConstIter::_Yes, int> = 0>
+    _Flist_iterator(const _Flist_iterator<_Mylist, _ConstIter::_No, _Checked>& _It) noexcept : _Ptr(_It._Ptr) {
         this->_Adopt(_It._Getcont());
     }
 
     _NODISCARD reference operator*() const noexcept {
 #if _ITERATOR_DEBUG_LEVEL == 2
-        if constexpr (_Checked) {
+        if constexpr (_Checked == _CheckedIter::_Yes) {
             const auto _Cont = static_cast<const _Mylist*>(this->_Getcont());
             _STL_ASSERT(_Cont, "cannot dereference value-initialized forward_list iterator");
             _STL_VERIFY(_Ptr != _Cont->_Before_head(), "cannot dereference forward_list before_begin");
@@ -71,7 +72,7 @@ public:
 
     _Flist_iterator& operator++() noexcept {
 #if _ITERATOR_DEBUG_LEVEL == 2
-        if constexpr (_Checked) {
+        if constexpr (_Checked == _CheckedIter::_Yes) {
             _STL_VERIFY(this->_Getcont(), "value-initialized forward_list iterator not incrementable");
         }
 #endif // _ITERATOR_DEBUG_LEVEL == 2
@@ -81,7 +82,7 @@ public:
 
     _Flist_iterator operator++(int) noexcept {
 #if _ITERATOR_DEBUG_LEVEL == 2
-        if constexpr (_Checked) {
+        if constexpr (_Checked == _CheckedIter::_Yes) {
             _STL_VERIFY(this->_Getcont(), "value-initialized forward_list iterator not incrementable");
         }
 #endif // _ITERATOR_DEBUG_LEVEL == 2
@@ -90,10 +91,10 @@ public:
         return _Tmp;
     }
 
-    template <bool _OtherConst>
+    template <_ConstIter _OtherConst>
     _NODISCARD bool operator==(const _Flist_iterator<_Mylist, _OtherConst, _Checked>& _Right) const noexcept {
 #if _ITERATOR_DEBUG_LEVEL == 2
-        if constexpr (_Checked) {
+        if constexpr (_Checked == _CheckedIter::_Yes) {
             _STL_VERIFY(this->_Getcont() == _Right._Getcont(), "forward_list iterators incompatible");
         }
 #endif // _ITERATOR_DEBUG_LEVEL == 2
@@ -105,10 +106,10 @@ public:
     }
 
 #if !_HAS_CXX20
-    template <bool _OtherConst>
+    template <_ConstIter _OtherConst>
     _NODISCARD bool operator!=(const _Flist_iterator<_Mylist, _OtherConst, _Checked>& _Right) const noexcept {
 #if _ITERATOR_DEBUG_LEVEL == 2
-        if constexpr (_Checked) {
+        if constexpr (_Checked == _CheckedIter::_Yes) {
             _STL_VERIFY(this->_Getcont() == _Right._Getcont(), "forward_list iterators incompatible");
         }
 #endif // _ITERATOR_DEBUG_LEVEL == 2
@@ -121,25 +122,25 @@ public:
 #endif // !_HAS_CXX20
 
 #if _ITERATOR_DEBUG_LEVEL == 2
-    template <bool _OtherConst>
+    template <_ConstIter _OtherConst>
     friend constexpr void _Verify_range(
         const _Flist_iterator& _First, const _Flist_iterator<_Mylist, _OtherConst, _Checked>& _Last) noexcept {
-        if constexpr (_Checked) {
+        if constexpr (_Checked == _CheckedIter::_Yes) {
             _STL_VERIFY(
                 _First._Getcont() == _Last._Getcont(), "forward_list iterators in range are from different containers");
         }
     }
 #endif // _ITERATOR_DEBUG_LEVEL == 2
 
-    using _Prevent_inheriting_unwrap = _Flist_iterator<_Mylist, _Const, true>;
+    using _Prevent_inheriting_unwrap = _Flist_iterator<_Mylist, _Const, _CheckedIter::_Yes>;
 
-    template <bool _IsChecked = _Checked, enable_if_t<_IsChecked, int> = 0>
+    template <_CheckedIter _IsChecked = _Checked, enable_if_t<_IsChecked == _CheckedIter::_Yes, int> = 0>
     _NODISCARD constexpr auto _Unwrapped() const noexcept {
-        return _Flist_iterator<_Mylist, _Const, false>{_Ptr, static_cast<const _Mylist*>(this->_Getcont())};
+        return _Flist_iterator<_Mylist, _Const, _CheckedIter::_No>{_Ptr, static_cast<const _Mylist*>(this->_Getcont())};
     }
 
-    template <bool _IsChecked = _Checked, enable_if_t<_IsChecked, int> = 0>
-    constexpr void _Seek_to(const _Flist_iterator<_Mylist, _Const, false>& _It) noexcept {
+    template <_CheckedIter _IsChecked = _Checked, enable_if_t<_IsChecked == _CheckedIter::_Yes, int> = 0>
+    constexpr void _Seek_to(const _Flist_iterator<_Mylist, _Const, _CheckedIter::_No>& _It) noexcept {
         _Ptr = _It._Ptr;
     }
 };
@@ -206,7 +207,8 @@ public:
         _Lockit _Lock(_LOCK_DEBUG);
         _Iterator_base12** _Pnext = &this->_Myproxy->_Myfirstiter;
         while (*_Pnext) {
-            const auto _Pnextptr = static_cast<_Flist_iterator<_Flist_val, true, true>&>(**_Pnext)._Ptr;
+            const auto _Pnextptr =
+                static_cast<_Flist_iterator<_Flist_val, _ConstIter::_Yes, _CheckedIter::_Yes>&>(**_Pnext)._Ptr;
             if (_Pnextptr == _BHead || (_Ptr != nullptr && _Pnextptr != _Ptr)) {
                 _Pnext = &(*_Pnext)->_Mynextiter;
             } else { // orphan the iterator
@@ -452,10 +454,10 @@ public:
     using reference       = value_type&;
     using const_reference = const value_type&;
 
-    using iterator                  = _Flist_iterator<_Scary_val, false, true>;
-    using const_iterator            = _Flist_iterator<_Scary_val, true, true>;
-    using _Unchecked_iterator       = _Flist_iterator<_Scary_val, false, false>;
-    using _Unchecked_const_iterator = _Flist_iterator<_Scary_val, true, false>;
+    using iterator                  = _Flist_iterator<_Scary_val, _ConstIter::_No, _CheckedIter::_Yes>;
+    using const_iterator            = _Flist_iterator<_Scary_val, _ConstIter::_Yes, _CheckedIter::_Yes>;
+    using _Unchecked_iterator       = _Flist_iterator<_Scary_val, _ConstIter::_No, _CheckedIter::_No>;
+    using _Unchecked_const_iterator = _Flist_iterator<_Scary_val, _ConstIter::_Yes, _CheckedIter::_No>;
 
     forward_list() noexcept(is_nothrow_default_constructible_v<_Alnode>) // strengthened
         : _Mypair(_Zero_then_variadic_args_t{}) {

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -47,9 +47,6 @@ namespace ranges {
         && (is_pointer_v<_It> || _Has_member_arrow<_It&>);
     // clang-format on
 
-    template <bool _IsConst, class _Ty>
-    using _Maybe_const = conditional_t<_IsConst, const _Ty, _Ty>;
-
     template <bool _IsWrapped, class _Ty>
     using _Maybe_wrapped = conditional_t<_IsWrapped, _Ty, _Unwrapped_t<_Ty>>;
 

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -220,6 +220,10 @@ struct identity {
 };
 #endif // _HAS_CXX20
 
+// ALIAS TEMPLATE _Maybe_const
+template <bool _IsConst, class _Ty>
+using _Maybe_const = conditional_t<_IsConst, const _Ty, _Ty>;
+
 // FUNCTION TEMPLATE _Pass_fn
 // TRANSITION, VSO-386225
 template <class _Fx>

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -1253,6 +1253,10 @@ _INLINE_VAR constexpr bool _Is_random_iter_v = is_convertible_v<_Iter_cat_t<_Ite
 template <class, class = void>
 struct _Is_checked_helper {}; // default definition, no longer used, retained due to pseudo-documentation
 
+// ENUMERATIONS _ConstIter, _CheckedIter
+enum class _ConstIter : bool { _No, _Yes };
+enum class _CheckedIter : bool { _No, _Yes };
+
 // FUNCTION TEMPLATE _Adl_verify_range
 #if _ITERATOR_DEBUG_LEVEL != 0
 template <class _Ty>

--- a/tests/std/tests/Dev10_500860_overloaded_address_of/test.cpp
+++ b/tests/std/tests/Dev10_500860_overloaded_address_of/test.cpp
@@ -128,8 +128,8 @@ template class std::unordered_multiset<Evil, Hash>;
 template class std::_Array_iterator<Evil, _ConstIter::_No, _CheckedIter::_Yes>;
 template class std::_Array_iterator<Evil, _ConstIter::_Yes, _CheckedIter::_Yes>;
 
-template class std::_Deque_iterator<_Deque_val<_Deque_simple_types<Evil>>, true, true>;
-template class std::_Deque_iterator<_Deque_val<_Deque_simple_types<Evil>>, false, true>;
+template class std::_Deque_iterator<_Deque_val<_Deque_simple_types<Evil>>, _ConstIter::_No, _CheckedIter::_Yes>;
+template class std::_Deque_iterator<_Deque_val<_Deque_simple_types<Evil>>, _ConstIter::_Yes, _CheckedIter::_Yes>;
 
 template class std::_Flist_iterator<_Flist_val<_Flist_simple_types<Evil>>, false, true>;
 template class std::_Flist_iterator<_Flist_val<_Flist_simple_types<Evil>>, true, true>;
@@ -152,8 +152,8 @@ template class std::_List_const_iterator<_List_val<_List_simple_types<pair<const
 template class std::_Array_iterator<Evil, _ConstIter::_No, _CheckedIter::_No>;
 template class std::_Array_iterator<Evil, _ConstIter::_Yes, _CheckedIter::_No>;
 
-template class std::_Deque_iterator<_Deque_val<_Deque_simple_types<Evil>>, true, false>;
-template class std::_Deque_iterator<_Deque_val<_Deque_simple_types<Evil>>, false, false>;
+template class std::_Deque_iterator<_Deque_val<_Deque_simple_types<Evil>>, _ConstIter::_No, _CheckedIter::_No>;
+template class std::_Deque_iterator<_Deque_val<_Deque_simple_types<Evil>>, _ConstIter::_Yes, _CheckedIter::_No>;
 
 template class std::_Flist_iterator<_Flist_val<_Flist_simple_types<Evil>>, false, false>;
 template class std::_Flist_iterator<_Flist_val<_Flist_simple_types<Evil>>, true, false>;

--- a/tests/std/tests/Dev10_500860_overloaded_address_of/test.cpp
+++ b/tests/std/tests/Dev10_500860_overloaded_address_of/test.cpp
@@ -125,8 +125,8 @@ template class std::unordered_set<Evil, Hash>;
 template class std::unordered_multiset<Evil, Hash>;
 
 // container iterators
-template class std::_Array_iterator<Evil, true, true>;
-template class std::_Array_iterator<Evil, false, true>;
+template class std::_Array_iterator<Evil, _ConstIter::_No, _CheckedIter::_Yes>;
+template class std::_Array_iterator<Evil, _ConstIter::_Yes, _CheckedIter::_Yes>;
 
 template class std::_Deque_iterator<_Deque_val<_Deque_simple_types<Evil>>, true, true>;
 template class std::_Deque_iterator<_Deque_val<_Deque_simple_types<Evil>>, false, true>;
@@ -149,8 +149,8 @@ template class std::_List_iterator<_List_val<_List_simple_types<pair<const Evil,
 template class std::_List_const_iterator<_List_val<_List_simple_types<pair<const Evil, Evil>>>>;
 
 // unchecked container iterators
-template class std::_Array_iterator<Evil, true, false>;
-template class std::_Array_iterator<Evil, false, false>;
+template class std::_Array_iterator<Evil, _ConstIter::_No, _CheckedIter::_No>;
+template class std::_Array_iterator<Evil, _ConstIter::_Yes, _CheckedIter::_No>;
 
 template class std::_Deque_iterator<_Deque_val<_Deque_simple_types<Evil>>, true, false>;
 template class std::_Deque_iterator<_Deque_val<_Deque_simple_types<Evil>>, false, false>;

--- a/tests/std/tests/Dev10_500860_overloaded_address_of/test.cpp
+++ b/tests/std/tests/Dev10_500860_overloaded_address_of/test.cpp
@@ -131,8 +131,8 @@ template class std::_Array_iterator<Evil, false, true>;
 template class std::_Deque_iterator<_Deque_val<_Deque_simple_types<Evil>>, true, true>;
 template class std::_Deque_iterator<_Deque_val<_Deque_simple_types<Evil>>, false, true>;
 
-template class std::_Flist_iterator<_Flist_val<_Flist_simple_types<Evil>>>;
-template class std::_Flist_const_iterator<_Flist_val<_Flist_simple_types<Evil>>>;
+template class std::_Flist_iterator<_Flist_val<_Flist_simple_types<Evil>>, false, true>;
+template class std::_Flist_iterator<_Flist_val<_Flist_simple_types<Evil>>, true, true>;
 
 template class std::_List_iterator<_List_val<_List_simple_types<Evil>>>;
 template class std::_List_const_iterator<_List_val<_List_simple_types<Evil>>>;
@@ -155,8 +155,8 @@ template class std::_Array_iterator<Evil, false, false>;
 template class std::_Deque_iterator<_Deque_val<_Deque_simple_types<Evil>>, true, false>;
 template class std::_Deque_iterator<_Deque_val<_Deque_simple_types<Evil>>, false, false>;
 
-template class std::_Flist_unchecked_iterator<_Flist_val<_Flist_simple_types<Evil>>>;
-template class std::_Flist_unchecked_const_iterator<_Flist_val<_Flist_simple_types<Evil>>>;
+template class std::_Flist_iterator<_Flist_val<_Flist_simple_types<Evil>>, false, false>;
+template class std::_Flist_iterator<_Flist_val<_Flist_simple_types<Evil>>, true, false>;
 
 template class std::_List_unchecked_iterator<_List_val<_List_simple_types<Evil>>>;
 template class std::_List_unchecked_const_iterator<_List_val<_List_simple_types<Evil>>>;

--- a/tests/std/tests/Dev10_500860_overloaded_address_of/test.cpp
+++ b/tests/std/tests/Dev10_500860_overloaded_address_of/test.cpp
@@ -124,9 +124,9 @@ template class std::unordered_multimap<Evil, Evil, Hash>;
 template class std::unordered_set<Evil, Hash>;
 template class std::unordered_multiset<Evil, Hash>;
 
-
-template class std::_Array_iterator<Evil, 5>;
-template class std::_Array_const_iterator<Evil, 5>;
+// container iterators
+template class std::_Array_iterator<Evil, true, true>;
+template class std::_Array_iterator<Evil, false, true>;
 
 template class std::_Deque_iterator<_Deque_val<_Deque_simple_types<Evil>>>;
 template class std::_Deque_const_iterator<_Deque_val<_Deque_simple_types<Evil>>>;
@@ -148,6 +148,9 @@ template class std::_Tree_const_iterator<_Tree_val<_Tree_simple_types<Evil>>>;
 template class std::_List_iterator<_List_val<_List_simple_types<pair<const Evil, Evil>>>>;
 template class std::_List_const_iterator<_List_val<_List_simple_types<pair<const Evil, Evil>>>>;
 
+// unchecked container iterators
+template class std::_Array_iterator<Evil, true, false>;
+template class std::_Array_iterator<Evil, false, false>;
 
 template class std::_Deque_unchecked_iterator<_Deque_val<_Deque_simple_types<Evil>>>;
 template class std::_Deque_unchecked_const_iterator<_Deque_val<_Deque_simple_types<Evil>>>;

--- a/tests/std/tests/Dev10_500860_overloaded_address_of/test.cpp
+++ b/tests/std/tests/Dev10_500860_overloaded_address_of/test.cpp
@@ -131,8 +131,8 @@ template class std::_Array_iterator<Evil, _ConstIter::_Yes, _CheckedIter::_Yes>;
 template class std::_Deque_iterator<_Deque_val<_Deque_simple_types<Evil>>, _ConstIter::_No, _CheckedIter::_Yes>;
 template class std::_Deque_iterator<_Deque_val<_Deque_simple_types<Evil>>, _ConstIter::_Yes, _CheckedIter::_Yes>;
 
-template class std::_Flist_iterator<_Flist_val<_Flist_simple_types<Evil>>, false, true>;
-template class std::_Flist_iterator<_Flist_val<_Flist_simple_types<Evil>>, true, true>;
+template class std::_Flist_iterator<_Flist_val<_Flist_simple_types<Evil>>, _ConstIter::_No, _CheckedIter::_Yes>;
+template class std::_Flist_iterator<_Flist_val<_Flist_simple_types<Evil>>, _ConstIter::_Yes, _CheckedIter::_Yes>;
 
 template class std::_List_iterator<_List_val<_List_simple_types<Evil>>>;
 template class std::_List_const_iterator<_List_val<_List_simple_types<Evil>>>;
@@ -155,8 +155,8 @@ template class std::_Array_iterator<Evil, _ConstIter::_Yes, _CheckedIter::_No>;
 template class std::_Deque_iterator<_Deque_val<_Deque_simple_types<Evil>>, _ConstIter::_No, _CheckedIter::_No>;
 template class std::_Deque_iterator<_Deque_val<_Deque_simple_types<Evil>>, _ConstIter::_Yes, _CheckedIter::_No>;
 
-template class std::_Flist_iterator<_Flist_val<_Flist_simple_types<Evil>>, false, false>;
-template class std::_Flist_iterator<_Flist_val<_Flist_simple_types<Evil>>, true, false>;
+template class std::_Flist_iterator<_Flist_val<_Flist_simple_types<Evil>>, _ConstIter::_No, _CheckedIter::_No>;
+template class std::_Flist_iterator<_Flist_val<_Flist_simple_types<Evil>>, _ConstIter::_Yes, _CheckedIter::_No>;
 
 template class std::_List_unchecked_iterator<_List_val<_List_simple_types<Evil>>>;
 template class std::_List_unchecked_const_iterator<_List_val<_List_simple_types<Evil>>>;

--- a/tests/std/tests/Dev10_500860_overloaded_address_of/test.cpp
+++ b/tests/std/tests/Dev10_500860_overloaded_address_of/test.cpp
@@ -128,8 +128,8 @@ template class std::unordered_multiset<Evil, Hash>;
 template class std::_Array_iterator<Evil, true, true>;
 template class std::_Array_iterator<Evil, false, true>;
 
-template class std::_Deque_iterator<_Deque_val<_Deque_simple_types<Evil>>>;
-template class std::_Deque_const_iterator<_Deque_val<_Deque_simple_types<Evil>>>;
+template class std::_Deque_iterator<_Deque_val<_Deque_simple_types<Evil>>, true, true>;
+template class std::_Deque_iterator<_Deque_val<_Deque_simple_types<Evil>>, false, true>;
 
 template class std::_Flist_iterator<_Flist_val<_Flist_simple_types<Evil>>>;
 template class std::_Flist_const_iterator<_Flist_val<_Flist_simple_types<Evil>>>;
@@ -152,8 +152,8 @@ template class std::_List_const_iterator<_List_val<_List_simple_types<pair<const
 template class std::_Array_iterator<Evil, true, false>;
 template class std::_Array_iterator<Evil, false, false>;
 
-template class std::_Deque_unchecked_iterator<_Deque_val<_Deque_simple_types<Evil>>>;
-template class std::_Deque_unchecked_const_iterator<_Deque_val<_Deque_simple_types<Evil>>>;
+template class std::_Deque_iterator<_Deque_val<_Deque_simple_types<Evil>>, true, false>;
+template class std::_Deque_iterator<_Deque_val<_Deque_simple_types<Evil>>, false, false>;
 
 template class std::_Flist_unchecked_iterator<_Flist_val<_Flist_simple_types<Evil>>>;
 template class std::_Flist_unchecked_const_iterator<_Flist_val<_Flist_simple_types<Evil>>>;


### PR DESCRIPTION
Renewal of the iterator machinery has been a repeated topic for the vNext branch.

This follows the recent approach by the ranges views machinery and passes an additional boolean around to signify whether it is a const_iterator or not.

Usually it would be a private sub class of the respective container, but thanks to every ones favorite `array<_Ty, 0>` this is not possible here.

This is more a RFC whether this is the right approach and whether it makes sense for the other containers.

Also this adds `_Begin` and `_End` pointer for iterator debug which would increase memory consumption but enableoverflow checks