### PR TITLE
Port test fix for VSO:119283

### DIFF
--- a/tests/std/tests/P0898R3_concepts/test.cpp
+++ b/tests/std/tests/P0898R3_concepts/test.cpp
@@ -1557,10 +1557,8 @@ namespace test_default_initializable {
         int x;
     };
     STATIC_ASSERT(default_initializable<S>);
-#if defined(__clang__) || defined(__EDG__) // TRANSITION, DevCom-952724
+#if defined(MSVC_INTERNAL_TESTING) || defined(__clang__) || defined(__EDG__) // TRANSITION, DevCom-952724
     STATIC_ASSERT(!default_initializable<S const>);
-#else // ^^^ no workaround / assert bug so we'll notice when it's fixed vvv
-    STATIC_ASSERT(default_initializable<S const>);
 #endif // TRANSITION, DevCom-952724
 
     // Also test GH-1603 "default_initializable accepts types that are not default-initializable"


### PR DESCRIPTION
When porting the fix for VSO:119283 to the 16.9 branch I discovered that there was another test that should have been enabled when using the internal Microsoft compiler. This PR makes that change.

Mirrors STL changes from MSVC-PR-312852.