### PR TITLE
`filesystem::u8path` should accept `char8_t` sources

### DIFF
--- a/stl/inc/filesystem
+++ b/stl/inc/filesystem
@@ -275,8 +275,8 @@ namespace filesystem {
 #ifdef __cpp_char8_t
     template <class _Conversion>
     _NODISCARD wstring _Convert_stringoid_to_wide(const basic_string_view<char8_t> _Input, _Conversion) {
-        static_assert(is_same_v<_Conversion, _Normal_conversion> || is_same_v<_Conversion, _Utf8_conversion>,
-            "invalid value_type, see N4810 D.17 [depr.fs.path.factory]/1");
+        static_assert(_Is_any_of_v<_Conversion, _Normal_conversion, _Utf8_conversion>);
+
         const string_view _Input_as_char{reinterpret_cast<const char*>(_Input.data()), _Input.size()};
         return _Convert_narrow_to_wide(__std_code_page::_Utf8, _Input_as_char);
     }

--- a/stl/inc/filesystem
+++ b/stl/inc/filesystem
@@ -275,8 +275,8 @@ namespace filesystem {
 #ifdef __cpp_char8_t
     template <class _Conversion>
     _NODISCARD wstring _Convert_stringoid_to_wide(const basic_string_view<char8_t> _Input, _Conversion) {
-        static_assert(
-            is_same_v<_Conversion, _Normal_conversion>, "invalid value_type, see N4810 D.17 [depr.fs.path.factory]/1");
+        static_assert(is_same_v<_Conversion, _Normal_conversion> || is_same_v<_Conversion, _Utf8_conversion>,
+            "invalid value_type, see N4810 D.17 [depr.fs.path.factory]/1");
         const string_view _Input_as_char{reinterpret_cast<const char*>(_Input.data()), _Input.size()};
         return _Convert_narrow_to_wide(__std_code_page::_Utf8, _Input_as_char);
     }

--- a/stl/inc/filesystem
+++ b/stl/inc/filesystem
@@ -256,7 +256,7 @@ namespace filesystem {
 
     template <class _Conversion>
     _NODISCARD wstring _Convert_stringoid_to_wide(const string_view _Input, _Conversion) {
-        static_assert(_Is_any_of_v<_Conversion, _Normal_conversion, _Utf8_conversion>);
+        _STL_INTERNAL_STATIC_ASSERT(_Is_any_of_v<_Conversion, _Normal_conversion, _Utf8_conversion>);
 
         if constexpr (is_same_v<_Conversion, _Normal_conversion>) {
             return _Convert_narrow_to_wide(__std_fs_code_page(), _Input);
@@ -275,7 +275,7 @@ namespace filesystem {
 #ifdef __cpp_char8_t
     template <class _Conversion>
     _NODISCARD wstring _Convert_stringoid_to_wide(const basic_string_view<char8_t> _Input, _Conversion) {
-        static_assert(_Is_any_of_v<_Conversion, _Normal_conversion, _Utf8_conversion>);
+        _STL_INTERNAL_STATIC_ASSERT(_Is_any_of_v<_Conversion, _Normal_conversion, _Utf8_conversion>);
 
         const string_view _Input_as_char{reinterpret_cast<const char*>(_Input.data()), _Input.size()};
         return _Convert_narrow_to_wide(__std_code_page::_Utf8, _Input_as_char);

--- a/tests/std/tests/P1423R3_char8_t_remediation/test.compile.pass.cpp
+++ b/tests/std/tests/P1423R3_char8_t_remediation/test.compile.pass.cpp
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#define _SILENCE_CXX20_U8PATH_DEPRECATION_WARNING 1
+#include <filesystem>
 #include <ostream>
+#include <string_view>
 #include <type_traits>
 #include <utility>
 
@@ -21,7 +24,7 @@ STATIC_ASSERT(stream_insertable<std::ostream, int&>);
 STATIC_ASSERT(stream_insertable<std::ostream, const int&>);
 
 template <class Stream, class charT>
-constexpr bool test() {
+constexpr bool test_stream_insertion() {
     // validate that expressions of type (possibly-const) charT and (possibly-const) charT* (possibly-const) are
     // equivalently insertable into Stream
     constexpr bool result = stream_insertable<Stream, charT>;
@@ -45,18 +48,25 @@ constexpr bool test() {
 }
 
 // Control cases
-STATIC_ASSERT(test<std::ostream, char>());
-STATIC_ASSERT(test<std::wostream, wchar_t>());
+STATIC_ASSERT(test_stream_insertion<std::ostream, char>());
+STATIC_ASSERT(test_stream_insertion<std::wostream, wchar_t>());
 
 #ifdef __cpp_char8_t
-STATIC_ASSERT(!test<std::ostream, char8_t>());
-STATIC_ASSERT(!test<std::wostream, char8_t>());
+STATIC_ASSERT(!test_stream_insertion<std::ostream, char8_t>());
+STATIC_ASSERT(!test_stream_insertion<std::wostream, char8_t>());
 #endif // __cpp_char8_t
 
 #ifdef _NATIVE_WCHAR_T_DEFINED
-STATIC_ASSERT(test<std::ostream, wchar_t>() == !_HAS_CXX20);
+STATIC_ASSERT(test_stream_insertion<std::ostream, wchar_t>() == !_HAS_CXX20);
 #endif // _NATIVE_WCHAR_T_DEFINED
-STATIC_ASSERT(test<std::ostream, char16_t>() == !_HAS_CXX20);
-STATIC_ASSERT(test<std::ostream, char32_t>() == !_HAS_CXX20);
-STATIC_ASSERT(test<std::wostream, char16_t>() == !_HAS_CXX20);
-STATIC_ASSERT(test<std::wostream, char32_t>() == !_HAS_CXX20);
+STATIC_ASSERT(test_stream_insertion<std::ostream, char16_t>() == !_HAS_CXX20);
+STATIC_ASSERT(test_stream_insertion<std::ostream, char32_t>() == !_HAS_CXX20);
+STATIC_ASSERT(test_stream_insertion<std::wostream, char16_t>() == !_HAS_CXX20);
+STATIC_ASSERT(test_stream_insertion<std::wostream, char32_t>() == !_HAS_CXX20);
+
+#ifdef __cpp_char8_t
+void test_u8path() {
+    (void) std::filesystem::u8path(u8"a");
+    (void) std::filesystem::u8path(std::basic_string_view{u8"a"});
+}
+#endif // __cpp_char8_t

--- a/tests/std/tests/P1423R3_char8_t_remediation/test.compile.pass.cpp
+++ b/tests/std/tests/P1423R3_char8_t_remediation/test.compile.pass.cpp
@@ -67,6 +67,8 @@ STATIC_ASSERT(test_stream_insertion<std::wostream, char32_t>() == !_HAS_CXX20);
 #ifdef __cpp_char8_t
 void test_u8path() {
     (void) std::filesystem::u8path(u8"a");
-    (void) std::filesystem::u8path(std::basic_string_view{u8"a"});
+    const std::basic_string_view sv{u8"a"};
+    (void) std::filesystem::u8path(sv);
+    (void) std::filesystem::u8path(sv.begin(), sv.end());
 }
 #endif // __cpp_char8_t


### PR DESCRIPTION
Fixes #1941
