### PR TITLE
Fix error in take_view::begin by casting to the appropriate size

### DIFF
--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -1927,7 +1927,7 @@ namespace ranges {
                 if constexpr (random_access_range<_Vw>) {
                     return _RANGES begin(_Range);
                 } else {
-                    const auto _Size = size();
+                    const auto _Size = static_cast<range_difference_t<_Vw>>(size());
                     return counted_iterator{_RANGES begin(_Range), _Size};
                 }
             } else {
@@ -1940,7 +1940,7 @@ namespace ranges {
                 if constexpr (random_access_range<const _Vw>) {
                     return _RANGES begin(_Range);
                 } else {
-                    const auto _Size = size();
+                    const auto _Size = static_cast<range_difference_t<_Vw>>(size());
                     return counted_iterator{_RANGES begin(_Range), _Size};
                 }
             } else {

--- a/tests/std/tests/P0896R4_views_take/test.cpp
+++ b/tests/std/tests/P0896R4_views_take/test.cpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <cassert>
 #include <forward_list>
+#include <map>
 #include <ranges>
 #include <span>
 #include <string_view>
@@ -510,6 +511,13 @@ constexpr void output_range_test() {
     }
 }
 
+void test_VSO1397309() {
+    constexpr int expected[] = {4, 8};
+    const map<int, string_view> values{{4, "Hello"sv}, {8, "Beautiful"sv}, {10, "World"sv}};
+
+    assert(ranges::equal(values | ranges::views::take(2) | ranges::views::keys, expected));
+}
+
 int main() {
     // Validate views
     { // ... copyable
@@ -558,4 +566,6 @@ int main() {
 
     STATIC_ASSERT((instantiation_test(), true));
     instantiation_test();
+
+    test_VSO1397309();
 }

--- a/tests/std/tests/P0896R4_views_take/test.cpp
+++ b/tests/std/tests/P0896R4_views_take/test.cpp
@@ -511,7 +511,7 @@ constexpr void output_range_test() {
     }
 }
 
-void test_VSO1397309() {
+void test_DevCom_1397309() {
     constexpr int expected[] = {4, 8};
     const map<int, string_view> values{{4, "Hello"sv}, {8, "Beautiful"sv}, {10, "World"sv}};
 
@@ -567,5 +567,5 @@ int main() {
     STATIC_ASSERT((instantiation_test(), true));
     instantiation_test();
 
-    test_VSO1397309();
+    test_DevCom_1397309();
 }


### PR DESCRIPTION
Note: we could use _Convert_size here but that would add additional overhead for questionable gain

This addresses https://developercommunity2.visualstudio.com/t/1397309

Thanks to @statementreply for pointing it out