### PR TITLE
`<fstream>`: Implement LWG-3430

### DIFF
--- a/stl/inc/fstream
+++ b/stl/inc/fstream
@@ -48,6 +48,18 @@ namespace experimental {
 } // namespace experimental
 #endif // _FSTREAM_SUPPORTS_EXPERIMENTAL_FILESYSTEM
 
+// clang-format off
+template <class _Ty>
+_INLINE_VAR constexpr bool _Is_any_path = _Is_any_of_v<_Ty
+#if _FSTREAM_SUPPORTS_EXPERIMENTAL_FILESYSTEM
+    , experimental::filesystem::path
+#endif // _FSTREAM_SUPPORTS_EXPERIMENTAL_FILESYSTEM
+#if _HAS_CXX17
+    , filesystem::path
+#endif // _HAS_CXX17
+    >;
+// clang-format on
+
 extern _CRTIMP2_PURE FILE* __CLRCALL_PURE_OR_CDECL _Fiopen(const char*, ios_base::openmode, int);
 extern _CRTIMP2_PURE FILE* __CLRCALL_PURE_OR_CDECL _Fiopen(const wchar_t*, ios_base::openmode, int);
 
@@ -830,19 +842,10 @@ public:
         const wstring& _Str, ios_base::openmode _Mode = ios_base::in, int _Prot = ios_base::_Default_open_prot)
         : basic_ifstream(_Str.c_str(), _Mode, _Prot) {} // extension
 
-#if _FSTREAM_SUPPORTS_EXPERIMENTAL_FILESYSTEM
-    template <class _Path_ish = experimental::filesystem::path>
-    explicit basic_ifstream(const _Identity_t<_Path_ish>& _Path, ios_base::openmode _Mode = ios_base::in,
-        int _Prot = ios_base::_Default_open_prot)
+    template <class _Ty, enable_if_t<_Is_any_path<_Ty>, int> = 0>
+    explicit basic_ifstream(
+        const _Ty& _Path, ios_base::openmode _Mode = ios_base::in, int _Prot = ios_base::_Default_open_prot)
         : basic_ifstream(_Path.c_str(), _Mode, _Prot) {} // _Prot is an extension
-#endif // _FSTREAM_SUPPORTS_EXPERIMENTAL_FILESYSTEM
-
-#if _HAS_CXX17
-    template <int = 0, class _Path_ish = filesystem::path>
-    explicit basic_ifstream(const _Identity_t<_Path_ish>& _Path, ios_base::openmode _Mode = ios_base::in,
-        int _Prot = ios_base::_Default_open_prot)
-        : basic_ifstream(_Path.c_str(), _Mode, _Prot) {} // _Prot is an extension
-#endif // _HAS_CXX17
 
 #ifdef _NATIVE_WCHAR_T_DEFINED
     explicit basic_ifstream(const unsigned short* _Filename, ios_base::openmode _Mode = ios_base::in,
@@ -1023,19 +1026,10 @@ public:
         const wstring& _Str, ios_base::openmode _Mode = ios_base::out, int _Prot = ios_base::_Default_open_prot)
         : basic_ofstream(_Str.c_str(), _Mode, _Prot) {} // extension
 
-#if _FSTREAM_SUPPORTS_EXPERIMENTAL_FILESYSTEM
-    template <class _Path_ish = experimental::filesystem::path>
-    explicit basic_ofstream(const _Identity_t<_Path_ish>& _Path, ios_base::openmode _Mode = ios_base::out,
-        int _Prot = ios_base::_Default_open_prot)
+    template <class _Ty, enable_if_t<_Is_any_path<_Ty>, int> = 0>
+    explicit basic_ofstream(
+        const _Ty& _Path, ios_base::openmode _Mode = ios_base::out, int _Prot = ios_base::_Default_open_prot)
         : basic_ofstream(_Path.c_str(), _Mode, _Prot) {} // _Prot is an extension
-#endif // _FSTREAM_SUPPORTS_EXPERIMENTAL_FILESYSTEM
-
-#if _HAS_CXX17
-    template <int = 0, class _Path_ish = filesystem::path>
-    explicit basic_ofstream(const _Identity_t<_Path_ish>& _Path, ios_base::openmode _Mode = ios_base::out,
-        int _Prot = ios_base::_Default_open_prot)
-        : basic_ofstream(_Path.c_str(), _Mode, _Prot) {} // _Prot is an extension
-#endif // _HAS_CXX17
 
 #ifdef _NATIVE_WCHAR_T_DEFINED
     explicit basic_ofstream(const unsigned short* _Filename, ios_base::openmode _Mode = ios_base::out,
@@ -1221,19 +1215,10 @@ public:
         int _Prot = ios_base::_Default_open_prot)
         : basic_fstream(_Str.c_str(), _Mode, _Prot) {} // extension
 
-#if _FSTREAM_SUPPORTS_EXPERIMENTAL_FILESYSTEM
-    template <class _Path_ish = experimental::filesystem::path>
-    explicit basic_fstream(const _Identity_t<_Path_ish>& _Path, ios_base::openmode _Mode = ios_base::in | ios_base::out,
+    template <class _Ty, enable_if_t<_Is_any_path<_Ty>, int> = 0>
+    explicit basic_fstream(const _Ty& _Path, ios_base::openmode _Mode = ios_base::in | ios_base::out,
         int _Prot = ios_base::_Default_open_prot)
         : basic_fstream(_Path.c_str(), _Mode, _Prot) {} // _Prot is an extension
-#endif // _FSTREAM_SUPPORTS_EXPERIMENTAL_FILESYSTEM
-
-#if _HAS_CXX17
-    template <int = 0, class _Path_ish = filesystem::path>
-    explicit basic_fstream(const _Identity_t<_Path_ish>& _Path, ios_base::openmode _Mode = ios_base::in | ios_base::out,
-        int _Prot = ios_base::_Default_open_prot)
-        : basic_fstream(_Path.c_str(), _Mode, _Prot) {} // _Prot is an extension
-#endif // _HAS_CXX17
 
 #ifdef _NATIVE_WCHAR_T_DEFINED
     explicit basic_fstream(const unsigned short* _Filename, ios_base::openmode _Mode = ios_base::in | ios_base::out,


### PR DESCRIPTION
LWG-3430 turns the constructors of `basic_{i,o,}fstream` that accept `filesystem::path` into templates that deduce the argument type and then constrain it to be `filesystem::path` to avoid potentially expensive implicit conversions. We already implement these constructors as templates for esoteric ABI-compatibility reasons (See https://github.com/microsoft/STL/blob/4c862ee11ce956556b810a813e77b0f8f97fb642/stl/inc/fstream#L20-L25) so the net change here is to make that template deduce the argument type and constrain it. I think we should also change our `experimental::filesystem::path` constructors in the spirit of LWG-3430, so I merged pairs of `experimental` / non-`experimental` constructors together using a new `_Is_any_path` trait to constrain.

Existing test coverage in `tests\std\tests\VSO_0000000_path_stream_parameter` seems sufficient, so I've added no new tests.
