### PR TITLE
Test deduction guides with header units internally

### DIFF
--- a/tests/std/tests/P1502R1_standard_library_header_units/test.cpp
+++ b/tests/std/tests/P1502R1_standard_library_header_units/test.cpp
@@ -115,7 +115,7 @@ int main() {
 
     {
         puts("Testing <array>.");
-#if 0 // TRANSITION, VSO-1088552 (deduction guides)
+#ifdef MSVC_INTERNAL_TESTING // TRANSITION, VSO-1088552 (deduction guides)
         constexpr array arr{10, 20, 30, 40, 50};
 #else // ^^^ no workaround / workaround vvv
         constexpr array<int, 5> arr{10, 20, 30, 40, 50};
@@ -570,7 +570,7 @@ int main() {
     {
         puts("Testing <ranges>.");
         constexpr int arr[]{11, 0, 22, 0, 33, 0, 44, 0, 55};
-#if 0 // TRANSITION, VSO-1088552 (deduction guides)
+#ifdef MSVC_INTERNAL_TESTING // TRANSITION, VSO-1088552 (deduction guides)
         assert(ranges::distance(views::filter(arr, [](int x) { return x == 0; })) == 4);
         static_assert(ranges::distance(views::filter(arr, [](int x) { return x != 0; })) == 5);
 #else // ^^^ no workaround / workaround vvv


### PR DESCRIPTION
Microsoft-internal VSO-1273005 "[Modules] c1xx does not fully resolve templates imported from IFC in the context of trailing requirements" blocks deduction guides for header units. When it's fixed, we'll enable these parts of the Standard Library Header Units test for the internal build until this fix ships in a VS Preview publicly, at which point we'll entirely remove the workarounds.

Works towards #60.

Mirrored in internal MSVC-PR-306384.