### PR TITLE
Visualise C++20 chrono additions

### DIFF
--- a/stl/debugger/STL.natvis
+++ b/stl/debugger/STL.natvis
@@ -685,7 +685,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
   </Type>
 
   <Type Name="std::chrono::duration&lt;*,std::ratio&lt;1,1000&gt; &gt;">
-      <DisplayString>{_MyRep} milliseconds</DisplayString>
+      <DisplayString Condition="_MyRep == 1">{_MyRep} millisecond</DisplayString>
       <DisplayString>{_MyRep} milliseconds</DisplayString>
       <Expand/>
   </Type>
@@ -733,10 +733,9 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
   </Type>
 
   <Type Name="std::chrono::day">
-      <DisplayString Condition="_Day == 11 || _Day == 12 || _Day == 13">{(int)_Day}th</DisplayString>
-      <DisplayString Condition="_Day % 10 == 1">{(int)_Day}st</DisplayString>
-      <DisplayString Condition="_Day % 10 == 2">{(int)_Day}nd</DisplayString>
-      <DisplayString Condition="_Day % 10 == 3">{(int)_Day}rd</DisplayString>
+      <DisplayString Condition="_Day % 10 == 1 &amp;&amp; _Day % 100 != 11">{(int)_Day}st</DisplayString>
+      <DisplayString Condition="_Day % 10 == 2 &amp;&amp; _Day % 100 != 12">{(int)_Day}nd</DisplayString>
+      <DisplayString Condition="_Day % 10 == 3 &amp;&amp; _Day % 100 != 13">{(int)_Day}rd</DisplayString>
       <DisplayString>{(int)_Day}th</DisplayString>
       <Expand/>
   </Type>

--- a/stl/debugger/STL.natvis
+++ b/stl/debugger/STL.natvis
@@ -802,7 +802,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
   </Type>
 
   <Type Name="std::chrono::month_day_last">
-      <DisplayString>Last {_Month}</DisplayString>
+      <DisplayString>Last day of {_Month}</DisplayString>
       <Expand>
         <Item Name="[month]">_Month</Item>
       </Expand>
@@ -842,7 +842,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
   </Type>
 
   <Type Name="std::chrono::year_month_day_last">
-      <DisplayString>Last day of {_Month_day_last._Month}, {_Year}</DisplayString>
+      <DisplayString>{_Month_day_last}, {_Year}</DisplayString>
       <Expand>
         <Item Name="[year]">_Year</Item>
         <Item Name="[month]">_Month_day_last._Month</Item>

--- a/stl/debugger/STL.natvis
+++ b/stl/debugger/STL.natvis
@@ -673,37 +673,214 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 
   <Type Name="std::chrono::duration&lt;*,std::ratio&lt;1,1000000000&gt; &gt;">
+      <DisplayString Condition="_MyRep == 1">{_MyRep} nanosecond</DisplayString>
       <DisplayString>{_MyRep} nanoseconds</DisplayString>
       <Expand/>
   </Type>
 
   <Type Name="std::chrono::duration&lt;*,std::ratio&lt;1,1000000&gt; &gt;">
+      <DisplayString Condition="_MyRep == 1">{_MyRep} microsecond</DisplayString>
       <DisplayString>{_MyRep} microseconds</DisplayString>
       <Expand/>
   </Type>
 
   <Type Name="std::chrono::duration&lt;*,std::ratio&lt;1,1000&gt; &gt;">
       <DisplayString>{_MyRep} milliseconds</DisplayString>
+      <DisplayString>{_MyRep} milliseconds</DisplayString>
       <Expand/>
   </Type>
 
   <Type Name="std::chrono::duration&lt;*,std::ratio&lt;1,1&gt; &gt;">
+      <DisplayString Condition="_MyRep == 1">{_MyRep} second</DisplayString>
       <DisplayString>{_MyRep} seconds</DisplayString>
       <Expand/>
   </Type>
 
   <Type Name="std::chrono::duration&lt;*,std::ratio&lt;60,1&gt; &gt;">
+      <DisplayString Condition="_MyRep == 1">{_MyRep} minute</DisplayString>
       <DisplayString>{_MyRep} minutes</DisplayString>
       <Expand/>
   </Type>
 
   <Type Name="std::chrono::duration&lt;*,std::ratio&lt;3600,1&gt; &gt;">
+      <DisplayString Condition="_MyRep == 1">{_MyRep} hour</DisplayString>
       <DisplayString>{_MyRep} hours</DisplayString>
       <Expand/>
   </Type>
 
+  <Type Name="std::chrono::duration&lt;*,std::ratio&lt;86400,1&gt; &gt;">
+      <DisplayString Condition="_MyRep == 1">{_MyRep} day</DisplayString>
+      <DisplayString>{_MyRep} days</DisplayString>
+      <Expand/>
+  </Type>
 
-  <!-- VC 2013 -->
+  <Type Name="std::chrono::duration&lt;*,std::ratio&lt;604800,1&gt; &gt;">
+      <DisplayString Condition="_MyRep == 1">{_MyRep} week</DisplayString>
+      <DisplayString>{_MyRep} weeks</DisplayString>
+      <Expand/>
+  </Type>
+
+  <Type Name="std::chrono::duration&lt;*,std::ratio&lt;2629746,1&gt; &gt;">
+      <DisplayString Condition="_MyRep == 1">{_MyRep} month</DisplayString>
+      <DisplayString>{_MyRep} months</DisplayString>
+      <Expand/>
+  </Type>
+
+  <Type Name="std::chrono::duration&lt;*,std::ratio&lt;31556952,1&gt; &gt;">
+      <DisplayString Condition="_MyRep == 1">{_MyRep} year</DisplayString>
+      <DisplayString>{_MyRep} years</DisplayString>
+      <Expand/>
+  </Type>
+
+  <Type Name="std::chrono::day">
+      <DisplayString Condition="_Day == 11 || _Day == 12 || _Day == 13">{(int)_Day}th</DisplayString>
+      <DisplayString Condition="_Day % 10 == 1">{(int)_Day}st</DisplayString>
+      <DisplayString Condition="_Day % 10 == 2">{(int)_Day}nd</DisplayString>
+      <DisplayString Condition="_Day % 10 == 3">{(int)_Day}rd</DisplayString>
+      <DisplayString>{(int)_Day}th</DisplayString>
+      <Expand/>
+  </Type>
+
+  <Type Name="std::chrono::month">
+	  <DisplayString Condition="_Month == 1">January</DisplayString>
+	  <DisplayString Condition="_Month == 2">February</DisplayString>
+	  <DisplayString Condition="_Month == 3">March</DisplayString>
+	  <DisplayString Condition="_Month == 4">April</DisplayString>
+	  <DisplayString Condition="_Month == 5">May</DisplayString>
+	  <DisplayString Condition="_Month == 6">June</DisplayString>
+	  <DisplayString Condition="_Month == 7">July</DisplayString>
+	  <DisplayString Condition="_Month == 8">August</DisplayString>
+	  <DisplayString Condition="_Month == 9">September</DisplayString>
+	  <DisplayString Condition="_Month == 10">October</DisplayString>
+	  <DisplayString Condition="_Month == 11">November</DisplayString>
+	  <DisplayString Condition="_Month == 12">December</DisplayString>
+	  <DisplayString>{_Month}</DisplayString>
+      <Expand/>
+  </Type>
+
+  <Type Name="std::chrono::year">
+	  <DisplayString>{_Year}</DisplayString>
+      <Expand/>
+  </Type>
+
+  <Type Name="std::chrono::weekday">
+	  <DisplayString Condition="_Weekday == 0">Sunday</DisplayString>
+	  <DisplayString Condition="_Weekday == 1">Monday</DisplayString>
+	  <DisplayString Condition="_Weekday == 2">Tuesday</DisplayString>
+	  <DisplayString Condition="_Weekday == 3">Wednesday</DisplayString>
+	  <DisplayString Condition="_Weekday == 4">Thursday</DisplayString>
+	  <DisplayString Condition="_Weekday == 5">Friday</DisplayString>
+	  <DisplayString Condition="_Weekday == 6">Saturday</DisplayString>
+	  <DisplayString>{_Weekday}</DisplayString>
+      <Expand/>
+  </Type>
+
+  <Type Name="std::chrono::weekday_indexed">
+	  <DisplayString Condition="_Index == 1">{(int)_Index}st {_Weekday}</DisplayString>
+	  <DisplayString Condition="_Index == 2">{(int)_Index}nd {_Weekday}</DisplayString>
+	  <DisplayString Condition="_Index == 3">{(int)_Index}rd {_Weekday}</DisplayString>
+	  <DisplayString Condition="_Index == 4 || _Index == 5">{(int)_Index}th {_Weekday}</DisplayString>
+	  <DisplayString>{(int)_Index}, {_Weekday}</DisplayString>
+      <Expand>
+        <Item Name="[weekday]">_Weekday</Item>
+        <Item Name="[index]">(int)_Index</Item>
+      </Expand>
+  </Type>
+
+  <Type Name="std::chrono::weekday_last">
+      <DisplayString>Last {_Weekday}</DisplayString>
+      <Expand>
+        <Item Name="[weekday]">_Weekday</Item>
+      </Expand>
+  </Type>
+
+  <Type Name="std::chrono::month_day">
+      <DisplayString>{_Month} {_Day}</DisplayString>
+        <Expand>
+          <Item Name="[month]">_Month</Item>
+          <Item Name="[day]">_Day</Item>
+      </Expand>
+  </Type>
+
+  <Type Name="std::chrono::month_day_last">
+      <DisplayString>Last {_Month}</DisplayString>
+      <Expand>
+        <Item Name="[month]">_Month</Item>
+      </Expand>
+  </Type>
+
+  <Type Name="std::chrono::month_weekday">
+      <DisplayString>{_Weekday_index} of {_Month}</DisplayString>
+        <Expand>
+          <Item Name="[month]">_Month</Item>
+          <Item Name="[weekday_indexed]">_Weekday_index</Item>
+      </Expand>
+  </Type>
+
+  <Type Name="std::chrono::month_weekday_last">
+      <DisplayString>Last {_Weekday_last._Weekday} of {_Month}</DisplayString>
+      <Expand>
+        <Item Name="[month]">_Month</Item>
+        <Item Name="[weekday]">_Weekday_last._Weekday</Item>
+      </Expand>
+  </Type>
+
+  <Type Name="std::chrono::year_month">
+      <DisplayString>{_Year} {_Month}</DisplayString>
+        <Expand>
+          <Item Name="[year]">_Year</Item>
+          <Item Name="[month]">_Month</Item>
+      </Expand>
+  </Type>
+
+  <Type Name="std::chrono::year_month_day">
+      <DisplayString>{_Year} {_Month} {_Day}</DisplayString>
+        <Expand>
+          <Item Name="[year]">_Year</Item>
+          <Item Name="[month]">_Month</Item>
+          <Item Name="[day]">_Day</Item>
+      </Expand>
+  </Type>
+
+  <Type Name="std::chrono::year_month_day_last">
+      <DisplayString>Last day of {_Month_day_last._Month}, {_Year}</DisplayString>
+      <Expand>
+        <Item Name="[year]">_Year</Item>
+        <Item Name="[month]">_Month_day_last._Month</Item>
+      </Expand>
+  </Type>
+
+  <Type Name="std::chrono::year_month_weekday">
+      <DisplayString>{_Weekday_index} of {_Month}, {_Year}</DisplayString>
+        <Expand>
+          <Item Name="[year]">_Year</Item>
+          <Item Name="[month]">_Month</Item>
+          <Item Name="[weekday_indexed]">_Weekday_index</Item>
+      </Expand>
+  </Type>
+
+  <Type Name="std::chrono::year_month_weekday_last">
+      <DisplayString>{_Weekday_last} of {_Month}, {_Year}</DisplayString>
+      <Expand>
+        <Item Name="[year]">_Year</Item>
+        <Item Name="[month]">_Month</Item>
+        <Item Name="[weekday]">_Weekday_last._Weekday</Item>
+      </Expand>
+  </Type>
+
+  <Type Name="std::chrono::hh_mm_ss&lt;*&gt;">
+      <DisplayString Condition="_Is_neg">-{_Hours._MyRep / 10}{_Hours._MyRep % 10}:{_Mins._MyRep / 10}{_Mins._MyRep % 10}:{_Secs._MyRep / 10}{_Secs._MyRep % 10}:{_Sub_secs._MyRep / 10}{_Sub_secs._MyRep % 10}</DisplayString>
+      <DisplayString>{_Hours._MyRep}h {_Mins._MyRep}m {_Secs._MyRep}s {_Sub_secs._MyRep}ss</DisplayString>
+      <Expand>
+        <Item Name="[hours]">_Hours</Item>
+        <Item Name="[minutes]">_Mins</Item>
+        <Item Name="[seconds]">_Secs</Item>
+        <Item Name="[subseconds]">_Sub_secs</Item>
+        <Item Name="[is_negative]">_Is_neg</Item>
+      </Expand>
+  </Type>
+
+	<!-- VC 2013 -->
   <Type Name="std::basic_string&lt;char,*&gt;" Priority="MediumLow">
       <DisplayString Condition="_Myres &lt; _BUF_SIZE">{_Bx._Buf,na}</DisplayString>
       <DisplayString Condition="_Myres &gt;= _BUF_SIZE">{_Bx._Ptr,na}</DisplayString>

--- a/stl/debugger/STL.natvis
+++ b/stl/debugger/STL.natvis
@@ -868,14 +868,14 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
   </Type>
 
   <Type Name="std::chrono::hh_mm_ss&lt;*&gt;">
-      <DisplayString Condition="_Is_neg">-{_Hours._MyRep / 10}{_Hours._MyRep % 10}:{_Mins._MyRep / 10}{_Mins._MyRep % 10}:{_Secs._MyRep / 10}{_Secs._MyRep % 10}:{_Sub_secs._MyRep / 10}{_Sub_secs._MyRep % 10}</DisplayString>
+      <DisplayString Condition="_Is_neg">-{_Hours._MyRep}h {_Mins._MyRep}m {_Secs._MyRep}s {_Sub_secs._MyRep}ss</DisplayString>
       <DisplayString>{_Hours._MyRep}h {_Mins._MyRep}m {_Secs._MyRep}s {_Sub_secs._MyRep}ss</DisplayString>
       <Expand>
+        <Item Name="[is_negative]">_Is_neg</Item>
         <Item Name="[hours]">_Hours</Item>
         <Item Name="[minutes]">_Mins</Item>
         <Item Name="[seconds]">_Secs</Item>
         <Item Name="[subseconds]">_Sub_secs</Item>
-        <Item Name="[is_negative]">_Is_neg</Item>
       </Expand>
   </Type>
 

--- a/stl/debugger/STL.natvis
+++ b/stl/debugger/STL.natvis
@@ -742,45 +742,45 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
   </Type>
 
   <Type Name="std::chrono::month">
-	  <DisplayString Condition="_Month == 1">January</DisplayString>
-	  <DisplayString Condition="_Month == 2">February</DisplayString>
-	  <DisplayString Condition="_Month == 3">March</DisplayString>
-	  <DisplayString Condition="_Month == 4">April</DisplayString>
-	  <DisplayString Condition="_Month == 5">May</DisplayString>
-	  <DisplayString Condition="_Month == 6">June</DisplayString>
-	  <DisplayString Condition="_Month == 7">July</DisplayString>
-	  <DisplayString Condition="_Month == 8">August</DisplayString>
-	  <DisplayString Condition="_Month == 9">September</DisplayString>
-	  <DisplayString Condition="_Month == 10">October</DisplayString>
-	  <DisplayString Condition="_Month == 11">November</DisplayString>
-	  <DisplayString Condition="_Month == 12">December</DisplayString>
-	  <DisplayString>{_Month}</DisplayString>
+      <DisplayString Condition="_Month == 1">January</DisplayString>
+      <DisplayString Condition="_Month == 2">February</DisplayString>
+      <DisplayString Condition="_Month == 3">March</DisplayString>
+      <DisplayString Condition="_Month == 4">April</DisplayString>
+      <DisplayString Condition="_Month == 5">May</DisplayString>
+      <DisplayString Condition="_Month == 6">June</DisplayString>
+      <DisplayString Condition="_Month == 7">July</DisplayString>
+      <DisplayString Condition="_Month == 8">August</DisplayString>
+      <DisplayString Condition="_Month == 9">September</DisplayString>
+      <DisplayString Condition="_Month == 10">October</DisplayString>
+      <DisplayString Condition="_Month == 11">November</DisplayString>
+      <DisplayString Condition="_Month == 12">December</DisplayString>
+      <DisplayString>{_Month}</DisplayString>
       <Expand/>
   </Type>
 
   <Type Name="std::chrono::year">
-	  <DisplayString>{_Year}</DisplayString>
+      <DisplayString>{_Year}</DisplayString>
       <Expand/>
   </Type>
 
   <Type Name="std::chrono::weekday">
-	  <DisplayString Condition="_Weekday == 0">Sunday</DisplayString>
-	  <DisplayString Condition="_Weekday == 1">Monday</DisplayString>
-	  <DisplayString Condition="_Weekday == 2">Tuesday</DisplayString>
-	  <DisplayString Condition="_Weekday == 3">Wednesday</DisplayString>
-	  <DisplayString Condition="_Weekday == 4">Thursday</DisplayString>
-	  <DisplayString Condition="_Weekday == 5">Friday</DisplayString>
-	  <DisplayString Condition="_Weekday == 6">Saturday</DisplayString>
-	  <DisplayString>{_Weekday}</DisplayString>
+      <DisplayString Condition="_Weekday == 0">Sunday</DisplayString>
+      <DisplayString Condition="_Weekday == 1">Monday</DisplayString>
+      <DisplayString Condition="_Weekday == 2">Tuesday</DisplayString>
+      <DisplayString Condition="_Weekday == 3">Wednesday</DisplayString>
+      <DisplayString Condition="_Weekday == 4">Thursday</DisplayString>
+      <DisplayString Condition="_Weekday == 5">Friday</DisplayString>
+      <DisplayString Condition="_Weekday == 6">Saturday</DisplayString>
+      <DisplayString>{_Weekday}</DisplayString>
       <Expand/>
   </Type>
 
   <Type Name="std::chrono::weekday_indexed">
-	  <DisplayString Condition="_Index == 1">{(int)_Index}st {_Weekday}</DisplayString>
-	  <DisplayString Condition="_Index == 2">{(int)_Index}nd {_Weekday}</DisplayString>
-	  <DisplayString Condition="_Index == 3">{(int)_Index}rd {_Weekday}</DisplayString>
-	  <DisplayString Condition="_Index == 4 || _Index == 5">{(int)_Index}th {_Weekday}</DisplayString>
-	  <DisplayString>{(int)_Index}, {_Weekday}</DisplayString>
+      <DisplayString Condition="_Index == 1">{(int)_Index}st {_Weekday}</DisplayString>
+      <DisplayString Condition="_Index == 2">{(int)_Index}nd {_Weekday}</DisplayString>
+      <DisplayString Condition="_Index == 3">{(int)_Index}rd {_Weekday}</DisplayString>
+      <DisplayString Condition="_Index == 4 || _Index == 5">{(int)_Index}th {_Weekday}</DisplayString>
+      <DisplayString>{(int)_Index}, {_Weekday}</DisplayString>
       <Expand>
         <Item Name="[weekday]">_Weekday</Item>
         <Item Name="[index]">(int)_Index</Item>
@@ -880,7 +880,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
       </Expand>
   </Type>
 
-	<!-- VC 2013 -->
+    <!-- VC 2013 -->
   <Type Name="std::basic_string&lt;char,*&gt;" Priority="MediumLow">
       <DisplayString Condition="_Myres &lt; _BUF_SIZE">{_Bx._Buf,na}</DisplayString>
       <DisplayString Condition="_Myres &gt;= _BUF_SIZE">{_Bx._Ptr,na}</DisplayString>

--- a/stl/debugger/STL.natvis
+++ b/stl/debugger/STL.natvis
@@ -880,7 +880,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
       </Expand>
   </Type>
 
-    <!-- VC 2013 -->
+  <!-- VC 2013 -->
   <Type Name="std::basic_string&lt;char,*&gt;" Priority="MediumLow">
       <DisplayString Condition="_Myres &lt; _BUF_SIZE">{_Bx._Buf,na}</DisplayString>
       <DisplayString Condition="_Myres &gt;= _BUF_SIZE">{_Bx._Ptr,na}</DisplayString>


### PR DESCRIPTION
* Added singular forms of durations (second, minute, etc.)
* Added visualisations for the new calendar types.
* It looks like this
![image](https://user-images.githubusercontent.com/2692096/112188892-57bd2d80-8bfb-11eb-9044-66bca3e1b2b0.png)

Thoughts and questions
* The 1st/2nd etc could probably be dropped on `day`?
* The `_last` types might be better without the "Last"s? 
* `is_negative` should probably be dropped?
* This is the first time I've messed with natvis' and couldn't find a way to specify a width, is that not possible? Seems a bit hacky the way I did it and should that be used for the calendar types as well to use the ISO date format (YYYY-MM-DD)? 