### PR TITLE
Move the macro for MSVC-internal testing

### DIFF
--- a/tests/std/tests/P1502R1_standard_library_header_units/custombuild.pl
+++ b/tests/std/tests/P1502R1_standard_library_header_units/custombuild.pl
@@ -99,8 +99,7 @@ sub CustomBuildHook()
         $header_unit_options .= " $_.obj";
     }
 
-    # TRANSITION, remove /DMSVC_INTERNAL_TESTING after all compiler bugs are fixed
-    Run::ExecuteCL("/DMSVC_INTERNAL_TESTING $export_header_options");
-    Run::ExecuteCL("/DMSVC_INTERNAL_TESTING test.cpp /Fe$cwd.exe $header_unit_options");
+    Run::ExecuteCL("$export_header_options");
+    Run::ExecuteCL("test.cpp /Fe$cwd.exe $header_unit_options");
 }
 1


### PR DESCRIPTION
When testing Standard Library Header Units in #1388, I arranged for the MSVC-internal test harness to pass `/DMSVC_INTERNAL_TESTING`, so we could activate portions of the test as soon as MSVC compiler bugs were fixed, before removing workarounds entirely (after the fixed compiler ships in a public VS Preview). That's been enormously successful.

Now that @miscco and @mnatsuhara are working on `constexpr` containers (#1407, #1502, #1546) and are discovering Super Awesome Compiler Bugs everywhere, this macro technique will be useful in other tests.

Accordingly, this PR removes the macro definition from `P1502R1_standard_library_header_units/custombuild.pl`, and we're going to define it for the entire `std` test suite in an MSVC-internal file, so any `std` test can sense it.

To be clear: This has *no effect* for contributors building and testing the repo with the public VS Preview. Only when a compiler bug is encountered, worked around, and eventually fixed by the compiler team, will it be recommended to guard the workaround with `#ifdef MSVC_INTERNAL_TESTING`. That will prevent the compiler from regressing before the fix ships.