### PR TITLE
Toolset update: VS 2019 16.10 Preview 2

### DIFF
--- a/.github/workflows/update-status-chart.yml
+++ b/.github/workflows/update-status-chart.yml
@@ -8,6 +8,7 @@ on:
   workflow_dispatch:
 jobs:
   build:
+    if: ${{ github.repository == 'microsoft/STL' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout gh-pages
@@ -17,7 +18,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: ">=15.12.0"
+          node-version: ">=16.0.0"
       - name: Run gather_stats.js
         run: |
           npm ci

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 __pycache__/
 .vs/
 .vscode/
+/azure-devops/vmss-config.json
+/azure-devops/vmss-protected.json
 /build/
 /out/
 /tools/out/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if (NOT DEFINED CMAKE_TOOLCHAIN_FILE AND EXISTS "${CMAKE_CURRENT_LIST_DIR}/vcpkg
     set(CMAKE_TOOLCHAIN_FILE "${CMAKE_CURRENT_LIST_DIR}/vcpkg/scripts/buildsystems/vcpkg.cmake")
 endif()
 
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION 3.20)
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 project(msvc_standard_libraries LANGUAGES CXX)
 

--- a/README.md
+++ b/README.md
@@ -143,10 +143,10 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 The STL uses boost-math headers to provide P0226R1 Mathematical Special Functions. We recommend using [vcpkg][] to
 acquire this dependency.
 
-1. Install Visual Studio 2019 16.10 Preview 1 or later.
+1. Install Visual Studio 2019 16.10 Preview 2 or later.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
-    * Otherwise, install [CMake][] 3.19 or later, and [Ninja][] 1.10.2 or later.
+    * Otherwise, install [CMake][] 3.20 or later, and [Ninja][] 1.10.2 or later.
 2. Open Visual Studio, and choose the "Clone or check out code" option. Enter the URL of this repository,
    `https://github.com/microsoft/STL`.
 3. Open a terminal in the IDE with `` Ctrl + ` `` (by default) or press on "View" in the top bar, and then "Terminal".
@@ -158,10 +158,10 @@ acquire this dependency.
 
 # How To Build With A Native Tools Command Prompt
 
-1. Install Visual Studio 2019 16.10 Preview 1 or later.
+1. Install Visual Studio 2019 16.10 Preview 2 or later.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
-    * Otherwise, install [CMake][] 3.19 or later, and [Ninja][] 1.10.2 or later.
+    * Otherwise, install [CMake][] 3.20 or later, and [Ninja][] 1.10.2 or later.
 2. Open a command prompt.
 3. Change directories to a location where you'd like a clone of this STL repository.
 4. `git clone https://github.com/microsoft/STL`
@@ -234,7 +234,7 @@ C:\Users\username\Desktop>dumpbin /IMPORTS .\example.exe | findstr msvcp
 # How To Run The Tests With A Native Tools Command Prompt
 
 1. Follow either [How To Build With A Native Tools Command Prompt][] or [How To Build With The Visual Studio IDE][].
-2. Acquire [Python][] 3.9.2 or newer and have it on the `PATH` (or run it directly using its absolute or relative path).
+2. Acquire [Python][] 3.9.4 or newer and have it on the `PATH` (or run it directly using its absolute or relative path).
 3. Have LLVM's `bin` directory on the `PATH` (so `clang-cl.exe` is available).
     * We recommend selecting "C++ Clang tools for Windows" in the VS Installer. This will automatically add LLVM to the
     `PATH` of the x86 and x64 Native Tools Command Prompts, and will ensure that you're using a supported version.

--- a/azure-devops/create-vmss.ps1
+++ b/azure-devops/create-vmss.ps1
@@ -30,7 +30,7 @@ $ImageOffer = 'Windows-10'
 $ImageSku = '20h2-ent-g2'
 
 $ProgressActivity = 'Creating Scale Set'
-$TotalProgress = 12
+$TotalProgress = 13
 $CurrentProgress = 1
 
 <#
@@ -399,6 +399,19 @@ New-AzVmss `
   -ResourceGroupName $ResourceGroupName `
   -Name $VmssName `
   -VirtualMachineScaleSet $Vmss
+
+####################################################################################################
+Write-Progress `
+  -Activity $ProgressActivity `
+  -Status 'Enabling VMSS diagnostic logs' `
+  -PercentComplete (100 / $TotalProgress * $CurrentProgress++)
+
+az vmss diagnostics set `
+  --resource-group $ResourceGroupName `
+  --vmss-name $VmssName `
+  --settings "$PSScriptRoot\vmss-config.json" `
+  --protected-settings "$PSScriptRoot\vmss-protected.json" `
+  --output none
 
 ####################################################################################################
 Write-Progress -Activity $ProgressActivity -Completed

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -91,7 +91,7 @@ if ([string]::IsNullOrEmpty($AdminUserPassword)) {
   $PsExecPath = Join-Path $ExtractedPsToolsPath 'PsExec64.exe'
 
   # https://github.com/PowerShell/PowerShell/releases/latest
-  $PowerShellZipUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.1.2/PowerShell-7.1.2-win-x64.zip'
+  $PowerShellZipUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.1.3/PowerShell-7.1.3-win-x64.zip'
   Write-Host "Downloading: $PowerShellZipUrl"
   $ExtractedPowerShellPath = DownloadAndExtractZip -Url $PowerShellZipUrl
   $PwshPath = Join-Path $ExtractedPowerShellPath 'pwsh.exe'
@@ -139,7 +139,7 @@ $Workloads = @(
 $ReleaseInPath = 'Preview'
 $Sku = 'Enterprise'
 $VisualStudioBootstrapperUrl = 'https://aka.ms/vs/16/pre/vs_enterprise.exe'
-$PythonUrl = 'https://www.python.org/ftp/python/3.9.2/python-3.9.2-amd64.exe'
+$PythonUrl = 'https://www.python.org/ftp/python/3.9.4/python-3.9.4-amd64.exe'
 
 # https://docs.microsoft.com/en-us/windows-hardware/drivers/download-the-wdk
 $WindowsDriverKitUrl = 'https://go.microsoft.com/fwlink/?linkid=2128854'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@ variables:
   buildOutputLocation: 'D:\build'
   vcpkgLocation: '$(Build.SourcesDirectory)/vcpkg'
 
-pool: 'StlBuild-2021-03-09-win10'
+pool: 'StlBuild-2021-04-23'
 
 stages:
   - stage: Code_Format

--- a/tests/std/tests/P1502R1_standard_library_header_units/custom_format.py
+++ b/tests/std/tests/P1502R1_standard_library_header_units/custom_format.py
@@ -101,12 +101,12 @@ class CustomTestFormat(STLTestFormat):
             compileTestCppWithEdg = True
             test.compileFlags.remove('/BE')
 
-        exportHeaderOptions = ['/exportHeader', '/Fo', '/MP']
+        exportHeaderOptions = ['/exportHeader', '/headerName:angle', '/Fo', '/MP']
         headerUnitOptions = []
         for header in stlHeaders:
             headerAbsolutePath = os.path.join(litConfig.cxx_headers, header)
 
-            exportHeaderOptions.append(headerAbsolutePath)
+            exportHeaderOptions.append(header)
 
             headerUnitOptions.append('/headerUnit')
             headerUnitOptions.append('{0}={1}.ifc'.format(headerAbsolutePath, header))

--- a/tests/std/tests/P1502R1_standard_library_header_units/custom_format.py
+++ b/tests/std/tests/P1502R1_standard_library_header_units/custom_format.py
@@ -104,12 +104,10 @@ class CustomTestFormat(STLTestFormat):
         exportHeaderOptions = ['/exportHeader', '/headerName:angle', '/Fo', '/MP']
         headerUnitOptions = []
         for header in stlHeaders:
-            headerAbsolutePath = os.path.join(litConfig.cxx_headers, header)
-
             exportHeaderOptions.append(header)
 
-            headerUnitOptions.append('/headerUnit')
-            headerUnitOptions.append('{0}={1}.ifc'.format(headerAbsolutePath, header))
+            headerUnitOptions.append('/headerUnit:angle')
+            headerUnitOptions.append('{0}={0}.ifc'.format(header))
 
             if not compileTestCppWithEdg:
                 headerUnitOptions.append(os.path.join(outputDir, header + '.obj'))

--- a/tests/std/tests/P1502R1_standard_library_header_units/custombuild.pl
+++ b/tests/std/tests/P1502R1_standard_library_header_units/custombuild.pl
@@ -88,11 +88,11 @@ sub CustomBuildHook()
         "version",
     );
 
-    my $export_header_options = "/exportHeader /Fo /MP";
+    my $export_header_options = "/exportHeader /headerName:angle /Fo /MP";
     my $header_unit_options = "";
 
     foreach (@stl_headers) {
-        $export_header_options .= " $stl_include_dir/$_";
+        $export_header_options .= " $_";
 
         $header_unit_options .= " /headerUnit";
         $header_unit_options .= " $stl_include_dir/$_=$_.ifc";

--- a/tests/std/tests/P1502R1_standard_library_header_units/custombuild.pl
+++ b/tests/std/tests/P1502R1_standard_library_header_units/custombuild.pl
@@ -6,7 +6,6 @@ use Run;
 sub CustomBuildHook()
 {
     my $cwd = Run::GetCWDName();
-    my $stl_include_dir = $ENV{STL_INCLUDE_DIR};
 
     my @stl_headers = (
         "algorithm",
@@ -94,8 +93,8 @@ sub CustomBuildHook()
     foreach (@stl_headers) {
         $export_header_options .= " $_";
 
-        $header_unit_options .= " /headerUnit";
-        $header_unit_options .= " $stl_include_dir/$_=$_.ifc";
+        $header_unit_options .= " /headerUnit:angle";
+        $header_unit_options .= " $_=$_.ifc";
         $header_unit_options .= " $_.obj";
     }
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION 3.20)
 project(msvc_standard_libraries_tools LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 20)


### PR DESCRIPTION
* Update the toolset to VS 2019 16.10 Preview 2.
  + This also enables VMSS diagnostic logs, now required by policy. The [checklist](https://github.com/microsoft/STL/wiki/Checklist-for-Updating-Toolset-and-or-Dependencies) has been updated accordingly.
  + This contains CMake 3.20, now required, which fixes #836.
* Change the Update Status Chart workflow to run for microsoft/STL only, as requested by @AdamBucior in #1769. I've tested this in my fork.
  + This also increases the required node-version. It doesn't really matter (the workflow always retrieves the latest) but it's a new major version.
* In the Standard Library Header Units test, use `/exportHeader /headerName:angle` and `/headerUnit:angle` (supported in Preview 2) to avoid the need for absolute paths.
* Test `vector`'s `constexpr` spaceships (supported in Preview 2), which fixes #1677.