### PR TITLE
<format>: Fix #1818, precision on altenrative general formatting

### DIFF
--- a/stl/inc/format
+++ b/stl/inc/format
@@ -2020,6 +2020,21 @@ _NODISCARD _OutputIt _Fmt_write(
                 if (!_Append_decimal) {
                     _Zeroes_to_append += 1;
                 }
+
+                // Leading zeroes are not significant if we used fixed point notation.
+                // Fixed point notation is only used if the exponent in scientific notation would be >= -4.
+                if (_Exponent_start == _Result.ptr && _Value != _Float{}) {
+                    auto _Abs_value = _STD abs(_Value);
+                    if (_Abs_value < 0.001) {
+                        _Zeroes_to_append += 4;
+                    } else if (_Abs_value < 0.01) {
+                        _Zeroes_to_append += 3;
+                    } else if (_Abs_value < 0.1) {
+                        _Zeroes_to_append += 2;
+                    } else if (_Abs_value < 1.0) {
+                        _Zeroes_to_append += 1;
+                    }
+                }
             }
         }
 

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -2016,23 +2016,22 @@ _NODISCARD _OutputIt _Fmt_write(
                 _Append_decimal = true;
             }
             if (_Specs._Type == 'g' || _Specs._Type == 'G') {
-                _Zeroes_to_append = _Extra_precision + _Precision - static_cast<int>(_Exponent_start - _Buffer_start);
+                auto _Digits = static_cast<int>(_Exponent_start - _Buffer_start);
+
                 if (!_Append_decimal) {
-                    _Zeroes_to_append += 1;
+                    --_Digits;
                 }
 
+                _Zeroes_to_append = _Extra_precision + _Precision - _Digits;
+
                 // Leading zeroes are not significant if we used fixed point notation.
-                // Fixed point notation is only used if the exponent in scientific notation would be >= -4.
-                if (_Exponent_start == _Result.ptr && _Value != _Float{}) {
-                    auto _Abs_value = _STD abs(_Value);
-                    if (_Abs_value < 0.001) {
-                        _Zeroes_to_append += 4;
-                    } else if (_Abs_value < 0.01) {
-                        _Zeroes_to_append += 3;
-                    } else if (_Abs_value < 0.1) {
-                        _Zeroes_to_append += 2;
-                    } else if (_Abs_value < 1.0) {
-                        _Zeroes_to_append += 1;
+                if (_Exponent_start == _Result.ptr && _STD abs(_Value) < 1.0 && _Value != 0.0) {
+                    for (auto _It = _Buffer_start; _It < _Result.ptr; ++_It) {
+                        if (*_It == '0') {
+                            ++_Zeroes_to_append;
+                        } else if (*_It != '.') {
+                            break;
+                        }
                     }
                 }
             }

--- a/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
@@ -1211,8 +1211,7 @@ void libfmt_formatter_test_hash_flag() {
     assert(format(STR("{0:#}"), -42.0l) == STR("-42.")); // behavior differs from libfmt, but conforms
     assert(format(STR("{:#.0e}"), 42.0) == STR("4.e+01"));
     assert(format(STR("{:#.0f}"), 0.01) == STR("0."));
-    // TRANSITION, GH-1818
-    // assert(format(STR("{:#.2g}"), 0.5) == STR("0.50"));
+    assert(format(STR("{:#.2g}"), 0.5) == STR("0.50"));
     assert(format(STR("{:#.0f}"), 0.5) == STR("0."));
     throw_helper(STR("{0:#"), 'c');
     throw_helper(STR("{0:#}"), 'c');

--- a/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
@@ -734,6 +734,8 @@ void test_float_specs() {
     assert(format(STR("{:#.3g}"), 0.05) == STR("0.0500"));
     assert(format(STR("{:#.3g}"), 0.0005) == STR("0.000500"));
     assert(format(STR("{:#.3g}"), 0.00005) == STR("5.00e-05"));
+    assert(format(STR("{:#.2g}"), 0.0999) == STR("0.10"));
+    assert(format(STR("{:#.3g}"), 0.000470) == STR("0.000470"));
 
     assert(format(STR("{:#} {:#}"), inf, nan) == STR("inf nan"));
     assert(format(STR("{:#a} {:#a}"), inf, nan) == STR("inf nan"));

--- a/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
@@ -727,6 +727,14 @@ void test_float_specs() {
     assert(format(STR("{:#.0g}"), Float{0}) == STR("0."));
     assert(format(STR("{:#.0G}"), Float{0}) == STR("0."));
 
+
+    assert(format(STR("{:#.2g}"), 0.5) == STR("0.50"));
+    assert(format(STR("{:#.1g}"), 0.5) == STR("0.5"));
+    assert(format(STR("{:#.3g}"), 0.5) == STR("0.500"));
+    assert(format(STR("{:#.3g}"), 0.05) == STR("0.0500"));
+    assert(format(STR("{:#.3g}"), 0.0005) == STR("0.000500"));
+    assert(format(STR("{:#.3g}"), 0.00005) == STR("5.00e-05"));
+
     assert(format(STR("{:#} {:#}"), inf, nan) == STR("inf nan"));
     assert(format(STR("{:#a} {:#a}"), inf, nan) == STR("inf nan"));
     assert(format(STR("{:#A} {:#A}"), inf, nan) == STR("INF NAN"));


### PR DESCRIPTION
The fix is to only count significant digits of fixed point numbers.
Since the `g` format specifier only outputs fixed point numbers
when the exponent would be at least `-4` (and not lower), and we can only reduce
significant digits by having leading zeroes, we just need to test
against values up to an exponent of -4. Anything below 1 needs an extra
zero appended, anything below 0.1 needs 2, etc.

Fixes #1818.

<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
