### PR TITLE
VS 2019 16.9 Preview 4 toolset update

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 The STL uses boost-math headers to provide P0226R1 Mathematical Special Functions. We recommend using [vcpkg][] to
 acquire this dependency.
 
-1. Install Visual Studio 2019 16.9 Preview 3 or later.
+1. Install Visual Studio 2019 16.9 Preview 4 or later.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
     * Otherwise, install [CMake][] 3.19 or later, and [Ninja][] 1.10.2 or later.
@@ -158,7 +158,7 @@ acquire this dependency.
 
 # How To Build With A Native Tools Command Prompt
 
-1. Install Visual Studio 2019 16.9 Preview 3 or later.
+1. Install Visual Studio 2019 16.9 Preview 4 or later.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
     * Otherwise, install [CMake][] 3.19 or later, and [Ninja][] 1.10.2 or later.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@ variables:
   buildOutputLocation: 'D:\build'
   vcpkgLocation: '$(Build.SourcesDirectory)/vcpkg'
 
-pool: 'StlBuild-2021-01-20-2'
+pool: 'StlBuild-2021-02-09'
 
 stages:
   - stage: Code_Format
@@ -69,7 +69,7 @@ stages:
           vsDevCmdArch: x86
 
   - stage: Build_And_Test_x64
-    dependsOn: Code_Format
+    dependsOn: Build_And_Test_x86
     displayName: 'Build and Test'
     jobs:
       - template: azure-devops/native-build-test.yml
@@ -78,7 +78,7 @@ stages:
           vsDevCmdArch: amd64
 
   - stage: Build_ARM
-    dependsOn: Code_Format
+    dependsOn: Build_And_Test_x86
     displayName: 'Build'
     jobs:
       - template: azure-devops/cross-build.yml
@@ -87,7 +87,7 @@ stages:
           vsDevCmdArch: arm
 
   - stage: Build_ARM64
-    dependsOn: Code_Format
+    dependsOn: Build_And_Test_x86
     displayName: 'Build'
     jobs:
       - template: azure-devops/cross-build.yml

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.19)
 project(msvc_standard_libraries_tools LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 20)


### PR DESCRIPTION
* README.md
  + Mention Preview 4.
* azure-pipelines.yml
  + Use the new pool.
  + To potentially decrease resource consumption (at the cost of latency), require x86 to succeed before building and testing x64, ARM, and ARM64.
* tools/CMakeLists.txt
  + I've previously forgotten to update the minimum CMake version here.

No product/test changes should be required; x86/x64 passed locally, and I saw no workarounds that can be removed.