### PR TITLE
Accept the 80-bit long double in <xutility>

### DIFF
--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -6002,7 +6002,7 @@ _NODISCARD _CONSTEXPR_BIT_CAST bool _Is_finite(const _Ty _Xx) { // constexpr isf
 #else // ^^^ 80-bit long double (not supported by MSVC in general, see GH-1316) / 64-bit long double vvv
     using _Traits = _Floating_type_traits<_Ty>;
     return _Float_abs_bits(_Xx) < _Traits::_Shifted_exponent_mask;
-#endif // ^^^ 64-bit long double ^^^
+#endif // 64-bit long double
 }
 
 // STRUCT _Nontrivial_dummy_type

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -5947,7 +5947,7 @@ struct _CXX17_DEPRECATE_ITERATOR_BASE_CLASS iterator { // base type for iterator
 // FUNCTION TEMPLATE _Float_abs_bits
 template <class _Ty, enable_if_t<is_floating_point_v<_Ty>, int> = 0>
 _NODISCARD _CONSTEXPR_BIT_CAST auto _Float_abs_bits(const _Ty& _Xx) {
-    using _Traits = _Floating_type_traits<_Ty>;
+    using _Traits    = _Floating_type_traits<_Ty>;
     using _Uint_type = typename _Traits::_Uint_type;
     const auto _Bits = _Bit_cast<_Uint_type>(_Xx);
     return _Bits & ~_Traits::_Shifted_sign_mask;

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -5971,12 +5971,8 @@ _NODISCARD _CONSTEXPR_BIT_CAST _Ty _Float_copysign(const _Ty _Magnitude, const _
 // FUNCTION TEMPLATE _Is_nan
 template <class _Ty, enable_if_t<is_floating_point_v<_Ty>, int> = 0>
 _NODISCARD _CONSTEXPR_BIT_CAST bool _Is_nan(const _Ty _Xx) { // constexpr isnan()
-#if defined(__LDBL_DIG__) && __LDBL_DIG__ == 18
-    return _CSTD _LDtest(&_Xx) == _NANCODE;
-#else // ^^^ 80-bit long double (not supported by MSVC in general, see GH-1316) / 64-bit long double vvv
     using _Traits = _Floating_type_traits<_Ty>;
     return _Float_abs_bits(_Xx) > _Traits::_Shifted_exponent_mask;
-#endif // ^^^ 64-bit long double ^^^
 }
 
 // FUNCTION TEMPLATE _Is_signaling_nan
@@ -6002,7 +5998,7 @@ _NODISCARD _CONSTEXPR_BIT_CAST bool _Is_inf(const _Ty _Xx) { // constexpr isinf(
 template <class _Ty, enable_if_t<is_floating_point_v<_Ty>, int> = 0>
 _NODISCARD _CONSTEXPR_BIT_CAST bool _Is_finite(const _Ty _Xx) { // constexpr isfinite()
 #if defined(__LDBL_DIG__) && __LDBL_DIG__ == 18
-    return _CSTD _LDtest(&_Xx) == _INFCODE;
+    return _CSTD _LDtest(&_Xx) == _FINITE;
 #else // ^^^ 80-bit long double (not supported by MSVC in general, see GH-1316) / 64-bit long double vvv
     using _Traits = _Floating_type_traits<_Ty>;
     return _Float_abs_bits(_Xx) < _Traits::_Shifted_exponent_mask;

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -5947,10 +5947,13 @@ struct _CXX17_DEPRECATE_ITERATOR_BASE_CLASS iterator { // base type for iterator
 // FUNCTION TEMPLATE _Float_abs_bits
 template <class _Ty, enable_if_t<is_floating_point_v<_Ty>, int> = 0>
 _NODISCARD _CONSTEXPR_BIT_CAST auto _Float_abs_bits(const _Ty& _Xx) {
+#if defined(__LDBL_DIG__) && __LDBL_DIG__ == 18
     using _Traits    = _Floating_type_traits<_Ty>;
+#else // ^^^ 80-bit long double (not supported by MSVC in general, see GH-1316) / 64-bit long double vvv
     using _Uint_type = typename _Traits::_Uint_type;
     const auto _Bits = _Bit_cast<_Uint_type>(_Xx);
     return _Bits & ~_Traits::_Shifted_sign_mask;
+#endif // ^^^ 64-bit long double ^^^
 }
 
 // FUNCTION TEMPLATE _Float_abs

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -5947,13 +5947,10 @@ struct _CXX17_DEPRECATE_ITERATOR_BASE_CLASS iterator { // base type for iterator
 // FUNCTION TEMPLATE _Float_abs_bits
 template <class _Ty, enable_if_t<is_floating_point_v<_Ty>, int> = 0>
 _NODISCARD _CONSTEXPR_BIT_CAST auto _Float_abs_bits(const _Ty& _Xx) {
-#if defined(__LDBL_DIG__) && __LDBL_DIG__ == 18
     using _Traits = _Floating_type_traits<_Ty>;
-#else // ^^^ 80-bit long double (not supported by MSVC in general, see GH-1316) / 64-bit long double vvv
     using _Uint_type = typename _Traits::_Uint_type;
     const auto _Bits = _Bit_cast<_Uint_type>(_Xx);
     return _Bits & ~_Traits::_Shifted_sign_mask;
-#endif // ^^^ 64-bit long double ^^^
 }
 
 // FUNCTION TEMPLATE _Float_abs
@@ -5974,8 +5971,12 @@ _NODISCARD _CONSTEXPR_BIT_CAST _Ty _Float_copysign(const _Ty _Magnitude, const _
 // FUNCTION TEMPLATE _Is_nan
 template <class _Ty, enable_if_t<is_floating_point_v<_Ty>, int> = 0>
 _NODISCARD _CONSTEXPR_BIT_CAST bool _Is_nan(const _Ty _Xx) { // constexpr isnan()
+#if defined(__LDBL_DIG__) && __LDBL_DIG__ == 18
+    return _CSTD _LDtest(&_Xx) == _NANCODE;
+#else // ^^^ 80-bit long double (not supported by MSVC in general, see GH-1316) / 64-bit long double vvv
     using _Traits = _Floating_type_traits<_Ty>;
     return _Float_abs_bits(_Xx) > _Traits::_Shifted_exponent_mask;
+#endif // ^^^ 64-bit long double ^^^
 }
 
 // FUNCTION TEMPLATE _Is_signaling_nan
@@ -6000,8 +6001,12 @@ _NODISCARD _CONSTEXPR_BIT_CAST bool _Is_inf(const _Ty _Xx) { // constexpr isinf(
 // FUNCTION TEMPLATE _Is_finite
 template <class _Ty, enable_if_t<is_floating_point_v<_Ty>, int> = 0>
 _NODISCARD _CONSTEXPR_BIT_CAST bool _Is_finite(const _Ty _Xx) { // constexpr isfinite()
+if defined(__LDBL_DIG__) && __LDBL_DIG__ == 18
+    return _CSTD _LDtest(&_Xx) == _INFCODE;
+#else // ^^^ 80-bit long double (not supported by MSVC in general, see GH-1316) / 64-bit long double vvv
     using _Traits = _Floating_type_traits<_Ty>;
     return _Float_abs_bits(_Xx) < _Traits::_Shifted_exponent_mask;
+#endif // ^^^ 64-bit long double ^^^
 }
 
 // STRUCT _Nontrivial_dummy_type

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -5948,7 +5948,7 @@ struct _CXX17_DEPRECATE_ITERATOR_BASE_CLASS iterator { // base type for iterator
 template <class _Ty, enable_if_t<is_floating_point_v<_Ty>, int> = 0>
 _NODISCARD _CONSTEXPR_BIT_CAST auto _Float_abs_bits(const _Ty& _Xx) {
 #if defined(__LDBL_DIG__) && __LDBL_DIG__ == 18
-    using _Traits    = _Floating_type_traits<_Ty>;
+    using _Traits = _Floating_type_traits<_Ty>;
 #else // ^^^ 80-bit long double (not supported by MSVC in general, see GH-1316) / 64-bit long double vvv
     using _Uint_type = typename _Traits::_Uint_type;
     const auto _Bits = _Bit_cast<_Uint_type>(_Xx);

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -6003,7 +6003,7 @@ template <class _Ty, enable_if_t<is_floating_point_v<_Ty>, int> = 0>
 _NODISCARD _CONSTEXPR_BIT_CAST bool _Is_finite(const _Ty _Xx) { // constexpr isfinite()
 #if defined(__LDBL_DIG__) && __LDBL_DIG__ == 18
     return _CSTD _LDtest(&_Xx) == _INFCODE;
-#else // ^^^ 80-bit long double (not supported by MSVC in general, see GH-1316) / 64-bit long double vvv^M
+#else // ^^^ 80-bit long double (not supported by MSVC in general, see GH-1316) / 64-bit long double vvv
     using _Traits = _Floating_type_traits<_Ty>;
     return _Float_abs_bits(_Xx) < _Traits::_Shifted_exponent_mask;
 #endif // ^^^ 64-bit long double ^^^

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -6001,11 +6001,11 @@ _NODISCARD _CONSTEXPR_BIT_CAST bool _Is_inf(const _Ty _Xx) { // constexpr isinf(
 // FUNCTION TEMPLATE _Is_finite
 template <class _Ty, enable_if_t<is_floating_point_v<_Ty>, int> = 0>
 _NODISCARD _CONSTEXPR_BIT_CAST bool _Is_finite(const _Ty _Xx) { // constexpr isfinite()
-    if defined (__LDBL_DIG__)
-        &&__LDBL_DIG__ == 18 return _CSTD _LDtest(&_Xx) == _INFCODE;
-#else // ^^^ 80-bit long double (not supported by MSVC in general, see GH-1316) / 64-bit long double vvv
-using _Traits = _Floating_type_traits<_Ty>;
-return _Float_abs_bits(_Xx) < _Traits::_Shifted_exponent_mask;
+#if defined(__LDBL_DIG__) && __LDBL_DIG__ == 18
+    return _CSTD _LDtest(&_Xx) == _INFCODE;
+#else // ^^^ 80-bit long double (not supported by MSVC in general, see GH-1316) / 64-bit long double vvv^M
+    using _Traits = _Floating_type_traits<_Ty>;
+    return _Float_abs_bits(_Xx) < _Traits::_Shifted_exponent_mask;
 #endif // ^^^ 64-bit long double ^^^
 }
 

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -6001,11 +6001,11 @@ _NODISCARD _CONSTEXPR_BIT_CAST bool _Is_inf(const _Ty _Xx) { // constexpr isinf(
 // FUNCTION TEMPLATE _Is_finite
 template <class _Ty, enable_if_t<is_floating_point_v<_Ty>, int> = 0>
 _NODISCARD _CONSTEXPR_BIT_CAST bool _Is_finite(const _Ty _Xx) { // constexpr isfinite()
-if defined(__LDBL_DIG__) && __LDBL_DIG__ == 18
-    return _CSTD _LDtest(&_Xx) == _INFCODE;
+    if defined (__LDBL_DIG__)
+        &&__LDBL_DIG__ == 18 return _CSTD _LDtest(&_Xx) == _INFCODE;
 #else // ^^^ 80-bit long double (not supported by MSVC in general, see GH-1316) / 64-bit long double vvv
-    using _Traits = _Floating_type_traits<_Ty>;
-    return _Float_abs_bits(_Xx) < _Traits::_Shifted_exponent_mask;
+using _Traits = _Floating_type_traits<_Ty>;
+return _Float_abs_bits(_Xx) < _Traits::_Shifted_exponent_mask;
 #endif // ^^^ 64-bit long double ^^^
 }
 


### PR DESCRIPTION
The previous codes only work for complex header file by PR's: 
https://github.com/microsoft/STL/pull/1316
https://github.com/microsoft/STL/pull/1728.

The _Bit_cast function in xutility header file does not allow 80 bits wide long double. The Intel C++ compiler uses /Qlong-double option to set the long double type to 80 bits wide. 

This patch generalizes the 80 bit long double check in xutility header file using same logic from https://github.com/microsoft/STL/pull/1316.  

