### PR TITLE
<format>: Add format, vformat, and local-less vformat_to

### DIFF
--- a/stl/inc/format
+++ b/stl/inc/format
@@ -1402,25 +1402,25 @@ _OutputIt vformat_to(
     return _Handler._Ctx.out();
 }
 
-string vformat(string_view _Fmt, format_args _Args) {
+inline string vformat(string_view _Fmt, format_args _Args) {
     string _Str;
     _STD vformat_to(_STD back_inserter(_Str), _Fmt, _Args);
     return _Str;
 }
 
-wstring vformat(wstring_view _Fmt, wformat_args _Args) {
+inline wstring vformat(wstring_view _Fmt, wformat_args _Args) {
     wstring _Str;
     _STD vformat_to(_STD back_inserter(_Str), _Fmt, _Args);
     return _Str;
 }
 
-string vformat(const locale& _Loc, string_view _Fmt, format_args _Args) {
+inline string vformat(const locale& _Loc, string_view _Fmt, format_args _Args) {
     string _Str;
     _STD vformat_to(_STD back_inserter(_Str), _Loc, _Fmt, _Args);
     return _Str;
 }
 
-wstring vformat(const locale& _Loc, wstring_view _Fmt, wformat_args _Args) {
+inline wstring vformat(const locale& _Loc, wstring_view _Fmt, wformat_args _Args) {
     wstring _Str;
     _STD vformat_to(_STD back_inserter(_Str), _Loc, _Fmt, _Args);
     return _Str;

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -1404,46 +1404,46 @@ _OutputIt vformat_to(
 
 string vformat(string_view _Fmt, format_args _Args) {
     string _Str;
-    vformat_to(back_inserter(_Str), _Fmt, _Args);
+    _STD vformat_to(_STD back_inserter(_Str), _Fmt, _Args);
     return _Str;
 }
 
 wstring vformat(wstring_view _Fmt, wformat_args _Args) {
     wstring _Str;
-    vformat_to(back_inserter(_Str), _Fmt, _Args);
+    _STD vformat_to(_STD back_inserter(_Str), _Fmt, _Args);
     return _Str;
 }
 
 string vformat(const locale& _Loc, string_view _Fmt, format_args _Args) {
     string _Str;
-    vformat_to(back_inserter(_Str), _Loc, _Fmt, _Args);
+    _STD vformat_to(_STD back_inserter(_Str), _Loc, _Fmt, _Args);
     return _Str;
 }
 
 wstring vformat(const locale& _Loc, wstring_view _Fmt, wformat_args _Args) {
     wstring _Str;
-    vformat_to(back_inserter(_Str), _Loc, _Fmt, _Args);
+    _STD vformat_to(_STD back_inserter(_Str), _Loc, _Fmt, _Args);
     return _Str;
 }
 
 template <class... _Types>
 string format(string_view _Fmt, const _Types&... _Args) {
-    return vformat(_Fmt, _STD make_format_args(_Args...));
+    return _STD vformat(_Fmt, _STD make_format_args(_Args...));
 }
 
 template <class... _Types>
 wstring format(wstring_view _Fmt, const _Types&... _Args) {
-    return vformat(_Fmt, _STD make_wformat_args(_Args...));
+    return _STD vformat(_Fmt, _STD make_wformat_args(_Args...));
 }
 
 template <class... _Types>
 string format(const locale& _Loc, string_view _Fmt, const _Types&... _Args) {
-    return vformat(_Loc, _Fmt, _STD make_format_args(_Args...));
+    return _STD vformat(_Loc, _Fmt, _STD make_format_args(_Args...));
 }
 
 template <class... _Types>
 wstring format(const locale& _Loc, wstring_view _Fmt, const _Types&... _Args) {
-    return vformat(_Loc, _Fmt, _STD make_wformat_args(_Args...));
+    return _STD vformat(_Loc, _Fmt, _STD make_wformat_args(_Args...));
 }
 
 _STD_END

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -1371,6 +1371,22 @@ template <class _Out, class _CharT>
 using format_args_t = basic_format_args<basic_format_context<_Out, _CharT>>;
 
 template <class _OutputIt>
+_OutputIt vformat_to(_OutputIt _Out, string_view _Fmt, format_args_t<type_identity_t<_OutputIt>, char> _Args) {
+    _Format_handler<_OutputIt, char, basic_format_context<_OutputIt, char>> _Handler(
+        _Out, _Fmt, _Args, locale::classic());
+    _Parse_format_string(_Fmt, _Handler);
+    return _Handler._Ctx.out();
+}
+
+template <class _OutputIt>
+_OutputIt vformat_to(_OutputIt _Out, wstring_view _Fmt, format_args_t<type_identity_t<_OutputIt>, wchar_t> _Args) {
+    _Format_handler<_OutputIt, wchar_t, basic_format_context<_OutputIt, wchar_t>> _Handler(
+        _Out, _Fmt, _Args, locale::classic());
+    _Parse_format_string(_Fmt, _Handler);
+    return _Handler._Ctx.out();
+}
+
+template <class _OutputIt>
 _OutputIt vformat_to(
     _OutputIt _Out, const locale& _Loc, string_view _Fmt, format_args_t<type_identity_t<_OutputIt>, char> _Args) {
     _Format_handler<_OutputIt, char, basic_format_context<_OutputIt, char>> _Handler(_Out, _Fmt, _Args, _Loc);
@@ -1386,11 +1402,49 @@ _OutputIt vformat_to(
     return _Handler._Ctx.out();
 }
 
-// FUNCTION vformat
-string vformat(string_view _Fmt, format_args _Args);
-wstring vformat(wstring_view _Fmt, wformat_args _Args);
-string vformat(const locale& _Loc, string_view _Fmt, format_args _Args);
-wstring vformat(const locale& _Loc, wstring_view _Fmt, wformat_args _Args);
+string vformat(string_view _Fmt, format_args _Args) {
+    string _Str;
+    vformat_to(back_inserter(_Str), _Fmt, _Args);
+    return _Str;
+}
+
+wstring vformat(wstring_view _Fmt, wformat_args _Args) {
+    wstring _Str;
+    vformat_to(back_inserter(_Str), _Fmt, _Args);
+    return _Str;
+}
+
+string vformat(const locale& _Loc, string_view _Fmt, format_args _Args) {
+    string _Str;
+    vformat_to(back_inserter(_Str), _Loc, _Fmt, _Args);
+    return _Str;
+}
+
+wstring vformat(const locale& _Loc, wstring_view _Fmt, wformat_args _Args) {
+    wstring _Str;
+    vformat_to(back_inserter(_Str), _Loc, _Fmt, _Args);
+    return _Str;
+}
+
+template <class... _Types>
+string format(string_view _Fmt, const _Types&... _Args) {
+    return vformat(_Fmt, _STD make_format_args(_Args...));
+}
+
+template <class... _Types>
+wstring format(wstring_view _Fmt, const _Types&... _Args) {
+    return vformat(_Fmt, _STD make_wformat_args(_Args...));
+}
+
+template <class... _Types>
+string format(const locale& _Loc, string_view _Fmt, const _Types&... _Args) {
+    return vformat(_Loc, _Fmt, _STD make_format_args(_Args...));
+}
+
+template <class... _Types>
+wstring format(const locale& _Loc, wstring_view _Fmt, const _Types&... _Args) {
+    return vformat(_Loc, _Fmt, _STD make_wformat_args(_Args...));
+}
 
 _STD_END
 

--- a/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
@@ -31,6 +31,7 @@ struct choose_literal<wchar_t> {
 };
 
 #define TYPED_LITERAL(CharT, Literal) (choose_literal<CharT>::choose(Literal, L##Literal))
+#define STR(Str)                      TYPED_LITERAL(charT, Str)
 
 template <class charT, class... Args>
 auto make_testing_format_args(Args&&... vals) {
@@ -55,6 +56,11 @@ void test_simple_formatting() {
     vformat_to(back_insert_iterator{output_string}, locale::classic(), TYPED_LITERAL(charT, "format"),
         make_testing_format_args<charT>());
     assert(output_string == TYPED_LITERAL(charT, "format"));
+
+    assert(format(STR("f")) == STR("f"));
+    assert(format(STR("format")) == STR("format"));
+    assert(format(locale::classic(), STR("f")) == STR("f"));
+    assert(format(locale::classic(), STR("format")) == STR("format"));
 }
 
 template <class charT>
@@ -130,6 +136,10 @@ void test_simple_replacement_field() {
     vformat_to(back_insert_iterator{output_string}, locale::classic(), TYPED_LITERAL(charT, "{}"),
         make_testing_format_args<charT>(TYPED_LITERAL(charT, "f")));
     assert(output_string == TYPED_LITERAL(charT, "f"));
+
+
+    assert(format(STR("{}"), STR("f")) == STR("f"));
+    assert(format(locale::classic(), STR("{}"), STR("f")) == STR("f"));
 
     // Test string_view
     output_string.clear();


### PR DESCRIPTION
Adds the functions. Only locally tested, as I do not want to mess up the
merge of the testing overhaul PR (#1719). These will be tested through
`format`, since it is just a pass-through.

`vformat_to` uses `locale::classic()` always, which is probably the right behavior
but we may want to change `_Format_handler` to hold a pointer instead of
a reference to a locale.

<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
