### PR TITLE
Status Chart: Weekly updates, chart.js 3.3.2, `spanGaps: false`

### DIFF
--- a/gather_stats.js
+++ b/gather_stats.js
@@ -425,6 +425,8 @@ function write_daily_table(script_start, all_prs, all_issues) {
         for (const key of ['pr', 'cxx20', 'cxx23', 'lwg', 'issue', 'bug']) {
             if (should_emit_data_point(rows, i, key)) {
                 str += `${key}: ${row[key]}, `;
+            } else {
+                str += `${key}: null, `;
             }
         }
 

--- a/index.html
+++ b/index.html
@@ -372,7 +372,7 @@
                         text: 'Average Age, Average Wait (days)',
                     },
                     min: 0,
-                    max: 180,
+                    max: 200,
                     ticks: {
                         stepSize: 20,
                     },
@@ -386,7 +386,7 @@
                         text: 'Combined Age, Combined Wait (PR-months)',
                     },
                     min: 0,
-                    max: 180,
+                    max: 200,
                     ticks: {
                         stepSize: 20,
                     },

--- a/index.html
+++ b/index.html
@@ -237,6 +237,7 @@
                     borderCapStyle: 'round',
                     borderJoinStyle: 'round',
                     fill: false,
+                    spanGaps: false,
                 },
                 point: {
                     radius: 0,

--- a/index.html
+++ b/index.html
@@ -26,8 +26,8 @@
             font-weight: bold;
         }
     </style>
-    <script src="https://cdn.jsdelivr.net/npm/chart.js@3.3.0/dist/chart.min.js"
-        integrity="sha256-KP9rTEikFk097YZVFmsYwZdAg4cdGdea8O/V7YZJUxw=" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@3.3.2/dist/chart.min.js"
+        integrity="sha256-qoN08nWXsFH+S9CtIq99e5yzYHioRHtNB9t2qy1MSmc=" crossorigin="anonymous"></script>
     <script
         src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns@2.0.0/dist/chartjs-adapter-date-fns.bundle.min.js"
         integrity="sha256-xlxh4PaMDyZ72hWQ7f/37oYI0E2PrBbtzi1yhvnG+/E=" crossorigin="anonymous"></script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
-        "@octokit/graphql": "^4.6.2",
+        "@octokit/graphql": "^4.6.3",
         "cli-progress": "^3.9.0",
         "dotenv": "^10.0.0",
         "luxon": "^1.27.0",
@@ -17,9 +17,9 @@
       }
     },
     "node_modules/@octokit/endpoint": {
-      "version": "6.0.11",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.11.tgz",
-      "integrity": "sha512-fUIPpx+pZyoLW4GCs3yMnlj2LfoXTWDUVPTC4V3MUEKZm48W+XYpeWSZCv+vYF1ZABUm2CqnDVf1sFtIYrj7KQ==",
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.12.tgz",
+      "integrity": "sha512-lF3puPwkQWGfkMClXb4k/eUT/nZKQfxinRWJrdZaJO85Dqwo/G0yOC434Jr2ojwafWJMYqFGFa5ms4jJUgujdA==",
       "dependencies": {
         "@octokit/types": "^6.0.3",
         "is-plain-object": "^5.0.0",
@@ -27,9 +27,9 @@
       }
     },
     "node_modules/@octokit/graphql": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.6.2.tgz",
-      "integrity": "sha512-WmsIR1OzOr/3IqfG9JIczI8gMJUMzzyx5j0XXQ4YihHtKlQc+u35VpVoOXhlKAlaBntvry1WpAzPl/a+s3n89Q==",
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.6.3.tgz",
+      "integrity": "sha512-ww2fYpuPPWhlKENk7g3Ynbqm6R5zqXOnbXuyELCiM/zjZq+hMlNOsiV/LgwCH81+i5FkeZA/IB/BgWGoAuXJwA==",
       "dependencies": {
         "@octokit/request": "^5.3.0",
         "@octokit/types": "^6.0.3",
@@ -37,27 +37,27 @@
       }
     },
     "node_modules/@octokit/openapi-types": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-7.2.1.tgz",
-      "integrity": "sha512-IHQJpLciwzwDvciLxiFj3IEV5VYn7lSVcj5cu0jbTwMfK4IG6/g8SPrVp3Le1VRzIiYSRcBzm1dA7vgWelYP3Q=="
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-7.3.2.tgz",
+      "integrity": "sha512-oJhK/yhl9Gt430OrZOzAl2wJqR0No9445vmZ9Ey8GjUZUpwuu/vmEFP0TDhDXdpGDoxD6/EIFHJEcY8nHXpDTA=="
     },
     "node_modules/@octokit/request": {
-      "version": "5.4.15",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.15.tgz",
-      "integrity": "sha512-6UnZfZzLwNhdLRreOtTkT9n57ZwulCve8q3IT/Z477vThu6snfdkBuhxnChpOKNGxcQ71ow561Qoa6uqLdPtag==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.5.0.tgz",
+      "integrity": "sha512-jxbMLQdQ3heFMZUaTLSCqcKs2oAHEYh7SnLLXyxbZmlULExZ/RXai7QUWWFKowcGGPlCZuKTZg0gSKHWrfYEoQ==",
       "dependencies": {
         "@octokit/endpoint": "^6.0.1",
         "@octokit/request-error": "^2.0.0",
-        "@octokit/types": "^6.7.1",
+        "@octokit/types": "^6.16.1",
         "is-plain-object": "^5.0.0",
         "node-fetch": "^2.6.1",
         "universal-user-agent": "^6.0.0"
       }
     },
     "node_modules/@octokit/request-error": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.5.tgz",
-      "integrity": "sha512-T/2wcCFyM7SkXzNoyVNWjyVlUwBvW3igM3Btr/eKYiPmucXTtkxt2RBsf6gn3LTzaLSLTQtNmvg+dGsOxQrjZg==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.6.tgz",
+      "integrity": "sha512-oGQkw2/m+bVUM8h5xO8qDWDELgTKvWy6MwM5kjJyibnQBO09TXHgodB4ym7JVrFDHkQSWt47UeP9GsE8a6Fj3Q==",
       "dependencies": {
         "@octokit/types": "^6.0.3",
         "deprecation": "^2.0.0",
@@ -65,11 +65,11 @@
       }
     },
     "node_modules/@octokit/types": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.16.0.tgz",
-      "integrity": "sha512-EktqSNq8EKXE82a7Vw33ozOEhFXIRik+rZHJTHAgVZRm/p2K5r5ecn5fVpRkLCm3CAVFwchRvt3yvtmfbt2LCQ==",
+      "version": "6.16.4",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.16.4.tgz",
+      "integrity": "sha512-UxhWCdSzloULfUyamfOg4dJxV9B+XjgrIZscI0VCbp4eNrjmorGEw+4qdwcpTsu6DIrm9tQsFQS2pK5QkqQ04A==",
       "dependencies": {
-        "@octokit/openapi-types": "^7.2.0"
+        "@octokit/openapi-types": "^7.3.2"
       }
     },
     "node_modules/ansi-regex": {
@@ -308,9 +308,9 @@
   },
   "dependencies": {
     "@octokit/endpoint": {
-      "version": "6.0.11",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.11.tgz",
-      "integrity": "sha512-fUIPpx+pZyoLW4GCs3yMnlj2LfoXTWDUVPTC4V3MUEKZm48W+XYpeWSZCv+vYF1ZABUm2CqnDVf1sFtIYrj7KQ==",
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.12.tgz",
+      "integrity": "sha512-lF3puPwkQWGfkMClXb4k/eUT/nZKQfxinRWJrdZaJO85Dqwo/G0yOC434Jr2ojwafWJMYqFGFa5ms4jJUgujdA==",
       "requires": {
         "@octokit/types": "^6.0.3",
         "is-plain-object": "^5.0.0",
@@ -318,9 +318,9 @@
       }
     },
     "@octokit/graphql": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.6.2.tgz",
-      "integrity": "sha512-WmsIR1OzOr/3IqfG9JIczI8gMJUMzzyx5j0XXQ4YihHtKlQc+u35VpVoOXhlKAlaBntvry1WpAzPl/a+s3n89Q==",
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.6.3.tgz",
+      "integrity": "sha512-ww2fYpuPPWhlKENk7g3Ynbqm6R5zqXOnbXuyELCiM/zjZq+hMlNOsiV/LgwCH81+i5FkeZA/IB/BgWGoAuXJwA==",
       "requires": {
         "@octokit/request": "^5.3.0",
         "@octokit/types": "^6.0.3",
@@ -328,27 +328,27 @@
       }
     },
     "@octokit/openapi-types": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-7.2.1.tgz",
-      "integrity": "sha512-IHQJpLciwzwDvciLxiFj3IEV5VYn7lSVcj5cu0jbTwMfK4IG6/g8SPrVp3Le1VRzIiYSRcBzm1dA7vgWelYP3Q=="
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-7.3.2.tgz",
+      "integrity": "sha512-oJhK/yhl9Gt430OrZOzAl2wJqR0No9445vmZ9Ey8GjUZUpwuu/vmEFP0TDhDXdpGDoxD6/EIFHJEcY8nHXpDTA=="
     },
     "@octokit/request": {
-      "version": "5.4.15",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.15.tgz",
-      "integrity": "sha512-6UnZfZzLwNhdLRreOtTkT9n57ZwulCve8q3IT/Z477vThu6snfdkBuhxnChpOKNGxcQ71ow561Qoa6uqLdPtag==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.5.0.tgz",
+      "integrity": "sha512-jxbMLQdQ3heFMZUaTLSCqcKs2oAHEYh7SnLLXyxbZmlULExZ/RXai7QUWWFKowcGGPlCZuKTZg0gSKHWrfYEoQ==",
       "requires": {
         "@octokit/endpoint": "^6.0.1",
         "@octokit/request-error": "^2.0.0",
-        "@octokit/types": "^6.7.1",
+        "@octokit/types": "^6.16.1",
         "is-plain-object": "^5.0.0",
         "node-fetch": "^2.6.1",
         "universal-user-agent": "^6.0.0"
       }
     },
     "@octokit/request-error": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.5.tgz",
-      "integrity": "sha512-T/2wcCFyM7SkXzNoyVNWjyVlUwBvW3igM3Btr/eKYiPmucXTtkxt2RBsf6gn3LTzaLSLTQtNmvg+dGsOxQrjZg==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.6.tgz",
+      "integrity": "sha512-oGQkw2/m+bVUM8h5xO8qDWDELgTKvWy6MwM5kjJyibnQBO09TXHgodB4ym7JVrFDHkQSWt47UeP9GsE8a6Fj3Q==",
       "requires": {
         "@octokit/types": "^6.0.3",
         "deprecation": "^2.0.0",
@@ -356,11 +356,11 @@
       }
     },
     "@octokit/types": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.16.0.tgz",
-      "integrity": "sha512-EktqSNq8EKXE82a7Vw33ozOEhFXIRik+rZHJTHAgVZRm/p2K5r5ecn5fVpRkLCm3CAVFwchRvt3yvtmfbt2LCQ==",
+      "version": "6.16.4",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.16.4.tgz",
+      "integrity": "sha512-UxhWCdSzloULfUyamfOg4dJxV9B+XjgrIZscI0VCbp4eNrjmorGEw+4qdwcpTsu6DIrm9tQsFQS2pK5QkqQ04A==",
       "requires": {
-        "@octokit/openapi-types": "^7.2.0"
+        "@octokit/openapi-types": "^7.3.2"
       }
     },
     "ansi-regex": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "tabWidth": 4
   },
   "dependencies": {
-    "@octokit/graphql": "^4.6.2",
+    "@octokit/graphql": "^4.6.3",
     "cli-progress": "^3.9.0",
     "dotenv": "^10.0.0",
     "luxon": "^1.27.0",

--- a/weekly_table.js
+++ b/weekly_table.js
@@ -208,4 +208,7 @@ const weekly_table = [
     { date: '2021-05-07', vso: 176, libcxx: 594 },
     { date: '2021-05-14', vso: 176, libcxx: 594 },
     { date: '2021-05-21', vso: 177, libcxx: 601 },
+    { date: '2021-05-28', vso: 178, libcxx: 601 },
+    { date: '2021-06-04', vso: 183, libcxx: 601 },
+    { date: '2021-06-11', vso: 178, libcxx: 601 },
 ];


### PR DESCRIPTION
* Update `weekly_table.js`.
* Update to chart.js 3.3.2, no observable changes.
* Increase the PR Age max to 200. :crying_cat_face:
* npm update.
* Set `spanGaps: false` and change `gather_stats.js` to emit `null` entries instead of omitting them entirely.
  + This refines #1895's logic to avoid emitting consecutive zeros. That worked when the cxx20 line simply stopped, but now that it's reappeared, chart.js will "span the gap" of missing values with a line at zero. Emitting `null` entries and setting `spanGaps: false` causes the line to vanish and reappear as desired.

:chart_with_upwards_trend: Live preview: [stephantlavavej.github.io/STL/](https://stephantlavavej.github.io/STL/)
===

This won't reflect `spanGaps: false` until the next automated update, after which it will look like this:

<img width="424" alt="span_gaps_false" src="https://user-images.githubusercontent.com/4231088/121758809-da0d0d80-cad7-11eb-9897-93264ec0f27d.png">
