### PR TITLE
Use static_cast for <void*> outside of converting to and from integers

### DIFF
--- a/stl/inc/memory_resource
+++ b/stl/inc/memory_resource
@@ -356,8 +356,7 @@ namespace pmr {
             void* const _Ptr                 = _Resource->allocate(_Bytes, _Align);
             _Check_alignment(_Ptr, _Align);
 
-            _Oversized_header* const _Hdr =
-                reinterpret_cast<_Oversized_header*>(reinterpret_cast<char*>(_Ptr) + _Bytes) - 1;
+            _Oversized_header* const _Hdr = reinterpret_cast<_Oversized_header*>(static_cast<char*>(_Ptr) + _Bytes) - 1;
 
             _Hdr->_Size  = _Bytes;
             _Hdr->_Align = _Align;
@@ -664,7 +663,7 @@ namespace pmr {
             }
 
             void* const _Result = _Current_buffer;
-            _Current_buffer     = reinterpret_cast<char*>(_Current_buffer) + _Bytes;
+            _Current_buffer     = static_cast<char*>(_Current_buffer) + _Bytes;
             _Space_available -= _Bytes;
             return _Result;
         }

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -146,7 +146,7 @@ inline void _Adjust_manually_vector_aligned(void*& _Ptr, size_t& _Bytes) {
     // adjust parameters from _Allocate_manually_vector_aligned to pass to operator delete
     _Bytes += _Non_user_size;
 
-    const uintptr_t* const _Ptr_user = reinterpret_cast<uintptr_t*>(_Ptr);
+    const uintptr_t* const _Ptr_user = static_cast<uintptr_t*>(_Ptr);
     const uintptr_t _Ptr_container   = _Ptr_user[-1];
 
     // If the following asserts, it likely means that we are performing

--- a/stl/src/ppltasks.cpp
+++ b/stl/src/ppltasks.cpp
@@ -235,7 +235,7 @@ namespace Concurrency {
             } else {
                 ComCallData callData;
                 ZeroMemory(&callData, sizeof(callData));
-                callData.pUserDefined = reinterpret_cast<void*>(&_Func);
+                callData.pUserDefined = &_Func;
 
                 HRESULT hresult = static_cast<IContextCallback*>(_M_context._M_pContextCallback)
                                       ->ContextCallback(&_PPLTaskContextCallbackBridge, &callData,


### PR DESCRIPTION
<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
