### PR TITLE
`<format>`/`<chrono>`: Remove `<array>` dependency.

### DIFF
--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -5967,7 +5967,8 @@ namespace chrono {
 
                     _Validate_specifiers(_Spec, _Val);
 
-                    _Stream << _STD put_time<_CharT>(&_Time, _Fmt_string(_Spec).data());
+                    _CharT _Fmt_str[4];
+                    _Stream << _STD put_time<_CharT>(&_Time, _Fmt_string(_Spec, _Fmt_str));
                 }
             }
 
@@ -6029,7 +6030,8 @@ namespace chrono {
                     }
 
                     const char _Gregorian_type = _Spec._Type == 'g' ? 'y' : 'Y';
-                    _Os << _STD put_time(&_Time, _Fmt_string({._Type = _Gregorian_type}).data());
+                    _CharT _Fmt_str[4];
+                    _Os << _STD put_time(&_Time, _Fmt_string({._Type = _Gregorian_type}, _Fmt_str));
                     return true;
                 }
 
@@ -6291,14 +6293,14 @@ namespace chrono {
             }
         }
 
-        _NODISCARD static basic_string<_CharT> _Fmt_string(const _Chrono_spec<_CharT>& _Spec) {
-            basic_string<_CharT> _Fmt_str(4, '\0');
+        _NODISCARD static _CharT* _Fmt_string(const _Chrono_spec<_CharT>& _Spec, _CharT* _Fmt_str) {
             size_t _Next_idx      = 0;
             _Fmt_str[_Next_idx++] = _CharT{'%'};
             if (_Spec._Modifier != '\0') {
                 _Fmt_str[_Next_idx++] = static_cast<_CharT>(_Spec._Modifier);
             }
-            _Fmt_str[_Next_idx] = static_cast<_CharT>(_Spec._Type);
+            _Fmt_str[_Next_idx++] = static_cast<_CharT>(_Spec._Type);
+            _Fmt_str[_Next_idx]   = _CharT{'\0'};
             return _Fmt_str;
         }
 

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -6293,7 +6293,7 @@ namespace chrono {
             }
         }
 
-        _NODISCARD static _CharT* _Fmt_string(const _Chrono_spec<_CharT>& _Spec, _CharT* _Fmt_str) {
+        _NODISCARD static const _CharT* _Fmt_string(const _Chrono_spec<_CharT>& _Spec, _CharT (&_Fmt_str)[4]) {
             size_t _Next_idx      = 0;
             _Fmt_str[_Next_idx++] = _CharT{'%'};
             if (_Spec._Modifier != '\0') {

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -35,6 +35,7 @@
 #endif // defined(__cpp_lib_concepts)
 
 #ifdef __cpp_lib_format
+#include <array>
 #include <format>
 #include <iomanip>
 #endif // defined(__cpp_lib_format)

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -35,7 +35,6 @@
 #endif // defined(__cpp_lib_concepts)
 
 #ifdef __cpp_lib_format
-#include <array>
 #include <format>
 #include <iomanip>
 #endif // defined(__cpp_lib_format)
@@ -6292,15 +6291,14 @@ namespace chrono {
             }
         }
 
-        _NODISCARD static array<_CharT, 4> _Fmt_string(const _Chrono_spec<_CharT>& _Spec) {
-            array<_CharT, 4> _Fmt_str;
+        _NODISCARD static basic_string<_CharT> _Fmt_string(const _Chrono_spec<_CharT>& _Spec) {
+            basic_string<_CharT> _Fmt_str(4, '\0');
             size_t _Next_idx      = 0;
             _Fmt_str[_Next_idx++] = _CharT{'%'};
             if (_Spec._Modifier != '\0') {
                 _Fmt_str[_Next_idx++] = static_cast<_CharT>(_Spec._Modifier);
             }
-            _Fmt_str[_Next_idx++] = static_cast<_CharT>(_Spec._Type);
-            _Fmt_str[_Next_idx]   = _CharT{'\0'};
+            _Fmt_str[_Next_idx] = static_cast<_CharT>(_Spec._Type);
             return _Fmt_str;
         }
 

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -1871,8 +1871,7 @@ template <class _CharT, class _OutputIt>
 _NODISCARD _OutputIt _Fmt_write(_OutputIt _Out, const void* const _Value) {
     // TRANSITION, Reusable buffer
     char _Buffer[_Format_min_buffer_length];
-    const auto [_End, _Ec] =
-        _STD to_chars(_Buffer, _STD end(_Buffer), reinterpret_cast<uintptr_t>(_Value), 16);
+    const auto [_End, _Ec] = _STD to_chars(_Buffer, _STD end(_Buffer), reinterpret_cast<uintptr_t>(_Value), 16);
     _STL_ASSERT(_Ec == errc{}, "to_chars failed");
     *_Out++ = '0';
     *_Out++ = 'x';

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -1844,9 +1844,9 @@ _NODISCARD _OutputIt _Fmt_write(_OutputIt _Out, const _Arithmetic _Value) {
     // clang-format on
     // TRANSITION, Reusable buffer
     char _Buffer[_Format_min_buffer_length];
-    const auto [_End, _Ec] = _STD to_chars(_Buffer, _Buffer + _Format_min_buffer_length, _Value);
+    const auto [_End, _Ec] = _STD to_chars(_STD begin(_Buffer), _STD end(_Buffer), _Value);
     _STL_ASSERT(_Ec == errc{}, "to_chars failed");
-    return _RANGES _Copy_unchecked(_Buffer, _End, _STD move(_Out)).out;
+    return _RANGES _Copy_unchecked(_STD begin(_Buffer), _End, _STD move(_Out)).out;
 }
 #pragma warning(pop)
 
@@ -1872,11 +1872,11 @@ _NODISCARD _OutputIt _Fmt_write(_OutputIt _Out, const void* const _Value) {
     // TRANSITION, Reusable buffer
     char _Buffer[_Format_min_buffer_length];
     const auto [_End, _Ec] =
-        _STD to_chars(_Buffer, _Buffer + _Format_min_buffer_length, reinterpret_cast<uintptr_t>(_Value), 16);
+        _STD to_chars(_STD begin(_Buffer), _STD end(_Buffer), reinterpret_cast<uintptr_t>(_Value), 16);
     _STL_ASSERT(_Ec == errc{}, "to_chars failed");
     *_Out++ = '0';
     *_Out++ = 'x';
-    return _RANGES _Copy_unchecked(_Buffer, _End, _STD move(_Out)).out;
+    return _RANGES _Copy_unchecked(_STD begin(_Buffer), _End, _STD move(_Out)).out;
 }
 #pragma warning(pop)
 
@@ -2137,12 +2137,11 @@ _NODISCARD _OutputIt _Write_integral(
     }
 
     // long long -1 representation in binary is 64 bits + sign
-    constexpr auto _Buffer_size = 65;
-    char _Buffer[_Buffer_size];
-    const auto [_End, _Ec] = _STD to_chars(_Buffer, _Buffer + _Buffer_size, _Value, _Base);
+    char _Buffer[65];
+    const auto [_End, _Ec] = _STD to_chars(_STD begin(_Buffer), _STD end(_Buffer), _Value, _Base);
     _STL_ASSERT(_Ec == errc{}, "to_chars failed");
 
-    auto _Buffer_start = _Buffer;
+    auto _Buffer_start = _STD begin(_Buffer);
     auto _Width        = static_cast<int>(_End - _Buffer_start);
 
     if (_Value >= _Integral{0}) {
@@ -2336,14 +2335,14 @@ _NODISCARD _OutputIt _Fmt_write(
     }
 
     if (_Precision == -1) {
-        _Result = _STD to_chars(_Buffer, _Buffer + _Buffer_size, _Value, _Format);
+        _Result = _STD to_chars(_STD begin(_Buffer), _STD end(_Buffer), _Value, _Format);
     } else {
-        _Result = _STD to_chars(_Buffer, _Buffer + _Buffer_size, _Value, _Format, _Precision);
+        _Result = _STD to_chars(_STD begin(_Buffer), _STD end(_Buffer), _Value, _Format, _Precision);
     }
 
     _STL_ASSERT(_Result.ec == errc{}, "to_chars failed");
 
-    auto _Buffer_start = _Buffer;
+    auto _Buffer_start = _STD begin(_Buffer);
     auto _Width        = static_cast<int>(_Result.ptr - _Buffer_start);
 
     const auto _Is_negative = (_STD signbit)(_Value);

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -44,7 +44,6 @@
 #pragma message("see https://github.com/microsoft/STL/issues/1814 for details.")
 #else // ^^^ !defined(__cpp_lib_format) / defined(__cpp_lib_format) vvv
 
-#include <array>
 #include <charconv>
 #include <concepts>
 #include <cstdint>
@@ -1844,10 +1843,10 @@ template <class _CharT, class _OutputIt, class _Arithmetic>
 _NODISCARD _OutputIt _Fmt_write(_OutputIt _Out, const _Arithmetic _Value) {
     // clang-format on
     // TRANSITION, Reusable buffer
-    array<char, _Format_min_buffer_length> _Buffer;
-    const auto [_End, _Ec] = _STD to_chars(_Buffer.data(), _Buffer.data() + _Buffer.size(), _Value);
+    char _Buffer[_Format_min_buffer_length];
+    const auto [_End, _Ec] = _STD to_chars(_Buffer, _Buffer + _Format_min_buffer_length, _Value);
     _STL_ASSERT(_Ec == errc{}, "to_chars failed");
-    return _RANGES _Copy_unchecked(_Buffer.data(), _End, _STD move(_Out)).out;
+    return _RANGES _Copy_unchecked(_Buffer, _End, _STD move(_Out)).out;
 }
 #pragma warning(pop)
 
@@ -1871,13 +1870,13 @@ _NODISCARD _OutputIt _Fmt_write(_OutputIt _Out, const _CharT _Value) {
 template <class _CharT, class _OutputIt>
 _NODISCARD _OutputIt _Fmt_write(_OutputIt _Out, const void* const _Value) {
     // TRANSITION, Reusable buffer
-    array<char, _Format_min_buffer_length> _Buffer;
+    char _Buffer[_Format_min_buffer_length];
     const auto [_End, _Ec] =
-        _STD to_chars(_Buffer.data(), _Buffer.data() + _Buffer.size(), reinterpret_cast<uintptr_t>(_Value), 16);
+        _STD to_chars(_Buffer, _Buffer + _Format_min_buffer_length, reinterpret_cast<uintptr_t>(_Value), 16);
     _STL_ASSERT(_Ec == errc{}, "to_chars failed");
     *_Out++ = '0';
     *_Out++ = 'x';
-    return _RANGES _Copy_unchecked(_Buffer.data(), _End, _STD move(_Out)).out;
+    return _RANGES _Copy_unchecked(_Buffer, _End, _STD move(_Out)).out;
 }
 #pragma warning(pop)
 
@@ -2138,11 +2137,12 @@ _NODISCARD _OutputIt _Write_integral(
     }
 
     // long long -1 representation in binary is 64 bits + sign
-    array<char, 65> _Buffer;
-    const auto [_End, _Ec] = _STD to_chars(_Buffer.data(), _Buffer.data() + _Buffer.size(), _Value, _Base);
+    constexpr auto _Buffer_size = 65;
+    char _Buffer[_Buffer_size];
+    const auto [_End, _Ec] = _STD to_chars(_Buffer, _Buffer + _Buffer_size, _Value, _Base);
     _STL_ASSERT(_Ec == errc{}, "to_chars failed");
 
-    auto _Buffer_start = _Buffer.data();
+    auto _Buffer_start = _Buffer;
     auto _Width        = static_cast<int>(_End - _Buffer_start);
 
     if (_Value >= _Integral{0}) {
@@ -2326,7 +2326,7 @@ _NODISCARD _OutputIt _Fmt_write(
     // We need to add an additional number to the max exponent to accommodate the ones place.
     constexpr auto _Max_precision = 1074;
     constexpr auto _Buffer_size   = _Max_precision + DBL_MAX_10_EXP + 3;
-    array<char, _Buffer_size> _Buffer;
+    char _Buffer[_Buffer_size];
     to_chars_result _Result;
 
     auto _Extra_precision = 0;
@@ -2336,14 +2336,14 @@ _NODISCARD _OutputIt _Fmt_write(
     }
 
     if (_Precision == -1) {
-        _Result = _STD to_chars(_Buffer.data(), _Buffer.data() + _Buffer.size(), _Value, _Format);
+        _Result = _STD to_chars(_Buffer, _Buffer + _Buffer_size, _Value, _Format);
     } else {
-        _Result = _STD to_chars(_Buffer.data(), _Buffer.data() + _Buffer.size(), _Value, _Format, _Precision);
+        _Result = _STD to_chars(_Buffer, _Buffer + _Buffer_size, _Value, _Format, _Precision);
     }
 
     _STL_ASSERT(_Result.ec == errc{}, "to_chars failed");
 
-    auto _Buffer_start = _Buffer.data();
+    auto _Buffer_start = _Buffer;
     auto _Width        = static_cast<int>(_Result.ptr - _Buffer_start);
 
     const auto _Is_negative = (_STD signbit)(_Value);

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -1844,9 +1844,9 @@ _NODISCARD _OutputIt _Fmt_write(_OutputIt _Out, const _Arithmetic _Value) {
     // clang-format on
     // TRANSITION, Reusable buffer
     char _Buffer[_Format_min_buffer_length];
-    const auto [_End, _Ec] = _STD to_chars(_STD begin(_Buffer), _STD end(_Buffer), _Value);
+    const auto [_End, _Ec] = _STD to_chars(_Buffer, _STD end(_Buffer), _Value);
     _STL_ASSERT(_Ec == errc{}, "to_chars failed");
-    return _RANGES _Copy_unchecked(_STD begin(_Buffer), _End, _STD move(_Out)).out;
+    return _RANGES _Copy_unchecked(_Buffer, _End, _STD move(_Out)).out;
 }
 #pragma warning(pop)
 
@@ -1872,11 +1872,11 @@ _NODISCARD _OutputIt _Fmt_write(_OutputIt _Out, const void* const _Value) {
     // TRANSITION, Reusable buffer
     char _Buffer[_Format_min_buffer_length];
     const auto [_End, _Ec] =
-        _STD to_chars(_STD begin(_Buffer), _STD end(_Buffer), reinterpret_cast<uintptr_t>(_Value), 16);
+        _STD to_chars(_Buffer, _STD end(_Buffer), reinterpret_cast<uintptr_t>(_Value), 16);
     _STL_ASSERT(_Ec == errc{}, "to_chars failed");
     *_Out++ = '0';
     *_Out++ = 'x';
-    return _RANGES _Copy_unchecked(_STD begin(_Buffer), _End, _STD move(_Out)).out;
+    return _RANGES _Copy_unchecked(_Buffer, _End, _STD move(_Out)).out;
 }
 #pragma warning(pop)
 
@@ -2138,10 +2138,10 @@ _NODISCARD _OutputIt _Write_integral(
 
     // long long -1 representation in binary is 64 bits + sign
     char _Buffer[65];
-    const auto [_End, _Ec] = _STD to_chars(_STD begin(_Buffer), _STD end(_Buffer), _Value, _Base);
+    const auto [_End, _Ec] = _STD to_chars(_Buffer, _STD end(_Buffer), _Value, _Base);
     _STL_ASSERT(_Ec == errc{}, "to_chars failed");
 
-    auto _Buffer_start = _STD begin(_Buffer);
+    auto _Buffer_start = _Buffer;
     auto _Width        = static_cast<int>(_End - _Buffer_start);
 
     if (_Value >= _Integral{0}) {
@@ -2335,14 +2335,14 @@ _NODISCARD _OutputIt _Fmt_write(
     }
 
     if (_Precision == -1) {
-        _Result = _STD to_chars(_STD begin(_Buffer), _STD end(_Buffer), _Value, _Format);
+        _Result = _STD to_chars(_Buffer, _STD end(_Buffer), _Value, _Format);
     } else {
-        _Result = _STD to_chars(_STD begin(_Buffer), _STD end(_Buffer), _Value, _Format, _Precision);
+        _Result = _STD to_chars(_Buffer, _STD end(_Buffer), _Value, _Format, _Precision);
     }
 
     _STL_ASSERT(_Result.ec == errc{}, "to_chars failed");
 
-    auto _Buffer_start = _STD begin(_Buffer);
+    auto _Buffer_start = _Buffer;
     auto _Width        = static_cast<int>(_Result.ptr - _Buffer_start);
 
     const auto _Is_negative = (_STD signbit)(_Value);


### PR DESCRIPTION
This removes `<array>` header dependency from the `<format>`.
Closes #2027.