### PR TITLE
Avoid calling size() in empty() member functions

### DIFF
--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -2798,7 +2798,7 @@ public:
     }
 
     _NODISCARD _CONSTEXPR20_CONTAINER bool empty() const noexcept {
-        return size() == 0;
+        return this->_Mysize == 0;
     }
 
     _NODISCARD _CONSTEXPR20_CONTAINER allocator_type get_allocator() const noexcept {

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -4016,7 +4016,7 @@ public:
 #endif // _HAS_CXX20
 
     _NODISCARD _CONSTEXPR20_CONTAINER bool empty() const noexcept {
-        return size() == 0;
+        return _Mypair._Myval2._Mysize == 0;
     }
 
     _CONSTEXPR20_CONTAINER size_type copy(

--- a/stl/inc/xtree
+++ b/stl/inc/xtree
@@ -1216,7 +1216,7 @@ public:
     }
 
     _NODISCARD bool empty() const noexcept {
-        return size() == 0;
+        return _Get_scary()->_Mysize == 0;
     }
 
     _NODISCARD allocator_type get_allocator() const noexcept {


### PR DESCRIPTION
Might slightly improve the speed of applications built in Debug mode.

Having `empty()` call `size()` is somewhat disappointing for users who follow the guideline to replace their `size()` calls by the corresponding `empty()` calls. For example by Clang-Tidy:
https://clang.llvm.org/extra/clang-tidy/checks/readability-container-size-empty.html

<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
