### PR TITLE
Don't rely on MSVC/Clang bugs in ranges test machinery

### DIFF
--- a/tests/std/include/range_algorithm_support.hpp
+++ b/tests/std/include/range_algorithm_support.hpp
@@ -327,6 +327,14 @@ template <class T, class Cat, class Elem, template <class> class TQuals, templat
 struct std::basic_common_reference<T, ::test::proxy_reference<Cat, Elem>, TQuals, UQuals> {
     using type = common_reference_t<TQuals<T>, Elem&>;
 };
+
+template <class Cat1, class Elem1, class Cat2, class Elem2, template <class> class TQuals,
+    template <class> class UQuals>
+    requires std::common_reference_with<Elem1&, Elem2&>
+struct std::basic_common_reference<::test::proxy_reference<Cat1, Elem1>, ::test::proxy_reference<Cat2, Elem2>, TQuals,
+    UQuals> {
+    using type = common_reference_t<Elem1&, Elem2&>;
+};
 // clang-format on
 
 namespace test {


### PR DESCRIPTION
EDG reported that `basic_common_reference<T, U>` is ambiguous when both `T` and `U` are specializations of `test::proxy_reference`, as occurs in `P0896R4_ranges_alg_equal`. Apparently both MSVC and Clang share the same bug here (See LLVM-50723) and pick a specialization to make this work.

I've verified that `cl /BE` compiles `P0896R4_ranges_alg_equal` successfully with this change (by temporarily hacking `concepts_20_matrix.lst` and `yvals_core.h`).
