### PR TITLE
<complex>: Fix warning C5219 when compiled with /Wall

### DIFF
--- a/stl/inc/complex
+++ b/stl/inc/complex
@@ -342,7 +342,8 @@ namespace _Math_algorithms {
             const _Ty _Bv_scaled_sqr = _Bv_scaled * _Bv_scaled;
             const _Ty _Norm_scaled   = _Av_scaled * _Av_scaled + _Bv_scaled_sqr;
             const _Ty _Real_shifted  = _STD log(_Norm_scaled) * _Ty{0.5};
-            return (_Real_shifted + _Exponent * _Cl) + _Exponent * _Cm;
+            const auto _Fexponent    = static_cast<_Ty>(_Exponent);
+            return (_Real_shifted + _Fexponent * _Cl) + _Fexponent * _Cm;
         }
     }
 } // namespace _Math_algorithms


### PR DESCRIPTION
<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
Fixes DevCom-1356190 and Microsoft-internal VSO-1289256 / AB#1289256 .