### PR TITLE
<format>: Add localized arg parsing support

### DIFF
--- a/stl/inc/format
+++ b/stl/inc/format
@@ -80,6 +80,7 @@ concept _Parse_spec_callbacks = requires(_Ty _At, basic_string_view<_CharT> _Sv,
     { _At._On_sign(_Sgn) } -> same_as<void>;
     { _At._On_hash() } -> same_as<void>;
     { _At._On_zero() } -> same_as<void>;
+    { _At._On_localized() } -> same_as<void>;
     { _At._On_type(_CharT{}) } -> same_as<void>;
 };
 template <class _Ty, class _CharT>
@@ -541,10 +542,20 @@ constexpr const _CharT* _Parse_format_specs(const _CharT* _Begin, const _CharT* 
 
     if (*_Begin == '.') {
         _Begin = _Parse_precision(_Begin, _End, _Callbacks);
+        if (++_Begin == _End) {
+            return _Begin;
+        }
+    }
+
+    if (*_Begin == 'L') {
+        _Callbacks._On_localized();
+        if (++_Begin == _End) {
+            return _Begin;
+        }
     }
 
     // If there's anything remaining we assume it's a type.
-    if (_Begin != _End && *_Begin != '}') {
+    if (*_Begin != '}') {
         _Callbacks._On_type(*_Begin++);
     }
     return _Begin;
@@ -676,6 +687,10 @@ public:
 
     constexpr void _On_precision(int _Precision) {
         _Specs._Precision = _Precision;
+    }
+
+    constexpr void _On_localized() {
+        _Specs._Localized = true;
     }
 
     constexpr void _On_type(_CharT _Type) {

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -542,7 +542,7 @@ constexpr const _CharT* _Parse_format_specs(const _CharT* _Begin, const _CharT* 
 
     if (*_Begin == '.') {
         _Begin = _Parse_precision(_Begin, _End, _Callbacks);
-        if (++_Begin == _End) {
+        if (_Begin == _End) {
             return _Begin;
         }
     }

--- a/tests/std/tests/P0645R10_text_formatting_parsing/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_parsing/test.cpp
@@ -43,6 +43,7 @@ struct noop_testing_callbacks {
     constexpr void _On_sign(_Sign) {}
     constexpr void _On_hash() {}
     constexpr void _On_zero() {}
+    constexpr void _On_localized() {}
     constexpr void _On_type(CharT) {}
 };
 
@@ -59,6 +60,7 @@ struct testing_callbacks {
     bool expected_auto_dynamic_precision = false;
     bool expected_hash                   = false;
     bool expected_zero                   = false;
+    bool expected_localized              = false;
     CharT expected_type                  = '\0';
     constexpr void _On_align(_Align aln) {
         assert(aln == expected_alignment);
@@ -92,6 +94,9 @@ struct testing_callbacks {
     }
     constexpr void _On_zero() {
         assert(expected_zero);
+    }
+    constexpr void _On_localized() {
+        assert(expected_localized);
     }
     constexpr void _On_type(CharT type) {
         assert(type == expected_type);
@@ -244,7 +249,7 @@ constexpr bool test_parse_format_specs() {
     view_typ s3(TYPED_LITERAL(CharT, "*^6}"));
     view_typ s4(TYPED_LITERAL(CharT, "6d}"));
     view_typ s5(TYPED_LITERAL(CharT, "*^+4.4a}"));
-    view_typ s6(TYPED_LITERAL(CharT, "*^+#04.4a}"));
+    view_typ s6(TYPED_LITERAL(CharT, "*^+#04.4La}"));
     test_parse_helper(parse_format_specs_fn, s0, false, s0.size() - 1, {.expected_width = 6});
     test_parse_helper(parse_format_specs_fn, s1, false, s1.size(),
         {.expected_alignment = _Align::_Left,
@@ -274,6 +279,7 @@ constexpr bool test_parse_format_specs() {
             .expected_precision = 4,
             .expected_hash      = true,
             .expected_zero      = true,
+            .expected_localized = true,
             .expected_type      = 'a'});
     return true;
 }


### PR DESCRIPTION
Just teaches the arg parser to set the localized spec.

<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
