### PR TITLE
<charconv>: small optimization of _Integer_to_chars for bases 3,6,5,7,9

### DIFF
--- a/stl/inc/charconv
+++ b/stl/inc/charconv
@@ -127,6 +127,17 @@ _NODISCARD to_chars_result _Integer_to_chars(
         } while (_Value != 0);
         break;
 
+    case 3:
+    case 5:
+    case 6:
+    case 7:
+    case 9:
+        do {
+            *--_RNext = static_cast<char>('0' + _Value % _Base);
+            _Value    = static_cast<_Unsigned>(_Value / _Base);
+        } while (_Value != 0);
+        break;
+
     default:
         do {
             *--_RNext = _Charconv_digits[_Value % _Base];


### PR DESCRIPTION
In case the base is less than 10 it is correct to calculate the digit by adding it to `'0'` instead of looking it up in the table. This is a small optimization
