### PR TITLE
`<format>`: Simplify type-erased argument storage

### DIFF
--- a/stl/inc/format
+++ b/stl/inc/format
@@ -1510,7 +1510,7 @@ public:
 
 private:
     template <class _Ty>
-    _NODISCARD static auto _Get_value_from_memory(const unsigned char* _Val) noexcept {
+    _NODISCARD static auto _Get_value_from_memory(const unsigned char* const _Val) noexcept {
         auto& _Temp = *reinterpret_cast<const unsigned char(*)[sizeof(_Ty)]>(_Val);
         return _Bit_cast<_Ty>(_Temp);
     }

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -1272,105 +1272,70 @@ concept _Has_formatter = requires(const _Ty& _Val, _Context& _Ctx) {
     _STD declval<typename _Context::template formatter_type<_Ty>>().format(_Val, _Ctx);
 };
 
-template <class _CharT>
-_NODISCARD constexpr size_t _Get_format_arg_type_storage_size(_Basic_format_arg_type _Type) noexcept {
-    switch (_Type) {
-    case _Basic_format_arg_type::_Int_type:
-        return sizeof(int);
-    case _Basic_format_arg_type::_UInt_type:
-        return sizeof(unsigned int);
-    case _Basic_format_arg_type::_Long_long_type:
-        return sizeof(long long);
-    case _Basic_format_arg_type::_ULong_long_type:
-        return sizeof(unsigned long long);
-    case _Basic_format_arg_type::_Bool_type:
-        return sizeof(bool);
-    case _Basic_format_arg_type::_Char_type:
-        return sizeof(_CharT);
-    case _Basic_format_arg_type::_Float_type:
-        return sizeof(float);
-    case _Basic_format_arg_type::_Double_type:
-        return sizeof(double);
-    case _Basic_format_arg_type::_Long_double_type:
-        return sizeof(long double);
-    case _Basic_format_arg_type::_Pointer_type:
-        return sizeof(void*);
-    case _Basic_format_arg_type::_CString_type:
-        return sizeof(const _CharT*);
-    case _Basic_format_arg_type::_String_type:
-        return sizeof(basic_string_view<_CharT>);
-    case _Basic_format_arg_type::_Custom_type:
-        return sizeof(void*) + sizeof(void (*)());
-    case _Basic_format_arg_type::_None:
-    default:
-        _STL_INTERNAL_CHECK(false);
-        return 0;
-    }
-}
-
-// See N4878 [format.arg]/5
-template <class _Context, _Has_formatter<_Context> _Ty>
-auto _Get_format_arg_storage_type(const _Ty&) {
-    // This function implements a mapping between types; it is never called outside of unevaluated operands.
+template <class _Context>
+struct _Format_arg_traits {
     using _Char_type = typename _Context::char_type;
-    if constexpr (is_same_v<_Ty, monostate>) {
-        return monostate{};
-    } else if constexpr (is_same_v<_Ty, bool>) {
-        return bool{};
-    } else if constexpr (is_same_v<_Ty, _Char_type>) {
-        return _Char_type{};
-    } else if constexpr (is_same_v<_Ty, char> && is_same_v<_Char_type, wchar_t>) {
-        return _Char_type{};
-    } else if constexpr (signed_integral<_Ty> && sizeof(_Ty) <= sizeof(int)) {
-        return int{};
-    } else if constexpr (unsigned_integral<_Ty> && sizeof(_Ty) <= sizeof(unsigned int)) {
-        return static_cast<unsigned int>(42);
-    } else if constexpr (signed_integral<_Ty> && sizeof(_Ty) <= sizeof(long long)) {
-        return static_cast<long long>(42);
-    } else if constexpr (unsigned_integral<_Ty> && sizeof(_Ty) <= sizeof(unsigned long long)) {
-        return static_cast<unsigned long long>(42);
-    } else if constexpr (is_same_v<_Ty, float>) {
-        return float{};
-    } else if constexpr (is_same_v<_Ty, double>) {
-        return double{};
-    } else if constexpr (is_same_v<_Ty, long double>) {
-        return static_cast<long double>(42);
-    } else {
-        return typename basic_format_arg<_Context>::handle{42};
+
+    // These overloads mirror the exposition-only single-argument constructor
+    // set of basic_format_arg (N4885 [format.arg]). They determine the mapping
+    // from "raw" to "erased" argument type for _Format_arg_store.
+    template <_Has_formatter<_Context> _Ty>
+    static auto _Phony_basic_format_arg_constructor(const _Ty&) {
+        // See N4885 [format.arg]/5
+        if constexpr (is_same_v<_Ty, bool>) {
+            return bool{};
+        } else if constexpr (is_same_v<_Ty, _Char_type>) {
+            return _Char_type{};
+        } else if constexpr (is_same_v<_Ty, char> && is_same_v<_Char_type, wchar_t>) {
+            return _Char_type{};
+        } else if constexpr (signed_integral<_Ty> && sizeof(_Ty) <= sizeof(int)) {
+            return int{};
+        } else if constexpr (unsigned_integral<_Ty> && sizeof(_Ty) <= sizeof(unsigned int)) {
+            return static_cast<unsigned int>(42);
+        } else if constexpr (signed_integral<_Ty> && sizeof(_Ty) <= sizeof(long long)) {
+            return static_cast<long long>(42);
+        } else if constexpr (unsigned_integral<_Ty> && sizeof(_Ty) <= sizeof(unsigned long long)) {
+            return static_cast<unsigned long long>(42);
+        } else {
+            return typename basic_format_arg<_Context>::handle{42};
+        }
     }
-}
 
-template <class _Context>
-auto _Get_format_arg_storage_type(const typename _Context::char_type*) // not defined
-    -> const typename _Context::char_type*;
+    static auto _Phony_basic_format_arg_constructor(float) -> float; // not defined
+    static auto _Phony_basic_format_arg_constructor(double) -> double; // not defined
+    static auto _Phony_basic_format_arg_constructor(long double) -> long double; // not defined
 
-template <class _Context, class _Traits>
-auto _Get_format_arg_storage_type(basic_string_view<typename _Context::char_type, _Traits>)
-    -> basic_string_view<typename _Context::char_type>; // not defined
+    static auto _Phony_basic_format_arg_constructor(const _Char_type*) -> const _Char_type*; // not defined
 
-template <class _Context, class _Traits, class _Alloc>
-auto _Get_format_arg_storage_type(const basic_string<typename _Context::char_type, _Traits, _Alloc>&)
-    -> basic_string_view<typename _Context::char_type>; // not defined
+    template <class _Traits>
+    static auto _Phony_basic_format_arg_constructor(basic_string_view<_Char_type, _Traits>)
+        -> basic_string_view<_Char_type>; // not defined
 
-template <class _Context>
-const void* _Get_format_arg_storage_type(nullptr_t); // not defined
+    template <class _Traits, class _Alloc>
+    static auto _Phony_basic_format_arg_constructor(const basic_string<_Char_type, _Traits, _Alloc>&)
+        -> basic_string_view<_Char_type>; // not defined
 
-// clang-format off
-template <class _Context, class _Ty>
-    requires is_void_v<_Ty>
-const void* _Get_format_arg_storage_type(_Ty*); // not defined
-// clang-format on
+    static auto _Phony_basic_format_arg_constructor(nullptr_t) -> const void*; // not defined
 
-template <class _Context, class _Ty>
-inline constexpr size_t _Get_format_arg_storage_size = sizeof(
-    _Get_format_arg_storage_type<_Context>(_STD declval<const _Ty&>()));
+    // clang-format off
+    template <class _Ty>
+        requires is_void_v<_Ty>
+    static auto _Phony_basic_format_arg_constructor(_Ty*) -> const void*; // not defined
+    // clang-format on
 
-struct _Format_arg_store_packed_index {
+    template <class _Ty>
+    using _Storage_type = decltype(_Phony_basic_format_arg_constructor(_STD declval<const _Ty&>()));
+
+    template <class _Ty>
+    static constexpr size_t _Storage_size = sizeof(_Storage_type<_Ty>);
+};
+
+struct _Format_arg_index {
     // TRANSITION, Should be templated on number of arguments for even less storage
     using _Index_type = size_t;
 
-    constexpr _Format_arg_store_packed_index() = default;
-    constexpr explicit _Format_arg_store_packed_index(const size_t _Index_) : _Index(_Index_) {
+    constexpr _Format_arg_index() = default;
+    constexpr explicit _Format_arg_index(const size_t _Index_) noexcept : _Index(_Index_) {
         _Type(_Basic_format_arg_type::_None);
     }
 
@@ -1393,95 +1358,73 @@ template <class _Context, class... _Args>
 class _Format_arg_store {
 private:
     using _CharType   = typename _Context::char_type;
-    using _Index_type = _Format_arg_store_packed_index;
+    using _Index_type = _Format_arg_index;
+    using _Traits     = _Format_arg_traits<_Context>;
 
     friend basic_format_args<_Context>;
 
     static constexpr size_t _Num_args       = sizeof...(_Args);
-    static constexpr size_t _Index_length   = _Num_args * sizeof(_Index_type);
-    static constexpr size_t _Storage_length = (_Get_format_arg_storage_size<_Context, _Args> + ... + 0);
+    static constexpr size_t _Storage_length = (_Traits::template _Storage_size<_Args> + ...);
 
-    // we store the data in memory as _Format_arg_store_packed_index[_Num_args] + unsigned char[_Storage_length]
-    alignas(_Index_type) unsigned char _Storage[_Index_length + _Storage_length];
+    _Index_type _Index_array[_Num_args];
+    unsigned char _Storage[_Storage_length];
 
     template <class _Ty>
-    void _Store_impl(const size_t _Arg_index, const _Basic_format_arg_type _Arg_type, _Ty _Val) noexcept {
-        const auto _Index_array = reinterpret_cast<_Index_type*>(_Storage);
-        const auto _Store_index = _Index_array[_Arg_index]._Index;
-        const auto _Length      = _Get_format_arg_type_storage_size<_CharType>(_Arg_type);
+    void _Store_impl(
+        const size_t _Arg_index, const _Basic_format_arg_type _Arg_type, const type_identity_t<_Ty>& _Val) noexcept {
+        _STL_INTERNAL_CHECK(_Arg_index < _Num_args);
 
-        _CSTD memcpy(_Storage + _Index_length + _Store_index, _STD addressof(_Val), _Length);
+        const auto _Store_index = _Index_array[_Arg_index]._Index;
+
+        _CSTD memcpy(_Storage + _Store_index, _STD addressof(_Val), sizeof(_Ty));
         _Index_array[_Arg_index]._Type(_Arg_type);
         if (_Arg_index + 1 < _Num_args) {
             // Set the starting index of the next arg, as that is dynamic, must be called with increasing index
-            _Index_array[_Arg_index + 1] = _Format_arg_store_packed_index{_Store_index + _Length};
+#pragma warning(suppress : 6386) // Buffer overrun while writing to '%s' ...
+            _Index_array[_Arg_index + 1] = _Format_arg_index{_Store_index + sizeof(_Ty)};
         }
     }
 
-    // See N4885 [format.arg]/5
-    // clang-format off
-    template <_Has_formatter<_Context> _Ty>
-    void _Store(const size_t _Arg_index, const _Ty& _Val) noexcept {
-        // clang-format on
-        if constexpr (is_same_v<_Ty, bool>) {
-            _Store_impl<bool>(_Arg_index, _Basic_format_arg_type::_Bool_type, _Val);
-        } else if constexpr (is_same_v<_Ty, _CharType>) {
-            _Store_impl<_CharType>(_Arg_index, _Basic_format_arg_type::_Char_type, _Val);
-        } else if constexpr (is_same_v<_Ty, char> && is_same_v<_CharType, wchar_t>) {
-            _Store_impl<_CharType>(_Arg_index, _Basic_format_arg_type::_Char_type, static_cast<wchar_t>(_Val));
-        } else if constexpr (signed_integral<_Ty> && sizeof(_Ty) <= sizeof(int)) {
-            _Store_impl<int>(_Arg_index, _Basic_format_arg_type::_Int_type, static_cast<int>(_Val));
-        } else if constexpr (unsigned_integral<_Ty> && sizeof(_Ty) <= sizeof(unsigned int)) {
-            _Store_impl<unsigned int>(_Arg_index, _Basic_format_arg_type::_UInt_type, static_cast<unsigned int>(_Val));
-        } else if constexpr (signed_integral<_Ty> && sizeof(_Ty) <= sizeof(long long)) {
-            _Store_impl<long long>(_Arg_index, _Basic_format_arg_type::_Long_long_type, static_cast<long long>(_Val));
-        } else if constexpr (unsigned_integral<_Ty> && sizeof(_Ty) <= sizeof(unsigned long long)) {
-            _Store_impl<unsigned long long>(
-                _Arg_index, _Basic_format_arg_type::_ULong_long_type, static_cast<unsigned long long>(_Val));
-        } else if constexpr (is_same_v<_Ty, float>) {
-            _Store_impl<float>(_Arg_index, _Basic_format_arg_type::_Float_type, _Val);
-        } else if constexpr (is_same_v<_Ty, double>) {
-            _Store_impl<double>(_Arg_index, _Basic_format_arg_type::_Double_type, _Val);
-        } else if constexpr (is_same_v<_Ty, long double>) {
-            _Store_impl<long double>(_Arg_index, _Basic_format_arg_type::_Long_double_type, _Val);
-        } else {
-            using _Handle_type = typename basic_format_arg<_Context>::handle;
-            _Store_impl<_Handle_type>(_Arg_index, _Basic_format_arg_type::_Custom_type, _Handle_type{_Val});
-        }
-    }
-
-    void _Store(const size_t _Arg_index, const _CharType* _Val) noexcept {
-        _Store_impl<const _CharType*>(_Arg_index, _Basic_format_arg_type::_CString_type, _Val);
-    }
-
-    template <class _Traits>
-    void _Store(const size_t _Arg_index, basic_string_view<_CharType, _Traits> _Val) noexcept {
-        _Store_impl<basic_string_view<_CharType>>(
-            _Arg_index, _Basic_format_arg_type::_String_type, basic_string_view<_CharType>{_Val});
-    }
-
-    template <class _Traits, class _Alloc>
-    void _Store(const size_t _Arg_index, const basic_string<_CharType, _Traits, _Alloc>& _Val) noexcept {
-        _Store_impl<basic_string_view<_CharType>>(
-            _Arg_index, _Basic_format_arg_type::_String_type, basic_string_view<_CharType>{_Val.data(), _Val.size()});
-    }
-
-    void _Store(const size_t _Arg_index, nullptr_t) noexcept {
-        _Store_impl<const void*>(_Arg_index, _Basic_format_arg_type::_Pointer_type, static_cast<const void*>(nullptr));
-    }
-
-    // clang-format off
     template <class _Ty>
-        requires is_void_v<_Ty>
-    void _Store(const size_t _Arg_index, _Ty* _Ptr) noexcept {
-        // clang-format on
-        _Store_impl<const void*>(_Arg_index, _Basic_format_arg_type::_Pointer_type, static_cast<const void*>(_Ptr));
+    void _Store(const size_t _Arg_index, const _Ty& _Val) noexcept {
+        using _Erased_type = typename _Traits::template _Storage_type<_Ty>;
+
+        if constexpr (is_same_v<_Erased_type, bool>) {
+            _Store_impl<_Erased_type>(_Arg_index, _Basic_format_arg_type::_Bool_type, _Val);
+        } else if constexpr (is_same_v<_Erased_type, _CharType>) {
+            _Store_impl<_Erased_type>(_Arg_index, _Basic_format_arg_type::_Char_type, static_cast<_Erased_type>(_Val));
+        } else if constexpr (is_same_v<_Erased_type, int>) {
+            _Store_impl<_Erased_type>(_Arg_index, _Basic_format_arg_type::_Int_type, static_cast<_Erased_type>(_Val));
+        } else if constexpr (is_same_v<_Erased_type, unsigned int>) {
+            _Store_impl<_Erased_type>(_Arg_index, _Basic_format_arg_type::_UInt_type, static_cast<_Erased_type>(_Val));
+        } else if constexpr (is_same_v<_Erased_type, long long>) {
+            _Store_impl<_Erased_type>(
+                _Arg_index, _Basic_format_arg_type::_Long_long_type, static_cast<_Erased_type>(_Val));
+        } else if constexpr (is_same_v<_Erased_type, unsigned long long>) {
+            _Store_impl<_Erased_type>(
+                _Arg_index, _Basic_format_arg_type::_ULong_long_type, static_cast<_Erased_type>(_Val));
+        } else if constexpr (is_same_v<_Erased_type, float>) {
+            _Store_impl<_Erased_type>(_Arg_index, _Basic_format_arg_type::_Float_type, _Val);
+        } else if constexpr (is_same_v<_Erased_type, double>) {
+            _Store_impl<_Erased_type>(_Arg_index, _Basic_format_arg_type::_Double_type, _Val);
+        } else if constexpr (is_same_v<_Erased_type, long double>) {
+            _Store_impl<_Erased_type>(_Arg_index, _Basic_format_arg_type::_Long_double_type, _Val);
+        } else if constexpr (is_same_v<_Erased_type, const void*>) {
+            _Store_impl<_Erased_type>(
+                _Arg_index, _Basic_format_arg_type::_Pointer_type, static_cast<_Erased_type>(_Val));
+        } else if constexpr (is_same_v<_Erased_type, const _CharType*>) {
+            _Store_impl<_Erased_type>(_Arg_index, _Basic_format_arg_type::_CString_type, _Val);
+        } else if constexpr (is_same_v<_Erased_type, basic_string_view<_CharType>>) {
+            _Store_impl<_Erased_type>(
+                _Arg_index, _Basic_format_arg_type::_String_type, _Erased_type{_Val.data(), _Val.size()});
+        } else {
+            _Store_impl<_Erased_type>(_Arg_index, _Basic_format_arg_type::_Custom_type, _Erased_type{_Val});
+        }
     }
 
 public:
     _Format_arg_store(const _Args&... _Vals) noexcept {
-        // Note: _Storage is uninitialized, so manually initialize the first index
-        _STD construct_at(reinterpret_cast<_Format_arg_store_packed_index*>(_Storage));
+        _Index_array[0]   = {};
         size_t _Arg_index = 0;
         (_Store(_Arg_index++, _Vals), ...);
     }
@@ -1492,32 +1435,27 @@ class _Format_arg_store<_Context> {};
 
 template <class _Context>
 class basic_format_args {
-private:
-    template <class _Ty>
-    _NODISCARD static auto _Get_value_from_memory(const unsigned char* _Val) noexcept {
-        auto& _Temp = *reinterpret_cast<const unsigned char(*)[sizeof(_Ty)]>(_Val);
-        return _Bit_cast<_Ty>(_Temp);
-    }
-
 public:
     basic_format_args() noexcept;
     basic_format_args(const _Format_arg_store<_Context>&) noexcept {}
     template <class... _Args>
     basic_format_args(const _Format_arg_store<_Context, _Args...>& _Store) noexcept
-        : _Num_args(sizeof...(_Args)), _Storage(_Store._Storage) {}
+        : _Num_args(sizeof...(_Args)), _Index_array(_Store._Index_array) {}
 
     _NODISCARD basic_format_arg<_Context> get(const size_t _Index) const noexcept {
         if (_Index >= _Num_args) {
             return basic_format_arg<_Context>{};
         }
 
-        using _CharType                   = typename _Context::char_type;
-        const auto _Packed_index          = reinterpret_cast<const _Format_arg_store_packed_index*>(_Storage)[_Index];
-        const auto _Index_length          = _Num_args * sizeof(_Format_arg_store_packed_index);
-        const unsigned char* _Arg_storage = _Storage + _Index_length + _Packed_index._Index;
+        using _CharType          = typename _Context::char_type;
+        const auto _Packed_index = _Index_array[_Index];
+        const auto _Arg_storage =
+            reinterpret_cast<const unsigned char*>(_Index_array + _Num_args) + _Packed_index._Index;
 
         switch (_Packed_index._Type()) {
         case _Basic_format_arg_type::_None:
+        default:
+            _STL_ASSERT(false, "Invalid basic_format_arg type");
             return basic_format_arg<_Context>{};
         case _Basic_format_arg_type::_Int_type:
             return basic_format_arg<_Context>{_Get_value_from_memory<int>(_Arg_storage)};
@@ -1546,9 +1484,6 @@ public:
         case _Basic_format_arg_type::_Custom_type:
             return basic_format_arg<_Context>{
                 _Get_value_from_memory<typename basic_format_arg<_Context>::handle>(_Arg_storage)};
-        default:
-            _STL_ASSERT(false, "Invalid basic_format_arg type");
-            return basic_format_arg<_Context>{};
         }
     }
 
@@ -1571,8 +1506,14 @@ public:
     }
 
 private:
-    size_t _Num_args              = 0;
-    const unsigned char* _Storage = nullptr;
+    template <class _Ty>
+    _NODISCARD static auto _Get_value_from_memory(const unsigned char* _Val) noexcept {
+        auto& _Temp = *reinterpret_cast<const unsigned char(*)[sizeof(_Ty)]>(_Val);
+        return _Bit_cast<_Ty>(_Temp);
+    }
+
+    size_t _Num_args                      = 0;
+    const _Format_arg_index* _Index_array = nullptr;
 };
 
 // _Lazy_locale is used instead of a std::locale so that the locale is only
@@ -2751,7 +2692,7 @@ struct _Format_handler {
 };
 
 // Generic formatter definition, the deleted default constructor
-// makes it "disabled" as per N4868 [formatter.formatter.spec]/5
+// makes it "disabled" as per N4885 [format.formatter.spec]/5
 template <class _Ty, class _CharT>
 struct formatter {
     formatter()                 = delete;

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -1364,8 +1364,8 @@ private:
     static constexpr size_t _Num_args       = sizeof...(_Args);
     static constexpr size_t _Storage_length = (_Traits::template _Storage_size<_Args> + ...);
 
-    // The actual storage representation: _Num_args offsets into _Storege, followed immediately by the untyped _Storage
-    // which olds copies of the object representations of arguments (with no regard for alignment). These must be
+    // The actual storage representation: _Num_args offsets into _Storage, followed immediately by the untyped _Storage
+    // which holds copies of the object representations of arguments (with no regard for alignment). These must be
     // allocated consecutively, since basic_format_args thinks it can store a pointer to _Index_array and use arithmetic
     // to access the bytes of _Storage.
     _Format_arg_index _Index_array[_Num_args];

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -1332,7 +1332,6 @@ struct _Format_arg_traits {
 
 struct _Format_arg_index {
     // TRANSITION, Should be templated on number of arguments for even less storage
-    using _Index_type = size_t;
 
     constexpr _Format_arg_index() = default;
     constexpr explicit _Format_arg_index(const size_t _Index_) noexcept : _Index(_Index_) {
@@ -1344,11 +1343,11 @@ struct _Format_arg_index {
     }
 
     constexpr void _Type(_Basic_format_arg_type _Val) noexcept {
-        _Type_ = static_cast<_Index_type>(_Val);
+        _Type_ = static_cast<size_t>(_Val);
     }
 
-    _Index_type _Index : (sizeof(_Index_type) * 8 - 4);
-    _Index_type _Type_ : 4;
+    size_t _Index : (sizeof(size_t) * 8 - 4);
+    size_t _Type_ : 4;
 };
 
 template <class _Context>
@@ -1357,16 +1356,19 @@ class basic_format_args;
 template <class _Context, class... _Args>
 class _Format_arg_store {
 private:
-    using _CharType   = typename _Context::char_type;
-    using _Index_type = _Format_arg_index;
-    using _Traits     = _Format_arg_traits<_Context>;
+    using _CharType = typename _Context::char_type;
+    using _Traits   = _Format_arg_traits<_Context>;
 
     friend basic_format_args<_Context>;
 
     static constexpr size_t _Num_args       = sizeof...(_Args);
     static constexpr size_t _Storage_length = (_Traits::template _Storage_size<_Args> + ...);
 
-    _Index_type _Index_array[_Num_args];
+    // The actual storage representation: _Num_args offsets into _Storege, followed immediately by the untyped _Storage
+    // which olds copies of the object representations of arguments (with no regard for alignment). These must be
+    // allocated consecutively, since basic_format_args thinks it can store a pointer to _Index_array and use arithmetic
+    // to access the bytes of _Storage.
+    _Format_arg_index _Index_array[_Num_args];
     unsigned char _Storage[_Storage_length];
 
     template <class _Ty>
@@ -1389,37 +1391,37 @@ private:
     void _Store(const size_t _Arg_index, const _Ty& _Val) noexcept {
         using _Erased_type = typename _Traits::template _Storage_type<_Ty>;
 
+        _Basic_format_arg_type _Arg_type;
         if constexpr (is_same_v<_Erased_type, bool>) {
-            _Store_impl<_Erased_type>(_Arg_index, _Basic_format_arg_type::_Bool_type, _Val);
+            _Arg_type = _Basic_format_arg_type::_Bool_type;
         } else if constexpr (is_same_v<_Erased_type, _CharType>) {
-            _Store_impl<_Erased_type>(_Arg_index, _Basic_format_arg_type::_Char_type, static_cast<_Erased_type>(_Val));
+            _Arg_type = _Basic_format_arg_type::_Char_type;
         } else if constexpr (is_same_v<_Erased_type, int>) {
-            _Store_impl<_Erased_type>(_Arg_index, _Basic_format_arg_type::_Int_type, static_cast<_Erased_type>(_Val));
+            _Arg_type = _Basic_format_arg_type::_Int_type;
         } else if constexpr (is_same_v<_Erased_type, unsigned int>) {
-            _Store_impl<_Erased_type>(_Arg_index, _Basic_format_arg_type::_UInt_type, static_cast<_Erased_type>(_Val));
+            _Arg_type = _Basic_format_arg_type::_UInt_type;
         } else if constexpr (is_same_v<_Erased_type, long long>) {
-            _Store_impl<_Erased_type>(
-                _Arg_index, _Basic_format_arg_type::_Long_long_type, static_cast<_Erased_type>(_Val));
+            _Arg_type = _Basic_format_arg_type::_Long_long_type;
         } else if constexpr (is_same_v<_Erased_type, unsigned long long>) {
-            _Store_impl<_Erased_type>(
-                _Arg_index, _Basic_format_arg_type::_ULong_long_type, static_cast<_Erased_type>(_Val));
+            _Arg_type = _Basic_format_arg_type::_ULong_long_type;
         } else if constexpr (is_same_v<_Erased_type, float>) {
-            _Store_impl<_Erased_type>(_Arg_index, _Basic_format_arg_type::_Float_type, _Val);
+            _Arg_type = _Basic_format_arg_type::_Float_type;
         } else if constexpr (is_same_v<_Erased_type, double>) {
-            _Store_impl<_Erased_type>(_Arg_index, _Basic_format_arg_type::_Double_type, _Val);
+            _Arg_type = _Basic_format_arg_type::_Double_type;
         } else if constexpr (is_same_v<_Erased_type, long double>) {
-            _Store_impl<_Erased_type>(_Arg_index, _Basic_format_arg_type::_Long_double_type, _Val);
+            _Arg_type = _Basic_format_arg_type::_Long_double_type;
         } else if constexpr (is_same_v<_Erased_type, const void*>) {
-            _Store_impl<_Erased_type>(
-                _Arg_index, _Basic_format_arg_type::_Pointer_type, static_cast<_Erased_type>(_Val));
+            _Arg_type = _Basic_format_arg_type::_Pointer_type;
         } else if constexpr (is_same_v<_Erased_type, const _CharType*>) {
-            _Store_impl<_Erased_type>(_Arg_index, _Basic_format_arg_type::_CString_type, _Val);
+            _Arg_type = _Basic_format_arg_type::_CString_type;
         } else if constexpr (is_same_v<_Erased_type, basic_string_view<_CharType>>) {
-            _Store_impl<_Erased_type>(
-                _Arg_index, _Basic_format_arg_type::_String_type, _Erased_type{_Val.data(), _Val.size()});
+            _Arg_type = _Basic_format_arg_type::_String_type;
         } else {
-            _Store_impl<_Erased_type>(_Arg_index, _Basic_format_arg_type::_Custom_type, _Erased_type{_Val});
+            _STL_INTERNAL_STATIC_ASSERT(is_same_v<_Erased_type, typename basic_format_arg<_Context>::handle>);
+            _Arg_type = _Basic_format_arg_type::_Custom_type;
         }
+
+        _Store_impl<_Erased_type>(_Arg_index, _Arg_type, static_cast<_Erased_type>(_Val));
     }
 
 public:
@@ -1447,7 +1449,8 @@ public:
             return basic_format_arg<_Context>{};
         }
 
-        using _CharType          = typename _Context::char_type;
+        using _CharType = typename _Context::char_type;
+        // The explanatory comment in _Format_arg_store explains how the following works.
         const auto _Packed_index = _Index_array[_Index];
         const auto _Arg_storage =
             reinterpret_cast<const unsigned char*>(_Index_array + _Num_args) + _Packed_index._Index;

--- a/tests/std/tests/P0645R10_text_formatting_args/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_args/test.cpp
@@ -209,7 +209,7 @@ void test_format_arg_store() {
     test_single_format_arg<Context, basic_string_view<char_type>, Arg_type::string_type>(get_input_sv<char_type>());
 }
 
-static_assert(sizeof(_Format_arg_index) == sizeof(_Format_arg_index::_Index_type));
+static_assert(sizeof(_Format_arg_index) == sizeof(std::size_t));
 static_assert(is_same_v<_Format_arg_traits<format_context>::_Storage_type<void*>, const void*>);
 
 template <class Context>

--- a/tests/std/tests/P0645R10_text_formatting_args/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_args/test.cpp
@@ -209,8 +209,8 @@ void test_format_arg_store() {
     test_single_format_arg<Context, basic_string_view<char_type>, Arg_type::string_type>(get_input_sv<char_type>());
 }
 
-static_assert(sizeof(_Format_arg_store_packed_index) == sizeof(_Format_arg_store_packed_index::_Index_type));
-static_assert(_Get_format_arg_storage_size<format_context, void*> == sizeof(const void*));
+static_assert(sizeof(_Format_arg_index) == sizeof(_Format_arg_index::_Index_type));
+static_assert(is_same_v<_Format_arg_traits<format_context>::_Storage_type<void*>, const void*>);
 
 int main() {
     test_basic_format_arg<format_context>();

--- a/tests/std/tests/P0645R10_text_formatting_args/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_args/test.cpp
@@ -209,7 +209,7 @@ void test_format_arg_store() {
     test_single_format_arg<Context, basic_string_view<char_type>, Arg_type::string_type>(get_input_sv<char_type>());
 }
 
-static_assert(sizeof(_Format_arg_index) == sizeof(std::size_t));
+static_assert(sizeof(_Format_arg_index) == sizeof(size_t));
 static_assert(is_same_v<_Format_arg_traits<format_context>::_Storage_type<void*>, const void*>);
 
 template <class Context>

--- a/tests/std/tests/P0645R10_text_formatting_args/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_args/test.cpp
@@ -49,7 +49,7 @@ enum class Arg_type : uint8_t {
 };
 
 template <class Context>
-auto visitor = [](auto&& arg) {
+constexpr auto visitor = [](auto&& arg) {
     using T         = decay_t<decltype(arg)>;
     using char_type = typename Context::char_type;
     if constexpr (is_same_v<T, monostate>) {
@@ -212,9 +212,16 @@ void test_format_arg_store() {
 static_assert(sizeof(_Format_arg_index) == sizeof(_Format_arg_index::_Index_type));
 static_assert(is_same_v<_Format_arg_traits<format_context>::_Storage_type<void*>, const void*>);
 
+template <class Context>
+void test_visit_monostate() {
+    assert(visit_format_arg(visitor<Context>, basic_format_arg<Context>()) == Arg_type::none);
+}
+
 int main() {
     test_basic_format_arg<format_context>();
     test_basic_format_arg<wformat_context>();
     test_format_arg_store<format_context>();
     test_format_arg_store<wformat_context>();
+    test_visit_monostate<format_context>();
+    test_visit_monostate<wformat_context>();
 }


### PR DESCRIPTION
Rename the overload set that emulates the exposition-only constructors of `basic_format_arg` from `_Get_format_arg_storage_type` to `_Phony_basic_format_arg_constructor` for clarity. Encapsulate that overload set - and the traits `_Storage_type` and `_Storage_size` that observe it - in a new class template `_Format_arg_traits`. Remove the bogus `monostate` case and split the floating-point types out from the function template overload to more closely reflect the `basic_format_arg` constructors.

Shorten `_Format_arg_store_packed_index` to `_Format_arg_index` and make its converting constructor unconditionally `noexcept`.

In `_Format_arg_store`, store indices in an array using the untyped storage only for erased arguments. In `_Store`, reuse `_Format_arg_traits::_Storage_type` instead of trying to duplicate the overload resolution process.

Add test coverage for `visit_format_arg(/**/, basic_format_arg</**/>())` to ensure that the `monostate` is properly visitable.