### PR TITLE
std::format parsing callbacks and machinery

### DIFF
--- a/stl/inc/format
+++ b/stl/inc/format
@@ -143,7 +143,7 @@ concept _Parse_arg_id_callbacks = requires(_Ty _At) {
 
 template<class _Ty, class _CharT>
 concept _Parse_replacement_field_callbacks = requires(_Ty _At, const _CharT* _Begin, const _CharT* _End) {
-    //{ _At._Parse_context } -> same_as<basic_format_parse_context<_CharT>>;
+    { _At._Parse_context };
     { _At._On_text(_Begin, _End) } -> same_as<void>;
     { _At._On_replacement_field(size_t{}, _STD declval<const _CharT*>()) } -> same_as<void>;
     { _At._On_format_specs(size_t{}, _Begin, _End) } -> same_as<const _CharT*>;

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -571,7 +571,7 @@ struct _Basic_format_specs {
 };
 
 
-// Extremely dull set of parsing callbacks that just fills a struct with parsed data.
+// _Parse_specs_callbacks that fill a _Basic_format_specs struct with the parsed data
 template <class _CharT>
 class _Specs_setter {
 public:
@@ -618,7 +618,9 @@ protected:
     _Basic_format_specs<_CharT> _Specs;
 };
 
-
+// Actually fetch the value of an argument associated with a dynamic
+// width or precision specifier. This will be called with either
+// _Width_checker or _Precision_checker as "_Handler".
 template <class _Handler, class _FormatArg>
 constexpr unsigned int _Get_dynamic_specs(_FormatArg _Arg) {
     unsigned long long _Val = visit_format_arg(_Handler(), _Arg);
@@ -640,6 +642,8 @@ constexpr basic_format_arg<_Context> _Get_arg(_Context _Ctx, size_t _Arg_id) {
     return _Arg;
 }
 
+// Checks that the type and value of an argument associated with a dynamic
+// width specifier is valid.
 class _Width_checker {
 public:
     template <class _Ty>
@@ -656,6 +660,8 @@ public:
     }
 };
 
+// Checks that the type and value of an argument associated with a dynamic
+// precision specifier is valid.
 class _Precision_checker {
 public:
     template <class _Ty>
@@ -672,6 +678,10 @@ public:
     }
 };
 
+// Parses standard format specs into a _Basic_format_specs using _Specs_setter, and,
+// in addition handles dynamic width and precision. This is seperate from _Specs setter
+// because it needs to know about the current basic_format_parse_context and basic_format_context
+// in order to fetch the width from the arguments.
 template <class _ParseContext, class _Context>
 class _Specs_handler : public _Specs_setter<typename _Context::char_type> {
 public:
@@ -703,7 +713,6 @@ private:
         return _STD _Get_arg(_Ctx, _Arg_id);
     }
 };
-
 class _Numeric_specs_checker {
     _Type _Arg_type = _Type::_None;
 
@@ -730,7 +739,10 @@ public:
         }
     }
 };
-
+// Uses _Numeric_specs_checker to check that the type of the argument printed by
+// a replacement field with format specs actually satisfies the requirements for
+// that format spec. If the requirements are met then calls the base class
+// handler method.
 template <class _Handler>
 class _Specs_checker : public _Handler {
     _Numeric_specs_checker _Numeric_checker;
@@ -1281,9 +1293,10 @@ public:
     void operator()(_Ty) const {}
 };
 
-// this is the visitor that's used for replacement fields,
+// This is the visitor that's used for "simple" replacement fields,
 // it could be a generic lambda (with overloaded), but that's
-// bad for throughput
+// bad for throughput. A simple replacement field is a replacement field
+// that's just "{}", without any format specs.
 template <class _OutputIt, class _CharT>
 struct _Default_arg_formatter {
     using _Context = basic_format_context<_OutputIt, _CharT>;

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -71,10 +71,10 @@ template <class _Ty, class _CharT>
 concept _Parse_spec_callbacks = requires(_Ty _At, basic_string_view<_CharT> _Sv, _Align _Aln, _Sign _Sgn) {
     { _At._On_align(_Aln) } -> same_as<void>;
     { _At._On_fill(_Sv) } -> same_as<void>;
-    { _At._On_width(unsigned{}) } -> same_as<void>;
+    { _At._On_width(static_cast<unsigned int>(0)) } -> same_as<void>;
     { _At._On_dynamic_width(size_t{}) } -> same_as<void>;
     { _At._On_dynamic_width(_Auto_id_tag{}) } -> same_as<void>;
-    { _At._On_precision(unsigned{}) } -> same_as<void>;
+    { _At._On_precision(static_cast<unsigned int>(0)) } -> same_as<void>;
     { _At._On_dynamic_precision(size_t{}) } -> same_as<void>;
     { _At._On_dynamic_precision(_Auto_id_tag{}) } -> same_as<void>;
     { _At._On_sign(_Sgn) } -> same_as<void>;

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -12,6 +12,7 @@
 #pragma message("The contents of <format> are available only with C++20 concepts support.")
 #else // ^^^ !defined(__cpp_lib_concepts) / defined(__cpp_lib_concepts) vvv
 
+#include <algorithm>
 #include <array>
 #include <charconv>
 #include <concepts>
@@ -92,7 +93,9 @@ public:
         return _Format_string.end();
     }
     constexpr void advance_to(const_iterator _It) {
-        _Format_string.remove_prefix(_It - begin());
+        _STL_INTERNAL_CHECK(_It - begin() >= 0);
+        using _Size_type = typename basic_string_view<_CharT>::size_type;
+        _Format_string.remove_prefix(static_cast<_Size_type>(_It - begin()));
     }
 
     // While the standard presents an exposition only enum value for
@@ -102,7 +105,7 @@ public:
     // _Next_arg_id == -1 means manual
     constexpr size_t next_arg_id() {
         if (_Next_arg_id >= 0) {
-            return _Next_arg_id++;
+            return static_cast<size_t>(_Next_arg_id++);
         }
         throw format_error("Can not switch from manual to automatic indexing");
     }
@@ -134,15 +137,15 @@ concept _Parse_spec_callbacks = requires(_Ty _At, basic_string_view<_CharT> _Sv,
 template <class _Ty, class _CharT>
 concept _Parse_arg_id_callbacks = requires(_Ty _At) {
     { _At._On_auto_id() } -> same_as<void>;
-    { _At._On_manual_id(int{}) } -> same_as<void>;
+    { _At._On_manual_id(size_t{}) } -> same_as<void>;
 };
 
 template<class _Ty, class _CharT>
 concept _Parse_replacement_field_callbacks = requires(_Ty _At, const _CharT* _Begin, const _CharT* _End) {
-    { _At._Parse_context } -> _STD convertible_to<basic_format_parse_context<_CharT>&>;
+    //{ _At._Parse_context } -> same_as<basic_format_parse_context<_CharT>>;
     { _At._On_text(_Begin, _End) } -> same_as<void>;
-    { _At._On_replacement_field(int{}, _STD declval<const _CharT*>()) } -> same_as<void>;
-    { _At._On_format_specs(int{}, _Begin, _End) } -> same_as<const _CharT*>;
+    { _At._On_replacement_field(size_t{}, _STD declval<const _CharT*>()) } -> same_as<void>;
+    { _At._On_format_specs(size_t{}, _Begin, _End) } -> same_as<const _CharT*>;
 };
 
 // clang-format on
@@ -197,7 +200,7 @@ constexpr const _CharT* _Parse_arg_id(const _CharT* _Begin, const _CharT* _End, 
         if (_Begin == _End || (*_Begin != '}' && *_Begin != ':')) {
             throw format_error("Invalid format string.");
         }
-        _Callbacks._On_manual_id(_Index);
+        _Callbacks._On_manual_id(static_cast<size_t>(_Index));
         return _Begin;
     }
     // This is where we would parse named arg ids if std::format were to support them.
@@ -256,7 +259,7 @@ struct _Width_adapter {
     constexpr void _On_auto_id() {
         _Callbacks._On_dynamic_width(_Auto_id_tag{});
     }
-    constexpr void _On_manual_id(int _Id) {
+    constexpr void _On_manual_id(size_t _Id) {
         _Callbacks._On_dynamic_width(_Id);
     }
 };
@@ -272,7 +275,7 @@ struct _Precision_adapter {
     constexpr void _On_auto_id() {
         _Callbacks._On_dynamic_precision(_Auto_id_tag{});
     }
-    constexpr void _On_manual_id(int _Id) {
+    constexpr void _On_manual_id(size_t _Id) {
         _Callbacks._On_dynamic_precision(_Id);
     }
 };
@@ -280,11 +283,11 @@ struct _Precision_adapter {
 template <class _CharT>
 struct _Id_adapter {
     basic_format_parse_context<_CharT>& _Parse_context;
-    int _Arg_id = 0;
+    size_t _Arg_id = 0;
     constexpr void _On_auto_id() {
         _Arg_id = _Parse_context.next_arg_id();
     }
-    constexpr void _On_manual_id(int _Id) {
+    constexpr void _On_manual_id(size_t _Id) {
         _Parse_context.check_arg_id(_Id);
         _Arg_id = _Id;
     }
@@ -408,7 +411,7 @@ constexpr const _CharT* _Parse_replacement_field(const _CharT* _Begin, const _Ch
 
     if (*_Begin == '}') {
         // string was "{}", and we have a replacement field
-        _Handler._On_replacement_field(_Handler._On_auto_id());
+        _Handler._On_replacement_field(_Handler._Parse_context.next_arg_id(), _Begin);
     } else if (*_Begin == '{') {
         // string was "{{", so we have a literal "{" to print
         _Handler._On_text(_Begin, _Begin + 1);
@@ -460,7 +463,7 @@ constexpr void _Parse_format_string(basic_string_view<_CharT> _Format_str, _Hand
     while (_Begin != _End) {
         const _CharT* _Pt = _Begin;
         if (*_Begin != '{') {
-            _Pt = _STD find(_Begin + 1, _End, '{', _Pt);
+            _Pt = _STD find(_Begin + 1, _End, '{');
             if (_Pt == _End) {
                 return _Writer_loop(_Begin, _End);
             }
@@ -479,6 +482,9 @@ public:
     class handle;
 
 private:
+    template <class _Visitor, class _Ctx>
+    friend auto visit_format_arg(_Visitor&& _Vis, basic_format_arg<_Ctx> _Arg) -> decltype(_Vis(0));
+
     using _CharT = typename _Context::char_type;
 
     using _Format_arg_value = variant<monostate, int, unsigned, long long, unsigned long long, bool,
@@ -514,6 +520,9 @@ private:
             return _Type::_Float32;
         }
         constexpr _Type operator()(double) {
+            return _Type::_Float64;
+        }
+        constexpr _Type operator()(long double) {
             return _Type::_Float64;
         }
         constexpr _Type operator()(const _CharT*) {
@@ -566,6 +575,7 @@ struct _Basic_format_specs {
 // Extremely dull set of parsing callbacks that just fills a struct with parsed data.
 template <class _CharT>
 class _Specs_setter {
+public:
     explicit constexpr _Specs_setter(_Basic_format_specs<_CharT> _Specs) : _Specs(_Specs) {}
 
     constexpr void _On_align(_Align _Aln) {
@@ -573,7 +583,11 @@ class _Specs_setter {
     }
 
     constexpr void _On_fill(basic_string_view<_CharT> _Sv) {
-        _Specs._Fill = _Sv;
+        if (_Sv.size() > 4) {
+            throw format_error("Invalid fill.");
+        }
+        _STD fill(_Specs._Fill, _Specs._Fill + 4, '\0');
+        _STD copy(_Sv.begin(), _Sv.end(), _Specs._Fill);
     }
 
     constexpr void _On_sign(_Sign _Sgn) {
@@ -593,7 +607,7 @@ class _Specs_setter {
         _Specs._Width = _Width;
     }
 
-    constexpr void _On_Precision(int _Precision) {
+    constexpr void _On_precision(int _Precision) {
         _Specs._Precision = _Precision;
     }
 
@@ -616,7 +630,7 @@ constexpr int _Get_dynamic_specs(_FormatArg _Arg) {
 }
 
 template <class _Context>
-constexpr basic_format_arg<_Context> _Get_arg(_Context _Ctx, int _Arg_id) {
+constexpr basic_format_arg<_Context> _Get_arg(_Context _Ctx, size_t _Arg_id) {
     // note: while this is parameterized on the _Arg_id type in libfmt we don't
     // need to do that in std::format because it's only called with either an integer
     // id or a named id (which we do not support in std::format)
@@ -685,7 +699,7 @@ private:
         return _STD _Get_arg(_Ctx, _Parse_ctx.next_arg_id());
     }
 
-    constexpr basic_format_arg<_Context> _Get_arg(int _Arg_id) {
+    constexpr basic_format_arg<_Context> _Get_arg(size_t _Arg_id) {
         _Parse_ctx.check_arg_id(_Arg_id);
         return _STD _Get_arg(_Ctx, _Arg_id);
     }
@@ -1194,6 +1208,10 @@ public:
     template <class _Ty>
     using formatter_type = formatter<_Ty, _CharT>;
 
+    constexpr basic_format_context(
+        _Out _OutputIt, basic_format_args<basic_format_context> _Ctx_args, const locale& _Loc)
+        : _OutputIt(_OutputIt), _Args(_Ctx_args), _Loc(_Loc) {}
+
     basic_format_arg<basic_format_context> arg(size_t _Id) const {
         return _Args.get(_Id);
     }
@@ -1208,10 +1226,14 @@ public:
         // TODO: IDL support probably required
         _OutputIt = _It;
     }
+
+    const basic_format_args<basic_format_context>& _Get_args() const {
+        return _Args;
+    }
 };
 
 template <class _Visitor, class _Context>
-auto visit_format_arg(_Visitor&& _Vis, basic_format_arg<_Context> _Arg) {
+auto visit_format_arg(_Visitor&& _Vis, basic_format_arg<_Context> _Arg) -> decltype(_Vis(0)) {
     return _STD visit(_STD forward<_Visitor>(_Vis), _Arg._Value);
 }
 
@@ -1229,6 +1251,14 @@ _OutputIt _Write(_OutputIt _Out, const _CharT* _Value) {
     while (*_Value) {
         *_Out++ = *_Value++;
     }
+    return _Out;
+}
+
+template <class _CharT, class _OutputIt, class _Ty>
+_OutputIt _Write(_OutputIt _Out, _Ty _Val) {
+    (void) _Val;
+    _STL_INTERNAL_CHECK(false);
+    return _Out;
 }
 
 // Dispatcher to call enabled custom formatters, and do nothing otherwise.
@@ -1261,7 +1291,7 @@ struct _Default_arg_formatter {
 
     _OutputIt _Out;
     basic_format_args<_Context> _Args;
-    locale& _Loc;
+    locale _Loc;
 
     template <class _Ty>
     _OutputIt operator()(_Ty _Val) {
@@ -1283,7 +1313,7 @@ struct _Format_handler {
     _Context _Ctx;
 
     explicit _Format_handler(
-        _OutputIt _Out, basic_string_view<_CharT> _Str, basic_format_args<_Context> _Format_args, locale& _Loc)
+        _OutputIt _Out, basic_string_view<_CharT> _Str, basic_format_args<_Context> _Format_args, const locale& _Loc)
         : _Parse_context(_Str), _Ctx(_Out, _Format_args, _Loc) {}
 
     void _On_text(const _CharT* _Begin, const _CharT* _End) {
@@ -1293,13 +1323,13 @@ struct _Format_handler {
         _Ctx.advance_to(_Out);
     }
 
-    void _On_replacement_field(int _Id, const _CharT*) {
+    void _On_replacement_field(size_t _Id, const _CharT*) {
         auto _Arg = _Ctx.arg(_Id);
-        _Ctx.advance_to(
-            visit_format_arg(_Default_arg_formatter<_OutputIt, _CharT>{_Ctx.out(), _Ctx.args(), _Ctx.locale()}, _Arg));
+        _Ctx.advance_to(visit_format_arg(
+            _Default_arg_formatter<_OutputIt, _CharT>{_Ctx.out(), _Ctx._Get_args(), _Ctx.locale()}, _Arg));
     }
 
-    const _CharT* _On_format_specs(int _Id, const _CharT* _Begin, const _CharT* _End) {
+    const _CharT* _On_format_specs(size_t _Id, const _CharT* _Begin, const _CharT* _End) {
         _Parse_context.advance_to(_Parse_context.begin() + (_Begin - &*_Parse_context.begin()));
         auto _Arg = _Ctx.arg(_Id);
         _Basic_format_specs<_CharT> _Specs;
@@ -1312,6 +1342,7 @@ struct _Format_handler {
         }
         // TODO: implement format spec dispatching.
         _STL_INTERNAL_CHECK(false);
+        return _Begin;
     }
 };
 
@@ -1338,6 +1369,7 @@ _Out vformat_to(
     _Out _OutputIt, const locale& _Loc, string_view _Fmt, format_args_t<type_identity_t<_Out>, char> _Args) {
     _Format_handler<_Out, char, basic_format_context<_Out, char>> _Handler(_OutputIt, _Fmt, _Args, _Loc);
     _Parse_format_string(_Fmt, _Handler);
+    return _Handler._Ctx.out();
 }
 
 // FUNCTION vformat

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -92,7 +92,7 @@ template<class _Ty, class _CharT>
 concept _Parse_replacement_field_callbacks = requires(_Ty _At, const _CharT* _Begin, const _CharT* _End) {
     { _At._Parse_context };
     { _At._On_text(_Begin, _End) } -> same_as<void>;
-    { _At._On_replacement_field(size_t{}, _STD declval<const _CharT*>()) } -> same_as<void>;
+    { _At._On_replacement_field(size_t{}, static_cast<const _CharT*>(nullptr)) } -> same_as<void>;
     { _At._On_format_specs(size_t{}, _Begin, _End) } -> same_as<const _CharT*>;
 };
 
@@ -127,7 +127,7 @@ public:
         _Format_string.remove_prefix(_Diff);
     }
 
-    // While the standard presents an exposition only enum value for
+    // While the standard presents an exposition-only enum value for
     // the indexing mode (manual, automatic, or unknown) we use _Next_arg_id to indicate it.
     // _Next_arg_id > 0 means automatic
     // _Next_arg_id == 0 means unknown
@@ -240,6 +240,43 @@ public:
     };
 };
 
+template <class _Visitor, class _Context>
+auto visit_format_arg(_Visitor&& _Vis, basic_format_arg<_Context> _Arg) {
+    switch (_Arg._Active_state) {
+    case _Basic_format_arg_type::_None:
+        return _Vis(_Arg._No_state);
+    case _Basic_format_arg_type::_Int_type:
+        return _Vis(_Arg._Int_state);
+    case _Basic_format_arg_type::_UInt_type:
+        return _Vis(_Arg._UInt_state);
+    case _Basic_format_arg_type::_Long_long_type:
+        return _Vis(_Arg._Long_long_state);
+    case _Basic_format_arg_type::_ULong_long_type:
+        return _Vis(_Arg._ULong_long_state);
+    case _Basic_format_arg_type::_Bool_type:
+        return _Vis(_Arg._Bool_state);
+    case _Basic_format_arg_type::_Char_type:
+        return _Vis(_Arg._Char_state);
+    case _Basic_format_arg_type::_Float_type:
+        return _Vis(_Arg._Float_state);
+    case _Basic_format_arg_type::_Double_type:
+        return _Vis(_Arg._Double_state);
+    case _Basic_format_arg_type::_Long_double_type:
+        return _Vis(_Arg._Long_double_state);
+    case _Basic_format_arg_type::_Pointer_type:
+        return _Vis(_Arg._Pointer_state);
+    case _Basic_format_arg_type::_CString_type:
+        return _Vis(_Arg._CString_state);
+    case _Basic_format_arg_type::_String_type:
+        return _Vis(_Arg._String_state);
+    case _Basic_format_arg_type::_Custom_type:
+        return _Vis(_Arg._Custom_state);
+    default:
+        _STL_VERIFY(false, "basic_format_arg is in impossible state");
+        return _Vis(0);
+    }
+}
+
 // we need to implement this ourselves because from_chars does not work with wide characters
 template <class _CharT>
 constexpr const _CharT* _Parse_nonnegative_integer(const _CharT* _Begin, const _CharT* _End, unsigned int& _Value) {
@@ -301,7 +338,9 @@ constexpr const _CharT* _Parse_align(const _CharT* _Begin, const _CharT* _End, _
     _STL_INTERNAL_CHECK(_Begin != _End && *_Begin != '}');
     // align and fill
     auto _Parsed_align = _Align::_None;
-    auto _Align_pt     = _Begin + 1;
+
+    // TODO: should increment one code point
+    auto _Align_pt = _Begin + 1;
     if (_Align_pt == _End) {
         _Align_pt = _Begin;
     }
@@ -535,56 +574,61 @@ template <class _CharT, _Parse_replacement_field_callbacks<_CharT> _HandlerT>
 constexpr void _Parse_format_string(basic_string_view<_CharT> _Format_str, _HandlerT&& _Handler) {
     auto _Begin = _Format_str.data();
     auto _End   = _Begin + _Format_str.size();
-    struct _Writer {
-        constexpr void operator()(const _CharT* _Begin, const _CharT* _End) {
-            if (_Begin == _End) {
-                return;
-            }
+    while (_Begin != _End) {
+        const _CharT* _OpeningCurl = _Begin;
+        if (*_Begin != '{') {
+            // we didn't start at an opening curl, find the next one
+            _OpeningCurl = _STD find(_Begin + 1, _End, '{');
+            _STL_INTERNAL_CHECK(_Begin != _OpeningCurl);
             for (;;) {
-                const _CharT* _Pt = _STD _Find_unchecked(_Begin, _End, '}');
-                if (_Pt == _End) {
-                    return _Handler._On_text(_Begin, _End);
+                const _CharT* _ClosingCurl = _STD _Find_unchecked(_Begin, _End, '}');
+
+                // In this case we didn't find either a closing curl or opening curl.
+                // Write the whole thing out.
+                if (_ClosingCurl == _OpeningCurl) {
+                    return _Handler._On_text(_Begin, _OpeningCurl);
                 }
-                ++_Pt;
-                if (_Pt == _End || *_Pt != '}') {
+                // We know _ClosingCurl isn't past the end because
+                // the above condition was not met.
+                ++_ClosingCurl;
+                if (_ClosingCurl == _OpeningCurl || *_ClosingCurl != '}') {
                     throw format_error("Unmatched '}' in format string.");
                 }
-                _Handler._On_text(_Begin, _Pt);
-                _Begin = _Pt + 1;
+                // We found two closing curls, so output online one of them
+                _Handler._On_text(_Begin, _ClosingCurl);
+
+                // skip over the second closing curl
+                _Begin = _ClosingCurl + 1;
+            }
+
+            // We are done, there were no replacement fields.
+            if (_OpeningCurl == _End) {
+                return;
             }
         }
-        _HandlerT& _Handler;
-    } _Writer_loop{_Handler};
-    while (_Begin != _End) {
-        const _CharT* _Pt = _Begin;
-        if (*_Begin != '{') {
-            _Pt = _STD find(_Begin + 1, _End, '{');
-            if (_Pt == _End) {
-                return _Writer_loop(_Begin, _End);
-            }
-        }
-        _Writer_loop(_Begin, _Pt);
-        _Begin = _Parse_replacement_field(_Pt, _End, _Handler);
+        // Parse the replacement field starting at _OpeningCurl and ending sometime before _End.
+        _Begin = _Parse_replacement_field(_OpeningCurl, _End, _Handler);
     }
 }
 
 
 template <class _CharT>
 struct _Basic_format_specs {
-    unsigned int _Width, _Precision;
+    unsigned int _Width;
+    unsigned int _Precision;
     char _Type;
     _Align _Alignment;
     _Sign _Sgn;
     bool _Alt;
+    // At most one codepoint (so one char32_t or four utf-8 char8_t).
     _CharT _Fill[4];
 };
-
 
 // Model of _Parse_specs_callbacks that fills a _Basic_format_specs with the parsed data.
 template <class _CharT>
 class _Specs_setter {
 public:
-    explicit constexpr _Specs_setter(_Basic_format_specs<_CharT> _Specs) : _Specs(_Specs) {}
+    explicit constexpr _Specs_setter(_Basic_format_specs<_CharT> _Specs_) : _Specs(_Specs_) {}
 
     constexpr void _On_align(_Align _Aln) {
         _Specs._Alignment = _Aln;
@@ -592,9 +636,9 @@ public:
 
     constexpr void _On_fill(basic_string_view<_CharT> _Sv) {
         if (_Sv.size() > 4) {
-            throw format_error("Invalid fill.");
+            throw format_error("Invalid fill (too long).");
         }
-        _STD fill(_Specs._Fill, _Specs._Fill + 4, '\0');
+        _STD fill(_Specs._Fill, _Specs._Fill + 4, _CharT{});
         _STD copy(_Sv.begin(), _Sv.end(), _Specs._Fill);
     }
 
@@ -608,7 +652,7 @@ public:
 
     constexpr void _On_zero() {
         _Specs._Alignment = _Align::_None;
-        _Specs._Fill[0]   = '0';
+        _Specs._Fill[0]   = _CharT{'0'};
     }
 
     constexpr void _On_width(unsigned int _Width) {
@@ -627,18 +671,6 @@ protected:
     _Basic_format_specs<_CharT> _Specs;
 };
 
-// Actually fetch the value of an argument associated with a dynamic
-// width or precision specifier. This will be called with either
-// _Width_checker or _Precision_checker as "_Handler".
-template <class _Handler, class _FormatArg>
-constexpr unsigned int _Get_dynamic_specs(_FormatArg _Arg) {
-    unsigned long long _Val = visit_format_arg(_Handler(), _Arg);
-    if (_Val > (_STD numeric_limits<unsigned int>::max)()) {
-        throw format_error("Number is too big.");
-    }
-    return static_cast<unsigned int>(_Val);
-}
-
 template <class _Context>
 constexpr basic_format_arg<_Context> _Get_arg(_Context _Ctx, size_t _Arg_id) {
     // note: while this is parameterized on the _Arg_id type in libfmt we don't
@@ -652,7 +684,7 @@ constexpr basic_format_arg<_Context> _Get_arg(_Context _Ctx, size_t _Arg_id) {
 }
 
 // Checks that the type and value of an argument associated with a dynamic
-// width specifier is valid.
+// width specifier are valid.
 class _Width_checker {
 public:
     template <class _Ty>
@@ -664,13 +696,14 @@ public:
                 }
             }
             return static_cast<unsigned long long>(_Value);
+        } else {
+            throw format_error("Width is not an integer.");
         }
-        throw format_error("Width is not an integer.");
     }
 };
 
 // Checks that the type and value of an argument associated with a dynamic
-// precision specifier is valid.
+// precision specifier are valid.
 class _Precision_checker {
 public:
     template <class _Ty>
@@ -678,17 +711,18 @@ public:
         if constexpr (is_integral_v<_Ty>) {
             if constexpr (is_signed_v<_Ty>) {
                 if (_Value < 0) {
-                    throw format_error("Nagative precision.");
+                    throw format_error("Negative precision.");
                 }
             }
             return static_cast<unsigned long long>(_Value);
+        } else {
+            throw format_error("Precision is not an integer.");
         }
-        throw format_error("Precision is not an integer.");
     }
 };
 
 // Parses standard format specs into a _Basic_format_specs using _Specs_setter, and,
-// in addition handles dynamic width and precision. This is seperate from _Specs setter
+// in addition handles dynamic width and precision. This is separate from _Specs setter
 // because it needs to know about the current basic_format_parse_context and basic_format_context
 // in order to fetch the width from the arguments.
 template <class _ParseContext, class _Context>
@@ -696,8 +730,8 @@ class _Specs_handler : public _Specs_setter<typename _Context::char_type> {
 public:
     using _CharT = typename _Context::char_type;
 
-    constexpr _Specs_handler(_Basic_format_specs<_CharT>& _Specs, _ParseContext& _Parse_ctx, _Context& _Ctx)
-        : _Specs_setter<_CharT>(_Specs), _Parse_ctx(_Parse_ctx), _Ctx(_Ctx) {}
+    constexpr _Specs_handler(_Basic_format_specs<_CharT>& _Specs_, _ParseContext& _Parse_ctx_, _Context& _Ctx_)
+        : _Specs_setter<_CharT>(_Specs_), _Parse_ctx(_Parse_ctx_), _Ctx(_Ctx_) {}
 
     template <class _Id>
     constexpr void _On_dynamic_width(_Id _Arg_id) {
@@ -721,20 +755,34 @@ private:
         _Parse_ctx.check_arg_id(_Arg_id);
         return _STD _Get_arg(_Ctx, _Arg_id);
     }
+
+    // Fetch the value of an argument associated with a dynamic
+    // width or precision specifier. This will be called with either
+    // _Width_checker or _Precision_checker as "_Handler".
+    template <class _Handler, class _FormatArg>
+    static constexpr unsigned int _Get_dynamic_specs(_FormatArg _Arg) {
+        unsigned long long _Val = _STD visit_format_arg(_Handler(), _Arg);
+        if (_Val > (_STD numeric_limits<unsigned int>::max)()) {
+            throw format_error("Number is too big.");
+        }
+        return static_cast<unsigned int>(_Val);
+    }
 };
+
 class _Numeric_specs_checker {
+private:
     _Basic_format_arg_type _Arg_type = _Basic_format_arg_type::_None;
 
 public:
-    constexpr _Numeric_specs_checker(_Basic_format_arg_type _Arg_type) : _Arg_type(_Arg_type) {}
+    constexpr explicit _Numeric_specs_checker(_Basic_format_arg_type _Arg_type_) : _Arg_type(_Arg_type_) {}
 
-    constexpr void _Require_numeric_argument() {
+    constexpr void _Require_numeric_argument() const {
         if (!_Is_arithmetic_fmt_type(_Arg_type)) {
             throw format_error("Format specifier requires numeric argument.");
         }
     }
 
-    constexpr void _Check_sign() {
+    constexpr void _Check_sign() const {
         _Require_numeric_argument();
         if (_Is_integral_fmt_type(_Arg_type) && _Arg_type != _Basic_format_arg_type::_Int_type
             && _Arg_type != _Basic_format_arg_type::_Long_long_type
@@ -743,7 +791,7 @@ public:
         }
     }
 
-    constexpr void _Check_precision() {
+    constexpr void _Check_precision() const {
         if (_Is_integral_fmt_type(_Arg_type) || _Arg_type == _Basic_format_arg_type::_Pointer_type) {
             throw format_error("Precision not allowed for this argument type.");
         }
@@ -756,24 +804,31 @@ public:
 // handler method.
 template <class _Handler>
 class _Specs_checker : public _Handler {
+private:
     _Numeric_specs_checker _Numeric_checker;
 
 public:
-    constexpr _Specs_checker(const _Handler& _Handler_inst, _Basic_format_arg_type _Arg_type)
-        : _Handler(_Handler_inst), _Numeric_checker(_Arg_type) {}
+    constexpr explicit _Specs_checker(const _Handler& _Handler_inst, _Basic_format_arg_type _Arg_type_)
+        : _Handler(_Handler_inst), _Numeric_checker(_Arg_type_) {}
 
     // _On_align has no checking, since we don't implement numeric alignments.
+
     constexpr void _On_sign(_Sign _Sgn) {
         _Numeric_checker._Check_sign();
         _Handler::_On_sign(_Sgn);
     }
 
     constexpr void _On_hash() {
+        // Note that '#' is not valid for CharT or bool unless you
+        // pass a numeric presentation type, but we encounter '#' before
+        // the presentation type so we can not check that requirement here
         _Numeric_checker._Require_numeric_argument();
         _Handler::_On_hash();
     }
 
     constexpr void _On_zero() {
+        // Note 0 is again not valid for CharT or bool unless a numeric
+        // presentation type is uesd.
         _Numeric_checker._Require_numeric_argument();
         _Handler::_On_zero();
     }
@@ -783,43 +838,6 @@ public:
         _Handler::_On_precision(_Precision);
     }
 };
-
-template <class _Visitor, class _Context>
-auto visit_format_arg(_Visitor&& _Vis, basic_format_arg<_Context> _Arg) {
-    switch (_Arg._Active_state) {
-    case _Basic_format_arg_type::_None:
-        return _Vis(_Arg._No_state);
-    case _Basic_format_arg_type::_Int_type:
-        return _Vis(_Arg._Int_state);
-    case _Basic_format_arg_type::_UInt_type:
-        return _Vis(_Arg._UInt_state);
-    case _Basic_format_arg_type::_Long_long_type:
-        return _Vis(_Arg._Long_long_state);
-    case _Basic_format_arg_type::_ULong_long_type:
-        return _Vis(_Arg._ULong_long_state);
-    case _Basic_format_arg_type::_Bool_type:
-        return _Vis(_Arg._Bool_state);
-    case _Basic_format_arg_type::_Char_type:
-        return _Vis(_Arg._Char_state);
-    case _Basic_format_arg_type::_Float_type:
-        return _Vis(_Arg._Float_state);
-    case _Basic_format_arg_type::_Double_type:
-        return _Vis(_Arg._Double_state);
-    case _Basic_format_arg_type::_Long_double_type:
-        return _Vis(_Arg._Long_double_state);
-    case _Basic_format_arg_type::_Pointer_type:
-        return _Vis(_Arg._Pointer_state);
-    case _Basic_format_arg_type::_CString_type:
-        return _Vis(_Arg._CString_state);
-    case _Basic_format_arg_type::_String_type:
-        return _Vis(_Arg._String_state);
-    case _Basic_format_arg_type::_Custom_type:
-        return _Vis(_Arg._Custom_state);
-    default:
-        _STL_VERIFY(false, "basic_format_arg is in impossible state");
-        return _Vis(0);
-    }
-}
 
 template <class _Context, class _Ty>
 /* consteval */ constexpr auto _Get_format_arg_storage_type() noexcept {
@@ -1068,8 +1086,8 @@ public:
     using formatter_type = formatter<_Ty, _CharT>;
 
     constexpr basic_format_context(
-        _Out _OutputIt, basic_format_args<basic_format_context> _Ctx_args, const locale& _Loc)
-        : _OutputIt(_OutputIt), _Args(_Ctx_args), _Loc(_Loc) {}
+        _Out _OutputIt_, basic_format_args<basic_format_context> _Ctx_args, const locale& _Loc_)
+        : _OutputIt(_OutputIt_), _Args(_Ctx_args), _Loc(_Loc_) {}
 
     basic_format_arg<basic_format_context> arg(size_t _Id) const {
         return _Args.get(_Id);
@@ -1125,11 +1143,12 @@ private:
     _Context& _Ctx;
 
 public:
-    explicit constexpr _Custom_formatter_dispatcher(basic_format_parse_context<_Char_type>& _Parse_ctx, _Context& _Ctx)
-        : _Parse_ctx(_Parse_ctx), _Ctx(_Ctx) {}
+    explicit constexpr _Custom_formatter_dispatcher(
+        basic_format_parse_context<_Char_type>& _Parse_ctx_, _Context& _Ctx_)
+        : _Parse_ctx(_Parse_ctx_), _Ctx(_Ctx_) {}
 
-    void operator()(typename basic_format_arg<_Context>::handle h) const {
-        h.format(_Parse_ctx, _Ctx);
+    void operator()(typename basic_format_arg<_Context>::handle _Handle) const {
+        _Handle.format(_Parse_ctx, _Ctx);
     }
 
     template <class _Ty>
@@ -1174,7 +1193,7 @@ struct _Format_handler {
     void _On_text(const _CharT* _Begin, const _CharT* _End) {
         auto _Size = _End - _Begin;
         auto _Out  = _Ctx.out();
-        _STD copy_n(_Begin, _Size, _Out);
+        _Out       = _STD copy_n(_Begin, _Size, _Out);
         _Ctx.advance_to(_Out);
     }
 

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -123,6 +123,7 @@ public:
     }
     constexpr void advance_to(const const_iterator _It) {
         _Adl_verify_range(_It, _Format_string.end());
+        // _It must be after _Format_string.begin().
         const auto _Diff = static_cast<size_t>(_It._Unwrapped() - _Format_string._Unchecked_begin());
         _Format_string.remove_prefix(_Diff);
     }
@@ -579,9 +580,8 @@ constexpr void _Parse_format_string(basic_string_view<_CharT> _Format_str, _Hand
         if (*_Begin != '{') {
             // we didn't start at an opening curl, find the next one
             _OpeningCurl = _STD find(_Begin + 1, _End, '{');
-            _STL_INTERNAL_CHECK(_Begin != _OpeningCurl);
             for (;;) {
-                const _CharT* _ClosingCurl = _STD _Find_unchecked(_Begin, _End, '}');
+                const _CharT* _ClosingCurl = _Find_unchecked(_Begin, _OpeningCurl, '}');
 
                 // In this case we didn't find either a closing curl or opening curl.
                 // Write the whole thing out.
@@ -594,7 +594,7 @@ constexpr void _Parse_format_string(basic_string_view<_CharT> _Format_str, _Hand
                 if (_ClosingCurl == _OpeningCurl || *_ClosingCurl != '}') {
                     throw format_error("Unmatched '}' in format string.");
                 }
-                // We found two closing curls, so output online one of them
+                // We found two closing curls, so output only one of them
                 _Handler._On_text(_Begin, _ClosingCurl);
 
                 // skip over the second closing curl
@@ -762,7 +762,7 @@ private:
     template <class _Handler, class _FormatArg>
     static constexpr unsigned int _Get_dynamic_specs(_FormatArg _Arg) {
         unsigned long long _Val = _STD visit_format_arg(_Handler(), _Arg);
-        if (_Val > (_STD numeric_limits<unsigned int>::max)()) {
+        if (_Val > (numeric_limits<unsigned int>::max)()) {
             throw format_error("Number is too big.");
         }
         return static_cast<unsigned int>(_Val);

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -761,6 +761,32 @@ public:
     }
 };
 
+template <class _Visitor, class _Context>
+auto visit_format_arg(_Visitor&& _Vis, basic_format_arg<_Context> _Arg) {
+    return _STD visit(_STD forward<_Visitor>(_Vis), _Arg._Value);
+}
+
+// The top level set of parsing "actions".
+// This is like the _Parse_spec_callbacks concept but need not be a concept
+// because it's not really involved in any user customization.
+template <class _ArgFormatter, typename _CharT, typename _Context>
+struct _Format_handler {
+    basic_format_parse_context<_CharT> _Parse_context;
+    _Context _Ctx;
+
+    explicit _Format_hander(typename _ArgFormatter::iterator _Out, basic_string_view<_Char> _Str,
+        basic_format_args<_Context> _Format_args, locale& _Loc)
+        : _Parse_context(_Str), _Ctx(_Out, _Format_args, _Loc) {}
+
+    void _On_text(const _CharT* _Begin, const _CharT* _End) {
+        /* TODO: output the text */
+    }
+
+    void _On_replacement_field(int _Id, const _CharT*) {}
+
+    const _CharT* _On_format_specs(int _Id, const _CharT* _Begin, const _CharT* _End) {}
+};
+
 using format_context  = basic_format_context<back_insert_iterator<string>, string::value_type>;
 using wformat_context = basic_format_context<back_insert_iterator<wstring>, wstring::value_type>;
 using format_args     = basic_format_args<format_context>;

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -220,7 +220,6 @@ constexpr const _CharT* _Parse_precision(const _CharT* _Begin, const _CharT* _En
     if (_Begin != _End) {
         _Ch = *_Begin;
     }
-
     if ('0' <= _Ch && _Ch <= '9') {
         int _Precision = 0;
         _Begin         = _Parse_nonnegative_integer(_Begin, _End, _Precision);

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -31,14 +31,6 @@ _STL_DISABLE_CLANG_WARNINGS
 
 _STD_BEGIN
 
-template <class... _Tys>
-struct _Overloaded : _Tys... {
-    using _Tys::operator()...;
-};
-
-template <class... _Tys>
-_Overloaded(_Tys...) -> _Overloaded<_Tys...>;
-
 class format_error : public runtime_error {
     using runtime_error::runtime_error;
 };

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -882,6 +882,9 @@ public:
         size_t _Arg_index = 0;
         (_Store(_Arg_index++, _Vals), ...);
     }
+    constexpr _Type _Get_type() {
+        return _STD visit(_Format_arg_type_to_enum<_CharT>{}, _Value);
+    }
 };
 
 template <class _Context>
@@ -1080,6 +1083,9 @@ struct _Format_handler {
     const _CharT* _On_format_specs(int _Id, const _CharT* _Begin, const _CharT* _End) {
         _Parse_context.advance_to(_Begin);
         auto _Arg = _Ctx.arg(_Id);
+        basic_format_specs<_CharT> _Specs;
+        _Specs_checker<_Specs_handler<basic_format_parse_context<_CharT>, _Context>> _Handler(
+            _Specs_handler<basic_format_parse_context<_CharT>, _Context>(_Specs, _Parse_context, _Ctx), _Arg.type())
     }
 };
 

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -333,6 +333,137 @@ constexpr const _CharT* _Parse_format_specs(const _CharT* _Begin, const _CharT* 
     return _Begin;
 }
 
+// TODO: test coverage
+template <class _CharT>
+class basic_format_parse_context {
+public:
+    using char_type      = _CharT;
+    using const_iterator = typename basic_string_view<_CharT>::const_iterator;
+    using iterator       = const_iterator;
+
+private:
+    basic_string_view<_CharT> _Format_string;
+    size_t _Num_args;
+    // The standard says this is size_t, however we use ptrdiff_t to save some space
+    // by not having to store the indexing mode. Below is a more detailed explanation
+    // of how this works.
+    ptrdiff_t _Next_arg_id = 0;
+
+public:
+    constexpr explicit basic_format_parse_context(basic_string_view<_CharT> _Fmt, size_t _Num_args_ = 0) noexcept
+        : _Format_string(_Fmt), _Num_args(_Num_args_) {}
+    basic_format_parse_context(const basic_format_parse_context&) = delete;
+    basic_format_parse_context& operator=(const basic_format_parse_context&) = delete;
+
+    _NODISCARD constexpr const_iterator begin() const noexcept {
+        return _Format_string.begin();
+    }
+    _NODISCARD constexpr const_iterator end() const noexcept {
+        return _Format_string.end();
+    }
+    constexpr void advance_to(const_iterator _It) {
+        _Format_string.remove_prefix(_It - begin());
+    }
+
+    // While the standard presents an exposition only enum value for
+    // the indexing mode (manual, automatic, or unknown) we use _Next_arg_id to indicate it.
+    // _Next_arg_id == 0 means unknown
+    // _Next_arg_id > 0 means automatic
+    // _Next_arg_id == -1 means manual
+    constexpr size_t next_arg_id() {
+        if (_Next_arg_id >= 0) {
+            return _Next_arg_id++;
+        }
+        throw format_error("Can not switch from manual to automatic indexing");
+    }
+    constexpr void check_arg_id(size_t _Id) {
+        (void) _Id;
+        if (_Next_arg_id > 0) {
+            throw format_error("Can not switch from automatic to manual indexing");
+        }
+        _Next_arg_id = -1;
+    }
+};
+
+template <class _Context>
+class basic_format_arg {
+public:
+    class handle;
+
+private:
+    using _CharT = typename _Context::char_type;
+
+    using _Format_arg_value = variant<monostate, int, unsigned, long long, unsigned long long, bool,
+        typename _Context::char_type, float, double, long double, const void*, const typename _Context::char_type,
+        basic_string_view<typename _Context::char_type>, handle>;
+
+    _Format_arg_value _Value;
+
+    template <class _CharT>
+    struct _Format_arg_type_to_enum {
+        constexpr _Type operator()(_STD monostate) {
+            return _Type::_None;
+        }
+        constexpr _Type operator()(int32_t) {
+            return _Type::_Int32;
+        }
+        constexpr _Type operator()(int64_t) {
+            return _Type::_Int64;
+        }
+        constexpr _Type operator()(uint32_t) {
+            return _Type::_UInt32;
+        }
+        constexpr _Type operator()(uint64_t) {
+            return _Type::_UInt64;
+        }
+        constexpr _Type operator()(bool) {
+            return _Type::_Bool;
+        }
+        constexpr _Type operator()(_CharT) {
+            return _Type::_Char;
+        }
+        constexpr _Type operator()(float) {
+            return _Type::_Float32;
+        }
+        constexpr _Type operator()(double) {
+            return _Type::_Float64;
+        }
+        constexpr _Type operator()(const _CharT*) {
+            return _Type::_CString;
+        }
+        constexpr _Type operator()(const basic_string_view<_CharT>&) {
+            return _Type::_String;
+        }
+        constexpr _Type operator()(const void*) {
+            return _Type::_Pointer;
+        }
+        constexpr _Type operator()(const basic_format_arg::handle&) {
+            return _Type::_Custom;
+        }
+    };
+
+public:
+    class handle {
+    private:
+        const void* _Ptr;
+        void (*_Format)(basic_format_parse_context<_CharT>& _Parse_ctx, _Context _Format_ctx, const void*);
+        friend basic_format_arg;
+
+    public:
+        void format(basic_format_parse_context<_CharT>& _Parse_ctx, _Context& _Format_ctx) {
+            _Format(_Parse_ctx, _Format_ctx, _Ptr);
+        }
+    };
+
+    basic_format_arg() noexcept = default;
+    explicit operator bool() const noexcept {
+        return !_STD holds_alternative<monostate>(_Value);
+    }
+    constexpr _Type _Get_type() {
+        return _STD visit(_Format_arg_type_to_enum<_CharT>{}, _Value);
+    }
+};
+
 template <typename _CharT>
 struct _Basic_format_specs {
     int _Width, _Precision;
@@ -393,7 +524,7 @@ constexpr int _Get_dynamic_specs(_FormatArg _Arg) {
     if (_Val > static_cast<unsigned int>((_STD numeric_limits<int>::max)())) {
         throw format_error("Number is too big.");
     }
-    return static_cast<int>(value);
+    return static_cast<int>(_Val);
 }
 
 template <class _Context>
@@ -407,6 +538,38 @@ constexpr basic_format_arg<_Context> _Get_arg(_Context _Ctx, int _Arg_id) {
     }
     return _Arg;
 }
+
+class _Width_checker {
+public:
+    template <class _Ty>
+    constexpr unsigned long long operator()(_Ty _Value) {
+        if constexpr (is_integral_v<_Ty>) {
+            if constexpr (is_signed_v<_Ty>) {
+                if (_Value < 0) {
+                    throw format_error("Negative width.");
+                }
+            }
+            return static_cast<unsigned long long>(_Value);
+        }
+        throw format_error("Width is not an integer.");
+    }
+};
+
+class _Precision_checker {
+public:
+    template <class _Ty>
+    constexpr unsigned long long operator()(_Ty _Value) {
+        if constexpr (is_integral_v<_Ty>) {
+            if constexpr (is_signed_v<_Ty>) {
+                if (_Value < 0) {
+                    throw format_error("Nagative precision.");
+                }
+            }
+            return static_cast<unsigned long long>(_Value);
+        }
+        throw format_error("Precision is not an integer.");
+    }
+};
 
 template <class _ParseContext, class _Context>
 class _Specs_handler : public _Specs_setter<typename _Context::char_type> {
@@ -464,38 +627,6 @@ public:
         if (_Is_integral_fmt_type(_Arg_type) || _Arg_type == _Type::_Pointer) {
             throw format_error("Precision not allowed for this argument type.");
         }
-    }
-};
-
-class _Width_checker {
-public:
-    template <class _Ty>
-    constexpr unsigned long long operator()(_Ty _Value) {
-        if constexpr (is_integral_v<_Ty>) {
-            if constexpr (is_signed_v<_Ty>) {
-                if (_Value < 0) {
-                    throw format_error("Negative width.");
-                }
-            }
-            return static_cast<unsigned long long>(_Value);
-        }
-        throw format_error("Width is not an integer.");
-    }
-};
-
-class _Precision_checker {
-public:
-    template <class _Ty>
-    constexpr unsigned long long operator()(_Ty _Value) {
-        if constexpr (is_integral_v<_Ty>) {
-            if constexpr (is_signed_v<_Ty>) {
-                if (_Value < 0) {
-                    throw format_error("Nagative precision.");
-                }
-            }
-            return static_cast<unsigned long long)(_Value);
-        }
-        throw format_error("Precision is not an integer.");
     }
 };
 
@@ -1051,8 +1182,8 @@ struct _Default_arg_formatter {
 
     _OutputIt operator()(typename basic_format_arg<_Context>::handle _Handle) {
         basic_format_parse_context<_CharT> _Parse_ctx({});
-        basic_format_context<_OutputIt, _CHarT> _Format_ctx(_Out, _Args, _Loc);
-        _Handle.format(parse_ctx, format_ctx);
+        basic_format_context<_OutputIt, _CharT> _Format_ctx(_Out, _Args, _Loc);
+        _Handle.format(_Parse_ctx, _Format_ctx);
         return _Format_ctx.out();
     }
 };
@@ -1066,7 +1197,7 @@ struct _Format_handler {
     _Context _Ctx;
 
     explicit _Format_handler(
-        typename _OutputIt _Out, basic_string_view<_CharT> _Str, basic_format_args<_Context> _Format_args, locale& _Loc)
+        _OutputIt _Out, basic_string_view<_CharT> _Str, basic_format_args<_Context> _Format_args, locale& _Loc)
         : _Parse_context(_Str), _Ctx(_Out, _Format_args, _Loc) {}
 
     void _On_text(const _CharT* _Begin, const _CharT* _End) {
@@ -1091,9 +1222,9 @@ struct _Format_handler {
     }
 
     const _CharT* _On_format_specs(int _Id, const _CharT* _Begin, const _CharT* _End) {
-        _Parse_context.advance_to(_Parse_ctx.begin() + (_Begin - &*_Parse_ctx.begin()));
+        _Parse_context.advance_to(_Parse_context.begin() + (_Begin - &*_Parse_context.begin()));
         auto _Arg = _Ctx.arg(_Id);
-        basic_format_specs<_CharT> _Specs;
+        _Basic_format_specs<_CharT> _Specs;
         _Specs_checker<_Specs_handler<basic_format_parse_context<_CharT>, _Context>> _Handler(
             _Specs_handler<basic_format_parse_context<_CharT>, _Context>(_Specs, _Parse_context, _Ctx),
             _Arg._Get_type());
@@ -1101,7 +1232,7 @@ struct _Format_handler {
         if (_Begin == _End || *_Begin != '}') {
             throw format_error("Missing '}' in format string.");
         }
-        _Ctx.advance_to(visit_format_arg())
+        _STL_INTERNAL_CHECK(false);
     }
 };
 

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -468,7 +468,7 @@ constexpr void _Parse_format_string(basic_string_view<_CharT> _Format_str, _Hand
                 return _Writer_loop(_Begin, _End);
             }
         }
-        _Writer_loop(_Begin, _End);
+        _Writer_loop(_Begin, _Pt);
         _Begin = _Parse_replacement_field(_Pt, _End, _Handler);
     }
 }

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -302,6 +302,16 @@ constexpr const _CharT* _Parse_format_specs(const _CharT* _Begin, const _CharT* 
     return _Begin;
 }
 
+template <typename _Char>
+struct _Basic_format_specs {
+    int width, precision;
+    char type;
+    _Align _Alignment;
+    _Sign _Sgn;
+    bool _Alt;
+    _Char _Fill[4];
+}
+
 template <class _Ty, class _CharT = char>
 struct formatter;
 
@@ -765,6 +775,27 @@ template <class _Visitor, class _Context>
 auto visit_format_arg(_Visitor&& _Vis, basic_format_arg<_Context> _Arg) {
     return _STD visit(_STD forward<_Visitor>(_Vis), _Arg._Value);
 }
+
+// Dispatcher to call enabled custom formatters, and do nothing otherwise.
+template <class _Context>
+class _Custom_formatter_dispatcher {
+private:
+    using _Char_type = typename _Context::char_type;
+
+    basic_format_parse_context<_Char_type>& _Parse_ctx;
+    _Context& _Ctx;
+
+public:
+    explicit constexpr _Custom_formatter_dispatcher(basic_format_parse_context<_Char_type>& _Parse_ctx, _Context& _Ctx)
+        : _Parse_ctx(_Parse_ctx), _Ctx(_Ctx) {}
+
+    void operator()(typename basic_format_arg<_Context>::handle h) const {
+        h.format(_Parse_ctx, _Ctx);
+    }
+
+    template <class _Ty>
+    void operator()(_Ty) const {}
+};
 
 // The top level set of parsing "actions".
 // This is like the _Parse_spec_callbacks concept but need not be a concept

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -12,7 +12,6 @@
 #pragma message("The contents of <format> are available only with C++20 concepts support.")
 #else // ^^^ !defined(__cpp_lib_concepts) / defined(__cpp_lib_concepts) vvv
 
-#include <algorithm>
 #include <array>
 #include <charconv>
 #include <concepts>
@@ -22,6 +21,7 @@
 #include <string>
 #include <string_view>
 #include <variant>
+#include <xutility>
 
 #pragma pack(push, _CRT_PACKING)
 #pragma warning(push, _STL_WARNING_LEVEL)
@@ -60,7 +60,7 @@ enum class _Type {
 constexpr bool _Is_integral_fmt_type(_Type _Ty) {
     return _Ty > _Type::_None && _Ty <= _Type::_Last_integer_type;
 }
-constexpr bool _Is_numeric_fmt_type(_Type _Ty) {
+constexpr bool _Is_arithmetic_fmt_type(_Type _Ty) {
     return _Ty > _Type::_None && _Ty <= _Type::_Last_numeric_type;
 }
 struct _Auto_id_tag {};
@@ -280,16 +280,22 @@ struct _Precision_adapter {
     }
 };
 
+// _Parse_arg_id expects a handler when it finds an argument id, however
+// _Parse_replacement_field actually needs to know the value of that argument ID to pass on
+// to _Handler._On_replacement_field or _Handler._On_format_specs. This _Parse_arg_id wrapper
+// stores the value of the arg id for later use, so _Parse_replacement_field has access to it.
 template <class _CharT>
 struct _Id_adapter {
     basic_format_parse_context<_CharT>& _Parse_context;
-    size_t _Arg_id = 0;
+    size_t _Arg_id = static_cast<size_t>(-1);
     constexpr void _On_auto_id() {
         _Arg_id = _Parse_context.next_arg_id();
+        _STL_INTERNAL_CHECK(_Arg_id != static_cast<size_t>(-1));
     }
     constexpr void _On_manual_id(size_t _Id) {
         _Parse_context.check_arg_id(_Id);
         _Arg_id = _Id;
+        _STL_INTERNAL_CHECK(_Arg_id != static_cast<size_t>(-1));
     }
 };
 
@@ -446,7 +452,7 @@ constexpr void _Parse_format_string(basic_string_view<_CharT> _Format_str, _Hand
                 return;
             }
             for (;;) {
-                const _CharT* _Pt = _STD find(_Begin, _End, '}');
+                const _CharT* _Pt = _STD _Find_unchecked(_Begin, _End, '}');
                 if (_Pt == _End) {
                     return _Handler._On_text(_Begin, _End);
                 }
@@ -494,7 +500,7 @@ private:
 
     template <class _CharT>
     struct _Format_arg_type_to_enum {
-        constexpr _Type operator()(_STD monostate) {
+        constexpr _Type operator()(monostate) {
             return _Type::_None;
         }
         constexpr _Type operator()(int32_t) {
@@ -560,7 +566,7 @@ public:
     }
 };
 
-template <typename _CharT>
+template <class _CharT>
 struct _Basic_format_specs {
     unsigned int _Width, _Precision;
     char _Type;
@@ -571,7 +577,7 @@ struct _Basic_format_specs {
 };
 
 
-// _Parse_specs_callbacks that fill a _Basic_format_specs struct with the parsed data
+// Model of _Parse_specs_callbacks that fills a _Basic_format_specs with the parsed data.
 template <class _CharT>
 class _Specs_setter {
 public:
@@ -720,7 +726,7 @@ public:
     constexpr _Numeric_specs_checker(_Type _Arg_type) : _Arg_type(_Arg_type) {}
 
     constexpr void _Require_numeric_argument() {
-        if (!_Is_numeric_fmt_type(_Arg_type)) {
+        if (!_Is_arithmetic_fmt_type(_Arg_type)) {
             throw format_error("Format specifier requires numeric argument.");
         }
     }
@@ -1320,7 +1326,7 @@ struct _Default_arg_formatter {
 };
 
 // The top level set of parsing "actions".
-template <class _OutputIt, typename _CharT, typename _Context>
+template <class _OutputIt, class _CharT, class _Context>
 struct _Format_handler {
     basic_format_parse_context<_CharT> _Parse_context;
     _Context _Ctx;

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -1002,6 +1002,16 @@ _OutputIt _Write(_OutputIt _Out, monostate) {
     return _Out;
 }
 
+template <class _CharT, class _OutputIt>
+_OutputIt _Write(_OutputIt _Out, const _CharT* _Value) {
+    if (!_Value) {
+        throw format_error("String pointer is null.");
+    }
+    while (*_Value) {
+        *_Out++ = *_Value++;
+    }
+}
+
 // Dispatcher to call enabled custom formatters, and do nothing otherwise.
 template <class _Context>
 class _Custom_formatter_dispatcher {
@@ -1081,11 +1091,17 @@ struct _Format_handler {
     }
 
     const _CharT* _On_format_specs(int _Id, const _CharT* _Begin, const _CharT* _End) {
-        _Parse_context.advance_to(_Begin);
+        _Parse_context.advance_to(_Parse_ctx.begin() + (_Begin - &*_Parse_ctx.begin()));
         auto _Arg = _Ctx.arg(_Id);
         basic_format_specs<_CharT> _Specs;
         _Specs_checker<_Specs_handler<basic_format_parse_context<_CharT>, _Context>> _Handler(
-            _Specs_handler<basic_format_parse_context<_CharT>, _Context>(_Specs, _Parse_context, _Ctx), _Arg.type())
+            _Specs_handler<basic_format_parse_context<_CharT>, _Context>(_Specs, _Parse_context, _Ctx),
+            _Arg._Get_type());
+        _Begin = _Parse_format_specs(_Begin, _End, _Handler);
+        if (_Begin == _End || *_Begin != '}') {
+            throw format_error("Missing '}' in format string.");
+        }
+        _Ctx.advance_to(visit_format_arg())
     }
 };
 

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -120,21 +120,21 @@ template <class _Ty, class _CharT>
 concept _Parse_spec_callbacks = requires(_Ty _At, basic_string_view<_CharT> _Sv, _Align _Aln, _Sign _Sgn) {
     { _At._On_align(_Aln) } -> same_as<void>;
     { _At._On_fill(_Sv) } -> same_as<void>;
-    { _At._On_width(_STD declval<int>()) } -> same_as<void>;
-    { _At._On_dynamic_width(_STD declval<int>()) } -> same_as<void>;
-    { _At._On_dynamic_width(_STD declval<_Auto_id_tag>()) } -> same_as<void>;
-    { _At._On_precision(_STD declval<int>()) } -> same_as<void>;
-    { _At._On_dynamic_precision(_STD declval<int>()) } -> same_as<void>;
-    { _At._On_dynamic_precision(_STD declval<_Auto_id_tag>()) } -> same_as<void>;
+    { _At._On_width(int{}) } -> same_as<void>;
+    { _At._On_dynamic_width(int{}) } -> same_as<void>;
+    { _At._On_dynamic_width(_Auto_id_tag{}) } -> same_as<void>;
+    { _At._On_precision(int{}) } -> same_as<void>;
+    { _At._On_dynamic_precision(int{}) } -> same_as<void>;
+    { _At._On_dynamic_precision(_Auto_id_tag{}) } -> same_as<void>;
     { _At._On_sign(_Sgn) } -> same_as<void>;
     { _At._On_hash() } -> same_as<void>;
     { _At._On_zero() } -> same_as<void>;
-    { _At._On_type(_STD declval<_CharT>()) } -> same_as<void>;
+    { _At._On_type(_CharT{}) } -> same_as<void>;
 };
 template <class _Ty, class _CharT>
 concept _Parse_arg_id_callbacks = requires(_Ty _At) {
     { _At._On_auto_id() } -> same_as<void>;
-    { _At._On_manual_id(_STD declval<int>()) } -> same_as<void>;
+    { _At._On_manual_id(int{}) } -> same_as<void>;
 };
 
 template<class _Ty, class _CharT>
@@ -1310,6 +1310,7 @@ struct _Format_handler {
         if (_Begin == _End || *_Begin != '}') {
             throw format_error("Missing '}' in format string.");
         }
+        // TODO: implement format spec dispatching.
         _STL_INTERNAL_CHECK(false);
     }
 };

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -333,15 +333,16 @@ constexpr const _CharT* _Parse_format_specs(const _CharT* _Begin, const _CharT* 
     return _Begin;
 }
 
-template <typename _Char>
+template <typename _CharT>
 struct _Basic_format_specs {
     int _Width, _Precision;
     char _Type;
     _Align _Alignment;
     _Sign _Sgn;
     bool _Alt;
-    _Char _Fill[4];
+    _CharT _Fill[4];
 };
+
 
 // Extremely dull set of parsing callbacks that just fills a struct with parsed data.
 template <class _CharT>
@@ -386,6 +387,59 @@ protected:
 };
 
 
+template <class _Handler, class _FormatArg>
+constexpr int _Get_dynamic_specs(_FormatArg _Arg) {
+    unsigned long long _Val = visit_format_arg(_Handler(), _Arg);
+    if (_Val > static_cast<unsigned int>((_STD numeric_limits<int>::max)())) {
+        throw format_error("Number is too big.");
+    }
+    return static_cast<int>(value);
+}
+
+template <class _Context>
+constexpr basic_format_arg<_Context> _Get_arg(_Context _Ctx, int _Arg_id) {
+    // note: while this is parameterized on the _Arg_id type in libfmt we don't
+    // need to do that in std::format because it's only called with either an integer
+    // id or a named id (which we do not support in std::format)
+    auto _Arg = _Ctx.arg(_Arg_id);
+    if (!_Arg) {
+        throw format_error("Argument not found.");
+    }
+    return _Arg;
+}
+
+template <class _ParseContext, class _Context>
+class _Specs_handler : public _Specs_setter<typename _Context::char_type> {
+public:
+    using _CharT = typename _Context::char_type;
+
+    constexpr _Specs_handler(_Basic_format_specs<_CharT>& _Specs, _ParseContext& _Parse_ctx, _Context& _Ctx)
+        : _Specs_setter<_CharT>(_Specs), _Parse_ctx(_Parse_ctx), _Ctx(_Ctx) {}
+
+    template <class _Id>
+    constexpr void _On_dynamic_width(_Id _Arg_id) {
+        this->_Specs._Width = _Get_dynamic_specs<_Width_checker>(_Get_arg(_Arg_id));
+    }
+
+    template <class _Id>
+    constexpr void _On_dynamic_precision(_Id _Arg_id) {
+        this->_Specs._Precision = _Get_dynamic_specs<_Precision_checker>(_Get_arg(_Arg_id));
+    }
+
+private:
+    _ParseContext& _Parse_ctx;
+    _Context& _Ctx;
+
+    constexpr basic_format_arg<_Context> _Get_arg(_Auto_id_tag) {
+        return _STD _Get_arg(_Ctx, _Parse_ctx.next_arg_id());
+    }
+
+    constexpr basic_format_arg<_Context> _Get_arg(int _Arg_id) {
+        _Parse_ctx.check_arg_id(_Arg_id);
+        return _STD _Get_arg(_Ctx, _Arg_id);
+    }
+};
+
 class _Numeric_specs_checker {
     _Type _Arg_type = _Type::_None;
 
@@ -413,13 +467,66 @@ public:
     }
 };
 
-class _Specs_checker {
+class _Width_checker {
+public:
+    template <class _Ty>
+    constexpr unsigned long long operator()(_Ty _Value) {
+        if constexpr (is_integral_v<_Ty>) {
+            if constexpr (is_signed_v<_Ty>) {
+                if (_Value < 0) {
+                    throw format_error("Negative width.");
+                }
+            }
+            return static_cast<unsigned long long>(_Value);
+        }
+        throw format_error("Width is not an integer.");
+    }
+};
+
+class _Precision_checker {
+public:
+    template <class _Ty>
+    constexpr unsigned long long operator()(_Ty _Value) {
+        if constexpr (is_integral_v<_Ty>) {
+            if constexpr (is_signed_v<_Ty>) {
+                if (_Value < 0) {
+                    throw format_error("Nagative precision.");
+                }
+            }
+            return static_cast<unsigned long long)(_Value);
+        }
+        throw format_error("Precision is not an integer.");
+    }
+};
+
+template <class _Handler>
+class _Specs_checker : public _Handler {
     _Numeric_specs_checker _Numeric_checker;
 
 public:
-    constexpr _Specs_checker(_Type _Arg_type) : _Numeric_checker(_Arg_type) {}
+    constexpr _Specs_checker(const _Handler& _Handler_inst, _Type _Arg_type)
+        : _Handler(_Handler_inst), _Numeric_checker(_Arg_type) {}
 
-    constexpr void _On_align(_Align _Aln) {}
+    // _On_align has no checking, since we don't implement numeric alignments.
+    constexpr void _On_sign(_Sign _Sgn) {
+        _Numeric_checker._Check_sign();
+        _Handler::_On_sign(_Sgn);
+    }
+
+    constexpr void _On_hash() {
+        _Numeric_checker._Require_numeric_argument();
+        _Handler::_On_hash();
+    }
+
+    constexpr void _On_zero() {
+        _Numeric_checker._Require_numeric_argument();
+        _Handler::_On_zero();
+    }
+
+    constexpr void _On_precision(int _Precision) {
+        _Numeric_checker._Check_precision();
+        _Handler::_On_precision(_Precision);
+    }
 };
 
 template <class _Ty, class _CharT = char>
@@ -913,16 +1020,40 @@ public:
     void operator()(_Ty) const {}
 };
 
+// this is the visitor that's used for replacement fields,
+// it could be a generic lambda (with overloaded), but that's
+// bad for throughput
+template <class _OutputIt, class _CharT>
+struct _Default_arg_formatter {
+    using _Context = basic_format_context<_OutputIt, _CharT>;
+
+    _OutputIt _Out;
+    basic_format_args<_Context> _Args;
+    locale& _Loc;
+
+    template <class _Ty>
+    _OutputIt operator()(_Ty _Val) {
+        return _Write<_CharT>(_Out, _Val);
+    }
+
+    _OutputIt operator()(typename basic_format_arg<_Context>::handle _Handle) {
+        basic_format_parse_context<_CharT> _Parse_ctx({});
+        basic_format_context<_OutputIt, _CHarT> _Format_ctx(_Out, _Args, _Loc);
+        _Handle.format(parse_ctx, format_ctx);
+        return _Format_ctx.out();
+    }
+};
+
 // The top level set of parsing "actions".
 // This is like the _Parse_spec_callbacks concept but need not be a concept
 // because it's not really involved in any user customization.
-template <class _ArgFormatter, typename _CharT, typename _Context>
+template <class _OutputIt, typename _CharT, typename _Context>
 struct _Format_handler {
     basic_format_parse_context<_CharT> _Parse_context;
     _Context _Ctx;
 
-    explicit _Format_handler(typename _ArgFormatter::iterator _Out, basic_string_view<_CharT> _Str,
-        basic_format_args<_Context> _Format_args, locale& _Loc)
+    explicit _Format_handler(
+        typename _OutputIt _Out, basic_string_view<_CharT> _Str, basic_format_args<_Context> _Format_args, locale& _Loc)
         : _Parse_context(_Str), _Ctx(_Out, _Format_args, _Loc) {}
 
     void _On_text(const _CharT* _Begin, const _CharT* _End) {
@@ -942,11 +1073,8 @@ struct _Format_handler {
 
     void _On_replacement_field(int _Id, const _CharT*) {
         auto _Arg = _Ctx.arg(_Id);
-        _Ctx.advance_to(visit_format_arg(
-            _Overloaded {
-
-            }
-        )
+        _Ctx.advance_to(
+            visit_format_arg(_Default_arg_formatter<_OutputIt, _CharT>{_Ctx.out(), _Ctx.args(), _Ctx.locale()}, _Arg));
     }
 
     const _CharT* _On_format_specs(int _Id, const _CharT* _Begin, const _CharT* _End) {

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -220,6 +220,7 @@ constexpr const _CharT* _Parse_precision(const _CharT* _Begin, const _CharT* _En
     if (_Begin != _End) {
         _Ch = *_Begin;
     }
+
     if ('0' <= _Ch && _Ch <= '9') {
         int _Precision = 0;
         _Begin         = _Parse_nonnegative_integer(_Begin, _End, _Precision);

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -310,7 +310,7 @@ struct _Basic_format_specs {
     _Sign _Sgn;
     bool _Alt;
     _Char _Fill[4];
-}
+};
 
 template <class _Ty, class _CharT = char>
 struct formatter;

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -30,6 +30,14 @@ _STL_DISABLE_CLANG_WARNINGS
 
 _STD_BEGIN
 
+template <class... _Tys>
+struct _Overloaded : _Tys... {
+    using _Tys::operator()...;
+};
+
+template <class... _Tys>
+_Overloaded(_Tys...) -> _Overloaded<_Tys...>;
+
 class format_error : public runtime_error {
     using runtime_error::runtime_error;
 };
@@ -38,6 +46,29 @@ enum class _Align { _None, _Left, _Right, _Center };
 
 enum class _Sign { _None, _Plus, _Minus, _Space };
 
+enum class _Type {
+    _None,
+    _Int32,
+    _Int64,
+    _UInt32,
+    _UInt64,
+    _Bool,
+    _Char,
+    _Last_integer_type = _Char,
+    _Float32,
+    _Float64,
+    _Last_numeric_type = _Float64,
+    _CString,
+    _String,
+    _Pointer,
+    _Custom
+};
+constexpr bool _Is_integral_fmt_type(_Type _Ty) {
+    return _Ty > _Type::_None && _Ty <= _Type::_Last_integer_type;
+}
+constexpr bool _Is_numeric_fmt_type(_Type _Ty) {
+    return _Ty > _Type::_None && _Ty <= _Type::_Last_numeric_type;
+}
 struct _Auto_id_tag {};
 
 // clang-format off
@@ -304,12 +335,91 @@ constexpr const _CharT* _Parse_format_specs(const _CharT* _Begin, const _CharT* 
 
 template <typename _Char>
 struct _Basic_format_specs {
-    int width, precision;
-    char type;
+    int _Width, _Precision;
+    char _Type;
     _Align _Alignment;
     _Sign _Sgn;
     bool _Alt;
     _Char _Fill[4];
+};
+
+// Extremely dull set of parsing callbacks that just fills a struct with parsed data.
+template <class _CharT>
+class _Specs_setter {
+    explicit constexpr _Specs_setter(_Basic_format_specs<_CharT> _Specs) : _Specs(_Specs) {}
+
+    constexpr void _On_align(_Align _Aln) {
+        _Specs._Alignment = _Aln;
+    }
+
+    constexpr void _On_fill(basic_string_view<_CharT> _Sv) {
+        _Specs._Fill = _Sv;
+    }
+
+    constexpr void _On_sign(_Sign _Sgn) {
+        _Specs._Sgn = _Sgn;
+    }
+
+    constexpr void _On_hash() {
+        _Specs._Alt = true;
+    }
+
+    constexpr void _On_zero() {
+        _Specs._Alignment = _Align::_None;
+        _Specs._Fill[0]   = '0';
+    }
+
+    constexpr void _On_width(int _Width) {
+        _Specs._Width = _Width;
+    }
+
+    constexpr void _On_Precision(int _Precision) {
+        _Specs._Precision = _Precision;
+    }
+
+    constexpr void _On_type(_CharT _Type) {
+        _Specs._Type = static_cast<_CharT>(_Type);
+    }
+
+protected:
+    _Basic_format_specs<_CharT> _Specs;
+};
+
+
+class _Numeric_specs_checker {
+    _Type _Arg_type = _Type::_None;
+
+public:
+    constexpr _Numeric_specs_checker(_Type _Arg_type) : _Arg_type(_Arg_type) {}
+
+    constexpr void _Require_numeric_argument() {
+        if (!_Is_numeric_fmt_type(_Arg_type)) {
+            throw format_error("Format specifier requires numeric argument.");
+        }
+    }
+
+    constexpr void _Check_sign() {
+        _Require_numeric_argument();
+        if (_Is_integral_fmt_type(_Arg_type) && _Arg_type != _Type::_Int32 && _Arg_type != _Type::_Int64
+            && _Arg_type != _Type::_Char) {
+            throw format_error("Format specifier requires signed argument.");
+        }
+    }
+
+    constexpr void _Check_precision() {
+        if (_Is_integral_fmt_type(_Arg_type) || _Arg_type == _Type::_Pointer) {
+            throw format_error("Precision not allowed for this argument type.");
+        }
+    }
+};
+
+class _Specs_checker {
+    _Numeric_specs_checker _Numeric_checker;
+
+public:
+    constexpr _Specs_checker(_Type _Arg_type) : _Numeric_checker(_Arg_type) {}
+
+    constexpr void _On_align(_Align _Aln) {}
 };
 
 template <class _Ty, class _CharT = char>
@@ -776,6 +886,12 @@ auto visit_format_arg(_Visitor&& _Vis, basic_format_arg<_Context> _Arg) {
     return _STD visit(_STD forward<_Visitor>(_Vis), _Arg._Value);
 }
 
+template <class _CharT, class _OutputIt>
+_OutputIt _Write(_OutputIt _Out, monostate) {
+    _STL_INTERNAL_CHECK(false);
+    return _Out;
+}
+
 // Dispatcher to call enabled custom formatters, and do nothing otherwise.
 template <class _Context>
 class _Custom_formatter_dispatcher {
@@ -826,6 +942,11 @@ struct _Format_handler {
 
     void _On_replacement_field(int _Id, const _CharT*) {
         auto _Arg = _Ctx.arg(_Id);
+        _Ctx.advance_to(visit_format_arg(
+            _Overloaded {
+
+            }
+        )
     }
 
     const _CharT* _On_format_specs(int _Id, const _CharT* _Begin, const _CharT* _End) {

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -774,17 +774,33 @@ struct _Format_handler {
     basic_format_parse_context<_CharT> _Parse_context;
     _Context _Ctx;
 
-    explicit _Format_hander(typename _ArgFormatter::iterator _Out, basic_string_view<_Char> _Str,
+    explicit _Format_handler(typename _ArgFormatter::iterator _Out, basic_string_view<_CharT> _Str,
         basic_format_args<_Context> _Format_args, locale& _Loc)
         : _Parse_context(_Str), _Ctx(_Out, _Format_args, _Loc) {}
 
     void _On_text(const _CharT* _Begin, const _CharT* _End) {
-        /* TODO: output the text */
+        auto _Size = _End - _Begin;
+        auto _Out  = _Ctx.out();
+        _STD copy_n(_Begin, _Size, _Out);
+        _Ctx.advance_to(_Out);
     }
 
-    void _On_replacement_field(int _Id, const _CharT*) {}
+    int _On_arg_id() {
+        return _Parse_context.next_arg_id();
+    }
 
-    const _CharT* _On_format_specs(int _Id, const _CharT* _Begin, const _CharT* _End) {}
+    int _On_arg_id(int _Id) {
+        return _Parse_context.check_arg_id(_Id);
+    }
+
+    void _On_replacement_field(int _Id, const _CharT*) {
+        auto _Arg = _Ctx.arg(_Id);
+    }
+
+    const _CharT* _On_format_specs(int _Id, const _CharT* _Begin, const _CharT* _End) {
+        _Parse_context.advance_to(_Begin);
+        auto _Arg = _Ctx.arg(_Id);
+    }
 };
 
 using format_context  = basic_format_context<back_insert_iterator<string>, string::value_type>;

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -12,6 +12,7 @@
 #pragma message("The contents of <format> are available only with C++20 concepts support.")
 #else // ^^^ !defined(__cpp_lib_concepts) / defined(__cpp_lib_concepts) vvv
 
+#include <array>
 #include <charconv>
 #include <concepts>
 #include <exception>
@@ -71,6 +72,57 @@ constexpr bool _Is_numeric_fmt_type(_Type _Ty) {
 }
 struct _Auto_id_tag {};
 
+template <class _CharT>
+class basic_format_parse_context {
+public:
+    using char_type      = _CharT;
+    using const_iterator = typename basic_string_view<_CharT>::const_iterator;
+    using iterator       = const_iterator;
+
+private:
+    basic_string_view<_CharT> _Format_string;
+    size_t _Num_args;
+    // The standard says this is size_t, however we use ptrdiff_t to save some space
+    // by not having to store the indexing mode. Below is a more detailed explanation
+    // of how this works.
+    ptrdiff_t _Next_arg_id = 0;
+
+public:
+    constexpr explicit basic_format_parse_context(basic_string_view<_CharT> _Fmt, size_t _Num_args_ = 0) noexcept
+        : _Format_string(_Fmt), _Num_args(_Num_args_) {}
+    basic_format_parse_context(const basic_format_parse_context&) = delete;
+    basic_format_parse_context& operator=(const basic_format_parse_context&) = delete;
+
+    _NODISCARD constexpr const_iterator begin() const noexcept {
+        return _Format_string.begin();
+    }
+    _NODISCARD constexpr const_iterator end() const noexcept {
+        return _Format_string.end();
+    }
+    constexpr void advance_to(const_iterator _It) {
+        _Format_string.remove_prefix(_It - begin());
+    }
+
+    // While the standard presents an exposition only enum value for
+    // the indexing mode (manual, automatic, or unknown) we use _Next_arg_id to indicate it.
+    // _Next_arg_id == 0 means unknown
+    // _Next_arg_id > 0 means automatic
+    // _Next_arg_id == -1 means manual
+    constexpr size_t next_arg_id() {
+        if (_Next_arg_id >= 0) {
+            return _Next_arg_id++;
+        }
+        throw format_error("Can not switch from manual to automatic indexing");
+    }
+    constexpr void check_arg_id(size_t _Id) {
+        (void) _Id;
+        if (_Next_arg_id > 0) {
+            throw format_error("Can not switch from automatic to manual indexing");
+        }
+        _Next_arg_id = -1;
+    }
+};
+
 // clang-format off
 template <class _Ty, class _CharT>
 concept _Parse_spec_callbacks = requires(_Ty _At, basic_string_view<_CharT> _Sv, _Align _Aln, _Sign _Sgn) {
@@ -92,6 +144,15 @@ concept _Parse_arg_id_callbacks = requires(_Ty _At) {
     { _At._On_auto_id() } -> same_as<void>;
     { _At._On_manual_id(_STD declval<int>()) } -> same_as<void>;
 };
+
+template<class _Ty, class _CharT>
+concept _Parse_replacement_field_callbacks = requires(_Ty _At, const _CharT* _Begin, const _CharT* _End) {
+    { _At._Parse_context } -> _STD convertible_to<basic_format_parse_context<_CharT>&>;
+    { _At._On_text(_Begin, _End) } -> same_as<void>;
+    { _At._On_replacement_field(int{}, _STD declval<const _CharT*>()) } -> same_as<void>;
+    { _At._On_format_specs(int{}, _Begin, _End) } -> same_as<const _CharT*>;
+};
+
 // clang-format on
 
 // we need to implement this ourselves because from_chars does not work with wide characters
@@ -224,6 +285,19 @@ struct _Precision_adapter {
     }
 };
 
+template <class _CharT>
+struct _Id_adapter {
+    basic_format_parse_context<_CharT>& _Parse_context;
+    int _Arg_id = 0;
+    constexpr void _On_auto_id() {
+        _Arg_id = _Parse_context.next_arg_id();
+    }
+    constexpr void _On_manual_id(int _Id) {
+        _Parse_context.check_arg_id(_Id);
+        _Arg_id = _Id;
+    }
+};
+
 template <class _CharT, _Parse_spec_callbacks<_CharT> _Callbacks_type>
 constexpr const _CharT* _Parse_width(const _CharT* _Begin, const _CharT* _End, _Callbacks_type&& _Callbacks) {
     _STL_INTERNAL_CHECK(_Begin != _End);
@@ -333,57 +407,79 @@ constexpr const _CharT* _Parse_format_specs(const _CharT* _Begin, const _CharT* 
     return _Begin;
 }
 
+template <class _CharT, _Parse_replacement_field_callbacks<_CharT> _HandlerT>
+constexpr const _CharT* _Parse_replacement_field(const _CharT* _Begin, const _CharT* _End, _HandlerT&& _Handler) {
+    ++_Begin;
+    if (_Begin == _End) {
+        throw format_error("Invalid format string.");
+    }
+
+    if (*_Begin == '}') {
+        // string was "{}", and we have a replacement field
+        _Handler._On_replacement_field(_Handler._On_auto_id());
+    } else if (*_Begin == '{') {
+        // string was "{{", so we have a literal "{" to print
+        _Handler._On_text(_Begin, _Begin + 1);
+    } else {
+        _Id_adapter<_CharT> _Adapter{_Handler._Parse_context};
+        _Begin     = _Parse_arg_id(_Begin, _End, _Adapter);
+        _CharT _Ch = _CharT{};
+        if (_Begin != _End) {
+            _Ch = *_Begin;
+        }
+        if (_Ch == '}') {
+            _Handler._On_replacement_field(_Adapter._Arg_id, _Begin);
+        } else if (_Ch == ':') {
+            _Begin = _Handler._On_format_specs(_Adapter._Arg_id, _Begin + 1, _End);
+            if (_Begin == _End || *_Begin != '}') {
+                throw format_error("Unknown format specifier.");
+            }
+        } else {
+            throw format_error("Missing '}' in format string.");
+        }
+    }
+    return _Begin + 1;
+}
+
+template <class _CharT, _Parse_replacement_field_callbacks<_CharT> _HandlerT>
+constexpr void _Parse_format_string(basic_string_view<_CharT> _Format_str, _HandlerT&& _Handler) {
+    auto _Begin = _Format_str.data();
+    auto _End   = _Begin + _Format_str.size();
+    struct _Writer {
+        constexpr void operator()(const _CharT* _Begin, const _CharT* _End) {
+            if (_Begin == _End) {
+                return;
+            }
+            for (;;) {
+                const _CharT* _Pt = _STD find(_Begin, _End, '}');
+                if (_Pt == _End) {
+                    return _Handler._On_text(_Begin, _End);
+                }
+                ++_Pt;
+                if (_Pt == _End || *_Pt != '}') {
+                    throw format_error("Unmatched '}' in format string.");
+                }
+                _Handler._On_text(_Begin, _Pt);
+                _Begin = _Pt + 1;
+            }
+        }
+        _HandlerT& _Handler;
+    } _Writer_loop{_Handler};
+    while (_Begin != _End) {
+        const _CharT* _Pt = _Begin;
+        if (*_Begin != '{') {
+            _Pt = _STD find(_Begin + 1, _End, '{', _Pt);
+            if (_Pt == _End) {
+                return _Writer_loop(_Begin, _End);
+            }
+        }
+        _Writer_loop(_Begin, _End);
+        _Begin = _Parse_replacement_field(_Pt, _End, _Handler);
+    }
+}
+
 // TODO: test coverage
-template <class _CharT>
-class basic_format_parse_context {
-public:
-    using char_type      = _CharT;
-    using const_iterator = typename basic_string_view<_CharT>::const_iterator;
-    using iterator       = const_iterator;
 
-private:
-    basic_string_view<_CharT> _Format_string;
-    size_t _Num_args;
-    // The standard says this is size_t, however we use ptrdiff_t to save some space
-    // by not having to store the indexing mode. Below is a more detailed explanation
-    // of how this works.
-    ptrdiff_t _Next_arg_id = 0;
-
-public:
-    constexpr explicit basic_format_parse_context(basic_string_view<_CharT> _Fmt, size_t _Num_args_ = 0) noexcept
-        : _Format_string(_Fmt), _Num_args(_Num_args_) {}
-    basic_format_parse_context(const basic_format_parse_context&) = delete;
-    basic_format_parse_context& operator=(const basic_format_parse_context&) = delete;
-
-    _NODISCARD constexpr const_iterator begin() const noexcept {
-        return _Format_string.begin();
-    }
-    _NODISCARD constexpr const_iterator end() const noexcept {
-        return _Format_string.end();
-    }
-    constexpr void advance_to(const_iterator _It) {
-        _Format_string.remove_prefix(_It - begin());
-    }
-
-    // While the standard presents an exposition only enum value for
-    // the indexing mode (manual, automatic, or unknown) we use _Next_arg_id to indicate it.
-    // _Next_arg_id == 0 means unknown
-    // _Next_arg_id > 0 means automatic
-    // _Next_arg_id == -1 means manual
-    constexpr size_t next_arg_id() {
-        if (_Next_arg_id >= 0) {
-            return _Next_arg_id++;
-        }
-        throw format_error("Can not switch from manual to automatic indexing");
-    }
-    constexpr void check_arg_id(size_t _Id) {
-        (void) _Id;
-        if (_Next_arg_id > 0) {
-            throw format_error("Can not switch from automatic to manual indexing");
-        }
-        _Next_arg_id = -1;
-    }
-};
 
 template <class _Context>
 class basic_format_arg {
@@ -1189,8 +1285,6 @@ struct _Default_arg_formatter {
 };
 
 // The top level set of parsing "actions".
-// This is like the _Parse_spec_callbacks concept but need not be a concept
-// because it's not really involved in any user customization.
 template <class _OutputIt, typename _CharT, typename _Context>
 struct _Format_handler {
     basic_format_parse_context<_CharT> _Parse_context;
@@ -1205,14 +1299,6 @@ struct _Format_handler {
         auto _Out  = _Ctx.out();
         _STD copy_n(_Begin, _Size, _Out);
         _Ctx.advance_to(_Out);
-    }
-
-    int _On_arg_id() {
-        return _Parse_context.next_arg_id();
-    }
-
-    int _On_arg_id(int _Id) {
-        return _Parse_context.check_arg_id(_Id);
     }
 
     void _On_replacement_field(int _Id, const _CharT*) {
@@ -1249,6 +1335,16 @@ auto make_format_args(const _Args&... _Vals) {
 template <class _Context = wformat_context, class... _Args>
 auto make_wformat_args(const _Args&... _Vals) {
     return _Format_arg_store<_Context, _Args...>{_Vals...};
+}
+
+template <class _Out, class _CharT>
+using format_args_t = basic_format_args<basic_format_context<_Out, _CharT>>;
+
+template <class _Out>
+_Out vformat_to(
+    _Out _OutputIt, const locale& _Loc, string_view _Fmt, format_args_t<type_identity_t<_Out>, char> _Args) {
+    _Format_handler<_Out, char, basic_format_context<_Out, char>> _Handler(_OutputIt, _Fmt, _Args, _Loc);
+    _Parse_format_string(_Fmt, _Handler);
 }
 
 // FUNCTION vformat

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -65,6 +65,7 @@ constexpr bool _Is_numeric_fmt_type(_Type _Ty) {
 }
 struct _Auto_id_tag {};
 
+// TODO: test coverage
 template <class _CharT>
 class basic_format_parse_context {
 public:
@@ -472,9 +473,8 @@ constexpr void _Parse_format_string(basic_string_view<_CharT> _Format_str, _Hand
     }
 }
 
+
 // TODO: test coverage
-
-
 template <class _Context>
 class basic_format_arg {
 public:
@@ -739,6 +739,7 @@ public:
         }
     }
 };
+
 // Uses _Numeric_specs_checker to check that the type of the argument printed by
 // a replacement field with format specs actually satisfies the requirements for
 // that format spec. If the requirements are met then calls the base class

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -40,84 +40,31 @@ enum class _Align { _None, _Left, _Right, _Center };
 
 enum class _Sign { _None, _Plus, _Minus, _Space };
 
-enum class _Type {
+enum class _Basic_format_arg_type : uint8_t {
     _None,
-    _Int32,
-    _Int64,
-    _UInt32,
-    _UInt64,
-    _Bool,
-    _Char,
-    _Last_integer_type = _Char,
-    _Float32,
-    _Float64,
-    _Last_numeric_type = _Float64,
-    _CString,
-    _String,
-    _Pointer,
-    _Custom
+    _Int_type,
+    _UInt_type,
+    _Long_long_type,
+    _ULong_long_type,
+    _Bool_type,
+    _Char_type,
+    _Float_type,
+    _Double_type,
+    _Long_double_type,
+    _Pointer_type,
+    _CString_type,
+    _String_type,
+    _Custom_type,
 };
-constexpr bool _Is_integral_fmt_type(_Type _Ty) {
-    return _Ty > _Type::_None && _Ty <= _Type::_Last_integer_type;
+static_assert(static_cast<int>(_Basic_format_arg_type::_Custom_type) <= 16);
+
+constexpr bool _Is_integral_fmt_type(_Basic_format_arg_type _Ty) {
+    return _Ty > _Basic_format_arg_type::_None && _Ty <= _Basic_format_arg_type::_ULong_long_type;
 }
-constexpr bool _Is_arithmetic_fmt_type(_Type _Ty) {
-    return _Ty > _Type::_None && _Ty <= _Type::_Last_numeric_type;
+constexpr bool _Is_arithmetic_fmt_type(_Basic_format_arg_type _Ty) {
+    return _Ty > _Basic_format_arg_type::_None && _Ty <= _Basic_format_arg_type::_Long_double_type;
 }
 struct _Auto_id_tag {};
-
-// TODO: test coverage
-template <class _CharT>
-class basic_format_parse_context {
-public:
-    using char_type      = _CharT;
-    using const_iterator = typename basic_string_view<_CharT>::const_iterator;
-    using iterator       = const_iterator;
-
-private:
-    basic_string_view<_CharT> _Format_string;
-    size_t _Num_args;
-    // The standard says this is size_t, however we use ptrdiff_t to save some space
-    // by not having to store the indexing mode. Below is a more detailed explanation
-    // of how this works.
-    ptrdiff_t _Next_arg_id = 0;
-
-public:
-    constexpr explicit basic_format_parse_context(basic_string_view<_CharT> _Fmt, size_t _Num_args_ = 0) noexcept
-        : _Format_string(_Fmt), _Num_args(_Num_args_) {}
-    basic_format_parse_context(const basic_format_parse_context&) = delete;
-    basic_format_parse_context& operator=(const basic_format_parse_context&) = delete;
-
-    _NODISCARD constexpr const_iterator begin() const noexcept {
-        return _Format_string.begin();
-    }
-    _NODISCARD constexpr const_iterator end() const noexcept {
-        return _Format_string.end();
-    }
-    constexpr void advance_to(const_iterator _It) {
-        _STL_INTERNAL_CHECK(_It - begin() >= 0);
-        using _Size_type = typename basic_string_view<_CharT>::size_type;
-        _Format_string.remove_prefix(static_cast<_Size_type>(_It - begin()));
-    }
-
-    // While the standard presents an exposition only enum value for
-    // the indexing mode (manual, automatic, or unknown) we use _Next_arg_id to indicate it.
-    // _Next_arg_id == 0 means unknown
-    // _Next_arg_id > 0 means automatic
-    // _Next_arg_id == -1 means manual
-    constexpr size_t next_arg_id() {
-        if (_Next_arg_id >= 0) {
-            return static_cast<size_t>(_Next_arg_id++);
-        }
-        throw format_error("Can not switch from manual to automatic indexing");
-    }
-    constexpr void check_arg_id(size_t _Id) {
-        (void) _Id;
-        if (_Next_arg_id > 0) {
-            throw format_error("Can not switch from automatic to manual indexing");
-        }
-        _Next_arg_id = -1;
-    }
-};
 
 // clang-format off
 template <class _Ty, class _CharT>
@@ -150,6 +97,148 @@ concept _Parse_replacement_field_callbacks = requires(_Ty _At, const _CharT* _Be
 };
 
 // clang-format on
+
+template <class _Ty, class _CharT = char>
+struct formatter;
+
+inline void _You_see_this_error_because_arg_id_is_out_of_range() noexcept {}
+
+template <class _CharT>
+class basic_format_parse_context {
+public:
+    using char_type      = _CharT;
+    using const_iterator = typename basic_string_view<_CharT>::const_iterator;
+    using iterator       = const_iterator;
+
+    constexpr explicit basic_format_parse_context(basic_string_view<_CharT> _Fmt, size_t _Num_args_ = 0) noexcept
+        : _Format_string(_Fmt), _Num_args(_Num_args_) {}
+    basic_format_parse_context(const basic_format_parse_context&) = delete;
+    basic_format_parse_context& operator=(const basic_format_parse_context&) = delete;
+
+    _NODISCARD constexpr const_iterator begin() const noexcept {
+        return _Format_string.begin();
+    }
+    _NODISCARD constexpr const_iterator end() const noexcept {
+        return _Format_string.end();
+    }
+    constexpr void advance_to(const const_iterator _It) {
+        _Adl_verify_range(_It, _Format_string.end());
+        const auto _Diff = static_cast<size_t>(_It._Unwrapped() - _Format_string._Unchecked_begin());
+        _Format_string.remove_prefix(_Diff);
+    }
+
+    // While the standard presents an exposition only enum value for
+    // the indexing mode (manual, automatic, or unknown) we use _Next_arg_id to indicate it.
+    // _Next_arg_id > 0 means automatic
+    // _Next_arg_id == 0 means unknown
+    // _Next_arg_id < 0 means manual
+    constexpr size_t next_arg_id() {
+        if (_Next_arg_id < 0) {
+            throw format_error("Can not switch from manual to automatic indexing");
+        }
+
+        return static_cast<size_t>(_Next_arg_id++);
+    }
+
+    constexpr void check_arg_id(const size_t _Id) {
+        if (_STD is_constant_evaluated()) {
+            if (_Id >= _Num_args) {
+                _You_see_this_error_because_arg_id_is_out_of_range();
+            }
+        }
+
+        if (_Next_arg_id > 0) {
+            throw format_error("Can not switch from automatic to manual indexing");
+        }
+        _Next_arg_id = -1;
+    }
+
+private:
+    basic_string_view<_CharT> _Format_string;
+    size_t _Num_args;
+    // The standard says this is size_t, however we use ptrdiff_t to save some space
+    // by not having to store the indexing mode. Above is a more detailed explanation
+    // of how this works.
+    ptrdiff_t _Next_arg_id = 0;
+};
+
+template <class _Context>
+class basic_format_arg {
+public:
+    using _CharType = typename _Context::char_type;
+
+    class handle {
+    private:
+        const void* _Ptr;
+        void (*_Format)(basic_format_parse_context<_CharType>& _Parse_ctx, _Context _Format_ctx, const void*);
+        friend basic_format_arg;
+
+    public:
+        template <class _Ty>
+        explicit handle(const _Ty& _Val) noexcept
+            : _Ptr(_STD addressof(_Val)),
+              _Format([](basic_format_parse_context<_CharType>& _Parse_ctx, _Context& _Format_ctx, const void* _Ptr) {
+                  typename _Context::template formatter_type<_Ty> _Formatter;
+                  _Parse_ctx.advance_to(_Formatter.parse(_Parse_ctx));
+                  _Format_ctx.advance_to(_Formatter.format(*static_cast<const _Ty*>(_Ptr), _Format_ctx));
+              }) {}
+
+        void format(basic_format_parse_context<_CharType>& _Parse_ctx, _Context& _Format_ctx) {
+            _Format(_Parse_ctx, _Format_ctx, _Ptr);
+        }
+    };
+
+    // TRANSITION, LLVM-49072
+    basic_format_arg() noexcept : _Active_state(_Basic_format_arg_type::_None), _No_state() {}
+
+    explicit basic_format_arg(const int _Val) noexcept
+        : _Active_state(_Basic_format_arg_type::_Int_type), _Int_state(_Val) {}
+    explicit basic_format_arg(const unsigned int _Val) noexcept
+        : _Active_state(_Basic_format_arg_type::_UInt_type), _UInt_state(_Val) {}
+    explicit basic_format_arg(const long long _Val) noexcept
+        : _Active_state(_Basic_format_arg_type::_Long_long_type), _Long_long_state(_Val) {}
+    explicit basic_format_arg(const unsigned long long _Val) noexcept
+        : _Active_state(_Basic_format_arg_type::_ULong_long_type), _ULong_long_state(_Val) {}
+    explicit basic_format_arg(const bool _Val) noexcept
+        : _Active_state(_Basic_format_arg_type::_Bool_type), _Bool_state(_Val) {}
+    explicit basic_format_arg(const _CharType _Val) noexcept
+        : _Active_state(_Basic_format_arg_type::_Char_type), _Char_state(_Val) {}
+    explicit basic_format_arg(const float _Val) noexcept
+        : _Active_state(_Basic_format_arg_type::_Float_type), _Float_state(_Val) {}
+    explicit basic_format_arg(const double _Val) noexcept
+        : _Active_state(_Basic_format_arg_type::_Double_type), _Double_state(_Val) {}
+    explicit basic_format_arg(const long double _Val) noexcept
+        : _Active_state(_Basic_format_arg_type::_Long_double_type), _Long_double_state(_Val) {}
+    explicit basic_format_arg(const void* _Val) noexcept
+        : _Active_state(_Basic_format_arg_type::_Pointer_type), _Pointer_state(_Val) {}
+    explicit basic_format_arg(const _CharType* _Val) noexcept
+        : _Active_state(_Basic_format_arg_type::_CString_type), _CString_state(_Val) {}
+    explicit basic_format_arg(const basic_string_view<_CharType> _Val) noexcept
+        : _Active_state(_Basic_format_arg_type::_String_type), _String_state(_Val) {}
+    explicit basic_format_arg(const handle _Val) noexcept
+        : _Active_state(_Basic_format_arg_type::_Custom_type), _Custom_state(_Val) {}
+    explicit operator bool() const noexcept {
+        return _Active_state != _Basic_format_arg_type::_None;
+    }
+
+    _Basic_format_arg_type _Active_state = _Basic_format_arg_type::_None;
+    union {
+        monostate _No_state = monostate{};
+        int _Int_state;
+        unsigned int _UInt_state;
+        long long _Long_long_state;
+        unsigned long long _ULong_long_state;
+        bool _Bool_state;
+        _CharType _Char_state;
+        float _Float_state;
+        double _Double_state;
+        long double _Long_double_state;
+        const void* _Pointer_state;
+        const _CharType* _CString_state;
+        basic_string_view<_CharType> _String_state;
+        handle _Custom_state;
+    };
+};
 
 // we need to implement this ourselves because from_chars does not work with wide characters
 template <class _CharT>
@@ -480,92 +569,6 @@ constexpr void _Parse_format_string(basic_string_view<_CharT> _Format_str, _Hand
 }
 
 
-// TODO: test coverage
-template <class _Context>
-class basic_format_arg {
-public:
-    class handle;
-
-private:
-    template <class _Visitor, class _Ctx>
-    friend auto visit_format_arg(_Visitor&& _Vis, basic_format_arg<_Ctx> _Arg) -> decltype(_Vis(0));
-
-    using _CharT = typename _Context::char_type;
-
-    using _Format_arg_value = variant<monostate, int, unsigned, long long, unsigned long long, bool,
-        typename _Context::char_type, float, double, long double, const void*, const typename _Context::char_type,
-        basic_string_view<typename _Context::char_type>, handle>;
-
-    _Format_arg_value _Value;
-
-    template <class _CharT>
-    struct _Format_arg_type_to_enum {
-        constexpr _Type operator()(monostate) {
-            return _Type::_None;
-        }
-        constexpr _Type operator()(int32_t) {
-            return _Type::_Int32;
-        }
-        constexpr _Type operator()(int64_t) {
-            return _Type::_Int64;
-        }
-        constexpr _Type operator()(uint32_t) {
-            return _Type::_UInt32;
-        }
-        constexpr _Type operator()(uint64_t) {
-            return _Type::_UInt64;
-        }
-        constexpr _Type operator()(bool) {
-            return _Type::_Bool;
-        }
-        constexpr _Type operator()(_CharT) {
-            return _Type::_Char;
-        }
-        constexpr _Type operator()(float) {
-            return _Type::_Float32;
-        }
-        constexpr _Type operator()(double) {
-            return _Type::_Float64;
-        }
-        constexpr _Type operator()(long double) {
-            return _Type::_Float64;
-        }
-        constexpr _Type operator()(const _CharT*) {
-            return _Type::_CString;
-        }
-        constexpr _Type operator()(const basic_string_view<_CharT>&) {
-            return _Type::_String;
-        }
-        constexpr _Type operator()(const void*) {
-            return _Type::_Pointer;
-        }
-        constexpr _Type operator()(const basic_format_arg::handle&) {
-            return _Type::_Custom;
-        }
-    };
-
-public:
-    class handle {
-    private:
-        const void* _Ptr;
-        void (*_Format)(basic_format_parse_context<_CharT>& _Parse_ctx, _Context _Format_ctx, const void*);
-        friend basic_format_arg;
-
-    public:
-        void format(basic_format_parse_context<_CharT>& _Parse_ctx, _Context& _Format_ctx) {
-            _Format(_Parse_ctx, _Format_ctx, _Ptr);
-        }
-    };
-
-    basic_format_arg() noexcept = default;
-    explicit operator bool() const noexcept {
-        return !_STD holds_alternative<monostate>(_Value);
-    }
-    constexpr _Type _Get_type() {
-        return _STD visit(_Format_arg_type_to_enum<_CharT>{}, _Value);
-    }
-};
-
 template <class _CharT>
 struct _Basic_format_specs {
     unsigned int _Width, _Precision;
@@ -720,10 +723,10 @@ private:
     }
 };
 class _Numeric_specs_checker {
-    _Type _Arg_type = _Type::_None;
+    _Basic_format_arg_type _Arg_type = _Basic_format_arg_type::_None;
 
 public:
-    constexpr _Numeric_specs_checker(_Type _Arg_type) : _Arg_type(_Arg_type) {}
+    constexpr _Numeric_specs_checker(_Basic_format_arg_type _Arg_type) : _Arg_type(_Arg_type) {}
 
     constexpr void _Require_numeric_argument() {
         if (!_Is_arithmetic_fmt_type(_Arg_type)) {
@@ -733,14 +736,15 @@ public:
 
     constexpr void _Check_sign() {
         _Require_numeric_argument();
-        if (_Is_integral_fmt_type(_Arg_type) && _Arg_type != _Type::_Int32 && _Arg_type != _Type::_Int64
-            && _Arg_type != _Type::_Char) {
+        if (_Is_integral_fmt_type(_Arg_type) && _Arg_type != _Basic_format_arg_type::_Int_type
+            && _Arg_type != _Basic_format_arg_type::_Long_long_type
+            && _Arg_type != _Basic_format_arg_type::_Char_type) {
             throw format_error("Format specifier requires signed argument.");
         }
     }
 
     constexpr void _Check_precision() {
-        if (_Is_integral_fmt_type(_Arg_type) || _Arg_type == _Type::_Pointer) {
+        if (_Is_integral_fmt_type(_Arg_type) || _Arg_type == _Basic_format_arg_type::_Pointer_type) {
             throw format_error("Precision not allowed for this argument type.");
         }
     }
@@ -755,7 +759,7 @@ class _Specs_checker : public _Handler {
     _Numeric_specs_checker _Numeric_checker;
 
 public:
-    constexpr _Specs_checker(const _Handler& _Handler_inst, _Type _Arg_type)
+    constexpr _Specs_checker(const _Handler& _Handler_inst, _Basic_format_arg_type _Arg_type)
         : _Handler(_Handler_inst), _Numeric_checker(_Arg_type) {}
 
     // _On_align has no checking, since we don't implement numeric alignments.
@@ -778,166 +782,6 @@ public:
         _Numeric_checker._Check_precision();
         _Handler::_On_precision(_Precision);
     }
-};
-
-template <class _Ty, class _CharT = char>
-struct formatter;
-
-inline void _You_see_this_error_because_arg_id_is_out_of_range() noexcept {}
-
-template <class _CharT>
-class basic_format_parse_context {
-public:
-    using char_type      = _CharT;
-    using const_iterator = typename basic_string_view<_CharT>::const_iterator;
-    using iterator       = const_iterator;
-
-    constexpr explicit basic_format_parse_context(basic_string_view<_CharT> _Fmt, size_t _Num_args_ = 0) noexcept
-        : _Format_string(_Fmt), _Num_args(_Num_args_) {}
-    basic_format_parse_context(const basic_format_parse_context&) = delete;
-    basic_format_parse_context& operator=(const basic_format_parse_context&) = delete;
-
-    _NODISCARD constexpr const_iterator begin() const noexcept {
-        return _Format_string.begin();
-    }
-    _NODISCARD constexpr const_iterator end() const noexcept {
-        return _Format_string.end();
-    }
-    constexpr void advance_to(const const_iterator _It) {
-        _Adl_verify_range(_It, _Format_string.end());
-        const auto _Diff = static_cast<size_t>(_It._Unwrapped() - _Format_string._Unchecked_begin());
-        _Format_string.remove_prefix(_Diff);
-    }
-
-    // While the standard presents an exposition only enum value for
-    // the indexing mode (manual, automatic, or unknown) we use _Next_arg_id to indicate it.
-    // _Next_arg_id > 0 means automatic
-    // _Next_arg_id == 0 means unknown
-    // _Next_arg_id < 0 means manual
-    constexpr size_t next_arg_id() {
-        if (_Next_arg_id < 0) {
-            throw format_error("Can not switch from manual to automatic indexing");
-        }
-
-        return static_cast<size_t>(_Next_arg_id++);
-    }
-
-    constexpr void check_arg_id(const size_t _Id) {
-        if (_STD is_constant_evaluated()) {
-            if (_Id >= _Num_args) {
-                _You_see_this_error_because_arg_id_is_out_of_range();
-            }
-        }
-
-        if (_Next_arg_id > 0) {
-            throw format_error("Can not switch from automatic to manual indexing");
-        }
-        _Next_arg_id = -1;
-    }
-
-private:
-    basic_string_view<_CharT> _Format_string;
-    size_t _Num_args;
-    // The standard says this is size_t, however we use ptrdiff_t to save some space
-    // by not having to store the indexing mode. Above is a more detailed explanation
-    // of how this works.
-    ptrdiff_t _Next_arg_id = 0;
-};
-
-enum class _Basic_format_arg_type : uint8_t {
-    _None,
-    _Int_type,
-    _UInt_type,
-    _Long_long_type,
-    _ULong_long_type,
-    _Bool_type,
-    _Char_type,
-    _Float_type,
-    _Double_type,
-    _Long_double_type,
-    _Pointer_type,
-    _CString_type,
-    _String_type,
-    _Custom_type,
-};
-static_assert(static_cast<int>(_Basic_format_arg_type::_Custom_type) <= 16);
-
-template <class _Context>
-class basic_format_arg {
-public:
-    using _CharType = typename _Context::char_type;
-
-    class handle {
-    private:
-        const void* _Ptr;
-        void (*_Format)(basic_format_parse_context<_CharType>& _Parse_ctx, _Context _Format_ctx, const void*);
-        friend basic_format_arg;
-
-    public:
-        template <class _Ty>
-        explicit handle(const _Ty& _Val) noexcept
-            : _Ptr(_STD addressof(_Val)),
-              _Format([](basic_format_parse_context<_CharType>& _Parse_ctx, _Context& _Format_ctx, const void* _Ptr) {
-                  typename _Context::template formatter_type<_Ty> _Formatter;
-                  _Parse_ctx.advance_to(_Formatter.parse(_Parse_ctx));
-                  _Format_ctx.advance_to(_Formatter.format(*static_cast<const _Ty*>(_Ptr), _Format_ctx));
-              }) {}
-
-        void format(basic_format_parse_context<_CharType>& _Parse_ctx, _Context& _Format_ctx) {
-            _Format(_Parse_ctx, _Format_ctx, _Ptr);
-        }
-    };
-
-    // TRANSITION, LLVM-49072
-    basic_format_arg() noexcept : _Active_state(_Basic_format_arg_type::_None), _No_state() {}
-
-    explicit basic_format_arg(const int _Val) noexcept
-        : _Active_state(_Basic_format_arg_type::_Int_type), _Int_state(_Val) {}
-    explicit basic_format_arg(const unsigned int _Val) noexcept
-        : _Active_state(_Basic_format_arg_type::_UInt_type), _UInt_state(_Val) {}
-    explicit basic_format_arg(const long long _Val) noexcept
-        : _Active_state(_Basic_format_arg_type::_Long_long_type), _Long_long_state(_Val) {}
-    explicit basic_format_arg(const unsigned long long _Val) noexcept
-        : _Active_state(_Basic_format_arg_type::_ULong_long_type), _ULong_long_state(_Val) {}
-    explicit basic_format_arg(const bool _Val) noexcept
-        : _Active_state(_Basic_format_arg_type::_Bool_type), _Bool_state(_Val) {}
-    explicit basic_format_arg(const _CharType _Val) noexcept
-        : _Active_state(_Basic_format_arg_type::_Char_type), _Char_state(_Val) {}
-    explicit basic_format_arg(const float _Val) noexcept
-        : _Active_state(_Basic_format_arg_type::_Float_type), _Float_state(_Val) {}
-    explicit basic_format_arg(const double _Val) noexcept
-        : _Active_state(_Basic_format_arg_type::_Double_type), _Double_state(_Val) {}
-    explicit basic_format_arg(const long double _Val) noexcept
-        : _Active_state(_Basic_format_arg_type::_Long_double_type), _Long_double_state(_Val) {}
-    explicit basic_format_arg(const void* _Val) noexcept
-        : _Active_state(_Basic_format_arg_type::_Pointer_type), _Pointer_state(_Val) {}
-    explicit basic_format_arg(const _CharType* _Val) noexcept
-        : _Active_state(_Basic_format_arg_type::_CString_type), _CString_state(_Val) {}
-    explicit basic_format_arg(const basic_string_view<_CharType> _Val) noexcept
-        : _Active_state(_Basic_format_arg_type::_String_type), _String_state(_Val) {}
-    explicit basic_format_arg(const handle _Val) noexcept
-        : _Active_state(_Basic_format_arg_type::_Custom_type), _Custom_state(_Val) {}
-    explicit operator bool() const noexcept {
-        return _Active_state != _Basic_format_arg_type::_None;
-    }
-
-    _Basic_format_arg_type _Active_state = _Basic_format_arg_type::_None;
-    union {
-        monostate _No_state = monostate{};
-        int _Int_state;
-        unsigned int _UInt_state;
-        long long _Long_long_state;
-        unsigned long long _ULong_long_state;
-        bool _Bool_state;
-        _CharType _Char_state;
-        float _Float_state;
-        double _Double_state;
-        long double _Long_double_state;
-        const void* _Pointer_state;
-        const _CharType* _CString_state;
-        basic_string_view<_CharType> _String_state;
-        handle _Custom_state;
-    };
 };
 
 template <class _Visitor, class _Context>
@@ -1133,9 +977,6 @@ public:
         size_t _Arg_index = 0;
         (_Store(_Arg_index++, _Vals), ...);
     }
-    constexpr _Type _Get_type() {
-        return _STD visit(_Format_arg_type_to_enum<_CharT>{}, _Value);
-    }
 };
 
 template <class _Context>
@@ -1250,11 +1091,6 @@ public:
     }
 };
 
-template <class _Visitor, class _Context>
-auto visit_format_arg(_Visitor&& _Vis, basic_format_arg<_Context> _Arg) -> decltype(_Vis(0)) {
-    return _STD visit(_STD forward<_Visitor>(_Vis), _Arg._Value);
-}
-
 template <class _CharT, class _OutputIt>
 _OutputIt _Write(_OutputIt _Out, monostate) {
     _STL_INTERNAL_CHECK(false);
@@ -1354,7 +1190,7 @@ struct _Format_handler {
         _Basic_format_specs<_CharT> _Specs;
         _Specs_checker<_Specs_handler<basic_format_parse_context<_CharT>, _Context>> _Handler(
             _Specs_handler<basic_format_parse_context<_CharT>, _Context>(_Specs, _Parse_context, _Ctx),
-            _Arg._Get_type());
+            _Arg._Active_state);
         _Begin = _Parse_format_specs(_Begin, _End, _Handler);
         if (_Begin == _End || *_Begin != '}') {
             throw format_error("Missing '}' in format string.");

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -123,11 +123,11 @@ template <class _Ty, class _CharT>
 concept _Parse_spec_callbacks = requires(_Ty _At, basic_string_view<_CharT> _Sv, _Align _Aln, _Sign _Sgn) {
     { _At._On_align(_Aln) } -> same_as<void>;
     { _At._On_fill(_Sv) } -> same_as<void>;
-    { _At._On_width(int{}) } -> same_as<void>;
-    { _At._On_dynamic_width(int{}) } -> same_as<void>;
+    { _At._On_width(unsigned{}) } -> same_as<void>;
+    { _At._On_dynamic_width(size_t{}) } -> same_as<void>;
     { _At._On_dynamic_width(_Auto_id_tag{}) } -> same_as<void>;
-    { _At._On_precision(int{}) } -> same_as<void>;
-    { _At._On_dynamic_precision(int{}) } -> same_as<void>;
+    { _At._On_precision(unsigned{}) } -> same_as<void>;
+    { _At._On_dynamic_precision(size_t{}) } -> same_as<void>;
     { _At._On_dynamic_precision(_Auto_id_tag{}) } -> same_as<void>;
     { _At._On_sign(_Sgn) } -> same_as<void>;
     { _At._On_hash() } -> same_as<void>;
@@ -152,9 +152,9 @@ concept _Parse_replacement_field_callbacks = requires(_Ty _At, const _CharT* _Be
 
 // we need to implement this ourselves because from_chars does not work with wide characters
 template <class _CharT>
-constexpr const _CharT* _Parse_nonnegative_integer(const _CharT* _Begin, const _CharT* _End, int& _Integer) {
+constexpr const _CharT* _Parse_nonnegative_integer(const _CharT* _Begin, const _CharT* _End, unsigned int& _Value) {
     _STL_INTERNAL_CHECK(_Begin != _End && '0' <= *_Begin && *_Begin <= '9');
-    unsigned int _Value             = 0;
+    _Value                          = 0;
     constexpr unsigned int _Max_int = static_cast<unsigned int>((numeric_limits<int>::max)());
     constexpr unsigned int _Big_int = _Max_int / 10;
 
@@ -169,7 +169,6 @@ constexpr const _CharT* _Parse_nonnegative_integer(const _CharT* _Begin, const _
     if (_Value > _Max_int) {
         throw format_error("Number is too big");
     }
-    _Integer = static_cast<int>(_Value);
     return _Begin;
 }
 
@@ -184,7 +183,7 @@ constexpr const _CharT* _Parse_arg_id(const _CharT* _Begin, const _CharT* _End, 
     }
 
     if (_Ch >= '0' && _Ch <= '9') {
-        int _Index = 0;
+        unsigned int _Index = 0;
         // arg_id is not allowed to have any leading zeros, but is allowed to be
         // equal to zero (but not '00'). So if _Ch is zero we skip the parsing, leave
         // _Index set to zero and let the validity checks below ensure that the arg_id
@@ -200,7 +199,7 @@ constexpr const _CharT* _Parse_arg_id(const _CharT* _Begin, const _CharT* _End, 
         if (_Begin == _End || (*_Begin != '}' && *_Begin != ':')) {
             throw format_error("Invalid format string.");
         }
-        _Callbacks._On_manual_id(static_cast<size_t>(_Index));
+        _Callbacks._On_manual_id(_Index);
         return _Begin;
     }
     // This is where we would parse named arg ids if std::format were to support them.
@@ -297,8 +296,8 @@ template <class _CharT, _Parse_spec_callbacks<_CharT> _Callbacks_type>
 constexpr const _CharT* _Parse_width(const _CharT* _Begin, const _CharT* _End, _Callbacks_type&& _Callbacks) {
     _STL_INTERNAL_CHECK(_Begin != _End);
     if ('1' <= *_Begin && *_Begin <= '9') {
-        int _Value = 0;
-        _Begin     = _Parse_nonnegative_integer(_Begin, _End, _Value);
+        unsigned int _Value = 0;
+        _Begin              = _Parse_nonnegative_integer(_Begin, _End, _Value);
         _Callbacks._On_width(_Value);
     } else if (*_Begin == '{') {
         ++_Begin;
@@ -322,8 +321,8 @@ constexpr const _CharT* _Parse_precision(const _CharT* _Begin, const _CharT* _En
     }
 
     if ('0' <= _Ch && _Ch <= '9') {
-        int _Precision = 0;
-        _Begin         = _Parse_nonnegative_integer(_Begin, _End, _Precision);
+        unsigned int _Precision = 0;
+        _Begin                  = _Parse_nonnegative_integer(_Begin, _End, _Precision);
         _Callbacks._On_precision(_Precision);
     } else if (_Ch == '{') {
         ++_Begin;
@@ -563,7 +562,7 @@ public:
 
 template <typename _CharT>
 struct _Basic_format_specs {
-    int _Width, _Precision;
+    unsigned int _Width, _Precision;
     char _Type;
     _Align _Alignment;
     _Sign _Sgn;
@@ -603,11 +602,11 @@ public:
         _Specs._Fill[0]   = '0';
     }
 
-    constexpr void _On_width(int _Width) {
+    constexpr void _On_width(unsigned int _Width) {
         _Specs._Width = _Width;
     }
 
-    constexpr void _On_precision(int _Precision) {
+    constexpr void _On_precision(unsigned int _Precision) {
         _Specs._Precision = _Precision;
     }
 
@@ -621,12 +620,12 @@ protected:
 
 
 template <class _Handler, class _FormatArg>
-constexpr int _Get_dynamic_specs(_FormatArg _Arg) {
+constexpr unsigned int _Get_dynamic_specs(_FormatArg _Arg) {
     unsigned long long _Val = visit_format_arg(_Handler(), _Arg);
-    if (_Val > static_cast<unsigned int>((_STD numeric_limits<int>::max)())) {
+    if (_Val > (_STD numeric_limits<unsigned int>::max)()) {
         throw format_error("Number is too big.");
     }
-    return static_cast<int>(_Val);
+    return static_cast<unsigned int>(_Val);
 }
 
 template <class _Context>
@@ -756,7 +755,7 @@ public:
         _Handler::_On_zero();
     }
 
-    constexpr void _On_precision(int _Precision) {
+    constexpr void _On_precision(unsigned int _Precision) {
         _Numeric_checker._Check_precision();
         _Handler::_On_precision(_Precision);
     }

--- a/tests/std/test.lst
+++ b/tests/std/test.lst
@@ -255,9 +255,9 @@ tests\P0616R0_using_move_in_numeric
 tests\P0631R8_numbers_math_constants
 tests\P0645R10_text_formatting_args
 tests\P0645R10_text_formatting_death
+tests\P0645R10_text_formatting_formatting
 tests\P0645R10_text_formatting_parse_contexts
 tests\P0645R10_text_formatting_parsing
-tests\P0645R10_text_formatting_formatting
 tests\P0660R10_jthread_and_cv_any
 tests\P0660R10_stop_token
 tests\P0660R10_stop_token_death

--- a/tests/std/test.lst
+++ b/tests/std/test.lst
@@ -257,6 +257,7 @@ tests\P0645R10_text_formatting_args
 tests\P0645R10_text_formatting_death
 tests\P0645R10_text_formatting_parse_contexts
 tests\P0645R10_text_formatting_parsing
+tests\P0645R10_text_formatting_formatting
 tests\P0660R10_jthread_and_cv_any
 tests\P0660R10_stop_token
 tests\P0660R10_stop_token_death

--- a/tests/std/tests/P0645R10_text_formatting_formatting/env.lst
+++ b/tests/std/tests/P0645R10_text_formatting_formatting/env.lst
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+RUNALL_INCLUDE ..\concepts_matrix.lst

--- a/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <assert.h>
+#include <format>
+#include <string_view>
+
+// TODO: fill in tests
+
+int main() {}

--- a/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
@@ -3,8 +3,12 @@
 
 #include <assert.h>
 #include <format>
+#include <string>
 #include <string_view>
 
 // TODO: fill in tests
+template std::back_insert_iterator<std::string> std::vformat_to(std::back_insert_iterator<std::string>, const locale&,
+    std::string_view, std::format_args_t<std::back_insert_iterator<std::string>, char>);
+
 
 int main() {}

--- a/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
@@ -3,12 +3,14 @@
 
 #include <assert.h>
 #include <format>
+#include <iterator>
+#include <locale>
 #include <string>
 #include <string_view>
 
 // TODO: fill in tests
-template std::back_insert_iterator<std::string> std::vformat_to(std::back_insert_iterator<std::string>, const locale&,
-    std::string_view, std::format_args_t<std::back_insert_iterator<std::string>, char>);
+template std::back_insert_iterator<std::string> std::vformat_to(std::back_insert_iterator<std::string>,
+    const std::locale&, std::string_view, std::format_args_t<std::back_insert_iterator<std::string>, char>);
 
 
 int main() {}

--- a/tests/std/tests/P0645R10_text_formatting_parsing/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_parsing/test.cpp
@@ -287,6 +287,5 @@ int main() {
     test_parse_format_specs<wchar_t>();
     static_assert(test_parse_format_specs<char>());
     static_assert(test_parse_format_specs<wchar_t>());
-
     return 0;
 }

--- a/tests/std/tests/P0645R10_text_formatting_parsing/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_parsing/test.cpp
@@ -290,7 +290,8 @@ constexpr bool test_specs_setter() {
 
 template <class CharT>
 constexpr bool test_specs_checker() {
-    _Specs_checker<noop_testing_callbacks<CharT>> checker(noop_testing_callbacks<CharT>{}, _Type::_Float32);
+    _Specs_checker<noop_testing_callbacks<CharT>> checker(
+        noop_testing_callbacks<CharT>{}, _Basic_format_arg_type::_Float_type);
     (void) checker;
     return true;
 }

--- a/tests/std/tests/P0645R10_text_formatting_parsing/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_parsing/test.cpp
@@ -31,6 +31,22 @@ struct choose_literal<wchar_t> {
 #define TYPED_LITERAL(CharT, Literal) (choose_literal<CharT>::choose(Literal, L##Literal))
 
 template <typename CharT>
+struct noop_testing_callbacks {
+    constexpr void _On_align(_Align) {}
+    constexpr void _On_fill(basic_string_view<CharT>) {}
+    constexpr void _On_width(int) {}
+    constexpr void _On_dynamic_width(int) {}
+    constexpr void _On_dynamic_width(_Auto_id_tag) {}
+    constexpr void _On_precision(int) {}
+    constexpr void _On_dynamic_precision(int) {}
+    constexpr void _On_dynamic_precision(_Auto_id_tag) {}
+    constexpr void _On_sign(_Sign) {}
+    constexpr void _On_hash() {}
+    constexpr void _On_zero() {}
+    constexpr void _On_type(CharT) {}
+};
+
+template <typename CharT>
 struct testing_callbacks {
     _Align expected_alignment = _Align::_None;
     _Sign expected_sign       = _Sign::_None;
@@ -262,6 +278,23 @@ constexpr bool test_parse_format_specs() {
     return true;
 }
 
+template <class CharT>
+constexpr bool test_specs_setter() {
+    // just instantiate for now.
+    _Basic_format_specs<CharT> specs = {};
+    _Specs_setter<CharT> setter(specs);
+
+    (void) setter;
+    return true;
+}
+
+template <class CharT>
+constexpr bool test_specs_checker() {
+    _Specs_checker<noop_testing_callbacks<CharT>> checker(noop_testing_callbacks<CharT>{}, _Type::_Float32);
+    (void) checker;
+    return true;
+}
+
 int main() {
     test_parse_align<char>();
     test_parse_align<wchar_t>();
@@ -287,5 +320,16 @@ int main() {
     test_parse_format_specs<wchar_t>();
     static_assert(test_parse_format_specs<char>());
     static_assert(test_parse_format_specs<wchar_t>());
+
+    test_specs_setter<char>();
+    test_specs_setter<wchar_t>();
+    static_assert(test_specs_setter<char>());
+    static_assert(test_specs_setter<wchar_t>());
+
+    test_specs_checker<char>();
+    test_specs_checker<wchar_t>();
+    static_assert(test_specs_checker<char>());
+    static_assert(test_specs_checker<wchar_t>());
+
     return 0;
 }

--- a/tests/std/tests/P0645R10_text_formatting_parsing/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_parsing/test.cpp
@@ -81,7 +81,7 @@ struct testing_callbacks {
         assert(type == expected_type);
     }
     constexpr void _On_sign(_Sign sgn) {
-        assert(sgn = expected_sign);
+        assert(sgn == expected_sign);
     }
     constexpr void _On_hash() {
         assert(expected_hash);
@@ -90,7 +90,7 @@ struct testing_callbacks {
         assert(expected_zero);
     }
     constexpr void _On_type(CharT type) {
-        assert(type = expected_type);
+        assert(type == expected_type);
     }
 };
 template <typename CharT>

--- a/tests/std/tests/P0645R10_text_formatting_parsing/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_parsing/test.cpp
@@ -80,6 +80,18 @@ struct testing_callbacks {
     constexpr void _On_type(CharT type) {
         assert(type == expected_type);
     }
+    constexpr void _On_sign(_Sign sgn) {
+        assert(sgn = expected_sign);
+    }
+    constexpr void _On_hash() {
+        assert(expected_hash);
+    }
+    constexpr void _On_zero() {
+        assert(expected_zero);
+    }
+    constexpr void _On_type(CharT type) {
+        assert(type = expected_type);
+    }
 };
 template <typename CharT>
 testing_callbacks(_Align, basic_string_view<CharT>) -> testing_callbacks<CharT>;

--- a/tests/std/tests/P0645R10_text_formatting_parsing/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_parsing/test.cpp
@@ -80,18 +80,6 @@ struct testing_callbacks {
     constexpr void _On_type(CharT type) {
         assert(type == expected_type);
     }
-    constexpr void _On_sign(_Sign sgn) {
-        assert(sgn == expected_sign);
-    }
-    constexpr void _On_hash() {
-        assert(expected_hash);
-    }
-    constexpr void _On_zero() {
-        assert(expected_zero);
-    }
-    constexpr void _On_type(CharT type) {
-        assert(type == expected_type);
-    }
 };
 template <typename CharT>
 testing_callbacks(_Align, basic_string_view<CharT>) -> testing_callbacks<CharT>;

--- a/tests/std/tests/P0645R10_text_formatting_parsing/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_parsing/test.cpp
@@ -34,11 +34,11 @@ template <typename CharT>
 struct noop_testing_callbacks {
     constexpr void _On_align(_Align) {}
     constexpr void _On_fill(basic_string_view<CharT>) {}
-    constexpr void _On_width(int) {}
-    constexpr void _On_dynamic_width(int) {}
+    constexpr void _On_width(unsigned int) {}
+    constexpr void _On_dynamic_width(size_t) {}
     constexpr void _On_dynamic_width(_Auto_id_tag) {}
-    constexpr void _On_precision(int) {}
-    constexpr void _On_dynamic_precision(int) {}
+    constexpr void _On_precision(unsigned int) {}
+    constexpr void _On_dynamic_precision(size_t) {}
     constexpr void _On_dynamic_precision(_Auto_id_tag) {}
     constexpr void _On_sign(_Sign) {}
     constexpr void _On_hash() {}
@@ -51,11 +51,11 @@ struct testing_callbacks {
     _Align expected_alignment = _Align::_None;
     _Sign expected_sign       = _Sign::_None;
     basic_string_view<CharT> expected_fill;
-    int expected_width                   = -1;
-    int expected_dynamic_width           = -1;
+    unsigned int expected_width          = static_cast<unsigned int>(-1);
+    size_t expected_dynamic_width        = static_cast<size_t>(-1);
     bool expected_auto_dynamic_width     = false;
-    int expected_precision               = -1;
-    int expected_dynamic_precision       = -1;
+    unsigned int expected_precision      = static_cast<unsigned int>(-1);
+    size_t expected_dynamic_precision    = static_cast<size_t>(-1);
     bool expected_auto_dynamic_precision = false;
     bool expected_hash                   = false;
     bool expected_zero                   = false;
@@ -66,19 +66,19 @@ struct testing_callbacks {
     constexpr void _On_fill(basic_string_view<CharT> str_view) {
         assert(str_view == expected_fill);
     }
-    constexpr void _On_width(int width) {
+    constexpr void _On_width(unsigned int width) {
         assert(width == expected_width);
     }
-    constexpr void _On_dynamic_width(int id) {
+    constexpr void _On_dynamic_width(size_t id) {
         assert(id == expected_dynamic_width);
     }
     constexpr void _On_dynamic_width(_Auto_id_tag) {
         assert(expected_auto_dynamic_width);
     }
-    constexpr void _On_precision(int pre) {
+    constexpr void _On_precision(unsigned int pre) {
         assert(pre == expected_precision);
     }
-    constexpr void _On_dynamic_precision(int id) {
+    constexpr void _On_dynamic_precision(size_t id) {
         assert(id == expected_dynamic_precision);
     }
     constexpr void _On_dynamic_precision(_Auto_id_tag) {
@@ -102,7 +102,7 @@ testing_callbacks(_Align, basic_string_view<CharT>) -> testing_callbacks<CharT>;
 
 struct testing_arg_id_callbacks {
     constexpr void _On_auto_id() {}
-    constexpr void _On_manual_id(int) {}
+    constexpr void _On_manual_id(size_t) {}
 };
 
 template <typename CharT, typename callback_type>


### PR DESCRIPTION
- adds `_Parse_format_string`
- adds `_Parse_replacement_field`
- adds `_Specs_setter` and `_Basic_format_specs`
- adds `_Specs_checker`, and `_Numeric_specs_checker`
- adds `_Format_handler` (note that `_On_format_specs` is incomplete)
- adds `vformat_to` definition
- adds `basic_format_args::get`

in total this is enough to get `vformat_to` instantiations to compile, although we can't run them without a few more `basic_format_arg` and `basic_format_args` related things.

Note that this `vformat_to` is the C++ 20 version of `vformat_to`, _NOT_ the proposed C++23 version (they have different ABIs)

Also note that this PR contains merge commits, they should go away if it's squashed, however.