### PR TITLE
Implement P2325R3 Views Should Not Be Required To Be Default Constructible

### DIFF
--- a/stl/inc/iterator
+++ b/stl/inc/iterator
@@ -134,18 +134,16 @@ public:
     using reference         = void;
 
     using container_type = _Container;
-
 #ifdef __cpp_lib_concepts
     using difference_type = ptrdiff_t;
-
-    _CONSTEXPR20 insert_iterator(_Container& _Cont, ranges::iterator_t<_Container> _Where)
-        : container(_STD addressof(_Cont)), iter(_STD move(_Where)) {}
+    using _Wrapped_iter   = ranges::iterator_t<_Container>;
 #else // ^^^ implementing Ranges // no Ranges vvv
     using difference_type = void;
-
-    _CONSTEXPR20 insert_iterator(_Container& _Cont, typename _Container::iterator _Where)
-        : container(_STD addressof(_Cont)), iter(_Where) {}
+    using _Wrapped_iter   = typename _Container::iterator;
 #endif // __cpp_lib_concepts
+
+    _CONSTEXPR20 insert_iterator(_Container& _Cont, _Wrapped_iter _Where)
+        : container(_STD addressof(_Cont)), iter(_STD move(_Where)) {}
 
     _CONSTEXPR20 insert_iterator& operator=(const typename _Container::value_type& _Val) {
         // insert into container and increment stored iterator
@@ -174,11 +172,7 @@ public:
 
 protected:
     _Container* container;
-#ifdef __cpp_lib_concepts
-    ranges::iterator_t<_Container> iter;
-#else
-    typename _Container::iterator iter;
-#endif // __cpp_lib_concepts
+    _Wrapped_iter iter;
 };
 
 // FUNCTION TEMPLATE inserter

--- a/stl/inc/iterator
+++ b/stl/inc/iterator
@@ -32,9 +32,7 @@ public:
 
 #ifdef __cpp_lib_concepts
     using difference_type = ptrdiff_t;
-
-    constexpr back_insert_iterator() noexcept = default;
-#else // ^^^ __cpp_lib_concepts / !__cpp_lib_concepts vvv
+#else
     using difference_type = void;
 #endif // __cpp_lib_concepts
 
@@ -64,7 +62,7 @@ public:
     }
 
 protected:
-    _Container* container = nullptr;
+    _Container* container;
 };
 
 // FUNCTION TEMPLATE back_inserter
@@ -87,9 +85,7 @@ public:
 
 #ifdef __cpp_lib_concepts
     using difference_type = ptrdiff_t;
-
-    constexpr front_insert_iterator() noexcept = default;
-#else // ^^^ __cpp_lib_concepts / !__cpp_lib_concepts vvv
+#else
     using difference_type = void;
 #endif // __cpp_lib_concepts
 
@@ -119,7 +115,7 @@ public:
     }
 
 protected:
-    _Container* container = nullptr;
+    _Container* container;
 };
 
 // FUNCTION TEMPLATE front_inserter
@@ -142,13 +138,14 @@ public:
 #ifdef __cpp_lib_concepts
     using difference_type = ptrdiff_t;
 
-    insert_iterator() = default;
-#else // ^^^ __cpp_lib_concepts / !__cpp_lib_concepts vvv
+    _CONSTEXPR20 insert_iterator(_Container& _Cont, ranges::iterator_t<_Container> _Where)
+        : container(_STD addressof(_Cont)), iter(_STD move(_Where)) {}
+#else // ^^^ implementing Ranges // no Ranges vvv
     using difference_type = void;
-#endif // __cpp_lib_concepts
 
     _CONSTEXPR20 insert_iterator(_Container& _Cont, typename _Container::iterator _Where)
         : container(_STD addressof(_Cont)), iter(_Where) {}
+#endif // __cpp_lib_concepts
 
     _CONSTEXPR20 insert_iterator& operator=(const typename _Container::value_type& _Val) {
         // insert into container and increment stored iterator
@@ -176,8 +173,12 @@ public:
     }
 
 protected:
-    _Container* container = nullptr;
-    typename _Container::iterator iter{};
+    _Container* container;
+#ifdef __cpp_lib_concepts
+    ranges::iterator_t<_Container> iter;
+#else
+    typename _Container::iterator iter;
+#endif // __cpp_lib_concepts
 };
 
 // FUNCTION TEMPLATE inserter
@@ -327,10 +328,6 @@ public:
     using traits_type  = _Traits;
     using ostream_type = basic_ostream<_Elem, _Traits>;
 
-#ifdef __cpp_lib_concepts
-    constexpr ostream_iterator() noexcept = default;
-#endif // __cpp_lib_concepts
-
     ostream_iterator(ostream_type& _Ostr, const _Elem* const _Delim = nullptr) noexcept /* strengthened */
         : _Mydelim(_Delim), _Myostr(_STD addressof(_Ostr)) {}
 
@@ -356,8 +353,8 @@ public:
     }
 
 private:
-    const _Elem* _Mydelim = nullptr; // pointer to delimiter string (NB: not freed)
-    ostream_type* _Myostr = nullptr; // pointer to output stream
+    const _Elem* _Mydelim; // pointer to delimiter string (NB: not freed)
+    ostream_type* _Myostr; // pointer to output stream
 };
 
 // CLASS TEMPLATE istreambuf_iterator
@@ -516,10 +513,6 @@ public:
     using streambuf_type = basic_streambuf<_Elem, _Traits>;
     using ostream_type   = basic_ostream<_Elem, _Traits>;
 
-#ifdef __cpp_lib_concepts
-    constexpr ostreambuf_iterator() noexcept = default;
-#endif // __cpp_lib_concepts
-
     ostreambuf_iterator(streambuf_type* _Sb) noexcept : _Strbuf(_Sb) {}
 
     ostreambuf_iterator(ostream_type& _Ostr) noexcept : _Strbuf(_Ostr.rdbuf()) {}
@@ -549,8 +542,8 @@ public:
     }
 
 private:
-    bool _Failed            = false; // true if any stores have failed
-    streambuf_type* _Strbuf = nullptr;
+    bool _Failed = false; // true if any stores have failed
+    streambuf_type* _Strbuf;
 };
 
 #ifdef __cpp_lib_concepts
@@ -566,7 +559,7 @@ class _Variantish {
 public:
     constexpr explicit _Variantish(_Common_iterator_construct_tag) noexcept : _Contains{_Variantish_state::_Nothing} {}
 
-    constexpr _Variantish() noexcept(is_nothrow_default_constructible_v<_It>)
+    constexpr _Variantish() noexcept(is_nothrow_default_constructible_v<_It>) requires default_initializable<_It>
         : _Iterator{}, _Contains{_Variantish_state::_Holds_iter} {}
 
     template <class... _Types>
@@ -849,7 +842,7 @@ private:
     };
 
 public:
-    constexpr common_iterator() = default;
+    constexpr common_iterator() requires default_initializable<_Iter> = default;
 
     constexpr common_iterator(_Iter _Right) noexcept(is_nothrow_move_constructible_v<_Iter>) // strengthened
         : _Val{in_place_type<_Iter>, _STD move(_Right)} {}
@@ -1057,7 +1050,7 @@ public:
     using iterator_type = _Iter;
 
     // [counted.iter.const]
-    constexpr counted_iterator() = default;
+    constexpr counted_iterator() requires default_initializable<_Iter> = default;
     constexpr counted_iterator(_Iter _Right, const iter_difference_t<_Iter> _Diff) noexcept(
         is_nothrow_move_constructible_v<_Iter>) // strengthened
         : _Current(_STD move(_Right)), _Length(_Diff) {

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -2511,28 +2511,29 @@ namespace ranges {
         range_difference_t<_Vw> _Count = 0;
 
         _NODISCARD constexpr auto _Find_first() {
-            if constexpr (!sized_range<_Vw>) {
+            if constexpr (sized_range<_Vw>) {
+                _STL_INTERNAL_STATIC_ASSERT(!random_access<_Vw>);
+                auto _Offset = _RANGES distance(_Range);
+                if constexpr (bidirectional_range<_Vw> && common_range<_Vw>) {
+                    if (_Count >= _Offset / 2) {
+                        auto _Result = _RANGES end(_Range);
+                        while (_Offset > _Count) {
+                            --_Offset;
+                            --_Result;
+                        }
+
+                        return _Result;
+                    }
+                }
+
+                if (_Offset > _Count) {
+                    _Offset = _Count;
+                }
+
+                return _RANGES next(_RANGES begin(_Range), _Offset);
+            } else {
                 return _RANGES next(_RANGES begin(_Range), _Count, _RANGES end(_Range));
             }
-
-            auto _Offset = _RANGES distance(_Range);
-            if constexpr (bidirectional_range<_Vw> && common_range<_Vw>) {
-                if (_Count >= _Offset / 2) {
-                    auto _Result = _RANGES end(_Range);
-                    while (_Offset > _Count) {
-                        --_Offset;
-                        --_Result;
-                    }
-
-                    return _Result;
-                }
-            }
-
-            if (_Offset > _Count) {
-                _Offset = _Count;
-            }
-
-            return _RANGES next(_RANGES begin(_Range), _Offset);
         }
 
     public:

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -1107,7 +1107,7 @@ namespace ranges {
         };
 
         basic_istream<_Elem, _Traits>* _Stream;
-        _Ty _Val = _Ty{};
+        _Ty _Val = _Ty{}; // Per LWG issue submitted but unnumbered as of 2021-06-15
 
     public:
         constexpr explicit basic_istream_view(basic_istream<_Elem, _Traits>& _Stream_) noexcept(
@@ -2858,7 +2858,7 @@ namespace ranges {
     template <class _Vw>
     class _Join_view_base : public view_interface<join_view<_Vw>> {
     protected:
-        /* [[no_unique_address]] */ views::all_t<range_reference_t<_Vw>> _Inner{};
+        /* [[no_unique_address]] */ _Defaultabox<views::all_t<range_reference_t<_Vw>>> _Inner{};
     };
 
     // clang-format off
@@ -2930,7 +2930,7 @@ namespace ranges {
                     return _Range;
                 } else {
                     _Parent->_Inner = views::all(_STD move(_Range));
-                    return _Parent->_Inner;
+                    return *_Parent->_Inner;
                 }
             }
 
@@ -2956,7 +2956,7 @@ namespace ranges {
                 if constexpr (_Deref_is_glvalue) {
                     _Last = _RANGES end(*_Outer);
                 } else {
-                    _Last = _RANGES end(_Parent->_Inner);
+                    _Last = _RANGES end(*_Parent->_Inner);
                 }
                 _STL_VERIFY(_Inner && *_Inner != _Last, "cannot dereference join_view end iterator");
             }
@@ -3024,7 +3024,7 @@ namespace ranges {
                         _Satisfy();
                     }
                 } else {
-                    if (++*_Inner == _RANGES end(_Parent->_Inner)) {
+                    if (++*_Inner == _RANGES end(*_Parent->_Inner)) {
                         ++_Outer;
                         _Satisfy();
                     }

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -256,21 +256,21 @@ namespace ranges {
 
         ~_Copyable_box() requires is_trivially_destructible_v<_Ty> = default;
 
-        ~_Copyable_box() {
+        _CONSTEXPR20_DYNALLOC ~_Copyable_box() {
             if (_Engaged) {
                 _Val.~_Ty();
             }
         }
 
         _Copyable_box(const _Copyable_box&) requires is_trivially_copy_constructible_v<_Ty> = default;
-        _Copyable_box(const _Copyable_box& _That) : _Engaged{_That._Engaged} {
+        _CONSTEXPR20_DYNALLOC _Copyable_box(const _Copyable_box& _That) : _Engaged{_That._Engaged} {
             if (_That._Engaged) {
                 _Construct_in_place(_Val, _That._Val);
             }
         }
 
         _Copyable_box(_Copyable_box&&) requires is_trivially_move_constructible_v<_Ty> = default;
-        _Copyable_box(_Copyable_box&& _That) : _Engaged{_That._Engaged} {
+        _CONSTEXPR20_DYNALLOC _Copyable_box(_Copyable_box&& _That) : _Engaged{_That._Engaged} {
             if (_That._Engaged) {
                 _Construct_in_place(_Val, _STD move(_That._Val));
             }
@@ -281,7 +281,8 @@ namespace ranges {
             requires copyable<_Ty> && is_trivially_copy_assignable_v<_Ty> = default;
         // clang-format on
 
-        _Copyable_box& operator=(const _Copyable_box& _That) noexcept(is_nothrow_copy_constructible_v<_Ty>&&
+        _CONSTEXPR20_DYNALLOC _Copyable_box& operator=(const _Copyable_box& _That) noexcept(
+            is_nothrow_copy_constructible_v<_Ty>&&
                 is_nothrow_copy_assignable_v<_Ty>) /* strengthened */ requires copyable<_Ty> {
             if (_Engaged) {
                 if (_That._Engaged) {
@@ -302,7 +303,8 @@ namespace ranges {
             return *this;
         }
 
-        _Copyable_box& operator=(const _Copyable_box& _That) noexcept(is_nothrow_copy_constructible_v<_Ty>) {
+        _CONSTEXPR20_DYNALLOC _Copyable_box& operator=(const _Copyable_box& _That) noexcept(
+            is_nothrow_copy_constructible_v<_Ty>) {
             if (_STD addressof(_That) == this) {
                 return *this;
             }
@@ -325,7 +327,8 @@ namespace ranges {
             requires movable<_Ty> && is_trivially_move_assignable_v<_Ty> = default;
         // clang-format on
 
-        _Copyable_box& operator=(_Copyable_box&& _That) noexcept(is_nothrow_move_constructible_v<_Ty>&&
+        _CONSTEXPR20_DYNALLOC _Copyable_box& operator=(_Copyable_box&& _That) noexcept(
+            is_nothrow_move_constructible_v<_Ty>&&
                 is_nothrow_move_assignable_v<_Ty>) /* strengthened */ requires movable<_Ty> {
             if (_Engaged) {
                 if (_That._Engaged) {
@@ -346,7 +349,8 @@ namespace ranges {
             return *this;
         }
 
-        _Copyable_box& operator=(_Copyable_box&& _That) noexcept(is_nothrow_move_constructible_v<_Ty>) {
+        _CONSTEXPR20_DYNALLOC _Copyable_box& operator=(_Copyable_box&& _That) noexcept(
+            is_nothrow_move_constructible_v<_Ty>) {
             if (_STD addressof(_That) == this) {
                 return *this;
             }
@@ -405,7 +409,7 @@ namespace ranges {
         _Copyable_box& operator=(const _Copyable_box&) requires copyable<_Ty> = default;
         _Copyable_box& operator=(_Copyable_box&&) requires movable<_Ty> = default;
 
-        _Copyable_box& operator=(const _Copyable_box& _That) noexcept {
+        _CONSTEXPR20_DYNALLOC _Copyable_box& operator=(const _Copyable_box& _That) noexcept {
             if (_STD addressof(_That) != this) {
                 _Val.~_Ty();
                 _Construct_in_place(_Val, _That._Val);
@@ -414,7 +418,7 @@ namespace ranges {
             return *this;
         }
 
-        _Copyable_box& operator=(_Copyable_box&& _That) noexcept {
+        _CONSTEXPR20_DYNALLOC _Copyable_box& operator=(_Copyable_box&& _That) noexcept {
             if (_STD addressof(_That) != this) {
                 _Val.~_Ty();
                 _Construct_in_place(_Val, _STD move(_That._Val));
@@ -452,8 +456,10 @@ namespace ranges {
             }
         }
 
-        _Defaultabox(
-            const _Defaultabox&) requires copy_constructible<_Ty>&& is_trivially_copy_constructible_v<_Ty> = default;
+        // clang-format off
+        _Defaultabox(const _Defaultabox&)
+            requires copy_constructible<_Ty> && is_trivially_copy_constructible_v<_Ty> = default;
+        // clang-format on
 
         _CONSTEXPR20_DYNALLOC _Defaultabox(const _Defaultabox& _That) requires copy_constructible<_Ty>
             : _Engaged{_That._Engaged} {
@@ -497,10 +503,7 @@ namespace ranges {
             return *this;
         }
 
-        // clang-format off
-        _Defaultabox& operator=(_Defaultabox&&) noexcept
-            requires is_trivially_move_assignable_v<_Ty> = default;
-        // clang-format on
+        _Defaultabox& operator=(_Defaultabox&&) noexcept requires is_trivially_move_assignable_v<_Ty> = default;
 
         _CONSTEXPR20_DYNALLOC _Defaultabox& operator=(_Defaultabox&& _That) noexcept(
             is_nothrow_move_constructible_v<_Ty>&& is_nothrow_move_assignable_v<_Ty>) /* strengthened */ {
@@ -523,7 +526,7 @@ namespace ranges {
             return *this;
         }
 
-        constexpr _Defaultabox& operator=(_Ty&& _That) noexcept(
+        _CONSTEXPR20_DYNALLOC _Defaultabox& operator=(_Ty&& _That) noexcept(
             is_nothrow_move_constructible_v<_Ty>&& is_nothrow_move_assignable_v<_Ty>) {
             if (_Engaged) {
                 _Val = _STD move(_That);
@@ -535,7 +538,7 @@ namespace ranges {
             return *this;
         }
 
-        constexpr _Defaultabox& operator=(const _Ty& _That) noexcept(
+        _CONSTEXPR20_DYNALLOC _Defaultabox& operator=(const _Ty& _That) noexcept(
             is_nothrow_copy_constructible_v<_Ty>&& is_nothrow_copy_assignable_v<_Ty>) requires copyable<_Ty> {
             if (_Engaged) {
                 _Val = _That;
@@ -560,28 +563,16 @@ namespace ranges {
             return _Val;
         }
 
-        constexpr void reset() noexcept {
+        constexpr void _Reset() noexcept {
             if (_Engaged) {
                 _Val.~_Ty();
                 _Engaged = false;
             }
         }
 
-        constexpr bool operator==(const _Defaultabox& _That) const
-            noexcept(noexcept(_Val == _That._Val)) /* requires equality_comparable<_Ty> */ {
-            if (_Engaged) {
-                if (_That._Engaged) {
-                    return _Val == _That._Val;
-                } else {
-                    return false;
-                }
-            } else {
-                if (_That._Engaged) {
-                    return false;
-                } else {
-                    return true;
-                }
-            }
+        _NODISCARD constexpr bool operator==(const _Defaultabox& _That) const noexcept(noexcept(_Val == _That._Val)) {
+            _STL_INTERNAL_STATIC_ASSERT(equality_comparable<_Ty>);
+            return _Engaged == _That._Engaged && (!_Engaged || _Val == _That._Val);
         }
 
     private:
@@ -598,7 +589,7 @@ namespace ranges {
     class _Defaultabox<_Ty> { // provide the same API more efficiently for default-constructible types
         // clang-format on
     public:
-        constexpr _Defaultabox& operator=(const _Ty& _Right) noexcept(
+        _NODISCARD constexpr _Defaultabox& operator=(const _Ty& _Right) noexcept(
             is_nothrow_copy_assignable_v<_Ty>) requires copyable<_Ty> {
             _Value = _Right;
             return *this;
@@ -612,21 +603,21 @@ namespace ranges {
             return true;
         }
 
-        constexpr _Ty& operator*() noexcept {
+        _NODISCARD constexpr _Ty& operator*() noexcept {
             return _Value;
         }
-        constexpr const _Ty& operator*() const noexcept {
+        _NODISCARD constexpr const _Ty& operator*() const noexcept {
             return _Value;
         }
 
-        constexpr void reset() noexcept(noexcept(_Value = _Ty())) {
-            _Value = _Ty();
+        constexpr void _Reset() noexcept(noexcept(_Value = _Ty{})) {
+            _Value = _Ty{};
         }
 
-        bool operator==(const _Defaultabox&) const = default;
+        _NODISCARD bool operator==(const _Defaultabox&) const = default;
 
     private:
-        /* [[no_unique_address]] */ _Ty _Value = _Ty();
+        /* [[no_unique_address]] */ _Ty _Value{};
     };
 
     // CLASS TEMPLATE ranges::empty_view
@@ -2950,7 +2941,7 @@ namespace ranges {
                     }
                 }
                 if constexpr (_Deref_is_glvalue) {
-                    _Inner.reset();
+                    _Inner._Reset();
                 }
             }
 

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -589,7 +589,7 @@ namespace ranges {
     class _Defaultabox<_Ty> { // provide the same API more efficiently for default-constructible types
         // clang-format on
     public:
-        _NODISCARD constexpr _Defaultabox& operator=(const _Ty& _Right) noexcept(
+        constexpr _Defaultabox& operator=(const _Ty& _Right) noexcept(
             is_nothrow_copy_assignable_v<_Ty>) requires copyable<_Ty> {
             _Value = _Right;
             return *this;

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -2512,7 +2512,7 @@ namespace ranges {
 
         _NODISCARD constexpr auto _Find_first() {
             if constexpr (sized_range<_Vw>) {
-                _STL_INTERNAL_STATIC_ASSERT(!random_access<_Vw>);
+                _STL_INTERNAL_STATIC_ASSERT(!random_access_range<_Vw>);
                 auto _Offset = _RANGES distance(_Range);
                 if constexpr (bidirectional_range<_Vw> && common_range<_Vw>) {
                     if (_Count >= _Offset / 2) {

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -242,48 +242,46 @@ namespace ranges {
     template <bool _Enable, class _Rng, class _Derived>
     using _Cached_position_t = conditional_t<_Enable, _Cached_position<_Rng, _Derived>, view_interface<_Derived>>;
 
-    // CLASS TEMPLATE ranges::_Semiregular_box
+    // CLASS TEMPLATE ranges::_Copyable_box
     template <_Copy_constructible_object _Ty>
-    class _Semiregular_box {
+    class _Copyable_box { // a simplified optional that augments copy_constructible types with full copyability
     public:
-        constexpr _Semiregular_box() noexcept : _Dummy{}, _Engaged{false} {}
-        constexpr _Semiregular_box() noexcept(
-            is_nothrow_default_constructible_v<_Ty>) requires default_initializable<_Ty>
+        constexpr _Copyable_box() noexcept(is_nothrow_default_constructible_v<_Ty>) requires default_initializable<_Ty>
             : _Val(), _Engaged{true} {}
 
         template <class... _Types>
-        constexpr _Semiregular_box(in_place_t, _Types&&... _Args) noexcept(
+        constexpr _Copyable_box(in_place_t, _Types&&... _Args) noexcept(
             is_nothrow_constructible_v<_Ty, _Types...>) // strengthened
             : _Val(_STD forward<_Types>(_Args)...), _Engaged{true} {}
 
-        ~_Semiregular_box() requires is_trivially_destructible_v<_Ty> = default;
+        ~_Copyable_box() requires is_trivially_destructible_v<_Ty> = default;
 
-        ~_Semiregular_box() {
+        ~_Copyable_box() {
             if (_Engaged) {
                 _Val.~_Ty();
             }
         }
 
-        _Semiregular_box(const _Semiregular_box&) requires is_trivially_copy_constructible_v<_Ty> = default;
-        _Semiregular_box(const _Semiregular_box& _That) : _Engaged{_That._Engaged} {
+        _Copyable_box(const _Copyable_box&) requires is_trivially_copy_constructible_v<_Ty> = default;
+        _Copyable_box(const _Copyable_box& _That) : _Engaged{_That._Engaged} {
             if (_That._Engaged) {
                 _Construct_in_place(_Val, _That._Val);
             }
         }
 
-        _Semiregular_box(_Semiregular_box&&) requires is_trivially_move_constructible_v<_Ty> = default;
-        _Semiregular_box(_Semiregular_box&& _That) : _Engaged{_That._Engaged} {
+        _Copyable_box(_Copyable_box&&) requires is_trivially_move_constructible_v<_Ty> = default;
+        _Copyable_box(_Copyable_box&& _That) : _Engaged{_That._Engaged} {
             if (_That._Engaged) {
                 _Construct_in_place(_Val, _STD move(_That._Val));
             }
         }
 
         // clang-format off
-        _Semiregular_box& operator=(const _Semiregular_box&) noexcept
+        _Copyable_box& operator=(const _Copyable_box&) noexcept
             requires copyable<_Ty> && is_trivially_copy_assignable_v<_Ty> = default;
         // clang-format on
 
-        _Semiregular_box& operator=(const _Semiregular_box& _That) noexcept(is_nothrow_copy_constructible_v<_Ty>&&
+        _Copyable_box& operator=(const _Copyable_box& _That) noexcept(is_nothrow_copy_constructible_v<_Ty>&&
                 is_nothrow_copy_assignable_v<_Ty>) /* strengthened */ requires copyable<_Ty> {
             if (_Engaged) {
                 if (_That._Engaged) {
@@ -304,7 +302,7 @@ namespace ranges {
             return *this;
         }
 
-        _Semiregular_box& operator=(const _Semiregular_box& _That) noexcept(is_nothrow_copy_constructible_v<_Ty>) {
+        _Copyable_box& operator=(const _Copyable_box& _That) noexcept(is_nothrow_copy_constructible_v<_Ty>) {
             if (_STD addressof(_That) != this) {
                 if (_Engaged) {
                     _Val.~_Ty();
@@ -321,11 +319,11 @@ namespace ranges {
         }
 
         // clang-format off
-        _Semiregular_box& operator=(_Semiregular_box&&) noexcept
+        _Copyable_box& operator=(_Copyable_box&&) noexcept
             requires movable<_Ty> && is_trivially_move_assignable_v<_Ty> = default;
         // clang-format on
 
-        _Semiregular_box& operator=(_Semiregular_box&& _That) noexcept(is_nothrow_move_constructible_v<_Ty>&&
+        _Copyable_box& operator=(_Copyable_box&& _That) noexcept(is_nothrow_move_constructible_v<_Ty>&&
                 is_nothrow_move_assignable_v<_Ty>) /* strengthened */ requires movable<_Ty> {
             if (_Engaged) {
                 if (_That._Engaged) {
@@ -346,15 +344,17 @@ namespace ranges {
             return *this;
         }
 
-        _Semiregular_box& operator=(_Semiregular_box&& _That) noexcept(is_nothrow_move_constructible_v<_Ty>) {
-            if (_Engaged) {
-                _Val.~_Ty();
-                _Engaged = false;
-            }
+        _Copyable_box& operator=(_Copyable_box&& _That) noexcept(is_nothrow_move_constructible_v<_Ty>) {
+            if (_STD addressof(_That) != this) {
+                if (_Engaged) {
+                    _Val.~_Ty();
+                    _Engaged = false;
+                }
 
-            if (_That._Engaged) {
-                _Construct_in_place(_Val, _STD move(_That._Val));
-                _Engaged = true;
+                if (_That._Engaged) {
+                    _Construct_in_place(_Val, _STD move(_That._Val));
+                    _Engaged = true;
+                }
             }
 
             return *this;
@@ -383,26 +383,25 @@ namespace ranges {
 
     // clang-format off
     template <_Copy_constructible_object _Ty>
-        requires default_initializable<_Ty>
-            && (copyable<_Ty>
-                || (is_nothrow_copy_constructible_v<_Ty>
-                    && (movable<_Ty> || is_nothrow_move_constructible_v<_Ty>)))
-    class _Semiregular_box<_Ty> {
+        requires copyable<_Ty>
+            || (is_nothrow_copy_constructible_v<_Ty>
+                && (movable<_Ty> || is_nothrow_move_constructible_v<_Ty>))
+    class _Copyable_box<_Ty> { // provide the same API more efficiently when we can avoid the disengaged state
         // clang-format on
     public:
-        _Semiregular_box() = default;
+        _Copyable_box() requires default_initializable<_Ty> = default;
 
         template <class... _Types>
-        constexpr _Semiregular_box(in_place_t, _Types&&... _Args) noexcept(
+        constexpr _Copyable_box(in_place_t, _Types&&... _Args) noexcept(
             is_nothrow_constructible_v<_Ty, _Types...>) // strengthened
             : _Val(_STD forward<_Types>(_Args)...) {}
 
-        _Semiregular_box(const _Semiregular_box&) = default;
-        _Semiregular_box(_Semiregular_box&&)      = default;
-        _Semiregular_box& operator=(const _Semiregular_box&) requires copyable<_Ty> = default;
-        _Semiregular_box& operator=(_Semiregular_box&&) requires movable<_Ty> = default;
+        _Copyable_box(const _Copyable_box&) = default;
+        _Copyable_box(_Copyable_box&&)      = default;
+        _Copyable_box& operator=(const _Copyable_box&) requires copyable<_Ty> = default;
+        _Copyable_box& operator=(_Copyable_box&&) requires movable<_Ty> = default;
 
-        _Semiregular_box& operator=(const _Semiregular_box& _That) noexcept {
+        _Copyable_box& operator=(const _Copyable_box& _That) noexcept {
             if (_STD addressof(_That) != this) {
                 _Val.~_Ty();
                 _Construct_in_place(_Val, _That._Val);
@@ -411,7 +410,7 @@ namespace ranges {
             return *this;
         }
 
-        _Semiregular_box& operator=(_Semiregular_box&& _That) noexcept {
+        _Copyable_box& operator=(_Copyable_box&& _That) noexcept {
             if (_STD addressof(_That) != this) {
                 _Val.~_Ty();
                 _Construct_in_place(_Val, _STD move(_That._Val));
@@ -433,6 +432,197 @@ namespace ranges {
 
     private:
         /* [[no_unique_address]] */ _Ty _Val = _Ty();
+    };
+
+    // CLASS TEMPLATE ranges::_Defaultabox
+    template <movable _Ty>
+    class _Defaultabox { // a simplified optional that augments movable types with default-constructibility
+    public:
+        constexpr _Defaultabox() noexcept : _Dummy{} {}
+
+        ~_Defaultabox() requires is_trivially_destructible_v<_Ty> = default;
+
+        _CONSTEXPR20_DYNALLOC ~_Defaultabox() {
+            if (_Engaged) {
+                _Val.~_Ty();
+            }
+        }
+
+        _Defaultabox(
+            const _Defaultabox&) requires copy_constructible<_Ty>&& is_trivially_copy_constructible_v<_Ty> = default;
+
+        _CONSTEXPR20_DYNALLOC _Defaultabox(const _Defaultabox& _That) requires copy_constructible<_Ty>
+            : _Engaged{_That._Engaged} {
+            if (_That._Engaged) {
+                _Construct_in_place(_Val, _That._Val);
+            }
+        }
+
+        _Defaultabox(_Defaultabox&&) requires is_trivially_move_constructible_v<_Ty> = default;
+
+        _CONSTEXPR20_DYNALLOC _Defaultabox(_Defaultabox&& _That) : _Engaged{_That._Engaged} {
+            if (_That._Engaged) {
+                _Construct_in_place(_Val, _STD move(_That._Val));
+            }
+        }
+
+        // clang-format off
+        _Defaultabox& operator=(const _Defaultabox&) noexcept
+            requires copyable<_Ty> && is_trivially_copy_assignable_v<_Ty> = default;
+        // clang-format on
+
+        _CONSTEXPR20_DYNALLOC _Defaultabox& operator=(const _Defaultabox& _That) noexcept(
+            is_nothrow_copy_constructible_v<_Ty>&&
+                is_nothrow_copy_assignable_v<_Ty>) /* strengthened */ requires copyable<_Ty> {
+            if (_Engaged) {
+                if (_That._Engaged) {
+                    _Val = _That._Val;
+                } else {
+                    _Val.~_Ty();
+                    _Engaged = false;
+                }
+            } else {
+                if (_That._Engaged) {
+                    _Construct_in_place(_Val, _That._Val);
+                    _Engaged = true;
+                } else {
+                    // nothing to do
+                }
+            }
+
+            return *this;
+        }
+
+        // clang-format off
+        _Defaultabox& operator=(_Defaultabox&&) noexcept
+            requires is_trivially_move_assignable_v<_Ty> = default;
+        // clang-format on
+
+        _CONSTEXPR20_DYNALLOC _Defaultabox& operator=(_Defaultabox&& _That) noexcept(
+            is_nothrow_move_constructible_v<_Ty>&& is_nothrow_move_assignable_v<_Ty>) /* strengthened */ {
+            if (_Engaged) {
+                if (_That._Engaged) {
+                    _Val = _STD move(_That._Val);
+                } else {
+                    _Val.~_Ty();
+                    _Engaged = false;
+                }
+            } else {
+                if (_That._Engaged) {
+                    _Construct_in_place(_Val, _STD move(_That._Val));
+                    _Engaged = true;
+                } else {
+                    // nothing to do
+                }
+            }
+
+            return *this;
+        }
+
+        constexpr _Defaultabox& operator=(_Ty&& _That) noexcept(
+            is_nothrow_move_constructible_v<_Ty>&& is_nothrow_move_assignable_v<_Ty>) {
+            if (_Engaged) {
+                _Val = _STD move(_That);
+            } else {
+                _Construct_in_place(_Val, _STD move(_That));
+                _Engaged = true;
+            }
+
+            return *this;
+        }
+
+        constexpr _Defaultabox& operator=(const _Ty& _That) noexcept(
+            is_nothrow_copy_constructible_v<_Ty>&& is_nothrow_copy_assignable_v<_Ty>) requires copyable<_Ty> {
+            if (_Engaged) {
+                _Val = _That;
+            } else {
+                _Construct_in_place(_Val, _That);
+                _Engaged = true;
+            }
+
+            return *this;
+        }
+
+        constexpr explicit operator bool() const noexcept {
+            return _Engaged;
+        }
+
+        _NODISCARD constexpr _Ty& operator*() noexcept {
+            _STL_INTERNAL_CHECK(_Engaged);
+            return _Val;
+        }
+        _NODISCARD constexpr const _Ty& operator*() const noexcept {
+            _STL_INTERNAL_CHECK(_Engaged);
+            return _Val;
+        }
+
+        constexpr void reset() noexcept {
+            if (_Engaged) {
+                _Val.~_Ty();
+                _Engaged = false;
+            }
+        }
+
+        constexpr bool operator==(const _Defaultabox& _That) const
+            noexcept(noexcept(_Val == _That._Val)) /* requires equality_comparable<_Ty> */ {
+            if (_Engaged) {
+                if (_That._Engaged) {
+                    return _Val == _That._Val;
+                } else {
+                    return false;
+                }
+            } else {
+                if (_That._Engaged) {
+                    return false;
+                } else {
+                    return true;
+                }
+            }
+        }
+
+    private:
+        union {
+            _Nontrivial_dummy_type _Dummy;
+            _Ty _Val;
+        };
+        bool _Engaged = false;
+    };
+
+    // clang-format off
+    template <movable _Ty>
+        requires default_initializable<_Ty>
+    class _Defaultabox<_Ty> { // provide the same API more efficiently for default-constructible types
+        // clang-format on
+    public:
+        constexpr _Defaultabox& operator=(const _Ty& _Right) noexcept(
+            is_nothrow_copy_assignable_v<_Ty>) requires copyable<_Ty> {
+            _Value = _Right;
+            return *this;
+        }
+        constexpr _Defaultabox& operator=(_Ty&& _Right) noexcept(is_nothrow_move_assignable_v<_Ty>) {
+            _Value = _STD move(_Right);
+            return *this;
+        }
+
+        constexpr explicit operator bool() const noexcept {
+            return true;
+        }
+
+        constexpr _Ty& operator*() noexcept {
+            return _Value;
+        }
+        constexpr const _Ty& operator*() const noexcept {
+            return _Value;
+        }
+
+        constexpr void reset() noexcept(noexcept(_Value = _Ty())) {
+            _Value = _Ty();
+        }
+
+        bool operator==(const _Defaultabox&) const = default;
+
+    private:
+        /* [[no_unique_address]] */ _Ty _Value = _Ty();
     };
 
     // CLASS TEMPLATE ranges::empty_view
@@ -476,7 +666,7 @@ namespace ranges {
     class single_view : public view_interface<single_view<_Ty>> {
         // clang-format on
     public:
-        single_view() = default;
+        single_view() requires default_initializable<_Ty> = default;
         constexpr explicit single_view(const _Ty& _Val_) noexcept(is_nothrow_copy_constructible_v<_Ty>) // strengthened
             : _Val{in_place, _Val_} {}
         constexpr explicit single_view(_Ty&& _Val_) noexcept(is_nothrow_move_constructible_v<_Ty>) // strengthened
@@ -516,7 +706,7 @@ namespace ranges {
         }
 
     private:
-        /* [[no_unique_address]] */ _Semiregular_box<_Ty> _Val{};
+        /* [[no_unique_address]] */ _Copyable_box<_Ty> _Val{};
     };
 
     namespace views {
@@ -560,10 +750,10 @@ namespace ranges {
         };
 
     template <weakly_incrementable _Wi>
-        requires semiregular<_Wi>
+        requires copyable<_Wi>
     struct _Ioterator {
         // clang-format on
-        /* [[no_unique_address]] */ _Wi _Current{};
+        /* [[no_unique_address]] */ _Wi _Current;
 
         using iterator_concept  = conditional_t<_Advanceable<_Wi>, random_access_iterator_tag,
             conditional_t<_Decrementable<_Wi>, bidirectional_iterator_tag,
@@ -722,7 +912,7 @@ namespace ranges {
 
     // clang-format off
     template <weakly_incrementable _Wi, semiregular _Bo>
-        requires _Weakly_equality_comparable_with<_Wi, _Bo> && semiregular<_Wi>
+        requires _Weakly_equality_comparable_with<_Wi, _Bo> && copyable<_Wi>
     struct _Iotinel {
         // clang-format on
     private:
@@ -759,7 +949,7 @@ namespace ranges {
 
     // clang-format off
     template <weakly_incrementable _Wi, semiregular _Bo = unreachable_sentinel_t>
-        requires _Weakly_equality_comparable_with<_Wi, _Bo> && semiregular<_Wi>
+        requires _Weakly_equality_comparable_with<_Wi, _Bo> && copyable<_Wi>
     class iota_view : public view_interface<iota_view<_Wi, _Bo>> {
         // clang-format on
     private:
@@ -781,7 +971,7 @@ namespace ranges {
         }
 
     public:
-        iota_view() = default;
+        iota_view() requires default_initializable<_Wi> = default;
 
         constexpr explicit iota_view(_Wi _Value_) noexcept(
             is_nothrow_move_constructible_v<_Wi>&& is_nothrow_default_constructible_v<_Bo>) // strengthened
@@ -875,14 +1065,13 @@ namespace ranges {
     private:
         class _Iterator {
         private:
-            basic_istream_view* _Parent = nullptr;
+            basic_istream_view* _Parent;
 
         public:
             using iterator_concept = input_iterator_tag;
             using difference_type  = ptrdiff_t;
             using value_type       = _Ty;
 
-            _Iterator() = default;
             constexpr explicit _Iterator(basic_istream_view& _Parent_) noexcept : _Parent{_STD addressof(_Parent_)} {}
 
             _Iterator(const _Iterator&) = delete;
@@ -894,9 +1083,6 @@ namespace ranges {
             _Iterator& operator++() {
 #if _ITERATOR_DEBUG_LEVEL != 0
                 // Per LWG-3489
-                _STL_VERIFY(_Parent != nullptr, "cannot increment default-initialized istream_view iterator");
-                _STL_VERIFY(
-                    _Parent->_Stream != nullptr, "cannot increment istream_view iterator with uninitialized stream");
                 _STL_VERIFY(!_Parent->_Stream_at_end(), "cannot increment istream_view iterator at end of stream");
 #endif // _ITERATOR_DEBUG_LEVEL != 0
                 *_Parent->_Stream >> _Parent->_Val;
@@ -910,32 +1096,26 @@ namespace ranges {
             _NODISCARD _Ty& operator*() const noexcept /* strengthened */ {
 #if _ITERATOR_DEBUG_LEVEL != 0
                 // Per LWG-3489
-                _STL_VERIFY(_Parent != nullptr, "cannot dereference default-initialized istream_view iterator");
-                _STL_VERIFY(
-                    _Parent->_Stream != nullptr, "cannot dereference istream_view iterator with uninitialized stream");
                 _STL_VERIFY(!_Parent->_Stream_at_end(), "cannot dereference istream_view iterator at end of stream");
 #endif // _ITERATOR_DEBUG_LEVEL != 0
                 return _Parent->_Val;
             }
 
             _NODISCARD friend bool operator==(const _Iterator& _Left, default_sentinel_t) noexcept /* strengthened */ {
-                return _Left._Parent == nullptr || _Left._Parent->_Stream_at_end();
+                return _Left._Parent->_Stream_at_end();
             }
         };
 
-        basic_istream<_Elem, _Traits>* _Stream = nullptr;
-        _Ty _Val                               = _Ty{};
+        basic_istream<_Elem, _Traits>* _Stream;
+        _Ty _Val = _Ty{};
 
     public:
-        basic_istream_view() = default;
         constexpr explicit basic_istream_view(basic_istream<_Elem, _Traits>& _Stream_) noexcept(
             is_nothrow_default_constructible_v<_Ty>) // strengthened
             : _Stream{_STD addressof(_Stream_)} {}
 
         _NODISCARD constexpr auto begin() {
-            if (_Stream) {
-                *_Stream >> _Val;
-            }
+            *_Stream >> _Val;
             return _Iterator{*this};
         }
 
@@ -961,14 +1141,12 @@ namespace ranges {
     class ref_view : public view_interface<ref_view<_Rng>> {
         // clang-format on
     private:
-        _Rng* _Range = nullptr;
+        _Rng* _Range;
 
         static void _Rvalue_poison(_Rng&);
         static void _Rvalue_poison(_Rng&&) = delete;
 
     public:
-        constexpr ref_view() noexcept = default;
-
         // clang-format off
         template <_Not_same_as<ref_view> _OtherRng>
         constexpr ref_view(_OtherRng&& _Other) noexcept(
@@ -1082,7 +1260,7 @@ namespace ranges {
         // clang-format on
     private:
         /* [[no_unique_address]] */ _Vw _Range{};
-        /* [[no_unique_address]] */ _Semiregular_box<_Pr> _Pred{};
+        /* [[no_unique_address]] */ _Copyable_box<_Pr> _Pred{};
 
         template <class _Traits> // TRANSITION, LWG-3289
         struct _Category_base {};
@@ -1115,7 +1293,8 @@ namespace ranges {
             using value_type       = range_value_t<_Vw>;
             using difference_type  = range_difference_t<_Vw>;
 
-            _Iterator() = default;
+            _Iterator() requires default_initializable<iterator_t<_Vw>> = default;
+
             constexpr _Iterator(filter_view& _Parent_, iterator_t<_Vw> _Current_) noexcept(
                 is_nothrow_move_constructible_v<iterator_t<_Vw>>) // strengthened
                 : _Current(_STD move(_Current_)), _Parent{_STD addressof(_Parent_)} {
@@ -1248,7 +1427,10 @@ namespace ranges {
         };
 
     public:
-        filter_view() = default;
+        // clang-format off
+        filter_view() requires default_initializable<_Vw> && default_initializable<_Pr> = default;
+        // clang-format on
+
         constexpr filter_view(_Vw _Range_, _Pr _Pred_) noexcept(
             is_nothrow_move_constructible_v<_Vw>&& is_nothrow_move_constructible_v<_Pr>) // strengthened
             : _Range(_STD move(_Range_)), _Pred{in_place, _STD move(_Pred_)} {}
@@ -1263,7 +1445,7 @@ namespace ranges {
 
         _NODISCARD constexpr const _Pr& pred() const noexcept /* strengthened */ {
 #if _CONTAINER_DEBUG_LEVEL > 0
-            _STL_VERIFY(_Pred, "value-initialized filter_view has no predicate");
+            _STL_VERIFY(_Pred, "filter_view has no predicate");
 #endif // _CONTAINER_DEBUG_LEVEL > 0
             return *_Pred;
         }
@@ -1305,7 +1487,7 @@ namespace ranges {
         private:
             template <class _Pr>
             struct _Partial : _Pipe::_Base<_Partial<_Pr>> {
-                /* [[no_unique_address]] */ _Semiregular_box<_Pr> _Pred;
+                /* [[no_unique_address]] */ _Copyable_box<_Pr> _Pred;
 
                 template <viewable_range _Rng>
                 _NODISCARD constexpr auto operator()(_Rng&& _Range) const& noexcept(
@@ -1361,7 +1543,7 @@ namespace ranges {
         // clang-format on
     private:
         /* [[no_unique_address]] */ _Vw _Range{};
-        /* [[no_unique_address]] */ _Semiregular_box<_Fn> _Fun{};
+        /* [[no_unique_address]] */ _Copyable_box<_Fn> _Fun{};
 
         template <bool _Const>
         class _Sentinel;
@@ -1413,7 +1595,7 @@ namespace ranges {
             using value_type       = remove_cvref_t<invoke_result_t<_Fn&, range_reference_t<_Base>>>;
             using difference_type  = range_difference_t<_Base>;
 
-            _Iterator() = default;
+            _Iterator() requires default_initializable<iterator_t<_Base>> = default;
 
             constexpr _Iterator(_Parent_t& _Parent_, iterator_t<_Base> _Current_) noexcept(
                 is_nothrow_move_constructible_v<iterator_t<_Base>>) // strengthened
@@ -1707,11 +1889,12 @@ namespace ranges {
                     noexcept(_Left._Last - _Get_current(_Right))) /* strengthened */ {
                 return _Left._Last - _Get_current(_Right);
             }
-            // clang-format on
         };
 
     public:
-        transform_view() = default;
+        transform_view() requires default_initializable<_Vw> && default_initializable<_Fn> = default;
+        // clang-format on
+
         constexpr transform_view(_Vw _Range_, _Fn _Fun_) noexcept(
             is_nothrow_move_constructible_v<_Vw>&& is_nothrow_move_constructible_v<_Fn>) // strengthened
             : _Range(_STD move(_Range_)), _Fun{in_place, _STD move(_Fun_)} {}
@@ -1791,7 +1974,7 @@ namespace ranges {
         private:
             template <class _Fn>
             struct _Partial : _Pipe::_Base<_Partial<_Fn>> {
-                /* [[no_unique_address]] */ _Semiregular_box<_Fn> _Fun;
+                /* [[no_unique_address]] */ _Copyable_box<_Fn> _Fun;
 
                 template <viewable_range _Rng>
                 _NODISCARD constexpr auto operator()(_Rng&& _Range) const& noexcept(
@@ -1907,7 +2090,7 @@ namespace ranges {
         };
 
     public:
-        take_view() = default;
+        take_view() requires default_initializable<_Vw> = default;
 
         constexpr take_view(_Vw _Range_, const range_difference_t<_Vw> _Count_) noexcept(
             is_nothrow_move_constructible_v<_Vw>) // strengthened
@@ -2136,7 +2319,7 @@ namespace ranges {
         // clang-format on
     private:
         /* [[no_unique_address]] */ _Vw _Range{};
-        /* [[no_unique_address]] */ _Semiregular_box<_Pr> _Pred{};
+        /* [[no_unique_address]] */ _Copyable_box<_Pr> _Pred{};
 
         template <bool _Const, bool _Wrapped = true>
         class _Sentinel {
@@ -2211,7 +2394,9 @@ namespace ranges {
         };
 
     public:
-        take_while_view() = default;
+        // clang-format off
+        take_while_view() requires default_initializable<_Vw> && default_initializable<_Pr> = default;
+        // clang-format on
 
         constexpr take_while_view(_Vw _Range_, _Pr _Pred_) noexcept(
             is_nothrow_move_constructible_v<_Vw>&& is_nothrow_move_constructible_v<_Pr>) // strengthened
@@ -2227,7 +2412,7 @@ namespace ranges {
 
         _NODISCARD constexpr const _Pr& pred() const noexcept /* strengthened */ {
 #if _CONTAINER_DEBUG_LEVEL > 0
-            _STL_VERIFY(_Pred, "value-initialized take_while_view has no predicate");
+            _STL_VERIFY(_Pred, "take_while_view has no predicate");
 #endif // _CONTAINER_DEBUG_LEVEL > 0
             return *_Pred;
         }
@@ -2253,7 +2438,7 @@ namespace ranges {
             requires (!_Simple_view<_Vw>) {
             // clang-format on
 #if _CONTAINER_DEBUG_LEVEL > 0
-            _STL_VERIFY(_Pred, "value-initialized take_while_view cannot call end");
+            _STL_VERIFY(_Pred, "cannot call end on a take_while_view with no predicate");
 #endif // _CONTAINER_DEBUG_LEVEL > 0
             return _Sentinel<false>{_RANGES end(_Range), _STD addressof(*_Pred)};
         }
@@ -2264,7 +2449,7 @@ namespace ranges {
             requires range<const _Vw> && indirect_unary_predicate<const _Pr, iterator_t<const _Vw>> {
             // clang-format on
 #if _CONTAINER_DEBUG_LEVEL > 0
-            _STL_VERIFY(_Pred, "value-initialized take_while_view cannot call end");
+            _STL_VERIFY(_Pred, "cannot call end on a take_while_view with no predicate");
 #endif // _CONTAINER_DEBUG_LEVEL > 0
             return _Sentinel<true>{_RANGES end(_Range), _STD addressof(*_Pred)};
         }
@@ -2279,7 +2464,7 @@ namespace ranges {
         private:
             template <class _Pr>
             struct _Partial : _Pipe::_Base<_Partial<_Pr>> {
-                /* [[no_unique_address]] */ _Semiregular_box<_Pr> _Pred;
+                /* [[no_unique_address]] */ _Copyable_box<_Pr> _Pred;
 
                 template <viewable_range _Rng>
                 _NODISCARD constexpr auto operator()(_Rng&& _Range) const& noexcept(
@@ -2322,7 +2507,7 @@ namespace ranges {
         range_difference_t<_Vw> _Count = 0;
 
     public:
-        drop_view() = default;
+        drop_view() requires default_initializable<_Vw> = default;
 
         constexpr drop_view(_Vw _Range_, const range_difference_t<_Vw> _Count_) noexcept(
             is_nothrow_move_constructible_v<_Vw>) // strengthened
@@ -2354,18 +2539,20 @@ namespace ranges {
                     }
                 }
 
-                iterator_t<_Vw> _Result;
-                if constexpr (sized_range<_Vw>) {
+                same_as<iterator_t<_Vw>> auto _Result = [this] {
+                    if constexpr (!sized_range<_Vw>) {
+                        return _RANGES next(_RANGES begin(_Range), _Count, _RANGES end(_Range));
+                    }
+
                     auto _Offset = _RANGES distance(_Range);
                     if constexpr (bidirectional_range<_Vw> && common_range<_Vw>) {
                         if (_Count >= _Offset / 2) {
-                            _Result = _RANGES end(_Range);
+                            auto _Result = _RANGES end(_Range);
                             while (_Offset > _Count) {
                                 --_Offset;
                                 --_Result;
                             }
 
-                            this->_Set_cache(_Range, _Result);
                             return _Result;
                         }
                     }
@@ -2374,10 +2561,8 @@ namespace ranges {
                         _Offset = _Count;
                     }
 
-                    _Result = _RANGES next(_RANGES begin(_Range), _Offset);
-                } else {
-                    _Result = _RANGES next(_RANGES begin(_Range), _Count, _RANGES end(_Range));
-                }
+                    return _RANGES next(_RANGES begin(_Range), _Offset);
+                }();
 
                 if constexpr (forward_range<_Vw>) {
                     this->_Set_cache(_Range, _Result);
@@ -2566,10 +2751,12 @@ namespace ranges {
         // clang-format on
     private:
         /* [[no_unique_address]] */ _Vw _Range{};
-        /* [[no_unique_address]] */ _Semiregular_box<_Pr> _Pred{};
+        /* [[no_unique_address]] */ _Copyable_box<_Pr> _Pred{};
 
     public:
-        drop_while_view() = default;
+        // clang-format off
+        drop_while_view() requires default_initializable<_Vw> && default_initializable<_Pr> = default;
+        // clang-format on
 
         constexpr drop_while_view(_Vw _Range_, _Pr _Pred_) noexcept(
             is_nothrow_move_constructible_v<_Vw>&& is_nothrow_move_constructible_v<_Pr>) // strengthened
@@ -2585,7 +2772,7 @@ namespace ranges {
 
         _NODISCARD constexpr const _Pr& pred() const noexcept /* strengthened */ {
 #if _CONTAINER_DEBUG_LEVEL > 0
-            _STL_VERIFY(_Pred, "value-initialized drop_while_view has no predicate");
+            _STL_VERIFY(_Pred, "drop_while_view has no predicate");
 #endif // _CONTAINER_DEBUG_LEVEL > 0
             return *_Pred;
         }
@@ -2626,7 +2813,7 @@ namespace ranges {
         private:
             template <class _Pr>
             struct _Partial : _Pipe::_Base<_Partial<_Pr>> {
-                /* [[no_unique_address]] */ _Semiregular_box<_Pr> _Pred;
+                /* [[no_unique_address]] */ _Copyable_box<_Pr> _Pred;
 
                 template <viewable_range _Rng>
                 _NODISCARD constexpr auto operator()(_Rng&& _Range) const& noexcept(
@@ -2735,7 +2922,7 @@ namespace ranges {
             static constexpr bool _Deref_is_glvalue = is_reference_v<_InnerRng<_Const>>;
 
             /* [[no_unique_address]] */ _OuterIter _Outer{};
-            /* [[no_unique_address]] */ _InnerIter _Inner{};
+            /* [[no_unique_address]] */ _Defaultabox<_InnerIter> _Inner{}; // per LWG issue unfiled as of 2021-06-14
             _Parent_t* _Parent{};
 
             constexpr auto& _Update_inner(_InnerRng<_Const> _Range) {
@@ -2752,12 +2939,12 @@ namespace ranges {
                 for (; _Outer != _Last; ++_Outer) {
                     auto& _Tmp = _Update_inner(*_Outer);
                     _Inner     = _RANGES begin(_Tmp);
-                    if (_Inner != _RANGES end(_Tmp)) {
+                    if (*_Inner != _RANGES end(_Tmp)) {
                         return;
                     }
                 }
                 if constexpr (_Deref_is_glvalue) {
-                    _Inner = _InnerIter{};
+                    _Inner.reset();
                 }
             }
 
@@ -2771,7 +2958,7 @@ namespace ranges {
                 } else {
                     _Last = _RANGES end(_Parent->_Inner);
                 }
-                _STL_VERIFY(_Inner != _Last, "cannot dereference join_view end iterator");
+                _STL_VERIFY(_Inner && *_Inner != _Last, "cannot dereference join_view end iterator");
             }
 
             constexpr void _Same_range(const _Iterator& _Right) const noexcept {
@@ -2791,7 +2978,9 @@ namespace ranges {
             using value_type      = range_value_t<_InnerRng<_Const>>;
             using difference_type = common_type_t<range_difference_t<_Base>, range_difference_t<_InnerRng<_Const>>>;
 
-            _Iterator() = default;
+            // clang-format off
+            _Iterator() requires default_initializable<_OuterIter> && default_initializable<_InnerIter> = default;
+            // clang-format on
 
             constexpr _Iterator(_Parent_t& _Parent_, _OuterIter _Outer_)
                 : _Outer{_STD move(_Outer_)}, _Parent{_STD addressof(_Parent_)} {
@@ -2811,11 +3000,11 @@ namespace ranges {
                 : _Outer{_STD move(_It._Outer)}, _Inner{_STD move(_It._Inner)}, _Parent{_It._Parent} {}
             // clang-format on
 
-            _NODISCARD constexpr decltype(auto) operator*() const noexcept(noexcept(*_Inner)) /* strengthened */ {
+            _NODISCARD constexpr decltype(auto) operator*() const noexcept(noexcept(**_Inner)) /* strengthened */ {
 #if _ITERATOR_DEBUG_LEVEL != 0
                 _Check_dereference();
 #endif // _ITERATOR_DEBUG_LEVEL != 0
-                return *_Inner;
+                return **_Inner;
             }
 
             // clang-format off
@@ -2825,17 +3014,17 @@ namespace ranges {
 #if _ITERATOR_DEBUG_LEVEL != 0
                 _Check_dereference();
 #endif // _ITERATOR_DEBUG_LEVEL != 0
-                return _Inner;
+                return *_Inner;
             }
 
             constexpr _Iterator& operator++() {
                 if constexpr (_Deref_is_glvalue) {
-                    if (++_Inner == _RANGES end(*_Outer)) {
+                    if (++*_Inner == _RANGES end(*_Outer)) {
                         ++_Outer;
                         _Satisfy();
                     }
                 } else {
-                    if (++_Inner == _RANGES end(_Parent->_Inner)) {
+                    if (++*_Inner == _RANGES end(_Parent->_Inner)) {
                         ++_Outer;
                         _Satisfy();
                     }
@@ -2862,11 +3051,11 @@ namespace ranges {
                     --_Outer;
                     _Inner = _RANGES end(*_Outer);
                 }
-                while (_Inner == _RANGES begin(*_Outer)) {
+                while (*_Inner == _RANGES begin(*_Outer)) {
                     --_Outer;
-                    _Inner = _RANGES end(*_Outer);
+                    *_Inner = _RANGES end(*_Outer);
                 }
-                --_Inner;
+                --*_Inner;
                 return *this;
             }
 
@@ -2893,23 +3082,23 @@ namespace ranges {
             }
 
             _NODISCARD friend constexpr decltype(auto) iter_move(const _Iterator& _It) noexcept(
-                noexcept(_RANGES iter_move(_It._Inner))) {
+                noexcept(_RANGES iter_move(*_It._Inner))) {
 #if _ITERATOR_DEBUG_LEVEL != 0
                 _It._Check_dereference();
 #endif // _ITERATOR_DEBUG_LEVEL != 0
-                return _RANGES iter_move(_It._Inner);
+                return _RANGES iter_move(*_It._Inner);
             }
 
             // clang-format off
             friend constexpr void iter_swap(const _Iterator& _Left, const _Iterator& _Right) noexcept(
-                noexcept(_RANGES iter_swap(_Left._Inner, _Right._Inner)))
+                noexcept(_RANGES iter_swap(*_Left._Inner, *_Right._Inner)))
                 requires indirectly_swappable<_InnerIter> {
                 // clang-format on
 #if _ITERATOR_DEBUG_LEVEL != 0
                 _Left._Check_dereference();
                 _Right._Check_dereference();
 #endif // _ITERATOR_DEBUG_LEVEL != 0
-                _RANGES iter_swap(_Left._Inner, _Right._Inner);
+                _RANGES iter_swap(*_Left._Inner, *_Right._Inner);
             }
         };
 
@@ -2961,7 +3150,8 @@ namespace ranges {
         };
 
     public:
-        join_view() = default;
+        join_view() requires default_initializable<_Vw> = default;
+
         constexpr explicit join_view(_Vw _Range_) noexcept(is_nothrow_move_constructible_v<_Vw>) // strengthened
             : _Range(_STD move(_Range_)) {}
 
@@ -3048,7 +3238,7 @@ namespace ranges {
     template <class _Vw, class _Pat>
     class _Split_view_base : public view_interface<split_view<_Vw, _Pat>> {
     protected:
-        /* [[no_unique_address]] */ iterator_t<_Vw> _Current{};
+        /* [[no_unique_address]] */ _Defaultabox<iterator_t<_Vw>> _Current{};
     };
 
     template <forward_range _Vw, class _Pat>
@@ -3103,7 +3293,7 @@ namespace ranges {
                 if constexpr (forward_range<_BaseTy>) {
                     return this->_Current;
                 } else {
-                    return _Parent->_Current;
+                    return *_Parent->_Current;
                 }
             }
 
@@ -3111,7 +3301,7 @@ namespace ranges {
                 if constexpr (forward_range<_BaseTy>) {
                     return this->_Current;
                 } else {
-                    return _Parent->_Current;
+                    return *_Parent->_Current;
                 }
             }
 
@@ -3351,7 +3541,10 @@ namespace ranges {
         };
 
     public:
-        split_view() = default;
+        // clang-format off
+        split_view() requires default_initializable<_Vw> && default_initializable<_Pat> = default;
+        // clang-format on
+
         constexpr split_view(_Vw _Range_, _Pat _Pattern_) noexcept(
             is_nothrow_move_constructible_v<_Vw>&& is_nothrow_move_constructible_v<_Pat>) // strengthened
             : _Range(_STD move(_Range_)), _Pattern(_STD move(_Pattern_)) {}
@@ -3512,7 +3705,8 @@ namespace ranges {
         /* [[no_unique_address]] */ _Vw _Base{};
 
     public:
-        common_view() = default;
+        common_view() requires default_initializable<_Vw> = default;
+
         constexpr explicit common_view(_Vw _Base_) noexcept(is_nothrow_move_constructible_v<_Vw>) // strengthened
             : _Base(_STD move(_Base_)) {}
 
@@ -3629,7 +3823,8 @@ namespace ranges {
         using _Rev_iter = reverse_iterator<iterator_t<_Rng>>;
 
     public:
-        reverse_view() = default;
+        reverse_view() requires default_initializable<_Vw> = default;
+
         constexpr explicit reverse_view(_Vw _Range_) noexcept(is_nothrow_move_constructible_v<_Vw>) // strengthened
             : _Range(_STD move(_Range_)) {}
 
@@ -3822,7 +4017,7 @@ namespace ranges {
             using value_type       = remove_cvref_t<tuple_element_t<_Index, range_value_t<_Base>>>;
             using difference_type  = range_difference_t<_Base>;
 
-            _Iterator() = default;
+            _Iterator() requires default_initializable<iterator_t<_Base>> = default;
 
             constexpr explicit _Iterator(iterator_t<_Base> _Current_) noexcept(
                 is_nothrow_move_constructible_v<iterator_t<_Base>>) // strengthened
@@ -4078,7 +4273,7 @@ namespace ranges {
         };
 
     public:
-        elements_view() = default;
+        elements_view() requires default_initializable<_Vw> = default;
 
         constexpr explicit elements_view(_Vw _Range_) noexcept(is_nothrow_move_constructible_v<_Vw>) // strengthened
             : _Range(_STD move(_Range_)) {}

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -303,16 +303,18 @@ namespace ranges {
         }
 
         _Copyable_box& operator=(const _Copyable_box& _That) noexcept(is_nothrow_copy_constructible_v<_Ty>) {
-            if (_STD addressof(_That) != this) {
-                if (_Engaged) {
-                    _Val.~_Ty();
-                    _Engaged = false;
-                }
+            if (_STD addressof(_That) == this) {
+                return *this;
+            }
 
-                if (_That._Engaged) {
-                    _Construct_in_place(_Val, _That._Val);
-                    _Engaged = true;
-                }
+            if (_Engaged) {
+                _Val.~_Ty();
+                _Engaged = false;
+            }
+
+            if (_That._Engaged) {
+                _Construct_in_place(_Val, _That._Val);
+                _Engaged = true;
             }
 
             return *this;
@@ -345,16 +347,18 @@ namespace ranges {
         }
 
         _Copyable_box& operator=(_Copyable_box&& _That) noexcept(is_nothrow_move_constructible_v<_Ty>) {
-            if (_STD addressof(_That) != this) {
-                if (_Engaged) {
-                    _Val.~_Ty();
-                    _Engaged = false;
-                }
+            if (_STD addressof(_That) == this) {
+                return *this;
+            }
 
-                if (_That._Engaged) {
-                    _Construct_in_place(_Val, _STD move(_That._Val));
-                    _Engaged = true;
-                }
+            if (_Engaged) {
+                _Val.~_Ty();
+                _Engaged = false;
+            }
+
+            if (_That._Engaged) {
+                _Construct_in_place(_Val, _STD move(_That._Val));
+                _Engaged = true;
             }
 
             return *this;
@@ -2506,6 +2510,31 @@ namespace ranges {
         /* [[no_unique_address]] */ _Vw _Range{};
         range_difference_t<_Vw> _Count = 0;
 
+        _NODISCARD constexpr auto _Find_first() {
+            if constexpr (!sized_range<_Vw>) {
+                return _RANGES next(_RANGES begin(_Range), _Count, _RANGES end(_Range));
+            }
+
+            auto _Offset = _RANGES distance(_Range);
+            if constexpr (bidirectional_range<_Vw> && common_range<_Vw>) {
+                if (_Count >= _Offset / 2) {
+                    auto _Result = _RANGES end(_Range);
+                    while (_Offset > _Count) {
+                        --_Offset;
+                        --_Result;
+                    }
+
+                    return _Result;
+                }
+            }
+
+            if (_Offset > _Count) {
+                _Offset = _Count;
+            }
+
+            return _RANGES next(_RANGES begin(_Range), _Offset);
+        }
+
     public:
         drop_view() requires default_initializable<_Vw> = default;
 
@@ -2539,31 +2568,7 @@ namespace ranges {
                     }
                 }
 
-                same_as<iterator_t<_Vw>> auto _Result = [this] {
-                    if constexpr (!sized_range<_Vw>) {
-                        return _RANGES next(_RANGES begin(_Range), _Count, _RANGES end(_Range));
-                    }
-
-                    auto _Offset = _RANGES distance(_Range);
-                    if constexpr (bidirectional_range<_Vw> && common_range<_Vw>) {
-                        if (_Count >= _Offset / 2) {
-                            auto _Result = _RANGES end(_Range);
-                            while (_Offset > _Count) {
-                                --_Offset;
-                                --_Result;
-                            }
-
-                            return _Result;
-                        }
-                    }
-
-                    if (_Offset > _Count) {
-                        _Offset = _Count;
-                    }
-
-                    return _RANGES next(_RANGES begin(_Range), _Offset);
-                }();
-
+                same_as<iterator_t<_Vw>> auto _Result = _Find_first();
                 if constexpr (forward_range<_Vw>) {
                     this->_Set_cache(_Range, _Result);
                 }

--- a/stl/inc/span
+++ b/stl/inc/span
@@ -232,7 +232,7 @@ class span;
 #ifdef __cpp_lib_concepts
 namespace ranges {
     template <class _Ty, size_t _Extent>
-    inline constexpr bool enable_view<span<_Ty, _Extent>> = _Extent == 0 || _Extent == dynamic_extent;
+    inline constexpr bool enable_view<span<_Ty, _Extent>> = true;
     template <class _Ty, size_t _Extent>
     inline constexpr bool enable_borrowed_range<span<_Ty, _Extent>> = true;
 } // namespace ranges

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -810,7 +810,7 @@ _NODISCARD constexpr auto _To_signed_like(const _Ty _Value) noexcept {
 // CONCEPT weakly_incrementable
 // clang-format off
 template <class _Ty>
-concept weakly_incrementable = default_initializable<_Ty> && movable<_Ty> && requires(_Ty __i) {
+concept weakly_incrementable = movable<_Ty> && requires(_Ty __i) {
     typename iter_difference_t<_Ty>;
     requires _Signed_integer_like<iter_difference_t<_Ty>>;
     { ++__i } -> same_as<_Ty&>;
@@ -2860,7 +2860,7 @@ namespace ranges {
     // clang-format off
     // CONCEPT ranges::view
     template <class _Ty>
-    concept view = range<_Ty> && movable<_Ty> && default_initializable<_Ty> && enable_view<_Ty>;
+    concept view = range<_Ty> && movable<_Ty> && enable_view<_Ty>;
 #endif // TRANSITION, GH-1814
 
     // CONCEPT ranges::output_range
@@ -3507,7 +3507,7 @@ namespace ranges {
         }
 
     public:
-        subrange() = default;
+        subrange() requires default_initializable<_It> = default;
 
         template <_Convertible_to_non_slicing<_It> _It2>
         constexpr subrange(_It2 _First_, _Se _Last_) requires (!_Store_size)

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -1279,7 +1279,7 @@
 #define __cpp_lib_polymorphic_allocator   201902L
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395 and GH-1814
-#define __cpp_lib_ranges 201911L
+#define __cpp_lib_ranges 202106L
 #endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 
 #define __cpp_lib_remove_cvref            201711L

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -245,6 +245,7 @@
 // P2102R0 Making "Implicit Expression Variations" More Explicit
 // P2106R0 Range Algorithm Result Types
 // P2116R0 Removing tuple-Like Protocol Support From Fixed-Extent span
+// P2325R3 Views Should Not Be Required To Be Default Constructible
 // P????R? directory_entry::clear_cache()
 
 // _HAS_CXX20 indirectly controls:

--- a/tests/std/include/range_algorithm_support.hpp
+++ b/tests/std/include/range_algorithm_support.hpp
@@ -624,7 +624,7 @@ namespace test {
         public:
             static_assert(Copy == Copyability::immobile);
 
-            range_base() = default;
+            range_base() = delete;
             constexpr explicit range_base(span<Element> elements) noexcept : elements_{elements} {}
 
             range_base(const range_base&) = delete;
@@ -640,7 +640,7 @@ namespace test {
         template <class Element>
         class range_base<Element, Copyability::move_only> {
         public:
-            range_base() = default;
+            range_base() = delete;
             constexpr explicit range_base(span<Element> elements) noexcept : elements_{elements} {}
 
             constexpr range_base(range_base&& that) noexcept

--- a/tests/std/include/range_algorithm_support.hpp
+++ b/tests/std/include/range_algorithm_support.hpp
@@ -370,7 +370,7 @@ namespace test {
         using Consterator = iterator<Category, const Element, Diff, Eq, Proxy, Wrapped>;
 
         // output iterator operations
-        iterator() = default;
+        iterator() requires at_least<fwd> || (Eq == CanCompare::yes) = default;
 
         constexpr explicit iterator(Element* ptr) noexcept : ptr_{ptr} {}
 

--- a/tests/std/tests/P0784R7_library_support_for_more_constexpr_containers/test.cpp
+++ b/tests/std/tests/P0784R7_library_support_for_more_constexpr_containers/test.cpp
@@ -412,11 +412,11 @@ struct Alloc {
         allocator<T>{}.deallocate(ptr, n);
     }
 
-    constexpr void construct(value_type* ptr, value_type n) requires(Construct) {
+    constexpr void construct(value_type* ptr, value_type n) requires Construct {
         construct_at(ptr, n);
     }
 
-    constexpr void destroy(value_type* ptr) requires(Destroy) {
+    constexpr void destroy(value_type* ptr) requires Destroy {
         destroy_at(ptr);
     }
 

--- a/tests/std/tests/P0896R4_counted_iterator/test.cpp
+++ b/tests/std/tests/P0896R4_counted_iterator/test.cpp
@@ -53,7 +53,10 @@ struct instantiator {
         int input[5] = {1, 2, 3, 4, 5};
         // [counted.iter.const]
         {
-            [[maybe_unused]] counted_iterator<Iter> defaultConstructed{};
+            STATIC_ASSERT(default_initializable<counted_iterator<Iter>> == default_initializable<Iter>);
+            if constexpr (default_initializable<Iter>) {
+                [[maybe_unused]] counted_iterator<Iter> defaultConstructed{};
+            }
 
             counted_iterator<Iter> constructed(Iter{input}, iter_difference_t<Iter>{2});
             counted_iterator<Iter> constructedEmpty{Iter{input}, iter_difference_t<Iter>{0}};
@@ -198,7 +201,7 @@ struct instantiator {
                 const same_as<iter_difference_t<Iter>> auto diff2 = iter2 - iter1;
                 assert(diff2 == -1);
             }
-            { // difference value-initialized
+            if constexpr (default_initializable<Iter>) { // difference value-initialized
                 const same_as<iter_difference_t<Iter>> auto diff1 = counted_iterator<Iter>{} - counted_iterator<Iter>{};
                 assert(diff1 == 0);
             }
@@ -269,7 +272,7 @@ struct instantiator {
                 assert(iter1 <=> iter1 == strong_ordering::equal);
                 assert(iter1 <=> iter1 == strong_ordering::equivalent);
             }
-            { // spaceship value-initialized
+            if constexpr (default_initializable<Iter>) { // spaceship value-initialized
                 assert(counted_iterator<Iter>{} <=> counted_iterator<Iter>{} == strong_ordering::equal);
                 assert(counted_iterator<Iter>{} <=> counted_iterator<Iter>{} == strong_ordering::equivalent);
             }

--- a/tests/std/tests/P0896R4_istream_view/test.cpp
+++ b/tests/std/tests/P0896R4_istream_view/test.cpp
@@ -46,30 +46,20 @@ void test_one_type() {
     // validate constructors
     istringstream nonempty_stream{"0"};
     istringstream empty_intstream{};
-    R default_constructed{};
     R empty_constructed{empty_intstream};
     R non_empty_constructed{nonempty_stream};
 
-    static_assert(is_nothrow_constructible_v<R> == is_nothrow_default_constructible_v<T>);
     static_assert(is_nothrow_constructible_v<R, istream&> == is_nothrow_default_constructible_v<T>);
 
     // validate member begin
     // NOTE: begin() consumes the first token
-    (void) default_constructed.begin(); // default-constructed basic_istream_view doesn't model range.
     assert(empty_constructed.begin() == default_sentinel);
     assert(non_empty_constructed.begin() != default_sentinel);
 
-    // validate default constructed istream::iterator
-    {
-        const ranges::iterator_t<R> default_constructed_it;
-        assert(default_constructed_it == default_sentinel);
-        static_assert(noexcept(default_constructed_it == default_sentinel));
-    }
-
     // validate member end
-    static_assert(same_as<decltype(default_constructed.end()), default_sentinel_t>);
-    static_assert(noexcept(default_constructed.end()));
-    static_assert(noexcept(ranges::end(default_constructed)));
+    static_assert(same_as<decltype(empty_constructed.end()), default_sentinel_t>);
+    static_assert(noexcept(empty_constructed.end()));
+    static_assert(noexcept(ranges::end(empty_constructed)));
 
     // Nonexistent member functions
     static_assert(!CanMemberSize<R>);
@@ -97,14 +87,10 @@ void test_one_type() {
 
 istringstream some_stream{"42"};
 constexpr bool test_constexpr() {
-    // Default constructor is constexpr
-    ranges::basic_istream_view<int, char> empty{};
-
-    // begin is constexpr??!?
-    (void) empty.begin();
-
     // stream constructor is constexpr
     ranges::basic_istream_view<int, char> meow{some_stream};
+
+    // begin is constexpr, but realistically unusable in a constant expression
 
     // end is constexpr
     (void) meow.end();

--- a/tests/std/tests/P0896R4_istream_view_death/test.cpp
+++ b/tests/std/tests/P0896R4_istream_view_death/test.cpp
@@ -13,46 +13,6 @@ using namespace std;
 
 using iview = ranges::basic_istream_view<int, char>;
 
-void test_preincrement_default_initialized() {
-    ranges::iterator_t<iview> it;
-    (void) ++it;
-}
-
-void test_postincrement_default_initialized() {
-    ranges::iterator_t<iview> it;
-    (void) it++;
-}
-
-void test_dereference_default_initialized() {
-    ranges::iterator_t<iview> it;
-    (void) *it;
-}
-
-void test_preincrement_no_stream() {
-    iview v;
-    auto it = v.begin();
-    (void) ++it;
-}
-
-void test_postincrement_no_stream() {
-    iview v;
-    auto it = v.begin();
-    (void) it++;
-}
-
-void test_dereference_no_stream() {
-    iview v;
-    auto it = v.begin();
-    (void) *it;
-}
-
-void test_compare_no_stream() {
-    iview v;
-    auto it = v.begin();
-    auto se = v.end();
-    (void) (it == se);
-}
-
 void test_preincrement_end_of_stream() {
     istringstream stream;
     iview view{stream};
@@ -79,13 +39,6 @@ int main(int argc, char* argv[]) {
 
 #if _ITERATOR_DEBUG_LEVEL != 0
     exec.add_death_tests({
-        test_preincrement_default_initialized,
-        test_postincrement_default_initialized,
-        test_dereference_default_initialized,
-        test_preincrement_no_stream,
-        test_postincrement_no_stream,
-        test_dereference_no_stream,
-        test_compare_no_stream,
         test_preincrement_end_of_stream,
         test_postincrement_end_of_stream,
         test_dereference_end_of_stream,

--- a/tests/std/tests/P0896R4_ranges_alg_adjacent_find/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_adjacent_find/test.cpp
@@ -6,6 +6,7 @@
 #include <cassert>
 #include <concepts>
 #include <ranges>
+#include <span>
 #include <utility>
 
 #include <range_algorithm_support.hpp>
@@ -53,8 +54,10 @@ int main() {
 }
 
 struct instantiator {
+    static constexpr int some_ints[] = {1, 2, 3};
     template <class Fwd>
-    static void call(Fwd&& fwd = {}) {
+    static void call() {
+        Fwd fwd{std::span{some_ints}};
         using ranges::adjacent_find, ranges::iterator_t;
 
         (void) adjacent_find(fwd);

--- a/tests/std/tests/P0896R4_ranges_alg_binary_search/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_binary_search/test.cpp
@@ -31,7 +31,7 @@ struct empty_ranges {
     template <ranges::forward_range Fwd>
     static constexpr void call() {
         // Validate empty ranges
-        const Fwd range{std::span<P, 0>{}};
+        const Fwd range{span<P, 0>{}};
 
         ASSERT(ranges::lower_bound(range, 42, ranges::less{}, get_first) == ranges::end(range));
         ASSERT(ranges::lower_bound(ranges::begin(range), ranges::end(range), 42, ranges::less{}, get_first)

--- a/tests/std/tests/P0896R4_ranges_alg_binary_search/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_binary_search/test.cpp
@@ -8,6 +8,7 @@
 #include <cassert>
 #include <concepts>
 #include <ranges>
+#include <span>
 #include <utility>
 
 #include <range_algorithm_support.hpp>
@@ -30,7 +31,7 @@ struct empty_ranges {
     template <ranges::forward_range Fwd>
     static constexpr void call() {
         // Validate empty ranges
-        const Fwd range{};
+        const Fwd range{std::span<P, 0>{}};
 
         ASSERT(ranges::lower_bound(range, 42, ranges::less{}, get_first) == ranges::end(range));
         ASSERT(ranges::lower_bound(ranges::begin(range), ranges::end(range), 42, ranges::less{}, get_first)

--- a/tests/std/tests/P0896R4_ranges_alg_equal/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_equal/test.cpp
@@ -7,6 +7,7 @@
 #include <concepts>
 #include <cstdlib>
 #include <ranges>
+#include <span>
 
 #include <range_algorithm_support.hpp>
 
@@ -87,8 +88,11 @@ int main() {
 
 struct instantiator {
     template <class In1, class In2>
-    static void call(In1&& in1 = {}, In2&& in2 = {}) {
+    static void call() {
         using ranges::begin, ranges::end, ranges::equal, ranges::iterator_t;
+
+        In1 in1{std::span<const int, 0>{}};
+        In2 in2{std::span<const int, 0>{}};
 
         if constexpr (!is_permissive) {
             (void) equal(in1, in2);

--- a/tests/std/tests/P0896R4_ranges_alg_find_end/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_find_end/test.cpp
@@ -79,9 +79,12 @@ int main() {
 #ifndef _PREFAST_ // TRANSITION, GH-1030
 struct instantiator {
     template <class Fwd1, class Fwd2>
-    static void call(Fwd1&& fwd1 = {}, Fwd2&& fwd2 = {}) {
+    static void call() {
         if constexpr (!is_permissive) { // These fail to compile in C1XX's permissive mode due to VSO-566808
             using ranges::iterator_t;
+
+            Fwd1 fwd1{std::span<const int, 0>{}};
+            Fwd2 fwd2{std::span<const int, 0>{}};
 
             (void) ranges::find_end(fwd1, fwd2);
             (void) ranges::find_end(ranges::begin(fwd1), ranges::end(fwd1), ranges::begin(fwd2), ranges::end(fwd2));

--- a/tests/std/tests/P0896R4_ranges_alg_heap/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_heap/test.cpp
@@ -9,6 +9,7 @@
 #include <cassert>
 #include <concepts>
 #include <ranges>
+#include <span>
 #include <utility>
 
 #include <range_algorithm_support.hpp>
@@ -35,7 +36,7 @@ struct empty_ranges {
     template <ranges::random_access_range Range>
     static constexpr void call() {
         // Validate empty ranges (only make_heap and sort_heap accept empty ranges)
-        const Range range{};
+        const Range range{span<P, 0>{}};
 
         ASSERT(ranges::make_heap(range, ranges::less{}, get_first) == ranges::end(range));
         ASSERT(ranges::make_heap(ranges::begin(range), ranges::end(range), ranges::less{}, get_first)

--- a/tests/std/tests/P0896R4_ranges_alg_includes/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_includes/test.cpp
@@ -5,6 +5,7 @@
 #include <cassert>
 #include <concepts>
 #include <ranges>
+#include <span>
 #include <utility>
 
 #include <range_algorithm_support.hpp>
@@ -38,14 +39,14 @@ struct instantiator {
         }
 
         { // Validate range overload, empty haystack
-            Haystack haystack{};
+            Haystack haystack{span<const P, 0>{}};
             Needle needle{needle_elements};
             const same_as<bool> auto result = includes(haystack, needle, ranges::less{}, get_first, add_one);
             assert(!result);
         }
         { // Validate iterator overload, empty needle
             Haystack haystack{haystack_elements};
-            Needle needle{};
+            Needle needle{span<const int, 0>{}};
             const same_as<bool> auto result = includes(
                 haystack.begin(), haystack.end(), needle.begin(), needle.end(), ranges::less{}, get_first, add_one);
             assert(result);

--- a/tests/std/tests/P0896R4_ranges_alg_inplace_merge/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_inplace_merge/test.cpp
@@ -5,6 +5,7 @@
 #include <cassert>
 #include <concepts>
 #include <ranges>
+#include <span>
 #include <utility>
 
 #include <range_algorithm_support.hpp>
@@ -31,7 +32,7 @@ struct instantiator {
             assert(equal(input, expected));
 
             // Validate empty range
-            const Range empty_range{};
+            const Range empty_range{span<P, 0>{}};
             const same_as<iterator_t<Range>> auto empty_result =
                 inplace_merge(empty_range, empty_range.begin(), ranges::less{}, get_first);
             assert(empty_result == empty_range.begin());
@@ -47,7 +48,7 @@ struct instantiator {
             assert(equal(input, expected));
 
             // Validate empty range
-            const Range empty_range{};
+            const Range empty_range{span<P, 0>{}};
             const same_as<iterator_t<Range>> auto empty_result =
                 inplace_merge(empty_range.begin(), empty_range.begin(), empty_range.end(), ranges::less{}, get_first);
             assert(empty_result == empty_range.end());

--- a/tests/std/tests/P0896R4_ranges_alg_is_permutation/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_is_permutation/test.cpp
@@ -49,7 +49,7 @@ struct instantiator {
 
         {
             // negative case [different lengths]
-            const Fwd2 suffix2{std::span{not_pairs}.subspan<2>()};
+            const Fwd2 suffix2{span{not_pairs}.subspan<2>()};
             assert(!ranges::is_permutation(range1, suffix2, ranges::equal_to{}, get_first, identity{}));
             assert(!ranges::is_permutation(suffix2, range1, ranges::equal_to{}, identity{}, get_first));
             assert(!ranges::is_permutation(ranges::begin(range1), ranges::end(range1), ranges::begin(suffix2),
@@ -74,16 +74,16 @@ struct instantiator {
 
         {
             // negative case [only final elements differ]
-            const Fwd1 r1{std::span{pairs}.subspan<0, 3>()};
-            const Fwd2 r2{std::span{not_pairs}.subspan<0, 3>()};
+            const Fwd1 r1{span{pairs}.subspan<0, 3>()};
+            const Fwd2 r2{span{not_pairs}.subspan<0, 3>()};
             assert(!ranges::is_permutation(r1, r2, ranges::equal_to{}, get_first, identity{}));
             assert(!ranges::is_permutation(ranges::begin(r1), ranges::end(r1), ranges::begin(r2), ranges::end(r2),
                 ranges::equal_to{}, get_first, identity{}));
         }
         {
             // negative case [only initial elements differ]
-            const Fwd1 r1{std::span{pairs}.subspan<1, 3>()};
-            const Fwd2 r2{std::span{not_pairs}.subspan<4, 3>()};
+            const Fwd1 r1{span{pairs}.subspan<1, 3>()};
+            const Fwd2 r2{span{not_pairs}.subspan<4, 3>()};
             assert(!ranges::is_permutation(r1, r2, ranges::equal_to{}, get_first, identity{}));
             assert(!ranges::is_permutation(ranges::begin(r1), ranges::end(r1), ranges::begin(r2), ranges::end(r2),
                 ranges::equal_to{}, get_first, identity{}));

--- a/tests/std/tests/P0896R4_ranges_alg_lexicographical_compare/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_lexicographical_compare/test.cpp
@@ -5,6 +5,7 @@
 #include <cassert>
 #include <concepts>
 #include <ranges>
+#include <span>
 #include <utility>
 
 #include <range_algorithm_support.hpp>
@@ -87,20 +88,20 @@ struct instantiator {
         }
 
         {
-            In1 empty1{};
+            In1 empty1{span<const P, 0>{}};
             In2 range2{right_equal};
             const same_as<bool> auto result = lexicographical_compare(empty1, range2, less{}, get_first, get_second);
             assert(result);
         }
         {
             In1 range1{left};
-            In2 empty2{};
+            In2 empty2{span<const P, 0>{}};
             const same_as<bool> auto result = lexicographical_compare(range1, empty2, less{}, get_first, get_second);
             assert(!result);
         }
         {
-            In1 empty1{};
-            In2 empty2{};
+            In1 empty1{span<const P, 0>{}};
+            In2 empty2{span<const P, 0>{}};
             const same_as<bool> auto result = lexicographical_compare(empty1, empty2, less{}, get_first, get_second);
             assert(!result);
         }
@@ -173,7 +174,7 @@ struct instantiator {
         }
 
         {
-            In1 empty1{};
+            In1 empty1{span<const P, 0>{}};
             In2 range2{right_equal};
             const same_as<bool> auto result = lexicographical_compare(
                 empty1.begin(), empty1.end(), range2.begin(), range2.end(), less{}, get_first, get_second);
@@ -181,14 +182,14 @@ struct instantiator {
         }
         {
             In1 range1{left};
-            In2 empty2{};
+            In2 empty2{span<const P, 0>{}};
             const same_as<bool> auto result = lexicographical_compare(
                 range1.begin(), range1.end(), empty2.begin(), empty2.end(), less{}, get_first, get_second);
             assert(!result);
         }
         {
-            In1 empty1{};
-            In2 empty2{};
+            In1 empty1{span<const P, 0>{}};
+            In2 empty2{span<const P, 0>{}};
             const same_as<bool> auto result = lexicographical_compare(
                 empty1.begin(), empty1.end(), empty2.begin(), empty2.end(), less{}, get_first, get_second);
             assert(!result);

--- a/tests/std/tests/P0896R4_ranges_alg_merge/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_merge/test.cpp
@@ -5,6 +5,7 @@
 #include <cassert>
 #include <concepts>
 #include <ranges>
+#include <span>
 #include <utility>
 
 #include <range_algorithm_support.hpp>
@@ -74,7 +75,7 @@ struct instantiator {
 
         { // Validate range overload, empty range1
             P output[size(elements2)]{};
-            R1 range1{};
+            R1 range1{span<const P, 0>{}};
             R2 range2{elements2};
             size_t counter = 0;
 
@@ -89,7 +90,7 @@ struct instantiator {
         { // Validate iterator overload, empty range2
             P output[size(elements1)]{};
             R1 range1{elements1};
-            R2 range2{};
+            R2 range2{span<const P, 0>{}};
             size_t counter = 0;
 
             const same_as<merge_result<iterator_t<R1>, iterator_t<R2>, O>> auto result =

--- a/tests/std/tests/P0896R4_ranges_alg_minmax/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_minmax/test.cpp
@@ -9,6 +9,7 @@
 #include <cassert>
 #include <concepts>
 #include <ranges>
+#include <span>
 #include <utility>
 
 #include <range_algorithm_support.hpp>
@@ -38,7 +39,7 @@ struct mm_element_empty {
     template <ranges::forward_range Fwd>
     static constexpr void call() {
         // Validate empty ranges
-        const Fwd range{};
+        const Fwd range{span<const P, 0>{}};
 
         ASSERT(ranges::min_element(range, ranges::less{}, get_first) == ranges::end(range));
         ASSERT(ranges::min_element(ranges::begin(range), ranges::end(range), ranges::less{}, get_first)

--- a/tests/std/tests/P0896R4_ranges_alg_mismatch/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_mismatch/test.cpp
@@ -6,6 +6,7 @@
 #include <cassert>
 #include <concepts>
 #include <ranges>
+#include <span>
 #include <utility>
 
 #include <range_algorithm_support.hpp>
@@ -78,8 +79,11 @@ int main() {
 #ifndef _PREFAST_ // TRANSITION, GH-1030
 struct instantiator {
     template <class In1, class In2>
-    static void call(In1&& in1 = {}, In2&& in2 = {}) {
+    static void call() {
         using ranges::begin, ranges::end, ranges::mismatch, ranges::iterator_t;
+
+        In1 in1{std::span<const int, 0>{}};
+        In2 in2{std::span<const int, 0>{}};
 
         if constexpr (!is_permissive) {
             (void) mismatch(in1, in2);

--- a/tests/std/tests/P0896R4_ranges_alg_nth_element/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_nth_element/test.cpp
@@ -5,6 +5,7 @@
 #include <cassert>
 #include <concepts>
 #include <ranges>
+#include <span>
 #include <utility>
 
 #include <range_algorithm_support.hpp>
@@ -63,7 +64,7 @@ struct instantiator {
 
         {
             // Validate empty range
-            const R range{};
+            const R range{span<P, 0>{}};
             const same_as<iterator_t<R>> auto result = nth_element(range, range.begin(), less{}, get_first);
             assert(result == range.end());
         }

--- a/tests/std/tests/P0896R4_ranges_alg_partial_sort_copy/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_partial_sort_copy/test.cpp
@@ -52,7 +52,7 @@ struct instantiator1 {
             }
 
             // also with empty input
-            In range1{};
+            In range1{span<const P, 0>{}};
             Out range2{output};
             const same_as<partial_sort_copy_result<iterator_t<In>, iterator_t<Out>>> auto result =
                 partial_sort_copy(range1, range2, less{}, get_first, get_first);
@@ -85,7 +85,7 @@ struct instantiator2 {
             }
 
             // also with empty input
-            In range1{};
+            In range1{span<const P, 0>{}};
             Out range2{output};
             const same_as<partial_sort_copy_result<iterator_t<In>, iterator_t<Out>>> auto result = partial_sort_copy(
                 range1.begin(), range1.end(), range2.begin(), range2.end(), less{}, get_first, get_first);

--- a/tests/std/tests/P0896R4_ranges_alg_partition/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_partition/test.cpp
@@ -9,6 +9,7 @@
 #include <concepts>
 #include <numeric>
 #include <ranges>
+#include <span>
 #include <utility>
 
 #include <range_algorithm_support.hpp>
@@ -31,16 +32,16 @@ struct empty_test {
         // Validate empty ranges
         using ranges::is_partitioned, ranges::partition, ranges::partition_point;
         {
-            Range range{};
+            Range range{span<P, 0>{}};
             ASSERT(is_partitioned(range, is_even, get_first));
         }
         {
-            Range range{};
+            Range range{span<P, 0>{}};
             ASSERT(is_partitioned(range.begin(), range.end(), is_even, get_first));
         }
 
         if constexpr (ranges::forward_range<Range>) {
-            const Range range{};
+            const Range range{span<P, 0>{}};
             {
                 const auto result = partition(range, is_even, get_first);
                 ASSERT(result.begin() == range.end());

--- a/tests/std/tests/P0896R4_ranges_alg_partition_copy/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_partition_copy/test.cpp
@@ -7,6 +7,7 @@
 #include <concepts>
 #include <numeric>
 #include <ranges>
+#include <span>
 #include <utility>
 
 #include <range_algorithm_support.hpp>
@@ -37,7 +38,7 @@ struct empty_test {
         using ranges::partition_copy, ranges::partition_copy_result, ranges::iterator_t;
 
         {
-            Range range{};
+            Range range{span<const P, 0>{}};
             same_as<partition_copy_result<iterator_t<Range>, Out1, Out2>> auto result =
                 partition_copy(range, Out1{nullptr}, Out2{nullptr}, is_even, get_first);
             ASSERT(result.in == range.end());
@@ -45,7 +46,7 @@ struct empty_test {
             ASSERT(result.out2.peek() == nullptr);
         }
         {
-            Range range{};
+            Range range{span<const P, 0>{}};
             same_as<partition_copy_result<iterator_t<Range>, Out1, Out2>> auto result =
                 partition_copy(range.begin(), range.end(), Out1{nullptr}, Out2{nullptr}, is_even, get_first);
             ASSERT(result.in == range.end());

--- a/tests/std/tests/P0896R4_ranges_alg_partition_copy/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_partition_copy/test.cpp
@@ -38,19 +38,16 @@ struct empty_test {
 
         {
             Range range{};
-            auto result = partition_copy(range, Out1{}, Out2{}, is_even, get_first);
-            STATIC_ASSERT(same_as<decltype(partition_copy(range, Out1{}, Out2{}, is_even, get_first)),
-                partition_copy_result<iterator_t<Range>, Out1, Out2>>);
+            same_as<partition_copy_result<iterator_t<Range>, Out1, Out2>> auto result =
+                partition_copy(range, Out1{nullptr}, Out2{nullptr}, is_even, get_first);
             ASSERT(result.in == range.end());
             ASSERT(result.out1.peek() == nullptr);
             ASSERT(result.out2.peek() == nullptr);
         }
         {
             Range range{};
-            auto result = partition_copy(range.begin(), range.end(), Out1{}, Out2{}, is_even, get_first);
-            STATIC_ASSERT(
-                same_as<decltype(partition_copy(range.begin(), range.end(), Out1{}, Out2{}, is_even, get_first)),
-                    partition_copy_result<iterator_t<Range>, Out1, Out2>>);
+            same_as<partition_copy_result<iterator_t<Range>, Out1, Out2>> auto result =
+                partition_copy(range.begin(), range.end(), Out1{nullptr}, Out2{nullptr}, is_even, get_first);
             ASSERT(result.in == range.end());
             ASSERT(result.out1.peek() == nullptr);
             ASSERT(result.out2.peek() == nullptr);

--- a/tests/std/tests/P0896R4_ranges_alg_partition_point/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_partition_point/test.cpp
@@ -30,7 +30,7 @@ struct empty_test {
         // Validate empty ranges
         using ranges::partition_point;
 
-        const Range range{};
+        const Range range{span<P, 0>{}};
         ASSERT(partition_point(range, is_even, get_first) == range.end());
         ASSERT(partition_point(range.begin(), range.end(), is_even, get_first) == range.end());
     }

--- a/tests/std/tests/P0896R4_ranges_alg_permutations/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_permutations/test.cpp
@@ -7,6 +7,7 @@
 #include <cstdio>
 #include <random>
 #include <ranges>
+#include <span>
 #include <utility>
 
 #include <range_algorithm_support.hpp>
@@ -202,7 +203,7 @@ struct empty_range_test {
             ranges::prev_permutation_result, ranges::iterator_t;
 
         { // Validate range overload, next_permutation
-            R range{};
+            R range{span<int_wrapper, 0>{}};
             const same_as<next_permutation_result<iterator_t<R>>> auto result =
                 next_permutation(range, ranges::less{}, get_val);
             assert(result.in == range.end());
@@ -210,7 +211,7 @@ struct empty_range_test {
         }
 
         { // Validate iterator overload, next_permutation
-            R range{};
+            R range{span<int_wrapper, 0>{}};
             const same_as<next_permutation_result<iterator_t<R>>> auto result =
                 next_permutation(range.begin(), range.end(), ranges::less{}, get_val);
             assert(result.in == range.end());
@@ -218,7 +219,7 @@ struct empty_range_test {
         }
 
         { // Validate range overload, prev_permutation
-            R range{};
+            R range{span<int_wrapper, 0>{}};
             const same_as<prev_permutation_result<iterator_t<R>>> auto result =
                 prev_permutation(range, ranges::less{}, get_val);
             assert(result.in == range.end());
@@ -226,7 +227,7 @@ struct empty_range_test {
         }
 
         { // Validate iterator overload, prev_permutation
-            R range{};
+            R range{span<int_wrapper, 0>{}};
             const same_as<prev_permutation_result<iterator_t<R>>> auto result =
                 prev_permutation(range.begin(), range.end(), ranges::less{}, get_val);
             assert(result.in == range.end());

--- a/tests/std/tests/P0896R4_ranges_alg_reverse/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_reverse/test.cpp
@@ -7,6 +7,7 @@
 #include <concepts>
 #include <numeric>
 #include <ranges>
+#include <span>
 #include <utility>
 
 #include <range_algorithm_support.hpp>
@@ -71,13 +72,13 @@ struct instantiator {
             assert(equal(input, expected_even));
         }
         { // Validate iterator + sentinel overload, empty range
-            R wrapped_input{};
+            R wrapped_input{span<nontrivial_int, 0>{}};
             auto result = reverse(wrapped_input.begin(), wrapped_input.end());
             STATIC_ASSERT(same_as<decltype(result), iterator_t<R>>);
             assert(result == wrapped_input.end());
         }
         { // Validate range overload, empty range
-            R wrapped_input{};
+            R wrapped_input{span<nontrivial_int, 0>{}};
             auto result = reverse(wrapped_input);
             STATIC_ASSERT(same_as<decltype(result), iterator_t<R>>);
             assert(result == wrapped_input.end());
@@ -136,13 +137,13 @@ struct test_vector {
         }
 
         { // Validate iterator + sentinel overload, vectorizable empty
-            R wrapped_input{};
+            R wrapped_input{span<ranges::range_value_t<R>, 0>{}};
             auto result = reverse(wrapped_input.begin(), wrapped_input.end());
             STATIC_ASSERT(same_as<decltype(result), iterator_t<R>>);
             assert(result == wrapped_input.end());
         }
         { // Validate range overload, vectorizable empty
-            R wrapped_input{};
+            R wrapped_input{span<ranges::range_value_t<R>, 0>{}};
             auto result = reverse(wrapped_input);
             STATIC_ASSERT(same_as<decltype(result), iterator_t<R>>);
             assert(result == wrapped_input.end());

--- a/tests/std/tests/P0896R4_ranges_alg_reverse_copy/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_reverse_copy/test.cpp
@@ -7,6 +7,7 @@
 #include <concepts>
 #include <numeric>
 #include <ranges>
+#include <span>
 #include <utility>
 
 #include <range_algorithm_support.hpp>
@@ -66,7 +67,7 @@ struct instantiator {
 
             { // Validate iterator overload, empty range
                 nontrivial_int output[3];
-                In wrapped_input{};
+                In wrapped_input{span<const nontrivial_int, 0>{}};
                 const same_as<reverse_copy_result<iterator_t<In>, Out>> auto result =
                     reverse_copy(wrapped_input.begin(), wrapped_input.end(), Out{output});
                 assert(result.in == wrapped_input.end());
@@ -74,7 +75,7 @@ struct instantiator {
             }
             { // Validate range overload, empty range
                 nontrivial_int output[3];
-                In wrapped_input{};
+                In wrapped_input{span<const nontrivial_int, 0>{}};
                 const same_as<reverse_copy_result<iterator_t<In>, Out>> auto result =
                     reverse_copy(wrapped_input, Out{output});
                 assert(result.in == wrapped_input.end());
@@ -129,7 +130,7 @@ struct test_vector {
 
         { // Validate iterator overload, vectorizable empty
             range_value_t<In> output[3];
-            In wrapped_input{};
+            In wrapped_input{span<range_value_t<In>, 0>{}};
             const same_as<reverse_copy_result<iterator_t<In>, Out>> auto result =
                 reverse_copy(wrapped_input.begin(), wrapped_input.end(), Out{output});
             assert(result.in == wrapped_input.end());
@@ -137,7 +138,7 @@ struct test_vector {
         }
         { // Validate range overload, vectorizable empty
             range_value_t<In> output[3];
-            In wrapped_input{};
+            In wrapped_input{span<range_value_t<In>, 0>{}};
             const same_as<reverse_copy_result<iterator_t<In>, Out>> auto result =
                 reverse_copy(wrapped_input, Out{output});
             assert(result.in == wrapped_input.end());

--- a/tests/std/tests/P0896R4_ranges_alg_set_difference/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_set_difference/test.cpp
@@ -58,7 +58,7 @@ struct instantiator {
 
         { // Validate range overload, empty range1
             P output[osize]{};
-            R1 range1{};
+            R1 range1{span<const P, 0>{}};
             R2 range2{elements2};
             const same_as<set_difference_result<iterator_t<R1>, O>> auto result =
                 set_difference(range1, range2, O{output}, ranges::less{}, get_first, get_second);
@@ -68,7 +68,7 @@ struct instantiator {
         { // Validate iterator overload, empty range2
             P output[osize]{};
             R1 range1{elements1};
-            R2 range2{};
+            R2 range2{span<const P, 0>{}};
             const same_as<set_difference_result<iterator_t<R1>, O>> auto result = set_difference(range1.begin(),
                 range1.end(), range2.begin(), range2.end(), O{output}, ranges::less{}, get_first, get_second);
             assert(result.in == range1.end());

--- a/tests/std/tests/P0896R4_ranges_alg_set_intersection/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_set_intersection/test.cpp
@@ -69,7 +69,7 @@ struct instantiator {
 
         { // Validate range overload, empty range1
             P output[osize]{};
-            R1 range1{};
+            R1 range1{span<const P, 0>{}};
             R2 range2{elements2};
             const same_as<set_intersection_result<iterator_t<R1>, iterator_t<R2>, O>> auto result =
                 set_intersection(range1, range2, O{output}, ranges::less{}, get_first, get_second);
@@ -80,7 +80,7 @@ struct instantiator {
         { // Validate iterator overload, empty range2
             P output[osize]{};
             R1 range1{elements1};
-            R2 range2{};
+            R2 range2{span<const P, 0>{}};
             const same_as<set_intersection_result<iterator_t<R1>, iterator_t<R2>, O>> auto result =
                 set_intersection(range1.begin(), range1.end(), range2.begin(), range2.end(), O{output}, ranges::less{},
                     get_first, get_second);

--- a/tests/std/tests/P0896R4_ranges_alg_set_symmetric_difference/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_set_symmetric_difference/test.cpp
@@ -69,7 +69,7 @@ struct instantiator {
 
         { // Validate range overload, empty range1
             P output[osize]{};
-            R1 range1{};
+            R1 range1{span<const P, 0>{}};
             R2 range2{elements2};
             const same_as<set_symmetric_difference_result<iterator_t<R1>, iterator_t<R2>, O>> auto result =
                 set_symmetric_difference(range1, range2, O{output}, ranges::less{}, get_first, get_second);
@@ -81,7 +81,7 @@ struct instantiator {
         { // Validate iterator overload, empty range2
             P output[osize]{};
             R1 range1{elements1};
-            R2 range2{};
+            R2 range2{span<const P, 0>{}};
             const same_as<set_symmetric_difference_result<iterator_t<R1>, iterator_t<R2>, O>> auto result =
                 set_symmetric_difference(range1.begin(), range1.end(), range2.begin(), range2.end(), O{output},
                     ranges::less{}, get_first, get_second);

--- a/tests/std/tests/P0896R4_ranges_alg_set_union/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_set_union/test.cpp
@@ -66,7 +66,7 @@ struct instantiator {
 
         { // Validate range overload, empty range1
             P output[osize]{};
-            R1 range1{};
+            R1 range1{span<const P, 0>{}};
             R2 range2{elements2};
             const same_as<set_union_result<iterator_t<R1>, iterator_t<R2>, O>> auto result =
                 set_union(range1, range2, O{output}, ranges::less{}, get_first, get_second);
@@ -78,7 +78,7 @@ struct instantiator {
         { // Validate iterator overload, empty range2
             P output[osize]{};
             R1 range1{elements1};
-            R2 range2{};
+            R2 range2{span<const P, 0>{}};
             const same_as<set_union_result<iterator_t<R1>, iterator_t<R2>, O>> auto result = set_union(range1.begin(),
                 range1.end(), range2.begin(), range2.end(), O{output}, ranges::less{}, get_first, get_second);
             assert(result.in1 == range1.end());

--- a/tests/std/tests/P0896R4_ranges_alg_sort/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_sort/test.cpp
@@ -6,6 +6,7 @@
 #include <cassert>
 #include <concepts>
 #include <ranges>
+#include <span>
 #include <utility>
 
 #include <range_algorithm_support.hpp>
@@ -42,7 +43,7 @@ struct instantiator {
         }
 
         { // Validate empty range
-            const R range{};
+            const R range{span<P, 0>{}};
             const same_as<iterator_t<R>> auto result = sort(range, less{}, get_first);
             assert(result == range.end());
             assert(is_sorted(range, less{}, get_first));

--- a/tests/std/tests/P0896R4_ranges_alg_stable_partition/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_stable_partition/test.cpp
@@ -5,6 +5,7 @@
 #include <cassert>
 #include <concepts>
 #include <ranges>
+#include <span>
 #include <utility>
 
 #include <range_algorithm_support.hpp>
@@ -34,7 +35,7 @@ struct instantiator {
             assert(is_sorted(range));
 
             // Validate empty range
-            const Range empty_range{};
+            const Range empty_range{span<P, 0>{}};
             const same_as<subrange<iterator_t<Range>>> auto empty_result =
                 stable_partition(empty_range, is_even, get_first);
             assert(empty_result.begin() == empty_range.end());
@@ -53,7 +54,7 @@ struct instantiator {
             assert(is_sorted(range));
 
             // Validate empty range
-            const Range empty_range{};
+            const Range empty_range{span<P, 0>{}};
             const same_as<subrange<iterator_t<Range>>> auto empty_result =
                 stable_partition(empty_range.begin(), empty_range.end(), is_even, get_first);
             assert(empty_result.begin() == empty_range.end());

--- a/tests/std/tests/P0896R4_ranges_alg_stable_sort/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_stable_sort/test.cpp
@@ -6,6 +6,7 @@
 #include <cassert>
 #include <concepts>
 #include <ranges>
+#include <span>
 #include <utility>
 
 #include <range_algorithm_support.hpp>
@@ -42,7 +43,7 @@ struct instantiator {
         }
 
         { // Validate empty range
-            const R range{};
+            const R range{span<P, 0>{}};
             const same_as<iterator_t<R>> auto result = stable_sort(range, less{}, get_first);
             assert(result == range.end());
             assert(is_sorted(range, less{}));

--- a/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
@@ -314,15 +314,12 @@ inline constexpr std::size_t destructible_archetype_max = 1;
                                                                                 \
     prefix##_archetype& operator=(prefix##_archetype const&) requires (I != 3); \
     prefix##_archetype& operator=(prefix##_archetype&&) requires (I == 4) = delete
-
-#define SEMIREGULAR_OPS(prefix, default_disable)                                \
-    prefix##_archetype() requires (I != default_disable);                       \
-    COPYABLE_OPS(prefix)
 // clang-format on
 
 template <std::size_t I>
 struct semiregular_archetype : destructible_archetype<I> {
-    SEMIREGULAR_OPS(semiregular, 5);
+    semiregular_archetype() requires(I != 5);
+    COPYABLE_OPS(semiregular);
 };
 
 inline constexpr std::size_t semiregular_archetype_max = 6;
@@ -370,7 +367,8 @@ inline constexpr std::size_t weakly_incrementable_archetype_max = 11;
 template <std::size_t I>
 struct incrementable_archetype : weakly_incrementable_archetype<I>,
                                  increment_ops<I, incrementable_archetype<I>, incrementable_archetype<I>> {
-    SEMIREGULAR_OPS(incrementable, 11);
+    incrementable_archetype() requires(I != 11);
+    COPYABLE_OPS(incrementable);
     using increment_ops<I, incrementable_archetype<I>, incrementable_archetype<I>>::operator++;
 
     // clang-format off
@@ -399,7 +397,8 @@ inline constexpr std::size_t iterator_archetype_max = 12;
 
 template <std::size_t I>
 struct sentinel_archetype : semiregular_archetype<I> {
-    SEMIREGULAR_OPS(sentinel, 5);
+    sentinel_archetype() requires(I != 5);
+    COPYABLE_OPS(sentinel);
 
     // clang-format off
     template <std::size_t J>
@@ -412,7 +411,8 @@ inline constexpr std::size_t sentinel_archetype_max = 7;
 
 template <std::size_t I>
 struct sized_sentinel_archetype : sentinel_archetype<I> {
-    SEMIREGULAR_OPS(sized_sentinel, 5);
+    sized_sentinel_archetype() requires(I != 5);
+    COPYABLE_OPS(sized_sentinel);
 };
 
 // clang-format off
@@ -498,7 +498,8 @@ inline constexpr std::size_t input_iterator_archetype_max = 16;
 template <std::size_t I>
 struct forward_iterator_archetype : input_iterator_archetype<I>,
                                     increment_ops<I, forward_iterator_archetype<I>, forward_iterator_archetype<I>> {
-    SEMIREGULAR_OPS(forward_iterator, 16);
+    forward_iterator_archetype() requires(I != 16);
+    COPYABLE_OPS(forward_iterator);
     using increment_ops<I, forward_iterator_archetype<I>, forward_iterator_archetype<I>>::operator++;
 
     // clang-format off
@@ -523,7 +524,8 @@ template <std::size_t I>
 struct bidi_iterator_archetype : forward_iterator_archetype<I>,
                                  increment_ops<I, bidi_iterator_archetype<I>, bidi_iterator_archetype<I>>,
                                  decrement_ops<I, bidi_iterator_archetype<I>> {
-    SEMIREGULAR_OPS(bidi_iterator, 16);
+    bidi_iterator_archetype() requires(I != 16);
+    COPYABLE_OPS(bidi_iterator);
     using increment_ops<I, bidi_iterator_archetype<I>, bidi_iterator_archetype<I>>::operator++;
 };
 
@@ -533,7 +535,8 @@ template <std::size_t I>
 struct random_iterator_archetype : bidi_iterator_archetype<I>,
                                    increment_ops<I, random_iterator_archetype<I>, random_iterator_archetype<I>>,
                                    decrement_ops<I, random_iterator_archetype<I>> {
-    SEMIREGULAR_OPS(random_iterator, 16);
+    random_iterator_archetype() requires(I != 16);
+    COPYABLE_OPS(random_iterator);
     using increment_ops<I, random_iterator_archetype<I>, random_iterator_archetype<I>>::operator++;
     using decrement_ops<I, random_iterator_archetype<I>>::operator--;
 
@@ -581,7 +584,8 @@ template <std::size_t I>
 struct contig_iterator_archetype : increment_ops<I, contig_iterator_archetype<I>, contig_iterator_archetype<I>>,
                                    decrement_ops<I, contig_iterator_archetype<I>>,
                                    contig_iterator_archetype_types<I> {
-    SEMIREGULAR_OPS(contig_iterator, 16);
+    contig_iterator_archetype() requires(I != 16);
+    COPYABLE_OPS(contig_iterator);
     using increment_ops<I, contig_iterator_archetype<I>, contig_iterator_archetype<I>>::operator++;
     using decrement_ops<I, contig_iterator_archetype<I>>::operator--;
 

--- a/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
@@ -386,11 +386,12 @@ template <std::size_t I>
 struct iterator_archetype : weakly_incrementable_archetype<I> {
     COPYABLE_OPS(iterator);
 
-    iterator_archetype& operator++() requires(I > 9);
-    void operator++(int) requires(I != 10);
+    // clang-format off
+    iterator_archetype& operator++() requires (I > 9);
+    void operator++(int) requires (I != 10);
 
-    void operator*() requires(I == 11);
-    int operator*() requires(I != 11);
+    void operator*() requires (I == 11);
+    int operator*() requires (I != 11);
     // clang-format on
 };
 

--- a/tests/std/tests/P0896R4_ranges_ref_view/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_ref_view/test.cpp
@@ -35,9 +35,6 @@ struct instantiator {
         { // constructors and assignment operators
             STATIC_ASSERT(!constructible_from<ref_view<R>, R>);
 
-            ref_view<R> default_constructed{};
-            STATIC_ASSERT(is_nothrow_default_constructible_v<ref_view<R>>);
-
             R wrapped_input{input};
             ref_view<R> same_range{wrapped_input};
             STATIC_ASSERT(is_nothrow_constructible_v<ref_view<R>, R&>);
@@ -48,13 +45,16 @@ struct instantiator {
             }
             assert(copy_constructed.end().peek() == end(input));
 
-            default_constructed = copy_constructed;
+            int other_data[3] = {4, 5, 6};
+            R wrapped_other{other_data};
+            ref_view<R> copy_assigned{wrapped_other};
+            copy_assigned = copy_constructed;
             if constexpr (forward_range<R>) {
-                assert(default_constructed.begin().peek() == begin(input));
+                assert(copy_assigned.begin().peek() == begin(input));
             }
-            assert(default_constructed.end().peek() == end(input));
+            assert(copy_assigned.end().peek() == end(input));
 
-            [[maybe_unused]] auto move_constructed = std::move(default_constructed);
+            [[maybe_unused]] auto move_constructed = std::move(copy_assigned);
             if constexpr (forward_range<R>) {
                 assert(move_constructed.begin().peek() == begin(input));
             }

--- a/tests/std/tests/P0896R4_ranges_ref_view/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_ref_view/test.cpp
@@ -121,7 +121,7 @@ struct instantiator {
 
                 STATIC_ASSERT(noexcept(as_const(test_view).empty()) == noexcept(ranges::empty(wrapped_input)));
 
-                R empty_range{};
+                R empty_range{span<int, 0>{}};
                 ref_view<R> empty_view{empty_range};
                 assert(empty_view.empty());
             }

--- a/tests/std/tests/P0896R4_ranges_subrange/test.compile.pass.cpp
+++ b/tests/std/tests/P0896R4_ranges_subrange/test.compile.pass.cpp
@@ -815,7 +815,7 @@ namespace test_subrange {
         using size_type = std::make_unsigned_t<std::iter_difference_t<I>>;
 
         // Validate SMFs
-        STATIC_ASSERT(default_initializable<Subrange>);
+        STATIC_ASSERT(default_initializable<Subrange> == default_initializable<I>);
         STATIC_ASSERT(movable<Subrange>);
         STATIC_ASSERT(!copyable<I> || copyable<Subrange>);
 

--- a/tests/std/tests/P0896R4_ranges_test_machinery/test.compile.pass.cpp
+++ b/tests/std/tests/P0896R4_ranges_test_machinery/test.compile.pass.cpp
@@ -21,7 +21,7 @@ constexpr bool iter_test() {
 
     using I = iterator<Category, Element, Diff, Eq, Proxy, Wrapped>;
 
-    STATIC_ASSERT(default_initializable<I>);
+    STATIC_ASSERT(default_initializable<I> == (Eq == CanCompare::yes));
     STATIC_ASSERT(movable<I>);
 
     STATIC_ASSERT(!movable<Element> || indirectly_writable<I, Element>);

--- a/tests/std/tests/P0896R4_stream_iterators/test.cpp
+++ b/tests/std/tests/P0896R4_stream_iterators/test.cpp
@@ -63,10 +63,7 @@ void test_ostream_iterator(basic_ostream<CharT, Traits>& os) {
 
 #ifdef __cpp_lib_concepts
     STATIC_ASSERT(output_iterator<I, const T&>);
-
     STATIC_ASSERT(is_same_v<typename I::difference_type, ptrdiff_t>);
-    { [[maybe_unused]] constexpr I constexprConstructed{}; }
-    STATIC_ASSERT(is_nothrow_default_constructible_v<I>);
 #endif // __cpp_lib_concepts
 }
 
@@ -100,10 +97,7 @@ void test_ostreambuf_iterator(basic_ostream<CharT, Traits>& os) {
 
 #ifdef __cpp_lib_concepts
     STATIC_ASSERT(output_iterator<I, const CharT&>);
-
     STATIC_ASSERT(is_same_v<typename I::difference_type, ptrdiff_t>);
-    { [[maybe_unused]] constexpr I constexprConstructed{}; }
-    STATIC_ASSERT(is_nothrow_default_constructible_v<I>);
 #endif // __cpp_lib_concepts
 }
 

--- a/tests/std/tests/P0896R4_views_all/test.cpp
+++ b/tests/std/tests/P0896R4_views_all/test.cpp
@@ -4,7 +4,6 @@
 #include <algorithm>
 #include <cassert>
 #include <ranges>
-#include <span>
 #include <string>
 #include <string_view>
 #include <type_traits>
@@ -207,12 +206,5 @@ int main() {
         string str{"Hello, World!"};
         test_one(str);
         assert(ranges::equal(views::all(str), str));
-    }
-
-    // Validate a non-view borrowed range
-    {
-        constexpr span s{some_ints};
-        static_assert(test_one(s));
-        test_one(s);
     }
 }

--- a/tests/std/tests/P0896R4_views_drop/test.cpp
+++ b/tests/std/tests/P0896R4_views_drop/test.cpp
@@ -399,7 +399,7 @@ struct instantiator {
         R r{some_ints};
         test_one(r, only_four_ints);
 
-        R empty_range{};
+        R empty_range{span<const int, 0>{}};
         test_one(empty_range, span<const int, 0>{});
     }
 };

--- a/tests/std/tests/P0896R4_views_drop/test.cpp
+++ b/tests/std/tests/P0896R4_views_drop/test.cpp
@@ -533,11 +533,6 @@ int main() {
     instantiation_test();
 
     {
-        // Validate a non-view borrowed range
-        constexpr span s{some_ints};
-        STATIC_ASSERT(test_one(s, only_four_ints));
-        test_one(s, only_four_ints);
-
         // Validate a view borrowed range
         constexpr auto v =
             views::iota(0ull, ranges::size(some_ints)) | views::transform([](auto i) { return some_ints[i]; });

--- a/tests/std/tests/P0896R4_views_drop_while/test.cpp
+++ b/tests/std/tests/P0896R4_views_drop_while/test.cpp
@@ -373,13 +373,6 @@ int main() {
         test_one(lst, expected_output);
     }
 
-    // Validate a non-view borrowed range
-    {
-        constexpr span s{some_ints};
-        STATIC_ASSERT(test_one(s, expected_output));
-        test_one(s, expected_output);
-    }
-
     // drop_while/reverse interaction test
     {
         auto dwr_pipe = views::drop_while(is_less_than<3>) | views::reverse;

--- a/tests/std/tests/P0896R4_views_elements/test.cpp
+++ b/tests/std/tests/P0896R4_views_elements/test.cpp
@@ -411,12 +411,6 @@ int main() {
         instantiation_test();
     }
 
-    { // Validate a non-view borrowed range
-        constexpr span s{some_pairs};
-        STATIC_ASSERT(test_one(s));
-        test_one(s);
-    }
-
     { // Validate a view borrowed range
         constexpr auto v = views::iota(0ull, ranges::size(expected_keys))
                          | views::transform([](auto i) { return make_pair(expected_keys[i], expected_values[i]); });

--- a/tests/std/tests/P0896R4_views_filter/test.cpp
+++ b/tests/std/tests/P0896R4_views_filter/test.cpp
@@ -347,13 +347,6 @@ int main() {
         test_one(lst, only_even_ints);
     }
 
-    // Validate a non-view borrowed range
-    {
-        constexpr span s{some_ints};
-        STATIC_ASSERT(test_one(s, only_even_ints));
-        test_one(s, only_even_ints);
-    }
-
     // filter/reverse interaction test
     {
         auto fr_pipe = views::filter(is_even) | views::reverse;

--- a/tests/std/tests/P0896R4_views_join/test.cpp
+++ b/tests/std/tests/P0896R4_views_join/test.cpp
@@ -132,7 +132,7 @@ constexpr bool test_one(Outer&& rng, Expected&& expected) {
 
         // Validate deduction guide
         same_as<R> auto r = join_view{forward<Outer>(rng)};
-#ifdef __cpp_lib_constexpr_dynamic_alloc
+#ifndef __cpp_lib_constexpr_dynamic_alloc
         if (!is_constant_evaluated())
 #endif // __cpp_lib_constexpr_dynamic_alloc
         {

--- a/tests/std/tests/P0896R4_views_join/test.cpp
+++ b/tests/std/tests/P0896R4_views_join/test.cpp
@@ -50,7 +50,7 @@ constexpr bool test_one(Outer&& rng, Expected&& expected) {
         static_assert(!ranges::random_access_range<R>);
         static_assert(!ranges::contiguous_range<R>);
 
-        constexpr bool is_view = ranges::view<Outer>;
+        constexpr bool is_view = ranges::view<remove_cvref_t<Outer>>;
 
         // Validate range adapter object
         // ...with lvalue argument
@@ -132,7 +132,12 @@ constexpr bool test_one(Outer&& rng, Expected&& expected) {
 
         // Validate deduction guide
         same_as<R> auto r = join_view{forward<Outer>(rng)};
-        assert(ranges::equal(r, expected));
+#ifdef __cpp_lib_constexpr_dynamic_alloc
+        if (!is_constant_evaluated())
+#endif // __cpp_lib_constexpr_dynamic_alloc
+        {
+            assert(ranges::equal(r, expected));
+        }
         const bool is_empty = ranges::empty(expected);
 
         // Validate lack of size

--- a/tests/std/tests/P0896R4_views_reverse/test.cpp
+++ b/tests/std/tests/P0896R4_views_reverse/test.cpp
@@ -307,7 +307,7 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
 struct instantiator {
     template <ranges::bidirectional_range R>
     static constexpr void call() {
-        R r{};
+        R r{span<const int, 0>{}};
         test_one(r, span<const int, 0>{});
     }
 };

--- a/tests/std/tests/P0896R4_views_reverse/test.cpp
+++ b/tests/std/tests/P0896R4_views_reverse/test.cpp
@@ -357,13 +357,6 @@ int main() {
             views::reverse(ranges::subrange{counted_iterator{lst.begin(), 2}, default_sentinel}), reversed_prefix));
     }
 
-    // Validate a non-view borrowed range
-    {
-        constexpr span s{some_ints};
-        static_assert(test_one(s, reversed_ints));
-        test_one(s, reversed_ints);
-    }
-
     // Get full instantiation coverage
     static_assert((test_bidi<instantiator, const int>(), true));
     test_bidi<instantiator, const int>();

--- a/tests/std/tests/P0896R4_views_split/test.cpp
+++ b/tests/std/tests/P0896R4_views_split/test.cpp
@@ -282,21 +282,21 @@ struct instantiator {
             Read read{span{text}};
             test_one(move_if_needed(read), ' ', expected_single);
 
-            Read empty{};
+            Read empty{span<const char, 0>{}};
             test_one(move_if_needed(empty), ' ', views::empty<string_view>);
         }
         { // Empty delimiter
             Read read{span{text}};
             test_one(move_if_needed(read), views::empty<char>, expected_empty);
 
-            Read empty{};
+            Read empty{span<const char, 0>{}};
             test_one(move_if_needed(empty), views::empty<char>, views::empty<string_view>);
         }
         if constexpr (ranges::forward_range<Read>) { // Range delimiter
             Read read{span{text}};
             test_one(move_if_needed(read), "is"sv, expected_range);
 
-            Read empty{};
+            Read empty{span<const char, 0>{}};
             test_one(move_if_needed(empty), "is"sv, views::empty<string_view>);
         }
     }

--- a/tests/std/tests/P0896R4_views_split/test.cpp
+++ b/tests/std/tests/P0896R4_views_split/test.cpp
@@ -317,13 +317,15 @@ constexpr bool instantiation_test() {
     // 4. Commonality
     // 3. Length of delimiter pattern (0/static 1/dynamic) [covered in instantiator::call]
 
-    instantiator::call<test_range<input_iterator_tag, Common::no, CanView::no, Copyability::immobile>>();
-    instantiator::call<test_range<input_iterator_tag, Common::no, CanView::yes, Copyability::move_only>>();
-    instantiator::call<test_range<input_iterator_tag, Common::no, CanView::yes, Copyability::copyable>>();
+    if (!std::is_constant_evaluated()) { // TRANSITION, P2231R1
+        instantiator::call<test_range<input_iterator_tag, Common::no, CanView::no, Copyability::immobile>>();
+        instantiator::call<test_range<input_iterator_tag, Common::no, CanView::yes, Copyability::move_only>>();
+        instantiator::call<test_range<input_iterator_tag, Common::no, CanView::yes, Copyability::copyable>>();
 
-    instantiator::call<test_range<input_iterator_tag, Common::yes, CanView::no, Copyability::immobile>>();
-    instantiator::call<test_range<input_iterator_tag, Common::yes, CanView::yes, Copyability::move_only>>();
-    instantiator::call<test_range<input_iterator_tag, Common::yes, CanView::yes, Copyability::copyable>>();
+        instantiator::call<test_range<input_iterator_tag, Common::yes, CanView::no, Copyability::immobile>>();
+        instantiator::call<test_range<input_iterator_tag, Common::yes, CanView::yes, Copyability::move_only>>();
+        instantiator::call<test_range<input_iterator_tag, Common::yes, CanView::yes, Copyability::copyable>>();
+    }
 
     instantiator::call<test_range<forward_iterator_tag, Common::no, CanView::no, Copyability::immobile>>();
     instantiator::call<test_range<forward_iterator_tag, Common::no, CanView::yes, Copyability::move_only>>();

--- a/tests/std/tests/P0896R4_views_take/test.cpp
+++ b/tests/std/tests/P0896R4_views_take/test.cpp
@@ -429,7 +429,7 @@ struct instantiator {
         R r{some_ints};
         test_one(r, only_four_ints);
 
-        R empty_range{};
+        R empty_range{span<const int, 0>{}};
         test_one(empty_range, span<const int, 0>{});
     }
 };

--- a/tests/std/tests/P0896R4_views_take/test.cpp
+++ b/tests/std/tests/P0896R4_views_take/test.cpp
@@ -580,11 +580,6 @@ int main() {
     instantiation_test();
 
     {
-        // Validate a non-view borrowed range
-        constexpr span s{some_ints};
-        STATIC_ASSERT(test_one(s, only_four_ints));
-        test_one(s, only_four_ints);
-
         // Validate a view borrowed range
         constexpr auto v =
             views::iota(0ull, ranges::size(some_ints)) | views::transform([](auto i) { return some_ints[i]; });

--- a/tests/std/tests/P0896R4_views_take_while/test.cpp
+++ b/tests/std/tests/P0896R4_views_take_while/test.cpp
@@ -432,13 +432,6 @@ int main() {
         test_one(lst, expected_output);
     }
 
-    // Validate a non-view borrowed range
-    {
-        constexpr span s{some_ints};
-        STATIC_ASSERT(test_one(s, expected_output));
-        test_one(s, expected_output);
-    }
-
     // take_while/reverse interaction test
     {
         auto twr_pipe = views::take_while(is_less_than<3>) | views::reverse;

--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
@@ -1224,10 +1224,10 @@ STATIC_ASSERT(__cpp_lib_quoted_string_io == 201304L);
 #if _HAS_CXX23 && !defined(__EDG__) // TRANSITION, EDG concepts support and GH-1814
 #ifndef __cpp_lib_ranges
 #error __cpp_lib_ranges is not defined
-#elif __cpp_lib_ranges != 201911L
-#error __cpp_lib_ranges is not 201911L
+#elif __cpp_lib_ranges != 202106L
+#error __cpp_lib_ranges is not 202106L
 #else
-STATIC_ASSERT(__cpp_lib_ranges == 201911L);
+STATIC_ASSERT(__cpp_lib_ranges == 202106L);
 #endif
 #else
 #ifdef __cpp_lib_ranges


### PR DESCRIPTION
Major changes:
1. `view` does not refine `default_initializable`. This means that even `span<int, 42>` - which is not default constructible - is a `view`. Replace `_Semiregular_box` with `_Copyable_box` which need not be default constructible when the wrapped type is not.

2. `weakly_incrementable` does not refine `default_initializable`; consequently neither do `input_or_output_iterator`, `input_iterator`, nor `output_iterator`. `forward_iterator` refines `incrementable` refines `regular`, and so is still `default_initalizable`. This proposal reverts the changes from P0896R4 that made `{back_,front_,}insert_iterator` and `ostream{buf,}_iterator` `default_initializable`.

3. The proposal leaves `join_view` broken for ranges of ranges with iterators that aren't default constructible - that defect is fixed here. This will be (but is not yet) the proposed resolution of an LWG issue.

4. The proposal also leaves `basic_stream_view` in a dangerous state by removing the DMI for the stored value: copying the view before the first call to `begin` could result in undefined behavior. This will be (but is not yet) the proposed resolution of an LWG issue.

5. This change makes `test::iterator` not default constructible when not modeling `forward_iterator`, and makes `test::range` not default constructible when the range is immovable or move-only. This gives us some good test coverage for non-default-constructible types.

Collateral damage:
* Repurpose `_Semiregular_box` into the working draft's new _`copyable-box`_, which no longer adds default construction behavior. Add a new `optional`-like `_Defaultabox` that augments a `movable` type with default construction behavior for deferred initialization of `view`s and `iterator`s which the working draft depicts as being stored in an `optional`.
* Remove all test cases that were using `span<T, N>` as an exemplar non-`view` `borrowed_range`.
* It's possible for `drop_while_view` and `take_while_view` to have no predicate even when not default-initialized; fixup error message and test cases.

Drive-by: Implement missed `insert_iterator` changes that use `ranges::iterator_t<Container>` instead of `typename Container::iterator`.

Fixes #1984.