### PR TITLE
Toolset update: VS 2019 16.10 Preview 1

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,6 +7,7 @@
 # Ensure GitHub detects our C++ code as C++ code.
 /stl/inc/** linguist-language=C++
 /stl/src/** linguist-language=C++
+*.h linguist-language=C++
 
 # Ensure GitHub detects our Perl legacy test harness code as Perl code instead of Raku.
 *.pl linguist-language=Perl

--- a/.gitattributes
+++ b/.gitattributes
@@ -9,5 +9,8 @@
 /stl/src/** linguist-language=C++
 *.h linguist-language=C++
 
+# Ensure GitHub detects lit.cfg and lit.local.cfg as Python instead of HAProxy.
+*.cfg linguist-language=Python
+
 # Ensure GitHub detects our Perl legacy test harness code as Perl code instead of Raku.
 *.pl linguist-language=Perl

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ project(msvc_standard_libraries LANGUAGES CXX)
 
 find_package(Boost REQUIRED)
 
-set(VCLIBS_MIN_BOOST_VERSION 1.74.0)
+set(VCLIBS_MIN_BOOST_VERSION 1.75.0)
 if("${Boost_VERSION}" VERSION_LESS "${VCLIBS_MIN_BOOST_VERSION}")
     message(FATAL_ERROR "Detected Boost version is too old (older than ${VCLIBS_MIN_BOOST_VERSION}).")
 endif()

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 The STL uses boost-math headers to provide P0226R1 Mathematical Special Functions. We recommend using [vcpkg][] to
 acquire this dependency.
 
-1. Install Visual Studio 2019 16.9 Preview 4 or later.
+1. Install Visual Studio 2019 16.10 Preview 1 or later.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
     * Otherwise, install [CMake][] 3.19 or later, and [Ninja][] 1.10.2 or later.
@@ -158,7 +158,7 @@ acquire this dependency.
 
 # How To Build With A Native Tools Command Prompt
 
-1. Install Visual Studio 2019 16.9 Preview 4 or later.
+1. Install Visual Studio 2019 16.10 Preview 1 or later.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
     * Otherwise, install [CMake][] 3.19 or later, and [Ninja][] 1.10.2 or later.
@@ -234,7 +234,7 @@ C:\Users\username\Desktop>dumpbin /IMPORTS .\example.exe | findstr msvcp
 # How To Run The Tests With A Native Tools Command Prompt
 
 1. Follow either [How To Build With A Native Tools Command Prompt][] or [How To Build With The Visual Studio IDE][].
-2. Acquire [Python][] 3.9.1 or newer and have it on the `PATH` (or run it directly using its absolute or relative path).
+2. Acquire [Python][] 3.9.2 or newer and have it on the `PATH` (or run it directly using its absolute or relative path).
 3. Have LLVM's `bin` directory on the `PATH` (so `clang-cl.exe` is available).
     * We recommend selecting "C++ Clang tools for Windows" in the VS Installer. This will automatically add LLVM to the
     `PATH` of the x86 and x64 Native Tools Command Prompts, and will ensure that you're using a supported version.

--- a/azure-devops/create-vmss.ps1
+++ b/azure-devops/create-vmss.ps1
@@ -20,9 +20,9 @@ $ErrorActionPreference = 'Stop'
 # https://aka.ms/azps-changewarnings
 $Env:SuppressAzurePowerShellBreakingChangeWarnings = 'true'
 
-$Location = 'northeurope'
+$Location = 'westus2'
 $Prefix = 'StlBuild-' + (Get-Date -Format 'yyyy-MM-dd')
-$VMSize = 'Standard_D32as_v4'
+$VMSize = 'Standard_D32ds_v4'
 $ProtoVMName = 'PROTOTYPE'
 $LiveVMPrefix = 'BUILD'
 $WindowsServerSku = '2019-Datacenter'

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -91,7 +91,7 @@ if ([string]::IsNullOrEmpty($AdminUserPassword)) {
   $PsExecPath = Join-Path $ExtractedPsToolsPath 'PsExec64.exe'
 
   # https://github.com/PowerShell/PowerShell/releases/latest
-  $PowerShellZipUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.1.1/PowerShell-7.1.1-win-x64.zip'
+  $PowerShellZipUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.1.2/PowerShell-7.1.2-win-x64.zip'
   Write-Host "Downloading: $PowerShellZipUrl"
   $ExtractedPowerShellPath = DownloadAndExtractZip -Url $PowerShellZipUrl
   $PwshPath = Join-Path $ExtractedPowerShellPath 'pwsh.exe'
@@ -139,7 +139,7 @@ $Workloads = @(
 $ReleaseInPath = 'Preview'
 $Sku = 'Enterprise'
 $VisualStudioBootstrapperUrl = 'https://aka.ms/vs/16/pre/vs_enterprise.exe'
-$PythonUrl = 'https://www.python.org/ftp/python/3.9.1/python-3.9.1-amd64.exe'
+$PythonUrl = 'https://www.python.org/ftp/python/3.9.2/python-3.9.2-amd64.exe'
 
 # https://docs.microsoft.com/en-us/windows-hardware/drivers/download-the-wdk
 $WindowsDriverKitUrl = 'https://go.microsoft.com/fwlink/?linkid=2128854'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@ variables:
   buildOutputLocation: 'D:\build'
   vcpkgLocation: '$(Build.SourcesDirectory)/vcpkg'
 
-pool: 'StlBuild-2021-02-17'
+pool: 'StlBuild-2021-03-02'
 
 stages:
   - stage: Code_Format

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -1809,57 +1809,28 @@ inline constexpr bool is_nothrow_invocable_r_v =
 #ifndef __clang__ // TRANSITION, LLVM-48860
 // STRUCT TEMPLATE is_layout_compatible
 template <class _Ty1, class _Ty2>
-#ifdef _IS_LAYOUT_COMPATIBLE_SUPPORTED
-struct is_layout_compatible : bool_constant<__is_layout_compatible(_Ty1, _Ty2)> {
-#else // ^^^ _IS_LAYOUT_COMPATIBLE_SUPPORTED / !_IS_LAYOUT_COMPATIBLE_SUPPORTED vvv
-struct is_layout_compatible : bool_constant<__builtin_is_layout_compatible(_Ty1, _Ty2)> {
-#endif // _IS_LAYOUT_COMPATIBLE_SUPPORTED
-};
+struct is_layout_compatible : bool_constant<__is_layout_compatible(_Ty1, _Ty2)> {};
 
 template <class _Ty1, class _Ty2>
-#ifdef _IS_LAYOUT_COMPATIBLE_SUPPORTED
 inline constexpr bool is_layout_compatible_v = __is_layout_compatible(_Ty1, _Ty2);
-#else // ^^^ _IS_LAYOUT_COMPATIBLE_SUPPORTED / !_IS_LAYOUT_COMPATIBLE_SUPPORTED vvv
-inline constexpr bool is_layout_compatible_v = __builtin_is_layout_compatible(_Ty1, _Ty2);
-#endif // _IS_LAYOUT_COMPATIBLE_SUPPORTED
 
 // STRUCT TEMPLATE is_pointer_interconvertible_base_of
 template <class _Base, class _Derived>
-struct is_pointer_interconvertible_base_of
-#ifdef _IS_LAYOUT_COMPATIBLE_SUPPORTED
-    : bool_constant<__is_pointer_interconvertible_base_of(_Base, _Derived)> {
-};
-#else // ^^^ _IS_LAYOUT_COMPATIBLE_SUPPORTED / !_IS_LAYOUT_COMPATIBLE_SUPPORTED vvv
-    : bool_constant<__builtin_is_pointer_interconvertible_base_of(_Base, _Derived)> {
-};
-#endif // _IS_LAYOUT_COMPATIBLE_SUPPORTED
+struct is_pointer_interconvertible_base_of : bool_constant<__is_pointer_interconvertible_base_of(_Base, _Derived)> {};
 
 template <class _Base, class _Derived>
-#ifdef _IS_LAYOUT_COMPATIBLE_SUPPORTED
 inline constexpr bool is_pointer_interconvertible_base_of_v = __is_pointer_interconvertible_base_of(_Base, _Derived);
-#else // ^^^ _IS_LAYOUT_COMPATIBLE_SUPPORTED / !_IS_LAYOUT_COMPATIBLE_SUPPORTED vvv
-inline constexpr bool is_pointer_interconvertible_base_of_v = __builtin_is_pointer_interconvertible_base_of(
-    _Base, _Derived);
-#endif // _IS_LAYOUT_COMPATIBLE_SUPPORTED
 
 // FUNCTION TEMPLATE is_pointer_interconvertible_with_class
 template <class _ClassTy, class _MemberTy>
 _NODISCARD constexpr bool is_pointer_interconvertible_with_class(_MemberTy _ClassTy::*_Pm) noexcept {
-#ifdef _IS_LAYOUT_COMPATIBLE_SUPPORTED
     return __is_pointer_interconvertible_with_class(_ClassTy, _Pm);
-#else // ^^^ _IS_LAYOUT_COMPATIBLE_SUPPORTED / !_IS_LAYOUT_COMPATIBLE_SUPPORTED vvv
-    return __builtin_is_pointer_interconvertible_with_class(_ClassTy, _Pm);
-#endif // _IS_LAYOUT_COMPATIBLE_SUPPORTED
 }
 
 // FUNCTION TEMPLATE is_corresponding_member
 template <class _ClassTy1, class _ClassTy2, class _MemberTy1, class _MemberTy2>
 _NODISCARD constexpr bool is_corresponding_member(_MemberTy1 _ClassTy1::*_Pm1, _MemberTy2 _ClassTy2::*_Pm2) noexcept {
-#ifdef _IS_LAYOUT_COMPATIBLE_SUPPORTED
     return __is_corresponding_member(_ClassTy1, _ClassTy2, _Pm1, _Pm2);
-#else // ^^^ _IS_LAYOUT_COMPATIBLE_SUPPORTED / !_IS_LAYOUT_COMPATIBLE_SUPPORTED vvv
-    return __builtin_is_corresponding_member(_ClassTy1, _ClassTy2, _Pm1, _Pm2);
-#endif // _IS_LAYOUT_COMPATIBLE_SUPPORTED
 }
 #endif // __clang__
 #endif // __EDG__

--- a/stl/inc/xatomic.h
+++ b/stl/inc/xatomic.h
@@ -31,9 +31,6 @@ _STL_DISABLE_CLANG_WARNINGS
 #ifdef _M_CEE_PURE
 #define _YIELD_PROCESSOR()
 #else // ^^^ _M_CEE_PURE / !_M_CEE_PURE vvv
-#if 1 // TRANSITION, VS 2019 16.10
-extern "C" void _mm_pause(void);
-#endif // TRANSITION, VS 2019 16.10
 #define _YIELD_PROCESSOR() _mm_pause()
 #endif // ^^^ !_M_CEE_PURE ^^^
 

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -531,8 +531,8 @@
 #error STL1000: Unexpected compiler version, expected Clang 11.0.0 or newer.
 #endif // ^^^ old Clang ^^^
 #elif defined(_MSC_VER)
-#if _MSC_VER < 1928 // Coarse-grained, not inspecting _MSC_FULL_VER
-#error STL1001: Unexpected compiler version, expected MSVC 19.28 or newer.
+#if _MSC_VER < 1929 // Coarse-grained, not inspecting _MSC_FULL_VER
+#error STL1001: Unexpected compiler version, expected MSVC 19.29 or newer.
 #endif // ^^^ old MSVC ^^^
 #else // vvv other compilers vvv
 // not attempting to detect other compilers

--- a/stl/msbuild/stl_base/stl.files.settings.targets
+++ b/stl/msbuild/stl_base/stl.files.settings.targets
@@ -57,6 +57,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
             $(CrtRoot)\github\stl\src\cthread.cpp;
             $(CrtRoot)\github\stl\src\mutex.cpp;
             $(CrtRoot)\github\stl\src\pplerror.cpp;
+            $(CrtRoot)\github\stl\src\ppltasks.cpp;
             $(CrtRoot)\github\stl\src\taskscheduler.cpp;
             $(CrtRoot)\github\stl\src\xnotify.cpp;
             $(CrtRoot)\github\stl\src\xtime.cpp;
@@ -146,14 +147,6 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
             $(CrtRoot)\github\stl\src\xwstoxfl.cpp;
             ">
             <BuildAs>nativecpp</BuildAs>
-        </BuildFiles>
-
-        <BuildFiles Include="
-            $(CrtRoot)\github\stl\src\ppltasks.cpp;
-            ">
-            <BuildAs>nativecpp</BuildAs>
-            <!-- ppltasks.cpp uses WRL, which is incompatible with /permissive- as of May 24, 2019 -->
-            <NeedsPermissiveMode>true</NeedsPermissiveMode>
         </BuildFiles>
 
         <BuildFiles Include="

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -375,16 +375,6 @@ std/utilities/utility/pairs/pairs.pair/assign_rv_pair_U_V.pass.cpp:0 FAIL
 std/algorithms/alg.sorting/alg.sort/partial.sort/partial_sort.pass.cpp:0 FAIL
 std/algorithms/alg.sorting/alg.sort/partial.sort/partial_sort_comp.pass.cpp:0 FAIL
 
-# VSO-1275530 "[constexpr] Temporaries created for functions do not have a ctor called (and have a redundant dtor)."
-std/numerics/numeric.ops/exclusive.scan/exclusive_scan.pass.cpp:0 FAIL
-std/numerics/numeric.ops/exclusive.scan/exclusive_scan_init_op.pass.cpp:0 FAIL
-std/numerics/numeric.ops/inclusive.scan/inclusive_scan.pass.cpp:0 FAIL
-std/numerics/numeric.ops/inclusive.scan/inclusive_scan_op.pass.cpp:0 FAIL
-std/numerics/numeric.ops/inclusive.scan/inclusive_scan_op_init.pass.cpp:0 FAIL
-std/numerics/numeric.ops/transform.exclusive.scan/transform_exclusive_scan_init_bop_uop.pass.cpp:0 FAIL
-std/numerics/numeric.ops/transform.inclusive.scan/transform_inclusive_scan_bop_uop.pass.cpp:0 FAIL
-std/numerics/numeric.ops/transform.inclusive.scan/transform_inclusive_scan_bop_uop_init.pass.cpp:0 FAIL
-
 
 # *** CLANG COMPILER BUGS ***
 # LLVM-33230 "Clang on Windows should define __STDCPP_THREADS__ to be 1"

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -358,10 +358,6 @@ std/utilities/meta/meta.unary/meta.unary.prop/is_constructible.pass.cpp:0 FAIL
 std/containers/views/span.cons/ptr_len.pass.cpp:0 FAIL
 std/containers/views/span.cons/ptr_ptr.pass.cpp:0 FAIL
 
-# DevCom-1336819 "cl constexpr temporary passing issue"
-std/numerics/numeric.ops/inner.product/inner_product_comp.pass.cpp:0 FAIL
-std/numerics/numeric.ops/accumulate/accumulate_op.pass.cpp:0 FAIL
-
 # VSO-1168723 "Implicit copy assignment incorrectly not constexpr when subobject has explicit constexpr copy constructor"
 std/utilities/utility/pairs/pairs.pair/assign_pair.pass.cpp:0 FAIL
 std/utilities/utility/pairs/pairs.pair/assign_rv_pair.pass.cpp:0 FAIL

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -358,10 +358,6 @@ std/utilities/meta/meta.unary/meta.unary.prop/is_constructible.pass.cpp:0 FAIL
 std/containers/views/span.cons/ptr_len.pass.cpp:0 FAIL
 std/containers/views/span.cons/ptr_ptr.pass.cpp:0 FAIL
 
-# DevCom-1336816 "cl errors on constexpr array of std::string"
-std/numerics/numeric.ops/adjacent.difference/adjacent_difference_op.pass.cpp:0 FAIL
-std/numerics/numeric.ops/partial.sum/partial_sum_op.pass.cpp:0 FAIL
-
 # DevCom-1336819 "cl constexpr temporary passing issue"
 std/numerics/numeric.ops/inner.product/inner_product_comp.pass.cpp:0 FAIL
 std/numerics/numeric.ops/accumulate/accumulate_op.pass.cpp:0 FAIL

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -358,10 +358,6 @@ utilities\meta\meta.unary\meta.unary.prop\is_constructible.pass.cpp
 containers\views\span.cons\ptr_len.pass.cpp
 containers\views\span.cons\ptr_ptr.pass.cpp
 
-# DevCom-1336819 "cl constexpr temporary passing issue"
-numerics\numeric.ops\inner.product\inner_product_comp.pass.cpp
-numerics\numeric.ops\accumulate\accumulate_op.pass.cpp
-
 # VSO-1168723 "Implicit copy assignment incorrectly not constexpr when subobject has explicit constexpr copy constructor"
 utilities\utility\pairs\pairs.pair\assign_pair.pass.cpp
 utilities\utility\pairs\pairs.pair\assign_rv_pair.pass.cpp

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -358,10 +358,6 @@ utilities\meta\meta.unary\meta.unary.prop\is_constructible.pass.cpp
 containers\views\span.cons\ptr_len.pass.cpp
 containers\views\span.cons\ptr_ptr.pass.cpp
 
-# DevCom-1336816 "cl errors on constexpr array of std::string"
-numerics\numeric.ops\adjacent.difference\adjacent_difference_op.pass.cpp
-numerics\numeric.ops\partial.sum\partial_sum_op.pass.cpp
-
 # DevCom-1336819 "cl constexpr temporary passing issue"
 numerics\numeric.ops\inner.product\inner_product_comp.pass.cpp
 numerics\numeric.ops\accumulate\accumulate_op.pass.cpp

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -375,16 +375,6 @@ utilities\utility\pairs\pairs.pair\assign_rv_pair_U_V.pass.cpp
 algorithms\alg.sorting\alg.sort\partial.sort\partial_sort.pass.cpp
 algorithms\alg.sorting\alg.sort\partial.sort\partial_sort_comp.pass.cpp
 
-# VSO-1275530 "[constexpr] Temporaries created for functions do not have a ctor called (and have a redundant dtor)."
-numerics\numeric.ops\exclusive.scan\exclusive_scan.pass.cpp
-numerics\numeric.ops\exclusive.scan\exclusive_scan_init_op.pass.cpp
-numerics\numeric.ops\inclusive.scan\inclusive_scan.pass.cpp
-numerics\numeric.ops\inclusive.scan\inclusive_scan_op.pass.cpp
-numerics\numeric.ops\inclusive.scan\inclusive_scan_op_init.pass.cpp
-numerics\numeric.ops\transform.exclusive.scan\transform_exclusive_scan_init_bop_uop.pass.cpp
-numerics\numeric.ops\transform.inclusive.scan\transform_inclusive_scan_bop_uop.pass.cpp
-numerics\numeric.ops\transform.inclusive.scan\transform_inclusive_scan_bop_uop_init.pass.cpp
-
 
 # *** CLANG COMPILER BUGS ***
 # LLVM-33230 "Clang on Windows should define __STDCPP_THREADS__ to be 1"

--- a/tests/std/tests/Dev11_0836436_get_time/test.cpp
+++ b/tests/std/tests/Dev11_0836436_get_time/test.cpp
@@ -496,7 +496,7 @@ void test_990695() {
         }
 
         {
-            // Should fail if EOF while not parsing specifier (N4878 [locale.time.get.members]/8.4).
+            // Should fail if EOF while not parsing specifier (N4878 [locale.time.get.members]/8.3).
             tm t{};
             istringstream iss("4");
             iss >> get_time(&t, "42");
@@ -504,7 +504,7 @@ void test_990695() {
         }
 
         {
-            // Trailing % should not be treated as a literal (N4878 [locale.time.get.members]/8.4 again).
+            // Trailing % should not be treated as a literal (N4878 [locale.time.get.members]/8.4).
             tm t{};
             istringstream iss("%");
             iss >> get_time(&t, "%");
@@ -520,7 +520,7 @@ void test_990695() {
         }
 
         {
-            // Literal match is case-insensitive.
+            // Literal match is case-insensitive (N4878 [locale.time.get.members]/8.6).
             tm t{};
             istringstream iss("aBc");
             iss >> get_time(&t, "AbC");

--- a/tests/std/tests/P0218R1_filesystem/test.cpp
+++ b/tests/std/tests/P0218R1_filesystem/test.cpp
@@ -3924,7 +3924,7 @@ int wmain(int argc, wchar_t* argv[]) {
 
     if (argc > 1) {
         run_interactive_tests(argc, argv);
-        return 0; // not a PM_ constant because the caller isn't run.pl here
+        return 0;
     }
 
     for (const auto& testCase : decompTestCases) {

--- a/tests/std/tests/P0218R1_filesystem/test.cpp
+++ b/tests/std/tests/P0218R1_filesystem/test.cpp
@@ -3908,9 +3908,7 @@ void run_interactive_tests(int argc, wchar_t* argv[]) {
 // mode.
 void test_devcom_953628() { // COMPILE-ONLY
     struct S : wstring {};
-#if defined(MSVC_INTERNAL_TESTING) || defined(__clang__) || defined(__EDG__) // TRANSITION, VSO-1270432
     path{S{}};
-#endif // defined(MSVC_INTERNAL_TESTING) || defined(__clang__) || defined(__EDG__)
 }
 
 int wmain(int argc, wchar_t* argv[]) {

--- a/tests/std/tests/P0784R7_library_machinery/test.cpp
+++ b/tests/std/tests/P0784R7_library_machinery/test.cpp
@@ -127,7 +127,7 @@ _CONSTEXPR20_DYNALLOC bool test() {
     }
 #endif // __cpp_lib_concepts
 
-#if defined(__cpp_constexpr_dynamic_alloc) && (defined(__clang__) || defined(__EDG__)) // TRANSITION, DevCom-1333853
+#if defined(__cpp_constexpr_dynamic_alloc)
     { // _Uninitialized_move_unchecked
         int_wrapper_move input[] = {1, 2, 3, 4};
         int_wrapper_move output[4];
@@ -140,7 +140,7 @@ _CONSTEXPR20_DYNALLOC bool test() {
             assert(equal(begin(input), end(input), begin(expected_after_move), end(expected_after_move)));
         }
     }
-#endif // defined(__cpp_constexpr_dynamic_alloc) && (defined(__clang__) || defined(__EDG__))
+#endif // defined(__cpp_constexpr_dynamic_alloc)
     return true;
 }
 

--- a/tests/std/tests/P0980R1_constexpr_strings/test.cpp
+++ b/tests/std/tests/P0980R1_constexpr_strings/test.cpp
@@ -169,7 +169,7 @@ template <class CharType>
 _CONSTEXPR20_CONTAINER bool test_interface() {
 #ifndef __EDG__ // TRANSITION, VSO-1273296
     using str = basic_string<CharType>;
-#if defined(MSVC_INTERNAL_TESTING) || defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 0 // TRANSITION, VSO-1269894
+
     { // constructors
         // range constructors
         str literal_constructed{get_literal_input<CharType>()};
@@ -352,13 +352,13 @@ _CONSTEXPR20_CONTAINER bool test_interface() {
         assign_conversion_start_length.assign(convertible, 2, 3);
         assert(equalRanges(assign_conversion_start_length, "llo"sv));
     }
-#endif // defined(MSVC_INTERNAL_TESTING) || defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 0
+
     { // allocator
         str default_constructed;
         [[maybe_unused]] const auto alloc = default_constructed.get_allocator();
         static_assert(is_same_v<remove_const_t<decltype(alloc)>, allocator<CharType>>);
     }
-#if defined(MSVC_INTERNAL_TESTING) || defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 0 // TRANSITION, VSO-1269894
+
     { // access
         str literal_constructed             = get_literal_input<CharType>();
         const str const_literal_constructed = get_literal_input<CharType>();
@@ -667,7 +667,6 @@ _CONSTEXPR20_CONTAINER bool test_interface() {
         assert(equalRanges(erased_free_if, "Hello fluffy kiens"sv));
 #endif // defined(MSVC_INTERNAL_TESTING) || defined(__EDG__)
     }
-#endif // defined(MSVC_INTERNAL_TESTING) || defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 0
 
     { // push_back / pop_back
         str pushed;
@@ -684,7 +683,7 @@ _CONSTEXPR20_CONTAINER bool test_interface() {
         assert(pushed.size() == 1);
         assert(pushed.back() == CharType{'y'});
     }
-#if defined(MSVC_INTERNAL_TESTING) || defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 0 // TRANSITION, VSO-1269894
+
     { // append
         const str literal_constructed = get_literal_input<CharType>();
 
@@ -1502,15 +1501,12 @@ _CONSTEXPR20_CONTAINER bool test_interface() {
         basic_string_view<CharType> sv = s;
         assert(equalRanges(sv, "Hello fluffy kittens"sv));
     }
-#endif // defined(MSVC_INTERNAL_TESTING) || defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 0
 #endif // __EDG__
     return true;
 }
 
 _CONSTEXPR20_CONTAINER bool test_udls() {
 #ifndef __EDG__ // TRANSITION, VSO-1273296
-#if defined(MSVC_INTERNAL_TESTING) || defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 0 // TRANSITION, VSO-1269894
-
     assert(equalRanges("purr purr"s, "purr purr"sv));
 #ifdef __cpp_char8_t
     assert(equalRanges(u8"purr purr"s, "purr purr"sv));
@@ -1518,8 +1514,6 @@ _CONSTEXPR20_CONTAINER bool test_udls() {
     assert(equalRanges(u"purr purr"s, "purr purr"sv));
     assert(equalRanges(U"purr purr"s, "purr purr"sv));
     assert(equalRanges(L"purr purr"s, "purr purr"sv));
-
-#endif // defined(MSVC_INTERNAL_TESTING) || defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 0
 #endif // __EDG__
     return true;
 }
@@ -1533,7 +1527,6 @@ struct CharLikeType {
 
 template <class CharType>
 _CONSTEXPR20_CONTAINER bool test_iterators() {
-#if defined(MSVC_INTERNAL_TESTING) || defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 0 // TRANSITION, VSO-1269894
 #ifndef __EDG__ // TRANSITION, VSO-1273296
     using str               = basic_string<CharType>;
     str literal_constructed = get_literal_input<CharType>();
@@ -1654,13 +1647,11 @@ _CONSTEXPR20_CONTAINER bool test_iterators() {
         assert(cit[2] == CharType{'l'});
     }
 #endif // __EDG__
-#endif // defined(MSVC_INTERNAL_TESTING) || defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 0
     return true;
 }
 
 template <class CharType>
 _CONSTEXPR20_CONTAINER bool test_growth() {
-#if defined(MSVC_INTERNAL_TESTING) || defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 0 // TRANSITION, VSO-1269894
     using str = basic_string<CharType>;
 #ifndef __EDG__ // TRANSITION, VSO-1273296
     {
@@ -1764,7 +1755,6 @@ _CONSTEXPR20_CONTAINER bool test_growth() {
     }
 #endif // defined(MSVC_INTERNAL_TESTING) || defined(__EDG__)
 #endif // __EDG__
-#endif // defined(MSVC_INTERNAL_TESTING) || defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 0
     return true;
 }
 

--- a/tests/std/tests/P0980R1_constexpr_strings/test.cpp
+++ b/tests/std/tests/P0980R1_constexpr_strings/test.cpp
@@ -447,7 +447,6 @@ _CONSTEXPR20_CONTAINER bool test_interface() {
         static_assert(is_same_v<remove_const_t<decltype(ce2)>, typename str::const_iterator>);
         assert(*prev(ce2) == CharType{'s'});
 
-#if defined(MSVC_INTERNAL_TESTING) || defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 // TRANSITION, 16.10p1
         const auto rb = literal_constructed.rbegin();
         static_assert(is_same_v<remove_const_t<decltype(rb)>, reverse_iterator<typename str::iterator>>);
         assert(*rb == CharType{'s'});
@@ -471,7 +470,6 @@ _CONSTEXPR20_CONTAINER bool test_interface() {
         const auto cre2 = const_literal_constructed.rend();
         static_assert(is_same_v<remove_const_t<decltype(cre2)>, reverse_iterator<typename str::const_iterator>>);
         assert(*prev(cre2) == CharType{'H'});
-#endif // defined(MSVC_INTERNAL_TESTING) || defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2
     }
 
     { // capacity
@@ -1560,19 +1558,15 @@ _CONSTEXPR20_CONTAINER bool test_iterators() {
         assert(*it == CharType{'l'});
         it += 2;
         assert(*it == CharType{'o'});
-#if defined(MSVC_INTERNAL_TESTING) || defined(__EDG__) // TRANSITION, 16.10p1
         it = 2 + it;
         assert(*it == CharType{'f'});
-#endif // defined(MSVC_INTERNAL_TESTING) || defined(__EDG__)
 
         auto cit = literal_constructed.cbegin() + 2;
         assert(*cit == CharType{'l'});
         cit += 2;
         assert(*cit == CharType{'o'});
-#if defined(MSVC_INTERNAL_TESTING) || defined(__EDG__) // TRANSITION, 16.10p1
         cit = 2 + cit;
         assert(*cit == CharType{'f'});
-#endif // defined(MSVC_INTERNAL_TESTING) || defined(__EDG__)
     }
 
     { // decrement

--- a/tests/std/tests/P0980R1_constexpr_strings/test.cpp
+++ b/tests/std/tests/P0980R1_constexpr_strings/test.cpp
@@ -437,21 +437,15 @@ _CONSTEXPR20_CONTAINER bool test_interface() {
 
         const auto e = literal_constructed.end();
         static_assert(is_same_v<remove_const_t<decltype(e)>, typename str::iterator>);
-#if defined(MSVC_INTERNAL_TESTING) || defined(__EDG__) // TRANSITION, VSO-1275530
         assert(*prev(e) == CharType{'s'});
-#endif // defined(MSVC_INTERNAL_TESTING) || defined(__EDG__)
 
         const auto ce = literal_constructed.cend();
         static_assert(is_same_v<remove_const_t<decltype(ce)>, typename str::const_iterator>);
-#if defined(MSVC_INTERNAL_TESTING) || defined(__EDG__) // TRANSITION, VSO-1275530
         assert(*prev(ce) == CharType{'s'});
-#endif // defined(MSVC_INTERNAL_TESTING) || defined(__EDG__)
 
         const auto ce2 = const_literal_constructed.end();
         static_assert(is_same_v<remove_const_t<decltype(ce2)>, typename str::const_iterator>);
-#if defined(MSVC_INTERNAL_TESTING) || defined(__EDG__) // TRANSITION, VSO-1275530
         assert(*prev(ce2) == CharType{'s'});
-#endif // defined(MSVC_INTERNAL_TESTING) || defined(__EDG__)
 
 #if defined(MSVC_INTERNAL_TESTING) || defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 // TRANSITION, 16.10p1
         const auto rb = literal_constructed.rbegin();
@@ -559,7 +553,6 @@ _CONSTEXPR20_CONTAINER bool test_interface() {
     }
 
     { // insert
-#if defined(MSVC_INTERNAL_TESTING) || defined(__EDG__) // TRANSITION, VSO-1275530
         str insert_char               = get_literal_input<CharType>();
         const CharType to_be_inserted = CharType{','};
         insert_char.insert(insert_char.begin() + 5, to_be_inserted);
@@ -634,14 +627,13 @@ _CONSTEXPR20_CONTAINER bool test_interface() {
         str insert_iter_count_char = get_literal_input<CharType>();
         insert_iter_count_char.insert(begin(insert_iter_count_char) + 5, 4, CharType{'o'});
         assert(equalRanges(insert_iter_count_char, "Hellooooo fluffy kittens"sv));
-#endif // defined(MSVC_INTERNAL_TESTING) || defined(__EDG__)
     }
 
     { // erase
         str erase_pos_count = get_literal_input<CharType>();
         erase_pos_count.erase(0, 6);
         assert(equalRanges(erase_pos_count, "fluffy kittens"sv));
-#if defined(MSVC_INTERNAL_TESTING) || defined(__EDG__) // TRANSITION, VSO-1275530
+
         str erase_iter = get_literal_input<CharType>();
         erase_iter.erase(erase_iter.begin());
         assert(equalRanges(erase_iter, "ello fluffy kittens"sv));
@@ -665,7 +657,6 @@ _CONSTEXPR20_CONTAINER bool test_interface() {
         str erased_free_if = get_literal_input<CharType>();
         erase_if(erased_free_if, [](const CharType val) { return val == CharType{'t'}; });
         assert(equalRanges(erased_free_if, "Hello fluffy kiens"sv));
-#endif // defined(MSVC_INTERNAL_TESTING) || defined(__EDG__)
     }
 
     { // push_back / pop_back
@@ -908,7 +899,7 @@ _CONSTEXPR20_CONTAINER bool test_interface() {
         str replaced_pos_count_str_shift = get_literal_input<CharType>();
         replaced_pos_count_str_shift.replace(13, 2, input);
         assert(equalRanges(replaced_pos_count_str_shift, "Hello fluffy dogttens"sv));
-#if defined(MSVC_INTERNAL_TESTING) || defined(__EDG__) // TRANSITION, VSO-1275530
+
         str replaced_iter_str = get_literal_input<CharType>();
         replaced_iter_str.replace(replaced_iter_str.cbegin() + 13, replaced_iter_str.cend(), input);
         assert(equalRanges(replaced_iter_str, "Hello fluffy dog"sv));
@@ -917,7 +908,7 @@ _CONSTEXPR20_CONTAINER bool test_interface() {
         replaced_iter_str_shift.replace(
             replaced_iter_str_shift.cbegin() + 13, replaced_iter_str_shift.cbegin() + 15, input);
         assert(equalRanges(replaced_iter_str_shift, "Hello fluffy dogttens"sv));
-#endif // defined(MSVC_INTERNAL_TESTING) || defined(__EDG__)
+
         str replaced_pos_count_str_pos_count = get_literal_input<CharType>();
         replaced_pos_count_str_pos_count.replace(13, 7, input, 1);
         assert(equalRanges(replaced_pos_count_str_pos_count, "Hello fluffy og"sv));
@@ -925,7 +916,7 @@ _CONSTEXPR20_CONTAINER bool test_interface() {
         str replaced_pos_count_str_pos_count_less = get_literal_input<CharType>();
         replaced_pos_count_str_pos_count_less.replace(13, 2, input, 1, 2);
         assert(equalRanges(replaced_pos_count_str_pos_count_less, "Hello fluffy ogttens"sv));
-#if defined(MSVC_INTERNAL_TESTING) || defined(__EDG__) // TRANSITION, VSO-1275530
+
         str replaced_iter_iter = get_literal_input<CharType>();
         replaced_iter_iter.replace(
             replaced_iter_iter.cbegin() + 13, replaced_iter_iter.cend(), input.begin(), input.end());
@@ -935,7 +926,7 @@ _CONSTEXPR20_CONTAINER bool test_interface() {
         replaced_iter_iter_less.replace(replaced_iter_iter_less.cbegin() + 13, replaced_iter_iter_less.cbegin() + 15,
             input.begin() + 1, input.end());
         assert(equalRanges(replaced_iter_iter_less, "Hello fluffy ogttens"sv));
-#endif // defined(MSVC_INTERNAL_TESTING) || defined(__EDG__)
+
         str replaced_pos_count_literal = get_literal_input<CharType>();
         replaced_pos_count_literal.replace(13, 2, get_dog<CharType>());
         assert(equalRanges(replaced_pos_count_literal, "Hello fluffy dogttens"sv));
@@ -943,7 +934,7 @@ _CONSTEXPR20_CONTAINER bool test_interface() {
         str replaced_pos_count_literal_count = get_literal_input<CharType>();
         replaced_pos_count_literal_count.replace(13, 2, get_dog<CharType>(), 2);
         assert(equalRanges(replaced_pos_count_literal_count, "Hello fluffy dottens"sv));
-#if defined(MSVC_INTERNAL_TESTING) || defined(__EDG__) // TRANSITION, VSO-1275530
+
         str replaced_iter_literal = get_literal_input<CharType>();
         replaced_iter_literal.replace(
             replaced_iter_literal.cbegin() + 13, replaced_iter_literal.cbegin() + 15, get_dog<CharType>());
@@ -953,11 +944,11 @@ _CONSTEXPR20_CONTAINER bool test_interface() {
         replaced_iter_literal_count.replace(replaced_iter_literal_count.cbegin() + 13,
             replaced_iter_literal_count.cbegin() + 15, get_dog<CharType>(), 2);
         assert(equalRanges(replaced_iter_literal_count, "Hello fluffy dottens"sv));
-#endif // defined(MSVC_INTERNAL_TESTING) || defined(__EDG__)
+
         str replaced_pos_count_chars = get_literal_input<CharType>();
         replaced_pos_count_chars.replace(13, 2, 5, CharType{'a'});
         assert(equalRanges(replaced_pos_count_chars, "Hello fluffy aaaaattens"sv));
-#if defined(MSVC_INTERNAL_TESTING) || defined(__EDG__) // TRANSITION, VSO-1275530
+
         str replaced_iter_chars = get_literal_input<CharType>();
         replaced_iter_chars.replace(
             replaced_iter_chars.cbegin() + 13, replaced_iter_chars.cbegin() + 15, 5, CharType{'a'});
@@ -967,17 +958,17 @@ _CONSTEXPR20_CONTAINER bool test_interface() {
         replaced_iter_init.replace(replaced_iter_init.cbegin() + 13, replaced_iter_init.cbegin() + 15,
             {CharType{'c'}, CharType{'u'}, CharType{'t'}, CharType{'e'}, CharType{' '}});
         assert(equalRanges(replaced_iter_init, "Hello fluffy cute ttens"sv));
-#endif // defined(MSVC_INTERNAL_TESTING) || defined(__EDG__)
+
         const string_view_convertible<CharType> convertible;
         str replaced_pos_count_conversion = get_dog<CharType>();
         replaced_pos_count_conversion.replace(1, 5, convertible);
         assert(equalRanges(replaced_pos_count_conversion, "dHello fluffy kittens"sv));
-#if defined(MSVC_INTERNAL_TESTING) || defined(__EDG__) // TRANSITION, VSO-1275530
+
         str replaced_iter_conversion = get_dog<CharType>();
         replaced_iter_conversion.replace(
             replaced_iter_conversion.cbegin() + 1, replaced_iter_conversion.cbegin() + 2, convertible);
         assert(equalRanges(replaced_iter_conversion, "dHello fluffy kittensg"sv));
-#endif // defined(MSVC_INTERNAL_TESTING) || defined(__EDG__)
+
         str replaced_pos_count_conversion_pos = get_dog<CharType>();
         replaced_pos_count_conversion_pos.replace(1, 5, convertible, 6);
         assert(equalRanges(replaced_pos_count_conversion_pos, "dfluffy kittens"sv));
@@ -1693,7 +1684,7 @@ _CONSTEXPR20_CONTAINER bool test_growth() {
         assert(v.size() == 1008);
         assert(v.capacity() == 1510);
     }
-#if defined(MSVC_INTERNAL_TESTING) || defined(__EDG__) // TRANSITION, VSO-1275530
+
     {
         str v(1007, CharType{'a'});
 
@@ -1753,7 +1744,6 @@ _CONSTEXPR20_CONTAINER bool test_growth() {
             assert(v.capacity() == 8015);
         }
     }
-#endif // defined(MSVC_INTERNAL_TESTING) || defined(__EDG__)
 #endif // __EDG__
     return true;
 }

--- a/tests/std/tests/P1004R2_constexpr_vector/test.cpp
+++ b/tests/std/tests/P1004R2_constexpr_vector/test.cpp
@@ -12,8 +12,7 @@
 
 using namespace std;
 
-#if defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 \
-    || defined(MSVC_INTERNAL_TESTING) // TRANSITION, VSO-1270433, VSO-1275530
+#if defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 || defined(MSVC_INTERNAL_TESTING) // TRANSITION, VSO-1270433
 static constexpr int input[] = {0, 1, 2, 3, 4, 5};
 #endif // defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 || defined(MSVC_INTERNAL_TESTING)
 
@@ -64,8 +63,7 @@ struct soccc_allocator {
 using vec = vector<int, soccc_allocator<int>>;
 
 _CONSTEXPR20_CONTAINER bool test_interface() {
-#if defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 \
-    || defined(MSVC_INTERNAL_TESTING) // TRANSITION, VSO-1270433, VSO-1275530
+#if defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 || defined(MSVC_INTERNAL_TESTING) // TRANSITION, VSO-1270433
     { // constructors
 
         // Non allocator constructors
@@ -513,8 +511,7 @@ _CONSTEXPR20_CONTAINER bool test_interface() {
 }
 
 _CONSTEXPR20_CONTAINER bool test_iterators() {
-#if defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 \
-    || defined(MSVC_INTERNAL_TESTING) // TRANSITION, VSO-1270433, VSO-1275530
+#if defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 || defined(MSVC_INTERNAL_TESTING) // TRANSITION, VSO-1270433
     vec range_constructed(begin(input), end(input));
 
 #if !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 // TRANSITION, VSO-1273381
@@ -614,8 +611,7 @@ _CONSTEXPR20_CONTAINER bool test_iterators() {
 }
 
 _CONSTEXPR20_CONTAINER bool test_growth() {
-#if defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 \
-    || defined(MSVC_INTERNAL_TESTING) // TRANSITION, VSO-1270433, VSO-1275530
+#if defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 || defined(MSVC_INTERNAL_TESTING) // TRANSITION, VSO-1270433
     {
         vector<int> v(1000, 1729);
 

--- a/tests/std/tests/P1004R2_constexpr_vector_bool/test.cpp
+++ b/tests/std/tests/P1004R2_constexpr_vector_bool/test.cpp
@@ -13,8 +13,7 @@
 
 using namespace std;
 
-#if defined(MSVC_INTERNAL_TESTING) || defined(__EDG__) \
-    || _ITERATOR_DEBUG_LEVEL != 2 // TRANSITION, VSO-1270433, VSO-1275530
+#if defined(MSVC_INTERNAL_TESTING) || defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 // TRANSITION, VSO-1270433
 #ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-const-variable" // TRANSITION, LLVM-48606
@@ -73,8 +72,7 @@ struct soccc_allocator {
 using vec = vector<bool, soccc_allocator<bool>>;
 
 _CONSTEXPR20_CONTAINER bool test_interface() {
-#if defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 \
-    || defined(MSVC_INTERNAL_TESTING) // TRANSITION, VSO-1270433, VSO-1275530
+#if defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 || defined(MSVC_INTERNAL_TESTING) // TRANSITION, VSO-1270433
     { // constructors
 
 // Non allocator constructors
@@ -541,8 +539,7 @@ _CONSTEXPR20_CONTAINER bool test_interface() {
 }
 
 _CONSTEXPR20_CONTAINER bool test_iterators() {
-#if defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 \
-    || defined(MSVC_INTERNAL_TESTING) // TRANSITION, VSO-1270433, VSO-1275530
+#if defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 || defined(MSVC_INTERNAL_TESTING) // TRANSITION, VSO-1270433
 #ifndef __EDG__ // TRANSITION, VSO-1274387
     vec range_constructed(begin(input), end(input));
 

--- a/tests/std/tests/P1502R1_standard_library_header_units/custom_format.py
+++ b/tests/std/tests/P1502R1_standard_library_header_units/custom_format.py
@@ -108,8 +108,8 @@ class CustomTestFormat(STLTestFormat):
 
             exportHeaderOptions.append(headerAbsolutePath)
 
-            headerUnitOptions.append('/headerUnit')
-            headerUnitOptions.append('{0}={1}.ifc'.format(headerAbsolutePath, header))
+            headerUnitOptions.append('/headerUnit:angle')
+            headerUnitOptions.append('{0}={0}.ifc'.format(header))
 
             if not compileTestCppWithEdg:
                 headerUnitOptions.append(os.path.join(outputDir, header + '.obj'))

--- a/tests/std/tests/P1502R1_standard_library_header_units/custom_format.py
+++ b/tests/std/tests/P1502R1_standard_library_header_units/custom_format.py
@@ -108,8 +108,8 @@ class CustomTestFormat(STLTestFormat):
 
             exportHeaderOptions.append(headerAbsolutePath)
 
-            headerUnitOptions.append('/headerUnit:angle')
-            headerUnitOptions.append('{0}={0}.ifc'.format(header))
+            headerUnitOptions.append('/headerUnit')
+            headerUnitOptions.append('{0}={1}.ifc'.format(headerAbsolutePath, header))
 
             if not compileTestCppWithEdg:
                 headerUnitOptions.append(os.path.join(outputDir, header + '.obj'))

--- a/tests/std/tests/P1502R1_standard_library_header_units/custombuild.pl
+++ b/tests/std/tests/P1502R1_standard_library_header_units/custombuild.pl
@@ -94,8 +94,8 @@ sub CustomBuildHook()
     foreach (@stl_headers) {
         $export_header_options .= " $stl_include_dir/$_";
 
-        $header_unit_options .= " /headerUnit:angle";
-        $header_unit_options .= " $_=$_.ifc";
+        $header_unit_options .= " /headerUnit";
+        $header_unit_options .= " $stl_include_dir/$_=$_.ifc";
         $header_unit_options .= " $_.obj";
     }
 

--- a/tests/std/tests/P1502R1_standard_library_header_units/custombuild.pl
+++ b/tests/std/tests/P1502R1_standard_library_header_units/custombuild.pl
@@ -94,8 +94,8 @@ sub CustomBuildHook()
     foreach (@stl_headers) {
         $export_header_options .= " $stl_include_dir/$_";
 
-        $header_unit_options .= " /headerUnit";
-        $header_unit_options .= " $stl_include_dir/$_=$_.ifc";
+        $header_unit_options .= " /headerUnit:angle";
+        $header_unit_options .= " $_=$_.ifc";
         $header_unit_options .= " $_.obj";
     }
 

--- a/tests/std/tests/P1502R1_standard_library_header_units/test.cpp
+++ b/tests/std/tests/P1502R1_standard_library_header_units/test.cpp
@@ -423,8 +423,10 @@ int main() {
 
     {
         puts("Testing <list>.");
+#ifdef MSVC_INTERNAL_TESTING // TRANSITION, VS 2019 16.10 Preview 2
         const list<int> l{10, 20, 30, 40, 50};
         assert(*next(l.begin(), 2) == 30);
+#endif // ^^^ no workaround ^^^
     }
 
     {
@@ -552,6 +554,7 @@ int main() {
         q.pop();
         assert(q.empty());
 
+#ifdef MSVC_INTERNAL_TESTING // TRANSITION, VS 2019 16.10 Preview 2
         priority_queue<int> pq;
         pq.push(50);
         pq.push(10);
@@ -567,6 +570,7 @@ int main() {
         assert(pq.top() == 10);
         pq.pop();
         assert(pq.empty());
+#endif // ^^^ no workaround ^^^
     }
 
     {
@@ -897,10 +901,12 @@ int main() {
 
     {
         puts("Testing <unordered_map>.");
+#ifdef MSVC_INTERNAL_TESTING // TRANSITION, VS 2019 16.10 Preview 2
         unordered_map<int, int> um{{1, 1}, {2, 4}, {3, 9}, {4, 16}, {5, 25}};
         for (const auto& p : um) {
             assert(p.first * p.first == p.second);
         }
+#endif // ^^^ no workaround ^^^
     }
 
     {

--- a/tests/std/tests/P1502R1_standard_library_header_units/test.cpp
+++ b/tests/std/tests/P1502R1_standard_library_header_units/test.cpp
@@ -423,10 +423,8 @@ int main() {
 
     {
         puts("Testing <list>.");
-#ifdef MSVC_INTERNAL_TESTING // TRANSITION, VS 2019 16.10 Preview 2
         const list<int> l{10, 20, 30, 40, 50};
         assert(*next(l.begin(), 2) == 30);
-#endif // ^^^ no workaround ^^^
     }
 
     {
@@ -554,7 +552,6 @@ int main() {
         q.pop();
         assert(q.empty());
 
-#ifdef MSVC_INTERNAL_TESTING // TRANSITION, VS 2019 16.10 Preview 2
         priority_queue<int> pq;
         pq.push(50);
         pq.push(10);
@@ -570,7 +567,6 @@ int main() {
         assert(pq.top() == 10);
         pq.pop();
         assert(pq.empty());
-#endif // ^^^ no workaround ^^^
     }
 
     {
@@ -901,12 +897,10 @@ int main() {
 
     {
         puts("Testing <unordered_map>.");
-#ifdef MSVC_INTERNAL_TESTING // TRANSITION, VS 2019 16.10 Preview 2
         unordered_map<int, int> um{{1, 1}, {2, 4}, {3, 9}, {4, 16}, {5, 25}};
         for (const auto& p : um) {
             assert(p.first * p.first == p.second);
         }
-#endif // ^^^ no workaround ^^^
     }
 
     {

--- a/tests/std/tests/P1502R1_standard_library_header_units/test.cpp
+++ b/tests/std/tests/P1502R1_standard_library_header_units/test.cpp
@@ -335,13 +335,9 @@ int main() {
         puts("Testing <future>.");
         promise<int> p{};
         future<int> f{p.get_future()};
-#ifdef MSVC_INTERNAL_TESTING // TRANSITION, VSO-1271718 (Standard Library Header Units ICE with C++20 chrono)
         assert(f.wait_for(chrono::seconds{0}) == future_status::timeout);
-#endif // ^^^ no workaround ^^^
         p.set_value(1729);
-#ifdef MSVC_INTERNAL_TESTING // TRANSITION, VSO-1271718 (Standard Library Header Units ICE with C++20 chrono)
         assert(f.wait_for(chrono::seconds{0}) == future_status::ready);
-#endif // ^^^ no workaround ^^^
         assert(f.get() == 1729);
     }
 
@@ -772,9 +768,7 @@ int main() {
                 }
                 l.count_down(); // tell main() that we're done
                 while (!token.stop_requested()) {
-#ifdef MSVC_INTERNAL_TESTING // TRANSITION, VSO-1271718 (Standard Library Header Units ICE with C++20 chrono)
                     this_thread::sleep_for(10ms); // not a timing assumption; avoids spinning furiously
-#endif // ^^^ no workaround ^^^
                 }
                 vec.push_back(-1000); // indicate that token.stop_requested() returned true
             }};

--- a/tests/std/tests/P1502R1_standard_library_header_units/test.cpp
+++ b/tests/std/tests/P1502R1_standard_library_header_units/test.cpp
@@ -231,7 +231,6 @@ int main() {
 
     {
         puts("Testing <condition_variable>.");
-#ifdef MSVC_INTERNAL_TESTING // TRANSITION, VS 2019 16.10 Preview 2
         condition_variable cv;
         mutex mut;
         vector<int> vec = {5};
@@ -266,7 +265,6 @@ int main() {
 
         static_assert(static_cast<int>(cv_status::no_timeout) == 0);
         static_assert(static_cast<int>(cv_status::timeout) == 1);
-#endif // ^^^ no workaround ^^^
     }
 
     {
@@ -617,14 +615,12 @@ int main() {
 
     {
         puts("Testing <scoped_allocator>.");
-#ifdef MSVC_INTERNAL_TESTING // TRANSITION, VS 2019 16.10 Preview 2
         vector<int, scoped_allocator_adaptor<allocator<int>>> v;
         v.push_back(11);
         v.push_back(22);
         v.push_back(33);
         constexpr int expected[]{11, 22, 33};
         assert(equal(v.begin(), v.end(), begin(expected), end(expected)));
-#endif // ^^^ no workaround ^^^
     }
 
     {
@@ -753,7 +749,6 @@ int main() {
 
     {
         puts("Testing <stop_token>.");
-#ifdef MSVC_INTERNAL_TESTING // TRANSITION, VS 2019 16.10 Preview 2
         vector<int> vec;
         {
             latch l{1};
@@ -786,7 +781,6 @@ int main() {
             1154, 577, 1732, 866, 433, 1300, 650, 325, 976, 488, 244, 122, 61, 184, 92, 46, 23, 70, 35, 106, 53, 160,
             80, 40, 20, 10, 5, 16, 8, 4, 2, 1, -1000};
         assert(equal(vec.begin(), vec.end(), begin(expected), end(expected)));
-#endif // ^^^ no workaround ^^^
     }
 
     {
@@ -847,7 +841,6 @@ int main() {
 
     {
         puts("Testing <tuple>.");
-#ifdef MSVC_INTERNAL_TESTING // TRANSITION, VS 2019 16.10 Preview 2
         constexpr tuple<int, char, double> t{1729, 'c', 1.25};
         assert(get<int>(t) == 1729);
         assert(get<char>(t) == 'c');
@@ -855,7 +848,6 @@ int main() {
         static_assert(get<int>(t) == 1729);
         static_assert(get<char>(t) == 'c');
         static_assert(get<double>(t) == 1.25);
-#endif // ^^^ no workaround ^^^
     }
 
     {

--- a/tests/std/tests/P1502R1_standard_library_header_units/test.cpp
+++ b/tests/std/tests/P1502R1_standard_library_header_units/test.cpp
@@ -231,6 +231,7 @@ int main() {
 
     {
         puts("Testing <condition_variable>.");
+#ifdef MSVC_INTERNAL_TESTING // TRANSITION, VS 2019 16.10 Preview 2
         condition_variable cv;
         mutex mut;
         vector<int> vec = {5};
@@ -265,6 +266,7 @@ int main() {
 
         static_assert(static_cast<int>(cv_status::no_timeout) == 0);
         static_assert(static_cast<int>(cv_status::timeout) == 1);
+#endif // ^^^ no workaround ^^^
     }
 
     {
@@ -615,12 +617,14 @@ int main() {
 
     {
         puts("Testing <scoped_allocator>.");
+#ifdef MSVC_INTERNAL_TESTING // TRANSITION, VS 2019 16.10 Preview 2
         vector<int, scoped_allocator_adaptor<allocator<int>>> v;
         v.push_back(11);
         v.push_back(22);
         v.push_back(33);
         constexpr int expected[]{11, 22, 33};
         assert(equal(v.begin(), v.end(), begin(expected), end(expected)));
+#endif // ^^^ no workaround ^^^
     }
 
     {
@@ -749,6 +753,7 @@ int main() {
 
     {
         puts("Testing <stop_token>.");
+#ifdef MSVC_INTERNAL_TESTING // TRANSITION, VS 2019 16.10 Preview 2
         vector<int> vec;
         {
             latch l{1};
@@ -781,6 +786,7 @@ int main() {
             1154, 577, 1732, 866, 433, 1300, 650, 325, 976, 488, 244, 122, 61, 184, 92, 46, 23, 70, 35, 106, 53, 160,
             80, 40, 20, 10, 5, 16, 8, 4, 2, 1, -1000};
         assert(equal(vec.begin(), vec.end(), begin(expected), end(expected)));
+#endif // ^^^ no workaround ^^^
     }
 
     {
@@ -841,6 +847,7 @@ int main() {
 
     {
         puts("Testing <tuple>.");
+#ifdef MSVC_INTERNAL_TESTING // TRANSITION, VS 2019 16.10 Preview 2
         constexpr tuple<int, char, double> t{1729, 'c', 1.25};
         assert(get<int>(t) == 1729);
         assert(get<char>(t) == 'c');
@@ -848,6 +855,7 @@ int main() {
         static_assert(get<int>(t) == 1729);
         static_assert(get<char>(t) == 'c');
         static_assert(get<double>(t) == 1.25);
+#endif // ^^^ no workaround ^^^
     }
 
     {


### PR DESCRIPTION
* `stl/msbuild/stl_base/stl.files.settings.targets`: Our internal legacy build system can build `ppltasks.cpp` with `/permissive-` now.
  + The modern CMake build system doesn't need this change: https://github.com/microsoft/STL/blob/108a1127362cd14fd27f7df61aa23efba4f6a105/stl/CMakeLists.txt#L288-L290
* Update the Virtual Machine Scale Set.
  + `README.md`: Mention VS 2019 16.10 Preview 1 and Python 3.9.2 as dependencies.
  + `azure-devops/create-vmss.ps1`: Move back to `westus2` (after #1654) and try switching from `Standard_D32as_v4` to `Standard_D32ds_v4`. This should have comparable performance, and spot VMs are [approximately half the cost](https://azure.microsoft.com/en-us/pricing/details/virtual-machines/windows/).
  + `azure-devops/provision-image.ps1`: Update to PowerShell 7.1.2 and Python 3.9.2.
  + `azure-pipelines.yml`: Use the new pool.
* `stl/inc/yvals_core.h`: Increase required `_MSC_VER` to `1929`.
  + Note that VS 2019 16.8 and 16.9 shared `1928`, while 16.10 and 16.11 will share `1929`.
  + The internal "checked-in toolset" has already been updated.
* `stl/inc/xatomic.h`: Remove an `_mm_pause` declaration workaround.
* `stl/inc/type_traits`: Fix #1637 by removing the `_IS_LAYOUT_COMPATIBLE_SUPPORTED` checks; now we unconditionally use the new names.
* Remove workarounds for VSO-1271718, DevCom-1318357/VSO-1270432, DevCom-1318341/VSO-1269894, VSO-1275530, DevCom-1333853/VSO-1276453, DevCom-1336816/VSO-1277619, DevCom-1336819/VSO-1277640, and an unspecified bug that was fixed in 16.10 Preview 1.
* `tests/std/tests/P0218R1_filesystem/test.cpp`: Remove an outdated comment about "not a `PM_` constant"; that machinery was removed long ago.
* `tests/std/tests/Dev11_0836436_get_time/test.cpp`: Fix/add [locale.time.get.members] citations, noticed after merging #1620.
* `.gitattributes`: Mark `*.h` as C++ (they're being detected as C) and `*.cfg` as Python (they're being detected as HAProxy, whatever that is).
* **Update the `vcpkg` submodule for Boost 1.75.0.**
  + `CMakeLists.txt`: Require Boost 1.75.0.
