### PR TITLE
<chrono>: Adjust for leap seconds when formatting `file_time`

### DIFF
--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -6467,8 +6467,9 @@ struct formatter<_CHRONO file_time<_Duration>, _CharT> {
 
     template <class _FormatContext>
     auto format(const _CHRONO file_time<_Duration>& _Val, _FormatContext& _FormatCtx) {
-        const auto _Sys = _CHRONO clock_cast<_CHRONO system_clock>(_Val);
-        return _Impl._Write(_FormatCtx, _Val, _Fill_tm(_Sys));
+        const auto _Utc = _CHRONO file_clock::to_utc(_Val);
+        const auto _Sys = _CHRONO utc_clock::to_sys(_Utc);
+        return _Impl._Write(_FormatCtx, _Utc, _Fill_tm(_Sys));
     }
 
 private:

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
@@ -296,6 +296,11 @@ void test_clock_formatter() {
             }
         }
     }
+
+    empty_braces_helper(file_clock::from_utc(utc_2016_12_31), STR("2016-12-31 00:00:00"));
+    empty_braces_helper(file_clock::from_utc(utc_2016_12_31) + 24h, STR("2017-01-01 00:00:00"));
+    empty_braces_helper(file_clock::from_utc(utc_2021_05_04), STR("2021-05-04 00:00:00"));
+    // TRANSITION: Test a leap second insertion after 2018-06 when there is one
 }
 
 template <typename CharT>


### PR DESCRIPTION
<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
Fixes #1899 

This PR does _not_ address #1822.

Edited to link to newly-created issue #1899, made while cleaning out the chrono project.  