### PR TITLE
_NODISCARD for <hash_map> and <hash_set>

### DIFF
--- a/stl/inc/hash_map
+++ b/stl/inc/hash_map
@@ -84,20 +84,21 @@ namespace stdext {
         };
 
         template <class _Ty1, class _Ty2>
-        static const _Kty& _Kfn(const pair<_Ty1, _Ty2>& _Val) noexcept { // extract key from element value
+        _NODISCARD static const _Kty& _Kfn(const pair<_Ty1, _Ty2>& _Val) noexcept { // extract key from element value
             return _Val.first;
         }
 
         template <class _Ty1, class _Ty2>
-        static const _Ty2& _Nonkfn(const pair<_Ty1, _Ty2>& _Val) noexcept { // extract non-key from element value
+        _NODISCARD static const _Ty2& _Nonkfn(
+            const pair<_Ty1, _Ty2>& _Val) noexcept { // extract non-key from element value
             return _Val.second;
         }
 
-        float& _Get_max_bucket_size() noexcept {
+        _NODISCARD float& _Get_max_bucket_size() noexcept {
             return _Max_buckets;
         }
 
-        const float& _Get_max_bucket_size() const noexcept {
+        _NODISCARD const float& _Get_max_bucket_size() const noexcept {
             return _Max_buckets;
         }
 
@@ -220,11 +221,11 @@ namespace stdext {
             return *this;
         }
 
-        mapped_type& operator[](const key_type& _Keyval) {
+        _NODISCARD mapped_type& operator[](const key_type& _Keyval) {
             return this->_Try_emplace(_Keyval).first->_Myval.second;
         }
 
-        mapped_type& at(const key_type& _Keyval) {
+        _NODISCARD mapped_type& at(const key_type& _Keyval) {
             const auto _Target = this->_Find_last(_Keyval, this->_Traitsobj(_Keyval));
             if (_Target._Duplicate) {
                 return _Target._Duplicate->_Myval.second;
@@ -233,7 +234,7 @@ namespace stdext {
             _Xout_of_range("invalid hash_map<K, T> key");
         }
 
-        const mapped_type& at(const key_type& _Keyval) const {
+        _NODISCARD const mapped_type& at(const key_type& _Keyval) const {
             const auto _Target = this->_Find_last(_Keyval, this->_Traitsobj(_Keyval));
             if (_Target._Duplicate) {
                 return _Target._Duplicate->_Myval.second;
@@ -245,27 +246,27 @@ namespace stdext {
         using reverse_iterator       = _STD reverse_iterator<iterator>;
         using const_reverse_iterator = _STD reverse_iterator<const_iterator>;
 
-        reverse_iterator rbegin() noexcept {
+        _NODISCARD reverse_iterator rbegin() noexcept {
             return reverse_iterator(this->end());
         }
 
-        const_reverse_iterator rbegin() const noexcept {
+        _NODISCARD const_reverse_iterator rbegin() const noexcept {
             return const_reverse_iterator(this->end());
         }
 
-        reverse_iterator rend() noexcept {
+        _NODISCARD reverse_iterator rend() noexcept {
             return reverse_iterator(this->begin());
         }
 
-        const_reverse_iterator rend() const noexcept {
+        _NODISCARD const_reverse_iterator rend() const noexcept {
             return const_reverse_iterator(this->begin());
         }
 
-        const_reverse_iterator crbegin() const noexcept {
+        _NODISCARD const_reverse_iterator crbegin() const noexcept {
             return rbegin();
         }
 
-        const_reverse_iterator crend() const noexcept {
+        _NODISCARD const_reverse_iterator crend() const noexcept {
             return rend();
         }
 
@@ -406,27 +407,27 @@ namespace stdext {
         using reverse_iterator       = _STD reverse_iterator<iterator>;
         using const_reverse_iterator = _STD reverse_iterator<const_iterator>;
 
-        reverse_iterator rbegin() noexcept {
+        _NODISCARD reverse_iterator rbegin() noexcept {
             return reverse_iterator(this->end());
         }
 
-        const_reverse_iterator rbegin() const noexcept {
+        _NODISCARD const_reverse_iterator rbegin() const noexcept {
             return const_reverse_iterator(this->end());
         }
 
-        reverse_iterator rend() noexcept {
+        _NODISCARD reverse_iterator rend() noexcept {
             return reverse_iterator(this->begin());
         }
 
-        const_reverse_iterator rend() const noexcept {
+        _NODISCARD const_reverse_iterator rend() const noexcept {
             return const_reverse_iterator(this->begin());
         }
 
-        const_reverse_iterator crbegin() const noexcept {
+        _NODISCARD const_reverse_iterator crbegin() const noexcept {
             return rbegin();
         }
 
-        const_reverse_iterator crend() const noexcept {
+        _NODISCARD const_reverse_iterator crend() const noexcept {
             return rend();
         }
 

--- a/stl/inc/hash_map
+++ b/stl/inc/hash_map
@@ -89,8 +89,8 @@ namespace stdext {
         }
 
         template <class _Ty1, class _Ty2>
-        _NODISCARD static const _Ty2& _Nonkfn(
-            const pair<_Ty1, _Ty2>& _Val) noexcept { // extract non-key from element value
+        _NODISCARD static const _Ty2& _Nonkfn(const pair<_Ty1, _Ty2>& _Val) noexcept {
+            // extract non-key from element value
             return _Val.second;
         }
 
@@ -221,7 +221,7 @@ namespace stdext {
             return *this;
         }
 
-        _NODISCARD mapped_type& operator[](const key_type& _Keyval) {
+        mapped_type& operator[](const key_type& _Keyval) {
             return this->_Try_emplace(_Keyval).first->_Myval.second;
         }
 

--- a/stl/inc/hash_set
+++ b/stl/inc/hash_set
@@ -62,20 +62,20 @@ namespace stdext {
 
         using value_compare = key_compare;
 
-        static const _Kty& _Kfn(const value_type& _Val) noexcept {
+        _NODISCARD static const _Kty& _Kfn(const value_type& _Val) noexcept {
             return _Val;
         }
 
-        static int _Nonkfn(const value_type&) noexcept {
+        _NODISCARD static int _Nonkfn(const value_type&) noexcept {
             // extract "non-key" from element value (for container equality)
             return 0;
         }
 
-        float& _Get_max_bucket_size() noexcept {
+        _NODISCARD float& _Get_max_bucket_size() noexcept {
             return _Max_buckets;
         }
 
-        const float& _Get_max_bucket_size() const noexcept {
+        _NODISCARD const float& _Get_max_bucket_size() const noexcept {
             return _Max_buckets;
         }
 
@@ -181,27 +181,27 @@ namespace stdext {
         using reverse_iterator       = _STD reverse_iterator<iterator>;
         using const_reverse_iterator = _STD reverse_iterator<const_iterator>;
 
-        reverse_iterator rbegin() noexcept {
+        _NODISCARD reverse_iterator rbegin() noexcept {
             return reverse_iterator(this->end());
         }
 
-        const_reverse_iterator rbegin() const noexcept {
+        _NODISCARD const_reverse_iterator rbegin() const noexcept {
             return const_reverse_iterator(this->end());
         }
 
-        reverse_iterator rend() noexcept {
+        _NODISCARD reverse_iterator rend() noexcept {
             return reverse_iterator(this->begin());
         }
 
-        const_reverse_iterator rend() const noexcept {
+        _NODISCARD const_reverse_iterator rend() const noexcept {
             return const_reverse_iterator(this->begin());
         }
 
-        const_reverse_iterator crbegin() const noexcept {
+        _NODISCARD const_reverse_iterator crbegin() const noexcept {
             return rbegin();
         }
 
-        const_reverse_iterator crend() const noexcept {
+        _NODISCARD const_reverse_iterator crend() const noexcept {
             return rend();
         }
 
@@ -325,27 +325,27 @@ namespace stdext {
         using reverse_iterator       = _STD reverse_iterator<iterator>;
         using const_reverse_iterator = _STD reverse_iterator<const_iterator>;
 
-        reverse_iterator rbegin() noexcept {
+        _NODISCARD reverse_iterator rbegin() noexcept {
             return reverse_iterator(this->end());
         }
 
-        const_reverse_iterator rbegin() const noexcept {
+        _NODISCARD const_reverse_iterator rbegin() const noexcept {
             return const_reverse_iterator(this->end());
         }
 
-        reverse_iterator rend() noexcept {
+        _NODISCARD reverse_iterator rend() noexcept {
             return reverse_iterator(this->begin());
         }
 
-        const_reverse_iterator rend() const noexcept {
+        _NODISCARD const_reverse_iterator rend() const noexcept {
             return const_reverse_iterator(this->begin());
         }
 
-        const_reverse_iterator crbegin() const noexcept {
+        _NODISCARD const_reverse_iterator crbegin() const noexcept {
             return rbegin();
         }
 
-        const_reverse_iterator crend() const noexcept {
+        _NODISCARD const_reverse_iterator crend() const noexcept {
             return rend();
         }
 


### PR DESCRIPTION
<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
Further addresses #206.

Even though it's deprecated, it's still in the codebase, and I've found some member functions that seemingly can be marked as `_NODISCARD`.

Also, I'm very unsure about the helper functions, so if I missed anything in there that can be marked `_NODISCARD` or has to be removed somewhere, then please let me know.