### PR TITLE
chronat: Allow day from month_day_last conditionally

### DIFF
--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -5454,6 +5454,12 @@ namespace chrono {
         switch (_Specs._Type) {
         case 'd':
         case 'e':
+            // Most months have a proper last day, but February depends on the year.
+            if constexpr (is_same_v<_Ty, month_day_last>) {
+                if (_Val.month() == February) {
+                    _THROW(format_error("Cannot print the last day of February without a year"));
+                }
+            }
             if (_Has_modifier) {
                 return false;
             }
@@ -5546,6 +5552,7 @@ namespace chrono {
             _Month = static_cast<unsigned int>(_Val.month());
         } else if constexpr (is_same_v<_Ty, month_day_last>) {
             _Month = static_cast<unsigned int>(_Val.month());
+            _Day   = static_cast<unsigned int>(_Last_day_table[_Month - 1]);
         } else if constexpr (is_same_v<_Ty, year_month>) {
             _Month = static_cast<unsigned int>(_Val.month());
             _Year  = static_cast<int>(_Val.year());
@@ -5766,13 +5773,13 @@ struct _Chrono_formatter {
     _NODISCARD constexpr bool _Is_valid_type(const char _Type) noexcept {
         if constexpr (is_same_v<_Ty, _CHRONO day>) {
             return _Type == 'd' || _Type == 'e';
-        } else if constexpr (_Is_any_of_v<_Ty, _CHRONO month, _CHRONO month_day_last>) {
+        } else if constexpr (is_same_v<_Ty, _CHRONO month>) {
             return _Type == 'b' || _Type == 'B' || _Type == 'h' || _Type == 'm';
         } else if constexpr (is_same_v<_Ty, _CHRONO year>) {
             return _Type == 'Y' || _Type == 'y' || _Type == 'C';
         } else if constexpr (is_same_v<_Ty, _CHRONO weekday>) {
             return _Type == 'a' || _Type == 'A' || _Type == 'u' || _Type == 'w';
-        } else if constexpr (is_same_v<_Ty, _CHRONO month_day>) {
+        } else if constexpr (_Is_any_of_v<_Ty, _CHRONO month_day, _CHRONO month_day_last>) {
             return _Is_valid_type<_CHRONO month>(_Type) || _Is_valid_type<_CHRONO day>(_Type);
         } else if constexpr (is_same_v<_Ty, _CHRONO year_month>) {
             return _Is_valid_type<_CHRONO year>(_Type) || _Is_valid_type<_CHRONO month>(_Type);

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
@@ -411,7 +411,8 @@ void test_month_day_last_formatter() {
     stream_helper(STR("Feb/last"), February / last);
 
     assert(format(STR("{:%B}"), June / last) == STR("June"));
-    throw_helper(STR("{:%d}"), June / last);
+    assert(format(STR("{:%d}"), June / last) == STR("30"));
+    throw_helper(STR("{:%d}"), February / last);
 }
 
 template <typename CharT>


### PR DESCRIPTION
Thanks to @MattStephanson and @statementreply on discord for mentioning these edge cases.

I originally thought that you can't get a day from `month_day_last`, but
it clearly makes sense, for most months. I changed some machinery around
so that we can always intercept a specifier, which means that we need to
do manual checking in the writer for localization.

This PR is more to illustrate how a specifier may be intercepted, and
that testing need only be done for specific types.

<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
