### PR TITLE
Test each list which can contain /BE independently

### DIFF
--- a/tests/std/tests/P1502R1_standard_library_header_units/custom_format.py
+++ b/tests/std/tests/P1502R1_standard_library_header_units/custom_format.py
@@ -1,7 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-import itertools
 import os
 
 from stl.test.format import STLTestFormat, TestStep

--- a/tests/std/tests/P1502R1_standard_library_header_units/custom_format.py
+++ b/tests/std/tests/P1502R1_standard_library_header_units/custom_format.py
@@ -93,9 +93,10 @@ class CustomTestFormat(STLTestFormat):
         outputDir, outputBase = test.getTempPaths()
         sourcePath = test.getSourcePath()
 
-        compileTestCppWithEdg = '/BE' in itertools.chain(test.flags, test.compileFlags)
-        if compileTestCppWithEdg:
+        if '/BE' in test.flags:
             test.flags.remove('/BE')
+
+        if '/BE' in test.compileFlags:
             test.compileFlags.remove('/BE')
 
         exportHeaderOptions = ['/exportHeader', '/Fo', '/MP']

--- a/tests/std/tests/P1502R1_standard_library_header_units/custom_format.py
+++ b/tests/std/tests/P1502R1_standard_library_header_units/custom_format.py
@@ -92,10 +92,13 @@ class CustomTestFormat(STLTestFormat):
         outputDir, outputBase = test.getTempPaths()
         sourcePath = test.getSourcePath()
 
+        compileTestCppWithEdg = False
         if '/BE' in test.flags:
+            compileTestCppWithEdg = True
             test.flags.remove('/BE')
 
         if '/BE' in test.compileFlags:
+            compileTestCppWithEdg = True
             test.compileFlags.remove('/BE')
 
         exportHeaderOptions = ['/exportHeader', '/Fo', '/MP']


### PR DESCRIPTION
If an item passed to `list.remove()` does not exist an error is thrown.
Therefore we must test `test.flags` and `test.compileFlags` independently for the presence of the `/BE` flag.

Works towards #60.