### PR TITLE
<format>: add no-spec formatting

### DIFF
--- a/stl/inc/format
+++ b/stl/inc/format
@@ -1118,7 +1118,7 @@ _OutputIt _Write(_OutputIt _Out, monostate) {
 
 // clang-format off
 template <class _CharT, class _OutputIt, class _Arithmetic>
-    requires is_arithmetic_v<_Arithmetic> && !same_as<_Arithmetic, bool> && !same_as<_Arithmetic, _CharT>
+    requires (is_arithmetic_v<_Arithmetic> && !same_as<_Arithmetic, bool> && !same_as<_Arithmetic, _CharT>)
 _OutputIt _Write(_OutputIt _Out, _Arithmetic _Value) {
     // clang-format on
     // TODO: Reusable buffer

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -665,7 +665,7 @@ public:
     }
 
     constexpr void _On_type(_CharT _Type) {
-        _Specs._Type = static_cast<char>(_Type);
+        _Specs._Type = static_cast<_CharT>(_Type);
     }
 
 protected:
@@ -1119,7 +1119,7 @@ _OutputIt _Write(_OutputIt _Out, monostate) {
 // This size is derived from the maximum length of an arithmetic type. The two contenders for widest are double and long
 // long. long long has a max length of ceil(log_10(2^64)) = 20 characters. double has a max length of
 // limits<double>::max_digits10 + the decimal + the sign + e + the exponent's sign + ceil(log_10(DBL_MAX_10_EXP))
-// = 17 + 1 + 1 + 1 + 3 = 24. An example is DBL_MAX which is "1.7976931348623158e+308".
+// = 17 + 1 + 1 + 1 + 3 = 24. An example is DBL_MAX which is "-1.7976931348623158e+308".
 inline constexpr size_t _Format_min_buffer_length = 24;
 
 // clang-format off
@@ -1127,9 +1127,9 @@ template <class _CharT, class _OutputIt, class _Arithmetic>
     requires (is_arithmetic_v<_Arithmetic> && !same_as<_Arithmetic, bool> && !same_as<_Arithmetic, _CharT>)
 _OutputIt _Write(_OutputIt _Out, _Arithmetic _Value) {
     // clang-format on
-    // TODO: Reusable buffer
+    // TRANSITION, Reusable buffer
     array<char, _Format_min_buffer_length> _Buffer;
-    auto [_End, _Ec] = _STD to_chars(_Buffer.data(), _Buffer.data() + _Buffer.size(), _Value);
+    const auto [_End, _Ec] = _STD to_chars(_Buffer.data(), _Buffer.data() + _Buffer.size(), _Value);
     _STL_ASSERT(_Ec == errc{}, "to_chars failed");
     return _STD copy(_Buffer.data(), _End, _Out);
 }
@@ -1147,9 +1147,9 @@ _OutputIt _Write(_OutputIt _Out, _CharT _Value) {
 
 template <class _CharT, class _OutputIt>
 _OutputIt _Write(_OutputIt _Out, const void* _Value) {
-    // TODO: Reusable buffer
-    array<char, 16> _Buffer;
-    auto [_End, _Ec] =
+    // TRANSITION, Reusable buffer
+    array<char, _Format_min_buffer_length> _Buffer;
+    const auto [_End, _Ec] =
         _STD to_chars(_Buffer.data(), _Buffer.data() + _Buffer.size(), reinterpret_cast<uintptr_t>(_Value), 16);
     _STL_ASSERT(_Ec == errc{}, "to_chars failed");
     *_Out++ = '0';

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -665,7 +665,7 @@ public:
     }
 
     constexpr void _On_type(_CharT _Type) {
-        _Specs._Type = static_cast<_CharT>(_Type);
+        _Specs._Type = static_cast<char>(_Type);
     }
 
 protected:
@@ -1116,6 +1116,41 @@ _OutputIt _Write(_OutputIt _Out, monostate) {
     return _Out;
 }
 
+// clang-format off
+template <class _CharT, class _OutputIt, class _Arithmetic>
+    requires is_arithmetic_v<_Arithmetic> && !same_as<_Arithmetic, bool> && !same_as<_Arithmetic, _CharT>
+_OutputIt _Write(_OutputIt _Out, _Arithmetic _Value) {
+    // clang-format on
+    // TODO: Reusable buffer
+    array<char, 24> _Buffer;
+    auto [_End, _Ec] = _STD to_chars(_Buffer.data(), _Buffer.data() + _Buffer.size(), _Value);
+    _STL_ASSERT(_Ec == errc{}, "to_chars failed");
+    return _STD copy(_Buffer.data(), _End, _Out);
+}
+
+template <class _CharT, class _OutputIt>
+_OutputIt _Write(_OutputIt _Out, bool _Value) {
+    return _Write(_Out, _Value ? "true" : "false");
+}
+
+template <class _CharT, class _OutputIt>
+_OutputIt _Write(_OutputIt _Out, _CharT _Value) {
+    *_Out++ = _Value;
+    return _Out;
+}
+
+template <class _CharT, class _OutputIt>
+_OutputIt _Write(_OutputIt _Out, const void* _Value) {
+    // TODO: Reusable buffer
+    array<char, 16> _Buffer;
+    auto [_End, _Ec] =
+        _STD to_chars(_Buffer.data(), _Buffer.data() + _Buffer.size(), reinterpret_cast<uintptr_t>(_Value), 16);
+    _STL_ASSERT(_Ec == errc{}, "to_chars failed");
+    *_Out++ = '0';
+    *_Out++ = 'x';
+    return _STD copy(_Buffer.data(), _End, _Out);
+}
+
 template <class _CharT, class _OutputIt>
 _OutputIt _Write(_OutputIt _Out, const _CharT* _Value) {
     if (!_Value) {
@@ -1127,11 +1162,9 @@ _OutputIt _Write(_OutputIt _Out, const _CharT* _Value) {
     return _Out;
 }
 
-template <class _CharT, class _OutputIt, class _Ty>
-_OutputIt _Write(_OutputIt _Out, _Ty _Val) {
-    (void) _Val;
-    _STL_INTERNAL_CHECK(false);
-    return _Out;
+template <class _CharT, class _OutputIt>
+_OutputIt _Write(_OutputIt _Out, basic_string_view<_CharT> _Value) {
+    return _STD copy(_Value.begin(), _Value.end(), _Out);
 }
 
 // Dispatcher to call enabled custom formatters, and do nothing otherwise.
@@ -1243,6 +1276,14 @@ template <class _Out>
 _Out vformat_to(
     _Out _OutputIt, const locale& _Loc, string_view _Fmt, format_args_t<type_identity_t<_Out>, char> _Args) {
     _Format_handler<_Out, char, basic_format_context<_Out, char>> _Handler(_OutputIt, _Fmt, _Args, _Loc);
+    _Parse_format_string(_Fmt, _Handler);
+    return _Handler._Ctx.out();
+}
+
+template <class _Out>
+_Out vformat_to(
+    _Out _OutputIt, const locale& _Loc, wstring_view _Fmt, format_args_t<type_identity_t<_Out>, wchar_t> _Args) {
+    _Format_handler<_Out, wchar_t, basic_format_context<_Out, wchar_t>> _Handler(_OutputIt, _Fmt, _Args, _Loc);
     _Parse_format_string(_Fmt, _Handler);
     return _Handler._Ctx.out();
 }

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -1116,13 +1116,19 @@ _OutputIt _Write(_OutputIt _Out, monostate) {
     return _Out;
 }
 
+// This size is derived from the maximum length of an arithmetic type. The two contenders for widest are double and long
+// long. long long has a max length of ceil(log_10(2^64)) = 20 characters. double has a max length of
+// limits<double>::max_digits10 + the decimal + the sign + e + the exponent's sign + ceil(log_10(DBL_MAX_10_EXP))
+// = 17 + 1 + 1 + 1 + 3 = 24. An example is DBL_MAX which is "1.7976931348623158e+308".
+inline constexpr size_t _Format_min_buffer_length = 24;
+
 // clang-format off
 template <class _CharT, class _OutputIt, class _Arithmetic>
     requires (is_arithmetic_v<_Arithmetic> && !same_as<_Arithmetic, bool> && !same_as<_Arithmetic, _CharT>)
 _OutputIt _Write(_OutputIt _Out, _Arithmetic _Value) {
     // clang-format on
     // TODO: Reusable buffer
-    array<char, 24> _Buffer;
+    array<char, _Format_min_buffer_length> _Buffer;
     auto [_End, _Ec] = _STD to_chars(_Buffer.data(), _Buffer.data() + _Buffer.size(), _Value);
     _STL_ASSERT(_Ec == errc{}, "to_chars failed");
     return _STD copy(_Buffer.data(), _End, _Out);
@@ -1135,8 +1141,8 @@ _OutputIt _Write(_OutputIt _Out, bool _Value) {
 
 template <class _CharT, class _OutputIt>
 _OutputIt _Write(_OutputIt _Out, _CharT _Value) {
-    *_Out++ = _Value;
-    return _Out;
+    *_Out = _Value;
+    return ++_Out;
 }
 
 template <class _CharT, class _OutputIt>
@@ -1272,18 +1278,18 @@ auto make_wformat_args(const _Args&... _Vals) {
 template <class _Out, class _CharT>
 using format_args_t = basic_format_args<basic_format_context<_Out, _CharT>>;
 
-template <class _Out>
-_Out vformat_to(
-    _Out _OutputIt, const locale& _Loc, string_view _Fmt, format_args_t<type_identity_t<_Out>, char> _Args) {
-    _Format_handler<_Out, char, basic_format_context<_Out, char>> _Handler(_OutputIt, _Fmt, _Args, _Loc);
+template <class _OutputIt>
+_OutputIt vformat_to(
+    _OutputIt _Out, const locale& _Loc, string_view _Fmt, format_args_t<type_identity_t<_OutputIt>, char> _Args) {
+    _Format_handler<_OutputIt, char, basic_format_context<_OutputIt, char>> _Handler(_Out, _Fmt, _Args, _Loc);
     _Parse_format_string(_Fmt, _Handler);
     return _Handler._Ctx.out();
 }
 
-template <class _Out>
-_Out vformat_to(
-    _Out _OutputIt, const locale& _Loc, wstring_view _Fmt, format_args_t<type_identity_t<_Out>, wchar_t> _Args) {
-    _Format_handler<_Out, wchar_t, basic_format_context<_Out, wchar_t>> _Handler(_OutputIt, _Fmt, _Args, _Loc);
+template <class _OutputIt>
+_OutputIt vformat_to(
+    _OutputIt _Out, const locale& _Loc, wstring_view _Fmt, format_args_t<type_identity_t<_OutputIt>, wchar_t> _Args) {
+    _Format_handler<_OutputIt, wchar_t, basic_format_context<_OutputIt, wchar_t>> _Handler(_Out, _Fmt, _Args, _Loc);
     _Parse_format_string(_Fmt, _Handler);
     return _Handler._Ctx.out();
 }

--- a/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
@@ -101,18 +101,22 @@ int main() {
     vformat_to(back_insert_iterator(output_string), locale::classic(), "{}", make_format_args('a'));
     assert(output_string == "a");
 
-    // Test void*
+    // Test const void*
     output_string.clear();
-    vformat_to(back_insert_iterator(output_string), locale::classic(), "{}", make_format_args((const void*) 0));
+    vformat_to(back_insert_iterator(output_string), locale::classic(), "{}",
+        make_format_args(static_cast<const void*>(nullptr)));
     assert(output_string == "0x0");
 
     /* TODO: Doesn't properly overload on void* and nullptr
+    // Test void*
     output_string.clear();
-    vformat_to(back_insert_iterator(output_string), locale::classic(), "{}", make_format_args(nullptr));
+    vformat_to(
+        back_insert_iterator(output_string), locale::classic(), "{}", make_format_args(static_cast<void*>(nullptr)));
     assert(output_string == "0x0");
 
+    // Test nullptr
     output_string.clear();
-    vformat_to(back_insert_iterator(output_string), locale::classic(), "{}", make_format_args((void*)0));
+    vformat_to(back_insert_iterator(output_string), locale::classic(), "{}", make_format_args(nullptr));
     assert(output_string == "0x0");
     */
 

--- a/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
@@ -82,18 +82,131 @@ int main() {
     vformat_to(back_insert_iterator(output_string), locale::classic(), "{0} {0}", make_format_args((const char*) "f"));
     assert(output_string == "f f");
 
-    // TODO: enable these in _Write function PR for sv and bool
-    /*
+    // Test string_view
     output_string.clear();
     vformat_to(back_insert_iterator(output_string), locale::classic(), "{}", make_format_args("f"sv));
     assert(output_string == "f");
-    */
 
-    /*
+    // Test bool
     output_string.clear();
     vformat_to(back_insert_iterator(output_string), locale::classic(), "{}", make_format_args(true));
     assert(output_string == "true");
+
+    output_string.clear();
+    vformat_to(back_insert_iterator(output_string), locale::classic(), "{}", make_format_args(false));
+    assert(output_string == "false");
+
+    // Test char
+    output_string.clear();
+    vformat_to(back_insert_iterator(output_string), locale::classic(), "{}", make_format_args('a'));
+    assert(output_string == "a");
+
+    // Test void*
+    output_string.clear();
+    vformat_to(back_insert_iterator(output_string), locale::classic(), "{}", make_format_args((const void*) 0));
+    assert(output_string == "0x0");
+
+    /* TODO: Doesn't properly overload on void* and nullptr
+    output_string.clear();
+    vformat_to(back_insert_iterator(output_string), locale::classic(), "{}", make_format_args(nullptr));
+    assert(output_string == "0x0");
+
+    output_string.clear();
+    vformat_to(back_insert_iterator(output_string), locale::classic(), "{}", make_format_args((void*)0));
+    assert(output_string == "0x0");
     */
+
+    // Test signed integers
+    output_string.clear();
+    vformat_to(back_insert_iterator(output_string), locale::classic(), "{}", make_format_args(1234));
+    assert(output_string == "1234");
+
+    output_string.clear();
+    vformat_to(back_insert_iterator(output_string), locale::classic(), "{}", make_format_args(1234ll));
+    assert(output_string == "1234");
+
+    output_string.clear();
+    vformat_to(back_insert_iterator(output_string), locale::classic(), "{}", make_format_args(INT_MIN));
+    assert(output_string == "-2147483648");
+
+    output_string.clear();
+    vformat_to(back_insert_iterator(output_string), locale::classic(), "{}", make_format_args(INT_MAX));
+    assert(output_string == "2147483647");
+
+    output_string.clear();
+    vformat_to(back_insert_iterator(output_string), locale::classic(), "{}", make_format_args(LLONG_MAX));
+    assert(output_string == "9223372036854775807");
+
+    output_string.clear();
+    vformat_to(back_insert_iterator(output_string), locale::classic(), "{}", make_format_args(LLONG_MIN));
+    assert(output_string == "-9223372036854775808");
+
+    // Test unsigned integers
+    output_string.clear();
+    vformat_to(back_insert_iterator(output_string), locale::classic(), "{}", make_format_args(1234u));
+    assert(output_string == "1234");
+
+    output_string.clear();
+    vformat_to(back_insert_iterator(output_string), locale::classic(), "{}", make_format_args(1234ull));
+    assert(output_string == "1234");
+
+    output_string.clear();
+    vformat_to(back_insert_iterator(output_string), locale::classic(), "{}", make_format_args(UINT_MAX));
+    assert(output_string == "4294967295");
+
+    output_string.clear();
+    vformat_to(back_insert_iterator(output_string), locale::classic(), "{}", make_format_args(ULLONG_MAX));
+    assert(output_string == "18446744073709551615");
+
+    // Test float
+    output_string.clear();
+    vformat_to(back_insert_iterator(output_string), locale::classic(), "{}", make_format_args(12.34f));
+    assert(output_string == "12.34");
+
+    output_string.clear();
+    vformat_to(back_insert_iterator(output_string), locale::classic(), "{}", make_format_args(FLT_MAX));
+    assert(output_string == "3.4028235e+38");
+
+    output_string.clear();
+    vformat_to(back_insert_iterator(output_string), locale::classic(), "{}", make_format_args(-FLT_MAX));
+    assert(output_string == "-3.4028235e+38");
+
+    output_string.clear();
+    vformat_to(back_insert_iterator(output_string), locale::classic(), "{}", make_format_args(FLT_MIN));
+    assert(output_string == "1.1754944e-38");
+
+    output_string.clear();
+    vformat_to(back_insert_iterator(output_string), locale::classic(), "{}", make_format_args(FLT_EPSILON));
+    assert(output_string == "1.1920929e-07");
+
+    output_string.clear();
+    vformat_to(back_insert_iterator(output_string), locale::classic(), "{}", make_format_args(FLT_TRUE_MIN));
+    assert(output_string == "1e-45");
+
+    // Test double
+    output_string.clear();
+    vformat_to(back_insert_iterator(output_string), locale::classic(), "{}", make_format_args(12.34));
+    assert(output_string == "12.34");
+
+    output_string.clear();
+    vformat_to(back_insert_iterator(output_string), locale::classic(), "{}", make_format_args(DBL_MAX));
+    assert(output_string == "1.7976931348623157e+308");
+
+    output_string.clear();
+    vformat_to(back_insert_iterator(output_string), locale::classic(), "{}", make_format_args(-DBL_MAX));
+    assert(output_string == "-1.7976931348623157e+308");
+
+    output_string.clear();
+    vformat_to(back_insert_iterator(output_string), locale::classic(), "{}", make_format_args(DBL_MIN));
+    assert(output_string == "2.2250738585072014e-308");
+
+    output_string.clear();
+    vformat_to(back_insert_iterator(output_string), locale::classic(), "{}", make_format_args(DBL_EPSILON));
+    assert(output_string == "2.220446049250313e-16");
+
+    output_string.clear();
+    vformat_to(back_insert_iterator(output_string), locale::classic(), "{}", make_format_args(DBL_TRUE_MIN));
+    assert(output_string == "5e-324");
 
     return 0;
 }

--- a/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
@@ -203,11 +203,6 @@ int main() {
     assert(output_string == "nan");
 
     output_string.clear();
-    vformat_to(back_insert_iterator(output_string), locale::classic(), "{}",
-        make_format_args(-numeric_limits<float>::quiet_NaN()));
-    assert(output_string == "-nan");
-
-    output_string.clear();
     vformat_to(back_insert_iterator(output_string), locale::classic(), "{}", make_format_args(0.f));
     assert(output_string == "0");
 
@@ -254,11 +249,6 @@ int main() {
     vformat_to(back_insert_iterator(output_string), locale::classic(), "{}",
         make_format_args(numeric_limits<double>::quiet_NaN()));
     assert(output_string == "nan");
-
-    output_string.clear();
-    vformat_to(back_insert_iterator(output_string), locale::classic(), "{}",
-        make_format_args(-numeric_limits<double>::quiet_NaN()));
-    assert(output_string == "-nan");
 
     output_string.clear();
     vformat_to(back_insert_iterator(output_string), locale::classic(), "{}", make_format_args(0.0));

--- a/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
@@ -187,6 +187,34 @@ int main() {
     vformat_to(back_insert_iterator(output_string), locale::classic(), "{}", make_format_args(FLT_TRUE_MIN));
     assert(output_string == "1e-45");
 
+    output_string.clear();
+    vformat_to(back_insert_iterator(output_string), locale::classic(), "{}",
+        make_format_args(numeric_limits<float>::infinity()));
+    assert(output_string == "inf");
+
+    output_string.clear();
+    vformat_to(back_insert_iterator(output_string), locale::classic(), "{}",
+        make_format_args(-numeric_limits<float>::infinity()));
+    assert(output_string == "-inf");
+
+    output_string.clear();
+    vformat_to(back_insert_iterator(output_string), locale::classic(), "{}",
+        make_format_args(numeric_limits<float>::quiet_NaN()));
+    assert(output_string == "nan");
+
+    output_string.clear();
+    vformat_to(back_insert_iterator(output_string), locale::classic(), "{}",
+        make_format_args(-numeric_limits<float>::quiet_NaN()));
+    assert(output_string == "-nan");
+
+    output_string.clear();
+    vformat_to(back_insert_iterator(output_string), locale::classic(), "{}", make_format_args(0.f));
+    assert(output_string == "0");
+
+    output_string.clear();
+    vformat_to(back_insert_iterator(output_string), locale::classic(), "{}", make_format_args(-0.f));
+    assert(output_string == "-0");
+
     // Test double
     output_string.clear();
     vformat_to(back_insert_iterator(output_string), locale::classic(), "{}", make_format_args(12.34));
@@ -212,5 +240,32 @@ int main() {
     vformat_to(back_insert_iterator(output_string), locale::classic(), "{}", make_format_args(DBL_TRUE_MIN));
     assert(output_string == "5e-324");
 
+    output_string.clear();
+    vformat_to(back_insert_iterator(output_string), locale::classic(), "{}",
+        make_format_args(numeric_limits<double>::infinity()));
+    assert(output_string == "inf");
+
+    output_string.clear();
+    vformat_to(back_insert_iterator(output_string), locale::classic(), "{}",
+        make_format_args(-numeric_limits<double>::infinity()));
+    assert(output_string == "-inf");
+
+    output_string.clear();
+    vformat_to(back_insert_iterator(output_string), locale::classic(), "{}",
+        make_format_args(numeric_limits<double>::quiet_NaN()));
+    assert(output_string == "nan");
+
+    output_string.clear();
+    vformat_to(back_insert_iterator(output_string), locale::classic(), "{}",
+        make_format_args(-numeric_limits<double>::quiet_NaN()));
+    assert(output_string == "-nan");
+
+    output_string.clear();
+    vformat_to(back_insert_iterator(output_string), locale::classic(), "{}", make_format_args(0.0));
+    assert(output_string == "0");
+
+    output_string.clear();
+    vformat_to(back_insert_iterator(output_string), locale::classic(), "{}", make_format_args(-0.0));
+    assert(output_string == "-0");
     return 0;
 }


### PR DESCRIPTION
<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
Add _Write functions to \<format>, as well as accompanying tests.

The buffer is a placeholder, and the max size of 24 was determined by the maximum size of a `double`'s meaningful digits (`numeric_limits<double>::max_digits10`) + 1 for sign + 1 for decimal + 1 for an exponent + 1 for the exponent sign + 3 for exponent width, which gives us 17+1+1+1+1+3=24. The only other possible max length contender is long long, but that has a max size of 20.

There is currently a bug that is being fixed regarding `void*` and `nullptr_t` args not being instantiable.

I also added a `v_format` overload for wide chars, for a quick test about using a `char` buffer against `wchar_t`. This is currently untested in the PR. It brought up an issue with `_On_type` casting to the wrong type (`_Specs._Type` is always a char).