### PR TITLE
<format>: Fix _Get_format_arg_storage_type

### DIFF
--- a/stl/inc/format
+++ b/stl/inc/format
@@ -840,10 +840,20 @@ public:
     }
 };
 
+// clang-format off
+template<class _Context, class _Ty>
+concept _Has_formatter = requires(const _Ty& _Val, _Context& _Ctx) {
+    _STD declval<typename _Context::template formatter_type<_Ty>>().format(_Val, _Ctx);
+};
+// clang-format on
+
 // See [format.arg]/5
+// clang-format off
 template <class _Context, class _Ty>
-/* consteval */ constexpr auto _Get_format_arg_storage_type(const _Ty&) noexcept {
-    return _STD declval<typename basic_format_arg<_Context>::handle>();
+    requires _Has_formatter<_Context, _Ty>
+/* consteval */ constexpr auto _Get_format_arg_storage_type(const _Ty& _Val) noexcept {
+    // clang-format on
+    return typename basic_format_arg<_Context>::handle(_Val);
 }
 
 // clang-format off
@@ -907,6 +917,10 @@ template <class _Ty>
     return static_cast<void*>(nullptr);
 }
 
+template <class _Context, class _Ty>
+inline constexpr size_t _Get_format_arg_storage_size = sizeof(
+    _Get_format_arg_storage_type<_Context>(_STD declval<_Ty>()));
+
 struct _Format_arg_store_packed_index {
     // TRANSITION, Should be templated on number of arguments for even less storage
     using _Index_type = size_t;
@@ -930,10 +944,9 @@ private:
 
     friend basic_format_args<_Context>;
 
-    static constexpr size_t _Num_args     = sizeof...(_Args);
-    static constexpr size_t _Index_length = _Num_args * sizeof(_Index_type);
-    static constexpr size_t _Storage_length =
-        (sizeof(_Get_format_arg_storage_type<_Context>(_STD declval<_Args>())) + ... + 0);
+    static constexpr size_t _Num_args       = sizeof...(_Args);
+    static constexpr size_t _Index_length   = _Num_args * sizeof(_Index_type);
+    static constexpr size_t _Storage_length = (_Get_format_arg_storage_size<_Context, _Args> + ... + 0);
 
     // we store the data in memory as _Format_arg_store_packed_index[_Index_length] + unsigned char[_Storage_length]
     unsigned char _Storage[_Index_length + _Storage_length];

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -840,44 +840,73 @@ public:
     }
 };
 
+// See [format.arg]/5
 template <class _Context, class _Ty>
-/* consteval */ constexpr auto _Get_format_arg_storage_type() noexcept {
+/* consteval */ constexpr size_t _Get_format_arg_storage_size(const _Ty&) noexcept {
+    return sizeof(basic_format_arg<_Context>::handle);
+}
+
+// clang-format off
+template <class _Context, class _Ty>
+    requires integral<_Ty> || floating_point<_Ty>
+/* consteval */ constexpr size_t _Get_format_arg_storage_size(_Ty) noexcept {
+    // clang-format on
     using _CharType = typename _Context::char_type;
     if constexpr (is_same_v<_Ty, monostate>) {
-        return monostate{};
-    } else if constexpr (is_same_v<_Ty, _CharType>) {
-        return _CharType{};
-    } else if constexpr (is_same_v<_Ty, char> && is_same_v<_CharType, wchar_t>) {
-        return _CharType{};
-    } else if constexpr (signed_integral<_Ty> && sizeof(_Ty) <= sizeof(int)) {
-        return int{};
-    } else if constexpr (unsigned_integral<_Ty> && sizeof(_Ty) <= sizeof(unsigned int)) {
-        return static_cast<unsigned int>(42);
-    } else if constexpr (signed_integral<_Ty> && sizeof(_Ty) <= sizeof(long long)) {
-        return static_cast<long long>(42);
-    } else if constexpr (unsigned_integral<_Ty> && sizeof(_Ty) <= sizeof(unsigned long long)) {
-        return static_cast<unsigned long long>(42);
+        return sizeof(monostate);
     } else if constexpr (is_same_v<_Ty, bool>) {
-        return bool{};
+        sizeof(bool);
+    } else if constexpr (is_same_v<_Ty, _Context::_CharType>) {
+        return sizeof(_Char_type);
+    } else if constexpr (is_same_v<_Ty, char> && is_same_v<_CharType, wchar_t>) {
+        return sizeof(_Char_type);
+    } else if constexpr (signed_integral<_Ty> && sizeof(_Ty) <= sizeof(int)) {
+        return sizeof(int);
+    } else if constexpr (unsigned_integral<_Ty> && sizeof(_Ty) <= sizeof(unsigned int)) {
+        return sizeof(unsigned int);
+    } else if constexpr (signed_integral<_Ty> && sizeof(_Ty) <= sizeof(long long)) {
+        return sizeof(long long);
+    } else if constexpr (unsigned_integral<_Ty> && sizeof(_Ty) <= sizeof(unsigned long long)) {
+        return sizeof(unsigned long long);
     } else if constexpr (is_same_v<_Ty, float>) {
-        return float{};
+        return sizeof(float);
     } else if constexpr (is_same_v<_Ty, double>) {
-        return double{};
+        return sizeof(double);
     } else if constexpr (is_same_v<_Ty, long double>) {
-        return static_cast<long double>(42);
-    } else if constexpr (is_same_v<_Ty, const void*>) {
-        return static_cast<const void*>(nullptr);
-    } else if constexpr (is_same_v<_Ty, const _CharType*>) {
-        return static_cast<const _CharType*>(nullptr);
-    } else if constexpr (is_same_v<_Ty, basic_string_view<_CharType>>) {
-        return basic_string_view<_CharType>{};
+        return sizeof(long double);
     } else {
-        return basic_format_arg<_Context>::handle();
+        static_assert(_Always_false<_Ty>, "Invalid type passed to _Get_format_arg_storage_type");
+        return static_cast<size_t>(-1);
     }
 }
 
-template <class _Context, class _Ty>
-inline constexpr size_t _Get_format_arg_storage_size = sizeof(_Get_format_arg_storage_type<_Context, _Ty>());
+template <class _Context, class _Char_type = typename _Context::char_type>
+/* consteval */ constexpr size_t _Get_format_arg_storage_size(const _Char_type*) noexcept {
+    return sizeof(nullptr);
+}
+
+template <class _Context, class _Traits, class _Char_type = typename _Context::char_type>
+/* consteval */ constexpr size_t _Get_format_arg_storage_size(basic_string_view<_CharType, _Traits>) noexcept {
+    return sizeof(basic_string_view<_CharType>);
+}
+
+template <class _Context, class _Traits, class _Alloc, class _Char_type = typename _Context::char_type>
+/* consteval */ constexpr size_t _Get_format_arg_storage_size(
+    const basic_string<_CharType, _Traits, _Alloc>&) noexcept {
+    return sizeof(basic_string_view<_CharType>);
+}
+
+/* consteval */ constexpr size_t _Get_format_arg_storage_size(nullptr_t) noexcept {
+    return sizeof(nullptr_t);
+}
+
+// clang-format off
+template <class _Ty>
+    requires is_void_v<_Ty>
+/* consteval */ constexpr size_t _Get_format_arg_storage_size(const _Ty*) noexcept {
+    // clang-format on
+    return sizeof(nullptr_t);
+}
 
 struct _Format_arg_store_packed_index {
     // TRANSITION, Should be templated on number of arguments for even less storage
@@ -904,7 +933,7 @@ private:
 
     static constexpr size_t _Num_args       = sizeof...(_Args);
     static constexpr size_t _Index_length   = _Num_args * sizeof(_Index_type);
-    static constexpr size_t _Storage_length = (_Get_format_arg_storage_size<_Context, _Args> + ... + 0);
+    static constexpr size_t _Storage_length = (_Get_format_arg_storage_size<_Context>(_STD declval<_Args>()) + ... + 0);
 
     // we store the data in memory as _Format_arg_store_packed_index[_Index_length] + unsigned char[_Storage_length]
     unsigned char _Storage[_Index_length + _Storage_length];
@@ -913,7 +942,7 @@ private:
     void _Store_impl(const size_t _Arg_index, const _Basic_format_arg_type _Arg_type, _Ty _Val) noexcept {
         const auto _Index_array = reinterpret_cast<_Index_type*>(_Storage);
         const auto _Store_index = _Index_array[_Arg_index]._Index;
-        const auto _Length      = _Get_format_arg_storage_size<_Context, _Ty>;
+        const auto _Length      = _Get_format_arg_storage_size<_Context>(_Ty);
 
         _CSTD memcpy(_Storage + _Index_length + _Store_index, _STD addressof(_Val), _Length);
         _Index_array[_Arg_index]._Type = _Arg_type;

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -842,38 +842,38 @@ public:
 
 // See [format.arg]/5
 template <class _Context, class _Ty>
-/* consteval */ constexpr size_t _Get_format_arg_storage_size(const _Ty&) noexcept {
-    return sizeof(basic_format_arg<_Context>::handle);
+/* consteval */ constexpr auto _Get_format_arg_storage_type(const _Ty&) noexcept {
+    return _STD declval<typename basic_format_arg<_Context>::handle>();
 }
 
 // clang-format off
 template <class _Context, class _Ty>
     requires integral<_Ty> || floating_point<_Ty>
-/* consteval */ constexpr size_t _Get_format_arg_storage_size(_Ty) noexcept {
+/* consteval */ constexpr auto _Get_format_arg_storage_type(_Ty) noexcept {
     // clang-format on
     using _Char_type = typename _Context::char_type;
     if constexpr (is_same_v<_Ty, monostate>) {
-        return sizeof(monostate);
+        return monostate{};
     } else if constexpr (is_same_v<_Ty, bool>) {
-        return sizeof(bool);
+        return bool{};
     } else if constexpr (is_same_v<_Ty, _Char_type>) {
-        return sizeof(_Char_type);
+        return _Char_type{};
     } else if constexpr (is_same_v<_Ty, char> && is_same_v<_Char_type, wchar_t>) {
-        return sizeof(_Char_type);
+        return _Char_type{};
     } else if constexpr (signed_integral<_Ty> && sizeof(_Ty) <= sizeof(int)) {
-        return sizeof(int);
+        return int{};
     } else if constexpr (unsigned_integral<_Ty> && sizeof(_Ty) <= sizeof(unsigned int)) {
-        return sizeof(unsigned int);
+        return static_cast<unsigned int>(42);
     } else if constexpr (signed_integral<_Ty> && sizeof(_Ty) <= sizeof(long long)) {
-        return sizeof(long long);
+        return static_cast<long long>(42);
     } else if constexpr (unsigned_integral<_Ty> && sizeof(_Ty) <= sizeof(unsigned long long)) {
-        return sizeof(unsigned long long);
+        return static_cast<unsigned long long>(42);
     } else if constexpr (is_same_v<_Ty, float>) {
-        return sizeof(float);
+        return float{};
     } else if constexpr (is_same_v<_Ty, double>) {
-        return sizeof(double);
+        return double{};
     } else if constexpr (is_same_v<_Ty, long double>) {
-        return sizeof(long double);
+        return static_cast<long double>(42);
     } else {
         static_assert(_Always_false<_Ty>, "Invalid type passed to _Get_format_arg_storage_type");
         return static_cast<size_t>(-1);
@@ -881,31 +881,30 @@ template <class _Context, class _Ty>
 }
 
 template <class _Context, class _Char_type = typename _Context::char_type>
-/* consteval */ constexpr size_t _Get_format_arg_storage_size(const _Char_type*) noexcept {
-    return sizeof(nullptr);
+/* consteval */ constexpr auto _Get_format_arg_storage_type(const _Char_type*) noexcept {
+    return static_cast<const _Char_type*>(nullptr);
 }
 
 template <class _Context, class _Traits, class _Char_type = typename _Context::char_type>
-/* consteval */ constexpr size_t _Get_format_arg_storage_size(basic_string_view<_Char_type, _Traits>) noexcept {
-    return sizeof(basic_string_view<_Char_type>);
+/* consteval */ constexpr auto _Get_format_arg_storage_type(basic_string_view<_Char_type, _Traits>) noexcept {
+    return basic_string_view<_Char_type>{};
 }
 
 template <class _Context, class _Traits, class _Alloc, class _Char_type = typename _Context::char_type>
-/* consteval */ constexpr size_t _Get_format_arg_storage_size(
-    const basic_string<_Char_type, _Traits, _Alloc>&) noexcept {
-    return sizeof(basic_string_view<_Char_type>);
+/* consteval */ constexpr auto _Get_format_arg_storage_type(const basic_string<_Char_type, _Traits, _Alloc>&) noexcept {
+    return basic_string_view<_Char_type>{};
 }
 
-/* consteval */ constexpr size_t _Get_format_arg_storage_size(nullptr_t) noexcept {
-    return sizeof(nullptr_t);
+/* consteval */ constexpr auto _Get_format_arg_storage_type(nullptr_t) noexcept {
+    return nullptr_t{};
 }
 
 // clang-format off
 template <class _Ty>
     requires is_void_v<_Ty>
-/* consteval */ constexpr size_t _Get_format_arg_storage_size(const _Ty*) noexcept {
+/* consteval */ constexpr auto _Get_format_arg_storage_type(const _Ty*) noexcept {
     // clang-format on
-    return sizeof(nullptr_t);
+    return static_cast<void*>(nullptr);
 }
 
 struct _Format_arg_store_packed_index {
@@ -931,9 +930,10 @@ private:
 
     friend basic_format_args<_Context>;
 
-    static constexpr size_t _Num_args       = sizeof...(_Args);
-    static constexpr size_t _Index_length   = _Num_args * sizeof(_Index_type);
-    static constexpr size_t _Storage_length = (_Get_format_arg_storage_size<_Context>(_STD declval<_Args>()) + ... + 0);
+    static constexpr size_t _Num_args     = sizeof...(_Args);
+    static constexpr size_t _Index_length = _Num_args * sizeof(_Index_type);
+    static constexpr size_t _Storage_length =
+        (sizeof(_Get_format_arg_storage_type<_Context>(_STD declval<_Args>())) + ... + 0);
 
     // we store the data in memory as _Format_arg_store_packed_index[_Index_length] + unsigned char[_Storage_length]
     unsigned char _Storage[_Index_length + _Storage_length];
@@ -942,7 +942,7 @@ private:
     void _Store_impl(const size_t _Arg_index, const _Basic_format_arg_type _Arg_type, _Ty _Val) noexcept {
         const auto _Index_array = reinterpret_cast<_Index_type*>(_Storage);
         const auto _Store_index = _Index_array[_Arg_index]._Index;
-        const auto _Length      = _Get_format_arg_storage_size<_Context>(_Val);
+        const auto _Length      = sizeof(_Get_format_arg_storage_type<_Context>(_Val));
 
         _CSTD memcpy(_Storage + _Index_length + _Store_index, _STD addressof(_Val), _Length);
         _Index_array[_Arg_index]._Type = _Arg_type;

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -841,19 +841,19 @@ public:
 };
 
 // clang-format off
-template<class _Context, class _Ty>
+template <class _Context, class _Ty>
 concept _Has_formatter = requires(const _Ty& _Val, _Context& _Ctx) {
     _STD declval<typename _Context::template formatter_type<_Ty>>().format(_Val, _Ctx);
 };
 // clang-format on
 
-// See [format.arg]/5
+// See N4878 [format.arg]/5
 // clang-format off
 template <class _Context, class _Ty>
     requires _Has_formatter<_Context, _Ty>
 /* consteval */ constexpr auto _Get_format_arg_storage_type(const _Ty& _Val) noexcept {
     // clang-format on
-    return typename basic_format_arg<_Context>::handle(_Val);
+    return typename basic_format_arg<_Context>::handle{_Val};
 }
 
 // clang-format off

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -851,14 +851,14 @@ template <class _Context, class _Ty>
     requires integral<_Ty> || floating_point<_Ty>
 /* consteval */ constexpr size_t _Get_format_arg_storage_size(_Ty) noexcept {
     // clang-format on
-    using _CharType = typename _Context::char_type;
+    using _Char_type = typename _Context::char_type;
     if constexpr (is_same_v<_Ty, monostate>) {
         return sizeof(monostate);
     } else if constexpr (is_same_v<_Ty, bool>) {
-        sizeof(bool);
-    } else if constexpr (is_same_v<_Ty, _Context::_CharType>) {
+        return sizeof(bool);
+    } else if constexpr (is_same_v<_Ty, _Char_type>) {
         return sizeof(_Char_type);
-    } else if constexpr (is_same_v<_Ty, char> && is_same_v<_CharType, wchar_t>) {
+    } else if constexpr (is_same_v<_Ty, char> && is_same_v<_Char_type, wchar_t>) {
         return sizeof(_Char_type);
     } else if constexpr (signed_integral<_Ty> && sizeof(_Ty) <= sizeof(int)) {
         return sizeof(int);
@@ -886,14 +886,14 @@ template <class _Context, class _Char_type = typename _Context::char_type>
 }
 
 template <class _Context, class _Traits, class _Char_type = typename _Context::char_type>
-/* consteval */ constexpr size_t _Get_format_arg_storage_size(basic_string_view<_CharType, _Traits>) noexcept {
-    return sizeof(basic_string_view<_CharType>);
+/* consteval */ constexpr size_t _Get_format_arg_storage_size(basic_string_view<_Char_type, _Traits>) noexcept {
+    return sizeof(basic_string_view<_Char_type>);
 }
 
 template <class _Context, class _Traits, class _Alloc, class _Char_type = typename _Context::char_type>
 /* consteval */ constexpr size_t _Get_format_arg_storage_size(
-    const basic_string<_CharType, _Traits, _Alloc>&) noexcept {
-    return sizeof(basic_string_view<_CharType>);
+    const basic_string<_Char_type, _Traits, _Alloc>&) noexcept {
+    return sizeof(basic_string_view<_Char_type>);
 }
 
 /* consteval */ constexpr size_t _Get_format_arg_storage_size(nullptr_t) noexcept {
@@ -942,7 +942,7 @@ private:
     void _Store_impl(const size_t _Arg_index, const _Basic_format_arg_type _Arg_type, _Ty _Val) noexcept {
         const auto _Index_array = reinterpret_cast<_Index_type*>(_Storage);
         const auto _Store_index = _Index_array[_Arg_index]._Index;
-        const auto _Length      = _Get_format_arg_storage_size<_Context>(_Ty);
+        const auto _Length      = _Get_format_arg_storage_size<_Context>(_Val);
 
         _CSTD memcpy(_Storage + _Index_length + _Store_index, _STD addressof(_Val), _Length);
         _Index_array[_Arg_index]._Type = _Arg_type;

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -905,12 +905,13 @@ template <class _Context, class _Traits, class _Alloc, class _Char_type = typena
     return basic_string_view<_Char_type>{};
 }
 
+template <class _Context>
 /* consteval */ constexpr auto _Get_format_arg_storage_type(nullptr_t) noexcept {
     return nullptr_t{};
 }
 
 // clang-format off
-template <class _Ty>
+template <class _Context, class _Ty>
     requires is_void_v<_Ty>
 /* consteval */ constexpr auto _Get_format_arg_storage_type(const _Ty*) noexcept {
     // clang-format on

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -907,7 +907,7 @@ template <class _Context, class _Traits, class _Alloc, class _Char_type = typena
 
 template <class _Context>
 /* consteval */ constexpr auto _Get_format_arg_storage_type(nullptr_t) noexcept {
-    return nullptr_t{};
+    return static_cast<const void*>(nullptr);
 }
 
 // clang-format off

--- a/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
@@ -75,11 +75,11 @@ int main() {
     assert(output_string == "}x");
 
     output_string.clear();
-    vformat_to(back_insert_iterator(output_string), locale::classic(), "{}", make_format_args((const char*) "f"));
+    vformat_to(back_insert_iterator(output_string), locale::classic(), "{}", make_format_args("f"));
     assert(output_string == "f");
 
     output_string.clear();
-    vformat_to(back_insert_iterator(output_string), locale::classic(), "{0} {0}", make_format_args((const char*) "f"));
+    vformat_to(back_insert_iterator(output_string), locale::classic(), "{0} {0}", make_format_args("f"));
     assert(output_string == "f f");
 
     // TODO: enable these in _Write function PR for sv and bool


### PR DESCRIPTION
This fixes the bug in _Format_arg_store that prevented making _Format_arg_stores from character literals. @miscco made the initial fix and I finished up the PR.

* _Get_format_arg_storage_type becomes an overload set that's called with declval (an alternative could be to use invoke_result on a function object with multiple op()s)
* because declval returns an rvalue reference the `const T&` overload must be constrained, or else it will bind to `char (&)[N]` parameters instead of the correct `const _Char_type*` overload