### PR TITLE
Static partition forward ranges correctly

### DIFF
--- a/stl/inc/execution
+++ b/stl/inc/execution
@@ -927,7 +927,7 @@ struct _Static_partition_range<_FwdIt, _Diff, false> {
         auto _Result                = _Division_points.begin();
         *_Result                    = _Get_unwrapped(_First);
         for (_Diff _Idx{}; _Idx < _Unchunked_items; ++_Idx) { // record bounds of chunks with an extra item
-            for (_Diff _This_chunk_size = _Chunk_size; 0 < _This_chunk_size--;) {
+            for (_Diff _This_chunk_size = _Chunk_size + 1; 0 < _This_chunk_size--;) {
                 if (_First == _Last) {
                     return false;
                 }

--- a/tests/std/include/parallel_algorithms_utilities.hpp
+++ b/tests/std/include/parallel_algorithms_utilities.hpp
@@ -7,9 +7,10 @@
 #include <thread>
 
 #ifdef EXHAUSTIVE
-const size_t max_parallel_test_case_n = 1000;
+const size_t max_parallel_test_case_n = 4096;
 #else // ^^^ EXHAUSTIVE ^^^ // vvv !EXHAUSTIVE vvv
-const size_t max_parallel_test_case_n = std::max(4u, std::thread::hardware_concurrency()) + 1;
+// The constant 32 comes from std::_Oversubscription_multiplier
+const size_t max_parallel_test_case_n = std::max(4u, std::thread::hardware_concurrency() * 32) + 1;
 #endif // EXHAUSTIVE
 
 #pragma warning(push)

--- a/tests/std/include/parallel_algorithms_utilities.hpp
+++ b/tests/std/include/parallel_algorithms_utilities.hpp
@@ -8,9 +8,12 @@
 
 #ifdef EXHAUSTIVE
 const size_t max_parallel_test_case_n = 4096;
+// // the number of linear steps a test case that is quadradic should attempt:
+const size_t quadradic_complexity_case_limit = SIZE_MAX;
 #else // ^^^ EXHAUSTIVE ^^^ // vvv !EXHAUSTIVE vvv
 // The constant 32 comes from std::_Oversubscription_multiplier
-const size_t max_parallel_test_case_n = std::max(4u, std::thread::hardware_concurrency() * 32) + 1;
+const size_t max_parallel_test_case_n        = std::max(4u, std::thread::hardware_concurrency() * 32) + 1;
+const size_t quadradic_complexity_case_limit = 128;
 #endif // EXHAUSTIVE
 
 #pragma warning(push)

--- a/tests/std/include/parallel_algorithms_utilities.hpp
+++ b/tests/std/include/parallel_algorithms_utilities.hpp
@@ -8,12 +8,12 @@
 
 #ifdef EXHAUSTIVE
 const size_t max_parallel_test_case_n = 4096;
-// // the number of linear steps a test case that is quadradic should attempt:
-const size_t quadradic_complexity_case_limit = SIZE_MAX;
+// the number of linear steps a test case that is quadratic should attempt:
+const size_t quadratic_complexity_case_limit = SIZE_MAX;
 #else // ^^^ EXHAUSTIVE ^^^ // vvv !EXHAUSTIVE vvv
 // The constant 32 comes from std::_Oversubscription_multiplier
 const size_t max_parallel_test_case_n        = std::max(4u, std::thread::hardware_concurrency() * 32) + 1;
-const size_t quadradic_complexity_case_limit = 128;
+const size_t quadratic_complexity_case_limit = 128;
 #endif // EXHAUSTIVE
 
 #pragma warning(push)

--- a/tests/std/tests/P0024R2_parallel_algorithms_adjacent_find/test.cpp
+++ b/tests/std/tests/P0024R2_parallel_algorithms_adjacent_find/test.cpp
@@ -36,14 +36,13 @@ void test_case_adjacent_find_parallel(const size_t testSize) {
     auto remaining_attempts = quadratic_complexity_case_limit;
     auto target             = tmp.begin();
     for (auto next = target; ++next != tmp.end(); target = next) {
-        if (--remaining_attempts == 0) {
-            return;
-        }
-
         auto old = *target;
         *target  = *next;
         assert(adjacent_find(par, tmp.begin(), tmp.end()) == target);
         *target = old;
+        if (--remaining_attempts == 0) {
+            return;
+        }
     }
 }
 

--- a/tests/std/tests/P0024R2_parallel_algorithms_adjacent_find/test.cpp
+++ b/tests/std/tests/P0024R2_parallel_algorithms_adjacent_find/test.cpp
@@ -33,8 +33,13 @@ void test_case_adjacent_find_parallel(const size_t testSize) {
     assert(less_result == tmp.begin());
     assert(ne_result == tmp.begin());
 
-    auto target = tmp.begin();
+    auto remaining_attempts = quadradic_complexity_case_limit;
+    auto target             = tmp.begin();
     for (auto next = target; ++next != tmp.end(); target = next) {
+        if (--remaining_attempts == 0) {
+            return;
+        }
+
         auto old = *target;
         *target  = *next;
         assert(adjacent_find(par, tmp.begin(), tmp.end()) == target);

--- a/tests/std/tests/P0024R2_parallel_algorithms_adjacent_find/test.cpp
+++ b/tests/std/tests/P0024R2_parallel_algorithms_adjacent_find/test.cpp
@@ -33,7 +33,7 @@ void test_case_adjacent_find_parallel(const size_t testSize) {
     assert(less_result == tmp.begin());
     assert(ne_result == tmp.begin());
 
-    auto remaining_attempts = quadradic_complexity_case_limit;
+    auto remaining_attempts = quadratic_complexity_case_limit;
     auto target             = tmp.begin();
     for (auto next = target; ++next != tmp.end(); target = next) {
         if (--remaining_attempts == 0) {

--- a/tests/std/tests/P0024R2_parallel_algorithms_count/test.cpp
+++ b/tests/std/tests/P0024R2_parallel_algorithms_count/test.cpp
@@ -30,7 +30,7 @@ void test_case_count_parallel(const size_t testSize, mt19937& gen) {
     iota(iterators.begin(), iterators.end(), c.begin());
     shuffle(iterators.begin(), iterators.end(), gen);
 
-    auto remainingAttempts = quadradic_complexity_case_limit;
+    auto remainingAttempts = quadratic_complexity_case_limit;
     ptrdiff_t consumed{};
     for (const auto& iter : iterators) {
         if (--remainingAttempts == 0) {

--- a/tests/std/tests/P0024R2_parallel_algorithms_count/test.cpp
+++ b/tests/std/tests/P0024R2_parallel_algorithms_count/test.cpp
@@ -30,8 +30,13 @@ void test_case_count_parallel(const size_t testSize, mt19937& gen) {
     iota(iterators.begin(), iterators.end(), c.begin());
     shuffle(iterators.begin(), iterators.end(), gen);
 
+    auto remainingAttempts = quadradic_complexity_case_limit;
     ptrdiff_t consumed{};
     for (const auto& iter : iterators) {
+        if (--remainingAttempts == 0) {
+            return;
+        }
+
         *iter = '\x00';
         ++consumed;
         assert(count(par, c.begin(), c.end(), '\x00') == consumed);

--- a/tests/std/tests/P0024R2_parallel_algorithms_count/test.cpp
+++ b/tests/std/tests/P0024R2_parallel_algorithms_count/test.cpp
@@ -33,16 +33,15 @@ void test_case_count_parallel(const size_t testSize, mt19937& gen) {
     auto remainingAttempts = quadratic_complexity_case_limit;
     ptrdiff_t consumed{};
     for (const auto& iter : iterators) {
-        if (--remainingAttempts == 0) {
-            return;
-        }
-
         *iter = '\x00';
         ++consumed;
         assert(count(par, c.begin(), c.end(), '\x00') == consumed);
         assert(count(par, c.begin(), c.end(), '\x01') == static_cast<ptrdiff_t>(testSize) - consumed);
         assert(count_if(par, c.begin(), c.end(), is_zero) == consumed);
         assert(count_if(par, c.begin(), c.end(), is_one) == static_cast<ptrdiff_t>(testSize) - consumed);
+        if (--remainingAttempts == 0) {
+            return;
+        }
     }
 }
 

--- a/tests/std/tests/P0024R2_parallel_algorithms_find_first_of/test.cpp
+++ b/tests/std/tests/P0024R2_parallel_algorithms_find_first_of/test.cpp
@@ -26,7 +26,7 @@ void test_case_find_first_of_parallel(const size_t testSize) {
     iota(candidates.begin(), candidates.end(), 0);
     auto expected        = tmp.begin();
     auto candidatesBegin = candidates.begin();
-    const auto limit     = std::min(testSize, quadradic_complexity_case_limit);
+    const auto limit     = std::min(testSize, quadratic_complexity_case_limit);
     for (size_t idx = 0; idx < limit; ++idx) {
         assert(expected == find_first_of(par, tmp.begin(), tmp.end(), candidatesBegin, candidates.end()));
         ++candidatesBegin;

--- a/tests/std/tests/P0024R2_parallel_algorithms_find_first_of/test.cpp
+++ b/tests/std/tests/P0024R2_parallel_algorithms_find_first_of/test.cpp
@@ -26,7 +26,8 @@ void test_case_find_first_of_parallel(const size_t testSize) {
     iota(candidates.begin(), candidates.end(), 0);
     auto expected        = tmp.begin();
     auto candidatesBegin = candidates.begin();
-    for (size_t idx = 0; idx < testSize; ++idx) {
+    const auto limit     = std::min(testSize, quadradic_complexity_case_limit);
+    for (size_t idx = 0; idx < limit; ++idx) {
         assert(expected == find_first_of(par, tmp.begin(), tmp.end(), candidatesBegin, candidates.end()));
         ++candidatesBegin;
         ++expected;

--- a/tests/std/tests/P0024R2_parallel_algorithms_is_heap/test.cpp
+++ b/tests/std/tests/P0024R2_parallel_algorithms_is_heap/test.cpp
@@ -35,7 +35,8 @@ void test_case_is_heap_parallel(const size_t testSize) {
     v[0] = 0;
 
     // (0, testSize - 1]
-    for (auto i = 1U; i < testSize; ++i) {
+    const auto limit = std::min(testSize, quadradic_complexity_case_limit);
+    for (auto i = 1U; i < limit; ++i) {
         v[i] = 1;
         assert(!is_heap(par, v.begin(), v.end()));
         assert(is_heap_until(par, v.begin(), v.end()) == v.begin() + static_cast<int>(i));
@@ -79,7 +80,7 @@ void test_case_is_heap_parallel(const size_t testSize) {
     assert(is_heap_until(par, v.begin(), v.end(), greater()) == secondElement);
     v[1] = 2;
 
-    for (auto i = 2U; i < testSize; ++i) {
+    for (auto i = 2U; i < limit; ++i) {
         const auto old = v[i];
         v[i]           = 0;
         assert(!is_heap(par, v.begin(), v.end()));
@@ -105,7 +106,7 @@ void test_case_is_heap_parallel(const size_t testSize) {
     assert(is_heap_until(par, v.begin(), v.end(), greater()) == v.begin() + 3);
     v[0] = testSize;
 
-    for (auto i = 1U; i < testSize; ++i) {
+    for (auto i = 1U; i < limit; ++i) {
         const auto old = v[i];
         v[i]           = 0;
         if (i < testSize / 2) {

--- a/tests/std/tests/P0024R2_parallel_algorithms_is_heap/test.cpp
+++ b/tests/std/tests/P0024R2_parallel_algorithms_is_heap/test.cpp
@@ -35,7 +35,7 @@ void test_case_is_heap_parallel(const size_t testSize) {
     v[0] = 0;
 
     // (0, testSize - 1]
-    const auto limit = std::min(testSize, quadradic_complexity_case_limit);
+    const auto limit = std::min(testSize, quadratic_complexity_case_limit);
     for (auto i = 1U; i < limit; ++i) {
         v[i] = 1;
         assert(!is_heap(par, v.begin(), v.end()));

--- a/tests/std/tests/P0024R2_parallel_algorithms_is_partitioned/test.cpp
+++ b/tests/std/tests/P0024R2_parallel_algorithms_is_partitioned/test.cpp
@@ -7,6 +7,7 @@
 #include <forward_list>
 #include <iterator>
 #include <list>
+#include <stddef.h>
 #include <vector>
 
 #include <parallel_algorithms_utilities.hpp>
@@ -27,8 +28,14 @@ void test_case_is_partitioned_parallel(const size_t testSize) {
     }
 
     // T ... T F T ... T with F positioned at each index
-    auto first = c.begin();
+    auto remainingAttempts = quadradic_complexity_case_limit;
+    auto first             = c.begin();
     for (size_t i = 0; i < testSize - 1; ++i, ++first) {
+        if (--remainingAttempts == 0) {
+            std::advance(first, static_cast<ptrdiff_t>(testSize - 1 - i));
+            break;
+        }
+
         *first = false;
         assert(!is_partitioned(par, c.begin(), c.end(), read_char_as_bool));
         *first = true;
@@ -39,8 +46,14 @@ void test_case_is_partitioned_parallel(const size_t testSize) {
     *first = true;
 
     // front to back change T to F, end up with all F
-    first = c.begin();
+    remainingAttempts = quadradic_complexity_case_limit;
+    first             = c.begin();
     for (size_t i = 0; i < testSize - 1; ++i, ++first) {
+        if (--remainingAttempts == 0) {
+            first = std::fill_n(first, static_cast<ptrdiff_t>(testSize - 1 - i), '\0');
+            break;
+        }
+
         *first = false;
         assert(!is_partitioned(par, c.begin(), c.end(), read_char_as_bool));
     }
@@ -61,25 +74,41 @@ void test_case_is_partitioned_parallel(const size_t testSize) {
     *first = false;
     ++first;
 
+    remainingAttempts = quadradic_complexity_case_limit;
     for (size_t i = 1; i < testSize; ++i, ++first) {
+        if (--remainingAttempts == 0) {
+            break;
+        }
+
         *first = true;
         assert(!is_partitioned(par, c.begin(), c.end(), read_char_as_bool));
         *first = false;
     }
 
     // front to back change F to T, end up with all T
-    first  = c.begin();
-    *first = true;
+    remainingAttempts = quadradic_complexity_case_limit;
+    first             = c.begin();
+    *first            = true;
     while (++first != c.end()) {
+        if (--remainingAttempts == 0) {
+            std::fill(first, c.end(), '\x01');
+            break;
+        }
+
         *first = true;
         assert(is_partitioned(par, c.begin(), c.end(), read_char_as_bool));
     }
 
     // testing with 2 partition points (T F T ... T F T ... T), where the F at index 1 is fixed and the second F is
     // tried at each index
-    first  = next(c.begin());
-    *first = false;
+    remainingAttempts = quadradic_complexity_case_limit;
+    first             = next(c.begin());
+    *first            = false;
     while (++first != c.end()) {
+        if (--remainingAttempts == 0) {
+            break;
+        }
+
         *first = false;
         assert(!is_partitioned(par, c.begin(), c.end(), read_char_as_bool));
         *first = true;
@@ -89,9 +118,14 @@ void test_case_is_partitioned_parallel(const size_t testSize) {
 
     // testing with 2 partition adjacent points (T...T F T F...F) where the adjacent partition points are tried at each
     // index
-    first       = c.begin();
-    auto second = next(first, 2);
+    remainingAttempts = quadradic_complexity_case_limit;
+    first             = c.begin();
+    auto second       = next(first, 2);
     for (; second != c.end(); ++first, ++second) {
+        if (--remainingAttempts == 0) {
+            return;
+        }
+
         *first  = true;
         *second = true;
         assert(!is_partitioned(par, c.begin(), c.end(), read_char_as_bool));

--- a/tests/std/tests/P0024R2_parallel_algorithms_is_partitioned/test.cpp
+++ b/tests/std/tests/P0024R2_parallel_algorithms_is_partitioned/test.cpp
@@ -31,14 +31,13 @@ void test_case_is_partitioned_parallel(const size_t testSize) {
     auto remainingAttempts = quadratic_complexity_case_limit;
     auto first             = c.begin();
     for (size_t i = 0; i < testSize - 1; ++i, ++first) {
+        *first = false;
+        assert(!is_partitioned(par, c.begin(), c.end(), read_char_as_bool));
+        *first = true;
         if (--remainingAttempts == 0) {
             std::advance(first, static_cast<ptrdiff_t>(testSize - 1 - i));
             break;
         }
-
-        *first = false;
-        assert(!is_partitioned(par, c.begin(), c.end(), read_char_as_bool));
-        *first = true;
     }
 
     *first = false;
@@ -49,13 +48,12 @@ void test_case_is_partitioned_parallel(const size_t testSize) {
     remainingAttempts = quadratic_complexity_case_limit;
     first             = c.begin();
     for (size_t i = 0; i < testSize - 1; ++i, ++first) {
+        *first = false;
+        assert(!is_partitioned(par, c.begin(), c.end(), read_char_as_bool));
         if (--remainingAttempts == 0) {
             first = std::fill_n(first, static_cast<ptrdiff_t>(testSize - 1 - i), '\0');
             break;
         }
-
-        *first = false;
-        assert(!is_partitioned(par, c.begin(), c.end(), read_char_as_bool));
     }
     *first = false;
 
@@ -76,13 +74,12 @@ void test_case_is_partitioned_parallel(const size_t testSize) {
 
     remainingAttempts = quadratic_complexity_case_limit;
     for (size_t i = 1; i < testSize; ++i, ++first) {
-        if (--remainingAttempts == 0) {
-            break;
-        }
-
         *first = true;
         assert(!is_partitioned(par, c.begin(), c.end(), read_char_as_bool));
         *first = false;
+        if (--remainingAttempts == 0) {
+            break;
+        }
     }
 
     // front to back change F to T, end up with all T
@@ -90,13 +87,12 @@ void test_case_is_partitioned_parallel(const size_t testSize) {
     first             = c.begin();
     *first            = true;
     while (++first != c.end()) {
+        *first = true;
+        assert(is_partitioned(par, c.begin(), c.end(), read_char_as_bool));
         if (--remainingAttempts == 0) {
             std::fill(first, c.end(), '\x01');
             break;
         }
-
-        *first = true;
-        assert(is_partitioned(par, c.begin(), c.end(), read_char_as_bool));
     }
 
     // testing with 2 partition points (T F T ... T F T ... T), where the F at index 1 is fixed and the second F is
@@ -105,13 +101,12 @@ void test_case_is_partitioned_parallel(const size_t testSize) {
     first             = next(c.begin());
     *first            = false;
     while (++first != c.end()) {
-        if (--remainingAttempts == 0) {
-            break;
-        }
-
         *first = false;
         assert(!is_partitioned(par, c.begin(), c.end(), read_char_as_bool));
         *first = true;
+        if (--remainingAttempts == 0) {
+            break;
+        }
     }
 
     fill(c.begin(), c.end(), false);
@@ -122,14 +117,13 @@ void test_case_is_partitioned_parallel(const size_t testSize) {
     first             = c.begin();
     auto second       = next(first, 2);
     for (; second != c.end(); ++first, ++second) {
-        if (--remainingAttempts == 0) {
-            break;
-        }
-
         *first  = true;
         *second = true;
         assert(!is_partitioned(par, c.begin(), c.end(), read_char_as_bool));
         *second = false;
+        if (--remainingAttempts == 0) {
+            break;
+        }
     }
 }
 

--- a/tests/std/tests/P0024R2_parallel_algorithms_is_partitioned/test.cpp
+++ b/tests/std/tests/P0024R2_parallel_algorithms_is_partitioned/test.cpp
@@ -123,7 +123,7 @@ void test_case_is_partitioned_parallel(const size_t testSize) {
     auto second       = next(first, 2);
     for (; second != c.end(); ++first, ++second) {
         if (--remainingAttempts == 0) {
-            return;
+            break;
         }
 
         *first  = true;

--- a/tests/std/tests/P0024R2_parallel_algorithms_is_partitioned/test.cpp
+++ b/tests/std/tests/P0024R2_parallel_algorithms_is_partitioned/test.cpp
@@ -28,7 +28,7 @@ void test_case_is_partitioned_parallel(const size_t testSize) {
     }
 
     // T ... T F T ... T with F positioned at each index
-    auto remainingAttempts = quadradic_complexity_case_limit;
+    auto remainingAttempts = quadratic_complexity_case_limit;
     auto first             = c.begin();
     for (size_t i = 0; i < testSize - 1; ++i, ++first) {
         if (--remainingAttempts == 0) {
@@ -46,7 +46,7 @@ void test_case_is_partitioned_parallel(const size_t testSize) {
     *first = true;
 
     // front to back change T to F, end up with all F
-    remainingAttempts = quadradic_complexity_case_limit;
+    remainingAttempts = quadratic_complexity_case_limit;
     first             = c.begin();
     for (size_t i = 0; i < testSize - 1; ++i, ++first) {
         if (--remainingAttempts == 0) {
@@ -74,7 +74,7 @@ void test_case_is_partitioned_parallel(const size_t testSize) {
     *first = false;
     ++first;
 
-    remainingAttempts = quadradic_complexity_case_limit;
+    remainingAttempts = quadratic_complexity_case_limit;
     for (size_t i = 1; i < testSize; ++i, ++first) {
         if (--remainingAttempts == 0) {
             break;
@@ -86,7 +86,7 @@ void test_case_is_partitioned_parallel(const size_t testSize) {
     }
 
     // front to back change F to T, end up with all T
-    remainingAttempts = quadradic_complexity_case_limit;
+    remainingAttempts = quadratic_complexity_case_limit;
     first             = c.begin();
     *first            = true;
     while (++first != c.end()) {
@@ -101,7 +101,7 @@ void test_case_is_partitioned_parallel(const size_t testSize) {
 
     // testing with 2 partition points (T F T ... T F T ... T), where the F at index 1 is fixed and the second F is
     // tried at each index
-    remainingAttempts = quadradic_complexity_case_limit;
+    remainingAttempts = quadratic_complexity_case_limit;
     first             = next(c.begin());
     *first            = false;
     while (++first != c.end()) {
@@ -118,7 +118,7 @@ void test_case_is_partitioned_parallel(const size_t testSize) {
 
     // testing with 2 partition adjacent points (T...T F T F...F) where the adjacent partition points are tried at each
     // index
-    remainingAttempts = quadradic_complexity_case_limit;
+    remainingAttempts = quadratic_complexity_case_limit;
     first             = c.begin();
     auto second       = next(first, 2);
     for (; second != c.end(); ++first, ++second) {

--- a/tests/std/tests/P0024R2_parallel_algorithms_is_sorted/test.cpp
+++ b/tests/std/tests/P0024R2_parallel_algorithms_is_sorted/test.cpp
@@ -46,19 +46,19 @@ void test_case_is_sorted_parallel(const size_t testSize) {
     // (first index, last index)
     auto remainingAttempts = quadratic_complexity_case_limit;
     ++next;
-    for (size_t i = 0; i < testSize - 2; ++i) {
-        if (--remainingAttempts == 0) {
-            std::advance(next, static_cast<ptrdiff_t>(testSize - 2 - i));
-            break;
+    {
+        size_t i = 0;
+        for (; i < testSize - 2 && remainingAttempts != 0; ++i, --remainingAttempts) {
+            *next = 1;
+            assert(!is_sorted(par, c.begin(), c.end()));
+            assert(!is_sorted(par, c.begin(), c.end(), greater()));
+            assert(is_sorted_until(par, c.begin(), c.end()) == std::next(next));
+            assert(is_sorted_until(par, c.begin(), c.end(), greater()) == next);
+            *next = 0;
+            ++next;
         }
 
-        *next = 1;
-        assert(!is_sorted(par, c.begin(), c.end()));
-        assert(!is_sorted(par, c.begin(), c.end(), greater()));
-        assert(is_sorted_until(par, c.begin(), c.end()) == std::next(next));
-        assert(is_sorted_until(par, c.begin(), c.end(), greater()) == next);
-        *next = 0;
-        ++next;
+        std::advance(next, static_cast<ptrdiff_t>(testSize - 2 - i));
     }
 
     // last index:
@@ -90,10 +90,6 @@ void test_case_is_sorted_parallel(const size_t testSize) {
     const auto secondElement = std::next(c.begin());
     const auto thirdElement  = std::next(secondElement);
     for (auto first = secondElement; first != last; ++first) {
-        if (--remainingAttempts == 0) {
-            break;
-        }
-
         const auto old = *first;
         *first         = 0;
         assert(!is_sorted(par, c.begin(), c.end()));
@@ -106,6 +102,9 @@ void test_case_is_sorted_parallel(const size_t testSize) {
         }
         *first = old;
         ++i;
+        if (--remainingAttempts == 0) {
+            break;
+        }
     }
 
     // increasing list except for first element

--- a/tests/std/tests/P0024R2_parallel_algorithms_is_sorted/test.cpp
+++ b/tests/std/tests/P0024R2_parallel_algorithms_is_sorted/test.cpp
@@ -44,7 +44,7 @@ void test_case_is_sorted_parallel(const size_t testSize) {
     *next = 0;
 
     // (first index, last index)
-    auto remainingAttempts = quadradic_complexity_case_limit;
+    auto remainingAttempts = quadratic_complexity_case_limit;
     ++next;
     for (size_t i = 0; i < testSize - 2; ++i) {
         if (--remainingAttempts == 0) {
@@ -85,7 +85,7 @@ void test_case_is_sorted_parallel(const size_t testSize) {
 
     // breaking the increasing list at each index [1, 2, ..., 0, ..., testSize-1, testSize]
     // Note that we skip the first case since [0, 2, ..., testSize-1, testSize] is still sorted
-    remainingAttempts        = quadradic_complexity_case_limit;
+    remainingAttempts        = quadratic_complexity_case_limit;
     int i                    = 1;
     const auto secondElement = std::next(c.begin());
     const auto thirdElement  = std::next(secondElement);

--- a/tests/std/tests/P0024R2_parallel_algorithms_is_sorted/test.cpp
+++ b/tests/std/tests/P0024R2_parallel_algorithms_is_sorted/test.cpp
@@ -10,6 +10,7 @@
 #include <iterator>
 #include <list>
 #include <numeric>
+#include <stddef.h>
 #include <vector>
 
 #include <parallel_algorithms_utilities.hpp>
@@ -43,8 +44,14 @@ void test_case_is_sorted_parallel(const size_t testSize) {
     *next = 0;
 
     // (first index, last index)
+    auto remainingAttempts = quadradic_complexity_case_limit;
     ++next;
     for (size_t i = 0; i < testSize - 2; ++i) {
+        if (--remainingAttempts == 0) {
+            std::advance(next, static_cast<ptrdiff_t>(testSize - 2 - i));
+            break;
+        }
+
         *next = 1;
         assert(!is_sorted(par, c.begin(), c.end()));
         assert(!is_sorted(par, c.begin(), c.end(), greater()));
@@ -78,10 +85,15 @@ void test_case_is_sorted_parallel(const size_t testSize) {
 
     // breaking the increasing list at each index [1, 2, ..., 0, ..., testSize-1, testSize]
     // Note that we skip the first case since [0, 2, ..., testSize-1, testSize] is still sorted
+    remainingAttempts        = quadradic_complexity_case_limit;
     int i                    = 1;
     const auto secondElement = std::next(c.begin());
     const auto thirdElement  = std::next(secondElement);
     for (auto first = secondElement; first != last; ++first) {
+        if (--remainingAttempts == 0) {
+            break;
+        }
+
         const auto old = *first;
         *first         = 0;
         assert(!is_sorted(par, c.begin(), c.end()));
@@ -97,11 +109,13 @@ void test_case_is_sorted_parallel(const size_t testSize) {
     }
 
     // increasing list except for first element
-    *c.begin() = testSize;
-    assert(!is_sorted(par, c.begin(), c.end()));
-    assert(!is_sorted(par, c.begin(), c.end(), greater()));
-    assert(is_sorted_until(par, c.begin(), c.end()) == std::next(c.begin()));
-    assert(is_sorted_until(par, c.begin(), c.end(), greater()) == std::next(c.begin(), 2));
+    if (remainingAttempts != 0) {
+        *c.begin() = testSize;
+        assert(!is_sorted(par, c.begin(), c.end()));
+        assert(!is_sorted(par, c.begin(), c.end(), greater()));
+        assert(is_sorted_until(par, c.begin(), c.end()) == std::next(c.begin()));
+        assert(is_sorted_until(par, c.begin(), c.end(), greater()) == std::next(c.begin(), 2));
+    }
 
     // decreasing list
     size_t val = testSize;

--- a/tests/std/tests/P0024R2_parallel_algorithms_mismatch/test.cpp
+++ b/tests/std/tests/P0024R2_parallel_algorithms_mismatch/test.cpp
@@ -48,7 +48,7 @@ void test_case_mismatch_signatures(const size_t testSize) {
     // Also test each counterexample position:
     auto defaultAnswer = defaults.begin();
     auto onesAnswer    = ones.begin();
-    for (auto remainingAttempts = quadradic_complexity_case_limit; --remainingAttempts != 0;) {
+    for (auto remainingAttempts = quadratic_complexity_case_limit; --remainingAttempts != 0;) {
         assert((mismatch(defaults.begin(), defaults.end(), ones.begin()) == ExpectedType{defaultAnswer, onesAnswer}));
         assert((mismatch(defaults.begin(), defaults.end(), ones.begin(), ones.end())
                 == ExpectedType{defaultAnswer, onesAnswer}));

--- a/tests/std/tests/P0024R2_parallel_algorithms_mismatch/test.cpp
+++ b/tests/std/tests/P0024R2_parallel_algorithms_mismatch/test.cpp
@@ -48,7 +48,7 @@ void test_case_mismatch_signatures(const size_t testSize) {
     // Also test each counterexample position:
     auto defaultAnswer = defaults.begin();
     auto onesAnswer    = ones.begin();
-    for (;;) {
+    for (auto remainingAttempts = quadradic_complexity_case_limit; --remainingAttempts != 0;) {
         assert((mismatch(defaults.begin(), defaults.end(), ones.begin()) == ExpectedType{defaultAnswer, onesAnswer}));
         assert((mismatch(defaults.begin(), defaults.end(), ones.begin(), ones.end())
                 == ExpectedType{defaultAnswer, onesAnswer}));

--- a/tests/std/tests/P0024R2_parallel_algorithms_mismatch/test.cpp
+++ b/tests/std/tests/P0024R2_parallel_algorithms_mismatch/test.cpp
@@ -48,7 +48,7 @@ void test_case_mismatch_signatures(const size_t testSize) {
     // Also test each counterexample position:
     auto defaultAnswer = defaults.begin();
     auto onesAnswer    = ones.begin();
-    for (auto remainingAttempts = quadratic_complexity_case_limit; --remainingAttempts != 0;) {
+    for (auto remainingAttempts = quadratic_complexity_case_limit; remainingAttempts != 0; --remainingAttempts) {
         assert((mismatch(defaults.begin(), defaults.end(), ones.begin()) == ExpectedType{defaultAnswer, onesAnswer}));
         assert((mismatch(defaults.begin(), defaults.end(), ones.begin(), ones.end())
                 == ExpectedType{defaultAnswer, onesAnswer}));

--- a/tests/std/tests/P0024R2_parallel_algorithms_set_difference/test.cpp
+++ b/tests/std/tests/P0024R2_parallel_algorithms_set_difference/test.cpp
@@ -95,9 +95,14 @@ void test_case_set_difference_parallel(const size_t testSize) {
     assert(rb == compare_result);
 
     // === Overlapping but not equal lists, no direct containment ===
+    auto remainingAttempts    = quadradic_complexity_case_limit;
     auto overlappingListBegin = lb;
     auto overlappingListEnd   = overlappingListBegin + shortListSize;
     for (auto overlappingPoint = sb; overlappingPoint < se; ++overlappingPoint) {
+        if (--remainingAttempts == 0) {
+            break;
+        }
+
         compare_result = set_difference(par, sb, se, overlappingListBegin, overlappingListEnd, rb);
         assert(equal(rb, compare_result, sb, overlappingPoint));
         ++overlappingListBegin;
@@ -140,9 +145,14 @@ void test_case_set_difference_parallel(const size_t testSize) {
     assert(rb == compare_result);
 
     // === Overlapping but not equal lists, no direct containment ===
+    remainingAttempts    = quadradic_complexity_case_limit;
     overlappingListBegin = lb + oddLength;
     overlappingListEnd   = overlappingListBegin + shortListSize;
     for (int overlappingPoint = 0; overlappingPoint < shortListSize; ++overlappingPoint) {
+        if (--remainingAttempts == 0) {
+            break;
+        }
+
         compare_result = set_difference(par, sb, se, overlappingListBegin, overlappingListEnd, rb, greater());
         assert(equal(rb, compare_result, sb + overlappingPoint, se));
         ++overlappingListBegin;

--- a/tests/std/tests/P0024R2_parallel_algorithms_set_difference/test.cpp
+++ b/tests/std/tests/P0024R2_parallel_algorithms_set_difference/test.cpp
@@ -95,7 +95,7 @@ void test_case_set_difference_parallel(const size_t testSize) {
     assert(rb == compare_result);
 
     // === Overlapping but not equal lists, no direct containment ===
-    auto remainingAttempts    = quadradic_complexity_case_limit;
+    auto remainingAttempts    = quadratic_complexity_case_limit;
     auto overlappingListBegin = lb;
     auto overlappingListEnd   = overlappingListBegin + shortListSize;
     for (auto overlappingPoint = sb; overlappingPoint < se; ++overlappingPoint) {
@@ -145,7 +145,7 @@ void test_case_set_difference_parallel(const size_t testSize) {
     assert(rb == compare_result);
 
     // === Overlapping but not equal lists, no direct containment ===
-    remainingAttempts    = quadradic_complexity_case_limit;
+    remainingAttempts    = quadratic_complexity_case_limit;
     overlappingListBegin = lb + oddLength;
     overlappingListEnd   = overlappingListBegin + shortListSize;
     for (int overlappingPoint = 0; overlappingPoint < shortListSize; ++overlappingPoint) {

--- a/tests/std/tests/P0024R2_parallel_algorithms_set_difference/test.cpp
+++ b/tests/std/tests/P0024R2_parallel_algorithms_set_difference/test.cpp
@@ -99,14 +99,13 @@ void test_case_set_difference_parallel(const size_t testSize) {
     auto overlappingListBegin = lb;
     auto overlappingListEnd   = overlappingListBegin + shortListSize;
     for (auto overlappingPoint = sb; overlappingPoint < se; ++overlappingPoint) {
-        if (--remainingAttempts == 0) {
-            break;
-        }
-
         compare_result = set_difference(par, sb, se, overlappingListBegin, overlappingListEnd, rb);
         assert(equal(rb, compare_result, sb, overlappingPoint));
         ++overlappingListBegin;
         ++overlappingListEnd;
+        if (--remainingAttempts == 0) {
+            break;
+        }
     }
 
     // shortList is a subset of longList, containing every other element of longList
@@ -149,14 +148,13 @@ void test_case_set_difference_parallel(const size_t testSize) {
     overlappingListBegin = lb + oddLength;
     overlappingListEnd   = overlappingListBegin + shortListSize;
     for (int overlappingPoint = 0; overlappingPoint < shortListSize; ++overlappingPoint) {
-        if (--remainingAttempts == 0) {
-            break;
-        }
-
         compare_result = set_difference(par, sb, se, overlappingListBegin, overlappingListEnd, rb, greater());
         assert(equal(rb, compare_result, sb + overlappingPoint, se));
         ++overlappingListBegin;
         ++overlappingListEnd;
+        if (--remainingAttempts == 0) {
+            break;
+        }
     }
 
     // test randomized input ranges

--- a/tests/std/tests/P0024R2_parallel_algorithms_set_intersection/test.cpp
+++ b/tests/std/tests/P0024R2_parallel_algorithms_set_intersection/test.cpp
@@ -83,14 +83,13 @@ void test_case_set_intersection_parallel(const size_t testSize) {
     auto overlappingListBegin = lb;
     auto overlappingListEnd   = overlappingListBegin + shortListSize;
     for (auto overlappingPoint = sb; overlappingPoint < se; ++overlappingPoint) {
-        if (--remainingAttempts == 0) {
-            break;
-        }
-
         compare_result = set_intersection(par, sb, se, overlappingListBegin, overlappingListEnd, rb);
         assert(equal(rb, compare_result, overlappingPoint, se));
         ++overlappingListBegin;
         ++overlappingListEnd;
+        if (--remainingAttempts == 0) {
+            break;
+        }
     }
 
     // shortList is a subset of longList, containing every other element of longList
@@ -126,14 +125,13 @@ void test_case_set_intersection_parallel(const size_t testSize) {
     overlappingListBegin = lb + oddLength;
     overlappingListEnd   = overlappingListBegin + shortListSize;
     for (int overlappingPoint = 0; overlappingPoint < shortListSize; ++overlappingPoint) {
-        if (--remainingAttempts == 0) {
-            break;
-        }
-
         compare_result = set_intersection(par, sb, se, overlappingListBegin, overlappingListEnd, rb, greater());
         assert(equal(rb, compare_result, sb, sb + overlappingPoint));
         ++overlappingListBegin;
         ++overlappingListEnd;
+        if (--remainingAttempts == 0) {
+            break;
+        }
     }
 
     // test randomized input ranges

--- a/tests/std/tests/P0024R2_parallel_algorithms_set_intersection/test.cpp
+++ b/tests/std/tests/P0024R2_parallel_algorithms_set_intersection/test.cpp
@@ -79,9 +79,14 @@ void test_case_set_intersection_parallel(const size_t testSize) {
     assert(equal(rb, compare_result, sb, se));
 
     // === Overlapping but not equal lists, no direct containments ===
+    auto remainingAttempts    = quadradic_complexity_case_limit;
     auto overlappingListBegin = lb;
     auto overlappingListEnd   = overlappingListBegin + shortListSize;
     for (auto overlappingPoint = sb; overlappingPoint < se; ++overlappingPoint) {
+        if (--remainingAttempts == 0) {
+            break;
+        }
+
         compare_result = set_intersection(par, sb, se, overlappingListBegin, overlappingListEnd, rb);
         assert(equal(rb, compare_result, overlappingPoint, se));
         ++overlappingListBegin;
@@ -117,9 +122,14 @@ void test_case_set_intersection_parallel(const size_t testSize) {
     compare_result = set_intersection(par, sb, se, sb, se, rb, greater());
     assert(equal(rb, compare_result, sb, se));
 
+    remainingAttempts    = quadradic_complexity_case_limit;
     overlappingListBegin = lb + oddLength;
     overlappingListEnd   = overlappingListBegin + shortListSize;
     for (int overlappingPoint = 0; overlappingPoint < shortListSize; ++overlappingPoint) {
+        if (--remainingAttempts == 0) {
+            break;
+        }
+
         compare_result = set_intersection(par, sb, se, overlappingListBegin, overlappingListEnd, rb, greater());
         assert(equal(rb, compare_result, sb, sb + overlappingPoint));
         ++overlappingListBegin;

--- a/tests/std/tests/P0024R2_parallel_algorithms_set_intersection/test.cpp
+++ b/tests/std/tests/P0024R2_parallel_algorithms_set_intersection/test.cpp
@@ -79,7 +79,7 @@ void test_case_set_intersection_parallel(const size_t testSize) {
     assert(equal(rb, compare_result, sb, se));
 
     // === Overlapping but not equal lists, no direct containments ===
-    auto remainingAttempts    = quadradic_complexity_case_limit;
+    auto remainingAttempts    = quadratic_complexity_case_limit;
     auto overlappingListBegin = lb;
     auto overlappingListEnd   = overlappingListBegin + shortListSize;
     for (auto overlappingPoint = sb; overlappingPoint < se; ++overlappingPoint) {
@@ -122,7 +122,7 @@ void test_case_set_intersection_parallel(const size_t testSize) {
     compare_result = set_intersection(par, sb, se, sb, se, rb, greater());
     assert(equal(rb, compare_result, sb, se));
 
-    remainingAttempts    = quadradic_complexity_case_limit;
+    remainingAttempts    = quadratic_complexity_case_limit;
     overlappingListBegin = lb + oddLength;
     overlappingListEnd   = overlappingListBegin + shortListSize;
     for (int overlappingPoint = 0; overlappingPoint < shortListSize; ++overlappingPoint) {


### PR DESCRIPTION
In DevCom-1326903 the user reports that forward ranges, specifically `std::map` in their case, produce incorrect results from `std::equal`. After reducing to `forward_list` and debugging through, the problem is that when processing "unchunked items" we aren't giving those initial chunks their extra item, so the `std::equal` call fails fast whenever there are unchunked items.

Testing before didn't catch this because the values I chose of being around the thread count didn't account for the underlying infrastructure using `_Oversubscription_multiplier` which meant that the partitioning edge cases were not exercised (in most cases the parallel algorithms tests were testing only 1 element per chunk).

`<execution>` Add the missing +1. Note that this +1 is the same +1 in the iterator-returning version on line 907.

`$/tests/std/include/parallel_algorithms_utilities.hpp`: Adjust the N constants to account for `_Oversubscription_multiplier`.

Resolves DevCom-1326903/VSO-1273957/AB#1273957.