### PR TITLE
<format>: Standard formatter specializations

### DIFF
--- a/stl/inc/format
+++ b/stl/inc/format
@@ -1933,7 +1933,8 @@ _FORMAT_SPECIALIZE_FOR(unsigned short, _Basic_format_arg_type::_UInt_type);
 _FORMAT_SPECIALIZE_FOR(long, _Basic_format_arg_type::_Int_type);
 _FORMAT_SPECIALIZE_FOR(unsigned long, _Basic_format_arg_type::_UInt_type);
 _FORMAT_SPECIALIZE_FOR(char, _Basic_format_arg_type::_Char_type);
-
+_FORMAT_SPECIALIZE_FOR(signed char, _Basic_format_arg_type::_Int_type);
+_FORMAT_SPECIALIZE_FOR(unsigned char, _Basic_format_arg_type::_UInt_type);
 #undef _FORMAT_SPECIALIZE_FOR
 
 // not using the macro because we'd like to avoid the formatter<wchar_t, char> specialization

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -845,7 +845,7 @@ private:
     _Dynamic_format_specs<_CharT>& _Dynamic_specs;
     _ParseContext& _Parse_ctx;
 
-    int _Verify_dynamic_arg_index_in_range(size_t _Idx) {
+    static int _Verify_dynamic_arg_index_in_range(size_t _Idx) {
         if (_Idx > static_cast<size_t>((numeric_limits<int>::max)())) {
             throw format_error("Dynamic width or precision index too large.");
         }
@@ -1934,11 +1934,13 @@ _FORMAT_SPECIALIZE_FOR(long, _Basic_format_arg_type::_Int_type);
 _FORMAT_SPECIALIZE_FOR(unsigned long, _Basic_format_arg_type::_UInt_type);
 _FORMAT_SPECIALIZE_FOR(char, _Basic_format_arg_type::_Char_type);
 
+#undef _FORMAT_SPECIALIZE_FOR
+
 // not using the macro because we'd like to avoid the formatter<wchar_t, char> specialization
 template <>
 struct formatter<wchar_t, wchar_t> : _Formatter_base<wchar_t, wchar_t, _Basic_format_arg_type::_Char_type> {};
 
-// We could use the macros for these specializations, but it's confusing to refer to symbols that are defined inside the
+// We could use the macro for these specializations, but it's confusing to refer to symbols that are defined inside the
 // macro in the macro's "call".
 template <_Format_supported_charT _CharT>
 struct formatter<_CharT*, _CharT> : _Formatter_base<_CharT*, _CharT, _Basic_format_arg_type::_CString_type> {};
@@ -1958,8 +1960,6 @@ struct formatter<basic_string<_CharT, _Traits, _Allocator>, _CharT>
 template <_Format_supported_charT _CharT, class _Traits>
 struct formatter<basic_string_view<_CharT, _Traits>, _CharT>
     : _Formatter_base<basic_string_view<_CharT, _Traits>, _CharT, _Basic_format_arg_type::_String_type> {};
-
-#undef _FORMAT_SPECIALIZE_FOR
 
 using format_context  = basic_format_context<back_insert_iterator<string>, string::value_type>;
 using wformat_context = basic_format_context<back_insert_iterator<wstring>, wstring::value_type>;

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -1880,15 +1880,13 @@ template <class _OutputIt, class _CharT>
 struct _Arg_formatter {
     using _Context = basic_format_context<_OutputIt, _CharT>;
 
-    _Context* _Ctx                                 = nullptr;
-    _Basic_format_specs<_CharT>* _Specs            = nullptr;
-    basic_format_parse_context<_CharT>* _Parse_ctx = nullptr;
+    _Context* _Ctx                      = nullptr;
+    _Basic_format_specs<_CharT>* _Specs = nullptr;
 
     _OutputIt operator()(typename basic_format_arg<_Context>::handle _Handle) {
-        _STL_ASSERT(false, "The custom handler should be structurally unreachable for _Arg_formatter");
+        _STL_VERIFY(false, "The custom handler should be structurally unreachable for _Arg_formatter");
         _STL_INTERNAL_CHECK(_Parse_ctx);
         _STL_INTERNAL_CHECK(_Ctx);
-        _Handle.format(*_Parse_ctx, *_Ctx);
         return _Ctx->out();
     }
 
@@ -1935,12 +1933,7 @@ struct _Format_handler {
             throw format_error("Missing '}' in format string.");
         }
         _Ctx.advance_to(_STD visit_format_arg(
-            _Arg_formatter<_OutputIt, _CharT>{
-                ._Ctx       = _STD addressof(_Ctx),
-                ._Specs     = _STD addressof(_Specs),
-                ._Parse_ctx = _STD addressof(_Parse_context),
-            },
-            _Arg));
+            _Arg_formatter<_OutputIt, _CharT>{._Ctx = _STD addressof(_Ctx), ._Specs = _STD addressof(_Specs)}, _Arg));
         return _Begin;
     }
 };
@@ -1983,7 +1976,10 @@ struct formatter<_Ty, _CharT> {
         if (_Specs._Dynamic_precision_index != -1) {
             _Specs._Precision = _Get_dynamic_specs<_Precision_checker>(_FormatCtx.arg(_Specs._Dynamic_precision_index));
         }
-        return visit_format_arg(_Arg_formatter<typename _FormatContext::iterator, _CharT>(_FormatCtx))
+        return visit_format_arg(
+            _Arg_formatter<typename _FormatContext::iterator, _CharT>{
+                ._Ctx = _STD addressof(_FormatCtx), ._Specs = _STD addressof(_Specs)},
+            basic_format_arg<_FormatContext>{_Val});
     }
 
 

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -1264,6 +1264,72 @@ constexpr size_t _Get_format_arg_type_storage_size(_Basic_format_arg_type _Type)
     }
 }
 
+template <class _Ty, class _CharT>
+constexpr _Basic_format_arg_type _Format_arg_storage_type_direct = _Basic_format_arg_type::_None;
+
+template <class _CharT>
+constexpr _Basic_format_arg_type _Format_arg_storage_type_direct<int, _CharT> = _Basic_format_arg_type::_Int_type;
+
+template <class _CharT>
+constexpr _Basic_format_arg_type _Format_arg_storage_type_direct<unsigned int, _CharT> =
+    _Basic_format_arg_type::_UInt_type;
+
+template <class _CharT>
+constexpr _Basic_format_arg_type _Format_arg_storage_type_direct<long long, _CharT> =
+    _Basic_format_arg_type::_Long_long_type;
+
+template <class _CharT>
+constexpr _Basic_format_arg_type _Format_arg_storage_type_direct<unsigned long long, _CharT> =
+    _Basic_format_arg_type::_ULong_long_type;
+
+template <class _CharT>
+constexpr _Basic_format_arg_type _Format_arg_storage_type_direct<bool, _CharT> = _Basic_format_arg_type::_Bool_type;
+
+template <class _CharT>
+constexpr _Basic_format_arg_type _Format_arg_storage_type_direct<_CharT, _CharT> = _Basic_format_arg_type::_Char_type;
+
+template <class _CharT>
+constexpr _Basic_format_arg_type _Format_arg_storage_type_direct<float, _CharT> = _Basic_format_arg_type::_Float_type;
+
+template <class _CharT>
+constexpr _Basic_format_arg_type _Format_arg_storage_type_direct<double, _CharT> = _Basic_format_arg_type::_Double_type;
+
+template <class _CharT>
+constexpr _Basic_format_arg_type _Format_arg_storage_type_direct<long double, _CharT> =
+    _Basic_format_arg_type::_Long_double_type;
+
+template <class _CharT>
+constexpr _Basic_format_arg_type _Format_arg_storage_type_direct<nullptr_t, _CharT> =
+    _Basic_format_arg_type::_Pointer_type;
+
+template <class _CharT>
+constexpr _Basic_format_arg_type _Format_arg_storage_type_direct<void*, _CharT> = _Basic_format_arg_type::_Pointer_type;
+
+template <class _CharT>
+constexpr _Basic_format_arg_type _Format_arg_storage_type_direct<const void*, _CharT> =
+    _Basic_format_arg_type::_Pointer_type;
+
+template <class _CharT>
+constexpr _Basic_format_arg_type _Format_arg_storage_type_direct<_CharT*, _CharT> =
+    _Basic_format_arg_type::_CString_type;
+
+template <class _CharT>
+constexpr _Basic_format_arg_type _Format_arg_storage_type_direct<const _CharT*, _CharT> =
+    _Basic_format_arg_type::_CString_type;
+
+template <class _CharT, size_t _Nty>
+constexpr _Basic_format_arg_type _Format_arg_storage_type_direct<const _CharT[_Nty], _CharT> =
+    _Basic_format_arg_type::_CString_type;
+
+template <class _CharT>
+constexpr _Basic_format_arg_type _Format_arg_storage_type_direct<basic_string_view<_CharT>, _CharT> =
+    _Basic_format_arg_type::_String_type;
+
+template <class _CharT>
+constexpr _Basic_format_arg_type _Format_arg_storage_type_direct<basic_string<_CharT>, _CharT> =
+    _Basic_format_arg_type::_String_type;
+
+
 template <class _CharT, class _OutputIt>
 _OutputIt _Write(_OutputIt _Out, monostate) {
     _STL_INTERNAL_CHECK(false);
@@ -1897,7 +1963,11 @@ struct formatter<_Ty, _CharT> {
     formatter() = default;
 
     template <class _ParseContext>
-    typename _ParseContext::iterator parse(_ParseContext& _ParseCtx) {}
+    typename _ParseContext::iterator parse(_ParseContext& _ParseCtx) {
+        auto _Type = _Format_arg_storage_type_direct<_Ty, _CharT>;
+        _Specs_checker<_Dynamic_specs_handler<_ParseContext>> _Handler(
+            _Dynamic_specs_handler<_ParseContext>(_Specs, _ParseCtx), _Type);
+    }
 
 private:
     _Dynamic_format_specs<_CharT> _Specs;

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -651,6 +651,15 @@ struct _Basic_format_specs {
     _CharT _Fill[4] = {' ', _CharT{0}, _CharT{0}, _CharT{0}};
 };
 
+// Adds width and precision references to _Basic_format_specs.
+// this is required for std::formatter implementations because we must
+// parse the format specs without having access to the format args (via a format context)
+template <class _CharT>
+struct _Dynamic_format_specs : _Basic_format_specs<_CharT> {
+    int _Dynamic_width_index     = -1;
+    int _Dynamic_precision_index = -1;
+};
+
 // Model of _Parse_specs_callbacks that fills a _Basic_format_specs with the parsed data.
 template <class _CharT>
 class _Specs_setter {
@@ -802,6 +811,37 @@ private:
         }
         return static_cast<int>(_Val);
     }
+};
+
+template <class _ParseContext>
+class _Dynamic_specs_handler : public _Specs_setter<typename _ParseContext::char_type> {
+public:
+    using _CharT = typename _ParseContext::char_type;
+
+    constexpr _Dynamic_specs_handler(_Dynamic_format_specs<_CharT>& _Specs_, _ParseContext& _Parse_ctx_)
+        : _Specs_setter<_CharT>(_Specs_), _Dynamic_specs(_Specs_), _Parse_ctx(_Parse_ctx_) {}
+
+    constexpr void _On_dynamic_width(size_t _Arg_id) {
+        _Parse_ctx.check_arg_id(_Arg_id);
+        _Dynamic_specs._Dynamic_width_index = _Arg_id;
+    }
+
+    constexpr void _On_dynamic_width(_Auto_id_tag) {
+        _Dynamic_specs._Dynamic_width_index = _Parse_ctx.next_arg_id();
+    }
+
+    constexpr void _On_dynamic_precision(size_t _Arg_id) {
+        _Parse_ctx.check_arg_id(_Arg_id);
+        _Dynamic_specs._Dynamic_precision_index = _Arg_id;
+    }
+
+    constexpr void _On_dynamic_precision(_Auto_id_tag) {
+        _Dynamic_specs._Dynamic_precision_index = _Parse_ctx.next_arg_id();
+    }
+
+private:
+    _Dynamic_format_specs<_CharT>& _Dynamic_specs;
+    _ParseContext& _Parse_ctx;
 };
 
 class _Numeric_specs_checker {
@@ -1846,6 +1886,21 @@ struct formatter {
     formatter()                 = delete;
     formatter(const formatter&) = delete;
     formatter operator=(const formatter&) = delete;
+};
+
+// clang-format off
+template <class _Ty, class _CharT>
+    requires _Is_any_of_v<_Ty, char, wchar_t>
+struct formatter<_Ty, _CharT> {
+    // clang-format on
+
+    formatter() = default;
+
+    template <class _ParseContext>
+    typename _ParseContext::iterator parse(_ParseContext& _ParseCtx) {}
+
+private:
+    _Dynamic_format_specs<_CharT> _Specs;
 };
 
 using format_context  = basic_format_context<back_insert_iterator<string>, string::value_type>;

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -765,6 +765,18 @@ public:
     }
 };
 
+// Fetch the value of an argument associated with a dynamic
+// width or precision specifier. This will be called with either
+// _Width_checker or _Precision_checker as "_Handler".
+template <class _Handler, class _FormatArg>
+static constexpr int _Get_dynamic_specs(_FormatArg _Arg) {
+    unsigned long long _Val = _STD visit_format_arg(_Handler(), _Arg);
+    if (_Val > (numeric_limits<int>::max)()) {
+        throw format_error("Number is too big.");
+    }
+    return static_cast<int>(_Val);
+}
+
 // Parses standard format specs into a _Basic_format_specs using _Specs_setter, and,
 // in addition handles dynamic width and precision. This is separate from _Specs setter
 // because it needs to know about the current basic_format_parse_context and basic_format_context
@@ -798,18 +810,6 @@ private:
     constexpr basic_format_arg<_Context> _Get_arg(size_t _Arg_id) {
         _Parse_ctx.check_arg_id(_Arg_id);
         return _STD _Get_arg(_Ctx, _Arg_id);
-    }
-
-    // Fetch the value of an argument associated with a dynamic
-    // width or precision specifier. This will be called with either
-    // _Width_checker or _Precision_checker as "_Handler".
-    template <class _Handler, class _FormatArg>
-    static constexpr int _Get_dynamic_specs(_FormatArg _Arg) {
-        unsigned long long _Val = _STD visit_format_arg(_Handler(), _Arg);
-        if (_Val > (numeric_limits<int>::max)()) {
-            throw format_error("Number is too big.");
-        }
-        return static_cast<int>(_Val);
     }
 };
 
@@ -1956,18 +1956,36 @@ struct formatter {
 
 // clang-format off
 template <class _Ty, class _CharT>
-    requires _Is_any_of_v<_Ty, char, wchar_t>
+    requires (_Format_arg_storage_type_direct<_Ty, _CharT> != _Basic_format_arg_type::_None)
 struct formatter<_Ty, _CharT> {
     // clang-format on
 
     formatter() = default;
 
-    template <class _ParseContext>
-    typename _ParseContext::iterator parse(_ParseContext& _ParseCtx) {
+    using _Pc = basic_format_parse_context<_CharT>;
+
+    _Pc::iterator parse(_Pc& _ParseCtx) {
         auto _Type = _Format_arg_storage_type_direct<_Ty, _CharT>;
         _Specs_checker<_Dynamic_specs_handler<_ParseContext>> _Handler(
             _Dynamic_specs_handler<_ParseContext>(_Specs, _ParseCtx), _Type);
+        auto _It = _Parse_format_specs(_ParseCtx.begin(), _ParseCtx.end(), _Handler);
+        if (_It == _ParseCtx.end() || *_It != '}') {
+            throw format_error("Mising '}' in format string.");
+        }
+        return _It;
     }
+
+    template <class _FormatContext>
+    typename _FormatContext::iterator format(const _Ty& _Val, _FormatContext& _FormatCtx) {
+        if (_Specs._Dynamic_width_index != -1) {
+            _Specs._Width = _Get_dynamic_specs<_Width_checker>(_FormatCtx.arg(_Specs._Dynamic_width_index));
+        }
+        if (_Specs._Dynamic_precision_index != -1) {
+            _Specs._Precision = _Get_dynamic_specs<_Precision_checker>(_FormatCtx.arg(_Specs._Dynamic_precision_index));
+        }
+        return visit_format_arg(_Arg_formatter<typename _FormatContext::iterator, _CharT>(_FormatCtx))
+    }
+
 
 private:
     _Dynamic_format_specs<_CharT> _Specs;

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -128,6 +128,12 @@ public:
     _NODISCARD constexpr const_iterator end() const noexcept {
         return _Format_string.end();
     }
+    _NODISCARD constexpr const _CharT* _Unchecked_begin() const noexcept {
+        return _Format_string._Unchecked_begin();
+    }
+    _NODISCARD constexpr const _CharT* _Unchecked_end() const noexcept {
+        return _Format_string._Unchecked_end();
+    }
     constexpr void advance_to(const const_iterator _It) {
         _Adl_verify_range(_It, _Format_string.end());
         // _It must be after _Format_string.begin().
@@ -845,7 +851,7 @@ private:
     _Dynamic_format_specs<_CharT>& _Dynamic_specs;
     _ParseContext& _Parse_ctx;
 
-    static int _Verify_dynamic_arg_index_in_range(const size_t _Idx) {
+    _NODISCARD constexpr static int _Verify_dynamic_arg_index_in_range(const size_t _Idx) {
         if (_Idx > static_cast<size_t>((numeric_limits<int>::max)())) {
             throw format_error("Dynamic width or precision index too large.");
         }
@@ -1879,17 +1885,15 @@ struct formatter {
 
 template <class _Ty, class _CharT, _Basic_format_arg_type _ArgType>
 struct _Formatter_base {
-
     using _Pc = basic_format_parse_context<_CharT>;
 
     typename _Pc::iterator parse(_Pc& _ParseCtx) {
         _Specs_checker<_Dynamic_specs_handler<_Pc>> _Handler(_Dynamic_specs_handler<_Pc>(_Specs, _ParseCtx), _ArgType);
-        auto _It = _ParseCtx.begin();
-        _It._Seek_to(_Parse_format_specs(_ParseCtx.begin()._Unwrapped(), _ParseCtx.end()._Unwrapped(), _Handler));
-        if (_It != _ParseCtx.end() && *_It != '}') {
+        auto _It = _Parse_format_specs(_ParseCtx._Unchecked_begin(), _ParseCtx._Unchecked_end(), _Handler);
+        if (_It != _ParseCtx._Unchecked_end() && *_It != '}') {
             throw format_error("Mising '}' in format string.");
         }
-        return _It;
+        return _ParseCtx.begin() + (_It - _ParseCtx._Unchecked_begin());
     }
 
     template <class _FormatContext>
@@ -1902,12 +1906,11 @@ struct _Formatter_base {
             _Specs._Precision = _Get_dynamic_specs<_Precision_checker>(
                 _FormatCtx.arg(static_cast<size_t>(_Specs._Dynamic_precision_index)));
         }
-        return visit_format_arg(
+        return _STD visit_format_arg(
             _Arg_formatter<typename _FormatContext::iterator, _CharT>{
                 ._Ctx = _STD addressof(_FormatCtx), ._Specs = _STD addressof(_Specs)},
             basic_format_arg<_FormatContext>{_Val});
     }
-
 
 private:
     _Dynamic_format_specs<_CharT> _Specs;

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -1889,7 +1889,7 @@ struct _Formatter_base {
 
     typename _Pc::iterator parse(_Pc& _ParseCtx) {
         _Specs_checker<_Dynamic_specs_handler<_Pc>> _Handler(_Dynamic_specs_handler<_Pc>(_Specs, _ParseCtx), _ArgType);
-        auto _It = _Parse_format_specs(_ParseCtx._Unchecked_begin(), _ParseCtx._Unchecked_end(), _Handler);
+        const auto _It = _Parse_format_specs(_ParseCtx._Unchecked_begin(), _ParseCtx._Unchecked_end(), _Handler);
         if (_It != _ParseCtx._Unchecked_end() && *_It != '}') {
             throw format_error("Mising '}' in format string.");
         }

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -779,6 +779,7 @@ public:
 // _Width_checker or _Precision_checker as "_Handler".
 template <class _Handler, class _FormatArg>
 _NODISCARD constexpr int _Get_dynamic_specs(const _FormatArg _Arg) {
+    _STL_INTERNAL_STATIC_ASSERT(_Is_any_of_v<_Handler, _Width_checker, _Precision_checker>);
     const unsigned long long _Val = _STD visit_format_arg(_Handler(), _Arg);
     if (_Val > (numeric_limits<int>::max)()) {
         throw format_error("Number is too big.");
@@ -1815,10 +1816,9 @@ struct _Arg_formatter {
     _Context* _Ctx                      = nullptr;
     _Basic_format_specs<_CharT>* _Specs = nullptr;
 
-    _OutputIt operator()(typename basic_format_arg<_Context>::handle _Handle) {
+    _OutputIt operator()(typename basic_format_arg<_Context>::handle) {
         _STL_VERIFY(false, "The custom handler should be structurally unreachable for _Arg_formatter");
         _STL_INTERNAL_CHECK(_Ctx);
-        (void) _Handle;
         return _Ctx->out();
     }
 

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -826,25 +826,31 @@ public:
 
     constexpr void _On_dynamic_width(size_t _Arg_id) {
         _Parse_ctx.check_arg_id(_Arg_id);
-        _Dynamic_specs._Dynamic_width_index = _Arg_id;
+        _Dynamic_specs._Dynamic_width_index = _Verify_dynamic_arg_index_in_range(_Arg_id);
     }
 
     constexpr void _On_dynamic_width(_Auto_id_tag) {
-        _Dynamic_specs._Dynamic_width_index = _Parse_ctx.next_arg_id();
+        _Dynamic_specs._Dynamic_width_index = _Verify_dynamic_arg_index_in_range(_Parse_ctx.next_arg_id());
     }
 
     constexpr void _On_dynamic_precision(size_t _Arg_id) {
         _Parse_ctx.check_arg_id(_Arg_id);
-        _Dynamic_specs._Dynamic_precision_index = _Arg_id;
+        _Dynamic_specs._Dynamic_precision_index = _Verify_dynamic_arg_index_in_range(_Arg_id);
     }
-
     constexpr void _On_dynamic_precision(_Auto_id_tag) {
-        _Dynamic_specs._Dynamic_precision_index = _Parse_ctx.next_arg_id();
+        _Dynamic_specs._Dynamic_precision_index = _Verify_dynamic_arg_index_in_range(_Parse_ctx.next_arg_id());
     }
 
 private:
     _Dynamic_format_specs<_CharT>& _Dynamic_specs;
     _ParseContext& _Parse_ctx;
+
+    int _Verify_dynamic_arg_index_in_range(size_t _Idx) {
+        if (_Idx > static_cast<size_t>((numeric_limits<int>::max)())) {
+            throw format_error("Dynamic width or precision index too large.");
+        }
+        return static_cast<int>(_Idx);
+    }
 };
 
 class _Numeric_specs_checker {
@@ -926,15 +932,7 @@ constexpr size_t _Get_format_arg_type_storage_size(_Basic_format_arg_type _Type)
 // clang-format off
 template <class _Context, class _Ty>
     requires _Has_formatter<_Context, _Ty>
-/* consteval */ constexpr auto _Get_format_arg_storage_type(const _Ty& _Val) noexcept {
-    // clang-format on
-    return typename basic_format_arg<_Context>::handle{_Val};
-}
-
-// clang-format off
-template <class _Context, class _Ty>
-    requires integral<_Ty> || floating_point<_Ty>
-/* consteval */ constexpr auto _Get_format_arg_storage_type(_Ty) noexcept {
+/* consteval */ constexpr auto _Get_format_arg_storage_type(const _Ty&) noexcept {
     // clang-format on
     using _Char_type = typename _Context::char_type;
     if constexpr (is_same_v<_Ty, monostate>) {
@@ -960,8 +958,7 @@ template <class _Context, class _Ty>
     } else if constexpr (is_same_v<_Ty, long double>) {
         return static_cast<long double>(42);
     } else {
-        static_assert(_Always_false<_Ty>, "Invalid type passed to _Get_format_arg_storage_type");
-        return static_cast<size_t>(-1);
+        return typename basic_format_arg<_Context>::handle{42};
     }
 }
 
@@ -1047,15 +1044,6 @@ private:
         requires _Has_formatter<_Context, _Ty>
     void _Store(const size_t _Arg_index, const _Ty& _Val) noexcept {
         // clang-format on
-        using _Handle_type = typename basic_format_arg<_Context>::handle;
-        _Store_impl<_Handle_type>(_Arg_index, _Basic_format_arg_type::_Custom_type, _Handle_type{_Val});
-    }
-
-    // clang-format off
-    template <class _Ty>
-        requires integral<_Ty> || floating_point<_Ty>
-    void _Store(const size_t _Arg_index, _Ty _Val) noexcept {
-        // clang-format on
         if constexpr (is_same_v<_Ty, bool>) {
             _Store_impl<bool>(_Arg_index, _Basic_format_arg_type::_Bool_type, _Val);
         } else if constexpr (is_same_v<_Ty, _CharType>) {
@@ -1078,7 +1066,8 @@ private:
         } else if constexpr (is_same_v<_Ty, long double>) {
             _Store_impl<long double>(_Arg_index, _Basic_format_arg_type::_Long_double_type, _Val);
         } else {
-            static_assert(_Always_false<_Ty>, "Invalid type passed to _Format_arg_store::_Store");
+            using _Handle_type = typename basic_format_arg<_Context>::handle;
+            _Store_impl<_Handle_type>(_Arg_index, _Basic_format_arg_type::_Custom_type, _Handle_type{_Val});
         }
     }
 
@@ -1266,73 +1255,6 @@ constexpr size_t _Get_format_arg_type_storage_size(_Basic_format_arg_type _Type)
         return 0;
     }
 }
-
-
-template <class _Ty, class _CharT>
-constexpr _Basic_format_arg_type _Format_arg_storage_type_direct = _Basic_format_arg_type::_None;
-
-template <class _CharT>
-constexpr _Basic_format_arg_type _Format_arg_storage_type_direct<int, _CharT> = _Basic_format_arg_type::_Int_type;
-
-template <class _CharT>
-constexpr _Basic_format_arg_type _Format_arg_storage_type_direct<unsigned int, _CharT> =
-    _Basic_format_arg_type::_UInt_type;
-
-template <class _CharT>
-constexpr _Basic_format_arg_type _Format_arg_storage_type_direct<long long, _CharT> =
-    _Basic_format_arg_type::_Long_long_type;
-
-template <class _CharT>
-constexpr _Basic_format_arg_type _Format_arg_storage_type_direct<unsigned long long, _CharT> =
-    _Basic_format_arg_type::_ULong_long_type;
-
-template <class _CharT>
-constexpr _Basic_format_arg_type _Format_arg_storage_type_direct<bool, _CharT> = _Basic_format_arg_type::_Bool_type;
-
-template <class _CharT>
-constexpr _Basic_format_arg_type _Format_arg_storage_type_direct<_CharT, _CharT> = _Basic_format_arg_type::_Char_type;
-
-template <class _CharT>
-constexpr _Basic_format_arg_type _Format_arg_storage_type_direct<float, _CharT> = _Basic_format_arg_type::_Float_type;
-
-template <class _CharT>
-constexpr _Basic_format_arg_type _Format_arg_storage_type_direct<double, _CharT> = _Basic_format_arg_type::_Double_type;
-
-template <class _CharT>
-constexpr _Basic_format_arg_type _Format_arg_storage_type_direct<long double, _CharT> =
-    _Basic_format_arg_type::_Long_double_type;
-
-template <class _CharT>
-constexpr _Basic_format_arg_type _Format_arg_storage_type_direct<nullptr_t, _CharT> =
-    _Basic_format_arg_type::_Pointer_type;
-
-template <class _CharT>
-constexpr _Basic_format_arg_type _Format_arg_storage_type_direct<void*, _CharT> = _Basic_format_arg_type::_Pointer_type;
-
-template <class _CharT>
-constexpr _Basic_format_arg_type _Format_arg_storage_type_direct<const void*, _CharT> =
-    _Basic_format_arg_type::_Pointer_type;
-
-template <class _CharT>
-constexpr _Basic_format_arg_type _Format_arg_storage_type_direct<_CharT*, _CharT> =
-    _Basic_format_arg_type::_CString_type;
-
-template <class _CharT>
-constexpr _Basic_format_arg_type _Format_arg_storage_type_direct<const _CharT*, _CharT> =
-    _Basic_format_arg_type::_CString_type;
-
-template <class _CharT, size_t _Nty>
-constexpr _Basic_format_arg_type _Format_arg_storage_type_direct<const _CharT[_Nty], _CharT> =
-    _Basic_format_arg_type::_CString_type;
-
-template <class _CharT>
-constexpr _Basic_format_arg_type _Format_arg_storage_type_direct<basic_string_view<_CharT>, _CharT> =
-    _Basic_format_arg_type::_String_type;
-
-template <class _CharT>
-constexpr _Basic_format_arg_type _Format_arg_storage_type_direct<basic_string<_CharT>, _CharT> =
-    _Basic_format_arg_type::_String_type;
-
 
 template <class _CharT, class _OutputIt>
 _OutputIt _Write(_OutputIt _Out, monostate) {
@@ -1928,6 +1850,10 @@ struct _Format_handler {
     const _CharT* _On_format_specs(size_t _Id, const _CharT* _Begin, const _CharT* _End) {
         _Parse_context.advance_to(_Parse_context.begin() + (_Begin - &*_Parse_context.begin()));
         auto _Arg = _Ctx.arg(_Id);
+        if (_Arg._Active_state == _Basic_format_arg_type::_Custom_type) {
+            _Arg._Custom_state.format(_Parse_context, _Ctx);
+            return _Parse_context.begin()._Unwrapped();
+        }
         _Basic_format_specs<_CharT> _Specs;
         _Specs_checker<_Specs_handler<basic_format_parse_context<_CharT>, _Context>> _Handler(
             _Specs_handler<basic_format_parse_context<_CharT>, _Context>(_Specs, _Parse_context, _Ctx),
@@ -1958,8 +1884,9 @@ struct _Formatter_base {
 
     typename _Pc::iterator parse(_Pc& _ParseCtx) {
         _Specs_checker<_Dynamic_specs_handler<_Pc>> _Handler(_Dynamic_specs_handler<_Pc>(_Specs, _ParseCtx), _ArgType);
-        auto _It = _Parse_format_specs(_ParseCtx.begin(), _ParseCtx.end(), _Handler);
-        if (_It == _ParseCtx.end() || *_It != '}') {
+        auto _It = _ParseCtx.begin();
+        _It._Seek_to(_Parse_format_specs(_ParseCtx.begin()._Unwrapped(), _ParseCtx.end()._Unwrapped(), _Handler));
+        if (_It != _ParseCtx.end() && *_It != '}') {
             throw format_error("Mising '}' in format string.");
         }
         return _It;
@@ -1967,11 +1894,13 @@ struct _Formatter_base {
 
     template <class _FormatContext>
     typename _FormatContext::iterator format(const _Ty& _Val, _FormatContext& _FormatCtx) {
-        if (_Specs._Dynamic_width_index != -1) {
-            _Specs._Width = _Get_dynamic_specs<_Width_checker>(_FormatCtx.arg(_Specs._Dynamic_width_index));
+        if (_Specs._Dynamic_width_index >= 0) {
+            _Specs._Width =
+                _Get_dynamic_specs<_Width_checker>(_FormatCtx.arg(static_cast<size_t>(_Specs._Dynamic_width_index)));
         }
-        if (_Specs._Dynamic_precision_index != -1) {
-            _Specs._Precision = _Get_dynamic_specs<_Precision_checker>(_FormatCtx.arg(_Specs._Dynamic_precision_index));
+        if (_Specs._Dynamic_precision_index >= 0) {
+            _Specs._Precision = _Get_dynamic_specs<_Precision_checker>(
+                _FormatCtx.arg(static_cast<size_t>(_Specs._Dynamic_precision_index)));
         }
         return visit_format_arg(
             _Arg_formatter<typename _FormatContext::iterator, _CharT>{
@@ -1984,8 +1913,53 @@ private:
     _Dynamic_format_specs<_CharT> _Specs;
 };
 
+#define _FORMAT_SPECIALIZE_FOR(_Type, _ArgType) \
+    template <_Format_supported_charT _CharT>   \
+    struct formatter<_Type, _CharT> : _Formatter_base<_Type, _CharT, _ArgType> {}
+
+_FORMAT_SPECIALIZE_FOR(int, _Basic_format_arg_type::_Int_type);
+_FORMAT_SPECIALIZE_FOR(unsigned int, _Basic_format_arg_type::_UInt_type);
+_FORMAT_SPECIALIZE_FOR(long long, _Basic_format_arg_type::_Long_long_type);
+_FORMAT_SPECIALIZE_FOR(unsigned long long, _Basic_format_arg_type::_ULong_long_type);
+_FORMAT_SPECIALIZE_FOR(bool, _Basic_format_arg_type::_Bool_type);
+_FORMAT_SPECIALIZE_FOR(float, _Basic_format_arg_type::_Float_type);
+_FORMAT_SPECIALIZE_FOR(double, _Basic_format_arg_type::_Double_type);
+_FORMAT_SPECIALIZE_FOR(long double, _Basic_format_arg_type::_Long_double_type);
+_FORMAT_SPECIALIZE_FOR(nullptr_t, _Basic_format_arg_type::_Pointer_type);
+_FORMAT_SPECIALIZE_FOR(void*, _Basic_format_arg_type::_Pointer_type);
+_FORMAT_SPECIALIZE_FOR(const void*, _Basic_format_arg_type::_Pointer_type);
+_FORMAT_SPECIALIZE_FOR(short, _Basic_format_arg_type::_Int_type);
+_FORMAT_SPECIALIZE_FOR(unsigned short, _Basic_format_arg_type::_UInt_type);
+_FORMAT_SPECIALIZE_FOR(long, _Basic_format_arg_type::_Int_type);
+_FORMAT_SPECIALIZE_FOR(unsigned long, _Basic_format_arg_type::_UInt_type);
+_FORMAT_SPECIALIZE_FOR(char, _Basic_format_arg_type::_Char_type);
+
+// not using the macro because we'd like to avoid the formatter<wchar_t, char> specialization
+template <>
+struct formatter<wchar_t, wchar_t> : _Formatter_base<wchar_t, wchar_t, _Basic_format_arg_type::_Char_type> {};
+
+// We could use the macros for these specializations, but it's confusing to refer to symbols that are defined inside the
+// macro in the macro's "call".
 template <_Format_supported_charT _CharT>
-struct formatter<int, _CharT> : _Formatter_base<int, _CharT, _Basic_format_arg_type::_Int_type> {};
+struct formatter<_CharT*, _CharT> : _Formatter_base<_CharT*, _CharT, _Basic_format_arg_type::_CString_type> {};
+
+template <_Format_supported_charT _CharT>
+struct formatter<const _CharT*, _CharT>
+    : _Formatter_base<const _CharT*, _CharT, _Basic_format_arg_type::_CString_type> {};
+
+template <_Format_supported_charT _CharT, size_t _Nty>
+struct formatter<const _CharT[_Nty], _CharT>
+    : _Formatter_base<const _CharT[_Nty], _CharT, _Basic_format_arg_type::_CString_type> {};
+
+template <_Format_supported_charT _CharT, class _Traits, class _Allocator>
+struct formatter<basic_string<_CharT, _Traits, _Allocator>, _CharT>
+    : _Formatter_base<basic_string<_CharT, _Traits, _Allocator>, _CharT, _Basic_format_arg_type::_String_type> {};
+
+template <_Format_supported_charT _CharT, class _Traits>
+struct formatter<basic_string_view<_CharT, _Traits>, _CharT>
+    : _Formatter_base<basic_string_view<_CharT, _Traits>, _CharT, _Basic_format_arg_type::_String_type> {};
+
+#undef _FORMAT_SPECIALIZE_FOR
 
 using format_context  = basic_format_context<back_insert_iterator<string>, string::value_type>;
 using wformat_context = basic_format_context<back_insert_iterator<wstring>, wstring::value_type>;

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -100,6 +100,9 @@ concept _Parse_replacement_field_callbacks = requires(_Ty _At, const _CharT* _Be
 template <class _Ty, class _CharT>
 concept _CharT_or_bool = same_as<_Ty, _CharT> || same_as<_Ty, bool>;
 
+template <class _CharT>
+concept _Format_supported_charT = _Is_any_of_v<_CharT, char, wchar_t>;
+
 // clang-format on
 
 template <class _Ty, class _CharT = char>
@@ -1264,6 +1267,7 @@ constexpr size_t _Get_format_arg_type_storage_size(_Basic_format_arg_type _Type)
     }
 }
 
+
 template <class _Ty, class _CharT>
 constexpr _Basic_format_arg_type _Format_arg_storage_type_direct = _Basic_format_arg_type::_None;
 
@@ -1885,8 +1889,8 @@ struct _Arg_formatter {
 
     _OutputIt operator()(typename basic_format_arg<_Context>::handle _Handle) {
         _STL_VERIFY(false, "The custom handler should be structurally unreachable for _Arg_formatter");
-        _STL_INTERNAL_CHECK(_Parse_ctx);
         _STL_INTERNAL_CHECK(_Ctx);
+        (void) _Handle;
         return _Ctx->out();
     }
 
@@ -1947,20 +1951,13 @@ struct formatter {
     formatter operator=(const formatter&) = delete;
 };
 
-// clang-format off
-template <class _Ty, class _CharT>
-    requires (_Format_arg_storage_type_direct<_Ty, _CharT> != _Basic_format_arg_type::_None)
-struct formatter<_Ty, _CharT> {
-    // clang-format on
-
-    formatter() = default;
+template <class _Ty, class _CharT, _Basic_format_arg_type _ArgType>
+struct _Formatter_base {
 
     using _Pc = basic_format_parse_context<_CharT>;
 
-    _Pc::iterator parse(_Pc& _ParseCtx) {
-        auto _Type = _Format_arg_storage_type_direct<_Ty, _CharT>;
-        _Specs_checker<_Dynamic_specs_handler<_ParseContext>> _Handler(
-            _Dynamic_specs_handler<_ParseContext>(_Specs, _ParseCtx), _Type);
+    typename _Pc::iterator parse(_Pc& _ParseCtx) {
+        _Specs_checker<_Dynamic_specs_handler<_Pc>> _Handler(_Dynamic_specs_handler<_Pc>(_Specs, _ParseCtx), _ArgType);
         auto _It = _Parse_format_specs(_ParseCtx.begin(), _ParseCtx.end(), _Handler);
         if (_It == _ParseCtx.end() || *_It != '}') {
             throw format_error("Mising '}' in format string.");
@@ -1986,6 +1983,9 @@ struct formatter<_Ty, _CharT> {
 private:
     _Dynamic_format_specs<_CharT> _Specs;
 };
+
+template <_Format_supported_charT _CharT>
+struct formatter<int, _CharT> : _Formatter_base<int, _CharT, _Basic_format_arg_type::_Int_type> {};
 
 using format_context  = basic_format_context<back_insert_iterator<string>, string::value_type>;
 using wformat_context = basic_format_context<back_insert_iterator<wstring>, wstring::value_type>;

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -831,20 +831,20 @@ public:
     constexpr _Dynamic_specs_handler(_Dynamic_format_specs<_CharT>& _Specs_, _ParseContext& _Parse_ctx_)
         : _Specs_setter<_CharT>(_Specs_), _Dynamic_specs(_Specs_), _Parse_ctx(_Parse_ctx_) {}
 
-    constexpr void _On_dynamic_width(size_t _Arg_id) {
+    constexpr void _On_dynamic_width(const size_t _Arg_id) {
         _Parse_ctx.check_arg_id(_Arg_id);
         _Dynamic_specs._Dynamic_width_index = _Verify_dynamic_arg_index_in_range(_Arg_id);
     }
 
-    constexpr void _On_dynamic_width(_Auto_id_tag) {
+    constexpr void _On_dynamic_width(const _Auto_id_tag) {
         _Dynamic_specs._Dynamic_width_index = _Verify_dynamic_arg_index_in_range(_Parse_ctx.next_arg_id());
     }
 
-    constexpr void _On_dynamic_precision(size_t _Arg_id) {
+    constexpr void _On_dynamic_precision(const size_t _Arg_id) {
         _Parse_ctx.check_arg_id(_Arg_id);
         _Dynamic_specs._Dynamic_precision_index = _Verify_dynamic_arg_index_in_range(_Arg_id);
     }
-    constexpr void _On_dynamic_precision(_Auto_id_tag) {
+    constexpr void _On_dynamic_precision(const _Auto_id_tag) {
         _Dynamic_specs._Dynamic_precision_index = _Verify_dynamic_arg_index_in_range(_Parse_ctx.next_arg_id());
     }
 

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -851,7 +851,7 @@ private:
     _Dynamic_format_specs<_CharT>& _Dynamic_specs;
     _ParseContext& _Parse_ctx;
 
-    _NODISCARD constexpr static int _Verify_dynamic_arg_index_in_range(const size_t _Idx) {
+    _NODISCARD static constexpr int _Verify_dynamic_arg_index_in_range(const size_t _Idx) {
         if (_Idx > static_cast<size_t>((numeric_limits<int>::max)())) {
             throw format_error("Dynamic width or precision index too large.");
         }

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -772,8 +772,8 @@ public:
 // width or precision specifier. This will be called with either
 // _Width_checker or _Precision_checker as "_Handler".
 template <class _Handler, class _FormatArg>
-static constexpr int _Get_dynamic_specs(_FormatArg _Arg) {
-    unsigned long long _Val = _STD visit_format_arg(_Handler(), _Arg);
+_NODISCARD constexpr int _Get_dynamic_specs(const _FormatArg _Arg) {
+    const unsigned long long _Val = _STD visit_format_arg(_Handler(), _Arg);
     if (_Val > (numeric_limits<int>::max)()) {
         throw format_error("Number is too big.");
     }
@@ -793,12 +793,12 @@ public:
         : _Specs_setter<_CharT>(_Specs_), _Parse_ctx(_Parse_ctx_), _Ctx(_Ctx_) {}
 
     template <class _Id>
-    constexpr void _On_dynamic_width(_Id _Arg_id) {
+    constexpr void _On_dynamic_width(const _Id _Arg_id) {
         this->_Specs._Width = _Get_dynamic_specs<_Width_checker>(_Get_arg(_Arg_id));
     }
 
     template <class _Id>
-    constexpr void _On_dynamic_precision(_Id _Arg_id) {
+    constexpr void _On_dynamic_precision(const _Id _Arg_id) {
         this->_Specs._Precision = _Get_dynamic_specs<_Precision_checker>(_Get_arg(_Arg_id));
     }
 
@@ -810,7 +810,7 @@ private:
         return _STD _Get_arg(_Ctx, _Parse_ctx.next_arg_id());
     }
 
-    constexpr basic_format_arg<_Context> _Get_arg(size_t _Arg_id) {
+    constexpr basic_format_arg<_Context> _Get_arg(const size_t _Arg_id) {
         _Parse_ctx.check_arg_id(_Arg_id);
         return _STD _Get_arg(_Ctx, _Arg_id);
     }
@@ -845,7 +845,7 @@ private:
     _Dynamic_format_specs<_CharT>& _Dynamic_specs;
     _ParseContext& _Parse_ctx;
 
-    static int _Verify_dynamic_arg_index_in_range(size_t _Idx) {
+    static int _Verify_dynamic_arg_index_in_range(const size_t _Idx) {
         if (_Idx > static_cast<size_t>((numeric_limits<int>::max)())) {
             throw format_error("Dynamic width or precision index too large.");
         }
@@ -1935,6 +1935,7 @@ _FORMAT_SPECIALIZE_FOR(unsigned long, _Basic_format_arg_type::_UInt_type);
 _FORMAT_SPECIALIZE_FOR(char, _Basic_format_arg_type::_Char_type);
 _FORMAT_SPECIALIZE_FOR(signed char, _Basic_format_arg_type::_Int_type);
 _FORMAT_SPECIALIZE_FOR(unsigned char, _Basic_format_arg_type::_UInt_type);
+
 #undef _FORMAT_SPECIALIZE_FOR
 
 // not using the macro because we'd like to avoid the formatter<wchar_t, char> specialization

--- a/tests/std/tests/P0645R10_text_formatting_args/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_args/test.cpp
@@ -31,16 +31,6 @@ constexpr auto get_input_sv() {
     }
 }
 
-class context {
-public:
-    using char_type = char;
-};
-
-class wcontext {
-public:
-    using char_type = wchar_t;
-};
-
 enum class Arg_type : uint8_t {
     none,
     int_type,
@@ -160,19 +150,11 @@ void test_format_arg_store() {
     test_empty_format_arg<Context>();
 
     test_single_format_arg<Context, char, Arg_type::char_type>(42);
-    if constexpr (is_same_v<char_type, char>) {
-        test_single_format_arg<Context, wchar_t, Arg_type::unsigned_type>(42);
-    } else {
+    if constexpr (is_same_v<char_type, wchar_t>) {
         test_single_format_arg<Context, wchar_t, Arg_type::char_type>(42);
     }
     test_single_format_arg<Context, unsigned char, Arg_type::unsigned_type>(42);
     test_single_format_arg<Context, signed char, Arg_type::int_type>(42);
-#ifdef __cpp_char8_t
-    test_single_format_arg<Context, char8_t, Arg_type::unsigned_type>(42);
-#endif // __cpp_char8_t
-    test_single_format_arg<Context, char16_t, Arg_type::unsigned_type>(42);
-    test_single_format_arg<Context, char32_t, Arg_type::unsigned_type>(42);
-
     test_single_format_arg<Context, int, Arg_type::int_type>(42);
     test_single_format_arg<Context, long, Arg_type::int_type>(42);
     test_single_format_arg<Context, int8_t, Arg_type::int_type>(42);
@@ -232,8 +214,8 @@ void test_format_arg_store() {
 }
 
 int main() {
-    test_basic_format_arg<context>();
-    test_basic_format_arg<wcontext>();
-    test_format_arg_store<context>();
-    test_format_arg_store<wcontext>();
+    test_basic_format_arg<format_context>();
+    test_basic_format_arg<wformat_context>();
+    test_format_arg_store<format_context>();
+    test_format_arg_store<wformat_context>();
 }

--- a/tests/std/tests/P0645R10_text_formatting_custom_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_custom_formatting/test.cpp
@@ -9,34 +9,56 @@
 #include <type_traits>
 using namespace std;
 
-struct custom_formattable_type {
-    string_view string_content;
-};
+// copied from the string_view tests
+template <typename CharT>
+struct choose_literal; // not defined
 
-struct custom_int_formattable_type {
-    int value;
+template <>
+struct choose_literal<char> {
+    static constexpr const char* choose(const char* s, const wchar_t*) {
+        return s;
+    }
 };
 
 template <>
-struct std::formatter<custom_formattable_type, char> {
+struct choose_literal<wchar_t> {
+    static constexpr const wchar_t* choose(const char*, const wchar_t* s) {
+        return s;
+    }
+};
+
+#define TYPED_LITERAL(CharT, Literal) (choose_literal<CharT>::choose(Literal, L##Literal))
+#define STR(Str)                      TYPED_LITERAL(charT, Str)
+
+struct basic_custom_formattable_type {
+    string_view string_content;
+};
+
+template <>
+struct std::formatter<basic_custom_formattable_type, char> {
     basic_format_parse_context<char>::iterator parse(basic_format_parse_context<char>& parse_ctx) {
         if (parse_ctx.begin() != parse_ctx.end()) {
             throw format_error{"only empty specs please"};
         }
         return parse_ctx.end();
     }
-    format_context::iterator format(const custom_formattable_type& val, format_context& ctx) {
+    format_context::iterator format(const basic_custom_formattable_type& val, format_context& ctx) {
         ctx.advance_to(copy(val.string_content.begin(), val.string_content.end(), ctx.out()));
         return ctx.out();
     }
 };
 
-template <>
-struct std::formatter<custom_int_formattable_type> : std::formatter<int> {
-    template <class FormatContext>
-    auto format(const custom_int_formattable_type& val, FormatContext& ctx) {
-        return std::formatter<int>::format(val.value, ctx);
-    }
+template <class T>
+struct custom_formattable_type {
+    T val;
+};
+
+template <class T, class charT>
+struct std::formatter<custom_formattable_type<T>, charT> : std::formatter<T, charT> {
+    template <class FC>
+    auto format(const custom_formattable_type<T>& val, FC& format_ctx) {
+        return std::formatter<T, charT>::format(val.val, format_ctx);
+    };
 };
 
 constexpr void test_disabled_formatter_is_disabled() {
@@ -49,8 +71,78 @@ constexpr void test_disabled_formatter_is_disabled() {
     static_assert(!is_move_assignable_v<F>);
 }
 
+template <class T, class charT>
+void test_custom_equiv_with_format(const charT* fmt_string, T&& val) {
+    assert(format(fmt_string, custom_formattable_type<T>{forward<T>(val)}) == format(fmt_string, val));
+}
+
+template <class T, class charT>
+void test_custom_equiv_with_format_mixed(const charT* fmt_string, T&& val) {
+    assert(format(fmt_string, custom_formattable_type<T>{forward<T>(val)}, val) == format(fmt_string, val, val));
+}
+
+template <class T, class charT>
+void test_numeric_custom_formattable_type() {
+    test_custom_equiv_with_format<T>(STR("{}"), 0);
+    test_custom_equiv_with_format<T>(STR("{}"), 42);
+    test_custom_equiv_with_format<T>(STR("{:+}"), 0);
+    test_custom_equiv_with_format<T>(STR("{}"), numeric_limits<T>::min());
+    test_custom_equiv_with_format<T>(STR("{}"), numeric_limits<T>::max());
+    test_custom_equiv_with_format<T>(STR("{:3}"), 1);
+    if constexpr (!is_floating_point_v<T> && !_Is_any_of_v<T, charT, bool>) {
+        test_custom_equiv_with_format<T>(STR("{:#x}"), 255);
+        test_custom_equiv_with_format<T>(STR("{:#X}"), 255);
+    }
+}
+
+template <class T, class charT>
+void test_numeric_mixed_args_custom_formattable_type() {
+    test_custom_equiv_with_format_mixed<T>(STR("{}{}"), 0);
+    test_custom_equiv_with_format_mixed<T>(STR("{1}{0}"), 42);
+    test_custom_equiv_with_format_mixed<T>(STR("{:+}{:-}"), 0);
+    test_custom_equiv_with_format_mixed<T>(STR("{}{}"), numeric_limits<T>::min());
+    test_custom_equiv_with_format_mixed<T>(STR("{}{}"), numeric_limits<T>::max());
+    test_custom_equiv_with_format_mixed<T>(STR("{:3}{:4}"), 1);
+    test_custom_equiv_with_format_mixed<T>(STR("{0}{0}"), 42);
+    if constexpr (!is_floating_point_v<T> && !_Is_any_of_v<T, charT, bool>) {
+        test_custom_equiv_with_format_mixed<T>(STR("{:#x}{}"), 255);
+        test_custom_equiv_with_format_mixed<T>(STR("{:#X}{}"), 255);
+    }
+}
+
+template <class charT>
+void test_custom_formattable_type() {
+    test_numeric_custom_formattable_type<int, charT>();
+    test_numeric_custom_formattable_type<long long, charT>();
+    test_numeric_custom_formattable_type<unsigned int, charT>();
+    test_numeric_custom_formattable_type<unsigned long long, charT>();
+    test_numeric_custom_formattable_type<short, charT>();
+#ifdef _NATIVE_WCHAR_T_DEFINED
+    test_numeric_custom_formattable_type<unsigned short, charT>();
+#endif
+    test_numeric_custom_formattable_type<float, charT>();
+    test_numeric_custom_formattable_type<double, charT>();
+}
+
+template <class charT>
+void test_mixed_custom_formattable_type() {
+    test_numeric_mixed_args_custom_formattable_type<int, charT>();
+    test_numeric_mixed_args_custom_formattable_type<long long, charT>();
+    test_numeric_mixed_args_custom_formattable_type<unsigned int, charT>();
+    test_numeric_mixed_args_custom_formattable_type<unsigned long long, charT>();
+    test_numeric_mixed_args_custom_formattable_type<short, charT>();
+#ifdef _NATIVE_WCHAR_T_DEFINED
+    test_numeric_mixed_args_custom_formattable_type<unsigned short, charT>();
+#endif
+    test_numeric_mixed_args_custom_formattable_type<float, charT>();
+    test_numeric_mixed_args_custom_formattable_type<double, charT>();
+}
+
 int main() {
-    assert(format("{}", custom_formattable_type{"f"}) == "f"s);
-    assert(format("{:+}", 0) == format("{:+}", custom_int_formattable_type{0}));
+    assert(format("{}", basic_custom_formattable_type{"f"}) == "f"s);
+    test_custom_formattable_type<char>();
+    test_custom_formattable_type<wchar_t>();
+    test_mixed_custom_formattable_type<char>();
+    test_mixed_custom_formattable_type<wchar_t>();
     return 0;
 }

--- a/tests/std/tests/P0645R10_text_formatting_custom_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_custom_formatting/test.cpp
@@ -58,7 +58,7 @@ struct std::formatter<custom_formattable_type<T>, charT> : std::formatter<T, cha
     template <class FC>
     auto format(const custom_formattable_type<T>& val, FC& format_ctx) {
         return std::formatter<T, charT>::format(val.val, format_ctx);
-    };
+    }
 };
 
 constexpr void test_disabled_formatter_is_disabled() {
@@ -72,13 +72,13 @@ constexpr void test_disabled_formatter_is_disabled() {
 }
 
 template <class T, class charT>
-void test_custom_equiv_with_format(const charT* fmt_string, T&& val) {
-    assert(format(fmt_string, custom_formattable_type<T>{forward<T>(val)}) == format(fmt_string, val));
+void test_custom_equiv_with_format(const charT* fmt_string, const T& val) {
+    assert(format(fmt_string, custom_formattable_type<T>{val}) == format(fmt_string, val));
 }
 
 template <class T, class charT>
-void test_custom_equiv_with_format_mixed(const charT* fmt_string, T&& val) {
-    assert(format(fmt_string, custom_formattable_type<T>{forward<T>(val)}, val) == format(fmt_string, val, val));
+void test_custom_equiv_with_format_mixed(const charT* fmt_string, const T& val) {
+    assert(format(fmt_string, custom_formattable_type<T>{val}, val) == format(fmt_string, val, val));
 }
 
 template <class T, class charT>

--- a/tests/std/tests/P0645R10_text_formatting_custom_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_custom_formatting/test.cpp
@@ -13,6 +13,10 @@ struct custom_formattable_type {
     string_view string_content;
 };
 
+struct custom_int_formattable_type {
+    int value;
+};
+
 template <>
 struct std::formatter<custom_formattable_type, char> {
     basic_format_parse_context<char>::iterator parse(basic_format_parse_context<char>& parse_ctx) {
@@ -27,8 +31,17 @@ struct std::formatter<custom_formattable_type, char> {
     }
 };
 
+template <>
+struct std::formatter<custom_int_formattable_type> : std::formatter<int> {
+    template <class FormatContext>
+    auto format(const custom_int_formattable_type& val, FormatContext& ctx) {
+        return std::formatter<int>::format(val.value, ctx);
+    }
+};
+
 constexpr void test_disabled_formatter_is_disabled() {
     using F = formatter<void, void>;
+
     static_assert(!is_default_constructible_v<F>);
     static_assert(!is_copy_constructible_v<F>);
     static_assert(!is_move_constructible_v<F>);
@@ -38,5 +51,6 @@ constexpr void test_disabled_formatter_is_disabled() {
 
 int main() {
     assert(format("{}", custom_formattable_type{"f"}) == "f"s);
+    assert(format("{:+}", 0) == format("{:+}", custom_int_formattable_type{0}));
     return 0;
 }


### PR DESCRIPTION
* adds standard formatter specializations
* changes how `_Get_format_arg_storage_type` and `_Store` work to more closely reflect the standard
* adds _Dynamic_format_specs and _Dynamic_specs_handler to store the arg index of dynamic width and precision since we can't fetch the referenced arg directly when we're formatting using a formatter specialization
* some minimal testing, I'm still thinking of what the best testing approach would be here.