### PR TITLE
Update vcpkg and require Boost 1.76.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ project(msvc_standard_libraries LANGUAGES CXX)
 
 find_package(Boost REQUIRED)
 
-set(VCLIBS_MIN_BOOST_VERSION 1.75.0)
+set(VCLIBS_MIN_BOOST_VERSION 1.76.0)
 if("${Boost_VERSION}" VERSION_LESS "${VCLIBS_MIN_BOOST_VERSION}")
     message(FATAL_ERROR "Detected Boost version is too old (older than ${VCLIBS_MIN_BOOST_VERSION}).")
 endif()


### PR DESCRIPTION
This updates the vcpkg submodule to be compatible with VS 2022 17.0 Preview 2, then increases our requirement to Boost 1.76.0. Without this PR, the STL's build instructions will fail for someone who has only VS 2022 installed. (The vcpkg fixes include https://github.com/microsoft/vcpkg-tool/pull/124, https://github.com/microsoft/vcpkg/pull/19086, and https://github.com/microsoft/vcpkg/pull/19159.)

I believe that the STL's CI was unaffected due to the caching that we perform.