### PR TITLE
chrono cleanups

### DIFF
--- a/stl/CMakeLists.txt
+++ b/stl/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(HEADERS
     ${CMAKE_CURRENT_LIST_DIR}/inc/__msvc_all_public_headers.hpp
     ${CMAKE_CURRENT_LIST_DIR}/inc/__msvc_system_error_abi.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/inc/__msvc_tzdb.hpp
     ${CMAKE_CURRENT_LIST_DIR}/inc/algorithm
     ${CMAKE_CURRENT_LIST_DIR}/inc/any
     ${CMAKE_CURRENT_LIST_DIR}/inc/array
@@ -233,7 +234,6 @@ set(HEADERS
     ${CMAKE_CURRENT_LIST_DIR}/inc/xtimec.h
     ${CMAKE_CURRENT_LIST_DIR}/inc/xtr1common
     ${CMAKE_CURRENT_LIST_DIR}/inc/xtree
-    ${CMAKE_CURRENT_LIST_DIR}/inc/xtzdb.h
     ${CMAKE_CURRENT_LIST_DIR}/inc/xutility
     ${CMAKE_CURRENT_LIST_DIR}/inc/ymath.h
     ${CMAKE_CURRENT_LIST_DIR}/inc/yvals.h

--- a/stl/inc/__msvc_tzdb.hpp
+++ b/stl/inc/__msvc_tzdb.hpp
@@ -76,9 +76,9 @@ _NODISCARD __std_tzdb_sys_info* __stdcall __std_tzdb_get_sys_info(
     const char* _Tz, size_t _Tz_len, __std_tzdb_epoch_milli _Local) noexcept;
 void __stdcall __std_tzdb_delete_sys_info(__std_tzdb_sys_info* _Info) noexcept;
 
-_NODISCARD __std_tzdb_leap_info* __stdcall __std_tzdb_get_reg_leap_seconds(
-    size_t _Prev_reg_ls_size, size_t* _Current_reg_ls_size) noexcept;
-void __stdcall __std_tzdb_delete_reg_leap_seconds(__std_tzdb_leap_info* _Info) noexcept;
+_NODISCARD __std_tzdb_leap_info* __stdcall __std_tzdb_get_leap_seconds(
+    size_t _Prev_ls_size, size_t* _Current_ls_size) noexcept;
+void __stdcall __std_tzdb_delete_leap_seconds(__std_tzdb_leap_info* _Info) noexcept;
 
 _NODISCARD void* __stdcall __std_calloc_crt(size_t _Count, size_t _Size) noexcept;
 void __stdcall __std_free_crt(void* _Ptr) noexcept;
@@ -114,7 +114,7 @@ struct _Tzdb_deleter<__std_tzdb_sys_info> {
 template <>
 struct _Tzdb_deleter<__std_tzdb_leap_info[]> {
     void operator()(__std_tzdb_leap_info* _Info) const noexcept {
-        __std_tzdb_delete_reg_leap_seconds(_Info);
+        __std_tzdb_delete_leap_seconds(_Info);
     }
 };
 

--- a/stl/inc/__msvc_tzdb.hpp
+++ b/stl/inc/__msvc_tzdb.hpp
@@ -22,7 +22,7 @@ _STL_DISABLE_CLANG_WARNINGS
 
 using __std_tzdb_epoch_milli = double;
 
-struct __std_tzdb_registry_leap_info {
+struct __std_tzdb_leap_info {
     uint16_t _Year;
     uint16_t _Month;
     uint16_t _Day;
@@ -76,9 +76,9 @@ _NODISCARD __std_tzdb_sys_info* __stdcall __std_tzdb_get_sys_info(
     const char* _Tz, size_t _Tz_len, __std_tzdb_epoch_milli _Local) noexcept;
 void __stdcall __std_tzdb_delete_sys_info(__std_tzdb_sys_info* _Info) noexcept;
 
-_NODISCARD __std_tzdb_registry_leap_info* __stdcall __std_tzdb_get_reg_leap_seconds(
+_NODISCARD __std_tzdb_leap_info* __stdcall __std_tzdb_get_reg_leap_seconds(
     size_t _Prev_reg_ls_size, size_t* _Current_reg_ls_size) noexcept;
-void __stdcall __std_tzdb_delete_reg_leap_seconds(__std_tzdb_registry_leap_info* _Rlsi) noexcept;
+void __stdcall __std_tzdb_delete_reg_leap_seconds(__std_tzdb_leap_info* _Info) noexcept;
 
 _NODISCARD void* __stdcall __std_calloc_crt(size_t _Count, size_t _Size) noexcept;
 void __stdcall __std_free_crt(void* _Ptr) noexcept;
@@ -112,8 +112,8 @@ struct _Tzdb_deleter<__std_tzdb_sys_info> {
 };
 
 template <>
-struct _Tzdb_deleter<__std_tzdb_registry_leap_info[]> {
-    void operator()(__std_tzdb_registry_leap_info* _Info) const noexcept {
+struct _Tzdb_deleter<__std_tzdb_leap_info[]> {
+    void operator()(__std_tzdb_leap_info* _Info) const noexcept {
         __std_tzdb_delete_reg_leap_seconds(_Info);
     }
 };

--- a/stl/inc/__msvc_tzdb.hpp
+++ b/stl/inc/__msvc_tzdb.hpp
@@ -1,11 +1,11 @@
-// xtzdb.h internal header
+// __msvc_tzdb.hpp internal header
 
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #pragma once
-#ifndef _XTZDB_H
-#define _XTZDB_H
+#ifndef __MSVC_TZDB_HPP
+#define __MSVC_TZDB_HPP
 #include <yvals.h>
 #if _STL_COMPILER_PREPROCESSOR
 #include <cstddef>
@@ -151,4 +151,4 @@ _STL_RESTORE_CLANG_WARNINGS
 #pragma warning(pop)
 #pragma pack(pop)
 #endif // _STL_COMPILER_PREPROCESSOR
-#endif // _XTZDB_H
+#endif // __MSVC_TZDB_HPP

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -2551,7 +2551,7 @@ namespace chrono {
 
     // [time.zone.db]
 
-    _NODISCARD inline string _Xtzdb_generate_current_zone() {
+    _NODISCARD inline string _Tzdb_generate_current_zone() {
         unique_ptr<__std_tzdb_current_zone_info, _Tzdb_deleter<__std_tzdb_current_zone_info>> _Info{
             __std_tzdb_get_current_zone()};
         if (_Info == nullptr) {
@@ -2596,11 +2596,11 @@ namespace chrono {
         }
 
         _NODISCARD const time_zone* current_zone() const {
-            return locate_zone(_Xtzdb_generate_current_zone());
+            return locate_zone(_Tzdb_generate_current_zone());
         }
     };
 
-    _NODISCARD inline tuple<string, decltype(tzdb::zones), decltype(tzdb::links)> _Xtzdb_generate_time_zones() {
+    _NODISCARD inline tuple<string, decltype(tzdb::zones), decltype(tzdb::links)> _Tzdb_generate_time_zones() {
         unique_ptr<__std_tzdb_time_zones_info, _Tzdb_deleter<__std_tzdb_time_zones_info>> _Info{
             __std_tzdb_get_time_zones()};
         if (_Info == nullptr) {
@@ -2626,8 +2626,7 @@ namespace chrono {
         return {_Info->_Version, _STD move(_Time_zones), _STD move(_Time_zone_links)};
     }
 
-    _NODISCARD inline pair<decltype(tzdb::leap_seconds), bool> _Xtzdb_generate_leap_seconds(
-        const size_t _Current_size) {
+    _NODISCARD inline pair<decltype(tzdb::leap_seconds), bool> _Tzdb_generate_leap_seconds(const size_t _Current_size) {
         // Returns empty vector if no new leap seconds are found.
         static constexpr leap_second _Known_leap_seconds[]{
             {sys_seconds{seconds{78796800}}, true, seconds{0}},
@@ -2700,7 +2699,7 @@ namespace chrono {
         return {_STD move(_Leap_sec_info), _All_ls_positive};
     }
 
-    _NODISCARD inline string _Xtzdb_update_version(const string_view _Version, const size_t _Num_leap_seconds) {
+    _NODISCARD inline string _Tzdb_update_version(const string_view _Version, const size_t _Num_leap_seconds) {
         string _Icu_version{_Version.substr(0, _Version.find_last_of('.'))};
         return _STD move(_Icu_version) + "." + _STD to_string(_Num_leap_seconds);
     }
@@ -2717,8 +2716,8 @@ namespace chrono {
         tzdb_list& operator=(const tzdb_list&) = delete;
 
         tzdb_list() {
-            auto [_Icu_version, _Zones, _Links] = _Xtzdb_generate_time_zones();
-            auto [_Leap_sec, _All_ls_positive]  = _Xtzdb_generate_leap_seconds(0);
+            auto [_Icu_version, _Zones, _Links] = _Tzdb_generate_time_zones();
+            auto [_Leap_sec, _All_ls_positive]  = _Tzdb_generate_leap_seconds(0);
             auto _Version                       = _Icu_version + "." + _STD to_string(_Leap_sec.size());
             _Tzdb_list.emplace_front(tzdb{
                 _STD move(_Version), _STD move(_Zones), _STD move(_Links), _STD move(_Leap_sec), _All_ls_positive});
@@ -2760,7 +2759,7 @@ namespace chrono {
 
         const tzdb& _Reload() {
             _Unique_lock _Lk(_Tzdb_mutex);
-            auto [_Leap_sec, _All_ls_positive] = _Xtzdb_generate_leap_seconds(_Tzdb_list.front().leap_seconds.size());
+            auto [_Leap_sec, _All_ls_positive] = _Tzdb_generate_leap_seconds(_Tzdb_list.front().leap_seconds.size());
             if (!_Leap_sec.empty()) {
                 const auto& _Tzdb = _Tzdb_list.front();
                 vector<time_zone> _Zones;
@@ -2771,7 +2770,7 @@ namespace chrono {
                     _Tzdb.links.begin(), _Tzdb.links.end(), _STD back_inserter(_Links), [](const auto& _Link) {
                         return time_zone_link{_Link.name(), _Link.target()};
                     });
-                auto _Version = _Xtzdb_update_version(_Tzdb.version, _Leap_sec.size());
+                auto _Version = _Tzdb_update_version(_Tzdb.version, _Leap_sec.size());
                 _Tzdb_list.emplace_front(tzdb{
                     _STD move(_Version), _STD move(_Zones), _STD move(_Links), _STD move(_Leap_sec), _All_ls_positive});
             }
@@ -2879,8 +2878,8 @@ namespace chrono {
     _NODISCARD inline string remote_version() {
         const auto& _Tzdb                = _CHRONO get_tzdb();
         const auto& _Version             = _Tzdb.version;
-        const auto [_Leap_sec, _Ignored] = _Xtzdb_generate_leap_seconds(_Tzdb.leap_seconds.size());
-        return _Leap_sec.empty() ? _Version : _Xtzdb_update_version(_Version, _Leap_sec.size());
+        const auto [_Leap_sec, _Ignored] = _Tzdb_generate_leap_seconds(_Tzdb.leap_seconds.size());
+        return _Leap_sec.empty() ? _Version : _Tzdb_update_version(_Version, _Leap_sec.size());
     }
 
     // [time.zone.zonedtraits]

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -2658,7 +2658,7 @@ namespace chrono {
             {sys_seconds{seconds{1483228800}}, true, seconds{26}},
         };
 
-        // __std_tzdb_get_reg_leap_seconds gets leap second (LS) data from the registry, but only if it contains more
+        // __std_tzdb_get_leap_seconds gets leap second (LS) data from the registry, but only if it contains more
         // LSs than we already know about. The registry only contains LSs after 2018, so we need to tell it how many of
         // *those* we already know about. The *total* number of LSs known at this point is a combination of what the
         // caller knows (_Current_size, 0 on first call) and the _Known_leap_seconds entries.
@@ -2668,7 +2668,7 @@ namespace chrono {
 
         size_t _Reg_post_2018_ls_size; // number of post-2018 LSs found in the registry
         unique_ptr<__std_tzdb_leap_info[], _Tzdb_deleter<__std_tzdb_leap_info[]>> _Reg_ls_data{
-            __std_tzdb_get_reg_leap_seconds(_Known_post_2018_ls_size, &_Reg_post_2018_ls_size)};
+            __std_tzdb_get_leap_seconds(_Known_post_2018_ls_size, &_Reg_post_2018_ls_size)};
 
         if (_Reg_post_2018_ls_size > _Known_post_2018_ls_size && !_Reg_ls_data) {
             _Xbad_alloc(); // registry has new data, but failed to allocate storage

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -2667,7 +2667,7 @@ namespace chrono {
             (_STD max)(_Current_size, _STD size(_Known_leap_seconds)) - _Pre_2018_count;
 
         size_t _Reg_post_2018_ls_size; // number of post-2018 LSs found in the registry
-        unique_ptr<__std_tzdb_registry_leap_info[], _Tzdb_deleter<__std_tzdb_registry_leap_info[]>> _Reg_ls_data{
+        unique_ptr<__std_tzdb_leap_info[], _Tzdb_deleter<__std_tzdb_leap_info[]>> _Reg_ls_data{
             __std_tzdb_get_reg_leap_seconds(_Known_post_2018_ls_size, &_Reg_post_2018_ls_size)};
 
         if (_Reg_post_2018_ls_size > _Known_post_2018_ls_size && !_Reg_ls_data) {

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -2680,8 +2680,7 @@ namespace chrono {
 
         if (_New_size > _Current_size) {
             _Leap_sec_info.reserve(_New_size);
-            _Leap_sec_info.insert(
-                _Leap_sec_info.begin(), _STD cbegin(_Known_leap_seconds), _STD cend(_Known_leap_seconds));
+            _Leap_sec_info.assign(_STD cbegin(_Known_leap_seconds), _STD cend(_Known_leap_seconds));
 
             for (size_t _Idx = 0; _Idx < _Reg_post_2018_ls_size; ++_Idx) {
                 // Leap seconds occur at _Ls._Hour:59:59. We store the next second after, so we need to add an entire
@@ -2703,7 +2702,6 @@ namespace chrono {
         return _STD move(_Icu_version) + "." + _STD to_string(_Num_leap_seconds);
     }
 
-    // TRANSITION: work in progress
     // CLASS tzdb_list
     class tzdb_list {
     private:
@@ -2827,14 +2825,20 @@ namespace chrono {
         if (_Tzdb_ptr == nullptr) {
             auto _My_tzdb = static_cast<tzdb_list*>(__std_calloc_crt(1, sizeof(tzdb_list)));
             if (_My_tzdb == nullptr) {
-                _Xruntime_error("bad allocation");
+                _Xruntime_error("bad allocation"); // not bad_alloc, see N4878 [time.zone.db.access]/4
             }
 
-            try {
-                _STD construct_at(_My_tzdb);
-            } catch (const exception& _Except) {
-                _Xruntime_error(_Except.what());
-            }
+            _TRY_BEGIN
+            _STD construct_at(_My_tzdb);
+            _CATCH(const runtime_error&)
+            __std_free_crt(_My_tzdb);
+            _RERAISE;
+            _CATCH(const exception& _Except)
+#if _HAS_EXCEPTIONS
+            __std_free_crt(_My_tzdb);
+            _Xruntime_error(_Except.what());
+#endif // _HAS_EXCEPTIONS
+            _CATCH_END
 
             if (_Global_tzdb_list.compare_exchange_strong(_Tzdb_ptr, _My_tzdb)) {
                 _Tzdb_ptr = _My_tzdb;
@@ -2864,11 +2868,15 @@ namespace chrono {
 
     // FUNCTION reload_tzdb
     inline const tzdb& reload_tzdb() {
-        try {
-            return _CHRONO get_tzdb_list()._Reload();
-        } catch (const exception& _Except) {
-            _Xruntime_error(_Except.what());
-        }
+        _TRY_BEGIN
+        return _CHRONO get_tzdb_list()._Reload();
+        _CATCH(const runtime_error&)
+        _RERAISE;
+        _CATCH(const exception& _Except)
+#if _HAS_EXCEPTIONS
+        _Xruntime_error(_Except.what());
+#endif // _HAS_EXCEPTIONS
+        _CATCH_END
     }
 
     // FUNCTION remote_version
@@ -3166,7 +3174,7 @@ namespace chrono {
         template <class _Duration>
         _NODISCARD static sys_time<common_type_t<_Duration, seconds>> to_sys(const utc_time<_Duration>& _Utc_time) {
             using _CommonType = common_type_t<_Duration, seconds>;
-            const auto _Lsi{get_leap_second_info(_Utc_time)};
+            const auto _Lsi{_CHRONO get_leap_second_info(_Utc_time)};
             _CommonType _Ticks;
             if (_Lsi.is_leap_second) {
                 const auto _Leap_sec_minus_one = _CHRONO floor<seconds>(_Utc_time.time_since_epoch()) - _Lsi.elapsed;
@@ -3310,8 +3318,8 @@ namespace filesystem {
             const chrono::file_time<_Duration>& _File_time) {
             using namespace chrono;
             using _CommonType = common_type_t<_Duration, seconds>;
-            const auto _Ticks =
-                _File_time.time_since_epoch() - duration_cast<seconds>(duration{__std_fs_file_time_epoch_adjustment});
+            const auto _Ticks = _File_time.time_since_epoch()
+                              - _CHRONO duration_cast<seconds>(duration{__std_fs_file_time_epoch_adjustment});
 
             if (_Ticks < _Cutoff.time_since_epoch()) {
                 return utc_clock::from_sys(sys_time<_CommonType>{_Ticks});
@@ -3325,7 +3333,7 @@ namespace filesystem {
             const chrono::utc_time<_Duration>& _Utc_time) {
             using namespace chrono;
             file_time<common_type_t<_Duration, seconds>> _File_time{
-                duration_cast<seconds>(duration{__std_fs_file_time_epoch_adjustment})};
+                _CHRONO duration_cast<seconds>(duration{__std_fs_file_time_epoch_adjustment})};
 
             if (_Utc_time < utc_seconds{_Cutoff.time_since_epoch()} + _Skipped_filetime_leap_seconds) {
                 _File_time += utc_clock::to_sys(_Utc_time).time_since_epoch();

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -2925,8 +2925,10 @@ namespace chrono {
 
         explicit zoned_time(_TimeZonePtr _Tz) noexcept /* strengthened */ : _Zone{_STD move(_Tz)} {}
 
-        template <class _Traits2                                                                             = _Traits,
+        // clang-format off
+        template <class _Traits2 = _Traits,
             enable_if_t<is_constructible_v<zoned_time, decltype(_Traits2::locate_zone(string_view{}))>, int> = 0>
+        // clang-format on
         explicit zoned_time(string_view _Name) : _Zone{_Traits::locate_zone(_Name)} {}
 
         template <class _Duration2, enable_if_t<is_convertible_v<sys_time<_Duration2>, sys_time<_Duration>>, int> = 0>
@@ -2935,10 +2937,11 @@ namespace chrono {
 
         zoned_time(_TimeZonePtr _Tz, const sys_time<_Duration>& _Sys) : _Zone{_STD move(_Tz)}, _Tp{_Sys} {}
 
-        template <class _Traits2 = _Traits,
-            enable_if_t<is_constructible_v<zoned_time, decltype(_Traits2::locate_zone(string_view{})),
-                            const sys_time<_Duration>&>,
-                int>             = 0>
+        // clang-format off
+        template <class _Traits2 = _Traits, enable_if_t<is_constructible_v<
+            zoned_time, decltype(_Traits2::locate_zone(string_view{})), const sys_time<_Duration>&>,
+            int> = 0>
+        // clang-format on
         zoned_time(string_view _Name, type_identity_t<const sys_time<_Duration>&> _Sys)
             : zoned_time{_Traits::locate_zone(_Name), _Sys} {}
 
@@ -2949,10 +2952,11 @@ namespace chrono {
         zoned_time(_TimeZonePtr _Tz, const local_time<_Duration>& _Local)
             : _Zone{_STD move(_Tz)}, _Tp{_Zone->to_sys(_Local)} {}
 
-        template <class _Traits2 = _Traits,
-            enable_if_t<is_constructible_v<zoned_time, decltype(_Traits2::locate_zone(string_view{})),
-                            const local_time<_Duration>&>,
-                int>             = 0>
+        // clang-format off
+        template <class _Traits2 = _Traits, enable_if_t<is_constructible_v<
+            zoned_time, decltype(_Traits2::locate_zone(string_view{})), const local_time<_Duration>&>,
+            int> = 0>
+        // clang-format on
         zoned_time(string_view _Name, type_identity_t<const local_time<_Duration>>& _Local)
             : zoned_time{_Traits::locate_zone(_Name), _Local} {}
 
@@ -2964,10 +2968,11 @@ namespace chrono {
         zoned_time(_TimeZonePtr _Tz, const local_time<_Duration>& _Local, choose _Choose)
             : _Zone{_STD move(_Tz)}, _Tp{_Zone->to_sys(_Local, _Choose)} {}
 
-        template <class _Traits2 = _Traits,
-            enable_if_t<is_constructible_v<zoned_time, decltype(_Traits2::locate_zone(string_view{})),
-                            const local_time<_Duration>&, choose>,
-                int>             = 0>
+        // clang-format off
+        template <class _Traits2 = _Traits, enable_if_t<is_constructible_v<
+            zoned_time, decltype(_Traits2::locate_zone(string_view{})), const local_time<_Duration>&, choose>,
+            int> = 0>
+        // clang-format on
         zoned_time(string_view _Name, type_identity_t<const local_time<_Duration>&> _Local, choose _Choose)
             : zoned_time{_Traits::locate_zone(_Name), _Local, _Choose} {}
 

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -2727,23 +2727,26 @@ namespace chrono {
         }
 
         const_iterator erase_after(const_iterator _Where) noexcept /* strengthened */ {
+            _Unique_lock _Lk(_Tzdb_mutex);
             return _Tzdb_list.erase_after(_Where);
         }
 
         _NODISCARD const_iterator begin() const noexcept {
+            _Shared_lock _Lk(_Tzdb_mutex);
             return _Tzdb_list.begin();
         }
 
         _NODISCARD const_iterator end() const noexcept {
-            return _Tzdb_list.end();
+            return _Tzdb_list.end(); // no lock necessary for forward_list::end()
         }
 
         _NODISCARD const_iterator cbegin() const noexcept {
+            _Shared_lock _Lk(_Tzdb_mutex);
             return _Tzdb_list.cbegin();
         }
 
         _NODISCARD const_iterator cend() const noexcept {
-            return _Tzdb_list.cend();
+            return _Tzdb_list.cend(); // no lock necessary for forward_list::cend()
         }
 
         template <class... _ArgsTy>
@@ -2784,21 +2787,11 @@ namespace chrono {
             _Shared_lock(const _Shared_lock&) = delete;
             _Shared_lock& operator=(const _Shared_lock&) = delete;
 
-            void _Unlock() {
-                if (_Owns) {
-                    _Smtx_unlock_shared(_Mtx);
-                }
-                _Owns = false;
-            }
-
             ~_Shared_lock() {
-                if (_Owns) {
-                    _Smtx_unlock_shared(_Mtx);
-                }
+                _Smtx_unlock_shared(_Mtx);
             }
 
             _Smtx_t* _Mtx;
-            bool _Owns = true;
         };
 
         struct _NODISCARD _Unique_lock {

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -16,6 +16,7 @@
 #include <xtimec.h>
 
 #if _HAS_CXX20
+#include <__msvc_tzdb.hpp>
 #include <algorithm>
 #include <atomic>
 #include <cmath>
@@ -27,7 +28,6 @@
 #include <vector>
 #include <xloctime>
 #include <xthreads.h>
-#include <xtzdb.h>
 #endif // _HAS_CXX20
 
 #pragma pack(push, _CRT_PACKING)

--- a/stl/inc/header-units.json
+++ b/stl/inc/header-units.json
@@ -6,6 +6,7 @@
     "BuildAsHeaderUnits": [
         // "__msvc_all_public_headers.hpp", // for testing, not production
         "__msvc_system_error_abi.hpp",
+        "__msvc_tzdb.hpp",
         "algorithm",
         "any",
         "array",
@@ -143,7 +144,6 @@
         "xtimec.h",
         "xtr1common",
         "xtree",
-        "xtzdb.h",
         "xutility",
         "ymath.h",
         "yvals.h",

--- a/stl/inc/xtzdb.h
+++ b/stl/inc/xtzdb.h
@@ -76,7 +76,7 @@ _NODISCARD __std_tzdb_sys_info* __stdcall __std_tzdb_get_sys_info(
     const char* _Tz, size_t _Tz_len, __std_tzdb_epoch_milli _Local) noexcept;
 void __stdcall __std_tzdb_delete_sys_info(__std_tzdb_sys_info* _Info) noexcept;
 
-__std_tzdb_registry_leap_info* __stdcall __std_tzdb_get_reg_leap_seconds(
+_NODISCARD __std_tzdb_registry_leap_info* __stdcall __std_tzdb_get_reg_leap_seconds(
     size_t _Prev_reg_ls_size, size_t* _Current_reg_ls_size) noexcept;
 void __stdcall __std_tzdb_delete_reg_leap_seconds(__std_tzdb_registry_leap_info* _Rlsi) noexcept;
 

--- a/stl/src/msvcp_atomic_wait.src
+++ b/stl/src/msvcp_atomic_wait.src
@@ -30,11 +30,11 @@ EXPORTS
     __std_release_shared_mutex_for_instance
     __std_submit_threadpool_work
     __std_tzdb_delete_current_zone
-    __std_tzdb_delete_reg_leap_seconds
+    __std_tzdb_delete_leap_seconds
     __std_tzdb_delete_sys_info
     __std_tzdb_delete_time_zones
     __std_tzdb_get_current_zone
-    __std_tzdb_get_reg_leap_seconds
+    __std_tzdb_get_leap_seconds
     __std_tzdb_get_sys_info
     __std_tzdb_get_time_zones
     __std_wait_for_threadpool_work_callbacks

--- a/stl/src/syncstream.cpp
+++ b/stl/src/syncstream.cpp
@@ -3,13 +3,13 @@
 
 // initialize syncstream mutex map
 
+#include <__msvc_tzdb.hpp>
 #include <functional>
 #include <map>
 #include <mutex>
 #include <new>
 #include <shared_mutex>
 #include <utility>
-#include <xtzdb.h>
 
 #pragma warning(disable : 4074)
 #pragma init_seg(compiler)

--- a/stl/src/tzdb.cpp
+++ b/stl/src/tzdb.cpp
@@ -551,7 +551,7 @@ void __stdcall __std_tzdb_delete_sys_info(__std_tzdb_sys_info* const _Info) noex
     }
 }
 
-_NODISCARD __std_tzdb_registry_leap_info* __stdcall __std_tzdb_get_reg_leap_seconds(
+_NODISCARD __std_tzdb_leap_info* __stdcall __std_tzdb_get_reg_leap_seconds(
     const size_t prev_reg_ls_size, size_t* const current_reg_ls_size) noexcept {
     // On exit---
     //    *current_reg_ls_size <= prev_reg_ls_size, reg_ls_data == nullptr --> no new data
@@ -572,14 +572,14 @@ _NODISCARD __std_tzdb_registry_leap_info* __stdcall __std_tzdb_get_reg_leap_seco
 
     DWORD byte_size = 0;
     status          = RegQueryValueExW(leap_sec_key, reg_subkey_name, nullptr, nullptr, nullptr, &byte_size);
-    static_assert(sizeof(__std_tzdb_registry_leap_info) == 12);
+    static_assert(sizeof(__std_tzdb_leap_info) == 12);
     const auto ls_size   = byte_size / 12;
     *current_reg_ls_size = ls_size;
 
-    __std_tzdb_registry_leap_info* reg_ls_data = nullptr;
+    __std_tzdb_leap_info* reg_ls_data = nullptr;
     if ((status == ERROR_SUCCESS || status == ERROR_MORE_DATA) && ls_size > prev_reg_ls_size) {
         try {
-            reg_ls_data = new __std_tzdb_registry_leap_info[ls_size];
+            reg_ls_data = new __std_tzdb_leap_info[ls_size];
             status      = RegQueryValueExW(
                 leap_sec_key, reg_subkey_name, nullptr, nullptr, reinterpret_cast<LPBYTE>(reg_ls_data), &byte_size);
             if (status != ERROR_SUCCESS) {
@@ -597,8 +597,8 @@ _NODISCARD __std_tzdb_registry_leap_info* __stdcall __std_tzdb_get_reg_leap_seco
     return reg_ls_data;
 }
 
-void __stdcall __std_tzdb_delete_reg_leap_seconds(__std_tzdb_registry_leap_info* _Rlsi) noexcept {
-    delete[] _Rlsi;
+void __stdcall __std_tzdb_delete_reg_leap_seconds(__std_tzdb_leap_info* _Info) noexcept {
+    delete[] _Info;
 }
 
 _NODISCARD void* __stdcall __std_calloc_crt(const size_t count, const size_t size) noexcept {

--- a/stl/src/tzdb.cpp
+++ b/stl/src/tzdb.cpp
@@ -551,7 +551,7 @@ void __stdcall __std_tzdb_delete_sys_info(__std_tzdb_sys_info* const _Info) noex
     }
 }
 
-__std_tzdb_registry_leap_info* __stdcall __std_tzdb_get_reg_leap_seconds(
+_NODISCARD __std_tzdb_registry_leap_info* __stdcall __std_tzdb_get_reg_leap_seconds(
     const size_t prev_reg_ls_size, size_t* const current_reg_ls_size) noexcept {
     // On exit---
     //    *current_reg_ls_size <= prev_reg_ls_size, reg_ls_data == nullptr --> no new data

--- a/stl/src/tzdb.cpp
+++ b/stl/src/tzdb.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include <__msvc_tzdb.hpp>
 #include <atomic>
 #include <functional>
 #include <icu.h>
@@ -8,7 +9,6 @@
 #include <memory>
 #include <string_view>
 #include <xfilesystem_abi.h>
-#include <xtzdb.h>
 
 #include <Windows.h>
 

--- a/stl/src/tzdb.cpp
+++ b/stl/src/tzdb.cpp
@@ -551,7 +551,7 @@ void __stdcall __std_tzdb_delete_sys_info(__std_tzdb_sys_info* const _Info) noex
     }
 }
 
-_NODISCARD __std_tzdb_leap_info* __stdcall __std_tzdb_get_reg_leap_seconds(
+_NODISCARD __std_tzdb_leap_info* __stdcall __std_tzdb_get_leap_seconds(
     const size_t prev_reg_ls_size, size_t* const current_reg_ls_size) noexcept {
     // On exit---
     //    *current_reg_ls_size <= prev_reg_ls_size, reg_ls_data == nullptr --> no new data
@@ -597,7 +597,7 @@ _NODISCARD __std_tzdb_leap_info* __stdcall __std_tzdb_get_reg_leap_seconds(
     return reg_ls_data;
 }
 
-void __stdcall __std_tzdb_delete_reg_leap_seconds(__std_tzdb_leap_info* _Info) noexcept {
+void __stdcall __std_tzdb_delete_leap_seconds(__std_tzdb_leap_info* _Info) noexcept {
     delete[] _Info;
 }
 

--- a/tests/std/include/timezone_data.hpp
+++ b/tests/std/include/timezone_data.hpp
@@ -4,7 +4,6 @@
 #pragma once
 #include <cassert>
 #include <chrono>
-#include <string>
 #include <string_view>
 #include <utility>
 

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_clocks/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_clocks/test.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include <algorithm>
 #include <cassert>
 #include <chrono>
 #include <cmath>
@@ -92,7 +93,7 @@ static_assert(!is_clock_v<no_steady>, "no_steady is a clock");
 static_assert(!is_clock_v<no_now>, "no_now is a clock");
 
 void test_is_leap_second(const year_month_day& ymd) {
-    const auto ls            = sys_days{ymd};
+    const sys_days ls{ymd};
     const auto& leap_seconds = get_tzdb().leap_seconds;
     assert(find(leap_seconds.begin(), leap_seconds.end(), ls + days{1}) != leap_seconds.end());
     assert(get_leap_second_info(utc_clock::from_sys<seconds>(ls) + days{1}).is_leap_second);
@@ -383,7 +384,7 @@ tzdb copy_tzdb() {
     vector<time_zone> zones;
     vector<time_zone_link> links;
     transform(my_tzdb.zones.begin(), my_tzdb.zones.end(), back_inserter(zones),
-        [](const auto& _Tz) { return time_zone{_Tz.name()}; });
+        [](const auto& tz) { return time_zone{tz.name()}; });
     transform(my_tzdb.links.begin(), my_tzdb.links.end(), back_inserter(links), [](const auto& link) {
         return time_zone_link{link.name(), link.target()};
     });

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_io/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_io/test.cpp
@@ -21,7 +21,7 @@ bool test_duration_basic_out(const duration<Rep, Period>& d, const CharT* expect
     return ss.str() == expected;
 }
 
-#define WIDEN(TYPE, STR) get<const TYPE*>(make_pair(STR, L##STR));
+#define WIDEN(TYPE, STR) get<const TYPE*>(pair{STR, L##STR});
 
 template <class CharT>
 bool test_duration_locale_out() {

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_time_zones/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_time_zones/test.cpp
@@ -146,9 +146,9 @@ void timezone_names_test() {
         assert(false);
     }
 
-    // FIXME: add a link to an issue. These may change overtime and might have to be removed from tests.
+    // FIXME: add a link to an issue. These may change over time and might have to be removed from tests.
 
-    // these are some example in which the ICU.dll and IANA database diverge in what they consider a zone or a link
+    // these are some examples in which the ICU.dll and IANA database diverge in what they consider a zone or a link
     assert(_Locate_zone_impl(my_tzdb.links, "Atlantic/Faroe") != nullptr); // is a time_zone in IANA
     assert(_Locate_zone_impl(my_tzdb.zones, "Africa/Addis_Ababa") != nullptr); // is a time_zone_link in IANA
     assert(_Locate_zone_impl(my_tzdb.links, "PST") != nullptr); // time_zone_link does not exist in IANA

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_time_zones/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_time_zones/test.cpp
@@ -146,7 +146,7 @@ void timezone_names_test() {
         assert(false);
     }
 
-    // FIXME: add a link to an issue. These may change over time and might have to be removed from tests.
+    // See GH-1786. These may change over time and might have to be removed from this test.
 
     // these are some examples in which the ICU.dll and IANA database diverge in what they consider a zone or a link
     assert(_Locate_zone_impl(my_tzdb.links, "Atlantic/Faroe") != nullptr); // is a time_zone in IANA


### PR DESCRIPTION
`<chrono>`
---
* Change `insert()`-at-`begin()` to `assign()` which is strictly more efficient. This is for a freshly constructed `vector` where only `reserve()` has been called, and this isn't in a loop, so the behavior is unchanged. (Note that `assign()` preserves the reserved capacity when it's sufficient, which is the case here.)
* Remove `// TRANSITION: work in progress` from `tzdb_list` (which is complete AFAIK).
* Comment why `get_tzdb_list()` throws `runtime_error` instead of `bad_alloc` for allocation failure.
* Enhance `get_tzdb_list()`'s exception handling:
  + Use `_TRY_BEGIN` etc. to preserve our minimal support for `_HAS_EXCEPTIONS=0`. (We need to directly test `#if _HAS_EXCEPTIONS` when referring to `_Except`, because it won't be declared in `_HAS_EXCEPTIONS=0` mode.)
  + Add a case to rethrow `runtime_error` unchanged.
  + In both `runtime_error` and `exception` cases, we need to `__std_free_crt` in order to avoid leaking.
* Similarly, enhance `reload_tzdb()`'s EH.
* Add `_CHRONO` qualification to non-`_Ugly` function calls.
* Enhance `tzdb_list`'s locking. The Standardese talks about multithreading for specific functions or pairs of functions (WG21-N4885 [time.zone.db.list]/3, `front()` "is thread-safe with respect to `reload_tzdb()`", [time.zone.db.access]/2 `get_tzdb_list()` "It is safe to call this function from multiple threads at one time."), and the original implementation appeared to follow this strictly, but I propose to extend this by applying reader/writer locks to all member functions. (Note, for example, that if another thread is simultaneously reloading to `emplace_front` a new element, neither `front()` nor `begin()` can be called simultaneously. The Standard says that `front()` must be thread-safe in this scenario, so we took a `_Shared_lock`, but it's silent about `begin()` which really seems like a defect to me.
  + There are naturally some remaining restrictions (e.g. can't `erase_after()` while someone is iterating through), but this seems like a cheap way to prevent rare catastrophes.
  + `_Shared_lock` here is never manually `_Unlock()`ed, so we can drop that and its `bool _Owns` to be slightly more efficient.

`xtzdb.h`, `src/tzdb.cpp`
---
* Mark `__std_tzdb_get_reg_leap_seconds()` as `_NODISCARD` for consistency and because it allocates.

`tests/std/include/timezone_data.hpp`
---
* `<string>` appeared to be completely unused.

`P0355R7_calendars_and_time_zones_clocks/test.cpp`
---
* Include `<algorithm>` for `find()`.
* Directly construct `const sys_days ls{ymd};`, avoiding "Almost Always Auto".
* Rename ugly `_Tz` in test code.

`P0355R7_calendars_and_time_zones_io/test.cpp`
---
* As this is C++20, we can use `pair` CTAD instead of `make_pair()`, which is simpler (and slightly less debug codegen, not that it matters in test code).

`P0355R7_calendars_and_time_zones_time_zones/test.cpp`
---
* Fix comment typos.