### PR TITLE
Fix more code bloat issues in <format>

### DIFF
--- a/stl/inc/format
+++ b/stl/inc/format
@@ -2864,7 +2864,7 @@ _NODISCARD auto make_wformat_args(const _Args&... _Vals) {
 
 template <output_iterator<const char&> _OutputIt>
 _OutputIt vformat_to(_OutputIt _Out, const string_view _Fmt, const format_args _Args) {
-    if constexpr (std::is_same_v<_OutputIt, _Fmt_it>) {
+    if constexpr (is_same_v<_OutputIt, _Fmt_it>) {
         _Format_handler<char> _Handler(_Out, _Fmt, _Args, _Lazy_locale{});
         _Parse_format_string(_Fmt, _Handler);
         return _Out;
@@ -2878,7 +2878,7 @@ _OutputIt vformat_to(_OutputIt _Out, const string_view _Fmt, const format_args _
 
 template <output_iterator<const wchar_t&> _OutputIt>
 _OutputIt vformat_to(_OutputIt _Out, const wstring_view _Fmt, const wformat_args _Args) {
-    if constexpr (std::is_same_v<_OutputIt, _Fmt_wit>) {
+    if constexpr (is_same_v<_OutputIt, _Fmt_wit>) {
         _Format_handler<wchar_t> _Handler(_Out, _Fmt, _Args, _Lazy_locale{});
         _Parse_format_string(_Fmt, _Handler);
         return _Out;
@@ -2892,7 +2892,7 @@ _OutputIt vformat_to(_OutputIt _Out, const wstring_view _Fmt, const wformat_args
 
 template <output_iterator<const char&> _OutputIt>
 _OutputIt vformat_to(_OutputIt _Out, const locale& _Loc, const string_view _Fmt, const format_args _Args) {
-    if constexpr (std::is_same_v<_OutputIt, _Fmt_it>) {
+    if constexpr (is_same_v<_OutputIt, _Fmt_it>) {
         _Format_handler<char> _Handler(_Out, _Fmt, _Args, _Lazy_locale{_Loc});
         _Parse_format_string(_Fmt, _Handler);
         return _Out;
@@ -2906,7 +2906,7 @@ _OutputIt vformat_to(_OutputIt _Out, const locale& _Loc, const string_view _Fmt,
 
 template <output_iterator<const wchar_t&> _OutputIt>
 _OutputIt vformat_to(_OutputIt _Out, const locale& _Loc, const wstring_view _Fmt, const wformat_args _Args) {
-    if constexpr (std::is_same_v<_OutputIt, _Fmt_wit>) {
+    if constexpr (is_same_v<_OutputIt, _Fmt_wit>) {
         _Format_handler<wchar_t> _Handler(_Out, _Fmt, _Args, _Lazy_locale{_Loc});
         _Parse_format_string(_Fmt, _Handler);
         return _Out;
@@ -2941,28 +2941,28 @@ _OutputIt format_to(_OutputIt _Out, const locale& _Loc, const wstring_view _Fmt,
 _NODISCARD inline string vformat(const string_view _Fmt, const format_args _Args) {
     string _Str;
     _Str.reserve(_Fmt.size() + _Args._Estimate_required_capacity());
-    _STD vformat_to(_STD back_inserter(_Str), _Fmt, _Args);
+    _STD vformat_to(back_insert_iterator{_Str}, _Fmt, _Args);
     return _Str;
 }
 
 _NODISCARD inline wstring vformat(const wstring_view _Fmt, const wformat_args _Args) {
     wstring _Str;
     _Str.reserve(_Fmt.size() + _Args._Estimate_required_capacity());
-    _STD vformat_to(_STD back_inserter(_Str), _Fmt, _Args);
+    _STD vformat_to(back_insert_iterator{_Str}, _Fmt, _Args);
     return _Str;
 }
 
 _NODISCARD inline string vformat(const locale& _Loc, const string_view _Fmt, const format_args _Args) {
     string _Str;
     _Str.reserve(_Fmt.size() + _Args._Estimate_required_capacity());
-    _STD vformat_to(_STD back_inserter(_Str), _Loc, _Fmt, _Args);
+    _STD vformat_to(back_insert_iterator{_Str}, _Loc, _Fmt, _Args);
     return _Str;
 }
 
 _NODISCARD inline wstring vformat(const locale& _Loc, const wstring_view _Fmt, const wformat_args _Args) {
     wstring _Str;
     _Str.reserve(_Fmt.size() + _Args._Estimate_required_capacity());
-    _STD vformat_to(_STD back_inserter(_Str), _Loc, _Fmt, _Args);
+    _STD vformat_to(back_insert_iterator{_Str}, _Loc, _Fmt, _Args);
     return _Str;
 }
 

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -2865,12 +2865,12 @@ _NODISCARD auto make_wformat_args(const _Args&... _Vals) {
 template <output_iterator<const char&> _OutputIt>
 _OutputIt vformat_to(_OutputIt _Out, const string_view _Fmt, const format_args _Args) {
     if constexpr (is_same_v<_OutputIt, _Fmt_it>) {
-        _Format_handler<char> _Handler(_Out, _Fmt, _Args, _Lazy_locale{});
+        _Format_handler<char> _Handler(_Out, _Fmt, _Args);
         _Parse_format_string(_Fmt, _Handler);
         return _Out;
     } else {
         _Fmt_iterator_buffer<_OutputIt, char> _Buf(_STD move(_Out));
-        _Format_handler<char> _Handler(_Fmt_it{_Buf}, _Fmt, _Args, _Lazy_locale{});
+        _Format_handler<char> _Handler(_Fmt_it{_Buf}, _Fmt, _Args);
         _Parse_format_string(_Fmt, _Handler);
         return _Buf._Out();
     }
@@ -2879,12 +2879,12 @@ _OutputIt vformat_to(_OutputIt _Out, const string_view _Fmt, const format_args _
 template <output_iterator<const wchar_t&> _OutputIt>
 _OutputIt vformat_to(_OutputIt _Out, const wstring_view _Fmt, const wformat_args _Args) {
     if constexpr (is_same_v<_OutputIt, _Fmt_wit>) {
-        _Format_handler<wchar_t> _Handler(_Out, _Fmt, _Args, _Lazy_locale{});
+        _Format_handler<wchar_t> _Handler(_Out, _Fmt, _Args);
         _Parse_format_string(_Fmt, _Handler);
         return _Out;
     } else {
         _Fmt_iterator_buffer<_OutputIt, wchar_t> _Buf(_STD move(_Out));
-        _Format_handler<wchar_t> _Handler(_Fmt_wit{_Buf}, _Fmt, _Args, _Lazy_locale{});
+        _Format_handler<wchar_t> _Handler(_Fmt_wit{_Buf}, _Fmt, _Args);
         _Parse_format_string(_Fmt, _Handler);
         return _Buf._Out();
     }

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -2707,8 +2707,11 @@ struct _Arg_formatter {
 };
 
 // The top level set of parsing "actions".
-template <class _OutputIt, class _CharT, class _Context>
+template <class _CharT>
 struct _Format_handler {
+    using _OutputIt = back_insert_iterator<_Fmt_buffer<_CharT>>;
+    using _Context  = basic_format_context<_OutputIt, _CharT>;
+
     basic_format_parse_context<_CharT> _Parse_context;
     _Context _Ctx;
 
@@ -2859,101 +2862,107 @@ _NODISCARD auto make_wformat_args(const _Args&... _Vals) {
     return _Format_arg_store<wformat_context, _Args...>{_Vals...};
 }
 
-template <class _Out, class _CharT>
-using format_args_t = basic_format_args<basic_format_context<_Out, _CharT>>;
-
 template <output_iterator<const char&> _OutputIt>
-_OutputIt vformat_to(
-    _OutputIt _Out, const string_view _Fmt, const format_args_t<type_identity_t<_OutputIt>, char> _Args) {
-    _Format_handler<_OutputIt, char, basic_format_context<_OutputIt, char>> _Handler(_STD move(_Out), _Fmt, _Args);
-    _Parse_format_string(_Fmt, _Handler);
-    return _Handler._Ctx.out();
+_OutputIt vformat_to(_OutputIt _Out, const string_view _Fmt, const format_args _Args) {
+    if constexpr (std::is_same_v<_OutputIt, _Fmt_it>) {
+        _Format_handler<char> _Handler(_Out, _Fmt, _Args, _Lazy_locale{});
+        _Parse_format_string(_Fmt, _Handler);
+        return _Out;
+    } else {
+        _Fmt_iterator_buffer<_OutputIt, char> _Buf(_STD move(_Out));
+        _Format_handler<char> _Handler(_Fmt_it{_Buf}, _Fmt, _Args, _Lazy_locale{});
+        _Parse_format_string(_Fmt, _Handler);
+        return _Buf._Out();
+    }
 }
 
 template <output_iterator<const wchar_t&> _OutputIt>
-_OutputIt vformat_to(
-    _OutputIt _Out, const wstring_view _Fmt, const format_args_t<type_identity_t<_OutputIt>, wchar_t> _Args) {
-    _Format_handler<_OutputIt, wchar_t, basic_format_context<_OutputIt, wchar_t>> _Handler(
-        _STD move(_Out), _Fmt, _Args);
-    _Parse_format_string(_Fmt, _Handler);
-    return _Handler._Ctx.out();
+_OutputIt vformat_to(_OutputIt _Out, const wstring_view _Fmt, const wformat_args _Args) {
+    if constexpr (std::is_same_v<_OutputIt, _Fmt_wit>) {
+        _Format_handler<wchar_t> _Handler(_Out, _Fmt, _Args, _Lazy_locale{});
+        _Parse_format_string(_Fmt, _Handler);
+        return _Out;
+    } else {
+        _Fmt_iterator_buffer<_OutputIt, wchar_t> _Buf(_STD move(_Out));
+        _Format_handler<wchar_t> _Handler(_Fmt_wit{_Buf}, _Fmt, _Args, _Lazy_locale{});
+        _Parse_format_string(_Fmt, _Handler);
+        return _Buf._Out();
+    }
 }
 
 template <output_iterator<const char&> _OutputIt>
-_OutputIt vformat_to(_OutputIt _Out, const locale& _Loc, const string_view _Fmt,
-    const format_args_t<type_identity_t<_OutputIt>, char> _Args) {
-    _Format_handler<_OutputIt, char, basic_format_context<_OutputIt, char>> _Handler(
-        _STD move(_Out), _Fmt, _Args, _Lazy_locale{_Loc});
-    _Parse_format_string(_Fmt, _Handler);
-    return _Handler._Ctx.out();
+_OutputIt vformat_to(_OutputIt _Out, const locale& _Loc, const string_view _Fmt, const format_args _Args) {
+    if constexpr (std::is_same_v<_OutputIt, _Fmt_it>) {
+        _Format_handler<char> _Handler(_Out, _Fmt, _Args, _Lazy_locale{_Loc});
+        _Parse_format_string(_Fmt, _Handler);
+        return _Out;
+    } else {
+        _Fmt_iterator_buffer<_OutputIt, char> _Buf(_STD move(_Out));
+        _Format_handler<char> _Handler(_Fmt_it{_Buf}, _Fmt, _Args, _Lazy_locale{_Loc});
+        _Parse_format_string(_Fmt, _Handler);
+        return _Buf._Out();
+    }
 }
 
 template <output_iterator<const wchar_t&> _OutputIt>
-_OutputIt vformat_to(_OutputIt _Out, const locale& _Loc, const wstring_view _Fmt,
-    const format_args_t<type_identity_t<_OutputIt>, wchar_t> _Args) {
-    _Format_handler<_OutputIt, wchar_t, basic_format_context<_OutputIt, wchar_t>> _Handler(
-        _STD move(_Out), _Fmt, _Args, _Lazy_locale{_Loc});
-    _Parse_format_string(_Fmt, _Handler);
-    return _Handler._Ctx.out();
+_OutputIt vformat_to(_OutputIt _Out, const locale& _Loc, const wstring_view _Fmt, const wformat_args _Args) {
+    if constexpr (std::is_same_v<_OutputIt, _Fmt_wit>) {
+        _Format_handler<wchar_t> _Handler(_Out, _Fmt, _Args, _Lazy_locale{_Loc});
+        _Parse_format_string(_Fmt, _Handler);
+        return _Out;
+    } else {
+        _Fmt_iterator_buffer<_OutputIt, wchar_t> _Buf(_STD move(_Out));
+        _Format_handler<wchar_t> _Handler(_Fmt_wit{_Buf}, _Fmt, _Args, _Lazy_locale{_Loc});
+        _Parse_format_string(_Fmt, _Handler);
+        return _Buf._Out();
+    }
 }
 
 template <output_iterator<const char&> _OutputIt, class... _Types>
 _OutputIt format_to(_OutputIt _Out, const string_view _Fmt, const _Types&... _Args) {
-    _Fmt_iterator_buffer<_OutputIt, char> _Buf(_STD move(_Out));
-    _STD vformat_to(_Fmt_it{_Buf}, _Fmt, _STD make_format_args(_Args...));
-    return _Buf._Out();
+    return _STD vformat_to(_STD move(_Out), _Fmt, _STD make_format_args(_Args...));
 }
 
 template <output_iterator<const wchar_t&> _OutputIt, class... _Types>
 _OutputIt format_to(_OutputIt _Out, const wstring_view _Fmt, const _Types&... _Args) {
-    _Fmt_iterator_buffer<_OutputIt, wchar_t> _Buf(_STD move(_Out));
-    _STD vformat_to(_Fmt_wit{_Buf}, _Fmt, _STD make_wformat_args(_Args...));
-    return _Buf._Out();
+    return _STD vformat_to(_STD move(_Out), _Fmt, _STD make_wformat_args(_Args...));
 }
 
 template <output_iterator<const char&> _OutputIt, class... _Types>
 _OutputIt format_to(_OutputIt _Out, const locale& _Loc, const string_view _Fmt, const _Types&... _Args) {
-    _Fmt_iterator_buffer<_OutputIt, char> _Buf(_STD move(_Out));
-    _STD vformat_to(_Fmt_it{_Buf}, _Loc, _Fmt, _STD make_format_args(_Args...));
-    return _Buf._Out();
+    return _STD vformat_to(_STD move(_Out), _Loc, _Fmt, _STD make_format_args(_Args...));
 }
 
 template <output_iterator<const wchar_t&> _OutputIt, class... _Types>
 _OutputIt format_to(_OutputIt _Out, const locale& _Loc, const wstring_view _Fmt, const _Types&... _Args) {
-    _Fmt_iterator_buffer<_OutputIt, wchar_t> _Buf(_STD move(_Out));
-    _STD vformat_to(_Fmt_wit{_Buf}, _Loc, _Fmt, _STD make_wformat_args(_Args...));
-    return _Buf._Out();
+    return _STD vformat_to(_STD move(_Out), _Loc, _Fmt, _STD make_wformat_args(_Args...));
 }
 
 _NODISCARD inline string vformat(const string_view _Fmt, const format_args _Args) {
     string _Str;
     _Str.reserve(_Fmt.size() + _Args._Estimate_required_capacity());
-    _Fmt_iterator_buffer<back_insert_iterator<string>, char> _Buf(back_insert_iterator{_Str});
-    _STD vformat_to(_Fmt_it{_Buf}, _Fmt, _Args);
+    _STD vformat_to(_STD back_inserter(_Str), _Fmt, _Args);
     return _Str;
 }
 
 _NODISCARD inline wstring vformat(const wstring_view _Fmt, const wformat_args _Args) {
     wstring _Str;
     _Str.reserve(_Fmt.size() + _Args._Estimate_required_capacity());
-    _Fmt_iterator_buffer<back_insert_iterator<wstring>, wchar_t> _Buf(back_insert_iterator{_Str});
-    _STD vformat_to(_Fmt_wit{_Buf}, _Fmt, _Args);
+    _STD vformat_to(_STD back_inserter(_Str), _Fmt, _Args);
     return _Str;
 }
 
 _NODISCARD inline string vformat(const locale& _Loc, const string_view _Fmt, const format_args _Args) {
     string _Str;
     _Str.reserve(_Fmt.size() + _Args._Estimate_required_capacity());
-    _Fmt_iterator_buffer<back_insert_iterator<string>, char> _Buf(back_insert_iterator{_Str});
-    _STD vformat_to(_Fmt_it{_Buf}, _Loc, _Fmt, _Args);
+    _STD vformat_to(_STD back_inserter(_Str), _Loc, _Fmt, _Args);
     return _Str;
 }
 
 _NODISCARD inline wstring vformat(const locale& _Loc, const wstring_view _Fmt, const wformat_args _Args) {
     wstring _Str;
     _Str.reserve(_Fmt.size() + _Args._Estimate_required_capacity());
-    _Fmt_iterator_buffer<back_insert_iterator<wstring>, wchar_t> _Buf(back_insert_iterator{_Str});
-    _STD vformat_to(_Fmt_wit{_Buf}, _Loc, _Fmt, _Args);
+    _STD vformat_to(_STD back_inserter(_Str), _Loc, _Fmt, _Args);
     return _Str;
 }
 

--- a/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
@@ -47,8 +47,11 @@ struct choose_literal<wchar_t> {
 
 template <class charT, class... Args>
 auto make_testing_format_args(Args&&... vals) {
-    using context = basic_format_context<back_insert_iterator<basic_string<charT>>, charT>;
-    return make_format_args<context>(forward<Args>(vals)...);
+    if constexpr (is_same_v<charT, wchar_t>) {
+        return make_wformat_args(forward<Args>(vals)...);
+    } else {
+        return make_format_args(forward<Args>(vals)...);
+    }
 }
 
 template <class charT, class... Args>


### PR DESCRIPTION
#1851 works around some code bloat issues by "type erasing" the output iterator. This diff fixes the root cause, `vformat_to`, removing the remaining code bloat issue. It also cleans up `format_to` and `vformat` by removing explicit buffer handling from there. `format_to_n` and `formatted_size` continue to use buffers directly as an optimization.

This change applies the second fix from [P2216](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p2216r3.html) that has been approved by LEWG and LWG and is awaiting plenary. The main change is to remove unnecessary template parameterization of format arguments passed to `vformat_to`.

Fixes #1883.