### PR TITLE
Rewrite InterlockedExchange128_nf with intrinsics on clang

### DIFF
--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -478,7 +478,7 @@ inline bool __stdcall _Atomic_wait_compare_16_bytes(const void* _Storage, void* 
 
 #ifdef _M_ARM64
 #ifdef __clang__ // TRANSITION, Clang 12
-    const auto _Dest = static_cast<const __int128*>(_Storage);
+    auto _Dest       = static_cast<__int128*>(const_cast<void*>(_Storage));
     const auto _Tmp  = static_cast<const __int128*>(_Comparand);
 
     do {

--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -478,8 +478,8 @@ inline bool __stdcall _Atomic_wait_compare_16_bytes(const void* _Storage, void* 
 
 #ifdef _M_ARM64
 #ifdef __clang__ // TRANSITION, Clang 12
-    auto _Dest       = static_cast<__int128*>(const_cast<void*>(_Storage));
-    const auto _Tmp  = static_cast<const __int128*>(_Comparand);
+    auto _Dest      = static_cast<__int128*>(const_cast<void*>(_Storage));
+    const auto _Tmp = static_cast<const __int128*>(_Comparand);
 
     do {
         if (__builtin_arm_ldrex(_Dest) != *_Tmp) {

--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -477,24 +477,24 @@ bool __stdcall _Atomic_wait_compare_non_lock_free(
 inline bool __stdcall _Atomic_wait_compare_16_bytes(const void* _Storage, void* _Comparand, size_t, void*) noexcept {
 
 #ifdef _M_ARM64
-#ifndef __clang__
+#ifdef __clang__ // TRANSITION, Clang 12
+    const auto _Dest = static_cast<const __int128*>(_Storage);
+    const auto _Tmp  = static_cast<const __int128*>(_Comparand);
+
+    do {
+        if (__builtin_arm_ldrex(_Dest) != *_Tmp) {
+            return false;
+        }
+    } while (__builtin_arm_strex(*_Tmp, _Dest));
+
+    return true;
+#else // ^^^ __clang__ / !__clang__ vvv
     const auto _Dest              = static_cast<long long*>(const_cast<void*>(_Storage));
     const auto _Cmp               = static_cast<const long long*>(_Comparand);
     alignas(16) long long _Tmp[2] = {_Cmp[0], _Cmp[1]};
 
     return _InterlockedCompareExchange128_nf(_Dest, _Tmp[1], _Tmp[0], _Tmp) != 0;
-#else // ^^^ !__clang__ / __clang__ vvv
-    const auto _Dest          = static_cast<__int128*>(const_cast<void*>(_Storage));
-    alignas(16) __int128 _Tmp = static_cast<const __int128*>(_Comparand)[0];
-
-    do {
-        if (__builtin_arm_ldrex(_Dest) != _Tmp) {
-            return false;
-        }
-    } while (__builtin_arm_strex(_Tmp, _Dest));
-
-    return true;
-#endif // ^^^ __clang__ ^^^
+#endif // ^^^ !__clang__ ^^^
 #else // ^^^ ARM64 / !ARM64 vvv
     const auto _Dest              = static_cast<long long*>(const_cast<void*>(_Storage));
     const auto _Cmp               = static_cast<const long long*>(_Comparand);

--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -484,7 +484,7 @@ inline bool __stdcall _Atomic_wait_compare_16_bytes(const void* _Storage, void* 
 
     return _InterlockedCompareExchange128_nf(_Dest, _Tmp[1], _Tmp[0], _Tmp) != 0;
 #else // ^^^ !__clang__ / __clang__ vvv
-    __int128* _Dest           = static_cast<__int128*>(const_cast<void*>(_Storage));
+    const auto _Dest          = static_cast<__int128*>(const_cast<void*>(_Storage));
     alignas(16) __int128 _Tmp = static_cast<const __int128*>(_Comparand)[0];
 
     do {

--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -475,11 +475,9 @@ bool __stdcall _Atomic_wait_compare_non_lock_free(
 
 #ifdef _WIN64
 inline bool __stdcall _Atomic_wait_compare_16_bytes(const void* _Storage, void* _Comparand, size_t, void*) noexcept {
-
-#ifdef _M_ARM64
-#ifdef __clang__ // TRANSITION, Clang 12
-    auto _Dest      = static_cast<__int128*>(const_cast<void*>(_Storage));
-    const auto _Tmp = static_cast<const __int128*>(_Comparand);
+#if defined(__clang__) && defined(_M_ARM64) // TRANSITION, Clang 12
+    const auto _Dest = static_cast<__int128*>(const_cast<void*>(_Storage));
+    const auto _Tmp  = static_cast<const __int128*>(_Comparand);
 
     do {
         if (__builtin_arm_ldrex(_Dest) != *_Tmp) {
@@ -488,20 +486,16 @@ inline bool __stdcall _Atomic_wait_compare_16_bytes(const void* _Storage, void* 
     } while (__builtin_arm_strex(*_Tmp, _Dest));
 
     return true;
-#else // ^^^ __clang__ / !__clang__ vvv
+#else // ^^^ workaround / no workaround vvv
     const auto _Dest              = static_cast<long long*>(const_cast<void*>(_Storage));
     const auto _Cmp               = static_cast<const long long*>(_Comparand);
     alignas(16) long long _Tmp[2] = {_Cmp[0], _Cmp[1]};
-
-    return _InterlockedCompareExchange128_nf(_Dest, _Tmp[1], _Tmp[0], _Tmp) != 0;
-#endif // ^^^ !__clang__ ^^^
-#else // ^^^ ARM64 / !ARM64 vvv
-    const auto _Dest              = static_cast<long long*>(const_cast<void*>(_Storage));
-    const auto _Cmp               = static_cast<const long long*>(_Comparand);
-    alignas(16) long long _Tmp[2] = {_Cmp[0], _Cmp[1]};
-
+#ifdef _M_X64
     return _STD_COMPARE_EXCHANGE_128(_Dest, _Tmp[1], _Tmp[0], _Tmp) != 0;
-#endif // ^^^ !ARM64 ^^^
+#else // ^^^ _M_X64 / ARM64 vvv
+    return _InterlockedCompareExchange128_nf(_Dest, _Tmp[1], _Tmp[0], _Tmp) != 0;
+#endif // ^^^ ARM64 ^^^
+#endif // TRANSITION, Clang 12
 }
 #endif // _WIN64
 #endif // _HAS_CXX20

--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -477,13 +477,13 @@ bool __stdcall _Atomic_wait_compare_non_lock_free(
 inline bool __stdcall _Atomic_wait_compare_16_bytes(const void* _Storage, void* _Comparand, size_t, void*) noexcept {
 #if defined(__clang__) && defined(_M_ARM64) // TRANSITION, Clang 12
     const auto _Dest = static_cast<__int128*>(const_cast<void*>(_Storage));
-    const auto _Tmp  = static_cast<const __int128*>(_Comparand);
+    const auto _Cmp  = static_cast<const __int128*>(_Comparand);
 
     do {
-        if (__builtin_arm_ldrex(_Dest) != *_Tmp) {
+        if (__builtin_arm_ldrex(_Dest) != *_Cmp) {
             return false;
         }
-    } while (__builtin_arm_strex(*_Tmp, _Dest));
+    } while (__builtin_arm_strex(*_Cmp, _Dest));
 
     return true;
 #else // ^^^ workaround / no workaround vvv

--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -475,14 +475,33 @@ bool __stdcall _Atomic_wait_compare_non_lock_free(
 
 #ifdef _WIN64
 inline bool __stdcall _Atomic_wait_compare_16_bytes(const void* _Storage, void* _Comparand, size_t, void*) noexcept {
+
+#ifdef _M_ARM64
+#ifndef __clang__
     const auto _Dest              = static_cast<long long*>(const_cast<void*>(_Storage));
     const auto _Cmp               = static_cast<const long long*>(_Comparand);
     alignas(16) long long _Tmp[2] = {_Cmp[0], _Cmp[1]};
-#ifdef _M_X64
-    return _STD_COMPARE_EXCHANGE_128(_Dest, _Tmp[1], _Tmp[0], _Tmp) != 0;
-#else // ^^^ _M_X64 / ARM64 vvv
+
     return _InterlockedCompareExchange128_nf(_Dest, _Tmp[1], _Tmp[0], _Tmp) != 0;
-#endif // ^^^ ARM64 ^^^
+#else // ^^^ !__clang__ / __clang__ vvv
+    __int128* _Dest           = static_cast<__int128*>(const_cast<void*>(_Storage));
+    alignas(16) __int128 _Tmp = static_cast<const __int128*>(_Comparand)[0];
+
+    do {
+        if (__builtin_arm_ldrex(_Dest) != _Tmp) {
+            return false;
+        }
+    } while (__builtin_arm_strex(_Tmp, _Dest));
+
+    return true;
+#endif // ^^^ __clang__ ^^^
+#else // ^^^ ARM64 / !ARM64 vvv
+    const auto _Dest              = static_cast<long long*>(const_cast<void*>(_Storage));
+    const auto _Cmp               = static_cast<const long long*>(_Comparand);
+    alignas(16) long long _Tmp[2] = {_Cmp[0], _Cmp[1]};
+
+    return _STD_COMPARE_EXCHANGE_128(_Dest, _Tmp[1], _Tmp[0], _Tmp) != 0;
+#endif // ^^^ !ARM64 ^^^
 }
 #endif // _WIN64
 #endif // _HAS_CXX20


### PR DESCRIPTION
I'm not sure the `alignas(16)` on the `__int128` is strictly necessary.
I'm also not 100% sure this is correct, though all the tests I ran on my Surface Pro X passed.

@BillyONeal @AlexGuteniev bat signals.

The codegen also seems right:
[https://godbolt.org/z/1d8MnT](https://godbolt.org/z/1d8MnT) vs
```
; Listing generated by Microsoft (R) Optimizing Compiler Version 19.28.29515.1

        TTL     C:\sources\test.obj
        ARM64

        AREA    |.drectve|, DRECTVE

        EXPORT  |?dest@@3RC_JC| [ DATA ]                ; dest

        AREA    |.data|, DATA
|?dest@@3RC_JC| DCQ 0x0, 0x0                            ;  = 0x0000000000000000 ; dest
        DCQ     0x1, 0x0                                ;  = 0x0000000000000001
        EXPORT  |main|

        AREA    |.pdata|, PDATA
|$pdata$main| DCD imagerel |$LN6|
        DCD     0x80004d
        ;Flags[SingleProEpi] functionLength[76] RegF[0] RegI[0] H[0] frameChainReturn[UnChained] frameSize[16]
; Function compile flags: /Odsp
; File C:\sources\test.cpp

        AREA    |.text$mn|, CODE, ARM64

|main|  PROC

; 6    : int main() {

|$LN6|
        sub         sp,sp,#0x10

; 7    :     __int64 compare[2];
; 8    :     _InterlockedCompareExchange128_nf(dest, compare[1], compare[0], compare);

        mov         x7,sp
        adrp        x8,|?dest@@3RC_JC|
        add         x15,x8,PageOffset(|?dest@@3RC_JC|)
        ldr         x14,[sp,#8]
        ldr         x13,[sp]
        ldp         x12,x11,[x7]
|$LN3@main|
        ldxp        x10,x9,[x15]
        cmp         x10,x12
        bne         |$LN4@main|
        cmp         x9,x11
        bne         |$LN4@main|
        stxp        w8,x13,x14,[x15]
        cmp         w8,#0
        bne         |$LN3@main|
|$LN4@main|
        stp         x10,x9,[x7]

; 9    :     return 0;

        mov         w0,#0
        add         sp,sp,#0x10
        ret

        ENDP  ; |main|

        END
```