### PR TITLE
Status Chart: Avoid emitting consecutive zeros

### DIFF
--- a/index.html
+++ b/index.html
@@ -372,9 +372,9 @@
                         text: 'Average Age, Average Wait (days)',
                     },
                     min: 0,
-                    max: 150,
+                    max: 180,
                     ticks: {
-                        stepSize: 10,
+                        stepSize: 20,
                     },
                 },
                 rightAxis: {
@@ -386,9 +386,9 @@
                         text: 'Combined Age, Combined Wait (PR-months)',
                     },
                     min: 0,
-                    max: 150,
+                    max: 180,
                     ticks: {
-                        stepSize: 10,
+                        stepSize: 20,
                     },
                 },
             },

--- a/index.html
+++ b/index.html
@@ -26,8 +26,8 @@
             font-weight: bold;
         }
     </style>
-    <script src="https://cdn.jsdelivr.net/npm/chart.js@3.2.0/dist/chart.min.js"
-        integrity="sha256-ovnFmAOngtHmlhZzPyGrofexz4Kdik4kEobc8B9r1Yk=" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@3.2.1/dist/chart.min.js"
+        integrity="sha256-uVEHWRIr846/vAdLJeybWxjPNStREzOlqLMXjW/Saeo=" crossorigin="anonymous"></script>
     <script
         src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns@2.0.0/dist/chartjs-adapter-date-fns.bundle.min.js"
         integrity="sha256-xlxh4PaMDyZ72hWQ7f/37oYI0E2PrBbtzi1yhvnG+/E=" crossorigin="anonymous"></script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,9 +37,9 @@
       }
     },
     "node_modules/@octokit/openapi-types": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-6.2.0.tgz",
-      "integrity": "sha512-V2vFYuawjpP5KUb8CPYsq20bXT4qnE8sH1QKpYqUlcNOntBiRr/VzGVvY0s+YXGgrVbFUVO4EI0VnHYSVBWfBg=="
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-7.0.0.tgz",
+      "integrity": "sha512-gV/8DJhAL/04zjTI95a7FhQwS6jlEE0W/7xeYAzuArD0KVAVWDLP2f3vi98hs3HLTczxXdRK/mF0tRoQPpolEw=="
     },
     "node_modules/@octokit/request": {
       "version": "5.4.15",
@@ -65,11 +65,11 @@
       }
     },
     "node_modules/@octokit/types": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.14.0.tgz",
-      "integrity": "sha512-43qHvDsPsKgNt4W4al3dyU6s2XZ7ZMsiiIw8rQcM9CyEo7g9W8/6m1W4xHuRqmEjTfG1U4qsE/E4Jftw1/Ak1g==",
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.14.2.tgz",
+      "integrity": "sha512-wiQtW9ZSy4OvgQ09iQOdyXYNN60GqjCL/UdMsepDr1Gr0QzpW6irIKbH3REuAHXAhxkEk9/F2a3Gcs1P6kW5jA==",
       "dependencies": {
-        "@octokit/openapi-types": "^6.2.0"
+        "@octokit/openapi-types": "^7.0.0"
       }
     },
     "node_modules/ansi-regex": {
@@ -328,9 +328,9 @@
       }
     },
     "@octokit/openapi-types": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-6.2.0.tgz",
-      "integrity": "sha512-V2vFYuawjpP5KUb8CPYsq20bXT4qnE8sH1QKpYqUlcNOntBiRr/VzGVvY0s+YXGgrVbFUVO4EI0VnHYSVBWfBg=="
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-7.0.0.tgz",
+      "integrity": "sha512-gV/8DJhAL/04zjTI95a7FhQwS6jlEE0W/7xeYAzuArD0KVAVWDLP2f3vi98hs3HLTczxXdRK/mF0tRoQPpolEw=="
     },
     "@octokit/request": {
       "version": "5.4.15",
@@ -356,11 +356,11 @@
       }
     },
     "@octokit/types": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.14.0.tgz",
-      "integrity": "sha512-43qHvDsPsKgNt4W4al3dyU6s2XZ7ZMsiiIw8rQcM9CyEo7g9W8/6m1W4xHuRqmEjTfG1U4qsE/E4Jftw1/Ak1g==",
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.14.2.tgz",
+      "integrity": "sha512-wiQtW9ZSy4OvgQ09iQOdyXYNN60GqjCL/UdMsepDr1Gr0QzpW6irIKbH3REuAHXAhxkEk9/F2a3Gcs1P6kW5jA==",
       "requires": {
-        "@octokit/openapi-types": "^6.2.0"
+        "@octokit/openapi-types": "^7.0.0"
       }
     },
     "ansi-regex": {

--- a/usernames_contributors.txt
+++ b/usernames_contributors.txt
@@ -1,6 +1,7 @@
 # This is very far from an exhaustive list of contributors, and confers no special status.
 # It's simply a list of contributors who have submitted a PR review marked as CHANGES_REQUESTED.
 
+2002Bishwajeet
 AdamBucior
 AlexGuteniev
 fsb4000

--- a/weekly_table.js
+++ b/weekly_table.js
@@ -204,4 +204,5 @@ const weekly_table = [
     { date: '2021-04-09', vso: 163, libcxx: 579 },
     { date: '2021-04-16', vso: 164, libcxx: 579 },
     { date: '2021-04-23', vso: 173, libcxx: 594 },
+    { date: '2021-04-30', vso: 173, libcxx: 594 },
 ];


### PR DESCRIPTION
* Avoid emitting consecutive zeros.
  + Now that we've finished C++20, the `cxx20` line is constantly zero. I want it to simply vanish, as the C++17 line did (which was manually recorded in weekly_table.js, so we just stopped recording data points). To do this in a general way, I'm splitting the daily table generation into two phases. First, we calculate all of the data points (this part takes a bit of time, so there's a progress bar). Then, we determine which data points should be kept - this requires looking at the previous and next values, so it has to be a separate phase. `should_emit_data_point()` will keep a value if it's nonzero (which we definitely need!), if the previous value exists and was nonzero (because when we fall to zero, we want to record a single zero before stopping), or if the next value exists and will be nonzero (to properly display liftoff from zero).
  + The optional chaining operator `?.` makes this look very nice because the bounds checks are implicit. In `rows[i - 1]?.[key] > 0`, when `i === 0`, then `rows[i - 1]` will be `undefined`; the optional chaining operator will short-circuit instead of attempting to access the `[key]` (which would otherwise be an error) and return `undefined`. Then `undefined > 0` is `false`, which is what we want - at the beginning of the dataset, there is no previous value to consider, so we'll consider only the current and next data point.
  + This also allows us to drop the hardcoded `begin_cxx23`.
* npm update.
* weekly_table.js: 2021-04-30 update.
* Adjust PR Age max and stepSize.
* Update usernames_contributors.txt.
* chart.js 3.2.1.

:chart_with_downwards_trend: Live preview: [stephantlavavej.github.io/STL/](https://stephantlavavej.github.io/STL/)
===
Note: To avoid merge conflicts, this doesn't update `daily_table.js`, thus the effect of dropping zeros can't be seen yet. It affects the beginning of the `bug` line, and the end of the `cxx20` line.