### PR TITLE
Extend `swap_ranges` vectorization

### DIFF
--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -2847,6 +2847,40 @@ namespace ranges {
             _STL_INTERNAL_STATIC_ASSERT(sentinel_for<_Se2, _It2>);
             _STL_INTERNAL_STATIC_ASSERT(indirectly_swappable<_It1, _It2>);
 
+#if _USE_STD_VECTOR_ALGORITHMS
+            using _Elem1 = remove_reference_t<iter_reference_t<_It1>>;
+            using _Elem2 = remove_reference_t<iter_reference_t<_It2>>;
+            if constexpr (same_as<_Elem1, _Elem2> && _Is_trivially_swappable_v<_Elem1> && //
+                          contiguous_iterator<_It1> && _Sized_or_unreachable_sentinel_for<_Se1, _It1> && //
+                          contiguous_iterator<_It2> && _Sized_or_unreachable_sentinel_for<_Se2, _It2>) {
+                if (!_STD is_constant_evaluated()) {
+                    constexpr bool _Is_sized1 = sized_sentinel_for<_Se1, _It1>;
+                    constexpr bool _Is_sized2 = sized_sentinel_for<_Se2, _It2>;
+                    const auto _First1_addr   = _STD to_address(_First1);
+                    const auto _First2_addr   = _STD to_address(_First2);
+                    if constexpr (_Is_sized1 && _Is_sized2) {
+                        const size_t _Count =
+                            (_STD min)(static_cast<size_t>(_Last1 - _First1), static_cast<size_t>(_Last2 - _First2));
+                        const auto _Last1_addr = _First1_addr + _Count;
+                        __std_swap_ranges_trivially_swappable_noalias(_First1_addr, _Last1_addr, _First2_addr);
+                        return {_First1 + _Count, _First2 + _Count};
+                    } else if constexpr (_Is_sized1) {
+                        const auto _Final1     = _RANGES next(_First1, _Last1);
+                        const auto _Last1_addr = _STD to_address(_Final1);
+                        __std_swap_ranges_trivially_swappable_noalias(_First1_addr, _Last1_addr, _First2_addr);
+                        return {_Final1, _First2 + (_Last1 - _First1)};
+                    } else if constexpr (_Is_sized2) {
+                        const auto _Final2     = _RANGES next(_First2, _Last2);
+                        const auto _Last2_addr = _STD to_address(_Final2);
+                        __std_swap_ranges_trivially_swappable_noalias(_First2_addr, _Last2_addr, _First1_addr);
+                        return {_First1 + (_Last2 - _First2), _Final2};
+                    } else {
+                        _STL_ASSERT(false, "Tried to swap_ranges with two unreachable sentinels");
+                    }
+                }
+            }
+#endif // _USE_STD_VECTOR_ALGORITHMS
+
             for (; _First1 != _Last1 && _First2 != _Last2; ++_First1, (void) ++_First2) {
                 _RANGES iter_swap(_First1, _First2);
             }

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -2860,7 +2860,7 @@ namespace ranges {
                     const auto _First2_addr   = _STD to_address(_First2);
                     if constexpr (_Is_sized1 && _Is_sized2) {
                         const size_t _Count =
-                            (_STD min)(static_cast<size_t>(_Last1 - _First1), static_cast<size_t>(_Last2 - _First2));
+                            (_STD min) (static_cast<size_t>(_Last1 - _First1), static_cast<size_t>(_Last2 - _First2));
                         const auto _Last1_addr = _First1_addr + _Count;
                         __std_swap_ranges_trivially_swappable_noalias(_First1_addr, _Last1_addr, _First2_addr);
                         return {_First1 + _Count, _First2 + _Count};

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -2850,9 +2850,9 @@ namespace ranges {
 #if _USE_STD_VECTOR_ALGORITHMS
             using _Elem1 = remove_reference_t<iter_reference_t<_It1>>;
             using _Elem2 = remove_reference_t<iter_reference_t<_It2>>;
-            if constexpr (same_as<_Elem1, _Elem2> && _Is_trivially_swappable_v<_Elem1> && //
-                          contiguous_iterator<_It1> && _Sized_or_unreachable_sentinel_for<_Se1, _It1> && //
-                          contiguous_iterator<_It2> && _Sized_or_unreachable_sentinel_for<_Se2, _It2>) {
+            if constexpr (same_as<_Elem1, _Elem2> && _Is_trivially_swappable_v<_Elem1> //
+                          && contiguous_iterator<_It1> && _Sized_or_unreachable_sentinel_for<_Se1, _It1> //
+                          && contiguous_iterator<_It2> && _Sized_or_unreachable_sentinel_for<_Se2, _It2>) {
                 if (!_STD is_constant_evaluated()) {
                     constexpr bool _Is_sized1 = sized_sentinel_for<_Se1, _It1>;
                     constexpr bool _Is_sized2 = sized_sentinel_for<_Se2, _It2>;

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -5808,32 +5808,30 @@ _NODISCARD _CONSTEXPR20 _FwdIt lower_bound(_FwdIt _First, _FwdIt _Last, const _T
 // FUNCTION TEMPLATE _Swap_ranges_unchecked
 template <class _FwdIt1, class _FwdIt2>
 _CONSTEXPR20 _FwdIt2 _Swap_ranges_unchecked(_FwdIt1 _First1, const _FwdIt1 _Last1, _FwdIt2 _First2) {
-    // swap [_First1, _Last1) with [_First2, ...), no special optimization
+    // swap [_First1, _Last1) with [_First2, ...)
+
+#if _USE_STD_VECTOR_ALGORITHMS
+    using _Elem1 = remove_reference_t<_Iter_ref_t<_FwdIt1>>;
+    using _Elem2 = remove_reference_t<_Iter_ref_t<_FwdIt2>>;
+    if constexpr (is_same_v<_Elem1, _Elem2> && _Is_trivially_swappable_v<_Elem1> && //
+                  _Iterators_are_contiguous<_FwdIt1, _FwdIt2>) {
+#ifdef __cpp_lib_is_constant_evaluated
+        if (!_STD is_constant_evaluated())
+#endif // __cpp_lib_is_constant_evaluated
+        {
+            __std_swap_ranges_trivially_swappable_noalias(
+                _To_address(_First1), _To_address(_Last1), _To_address(_First2));
+            return _First2 + (_Last1 - _First1);
+        }
+    }
+#endif // _USE_STD_VECTOR_ALGORITHMS
+
     for (; _First1 != _Last1; ++_First1, (void) ++_First2) {
         _STD iter_swap(_First1, _First2);
     }
 
     return _First2;
 }
-
-#if _USE_STD_VECTOR_ALGORITHMS
-template <class _Ty, enable_if_t<_Is_trivially_swappable_v<_Ty>, int> = 0>
-_CONSTEXPR20 _Ty* _Swap_ranges_unchecked(_Ty* _First1, _Ty* const _Last1, _Ty* _First2) {
-    // swap [_First1, _Last1) with [_First2, ...), trivially swappable optimization
-#ifdef __cpp_lib_is_constant_evaluated
-    if (_STD is_constant_evaluated()) {
-        for (; _First1 != _Last1; ++_First1, (void) ++_First2) {
-            _STD iter_swap(_First1, _First2);
-        }
-
-        return _First2;
-    }
-#endif // __cpp_lib_is_constant_evaluated
-
-    __std_swap_ranges_trivially_swappable_noalias(_First1, _Last1, _First2);
-    return _First2 + (_Last1 - _First1);
-}
-#endif // _USE_STD_VECTOR_ALGORITHMS
 
 // CLASS TEMPLATE _Rng_from_urng
 template <class _Diff, class _Urng>

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -5815,7 +5815,7 @@ _CONSTEXPR20 _FwdIt2 _Swap_ranges_unchecked(_FwdIt1 _First1, const _FwdIt1 _Last
     using _Elem2 = remove_reference_t<_Iter_ref_t<_FwdIt2>>;
     if constexpr (is_same_v<_Elem1, _Elem2> && _Is_trivially_swappable_v<_Elem1> && //
                   _Iterators_are_contiguous<_FwdIt1, _FwdIt2>) {
-#ifdef _HAS_CXX20
+#if _HAS_CXX20
         if (!_STD is_constant_evaluated())
 #endif // _HAS_CXX20
         {

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -5813,8 +5813,8 @@ _CONSTEXPR20 _FwdIt2 _Swap_ranges_unchecked(_FwdIt1 _First1, const _FwdIt1 _Last
 #if _USE_STD_VECTOR_ALGORITHMS
     using _Elem1 = remove_reference_t<_Iter_ref_t<_FwdIt1>>;
     using _Elem2 = remove_reference_t<_Iter_ref_t<_FwdIt2>>;
-    if constexpr (is_same_v<_Elem1, _Elem2> && _Is_trivially_swappable_v<_Elem1> && //
-                  _Iterators_are_contiguous<_FwdIt1, _FwdIt2>) {
+    if constexpr (is_same_v<_Elem1, _Elem2> && _Is_trivially_swappable_v<_Elem1> //
+                  && _Iterators_are_contiguous<_FwdIt1, _FwdIt2>) {
 #if _HAS_CXX20
         if (!_STD is_constant_evaluated())
 #endif // _HAS_CXX20

--- a/tests/std/tests/P0896R4_ranges_alg_swap_ranges/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_swap_ranges/test.cpp
@@ -95,6 +95,8 @@ constexpr void run_tests() {
     instantiator::call<test_range<bidi, ProxyRef::yes>, test_range<input, ProxyRef::yes>>();
     instantiator::call<test_range<random, ProxyRef::yes>, test_range<input, ProxyRef::yes>>();
     instantiator::call<test_range<contiguous, ProxyRef::no>, test_range<input, ProxyRef::yes>>();
+
+    instantiator::call<test_range<contiguous, ProxyRef::no>, test_range<contiguous, ProxyRef::no>>();
 }
 
 int main() {


### PR DESCRIPTION
Implements missing vectorization for `ranges::swap_ranges` and refactors `std::swap_ranges` to enable vectorization for all contiguous iterators.