### PR TITLE
<format>: initial replacement field tests (and numeric arg indexing)

### DIFF
--- a/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
@@ -9,7 +9,7 @@
 #include <string_view>
 
 using namespace std;
-
+using namespace std::string_view_literals;
 // TODO: fill in tests
 template back_insert_iterator<string> std::vformat_to(
     back_insert_iterator<string>, const locale&, string_view, format_args_t<back_insert_iterator<string>, char>);
@@ -74,6 +74,27 @@ int main() {
     output_string.clear();
     vformat_to(back_insert_iterator(output_string), locale::classic(), "}}x", make_format_args());
     assert(output_string == "}x");
+
+    output_string.clear();
+    vformat_to(back_insert_iterator(output_string), locale::classic(), "{}", make_format_args((const char*) "f"));
+    assert(output_string == "f");
+
+    output_string.clear();
+    vformat_to(back_insert_iterator(output_string), locale::classic(), "{0} {0}", make_format_args((const char*) "f"));
+    assert(output_string == "f f");
+
+    // TODO: enable these in _Write function PR for sv and bool
+    /*
+    output_string.clear();
+    vformat_to(back_insert_iterator(output_string), locale::classic(), "{}", make_format_args("f"sv));
+    assert(output_string == "f");
+    */
+
+    /*
+    output_string.clear();
+    vformat_to(back_insert_iterator(output_string), locale::classic(), "{}", make_format_args(true));
+    assert(output_string == "true");
+    */
 
     return 0;
 }

--- a/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
@@ -9,7 +9,6 @@
 #include <string_view>
 
 using namespace std;
-using namespace std::string_view_literals;
 // TODO: fill in tests
 template back_insert_iterator<string> std::vformat_to(
     back_insert_iterator<string>, const locale&, string_view, format_args_t<back_insert_iterator<string>, char>);


### PR DESCRIPTION
adds simple tests for replacement fields and arg-id based indexing.

some fun facts:
* it looks like `make_format_args("f")` does not work because format_args_store doesn't understand char (&)[N]. This is a bug that's probably a very simple fix in format_arg_store (a decay_t around line 845 is probably all that's needed). I want to talk to miscco first to see if there's anything I'm missing but I'll have a PR that does that tonight if possible.
* commented tests are for writer functions that are to be implemented in an upcoming PR from Elnar, He'll uncomment them in his PR.
