### PR TITLE
Remove need for subtraction

### DIFF
--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -109,9 +109,9 @@ struct _Char_traits { // properties of a string or stream element
                 for (size_t _Idx = 0; _Idx != _Count; ++_Idx) {
                     _First1[_Idx] = _First2[_Idx];
                 }
-            } else {
-                for (size_t _Idx = _Count; _Idx != 0; --_Idx) {
-                    _First1[_Idx - 1] = _First2[_Idx - 1];
+            } else if (_Count != 0) { // Prevent underflow
+                for (size_t _Idx = _Count - 1; _Idx != 0; --_Idx) {
+                    _First1[_Idx] = _First2[_Idx];
                 }
             }
 


### PR DESCRIPTION
Just check for 0 and then do the subtraction. Two checks is less expensive than a subtraction every loop

<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
