### PR TITLE
Adopt LWG-3555 `{transform,elements}_view::iterator::iterator_concept` should consider `const`-qualification of the underlying range

### DIFF
--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -1407,9 +1407,9 @@ namespace ranges {
 #endif // _ITERATOR_DEBUG_LEVEL != 0
 
         public:
-            using iterator_concept = conditional_t<random_access_range<_Vw>, random_access_iterator_tag,
-                conditional_t<bidirectional_range<_Vw>, bidirectional_iterator_tag,
-                    conditional_t<forward_range<_Vw>, forward_iterator_tag, input_iterator_tag>>>;
+            using iterator_concept = conditional_t<random_access_range<_Base>, random_access_iterator_tag,
+                conditional_t<bidirectional_range<_Base>, bidirectional_iterator_tag,
+                    conditional_t<forward_range<_Base>, forward_iterator_tag, input_iterator_tag>>>;
             using value_type       = remove_cvref_t<invoke_result_t<_Fn&, range_reference_t<_Base>>>;
             using difference_type  = range_difference_t<_Base>;
 
@@ -3756,9 +3756,9 @@ namespace ranges {
             iterator_t<_Base> _Current{};
 
         public:
-            using iterator_concept = conditional_t<random_access_range<_Vw>, random_access_iterator_tag,
-                conditional_t<bidirectional_range<_Vw>, bidirectional_iterator_tag,
-                    conditional_t<forward_range<_Vw>, forward_iterator_tag, input_iterator_tag>>>;
+            using iterator_concept = conditional_t<random_access_range<_Base>, random_access_iterator_tag,
+                conditional_t<bidirectional_range<_Base>, bidirectional_iterator_tag,
+                    conditional_t<forward_range<_Base>, forward_iterator_tag, input_iterator_tag>>>;
             using value_type       = remove_cvref_t<tuple_element_t<_Index, range_value_t<_Base>>>;
             using difference_type  = range_difference_t<_Base>;
 

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -249,6 +249,7 @@
 
 // _HAS_CXX20 indirectly controls:
 // P0619R4 Removing C++17-Deprecated Features
+// LWG-3555 view::iterator::iterator_concept should consider const-qualification of the underlying range
 
 // _HAS_CXX20 and _SILENCE_ALL_CXX20_DEPRECATION_WARNINGS control:
 // P0767R1 Deprecating is_pod

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -249,7 +249,6 @@
 
 // _HAS_CXX20 indirectly controls:
 // P0619R4 Removing C++17-Deprecated Features
-// LWG-3555 view::iterator::iterator_concept should consider const-qualification of the underlying range
 
 // _HAS_CXX20 and _SILENCE_ALL_CXX20_DEPRECATION_WARNINGS control:
 // P0767R1 Deprecating is_pod


### PR DESCRIPTION
I did not add tests yet, as we currently do not test it for elements_view at all and we should think about how / whether it makes sense to test this generically