### PR TITLE
<format>: Add format_to_n and formatted_size

### DIFF
--- a/stl/inc/format
+++ b/stl/inc/format
@@ -1998,7 +1998,7 @@ auto make_wformat_args(const _Args&... _Vals) {
 template <class _Out, class _CharT>
 using format_args_t = basic_format_args<basic_format_context<_Out, _CharT>>;
 
-template <class _OutputIt>
+template <output_iterator<const char&> _OutputIt>
 _OutputIt vformat_to(_OutputIt _Out, string_view _Fmt, format_args_t<type_identity_t<_OutputIt>, char> _Args) {
     _Format_handler<_OutputIt, char, basic_format_context<_OutputIt, char>> _Handler(
         _Out, _Fmt, _Args, locale::classic());
@@ -2006,7 +2006,7 @@ _OutputIt vformat_to(_OutputIt _Out, string_view _Fmt, format_args_t<type_identi
     return _Handler._Ctx.out();
 }
 
-template <class _OutputIt>
+template <output_iterator<const wchar_t&> _OutputIt>
 _OutputIt vformat_to(_OutputIt _Out, wstring_view _Fmt, format_args_t<type_identity_t<_OutputIt>, wchar_t> _Args) {
     _Format_handler<_OutputIt, wchar_t, basic_format_context<_OutputIt, wchar_t>> _Handler(
         _Out, _Fmt, _Args, locale::classic());
@@ -2014,7 +2014,7 @@ _OutputIt vformat_to(_OutputIt _Out, wstring_view _Fmt, format_args_t<type_ident
     return _Handler._Ctx.out();
 }
 
-template <class _OutputIt>
+template <output_iterator<const char&> _OutputIt>
 _OutputIt vformat_to(
     _OutputIt _Out, const locale& _Loc, string_view _Fmt, format_args_t<type_identity_t<_OutputIt>, char> _Args) {
     _Format_handler<_OutputIt, char, basic_format_context<_OutputIt, char>> _Handler(_Out, _Fmt, _Args, _Loc);
@@ -2022,7 +2022,7 @@ _OutputIt vformat_to(
     return _Handler._Ctx.out();
 }
 
-template <class _OutputIt>
+template <output_iterator<const wchar_t&> _OutputIt>
 _OutputIt vformat_to(
     _OutputIt _Out, const locale& _Loc, wstring_view _Fmt, format_args_t<type_identity_t<_OutputIt>, wchar_t> _Args) {
     _Format_handler<_OutputIt, wchar_t, basic_format_context<_OutputIt, wchar_t>> _Handler(_Out, _Fmt, _Args, _Loc);
@@ -2113,51 +2113,50 @@ struct format_to_n_result {
     iter_difference_t<_OutputIt> size;
 };
 
-template <class _OutputIt, class... _Types>
+template <output_iterator<const char&> _OutputIt, class... _Types>
 format_to_n_result<_OutputIt> format_to_n(
-    _OutputIt _Out, iter_difference_t<_OutputIt> _Max, string_view _Fmt, const _Types&... _Args) {
-    _Format_to_n_iterator<_OutputIt, char> _It{._Out = _Out, ._Max = _Max};
+    _OutputIt _Out, const iter_difference_t<_OutputIt> _Max, const string_view _Fmt, const _Types&... _Args) {
+    _Format_to_n_iterator<_OutputIt, char> _It{._Out = _STD move(_Out), ._Max = _Max};
 
     using _Context  = basic_format_context<decltype(_It), char>;
     auto _Arg_store = _Format_arg_store<_Context, _Types...>{_Args...};
-    _It             = _STD vformat_to(_It, _Fmt, _STD move(_Arg_store));
-    return {.out = _It._Out, .size = _It._Count};
+    _It             = _STD vformat_to(_STD move(_It), _Fmt, _STD move(_Arg_store));
+    return {.out = _STD move(_It._Out), .size = _It._Count};
 }
 
-template <class _OutputIt, class... _Types>
+template <output_iterator<const wchar_t&> _OutputIt, class... _Types>
 format_to_n_result<_OutputIt> format_to_n(
-    _OutputIt _Out, iter_difference_t<_OutputIt> _Max, wstring_view _Fmt, const _Types&... _Args) {
-    _Format_to_n_iterator<_OutputIt, wchar_t> _It{._Out = _Out, ._Max = _Max};
+    _OutputIt _Out, const iter_difference_t<_OutputIt> _Max, const wstring_view _Fmt, const _Types&... _Args) {
+    _Format_to_n_iterator<_OutputIt, wchar_t> _It{._Out = _STD move(_Out), ._Max = _Max};
 
     using _Context  = basic_format_context<decltype(_It), wchar_t>;
     auto _Arg_store = _Format_arg_store<_Context, _Types...>{_Args...};
-    _It             = _STD vformat_to(_It, _Fmt, _STD move(_Arg_store));
-    return {.out = _It._Out, .size = _It._Count};
+    _It             = _STD vformat_to(_STD move(_It), _Fmt, _STD move(_Arg_store));
+    return {.out = _STD move(_It._Out), .size = _It._Count};
 }
 
-template <class _OutputIt, class... _Types>
-format_to_n_result<_OutputIt> format_to_n(
-    _OutputIt _Out, iter_difference_t<_OutputIt> _Max, const locale& _Loc, string_view _Fmt, const _Types&... _Args) {
-    _Format_to_n_iterator<_OutputIt, char> _It{._Out = _Out, ._Max = _Max};
+template <output_iterator<const char&> _OutputIt, class... _Types>
+format_to_n_result<_OutputIt> format_to_n(_OutputIt _Out, const iter_difference_t<_OutputIt> _Max, const locale& _Loc,
+    const string_view _Fmt, const _Types&... _Args) {
+    _Format_to_n_iterator<_OutputIt, char> _It{._Out = _STD move(_Out), ._Max = _Max};
 
     using _Context  = basic_format_context<decltype(_It), char>;
     auto _Arg_store = _Format_arg_store<_Context, _Types...>{_Args...};
-    _It             = _STD vformat_to(_It, _Loc, _Fmt, _STD move(_Arg_store));
-    return {.out = _It._Out, .size = _It._Count};
+    _It             = _STD vformat_to(_STD move(_It), _Loc, _Fmt, _STD move(_Arg_store));
+    return {.out = _STD move(_It._Out), .size = _It._Count};
 }
 
-template <class _OutputIt, class... _Types>
-format_to_n_result<_OutputIt> format_to_n(
-    _OutputIt _Out, iter_difference_t<_OutputIt> _Max, const locale& _Loc, wstring_view _Fmt, const _Types&... _Args) {
-    _Format_to_n_iterator<_OutputIt, wchar_t> _It{._Out = _Out, ._Max = _Max};
+template <output_iterator<const wchar_t&> _OutputIt, class... _Types>
+format_to_n_result<_OutputIt> format_to_n(_OutputIt _Out, const iter_difference_t<_OutputIt> _Max, const locale& _Loc,
+    const wstring_view _Fmt, const _Types&... _Args) {
+    _Format_to_n_iterator<_OutputIt, wchar_t> _It{._Out = _STD move(_Out), ._Max = _Max};
 
     using _Context  = basic_format_context<decltype(_It), wchar_t>;
     auto _Arg_store = _Format_arg_store<_Context, _Types...>{_Args...};
-    _It             = _STD vformat_to(_It, _Loc, _Fmt, _STD move(_Arg_store));
-    return {.out = _It._Out, .size = _It._Count};
+    _It             = _STD vformat_to(_STD move(_It), _Loc, _Fmt, _STD move(_Arg_store));
+    return {.out = _STD move(_It._Out), .size = _It._Count};
 }
 
-template <class _CharT>
 struct _Counting_iterator {
     size_t _Count = 0;
 
@@ -2167,6 +2166,7 @@ struct _Counting_iterator {
     using pointer           = void;
     using reference         = void;
 
+    template <class _CharT>
     _Counting_iterator& operator=(_CharT) {
         ++_Count;
         return *this;
@@ -2186,31 +2186,31 @@ struct _Counting_iterator {
 };
 
 template <class... _Types>
-size_t formatted_size(string_view _Fmt, const _Types&... _Args) {
-    using _Context  = basic_format_context<_Counting_iterator<char>, char>;
+size_t formatted_size(const string_view _Fmt, const _Types&... _Args) {
+    using _Context  = basic_format_context<_Counting_iterator, char>;
     auto _Arg_store = _Format_arg_store<_Context, _Types...>{_Args...};
-    return _STD vformat_to(_Counting_iterator<char>{}, _Fmt, _STD move(_Arg_store))._Count;
+    return _STD vformat_to(_Counting_iterator{}, _Fmt, _STD move(_Arg_store))._Count;
 }
 
 template <class... _Types>
-size_t formatted_size(wstring_view _Fmt, const _Types&... _Args) {
-    using _Context  = basic_format_context<_Counting_iterator<wchar_t>, wchar_t>;
+size_t formatted_size(const wstring_view _Fmt, const _Types&... _Args) {
+    using _Context  = basic_format_context<_Counting_iterator, wchar_t>;
     auto _Arg_store = _Format_arg_store<_Context, _Types...>{_Args...};
-    return _STD vformat_to(_Counting_iterator<wchar_t>{}, _Fmt, _STD move(_Arg_store))._Count;
+    return _STD vformat_to(_Counting_iterator{}, _Fmt, _STD move(_Arg_store))._Count;
 }
 
 template <class... _Types>
-size_t formatted_size(const locale& _Loc, string_view _Fmt, const _Types&... _Args) {
-    using _Context  = basic_format_context<_Counting_iterator<char>, char>;
+size_t formatted_size(const locale& _Loc, const string_view _Fmt, const _Types&... _Args) {
+    using _Context  = basic_format_context<_Counting_iterator, char>;
     auto _Arg_store = _Format_arg_store<_Context, _Types...>{_Args...};
-    return _STD vformat_to(_Counting_iterator<char>{}, _Loc, _Fmt, _STD move(_Arg_store))._Count;
+    return _STD vformat_to(_Counting_iterator{}, _Loc, _Fmt, _STD move(_Arg_store))._Count;
 }
 
 template <class... _Types>
-size_t formatted_size(const locale& _Loc, wstring_view _Fmt, const _Types&... _Args) {
-    using _Context  = basic_format_context<_Counting_iterator<wchar_t>, wchar_t>;
+size_t formatted_size(const locale& _Loc, const wstring_view _Fmt, const _Types&... _Args) {
+    using _Context  = basic_format_context<_Counting_iterator, wchar_t>;
     auto _Arg_store = _Format_arg_store<_Context, _Types...>{_Args...};
-    return _STD vformat_to(_Counting_iterator<wchar_t>{}, _Loc, _Fmt, _STD move(_Arg_store))._Count;
+    return _STD vformat_to(_Counting_iterator{}, _Loc, _Fmt, _STD move(_Arg_store))._Count;
 }
 
 _STD_END

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -1356,21 +1356,21 @@ _NODISCARD constexpr string_view _Get_integral_prefix(const char _Type, const _I
 template <class _OutputIt>
 _OutputIt _Write_sign(_OutputIt _Out, const _Sign _Sgn, const bool _Is_negative) {
     if (_Is_negative) {
-        *_Out = '-';
+        *_Out++ = '-';
     } else {
         switch (_Sgn) {
         case _Sign::_Plus:
-            *_Out = '+';
+            *_Out++ = '+';
             break;
         case _Sign::_Space:
-            *_Out = ' ';
+            *_Out++ = ' ';
             break;
         case _Sign::_None:
         case _Sign::_Minus:
             break;
         }
     }
-    return ++_Out;
+    return _Out;
 }
 
 inline void _Buffer_to_uppercase(char* _Begin, const char* _End) {
@@ -2072,6 +2072,145 @@ string format(const locale& _Loc, string_view _Fmt, const _Types&... _Args) {
 template <class... _Types>
 wstring format(const locale& _Loc, wstring_view _Fmt, const _Types&... _Args) {
     return _STD vformat(_Loc, _Fmt, _STD make_wformat_args(_Args...));
+}
+
+template <class _OutputIt, class _CharT>
+struct _Format_to_n_iterator {
+    _OutputIt _Out;
+    iter_difference_t<_OutputIt> _Max;
+    iter_difference_t<_OutputIt> _Count = 0;
+
+    using iterator_category = output_iterator_tag;
+    using value_type        = void;
+    using difference_type   = iter_difference_t<_OutputIt>;
+    using pointer           = void;
+    using reference         = void;
+
+    _Format_to_n_iterator& operator=(_CharT _Ch) {
+        if (_Count < _Max) {
+            *_Out++ = _Ch;
+        }
+        ++_Count;
+        return *this;
+    }
+
+    _Format_to_n_iterator& operator*() {
+        return *this;
+    }
+
+    _Format_to_n_iterator& operator++() {
+        return *this;
+    }
+
+    _Format_to_n_iterator& operator++(int) {
+        return *this;
+    }
+};
+
+template <class _OutputIt>
+struct format_to_n_result {
+    _OutputIt out;
+    iter_difference_t<_OutputIt> size;
+};
+
+template <class _OutputIt, class... _Types>
+format_to_n_result<_OutputIt> format_to_n(
+    _OutputIt _Out, iter_difference_t<_OutputIt> _Max, string_view _Fmt, const _Types&... _Args) {
+    _Format_to_n_iterator<_OutputIt, char> _It{._Out = _Out, ._Max = _Max};
+
+    using _Context  = basic_format_context<decltype(_It), char>;
+    auto _Arg_store = _Format_arg_store<_Context, _Types...>{_Args...};
+    _It             = _STD vformat_to(_It, _Fmt, _STD move(_Arg_store));
+    return {.out = _It._Out, .size = _It._Count};
+}
+
+template <class _OutputIt, class... _Types>
+format_to_n_result<_OutputIt> format_to_n(
+    _OutputIt _Out, iter_difference_t<_OutputIt> _Max, wstring_view _Fmt, const _Types&... _Args) {
+    _Format_to_n_iterator<_OutputIt, wchar_t> _It{._Out = _Out, ._Max = _Max};
+
+    using _Context  = basic_format_context<decltype(_It), wchar_t>;
+    auto _Arg_store = _Format_arg_store<_Context, _Types...>{_Args...};
+    _It             = _STD vformat_to(_It, _Fmt, _STD move(_Arg_store));
+    return {.out = _It._Out, .size = _It._Count};
+}
+
+template <class _OutputIt, class... _Types>
+format_to_n_result<_OutputIt> format_to_n(
+    _OutputIt _Out, iter_difference_t<_OutputIt> _Max, const locale& _Loc, string_view _Fmt, const _Types&... _Args) {
+    _Format_to_n_iterator<_OutputIt, char> _It{._Out = _Out, ._Max = _Max};
+
+    using _Context  = basic_format_context<decltype(_It), char>;
+    auto _Arg_store = _Format_arg_store<_Context, _Types...>{_Args...};
+    _It             = _STD vformat_to(_It, _Loc, _Fmt, _STD move(_Arg_store));
+    return {.out = _It._Out, .size = _It._Count};
+}
+
+template <class _OutputIt, class... _Types>
+format_to_n_result<_OutputIt> format_to_n(
+    _OutputIt _Out, iter_difference_t<_OutputIt> _Max, const locale& _Loc, wstring_view _Fmt, const _Types&... _Args) {
+    _Format_to_n_iterator<_OutputIt, wchar_t> _It{._Out = _Out, ._Max = _Max};
+
+    using _Context  = basic_format_context<decltype(_It), wchar_t>;
+    auto _Arg_store = _Format_arg_store<_Context, _Types...>{_Args...};
+    _It             = _STD vformat_to(_It, _Loc, _Fmt, _STD move(_Arg_store));
+    return {.out = _It._Out, .size = _It._Count};
+}
+
+template <class _CharT>
+struct _Counting_iterator {
+    size_t _Count = 0;
+
+    using iterator_category = output_iterator_tag;
+    using value_type        = void;
+    using difference_type   = ptrdiff_t;
+    using pointer           = void;
+    using reference         = void;
+
+    _Counting_iterator& operator=(_CharT) {
+        ++_Count;
+        return *this;
+    }
+
+    _Counting_iterator& operator*() {
+        return *this;
+    }
+
+    _Counting_iterator& operator++() {
+        return *this;
+    }
+
+    _Counting_iterator& operator++(int) {
+        return *this;
+    }
+};
+
+template <class... _Types>
+size_t formatted_size(string_view _Fmt, const _Types&... _Args) {
+    using _Context  = basic_format_context<_Counting_iterator<char>, char>;
+    auto _Arg_store = _Format_arg_store<_Context, _Types...>{_Args...};
+    return _STD vformat_to(_Counting_iterator<char>{}, _Fmt, _STD move(_Arg_store))._Count;
+}
+
+template <class... _Types>
+size_t formatted_size(wstring_view _Fmt, const _Types&... _Args) {
+    using _Context  = basic_format_context<_Counting_iterator<wchar_t>, wchar_t>;
+    auto _Arg_store = _Format_arg_store<_Context, _Types...>{_Args...};
+    return _STD vformat_to(_Counting_iterator<wchar_t>{}, _Fmt, _STD move(_Arg_store))._Count;
+}
+
+template <class... _Types>
+size_t formatted_size(const locale& _Loc, string_view _Fmt, const _Types&... _Args) {
+    using _Context  = basic_format_context<_Counting_iterator<char>, char>;
+    auto _Arg_store = _Format_arg_store<_Context, _Types...>{_Args...};
+    return _STD vformat_to(_Counting_iterator<char>{}, _Loc, _Fmt, _STD move(_Arg_store))._Count;
+}
+
+template <class... _Types>
+size_t formatted_size(const locale& _Loc, wstring_view _Fmt, const _Types&... _Args) {
+    using _Context  = basic_format_context<_Counting_iterator<wchar_t>, wchar_t>;
+    auto _Arg_store = _Format_arg_store<_Context, _Types...>{_Args...};
+    return _STD vformat_to(_Counting_iterator<wchar_t>{}, _Loc, _Fmt, _STD move(_Arg_store))._Count;
 }
 
 _STD_END

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -2080,11 +2080,7 @@ struct _Format_to_n_iterator {
     iter_difference_t<_OutputIt> _Max;
     iter_difference_t<_OutputIt> _Count = 0;
 
-    using iterator_category = output_iterator_tag;
-    using value_type        = void;
-    using difference_type   = iter_difference_t<_OutputIt>;
-    using pointer           = void;
-    using reference         = void;
+    using difference_type = iter_difference_t<_OutputIt>;
 
     _Format_to_n_iterator& operator=(_CharT _Ch) {
         if (_Count < _Max) {
@@ -2119,7 +2115,7 @@ format_to_n_result<_OutputIt> format_to_n(
     _Format_to_n_iterator<_OutputIt, char> _It{._Out = _STD move(_Out), ._Max = _Max};
 
     using _Context  = basic_format_context<decltype(_It), char>;
-    auto _Arg_store = _Format_arg_store<_Context, _Types...>{_Args...};
+    auto _Arg_store = _STD make_format_args<_Context>(_Args...);
     _It             = _STD vformat_to(_STD move(_It), _Fmt, _STD move(_Arg_store));
     return {.out = _STD move(_It._Out), .size = _It._Count};
 }
@@ -2130,7 +2126,7 @@ format_to_n_result<_OutputIt> format_to_n(
     _Format_to_n_iterator<_OutputIt, wchar_t> _It{._Out = _STD move(_Out), ._Max = _Max};
 
     using _Context  = basic_format_context<decltype(_It), wchar_t>;
-    auto _Arg_store = _Format_arg_store<_Context, _Types...>{_Args...};
+    auto _Arg_store = _STD make_format_args<_Context>(_Args...);
     _It             = _STD vformat_to(_STD move(_It), _Fmt, _STD move(_Arg_store));
     return {.out = _STD move(_It._Out), .size = _It._Count};
 }
@@ -2141,7 +2137,7 @@ format_to_n_result<_OutputIt> format_to_n(_OutputIt _Out, const iter_difference_
     _Format_to_n_iterator<_OutputIt, char> _It{._Out = _STD move(_Out), ._Max = _Max};
 
     using _Context  = basic_format_context<decltype(_It), char>;
-    auto _Arg_store = _Format_arg_store<_Context, _Types...>{_Args...};
+    auto _Arg_store = _STD make_format_args<_Context>(_Args...);
     _It             = _STD vformat_to(_STD move(_It), _Loc, _Fmt, _STD move(_Arg_store));
     return {.out = _STD move(_It._Out), .size = _It._Count};
 }
@@ -2152,7 +2148,7 @@ format_to_n_result<_OutputIt> format_to_n(_OutputIt _Out, const iter_difference_
     _Format_to_n_iterator<_OutputIt, wchar_t> _It{._Out = _STD move(_Out), ._Max = _Max};
 
     using _Context  = basic_format_context<decltype(_It), wchar_t>;
-    auto _Arg_store = _Format_arg_store<_Context, _Types...>{_Args...};
+    auto _Arg_store = _STD make_format_args<_Context>(_Args...);
     _It             = _STD vformat_to(_STD move(_It), _Loc, _Fmt, _STD move(_Arg_store));
     return {.out = _STD move(_It._Out), .size = _It._Count};
 }
@@ -2160,11 +2156,7 @@ format_to_n_result<_OutputIt> format_to_n(_OutputIt _Out, const iter_difference_
 struct _Counting_iterator {
     size_t _Count = 0;
 
-    using iterator_category = output_iterator_tag;
-    using value_type        = void;
-    using difference_type   = ptrdiff_t;
-    using pointer           = void;
-    using reference         = void;
+    using difference_type = ptrdiff_t;
 
     template <class _CharT>
     _Counting_iterator& operator=(_CharT) {
@@ -2188,28 +2180,28 @@ struct _Counting_iterator {
 template <class... _Types>
 size_t formatted_size(const string_view _Fmt, const _Types&... _Args) {
     using _Context  = basic_format_context<_Counting_iterator, char>;
-    auto _Arg_store = _Format_arg_store<_Context, _Types...>{_Args...};
+    auto _Arg_store = _STD make_format_args<_Context>(_Args...);
     return _STD vformat_to(_Counting_iterator{}, _Fmt, _STD move(_Arg_store))._Count;
 }
 
 template <class... _Types>
 size_t formatted_size(const wstring_view _Fmt, const _Types&... _Args) {
     using _Context  = basic_format_context<_Counting_iterator, wchar_t>;
-    auto _Arg_store = _Format_arg_store<_Context, _Types...>{_Args...};
+    auto _Arg_store = _STD make_format_args<_Context>(_Args...);
     return _STD vformat_to(_Counting_iterator{}, _Fmt, _STD move(_Arg_store))._Count;
 }
 
 template <class... _Types>
 size_t formatted_size(const locale& _Loc, const string_view _Fmt, const _Types&... _Args) {
     using _Context  = basic_format_context<_Counting_iterator, char>;
-    auto _Arg_store = _Format_arg_store<_Context, _Types...>{_Args...};
+    auto _Arg_store = _STD make_format_args<_Context>(_Args...);
     return _STD vformat_to(_Counting_iterator{}, _Loc, _Fmt, _STD move(_Arg_store))._Count;
 }
 
 template <class... _Types>
 size_t formatted_size(const locale& _Loc, const wstring_view _Fmt, const _Types&... _Args) {
     using _Context  = basic_format_context<_Counting_iterator, wchar_t>;
-    auto _Arg_store = _Format_arg_store<_Context, _Types...>{_Args...};
+    auto _Arg_store = _STD make_format_args<_Context>(_Args...);
     return _STD vformat_to(_Counting_iterator{}, _Loc, _Fmt, _STD move(_Arg_store))._Count;
 }
 

--- a/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
@@ -842,30 +842,33 @@ void test_spec_replacement_field() {
 }
 
 template <class charT, class... Args>
-void test_size_helper(size_t expected_size, basic_string_view<charT> fmt, const Args&... args) {
+void test_size_helper(const size_t expected_size, const basic_string_view<charT> fmt, const Args&... args) {
     assert(formatted_size(fmt, args...) == expected_size);
     assert(formatted_size(locale::classic(), fmt, args...) == expected_size);
+
+    const auto signed_size = static_cast<ptrdiff_t>(expected_size);
     basic_string<charT> str;
     {
         str.resize(expected_size);
-        auto res = format_to_n(str.begin(), expected_size, fmt, args...);
-        assert(res.size == expected_size);
-        assert(res.out - str.begin() == expected_size);
+        const auto res = format_to_n(str.begin(), signed_size, fmt, args...);
+        assert(res.size == signed_size);
+        assert(res.out - str.begin() == signed_size);
         assert(res.out == str.end());
+        assert(format(fmt, args...) == str);
 
         basic_string<charT> locale_str;
         locale_str.resize(expected_size);
-        auto locale_res = format_to_n(locale_str.begin(), expected_size, locale::classic(), fmt, args...);
+        format_to_n(locale_str.begin(), signed_size, locale::classic(), fmt, args...);
         assert(str == locale_str);
         assert(locale_str.size() == expected_size);
     }
     basic_string<charT> half_str;
     {
-        auto half_size = expected_size / 2;
+        const auto half_size = expected_size / 2;
         half_str.resize(half_size);
-        auto res = format_to_n(half_str.begin(), half_size, fmt, args...);
-        assert(res.size == expected_size);
-        assert(res.out - half_str.begin() == half_size);
+        const auto res = format_to_n(half_str.begin(), static_cast<ptrdiff_t>(half_size), fmt, args...);
+        assert(res.size == signed_size);
+        assert(static_cast<size_t>(res.out - half_str.begin()) == half_size);
         assert(res.out == half_str.end());
     }
     assert(str.starts_with(half_str));

--- a/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
@@ -841,6 +841,43 @@ void test_spec_replacement_field() {
     test_string_specs<charT>();
 }
 
+template <class charT, class... Args>
+void test_size_helper(size_t expected_size, basic_string_view<charT> fmt, const Args&... args) {
+    assert(formatted_size(fmt, args...) == expected_size);
+    assert(formatted_size(locale::classic(), fmt, args...) == expected_size);
+    basic_string<charT> str;
+    {
+        str.resize(expected_size);
+        auto res = format_to_n(str.begin(), expected_size, fmt, args...);
+        assert(res.size == expected_size);
+        assert(res.out - str.begin() == expected_size);
+        assert(res.out == str.end());
+
+        basic_string<charT> locale_str;
+        locale_str.resize(expected_size);
+        auto locale_res = format_to_n(locale_str.begin(), expected_size, locale::classic(), fmt, args...);
+        assert(str == locale_str);
+        assert(locale_str.size() == expected_size);
+    }
+    basic_string<charT> half_str;
+    {
+        auto half_size = expected_size / 2;
+        half_str.resize(half_size);
+        auto res = format_to_n(half_str.begin(), half_size, fmt, args...);
+        assert(res.size == expected_size);
+        assert(res.out - half_str.begin() == half_size);
+        assert(res.out == half_str.end());
+    }
+    assert(str.starts_with(half_str));
+}
+
+template <class charT>
+void test_size() {
+    test_size_helper<charT>(3, STR("{}"), 123);
+    test_size_helper<charT>(6, STR("{}"), 3.1415);
+    test_size_helper<charT>(8, STR("{:8}"), STR("scully"));
+}
+
 int main() {
     test_simple_formatting<char>();
     test_simple_formatting<wchar_t>();
@@ -859,6 +896,9 @@ int main() {
 
     test_spec_replacement_field<char>();
     test_spec_replacement_field<wchar_t>();
+
+    test_size<char>();
+    test_size<wchar_t>();
 
     return 0;
 }


### PR DESCRIPTION
Similar methods were used to implement both features: by creating our
own output iterators that either count characters or only insert up
until a certain character count. The output iterators were modelled
after back_insert_iterator. There can definitely be more tests, I just
wanted the methodology to be reviewed first and then testing can be
added a bit later.

<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
