### PR TITLE
Status Chart: Weekly update, fix Luxon 2.0 breaking change

### DIFF
--- a/gather_stats.js
+++ b/gather_stats.js
@@ -11,7 +11,7 @@ const { DateTime, Duration, Settings } = require('luxon');
 const { graphql } = require('@octokit/graphql');
 const yargs = require('yargs/yargs');
 
-Settings.defaultZoneName = 'America/Los_Angeles';
+Settings.defaultZone = 'America/Los_Angeles';
 
 if (process.env.SECRET_GITHUB_PERSONAL_ACCESS_TOKEN === undefined) {
     // GitHub Actions will provide the PAT as an environment variable. Otherwise, we need to load the .env file.

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,9 +37,9 @@
       }
     },
     "node_modules/@octokit/openapi-types": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-8.3.0.tgz",
-      "integrity": "sha512-ZFyQ30tNpoATI7o+Z9MWFUzUgWisB8yduhcky7S4UYsRijgIGSnwUKzPBDGzf/Xkx1DuvUtqzvmuFlDSqPJqmQ=="
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-9.1.1.tgz",
+      "integrity": "sha512-xmyPP9tVb4T4A6Lk6SL6ScnIqAHpPV4jfMZI8VtY286212ri9J/6IFGuLsZ26daADUmriuLejake4k+azEfnaw=="
     },
     "node_modules/@octokit/request": {
       "version": "5.6.0",
@@ -65,11 +65,11 @@
       }
     },
     "node_modules/@octokit/types": {
-      "version": "6.19.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.19.0.tgz",
-      "integrity": "sha512-9wdZFiJfonDyU6DjIgDHxAIn92vdSUBOwAXbO2F9rOFt6DJwuAkyGLu1CvdJPphCbPBoV9iSDMX7y4fu0v6AtA==",
+      "version": "6.21.1",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.21.1.tgz",
+      "integrity": "sha512-PP+m3T5EWZKawru4zi/FvX8KL2vkO5f1fLthx78/7743p7RtJUevt3z7698k+7oAYRA7YuVqfXthSEHqkDvZ8g==",
       "dependencies": {
-        "@octokit/openapi-types": "^8.3.0"
+        "@octokit/openapi-types": "^9.1.1"
       }
     },
     "node_modules/ansi-regex": {
@@ -328,9 +328,9 @@
       }
     },
     "@octokit/openapi-types": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-8.3.0.tgz",
-      "integrity": "sha512-ZFyQ30tNpoATI7o+Z9MWFUzUgWisB8yduhcky7S4UYsRijgIGSnwUKzPBDGzf/Xkx1DuvUtqzvmuFlDSqPJqmQ=="
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-9.1.1.tgz",
+      "integrity": "sha512-xmyPP9tVb4T4A6Lk6SL6ScnIqAHpPV4jfMZI8VtY286212ri9J/6IFGuLsZ26daADUmriuLejake4k+azEfnaw=="
     },
     "@octokit/request": {
       "version": "5.6.0",
@@ -356,11 +356,11 @@
       }
     },
     "@octokit/types": {
-      "version": "6.19.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.19.0.tgz",
-      "integrity": "sha512-9wdZFiJfonDyU6DjIgDHxAIn92vdSUBOwAXbO2F9rOFt6DJwuAkyGLu1CvdJPphCbPBoV9iSDMX7y4fu0v6AtA==",
+      "version": "6.21.1",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.21.1.tgz",
+      "integrity": "sha512-PP+m3T5EWZKawru4zi/FvX8KL2vkO5f1fLthx78/7743p7RtJUevt3z7698k+7oAYRA7YuVqfXthSEHqkDvZ8g==",
       "requires": {
-        "@octokit/openapi-types": "^8.3.0"
+        "@octokit/openapi-types": "^9.1.1"
       }
     },
     "ansi-regex": {

--- a/usernames_contributors.txt
+++ b/usernames_contributors.txt
@@ -7,5 +7,6 @@ AlexGuteniev
 fsb4000
 MichaelRizkalla
 miscco
+sam20908
 statementreply
 timsong-cpp

--- a/weekly_table.js
+++ b/weekly_table.js
@@ -216,4 +216,5 @@ const weekly_table = [
     { date: '2021-07-02', vso: 170, libcxx: 602 },
     { date: '2021-07-09', vso: 172, libcxx: 602 },
     { date: '2021-07-16', vso: 171, libcxx: 602 },
+    { date: '2021-07-23', vso: 172, libcxx: 603 },
 ];


### PR DESCRIPTION
When I updated [Luxon](https://github.com/moment/luxon)'s major version to 2.0 in #2063, the next automated update changed tons of data points. As they [documented](https://github.com/moment/luxon/blob/074cb06e4725bba6be3d581a13ee4d2b7090d43a/docs/upgrading.md#default-zone), we need to use `Settings.defaultZone` to make the script's calculations always use Pacific Time (originally done in #1764).

I've verified this change by temporarily enabling automated updates in my fork, and verifying that GitHub Actions will generate exactly the old data (followed by newly added days).

:chart_with_upwards_trend: Live preview: [stephantlavavej.github.io/STL/](https://stephantlavavej.github.io/STL/)
===
