### PR TITLE
Allow silencing the experimental coroutine warning

### DIFF
--- a/stl/inc/experimental/coroutine
+++ b/stl/inc/experimental/coroutine
@@ -32,10 +32,11 @@ support Clang. You can define _SILENCE_CLANG_COROUTINE_MESSAGE to silence this m
 unsupported.
 #endif // defined(__clang__) && !defined(_SILENCE_CLANG_COROUTINE_MESSAGE)
 
-#ifdef __cpp_impl_coroutine
+#if defined(__cpp_impl_coroutine) && !defined(_SILENCE_EXPERIMENTAL_COROUTINE_WARNING)
 #error The <experimental/coroutine> and <experimental/resumable> headers are only supported \
-with /await and implement pre-C++20 coroutine support. Use <coroutine> for standard C++20 coroutines.
-#endif // __cpp_impl_coroutine
+with /await and implement pre-C++20 coroutine support. Use <coroutine> for standard C++20 coroutines. \
+You can define _SILENCE_EXPERIMENTAL_COROUTINE_WARNING to acknowledge that you have received this warning.
+#endif // defined(__cpp_impl_coroutine) && !defined(_SILENCE_EXPERIMENTAL_COROUTINE_WARNING)
 
 // intrinsics used in implementation of coroutine_handle
 extern "C" size_t _coro_resume(void*);


### PR DESCRIPTION
Add an option macro to allow users to silence the experimental coroutine warning.

Some third-party libraries (such as `cppwinrt`) are very slow to distribute new versions. The latest version of `cppwinrt` currently included in the `Windows SDK` is `v2.0.200609.3`, which was released on (9 Jun 2020).

In the older version of these libraries (the latest distributed version), it still use the `<experimental/coroutine>` header. Therefore, if we bump our own projects to C++20, this warning will always prevent compilation.

Using a released but undistributed version sometimes doesn't work, for example `cppwinrt`, if we use the local version it will require installation through the `Nuget` package manager, which is almost impossible to do in `CMake`.

For more information on this problem in `cppwinrt`, see https://github.com/microsoft/cppwinrt/issues/866.

This PR should not break any existing code, and the `<experimental/coroutine>` header should work well with the standard `<coroutine>` header, since they have different namespaces. But I'm not sure the naming of that option macro is appropriate.