### PR TITLE
[[nodiscard]] for constructors

### DIFF
--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -445,7 +445,7 @@ inline void _Atomic_lock_release(_Smtx_t* _Spinlock) noexcept {
 }
 
 template <class _Spinlock_t>
-class _Atomic_lock_guard {
+class _NODISCARD _Atomic_lock_guard {
 public:
     explicit _Atomic_lock_guard(_Spinlock_t& _Spinlock_) noexcept : _Spinlock(_Spinlock_) {
         _Atomic_lock_acquire(_Spinlock);

--- a/stl/inc/condition_variable
+++ b/stl/inc/condition_variable
@@ -29,7 +29,7 @@ _STL_DISABLE_CLANG_WARNINGS
 
 _STD_BEGIN
 template <class _Lock>
-struct _Unlock_guard {
+struct _NODISCARD _Unlock_guard {
     explicit _Unlock_guard(_Lock& _Mtx_) : _Mtx(_Mtx_) {
         _Mtx.unlock();
     }

--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -2281,13 +2281,12 @@ void _Deallocate_flexible_array(_Refc* const _Ptr) noexcept {
 }
 
 template <class _NoThrowIt>
-struct _Uninitialized_rev_destroying_backout {
+struct _NODISCARD _Uninitialized_rev_destroying_backout {
     // struct to undo partially constructed ranges in _Uninitialized_xxx algorithms
     _NoThrowIt _First;
     _NoThrowIt _Last;
 
-    explicit _Uninitialized_rev_destroying_backout(_NoThrowIt _Dest) noexcept
-        : _First(_Dest), _Last(_Dest) {} // TRANSITION, P1771R1 [[nodiscard]] For Constructors
+    explicit _Uninitialized_rev_destroying_backout(_NoThrowIt _Dest) noexcept : _First(_Dest), _Last(_Dest) {}
 
     _Uninitialized_rev_destroying_backout(const _Uninitialized_rev_destroying_backout&) = delete;
     _Uninitialized_rev_destroying_backout& operator=(const _Uninitialized_rev_destroying_backout&) = delete;
@@ -2646,7 +2645,7 @@ private:
 
 #if _HAS_CXX20
 template <class _Alloc>
-class _Uninitialized_rev_destroying_backout_al {
+class _NODISCARD _Uninitialized_rev_destroying_backout_al {
     // class to undo partially constructed ranges in _Uninitialized_xxx_al algorithms
 
 private:
@@ -2654,7 +2653,7 @@ private:
 
 public:
     _Uninitialized_rev_destroying_backout_al(pointer _Dest, _Alloc& _Al_) noexcept
-        : _First(_Dest), _Last(_Dest), _Al(_Al_) {} // TRANSITION, P1771R1 [[nodiscard]] For Constructors
+        : _First(_Dest), _Last(_Dest), _Al(_Al_) {}
 
     _Uninitialized_rev_destroying_backout_al(const _Uninitialized_rev_destroying_backout_al&) = delete;
     _Uninitialized_rev_destroying_backout_al& operator=(const _Uninitialized_rev_destroying_backout_al&) = delete;

--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -2329,7 +2329,7 @@ void _Reverse_destroy_multidimensional_n(_Ty* const _Arr, size_t _Size) noexcept
 }
 
 template <class _Ty>
-struct _Reverse_destroy_multidimensional_n_guard {
+struct _NODISCARD _Reverse_destroy_multidimensional_n_guard {
     _Ty* _Target;
     size_t _Index;
 
@@ -2696,7 +2696,7 @@ void _Reverse_destroy_multidimensional_n_al(_Ty* const _Arr, size_t _Size, _Allo
 }
 
 template <class _Ty, class _Alloc>
-struct _Reverse_destroy_multidimensional_n_al_guard {
+struct _NODISCARD _Reverse_destroy_multidimensional_n_al_guard {
     _Ty* _Target;
     size_t _Index;
     _Alloc& _Al;
@@ -2913,7 +2913,7 @@ _NODISCARD
 
 #if _HAS_CXX20
 template <class _Refc>
-struct _Global_delete_guard {
+struct _NODISCARD _Global_delete_guard {
     _Refc* _Target;
 
     ~_Global_delete_guard() {

--- a/stl/inc/mutex
+++ b/stl/inc/mutex
@@ -125,7 +125,7 @@ _INLINE_VAR constexpr try_to_lock_t try_to_lock{};
 
 // CLASS TEMPLATE unique_lock
 template <class _Mutex>
-class unique_lock { // whizzy class with destructor that unlocks mutex
+class _NODISCARD_CTOR unique_lock { // whizzy class with destructor that unlocks mutex
 public:
     using mutex_type = _Mutex;
 
@@ -421,7 +421,7 @@ void lock(_Lock0& _Lk0, _Lock1& _Lk1, _LockN&... _LkN) { // lock multiple locks,
 
 // CLASS TEMPLATE lock_guard
 template <class _Mutex>
-class lock_guard { // class with destructor that unlocks a mutex
+class _NODISCARD_CTOR lock_guard { // class with destructor that unlocks a mutex
 public:
     using mutex_type = _Mutex;
 
@@ -445,7 +445,7 @@ private:
 #if _HAS_CXX17
 // CLASS TEMPLATE scoped_lock
 template <class... _Mutexes>
-class scoped_lock { // class with destructor that unlocks mutexes
+class _NODISCARD_CTOR scoped_lock { // class with destructor that unlocks mutexes
 public:
     explicit scoped_lock(_Mutexes&... _Mtxes) : _MyMutexes(_Mtxes...) { // construct and lock
         _STD lock(_Mtxes...);
@@ -465,7 +465,7 @@ private:
 };
 
 template <class _Mutex>
-class scoped_lock<_Mutex> {
+class _NODISCARD_CTOR scoped_lock<_Mutex> {
 public:
     using mutex_type = _Mutex;
 

--- a/stl/inc/mutex
+++ b/stl/inc/mutex
@@ -125,7 +125,7 @@ _INLINE_VAR constexpr try_to_lock_t try_to_lock{};
 
 // CLASS TEMPLATE unique_lock
 template <class _Mutex>
-class _NODISCARD_CTOR unique_lock { // whizzy class with destructor that unlocks mutex
+class _NODISCARD unique_lock { // whizzy class with destructor that unlocks mutex
 public:
     using mutex_type = _Mutex;
 
@@ -421,7 +421,7 @@ void lock(_Lock0& _Lk0, _Lock1& _Lk1, _LockN&... _LkN) { // lock multiple locks,
 
 // CLASS TEMPLATE lock_guard
 template <class _Mutex>
-class _NODISCARD_CTOR lock_guard { // class with destructor that unlocks a mutex
+class _NODISCARD lock_guard { // class with destructor that unlocks a mutex
 public:
     using mutex_type = _Mutex;
 
@@ -445,7 +445,7 @@ private:
 #if _HAS_CXX17
 // CLASS TEMPLATE scoped_lock
 template <class... _Mutexes>
-class _NODISCARD_CTOR scoped_lock { // class with destructor that unlocks mutexes
+class _NODISCARD scoped_lock { // class with destructor that unlocks mutexes
 public:
     explicit scoped_lock(_Mutexes&... _Mtxes) : _MyMutexes(_Mtxes...) { // construct and lock
         _STD lock(_Mtxes...);
@@ -465,7 +465,7 @@ private:
 };
 
 template <class _Mutex>
-class _NODISCARD_CTOR scoped_lock<_Mutex> {
+class _NODISCARD scoped_lock<_Mutex> {
 public:
     using mutex_type = _Mutex;
 

--- a/stl/inc/shared_mutex
+++ b/stl/inc/shared_mutex
@@ -227,7 +227,7 @@ private:
 
 // CLASS TEMPLATE shared_lock
 template <class _Mutex>
-class _NODISCARD_CTOR shared_lock { // shareable lock
+class _NODISCARD shared_lock { // shareable lock
 public:
     using mutex_type = _Mutex;
 

--- a/stl/inc/shared_mutex
+++ b/stl/inc/shared_mutex
@@ -227,7 +227,7 @@ private:
 
 // CLASS TEMPLATE shared_lock
 template <class _Mutex>
-class shared_lock { // shareable lock
+class _NODISCARD_CTOR shared_lock { // shareable lock
 public:
     using mutex_type = _Mutex;
 

--- a/stl/inc/thread
+++ b/stl/inc/thread
@@ -85,7 +85,7 @@ private:
 
 public:
     template <class _Fn, class... _Args, enable_if_t<!is_same_v<_Remove_cvref_t<_Fn>, thread>, int> = 0>
-    explicit thread(_Fn&& _Fx, _Args&&... _Ax) {
+    _NODISCARD_CTOR explicit thread(_Fn&& _Fx, _Args&&... _Ax) {
         _Start(_STD forward<_Fn>(_Fx), _STD forward<_Args>(_Ax)...);
     }
 
@@ -282,7 +282,7 @@ public:
     jthread() noexcept : _Impl{}, _Ssource{nostopstate} {}
 
     template <class _Fn, class... _Args, enable_if_t<!is_same_v<remove_cvref_t<_Fn>, jthread>, int> = 0>
-    explicit jthread(_Fn&& _Fx, _Args&&... _Ax) {
+    _NODISCARD_CTOR explicit jthread(_Fn&& _Fx, _Args&&... _Ax) {
         if constexpr (is_invocable_v<decay_t<_Fn>, stop_token, decay_t<_Args>...>) {
             _Impl._Start(_STD forward<_Fn>(_Fx), _Ssource.get_token(), _STD forward<_Args>(_Ax)...);
         } else {

--- a/stl/inc/xhash
+++ b/stl/inc/xhash
@@ -486,7 +486,7 @@ private:
         _Pocma(_Vec._Mypair._Get_first(), _Right._Vec._Mypair._Get_first());
     }
 
-    struct _Clear_guard {
+    struct _NODISCARD _Clear_guard {
         _Hash* _Target;
 
         explicit _Clear_guard(_Hash* const _Target_) : _Target(_Target_) {}

--- a/stl/inc/xlocale
+++ b/stl/inc/xlocale
@@ -159,7 +159,7 @@ public:
         facet& __CLR_OR_THIS_CALL operator=(const facet&) = delete;
     };
 
-    struct _Facet_guard {
+    struct _NODISCARD _Facet_guard {
         facet* _Target;
         ~_Facet_guard() {
             if (_Target) {
@@ -1377,7 +1377,7 @@ private:
 
 #if defined(__cpp_char8_t) && !defined(_M_CEE_PURE)
 template <class _From, class _To>
-struct _Codecvt_guard {
+struct _NODISCARD _Codecvt_guard {
     const _From* const& _First1;
     const _From*& _Mid1;
     _To* const& _First2;

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -25,7 +25,7 @@ _STL_DISABLE_CLANG_WARNINGS
 _STD_BEGIN
 // STRUCT TEMPLATE _Tidy_guard
 template <class _Ty>
-struct _Tidy_guard { // class with destructor that calls _Tidy
+struct _NODISCARD _Tidy_guard { // class with destructor that calls _Tidy
     _Ty* _Target;
     ~_Tidy_guard() {
         if (_Target) {
@@ -36,7 +36,7 @@ struct _Tidy_guard { // class with destructor that calls _Tidy
 
 // STRUCT TEMPLATE _Tidy_deallocate_guard
 template <class _Ty>
-struct _Tidy_deallocate_guard { // class with destructor that calls _Tidy_deallocate
+struct _NODISCARD _Tidy_deallocate_guard { // class with destructor that calls _Tidy_deallocate
     _Ty* _Target;
     ~_Tidy_deallocate_guard() {
         if (_Target) {
@@ -226,7 +226,7 @@ void _Deallocate(void* _Ptr, size_t _Bytes) noexcept {
 // FUNCTION TEMPLATE _Global_new
 template <class _Ty, class... _Types>
 _Ty* _Global_new(_Types&&... _Args) { // acts as "new" while disallowing user overload selection
-    struct _Guard_type {
+    struct _NODISCARD _Guard_type {
         void* _Result;
         ~_Guard_type() {
             if (_Result) {

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -1415,7 +1415,8 @@ void _Return_temporary_buffer(_Ty* const _Pbuf) noexcept {
 
 // STRUCT TEMPLATE _Uninitialized_backout
 template <class _NoThrowFwdIt>
-struct _Uninitialized_backout { // struct to undo partially constructed ranges in _Uninitialized_xxx algorithms
+struct _NODISCARD _Uninitialized_backout {
+    // struct to undo partially constructed ranges in _Uninitialized_xxx algorithms
     _NoThrowFwdIt _First;
     _NoThrowFwdIt _Last;
 
@@ -1513,7 +1514,8 @@ _NoThrowFwdIt _Uninitialized_move_unchecked(_InIt _First, const _InIt _Last, _No
 
 // STRUCT TEMPLATE _Uninitialized_backout_al
 template <class _Alloc>
-class _Uninitialized_backout_al { // struct to undo partially constructed ranges in _Uninitialized_xxx_al algorithms
+class _NODISCARD _Uninitialized_backout_al {
+    // struct to undo partially constructed ranges in _Uninitialized_xxx_al algorithms
     using pointer = _Alloc_ptr_t<_Alloc>;
 
 public:

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -351,6 +351,14 @@
 // _HAS_NODISCARD (in vcruntime.h) controls:
 // [[nodiscard]] attributes on STL functions
 
+#ifndef __has_cpp_attribute
+#define _NODISCARD_CTOR
+#elif __has_cpp_attribute(nodiscard) >= 201907L
+#define _NODISCARD_CTOR _NODISCARD
+#else
+#define _NODISCARD_CTOR
+#endif
+
 // Determine if we should use [[msvc::known_semantics]] to communicate to the compiler
 // that certain type trait specializations have the standard-mandated semantics
 #ifndef __has_cpp_attribute

--- a/stl/src/atomic_wait.cpp
+++ b/stl/src/atomic_wait.cpp
@@ -26,7 +26,7 @@ namespace {
         CONDITION_VARIABLE _Condition;
     };
 
-    struct _Guarded_wait_context : _Wait_context {
+    struct _NODISCARD _Guarded_wait_context : _Wait_context {
         _Guarded_wait_context(const void* _Storage_, _Wait_context* const _Head) noexcept
             : _Wait_context{_Storage_, _Head, _Head->_Prev, CONDITION_VARIABLE_INIT} {
             _Prev->_Next = this;
@@ -44,7 +44,7 @@ namespace {
         _Guarded_wait_context& operator=(const _Guarded_wait_context&) = delete;
     };
 
-    class _SrwLock_guard {
+    class _NODISCARD _SrwLock_guard {
     public:
         explicit _SrwLock_guard(SRWLOCK& _Locked_) noexcept : _Locked(&_Locked_) {
             AcquireSRWLockExclusive(_Locked);


### PR DESCRIPTION
Fixes #63.

If there are any more places where it would make sense to add `[[nodiscard]]` please let me know.