### PR TITLE
<format>: Add format_to

### DIFF
--- a/stl/inc/format
+++ b/stl/inc/format
@@ -2032,26 +2032,26 @@ _OutputIt vformat_to(
 
 template <class _OutputIt, class... _Types>
 _OutputIt format_to(_OutputIt _Out, string_view _Fmt, const _Types&... _Args) {
-    using _Context = _STD basic_format_context<_OutputIt, char>;
-    return vformat_to(_STD move(_Out), _Fmt, make_format_args<_Context>(_Args...));
+    using _Context = basic_format_context<_OutputIt, char>;
+    return _STD vformat_to(_STD move(_Out), _Fmt, _STD make_format_args<_Context>(_Args...));
 }
 
 template <class _OutputIt, class... _Types>
 _OutputIt format_to(_OutputIt _Out, wstring_view _Fmt, const _Types&... _Args) {
-    using _Context = _STD basic_format_context<_OutputIt, wchar_t>;
-    return vformat_to(_STD move(_Out), _Fmt, make_format_args<_Context>(_Args...));
+    using _Context = basic_format_context<_OutputIt, wchar_t>;
+    return _STD vformat_to(_STD move(_Out), _Fmt, _STD make_format_args<_Context>(_Args...));
 }
 
 template <class _OutputIt, class... _Types>
 _OutputIt format_to(_OutputIt _Out, const locale& _Loc, string_view _Fmt, const _Types&... _Args) {
-    using _Context = _STD basic_format_context<_OutputIt, char>;
-    return vformat_to(_STD move(_Out), _Loc, _Fmt, make_format_args<_Context>(_Args...));
+    using _Context = basic_format_context<_OutputIt, char>;
+    return _STD vformat_to(_STD move(_Out), _Loc, _Fmt, _STD make_format_args<_Context>(_Args...));
 }
 
 template <class _OutputIt, class... _Types>
 _OutputIt format_to(_OutputIt _Out, const locale& _Loc, wstring_view _Fmt, const _Types&... _Args) {
-    using _Context = _STD basic_format_context<_OutputIt, wchar_t>;
-    return vformat_to(_STD move(_Out), _Loc, _Fmt, make_format_args<_Context>(_Args...));
+    using _Context = basic_format_context<_OutputIt, wchar_t>;
+    return _STD vformat_to(_STD move(_Out), _Loc, _Fmt, _STD make_format_args<_Context>(_Args...));
 }
 
 inline string vformat(string_view _Fmt, format_args _Args) {

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -2030,6 +2030,30 @@ _OutputIt vformat_to(
     return _Handler._Ctx.out();
 }
 
+template <class _OutputIt, class... _Types>
+_OutputIt format_to(_OutputIt _Out, string_view _Fmt, const _Types&... _Args) {
+    using _Context = _STD basic_format_context<_OutputIt, char>;
+    return vformat_to(_STD move(_Out), _Fmt, make_format_args<_Context>(_Args...));
+}
+
+template <class _OutputIt, class... _Types>
+_OutputIt format_to(_OutputIt _Out, wstring_view _Fmt, const _Types&... _Args) {
+    using _Context = _STD basic_format_context<_OutputIt, wchar_t>;
+    return vformat_to(_STD move(_Out), _Fmt, make_format_args<_Context>(_Args...));
+}
+
+template <class _OutputIt, class... _Types>
+_OutputIt format_to(_OutputIt _Out, const locale& _Loc, string_view _Fmt, const _Types&... _Args) {
+    using _Context = _STD basic_format_context<_OutputIt, char>;
+    return vformat_to(_STD move(_Out), _Loc, _Fmt, make_format_args<_Context>(_Args...));
+}
+
+template <class _OutputIt, class... _Types>
+_OutputIt format_to(_OutputIt _Out, const locale& _Loc, wstring_view _Fmt, const _Types&... _Args) {
+    using _Context = _STD basic_format_context<_OutputIt, wchar_t>;
+    return vformat_to(_STD move(_Out), _Loc, _Fmt, make_format_args<_Context>(_Args...));
+}
+
 inline string vformat(string_view _Fmt, format_args _Args) {
     string _Str;
     _STD vformat_to(_STD back_inserter(_Str), _Fmt, _Args);

--- a/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
@@ -74,6 +74,14 @@ void test_simple_formatting() {
         back_insert_iterator{output_string}, locale::classic(), STR("format"), make_testing_format_args<charT>());
     assert(output_string == STR("format"));
 
+    output_string.clear();
+    format_to(back_insert_iterator{output_string}, STR("format"));
+    assert(output_string == STR("format"));
+
+    output_string.clear();
+    format_to(back_insert_iterator{output_string}, locale::classic(), STR("format"));
+    assert(output_string == STR("format"));
+
     assert(format(STR("f")) == STR("f"));
     assert(format(STR("format")) == STR("format"));
     assert(format(locale::classic(), STR("f")) == STR("f"));
@@ -142,6 +150,13 @@ void test_simple_replacement_field() {
         back_insert_iterator{output_string}, locale::classic(), STR("{}"), make_testing_format_args<charT>(STR("f")));
     assert(output_string == STR("f"));
 
+    output_string.clear();
+    format_to(back_insert_iterator{output_string}, STR("{}"), STR("f"));
+    assert(output_string == STR("f"));
+
+    output_string.clear();
+    format_to(back_insert_iterator{output_string}, locale::classic(), STR("{}"), STR("f"));
+    assert(output_string == STR("f"));
 
     assert(format(STR("{}"), STR("f")) == STR("f"));
     assert(format(locale::classic(), STR("{}"), STR("f")) == STR("f"));


### PR DESCRIPTION
Mostly a passthrough function, however it is moving the iterator instead
of copying it so this will gel better with the move-only iterator PR I
have planned.

<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
