### PR TITLE
<format>: Add specful writers

### DIFF
--- a/stl/inc/format
+++ b/stl/inc/format
@@ -1245,16 +1245,17 @@ _OutputIt _Write(_OutputIt _Out, basic_string_view<_CharT> _Value) {
 
 template <class _CharT, class _OutputIt, class _Func>
 _OutputIt _Write_aligned(
-    _OutputIt _Out, int _Width, _Basic_format_specs<_CharT>& _Specs, _Align _Default_align, _Func&& _Fn) {
+    _OutputIt _Out, int _Width, const _Basic_format_specs<_CharT>& _Specs, _Align _Default_align, _Func&& _Fn) {
     int _Fill_left  = 0;
     int _Fill_right = 0;
+    auto _Alignment = _Specs._Alignment;
 
-    if (_Specs._Alignment == _Align::_None) {
-        _Specs._Alignment = _Default_align;
+    if (_Alignment == _Align::_None) {
+        _Alignment = _Default_align;
     }
 
     if (_Width < _Specs._Width) {
-        switch (_Specs._Alignment) {
+        switch (_Alignment) {
         case _Align::_Left:
             _Fill_right = _Specs._Width - _Width;
             break;
@@ -1267,6 +1268,7 @@ _OutputIt _Write_aligned(
             break;
         case _Align::_None:
             _STL_ASSERT(false, "Invalid alignment");
+            break;
         }
     }
 
@@ -1291,8 +1293,10 @@ _NODISCARD constexpr string_view _Get_integral_prefix(char _Type, _Integral _Val
         if (_Value != _Integral{0}) {
             return "0"sv;
         }
+        return {};
+    default:
+        return {};
     }
-    return {};
 }
 
 template <class _OutputIt>
@@ -1315,7 +1319,7 @@ _OutputIt _Write_sign(_OutputIt _Out, _Sign _Sgn, bool _Is_negative) {
     return ++_Out;
 }
 
-inline void _Fmt_buffer_to_uppercase(char* _Begin, const char* _End) {
+inline void _Buffer_to_uppercase(char* _Begin, const char* _End) {
     for (; _Begin != _End; ++_Begin) {
         *_Begin = static_cast<char>(_CSTD toupper(*_Begin));
     }
@@ -1335,7 +1339,7 @@ _NODISCARD constexpr bool _In_bounds(_Ty _Value) {
 }
 
 template <class _CharT, class _OutputIt>
-_OutputIt _Write(_OutputIt _Out, monostate, _Basic_format_specs<_CharT>&) {
+_OutputIt _Write(_OutputIt _Out, monostate, const _Basic_format_specs<_CharT>&) {
     _STL_INTERNAL_CHECK(false);
     return _Out;
 }
@@ -1343,8 +1347,8 @@ _OutputIt _Write(_OutputIt _Out, monostate, _Basic_format_specs<_CharT>&) {
 #pragma warning(push)
 #pragma warning(disable : 4365) // 'argument': conversion from 'char' to 'const wchar_t', signed/unsigned mismatch
 template <class _CharT, class _OutputIt, integral _Integral>
-_OutputIt _Write_integral(_OutputIt _Out, _Integral _Value, _Basic_format_specs<_CharT>& _Specs) {
-    if (_Specs._Type && _Specs._Type == 'c') {
+_OutputIt _Write_integral(_OutputIt _Out, _Integral _Value, _Basic_format_specs<_CharT> _Specs) {
+    if (_Specs._Type == 'c') {
         if (!_In_bounds<_CharT>(_Value)) {
             throw format_error("integral cannot be stored in charT");
         }
@@ -1364,7 +1368,7 @@ _OutputIt _Write_integral(_OutputIt _Out, _Integral _Value, _Basic_format_specs<
     bool _To_upper = false;
 
     switch (_Specs._Type) {
-    case 0:
+    case '\0':
     case 'd':
         break;
     case 'B':
@@ -1388,7 +1392,7 @@ _OutputIt _Write_integral(_OutputIt _Out, _Integral _Value, _Basic_format_specs<
 
     // long long -1 representation in binary is 64 bits + sign
     array<char, 65> _Buffer;
-    const auto [_End, _Ec] = to_chars(_Buffer.data(), _Buffer.data() + _Buffer.size(), _Value, _Base);
+    const auto [_End, _Ec] = _STD to_chars(_Buffer.data(), _Buffer.data() + _Buffer.size(), _Value, _Base);
     _STL_ASSERT(_Ec == errc{}, "to_chars failed");
 
     auto _Buffer_start = _Buffer.data();
@@ -1404,7 +1408,7 @@ _OutputIt _Write_integral(_OutputIt _Out, _Integral _Value, _Basic_format_specs<
     }
 
     if (_To_upper) {
-        _Fmt_buffer_to_uppercase(_Buffer_start, _End);
+        _Buffer_to_uppercase(_Buffer_start, _End);
     }
 
     string_view _Prefix;
@@ -1434,17 +1438,15 @@ _OutputIt _Write_integral(_OutputIt _Out, _Integral _Value, _Basic_format_specs<
 // clang-format off
 template <class _CharT, class _OutputIt, integral _Integral>
     requires (!_CharT_or_bool<_Integral, _CharT>)
-_OutputIt _Write(_OutputIt _Out, _Integral _Value, _Basic_format_specs<_CharT>& _Specs) {
+_OutputIt _Write(_OutputIt _Out, _Integral _Value, const _Basic_format_specs<_CharT>& _Specs) {
     // clang-format on
     return _Write_integral(_Out, _Value, _Specs);
 }
 
 template <class _CharT, class _OutputIt>
-_OutputIt _Write(_OutputIt _Out, bool _Value, _Basic_format_specs<_CharT>& _Specs) {
-    if (_Specs._Type && _Specs._Type != 's') {
-        // Standard says to cast to unsigned char, but this is just going to be wider and prevent an extra template
-        // instantiation.
-        return _Write_integral(_Out, static_cast<unsigned int>(_Value), _Specs);
+_OutputIt _Write(_OutputIt _Out, bool _Value, const _Basic_format_specs<_CharT>& _Specs) {
+    if (_Specs._Type != '\0' && _Specs._Type != 's') {
+        return _Write_integral(_Out, static_cast<unsigned char>(_Value), _Specs);
     }
 
     if (_Specs._Precision != -1) {
@@ -1459,8 +1461,8 @@ _OutputIt _Write(_OutputIt _Out, bool _Value, _Basic_format_specs<_CharT>& _Spec
 }
 
 template <class _CharT, class _OutputIt>
-_OutputIt _Write(_OutputIt _Out, _CharT _Value, _Basic_format_specs<_CharT>& _Specs) {
-    if (_Specs._Type && _Specs._Type != 'c') {
+_OutputIt _Write(_OutputIt _Out, _CharT _Value, _Basic_format_specs<_CharT> _Specs) {
+    if (_Specs._Type != '\0' && _Specs._Type != 'c') {
         return _Write_integral(_Out, _Value, _Specs);
     }
 
@@ -1469,24 +1471,26 @@ _OutputIt _Write(_OutputIt _Out, _CharT _Value, _Basic_format_specs<_CharT>& _Sp
     }
 
     // Clear the type so that the string_view writer doesn't fail on 'c'.
-    _Specs._Type = 0;
-    return _Write(_Out, basic_string_view<_CharT>(&_Value, 1), _Specs);
+    _Specs._Type = '\0';
+    return _Write(_Out, basic_string_view<_CharT>{&_Value, 1}, _Specs);
 }
 
 #pragma warning(push)
 #pragma warning(disable : 4365) // 'argument': conversion from 'char' to 'const wchar_t', signed/unsigned mismatch
 template <class _CharT, class _OutputIt, floating_point _Float>
-_OutputIt _Write(_OutputIt _Out, _Float _Value, _Basic_format_specs<_CharT>& _Specs) {
-    if (_Specs._Sgn == _Sign::_None) {
-        _Specs._Sgn = _Sign::_Minus;
+_OutputIt _Write(_OutputIt _Out, _Float _Value, const _Basic_format_specs<_CharT>& _Specs) {
+    auto _Sgn = _Specs._Sgn;
+    if (_Sgn == _Sign::_None) {
+        _Sgn = _Sign::_Minus;
     }
 
-    auto _To_upper = false;
-    auto _Format   = chars_format::general;
-    auto _Exponent = '\0';
+    auto _To_upper  = false;
+    auto _Format    = chars_format::general;
+    auto _Exponent  = '\0';
+    auto _Precision = _Specs._Precision;
 
     switch (_Specs._Type) {
-    case 0:
+    case '\0':
         break;
     case 'A':
         _To_upper = true;
@@ -1499,16 +1503,16 @@ _OutputIt _Write(_OutputIt _Out, _Float _Value, _Basic_format_specs<_CharT>& _Sp
         _To_upper = true;
         [[fallthrough]];
     case 'e':
-        if (_Specs._Precision == -1) {
-            _Specs._Precision = 6;
+        if (_Precision == -1) {
+            _Precision = 6;
         }
         _Format   = chars_format::scientific;
         _Exponent = 'e';
         break;
     case 'F':
     case 'f':
-        if (_Specs._Precision == -1) {
-            _Specs._Precision = 6;
+        if (_Precision == -1) {
+            _Precision = 6;
         }
         _Format = chars_format::fixed;
         break;
@@ -1516,8 +1520,8 @@ _OutputIt _Write(_OutputIt _Out, _Float _Value, _Basic_format_specs<_CharT>& _Sp
         _To_upper = true;
         [[fallthrough]];
     case 'g':
-        if (_Specs._Precision == -1) {
-            _Specs._Precision = 6;
+        if (_Precision == -1) {
+            _Precision = 6;
         }
         _Format   = chars_format::general;
         _Exponent = 'e';
@@ -1529,10 +1533,10 @@ _OutputIt _Write(_OutputIt _Out, _Float _Value, _Basic_format_specs<_CharT>& _Sp
     array<char, _Format_min_buffer_length> _Buffer;
     to_chars_result _Result;
 
-    if (_Specs._Precision == -1) {
-        _Result = to_chars(_Buffer.data(), _Buffer.data() + _Buffer.size(), _Value, _Format);
+    if (_Precision == -1) {
+        _Result = _STD to_chars(_Buffer.data(), _Buffer.data() + _Buffer.size(), _Value, _Format);
     } else {
-        _Result = to_chars(_Buffer.data(), _Buffer.data() + _Buffer.size(), _Value, _Format, _Specs._Precision);
+        _Result = _STD to_chars(_Buffer.data(), _Buffer.data() + _Buffer.size(), _Value, _Format, _Precision);
     }
 
     _STL_ASSERT(_Result.ec == errc{}, "to_chars failed");
@@ -1540,19 +1544,19 @@ _OutputIt _Write(_OutputIt _Out, _Float _Value, _Basic_format_specs<_CharT>& _Sp
     auto _Buffer_start = _Buffer.data();
     auto _Width        = static_cast<int>(_Result.ptr - _Buffer_start);
 
-    const auto _Is_negative = signbit(_Value);
+    const auto _Is_negative = _STD signbit(_Value);
 
     if (_Is_negative) {
         // Remove the '-', it will be dealt with directly
         _Buffer_start += 1;
     } else {
-        if (_Specs._Sgn != _Sign::_Minus) {
+        if (_Sgn != _Sign::_Minus) {
             _Width += 1;
         }
     }
 
     if (_To_upper) {
-        _Fmt_buffer_to_uppercase(_Buffer_start, _Result.ptr);
+        _Buffer_to_uppercase(_Buffer_start, _Result.ptr);
         _Exponent = static_cast<char>(_CSTD toupper(_Exponent));
     }
 
@@ -1564,11 +1568,11 @@ _OutputIt _Write(_OutputIt _Out, _Float _Value, _Basic_format_specs<_CharT>& _Sp
 
     if (_Specs._Alt && _Is_finite) {
         auto _Radix_point = _Result.ptr;
-        for (auto it = _Buffer_start; it < _Result.ptr; ++it) {
-            if (*it == '.') {
-                _Radix_point = it;
-            } else if (*it == _Exponent) {
-                _Exponent_start = it;
+        for (auto _It = _Buffer_start; _It < _Result.ptr; ++_It) {
+            if (*_It == '.') {
+                _Radix_point = _It;
+            } else if (*_It == _Exponent) {
+                _Exponent_start = _It;
             }
         }
         if (_Radix_point == _Result.ptr) {
@@ -1577,7 +1581,7 @@ _OutputIt _Write(_OutputIt _Out, _Float _Value, _Basic_format_specs<_CharT>& _Sp
         }
 
         if (_Specs._Type == 'g' || _Specs._Type == 'G') {
-            _Zeroes_to_append = _Specs._Precision - static_cast<int>(_Exponent_start - _Buffer_start);
+            _Zeroes_to_append = _Precision - static_cast<int>(_Exponent_start - _Buffer_start);
             if (!_Append_decimal) {
                 _Zeroes_to_append += 1;
             }
@@ -1587,7 +1591,7 @@ _OutputIt _Write(_OutputIt _Out, _Float _Value, _Basic_format_specs<_CharT>& _Sp
 
     const bool _Write_leading_zeroes = _Specs._Leading_zero && _Specs._Alignment == _Align::_None;
     auto _Writer                     = [&](_OutputIt _Out) {
-        _Out = _Write_sign(_Out, _Specs._Sgn, _Is_negative);
+        _Out = _Write_sign(_Out, _Sgn, _Is_negative);
 
         if (_Write_leading_zeroes && _Width < _Specs._Width && _Is_finite) {
             _Out = _STD fill_n(_Out, _Specs._Width - _Width, '0');
@@ -1600,7 +1604,7 @@ _OutputIt _Write(_OutputIt _Out, _Float _Value, _Basic_format_specs<_CharT>& _Sp
             if (_Append_decimal) {
                 *_Out++ = '.';
             }
-            while (_Zeroes_to_append-- > 0) {
+            for (; _Zeroes_to_append > 0; --_Zeroes_to_append) {
                 *_Out++ = '0';
             }
         }
@@ -1617,8 +1621,8 @@ _OutputIt _Write(_OutputIt _Out, _Float _Value, _Basic_format_specs<_CharT>& _Sp
 #pragma warning(pop)
 
 template <class _CharT, class _OutputIt>
-_OutputIt _Write(_OutputIt _Out, const void* _Value, _Basic_format_specs<_CharT>& _Specs) {
-    if (_Specs._Type && _Specs._Type != 'p') {
+_OutputIt _Write(_OutputIt _Out, const void* _Value, const _Basic_format_specs<_CharT>& _Specs) {
+    if (_Specs._Type != '\0' && _Specs._Type != 'p') {
         throw format_error("invalid const void* type");
     }
 
@@ -1642,7 +1646,7 @@ _OutputIt _Write(_OutputIt _Out, const void* _Value, _Basic_format_specs<_CharT>
     // Add 3 to the bit width so we always round up on the division.
     // Divide that by the amount of bits a hex number represents (log2(16) = log2(2^4) = 4).
     // Add 2 for the 0x prefix.
-    auto _Width = 2 + static_cast<int>(bit_width(reinterpret_cast<uintptr_t>(_Value)) + 3) / 4;
+    auto _Width = 2 + static_cast<int>(_STD bit_width(reinterpret_cast<uintptr_t>(_Value)) + 3) / 4;
 
     // Since the bit width of 0 is 0, special case it instead of complicating the math even more.
     if (_Value == nullptr) {
@@ -1654,13 +1658,13 @@ _OutputIt _Write(_OutputIt _Out, const void* _Value, _Basic_format_specs<_CharT>
 }
 
 template <class _CharT, class _OutputIt>
-_OutputIt _Write(_OutputIt _Out, const _CharT* _Value, _Basic_format_specs<_CharT>& _Specs) {
-    return _Write(_Out, basic_string_view<_CharT>(_Value), _Specs);
+_OutputIt _Write(_OutputIt _Out, const _CharT* _Value, const _Basic_format_specs<_CharT>& _Specs) {
+    return _Write(_Out, basic_string_view<_CharT>{_Value}, _Specs);
 }
 
 template <class _CharT, class _OutputIt>
-_OutputIt _Write(_OutputIt _Out, basic_string_view<_CharT> _Value, _Basic_format_specs<_CharT>& _Specs) {
-    if (_Specs._Type && _Specs._Type != 's') {
+_OutputIt _Write(_OutputIt _Out, basic_string_view<_CharT> _Value, const _Basic_format_specs<_CharT>& _Specs) {
+    if (_Specs._Type != '\0' && _Specs._Type != 's') {
         throw format_error("invalid string type");
     }
 

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -1307,6 +1307,10 @@ _OutputIt _Write_sign(_OutputIt _Out, _Sign _Sgn, bool _Is_negative) {
         case _Sign::_Space:
             _Out = ' ';
             break;
+
+        case _Sign::_None:
+        case _Sign::_Minus:
+            break;
         }
     }
     return ++_Out;
@@ -1411,7 +1415,7 @@ _OutputIt _Write_integral(_OutputIt _Out, _Integral _Value, _Basic_format_specs<
 
     bool _Write_leading_zeroes = _Specs._Leading_zero && _Specs._Alignment == _Align::_None;
 
-    auto _Writer = [&](_OutputIt _Out) {
+    auto _Writer = [&, _End = _End](_OutputIt _Out) {
         _Out = _Write_sign(_Out, _Specs._Sgn, _Value < _Integral{0});
         _Out = _STD copy(_Prefix.begin(), _Prefix.end(), _Out);
         if (_Write_leading_zeroes && _Width < _Specs._Width) {

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -833,10 +833,6 @@ public:
 
     // _On_align has no checking, since we don't implement numeric alignments.
 
-    constexpr void _On_sign(_Sign _Sgn) {
-        _Handler::_On_sign(_Sgn);
-    }
-
     constexpr void _On_hash() {
         // Note that '#' is not valid for CharT or bool unless you
         // pass a numeric presentation type, but we encounter '#' before
@@ -1315,7 +1311,7 @@ _OutputIt _Write_sign(_OutputIt _Out, _Sign _Sgn, bool _Is_negative) {
     return ++_Out;
 }
 
-void _Fmt_buffer_to_uppercase(char* _Begin, const char* _End) {
+inline void _Fmt_buffer_to_uppercase(char* _Begin, const char* _End) {
     for (auto _It = _Begin; _It < _End; ++_It) {
         *_It = static_cast<char>(_CSTD toupper(*_It));
     }

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -88,13 +88,16 @@ concept _Parse_arg_id_callbacks = requires(_Ty _At) {
     { _At._On_manual_id(size_t{}) } -> same_as<void>;
 };
 
-template<class _Ty, class _CharT>
+template <class _Ty, class _CharT>
 concept _Parse_replacement_field_callbacks = requires(_Ty _At, const _CharT* _Begin, const _CharT* _End) {
     { _At._Parse_context };
     { _At._On_text(_Begin, _End) } -> same_as<void>;
     { _At._On_replacement_field(size_t{}, static_cast<const _CharT*>(nullptr)) } -> same_as<void>;
     { _At._On_format_specs(size_t{}, _Begin, _End) } -> same_as<const _CharT*>;
 };
+
+template <class _Ty, class _CharT>
+concept _CharT_or_bool = same_as<_Ty, _CharT> || same_as<_Ty, bool>;
 
 // clang-format on
 
@@ -665,9 +668,6 @@ public:
 
     constexpr void _On_zero() {
         _Specs._Leading_zero = true;
-        if (_Specs._Alignment == _Align::_None) {
-            _Specs._Fill[0] = _CharT{'0'};
-        }
     }
 
     constexpr void _On_width(int _Width) {
@@ -834,7 +834,6 @@ public:
     // _On_align has no checking, since we don't implement numeric alignments.
 
     constexpr void _On_sign(_Sign _Sgn) {
-        _Numeric_checker._Check_sign();
         _Handler::_On_sign(_Sgn);
     }
 
@@ -1191,7 +1190,7 @@ inline constexpr size_t _Format_min_buffer_length = 24;
 #pragma warning(disable : 4365) // 'argument': conversion from 'char' to 'const wchar_t', signed/unsigned mismatch
 // clang-format off
 template <class _CharT, class _OutputIt, class _Arithmetic>
-    requires (is_arithmetic_v<_Arithmetic> && !same_as<_Arithmetic, bool> && !same_as<_Arithmetic, _CharT>)
+    requires (is_arithmetic_v<_Arithmetic> && !_CharT_or_bool<_Arithmetic, _CharT>)
 _OutputIt _Write(_OutputIt _Out, _Arithmetic _Value) {
     // clang-format on
     // TRANSITION, Reusable buffer
@@ -1248,13 +1247,423 @@ _OutputIt _Write(_OutputIt _Out, basic_string_view<_CharT> _Value) {
     return _STD copy(_Value.begin(), _Value.end(), _Out);
 }
 
-// TODO: placeholder write
-template <class _CharT, class _OutputIt, class _Ty>
-_OutputIt _Write(_OutputIt _Out, _Ty _Val, _Basic_format_specs<_CharT>& _Specs) {
+template <class _CharT, class _OutputIt, class _Func>
+_OutputIt _Write_aligned(
+    _OutputIt _Out, int _Width, _Basic_format_specs<_CharT>& _Specs, _Align _Default_align, _Func&& _Fn) {
+    int _Fill_left  = 0;
+    int _Fill_right = 0;
+
+    if (_Specs._Alignment == _Align::_None)
+        _Specs._Alignment = _Default_align;
+
+    if (_Width < _Specs._Width) {
+        switch (_Specs._Alignment) {
+        case _Align::_Left:
+            _Fill_right = _Specs._Width - _Width;
+            break;
+        case _Align::_Right:
+            _Fill_left = _Specs._Width - _Width;
+            break;
+        case _Align::_Center:
+            _Fill_left  = (_Specs._Width - _Width) / 2;
+            _Fill_right = _Specs._Width - _Width - _Fill_left;
+            break;
+        default:
+            _STL_ASSERT(false, "Invalid alignment");
+        }
+    }
+
+    // TRANSITION, add support for unicode/wide formats
+    _Out = _STD fill_n(_Out, _Fill_left, _Specs._Fill[0]);
+    _Out = _Fn(_Out);
+    return _STD fill_n(_Out, _Fill_right, _Specs._Fill[0]);
+}
+
+template <integral _Integral>
+string_view _Get_integral_prefix(char _Type, _Integral _Value) {
+    switch (_Type) {
+    case 'b':
+        return "0b"sv;
+    case 'B':
+        return "0B"sv;
+    case 'x':
+        return "0x"sv;
+    case 'X':
+        return "0X"sv;
+    case 'o':
+        if (_Value != _Integral{0})
+            return "0"sv;
+    }
+    return {};
+}
+
+template <class _OutputIt>
+_OutputIt _Write_sign(_OutputIt _Out, _Sign _Sgn, bool _Is_negative) {
+    if (_Is_negative) {
+        _Out = '-';
+    } else {
+        switch (_Sgn) {
+        case _Sign::_Plus:
+            _Out = '+';
+            break;
+
+        case _Sign::_Space:
+            _Out = ' ';
+            break;
+        }
+    }
+    return ++_Out;
+}
+
+void _Fmt_buffer_to_uppercase(char* _Begin, const char* _End) {
+    for (auto _It = _Begin; _It < _End; ++_It) {
+        *_It = static_cast<char>(_CSTD toupper(*_It));
+    }
+}
+
+template <class _CharT, class _Ty>
+bool _In_bounds(_Ty _Value) {
+    if constexpr (is_unsigned_v<_CharT> && is_unsigned_v<_Ty>) {
+        return _Value <= (numeric_limits<_CharT>::max)();
+    } else if constexpr (is_unsigned_v<_CharT>) {
+        return _Value >= 0 && static_cast<make_unsigned_t<_Ty>>(_Value) <= (numeric_limits<_CharT>::max)();
+    } else if constexpr (is_unsigned_v<_Ty>) {
+        return _Value <= static_cast<make_unsigned_t<_CharT>>((numeric_limits<_CharT>::max)());
+    } else {
+        return (numeric_limits<_CharT>::min)() <= _Value && _Value <= (numeric_limits<_CharT>::max)();
+    }
+}
+
+template <class _CharT, class _OutputIt>
+_OutputIt _Write(_OutputIt _Out, monostate, _Basic_format_specs<_CharT>&) {
     _STL_INTERNAL_CHECK(false);
-    (void) _Val;
-    (void) _Specs;
     return _Out;
+}
+
+#pragma warning(push)
+#pragma warning(disable : 4365) // 'argument': conversion from 'char' to 'const wchar_t', signed/unsigned mismatch
+template <class _CharT, class _OutputIt, integral _Integral>
+_OutputIt _Write_integral(_OutputIt _Out, _Integral _Value, _Basic_format_specs<_CharT>& _Specs) {
+    if (_Specs._Type && _Specs._Type == 'c') {
+        if (!_In_bounds<_CharT>(_Value))
+            throw format_error("integral cannot be stored in charT");
+        _Specs._Alt = false;
+        return _Write(_Out, static_cast<_CharT>(_Value), _Specs);
+    }
+
+    if (_Specs._Precision != -1)
+        throw format_error("integral cannot have a precision");
+
+    if (_Specs._Sgn == _Sign::_None)
+        _Specs._Sgn = _Sign::_Minus;
+
+    int _Base      = 10;
+    bool _To_upper = false;
+
+    switch (_Specs._Type) {
+    case 0:
+    case 'd':
+        break;
+
+    case 'B':
+        _To_upper = true;
+    case 'b':
+        _Base = 2;
+        break;
+
+    case 'X':
+        _To_upper = true;
+    case 'x':
+        _Base = 16;
+        break;
+
+    case 'o':
+        _Base = 8;
+        break;
+
+    default:
+        throw format_error("invalid integral type");
+    }
+
+    // long long -1 representation in binary is 64 bits + sign
+    array<char, 65> _Buffer;
+    const auto [_End, _Ec] = to_chars(_Buffer.data(), _Buffer.data() + _Buffer.size(), _Value, _Base);
+    _STL_ASSERT(_Ec == errc{}, "to_chars failed");
+
+    auto _Buffer_start = _Buffer.data();
+    auto _Width        = static_cast<int>(_End - _Buffer_start);
+
+    if (_Value >= _Integral{0}) {
+        if (_Specs._Sgn != _Sign::_Minus) {
+            _Width += 1;
+        }
+    } else {
+        // Remove the '-', it will be dealt with directly
+        _Buffer_start += 1;
+    }
+
+    if (_To_upper) {
+        _Fmt_buffer_to_uppercase(_Buffer_start, _End);
+    }
+
+    string_view _Prefix;
+    if (_Specs._Alt) {
+        _Prefix = _Get_integral_prefix(_Specs._Type, _Value);
+        _Width += static_cast<int>(_Prefix.size());
+    }
+
+    bool _Write_leading_zeroes = _Specs._Leading_zero && _Specs._Alignment == _Align::_None;
+
+    auto _Writer = [&](_OutputIt _Out) {
+        _Out = _Write_sign(_Out, _Specs._Sgn, _Value < _Integral{0});
+        _Out = _STD copy(_Prefix.begin(), _Prefix.end(), _Out);
+        if (_Write_leading_zeroes && _Width < _Specs._Width) {
+            _Out = _STD fill_n(_Out, _Specs._Width - _Width, '0');
+        }
+        return _STD copy(_Buffer_start, _End, _Out);
+    };
+
+    if (_Write_leading_zeroes)
+        return _Writer(_Out);
+
+    return _Write_aligned(_Out, _Width, _Specs, _Align::_Right, _Writer);
+}
+#pragma warning(pop)
+
+// clang-format off
+template <class _CharT, class _OutputIt, integral _Integral>
+    requires (!_CharT_or_bool<_Integral, _CharT>)
+_OutputIt _Write(_OutputIt _Out, _Integral _Value, _Basic_format_specs<_CharT>& _Specs) {
+    // clang-format on
+    return _Write_integral(_Out, _Value, _Specs);
+}
+
+template <class _CharT, class _OutputIt>
+_OutputIt _Write(_OutputIt _Out, bool _Value, _Basic_format_specs<_CharT>& _Specs) {
+    if (_Specs._Type && _Specs._Type != 's') {
+        // Standard says to cast to unsigned char, but this is just going to be wider and prevent an extra template
+        // instantiation.
+        return _Write_integral(_Out, static_cast<unsigned int>(_Value), _Specs);
+    }
+
+    if (_Specs._Precision != -1)
+        throw format_error("bool cannot have a precision");
+
+    if constexpr (is_same_v<_CharT, wchar_t>) {
+        return _Write(_Out, _Value ? L"true" : L"false", _Specs);
+    } else {
+        return _Write(_Out, _Value ? "true" : "false", _Specs);
+    }
+}
+
+template <class _CharT, class _OutputIt>
+_OutputIt _Write(_OutputIt _Out, _CharT _Value, _Basic_format_specs<_CharT>& _Specs) {
+    if (_Specs._Type && _Specs._Type != 'c')
+        return _Write_integral(_Out, _Value, _Specs);
+
+    if (_Specs._Precision != -1)
+        throw format_error("charT cannot have a precision");
+
+    // Clear the type so that the string_view writer doesn't fail on 'c'.
+    _Specs._Type = 0;
+    return _Write(_Out, basic_string_view<_CharT>(&_Value, 1), _Specs);
+}
+
+#pragma warning(push)
+#pragma warning(disable : 4365) // 'argument': conversion from 'char' to 'const wchar_t', signed/unsigned mismatch
+template <class _CharT, class _OutputIt, floating_point _Float>
+_OutputIt _Write(_OutputIt _Out, _Float _Value, _Basic_format_specs<_CharT>& _Specs) {
+    if (_Specs._Sgn == _Sign::_None)
+        _Specs._Sgn = _Sign::_Minus;
+
+    auto _To_upper = false;
+    auto _Format   = chars_format::general;
+    auto _Exponent = '\0';
+
+    switch (_Specs._Type) {
+    case 0:
+        break;
+
+    case 'A':
+        _To_upper = true;
+    case 'a':
+        _Format   = chars_format::hex;
+        _Exponent = 'p';
+        break;
+
+    case 'E':
+        _To_upper = true;
+    case 'e':
+        if (_Specs._Precision == -1)
+            _Specs._Precision = 6;
+        _Format   = chars_format::scientific;
+        _Exponent = 'e';
+        break;
+
+    case 'F':
+    case 'f':
+        if (_Specs._Precision == -1)
+            _Specs._Precision = 6;
+        _Format = chars_format::fixed;
+        break;
+
+    case 'G':
+        _To_upper = true;
+    case 'g':
+        if (_Specs._Precision == -1)
+            _Specs._Precision = 6;
+        _Format   = chars_format::general;
+        _Exponent = 'e';
+        break;
+
+    default:
+        throw format_error("invalid floating point type");
+    }
+
+    array<char, _Format_min_buffer_length> _Buffer;
+    to_chars_result _Result;
+
+    if (_Specs._Precision == -1) {
+        _Result = to_chars(_Buffer.data(), _Buffer.data() + _Buffer.size(), _Value, _Format);
+    } else {
+        _Result = to_chars(_Buffer.data(), _Buffer.data() + _Buffer.size(), _Value, _Format, _Specs._Precision);
+    }
+
+    _STL_ASSERT(_Result.ec == errc{}, "to_chars failed");
+
+    auto _Buffer_start = _Buffer.data();
+    auto _Width        = static_cast<int>(_Result.ptr - _Buffer_start);
+
+    auto _Is_negative = signbit(_Value);
+
+    if (_Is_negative) {
+        // Remove the '-', it will be dealt with directly
+        _Buffer_start += 1;
+    } else {
+        if (_Specs._Sgn != _Sign::_Minus) {
+            _Width += 1;
+        }
+    }
+
+    if (_To_upper) {
+        _Fmt_buffer_to_uppercase(_Buffer_start, _Result.ptr);
+        _Exponent = static_cast<char>(_CSTD toupper(_Exponent));
+    }
+
+    auto _Is_finite = !_STD isnan(_Value) && !_STD isinf(_Value);
+
+    auto _Append_decimal   = false;
+    auto _Exponent_start   = _Result.ptr;
+    auto _Zeroes_to_append = 0;
+
+    if (_Specs._Alt && _Is_finite) {
+        auto _Radix_point = _Result.ptr;
+        for (auto it = _Buffer_start; it < _Result.ptr; ++it) {
+            if (*it == '.') {
+                _Radix_point = it;
+            } else if (*it == _Exponent) {
+                _Exponent_start = it;
+            }
+        }
+        if (_Radix_point == _Result.ptr) {
+            ++_Width;
+            _Append_decimal = true;
+        }
+
+        if (_Specs._Type == 'g' || _Specs._Type == 'G') {
+            _Zeroes_to_append = _Specs._Precision - static_cast<int>(_Exponent_start - _Buffer_start);
+            if (!_Append_decimal)
+                _Zeroes_to_append += 1;
+            _Width += _Zeroes_to_append;
+        }
+    }
+
+    bool _Write_leading_zeroes = _Specs._Leading_zero && _Specs._Alignment == _Align::_None;
+
+    auto _Writer = [&](_OutputIt _Out) {
+        _Out = _Write_sign(_Out, _Specs._Sgn, _Is_negative);
+
+        if (_Write_leading_zeroes && _Width < _Specs._Width && _Is_finite) {
+            _Out = _STD fill_n(_Out, _Specs._Width - _Width, '0');
+        }
+
+        if (_Specs._Alt) {
+            _Out          = _STD copy(_Buffer_start, _Exponent_start, _Out);
+            _Buffer_start = _Exponent_start;
+
+            if (_Append_decimal)
+                _Out++ = '.';
+            while (_Zeroes_to_append-- > 0)
+                _Out++ = '0';
+        }
+
+        return _STD copy(_Buffer_start, _Result.ptr, _Out);
+    };
+
+    if (_Write_leading_zeroes && _Is_finite)
+        return _Writer(_Out);
+
+    return _Write_aligned(_Out, _Width, _Specs, _Align::_Right, _Writer);
+}
+#pragma warning(pop)
+
+template <class _CharT, class _OutputIt>
+_OutputIt _Write(_OutputIt _Out, const void* _Value, _Basic_format_specs<_CharT>& _Specs) {
+    if (_Specs._Type && _Specs._Type != 'p')
+        throw format_error("invalid const void* type");
+
+    if (_Specs._Sgn != _Sign::_None)
+        throw format_error("const void* cannot have a sign");
+
+    if (_Specs._Alt)
+        throw format_error("const void* cannot have an alternative representation");
+
+    if (_Specs._Precision != -1)
+        throw format_error("const void* cannot have a precision");
+
+    if (_Specs._Leading_zero)
+        throw format_error("const void* cannot have a leading zero");
+
+    // Compute the bit width of the pointer (i.e. how many bits it takes to be represented).
+    // Add 3 to the bit width so we always round up on the division.
+    // Divide that by the amount of bits a hex number represents (log2(16) = log2(2^4) = 4).
+    // Add 2 for the 0x prefix.
+    auto _Width = 2 + static_cast<int>(bit_width(reinterpret_cast<uintptr_t>(_Value)) + 3) / 4;
+
+    // Since the bit width of 0 is 0, special case it instead of complicating the math even more.
+    if (_Value == nullptr)
+        _Width = 3;
+
+    return _Write_aligned(
+        _Out, _Width, _Specs, _Align::_Left, [=](_OutputIt _Out) { return _Write<_CharT>(_Out, _Value); });
+}
+
+template <class _CharT, class _OutputIt>
+_OutputIt _Write(_OutputIt _Out, const _CharT* _Value, _Basic_format_specs<_CharT>& _Specs) {
+    return _Write(_Out, basic_string_view<_CharT>(_Value), _Specs);
+}
+
+template <class _CharT, class _OutputIt>
+_OutputIt _Write(_OutputIt _Out, basic_string_view<_CharT> _Value, _Basic_format_specs<_CharT>& _Specs) {
+    if (_Specs._Type && _Specs._Type != 's')
+        throw format_error("invalid string type");
+
+    if (_Specs._Sgn != _Sign::_None)
+        throw format_error("string cannot have a sign");
+
+    if (_Specs._Alt)
+        throw format_error("string cannot have an alternative representation");
+
+    if (_Specs._Leading_zero)
+        throw format_error("string cannot have a leading zero");
+
+    auto _Printed_size = static_cast<int>(_Value.size());
+
+    if (_Specs._Precision != -1 && _Printed_size > _Specs._Precision)
+        _Printed_size = _Specs._Precision;
+
+    return _Write_aligned(_Out, _Printed_size, _Specs, _Align::_Left,
+        [=](_OutputIt _Out) { return _Write(_Out, _Value.substr(size_t{0}, static_cast<size_t>(_Printed_size))); });
 }
 
 // This is the visitor that's used for "simple" replacement fields,

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -1249,8 +1249,9 @@ _OutputIt _Write_aligned(
     int _Fill_left  = 0;
     int _Fill_right = 0;
 
-    if (_Specs._Alignment == _Align::_None)
+    if (_Specs._Alignment == _Align::_None) {
         _Specs._Alignment = _Default_align;
+    }
 
     if (_Width < _Specs._Width) {
         switch (_Specs._Alignment) {
@@ -1265,7 +1266,6 @@ _OutputIt _Write_aligned(
             _Fill_right = _Specs._Width - _Width - _Fill_left;
             break;
         case _Align::_None:
-        default:
             _STL_ASSERT(false, "Invalid alignment");
         }
     }
@@ -1277,7 +1277,7 @@ _OutputIt _Write_aligned(
 }
 
 template <integral _Integral>
-string_view _Get_integral_prefix(char _Type, _Integral _Value) {
+_NODISCARD constexpr string_view _Get_integral_prefix(char _Type, _Integral _Value) {
     switch (_Type) {
     case 'b':
         return "0b"sv;
@@ -1288,8 +1288,9 @@ string_view _Get_integral_prefix(char _Type, _Integral _Value) {
     case 'X':
         return "0X"sv;
     case 'o':
-        if (_Value != _Integral{0})
+        if (_Value != _Integral{0}) {
             return "0"sv;
+        }
     }
     return {};
 }
@@ -1297,17 +1298,15 @@ string_view _Get_integral_prefix(char _Type, _Integral _Value) {
 template <class _OutputIt>
 _OutputIt _Write_sign(_OutputIt _Out, _Sign _Sgn, bool _Is_negative) {
     if (_Is_negative) {
-        _Out = '-';
+        *_Out = '-';
     } else {
         switch (_Sgn) {
         case _Sign::_Plus:
-            _Out = '+';
+            *_Out = '+';
             break;
-
         case _Sign::_Space:
-            _Out = ' ';
+            *_Out = ' ';
             break;
-
         case _Sign::_None:
         case _Sign::_Minus:
             break;
@@ -1317,13 +1316,13 @@ _OutputIt _Write_sign(_OutputIt _Out, _Sign _Sgn, bool _Is_negative) {
 }
 
 inline void _Fmt_buffer_to_uppercase(char* _Begin, const char* _End) {
-    for (auto _It = _Begin; _It < _End; ++_It) {
-        *_It = static_cast<char>(_CSTD toupper(*_It));
+    for (; _Begin != _End; ++_Begin) {
+        *_Begin = static_cast<char>(_CSTD toupper(*_Begin));
     }
 }
 
-template <class _CharT, class _Ty>
-bool _In_bounds(_Ty _Value) {
+template <class _CharT, integral _Ty>
+_NODISCARD constexpr bool _In_bounds(_Ty _Value) {
     if constexpr (is_unsigned_v<_CharT> && is_unsigned_v<_Ty>) {
         return _Value <= (numeric_limits<_CharT>::max)();
     } else if constexpr (is_unsigned_v<_CharT>) {
@@ -1346,17 +1345,20 @@ _OutputIt _Write(_OutputIt _Out, monostate, _Basic_format_specs<_CharT>&) {
 template <class _CharT, class _OutputIt, integral _Integral>
 _OutputIt _Write_integral(_OutputIt _Out, _Integral _Value, _Basic_format_specs<_CharT>& _Specs) {
     if (_Specs._Type && _Specs._Type == 'c') {
-        if (!_In_bounds<_CharT>(_Value))
+        if (!_In_bounds<_CharT>(_Value)) {
             throw format_error("integral cannot be stored in charT");
+        }
         _Specs._Alt = false;
         return _Write(_Out, static_cast<_CharT>(_Value), _Specs);
     }
 
-    if (_Specs._Precision != -1)
+    if (_Specs._Precision != -1) {
         throw format_error("integral cannot have a precision");
+    }
 
-    if (_Specs._Sgn == _Sign::_None)
+    if (_Specs._Sgn == _Sign::_None) {
         _Specs._Sgn = _Sign::_Minus;
+    }
 
     int _Base      = 10;
     bool _To_upper = false;
@@ -1365,23 +1367,21 @@ _OutputIt _Write_integral(_OutputIt _Out, _Integral _Value, _Basic_format_specs<
     case 0:
     case 'd':
         break;
-
     case 'B':
         _To_upper = true;
+        [[fallthrough]];
     case 'b':
         _Base = 2;
         break;
-
     case 'X':
         _To_upper = true;
+        [[fallthrough]];
     case 'x':
         _Base = 16;
         break;
-
     case 'o':
         _Base = 8;
         break;
-
     default:
         throw format_error("invalid integral type");
     }
@@ -1413,9 +1413,8 @@ _OutputIt _Write_integral(_OutputIt _Out, _Integral _Value, _Basic_format_specs<
         _Width += static_cast<int>(_Prefix.size());
     }
 
-    bool _Write_leading_zeroes = _Specs._Leading_zero && _Specs._Alignment == _Align::_None;
-
-    auto _Writer = [&, _End = _End](_OutputIt _Out) {
+    const bool _Write_leading_zeroes = _Specs._Leading_zero && _Specs._Alignment == _Align::_None;
+    auto _Writer                     = [&, _End = _End](_OutputIt _Out) {
         _Out = _Write_sign(_Out, _Specs._Sgn, _Value < _Integral{0});
         _Out = _STD copy(_Prefix.begin(), _Prefix.end(), _Out);
         if (_Write_leading_zeroes && _Width < _Specs._Width) {
@@ -1424,8 +1423,9 @@ _OutputIt _Write_integral(_OutputIt _Out, _Integral _Value, _Basic_format_specs<
         return _STD copy(_Buffer_start, _End, _Out);
     };
 
-    if (_Write_leading_zeroes)
+    if (_Write_leading_zeroes) {
         return _Writer(_Out);
+    }
 
     return _Write_aligned(_Out, _Width, _Specs, _Align::_Right, _Writer);
 }
@@ -1447,8 +1447,9 @@ _OutputIt _Write(_OutputIt _Out, bool _Value, _Basic_format_specs<_CharT>& _Spec
         return _Write_integral(_Out, static_cast<unsigned int>(_Value), _Specs);
     }
 
-    if (_Specs._Precision != -1)
+    if (_Specs._Precision != -1) {
         throw format_error("bool cannot have a precision");
+    }
 
     if constexpr (is_same_v<_CharT, wchar_t>) {
         return _Write(_Out, _Value ? L"true" : L"false", _Specs);
@@ -1459,11 +1460,13 @@ _OutputIt _Write(_OutputIt _Out, bool _Value, _Basic_format_specs<_CharT>& _Spec
 
 template <class _CharT, class _OutputIt>
 _OutputIt _Write(_OutputIt _Out, _CharT _Value, _Basic_format_specs<_CharT>& _Specs) {
-    if (_Specs._Type && _Specs._Type != 'c')
+    if (_Specs._Type && _Specs._Type != 'c') {
         return _Write_integral(_Out, _Value, _Specs);
+    }
 
-    if (_Specs._Precision != -1)
+    if (_Specs._Precision != -1) {
         throw format_error("charT cannot have a precision");
+    }
 
     // Clear the type so that the string_view writer doesn't fail on 'c'.
     _Specs._Type = 0;
@@ -1474,8 +1477,9 @@ _OutputIt _Write(_OutputIt _Out, _CharT _Value, _Basic_format_specs<_CharT>& _Sp
 #pragma warning(disable : 4365) // 'argument': conversion from 'char' to 'const wchar_t', signed/unsigned mismatch
 template <class _CharT, class _OutputIt, floating_point _Float>
 _OutputIt _Write(_OutputIt _Out, _Float _Value, _Basic_format_specs<_CharT>& _Specs) {
-    if (_Specs._Sgn == _Sign::_None)
+    if (_Specs._Sgn == _Sign::_None) {
         _Specs._Sgn = _Sign::_Minus;
+    }
 
     auto _To_upper = false;
     auto _Format   = chars_format::general;
@@ -1484,39 +1488,40 @@ _OutputIt _Write(_OutputIt _Out, _Float _Value, _Basic_format_specs<_CharT>& _Sp
     switch (_Specs._Type) {
     case 0:
         break;
-
     case 'A':
         _To_upper = true;
+        [[fallthrough]];
     case 'a':
         _Format   = chars_format::hex;
         _Exponent = 'p';
         break;
-
     case 'E':
         _To_upper = true;
+        [[fallthrough]];
     case 'e':
-        if (_Specs._Precision == -1)
+        if (_Specs._Precision == -1) {
             _Specs._Precision = 6;
+        }
         _Format   = chars_format::scientific;
         _Exponent = 'e';
         break;
-
     case 'F':
     case 'f':
-        if (_Specs._Precision == -1)
+        if (_Specs._Precision == -1) {
             _Specs._Precision = 6;
+        }
         _Format = chars_format::fixed;
         break;
-
     case 'G':
         _To_upper = true;
+        [[fallthrough]];
     case 'g':
-        if (_Specs._Precision == -1)
+        if (_Specs._Precision == -1) {
             _Specs._Precision = 6;
+        }
         _Format   = chars_format::general;
         _Exponent = 'e';
         break;
-
     default:
         throw format_error("invalid floating point type");
     }
@@ -1535,7 +1540,7 @@ _OutputIt _Write(_OutputIt _Out, _Float _Value, _Basic_format_specs<_CharT>& _Sp
     auto _Buffer_start = _Buffer.data();
     auto _Width        = static_cast<int>(_Result.ptr - _Buffer_start);
 
-    auto _Is_negative = signbit(_Value);
+    const auto _Is_negative = signbit(_Value);
 
     if (_Is_negative) {
         // Remove the '-', it will be dealt with directly
@@ -1551,7 +1556,7 @@ _OutputIt _Write(_OutputIt _Out, _Float _Value, _Basic_format_specs<_CharT>& _Sp
         _Exponent = static_cast<char>(_CSTD toupper(_Exponent));
     }
 
-    auto _Is_finite = !_STD isnan(_Value) && !_STD isinf(_Value);
+    const auto _Is_finite = !_STD isnan(_Value) && !_STD isinf(_Value);
 
     auto _Append_decimal   = false;
     auto _Exponent_start   = _Result.ptr;
@@ -1573,15 +1578,15 @@ _OutputIt _Write(_OutputIt _Out, _Float _Value, _Basic_format_specs<_CharT>& _Sp
 
         if (_Specs._Type == 'g' || _Specs._Type == 'G') {
             _Zeroes_to_append = _Specs._Precision - static_cast<int>(_Exponent_start - _Buffer_start);
-            if (!_Append_decimal)
+            if (!_Append_decimal) {
                 _Zeroes_to_append += 1;
+            }
             _Width += _Zeroes_to_append;
         }
     }
 
-    bool _Write_leading_zeroes = _Specs._Leading_zero && _Specs._Alignment == _Align::_None;
-
-    auto _Writer = [&](_OutputIt _Out) {
+    const bool _Write_leading_zeroes = _Specs._Leading_zero && _Specs._Alignment == _Align::_None;
+    auto _Writer                     = [&](_OutputIt _Out) {
         _Out = _Write_sign(_Out, _Specs._Sgn, _Is_negative);
 
         if (_Write_leading_zeroes && _Width < _Specs._Width && _Is_finite) {
@@ -1592,17 +1597,20 @@ _OutputIt _Write(_OutputIt _Out, _Float _Value, _Basic_format_specs<_CharT>& _Sp
             _Out          = _STD copy(_Buffer_start, _Exponent_start, _Out);
             _Buffer_start = _Exponent_start;
 
-            if (_Append_decimal)
-                _Out++ = '.';
-            while (_Zeroes_to_append-- > 0)
-                _Out++ = '0';
+            if (_Append_decimal) {
+                *_Out++ = '.';
+            }
+            while (_Zeroes_to_append-- > 0) {
+                *_Out++ = '0';
+            }
         }
 
         return _STD copy(_Buffer_start, _Result.ptr, _Out);
     };
 
-    if (_Write_leading_zeroes && _Is_finite)
+    if (_Write_leading_zeroes && _Is_finite) {
         return _Writer(_Out);
+    }
 
     return _Write_aligned(_Out, _Width, _Specs, _Align::_Right, _Writer);
 }
@@ -1610,20 +1618,25 @@ _OutputIt _Write(_OutputIt _Out, _Float _Value, _Basic_format_specs<_CharT>& _Sp
 
 template <class _CharT, class _OutputIt>
 _OutputIt _Write(_OutputIt _Out, const void* _Value, _Basic_format_specs<_CharT>& _Specs) {
-    if (_Specs._Type && _Specs._Type != 'p')
+    if (_Specs._Type && _Specs._Type != 'p') {
         throw format_error("invalid const void* type");
+    }
 
-    if (_Specs._Sgn != _Sign::_None)
+    if (_Specs._Sgn != _Sign::_None) {
         throw format_error("const void* cannot have a sign");
+    }
 
-    if (_Specs._Alt)
+    if (_Specs._Alt) {
         throw format_error("const void* cannot have an alternative representation");
+    }
 
-    if (_Specs._Precision != -1)
+    if (_Specs._Precision != -1) {
         throw format_error("const void* cannot have a precision");
+    }
 
-    if (_Specs._Leading_zero)
+    if (_Specs._Leading_zero) {
         throw format_error("const void* cannot have a leading zero");
+    }
 
     // Compute the bit width of the pointer (i.e. how many bits it takes to be represented).
     // Add 3 to the bit width so we always round up on the division.
@@ -1632,8 +1645,9 @@ _OutputIt _Write(_OutputIt _Out, const void* _Value, _Basic_format_specs<_CharT>
     auto _Width = 2 + static_cast<int>(bit_width(reinterpret_cast<uintptr_t>(_Value)) + 3) / 4;
 
     // Since the bit width of 0 is 0, special case it instead of complicating the math even more.
-    if (_Value == nullptr)
+    if (_Value == nullptr) {
         _Width = 3;
+    }
 
     return _Write_aligned(
         _Out, _Width, _Specs, _Align::_Left, [=](_OutputIt _Out) { return _Write<_CharT>(_Out, _Value); });
@@ -1646,22 +1660,27 @@ _OutputIt _Write(_OutputIt _Out, const _CharT* _Value, _Basic_format_specs<_Char
 
 template <class _CharT, class _OutputIt>
 _OutputIt _Write(_OutputIt _Out, basic_string_view<_CharT> _Value, _Basic_format_specs<_CharT>& _Specs) {
-    if (_Specs._Type && _Specs._Type != 's')
+    if (_Specs._Type && _Specs._Type != 's') {
         throw format_error("invalid string type");
+    }
 
-    if (_Specs._Sgn != _Sign::_None)
+    if (_Specs._Sgn != _Sign::_None) {
         throw format_error("string cannot have a sign");
+    }
 
-    if (_Specs._Alt)
+    if (_Specs._Alt) {
         throw format_error("string cannot have an alternative representation");
+    }
 
-    if (_Specs._Leading_zero)
+    if (_Specs._Leading_zero) {
         throw format_error("string cannot have a leading zero");
+    }
 
     auto _Printed_size = static_cast<int>(_Value.size());
 
-    if (_Specs._Precision != -1 && _Printed_size > _Specs._Precision)
+    if (_Specs._Precision != -1 && _Printed_size > _Specs._Precision) {
         _Printed_size = _Specs._Precision;
+    }
 
     return _Write_aligned(_Out, _Printed_size, _Specs, _Align::_Left,
         [=](_OutputIt _Out) { return _Write(_Out, _Value.substr(size_t{0}, static_cast<size_t>(_Printed_size))); });

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -1264,6 +1264,7 @@ _OutputIt _Write_aligned(
             _Fill_left  = (_Specs._Width - _Width) / 2;
             _Fill_right = _Specs._Width - _Width - _Fill_left;
             break;
+        case _Align::_None:
         default:
             _STL_ASSERT(false, "Invalid alignment");
         }

--- a/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
@@ -4,6 +4,7 @@
 #include <assert.h>
 #include <format>
 #include <iterator>
+#include <limits>
 #include <locale>
 #include <string>
 #include <string_view>
@@ -47,7 +48,7 @@ void throw_helper(const charT* fmt, const Args&... vals) {
     try {
         format(fmt, vals...);
         assert(false);
-    } catch (format_error) {
+    } catch (const format_error&) {
     }
 }
 
@@ -679,7 +680,7 @@ void test_pointer_specs() {
 
 template <class charT>
 void test_string_specs() {
-    auto cstr = STR("foo");
+    auto cstr = STR("scully");
     auto view = basic_string_view{cstr};
 
     assert(format(STR("{:}"), cstr) == cstr);
@@ -703,19 +704,19 @@ void test_string_specs() {
     throw_helper(STR("{:0}"), view);
 
     // Width
-    assert(format(STR("{:5}"), cstr) == STR("foo  "));
-    assert(format(STR("{:5}"), view) == STR("foo  "));
+    assert(format(STR("{:8}"), cstr) == STR("scully  "));
+    assert(format(STR("{:8}"), view) == STR("scully  "));
 
     // Precision
-    assert(format(STR("{:.2}"), cstr) == STR("fo"));
-    assert(format(STR("{:5.2}"), cstr) == STR("fo   "));
-    assert(format(STR("{:5.2}"), cstr) == STR("fo   "));
-    assert(format(STR("{:>5.2}"), cstr) == STR("   fo"));
+    assert(format(STR("{:.2}"), cstr) == STR("sc"));
+    assert(format(STR("{:5.2}"), cstr) == STR("sc   "));
+    assert(format(STR("{:5.2}"), cstr) == STR("sc   "));
+    assert(format(STR("{:>5.2}"), cstr) == STR("   sc"));
 
-    assert(format(STR("{:.2}"), view) == STR("fo"));
-    assert(format(STR("{:5.2}"), view) == STR("fo   "));
-    assert(format(STR("{:5.2}"), view) == STR("fo   "));
-    assert(format(STR("{:>5.2}"), view) == STR("   fo"));
+    assert(format(STR("{:.2}"), view) == STR("sc"));
+    assert(format(STR("{:5.2}"), view) == STR("sc   "));
+    assert(format(STR("{:5.2}"), view) == STR("sc   "));
+    assert(format(STR("{:>5.2}"), view) == STR("   sc"));
 
     // Types
     assert(format(STR("{:s}"), cstr) == cstr);

--- a/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
@@ -42,6 +42,15 @@ auto make_testing_format_args(Args&&... vals) {
     }
 }
 
+template <class charT, class... Args>
+void throw_helper(const charT* fmt, const Args&... vals) {
+    try {
+        format(fmt, vals...);
+        assert(false);
+    } catch (format_error) {
+    }
+}
+
 
 // tests for format with no format args or replacement fields
 template <class charT>
@@ -340,8 +349,398 @@ void test_multiple_replacement_fields() {
     assert(output_string == STR("f f"));
 }
 
-int main() {
+template <class charT>
+void test_fill_and_align() {
+    auto writer = [](auto out) {
+        out++ = 'A';
+        out++ = 'B';
+        return out;
+    };
 
+    _Basic_format_specs<charT> specs;
+
+    auto tester = [&] {
+        basic_string<charT> output_string;
+        _Write_aligned(back_inserter(output_string), 2, specs, _Align::_Left, writer);
+        return output_string;
+    };
+
+    assert(tester() == STR("AB"));
+
+    specs._Width = 1;
+    assert(tester() == STR("AB"));
+
+
+    specs._Width     = 5;
+    specs._Alignment = _Align::_Left;
+    assert(tester() == STR("AB   "));
+
+    specs._Alignment = _Align::_Right;
+    assert(tester() == STR("   AB"));
+
+    specs._Alignment = _Align::_Center;
+    assert(tester() == STR(" AB  "));
+
+
+    specs._Alignment = _Align::_Left;
+    specs._Fill[0]   = {'*'};
+    assert(tester() == STR("AB***"));
+
+    specs._Alignment = _Align::_Right;
+    assert(tester() == STR("***AB"));
+
+    specs._Alignment = _Align::_Center;
+    assert(tester() == STR("*AB**"));
+}
+
+template <class charT, class integral>
+void test_intergal_specs() {
+    assert(format(STR("{:}"), integral{0}) == STR("0"));
+
+    // Sign
+    assert(format(STR("{: }"), integral{0}) == STR(" 0"));
+    assert(format(STR("{:+}"), integral{0}) == STR("+0"));
+    assert(format(STR("{:-}"), integral{0}) == STR("0"));
+
+    if constexpr (is_signed_v<integral>) {
+        assert(format(STR("{: }"), integral{-1}) == STR("-1"));
+        assert(format(STR("{:+}"), integral{-1}) == STR("-1"));
+        assert(format(STR("{:-}"), integral{-1}) == STR("-1"));
+    }
+
+    assert(format(STR("{: 3}"), integral{1}) == STR("  1"));
+    assert(format(STR("{:+3}"), integral{1}) == STR(" +1"));
+    assert(format(STR("{:-3}"), integral{1}) == STR("  1"));
+
+    // Alternate form
+    assert(format(STR("{:#}"), integral{0}) == STR("0"));
+    assert(format(STR("{:#d}"), integral{0}) == STR("0"));
+    assert(format(STR("{:#c}"), integral{'a'}) == STR("a"));
+
+    assert(format(STR("{:#b}"), integral{0}) == STR("0b0"));
+    assert(format(STR("{:#B}"), integral{0}) == STR("0B0"));
+
+    assert(format(STR("{:#o}"), integral{0}) == STR("0"));
+    assert(format(STR("{:#o}"), integral{1}) == STR("01"));
+
+    assert(format(STR("{:#x}"), integral{0}) == STR("0x0"));
+    assert(format(STR("{:#X}"), integral{0}) == STR("0X0"));
+    assert(format(STR("{:#x}"), integral{255}) == STR("0xff"));
+    assert(format(STR("{:#X}"), integral{255}) == STR("0XFF"));
+
+    assert(format(STR("{:+#6x}"), integral{255}) == STR(" +0xff"));
+
+    if constexpr (is_signed_v<integral>) {
+        assert(format(STR("{:#o}"), integral{-1}) == STR("-01"));
+        assert(format(STR("{:#x}"), integral{-255}) == STR("-0xff"));
+        assert(format(STR("{:#X}"), integral{-255}) == STR("-0XFF"));
+    }
+
+    // Leading zero
+    assert(format(STR("{:0}"), integral{0}) == STR("0"));
+    assert(format(STR("{:03}"), integral{0}) == STR("000"));
+    assert(format(STR("{:+03}"), integral{0}) == STR("+00"));
+    assert(format(STR("{:<03}"), integral{0}) == STR("0  "));
+    assert(format(STR("{:>03}"), integral{0}) == STR("  0"));
+    assert(format(STR("{:+#06X}"), integral{5}) == STR("+0X005"));
+
+    // Width
+    assert(format(STR("{:3}"), integral{0}) == STR("  0"));
+
+    // Precision
+    throw_helper(STR("{:.1}"), integral{0});
+
+    // Type
+    assert(format(STR("{:b}"), integral{0}) == STR("0"));
+    assert(format(STR("{:b}"), integral{100}) == STR("1100100"));
+
+    assert(format(STR("{:d}"), integral{100}) == STR("100"));
+
+    throw_helper(STR("{:c}"), integral{numeric_limits<charT>::max()} + 1);
+    if constexpr (is_signed_v<integral>) {
+        throw_helper(STR("{:c}"), integral{numeric_limits<charT>::min()} - 1);
+    }
+}
+
+template <class charT, class T>
+void test_type(const charT* fmt, T val) {
+    assert(format(fmt, val) == format(fmt, static_cast<int>(val)));
+}
+
+template <class charT>
+void test_bool_specs() {
+    assert(format(STR("{:}"), true) == STR("true"));
+    assert(format(STR("{:}"), false) == STR("false"));
+
+    // Sign
+    throw_helper(STR("{: }"), true);
+    throw_helper(STR("{:+}"), true);
+    throw_helper(STR("{:-}"), true);
+
+    // Alternate form
+    throw_helper(STR("{:#}"), true);
+
+    // Leading zero
+    throw_helper(STR("{:0}"), true);
+
+    // Width
+    assert(format(STR("{:6}"), true) == STR("true  "));
+    assert(format(STR("{:6}"), false) == STR("false "));
+
+    // Precision
+    throw_helper(STR("{:.5}"), true);
+
+    // Type
+    assert(format(STR("{:s}"), true) == STR("true"));
+    throw_helper(STR("{:a}"), true);
+
+    test_type(STR("{:b}"), true);
+    test_type(STR("{:B}"), true);
+    test_type(STR("{:c}"), true);
+    test_type(STR("{:d}"), true);
+    test_type(STR("{:o}"), true);
+    test_type(STR("{:x}"), true);
+    test_type(STR("{:X}"), true);
+
+    test_type(STR("{:b}"), false);
+    test_type(STR("{:B}"), false);
+    test_type(STR("{:c}"), false);
+    test_type(STR("{:d}"), false);
+    test_type(STR("{:o}"), false);
+    test_type(STR("{:x}"), false);
+    test_type(STR("{:X}"), false);
+}
+
+template <class charT>
+void test_char_specs() {
+    assert(format(STR("{:}"), charT{'X'}) == STR("X"));
+
+    // Sign
+    throw_helper(STR("{: }"), charT{'X'});
+    throw_helper(STR("{:+}"), charT{'X'});
+    throw_helper(STR("{:-}"), charT{'X'});
+
+    // Alternate form
+    throw_helper(STR("{:#}"), charT{'X'});
+
+    // Leading zero
+    throw_helper(STR("{:0}"), charT{'X'});
+
+    // Width
+    assert(format(STR("{:3}"), charT{'X'}) == STR("X  "));
+
+    // Precision
+    throw_helper(STR("{:.5}"), charT{'X'});
+
+    // Types
+    assert(format(STR("{:c}"), charT{'X'}) == STR("X"));
+    throw_helper(STR("{:a}"), charT{'X'});
+
+    test_type(STR("{:b}"), charT{'X'});
+    test_type(STR("{:B}"), charT{'X'});
+    test_type(STR("{:c}"), charT{'X'});
+    test_type(STR("{:d}"), charT{'X'});
+    test_type(STR("{:o}"), charT{'X'});
+    test_type(STR("{:x}"), charT{'X'});
+    test_type(STR("{:X}"), charT{'X'});
+
+    test_type(STR("{:+d}"), charT{'X'});
+}
+
+template <class charT, class Float>
+void test_float_specs() {
+    const Float inf = numeric_limits<Float>::infinity();
+    const Float nan = numeric_limits<Float>::quiet_NaN();
+
+    assert(format(STR("{:}"), Float{0}) == STR("0"));
+    assert(format(STR("{:}"), inf) == STR("inf"));
+    assert(format(STR("{:}"), nan) == STR("nan"));
+
+    // Sign
+    assert(format(STR("{: }"), Float{0}) == STR(" 0"));
+    assert(format(STR("{:+}"), Float{0}) == STR("+0"));
+    assert(format(STR("{:-}"), Float{0}) == STR("0"));
+
+    assert(format(STR("{: }"), Float{-1}) == STR("-1"));
+    assert(format(STR("{:+}"), Float{-1}) == STR("-1"));
+    assert(format(STR("{:-}"), Float{-1}) == STR("-1"));
+
+    assert(format(STR("{: 3}"), Float{1}) == STR("  1"));
+    assert(format(STR("{:+3}"), Float{1}) == STR(" +1"));
+    assert(format(STR("{:-3}"), Float{1}) == STR("  1"));
+
+    assert(format(STR("{: }"), inf) == STR(" inf"));
+    assert(format(STR("{:+}"), inf) == STR("+inf"));
+    assert(format(STR("{:-}"), inf) == STR("inf"));
+
+    assert(format(STR("{: }"), -inf) == STR("-inf"));
+    assert(format(STR("{:+}"), -inf) == STR("-inf"));
+    assert(format(STR("{:-}"), -inf) == STR("-inf"));
+
+    assert(format(STR("{: }"), nan) == STR(" nan"));
+    assert(format(STR("{:+}"), nan) == STR("+nan"));
+    assert(format(STR("{:-}"), nan) == STR("nan"));
+
+    // Alternate form
+    assert(format(STR("{:#}"), Float{0}) == STR("0."));
+    assert(format(STR("{:#a}"), Float{0}) == STR("0.p+0"));
+    assert(format(STR("{:#A}"), Float{0}) == STR("0.P+0"));
+    assert(format(STR("{:#.0e}"), Float{0}) == STR("0.e+00"));
+    assert(format(STR("{:#.0E}"), Float{0}) == STR("0.E+00"));
+    assert(format(STR("{:#.0f}"), Float{0}) == STR("0."));
+    assert(format(STR("{:#.0F}"), Float{0}) == STR("0."));
+    assert(format(STR("{:#g}"), Float{0}) == STR("0.00000"));
+    assert(format(STR("{:#G}"), Float{0}) == STR("0.00000"));
+    assert(format(STR("{:#g}"), Float{1.2}) == STR("1.20000"));
+    assert(format(STR("{:#G}"), Float{1.2}) == STR("1.20000"));
+    assert(format(STR("{:#g}"), Float{1'000'000}) == STR("1.00000e+06"));
+    assert(format(STR("{:#g}"), Float{12.2}) == STR("12.2000"));
+    assert(format(STR("{:#.0g}"), Float{0}) == STR("0."));
+    assert(format(STR("{:#.0G}"), Float{0}) == STR("0."));
+
+    assert(format(STR("{:#} {:#}"), inf, nan) == STR("inf nan"));
+    assert(format(STR("{:#a} {:#a}"), inf, nan) == STR("inf nan"));
+    assert(format(STR("{:#A} {:#A}"), inf, nan) == STR("INF NAN"));
+    assert(format(STR("{:#e} {:#e}"), inf, nan) == STR("inf nan"));
+    assert(format(STR("{:#E} {:#E}"), inf, nan) == STR("INF NAN"));
+    assert(format(STR("{:#f} {:#f}"), inf, nan) == STR("inf nan"));
+    assert(format(STR("{:#F} {:#F}"), inf, nan) == STR("inf nan"));
+    assert(format(STR("{:#g} {:#g}"), inf, nan) == STR("inf nan"));
+    assert(format(STR("{:#G} {:#G}"), inf, nan) == STR("INF NAN"));
+
+    // Width
+    assert(format(STR("{:3}"), Float{0}) == STR("  0"));
+    assert(format(STR("{:#9G}"), Float{12.2}) == STR("  12.2000"));
+    assert(format(STR("{:#12g}"), Float{1'000'000}) == STR(" 1.00000e+06"));
+
+    // Precision
+    Float value = 1234.52734375;
+    assert(format(STR("{:.4}"), value) == STR("1235"));
+    assert(format(STR("{:.1}"), inf) == STR("inf"));
+    assert(format(STR("{:.1}"), nan) == STR("nan"));
+
+    assert(format(STR("{:.4a}"), value) == STR("1.34a2p+10"));
+    assert(format(STR("{:.4A}"), value) == STR("1.34A2P+10"));
+
+    assert(format(STR("{:.4e}"), value) == STR("1.2345e+03"));
+    assert(format(STR("{:.4E}"), value) == STR("1.2345E+03"));
+
+    assert(format(STR("{:.4f}"), value) == STR("1234.5273"));
+    assert(format(STR("{:.4F}"), value) == STR("1234.5273"));
+
+    assert(format(STR("{:.4g}"), value) == STR("1235"));
+    assert(format(STR("{:.4G}"), value) == STR("1235"));
+
+    // Leading zero
+    assert(format(STR("{:06}"), Float{0}) == STR("000000"));
+    assert(format(STR("{:06}"), Float{1.2}) == STR("0001.2"));
+    assert(format(STR("{:06}"), nan) == STR("   nan"));
+    assert(format(STR("{:06}"), inf) == STR("   inf"));
+
+    // Type
+    assert(format(STR("{:a}"), value) == STR("1.34a1cp+10"));
+    assert(format(STR("{:A}"), value) == STR("1.34A1CP+10"));
+
+    assert(format(STR("{:e}"), value) == STR("1.234527e+03"));
+    assert(format(STR("{:E}"), value) == STR("1.234527E+03"));
+
+    assert(format(STR("{:f}"), value) == STR("1234.527344"));
+    assert(format(STR("{:F}"), value) == STR("1234.527344"));
+
+    assert(format(STR("{:g}"), value) == STR("1234.53"));
+    assert(format(STR("{:G}"), value) == STR("1234.53"));
+}
+
+template <class charT>
+void test_pointer_specs() {
+    assert(format(STR("{:}"), nullptr) == STR("0x0"));
+
+    // Sign
+    throw_helper(STR("{: }"), nullptr);
+    throw_helper(STR("{:+}"), nullptr);
+    throw_helper(STR("{:-}"), nullptr);
+
+    // Alternate form
+    throw_helper(STR("{:#}"), nullptr);
+
+    // Leading zero
+    throw_helper(STR("{:0}"), nullptr);
+
+    // Width
+    assert(format(STR("{:5}"), nullptr) == STR("0x0  "));
+
+    // Precision
+    throw_helper(STR("{:.5}"), nullptr);
+
+    // Types
+    assert(format(STR("{:p}"), nullptr) == STR("0x0"));
+    throw_helper(STR("{:a}"), nullptr);
+}
+
+template <class charT>
+void test_string_specs() {
+    auto cstr = STR("foo");
+    auto view = basic_string_view{cstr};
+
+    assert(format(STR("{:}"), cstr) == cstr);
+    assert(format(STR("{:}"), view) == cstr);
+
+    // Sign
+    throw_helper(STR("{: }"), cstr);
+    throw_helper(STR("{:+}"), cstr);
+    throw_helper(STR("{:-}"), cstr);
+
+    throw_helper(STR("{: }"), view);
+    throw_helper(STR("{:+}"), view);
+    throw_helper(STR("{:-}"), view);
+
+    // Alternate form
+    throw_helper(STR("{:#}"), cstr);
+    throw_helper(STR("{:#}"), view);
+
+    // Leading zero
+    throw_helper(STR("{:0}"), cstr);
+    throw_helper(STR("{:0}"), view);
+
+    // Width
+    assert(format(STR("{:5}"), cstr) == STR("foo  "));
+    assert(format(STR("{:5}"), view) == STR("foo  "));
+
+    // Precision
+    assert(format(STR("{:.2}"), cstr) == STR("fo"));
+    assert(format(STR("{:5.2}"), cstr) == STR("fo   "));
+    assert(format(STR("{:5.2}"), cstr) == STR("fo   "));
+    assert(format(STR("{:>5.2}"), cstr) == STR("   fo"));
+
+    assert(format(STR("{:.2}"), view) == STR("fo"));
+    assert(format(STR("{:5.2}"), view) == STR("fo   "));
+    assert(format(STR("{:5.2}"), view) == STR("fo   "));
+    assert(format(STR("{:>5.2}"), view) == STR("   fo"));
+
+    // Types
+    assert(format(STR("{:s}"), cstr) == cstr);
+    throw_helper(STR("{:a}"), cstr);
+
+    assert(format(STR("{:s}"), view) == cstr);
+    throw_helper(STR("{:a}"), view);
+}
+
+template <class charT>
+void test_spec_replacement_field() {
+    test_intergal_specs<charT, int>();
+    test_intergal_specs<charT, unsigned int>();
+    test_intergal_specs<charT, long long>();
+    test_intergal_specs<charT, unsigned long long>();
+    test_bool_specs<charT>();
+    test_char_specs<charT>();
+    test_float_specs<charT, float>();
+    test_float_specs<charT, double>();
+    test_float_specs<charT, long double>();
+    test_pointer_specs<charT>();
+    test_string_specs<charT>();
+}
+
+int main() {
     test_simple_formatting<char>();
     test_simple_formatting<wchar_t>();
 
@@ -353,6 +752,12 @@ int main() {
 
     test_multiple_replacement_fields<char>();
     test_multiple_replacement_fields<wchar_t>();
+
+    test_fill_and_align<char>();
+    test_fill_and_align<wchar_t>();
+
+    test_spec_replacement_field<char>();
+    test_spec_replacement_field<wchar_t>();
 
     return 0;
 }


### PR DESCRIPTION
Adds specful writers for all types. Supports all specifiers except
locale, and does not currently support non-ascii fill characters. I'm
sure there's more tests to add, but getting the bulk of it reviewed now
seems like a better approach and deficient areas can be identified.

I am unsure about the naming of some helper functions, I feel like
`_In_bounds` is the worst offender, with `_Fmt_buffer_to_uppercase`
a close second.

<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
