### PR TITLE
Add target architectures as features

### DIFF
--- a/tests/utils/stl/test/features.py
+++ b/tests/utils/stl/test/features.py
@@ -46,11 +46,17 @@ def getDefaultFeatures(config, litConfig):
         DEFAULT_FEATURES.append(Feature(name='edg'))
         DEFAULT_FEATURES.append(Feature(name='arch_ia32'))
         DEFAULT_FEATURES.append(Feature(name='arch_avx2'))
+        DEFAULT_FEATURES.append(Feature(name='x86'))
 
-    if litConfig.target_arch.casefold() == 'x64'.casefold():
+    elif litConfig.target_arch.casefold() == 'x64'.casefold():
         DEFAULT_FEATURES.append(Feature(name='arch_avx2'))
+        DEFAULT_FEATURES.append(Feature(name='x64'))
 
-    if litConfig.target_arch.casefold() == 'arm'.casefold():
+    elif litConfig.target_arch.casefold() == 'arm'.casefold():
         DEFAULT_FEATURES.append(Feature(name='arch_vfpv4'))
+        DEFAULT_FEATURES.append(Feature(name='arm'))
+
+    elif litConfig.target_arch.casefold() == 'arm64'.casefold():
+        DEFAULT_FEATURES.append(Feature(name='arm64'))
 
     return DEFAULT_FEATURES


### PR DESCRIPTION
The `nvcc` tests are only meant to be run when testing the `x64` version of the STL so when they were added I made them require an `x64` feature. However, I forgot to add that feature when adding the tests and so the tests were just always skipped.
This PR makes all the target architectures also features.