### PR TITLE
Skip tr1/tests/thread, minor style cleanups

### DIFF
--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -1800,7 +1800,6 @@ template <class _Ty1, class _Ty2>
 _NODISCARD strong_ordering operator<=>(const shared_ptr<_Ty1>& _Left, const shared_ptr<_Ty2>& _Right) noexcept {
     return _Left.get() <=> _Right.get();
 }
-
 #else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
 template <class _Ty1, class _Ty2>
 _NODISCARD bool operator!=(const shared_ptr<_Ty1>& _Left, const shared_ptr<_Ty2>& _Right) noexcept {
@@ -1838,7 +1837,6 @@ template <class _Ty>
 _NODISCARD strong_ordering operator<=>(const shared_ptr<_Ty>& _Left, nullptr_t) noexcept {
     return _Left.get() <=> static_cast<typename shared_ptr<_Ty>::element_type*>(nullptr);
 }
-
 #else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
 template <class _Ty>
 _NODISCARD bool operator==(nullptr_t, const shared_ptr<_Ty>& _Right) noexcept {

--- a/stl/inc/queue
+++ b/stl/inc/queue
@@ -156,12 +156,13 @@ public:
     friend bool operator>  <>(const queue&, const queue&);
     friend bool operator<= <>(const queue&, const queue&);
     friend bool operator>= <>(const queue&, const queue&);
+    // clang-format on
+
 #ifdef __cpp_lib_concepts
     template <class _Ty2, three_way_comparable _Container2>
     friend compare_three_way_result_t<_Container2> operator<=>(
         const queue<_Ty2, _Container2>&, const queue<_Ty2, _Container2>&);
 #endif // __cpp_lib_concepts
-    // clang-format on
 
 protected:
     _Container c{};

--- a/stl/inc/scoped_allocator
+++ b/stl/inc/scoped_allocator
@@ -248,22 +248,20 @@ scoped_allocator_adaptor(_Outer, _Inner...) -> scoped_allocator_adaptor<_Outer, 
 
 template <class _Outer1, class _Outer2, class _Inner1, class... _Inner>
 _NODISCARD bool operator==(const scoped_allocator_adaptor<_Outer1, _Inner1, _Inner...>& _Left,
-    const scoped_allocator_adaptor<_Outer2, _Inner1, _Inner...>&
-        _Right) noexcept { // compare scoped_allocator_adaptors for equality
+    const scoped_allocator_adaptor<_Outer2, _Inner1, _Inner...>& _Right) noexcept {
     return _Left.outer_allocator() == _Right.outer_allocator() && _Left.inner_allocator() == _Right.inner_allocator();
 }
 
 template <class _Outer1, class _Outer2>
-_NODISCARD bool operator==(const scoped_allocator_adaptor<_Outer1>& _Left,
-    const scoped_allocator_adaptor<_Outer2>& _Right) noexcept { // compare scoped_allocator_adaptors for equality
+_NODISCARD bool operator==(
+    const scoped_allocator_adaptor<_Outer1>& _Left, const scoped_allocator_adaptor<_Outer2>& _Right) noexcept {
     return _Left.outer_allocator() == _Right.outer_allocator();
 }
 
 #if !_HAS_CXX20
 template <class _Outer1, class _Outer2, class... _Inner>
 _NODISCARD bool operator!=(const scoped_allocator_adaptor<_Outer1, _Inner...>& _Left,
-    const scoped_allocator_adaptor<_Outer2, _Inner...>&
-        _Right) noexcept { // compare scoped_allocator_adaptors for equality
+    const scoped_allocator_adaptor<_Outer2, _Inner...>& _Right) noexcept {
     return !(_Left == _Right);
 }
 #endif // !_HAS_CXX20

--- a/stl/inc/stack
+++ b/stl/inc/stack
@@ -146,12 +146,13 @@ public:
     friend bool operator>  <>(const stack&, const stack&);
     friend bool operator<= <>(const stack&, const stack&);
     friend bool operator>= <>(const stack&, const stack&);
+    // clang-format on
+
 #ifdef __cpp_lib_concepts
     template <class _Ty2, three_way_comparable _Container2>
     friend compare_three_way_result_t<_Container2> operator<=>(
         const stack<_Ty2, _Container2>&, const stack<_Ty2, _Container2>&);
 #endif // __cpp_lib_concepts
-    // clang-format on
 
 protected:
     _Container c{};

--- a/tests/tr1/expected_results.txt
+++ b/tests/tr1/expected_results.txt
@@ -1,2 +1,5 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# TRANSITION, flaky test (see GH-1642 and GH-718)
+tests/thread SKIPPED

--- a/tests/tr1/test.lst
+++ b/tests/tr1/test.lst
@@ -180,7 +180,7 @@ tests\string2
 tests\strstream
 tests\system_error
 
-# TRANSITION, flaky test
+# TRANSITION, flaky test (see GH-1642 and GH-718)
 # tests\thread
 
 tests\tuple


### PR DESCRIPTION
* Skip `tr1/tests/thread` due to #1642 - there are both product and test issues here. We were already skipping it for the MSVC-internal test harness, but the GitHub test harness runs all test directories by default (ignoring `test.lst`), so we need to skip it with `expected_results.txt`.
* Remove unnecessary blank lines that @mnatsuhara noticed while reviewing #1678.
* Remove unnecessary comments in `scoped_allocator_adaptor`'s equality operators that were causing annoying wrapping.
* `queue` and `stack` disable clang-format to make this syntax easier to understand:
  https://github.com/microsoft/STL/blob/b52c3797e262cbce28166d92f9d1b8f2bfeb5ac5/stl/inc/queue#L152-L158
  Otherwise, clang-format would make this look like `operator<=<>` which is totally weird. However, the spaceship operator uses different syntax, so we can move it outside of the region where clang-format is disabled.