### PR TITLE
Port STL portion of compiler backend changes

### DIFF
--- a/stl/inc/complex
+++ b/stl/inc/complex
@@ -20,16 +20,16 @@
 // no intrinsics for /clr:pure
 #elif defined(__clang__)
 // TRANSITION, not using FMA intrinsics for Clang yet
-#elif defined(_M_IX86) || defined(_M_X64)
+#elif defined(_M_IX86) || (defined(_M_X64) && !defined(_M_ARM64EC))
 #define _FMP_USING_X86_X64_INTRINSICS
 #include <emmintrin.h>
 #include <isa_availability.h>
 extern "C" int __isa_available;
 extern "C" __m128d __cdecl _mm_fmsub_sd(__m128d, __m128d, __m128d);
-#elif defined(_M_ARM64)
+#elif defined(_M_ARM64) || defined(_M_ARM64EC)
 #define _FMP_USING_ARM64_INTRINSICS
 #include <arm64_neon.h>
-#endif // ^^^ defined(_M_ARM64) ^^^
+#endif // ^^^ defined(_M_ARM64) || defined(_M_ARM64EC) ^^^
 
 #pragma pack(push, _CRT_PACKING)
 #pragma warning(push, _STL_WARNING_LEVEL)

--- a/stl/msbuild/stl_1/msvcp_1.settings.targets
+++ b/stl/msbuild/stl_1/msvcp_1.settings.targets
@@ -33,8 +33,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         <UseMsvcrt>false</UseMsvcrt>
         <GenerateImportLib>true</GenerateImportLib>
         <RCIntermediateOutputDirectory>$(IntermediateOutputDirectory)</RCIntermediateOutputDirectory>
-        <IntermediateImportLibOutput>$(CrtBuildDirNative)\msvcprt_1$(BuildSuffix).$(MsvcpFlavor).import_only.lib</IntermediateImportLibOutput>
-        <IntermediateImportLibOutputA64X>$(CrtBuildDir)\msvcprt_1$(BuildSuffix).$(MsvcpFlavor).import_only.lib</IntermediateImportLibOutputA64X>
+        <IntermediateImportLibOutput>$(CrtBuildDir)\msvcprt_1$(BuildSuffix).$(MsvcpFlavor).import_only.lib</IntermediateImportLibOutput>
         <DllDefName>$(LibOutputFileName).$(MsvcpFlavor)</DllDefName>
         <DllDef>$(IntermediateOutputDirectory)\$(DllDefName).def</DllDef>
 

--- a/stl/msbuild/stl_2/msvcp_2.settings.targets
+++ b/stl/msbuild/stl_2/msvcp_2.settings.targets
@@ -33,8 +33,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         <UseMsvcrt>false</UseMsvcrt>
         <GenerateImportLib>true</GenerateImportLib>
         <RCIntermediateOutputDirectory>$(IntermediateOutputDirectory)</RCIntermediateOutputDirectory>
-        <IntermediateImportLibOutput>$(CrtBuildDirNative)\msvcprt_2$(BuildSuffix).$(MsvcpFlavor).import_only.lib</IntermediateImportLibOutput>
-        <IntermediateImportLibOutputA64X>$(CrtBuildDir)\msvcprt_2$(BuildSuffix).$(MsvcpFlavor).import_only.lib</IntermediateImportLibOutputA64X>
+        <IntermediateImportLibOutput>$(CrtBuildDir)\msvcprt_2$(BuildSuffix).$(MsvcpFlavor).import_only.lib</IntermediateImportLibOutput>
         <DllDefName>$(LibOutputFileName).$(MsvcpFlavor)</DllDefName>
         <DllDef>$(IntermediateOutputDirectory)\$(DllDefName).def</DllDef>
 

--- a/stl/msbuild/stl_atomic_wait/msvcp_atomic_wait.settings.targets
+++ b/stl/msbuild/stl_atomic_wait/msvcp_atomic_wait.settings.targets
@@ -33,8 +33,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         <UseMsvcrt>false</UseMsvcrt>
         <GenerateImportLib>true</GenerateImportLib>
         <RCIntermediateOutputDirectory>$(IntermediateOutputDirectory)</RCIntermediateOutputDirectory>
-        <IntermediateImportLibOutput>$(CrtBuildDirNative)\msvcprt_atomic_wait$(BuildSuffix).$(MsvcpFlavor).import_only.lib</IntermediateImportLibOutput>
-        <IntermediateImportLibOutputA64X>$(CrtBuildDir)\msvcprt_atomic_wait$(BuildSuffix).$(MsvcpFlavor).import_only.lib</IntermediateImportLibOutputA64X>
+        <IntermediateImportLibOutput>$(CrtBuildDir)\msvcprt_atomic_wait$(BuildSuffix).$(MsvcpFlavor).import_only.lib</IntermediateImportLibOutput>
         <DllDefName>$(LibOutputFileName).$(MsvcpFlavor)</DllDefName>
         <DllDef>$(IntermediateOutputDirectory)\$(DllDefName).def</DllDef>
 

--- a/stl/msbuild/stl_base/msvcp.settings.targets
+++ b/stl/msbuild/stl_base/msvcp.settings.targets
@@ -36,8 +36,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         <UseMsvcrt>false</UseMsvcrt>
         <GenerateImportLib>true</GenerateImportLib>
         <RCIntermediateOutputDirectory>$(IntermediateOutputDirectory)</RCIntermediateOutputDirectory>
-        <IntermediateImportLibOutput>$(CrtBuildDirNative)\msvcprt_base$(BuildSuffix).$(MsvcpFlavor).import_only.lib</IntermediateImportLibOutput>
-        <IntermediateImportLibOutputA64X>$(CrtBuildDir)\msvcprt_base$(BuildSuffix).$(MsvcpFlavor).import_only.lib</IntermediateImportLibOutputA64X>
+        <IntermediateImportLibOutput>$(CrtBuildDir)\msvcprt_base$(BuildSuffix).$(MsvcpFlavor).import_only.lib</IntermediateImportLibOutput>
         <DllDefName>$(LibOutputFileName).$(MsvcpFlavor)</DllDefName>
         <DllDef>$(IntermediateOutputDirectory)\$(DllDefName).def</DllDef>
         <ClDefines Condition="'$(DependsOnConcRT)' == 'true'">$(ClDefines);_STL_CONCRT_SUPPORT</ClDefines>

--- a/stl/msbuild/stl_codecvt_ids/msvcp_codecvt_ids.settings.targets
+++ b/stl/msbuild/stl_codecvt_ids/msvcp_codecvt_ids.settings.targets
@@ -33,8 +33,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         <UseMsvcrt>false</UseMsvcrt>
         <GenerateImportLib>true</GenerateImportLib>
         <RCIntermediateOutputDirectory>$(IntermediateOutputDirectory)</RCIntermediateOutputDirectory>
-        <IntermediateImportLibOutput>$(CrtBuildDirNative)\msvcprt$(BuildSuffix)_codecvt_ids.$(MsvcpFlavor).import_only.lib</IntermediateImportLibOutput>
-        <IntermediateImportLibOutputA64X>$(CrtBuildDir)\msvcprt$(BuildSuffix)_codecvt_ids.$(MsvcpFlavor).import_only.lib</IntermediateImportLibOutputA64X>
+        <IntermediateImportLibOutput>$(CrtBuildDir)\msvcprt$(BuildSuffix)_codecvt_ids.$(MsvcpFlavor).import_only.lib</IntermediateImportLibOutput>
         <DllDefName>$(LibOutputFileName).$(MsvcpFlavor)</DllDefName>
         <DllDef>$(IntermediateOutputDirectory)\$(DllDefName).def</DllDef>
 


### PR DESCRIPTION
The compiler backend devs modified the STL in their MSVC-internal branch `prod/be`; these changes have flowed into the MSVC-internal branch `prod/fe` shared by the compiler frontend and libraries, so we need to mirror these changes to GitHub (which is the Source Of Truth for the STL). See #1344 and #1431 for context.

* MSVC-PR-311897 merged `main` into `prod/fe`, bringing
  + MSVC-PR-309259 which modified `stl/inc/complex`, and
  + MSVC-PR-308311 which modified `stl/msbuild`.