### PR TITLE
Return `_Nontrivial_dummy_type` to `<optional>`

### DIFF
--- a/stl/inc/optional
+++ b/stl/inc/optional
@@ -54,6 +54,13 @@ protected:
     _THROW(bad_optional_access{});
 }
 
+struct _Nontrivial_dummy_type {
+    constexpr _Nontrivial_dummy_type() noexcept {
+        // This default constructor is user-provided to avoid zero-initialization when objects are value-initialized.
+    }
+};
+_STL_INTERNAL_STATIC_ASSERT(!is_trivially_default_constructible_v<_Nontrivial_dummy_type>);
+
 template <class _Ty, bool = is_trivially_destructible_v<_Ty>>
 struct _Optional_destruct_base { // either contains a value of _Ty or is empty (trivial destructor)
     union {

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -5777,13 +5777,6 @@ _NODISCARD _CONSTEXPR_BIT_CAST bool _Is_finite(const _Ty _Xx) { // constexpr isf
     return _Float_abs_bits(_Xx) < _Traits::_Shifted_exponent_mask;
 }
 
-struct _Nontrivial_dummy_type {
-    constexpr _Nontrivial_dummy_type() noexcept {
-        // This default constructor is user-provided to avoid zero-initialization when objects are value-initialized.
-    }
-};
-_STL_INTERNAL_STATIC_ASSERT(!is_trivially_default_constructible_v<_Nontrivial_dummy_type>);
-
 #if _HAS_CXX17
 struct monostate {};
 #endif // _HAS_CXX17


### PR DESCRIPTION
We pushed this type up into `<xutility>` to use implementing the `optional`-alikes in `<ranges>`. After realizing that the updated C++20 `constexpr` rules mean we can avoid activating any union alternative in a `constexpr` constructor if we like, we removed the uses in `<ranges>`. This PR simply moves the type back to `<optional>` since it's no longer used elsewhere.
