### PR TITLE
Remove constructible_from test case

### DIFF
--- a/tests/std/tests/P0898R3_concepts/test.cpp
+++ b/tests/std/tests/P0898R3_concepts/test.cpp
@@ -1425,9 +1425,6 @@ namespace test_constructible_from {
     STATIC_ASSERT(test<int&, ExplicitTo<int&>>());
     STATIC_ASSERT(test<int const&, ExplicitTo<int&>>());
     STATIC_ASSERT(test<int const&, ExplicitTo<int&>&>());
-#if defined(__clang__) // TRANSITION, VSO-1357053 (MSVC) and VSO-1357056 (EDG)
-    STATIC_ASSERT(test<int const&, ExplicitTo<int&&>>());
-#endif // TRANSITION, VSO-1357053 (MSVC) and VSO-1357056 (EDG)
 
     struct Multiparameter {
         explicit Multiparameter(int);

--- a/tests/std/tests/P0898R3_concepts/test.cpp
+++ b/tests/std/tests/P0898R3_concepts/test.cpp
@@ -1454,9 +1454,6 @@ namespace test_constructible_from {
     // Binding through reference-compatible type is required to perform
     // direct-initialization as described in N4849 [over.match.ref]/1.1:
     STATIC_ASSERT(test<int&, ExplicitTo<int&>>());
-#if defined(__clang__) // TRANSITION, VSO-1357053 (MSVC) and VSO-1357056 (EDG)
-    STATIC_ASSERT(test<int const&, ExplicitTo<int&&>>());
-#endif // TRANSITION, VSO-1357053 (MSVC) and VSO-1357056 (EDG)
     STATIC_ASSERT(test<int&&, ExplicitTo<int&&>>());
 
     // Binding through temporary behaves like copy-initialization,


### PR DESCRIPTION
... that was invalidated by WG21-P1787 "Declarations and where to find them". This is the darkest shadowy corner of a test filled with corner cases, and as such I don't feel it's worth the trouble of tracking which compiler front ends have correct behavior and which not.

Fixes VSO-1357053/AB#1357053.
