### PR TITLE
wd, wdi formatting

### DIFF
--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -5957,6 +5957,14 @@ struct formatter<_CHRONO year, _CharT> //
     : _Fill_tm_formatter<_CHRONO year, _CharT> {};
 
 template <class _CharT>
+struct formatter<_CHRONO weekday, _CharT> //
+    : _Fill_tm_formatter<_CHRONO weekday, _CharT> {};
+
+template <class _CharT>
+struct formatter<_CHRONO weekday_indexed, _CharT> //
+    : _Fill_tm_formatter<_CHRONO weekday_indexed, _CharT> {};
+
+template <class _CharT>
 struct formatter<_CHRONO month_day, _CharT> //
     : _Fill_tm_formatter<_CHRONO month_day, _CharT> {};
 
@@ -6110,13 +6118,6 @@ template <class _Duration, class _CharT>
 struct formatter<_CHRONO local_time<_Duration>, _CharT> //
     : _Fill_tm_formatter<_CHRONO local_time<_Duration>, _CharT> {};
 
-template <class _CharT>
-struct formatter<_CHRONO weekday, _CharT> //
-    : _Fill_tm_formatter<_CHRONO weekday, _CharT> {};
-
-template <class _CharT>
-struct formatter<_CHRONO weekday_indexed, _CharT> //
-    : _Fill_tm_formatter<_CHRONO weekday_indexed, _CharT> {};
 #endif // __cpp_lib_concepts
 #endif // _HAS_CXX20
 

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -5464,6 +5464,10 @@ namespace chrono {
             _Month = static_cast<unsigned int>(_Val);
         } else if constexpr (is_same_v<_Ty, year>) {
             _Year = static_cast<int>(_Val);
+        } else if constexpr (is_same_v<_Ty, weekday>) {
+            _Weekday = static_cast<int>(_Val.c_encoding());
+        } else if constexpr (is_same_v<_Ty, weekday_indexed>) {
+            _Weekday = static_cast<int>(_Val.weekday().c_encoding());
         } else if constexpr (is_same_v<_Ty, month_day>) {
             _Day   = static_cast<unsigned int>(_Val.day());
             _Month = static_cast<unsigned int>(_Val.month());
@@ -5744,7 +5748,7 @@ struct _Chrono_formatter {
             return _Type == 'b' || _Type == 'B' || _Type == 'h' || _Type == 'm';
         } else if constexpr (is_same_v<_Ty, _CHRONO year>) {
             return _Type == 'Y' || _Type == 'y' || _Type == 'C';
-        } else if constexpr (is_same_v<_Ty, _CHRONO weekday>) {
+        } else if constexpr (_Is_any_of_v<_Ty, _CHRONO weekday, _CHRONO weekday_indexed>) {
             return _Type == 'a' || _Type == 'A' || _Type == 'u' || _Type == 'w';
         } else if constexpr (_Is_any_of_v<_Ty, _CHRONO month_day, _CHRONO month_day_last>) {
             return _Is_valid_type<_CHRONO month>(_Type) || _Is_valid_type<_CHRONO day>(_Type);
@@ -6106,7 +6110,13 @@ template <class _Duration, class _CharT>
 struct formatter<_CHRONO local_time<_Duration>, _CharT> //
     : _Fill_tm_formatter<_CHRONO local_time<_Duration>, _CharT> {};
 
+template <class _CharT>
+struct formatter<_CHRONO weekday, _CharT> //
+    : _Fill_tm_formatter<_CHRONO weekday, _CharT> {};
 
+template <class _CharT>
+struct formatter<_CHRONO weekday_indexed, _CharT> //
+    : _Fill_tm_formatter<_CHRONO weekday_indexed, _CharT> {};
 #endif // __cpp_lib_concepts
 #endif // _HAS_CXX20
 

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -276,11 +276,8 @@ std/utilities/memory/default.allocator/allocator.members/allocate.verify.cpp SKI
 
 # *** MISSING STL FEATURES ***
 # C++20 P0355R7 "<chrono> Calendars And Time Zones"
-std/utilities/time/time.cal/time.cal.mwd/time.cal.mwd.nonmembers/streaming.pass.cpp FAIL
 std/utilities/time/time.cal/time.cal.mwdlast/time.cal.mwdlast.nonmembers/streaming.pass.cpp FAIL
 std/utilities/time/time.cal/time.cal.wdidx/time.cal.wdidx.nonmembers/streaming.pass.cpp FAIL
-std/utilities/time/time.cal/time.cal.wdlast/time.cal.wdlast.nonmembers/streaming.pass.cpp FAIL
-std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.nonmembers/streaming.pass.cpp FAIL
 std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.nonmembers/streaming.pass.cpp FAIL
 std/utilities/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.nonmembers/streaming.pass.cpp FAIL
 
@@ -878,6 +875,9 @@ std/utilities/time/time.cal/time.cal.day/time.cal.day.nonmembers/streaming.pass.
 std/utilities/time/time.cal/time.cal.md/time.cal.md.nonmembers/streaming.pass.cpp SKIPPED
 std/utilities/time/time.cal/time.cal.mdlast/streaming.pass.cpp SKIPPED
 std/utilities/time/time.cal/time.cal.month/time.cal.month.nonmembers/streaming.pass.cpp SKIPPED
+std/utilities/time/time.cal/time.cal.mwd/time.cal.mwd.nonmembers/streaming.pass.cpp SKIPPED
+std/utilities/time/time.cal/time.cal.wdlast/time.cal.wdlast.nonmembers/streaming.pass.cpp SKIPPED
+std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.nonmembers/streaming.pass.cpp SKIPPED
 std/utilities/time/time.cal/time.cal.year/time.cal.year.nonmembers/streaming.pass.cpp SKIPPED
 std/utilities/time/time.cal/time.cal.ym/time.cal.ym.nonmembers/streaming.pass.cpp SKIPPED
 std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.nonmembers/streaming.pass.cpp SKIPPED

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -276,11 +276,8 @@ utilities\memory\default.allocator\allocator.members\allocate.verify.cpp
 
 # *** MISSING STL FEATURES ***
 # C++20 P0355R7 "<chrono> Calendars And Time Zones"
-utilities\time\time.cal\time.cal.mwd\time.cal.mwd.nonmembers\streaming.pass.cpp
 utilities\time\time.cal\time.cal.mwdlast\time.cal.mwdlast.nonmembers\streaming.pass.cpp
 utilities\time\time.cal\time.cal.wdidx\time.cal.wdidx.nonmembers\streaming.pass.cpp
-utilities\time\time.cal\time.cal.wdlast\time.cal.wdlast.nonmembers\streaming.pass.cpp
-utilities\time\time.cal\time.cal.weekday\time.cal.weekday.nonmembers\streaming.pass.cpp
 utilities\time\time.cal\time.cal.ymwd\time.cal.ymwd.nonmembers\streaming.pass.cpp
 utilities\time\time.cal\time.cal.ymwdlast\time.cal.ymwdlast.nonmembers\streaming.pass.cpp
 

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
@@ -352,6 +352,34 @@ void test_year_formatter() {
 }
 
 template <typename CharT>
+void test_weekday_formatter() {
+    weekday invalid{10};
+    assert(format(STR("{}"), weekday{3}) == STR("Wed"));
+    stream_helper(STR("Wed"), weekday{3});
+    stream_helper(STR("10 is not a valid weekday"), invalid);
+
+    assert(format(STR("{:%a %A}"), weekday{6}) == STR("Sat Saturday"));
+    assert(format(STR("{:%u %w}"), weekday{6}) == STR("6 6"));
+    assert(format(STR("{:%u %w}"), weekday{0}) == STR("7 0"));
+}
+
+template <typename CharT>
+void test_weekday_indexed_formatter() {
+    weekday_indexed invalid1{Tuesday, 10};
+    weekday_indexed invalid2{weekday{10}, 3};
+    weekday_indexed invalid3{weekday{14}, 9};
+    assert(format(STR("{}"), weekday_indexed{Monday, 1}) == STR("Mon[1]"));
+    stream_helper(STR("Mon[1]"), weekday_indexed{Monday, 1});
+    stream_helper(STR("Tue[10 is not a valid index]"), invalid1);
+    stream_helper(STR("10 is not a valid weekday[3]"), invalid2);
+    stream_helper(STR("14 is not a valid weekday[9 is not a valid index]"), invalid3);
+
+    assert(format(STR("{:%a %A}"), weekday_indexed{Monday, 2}) == STR("Mon Monday"));
+    assert(format(STR("{:%u %w}"), weekday_indexed{Tuesday, 3}) == STR("2 2"));
+    assert(format(STR("{:%u %w}"), weekday_indexed{Sunday, 4}) == STR("7 0"));
+}
+
+template <typename CharT>
 void test_year_month_day_formatter() {
     year_month_day invalid{year{1234}, month{0}, day{31}};
     assert(format(STR("{}"), year_month_day{year{1900}, month{2}, day{1}}) == STR("1900-02-01"));
@@ -459,6 +487,12 @@ int main() {
 
     test_year_formatter<char>();
     test_year_formatter<wchar_t>();
+
+    test_weekday_formatter<char>();
+    test_weekday_formatter<wchar_t>();
+
+    test_weekday_indexed_formatter<char>();
+    test_weekday_indexed_formatter<wchar_t>();
 
     test_year_month_day_formatter<char>();
     test_year_month_day_formatter<wchar_t>();


### PR DESCRIPTION
Adds `operator<<` and `struct formatter`s for both `weekday` and `weekday_indexed`. 

Looking through Table 101, I didn't see any specifiers that would apply only to `weekday_indexed`, so it just shares the same specifiers as `weekday`. 