### PR TITLE
cleared comment TRANSITION 

### DIFF
--- a/stl/inc/compare
+++ b/stl/inc/compare
@@ -322,7 +322,7 @@ struct compare_three_way_result<_Ty1, _Ty2> {
 
 struct compare_three_way {
     template <class _Ty1, class _Ty2>
-        requires three_way_comparable_with<_Ty1, _Ty2> // TRANSITION, GH-489
+        requires three_way_comparable_with<_Ty1, _Ty2>
     _NODISCARD constexpr auto operator()(_Ty1&& _Left, _Ty2&& _Right) const
         noexcept(noexcept(_STD forward<_Ty1>(_Left) <=> _STD forward<_Ty2>(_Right))) /* strengthened */ {
         return _STD forward<_Ty1>(_Left) <=> _STD forward<_Ty2>(_Right);

--- a/stl/inc/functional
+++ b/stl/inc/functional
@@ -2105,7 +2105,7 @@ namespace ranges {
     struct not_equal_to {
         // clang-format off
         template <class _Ty1, class _Ty2>
-            requires equality_comparable_with<_Ty1, _Ty2> // TRANSITION, GH-489
+            requires equality_comparable_with<_Ty1, _Ty2>
         _NODISCARD constexpr bool operator()(_Ty1&& _Left, _Ty2&& _Right) const noexcept(noexcept(
             static_cast<bool>(static_cast<_Ty1&&>(_Left) == static_cast<_Ty2&&>(_Right)))) /* strengthened */ {
             return !static_cast<bool>(static_cast<_Ty1&&>(_Left) == static_cast<_Ty2&&>(_Right));
@@ -2118,7 +2118,7 @@ namespace ranges {
     struct greater_equal {
         // clang-format off
         template <class _Ty1, class _Ty2>
-            requires totally_ordered_with<_Ty1, _Ty2> // TRANSITION, GH-489
+            requires totally_ordered_with<_Ty1, _Ty2>
         _NODISCARD constexpr bool operator()(_Ty1&& _Left, _Ty2&& _Right) const noexcept(noexcept(
             static_cast<bool>(static_cast<_Ty1&&>(_Left) < static_cast<_Ty2&&>(_Right)))) /* strengthened */ {
             return !static_cast<bool>(static_cast<_Ty1&&>(_Left) < static_cast<_Ty2&&>(_Right));
@@ -2131,7 +2131,7 @@ namespace ranges {
     struct less_equal {
         // clang-format off
         template <class _Ty1, class _Ty2>
-            requires totally_ordered_with<_Ty1, _Ty2> // TRANSITION, GH-489
+            requires totally_ordered_with<_Ty1, _Ty2>
         _NODISCARD constexpr bool operator()(_Ty1&& _Left, _Ty2&& _Right) const noexcept(noexcept(
             static_cast<bool>(static_cast<_Ty2&&>(_Right) < static_cast<_Ty1&&>(_Left)))) /* strengthened */ {
             return !static_cast<bool>(static_cast<_Ty2&&>(_Right) < static_cast<_Ty1&&>(_Left));

--- a/stl/inc/system_error
+++ b/stl/inc/system_error
@@ -96,7 +96,6 @@ public:
     }
 #endif // !_HAS_CXX20
 
-
 #ifdef __cpp_lib_concepts
     _NODISCARD strong_ordering operator<=>(const error_category& _Right) const noexcept {
         return compare_three_way{}(_Addr, _Right._Addr);
@@ -180,7 +179,6 @@ public:
     _NODISCARD friend bool operator==(const error_code& _Left, const error_condition& _Right) noexcept {
         return _System_error_equal(_Left, _Right);
     }
-
 
 #ifdef __cpp_lib_concepts
     _NODISCARD friend strong_ordering operator<=>(const error_code& _Left, const error_code& _Right) noexcept {
@@ -267,7 +265,6 @@ public:
         return _Left.category() == _Right.category() && _Left.value() == _Right.value();
     }
 
-
 #ifdef __cpp_lib_concepts
     _NODISCARD friend strong_ordering operator<=>(
         const error_condition& _Left, const error_condition& _Right) noexcept {
@@ -320,7 +317,6 @@ _NODISCARD inline bool operator==(const error_code& _Left, const error_condition
 _NODISCARD inline bool operator==(const error_condition& _Left, const error_condition& _Right) noexcept {
     return _Left.category() == _Right.category() && _Left.value() == _Right.value();
 }
-
 
 #ifdef __cpp_lib_concepts
 _NODISCARD inline strong_ordering operator<=>(const error_code& _Left, const error_code& _Right) noexcept {

--- a/stl/inc/system_error
+++ b/stl/inc/system_error
@@ -96,7 +96,7 @@ public:
     }
 #endif // !_HAS_CXX20
 
-// TRANSITION, GH-489
+
 #ifdef __cpp_lib_concepts
     _NODISCARD strong_ordering operator<=>(const error_category& _Right) const noexcept {
         return compare_three_way{}(_Addr, _Right._Addr);
@@ -181,7 +181,7 @@ public:
         return _System_error_equal(_Left, _Right);
     }
 
-// TRANSITION, GH-489
+
 #ifdef __cpp_lib_concepts
     _NODISCARD friend strong_ordering operator<=>(const error_code& _Left, const error_code& _Right) noexcept {
         if (const auto _Result = _Left.category() <=> _Right.category(); _Result != 0) {
@@ -267,7 +267,7 @@ public:
         return _Left.category() == _Right.category() && _Left.value() == _Right.value();
     }
 
-// TRANSITION, GH-489
+
 #ifdef __cpp_lib_concepts
     _NODISCARD friend strong_ordering operator<=>(
         const error_condition& _Left, const error_condition& _Right) noexcept {
@@ -321,7 +321,7 @@ _NODISCARD inline bool operator==(const error_condition& _Left, const error_cond
     return _Left.category() == _Right.category() && _Left.value() == _Right.value();
 }
 
-// TRANSITION, GH-489
+
 #ifdef __cpp_lib_concepts
 _NODISCARD inline strong_ordering operator<=>(const error_code& _Left, const error_code& _Right) noexcept {
     if (const auto _Result = _Left.category() <=> _Right.category(); _Result != 0) {

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -2969,7 +2969,7 @@ namespace ranges {
     struct equal_to {
         // clang-format off
         template <class _Ty1, class _Ty2>
-            requires equality_comparable_with<_Ty1, _Ty2> // TRANSITION, GH-489
+            requires equality_comparable_with<_Ty1, _Ty2>
         _NODISCARD constexpr bool operator()(_Ty1&& _Left, _Ty2&& _Right) const noexcept(noexcept(
             static_cast<bool>(static_cast<_Ty1&&>(_Left) == static_cast<_Ty2&&>(_Right)))) /* strengthened */ {
             return static_cast<bool>(static_cast<_Ty1&&>(_Left) == static_cast<_Ty2&&>(_Right));
@@ -2982,7 +2982,7 @@ namespace ranges {
     struct less {
         // clang-format off
         template <class _Ty1, class _Ty2>
-            requires totally_ordered_with<_Ty1, _Ty2> // TRANSITION, GH-489
+            requires totally_ordered_with<_Ty1, _Ty2>
         _NODISCARD constexpr bool operator()(_Ty1&& _Left, _Ty2&& _Right) const noexcept(noexcept(
             static_cast<bool>(static_cast<_Ty1&&>(_Left) < static_cast<_Ty2&&>(_Right)))) /* strengthened */ {
             return static_cast<bool>(static_cast<_Ty1&&>(_Left) < static_cast<_Ty2&&>(_Right));
@@ -2995,7 +2995,7 @@ namespace ranges {
     struct greater {
         // clang-format off
         template <class _Ty1, class _Ty2>
-            requires totally_ordered_with<_Ty1, _Ty2> // TRANSITION, GH-489
+            requires totally_ordered_with<_Ty1, _Ty2>
         _NODISCARD constexpr bool operator()(_Ty1&& _Left, _Ty2&& _Right) const noexcept(noexcept(
             static_cast<bool>(static_cast<_Ty2&&>(_Right) < static_cast<_Ty1&&>(_Left)))) /* strengthened */ {
             return static_cast<bool>(static_cast<_Ty2&&>(_Right) < static_cast<_Ty1&&>(_Left));


### PR DESCRIPTION
Closes #2182 

this pr will close the above issue .
i had removed all the 11 occurences of  `// TRANSITION, GH-489` across 4 files (`<compare>`, `<functional>`, `<system_error>`, and `<xutility>`).

<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
