### PR TITLE
`<chrono>` Estimate width of aligned chronat strings

### DIFF
--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -5966,8 +5966,10 @@ namespace chrono {
                 }
             }
 
-            return _Write_aligned(_STD move(_FormatCtx.out()), static_cast<int>(_Stream.view().size()), _Specs,
-                _Fmt_align::_Left, [&](auto _Out) { return _Fmt_write(_STD move(_Out), _Stream.view()); });
+            int _Estimated_width = -1;
+            (void) _Measure_string_prefix(_Stream.view(), _Estimated_width);
+            return _Write_aligned(_STD move(_FormatCtx.out()), _Estimated_width, _Specs, _Fmt_align::_Left,
+                [&](auto _Out) { return _Fmt_write(_STD move(_Out), _Stream.view()); });
         }
 
         // This echoes the functionality of put_time, but is able to handle invalid dates (when !ok()) since the

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/env.lst
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/env.lst
@@ -2,3 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 RUNALL_INCLUDE ..\concepts_latest_matrix.lst
+RUNALL_CROSSLIST
+PM_CL="/utf-8"

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
@@ -3,6 +3,7 @@
 
 #include <assert.h>
 #include <chrono>
+#include <clocale>
 #include <concepts>
 #include <format>
 #include <iostream>
@@ -973,7 +974,7 @@ void test() {
 #if !defined(_DLL) || _ITERATOR_DEBUG_LEVEL == DEFAULT_IDL_SETTING
     test_locale<wchar_t>();
 #ifndef MSVC_INTERNAL_TESTING // TRANSITION, the Windows version on Contest VMs doesn't always understand ".UTF-8"
-    setlocale(LC_ALL, ".UTF-8");
+    assert(setlocale(LC_ALL, ".UTF-8") != nullptr);
     test_locale<char>();
 #endif // MSVC_INTERNAL_TESTING
 #endif // !defined(_DLL) || _ITERATOR_DEBUG_LEVEL == DEFAULT_IDL_SETTING

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
@@ -30,6 +30,13 @@ template <typename CharT>
 
 #define STR(Literal) (choose_literal<CharT>(Literal, L##Literal))
 
+// Test against IDL mismatch between the DLL which stores the locale and the code which uses it.
+#ifdef _DEBUG
+#define DEFAULT_IDL_SETTING 2
+#else
+#define DEFAULT_IDL_SETTING 0
+#endif
+
 template <typename CharT>
 struct testing_callbacks {
     _Fmt_align expected_alignment = _Fmt_align::_None;
@@ -962,7 +969,9 @@ void test() {
     test_zoned_time_formatter<char>();
     test_zoned_time_formatter<wchar_t>();
 
+#if !defined(_DLL) || _ITERATOR_DEBUG_LEVEL == DEFAULT_IDL_SETTING
     test_locale();
+#endif // !defined(_DLL) || _ITERATOR_DEBUG_LEVEL == DEFAULT_IDL_SETTING
 }
 
 int main() {

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
@@ -892,9 +892,10 @@ void test_zoned_time_formatter() {
     assert(format(STR("{:%g %G %U %V %W}"), zt) == STR("21 2021 16 16 16"));
 }
 
+template <typename CharT>
 void test_locale() {
-    assert(format(locale{"zh-CN"}, L"{:^22%Y %B %d %A}", 2021y / June / 16d)
-           == L" 2021 \u516D\u6708 16 \u661F\u671F\u4E09  ");
+    assert(format(locale{"zh-CN"}, STR("{:^22%Y %B %d %A}"), 2021y / June / 16d)
+           == STR(" 2021 \u516D\u6708 16 \u661F\u671F\u4E09  "));
 }
 
 void test() {
@@ -970,7 +971,11 @@ void test() {
     test_zoned_time_formatter<wchar_t>();
 
 #if !defined(_DLL) || _ITERATOR_DEBUG_LEVEL == DEFAULT_IDL_SETTING
-    test_locale();
+    test_locale<wchar_t>();
+#ifndef MSVC_INTERNAL_TESTING // TRANSITION, the Windows version on Contest VMs doesn't always understand ".UTF-8"
+    setlocale(LC_ALL, ".UTF-8");
+    test_locale<char>();
+#endif // MSVC_INTERNAL_TESTING
 #endif // !defined(_DLL) || _ITERATOR_DEBUG_LEVEL == DEFAULT_IDL_SETTING
 }
 

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
@@ -6,6 +6,7 @@
 #include <concepts>
 #include <format>
 #include <iostream>
+#include <locale>
 #include <sstream>
 #include <stdio.h>
 #include <string>
@@ -884,6 +885,11 @@ void test_zoned_time_formatter() {
     assert(format(STR("{:%g %G %U %V %W}"), zt) == STR("21 2021 16 16 16"));
 }
 
+void test_locale() {
+    assert(format(locale{"zh-CN"}, L"{:^22%Y %B %d %A}", 2021y / June / 16d)
+           == L" 2021 \u516D\u6708 16 \u661F\u671F\u4E09  ");
+}
+
 void test() {
     test_parse_conversion_spec<char>();
     test_parse_conversion_spec<wchar_t>();
@@ -955,6 +961,8 @@ void test() {
 
     test_zoned_time_formatter<char>();
     test_zoned_time_formatter<wchar_t>();
+
+    test_locale();
 }
 
 int main() {


### PR DESCRIPTION
Fixes #2002.