### PR TITLE
Remove rarely true check in char_traits::move

### DIFF
--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -90,10 +90,6 @@ struct _Char_traits { // properties of a string or stream element
             // If _First1 is in the src range, we need a backward loop.
             // Otherwise, the forward loop works (even if the back of dest overlaps the front of src).
 
-            if (_First1 == _First2) {
-                return _First1; // Self-assignment; either loop would work, but returning immediately is faster.
-            }
-
             // Usually, we would compare pointers with less-than, even though they could belong to different arrays.
             // However, we're not allowed to do that during constant evaluation, so we need a linear scan for equality.
             bool _Loop_forward = true;


### PR DESCRIPTION
While it is faster to just leave when the source and destination are the same, most programmers would not make that mistake, and if they did, it would be a rarity and a reflection of something going wrong in their code in the first place.

There is no reason to do this check if speed and code size are of utmost importance.

<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
