### PR TITLE
Don't call bit_width if value is nullptr in _Fmt_write

### DIFF
--- a/stl/inc/format
+++ b/stl/inc/format
@@ -2497,11 +2497,13 @@ _NODISCARD _OutputIt _Fmt_write(
     // Add 3 to the bit width so we always round up on the division.
     // Divide that by the amount of bits a hexit represents (log2(16) = log2(2^4) = 4).
     // Add 2 for the 0x prefix.
-    auto _Width = 2 + static_cast<int>(_STD bit_width(reinterpret_cast<uintptr_t>(_Value)) + 3) / 4;
+    int _Width;
 
     // Since the bit width of 0 is 0, special case it instead of complicating the math even more.
     if (_Value == nullptr) {
         _Width = 3;
+    } else {
+        _Width = 2 + static_cast<int>(_STD bit_width(reinterpret_cast<uintptr_t>(_Value)) + 3) / 4;
     }
 
     return _Write_aligned(_STD move(_Out), _Width, _Specs, _Fmt_align::_Left,


### PR DESCRIPTION
<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
