### PR TITLE
Implement LWG-3171 "LWG-2989 breaks directory_entry stream insertion"

### DIFF
--- a/stl/inc/filesystem
+++ b/stl/inc/filesystem
@@ -2471,8 +2471,8 @@ namespace filesystem {
 
         // [fs.dir.entry.io], inserter
         template <class _Elem, class _Traits>
-        friend _STD basic_ostream<_Elem, _Traits>& operator<<(
-            _STD basic_ostream<_Elem, _Traits>& _Ostr, const directory_entry& _Entry) {
+        friend _STD basic_ostream<_Elem, _Traits>& operator<<( // TRANSITION, VSO-570323
+            _STD basic_ostream<_Elem, _Traits>& _Ostr, const directory_entry& _Entry) { // TRANSITION, VSO-570323
             // insert a directory_entry into a stream
             return _Ostr << _Entry.path();
         }

--- a/stl/inc/filesystem
+++ b/stl/inc/filesystem
@@ -2469,6 +2469,14 @@ namespace filesystem {
             return _Path >= _Rhs._Path;
         }
 
+        // [fs.dir.entry.io], inserter
+        template <class _Elem, class _Traits>
+        friend _STD basic_ostream<_Elem, _Traits>& operator<<(
+            _STD basic_ostream<_Elem, _Traits>& _Ostr, const directory_entry& _Entry) {
+            // insert a directory_entry into a stream
+            return _Ostr << _Entry.path();
+        }
+
     private:
         void _Refresh(const __std_fs_find_data& _Data) noexcept {
             _Cached_data._Attributes        = _Data._Attributes;


### PR DESCRIPTION
<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->

Fixes #1467.