### PR TITLE
Fix bug in memset optimization of ranges::uninitialized_value_construct

### DIFF
--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -538,7 +538,7 @@ namespace ranges {
 
         template <forward_iterator _It, sentinel_for<_It> _Se, class _Pj = identity,
             indirect_binary_predicate<projected<_It, _Pj>, projected<_It, _Pj>> _Pr = ranges::equal_to>
-        _NODISCARD constexpr _It operator()(_It _First, const _Se _Last, _Pr _Pred = {}, _Pj _Proj = {}) const {
+        _NODISCARD constexpr _It operator()(_It _First, _Se _Last, _Pr _Pred = {}, _Pj _Proj = {}) const {
             _Adl_verify_range(_First, _Last);
 
             auto _UResult = _Adjacent_find_unchecked(

--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -334,7 +334,7 @@ namespace ranges {
 
     private:
         template <class _It, class _Se, class _Ty>
-        _NODISCARD static _It _Uninitialized_fill_unchecked(_It _OFirst, const _Se _OLast, const _Ty& _Val) {
+        _NODISCARD static _It _Uninitialized_fill_unchecked(_It _OFirst, _Se _OLast, const _Ty& _Val) {
             _STL_INTERNAL_STATIC_ASSERT(_No_throw_forward_iterator<_It>);
             _STL_INTERNAL_STATIC_ASSERT(_No_throw_sentinel_for<_Se, _It>);
             _STL_INTERNAL_STATIC_ASSERT(constructible_from<iter_value_t<_It>, const _Ty&>);
@@ -792,7 +792,7 @@ namespace ranges {
 
     private:
         template <class _It, class _Se>
-        _NODISCARD static _It _Uninitialized_value_construct_unchecked(_It _OFirst, const _Se _OLast) {
+        _NODISCARD static _It _Uninitialized_value_construct_unchecked(_It _OFirst, _Se _OLast) {
             _STL_INTERNAL_STATIC_ASSERT(_No_throw_forward_iterator<_It>);
             _STL_INTERNAL_STATIC_ASSERT(_No_throw_sentinel_for<_Se, _It>);
             _STL_INTERNAL_STATIC_ASSERT(default_initializable<iter_value_t<_It>>);

--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -798,10 +798,7 @@ namespace ranges {
             _STL_INTERNAL_STATIC_ASSERT(default_initializable<iter_value_t<_It>>);
 
             if constexpr (_Use_memset_value_construct_v<_It>) {
-                const auto _OFinal = _RANGES next(_OFirst, _STD move(_OLast));
-                const auto _Count  = static_cast<size_t>(_OFinal - _OFirst);
-                _CSTD memset(_OFirst, 0, _Count);
-                return _OFinal;
+                return _Zero_range(_OFirst, _RANGES next(_OFirst, _STD move(_OLast)));
             } else {
                 _Uninitialized_backout _Backout{_STD move(_OFirst)};
 
@@ -850,8 +847,7 @@ namespace ranges {
 
             auto _UFirst = _Get_unwrapped_n(_STD move(_First), _Count);
             if constexpr (_Use_memset_value_construct_v<_It>) {
-                _CSTD memset(_UFirst, 0, static_cast<size_t>(_Count));
-                _Seek_wrapped(_First, _UFirst + _Count);
+                _Seek_wrapped(_First, _Zero_range(_UFirst, _UFirst + _Count));
             } else {
                 _Uninitialized_backout _Backout{_STD move(_UFirst)};
 

--- a/tests/std/tests/P0896R4_ranges_alg_uninitialized_fill/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_uninitialized_fill/test.cpp
@@ -141,6 +141,20 @@ struct throwing_test {
     }
 };
 
+struct memset_test {
+    static constexpr int expected[] = {42, 42, 42};
+
+    static void call() {
+        { // Validate only range overload
+            int input[3];
+
+            const auto result = ranges::uninitialized_fill(input, 42);
+            assert(result == end(input));
+            assert(ranges::equal(input, expected));
+        }
+    }
+};
+
 using test_range = test::range<test::fwd, int_wrapper, test::Sized::no, test::CanDifference::no, test::Common::no,
     test::CanCompare::yes, test::ProxyRef::no>;
 
@@ -150,4 +164,5 @@ int main() {
 
     instantiator::call<test_range>();
     throwing_test::call<test_range>();
+    memset_test::call();
 }

--- a/tests/std/tests/P0896R4_ranges_alg_uninitialized_fill/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_uninitialized_fill/test.cpp
@@ -142,13 +142,13 @@ struct throwing_test {
 };
 
 struct memset_test {
-    static constexpr int expected[] = {42, 42, 42};
+    static constexpr unsigned char expected[] = {42, 42, 42};
 
     static void call() {
         { // Validate only range overload
-            int input[3];
+            unsigned char input[3];
 
-            const auto result = ranges::uninitialized_fill(input, 42);
+            const auto result = ranges::uninitialized_fill(input, static_cast<unsigned char>(42));
             assert(result == end(input));
             assert(ranges::equal(input, expected));
         }

--- a/tests/std/tests/P0896R4_ranges_alg_uninitialized_fill_n/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_uninitialized_fill_n/test.cpp
@@ -121,13 +121,13 @@ struct throwing_test {
 };
 
 struct memset_test {
-    static constexpr int expected[] = {42, 42, 42};
+    static constexpr unsigned char expected[] = {42, 42, 42};
 
     static void call() {
         { // Validate only range overload
-            int input[3];
+            unsigned char input[3];
 
-            const auto result = ranges::uninitialized_fill_n(input, 3, 42);
+            const auto result = ranges::uninitialized_fill_n(input, 3, static_cast<unsigned char>(42));
             assert(result == end(input));
             assert(ranges::equal(input, expected));
         }

--- a/tests/std/tests/P0896R4_ranges_alg_uninitialized_fill_n/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_uninitialized_fill_n/test.cpp
@@ -120,6 +120,20 @@ struct throwing_test {
     }
 };
 
+struct memset_test {
+    static constexpr int expected[] = {42, 42, 42};
+
+    static void call() {
+        { // Validate only range overload
+            int input[3];
+
+            const auto result = ranges::uninitialized_fill_n(input, 3, 42);
+            assert(result == end(input));
+            assert(ranges::equal(input, expected));
+        }
+    }
+};
+
 using test_range = test::range<test::fwd, int_wrapper, test::Sized::no, test::CanDifference::no, test::Common::no,
     test::CanCompare::yes, test::ProxyRef::no>;
 
@@ -129,4 +143,5 @@ int main() {
 
     instantiator::call<test_range>();
     throwing_test::call<test_range>();
+    memset_test::call();
 }

--- a/tests/std/tests/P0896R4_ranges_alg_uninitialized_value_construct/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_uninitialized_value_construct/test.cpp
@@ -121,6 +121,20 @@ struct throwing_test {
     }
 };
 
+struct memset_test {
+    static constexpr int expected[] = {0, 0, 0};
+
+    static void call() {
+        { // Validate only range overload
+            int input[3];
+
+            const auto result = ranges::uninitialized_value_construct(input);
+            assert(result == end(input));
+            assert(ranges::equal(input, expected));
+        }
+    }
+};
+
 using test_range = test::range<test::fwd, int_wrapper, test::Sized::no, test::CanDifference::no, test::Common::no,
     test::CanCompare::yes, test::ProxyRef::no>;
 
@@ -130,4 +144,5 @@ int main() {
 
     instantiator::call<test_range>();
     throwing_test::call<test_range>();
+    memset_test::call();
 }

--- a/tests/std/tests/P0896R4_ranges_alg_uninitialized_value_construct_n/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_uninitialized_value_construct_n/test.cpp
@@ -100,6 +100,20 @@ struct throwing_test {
     }
 };
 
+struct memset_test {
+    static constexpr int expected[] = {0, 0, 0};
+
+    static void call() {
+        { // Validate only range overload
+            int input[3];
+
+            const auto result = ranges::uninitialized_value_construct_n(begin(input), 3);
+            assert(result == end(input));
+            assert(ranges::equal(input, expected));
+        }
+    }
+};
+
 using test_range = test::range<test::fwd, int_wrapper, test::Sized::no, test::CanDifference::no, test::Common::no,
     test::CanCompare::yes, test::ProxyRef::no>;
 
@@ -109,4 +123,5 @@ int main() {
 
     instantiator::call<test_range>();
     throwing_test::call<test_range>();
+    memset_test::call();
 }


### PR DESCRIPTION
🤦 

memset takes count in bytes not number of elements...