### PR TITLE
<format> tests from libfmt

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -137,3 +137,33 @@ In addition, certain files include the notices provided below.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+
+----------------------
+
+// Copyright (c) 2012 - present, Victor Zverovich
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// --- Optional exception to the license ---
+//
+// As an exception, if, as a result of your compiling your source code, portions
+// of this Software are embedded into a machine-executable object form of such
+// source code, you may redistribute such embedded portions in such object form
+// without including the above copyright and permission notices.

--- a/docs/cgmanifest.json
+++ b/docs/cgmanifest.json
@@ -22,6 +22,15 @@
             "component": {
                 "type": "git",
                 "git": {
+                    "repositoryUrl": "https://github.com/fmtlib/fmt",
+                    "commitHash": "273d8865e31659f69528623754c1742b2819ad26"
+                }
+            }
+        },
+        {
+            "component": {
+                "type": "git",
+                "git": {
                     "repositoryUrl": "https://github.com/ulfjack/ryu.git",
                     "commitHash": "59661c3f883dfd39cef6dc8eaf2fcbaae53597e8"
                 }

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -5207,7 +5207,7 @@ namespace chrono {
         int _Dynamic_width_index     = -1;
         int _Dynamic_precision_index = -1;
         _Align _Alignment            = _Align::_None;
-        uint8_t _Fill_length         = 0;
+        uint8_t _Fill_length         = 1;
         // At most one codepoint (so one char32_t or four utf-8 char8_t)
         _CharT _Fill[4 / sizeof(_CharT)] = {_CharT{' '}};
         // recursive definition in grammar, so could have any number of these with literal chars

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -5207,6 +5207,7 @@ namespace chrono {
         int _Dynamic_width_index     = -1;
         int _Dynamic_precision_index = -1;
         _Align _Alignment            = _Align::_None;
+        uint8_t _Fill_length         = 0;
         // At most one codepoint (so one char32_t or four utf-8 char8_t)
         _CharT _Fill[4 / sizeof(_CharT)] = {_CharT{' '}};
         // recursive definition in grammar, so could have any number of these with literal chars
@@ -5232,6 +5233,7 @@ namespace chrono {
 
             const auto _Pos = _STD _Copy_unchecked(_Sv._Unchecked_begin(), _Sv._Unchecked_end(), _Specs._Fill);
             _STD fill(_Pos, _STD end(_Specs._Fill), _CharT{});
+            _Specs._Fill_length = static_cast<uint8_t>(_Sv.size());
         }
 
         constexpr void _On_width(int _Width) {

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -3,6 +3,37 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// NOTE:
+// The contents of this header are derived in part from libfmt under the following license:
+
+// Copyright (c) 2012 - present, Victor Zverovich
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// --- Optional exception to the license ---
+//
+// As an exception, if, as a result of your compiling your source code, portions
+// of this Software are embedded into a machine-executable object form of such
+// source code, you may redistribute such embedded portions in such object form
+// without including the above copyright and permission notices.
+
 #pragma once
 #ifndef _FORMAT_
 #define _FORMAT_

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -812,14 +812,15 @@ void _Parse_format_string(basic_string_view<_CharT> _Format_str, _HandlerT&& _Ha
 
 template <class _CharT>
 struct _Basic_format_specs {
-    int _Width         = 0;
-    int _Precision     = -1;
-    char _Type         = '\0';
-    _Align _Alignment  = _Align::_None;
-    _Sign _Sgn         = _Sign::_None;
-    bool _Alt          = false;
-    bool _Localized    = false;
-    bool _Leading_zero = false;
+    int _Width           = 0;
+    int _Precision       = -1;
+    char _Type           = '\0';
+    _Align _Alignment    = _Align::_None;
+    _Sign _Sgn           = _Sign::_None;
+    bool _Alt            = false;
+    bool _Localized      = false;
+    bool _Leading_zero   = false;
+    uint8_t _Fill_length = 1;
     // At most one codepoint (so one char32_t or four utf-8 char8_t).
     _CharT _Fill[4 / sizeof(_CharT)] = {_CharT{' '}};
 };
@@ -850,6 +851,7 @@ public:
 
         const auto _Pos = _STD _Copy_unchecked(_Sv._Unchecked_begin(), _Sv._Unchecked_end(), _Specs._Fill);
         _STD fill(_Pos, _STD end(_Specs._Fill), _CharT{});
+        _Specs._Fill_length = static_cast<uint8_t>(_Sv.size());
     }
 
     constexpr void _On_sign(_Sign _Sgn) {
@@ -1560,7 +1562,7 @@ _NODISCARD _OutputIt _Write_aligned(_OutputIt _Out, const int _Width, const _Bas
         }
     }
 
-    const basic_string_view<_CharT> _Fill_char{_Specs._Fill, _RANGES find(_Specs._Fill, '\0')};
+    const basic_string_view<_CharT> _Fill_char{_Specs._Fill, _Specs._Fill_length};
     for (; _Fill_left > 0; --_Fill_left) {
         _Out = _RANGES copy(_Fill_char, _STD move(_Out)).out;
     }

--- a/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
@@ -1105,7 +1105,7 @@ void libfmt_formatter_test_fill() {
     assert(format(STR("{0:*<5}"), 'c') == STR("c****"));
     assert(format(STR("{0:*<5}"), STR("abc")) == STR("abc**"));
     assert(format(STR("{0:*>8}"), reinterpret_cast<void*>(0xface)) == STR("**0xface"));
-    assert(format(STR("{:}="), STR("foo")) == STR("foo="));
+    assert(format(STR("{:}="), STR("meow")) == STR("meow="));
     assert(format(basic_string_view<charT>(STR("{:\0>4}"), 6), '*') == basic_string<charT>(STR("\0\0\0*"), 4));
     throw_helper(STR("{:\x80\x80\x80\x80\x80>}"), 0);
 }
@@ -1208,13 +1208,13 @@ void libfmt_formatter_test_hash_flag() {
     assert(format(STR("{0:#x}"), 0x42ull) == STR("0x42"));
     assert(format(STR("{0:#o}"), 042ull) == STR("042"));
 
-    // differs from libfmt, but conforms
+    // behavior differs from libfmt, but conforms
     assert(format(STR("{0:#}"), -42.0) == STR("-42."));
-    // differs from libfmt, but conforms
+    // behavior differs from libfmt, but conforms
     assert(format(STR("{0:#}"), -42.0l) == STR("-42."));
     assert(format(STR("{:#.0e}"), 42.0) == STR("4.e+01"));
     assert(format(STR("{:#.0f}"), 0.01) == STR("0."));
-    // differs from libfmt, but conforms
+    // behavior differs from libfmt, but conforms
     assert(format(STR("{:#.2g}"), 0.5) == STR("0.5"));
     assert(format(STR("{:#.0f}"), 0.5) == STR("0."));
     throw_helper(STR("{0:#"), 'c');

--- a/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
@@ -1115,14 +1115,11 @@ void libfmt_formatter_test_plus_sign() {
     assert(format(STR("{0:+}"), 42) == STR("+42"));
     assert(format(STR("{0:+}"), -42) == STR("-42"));
     assert(format(STR("{0:+}"), 42) == STR("+42"));
-    // behavior differs from libfmt, but conforms
-    assert(format(STR("{0:+}"), 42u) == STR("+42"));
+    assert(format(STR("{0:+}"), 42u) == STR("+42")); // behavior differs from libfmt, but conforms
     assert(format(STR("{0:+}"), 42l) == STR("+42"));
-    // behavior differs from libfmt, but conforms
-    assert(format(STR("{0:+}"), 42ul) == STR("+42"));
+    assert(format(STR("{0:+}"), 42ul) == STR("+42")); // behavior differs from libfmt, but conforms
     assert(format(STR("{0:+}"), 42ll) == STR("+42"));
-    // behavior differs from libfmt, but conforms
-    assert(format(STR("{0:+}"), 42ull) == STR("+42"));
+    assert(format(STR("{0:+}"), 42ull) == STR("+42")); // behavior differs from libfmt, but conforms
     assert(format(STR("{0:+}"), 42.0) == STR("+42"));
     assert(format(STR("{0:+}"), 42.0l) == STR("+42"));
     throw_helper(STR("{0:+"), 'c');
@@ -1136,14 +1133,11 @@ void libfmt_formatter_test_minus_sign() {
     assert(format(STR("{0:-}"), 42) == STR("42"));
     assert(format(STR("{0:-}"), -42) == STR("-42"));
     assert(format(STR("{0:-}"), 42) == STR("42"));
-    // behavior differs from libfmt, but conforms
-    assert(format(STR("{0:-}"), 42u) == STR("42"));
+    assert(format(STR("{0:-}"), 42u) == STR("42")); // behavior differs from libfmt, but conforms
     assert(format(STR("{0:-}"), 42l) == STR("42"));
-    // behavior differs from libfmt, but conforms
-    assert(format(STR("{0:-}"), 42ul) == STR("42"));
+    assert(format(STR("{0:-}"), 42ul) == STR("42")); // behavior differs from libfmt, but conforms
     assert(format(STR("{0:-}"), 42ll) == STR("42"));
-    // behavior differs from libfmt, but conforms
-    assert(format(STR("{0:-}"), 42ull) == STR("42"));
+    assert(format(STR("{0:-}"), 42ull) == STR("42")); // behavior differs from libfmt, but conforms
     assert(format(STR("{0:-}"), 42.0) == STR("42"));
     assert(format(STR("{0:-}"), 42.0l) == STR("42"));
     throw_helper(STR("{0:-"), 'c');
@@ -1157,14 +1151,11 @@ void libfmt_formatter_test_space_sign() {
     assert(format(STR("{0: }"), 42) == STR(" 42"));
     assert(format(STR("{0: }"), -42) == STR("-42"));
     assert(format(STR("{0: }"), 42) == STR(" 42"));
-    // behavior differs from libfmt, but conforms
-    assert(format(STR("{0: }"), 42u) == STR(" 42"));
+    assert(format(STR("{0: }"), 42u) == STR(" 42")); // behavior differs from libfmt, but conforms
     assert(format(STR("{0: }"), 42l) == STR(" 42"));
-    // behavior differs from libfmt, but conforms
-    assert(format(STR("{0: }"), 42ul) == STR(" 42"));
+    assert(format(STR("{0: }"), 42ul) == STR(" 42")); // behavior differs from libfmt, but conforms
     assert(format(STR("{0: }"), 42ll) == STR(" 42"));
-    // behavior differs from libfmt, but conforms
-    assert(format(STR("{0: }"), 42ull) == STR(" 42"));
+    assert(format(STR("{0: }"), 42ull) == STR(" 42")); // behavior differs from libfmt, but conforms
     assert(format(STR("{0: }"), 42.0) == STR(" 42"));
     assert(format(STR("{0: }"), 42.0l) == STR(" 42"));
     throw_helper(STR("{0: "), 'c');
@@ -1208,14 +1199,11 @@ void libfmt_formatter_test_hash_flag() {
     assert(format(STR("{0:#x}"), 0x42ull) == STR("0x42"));
     assert(format(STR("{0:#o}"), 042ull) == STR("042"));
 
-    // behavior differs from libfmt, but conforms
-    assert(format(STR("{0:#}"), -42.0) == STR("-42."));
-    // behavior differs from libfmt, but conforms
-    assert(format(STR("{0:#}"), -42.0l) == STR("-42."));
+    assert(format(STR("{0:#}"), -42.0) == STR("-42.")); // behavior differs from libfmt, but conforms
+    assert(format(STR("{0:#}"), -42.0l) == STR("-42.")); // behavior differs from libfmt, but conforms
     assert(format(STR("{:#.0e}"), 42.0) == STR("4.e+01"));
     assert(format(STR("{:#.0f}"), 0.01) == STR("0."));
-    // behavior differs from libfmt, but conforms
-    assert(format(STR("{:#.2g}"), 0.5) == STR("0.5"));
+    assert(format(STR("{:#.2g}"), 0.5) == STR("0.5")); // behavior differs from libfmt, but conforms
     assert(format(STR("{:#.0f}"), 0.5) == STR("0."));
     throw_helper(STR("{0:#"), 'c');
     throw_helper(STR("{0:#}"), 'c');

--- a/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
@@ -1203,7 +1203,8 @@ void libfmt_formatter_test_hash_flag() {
     assert(format(STR("{0:#}"), -42.0l) == STR("-42.")); // behavior differs from libfmt, but conforms
     assert(format(STR("{:#.0e}"), 42.0) == STR("4.e+01"));
     assert(format(STR("{:#.0f}"), 0.01) == STR("0."));
-    assert(format(STR("{:#.2g}"), 0.5) == STR("0.5")); // behavior differs from libfmt, but conforms
+    // TRANSITION, GH-1818
+    // assert(format(STR("{:#.2g}"), 0.5) == STR("0.50")); // behavior differs from libfmt, but conforms
     assert(format(STR("{:#.0f}"), 0.5) == STR("0."));
     throw_helper(STR("{0:#"), 'c');
     throw_helper(STR("{0:#}"), 'c');

--- a/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
@@ -1007,6 +1007,236 @@ void test_multibyte_format_strings() {
     setlocale(LC_ALL, nullptr);
 }
 
+template <class charT>
+void libfmt_formatter_test_escape() {
+    assert(format(STR("{{")) == STR("{"));
+    assert(format(STR("before {{")) == STR("before {"));
+    assert(format(STR("{{ after")) == STR("{ after"));
+    assert(format(STR("before {{ after")) == STR("before { after"));
+    assert(format(STR("}}")) == STR("}"));
+    assert(format(STR("before }}")) == STR("before }"));
+    assert(format(STR("}} after")) == STR("} after"));
+    assert(format(STR("before }} after")) == STR("before } after"));
+    assert(format(STR("{{}}")) == STR("{}"));
+    assert(format(STR("{{{0}}}"), 42) == STR("{42}"));
+}
+
+template <class charT>
+void libfmt_formatter_test_args_in_different_position() {
+    assert(format(STR("{0}"), 42) == STR("42"));
+    assert(format(STR("before {0}"), 42) == STR("before 42"));
+    assert(format(STR("{0} after"), 42) == STR("42 after"));
+    assert(format(STR("before {0} after"), 42) == STR("before 42 after"));
+    assert(format(STR("{0} = {1}"), STR("answer"), 42) == STR("answer = 42"));
+    assert(format(STR("{1} is the {0}"), STR("answer"), 42) == STR("42 is the answer"));
+    assert(format(STR("{0}{1}{0}"), STR("abra"), STR("cad")) == STR("abracadabra"));
+}
+template <class charT>
+void libfmt_formatter_test_left_align() {
+    assert(format(STR("{0:<4}"), 42) == STR("42  "));
+    assert(format(STR("{0:<4o}"), 042) == STR("42  "));
+    assert(format(STR("{0:<4x}"), 0x42) == STR("42  "));
+    assert(format(STR("{0:<5}"), -42) == STR("-42  "));
+    assert(format(STR("{0:<5}"), 42u) == STR("42   "));
+    assert(format(STR("{0:<5}"), -42l) == STR("-42  "));
+    assert(format(STR("{0:<5}"), 42ul) == STR("42   "));
+    assert(format(STR("{0:<5}"), -42ll) == STR("-42  "));
+    assert(format(STR("{0:<5}"), 42ull) == STR("42   "));
+    assert(format(STR("{0:<5}"), -42.0) == STR("-42  "));
+    assert(format(STR("{0:<5}"), -42.0l) == STR("-42  "));
+    assert(format(STR("{0:<5}"), 'c') == STR("c    "));
+    assert(format(STR("{0:<5}"), STR("abc")) == STR("abc  "));
+    assert(format(STR("{0:<8}"), reinterpret_cast<void*>(0xface)) == STR("0xface  "));
+}
+
+template <class charT>
+void libfmt_formatter_test_right_align() {
+    assert(format(STR("{0:>4}"), 42) == STR("  42"));
+    assert(format(STR("{0:>4o}"), 042) == STR("  42"));
+    assert(format(STR("{0:>4x}"), 0x42) == STR("  42"));
+    assert(format(STR("{0:>5}"), -42) == STR("  -42"));
+    assert(format(STR("{0:>5}"), 42u) == STR("   42"));
+    assert(format(STR("{0:>5}"), -42l) == STR("  -42"));
+    assert(format(STR("{0:>5}"), 42ul) == STR("   42"));
+    assert(format(STR("{0:>5}"), -42ll) == STR("  -42"));
+    assert(format(STR("{0:>5}"), 42ull) == STR("   42"));
+    assert(format(STR("{0:>5}"), -42.0) == STR("  -42"));
+    assert(format(STR("{0:>5}"), -42.0l) == STR("  -42"));
+    assert(format(STR("{0:>5}"), 'c') == STR("    c"));
+    assert(format(STR("{0:>5}"), STR("abc")) == STR("  abc"));
+    assert(format(STR("{0:>8}"), reinterpret_cast<void*>(0xface)) == STR("  0xface"));
+}
+
+template <class charT>
+void libfmt_formatter_test_center_align() {
+    assert(format(STR("{0:^5}"), 42) == STR(" 42  "));
+    assert(format(STR("{0:^5o}"), 042) == STR(" 42  "));
+    assert(format(STR("{0:^5x}"), 0x42) == STR(" 42  "));
+    assert(format(STR("{0:^5}"), -42) == STR(" -42 "));
+    assert(format(STR("{0:^5}"), 42u) == STR(" 42  "));
+    assert(format(STR("{0:^5}"), -42l) == STR(" -42 "));
+    assert(format(STR("{0:^5}"), 42ul) == STR(" 42  "));
+    assert(format(STR("{0:^5}"), -42ll) == STR(" -42 "));
+    assert(format(STR("{0:^5}"), 42ull) == STR(" 42  "));
+    assert(format(STR("{0:^5}"), -42.0) == STR(" -42 "));
+    assert(format(STR("{0:^5}"), -42.0l) == STR(" -42 "));
+    assert(format(STR("{0:^5}"), 'c') == STR("  c  "));
+    assert(format(STR("{0:^6}"), STR("abc")) == STR(" abc  "));
+    assert(format(STR("{0:^8}"), reinterpret_cast<void*>(0xface)) == STR(" 0xface "));
+}
+
+template <class charT>
+void libfmt_formatter_test_fill() {
+    throw_helper(STR("{0:{<5}"), 'c');
+    throw_helper(STR("{0:{<5}}"), 'c');
+    assert(format(STR("{0:*>4}"), 42) == STR("**42"));
+    assert(format(STR("{0:*>5}"), -42) == STR("**-42"));
+    assert(format(STR("{0:*>5}"), 42u) == STR("***42"));
+    assert(format(STR("{0:*>5}"), -42l) == STR("**-42"));
+    assert(format(STR("{0:*>5}"), 42ul) == STR("***42"));
+    assert(format(STR("{0:*>5}"), -42ll) == STR("**-42"));
+    assert(format(STR("{0:*>5}"), 42ull) == STR("***42"));
+    assert(format(STR("{0:*>5}"), -42.0) == STR("**-42"));
+    assert(format(STR("{0:*>5}"), -42.0l) == STR("**-42"));
+    assert(format(STR("{0:*<5}"), 'c') == STR("c****"));
+    assert(format(STR("{0:*<5}"), STR("abc")) == STR("abc**"));
+    assert(format(STR("{0:*>8}"), reinterpret_cast<void*>(0xface)) == STR("**0xface"));
+    assert(format(STR("{:}="), STR("foo")) == STR("foo="));
+    assert(format(basic_string_view<charT>(STR("{:\0>4}"), 6), '*') == basic_string<charT>(STR("\0\0\0*"), 4));
+    // assert(format(STR("{0:ж>4}"), 42) == STR("жж42"));
+    throw_helper(STR("{:\x80\x80\x80\x80\x80>}"), 0);
+}
+
+template <class charT>
+void libfmt_formatter_test_plus_sign() {
+    assert(format(STR("{0:+}"), 42) == STR("+42"));
+    assert(format(STR("{0:+}"), -42) == STR("-42"));
+    assert(format(STR("{0:+}"), 42) == STR("+42"));
+    // behavior differs from libfmt, but conforms
+    assert(format(STR("{0:+}"), 42u) == STR("+42"));
+    assert(format(STR("{0:+}"), 42l) == STR("+42"));
+    // behavior differs from libfmt, but conforms
+    assert(format(STR("{0:+}"), 42ul) == STR("+42"));
+    assert(format(STR("{0:+}"), 42ll) == STR("+42"));
+    // behavior differs from libfmt, but conforms
+    assert(format(STR("{0:+}"), 42ull) == STR("+42"));
+    assert(format(STR("{0:+}"), 42.0) == STR("+42"));
+    assert(format(STR("{0:+}"), 42.0l) == STR("+42"));
+    throw_helper(STR("{0:+"), 'c');
+    throw_helper(STR("{0:+}"), 'c');
+    throw_helper(STR("{0:+}"), STR("abc"));
+    throw_helper(STR("{0:+}"), reinterpret_cast<void*>(0x42));
+}
+
+template <class charT>
+void libfmt_formatter_test_minus_sign() {
+    assert(format(STR("{0:-}"), 42) == STR("42"));
+    assert(format(STR("{0:-}"), -42) == STR("-42"));
+    assert(format(STR("{0:-}"), 42) == STR("42"));
+    // behavior differs from libfmt, but conforms
+    assert(format(STR("{0:-}"), 42u) == STR("42"));
+    assert(format(STR("{0:-}"), 42l) == STR("42"));
+    // behavior differs from libfmt, but conforms
+    assert(format(STR("{0:-}"), 42ul) == STR("42"));
+    assert(format(STR("{0:-}"), 42ll) == STR("42"));
+    // behavior differs from libfmt, but conforms
+    assert(format(STR("{0:-}"), 42ull) == STR("42"));
+    assert(format(STR("{0:-}"), 42.0) == STR("42"));
+    assert(format(STR("{0:-}"), 42.0l) == STR("42"));
+    throw_helper(STR("{0:-"), 'c');
+    throw_helper(STR("{0:-}"), 'c');
+    throw_helper(STR("{0:-}"), STR("abc"));
+    throw_helper(STR("{0:-}"), reinterpret_cast<void*>(0x42));
+}
+
+template <class charT>
+void libfmt_formatter_test_space_sign() {
+    assert(format(STR("{0: }"), 42) == STR(" 42"));
+    assert(format(STR("{0: }"), -42) == STR("-42"));
+    assert(format(STR("{0: }"), 42) == STR(" 42"));
+    // behavior differs from libfmt, but conforms
+    assert(format(STR("{0: }"), 42u) == STR(" 42"));
+    assert(format(STR("{0: }"), 42l) == STR(" 42"));
+    // behavior differs from libfmt, but conforms
+    assert(format(STR("{0: }"), 42ul) == STR(" 42"));
+    assert(format(STR("{0: }"), 42ll) == STR(" 42"));
+    // behavior differs from libfmt, but conforms
+    assert(format(STR("{0: }"), 42ull) == STR(" 42"));
+    assert(format(STR("{0: }"), 42.0) == STR(" 42"));
+    assert(format(STR("{0: }"), 42.0l) == STR(" 42"));
+    throw_helper(STR("{0: "), 'c');
+    throw_helper(STR("{0: }"), 'c');
+    throw_helper(STR("{0: }"), STR("abc"));
+    throw_helper(STR("{0: }"), reinterpret_cast<void*>(0x42));
+}
+
+template <class charT>
+void libfmt_formatter_test_hash_flag() {
+    assert(format(STR("{0:#}"), 42) == STR("42"));
+    assert(format(STR("{0:#}"), -42) == STR("-42"));
+    assert(format(STR("{0:#b}"), 42) == STR("0b101010"));
+    assert(format(STR("{0:#B}"), 42) == STR("0B101010"));
+    assert(format(STR("{0:#b}"), -42) == STR("-0b101010"));
+    assert(format(STR("{0:#x}"), 0x42) == STR("0x42"));
+    assert(format(STR("{0:#X}"), 0x42) == STR("0X42"));
+    assert(format(STR("{0:#x}"), -0x42) == STR("-0x42"));
+    assert(format(STR("{0:#o}"), 0) == STR("0"));
+    assert(format(STR("{0:#o}"), 042) == STR("042"));
+    assert(format(STR("{0:#o}"), -042) == STR("-042"));
+    assert(format(STR("{0:#}"), 42u) == STR("42"));
+    assert(format(STR("{0:#x}"), 0x42u) == STR("0x42"));
+    assert(format(STR("{0:#o}"), 042u) == STR("042"));
+
+    assert(format(STR("{0:#}"), -42l) == STR("-42"));
+    assert(format(STR("{0:#x}"), 0x42l) == STR("0x42"));
+    assert(format(STR("{0:#x}"), -0x42l) == STR("-0x42"));
+    assert(format(STR("{0:#o}"), 042l) == STR("042"));
+    assert(format(STR("{0:#o}"), -042l) == STR("-042"));
+    assert(format(STR("{0:#}"), 42ul) == STR("42"));
+    assert(format(STR("{0:#x}"), 0x42ul) == STR("0x42"));
+    assert(format(STR("{0:#o}"), 042ul) == STR("042"));
+
+    assert(format(STR("{0:#}"), -42ll) == STR("-42"));
+    assert(format(STR("{0:#x}"), 0x42ll) == STR("0x42"));
+    assert(format(STR("{0:#x}"), -0x42ll) == STR("-0x42"));
+    assert(format(STR("{0:#o}"), 042ll) == STR("042"));
+    assert(format(STR("{0:#o}"), -042ll) == STR("-042"));
+    assert(format(STR("{0:#}"), 42ull) == STR("42"));
+    assert(format(STR("{0:#x}"), 0x42ull) == STR("0x42"));
+    assert(format(STR("{0:#o}"), 042ull) == STR("042"));
+
+    // differs from libfmt, but conforms
+    assert(format(STR("{0:#}"), -42.0) == STR("-42."));
+    // differs from libfmt, but conforms
+    assert(format(STR("{0:#}"), -42.0l) == STR("-42."));
+    assert(format(STR("{:#.0e}"), 42.0) == STR("4.e+01"));
+    assert(format(STR("{:#.0f}"), 0.01) == STR("0."));
+    // differs from libfmt, but conforms
+    assert(format(STR("{:#.2g}"), 0.5) == STR("0.5"));
+    assert(format(STR("{:#.0f}"), 0.5) == STR("0."));
+    throw_helper(STR("{0:#"), 'c');
+    throw_helper(STR("{0:#}"), 'c');
+    throw_helper(STR("{0:#}"), STR("abc"));
+    throw_helper(STR("{0:#}"), reinterpret_cast<void*>(0x42));
+}
+
+template <class charT>
+void libfmt_formatter_test_zero_flag() {
+    assert(format(STR("{0:0}"), 42) == STR("42"));
+    assert(format(STR("{0:05}"), -42) == STR("-0042"));
+    assert(format(STR("{0:05}"), 42u) == STR("00042"));
+    assert(format(STR("{0:05}"), -42l) == STR("-0042"));
+    assert(format(STR("{0:05}"), 42ul) == STR("00042"));
+    assert(format(STR("{0:05}"), -42ll) == STR("-0042"));
+    assert(format(STR("{0:05}"), 42ull) == STR("00042"));
+    assert(format(STR("{0:07}"), -42.0) == STR("-000042"));
+    assert(format(STR("{0:07}"), -42.0l) == STR("-000042"));
+    throw_helper(STR("{0:0"), 'c');
+    throw_helper(STR("{0:05}"), 'c');
+    throw_helper(STR("{0:05}"), STR("abc"));
+    throw_helper(STR("{0:05}"), reinterpret_cast<void*>(0x42));
+}
+
 int main() {
     test_simple_formatting<char>();
     test_simple_formatting<wchar_t>();
@@ -1030,6 +1260,36 @@ int main() {
     test_size<wchar_t>();
 
     test_multibyte_format_strings();
+
+    libfmt_formatter_test_escape<char>();
+    libfmt_formatter_test_escape<wchar_t>();
+
+    libfmt_formatter_test_args_in_different_position<char>();
+    libfmt_formatter_test_args_in_different_position<wchar_t>();
+
+    libfmt_formatter_test_left_align<char>();
+    libfmt_formatter_test_left_align<wchar_t>();
+
+    libfmt_formatter_test_right_align<char>();
+    libfmt_formatter_test_right_align<wchar_t>();
+
+    libfmt_formatter_test_fill<char>();
+    libfmt_formatter_test_fill<wchar_t>();
+
+    libfmt_formatter_test_plus_sign<char>();
+    libfmt_formatter_test_plus_sign<wchar_t>();
+
+    libfmt_formatter_test_minus_sign<char>();
+    libfmt_formatter_test_minus_sign<wchar_t>();
+
+    libfmt_formatter_test_space_sign<char>();
+    libfmt_formatter_test_space_sign<wchar_t>();
+
+    libfmt_formatter_test_hash_flag<char>();
+    libfmt_formatter_test_hash_flag<wchar_t>();
+
+    libfmt_formatter_test_zero_flag<char>();
+    libfmt_formatter_test_zero_flag<wchar_t>();
 
     return 0;
 }

--- a/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
@@ -1276,6 +1276,9 @@ int main() {
     libfmt_formatter_test_right_align<char>();
     libfmt_formatter_test_right_align<wchar_t>();
 
+    libfmt_formatter_test_center_align<char>();
+    libfmt_formatter_test_center_align<wchar_t>();
+
     libfmt_formatter_test_fill<char>();
     libfmt_formatter_test_fill<wchar_t>();
 

--- a/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
@@ -1103,7 +1103,6 @@ void libfmt_formatter_test_fill() {
     assert(format(STR("{0:*>8}"), reinterpret_cast<void*>(0xface)) == STR("**0xface"));
     assert(format(STR("{:}="), STR("foo")) == STR("foo="));
     assert(format(basic_string_view<charT>(STR("{:\0>4}"), 6), '*') == basic_string<charT>(STR("\0\0\0*"), 4));
-    // assert(format(STR("{0:ж>4}"), 42) == STR("жж42"));
     throw_helper(STR("{:\x80\x80\x80\x80\x80>}"), 0);
 }
 

--- a/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
@@ -1204,7 +1204,7 @@ void libfmt_formatter_test_hash_flag() {
     assert(format(STR("{:#.0e}"), 42.0) == STR("4.e+01"));
     assert(format(STR("{:#.0f}"), 0.01) == STR("0."));
     // TRANSITION, GH-1818
-    // assert(format(STR("{:#.2g}"), 0.5) == STR("0.50")); // behavior differs from libfmt, but conforms
+    // assert(format(STR("{:#.2g}"), 0.5) == STR("0.50"));
     assert(format(STR("{:#.0f}"), 0.5) == STR("0."));
     throw_helper(STR("{0:#"), 'c');
     throw_helper(STR("{0:#}"), 'c');

--- a/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
@@ -1007,6 +1007,10 @@ void test_multibyte_format_strings() {
     setlocale(LC_ALL, nullptr);
 }
 
+// the libfmt_ tests are derived from tests in
+// libfmt, Copyright (c) 2012 - present, Victor Zverovich
+// see NOTICE.txt for more information.
+
 template <class charT>
 void libfmt_formatter_test_escape() {
     assert(format(STR("{{")) == STR("{"));


### PR DESCRIPTION
* adds some tests converted from libfmt's test suite, with comments when std::format's behavior differs
* adds proper copyright banner to format and NOTICE.txt
