### PR TITLE
Fix format("{:F}", Inf or NaN)

### DIFF
--- a/stl/inc/format
+++ b/stl/inc/format
@@ -1916,6 +1916,8 @@ _NODISCARD _OutputIt _Fmt_write(
         _Exponent = 'e';
         break;
     case 'F':
+        _To_upper = true;
+        [[fallthrough]];
     case 'f':
         if (_Precision == -1) {
             _Precision = 6;

--- a/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
@@ -743,7 +743,7 @@ void test_float_specs() {
     assert(format(STR("{:#e} {:#e}"), inf, nan) == STR("inf nan"));
     assert(format(STR("{:#E} {:#E}"), inf, nan) == STR("INF NAN"));
     assert(format(STR("{:#f} {:#f}"), inf, nan) == STR("inf nan"));
-    assert(format(STR("{:#F} {:#F}"), inf, nan) == STR("inf nan"));
+    assert(format(STR("{:#F} {:#F}"), inf, nan) == STR("INF NAN"));
     assert(format(STR("{:#g} {:#g}"), inf, nan) == STR("inf nan"));
     assert(format(STR("{:#G} {:#G}"), inf, nan) == STR("INF NAN"));
 
@@ -825,6 +825,15 @@ void test_float_specs() {
 
     assert(format(STR("{:g}"), value) == STR("1234.53"));
     assert(format(STR("{:G}"), value) == STR("1234.53"));
+
+    assert(format(STR("{:a} {:a}"), inf, nan) == STR("inf nan"));
+    assert(format(STR("{:A} {:A}"), inf, nan) == STR("INF NAN"));
+    assert(format(STR("{:e} {:e}"), inf, nan) == STR("inf nan"));
+    assert(format(STR("{:E} {:E}"), inf, nan) == STR("INF NAN"));
+    assert(format(STR("{:f} {:f}"), inf, nan) == STR("inf nan"));
+    assert(format(STR("{:F} {:F}"), inf, nan) == STR("INF NAN"));
+    assert(format(STR("{:g} {:g}"), inf, nan) == STR("inf nan"));
+    assert(format(STR("{:G} {:G}"), inf, nan) == STR("INF NAN"));
 }
 
 template <class charT>


### PR DESCRIPTION
<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->

It should print upper case "INF" or "NAN".