### PR TITLE
make bitset use popcount with ISA detection out of loop

### DIFF
--- a/stl/inc/bitset
+++ b/stl/inc/bitset
@@ -337,7 +337,7 @@ public:
     }
 
     _NODISCARD size_t count() const noexcept { // count number of set bits
-        return _Select_popcount_impl([this](auto _Popcount_impl) {
+        return _Select_popcount_impl<_Ty>([this](auto _Popcount_impl) {
             size_t _Val = 0;
             for (size_t _Wpos = 0; _Wpos <= _Words; ++_Wpos) {
                 _Val += _Popcount_impl(_Array[_Wpos]);

--- a/stl/inc/bitset
+++ b/stl/inc/bitset
@@ -10,6 +10,7 @@
 #if _STL_COMPILER_PREPROCESSOR
 #include <iosfwd>
 #include <xstring>
+#include <limits>
 
 #pragma pack(push, _CRT_PACKING)
 #pragma warning(push, _STL_WARNING_LEVEL)
@@ -336,30 +337,15 @@ public:
     }
 
     _NODISCARD size_t count() const noexcept { // count number of set bits
-        const char* const _Bitsperbyte = "\0\1\1\2\1\2\2\3\1\2\2\3\2\3\3\4"
-                                         "\1\2\2\3\2\3\3\4\2\3\3\4\3\4\4\5"
-                                         "\1\2\2\3\2\3\3\4\2\3\3\4\3\4\4\5"
-                                         "\2\3\3\4\3\4\4\5\3\4\4\5\4\5\5\6"
-                                         "\1\2\2\3\2\3\3\4\2\3\3\4\3\4\4\5"
-                                         "\2\3\3\4\3\4\4\5\3\4\4\5\4\5\5\6"
-                                         "\2\3\3\4\3\4\4\5\3\4\4\5\4\5\5\6"
-                                         "\3\4\4\5\4\5\5\6\4\5\5\6\5\6\6\7"
-                                         "\1\2\2\3\2\3\3\4\2\3\3\4\3\4\4\5"
-                                         "\2\3\3\4\3\4\4\5\3\4\4\5\4\5\5\6"
-                                         "\2\3\3\4\3\4\4\5\3\4\4\5\4\5\5\6"
-                                         "\3\4\4\5\4\5\5\6\4\5\5\6\5\6\6\7"
-                                         "\2\3\3\4\3\4\4\5\3\4\4\5\4\5\5\6"
-                                         "\3\4\4\5\4\5\5\6\4\5\5\6\5\6\6\7"
-                                         "\3\4\4\5\4\5\5\6\4\5\5\6\5\6\6\7"
-                                         "\4\5\5\6\5\6\6\7\5\6\6\7\6\7\7\x8";
-        const unsigned char* _Ptr       = &reinterpret_cast<const unsigned char&>(_Array);
-        const unsigned char* const _End = _Ptr + sizeof(_Array);
-        size_t _Val                     = 0;
-        for (; _Ptr != _End; ++_Ptr) {
-            _Val += _Bitsperbyte[*_Ptr];
-        }
+        return _SelectPopCountImpl([this](auto _Popcount_impl) {
+            size_t _Val = 0;
+            for (size_t _Wpos = 0; _Wpos <= _Words; ++_Wpos) {
+                _Val += _Popcount_impl(_Array[_Wpos]);
+            }
 
-        return _Val;
+            return _Val;
+        });
+
     }
 
     _NODISCARD constexpr size_t size() const noexcept {

--- a/stl/inc/bitset
+++ b/stl/inc/bitset
@@ -9,8 +9,8 @@
 #include <yvals_core.h>
 #if _STL_COMPILER_PREPROCESSOR
 #include <iosfwd>
-#include <xstring>
 #include <limits>
+#include <xstring>
 
 #pragma pack(push, _CRT_PACKING)
 #pragma warning(push, _STL_WARNING_LEVEL)
@@ -345,7 +345,6 @@ public:
 
             return _Val;
         });
-
     }
 
     _NODISCARD constexpr size_t size() const noexcept {

--- a/stl/inc/bitset
+++ b/stl/inc/bitset
@@ -337,7 +337,7 @@ public:
     }
 
     _NODISCARD size_t count() const noexcept { // count number of set bits
-        return _SelectPopCountImpl([this](auto _Popcount_impl) {
+        return _Select_popcount_impl([this](auto _Popcount_impl) {
             size_t _Val = 0;
             for (size_t _Wpos = 0; _Wpos <= _Words; ++_Wpos) {
                 _Val += _Popcount_impl(_Array[_Wpos]);

--- a/stl/inc/limits
+++ b/stl/inc/limits
@@ -1032,6 +1032,12 @@ _NODISCARD constexpr int _Countr_zero_fallback(const _Ty _Val) noexcept {
 template <class _Ty>
 _NODISCARD constexpr int _Popcount_fallback(_Ty _Val) noexcept {
     constexpr int _Digits = numeric_limits<_Ty>::digits;
+#if defined(_M_IX86) || defined(_M_ARM)
+    if constexpr (_Digits == 64) {
+        return _Popcount_fallback(static_cast<unsigned long>(_Val))
+             + _Popcount_fallback(static_cast<unsigned long>(_Val >> 32));
+    }
+#endif // defined(_M_IX86) || defined(_M_ARM)
     // we static_cast these bit patterns in order to truncate them to the correct size
     _Val = static_cast<_Ty>(_Val - ((_Val >> 1) & static_cast<_Ty>(0x5555'5555'5555'5555ull)));
     _Val = static_cast<_Ty>((_Val & static_cast<_Ty>(0x3333'3333'3333'3333ull))
@@ -1042,14 +1048,6 @@ _NODISCARD constexpr int _Popcount_fallback(_Ty _Val) noexcept {
     // Extract highest byte
     return static_cast<int>(_Val >> (_Digits - 8));
 }
-
-#if defined(_M_IX86) || defined(_M_ARM)
-template <>
-_NODISCARD constexpr int _Popcount_fallback<unsigned long long>(unsigned long long _Val) noexcept {
-    return _Popcount_fallback(static_cast<unsigned long>(_Val))
-         + _Popcount_fallback(static_cast<unsigned long>(_Val >> 32));
-}
-#endif
 
 #if defined(_M_IX86) || defined(_M_X64)
 extern "C" {
@@ -1180,8 +1178,8 @@ _NODISCARD _CONSTEXPR20 int _Popcount(const _Ty _Val) noexcept {
     return _Popcount_fallback(_Val);
 }
 
-template <typename _Ty, typename _Fn>
-auto _Select_popcount_impl(_Fn _Callback) {
+template <class _Ty, class _Fn>
+decltype(auto) _Select_popcount_impl(_Fn _Callback) {
     // TRANSITION, DevCom-1527995: Lambdas in this function ensure inlining
 #if _HAS_POPCNT_INTRINSICS
 #ifndef __AVX__

--- a/stl/inc/limits
+++ b/stl/inc/limits
@@ -1043,6 +1043,13 @@ struct _Popcount_fallback_t {
         // Extract highest byte
         return static_cast<int>(_Val >> (_Digits - 8));
     }
+
+#if defined(_M_IX86) || defined(_M_ARM)
+    template <>
+    _NODISCARD constexpr int operator()<unsigned long long>(unsigned long long _Val) noexcept {
+        return operator()(static_cast<unsigned long>(_Val)) + operator()(static_cast<unsigned long>(_Val >> 32));
+    }
+#endif
 };
 
 #if defined(_M_IX86) || defined(_M_X64)
@@ -1104,6 +1111,7 @@ _NODISCARD int _Checked_x86_x64_countr_zero(const _Ty _Val) noexcept {
 #define _HAS_POPCNT_INTRINSICS 0
 #endif // ^^^ intrinsics unavailable ^^^
 
+#if _HAS_POPCNT_INTRINSICS
 struct _Unhecked_x86_x64_popcount_t {
     template <class _Ty>
     _NODISCARD int operator()(const _Ty _Val) noexcept {
@@ -1122,7 +1130,6 @@ struct _Unhecked_x86_x64_popcount_t {
     }
 };
 
-#if _HAS_POPCNT_INTRINSICS
 struct _Checked_x86_x64_popcount_t {
     template <class _Ty>
     _NODISCARD int operator()(const _Ty _Val) noexcept {

--- a/stl/inc/limits
+++ b/stl/inc/limits
@@ -1188,7 +1188,7 @@ _NODISCARD _CONSTEXPR20 int _Popcount(const _Ty _Val) noexcept {
 }
 
 template <typename _Fn>
-auto _SelectPopCountImpl(_Fn _Callback) {
+auto _Select_popcount_impl(_Fn _Callback) {
 #if _HAS_POPCNT_INTRINSICS
 #ifndef __AVX__
     const bool _Definitely_have_popcnt = __isa_available >= __ISA_AVAILABLE_SSE42;

--- a/stl/inc/limits
+++ b/stl/inc/limits
@@ -1029,19 +1029,21 @@ _NODISCARD constexpr int _Countr_zero_fallback(const _Ty _Val) noexcept {
 
 // Implementation of popcount without using specialized CPU instructions.
 // Used at compile time and when said instructions are not supported.
-template <class _Ty>
-_NODISCARD constexpr int _Popcount_fallback(_Ty _Val) noexcept {
-    constexpr int _Digits = numeric_limits<_Ty>::digits;
-    // we static_cast these bit patterns in order to truncate them to the correct size
-    _Val = static_cast<_Ty>(_Val - ((_Val >> 1) & static_cast<_Ty>(0x5555'5555'5555'5555ull)));
-    _Val = static_cast<_Ty>((_Val & static_cast<_Ty>(0x3333'3333'3333'3333ull))
-                            + ((_Val >> 2) & static_cast<_Ty>(0x3333'3333'3333'3333ull)));
-    _Val = static_cast<_Ty>((_Val + (_Val >> 4)) & static_cast<_Ty>(0x0F0F'0F0F'0F0F'0F0Full));
-    // Multiply by one in each byte, so that it will have the sum of all source bytes in the highest byte
-    _Val = static_cast<_Ty>(_Val * static_cast<_Ty>(0x0101'0101'0101'0101ull));
-    // Extract highest byte
-    return static_cast<int>(_Val >> (_Digits - 8));
-}
+struct _Popcount_fallback_t {
+    template <class _Ty>
+    _NODISCARD constexpr int operator()(_Ty _Val) noexcept {
+        constexpr int _Digits = numeric_limits<_Ty>::digits;
+        // we static_cast these bit patterns in order to truncate them to the correct size
+        _Val = static_cast<_Ty>(_Val - ((_Val >> 1) & static_cast<_Ty>(0x5555'5555'5555'5555ull)));
+        _Val = static_cast<_Ty>((_Val & static_cast<_Ty>(0x3333'3333'3333'3333ull))
+                                + ((_Val >> 2) & static_cast<_Ty>(0x3333'3333'3333'3333ull)));
+        _Val = static_cast<_Ty>((_Val + (_Val >> 4)) & static_cast<_Ty>(0x0F0F'0F0F'0F0F'0F0Full));
+        // Multiply by one in each byte, so that it will have the sum of all source bytes in the highest byte
+        _Val = static_cast<_Ty>(_Val * static_cast<_Ty>(0x0101'0101'0101'0101ull));
+        // Extract highest byte
+        return static_cast<int>(_Val >> (_Digits - 8));
+    }
+};
 
 #if defined(_M_IX86) || defined(_M_X64)
 extern "C" {
@@ -1102,36 +1104,46 @@ _NODISCARD int _Checked_x86_x64_countr_zero(const _Ty _Val) noexcept {
 #define _HAS_POPCNT_INTRINSICS 0
 #endif // ^^^ intrinsics unavailable ^^^
 
-#if _HAS_POPCNT_INTRINSICS
-template <class _Ty>
-_NODISCARD int _Checked_x86_x64_popcount(const _Ty _Val) noexcept {
-    constexpr int _Digits = numeric_limits<_Ty>::digits;
-#ifndef __AVX__
-    const bool _Definitely_have_popcnt = __isa_available >= __ISA_AVAILABLE_SSE42;
-    if (!_Definitely_have_popcnt) {
-        return _Popcount_fallback(_Val);
-    }
-#endif // !defined(__AVX__)
-
-    if constexpr (_Digits <= 16) {
-        return static_cast<int>(__popcnt16(_Val));
-    } else if constexpr (_Digits == 32) {
-        return static_cast<int>(__popcnt(_Val));
-    } else {
+struct _Unhecked_x86_x64_popcount_t {
+    template <class _Ty>
+    _NODISCARD int operator()(const _Ty _Val) noexcept {
+        constexpr int _Digits = numeric_limits<_Ty>::digits;
+        if constexpr (_Digits <= 16) {
+            return static_cast<int>(__popcnt16(_Val));
+        } else if constexpr (_Digits == 32) {
+            return static_cast<int>(__popcnt(_Val));
+        } else {
 #ifdef _M_IX86
-        return static_cast<int>(__popcnt(_Val >> 32) + __popcnt(static_cast<unsigned int>(_Val)));
+            return static_cast<int>(__popcnt(_Val >> 32) + __popcnt(static_cast<unsigned int>(_Val)));
 #else // ^^^ _M_IX86 / !_M_IX86 vvv
-        return static_cast<int>(__popcnt64(_Val));
+            return static_cast<int>(__popcnt64(_Val));
 #endif // _M_IX86
+        }
     }
-}
+};
+
+#if _HAS_POPCNT_INTRINSICS
+struct _Checked_x86_x64_popcount_t {
+    template <class _Ty>
+    _NODISCARD int operator()(const _Ty _Val) noexcept {
+#ifndef __AVX__
+        const bool _Definitely_have_popcnt = __isa_available >= __ISA_AVAILABLE_SSE42;
+        if (!_Definitely_have_popcnt) {
+            return _Popcount_fallback_t{}(_Val);
+        }
+#endif // !defined(__AVX__)
+        return _Unhecked_x86_x64_popcount_t{}(_Val);
+    }
+};
 #endif // _HAS_POPCNT_INTRINSICS
 
 #if _HAS_NEON_INTRINSICS
-_NODISCARD inline int _Arm64_popcount(const unsigned long long _Val) noexcept {
-    const __n64 _Temp = neon_cnt(__uint64ToN64_v(_Val));
-    return neon_addv8(_Temp).n8_i8[0];
-}
+struct _Arm64_popcount_t {
+    _NODISCARD inline int operator()(const unsigned long long _Val) noexcept {
+        const __n64 _Temp = neon_cnt(__uint64ToN64_v(_Val));
+        return neon_addv8(_Temp).n8_i8[0];
+    }
+};
 #endif // _HAS_NEON_INTRINSICS
 
 template <class _Ty>
@@ -1159,13 +1171,30 @@ _NODISCARD _CONSTEXPR20 int _Popcount(const _Ty _Val) noexcept {
 #endif // _HAS_CXX20
     {
 #if _HAS_POPCNT_INTRINSICS
-        return _Checked_x86_x64_popcount(_Val);
+        return _Checked_x86_x64_popcount_t{}(_Val);
 #elif _HAS_NEON_INTRINSICS // ^^^ x86/x64 intrinsics available ^^^ / vvv ARM64 intrinsics available vvv
-        return _Arm64_popcount(_Val);
+        return _Arm64_popcount_t{}(_Val);
 #endif // ^^^ ARM64 intrinsics available ^^^
     }
 #endif // ^^^ any intrinsics available ^^^
-    return _Popcount_fallback(_Val);
+    return _Popcount_fallback_t{}(_Val);
+}
+
+template<typename _Fn>
+auto _SelectPopCountImpl(_Fn _Callback) {
+#if _HAS_POPCNT_INTRINSICS
+#ifndef __AVX__
+    const bool _Definitely_have_popcnt = __isa_available >= __ISA_AVAILABLE_SSE42;
+    if (!_Definitely_have_popcnt) {
+        return _Callback(_Popcount_fallback_t{});
+    }
+#endif // !defined(__AVX__)
+    return _Callback(_Unhecked_x86_x64_popcount_t{});
+#elif _HAS_NEON_INTRINSICS  // ^^^ x86/x64 intrinsics available ^^^ / vvv ARM64 intrinsics available vvv
+    return _Callback(_Arm64_popcount_t{});
+#else // ^^^ ARM64 intrinsics available ^^^
+    return _Callback(_Popcount_fallback_t{});
+#endif
 }
 
 #undef _HAS_POPCNT_INTRINSICS

--- a/stl/inc/limits
+++ b/stl/inc/limits
@@ -1112,7 +1112,7 @@ _NODISCARD int _Checked_x86_x64_countr_zero(const _Ty _Val) noexcept {
 
 #if _HAS_POPCNT_INTRINSICS
 template <class _Ty>
-_NODISCARD int _Unhecked_x86_x64_popcount(const _Ty _Val) noexcept {
+_NODISCARD int _Unchecked_x86_x64_popcount(const _Ty _Val) noexcept {
     constexpr int _Digits = numeric_limits<_Ty>::digits;
     if constexpr (_Digits <= 16) {
         return static_cast<int>(__popcnt16(_Val));
@@ -1135,7 +1135,7 @@ _NODISCARD int _Checked_x86_x64_popcount(const _Ty _Val) noexcept {
         return _Popcount_fallback(_Val);
     }
 #endif // !defined(__AVX__)
-    return _Unhecked_x86_x64_popcount(_Val);
+    return _Unchecked_x86_x64_popcount(_Val);
 }
 #endif // _HAS_POPCNT_INTRINSICS
 
@@ -1190,7 +1190,7 @@ auto _Select_popcount_impl(_Fn _Callback) {
         return _Callback([](_Ty _Val) { return _Popcount_fallback(_Val); });
     }
 #endif // !defined(__AVX__)
-    return _Callback([](_Ty _Val) { return _Unhecked_x86_x64_popcount(_Val); });
+    return _Callback([](_Ty _Val) { return _Unchecked_x86_x64_popcount(_Val); });
 #elif _HAS_NEON_INTRINSICS // ^^^ x86/x64 intrinsics available ^^^ / vvv ARM64 intrinsics available vvv
     return _Callback([](_Ty _Val) { return _Arm64_popcount(_Val); });
 #else // ^^^ ARM64 intrinsics available ^^^ / vvv no intrinsics available vvv

--- a/stl/inc/limits
+++ b/stl/inc/limits
@@ -1180,21 +1180,21 @@ _NODISCARD _CONSTEXPR20 int _Popcount(const _Ty _Val) noexcept {
     return _Popcount_fallback(_Val);
 }
 
-template <typename _Fn>
+template <typename _Ty, typename _Fn>
 auto _Select_popcount_impl(_Fn _Callback) {
     // TRANSITION, DevCom-1527995: Lambdas in this function ensure inlining
 #if _HAS_POPCNT_INTRINSICS
 #ifndef __AVX__
     const bool _Definitely_have_popcnt = __isa_available >= __ISA_AVAILABLE_SSE42;
     if (!_Definitely_have_popcnt) {
-        return _Callback([](auto _Val) { return _Popcount_fallback(_Val); });
+        return _Callback([](_Ty _Val) { return _Popcount_fallback(_Val); });
     }
 #endif // !defined(__AVX__)
-    return _Callback([](auto _Val) { return _Unhecked_x86_x64_popcount(_Val); });
+    return _Callback([](_Ty _Val) { return _Unhecked_x86_x64_popcount(_Val); });
 #elif _HAS_NEON_INTRINSICS // ^^^ x86/x64 intrinsics available ^^^ / vvv ARM64 intrinsics available vvv
-    return _Callback([](auto _Val) { return _Arm64_popcount(_Val); });
+    return _Callback([](_Ty _Val) { return _Arm64_popcount(_Val); });
 #else // ^^^ ARM64 intrinsics available ^^^ / vvv no intrinsics available vvv
-    return _Callback([](auto _Val) { return _Popcount_fallback(_Val); });
+    return _Callback([](_Ty _Val) { return _Popcount_fallback(_Val); });
 #endif // ^^^ no intrinsics available ^^^
 }
 

--- a/stl/inc/limits
+++ b/stl/inc/limits
@@ -1029,28 +1029,26 @@ _NODISCARD constexpr int _Countr_zero_fallback(const _Ty _Val) noexcept {
 
 // Implementation of popcount without using specialized CPU instructions.
 // Used at compile time and when said instructions are not supported.
-struct _Popcount_fallback_t {
-    template <class _Ty>
-    _NODISCARD constexpr int operator()(_Ty _Val) noexcept {
-        constexpr int _Digits = numeric_limits<_Ty>::digits;
-        // we static_cast these bit patterns in order to truncate them to the correct size
-        _Val = static_cast<_Ty>(_Val - ((_Val >> 1) & static_cast<_Ty>(0x5555'5555'5555'5555ull)));
-        _Val = static_cast<_Ty>((_Val & static_cast<_Ty>(0x3333'3333'3333'3333ull))
-                                + ((_Val >> 2) & static_cast<_Ty>(0x3333'3333'3333'3333ull)));
-        _Val = static_cast<_Ty>((_Val + (_Val >> 4)) & static_cast<_Ty>(0x0F0F'0F0F'0F0F'0F0Full));
-        // Multiply by one in each byte, so that it will have the sum of all source bytes in the highest byte
-        _Val = static_cast<_Ty>(_Val * static_cast<_Ty>(0x0101'0101'0101'0101ull));
-        // Extract highest byte
-        return static_cast<int>(_Val >> (_Digits - 8));
-    }
+template <class _Ty>
+_NODISCARD constexpr int _Popcount_fallback(_Ty _Val) noexcept {
+    constexpr int _Digits = numeric_limits<_Ty>::digits;
+    // we static_cast these bit patterns in order to truncate them to the correct size
+    _Val = static_cast<_Ty>(_Val - ((_Val >> 1) & static_cast<_Ty>(0x5555'5555'5555'5555ull)));
+    _Val = static_cast<_Ty>((_Val & static_cast<_Ty>(0x3333'3333'3333'3333ull))
+                            + ((_Val >> 2) & static_cast<_Ty>(0x3333'3333'3333'3333ull)));
+    _Val = static_cast<_Ty>((_Val + (_Val >> 4)) & static_cast<_Ty>(0x0F0F'0F0F'0F0F'0F0Full));
+    // Multiply by one in each byte, so that it will have the sum of all source bytes in the highest byte
+    _Val = static_cast<_Ty>(_Val * static_cast<_Ty>(0x0101'0101'0101'0101ull));
+    // Extract highest byte
+    return static_cast<int>(_Val >> (_Digits - 8));
+}
 
 #if defined(_M_IX86) || defined(_M_ARM)
-    template <>
-    _NODISCARD constexpr int operator()<unsigned long long>(unsigned long long _Val) noexcept {
-        return operator()(static_cast<unsigned long>(_Val)) + operator()(static_cast<unsigned long>(_Val >> 32));
-    }
+template <>
+_NODISCARD constexpr int _Popcount_fallback<unsigned long long>(unsigned long long _Val) noexcept {
+    return operator()(static_cast<unsigned long>(_Val)) + operator()(static_cast<unsigned long>(_Val >> 32));
+}
 #endif
-};
 
 #if defined(_M_IX86) || defined(_M_X64)
 extern "C" {
@@ -1112,36 +1110,32 @@ _NODISCARD int _Checked_x86_x64_countr_zero(const _Ty _Val) noexcept {
 #endif // ^^^ intrinsics unavailable ^^^
 
 #if _HAS_POPCNT_INTRINSICS
-struct _Unhecked_x86_x64_popcount_t {
-    template <class _Ty>
-    _NODISCARD int operator()(const _Ty _Val) noexcept {
-        constexpr int _Digits = numeric_limits<_Ty>::digits;
-        if constexpr (_Digits <= 16) {
-            return static_cast<int>(__popcnt16(_Val));
-        } else if constexpr (_Digits == 32) {
-            return static_cast<int>(__popcnt(_Val));
-        } else {
+template <class _Ty>
+_NODISCARD int _Unhecked_x86_x64_popcount(const _Ty _Val) noexcept {
+    constexpr int _Digits = numeric_limits<_Ty>::digits;
+    if constexpr (_Digits <= 16) {
+        return static_cast<int>(__popcnt16(_Val));
+    } else if constexpr (_Digits == 32) {
+        return static_cast<int>(__popcnt(_Val));
+    } else {
 #ifdef _M_IX86
-            return static_cast<int>(__popcnt(_Val >> 32) + __popcnt(static_cast<unsigned int>(_Val)));
+        return static_cast<int>(__popcnt(_Val >> 32) + __popcnt(static_cast<unsigned int>(_Val)));
 #else // ^^^ _M_IX86 / !_M_IX86 vvv
-            return static_cast<int>(__popcnt64(_Val));
+        return static_cast<int>(__popcnt64(_Val));
 #endif // _M_IX86
-        }
     }
-};
+}
 
-struct _Checked_x86_x64_popcount_t {
-    template <class _Ty>
-    _NODISCARD int operator()(const _Ty _Val) noexcept {
+template <class _Ty>
+_NODISCARD int _Checked_x86_x64_popcount(const _Ty _Val) noexcept {
 #ifndef __AVX__
-        const bool _Definitely_have_popcnt = __isa_available >= __ISA_AVAILABLE_SSE42;
-        if (!_Definitely_have_popcnt) {
-            return _Popcount_fallback_t{}(_Val);
-        }
-#endif // !defined(__AVX__)
-        return _Unhecked_x86_x64_popcount_t{}(_Val);
+    const bool _Definitely_have_popcnt = __isa_available >= __ISA_AVAILABLE_SSE42;
+    if (!_Definitely_have_popcnt) {
+        return _Popcount_fallback(_Val);
     }
-};
+#endif // !defined(__AVX__)
+    return _Unhecked_x86_x64_popcount(_Val);
+}
 #endif // _HAS_POPCNT_INTRINSICS
 
 #if _HAS_NEON_INTRINSICS
@@ -1178,29 +1172,30 @@ _NODISCARD _CONSTEXPR20 int _Popcount(const _Ty _Val) noexcept {
 #endif // _HAS_CXX20
     {
 #if _HAS_POPCNT_INTRINSICS
-        return _Checked_x86_x64_popcount_t{}(_Val);
+        return _Checked_x86_x64_popcount(_Val);
 #elif _HAS_NEON_INTRINSICS // ^^^ x86/x64 intrinsics available ^^^ / vvv ARM64 intrinsics available vvv
-        return _Arm64_popcount_t{}(_Val);
+        return _Arm64_popcount(_Val);
 #endif // ^^^ ARM64 intrinsics available ^^^
     }
 #endif // ^^^ any intrinsics available ^^^
-    return _Popcount_fallback_t{}(_Val);
+    return _Popcount_fallback(_Val);
 }
 
 template <typename _Fn>
 auto _Select_popcount_impl(_Fn _Callback) {
+    // Lambdas in this function ensure inlining
 #if _HAS_POPCNT_INTRINSICS
 #ifndef __AVX__
     const bool _Definitely_have_popcnt = __isa_available >= __ISA_AVAILABLE_SSE42;
     if (!_Definitely_have_popcnt) {
-        return _Callback(_Popcount_fallback_t{});
+        return _Callback([](auto _Val) { return _Popcount_fallback(_Val); });
     }
 #endif // !defined(__AVX__)
-    return _Callback(_Unhecked_x86_x64_popcount_t{});
+    return _Callback([](auto _Val) { return _Unhecked_x86_x64_popcount(_Val); });
 #elif _HAS_NEON_INTRINSICS // ^^^ x86/x64 intrinsics available ^^^ / vvv ARM64 intrinsics available vvv
-    return _Callback(_Arm64_popcount_t{});
+    return _Callback([](auto _Val) { return _Arm64_popcount(_Val); });
 #else // ^^^ ARM64 intrinsics available ^^^
-    return _Callback(_Popcount_fallback_t{});
+    return _Callback([](auto _Val) { return _Popcount_fallback(_Val); });
 #endif
 }
 

--- a/stl/inc/limits
+++ b/stl/inc/limits
@@ -1046,7 +1046,8 @@ _NODISCARD constexpr int _Popcount_fallback(_Ty _Val) noexcept {
 #if defined(_M_IX86) || defined(_M_ARM)
 template <>
 _NODISCARD constexpr int _Popcount_fallback<unsigned long long>(unsigned long long _Val) noexcept {
-    return operator()(static_cast<unsigned long>(_Val)) + operator()(static_cast<unsigned long>(_Val >> 32));
+    return _Popcount_fallback(static_cast<unsigned long>(_Val))
+         + _Popcount_fallback(static_cast<unsigned long>(_Val >> 32));
 }
 #endif
 

--- a/stl/inc/limits
+++ b/stl/inc/limits
@@ -1139,12 +1139,10 @@ _NODISCARD int _Checked_x86_x64_popcount(const _Ty _Val) noexcept {
 #endif // _HAS_POPCNT_INTRINSICS
 
 #if _HAS_NEON_INTRINSICS
-struct _Arm64_popcount_t {
-    _NODISCARD inline int operator()(const unsigned long long _Val) noexcept {
-        const __n64 _Temp = neon_cnt(__uint64ToN64_v(_Val));
-        return neon_addv8(_Temp).n8_i8[0];
-    }
-};
+_NODISCARD inline int _Arm64_popcount(const unsigned long long _Val) noexcept {
+    const __n64 _Temp = neon_cnt(__uint64ToN64_v(_Val));
+    return neon_addv8(_Temp).n8_i8[0];
+}
 #endif // _HAS_NEON_INTRINSICS
 
 template <class _Ty>

--- a/stl/inc/limits
+++ b/stl/inc/limits
@@ -1182,7 +1182,7 @@ _NODISCARD _CONSTEXPR20 int _Popcount(const _Ty _Val) noexcept {
 
 template <typename _Fn>
 auto _Select_popcount_impl(_Fn _Callback) {
-    // Lambdas in this function ensure inlining
+    // TRANSITION, DevCom-1527995: Lambdas in this function ensure inlining
 #if _HAS_POPCNT_INTRINSICS
 #ifndef __AVX__
     const bool _Definitely_have_popcnt = __isa_available >= __ISA_AVAILABLE_SSE42;
@@ -1193,9 +1193,9 @@ auto _Select_popcount_impl(_Fn _Callback) {
     return _Callback([](auto _Val) { return _Unhecked_x86_x64_popcount(_Val); });
 #elif _HAS_NEON_INTRINSICS // ^^^ x86/x64 intrinsics available ^^^ / vvv ARM64 intrinsics available vvv
     return _Callback([](auto _Val) { return _Arm64_popcount(_Val); });
-#else // ^^^ ARM64 intrinsics available ^^^
+#else // ^^^ ARM64 intrinsics available ^^^ / vvv no intrinsics available vvv
     return _Callback([](auto _Val) { return _Popcount_fallback(_Val); });
-#endif
+#endif // ^^^ no intrinsics available ^^^
 }
 
 #undef _HAS_POPCNT_INTRINSICS

--- a/stl/inc/limits
+++ b/stl/inc/limits
@@ -1187,7 +1187,7 @@ _NODISCARD _CONSTEXPR20 int _Popcount(const _Ty _Val) noexcept {
     return _Popcount_fallback_t{}(_Val);
 }
 
-template<typename _Fn>
+template <typename _Fn>
 auto _SelectPopCountImpl(_Fn _Callback) {
 #if _HAS_POPCNT_INTRINSICS
 #ifndef __AVX__
@@ -1197,7 +1197,7 @@ auto _SelectPopCountImpl(_Fn _Callback) {
     }
 #endif // !defined(__AVX__)
     return _Callback(_Unhecked_x86_x64_popcount_t{});
-#elif _HAS_NEON_INTRINSICS  // ^^^ x86/x64 intrinsics available ^^^ / vvv ARM64 intrinsics available vvv
+#elif _HAS_NEON_INTRINSICS // ^^^ x86/x64 intrinsics available ^^^ / vvv ARM64 intrinsics available vvv
     return _Callback(_Arm64_popcount_t{});
 #else // ^^^ ARM64 intrinsics available ^^^
     return _Callback(_Popcount_fallback_t{});


### PR DESCRIPTION
Resolve  #667

Moving dispatch out of loop does not rely on compiler optimization.

Rewrite of #2126 PR. The original PR had an issue that it relied on compiler optimization to move the check out of loop, which did not happen always.

To make sure the machinery is kept in `<limits>`, the callback is used. To make sure the functions are always inlined into the callback, they are wrapped into lambdas.

Additionally, as @statementreply suggested, made 32-bit version of fallback using 32-bit types, and for 64-bit types making work by parts.

<details>
<summary>Benchmark</summary>

```C++
// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception

#include <bit>
#include <chrono>
#include <iostream>
#include <random>
#include <limits>

template<std::size_t Words>
struct bitset {

    void populate() {
        std::mt19937 mt(43223);
        std::uniform_int_distribution<Ty> dis(std::numeric_limits<Ty>::min(), std::numeric_limits<Ty>::max());
        for (std::size_t Wpos = 0; Wpos <= Words; ++Wpos) {
            Array[Wpos] = dis(mt);
        }
    }

    using Ty = std::uint64_t;

    size_t count_old() const noexcept {
        const char* const _Bitsperbyte =
            "\0\1\1\2\1\2\2\3\1\2\2\3\2\3\3\4"
            "\1\2\2\3\2\3\3\4\2\3\3\4\3\4\4\5"
            "\1\2\2\3\2\3\3\4\2\3\3\4\3\4\4\5"
            "\2\3\3\4\3\4\4\5\3\4\4\5\4\5\5\6"
            "\1\2\2\3\2\3\3\4\2\3\3\4\3\4\4\5"
            "\2\3\3\4\3\4\4\5\3\4\4\5\4\5\5\6"
            "\2\3\3\4\3\4\4\5\3\4\4\5\4\5\5\6"
            "\3\4\4\5\4\5\5\6\4\5\5\6\5\6\6\7"
            "\1\2\2\3\2\3\3\4\2\3\3\4\3\4\4\5"
            "\2\3\3\4\3\4\4\5\3\4\4\5\4\5\5\6"
            "\2\3\3\4\3\4\4\5\3\4\4\5\4\5\5\6"
            "\3\4\4\5\4\5\5\6\4\5\5\6\5\6\6\7"
            "\2\3\3\4\3\4\4\5\3\4\4\5\4\5\5\6"
            "\3\4\4\5\4\5\5\6\4\5\5\6\5\6\6\7"
            "\3\4\4\5\4\5\5\6\4\5\5\6\5\6\6\7"
            "\4\5\5\6\5\6\6\7\5\6\6\7\6\7\7\x8";
        const unsigned char* _Ptr = &reinterpret_cast<const unsigned char&>(Array);
        const unsigned char* const _End = _Ptr + sizeof(Array);
        size_t _Val = 0;
        for (; _Ptr != _End; ++_Ptr) {
            _Val += _Bitsperbyte[*_Ptr];
        }

        return _Val;
    }

    size_t count_new() const noexcept {
        return std::_Select_popcount_impl<Ty>([this](auto _Popcount_impl) {
            constexpr auto _Count = Words;
            size_t _Val = 0;
            for (size_t _Wpos = 0; _Wpos <= _Count; ++_Wpos) {
                _Val += _Popcount_impl(Array[_Wpos]);
            }
            return _Val;
            });
    }

    Ty Array[Words + 1];
};

volatile std::size_t result;

int main()
{
    const int N = 20000;
    bitset<10'000> bs;
    bs.populate();

    std::chrono::steady_clock::duration d1{};
    std::chrono::steady_clock::duration d2{};
    std::chrono::steady_clock::duration d3{};
    std::chrono::steady_clock::time_point t;

    t = std::chrono::steady_clock::now();
    for (int i = 0; i < N; ++i) {
        result = bs.count_old();
    }
    d1 = std::chrono::steady_clock::now() - t;

    t = std::chrono::steady_clock::now();
    for (int i = 0; i < N; ++i) {
        result = bs.count_new();
    }
    d2 = std::chrono::steady_clock::now() - t;

    std::__isa_available = 0;
    t = std::chrono::steady_clock::now();
    for (int i = 0; i < N; ++i) {
        result = bs.count_new();
    }
    d3 = std::chrono::steady_clock::now() - t;

    std::cout << "old\t" << d1 << "\n";
    std::cout << "new\t" << d2 << "\n";
    std::cout << "new fb\t" << d3 << "\n";
    return 0;
}
```

</details>

**Results:**
(fb stands for fallback implementation when `__isa_available` is set to zero)
x64
```
old     538852500ns
new     154080600ns
new fb  311499000ns
```
x86
```
old     1245970000ns
new     153716400ns
new fb  480384500ns
```
