### PR TITLE
<format>: remove todos, add feature macro

### DIFF
--- a/stl/inc/format
+++ b/stl/inc/format
@@ -1203,7 +1203,6 @@ private:
     const unsigned char* _Storage = nullptr;
 };
 
-// TODO: test coverage
 // clang-format off
 template <class _Out, class _CharT>
     requires output_iterator<_Out, const _CharT&>
@@ -1236,7 +1235,6 @@ public:
         return _STD move(_OutputIt);
     }
     void advance_to(iterator _It) {
-        // TODO: IDL support probably required
         _OutputIt = _STD move(_It);
     }
 

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -1226,9 +1226,14 @@
 #define __cpp_lib_constexpr_vector 201907L
 #endif // defined(__cpp_constexpr_dynamic_alloc) && !defined(__clang__)
 
-#define __cpp_lib_destroying_delete            201806L
-#define __cpp_lib_endian                       201907L
-#define __cpp_lib_erase_if                     202002L
+#define __cpp_lib_destroying_delete 201806L
+#define __cpp_lib_endian            201907L
+#define __cpp_lib_erase_if          202002L
+
+#ifdef __cpp_lib_concepts // TRANSITION, GH-395
+#define __cpp_lib_format 201907L
+#endif // __cpp_lib_format
+
 #define __cpp_lib_generic_unordered_lookup     201811L
 #define __cpp_lib_int_pow2                     202002L
 #define __cpp_lib_integer_comparison_functions 202002L

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -165,6 +165,7 @@
 // P0608R3 Improving variant's Converting Constructor/Assignment
 // P0616R0 Using move() In <numeric>
 // P0631R8 <numbers> Math Constants
+// P0645R10 <format> text formatting
 // P0646R1 list/forward_list remove()/remove_if()/unique() Return size_type
 // P0653R2 to_address()
 // P0655R1 visit<R>()
@@ -1232,7 +1233,7 @@
 
 #ifdef __cpp_lib_concepts // TRANSITION, GH-395
 #define __cpp_lib_format 201907L
-#endif // __cpp_lib_format
+#endif // __cpp_lib_concepts
 
 #define __cpp_lib_generic_unordered_lookup     201811L
 #define __cpp_lib_int_pow2                     202002L

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -165,7 +165,7 @@
 // P0608R3 Improving variant's Converting Constructor/Assignment
 // P0616R0 Using move() In <numeric>
 // P0631R8 <numbers> Math Constants
-// P0645R10 <format> text formatting
+// P0645R10 <format> Text Formatting
 // P0646R1 list/forward_list remove()/remove_if()/unique() Return size_type
 // P0653R2 to_address()
 // P0655R1 visit<R>()

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -301,9 +301,6 @@ std/utilities/variant/variant.variant/variant.assign/T.pass.cpp FAIL
 std/utilities/variant/variant.variant/variant.ctor/conv.pass.cpp FAIL
 std/utilities/variant/variant.variant/variant.ctor/T.pass.cpp FAIL
 
-# C++20 P0645R10 "<format> Text Formatting"
-std/language.support/support.limits/support.limits.general/format.version.pass.cpp FAIL
-
 # C++20 P0784R7 "More constexpr containers"
 std/utilities/memory/allocator.traits/allocator.traits.members/construct.pass.cpp FAIL
 std/utilities/memory/allocator.traits/allocator.traits.members/destroy.pass.cpp FAIL

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -301,9 +301,6 @@ utilities\variant\variant.variant\variant.assign\T.pass.cpp
 utilities\variant\variant.variant\variant.ctor\conv.pass.cpp
 utilities\variant\variant.variant\variant.ctor\T.pass.cpp
 
-# C++20 P0645R10 "<format> Text Formatting"
-language.support\support.limits\support.limits.general\format.version.pass.cpp
-
 # C++20 P0784R7 "More constexpr containers"
 utilities\memory\allocator.traits\allocator.traits.members\construct.pass.cpp
 utilities\memory\allocator.traits\allocator.traits.members\destroy.pass.cpp

--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
@@ -615,20 +615,6 @@ STATIC_ASSERT(__cpp_lib_erase_if == 202002L);
 #endif
 #endif
 
-#if _HAS_CXX20 && !defined(__EDG__)
-#ifndef __cpp_lib_format
-#error __cpp_lib_format is not defined
-#elif __cpp_lib_format != 201907L
-#error __cpp_lib_format is not 201907L
-#else
-STATIC_ASSERT(__cpp_lib_format == 201907L);
-#endif
-#else
-#ifdef __cpp_lib_format
-#error __cpp_lib_format is defined
-#endif
-#endif
-
 #ifndef __cpp_lib_exchange_function
 #error __cpp_lib_exchange_function is not defined
 #elif __cpp_lib_exchange_function != 201304L
@@ -686,6 +672,20 @@ STATIC_ASSERT(__cpp_lib_filesystem == 201703L);
 #else
 #ifdef __cpp_lib_filesystem
 #error __cpp_lib_filesystem is defined
+#endif
+#endif
+
+#if _HAS_CXX20 && !defined(__EDG__)
+#ifndef __cpp_lib_format
+#error __cpp_lib_format is not defined
+#elif __cpp_lib_format != 201907L
+#error __cpp_lib_format is not 201907L
+#else
+STATIC_ASSERT(__cpp_lib_format == 201907L);
+#endif
+#else
+#ifdef __cpp_lib_format
+#error __cpp_lib_format is defined
 #endif
 #endif
 

--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
@@ -615,6 +615,20 @@ STATIC_ASSERT(__cpp_lib_erase_if == 202002L);
 #endif
 #endif
 
+#if _HAS_CXX20 && !defined(__EDG__)
+#ifndef __cpp_lib_format
+#error __cpp_lib_format is not defined
+#elif __cpp_lib_format != 201907L
+#error __cpp_lib_format is not 201907L
+#else
+STATIC_ASSERT(__cpp_lib_format == 201907L);
+#endif
+#else
+#ifdef __cpp_lib_format
+#error __cpp_lib_format is defined
+#endif
+#endif
+
 #ifndef __cpp_lib_exchange_function
 #error __cpp_lib_exchange_function is not defined
 #elif __cpp_lib_exchange_function != 201304L


### PR DESCRIPTION
removes done todos (I don't think we actually need IDL support on advance_to).

Also adds the format feature test macro and it's test.

There is one more TODO comment in format that will be removed when code point size computation lands later today.