### PR TITLE
Enable constexpr_vector_bool internal testing

### DIFF
--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -3031,12 +3031,18 @@ public:
         _Iterator_base12** _Pnext = &this->_Myproxy->_Myfirstiter;
         while (*_Pnext) { // test offset from beginning of vector
             const auto& _Pnextiter = static_cast<const_iterator&>(**_Pnext);
-            const auto _Off        = static_cast<size_type>(_VBITS * (_Pnextiter._Myptr - _Base)) + _Pnextiter._Myoff;
+            const auto _Temp       = *_Pnext; // TRANSITION, VSO-1269037
+            if (!_Pnextiter._Myptr) { // orphan the iterator
+                _Temp->_Myproxy = nullptr;
+                *_Pnext         = _Temp->_Mynextiter;
+                continue;
+            }
+            const auto _Off = static_cast<size_type>(_VBITS * (_Pnextiter._Myptr - _Base)) + _Pnextiter._Myoff;
             if (_Off < _Offlo || _Offhi < _Off) {
-                _Pnext = &(*_Pnext)->_Mynextiter;
+                _Pnext = &_Temp->_Mynextiter;
             } else { // orphan the iterator
-                (*_Pnext)->_Myproxy = nullptr;
-                *_Pnext             = (*_Pnext)->_Mynextiter;
+                _Temp->_Myproxy = nullptr;
+                *_Pnext         = _Temp->_Mynextiter;
             }
         }
     }

--- a/tests/std/tests/P1004R2_constexpr_vector_bool/test.cpp
+++ b/tests/std/tests/P1004R2_constexpr_vector_bool/test.cpp
@@ -73,8 +73,8 @@ struct soccc_allocator {
 using vec = vector<bool, soccc_allocator<bool>>;
 
 _CONSTEXPR20_CONTAINER bool test_interface() {
-#if defined(__EDG__) \
-    || _ITERATOR_DEBUG_LEVEL != 2 // || defined(MSVC_INTERNAL_TESTING) // TRANSITION, VSO-1270433, VSO-1275530
+#if defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 \
+    || defined(MSVC_INTERNAL_TESTING) // TRANSITION, VSO-1270433, VSO-1275530
     { // constructors
 
 // Non allocator constructors
@@ -541,8 +541,8 @@ _CONSTEXPR20_CONTAINER bool test_interface() {
 }
 
 _CONSTEXPR20_CONTAINER bool test_iterators() {
-#if defined(__EDG__) \
-    || _ITERATOR_DEBUG_LEVEL != 2 // || defined(MSVC_INTERNAL_TESTING) // TRANSITION, VSO-1270433, VSO-1275530
+#if defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 \
+    || defined(MSVC_INTERNAL_TESTING) // TRANSITION, VSO-1270433, VSO-1275530
 #ifndef __EDG__ // TRANSITION, VSO-1274387
     vec range_constructed(begin(input), end(input));
 


### PR DESCRIPTION
* Enables constexpr_vector_bool testing with `MSVC_INTERNAL_TESTING`

* Adds a workaround to `_Orphan_range_unlocked` in `vector<bool>`

* Fixes UB resulting from subtracting from a nullptr

Mirrors changes in MSVC-PR-306712.
<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
