### PR TITLE
Build header units in parallel

### DIFF
--- a/tests/std/tests/P1502R1_standard_library_header_units/custom_format.py
+++ b/tests/std/tests/P1502R1_standard_library_header_units/custom_format.py
@@ -98,19 +98,21 @@ class CustomTestFormat(STLTestFormat):
             test.flags.remove('/BE')
             test.compileFlags.remove('/BE')
 
+        exportHeaderOptions = ['/exportHeader', '/Fo', '/MP']
         headerUnitOptions = []
         for header in stlHeaders:
-            headerObjPath = os.path.join(outputDir, header + '.obj')
+            headerAbsolutePath = os.path.join(litConfig.cxx_headers, header)
+
+            exportHeaderOptions.append(headerAbsolutePath)
 
             headerUnitOptions.append('/headerUnit')
-            headerUnitOptions.append('{0}/{1}={1}.ifc'.format(litConfig.cxx_headers, header))
+            headerUnitOptions.append('{0}={1}.ifc'.format(headerAbsolutePath, header))
 
             if not compileTestCppWithEdg:
-                headerUnitOptions.append(headerObjPath)
+                headerUnitOptions.append(os.path.join(outputDir, header + '.obj'))
 
-            cmd = [test.cxx, *test.flags, *test.compileFlags,
-                   '/exportHeader', '<{}>'.format(header), '/Fo{}'.format(headerObjPath)]
-            yield TestStep(cmd, shared.execDir, shared.env, False)
+        cmd = [test.cxx, *test.flags, *test.compileFlags, *exportHeaderOptions]
+        yield TestStep(cmd, shared.execDir, shared.env, False)
 
         if compileTestCppWithEdg:
             test.compileFlags.append('/BE')

--- a/tests/std/tests/P1502R1_standard_library_header_units/custombuild.pl
+++ b/tests/std/tests/P1502R1_standard_library_header_units/custombuild.pl
@@ -88,18 +88,19 @@ sub CustomBuildHook()
         "version",
     );
 
+    my $export_header_options = "/exportHeader /Fo /MP";
     my $header_unit_options = "";
 
     foreach (@stl_headers) {
+        $export_header_options .= " $stl_include_dir/$_";
+
         $header_unit_options .= " /headerUnit";
         $header_unit_options .= " $stl_include_dir/$_=$_.ifc";
         $header_unit_options .= " $_.obj";
-
-        # TRANSITION, remove /DMSVC_INTERNAL_TESTING after all compiler bugs are fixed
-        Run::ExecuteCL("/DMSVC_INTERNAL_TESTING /exportHeader \"<$_>\" /Fo$_.obj");
     }
 
     # TRANSITION, remove /DMSVC_INTERNAL_TESTING after all compiler bugs are fixed
+    Run::ExecuteCL("/DMSVC_INTERNAL_TESTING $export_header_options");
     Run::ExecuteCL("/DMSVC_INTERNAL_TESTING test.cpp /Fe$cwd.exe $header_unit_options");
 }
 1


### PR DESCRIPTION
On my 6-core 12-thread machine (Python), this improves the test time for all configurations from 53s to 32s.

For MSVC-internal Contest (Perl), this improves each configuration's test time from (between 1m 30s and 2m 7s) to (approximately 14s).

Previously, I thought that this was impossible because we had to vary the command lines. However, `/exportHeader` can be given multiple headers simultaneously, they just need to be named with absolute paths instead of angle brackets. We also need to pass `/Fo` to make it generate object files. (It's possible to control the output directory for object files, by passing it to `/Fo` with a trailing slash/backslash, and it's possible to control the output directory for IFC files with `/ifcOutput`, but it appears that this is unnecessary as both of our test harnesses run these commands in the per-configuration output directory that we want.)

:rocket: :rocket: :rocket:
===