### PR TITLE
Fix a severe code bloat issue in <format>

### DIFF
--- a/stl/inc/format
+++ b/stl/inc/format
@@ -1647,16 +1647,16 @@ public:
 };
 
 template <class _Container>
-class _Fmt_iterator_buffer<_STD back_insert_iterator<_Container>,
-    enable_if_t<_STD contiguous_iterator<typename _Container::iterator>, typename _Container::value_type>>
+class _Fmt_iterator_buffer<back_insert_iterator<_Container>,
+    enable_if_t<contiguous_iterator<typename _Container::iterator>, typename _Container::value_type>>
     final : public _Fmt_buffer<typename _Container::value_type> {
 private:
     _Container& _Cont;
 
-    struct _Accessor : _STD back_insert_iterator<_Container> {
-        _Accessor(_STD back_insert_iterator<_Container> _Iter) : back_insert_iterator<_Container>(_Iter) {}
+    struct _Accessor : back_insert_iterator<_Container> {
+        explicit _Accessor(back_insert_iterator<_Container> _Iter) : back_insert_iterator<_Container>(_Iter) {}
 
-        using _STD back_insert_iterator<_Container>::container;
+        using back_insert_iterator<_Container>::container;
     };
 
     void _Grow(size_t _Capacity) final {
@@ -1668,7 +1668,7 @@ public:
     explicit _Fmt_iterator_buffer(_Container& _Cont_)
         : _Fmt_buffer<typename _Container::value_type>(_Cont_.size()), _Cont(_Cont_) {}
 
-    explicit _Fmt_iterator_buffer(_STD back_insert_iterator<_Container> _Out, ptrdiff_t = 0)
+    explicit _Fmt_iterator_buffer(back_insert_iterator<_Container> _Out, ptrdiff_t = 0)
         : _Fmt_iterator_buffer(*_Accessor{_Out}.container) {}
 
     _NODISCARD auto _Out() noexcept {

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -1496,6 +1496,214 @@ public:
     }
 };
 
+template <class _Ty>
+class _Fmt_buffer {
+private:
+    _Ty* _Ptr        = nullptr;
+    size_t _Size     = 0;
+    size_t _Capacity = 0;
+
+protected:
+    explicit _Fmt_buffer(const size_t _Sz) noexcept : _Size(_Sz), _Capacity(_Sz) {}
+
+    _Fmt_buffer(_Ty* _Data, const size_t _Sz, const size_t _Cap) noexcept : _Ptr(_Data), _Size(_Sz), _Capacity(_Cap) {}
+
+    void _Set(_Ty* _Buf_data, const size_t _Buf_capacity) noexcept {
+        _Ptr      = _Buf_data;
+        _Capacity = _Buf_capacity;
+    }
+
+    virtual void _Grow(size_t _Capacity) = 0;
+
+public:
+    using value_type      = _Ty;
+    using const_reference = const _Ty&;
+
+    _Fmt_buffer(const _Fmt_buffer&) = delete;
+    void operator=(const _Fmt_buffer&) = delete;
+
+    _NODISCARD _Ty* begin() noexcept {
+        return _Ptr;
+    }
+
+    _NODISCARD _Ty* end() noexcept {
+        return _Ptr + _Size;
+    }
+
+    _NODISCARD size_t size() const noexcept {
+        return _Size;
+    }
+
+    _NODISCARD size_t capacity() const noexcept {
+        return _Capacity;
+    }
+
+    void clear() noexcept {
+        _Size = 0;
+    }
+
+    void try_resize(const size_t _Count) {
+        try_reserve(_Count);
+        _Size = _Count <= _Capacity ? _Count : _Capacity;
+    }
+
+    void try_reserve(const size_t _New_capacity) {
+        if (_New_capacity > _Capacity) {
+            _Grow(_New_capacity);
+        }
+    }
+
+    void push_back(const _Ty _Value) {
+        try_reserve(_Size + 1);
+        _Ptr[_Size++] = _Value;
+    }
+};
+
+struct _Fmt_buffer_traits {
+    explicit _Fmt_buffer_traits(ptrdiff_t) {}
+
+    _NODISCARD size_t count() const noexcept {
+        return 0;
+    }
+
+    _NODISCARD size_t limit(const size_t _Size) noexcept {
+        return _Size;
+    }
+};
+
+class _Fmt_fixed_buffer_traits {
+private:
+    ptrdiff_t _Count = 0;
+    ptrdiff_t _Limit;
+
+public:
+    explicit _Fmt_fixed_buffer_traits(const ptrdiff_t _Lim) noexcept : _Limit(_Lim) {}
+
+    _NODISCARD size_t count() const noexcept {
+        return static_cast<size_t>(_Count);
+    }
+
+    _NODISCARD size_t limit(const size_t _Size) noexcept {
+        size_t _Avail = static_cast<size_t>(_Limit > _Count ? _Limit - _Count : 0);
+        _Count += _Size;
+        return _Size < _Avail ? _Size : _Avail;
+    }
+};
+
+inline constexpr size_t _Fmt_buffer_size = 256;
+
+template <class _OutputIt, class _Ty, class _Traits = _Fmt_buffer_traits>
+class _Fmt_iterator_buffer final : public _Traits, public _Fmt_buffer<_Ty> {
+private:
+    _OutputIt _Out;
+    _Ty _Data[_Fmt_buffer_size];
+
+protected:
+    void _Grow(size_t) final {
+        if (this->size() == _Fmt_buffer_size) {
+            _Flush();
+        }
+    }
+
+    void _Flush() {
+        auto _Size = this->size();
+        this->clear();
+        _Out = _STD _Copy_unchecked(_Data, _Data + this->limit(_Size), _STD move(_Out));
+    }
+
+public:
+    explicit _Fmt_iterator_buffer(_OutputIt _Output, ptrdiff_t _Size = _Fmt_buffer_size)
+        : _Traits(_Size), _Fmt_buffer<_Ty>(_Data, 0, _Fmt_buffer_size), _Out(_STD move(_Output)) {}
+
+    ~_Fmt_iterator_buffer() {
+        if (this->size() != 0) {
+            _Flush();
+        }
+    }
+
+    _NODISCARD _OutputIt out() {
+        _Flush();
+        return _STD move(_Out);
+    }
+
+    _NODISCARD ptrdiff_t count() const noexcept {
+        return static_cast<ptrdiff_t>(_Traits::count() + this->size());
+    }
+};
+
+template <class _Ty>
+class _Fmt_iterator_buffer<_Ty*, _Ty> final : public _Fmt_buffer<_Ty> {
+protected:
+    void _Grow(size_t) final {}
+
+public:
+    explicit _Fmt_iterator_buffer(_Ty* _Out, ptrdiff_t = 0) : _Fmt_buffer<_Ty>(_Out, 0, ~size_t()) {}
+
+    _NODISCARD _Ty* out() noexcept {
+        return this->end();
+    }
+};
+
+template <class _Container>
+class _Fmt_iterator_buffer<_STD back_insert_iterator<_Container>,
+    enable_if_t<_STD contiguous_iterator<typename _Container::iterator>, typename _Container::value_type>>
+    final : public _Fmt_buffer<typename _Container::value_type> {
+private:
+    _Container& _Cont;
+
+    struct _Accessor : _STD back_insert_iterator<_Container> {
+        _Accessor(_STD back_insert_iterator<_Container> _Iter) : back_insert_iterator<_Container>(_Iter) {}
+
+        using _STD back_insert_iterator<_Container>::container;
+    };
+
+protected:
+    void _Grow(size_t _Capacity) final {
+        _Cont.resize(_Capacity);
+        this->_Set(&_Cont[0], _Capacity);
+    }
+
+public:
+    explicit _Fmt_iterator_buffer(_Container& _C)
+        : _Fmt_buffer<typename _Container::value_type>(_C.size()), _Cont(_C) {}
+
+    explicit _Fmt_iterator_buffer(_STD back_insert_iterator<_Container> _Out, ptrdiff_t = 0)
+        : _Fmt_iterator_buffer(*_Accessor(_STD move(_Out)).container) {}
+
+    _NODISCARD auto out() noexcept {
+        return _STD back_inserter(_Cont);
+    }
+};
+
+template <class _Ty>
+class _Fmt_counting_buffer final : public _Fmt_buffer<_Ty> {
+private:
+    _Ty _Data[_Fmt_buffer_size];
+    size_t _Count = 0;
+
+protected:
+    void _Grow(size_t) final {
+        if (this->size() != _Fmt_buffer_size) {
+            return;
+        }
+        _Count += this->size();
+        this->clear();
+    }
+
+public:
+    _Fmt_counting_buffer() : _Fmt_buffer<_Ty>(_Data, 0, _Fmt_buffer_size) {}
+
+    _NODISCARD size_t count() const noexcept {
+        return _Count + this->size();
+    }
+};
+
+using _Fmt_it  = back_insert_iterator<_Fmt_buffer<char>>;
+using _Fmt_wit = back_insert_iterator<_Fmt_buffer<wchar_t>>;
+
+using format_context  = basic_format_context<_Fmt_it, char>;
+using wformat_context = basic_format_context<_Fmt_wit, wchar_t>;
+
 template <class _CharT, class _OutputIt>
 _NODISCARD _OutputIt _Fmt_write(_OutputIt _Out, monostate) {
     _STL_INTERNAL_CHECK(false);
@@ -2557,215 +2765,8 @@ template <_Format_supported_charT _CharT, class _Traits>
 struct formatter<basic_string_view<_CharT, _Traits>, _CharT>
     : _Formatter_base<basic_string_view<_CharT, _Traits>, _CharT, _Basic_format_arg_type::_String_type> {};
 
-template <class _Ty>
-class _Fmt_buffer {
-private:
-    _Ty* _Ptr        = nullptr;
-    size_t _Size     = 0;
-    size_t _Capacity = 0;
-
-protected:
-    explicit _Fmt_buffer(const size_t _Sz) noexcept : _Size(_Sz), _Capacity(_Sz) {}
-
-    _Fmt_buffer(_Ty* _Data, const size_t _Sz, const size_t _Cap) noexcept : _Ptr(_Data), _Size(_Sz), _Capacity(_Cap) {}
-
-    void _Set(_Ty* _Buf_data, const size_t _Buf_capacity) noexcept {
-        _Ptr      = _Buf_data;
-        _Capacity = _Buf_capacity;
-    }
-
-    virtual void _Grow(size_t _Capacity) = 0;
-
-public:
-    using value_type      = _Ty;
-    using const_reference = const _Ty&;
-
-    _Fmt_buffer(const _Fmt_buffer&) = delete;
-    void operator=(const _Fmt_buffer&) = delete;
-
-    _NODISCARD _Ty* begin() noexcept {
-        return _Ptr;
-    }
-
-    _NODISCARD _Ty* end() noexcept {
-        return _Ptr + _Size;
-    }
-
-    _NODISCARD size_t size() const noexcept {
-        return _Size;
-    }
-
-    _NODISCARD size_t capacity() const noexcept {
-        return _Capacity;
-    }
-
-    void clear() noexcept {
-        _Size = 0;
-    }
-
-    void try_resize(const size_t _Count) {
-        try_reserve(_Count);
-        _Size = _Count <= _Capacity ? _Count : _Capacity;
-    }
-
-    void try_reserve(const size_t _New_capacity) {
-        if (_New_capacity > _Capacity) {
-            _Grow(_New_capacity);
-        }
-    }
-
-    void push_back(const _Ty _Value) {
-        try_reserve(_Size + 1);
-        _Ptr[_Size++] = _Value;
-    }
-};
-
-struct _Fmt_buffer_traits {
-    explicit _Fmt_buffer_traits(ptrdiff_t) {}
-
-    _NODISCARD size_t count() const noexcept {
-        return 0;
-    }
-
-    _NODISCARD size_t limit(const size_t _Size) noexcept {
-        return _Size;
-    }
-};
-
-class _Fmt_fixed_buffer_traits {
-private:
-    ptrdiff_t _Count = 0;
-    ptrdiff_t _Limit;
-
-public:
-    explicit _Fmt_fixed_buffer_traits(const ptrdiff_t _Lim) noexcept : _Limit(_Lim) {}
-
-    _NODISCARD size_t count() const noexcept {
-        return static_cast<size_t>(_Count);
-    }
-
-    _NODISCARD size_t limit(const size_t _Size) noexcept {
-        size_t _Avail = static_cast<size_t>(_Limit > _Count ? _Limit - _Count : 0);
-        _Count += _Size;
-        return _Size < _Avail ? _Size : _Avail;
-    }
-};
-
-inline constexpr size_t _Fmt_buffer_size = 256;
-
-template <class _OutputIt, class _Ty, class _Traits = _Fmt_buffer_traits>
-class _Fmt_iterator_buffer final : public _Traits, public _Fmt_buffer<_Ty> {
-private:
-    _OutputIt _Out;
-    _Ty _Data[_Fmt_buffer_size];
-
-protected:
-    void _Grow(size_t) final {
-        if (this->size() == _Fmt_buffer_size) {
-            _Flush();
-        }
-    }
-
-    void _Flush() {
-        auto _Size = this->size();
-        this->clear();
-        _Out = _STD _Copy_unchecked(_Data, _Data + this->limit(_Size), _STD move(_Out));
-    }
-
-public:
-    explicit _Fmt_iterator_buffer(_OutputIt _Output, ptrdiff_t _Size = _Fmt_buffer_size)
-        : _Traits(_Size), _Fmt_buffer<_Ty>(_Data, 0, _Fmt_buffer_size), _Out(_STD move(_Output)) {}
-
-    ~_Fmt_iterator_buffer() {
-        if (this->size() != 0) {
-            _Flush();
-        }
-    }
-
-    _NODISCARD _OutputIt out() {
-        _Flush();
-        return _STD move(_Out);
-    }
-
-    _NODISCARD ptrdiff_t count() const noexcept {
-        return static_cast<ptrdiff_t>(_Traits::count() + this->size());
-    }
-};
-
-template <class _Ty>
-class _Fmt_iterator_buffer<_Ty*, _Ty> final : public _Fmt_buffer<_Ty> {
-protected:
-    void _Grow(size_t) final {}
-
-public:
-    explicit _Fmt_iterator_buffer(_Ty* _Out, ptrdiff_t = 0) : _Fmt_buffer<_Ty>(_Out, 0, ~size_t()) {}
-
-    _NODISCARD _Ty* out() noexcept {
-        return this->end();
-    }
-};
-
-template <class _Container>
-class _Fmt_iterator_buffer<_STD back_insert_iterator<_Container>,
-    enable_if_t<_STD contiguous_iterator<typename _Container::iterator>, typename _Container::value_type>>
-    final : public _Fmt_buffer<typename _Container::value_type> {
-private:
-    _Container& _Cont;
-
-    struct _Accessor : _STD back_insert_iterator<_Container> {
-        _Accessor(_STD back_insert_iterator<_Container> _Iter) : back_insert_iterator<_Container>(_Iter) {}
-
-        using _STD back_insert_iterator<_Container>::container;
-    };
-
-protected:
-    void _Grow(size_t _Capacity) final {
-        _Cont.resize(_Capacity);
-        this->_Set(&_Cont[0], _Capacity);
-    }
-
-public:
-    explicit _Fmt_iterator_buffer(_Container& _C)
-        : _Fmt_buffer<typename _Container::value_type>(_C.size()), _Cont(_C) {}
-
-    explicit _Fmt_iterator_buffer(_STD back_insert_iterator<_Container> _Out, ptrdiff_t = 0)
-        : _Fmt_iterator_buffer(*_Accessor(_STD move(_Out)).container) {}
-
-    _NODISCARD auto out() noexcept {
-        return _STD back_inserter(_Cont);
-    }
-};
-
-template <class _Ty>
-class _Fmt_counting_buffer final : public _Fmt_buffer<_Ty> {
-private:
-    _Ty _Data[_Fmt_buffer_size];
-    size_t _Count = 0;
-
-protected:
-    void _Grow(size_t) final {
-        if (this->size() != _Fmt_buffer_size) {
-            return;
-        }
-        _Count += this->size();
-        this->clear();
-    }
-
-public:
-    _Fmt_counting_buffer() : _Fmt_buffer<_Ty>(_Data, 0, _Fmt_buffer_size) {}
-
-    _NODISCARD size_t count() const noexcept {
-        return _Count + this->size();
-    }
-};
-
-using _Fmt_it  = back_insert_iterator<_Fmt_buffer<char>>;
-using _Fmt_wit = back_insert_iterator<_Fmt_buffer<wchar_t>>;
-
-using format_context  = basic_format_context<_Fmt_it, char>;
-using wformat_context = basic_format_context<_Fmt_wit, wchar_t>;
-using format_args     = basic_format_args<format_context>;
-using wformat_args    = basic_format_args<wformat_context>;
+using format_args  = basic_format_args<format_context>;
+using wformat_args = basic_format_args<wformat_context>;
 
 template <class _Context = format_context, class... _Args>
 _NODISCARD auto make_format_args(const _Args&... _Vals) {
@@ -2826,14 +2827,14 @@ _OutputIt format_to(_OutputIt _Out, const string_view _Fmt, const _Types&... _Ar
 template <output_iterator<const wchar_t&> _OutputIt, class... _Types>
 _OutputIt format_to(_OutputIt _Out, const wstring_view _Fmt, const _Types&... _Args) {
     _Fmt_iterator_buffer<_OutputIt, wchar_t> _Buf(_STD move(_Out));
-    _STD vformat_to(_Fmt_wit(_Buf), _Fmt, make_wformat_args(_Args...));
+    _STD vformat_to(_Fmt_wit(_Buf), _Fmt, _STD make_wformat_args(_Args...));
     return _Buf.out();
 }
 
 template <output_iterator<const char&> _OutputIt, class... _Types>
 _OutputIt format_to(_OutputIt _Out, const locale& _Loc, const string_view _Fmt, const _Types&... _Args) {
     _Fmt_iterator_buffer<_OutputIt, char> _Buf(_STD move(_Out));
-    _STD vformat_to(_Fmt_it(_Buf), _Loc, _Fmt, make_format_args(_Args...));
+    _STD vformat_to(_Fmt_it(_Buf), _Loc, _Fmt, _STD make_format_args(_Args...));
     return _Buf.out();
 }
 

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -1646,10 +1646,15 @@ public:
     }
 };
 
+// clang-format off
 template <class _Container>
-class _Fmt_iterator_buffer<back_insert_iterator<_Container>,
-    enable_if_t<contiguous_iterator<typename _Container::iterator>, typename _Container::value_type>>
-    final : public _Fmt_buffer<typename _Container::value_type> {
+    requires _RANGES contiguous_range<_Container> && _RANGES sized_range<_Container>
+        && requires(_Container& _Cont, const _RANGES range_value_t<_Container>& _Val) {
+            _Cont.push_back(_Val);
+        }
+// clang-format on
+class _Fmt_iterator_buffer<back_insert_iterator<_Container>, _RANGES range_value_t<_Container>> final
+    : public _Fmt_buffer<_RANGES range_value_t<_Container>> {
 private:
     _Container& _Cont;
 
@@ -1666,7 +1671,7 @@ private:
 
 public:
     explicit _Fmt_iterator_buffer(_Container& _Cont_)
-        : _Fmt_buffer<typename _Container::value_type>(_Cont_.size()), _Cont(_Cont_) {}
+        : _Fmt_buffer<_RANGES range_value_t<_Container>>(_RANGES size(_Cont_)), _Cont(_Cont_) {}
 
     explicit _Fmt_iterator_buffer(back_insert_iterator<_Container> _Out, ptrdiff_t = 0)
         : _Fmt_iterator_buffer(*_Accessor{_Out}.container) {}

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -2557,8 +2557,202 @@ template <_Format_supported_charT _CharT, class _Traits>
 struct formatter<basic_string_view<_CharT, _Traits>, _CharT>
     : _Formatter_base<basic_string_view<_CharT, _Traits>, _CharT, _Basic_format_arg_type::_String_type> {};
 
-using format_context  = basic_format_context<back_insert_iterator<string>, string::value_type>;
-using wformat_context = basic_format_context<back_insert_iterator<wstring>, wstring::value_type>;
+template <class _Ty>
+class _Fmt_buffer {
+private:
+    _Ty* _Ptr        = nullptr;
+    size_t _Size     = 0;
+    size_t _Capacity = 0;
+
+protected:
+    explicit _Fmt_buffer(const size_t _Sz) noexcept : _Size(_Sz), _Capacity(_Sz) {}
+    _Fmt_buffer(_Ty* _Data, const size_t _Sz, const size_t _Cap) noexcept : _Ptr(_Data), _Size(_Sz), _Capacity(_Cap) {}
+
+    void _Set(_Ty* _Buf_data, const size_t _Buf_capacity) noexcept {
+        _Ptr      = _Buf_data;
+        _Capacity = _Buf_capacity;
+    }
+
+    virtual void _Grow(size_t _Capacity) = 0;
+
+public:
+    using value_type      = _Ty;
+    using const_reference = const _Ty&;
+
+    _Fmt_buffer(const _Fmt_buffer&) = delete;
+    void operator=(const _Fmt_buffer&) = delete;
+
+    _NODISCARD _Ty* begin() noexcept {
+        return _Ptr;
+    }
+    _NODISCARD _Ty* end() noexcept {
+        return _Ptr + _Size;
+    }
+
+    _NODISCARD size_t size() const noexcept {
+        return _Size;
+    }
+
+    _NODISCARD size_t capacity() const noexcept {
+        return _Capacity;
+    }
+
+    void clear() noexcept {
+        _Size = 0;
+    }
+
+    void try_resize(const size_t _Count) {
+        try_reserve(_Count);
+        _Size = _Count <= _Capacity ? _Count : _Capacity;
+    }
+
+    void try_reserve(const size_t _New_capacity) {
+        if (_New_capacity > _Capacity) {
+            _Grow(_New_capacity);
+        }
+    }
+
+    void push_back(const _Ty _Value) {
+        try_reserve(_Size + 1);
+        _Ptr[_Size++] = _Value;
+    }
+};
+
+struct _Fmt_buffer_traits {
+    explicit _Fmt_buffer_traits(ptrdiff_t) {}
+    _NODISCARD size_t count() const noexcept {
+        return 0;
+    }
+    _NODISCARD size_t limit(const size_t _Size) noexcept {
+        return _Size;
+    }
+};
+
+class _Fmt_fixed_buffer_traits {
+private:
+    size_t _Count = 0;
+    size_t _Limit;
+
+public:
+    explicit _Fmt_fixed_buffer_traits(const ptrdiff_t _Lim) noexcept : _Limit(static_cast<size_t>(_Lim)) {}
+    _NODISCARD size_t count() const noexcept {
+        return _Count;
+    }
+    _NODISCARD size_t limit(const size_t _Size) noexcept {
+        size_t _Avail = _Limit > _Count ? _Limit - _Count : 0;
+        _Count += _Size;
+        return _Size < _Avail ? _Size : _Avail;
+    }
+};
+
+inline constexpr size_t _Fmt_buffer_size = 256;
+
+template <class _OutputIt, class _Ty, class _Traits = _Fmt_buffer_traits>
+class _Fmt_iterator_buffer final : public _Traits, public _Fmt_buffer<_Ty> {
+private:
+    _OutputIt _Out;
+    _Ty _Data[_Fmt_buffer_size];
+
+protected:
+    void _Grow(size_t) final override {
+        if (this->size() == _Fmt_buffer_size) {
+            _Flush();
+        }
+    }
+    void _Flush() {
+        auto _Size = this->size();
+        this->clear();
+        _Out = _STD _Copy_unchecked(_Data, _Data + this->limit(_Size), _STD move(_Out));
+    }
+
+public:
+    explicit _Fmt_iterator_buffer(_OutputIt _Output, ptrdiff_t _Size = _Fmt_buffer_size)
+        : _Traits(_Size), _Fmt_buffer<_Ty>(_Data, 0, _Fmt_buffer_size), _Out(_STD move(_Output)) {}
+    ~_Fmt_iterator_buffer() {
+        if (this->size() != 0) {
+            _Flush();
+        }
+    }
+
+    _NODISCARD _OutputIt out() {
+        _Flush();
+        return _STD move(_Out);
+    }
+    _NODISCARD ptrdiff_t count() const noexcept {
+        return static_cast<ptrdiff_t>(_Traits::count() + this->size());
+    }
+};
+
+template <class _Ty>
+class _Fmt_iterator_buffer<_Ty*, _Ty> final : public _Fmt_buffer<_Ty> {
+protected:
+    void _Grow(size_t) final override {}
+
+public:
+    explicit _Fmt_iterator_buffer(_Ty* _Out, ptrdiff_t = 0) : _Fmt_buffer<_Ty>(_Out, 0, ~size_t()) {}
+
+    _NODISCARD _Ty* out() noexcept {
+        return this->end();
+    }
+};
+
+template <class _Container>
+class _Fmt_iterator_buffer<_STD back_insert_iterator<_Container>,
+    enable_if_t<_STD contiguous_iterator<typename _Container::iterator>, typename _Container::value_type>>
+    final : public _Fmt_buffer<typename _Container::value_type> {
+private:
+    _Container& _Cont;
+
+    struct _Accessor : _STD back_insert_iterator<_Container> {
+        _Accessor(_STD back_insert_iterator<_Container> _Iter) : back_insert_iterator<_Container>(_Iter) {}
+        using _STD back_insert_iterator<_Container>::container;
+    };
+
+protected:
+    void _Grow(size_t _Capacity) final override {
+        _Cont.resize(_Capacity);
+        this->_Set(&_Cont[0], _Capacity);
+    }
+
+public:
+    explicit _Fmt_iterator_buffer(_Container& _C)
+        : _Fmt_buffer<typename _Container::value_type>(_C.size()), _Cont(_C) {}
+    explicit _Fmt_iterator_buffer(_STD back_insert_iterator<_Container> _Out, ptrdiff_t = 0)
+        : _Fmt_iterator_buffer(*_Accessor(_STD move(_Out)).container) {}
+
+    _NODISCARD auto out() {
+        return _STD back_inserter(_Cont);
+    }
+};
+
+template <class _Ty>
+class _Fmt_counting_buffer final : public _Fmt_buffer<_Ty> {
+private:
+    _Ty _Data[_Fmt_buffer_size];
+    size_t _Count = 0;
+
+protected:
+    void _Grow(size_t) final override {
+        if (this->size() != _Fmt_buffer_size) {
+            return;
+        }
+        _Count += this->size();
+        this->clear();
+    }
+
+public:
+    _Fmt_counting_buffer() : _Fmt_buffer<_Ty>(_Data, 0, _Fmt_buffer_size) {}
+
+    _NODISCARD size_t count() const noexcept {
+        return _Count + this->size();
+    }
+};
+
+using _Fmt_it  = back_insert_iterator<_Fmt_buffer<char>>;
+using _Fmt_wit = back_insert_iterator<_Fmt_buffer<wchar_t>>;
+
+using format_context  = basic_format_context<_Fmt_it, char>;
+using wformat_context = basic_format_context<_Fmt_wit, wchar_t>;
 using format_args     = basic_format_args<format_context>;
 using wformat_args    = basic_format_args<wformat_context>;
 
@@ -2613,49 +2807,57 @@ _OutputIt vformat_to(_OutputIt _Out, const locale& _Loc, const wstring_view _Fmt
 
 template <output_iterator<const char&> _OutputIt, class... _Types>
 _OutputIt format_to(_OutputIt _Out, const string_view _Fmt, const _Types&... _Args) {
-    using _Context = basic_format_context<_OutputIt, char>;
-    return _STD vformat_to(_STD move(_Out), _Fmt, _STD make_format_args<_Context>(_Args...));
+    _Fmt_iterator_buffer<_OutputIt, char> _Buf(_STD move(_Out));
+    _STD vformat_to(_Fmt_it(_Buf), _Fmt, _STD make_format_args(_Args...));
+    return _Buf.out();
 }
 
 template <output_iterator<const wchar_t&> _OutputIt, class... _Types>
 _OutputIt format_to(_OutputIt _Out, const wstring_view _Fmt, const _Types&... _Args) {
-    using _Context = basic_format_context<_OutputIt, wchar_t>;
-    return _STD vformat_to(_STD move(_Out), _Fmt, _STD make_format_args<_Context>(_Args...));
+    _Fmt_iterator_buffer<_OutputIt, wchar_t> _Buf(_STD move(_Out));
+    _STD vformat_to(_Fmt_wit(_Buf), _Fmt, make_wformat_args(_Args...));
+    return _Buf.out();
 }
 
 template <output_iterator<const char&> _OutputIt, class... _Types>
 _OutputIt format_to(_OutputIt _Out, const locale& _Loc, const string_view _Fmt, const _Types&... _Args) {
-    using _Context = basic_format_context<_OutputIt, char>;
-    return _STD vformat_to(_STD move(_Out), _Loc, _Fmt, _STD make_format_args<_Context>(_Args...));
+    _Fmt_iterator_buffer<_OutputIt, char> _Buf(_STD move(_Out));
+    _STD vformat_to(_Fmt_it(_Buf), _Loc, _Fmt, make_format_args(_Args...));
+    return _Buf.out();
 }
 
 template <output_iterator<const wchar_t&> _OutputIt, class... _Types>
 _OutputIt format_to(_OutputIt _Out, const locale& _Loc, const wstring_view _Fmt, const _Types&... _Args) {
-    using _Context = basic_format_context<_OutputIt, wchar_t>;
-    return _STD vformat_to(_STD move(_Out), _Loc, _Fmt, _STD make_format_args<_Context>(_Args...));
+    _Fmt_iterator_buffer<_OutputIt, wchar_t> _Buf(_STD move(_Out));
+    _STD vformat_to(_Fmt_wit(_Buf), _Loc, _Fmt, _STD make_wformat_args(_Args...));
+    return _Buf.out();
 }
 
 _NODISCARD inline string vformat(const string_view _Fmt, const format_args _Args) {
     string _Str;
-    _STD vformat_to(_STD back_inserter(_Str), _Fmt, _Args);
+    _Fmt_iterator_buffer<back_insert_iterator<string>, char> _Buf(_STD back_inserter(_Str));
+    _STD vformat_to(_Fmt_it(_Buf), _Fmt, _Args);
     return _Str;
 }
 
 _NODISCARD inline wstring vformat(const wstring_view _Fmt, const wformat_args _Args) {
     wstring _Str;
-    _STD vformat_to(_STD back_inserter(_Str), _Fmt, _Args);
+    _Fmt_iterator_buffer<back_insert_iterator<wstring>, wchar_t> _Buf(_STD back_inserter(_Str));
+    _STD vformat_to(_Fmt_wit(_Buf), _Fmt, _Args);
     return _Str;
 }
 
 _NODISCARD inline string vformat(const locale& _Loc, const string_view _Fmt, const format_args _Args) {
     string _Str;
-    _STD vformat_to(_STD back_inserter(_Str), _Loc, _Fmt, _Args);
+    _Fmt_iterator_buffer<back_insert_iterator<string>, char> _Buf(_STD back_inserter(_Str));
+    _STD vformat_to(_Fmt_it(_Buf), _Loc, _Fmt, _Args);
     return _Str;
 }
 
 _NODISCARD inline wstring vformat(const locale& _Loc, const wstring_view _Fmt, const wformat_args _Args) {
     wstring _Str;
-    _STD vformat_to(_STD back_inserter(_Str), _Loc, _Fmt, _Args);
+    _Fmt_iterator_buffer<back_insert_iterator<wstring>, wchar_t> _Buf(_STD back_inserter(_Str));
+    _STD vformat_to(_Fmt_wit(_Buf), _Loc, _Fmt, _Args);
     return _Str;
 }
 
@@ -2679,35 +2881,6 @@ _NODISCARD wstring format(const locale& _Loc, const wstring_view _Fmt, const _Ty
     return _STD vformat(_Loc, _Fmt, _STD make_wformat_args(_Args...));
 }
 
-template <class _OutputIt, class _CharT>
-struct _Format_to_n_iterator {
-    _OutputIt _Out;
-    iter_difference_t<_OutputIt> _Max;
-    iter_difference_t<_OutputIt> _Count = 0;
-
-    using difference_type = iter_difference_t<_OutputIt>;
-
-    _Format_to_n_iterator& operator=(_CharT _Ch) {
-        if (_Count < _Max) {
-            *_Out++ = _Ch;
-        }
-        ++_Count;
-        return *this;
-    }
-
-    _NODISCARD _Format_to_n_iterator& operator*() {
-        return *this;
-    }
-
-    _Format_to_n_iterator& operator++() {
-        return *this;
-    }
-
-    _Format_to_n_iterator& operator++(int) {
-        return *this;
-    }
-};
-
 template <class _OutputIt>
 struct format_to_n_result {
     _OutputIt out;
@@ -2717,97 +2890,61 @@ struct format_to_n_result {
 template <output_iterator<const char&> _OutputIt, class... _Types>
 format_to_n_result<_OutputIt> format_to_n(
     _OutputIt _Out, const iter_difference_t<_OutputIt> _Max, const string_view _Fmt, const _Types&... _Args) {
-    _Format_to_n_iterator<_OutputIt, char> _It{._Out = _STD move(_Out), ._Max = _Max};
-
-    using _Context  = basic_format_context<decltype(_It), char>;
-    auto _Arg_store = _STD make_format_args<_Context>(_Args...);
-    _It             = _STD vformat_to(_STD move(_It), _Fmt, _STD move(_Arg_store));
-    return {.out = _STD move(_It._Out), .size = _It._Count};
+    _Fmt_iterator_buffer<_OutputIt, char, _Fmt_fixed_buffer_traits> _Buf(_STD move(_Out), _Max);
+    _STD vformat_to(_Fmt_it(_Buf), _Fmt, _STD make_format_args(_Args...));
+    return {.out = _Buf.out(), .size = _Buf.count()};
 }
 
 template <output_iterator<const wchar_t&> _OutputIt, class... _Types>
 format_to_n_result<_OutputIt> format_to_n(
     _OutputIt _Out, const iter_difference_t<_OutputIt> _Max, const wstring_view _Fmt, const _Types&... _Args) {
-    _Format_to_n_iterator<_OutputIt, wchar_t> _It{._Out = _STD move(_Out), ._Max = _Max};
-
-    using _Context  = basic_format_context<decltype(_It), wchar_t>;
-    auto _Arg_store = _STD make_format_args<_Context>(_Args...);
-    _It             = _STD vformat_to(_STD move(_It), _Fmt, _STD move(_Arg_store));
-    return {.out = _STD move(_It._Out), .size = _It._Count};
+    _Fmt_iterator_buffer<_OutputIt, wchar_t, _Fmt_fixed_buffer_traits> _Buf(_STD move(_Out), _Max);
+    _STD vformat_to(_Fmt_wit(_Buf), _Fmt, _STD make_wformat_args(_Args...));
+    return {.out = _Buf.out(), .size = _Buf.count()};
 }
 
 template <output_iterator<const char&> _OutputIt, class... _Types>
 format_to_n_result<_OutputIt> format_to_n(_OutputIt _Out, const iter_difference_t<_OutputIt> _Max, const locale& _Loc,
     const string_view _Fmt, const _Types&... _Args) {
-    _Format_to_n_iterator<_OutputIt, char> _It{._Out = _STD move(_Out), ._Max = _Max};
-
-    using _Context  = basic_format_context<decltype(_It), char>;
-    auto _Arg_store = _STD make_format_args<_Context>(_Args...);
-    _It             = _STD vformat_to(_STD move(_It), _Loc, _Fmt, _STD move(_Arg_store));
-    return {.out = _STD move(_It._Out), .size = _It._Count};
+    _Fmt_iterator_buffer<_OutputIt, char, _Fmt_fixed_buffer_traits> _Buf(_STD move(_Out), _Max);
+    _STD vformat_to(_Fmt_it(_Buf), _Loc, _Fmt, _STD make_format_args(_Args...));
+    return {.out = _Buf.out(), .size = _Buf.count()};
 }
 
 template <output_iterator<const wchar_t&> _OutputIt, class... _Types>
 format_to_n_result<_OutputIt> format_to_n(_OutputIt _Out, const iter_difference_t<_OutputIt> _Max, const locale& _Loc,
     const wstring_view _Fmt, const _Types&... _Args) {
-    _Format_to_n_iterator<_OutputIt, wchar_t> _It{._Out = _STD move(_Out), ._Max = _Max};
-
-    using _Context  = basic_format_context<decltype(_It), wchar_t>;
-    auto _Arg_store = _STD make_format_args<_Context>(_Args...);
-    _It             = _STD vformat_to(_STD move(_It), _Loc, _Fmt, _STD move(_Arg_store));
-    return {.out = _STD move(_It._Out), .size = _It._Count};
+    _Fmt_iterator_buffer<_OutputIt, wchar_t, _Fmt_fixed_buffer_traits> _Buf(_STD move(_Out), _Max);
+    _STD vformat_to(_Fmt_wit(_Buf), _Loc, _Fmt, _STD make_wformat_args(_Args...));
+    return {.out = _Buf.out(), .size = _Buf.count()};
 }
-
-struct _Counting_iterator {
-    size_t _Count = 0;
-
-    using difference_type = ptrdiff_t;
-
-    template <class _CharT>
-    _Counting_iterator& operator=(_CharT) {
-        ++_Count;
-        return *this;
-    }
-
-    _NODISCARD _Counting_iterator& operator*() {
-        return *this;
-    }
-
-    _Counting_iterator& operator++() {
-        return *this;
-    }
-
-    _Counting_iterator& operator++(int) {
-        return *this;
-    }
-};
 
 template <class... _Types>
 _NODISCARD size_t formatted_size(const string_view _Fmt, const _Types&... _Args) {
-    using _Context  = basic_format_context<_Counting_iterator, char>;
-    auto _Arg_store = _STD make_format_args<_Context>(_Args...);
-    return _STD vformat_to(_Counting_iterator{}, _Fmt, _STD move(_Arg_store))._Count;
+    _Fmt_counting_buffer<char> _Buf;
+    _STD vformat_to(_Fmt_it(_Buf), _Fmt, _STD make_format_args(_Args...));
+    return _Buf.count();
 }
 
 template <class... _Types>
 _NODISCARD size_t formatted_size(const wstring_view _Fmt, const _Types&... _Args) {
-    using _Context  = basic_format_context<_Counting_iterator, wchar_t>;
-    auto _Arg_store = _STD make_format_args<_Context>(_Args...);
-    return _STD vformat_to(_Counting_iterator{}, _Fmt, _STD move(_Arg_store))._Count;
+    _Fmt_counting_buffer<wchar_t> _Buf;
+    _STD vformat_to(_Fmt_wit(_Buf), _Fmt, _STD make_wformat_args(_Args...));
+    return _Buf.count();
 }
 
 template <class... _Types>
 _NODISCARD size_t formatted_size(const locale& _Loc, const string_view _Fmt, const _Types&... _Args) {
-    using _Context  = basic_format_context<_Counting_iterator, char>;
-    auto _Arg_store = _STD make_format_args<_Context>(_Args...);
-    return _STD vformat_to(_Counting_iterator{}, _Loc, _Fmt, _STD move(_Arg_store))._Count;
+    _Fmt_counting_buffer<char> _Buf;
+    _STD vformat_to(_Fmt_it(_Buf), _Loc, _Fmt, _STD make_format_args(_Args...));
+    return _Buf.count();
 }
 
 template <class... _Types>
 _NODISCARD size_t formatted_size(const locale& _Loc, const wstring_view _Fmt, const _Types&... _Args) {
-    using _Context  = basic_format_context<_Counting_iterator, wchar_t>;
-    auto _Arg_store = _STD make_format_args<_Context>(_Args...);
-    return _STD vformat_to(_Counting_iterator{}, _Loc, _Fmt, _STD move(_Arg_store))._Count;
+    _Fmt_counting_buffer<wchar_t> _Buf;
+    _STD vformat_to(_Fmt_wit(_Buf), _Loc, _Fmt, _STD make_wformat_args(_Args...));
+    return _Buf.count();
 }
 
 _STD_END

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -1496,8 +1496,6 @@ public:
     }
 };
 
-#pragma warning(push)
-#pragma warning(disable : 4265) // non-virtual destructor in base class
 template <class _Ty>
 class _Fmt_buffer {
 private:
@@ -1507,6 +1505,8 @@ private:
 
 protected:
     explicit _Fmt_buffer(const size_t _Size) noexcept : _Size_(_Size), _Capacity_(_Size) {}
+
+    ~_Fmt_buffer() = default;
 
     _Fmt_buffer(_Ty* _Data, const size_t _Size, const size_t _Capacity) noexcept
         : _Ptr_(_Data), _Size_(_Size), _Capacity_(_Capacity) {}
@@ -1560,7 +1560,6 @@ public:
         _Ptr_[_Size_++] = _Value;
     }
 };
-#pragma warning(pop)
 
 struct _Fmt_buffer_traits {
     explicit _Fmt_buffer_traits(ptrdiff_t) {}

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -1496,96 +1496,99 @@ public:
     }
 };
 
+#pragma warning(push)
+#pragma warning(disable : 4265) // non-virtual destructor in base class
 template <class _Ty>
 class _Fmt_buffer {
 private:
-    _Ty* _Ptr        = nullptr;
-    size_t _Size     = 0;
-    size_t _Capacity = 0;
+    _Ty* _Ptr_        = nullptr;
+    size_t _Size_     = 0;
+    size_t _Capacity_ = 0;
 
 protected:
-    explicit _Fmt_buffer(const size_t _Sz) noexcept : _Size(_Sz), _Capacity(_Sz) {}
+    explicit _Fmt_buffer(const size_t _Size) noexcept : _Size_(_Size), _Capacity_(_Size) {}
 
-    _Fmt_buffer(_Ty* _Data, const size_t _Sz, const size_t _Cap) noexcept : _Ptr(_Data), _Size(_Sz), _Capacity(_Cap) {}
+    _Fmt_buffer(_Ty* _Data, const size_t _Size, const size_t _Capacity) noexcept
+        : _Ptr_(_Data), _Size_(_Size), _Capacity_(_Capacity) {}
 
     void _Set(_Ty* _Buf_data, const size_t _Buf_capacity) noexcept {
-        _Ptr      = _Buf_data;
-        _Capacity = _Buf_capacity;
+        _Ptr_      = _Buf_data;
+        _Capacity_ = _Buf_capacity;
     }
 
     virtual void _Grow(size_t _Capacity) = 0;
 
 public:
-    using value_type      = _Ty;
-    using const_reference = const _Ty&;
+    using value_type = _Ty;
 
     _Fmt_buffer(const _Fmt_buffer&) = delete;
     void operator=(const _Fmt_buffer&) = delete;
 
     _NODISCARD _Ty* begin() noexcept {
-        return _Ptr;
+        return _Ptr_;
     }
 
     _NODISCARD _Ty* end() noexcept {
-        return _Ptr + _Size;
+        return _Ptr_ + _Size_;
     }
 
-    _NODISCARD size_t size() const noexcept {
-        return _Size;
+    _NODISCARD size_t _Size() const noexcept {
+        return _Size_;
     }
 
-    _NODISCARD size_t capacity() const noexcept {
-        return _Capacity;
+    _NODISCARD size_t _Capacity() const noexcept {
+        return _Capacity_;
     }
 
-    void clear() noexcept {
-        _Size = 0;
+    void _Clear() noexcept {
+        _Size_ = 0;
     }
 
-    void try_resize(const size_t _Count) {
-        try_reserve(_Count);
-        _Size = _Count <= _Capacity ? _Count : _Capacity;
+    void _Try_resize(const size_t _Count) {
+        _Try_reserve(_Count);
+        _Size_ = _Count <= _Capacity_ ? _Count : _Capacity_;
     }
 
-    void try_reserve(const size_t _New_capacity) {
-        if (_New_capacity > _Capacity) {
+    void _Try_reserve(const size_t _New_capacity) {
+        if (_New_capacity > _Capacity_) {
             _Grow(_New_capacity);
         }
     }
 
     void push_back(const _Ty _Value) {
-        try_reserve(_Size + 1);
-        _Ptr[_Size++] = _Value;
+        _Try_reserve(_Size_ + 1);
+        _Ptr_[_Size_++] = _Value;
     }
 };
+#pragma warning(pop)
 
 struct _Fmt_buffer_traits {
     explicit _Fmt_buffer_traits(ptrdiff_t) {}
 
-    _NODISCARD size_t count() const noexcept {
+    _NODISCARD size_t _Count() const noexcept {
         return 0;
     }
 
-    _NODISCARD size_t limit(const size_t _Size) noexcept {
+    _NODISCARD size_t _Limit(const size_t _Size) noexcept {
         return _Size;
     }
 };
 
 class _Fmt_fixed_buffer_traits {
 private:
-    ptrdiff_t _Count = 0;
-    ptrdiff_t _Limit;
+    ptrdiff_t _Count_ = 0;
+    ptrdiff_t _Limit_;
 
 public:
-    explicit _Fmt_fixed_buffer_traits(const ptrdiff_t _Lim) noexcept : _Limit(_Lim) {}
+    explicit _Fmt_fixed_buffer_traits(const ptrdiff_t _Limit) noexcept : _Limit_(_Limit) {}
 
-    _NODISCARD size_t count() const noexcept {
-        return static_cast<size_t>(_Count);
+    _NODISCARD size_t _Count() const noexcept {
+        return static_cast<size_t>(_Count_);
     }
 
-    _NODISCARD size_t limit(const size_t _Size) noexcept {
-        size_t _Avail = static_cast<size_t>(_Limit > _Count ? _Limit - _Count : 0);
-        _Count += _Size;
+    _NODISCARD size_t _Limit(const size_t _Size) noexcept {
+        size_t _Avail = static_cast<size_t>(_Limit_ > _Count_ ? _Limit_ - _Count_ : 0);
+        _Count_ += _Size;
         return _Size < _Avail ? _Size : _Avail;
     }
 };
@@ -1595,51 +1598,50 @@ inline constexpr size_t _Fmt_buffer_size = 256;
 template <class _OutputIt, class _Ty, class _Traits = _Fmt_buffer_traits>
 class _Fmt_iterator_buffer final : public _Traits, public _Fmt_buffer<_Ty> {
 private:
-    _OutputIt _Out;
+    _OutputIt _Output;
     _Ty _Data[_Fmt_buffer_size];
 
-protected:
     void _Grow(size_t) final {
-        if (this->size() == _Fmt_buffer_size) {
+        if (this->_Size() == _Fmt_buffer_size) {
             _Flush();
         }
     }
 
     void _Flush() {
-        auto _Size = this->size();
-        this->clear();
-        _Out = _STD _Copy_unchecked(_Data, _Data + this->limit(_Size), _STD move(_Out));
+        auto _Size = this->_Size();
+        this->_Clear();
+        _Output = _STD _Copy_unchecked(_Data, _Data + this->_Limit(_Size), _STD move(_Output));
     }
 
 public:
-    explicit _Fmt_iterator_buffer(_OutputIt _Output, ptrdiff_t _Size = _Fmt_buffer_size)
-        : _Traits(_Size), _Fmt_buffer<_Ty>(_Data, 0, _Fmt_buffer_size), _Out(_STD move(_Output)) {}
+    explicit _Fmt_iterator_buffer(_OutputIt _Out, ptrdiff_t _Size = _Fmt_buffer_size)
+        : _Traits(_Size), _Fmt_buffer<_Ty>(_Data, 0, _Fmt_buffer_size), _Output(_STD move(_Out)) {}
 
     ~_Fmt_iterator_buffer() {
-        if (this->size() != 0) {
+        if (this->_Size() != 0) {
             _Flush();
         }
     }
 
-    _NODISCARD _OutputIt out() {
+    _NODISCARD _OutputIt _Out() {
         _Flush();
-        return _STD move(_Out);
+        return _STD move(_Output);
     }
 
-    _NODISCARD ptrdiff_t count() const noexcept {
-        return static_cast<ptrdiff_t>(_Traits::count() + this->size());
+    _NODISCARD ptrdiff_t _Count() const noexcept {
+        return static_cast<ptrdiff_t>(_Traits::_Count() + this->_Size());
     }
 };
 
 template <class _Ty>
 class _Fmt_iterator_buffer<_Ty*, _Ty> final : public _Fmt_buffer<_Ty> {
-protected:
+private:
     void _Grow(size_t) final {}
 
 public:
-    explicit _Fmt_iterator_buffer(_Ty* _Out, ptrdiff_t = 0) : _Fmt_buffer<_Ty>(_Out, 0, ~size_t()) {}
+    explicit _Fmt_iterator_buffer(_Ty* _Out, ptrdiff_t = 0) : _Fmt_buffer<_Ty>(_Out, 0, ~size_t{}) {}
 
-    _NODISCARD _Ty* out() noexcept {
+    _NODISCARD _Ty* _Out() noexcept {
         return this->end();
     }
 };
@@ -1657,21 +1659,20 @@ private:
         using _STD back_insert_iterator<_Container>::container;
     };
 
-protected:
     void _Grow(size_t _Capacity) final {
         _Cont.resize(_Capacity);
-        this->_Set(&_Cont[0], _Capacity);
+        this->_Set(_RANGES data(_Cont), _Capacity);
     }
 
 public:
-    explicit _Fmt_iterator_buffer(_Container& _C)
-        : _Fmt_buffer<typename _Container::value_type>(_C.size()), _Cont(_C) {}
+    explicit _Fmt_iterator_buffer(_Container& _Cont_)
+        : _Fmt_buffer<typename _Container::value_type>(_Cont_.size()), _Cont(_Cont_) {}
 
     explicit _Fmt_iterator_buffer(_STD back_insert_iterator<_Container> _Out, ptrdiff_t = 0)
-        : _Fmt_iterator_buffer(*_Accessor(_STD move(_Out)).container) {}
+        : _Fmt_iterator_buffer(*_Accessor{_Out}.container) {}
 
-    _NODISCARD auto out() noexcept {
-        return _STD back_inserter(_Cont);
+    _NODISCARD auto _Out() noexcept {
+        return back_insert_iterator{_Cont};
     }
 };
 
@@ -1679,22 +1680,21 @@ template <class _Ty>
 class _Fmt_counting_buffer final : public _Fmt_buffer<_Ty> {
 private:
     _Ty _Data[_Fmt_buffer_size];
-    size_t _Count = 0;
+    size_t _Count_ = 0;
 
-protected:
     void _Grow(size_t) final {
-        if (this->size() != _Fmt_buffer_size) {
+        if (this->_Size() != _Fmt_buffer_size) {
             return;
         }
-        _Count += this->size();
-        this->clear();
+        _Count_ += this->_Size();
+        this->_Clear();
     }
 
 public:
     _Fmt_counting_buffer() : _Fmt_buffer<_Ty>(_Data, 0, _Fmt_buffer_size) {}
 
-    _NODISCARD size_t count() const noexcept {
-        return _Count + this->size();
+    _NODISCARD size_t _Count() const noexcept {
+        return _Count_ + this->_Size();
     }
 };
 
@@ -2820,56 +2820,56 @@ _OutputIt vformat_to(_OutputIt _Out, const locale& _Loc, const wstring_view _Fmt
 template <output_iterator<const char&> _OutputIt, class... _Types>
 _OutputIt format_to(_OutputIt _Out, const string_view _Fmt, const _Types&... _Args) {
     _Fmt_iterator_buffer<_OutputIt, char> _Buf(_STD move(_Out));
-    _STD vformat_to(_Fmt_it(_Buf), _Fmt, _STD make_format_args(_Args...));
-    return _Buf.out();
+    _STD vformat_to(_Fmt_it{_Buf}, _Fmt, _STD make_format_args(_Args...));
+    return _Buf._Out();
 }
 
 template <output_iterator<const wchar_t&> _OutputIt, class... _Types>
 _OutputIt format_to(_OutputIt _Out, const wstring_view _Fmt, const _Types&... _Args) {
     _Fmt_iterator_buffer<_OutputIt, wchar_t> _Buf(_STD move(_Out));
-    _STD vformat_to(_Fmt_wit(_Buf), _Fmt, _STD make_wformat_args(_Args...));
-    return _Buf.out();
+    _STD vformat_to(_Fmt_wit{_Buf}, _Fmt, _STD make_wformat_args(_Args...));
+    return _Buf._Out();
 }
 
 template <output_iterator<const char&> _OutputIt, class... _Types>
 _OutputIt format_to(_OutputIt _Out, const locale& _Loc, const string_view _Fmt, const _Types&... _Args) {
     _Fmt_iterator_buffer<_OutputIt, char> _Buf(_STD move(_Out));
-    _STD vformat_to(_Fmt_it(_Buf), _Loc, _Fmt, _STD make_format_args(_Args...));
-    return _Buf.out();
+    _STD vformat_to(_Fmt_it{_Buf}, _Loc, _Fmt, _STD make_format_args(_Args...));
+    return _Buf._Out();
 }
 
 template <output_iterator<const wchar_t&> _OutputIt, class... _Types>
 _OutputIt format_to(_OutputIt _Out, const locale& _Loc, const wstring_view _Fmt, const _Types&... _Args) {
     _Fmt_iterator_buffer<_OutputIt, wchar_t> _Buf(_STD move(_Out));
-    _STD vformat_to(_Fmt_wit(_Buf), _Loc, _Fmt, _STD make_wformat_args(_Args...));
-    return _Buf.out();
+    _STD vformat_to(_Fmt_wit{_Buf}, _Loc, _Fmt, _STD make_wformat_args(_Args...));
+    return _Buf._Out();
 }
 
 _NODISCARD inline string vformat(const string_view _Fmt, const format_args _Args) {
     string _Str;
-    _Fmt_iterator_buffer<back_insert_iterator<string>, char> _Buf(_STD back_inserter(_Str));
-    _STD vformat_to(_Fmt_it(_Buf), _Fmt, _Args);
+    _Fmt_iterator_buffer<back_insert_iterator<string>, char> _Buf(back_insert_iterator{_Str});
+    _STD vformat_to(_Fmt_it{_Buf}, _Fmt, _Args);
     return _Str;
 }
 
 _NODISCARD inline wstring vformat(const wstring_view _Fmt, const wformat_args _Args) {
     wstring _Str;
-    _Fmt_iterator_buffer<back_insert_iterator<wstring>, wchar_t> _Buf(_STD back_inserter(_Str));
-    _STD vformat_to(_Fmt_wit(_Buf), _Fmt, _Args);
+    _Fmt_iterator_buffer<back_insert_iterator<wstring>, wchar_t> _Buf(back_insert_iterator{_Str});
+    _STD vformat_to(_Fmt_wit{_Buf}, _Fmt, _Args);
     return _Str;
 }
 
 _NODISCARD inline string vformat(const locale& _Loc, const string_view _Fmt, const format_args _Args) {
     string _Str;
-    _Fmt_iterator_buffer<back_insert_iterator<string>, char> _Buf(_STD back_inserter(_Str));
-    _STD vformat_to(_Fmt_it(_Buf), _Loc, _Fmt, _Args);
+    _Fmt_iterator_buffer<back_insert_iterator<string>, char> _Buf(back_insert_iterator{_Str});
+    _STD vformat_to(_Fmt_it{_Buf}, _Loc, _Fmt, _Args);
     return _Str;
 }
 
 _NODISCARD inline wstring vformat(const locale& _Loc, const wstring_view _Fmt, const wformat_args _Args) {
     wstring _Str;
-    _Fmt_iterator_buffer<back_insert_iterator<wstring>, wchar_t> _Buf(_STD back_inserter(_Str));
-    _STD vformat_to(_Fmt_wit(_Buf), _Loc, _Fmt, _Args);
+    _Fmt_iterator_buffer<back_insert_iterator<wstring>, wchar_t> _Buf(back_insert_iterator{_Str});
+    _STD vformat_to(_Fmt_wit{_Buf}, _Loc, _Fmt, _Args);
     return _Str;
 }
 
@@ -2903,60 +2903,60 @@ template <output_iterator<const char&> _OutputIt, class... _Types>
 format_to_n_result<_OutputIt> format_to_n(
     _OutputIt _Out, const iter_difference_t<_OutputIt> _Max, const string_view _Fmt, const _Types&... _Args) {
     _Fmt_iterator_buffer<_OutputIt, char, _Fmt_fixed_buffer_traits> _Buf(_STD move(_Out), _Max);
-    _STD vformat_to(_Fmt_it(_Buf), _Fmt, _STD make_format_args(_Args...));
-    return {.out = _Buf.out(), .size = _Buf.count()};
+    _STD vformat_to(_Fmt_it{_Buf}, _Fmt, _STD make_format_args(_Args...));
+    return {.out = _Buf._Out(), .size = _Buf._Count()};
 }
 
 template <output_iterator<const wchar_t&> _OutputIt, class... _Types>
 format_to_n_result<_OutputIt> format_to_n(
     _OutputIt _Out, const iter_difference_t<_OutputIt> _Max, const wstring_view _Fmt, const _Types&... _Args) {
     _Fmt_iterator_buffer<_OutputIt, wchar_t, _Fmt_fixed_buffer_traits> _Buf(_STD move(_Out), _Max);
-    _STD vformat_to(_Fmt_wit(_Buf), _Fmt, _STD make_wformat_args(_Args...));
-    return {.out = _Buf.out(), .size = _Buf.count()};
+    _STD vformat_to(_Fmt_wit{_Buf}, _Fmt, _STD make_wformat_args(_Args...));
+    return {.out = _Buf._Out(), .size = _Buf._Count()};
 }
 
 template <output_iterator<const char&> _OutputIt, class... _Types>
 format_to_n_result<_OutputIt> format_to_n(_OutputIt _Out, const iter_difference_t<_OutputIt> _Max, const locale& _Loc,
     const string_view _Fmt, const _Types&... _Args) {
     _Fmt_iterator_buffer<_OutputIt, char, _Fmt_fixed_buffer_traits> _Buf(_STD move(_Out), _Max);
-    _STD vformat_to(_Fmt_it(_Buf), _Loc, _Fmt, _STD make_format_args(_Args...));
-    return {.out = _Buf.out(), .size = _Buf.count()};
+    _STD vformat_to(_Fmt_it{_Buf}, _Loc, _Fmt, _STD make_format_args(_Args...));
+    return {.out = _Buf._Out(), .size = _Buf._Count()};
 }
 
 template <output_iterator<const wchar_t&> _OutputIt, class... _Types>
 format_to_n_result<_OutputIt> format_to_n(_OutputIt _Out, const iter_difference_t<_OutputIt> _Max, const locale& _Loc,
     const wstring_view _Fmt, const _Types&... _Args) {
     _Fmt_iterator_buffer<_OutputIt, wchar_t, _Fmt_fixed_buffer_traits> _Buf(_STD move(_Out), _Max);
-    _STD vformat_to(_Fmt_wit(_Buf), _Loc, _Fmt, _STD make_wformat_args(_Args...));
-    return {.out = _Buf.out(), .size = _Buf.count()};
+    _STD vformat_to(_Fmt_wit{_Buf}, _Loc, _Fmt, _STD make_wformat_args(_Args...));
+    return {.out = _Buf._Out(), .size = _Buf._Count()};
 }
 
 template <class... _Types>
 _NODISCARD size_t formatted_size(const string_view _Fmt, const _Types&... _Args) {
     _Fmt_counting_buffer<char> _Buf;
-    _STD vformat_to(_Fmt_it(_Buf), _Fmt, _STD make_format_args(_Args...));
-    return _Buf.count();
+    _STD vformat_to(_Fmt_it{_Buf}, _Fmt, _STD make_format_args(_Args...));
+    return _Buf._Count();
 }
 
 template <class... _Types>
 _NODISCARD size_t formatted_size(const wstring_view _Fmt, const _Types&... _Args) {
     _Fmt_counting_buffer<wchar_t> _Buf;
-    _STD vformat_to(_Fmt_wit(_Buf), _Fmt, _STD make_wformat_args(_Args...));
-    return _Buf.count();
+    _STD vformat_to(_Fmt_wit{_Buf}, _Fmt, _STD make_wformat_args(_Args...));
+    return _Buf._Count();
 }
 
 template <class... _Types>
 _NODISCARD size_t formatted_size(const locale& _Loc, const string_view _Fmt, const _Types&... _Args) {
     _Fmt_counting_buffer<char> _Buf;
-    _STD vformat_to(_Fmt_it(_Buf), _Loc, _Fmt, _STD make_format_args(_Args...));
-    return _Buf.count();
+    _STD vformat_to(_Fmt_it{_Buf}, _Loc, _Fmt, _STD make_format_args(_Args...));
+    return _Buf._Count();
 }
 
 template <class... _Types>
 _NODISCARD size_t formatted_size(const locale& _Loc, const wstring_view _Fmt, const _Types&... _Args) {
     _Fmt_counting_buffer<wchar_t> _Buf;
-    _STD vformat_to(_Fmt_wit(_Buf), _Loc, _Fmt, _STD make_wformat_args(_Args...));
-    return _Buf.count();
+    _STD vformat_to(_Fmt_wit{_Buf}, _Loc, _Fmt, _STD make_wformat_args(_Args...));
+    return _Buf._Count();
 }
 
 _STD_END

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -2566,6 +2566,7 @@ private:
 
 protected:
     explicit _Fmt_buffer(const size_t _Sz) noexcept : _Size(_Sz), _Capacity(_Sz) {}
+
     _Fmt_buffer(_Ty* _Data, const size_t _Sz, const size_t _Cap) noexcept : _Ptr(_Data), _Size(_Sz), _Capacity(_Cap) {}
 
     void _Set(_Ty* _Buf_data, const size_t _Buf_capacity) noexcept {
@@ -2585,6 +2586,7 @@ public:
     _NODISCARD _Ty* begin() noexcept {
         return _Ptr;
     }
+
     _NODISCARD _Ty* end() noexcept {
         return _Ptr + _Size;
     }
@@ -2620,9 +2622,11 @@ public:
 
 struct _Fmt_buffer_traits {
     explicit _Fmt_buffer_traits(ptrdiff_t) {}
+
     _NODISCARD size_t count() const noexcept {
         return 0;
     }
+
     _NODISCARD size_t limit(const size_t _Size) noexcept {
         return _Size;
     }
@@ -2635,9 +2639,11 @@ private:
 
 public:
     explicit _Fmt_fixed_buffer_traits(const ptrdiff_t _Lim) noexcept : _Limit(_Lim) {}
+
     _NODISCARD size_t count() const noexcept {
         return static_cast<size_t>(_Count);
     }
+
     _NODISCARD size_t limit(const size_t _Size) noexcept {
         size_t _Avail = static_cast<size_t>(_Limit > _Count ? _Limit - _Count : 0);
         _Count += _Size;
@@ -2654,11 +2660,12 @@ private:
     _Ty _Data[_Fmt_buffer_size];
 
 protected:
-    void _Grow(size_t) final override {
+    void _Grow(size_t) final {
         if (this->size() == _Fmt_buffer_size) {
             _Flush();
         }
     }
+
     void _Flush() {
         auto _Size = this->size();
         this->clear();
@@ -2668,6 +2675,7 @@ protected:
 public:
     explicit _Fmt_iterator_buffer(_OutputIt _Output, ptrdiff_t _Size = _Fmt_buffer_size)
         : _Traits(_Size), _Fmt_buffer<_Ty>(_Data, 0, _Fmt_buffer_size), _Out(_STD move(_Output)) {}
+
     ~_Fmt_iterator_buffer() {
         if (this->size() != 0) {
             _Flush();
@@ -2678,6 +2686,7 @@ public:
         _Flush();
         return _STD move(_Out);
     }
+
     _NODISCARD ptrdiff_t count() const noexcept {
         return static_cast<ptrdiff_t>(_Traits::count() + this->size());
     }
@@ -2686,7 +2695,7 @@ public:
 template <class _Ty>
 class _Fmt_iterator_buffer<_Ty*, _Ty> final : public _Fmt_buffer<_Ty> {
 protected:
-    void _Grow(size_t) final override {}
+    void _Grow(size_t) final {}
 
 public:
     explicit _Fmt_iterator_buffer(_Ty* _Out, ptrdiff_t = 0) : _Fmt_buffer<_Ty>(_Out, 0, ~size_t()) {}
@@ -2705,11 +2714,12 @@ private:
 
     struct _Accessor : _STD back_insert_iterator<_Container> {
         _Accessor(_STD back_insert_iterator<_Container> _Iter) : back_insert_iterator<_Container>(_Iter) {}
+
         using _STD back_insert_iterator<_Container>::container;
     };
 
 protected:
-    void _Grow(size_t _Capacity) final override {
+    void _Grow(size_t _Capacity) final {
         _Cont.resize(_Capacity);
         this->_Set(&_Cont[0], _Capacity);
     }
@@ -2717,10 +2727,11 @@ protected:
 public:
     explicit _Fmt_iterator_buffer(_Container& _C)
         : _Fmt_buffer<typename _Container::value_type>(_C.size()), _Cont(_C) {}
+
     explicit _Fmt_iterator_buffer(_STD back_insert_iterator<_Container> _Out, ptrdiff_t = 0)
         : _Fmt_iterator_buffer(*_Accessor(_STD move(_Out)).container) {}
 
-    _NODISCARD auto out() {
+    _NODISCARD auto out() noexcept {
         return _STD back_inserter(_Cont);
     }
 };
@@ -2732,7 +2743,7 @@ private:
     size_t _Count = 0;
 
 protected:
-    void _Grow(size_t) final override {
+    void _Grow(size_t) final {
         if (this->size() != _Fmt_buffer_size) {
             return;
         }

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -2630,16 +2630,16 @@ struct _Fmt_buffer_traits {
 
 class _Fmt_fixed_buffer_traits {
 private:
-    size_t _Count = 0;
-    size_t _Limit;
+    ptrdiff_t _Count = 0;
+    ptrdiff_t _Limit;
 
 public:
-    explicit _Fmt_fixed_buffer_traits(const ptrdiff_t _Lim) noexcept : _Limit(static_cast<size_t>(_Lim)) {}
+    explicit _Fmt_fixed_buffer_traits(const ptrdiff_t _Lim) noexcept : _Limit(_Lim) {}
     _NODISCARD size_t count() const noexcept {
-        return _Count;
+        return static_cast<size_t>(_Count);
     }
     _NODISCARD size_t limit(const size_t _Size) noexcept {
-        size_t _Avail = _Limit > _Count ? _Limit - _Count : 0;
+        size_t _Avail = static_cast<size_t>(_Limit > _Count ? _Limit - _Count : 0);
         _Count += _Size;
         return _Size < _Avail ? _Size : _Avail;
     }

--- a/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
@@ -48,11 +48,7 @@ struct choose_literal<wchar_t> {
 template <class charT, class... Args>
 auto make_testing_format_args(Args&&... vals) {
     using context = basic_format_context<back_insert_iterator<basic_string<charT>>, charT>;
-    if constexpr (is_same_v<charT, wchar_t>) {
-        return make_wformat_args<context>(forward<Args>(vals)...);
-    } else {
-        return make_format_args<context>(forward<Args>(vals)...);
-    }
+    return make_format_args<context>(forward<Args>(vals)...);
 }
 
 template <class charT, class... Args>

--- a/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
@@ -47,10 +47,11 @@ struct choose_literal<wchar_t> {
 
 template <class charT, class... Args>
 auto make_testing_format_args(Args&&... vals) {
+    using context = basic_format_context<back_insert_iterator<basic_string<charT>>, charT>;
     if constexpr (is_same_v<charT, wchar_t>) {
-        return make_wformat_args(forward<Args>(vals)...);
+        return make_wformat_args<context>(forward<Args>(vals)...);
     } else {
-        return make_format_args(forward<Args>(vals)...);
+        return make_format_args<context>(forward<Args>(vals)...);
     }
 }
 


### PR DESCRIPTION
Fix code bloat in formatting functions by "type erasing" the output iterator as [implemented in {fmt}](https://github.com/fmtlib/fmt/blob/6271406233585a9178592b0492b190786bf0ee98/include/fmt/core.h#L716) and [suggested in the standard](https://eel.is/c++draft/format#context-4):

> For a given type charT, implementations are encouraged to provide a single instantiation of basic_­format_­context for appending to basic_­string<charT>, vector<charT>, or any other container with contiguous storage by wrapping those in temporary objects with a uniform interface (such as a span<charT>) and polymorphic reallocation.

Previously a ton of formatting code was instantiated for every output iterator type passed to `format_to` and `format_to_n`. `format` and `formatted_size` also contributed to this via iterators used internally.

For example, the binary size increase when using a new iterator type dropped form ~30k (#1835) to just ~1k:

```
17.04.2021  10:51           371 200 format-one.exe
17.04.2021  10:51           372 224 format-two.exe
```
In addition to improving binary code size this can potentially benefit compile times (fewer template instantiations) and performance provided that `back_insert_iterator<buffer<Char>>` is handled properly in the implementation (not part of this PR). In particular `formatted_size` and `format_to_n` are now easier to optimize because they write to a contiguous buffer instead of doing character-by-character output. I haven't done any compile time or performance measurements though.

Fixes most of #1835 except for `vformat_to` that will be addressed separately.