### PR TITLE
`std::string_view` must be `std::is_trivially_move_constructible_v`

### DIFF
--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -1248,6 +1248,8 @@ public:
 
     constexpr basic_string_view(const basic_string_view&) noexcept = default;
     constexpr basic_string_view& operator=(const basic_string_view&) noexcept = default;
+    constexpr basic_string_view(basic_string_view&&) noexcept                 = default;
+    constexpr basic_string_view& operator=(basic_string_view&&) noexcept = default;
 
     /* implicit */ constexpr basic_string_view(_In_z_ const const_pointer _Ntcts) noexcept // strengthened
         : _Mydata(_Ntcts), _Mysize(_Traits::length(_Ntcts)) {}

--- a/tests/std/tests/P0220R1_string_view/test.cpp
+++ b/tests/std/tests/P0220R1_string_view/test.cpp
@@ -1244,6 +1244,8 @@ static_assert(!is_constructible_v<string, nullptr_t>, "constructing string from 
 static_assert(!is_assignable_v<string&, nullptr_t>, "assigning nullptr_t to string is prohibited");
 #endif // _HAS_CXX23
 
+static_assert(is_trivially_move_constructible_v<string_view>);
+
 int main() {
     test_case_default_constructor();
     test_case_ntcts_constructor();


### PR DESCRIPTION
Thanks @frederick-vs-ja for finding the issue at #2111

We didn't have move consturctor and after adding range constructors (https://github.com/microsoft/STL/commit/6fe02ac09e0ac84185a278c6aee283bf8869b341) string_view was no longer trivially move constructible.
