### PR TITLE
Fix `test_permutations()` in `P0202R3_constexpr_algorithm_and_exchange`

### DIFF
--- a/tests/std/tests/P0202R3_constexpr_algorithm_and_exchange/test.cpp
+++ b/tests/std/tests/P0202R3_constexpr_algorithm_and_exchange/test.cpp
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include <algorithm>
-#include <array>
 #include <assert.h>
 #include <functional>
 #include <iterator>
@@ -468,50 +467,54 @@ constexpr void test_pop_heap_and_push_heap() {
 }
 
 constexpr void test_permutations() {
-    int buff[] = {1, 2, 3, 4};
-    // using std::array here is TRANSITION, DevCom-892153
-    constexpr array<const int, 4> expected[] = {
-        array<const int, 4>{10, 20, 30, 40},
-        array<const int, 4>{10, 20, 40, 30},
-        array<const int, 4>{10, 30, 20, 40},
-        array<const int, 4>{10, 30, 40, 20},
-        array<const int, 4>{10, 40, 20, 30},
-        array<const int, 4>{10, 40, 30, 20},
-        array<const int, 4>{20, 10, 30, 40},
-        array<const int, 4>{20, 10, 40, 30},
-        array<const int, 4>{20, 30, 10, 40},
-        array<const int, 4>{20, 30, 40, 10},
-        array<const int, 4>{20, 40, 10, 30},
-        array<const int, 4>{20, 40, 30, 10},
-        array<const int, 4>{30, 10, 20, 40},
-        array<const int, 4>{30, 10, 40, 20},
-        array<const int, 4>{30, 20, 10, 40},
-        array<const int, 4>{30, 20, 40, 10},
-        array<const int, 4>{30, 40, 10, 20},
-        array<const int, 4>{30, 40, 20, 10},
-        array<const int, 4>{40, 10, 20, 30},
-        array<const int, 4>{40, 10, 30, 20},
-        array<const int, 4>{40, 20, 10, 30},
-        array<const int, 4>{40, 20, 30, 10},
-        array<const int, 4>{40, 30, 10, 20},
-        array<const int, 4>{40, 30, 20, 10},
+    int buff[] = {10, 20, 30, 40};
+
+    constexpr int expected[24][4] = {
+        {10, 20, 30, 40},
+        {10, 20, 40, 30},
+        {10, 30, 20, 40},
+        {10, 30, 40, 20},
+        {10, 40, 20, 30},
+        {10, 40, 30, 20},
+        {20, 10, 30, 40},
+        {20, 10, 40, 30},
+        {20, 30, 10, 40},
+        {20, 30, 40, 10},
+        {20, 40, 10, 30},
+        {20, 40, 30, 10},
+        {30, 10, 20, 40},
+        {30, 10, 40, 20},
+        {30, 20, 10, 40},
+        {30, 20, 40, 10},
+        {30, 40, 10, 20},
+        {30, 40, 20, 10},
+        {40, 10, 20, 30},
+        {40, 10, 30, 20},
+        {40, 20, 10, 30},
+        {40, 20, 30, 10},
+        {40, 30, 10, 20},
+        {40, 30, 20, 10},
     };
 
-    auto cursor = begin(expected);
+    size_t cursor = 0;
     do {
-        assert(equal(begin(buff), end(buff), cursor->begin(), cursor->end()));
+        assert(equal(begin(buff), end(buff), begin(expected[cursor]), end(expected[cursor])));
         ++cursor;
     } while (next_permutation(begin(buff), end(buff)));
 
-    assert(cursor == end(expected));
+    assert(cursor == 24);
+    assert(equal(begin(buff), end(buff), begin(expected[0]), end(expected[0])));
+
     assert(!prev_permutation(begin(buff), end(buff)));
+    cursor = 23;
 
     do {
-        assert(equal(begin(buff), end(buff), cursor->begin(), cursor->end()));
+        assert(equal(begin(buff), end(buff), begin(expected[cursor]), end(expected[cursor])));
         --cursor;
     } while (prev_permutation(begin(buff), end(buff)));
 
-    assert(is_sorted(begin(buff), end(buff)));
+    assert(cursor == static_cast<size_t>(-1));
+    assert(equal(begin(buff), end(buff), begin(expected[23]), end(expected[23])));
 }
 
 constexpr bool test() {

--- a/tests/std/tests/P0202R3_constexpr_algorithm_and_exchange/test.cpp
+++ b/tests/std/tests/P0202R3_constexpr_algorithm_and_exchange/test.cpp
@@ -145,7 +145,7 @@ struct output_pointer {
 // test all the algorithms that have is_constant_evaluated() calls
 
 template <class I, class O>
-constexpr bool test_copy() {
+constexpr void test_copy() {
     const int a[] = {10, 20, 30};
     int b[3]{};
     assert(copy(I{begin(a)}, I{end(a)}, O{begin(b)}) == O{end(b)});
@@ -155,11 +155,10 @@ constexpr bool test_copy() {
     assert(b[0] == 10);
     assert(b[1] == 20);
     assert(b[2] == 30);
-    return true;
 }
 
 template <class I, class O>
-constexpr bool test_copy_n() {
+constexpr void test_copy_n() {
     const int a[] = {10, 20, 30};
     int b[3]{};
     assert(copy_n(I{begin(a)}, 3, O{begin(b)}) == O{end(b)});
@@ -169,11 +168,10 @@ constexpr bool test_copy_n() {
     assert(b[0] == 10);
     assert(b[1] == 20);
     assert(b[2] == 30);
-    return true;
 }
 
 template <class I, class O>
-constexpr bool test_copy_backward() {
+constexpr void test_copy_backward() {
     const int a[] = {10, 20, 30};
     int b[3]{};
     assert(copy_backward(I{begin(a)}, I{end(a)}, O{end(b)}) == O{begin(b)});
@@ -183,11 +181,10 @@ constexpr bool test_copy_backward() {
     assert(b[0] == 10);
     assert(b[1] == 20);
     assert(b[2] == 30);
-    return true;
 }
 
 template <class I, class O>
-constexpr bool test_move() {
+constexpr void test_move() {
     const int a[] = {10, 20, 30};
     int b[3]{};
     assert(move(I{begin(a)}, I{end(a)}, O{begin(b)}) == O{end(b)});
@@ -197,11 +194,10 @@ constexpr bool test_move() {
     assert(b[0] == 10);
     assert(b[1] == 20);
     assert(b[2] == 30);
-    return true;
 }
 
 template <class I, class O>
-constexpr bool test_move_backward() {
+constexpr void test_move_backward() {
     const int a[] = {10, 20, 30};
     int b[3]{};
     assert(move_backward(I{begin(a)}, I{end(a)}, O{end(b)}) == O{begin(b)});
@@ -211,27 +207,24 @@ constexpr bool test_move_backward() {
     assert(b[0] == 10);
     assert(b[1] == 20);
     assert(b[2] == 30);
-    return true;
 }
 
 template <class O>
-constexpr bool test_fill() {
+constexpr void test_fill() {
     int a[] = {10, 20, 30};
     fill(O{begin(a)}, O{end(a)}, 20);
     assert(all_of(begin(a), end(a), [](int i) { return i == 20; }));
-    return true;
 }
 
 template <class O>
-constexpr bool test_fill_n() {
+constexpr void test_fill_n() {
     int a[] = {10, 20, 30};
     fill_n(O{begin(a)}, size(a), 20);
     assert(all_of(begin(a), end(a), [](int i) { return i == 20; }));
-    return true;
 }
 
 template <class I>
-constexpr bool test_equal() {
+constexpr void test_equal() {
     const int a[] = {10, 20, 30};
     const int b[] = {10, 20, 30};
     const int c[] = {40, 50, 60};
@@ -247,33 +240,30 @@ constexpr bool test_equal() {
     assert(!equal(I{begin(a)}, I{end(a)}, I{begin(a)}, I{begin(a)}));
     assert(!equal(I{begin(a)}, I{end(a)}, I{begin(b)}, I{end(b)}, not_equal_to{}));
     assert(!equal(I{begin(a)}, I{end(a)}, I{begin(a)}, I{end(a)}, not_equal_to{}));
-    return true;
 }
 
 template <class IntPtr, class CharPtr>
-constexpr bool test_find() {
+constexpr void test_find() {
     const int a[] = {10, 20, 30};
     assert(find(IntPtr{begin(a)}, IntPtr{end(a)}, 20) == IntPtr{a + 1});
 
     const char b[] = {'\x0A', '\x14', '\x1E'};
     assert(find(CharPtr{begin(b)}, CharPtr{end(b)}, 20) == CharPtr{b + 1});
-    return true;
 }
 
 template <class V, class IO>
-constexpr bool test_reverse() {
+constexpr void test_reverse() {
     V a[] = {10, 20, 30};
     reverse(IO{begin(a)}, IO{end(a)});
     assert(a[0] == 30);
     assert(a[1] == 20);
     assert(a[2] == 10);
-    return true;
 }
 
 // test remaining algorithms that had nothing tested by libcxx as of 2020-01-21
 
 template <class I, class O>
-constexpr bool test_rotate_copy() {
+constexpr void test_rotate_copy() {
     const int a[] = {10, 20, 30};
     int b[3]{};
     assert(rotate_copy(I{begin(a)}, I{next(a)}, I{end(a)}, O{begin(b)}) == O{end(b)});
@@ -283,33 +273,30 @@ constexpr bool test_rotate_copy() {
     assert(b[0] == 20);
     assert(b[1] == 30);
     assert(b[2] == 10);
-    return true;
 }
 
 template <class I, class O>
-constexpr bool test_merge() {
+constexpr void test_merge() {
     const int a[]        = {10, 20, 30, 40, 50, 60};
     const int b[]        = {20, 40, 60, 80, 100, 120};
     const int expected[] = {10, 20, 20, 30, 40, 40, 50, 60, 60, 80, 100, 120};
     int r[size(expected)]{};
     assert(merge(I{begin(a)}, I{end(a)}, I{begin(b)}, I{end(b)}, O{begin(r)}) == O{end(r)});
     assert(equal(begin(r), end(r), begin(expected), end(expected)));
-    return true;
 }
 
 template <class I, class O>
-constexpr bool test_set_union() {
+constexpr void test_set_union() {
     const int a[]        = {10, 20, 30, 40, 50, 60};
     const int b[]        = {20, 40, 60, 80, 100, 120};
     const int expected[] = {10, 20, 30, 40, 50, 60, 80, 100, 120};
     int r[size(expected)]{};
     assert(set_union(I{begin(a)}, I{end(a)}, I{begin(b)}, I{end(b)}, O{begin(r)}) == O{end(r)});
     assert(equal(begin(r), end(r), begin(expected), end(expected)));
-    return true;
 }
 
 template <class I, class O>
-constexpr bool test_set_difference() {
+constexpr void test_set_difference() {
     const int a[] = {10, 20, 30, 40, 50, 60};
     const int b[] = {20, 40, 60, 80, 100, 120};
     int r[3]{};
@@ -317,11 +304,10 @@ constexpr bool test_set_difference() {
     assert(r[0] == 10);
     assert(r[1] == 30);
     assert(r[2] == 50);
-    return true;
 }
 
 template <class I, class O>
-constexpr bool test_set_symmetric_difference() {
+constexpr void test_set_symmetric_difference() {
     const int a[] = {10, 20, 30, 40, 50, 60};
     const int b[] = {20, 40, 60, 80, 100, 120};
     int r[6]{};
@@ -332,21 +318,19 @@ constexpr bool test_set_symmetric_difference() {
     assert(r[3] == 80);
     assert(r[4] == 100);
     assert(r[5] == 120);
-    return true;
 }
 
 // Also test P0879R0 constexpr for swapping functions
 
 template <class IO>
-constexpr bool test_rotate() {
+constexpr void test_rotate() {
     int a[] = {50, 60, 10, 20, 30, 40};
     assert(rotate(IO{begin(a)}, next(IO{begin(a)}, 2), IO{end(a)}) == IO{a + 4});
     assert(is_sorted(begin(a), end(a)));
-    return true;
 }
 
 template <class IO>
-constexpr bool test_partition() {
+constexpr void test_partition() {
     const auto isNegative     = [](int b) { return b < 0; };
     int a[]                   = {10, 20, -10, -20, 100, 450, -1000};
     const auto partitionPoint = partition(IO{begin(a)}, IO{end(a)}, isNegative);
@@ -354,27 +338,24 @@ constexpr bool test_partition() {
     assert(partitionPoint == IO{a + 3});
     assert(all_of(IO{begin(a)}, partitionPoint, isNegative));
     assert(none_of(partitionPoint, IO{end(a)}, isNegative));
-    return true;
 }
 
-constexpr bool test_sort() {
+constexpr void test_sort() {
     int a[] = {10, 20, -10, -20, 100, 450, -1000};
     sort(begin(a), end(a));
     assert(is_sorted(begin(a), end(a)));
-    return true;
 }
 
-constexpr bool test_partial_sort() {
+constexpr void test_partial_sort() {
     int a[] = {1000, 10000, 2000, 20, 60, 80};
     partial_sort(begin(a), a + 3, end(a));
     assert(a[0] == 20);
     assert(a[1] == 60);
     assert(a[2] == 80);
-    return true;
 }
 
 template <class I>
-constexpr bool test_partial_sort_copy() {
+constexpr void test_partial_sort_copy() {
     const int a[] = {1000, 10000, 2000, 20, 60, 80};
     int b[size(a) + 1]{};
     assert(partial_sort_copy(I{begin(a)}, I{end(a)}, begin(b), begin(b) + 3) == begin(b) + 3);
@@ -388,20 +369,18 @@ constexpr bool test_partial_sort_copy() {
     assert(b[3] == 1000);
     assert(b[4] == 2000);
     assert(b[5] == 10000);
-    return true;
 }
 
-constexpr bool test_nth_element() {
+constexpr void test_nth_element() {
     const auto isNegative = [](int b) { return b < 0; };
     int a[]               = {10, 20, -10, -20, 100, 450, -1000};
     nth_element(begin(a), begin(a) + 3, end(a));
     assert(all_of(begin(a), a + 2, isNegative));
     assert(a[2] == -10);
     assert(none_of(a + 4, end(a), isNegative));
-    return true;
 }
 
-constexpr bool test_is_heap() {
+constexpr void test_is_heap() {
     int buff[] = {
         1668617627,
         1429106719,
@@ -418,10 +397,9 @@ constexpr bool test_is_heap() {
     assert(is_heap(begin(buff), end(buff)));
     swap(buff[0], buff[1]);
     assert(!is_heap(begin(buff), end(buff)));
-    return true;
 }
 
-constexpr bool test_make_heap_and_sort_heap() {
+constexpr void test_make_heap_and_sort_heap() {
     int buff[] = {
         -1200257975,
         -1260655766,
@@ -439,10 +417,9 @@ constexpr bool test_make_heap_and_sort_heap() {
     assert(is_heap(begin(buff), end(buff)));
     sort_heap(begin(buff), end(buff));
     assert(is_sorted(begin(buff), end(buff)));
-    return true;
 }
 
-constexpr bool test_pop_heap_and_push_heap() {
+constexpr void test_pop_heap_and_push_heap() {
     int buff[] = {
         1668617627,
         1429106719,
@@ -488,10 +465,9 @@ constexpr bool test_pop_heap_and_push_heap() {
     };
     assert(is_heap(begin(expectedPushed), end(expectedPushed)));
     assert(equal(begin(buff), end(buff), begin(expectedPushed), end(expectedPushed)));
-    return true;
 }
 
-constexpr bool test_permutations() {
+constexpr void test_permutations() {
     int buff[] = {1, 2, 3, 4};
     // using std::array here is TRANSITION, DevCom-892153
     constexpr array<const int, 4> expected[] = {
@@ -536,65 +512,62 @@ constexpr bool test_permutations() {
     } while (prev_permutation(begin(buff), end(buff)));
 
     assert(is_sorted(begin(buff), end(buff)));
-    return true;
 }
 
 constexpr bool test() {
-    // clang-format off
-    return
-        test_copy<input_pointer<const int>, output_pointer<int>>()
-        && test_copy<const int*, int*>()
-        && test_copy_n<input_pointer<const int>, output_pointer<int>>()
-        && test_copy_n<const int*, int*>()
-        && test_copy_backward<bidirectional_pointer<const int>, bidirectional_pointer<int>>()
-        && test_copy_backward<const int*, int*>()
-        && test_move<input_pointer<const int>, output_pointer<int>>()
-        && test_move<const int*, int*>()
-        && test_move_backward<bidirectional_pointer<const int>, bidirectional_pointer<int>>()
-        && test_move_backward<const int*, int*>()
-        && test_fill<forward_pointer<int>>()
-        && test_fill<int*>()
-        && test_fill_n<forward_pointer<int>>()
-        && test_fill_n<int*>()
-        && test_equal<input_pointer<const int>>()
-        && test_equal<const int*>()
-        && test_find<input_pointer<const int>, input_pointer<const char>>()
-        && test_find<const int*, const char*>()
-        && test_reverse<char, bidirectional_pointer<char>>()
-        && test_reverse<char, char*>()
-        && test_reverse<short, bidirectional_pointer<short>>()
-        && test_reverse<short, short*>()
-        && test_reverse<int, bidirectional_pointer<int>>()
-        && test_reverse<int, int*>()
-        && test_reverse<long, bidirectional_pointer<long>>()
-        && test_reverse<long, long*>()
-        && test_reverse<long long, bidirectional_pointer<long long>>()
-        && test_reverse<long long, long long*>()
-        && test_rotate_copy<input_pointer<const int>, output_pointer<int>>()
-        && test_rotate_copy<const int*, int*>()
-        && test_merge<input_pointer<const int>, output_pointer<int>>()
-        && test_merge<const int*, int*>()
-        && test_set_union<input_pointer<const int>, output_pointer<int>>()
-        && test_set_union<const int*, int*>()
-        && test_set_difference<input_pointer<const int>, output_pointer<int>>()
-        && test_set_difference<const int*, int*>()
-        && test_set_symmetric_difference<input_pointer<const int>, output_pointer<int>>()
-        && test_set_symmetric_difference<const int*, int*>()
-        && test_rotate<bidirectional_pointer<int>>()
-        && test_rotate<int*>()
-        && test_partition<forward_pointer<int>>()
-        && test_partition<bidirectional_pointer<int>>()
-        && test_partition<int*>()
-        && test_sort()
-        && test_partial_sort()
-        && test_partial_sort_copy<input_pointer<const int>>()
-        && test_partial_sort_copy<const int*>()
-        && test_nth_element()
-        && test_is_heap()
-        && test_make_heap_and_sort_heap()
-        && test_pop_heap_and_push_heap()
-        ;
-    // clang-format on
+    test_copy<input_pointer<const int>, output_pointer<int>>();
+    test_copy<const int*, int*>();
+    test_copy_n<input_pointer<const int>, output_pointer<int>>();
+    test_copy_n<const int*, int*>();
+    test_copy_backward<bidirectional_pointer<const int>, bidirectional_pointer<int>>();
+    test_copy_backward<const int*, int*>();
+    test_move<input_pointer<const int>, output_pointer<int>>();
+    test_move<const int*, int*>();
+    test_move_backward<bidirectional_pointer<const int>, bidirectional_pointer<int>>();
+    test_move_backward<const int*, int*>();
+    test_fill<forward_pointer<int>>();
+    test_fill<int*>();
+    test_fill_n<forward_pointer<int>>();
+    test_fill_n<int*>();
+    test_equal<input_pointer<const int>>();
+    test_equal<const int*>();
+    test_find<input_pointer<const int>, input_pointer<const char>>();
+    test_find<const int*, const char*>();
+    test_reverse<char, bidirectional_pointer<char>>();
+    test_reverse<char, char*>();
+    test_reverse<short, bidirectional_pointer<short>>();
+    test_reverse<short, short*>();
+    test_reverse<int, bidirectional_pointer<int>>();
+    test_reverse<int, int*>();
+    test_reverse<long, bidirectional_pointer<long>>();
+    test_reverse<long, long*>();
+    test_reverse<long long, bidirectional_pointer<long long>>();
+    test_reverse<long long, long long*>();
+    test_rotate_copy<input_pointer<const int>, output_pointer<int>>();
+    test_rotate_copy<const int*, int*>();
+    test_merge<input_pointer<const int>, output_pointer<int>>();
+    test_merge<const int*, int*>();
+    test_set_union<input_pointer<const int>, output_pointer<int>>();
+    test_set_union<const int*, int*>();
+    test_set_difference<input_pointer<const int>, output_pointer<int>>();
+    test_set_difference<const int*, int*>();
+    test_set_symmetric_difference<input_pointer<const int>, output_pointer<int>>();
+    test_set_symmetric_difference<const int*, int*>();
+    test_rotate<bidirectional_pointer<int>>();
+    test_rotate<int*>();
+    test_partition<forward_pointer<int>>();
+    test_partition<bidirectional_pointer<int>>();
+    test_partition<int*>();
+    test_sort();
+    test_partial_sort();
+    test_partial_sort_copy<input_pointer<const int>>();
+    test_partial_sort_copy<const int*>();
+    test_nth_element();
+    test_is_heap();
+    test_make_heap_and_sort_heap();
+    test_pop_heap_and_push_heap();
+
+    return true;
 }
 
 int main() {

--- a/tests/std/tests/P0202R3_constexpr_algorithm_and_exchange/test.cpp
+++ b/tests/std/tests/P0202R3_constexpr_algorithm_and_exchange/test.cpp
@@ -566,6 +566,7 @@ constexpr bool test() {
     test_is_heap();
     test_make_heap_and_sort_heap();
     test_pop_heap_and_push_heap();
+    test_permutations();
 
     return true;
 }


### PR DESCRIPTION
First, this simplifies the `P0202R3_constexpr_algorithm_and_exchange` test by avoiding a huge unnecessary `&&` chain. When performing "dual mode" testing at runtime and compiletime, only the top-level function needs to be `constexpr bool` returning `true` (even that isn't strictly necessary, but it's convenient). The helper functions can be `constexpr void`; any failures will still be detected by failed `assert`s.

Second, this adds a missing call to `test_permutations()`.

Third, this fixes `test_permutations()` which never worked.

* Regardless of whether DevCom-892153 is a compiler bug, we don't need `<array>`; we can use a built-in multidimensional array with a `size_t cursor`.
* `int buff[] = {1, 2, 3, 4};` needs to be `int buff[] = {10, 20, 30, 40};`.
* This says `constexpr int expected[24][4]` instead of `constexpr int expected[][4]` for clarity. I didn't bother to extract `24` as a magic number, although I could do that if anyone wants.
* After cycling through `next_permutation()`, this verifies that `buff` has wrapped around to be equal to `expected[0]`.
* Previously, after `assert(!prev_permutation(begin(buff), end(buff)));`, this dereferenced `cursor == end(expected)`. Now we reset `cursor = 23;`.
* After cycling through `prev_permutation()`, this attempted to verify `assert(is_sorted(begin(buff), end(buff)));`. That's incorrect - the array is in ascending order after cycling through `next_permutation()`, but in descending order after cycling through `prev_permutation()`. I have replaced this with stricter tests: we inspect both `cursor` and verify that we have exactly `expected[23]`'s content (this is stricter than verifying `is_sorted()` with `greater<>{}`).
  + Technically, this final check of the array's contents is redundant (we performed it during the first iteration of the `do/while` loop after `assert(!prev_permutation(begin(buff), end(buff)));`) but it seems reasonable to maintain consistency with the `next_permutation()` code above.