### PR TITLE
<format>: Increase the buffer size for specful floats

### DIFF
--- a/stl/inc/format
+++ b/stl/inc/format
@@ -1545,8 +1545,31 @@ _OutputIt _Write(_OutputIt _Out, const _Float _Value, const _Basic_format_specs<
         throw format_error("invalid floating point type");
     }
 
-    array<char, _Format_min_buffer_length> _Buffer;
+    // Consider the powers of 2 in decimal:
+    // 2^-1 = 0.5
+    // 2^-2 = 0.25
+    // 2^-3 = 0.125
+    // 2^-4 = 0.0625
+    // Each power of 2 consumes one more decimal digit. This is because:
+    // 2^-N * 5^-N = 10^-N
+    // 2^-N = 10^-N * 5^N
+    // Example: 2^-4 = 10^-4 * 5^4 = 0.0001 * 625
+    // Therefore, the min subnormal 2^-1074 consumes 1074 digits of precision (digits after the decimal point).
+    // We need 3 more characters for a potential negative sign, the zero integer part, and the decimal point.
+    // Therefore, the precision can be clamped to 1074.
+    // The largest number consumes 309 digits before the decimal point. With a precision of 1074, and it being negative,
+    // it would use a buffer of size 1074+309+2.
+    // We need to add an additional number to the max exponent to accommodate the ones place.
+    constexpr auto _Max_precision = 1074;
+    constexpr auto _Buffer_size   = _Max_precision + DBL_MAX_10_EXP + 3;
+    array<char, _Buffer_size> _Buffer;
     to_chars_result _Result;
+
+    auto _Extra_precision = 0;
+    if (_Precision > _Max_precision) {
+        _Extra_precision = _Precision - _Max_precision;
+        _Precision       = _Max_precision;
+    }
 
     if (_Precision == -1) {
         _Result = _STD to_chars(_Buffer.data(), _Buffer.data() + _Buffer.size(), _Value, _Format);
@@ -1596,13 +1619,17 @@ _OutputIt _Write(_OutputIt _Out, const _Float _Value, const _Basic_format_specs<
         }
 
         if (_Specs._Type == 'g' || _Specs._Type == 'G') {
-            _Zeroes_to_append = _Precision - static_cast<int>(_Exponent_start - _Buffer_start);
+            _Zeroes_to_append = _Extra_precision + _Precision - static_cast<int>(_Exponent_start - _Buffer_start);
             if (!_Append_decimal) {
                 _Zeroes_to_append += 1;
             }
-            _Width += _Zeroes_to_append;
         }
     }
+
+    if (_Is_finite && (_Specs._Type == 'f' || _Specs._Type == 'F')) {
+        _Zeroes_to_append = _Extra_precision;
+    }
+    _Width += _Zeroes_to_append;
 
     const bool _Write_leading_zeroes = _Specs._Leading_zero && _Specs._Alignment == _Align::_None;
     auto _Writer                     = [&](_OutputIt _Out) {
@@ -1612,16 +1639,15 @@ _OutputIt _Write(_OutputIt _Out, const _Float _Value, const _Basic_format_specs<
             _Out = _STD fill_n(_Out, _Specs._Width - _Width, '0');
         }
 
-        if (_Specs._Alt) {
-            _Out          = _STD copy(_Buffer_start, _Exponent_start, _Out);
-            _Buffer_start = _Exponent_start;
+        _Out          = _STD copy(_Buffer_start, _Exponent_start, _Out);
+        _Buffer_start = _Exponent_start;
 
-            if (_Append_decimal) {
-                *_Out++ = '.';
-            }
-            for (; _Zeroes_to_append > 0; --_Zeroes_to_append) {
-                *_Out++ = '0';
-            }
+        if (_Specs._Alt && _Append_decimal) {
+            *_Out++ = '.';
+        }
+
+        for (; _Zeroes_to_append > 0; --_Zeroes_to_append) {
+            *_Out++ = '0';
         }
 
         return _STD copy(_Buffer_start, _Result.ptr, _Out);


### PR DESCRIPTION
Special thanks to @StephanTLavavej for helping define the limits of floating point
numbers.

The issue is basically that the buffer for specful floats was too small.
You can specify an arbitrary precision for some formatting types, which
means a lot more zeroes basically everywhere. If we only consider the
most precision needed to represent a floating point number full, we need
to consider the smallest double. It has an exponent of 2^-1074. As
proven in the comment, each power of 2 adds an additional decimal digit,
giving us a limit of 1074 decimal digits necessary to fully represent
the smallest number. On top of this, we need the decimal point, the
preceding 0, and a negative sign, bumping us to a total of 1077
characters. Any additional precision would only add 0s to the end of
this number. Now consider the largest number. It is much easier to
represent, clocking in at just 309 digits, none of which are decimal
points. However, if we format it as a fixed point with 1074 precision,
we would get 1074 zeroes at the end. To not worry about inspecting the
value we format, I have chosen a large enough buffer to accommodate the
largest number with the largest meaningful precision. Any precision past
this is just appending 0s.

Since only 'f' and '#g' care about the extra zeroes, the code change is
pretty manageable.

<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
