### PR TITLE
Suppress warning C4640 emitted by MSVC constinit

### DIFF
--- a/tests/std/tests/P0083R3_splicing_maps_and_sets/test.cpp
+++ b/tests/std/tests/P0083R3_splicing_maps_and_sets/test.cpp
@@ -154,6 +154,7 @@ void test_node_handle(NodeHandle& nh1, NodeHandle& nh2, Validator1 v1, Validator
     static_assert(std::is_nothrow_default_constructible_v<NodeHandle>);
     CHECK_EMPTY(NodeHandle{});
 #if defined(__cpp_constinit)
+#pragma warning(suppress : 4640) // C4640 emitted by MSVC because 'NodeHandle' type has non-trivial dtor
     { static constinit NodeHandle static_handle{}; }
 #elif defined(__clang__)
     { [[clang::require_constant_initialization]] static NodeHandle static_handle{}; }


### PR DESCRIPTION
Mark Hall is implementing `constinit` for MSVC in internal MSVC-PR-301193 and needs to suppress a harmless warning in test code.

We disable magic statics in our test suite, and enable the off-by-default [warning C4640](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4640?view=msvc-160), to find any places where we're unintentionally using magic statics in product code. Here, this test code is eligible for `constinit`, but needs magic statics because its destructor is non-trivial. That's okay, so we can just suppress the warning.