### PR TITLE
`<chrono>`: optimize `chrono::steady_clock::now()`

### DIFF
--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -702,8 +702,8 @@ namespace chrono {
         static constexpr bool is_steady = true;
 
         _NODISCARD static time_point now() noexcept { // get current time
-            const long long _Freq = _Query_perf_frequency(); // doesn't change after system boot
-            const long long _Ctr  = _Query_perf_counter();
+            static const long long _Freq = _Query_perf_frequency(); // doesn't change after system boot
+            const long long _Ctr         = _Query_perf_counter();
             static_assert(period::num == 1, "This assumes period::num == 1.");
             // Instead of just having "(_Ctr * period::den) / _Freq",
             // the algorithm below prevents overflow when _Ctr is sufficiently large.

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -705,19 +705,20 @@ namespace chrono {
             const long long _Freq = _Query_perf_frequency(); // doesn't change after system boot
             const long long _Ctr  = _Query_perf_counter();
             static_assert(period::num == 1, "This assumes period::num == 1.");
-            // Instead of just having "(_Ctr * period::den) / _Freq",
-            // the algorithm below prevents overflow when _Ctr is sufficiently large.
-            // It assumes that _Freq * period::den does not overflow, which is currently true for nano period.
-            // It is not realistic for _Ctr to accumulate to large values from zero with this assumption,
-            // but the initial value of _Ctr could be large.
             // 10 MHz is a very common QPC frequency on modern PCs. Optimizing for
             // this specific frequency can double the performance of this function by
             // avoiding the expensive frequency conversion path.
-            if (_Freq == 10000000) {
-                static_assert(period::den % 10000000 == 0, "It should never fail.");
-                constexpr long long _Multiplier = period::den / 10000000;
+            constexpr long long _TenMHz = 10'000'000;
+            if (_Freq == _TenMHz) {
+                static_assert(period::den % _TenMHz == 0, "It should never fail.");
+                constexpr long long _Multiplier = period::den / _TenMHz;
                 return time_point(duration(_Ctr * _Multiplier));
             } else {
+                // Instead of just having "(_Ctr * period::den) / _Freq",
+                // the algorithm below prevents overflow when _Ctr is sufficiently large.
+                // It assumes that _Freq * period::den does not overflow, which is currently true for nano period.
+                // It is not realistic for _Ctr to accumulate to large values from zero with this assumption,
+                // but the initial value of _Ctr could be large.
                 const long long _Whole = (_Ctr / _Freq) * period::den;
                 const long long _Part  = (_Ctr % _Freq) * period::den / _Freq;
                 return time_point(duration(_Whole + _Part));

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -710,9 +710,18 @@ namespace chrono {
             // It assumes that _Freq * period::den does not overflow, which is currently true for nano period.
             // It is not realistic for _Ctr to accumulate to large values from zero with this assumption,
             // but the initial value of _Ctr could be large.
-            const long long _Whole = (_Ctr / _Freq) * period::den;
-            const long long _Part  = (_Ctr % _Freq) * period::den / _Freq;
-            return time_point(duration(_Whole + _Part));
+            // 10 MHz is a very common QPC frequency on modern PCs. Optimizing for
+            // this specific frequency can double the performance of this function by
+            // avoiding the expensive frequency conversion path.
+            if (_Freq == 10000000) {
+                static_assert(period::den % 10000000 == 0, "It should never fail.");
+                constexpr long long _Multiplier = period::den / 10000000;
+                return time_point(duration(_Ctr * _Multiplier));
+            } else {
+                const long long _Whole = (_Ctr / _Freq) * period::den;
+                const long long _Part  = (_Ctr % _Freq) * period::den / _Freq;
+                return time_point(duration(_Whole + _Part));
+            }
         }
     };
 

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -702,8 +702,8 @@ namespace chrono {
         static constexpr bool is_steady = true;
 
         _NODISCARD static time_point now() noexcept { // get current time
-            static const long long _Freq = _Query_perf_frequency(); // doesn't change after system boot
-            const long long _Ctr         = _Query_perf_counter();
+            const long long _Freq = _Query_perf_frequency(); // doesn't change after system boot
+            const long long _Ctr  = _Query_perf_counter();
             static_assert(period::num == 1, "This assumes period::num == 1.");
             // Instead of just having "(_Ctr * period::den) / _Freq",
             // the algorithm below prevents overflow when _Ctr is sufficiently large.


### PR DESCRIPTION
Closes #2085

