### PR TITLE
`<chrono>` Formatting: C++20's Final Boss

### DIFF
--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -5465,28 +5465,40 @@ namespace chrono {
         _STL_INTERNAL_CHECK(false);
     }
 
-    template <class _CharT, class _Traits, class _Duration>
-    void _Write_seconds(basic_ostream<_CharT, _Traits>& _Os, const hh_mm_ss<_Duration>& _Val) {
-        _Os << _STD format(_STATICALLY_WIDEN(_CharT, "{:02}"), _Val.seconds().count());
-        if constexpr (hh_mm_ss<_Duration>::fractional_width > 0) {
+    template <unsigned int _Fractional_width, class _CharT, class _Traits, class _Precision>
+    void _Write_fractional_seconds(
+        basic_ostream<_CharT, _Traits>& _Os, const seconds& _Seconds, const _Precision& _Subseconds) {
+        _Os << _STD format(_STATICALLY_WIDEN(_CharT, "{:02}"), _Seconds.count());
+        if constexpr (_Fractional_width > 0) {
             _Os << _STD use_facet<numpunct<_CharT>>(_Os.getloc()).decimal_point();
-            if constexpr (treat_as_floating_point_v<typename hh_mm_ss<_Duration>::precision::rep>) {
-                _Os << _STD format(_STATICALLY_WIDEN(_CharT, "{:0{}.0f}"), _STD floor(_Val.subseconds().count()),
-                    _Val.fractional_width);
-            } else {
+            if constexpr (treat_as_floating_point_v<typename _Precision::rep>) {
                 _Os << _STD format(
-                    _STATICALLY_WIDEN(_CharT, "{:0{}}"), _Val.subseconds().count(), _Val.fractional_width);
+                    _STATICALLY_WIDEN(_CharT, "{:0{}.0f}"), _STD floor(_Subseconds.count()), _Fractional_width);
+            } else {
+                _Os << _STD format(_STATICALLY_WIDEN(_CharT, "{:0{}}"), _Subseconds.count(), _Fractional_width);
             }
         }
+    }
+
+    template <class _CharT, class _Traits, class _Duration>
+    void _Write_seconds(basic_ostream<_CharT, _Traits>& _Os, const hh_mm_ss<_Duration>& _Val) {
+        _Write_fractional_seconds<hh_mm_ss<_Duration>::fractional_width>(_Os, _Val.seconds(), _Val.subseconds());
     }
 
     template <class _CharT, class _Traits, class _Clock, class _Duration>
     void _Write_seconds(basic_ostream<_CharT, _Traits>& _Os, const time_point<_Clock, _Duration>& _Val) {
         if constexpr (is_same_v<_Clock, utc_clock>) {
-            if (_CHRONO get_leap_second_info(_Val).is_leap_second) {
-                _Os << _STATICALLY_WIDEN(_CharT, "60");
-                return;
+            const auto _Lsi = _CHRONO get_leap_second_info(_Val);
+            const auto _Dp =
+                _CHRONO floor<days>(_Val - _Lsi.elapsed) + _Lsi.elapsed - seconds{_Lsi.is_leap_second ? 1 : 0};
+            const hh_mm_ss _Hms{_Val - _Dp};
+            constexpr auto _Fractional_width = decltype(_Hms)::fractional_width;
+            if (_Lsi.is_leap_second) {
+                _Write_fractional_seconds<_Fractional_width>(_Os, _Hms.seconds() + seconds{60}, _Hms.subseconds());
+            } else {
+                _Write_fractional_seconds<_Fractional_width>(_Os, _Hms.seconds(), _Hms.subseconds());
             }
+            return;
         }
         const auto _Dp = _CHRONO floor<days>(_Val);
         _Write_seconds(_Os, hh_mm_ss{_Val - _Dp});

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -774,6 +774,19 @@ namespace chrono {
         return _Rnext;
     }
 
+    template <class _Period, class _CharT, class _Traits>
+    void _Write_unit_suffix(basic_ostream<_CharT, _Traits>& _Os) {
+        constexpr auto _Suffix = _Get_literal_unit_suffix<_CharT, _Period>();
+        if constexpr (_Suffix == nullptr) {
+            _CharT _Buffer[2 * (numeric_limits<intmax_t>::digits10 + 1) + 5] = {}; // 2 numbers + "[/]s\0"
+            const _CharT* const _Begin =
+                _Get_general_unit_suffix<_CharT>(_STD end(_Buffer), _Period::num, _Period::den);
+            _Os << _Begin;
+        } else {
+            _Os << _Suffix;
+        }
+    }
+
     template <class _CharT, class _Traits, class _Rep, class _Period>
     basic_ostream<_CharT, _Traits>& operator<<(
         basic_ostream<_CharT, _Traits>& _Os, const duration<_Rep, _Period>& _Dur) {
@@ -782,16 +795,7 @@ namespace chrono {
         _Sstr.imbue(_Os.getloc());
         _Sstr.precision(_Os.precision());
         _Sstr << _Dur.count();
-
-        constexpr auto _Suffix = _Get_literal_unit_suffix<_CharT, _Period>();
-        if constexpr (_Suffix == nullptr) {
-            _CharT _Buffer[2 * (numeric_limits<intmax_t>::digits10 + 1) + 5] = {}; // 2 numbers + "[/]s\0"
-            const _CharT* const _Begin =
-                _Get_general_unit_suffix<_CharT>(_STD end(_Buffer), _Period::num, _Period::den);
-            _Sstr << _Begin;
-        } else {
-            _Sstr << _Suffix;
-        }
+        _Write_unit_suffix<_Period>(_Sstr);
 
         return _Os << _Sstr.str();
     }
@@ -5470,6 +5474,12 @@ namespace chrono {
         _Write_seconds(_Os, hh_mm_ss{_Val - _Dp});
     }
 
+    template <class _CharT, class _Traits, class _Rep, class _Period>
+    void _Write_seconds(basic_ostream<_CharT, _Traits>& _Os, const duration<_Rep, _Period>& _Val) {
+        const auto _Dp = _CHRONO duration_cast<days>(_Val);
+        _Write_seconds(_Os, hh_mm_ss{_Val - _Dp});
+    }
+
     template <class _Ty>
     _NODISCARD tm _Fill_tm(const _Ty& _Val) {
         unsigned int _Day   = 0;
@@ -5480,7 +5490,10 @@ namespace chrono {
         int _Minutes        = 0;
         int _Seconds        = 0;
 
-        if constexpr (is_same_v<_Ty, day>) {
+        if constexpr (_Is_specialization_v<_Ty, duration>) {
+            const auto _Dp = _CHRONO duration_cast<days>(_Val);
+            return _Fill_tm(hh_mm_ss{_Val - _Dp});
+        } else if constexpr (is_same_v<_Ty, day>) {
             _Day = static_cast<unsigned int>(_Val);
         } else if constexpr (is_same_v<_Ty, month>) {
             _Month = static_cast<unsigned int>(_Val);
@@ -5779,7 +5792,9 @@ namespace chrono {
 
         template <class _Ty>
         _NODISCARD constexpr bool _Is_valid_type(const char _Type) noexcept {
-            if constexpr (is_same_v<_Ty, day>) {
+            if constexpr (_Is_specialization_v<_Ty, duration>) {
+                return _Type == 'j' || _Type == 'q' || _Type == 'Q' || _Is_valid_type<hh_mm_ss<seconds>>(_Type);
+            } else if constexpr (is_same_v<_Ty, day>) {
                 return _Type == 'd' || _Type == 'e';
             } else if constexpr (is_same_v<_Ty, month>) {
                 return _Type == 'b' || _Type == 'B' || _Type == 'h' || _Type == 'm';
@@ -5823,6 +5838,10 @@ namespace chrono {
                 _Stream.imbue(_FormatCtx.locale());
                 if constexpr (_Is_specialization_v<_Ty, hh_mm_ss>) {
                     if (_Val.is_negative()) {
+                        _Stream << _CharT{'-'};
+                    }
+                } else if constexpr (_Is_specialization_v<_Ty, duration>) {
+                    if (_Val < _Ty::zero()) {
                         _Stream << _CharT{'-'};
                     }
                 }
@@ -5891,6 +5910,21 @@ namespace chrono {
                     _Os << (_Spec._Type == 'd' ? _CharT{'0'} : _CharT{' '});
                 }
                 _Os << _Time.tm_mday;
+                return true;
+            case 'j':
+                if constexpr (_Is_specialization_v<_Ty, duration>) {
+                    _Os << _STD abs(_CHRONO duration_cast<days>(_Val).count());
+                }
+                return true;
+            case 'q':
+                if constexpr (_Is_specialization_v<_Ty, duration>) {
+                    _Write_unit_suffix<typename _Ty::period>(_Os);
+                }
+                return true;
+            case 'Q':
+                if constexpr (_Is_specialization_v<_Ty, duration>) {
+                    _Os << _STD abs(_Val.count());
+                }
                 return true;
             case 'm':
                 if (_Has_modifier) {
@@ -5996,6 +6030,10 @@ struct _Fill_tm_formatter {
 private:
     _CHRONO _Chrono_formatter<_CharT> _Impl;
 };
+
+template <class _Rep, class _Period, class _CharT>
+struct formatter<_CHRONO duration<_Rep, _Period>, _CharT>
+    : _Fill_tm_formatter<_CHRONO duration<_Rep, _Period>, _CharT> {};
 
 template <class _CharT>
 struct formatter<_CHRONO day, _CharT> //

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -5225,8 +5225,8 @@ concept _Chrono_parse_spec_callbacks = _Parse_align_callbacks<_Ty, _CharT>
 
 // clang-format off
 template <class _Ty>
-concept _Has_ok = requires (_Ty _At) {
-    {_At.ok()} -> same_as<bool>;
+concept _Has_ok = requires(_Ty _At) {
+    { _At.ok() } -> same_as<bool>;
 };
 // clang-format on
 
@@ -5473,7 +5473,7 @@ namespace chrono {
             _Month = static_cast<unsigned int>(_Val.month());
         } else if constexpr (is_same_v<_Ty, month_day_last>) {
             _Month = static_cast<unsigned int>(_Val.month());
-            _Day   = static_cast<unsigned int>(_Last_day_table[_Month - 1]);
+            _Day   = static_cast<unsigned int>(_Last_day_table[(_Month - 1) & 0xF]);
         } else if constexpr (is_same_v<_Ty, year_month>) {
             _Month = static_cast<unsigned int>(_Val.month());
             _Year  = static_cast<int>(_Val.year());
@@ -5621,7 +5621,7 @@ namespace chrono {
 
     template <class _CharT, class _Traits, class _Duration>
     // clang-format off
-        requires (!treat_as_floating_point_v<typename _Duration::rep> && (_Duration{1} < days{1}))
+        requires (!treat_as_floating_point_v<typename _Duration::rep> && _Duration{1} < days{1})
     basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const sys_time<_Duration>& _Val) {
         // clang-format on
         const auto _Dp = _CHRONO floor<days>(_Val);
@@ -5660,8 +5660,13 @@ namespace chrono {
     }
 } // namespace chrono
 
-template <class _CharT, bool _Allow_precision>
+template <class _CharT>
 struct _Chrono_formatter {
+    _Chrono_formatter() = default;
+
+    explicit _Chrono_formatter(const basic_string_view<_CharT> _Time_zone_abbreviation_)
+        : _Time_zone_abbreviation{_Time_zone_abbreviation_} {}
+
     template <class _Ty>
     _NODISCARD auto _Parse(basic_format_parse_context<_CharT>& _Parse_ctx) {
         _Chrono_specs_setter<_CharT, basic_format_parse_context<_CharT>> _Callback{_Specs, _Parse_ctx};
@@ -5673,8 +5678,18 @@ struct _Chrono_formatter {
             _THROW(format_error("Missing '}' in format string."));
         }
 
-        if (!_Allow_precision && _Specs._Precision != -1) {
-            _THROW(format_error("Precision specification invalid for type."));
+        if constexpr (_Is_specialization_v<_Ty, _CHRONO duration>) {
+            if constexpr (!_CHRONO treat_as_floating_point_v<typename _Ty::rep>) {
+                if (_Specs._Precision != -1) {
+                    _THROW(format_error("Precision specification invalid for chrono::duration type with "
+                                        "integral representation type, see N4885 [time.format]/1."));
+                }
+            }
+        } else {
+            if (_Specs._Precision != -1) {
+                _THROW(format_error("Precision specification invalid for non-chrono::duration type, "
+                                    "see N4885 [time.format]/1."));
+            }
         }
 
         const auto& _List = _Specs._Chrono_specs_list;
@@ -5843,9 +5858,11 @@ struct _Chrono_formatter {
                     _THROW(format_error("Cannot print the last day of February without a year"));
                 }
             }
+
             if (_Has_modifier) {
                 return false;
             }
+
             if (_Time.tm_mday < 10) {
                 _Os << (_Specs._Type == 'd' ? _CharT{'0'} : _CharT{' '});
             }
@@ -5855,6 +5872,7 @@ struct _Chrono_formatter {
             if (_Has_modifier) {
                 return false;
             }
+
             if (_Month < 10) {
                 _Os << _CharT{'0'};
             }
@@ -5864,6 +5882,7 @@ struct _Chrono_formatter {
             if (_Has_modifier) {
                 return false;
             }
+
             if (_Year < 0) {
                 _Os << _CharT{'-'};
             }
@@ -5879,6 +5898,7 @@ struct _Chrono_formatter {
             if (_Has_modifier) {
                 return false;
             }
+
             if (_Year < 0) {
                 _Os << _CharT{'-'};
             }
@@ -5901,8 +5921,8 @@ struct _Chrono_formatter {
             return true;
         case 'H':
             if constexpr (_Is_specialization_v<_Ty, _CHRONO hh_mm_ss>) {
-                if (-_CHRONO hours{24} >= _Val.hours() || _Val.hours() >= _CHRONO hours{24}) {
-                    _THROW(format_error("Cannot localize hh_mm_ss longer than 24 hours."));
+                if (_Val.hours() <= -_CHRONO hours{24} || _CHRONO hours{24} <= _Val.hours()) {
+                    _THROW(format_error("Cannot localize hh_mm_ss with an absolute value of 24 hours or more."));
                 }
             }
             return false;
@@ -5934,7 +5954,7 @@ struct _Chrono_formatter {
 
     _Chrono_format_specs<_CharT> _Specs{};
     bool _No_chrono_specs = false;
-    basic_string_view<_CharT> _Time_zone_abbreviation;
+    basic_string_view<_CharT> _Time_zone_abbreviation{};
 };
 
 template <class _Ty, class _CharT>
@@ -5949,7 +5969,7 @@ struct _Fill_tm_formatter {
     }
 
 private:
-    _Chrono_formatter<_CharT, false> _Impl;
+    _Chrono_formatter<_CharT> _Impl;
 };
 
 template <class _CharT>
@@ -6006,10 +6026,6 @@ struct formatter<_CHRONO hh_mm_ss<_CHRONO duration<_Rep, _Period>>, _CharT>
 
 template <class _Duration, class _CharT>
 struct formatter<_CHRONO sys_time<_Duration>, _CharT> {
-    formatter() {
-        _Impl._Time_zone_abbreviation = _STATICALLY_WIDEN(_CharT, "UTC");
-    }
-
     auto parse(basic_format_parse_context<_CharT>& _Parse_ctx) {
         return _Impl.template _Parse<_CHRONO sys_time<_Duration>>(_Parse_ctx);
     }
@@ -6020,15 +6036,11 @@ struct formatter<_CHRONO sys_time<_Duration>, _CharT> {
     }
 
 private:
-    _Chrono_formatter<_CharT, false> _Impl;
+    _Chrono_formatter<_CharT> _Impl{_STATICALLY_WIDEN(_CharT, "UTC")};
 };
 
 template <class _Duration, class _CharT>
 struct formatter<_CHRONO utc_time<_Duration>, _CharT> {
-    formatter() {
-        _Impl._Time_zone_abbreviation = _STATICALLY_WIDEN(_CharT, "UTC");
-    }
-
     auto parse(basic_format_parse_context<_CharT>& _Parse_ctx) {
         return _Impl.template _Parse<_CHRONO utc_time<_Duration>>(_Parse_ctx);
     }
@@ -6040,58 +6052,49 @@ struct formatter<_CHRONO utc_time<_Duration>, _CharT> {
     }
 
 private:
-    _Chrono_formatter<_CharT, false> _Impl;
+    _Chrono_formatter<_CharT> _Impl{_STATICALLY_WIDEN(_CharT, "UTC")};
 };
 
 template <class _Duration, class _CharT>
 struct formatter<_CHRONO tai_time<_Duration>, _CharT> {
-    formatter() {
-        _Impl._Time_zone_abbreviation = _STATICALLY_WIDEN(_CharT, "TAI");
-    }
-
     auto parse(basic_format_parse_context<_CharT>& _Parse_ctx) {
         return _Impl.template _Parse<_CHRONO tai_time<_Duration>>(_Parse_ctx);
     }
 
     template <class _FormatContext>
     auto format(const _CHRONO tai_time<_Duration>& _Val, _FormatContext& _FormatCtx) {
-        const auto _Sys = _CHRONO sys_time<_Duration>{_Val.time_since_epoch()}
-                        - (_CHRONO sys_days{_CHRONO year{1970} / 1 / 1} - _CHRONO sys_days{_CHRONO year{1958} / 1 / 1});
+        using namespace chrono;
+        using _Common = common_type_t<_Duration, days>; // slightly optimize by performing conversion at compile time
+        constexpr _Common _Offset{sys_days{year{1970} / January / 1} - sys_days{year{1958} / January / 1}};
+        const auto _Sys = sys_time<_Duration>{_Val.time_since_epoch()} - _Offset;
         return _Impl._Write(_FormatCtx, _Val, _Fill_tm(_Sys));
     }
 
 private:
-    _Chrono_formatter<_CharT, false> _Impl;
+    _Chrono_formatter<_CharT> _Impl{_STATICALLY_WIDEN(_CharT, "TAI")};
 };
 
 template <class _Duration, class _CharT>
 struct formatter<_CHRONO gps_time<_Duration>, _CharT> {
-    formatter() {
-        _Impl._Time_zone_abbreviation = _STATICALLY_WIDEN(_CharT, "GPS");
-    }
-
     auto parse(basic_format_parse_context<_CharT>& _Parse_ctx) {
         return _Impl.template _Parse<_CHRONO gps_time<_Duration>>(_Parse_ctx);
     }
 
     template <class _FormatContext>
     auto format(const _CHRONO gps_time<_Duration>& _Val, _FormatContext& _FormatCtx) {
-        const auto _Sys = _CHRONO sys_time<_Duration>{_Val.time_since_epoch()}
-                        + (_CHRONO sys_days{_CHRONO year{1980} / 1 / _CHRONO Sunday[1]}
-                            - _CHRONO sys_days{_CHRONO year{1970} / 1 / 1});
+        using namespace chrono;
+        using _Common = common_type_t<_Duration, days>; // slightly optimize by performing conversion at compile time
+        constexpr _Common _Offset{sys_days{year{1980} / January / Sunday[1]} - sys_days{year{1970} / January / 1}};
+        const auto _Sys = sys_time<_Duration>{_Val.time_since_epoch()} + _Offset;
         return _Impl._Write(_FormatCtx, _Val, _Fill_tm(_Sys));
     }
 
 private:
-    _Chrono_formatter<_CharT, false> _Impl;
+    _Chrono_formatter<_CharT> _Impl{_STATICALLY_WIDEN(_CharT, "GPS")};
 };
 
 template <class _Duration, class _CharT>
 struct formatter<_CHRONO file_time<_Duration>, _CharT> {
-    formatter() {
-        _Impl._Time_zone_abbreviation = _STATICALLY_WIDEN(_CharT, "UTC");
-    }
-
     auto parse(basic_format_parse_context<_CharT>& _Parse_ctx) {
         return _Impl.template _Parse<_CHRONO file_time<_Duration>>(_Parse_ctx);
     }
@@ -6103,7 +6106,7 @@ struct formatter<_CHRONO file_time<_Duration>, _CharT> {
     }
 
 private:
-    _Chrono_formatter<_CharT, false> _Impl;
+    _Chrono_formatter<_CharT> _Impl{_STATICALLY_WIDEN(_CharT, "UTC")};
 };
 
 template <class _Duration, class _CharT>

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -22,9 +22,11 @@
 #include <cmath>
 #include <compare>
 #include <forward_list>
+#include <iomanip>
 #include <istream>
 #include <memory>
 #include <optional>
+#include <string>
 #include <vector>
 #include <xloctime>
 #include <xthreads.h>
@@ -32,6 +34,8 @@
 #ifdef __cpp_lib_concepts
 #include <concepts>
 #include <format>
+#include <iostream>
+#include <sstream>
 #endif // defined(__cpp_lib_concepts)
 #endif // _HAS_CXX20
 
@@ -5177,184 +5181,434 @@ namespace chrono {
         return _CHRONO from_stream(_Is, _Tpi._Fmt.c_str(), _Tpi._Tp, _Tpi._Abbrev, _Tpi._Offset);
     }
 
-#ifdef __cpp_lib_concepts
-    // [time.format]
-
-    // clang-format off
-    template <class _Ty, class _CharT>
-    concept _Chrono_parse_spec_callbacks = _Parse_align_callbacks<_Ty, _CharT>
-                                           && _Parse_width_callbacks<_Ty, _CharT>
-                                           && _Parse_precision_callbacks<_Ty, _CharT>
-                                           && _Width_adapter_callbacks<_Ty, _CharT>
-                                           && _Precision_adapter_callbacks<_Ty, _CharT>
-                                           && requires(_Ty _At, basic_string_view<_CharT> _Sv, _Fmt_align _Aln) {
-        { _At._On_conversion_spec(_CharT{}, _CharT{}) } -> same_as<void>;
-        { _At._On_lit_char(_CharT{}) } -> same_as<void>;
-    };
-    // clang-format on
-
-    template <class _CharT>
-    struct _Chrono_specs {
-        _CharT _Lit_char = _CharT{0}; // any character other than '{', '}', or '%'
-        char _Modifier   = '\0'; // either 'E' or 'O'
-        char _Type       = '\0';
-    };
-
-    template <class _CharT>
-    struct _Chrono_format_specs {
-        int _Width                   = 0;
-        int _Precision               = -1;
-        int _Dynamic_width_index     = -1;
-        int _Dynamic_precision_index = -1;
-        _Fmt_align _Alignment        = _Fmt_align::_None;
-        uint8_t _Fill_length         = 1;
-        // At most one codepoint (so one char32_t or four utf-8 char8_t)
-        _CharT _Fill[4 / sizeof(_CharT)] = {_CharT{' '}};
-        // recursive definition in grammar, so could have any number of these with literal chars
-        vector<_Chrono_specs<_CharT>> _Chrono_specs_list;
-    };
-
-    // Model of _Chrono_parse_spec_callbacks that fills a _Chrono_format_specs with the parsed data
-    template <class _CharT>
-    class _Chrono_specs_setter {
-    public:
-        constexpr explicit _Chrono_specs_setter(_Chrono_format_specs<_CharT>& _Specs_) : _Specs(_Specs_) {}
-
-        // same as _Specs_setter
-        constexpr void _On_align(_Fmt_align _Aln) {
-            _Specs._Alignment = _Aln;
-        }
-
-        // same as _Specs_setter
-        constexpr void _On_fill(basic_string_view<_CharT> _Sv) {
-            if (_Sv.size() > _STD size(_Specs._Fill)) {
-                _THROW(format_error("Invalid fill (too long)."));
-            }
-
-            const auto _Pos = _STD _Copy_unchecked(_Sv._Unchecked_begin(), _Sv._Unchecked_end(), _Specs._Fill);
-            _STD fill(_Pos, _STD end(_Specs._Fill), _CharT{});
-            _Specs._Fill_length = static_cast<uint8_t>(_Sv.size());
-        }
-
-        constexpr void _On_width(int _Width) {
-            _Specs._Width = _Width;
-        }
-
-        constexpr void _On_precision(int _Prec) {
-            _Specs._Precision = _Prec;
-        }
-
-        constexpr void _On_conversion_spec(_CharT _Modifier, _CharT _Type) {
-            // NOTE: same performance note from _Basic_format_specs also applies here
-            const char _Char_mod  = static_cast<char>(_Modifier);
-            const char _Char_type = static_cast<char>(_Type);
-            if (_Char_mod != '\0' && _Char_mod != 'E' && _Char_mod != 'O') {
-                _THROW(format_error("Invalid modifier specification."));
-            }
-
-            if (_Type < 0 || _Type > (numeric_limits<signed char>::max)()) {
-                _THROW(format_error("Invalid type specification."));
-            }
-
-            _Chrono_specs<_CharT> _Conv_spec{._Modifier = _Char_mod, ._Type = _Char_type};
-            _Specs._Chrono_specs_list.push_back(_Conv_spec);
-        }
-
-        constexpr void _On_lit_char(_CharT _Lit_ch) {
-            _Chrono_specs<_CharT> _Lit_char_spec{._Lit_char = _Lit_ch};
-            _Specs._Chrono_specs_list.push_back(_Lit_char_spec);
-        }
-
-    protected:
-        _Chrono_format_specs<_CharT>& _Specs;
-    };
-
-    template <class _CharT, _Chrono_parse_spec_callbacks<_CharT> _Callbacks_type>
-    _NODISCARD constexpr const _CharT* _Parse_conversion_specs(
-        const _CharT* _Begin, const _CharT* _End, _Callbacks_type&& _Callbacks) {
-        _STL_INTERNAL_CHECK(*_Begin == '%');
-        ++_Begin;
-        if (_Begin == _End || *_Begin == '}') {
-            _THROW(format_error("Invalid format string."));
-        }
-
-        _CharT _Mod = '\0';
-        _CharT _Ch  = *_Begin;
-
-        if (_Ch == 'E' || _Ch == 'O') { // includes modifier
-            _Mod = _Ch;
-            ++_Begin;
-            if (_Begin == _End || *_Begin == '}') {
-                _THROW(format_error("Invalid format string - missing type after modifier."));
-            }
-        }
-
-        _CharT _Type = *_Begin;
-        _Callbacks._On_conversion_spec(_Mod, _Type);
-
-        return ++_Begin;
-    }
-
-    template <class _CharT, _Chrono_parse_spec_callbacks<_CharT> _Callbacks_type>
-    _NODISCARD constexpr const _CharT* _Parse_chrono_format_specs(
-        const _CharT* _Begin, const _CharT* _End, _Callbacks_type&& _Callbacks) {
-        if (_Begin == _End || *_Begin == '}') {
-            return _Begin;
-        }
-
-        _Begin = _Parse_align(_Begin, _End, _Callbacks);
-        if (_Begin == _End) {
-            return _Begin;
-        }
-
-        _Begin = _Parse_width(_Begin, _End, _Callbacks);
-        if (_Begin == _End) {
-            return _Begin;
-        }
-
-        if (*_Begin == '.') {
-            _Begin = _Parse_precision(_Begin, _End, _Callbacks);
-            if (_Begin == _End) {
-                return _Begin;
-            }
-        }
-
-        // chrono-spec
-        while (_Begin != _End && *_Begin != '}') {
-            if (*_Begin == '%') { // conversion-spec
-                if (_Begin + 1 == _End) {
-                    _THROW(format_error("Invalid format string - missing type after %"));
-                }
-
-                const _CharT _Next_ch = *(_Begin + 1);
-                switch (_Next_ch) {
-                case 'n':
-                    _Callbacks._On_lit_char('\n');
-                    _Begin += 2;
-                    break;
-                case 't':
-                    _Callbacks._On_lit_char('\t');
-                    _Begin += 2;
-                    break;
-                case '%':
-                    _Callbacks._On_lit_char('%');
-                    _Begin += 2;
-                    break;
-                default: // some other type
-                    _Begin = _Parse_conversion_specs(_Begin, _End, _Callbacks);
-                    break;
-                }
-            } else { // literal-char
-                _Callbacks._On_lit_char(*_Begin);
-                ++_Begin;
-            }
-        }
-
-        return _Begin;
-    }
-#endif // __cpp_lib_concepts
 #endif // _HAS_CXX20
 } // namespace chrono
+
+#if _HAS_CXX20
+#ifdef __cpp_lib_concepts
+  // [time.format]
+
+template <class _CharT>
+struct _Choose_literal {
+    static constexpr const _CharT* _Choose(const char* _Str, const wchar_t* _WStr) {
+        if constexpr (is_same_v<_CharT, char>) {
+            return _Str;
+        } else {
+            return _WStr;
+        }
+    }
+};
+
+#define _STATICALLY_WIDEN(_CharT, _Literal) (_Choose_literal<_CharT>::_Choose(_Literal, L##_Literal))
+
+
+// clang-format off
+template <class _Ty, class _CharT>
+concept _Chrono_parse_spec_callbacks = _Parse_align_callbacks<_Ty, _CharT>
+                                        && _Parse_width_callbacks<_Ty, _CharT>
+                                        && _Parse_precision_callbacks<_Ty, _CharT>
+                                        && _Width_adapter_callbacks<_Ty, _CharT>
+                                        && _Precision_adapter_callbacks<_Ty, _CharT>
+                                        && requires(_Ty _At, basic_string_view<_CharT> _Sv, _Fmt_align _Aln) {
+    { _At._On_conversion_spec(_CharT{}, _CharT{}) } -> same_as<void>;
+    { _At._On_lit_char(_CharT{}) } -> same_as<void>;
+};
+// clang-format on
+
+// A chrono spec is either a type (with an optional modifier), OR a literal character, never both.
+template <class _CharT>
+struct _Chrono_specs {
+    _CharT _Lit_char = _CharT{'\0'}; // any character other than '{', '}', or '%'
+    _CharT _Modifier = _CharT{'\0'}; // either 'E' or 'O'
+    _CharT _Type     = _CharT{'\0'};
+};
+
+template <class _CharT>
+struct _Chrono_format_specs {
+    int _Width                   = 0;
+    int _Precision               = -1;
+    int _Dynamic_width_index     = -1;
+    int _Dynamic_precision_index = -1;
+    _Fmt_align _Alignment        = _Fmt_align::_None;
+    uint8_t _Fill_length         = 1;
+    // At most one codepoint (so one char32_t or four utf-8 char8_t)
+    _CharT _Fill[4 / sizeof(_CharT)] = {_CharT{' '}};
+    // recursive definition in grammar, so could have any number of these with literal chars
+    vector<_Chrono_specs<_CharT>> _Chrono_specs_list;
+};
+
+// Model of _Chrono_parse_spec_callbacks that fills a _Chrono_format_specs with the parsed data
+template <class _CharT, class _ParseContext>
+class _Chrono_specs_setter {
+public:
+    constexpr explicit _Chrono_specs_setter(_Chrono_format_specs<_CharT>& _Specs_, _ParseContext& _Parse_ctx_)
+        : _Specs(_Specs_), _Parse_ctx(_Parse_ctx_) {}
+
+    // same as _Specs_setter
+    constexpr void _On_align(_Fmt_align _Aln) {
+        _Specs._Alignment = _Aln;
+    }
+
+    // same as _Specs_setter
+    constexpr void _On_fill(basic_string_view<_CharT> _Sv) {
+        if (_Sv.size() > _STD size(_Specs._Fill)) {
+            _THROW(format_error("Invalid fill (too long)."));
+        }
+
+        const auto _Pos = _STD _Copy_unchecked(_Sv._Unchecked_begin(), _Sv._Unchecked_end(), _Specs._Fill);
+        _STD fill(_Pos, _STD end(_Specs._Fill), _CharT{});
+        _Specs._Fill_length = static_cast<uint8_t>(_Sv.size());
+    }
+
+    constexpr void _On_width(int _Width) {
+        _Specs._Width = _Width;
+    }
+
+    constexpr void _On_precision(int _Prec) {
+        _Specs._Precision = _Prec;
+    }
+
+    constexpr void _On_dynamic_width(const size_t _Arg_id) {
+        _Parse_ctx.check_arg_id(_Arg_id);
+        _Specs._Dynamic_width_index = _Verify_dynamic_arg_index_in_range(_Arg_id);
+    }
+
+    constexpr void _On_dynamic_width(const _Auto_id_tag) {
+        _Specs._Dynamic_width_index = _Verify_dynamic_arg_index_in_range(_Parse_ctx.next_arg_id());
+    }
+
+    constexpr void _On_dynamic_precision(const size_t _Arg_id) {
+        _Parse_ctx.check_arg_id(_Arg_id);
+        _Specs._Dynamic_precision_index = _Verify_dynamic_arg_index_in_range(_Arg_id);
+    }
+
+    constexpr void _On_dynamic_precision(const _Auto_id_tag) {
+        _Specs._Dynamic_precision_index = _Verify_dynamic_arg_index_in_range(_Parse_ctx.next_arg_id());
+    }
+
+    constexpr void _On_conversion_spec(_CharT _Modifier, _CharT _Type) {
+        // NOTE: same performance note from _Basic_format_specs also applies here
+        if (_Modifier != '\0' && _Modifier != 'E' && _Modifier != 'O') {
+            _THROW(format_error("Invalid modifier specification."));
+        }
+
+        if (_Type < 0 || _Type > (numeric_limits<signed char>::max)()) {
+            _THROW(format_error("Invalid type specification."));
+        }
+
+        _Chrono_specs<_CharT> _Conv_spec{._Modifier = _Modifier, ._Type = _Type};
+        _Specs._Chrono_specs_list.push_back(_Conv_spec);
+    }
+
+    constexpr void _On_lit_char(_CharT _Lit_ch) {
+        _Chrono_specs<_CharT> _Lit_char_spec{._Lit_char = _Lit_ch};
+        _Specs._Chrono_specs_list.push_back(_Lit_char_spec);
+    }
+
+protected:
+    _Chrono_format_specs<_CharT>& _Specs;
+
+private:
+    _ParseContext& _Parse_ctx;
+
+    _NODISCARD static constexpr int _Verify_dynamic_arg_index_in_range(const size_t _Idx) {
+        if (_Idx > static_cast<size_t>((numeric_limits<int>::max)())) {
+            _THROW(format_error("Dynamic width or precision index too large."));
+        }
+
+        return static_cast<int>(_Idx);
+    }
+};
+
+// assumes that the required '%' at the beginning of a conversion-spec has already been consumed
+template <class _CharT, _Chrono_parse_spec_callbacks<_CharT> _Callbacks_type>
+_NODISCARD constexpr const _CharT* _Parse_conversion_specs(
+    const _CharT* _Begin, const _CharT* _End, _Callbacks_type&& _Callbacks) {
+    if (_Begin == _End || *_Begin == '}') {
+        _THROW(format_error("Invalid format string."));
+    }
+
+    _CharT _Mod = '\0';
+    _CharT _Ch  = *_Begin;
+
+    if (_Ch == 'E' || _Ch == 'O') { // includes modifier
+        _Mod = _Ch;
+        ++_Begin;
+        if (_Begin == _End || *_Begin == '}') {
+            _THROW(format_error("Invalid format string - missing type after modifier."));
+        }
+    }
+
+    _CharT _Type = *_Begin;
+    _Callbacks._On_conversion_spec(_Mod, _Type);
+
+    return ++_Begin;
+}
+
+template <class _CharT, _Chrono_parse_spec_callbacks<_CharT> _Callbacks_type>
+_NODISCARD constexpr const _CharT* _Parse_chrono_format_specs(
+    const _CharT* _Begin, const _CharT* _End, _Callbacks_type&& _Callbacks) {
+    if (_Begin == _End || *_Begin == '}') {
+        return _Begin;
+    }
+
+    _Begin = _Parse_align(_Begin, _End, _Callbacks);
+    if (_Begin == _End) {
+        return _Begin;
+    }
+
+    _Begin = _Parse_width(_Begin, _End, _Callbacks);
+    if (_Begin == _End) {
+        return _Begin;
+    }
+
+    if (*_Begin == '.') {
+        _Begin = _Parse_precision(_Begin, _End, _Callbacks);
+        if (_Begin == _End) {
+            return _Begin;
+        }
+    }
+
+    if (_Begin != _End && *_Begin != '}' && *_Begin != '%') {
+        _THROW(format_error("Invalid format string - chrono-specs must begin with conversion-specs"));
+    }
+
+    // chrono-spec
+    while (_Begin != _End && *_Begin != '}') {
+        if (*_Begin == '%') { // conversion-spec
+            if (++_Begin == _End) {
+                _THROW(format_error("Invalid format string - missing type after %"));
+            }
+
+            _CharT _Next_ch = *_Begin;
+            switch (_Next_ch) {
+            case 'n':
+                _Callbacks._On_lit_char('\n');
+                ++_Begin;
+                break;
+            case 't':
+                _Callbacks._On_lit_char('\t');
+                ++_Begin;
+                break;
+            case '%':
+                _Callbacks._On_lit_char('%');
+                ++_Begin;
+                break;
+            default: // some other type
+                _Begin = _Parse_conversion_specs(_Begin, _End, _Callbacks);
+                break;
+            }
+        } else { // literal-char
+            _Callbacks._On_lit_char(*_Begin);
+            ++_Begin;
+        }
+    }
+
+    return _Begin;
+}
+
+namespace chrono {
+    /*
+    template <class _CharT, class _Traits, class _Duration>
+    // clang-format off
+        requires (!treat_as_floating_point_v<typename _Duration::rep> && (_Duration{1} < days{1}))
+    basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const sys_time<_Duration>& _Clock) {
+        // clang-format on
+        const auto _Dp = floor<days>(_Clock);
+        return _Os << year_month_day{_Dp} << _STATICALLY_WIDEN(_CharT, " ") << hh_mm_ss{_Clock - _Dp};
+    }
+
+    template <class _CharT, class _Traits>
+    basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const sys_days& _Clock) {
+        return _Os << year_month_day{_Clock};
+    }
+
+    template <class _CharT, class _Traits, class _Duration>
+    basic_ostream<_CharT, _Traits>& operator<<(
+        basic_ostream<_CharT, _Traits>& _Os, const utc_clock<_Duration>& _Clock) {
+        return _Os << format(_STATICALLY_WIDEN(_CharT, "{:%F %T}"), _Clock);
+    }*/
+
+    template <class _CharT, class _Traits>
+    basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const day& _Val) {
+        if (static_cast<unsigned int>(_Val) < 10) {
+            _Os << _CharT{'0'};
+        }
+        _Os << static_cast<unsigned int>(_Val);
+        if (!_Val.ok()) {
+            _Os << _STATICALLY_WIDEN(_CharT, " is not a valid day");
+        }
+
+        return _Os;
+    }
+
+    template <class _CharT, class _Traits>
+    basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const month& _Val) {
+        if (_Val.ok()) {
+            // tm_mon is [0, 11] while month is [1, 12]
+            const tm _Time = {.tm_mon = static_cast<int>(static_cast<unsigned int>(_Val)) - 1};
+            return _Os << _STD put_time(&_Time, _STATICALLY_WIDEN(_CharT, "%b"));
+        }
+
+        if (static_cast<unsigned int>(_Val) < 10) {
+            _Os << _CharT{'0'};
+        }
+        return _Os << static_cast<unsigned int>(_Val) << _STATICALLY_WIDEN(_CharT, " is not a valid month");
+    }
+} // namespace chrono
+
+/*
+template <class _Duration, class _CharT>
+struct formatter<_CHRONO sys_time<_Duration>, _CharT> {
+    typename basic_format_parse_context<_CharT>::iterator parse(basic_format_parse_context<_CharT>& _Parse_ctx) {
+        _Chrono_format_specs<_CharT> _Specs{};
+        _Chrono_specs_setter<_CharT, basic_format_parse_context<_CharT>> _Callback{_Specs, _Parse_ctx};
+        const auto _It =
+            _Parse_chrono_format_specs(_Parse_ctx._Unchecked_begin(), _Parse_ctx._Unchecked_end(), _Callback);
+        const auto _Res_iter = _Parse_ctx.begin() + (_It - _Parse_ctx._Unchecked_begin());
+
+        if (_It != _Parse_ctx._Unchecked_end() && *_It != '}') {
+            _THROW(format_error("Missing '}' in format string."));
+        }
+    }
+};
+*/
+
+template <class _CharT, bool _Allow_precision>
+struct _Chrono_formatter {
+    typename basic_format_parse_context<_CharT>::iterator _Parse(
+        basic_format_parse_context<_CharT>& _Parse_ctx, string_view _Valid_types) {
+        _Chrono_specs_setter<_CharT, basic_format_parse_context<_CharT>> _Callback{_Specs, _Parse_ctx};
+        const auto _It =
+            _Parse_chrono_format_specs(_Parse_ctx._Unchecked_begin(), _Parse_ctx._Unchecked_end(), _Callback);
+        const auto _Res_iter = _Parse_ctx.begin() + (_It - _Parse_ctx._Unchecked_begin());
+
+        if (_It != _Parse_ctx._Unchecked_end() && *_It != '}') {
+            _THROW(format_error("Missing '}' in format string."));
+        }
+
+        if (!_Allow_precision && _Specs._Precision != -1) {
+            _THROW(format_error("Precision specification invalid for type."));
+        }
+
+        const auto& _List = _Specs._Chrono_specs_list;
+
+        // [time.format]/6
+        if (_List.empty()) {
+            _No_chrono_specs = true;
+            return _Res_iter;
+        }
+
+        for (const auto& _Spec : _List) {
+            if (_Spec._Type != '\0' && _RANGES find(_Valid_types, _Spec._Type) == _Valid_types.end()) {
+                _THROW(format_error("Invalid type."));
+            }
+            _Check_modifier(_Spec._Type, _Spec._Modifier);
+        }
+
+        return _Res_iter;
+    }
+
+    void _Check_modifier(const _CharT _Type, const _CharT _Modifier) {
+        if (_Modifier == _CharT{'\0'}) {
+            return;
+        }
+
+        enum _Allowed_bit { _E_mod = 1, _O_mod = 2, _EO_mod = _E_mod | _O_mod };
+
+        struct _Table_entry {
+            char _Type;
+            _Allowed_bit _Allowed;
+        };
+
+        const _Allowed_bit _Mod = _Modifier == _CharT{'E'} ? _E_mod : _O_mod;
+
+        static const _Table_entry _Table[] = {{'d', _O_mod}, {'e', _O_mod}, {'m', _O_mod}};
+
+        if (auto _It = _RANGES find(_Table, static_cast<char>(_Type), &_Table_entry::_Type); _It != _STD end(_Table)) {
+            if (_It->_Allowed & _Mod) {
+                return;
+            }
+        }
+
+        _THROW(format_error("Incompatible modifier for type"));
+    }
+
+    template <class _FormatContext, class _Ty>
+    typename _FormatContext::iterator _Write(_FormatContext& _FormatCtx, const _Ty& _Val, const tm& _Time) {
+        basic_stringstream<_CharT> _Stream;
+
+        if (_No_chrono_specs) {
+            _Stream << _Val;
+        } else {
+            _Stream.imbue(_FormatCtx.locale());
+            for (const auto& _Spec : _Specs._Chrono_specs_list) {
+                if (_Spec._Lit_char != _CharT{'\0'}) {
+                    _Stream << _Spec._Lit_char;
+                    continue;
+                }
+
+                // TRANSITION, out of bounds may be legal for non-localized decimal printing, but it isn't very
+                // consistent.
+                if (!_Val.ok()) {
+                    _THROW(format_error("Cannot print out-of-bounds time point."));
+                }
+
+                _CharT _Fmt_str[4];
+                size_t _Next_idx      = 0;
+                _Fmt_str[_Next_idx++] = _CharT{'%'};
+                if (_Spec._Modifier != _CharT{'\0'}) {
+                    _Fmt_str[_Next_idx++] = _Spec._Modifier;
+                }
+                _Fmt_str[_Next_idx++] = _Spec._Type;
+                _Fmt_str[_Next_idx]   = _CharT{'\0'};
+
+                _Stream << _STD put_time<_CharT>(&_Time, _Fmt_str);
+            }
+        }
+
+        return _Write_aligned(_STD move(_FormatCtx.out()), static_cast<int>(_Stream.view().size()), _Specs,
+            _Fmt_align::_Left, [&](auto _Out) { return _Fmt_write(_STD move(_Out), _Stream.view()); });
+    }
+
+    _Chrono_format_specs<_CharT> _Specs{};
+    bool _No_chrono_specs = false;
+};
+
+template <class _CharT>
+struct formatter<_CHRONO day, _CharT> {
+    typename basic_format_parse_context<_CharT>::iterator parse(basic_format_parse_context<_CharT>& _Parse_ctx) {
+        return _Impl._Parse(_Parse_ctx, "de");
+    }
+
+    template <class _FormatContext>
+    typename _FormatContext::iterator format(const _CHRONO day& _Val, _FormatContext& _FormatCtx) {
+        const tm _Time = {.tm_mday = static_cast<int>(static_cast<unsigned int>(_Val))};
+        return _Impl._Write(_FormatCtx, _Val, _Time);
+    }
+
+private:
+    _Chrono_formatter<_CharT, false> _Impl;
+};
+
+template <class _CharT>
+struct formatter<_CHRONO month, _CharT> {
+    typename basic_format_parse_context<_CharT>::iterator parse(basic_format_parse_context<_CharT>& _Parse_ctx) {
+        return _Impl._Parse(_Parse_ctx, "bBhm");
+    }
+
+    template <class _FormatContext>
+    typename _FormatContext::iterator format(const _CHRONO month& _Val, _FormatContext& _FormatCtx) {
+        // tm_mon is [0, 11] while month is [1, 12]
+        const tm _Time = {.tm_mon = static_cast<int>(static_cast<unsigned int>(_Val)) - 1};
+        return _Impl._Write(_FormatCtx, _Val, _Time);
+    }
+
+private:
+    _Chrono_formatter<_CharT, false> _Impl;
+};
+#endif // __cpp_lib_concepts
+#endif // _HAS_CXX20
 
 // HELPERS
 template <class _Rep, class _Period>
@@ -5410,7 +5664,8 @@ inline namespace literals {
             return _CHRONO duration<double>(_Val);
         }
 
-        _NODISCARD constexpr _CHRONO milliseconds operator"" ms(unsigned long long _Val) noexcept /* strengthened */ {
+        _NODISCARD constexpr _CHRONO milliseconds operator"" ms(unsigned long long _Val) noexcept
+        /* strengthened */ {
             return _CHRONO milliseconds(_Val);
         }
 
@@ -5419,7 +5674,8 @@ inline namespace literals {
             return _CHRONO duration<double, milli>(_Val);
         }
 
-        _NODISCARD constexpr _CHRONO microseconds operator"" us(unsigned long long _Val) noexcept /* strengthened */ {
+        _NODISCARD constexpr _CHRONO microseconds operator"" us(unsigned long long _Val) noexcept
+        /* strengthened */ {
             return _CHRONO microseconds(_Val);
         }
 
@@ -5428,7 +5684,8 @@ inline namespace literals {
             return _CHRONO duration<double, micro>(_Val);
         }
 
-        _NODISCARD constexpr _CHRONO nanoseconds operator"" ns(unsigned long long _Val) noexcept /* strengthened */ {
+        _NODISCARD constexpr _CHRONO nanoseconds operator"" ns(unsigned long long _Val) noexcept
+        /* strengthened */ {
             return _CHRONO nanoseconds(_Val);
         }
 

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -5446,33 +5446,50 @@ namespace chrono {
     // mandates that invalid dates still be formatted properly.  For example, put_time isn't able to handle a tm_mday of
     // 40, but format("{:%d}", day{40}) should return "40" and operator<< for day prints "40 is not a valid day".
     template <class _CharT, class _Ty>
-    bool _Try_simple_write(basic_ostream<_CharT>& _Os, const char _Type, const tm& _Time, const _Ty& _Val) {
-        const auto _Year  = _Time.tm_year + 1900;
-        const auto _Month = _Time.tm_mon + 1;
-        switch (_Type) {
+    bool _Custom_write(
+        basic_ostream<_CharT>& _Os, const _Chrono_specs<_CharT>& _Specs, const tm& _Time, const _Ty& _Val) {
+        const auto _Year         = _Time.tm_year + 1900;
+        const auto _Month        = _Time.tm_mon + 1;
+        const bool _Has_modifier = _Specs._Modifier != '\0';
+        switch (_Specs._Type) {
         case 'd':
         case 'e':
+            if (_Has_modifier) {
+                return false;
+            }
             if (_Time.tm_mday < 10) {
-                _Os << (_Type == 'd' ? _CharT{'0'} : _CharT{' '});
+                _Os << (_Specs._Type == 'd' ? _CharT{'0'} : _CharT{' '});
             }
             _Os << _Time.tm_mday;
             return true;
         case 'm':
+            if (_Has_modifier) {
+                return false;
+            }
             if (_Month < 10) {
                 _Os << _CharT{'0'};
             }
             _Os << _Month;
             return true;
         case 'Y':
+            if (_Has_modifier) {
+                return false;
+            }
             if (_Year < 0) {
                 _Os << _CharT{'-'};
             }
             _Os << _STD format(_STATICALLY_WIDEN(_CharT, "{:04}"), _STD abs(_Year));
             return true;
         case 'y':
+            if (_Has_modifier) {
+                return false;
+            }
             _Os << _STD format(_STATICALLY_WIDEN(_CharT, "{:02}"), _Year < 0 ? 100 + (_Year % 100) : _Year % 100);
             return true;
         case 'C':
+            if (_Has_modifier) {
+                return false;
+            }
             if (_Year < 0) {
                 _Os << _CharT{'-'};
             }
@@ -5480,24 +5497,27 @@ namespace chrono {
                 _STATICALLY_WIDEN(_CharT, "{:02}"), _STD abs(_Time_parse_fields::_Decompose_year(_Year).first) / 100);
             return true;
         case 'F':
-            _Try_simple_write(_Os, 'Y', _Time, _Val);
+            _Custom_write(_Os, {._Type = 'Y'}, _Time, _Val);
             _Os << _CharT{'-'};
-            _Try_simple_write(_Os, 'm', _Time, _Val);
+            _Custom_write(_Os, {._Type = 'm'}, _Time, _Val);
             _Os << _CharT{'-'};
-            _Try_simple_write(_Os, 'd', _Time, _Val);
+            _Custom_write(_Os, {._Type = 'd'}, _Time, _Val);
             return true;
         case 'D':
-            _Try_simple_write(_Os, 'm', _Time, _Val);
+            _Custom_write(_Os, {._Type = 'm'}, _Time, _Val);
             _Os << _CharT{'/'};
-            _Try_simple_write(_Os, 'd', _Time, _Val);
+            _Custom_write(_Os, {._Type = 'd'}, _Time, _Val);
             _Os << _CharT{'/'};
-            _Try_simple_write(_Os, 'y', _Time, _Val);
+            _Custom_write(_Os, {._Type = 'y'}, _Time, _Val);
             return true;
         case 'T':
             // Alias for %H:%M:%S but we need to rewrite %S to display fractions of a second.
             _Os << _STD put_time(&_Time, _STATICALLY_WIDEN(_CharT, "%H:%M:"));
             [[fallthrough]];
         case 'S':
+            if (_Has_modifier) {
+                return false;
+            }
             _Write_seconds(_Os, _Val);
             return true;
         default:
@@ -5790,11 +5810,12 @@ struct _Chrono_formatter {
                     continue;
                 }
 
-                // For non-localized writes, we can sometimes avoid calling put_time.
-                if (_Spec._Modifier == '\0' && _CHRONO _Try_simple_write(_Stream, _Spec._Type, _Time, _Val)) {
+                // We need to manually do certain writes, either because the specification is different from put_time or
+                // custom logic is needed.
+                if (_CHRONO _Custom_write(_Stream, _Spec, _Time, _Val)) {
                     continue;
                 }
-                // Otherwise, we should throw to avoid triggering asserts within put_time machinery.
+                // Otherwise, we should throw on out-of-bounds to avoid triggering asserts within put_time machinery.
                 if constexpr (_Has_ok<_Ty>) {
                     if (!_Val.ok()) {
                         _THROW(format_error("Cannot localize out-of-bounds time point."));

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -5965,13 +5965,8 @@ namespace chrono {
                     if (_Custom_write(_Stream, _Spec, _Time, _Val)) {
                         continue;
                     }
-                    // Otherwise, we should throw on out-of-bounds to avoid triggering asserts within put_time
-                    // machinery.
-                    if constexpr (_Has_ok<_Ty>) {
-                        if (!_Val.ok()) {
-                            _THROW(format_error("Cannot localize out-of-bounds time point."));
-                        }
-                    }
+
+                    _Validate_specifiers(_Spec, _Val);
 
                     _Stream << _STD put_time<_CharT>(&_Time, _Fmt_string(_Spec).data());
                 }
@@ -5998,28 +5993,16 @@ namespace chrono {
             const auto _Month        = _Time.tm_mon + 1;
             const bool _Has_modifier = _Spec._Modifier != '\0';
             switch (_Spec._Type) {
-            case 'a':
-            case 'A':
-            case 'u':
-            case 'w':
-                if constexpr (_Is_any_of_v<_Ty, year_month_weekday, year_month_weekday_last>) {
-                    if (!_Val.weekday().ok()) {
-                        _THROW(format_error("Cannot print invalid weekday"));
-                    }
-                    _Os << _STD put_time(&_Time, _Fmt_string(_Spec).data());
-                    return true;
-                } else if constexpr (_Has_ok<_Ty>) {
-                    if (!_Val.ok()) {
-                        _THROW(format_error("Cannot print invalid weekday"));
-                    }
-                }
-                return false;
-            case 'd':
+            case 'd': // Print days as a decimal, even if invalid.
             case 'e':
                 // Most months have a proper last day, but February depends on the year.
                 if constexpr (is_same_v<_Ty, month_day_last>) {
                     if (_Val.month() == February) {
                         _THROW(format_error("Cannot print the last day of February without a year"));
+                    }
+
+                    if (!_Val.ok()) {
+                        return false;
                     }
                 }
 
@@ -6063,20 +6046,6 @@ namespace chrono {
                 if constexpr (_Is_specialization_v<_Ty, duration>) {
                     _Os << _STD abs(_CHRONO duration_cast<days>(_Val).count());
                     return true;
-                } else if constexpr (is_same_v<_Ty, month_day>) {
-                    if (_Val.month() > February) {
-                        _THROW(format_error("The day of year for a month_day past February is ambiguous."));
-                    }
-                } else if constexpr (is_same_v<_Ty, month_day_last>) {
-                    if (_Val.month() >= February) {
-                        _THROW(format_error("The day of year for a month_day_last other than January is ambiguous"));
-                    }
-                }
-
-                if constexpr (_Has_ok<_Ty>) {
-                    if (!_Val.ok()) {
-                        _THROW(format_error("Cannot print invalid day of year"));
-                    }
                 }
                 return false;
             case 'q':
@@ -6089,7 +6058,7 @@ namespace chrono {
                     _Os << _STD abs(_Val.count());
                 }
                 return true;
-            case 'm':
+            case 'm': // Print months as a decimal, even if invalid.
                 if (_Has_modifier) {
                     return false;
                 }
@@ -6099,7 +6068,7 @@ namespace chrono {
                 }
                 _Os << _Month;
                 return true;
-            case 'Y':
+            case 'Y': // Print years as a decimal, even if invalid.
                 if (_Has_modifier) {
                     return false;
                 }
@@ -6109,13 +6078,13 @@ namespace chrono {
                 }
                 _Os << _STD format(_STATICALLY_WIDEN(_CharT, "{:04}"), _STD abs(_Year));
                 return true;
-            case 'y':
+            case 'y': // Print the two-digit year as a decimal, even if invalid.
                 if (_Has_modifier) {
                     return false;
                 }
                 _Os << _STD format(_STATICALLY_WIDEN(_CharT, "{:02}"), _Year < 0 ? 100 + (_Year % 100) : _Year % 100);
                 return true;
-            case 'C':
+            case 'C': // Print the century as a decimal, even if invalid.
                 if (_Has_modifier) {
                     return false;
                 }
@@ -6126,30 +6095,23 @@ namespace chrono {
                 _Os << _STD format(_STATICALLY_WIDEN(_CharT, "{:02}"),
                     _STD abs(_Time_parse_fields::_Decompose_year(_Year).first) / 100);
                 return true;
-            case 'F':
+            case 'F': // Print YMD even if invalid.
                 _Custom_write(_Os, {._Type = 'Y'}, _Time, _Val);
                 _Os << _CharT{'-'};
                 _Custom_write(_Os, {._Type = 'm'}, _Time, _Val);
                 _Os << _CharT{'-'};
                 _Custom_write(_Os, {._Type = 'd'}, _Time, _Val);
                 return true;
-            case 'D':
+            case 'D': // Print YMD even if invalid.
                 _Custom_write(_Os, {._Type = 'm'}, _Time, _Val);
                 _Os << _CharT{'/'};
                 _Custom_write(_Os, {._Type = 'd'}, _Time, _Val);
                 _Os << _CharT{'/'};
                 _Custom_write(_Os, {._Type = 'y'}, _Time, _Val);
                 return true;
-            case 'H':
-                if constexpr (_Is_specialization_v<_Ty, hh_mm_ss>) {
-                    if (_Val.hours() >= hours{24}) {
-                        _THROW(format_error("Cannot localize hh_mm_ss with an absolute value of 24 hours or more."));
-                    }
-                }
-                return false;
             case 'T':
                 // Alias for %H:%M:%S but we need to rewrite %S to display fractions of a second.
-                _Custom_write(_Os, {._Type = 'H'}, _Time, _Val);
+                _Validate_specifiers({._Type = 'H'}, _Val);
                 _Os << _STD put_time(&_Time, _STATICALLY_WIDEN(_CharT, "%H:%M:"));
                 [[fallthrough]];
             case 'S':
@@ -6199,6 +6161,127 @@ namespace chrono {
                 }
             default:
                 return false;
+            }
+        }
+
+        template <class _Ty>
+        static void _Validate_specifiers(const _Chrono_spec<_CharT>& _Spec, const _Ty& _Val) {
+            // clang-format off
+            if constexpr (_Is_specialization_v<_Ty, duration> || is_same_v<_Ty, sys_info>
+                || _Is_specialization_v<_Ty, time_point> || _Is_specialization_v<_Ty, _Local_time_format_t>) {
+                return;
+            }
+            // clang-format on
+
+            if constexpr (_Is_specialization_v<_Ty, hh_mm_ss>) {
+                if (_Spec._Type == 'H' && _Val.hours() >= hours{24}) {
+                    _THROW(format_error("Cannot localize hh_mm_ss with an absolute value of 24 hours or more."));
+                }
+                return;
+            }
+
+            constexpr bool _Is_ymd =
+                _Is_any_of_v<_Ty, year_month_day, year_month_day_last, year_month_weekday, year_month_weekday_last>;
+
+            const auto _Validate = [&] {
+                switch (_Spec._Type) {
+                case 'a':
+                case 'A':
+                case 'u':
+                case 'w':
+                    if constexpr (_Is_any_of_v<_Ty, weekday, weekday_last>) {
+                        return _Val.ok();
+                    } else if constexpr (_Is_any_of_v<_Ty, weekday_indexed, year_month_weekday,
+                                             year_month_weekday_last>) {
+                        return _Val.weekday().ok();
+                    } else if constexpr (is_same_v<_Ty, month_weekday>) {
+                        return _Val.weekday_indexed().weekday().ok();
+                    } else if constexpr (is_same_v<_Ty, month_weekday_last>) {
+                        return _Val.weekday_last().ok();
+                    } else if constexpr (_Is_any_of_v<_Ty, year_month_day, year_month_day_last>) {
+                        return _Val.ok();
+                    }
+                    break;
+
+                case 'b':
+                case 'B':
+                case 'h':
+                case 'm':
+                    if constexpr (is_same_v<_Ty, month>) {
+                        return _Val.ok();
+                    } else if constexpr (_Is_any_of_v<_Ty, month_day, month_day_last, month_weekday, month_weekday_last,
+                                             year_month> || _Is_ymd) {
+                        return _Val.month().ok();
+                    }
+                    break;
+
+                case 'C':
+                case 'y':
+                case 'Y':
+                    if constexpr (is_same_v<_Ty, year>) {
+                        return _Val.ok();
+                    } else if constexpr (_Is_any_of_v<_Ty, year_month> || _Is_ymd) {
+                        return _Val.year().ok();
+                    }
+                    break;
+
+                case 'd':
+                case 'e':
+                    if constexpr (_Is_any_of_v<_Ty, day, month_day_last>) {
+                        return _Val.ok();
+                    } else if constexpr (is_same_v<_Ty, month_day>) {
+                        return _Val.day().ok();
+                    } else if constexpr (_Is_ymd) {
+                        const year_month_day& _Ymd{_Val};
+                        return _Ymd.day().ok();
+                    }
+                    break;
+
+                case 'D':
+                case 'F':
+                    if constexpr (_Has_ok<_Ty>) {
+                        return _Val.ok();
+                    }
+                    break;
+
+                case 'j':
+                    if constexpr (is_same_v<_Ty, month_day>) {
+                        if (_Val.month() > February) {
+                            _THROW(format_error("The day of year for a month_day past February is ambiguous."));
+                        }
+                        return true;
+                    } else if constexpr (is_same_v<_Ty, month_day_last>) {
+                        if (_Val.month() >= February) {
+                            _THROW(
+                                format_error("The day of year for a month_day_last other than January is ambiguous"));
+                        }
+                        return true;
+                    } else if constexpr (_Is_ymd) {
+                        return _Val.ok();
+                    }
+                    break;
+
+                case 'g':
+                case 'G':
+                case 'U':
+                case 'V':
+                case 'W':
+                    if constexpr (_Is_ymd) {
+                        return _Val.ok();
+                    }
+                    break;
+
+                default:
+                    if constexpr (_Has_ok<_Ty>) {
+                        return _Val.ok();
+                    }
+                    return true;
+                }
+                _STL_INTERNAL_CHECK(false);
+                return false;
+            };
+            if (!_Validate()) {
+                _THROW(format_error("Cannot localize out-of-bounds time point."));
             }
         }
 

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -5454,6 +5454,12 @@ namespace chrono {
         switch (_Specs._Type) {
         case 'd':
         case 'e':
+            // Most months have a proper last day, but February depends on the year.
+            if constexpr (is_same_v<_Ty, month_day_last>) {
+                if (_Val.month() == February) {
+                    _THROW(format_error("Cannot print the last day of February without a year"));
+                }
+            }
             if (_Has_modifier) {
                 return false;
             }
@@ -5546,6 +5552,7 @@ namespace chrono {
             _Month = static_cast<unsigned int>(_Val.month());
         } else if constexpr (is_same_v<_Ty, month_day_last>) {
             _Month = static_cast<unsigned int>(_Val.month());
+            _Day   = static_cast<unsigned int>(_Last_day_table[_Month - 1]);
         } else if constexpr (is_same_v<_Ty, year_month>) {
             _Month = static_cast<unsigned int>(_Val.month());
             _Year  = static_cast<int>(_Val.year());
@@ -5766,13 +5773,13 @@ struct _Chrono_formatter {
     _NODISCARD constexpr bool _Is_valid_type(const char _Type) noexcept {
         if constexpr (is_same_v<_Ty, _CHRONO day>) {
             return _Type == 'd' || _Type == 'e';
-        } else if constexpr (_Is_any_of_v<_Ty, _CHRONO month, _CHRONO month_day_last>) {
+        } else if constexpr (is_same_v<_Ty, _CHRONO month>) {
             return _Type == 'b' || _Type == 'B' || _Type == 'h' || _Type == 'm';
         } else if constexpr (is_same_v<_Ty, _CHRONO year>) {
             return _Type == 'Y' || _Type == 'y' || _Type == 'C';
         } else if constexpr (is_same_v<_Ty, _CHRONO weekday>) {
             return _Type == 'a' || _Type == 'A' || _Type == 'u' || _Type == 'w';
-        } else if constexpr (is_same_v<_Ty, _CHRONO month_day>) {
+        } else if constexpr (_Is_any_of_v<_Ty, _CHRONO month_day, _CHRONO month_day_last>) {
             return _Is_valid_type<_CHRONO month>(_Type) || _Is_valid_type<_CHRONO day>(_Type);
         } else if constexpr (is_same_v<_Ty, _CHRONO year_month>) {
             return _Is_valid_type<_CHRONO year>(_Type) || _Is_valid_type<_CHRONO month>(_Type);

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -5621,7 +5621,25 @@ struct _Chrono_formatter {
         };
 
         static constexpr _Table_entry _Table[] = {
-            {'d', _O_mod}, {'e', _O_mod}, {'m', _O_mod}, {'Y', _E_mod}, {'y', _EO_mod}, {'C', _E_mod}};
+            {'Y', _E_mod},
+            {'y', _EO_mod},
+            {'C', _E_mod},
+            {'m', _O_mod},
+            {'U', _O_mod},
+            {'W', _O_mod},
+            {'V', _O_mod},
+            {'d', _O_mod},
+            {'e', _O_mod},
+            {'w', _O_mod},
+            {'u', _O_mod},
+            {'H', _O_mod},
+            {'I', _O_mod},
+            {'M', _O_mod},
+            {'S', _O_mod},
+            {'c', _E_mod},
+            {'x', _E_mod},
+            {'X', _E_mod},
+        };
 
         const _Allowed_bit _Mod = _Modifier == 'E' ? _E_mod : _O_mod;
 

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -5408,6 +5408,62 @@ _NODISCARD constexpr const _CharT* _Parse_chrono_format_specs(
 }
 
 namespace chrono {
+    // This echoes the functionality of put_time, but is able to handle invalid dates (when !ok()) since the Standard
+    // mandates that invalid dates still be formatted properly.  For example, put_time isn't able to handle a tm_mday of
+    // 40, but format("{:%d}", day{40}) should return "40" and operator<< for day prints "40 is not a valid day".
+    template <class _CharT>
+    bool _Try_simple_write(basic_ostream<_CharT>& _Os, const char _Type, const tm& _Time) {
+        const auto _Year  = _Time.tm_year + 1900;
+        const auto _Month = _Time.tm_mon + 1;
+        switch (_Type) {
+        case 'd':
+        case 'e':
+            if (_Time.tm_mday < 10) {
+                _Os << (_Type == 'd' ? _CharT{'0'} : _CharT{' '});
+            }
+            _Os << _Time.tm_mday;
+            return true;
+        case 'm':
+            if (_Month < 10) {
+                _Os << _CharT{'0'};
+            }
+            _Os << _Month;
+            return true;
+        case 'Y':
+            if (_Year < 0) {
+                _Os << _CharT{'-'};
+            }
+            _Os << _STD format(_STATICALLY_WIDEN(_CharT, "{:04}"), _STD abs(_Year));
+            return true;
+        case 'y':
+            _Os << _STD format(_STATICALLY_WIDEN(_CharT, "{:02}"), _Year < 0 ? 100 + (_Year % 100) : _Year % 100);
+            return true;
+        case 'C':
+            if (_Year < 0) {
+                _Os << _CharT{'-'};
+            }
+            _Os << _STD format(
+                _STATICALLY_WIDEN(_CharT, "{:02}"), _STD abs(_Time_parse_fields::_Decompose_year(_Year).first) / 100);
+            return true;
+        case 'F':
+            _Try_simple_write(_Os, 'Y', _Time);
+            _Os << _CharT{'-'};
+            _Try_simple_write(_Os, 'm', _Time);
+            _Os << _CharT{'-'};
+            _Try_simple_write(_Os, 'd', _Time);
+            return true;
+        case 'D':
+            _Try_simple_write(_Os, 'm', _Time);
+            _Os << _CharT{'/'};
+            _Try_simple_write(_Os, 'd', _Time);
+            _Os << _CharT{'/'};
+            _Try_simple_write(_Os, 'y', _Time);
+            return true;
+        default:
+            return false;
+        }
+    }
+
     /*
     template <class _CharT, class _Traits, class _Duration>
     // clang-format off
@@ -5431,10 +5487,8 @@ namespace chrono {
 
     template <class _CharT, class _Traits>
     basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const day& _Val) {
-        if (static_cast<unsigned int>(_Val) < 10) {
-            _Os << _CharT{'0'};
-        }
-        _Os << static_cast<unsigned int>(_Val);
+        const tm _Time = {.tm_mday = static_cast<int>(static_cast<unsigned int>(_Val))};
+        _Try_simple_write(_Os, 'd', _Time);
         if (!_Val.ok()) {
             _Os << _STATICALLY_WIDEN(_CharT, " is not a valid day");
         }
@@ -5450,6 +5504,28 @@ namespace chrono {
             return _Os << _STD put_time(&_Time, _STATICALLY_WIDEN(_CharT, "%b"));
         }
         return _Os << static_cast<unsigned int>(_Val) << _STATICALLY_WIDEN(_CharT, " is not a valid month");
+    }
+
+    template <class _CharT, class _Traits>
+    basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const year& _Val) {
+        const tm _Time = {.tm_year = static_cast<int>(_Val) - 1900};
+        _Try_simple_write(_Os, 'Y', _Time);
+        if (!_Val.ok()) {
+            _Os << _STATICALLY_WIDEN(_CharT, " is not a valid year");
+        }
+        return _Os;
+    }
+
+    template <class _CharT, class _Traits>
+    basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const year_month_day& _Val) {
+        const tm _Time = {.tm_mday = static_cast<int>(static_cast<unsigned int>(_Val.day())),
+            .tm_mon                = static_cast<int>(static_cast<unsigned int>(_Val.month())) - 1,
+            .tm_year               = static_cast<int>(_Val.year()) - 1900};
+        _Try_simple_write(_Os, 'F', _Time);
+        if (!_Val.ok()) {
+            _Os << _STATICALLY_WIDEN(_CharT, " is not a valid date");
+        }
+        return _Os;
     }
 } // namespace chrono
 
@@ -5472,7 +5548,8 @@ struct formatter<_CHRONO sys_time<_Duration>, _CharT> {
 
 template <class _CharT, bool _Allow_precision>
 struct _Chrono_formatter {
-    auto _Parse(basic_format_parse_context<_CharT>& _Parse_ctx, string_view _Valid_types) {
+    template <class _Ty>
+    _NODISCARD auto _Parse(basic_format_parse_context<_CharT>& _Parse_ctx) {
         _Chrono_specs_setter<_CharT, basic_format_parse_context<_CharT>> _Callback{_Specs, _Parse_ctx};
         const auto _It =
             _Parse_chrono_format_specs(_Parse_ctx._Unchecked_begin(), _Parse_ctx._Unchecked_end(), _Callback);
@@ -5495,7 +5572,7 @@ struct _Chrono_formatter {
         }
 
         for (const auto& _Spec : _List) {
-            if (_Spec._Type != '\0' && _RANGES find(_Valid_types, _Spec._Type) == _Valid_types.end()) {
+            if (_Spec._Type != '\0' && !_Is_valid_type<_Ty>(_Spec._Type)) {
                 _THROW(format_error("Invalid type."));
             }
             _Check_modifier(_Spec._Type, _Spec._Modifier);
@@ -5516,7 +5593,8 @@ struct _Chrono_formatter {
             _Allowed_bit _Allowed;
         };
 
-        static const _Table_entry _Table[] = {{'d', _O_mod}, {'e', _O_mod}, {'m', _O_mod}};
+        static const _Table_entry _Table[] = {
+            {'d', _O_mod}, {'e', _O_mod}, {'m', _O_mod}, {'Y', _E_mod}, {'y', _EO_mod}, {'C', _E_mod}};
 
         const _Allowed_bit _Mod = _Modifier == 'E' ? _E_mod : _O_mod;
 
@@ -5529,8 +5607,25 @@ struct _Chrono_formatter {
         _THROW(format_error("Incompatible modifier for type"));
     }
 
+    template <class _Ty>
+    _NODISCARD constexpr bool _Is_valid_type(const char _Type) noexcept {
+        if constexpr (is_same_v<_Ty, _CHRONO day>) {
+            return _Type == 'd' || _Type == 'e';
+        } else if constexpr (is_same_v<_Ty, _CHRONO month>) {
+            return _Type == 'b' || _Type == 'B' || _Type == 'h' || _Type == 'm';
+        } else if constexpr (is_same_v<_Ty, _CHRONO year>) {
+            return _Type == 'Y' || _Type == 'y' || _Type == 'C';
+        } else if constexpr (is_same_v<_Ty, _CHRONO year_month_day>) {
+            return _Type == 'D' || _Type == 'F' || _Is_valid_type<_CHRONO year>(_Type)
+                || _Is_valid_type<_CHRONO month>(_Type) || _Is_valid_type<_CHRONO day>(_Type);
+        } else {
+            // TRANSITION, remove when all types are added
+            static_assert(_Always_false<_Ty>, "unsupported type");
+        }
+    }
+
     template <class _FormatContext, class _Ty>
-    auto _Write(_FormatContext& _FormatCtx, const _Ty& _Val, const tm& _Time) {
+    _NODISCARD auto _Write(_FormatContext& _FormatCtx, const _Ty& _Val, const tm& _Time) {
         basic_stringstream<_CharT> _Stream;
 
         if (_No_chrono_specs) {
@@ -5543,10 +5638,12 @@ struct _Chrono_formatter {
                     continue;
                 }
 
-                // TRANSITION, out of bounds may be legal for non-localized decimal printing, but it isn't very
-                // consistent.
-                if (!_Val.ok()) {
-                    _THROW(format_error("Cannot print out-of-bounds time point."));
+                if (_Type_needs_bounds_checking(_Spec)) {
+                    if (!_Val.ok()) {
+                        _THROW(format_error("Cannot localize out-of-bounds time point."));
+                    }
+                } else if (_Spec._Modifier == '\0' && _CHRONO _Try_simple_write(_Stream, _Spec._Type, _Time)) {
+                    continue;
                 }
 
                 _CharT _Fmt_str[4];
@@ -5566,18 +5663,35 @@ struct _Chrono_formatter {
             _Fmt_align::_Left, [&](auto _Out) { return _Fmt_write(_STD move(_Out), _Stream.view()); });
     }
 
+    _NODISCARD bool _Type_needs_bounds_checking(const _Chrono_specs<_CharT>& _Spec) noexcept {
+        // [tab:time.format.spec]
+        switch (_Spec._Type) {
+        case 'a':
+        case 'A':
+        case 'b':
+        case 'B':
+        case 'h':
+        case 'z':
+        case 'Z':
+            return true;
+
+        default:
+            return false;
+        }
+    }
+
     _Chrono_format_specs<_CharT> _Specs{};
     bool _No_chrono_specs = false;
 };
 
 template <class _CharT>
 struct formatter<_CHRONO day, _CharT> {
-    typename basic_format_parse_context<_CharT>::iterator parse(basic_format_parse_context<_CharT>& _Parse_ctx) {
-        return _Impl._Parse(_Parse_ctx, "de");
+    auto parse(basic_format_parse_context<_CharT>& _Parse_ctx) {
+        return _Impl.template _Parse<_CHRONO day>(_Parse_ctx);
     }
 
     template <class _FormatContext>
-    typename _FormatContext::iterator format(const _CHRONO day& _Val, _FormatContext& _FormatCtx) {
+    auto format(const _CHRONO day& _Val, _FormatContext& _FormatCtx) {
         const tm _Time = {.tm_mday = static_cast<int>(static_cast<unsigned int>(_Val))};
         return _Impl._Write(_FormatCtx, _Val, _Time);
     }
@@ -5588,14 +5702,48 @@ private:
 
 template <class _CharT>
 struct formatter<_CHRONO month, _CharT> {
-    typename basic_format_parse_context<_CharT>::iterator parse(basic_format_parse_context<_CharT>& _Parse_ctx) {
-        return _Impl._Parse(_Parse_ctx, "bBhm");
+    auto parse(basic_format_parse_context<_CharT>& _Parse_ctx) {
+        return _Impl.template _Parse<_CHRONO month>(_Parse_ctx);
     }
 
     template <class _FormatContext>
-    typename _FormatContext::iterator format(const _CHRONO month& _Val, _FormatContext& _FormatCtx) {
+    auto format(const _CHRONO month& _Val, _FormatContext& _FormatCtx) {
         // tm_mon is [0, 11] while month is [1, 12]
         const tm _Time = {.tm_mon = static_cast<int>(static_cast<unsigned int>(_Val)) - 1};
+        return _Impl._Write(_FormatCtx, _Val, _Time);
+    }
+
+private:
+    _Chrono_formatter<_CharT, false> _Impl;
+};
+
+template <class _CharT>
+struct formatter<_CHRONO year, _CharT> {
+    auto parse(basic_format_parse_context<_CharT>& _Parse_ctx) {
+        return _Impl.template _Parse<_CHRONO year>(_Parse_ctx);
+    }
+
+    template <class _FormatContext>
+    auto format(const _CHRONO year& _Val, _FormatContext& _FormatCtx) {
+        const tm _Time = {.tm_year = static_cast<int>(_Val) - 1900};
+        return _Impl._Write(_FormatCtx, _Val, _Time);
+    }
+
+private:
+    _Chrono_formatter<_CharT, false> _Impl;
+};
+
+template <class _CharT>
+struct formatter<_CHRONO year_month_day, _CharT> {
+    auto parse(basic_format_parse_context<_CharT>& _Parse_ctx) {
+        return _Impl.template _Parse<_CHRONO year_month_day>(_Parse_ctx);
+    }
+
+    template <class _FormatContext>
+    auto format(const _CHRONO year_month_day& _Val, _FormatContext& _FormatCtx) {
+        const tm _Time = {.tm_mday = static_cast<int>(static_cast<unsigned int>(_Val.day())),
+            .tm_mon                = static_cast<int>(static_cast<unsigned int>(_Val.month())) - 1,
+            .tm_year               = static_cast<int>(_Val.year()) - 1900};
         return _Impl._Write(_FormatCtx, _Val, _Time);
     }
 

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -5469,9 +5469,14 @@ namespace chrono {
     void _Write_seconds(basic_ostream<_CharT, _Traits>& _Os, const hh_mm_ss<_Duration>& _Val) {
         _Os << _STD format(_STATICALLY_WIDEN(_CharT, "{:02}"), _Val.seconds().count());
         if constexpr (hh_mm_ss<_Duration>::fractional_width > 0) {
-            _Os << _STD format(_STATICALLY_WIDEN(_CharT, "{0}{1:0{2}}"),
-                _STD use_facet<numpunct<_CharT>>(_Os.getloc()).decimal_point(), _Val.subseconds().count(),
-                _Val.fractional_width);
+            _Os << _STD use_facet<numpunct<_CharT>>(_Os.getloc()).decimal_point();
+            if constexpr (treat_as_floating_point_v<typename hh_mm_ss<_Duration>::precision::rep>) {
+                _Os << _STD format(_STATICALLY_WIDEN(_CharT, "{:0{}.0f}"), _STD floor(_Val.subseconds().count()),
+                    _Val.fractional_width);
+            } else {
+                _Os << _STD format(
+                    _STATICALLY_WIDEN(_CharT, "{:0{}}"), _Val.subseconds().count(), _Val.fractional_width);
+            }
         }
     }
 

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -5488,7 +5488,7 @@ namespace chrono {
             _Year = static_cast<int>(_Val);
         } else if constexpr (is_same_v<_Ty, weekday>) {
             _Weekday = static_cast<int>(_Val.c_encoding());
-        } else if constexpr (is_same_v<_Ty, weekday_indexed>) {
+        } else if constexpr (_Is_any_of_v<_Ty, weekday_indexed, weekday_last>) {
             _Weekday = static_cast<int>(_Val.weekday().c_encoding());
         } else if constexpr (is_same_v<_Ty, month_day>) {
             _Day   = static_cast<unsigned int>(_Val.day());
@@ -5496,6 +5496,12 @@ namespace chrono {
         } else if constexpr (is_same_v<_Ty, month_day_last>) {
             _Month = static_cast<unsigned int>(_Val.month());
             _Day   = static_cast<unsigned int>(_Last_day_table[(_Month - 1) & 0xF]);
+        } else if constexpr (is_same_v<_Ty, month_weekday>) {
+            _Month   = static_cast<unsigned int>(_Val.month());
+            _Weekday = static_cast<int>(_Val.weekday_indexed().weekday().c_encoding());
+        } else if constexpr (is_same_v<_Ty, month_weekday_last>) {
+            _Month   = static_cast<unsigned int>(_Val.month());
+            _Weekday = static_cast<int>(_Val.weekday_last().weekday().c_encoding());
         } else if constexpr (is_same_v<_Ty, year_month>) {
             _Month = static_cast<unsigned int>(_Val.month());
             _Year  = static_cast<int>(_Val.year());
@@ -5509,12 +5515,7 @@ namespace chrono {
             _Month   = static_cast<unsigned int>(_Val.month());
             _Year    = static_cast<int>(_Val.year());
             _Weekday = year_month_day{_Val}._Calculate_weekday();
-        } else if constexpr (is_same_v<_Ty, year_month_weekday>) {
-            _Day     = static_cast<unsigned int>(year_month_day{_Val}.day());
-            _Month   = static_cast<unsigned int>(_Val.month());
-            _Year    = static_cast<int>(_Val.year());
-            _Weekday = static_cast<int>(_Val.weekday().c_encoding());
-        } else if constexpr (is_same_v<_Ty, year_month_weekday_last>) {
+        } else if constexpr (_Is_any_of_v<_Ty, year_month_weekday, year_month_weekday_last>) {
             _Day     = static_cast<unsigned int>(year_month_day{_Val}.day());
             _Month   = static_cast<unsigned int>(_Val.month());
             _Year    = static_cast<int>(_Val.year());
@@ -5785,10 +5786,12 @@ struct _Chrono_formatter {
             return _Type == 'b' || _Type == 'B' || _Type == 'h' || _Type == 'm';
         } else if constexpr (is_same_v<_Ty, _CHRONO year>) {
             return _Type == 'Y' || _Type == 'y' || _Type == 'C';
-        } else if constexpr (_Is_any_of_v<_Ty, _CHRONO weekday, _CHRONO weekday_indexed>) {
+        } else if constexpr (_Is_any_of_v<_Ty, _CHRONO weekday, _CHRONO weekday_indexed, _CHRONO weekday_last>) {
             return _Type == 'a' || _Type == 'A' || _Type == 'u' || _Type == 'w';
         } else if constexpr (_Is_any_of_v<_Ty, _CHRONO month_day, _CHRONO month_day_last>) {
             return _Is_valid_type<_CHRONO month>(_Type) || _Is_valid_type<_CHRONO day>(_Type);
+        } else if constexpr (_Is_any_of_v<_Ty, _CHRONO month_weekday, _CHRONO month_weekday_last>) {
+            return _Is_valid_type<_CHRONO month>(_Type) || _Is_valid_type<_CHRONO weekday>(_Type);
         } else if constexpr (is_same_v<_Ty, _CHRONO year_month>) {
             return _Is_valid_type<_CHRONO year>(_Type) || _Is_valid_type<_CHRONO month>(_Type);
         } else if constexpr (_Is_any_of_v<_Ty, _CHRONO year_month_day, _CHRONO year_month_day_last,
@@ -5808,8 +5811,7 @@ struct _Chrono_formatter {
             return _Type == 'c' || _Type == 'x' || _Type == 'X' || _Is_valid_type<_CHRONO year_month_day>(_Type)
                 || _Is_valid_type<_CHRONO hh_mm_ss<_CHRONO seconds>>(_Type);
         } else {
-            // TRANSITION, remove when all types are added
-            static_assert(_Always_false<_Ty>, "unsupported type");
+            static_assert(_Always_false<_Ty>, "should be unreachable");
         }
     }
 
@@ -6015,12 +6017,24 @@ struct formatter<_CHRONO weekday_indexed, _CharT> //
     : _Fill_tm_formatter<_CHRONO weekday_indexed, _CharT> {};
 
 template <class _CharT>
+struct formatter<_CHRONO weekday_last, _CharT> //
+    : _Fill_tm_formatter<_CHRONO weekday_last, _CharT> {};
+
+template <class _CharT>
 struct formatter<_CHRONO month_day, _CharT> //
     : _Fill_tm_formatter<_CHRONO month_day, _CharT> {};
 
 template <class _CharT>
 struct formatter<_CHRONO month_day_last, _CharT> //
     : _Fill_tm_formatter<_CHRONO month_day_last, _CharT> {};
+
+template <class _CharT>
+struct formatter<_CHRONO month_weekday, _CharT> //
+    : _Fill_tm_formatter<_CHRONO month_weekday, _CharT> {};
+
+template <class _CharT>
+struct formatter<_CHRONO month_weekday_last, _CharT> //
+    : _Fill_tm_formatter<_CHRONO month_weekday_last, _CharT> {};
 
 template <class _CharT>
 struct formatter<_CHRONO year_month, _CharT> //

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -5830,15 +5830,7 @@ namespace chrono {
                 }
             }
 
-            const auto& _List = _Specs._Chrono_specs_list;
-
-            // [time.format]/6
-            if (_List.empty()) {
-                _No_chrono_specs = true;
-                return _Res_iter;
-            }
-
-            for (const auto& _Spec : _List) {
+            for (const auto& _Spec : _Specs._Chrono_specs_list) {
                 if (_Spec._Type != '\0' && !_Is_valid_type<_Ty>(_Spec._Type)) {
                     _THROW(format_error("Invalid type."));
                 }
@@ -5940,8 +5932,8 @@ namespace chrono {
         _NODISCARD auto _Write(_FormatContext& _FormatCtx, const _Ty& _Val, const tm& _Time) {
             basic_ostringstream<_CharT> _Stream;
 
-            if (_No_chrono_specs) {
-                _Stream << _Val;
+            if (_Specs._Chrono_specs_list.empty()) {
+                _Stream << _Val; // N4885 [time.format]/6
             } else {
                 _Stream.imbue(_FormatCtx.locale());
                 if constexpr (_Is_specialization_v<_Ty, hh_mm_ss>) {
@@ -6303,7 +6295,6 @@ namespace chrono {
         }
 
         _Chrono_format_specs<_CharT> _Specs{};
-        bool _No_chrono_specs = false;
         basic_string_view<_CharT> _Time_zone_abbreviation{};
     };
 } // namespace chrono

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -6082,7 +6082,8 @@ namespace chrono {
                 if (_Has_modifier) {
                     return false;
                 }
-                _Os << _STD format(_STATICALLY_WIDEN(_CharT, "{:02}"), _Year < 0 ? 100 + (_Year % 100) : _Year % 100);
+                _Os << _STD format(
+                    _STATICALLY_WIDEN(_CharT, "{:02}"), _Time_parse_fields::_Decompose_year(_Year).second);
                 return true;
             case 'C': // Print the century as a decimal, even if invalid.
                 if (_Has_modifier) {

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -5693,11 +5693,8 @@ struct _Chrono_formatter {
                     continue;
                 }
 
-                if (_Type_needs_bounds_checking(_Spec)) {
-                    if (!_Val.ok()) {
-                        _THROW(format_error("Cannot localize out-of-bounds time point."));
-                    }
-                } else if (_Spec._Modifier == '\0') {
+                // For non-localized writes, we can sometimes avoid calling put_time.
+                if (_Spec._Modifier == '\0') {
                     if (_CHRONO _Try_simple_write(_Stream, _Spec._Type, _Time)) {
                         continue;
                     } else if constexpr (_Is_specialization_v<_Ty, _CHRONO hh_mm_ss>) {
@@ -5706,6 +5703,10 @@ struct _Chrono_formatter {
                             continue;
                         }
                     }
+                }
+                // Otherwise, we should throw to avoid triggering asserts within put_time machinery.
+                if (!_Val.ok()) {
+                    _THROW(format_error("Cannot localize out-of-bounds time point."));
                 }
 
                 _CharT _Fmt_str[4];
@@ -5723,23 +5724,6 @@ struct _Chrono_formatter {
 
         return _Write_aligned(_STD move(_FormatCtx.out()), static_cast<int>(_Stream.view().size()), _Specs,
             _Fmt_align::_Left, [&](auto _Out) { return _Fmt_write(_STD move(_Out), _Stream.view()); });
-    }
-
-    _NODISCARD bool _Type_needs_bounds_checking(const _Chrono_specs<_CharT>& _Spec) noexcept {
-        // [tab:time.format.spec]
-        switch (_Spec._Type) {
-        case 'a':
-        case 'A':
-        case 'b':
-        case 'B':
-        case 'h':
-        case 'z':
-        case 'Z':
-            return true;
-
-        default:
-            return false;
-        }
     }
 
     _Chrono_format_specs<_CharT> _Specs{};

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -5498,10 +5498,10 @@ namespace chrono {
             } else {
                 _Write_fractional_seconds<_Fractional_width>(_Os, _Hms.seconds(), _Hms.subseconds());
             }
-            return;
+        } else {
+            const auto _Dp = _CHRONO floor<days>(_Val);
+            _Write_seconds(_Os, hh_mm_ss{_Val - _Dp});
         }
-        const auto _Dp = _CHRONO floor<days>(_Val);
-        _Write_seconds(_Os, hh_mm_ss{_Val - _Dp});
     }
 
     template <class _CharT, class _Traits, class _Duration>
@@ -5848,7 +5848,7 @@ namespace chrono {
             return _Res_iter;
         }
 
-        void _Check_modifier(const char _Type, const char _Modifier) {
+        static void _Check_modifier(const char _Type, const char _Modifier) {
             if (_Modifier == '\0') {
                 return;
             }
@@ -5894,7 +5894,7 @@ namespace chrono {
         }
 
         template <class _Ty>
-        _NODISCARD constexpr bool _Is_valid_type(const char _Type) noexcept {
+        _NODISCARD static constexpr bool _Is_valid_type(const char _Type) noexcept {
             if constexpr (_Is_specialization_v<_Ty, duration>) {
                 return _Type == 'j' || _Type == 'q' || _Type == 'Q' || _Is_valid_type<hh_mm_ss<seconds>>(_Type);
             } else if constexpr (is_same_v<_Ty, day>) {
@@ -5910,11 +5910,12 @@ namespace chrono {
             } else if constexpr (_Is_any_of_v<_Ty, month_weekday, month_weekday_last>) {
                 return _Is_valid_type<month>(_Type) || _Is_valid_type<weekday>(_Type);
             } else if constexpr (is_same_v<_Ty, year_month>) {
-                return _Is_valid_type<year>(_Type) || _Is_valid_type<month>(_Type);
+                return _Type == 'g' || _Type == 'G' || _Is_valid_type<year>(_Type) || _Is_valid_type<month>(_Type);
             } else if constexpr (_Is_any_of_v<_Ty, year_month_day, year_month_day_last, year_month_weekday,
                                      year_month_weekday_last>) {
-                return _Type == 'D' || _Type == 'F' || _Type == 'j' || _Is_valid_type<year>(_Type)
-                    || _Is_valid_type<month>(_Type) || _Is_valid_type<day>(_Type) || _Is_valid_type<weekday>(_Type);
+                return _Type == 'D' || _Type == 'F' || _Type == 'g' || _Type == 'G' || _Type == 'j' || _Type == 'U'
+                    || _Type == 'V' || _Type == 'W' || _Is_valid_type<year>(_Type) || _Is_valid_type<month>(_Type)
+                    || _Is_valid_type<day>(_Type) || _Is_valid_type<weekday>(_Type);
             } else if constexpr (_Is_specialization_v<_Ty, hh_mm_ss>) {
                 return _Type == 'H' || _Type == 'I' || _Type == 'M' || _Type == 'S' || _Type == 'r' || _Type == 'R'
                     || _Type == 'T' || _Type == 'p';
@@ -6031,19 +6032,32 @@ namespace chrono {
                 }
                 _Os << _Time.tm_mday;
                 return true;
-            case 'r':
-                if constexpr (_Is_specialization_v<_Ty, hh_mm_ss>) {
-                    // put_time uses _Strftime in order to bypass reference-counting that locale uses. This function
-                    // takes the locale information by pointer, but the pointer (from _Gettnames) returns a copy.
-                    // _Strftime delegates to other functions but eventually (for the C locale) has the %r specifier
-                    // rewritten. It checks for the locale by comparing pointers, which do not compare equal as we have
-                    // a copy of the pointer instead of the original. Therefore, we replace %r for the C locale
-                    // ourselves.
-                    if (_Os.getloc() == locale::classic()) {
-                        _Os << _STD put_time(&_Time, _STATICALLY_WIDEN(_CharT, "%I:%M:%S %p"));
-                        return true;
+            case 'g':
+            case 'G':
+                if constexpr (is_same_v<_Ty, year_month>) {
+                    if (_Val.month() == January || _Val.month() == December) {
+                        _THROW(format_error(
+                            "The ISO week-based year for a year_month of January or December is ambiguous."));
                     }
+
+                    const char _Gregorian_type = _Spec._Type == 'g' ? 'y' : 'Y';
+                    _Os << _STD put_time(&_Time, _Fmt_string({._Type = _Gregorian_type}).data());
+                    return true;
                 }
+
+                return false;
+            case 'r':
+                // put_time uses _Strftime in order to bypass reference-counting that locale uses. This function
+                // takes the locale information by pointer, but the pointer (from _Gettnames) returns a copy.
+                // _Strftime delegates to other functions but eventually (for the C locale) has the %r specifier
+                // rewritten. It checks for the locale by comparing pointers, which do not compare equal as we have
+                // a copy of the pointer instead of the original. Therefore, we replace %r for the C locale
+                // ourselves.
+                if (_Os.getloc() == locale::classic()) {
+                    _Os << _STD put_time(&_Time, _STATICALLY_WIDEN(_CharT, "%I:%M:%S %p"));
+                    return true;
+                }
+
                 return false;
             case 'j':
                 if constexpr (_Is_specialization_v<_Ty, duration>) {
@@ -6058,6 +6072,7 @@ namespace chrono {
                         _THROW(format_error("The day of year for a month_day_last other than January is ambiguous"));
                     }
                 }
+
                 if constexpr (_Has_ok<_Ty>) {
                     if (!_Val.ok()) {
                         _THROW(format_error("Cannot print invalid day of year"));
@@ -6187,7 +6202,7 @@ namespace chrono {
             }
         }
 
-        _NODISCARD array<_CharT, 4> _Fmt_string(const _Chrono_spec<_CharT>& _Spec) {
+        _NODISCARD static array<_CharT, 4> _Fmt_string(const _Chrono_spec<_CharT>& _Spec) {
             array<_CharT, 4> _Fmt_str;
             size_t _Next_idx      = 0;
             _Fmt_str[_Next_idx++] = _CharT{'%'};

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -5446,6 +5446,19 @@ _NODISCARD constexpr const _CharT* _Parse_chrono_format_specs(
 }
 
 namespace chrono {
+    template <class _Duration>
+    struct _Local_time_format_t {
+        local_time<_Duration> _Time;
+        const string* _Abbrev      = nullptr;
+        const seconds* _Offset_sec = nullptr;
+    };
+
+    template <class _Duration>
+    _NODISCARD _Local_time_format_t<_Duration> local_time_format(const local_time<_Duration> _Time,
+        const string* const _Abbrev = nullptr, const seconds* const _Offset_sec = nullptr) {
+        return {_Time, _Abbrev, _Offset_sec};
+    }
+
     // Replacement for %S, as put_time does not honor writing fractional seconds.
     template <class _CharT, class _Traits, class _Ty>
     void _Write_seconds(basic_ostream<_CharT, _Traits>&, const _Ty&) {
@@ -5474,6 +5487,11 @@ namespace chrono {
         _Write_seconds(_Os, hh_mm_ss{_Val - _Dp});
     }
 
+    template <class _CharT, class _Traits, class _Duration>
+    void _Write_seconds(basic_ostream<_CharT, _Traits>& _Os, const _Local_time_format_t<_Duration>& _Val) {
+        _Write_seconds(_Os, _Val._Time);
+    }
+
     template <class _CharT, class _Traits, class _Rep, class _Period>
     void _Write_seconds(basic_ostream<_CharT, _Traits>& _Os, const duration<_Rep, _Period>& _Val) {
         const auto _Dp = _CHRONO duration_cast<days>(_Val);
@@ -5493,6 +5511,8 @@ namespace chrono {
         if constexpr (_Is_specialization_v<_Ty, duration>) {
             const auto _Dp = _CHRONO duration_cast<days>(_Val);
             return _Fill_tm(hh_mm_ss{_Val - _Dp});
+        } else if constexpr (_Is_specialization_v<_Ty, _Local_time_format_t>) {
+            return _Fill_tm(_Val._Time);
         } else if constexpr (is_same_v<_Ty, day>) {
             _Day = static_cast<unsigned int>(_Val);
         } else if constexpr (is_same_v<_Ty, month>) {
@@ -5738,6 +5758,21 @@ namespace chrono {
         return _Os << sys_time<_Duration>{_Val.time_since_epoch()};
     }
 
+    template <class _CharT, class _Traits, class _Duration>
+    basic_ostream<_CharT, _Traits>& operator<<(
+        basic_ostream<_CharT, _Traits>& _Os, const _Local_time_format_t<_Duration>& _Val) {
+        // Doesn't appear in the Standard, but allowed by N4885 [global.functions]/2.
+        // Implements N4885 [time.zone.zonedtime.nonmembers]/2 for zoned_time.
+        return _Os << _STD format(_Os.getloc(), _STATICALLY_WIDEN(_CharT, "{:%F %T %Z}"), _Val);
+    }
+
+    template <class _CharT, class _Traits, class _Duration, class _TimeZonePtr>
+    basic_ostream<_CharT, _Traits>& operator<<(
+        basic_ostream<_CharT, _Traits>& _Os, const zoned_time<_Duration, _TimeZonePtr>& _Val) {
+        const auto _Info = _Val.get_info();
+        return _Os << _Local_time_format_t<_Duration>{_Val.get_local_time(), &_Info.abbrev};
+    }
+
     template <class _CharT>
     struct _Chrono_formatter {
         _Chrono_formatter() = default;
@@ -5868,6 +5903,8 @@ namespace chrono {
                 }
                 return _Type == 'c' || _Type == 'x' || _Type == 'X' || _Is_valid_type<year_month_day>(_Type)
                     || _Is_valid_type<hh_mm_ss<seconds>>(_Type);
+            } else if constexpr (_Is_specialization_v<_Ty, _Local_time_format_t>) {
+                return _Type == 'z' || _Type == 'Z' || _Is_valid_type<decltype(_Ty::_Time)>(_Type);
             } else {
                 static_assert(_Always_false<_Ty>, "should be unreachable");
             }
@@ -6051,6 +6088,11 @@ namespace chrono {
                     _Os << _Widen_string<_CharT>(_Val.abbrev);
                 } else if constexpr (is_same_v<_Ty, local_info>) {
                     _Os << _Widen_string<_CharT>(_Val.first.abbrev);
+                } else if constexpr (_Is_specialization_v<_Ty, _Local_time_format_t>) {
+                    if (_Val._Abbrev == nullptr) {
+                        _THROW(format_error("Cannot print local-time-format-t with null abbrev."));
+                    }
+                    _Os << _Widen_string<_CharT>(*_Val._Abbrev);
                 } else {
                     _Os << _Time_zone_abbreviation;
                 }
@@ -6063,6 +6105,11 @@ namespace chrono {
                         _Offset = hh_mm_ss<seconds>{_Val.offset};
                     } else if constexpr (is_same_v<_Ty, local_info>) {
                         _Offset = hh_mm_ss<seconds>{_Val.first.offset};
+                    } else if constexpr (_Is_specialization_v<_Ty, _Local_time_format_t>) {
+                        if (_Val._Offset_sec == nullptr) {
+                            _THROW(format_error("Cannot print local-time-format-t with null offset_sec."));
+                        }
+                        _Offset = hh_mm_ss<seconds>{*_Val._Offset_sec};
                     } else {
                         _Offset = hh_mm_ss<seconds>{};
                     }
@@ -6265,6 +6312,22 @@ private:
 template <class _Duration, class _CharT>
 struct formatter<_CHRONO local_time<_Duration>, _CharT> //
     : _Fill_tm_formatter<_CHRONO local_time<_Duration>, _CharT> {};
+
+template <class _Duration, class _CharT>
+struct formatter<_CHRONO _Local_time_format_t<_Duration>, _CharT>
+    : _Fill_tm_formatter<_CHRONO _Local_time_format_t<_Duration>, _CharT> {};
+
+template <class _Duration, class _TimeZonePtr, class _CharT>
+struct formatter<_CHRONO zoned_time<_Duration, _TimeZonePtr>, _CharT>
+    : formatter<_CHRONO _Local_time_format_t<_Duration>, _CharT> {
+
+    template <class _FormatContext>
+    auto format(const _CHRONO zoned_time<_Duration, _TimeZonePtr>& _Val, _FormatContext& _FormatCtx) {
+        using _Mybase    = formatter<_CHRONO _Local_time_format_t<_Duration>, _CharT>;
+        const auto _Info = _Val.get_info();
+        return _Mybase::format({_Val.get_local_time(), &_Info.abbrev, &_Info.offset}, _FormatCtx);
+    }
+};
 
 namespace chrono {
     template <class _Duration>

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -5899,8 +5899,16 @@ struct _Chrono_formatter {
             _Os << _CharT{'/'};
             _Custom_write(_Os, {._Type = 'y'}, _Time, _Val);
             return true;
+        case 'H':
+            if constexpr (_Is_specialization_v<_Ty, _CHRONO hh_mm_ss>) {
+                if (-_CHRONO hours{24} >= _Val.hours() || _Val.hours() >= _CHRONO hours{24}) {
+                    _THROW(format_error("Cannot localize hh_mm_ss longer than 24 hours."));
+                }
+            }
+            return false;
         case 'T':
             // Alias for %H:%M:%S but we need to rewrite %S to display fractions of a second.
+            _Custom_write(_Os, {._Type = 'H'}, _Time, _Val);
             _Os << _STD put_time(&_Time, _STATICALLY_WIDEN(_CharT, "%H:%M:"));
             [[fallthrough]];
         case 'S':
@@ -5993,24 +6001,8 @@ struct formatter<_CHRONO year_month_weekday_last, _CharT>
     : _Fill_tm_formatter<_CHRONO year_month_weekday_last, _CharT> {};
 
 template <class _Rep, class _Period, class _CharT>
-struct formatter<_CHRONO hh_mm_ss<_CHRONO duration<_Rep, _Period>>, _CharT> {
-    using _Ty = _CHRONO hh_mm_ss<_CHRONO duration<_Rep, _Period>>;
-
-    auto parse(basic_format_parse_context<_CharT>& _Parse_ctx) {
-        return _Impl.template _Parse<_Ty>(_Parse_ctx);
-    }
-
-    template <class _FormatContext>
-    auto format(const _Ty& _Val, _FormatContext& _FormatCtx) {
-        if (-_CHRONO hours{24} >= _Val.hours() || _Val.hours() >= _CHRONO hours{24}) {
-            _THROW(format_error("Cannot localize hh_mm_ss longer than 24 hours."));
-        }
-        return _Impl._Write(_FormatCtx, _Val, _Fill_tm(_Val));
-    }
-
-private:
-    _Chrono_formatter<_CharT, false> _Impl;
-};
+struct formatter<_CHRONO hh_mm_ss<_CHRONO duration<_Rep, _Period>>, _CharT>
+    : _Fill_tm_formatter<_CHRONO hh_mm_ss<_CHRONO duration<_Rep, _Period>>, _CharT> {};
 
 template <class _Duration, class _CharT>
 struct formatter<_CHRONO sys_time<_Duration>, _CharT> {

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -6014,6 +6014,20 @@ namespace chrono {
                 }
                 _Os << _Time.tm_mday;
                 return true;
+            case 'r':
+                if constexpr (_Is_specialization_v<_Ty, hh_mm_ss>) {
+                    // put_time uses _Strftime in order to bypass reference-counting that locale uses. This function
+                    // takes the locale information by pointer, but the pointer (from _Gettnames) returns a copy.
+                    // _Strftime delegates to other functions but eventually (for the C locale) has the %r specifier
+                    // rewritten. It checks for the locale by comparing pointers, which do not compare equal as we have
+                    // a copy of the pointer instead of the original. Therefore, we replace %r for the C locale
+                    // ourselves.
+                    if (_Os.getloc() == locale::classic()) {
+                        _Os << _STD put_time(&_Time, _STATICALLY_WIDEN(_CharT, "%I:%M:%S %p"));
+                        return true;
+                    }
+                }
+                return false;
             case 'j':
                 if constexpr (_Is_specialization_v<_Ty, duration>) {
                     _Os << _STD abs(_CHRONO duration_cast<days>(_Val).count());

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -5501,24 +5501,6 @@ namespace chrono {
     }*/
 
     template <class _Ty>
-    concept _Has_day = requires(const _Ty& _At) {
-        { _At.day() }
-        ->same_as<day>;
-    };
-
-    template <class _Ty>
-    concept _Has_month = requires(const _Ty& _At) {
-        { _At.month() }
-        ->same_as<month>;
-    };
-
-    template <class _Ty>
-    concept _Has_year = requires(const _Ty& _At) {
-        { _At.year() }
-        ->same_as<year>;
-    };
-
-    template <class _Ty>
     tm _Fill_tm(const _Ty& _Val) {
         unsigned int _Day   = 0;
         unsigned int _Month = 0;

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -5613,7 +5613,7 @@ struct _Chrono_formatter {
             return;
         }
 
-        enum _Allowed_bit { _E_mod = 1, _O_mod = 2, _EO_mod = _E_mod | _O_mod };
+        enum _Allowed_bit : uint8_t { _E_mod = 1, _O_mod = 2, _EO_mod = _E_mod | _O_mod };
 
         struct _Table_entry {
             char _Type;
@@ -5621,24 +5621,25 @@ struct _Chrono_formatter {
         };
 
         static constexpr _Table_entry _Table[] = {
-            {'Y', _E_mod},
-            {'y', _EO_mod},
+            {'c', _E_mod},
             {'C', _E_mod},
-            {'m', _O_mod},
-            {'U', _O_mod},
-            {'W', _O_mod},
-            {'V', _O_mod},
             {'d', _O_mod},
             {'e', _O_mod},
-            {'w', _O_mod},
-            {'u', _O_mod},
             {'H', _O_mod},
             {'I', _O_mod},
+            {'m', _O_mod},
             {'M', _O_mod},
             {'S', _O_mod},
-            {'c', _E_mod},
+            {'u', _O_mod},
+            {'U', _O_mod},
+            {'V', _O_mod},
+            {'w', _O_mod},
+            {'W', _O_mod},
             {'x', _E_mod},
             {'X', _E_mod},
+            {'y', _EO_mod},
+            {'Y', _E_mod},
+            {'z', _EO_mod},
         };
 
         const _Allowed_bit _Mod = _Modifier == 'E' ? _E_mod : _O_mod;

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -5537,6 +5537,8 @@ namespace chrono {
             _Hours   = _Val.hours().count();
             _Minutes = _Val.minutes().count();
             _Seconds = static_cast<int>(_Val.seconds().count());
+        } else if constexpr (_Is_any_of_v<_Ty, sys_info, local_info>) {
+            return {}; // none of the valid conversion specifiers need tm fields
         } else if constexpr (_Is_specialization_v<_Ty, time_point>) {
             const auto _Dp = _CHRONO floor<days>(_Val);
             const year_month_day _Ymd{_Dp};
@@ -5653,6 +5655,47 @@ namespace chrono {
     template <class _CharT, class _Traits, class _Duration>
     basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const hh_mm_ss<_Duration>& _Val) {
         return _Os << _STD format(_Os.getloc(), _STATICALLY_WIDEN(_CharT, "{:%T}"), _Val);
+    }
+
+#pragma warning(push)
+#pragma warning(disable : 4365) // 'argument': conversion from 'char' to 'const wchar_t', signed/unsigned mismatch
+    template <class _CharT>
+    _NODISCARD decltype(auto) _Widen_string(const string& _Str) {
+        if constexpr (is_same_v<_CharT, char>) {
+            return _Str;
+        } else {
+            return wstring{_Str.begin(), _Str.end()}; // TRANSITION, should probably use ctype::widen
+        }
+    }
+#pragma warning(pop)
+
+    template <class _CharT, class _Traits>
+    basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const sys_info& _Val) {
+        return _Os << _STD format(_Os.getloc(),
+                   _STATICALLY_WIDEN(_CharT, "begin: {}, end: {}, offset: {}, save: {}, abbrev: {}"), //
+                   _Val.begin, _Val.end, _Val.offset, _Val.save, _Widen_string<_CharT>(_Val.abbrev));
+    }
+
+    template <class _CharT, class _Traits>
+    basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const local_info& _Val) {
+        switch (_Val.result) {
+        case local_info::unique:
+            return _Os << _STD format(_Os.getloc(), //
+                       _STATICALLY_WIDEN(_CharT, "result: unique, first: ({})"), //
+                       _Val.first);
+        case local_info::nonexistent:
+            return _Os << _STD format(_Os.getloc(),
+                       _STATICALLY_WIDEN(_CharT, "result: nonexistent, first: ({}), second: ({})"), //
+                       _Val.first, _Val.second);
+        case local_info::ambiguous:
+            return _Os << _STD format(_Os.getloc(),
+                       _STATICALLY_WIDEN(_CharT, "result: ambiguous, first: ({}), second: ({})"), //
+                       _Val.first, _Val.second);
+        default:
+            return _Os << _STD format(_Os.getloc(), //
+                       _STATICALLY_WIDEN(_CharT, "result: {}, first: ({}), second: ({})"), //
+                       _Val.result, _Val.first, _Val.second);
+        }
     }
 
     template <class _CharT, class _Traits, class _Duration>
@@ -5815,6 +5858,8 @@ namespace chrono {
             } else if constexpr (_Is_specialization_v<_Ty, hh_mm_ss>) {
                 return _Type == 'H' || _Type == 'I' || _Type == 'M' || _Type == 'S' || _Type == 'r' || _Type == 'R'
                     || _Type == 'T' || _Type == 'p';
+            } else if constexpr (_Is_any_of_v<_Ty, sys_info, local_info>) {
+                return _Type == 'z' || _Type == 'Z';
             } else if constexpr (_Is_specialization_v<_Ty, time_point>) {
                 if constexpr (!is_same_v<typename _Ty::clock, local_t>) {
                     if (_Type == 'z' || _Type == 'Z') {
@@ -5889,6 +5934,12 @@ namespace chrono {
         template <class _Ty>
         bool _Custom_write(
             basic_ostream<_CharT>& _Os, const _Chrono_spec<_CharT>& _Spec, const tm& _Time, const _Ty& _Val) {
+            if constexpr (is_same_v<_Ty, local_info>) {
+                if (_Val.result != local_info::unique) {
+                    _THROW(format_error("Cannot print non-unique local_info"));
+                }
+            }
+
             const auto _Year         = _Time.tm_year + 1900;
             const auto _Month        = _Time.tm_mon + 1;
             const bool _Has_modifier = _Spec._Modifier != '\0';
@@ -5996,15 +6047,34 @@ namespace chrono {
                 _Write_seconds(_Os, _Val);
                 return true;
             case 'Z':
-                _Os << _Time_zone_abbreviation;
+                if constexpr (is_same_v<_Ty, sys_info>) {
+                    _Os << _Widen_string<_CharT>(_Val.abbrev);
+                } else if constexpr (is_same_v<_Ty, local_info>) {
+                    _Os << _Widen_string<_CharT>(_Val.first.abbrev);
+                } else {
+                    _Os << _Time_zone_abbreviation;
+                }
                 return true;
             case 'z':
-                _Os << _STATICALLY_WIDEN(_CharT, "+00");
-                if (_Has_modifier) {
-                    _Os << _CharT{':'};
+                {
+                    hh_mm_ss<seconds> _Offset;
+
+                    if constexpr (is_same_v<_Ty, sys_info>) {
+                        _Offset = hh_mm_ss<seconds>{_Val.offset};
+                    } else if constexpr (is_same_v<_Ty, local_info>) {
+                        _Offset = hh_mm_ss<seconds>{_Val.first.offset};
+                    } else {
+                        _Offset = hh_mm_ss<seconds>{};
+                    }
+
+                    const auto _Sign = _Offset.is_negative() ? _CharT{'-'} : _CharT{'+'};
+                    const auto _Separator =
+                        _Has_modifier ? _STATICALLY_WIDEN(_CharT, ":") : _STATICALLY_WIDEN(_CharT, "");
+
+                    _Os << _STD format(_STATICALLY_WIDEN(_CharT, "{}{:02}{}{:02}"), _Sign, _Offset.hours().count(),
+                        _Separator, _Offset.minutes().count());
+                    return true;
                 }
-                _Os << _STATICALLY_WIDEN(_CharT, "00");
-                return true;
             default:
                 return false;
             }
@@ -6098,6 +6168,14 @@ struct formatter<_CHRONO year_month_weekday_last, _CharT>
 template <class _Rep, class _Period, class _CharT>
 struct formatter<_CHRONO hh_mm_ss<_CHRONO duration<_Rep, _Period>>, _CharT>
     : _Fill_tm_formatter<_CHRONO hh_mm_ss<_CHRONO duration<_Rep, _Period>>, _CharT> {};
+
+template <class _CharT>
+struct formatter<_CHRONO sys_info, _CharT> //
+    : _Fill_tm_formatter<_CHRONO sys_info, _CharT> {};
+
+template <class _CharT>
+struct formatter<_CHRONO local_info, _CharT> //
+    : _Fill_tm_formatter<_CHRONO local_info, _CharT> {};
 
 template <class _Duration, class _CharT>
 struct formatter<_CHRONO sys_time<_Duration>, _CharT> {

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -5521,6 +5521,14 @@ namespace chrono {
             _Month = static_cast<unsigned int>(_Val);
         } else if constexpr (is_same_v<_Ty, year>) {
             _Year = static_cast<int>(_Val);
+        } else if constexpr (is_same_v<_Ty, month_day>) {
+            _Day   = static_cast<unsigned int>(_Val.day());
+            _Month = static_cast<unsigned int>(_Val.month());
+        } else if constexpr (is_same_v<_Ty, month_day_last>) {
+            _Month = static_cast<unsigned int>(_Val.month());
+        } else if constexpr (is_same_v<_Ty, year_month>) {
+            _Month = static_cast<unsigned int>(_Val.month());
+            _Year  = static_cast<int>(_Val.year());
         } else if constexpr (is_same_v<_Ty, year_month_day>) {
             _Day     = static_cast<unsigned int>(_Val.day());
             _Month   = static_cast<unsigned int>(_Val.month());
@@ -5738,12 +5746,16 @@ struct _Chrono_formatter {
     _NODISCARD constexpr bool _Is_valid_type(const char _Type) noexcept {
         if constexpr (is_same_v<_Ty, _CHRONO day>) {
             return _Type == 'd' || _Type == 'e';
-        } else if constexpr (is_same_v<_Ty, _CHRONO month>) {
+        } else if constexpr (_Is_any_of_v<_Ty, _CHRONO month, _CHRONO month_day_last>) {
             return _Type == 'b' || _Type == 'B' || _Type == 'h' || _Type == 'm';
         } else if constexpr (is_same_v<_Ty, _CHRONO year>) {
             return _Type == 'Y' || _Type == 'y' || _Type == 'C';
         } else if constexpr (is_same_v<_Ty, _CHRONO weekday>) {
             return _Type == 'a' || _Type == 'A' || _Type == 'u' || _Type == 'w';
+        } else if constexpr (is_same_v<_Ty, _CHRONO month_day>) {
+            return _Is_valid_type<_CHRONO month>(_Type) || _Is_valid_type<_CHRONO day>(_Type);
+        } else if constexpr (is_same_v<_Ty, _CHRONO year_month>) {
+            return _Is_valid_type<_CHRONO year>(_Type) || _Is_valid_type<_CHRONO month>(_Type);
         } else if constexpr (_Is_any_of_v<_Ty, _CHRONO year_month_day, _CHRONO year_month_day_last,
                                  _CHRONO year_month_weekday, _CHRONO year_month_weekday_last>) {
             return _Type == 'D' || _Type == 'F' || _Is_valid_type<_CHRONO year>(_Type)
@@ -5836,6 +5848,18 @@ struct formatter<_CHRONO month, _CharT> //
 template <class _CharT>
 struct formatter<_CHRONO year, _CharT> //
     : _Fill_tm_formatter<_CHRONO year, _CharT> {};
+
+template <class _CharT>
+struct formatter<_CHRONO month_day, _CharT> //
+    : _Fill_tm_formatter<_CHRONO month_day, _CharT> {};
+
+template <class _CharT>
+struct formatter<_CHRONO month_day_last, _CharT> //
+    : _Fill_tm_formatter<_CHRONO month_day_last, _CharT> {};
+
+template <class _CharT>
+struct formatter<_CHRONO year_month, _CharT> //
+    : _Fill_tm_formatter<_CHRONO year_month, _CharT> {};
 
 template <class _CharT>
 struct formatter<_CHRONO year_month_day, _CharT> //

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -5223,6 +5223,13 @@ concept _Chrono_parse_spec_callbacks = _Parse_align_callbacks<_Ty, _CharT>
 };
 // clang-format on
 
+// clang-format off
+template <class _Ty>
+concept _Has_ok = requires (_Ty _At) {
+    {_At.ok()} -> same_as<bool>;
+};
+// clang-format on
+
 // A chrono spec is either a type (with an optional modifier), OR a literal character, never both.
 template <class _CharT>
 struct _Chrono_specs {
@@ -5413,11 +5420,33 @@ _NODISCARD constexpr const _CharT* _Parse_chrono_format_specs(
 }
 
 namespace chrono {
+    // Replacement for %S, as put_time does not honor writing fractional seconds.
+    template <class _CharT, class _Traits, class _Ty>
+    void _Write_seconds(basic_ostream<_CharT, _Traits>&, const _Ty&) {
+        _STL_INTERNAL_CHECK(false);
+    }
+
+    template <class _CharT, class _Traits, class _Duration>
+    void _Write_seconds(basic_ostream<_CharT, _Traits>& _Os, const hh_mm_ss<_Duration>& _Val) {
+        _Os << _STD format(_STATICALLY_WIDEN(_CharT, "{:02}"), _Val.seconds().count());
+        if constexpr (hh_mm_ss<_Duration>::fractional_width > 0) {
+            _Os << _STD format(_STATICALLY_WIDEN(_CharT, "{0}{1:0{2}}"),
+                _STD use_facet<numpunct<_CharT>>(_Os.getloc()).decimal_point(), _Val.subseconds().count(),
+                _Val.fractional_width);
+        }
+    }
+
+    template <class _CharT, class _Traits, class _Clock, class _Duration>
+    void _Write_seconds(basic_ostream<_CharT, _Traits>& _Os, const time_point<_Clock, _Duration>& _Val) {
+        const auto _Dp = _CHRONO floor<days>(_Val);
+        _Write_seconds(_Os, hh_mm_ss{_Val - _Dp});
+    }
+
     // This echoes the functionality of put_time, but is able to handle invalid dates (when !ok()) since the Standard
     // mandates that invalid dates still be formatted properly.  For example, put_time isn't able to handle a tm_mday of
     // 40, but format("{:%d}", day{40}) should return "40" and operator<< for day prints "40 is not a valid day".
-    template <class _CharT>
-    bool _Try_simple_write(basic_ostream<_CharT>& _Os, const char _Type, const tm& _Time) {
+    template <class _CharT, class _Ty>
+    bool _Try_simple_write(basic_ostream<_CharT>& _Os, const char _Type, const tm& _Time, const _Ty& _Val) {
         const auto _Year  = _Time.tm_year + 1900;
         const auto _Month = _Time.tm_mon + 1;
         switch (_Type) {
@@ -5451,54 +5480,30 @@ namespace chrono {
                 _STATICALLY_WIDEN(_CharT, "{:02}"), _STD abs(_Time_parse_fields::_Decompose_year(_Year).first) / 100);
             return true;
         case 'F':
-            _Try_simple_write(_Os, 'Y', _Time);
+            _Try_simple_write(_Os, 'Y', _Time, _Val);
             _Os << _CharT{'-'};
-            _Try_simple_write(_Os, 'm', _Time);
+            _Try_simple_write(_Os, 'm', _Time, _Val);
             _Os << _CharT{'-'};
-            _Try_simple_write(_Os, 'd', _Time);
+            _Try_simple_write(_Os, 'd', _Time, _Val);
             return true;
         case 'D':
-            _Try_simple_write(_Os, 'm', _Time);
+            _Try_simple_write(_Os, 'm', _Time, _Val);
             _Os << _CharT{'/'};
-            _Try_simple_write(_Os, 'd', _Time);
+            _Try_simple_write(_Os, 'd', _Time, _Val);
             _Os << _CharT{'/'};
-            _Try_simple_write(_Os, 'y', _Time);
+            _Try_simple_write(_Os, 'y', _Time, _Val);
+            return true;
+        case 'T':
+            // Alias for %H:%M:%S but we need to rewrite %S to display fractions of a second.
+            _Os << _STD put_time(&_Time, _STATICALLY_WIDEN(_CharT, "%H:%M:"));
+            [[fallthrough]];
+        case 'S':
+            _Write_seconds(_Os, _Val);
             return true;
         default:
             return false;
         }
     }
-
-    template <class _CharT, class _Traits, class _Duration>
-    void _Write_seconds(basic_ostream<_CharT, _Traits>& _Os, const hh_mm_ss<_Duration>& _Val) {
-        _Os << _STD format(_STATICALLY_WIDEN(_CharT, "{:02}"), _Val.seconds().count());
-        if constexpr (hh_mm_ss<_Duration>::fractional_width > 0) {
-            _Os << _STD format(_STATICALLY_WIDEN(_CharT, "{0}{1:0{2}}"),
-                _STD use_facet<numpunct<_CharT>>(_Os.getloc()).decimal_point(), _Val.subseconds().count(),
-                _Val.fractional_width);
-        }
-    }
-
-    /*
-    template <class _CharT, class _Traits, class _Duration>
-    // clang-format off
-        requires (!treat_as_floating_point_v<typename _Duration::rep> && (_Duration{1} < days{1}))
-    basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const sys_time<_Duration>& _Clock) {
-        // clang-format on
-        const auto _Dp = floor<days>(_Clock);
-        return _Os << year_month_day{_Dp} << _STATICALLY_WIDEN(_CharT, " ") << hh_mm_ss{_Clock - _Dp};
-    }
-
-    template <class _CharT, class _Traits>
-    basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const sys_days& _Clock) {
-        return _Os << year_month_day{_Clock};
-    }
-
-    template <class _CharT, class _Traits, class _Duration>
-    basic_ostream<_CharT, _Traits>& operator<<(
-        basic_ostream<_CharT, _Traits>& _Os, const utc_clock<_Duration>& _Clock) {
-        return _Os << format(_STATICALLY_WIDEN(_CharT, "{:%F %T}"), _Clock);
-    }*/
 
     template <class _Ty>
     _NODISCARD tm _Fill_tm(const _Ty& _Val) {
@@ -5649,23 +5654,6 @@ namespace chrono {
     }
 } // namespace chrono
 
-/*
-template <class _Duration, class _CharT>
-struct formatter<_CHRONO sys_time<_Duration>, _CharT> {
-    typename basic_format_parse_context<_CharT>::iterator parse(basic_format_parse_context<_CharT>& _Parse_ctx) {
-        _Chrono_format_specs<_CharT> _Specs{};
-        _Chrono_specs_setter<_CharT, basic_format_parse_context<_CharT>> _Callback{_Specs, _Parse_ctx};
-        const auto _It =
-            _Parse_chrono_format_specs(_Parse_ctx._Unchecked_begin(), _Parse_ctx._Unchecked_end(), _Callback);
-        const auto _Res_iter = _Parse_ctx.begin() + (_It - _Parse_ctx._Unchecked_begin());
-
-        if (_It != _Parse_ctx._Unchecked_end() && *_It != '}') {
-            _THROW(format_error("Missing '}' in format string."));
-        }
-    }
-};
-*/
-
 template <class _CharT, bool _Allow_precision>
 struct _Chrono_formatter {
     template <class _Ty>
@@ -5761,6 +5749,9 @@ struct _Chrono_formatter {
             return _Type == 'D' || _Type == 'F' || _Is_valid_type<_CHRONO year>(_Type)
                 || _Is_valid_type<_CHRONO month>(_Type) || _Is_valid_type<_CHRONO day>(_Type)
                 || _Is_valid_type<_CHRONO weekday>(_Type);
+        } else if constexpr (_Is_specialization_v<_Ty, _CHRONO hh_mm_ss>) {
+            return _Type == 'H' || _Type == 'I' || _Type == 'M' || _Type == 'S' || _Type == 'r' || _Type == 'R'
+                || _Type == 'T' || _Type == 'p';
         } else {
             // TRANSITION, remove when all types are added
             static_assert(_Always_false<_Ty>, "unsupported type");
@@ -5788,19 +5779,14 @@ struct _Chrono_formatter {
                 }
 
                 // For non-localized writes, we can sometimes avoid calling put_time.
-                if (_Spec._Modifier == '\0') {
-                    if (_CHRONO _Try_simple_write(_Stream, _Spec._Type, _Time)) {
-                        continue;
-                    } else if constexpr (_Is_specialization_v<_Ty, _CHRONO hh_mm_ss>) {
-                        if (_Spec._Type == 'S') {
-                            _CHRONO _Write_seconds(_Stream, _Val);
-                            continue;
-                        }
-                    }
+                if (_Spec._Modifier == '\0' && _CHRONO _Try_simple_write(_Stream, _Spec._Type, _Time, _Val)) {
+                    continue;
                 }
                 // Otherwise, we should throw to avoid triggering asserts within put_time machinery.
-                if (!_Val.ok()) {
-                    _THROW(format_error("Cannot localize out-of-bounds time point."));
+                if constexpr (_Has_ok<_Ty>) {
+                    if (!_Val.ok()) {
+                        _THROW(format_error("Cannot localize out-of-bounds time point."));
+                    }
                 }
 
                 _CharT _Fmt_str[4];
@@ -5866,6 +5852,27 @@ struct formatter<_CHRONO year_month_weekday, _CharT> //
 template <class _CharT>
 struct formatter<_CHRONO year_month_weekday_last, _CharT>
     : _Fill_tm_formatter<_CHRONO year_month_weekday_last, _CharT> {};
+
+template <class _Rep, class _Period, class _CharT>
+struct formatter<_CHRONO hh_mm_ss<_CHRONO duration<_Rep, _Period>>, _CharT> {
+    using _Ty = _CHRONO hh_mm_ss<_CHRONO duration<_Rep, _Period>>;
+
+    auto parse(basic_format_parse_context<_CharT>& _Parse_ctx) {
+        return _Impl.template _Parse<_Ty>(_Parse_ctx);
+    }
+
+    template <class _FormatContext>
+    auto format(const _Ty& _Val, _FormatContext& _FormatCtx) {
+        if (-_CHRONO hours{24} >= _Val.hours() || _Val.hours() >= _CHRONO hours{24}) {
+            _THROW(format_error("Cannot localize hh_mm_ss longer than 24 hours."));
+        }
+        return _Impl._Write(_FormatCtx, _Val, _Fill_tm(_Val));
+    }
+
+private:
+    _Chrono_formatter<_CharT, false> _Impl;
+};
+
 
 #endif // __cpp_lib_concepts
 #endif // _HAS_CXX20

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -5210,7 +5210,7 @@ concept _Chrono_parse_spec_callbacks = _Parse_align_callbacks<_Ty, _CharT>
                                         && _Width_adapter_callbacks<_Ty, _CharT>
                                         && _Precision_adapter_callbacks<_Ty, _CharT>
                                         && requires(_Ty _At, basic_string_view<_CharT> _Sv, _Fmt_align _Aln) {
-    { _At._On_conversion_spec(_CharT{}, _CharT{}) } -> same_as<void>;
+    { _At._On_conversion_spec(char{}, _CharT{}) } -> same_as<void>;
     { _At._On_lit_char(_CharT{}) } -> same_as<void>;
 };
 // clang-format on
@@ -5219,8 +5219,8 @@ concept _Chrono_parse_spec_callbacks = _Parse_align_callbacks<_Ty, _CharT>
 template <class _CharT>
 struct _Chrono_specs {
     _CharT _Lit_char = _CharT{'\0'}; // any character other than '{', '}', or '%'
-    _CharT _Modifier = _CharT{'\0'}; // either 'E' or 'O'
-    _CharT _Type     = _CharT{'\0'};
+    char _Modifier   = '\0'; // either 'E' or 'O'
+    char _Type       = '\0';
 };
 
 template <class _CharT>
@@ -5286,7 +5286,7 @@ public:
         _Specs._Dynamic_precision_index = _Verify_dynamic_arg_index_in_range(_Parse_ctx.next_arg_id());
     }
 
-    constexpr void _On_conversion_spec(_CharT _Modifier, _CharT _Type) {
+    constexpr void _On_conversion_spec(char _Modifier, _CharT _Type) {
         // NOTE: same performance note from _Basic_format_specs also applies here
         if (_Modifier != '\0' && _Modifier != 'E' && _Modifier != 'O') {
             _THROW(format_error("Invalid modifier specification."));
@@ -5296,7 +5296,7 @@ public:
             _THROW(format_error("Invalid type specification."));
         }
 
-        _Chrono_specs<_CharT> _Conv_spec{._Modifier = _Modifier, ._Type = _Type};
+        _Chrono_specs<_CharT> _Conv_spec{._Modifier = _Modifier, ._Type = static_cast<char>(_Type)};
         _Specs._Chrono_specs_list.push_back(_Conv_spec);
     }
 
@@ -5328,11 +5328,11 @@ _NODISCARD constexpr const _CharT* _Parse_conversion_specs(
         _THROW(format_error("Invalid format string."));
     }
 
-    _CharT _Mod = '\0';
-    _CharT _Ch  = *_Begin;
+    char _Mod  = '\0';
+    _CharT _Ch = *_Begin;
 
     if (_Ch == 'E' || _Ch == 'O') { // includes modifier
-        _Mod = _Ch;
+        _Mod = static_cast<char>(_Ch);
         ++_Begin;
         if (_Begin == _End || *_Begin == '}') {
             _THROW(format_error("Invalid format string - missing type after modifier."));
@@ -5449,10 +5449,6 @@ namespace chrono {
             const tm _Time = {.tm_mon = static_cast<int>(static_cast<unsigned int>(_Val)) - 1};
             return _Os << _STD put_time(&_Time, _STATICALLY_WIDEN(_CharT, "%b"));
         }
-
-        if (static_cast<unsigned int>(_Val) < 10) {
-            _Os << _CharT{'0'};
-        }
         return _Os << static_cast<unsigned int>(_Val) << _STATICALLY_WIDEN(_CharT, " is not a valid month");
     }
 } // namespace chrono
@@ -5476,8 +5472,7 @@ struct formatter<_CHRONO sys_time<_Duration>, _CharT> {
 
 template <class _CharT, bool _Allow_precision>
 struct _Chrono_formatter {
-    typename basic_format_parse_context<_CharT>::iterator _Parse(
-        basic_format_parse_context<_CharT>& _Parse_ctx, string_view _Valid_types) {
+    auto _Parse(basic_format_parse_context<_CharT>& _Parse_ctx, string_view _Valid_types) {
         _Chrono_specs_setter<_CharT, basic_format_parse_context<_CharT>> _Callback{_Specs, _Parse_ctx};
         const auto _It =
             _Parse_chrono_format_specs(_Parse_ctx._Unchecked_begin(), _Parse_ctx._Unchecked_end(), _Callback);
@@ -5509,8 +5504,8 @@ struct _Chrono_formatter {
         return _Res_iter;
     }
 
-    void _Check_modifier(const _CharT _Type, const _CharT _Modifier) {
-        if (_Modifier == _CharT{'\0'}) {
+    void _Check_modifier(const char _Type, const char _Modifier) {
+        if (_Modifier == '\0') {
             return;
         }
 
@@ -5521,11 +5516,11 @@ struct _Chrono_formatter {
             _Allowed_bit _Allowed;
         };
 
-        const _Allowed_bit _Mod = _Modifier == _CharT{'E'} ? _E_mod : _O_mod;
-
         static const _Table_entry _Table[] = {{'d', _O_mod}, {'e', _O_mod}, {'m', _O_mod}};
 
-        if (auto _It = _RANGES find(_Table, static_cast<char>(_Type), &_Table_entry::_Type); _It != _STD end(_Table)) {
+        const _Allowed_bit _Mod = _Modifier == 'E' ? _E_mod : _O_mod;
+
+        if (auto _It = _RANGES find(_Table, _Type, &_Table_entry::_Type); _It != _STD end(_Table)) {
             if (_It->_Allowed & _Mod) {
                 return;
             }
@@ -5535,7 +5530,7 @@ struct _Chrono_formatter {
     }
 
     template <class _FormatContext, class _Ty>
-    typename _FormatContext::iterator _Write(_FormatContext& _FormatCtx, const _Ty& _Val, const tm& _Time) {
+    auto _Write(_FormatContext& _FormatCtx, const _Ty& _Val, const tm& _Time) {
         basic_stringstream<_CharT> _Stream;
 
         if (_No_chrono_specs) {
@@ -5557,10 +5552,10 @@ struct _Chrono_formatter {
                 _CharT _Fmt_str[4];
                 size_t _Next_idx      = 0;
                 _Fmt_str[_Next_idx++] = _CharT{'%'};
-                if (_Spec._Modifier != _CharT{'\0'}) {
-                    _Fmt_str[_Next_idx++] = _Spec._Modifier;
+                if (_Spec._Modifier != '\0') {
+                    _Fmt_str[_Next_idx++] = static_cast<_CharT>(_Spec._Modifier);
                 }
-                _Fmt_str[_Next_idx++] = _Spec._Type;
+                _Fmt_str[_Next_idx++] = static_cast<_CharT>(_Spec._Type);
                 _Fmt_str[_Next_idx]   = _CharT{'\0'};
 
                 _Stream << _STD put_time<_CharT>(&_Time, _Fmt_str);

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -5254,7 +5254,7 @@ concept _Has_ok = requires(_Ty _At) {
 
 // A chrono spec is either a type (with an optional modifier), OR a literal character, never both.
 template <class _CharT>
-struct _Chrono_specs {
+struct _Chrono_spec {
     _CharT _Lit_char = _CharT{'\0'}; // any character other than '{', '}', or '%'
     char _Modifier   = '\0'; // either 'E' or 'O'
     char _Type       = '\0';
@@ -5270,8 +5270,8 @@ struct _Chrono_format_specs {
     uint8_t _Fill_length         = 1;
     // At most one codepoint (so one char32_t or four utf-8 char8_t)
     _CharT _Fill[4 / sizeof(_CharT)] = {_CharT{' '}};
-    // recursive definition in grammar, so could have any number of these with literal chars
-    vector<_Chrono_specs<_CharT>> _Chrono_specs_list;
+    // recursive definition in grammar, so could have any number of these
+    vector<_Chrono_spec<_CharT>> _Chrono_specs_list;
 };
 
 // Model of _Chrono_parse_spec_callbacks that fills a _Chrono_format_specs with the parsed data
@@ -5333,12 +5333,12 @@ public:
             _THROW(format_error("Invalid type specification."));
         }
 
-        _Chrono_specs<_CharT> _Conv_spec{._Modifier = _Modifier, ._Type = static_cast<char>(_Type)};
+        _Chrono_spec<_CharT> _Conv_spec{._Modifier = _Modifier, ._Type = static_cast<char>(_Type)};
         _Specs._Chrono_specs_list.push_back(_Conv_spec);
     }
 
     constexpr void _On_lit_char(_CharT _Lit_ch) {
-        _Chrono_specs<_CharT> _Lit_char_spec{._Lit_char = _Lit_ch};
+        _Chrono_spec<_CharT> _Lit_char_spec{._Lit_char = _Lit_ch};
         _Specs._Chrono_specs_list.push_back(_Lit_char_spec);
     }
 
@@ -5681,305 +5681,306 @@ namespace chrono {
     basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const local_time<_Duration>& _Val) {
         return _Os << sys_time<_Duration>{_Val.time_since_epoch()};
     }
-} // namespace chrono
 
-template <class _CharT>
-struct _Chrono_formatter {
-    _Chrono_formatter() = default;
+    template <class _CharT>
+    struct _Chrono_formatter {
+        _Chrono_formatter() = default;
 
-    explicit _Chrono_formatter(const basic_string_view<_CharT> _Time_zone_abbreviation_)
-        : _Time_zone_abbreviation{_Time_zone_abbreviation_} {}
+        explicit _Chrono_formatter(const basic_string_view<_CharT> _Time_zone_abbreviation_)
+            : _Time_zone_abbreviation{_Time_zone_abbreviation_} {}
 
-    template <class _Ty>
-    _NODISCARD auto _Parse(basic_format_parse_context<_CharT>& _Parse_ctx) {
-        _Chrono_specs_setter<_CharT, basic_format_parse_context<_CharT>> _Callback{_Specs, _Parse_ctx};
-        const auto _It =
-            _Parse_chrono_format_specs(_Parse_ctx._Unchecked_begin(), _Parse_ctx._Unchecked_end(), _Callback);
-        const auto _Res_iter = _Parse_ctx.begin() + (_It - _Parse_ctx._Unchecked_begin());
+        template <class _Ty>
+        _NODISCARD auto _Parse(basic_format_parse_context<_CharT>& _Parse_ctx) {
+            _Chrono_specs_setter<_CharT, basic_format_parse_context<_CharT>> _Callback{_Specs, _Parse_ctx};
+            const auto _It =
+                _Parse_chrono_format_specs(_Parse_ctx._Unchecked_begin(), _Parse_ctx._Unchecked_end(), _Callback);
+            const auto _Res_iter = _Parse_ctx.begin() + (_It - _Parse_ctx._Unchecked_begin());
 
-        if (_It != _Parse_ctx._Unchecked_end() && *_It != '}') {
-            _THROW(format_error("Missing '}' in format string."));
-        }
+            if (_It != _Parse_ctx._Unchecked_end() && *_It != '}') {
+                _THROW(format_error("Missing '}' in format string."));
+            }
 
-        if constexpr (_Is_specialization_v<_Ty, _CHRONO duration>) {
-            if constexpr (!_CHRONO treat_as_floating_point_v<typename _Ty::rep>) {
+            if constexpr (_Is_specialization_v<_Ty, duration>) {
+                if constexpr (!treat_as_floating_point_v<typename _Ty::rep>) {
+                    if (_Specs._Precision != -1) {
+                        _THROW(format_error("Precision specification invalid for chrono::duration type with "
+                                            "integral representation type, see N4885 [time.format]/1."));
+                    }
+                }
+            } else {
                 if (_Specs._Precision != -1) {
-                    _THROW(format_error("Precision specification invalid for chrono::duration type with "
-                                        "integral representation type, see N4885 [time.format]/1."));
+                    _THROW(format_error("Precision specification invalid for non-chrono::duration type, "
+                                        "see N4885 [time.format]/1."));
                 }
             }
-        } else {
-            if (_Specs._Precision != -1) {
-                _THROW(format_error("Precision specification invalid for non-chrono::duration type, "
-                                    "see N4885 [time.format]/1."));
+
+            const auto& _List = _Specs._Chrono_specs_list;
+
+            // [time.format]/6
+            if (_List.empty()) {
+                _No_chrono_specs = true;
+                return _Res_iter;
             }
-        }
 
-        const auto& _List = _Specs._Chrono_specs_list;
+            for (const auto& _Spec : _List) {
+                if (_Spec._Type != '\0' && !_Is_valid_type<_Ty>(_Spec._Type)) {
+                    _THROW(format_error("Invalid type."));
+                }
+                _Check_modifier(_Spec._Type, _Spec._Modifier);
+            }
 
-        // [time.format]/6
-        if (_List.empty()) {
-            _No_chrono_specs = true;
             return _Res_iter;
         }
 
-        for (const auto& _Spec : _List) {
-            if (_Spec._Type != '\0' && !_Is_valid_type<_Ty>(_Spec._Type)) {
-                _THROW(format_error("Invalid type."));
-            }
-            _Check_modifier(_Spec._Type, _Spec._Modifier);
-        }
-
-        return _Res_iter;
-    }
-
-    void _Check_modifier(const char _Type, const char _Modifier) {
-        if (_Modifier == '\0') {
-            return;
-        }
-
-        enum _Allowed_bit : uint8_t { _E_mod = 1, _O_mod = 2, _EO_mod = _E_mod | _O_mod };
-
-        struct _Table_entry {
-            char _Type;
-            _Allowed_bit _Allowed;
-        };
-
-        static constexpr _Table_entry _Table[] = {
-            {'c', _E_mod},
-            {'C', _E_mod},
-            {'d', _O_mod},
-            {'e', _O_mod},
-            {'H', _O_mod},
-            {'I', _O_mod},
-            {'m', _O_mod},
-            {'M', _O_mod},
-            {'S', _O_mod},
-            {'u', _O_mod},
-            {'U', _O_mod},
-            {'V', _O_mod},
-            {'w', _O_mod},
-            {'W', _O_mod},
-            {'x', _E_mod},
-            {'X', _E_mod},
-            {'y', _EO_mod},
-            {'Y', _E_mod},
-            {'z', _EO_mod},
-        };
-
-        const _Allowed_bit _Mod = _Modifier == 'E' ? _E_mod : _O_mod;
-
-        if (auto _It = _RANGES find(_Table, _Type, &_Table_entry::_Type); _It != _STD end(_Table)) {
-            if (_It->_Allowed & _Mod) {
+        void _Check_modifier(const char _Type, const char _Modifier) {
+            if (_Modifier == '\0') {
                 return;
             }
-        }
 
-        _THROW(format_error("Incompatible modifier for type"));
-    }
+            enum _Allowed_bit : uint8_t { _E_mod = 1, _O_mod = 2, _EO_mod = _E_mod | _O_mod };
 
-    template <class _Ty>
-    _NODISCARD constexpr bool _Is_valid_type(const char _Type) noexcept {
-        if constexpr (is_same_v<_Ty, _CHRONO day>) {
-            return _Type == 'd' || _Type == 'e';
-        } else if constexpr (is_same_v<_Ty, _CHRONO month>) {
-            return _Type == 'b' || _Type == 'B' || _Type == 'h' || _Type == 'm';
-        } else if constexpr (is_same_v<_Ty, _CHRONO year>) {
-            return _Type == 'Y' || _Type == 'y' || _Type == 'C';
-        } else if constexpr (_Is_any_of_v<_Ty, _CHRONO weekday, _CHRONO weekday_indexed, _CHRONO weekday_last>) {
-            return _Type == 'a' || _Type == 'A' || _Type == 'u' || _Type == 'w';
-        } else if constexpr (_Is_any_of_v<_Ty, _CHRONO month_day, _CHRONO month_day_last>) {
-            return _Is_valid_type<_CHRONO month>(_Type) || _Is_valid_type<_CHRONO day>(_Type);
-        } else if constexpr (_Is_any_of_v<_Ty, _CHRONO month_weekday, _CHRONO month_weekday_last>) {
-            return _Is_valid_type<_CHRONO month>(_Type) || _Is_valid_type<_CHRONO weekday>(_Type);
-        } else if constexpr (is_same_v<_Ty, _CHRONO year_month>) {
-            return _Is_valid_type<_CHRONO year>(_Type) || _Is_valid_type<_CHRONO month>(_Type);
-        } else if constexpr (_Is_any_of_v<_Ty, _CHRONO year_month_day, _CHRONO year_month_day_last,
-                                 _CHRONO year_month_weekday, _CHRONO year_month_weekday_last>) {
-            return _Type == 'D' || _Type == 'F' || _Is_valid_type<_CHRONO year>(_Type)
-                || _Is_valid_type<_CHRONO month>(_Type) || _Is_valid_type<_CHRONO day>(_Type)
-                || _Is_valid_type<_CHRONO weekday>(_Type);
-        } else if constexpr (_Is_specialization_v<_Ty, _CHRONO hh_mm_ss>) {
-            return _Type == 'H' || _Type == 'I' || _Type == 'M' || _Type == 'S' || _Type == 'r' || _Type == 'R'
-                || _Type == 'T' || _Type == 'p';
-        } else if constexpr (_Is_specialization_v<_Ty, _CHRONO time_point>) {
-            if constexpr (!is_same_v<typename _Ty::clock, _CHRONO local_t>) {
-                if (_Type == 'z' || _Type == 'Z') {
-                    return true;
-                }
-            }
-            return _Type == 'c' || _Type == 'x' || _Type == 'X' || _Is_valid_type<_CHRONO year_month_day>(_Type)
-                || _Is_valid_type<_CHRONO hh_mm_ss<_CHRONO seconds>>(_Type);
-        } else {
-            static_assert(_Always_false<_Ty>, "should be unreachable");
-        }
-    }
+            struct _Table_entry {
+                char _Type;
+                _Allowed_bit _Allowed;
+            };
 
-    template <class _FormatContext, class _Ty>
-    _NODISCARD auto _Write(_FormatContext& _FormatCtx, const _Ty& _Val, const tm& _Time) {
-        basic_ostringstream<_CharT> _Stream;
+            static constexpr _Table_entry _Table[] = {
+                {'c', _E_mod},
+                {'C', _E_mod},
+                {'d', _O_mod},
+                {'e', _O_mod},
+                {'H', _O_mod},
+                {'I', _O_mod},
+                {'m', _O_mod},
+                {'M', _O_mod},
+                {'S', _O_mod},
+                {'u', _O_mod},
+                {'U', _O_mod},
+                {'V', _O_mod},
+                {'w', _O_mod},
+                {'W', _O_mod},
+                {'x', _E_mod},
+                {'X', _E_mod},
+                {'y', _EO_mod},
+                {'Y', _E_mod},
+                {'z', _EO_mod},
+            };
 
-        if (_No_chrono_specs) {
-            _Stream << _Val;
-        } else {
-            _Stream.imbue(_FormatCtx.locale());
-            if constexpr (_Is_specialization_v<_Ty, _CHRONO hh_mm_ss>) {
-                if (_Val.is_negative()) {
-                    _Stream << _CharT{'-'};
+            const _Allowed_bit _Mod = _Modifier == 'E' ? _E_mod : _O_mod;
+
+            if (auto _It = _RANGES find(_Table, _Type, &_Table_entry::_Type); _It != _STD end(_Table)) {
+                if (_It->_Allowed & _Mod) {
+                    return;
                 }
             }
 
-            for (const auto& _Spec : _Specs._Chrono_specs_list) {
-                if (_Spec._Lit_char != _CharT{'\0'}) {
-                    _Stream << _Spec._Lit_char;
-                    continue;
-                }
+            _THROW(format_error("Incompatible modifier for type"));
+        }
 
-                // We need to manually do certain writes, either because the specification is different from put_time or
-                // custom logic is needed.
-                if (_Custom_write(_Stream, _Spec, _Time, _Val)) {
-                    continue;
+        template <class _Ty>
+        _NODISCARD constexpr bool _Is_valid_type(const char _Type) noexcept {
+            if constexpr (is_same_v<_Ty, day>) {
+                return _Type == 'd' || _Type == 'e';
+            } else if constexpr (is_same_v<_Ty, month>) {
+                return _Type == 'b' || _Type == 'B' || _Type == 'h' || _Type == 'm';
+            } else if constexpr (is_same_v<_Ty, year>) {
+                return _Type == 'Y' || _Type == 'y' || _Type == 'C';
+            } else if constexpr (_Is_any_of_v<_Ty, weekday, weekday_indexed, weekday_last>) {
+                return _Type == 'a' || _Type == 'A' || _Type == 'u' || _Type == 'w';
+            } else if constexpr (_Is_any_of_v<_Ty, month_day, month_day_last>) {
+                return _Is_valid_type<month>(_Type) || _Is_valid_type<day>(_Type);
+            } else if constexpr (_Is_any_of_v<_Ty, month_weekday, month_weekday_last>) {
+                return _Is_valid_type<month>(_Type) || _Is_valid_type<weekday>(_Type);
+            } else if constexpr (is_same_v<_Ty, year_month>) {
+                return _Is_valid_type<year>(_Type) || _Is_valid_type<month>(_Type);
+            } else if constexpr (_Is_any_of_v<_Ty, year_month_day, year_month_day_last, year_month_weekday,
+                                     year_month_weekday_last>) {
+                return _Type == 'D' || _Type == 'F' || _Is_valid_type<year>(_Type) || _Is_valid_type<month>(_Type)
+                    || _Is_valid_type<day>(_Type) || _Is_valid_type<weekday>(_Type);
+            } else if constexpr (_Is_specialization_v<_Ty, hh_mm_ss>) {
+                return _Type == 'H' || _Type == 'I' || _Type == 'M' || _Type == 'S' || _Type == 'r' || _Type == 'R'
+                    || _Type == 'T' || _Type == 'p';
+            } else if constexpr (_Is_specialization_v<_Ty, time_point>) {
+                if constexpr (!is_same_v<typename _Ty::clock, local_t>) {
+                    if (_Type == 'z' || _Type == 'Z') {
+                        return true;
+                    }
                 }
-                // Otherwise, we should throw on out-of-bounds to avoid triggering asserts within put_time machinery.
-                if constexpr (_Has_ok<_Ty>) {
-                    if (!_Val.ok()) {
-                        _THROW(format_error("Cannot localize out-of-bounds time point."));
+                return _Type == 'c' || _Type == 'x' || _Type == 'X' || _Is_valid_type<year_month_day>(_Type)
+                    || _Is_valid_type<hh_mm_ss<seconds>>(_Type);
+            } else {
+                static_assert(_Always_false<_Ty>, "should be unreachable");
+            }
+        }
+
+        template <class _FormatContext, class _Ty>
+        _NODISCARD auto _Write(_FormatContext& _FormatCtx, const _Ty& _Val, const tm& _Time) {
+            basic_ostringstream<_CharT> _Stream;
+
+            if (_No_chrono_specs) {
+                _Stream << _Val;
+            } else {
+                _Stream.imbue(_FormatCtx.locale());
+                if constexpr (_Is_specialization_v<_Ty, hh_mm_ss>) {
+                    if (_Val.is_negative()) {
+                        _Stream << _CharT{'-'};
                     }
                 }
 
-                _CharT _Fmt_str[4];
-                size_t _Next_idx      = 0;
-                _Fmt_str[_Next_idx++] = _CharT{'%'};
-                if (_Spec._Modifier != '\0') {
-                    _Fmt_str[_Next_idx++] = static_cast<_CharT>(_Spec._Modifier);
-                }
-                _Fmt_str[_Next_idx++] = static_cast<_CharT>(_Spec._Type);
-                _Fmt_str[_Next_idx]   = _CharT{'\0'};
+                for (const auto& _Spec : _Specs._Chrono_specs_list) {
+                    if (_Spec._Lit_char != _CharT{'\0'}) {
+                        _Stream << _Spec._Lit_char;
+                        continue;
+                    }
 
-                _Stream << _STD put_time<_CharT>(&_Time, _Fmt_str);
+                    // We need to manually do certain writes, either because the specification is different from
+                    // put_time or custom logic is needed.
+                    if (_Custom_write(_Stream, _Spec, _Time, _Val)) {
+                        continue;
+                    }
+                    // Otherwise, we should throw on out-of-bounds to avoid triggering asserts within put_time
+                    // machinery.
+                    if constexpr (_Has_ok<_Ty>) {
+                        if (!_Val.ok()) {
+                            _THROW(format_error("Cannot localize out-of-bounds time point."));
+                        }
+                    }
+
+                    _CharT _Fmt_str[4];
+                    size_t _Next_idx      = 0;
+                    _Fmt_str[_Next_idx++] = _CharT{'%'};
+                    if (_Spec._Modifier != '\0') {
+                        _Fmt_str[_Next_idx++] = static_cast<_CharT>(_Spec._Modifier);
+                    }
+                    _Fmt_str[_Next_idx++] = static_cast<_CharT>(_Spec._Type);
+                    _Fmt_str[_Next_idx]   = _CharT{'\0'};
+
+                    _Stream << _STD put_time<_CharT>(&_Time, _Fmt_str);
+                }
+            }
+
+            return _Write_aligned(_STD move(_FormatCtx.out()), static_cast<int>(_Stream.view().size()), _Specs,
+                _Fmt_align::_Left, [&](auto _Out) { return _Fmt_write(_STD move(_Out), _Stream.view()); });
+        }
+
+        // This echoes the functionality of put_time, but is able to handle invalid dates (when !ok()) since the
+        // Standard mandates that invalid dates still be formatted properly.  For example, put_time isn't able to handle
+        // a tm_mday of 40, but format("{:%d}", day{40}) should return "40" and operator<< for day prints
+        // "40 is not a valid day".
+        template <class _Ty>
+        bool _Custom_write(
+            basic_ostream<_CharT>& _Os, const _Chrono_spec<_CharT>& _Spec, const tm& _Time, const _Ty& _Val) {
+            const auto _Year         = _Time.tm_year + 1900;
+            const auto _Month        = _Time.tm_mon + 1;
+            const bool _Has_modifier = _Spec._Modifier != '\0';
+            switch (_Spec._Type) {
+            case 'd':
+            case 'e':
+                // Most months have a proper last day, but February depends on the year.
+                if constexpr (is_same_v<_Ty, month_day_last>) {
+                    if (_Val.month() == February) {
+                        _THROW(format_error("Cannot print the last day of February without a year"));
+                    }
+                }
+
+                if (_Has_modifier) {
+                    return false;
+                }
+
+                if (_Time.tm_mday < 10) {
+                    _Os << (_Spec._Type == 'd' ? _CharT{'0'} : _CharT{' '});
+                }
+                _Os << _Time.tm_mday;
+                return true;
+            case 'm':
+                if (_Has_modifier) {
+                    return false;
+                }
+
+                if (_Month < 10) {
+                    _Os << _CharT{'0'};
+                }
+                _Os << _Month;
+                return true;
+            case 'Y':
+                if (_Has_modifier) {
+                    return false;
+                }
+
+                if (_Year < 0) {
+                    _Os << _CharT{'-'};
+                }
+                _Os << _STD format(_STATICALLY_WIDEN(_CharT, "{:04}"), _STD abs(_Year));
+                return true;
+            case 'y':
+                if (_Has_modifier) {
+                    return false;
+                }
+                _Os << _STD format(_STATICALLY_WIDEN(_CharT, "{:02}"), _Year < 0 ? 100 + (_Year % 100) : _Year % 100);
+                return true;
+            case 'C':
+                if (_Has_modifier) {
+                    return false;
+                }
+
+                if (_Year < 0) {
+                    _Os << _CharT{'-'};
+                }
+                _Os << _STD format(_STATICALLY_WIDEN(_CharT, "{:02}"),
+                    _STD abs(_Time_parse_fields::_Decompose_year(_Year).first) / 100);
+                return true;
+            case 'F':
+                _Custom_write(_Os, {._Type = 'Y'}, _Time, _Val);
+                _Os << _CharT{'-'};
+                _Custom_write(_Os, {._Type = 'm'}, _Time, _Val);
+                _Os << _CharT{'-'};
+                _Custom_write(_Os, {._Type = 'd'}, _Time, _Val);
+                return true;
+            case 'D':
+                _Custom_write(_Os, {._Type = 'm'}, _Time, _Val);
+                _Os << _CharT{'/'};
+                _Custom_write(_Os, {._Type = 'd'}, _Time, _Val);
+                _Os << _CharT{'/'};
+                _Custom_write(_Os, {._Type = 'y'}, _Time, _Val);
+                return true;
+            case 'H':
+                if constexpr (_Is_specialization_v<_Ty, hh_mm_ss>) {
+                    if (_Val.hours() >= hours{24}) {
+                        _THROW(format_error("Cannot localize hh_mm_ss with an absolute value of 24 hours or more."));
+                    }
+                }
+                return false;
+            case 'T':
+                // Alias for %H:%M:%S but we need to rewrite %S to display fractions of a second.
+                _Custom_write(_Os, {._Type = 'H'}, _Time, _Val);
+                _Os << _STD put_time(&_Time, _STATICALLY_WIDEN(_CharT, "%H:%M:"));
+                [[fallthrough]];
+            case 'S':
+                if (_Has_modifier) {
+                    return false;
+                }
+                _Write_seconds(_Os, _Val);
+                return true;
+            case 'Z':
+                _Os << _Time_zone_abbreviation;
+                return true;
+            case 'z':
+                _Os << _STATICALLY_WIDEN(_CharT, "+00");
+                if (_Has_modifier) {
+                    _Os << _CharT{':'};
+                }
+                _Os << _STATICALLY_WIDEN(_CharT, "00");
+                return true;
+            default:
+                return false;
             }
         }
 
-        return _Write_aligned(_STD move(_FormatCtx.out()), static_cast<int>(_Stream.view().size()), _Specs,
-            _Fmt_align::_Left, [&](auto _Out) { return _Fmt_write(_STD move(_Out), _Stream.view()); });
-    }
-
-    // This echoes the functionality of put_time, but is able to handle invalid dates (when !ok()) since the Standard
-    // mandates that invalid dates still be formatted properly.  For example, put_time isn't able to handle a tm_mday of
-    // 40, but format("{:%d}", day{40}) should return "40" and operator<< for day prints "40 is not a valid day".
-    template <class _Ty>
-    bool _Custom_write(
-        basic_ostream<_CharT>& _Os, const _Chrono_specs<_CharT>& _Specs, const tm& _Time, const _Ty& _Val) {
-        const auto _Year         = _Time.tm_year + 1900;
-        const auto _Month        = _Time.tm_mon + 1;
-        const bool _Has_modifier = _Specs._Modifier != '\0';
-        switch (_Specs._Type) {
-        case 'd':
-        case 'e':
-            // Most months have a proper last day, but February depends on the year.
-            if constexpr (is_same_v<_Ty, _CHRONO month_day_last>) {
-                if (_Val.month() == _CHRONO February) {
-                    _THROW(format_error("Cannot print the last day of February without a year"));
-                }
-            }
-
-            if (_Has_modifier) {
-                return false;
-            }
-
-            if (_Time.tm_mday < 10) {
-                _Os << (_Specs._Type == 'd' ? _CharT{'0'} : _CharT{' '});
-            }
-            _Os << _Time.tm_mday;
-            return true;
-        case 'm':
-            if (_Has_modifier) {
-                return false;
-            }
-
-            if (_Month < 10) {
-                _Os << _CharT{'0'};
-            }
-            _Os << _Month;
-            return true;
-        case 'Y':
-            if (_Has_modifier) {
-                return false;
-            }
-
-            if (_Year < 0) {
-                _Os << _CharT{'-'};
-            }
-            _Os << _STD format(_STATICALLY_WIDEN(_CharT, "{:04}"), _STD abs(_Year));
-            return true;
-        case 'y':
-            if (_Has_modifier) {
-                return false;
-            }
-            _Os << _STD format(_STATICALLY_WIDEN(_CharT, "{:02}"), _Year < 0 ? 100 + (_Year % 100) : _Year % 100);
-            return true;
-        case 'C':
-            if (_Has_modifier) {
-                return false;
-            }
-
-            if (_Year < 0) {
-                _Os << _CharT{'-'};
-            }
-            _Os << _STD format(_STATICALLY_WIDEN(_CharT, "{:02}"),
-                _STD abs(_CHRONO _Time_parse_fields::_Decompose_year(_Year).first) / 100);
-            return true;
-        case 'F':
-            _Custom_write(_Os, {._Type = 'Y'}, _Time, _Val);
-            _Os << _CharT{'-'};
-            _Custom_write(_Os, {._Type = 'm'}, _Time, _Val);
-            _Os << _CharT{'-'};
-            _Custom_write(_Os, {._Type = 'd'}, _Time, _Val);
-            return true;
-        case 'D':
-            _Custom_write(_Os, {._Type = 'm'}, _Time, _Val);
-            _Os << _CharT{'/'};
-            _Custom_write(_Os, {._Type = 'd'}, _Time, _Val);
-            _Os << _CharT{'/'};
-            _Custom_write(_Os, {._Type = 'y'}, _Time, _Val);
-            return true;
-        case 'H':
-            if constexpr (_Is_specialization_v<_Ty, _CHRONO hh_mm_ss>) {
-                if (_Val.hours() >= _CHRONO hours{24}) {
-                    _THROW(format_error("Cannot localize hh_mm_ss with an absolute value of 24 hours or more."));
-                }
-            }
-            return false;
-        case 'T':
-            // Alias for %H:%M:%S but we need to rewrite %S to display fractions of a second.
-            _Custom_write(_Os, {._Type = 'H'}, _Time, _Val);
-            _Os << _STD put_time(&_Time, _STATICALLY_WIDEN(_CharT, "%H:%M:"));
-            [[fallthrough]];
-        case 'S':
-            if (_Has_modifier) {
-                return false;
-            }
-            _Write_seconds(_Os, _Val);
-            return true;
-        case 'Z':
-            _Os << _Time_zone_abbreviation;
-            return true;
-        case 'z':
-            _Os << _STATICALLY_WIDEN(_CharT, "+00");
-            if (_Has_modifier) {
-                _Os << _CharT{':'};
-            }
-            _Os << _STATICALLY_WIDEN(_CharT, "00");
-            return true;
-        default:
-            return false;
-        }
-    }
-
-    _Chrono_format_specs<_CharT> _Specs{};
-    bool _No_chrono_specs = false;
-    basic_string_view<_CharT> _Time_zone_abbreviation{};
-};
+        _Chrono_format_specs<_CharT> _Specs{};
+        bool _No_chrono_specs = false;
+        basic_string_view<_CharT> _Time_zone_abbreviation{};
+    };
+} // namespace chrono
 
 template <class _Ty, class _CharT>
 struct _Fill_tm_formatter {
@@ -5993,7 +5994,7 @@ struct _Fill_tm_formatter {
     }
 
 private:
-    _Chrono_formatter<_CharT> _Impl;
+    _CHRONO _Chrono_formatter<_CharT> _Impl;
 };
 
 template <class _CharT>
@@ -6072,7 +6073,7 @@ struct formatter<_CHRONO sys_time<_Duration>, _CharT> {
     }
 
 private:
-    _Chrono_formatter<_CharT> _Impl{_STATICALLY_WIDEN(_CharT, "UTC")};
+    _CHRONO _Chrono_formatter<_CharT> _Impl{_STATICALLY_WIDEN(_CharT, "UTC")};
 };
 
 template <class _Duration, class _CharT>
@@ -6088,7 +6089,7 @@ struct formatter<_CHRONO utc_time<_Duration>, _CharT> {
     }
 
 private:
-    _Chrono_formatter<_CharT> _Impl{_STATICALLY_WIDEN(_CharT, "UTC")};
+    _CHRONO _Chrono_formatter<_CharT> _Impl{_STATICALLY_WIDEN(_CharT, "UTC")};
 };
 
 template <class _Duration, class _CharT>
@@ -6107,7 +6108,7 @@ struct formatter<_CHRONO tai_time<_Duration>, _CharT> {
     }
 
 private:
-    _Chrono_formatter<_CharT> _Impl{_STATICALLY_WIDEN(_CharT, "TAI")};
+    _CHRONO _Chrono_formatter<_CharT> _Impl{_STATICALLY_WIDEN(_CharT, "TAI")};
 };
 
 template <class _Duration, class _CharT>
@@ -6126,7 +6127,7 @@ struct formatter<_CHRONO gps_time<_Duration>, _CharT> {
     }
 
 private:
-    _Chrono_formatter<_CharT> _Impl{_STATICALLY_WIDEN(_CharT, "GPS")};
+    _CHRONO _Chrono_formatter<_CharT> _Impl{_STATICALLY_WIDEN(_CharT, "GPS")};
 };
 
 template <class _Duration, class _CharT>
@@ -6142,7 +6143,7 @@ struct formatter<_CHRONO file_time<_Duration>, _CharT> {
     }
 
 private:
-    _Chrono_formatter<_CharT> _Impl{_STATICALLY_WIDEN(_CharT, "UTC")};
+    _CHRONO _Chrono_formatter<_CharT> _Impl{_STATICALLY_WIDEN(_CharT, "UTC")};
 };
 
 template <class _Duration, class _CharT>

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -5438,97 +5438,14 @@ namespace chrono {
 
     template <class _CharT, class _Traits, class _Clock, class _Duration>
     void _Write_seconds(basic_ostream<_CharT, _Traits>& _Os, const time_point<_Clock, _Duration>& _Val) {
+        if constexpr (is_same_v<_Clock, utc_clock>) {
+            if (_CHRONO get_leap_second_info(_Val).is_leap_second) {
+                _Os << _STATICALLY_WIDEN(_CharT, "60");
+                return;
+            }
+        }
         const auto _Dp = _CHRONO floor<days>(_Val);
         _Write_seconds(_Os, hh_mm_ss{_Val - _Dp});
-    }
-
-    // This echoes the functionality of put_time, but is able to handle invalid dates (when !ok()) since the Standard
-    // mandates that invalid dates still be formatted properly.  For example, put_time isn't able to handle a tm_mday of
-    // 40, but format("{:%d}", day{40}) should return "40" and operator<< for day prints "40 is not a valid day".
-    template <class _CharT, class _Ty>
-    bool _Custom_write(
-        basic_ostream<_CharT>& _Os, const _Chrono_specs<_CharT>& _Specs, const tm& _Time, const _Ty& _Val) {
-        const auto _Year         = _Time.tm_year + 1900;
-        const auto _Month        = _Time.tm_mon + 1;
-        const bool _Has_modifier = _Specs._Modifier != '\0';
-        switch (_Specs._Type) {
-        case 'd':
-        case 'e':
-            // Most months have a proper last day, but February depends on the year.
-            if constexpr (is_same_v<_Ty, month_day_last>) {
-                if (_Val.month() == February) {
-                    _THROW(format_error("Cannot print the last day of February without a year"));
-                }
-            }
-            if (_Has_modifier) {
-                return false;
-            }
-            if (_Time.tm_mday < 10) {
-                _Os << (_Specs._Type == 'd' ? _CharT{'0'} : _CharT{' '});
-            }
-            _Os << _Time.tm_mday;
-            return true;
-        case 'm':
-            if (_Has_modifier) {
-                return false;
-            }
-            if (_Month < 10) {
-                _Os << _CharT{'0'};
-            }
-            _Os << _Month;
-            return true;
-        case 'Y':
-            if (_Has_modifier) {
-                return false;
-            }
-            if (_Year < 0) {
-                _Os << _CharT{'-'};
-            }
-            _Os << _STD format(_STATICALLY_WIDEN(_CharT, "{:04}"), _STD abs(_Year));
-            return true;
-        case 'y':
-            if (_Has_modifier) {
-                return false;
-            }
-            _Os << _STD format(_STATICALLY_WIDEN(_CharT, "{:02}"), _Year < 0 ? 100 + (_Year % 100) : _Year % 100);
-            return true;
-        case 'C':
-            if (_Has_modifier) {
-                return false;
-            }
-            if (_Year < 0) {
-                _Os << _CharT{'-'};
-            }
-            _Os << _STD format(
-                _STATICALLY_WIDEN(_CharT, "{:02}"), _STD abs(_Time_parse_fields::_Decompose_year(_Year).first) / 100);
-            return true;
-        case 'F':
-            _Custom_write(_Os, {._Type = 'Y'}, _Time, _Val);
-            _Os << _CharT{'-'};
-            _Custom_write(_Os, {._Type = 'm'}, _Time, _Val);
-            _Os << _CharT{'-'};
-            _Custom_write(_Os, {._Type = 'd'}, _Time, _Val);
-            return true;
-        case 'D':
-            _Custom_write(_Os, {._Type = 'm'}, _Time, _Val);
-            _Os << _CharT{'/'};
-            _Custom_write(_Os, {._Type = 'd'}, _Time, _Val);
-            _Os << _CharT{'/'};
-            _Custom_write(_Os, {._Type = 'y'}, _Time, _Val);
-            return true;
-        case 'T':
-            // Alias for %H:%M:%S but we need to rewrite %S to display fractions of a second.
-            _Os << _STD put_time(&_Time, _STATICALLY_WIDEN(_CharT, "%H:%M:"));
-            [[fallthrough]];
-        case 'S':
-            if (_Has_modifier) {
-                return false;
-            }
-            _Write_seconds(_Os, _Val);
-            return true;
-        default:
-            return false;
-        }
     }
 
     template <class _Ty>
@@ -5580,6 +5497,16 @@ namespace chrono {
             _Hours   = _Val.hours().count();
             _Minutes = _Val.minutes().count();
             _Seconds = static_cast<int>(_Val.seconds().count());
+        } else if constexpr (_Is_specialization_v<_Ty, time_point>) {
+            const auto _Dp = _CHRONO floor<days>(_Val);
+            const year_month_day _Ymd{_Dp};
+            const hh_mm_ss _Time{_Val - _Dp};
+            const auto _Hms = _Fill_tm(_Time);
+            auto _Tm        = _Fill_tm(_Ymd);
+            _Tm.tm_sec      = _Hms.tm_sec;
+            _Tm.tm_min      = _Hms.tm_min;
+            _Tm.tm_hour     = _Hms.tm_hour;
+            return _Tm;
         }
 
         tm _Time;
@@ -5687,6 +5614,46 @@ namespace chrono {
     basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const hh_mm_ss<_Duration>& _Val) {
         return _Os << _STD format(_Os.getloc(), _STATICALLY_WIDEN(_CharT, "{:%T}"), _Val);
     }
+
+    template <class _CharT, class _Traits, class _Duration>
+    // clang-format off
+        requires (!treat_as_floating_point_v<typename _Duration::rep> && (_Duration{1} < days{1}))
+    basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const sys_time<_Duration>& _Val) {
+        // clang-format on
+        const auto _Dp = _CHRONO floor<days>(_Val);
+        return _Os << _STD format(
+                   _Os.getloc(), _STATICALLY_WIDEN(_CharT, "{} {}"), year_month_day{_Dp}, hh_mm_ss{_Val - _Dp});
+    }
+
+    template <class _CharT, class _Traits>
+    basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const sys_days& _Val) {
+        return _Os << year_month_day{_Val};
+    }
+
+    template <class _CharT, class _Traits, class _Duration>
+    basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const utc_time<_Duration>& _Val) {
+        return _Os << _STD format(_STATICALLY_WIDEN(_CharT, "{:%F %T}"), _Val);
+    }
+
+    template <class _CharT, class _Traits, class _Duration>
+    basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const tai_time<_Duration>& _Val) {
+        return _Os << _STD format(_STATICALLY_WIDEN(_CharT, "{:%F %T}"), _Val);
+    }
+
+    template <class _CharT, class _Traits, class _Duration>
+    basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const gps_time<_Duration>& _Val) {
+        return _Os << _STD format(_STATICALLY_WIDEN(_CharT, "{:%F %T}"), _Val);
+    }
+
+    template <class _CharT, class _Traits, class _Duration>
+    basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const file_time<_Duration>& _Val) {
+        return _Os << _STD format(_STATICALLY_WIDEN(_CharT, "{:%F %T}"), _Val);
+    }
+
+    template <class _CharT, class _Traits, class _Duration>
+    basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const local_time<_Duration>& _Val) {
+        return _Os << sys_time<_Duration>{_Val.time_since_epoch()};
+    }
 } // namespace chrono
 
 template <class _CharT, bool _Allow_precision>
@@ -5791,6 +5758,14 @@ struct _Chrono_formatter {
         } else if constexpr (_Is_specialization_v<_Ty, _CHRONO hh_mm_ss>) {
             return _Type == 'H' || _Type == 'I' || _Type == 'M' || _Type == 'S' || _Type == 'r' || _Type == 'R'
                 || _Type == 'T' || _Type == 'p';
+        } else if constexpr (_Is_specialization_v<_Ty, _CHRONO time_point>) {
+            if constexpr (!is_same_v<typename _Ty::clock, _CHRONO local_t>) {
+                if (_Type == 'z' || _Type == 'Z') {
+                    return true;
+                }
+            }
+            return _Type == 'c' || _Type == 'x' || _Type == 'X' || _Is_valid_type<_CHRONO year_month_day>(_Type)
+                || _Is_valid_type<_CHRONO hh_mm_ss<_CHRONO seconds>>(_Type);
         } else {
             // TRANSITION, remove when all types are added
             static_assert(_Always_false<_Ty>, "unsupported type");
@@ -5819,7 +5794,7 @@ struct _Chrono_formatter {
 
                 // We need to manually do certain writes, either because the specification is different from put_time or
                 // custom logic is needed.
-                if (_CHRONO _Custom_write(_Stream, _Spec, _Time, _Val)) {
+                if (_Custom_write(_Stream, _Spec, _Time, _Val)) {
                     continue;
                 }
                 // Otherwise, we should throw on out-of-bounds to avoid triggering asserts within put_time machinery.
@@ -5846,8 +5821,108 @@ struct _Chrono_formatter {
             _Fmt_align::_Left, [&](auto _Out) { return _Fmt_write(_STD move(_Out), _Stream.view()); });
     }
 
+    // This echoes the functionality of put_time, but is able to handle invalid dates (when !ok()) since the Standard
+    // mandates that invalid dates still be formatted properly.  For example, put_time isn't able to handle a tm_mday of
+    // 40, but format("{:%d}", day{40}) should return "40" and operator<< for day prints "40 is not a valid day".
+    template <class _Ty>
+    bool _Custom_write(
+        basic_ostream<_CharT>& _Os, const _Chrono_specs<_CharT>& _Specs, const tm& _Time, const _Ty& _Val) {
+        const auto _Year         = _Time.tm_year + 1900;
+        const auto _Month        = _Time.tm_mon + 1;
+        const bool _Has_modifier = _Specs._Modifier != '\0';
+        switch (_Specs._Type) {
+        case 'd':
+        case 'e':
+            // Most months have a proper last day, but February depends on the year.
+            if constexpr (is_same_v<_Ty, _CHRONO month_day_last>) {
+                if (_Val.month() == _CHRONO February) {
+                    _THROW(format_error("Cannot print the last day of February without a year"));
+                }
+            }
+            if (_Has_modifier) {
+                return false;
+            }
+            if (_Time.tm_mday < 10) {
+                _Os << (_Specs._Type == 'd' ? _CharT{'0'} : _CharT{' '});
+            }
+            _Os << _Time.tm_mday;
+            return true;
+        case 'm':
+            if (_Has_modifier) {
+                return false;
+            }
+            if (_Month < 10) {
+                _Os << _CharT{'0'};
+            }
+            _Os << _Month;
+            return true;
+        case 'Y':
+            if (_Has_modifier) {
+                return false;
+            }
+            if (_Year < 0) {
+                _Os << _CharT{'-'};
+            }
+            _Os << _STD format(_STATICALLY_WIDEN(_CharT, "{:04}"), _STD abs(_Year));
+            return true;
+        case 'y':
+            if (_Has_modifier) {
+                return false;
+            }
+            _Os << _STD format(_STATICALLY_WIDEN(_CharT, "{:02}"), _Year < 0 ? 100 + (_Year % 100) : _Year % 100);
+            return true;
+        case 'C':
+            if (_Has_modifier) {
+                return false;
+            }
+            if (_Year < 0) {
+                _Os << _CharT{'-'};
+            }
+            _Os << _STD format(_STATICALLY_WIDEN(_CharT, "{:02}"),
+                _STD abs(_CHRONO _Time_parse_fields::_Decompose_year(_Year).first) / 100);
+            return true;
+        case 'F':
+            _Custom_write(_Os, {._Type = 'Y'}, _Time, _Val);
+            _Os << _CharT{'-'};
+            _Custom_write(_Os, {._Type = 'm'}, _Time, _Val);
+            _Os << _CharT{'-'};
+            _Custom_write(_Os, {._Type = 'd'}, _Time, _Val);
+            return true;
+        case 'D':
+            _Custom_write(_Os, {._Type = 'm'}, _Time, _Val);
+            _Os << _CharT{'/'};
+            _Custom_write(_Os, {._Type = 'd'}, _Time, _Val);
+            _Os << _CharT{'/'};
+            _Custom_write(_Os, {._Type = 'y'}, _Time, _Val);
+            return true;
+        case 'T':
+            // Alias for %H:%M:%S but we need to rewrite %S to display fractions of a second.
+            _Os << _STD put_time(&_Time, _STATICALLY_WIDEN(_CharT, "%H:%M:"));
+            [[fallthrough]];
+        case 'S':
+            if (_Has_modifier) {
+                return false;
+            }
+            _Write_seconds(_Os, _Val);
+            return true;
+        case 'Z':
+            _Os << _Time_zone_abbreviation;
+            return true;
+        case 'z':
+            _Os << _STATICALLY_WIDEN(_CharT, "+00");
+            if (_Has_modifier) {
+                _Os << _CharT{':'};
+            }
+            _Os << _STATICALLY_WIDEN(_CharT, "00");
+            return true;
+        default:
+            return false;
+        }
+    }
+
     _Chrono_format_specs<_CharT> _Specs{};
     bool _No_chrono_specs = false;
+    basic_string_view<_CharT> _Time_zone_abbreviation;
 };
 
 template <class _Ty, class _CharT>
@@ -5924,6 +5999,112 @@ struct formatter<_CHRONO hh_mm_ss<_CHRONO duration<_Rep, _Period>>, _CharT> {
 private:
     _Chrono_formatter<_CharT, false> _Impl;
 };
+
+template <class _Duration, class _CharT>
+struct formatter<_CHRONO sys_time<_Duration>, _CharT> {
+    formatter() {
+        _Impl._Time_zone_abbreviation = _STATICALLY_WIDEN(_CharT, "UTC");
+    }
+
+    auto parse(basic_format_parse_context<_CharT>& _Parse_ctx) {
+        return _Impl.template _Parse<_CHRONO sys_time<_Duration>>(_Parse_ctx);
+    }
+
+    template <class _FormatContext>
+    auto format(const _CHRONO sys_time<_Duration>& _Val, _FormatContext& _FormatCtx) {
+        return _Impl._Write(_FormatCtx, _Val, _Fill_tm(_Val));
+    }
+
+private:
+    _Chrono_formatter<_CharT, false> _Impl;
+};
+
+template <class _Duration, class _CharT>
+struct formatter<_CHRONO utc_time<_Duration>, _CharT> {
+    formatter() {
+        _Impl._Time_zone_abbreviation = _STATICALLY_WIDEN(_CharT, "UTC");
+    }
+
+    auto parse(basic_format_parse_context<_CharT>& _Parse_ctx) {
+        return _Impl.template _Parse<_CHRONO utc_time<_Duration>>(_Parse_ctx);
+    }
+
+    template <class _FormatContext>
+    auto format(const _CHRONO utc_time<_Duration>& _Val, _FormatContext& _FormatCtx) {
+        const auto _Sys = _CHRONO utc_clock::to_sys(_Val);
+        return _Impl._Write(_FormatCtx, _Val, _Fill_tm(_Sys));
+    }
+
+private:
+    _Chrono_formatter<_CharT, false> _Impl;
+};
+
+template <class _Duration, class _CharT>
+struct formatter<_CHRONO tai_time<_Duration>, _CharT> {
+    formatter() {
+        _Impl._Time_zone_abbreviation = _STATICALLY_WIDEN(_CharT, "TAI");
+    }
+
+    auto parse(basic_format_parse_context<_CharT>& _Parse_ctx) {
+        return _Impl.template _Parse<_CHRONO tai_time<_Duration>>(_Parse_ctx);
+    }
+
+    template <class _FormatContext>
+    auto format(const _CHRONO tai_time<_Duration>& _Val, _FormatContext& _FormatCtx) {
+        const auto _Sys = _CHRONO sys_time<_Duration>{_Val.time_since_epoch()}
+                        - (_CHRONO sys_days{_CHRONO year{1970} / 1 / 1} - _CHRONO sys_days{_CHRONO year{1958} / 1 / 1});
+        return _Impl._Write(_FormatCtx, _Val, _Fill_tm(_Sys));
+    }
+
+private:
+    _Chrono_formatter<_CharT, false> _Impl;
+};
+
+template <class _Duration, class _CharT>
+struct formatter<_CHRONO gps_time<_Duration>, _CharT> {
+    formatter() {
+        _Impl._Time_zone_abbreviation = _STATICALLY_WIDEN(_CharT, "GPS");
+    }
+
+    auto parse(basic_format_parse_context<_CharT>& _Parse_ctx) {
+        return _Impl.template _Parse<_CHRONO gps_time<_Duration>>(_Parse_ctx);
+    }
+
+    template <class _FormatContext>
+    auto format(const _CHRONO gps_time<_Duration>& _Val, _FormatContext& _FormatCtx) {
+        const auto _Sys = _CHRONO sys_time<_Duration>{_Val.time_since_epoch()}
+                        + (_CHRONO sys_days{_CHRONO year{1980} / 1 / _CHRONO Sunday[1]}
+                            - _CHRONO sys_days{_CHRONO year{1970} / 1 / 1});
+        return _Impl._Write(_FormatCtx, _Val, _Fill_tm(_Sys));
+    }
+
+private:
+    _Chrono_formatter<_CharT, false> _Impl;
+};
+
+template <class _Duration, class _CharT>
+struct formatter<_CHRONO file_time<_Duration>, _CharT> {
+    formatter() {
+        _Impl._Time_zone_abbreviation = _STATICALLY_WIDEN(_CharT, "UTC");
+    }
+
+    auto parse(basic_format_parse_context<_CharT>& _Parse_ctx) {
+        return _Impl.template _Parse<_CHRONO file_time<_Duration>>(_Parse_ctx);
+    }
+
+    template <class _FormatContext>
+    auto format(const _CHRONO file_time<_Duration>& _Val, _FormatContext& _FormatCtx) {
+        const auto _Sys = _CHRONO clock_cast<_CHRONO system_clock>(_Val);
+        return _Impl._Write(_FormatCtx, _Val, _Fill_tm(_Sys));
+    }
+
+private:
+    _Chrono_formatter<_CharT, false> _Impl;
+};
+
+template <class _Duration, class _CharT>
+struct formatter<_CHRONO local_time<_Duration>, _CharT> //
+    : _Fill_tm_formatter<_CHRONO local_time<_Duration>, _CharT> {};
 
 
 #endif // __cpp_lib_concepts

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -5500,10 +5500,65 @@ namespace chrono {
         return _Os << format(_STATICALLY_WIDEN(_CharT, "{:%F %T}"), _Clock);
     }*/
 
+    template <class _Ty>
+    concept _Has_day = requires(const _Ty& _At) {
+        { _At.day() }
+        ->same_as<day>;
+    };
+
+    template <class _Ty>
+    concept _Has_month = requires(const _Ty& _At) {
+        { _At.month() }
+        ->same_as<month>;
+    };
+
+    template <class _Ty>
+    concept _Has_year = requires(const _Ty& _At) {
+        { _At.year() }
+        ->same_as<year>;
+    };
+
+    template <class _Ty>
+    tm _Fill_tm(const _Ty& _Val) {
+        unsigned int _Day   = 0;
+        unsigned int _Month = 0;
+        int _Year           = 0;
+        int _Weekday        = 0;
+        int _Hours          = 0;
+        int _Minutes        = 0;
+        int _Seconds        = 0;
+
+        if constexpr (is_same_v<_Ty, day>) {
+            _Day = static_cast<unsigned int>(_Val);
+        } else if constexpr (is_same_v<_Ty, month>) {
+            _Month = static_cast<unsigned int>(_Val);
+        } else if constexpr (is_same_v<_Ty, year>) {
+            _Year = static_cast<int>(_Val);
+        } else if constexpr (is_same_v<_Ty, year_month_day>) {
+            _Day     = static_cast<unsigned int>(_Val.day());
+            _Month   = static_cast<unsigned int>(_Val.month());
+            _Year    = static_cast<int>(_Val.year());
+            _Weekday = _Val._Calculate_weekday();
+        } else if constexpr (_Is_specialization_v<_Ty, hh_mm_ss>) {
+            _Hours   = _Val.hours().count();
+            _Minutes = _Val.minutes().count();
+            _Seconds = static_cast<int>(_Val.seconds().count());
+        }
+
+        tm _Time;
+        _Time.tm_sec  = _Seconds;
+        _Time.tm_min  = _Minutes;
+        _Time.tm_hour = _Hours;
+        _Time.tm_mday = static_cast<int>(_Day);
+        _Time.tm_mon  = static_cast<int>(_Month) - 1;
+        _Time.tm_year = _Year - 1900;
+        _Time.tm_wday = _Weekday;
+        return _Time;
+    }
+
     template <class _CharT, class _Traits>
     basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const day& _Val) {
-        const tm _Time = {.tm_mday = static_cast<int>(static_cast<unsigned int>(_Val))};
-        _Try_simple_write(_Os, 'd', _Time);
+        _Try_simple_write(_Os, 'd', _Fill_tm(_Val));
         if (!_Val.ok()) {
             _Os << _STATICALLY_WIDEN(_CharT, " is not a valid day");
         }
@@ -5514,8 +5569,7 @@ namespace chrono {
     template <class _CharT, class _Traits>
     basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const month& _Val) {
         if (_Val.ok()) {
-            // tm_mon is [0, 11] while month is [1, 12]
-            const tm _Time = {.tm_mon = static_cast<int>(static_cast<unsigned int>(_Val)) - 1};
+            const tm _Time = _Fill_tm(_Val);
             return _Os << _STD put_time(&_Time, _STATICALLY_WIDEN(_CharT, "%b"));
         }
         return _Os << static_cast<unsigned int>(_Val) << _STATICALLY_WIDEN(_CharT, " is not a valid month");
@@ -5523,8 +5577,7 @@ namespace chrono {
 
     template <class _CharT, class _Traits>
     basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const year& _Val) {
-        const tm _Time = {.tm_year = static_cast<int>(_Val) - 1900};
-        _Try_simple_write(_Os, 'Y', _Time);
+        _Try_simple_write(_Os, 'Y', _Fill_tm(_Val));
         if (!_Val.ok()) {
             _Os << _STATICALLY_WIDEN(_CharT, " is not a valid year");
         }
@@ -5533,10 +5586,7 @@ namespace chrono {
 
     template <class _CharT, class _Traits>
     basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const year_month_day& _Val) {
-        const tm _Time = {.tm_mday = static_cast<int>(static_cast<unsigned int>(_Val.day())),
-            .tm_mon                = static_cast<int>(static_cast<unsigned int>(_Val.month())) - 1,
-            .tm_year               = static_cast<int>(_Val.year()) - 1900};
-        _Try_simple_write(_Os, 'F', _Time);
+        _Try_simple_write(_Os, 'F', _Fill_tm(_Val));
         if (!_Val.ok()) {
             _Os << _STATICALLY_WIDEN(_CharT, " is not a valid date");
         }
@@ -5545,8 +5595,7 @@ namespace chrono {
 
     template <class _CharT, class _Traits, class _Duration>
     basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const hh_mm_ss<_Duration>& _Val) {
-        const tm _Time = {
-            .tm_min = static_cast<int>(_Val.minutes().count()), .tm_hour = static_cast<int>(_Val.hours().count())};
+        const tm _Time = _Fill_tm(_Val);
         if (_Val.is_negative()) {
             _Os << _CharT{'-'};
         }
@@ -5738,8 +5787,7 @@ struct formatter<_CHRONO day, _CharT> {
 
     template <class _FormatContext>
     auto format(const _CHRONO day& _Val, _FormatContext& _FormatCtx) {
-        const tm _Time = {.tm_mday = static_cast<int>(static_cast<unsigned int>(_Val))};
-        return _Impl._Write(_FormatCtx, _Val, _Time);
+        return _Impl._Write(_FormatCtx, _Val, _Fill_tm(_Val));
     }
 
 private:
@@ -5754,9 +5802,7 @@ struct formatter<_CHRONO month, _CharT> {
 
     template <class _FormatContext>
     auto format(const _CHRONO month& _Val, _FormatContext& _FormatCtx) {
-        // tm_mon is [0, 11] while month is [1, 12]
-        const tm _Time = {.tm_mon = static_cast<int>(static_cast<unsigned int>(_Val)) - 1};
-        return _Impl._Write(_FormatCtx, _Val, _Time);
+        return _Impl._Write(_FormatCtx, _Val, _Fill_tm(_Val));
     }
 
 private:
@@ -5771,8 +5817,7 @@ struct formatter<_CHRONO year, _CharT> {
 
     template <class _FormatContext>
     auto format(const _CHRONO year& _Val, _FormatContext& _FormatCtx) {
-        const tm _Time = {.tm_year = static_cast<int>(_Val) - 1900};
-        return _Impl._Write(_FormatCtx, _Val, _Time);
+        return _Impl._Write(_FormatCtx, _Val, _Fill_tm(_Val));
     }
 
 private:
@@ -5787,11 +5832,7 @@ struct formatter<_CHRONO year_month_day, _CharT> {
 
     template <class _FormatContext>
     auto format(const _CHRONO year_month_day& _Val, _FormatContext& _FormatCtx) {
-        const tm _Time = {.tm_mday = static_cast<int>(static_cast<unsigned int>(_Val.day())),
-            .tm_mon                = static_cast<int>(static_cast<unsigned int>(_Val.month())) - 1,
-            .tm_year               = static_cast<int>(_Val.year()) - 1900,
-            .tm_wday               = _Val._Calculate_weekday()};
-        return _Impl._Write(_FormatCtx, _Val, _Time);
+        return _Impl._Write(_FormatCtx, _Val, _Fill_tm(_Val));
     }
 
 private:

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -6023,6 +6023,10 @@ namespace chrono {
                             "The ISO week-based year for a year_month of January or December is ambiguous."));
                     }
 
+                    if (!_Val.ok()) {
+                        _THROW(format_error("The ISO week-based year for an out-of-bounds year_month is ambiguous."));
+                    }
+
                     const char _Gregorian_type = _Spec._Type == 'g' ? 'y' : 'Y';
                     _Os << _STD put_time(&_Time, _Fmt_string({._Type = _Gregorian_type}).data());
                     return true;

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -11,7 +11,6 @@
 #include <ctime>
 #include <limits>
 #include <ratio>
-#include <sstream>
 #include <utility>
 #include <xtimec.h>
 
@@ -22,10 +21,10 @@
 #include <cmath>
 #include <compare>
 #include <forward_list>
-#include <iomanip>
 #include <istream>
 #include <memory>
 #include <optional>
+#include <sstream>
 #include <string>
 #include <vector>
 #include <xloctime>
@@ -34,8 +33,7 @@
 #ifdef __cpp_lib_concepts
 #include <concepts>
 #include <format>
-#include <iostream>
-#include <sstream>
+#include <iomanip>
 #endif // defined(__cpp_lib_concepts)
 #endif // _HAS_CXX20
 
@@ -2215,12 +2213,6 @@ namespace chrono {
         _CHRONO seconds _Secs;
         precision _Sub_secs;
     };
-
-    template <class _Ty>
-    constexpr inline bool _Is_hh_mm_ss = false;
-
-    template <class _Duration>
-    constexpr inline bool _Is_hh_mm_ss<hh_mm_ss<_Duration>> = true;
 
     _NODISCARD constexpr bool is_am(const hours& _Hours) noexcept {
         return _Hours >= hours{0} && _Hours <= hours{11};
@@ -5207,17 +5199,15 @@ namespace chrono {
   // [time.format]
 
 template <class _CharT>
-struct _Choose_literal {
-    static constexpr const _CharT* _Choose(const char* _Str, const wchar_t* _WStr) {
-        if constexpr (is_same_v<_CharT, char>) {
-            return _Str;
-        } else {
-            return _WStr;
-        }
+_NODISCARD constexpr const _CharT* _Choose_literal(const char* const _Str, const wchar_t* const _WStr) noexcept {
+    if constexpr (is_same_v<_CharT, char>) {
+        return _Str;
+    } else {
+        return _WStr;
     }
-};
+}
 
-#define _STATICALLY_WIDEN(_CharT, _Literal) (_Choose_literal<_CharT>::_Choose(_Literal, L##_Literal))
+#define _STATICALLY_WIDEN(_CharT, _Literal) (_Choose_literal<_CharT>(_Literal, L##_Literal))
 
 
 // clang-format off
@@ -5291,7 +5281,7 @@ public:
         _Specs._Dynamic_width_index = _Verify_dynamic_arg_index_in_range(_Arg_id);
     }
 
-    constexpr void _On_dynamic_width(const _Auto_id_tag) {
+    constexpr void _On_dynamic_width(_Auto_id_tag) {
         _Specs._Dynamic_width_index = _Verify_dynamic_arg_index_in_range(_Parse_ctx.next_arg_id());
     }
 
@@ -5300,7 +5290,7 @@ public:
         _Specs._Dynamic_precision_index = _Verify_dynamic_arg_index_in_range(_Arg_id);
     }
 
-    constexpr void _On_dynamic_precision(const _Auto_id_tag) {
+    constexpr void _On_dynamic_precision(_Auto_id_tag) {
         _Specs._Dynamic_precision_index = _Verify_dynamic_arg_index_in_range(_Parse_ctx.next_arg_id());
     }
 
@@ -5323,10 +5313,8 @@ public:
         _Specs._Chrono_specs_list.push_back(_Lit_char_spec);
     }
 
-protected:
-    _Chrono_format_specs<_CharT>& _Specs;
-
 private:
+    _Chrono_format_specs<_CharT>& _Specs;
     _ParseContext& _Parse_ctx;
 
     _NODISCARD static constexpr int _Verify_dynamic_arg_index_in_range(const size_t _Idx) {
@@ -5387,8 +5375,8 @@ _NODISCARD constexpr const _CharT* _Parse_chrono_format_specs(
         }
     }
 
-    if (_Begin != _End && *_Begin != '}' && *_Begin != '%') {
-        _THROW(format_error("Invalid format string - chrono-specs must begin with conversion-specs"));
+    if (*_Begin != '}' && *_Begin != '%') {
+        _THROW(format_error("Invalid format string - chrono-specs must begin with conversion-spec"));
     }
 
     // chrono-spec
@@ -5398,8 +5386,7 @@ _NODISCARD constexpr const _CharT* _Parse_chrono_format_specs(
                 _THROW(format_error("Invalid format string - missing type after %"));
             }
 
-            _CharT _Next_ch = *_Begin;
-            switch (_Next_ch) {
+            switch (*_Begin) {
             case 'n':
                 _Callbacks._On_lit_char('\n');
                 ++_Begin;
@@ -5484,9 +5471,9 @@ namespace chrono {
 
     template <class _CharT, class _Traits, class _Duration>
     void _Write_seconds(basic_ostream<_CharT, _Traits>& _Os, const hh_mm_ss<_Duration>& _Val) {
-        _Os << format(_STATICALLY_WIDEN(_CharT, "{:02}"), _Val.seconds().count());
+        _Os << _STD format(_STATICALLY_WIDEN(_CharT, "{:02}"), _Val.seconds().count());
         if constexpr (hh_mm_ss<_Duration>::fractional_width > 0) {
-            _Os << format(_STATICALLY_WIDEN(_CharT, "{0}{1:0{2}}"),
+            _Os << _STD format(_STATICALLY_WIDEN(_CharT, "{0}{1:0{2}}"),
                 _STD use_facet<numpunct<_CharT>>(_Os.getloc()).decimal_point(), _Val.subseconds().count(),
                 _Val.fractional_width);
         }
@@ -5633,7 +5620,7 @@ struct _Chrono_formatter {
             _Allowed_bit _Allowed;
         };
 
-        static const _Table_entry _Table[] = {
+        static constexpr _Table_entry _Table[] = {
             {'d', _O_mod}, {'e', _O_mod}, {'m', _O_mod}, {'Y', _E_mod}, {'y', _EO_mod}, {'C', _E_mod}};
 
         const _Allowed_bit _Mod = _Modifier == 'E' ? _E_mod : _O_mod;
@@ -5669,13 +5656,13 @@ struct _Chrono_formatter {
 
     template <class _FormatContext, class _Ty>
     _NODISCARD auto _Write(_FormatContext& _FormatCtx, const _Ty& _Val, const tm& _Time) {
-        basic_stringstream<_CharT> _Stream;
+        basic_ostringstream<_CharT> _Stream;
 
         if (_No_chrono_specs) {
             _Stream << _Val;
         } else {
             _Stream.imbue(_FormatCtx.locale());
-            if constexpr (_CHRONO _Is_hh_mm_ss<_Ty>) {
+            if constexpr (_Is_specialization_v<_Ty, _CHRONO hh_mm_ss>) {
                 if (_Val.is_negative()) {
                     _Stream << _CharT{'-'};
                 }
@@ -5694,7 +5681,7 @@ struct _Chrono_formatter {
                 } else if (_Spec._Modifier == '\0') {
                     if (_CHRONO _Try_simple_write(_Stream, _Spec._Type, _Time)) {
                         continue;
-                    } else if constexpr (_CHRONO _Is_hh_mm_ss<_Ty>) {
+                    } else if constexpr (_Is_specialization_v<_Ty, _CHRONO hh_mm_ss>) {
                         if (_Spec._Type == 'S') {
                             _CHRONO _Write_seconds(_Stream, _Val);
                             continue;
@@ -5864,8 +5851,7 @@ inline namespace literals {
             return _CHRONO duration<double>(_Val);
         }
 
-        _NODISCARD constexpr _CHRONO milliseconds operator"" ms(unsigned long long _Val) noexcept
-        /* strengthened */ {
+        _NODISCARD constexpr _CHRONO milliseconds operator"" ms(unsigned long long _Val) noexcept /* strengthened */ {
             return _CHRONO milliseconds(_Val);
         }
 
@@ -5874,8 +5860,7 @@ inline namespace literals {
             return _CHRONO duration<double, milli>(_Val);
         }
 
-        _NODISCARD constexpr _CHRONO microseconds operator"" us(unsigned long long _Val) noexcept
-        /* strengthened */ {
+        _NODISCARD constexpr _CHRONO microseconds operator"" us(unsigned long long _Val) noexcept /* strengthened */ {
             return _CHRONO microseconds(_Val);
         }
 
@@ -5884,8 +5869,7 @@ inline namespace literals {
             return _CHRONO duration<double, micro>(_Val);
         }
 
-        _NODISCARD constexpr _CHRONO nanoseconds operator"" ns(unsigned long long _Val) noexcept
-        /* strengthened */ {
+        _NODISCARD constexpr _CHRONO nanoseconds operator"" ns(unsigned long long _Val) noexcept /* strengthened */ {
             return _CHRONO nanoseconds(_Val);
         }
 
@@ -5907,6 +5891,8 @@ inline namespace literals {
 namespace chrono {
     using namespace literals::chrono_literals;
 } // namespace chrono
+
+#undef _STATICALLY_WIDEN
 
 _STD_END
 #pragma pop_macro("new")

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -1433,6 +1433,18 @@ namespace chrono {
             return _Day >= _CHRONO day{1} && _Day <= _Last_day(_Year, _Month);
         }
 
+        _NODISCARD constexpr int _Calculate_weekday() const noexcept {
+            const int _Day_int   = static_cast<int>(static_cast<unsigned int>(_Day));
+            const int _Month_int = static_cast<int>(static_cast<unsigned int>(_Month));
+
+            const int _Era_year = static_cast<int>(_Year) - (_Month_int <= 2);
+            const int _Era      = (_Era_year >= 0 ? _Era_year : _Era_year - 399) / 400;
+            const int _Yoe      = _Era_year - _Era * 400;
+            const int _Yday_era = ((979 * (_Month_int + (_Month_int > 2 ? -3 : 9)) + 19) >> 5) + _Day_int - 1;
+            const int _Doe      = ((1461 * _Yoe) >> 2) - _Yoe / 100 + _Yday_era;
+            return (_Doe + 3) % 7; // the era began on a Wednesday
+        }
+
     private:
         _CHRONO year _Year;
         _CHRONO month _Month;
@@ -5643,9 +5655,12 @@ struct _Chrono_formatter {
             return _Type == 'b' || _Type == 'B' || _Type == 'h' || _Type == 'm';
         } else if constexpr (is_same_v<_Ty, _CHRONO year>) {
             return _Type == 'Y' || _Type == 'y' || _Type == 'C';
+        } else if constexpr (is_same_v<_Ty, _CHRONO weekday>) {
+            return _Type == 'a' || _Type == 'A' || _Type == 'u' || _Type == 'w';
         } else if constexpr (is_same_v<_Ty, _CHRONO year_month_day>) {
             return _Type == 'D' || _Type == 'F' || _Is_valid_type<_CHRONO year>(_Type)
-                || _Is_valid_type<_CHRONO month>(_Type) || _Is_valid_type<_CHRONO day>(_Type);
+                || _Is_valid_type<_CHRONO month>(_Type) || _Is_valid_type<_CHRONO day>(_Type)
+                || _Is_valid_type<_CHRONO weekday>(_Type);
         } else {
             // TRANSITION, remove when all types are added
             static_assert(_Always_false<_Ty>, "unsupported type");
@@ -5784,7 +5799,8 @@ struct formatter<_CHRONO year_month_day, _CharT> {
     auto format(const _CHRONO year_month_day& _Val, _FormatContext& _FormatCtx) {
         const tm _Time = {.tm_mday = static_cast<int>(static_cast<unsigned int>(_Val.day())),
             .tm_mon                = static_cast<int>(static_cast<unsigned int>(_Val.month())) - 1,
-            .tm_year               = static_cast<int>(_Val.year()) - 1900};
+            .tm_year               = static_cast<int>(_Val.year()) - 1900,
+            .tm_wday               = _Val._Calculate_weekday()};
         return _Impl._Write(_FormatCtx, _Val, _Time);
     }
 

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -5473,7 +5473,7 @@ namespace chrono {
     template <class _CharT, class _Traits, class _Duration>
     void _Write_seconds(basic_ostream<_CharT, _Traits>& _Os, const hh_mm_ss<_Duration>& _Val) {
         _Os << format(_STATICALLY_WIDEN(_CharT, "{:02}"), _Val.seconds().count());
-        if constexpr (_Val.fractional_width > 0) {
+        if constexpr (hh_mm_ss<_Duration>::fractional_width > 0) {
             _Os << format(_STATICALLY_WIDEN(_CharT, "{0}{1:0{2}}"),
                 _STD use_facet<numpunct<_CharT>>(_Os.getloc()).decimal_point(), _Val.subseconds().count(),
                 _Val.fractional_width);
@@ -5660,7 +5660,7 @@ struct _Chrono_formatter {
             _Stream << _Val;
         } else {
             _Stream.imbue(_FormatCtx.locale());
-            if constexpr (_Is_hh_mm_ss<_Ty>) {
+            if constexpr (_CHRONO _Is_hh_mm_ss<_Ty>) {
                 if (_Val.is_negative()) {
                     _Stream << _CharT{'-'};
                 }
@@ -5679,7 +5679,7 @@ struct _Chrono_formatter {
                 } else if (_Spec._Modifier == '\0') {
                     if (_CHRONO _Try_simple_write(_Stream, _Spec._Type, _Time)) {
                         continue;
-                    } else if constexpr (_Is_hh_mm_ss<_Ty>) {
+                    } else if constexpr (_CHRONO _Is_hh_mm_ss<_Ty>) {
                         if (_Spec._Type == 'S') {
                             _CHRONO _Write_seconds(_Stream, _Val);
                             continue;

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -2204,6 +2204,12 @@ namespace chrono {
         precision _Sub_secs;
     };
 
+    template <class _Ty>
+    constexpr inline bool _Is_hh_mm_ss = false;
+
+    template <class _Duration>
+    constexpr inline bool _Is_hh_mm_ss<hh_mm_ss<_Duration>> = true;
+
     _NODISCARD constexpr bool is_am(const hours& _Hours) noexcept {
         return _Hours >= hours{0} && _Hours <= hours{11};
     }
@@ -5464,6 +5470,16 @@ namespace chrono {
         }
     }
 
+    template <class _CharT, class _Traits, class _Duration>
+    void _Write_seconds(basic_ostream<_CharT, _Traits>& _Os, const hh_mm_ss<_Duration>& _Val) {
+        _Os << format(_STATICALLY_WIDEN(_CharT, "{:02}"), _Val.seconds().count());
+        if constexpr (_Val.fractional_width > 0) {
+            _Os << format(_STATICALLY_WIDEN(_CharT, "{0}{1:0{2}}"),
+                _STD use_facet<numpunct<_CharT>>(_Os.getloc()).decimal_point(), _Val.subseconds().count(),
+                _Val.fractional_width);
+        }
+    }
+
     /*
     template <class _CharT, class _Traits, class _Duration>
     // clang-format off
@@ -5525,6 +5541,18 @@ namespace chrono {
         if (!_Val.ok()) {
             _Os << _STATICALLY_WIDEN(_CharT, " is not a valid date");
         }
+        return _Os;
+    }
+
+    template <class _CharT, class _Traits, class _Duration>
+    basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const hh_mm_ss<_Duration>& _Val) {
+        const tm _Time = {
+            .tm_min = static_cast<int>(_Val.minutes().count()), .tm_hour = static_cast<int>(_Val.hours().count())};
+        if (_Val.is_negative()) {
+            _Os << _CharT{'-'};
+        }
+        _Os << _STD put_time(&_Time, _STATICALLY_WIDEN(_CharT, "%H:%M:"));
+        _Write_seconds(_Os, _Val);
         return _Os;
     }
 } // namespace chrono
@@ -5632,6 +5660,12 @@ struct _Chrono_formatter {
             _Stream << _Val;
         } else {
             _Stream.imbue(_FormatCtx.locale());
+            if constexpr (_Is_hh_mm_ss<_Ty>) {
+                if (_Val.is_negative()) {
+                    _Stream << _CharT{'-'};
+                }
+            }
+
             for (const auto& _Spec : _Specs._Chrono_specs_list) {
                 if (_Spec._Lit_char != _CharT{'\0'}) {
                     _Stream << _Spec._Lit_char;
@@ -5642,8 +5676,15 @@ struct _Chrono_formatter {
                     if (!_Val.ok()) {
                         _THROW(format_error("Cannot localize out-of-bounds time point."));
                     }
-                } else if (_Spec._Modifier == '\0' && _CHRONO _Try_simple_write(_Stream, _Spec._Type, _Time)) {
-                    continue;
+                } else if (_Spec._Modifier == '\0') {
+                    if (_CHRONO _Try_simple_write(_Stream, _Spec._Type, _Time)) {
+                        continue;
+                    } else if constexpr (_Is_hh_mm_ss<_Ty>) {
+                        if (_Spec._Type == 'S') {
+                            _CHRONO _Write_seconds(_Stream, _Val);
+                            continue;
+                        }
+                    }
                 }
 
                 _CharT _Fmt_str[4];

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -5464,6 +5464,10 @@ namespace chrono {
             _Month = static_cast<unsigned int>(_Val);
         } else if constexpr (is_same_v<_Ty, year>) {
             _Year = static_cast<int>(_Val);
+        } else if constexpr (is_same_v<_Ty, weekday>) {
+            _Weekday = static_cast<int>(_Val.c_encoding());
+        } else if constexpr (is_same_v<_Ty, weekday_indexed>) {
+            _Weekday = static_cast<int>(_Val.weekday().c_encoding());
         } else if constexpr (is_same_v<_Ty, month_day>) {
             _Day   = static_cast<unsigned int>(_Val.day());
             _Month = static_cast<unsigned int>(_Val.month());
@@ -5744,7 +5748,7 @@ struct _Chrono_formatter {
             return _Type == 'b' || _Type == 'B' || _Type == 'h' || _Type == 'm';
         } else if constexpr (is_same_v<_Ty, _CHRONO year>) {
             return _Type == 'Y' || _Type == 'y' || _Type == 'C';
-        } else if constexpr (is_same_v<_Ty, _CHRONO weekday>) {
+        } else if constexpr (_Is_any_of_v<_Ty, _CHRONO weekday, _CHRONO weekday_indexed>) {
             return _Type == 'a' || _Type == 'A' || _Type == 'u' || _Type == 'w';
         } else if constexpr (_Is_any_of_v<_Ty, _CHRONO month_day, _CHRONO month_day_last>) {
             return _Is_valid_type<_CHRONO month>(_Type) || _Is_valid_type<_CHRONO day>(_Type);
@@ -5953,6 +5957,14 @@ struct formatter<_CHRONO year, _CharT> //
     : _Fill_tm_formatter<_CHRONO year, _CharT> {};
 
 template <class _CharT>
+struct formatter<_CHRONO weekday, _CharT> //
+    : _Fill_tm_formatter<_CHRONO weekday, _CharT> {};
+
+template <class _CharT>
+struct formatter<_CHRONO weekday_indexed, _CharT> //
+    : _Fill_tm_formatter<_CHRONO weekday_indexed, _CharT> {};
+
+template <class _CharT>
 struct formatter<_CHRONO month_day, _CharT> //
     : _Fill_tm_formatter<_CHRONO month_day, _CharT> {};
 
@@ -6105,7 +6117,6 @@ private:
 template <class _Duration, class _CharT>
 struct formatter<_CHRONO local_time<_Duration>, _CharT> //
     : _Fill_tm_formatter<_CHRONO local_time<_Duration>, _CharT> {};
-
 
 #endif // __cpp_lib_concepts
 #endif // _HAS_CXX20

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -5503,6 +5503,7 @@ namespace chrono {
         unsigned int _Day   = 0;
         unsigned int _Month = 0;
         int _Year           = 0;
+        int _Yearday        = 0;
         int _Weekday        = 0;
         int _Hours          = 0;
         int _Minutes        = 0;
@@ -5526,9 +5527,17 @@ namespace chrono {
         } else if constexpr (is_same_v<_Ty, month_day>) {
             _Day   = static_cast<unsigned int>(_Val.day());
             _Month = static_cast<unsigned int>(_Val.month());
+            if (_Val.month() == January) {
+                _Yearday = static_cast<int>(_Day) - 1;
+            } else if (_Val.month() == February) {
+                _Yearday = 31 + static_cast<int>(_Day) - 1;
+            }
         } else if constexpr (is_same_v<_Ty, month_day_last>) {
             _Month = static_cast<unsigned int>(_Val.month());
             _Day   = static_cast<unsigned int>(_Last_day_table[(_Month - 1) & 0xF]);
+            if (_Val.month() == January) {
+                _Yearday = 30;
+            }
         } else if constexpr (is_same_v<_Ty, month_weekday>) {
             _Month   = static_cast<unsigned int>(_Val.month());
             _Weekday = static_cast<int>(_Val.weekday_indexed().weekday().c_encoding());
@@ -5538,21 +5547,19 @@ namespace chrono {
         } else if constexpr (is_same_v<_Ty, year_month>) {
             _Month = static_cast<unsigned int>(_Val.month());
             _Year  = static_cast<int>(_Val.year());
-        } else if constexpr (is_same_v<_Ty, year_month_day>) {
-            _Day     = static_cast<unsigned int>(_Val.day());
-            _Month   = static_cast<unsigned int>(_Val.month());
-            _Year    = static_cast<int>(_Val.year());
-            _Weekday = _Val._Calculate_weekday();
-        } else if constexpr (is_same_v<_Ty, year_month_day_last>) {
-            _Day     = static_cast<unsigned int>(_Val.day());
-            _Month   = static_cast<unsigned int>(_Val.month());
-            _Year    = static_cast<int>(_Val.year());
-            _Weekday = year_month_day{_Val}._Calculate_weekday();
+        } else if constexpr (_Is_any_of_v<_Ty, year_month_day, year_month_day_last>) {
+            _Day   = static_cast<unsigned int>(_Val.day());
+            _Month = static_cast<unsigned int>(_Val.month());
+            _Year  = static_cast<int>(_Val.year());
+            if (_Val.ok()) {
+                const year_month_day& _Ymd = _Val;
+                _Weekday                   = _Ymd._Calculate_weekday();
+                _Yearday = (static_cast<sys_days>(_Val) - static_cast<sys_days>(_Val.year() / January / 1)).count();
+            }
         } else if constexpr (_Is_any_of_v<_Ty, year_month_weekday, year_month_weekday_last>) {
-            _Day     = static_cast<unsigned int>(year_month_day{_Val}.day());
-            _Month   = static_cast<unsigned int>(_Val.month());
-            _Year    = static_cast<int>(_Val.year());
-            _Weekday = static_cast<int>(_Val.weekday().c_encoding());
+            auto _Tm    = _Fill_tm(year_month_day{_Val});
+            _Tm.tm_wday = static_cast<int>(_Val.weekday().c_encoding());
+            return _Tm;
         } else if constexpr (_Is_specialization_v<_Ty, hh_mm_ss>) {
             _Hours   = _Val.hours().count();
             _Minutes = _Val.minutes().count();
@@ -5578,6 +5585,7 @@ namespace chrono {
         _Time.tm_mday = static_cast<int>(_Day);
         _Time.tm_mon  = static_cast<int>(_Month) - 1;
         _Time.tm_year = _Year - 1900;
+        _Time.tm_yday = _Yearday;
         _Time.tm_wday = _Weekday;
         return _Time;
     }
@@ -5881,15 +5889,15 @@ namespace chrono {
             } else if constexpr (_Is_any_of_v<_Ty, weekday, weekday_indexed, weekday_last>) {
                 return _Type == 'a' || _Type == 'A' || _Type == 'u' || _Type == 'w';
             } else if constexpr (_Is_any_of_v<_Ty, month_day, month_day_last>) {
-                return _Is_valid_type<month>(_Type) || _Is_valid_type<day>(_Type);
+                return _Type == 'j' || _Is_valid_type<month>(_Type) || _Is_valid_type<day>(_Type);
             } else if constexpr (_Is_any_of_v<_Ty, month_weekday, month_weekday_last>) {
                 return _Is_valid_type<month>(_Type) || _Is_valid_type<weekday>(_Type);
             } else if constexpr (is_same_v<_Ty, year_month>) {
                 return _Is_valid_type<year>(_Type) || _Is_valid_type<month>(_Type);
             } else if constexpr (_Is_any_of_v<_Ty, year_month_day, year_month_day_last, year_month_weekday,
                                      year_month_weekday_last>) {
-                return _Type == 'D' || _Type == 'F' || _Is_valid_type<year>(_Type) || _Is_valid_type<month>(_Type)
-                    || _Is_valid_type<day>(_Type) || _Is_valid_type<weekday>(_Type);
+                return _Type == 'D' || _Type == 'F' || _Type == 'j' || _Is_valid_type<year>(_Type)
+                    || _Is_valid_type<month>(_Type) || _Is_valid_type<day>(_Type) || _Is_valid_type<weekday>(_Type);
             } else if constexpr (_Is_specialization_v<_Ty, hh_mm_ss>) {
                 return _Type == 'H' || _Type == 'I' || _Type == 'M' || _Type == 'S' || _Type == 'r' || _Type == 'R'
                     || _Type == 'T' || _Type == 'p';
@@ -5947,16 +5955,7 @@ namespace chrono {
                         }
                     }
 
-                    _CharT _Fmt_str[4];
-                    size_t _Next_idx      = 0;
-                    _Fmt_str[_Next_idx++] = _CharT{'%'};
-                    if (_Spec._Modifier != '\0') {
-                        _Fmt_str[_Next_idx++] = static_cast<_CharT>(_Spec._Modifier);
-                    }
-                    _Fmt_str[_Next_idx++] = static_cast<_CharT>(_Spec._Type);
-                    _Fmt_str[_Next_idx]   = _CharT{'\0'};
-
-                    _Stream << _STD put_time<_CharT>(&_Time, _Fmt_str);
+                    _Stream << _STD put_time<_CharT>(&_Time, _Fmt_string(_Spec).data());
                 }
             }
 
@@ -5981,6 +5980,22 @@ namespace chrono {
             const auto _Month        = _Time.tm_mon + 1;
             const bool _Has_modifier = _Spec._Modifier != '\0';
             switch (_Spec._Type) {
+            case 'a':
+            case 'A':
+            case 'u':
+            case 'w':
+                if constexpr (_Is_any_of_v<_Ty, year_month_weekday, year_month_weekday_last>) {
+                    if (!_Val.weekday().ok()) {
+                        _THROW(format_error("Cannot print invalid weekday"));
+                    }
+                    _Os << _STD put_time(&_Time, _Fmt_string(_Spec).data());
+                    return true;
+                } else if constexpr (_Has_ok<_Ty>) {
+                    if (!_Val.ok()) {
+                        _THROW(format_error("Cannot print invalid weekday"));
+                    }
+                }
+                return false;
             case 'd':
             case 'e':
                 // Most months have a proper last day, but February depends on the year.
@@ -6002,8 +6017,22 @@ namespace chrono {
             case 'j':
                 if constexpr (_Is_specialization_v<_Ty, duration>) {
                     _Os << _STD abs(_CHRONO duration_cast<days>(_Val).count());
+                    return true;
+                } else if constexpr (is_same_v<_Ty, month_day>) {
+                    if (_Val.month() > February) {
+                        _THROW(format_error("The day of year for a month_day past February is ambiguous."));
+                    }
+                } else if constexpr (is_same_v<_Ty, month_day_last>) {
+                    if (_Val.month() >= February) {
+                        _THROW(format_error("The day of year for a month_day_last other than January is ambiguous"));
+                    }
                 }
-                return true;
+                if constexpr (_Has_ok<_Ty>) {
+                    if (!_Val.ok()) {
+                        _THROW(format_error("Cannot print invalid day of year"));
+                    }
+                }
+                return false;
             case 'q':
                 if constexpr (_Is_specialization_v<_Ty, duration>) {
                     _Write_unit_suffix<typename _Ty::period>(_Os);
@@ -6125,6 +6154,18 @@ namespace chrono {
             default:
                 return false;
             }
+        }
+
+        _NODISCARD array<_CharT, 4> _Fmt_string(const _Chrono_spec<_CharT>& _Spec) {
+            array<_CharT, 4> _Fmt_str;
+            size_t _Next_idx      = 0;
+            _Fmt_str[_Next_idx++] = _CharT{'%'};
+            if (_Spec._Modifier != '\0') {
+                _Fmt_str[_Next_idx++] = static_cast<_CharT>(_Spec._Modifier);
+            }
+            _Fmt_str[_Next_idx++] = static_cast<_CharT>(_Spec._Type);
+            _Fmt_str[_Next_idx]   = _CharT{'\0'};
+            return _Fmt_str;
         }
 
         _Chrono_format_specs<_CharT> _Specs{};

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -5501,7 +5501,7 @@ namespace chrono {
     }*/
 
     template <class _Ty>
-    tm _Fill_tm(const _Ty& _Val) {
+    _NODISCARD tm _Fill_tm(const _Ty& _Val) {
         unsigned int _Day   = 0;
         unsigned int _Month = 0;
         int _Year           = 0;
@@ -5521,6 +5521,21 @@ namespace chrono {
             _Month   = static_cast<unsigned int>(_Val.month());
             _Year    = static_cast<int>(_Val.year());
             _Weekday = _Val._Calculate_weekday();
+        } else if constexpr (is_same_v<_Ty, year_month_day_last>) {
+            _Day     = static_cast<unsigned int>(_Val.day());
+            _Month   = static_cast<unsigned int>(_Val.month());
+            _Year    = static_cast<int>(_Val.year());
+            _Weekday = year_month_day{_Val}._Calculate_weekday();
+        } else if constexpr (is_same_v<_Ty, year_month_weekday>) {
+            _Day     = static_cast<unsigned int>(year_month_day{_Val}.day());
+            _Month   = static_cast<unsigned int>(_Val.month());
+            _Year    = static_cast<int>(_Val.year());
+            _Weekday = static_cast<int>(_Val.weekday().c_encoding());
+        } else if constexpr (is_same_v<_Ty, year_month_weekday_last>) {
+            _Day     = static_cast<unsigned int>(year_month_day{_Val}.day());
+            _Month   = static_cast<unsigned int>(_Val.month());
+            _Year    = static_cast<int>(_Val.year());
+            _Weekday = static_cast<int>(_Val.weekday().c_encoding());
         } else if constexpr (_Is_specialization_v<_Ty, hh_mm_ss>) {
             _Hours   = _Val.hours().count();
             _Minutes = _Val.minutes().count();
@@ -5540,50 +5555,97 @@ namespace chrono {
 
     template <class _CharT, class _Traits>
     basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const day& _Val) {
-        _Try_simple_write(_Os, 'd', _Fill_tm(_Val));
-        if (!_Val.ok()) {
-            _Os << _STATICALLY_WIDEN(_CharT, " is not a valid day");
-        }
-
-        return _Os;
+        return _Os << (_Val.ok() ? _STD format(_STATICALLY_WIDEN(_CharT, "{:%d}"), _Val)
+                                 : _STD format(_STATICALLY_WIDEN(_CharT, "{:%d} is not a valid day"), _Val));
     }
 
     template <class _CharT, class _Traits>
     basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const month& _Val) {
-        if (_Val.ok()) {
-            const tm _Time = _Fill_tm(_Val);
-            return _Os << _STD put_time(&_Time, _STATICALLY_WIDEN(_CharT, "%b"));
-        }
-        return _Os << static_cast<unsigned int>(_Val) << _STATICALLY_WIDEN(_CharT, " is not a valid month");
+        return _Os << (_Val.ok() ? _STD format(_Os.getloc(), _STATICALLY_WIDEN(_CharT, "{:%b}"), _Val)
+                                 : _STD format(_Os.getloc(), _STATICALLY_WIDEN(_CharT, "{} is not a valid month"),
+                                     static_cast<unsigned int>(_Val)));
     }
 
     template <class _CharT, class _Traits>
     basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const year& _Val) {
-        _Try_simple_write(_Os, 'Y', _Fill_tm(_Val));
-        if (!_Val.ok()) {
-            _Os << _STATICALLY_WIDEN(_CharT, " is not a valid year");
-        }
-        return _Os;
+        return _Os << (_Val.ok() ? _STD format(_STATICALLY_WIDEN(_CharT, "{:%Y}"), _Val)
+                                 : _STD format(_STATICALLY_WIDEN(_CharT, "{:%Y} is not a valid year"), _Val));
+    }
+
+    template <class _CharT, class _Traits>
+    basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const weekday& _Val) {
+        return _Os << (_Val.ok() ? _STD format(_Os.getloc(), _STATICALLY_WIDEN(_CharT, "{:%a}"), _Val)
+                                 : _STD format(_Os.getloc(), _STATICALLY_WIDEN(_CharT, "{} is not a valid weekday"),
+                                     _Val.c_encoding()));
+    }
+
+    template <class _CharT, class _Traits>
+    basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const weekday_indexed& _Val) {
+        const auto _Idx = _Val.index();
+        return _Os << (_Idx >= 1 && _Idx <= 5
+                           ? _STD format(_Os.getloc(), _STATICALLY_WIDEN(_CharT, "{}[{}]"), _Val.weekday(), _Idx)
+                           : _STD format(_Os.getloc(), _STATICALLY_WIDEN(_CharT, "{}[{} is not a valid index]"),
+                               _Val.weekday(), _Idx));
+    }
+
+    template <class _CharT, class _Traits>
+    basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const weekday_last& _Val) {
+        return _Os << _STD format(_Os.getloc(), _STATICALLY_WIDEN(_CharT, "{}[last]"), _Val.weekday());
+    }
+
+    template <class _CharT, class _Traits>
+    basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const month_day& _Val) {
+        return _Os << _STD format(_Os.getloc(), _STATICALLY_WIDEN(_CharT, "{}/{}"), _Val.month(), _Val.day());
+    }
+
+    template <class _CharT, class _Traits>
+    basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const month_day_last& _Val) {
+        return _Os << _STD format(_Os.getloc(), _STATICALLY_WIDEN(_CharT, "{}/last"), _Val.month());
+    }
+
+    template <class _CharT, class _Traits>
+    basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const month_weekday& _Val) {
+        return _Os << _STD format(
+                   _Os.getloc(), _STATICALLY_WIDEN(_CharT, "{}/{}"), _Val.month(), _Val.weekday_indexed());
+    }
+
+    template <class _CharT, class _Traits>
+    basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const month_weekday_last& _Val) {
+        return _Os << _STD format(_Os.getloc(), _STATICALLY_WIDEN(_CharT, "{}/{}"), _Val.month(), _Val.weekday_last());
+    }
+
+    template <class _CharT, class _Traits>
+    basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const year_month& _Val) {
+        return _Os << _STD format(_Os.getloc(), _STATICALLY_WIDEN(_CharT, "{}/{}"), _Val.year(), _Val.month());
     }
 
     template <class _CharT, class _Traits>
     basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const year_month_day& _Val) {
-        _Try_simple_write(_Os, 'F', _Fill_tm(_Val));
-        if (!_Val.ok()) {
-            _Os << _STATICALLY_WIDEN(_CharT, " is not a valid date");
-        }
-        return _Os;
+        return _Os << (_Val.ok() ? _STD format(_STATICALLY_WIDEN(_CharT, "{:%F}"), _Val)
+                                 : _STD format(_STATICALLY_WIDEN(_CharT, "{:%F} is not a valid date"), _Val));
+    }
+
+    template <class _CharT, class _Traits>
+    basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const year_month_day_last& _Val) {
+        return _Os << _STD format(_Os.getloc(), _STATICALLY_WIDEN(_CharT, "{}/{}"), _Val.year(), _Val.month_day_last());
+    }
+
+    template <class _CharT, class _Traits>
+    basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const year_month_weekday& _Val) {
+        return _Os << _STD format(_Os.getloc(), _STATICALLY_WIDEN(_CharT, "{}/{}/{}"), _Val.year(), _Val.month(),
+                   _Val.weekday_indexed());
+    }
+
+    template <class _CharT, class _Traits>
+    basic_ostream<_CharT, _Traits>& operator<<(
+        basic_ostream<_CharT, _Traits>& _Os, const year_month_weekday_last& _Val) {
+        return _Os << _STD format(
+                   _Os.getloc(), _STATICALLY_WIDEN(_CharT, "{}/{}/{}"), _Val.year(), _Val.month(), _Val.weekday_last());
     }
 
     template <class _CharT, class _Traits, class _Duration>
     basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const hh_mm_ss<_Duration>& _Val) {
-        const tm _Time = _Fill_tm(_Val);
-        if (_Val.is_negative()) {
-            _Os << _CharT{'-'};
-        }
-        _Os << _STD put_time(&_Time, _STATICALLY_WIDEN(_CharT, "%H:%M:"));
-        _Write_seconds(_Os, _Val);
-        return _Os;
+        return _Os << _STD format(_Os.getloc(), _STATICALLY_WIDEN(_CharT, "{:%T}"), _Val);
     }
 } // namespace chrono
 
@@ -5694,7 +5756,8 @@ struct _Chrono_formatter {
             return _Type == 'Y' || _Type == 'y' || _Type == 'C';
         } else if constexpr (is_same_v<_Ty, _CHRONO weekday>) {
             return _Type == 'a' || _Type == 'A' || _Type == 'u' || _Type == 'w';
-        } else if constexpr (is_same_v<_Ty, _CHRONO year_month_day>) {
+        } else if constexpr (_Is_any_of_v<_Ty, _CHRONO year_month_day, _CHRONO year_month_day_last,
+                                 _CHRONO year_month_weekday, _CHRONO year_month_weekday_last>) {
             return _Type == 'D' || _Type == 'F' || _Is_valid_type<_CHRONO year>(_Type)
                 || _Is_valid_type<_CHRONO month>(_Type) || _Is_valid_type<_CHRONO day>(_Type)
                 || _Is_valid_type<_CHRONO weekday>(_Type);
@@ -5761,14 +5824,14 @@ struct _Chrono_formatter {
     bool _No_chrono_specs = false;
 };
 
-template <class _CharT>
-struct formatter<_CHRONO day, _CharT> {
+template <class _Ty, class _CharT>
+struct _Fill_tm_formatter {
     auto parse(basic_format_parse_context<_CharT>& _Parse_ctx) {
-        return _Impl.template _Parse<_CHRONO day>(_Parse_ctx);
+        return _Impl.template _Parse<_Ty>(_Parse_ctx);
     }
 
     template <class _FormatContext>
-    auto format(const _CHRONO day& _Val, _FormatContext& _FormatCtx) {
+    auto format(const _Ty& _Val, _FormatContext& _FormatCtx) {
         return _Impl._Write(_FormatCtx, _Val, _Fill_tm(_Val));
     }
 
@@ -5777,49 +5840,33 @@ private:
 };
 
 template <class _CharT>
-struct formatter<_CHRONO month, _CharT> {
-    auto parse(basic_format_parse_context<_CharT>& _Parse_ctx) {
-        return _Impl.template _Parse<_CHRONO month>(_Parse_ctx);
-    }
-
-    template <class _FormatContext>
-    auto format(const _CHRONO month& _Val, _FormatContext& _FormatCtx) {
-        return _Impl._Write(_FormatCtx, _Val, _Fill_tm(_Val));
-    }
-
-private:
-    _Chrono_formatter<_CharT, false> _Impl;
-};
+struct formatter<_CHRONO day, _CharT> //
+    : _Fill_tm_formatter<_CHRONO day, _CharT> {};
 
 template <class _CharT>
-struct formatter<_CHRONO year, _CharT> {
-    auto parse(basic_format_parse_context<_CharT>& _Parse_ctx) {
-        return _Impl.template _Parse<_CHRONO year>(_Parse_ctx);
-    }
-
-    template <class _FormatContext>
-    auto format(const _CHRONO year& _Val, _FormatContext& _FormatCtx) {
-        return _Impl._Write(_FormatCtx, _Val, _Fill_tm(_Val));
-    }
-
-private:
-    _Chrono_formatter<_CharT, false> _Impl;
-};
+struct formatter<_CHRONO month, _CharT> //
+    : _Fill_tm_formatter<_CHRONO month, _CharT> {};
 
 template <class _CharT>
-struct formatter<_CHRONO year_month_day, _CharT> {
-    auto parse(basic_format_parse_context<_CharT>& _Parse_ctx) {
-        return _Impl.template _Parse<_CHRONO year_month_day>(_Parse_ctx);
-    }
+struct formatter<_CHRONO year, _CharT> //
+    : _Fill_tm_formatter<_CHRONO year, _CharT> {};
 
-    template <class _FormatContext>
-    auto format(const _CHRONO year_month_day& _Val, _FormatContext& _FormatCtx) {
-        return _Impl._Write(_FormatCtx, _Val, _Fill_tm(_Val));
-    }
+template <class _CharT>
+struct formatter<_CHRONO year_month_day, _CharT> //
+    : _Fill_tm_formatter<_CHRONO year_month_day, _CharT> {};
 
-private:
-    _Chrono_formatter<_CharT, false> _Impl;
-};
+template <class _CharT>
+struct formatter<_CHRONO year_month_day_last, _CharT> //
+    : _Fill_tm_formatter<_CHRONO year_month_day_last, _CharT> {};
+
+template <class _CharT>
+struct formatter<_CHRONO year_month_weekday, _CharT> //
+    : _Fill_tm_formatter<_CHRONO year_month_weekday, _CharT> {};
+
+template <class _CharT>
+struct formatter<_CHRONO year_month_weekday_last, _CharT>
+    : _Fill_tm_formatter<_CHRONO year_month_weekday_last, _CharT> {};
+
 #endif // __cpp_lib_concepts
 #endif // _HAS_CXX20
 

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -2266,16 +2266,38 @@ namespace chrono {
     class nonexistent_local_time : public runtime_error {
     public:
         template <class _Duration>
-        nonexistent_local_time(const local_time<_Duration>&, const local_info&)
-            : runtime_error("TRANSITION: work in progress") {}
+        nonexistent_local_time(const local_time<_Duration>& _Tp, const local_info& _Info)
+            : runtime_error(_Make_string(_Tp, _Info)) {}
+
+    private:
+#ifdef __cpp_lib_concepts
+        template <class _Duration>
+        _NODISCARD static string _Make_string(const local_time<_Duration>& _Tp, const local_info& _Info);
+#else // ^^^ no workaround / workaround vvv
+        template <class _Duration>
+        _NODISCARD static string _Make_string(const local_time<_Duration>&, const local_info&) {
+            return "nonexistent_local_time";
+        }
+#endif // ^^^ workaround ^^^
     };
 
     // CLASS ambiguous_local_time
     class ambiguous_local_time : public runtime_error {
     public:
         template <class _Duration>
-        ambiguous_local_time(const local_time<_Duration>&, const local_info&)
-            : runtime_error("TRANSITION: work in progress") {}
+        ambiguous_local_time(const local_time<_Duration>& _Tp, const local_info& _Info)
+            : runtime_error(_Make_string(_Tp, _Info)) {}
+
+    private:
+#ifdef __cpp_lib_concepts
+        template <class _Duration>
+        _NODISCARD static string _Make_string(const local_time<_Duration>& _Tp, const local_info& _Info);
+#else // ^^^ no workaround / workaround vvv
+        template <class _Duration>
+        _NODISCARD static string _Make_string(const local_time<_Duration>&, const local_info&) {
+            return "ambiguous_local_time";
+        }
+#endif // ^^^ workaround ^^^
     };
 
     // [time.zone.timezone]
@@ -3180,7 +3202,7 @@ namespace chrono {
 #ifdef __cpp_lib_concepts
             const auto _Leap_cmp = _Utc_leap_second <=> _Time_floor;
 #else // ^^^ __cpp_lib_concepts / TRANSITION, GH-395 workaround vvv
-            const auto _Leap_cmp = _Utc_leap_second > _Time_floor  ? strong_ordering::greater
+            const auto _Leap_cmp = _Utc_leap_second > _Time_floor ? strong_ordering::greater
                                  : _Utc_leap_second == _Time_floor ? strong_ordering::equal
                                                                    : strong_ordering::less;
 #endif // ^^^ workaround
@@ -5921,7 +5943,7 @@ struct _Chrono_formatter {
             return true;
         case 'H':
             if constexpr (_Is_specialization_v<_Ty, _CHRONO hh_mm_ss>) {
-                if (_Val.hours() <= -_CHRONO hours{24} || _CHRONO hours{24} <= _Val.hours()) {
+                if (_Val.hours() >= _CHRONO hours{24}) {
                     _THROW(format_error("Cannot localize hh_mm_ss with an absolute value of 24 hours or more."));
                 }
             }
@@ -6112,6 +6134,29 @@ private:
 template <class _Duration, class _CharT>
 struct formatter<_CHRONO local_time<_Duration>, _CharT> //
     : _Fill_tm_formatter<_CHRONO local_time<_Duration>, _CharT> {};
+
+namespace chrono {
+    template <class _Duration>
+    _NODISCARD string nonexistent_local_time::_Make_string(const local_time<_Duration>& _Tp, const local_info& _Info) {
+        ostringstream _Os;
+        _Os << _Tp << " is in a gap between\n"
+            << local_seconds{_Info.first.end.time_since_epoch()} + _Info.first.offset << ' ' << _Info.first.abbrev
+            << " and\n"
+            << local_seconds{_Info.second.begin.time_since_epoch()} + _Info.second.offset << ' ' << _Info.second.abbrev
+            << " which are both equivalent to\n"
+            << _Info.first.end << " UTC";
+        return _STD move(_Os).str();
+    }
+
+    template <class _Duration>
+    _NODISCARD string ambiguous_local_time::_Make_string(const local_time<_Duration>& _Tp, const local_info& _Info) {
+        ostringstream _Os;
+        _Os << _Tp << " is ambiguous. It could be\n"
+            << _Tp << ' ' << _Info.first.abbrev << " == " << _Tp - _Info.first.offset << " UTC or\n"
+            << _Tp << ' ' << _Info.second.abbrev << " == " << _Tp - _Info.second.offset << " UTC";
+        return _STD move(_Os).str();
+    }
+} // namespace chrono
 
 #endif // __cpp_lib_concepts
 #endif // _HAS_CXX20

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -1598,9 +1598,9 @@ _NODISCARD _OutputIt _Fmt_write(_OutputIt _Out, const basic_string_view<_CharT> 
     return _RANGES copy(_Value, _STD move(_Out)).out;
 }
 
-template <class _CharT, class _OutputIt, class _Func>
-_NODISCARD _OutputIt _Write_aligned(_OutputIt _Out, const int _Width, const _Basic_format_specs<_CharT>& _Specs,
-    const _Fmt_align _Default_align, _Func&& _Fn) {
+template <class _OutputIt, class _Specs_type, class _Func>
+_NODISCARD _OutputIt _Write_aligned(
+    _OutputIt _Out, const int _Width, const _Specs_type& _Specs, const _Fmt_align _Default_align, _Func&& _Fn) {
     int _Fill_left  = 0;
     int _Fill_right = 0;
     auto _Alignment = _Specs._Alignment;
@@ -1627,7 +1627,7 @@ _NODISCARD _OutputIt _Write_aligned(_OutputIt _Out, const int _Width, const _Bas
         }
     }
 
-    const basic_string_view<_CharT> _Fill_char{_Specs._Fill, _Specs._Fill_length};
+    const basic_string_view _Fill_char{_Specs._Fill, _Specs._Fill_length};
     for (; _Fill_left > 0; --_Fill_left) {
         _Out = _RANGES copy(_Fill_char, _STD move(_Out)).out;
     }

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -140,7 +140,6 @@
 // P0325R4 to_array()
 // P0339R6 polymorphic_allocator<>
 // P0355R7 <chrono> Calendars And Time Zones
-//     (partially implemented)
 // P0356R5 bind_front()
 // P0357R3 Supporting Incomplete Types In reference_wrapper
 // P0408R7 Efficient Access To basic_stringbuf's Buffer
@@ -1172,12 +1171,6 @@
 #define __cpp_lib_variant               201606L
 #endif // _HAS_CXX17
 
-#if _HAS_CXX17
-#define __cpp_lib_chrono 201611L // P0505R0 constexpr For <chrono> (Again)
-#else // _HAS_CXX17
-#define __cpp_lib_chrono 201510L // P0092R1 <chrono> floor(), ceil(), round(), abs()
-#endif // _HAS_CXX17
-
 // C++20
 #define __cpp_lib_atomic_value_initialization 201911L
 
@@ -1301,6 +1294,14 @@
 #define __cpp_lib_array_constexpr 201811L // P1032R1 Miscellaneous constexpr
 #elif _HAS_CXX17 // ^^^ _HAS_CXX20 / _HAS_CXX17 vvv
 #define __cpp_lib_array_constexpr 201803L
+#endif // _HAS_CXX17
+
+#if _HAS_CXX20 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
+#define __cpp_lib_chrono 201907L // P1466R3 Miscellaneous Minor Fixes For <chrono>
+#elif _HAS_CXX17
+#define __cpp_lib_chrono 201611L // P0505R0 constexpr For <chrono> (Again)
+#else // _HAS_CXX17
+#define __cpp_lib_chrono 201510L // P0092R1 <chrono> floor(), ceil(), round(), abs()
 #endif // _HAS_CXX17
 
 #if _HAS_CXX20

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -276,14 +276,11 @@ std/utilities/memory/default.allocator/allocator.members/allocate.verify.cpp SKI
 
 # *** MISSING STL FEATURES ***
 # C++20 P0355R7 "<chrono> Calendars And Time Zones"
-std/utilities/time/time.cal/time.cal.md/time.cal.md.nonmembers/streaming.pass.cpp FAIL
-std/utilities/time/time.cal/time.cal.mdlast/streaming.pass.cpp FAIL
 std/utilities/time/time.cal/time.cal.mwd/time.cal.mwd.nonmembers/streaming.pass.cpp FAIL
 std/utilities/time/time.cal/time.cal.mwdlast/time.cal.mwdlast.nonmembers/streaming.pass.cpp FAIL
 std/utilities/time/time.cal/time.cal.wdidx/time.cal.wdidx.nonmembers/streaming.pass.cpp FAIL
 std/utilities/time/time.cal/time.cal.wdlast/time.cal.wdlast.nonmembers/streaming.pass.cpp FAIL
 std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.nonmembers/streaming.pass.cpp FAIL
-std/utilities/time/time.cal/time.cal.ym/time.cal.ym.nonmembers/streaming.pass.cpp FAIL
 std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.nonmembers/streaming.pass.cpp FAIL
 std/utilities/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.nonmembers/streaming.pass.cpp FAIL
 
@@ -878,7 +875,10 @@ std/utilities/function.objects/func.search/func.search.bmh/pred.pass.cpp PASS
 
 # Not yet implemented in libcxx and marked as "XFAIL: *"
 std/utilities/time/time.cal/time.cal.day/time.cal.day.nonmembers/streaming.pass.cpp SKIPPED
+std/utilities/time/time.cal/time.cal.md/time.cal.md.nonmembers/streaming.pass.cpp SKIPPED
+std/utilities/time/time.cal/time.cal.mdlast/streaming.pass.cpp SKIPPED
 std/utilities/time/time.cal/time.cal.month/time.cal.month.nonmembers/streaming.pass.cpp SKIPPED
 std/utilities/time/time.cal/time.cal.year/time.cal.year.nonmembers/streaming.pass.cpp SKIPPED
+std/utilities/time/time.cal/time.cal.ym/time.cal.ym.nonmembers/streaming.pass.cpp SKIPPED
 std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.nonmembers/streaming.pass.cpp SKIPPED
 std/utilities/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.nonmembers/streaming.pass.cpp SKIPPED

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -640,6 +640,9 @@ std/language.support/support.limits/support.limits.general/algorithm.version.pas
 std/language.support/support.limits/support.limits.general/functional.version.pass.cpp FAIL
 std/language.support/support.limits/support.limits.general/iterator.version.pass.cpp FAIL
 
+# Test expects __cpp_lib_chrono to have the old value 201611L for P0505R0; we define the C++20 value 201907L for P1466R3.
+std/language.support/support.limits/support.limits.general/chrono.version.pass.cpp FAIL
+
 # We unconditionally define __cpp_lib_addressof_constexpr; test error says it
 # "should not be defined when TEST_HAS_BUILTIN(__builtin_addressof) || TEST_GCC_VER >= 700 is not defined!"
 std/language.support/support.limits/support.limits.general/memory.version.pass.cpp FAIL

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -283,10 +283,7 @@ std/utilities/time/time.cal/time.cal.mwdlast/time.cal.mwdlast.nonmembers/streami
 std/utilities/time/time.cal/time.cal.wdidx/time.cal.wdidx.nonmembers/streaming.pass.cpp FAIL
 std/utilities/time/time.cal/time.cal.wdlast/time.cal.wdlast.nonmembers/streaming.pass.cpp FAIL
 std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.nonmembers/streaming.pass.cpp FAIL
-std/utilities/time/time.cal/time.cal.year/time.cal.year.nonmembers/streaming.pass.cpp FAIL
 std/utilities/time/time.cal/time.cal.ym/time.cal.ym.nonmembers/streaming.pass.cpp FAIL
-std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.nonmembers/streaming.pass.cpp FAIL
-std/utilities/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.nonmembers/streaming.pass.cpp FAIL
 std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.nonmembers/streaming.pass.cpp FAIL
 std/utilities/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.nonmembers/streaming.pass.cpp FAIL
 
@@ -882,3 +879,6 @@ std/utilities/function.objects/func.search/func.search.bmh/pred.pass.cpp PASS
 # Not yet implemented in libcxx and marked as "XFAIL: *"
 std/utilities/time/time.cal/time.cal.day/time.cal.day.nonmembers/streaming.pass.cpp SKIPPED
 std/utilities/time/time.cal/time.cal.month/time.cal.month.nonmembers/streaming.pass.cpp SKIPPED
+std/utilities/time/time.cal/time.cal.year/time.cal.year.nonmembers/streaming.pass.cpp SKIPPED
+std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.nonmembers/streaming.pass.cpp SKIPPED
+std/utilities/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.nonmembers/streaming.pass.cpp SKIPPED

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -276,11 +276,8 @@ std/utilities/memory/default.allocator/allocator.members/allocate.verify.cpp SKI
 
 # *** MISSING STL FEATURES ***
 # C++20 P0355R7 "<chrono> Calendars And Time Zones"
-std/utilities/time/time.cal/time.cal.mwd/time.cal.mwd.nonmembers/streaming.pass.cpp FAIL
 std/utilities/time/time.cal/time.cal.mwdlast/time.cal.mwdlast.nonmembers/streaming.pass.cpp FAIL
 std/utilities/time/time.cal/time.cal.wdidx/time.cal.wdidx.nonmembers/streaming.pass.cpp FAIL
-std/utilities/time/time.cal/time.cal.wdlast/time.cal.wdlast.nonmembers/streaming.pass.cpp FAIL
-std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.nonmembers/streaming.pass.cpp FAIL
 std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.nonmembers/streaming.pass.cpp FAIL
 std/utilities/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.nonmembers/streaming.pass.cpp FAIL
 
@@ -878,6 +875,9 @@ std/utilities/time/time.cal/time.cal.day/time.cal.day.nonmembers/streaming.pass.
 std/utilities/time/time.cal/time.cal.md/time.cal.md.nonmembers/streaming.pass.cpp SKIPPED
 std/utilities/time/time.cal/time.cal.mdlast/streaming.pass.cpp SKIPPED
 std/utilities/time/time.cal/time.cal.month/time.cal.month.nonmembers/streaming.pass.cpp SKIPPED
+std/utilities/time/time.cal/time.cal.mwd/time.cal.mwd.nonmembers/streaming.pass.cpp SKIPPED
+std/utilities/time/time.cal/time.cal.wdlast/time.cal.wdlast.nonmembers/streaming.pass.cpp SKIPPED
+std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.nonmembers/streaming.pass.cpp SKIPPED
 std/utilities/time/time.cal/time.cal.year/time.cal.year.nonmembers/streaming.pass.cpp SKIPPED
 std/utilities/time/time.cal/time.cal.ym/time.cal.ym.nonmembers/streaming.pass.cpp SKIPPED
 std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.nonmembers/streaming.pass.cpp SKIPPED

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -276,10 +276,8 @@ std/utilities/memory/default.allocator/allocator.members/allocate.verify.cpp SKI
 
 # *** MISSING STL FEATURES ***
 # C++20 P0355R7 "<chrono> Calendars And Time Zones"
-std/utilities/time/time.cal/time.cal.day/time.cal.day.nonmembers/streaming.pass.cpp FAIL
 std/utilities/time/time.cal/time.cal.md/time.cal.md.nonmembers/streaming.pass.cpp FAIL
 std/utilities/time/time.cal/time.cal.mdlast/streaming.pass.cpp FAIL
-std/utilities/time/time.cal/time.cal.month/time.cal.month.nonmembers/streaming.pass.cpp FAIL
 std/utilities/time/time.cal/time.cal.mwd/time.cal.mwd.nonmembers/streaming.pass.cpp FAIL
 std/utilities/time/time.cal/time.cal.mwdlast/time.cal.mwdlast.nonmembers/streaming.pass.cpp FAIL
 std/utilities/time/time.cal/time.cal.wdidx/time.cal.wdidx.nonmembers/streaming.pass.cpp FAIL
@@ -870,7 +868,7 @@ std/re/re.alg/re.alg.search/extended.locale.pass.cpp FAIL
 
 
 # *** XFAILs WHICH PASS ***
-# Not yet implemented in libcxx and marked as XFAIL
+# Not yet implemented in libcxx and marked as "XFAIL: libc++"
 std/strings/c.strings/cuchar.pass.cpp PASS
 std/utilities/function.objects/func.search/func.search.bm/default.pass.cpp PASS
 std/utilities/function.objects/func.search/func.search.bm/hash.pass.cpp PASS
@@ -880,3 +878,7 @@ std/utilities/function.objects/func.search/func.search.bmh/default.pass.cpp PASS
 std/utilities/function.objects/func.search/func.search.bmh/hash.pass.cpp PASS
 std/utilities/function.objects/func.search/func.search.bmh/hash.pred.pass.cpp PASS
 std/utilities/function.objects/func.search/func.search.bmh/pred.pass.cpp PASS
+
+# Not yet implemented in libcxx and marked as "XFAIL: *"
+std/utilities/time/time.cal/time.cal.day/time.cal.day.nonmembers/streaming.pass.cpp SKIPPED
+std/utilities/time/time.cal/time.cal.month/time.cal.month.nonmembers/streaming.pass.cpp SKIPPED

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -275,32 +275,6 @@ std/utilities/memory/default.allocator/allocator.members/allocate.verify.cpp SKI
 
 
 # *** MISSING STL FEATURES ***
-# C++20 P0355R7 "<chrono> Calendars And Time Zones"
-std/utilities/time/time.cal/time.cal.mwdlast/time.cal.mwdlast.nonmembers/streaming.pass.cpp FAIL
-std/utilities/time/time.cal/time.cal.wdidx/time.cal.wdidx.nonmembers/streaming.pass.cpp FAIL
-std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.nonmembers/streaming.pass.cpp FAIL
-std/utilities/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.nonmembers/streaming.pass.cpp FAIL
-
-# C++20 P0466R5 "Layout-Compatibility And Pointer-Interconvertibility Traits"
-std/language.support/support.limits/support.limits.general/type_traits.version.pass.cpp:1 FAIL
-
-# C++20 P0608R3 "Improving variant's Converting Constructor/Assignment"
-std/utilities/variant/variant.variant/variant.assign/conv.pass.cpp FAIL
-std/utilities/variant/variant.variant/variant.assign/T.pass.cpp FAIL
-std/utilities/variant/variant.variant/variant.ctor/conv.pass.cpp FAIL
-std/utilities/variant/variant.variant/variant.ctor/T.pass.cpp FAIL
-
-# C++20 P0784R7 "More constexpr containers"
-std/utilities/memory/allocator.traits/allocator.traits.members/construct.pass.cpp FAIL
-std/utilities/memory/allocator.traits/allocator.traits.members/destroy.pass.cpp FAIL
-std/utilities/memory/specialized.algorithms/specialized.construct/construct_at.pass.cpp FAIL
-
-# C++20 P0896R4 "<ranges>"
-std/language.support/support.limits/support.limits.general/algorithm.version.pass.cpp FAIL
-std/language.support/support.limits/support.limits.general/functional.version.pass.cpp FAIL
-std/language.support/support.limits/support.limits.general/iterator.version.pass.cpp FAIL
-std/language.support/support.limits/support.limits.general/memory.version.pass.cpp FAIL
-
 # C++23 P1048R1 "is_scoped_enum"
 std/utilities/meta/meta.unary/meta.unary.prop/is_scoped_enum.pass.cpp FAIL
 
@@ -651,6 +625,25 @@ std/utilities/allocator.adaptor/allocator.adaptor.members/construct_pair_rvalue.
 std/utilities/allocator.adaptor/allocator.adaptor.members/construct_pair_values.pass.cpp FAIL
 std/utilities/allocator.adaptor/allocator.adaptor.members/construct_type.pass.cpp FAIL
 
+# Bogus test uses std::cout without including <iostream>.
+std/utilities/time/time.cal/time.cal.wdidx/time.cal.wdidx.nonmembers/streaming.pass.cpp FAIL
+
+# Bogus test constructs year_month_weekday from weekday, but the constructor actually takes weekday_indexed.
+std/utilities/time/time.cal/time.cal.ymwd/time.cal.ymwd.nonmembers/streaming.pass.cpp FAIL
+
+# We define __cpp_lib_has_unique_object_representations in C++17 mode; test error says it
+# "should not be defined when TEST_HAS_BUILTIN_IDENTIFIER(__has_unique_object_representations) || TEST_GCC_VER >= 700 is not defined!"
+std/language.support/support.limits/support.limits.general/type_traits.version.pass.cpp:1 FAIL
+
+# Tests expect __cpp_lib_ranges to have the old value 201811L for P0896R4; we define the C++20 value 201911L for P1716R3.
+std/language.support/support.limits/support.limits.general/algorithm.version.pass.cpp FAIL
+std/language.support/support.limits/support.limits.general/functional.version.pass.cpp FAIL
+std/language.support/support.limits/support.limits.general/iterator.version.pass.cpp FAIL
+
+# We unconditionally define __cpp_lib_addressof_constexpr; test error says it
+# "should not be defined when TEST_HAS_BUILTIN(__builtin_addressof) || TEST_GCC_VER >= 700 is not defined!"
+std/language.support/support.limits/support.limits.general/memory.version.pass.cpp FAIL
+
 
 # *** LIKELY STL BUGS ***
 # Not yet analyzed, likely STL bugs. Assertions and other runtime failures.
@@ -857,6 +850,19 @@ std/re/re.alg/re.alg.search/basic.locale.pass.cpp FAIL
 std/re/re.alg/re.alg.search/ecma.locale.pass.cpp FAIL
 std/re/re.alg/re.alg.search/extended.locale.pass.cpp FAIL
 
+# Not yet analyzed. Various static_asserts.
+std/utilities/variant/variant.variant/variant.assign/conv.pass.cpp FAIL
+std/utilities/variant/variant.variant/variant.assign/T.pass.cpp FAIL
+std/utilities/variant/variant.variant/variant.ctor/conv.pass.cpp FAIL
+std/utilities/variant/variant.variant/variant.ctor/T.pass.cpp FAIL
+
+# Not yet analyzed. Involves incomplete types.
+std/utilities/memory/allocator.traits/allocator.traits.members/construct.pass.cpp FAIL
+std/utilities/memory/allocator.traits/allocator.traits.members/destroy.pass.cpp FAIL
+
+# Not yet analyzed. Error mentions allocator<const T>.
+std/utilities/memory/specialized.algorithms/specialized.construct/construct_at.pass.cpp FAIL
+
 
 # *** XFAILs WHICH PASS ***
 # Not yet implemented in libcxx and marked as "XFAIL: libc++"
@@ -876,9 +882,11 @@ std/utilities/time/time.cal/time.cal.md/time.cal.md.nonmembers/streaming.pass.cp
 std/utilities/time/time.cal/time.cal.mdlast/streaming.pass.cpp SKIPPED
 std/utilities/time/time.cal/time.cal.month/time.cal.month.nonmembers/streaming.pass.cpp SKIPPED
 std/utilities/time/time.cal/time.cal.mwd/time.cal.mwd.nonmembers/streaming.pass.cpp SKIPPED
+std/utilities/time/time.cal/time.cal.mwdlast/time.cal.mwdlast.nonmembers/streaming.pass.cpp SKIPPED
 std/utilities/time/time.cal/time.cal.wdlast/time.cal.wdlast.nonmembers/streaming.pass.cpp SKIPPED
 std/utilities/time/time.cal/time.cal.weekday/time.cal.weekday.nonmembers/streaming.pass.cpp SKIPPED
 std/utilities/time/time.cal/time.cal.year/time.cal.year.nonmembers/streaming.pass.cpp SKIPPED
 std/utilities/time/time.cal/time.cal.ym/time.cal.ym.nonmembers/streaming.pass.cpp SKIPPED
 std/utilities/time/time.cal/time.cal.ymd/time.cal.ymd.nonmembers/streaming.pass.cpp SKIPPED
 std/utilities/time/time.cal/time.cal.ymdlast/time.cal.ymdlast.nonmembers/streaming.pass.cpp SKIPPED
+std/utilities/time/time.cal/time.cal.ymwdlast/time.cal.ymwdlast.nonmembers/streaming.pass.cpp SKIPPED

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -276,11 +276,8 @@ utilities\memory\default.allocator\allocator.members\allocate.verify.cpp
 
 # *** MISSING STL FEATURES ***
 # C++20 P0355R7 "<chrono> Calendars And Time Zones"
-utilities\time\time.cal\time.cal.mwd\time.cal.mwd.nonmembers\streaming.pass.cpp
 utilities\time\time.cal\time.cal.mwdlast\time.cal.mwdlast.nonmembers\streaming.pass.cpp
 utilities\time\time.cal\time.cal.wdidx\time.cal.wdidx.nonmembers\streaming.pass.cpp
-utilities\time\time.cal\time.cal.wdlast\time.cal.wdlast.nonmembers\streaming.pass.cpp
-utilities\time\time.cal\time.cal.weekday\time.cal.weekday.nonmembers\streaming.pass.cpp
 utilities\time\time.cal\time.cal.ymwd\time.cal.ymwd.nonmembers\streaming.pass.cpp
 utilities\time\time.cal\time.cal.ymwdlast\time.cal.ymwdlast.nonmembers\streaming.pass.cpp
 

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -276,14 +276,11 @@ utilities\memory\default.allocator\allocator.members\allocate.verify.cpp
 
 # *** MISSING STL FEATURES ***
 # C++20 P0355R7 "<chrono> Calendars And Time Zones"
-utilities\time\time.cal\time.cal.md\time.cal.md.nonmembers\streaming.pass.cpp
-utilities\time\time.cal\time.cal.mdlast\streaming.pass.cpp
 utilities\time\time.cal\time.cal.mwd\time.cal.mwd.nonmembers\streaming.pass.cpp
 utilities\time\time.cal\time.cal.mwdlast\time.cal.mwdlast.nonmembers\streaming.pass.cpp
 utilities\time\time.cal\time.cal.wdidx\time.cal.wdidx.nonmembers\streaming.pass.cpp
 utilities\time\time.cal\time.cal.wdlast\time.cal.wdlast.nonmembers\streaming.pass.cpp
 utilities\time\time.cal\time.cal.weekday\time.cal.weekday.nonmembers\streaming.pass.cpp
-utilities\time\time.cal\time.cal.ym\time.cal.ym.nonmembers\streaming.pass.cpp
 utilities\time\time.cal\time.cal.ymwd\time.cal.ymwd.nonmembers\streaming.pass.cpp
 utilities\time\time.cal\time.cal.ymwdlast\time.cal.ymwdlast.nonmembers\streaming.pass.cpp
 

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -276,10 +276,8 @@ utilities\memory\default.allocator\allocator.members\allocate.verify.cpp
 
 # *** MISSING STL FEATURES ***
 # C++20 P0355R7 "<chrono> Calendars And Time Zones"
-utilities\time\time.cal\time.cal.day\time.cal.day.nonmembers\streaming.pass.cpp
 utilities\time\time.cal\time.cal.md\time.cal.md.nonmembers\streaming.pass.cpp
 utilities\time\time.cal\time.cal.mdlast\streaming.pass.cpp
-utilities\time\time.cal\time.cal.month\time.cal.month.nonmembers\streaming.pass.cpp
 utilities\time\time.cal\time.cal.mwd\time.cal.mwd.nonmembers\streaming.pass.cpp
 utilities\time\time.cal\time.cal.mwdlast\time.cal.mwdlast.nonmembers\streaming.pass.cpp
 utilities\time\time.cal\time.cal.wdidx\time.cal.wdidx.nonmembers\streaming.pass.cpp

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -275,32 +275,6 @@ utilities\memory\default.allocator\allocator.members\allocate.verify.cpp
 
 
 # *** MISSING STL FEATURES ***
-# C++20 P0355R7 "<chrono> Calendars And Time Zones"
-utilities\time\time.cal\time.cal.mwdlast\time.cal.mwdlast.nonmembers\streaming.pass.cpp
-utilities\time\time.cal\time.cal.wdidx\time.cal.wdidx.nonmembers\streaming.pass.cpp
-utilities\time\time.cal\time.cal.ymwd\time.cal.ymwd.nonmembers\streaming.pass.cpp
-utilities\time\time.cal\time.cal.ymwdlast\time.cal.ymwdlast.nonmembers\streaming.pass.cpp
-
-# C++20 P0466R5 "Layout-Compatibility And Pointer-Interconvertibility Traits"
-language.support\support.limits\support.limits.general\type_traits.version.pass.cpp
-
-# C++20 P0608R3 "Improving variant's Converting Constructor/Assignment"
-utilities\variant\variant.variant\variant.assign\conv.pass.cpp
-utilities\variant\variant.variant\variant.assign\T.pass.cpp
-utilities\variant\variant.variant\variant.ctor\conv.pass.cpp
-utilities\variant\variant.variant\variant.ctor\T.pass.cpp
-
-# C++20 P0784R7 "More constexpr containers"
-utilities\memory\allocator.traits\allocator.traits.members\construct.pass.cpp
-utilities\memory\allocator.traits\allocator.traits.members\destroy.pass.cpp
-utilities\memory\specialized.algorithms\specialized.construct\construct_at.pass.cpp
-
-# C++20 P0896R4 "<ranges>"
-language.support\support.limits\support.limits.general\algorithm.version.pass.cpp
-language.support\support.limits\support.limits.general\functional.version.pass.cpp
-language.support\support.limits\support.limits.general\iterator.version.pass.cpp
-language.support\support.limits\support.limits.general\memory.version.pass.cpp
-
 # C++23 P1048R1 "is_scoped_enum"
 utilities\meta\meta.unary\meta.unary.prop\is_scoped_enum.pass.cpp
 
@@ -651,6 +625,25 @@ utilities\allocator.adaptor\allocator.adaptor.members\construct_pair_rvalue.pass
 utilities\allocator.adaptor\allocator.adaptor.members\construct_pair_values.pass.cpp
 utilities\allocator.adaptor\allocator.adaptor.members\construct_type.pass.cpp
 
+# Bogus test uses std::cout without including <iostream>.
+utilities\time\time.cal\time.cal.wdidx\time.cal.wdidx.nonmembers\streaming.pass.cpp
+
+# Bogus test constructs year_month_weekday from weekday, but the constructor actually takes weekday_indexed.
+utilities\time\time.cal\time.cal.ymwd\time.cal.ymwd.nonmembers\streaming.pass.cpp
+
+# We define __cpp_lib_has_unique_object_representations in C++17 mode; test error says it
+# "should not be defined when TEST_HAS_BUILTIN_IDENTIFIER(__has_unique_object_representations) || TEST_GCC_VER >= 700 is not defined!"
+language.support\support.limits\support.limits.general\type_traits.version.pass.cpp
+
+# Tests expect __cpp_lib_ranges to have the old value 201811L for P0896R4; we define the C++20 value 201911L for P1716R3.
+language.support\support.limits\support.limits.general\algorithm.version.pass.cpp
+language.support\support.limits\support.limits.general\functional.version.pass.cpp
+language.support\support.limits\support.limits.general\iterator.version.pass.cpp
+
+# We unconditionally define __cpp_lib_addressof_constexpr; test error says it
+# "should not be defined when TEST_HAS_BUILTIN(__builtin_addressof) || TEST_GCC_VER >= 700 is not defined!"
+language.support\support.limits\support.limits.general\memory.version.pass.cpp
+
 
 # *** LIKELY STL BUGS ***
 # Not yet analyzed, likely STL bugs. Assertions and other runtime failures.
@@ -856,6 +849,19 @@ re\re.alg\re.alg.search\awk.locale.pass.cpp
 re\re.alg\re.alg.search\basic.locale.pass.cpp
 re\re.alg\re.alg.search\ecma.locale.pass.cpp
 re\re.alg\re.alg.search\extended.locale.pass.cpp
+
+# Not yet analyzed. Various static_asserts.
+utilities\variant\variant.variant\variant.assign\conv.pass.cpp
+utilities\variant\variant.variant\variant.assign\T.pass.cpp
+utilities\variant\variant.variant\variant.ctor\conv.pass.cpp
+utilities\variant\variant.variant\variant.ctor\T.pass.cpp
+
+# Not yet analyzed. Involves incomplete types.
+utilities\memory\allocator.traits\allocator.traits.members\construct.pass.cpp
+utilities\memory\allocator.traits\allocator.traits.members\destroy.pass.cpp
+
+# Not yet analyzed. Error mentions allocator<const T>.
+utilities\memory\specialized.algorithms\specialized.construct\construct_at.pass.cpp
 
 
 # *** SKIPPED FOR MSVC-INTERNAL CONTEST ONLY ***

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -283,10 +283,7 @@ utilities\time\time.cal\time.cal.mwdlast\time.cal.mwdlast.nonmembers\streaming.p
 utilities\time\time.cal\time.cal.wdidx\time.cal.wdidx.nonmembers\streaming.pass.cpp
 utilities\time\time.cal\time.cal.wdlast\time.cal.wdlast.nonmembers\streaming.pass.cpp
 utilities\time\time.cal\time.cal.weekday\time.cal.weekday.nonmembers\streaming.pass.cpp
-utilities\time\time.cal\time.cal.year\time.cal.year.nonmembers\streaming.pass.cpp
 utilities\time\time.cal\time.cal.ym\time.cal.ym.nonmembers\streaming.pass.cpp
-utilities\time\time.cal\time.cal.ymd\time.cal.ymd.nonmembers\streaming.pass.cpp
-utilities\time\time.cal\time.cal.ymdlast\time.cal.ymdlast.nonmembers\streaming.pass.cpp
 utilities\time\time.cal\time.cal.ymwd\time.cal.ymwd.nonmembers\streaming.pass.cpp
 utilities\time\time.cal\time.cal.ymwdlast\time.cal.ymwdlast.nonmembers\streaming.pass.cpp
 

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -640,6 +640,9 @@ language.support\support.limits\support.limits.general\algorithm.version.pass.cp
 language.support\support.limits\support.limits.general\functional.version.pass.cpp
 language.support\support.limits\support.limits.general\iterator.version.pass.cpp
 
+# Test expects __cpp_lib_chrono to have the old value 201611L for P0505R0; we define the C++20 value 201907L for P1466R3.
+language.support\support.limits\support.limits.general\chrono.version.pass.cpp
+
 # We unconditionally define __cpp_lib_addressof_constexpr; test error says it
 # "should not be defined when TEST_HAS_BUILTIN(__builtin_addressof) || TEST_GCC_VER >= 700 is not defined!"
 language.support\support.limits\support.limits.general\memory.version.pass.cpp

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
@@ -352,6 +352,34 @@ void test_year_formatter() {
 }
 
 template <typename CharT>
+void test_weekday_formatter() {
+    weekday invalid{10};
+    assert(format(STR("{}"), weekday{3}) == STR("Wed"));
+    stream_helper(STR("Wed"), weekday{3});
+    stream_helper(STR("10 is not a valid weekday"), invalid);
+
+    assert(format(STR("{:%a %A}"), weekday{6}) == STR("Sat Saturday"));
+    assert(format(STR("{:%u %w}"), weekday{6}) == STR("6 6"));
+    assert(format(STR("{:%u %w}"), weekday{0}) == STR("7 0"));
+}
+
+template <typename CharT>
+void test_weekday_indexed_formatter() {
+    weekday_indexed invalid1{Tuesday, 10};
+    weekday_indexed invalid2{weekday{10}, 3};
+    weekday_indexed invalid3{weekday{14}, 9};
+    assert(format(STR("{}"), weekday_indexed{Monday, 1}) == STR("Mon[1]"));
+    stream_helper(STR("Mon[1]"), weekday_indexed{Monday, 1});
+    stream_helper(STR("Tue[10 is not a valid index]"), invalid1);
+    stream_helper(STR("10 is not a valid weekday[3]"), invalid2);
+    stream_helper(STR("14 is not a valid weekday[9 is not a valid index]"), invalid3);
+
+    assert(format(STR("{:%a %A}"), weekday_indexed{Monday, 2}) == STR("Mon Monday"));
+    assert(format(STR("{:%u %w}"), weekday_indexed{Tuesday, 3}) == STR("2 2"));
+    assert(format(STR("{:%u %w}"), weekday_indexed{Sunday, 4}) == STR("7 0"));
+}
+
+template <typename CharT>
 void test_year_month_day_formatter() {
     year_month_day invalid{year{1234}, month{0}, day{31}};
     assert(format(STR("{}"), year_month_day{year{1900}, month{2}, day{1}}) == STR("1900-02-01"));
@@ -459,6 +487,12 @@ int main() {
 
     test_year_formatter<char>();
     test_year_formatter<wchar_t>();
+
+    test_weekday_formatter<char>();
+    test_weekday_formatter<wchar_t>();
+
+    test_weekday_indexed_formatter<char>();
+    test_weekday_indexed_formatter<wchar_t>();
 
     test_year_month_day_formatter<char>();
     test_year_month_day_formatter<wchar_t>();

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
@@ -364,11 +364,29 @@ void test_year_month_day_formatter() {
 }
 
 template <typename CharT>
+void test_year_month_day_last_formatter() {
+    // FIXME, TEST format() AND operator<< WHEN formatter FOR month_day_last IS IMPLEMENTED
+    // assert(format(STR("{:%F}"), 2021y / April / last) == STR("2021-04-30"));
+}
+
+template <typename CharT>
+void test_year_month_weekday_formatter() {
+    // FIXME, TEST format() AND operator<< WHEN formatter FOR weekday_indexed IS IMPLEMENTED
+}
+
+template <typename CharT>
+void test_year_month_weekday_last_formatter() {
+    // FIXME, TEST format() AND operator<< WHEN formatter FOR weekday_last IS IMPLEMENTED
+}
+
+template <typename CharT>
 void test_hh_mm_ss_formatter() {
+#if 0 // FIXME, TEST format() AND operator<< WHEN formatter FOR hh_mm_ss IS IMPLEMENTED
     stream_helper(STR("-01:08:03.007"), hh_mm_ss{-4083007ms});
     stream_helper(STR("01:08:03.007"), hh_mm_ss{4083007ms});
     stream_helper(STR("18:15:45.123"), hh_mm_ss{65745123ms});
     stream_helper(STR("18:15:45"), hh_mm_ss{65745s});
+#endif // FIXME
 }
 
 int main() {
@@ -389,6 +407,15 @@ int main() {
 
     test_year_month_day_formatter<char>();
     test_year_month_day_formatter<wchar_t>();
+
+    test_year_month_day_last_formatter<char>();
+    test_year_month_day_last_formatter<wchar_t>();
+
+    test_year_month_weekday_formatter<char>();
+    test_year_month_weekday_formatter<wchar_t>();
+
+    test_year_month_weekday_last_formatter<char>();
+    test_year_month_weekday_last_formatter<wchar_t>();
 
     test_hh_mm_ss_formatter<char>();
     test_hh_mm_ss_formatter<wchar_t>();

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
@@ -546,12 +546,18 @@ void test_year_month_formatter() {
     assert(format(STR("{:%Y %B}"), 2000y / July) == STR("2000 July"));
     throw_helper(STR("{:%d}"), 2000y / July);
 
+    throw_helper(STR("{:%g}"), 2005y / month{0});
+    throw_helper(STR("{:%G}"), 2005y / month{0});
     throw_helper(STR("{:%g}"), 2005y / January);
     throw_helper(STR("{:%G}"), 2005y / January);
     assert(format(STR("{:%g %G}"), 2005y / February) == STR("05 2005"));
     assert(format(STR("{:%g %G}"), 2005y / November) == STR("05 2005"));
     throw_helper(STR("{:%g}"), 2005y / December);
     throw_helper(STR("{:%G}"), 2005y / December);
+    throw_helper(STR("{:%g}"), 2005y / month{13});
+    throw_helper(STR("{:%G}"), 2005y / month{13});
+    throw_helper(STR("{:%g}"), year{-32768} / November);
+    throw_helper(STR("{:%G}"), year{-32768} / November);
 }
 
 template <typename CharT>

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
@@ -593,6 +593,14 @@ void test_hh_mm_ss_formatter() {
     empty_braces_helper(hh_mm_ss{4083007ms}, STR("01:08:03.007"));
     empty_braces_helper(hh_mm_ss{65745123ms}, STR("18:15:45.123"));
     empty_braces_helper(hh_mm_ss{65745s}, STR("18:15:45"));
+    empty_braces_helper(hh_mm_ss{0.1ns}, STR("00:00:00.000000000"));
+    empty_braces_helper(hh_mm_ss{1.45ns}, STR("00:00:00.000000001"));
+    empty_braces_helper(hh_mm_ss{1.56ns}, STR("00:00:00.000000001"));
+    empty_braces_helper(hh_mm_ss{1e+8ns}, STR("00:00:00.100000000"));
+    empty_braces_helper(hh_mm_ss{999'999.9us}, STR("00:00:00.999999"));
+    empty_braces_helper(hh_mm_ss{59'999'999.9us}, STR("00:00:59.999999"));
+    empty_braces_helper(hh_mm_ss{3'599'999'999.9us}, STR("00:59:59.999999"));
+    empty_braces_helper(hh_mm_ss{86'399'999'999.9us}, STR("23:59:59.999999"));
 
     assert(format(STR("{:%H %I %M %S %r %R %T %p}"), hh_mm_ss{13h + 14min + 15351ms})
            == STR("13 01 14 15.351 01:14:15 PM 13:14 13:14:15.351 PM"));

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
@@ -298,6 +298,7 @@ void test_day_formatter() {
     assert(format(STR("{:%d %d %d}"), day{27}) == STR("27 27 27"));
     assert(format(STR("{:%d}"), day{200}) == STR("200"));
     throw_helper(STR("{:%Ed}"), day{10});
+    throw_helper(STR("{:%Od}"), day{40});
     assert(format(STR("{}"), day{0}) == STR("00 is not a valid day"));
 
     // Op <<

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
@@ -249,6 +249,24 @@ void test_clock_formatter() {
     assert(format(STR("{:%Z %z %Oz %Ez}"), file_time<seconds>{}) == STR("UTC +0000 +00:00 +00:00"));
     throw_helper(STR("{:%Z %z %Oz %Ez}"), local_seconds{});
 
+    assert(format(STR("{:%g %G %U %V %W}"), sys_days{2010y / January / 1}) == STR("09 2009 00 53 00"));
+    assert(format(STR("{:%g %G %U %V %W}"), sys_days{2010y / January / 2}) == STR("09 2009 00 53 00"));
+    assert(format(STR("{:%g %G %U %V %W}"), sys_days{2010y / January / 3}) == STR("09 2009 01 53 00"));
+    assert(format(STR("{:%g %G %U %V %W}"), sys_days{2010y / January / 4}) == STR("10 2010 01 01 01"));
+    assert(format(STR("{:%g %G %U %V %W}"), sys_days{2010y / January / 5}) == STR("10 2010 01 01 01"));
+    assert(format(STR("{:%g %G %U %V %W}"), sys_days{2010y / January / 6}) == STR("10 2010 01 01 01"));
+    assert(format(STR("{:%g %G %U %V %W}"), sys_days{2010y / January / 7}) == STR("10 2010 01 01 01"));
+    assert(format(STR("{:%g %G %U %V %W}"), sys_days{2010y / May / 1}) == STR("10 2010 17 17 17"));
+    assert(format(STR("{:%g %G %U %V %W}"), sys_days{2010y / May / 2}) == STR("10 2010 18 17 17"));
+    assert(format(STR("{:%g %G %U %V %W}"), sys_days{2010y / May / 3}) == STR("10 2010 18 18 18"));
+    assert(format(STR("{:%g %G %U %V %W}"), sys_days{2010y / December / 25}) == STR("10 2010 51 51 51"));
+    assert(format(STR("{:%g %G %U %V %W}"), sys_days{2010y / December / 26}) == STR("10 2010 52 51 51"));
+    assert(format(STR("{:%g %G %U %V %W}"), sys_days{2010y / December / 27}) == STR("10 2010 52 52 52"));
+    assert(format(STR("{:%g %G %U %V %W}"), sys_days{2010y / December / 28}) == STR("10 2010 52 52 52"));
+    assert(format(STR("{:%g %G %U %V %W}"), sys_days{2010y / December / 29}) == STR("10 2010 52 52 52"));
+    assert(format(STR("{:%g %G %U %V %W}"), sys_days{2010y / December / 30}) == STR("10 2010 52 52 52"));
+    assert(format(STR("{:%g %G %U %V %W}"), sys_days{2010y / December / 31}) == STR("10 2010 52 52 52"));
+
     assert(format(STR("{:%S}"), utc_clock::from_sys(get_tzdb().leap_seconds.front().date()) - 1s) == STR("60"));
     assert(format(STR("{:%F %T}"), utc_clock::from_sys(get_tzdb().leap_seconds.front().date()))
            == STR("1972-07-01 00:00:00"));
@@ -515,6 +533,13 @@ void test_year_month_formatter() {
 
     assert(format(STR("{:%Y %B}"), 2000y / July) == STR("2000 July"));
     throw_helper(STR("{:%d}"), 2000y / July);
+
+    throw_helper(STR("{:%g}"), 2005y / January);
+    throw_helper(STR("{:%G}"), 2005y / January);
+    assert(format(STR("{:%g %G}"), 2005y / February) == STR("05 2005"));
+    assert(format(STR("{:%g %G}"), 2005y / November) == STR("05 2005"));
+    throw_helper(STR("{:%g}"), 2005y / December);
+    throw_helper(STR("{:%G}"), 2005y / December);
 }
 
 template <typename CharT>
@@ -533,6 +558,24 @@ void test_year_month_day_formatter() {
     assert(format(STR("{:%j}"), 1900y / May / 7) == STR("127"));
     assert(format(STR("{:%j}"), 2000y / May / 7) == STR("128"));
     throw_helper(STR("{:%j}"), invalid);
+
+    assert(format(STR("{:%g %G %U %V %W}"), 2010y / January / 1) == STR("09 2009 00 53 00"));
+    assert(format(STR("{:%g %G %U %V %W}"), 2010y / January / 2) == STR("09 2009 00 53 00"));
+    assert(format(STR("{:%g %G %U %V %W}"), 2010y / January / 3) == STR("09 2009 01 53 00"));
+    assert(format(STR("{:%g %G %U %V %W}"), 2010y / January / 4) == STR("10 2010 01 01 01"));
+    assert(format(STR("{:%g %G %U %V %W}"), 2010y / January / 5) == STR("10 2010 01 01 01"));
+    assert(format(STR("{:%g %G %U %V %W}"), 2010y / January / 6) == STR("10 2010 01 01 01"));
+    assert(format(STR("{:%g %G %U %V %W}"), 2010y / January / 7) == STR("10 2010 01 01 01"));
+    assert(format(STR("{:%g %G %U %V %W}"), 2010y / May / 1) == STR("10 2010 17 17 17"));
+    assert(format(STR("{:%g %G %U %V %W}"), 2010y / May / 2) == STR("10 2010 18 17 17"));
+    assert(format(STR("{:%g %G %U %V %W}"), 2010y / May / 3) == STR("10 2010 18 18 18"));
+    assert(format(STR("{:%g %G %U %V %W}"), 2010y / December / 25) == STR("10 2010 51 51 51"));
+    assert(format(STR("{:%g %G %U %V %W}"), 2010y / December / 26) == STR("10 2010 52 51 51"));
+    assert(format(STR("{:%g %G %U %V %W}"), 2010y / December / 27) == STR("10 2010 52 52 52"));
+    assert(format(STR("{:%g %G %U %V %W}"), 2010y / December / 28) == STR("10 2010 52 52 52"));
+    assert(format(STR("{:%g %G %U %V %W}"), 2010y / December / 29) == STR("10 2010 52 52 52"));
+    assert(format(STR("{:%g %G %U %V %W}"), 2010y / December / 30) == STR("10 2010 52 52 52"));
+    assert(format(STR("{:%g %G %U %V %W}"), 2010y / December / 31) == STR("10 2010 52 52 52"));
 }
 
 template <typename CharT>
@@ -557,6 +600,8 @@ void test_year_month_day_last_formatter() {
     assert(format(STR("{:%j}"), 1900y / February / last) == STR("059"));
     assert(format(STR("{:%j}"), 2000y / February / last) == STR("060"));
     throw_helper(STR("{:%j}"), year{1900} / month{13} / last);
+
+    assert(format(STR("{:%g %G %U %V %W}"), 2010y / May / last) == STR("10 2010 22 22 22"));
 }
 
 template <typename CharT>
@@ -586,6 +631,8 @@ void test_year_month_weekday_formatter() {
 
     assert(format(STR("{:%j}"), 1900y / January / Tuesday[2]) == STR("009"));
     throw_helper(STR("{:%j}"), invalid1);
+
+    assert(format(STR("{:%g %G %U %V %W}"), 2010y / May / Monday[5]) == STR("10 2010 22 22 22"));
 }
 
 template <typename CharT>
@@ -613,6 +660,8 @@ void test_year_month_weekday_last_formatter() {
 
     assert(format(STR("{:%j}"), 1900y / January / Tuesday[last]) == STR("030"));
     throw_helper(STR("{:%j}"), invalid1);
+
+    assert(format(STR("{:%g %G %U %V %W}"), 2010y / May / Monday[last]) == STR("10 2010 22 22 22"));
 }
 
 template <typename CharT>
@@ -798,7 +847,8 @@ void test_local_time_format_formatter() {
     assert(format(STR("{:%c, %x, %X}"), ltf) == STR("04/19/21 01:02:03, 04/19/21, 01:02:03"));
     assert(format(STR("{:%D %F, %Y %C %y, %b %B %h %m, %d %e, %a %A %u %w}"), ltf)
            == STR("04/19/21 2021-04-19, 2021 20 21, Apr April Apr 04, 19 19, Mon Monday 1 1"));
-    assert(format(STR("{:%H %I %M %S %r %R %T %p}"), ltf) == STR("01 01 02 03 01:02:03 01:02 01:02:03 AM"));
+    assert(format(STR("{:%H %I %M %S, %r, %R %T %p}"), ltf) == STR("01 01 02 03, 01:02:03 AM, 01:02 01:02:03 AM"));
+    assert(format(STR("{:%g %G %U %V %W}"), ltf) == STR("21 2021 16 16 16"));
 }
 
 template <typename CharT>
@@ -812,7 +862,8 @@ void test_zoned_time_formatter() {
     assert(format(STR("{:%c, %x, %X}"), zt) == STR("04/19/21 08:16:17, 04/19/21, 08:16:17"));
     assert(format(STR("{:%D %F, %Y %C %y, %b %B %h %m, %d %e, %a %A %u %w}"), zt)
            == STR("04/19/21 2021-04-19, 2021 20 21, Apr April Apr 04, 19 19, Mon Monday 1 1"));
-    assert(format(STR("{:%H %I %M %S %r %R %T %p}"), zt) == STR("08 08 16 17 08:16:17 08:16 08:16:17 AM"));
+    assert(format(STR("{:%H %I %M %S, %r, %R %T %p}"), zt) == STR("08 08 16 17, 08:16:17 AM, 08:16 08:16:17 AM"));
+    assert(format(STR("{:%g %G %U %V %W}"), zt) == STR("21 2021 16 16 16"));
 }
 
 int main() {

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
@@ -878,7 +878,7 @@ void test_zoned_time_formatter() {
     assert(format(STR("{:%g %G %U %V %W}"), zt) == STR("21 2021 16 16 16"));
 }
 
-int main() {
+void test() {
     test_parse_conversion_spec<char>();
     test_parse_conversion_spec<wchar_t>();
 
@@ -949,4 +949,8 @@ int main() {
 
     test_zoned_time_formatter<char>();
     test_zoned_time_formatter<wchar_t>();
+}
+
+int main() {
+    run_tz_test([] { test(); });
 }

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
@@ -595,10 +595,10 @@ void test_hh_mm_ss_formatter() {
     empty_braces_helper(hh_mm_ss{65745s}, STR("18:15:45"));
 
     assert(format(STR("{:%H %I %M %S %r %R %T %p}"), hh_mm_ss{13h + 14min + 15351ms})
-           == STR("13 01 14 15.351 13:14:15 13:14 13:14:15.351 PM"));
+           == STR("13 01 14 15.351 01:14:15 PM 13:14 13:14:15.351 PM"));
 
     assert(format(STR("{:%H %I %M %S %r %R %T %p}"), hh_mm_ss{-13h - 14min - 15351ms})
-           == STR("-13 01 14 15.351 13:14:15 13:14 13:14:15.351 PM"));
+           == STR("-13 01 14 15.351 01:14:15 PM 13:14 13:14:15.351 PM"));
 
     throw_helper(STR("{}"), hh_mm_ss{24h});
     throw_helper(STR("{}"), hh_mm_ss{-24h});

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
@@ -423,6 +423,27 @@ void test_year_month_formatter() {
     throw_helper(STR("{:%d}"), 2000y / July);
 }
 
+template <typename CharT>
+void test_clock_formatter() {
+    stream_helper(STR("1970-01-01 00:00:00"), sys_seconds{});
+    stream_helper(STR("1970-01-01"), sys_days{});
+    stream_helper(STR("1970-01-01 00:00:00"), utc_seconds{});
+    stream_helper(STR("1958-01-01 00:00:00"), tai_seconds{});
+    stream_helper(STR("1980-01-06 00:00:00"), gps_seconds{});
+    stream_helper(STR("1601-01-01 00:00:00"), file_time<seconds>{});
+    stream_helper(STR("1970-01-01 00:00:00"), local_seconds{});
+
+    assert(format(STR("{:%Z %z %Oz %Ez}"), sys_seconds{}) == STR("UTC +0000 +00:00 +00:00"));
+    assert(format(STR("{:%Z %z %Oz %Ez}"), sys_days{}) == STR("UTC +0000 +00:00 +00:00"));
+    assert(format(STR("{:%Z %z %Oz %Ez}"), utc_seconds{}) == STR("UTC +0000 +00:00 +00:00"));
+    assert(format(STR("{:%Z %z %Oz %Ez}"), tai_seconds{}) == STR("TAI +0000 +00:00 +00:00"));
+    assert(format(STR("{:%Z %z %Oz %Ez}"), gps_seconds{}) == STR("GPS +0000 +00:00 +00:00"));
+    assert(format(STR("{:%Z %z %Oz %Ez}"), file_time<seconds>{}) == STR("UTC +0000 +00:00 +00:00"));
+    throw_helper(STR("{:%Z %z %Oz %Ez}"), local_seconds{});
+
+    assert(format(STR("{:%S}"), utc_clock::from_sys(get_tzdb().leap_seconds.front().date()) - 1s) == STR("60"));
+}
+
 int main() {
     test_parse_conversion_spec<char>();
     test_parse_conversion_spec<wchar_t>();
@@ -462,4 +483,7 @@ int main() {
 
     test_year_month_formatter<char>();
     test_year_month_formatter<wchar_t>();
+
+    test_clock_formatter<char>();
+    test_clock_formatter<wchar_t>();
 }

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
@@ -357,6 +357,7 @@ void test_year_month_day_formatter() {
     assert(format(STR("{:%Y %b %d}"), year_month_day{year{1234}, month{5}, day{6}}) == STR("1234 May 06"));
     assert(format(STR("{:%F %D}"), invalid) == STR("1234-00-31 00/31/34"));
     assert(format(STR("{:%a %A}"), year_month_day{year{1900}, month{1}, day{4}}) == STR("Thu Thursday"));
+    assert(format(STR("{:%u %w}"), year_month_day{year{1900}, month{1}, day{4}}) == STR("4 4"));
 }
 
 template <typename CharT>

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
@@ -220,7 +220,6 @@ constexpr void print(Str str) {
     }
 }
 
-#ifndef __clang__ // TRANSITION, LLVM-48606
 template <typename CharT>
 void test_day_formatter() {
     using view_typ = basic_string_view<CharT>;
@@ -332,7 +331,6 @@ void test_month_formatter() {
     stream_helper(STR("00 is not a valid month"), month{0});
     stream_helper(STR("20 is not a valid month"), month{20});
 }
-#endif // __clang__
 
 int main() {
     test_parse_conversion_spec<char>();

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
@@ -219,6 +219,27 @@ constexpr void print(Str str) {
 }
 
 template <typename CharT>
+void test_duration_formatter() {
+    empty_braces_helper(seconds{5}, STR("5s"));
+    empty_braces_helper(minutes{7}, STR("7min"));
+    empty_braces_helper(hours{9}, STR("9h"));
+    empty_braces_helper(days{2}, STR("2d"));
+    empty_braces_helper(-seconds{5}, STR("-5s"));
+    empty_braces_helper(duration<int, ratio<3, 1>>{40}, STR("40[3]s"));
+    empty_braces_helper(duration<int, ratio<3, 7>>{40}, STR("40[3/7]s"));
+
+    assert(format(STR("{:%T}"), 4083007ms) == STR("01:08:03.007"));
+    assert(format(STR("{:%T}"), -4083007ms) == STR("-01:08:03.007"));
+
+    assert(format(STR("{:%T %j %q %Q}"), days{4} + 30min) == STR("00:30:00 4 min 5790"));
+    assert(format(STR("{:%T %j %q %Q}"), -days{4} - 30min) == STR("-00:30:00 4 min 5790"));
+    assert(format(STR("{:%T %j}"), days{4} + 23h + 30min) == STR("23:30:00 4"));
+    assert(format(STR("{:%T %j}"), -days{4} - 23h - 30min) == STR("-23:30:00 4"));
+    assert(format(STR("{:%T %j}"), duration<float, days::period>{1.55f}) == STR("13:11:59 1"));
+    assert(format(STR("{:%T %j}"), duration<float, days::period>{-1.55f}) == STR("-13:11:59 1"));
+}
+
+template <typename CharT>
 void test_clock_formatter() {
     empty_braces_helper(sys_seconds{}, STR("1970-01-01 00:00:00"));
     empty_braces_helper(sys_days{}, STR("1970-01-01"));
@@ -596,6 +617,9 @@ int main() {
 
     test_parse_chrono_format_specs<char>();
     test_parse_chrono_format_specs<wchar_t>();
+
+    test_duration_formatter<char>();
+    test_duration_formatter<wchar_t>();
 
     test_clock_formatter<char>();
     test_clock_formatter<wchar_t>();

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
@@ -413,6 +413,8 @@ void test_year_formatter() {
 
     assert(format(STR("{:%Y %y%C}"), year{1912}) == STR("1912 1219"));
     assert(format(STR("{:%Y %y%C}"), year{-1912}) == STR("-1912 88-20"));
+    assert(format(STR("{:%Y %y%C}"), year{-200}) == STR("-0200 00-02"));
+    assert(format(STR("{:%Y %y%C}"), year{200}) == STR("0200 0002"));
     // TRANSITION, add tests for EY Oy Ey EC
 
     empty_braces_helper(year{1900}, STR("1900"));

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
@@ -6,6 +6,7 @@
 #include <concepts>
 #include <format>
 #include <iostream>
+#include <sstream>
 #include <stdio.h>
 #include <string_view>
 #include <type_traits>
@@ -205,12 +206,13 @@ void throw_helper(const charT* fmt, const Args&... vals) {
 
 template <class charT, class... Args>
 void stream_helper(const charT* expect, const Args&... vals) {
-    basic_stringstream<charT> stream;
+    basic_ostringstream<charT> stream;
     (stream << ... << vals);
     assert(stream.str() == expect);
     assert(stream);
 }
 
+// FIXME: TEMPORARY CODE FOR WRITING TESTS, REMOVE BEFORE MERGING
 template <class Str>
 constexpr void print(Str str) {
     if constexpr (is_same_v<Str, string>) {

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
@@ -299,6 +299,7 @@ void test_day_formatter() {
     assert(format(STR("{:%d}"), day{200}) == STR("200"));
     throw_helper(STR("{:%Ed}"), day{10});
     throw_helper(STR("{:%Od}"), day{40});
+    throw_helper(STR("{:%Ed}"), day{40});
     assert(format(STR("{}"), day{0}) == STR("00 is not a valid day"));
 
     // Op <<
@@ -381,12 +382,19 @@ void test_year_month_weekday_last_formatter() {
 
 template <typename CharT>
 void test_hh_mm_ss_formatter() {
-#if 0 // FIXME, TEST format() AND operator<< WHEN formatter FOR hh_mm_ss IS IMPLEMENTED
     stream_helper(STR("-01:08:03.007"), hh_mm_ss{-4083007ms});
     stream_helper(STR("01:08:03.007"), hh_mm_ss{4083007ms});
     stream_helper(STR("18:15:45.123"), hh_mm_ss{65745123ms});
     stream_helper(STR("18:15:45"), hh_mm_ss{65745s});
-#endif // FIXME
+
+    assert(format(STR("{:%H %I %M %S %r %R %T %p}"), hh_mm_ss{13h + 14min + 15351ms})
+           == STR("13 01 14 15.351 13:14:15 13:14 13:14:15.351 PM"));
+
+    assert(format(STR("{:%H %I %M %S %r %R %T %p}"), hh_mm_ss{-13h - 14min - 15351ms})
+           == STR("-13 01 14 15.351 13:14:15 13:14 13:14:15.351 PM"));
+
+    throw_helper(STR("{}"), hh_mm_ss{24h});
+    throw_helper(STR("{}"), hh_mm_ss{-24h});
 }
 
 int main() {

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
@@ -423,6 +423,7 @@ void test_hh_mm_ss_formatter() {
 
     throw_helper(STR("{}"), hh_mm_ss{24h});
     throw_helper(STR("{}"), hh_mm_ss{-24h});
+    assert(format(STR("{:%M %S}"), hh_mm_ss{27h + 12min + 30s}) == STR("12 30"));
 }
 
 template <typename CharT>

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
@@ -294,7 +294,7 @@ void test_day_formatter() {
     assert(res == a8);
 
     assert(format(STR("{:%d %d %d}"), day{27}) == STR("27 27 27"));
-    throw_helper(STR("{:%d}"), day{200});
+    assert(format(STR("{:%d}"), day{200}) == STR("200"));
     throw_helper(STR("{:%Ed}"), day{10});
     assert(format(STR("{}"), day{0}) == STR("00 is not a valid day"));
 
@@ -316,10 +316,10 @@ void test_month_formatter() {
     assert(format(STR("{:%m %Om}"), month{1}) == STR("01 01"));
 
     // Out of bounds month
-    throw_helper(STR("{:%m}"), month{0});
+    assert(format(STR("{:%m}"), month{0}) == STR("00"));
     throw_helper(STR("{:%b}"), month{0});
     throw_helper(STR("{:%h}"), month{0});
-    throw_helper(STR("{::%B}"), month{0});
+    throw_helper(STR("{:%B}"), month{0});
 
     // Invalid specs
     throw_helper(STR("{:%A}"), month{1});
@@ -330,6 +330,32 @@ void test_month_formatter() {
     stream_helper(STR("Dec"), month{12});
     stream_helper(STR("0 is not a valid month"), month{0});
     stream_helper(STR("20 is not a valid month"), month{20});
+}
+
+template <typename CharT>
+void test_year_formatter() {
+    assert(format(STR("{}"), year{0}) == STR("0000"));
+    assert(format(STR("{}"), year{-200}) == STR("-0200"));
+    assert(format(STR("{}"), year{121}) == STR("0121"));
+
+    assert(format(STR("{:%Y %y%C}"), year{1912}) == STR("1912 1219"));
+    assert(format(STR("{:%Y %y%C}"), year{-1912}) == STR("-1912 88-20"));
+    // TRANSITION, add tests for EY Oy Ey EC
+
+    stream_helper(STR("1900"), year{1900});
+    stream_helper(STR("2000"), year{2000});
+    stream_helper(STR("-32768 is not a valid year"), year{-32768});
+}
+
+template <typename CharT>
+void test_year_month_day_formatter() {
+    year_month_day invalid{year{1234}, month{0}, day{31}};
+    assert(format(STR("{}"), year_month_day{year{1900}, month{2}, day{1}}) == STR("1900-02-01"));
+    stream_helper(STR("1900-02-01"), year_month_day{year{1900}, month{2}, day{1}});
+    stream_helper(STR("1234-00-31 is not a valid date"), invalid);
+
+    assert(format(STR("{:%Y %b %d}"), year_month_day{year{1234}, month{5}, day{6}}) == STR("1234 May 06"));
+    assert(format(STR("{:%F %D}"), invalid) == STR("1234-00-31 00/31/34"));
 }
 
 int main() {
@@ -344,4 +370,10 @@ int main() {
 
     test_month_formatter<char>();
     test_month_formatter<wchar_t>();
+
+    test_year_formatter<char>();
+    test_year_formatter<wchar_t>();
+
+    test_year_month_day_formatter<char>();
+    test_year_month_day_formatter<wchar_t>();
 }

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
@@ -411,7 +411,8 @@ void test_month_day_last_formatter() {
     stream_helper(STR("Feb/last"), February / last);
 
     assert(format(STR("{:%B}"), June / last) == STR("June"));
-    throw_helper(STR("{:%d}"), June / last);
+    assert(format(STR("{:%d}"), June / last) == STR("30"));
+    throw_helper(STR("{:%d}"), February / last);
 }
 
 template <typename CharT>

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
@@ -397,6 +397,31 @@ void test_hh_mm_ss_formatter() {
     throw_helper(STR("{}"), hh_mm_ss{-24h});
 }
 
+template <typename CharT>
+void test_month_day_formatter() {
+    stream_helper(STR("Jan/16"), January / 16);
+    stream_helper(STR("13 is not a valid month/40 is not a valid day"), month{13} / day{40});
+
+    assert(format(STR("{:%B %d}"), June / 17) == STR("June 17"));
+    throw_helper(STR("{:%Y}"), June / 17);
+}
+
+template <typename CharT>
+void test_month_day_last_formatter() {
+    stream_helper(STR("Feb/last"), February / last);
+
+    assert(format(STR("{:%B}"), June / last) == STR("June"));
+    throw_helper(STR("{:%d}"), June / last);
+}
+
+template <typename CharT>
+void test_year_month_formatter() {
+    stream_helper(STR("1444/Oct"), 1444y / October);
+
+    assert(format(STR("{:%Y %B}"), 2000y / July) == STR("2000 July"));
+    throw_helper(STR("{:%d}"), 2000y / July);
+}
+
 int main() {
     test_parse_conversion_spec<char>();
     test_parse_conversion_spec<wchar_t>();
@@ -427,4 +452,13 @@ int main() {
 
     test_hh_mm_ss_formatter<char>();
     test_hh_mm_ss_formatter<wchar_t>();
+
+    test_month_day_formatter<char>();
+    test_month_day_formatter<wchar_t>();
+
+    test_month_day_last_formatter<char>();
+    test_month_day_last_formatter<wchar_t>();
+
+    test_year_month_formatter<char>();
+    test_year_month_formatter<wchar_t>();
 }

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
@@ -358,6 +358,14 @@ void test_year_month_day_formatter() {
     assert(format(STR("{:%F %D}"), invalid) == STR("1234-00-31 00/31/34"));
 }
 
+template <typename CharT>
+void test_hh_mm_ss_formatter() {
+    stream_helper(STR("-01:08:03.007"), hh_mm_ss{-4083007ms});
+    stream_helper(STR("01:08:03.007"), hh_mm_ss{4083007ms});
+    stream_helper(STR("18:15:45.123"), hh_mm_ss{65745123ms});
+    stream_helper(STR("18:15:45"), hh_mm_ss{65745s});
+}
+
 int main() {
     test_parse_conversion_spec<char>();
     test_parse_conversion_spec<wchar_t>();
@@ -376,4 +384,7 @@ int main() {
 
     test_year_month_day_formatter<char>();
     test_year_month_day_formatter<wchar_t>();
+
+    test_hh_mm_ss_formatter<char>();
+    test_hh_mm_ss_formatter<wchar_t>();
 }

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
@@ -72,9 +72,9 @@ struct testing_callbacks {
     void _On_dynamic_precision(_Auto_id_tag) {
         assert(expected_auto_dynamic_precision);
     }
-    void _On_conversion_spec(CharT mod, CharT type) {
+    void _On_conversion_spec(char mod, CharT type) {
         assert(mod == expected_chrono_specs[curr_index]._Modifier);
-        assert(type == expected_chrono_specs[curr_index]._Type);
+        assert(static_cast<char>(type) == expected_chrono_specs[curr_index]._Type);
         assert(expected_chrono_specs[curr_index]._Lit_char == CharT{0}); // not set
         ++curr_index;
     }
@@ -308,7 +308,7 @@ template <typename CharT>
 void test_month_formatter() {
     assert(format(STR("{}"), month{1}) == STR("Jan"));
     assert(format(STR("{}"), month{12}) == STR("Dec"));
-    assert(format(STR("{}"), month{0}) == STR("00 is not a valid month"));
+    assert(format(STR("{}"), month{0}) == STR("0 is not a valid month"));
     assert(format(STR("{}"), month{20}) == STR("20 is not a valid month"));
 
     // Specs
@@ -328,7 +328,7 @@ void test_month_formatter() {
     // Op <<
     stream_helper(STR("Jan"), month{1});
     stream_helper(STR("Dec"), month{12});
-    stream_helper(STR("00 is not a valid month"), month{0});
+    stream_helper(STR("0 is not a valid month"), month{0});
     stream_helper(STR("20 is not a valid month"), month{20});
 }
 

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
@@ -356,6 +356,7 @@ void test_year_month_day_formatter() {
 
     assert(format(STR("{:%Y %b %d}"), year_month_day{year{1234}, month{5}, day{6}}) == STR("1234 May 06"));
     assert(format(STR("{:%F %D}"), invalid) == STR("1234-00-31 00/31/34"));
+    assert(format(STR("{:%a %A}"), year_month_day{year{1900}, month{1}, day{4}}) == STR("Thu Thursday"));
 }
 
 template <typename CharT>

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
@@ -418,6 +418,12 @@ void test_month_day_formatter() {
 
     assert(format(STR("{:%B %d}"), June / 17) == STR("June 17"));
     throw_helper(STR("{:%Y}"), June / 17);
+
+    assert(format(STR("{:%j}"), January / 5) == STR("005"));
+    assert(format(STR("{:%j}"), February / 5) == STR("036"));
+    assert(format(STR("{:%j}"), February / 28) == STR("059"));
+    assert(format(STR("{:%j}"), February / 29) == STR("060"));
+    throw_helper(STR("{:%j}"), March / 1);
 }
 
 template <typename CharT>
@@ -427,6 +433,10 @@ void test_month_day_last_formatter() {
     assert(format(STR("{:%B}"), June / last) == STR("June"));
     assert(format(STR("{:%d}"), June / last) == STR("30"));
     throw_helper(STR("{:%d}"), February / last);
+
+    assert(format(STR("{:%j}"), January / last) == STR("031"));
+    throw_helper(STR("{:%j}"), February / last);
+    throw_helper(STR("{:%j}"), April / last);
 }
 
 template <typename CharT>
@@ -489,6 +499,12 @@ void test_year_month_day_formatter() {
     assert(format(STR("{:%F %D}"), invalid) == STR("1234-00-31 00/31/34"));
     assert(format(STR("{:%a %A}"), year_month_day{year{1900}, month{1}, day{4}}) == STR("Thu Thursday"));
     assert(format(STR("{:%u %w}"), year_month_day{year{1900}, month{1}, day{4}}) == STR("4 4"));
+    throw_helper(STR("{:%u}"), invalid);
+
+    assert(format(STR("{:%j}"), 1900y / January / 4) == STR("004"));
+    assert(format(STR("{:%j}"), 1900y / May / 7) == STR("127"));
+    assert(format(STR("{:%j}"), 2000y / May / 7) == STR("128"));
+    throw_helper(STR("{:%j}"), invalid);
 }
 
 template <typename CharT>
@@ -506,6 +522,13 @@ void test_year_month_day_last_formatter() {
     constexpr auto fmt = STR("{:%D %F, %Y %C %y, %b %B %h %m, %d %e, %a %A %u %w}");
     assert(format(fmt, ymdl1) == STR("04/30/21 2021-04-30, 2021 20 21, Apr April Apr 04, 30 30, Fri Friday 5 5"));
     assert(format(fmt, ymdl2) == STR("02/29/04 2004-02-29, 2004 20 04, Feb February Feb 02, 29 29, Sun Sunday 7 0"));
+
+    throw_helper(STR("{:%u}"), invalid);
+
+    assert(format(STR("{:%j}"), 1900y / January / last) == STR("031"));
+    assert(format(STR("{:%j}"), 1900y / February / last) == STR("059"));
+    assert(format(STR("{:%j}"), 2000y / February / last) == STR("060"));
+    throw_helper(STR("{:%j}"), year{1900} / month{13} / last);
 }
 
 template <typename CharT>
@@ -529,6 +552,12 @@ void test_year_month_weekday_formatter() {
     constexpr auto fmt = STR("{:%D %F, %Y %C %y, %b %B %h %m, %d %e, %a %A %u %w}");
     assert(format(fmt, ymwd1) == STR("04/30/21 2021-04-30, 2021 20 21, Apr April Apr 04, 30 30, Fri Friday 5 5"));
     assert(format(fmt, ymwd2) == STR("02/29/04 2004-02-29, 2004 20 04, Feb February Feb 02, 29 29, Sun Sunday 7 0"));
+
+    assert(format(STR("{:%u}"), invalid1) == STR("5"));
+    throw_helper(STR("{:%u}"), invalid2);
+
+    assert(format(STR("{:%j}"), 1900y / January / Tuesday[2]) == STR("009"));
+    throw_helper(STR("{:%j}"), invalid1);
 }
 
 template <typename CharT>
@@ -550,6 +579,12 @@ void test_year_month_weekday_last_formatter() {
     constexpr auto fmt = STR("{:%D %F, %Y %C %y, %b %B %h %m, %d %e, %a %A %u %w}");
     assert(format(fmt, ymwdl1) == STR("04/30/21 2021-04-30, 2021 20 21, Apr April Apr 04, 30 30, Fri Friday 5 5"));
     assert(format(fmt, ymwdl2) == STR("02/29/04 2004-02-29, 2004 20 04, Feb February Feb 02, 29 29, Sun Sunday 7 0"));
+
+    assert(format(STR("{:%u}"), invalid2) == STR("5"));
+    throw_helper(STR("{:%u}"), invalid1);
+
+    assert(format(STR("{:%j}"), 1900y / January / Tuesday[last]) == STR("030"));
+    throw_helper(STR("{:%j}"), invalid1);
 }
 
 template <typename CharT>

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
@@ -444,6 +444,7 @@ void test_weekday_indexed_formatter() {
     assert(format(STR("{:%a %A}"), weekday_indexed{Monday, 2}) == STR("Mon Monday"));
     assert(format(STR("{:%u %w}"), weekday_indexed{Tuesday, 3}) == STR("2 2"));
     assert(format(STR("{:%u %w}"), weekday_indexed{Sunday, 4}) == STR("7 0"));
+    assert(format(STR("{:%u %w}"), weekday_indexed{Sunday, 10}) == STR("7 0"));
 }
 
 template <typename CharT>
@@ -464,6 +465,8 @@ void test_month_day_formatter() {
 
     assert(format(STR("{:%B %d}"), June / 17) == STR("June 17"));
     throw_helper(STR("{:%Y}"), June / 17);
+    assert(format(STR("{:%B}"), June / day{40}) == STR("June"));
+    throw_helper(STR("{:%B}"), month{13} / 17);
 
     assert(format(STR("{:%j}"), January / 5) == STR("005"));
     assert(format(STR("{:%j}"), February / 5) == STR("036"));
@@ -479,6 +482,7 @@ void test_month_day_last_formatter() {
     assert(format(STR("{:%B}"), June / last) == STR("June"));
     assert(format(STR("{:%d}"), June / last) == STR("30"));
     throw_helper(STR("{:%d}"), February / last);
+    throw_helper(STR("{:%B}"), month{13} / last);
 
     assert(format(STR("{:%j}"), January / last) == STR("031"));
     throw_helper(STR("{:%j}"), February / last);
@@ -505,6 +509,9 @@ void test_month_weekday_formatter() {
 
     assert(format(STR("{:%b %B %h %m %a %A %u %w}"), mwd1) == STR("Aug August Aug 08 Tue Tuesday 2 2"));
     assert(format(STR("{:%b %B %h %m %a %A %u %w}"), mwd2) == STR("Dec December Dec 12 Sun Sunday 7 0"));
+
+    assert(format(STR("{:%u}"), invalid1) == STR("5"));
+    throw_helper(STR("{:%u}"), invalid2);
 }
 
 template <typename CharT>
@@ -525,6 +532,9 @@ void test_month_weekday_last_formatter() {
 
     assert(format(STR("{:%b %B %h %m %a %A %u %w}"), mwdl1) == STR("Aug August Aug 08 Tue Tuesday 2 2"));
     assert(format(STR("{:%b %B %h %m %a %A %u %w}"), mwdl2) == STR("Dec December Dec 12 Sun Sunday 7 0"));
+
+    assert(format(STR("{:%u}"), invalid2) == STR("5"));
+    throw_helper(STR("{:%u}"), invalid1);
 }
 
 template <typename CharT>

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_time_zones/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_time_zones/test.cpp
@@ -360,46 +360,40 @@ void validate_precision(const time_zone* tz, const pair<Transition, Transition>&
 
 void timezone_precision_test() {
     const auto& my_tzdb = get_tzdb();
-    using MilliDur      = duration<double, milli>;
-    using MicroDur      = duration<double, micro>;
 
     {
         using namespace Sydney;
         auto tz = my_tzdb.locate_zone(Tz_name);
         validate_precision(tz, Std_to_Day, sys_seconds::duration{1});
-        validate_precision(tz, Std_to_Day, MilliDur{1});
-        validate_precision(tz, Std_to_Day, MilliDur{0.5});
-        validate_precision(tz, Std_to_Day, MilliDur{0.05});
-        validate_precision(tz, Std_to_Day, MilliDur{0.005});
-        validate_precision(tz, Std_to_Day, MilliDur{0.0005});
-        // precision limit...
 
-        validate_precision(tz, Std_to_Day, MicroDur{1});
-        validate_precision(tz, Std_to_Day, MicroDur{0.5});
-        // precision limit...
+        validate_precision(tz, Std_to_Day, milliseconds{100});
+        validate_precision(tz, Std_to_Day, milliseconds{10});
+        validate_precision(tz, Std_to_Day, milliseconds{1});
+
+        validate_precision(tz, Std_to_Day, microseconds{100});
+        validate_precision(tz, Std_to_Day, microseconds{10});
+        validate_precision(tz, Std_to_Day, microseconds{1});
 
         // validate opposite transition
-        validate_precision(tz, Day_to_Std, MicroDur{0.5});
-        validate_precision(tz, Day_to_Std, MilliDur{0.0005});
+        validate_precision(tz, Day_to_Std, milliseconds{1});
+        validate_precision(tz, Day_to_Std, microseconds{1});
     }
     {
         using namespace LA;
         auto tz = my_tzdb.locate_zone(Tz_name);
         validate_precision(tz, Std_to_Day, sys_seconds::duration{1});
-        validate_precision(tz, Std_to_Day, MilliDur{1});
-        validate_precision(tz, Std_to_Day, MilliDur{0.5});
-        validate_precision(tz, Std_to_Day, MilliDur{0.05});
-        validate_precision(tz, Std_to_Day, MilliDur{0.005});
-        validate_precision(tz, Std_to_Day, MilliDur{0.0005});
-        // precision limit...
 
-        validate_precision(tz, Std_to_Day, MicroDur{1});
-        validate_precision(tz, Std_to_Day, MicroDur{0.5});
-        // precision limit...
+        validate_precision(tz, Std_to_Day, milliseconds{100});
+        validate_precision(tz, Std_to_Day, milliseconds{10});
+        validate_precision(tz, Std_to_Day, milliseconds{1});
+
+        validate_precision(tz, Std_to_Day, microseconds{100});
+        validate_precision(tz, Std_to_Day, microseconds{10});
+        validate_precision(tz, Std_to_Day, microseconds{1});
 
         // validate opposite transition
-        validate_precision(tz, Day_to_Std, MicroDur{0.5});
-        validate_precision(tz, Day_to_Std, MilliDur{0.0005});
+        validate_precision(tz, Day_to_Std, milliseconds{1});
+        validate_precision(tz, Day_to_Std, microseconds{1});
     }
 }
 

--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
@@ -325,6 +325,12 @@ STATIC_ASSERT(__cpp_lib_char8_t == 201907L);
 
 #ifndef __cpp_lib_chrono
 #error __cpp_lib_chrono is not defined
+#elif _HAS_CXX20 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
+#if __cpp_lib_chrono != 201907L
+#error __cpp_lib_chrono is not 201907L
+#else
+STATIC_ASSERT(__cpp_lib_chrono == 201907L);
+#endif
 #elif _HAS_CXX17
 #if __cpp_lib_chrono != 201611L
 #error __cpp_lib_chrono is not 201611L


### PR DESCRIPTION
This merges the work that @eldakesh-ms and @mnatsuhara have accumulated in our `chronat2` feature branch.

Thanks to @statementreply and @MattStephanson for their assistance, and to everyone who worked on the previous `<chrono>` PRs #1341, #323, and #1789 (including @SuperWig and @d-winsor). *Also* thanks to @barcharcraz and everyone who worked on the `<format>` PRs #1821 and #1834, plus more in flight.

Resolves #12. Completes C++20.

---

You stand at the entrance to the Fortress of Chronat. Unlike the last boss's fortress, which extended to infinity in two directions, this fortress seems eternal instead of infinite. Some of it appears to have been constructed in 1970, but there are moss-covered stones from 1600, and some columns are made of a metal-plastic alloy that hasn't been invented yet. Before you reach for the door's handle, it opens smoothly, as if it knew when you would arrive.

Inside, there is only a desk with a cat-a-day calendar, a ticking metronome, and a globe. A hollow voice booms: "Fool! You think to challenge me? I am more than human. More than machinery. I am a *specification*, and I am everywhere and everywhen. My satellites in orbit have continuously tracked you here. My atomic clocks recorded when you entered this world - and when you will leave. How could you hope to defeat *time itself*? Indeed, you are too late, as I was Standardized months ago!"

You grit your teeth, ready your feature branch, and charge forward with a shout: "Your time is up!"

---

For this (time-critical) review, note that there are a number of cards in the To Do column of the [Chrono Project](https://github.com/microsoft/STL/projects/7?fullscreen=true) tracking minor bugs that will be converted to issues, such as compile-time errors with extreme ratios like `duration<long long, femto>`, incorrect printing of `INT64_MIN`, precision handling in `%S` and `%Q`, and so forth. We expect to fix these in following PRs for VS 2019 16.10 Preview 4 and beyond, but we don't want to delay this feature shipping in Preview 3.

We have about a day to fix any problems found during final review. Severe bugs in common scenarios are the most important to find. Anything that impacts ABI is also important to identify (although we will hopefully have some time between completing C++20 and locking down its ABI, see #1814). If issues aren't very severe, and especially if they are time-consuming to investigate and resolve, we'll file tracking issues. Similarly for comments about possible added test coverage or cleanups (see #1805 for an example).