### PR TITLE
<random>: Fix min/max of a few random distributions and gamma_distribution::param_type::operator==

### DIFF
--- a/stl/inc/random
+++ b/stl/inc/random
@@ -3057,7 +3057,7 @@ public:
         }
 
         _NODISCARD bool operator==(const param_type& _Right) const {
-            return _Px == _Right._Px;
+            return _Alpha == _Right._Alpha && _Beta == _Right._Beta;
         }
 
         _NODISCARD bool operator!=(const param_type& _Right) const {

--- a/stl/inc/random
+++ b/stl/inc/random
@@ -2780,7 +2780,7 @@ public:
     }
 
     _NODISCARD result_type(max)() const { // get largest possible result
-        return (numeric_limits<result_type>::max)();
+        return numeric_limits<result_type>::infinity();
     }
 
     void reset() {} // clear internal state
@@ -2917,11 +2917,11 @@ public:
     }
 
     _NODISCARD result_type(min)() const { // get smallest possible result
-        return -(numeric_limits<result_type>::max)();
+        return -numeric_limits<result_type>::infinity();
     }
 
     _NODISCARD result_type(max)() const { // get largest possible result
-        return (numeric_limits<result_type>::max)();
+        return numeric_limits<result_type>::infinity();
     }
 
     void reset() { // clear internal state
@@ -3111,11 +3111,11 @@ public:
     }
 
     _NODISCARD result_type(min)() const { // get smallest possible result
-        return numeric_limits<result_type>::denorm_min();
+        return result_type{0.0};
     }
 
     _NODISCARD result_type(max)() const { // get largest possible result
-        return (numeric_limits<result_type>::max)();
+        return numeric_limits<result_type>::infinity();
     }
 
     void reset() {} // clear internal state
@@ -3306,7 +3306,7 @@ public:
     }
 
     _NODISCARD result_type(max)() const { // get largest possible result
-        return (numeric_limits<result_type>::max)();
+        return numeric_limits<result_type>::infinity();
     }
 
     void reset() {} // clear internal state
@@ -3438,11 +3438,11 @@ public:
     }
 
     _NODISCARD result_type(min)() const { // get smallest possible result
-        return -(numeric_limits<result_type>::max)();
+        return -numeric_limits<result_type>::infinity();
     }
 
     _NODISCARD result_type(max)() const { // get largest possible result
-        return (numeric_limits<result_type>::max)();
+        return numeric_limits<result_type>::infinity();
     }
 
     void reset() {} // clear internal state
@@ -3576,11 +3576,11 @@ public:
     }
 
     _NODISCARD result_type(min)() const { // get smallest possible result
-        return numeric_limits<result_type>::denorm_min();
+        return result_type{0.0};
     }
 
     _NODISCARD result_type(max)() const { // get largest possible result
-        return (numeric_limits<result_type>::max)();
+        return numeric_limits<result_type>::infinity();
     }
 
     void reset() {} // clear internal state
@@ -3702,11 +3702,11 @@ public:
     }
 
     _NODISCARD result_type(min)() const { // get smallest possible result
-        return numeric_limits<result_type>::denorm_min();
+        return result_type{0.0};
     }
 
     _NODISCARD result_type(max)() const { // get largest possible result
-        return (numeric_limits<result_type>::max)();
+        return numeric_limits<result_type>::infinity();
     }
 
     void reset() {} // clear internal state
@@ -3834,11 +3834,11 @@ public:
     }
 
     _NODISCARD result_type(min)() const { // get smallest possible result
-        return -(numeric_limits<result_type>::max)();
+        return -numeric_limits<result_type>::infinity();
     }
 
     _NODISCARD result_type(max)() const { // get largest possible result
-        return (numeric_limits<result_type>::max)();
+        return numeric_limits<result_type>::infinity();
     }
 
     void reset() {} // clear internal state
@@ -4035,7 +4035,7 @@ public:
     }
 
     _NODISCARD result_type(max)() const { // get largest possible result
-        return (numeric_limits<result_type>::max)();
+        return numeric_limits<result_type>::infinity();
     }
 
     void reset() {} // clear internal state
@@ -4168,11 +4168,11 @@ public:
     }
 
     _NODISCARD result_type(min)() const { // get smallest possible result
-        return -(numeric_limits<result_type>::max)();
+        return -numeric_limits<result_type>::infinity();
     }
 
     _NODISCARD result_type(max)() const { // get largest possible result
-        return (numeric_limits<result_type>::max)();
+        return numeric_limits<result_type>::infinity();
     }
 
     void reset() {} // clear internal state

--- a/stl/inc/random
+++ b/stl/inc/random
@@ -2917,7 +2917,7 @@ public:
     }
 
     _NODISCARD result_type(min)() const { // get smallest possible result
-        return numeric_limits<result_type>::denorm_min();
+        return -(numeric_limits<result_type>::max)();
     }
 
     _NODISCARD result_type(max)() const { // get largest possible result
@@ -3576,7 +3576,7 @@ public:
     }
 
     _NODISCARD result_type(min)() const { // get smallest possible result
-        return -(numeric_limits<result_type>::max)();
+        return numeric_limits<result_type>::denorm_min();
     }
 
     _NODISCARD result_type(max)() const { // get largest possible result

--- a/stl/inc/random
+++ b/stl/inc/random
@@ -3438,7 +3438,7 @@ public:
     }
 
     _NODISCARD result_type(min)() const { // get smallest possible result
-        return (numeric_limits<result_type>::min)();
+        return -(numeric_limits<result_type>::max)();
     }
 
     _NODISCARD result_type(max)() const { // get largest possible result

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -818,34 +818,16 @@ std/numerics/rand/rand.dis/rand.dist.bern/rand.dist.bern.geo/eval_param.pass.cpp
 std/numerics/rand/rand.dis/rand.dist.bern/rand.dist.bern.geo/eval.pass.cpp FAIL
 std/numerics/rand/rand.dis/rand.dist.bern/rand.dist.bern.negbin/eval_param.pass.cpp FAIL
 std/numerics/rand/rand.dis/rand.dist.bern/rand.dist.bern.negbin/eval.pass.cpp FAIL
-std/numerics/rand/rand.dis/rand.dist.norm/rand.dist.norm.cauchy/max.pass.cpp FAIL
-std/numerics/rand/rand.dis/rand.dist.norm/rand.dist.norm.cauchy/min.pass.cpp FAIL
-std/numerics/rand/rand.dis/rand.dist.norm/rand.dist.norm.chisq/max.pass.cpp FAIL
-std/numerics/rand/rand.dis/rand.dist.norm/rand.dist.norm.chisq/min.pass.cpp FAIL
-std/numerics/rand/rand.dis/rand.dist.norm/rand.dist.norm.f/max.pass.cpp FAIL
 std/numerics/rand/rand.dis/rand.dist.norm/rand.dist.norm.lognormal/eval_param.pass.cpp FAIL
 std/numerics/rand/rand.dis/rand.dist.norm/rand.dist.norm.lognormal/eval.pass.cpp FAIL
-std/numerics/rand/rand.dis/rand.dist.norm/rand.dist.norm.lognormal/max.pass.cpp FAIL
-std/numerics/rand/rand.dis/rand.dist.norm/rand.dist.norm.lognormal/min.pass.cpp FAIL
-std/numerics/rand/rand.dis/rand.dist.norm/rand.dist.norm.normal/max.pass.cpp FAIL
-std/numerics/rand/rand.dis/rand.dist.norm/rand.dist.norm.normal/min.pass.cpp FAIL
 std/numerics/rand/rand.dis/rand.dist.norm/rand.dist.norm.t/eval_param.pass.cpp FAIL
 std/numerics/rand/rand.dis/rand.dist.norm/rand.dist.norm.t/eval.pass.cpp FAIL
-std/numerics/rand/rand.dis/rand.dist.norm/rand.dist.norm.t/max.pass.cpp FAIL
-std/numerics/rand/rand.dis/rand.dist.norm/rand.dist.norm.t/min.pass.cpp FAIL
-std/numerics/rand/rand.dis/rand.dist.pois/rand.dist.pois.exp/max.pass.cpp FAIL
 std/numerics/rand/rand.dis/rand.dist.pois/rand.dist.pois.extreme/eval_param.pass.cpp FAIL
 std/numerics/rand/rand.dis/rand.dist.pois/rand.dist.pois.extreme/eval.pass.cpp FAIL
-std/numerics/rand/rand.dis/rand.dist.pois/rand.dist.pois.extreme/max.pass.cpp FAIL
-std/numerics/rand/rand.dis/rand.dist.pois/rand.dist.pois.extreme/min.pass.cpp FAIL
-std/numerics/rand/rand.dis/rand.dist.pois/rand.dist.pois.gamma/eq.pass.cpp FAIL
 std/numerics/rand/rand.dis/rand.dist.pois/rand.dist.pois.gamma/eval_param.pass.cpp FAIL
 std/numerics/rand/rand.dis/rand.dist.pois/rand.dist.pois.gamma/eval.pass.cpp FAIL
-std/numerics/rand/rand.dis/rand.dist.pois/rand.dist.pois.gamma/max.pass.cpp FAIL
-std/numerics/rand/rand.dis/rand.dist.pois/rand.dist.pois.gamma/min.pass.cpp FAIL
 std/numerics/rand/rand.dis/rand.dist.pois/rand.dist.pois.poisson/eval_param.pass.cpp FAIL
 std/numerics/rand/rand.dis/rand.dist.pois/rand.dist.pois.poisson/eval.pass.cpp FAIL
-std/numerics/rand/rand.dis/rand.dist.pois/rand.dist.pois.weibull/max.pass.cpp FAIL
 std/numerics/rand/rand.dis/rand.dist.uni/rand.dist.uni.real/param_ctor.pass.cpp FAIL
 
 # Not yet analyzed, likely STL bugs. Various assertions.

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -818,34 +818,16 @@ numerics\rand\rand.dis\rand.dist.bern\rand.dist.bern.geo\eval_param.pass.cpp
 numerics\rand\rand.dis\rand.dist.bern\rand.dist.bern.geo\eval.pass.cpp
 numerics\rand\rand.dis\rand.dist.bern\rand.dist.bern.negbin\eval_param.pass.cpp
 numerics\rand\rand.dis\rand.dist.bern\rand.dist.bern.negbin\eval.pass.cpp
-numerics\rand\rand.dis\rand.dist.norm\rand.dist.norm.cauchy\max.pass.cpp
-numerics\rand\rand.dis\rand.dist.norm\rand.dist.norm.cauchy\min.pass.cpp
-numerics\rand\rand.dis\rand.dist.norm\rand.dist.norm.chisq\max.pass.cpp
-numerics\rand\rand.dis\rand.dist.norm\rand.dist.norm.chisq\min.pass.cpp
-numerics\rand\rand.dis\rand.dist.norm\rand.dist.norm.f\max.pass.cpp
 numerics\rand\rand.dis\rand.dist.norm\rand.dist.norm.lognormal\eval_param.pass.cpp
 numerics\rand\rand.dis\rand.dist.norm\rand.dist.norm.lognormal\eval.pass.cpp
-numerics\rand\rand.dis\rand.dist.norm\rand.dist.norm.lognormal\max.pass.cpp
-numerics\rand\rand.dis\rand.dist.norm\rand.dist.norm.lognormal\min.pass.cpp
-numerics\rand\rand.dis\rand.dist.norm\rand.dist.norm.normal\max.pass.cpp
-numerics\rand\rand.dis\rand.dist.norm\rand.dist.norm.normal\min.pass.cpp
 numerics\rand\rand.dis\rand.dist.norm\rand.dist.norm.t\eval_param.pass.cpp
 numerics\rand\rand.dis\rand.dist.norm\rand.dist.norm.t\eval.pass.cpp
-numerics\rand\rand.dis\rand.dist.norm\rand.dist.norm.t\max.pass.cpp
-numerics\rand\rand.dis\rand.dist.norm\rand.dist.norm.t\min.pass.cpp
-numerics\rand\rand.dis\rand.dist.pois\rand.dist.pois.exp\max.pass.cpp
 numerics\rand\rand.dis\rand.dist.pois\rand.dist.pois.extreme\eval_param.pass.cpp
 numerics\rand\rand.dis\rand.dist.pois\rand.dist.pois.extreme\eval.pass.cpp
-numerics\rand\rand.dis\rand.dist.pois\rand.dist.pois.extreme\max.pass.cpp
-numerics\rand\rand.dis\rand.dist.pois\rand.dist.pois.extreme\min.pass.cpp
-numerics\rand\rand.dis\rand.dist.pois\rand.dist.pois.gamma\eq.pass.cpp
 numerics\rand\rand.dis\rand.dist.pois\rand.dist.pois.gamma\eval_param.pass.cpp
 numerics\rand\rand.dis\rand.dist.pois\rand.dist.pois.gamma\eval.pass.cpp
-numerics\rand\rand.dis\rand.dist.pois\rand.dist.pois.gamma\max.pass.cpp
-numerics\rand\rand.dis\rand.dist.pois\rand.dist.pois.gamma\min.pass.cpp
 numerics\rand\rand.dis\rand.dist.pois\rand.dist.pois.poisson\eval_param.pass.cpp
 numerics\rand\rand.dis\rand.dist.pois\rand.dist.pois.poisson\eval.pass.cpp
-numerics\rand\rand.dis\rand.dist.pois\rand.dist.pois.weibull\max.pass.cpp
 numerics\rand\rand.dis\rand.dist.uni\rand.dist.uni.real\param_ctor.pass.cpp
 
 # Not yet analyzed, likely STL bugs. Various assertions.


### PR DESCRIPTION
<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->

- Fix wrong `normal_distribution::min`, `lognormal_distribution::min`, and `extreme_value_distribution::min` values
- Fix `gamma_distribution::param_type::operator==`
- Return -Inf/+0/+Inf instead of -max/+denorm_min/+max for `min`/`max` of unbounded (positive)? real random distributions
