### PR TITLE
Toolset update: VS 2019 16.11 Preview 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 The STL uses boost-math headers to provide P0226R1 Mathematical Special Functions. We recommend using [vcpkg][] to
 acquire this dependency.
 
-1. Install Visual Studio 2019 16.11 Preview 1 or later.
+1. Install Visual Studio 2019 16.11 Preview 2 or later.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
     * Otherwise, install [CMake][] 3.20 or later, and [Ninja][] 1.10.2 or later.
@@ -158,7 +158,7 @@ acquire this dependency.
 
 # How To Build With A Native Tools Command Prompt
 
-1. Install Visual Studio 2019 16.11 Preview 1 or later.
+1. Install Visual Studio 2019 16.11 Preview 2 or later.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
     * Otherwise, install [CMake][] 3.20 or later, and [Ninja][] 1.10.2 or later.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@ variables:
   buildOutputLocation: 'D:\build'
   vcpkgLocation: '$(Build.SourcesDirectory)/vcpkg'
 
-pool: 'StlBuild-2021-06-02'
+pool: 'StlBuild-2021-06-15'
 
 stages:
   - stage: Code_Format


### PR DESCRIPTION
Should be a totally uneventful toolset update. This incorporates June's Patch Tuesday into the VM.

(Preparing it required learning how to downgrade Azure PowerShell from 6.1.0 to 6.0.0, now documented in the wiki.)