### PR TITLE
`<chrono>`: Allows the parsing of year + day-of-year to a `time_point`

### DIFF
--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -4122,12 +4122,9 @@ namespace chrono {
 
             if constexpr (_Can_rep_day) {
                 if (_For_time_point) {
-                    year_month_day _Ymd;
-                    if (_Make_year_month_day(_Ymd, true)) {
-                        _Result += _CHRONO duration_cast<_DurationType>(static_cast<sys_days>(_Ymd).time_since_epoch());
-                    } else {
-                        return false;
-                    }
+                    const year_month_day _Ymd{year{*_Century + *_Two_dig_year},
+                        month{static_cast<unsigned int>(*_Month)}, day{static_cast<unsigned int>(*_Day)}};
+                    _Result += _CHRONO duration_cast<_DurationType>(static_cast<sys_days>(_Ymd).time_since_epoch());
                 } else if (_Used & _F_doy) {
                     _Result += _CHRONO duration_cast<_DurationType>(days{*_Day_of_year});
                 }
@@ -4157,7 +4154,7 @@ namespace chrono {
         template <class _DurationType>
         _NODISCARD bool _Make_time_point(_DurationType& _Dur, _LeapSecondRep _Leap) {
 
-            const bool _Consistent{_Calculate_hour24() && _Calculate_year_fields()};
+            const bool _Consistent{_Calculate_hour24() && _Calculate_year_fields() && _Calculate_ymd()};
             if (!_Consistent || !_Apply_duration_fields<_Parse_tp_or_duration::_Time_point>(_Dur)) {
                 return false;
             }

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_io/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_io/test.cpp
@@ -718,6 +718,8 @@ void parse_calendar_types_basic() {
     test_parse("366 2004-12-31", "%j %F", ymd);
     assert(ymd == 2004y / December / last);
 
+    test_parse("82 1882", "%j %Y", ymd);
+    assert(ymd == 23d / March / 1882y);
     fail_parse("366 2001", "%j %Y", ymd);
     fail_parse("367 2004", "%j %Y", ymd);
 
@@ -1086,6 +1088,10 @@ void parse_timepoints() {
     assert(st == sys_days{23d / June / 1912y});
     test_parse("1912-06-23 23:59:59", "%F %T", st);
     assert(st == sys_days{23d / June / 1912y} + 23h + 59min + 59s);
+
+    // GH-1938: parsing timepoint with year and day-of-year
+    test_parse("1882.82", "%Y.%j", st);
+    assert(st == sys_days{23d / March / 1882y});
 }
 
 void parse_wchar() {


### PR DESCRIPTION
Fixes #1938.

 - Call to _Calculate_ymd should be sooner, so that parsed fields are
   converted to Gregorian YMD before we call _Apply_duration_fields.