### PR TITLE
`<tuple>`: LWG-3528 `make_from_tuple` can perform (the equivalent of) a C-style cast

### DIFF
--- a/stl/inc/tuple
+++ b/stl/inc/tuple
@@ -981,10 +981,10 @@ constexpr decltype(auto) apply(_Callable&& _Obj, _Tuple&& _Tpl) { // invoke _Obj
 }
 
 template <class _Ty, class _Tuple, size_t... _Indices>
-constexpr _Ty _Make_from_tuple_impl(
-    _Tuple&& _Tpl, index_sequence<_Indices...>) { // construct _Ty from the elements of _Tpl
-    static_assert(is_constructible_v<_Ty, decltype(_STD get<_Indices>(_STD declval<_Tuple>()))...>,
-        "C-style cast is forbidden (N4892 [tuple.apply]/2).");
+constexpr _Ty _Make_from_tuple_impl(_Tuple&& _Tpl, index_sequence<_Indices...>) {
+    // construct _Ty from the elements of _Tpl
+    static_assert(is_constructible_v<_Ty, decltype(_STD get<_Indices>(_STD forward<_Tuple>(_Tpl)))...>,
+        "the target type must be constructible from the fields of the argument tuple (N4892 [tuple.apply]/2).");
     return _Ty(_STD get<_Indices>(_STD forward<_Tuple>(_Tpl))...);
 }
 


### PR DESCRIPTION
Although `requires` is used in LWG-3528, I believe that only hard error is required, because `std::make_from_tuple` itself is still unconstrained.

Works towards #1965.