### PR TITLE
`<format>`: Fix signed/unsigned mismatch in `_In_bounds`

### DIFF
--- a/stl/inc/format
+++ b/stl/inc/format
@@ -2049,17 +2049,12 @@ inline void _Buffer_to_uppercase(char* _Begin, const char* _End) {
     }
 }
 
+template <class _Ty>
+using _Make_standard_integer = conditional_t<is_signed_v<_Ty>, make_signed_t<_Ty>, make_unsigned_t<_Ty>>;
+
 template <class _CharT, integral _Ty>
 _NODISCARD constexpr bool _In_bounds(const _Ty _Value) {
-    if constexpr (is_unsigned_v<_CharT> && is_unsigned_v<_Ty>) {
-        return _Value <= (numeric_limits<_CharT>::max)();
-    } else if constexpr (is_unsigned_v<_CharT>) {
-        return _Value >= 0 && static_cast<make_unsigned_t<_Ty>>(_Value) <= (numeric_limits<_CharT>::max)();
-    } else if constexpr (is_unsigned_v<_Ty>) {
-        return _Value <= static_cast<make_unsigned_t<_CharT>>((numeric_limits<_CharT>::max)());
-    } else {
-        return (numeric_limits<_CharT>::min)() <= _Value && _Value <= (numeric_limits<_CharT>::max)();
-    }
+    return _STD in_range<_Make_standard_integer<_CharT>>(static_cast<_Make_standard_integer<_Ty>>(_Value));
 }
 
 _NODISCARD inline int _Count_separators(size_t _Digits, const string_view _Groups) {


### PR DESCRIPTION
This reimplements `<format>`'s `_In_bounds` with C++20 `in_range` to fix VSO-1314150 "[RWC][Regression][prod/fe][std:c++latest] Google_Snappy/Glslang/ITK failed with warning C4018". (I haven't personally reproed this warning, but the messages clearly indicate `_In_bounds`, and C++20 `in_range` should completely avoid such warnings in addition to having an optimal implementation.)

We need `_Make_standard_integer` to map any character types (`char`, `wchar_t`, `char8_t`, `char16_t`, `char32_t`) to the signed/unsigned integer types (`[unsigned]` `char`/`short`/`int`/`long`/`long long`) with the same signedness/width, because C++20 `in_range` requires that. We specifically don't handle `bool`, which should never be given to `_In_bounds` (I checked the usage) and is rejected with a guaranteed `static_assert` by C++20 `in_range`.

<details>
  <summary>warning C4018: '<=': signed/unsigned mismatch</summary>

```
gtest-all.i(127456): error C2220: the following warning is treated as an error
gtest-all.i(127560): note: see reference to function template instantiation 'bool std::_In_bounds<_CharT,_Integral>(const _Ty)' being compiled
        with
        [
            _CharT=char,
            _Integral=int,
            _Ty=int
        ]
gtest-all.i(127669): note: see reference to function template instantiation '_OutputIt std::_Write_integral<_CharT,std::back_insert_iterator<std::string>,_Integral>(_OutputIt,const _Integral,std::_Basic_format_specs<_CharT>,std::locale)' being compiled
        with
        [
            _OutputIt=std::back_insert_iterator<std::string>,
            _CharT=char,
            _Integral=int
        ]
gtest-all.i(128179): note: see reference to function template instantiation '_OutputIt std::_Fmt_write<_CharT,std::back_insert_iterator<std::string>,_Ty>(_OutputIt,const _Integral,const std::_Basic_format_specs<_CharT> &,std::locale)' being compiled
        with
        [
            _OutputIt=std::back_insert_iterator<std::string>,
            _CharT=char,
            _Ty=int,
            _Integral=int
        ]
gtest-all.i(126088): note: see reference to function template instantiation '_OutputIt std::_Arg_formatter<_OutputIt,_CharT>::operator ()<int>(_Ty)' being compiled
        with
        [
            _OutputIt=std::back_insert_iterator<std::string>,
            _CharT=char,
            _Ty=int
        ]
gtest-all.i(126088): note: see reference to function template instantiation '_OutputIt std::_Arg_formatter<_OutputIt,_CharT>::operator ()<int>(_Ty)' being compiled
        with
        [
            _OutputIt=std::back_insert_iterator<std::string>,
            _CharT=char,
            _Ty=int
        ]
gtest-all.i(128221): note: see reference to function template instantiation '_OutputIt std::visit_format_arg<std::_Arg_formatter<_OutputIt,_CharT>,_Context>(_Visitor &&,std::basic_format_arg<_Context>)' being compiled
        with
        [
            _OutputIt=std::back_insert_iterator<std::string>,
            _CharT=char,
            _Context=std::format_context,
            _Visitor=std::_Arg_formatter<std::back_insert_iterator<std::string>,char>
        ]
gtest-all.i(128203): note: while compiling class template member function 'const _CharT *std::_Format_handler<_OutputIt,_CharT,std::basic_format_context<std::back_insert_iterator<std::string>,_CharT>>::_On_format_specs(const size_t,const _CharT *,const _CharT *)'
        with
        [
            _CharT=char,
            _OutputIt=std::back_insert_iterator<std::string>
        ]
gtest-all.i(126551): note: see reference to function template instantiation 'const _CharT *std::_Format_handler<_OutputIt,_CharT,std::basic_format_context<std::back_insert_iterator<std::string>,_CharT>>::_On_format_specs(const size_t,const _CharT *,const _CharT *)' being compiled
        with
        [
            _CharT=char,
            _OutputIt=std::back_insert_iterator<std::string>
        ]
gtest-all.i(128342): note: see reference to class template instantiation 'std::_Format_handler<_OutputIt,char,std::basic_format_context<std::back_insert_iterator<std::string>,char>>' being compiled
        with
        [
            _OutputIt=std::back_insert_iterator<std::string>
        ]
gtest-all.i(128400): note: see reference to function template instantiation '_OutputIt std::vformat_to<std::back_insert_iterator<std::string>>(_OutputIt,const std::string_view,const std::basic_format_args<std::format_context>)' being compiled
        with
        [
            _OutputIt=std::back_insert_iterator<std::string>
        ]
gtest-all.i(127456): warning C4018: '<=': signed/unsigned mismatch
gtest-all.i(127454): warning C4018: '<=': signed/unsigned mismatch
gtest-all.i(127560): note: see reference to function template instantiation 'bool std::_In_bounds<_CharT,_Integral>(const _Ty)' being compiled
        with
        [
            _CharT=char,
            _Integral=unsigned int,
            _Ty=unsigned int
        ]
gtest-all.i(127669): note: see reference to function template instantiation '_OutputIt std::_Write_integral<_CharT,std::back_insert_iterator<std::string>,_Integral>(_OutputIt,const _Integral,std::_Basic_format_specs<_CharT>,std::locale)' being compiled
        with
        [
            _OutputIt=std::back_insert_iterator<std::string>,
            _CharT=char,
            _Integral=unsigned int
        ]
gtest-all.i(128179): note: see reference to function template instantiation '_OutputIt std::_Fmt_write<_CharT,std::back_insert_iterator<std::string>,_Ty>(_OutputIt,const _Integral,const std::_Basic_format_specs<_CharT> &,std::locale)' being compiled
        with
        [
            _OutputIt=std::back_insert_iterator<std::string>,
            _CharT=char,
            _Ty=unsigned int,
            _Integral=unsigned int
        ]
gtest-all.i(126090): note: see reference to function template instantiation '_OutputIt std::_Arg_formatter<_OutputIt,_CharT>::operator ()<unsigned int>(_Ty)' being compiled
        with
        [
            _OutputIt=std::back_insert_iterator<std::string>,
            _CharT=char,
            _Ty=unsigned int
        ]
gtest-all.i(126090): note: see reference to function template instantiation '_OutputIt std::_Arg_formatter<_OutputIt,_CharT>::operator ()<unsigned int>(_Ty)' being compiled
        with
        [
            _OutputIt=std::back_insert_iterator<std::string>,
            _CharT=char,
            _Ty=unsigned int
        ]
```
</details>
