### PR TITLE
Partially activate more Header Units test coverage

### DIFF
--- a/tests/std/tests/P1502R1_standard_library_header_units/test.cpp
+++ b/tests/std/tests/P1502R1_standard_library_header_units/test.cpp
@@ -324,11 +324,11 @@ int main() {
         puts("Testing <future>.");
         promise<int> p{};
         future<int> f{p.get_future()};
-#if 0 // TRANSITION, VSO-1271718 (Standard Library Header Units ICE with C++20 chrono)
+#ifdef MSVC_INTERNAL_TESTING // TRANSITION, VSO-1271718 (Standard Library Header Units ICE with C++20 chrono)
         assert(f.wait_for(chrono::seconds{0}) == future_status::timeout);
 #endif // ^^^ no workaround ^^^
         p.set_value(1729);
-#if 0 // TRANSITION, VSO-1271718 (Standard Library Header Units ICE with C++20 chrono)
+#ifdef MSVC_INTERNAL_TESTING // TRANSITION, VSO-1271718 (Standard Library Header Units ICE with C++20 chrono)
         assert(f.wait_for(chrono::seconds{0}) == future_status::ready);
 #endif // ^^^ no workaround ^^^
         assert(f.get() == 1729);
@@ -760,7 +760,7 @@ int main() {
                 }
                 l.count_down(); // tell main() that we're done
                 while (!token.stop_requested()) {
-#if 0 // TRANSITION, VSO-1271718 (Standard Library Header Units ICE with C++20 chrono)
+#ifdef MSVC_INTERNAL_TESTING // TRANSITION, VSO-1271718 (Standard Library Header Units ICE with C++20 chrono)
                     this_thread::sleep_for(10ms); // not a timing assumption; avoids spinning furiously
 #endif // ^^^ no workaround ^^^
                 }


### PR DESCRIPTION
The Microsoft-internal compiler bug VSO-1271718 "Standard Library Header Units ICE with C++20 chrono" has been fixed for VS 2019 16.10 Preview 1. To prevent compiler regressions between now and the time when Preview 1 ships publicly, we should activate the affected parts of the Standard Library Header Units test for the MSVC-internal test harness.

When Preview 1 is publicly available, we'll be able to remove these workarounds unconditionally.

As an aside, what triggered this ICE was the technique needed to implement LWG-3260:
https://github.com/microsoft/STL/blob/47cd70315d560e4fe1ac699c0eb8ec8bfc5cb658/stl/inc/chrono#L1253-L1254