### PR TITLE
Adapt some return statements to P2266R1 "Simpler implicit move"

### DIFF
--- a/stl/inc/string
+++ b/stl/inc/string
@@ -63,7 +63,7 @@ basic_istream<_Elem, _Traits>& getline(basic_istream<_Elem, _Traits>&& _Istr,
     }
 
     _Istr.setstate(_State);
-    return _Istr;
+    return static_cast<basic_istream<_Elem, _Traits>&>(_Istr);
 }
 
 template <class _Elem, class _Traits, class _Alloc>

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -4968,7 +4968,7 @@ basic_istream<_Elem, _Traits>& operator>>(
     }
 
     _Istr.setstate(_State);
-    return _Istr;
+    return static_cast<basic_istream<_Elem, _Traits>&>(_Istr);
 }
 
 template <class _Elem, class _Traits, class _Alloc>


### PR DESCRIPTION
...as implemented by Clang 13 trunk in C++23 mode (see
<https://reviews.llvm.org/D99005> "[clang] Implement P2266 Simpler implicit
move").  These are the two issues I came across when building LibreOffice with
clang-cl; there may be more such issues across STL:

> ```
> In file included from C:/lo-clang/core/setup_native/source/win32/customactions/reg_dlls/reg_dlls.cxx:12:
> C:/PROGRA~2/MIB055~1/2019/COMMUN~1/VC/Tools/MSVC/1429~1.300/Include\string(66,12): error: non-const lvalue reference to type 'basic_istream<...>' cannot bind to a temporary of type 'basic_istream<...>'
>     return _Istr;
>            ^~~~~
> C:/PROGRA~2/MIB055~1/2019/COMMUN~1/VC/Tools/MSVC/1429~1.300/Include\string(78,12): note: in instantiation of function template specialization 'std::getline<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t>>' requested here
>     return getline(_STD move(_Istr), _Str, _Delim);
>            ^
> C:/lo-clang/core/setup_native/source/win32/customactions/reg_dlls/reg_dlls.cxx(197,17): note: in instantiation of function template specialization 'std::getline<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t>>' requested here
>     while (std::getline(ss, sToken, L'|'))
>                 ^
> ```

and

> ```
> In file included from C:/lo-clang/core/l10ntools/source/merge.cxx:21:
> In file included from C:/lo-clang/core/include\sal/log.hxx:20:
> In file included from C:/PROGRA~2/MIB055~1/2019/COMMUN~1/VC/Tools/MSVC/1429~1.300/Include\sstream:11:
> In file included from C:/PROGRA~2/MIB055~1/2019/COMMUN~1/VC/Tools/MSVC/1429~1.300/Include\istream:11:
> In file included from C:/PROGRA~2/MIB055~1/2019/COMMUN~1/VC/Tools/MSVC/1429~1.300/Include\ostream:11:
> In file included from C:/PROGRA~2/MIB055~1/2019/COMMUN~1/VC/Tools/MSVC/1429~1.300/Include\ios:11:
> In file included from C:/PROGRA~2/MIB055~1/2019/COMMUN~1/VC/Tools/MSVC/1429~1.300/Include\xlocnum:16:
> In file included from C:/PROGRA~2/MIB055~1/2019/COMMUN~1/VC/Tools/MSVC/1429~1.300/Include\streambuf:11:
> In file included from C:/PROGRA~2/MIB055~1/2019/COMMUN~1/VC/Tools/MSVC/1429~1.300/Include\xiosbase:12:
> In file included from C:/PROGRA~2/MIB055~1/2019/COMMUN~1/VC/Tools/MSVC/1429~1.300/Include\system_error:14:
> In file included from C:/PROGRA~2/MIB055~1/2019/COMMUN~1/VC/Tools/MSVC/1429~1.300/Include\stdexcept:12:
> C:/PROGRA~2/MIB055~1/2019/COMMUN~1/VC/Tools/MSVC/1429~1.300/Include\xstring(4971,12): error: non-const lvalue reference to type 'basic_istream<...>' cannot bind to a temporary of type 'basic_istream<...>'
>     return _Istr;
>            ^~~~~
> C:/PROGRA~2/MIB055~1/2019/COMMUN~1/VC/Tools/MSVC/1429~1.300/Include\xstring(4977,29): note: in instantiation of function template specialization 'std::operator>><char, std::char_traits<char>, std::allocator<char>>' requested here
>     return _STD move(_Istr) >> _Str;
>                             ^
> C:/lo-clang/core/l10ntools/source/merge.cxx(125,18): note: in instantiation of function template specialization 'std::operator>><char, std::char_traits<char>, std::allocator<char>>' requested here
>     aInputStream >> sPoFile;
>                  ^
> ```
