### PR TITLE
Correct overly-strengthened noexcept-specifier for basic_string_view constructor

### DIFF
--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -1248,7 +1248,7 @@ public:
     // clang-format off
     template <contiguous_iterator _It, sized_sentinel_for<_It> _Se>
         requires (is_same_v<iter_value_t<_It>, _Elem> && !is_convertible_v<_Se, size_type>)
-    constexpr basic_string_view(_It _First, _Se _Last) noexcept // strengthened
+    constexpr basic_string_view(_It _First, _Se _Last) noexcept(noexcept(_Last - _First)) // strengthened
         : _Mydata(_STD to_address(_First)), _Mysize(static_cast<size_type>(_Last - _First)) {}
     // clang-format on
 #endif // __cpp_lib_concepts


### PR DESCRIPTION
IIRC this _noexcept-specifier_ was originally (incorrectly) `noexcept(to_address(_First))` in the Standard, which was "corrected" both here and in an LWG issue to `noexcept(true)` since `to_address` never throws. WG21 noticed that we'd been ignoring all along that the difference operation in the size calculation could throw and fixed the Standard by removing the _noexcept-specifier_ completely, but for whatever reason I dropped the ball on fixing our strengthening appropriately until last week when I noticed this while experimentally implementing WG21-P1989.