### PR TITLE
feature/spaceship: Clause 17: Feature-test macro, yvals_core.h comment

### DIFF
--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -208,6 +208,7 @@
 // P1456R1 Move-Only Views
 // P1474R1 Helpful Pointers For contiguous_iterator
 // P1612R1 Relocating endian To <bit>
+// P1614R2 Adding Spaceship <=> To The Library
 // P1645R1 constexpr For <numeric> Algorithms
 // P1651R0 bind_front() Should Not Unwrap reference_wrapper
 // P1690R1 Refining Heterogeneous Lookup For Unordered Containers
@@ -1248,7 +1249,7 @@
 #define __cpp_lib_starts_ends_with        201711L
 
 #ifdef __cpp_lib_concepts // TRANSITION, GH-395
-#define __cpp_lib_three_way_comparison 201711L
+#define __cpp_lib_three_way_comparison 201907L
 #endif // __cpp_lib_concepts
 
 #define __cpp_lib_to_address    201711L

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -320,9 +320,6 @@ std/language.support/support.limits/support.limits.general/functional.version.pa
 std/language.support/support.limits/support.limits.general/iterator.version.pass.cpp FAIL
 std/language.support/support.limits/support.limits.general/memory.version.pass.cpp FAIL
 
-# C++20 P1614R2 "Adding Spaceship <=> To The Library"
-std/language.support/support.limits/support.limits.general/compare.version.pass.cpp FAIL
-
 # C++23 P1048R1 "is_scoped_enum"
 std/utilities/meta/meta.unary/meta.unary.prop/is_scoped_enum.pass.cpp FAIL
 

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -320,9 +320,6 @@ language.support\support.limits\support.limits.general\functional.version.pass.c
 language.support\support.limits\support.limits.general\iterator.version.pass.cpp
 language.support\support.limits\support.limits.general\memory.version.pass.cpp
 
-# C++20 P1614R2 "Adding Spaceship <=> To The Library"
-language.support\support.limits\support.limits.general\compare.version.pass.cpp
-
 # C++23 P1048R1 "is_scoped_enum"
 utilities\meta\meta.unary\meta.unary.prop\is_scoped_enum.pass.cpp
 

--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
@@ -1406,10 +1406,10 @@ STATIC_ASSERT(__cpp_lib_string_view == 201803L);
 #if _HAS_CXX20 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
 #ifndef __cpp_lib_three_way_comparison
 #error __cpp_lib_three_way_comparison is not defined
-#elif __cpp_lib_three_way_comparison != 201711L
-#error __cpp_lib_three_way_comparison is not 201711L
+#elif __cpp_lib_three_way_comparison != 201907L
+#error __cpp_lib_three_way_comparison is not 201907L
 #else
-STATIC_ASSERT(__cpp_lib_three_way_comparison == 201711L);
+STATIC_ASSERT(__cpp_lib_three_way_comparison == 201907L);
 #endif
 #else
 #ifdef __cpp_lib_three_way_comparison


### PR DESCRIPTION
Works towards #62.

This adds [P1614R2](https://wg21.link/P1614R2) Adding Spaceship `<=>` To The Library to `yvals_core.h`'s list of `_HAS_CXX20` features, and increases the value of the feature-test macro as specified in WG21-N4878 (see [SD-FeatureTest](https://isocpp.org/std/standing-documents/sd-6-sg10-feature-test-recommendations) to double-check). The feature-test macro remains additionally guarded by `__cpp_lib_concepts`. Finally, this updates the test accordingly, and unskips libcxx's test.

After this PR, the only remaining work for Clause 17 Language Support is #489 (where we need compiler support).