### PR TITLE
Avoid conflict with ICU macroizing _No

### DIFF
--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -2082,10 +2082,10 @@ struct _Alignas_storage_unit {
     alignas(_Align) char _Space[_Align];
 };
 
-enum class _Check_overflow : bool { _No, _Yes };
+enum class _Check_overflow : bool { _Nope, _Yes };
 
 template <class _Refc, _Check_overflow _Check>
-_NODISCARD size_t _Calculate_bytes_for_flexible_array(const size_t _Count) noexcept(_Check == _Check_overflow::_No) {
+_NODISCARD size_t _Calculate_bytes_for_flexible_array(const size_t _Count) noexcept(_Check == _Check_overflow::_Nope) {
     constexpr size_t _Align = alignof(_Refc);
 
     size_t _Bytes = sizeof(_Refc); // contains storage for one element
@@ -2691,7 +2691,7 @@ private:
 
         _Rebind_alloc_t<_Alloc, _Storage> _Al(this->_Get_val());
         const size_t _Bytes =
-            _Calculate_bytes_for_flexible_array<_Ref_count_unbounded_array_alloc, _Check_overflow::_No>(_Size);
+            _Calculate_bytes_for_flexible_array<_Ref_count_unbounded_array_alloc, _Check_overflow::_Nope>(_Size);
         const size_t _Storage_units = _Bytes / sizeof(_Storage);
 
         this->~_Ref_count_unbounded_array_alloc();

--- a/stl/inc/xlocale
+++ b/stl/inc/xlocale
@@ -3242,7 +3242,7 @@ protected:
 };
 
 // FUNCTION TEMPLATE _Getloctxt
-enum class _Case_sensitive : bool { _No, _Yes };
+enum class _Case_sensitive : bool { _Nope, _Yes };
 
 template <class _InIt, class _Elem>
 int __CRTDECL _Getloctxt(

--- a/stl/inc/xloctime
+++ b/stl/inc/xloctime
@@ -326,7 +326,7 @@ protected:
 
     virtual _InIt __CLR_OR_THIS_CALL do_get_weekday(_InIt _First, _InIt _Last, ios_base&, ios_base::iostate& _State,
         tm* _Pt) const { // get weekday from [_First, _Last) into _Pt
-        int _Num = _Getloctxt(_First, _Last, 0, _Days, _Case_sensitive::_No);
+        int _Num = _Getloctxt(_First, _Last, 0, _Days, _Case_sensitive::_Nope);
         if (_Num < 0) {
             _State |= ios_base::failbit;
         } else {
@@ -338,7 +338,7 @@ protected:
 
     virtual _InIt __CLR_OR_THIS_CALL do_get_monthname(_InIt _First, _InIt _Last, ios_base&, ios_base::iostate& _State,
         tm* _Pt) const { // get month from [_First, _Last) into _Pt
-        int _Num = _Getloctxt(_First, _Last, 0, _Months, _Case_sensitive::_No);
+        int _Num = _Getloctxt(_First, _Last, 0, _Months, _Case_sensitive::_Nope);
 
         if (_Num < 0) {
             _State |= ios_base::failbit;
@@ -444,7 +444,7 @@ protected:
             break;
 
         case 'p':
-            _Ans = _Getloctxt(_First, _Last, 0, ":AM:am:PM:pm", _Case_sensitive::_No);
+            _Ans = _Getloctxt(_First, _Last, 0, ":AM:am:PM:pm", _Case_sensitive::_Nope);
             if (_Ans < 0) {
                 _State |= ios_base::failbit;
             } else if (1 < _Ans) {


### PR DESCRIPTION
[#1543](https://github.com/microsoft/STL/pull/1543) added:

https://github.com/microsoft/STL/blob/f93cf3a0e3b6f0f356ffdae0cebc6b772b38481f/stl/inc/xlocale#L3245

This conflicts with an ICU header that macroizes `_No`, reported as [ICU-21461](https://unicode-org.atlassian.net/browse/ICU-21461). This breaks Tensorflow, MySQL, and PDFium in our Real World Code test harness.

While ICU should avoid macroizing these reserved identifiers, the STL should avoid breaking RWC, so this PR renames `_No` to `_Nope`. We had previously used this identifier in `<memory>`, but apparently nobody noticed/complained because no projects were including the conflicting headers in the conflicting order. (There are other conflicts like this: `_Pi` in `<complex>`, `_Cc` in `<limits>`, and `_Mn` in `<regex>`.)

For consistency, I am changing all of the `_No` occurrences. I didn't think it was necessary to make `_Yes` sound more parallel (`_Nope/_Yep` or `_Nay/_Yea` or whatever). At this time, I don't think it's necessary for the STL to rename the other conflicting identifiers, since the STL is allowed to use them, and they aren't causing RWC breaks.