### PR TITLE
<xhash>: Fix compiler error when dllexporting a class derived from unordered_set

### DIFF
--- a/stl/inc/xhash
+++ b/stl/inc/xhash
@@ -1841,6 +1841,7 @@ protected:
         }
     }
 
+    template <bool _Multi2 = _Traits::_Multi, enable_if_t<_Multi2, int> = 0>
     _NODISCARD bool _Multi_equal(const _Hash& _Right) const {
         static_assert(_Traits::_Multi, "This function only works with multi containers");
         _STL_INTERNAL_CHECK(this->size() == _Right.size());

--- a/tests/std/test.lst
+++ b/tests/std/test.lst
@@ -173,6 +173,7 @@ tests\GH_001105_custom_streambuf_throws
 tests\GH_001123_random_cast_out_of_range
 tests\GH_001411_core_headers
 tests\GH_001541_case_sensitive_boolalpha
+tests\GH_001638_dllexport_derived_classes
 tests\LWG2597_complex_branch_cut
 tests\LWG3018_shared_ptr_function
 tests\P0019R8_atomic_ref

--- a/tests/std/tests/GH_001638_dllexport_derived_classes/env.lst
+++ b/tests/std/tests/GH_001638_dllexport_derived_classes/env.lst
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+RUNALL_INCLUDE ..\usual_matrix.lst

--- a/tests/std/tests/GH_001638_dllexport_derived_classes/env.lst
+++ b/tests/std/tests/GH_001638_dllexport_derived_classes/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\usual_matrix.lst
+RUNALL_INCLUDE ..\impure_matrix.lst

--- a/tests/std/tests/GH_001638_dllexport_derived_classes/test.compile.pass.cpp
+++ b/tests/std/tests/GH_001638_dllexport_derived_classes/test.compile.pass.cpp
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <array>
+#include <deque>
+#include <forward_list>
+#include <list>
+#include <map>
+#include <queue>
+#include <set>
+#include <stack>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#if _HAS_CXX20
+#include <span>
+#endif // _HAS_CXX20
+
+using namespace std;
+
+int main() {} // COMPILE-ONLY
+
+#pragma warning(disable : 4251) // class 'A' needs to have dll-interface to be used by clients of class 'B'
+#pragma warning(disable : 4275) // non dll-interface struct 'A' used as base for dll-interface class 'B'
+
+struct __declspec(dllexport) ExportedArray : array<int, 3> {};
+struct __declspec(dllexport) ExportedArrayZero : array<int, 0> {};
+struct __declspec(dllexport) ExportedDeque : deque<int> {};
+struct __declspec(dllexport) ExportedForwardList : forward_list<int> {};
+struct __declspec(dllexport) ExportedList : list<int> {};
+struct __declspec(dllexport) ExportedVector : vector<int> {};
+struct __declspec(dllexport) ExportedVectorBool : vector<bool> {};
+
+struct __declspec(dllexport) ExportedMap : map<int, int> {};
+struct __declspec(dllexport) ExportedMultimap : multimap<int, int> {};
+struct __declspec(dllexport) ExportedSet : set<int> {};
+struct __declspec(dllexport) ExportedMultiset : multiset<int> {};
+
+struct __declspec(dllexport) ExportedUnorderedMap : unordered_map<int, int> {};
+struct __declspec(dllexport) ExportedUnorderedMultimap : unordered_multimap<int, int> {};
+struct __declspec(dllexport) ExportedUnorderedSet : unordered_set<int> {};
+struct __declspec(dllexport) ExportedUnorderedMultiset : unordered_multiset<int> {};
+
+struct __declspec(dllexport) ExportedQueue : queue<int> {};
+struct __declspec(dllexport) ExportedPriorityQueue : priority_queue<int> {};
+struct __declspec(dllexport) ExportedStack : stack<int> {};
+
+#if _HAS_CXX20
+struct __declspec(dllexport) ExportedSpan : span<int> {};
+struct __declspec(dllexport) ExportedSpanThree : span<int, 3> {};
+#endif // _HAS_CXX20


### PR DESCRIPTION
Fixes #1638.

Ordinarily, member functions of a class template are instantiated "on demand" when they're called. (I always remember this as being what allows `list<T>` to not require `operator<` from `T`, unless and until `list<T>::sort()` is called.) However, if a user derives from a Standard class template, and then `__declspec(dllexport)`s their derived class, all of the member functions of the Standard class template must be instantiated.

This is how #423 caused a regression in VS 2019 16.6. `_Hash::_Multi_equal()` is called only for multi containers (`unordered_multimap` and `unordered_multiset`), so it `static_assert`s that `_Traits::_Multi` is `true`. However, `dllexport` can attempt to instantiate this for the unique containers (`unordered_map` and `unordered_set`).

There are several possible fixes, but I felt that the least invasive was to make `_Multi_equal()` a member function template. That alone would be sufficient (i.e. `template <int = 0>` would work), but constraining it to exist for multi containers is simple. I left the `static_assert` alone, as it provides a bit of an explanation, even though it is redundant with the constraint now.

I am also adding a regression test, as this is an uncommon but recurring headache in the containers. This covers all of the containers, container adaptors, and views in the Containers clause - which are the most likely to be affected, as they sometimes have conditionally activated code like this. In theory, this test could be extended to cover any Standard type; if we encounter problems in the future, it is easy to extend, but right now having something is better than nothing.