### PR TITLE
<ranges>: Relax constraints on view_drop and view_take range adaptors

### DIFF
--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -2047,11 +2047,41 @@ namespace ranges {
                 // clang-format off
                 template <viewable_range _Rng>
                     requires convertible_to<_Ty&, range_difference_t<_Rng>>
-                _NODISCARD constexpr auto operator()(_Rng&& _Range) const
+                _NODISCARD constexpr auto operator()(_Rng&& _Range) &
                     noexcept(noexcept(_Take_fn{}(_STD forward<_Rng>(_Range), _Length))) {
                     // clang-format on
                     _STL_INTERNAL_STATIC_ASSERT(is_aggregate_v<_Partial>);
                     return _Take_fn{}(_STD forward<_Rng>(_Range), _Length);
+                }
+
+                // clang-format off
+                template <viewable_range _Rng>
+                    requires convertible_to<const _Ty&, range_difference_t<_Rng>>
+                _NODISCARD constexpr auto operator()(_Rng&& _Range) const&
+                    noexcept(noexcept(_Take_fn{}(_STD forward<_Rng>(_Range), _Length))) {
+                    // clang-format on
+                    _STL_INTERNAL_STATIC_ASSERT(is_aggregate_v<_Partial>);
+                    return _Take_fn{}(_STD forward<_Rng>(_Range), _Length);
+                }
+
+                // clang-format off
+                template <viewable_range _Rng>
+                    requires convertible_to<_Ty, range_difference_t<_Rng>>
+                _NODISCARD constexpr auto operator()(_Rng&& _Range) &&
+                    noexcept(noexcept(_Take_fn{}(_STD forward<_Rng>(_Range), _STD move(_Length)))) {
+                    // clang-format on
+                    _STL_INTERNAL_STATIC_ASSERT(is_aggregate_v<_Partial>);
+                    return _Take_fn{}(_STD forward<_Rng>(_Range), _STD move(_Length));
+                }
+
+                // clang-format off
+                template <viewable_range _Rng>
+                    requires convertible_to<const _Ty, range_difference_t<_Rng>>
+                _NODISCARD constexpr auto operator()(_Rng&& _Range) const&&
+                    noexcept(noexcept(_Take_fn{}(_STD forward<_Rng>(_Range), _STD move(_Length)))) {
+                    // clang-format on
+                    _STL_INTERNAL_STATIC_ASSERT(is_aggregate_v<_Partial>);
+                    return _Take_fn{}(_STD forward<_Rng>(_Range), _STD move(_Length));
                 }
             };
 
@@ -2446,11 +2476,41 @@ namespace ranges {
                 // clang-format off
                 template <viewable_range _Rng>
                     requires convertible_to<_Ty&, range_difference_t<_Rng>>
-                _NODISCARD constexpr auto operator()(_Rng&& _Range) const
+                _NODISCARD constexpr auto operator()(_Rng&& _Range) &
                     noexcept(noexcept(_Drop_fn{}(_STD forward<_Rng>(_Range), _Length))) {
                     // clang-format on
                     _STL_INTERNAL_STATIC_ASSERT(is_aggregate_v<_Partial>);
                     return _Drop_fn{}(_STD forward<_Rng>(_Range), _Length);
+                }
+
+                // clang-format off
+                template <viewable_range _Rng>
+                    requires convertible_to<const _Ty&, range_difference_t<_Rng>>
+                _NODISCARD constexpr auto operator()(_Rng&& _Range) const&
+                    noexcept(noexcept(_Drop_fn{}(_STD forward<_Rng>(_Range), _Length))) {
+                    // clang-format on
+                    _STL_INTERNAL_STATIC_ASSERT(is_aggregate_v<_Partial>);
+                    return _Drop_fn{}(_STD forward<_Rng>(_Range), _Length);
+                }
+
+                // clang-format off
+                template <viewable_range _Rng>
+                    requires convertible_to<_Ty, range_difference_t<_Rng>>
+                _NODISCARD constexpr auto operator()(_Rng&& _Range) &&
+                    noexcept(noexcept(_Drop_fn{}(_STD forward<_Rng>(_Range), _STD move(_Length)))) {
+                    // clang-format on
+                    _STL_INTERNAL_STATIC_ASSERT(is_aggregate_v<_Partial>);
+                    return _Drop_fn{}(_STD forward<_Rng>(_Range), _STD move(_Length));
+                }
+
+                // clang-format off
+                template <viewable_range _Rng>
+                    requires convertible_to<const _Ty, range_difference_t<_Rng>>
+                _NODISCARD constexpr auto operator()(_Rng&& _Range) const&&
+                    noexcept(noexcept(_Drop_fn{}(_STD forward<_Rng>(_Range), _STD move(_Length)))) {
+                    // clang-format on
+                    _STL_INTERNAL_STATIC_ASSERT(is_aggregate_v<_Partial>);
+                    return _Drop_fn{}(_STD forward<_Rng>(_Range), _STD move(_Length));
                 }
             };
 

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -2089,7 +2089,7 @@ namespace ranges {
                 }
             }
 
-            template <move_constructible _Ty> // TRANSITION, LWG issue unnumbered as of 2021-06-04
+            template <move_constructible _Ty> // LWG-3509
             _NODISCARD constexpr auto operator()(_Ty _Length) const noexcept {
                 return _Partial<_Ty>{._Length = _STD move(_Length)};
             }
@@ -2489,7 +2489,7 @@ namespace ranges {
                 }
             }
 
-            template <move_constructible _Ty> // TRANSITION, LWG issue unnumbered as of 2021-06-04
+            template <move_constructible _Ty> // LWG-3509
             _NODISCARD constexpr auto operator()(_Ty _Length) const noexcept {
                 return _Partial<_Ty>{._Length = _STD move(_Length)};
             }

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -2489,9 +2489,9 @@ namespace ranges {
                 }
             }
 
-            template <class _Ty>
+            template <move_constructible _Ty> // TRANSITION, LWG issue unnumbered as of 2021-06-04
             _NODISCARD constexpr auto operator()(_Ty _Length) const noexcept {
-                return _Partial<_Ty>{._Length = _Length};
+                return _Partial<_Ty>{._Length = _STD move(_Length)};
             }
         };
 

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -2089,7 +2089,7 @@ namespace ranges {
                 }
             }
 
-            template <move_constructible _Ty> // LWG-3509
+            template <move_constructible _Ty>
             _NODISCARD constexpr auto operator()(_Ty _Length) const noexcept {
                 return _Partial<_Ty>{._Length = _STD move(_Length)};
             }
@@ -2489,7 +2489,7 @@ namespace ranges {
                 }
             }
 
-            template <move_constructible _Ty> // LWG-3509
+            template <move_constructible _Ty>
             _NODISCARD constexpr auto operator()(_Ty _Length) const noexcept {
                 return _Partial<_Ty>{._Length = _STD move(_Length)};
             }

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -2089,7 +2089,7 @@ namespace ranges {
                 }
             }
 
-            template <move_constructible _Ty>  // TRANSITION, LWG issue unnumbered as of 2021-06-04
+            template <move_constructible _Ty> // TRANSITION, LWG issue unnumbered as of 2021-06-04
             _NODISCARD constexpr auto operator()(_Ty _Length) const noexcept {
                 return _Partial<_Ty>{._Length = _STD move(_Length)};
             }

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -2040,7 +2040,7 @@ namespace ranges {
             template <class _Rng>
             static constexpr _Choice_t<_St> _Choice = _Choose<_Rng>();
 
-            template <_Integer_like _Ty>
+            template <class _Ty>
             struct _Partial : _Pipe::_Base<_Partial<_Ty>> {
                 _Ty _Length;
 
@@ -2089,7 +2089,7 @@ namespace ranges {
                 }
             }
 
-            template <_Integer_like _Ty>
+            template <class _Ty>
             _NODISCARD constexpr auto operator()(_Ty _Length) const noexcept {
                 return _Partial<_Ty>{._Length = _Length};
             }
@@ -2439,7 +2439,7 @@ namespace ranges {
             template <class _Rng>
             static constexpr _Choice_t<_St> _Choice = _Choose<_Rng>();
 
-            template <_Integer_like _Ty>
+            template <class _Ty>
             struct _Partial : _Pipe::_Base<_Partial<_Ty>> {
                 _Ty _Length;
 
@@ -2489,7 +2489,7 @@ namespace ranges {
                 }
             }
 
-            template <_Integer_like _Ty>
+            template <class _Ty>
             _NODISCARD constexpr auto operator()(_Ty _Length) const noexcept {
                 return _Partial<_Ty>{._Length = _Length};
             }

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -2089,9 +2089,9 @@ namespace ranges {
                 }
             }
 
-            template <class _Ty>
+            template <move_constructible _Ty>  // TRANSITION, LWG issue unnumbered as of 2021-06-04
             _NODISCARD constexpr auto operator()(_Ty _Length) const noexcept {
-                return _Partial<_Ty>{._Length = _Length};
+                return _Partial<_Ty>{._Length = _STD move(_Length)};
             }
         };
 

--- a/tests/std/tests/P0896R4_views_drop/test.cpp
+++ b/tests/std/tests/P0896R4_views_drop/test.cpp
@@ -17,17 +17,17 @@ using namespace std;
 #pragma warning(disable : 6011) // Dereferencing NULL pointer '%s'
 
 struct evil_convertible_to_difference {
+    evil_convertible_to_difference() = default;
     evil_convertible_to_difference(const evil_convertible_to_difference&) {
         throw(42);
     }
-    evil_convertible_to_difference(evil_convertible_to_difference&&) {}
+    evil_convertible_to_difference(evil_convertible_to_difference&&) = default;
     evil_convertible_to_difference& operator=(const evil_convertible_to_difference&) {
         throw(42);
         return *this;
     }
-    evil_convertible_to_difference& operator=(evil_convertible_to_difference&&) {
-        return *this;
-    }
+    evil_convertible_to_difference& operator=(evil_convertible_to_difference&&) = default;
+
     constexpr operator int() const noexcept {
         return 4;
     }

--- a/tests/std/tests/P0896R4_views_drop/test.cpp
+++ b/tests/std/tests/P0896R4_views_drop/test.cpp
@@ -16,7 +16,18 @@ using namespace std;
 
 #pragma warning(disable : 6011) // Dereferencing NULL pointer '%s'
 
-struct convertible {
+struct evil_convertible_to_difference {
+    evil_convertible_to_difference(const evil_convertible_to_difference&) {
+        throw(42);
+    }
+    evil_convertible_to_difference(evil_convertible_to_difference&&) {}
+    evil_convertible_to_difference& operator=(const evil_convertible_to_difference&) {
+        throw(42);
+        return *this;
+    }
+    evil_convertible_to_difference& operator=(evil_convertible_to_difference&&) {
+        return *this;
+    }
     constexpr operator int() const noexcept {
         return 4;
     }
@@ -538,7 +549,7 @@ int main() {
         auto r1 = s | views::drop(integral_constant<int, 4>{});
         assert(ranges::equal(r1, only_four_ints));
 
-        auto r2 = s | views::drop(convertible{});
+        auto r2 = s | views::drop(evil_convertible_to_difference{});
         assert(ranges::equal(r2, only_four_ints));
     }
 }

--- a/tests/std/tests/P0896R4_views_drop/test.cpp
+++ b/tests/std/tests/P0896R4_views_drop/test.cpp
@@ -22,7 +22,7 @@ struct evil_convertible_to_difference {
         throw(42);
     }
     evil_convertible_to_difference(evil_convertible_to_difference&&) = default;
-    evil_convertible_to_difference& operator=(const evil_convertible_to_difference&) {
+    evil_convertible_to_difference& operator                         =(const evil_convertible_to_difference&) {
         throw(42);
         return *this;
     }

--- a/tests/std/tests/P0896R4_views_drop/test.cpp
+++ b/tests/std/tests/P0896R4_views_drop/test.cpp
@@ -16,6 +16,12 @@ using namespace std;
 
 #pragma warning(disable : 6011) // Dereferencing NULL pointer '%s'
 
+struct convertible {
+    constexpr operator int() const noexcept {
+        return 4;
+    }
+};
+
 // Test a silly precomposed range adaptor pipeline
 constexpr auto pipeline = views::drop(1) | views::drop(1) | views::drop(1) | views::drop(1);
 
@@ -525,5 +531,14 @@ int main() {
             views::iota(0ull, ranges::size(some_ints)) | views::transform([](auto i) { return some_ints[i]; });
         STATIC_ASSERT(test_one(v, only_four_ints));
         test_one(v, only_four_ints);
+    }
+
+    { // Validate that we can use something that is convertible to integral (#1957)
+        constexpr span s{some_ints};
+        auto r1 = s | views::drop(integral_constant<int, 4>{});
+        assert(ranges::equal(r1, only_four_ints));
+
+        auto r2 = s | views::drop(convertible{});
+        assert(ranges::equal(r2, only_four_ints));
     }
 }

--- a/tests/std/tests/P0896R4_views_drop/test.cpp
+++ b/tests/std/tests/P0896R4_views_drop/test.cpp
@@ -19,11 +19,12 @@ using namespace std;
 struct evil_convertible_to_difference {
     evil_convertible_to_difference() = default;
     evil_convertible_to_difference(const evil_convertible_to_difference&) {
-        throw(42);
+        throw 42;
     }
     evil_convertible_to_difference(evil_convertible_to_difference&&) = default;
-    evil_convertible_to_difference& operator                         =(const evil_convertible_to_difference&) {
-        throw(42);
+
+    evil_convertible_to_difference& operator=(const evil_convertible_to_difference&) {
+        throw 42;
         return *this;
     }
     evil_convertible_to_difference& operator=(evil_convertible_to_difference&&) = default;
@@ -544,7 +545,7 @@ int main() {
         test_one(v, only_four_ints);
     }
 
-    { // Validate that we can use something that is convertible to integral (#1957)
+    { // Validate that we can use something that is convertible to integral (GH-1957)
         constexpr span s{some_ints};
         auto r1 = s | views::drop(integral_constant<int, 4>{});
         assert(ranges::equal(r1, only_four_ints));

--- a/tests/std/tests/P0896R4_views_take/test.cpp
+++ b/tests/std/tests/P0896R4_views_take/test.cpp
@@ -20,11 +20,12 @@ using namespace std;
 struct evil_convertible_to_difference {
     evil_convertible_to_difference() = default;
     evil_convertible_to_difference(const evil_convertible_to_difference&) {
-        throw(42);
+        throw 42;
     }
     evil_convertible_to_difference(evil_convertible_to_difference&&) = default;
-    evil_convertible_to_difference& operator                         =(const evil_convertible_to_difference&) {
-        throw(42);
+
+    evil_convertible_to_difference& operator=(const evil_convertible_to_difference&) {
+        throw 42;
         return *this;
     }
     evil_convertible_to_difference& operator=(evil_convertible_to_difference&&) = default;
@@ -591,7 +592,7 @@ int main() {
         test_one(v, only_four_ints);
     }
 
-    { // Validate that we can use something that is convertible to integral (#1957)
+    { // Validate that we can use something that is convertible to integral (GH-1957)
         constexpr span s{some_ints};
         auto r1 = s | views::take(integral_constant<int, 4>{});
         assert(ranges::equal(r1, only_four_ints));

--- a/tests/std/tests/P0896R4_views_take/test.cpp
+++ b/tests/std/tests/P0896R4_views_take/test.cpp
@@ -23,7 +23,7 @@ struct evil_convertible_to_difference {
         throw(42);
     }
     evil_convertible_to_difference(evil_convertible_to_difference&&) = default;
-    evil_convertible_to_difference& operator=(const evil_convertible_to_difference&) {
+    evil_convertible_to_difference& operator                         =(const evil_convertible_to_difference&) {
         throw(42);
         return *this;
     }

--- a/tests/std/tests/P0896R4_views_take/test.cpp
+++ b/tests/std/tests/P0896R4_views_take/test.cpp
@@ -18,17 +18,17 @@ using namespace std;
 #pragma warning(disable : 6011) // Dereferencing NULL pointer '%s'
 
 struct evil_convertible_to_difference {
+    evil_convertible_to_difference() = default;
     evil_convertible_to_difference(const evil_convertible_to_difference&) {
         throw(42);
     }
-    evil_convertible_to_difference(evil_convertible_to_difference&&) {}
+    evil_convertible_to_difference(evil_convertible_to_difference&&) = default;
     evil_convertible_to_difference& operator=(const evil_convertible_to_difference&) {
         throw(42);
         return *this;
     }
-    evil_convertible_to_difference& operator=(evil_convertible_to_difference&&) {
-        return *this;
-    }
+    evil_convertible_to_difference& operator=(evil_convertible_to_difference&&) = default;
+
     constexpr operator int() const noexcept {
         return 4;
     }

--- a/tests/std/tests/P0896R4_views_take/test.cpp
+++ b/tests/std/tests/P0896R4_views_take/test.cpp
@@ -17,11 +17,23 @@ using namespace std;
 
 #pragma warning(disable : 6011) // Dereferencing NULL pointer '%s'
 
-struct convertible {
+struct evil_convertible_to_difference {
+    evil_convertible_to_difference(const evil_convertible_to_difference&) {
+        throw(42);
+    }
+    evil_convertible_to_difference(evil_convertible_to_difference&&) {}
+    evil_convertible_to_difference& operator=(const evil_convertible_to_difference&) {
+        throw(42);
+        return *this;
+    }
+    evil_convertible_to_difference& operator=(evil_convertible_to_difference&&) {
+        return *this;
+    }
     constexpr operator int() const noexcept {
         return 4;
     }
 };
+
 
 // Test a silly precomposed range adaptor pipeline
 constexpr auto pipeline = views::take(7) | views::take(6) | views::take(5) | views::take(4);
@@ -584,7 +596,7 @@ int main() {
         auto r1 = s | views::take(integral_constant<int, 4>{});
         assert(ranges::equal(r1, only_four_ints));
 
-        auto r2 = s | views::take(convertible{});
+        auto r2 = s | views::take(evil_convertible_to_difference{});
         assert(ranges::equal(r2, only_four_ints));
     }
 

--- a/tests/std/tests/P0896R4_views_take/test.cpp
+++ b/tests/std/tests/P0896R4_views_take/test.cpp
@@ -17,6 +17,12 @@ using namespace std;
 
 #pragma warning(disable : 6011) // Dereferencing NULL pointer '%s'
 
+struct convertible {
+    constexpr operator int() const noexcept {
+        return 4;
+    }
+};
+
 // Test a silly precomposed range adaptor pipeline
 constexpr auto pipeline = views::take(7) | views::take(6) | views::take(5) | views::take(4);
 
@@ -571,6 +577,15 @@ int main() {
             views::iota(0ull, ranges::size(some_ints)) | views::transform([](auto i) { return some_ints[i]; });
         STATIC_ASSERT(test_one(v, only_four_ints));
         test_one(v, only_four_ints);
+    }
+
+    { // Validate that we can use something that is convertible to integral (#1957)
+        constexpr span s{some_ints};
+        auto r1 = s | views::take(integral_constant<int, 4>{});
+        assert(ranges::equal(r1, only_four_ints));
+
+        auto r2 = s | views::take(convertible{});
+        assert(ranges::equal(r2, only_four_ints));
     }
 
     test_DevCom_1397309();


### PR DESCRIPTION
We were constraining them to integer like types. However, anything that is convertible to range difference should pass.

Fixes #1957