### PR TITLE
Toolset update: VS 2019 16.9 Preview 3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if (NOT DEFINED CMAKE_TOOLCHAIN_FILE AND EXISTS "${CMAKE_CURRENT_LIST_DIR}/vcpkg
     set(CMAKE_TOOLCHAIN_FILE "${CMAKE_CURRENT_LIST_DIR}/vcpkg/scripts/buildsystems/vcpkg.cmake")
 endif()
 
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.19)
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 project(msvc_standard_libraries LANGUAGES CXX)
 

--- a/README.md
+++ b/README.md
@@ -143,10 +143,10 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 The STL uses boost-math headers to provide P0226R1 Mathematical Special Functions. We recommend using [vcpkg][] to
 acquire this dependency.
 
-1. Install Visual Studio 2019 16.9 Preview 2 or later.
+1. Install Visual Studio 2019 16.9 Preview 3 or later.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
-    * Otherwise, install [CMake][] 3.18 or later, and [Ninja][] 1.8.2 or later.
+    * Otherwise, install [CMake][] 3.19 or later, and [Ninja][] 1.10.2 or later.
 2. Open Visual Studio, and choose the "Clone or check out code" option. Enter the URL of this repository,
    `https://github.com/microsoft/STL`.
 3. Open a terminal in the IDE with `` Ctrl + ` `` (by default) or press on "View" in the top bar, and then "Terminal".
@@ -158,10 +158,10 @@ acquire this dependency.
 
 # How To Build With A Native Tools Command Prompt
 
-1. Install Visual Studio 2019 16.9 Preview 2 or later.
+1. Install Visual Studio 2019 16.9 Preview 3 or later.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
-    * Otherwise, install [CMake][] 3.18 or later, and [Ninja][] 1.8.2 or later.
+    * Otherwise, install [CMake][] 3.19 or later, and [Ninja][] 1.10.2 or later.
 2. Open a command prompt.
 3. Change directories to a location where you'd like a clone of this STL repository.
 4. `git clone https://github.com/microsoft/STL`
@@ -234,7 +234,7 @@ C:\Users\username\Desktop>dumpbin /IMPORTS .\example.exe | findstr msvcp
 # How To Run The Tests With A Native Tools Command Prompt
 
 1. Follow either [How To Build With A Native Tools Command Prompt][] or [How To Build With The Visual Studio IDE][].
-2. Acquire [Python][] 3.9 or newer and have it on the `PATH` (or run it directly using its absolute or relative path).
+2. Acquire [Python][] 3.9.1 or newer and have it on the `PATH` (or run it directly using its absolute or relative path).
 3. Have LLVM's `bin` directory on the `PATH` (so `clang-cl.exe` is available).
     * We recommend selecting "C++ Clang tools for Windows" in the VS Installer. This will automatically add LLVM to the
     `PATH` of the x86 and x64 Native Tools Command Prompts, and will ensure that you're using a supported version.

--- a/azure-devops/create-vmss.ps1
+++ b/azure-devops/create-vmss.ps1
@@ -17,6 +17,9 @@ or are running from Azure Cloud Shell.
 
 $ErrorActionPreference = 'Stop'
 
+# https://aka.ms/azps-changewarnings
+$Env:SuppressAzurePowerShellBreakingChangeWarnings = 'true'
+
 $Location = 'westus2'
 $Prefix = 'StlBuild-' + (Get-Date -Format 'yyyy-MM-dd')
 $VMSize = 'Standard_D32as_v4'

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -396,3 +396,9 @@ Write-Host 'Finished updating PATH!'
 
 PipInstall pip
 PipInstall psutil
+
+# https://docs.microsoft.com/en-us/windows-hardware/drivers/devtest/bcdedit--set#verification-settings
+Write-Host 'Enabling test-signed kernel-mode drivers...'
+bcdedit /set testsigning on
+
+Write-Host 'Done!'

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -354,7 +354,7 @@ Function PipInstall {
 
   try {
     Write-Host "Installing or upgrading $Package..."
-    python.exe -m pip install --upgrade $Package
+    python.exe -m pip install --progress-bar off --upgrade $Package
     Write-Host "Done installing or upgrading $Package."
   }
   catch {

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -101,7 +101,7 @@ if ([string]::IsNullOrEmpty($AdminUserPassword)) {
     '-u',
     'AdminUser',
     '-p',
-    $AdminUserPassword,
+    'AdminUserPassword_REDACTED',
     '-accepteula',
     '-h',
     $PwshPath,
@@ -110,8 +110,8 @@ if ([string]::IsNullOrEmpty($AdminUserPassword)) {
     '-File',
     $PSCommandPath
   )
-
   Write-Host "Executing: $PsExecPath $PsExecArgs"
+  $PsExecArgs[3] = $AdminUserPassword
 
   $proc = Start-Process -FilePath $PsExecPath -ArgumentList $PsExecArgs -Wait -PassThru
   Write-Host 'Reading transcript...'

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -91,7 +91,7 @@ if ([string]::IsNullOrEmpty($AdminUserPassword)) {
   $PsExecPath = Join-Path $ExtractedPsToolsPath 'PsExec64.exe'
 
   # https://github.com/PowerShell/PowerShell/releases/latest
-  $PowerShellZipUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.1.0/PowerShell-7.1.0-win-x64.zip'
+  $PowerShellZipUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.1.1/PowerShell-7.1.1-win-x64.zip'
   Write-Host "Downloading: $PowerShellZipUrl"
   $ExtractedPowerShellPath = DownloadAndExtractZip -Url $PowerShellZipUrl
   $PwshPath = Join-Path $ExtractedPowerShellPath 'pwsh.exe'

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -56,9 +56,18 @@ if ([string]::IsNullOrEmpty($AdminUserPassword)) {
   Start-Transcript -Path $TranscriptPath
 } else {
   Write-Host 'AdminUser password supplied; switching to AdminUser.'
-  $PsExecPath = Get-TempFilePath -Extension 'exe'
-  Write-Host "Downloading psexec to: $PsExecPath"
-  & curl.exe -L -o $PsExecPath -s -S https://live.sysinternals.com/PsExec64.exe
+
+  # https://docs.microsoft.com/en-us/sysinternals/downloads/psexec
+  $PsToolsZipUrl = 'https://download.sysinternals.com/files/PSTools.zip'
+  $PsToolsZipPath = Get-TempFilePath -Extension 'PSTools.zip'
+  Write-Host "Downloading $PsToolsZipUrl to: $PsToolsZipPath"
+  & curl.exe -L -o $PsToolsZipPath -s -S $PsToolsZipUrl
+
+  $TempSubdirPath = Get-TempFilePath -Extension 'dir'
+  Write-Host "Extracting $PsToolsZipPath to: $TempSubdirPath"
+  Expand-Archive -Path $PsToolsZipPath -DestinationPath $TempSubdirPath -Force
+  $PsExecPath = Join-Path $TempSubdirPath 'PsExec64.exe'
+
   $PsExecArgs = @(
     '-u',
     'AdminUser',

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -138,7 +138,7 @@ $Workloads = @(
 $ReleaseInPath = 'Preview'
 $Sku = 'Enterprise'
 $VisualStudioBootstrapperUrl = 'https://aka.ms/vs/16/pre/vs_enterprise.exe'
-$PythonUrl = 'https://www.python.org/ftp/python/3.9.0/python-3.9.0-amd64.exe'
+$PythonUrl = 'https://www.python.org/ftp/python/3.9.1/python-3.9.1-amd64.exe'
 
 # https://docs.microsoft.com/en-us/windows-hardware/drivers/download-the-wdk
 $WindowsDriverKitUrl = 'https://go.microsoft.com/fwlink/?linkid=2128854'

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -83,7 +83,7 @@ Function DownloadAndExtractZip {
 $TranscriptPath = 'C:\provision-image-transcript.txt'
 
 if ([string]::IsNullOrEmpty($AdminUserPassword)) {
-  Start-Transcript -Path $TranscriptPath
+  Start-Transcript -Path $TranscriptPath -UseMinimalHeader
 } else {
   Write-Host 'AdminUser password supplied; switching to AdminUser.'
 
@@ -92,6 +92,11 @@ if ([string]::IsNullOrEmpty($AdminUserPassword)) {
   $ExtractedPsToolsPath = DownloadAndExtractZip -Url $PsToolsZipUrl
   $PsExecPath = Join-Path $ExtractedPsToolsPath 'PsExec64.exe'
 
+  # https://github.com/PowerShell/PowerShell/releases/latest
+  $PowerShellZipUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.1.0/PowerShell-7.1.0-win-x64.zip'
+  $ExtractedPowerShellPath = DownloadAndExtractZip -Url $PowerShellZipUrl
+  $PwshPath = Join-Path $ExtractedPowerShellPath 'pwsh.exe'
+
   $PsExecArgs = @(
     '-u',
     'AdminUser',
@@ -99,7 +104,7 @@ if ([string]::IsNullOrEmpty($AdminUserPassword)) {
     $AdminUserPassword,
     '-accepteula',
     '-h',
-    'C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe',
+    $PwshPath,
     '-ExecutionPolicy',
     'Unrestricted',
     '-File',
@@ -112,7 +117,8 @@ if ([string]::IsNullOrEmpty($AdminUserPassword)) {
   Write-Host 'Reading transcript...'
   Get-Content -Path $TranscriptPath
   Write-Host 'Cleaning up...'
-  Remove-Item $PsExecPath
+  Remove-Item -Recurse -Path $ExtractedPsToolsPath
+  Remove-Item -Recurse -Path $ExtractedPowerShellPath
   exit $proc.ExitCode
 }
 

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -70,11 +70,8 @@ Function DownloadAndExtractZip {
   }
 
   $ZipPath = Get-TempFilePath -Extension 'zip'
-  Write-Host "Downloading $Url to: $ZipPath"
   & curl.exe -L -o $ZipPath -s -S $Url
-
   $TempSubdirPath = Get-TempFilePath -Extension 'dir'
-  Write-Host "Extracting $ZipPath to: $TempSubdirPath"
   Expand-Archive -Path $ZipPath -DestinationPath $TempSubdirPath -Force
 
   return $TempSubdirPath
@@ -89,11 +86,13 @@ if ([string]::IsNullOrEmpty($AdminUserPassword)) {
 
   # https://docs.microsoft.com/en-us/sysinternals/downloads/psexec
   $PsToolsZipUrl = 'https://download.sysinternals.com/files/PSTools.zip'
+  Write-Host "Downloading: $PsToolsZipUrl"
   $ExtractedPsToolsPath = DownloadAndExtractZip -Url $PsToolsZipUrl
   $PsExecPath = Join-Path $ExtractedPsToolsPath 'PsExec64.exe'
 
   # https://github.com/PowerShell/PowerShell/releases/latest
   $PowerShellZipUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.1.0/PowerShell-7.1.0-win-x64.zip'
+  Write-Host "Downloading: $PowerShellZipUrl"
   $ExtractedPowerShellPath = DownloadAndExtractZip -Url $PowerShellZipUrl
   $PwshPath = Join-Path $ExtractedPowerShellPath 'pwsh.exe'
 

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -102,6 +102,7 @@ if ([string]::IsNullOrEmpty($AdminUserPassword)) {
     '-p',
     'AdminUserPassword_REDACTED',
     '-accepteula',
+    '-i',
     '-h',
     $PwshPath,
     '-ExecutionPolicy',

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,7 @@
 variables:
   tmpDir: 'D:\Temp'
 
-pool: 'StlBuild-2020-12-08-1'
+pool: 'StlBuild-2021-01-20-2'
 
 stages:
   - stage: Code_Format

--- a/tests/std/tests/P0220R1_optional/test.cpp
+++ b/tests/std/tests/P0220R1_optional/test.cpp
@@ -5495,13 +5495,17 @@ constexpr int test()
     {
         optional<X> opt(in_place, 2);
         Y y(3);
+#ifndef __EDG__ // TRANSITION, VSO-1268140
         assert(std::move(opt).value_or(y) == 2);
         assert(*opt == 0);
+#endif // ^^^ no workaround ^^^
     }
     {
         optional<X> opt(in_place, 2);
+#ifndef __EDG__ // TRANSITION, VSO-1268140
         assert(std::move(opt).value_or(Y(3)) == 2);
         assert(*opt == 0);
+#endif // ^^^ no workaround ^^^
     }
     {
         optional<X> opt;


### PR DESCRIPTION
* **`azure-devops/provision-image.ps1`**
  + Obtain `PsExec64.exe` by downloading and extracting `PSTools.zip`, which is apparently recommended over directly downloading the executable.
  + Download and extract PowerShell 7.1.1 so we can pass `-UseMinimalHeader` to `Start-Transcript`, which reduces log verbosity.
  + Centralize common machinery in `Function DownloadAndExtractZip`.
  + Redact the `AdminUserPassword` when printing logs.
  + PsExec now requires [the `-i` option](https://docs.microsoft.com/en-us/sysinternals/downloads/psexec#using-psexec) when using `-h`. (Without it, the script fails with a difficult-to-understand error.)
  + Cleanup the extracted ZIP directories.
  + Update to Python 3.9.1.
  + Now that we're running in interactive mode, `pip install` prints useful information in the transcript (yay) but also a noisy progress bar that does us no good (because we only see the transcript when everything is done). So, run `pip install` with `--progress-bar off`.
  + Use `bcdedit` to enable test-signed kernel-mode drivers. (Works towards #1421, untested here.)
* **`azure-devops/create-vmss.ps1`**
  + Set `SuppressAzurePowerShellBreakingChangeWarnings`; this noise has never been useful to us.
* **`README.md`**
  + Update VS, CMake, Ninja, Python versions. (CMake and Ninja were updated in Preview 3.)
* **`CMakeLists.txt`**
  + Require CMake 3.19. (We don't need anything from it yet - this is just the general principle of minimizing our support matrix.)
* **`azure-pipelines.yml`**
  + Use the new VMSS pool.
* **`tests/std/tests/P0220R1_optional/test.cpp`**
  + Work around (Microsoft-internal bug) VSO-1268140 "EDG: weirdness evaluating rvalue-qualified constexpr member function", reduced and reported by @CaseyCarter.