### PR TITLE
`<chrono>`: Implement exception class constructors

### DIFF
--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -2266,16 +2266,38 @@ namespace chrono {
     class nonexistent_local_time : public runtime_error {
     public:
         template <class _Duration>
-        nonexistent_local_time(const local_time<_Duration>&, const local_info&)
-            : runtime_error("TRANSITION: work in progress") {}
+        nonexistent_local_time(const local_time<_Duration>& _Tp, const local_info& _Info)
+            : runtime_error(_Make_string(_Tp, _Info)) {}
+
+    private:
+#ifdef __cpp_lib_concepts
+        template <class _Duration>
+        _NODISCARD static string _Make_string(const local_time<_Duration>& _Tp, const local_info& _Info);
+#else // ^^^ no workaround / workaround vvv
+        template <class _Duration>
+        _NODISCARD static string _Make_string(const local_time<_Duration>&, const local_info&) {
+            return "nonexistent_local_time";
+        }
+#endif // ^^^ workaround ^^^
     };
 
     // CLASS ambiguous_local_time
     class ambiguous_local_time : public runtime_error {
     public:
         template <class _Duration>
-        ambiguous_local_time(const local_time<_Duration>&, const local_info&)
-            : runtime_error("TRANSITION: work in progress") {}
+        ambiguous_local_time(const local_time<_Duration>& _Tp, const local_info& _Info)
+            : runtime_error(_Make_string(_Tp, _Info)) {}
+
+    private:
+#ifdef __cpp_lib_concepts
+        template <class _Duration>
+        _NODISCARD static string _Make_string(const local_time<_Duration>& _Tp, const local_info& _Info);
+#else // ^^^ no workaround / workaround vvv
+        template <class _Duration>
+        _NODISCARD static string _Make_string(const local_time<_Duration>&, const local_info&) {
+            return "ambiguous_local_time";
+        }
+#endif // ^^^ workaround ^^^
     };
 
     // [time.zone.timezone]
@@ -3180,7 +3202,7 @@ namespace chrono {
 #ifdef __cpp_lib_concepts
             const auto _Leap_cmp = _Utc_leap_second <=> _Time_floor;
 #else // ^^^ __cpp_lib_concepts / TRANSITION, GH-395 workaround vvv
-            const auto _Leap_cmp = _Utc_leap_second > _Time_floor  ? strong_ordering::greater
+            const auto _Leap_cmp = _Utc_leap_second > _Time_floor ? strong_ordering::greater
                                  : _Utc_leap_second == _Time_floor ? strong_ordering::equal
                                                                    : strong_ordering::less;
 #endif // ^^^ workaround
@@ -6112,6 +6134,29 @@ private:
 template <class _Duration, class _CharT>
 struct formatter<_CHRONO local_time<_Duration>, _CharT> //
     : _Fill_tm_formatter<_CHRONO local_time<_Duration>, _CharT> {};
+
+namespace chrono {
+    template <class _Duration>
+    _NODISCARD string nonexistent_local_time::_Make_string(const local_time<_Duration>& _Tp, const local_info& _Info) {
+        ostringstream _Os;
+        _Os << _Tp << " is in a gap between\n"
+            << local_seconds{_Info.first.end.time_since_epoch()} + _Info.first.offset << ' ' << _Info.first.abbrev
+            << " and\n"
+            << local_seconds{_Info.second.begin.time_since_epoch()} + _Info.second.offset << ' ' << _Info.second.abbrev
+            << " which are both equivalent to\n"
+            << _Info.first.end << " UTC";
+        return _STD move(_Os).str();
+    }
+
+    template <class _Duration>
+    _NODISCARD string ambiguous_local_time::_Make_string(const local_time<_Duration>& _Tp, const local_info& _Info) {
+        ostringstream _Os;
+        _Os << _Tp << " is ambiguous. It could be\n"
+            << _Tp << ' ' << _Info.first.abbrev << " == " << _Tp - _Info.first.offset << " UTC or\n"
+            << _Tp << ' ' << _Info.second.abbrev << " == " << _Tp - _Info.second.offset << " UTC";
+        return _STD move(_Os).str();
+    }
+} // namespace chrono
 
 #endif // __cpp_lib_concepts
 #endif // _HAS_CXX20

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -5921,7 +5921,7 @@ struct _Chrono_formatter {
             return true;
         case 'H':
             if constexpr (_Is_specialization_v<_Ty, _CHRONO hh_mm_ss>) {
-                if (_Val.hours() <= -_CHRONO hours{24} || _CHRONO hours{24} <= _Val.hours()) {
+                if (_Val.hours() >= _CHRONO hours{24}) {
                     _THROW(format_error("Cannot localize hh_mm_ss with an absolute value of 24 hours or more."));
                 }
             }

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_time_zones/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_time_zones/test.cpp
@@ -360,46 +360,40 @@ void validate_precision(const time_zone* tz, const pair<Transition, Transition>&
 
 void timezone_precision_test() {
     const auto& my_tzdb = get_tzdb();
-    using MilliDur      = duration<double, milli>;
-    using MicroDur      = duration<double, micro>;
 
     {
         using namespace Sydney;
         auto tz = my_tzdb.locate_zone(Tz_name);
         validate_precision(tz, Std_to_Day, sys_seconds::duration{1});
-        validate_precision(tz, Std_to_Day, MilliDur{1});
-        validate_precision(tz, Std_to_Day, MilliDur{0.5});
-        validate_precision(tz, Std_to_Day, MilliDur{0.05});
-        validate_precision(tz, Std_to_Day, MilliDur{0.005});
-        validate_precision(tz, Std_to_Day, MilliDur{0.0005});
-        // precision limit...
 
-        validate_precision(tz, Std_to_Day, MicroDur{1});
-        validate_precision(tz, Std_to_Day, MicroDur{0.5});
-        // precision limit...
+        validate_precision(tz, Std_to_Day, milliseconds{100});
+        validate_precision(tz, Std_to_Day, milliseconds{10});
+        validate_precision(tz, Std_to_Day, milliseconds{1});
+
+        validate_precision(tz, Std_to_Day, microseconds{100});
+        validate_precision(tz, Std_to_Day, microseconds{10});
+        validate_precision(tz, Std_to_Day, microseconds{1});
 
         // validate opposite transition
-        validate_precision(tz, Day_to_Std, MicroDur{0.5});
-        validate_precision(tz, Day_to_Std, MilliDur{0.0005});
+        validate_precision(tz, Day_to_Std, milliseconds{1});
+        validate_precision(tz, Day_to_Std, microseconds{1});
     }
     {
         using namespace LA;
         auto tz = my_tzdb.locate_zone(Tz_name);
         validate_precision(tz, Std_to_Day, sys_seconds::duration{1});
-        validate_precision(tz, Std_to_Day, MilliDur{1});
-        validate_precision(tz, Std_to_Day, MilliDur{0.5});
-        validate_precision(tz, Std_to_Day, MilliDur{0.05});
-        validate_precision(tz, Std_to_Day, MilliDur{0.005});
-        validate_precision(tz, Std_to_Day, MilliDur{0.0005});
-        // precision limit...
 
-        validate_precision(tz, Std_to_Day, MicroDur{1});
-        validate_precision(tz, Std_to_Day, MicroDur{0.5});
-        // precision limit...
+        validate_precision(tz, Std_to_Day, milliseconds{100});
+        validate_precision(tz, Std_to_Day, milliseconds{10});
+        validate_precision(tz, Std_to_Day, milliseconds{1});
+
+        validate_precision(tz, Std_to_Day, microseconds{100});
+        validate_precision(tz, Std_to_Day, microseconds{10});
+        validate_precision(tz, Std_to_Day, microseconds{1});
 
         // validate opposite transition
-        validate_precision(tz, Day_to_Std, MicroDur{0.5});
-        validate_precision(tz, Day_to_Std, MilliDur{0.0005});
+        validate_precision(tz, Day_to_Std, milliseconds{1});
+        validate_precision(tz, Day_to_Std, microseconds{1});
     }
 }
 


### PR DESCRIPTION
* @statementreply noticed that `hh_mm_ss::hours()` is already an absolute value.
* Implement and test `nonexistent_local_time` and `ambiguous_local_time` (with a non-concepts placeholder).
  + The only difference from the Standardese is that I'm returning `_STD move(_Os).str()` as I believe it's equivalent and hopefully more efficient.
* Fix `P0355R7_calendars_and_time_zones_time_zones`.
  + We can't use floating-point durations because the exception constructors in [time.zone.exception] will stream `local_time<Duration>`, and [time.clock.local] implements that by streaming `sys_time<Duration>`, and that's constrained by [time.clock.system.nonmembers] to reject floating-point durations.
