### PR TITLE
`<bit>`: `bit_ceil`(T(-1)) is not a constant expression

### DIFF
--- a/stl/inc/bit
+++ b/stl/inc/bit
@@ -54,11 +54,11 @@ _NODISCARD constexpr _Ty bit_ceil(const _Ty _Val) noexcept /* strengthened */ {
             return _Ty{1} << _Num;
         } else { // for types subject to integral promotion
             constexpr int _Offset_for_ub = numeric_limits<unsigned int>::digits - numeric_limits<_Ty>::digits;
-            return _Ty(1u << (_Num + _Offset_for_ub) >> _Offset_for_ub);
+            return static_cast<_Ty>(1u << (_Num + _Offset_for_ub) >> _Offset_for_ub);
         }
     }
 
-    return _Ty(_Ty{1} << _Num);
+    return static_cast<_Ty>(_Ty{1} << _Num);
 }
 
 template <class _Ty, enable_if_t<_Is_standard_unsigned_integer<_Ty>, int> = 0>

--- a/stl/inc/bit
+++ b/stl/inc/bit
@@ -44,11 +44,17 @@ _NODISCARD constexpr bool has_single_bit(const _Ty _Val) noexcept {
 
 template <class _Ty, enable_if_t<_Is_standard_unsigned_integer<_Ty>, int> = 0>
 _NODISCARD constexpr _Ty bit_ceil(const _Ty _Val) noexcept /* strengthened */ {
-    if (_Val == 0) {
-        return 1;
+    if (_Val <= 1u) {
+        return _Ty{1};
     }
 
-    return static_cast<_Ty>(_Ty{1} << (numeric_limits<_Ty>::digits - _STD countl_zero(static_cast<_Ty>(_Val - 1))));
+    const int _Num = numeric_limits<_Ty>::digits - _STD countl_zero(static_cast<_Ty>(_Val - 1));
+    if constexpr (sizeof(_Ty) >= sizeof(unsigned int)) {
+        return _Ty{1} << _Num;
+    } else { // for types subject to integral promotion
+        constexpr int _Offset_for_ub = numeric_limits<unsigned int>::digits - numeric_limits<_Ty>::digits;
+        return _Ty(1u << (_Num + _Offset_for_ub) >> _Offset_for_ub);
+    }
 }
 
 template <class _Ty, enable_if_t<_Is_standard_unsigned_integer<_Ty>, int> = 0>

--- a/stl/inc/bit
+++ b/stl/inc/bit
@@ -49,9 +49,8 @@ _NODISCARD constexpr _Ty bit_ceil(const _Ty _Val) noexcept /* strengthened */ {
     }
 
     const int _Num = numeric_limits<_Ty>::digits - _STD countl_zero(static_cast<_Ty>(_Val - 1));
-    if constexpr (sizeof(_Ty) >= sizeof(unsigned int)) {
-        return _Ty{1} << _Num;
-    } else { // for types subject to integral promotion
+
+    if constexpr (sizeof(_Ty) < sizeof(unsigned int)) { // for types subject to integral promotion
         if (_STD is_constant_evaluated()) {
             // because https://en.cppreference.com/w/cpp/language/implicit_conversion#Integral_promotion
             // the compiler will not generate a compile time error for
@@ -61,10 +60,10 @@ _NODISCARD constexpr _Ty bit_ceil(const _Ty _Val) noexcept /* strengthened */ {
             // so we do conversions to work with the "unsigned int" type, for which the compiler will generate errors
             constexpr int _Offset_for_ub = numeric_limits<unsigned int>::digits - numeric_limits<_Ty>::digits;
             return static_cast<_Ty>(1u << (_Num + _Offset_for_ub) >> _Offset_for_ub);
-        } else {
-            return static_cast<_Ty>(_Ty{1} << _Num);
         }
     }
+
+    return static_cast<_Ty>(_Ty{1} << _Num);
 }
 
 template <class _Ty, enable_if_t<_Is_standard_unsigned_integer<_Ty>, int> = 0>

--- a/stl/inc/bit
+++ b/stl/inc/bit
@@ -49,12 +49,16 @@ _NODISCARD constexpr _Ty bit_ceil(const _Ty _Val) noexcept /* strengthened */ {
     }
 
     const int _Num = numeric_limits<_Ty>::digits - _STD countl_zero(static_cast<_Ty>(_Val - 1));
-    if constexpr (sizeof(_Ty) >= sizeof(unsigned int)) {
-        return _Ty{1} << _Num;
-    } else { // for types subject to integral promotion
-        constexpr int _Offset_for_ub = numeric_limits<unsigned int>::digits - numeric_limits<_Ty>::digits;
-        return _Ty(1u << (_Num + _Offset_for_ub) >> _Offset_for_ub);
+    if (_STD is_constant_evaluated()) {
+        if constexpr (sizeof(_Ty) >= sizeof(unsigned int)) {
+            return _Ty{1} << _Num;
+        } else { // for types subject to integral promotion
+            constexpr int _Offset_for_ub = numeric_limits<unsigned int>::digits - numeric_limits<_Ty>::digits;
+            return _Ty(1u << (_Num + _Offset_for_ub) >> _Offset_for_ub);
+        }
     }
+
+    return _Ty(_Ty{1} << _Num);
 }
 
 template <class _Ty, enable_if_t<_Is_standard_unsigned_integer<_Ty>, int> = 0>

--- a/stl/inc/bit
+++ b/stl/inc/bit
@@ -49,16 +49,16 @@ _NODISCARD constexpr _Ty bit_ceil(const _Ty _Val) noexcept /* strengthened */ {
     }
 
     const int _Num = numeric_limits<_Ty>::digits - _STD countl_zero(static_cast<_Ty>(_Val - 1));
-    if (_STD is_constant_evaluated()) {
-        if constexpr (sizeof(_Ty) >= sizeof(unsigned int)) {
-            return _Ty{1} << _Num;
-        } else { // for types subject to integral promotion
+    if constexpr (sizeof(_Ty) >= sizeof(unsigned int)) {
+        return _Ty{1} << _Num;
+    } else { // for types subject to integral promotion
+        if (_STD is_constant_evaluated()) {
             constexpr int _Offset_for_ub = numeric_limits<unsigned int>::digits - numeric_limits<_Ty>::digits;
             return static_cast<_Ty>(1u << (_Num + _Offset_for_ub) >> _Offset_for_ub);
+        } else {
+            return static_cast<_Ty>(_Ty{1} << _Num);
         }
     }
-
-    return static_cast<_Ty>(_Ty{1} << _Num);
 }
 
 template <class _Ty, enable_if_t<_Is_standard_unsigned_integer<_Ty>, int> = 0>

--- a/stl/inc/bit
+++ b/stl/inc/bit
@@ -52,12 +52,15 @@ _NODISCARD constexpr _Ty bit_ceil(const _Ty _Val) noexcept /* strengthened */ {
 
     if constexpr (sizeof(_Ty) < sizeof(unsigned int)) { // for types subject to integral promotion
         if (_STD is_constant_evaluated()) {
-            // because https://en.cppreference.com/w/cpp/language/implicit_conversion#Integral_promotion
+            // Because N4892 [expr.shift]/1 "integral promotions are performed"
             // the compiler will not generate a compile time error for
             // uint8_t{1} << 8
             // or
             // uint16_t{1} << 16
-            // so we do conversions to work with the "unsigned int" type, for which the compiler will generate errors
+            // so we must manually enforce N4892 [bit.pow.two]/5, 8:
+            // "Preconditions: N is representable as a value of type T."
+            // "Remarks: A function call expression that violates the precondition in the Preconditions: element
+            // is not a core constant expression (7.7)."
             constexpr int _Offset_for_ub = numeric_limits<unsigned int>::digits - numeric_limits<_Ty>::digits;
             return static_cast<_Ty>(1u << (_Num + _Offset_for_ub) >> _Offset_for_ub);
         }

--- a/stl/inc/bit
+++ b/stl/inc/bit
@@ -53,6 +53,12 @@ _NODISCARD constexpr _Ty bit_ceil(const _Ty _Val) noexcept /* strengthened */ {
         return _Ty{1} << _Num;
     } else { // for types subject to integral promotion
         if (_STD is_constant_evaluated()) {
+            // because https://en.cppreference.com/w/cpp/language/implicit_conversion#Integral_promotion
+            // the compiler will not generate a compile time error for
+            // uint8_t{1} << 8
+            // or
+            // uint16_t{1} << 16
+            // so we do conversions to work with the "unsigned int" type, for which the compiler will generate errors
             constexpr int _Offset_for_ub = numeric_limits<unsigned int>::digits - numeric_limits<_Ty>::digits;
             return static_cast<_Ty>(1u << (_Num + _Offset_for_ub) >> _Offset_for_ub);
         } else {

--- a/stl/inc/bit
+++ b/stl/inc/bit
@@ -42,6 +42,8 @@ _NODISCARD constexpr bool has_single_bit(const _Ty _Val) noexcept {
     return _Val != 0 && (_Val & (_Val - 1)) == 0;
 }
 
+inline void _Precondition_violation_in_bit_ceil() noexcept {}
+
 template <class _Ty, enable_if_t<_Is_standard_unsigned_integer<_Ty>, int> = 0>
 _NODISCARD constexpr _Ty bit_ceil(const _Ty _Val) noexcept /* strengthened */ {
     if (_Val <= 1u) {
@@ -61,8 +63,9 @@ _NODISCARD constexpr _Ty bit_ceil(const _Ty _Val) noexcept /* strengthened */ {
             // "Preconditions: N is representable as a value of type T."
             // "Remarks: A function call expression that violates the precondition in the Preconditions: element
             // is not a core constant expression (7.7)."
-            constexpr int _Offset_for_ub = numeric_limits<unsigned int>::digits - numeric_limits<_Ty>::digits;
-            return static_cast<_Ty>(1u << (_Num + _Offset_for_ub) >> _Offset_for_ub);
+            if (_Num == numeric_limits<_Ty>::digits) {
+                _Precondition_violation_in_bit_ceil();
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #1595 

https://gcc.godbolt.org/z/68MGqPG8z

`bit_ceil.fail.cpp` is already unskipped.

https://github.com/microsoft/STL/pull/1920/files#diff-cc6f92924b9b137833cf021a8871d88049f0dd2268a6c2749a734c81503f6cf7L435-L437