### PR TITLE
feature/spaceship: Clause 23: Iterators

### DIFF
--- a/stl/inc/iterator
+++ b/stl/inc/iterator
@@ -302,11 +302,13 @@ _NODISCARD bool operator==(const istream_iterator<_Ty, _Elem, _Traits, _Diff>& _
     return _Left._Equal(_Right);
 }
 
+#if !_HAS_CXX20
 template <class _Ty, class _Elem, class _Traits, class _Diff>
 _NODISCARD bool operator!=(const istream_iterator<_Ty, _Elem, _Traits, _Diff>& _Left,
     const istream_iterator<_Ty, _Elem, _Traits, _Diff>& _Right) noexcept /* strengthened */ {
     return !(_Left == _Right);
 }
+#endif // !_HAS_CXX20
 
 // CLASS TEMPLATE ostream_iterator
 template <class _Ty, class _Elem = char, class _Traits = char_traits<_Elem>>
@@ -488,11 +490,13 @@ _NODISCARD bool operator==(
     return _Left.equal(_Right);
 }
 
+#if !_HAS_CXX20
 template <class _Elem, class _Traits>
 _NODISCARD bool operator!=(
     const istreambuf_iterator<_Elem, _Traits>& _Left, const istreambuf_iterator<_Elem, _Traits>& _Right) {
     return !(_Left == _Right);
 }
+#endif // !_HAS_CXX20
 
 // CLASS TEMPLATE ostreambuf_iterator
 template <class _Elem, class _Traits>

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -661,6 +661,9 @@ std/utilities/memory/util.smartptr/util.smartptr.shared/libcxx.control_block_lay
 # Non-Standard assumption that std::filesystem::file_time_type::duration::period is std::nano
 std/input.output/filesystems/fs.filesystem.synopsis/file_time_type_resolution.compile.pass.cpp FAIL
 
+# P1614R2 "Adding Spaceship <=> To The Library" makes `std::operator!=(i1, i3)` an error
+std/iterators/stream.iterators/istream.iterator/istream.iterator.ops/equal.pass.cpp FAIL
+
 
 # *** LIKELY STL BUGS ***
 # Not yet analyzed, likely STL bugs. Assertions and other runtime failures.

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -661,6 +661,9 @@ utilities\memory\util.smartptr\util.smartptr.shared\libcxx.control_block_layout.
 # Non-Standard assumption that std::filesystem::file_time_type::duration::period is std::nano
 input.output\filesystems\fs.filesystem.synopsis\file_time_type_resolution.compile.pass.cpp
 
+# P1614R2 "Adding Spaceship <=> To The Library" makes `std::operator!=(i1, i3)` an error
+iterators\stream.iterators\istream.iterator\istream.iterator.ops\equal.pass.cpp
+
 
 # *** LIKELY STL BUGS ***
 # Not yet analyzed, likely STL bugs. Assertions and other runtime failures.


### PR DESCRIPTION
Works towards #62.

@CaseyCarter and I audited WG21-P1614's changes to Clause 23 Iterators, and found that everything was already implemented (in `main`, not just `feature/spaceship`) with the exception of `operator!=` removal for `istream_iterator` and `istreambuf_iterator`. I've implemented those removals for C++20 mode.

In general, we believe that `operator!=` removal doesn't merit the addition of test coverage - we should already have been testing `!=`, and now the compiler will rewrite it for us. In this case, we need to skip a libcxx test, as they were directly calling `std::operator!=` which this C++20 feature intentionally makes into an error.

Two notes from our investigation:

(1) `unreachable_sentinel_t`
---
WG21-N4878 [unreachable.sentinel]/2 depicts a by-value parameter:
```cpp
struct unreachable_sentinel_t {
  template<weakly_incrementable I>
    friend constexpr bool operator==(unreachable_sentinel_t, const I&) noexcept
    { return false; }
};
```
while we implement a by-reference parameter:
https://github.com/microsoft/STL/blob/7f08bb3887f32156df003458b2de71fffbfe59e5/stl/inc/xutility#L4014
The difference is essentially unobservable, and a significant restructuring would be required in order to take `unreachable_sentinel_t` by value while preserving our compiler throughput workaround for MSVC permissive mode - not worth it.

(2) `common_iterator`
---
WG21-N4878 [common.iter.cmp] depicts two overloads:
```cpp
template<class I2, sentinel_for<I> S2>
  requires sentinel_for<S, I2>
friend bool operator==(
  const common_iterator& x, const common_iterator<I2, S2>& y);

template<class I2, sentinel_for<I> S2>
  requires sentinel_for<S, I2> && equality_comparable_with<I, I2>
friend bool operator==(
  const common_iterator& x, const common_iterator<I2, S2>& y);
```
while we implement one overload:
https://github.com/microsoft/STL/blob/7f08bb3887f32156df003458b2de71fffbfe59e5/stl/inc/iterator#L937-L964

This is conformant, as the `if constexpr (equality_comparable_with<_Iter, _OIter>)` implements the behavior of the two-overload set, with far less code repetition and compiler throughput impact.