### PR TITLE
Fix make_shared with throwing destructors

### DIFF
--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -1145,6 +1145,12 @@ public:
     _Ref_count_resource(_Resource _Px, _Dx _Dt)
         : _Ref_count_base(), _Mypair(_One_then_variadic_args_t{}, _STD move(_Dt), _Px) {}
 
+#ifdef __EDG__ // TRANSITION, VSO-1292293
+    virtual ~_Ref_count_resource() noexcept override {} // TRANSITION, should be non-virtual
+#else // ^^^ workaround / no workaround vvv
+    virtual ~_Ref_count_resource() noexcept override = default; // TRANSITION, should be non-virtual
+#endif // ^^^ no workaround ^^^
+
     virtual void* _Get_deleter(const type_info& _Typeid) const noexcept override {
 #if _HAS_STATIC_RTTI
         if (_Typeid == typeid(_Dx)) {
@@ -1177,6 +1183,12 @@ public:
     _Ref_count_resource_alloc(_Resource _Px, _Dx _Dt, const _Alloc& _Ax)
         : _Ref_count_base(),
           _Mypair(_One_then_variadic_args_t{}, _STD move(_Dt), _One_then_variadic_args_t{}, _Ax, _Px) {}
+
+#ifdef __EDG__ // TRANSITION, VSO-1292293
+    virtual ~_Ref_count_resource_alloc() noexcept override {} // TRANSITION, should be non-virtual
+#else // ^^^ workaround / no workaround vvv
+    virtual ~_Ref_count_resource_alloc() noexcept override = default; // TRANSITION, should be non-virtual
+#endif // ^^^ no workaround ^^^
 
     virtual void* _Get_deleter(const type_info& _Typeid) const noexcept override {
 #if _HAS_STATIC_RTTI
@@ -2012,7 +2024,7 @@ public:
         }
     }
 
-    ~_Ref_count_obj2() {
+    virtual ~_Ref_count_obj2() noexcept override { // TRANSITION, should be non-virtual
         // nothing to do, _Storage._Value was already destroyed in _Destroy
 
         // N4849 [class.dtor]/7:
@@ -2276,7 +2288,7 @@ private:
         _Wrap<_Element_type> _Storage; // flexible array must be last member
     };
 
-    ~_Ref_count_unbounded_array() {
+    virtual ~_Ref_count_unbounded_array() noexcept override { // TRANSITION, should be non-virtual
         // nothing to do, _Ty is trivially destructible
 
         // See N4849 [class.dtor]/7.
@@ -2324,7 +2336,7 @@ private:
         _Wrap<_Element_type> _Storage; // flexible array must be last member
     };
 
-    ~_Ref_count_unbounded_array() {
+    virtual ~_Ref_count_unbounded_array() noexcept override { // TRANSITION, should be non-virtual
         // nothing to do, _Storage was already destroyed in _Destroy
 
         // See N4849 [class.dtor]/7.
@@ -2363,7 +2375,7 @@ public:
     };
 
 private:
-    ~_Ref_count_bounded_array() {
+    virtual ~_Ref_count_bounded_array() noexcept override { // TRANSITION, should be non-virtual
         // nothing to do, _Storage was already destroyed in _Destroy
 
         // See N4849 [class.dtor]/7.
@@ -2449,7 +2461,7 @@ public:
     };
 
 private:
-    ~_Ref_count_obj_alloc3() {
+    virtual ~_Ref_count_obj_alloc3() noexcept override { // TRANSITION, should be non-virtual
         // nothing to do; _Storage._Value already destroyed by _Destroy()
 
         // See N4849 [class.dtor]/7.
@@ -2637,7 +2649,7 @@ private:
         _Wrap<_Element_type> _Storage; // flexible array must be last member
     };
 
-    ~_Ref_count_unbounded_array_alloc() {
+    virtual ~_Ref_count_unbounded_array_alloc() noexcept override { // TRANSITION, should be non-virtual
         // nothing to do; _Storage._Value already destroyed by _Destroy()
 
         // See N4849 [class.dtor]/7.
@@ -2698,7 +2710,7 @@ public:
     };
 
 private:
-    ~_Ref_count_bounded_array_alloc() {
+    virtual ~_Ref_count_bounded_array_alloc() noexcept override { // TRANSITION, should be non-virtual
         // nothing to do; _Storage._Value already destroyed by _Destroy()
 
         // See N4849 [class.dtor]/7.

--- a/tests/std/tests/P0674R1_make_shared_for_arrays/test.cpp
+++ b/tests/std/tests/P0674R1_make_shared_for_arrays/test.cpp
@@ -623,6 +623,67 @@ void test_allocate_shared_array_unknown_bounds() {
     }
 }
 
+// Test GH-1733 "<memory>: error C2694 when calling make_shared on class with throwing destructor"
+struct NontrivialThrowingDtor {
+    ~NontrivialThrowingDtor() noexcept(false) {}
+};
+static_assert(!is_nothrow_destructible_v<NontrivialThrowingDtor>);
+static_assert(!is_trivially_destructible_v<NontrivialThrowingDtor>);
+
+struct TrivialThrowingDtor {
+    ~TrivialThrowingDtor() noexcept(false) = default;
+};
+
+#ifndef __EDG__ // TRANSITION, VSO-1292292
+static_assert(!is_nothrow_destructible_v<TrivialThrowingDtor>);
+#endif // ^^^ no workaround ^^^
+static_assert(is_trivially_destructible_v<TrivialThrowingDtor>);
+
+template <class T>
+struct WeirdDeleter {
+    void operator()(T* const ptr) const {
+        delete ptr;
+    }
+
+    ~WeirdDeleter() noexcept(false) {}
+};
+static_assert(!is_nothrow_destructible_v<WeirdDeleter<int>>);
+
+void test_GH_1733() {
+    WeirdDeleter<NontrivialThrowingDtor> del;
+    allocator<int> al;
+
+    // _Ref_count
+    (void) shared_ptr<NontrivialThrowingDtor>{new NontrivialThrowingDtor};
+
+    // _Ref_count_resource
+    (void) shared_ptr<NontrivialThrowingDtor>{new NontrivialThrowingDtor, del};
+
+    // _Ref_count_resource_alloc
+    (void) shared_ptr<NontrivialThrowingDtor>{new NontrivialThrowingDtor, del, al};
+
+    // _Ref_count_obj2
+    (void) make_shared<NontrivialThrowingDtor>();
+
+    // _Ref_count_obj_alloc3
+    (void) allocate_shared<NontrivialThrowingDtor>(al);
+
+    // _Ref_count_unbounded_array<_Ty, true>
+    (void) make_shared<TrivialThrowingDtor[]>(10);
+
+    // _Ref_count_unbounded_array<_Ty, false>
+    (void) make_shared<NontrivialThrowingDtor[]>(10);
+
+    // _Ref_count_bounded_array
+    (void) make_shared<NontrivialThrowingDtor[10]>();
+
+    // _Ref_count_unbounded_array_alloc
+    (void) allocate_shared<NontrivialThrowingDtor[]>(al, 10);
+
+    // _Ref_count_bounded_array_alloc
+    (void) allocate_shared<NontrivialThrowingDtor[10]>(al);
+}
+
 int main() {
     test_make_shared_not_array();
     test_make_shared_array_known_bounds();
@@ -631,4 +692,6 @@ int main() {
     test_allocate_shared_not_array();
     test_allocate_shared_array_known_bounds();
     test_allocate_shared_array_unknown_bounds();
+
+    test_GH_1733();
 }


### PR DESCRIPTION
Fixes #1733.

The STL is allowed to assume that user destructors don't emit exceptions (WG21-N4878 [tab:cpp17.destructible]), but user destructors can be marked `noexcept(false)` as long as they never emit exceptions when interacting with the STL. The bug being fixed here is that 9 out of 10 `shared_ptr` control blocks would fail to compile for `noexcept(false)` destructors. (The only unaffected control block was the simplest, `_Ref_count`, which stores only a pointer.)

We can mark `~_Ref_count_resource()` and `~_Ref_count_resource_alloc()` as `noexcept` and define them as `= default;` thanks to WG21-N4878 [dcl.fct.def.default]/2.2:

> The type `T`<sub>1</sub> of an explicitly defaulted special member function `F` is allowed to differ from the type `T`<sub>2</sub> it would have had if it were implicitly declared, as follows: [...] `T`<sub>1</sub> and `T`<sub>2</sub> may have differing exception specifications

For the other destructors which were already being provided by the library, the fix is to mark them as `noexcept`. I'm additionally marking them as `virtual override` for consistency, and copying the `// TRANSITION, should be non-virtual` comment from the base class.

Because this interacts with virtual member functions, we need to think carefully about ABI. I manually verified that the vtable layout isn't changing;

```
C:\Temp>type meow.cpp
```
```cpp
#include <memory>
using namespace std;

int main() {
    shared_ptr<int> sp{new int, default_delete<int>{}};
}
```
```
C:\Temp>cl /EHsc /nologo /W4 /std:c++latest /c /d1reportSingleClassLayout_Ref_count_resource meow.cpp
meow.cpp
```

Before:
===
```
class std::_Ref_count_resource<int *,struct std::default_delete<int> >  size(16):
        +---
 0      | +--- (base class std::_Ref_count_base)
 0      | | {vfptr}
 4      | | _Uses
 8      | | _Weaks
        | +---
12      | ?$_Compressed_pair@U?$default_delete@H@std@@PAH$00 _Mypair
        +---

std::_Ref_count_resource<int *,struct std::default_delete<int> >::$vftable@:
        | &?$_Ref_count_resource@PAHU?$default_delete@H@std@@_meta
        |  0
 0      | &std::_Ref_count_resource<int *,struct std::default_delete<int> >::_Destroy
 1      | &std::_Ref_count_resource<int *,struct std::default_delete<int> >::_Delete_this
 2      | &std::_Ref_count_resource<int *,struct std::default_delete<int> >::{dtor}
 3      | &std::_Ref_count_resource<int *,struct std::default_delete<int> >::_Get_deleter

std::_Ref_count_resource<int *,struct std::default_delete<int> >::_Get_deleter this adjustor: 0
std::_Ref_count_resource<int *,struct std::default_delete<int> >::_Destroy this adjustor: 0
std::_Ref_count_resource<int *,struct std::default_delete<int> >::_Delete_this this adjustor: 0
std::_Ref_count_resource<int *,struct std::default_delete<int> >::{dtor} this adjustor: 0
std::_Ref_count_resource<int *,struct std::default_delete<int> >::__delDtor this adjustor: 0
std::_Ref_count_resource<int *,struct std::default_delete<int> >::__vecDelDtor this adjustor: 0
```

After:
===
```
class std::_Ref_count_resource<int *,struct std::default_delete<int> >  size(16):
        +---
 0      | +--- (base class std::_Ref_count_base)
 0      | | {vfptr}
 4      | | _Uses
 8      | | _Weaks
        | +---
12      | ?$_Compressed_pair@U?$default_delete@H@std@@PAH$00 _Mypair
        +---

std::_Ref_count_resource<int *,struct std::default_delete<int> >::$vftable@:
        | &?$_Ref_count_resource@PAHU?$default_delete@H@std@@_meta
        |  0
 0      | &std::_Ref_count_resource<int *,struct std::default_delete<int> >::_Destroy
 1      | &std::_Ref_count_resource<int *,struct std::default_delete<int> >::_Delete_this
 2      | &std::_Ref_count_resource<int *,struct std::default_delete<int> >::{dtor}
 3      | &std::_Ref_count_resource<int *,struct std::default_delete<int> >::_Get_deleter

std::_Ref_count_resource<int *,struct std::default_delete<int> >::{dtor} this adjustor: 0
std::_Ref_count_resource<int *,struct std::default_delete<int> >::_Get_deleter this adjustor: 0
std::_Ref_count_resource<int *,struct std::default_delete<int> >::_Destroy this adjustor: 0
std::_Ref_count_resource<int *,struct std::default_delete<int> >::_Delete_this this adjustor: 0
std::_Ref_count_resource<int *,struct std::default_delete<int> >::__delDtor this adjustor: 0
std::_Ref_count_resource<int *,struct std::default_delete<int> >::__vecDelDtor this adjustor: 0
```

The virtual function table order is unchanged, and it follows the base class order (which, after thinking about it for a moment, is how virtual functions must work):

https://github.com/microsoft/STL/blob/c5ee3b32bd3ee219b6d93d72f24429ae6e240ced/stl/inc/memory#L1046-L1121

The only difference is that `/d1reportSingleClassLayout` is reporting "`this` adjustors" in derived order, and I'm inserting the definitions of `~_Ref_count_resource()` and `~_Ref_count_resource_alloc()` near the top. As far as I know, this difference is purely cosmetic (it doesn't reflect any physical ordering).

The test contains comments indicating which control blocks are being tested; mostly for clarity, partially so that any future searches for control block names will find these tests.

Along the way, I reported (internally, because I was a lazy kitty) and worked around:

* VSO-1292292 "EDG mishandles trivial throwing destructors"
* VSO-1292293 "EDG incorrectly rejects defaulted noexcept dtor when a data member has a throwing dtor"