### PR TITLE
<xkeycheck.h>: Fix circular inclusion for Header Units

### DIFF
--- a/stl/inc/xkeycheck.h
+++ b/stl/inc/xkeycheck.h
@@ -6,7 +6,10 @@
 #pragma once
 #ifndef _XKEYCHECK_H
 #define _XKEYCHECK_H
-#include <yvals_core.h>
+
+// xkeycheck.h assumes that it's being included by yvals_core.h in a specific order.
+// Nothing else should include xkeycheck.h.
+
 #if _STL_COMPILER_PREPROCESSOR
 
 #if defined(__cplusplus) && !defined(_ALLOW_KEYWORD_MACROS) && !defined(__INTELLISENSE__)


### PR DESCRIPTION
Works towards #60.

Discovered by @olgaark - we've done something weird in the machinery that detects macroized keywords, and this is a problem for building Standard Library Header Units.

We had correctly marked `xkeycheck.h` as **not** being automatically importable as a header unit:
https://github.com/microsoft/STL/blob/3c13e3ec1db421c1992ac2782c301d7a2da7aa35/stl/inc/header-units.json#L126

And correctly marked `yvals_core.h` (the STL's central internal header) as being importable (like the vast majority of STL headers):
https://github.com/microsoft/STL/blob/3c13e3ec1db421c1992ac2782c301d7a2da7aa35/stl/inc/header-units.json#L148

Next, `yvals_core.h` defines `_STL_COMPILER_PREPROCESSOR`:
https://github.com/microsoft/STL/blob/3c13e3ec1db421c1992ac2782c301d7a2da7aa35/stl/inc/yvals_core.h#L9-L18

And includes `vcruntime.h` for `_HAS_CXX17` etc. before including `xkeycheck.h`:
https://github.com/microsoft/STL/blob/3c13e3ec1db421c1992ac2782c301d7a2da7aa35/stl/inc/yvals_core.h#L341-L342

:beetle: Finally, because `xkeycheck.h` wants `_STL_COMPILER_PREPROCESSOR` and `_HAS_CXX17` etc. it includes `yvals_core.h`, which is **circular inclusion**!
https://github.com/microsoft/STL/blob/3c13e3ec1db421c1992ac2782c301d7a2da7aa35/stl/inc/xkeycheck.h#L6-L10

This wasn't causing problems for ordinary compilation (because `yvals_core.h`'s `#pragma once` and include guards prevent the recursion), but attempting to build STL Header Units in an optimal way involves "source dependencies" scanning, and this makes `yvals_core.h` look like it includes itself, which is a problem.

The fix is simple: remove the circular inclusion, and simply comment that `xkeycheck.h` is super special. Nothing else in the STL includes it, and users should not be including it directly. (I vaguely recall that at one time, every STL header tried to include `xkeycheck.h` itself, but we centralized this long ago.)