### PR TITLE
silence future "unused capture" warning

### DIFF
--- a/tests/std/tests/Dev11_0748972_function_crash_out_of_memory/test.cpp
+++ b/tests/std/tests/Dev11_0748972_function_crash_out_of_memory/test.cpp
@@ -76,6 +76,7 @@ void test(const int num) {
         vector<int> v(10, 1729);
         long long a = 0, b = 0, c = 0, d = 0, e = 0;
         auto big_lambda = [v, a, b, c, d, e] {
+            (void) v;
             (void) a;
             (void) b;
             (void) c;


### PR DESCRIPTION
Hello, people of 2020! I've traveled back in time to silence a warning about an unused lambda capture that will some day appear without warning, giving birth to Skynet and bringing about the end of days. You're welcome.

[This ports the changes from internal MSVC-PR-292175.]