### PR TITLE
<algorithm>: fill does not accept volatile byte pointers

### DIFF
--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -4352,10 +4352,11 @@ template <>
 struct _Is_character_or_byte_or_bool<bool> : true_type {};
 
 // _Fill_memset_is_safe determines if _FwdIt and _Ty are eligible for memset optimization in fill
+// Need to explicity test for volatile because _Unwrap_enum_t discards qualifiers.
 template <class _FwdIt, class _Ty, bool = is_pointer_v<_FwdIt>>
 _INLINE_VAR constexpr bool _Fill_memset_is_safe = conjunction_v<is_scalar<_Ty>,
     _Is_character_or_byte_or_bool<_Unwrap_enum_t<remove_reference_t<_Iter_ref_t<_FwdIt>>>>,
-    is_assignable<_Iter_ref_t<_FwdIt>, const _Ty&>>;
+    negation<is_volatile<remove_reference_t<_Iter_ref_t<_FwdIt>>>>, is_assignable<_Iter_ref_t<_FwdIt>, const _Ty&>>;
 
 template <class _FwdIt, class _Ty>
 _INLINE_VAR constexpr bool _Fill_memset_is_safe<_FwdIt, _Ty, false> = false;

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -4351,8 +4351,8 @@ struct _Is_character_or_byte_or_bool<byte> : true_type {};
 template <>
 struct _Is_character_or_byte_or_bool<bool> : true_type {};
 
-// _Fill_memset_is_safe determines if _FwdIt and _Ty are eligible for memset optimization in fill
-// Need to explicity test for volatile because _Unwrap_enum_t discards qualifiers.
+// _Fill_memset_is_safe determines if _FwdIt and _Ty are eligible for memset optimization in fill.
+// Need to explicitly test for volatile because _Unwrap_enum_t discards qualifiers.
 template <class _FwdIt, class _Ty, bool = is_pointer_v<_FwdIt>>
 _INLINE_VAR constexpr bool _Fill_memset_is_safe = conjunction_v<is_scalar<_Ty>,
     _Is_character_or_byte_or_bool<_Unwrap_enum_t<remove_reference_t<_Iter_ref_t<_FwdIt>>>>,

--- a/tests/std/tests/VSO_0180469_fill_family/test.cpp
+++ b/tests/std/tests/VSO_0180469_fill_family/test.cpp
@@ -134,6 +134,9 @@ int main() {
     test_fill<char, int>();
 
     test_fill<volatile char, char>(); // Test GH-1183
+#ifdef __cpp_lib_byte
+    test_fill<volatile byte, byte>(); // Test GH-1556
+#endif // __cpp_lib_byte
 
     test_uninitialized_fill(
         [](count_copies* buff, size_t n, const count_copies& src) { uninitialized_fill(buff, buff + n, src); });


### PR DESCRIPTION
Fixes #1556. In `_Fill_memset_is_safe`, the `_Unwrap_enum_t` template discards qualifiers of enum types, including `byte`, so `volatile` needs to be checked explicitly.