### PR TITLE
<format>: Fix the signature of `make_wformat_args`

### DIFF
--- a/stl/inc/format
+++ b/stl/inc/format
@@ -2567,9 +2567,9 @@ _NODISCARD auto make_format_args(const _Args&... _Vals) {
     return _Format_arg_store<_Context, _Args...>{_Vals...};
 }
 
-template <class _Context = wformat_context, class... _Args>
+template <class... _Args>
 _NODISCARD auto make_wformat_args(const _Args&... _Vals) {
-    return _Format_arg_store<_Context, _Args...>{_Vals...};
+    return _Format_arg_store<wformat_context, _Args...>{_Vals...};
 }
 
 template <class _Out, class _CharT>


### PR DESCRIPTION
<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
The existing code doesn't match [[format.arg.store]](https://wg21.link/format.arg.store#lib:make_wformat_args).