### PR TITLE
Azure Pipelines: Move VMSS location, don't publish artifacts

### DIFF
--- a/azure-devops/create-vmss.ps1
+++ b/azure-devops/create-vmss.ps1
@@ -20,7 +20,7 @@ $ErrorActionPreference = 'Stop'
 # https://aka.ms/azps-changewarnings
 $Env:SuppressAzurePowerShellBreakingChangeWarnings = 'true'
 
-$Location = 'westus2'
+$Location = 'northeurope'
 $Prefix = 'StlBuild-' + (Get-Date -Format 'yyyy-MM-dd')
 $VMSize = 'Standard_D32as_v4'
 $ProtoVMName = 'PROTOTYPE'

--- a/azure-devops/cross-build.yml
+++ b/azure-devops/cross-build.yml
@@ -48,4 +48,4 @@ jobs:
       targetPlatform: ${{ parameters.targetPlatform }}
       targetArch: ${{ parameters.vsDevCmdArch }}
       displayName: 'Build Tests'
-      publishArtifact: true
+      publishArtifact: false # disabled due to GH-1653

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@ variables:
   buildOutputLocation: 'D:\build'
   vcpkgLocation: '$(Build.SourcesDirectory)/vcpkg'
 
-pool: 'StlBuild-2021-02-09'
+pool: 'StlBuild-2021-02-17'
 
 stages:
   - stage: Code_Format


### PR DESCRIPTION
Our Azure Pipelines checks were unable to run for most of Tuesday (2021-02-16), briefly from (Pacific Time) 3:39 PM to 3:49 PM and then continuously from 5:09 PM until now (~2 AM Wednesday), with the error message:

> Failed to increase capacity with error: The requested size for resource '/subscriptions/ddddd02b-5e77-473c-afde-c40253b5343e/resourceGroups/STLBUILD-2021-02-09/providers/Microsoft.Compute/virtualMachineScaleSets/StlBuild-2021-02-09-Vmss' is currently not available in location 'westus2' zones '' for subscription 'ddddd02b-5e77-473c-afde-c40253b5343e'. Please try another size or deploy to a different location or zones. See https://aka.ms/azureskunotavailable for details.

It doesn't appear that we're over budget, and vcpkg was experiencing the same error. Attempting to create VMs of many different SKUs in West US 2 failed, so it's not specific to our current SKU. Attempting to create VMs in West US and South Central US also failed. However, @BillyONeal had the idea to try a different continent (suspecting that recent extreme weather in the US was related), and the first region I tried, North Europe, succeeded.

If this Virtual Machine Scale Set can scale up to handle a build/test run, I think we should switch to it temporarily. We don't perform very much network access (just cloning repos, and we have gone to considerable lengths to minimize how much of llvm-project we download), and it isn't latency-sensitive at all.

And on the topic of network access, I recently noticed that we're uploading and storing a zillion bytes. This PR attempts to fix #1653 in a minimal way, leaving the machinery in place if it needs to be refined in the future.