### PR TITLE
Improve coroutine_handle visualization with intrinsics

### DIFF
--- a/stl/debugger/STL.natvis
+++ b/stl/debugger/STL.natvis
@@ -1599,7 +1599,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
     </Expand>
   </Type>
 
-  <!-- Visualizer for standard coroutines (/std:c++20) -->
+  <!-- Visualizer for standard coroutines (/std:c++20, /await:strict) -->
   <Type Name="std::coroutine_handle&lt;*&gt;" IncludeView="ViewPromise">
     <Expand>
       <Item Name="Promise">*reinterpret_cast&lt;$T1 *&gt;(reinterpret_cast&lt;char*&gt;(_Ptr) + 2*sizeof(void*))</Item>
@@ -1607,8 +1607,20 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
   </Type>
 
   <Type Name="std::coroutine_handle&lt;*&gt;">
-    <DisplayString Condition="*reinterpret_cast&lt;void(__cdecl**)(void*)&gt;(_Ptr) != nullptr">{*reinterpret_cast&lt;void(__cdecl**)(void*)&gt;(_Ptr),na}</DisplayString>
-    <DisplayString Condition="*reinterpret_cast&lt;void(__cdecl**)(void*)&gt;(_Ptr) == nullptr">{*(reinterpret_cast&lt;void(__cdecl**)(void*)&gt;(_Ptr) + 1),na}</DisplayString>
+    <Intrinsic Name="suspend_point" SourceId="FA88A41F-A641-47C8-8373-4889B7564FCF" LanguageId="3A12D0B7-C26C-11D0-B442-00A0244A1DD2" Id="1" ReturnType="int">
+        <Parameter Type="void*" />
+    </Intrinsic>
+    <Intrinsic Name="suspend_point_line" SourceId="FA88A41F-A641-47C8-8373-4889B7564FCF" LanguageId="3A12D0B7-C26C-11D0-B442-00A0244A1DD2" Id="2" ReturnType="unsigned int">
+        <Parameter Type="void*" />
+    </Intrinsic>
+    <Intrinsic Name="primary_function" SourceId="FA88A41F-A641-47C8-8373-4889B7564FCF" LanguageId="3A12D0B7-C26C-11D0-B442-00A0244A1DD2" Id="3" ReturnType="void*">
+        <Parameter Type="void*" />
+    </Intrinsic>
+    <DisplayString Condition="_Ptr == nullptr">empty</DisplayString>
+    <DisplayString Condition="_Ptr != nullptr &amp;&amp; suspend_point(_Ptr) &lt; 1">{primary_function(_Ptr),na} #final suspend</DisplayString>
+    <DisplayString Condition="_Ptr != nullptr &amp;&amp; suspend_point(_Ptr) == 1">{primary_function(_Ptr),na} #initial suspend</DisplayString>
+    <DisplayString Condition="_Ptr != nullptr &amp;&amp; suspend_point(_Ptr) &gt; 1 &amp;&amp; suspend_point_line(_Ptr) == 0">{primary_function(_Ptr),na} #suspend point {suspend_point(_Ptr)}</DisplayString>
+    <DisplayString Condition="_Ptr != nullptr &amp;&amp; suspend_point(_Ptr) &gt; 1 &amp;&amp; suspend_point_line(_Ptr) != 0">{primary_function(_Ptr),na} #suspend point {suspend_point(_Ptr)}, line {suspend_point_line(_Ptr)}</DisplayString>
     <Expand>
       <ExpandedItem>this,view(ViewPromise)</ExpandedItem>
     </Expand>


### PR DESCRIPTION
This improves the visualization of `std::coroutine_handle`. These are
implemented by native visualization code and will require an updated
Visual Studio to work. All take the frame pointer `_Ptr` as an argument.

 * `primary_function` returns the address of the user coroutine function.
 This is used in the display name of the `coroutine_handle` to indicate
 with which coroutine it is associated instead of the compiler-generated
 resume function.
 * `suspend_point` returns the suspend point index at which the coroutine
 is currently suspended. The natvis rules will display friendly names
 for the special suspend points for initial (1) and final (0, -1) suspend.
 * `suspend_point_line` returns the line number of the current suspend
 point. This requires additional debugging info in the .PDB which is
 not present in the initial compiler releases with standard coroutine
 support. The natvis rules will omit the line number if it's not available.

<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
