### PR TITLE
Port internal msbuild changes for ARM64EC

### DIFF
--- a/stl/msbuild/stl_1/md/msvcp_1_netfx/msvcp_1.nativeproj
+++ b/stl/msbuild/stl_1/md/msvcp_1_netfx/msvcp_1.nativeproj
@@ -8,6 +8,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
     <PropertyGroup>
         <CrtBuildModel>md</CrtBuildModel>
         <MsvcpFlavor>netfx</MsvcpFlavor>
+        <Arm64X>true</Arm64X>
     </PropertyGroup>
 
     <Import Project="$(MSBuildThisFileDirectory)..\..\msvcp_1.settings.targets"/>

--- a/stl/msbuild/stl_1/stl_1.files.settings.targets
+++ b/stl/msbuild/stl_1/stl_1.files.settings.targets
@@ -28,7 +28,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
           <ExpectedExportsList>$(MSBuildThisFileDirectory)\i386.exports</ExpectedExportsList>
         </PropertyGroup>
       </When>
-      <When Condition="'$(BuildArchitecture)' == 'amd64'">
+      <When Condition="'$(BuildArchitecture)' == 'amd64' or '$(BuildArchitecture)' == 'arm64ec'">
         <PropertyGroup>
           <ExpectedExportsList>$(MSBuildThisFileDirectory)\amd64.exports</ExpectedExportsList>
         </PropertyGroup>

--- a/stl/msbuild/stl_1/xmd/msvcp_1_netfx/msvcp_1.nativeproj
+++ b/stl/msbuild/stl_1/xmd/msvcp_1_netfx/msvcp_1.nativeproj
@@ -8,6 +8,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
     <PropertyGroup>
         <CrtBuildModel>xmd</CrtBuildModel>
         <MsvcpFlavor>netfx</MsvcpFlavor>
+        <Arm64X>true</Arm64X>
     </PropertyGroup>
 
     <Import Project="$(MSBuildThisFileDirectory)..\..\msvcp_1.settings.targets"/>

--- a/stl/msbuild/stl_2/md/msvcp_2_netfx/msvcp_2.nativeproj
+++ b/stl/msbuild/stl_2/md/msvcp_2_netfx/msvcp_2.nativeproj
@@ -8,6 +8,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
     <PropertyGroup>
         <CrtBuildModel>md</CrtBuildModel>
         <MsvcpFlavor>netfx</MsvcpFlavor>
+        <Arm64X>true</Arm64X>
     </PropertyGroup>
 
     <Import Project="$(MSBuildThisFileDirectory)..\..\msvcp_2.settings.targets"/>

--- a/stl/msbuild/stl_2/stl_2.files.settings.targets
+++ b/stl/msbuild/stl_2/stl_2.files.settings.targets
@@ -28,7 +28,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
           <ExpectedExportsList>$(MSBuildThisFileDirectory)\i386.exports</ExpectedExportsList>
         </PropertyGroup>
       </When>
-      <When Condition="'$(BuildArchitecture)' == 'amd64'">
+      <When Condition="'$(BuildArchitecture)' == 'amd64' or '$(BuildArchitecture)' == 'arm64ec'">
         <PropertyGroup>
           <ExpectedExportsList>$(MSBuildThisFileDirectory)\amd64.exports</ExpectedExportsList>
         </PropertyGroup>

--- a/stl/msbuild/stl_2/xmd/msvcp_2_netfx/msvcp_2.nativeproj
+++ b/stl/msbuild/stl_2/xmd/msvcp_2_netfx/msvcp_2.nativeproj
@@ -8,6 +8,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
     <PropertyGroup>
         <CrtBuildModel>xmd</CrtBuildModel>
         <MsvcpFlavor>netfx</MsvcpFlavor>
+        <Arm64X>true</Arm64X>
     </PropertyGroup>
 
     <Import Project="$(MSBuildThisFileDirectory)..\..\msvcp_2.settings.targets"/>

--- a/stl/msbuild/stl_atomic_wait/md/msvcp_atomic_wait_netfx/msvcp_atomic_wait.nativeproj
+++ b/stl/msbuild/stl_atomic_wait/md/msvcp_atomic_wait_netfx/msvcp_atomic_wait.nativeproj
@@ -8,6 +8,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
     <PropertyGroup>
         <CrtBuildModel>md</CrtBuildModel>
         <MsvcpFlavor>netfx</MsvcpFlavor>
+        <Arm64X>true</Arm64X>
     </PropertyGroup>
 
     <Import Project="$(MSBuildThisFileDirectory)..\..\msvcp_atomic_wait.settings.targets"/>

--- a/stl/msbuild/stl_atomic_wait/xmd/msvcp_atomic_wait_netfx/msvcp_atomic_wait.nativeproj
+++ b/stl/msbuild/stl_atomic_wait/xmd/msvcp_atomic_wait_netfx/msvcp_atomic_wait.nativeproj
@@ -8,6 +8,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
     <PropertyGroup>
         <CrtBuildModel>xmd</CrtBuildModel>
         <MsvcpFlavor>netfx</MsvcpFlavor>
+        <Arm64X>true</Arm64X>
     </PropertyGroup>
 
     <Import Project="$(MSBuildThisFileDirectory)..\..\msvcp_atomic_wait.settings.targets"/>

--- a/stl/msbuild/stl_base/md/msvcp_netfx/msvcp.nativeproj
+++ b/stl/msbuild/stl_base/md/msvcp_netfx/msvcp.nativeproj
@@ -8,6 +8,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
     <PropertyGroup>
         <CrtBuildModel>md</CrtBuildModel>
         <MsvcpFlavor>netfx</MsvcpFlavor>
+        <Arm64X>true</Arm64X>
     </PropertyGroup>
 
     <Import Project="$(MSBuildThisFileDirectory)..\..\msvcp.settings.targets"/>

--- a/stl/msbuild/stl_base/stl.files.settings.targets
+++ b/stl/msbuild/stl_base/stl.files.settings.targets
@@ -209,7 +209,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
           </Otherwise>
         </Choose>
       </When>
-      <When Condition="'$(BuildArchitecture)' == 'amd64'">
+      <When Condition="'$(BuildArchitecture)' == 'amd64' or '$(BuildArchitecture)' == 'arm64ec'">
         <Choose>
           <When Condition="'$(MsvcpFlavor)' == 'kernel32' or '$(MsvcpFlavor)' == 'netfx'">
             <PropertyGroup>

--- a/stl/msbuild/stl_base/xmd/msvcp_netfx/msvcp.nativeproj
+++ b/stl/msbuild/stl_base/xmd/msvcp_netfx/msvcp.nativeproj
@@ -8,6 +8,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
     <PropertyGroup>
         <CrtBuildModel>xmd</CrtBuildModel>
         <MsvcpFlavor>netfx</MsvcpFlavor>
+        <Arm64X>true</Arm64X>
     </PropertyGroup>
 
     <Import Project="$(MSBuildThisFileDirectory)..\..\msvcp.settings.targets"/>

--- a/stl/msbuild/stl_codecvt_ids/md/msvcp_codecvt_ids_netfx/msvcp_codecvt_ids.nativeproj
+++ b/stl/msbuild/stl_codecvt_ids/md/msvcp_codecvt_ids_netfx/msvcp_codecvt_ids.nativeproj
@@ -8,6 +8,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
     <PropertyGroup>
         <CrtBuildModel>md</CrtBuildModel>
         <MsvcpFlavor>netfx</MsvcpFlavor>
+        <Arm64X>true</Arm64X>
     </PropertyGroup>
 
     <Import Project="$(MSBuildThisFileDirectory)..\..\msvcp_codecvt_ids.settings.targets"/>

--- a/stl/msbuild/stl_codecvt_ids/stl_codecvt_ids.files.settings.targets
+++ b/stl/msbuild/stl_codecvt_ids/stl_codecvt_ids.files.settings.targets
@@ -28,7 +28,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
           <ExpectedExportsList>$(MSBuildThisFileDirectory)\i386.exports</ExpectedExportsList>
         </PropertyGroup>
       </When>
-      <When Condition="'$(BuildArchitecture)' == 'amd64'">
+      <When Condition="'$(BuildArchitecture)' == 'amd64' or '$(BuildArchitecture)' == 'arm64ec'">
         <PropertyGroup>
           <ExpectedExportsList>$(MSBuildThisFileDirectory)\amd64.exports</ExpectedExportsList>
         </PropertyGroup>

--- a/stl/msbuild/stl_codecvt_ids/xmd/msvcp_codecvt_ids_netfx/msvcp_codecvt_ids.nativeproj
+++ b/stl/msbuild/stl_codecvt_ids/xmd/msvcp_codecvt_ids_netfx/msvcp_codecvt_ids.nativeproj
@@ -8,6 +8,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
     <PropertyGroup>
         <CrtBuildModel>xmd</CrtBuildModel>
         <MsvcpFlavor>netfx</MsvcpFlavor>
+        <Arm64X>true</Arm64X>
     </PropertyGroup>
 
     <Import Project="$(MSBuildThisFileDirectory)..\..\msvcp_codecvt_ids.settings.targets"/>

--- a/stl/msbuild/stl_post/md/msvcp_post_netfx/msvcp_post.nativeproj
+++ b/stl/msbuild/stl_post/md/msvcp_post_netfx/msvcp_post.nativeproj
@@ -8,6 +8,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
     <PropertyGroup>
         <CrtBuildModel>md</CrtBuildModel>
         <MsvcpFlavor>netfx</MsvcpFlavor>
+        <Arm64X>true</Arm64X>
     </PropertyGroup>
 
     <Import Project="$(MSBuildThisFileDirectory)..\..\msvcp_post.settings.targets"/>

--- a/stl/msbuild/stl_post/xmd/msvcp_post_netfx/msvcp_post.nativeproj
+++ b/stl/msbuild/stl_post/xmd/msvcp_post_netfx/msvcp_post.nativeproj
@@ -8,6 +8,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
     <PropertyGroup>
         <CrtBuildModel>xmd</CrtBuildModel>
         <MsvcpFlavor>netfx</MsvcpFlavor>
+        <Arm64X>true</Arm64X>
     </PropertyGroup>
 
     <Import Project="$(MSBuildThisFileDirectory)..\..\msvcp_post.settings.targets"/>


### PR DESCRIPTION
This ports John Porto's MSVC-PR-336641 "[ARM64EC] Chameleonize `*_clr0400.dll`".

This updates the `stl/msbuild` directory (with no impact for the modern GitHub CMake build) for the compiler back-end's work on ARM64EC (which I still don't fully understand, but now there's a [public announcement](https://blogs.windows.com/windowsdeveloper/2021/06/28/announcing-arm64ec-building-native-and-interoperable-apps-for-windows-11-on-arm/) about the tech for those who are curious).