### PR TITLE
<format>: vformat_to parsing and escaping tests

### DIFF
--- a/stl/inc/format
+++ b/stl/inc/format
@@ -579,7 +579,7 @@ constexpr void _Parse_format_string(basic_string_view<_CharT> _Format_str, _Hand
         const _CharT* _OpeningCurl = _Begin;
         if (*_Begin != '{') {
             // we didn't start at an opening curl, find the next one
-            _OpeningCurl = _STD find(_Begin + 1, _End, '{');
+            _OpeningCurl = _Find_unchecked(_Begin + 1, _End, '{');
             for (;;) {
                 const _CharT* _ClosingCurl = _Find_unchecked(_Begin, _OpeningCurl, '}');
 

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -583,7 +583,7 @@ constexpr void _Parse_format_string(basic_string_view<_CharT> _Format_str, _Hand
             for (;;) {
                 const _CharT* _ClosingCurl = _Find_unchecked(_Begin, _OpeningCurl, '}');
 
-                // In this case we didn't find either a closing curl or opening curl.
+                // In this case there are neither closing nor opening curls in [_Begin, _OpenCurl)
                 // Write the whole thing out.
                 if (_ClosingCurl == _OpeningCurl) {
                     _Handler._On_text(_Begin, _OpeningCurl);

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -586,7 +586,8 @@ constexpr void _Parse_format_string(basic_string_view<_CharT> _Format_str, _Hand
                 // In this case we didn't find either a closing curl or opening curl.
                 // Write the whole thing out.
                 if (_ClosingCurl == _OpeningCurl) {
-                    return _Handler._On_text(_Begin, _OpeningCurl);
+                    _Handler._On_text(_Begin, _OpeningCurl);
+                    break;
                 }
                 // We know _ClosingCurl isn't past the end because
                 // the above condition was not met.

--- a/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
@@ -8,9 +8,71 @@
 #include <string>
 #include <string_view>
 
+using namespace std;
+
 // TODO: fill in tests
-template std::back_insert_iterator<std::string> std::vformat_to(std::back_insert_iterator<std::string>,
-    const std::locale&, std::string_view, std::format_args_t<std::back_insert_iterator<std::string>, char>);
+template back_insert_iterator<string> std::vformat_to(
+    back_insert_iterator<string>, const locale&, string_view, format_args_t<back_insert_iterator<string>, char>);
 
 
-int main() {}
+int main() {
+    string output_string = "";
+
+    vformat_to(back_insert_iterator(output_string), locale::classic(), "f", make_format_args());
+    assert(output_string == "f");
+
+    output_string.clear();
+    vformat_to(back_insert_iterator(output_string), locale::classic(), "format", make_format_args());
+    assert(output_string == "format");
+
+    // test escaped opening curlies
+    output_string.clear();
+    vformat_to(back_insert_iterator(output_string), locale::classic(), "{{", make_format_args());
+    assert(output_string == "{");
+
+    output_string.clear();
+    vformat_to(back_insert_iterator(output_string), locale::classic(), "{{{{", make_format_args());
+    assert(output_string == "{{");
+
+    output_string.clear();
+    vformat_to(back_insert_iterator(output_string), locale::classic(), "x{{", make_format_args());
+    assert(output_string == "x{");
+
+    output_string.clear();
+    vformat_to(back_insert_iterator(output_string), locale::classic(), "{{ {{", make_format_args());
+    assert(output_string == "{ {");
+
+    output_string.clear();
+    vformat_to(back_insert_iterator(output_string), locale::classic(), "x{{x", make_format_args());
+    assert(output_string == "x{x");
+
+    output_string.clear();
+    vformat_to(back_insert_iterator(output_string), locale::classic(), "{{x", make_format_args());
+    assert(output_string == "{x");
+
+    // tests escaped closing curlies
+    output_string.clear();
+    vformat_to(back_insert_iterator(output_string), locale::classic(), "}}", make_format_args());
+    assert(output_string == "}");
+
+    output_string.clear();
+    vformat_to(back_insert_iterator(output_string), locale::classic(), "}}}}", make_format_args());
+    assert(output_string == "}}");
+
+    output_string.clear();
+    vformat_to(back_insert_iterator(output_string), locale::classic(), "x}}", make_format_args());
+    assert(output_string == "x}");
+
+    output_string.clear();
+    vformat_to(back_insert_iterator(output_string), locale::classic(), "}} }}", make_format_args());
+    assert(output_string == "} }");
+
+    output_string.clear();
+    vformat_to(back_insert_iterator(output_string), locale::classic(), "x}}x", make_format_args());
+    assert(output_string == "x}x");
+
+    output_string.clear();
+    vformat_to(back_insert_iterator(output_string), locale::classic(), "}}x", make_format_args());
+    assert(output_string == "}x");
+    return 0;
+}

--- a/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
@@ -25,7 +25,7 @@ int main() {
     vformat_to(back_insert_iterator(output_string), locale::classic(), "format", make_format_args());
     assert(output_string == "format");
 
-    // test escaped opening curlies
+    // test escaped opening curls
     output_string.clear();
     vformat_to(back_insert_iterator(output_string), locale::classic(), "{{", make_format_args());
     assert(output_string == "{");
@@ -50,7 +50,7 @@ int main() {
     vformat_to(back_insert_iterator(output_string), locale::classic(), "{{x", make_format_args());
     assert(output_string == "{x");
 
-    // tests escaped closing curlies
+    // tests escaped closing curls
     output_string.clear();
     vformat_to(back_insert_iterator(output_string), locale::classic(), "}}", make_format_args());
     assert(output_string == "}");

--- a/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
@@ -74,5 +74,6 @@ int main() {
     output_string.clear();
     vformat_to(back_insert_iterator(output_string), locale::classic(), "}}x", make_format_args());
     assert(output_string == "}x");
+
     return 0;
 }


### PR DESCRIPTION
Tests various argumentless calls for vformat_to (the most core of the format functions) and tests that escaped curly braces are escaped correctly.

Fixes a bug caused by not changing "return" to "break" when inlining the _Writer_loop loop.