### PR TITLE
add cmakeToolchain to CMakeSettings.json

### DIFF
--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -10,7 +10,8 @@
       "generator": "Ninja",
       "inheritEnvironments": [ "msvc_x86" ],
       "installRoot": "${projectDir}\\out\\install\\${name}",
-      "variables": []
+      "variables": [],
+      "cmakeToolchain": "./vcpkg/scripts/buildsystems/vcpkg.cmake"
     },
     {
       "name": "x64",
@@ -22,7 +23,8 @@
       "generator": "Ninja",
       "inheritEnvironments": [ "msvc_x64_x64" ],
       "installRoot": "${projectDir}\\out\\install\\${name}",
-      "variables": []
+      "variables": [],
+      "cmakeToolchain": "./vcpkg/scripts/buildsystems/vcpkg.cmake"
     },
     {
       "name": "ARM",
@@ -34,7 +36,8 @@
       "generator": "Ninja",
       "inheritEnvironments": [ "msvc_arm" ],
       "installRoot": "${projectDir}\\out\\install\\${name}",
-      "variables": []
+      "variables": [],
+      "cmakeToolchain": "./vcpkg/scripts/buildsystems/vcpkg.cmake"
     },
     {
       "name": "ARM64",
@@ -46,7 +49,8 @@
       "generator": "Ninja",
       "inheritEnvironments": [ "msvc_arm64" ],
       "installRoot": "${projectDir}\\out\\install\\${name}",
-      "variables": []
+      "variables": [],
+      "cmakeToolchain": "./vcpkg/scripts/buildsystems/vcpkg.cmake"
     }
   ]
 }

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -5,52 +5,52 @@
       "buildCommandArgs": "-v",
       "buildRoot": "${projectDir}\\out\\build\\${name}",
       "cmakeCommandArgs": "",
+      "cmakeToolchain": "${projectDir}\\vcpkg\\scripts\\buildsystems\\vcpkg.cmake",
       "configurationType": "Debug",
       "ctestCommandArgs": "",
       "generator": "Ninja",
       "inheritEnvironments": [ "msvc_x86" ],
       "installRoot": "${projectDir}\\out\\install\\${name}",
-      "variables": [],
-      "cmakeToolchain": "./vcpkg/scripts/buildsystems/vcpkg.cmake"
+      "variables": []
     },
     {
       "name": "x64",
       "buildCommandArgs": "-v",
       "buildRoot": "${projectDir}\\out\\build\\${name}",
       "cmakeCommandArgs": "",
+      "cmakeToolchain": "${projectDir}\\vcpkg\\scripts\\buildsystems\\vcpkg.cmake",
       "configurationType": "Debug",
       "ctestCommandArgs": "",
       "generator": "Ninja",
       "inheritEnvironments": [ "msvc_x64_x64" ],
       "installRoot": "${projectDir}\\out\\install\\${name}",
-      "variables": [],
-      "cmakeToolchain": "./vcpkg/scripts/buildsystems/vcpkg.cmake"
+      "variables": []
     },
     {
       "name": "ARM",
       "buildCommandArgs": "-v",
       "buildRoot": "${projectDir}\\out\\build\\${name}",
       "cmakeCommandArgs": "",
+      "cmakeToolchain": "${projectDir}\\vcpkg\\scripts\\buildsystems\\vcpkg.cmake",
       "configurationType": "Debug",
       "ctestCommandArgs": "",
       "generator": "Ninja",
       "inheritEnvironments": [ "msvc_arm" ],
       "installRoot": "${projectDir}\\out\\install\\${name}",
-      "variables": [],
-      "cmakeToolchain": "./vcpkg/scripts/buildsystems/vcpkg.cmake"
+      "variables": []
     },
     {
       "name": "ARM64",
       "buildCommandArgs": "-v",
       "buildRoot": "${projectDir}\\out\\build\\${name}",
       "cmakeCommandArgs": "",
+      "cmakeToolchain": "${projectDir}\\vcpkg\\scripts\\buildsystems\\vcpkg.cmake",
       "configurationType": "Debug",
       "ctestCommandArgs": "",
       "generator": "Ninja",
       "inheritEnvironments": [ "msvc_arm64" ],
       "installRoot": "${projectDir}\\out\\install\\${name}",
-      "variables": [],
-      "cmakeToolchain": "./vcpkg/scripts/buildsystems/vcpkg.cmake"
+      "variables": []
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -152,8 +152,7 @@ acquire this dependency.
 3. Open a terminal in the IDE with `` Ctrl + ` `` (by default) or press on "View" in the top bar, and then "Terminal".
 4. In the terminal, invoke `git submodule update --init --progress llvm-project vcpkg`
 5. In the terminal, invoke `.\vcpkg\bootstrap-vcpkg.bat`
-6. In the terminal, invoke `.\vcpkg\vcpkg.exe install boost-math:x86-windows boost-math:x64-windows`
-7. Choose the architecture you wish to build in the IDE, and build as you would any other project. All necessary CMake
+6. Choose the architecture you wish to build in the IDE, and build as you would any other project. All necessary CMake
    settings are set by `CMakeSettings.json`.
 
 # How To Build With A Native Tools Command Prompt
@@ -168,7 +167,6 @@ acquire this dependency.
 5. `cd STL`
 6. `git submodule update --init --progress llvm-project vcpkg`
 7. `.\vcpkg\bootstrap-vcpkg.bat`
-8. `.\vcpkg\vcpkg.exe install boost-math:x86-windows boost-math:x64-windows`
 
 To build the x86 target:
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,11 @@
+{
+    "name": "stl",
+    "version-string": "143",
+    "builtin-baseline": "1257354a3ab0bebd8abe95281ca561537853578c",
+    "dependencies": [
+        {
+            "name": "boost-math",
+            "version>=": "1.76.0"
+        }
+    ]
+}


### PR DESCRIPTION
Today I tried to build STL from Visual Studio 2022 IDE (first try, before only command line)
And I had to add cmakeToolchain or I got an error: "BOOST NOT FOUND".
So I decided to contribute my changes.

![изображение](https://user-images.githubusercontent.com/4289847/128720622-544c3da0-d4ab-4940-b601-c92deaebbdda.png)
