### PR TITLE
<type_traits> add declval failure assertion for instantiation (#2087)

### DIFF
--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -132,7 +132,9 @@ template <class _Ty>
 using add_rvalue_reference_t = typename _Add_reference<_Ty>::_Rvalue;
 
 template <class _Ty>
-add_rvalue_reference_t<_Ty> declval() noexcept;
+add_rvalue_reference_t<_Ty> declval() noexcept {
+    static_assert(_Always_false<_Ty>, "Calling declval is ill-formed, see N4892 [declval]/2.");
+}
 
 template <class _Ty>
 struct remove_extent { // remove array extent


### PR DESCRIPTION
The static assertion will prevent the instantiation of ::std::declval at compile-time, preventing its' usage in an evaluated context.

Fixes #2087 .
<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
