### PR TITLE
<format>: Fix arg overload resolution

### DIFF
--- a/stl/inc/format
+++ b/stl/inc/format
@@ -1008,19 +1008,27 @@ template <class _Context, class _Ty>
 
 template <class _Context, class _Ty>
 inline constexpr size_t _Get_format_arg_storage_size = sizeof(
-    _Get_format_arg_storage_type<_Context>(static_cast<const _Ty&>(_STD declval<_Ty>())));
+    _Get_format_arg_storage_type<_Context>(_STD declval<const _Ty&>()));
 
 struct _Format_arg_store_packed_index {
     // TRANSITION, Should be templated on number of arguments for even less storage
     using _Index_type = size_t;
 
     constexpr _Format_arg_store_packed_index() = default;
-    constexpr explicit _Format_arg_store_packed_index(const size_t _Index)
-        : _Index(static_cast<_Index_type>(_Index)), _Type(static_cast<_Index_type>(_Basic_format_arg_type::_None)) {}
+    constexpr explicit _Format_arg_store_packed_index(const size_t _Index) : _Index(static_cast<_Index_type>(_Index)) {
+        _Type(_Basic_format_arg_type::_None);
+    }
 
+    _NODISCARD constexpr _Basic_format_arg_type _Type() const noexcept {
+        return static_cast<_Basic_format_arg_type>(_Type_);
+    }
+
+    constexpr void _Type(_Basic_format_arg_type _Val) noexcept {
+        _Type_ = static_cast<_Index_type>(_Val);
+    }
 
     _Index_type _Index : (sizeof(_Index_type) * 8 - 4);
-    _Index_type _Type : 4;
+    _Index_type _Type_ : 4;
 };
 
 template <class _Context>
@@ -1048,7 +1056,7 @@ private:
         const auto _Length      = _Get_format_arg_type_storage_size<_CharType>(_Arg_type);
 
         _CSTD memcpy(_Storage + _Index_length + _Store_index, _STD addressof(_Val), _Length);
-        _Index_array[_Arg_index]._Type = static_cast<_Index_type::_Index_type>(_Arg_type);
+        _Index_array[_Arg_index]._Type(_Arg_type);
         if (_Arg_index + 1 < _Num_args) {
             // Set the starting index of the next arg, as that is dynamic, must be called with increasing index
             _Index_array[_Arg_index + 1] = _Format_arg_store_packed_index{_Store_index + _Length};
@@ -1154,7 +1162,7 @@ public:
         const auto _Index_length          = _Num_args * sizeof(_Format_arg_store_packed_index);
         const unsigned char* _Arg_storage = _Storage + _Index_length + _Packed_index._Index;
 
-        switch (static_cast<_Basic_format_arg_type>(_Packed_index._Type)) {
+        switch (_Packed_index._Type()) {
         case _Basic_format_arg_type::_None:
             return basic_format_arg<_Context>{};
         case _Basic_format_arg_type::_Int_type:

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -976,19 +976,21 @@ template <class _Context, class _Ty>
     }
 }
 
-template <class _Context, class _Char_type = typename _Context::char_type>
-/* consteval */ constexpr auto _Get_format_arg_storage_type(const _Char_type*) noexcept {
-    return static_cast<const _Char_type*>(nullptr);
+template <class _Context>
+/* consteval */ constexpr auto _Get_format_arg_storage_type(const typename _Context::char_type*) noexcept {
+    return static_cast<const typename _Context::char_type*>(nullptr);
 }
 
-template <class _Context, class _Traits, class _Char_type = typename _Context::char_type>
-/* consteval */ constexpr auto _Get_format_arg_storage_type(basic_string_view<_Char_type, _Traits>) noexcept {
-    return basic_string_view<_Char_type>{};
+template <class _Context, class _Traits>
+/* consteval */ constexpr auto _Get_format_arg_storage_type(
+    basic_string_view<typename _Context::char_type, _Traits>) noexcept {
+    return basic_string_view<typename _Context::char_type>{};
 }
 
-template <class _Context, class _Traits, class _Alloc, class _Char_type = typename _Context::char_type>
-/* consteval */ constexpr auto _Get_format_arg_storage_type(const basic_string<_Char_type, _Traits, _Alloc>&) noexcept {
-    return basic_string_view<_Char_type>{};
+template <class _Context, class _Traits, class _Alloc>
+/* consteval */ constexpr auto _Get_format_arg_storage_type(
+    const basic_string<typename _Context::char_type, _Traits, _Alloc>&) noexcept {
+    return basic_string_view<typename _Context::char_type>{};
 }
 
 template <class _Context>
@@ -1006,7 +1008,7 @@ template <class _Context, class _Ty>
 
 template <class _Context, class _Ty>
 inline constexpr size_t _Get_format_arg_storage_size = sizeof(
-    _Get_format_arg_storage_type<_Context>(_STD declval<_Ty>()));
+    _Get_format_arg_storage_type<_Context>(static_cast<const _Ty&>(_STD declval<_Ty>())));
 
 struct _Format_arg_store_packed_index {
     // TRANSITION, Should be templated on number of arguments for even less storage
@@ -1014,10 +1016,11 @@ struct _Format_arg_store_packed_index {
 
     constexpr _Format_arg_store_packed_index() = default;
     constexpr explicit _Format_arg_store_packed_index(const size_t _Index)
-        : _Index(static_cast<_Index_type>(_Index)), _Type(_Basic_format_arg_type::_None) {}
+        : _Index(static_cast<_Index_type>(_Index)), _Type(static_cast<_Index_type>(_Basic_format_arg_type::_None)) {}
+
 
     _Index_type _Index : (sizeof(_Index_type) * 8 - 4);
-    _Basic_format_arg_type _Type : 4;
+    _Index_type _Type : 4;
 };
 
 template <class _Context>
@@ -1045,7 +1048,7 @@ private:
         const auto _Length      = _Get_format_arg_type_storage_size<_CharType>(_Arg_type);
 
         _CSTD memcpy(_Storage + _Index_length + _Store_index, _STD addressof(_Val), _Length);
-        _Index_array[_Arg_index]._Type = _Arg_type;
+        _Index_array[_Arg_index]._Type = static_cast<_Index_type::_Index_type>(_Arg_type);
         if (_Arg_index + 1 < _Num_args) {
             // Set the starting index of the next arg, as that is dynamic, must be called with increasing index
             _Index_array[_Arg_index + 1] = _Format_arg_store_packed_index{_Store_index + _Length};
@@ -1151,7 +1154,7 @@ public:
         const auto _Index_length          = _Num_args * sizeof(_Format_arg_store_packed_index);
         const unsigned char* _Arg_storage = _Storage + _Index_length + _Packed_index._Index;
 
-        switch (_Packed_index._Type) {
+        switch (static_cast<_Basic_format_arg_type>(_Packed_index._Type)) {
         case _Basic_format_arg_type::_None:
             return basic_format_arg<_Context>{};
         case _Basic_format_arg_type::_Int_type:

--- a/tests/std/tests/P0645R10_text_formatting_args/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_args/test.cpp
@@ -214,6 +214,7 @@ void test_format_arg_store() {
 }
 
 static_assert(sizeof(_Format_arg_store_packed_index) == sizeof(_Format_arg_store_packed_index::_Index_type));
+static_assert(_Get_format_arg_storage_size<format_context, void*> == sizeof(basic_format_arg<format_context>::handle));
 
 int main() {
     test_basic_format_arg<format_context>();

--- a/tests/std/tests/P0645R10_text_formatting_args/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_args/test.cpp
@@ -213,6 +213,8 @@ void test_format_arg_store() {
     test_single_format_arg<Context, basic_string_view<char_type>, Arg_type::string_type>(get_input_sv<char_type>());
 }
 
+static_assert(sizeof(_Format_arg_store_packed_index) == sizeof(_Format_arg_store_packed_index::_Index_type));
+
 int main() {
     test_basic_format_arg<format_context>();
     test_basic_format_arg<wformat_context>();


### PR DESCRIPTION
There seems to be a compiler bug picking the wrong function in an
overload set. I've filed it as DevCom-1390432. This sidesteps the bug, and also
fixes a latent bug with `_Get_format_arg_storage_type`.

The issue was that the overload for `const _Ty&` was being picked for
`_Store`, so a `void*` was stored as a handle, but the `_Get_format_arg_storage_type`
overload that was being picked was the one for void pointers. This cause us to
buffer overrun the storage. Now it always picks the `const _Ty&` overload
(which seems weird but that is what the overload resolution is supposed to be).

There is also a fix for the packed index, that wasn't very packed
because the types of the bitfield were different. This should save space
as intended.

<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
