### PR TITLE
Enable constexpr vector internal tests

### DIFF
--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -1776,8 +1776,9 @@ private:
                 const auto _Temp = *_Pnext; // TRANSITION, VSO-1269037
                 _Pnext           = &_Temp->_Mynextiter;
             } else { // orphan the iterator
-                (*_Pnext)->_Myproxy = nullptr;
-                *_Pnext             = (*_Pnext)->_Mynextiter;
+                const auto _Temp = *_Pnext; // TRANSITION, VSO-1269037
+                _Temp->_Myproxy  = nullptr;
+                *_Pnext          = _Temp->_Mynextiter;
             }
         }
     }

--- a/tests/std/tests/P1004R2_constexpr_vector/test.cpp
+++ b/tests/std/tests/P1004R2_constexpr_vector/test.cpp
@@ -12,8 +12,8 @@
 
 using namespace std;
 
-#if defined(__EDG__) \
-    || _ITERATOR_DEBUG_LEVEL != 2 // || defined(MSVC_INTERNAL_TESTING) // TRANSITION, VSO-1270433, VSO-1275530
+#if defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 \
+    || defined(MSVC_INTERNAL_TESTING) // TRANSITION, VSO-1270433, VSO-1275530
 static constexpr int input[] = {0, 1, 2, 3, 4, 5};
 #endif // defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 || defined(MSVC_INTERNAL_TESTING)
 
@@ -64,8 +64,8 @@ struct soccc_allocator {
 using vec = vector<int, soccc_allocator<int>>;
 
 _CONSTEXPR20_CONTAINER bool test_interface() {
-#if defined(__EDG__) \
-    || _ITERATOR_DEBUG_LEVEL != 2 // || defined(MSVC_INTERNAL_TESTING) // TRANSITION, VSO-1270433, VSO-1275530
+#if defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 \
+    || defined(MSVC_INTERNAL_TESTING) // TRANSITION, VSO-1270433, VSO-1275530
     { // constructors
 
         // Non allocator constructors
@@ -513,8 +513,8 @@ _CONSTEXPR20_CONTAINER bool test_interface() {
 }
 
 _CONSTEXPR20_CONTAINER bool test_iterators() {
-#if defined(__EDG__) \
-    || _ITERATOR_DEBUG_LEVEL != 2 // || defined(MSVC_INTERNAL_TESTING) // TRANSITION, VSO-1270433, VSO-1275530
+#if defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 \
+    || defined(MSVC_INTERNAL_TESTING) // TRANSITION, VSO-1270433, VSO-1275530
     vec range_constructed(begin(input), end(input));
 
 #if !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 // TRANSITION, VSO-1273381
@@ -614,8 +614,8 @@ _CONSTEXPR20_CONTAINER bool test_iterators() {
 }
 
 _CONSTEXPR20_CONTAINER bool test_growth() {
-#if defined(__EDG__) \
-    || _ITERATOR_DEBUG_LEVEL != 2 // || defined(MSVC_INTERNAL_TESTING) // TRANSITION, VSO-1270433, VSO-1275530
+#if defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 \
+    || defined(MSVC_INTERNAL_TESTING) // TRANSITION, VSO-1270433, VSO-1275530
     {
         vector<int> v(1000, 1729);
 


### PR DESCRIPTION
Uncomments the `MSVC_INTERNAL_TESTING` conditionals on tests and also
adds a compiler workaround in vector.

Mirrors changes in internal MSVC-PR-305986.