### PR TITLE
<chrono> Fixes two-digit year formatting for negative centuries.

### DIFF
--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -6113,7 +6113,8 @@ namespace chrono {
                 if (_Has_modifier) {
                     return false;
                 }
-                _Os << _STD format(_STATICALLY_WIDEN(_CharT, "{:02}"), _Year < 0 ? 100 + (_Year % 100) : _Year % 100);
+                _Os << _STD format(
+                    _STATICALLY_WIDEN(_CharT, "{:02}"), _Time_parse_fields::_Decompose_year(_Year).second);
                 return true;
             case 'C':
                 if (_Has_modifier) {

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
@@ -413,6 +413,8 @@ void test_year_formatter() {
 
     assert(format(STR("{:%Y %y%C}"), year{1912}) == STR("1912 1219"));
     assert(format(STR("{:%Y %y%C}"), year{-1912}) == STR("-1912 88-20"));
+    assert(format(STR("{:%Y %y%C}"), year{-200}) == STR("-0200 00-02"));
+    assert(format(STR("{:%Y %y%C}"), year{200}) == STR("0200 0002"));
     // TRANSITION, add tests for EY Oy Ey EC
 
     empty_braces_helper(year{1900}, STR("1900"));


### PR DESCRIPTION
Fixes the issue @statementreply noticed in #1870, that the two-digit year is not calculated correctly for negative centuries.