### PR TITLE
`<chrono>` formatting: `weekday_last`, `month_weekday`, `month_weekday_last`

### DIFF
--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -5488,7 +5488,7 @@ namespace chrono {
             _Year = static_cast<int>(_Val);
         } else if constexpr (is_same_v<_Ty, weekday>) {
             _Weekday = static_cast<int>(_Val.c_encoding());
-        } else if constexpr (is_same_v<_Ty, weekday_indexed>) {
+        } else if constexpr (_Is_any_of_v<_Ty, weekday_indexed, weekday_last>) {
             _Weekday = static_cast<int>(_Val.weekday().c_encoding());
         } else if constexpr (is_same_v<_Ty, month_day>) {
             _Day   = static_cast<unsigned int>(_Val.day());
@@ -5496,6 +5496,12 @@ namespace chrono {
         } else if constexpr (is_same_v<_Ty, month_day_last>) {
             _Month = static_cast<unsigned int>(_Val.month());
             _Day   = static_cast<unsigned int>(_Last_day_table[(_Month - 1) & 0xF]);
+        } else if constexpr (is_same_v<_Ty, month_weekday>) {
+            _Month   = static_cast<unsigned int>(_Val.month());
+            _Weekday = static_cast<int>(_Val.weekday_indexed().weekday().c_encoding());
+        } else if constexpr (is_same_v<_Ty, month_weekday_last>) {
+            _Month   = static_cast<unsigned int>(_Val.month());
+            _Weekday = static_cast<int>(_Val.weekday_last().weekday().c_encoding());
         } else if constexpr (is_same_v<_Ty, year_month>) {
             _Month = static_cast<unsigned int>(_Val.month());
             _Year  = static_cast<int>(_Val.year());
@@ -5509,12 +5515,7 @@ namespace chrono {
             _Month   = static_cast<unsigned int>(_Val.month());
             _Year    = static_cast<int>(_Val.year());
             _Weekday = year_month_day{_Val}._Calculate_weekday();
-        } else if constexpr (is_same_v<_Ty, year_month_weekday>) {
-            _Day     = static_cast<unsigned int>(year_month_day{_Val}.day());
-            _Month   = static_cast<unsigned int>(_Val.month());
-            _Year    = static_cast<int>(_Val.year());
-            _Weekday = static_cast<int>(_Val.weekday().c_encoding());
-        } else if constexpr (is_same_v<_Ty, year_month_weekday_last>) {
+        } else if constexpr (_Is_any_of_v<_Ty, year_month_weekday, year_month_weekday_last>) {
             _Day     = static_cast<unsigned int>(year_month_day{_Val}.day());
             _Month   = static_cast<unsigned int>(_Val.month());
             _Year    = static_cast<int>(_Val.year());
@@ -5785,10 +5786,12 @@ struct _Chrono_formatter {
             return _Type == 'b' || _Type == 'B' || _Type == 'h' || _Type == 'm';
         } else if constexpr (is_same_v<_Ty, _CHRONO year>) {
             return _Type == 'Y' || _Type == 'y' || _Type == 'C';
-        } else if constexpr (_Is_any_of_v<_Ty, _CHRONO weekday, _CHRONO weekday_indexed>) {
+        } else if constexpr (_Is_any_of_v<_Ty, _CHRONO weekday, _CHRONO weekday_indexed, _CHRONO weekday_last>) {
             return _Type == 'a' || _Type == 'A' || _Type == 'u' || _Type == 'w';
         } else if constexpr (_Is_any_of_v<_Ty, _CHRONO month_day, _CHRONO month_day_last>) {
             return _Is_valid_type<_CHRONO month>(_Type) || _Is_valid_type<_CHRONO day>(_Type);
+        } else if constexpr (_Is_any_of_v<_Ty, _CHRONO month_weekday, _CHRONO month_weekday_last>) {
+            return _Is_valid_type<_CHRONO month>(_Type) || _Is_valid_type<_CHRONO weekday>(_Type);
         } else if constexpr (is_same_v<_Ty, _CHRONO year_month>) {
             return _Is_valid_type<_CHRONO year>(_Type) || _Is_valid_type<_CHRONO month>(_Type);
         } else if constexpr (_Is_any_of_v<_Ty, _CHRONO year_month_day, _CHRONO year_month_day_last,
@@ -5808,8 +5811,7 @@ struct _Chrono_formatter {
             return _Type == 'c' || _Type == 'x' || _Type == 'X' || _Is_valid_type<_CHRONO year_month_day>(_Type)
                 || _Is_valid_type<_CHRONO hh_mm_ss<_CHRONO seconds>>(_Type);
         } else {
-            // TRANSITION, remove when all types are added
-            static_assert(_Always_false<_Ty>, "unsupported type");
+            static_assert(_Always_false<_Ty>, "should be unreachable");
         }
     }
 
@@ -6015,12 +6017,24 @@ struct formatter<_CHRONO weekday_indexed, _CharT> //
     : _Fill_tm_formatter<_CHRONO weekday_indexed, _CharT> {};
 
 template <class _CharT>
+struct formatter<_CHRONO weekday_last, _CharT> //
+    : _Fill_tm_formatter<_CHRONO weekday_last, _CharT> {};
+
+template <class _CharT>
 struct formatter<_CHRONO month_day, _CharT> //
     : _Fill_tm_formatter<_CHRONO month_day, _CharT> {};
 
 template <class _CharT>
 struct formatter<_CHRONO month_day_last, _CharT> //
     : _Fill_tm_formatter<_CHRONO month_day_last, _CharT> {};
+
+template <class _CharT>
+struct formatter<_CHRONO month_weekday, _CharT> //
+    : _Fill_tm_formatter<_CHRONO month_weekday, _CharT> {};
+
+template <class _CharT>
+struct formatter<_CHRONO month_weekday_last, _CharT> //
+    : _Fill_tm_formatter<_CHRONO month_weekday_last, _CharT> {};
 
 template <class _CharT>
 struct formatter<_CHRONO year_month, _CharT> //

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -275,32 +275,6 @@ std/utilities/memory/default.allocator/allocator.members/allocate.verify.cpp SKI
 
 
 # *** MISSING STL FEATURES ***
-# C++20 P0355R7 "<chrono> Calendars And Time Zones"
-std/utilities/time/time.cal/time.cal.mwdlast/time.cal.mwdlast.nonmembers/streaming.pass.cpp FAIL
-std/utilities/time/time.cal/time.cal.wdidx/time.cal.wdidx.nonmembers/streaming.pass.cpp FAIL
-std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.nonmembers/streaming.pass.cpp FAIL
-std/utilities/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.nonmembers/streaming.pass.cpp FAIL
-
-# C++20 P0466R5 "Layout-Compatibility And Pointer-Interconvertibility Traits"
-std/language.support/support.limits/support.limits.general/type_traits.version.pass.cpp:1 FAIL
-
-# C++20 P0608R3 "Improving variant's Converting Constructor/Assignment"
-std/utilities/variant/variant.variant/variant.assign/conv.pass.cpp FAIL
-std/utilities/variant/variant.variant/variant.assign/T.pass.cpp FAIL
-std/utilities/variant/variant.variant/variant.ctor/conv.pass.cpp FAIL
-std/utilities/variant/variant.variant/variant.ctor/T.pass.cpp FAIL
-
-# C++20 P0784R7 "More constexpr containers"
-std/utilities/memory/allocator.traits/allocator.traits.members/construct.pass.cpp FAIL
-std/utilities/memory/allocator.traits/allocator.traits.members/destroy.pass.cpp FAIL
-std/utilities/memory/specialized.algorithms/specialized.construct/construct_at.pass.cpp FAIL
-
-# C++20 P0896R4 "<ranges>"
-std/language.support/support.limits/support.limits.general/algorithm.version.pass.cpp FAIL
-std/language.support/support.limits/support.limits.general/functional.version.pass.cpp FAIL
-std/language.support/support.limits/support.limits.general/iterator.version.pass.cpp FAIL
-std/language.support/support.limits/support.limits.general/memory.version.pass.cpp FAIL
-
 # C++23 P1048R1 "is_scoped_enum"
 std/utilities/meta/meta.unary/meta.unary.prop/is_scoped_enum.pass.cpp FAIL
 
@@ -651,6 +625,25 @@ std/utilities/allocator.adaptor/allocator.adaptor.members/construct_pair_rvalue.
 std/utilities/allocator.adaptor/allocator.adaptor.members/construct_pair_values.pass.cpp FAIL
 std/utilities/allocator.adaptor/allocator.adaptor.members/construct_type.pass.cpp FAIL
 
+# Bogus test uses std::cout without including <iostream>.
+std/utilities/time/time.cal/time.cal.wdidx/time.cal.wdidx.nonmembers/streaming.pass.cpp FAIL
+
+# Bogus test constructs year_month_weekday from weekday, but the constructor actually takes weekday_indexed.
+std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.nonmembers/streaming.pass.cpp FAIL
+
+# We define __cpp_lib_has_unique_object_representations in C++17 mode; test error says it
+# "should not be defined when TEST_HAS_BUILTIN_IDENTIFIER(__has_unique_object_representations) || TEST_GCC_VER >= 700 is not defined!"
+std/language.support/support.limits/support.limits.general/type_traits.version.pass.cpp:1 FAIL
+
+# Tests expect __cpp_lib_ranges to have the old value 201811L for P0896R4; we define the C++20 value 201911L for P1716R3.
+std/language.support/support.limits/support.limits.general/algorithm.version.pass.cpp FAIL
+std/language.support/support.limits/support.limits.general/functional.version.pass.cpp FAIL
+std/language.support/support.limits/support.limits.general/iterator.version.pass.cpp FAIL
+
+# We unconditionally define __cpp_lib_addressof_constexpr; test error says it
+# "should not be defined when TEST_HAS_BUILTIN(__builtin_addressof) || TEST_GCC_VER >= 700 is not defined!"
+std/language.support/support.limits/support.limits.general/memory.version.pass.cpp FAIL
+
 
 # *** LIKELY STL BUGS ***
 # Not yet analyzed, likely STL bugs. Assertions and other runtime failures.
@@ -857,6 +850,19 @@ std/re/re.alg/re.alg.search/basic.locale.pass.cpp FAIL
 std/re/re.alg/re.alg.search/ecma.locale.pass.cpp FAIL
 std/re/re.alg/re.alg.search/extended.locale.pass.cpp FAIL
 
+# Not yet analyzed. Various static_asserts.
+std/utilities/variant/variant.variant/variant.assign/conv.pass.cpp FAIL
+std/utilities/variant/variant.variant/variant.assign/T.pass.cpp FAIL
+std/utilities/variant/variant.variant/variant.ctor/conv.pass.cpp FAIL
+std/utilities/variant/variant.variant/variant.ctor/T.pass.cpp FAIL
+
+# Not yet analyzed. Involves incomplete types.
+std/utilities/memory/allocator.traits/allocator.traits.members/construct.pass.cpp FAIL
+std/utilities/memory/allocator.traits/allocator.traits.members/destroy.pass.cpp FAIL
+
+# Not yet analyzed. Error mentions allocator<const T>.
+std/utilities/memory/specialized.algorithms/specialized.construct/construct_at.pass.cpp FAIL
+
 
 # *** XFAILs WHICH PASS ***
 # Not yet implemented in libcxx and marked as "XFAIL: libc++"
@@ -876,9 +882,11 @@ std/utilities/time/time.cal/time.cal.md/time.cal.md.nonmembers/streaming.pass.cp
 std/utilities/time/time.cal/time.cal.mdlast/streaming.pass.cpp SKIPPED
 std/utilities/time/time.cal/time.cal.month/time.cal.month.nonmembers/streaming.pass.cpp SKIPPED
 std/utilities/time/time.cal/time.cal.mwd/time.cal.mwd.nonmembers/streaming.pass.cpp SKIPPED
+std/utilities/time/time.cal/time.cal.mwdlast/time.cal.mwdlast.nonmembers/streaming.pass.cpp SKIPPED
 std/utilities/time/time.cal/time.cal.wdlast/time.cal.wdlast.nonmembers/streaming.pass.cpp SKIPPED
 std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.nonmembers/streaming.pass.cpp SKIPPED
 std/utilities/time/time.cal/time.cal.year/time.cal.year.nonmembers/streaming.pass.cpp SKIPPED
 std/utilities/time/time.cal/time.cal.ym/time.cal.ym.nonmembers/streaming.pass.cpp SKIPPED
 std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.nonmembers/streaming.pass.cpp SKIPPED
 std/utilities/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.nonmembers/streaming.pass.cpp SKIPPED
+std/utilities/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.nonmembers/streaming.pass.cpp SKIPPED

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -275,32 +275,6 @@ utilities\memory\default.allocator\allocator.members\allocate.verify.cpp
 
 
 # *** MISSING STL FEATURES ***
-# C++20 P0355R7 "<chrono> Calendars And Time Zones"
-utilities\time\time.cal\time.cal.mwdlast\time.cal.mwdlast.nonmembers\streaming.pass.cpp
-utilities\time\time.cal\time.cal.wdidx\time.cal.wdidx.nonmembers\streaming.pass.cpp
-utilities\time\time.cal\time.cal.ymwd\time.cal.ymwd.nonmembers\streaming.pass.cpp
-utilities\time\time.cal\time.cal.ymwdlast\time.cal.ymwdlast.nonmembers\streaming.pass.cpp
-
-# C++20 P0466R5 "Layout-Compatibility And Pointer-Interconvertibility Traits"
-language.support\support.limits\support.limits.general\type_traits.version.pass.cpp
-
-# C++20 P0608R3 "Improving variant's Converting Constructor/Assignment"
-utilities\variant\variant.variant\variant.assign\conv.pass.cpp
-utilities\variant\variant.variant\variant.assign\T.pass.cpp
-utilities\variant\variant.variant\variant.ctor\conv.pass.cpp
-utilities\variant\variant.variant\variant.ctor\T.pass.cpp
-
-# C++20 P0784R7 "More constexpr containers"
-utilities\memory\allocator.traits\allocator.traits.members\construct.pass.cpp
-utilities\memory\allocator.traits\allocator.traits.members\destroy.pass.cpp
-utilities\memory\specialized.algorithms\specialized.construct\construct_at.pass.cpp
-
-# C++20 P0896R4 "<ranges>"
-language.support\support.limits\support.limits.general\algorithm.version.pass.cpp
-language.support\support.limits\support.limits.general\functional.version.pass.cpp
-language.support\support.limits\support.limits.general\iterator.version.pass.cpp
-language.support\support.limits\support.limits.general\memory.version.pass.cpp
-
 # C++23 P1048R1 "is_scoped_enum"
 utilities\meta\meta.unary\meta.unary.prop\is_scoped_enum.pass.cpp
 
@@ -651,6 +625,25 @@ utilities\allocator.adaptor\allocator.adaptor.members\construct_pair_rvalue.pass
 utilities\allocator.adaptor\allocator.adaptor.members\construct_pair_values.pass.cpp
 utilities\allocator.adaptor\allocator.adaptor.members\construct_type.pass.cpp
 
+# Bogus test uses std::cout without including <iostream>.
+utilities\time\time.cal\time.cal.wdidx\time.cal.wdidx.nonmembers\streaming.pass.cpp
+
+# Bogus test constructs year_month_weekday from weekday, but the constructor actually takes weekday_indexed.
+utilities\time\time.cal\time.cal.ymwd\time.cal.ymwd.nonmembers\streaming.pass.cpp
+
+# We define __cpp_lib_has_unique_object_representations in C++17 mode; test error says it
+# "should not be defined when TEST_HAS_BUILTIN_IDENTIFIER(__has_unique_object_representations) || TEST_GCC_VER >= 700 is not defined!"
+language.support\support.limits\support.limits.general\type_traits.version.pass.cpp
+
+# Tests expect __cpp_lib_ranges to have the old value 201811L for P0896R4; we define the C++20 value 201911L for P1716R3.
+language.support\support.limits\support.limits.general\algorithm.version.pass.cpp
+language.support\support.limits\support.limits.general\functional.version.pass.cpp
+language.support\support.limits\support.limits.general\iterator.version.pass.cpp
+
+# We unconditionally define __cpp_lib_addressof_constexpr; test error says it
+# "should not be defined when TEST_HAS_BUILTIN(__builtin_addressof) || TEST_GCC_VER >= 700 is not defined!"
+language.support\support.limits\support.limits.general\memory.version.pass.cpp
+
 
 # *** LIKELY STL BUGS ***
 # Not yet analyzed, likely STL bugs. Assertions and other runtime failures.
@@ -856,6 +849,19 @@ re\re.alg\re.alg.search\awk.locale.pass.cpp
 re\re.alg\re.alg.search\basic.locale.pass.cpp
 re\re.alg\re.alg.search\ecma.locale.pass.cpp
 re\re.alg\re.alg.search\extended.locale.pass.cpp
+
+# Not yet analyzed. Various static_asserts.
+utilities\variant\variant.variant\variant.assign\conv.pass.cpp
+utilities\variant\variant.variant\variant.assign\T.pass.cpp
+utilities\variant\variant.variant\variant.ctor\conv.pass.cpp
+utilities\variant\variant.variant\variant.ctor\T.pass.cpp
+
+# Not yet analyzed. Involves incomplete types.
+utilities\memory\allocator.traits\allocator.traits.members\construct.pass.cpp
+utilities\memory\allocator.traits\allocator.traits.members\destroy.pass.cpp
+
+# Not yet analyzed. Error mentions allocator<const T>.
+utilities\memory\specialized.algorithms\specialized.construct\construct_at.pass.cpp
 
 
 # *** SKIPPED FOR MSVC-INTERNAL CONTEST ONLY ***


### PR DESCRIPTION
- Add/test `weekday_last`, `month_weekday`, `month_weekday_last`.
  * In `_Fill_tm()`:
    + `weekday_indexed` and `weekday_last` can share code.
    + `month_weekday` and `month_weekday_last` have different accessors.
    + Cleanup: Unify the code for `year_month_weekday` and `year_month_weekday_last`.
  * In `_Is_valid_type()`:
    + `weekday`, `weekday_indexed`, and `weekday_last` all support the "weekday types".
    + `month_weekday` and `month_weekday_last` support "month types" and "weekday types". (As mentioned above, their accessors are actually `weekday_indexed()` and `weekday_last()`, but it seemed pointless to have separate cases to "recurse" into the `weekday_indexed` and `weekday_last` types, when the answer is always the same.)
    + Remove TRANSITION and change the final `static_assert` to `"should be unreachable"`, which is the pattern that we use elsewhere.
  * Add the new formatters, all powered by `_Fill_tm_formatter`.
- In `P0355R7_calendars_and_time_zones_formatting/test.cpp`:
  * Rename `charT` to `CharT` for consistency (this is needed by the `STR` macro, if it were ever used in these functions).
  * Add `empty_braces_helper()` to test both `format("{}")` and `operator<<`. This should supersede `stream_helper()` but I'm not making that change here.
  * Test the new types.
  * Implement tests for `year_month_day_last`, `year_month_weekday`, and `year_month_weekday_last` now that the necessary formatters are available.
  * Call the new test functions.
- Update libcxx skips for C++20 features. (This extends *slightly* outside of chronat's focus, but given that we have to update the skips, it's nice to have no C++20 features listed as "missing" here.)
