### PR TITLE
Avoid concepts when __cpp_lib_concepts isn't defined

### DIFF
--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -58,20 +58,18 @@ namespace chrono {
     };
 
 #if _HAS_CXX20
-    template <class _Clock>
-    concept _Is_clock = requires {
-        typename _Clock::rep;
-        typename _Clock::period;
-        typename _Clock::duration;
-        typename _Clock::time_point;
-        _Clock::is_steady;
-        _Clock::now();
-    };
+    template <class _Clock, class = void>
+    struct _Is_clock : false_type {};
 
     template <class _Clock>
-    struct is_clock : bool_constant<_Is_clock<_Clock>> {};
+    struct _Is_clock<_Clock, void_t<typename _Clock::rep, typename _Clock::period, typename _Clock::duration,
+                                 typename _Clock::time_point, decltype(_Clock::is_steady), decltype(_Clock::now())>>
+        : true_type {}; // TRANSITION, GH-602
+
     template <class _Clock>
-    inline constexpr bool is_clock_v = _Is_clock<_Clock>;
+    struct is_clock : _Is_clock<_Clock>::type {};
+    template <class _Clock>
+    inline constexpr bool is_clock_v = _Is_clock<_Clock>::value;
 #endif // _HAS_CXX20
 
     // CLASS TEMPLATE duration

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -59,17 +59,18 @@ namespace chrono {
 
 #if _HAS_CXX20
     template <class _Clock, class = void>
-    struct _Is_clock : false_type {};
+    inline constexpr bool _Is_clock_v = false;
 
     template <class _Clock>
-    struct _Is_clock<_Clock, void_t<typename _Clock::rep, typename _Clock::period, typename _Clock::duration,
-                                 typename _Clock::time_point, decltype(_Clock::is_steady), decltype(_Clock::now())>>
-        : true_type {}; // TRANSITION, GH-602
+    inline constexpr bool
+        _Is_clock_v<_Clock, void_t<typename _Clock::rep, typename _Clock::period, typename _Clock::duration,
+                                typename _Clock::time_point, decltype(_Clock::is_steady), decltype(_Clock::now())>> =
+            true; // TRANSITION, GH-602
 
     template <class _Clock>
-    struct is_clock : _Is_clock<_Clock>::type {};
+    struct is_clock : bool_constant<_Is_clock_v<_Clock>> {};
     template <class _Clock>
-    inline constexpr bool is_clock_v = _Is_clock<_Clock>::value;
+    inline constexpr bool is_clock_v = _Is_clock_v<_Clock>;
 #endif // _HAS_CXX20
 
     // CLASS TEMPLATE duration

--- a/stl/inc/sstream
+++ b/stl/inc/sstream
@@ -168,7 +168,7 @@ public:
     }
 
 #if _HAS_CXX20
-    template <_Allocator _Alloc2>
+    template <class _Alloc2, enable_if_t<_Is_allocator<_Alloc2>::value, int> = 0>
     _NODISCARD basic_string<_Elem, _Traits, _Alloc2> str(const _Alloc2& _Al) const {
         return basic_string<_Elem, _Traits, _Alloc2>{view(), _Al};
     }
@@ -632,7 +632,7 @@ public:
     }
 
 #if _HAS_CXX20
-    template <_Allocator _Alloc2>
+    template <class _Alloc2, enable_if_t<_Is_allocator<_Alloc2>::value, int> = 0>
     _NODISCARD basic_string<_Elem, _Traits, _Alloc2> str(const _Alloc2& _Al) const {
         return _Stringbuffer.str(_Al);
     }
@@ -752,7 +752,7 @@ public:
     }
 
 #if _HAS_CXX20
-    template <_Allocator _Alloc2>
+    template <class _Alloc2, enable_if_t<_Is_allocator<_Alloc2>::value, int> = 0>
     _NODISCARD basic_string<_Elem, _Traits, _Alloc2> str(const _Alloc2& _Al) const {
         return _Stringbuffer.str(_Al);
     }
@@ -878,7 +878,7 @@ public:
     }
 
 #if _HAS_CXX20
-    template <_Allocator _Alloc2>
+    template <class _Alloc2, enable_if_t<_Is_allocator<_Alloc2>::value, int> = 0>
     _NODISCARD basic_string<_Elem, _Traits, _Alloc2> str(const _Alloc2& _Al) const {
         return _Stringbuffer.str(_Al);
     }

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -1459,11 +1459,6 @@ using _Enable_if_execution_policy_t = typename remove_reference_t<_ExPo>::_Stand
 
 #endif // _HAS_CXX17
 
-#if _HAS_CXX20
-template <class _Ty>
-concept _Allocator = _Is_allocator<_Ty>::value;
-#endif // _HAS_CXX20
-
 // FUNCTION TEMPLATE _Idl_distance
 template <class _Checked, class _Iter>
 _NODISCARD constexpr auto _Idl_distance(const _Iter& _First, const _Iter& _Last) {


### PR DESCRIPTION
Fixes DevCom-1367531 / VSO-1292416 "Intel C++ Compiler, ICL, has compilation failure because use of concepts in header file not guarded with `ifdef __cpp_lib_concepts`".

Earlier related discussion: https://github.com/microsoft/STL/pull/919#discussion_r556236846

Our current policies are:

* We test and support MSVC, Clang, EDG for IntelliSense, and CUDA 10.1 Update 2. While we neither test nor support the Intel C++ Compiler, we try to avoid breaking it gratuitously, and we'll fix such breaks as long as doing so doesn't introduce significant codebase complexity.
* Because the EDG front-end has several active compiler bugs affecting C++20 concepts (see #1621), we currently:
  + Have a de facto "C++20 without concepts" mode when `_HAS_CXX20 && !defined(__cpp_lib_concepts)`. Some machinery is unavailable in this mode (e.g. `<ranges>`, some spaceship operators).
  + In C++20-only code, we avoid using concepts "unnecessarily" - i.e. we'll use SFINAE to implement constraints, even when concepts might be a bit more convenient, due to the EDG limitation specifically and residual concern about compiler bugs generally. (Doesn't apply in code that definitely needs concepts, like `<ranges>`.)

Although EDG IntelliSense didn't have trouble with the `concept _Allocator` introduced by #919, the fact that it's causing a headache for the Intel C++ Compiler, it's easily avoided by using SFINAE, and using SFINAE is more consistent with our conventions, leads me to believe that we should make this change.

I checked (by preprocessing `__msvc_all_public_headers.hpp` with `/BE`) and the only other occurrence of a `concept` in `_HAS_CXX20 && !defined(__cpp_lib_concepts)` mode was the `is_clock` implementation added by #323. To be consistent, I'm converting that one to SFINAE too (and marking it as `// TRANSITION, GH-602` as a reminder to switch back). Fortunately, `void_t` makes it easy to query for the validity of multiple things simultaneously. As this is targeted, it shouldn't interfere with `feature/chrono` merging.

Note that this "C++20 without concepts" mode is **not** permanent (maintaining it adds additional complexity to the codebase). After the EDG IntelliSense bugs are fixed, we'll begin using concepts unconditionally in C++20 mode (see #395), and converting SFINAE to concepts in C++20-only code when that makes sense (see #602).