### PR TITLE
<memory>: Guard aligned allocation with __cpp_aligned_new

### DIFF
--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -2070,20 +2070,26 @@ template <class _Refc>
 _NODISCARD _Refc* _Allocate_flexible_array(const size_t _Count) {
     const size_t _Bytes     = _Calculate_bytes_for_flexible_array<_Refc, _Check_overflow::_Yes>(_Count);
     constexpr size_t _Align = alignof(_Refc);
-    if constexpr (_Align <= __STDCPP_DEFAULT_NEW_ALIGNMENT__) {
-        return static_cast<_Refc*>(::operator new(_Bytes));
-    } else {
+#ifdef __cpp_aligned_new
+    if constexpr (_Align > __STDCPP_DEFAULT_NEW_ALIGNMENT__) {
         return static_cast<_Refc*>(::operator new (_Bytes, align_val_t{_Align}));
+    } else
+#endif // __cpp_aligned_new
+    {
+        return static_cast<_Refc*>(::operator new(_Bytes));
     }
 }
 
 template <class _Refc>
 void _Deallocate_flexible_array(_Refc* const _Ptr) noexcept {
     constexpr size_t _Align = alignof(_Refc);
-    if constexpr (_Align <= __STDCPP_DEFAULT_NEW_ALIGNMENT__) {
-        ::operator delete(static_cast<void*>(_Ptr));
-    } else {
+#ifdef __cpp_aligned_new
+    if constexpr (_Align > __STDCPP_DEFAULT_NEW_ALIGNMENT__) {
         ::operator delete (static_cast<void*>(_Ptr), align_val_t{_Align});
+    } else
+#endif // __cpp_aligned_new
+    {
+        ::operator delete(static_cast<void*>(_Ptr));
     }
 }
 


### PR DESCRIPTION
We introduced a couple of unguarded uses in `<memory>` in #309 "P0674R1 `make_shared` For Arrays", causing breakage when users compile with `/Zc:alignedNew-`.

Fixes DevCom-1346191.
Fixes VSO-1283107 / AB#1283107.

@microsoft/vclibs note the lack of test coverage for `/Zc:alignedNew-` which (1) is necessary to validate the fix, and (2) would have caught the bug in the first place. Is it time to bite the bullet and add `/Zc:alignedNew-` coverage to our test matrices?