### PR TITLE
Fix uninitialized_meow memcpy optimization

### DIFF
--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -79,7 +79,7 @@ namespace ranges {
             _STL_INTERNAL_STATIC_ASSERT(constructible_from<iter_value_t<_Out>, iter_reference_t<_It>>);
 
             if constexpr (is_same_v<_Se, _It> && _Ptr_copy_cat<_It, _Out>::_Really_trivial) {
-                return {_ILast, _Copy_memcpy_common(_IFirst, _ILast, _OFirst, _OLast)};
+                return _Copy_memcpy_common(_IFirst, _ILast, _OFirst, _OLast);
             } else {
                 _Uninitialized_backout _Backout{_STD move(_OFirst)};
 
@@ -149,7 +149,7 @@ namespace ranges {
             auto _OFirst      = _Get_unwrapped(_STD move(_First2));
             const auto _OLast = _Get_unwrapped(_STD move(_Last2));
             if constexpr (_Ptr_copy_cat<_It, _Out>::_Really_trivial) {
-                _OFirst = _Copy_memcpy_common(_IFirst, _IFirst + _Count, _OFirst, _OLast);
+                return _Copy_memcpy_common(_IFirst, _IFirst + _Count, _OFirst, _OLast);
             } else {
                 _Uninitialized_backout _Backout{_STD move(_OFirst)};
 
@@ -283,7 +283,7 @@ namespace ranges {
             auto _OFirst      = _Get_unwrapped(_STD move(_First2));
             const auto _OLast = _Get_unwrapped(_STD move(_Last2));
             if constexpr (_Ptr_move_cat<_It, _Out>::_Really_trivial) {
-                _OFirst = _Copy_memcpy_common(_IFirst, _IFirst + _Count, _OFirst, _OLast);
+                return _Copy_memcpy_common(_IFirst, _IFirst + _Count, _OFirst, _OLast);
             } else {
                 _Uninitialized_backout _Backout{_STD move(_OFirst)};
 

--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -79,7 +79,7 @@ namespace ranges {
             _STL_INTERNAL_STATIC_ASSERT(constructible_from<iter_value_t<_Out>, iter_reference_t<_It>>);
 
             if constexpr (is_same_v<_Se, _It> && _Ptr_copy_cat<_It, _Out>::_Really_trivial) {
-                return _Copy_memcpy_common(_IFirst, _ILast, _OFirst, _OLast);
+                return {_ILast, _Copy_memcpy_common(_IFirst, _ILast, _OFirst, _OLast)};
             } else {
                 _Uninitialized_backout _Backout{_STD move(_OFirst)};
 

--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -149,7 +149,9 @@ namespace ranges {
             auto _OFirst      = _Get_unwrapped(_STD move(_First2));
             const auto _OLast = _Get_unwrapped(_STD move(_Last2));
             if constexpr (_Ptr_copy_cat<_It, _Out>::_Really_trivial) {
-                return _Copy_memcpy_common(_IFirst, _IFirst + _Count, _OFirst, _OLast);
+                auto _UResult = _Copy_memcpy_common(_IFirst, _IFirst + _Count, _OFirst, _OLast);
+                _IFirst       = _UResult.in;
+                _OFirst       = _UResult.out;
             } else {
                 _Uninitialized_backout _Backout{_STD move(_OFirst)};
 
@@ -283,7 +285,9 @@ namespace ranges {
             auto _OFirst      = _Get_unwrapped(_STD move(_First2));
             const auto _OLast = _Get_unwrapped(_STD move(_Last2));
             if constexpr (_Ptr_move_cat<_It, _Out>::_Really_trivial) {
-                return _Copy_memcpy_common(_IFirst, _IFirst + _Count, _OFirst, _OLast);
+                auto _UResult = _Copy_memcpy_common(_IFirst, _IFirst + _Count, _OFirst, _OLast);
+                _IFirst       = _UResult.in;
+                _OFirst       = _UResult.out;
             } else {
                 _Uninitialized_backout _Backout{_STD move(_OFirst)};
 

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -1551,6 +1551,18 @@ namespace ranges {
         && _No_throw_forward_iterator<iterator_t<_Rng>>;
     // clang-format on
 
+    template <class _InIt, class _OutIt>
+    in_out_result<_InIt, _OutIt> _Copy_memcpy_common(
+        _InIt _IFirst, _InIt _ILast, _OutIt _OFirst, _OutIt _OLast) noexcept {
+        const auto _IFirst_ch = const_cast<char*>(reinterpret_cast<const volatile char*>(_IFirst));
+        const auto _ILast_ch  = const_cast<const char*>(reinterpret_cast<const volatile char*>(_ILast));
+        const auto _OFirst_ch = const_cast<char*>(reinterpret_cast<volatile char*>(_OFirst));
+        const auto _OLast_ch  = const_cast<const char*>(reinterpret_cast<const volatile char*>(_OLast));
+        const auto _Count     = static_cast<size_t>((_STD min)(_ILast_ch - _IFirst_ch, _OLast_ch - _OFirst_ch));
+        _CSTD memcpy(_OFirst_ch, _IFirst_ch, _Count);
+        return {reinterpret_cast<_InIt>(_IFirst_ch + _Count), reinterpret_cast<_OutIt>(_OFirst_ch + _Count)};
+    }
+
     // ALIAS TEMPLATE uninitialized_move_result
     template <class _In, class _Out>
     using uninitialized_move_result = in_out_result<_In, _Out>;
@@ -1564,7 +1576,7 @@ namespace ranges {
             _It _IFirst, const _Se _ILast, _Out _OFirst, const _OSe _OLast) {
         // clang-format on
         if constexpr (is_same_v<_Se, _It> && _Ptr_move_cat<_It, _Out>::_Really_trivial) {
-            return {_ILast, _Copy_memcpy_common(_IFirst, _ILast, _OFirst, _OLast)};
+            return _Copy_memcpy_common(_IFirst, _ILast, _OFirst, _OLast);
         } else {
             _Uninitialized_backout _Backout{_STD move(_OFirst)};
 

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -1564,7 +1564,7 @@ namespace ranges {
             _It _IFirst, const _Se _ILast, _Out _OFirst, const _OSe _OLast) {
         // clang-format on
         if constexpr (is_same_v<_Se, _It> && _Ptr_move_cat<_It, _Out>::_Really_trivial) {
-            return _Copy_memcpy_common(_IFirst, _ILast, _OFirst, _OLast);
+            return {_ILast, _Copy_memcpy_common(_IFirst, _ILast, _OFirst, _OLast)};
         } else {
             _Uninitialized_backout _Backout{_STD move(_OFirst)};
 

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -4102,17 +4102,6 @@ _OutIt _Copy_memmove(move_iterator<_InIt> _First, move_iterator<_InIt> _Last, _O
     return _Copy_memmove(_First.base(), _Last.base(), _Dest);
 }
 
-template <class _InIt, class _OutIt>
-_OutIt _Copy_memcpy_common(_InIt _IFirst, _InIt _ILast, _OutIt _OFirst, _OutIt _OLast) noexcept {
-    const auto _IFirst_ch = const_cast<const char*>(reinterpret_cast<const volatile char*>(_IFirst));
-    const auto _ILast_ch  = const_cast<const char*>(reinterpret_cast<const volatile char*>(_ILast));
-    const auto _OFirst_ch = const_cast<char*>(reinterpret_cast<volatile char*>(_OFirst));
-    const auto _OLast_ch  = const_cast<const char*>(reinterpret_cast<const volatile char*>(_OLast));
-    const auto _Count     = static_cast<size_t>((_STD min)(_ILast_ch - _IFirst_ch, _OLast_ch - _OFirst_ch));
-    _CSTD memcpy(_OFirst_ch, _IFirst_ch, _Count);
-    return reinterpret_cast<_OutIt>(_OFirst_ch + _Count);
-}
-
 // VARIABLE TEMPLATE _Is_vb_iterator
 template <class _It, bool _RequiresMutable = false>
 _INLINE_VAR constexpr bool _Is_vb_iterator = false;

--- a/tests/std/tests/P0896R4_ranges_alg_uninitialized_copy/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_uninitialized_copy/test.cpp
@@ -160,6 +160,21 @@ struct throwing_test {
     }
 };
 
+struct memcopy_test {
+    static constexpr int expected_output[] = {13, 55, 12345};
+    static constexpr int expected_input[]  = {13, 55, 12345};
+
+    static void call() {
+        // Validate only range overload (one is plenty since they both use the same backend)
+        int input[]  = {13, 55, 12345};
+        int output[] = {-1, -1, -1};
+
+        ranges::uninitialized_copy(input, output);
+        assert(ranges::equal(input, expected_input));
+        assert(ranges::equal(output, expected_output));
+    }
+};
+
 template <test::ProxyRef IsProxy>
 using test_input  = test::range<test::input, int_wrapper, test::Sized::no, test::CanDifference::no, test::Common::no,
     test::CanCompare::yes, IsProxy>;
@@ -174,4 +189,5 @@ int main() {
     instantiator::call<test_input<test::ProxyRef::yes>, test_output>();
     throwing_test::call<test_input<test::ProxyRef::no>, test_output>();
     throwing_test::call<test_input<test::ProxyRef::yes>, test_output>();
+    memcopy_test::call();
 }

--- a/tests/std/tests/P0896R4_ranges_alg_uninitialized_copy/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_uninitialized_copy/test.cpp
@@ -76,21 +76,16 @@ struct holder {
     }
 };
 
-template <class R>
-void not_ranges_destroy(R&& r) { // TRANSITION, ranges::destroy
-    for (auto& e : r) {
-        destroy_at(&e);
-    }
-}
-
 struct instantiator {
-    static constexpr int expected_output[] = {13, 55, 12345};
-    static constexpr int expected_input[]  = {13, 55, 12345};
+    static constexpr int expected_output[]      = {13, 55, 12345};
+    static constexpr int expected_output_long[] = {13, 55, 12345, -1};
+    static constexpr int expected_input[]       = {13, 55, 12345};
+    static constexpr int expected_input_long[]  = {13, 55, 12345, 42};
 
     template <ranges::input_range R, ranges::forward_range W>
     static void call() {
-        using ranges::uninitialized_copy, ranges::uninitialized_copy_result, ranges::equal, ranges::equal_to,
-            ranges::iterator_t;
+        using ranges::destroy, ranges::uninitialized_copy, ranges::uninitialized_copy_result, ranges::equal,
+            ranges::equal_to, ranges::iterator_t;
 
         { // Validate range overload
             int_wrapper input[3] = {13, 55, 12345};
@@ -107,7 +102,7 @@ struct instantiator {
             assert(result.out == wrapped_output.end());
             assert(equal(wrapped_output, expected_output, equal_to{}, &int_wrapper::val));
             assert(equal(input, expected_input, equal_to{}, &int_wrapper::val));
-            not_ranges_destroy(wrapped_output);
+            destroy(wrapped_output);
             assert(int_wrapper::constructions == 3);
             assert(int_wrapper::destructions == 3);
         }
@@ -127,9 +122,50 @@ struct instantiator {
             assert(result.out == wrapped_output.end());
             assert(equal(wrapped_output, expected_output, equal_to{}, &int_wrapper::val));
             assert(equal(input, expected_input, equal_to{}, &int_wrapper::val));
-            not_ranges_destroy(wrapped_output);
+            destroy(wrapped_output);
             assert(int_wrapper::constructions == 3);
             assert(int_wrapper::destructions == 3);
+        }
+
+        { // Validate range overload shorter output
+            int_wrapper input[4] = {13, 55, 12345, 42};
+            R wrapped_input{input};
+            holder<int_wrapper, 3> mem;
+            W wrapped_output{mem.as_span()};
+
+            int_wrapper::clear_counts();
+            same_as<uninitialized_copy_result<iterator_t<R>, iterator_t<W>>> auto result =
+                uninitialized_copy(wrapped_input, wrapped_output);
+            assert(int_wrapper::constructions == 3);
+            assert(int_wrapper::destructions == 0);
+            assert(++result.in == wrapped_input.end());
+            assert(result.out == wrapped_output.end());
+            assert(equal(wrapped_output, expected_output, equal_to{}, &int_wrapper::val));
+            assert(equal(input, expected_input_long, equal_to{}, &int_wrapper::val));
+            destroy(wrapped_output);
+            assert(int_wrapper::constructions == 3);
+            assert(int_wrapper::destructions == 3);
+        }
+
+        { // Validate range overload shorter input
+            int_wrapper input[3] = {13, 55, 12345};
+            R wrapped_input{input};
+            holder<int_wrapper, 4> mem;
+            W wrapped_output{mem.as_span()};
+
+            int_wrapper::clear_counts();
+            same_as<uninitialized_copy_result<iterator_t<R>, iterator_t<W>>> auto result =
+                uninitialized_copy(wrapped_input, wrapped_output);
+            assert(int_wrapper::constructions == 3);
+            assert(int_wrapper::destructions == 0);
+            assert(result.in == wrapped_input.end());
+            construct_at(addressof(*result.out), -1); // Need to construct non written element for comparison
+            assert(++result.out == wrapped_output.end());
+            assert(equal(wrapped_output, expected_output_long, equal_to{}, &int_wrapper::val));
+            assert(equal(input, expected_input, equal_to{}, &int_wrapper::val));
+            destroy(wrapped_output);
+            assert(int_wrapper::constructions == 4);
+            assert(int_wrapper::destructions == 4);
         }
     }
 };
@@ -161,17 +197,44 @@ struct throwing_test {
 };
 
 struct memcopy_test {
-    static constexpr int expected_output[] = {13, 55, 12345};
-    static constexpr int expected_input[]  = {13, 55, 12345};
+    static constexpr int expected_output[]      = {13, 55, 12345};
+    static constexpr int expected_output_long[] = {13, 55, 12345, -1};
+    static constexpr int expected_input[]       = {13, 55, 12345};
+    static constexpr int expected_input_long[]  = {13, 55, 12345, 42};
 
     static void call() {
-        // Validate only range overload (one is plenty since they both use the same backend)
-        int input[]  = {13, 55, 12345};
-        int output[] = {-1, -1, -1};
+        { // Validate only range overload
+            int input[]  = {13, 55, 12345};
+            int output[] = {-1, -1, -1};
 
-        ranges::uninitialized_copy(input, output);
-        assert(ranges::equal(input, expected_input));
-        assert(ranges::equal(output, expected_output));
+            const auto result = ranges::uninitialized_copy(input, output);
+            assert(result.in == end(input));
+            assert(result.out == end(output));
+            assert(ranges::equal(input, expected_input));
+            assert(ranges::equal(output, expected_output));
+        }
+
+        { // Validate input shorter
+            int input[]  = {13, 55, 12345};
+            int output[] = {-1, -1, -1, -1};
+
+            auto result = ranges::uninitialized_copy(input, output);
+            assert(result.in == end(input));
+            assert(++result.out == end(output));
+            assert(ranges::equal(input, expected_input));
+            assert(ranges::equal(output, expected_output_long));
+        }
+
+        { // Validate output shorter
+            int input[]  = {13, 55, 12345, 42};
+            int output[] = {-1, -1, -1};
+
+            auto result = ranges::uninitialized_copy(input, output);
+            assert(++result.in == end(input));
+            assert(result.out == end(output));
+            assert(ranges::equal(input, expected_input_long));
+            assert(ranges::equal(output, expected_output));
+        }
     }
 };
 

--- a/tests/std/tests/P0896R4_ranges_alg_uninitialized_copy/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_uninitialized_copy/test.cpp
@@ -196,7 +196,7 @@ struct throwing_test {
     }
 };
 
-struct memcopy_test {
+struct memcpy_test {
     static constexpr int expected_output[]      = {13, 55, 12345};
     static constexpr int expected_output_long[] = {13, 55, 12345, -1};
     static constexpr int expected_input[]       = {13, 55, 12345};
@@ -252,5 +252,5 @@ int main() {
     instantiator::call<test_input<test::ProxyRef::yes>, test_output>();
     throwing_test::call<test_input<test::ProxyRef::no>, test_output>();
     throwing_test::call<test_input<test::ProxyRef::yes>, test_output>();
-    memcopy_test::call();
+    memcpy_test::call();
 }

--- a/tests/std/tests/P0896R4_ranges_alg_uninitialized_copy_n/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_uninitialized_copy_n/test.cpp
@@ -165,7 +165,7 @@ struct throwing_test {
     }
 };
 
-struct memcopy_test {
+struct memcpy_test {
     static constexpr int expected_output[]      = {13, 55, 12345, -1};
     static constexpr int expected_output_long[] = {13, 55, -1, -1};
     static constexpr int expected_input[]       = {13, 55, 12345, 42};
@@ -226,5 +226,5 @@ int main() {
     instantiator::call<test_input<test::ProxyRef::yes>, test_output>();
     throwing_test::call<test_input<test::ProxyRef::no>, test_output>();
     throwing_test::call<test_input<test::ProxyRef::yes>, test_output>();
-    memcopy_test::call();
+    memcpy_test::call();
 }

--- a/tests/std/tests/P0896R4_ranges_alg_uninitialized_copy_n/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_uninitialized_copy_n/test.cpp
@@ -9,6 +9,7 @@
 #include <ranges>
 #include <span>
 #include <utility>
+#include <vector>
 
 #include <range_algorithm_support.hpp>
 
@@ -174,43 +175,37 @@ struct memcopy_test {
     static void call() {
         using ranges::uninitialized_copy_n, ranges::uninitialized_copy_n_result, ranges::equal, ranges::iterator_t;
         { // Validate range overload
-            int input[]  = {13, 55, 12345, 42};
-            int output[] = {-1, -1, -1, -1};
-            span<int> wrapped_input{input};
-            span<int> wrapped_output{output};
+            vector<int> input  = {13, 55, 12345, 42};
+            vector<int> output = {-1, -1, -1, -1};
 
-            const same_as<uninitialized_copy_n_result<iterator_t<span<int>>, iterator_t<span<int>>>> auto result =
-                uninitialized_copy_n(wrapped_input.begin(), 3, begin(wrapped_output), end(wrapped_output));
-            assert(next(result.in) == end(wrapped_input));
-            assert(next(result.out) == end(wrapped_output));
+            const same_as<uninitialized_copy_n_result<iterator_t<vector<int>>, iterator_t<vector<int>>>> auto result =
+                uninitialized_copy_n(input.begin(), 3, output.begin(), output.end());
+            assert(next(result.in) == input.end());
+            assert(next(result.out) == output.end());
             assert(equal(input, expected_input));
             assert(equal(output, expected_output));
         }
 
         { // Validate shorter input
-            int input[]  = {13, 55};
-            int output[] = {-1, -1, -1, -1};
-            span<int> wrapped_input{input};
-            span<int> wrapped_output{output};
+            vector<int> input  = {13, 55};
+            vector<int> output = {-1, -1, -1, -1};
 
-            const same_as<uninitialized_copy_n_result<iterator_t<span<int>>, iterator_t<span<int>>>> auto result =
-                uninitialized_copy_n(wrapped_input.begin(), 2, begin(wrapped_output), end(wrapped_output));
-            assert(result.in == end(wrapped_input));
-            assert(next(result.out, 2) == end(wrapped_output));
+            const same_as<uninitialized_copy_n_result<iterator_t<vector<int>>, iterator_t<vector<int>>>> auto result =
+                uninitialized_copy_n(input.begin(), 2, output.begin(), output.end());
+            assert(result.in == input.end());
+            assert(next(result.out, 2) == output.end());
             assert(equal(input, expected_input_short));
             assert(equal(output, expected_output_long));
         }
 
         { // Validate shorter output
-            int input[]  = {13, 55, 12345, 42};
-            int output[] = {-1, -1};
-            span<int> wrapped_input{input};
-            span<int> wrapped_output{output};
+            vector<int> input  = {13, 55, 12345, 42};
+            vector<int> output = {-1, -1};
 
-            const same_as<uninitialized_copy_n_result<iterator_t<span<int>>, iterator_t<span<int>>>> auto result =
-                uninitialized_copy_n(wrapped_input.begin(), 2, begin(wrapped_output), end(wrapped_output));
-            assert(next(result.in, 2) == end(wrapped_input));
-            assert(result.out == end(wrapped_output));
+            const same_as<uninitialized_copy_n_result<iterator_t<vector<int>>, iterator_t<vector<int>>>> auto result =
+                uninitialized_copy_n(input.begin(), 2, output.begin(), output.end());
+            assert(next(result.in, 2) == input.end());
+            assert(result.out == output.end());
             assert(equal(input, expected_input));
             assert(equal(output, expected_input_short));
         }

--- a/tests/std/tests/P0896R4_ranges_alg_uninitialized_copy_n/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_uninitialized_copy_n/test.cpp
@@ -172,31 +172,47 @@ struct memcopy_test {
     static constexpr int expected_input_long[]  = {13, 55, 12345, 42};
 
     static void call() {
+        using ranges::uninitialized_copy_n, ranges::uninitialized_copy_n_result, ranges::equal, ranges::iterator_t;
         { // Validate range overload
             int input[]  = {13, 55, 12345, 42};
             int output[] = {-1, -1, -1, -1};
+            span<int> wrapped_input{input};
+            span<int> wrapped_output{output};
 
-            ranges::uninitialized_copy_n(input, 3, begin(output), end(output));
-            assert(ranges::equal(input, expected_input));
-            assert(ranges::equal(output, expected_output));
+            const same_as<uninitialized_copy_n_result<iterator_t<span<int>>, iterator_t<span<int>>>> auto result =
+                uninitialized_copy_n(wrapped_input.begin(), 3, begin(wrapped_output), end(wrapped_output));
+            assert(next(result.in) == end(wrapped_input));
+            assert(next(result.out) == end(wrapped_output));
+            assert(equal(input, expected_input));
+            assert(equal(output, expected_output));
         }
 
         { // Validate shorter input
             int input[]  = {13, 55};
             int output[] = {-1, -1, -1, -1};
+            span<int> wrapped_input{input};
+            span<int> wrapped_output{output};
 
-            ranges::uninitialized_copy_n(input, 2, begin(output), end(output));
-            assert(ranges::equal(input, expected_input_short));
-            assert(ranges::equal(output, expected_output_long));
+            const same_as<uninitialized_copy_n_result<iterator_t<span<int>>, iterator_t<span<int>>>> auto result =
+                uninitialized_copy_n(wrapped_input.begin(), 2, begin(wrapped_output), end(wrapped_output));
+            assert(result.in == end(wrapped_input));
+            assert(next(result.out, 2) == end(wrapped_output));
+            assert(equal(input, expected_input_short));
+            assert(equal(output, expected_output_long));
         }
 
         { // Validate shorter output
             int input[]  = {13, 55, 12345, 42};
             int output[] = {-1, -1};
+            span<int> wrapped_input{input};
+            span<int> wrapped_output{output};
 
-            ranges::uninitialized_copy_n(input, 3, begin(output), end(output));
-            assert(ranges::equal(input, expected_input));
-            assert(ranges::equal(output, expected_input_short));
+            const same_as<uninitialized_copy_n_result<iterator_t<span<int>>, iterator_t<span<int>>>> auto result =
+                uninitialized_copy_n(wrapped_input.begin(), 2, begin(wrapped_output), end(wrapped_output));
+            assert(next(result.in, 2) == end(wrapped_input));
+            assert(result.out == end(wrapped_output));
+            assert(equal(input, expected_input));
+            assert(equal(output, expected_input_short));
         }
     }
 };

--- a/tests/std/tests/P0896R4_ranges_alg_uninitialized_copy_n/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_uninitialized_copy_n/test.cpp
@@ -66,39 +66,77 @@ struct holder {
     }
 };
 
-template <class R>
-void not_ranges_destroy(R&& r) { // TRANSITION, ranges::destroy
-    for (auto& e : r) {
-        destroy_at(&e);
-    }
-}
-
 struct instantiator {
-    static constexpr int expected_output[] = {13, 55, 12345};
-    static constexpr int expected_input[]  = {13, 55, 12345};
+    static constexpr int expected_output[]      = {13, 55, 12345};
+    static constexpr int expected_output_long[] = {13, 55, 12345, -1};
+    static constexpr int expected_input[]       = {13, 55, 12345};
+    static constexpr int expected_input_long[]  = {13, 55, 12345, 42};
 
     template <ranges::input_range Read, ranges::forward_range Write>
     static void call() {
-        using ranges::uninitialized_copy_n, ranges::uninitialized_copy_n_result, ranges::equal, ranges::equal_to,
-            ranges::iterator_t;
+        using ranges::destroy, ranges::uninitialized_copy_n, ranges::uninitialized_copy_n_result, ranges::equal,
+            ranges::equal_to, ranges::iterator_t;
 
-        int_wrapper input[3] = {13, 55, 12345};
-        Read wrapped_input{input};
-        holder<int_wrapper, 3> mem;
-        Write wrapped_output{mem.as_span()};
+        { // Validate equal ranges
+            int_wrapper input[3] = {13, 55, 12345};
+            Read wrapped_input{input};
+            holder<int_wrapper, 3> mem;
+            Write wrapped_output{mem.as_span()};
 
-        int_wrapper::clear_counts();
-        const same_as<uninitialized_copy_n_result<iterator_t<Read>, iterator_t<Write>>> auto result =
-            uninitialized_copy_n(wrapped_input.begin(), 3, wrapped_output.begin(), wrapped_output.end());
-        assert(int_wrapper::constructions == 3);
-        assert(int_wrapper::destructions == 0);
-        assert(result.in == wrapped_input.end());
-        assert(result.out == wrapped_output.end());
-        assert(equal(wrapped_output, expected_output, equal_to{}, &int_wrapper::val));
-        assert(equal(input, expected_input, equal_to{}, &int_wrapper::val));
-        not_ranges_destroy(wrapped_output);
-        assert(int_wrapper::constructions == 3);
-        assert(int_wrapper::destructions == 3);
+            int_wrapper::clear_counts();
+            const same_as<uninitialized_copy_n_result<iterator_t<Read>, iterator_t<Write>>> auto result =
+                uninitialized_copy_n(wrapped_input.begin(), 3, wrapped_output.begin(), wrapped_output.end());
+            assert(int_wrapper::constructions == 3);
+            assert(int_wrapper::destructions == 0);
+            assert(result.in == wrapped_input.end());
+            assert(result.out == wrapped_output.end());
+            assert(equal(wrapped_output, expected_output, equal_to{}, &int_wrapper::val));
+            assert(equal(input, expected_input, equal_to{}, &int_wrapper::val));
+            destroy(wrapped_output);
+            assert(int_wrapper::constructions == 3);
+            assert(int_wrapper::destructions == 3);
+        }
+
+        { // Validate shorter output
+            int_wrapper input[4] = {13, 55, 12345, 42};
+            Read wrapped_input{input};
+            holder<int_wrapper, 3> mem;
+            Write wrapped_output{mem.as_span()};
+
+            int_wrapper::clear_counts();
+            same_as<uninitialized_copy_n_result<iterator_t<Read>, iterator_t<Write>>> auto result =
+                uninitialized_copy_n(wrapped_input.begin(), 3, wrapped_output.begin(), wrapped_output.end());
+            assert(int_wrapper::constructions == 3);
+            assert(int_wrapper::destructions == 0);
+            assert(++result.in == wrapped_input.end());
+            assert(result.out == wrapped_output.end());
+            assert(equal(wrapped_output, expected_output, equal_to{}, &int_wrapper::val));
+            assert(equal(input, expected_input_long, equal_to{}, &int_wrapper::val));
+            destroy(wrapped_output);
+            assert(int_wrapper::constructions == 3);
+            assert(int_wrapper::destructions == 3);
+        }
+
+        { // Validate shorter input
+            int_wrapper input[3] = {13, 55, 12345};
+            Read wrapped_input{input};
+            holder<int_wrapper, 4> mem;
+            Write wrapped_output{mem.as_span()};
+
+            int_wrapper::clear_counts();
+            same_as<uninitialized_copy_n_result<iterator_t<Read>, iterator_t<Write>>> auto result =
+                uninitialized_copy_n(wrapped_input.begin(), 3, wrapped_output.begin(), wrapped_output.end());
+            assert(int_wrapper::constructions == 3);
+            assert(int_wrapper::destructions == 0);
+            assert(result.in == wrapped_input.end());
+            construct_at(addressof(*result.out), -1); // Need to construct non written element for comparison
+            assert(++result.out == wrapped_output.end());
+            assert(equal(wrapped_output, expected_output_long, equal_to{}, &int_wrapper::val));
+            assert(equal(input, expected_input, equal_to{}, &int_wrapper::val));
+            destroy(wrapped_output);
+            assert(int_wrapper::constructions == 4);
+            assert(int_wrapper::destructions == 4);
+        }
     }
 };
 
@@ -127,17 +165,39 @@ struct throwing_test {
 };
 
 struct memcopy_test {
-    static constexpr int expected_output[] = {13, 55, 12345, -1};
-    static constexpr int expected_input[]  = {13, 55, 12345, 42};
+    static constexpr int expected_output[]      = {13, 55, 12345, -1};
+    static constexpr int expected_output_long[] = {13, 55, -1, -1};
+    static constexpr int expected_input[]       = {13, 55, 12345, 42};
+    static constexpr int expected_input_short[] = {13, 55};
+    static constexpr int expected_input_long[]  = {13, 55, 12345, 42};
 
     static void call() {
-        // Validate only range overload (one is plenty since they both use the same backend)
-        int input[]  = {13, 55, 12345, 42};
-        int output[] = {-1, -1, -1, -1};
+        { // Validate range overload
+            int input[]  = {13, 55, 12345, 42};
+            int output[] = {-1, -1, -1, -1};
 
-        ranges::uninitialized_copy_n(input, 3, output, output + 4);
-        assert(ranges::equal(input, expected_input));
-        assert(ranges::equal(output, expected_output));
+            ranges::uninitialized_copy_n(input, 3, begin(output), end(output));
+            assert(ranges::equal(input, expected_input));
+            assert(ranges::equal(output, expected_output));
+        }
+
+        { // Validate shorter input
+            int input[]  = {13, 55};
+            int output[] = {-1, -1, -1, -1};
+
+            ranges::uninitialized_copy_n(input, 2, begin(output), end(output));
+            assert(ranges::equal(input, expected_input_short));
+            assert(ranges::equal(output, expected_output_long));
+        }
+
+        { // Validate shorter output
+            int input[]  = {13, 55, 12345, 42};
+            int output[] = {-1, -1};
+
+            ranges::uninitialized_copy_n(input, 3, begin(output), end(output));
+            assert(ranges::equal(input, expected_input));
+            assert(ranges::equal(output, expected_input_short));
+        }
     }
 };
 

--- a/tests/std/tests/P0896R4_ranges_alg_uninitialized_copy_n/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_uninitialized_copy_n/test.cpp
@@ -126,6 +126,21 @@ struct throwing_test {
     }
 };
 
+struct memcopy_test {
+    static constexpr int expected_output[] = {13, 55, 12345, -1};
+    static constexpr int expected_input[]  = {13, 55, 12345, 42};
+
+    static void call() {
+        // Validate only range overload (one is plenty since they both use the same backend)
+        int input[]  = {13, 55, 12345, 42};
+        int output[] = {-1, -1, -1, -1};
+
+        ranges::uninitialized_copy_n(input, 3, output, output + 4);
+        assert(ranges::equal(input, expected_input));
+        assert(ranges::equal(output, expected_output));
+    }
+};
+
 template <test::ProxyRef IsProxy>
 using test_input  = test::range<test::input, int_wrapper, test::Sized::no, test::CanDifference::no, test::Common::no,
     test::CanCompare::yes, IsProxy>;
@@ -140,4 +155,5 @@ int main() {
     instantiator::call<test_input<test::ProxyRef::yes>, test_output>();
     throwing_test::call<test_input<test::ProxyRef::no>, test_output>();
     throwing_test::call<test_input<test::ProxyRef::yes>, test_output>();
+    memcopy_test::call();
 }

--- a/tests/std/tests/P0896R4_ranges_alg_uninitialized_move/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_uninitialized_move/test.cpp
@@ -154,6 +154,21 @@ struct throwing_test {
     }
 };
 
+struct memcopy_test {
+    static constexpr int expected_output[] = {13, 55, 12345};
+    static constexpr int expected_input[]  = {13, 55, 12345};
+
+    static void call() {
+        // Validate only range overload (one is plenty since they both use the same backend)
+        int input[]  = {13, 55, 12345};
+        int output[] = {-1, -1, -1};
+
+        ranges::uninitialized_move(input, output);
+        assert(ranges::equal(input, expected_input));
+        assert(ranges::equal(output, expected_output));
+    }
+};
+
 template <test::ProxyRef IsProxy>
 using test_input  = test::range<test::input, int_wrapper, test::Sized::no, test::CanDifference::no, test::Common::no,
     test::CanCompare::yes, IsProxy>;
@@ -168,4 +183,5 @@ int main() {
     instantiator::call<test_input<test::ProxyRef::yes>, test_output>();
     throwing_test::call<test_input<test::ProxyRef::no>, test_output>();
     throwing_test::call<test_input<test::ProxyRef::yes>, test_output>();
+    memcopy_test::call();
 }

--- a/tests/std/tests/P0896R4_ranges_alg_uninitialized_move/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_uninitialized_move/test.cpp
@@ -85,8 +85,8 @@ struct instantiator {
 
     template <ranges::input_range R, ranges::forward_range W>
     static void call() {
-        using ranges::destroy, ranges::uninitialized_move, ranges::uninitialized_move_result, ranges::destroy,
-            ranges::equal, ranges::equal_to, ranges::iterator_t;
+        using ranges::uninitialized_move, ranges::uninitialized_move_result, ranges::destroy, ranges::equal,
+            ranges::equal_to, ranges::iterator_t;
 
         { // Validate range overload
             int_wrapper input[3] = {13, 55, 12345};
@@ -197,7 +197,7 @@ struct throwing_test {
     }
 };
 
-struct memcopy_test {
+struct memcpy_test {
     static constexpr int expected_output[]      = {13, 55, 12345};
     static constexpr int expected_output_long[] = {13, 55, 12345, -1};
     static constexpr int expected_input[]       = {13, 55, 12345};
@@ -251,5 +251,5 @@ int main() {
     instantiator::call<test_input<test::ProxyRef::yes>, test_output>();
     throwing_test::call<test_input<test::ProxyRef::no>, test_output>();
     throwing_test::call<test_input<test::ProxyRef::yes>, test_output>();
-    memcopy_test::call();
+    memcpy_test::call();
 }

--- a/tests/std/tests/P0896R4_ranges_alg_uninitialized_move/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_uninitialized_move/test.cpp
@@ -78,13 +78,15 @@ struct holder {
 };
 
 struct instantiator {
-    static constexpr int expected_output[] = {13, 55, 12345};
-    static constexpr int expected_input[]  = {-1, -1, -1};
+    static constexpr int expected_output[]      = {13, 55, 12345};
+    static constexpr int expected_output_long[] = {13, 55, 12345, -1};
+    static constexpr int expected_input[]       = {-1, -1, -1};
+    static constexpr int expected_input_long[]  = {-1, -1, -1, 42};
 
     template <ranges::input_range R, ranges::forward_range W>
     static void call() {
-        using ranges::uninitialized_move, ranges::uninitialized_move_result, ranges::destroy, ranges::equal,
-            ranges::equal_to, ranges::iterator_t;
+        using ranges::destroy, ranges::uninitialized_move, ranges::uninitialized_move_result, ranges::destroy,
+            ranges::equal, ranges::equal_to, ranges::iterator_t;
 
         { // Validate range overload
             int_wrapper input[3] = {13, 55, 12345};
@@ -125,6 +127,47 @@ struct instantiator {
             assert(int_wrapper::constructions == 3);
             assert(int_wrapper::destructions == 3);
         }
+
+        { // Validate range overload shorter output
+            int_wrapper input[4] = {13, 55, 12345, 42};
+            R wrapped_input{input};
+            holder<int_wrapper, 3> mem;
+            W wrapped_output{mem.as_span()};
+
+            int_wrapper::clear_counts();
+            same_as<uninitialized_move_result<iterator_t<R>, iterator_t<W>>> auto result =
+                uninitialized_move(wrapped_input, wrapped_output);
+            assert(int_wrapper::constructions == 3);
+            assert(int_wrapper::destructions == 0);
+            assert(++result.in == wrapped_input.end());
+            assert(result.out == wrapped_output.end());
+            assert(equal(wrapped_output, expected_output, equal_to{}, &int_wrapper::val));
+            assert(equal(input, expected_input_long, equal_to{}, &int_wrapper::val));
+            destroy(wrapped_output);
+            assert(int_wrapper::constructions == 3);
+            assert(int_wrapper::destructions == 3);
+        }
+
+        { // Validate range overload shorter input
+            int_wrapper input[3] = {13, 55, 12345};
+            R wrapped_input{input};
+            holder<int_wrapper, 4> mem;
+            W wrapped_output{mem.as_span()};
+
+            int_wrapper::clear_counts();
+            same_as<uninitialized_move_result<iterator_t<R>, iterator_t<W>>> auto result =
+                uninitialized_move(wrapped_input, wrapped_output);
+            assert(int_wrapper::constructions == 3);
+            assert(int_wrapper::destructions == 0);
+            assert(result.in == wrapped_input.end());
+            construct_at(addressof(*result.out), -1); // Need to construct non written element for comparison
+            assert(++result.out == wrapped_output.end());
+            assert(equal(wrapped_output, expected_output_long, equal_to{}, &int_wrapper::val));
+            assert(equal(input, expected_input, equal_to{}, &int_wrapper::val));
+            destroy(wrapped_output);
+            assert(int_wrapper::constructions == 4);
+            assert(int_wrapper::destructions == 4);
+        }
     }
 };
 
@@ -155,17 +198,42 @@ struct throwing_test {
 };
 
 struct memcopy_test {
-    static constexpr int expected_output[] = {13, 55, 12345};
-    static constexpr int expected_input[]  = {13, 55, 12345};
+    static constexpr int expected_output[]      = {13, 55, 12345};
+    static constexpr int expected_output_long[] = {13, 55, 12345, -1};
+    static constexpr int expected_input[]       = {13, 55, 12345};
+    static constexpr int expected_input_long[]  = {13, 55, 12345, 42};
 
     static void call() {
-        // Validate only range overload (one is plenty since they both use the same backend)
-        int input[]  = {13, 55, 12345};
-        int output[] = {-1, -1, -1};
+        { // Validate range
+            int input[]  = {13, 55, 12345};
+            int output[] = {-1, -1, -1};
 
-        ranges::uninitialized_move(input, output);
-        assert(ranges::equal(input, expected_input));
-        assert(ranges::equal(output, expected_output));
+            ranges::uninitialized_move(input, output);
+            assert(ranges::equal(input, expected_input));
+            assert(ranges::equal(output, expected_output));
+        }
+
+        { // Validate input shorter
+            int input[]  = {13, 55, 12345};
+            int output[] = {-1, -1, -1, -1};
+
+            auto result = ranges::uninitialized_move(input, output);
+            assert(result.in == end(input));
+            assert(++result.out == end(output));
+            assert(ranges::equal(input, expected_input));
+            assert(ranges::equal(output, expected_output_long));
+        }
+
+        { // Validate output shorter
+            int input[]  = {13, 55, 12345, 42};
+            int output[] = {-1, -1, -1};
+
+            auto result = ranges::uninitialized_move(input, output);
+            assert(++result.in == end(input));
+            assert(result.out == end(output));
+            assert(ranges::equal(input, expected_input_long));
+            assert(ranges::equal(output, expected_output));
+        }
     }
 };
 

--- a/tests/std/tests/P0896R4_ranges_alg_uninitialized_move_n/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_uninitialized_move_n/test.cpp
@@ -173,31 +173,47 @@ struct memcopy_test {
     static constexpr int expected_input_long[]  = {13, 55, 12345, 42};
 
     static void call() {
+        using ranges::uninitialized_move_n, ranges::uninitialized_move_n_result, ranges::equal, ranges::iterator_t;
         { // Validate range overload
             int input[]  = {13, 55, 12345, 42};
             int output[] = {-1, -1, -1, -1};
+            span<int> wrapped_input{input};
+            span<int> wrapped_output{output};
 
-            ranges::uninitialized_move_n(input, 3, begin(output), end(output));
-            assert(ranges::equal(input, expected_input));
-            assert(ranges::equal(output, expected_output));
+            const same_as<uninitialized_move_n_result<iterator_t<span<int>>, iterator_t<span<int>>>> auto result =
+                uninitialized_move_n(wrapped_input.begin(), 3, begin(wrapped_output), end(wrapped_output));
+            assert(next(result.in) == end(wrapped_input));
+            assert(next(result.out) == end(wrapped_output));
+            assert(equal(input, expected_input));
+            assert(equal(output, expected_output));
         }
 
         { // Validate shorter input
             int input[]  = {13, 55};
             int output[] = {-1, -1, -1, -1};
+            span<int> wrapped_input{input};
+            span<int> wrapped_output{output};
 
-            ranges::uninitialized_move_n(input, 2, begin(output), end(output));
-            assert(ranges::equal(input, expected_input_short));
-            assert(ranges::equal(output, expected_output_long));
+            const same_as<uninitialized_move_n_result<iterator_t<span<int>>, iterator_t<span<int>>>> auto result =
+                uninitialized_move_n(wrapped_input.begin(), 2, begin(wrapped_output), end(wrapped_output));
+            assert(result.in == end(wrapped_input));
+            assert(next(result.out, 2) == end(wrapped_output));
+            assert(equal(input, expected_input_short));
+            assert(equal(output, expected_output_long));
         }
 
         { // Validate shorter output
             int input[]  = {13, 55, 12345, 42};
             int output[] = {-1, -1};
+            span<int> wrapped_input{input};
+            span<int> wrapped_output{output};
 
-            ranges::uninitialized_move_n(input, 3, begin(output), end(output));
-            assert(ranges::equal(input, expected_input));
-            assert(ranges::equal(output, expected_input_short));
+            const same_as<uninitialized_move_n_result<iterator_t<span<int>>, iterator_t<span<int>>>> auto result =
+                uninitialized_move_n(wrapped_input.begin(), 2, begin(wrapped_output), end(wrapped_output));
+            assert(next(result.in, 2) == end(wrapped_input));
+            assert(result.out == end(wrapped_output));
+            assert(equal(input, expected_input));
+            assert(equal(output, expected_input_short));
         }
     }
 };

--- a/tests/std/tests/P0896R4_ranges_alg_uninitialized_move_n/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_uninitialized_move_n/test.cpp
@@ -175,43 +175,37 @@ struct memcopy_test {
     static void call() {
         using ranges::uninitialized_move_n, ranges::uninitialized_move_n_result, ranges::equal, ranges::iterator_t;
         { // Validate range overload
-            int input[]  = {13, 55, 12345, 42};
-            int output[] = {-1, -1, -1, -1};
-            span<int> wrapped_input{input};
-            span<int> wrapped_output{output};
+            vector<int> input  = {13, 55, 12345, 42};
+            vector<int> output = {-1, -1, -1, -1};
 
-            const same_as<uninitialized_move_n_result<iterator_t<span<int>>, iterator_t<span<int>>>> auto result =
-                uninitialized_move_n(wrapped_input.begin(), 3, begin(wrapped_output), end(wrapped_output));
-            assert(next(result.in) == end(wrapped_input));
-            assert(next(result.out) == end(wrapped_output));
+            const same_as<uninitialized_move_n_result<iterator_t<vector<int>>, iterator_t<vector<int>>>> auto result =
+                uninitialized_move_n(input.begin(), 3, output.begin(), output.end());
+            assert(next(result.in) == input.end());
+            assert(next(result.out) == output.end());
             assert(equal(input, expected_input));
             assert(equal(output, expected_output));
         }
 
         { // Validate shorter input
-            int input[]  = {13, 55};
-            int output[] = {-1, -1, -1, -1};
-            span<int> wrapped_input{input};
-            span<int> wrapped_output{output};
+            vector<int> input  = {13, 55};
+            vector<int> output = {-1, -1, -1, -1};
 
-            const same_as<uninitialized_move_n_result<iterator_t<span<int>>, iterator_t<span<int>>>> auto result =
-                uninitialized_move_n(wrapped_input.begin(), 2, begin(wrapped_output), end(wrapped_output));
-            assert(result.in == end(wrapped_input));
-            assert(next(result.out, 2) == end(wrapped_output));
+            const same_as<uninitialized_move_n_result<iterator_t<vector<int>>, iterator_t<vector<int>>>> auto result =
+                uninitialized_move_n(input.begin(), 2, output.begin(), output.end());
+            assert(result.in == input.end());
+            assert(next(result.out, 2) == output.end());
             assert(equal(input, expected_input_short));
             assert(equal(output, expected_output_long));
         }
 
         { // Validate shorter output
-            int input[]  = {13, 55, 12345, 42};
-            int output[] = {-1, -1};
-            span<int> wrapped_input{input};
-            span<int> wrapped_output{output};
+            vector<int> input  = {13, 55, 12345, 42};
+            vector<int> output = {-1, -1};
 
-            const same_as<uninitialized_move_n_result<iterator_t<span<int>>, iterator_t<span<int>>>> auto result =
-                uninitialized_move_n(wrapped_input.begin(), 2, begin(wrapped_output), end(wrapped_output));
-            assert(next(result.in, 2) == end(wrapped_input));
-            assert(result.out == end(wrapped_output));
+            const same_as<uninitialized_move_n_result<iterator_t<vector<int>>, iterator_t<vector<int>>>> auto result =
+                uninitialized_move_n(input.begin(), 2, output.begin(), output.end());
+            assert(next(result.in, 2) == input.end());
+            assert(result.out == output.end());
             assert(equal(input, expected_input));
             assert(equal(output, expected_input_short));
         }

--- a/tests/std/tests/P0896R4_ranges_alg_uninitialized_move_n/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_uninitialized_move_n/test.cpp
@@ -128,6 +128,21 @@ struct throwing_test {
     }
 };
 
+struct memcopy_test {
+    static constexpr int expected_output[] = {13, 55, 12345, -1};
+    static constexpr int expected_input[]  = {13, 55, 12345, 42};
+
+    static void call() {
+        // Validate only range overload (one is plenty since they both use the same backend)
+        int input[]  = {13, 55, 12345, 42};
+        int output[] = {-1, -1, -1, -1};
+
+        ranges::uninitialized_move_n(input, 3, output, output + 4);
+        assert(ranges::equal(input, expected_input));
+        assert(ranges::equal(output, expected_output));
+    }
+};
+
 template <test::ProxyRef IsProxy>
 using test_input  = test::range<test::input, int_wrapper, test::Sized::no, test::CanDifference::no, test::Common::no,
     test::CanCompare::yes, IsProxy>;
@@ -142,4 +157,5 @@ int main() {
     instantiator::call<test_input<test::ProxyRef::yes>, test_output>();
     throwing_test::call<test_input<test::ProxyRef::no>, test_output>();
     throwing_test::call<test_input<test::ProxyRef::yes>, test_output>();
+    memcopy_test::call();
 }

--- a/tests/std/tests/P0896R4_ranges_alg_uninitialized_move_n/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_uninitialized_move_n/test.cpp
@@ -9,6 +9,7 @@
 #include <ranges>
 #include <span>
 #include <utility>
+#include <vector>
 
 #include <range_algorithm_support.hpp>
 
@@ -165,7 +166,7 @@ struct throwing_test {
     }
 };
 
-struct memcopy_test {
+struct memcpy_test {
     static constexpr int expected_output[]      = {13, 55, 12345, -1};
     static constexpr int expected_output_long[] = {13, 55, -1, -1};
     static constexpr int expected_input[]       = {13, 55, 12345, 42};
@@ -226,5 +227,5 @@ int main() {
     instantiator::call<test_input<test::ProxyRef::yes>, test_output>();
     throwing_test::call<test_input<test::ProxyRef::no>, test_output>();
     throwing_test::call<test_input<test::ProxyRef::yes>, test_output>();
-    memcopy_test::call();
+    memcpy_test::call();
 }


### PR DESCRIPTION
Found by accident. Added some tests for the copy/move code pathes.