### PR TITLE
Status Chart: Weekly update, save/load options

### DIFF
--- a/daily_table.js
+++ b/daily_table.js
@@ -519,5 +519,12 @@ const daily_table = [
     { date: '2021-01-30', merged: 21.16, pr: 41, cxx20: 12, cxx23: 4, lwg: 2, issue: 311, bug: 102, avg_age: 104.74, avg_wait: 80.10, sum_age: 143.15, sum_wait: 109.47, },
     { date: '2021-01-31', merged: 20.96, pr: 41, cxx20: 12, cxx23: 4, lwg: 2, issue: 311, bug: 102, avg_age: 105.74, avg_wait: 81.10, sum_age: 144.51, sum_wait: 110.84, },
     { date: '2021-02-01', merged: 23.76, pr: 40, cxx20: 12, cxx23: 4, lwg: 2, issue: 313, bug: 103, avg_age: 98.10, avg_wait: 81.61, sum_age: 130.81, sum_wait: 108.81, },
+    { date: '2021-02-02', merged: 26.56, pr: 41, cxx20: 12, cxx23: 4, lwg: 2, issue: 314, bug: 103, avg_age: 96.68, avg_wait: 80.13, sum_age: 132.13, sum_wait: 109.51, },
+    { date: '2021-02-03', merged: 28.30, pr: 40, cxx20: 12, cxx23: 4, lwg: 2, issue: 318, bug: 103, avg_age: 98.84, avg_wait: 82.97, sum_age: 131.79, sum_wait: 110.62, },
+    { date: '2021-02-04', merged: 28.80, pr: 40, cxx20: 12, cxx23: 4, lwg: 2, issue: 318, bug: 103, avg_age: 99.59, avg_wait: 81.00, sum_age: 132.79, sum_wait: 108.00, },
+    { date: '2021-02-05', merged: 29.25, pr: 44, cxx20: 12, cxx23: 4, lwg: 2, issue: 318, bug: 103, avg_age: 91.32, avg_wait: 74.54, sum_age: 133.94, sum_wait: 109.33, },
+    { date: '2021-02-06', merged: 28.70, pr: 44, cxx20: 12, cxx23: 4, lwg: 2, issue: 319, bug: 104, avg_age: 92.32, avg_wait: 75.54, sum_age: 135.41, sum_wait: 110.79, },
+    { date: '2021-02-07', merged: 28.15, pr: 45, cxx20: 12, cxx23: 4, lwg: 2, issue: 319, bug: 104, avg_age: 91.25, avg_wait: 74.84, sum_age: 136.88, sum_wait: 112.26, },
+    { date: '2021-02-08', merged: 27.59, pr: 46, cxx20: 12, cxx23: 4, lwg: 2, issue: 319, bug: 104, avg_age: 90.26, avg_wait: 74.21, sum_age: 138.40, sum_wait: 113.78, },
 ];
 // Generated file - DO NOT EDIT manually!

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
-        "@octokit/graphql": "^4.5.9",
+        "@octokit/graphql": "^4.6.0",
         "cli-progress": "^3.9.0",
         "dotenv": "^8.2.0",
         "luxon": "^1.25.0"
@@ -26,9 +26,9 @@
       }
     },
     "node_modules/@octokit/graphql": {
-      "version": "4.5.9",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.5.9.tgz",
-      "integrity": "sha512-c+0yofIugUNqo+ktrLaBlWSbjSq/UF8ChAyxQzbD3X74k1vAuyLKdDJmPwVExUFSp6+U1FzWe+3OkeRsIqV0vg==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.6.0.tgz",
+      "integrity": "sha512-CJ6n7izLFXLvPZaWzCQDjU/RP+vHiZmWdOunaCS87v+2jxMsW9FB5ktfIxybRBxZjxuJGRnxk7xJecWTVxFUYQ==",
       "dependencies": {
         "@octokit/request": "^5.3.0",
         "@octokit/types": "^6.0.3",
@@ -36,9 +36,9 @@
       }
     },
     "node_modules/@octokit/openapi-types": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-3.4.1.tgz",
-      "integrity": "sha512-7Sjm3UwEAM11f+ck9+qlyEfgl8hCk5sSZBU2qcWY8+8ibowjqcwxhhtvY0/pjHPF8mcvmedFpGmmIYs2qM9/+Q=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-4.0.1.tgz",
+      "integrity": "sha512-k2hRcfcLRyPJjtYfJLzg404n7HZ6sUpAWAR/uNI8tf96NgatWOpw1ocdF+WFfx/trO1ivBh7ckynO1rn+xAw/Q=="
     },
     "node_modules/@octokit/request": {
       "version": "5.4.14",
@@ -66,18 +66,18 @@
       }
     },
     "node_modules/@octokit/types": {
-      "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.7.1.tgz",
-      "integrity": "sha512-OzRXbizUfixgzTjlSZQj+yuo0J9vAMOLtpsIm3JjQUsI3CcLXZnVaxRIWtYD+iwHznnvG9fJlPHM6SRp77fUcw==",
+      "version": "6.8.2",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.8.2.tgz",
+      "integrity": "sha512-RpG0NJd7OKSkWptiFhy1xCLkThs5YoDIKM21lEtDmUvSpbaIEfrxzckWLUGDFfF8RydSyngo44gDv8m2hHruUg==",
       "dependencies": {
-        "@octokit/openapi-types": "^3.4.1",
+        "@octokit/openapi-types": "^4.0.0",
         "@types/node": ">= 8"
       }
     },
     "node_modules/@types/node": {
-      "version": "14.14.22",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.22.tgz",
-      "integrity": "sha512-g+f/qj/cNcqKkc3tFqlXOYjrmZA+jNBiDzbP3kH+B+otKFqAdPgVTGP1IeKRdMml/aE69as5S4FqtxAbl+LaMw=="
+      "version": "14.14.25",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.25.tgz",
+      "integrity": "sha512-EPpXLOVqDvisVxtlbvzfyqSsFeQxltFbluZNRndIb8tr9KiBnYNLzrc1N3pyKUCww2RNrfHDViqDWWE1LCJQtQ=="
     },
     "node_modules/ansi-regex": {
       "version": "5.0.0",
@@ -212,9 +212,9 @@
       }
     },
     "@octokit/graphql": {
-      "version": "4.5.9",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.5.9.tgz",
-      "integrity": "sha512-c+0yofIugUNqo+ktrLaBlWSbjSq/UF8ChAyxQzbD3X74k1vAuyLKdDJmPwVExUFSp6+U1FzWe+3OkeRsIqV0vg==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.6.0.tgz",
+      "integrity": "sha512-CJ6n7izLFXLvPZaWzCQDjU/RP+vHiZmWdOunaCS87v+2jxMsW9FB5ktfIxybRBxZjxuJGRnxk7xJecWTVxFUYQ==",
       "requires": {
         "@octokit/request": "^5.3.0",
         "@octokit/types": "^6.0.3",
@@ -222,9 +222,9 @@
       }
     },
     "@octokit/openapi-types": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-3.4.1.tgz",
-      "integrity": "sha512-7Sjm3UwEAM11f+ck9+qlyEfgl8hCk5sSZBU2qcWY8+8ibowjqcwxhhtvY0/pjHPF8mcvmedFpGmmIYs2qM9/+Q=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-4.0.1.tgz",
+      "integrity": "sha512-k2hRcfcLRyPJjtYfJLzg404n7HZ6sUpAWAR/uNI8tf96NgatWOpw1ocdF+WFfx/trO1ivBh7ckynO1rn+xAw/Q=="
     },
     "@octokit/request": {
       "version": "5.4.14",
@@ -252,18 +252,18 @@
       }
     },
     "@octokit/types": {
-      "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.7.1.tgz",
-      "integrity": "sha512-OzRXbizUfixgzTjlSZQj+yuo0J9vAMOLtpsIm3JjQUsI3CcLXZnVaxRIWtYD+iwHznnvG9fJlPHM6SRp77fUcw==",
+      "version": "6.8.2",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.8.2.tgz",
+      "integrity": "sha512-RpG0NJd7OKSkWptiFhy1xCLkThs5YoDIKM21lEtDmUvSpbaIEfrxzckWLUGDFfF8RydSyngo44gDv8m2hHruUg==",
       "requires": {
-        "@octokit/openapi-types": "^3.4.1",
+        "@octokit/openapi-types": "^4.0.0",
         "@types/node": ">= 8"
       }
     },
     "@types/node": {
-      "version": "14.14.22",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.22.tgz",
-      "integrity": "sha512-g+f/qj/cNcqKkc3tFqlXOYjrmZA+jNBiDzbP3kH+B+otKFqAdPgVTGP1IeKRdMml/aE69as5S4FqtxAbl+LaMw=="
+      "version": "14.14.25",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.25.tgz",
+      "integrity": "sha512-EPpXLOVqDvisVxtlbvzfyqSsFeQxltFbluZNRndIb8tr9KiBnYNLzrc1N3pyKUCww2RNrfHDViqDWWE1LCJQtQ=="
     },
     "ansi-regex": {
       "version": "5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "@octokit/graphql": "^4.6.0",
         "cli-progress": "^3.9.0",
         "dotenv": "^8.2.0",
-        "luxon": "^1.25.0"
+        "luxon": "^1.25.0",
+        "yargs": "^16.2.0"
       }
     },
     "node_modules/@octokit/endpoint": {
@@ -87,6 +88,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/cli-progress": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.9.0.tgz",
@@ -98,6 +113,32 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/colors": {
       "version": "1.4.0",
@@ -124,6 +165,22 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "node_modules/escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
@@ -165,6 +222,14 @@
         "wrappy": "1"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/string-width": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
@@ -194,10 +259,59 @@
       "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
       "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w=="
     },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "node_modules/y18n": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
+      "integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "20.2.4",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+      "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+      "engines": {
+        "node": ">=10"
+      }
     }
   },
   "dependencies": {
@@ -270,6 +384,14 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
       "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
     },
+    "ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "requires": {
+        "color-convert": "^2.0.1"
+      }
+    },
     "cli-progress": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.9.0.tgz",
@@ -278,6 +400,29 @@
         "colors": "^1.1.2",
         "string-width": "^4.2.0"
       }
+    },
+    "cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "requires": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "colors": {
       "version": "1.4.0",
@@ -298,6 +443,16 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
     "is-fullwidth-code-point": {
       "version": "3.0.0",
@@ -327,6 +482,11 @@
         "wrappy": "1"
       }
     },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+    },
     "string-width": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
@@ -350,10 +510,44 @@
       "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
       "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w=="
     },
+    "wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      }
+    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "y18n": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
+      "integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg=="
+    },
+    "yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "requires": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      }
+    },
+    "yargs-parser": {
+      "version": "20.2.4",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+      "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@octokit/graphql": "^4.6.0",
     "cli-progress": "^3.9.0",
     "dotenv": "^8.2.0",
-    "luxon": "^1.25.0"
+    "luxon": "^1.25.0",
+    "yargs": "^16.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "tabWidth": 4
   },
   "dependencies": {
-    "@octokit/graphql": "^4.5.9",
+    "@octokit/graphql": "^4.6.0",
     "cli-progress": "^3.9.0",
     "dotenv": "^8.2.0",
     "luxon": "^1.25.0"

--- a/usernames_contributors.txt
+++ b/usernames_contributors.txt
@@ -3,6 +3,7 @@
 
 AlexGuteniev
 fsb4000
+MichaelRizkalla
 miscco
 statementreply
 timsong-cpp

--- a/weekly_table.js
+++ b/weekly_table.js
@@ -191,4 +191,5 @@ const weekly_table = [
     { date: '2021-01-15', vso: 151, libcxx: 563 },
     { date: '2021-01-22', vso: 152, libcxx: 563 },
     { date: '2021-01-29', vso: 152, libcxx: 563 },
+    { date: '2021-02-05', vso: 155, libcxx: 588 },
 ];


### PR DESCRIPTION
In addition to a weekly update, this adds a save/load feature to make development easier. When working on the code that consumes the GraphQL result and transforms it into the datapoints for the displayed charts, it's slow and wasteful to query the network for 20-ish seconds during every test run.

I originally developed the Status Chart rapidly with temporary `JSON.stringify` and `JSON.parse` calls. Now I've implemented robust option parsing with [yargs](https://github.com/yargs/yargs), and the save/load functionality doesn't affect the rest of the code. The only exception is during the final output - when loading a previously retrieved response, I thought it was confusing to print that any rate limit points were spent. (This would have been printed during the original retrieval when it was saved.) I felt that `if (!argv['load-file'])` was the simplest way to handle this, instead of nulling out the `rate_limit` and testing that.

Live preview: [stephantlavavej.github.io/STL/](https://stephantlavavej.github.io/STL/)
===