### PR TITLE
Adopt LWG-3553 Useless constraint in `split_view::outer-iterator::value_type::begin()`

### DIFF
--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -3074,15 +3074,9 @@ namespace ranges {
                     is_nothrow_move_constructible_v<_Outer_iter>) // strengthened
                     : _First{_STD move(_First_)} {}
 
-                _NODISCARD constexpr auto begin() const requires copyable<_Outer_iter> {
+                _NODISCARD constexpr auto begin() const {
                     return _Inner_iter<_Const>{_First};
                 }
-
-                // clang-format off
-                _NODISCARD constexpr auto begin() requires (!copyable<_Outer_iter>) {
-                    return _Inner_iter<_Const>{_STD move(_First)};
-                }
-                // clang-format on
 
                 _NODISCARD constexpr default_sentinel_t end() const noexcept {
                     return default_sentinel;

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -249,7 +249,6 @@
 
 // _HAS_CXX20 indirectly controls:
 // P0619R4 Removing C++17-Deprecated Features
-// LWG-3553 Remove constraint in split_view::outer-iterator::value_type::begin()
 
 // _HAS_CXX20 and _SILENCE_ALL_CXX20_DEPRECATION_WARNINGS control:
 // P0767R1 Deprecating is_pod

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -249,6 +249,7 @@
 
 // _HAS_CXX20 indirectly controls:
 // P0619R4 Removing C++17-Deprecated Features
+// LWG-3553 Remove constraint in split_view::outer-iterator::value_type::begin()
 
 // _HAS_CXX20 and _SILENCE_ALL_CXX20_DEPRECATION_WARNINGS control:
 // P0767R1 Deprecating is_pod


### PR DESCRIPTION
As thisis an internal interface that was never used there is no need for additional tests