### PR TITLE
<format>: call writer functions with specs when specs are provided

### DIFF
--- a/stl/inc/format
+++ b/stl/inc/format
@@ -676,6 +676,9 @@ public:
     }
 
     constexpr void _On_type(_CharT _Type) {
+        if (_Type < 0 || _Type > (numeric_limits<signed char>::max)()) {
+            throw format_error("Invalid type specification.");
+        }
         _Specs._Type = static_cast<char>(_Type);
     }
 

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -679,6 +679,8 @@ public:
     }
 
     constexpr void _On_type(_CharT _Type) {
+        // performance note: this could be optimized to one comparison by
+        // first casting to unsigned int (the negative values will be 128-255)
         if (_Type < 0 || _Type > (numeric_limits<signed char>::max)()) {
             throw format_error("Invalid type specification.");
         }

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -615,14 +615,15 @@ constexpr void _Parse_format_string(basic_string_view<_CharT> _Format_str, _Hand
 
 template <class _CharT>
 struct _Basic_format_specs {
-    unsigned int _Width;
-    unsigned int _Precision;
-    char _Type;
-    _Align _Alignment;
-    _Sign _Sgn;
-    bool _Alt;
+    unsigned int _Width     = 0;
+    unsigned int _Precision = 0;
+    char _Type              = '\0';
+    _Align _Alignment       = _Align::_None;
+    _Sign _Sgn              = _Sign::_None;
+    bool _Alt               = false;
+    bool _Localized         = false;
     // At most one codepoint (so one char32_t or four utf-8 char8_t).
-    _CharT _Fill[4];
+    _CharT _Fill[4] = {' ', _CharT{0}, _CharT{0}, _CharT{0}};
 };
 
 // Model of _Parse_specs_callbacks that fills a _Basic_format_specs with the parsed data.
@@ -665,7 +666,7 @@ public:
     }
 
     constexpr void _On_type(_CharT _Type) {
-        _Specs._Type = static_cast<_CharT>(_Type);
+        _Specs._Type = static_cast<char>(_Type);
     }
 
 protected:
@@ -1219,27 +1220,14 @@ _OutputIt _Write(_OutputIt _Out, basic_string_view<_CharT> _Value) {
     return _STD copy(_Value.begin(), _Value.end(), _Out);
 }
 
-// Dispatcher to call enabled custom formatters, and do nothing otherwise.
-template <class _Context>
-class _Custom_formatter_dispatcher {
-private:
-    using _Char_type = typename _Context::char_type;
-
-    basic_format_parse_context<_Char_type>& _Parse_ctx;
-    _Context& _Ctx;
-
-public:
-    explicit constexpr _Custom_formatter_dispatcher(
-        basic_format_parse_context<_Char_type>& _Parse_ctx_, _Context& _Ctx_)
-        : _Parse_ctx(_Parse_ctx_), _Ctx(_Ctx_) {}
-
-    void operator()(typename basic_format_arg<_Context>::handle _Handle) const {
-        _Handle.format(_Parse_ctx, _Ctx);
-    }
-
-    template <class _Ty>
-    void operator()(_Ty) const {}
-};
+// TODO: placeholder write
+template <class _CharT, class _OutputIt, class _Ty>
+_OutputIt _Write(_OutputIt _Out, _Ty _Val, _Basic_format_specs<_CharT>& _Specs) {
+    _STL_INTERNAL_CHECK(false);
+    (void) _Val;
+    (void) _Specs;
+    return _Out;
+}
 
 // This is the visitor that's used for "simple" replacement fields,
 // it could be a generic lambda (with overloaded), but that's
@@ -1263,6 +1251,31 @@ struct _Default_arg_formatter {
         basic_format_context<_OutputIt, _CharT> _Format_ctx(_Out, _Args, _Loc);
         _Handle.format(_Parse_ctx, _Format_ctx);
         return _Format_ctx.out();
+    }
+};
+
+// Visitor used for replacement fields that contain specs
+template <class _OutputIt, class _CharT>
+struct _Arg_formatter {
+    using _Context = basic_format_context<_OutputIt, _CharT>;
+
+    _Context* _Ctx                                 = nullptr;
+    _Basic_format_specs<_CharT>* _Specs            = nullptr;
+    basic_format_parse_context<_CharT>* _Parse_ctx = nullptr;
+
+    _OutputIt operator()(typename basic_format_arg<_Context>::handle _Handle) {
+        _STL_ASSERT(false, "The custom handler should be structurally unreachable for _Arg_formatter");
+        _STL_INTERNAL_CHECK(_Parse_ctx);
+        _STL_INTERNAL_CHECK(_Ctx);
+        _Handle.format(*_Parse_ctx, *_Ctx);
+        return _Ctx->out();
+    }
+
+    template <class _Ty>
+    _OutputIt operator()(_Ty _Val) {
+        _STL_INTERNAL_CHECK(_Specs);
+        _STL_INTERNAL_CHECK(_Ctx);
+        return _Write(_Ctx->out(), _Val, *_Specs);
     }
 };
 
@@ -1300,8 +1313,13 @@ struct _Format_handler {
         if (_Begin == _End || *_Begin != '}') {
             throw format_error("Missing '}' in format string.");
         }
-        // TODO: implement format spec dispatching.
-        _STL_INTERNAL_CHECK(false);
+        _Ctx.advance_to(visit_format_arg(
+            _Arg_formatter<_OutputIt, _CharT>{
+                ._Ctx       = &_Ctx,
+                ._Specs     = &_Specs,
+                ._Parse_ctx = &_Parse_context,
+            },
+            _Arg));
         return _Begin;
     }
 };

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -1329,7 +1329,7 @@ struct _Format_handler {
         if (_Begin == _End || *_Begin != '}') {
             throw format_error("Missing '}' in format string.");
         }
-        _Ctx.advance_to(visit_format_arg(
+        _Ctx.advance_to(_STD visit_format_arg(
             _Arg_formatter<_OutputIt, _CharT>{
                 ._Ctx       = &_Ctx,
                 ._Specs     = &_Specs,

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -625,13 +625,14 @@ constexpr void _Parse_format_string(basic_string_view<_CharT> _Format_str, _Hand
 
 template <class _CharT>
 struct _Basic_format_specs {
-    int _Width        = 0;
-    int _Precision    = -1;
-    char _Type        = '\0';
-    _Align _Alignment = _Align::_None;
-    _Sign _Sgn        = _Sign::_None;
-    bool _Alt         = false;
-    bool _Localized   = false;
+    int _Width         = 0;
+    int _Precision     = -1;
+    char _Type         = '\0';
+    _Align _Alignment  = _Align::_None;
+    _Sign _Sgn         = _Sign::_None;
+    bool _Alt          = false;
+    bool _Localized    = false;
+    bool _Leading_zero = false;
     // At most one codepoint (so one char32_t or four utf-8 char8_t).
     _CharT _Fill[4] = {' ', _CharT{0}, _CharT{0}, _CharT{0}};
 };
@@ -663,8 +664,10 @@ public:
     }
 
     constexpr void _On_zero() {
-        _Specs._Alignment = _Align::_None;
-        _Specs._Fill[0]   = _CharT{'0'};
+        _Specs._Leading_zero = true;
+        if (_Specs._Alignment == _Align::_None) {
+            _Specs._Fill[0] = _CharT{'0'};
+        }
     }
 
     constexpr void _On_width(int _Width) {

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -71,10 +71,10 @@ template <class _Ty, class _CharT>
 concept _Parse_spec_callbacks = requires(_Ty _At, basic_string_view<_CharT> _Sv, _Align _Aln, _Sign _Sgn) {
     { _At._On_align(_Aln) } -> same_as<void>;
     { _At._On_fill(_Sv) } -> same_as<void>;
-    { _At._On_width(static_cast<unsigned int>(0)) } -> same_as<void>;
+    { _At._On_width(int{}) } -> same_as<void>;
     { _At._On_dynamic_width(size_t{}) } -> same_as<void>;
     { _At._On_dynamic_width(_Auto_id_tag{}) } -> same_as<void>;
-    { _At._On_precision(static_cast<unsigned int>(0)) } -> same_as<void>;
+    { _At._On_precision(int{}) } -> same_as<void>;
     { _At._On_dynamic_precision(size_t{}) } -> same_as<void>;
     { _At._On_dynamic_precision(_Auto_id_tag{}) } -> same_as<void>;
     { _At._On_sign(_Sgn) } -> same_as<void>;
@@ -278,7 +278,7 @@ auto visit_format_arg(_Visitor&& _Vis, basic_format_arg<_Context> _Arg) {
     }
 }
 
-// we need to implement this ourselves because from_chars does not work with wide characters
+// we need to implement this ourselves because from_chars does not work with wide characters and isn't constexpr
 template <class _CharT>
 constexpr const _CharT* _Parse_nonnegative_integer(const _CharT* _Begin, const _CharT* _End, unsigned int& _Value) {
     _STL_INTERNAL_CHECK(_Begin != _End && '0' <= *_Begin && *_Begin <= '9');
@@ -297,6 +297,16 @@ constexpr const _CharT* _Parse_nonnegative_integer(const _CharT* _Begin, const _
     if (_Value > _Max_int) {
         throw format_error("Number is too big");
     }
+    return _Begin;
+}
+
+template <class _CharT>
+constexpr const _CharT* _Parse_nonnegative_integer(const _CharT* _Begin, const _CharT* _End, int& _Value) {
+    unsigned int _Val_unsigned = 0;
+
+    _Begin = _Parse_nonnegative_integer(_Begin, _End, _Val_unsigned);
+    // Never invalid because _Parse_nonnegative_integer throws an error for values that don't fit in signed integers
+    _Value = static_cast<int>(_Val_unsigned);
     return _Begin;
 }
 
@@ -432,8 +442,8 @@ template <class _CharT, _Parse_spec_callbacks<_CharT> _Callbacks_type>
 constexpr const _CharT* _Parse_width(const _CharT* _Begin, const _CharT* _End, _Callbacks_type&& _Callbacks) {
     _STL_INTERNAL_CHECK(_Begin != _End);
     if ('1' <= *_Begin && *_Begin <= '9') {
-        unsigned int _Value = 0;
-        _Begin              = _Parse_nonnegative_integer(_Begin, _End, _Value);
+        int _Value = 0;
+        _Begin     = _Parse_nonnegative_integer(_Begin, _End, _Value);
         _Callbacks._On_width(_Value);
     } else if (*_Begin == '{') {
         ++_Begin;
@@ -457,8 +467,8 @@ constexpr const _CharT* _Parse_precision(const _CharT* _Begin, const _CharT* _En
     }
 
     if ('0' <= _Ch && _Ch <= '9') {
-        unsigned int _Precision = 0;
-        _Begin                  = _Parse_nonnegative_integer(_Begin, _End, _Precision);
+        int _Precision = 0;
+        _Begin         = _Parse_nonnegative_integer(_Begin, _End, _Precision);
         _Callbacks._On_precision(_Precision);
     } else if (_Ch == '{') {
         ++_Begin;
@@ -615,13 +625,13 @@ constexpr void _Parse_format_string(basic_string_view<_CharT> _Format_str, _Hand
 
 template <class _CharT>
 struct _Basic_format_specs {
-    unsigned int _Width     = 0;
-    unsigned int _Precision = 0;
-    char _Type              = '\0';
-    _Align _Alignment       = _Align::_None;
-    _Sign _Sgn              = _Sign::_None;
-    bool _Alt               = false;
-    bool _Localized         = false;
+    int _Width        = 0;
+    int _Precision    = -1;
+    char _Type        = '\0';
+    _Align _Alignment = _Align::_None;
+    _Sign _Sgn        = _Sign::_None;
+    bool _Alt         = false;
+    bool _Localized   = false;
     // At most one codepoint (so one char32_t or four utf-8 char8_t).
     _CharT _Fill[4] = {' ', _CharT{0}, _CharT{0}, _CharT{0}};
 };
@@ -657,11 +667,11 @@ public:
         _Specs._Fill[0]   = _CharT{'0'};
     }
 
-    constexpr void _On_width(unsigned int _Width) {
+    constexpr void _On_width(int _Width) {
         _Specs._Width = _Width;
     }
 
-    constexpr void _On_precision(unsigned int _Precision) {
+    constexpr void _On_precision(int _Precision) {
         _Specs._Precision = _Precision;
     }
 
@@ -762,12 +772,12 @@ private:
     // width or precision specifier. This will be called with either
     // _Width_checker or _Precision_checker as "_Handler".
     template <class _Handler, class _FormatArg>
-    static constexpr unsigned int _Get_dynamic_specs(_FormatArg _Arg) {
+    static constexpr int _Get_dynamic_specs(_FormatArg _Arg) {
         unsigned long long _Val = _STD visit_format_arg(_Handler(), _Arg);
-        if (_Val > (numeric_limits<unsigned int>::max)()) {
+        if (_Val > (numeric_limits<int>::max)()) {
             throw format_error("Number is too big.");
         }
-        return static_cast<unsigned int>(_Val);
+        return static_cast<int>(_Val);
     }
 };
 
@@ -835,7 +845,7 @@ public:
         _Handler::_On_zero();
     }
 
-    constexpr void _On_precision(unsigned int _Precision) {
+    constexpr void _On_precision(int _Precision) {
         _Numeric_checker._Check_precision();
         _Handler::_On_precision(_Precision);
     }

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -1331,9 +1331,9 @@ struct _Format_handler {
         }
         _Ctx.advance_to(_STD visit_format_arg(
             _Arg_formatter<_OutputIt, _CharT>{
-                ._Ctx       = &_Ctx,
-                ._Specs     = &_Specs,
-                ._Parse_ctx = &_Parse_context,
+                ._Ctx       = _STD addressof(_Ctx),
+                ._Specs     = _STD addressof(_Specs),
+                ._Parse_ctx = _STD addressof(_Parse_context),
             },
             _Arg));
         return _Begin;

--- a/tests/std/tests/P0645R10_text_formatting_parsing/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_parsing/test.cpp
@@ -51,10 +51,10 @@ struct testing_callbacks {
     _Align expected_alignment = _Align::_None;
     _Sign expected_sign       = _Sign::_None;
     basic_string_view<CharT> expected_fill;
-    unsigned int expected_width          = static_cast<unsigned int>(-1);
+    int expected_width                   = -1;
     size_t expected_dynamic_width        = static_cast<size_t>(-1);
     bool expected_auto_dynamic_width     = false;
-    unsigned int expected_precision      = static_cast<unsigned int>(-1);
+    int expected_precision               = -1;
     size_t expected_dynamic_precision    = static_cast<size_t>(-1);
     bool expected_auto_dynamic_precision = false;
     bool expected_hash                   = false;
@@ -66,7 +66,7 @@ struct testing_callbacks {
     constexpr void _On_fill(basic_string_view<CharT> str_view) {
         assert(str_view == expected_fill);
     }
-    constexpr void _On_width(unsigned int width) {
+    constexpr void _On_width(int width) {
         assert(width == expected_width);
     }
     constexpr void _On_dynamic_width(size_t id) {
@@ -75,7 +75,7 @@ struct testing_callbacks {
     constexpr void _On_dynamic_width(_Auto_id_tag) {
         assert(expected_auto_dynamic_width);
     }
-    constexpr void _On_precision(unsigned int pre) {
+    constexpr void _On_precision(int pre) {
         assert(pre == expected_precision);
     }
     constexpr void _On_dynamic_precision(size_t id) {


### PR DESCRIPTION
* `_Arg_formatter` could perhaps be merged with `_Custom_arg_formatter`, they are separate in libfmt for what looks like perf reasons, but it shouldn't be a huge deal if we merge them.
* added a version of `_Parse_nonnegative_integer` that outputs signed integers (it's just a cast, but makes the types line up for both width/precision and for argument IDs).