### PR TITLE
<format>: Enable void* and nullptr tests

### DIFF
--- a/stl/inc/format
+++ b/stl/inc/format
@@ -915,7 +915,7 @@ template <class _Context, class _Ty>
     requires is_void_v<_Ty>
 /* consteval */ constexpr auto _Get_format_arg_storage_type(const _Ty*) noexcept {
     // clang-format on
-    return static_cast<void*>(nullptr);
+    return static_cast<const void*>(nullptr);
 }
 
 template <class _Context, class _Ty>
@@ -967,8 +967,11 @@ private:
     }
 
     // See [format.arg]/5
+    // clang-format off
     template <class _Ty>
+        requires _Has_formatter<_Context, _Ty>
     void _Store(const size_t _Arg_index, const _Ty& _Val) noexcept {
+        // clang-format on
         _Store_impl<typename basic_format_arg<_Context>::handle>(
             _Arg_index, _Basic_format_arg_type::_Custom_type, basic_format_arg<_Context>::handle(_Val));
     }

--- a/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
@@ -107,7 +107,6 @@ int main() {
         make_format_args(static_cast<const void*>(nullptr)));
     assert(output_string == "0x0");
 
-    /* TODO: Doesn't properly overload on void* and nullptr
     // Test void*
     output_string.clear();
     vformat_to(
@@ -118,7 +117,6 @@ int main() {
     output_string.clear();
     vformat_to(back_insert_iterator(output_string), locale::classic(), "{}", make_format_args(nullptr));
     assert(output_string == "0x0");
-    */
 
     // Test signed integers
     output_string.clear();


### PR DESCRIPTION
Enables the tests, fixes a bug that prevents the tests from working by
constraining `_Store` on `_Has_formatter`. Also fixes a (visual only)
inconsistency of the return type of `_Get_format_arg_store_type`.

<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
