### PR TITLE
LWG-3170 is_always_equal added to std::allocator makes the standard library treat derived types as always equal

### DIFF
--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -400,10 +400,12 @@ struct _Get_is_always_equal {
     using type = bool_constant<is_empty_v<_Ty>>;
 };
 
+_STL_DISABLE_DEPRECATED_WARNING
 template <class _Ty>
 struct _Get_is_always_equal<_Ty, void_t<typename _Ty::is_always_equal>> {
     using type = typename _Ty::is_always_equal;
 };
+_STL_RESTORE_DEPRECATED_WARNING
 
 // STRUCT TEMPLATE _Get_rebind_type
 template <class _Ty, class _Other, class = void>

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -776,7 +776,7 @@ public:
     using size_type       = size_t;
     using difference_type = ptrdiff_t;
 
-    using propagate_on_container_move_assignment = true_type;
+    using propagate_on_container_move_assignment                 = true_type;
     using is_always_equal _CXX17_DEPRECATE_OLD_ALLOCATOR_MEMBERS = true_type;
 
     template <class _Other>
@@ -838,7 +838,7 @@ public:
     using size_type       = size_t;
     using difference_type = ptrdiff_t;
 
-    using propagate_on_container_move_assignment = true_type;
+    using propagate_on_container_move_assignment                 = true_type;
     using is_always_equal _CXX17_DEPRECATE_OLD_ALLOCATOR_MEMBERS = true_type;
 
     template <class _Other>

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -777,7 +777,7 @@ public:
     using difference_type = ptrdiff_t;
 
     using propagate_on_container_move_assignment = true_type;
-    using is_always_equal                        = true_type;
+    using is_always_equal _CXX17_DEPRECATE_OLD_ALLOCATOR_MEMBERS = true_type;
 
     template <class _Other>
     struct _CXX17_DEPRECATE_OLD_ALLOCATOR_MEMBERS rebind {
@@ -839,7 +839,7 @@ public:
     using difference_type = ptrdiff_t;
 
     using propagate_on_container_move_assignment = true_type;
-    using is_always_equal                        = true_type;
+    using is_always_equal _CXX17_DEPRECATE_OLD_ALLOCATOR_MEMBERS = true_type;
 
     template <class _Other>
     struct _CXX17_DEPRECATE_OLD_ALLOCATOR_MEMBERS rebind {


### PR DESCRIPTION
Fixes #1466 
`using is_always_equal = true_type;` presents in `_Default_allocator_traits`, so according to this part of LWG:

    Add a new subclause in Annex D after D.13 [depr.str.strstreams]:

```
D.? The default allocator [depr.default.allocator]

-?- The following member is defined in addition to those specified in 20.10.10 [default.allocator]:

namespace std {
  template <class T> class allocator {
  public:
    using is_always_equal = true_type;
  };
}
```

I've just marked `is_always_equal` member of `std::allocator<T>` as deprecated