### PR TITLE
<chrono: Rewrite %r spec for C locale

### DIFF
--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -5999,6 +5999,20 @@ namespace chrono {
                 }
                 _Os << _Time.tm_mday;
                 return true;
+            case 'r':
+                if constexpr (_Is_specialization_v<_Ty, hh_mm_ss>) {
+                    // put_time uses _Strftime in order to bypass reference-counting that locale uses. This function
+                    // takes the locale information by pointer, but the pointer (from _Gettnames) returns a copy.
+                    // _Strftime delegates to other functions but eventually (for the C locale) has the %r specifier
+                    // rewritten. It checks for the locale by comparing pointers, which do not compare equal as we have
+                    // a copy of the pointer instead of the original. Therefore, we replace %r for the C locale
+                    // ourselves.
+                    if (_Os.getloc() == locale::classic()) {
+                        _Os << _STD put_time(&_Time, _STATICALLY_WIDEN(_CharT, "%I:%M:%S %p"));
+                        return true;
+                    }
+                }
+                return false;
             case 'j':
                 if constexpr (_Is_specialization_v<_Ty, duration>) {
                     _Os << _STD abs(_CHRONO duration_cast<days>(_Val).count());

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
@@ -560,10 +560,10 @@ void test_hh_mm_ss_formatter() {
     empty_braces_helper(hh_mm_ss{65745s}, STR("18:15:45"));
 
     assert(format(STR("{:%H %I %M %S %r %R %T %p}"), hh_mm_ss{13h + 14min + 15351ms})
-           == STR("13 01 14 15.351 13:14:15 13:14 13:14:15.351 PM"));
+           == STR("13 01 14 15.351 01:14:15 PM 13:14 13:14:15.351 PM"));
 
     assert(format(STR("{:%H %I %M %S %r %R %T %p}"), hh_mm_ss{-13h - 14min - 15351ms})
-           == STR("-13 01 14 15.351 13:14:15 13:14 13:14:15.351 PM"));
+           == STR("-13 01 14 15.351 01:14:15 PM 13:14 13:14:15.351 PM"));
 
     throw_helper(STR("{}"), hh_mm_ss{24h});
     throw_helper(STR("{}"), hh_mm_ss{-24h});


### PR DESCRIPTION
put_time(%r) does the wrong thing when we use the C locale, due to some
internal machinery. It could get fixed further down level, but that
change is a lot more impactful. Instead, we simply rewrite %r when the C
locale is used in chrono.

This basically has to do with the way that _Strftime, _Gettnames, and
expand_time work together. _Gettnames returns a copy of its data and
expand_time figures out the locale based on pointer comparison.

<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
