### PR TITLE
Add missing precondition check in `forward_list::splice_after`

### DIFF
--- a/stl/inc/forward_list
+++ b/stl/inc/forward_list
@@ -1093,6 +1093,7 @@ public:
             _Where._Getcont() == _STD addressof(_Mypair._Myval2), "forward_list splice_after iterator outside range");
         _STL_VERIFY(_First._Getcont() == _STD addressof(_Right._Mypair._Myval2),
             "forward_list splice_after iterator outside range");
+        _STL_VERIFY(_First._Ptr->_Next != nullptr, "forward_list splice_after iterator outside range");
 #endif // _ITERATOR_DEBUG_LEVEL == 2
 
         _Splice_after(_Where._Ptr, _Right, _First._Ptr);


### PR DESCRIPTION
`forward_list::splice_after(target_iterator, some_list, before_source_iterator)` requires that `++before_source_iterator` - the iterator that denotes the element to be removed from `some_list` and inserted into `*this` after `target_iterator` - be dereferenceable. We conventionally don't check preconditions when the result of violation is to dereference a `nullptr`, since the behavior is nicely predictable, but doing so here avoids confusion about what otherwise seems like a reasonable call as in DevCom-1456054.
