### PR TITLE
Allow atomic_ref<const T>

### DIFF
--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -2346,12 +2346,7 @@ private:
     using _Base = _Choose_atomic_base_t<_Ty, _Ty&>;
 
 public:
-    // clang-format off
-    static_assert(is_trivially_copyable_v<_Ty> && is_copy_constructible_v<_Ty> && is_move_constructible_v<_Ty>
-        && is_copy_assignable_v<_Ty> && is_move_assignable_v<_Ty>,
-        "atomic_ref<T> requires T to be trivially copyable, copy constructible, move constructible, copy assignable, "
-        "and move assignable.");
-    // clang-format on
+    static_assert(is_trivially_copyable_v<_Ty>, "atomic_ref<T> requires T to be trivially copyable.");
 
     using value_type = _Ty;
 

--- a/tests/std/tests/P0019R8_atomic_ref/test.cpp
+++ b/tests/std/tests/P0019R8_atomic_ref/test.cpp
@@ -270,9 +270,9 @@ void test_ptr_ops() {
 }
 
 // GH-1497 <atomic>: atomic_ref<const T> fails to compile
-void test_gh_1497() {
+void test_gh_1497_const_type() {
     {
-        const int ci{1729};
+        static constexpr int ci{1729}; // static storage duration, so this is stored in read-only memory
         const std::atomic_ref atom{ci};
         assert(atom.load() == 1729);
     }
@@ -340,5 +340,5 @@ int main() {
     test_ptr_ops<char*>();
     test_ptr_ops<long*>();
 
-    test_gh_1497();
+    test_gh_1497_const_type();
 }

--- a/tests/std/tests/P0019R8_atomic_ref/test.cpp
+++ b/tests/std/tests/P0019R8_atomic_ref/test.cpp
@@ -269,6 +269,26 @@ void test_ptr_ops() {
     assert(ry.load() == a + 0x10);
 }
 
+// GH-1497 <atomic>: atomic_ref<const T> fails to compile
+void test_gh_1497() {
+    {
+        const int ci{1729};
+        const std::atomic_ref atom{ci};
+        assert(atom.load() == 1729);
+    }
+
+    {
+        int i{11};
+        const std::atomic_ref<int> atom_modify{i};
+        const std::atomic_ref<const int> atom_observe{i};
+        assert(atom_modify.load() == 11);
+        assert(atom_observe.load() == 11);
+        atom_modify.store(22);
+        assert(atom_modify.load() == 22);
+        assert(atom_observe.load() == 22);
+    }
+}
+
 int main() {
     test_ops<false, char>();
     test_ops<false, signed char>();
@@ -319,4 +339,6 @@ int main() {
 
     test_ptr_ops<char*>();
     test_ptr_ops<long*>();
+
+    test_gh_1497();
 }


### PR DESCRIPTION
Fixes #1497. While `atomic` and `atomic_ref` are similar in many ways, they need different `static_assert`s:

:heavy_check_mark: `atomic`
---
WG21-N4868 [31.8.1 [atomics.types.generic.general]/1](https://eel.is/c++draft/atomics.types.generic.general#1): "The program is ill-formed if any of `is_­trivially_­copyable_­v<T>`, `is_­copy_­constructible_­v<T>`, `is_­move_­constructible_­v<T>`, `is_­copy_­assignable_­v<T>`, or `is_­move_­assignable_­v<T>` is `false`."
https://github.com/microsoft/STL/blob/19c683d70647f9d89d47f5a0ad25165fc8becbf3/stl/inc/atomic#L2165-L2168

:beetle: `atomic_ref`
---
WG21-N4868 [31.7.1 [atomics.ref.generic.general]/2](https://eel.is/c++draft/atomics.ref.generic.general#2): "The program is ill-formed if `is_­trivially_­copyable_­v<T>` is false."
https://github.com/microsoft/STL/blob/19c683d70647f9d89d47f5a0ad25165fc8becbf3/stl/inc/atomic#L2350-L2353

Testing
---
I looked into testing a non-copy-constructible, yet trivially-copy-assignable, type. However, because `atomic_ref::store` passes `T` by value, it appears that this doesn't actually work, and it's unclear from the Standardese whether it's supposed to. So, this PR simply fixes the `static_assert` to match the Standardese and tests `atomic_ref<const int>`.