### PR TITLE
Allow discarding unique_lock and shared_lock

### DIFF
--- a/stl/inc/mutex
+++ b/stl/inc/mutex
@@ -132,34 +132,35 @@ public:
     // CONSTRUCT, ASSIGN, AND DESTROY
     unique_lock() noexcept : _Pmtx(nullptr), _Owns(false) {}
 
-    explicit unique_lock(_Mutex& _Mtx) : _Pmtx(_STD addressof(_Mtx)), _Owns(false) { // construct and lock
+    _NODISCARD_CTOR explicit unique_lock(_Mutex& _Mtx)
+        : _Pmtx(_STD addressof(_Mtx)), _Owns(false) { // construct and lock
         _Pmtx->lock();
         _Owns = true;
     }
 
-    unique_lock(_Mutex& _Mtx, adopt_lock_t)
+    _NODISCARD_CTOR unique_lock(_Mutex& _Mtx, adopt_lock_t)
         : _Pmtx(_STD addressof(_Mtx)), _Owns(true) {} // construct and assume already locked
 
     unique_lock(_Mutex& _Mtx, defer_lock_t) noexcept
         : _Pmtx(_STD addressof(_Mtx)), _Owns(false) {} // construct but don't lock
 
-    unique_lock(_Mutex& _Mtx, try_to_lock_t)
+    _NODISCARD_CTOR unique_lock(_Mutex& _Mtx, try_to_lock_t)
         : _Pmtx(_STD addressof(_Mtx)), _Owns(_Pmtx->try_lock()) {} // construct and try to lock
 
     template <class _Rep, class _Period>
-    unique_lock(_Mutex& _Mtx, const chrono::duration<_Rep, _Period>& _Rel_time)
+    _NODISCARD_CTOR unique_lock(_Mutex& _Mtx, const chrono::duration<_Rep, _Period>& _Rel_time)
         : _Pmtx(_STD addressof(_Mtx)), _Owns(_Pmtx->try_lock_for(_Rel_time)) {} // construct and lock with timeout
 
     template <class _Clock, class _Duration>
-    unique_lock(_Mutex& _Mtx, const chrono::time_point<_Clock, _Duration>& _Abs_time)
+    _NODISCARD_CTOR unique_lock(_Mutex& _Mtx, const chrono::time_point<_Clock, _Duration>& _Abs_time)
         : _Pmtx(_STD addressof(_Mtx)), _Owns(_Pmtx->try_lock_until(_Abs_time)) {} // construct and lock with timeout
 
-    unique_lock(_Mutex& _Mtx, const xtime* _Abs_time)
+    _NODISCARD_CTOR unique_lock(_Mutex& _Mtx, const xtime* _Abs_time)
         : _Pmtx(_STD addressof(_Mtx)), _Owns(false) { // try to lock until _Abs_time
         _Owns = _Pmtx->try_lock_until(_Abs_time);
     }
 
-    unique_lock(unique_lock&& _Other) noexcept : _Pmtx(_Other._Pmtx), _Owns(_Other._Owns) {
+    _NODISCARD_CTOR unique_lock(unique_lock&& _Other) noexcept : _Pmtx(_Other._Pmtx), _Owns(_Other._Owns) {
         _Other._Pmtx = nullptr;
         _Other._Owns = false;
     }

--- a/stl/inc/mutex
+++ b/stl/inc/mutex
@@ -125,7 +125,7 @@ _INLINE_VAR constexpr try_to_lock_t try_to_lock{};
 
 // CLASS TEMPLATE unique_lock
 template <class _Mutex>
-class _NODISCARD unique_lock { // whizzy class with destructor that unlocks mutex
+class unique_lock { // whizzy class with destructor that unlocks mutex
 public:
     using mutex_type = _Mutex;
 

--- a/stl/inc/shared_mutex
+++ b/stl/inc/shared_mutex
@@ -227,13 +227,13 @@ private:
 
 // CLASS TEMPLATE shared_lock
 template <class _Mutex>
-class _NODISCARD shared_lock { // shareable lock
+class shared_lock { // shareable lock
 public:
     using mutex_type = _Mutex;
 
     shared_lock() noexcept : _Pmtx(nullptr), _Owns(false) {}
 
-    explicit shared_lock(mutex_type& _Mtx)
+    _NODISCARD_CTOR explicit shared_lock(mutex_type& _Mtx)
         : _Pmtx(_STD addressof(_Mtx)), _Owns(true) { // construct with mutex and lock shared
         _Mtx.lock_shared();
     }
@@ -241,20 +241,20 @@ public:
     shared_lock(mutex_type& _Mtx, defer_lock_t) noexcept
         : _Pmtx(_STD addressof(_Mtx)), _Owns(false) {} // construct with unlocked mutex
 
-    shared_lock(mutex_type& _Mtx, try_to_lock_t)
+    _NODISCARD_CTOR shared_lock(mutex_type& _Mtx, try_to_lock_t)
         : _Pmtx(_STD addressof(_Mtx)), _Owns(_Mtx.try_lock_shared()) {} // construct with mutex and try to lock shared
 
-    shared_lock(mutex_type& _Mtx, adopt_lock_t)
+    _NODISCARD_CTOR shared_lock(mutex_type& _Mtx, adopt_lock_t)
         : _Pmtx(_STD addressof(_Mtx)), _Owns(true) {} // construct with mutex and adopt ownership
 
     template <class _Rep, class _Period>
-    shared_lock(mutex_type& _Mtx, const chrono::duration<_Rep, _Period>& _Rel_time)
+    _NODISCARD_CTOR shared_lock(mutex_type& _Mtx, const chrono::duration<_Rep, _Period>& _Rel_time)
         : _Pmtx(_STD addressof(_Mtx)), _Owns(_Mtx.try_lock_shared_for(_Rel_time)) {
         // construct with mutex and try to lock for relative time
     }
 
     template <class _Clock, class _Duration>
-    shared_lock(mutex_type& _Mtx, const chrono::time_point<_Clock, _Duration>& _Abs_time)
+    _NODISCARD_CTOR shared_lock(mutex_type& _Mtx, const chrono::time_point<_Clock, _Duration>& _Abs_time)
         : _Pmtx(_STD addressof(_Mtx)), _Owns(_Mtx.try_lock_shared_until(_Abs_time)) {
         // construct with mutex and try to lock until absolute time
     }

--- a/stl/inc/shared_mutex
+++ b/stl/inc/shared_mutex
@@ -265,7 +265,7 @@ public:
         }
     }
 
-    shared_lock(shared_lock&& _Other) noexcept : _Pmtx(_Other._Pmtx), _Owns(_Other._Owns) {
+    _NODISCARD_CTOR shared_lock(shared_lock&& _Other) noexcept : _Pmtx(_Other._Pmtx), _Owns(_Other._Owns) {
         _Other._Pmtx = nullptr;
         _Other._Owns = false;
     }

--- a/tests/std/tests/VSO_0226079_mutex/test.cpp
+++ b/tests/std/tests/VSO_0226079_mutex/test.cpp
@@ -496,6 +496,21 @@ void test_nonmember_try_lock() {
     rtOt.join();
 }
 
+// Also test VSO-1253916, in which RWC like the following broke when we annotated unique_lock with [[nodiscard]].
+unique_lock<shared_mutex> do_locked_things(unique_lock<shared_mutex> lck) {
+    return lck;
+}
+
+shared_lock<shared_mutex> do_shared_locked_things(shared_lock<shared_mutex> lck) {
+    return lck;
+}
+
+void test_vso_1253916() {
+    shared_mutex mtx;
+    do_locked_things(unique_lock<shared_mutex>{mtx});
+    do_shared_locked_things(shared_lock<shared_mutex>{mtx});
+}
+
 int main() {
     {
         mutex_test_fixture<mutex> fixture;
@@ -537,4 +552,6 @@ int main() {
 
     test_nonmember_lock();
     test_nonmember_try_lock();
+
+    test_vso_1253916();
 }


### PR DESCRIPTION
To unbreak RWC which uses the exact "return a lock from a function to allow the caller to do more work before unlocking" use case we were worried about.

Fixes VSO-1253916/AB#1253916.