### PR TITLE
Add escape hatch for _USE_STD_VECTOR_ALGORITHMS

### DIFF
--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -21,13 +21,18 @@ _STL_DISABLE_CLANG_WARNINGS
 #pragma push_macro("new")
 #undef new
 
+#if (defined(_M_IX86) || defined(_M_X64)) && !defined(_M_CEE_PURE) \
+    && !defined(_M_HYBRID) && !defined(_M_ARM64EC)
 #ifndef _USE_STD_VECTOR_ALGORITHMS
-#if (defined(_M_IX86) || defined(_M_X64)) && !defined(_M_CEE_PURE) && !defined(_M_HYBRID) && !defined(_M_ARM64EC)
 #define _USE_STD_VECTOR_ALGORITHMS 1
-#else
-#define _USE_STD_VECTOR_ALGORITHMS 0
 #endif
+#else // ^^^ arch supports vector algorithms / no support for vector algorithms vvv
+#ifndef _USE_STD_VECTOR_ALGORITHMS
+#define _USE_STD_VECTOR_ALGORITHMS 0
+#elif _USE_STD_VECTOR_ALGORITHMS
+#error Vector algorithms are not supported on this architecture, but _USE_STD_VECTOR_ALGORITHMS is set.
 #endif // _USE_STD_VECTOR_ALGORITHMS
+#endif // ^^^ no support for vector algorithms ^^^
 
 #ifdef __CUDACC__
 #define _CONSTEXPR_BIT_CAST inline

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -24,7 +24,7 @@ _STL_DISABLE_CLANG_WARNINGS
 #if (defined(_M_IX86) || defined(_M_X64)) && !defined(_M_CEE_PURE) && !defined(_M_HYBRID) && !defined(_M_ARM64EC)
 #ifndef _USE_STD_VECTOR_ALGORITHMS
 #define _USE_STD_VECTOR_ALGORITHMS 1
-#endif
+#endif // _USE_STD_VECTOR_ALGORITHMS
 #else // ^^^ arch supports vector algorithms / no support for vector algorithms vvv
 #ifndef _USE_STD_VECTOR_ALGORITHMS
 #define _USE_STD_VECTOR_ALGORITHMS 0

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -21,10 +21,12 @@ _STL_DISABLE_CLANG_WARNINGS
 #pragma push_macro("new")
 #undef new
 
+#ifndef _USE_STD_VECTOR_ALGORITHMS
 #if (defined(_M_IX86) || defined(_M_X64)) && !defined(_M_CEE_PURE) && !defined(_M_HYBRID) && !defined(_M_ARM64EC)
 #define _USE_STD_VECTOR_ALGORITHMS 1
 #else
 #define _USE_STD_VECTOR_ALGORITHMS 0
+#endif
 #endif
 
 #ifdef __CUDACC__

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -21,8 +21,7 @@ _STL_DISABLE_CLANG_WARNINGS
 #pragma push_macro("new")
 #undef new
 
-#if (defined(_M_IX86) || defined(_M_X64)) && !defined(_M_CEE_PURE) \
-    && !defined(_M_HYBRID) && !defined(_M_ARM64EC)
+#if (defined(_M_IX86) || defined(_M_X64)) && !defined(_M_CEE_PURE) && !defined(_M_HYBRID) && !defined(_M_ARM64EC)
 #ifndef _USE_STD_VECTOR_ALGORITHMS
 #define _USE_STD_VECTOR_ALGORITHMS 1
 #endif

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -27,7 +27,7 @@ _STL_DISABLE_CLANG_WARNINGS
 #else
 #define _USE_STD_VECTOR_ALGORITHMS 0
 #endif
-#endif
+#endif // _USE_STD_VECTOR_ALGORITHMS
 
 #ifdef __CUDACC__
 #define _CONSTEXPR_BIT_CAST inline

--- a/tests/std/tests/VSO_0000000_vector_algorithms/env.lst
+++ b/tests/std/tests/VSO_0000000_vector_algorithms/env.lst
@@ -2,3 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 RUNALL_INCLUDE ..\usual_matrix.lst
+RUNALL_CROSSLIST
+PM_CL="" # Test default setting
+PM_CL="/D_USE_STD_VECTOR_ALGORITHMS=0" # Test escape hatch, see GH-1751


### PR DESCRIPTION
There are projects in Windows that are using the STL in a header-only capacity, but using vector algorithms requires that the .lib be linked in. This change allows `_USE_STD_VECTOR_ALGORITHMS` to be manually set by the project in order to opt-out of requiring this .lib dependency. These projects used to specify `/D_HAS_IF_CONSTEXPR=0` to avoid this dependency, but that has been removed and using `/D_USE_STD_VECTOR_ALGORITHMS=0` is more targeted towards their actual desire anyway.