### PR TITLE
Fixed a narrowing conversion bug in std::views::take_view.

### DIFF
--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -1927,7 +1927,7 @@ namespace ranges {
                 if constexpr (random_access_range<_Vw>) {
                     return _RANGES begin(_Range);
                 } else {
-                    const auto _Size = size();
+                    const auto _Size = static_cast<range_difference_t<_Vw>>(size());
                     return counted_iterator{_RANGES begin(_Range), _Size};
                 }
             } else {
@@ -1940,7 +1940,7 @@ namespace ranges {
                 if constexpr (random_access_range<const _Vw>) {
                     return _RANGES begin(_Range);
                 } else {
-                    const auto _Size = size();
+                    const auto _Size = static_cast<range_difference_t<_Vw>>(size());
                     return counted_iterator{_RANGES begin(_Range), _Size};
                 }
             } else {


### PR DESCRIPTION
_Size type is decltype(std::ranges::size(_Range)).
But, counted_iterator's second parameter type is const iter_difference_t<_Iter>.
