### PR TITLE
Status Chart: Weekly update, strict mode

### DIFF
--- a/daily_table.js
+++ b/daily_table.js
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 // Generated file - DO NOT EDIT manually!
+'use strict';
 const daily_table = [
     { date: '2019-09-05', merged: 3.00, pr: 1, cxx20: 60, lwg: 7, issue: 5, bug: 0, avg_age: 0.23, avg_wait: 0.23, sum_age: 0.01, sum_wait: 0.01, },
     { date: '2019-09-06', merged: 6.00, pr: 1, cxx20: 60, lwg: 7, issue: 6, bug: 0, avg_age: 0.03, avg_wait: 0.03, sum_age: 0.00, sum_wait: 0.00, },
@@ -526,5 +527,12 @@ const daily_table = [
     { date: '2021-02-06', merged: 28.70, pr: 44, cxx20: 12, cxx23: 4, lwg: 2, issue: 319, bug: 104, avg_age: 92.32, avg_wait: 75.54, sum_age: 135.41, sum_wait: 110.79, },
     { date: '2021-02-07', merged: 28.15, pr: 45, cxx20: 12, cxx23: 4, lwg: 2, issue: 319, bug: 104, avg_age: 91.25, avg_wait: 74.84, sum_age: 136.88, sum_wait: 112.26, },
     { date: '2021-02-08', merged: 27.59, pr: 46, cxx20: 12, cxx23: 4, lwg: 2, issue: 319, bug: 104, avg_age: 90.26, avg_wait: 74.21, sum_age: 138.40, sum_wait: 113.78, },
+    { date: '2021-02-09', merged: 27.99, pr: 49, cxx20: 12, cxx23: 4, lwg: 2, issue: 319, bug: 104, avg_age: 85.70, avg_wait: 70.55, sum_age: 139.98, sum_wait: 115.22, },
+    { date: '2021-02-10', merged: 27.36, pr: 50, cxx20: 12, cxx23: 4, lwg: 2, issue: 321, bug: 105, avg_age: 84.97, avg_wait: 70.07, sum_age: 141.62, sum_wait: 116.78, },
+    { date: '2021-02-11', merged: 27.66, pr: 49, cxx20: 12, cxx23: 4, lwg: 2, issue: 324, bug: 105, avg_age: 87.60, avg_wait: 69.34, sum_age: 143.07, sum_wait: 113.26, },
+    { date: '2021-02-12', merged: 36.96, pr: 40, cxx20: 12, cxx23: 4, lwg: 2, issue: 321, bug: 103, avg_age: 105.37, avg_wait: 81.87, sum_age: 140.50, sum_wait: 109.15, },
+    { date: '2021-02-13', merged: 36.26, pr: 41, cxx20: 12, cxx23: 4, lwg: 2, issue: 322, bug: 104, avg_age: 103.80, avg_wait: 80.86, sum_age: 141.86, sum_wait: 110.51, },
+    { date: '2021-02-14', merged: 35.59, pr: 41, cxx20: 12, cxx23: 4, lwg: 2, issue: 322, bug: 104, avg_age: 104.80, avg_wait: 81.86, sum_age: 143.22, sum_wait: 111.88, },
+    { date: '2021-02-15', merged: 34.79, pr: 42, cxx20: 12, cxx23: 4, lwg: 2, issue: 322, bug: 104, avg_age: 103.29, avg_wait: 80.90, sum_age: 144.60, sum_wait: 113.26, },
 ];
 // Generated file - DO NOT EDIT manually!

--- a/gather_stats.js
+++ b/gather_stats.js
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+'use strict';
+
 const fs = require('fs');
 
 const cliProgress = require('cli-progress');
@@ -313,6 +315,7 @@ function write_generated_file(filename, table_str) {
     let str = '// Copyright (c) Microsoft Corporation.\n';
     str += '// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception\n\n';
     str += generated_file_warning_comment;
+    str += "'use strict';\n";
     str += table_str;
     str += generated_file_warning_comment;
 

--- a/index.html
+++ b/index.html
@@ -35,6 +35,8 @@
     <script src="weekly_table.js"></script>
     <script src="monthly_table.js"></script>
     <script>
+        'use strict';
+
         function get_values(table, key) {
             return table.filter(row => row[key] !== undefined).map(row => ({ x: row.date, y: row[key] }));
         }

--- a/monthly_table.js
+++ b/monthly_table.js
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 // Generated file - DO NOT EDIT manually!
+'use strict';
 const monthly_table = [
     { date: '2019-10-16', merge_bar: 29, },
     { date: '2019-11-16', merge_bar: 20, },

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@octokit/graphql": "^4.6.0",
         "cli-progress": "^3.9.0",
         "dotenv": "^8.2.0",
-        "luxon": "^1.25.0",
+        "luxon": "^1.26.0",
         "yargs": "^16.2.0"
       }
     },
@@ -37,9 +37,9 @@
       }
     },
     "node_modules/@octokit/openapi-types": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-4.0.1.tgz",
-      "integrity": "sha512-k2hRcfcLRyPJjtYfJLzg404n7HZ6sUpAWAR/uNI8tf96NgatWOpw1ocdF+WFfx/trO1ivBh7ckynO1rn+xAw/Q=="
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-4.0.4.tgz",
+      "integrity": "sha512-31zY8JIuz3h6RAFOnyA8FbOwhILILiBu1qD81RyZZWY7oMBhIdBn6MaAmnnptLhB4jk0g50nkQkUVP4kUzppcA=="
     },
     "node_modules/@octokit/request": {
       "version": "5.4.14",
@@ -67,18 +67,12 @@
       }
     },
     "node_modules/@octokit/types": {
-      "version": "6.8.2",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.8.2.tgz",
-      "integrity": "sha512-RpG0NJd7OKSkWptiFhy1xCLkThs5YoDIKM21lEtDmUvSpbaIEfrxzckWLUGDFfF8RydSyngo44gDv8m2hHruUg==",
+      "version": "6.8.5",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.8.5.tgz",
+      "integrity": "sha512-ZsQawftZoi0kSF2pCsdgLURbOjtVcHnBOXiSxBKSNF56CRjARt5rb/g8WJgqB8vv4lgUEHrv06EdDKYQ22vA9Q==",
       "dependencies": {
-        "@octokit/openapi-types": "^4.0.0",
-        "@types/node": ">= 8"
+        "@octokit/openapi-types": "^4.0.3"
       }
-    },
-    "node_modules/@types/node": {
-      "version": "14.14.25",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.25.tgz",
-      "integrity": "sha512-EPpXLOVqDvisVxtlbvzfyqSsFeQxltFbluZNRndIb8tr9KiBnYNLzrc1N3pyKUCww2RNrfHDViqDWWE1LCJQtQ=="
     },
     "node_modules/ansi-regex": {
       "version": "5.0.0",
@@ -199,9 +193,9 @@
       }
     },
     "node_modules/luxon": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.25.0.tgz",
-      "integrity": "sha512-hEgLurSH8kQRjY6i4YLey+mcKVAWXbDNlZRmM6AgWDJ1cY3atl8Ztf5wEY7VBReFbmGnwQPz7KYJblL8B2k0jQ==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.26.0.tgz",
+      "integrity": "sha512-+V5QIQ5f6CDXQpWNICELwjwuHdqeJM1UenlZWx5ujcRMc9venvluCjFb4t5NYLhb6IhkbMVOxzVuOqkgMxee2A==",
       "engines": {
         "node": "*"
       }
@@ -306,9 +300,9 @@
       }
     },
     "node_modules/yargs-parser": {
-      "version": "20.2.4",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
-      "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+      "version": "20.2.5",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.5.tgz",
+      "integrity": "sha512-jYRGS3zWy20NtDtK2kBgo/TlAoy5YUuhD9/LZ7z7W4j1Fdw2cqD0xEEclf8fxc8xjD6X5Qr+qQQwCEsP8iRiYg==",
       "engines": {
         "node": ">=10"
       }
@@ -336,9 +330,9 @@
       }
     },
     "@octokit/openapi-types": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-4.0.1.tgz",
-      "integrity": "sha512-k2hRcfcLRyPJjtYfJLzg404n7HZ6sUpAWAR/uNI8tf96NgatWOpw1ocdF+WFfx/trO1ivBh7ckynO1rn+xAw/Q=="
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-4.0.4.tgz",
+      "integrity": "sha512-31zY8JIuz3h6RAFOnyA8FbOwhILILiBu1qD81RyZZWY7oMBhIdBn6MaAmnnptLhB4jk0g50nkQkUVP4kUzppcA=="
     },
     "@octokit/request": {
       "version": "5.4.14",
@@ -366,18 +360,12 @@
       }
     },
     "@octokit/types": {
-      "version": "6.8.2",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.8.2.tgz",
-      "integrity": "sha512-RpG0NJd7OKSkWptiFhy1xCLkThs5YoDIKM21lEtDmUvSpbaIEfrxzckWLUGDFfF8RydSyngo44gDv8m2hHruUg==",
+      "version": "6.8.5",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.8.5.tgz",
+      "integrity": "sha512-ZsQawftZoi0kSF2pCsdgLURbOjtVcHnBOXiSxBKSNF56CRjARt5rb/g8WJgqB8vv4lgUEHrv06EdDKYQ22vA9Q==",
       "requires": {
-        "@octokit/openapi-types": "^4.0.0",
-        "@types/node": ">= 8"
+        "@octokit/openapi-types": "^4.0.3"
       }
-    },
-    "@types/node": {
-      "version": "14.14.25",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.25.tgz",
-      "integrity": "sha512-EPpXLOVqDvisVxtlbvzfyqSsFeQxltFbluZNRndIb8tr9KiBnYNLzrc1N3pyKUCww2RNrfHDViqDWWE1LCJQtQ=="
     },
     "ansi-regex": {
       "version": "5.0.0",
@@ -465,9 +453,9 @@
       "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
     },
     "luxon": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.25.0.tgz",
-      "integrity": "sha512-hEgLurSH8kQRjY6i4YLey+mcKVAWXbDNlZRmM6AgWDJ1cY3atl8Ztf5wEY7VBReFbmGnwQPz7KYJblL8B2k0jQ=="
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.26.0.tgz",
+      "integrity": "sha512-+V5QIQ5f6CDXQpWNICELwjwuHdqeJM1UenlZWx5ujcRMc9venvluCjFb4t5NYLhb6IhkbMVOxzVuOqkgMxee2A=="
     },
     "node-fetch": {
       "version": "2.6.1",
@@ -545,9 +533,9 @@
       }
     },
     "yargs-parser": {
-      "version": "20.2.4",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
-      "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA=="
+      "version": "20.2.5",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.5.tgz",
+      "integrity": "sha512-jYRGS3zWy20NtDtK2kBgo/TlAoy5YUuhD9/LZ7z7W4j1Fdw2cqD0xEEclf8fxc8xjD6X5Qr+qQQwCEsP8iRiYg=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@octokit/graphql": "^4.6.0",
     "cli-progress": "^3.9.0",
     "dotenv": "^8.2.0",
-    "luxon": "^1.25.0",
+    "luxon": "^1.26.0",
     "yargs": "^16.2.0"
   }
 }

--- a/weekly_table.js
+++ b/weekly_table.js
@@ -192,4 +192,5 @@ const weekly_table = [
     { date: '2021-01-22', vso: 152, libcxx: 563 },
     { date: '2021-01-29', vso: 152, libcxx: 563 },
     { date: '2021-02-05', vso: 155, libcxx: 588 },
+    { date: '2021-02-12', vso: 158, libcxx: 570 },
 ];

--- a/weekly_table.js
+++ b/weekly_table.js
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+'use strict';
 const weekly_table = [
     { date: '2017-06-09', cxx17: 17, lwg: 44, vso: 247, libcxx: 526 },
     { date: '2017-06-16', cxx17: 17, lwg: 43, vso: 246, libcxx: 526 },


### PR DESCRIPTION
Today I learned about [JavaScript's strict mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode). This applies strict mode to `gather_stats.js`, `index.html`'s script, and the data tables for good measure. I verified (with temporary console logging) that this takes effect.

Live preview: [stephantlavavej.github.io/STL/](https://stephantlavavej.github.io/STL/)
===