### PR TITLE
Toolset update: VS 2019 16.11 Preview 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 The STL uses boost-math headers to provide P0226R1 Mathematical Special Functions. We recommend using [vcpkg][] to
 acquire this dependency.
 
-1. Install Visual Studio 2019 16.10 Preview 4 or later.
+1. Install Visual Studio 2019 16.11 Preview 1 or later.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
     * Otherwise, install [CMake][] 3.20 or later, and [Ninja][] 1.10.2 or later.
@@ -158,7 +158,7 @@ acquire this dependency.
 
 # How To Build With A Native Tools Command Prompt
 
-1. Install Visual Studio 2019 16.10 Preview 4 or later.
+1. Install Visual Studio 2019 16.11 Preview 1 or later.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
     * Otherwise, install [CMake][] 3.20 or later, and [Ninja][] 1.10.2 or later.

--- a/azure-devops/create-vmss.ps1
+++ b/azure-devops/create-vmss.ps1
@@ -27,7 +27,7 @@ $ProtoVMName = 'PROTOTYPE'
 $LiveVMPrefix = 'BUILD'
 $ImagePublisher = 'MicrosoftWindowsDesktop'
 $ImageOffer = 'Windows-10'
-$ImageSku = '20h2-ent-g2'
+$ImageSku = '21h1-ent-g2'
 
 $ProgressActivity = 'Creating Scale Set'
 $TotalProgress = 14

--- a/azure-devops/create-vmss.ps1
+++ b/azure-devops/create-vmss.ps1
@@ -310,6 +310,8 @@ Write-Progress `
   -Status 'Sleeping after restart' `
   -PercentComplete (100 / $TotalProgress * $CurrentProgress++)
 
+# The VM appears to be busy immediately after restarting.
+# This workaround waits for a minute before attempting to run sysprep.ps1.
 Start-Sleep -Seconds 60
 
 ####################################################################################################

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@ variables:
   buildOutputLocation: 'D:\build'
   vcpkgLocation: '$(Build.SourcesDirectory)/vcpkg'
 
-pool: 'StlBuild-2021-05-18'
+pool: 'StlBuild-2021-06-02'
 
 stages:
   - stage: Code_Format

--- a/tests/utils/stl/test/tests.py
+++ b/tests/utils/stl/test/tests.py
@@ -234,7 +234,7 @@ class STLTest(Test):
                 if flag[5:] == 'c++latest':
                     self._addCustomFeature('c++2a')
                 elif flag[5:] == 'c++20':
-                    self.requires.append('unsupported_potato') # TRANSITION, VS2019 Preview 16.11
+                    self._addCustomFeature('c++2a')
                 elif flag[5:] == 'c++17':
                     self._addCustomFeature('c++17')
                 elif flag[5:] == 'c++14':


### PR DESCRIPTION
* Update the toolset to VS 2019 16.11 Preview 1.
* Update the VM OS to 21h1-ent-g2.
* Comment the Start-Sleep workaround as requested by @barcharcraz in https://github.com/microsoft/STL/pull/1920#discussion_r635663108 .
* Update `tests.py` for `/std:c++20`.
  + This makes both `/std:c++20` and `/std:c++latest` add the custom feature `'c++2a'`. It appears that libcxx hasn't yet converted their test suite to distinguish `c++2a` (C++20) and `c++2b` (C++23). I expect that we'll need to change `tests.py` later, so that these compiler options activate different custom features.

```
[x86]
Testing Time: 2195.59s
  Skipped          :   412
  Unsupported      :  2073
  Passed           : 25465
  Expectedly Failed:   626

[x64]
Testing Time: 2096.81s
  Skipped          :   412
  Unsupported      :  4027
  Passed           : 23511
  Expectedly Failed:   626
```
