### PR TITLE
Toolset update: VS 2019 16.10 Preview 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 The STL uses boost-math headers to provide P0226R1 Mathematical Special Functions. We recommend using [vcpkg][] to
 acquire this dependency.
 
-1. Install Visual Studio 2019 16.10 Preview 3 or later.
+1. Install Visual Studio 2019 16.10 Preview 4 or later.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
     * Otherwise, install [CMake][] 3.20 or later, and [Ninja][] 1.10.2 or later.
@@ -158,7 +158,7 @@ acquire this dependency.
 
 # How To Build With A Native Tools Command Prompt
 
-1. Install Visual Studio 2019 16.10 Preview 3 or later.
+1. Install Visual Studio 2019 16.10 Preview 4 or later.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
     * Otherwise, install [CMake][] 3.20 or later, and [Ninja][] 1.10.2 or later.

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 The STL uses boost-math headers to provide P0226R1 Mathematical Special Functions. We recommend using [vcpkg][] to
 acquire this dependency.
 
-1. Install Visual Studio 2019 16.10 Preview 2 or later.
+1. Install Visual Studio 2019 16.10 Preview 3 or later.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
     * Otherwise, install [CMake][] 3.20 or later, and [Ninja][] 1.10.2 or later.
@@ -158,7 +158,7 @@ acquire this dependency.
 
 # How To Build With A Native Tools Command Prompt
 
-1. Install Visual Studio 2019 16.10 Preview 2 or later.
+1. Install Visual Studio 2019 16.10 Preview 3 or later.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
     * Otherwise, install [CMake][] 3.20 or later, and [Ninja][] 1.10.2 or later.
@@ -234,7 +234,7 @@ C:\Users\username\Desktop>dumpbin /IMPORTS .\example.exe | findstr msvcp
 # How To Run The Tests With A Native Tools Command Prompt
 
 1. Follow either [How To Build With A Native Tools Command Prompt][] or [How To Build With The Visual Studio IDE][].
-2. Acquire [Python][] 3.9.4 or newer and have it on the `PATH` (or run it directly using its absolute or relative path).
+2. Acquire [Python][] 3.9.5 or newer and have it on the `PATH` (or run it directly using its absolute or relative path).
 3. Have LLVM's `bin` directory on the `PATH` (so `clang-cl.exe` is available).
     * We recommend selecting "C++ Clang tools for Windows" in the VS Installer. This will automatically add LLVM to the
     `PATH` of the x86 and x64 Native Tools Command Prompts, and will ensure that you're using a supported version.

--- a/azure-devops/create-vmss.ps1
+++ b/azure-devops/create-vmss.ps1
@@ -30,7 +30,7 @@ $ImageOffer = 'Windows-10'
 $ImageSku = '20h2-ent-g2'
 
 $ProgressActivity = 'Creating Scale Set'
-$TotalProgress = 13
+$TotalProgress = 14
 $CurrentProgress = 1
 
 <#
@@ -303,6 +303,14 @@ Write-Progress `
   -PercentComplete (100 / $TotalProgress * $CurrentProgress++)
 
 Restart-AzVM -ResourceGroupName $ResourceGroupName -Name $ProtoVMName
+
+####################################################################################################
+Write-Progress `
+  -Activity $ProgressActivity `
+  -Status 'Sleeping after restart' `
+  -PercentComplete (100 / $TotalProgress * $CurrentProgress++)
+
+Start-Sleep -Seconds 60
 
 ####################################################################################################
 Write-Progress `

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -139,7 +139,7 @@ $Workloads = @(
 $ReleaseInPath = 'Preview'
 $Sku = 'Enterprise'
 $VisualStudioBootstrapperUrl = 'https://aka.ms/vs/16/pre/vs_enterprise.exe'
-$PythonUrl = 'https://www.python.org/ftp/python/3.9.4/python-3.9.4-amd64.exe'
+$PythonUrl = 'https://www.python.org/ftp/python/3.9.5/python-3.9.5-amd64.exe'
 
 # https://docs.microsoft.com/en-us/windows-hardware/drivers/download-the-wdk
 $WindowsDriverKitUrl = 'https://go.microsoft.com/fwlink/?linkid=2128854'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@ variables:
   buildOutputLocation: 'D:\build'
   vcpkgLocation: '$(Build.SourcesDirectory)/vcpkg'
 
-pool: 'StlBuild-2021-05-11'
+pool: 'StlBuild-2021-05-18'
 
 stages:
   - stage: Code_Format

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@ variables:
   buildOutputLocation: 'D:\build'
   vcpkgLocation: '$(Build.SourcesDirectory)/vcpkg'
 
-pool: 'StlBuild-2021-04-23'
+pool: 'StlBuild-2021-05-11'
 
 stages:
   - stage: Code_Format

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -2977,8 +2977,8 @@ namespace chrono {
         explicit zoned_time(_TimeZonePtr _Tz) noexcept /* strengthened */ : _Zone{_STD move(_Tz)} {}
 
         // clang-format off
-        template <class _Traits2 = _Traits, enable_if_t<is_constructible< // TRANSITION, VSO-1303556
-            zoned_time, decltype(_Traits2::locate_zone(string_view{}))>::value,
+        template <class _Traits2 = _Traits, enable_if_t<is_constructible_v<
+            zoned_time, decltype(_Traits2::locate_zone(string_view{}))>,
             int> = 0>
         // clang-format on
         explicit zoned_time(string_view _Name) : _Zone{_Traits::locate_zone(_Name)} {}
@@ -2990,8 +2990,8 @@ namespace chrono {
         zoned_time(_TimeZonePtr _Tz, const sys_time<_Duration>& _Sys) : _Zone{_STD move(_Tz)}, _Tp{_Sys} {}
 
         // clang-format off
-        template <class _Traits2 = _Traits, enable_if_t<is_constructible< // TRANSITION, VSO-1303556
-            zoned_time, decltype(_Traits2::locate_zone(string_view{})), const sys_time<_Duration>&>::value,
+        template <class _Traits2 = _Traits, enable_if_t<is_constructible_v<
+            zoned_time, decltype(_Traits2::locate_zone(string_view{})), const sys_time<_Duration>&>,
             int> = 0>
         // clang-format on
         zoned_time(string_view _Name, type_identity_t<const sys_time<_Duration>&> _Sys)
@@ -3005,8 +3005,8 @@ namespace chrono {
             : _Zone{_STD move(_Tz)}, _Tp{_Zone->to_sys(_Local)} {}
 
         // clang-format off
-        template <class _Traits2 = _Traits, enable_if_t<is_constructible< // TRANSITION, VSO-1303556
-            zoned_time, decltype(_Traits2::locate_zone(string_view{})), const local_time<_Duration>&>::value,
+        template <class _Traits2 = _Traits, enable_if_t<is_constructible_v<
+            zoned_time, decltype(_Traits2::locate_zone(string_view{})), const local_time<_Duration>&>,
             int> = 0>
         // clang-format on
         zoned_time(string_view _Name, type_identity_t<const local_time<_Duration>>& _Local)
@@ -3021,8 +3021,8 @@ namespace chrono {
             : _Zone{_STD move(_Tz)}, _Tp{_Zone->to_sys(_Local, _Choose)} {}
 
         // clang-format off
-        template <class _Traits2 = _Traits, enable_if_t<is_constructible< // TRANSITION, VSO-1303556
-            zoned_time, decltype(_Traits2::locate_zone(string_view{})), const local_time<_Duration>&, choose>::value,
+        template <class _Traits2 = _Traits, enable_if_t<is_constructible_v<
+            zoned_time, decltype(_Traits2::locate_zone(string_view{})), const local_time<_Duration>&, choose>,
             int> = 0>
         // clang-format on
         zoned_time(string_view _Name, type_identity_t<const local_time<_Duration>&> _Local, choose _Choose)
@@ -3041,9 +3041,9 @@ namespace chrono {
 
         // clang-format off
         template <class _Duration2, class _TimeZonePtr2,
-            class _Traits2 = _Traits, enable_if_t<is_constructible< // TRANSITION, VSO-1303556
+            class _Traits2 = _Traits, enable_if_t<is_constructible_v<
             zoned_time, decltype(_Traits2::locate_zone(string_view{})),
-            const zoned_time<_Duration2, _TimeZonePtr2>&>::value,
+            const zoned_time<_Duration2, _TimeZonePtr2>&>,
             int> = 0>
         // clang-format on
         zoned_time(string_view _Name, const zoned_time<_Duration2, _TimeZonePtr2>& _Zt)
@@ -3051,9 +3051,9 @@ namespace chrono {
 
         // clang-format off
         template <class _Duration2, class _TimeZonePtr2,
-            class _Traits2 = _Traits, enable_if_t<is_constructible< // TRANSITION, VSO-1303556
+            class _Traits2 = _Traits, enable_if_t<is_constructible_v<
             zoned_time, decltype(_Traits2::locate_zone(string_view{})),
-            const zoned_time<_Duration2, _TimeZonePtr2>&, choose>::value,
+            const zoned_time<_Duration2, _TimeZonePtr2>&, choose>,
             int> = 0>
         // clang-format on
         zoned_time(string_view _Name, const zoned_time<_Duration2, _TimeZonePtr2>& _Zt, choose _Choose)

--- a/stl/inc/execution
+++ b/stl/inc/execution
@@ -446,7 +446,7 @@ struct _Parallel_choose_min_chunk {
             }
         }
 
-        lock_guard<mutex> _Lck(_Mtx); // TRANSITION, VSO-671180
+        lock_guard _Lck(_Mtx);
         if (_Selected_chunk.load(memory_order_relaxed) == _Chunk) {
             _Result = _Local_result;
         }
@@ -481,7 +481,7 @@ struct _Parallel_choose_max_chunk {
             }
         }
 
-        lock_guard<mutex> _Lck(_Mtx); // TRANSITION, VSO-671180
+        lock_guard _Lck(_Mtx);
         if (_Selected_chunk.load(memory_order_relaxed) == _Chunk) {
             _Result = _Local_result;
         }
@@ -589,7 +589,7 @@ public:
             auto _New_segment = _Segment->_Grow(_Local_b, _Local_t);
             _Circular_buffer<_Ty>* _Detached_segment;
             {
-                lock_guard<mutex> _Lck(_Segment_lock); // TRANSITION, VSO-671180
+                lock_guard _Lck(_Segment_lock);
                 _Detached_segment = _STD exchange(_Segment, _New_segment);
             } // unlock
 
@@ -614,7 +614,7 @@ public:
 
             _Circular_buffer<_Ty>* _Stealing_segment;
             {
-                lock_guard<mutex> _Lck(_Segment_lock); // TRANSITION, VSO-671180
+                lock_guard _Lck(_Segment_lock);
                 _Stealing_segment = _Segment;
                 _MT_INCR(_Stealing_segment->_Ref_count);
             }
@@ -750,7 +750,7 @@ struct _Work_stealing_team { // inter-thread communication for threads working o
     _Work_stealing_membership<_Ty> _Join_team() noexcept {
         size_t _Id;
         {
-            lock_guard<mutex> _Lck(_Available_mutex); // TRANSITION, VSO-671180
+            lock_guard _Lck(_Available_mutex);
             _Id = _Available_queues.top();
             _Available_queues.pop();
         } // unlock
@@ -764,7 +764,7 @@ struct _Work_stealing_team { // inter-thread communication for threads working o
     }
 
     void _Leave_team(size_t _Id) noexcept {
-        lock_guard<mutex> _Lck(_Available_mutex); // TRANSITION, VSO-671180
+        lock_guard _Lck(_Available_mutex);
         _Available_queues.push(_Id);
     }
 

--- a/stl/inc/queue
+++ b/stl/inc/queue
@@ -108,7 +108,7 @@ public:
         _Swap_adl(c, _Right.c);
     }
 
-    _NODISCARD const _Container& _Get_container() const noexcept { // TRANSITION, VSO-1307828
+    _NODISCARD const _Container& _Get_container() const noexcept {
         return c;
     }
 

--- a/stl/inc/stack
+++ b/stl/inc/stack
@@ -98,7 +98,7 @@ public:
         _Swap_adl(c, _Right.c);
     }
 
-    _NODISCARD const _Container& _Get_container() const noexcept { // TRANSITION, VSO-1307828
+    _NODISCARD const _Container& _Get_container() const noexcept {
         return c;
     }
 

--- a/stl/inc/tuple
+++ b/stl/inc/tuple
@@ -683,10 +683,10 @@ public:
     }
 
 #ifdef __cpp_lib_concepts
-    template <class _First, class... _Other,
-        class _Ret = common_comparison_category_t<_Synth_three_way_result<_This, _First>, // TRANSITION, DevCom-1344701
-            _Synth_three_way_result<_Rest, _Other>...>> // (should be a normal or trailing return type)
-    _NODISCARD constexpr _Ret _Three_way_compare(const tuple<_First, _Other...>& _Right) const {
+    template <class _First, class... _Other>
+    _NODISCARD constexpr common_comparison_category_t<_Synth_three_way_result<_This, _First>,
+        _Synth_three_way_result<_Rest, _Other>...>
+        _Three_way_compare(const tuple<_First, _Other...>& _Right) const {
         if (auto _Result = _Synth_three_way{}(_Myfirst._Val, _Right._Myfirst._Val); _Result != 0) {
             return _Result;
         }

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -1364,11 +1364,7 @@ template <class _Ty1, class _Ty2, class = void>
 struct _Common_reference2A : _Common_reference2B<_Ty1, _Ty2> {};
 
 template <class _Ty1, class _Ty2, class _Result = _Cond_res<_Copy_cv<_Ty1, _Ty2>&, _Copy_cv<_Ty2, _Ty1>&>,
-#ifdef __EDG__ // TRANSITION, VSO-948614
-    enable_if_t<is_lvalue_reference<_Result>::value, int> = 0>
-#else // ^^^ workaround / no workaround vvv
     enable_if_t<is_lvalue_reference_v<_Result>, int> = 0>
-#endif // TRANSITION, VSO-948614
 using _LL_common_ref = _Result;
 
 template <class _Ty1, class _Ty2>

--- a/stl/inc/variant
+++ b/stl/inc/variant
@@ -1173,18 +1173,11 @@ public:
         } else if constexpr (sizeof...(_Types) < 32) {
             // Limit the size of variants that use this quadratic code size implementation of swap.
             _Variant_raw_visit(index(), _Storage(),
-                [this, &_That](auto _My_ref)
-#ifndef __EDG__ // TRANSITION, VSO-897887
-                    noexcept(conjunction_v<is_nothrow_move_constructible<_Types>..., is_nothrow_swappable<_Types>...>)
-#endif // TRANSITION, VSO-897887
-                {
+                [this, &_That](auto _My_ref) noexcept(
+                    conjunction_v<is_nothrow_move_constructible<_Types>..., is_nothrow_swappable<_Types>...>) {
                     _Variant_raw_visit(_That.index(), _That._Storage(),
-                        [this, &_That, _My_ref](auto _That_ref)
-#ifndef __EDG__ // TRANSITION, VSO-897887
-                            noexcept(conjunction_v<is_nothrow_move_constructible<_Types>...,
-                                is_nothrow_swappable<_Types>...>)
-#endif // TRANSITION, VSO-897887
-                        {
+                        [this, &_That, _My_ref](auto _That_ref) noexcept(
+                            conjunction_v<is_nothrow_move_constructible<_Types>..., is_nothrow_swappable<_Types>...>) {
                             constexpr size_t _That_idx = decltype(_That_ref)::_Idx;
 #ifdef __EDG__ // TRANSITION, VSO-657455
                             constexpr size_t _My_idx = decltype(_My_ref)::_Idx + 0 * _That_idx;
@@ -1218,11 +1211,7 @@ public:
         } else {
             if (this->_Which == _That._Which) {
                 _Variant_raw_visit(static_cast<size_t>(this->_Which), _That._Storage(),
-                    [this](auto _Ref)
-#ifndef __EDG__ // TRANSITION, VSO-897887
-                        noexcept(conjunction_v<is_nothrow_swappable<_Types>...>)
-#endif // TRANSITION, VSO-897887
-                    {
+                    [this](auto _Ref) noexcept(conjunction_v<is_nothrow_swappable<_Types>...>) {
                         constexpr size_t _Idx = decltype(_Ref)::_Idx;
                         if constexpr (_Idx != variant_npos) {
                             _Swap_adl(_Variant_raw_get<_Idx>(this->_Storage()), _Ref._Val);
@@ -1255,11 +1244,7 @@ private:
         // steal the contained value from _That
         this->_Reset();
         _Variant_raw_visit(_That.index(), _That._Storage(),
-            [this](auto _Ref)
-#ifndef __EDG__ // TRANSITION, VSO-897887
-                noexcept(conjunction_v<is_nothrow_move_constructible<_Types>...>)
-#endif // TRANSITION, VSO-897887
-            {
+            [this](auto _Ref) noexcept(conjunction_v<is_nothrow_move_constructible<_Types>...>) {
                 constexpr size_t _Idx = decltype(_Ref)::_Idx;
                 if constexpr (_Idx != variant_npos) {
                     this->_Emplace_valueless<_Idx>(_STD move(_Ref._Val));

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -432,9 +432,6 @@ std/numerics/c.math/cmath.pass.cpp FAIL
 # GH-1596: <algorithm>: unqualified calls to _Adl_verify_range incorrectly cause instantiation
 std/algorithms/robust_against_adl.pass.cpp FAIL
 
-# GH-1595: <bit>: bit_ceil(T(-1)) should not be a constant expression
-std/numerics/bit/bit.pow.two/bit_ceil.fail.cpp:0 FAIL
-
 
 # *** CRT BUGS ***
 # We're permanently missing aligned_alloc().

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -432,9 +432,6 @@ numerics\c.math\cmath.pass.cpp
 # GH-1596: <algorithm>: unqualified calls to _Adl_verify_range incorrectly cause instantiation
 algorithms\robust_against_adl.pass.cpp
 
-# GH-1595: <bit>: bit_ceil(T(-1)) should not be a constant expression
-numerics\bit\bit.pow.two\bit_ceil.fail.cpp
-
 
 # *** CRT BUGS ***
 # We're permanently missing aligned_alloc().

--- a/tests/std/tests/Dev11_0535636_functional_overhaul/test.cpp
+++ b/tests/std/tests/Dev11_0535636_functional_overhaul/test.cpp
@@ -980,11 +980,9 @@ void test_reference_wrapper_invocation() {
 
     assert(i == 10);
 
-#ifndef __EDG__ // TRANSITION, DevCom-939485
     const auto noexcept_lambda     = []() noexcept {};
     const auto noexcept_lambda_ref = ref(noexcept_lambda);
     STATIC_ASSERT(noexcept(noexcept_lambda_ref())); // strengthened
-#endif // __EDG__
 
     reference_wrapper<int(int)> rw_fxn(quadruple);
     assert(rw_fxn(9) == 36);

--- a/tests/std/tests/Dev11_0535636_functional_overhaul/test.cpp
+++ b/tests/std/tests/Dev11_0535636_functional_overhaul/test.cpp
@@ -1055,12 +1055,18 @@ constexpr bool test_invoke_constexpr() {
     auto p = &thing;
 
     assert(&invoke(&Thing::m_x, *p) == &p->m_x);
-    // assert(&invoke(&Thing::m_x, ref(*sp)) == &sp->m_x); TRANSITION, P1065R2
+#if _HAS_CXX20
+#if defined(__clang__) || defined(__EDG__) // TRANSITION, DevCom-1419425 "constexpr PMD emits bogus error C2131"
+    assert(&invoke(&Thing::m_x, ref(*p)) == &p->m_x);
+#endif // ^^^ no workaround ^^^
+#endif // _HAS_CXX20
     assert(&invoke(&Thing::m_x, p) == &p->m_x);
 
 #ifndef _M_CEE // TRANSITION, DevCom-939490
     assert(invoke(&Thing::sum, *p, 3) == 1023);
-    // assert(invoke(&Thing::sum, ref(*sp), 4) == 1024); TRANSITION, P1065R2
+#if _HAS_CXX20
+    assert(invoke(&Thing::sum, ref(*p), 4) == 1024);
+#endif // _HAS_CXX20
     assert(invoke(&Thing::sum, p, 5) == 1025);
 #endif // _M_CEE
 

--- a/tests/std/tests/P0067R5_charconv/float_to_chars_test_cases.hpp
+++ b/tests/std/tests/P0067R5_charconv/float_to_chars_test_cases.hpp
@@ -140,7 +140,7 @@ inline constexpr FloatToCharsTestCase float_to_chars_test_cases[] = {
     {6.0898e-39f, chars_format::scientific, "6.0898e-39"},
     {0.0010310042f, chars_format::scientific, "1.0310042e-03"},
     {2.8823261e17f, chars_format::scientific, "2.882326e+17"},
-    {0x1.5c87fap-84f, chars_format::scientific, "7.038531e-26"}, // TRANSITION, VSO-629490, should be 7.038531e-26f
+    {7.038531e-26f, chars_format::scientific, "7.038531e-26"},
     {9.2234038e17f, chars_format::scientific, "9.223404e+17"},
     {6.7108872e7f, chars_format::scientific, "6.710887e+07"},
     {1.0e-44f, chars_format::scientific, "1e-44"},

--- a/tests/std/tests/P0088R3_variant/test.cpp
+++ b/tests/std/tests/P0088R3_variant/test.cpp
@@ -1769,7 +1769,6 @@ int run_test()
   static_assert(!std::is_assignable<std::variant<int, int>, int>::value, "");
   static_assert(!std::is_assignable<std::variant<long, long long>, int>::value, "");
 #if _HAS_CXX20
-#ifndef __EDG__ // TRANSITION, DevCom-1337958
   static_assert(std::is_assignable<std::variant<char>, int>::value == VariantAllowsNarrowingConversions, "");
 
   static_assert(std::is_assignable<std::variant<std::string, float>, int>::value
@@ -1779,7 +1778,6 @@ int run_test()
   static_assert(!std::is_assignable<std::variant<std::string, bool>, int>::value, "");
 
   static_assert(!std::is_assignable<std::variant<int, bool>, decltype("meow")>::value, "");
-#endif // !__EDG__
   static_assert(!std::is_assignable<std::variant<int, const bool>, decltype("meow")>::value, "");
   static_assert(!std::is_assignable<std::variant<int, const volatile bool>, decltype("meow")>::value, "");
 
@@ -3053,7 +3051,6 @@ void test_T_assignment_sfinae() {
     static_assert(!std::is_assignable<V, int>::value, "no matching operator=");
   }
 #if _HAS_CXX20
-#ifndef __EDG__ // TRANSITION, DevCom-1337958
   {
     using V = std::variant<std::string, float>;
     static_assert(std::is_assignable<V, int>::value == VariantAllowsNarrowingConversions,
@@ -3066,12 +3063,13 @@ void test_T_assignment_sfinae() {
     struct X {
       operator void*();
     };
+#ifndef __EDG__ // TRANSITION, VSO-1327220
     static_assert(!std::is_assignable<V, X>::value,
                   "no boolean conversion in operator=");
+#endif // !__EDG__
     static_assert(std::is_assignable<V, std::false_type>::value,
                   "no converted to bool in operator=");
   }
-#endif // !__EDG__
 #endif // _HAS_CXX20
   {
     struct X {};
@@ -3111,7 +3109,6 @@ void test_T_assignment_basic() {
     assert(std::get<1>(v) == 43);
   }
 #if _HAS_CXX20
-#ifndef __EDG__ // TRANSITION, DevCom-1337958
 #ifndef TEST_VARIANT_ALLOWS_NARROWING_CONVERSIONS
   {
     std::variant<unsigned, long> v;
@@ -3123,7 +3120,6 @@ void test_T_assignment_basic() {
     assert(std::get<0>(v) == 43);
   }
 #endif
-#endif // !__EDG__
   {
     std::variant<std::string, bool> v = true;
     v = "bar";
@@ -3277,7 +3273,6 @@ int run_test()
   static_assert(!std::is_constructible<std::variant<int, int>, int>::value, "");
   static_assert(!std::is_constructible<std::variant<long, long long>, int>::value, "");
 #if _HAS_CXX20
-#ifndef __EDG__ // TRANSITION, DevCom-1337958
   static_assert(std::is_constructible<std::variant<char>, int>::value == VariantAllowsNarrowingConversions, "");
 
   static_assert(std::is_constructible<std::variant<std::string, float>, int>::value
@@ -3289,7 +3284,6 @@ int run_test()
   static_assert(!std::is_constructible<std::variant<int, bool>, decltype("meow")>::value, "");
   static_assert(!std::is_constructible<std::variant<int, const bool>, decltype("meow")>::value, "");
   static_assert(!std::is_constructible<std::variant<int, const volatile bool>, decltype("meow")>::value, "");
-#endif // !__EDG__
   static_assert(std::is_constructible<std::variant<bool>, std::true_type>::value, "");
   static_assert(!std::is_constructible<std::variant<bool>, std::unique_ptr<char> >::value, "");
 #ifndef TEST_PERMISSIVE
@@ -4581,7 +4575,6 @@ void test_T_ctor_sfinae() {
                   "no matching constructor");
   }
 #if _HAS_CXX20
-#ifndef __EDG__ // TRANSITION, DevCom-1337958
   {
     using V = std::variant<std::string, float>;
     static_assert(std::is_constructible<V, int>::value == VariantAllowsNarrowingConversions,
@@ -4594,12 +4587,13 @@ void test_T_ctor_sfinae() {
     struct X {
       operator void*();
     };
+#ifndef __EDG__ // TRANSITION, VSO-1327220
     static_assert(!std::is_constructible<V, X>::value,
                   "no boolean conversion in constructor");
+#endif // !__EDG__
     static_assert(std::is_constructible<V, std::false_type>::value,
                   "no converted to bool in constructor");
   }
-#endif // !__EDG__
 #endif // _HAS_CXX20
   {
     struct X {};
@@ -4645,7 +4639,6 @@ void test_T_ctor_basic() {
     static_assert(std::get<1>(v) == 42, "");
   }
 #if _HAS_CXX20
-#ifndef __EDG__ // TRANSITION, DevCom-1337958
 #ifndef TEST_VARIANT_ALLOWS_NARROWING_CONVERSIONS
   {
     constexpr std::variant<unsigned, long> v(42);
@@ -4653,7 +4646,6 @@ void test_T_ctor_basic() {
     static_assert(std::get<1>(v) == 42, "");
   }
 #endif
-#endif // !__EDG__
   {
     std::variant<std::string, bool const> v = "meow";
     assert(v.index() == 0);

--- a/tests/std/tests/P0122R7_span/test.cpp
+++ b/tests/std/tests/P0122R7_span/test.cpp
@@ -242,13 +242,11 @@ constexpr bool test() {
         FunctionTakingSpan<const int>({as_const(arr), 3});
         FunctionTakingSpan<const int>({cbegin(arr), 3});
 
-#ifndef __EDG__ // TRANSITION, VSO-1079405
         static_assert(is_same_v<decltype(span{arr, 3}), span<int>>);
         static_assert(is_same_v<decltype(span{begin(arr), 3}), span<int>>);
 
         static_assert(is_same_v<decltype(span{as_const(arr), 3}), span<const int>>);
         static_assert(is_same_v<decltype(span{cbegin(arr), 3}), span<const int>>);
-#endif // TRANSITION, VSO-1079405
 
 #ifdef __cpp_lib_concepts
         static_assert(is_nothrow_constructible_v<span<int>, array<int, 3>::iterator, size_t>); // strengthened
@@ -351,10 +349,8 @@ constexpr bool test() {
         FunctionTakingSpan<const int>({cbegin(arr), end(arr)});
         FunctionTakingSpan<const int>({cbegin(arr), cend(arr)});
 
-#ifndef __EDG__ // TRANSITION, VSO-1079405
         static_assert(is_same_v<decltype(span{begin(arr), end(arr)}), span<int>>);
         static_assert(is_same_v<decltype(span{cbegin(arr), cend(arr)}), span<const int>>);
-#endif // TRANSITION, VSO-1079405
 
 #ifdef __cpp_lib_concepts
         static_assert(is_nothrow_constructible_v<span<int>, int*, const int*>); // strengthened
@@ -568,14 +564,12 @@ constexpr bool test() {
         FunctionTakingSpan<const int* const>(as_const(stl_nullptr));
 #endif // TRANSITION, VSO-1079410
 
-#ifndef __EDG__ // TRANSITION, VSO-1079405
         static_assert(is_same_v<decltype(span{arr}), span<int, 3>>);
         static_assert(is_same_v<decltype(span{as_const(arr)}), span<const int, 3>>);
         static_assert(is_same_v<decltype(span{stl}), span<int, 3>>);
         static_assert(is_same_v<decltype(span{as_const(stl)}), span<const int, 3>>);
         static_assert(is_same_v<decltype(span{stl_nullptr}), span<int*, 3>>);
         static_assert(is_same_v<decltype(span{as_const(stl_nullptr)}), span<int* const, 3>>);
-#endif // TRANSITION, VSO-1079405
     }
 
     {
@@ -789,12 +783,10 @@ constexpr bool test() {
         FunctionTakingSpan<const int, 3>(orig_three);
         FunctionTakingSpan<const int, 3>(orig_const_three);
 
-#ifndef __EDG__ // TRANSITION, VSO-1079405
         static_assert(is_same_v<decltype(span{orig_dyn}), span<int>>);
         static_assert(is_same_v<decltype(span{orig_three}), span<int, 3>>);
         static_assert(is_same_v<decltype(span{orig_const_dyn}), span<const int>>);
         static_assert(is_same_v<decltype(span{orig_const_three}), span<const int, 3>>);
-#endif // TRANSITION, VSO-1079405
     }
 
     {

--- a/tests/std/tests/P0220R1_optional/test.cpp
+++ b/tests/std/tests/P0220R1_optional/test.cpp
@@ -5495,17 +5495,13 @@ constexpr int test()
     {
         optional<X> opt(in_place, 2);
         Y y(3);
-#ifndef __EDG__ // TRANSITION, VSO-1268140
         assert(std::move(opt).value_or(y) == 2);
         assert(*opt == 0);
-#endif // ^^^ no workaround ^^^
     }
     {
         optional<X> opt(in_place, 2);
-#ifndef __EDG__ // TRANSITION, VSO-1268140
         assert(std::move(opt).value_or(Y(3)) == 2);
         assert(*opt == 0);
-#endif // ^^^ no workaround ^^^
     }
     {
         optional<X> opt;

--- a/tests/std/tests/P0325R4_to_array/test.cpp
+++ b/tests/std/tests/P0325R4_to_array/test.cpp
@@ -36,9 +36,7 @@ constexpr bool assert_constexpr() {
     assert_equal(to_array("meow"), array<char, 5>{'m', 'e', 'o', 'w', '\0'});
     assert_equal(to_array({1, 2}), array<int, 2>{1, 2});
 
-#ifndef __EDG__ // TRANSITION, VSO-985022
     assert_equal(to_array<long>({1, 2}), array<long, 2>{1, 2});
-#endif // __EDG__
     assert_equal(to_array(a), array<int, 3>{0, 0, 0});
     assert_equal(to_array(const_a), array<int, 3>{0, 0, 0});
     assert_equal(to_array(move(a)), array<int, 3>{0, 0, 0});

--- a/tests/std/tests/P0466R5_layout_compatibility_and_pointer_interconvertibility_traits/test.cpp
+++ b/tests/std/tests/P0466R5_layout_compatibility_and_pointer_interconvertibility_traits/test.cpp
@@ -73,11 +73,9 @@ constexpr bool test() {
         ASSERT(is_layout_compatible_v<int[], int[]>);
         ASSERT(is_layout_compatible_v<int[3], int[3]>);
 
-#if defined(__clang__) || defined(__EDG__) // TRANSITION, VSO-1269781
         ASSERT(is_layout_compatible_v<const int[], int[]>);
         ASSERT(is_layout_compatible_v<const int[3], int[3]>);
         ASSERT(is_layout_compatible_v<int[], volatile int[]>);
-#endif // TRANSITION, VSO-1269781
 
         ASSERT(!is_layout_compatible_v<int, char>);
         ASSERT(!is_layout_compatible_v<int, void>);

--- a/tests/std/tests/P0608R3_improved_variant_converting_constructor/test.cpp
+++ b/tests/std/tests/P0608R3_improved_variant_converting_constructor/test.cpp
@@ -85,9 +85,7 @@ void assert_more_examples() {
     static_assert(is_constructible_v<variant<float, bool, convertible_bool>, convertible_bool>);
     static_assert(is_constructible_v<variant<float, bool, convertible_bool>, bool>);
     static_assert(is_constructible_v<variant<char, int>, bool>);
-#ifdef __clang__ // TRANSITION, DevCom-1338628
     static_assert(is_constructible_v<variant<double_double>, int>);
-#endif // __clang__
     static_assert(!is_constructible_v<variant<float>, unsigned int>);
     static_assert(!is_constructible_v<variant<char, default_struct>, int>);
     static_assert(!is_constructible_v<variant<float, long, long long>, int>);
@@ -102,9 +100,7 @@ void assert_more_examples() {
     static_assert(is_assignable_v<variant<float, bool, convertible_bool>, convertible_bool>);
     static_assert(is_assignable_v<variant<float, bool, convertible_bool>, bool>);
     static_assert(is_assignable_v<variant<char, int>, bool>);
-#ifdef __clang__ // TRANSITION, DevCom-1338628
     static_assert(is_assignable_v<variant<double_double>, int>);
-#endif // __clang__
     static_assert(!is_assignable_v<variant<float>, unsigned int>);
     static_assert(!is_assignable_v<variant<char, default_struct>, int>);
     static_assert(!is_assignable_v<variant<float, long, long long>, int>);
@@ -218,7 +214,6 @@ void test_assignment_operator() {
     assert(b.index() == 2);
     assert(get<2>(b).x_ == 12.5);
 
-#ifdef __clang__ // TRANSITION, DevCom-1338628
     variant<void*, bool, double_double> c;
     assert(c.index() == 0);
     c = false; // bool
@@ -231,7 +226,6 @@ void test_assignment_operator() {
     c = static_cast<void*>(&c_data); // void*
     assert(c.index() == 0);
     assert(static_cast<double_double*>(get<0>(c))->x_ == 1.2);
-#endif // __clang__
 }
 
 int main() {

--- a/tests/std/tests/P0608R3_improved_variant_converting_constructor/test.cpp
+++ b/tests/std/tests/P0608R3_improved_variant_converting_constructor/test.cpp
@@ -38,17 +38,13 @@ void assert_P0608R3() {
     static_assert(is_constructible_v<variant<char, optional<char16_t>>, char16_t>);
     static_assert(is_constructible_v<variant<int, reference_wrapper<double>>, double&>);
     static_assert(is_constructible_v<variant<float, int>, char>);
-#ifndef __EDG__ // TRANSITION, DevCom-1337958
     static_assert(is_constructible_v<variant<float, long>, int>);
     static_assert(is_constructible_v<variant<float, long long>, int>);
     static_assert(is_constructible_v<variant<float, long, double>, int>);
     static_assert(is_constructible_v<variant<float, vector<int>, long long>, int>);
-#endif // !__EDG__
     static_assert(is_constructible_v<variant<float, int, long long>, char>);
-#ifndef __EDG__ // TRANSITION, DevCom-1337958
     static_assert(!is_constructible_v<variant<float>, int>);
     static_assert(!is_constructible_v<variant<float, vector<int>>, int>);
-#endif // !__EDG__
     static_assert(!is_constructible_v<variant<float, char>, int>);
 
     static_assert(is_assignable_v<variant<string, bool>, const char*>);
@@ -56,17 +52,13 @@ void assert_P0608R3() {
     static_assert(is_assignable_v<variant<char, optional<char16_t>>, char16_t>);
     static_assert(is_assignable_v<variant<int, reference_wrapper<double>>, double&>);
     static_assert(is_assignable_v<variant<float, int>, char>);
-#ifndef __EDG__ // TRANSITION, DevCom-1337958
     static_assert(is_assignable_v<variant<float, long>, int>);
     static_assert(is_assignable_v<variant<float, long long>, int>);
     static_assert(is_assignable_v<variant<float, long, double>, int>);
     static_assert(is_assignable_v<variant<float, vector<int>, long long>, int>);
-#endif // !__EDG__
     static_assert(is_assignable_v<variant<float, int, long long>, char>);
-#ifndef __EDG__ // TRANSITION, DevCom-1337958
     static_assert(!is_assignable_v<variant<float>, int>);
     static_assert(!is_assignable_v<variant<float, vector<int>>, int>);
-#endif // !__EDG__
     static_assert(!is_assignable_v<variant<float, char>, int>);
 }
 
@@ -93,13 +85,11 @@ void assert_more_examples() {
     static_assert(is_constructible_v<variant<float, bool, convertible_bool>, convertible_bool>);
     static_assert(is_constructible_v<variant<float, bool, convertible_bool>, bool>);
     static_assert(is_constructible_v<variant<char, int>, bool>);
-#ifndef __EDG__ // TRANSITION, DevCom-1337958
 #ifdef __clang__ // TRANSITION, DevCom-1338628
     static_assert(is_constructible_v<variant<double_double>, int>);
 #endif // __clang__
     static_assert(!is_constructible_v<variant<float>, unsigned int>);
     static_assert(!is_constructible_v<variant<char, default_struct>, int>);
-#endif // !__EDG__
     static_assert(!is_constructible_v<variant<float, long, long long>, int>);
 
     static_assert(is_assignable_v<variant<double_double>, double>);
@@ -112,13 +102,11 @@ void assert_more_examples() {
     static_assert(is_assignable_v<variant<float, bool, convertible_bool>, convertible_bool>);
     static_assert(is_assignable_v<variant<float, bool, convertible_bool>, bool>);
     static_assert(is_assignable_v<variant<char, int>, bool>);
-#ifndef __EDG__ // TRANSITION, DevCom-1337958
 #ifdef __clang__ // TRANSITION, DevCom-1338628
     static_assert(is_assignable_v<variant<double_double>, int>);
 #endif // __clang__
     static_assert(!is_assignable_v<variant<float>, unsigned int>);
     static_assert(!is_assignable_v<variant<char, default_struct>, int>);
-#endif // !__EDG__
     static_assert(!is_assignable_v<variant<float, long, long long>, int>);
 }
 
@@ -144,16 +132,13 @@ void test_variant_constructor_P0608R3() {
 
     variant<float, long> e;
     assert(e.index() == 0);
-#ifndef __EDG__ // TRANSITION, DevCom-1337958
     e = 0; // long
     assert(e.index() == 1);
-#endif // !__EDG__
 
     variant<float, int> f = 'a'; // int
     assert(f.index() == 1);
     assert(get<int>(f) == 97);
 
-#ifndef __EDG__ // TRANSITION, DevCom-1337958
     variant<float, long> g = 0; // long
     assert(g.index() == 1);
 
@@ -162,7 +147,6 @@ void test_variant_constructor_P0608R3() {
 
     variant<float, vector<int>, long long> i = 0; // long long
     assert(i.index() == 2);
-#endif // !__EDG__
 
     variant<float, int, long long> j = 'a'; // int
     assert(j.index() == 1);
@@ -223,7 +207,6 @@ void test_assignment_operator() {
     assert(a.index() == 1);
     assert(get<bool>(a) == true);
 
-#ifndef __EDG__ // TRANSITION, DevCom-1337958
     bool b_data                         = true;
     variant<bool, int, double_double> b = b_data; // bool
     assert(b.index() == 0);
@@ -234,7 +217,6 @@ void test_assignment_operator() {
     b = 12.5; // double_double
     assert(b.index() == 2);
     assert(get<2>(b).x_ == 12.5);
-#endif // !__EDG__
 
 #ifdef __clang__ // TRANSITION, DevCom-1338628
     variant<void*, bool, double_double> c;

--- a/tests/std/tests/P0674R1_make_shared_for_arrays/test.cpp
+++ b/tests/std/tests/P0674R1_make_shared_for_arrays/test.cpp
@@ -634,9 +634,7 @@ struct TrivialThrowingDtor {
     ~TrivialThrowingDtor() noexcept(false) = default;
 };
 
-#ifndef __EDG__ // TRANSITION, VSO-1292292
 static_assert(!is_nothrow_destructible_v<TrivialThrowingDtor>);
-#endif // ^^^ no workaround ^^^
 static_assert(is_trivially_destructible_v<TrivialThrowingDtor>);
 
 template <class T>

--- a/tests/std/tests/P0784R7_library_support_for_more_constexpr_containers/test.cpp
+++ b/tests/std/tests/P0784R7_library_support_for_more_constexpr_containers/test.cpp
@@ -223,7 +223,6 @@ void test_array(const T& val) {
 }
 
 #ifdef __cpp_lib_constexpr_dynamic_alloc
-#ifndef __EDG__ // TRANSITION, VSO-1269976
 template <class T>
 struct storage_for {
     union {
@@ -269,7 +268,6 @@ constexpr void test_compiletime() {
     }
 }
 static_assert((test_compiletime(), true));
-#endif // __EDG__
 
 template <class T>
 struct A {
@@ -389,7 +387,6 @@ constexpr void test_compiletime_destroy_variants() {
 }
 static_assert((test_compiletime_destroy_variants(), true));
 
-#ifndef __EDG__ // TRANSITION, VSO-1269976
 template <class T, bool Construct = false, bool Destroy = false>
 struct Alloc {
     using value_type = T;
@@ -503,7 +500,6 @@ constexpr void test_compiletime_allocator_traits() {
     }
 }
 static_assert((test_compiletime_allocator_traits(), true));
-#endif // __EDG__
 
 constexpr void test_compiletime_allocator() {
     {

--- a/tests/std/tests/P0784R7_library_support_for_more_constexpr_containers/test.cpp
+++ b/tests/std/tests/P0784R7_library_support_for_more_constexpr_containers/test.cpp
@@ -91,10 +91,8 @@ static_assert(can_construct_at<const volatile int, int&>);
 
 struct X {};
 
-#ifndef __EDG__ // TRANSITION, VSO-1075296
 static_assert(!can_construct_at<int, X>);
 static_assert(!can_construct_at<X, int>);
-#endif // __EDG__
 
 // note that indestructible isn't constructible but is construct_at-ible:
 struct indestructible {
@@ -124,12 +122,10 @@ static_assert(!can_construct_at<string, X>);
 
 // The following static_asserts test our strengthening of noexcept
 
-#ifndef __EDG__ // TRANSITION, VSO-1075296
 static_assert(construct_at_noexcept<int, int>());
 static_assert(construct_at_noexcept<const int, int>());
 static_assert(construct_at_noexcept<volatile int, int>());
 static_assert(construct_at_noexcept<const volatile int, int>());
-#endif // __EDG__
 
 static_assert(!construct_at_noexcept<string, const char (&)[6]>());
 static_assert(!construct_at_noexcept<const string, const char (&)[6]>());

--- a/tests/std/tests/P0784R7_library_support_for_more_constexpr_containers/test.cpp
+++ b/tests/std/tests/P0784R7_library_support_for_more_constexpr_containers/test.cpp
@@ -286,7 +286,7 @@ struct nontrivial_A {
 };
 
 constexpr void test_compiletime_destroy_variants() {
-#ifndef __EDG__ // TRANSITION, VSO-1270011
+#ifndef __EDG__ // TRANSITION, VSO-1327238
     {
         allocator<A<int>> alloc{};
         A<int>* a = alloc.allocate(10);

--- a/tests/std/tests/P0896R4_ranges_range_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_range_machinery/test.cpp
@@ -1889,10 +1889,8 @@ namespace unwrapped_begin_end {
 
 int main() {
     // Validate conditional constexpr
-#ifdef __clang__ // TRANSITION, VSO-977008
     STATIC_ASSERT(test_array_ish<std::initializer_list<int>>());
     STATIC_ASSERT(test_array_ish<std::initializer_list<int const>>());
-#endif // TRANSITION, VSO-977008
     STATIC_ASSERT(test_array_ish<int[3]>());
     STATIC_ASSERT(test_array_ish<int const[3]>());
 

--- a/tests/std/tests/P0896R4_views_drop/test.cpp
+++ b/tests/std/tests/P0896R4_views_drop/test.cpp
@@ -460,11 +460,7 @@ constexpr void output_range_test() {
         test::CanCompare::no, test::ProxyRef::yes, test::CanView::yes, test::Copyability::move_only>;
     int some_writable_ints[] = {0, 1, 2, 3};
     STATIC_ASSERT(same_as<decltype(views::drop(R{some_writable_ints}, 2)), ranges::drop_view<R>>);
-#if !defined(__clang__) && !defined(__EDG__) // TRANSITION, VSO-1217687
-    ranges::fill(views::drop(R{some_writable_ints}, 2), 42);
-#else // ^^^ workaround / no workaround vvv
     ranges::fill(R{some_writable_ints} | views::drop(2), 42);
-#endif // TRANSITION, VSO-1217687
     assert(ranges::equal(some_writable_ints, initializer_list<int>{0, 1, 42, 42}));
 }
 

--- a/tests/std/tests/P0896R4_views_take/test.cpp
+++ b/tests/std/tests/P0896R4_views_take/test.cpp
@@ -495,18 +495,10 @@ constexpr void output_range_test() {
         STATIC_ASSERT(same_as<decltype(views::take(R{some_writable_ints}, 99999)), ranges::take_view<R>>);
 
         // How do I implement "Fill up to n elements in {output range} with {value}"?
-#if !defined(__clang__) && !defined(__EDG__) // TRANSITION, VSO-1217687
-        ranges::fill(views::take(R{some_writable_ints}, 99999), 42);
-#else // ^^^ workaround / no workaround vvv
         ranges::fill(R{some_writable_ints} | views::take(99999), 42);
-#endif // TRANSITION, VSO-1217687
         assert(ranges::equal(some_writable_ints, initializer_list<int>{42, 42, 42, 42}));
 
-#if !defined(__clang__) && !defined(__EDG__) // TRANSITION, VSO-1217687
-        ranges::fill(views::take(R{some_writable_ints}, 3), 13);
-#else // ^^^ workaround / no workaround vvv
         ranges::fill(R{some_writable_ints} | views::take(3), 13);
-#endif // TRANSITION, VSO-1217687
         assert(ranges::equal(some_writable_ints, initializer_list<int>{13, 13, 13, 42}));
     }
 }

--- a/tests/std/tests/P0898R3_concepts/test.cpp
+++ b/tests/std/tests/P0898R3_concepts/test.cpp
@@ -1492,13 +1492,9 @@ namespace test_default_initializable {
     using std::default_initializable, std::initializer_list;
 
     STATIC_ASSERT(default_initializable<int>);
-#if defined(MSVC_INTERNAL_TESTING) || defined(__clang__) || defined(__EDG__) // TRANSITION, DevCom-952724
     STATIC_ASSERT(!default_initializable<int const>);
-#endif // TRANSITION, DevCom-952724
     STATIC_ASSERT(default_initializable<int volatile>);
-#if defined(MSVC_INTERNAL_TESTING) || defined(__clang__) || defined(__EDG__) // TRANSITION, DevCom-952724
     STATIC_ASSERT(!default_initializable<int const volatile>);
-#endif // TRANSITION, DevCom-952724
     STATIC_ASSERT(default_initializable<double>);
     STATIC_ASSERT(!default_initializable<void>);
 
@@ -1511,9 +1507,7 @@ namespace test_default_initializable {
     STATIC_ASSERT(!default_initializable<int[]>);
     STATIC_ASSERT(!default_initializable<char[]>);
     STATIC_ASSERT(!default_initializable<char[][3]>);
-#if defined(MSVC_INTERNAL_TESTING) || defined(__clang__) || defined(__EDG__) // TRANSITION, DevCom-952724
     STATIC_ASSERT(!default_initializable<int const[2]>);
-#endif // TRANSITION, DevCom-952724
 
     STATIC_ASSERT(!default_initializable<int&>);
     STATIC_ASSERT(!default_initializable<int const&>);

--- a/tests/std/tests/P0980R1_constexpr_strings/test.cpp
+++ b/tests/std/tests/P0980R1_constexpr_strings/test.cpp
@@ -213,10 +213,10 @@ _CONSTEXPR20_CONTAINER bool test_interface() {
 
         str ptr_size_constructed(get_literal_input<CharType>(), 2);
         assert(equalRanges(ptr_size_constructed, "He"sv));
-#if defined(MSVC_INTERNAL_TESTING) || defined(__EDG__) // TRANSITION, VSO-1270433
+
         str iterator_constructed(literal_constructed.begin(), literal_constructed.end());
         assert(equalRanges(iterator_constructed, literal_constructed));
-#endif // defined(MSVC_INTERNAL_TESTING) || defined(__EDG__)
+
         const string_view_convertible<CharType> convertible;
         str conversion_constructed(convertible);
         assert(equalRanges(conversion_constructed, literal_constructed));
@@ -261,10 +261,10 @@ _CONSTEXPR20_CONTAINER bool test_interface() {
 
         str ptr_size_constructed(get_literal_input<CharType>(), 2, alloc);
         assert(equalRanges(ptr_size_constructed, "He"sv));
-#if defined(MSVC_INTERNAL_TESTING) || defined(__EDG__) // TRANSITION, VSO-1270433
+
         str iterator_constructed(literal_constructed.begin(), literal_constructed.end(), alloc);
         assert(equalRanges(iterator_constructed, literal_constructed));
-#endif // defined(MSVC_INTERNAL_TESTING) || defined(__EDG__)
+
         const string_view_convertible<CharType> convertible;
         str conversion_constructed(convertible, alloc);
         assert(equalRanges(conversion_constructed, literal_constructed));

--- a/tests/std/tests/P1004R2_constexpr_vector/test.cpp
+++ b/tests/std/tests/P1004R2_constexpr_vector/test.cpp
@@ -12,9 +12,7 @@
 
 using namespace std;
 
-#if defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 || defined(MSVC_INTERNAL_TESTING) // TRANSITION, VSO-1270433
 static constexpr int input[] = {0, 1, 2, 3, 4, 5};
-#endif // defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 || defined(MSVC_INTERNAL_TESTING)
 
 template <typename T>
 struct soccc_allocator {
@@ -63,7 +61,6 @@ struct soccc_allocator {
 using vec = vector<int, soccc_allocator<int>>;
 
 _CONSTEXPR20_CONTAINER bool test_interface() {
-#if defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 || defined(MSVC_INTERNAL_TESTING) // TRANSITION, VSO-1270433
     { // constructors
 
         // Non allocator constructors
@@ -506,12 +503,11 @@ _CONSTEXPR20_CONTAINER bool test_interface() {
         static_assert(is_same_v<remove_const_t<decltype(ge)>, bool>);
         assert(!ge);
     }
-#endif // defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 || defined(MSVC_INTERNAL_TESTING)
+
     return true;
 }
 
 _CONSTEXPR20_CONTAINER bool test_iterators() {
-#if defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 || defined(MSVC_INTERNAL_TESTING) // TRANSITION, VSO-1270433
     vec range_constructed(begin(input), end(input));
 
 #if !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 // TRANSITION, VSO-1273381
@@ -606,12 +602,11 @@ _CONSTEXPR20_CONTAINER bool test_iterators() {
     }
 
 #endif // !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2
-#endif // defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 || defined(MSVC_INTERNAL_TESTING)
+
     return true;
 }
 
 _CONSTEXPR20_CONTAINER bool test_growth() {
-#if defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 || defined(MSVC_INTERNAL_TESTING) // TRANSITION, VSO-1270433
     {
         vector<int> v(1000, 1729);
 
@@ -707,7 +702,7 @@ _CONSTEXPR20_CONTAINER bool test_growth() {
         assert(v.capacity() == 8000);
 #endif // __EDG__
     }
-#endif // defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 || defined(MSVC_INTERNAL_TESTING)
+
     return true;
 }
 

--- a/tests/std/tests/P1004R2_constexpr_vector_bool/test.cpp
+++ b/tests/std/tests/P1004R2_constexpr_vector_bool/test.cpp
@@ -13,7 +13,6 @@
 
 using namespace std;
 
-#if defined(MSVC_INTERNAL_TESTING) || defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 // TRANSITION, VSO-1270433
 #ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-const-variable" // TRANSITION, LLVM-48606
@@ -23,7 +22,6 @@ static constexpr bool input_flipped[] = {false, true, false, false, true, false}
 #ifdef __clang__
 #pragma clang diagnostic pop
 #endif // __clang__
-#endif // defined(MSVC_INTERNAL_TESTING) || defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2
 
 template <typename T>
 struct soccc_allocator {
@@ -72,7 +70,6 @@ struct soccc_allocator {
 using vec = vector<bool, soccc_allocator<bool>>;
 
 _CONSTEXPR20_CONTAINER bool test_interface() {
-#if defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 || defined(MSVC_INTERNAL_TESTING) // TRANSITION, VSO-1270433
     { // constructors
 
 // Non allocator constructors
@@ -533,13 +530,11 @@ _CONSTEXPR20_CONTAINER bool test_interface() {
         assert(ge);
 #endif // __EDG__
     }
-#endif // defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 || defined(MSVC_INTERNAL_TESTING)
 
     return true;
 }
 
 _CONSTEXPR20_CONTAINER bool test_iterators() {
-#if defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 || defined(MSVC_INTERNAL_TESTING) // TRANSITION, VSO-1270433
 #ifndef __EDG__ // TRANSITION, VSO-1274387
     vec range_constructed(begin(input), end(input));
 
@@ -628,7 +623,6 @@ _CONSTEXPR20_CONTAINER bool test_iterators() {
     }
 #endif // __EDG__
 #endif // !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2
-#endif // defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 || defined(MSVC_INTERNAL_TESTING)
 
     return true;
 }

--- a/tests/std/tests/P1502R1_standard_library_header_units/test.cpp
+++ b/tests/std/tests/P1502R1_standard_library_header_units/test.cpp
@@ -126,11 +126,7 @@ int main() {
 
     {
         puts("Testing <array>.");
-#ifdef MSVC_INTERNAL_TESTING // TRANSITION, VSO-1309454 (duplicated deduction guides)
         constexpr array arr{10, 20, 30, 40, 50};
-#else // ^^^ no workaround / workaround vvv
-        constexpr array<int, 5> arr{10, 20, 30, 40, 50};
-#endif // ^^^ workaround ^^^
         assert(arr[2] == 30);
         static_assert(arr[2] == 30);
     }
@@ -581,17 +577,8 @@ int main() {
     {
         puts("Testing <ranges>.");
         constexpr int arr[]{11, 0, 22, 0, 33, 0, 44, 0, 55};
-#ifdef MSVC_INTERNAL_TESTING // TRANSITION, VSO-1309454 (duplicated deduction guides)
         assert(ranges::distance(views::filter(arr, [](int x) { return x == 0; })) == 4);
         static_assert(ranges::distance(views::filter(arr, [](int x) { return x != 0; })) == 5);
-#else // ^^^ no workaround / workaround vvv
-        auto is_zero = [](int x) { return x == 0; };
-        using FV1    = ranges::filter_view<ranges::ref_view<decltype(arr)>, decltype(is_zero)>;
-        assert(ranges::distance(FV1{arr, is_zero}) == 4);
-        constexpr auto not_zero = [](int x) { return x != 0; };
-        using FV2 = ranges::filter_view<ranges::ref_view<decltype(arr)>, remove_const_t<decltype(not_zero)>>;
-        static_assert(ranges::distance(FV2{arr, not_zero}) == 5);
-#endif // ^^^ workaround ^^^
     }
 
     {

--- a/tests/std/tests/VSO_0000000_more_pair_tuple_sfinae/test.cpp
+++ b/tests/std/tests/VSO_0000000_more_pair_tuple_sfinae/test.cpp
@@ -58,7 +58,7 @@ struct ExplicitDefault {
 template <typename T>
 constexpr bool OrdinaryDC = is_default_constructible_v<T>&& IsImplicitlyDefaultConstructible<T>::value;
 
-#ifdef __EDG__ // TRANSITION, VSO-590216
+#ifdef __EDG__ // TRANSITION, VSO-1327248
 template <typename T>
 constexpr bool ExplicitDC = is_default_constructible_v<T>;
 #else // ^^^ workaround ^^^ / vvv no workaround vvv


### PR DESCRIPTION
* Update the toolset to VS 2019 16.10 Preview 4 and Python 3.9.5.
  + I'm adding a step to `create-vmss.ps1` that sleeps for 60 seconds after rebooting the VM, before running `sysprep.ps1`. This is because the script failed twice, saying that something else was busy. Each failure costs about 30 minutes. I don't understand the root cause, but I'm hoping that this sleep should make the script more robust, even though this is not a good technique.
* This also removes an enormous number of compiler bug workarounds. Many were fixed before 16.10p4 but we were incredibly busy and didn't have time to react.
* DevCom-952724 "MSVC allows default-initialized const int in new-expression" was mostly fixed, but we still need the workaround for: https://github.com/microsoft/STL/blob/18c12ab01896e73e95a69ceba9fbd7250304f895/tests/std/tests/P0898R3_concepts/test.cpp#L1560-L1562
  As this is passing with `MSVC_INTERNAL_TESTING`, I didn't report a new bug - I assume we just need a followup fix that didn't get into Preview 4. We can check again in the future and report a new bug if it persists.
* We need to unskip `bit_ceil.fail.cpp`, which now fails to compile (as desired!) with:
  ```
  bit_ceil.fail.cpp(39): error C2131: expression did not evaluate to a constant
  bit(51): note: failure was caused by the right operand of '<<' being too large (undefined behavior)
  ```
  I've left GH-1595 open because there may be remaining work to do.
* Enabling commented-out coverage for WG21-P1065 in `Dev11_0535636_functional_overhaul` (fixing mentions of a nonexistent `sp`) revealed an MSVC compiler bug which I reported as DevCom-1419425 "constexpr PMD emits bogus error C2131".
  + This is the only cleanup that isn't a compiler workaround removal; it was TRANSITION because we implemented `constexpr invoke()` before `constexpr ref()`. It ended up being a compiler workaround addition, though! :smiley_cat:
* DevCom-1337958 "allowing narrowing conversions during template evaluation with /BE" was mostly fixed; I reported VSO-1327220 "EDG doesn't detect narrowing conversions from a user-defined type to a pointer type to bool".
* When removing workarounds in product code, especially workarounds for EDG, I'm a little concerned about breaking CUDA. All of the product changes here are C++17/20 so there's no CUDA 10.1 Update 2 impact.
* VSO-590216 "REPORTED: EDG should implement CWG 1518 for IsImplicitlyDefaultConstructible" wasn't completely fixed; I reported VSO-1327248 "EDG still doesn't handle IsImplicitlyDefaultConstructible".
* VSO-1270011 "REPORTED: [Feedback] ICE during constant evaluation with /BE" wasn't completely fixed; I reported VSO-1327238 "EDG still ICEs with library support for constexpr containers".
* VSO-1307828 "Standard Library Header Units: ICE with queue's friend bool operator==" was fixed, but I'd like to keep the `_Get_container()` workaround permanently. It's much simpler than the previous friendship scheme, and I'm willing to pay the debug codegen cost of a helper function here (we sometimes spend code complexity to improve debug codegen, but this is too much for too obscure of an scenario).