### PR TITLE
Status Chart: Weekly update, show/hide params

### DIFF
--- a/daily_table.js
+++ b/daily_table.js
@@ -539,5 +539,6 @@ const daily_table = [
     { date: '2021-02-18', merged: 43.21, pr: 35, cxx20: 10, cxx23: 4, lwg: 2, issue: 325, bug: 105, avg_age: 120.54, avg_wait: 96.26, sum_age: 140.64, sum_wait: 112.30, },
     { date: '2021-02-19', merged: 46.35, pr: 35, cxx20: 9, cxx23: 4, lwg: 2, issue: 325, bug: 105, avg_age: 120.39, avg_wait: 96.72, sum_age: 140.45, sum_wait: 112.84, },
     { date: '2021-02-20', merged: 45.45, pr: 38, cxx20: 9, cxx23: 4, lwg: 2, issue: 325, bug: 105, avg_age: 111.85, avg_wait: 90.01, sum_age: 141.68, sum_wait: 114.01, },
+    { date: '2021-02-21', merged: 44.52, pr: 38, cxx20: 9, cxx23: 4, lwg: 2, issue: 325, bug: 105, avg_age: 99.80, avg_wait: 77.96, sum_age: 126.42, sum_wait: 98.74, },
 ];
 // Generated file - DO NOT EDIT manually!

--- a/daily_table.js
+++ b/daily_table.js
@@ -538,5 +538,6 @@ const daily_table = [
     { date: '2021-02-17', merged: 40.06, pr: 37, cxx20: 10, cxx23: 4, lwg: 2, issue: 324, bug: 104, avg_age: 114.11, avg_wait: 91.06, sum_age: 140.73, sum_wait: 112.31, },
     { date: '2021-02-18', merged: 43.21, pr: 35, cxx20: 10, cxx23: 4, lwg: 2, issue: 325, bug: 105, avg_age: 120.54, avg_wait: 96.26, sum_age: 140.64, sum_wait: 112.30, },
     { date: '2021-02-19', merged: 46.35, pr: 35, cxx20: 9, cxx23: 4, lwg: 2, issue: 325, bug: 105, avg_age: 120.39, avg_wait: 96.72, sum_age: 140.45, sum_wait: 112.84, },
+    { date: '2021-02-20', merged: 45.45, pr: 38, cxx20: 9, cxx23: 4, lwg: 2, issue: 325, bug: 105, avg_age: 111.85, avg_wait: 90.01, sum_age: 141.68, sum_wait: 114.01, },
 ];
 // Generated file - DO NOT EDIT manually!

--- a/daily_table.js
+++ b/daily_table.js
@@ -534,5 +534,9 @@ const daily_table = [
     { date: '2021-02-13', merged: 36.26, pr: 41, cxx20: 12, cxx23: 4, lwg: 2, issue: 322, bug: 104, avg_age: 103.80, avg_wait: 80.86, sum_age: 141.86, sum_wait: 110.51, },
     { date: '2021-02-14', merged: 35.59, pr: 41, cxx20: 12, cxx23: 4, lwg: 2, issue: 322, bug: 104, avg_age: 104.80, avg_wait: 81.86, sum_age: 143.22, sum_wait: 111.88, },
     { date: '2021-02-15', merged: 34.79, pr: 42, cxx20: 12, cxx23: 4, lwg: 2, issue: 322, bug: 104, avg_age: 103.29, avg_wait: 80.90, sum_age: 144.60, sum_wait: 113.26, },
+    { date: '2021-02-16', merged: 33.91, pr: 42, cxx20: 12, cxx23: 4, lwg: 2, issue: 323, bug: 104, avg_age: 104.29, avg_wait: 80.11, sum_age: 146.00, sum_wait: 112.16, },
+    { date: '2021-02-17', merged: 40.06, pr: 37, cxx20: 10, cxx23: 4, lwg: 2, issue: 324, bug: 104, avg_age: 114.11, avg_wait: 91.06, sum_age: 140.73, sum_wait: 112.31, },
+    { date: '2021-02-18', merged: 43.21, pr: 35, cxx20: 10, cxx23: 4, lwg: 2, issue: 325, bug: 105, avg_age: 120.54, avg_wait: 96.26, sum_age: 140.64, sum_wait: 112.30, },
+    { date: '2021-02-19', merged: 46.35, pr: 35, cxx20: 9, cxx23: 4, lwg: 2, issue: 325, bug: 105, avg_age: 120.39, avg_wait: 96.72, sum_age: 140.45, sum_wait: 112.84, },
 ];
 // Generated file - DO NOT EDIT manually!

--- a/index.html
+++ b/index.html
@@ -41,6 +41,20 @@
             return table.filter(row => row[key] !== undefined).map(row => ({ x: row.date, y: row[key] }));
         }
 
+        const url_search_params = new URLSearchParams(window.location.search);
+
+        function get_hidden(key, default_value = false) {
+            const value = url_search_params.get(key);
+
+            if (value === 'hide') {
+                return true;
+            } else if (value === 'show') {
+                return false;
+            } else {
+                return default_value;
+            }
+        }
+
         const status_data = {
             datasets: [
                 {
@@ -49,6 +63,7 @@
                     borderColor: '#9966FF',
                     backgroundColor: '#9966FF',
                     yAxisID: 'smallAxis',
+                    hidden: get_hidden('cxx17'),
                 },
                 {
                     data: get_values(weekly_table, 'cxx20').concat(get_values(daily_table, 'cxx20')),
@@ -56,6 +71,7 @@
                     borderColor: '#7030A0',
                     backgroundColor: '#7030A0',
                     yAxisID: 'smallAxis',
+                    hidden: get_hidden('cxx20'),
                 },
                 {
                     data: get_values(weekly_table, 'cxx23').concat(get_values(daily_table, 'cxx23')),
@@ -64,6 +80,7 @@
                     backgroundColor: '#9966FF',
                     borderDash: [10, 5],
                     yAxisID: 'smallAxis',
+                    hidden: get_hidden('cxx23'),
                 },
                 {
                     data: get_values(weekly_table, 'lwg').concat(get_values(daily_table, 'lwg')),
@@ -71,6 +88,7 @@
                     borderColor: '#0070C0',
                     backgroundColor: '#0070C0',
                     yAxisID: 'smallAxis',
+                    hidden: get_hidden('lwg'),
                 },
                 {
                     data: get_values(daily_table, 'pr'),
@@ -78,6 +96,7 @@
                     borderColor: '#00B050',
                     backgroundColor: '#00B050',
                     yAxisID: 'smallAxis',
+                    hidden: get_hidden('pr'),
                 },
                 {
                     data: get_values(weekly_table, 'vso'),
@@ -85,6 +104,7 @@
                     borderColor: '#900000',
                     backgroundColor: '#900000',
                     yAxisID: 'largeAxis',
+                    hidden: get_hidden('vso'),
                 },
                 {
                     data: get_values(daily_table, 'bug'),
@@ -92,6 +112,7 @@
                     borderColor: '#FF0000',
                     backgroundColor: '#FF0000',
                     yAxisID: 'largeAxis',
+                    hidden: get_hidden('bug'),
                 },
                 {
                     data: get_values(daily_table, 'issue'),
@@ -99,6 +120,7 @@
                     borderColor: '#909090',
                     backgroundColor: '#909090',
                     yAxisID: 'largeAxis',
+                    hidden: get_hidden('issue'),
                 },
                 {
                     data: get_values(weekly_table, 'libcxx'),
@@ -106,6 +128,7 @@
                     borderColor: '#FFC000',
                     backgroundColor: '#FFC000',
                     yAxisID: 'largeAxis',
+                    hidden: get_hidden('libcxx'),
                 },
             ],
         };
@@ -118,7 +141,7 @@
                     borderColor: '#909090',
                     backgroundColor: '#909090',
                     yAxisID: 'leftAxis',
-                    hidden: true,
+                    hidden: get_hidden('avg_age', true),
                 },
                 {
                     data: get_values(daily_table, 'avg_wait'),
@@ -126,7 +149,7 @@
                     borderColor: '#FF9090',
                     backgroundColor: '#FF9090',
                     yAxisID: 'leftAxis',
-                    hidden: true,
+                    hidden: get_hidden('avg_wait', true),
                 },
                 {
                     data: get_values(daily_table, 'sum_age'),
@@ -134,6 +157,7 @@
                     borderColor: '#000000',
                     backgroundColor: '#000000',
                     yAxisID: 'rightAxis',
+                    hidden: get_hidden('sum_age'),
                 },
                 {
                     data: get_values(daily_table, 'sum_wait'),
@@ -141,6 +165,7 @@
                     borderColor: '#FF0000',
                     backgroundColor: '#FF0000',
                     yAxisID: 'rightAxis',
+                    hidden: get_hidden('sum_wait'),
                 },
             ],
         };
@@ -153,6 +178,7 @@
                     borderColor: '#00B050',
                     backgroundColor: '#00B050',
                     yAxisID: 'mergeAxis',
+                    hidden: get_hidden('merged'),
                 },
                 {
                     type: 'bar',
@@ -160,6 +186,7 @@
                     label: 'Bars: Calendar Months',
                     borderWidth: 1,
                     yAxisID: 'mergeAxis',
+                    hidden: get_hidden('merge_bar'),
                 },
             ],
         };

--- a/package-lock.json
+++ b/package-lock.json
@@ -300,9 +300,9 @@
       }
     },
     "node_modules/yargs-parser": {
-      "version": "20.2.5",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.5.tgz",
-      "integrity": "sha512-jYRGS3zWy20NtDtK2kBgo/TlAoy5YUuhD9/LZ7z7W4j1Fdw2cqD0xEEclf8fxc8xjD6X5Qr+qQQwCEsP8iRiYg==",
+      "version": "20.2.6",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.6.tgz",
+      "integrity": "sha512-AP1+fQIWSM/sMiET8fyayjx/J+JmTPt2Mr0FkrgqB4todtfa53sOsrSAcIrJRD5XS20bKUwaDIuMkWKCEiQLKA==",
       "engines": {
         "node": ">=10"
       }
@@ -533,9 +533,9 @@
       }
     },
     "yargs-parser": {
-      "version": "20.2.5",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.5.tgz",
-      "integrity": "sha512-jYRGS3zWy20NtDtK2kBgo/TlAoy5YUuhD9/LZ7z7W4j1Fdw2cqD0xEEclf8fxc8xjD6X5Qr+qQQwCEsP8iRiYg=="
+      "version": "20.2.6",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.6.tgz",
+      "integrity": "sha512-AP1+fQIWSM/sMiET8fyayjx/J+JmTPt2Mr0FkrgqB4todtfa53sOsrSAcIrJRD5XS20bKUwaDIuMkWKCEiQLKA=="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,9 +37,9 @@
       }
     },
     "node_modules/@octokit/openapi-types": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-4.0.4.tgz",
-      "integrity": "sha512-31zY8JIuz3h6RAFOnyA8FbOwhILILiBu1qD81RyZZWY7oMBhIdBn6MaAmnnptLhB4jk0g50nkQkUVP4kUzppcA=="
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-5.1.0.tgz",
+      "integrity": "sha512-bodZvSYgycbUuuKrC/anCBUExvaSSWzMMFz0xl7pcJujxnmGxvqvcFHktjx1ZOSyeNKLfYF0QCgibaHUGsZTng=="
     },
     "node_modules/@octokit/request": {
       "version": "5.4.14",
@@ -67,11 +67,11 @@
       }
     },
     "node_modules/@octokit/types": {
-      "version": "6.8.5",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.8.5.tgz",
-      "integrity": "sha512-ZsQawftZoi0kSF2pCsdgLURbOjtVcHnBOXiSxBKSNF56CRjARt5rb/g8WJgqB8vv4lgUEHrv06EdDKYQ22vA9Q==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.10.0.tgz",
+      "integrity": "sha512-aMDo10kglofejJ96edCBIgQLVuzMDyjxmhdgEcoUUD64PlHYSrNsAGqN0wZtoiX4/PCQ3JLA50IpkP1bcKD/cA==",
       "dependencies": {
-        "@octokit/openapi-types": "^4.0.3"
+        "@octokit/openapi-types": "^5.1.0"
       }
     },
     "node_modules/ansi-regex": {
@@ -330,9 +330,9 @@
       }
     },
     "@octokit/openapi-types": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-4.0.4.tgz",
-      "integrity": "sha512-31zY8JIuz3h6RAFOnyA8FbOwhILILiBu1qD81RyZZWY7oMBhIdBn6MaAmnnptLhB4jk0g50nkQkUVP4kUzppcA=="
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-5.1.0.tgz",
+      "integrity": "sha512-bodZvSYgycbUuuKrC/anCBUExvaSSWzMMFz0xl7pcJujxnmGxvqvcFHktjx1ZOSyeNKLfYF0QCgibaHUGsZTng=="
     },
     "@octokit/request": {
       "version": "5.4.14",
@@ -360,11 +360,11 @@
       }
     },
     "@octokit/types": {
-      "version": "6.8.5",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.8.5.tgz",
-      "integrity": "sha512-ZsQawftZoi0kSF2pCsdgLURbOjtVcHnBOXiSxBKSNF56CRjARt5rb/g8WJgqB8vv4lgUEHrv06EdDKYQ22vA9Q==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.10.0.tgz",
+      "integrity": "sha512-aMDo10kglofejJ96edCBIgQLVuzMDyjxmhdgEcoUUD64PlHYSrNsAGqN0wZtoiX4/PCQ3JLA50IpkP1bcKD/cA==",
       "requires": {
-        "@octokit/openapi-types": "^4.0.3"
+        "@octokit/openapi-types": "^5.1.0"
       }
     },
     "ansi-regex": {

--- a/weekly_table.js
+++ b/weekly_table.js
@@ -194,4 +194,5 @@ const weekly_table = [
     { date: '2021-01-29', vso: 152, libcxx: 563 },
     { date: '2021-02-05', vso: 155, libcxx: 588 },
     { date: '2021-02-12', vso: 158, libcxx: 570 },
+    { date: '2021-02-19', vso: 159, libcxx: 579 },
 ];


### PR DESCRIPTION
9 features remaining!

This implements a new Status Chart feature: it can now be passed a query string to show/hide (usually hide) lines, which can be convenient if you want to link to *just* the C++20 line, for example.

I chose `show` and `hide` for maximum clarity (instead of `y`/`n` etc.). In the future, I'll probably teach the Status Chart to update the query string when the legend is clicked. For now, the query string is undocumented - you have to read the source to know the key names used.

Live preview: [stephantlavavej.github.io/STL/](https://stephantlavavej.github.io/STL/)
===

Query string preview: [stephantlavavej.github.io/STL/?cxx17=hide&cxx23=hide&lwg=hide&pr=hide&vso=hide&bug=hide&issue=hide&libcxx=hide](https://stephantlavavej.github.io/STL/?cxx17=hide&cxx23=hide&lwg=hide&pr=hide&vso=hide&bug=hide&issue=hide&libcxx=hide)
