### PR TITLE
Generalize the 80-bit long double in <complex> for Clang

### DIFF
--- a/stl/inc/complex
+++ b/stl/inc/complex
@@ -539,7 +539,7 @@ public:
     }
 
     static bool _Isinf(_Ty _Left) { // test for infinity
-#if defined(__INTEL_COMPILER) && defined(__LONG_DOUBLE_SIZE__) && __LONG_DOUBLE_SIZE__ == 80
+#if defined(__LDBL_DIG__) && __LDBL_DIG__ == 18
         return _CSTD _LDtest(&_Left) == _INFCODE;
 #else // ^^^ 80-bit long double (not supported by MSVC in general, see GH-1316) / 64-bit long double vvv
         const auto _Uint = _Bit_cast<uint64_t>(_Left);
@@ -548,7 +548,7 @@ public:
     }
 
     static _CONSTEXPR20 bool _Isnan(_Ty _Left) {
-#if defined(__INTEL_COMPILER) && defined(__LONG_DOUBLE_SIZE__) && __LONG_DOUBLE_SIZE__ == 80
+#if defined(__LDBL_DIG__) && __LDBL_DIG__ == 18
         return _CSTD _LDtest(&_Left) == _NANCODE;
 #else // ^^^ 80-bit long double (not supported by MSVC in general, see GH-1316) / 64-bit long double vvv
         const auto _Uint = _Bit_cast<uint64_t>(_Left);


### PR DESCRIPTION
The previous check works for the EDG-based Intel compiler ONLY, but
Clang and GCC both have the -mlong-double-80 options (see
https://godbolt.org/z/h7s4Te). This patch generalizes the 80 bit check
to work with any compiler that defines the __LDBL_DIG__ macro.

There are a couple of other macro options that are equally as opaque
(such as __LDBL_MANT_DIG__ and __LDBL_DECIMAL_DIG__), but this seemed
the most general. Note that it ALSO works in ICC, as well as all Clang
derivatives (such as Intel's DPCPP).

<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
