### PR TITLE
Skip flaky `tr1` tests

### DIFF
--- a/tests/tr1/expected_results.txt
+++ b/tests/tr1/expected_results.txt
@@ -1,5 +1,11 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+# TRANSITION, flaky tests
+tests/atomic1 SKIPPED
+tests/atomic2 SKIPPED
+tests/atomic4 SKIPPED
+tests/condition_variable SKIPPED
+
 # TRANSITION, flaky test (see GH-1642 and GH-718)
 tests/thread SKIPPED

--- a/tests/tr1/test.lst
+++ b/tests/tr1/test.lst
@@ -4,9 +4,12 @@
 tests\algorithm
 tests\array
 tests\atomic
-tests\atomic1
-tests\atomic2
-tests\atomic4
+
+# TRANSITION, flaky tests
+# tests\atomic1
+# tests\atomic2
+# tests\atomic4
+
 tests\bitset
 tests\cctype
 tests\cerrno
@@ -22,7 +25,10 @@ tests\codecvt
 tests\complex1
 tests\complex2
 tests\complex3
-tests\condition_variable
+
+# TRANSITION, flaky tests
+# tests\condition_variable
+
 tests\csetjmp
 tests\csignal
 tests\cstdarg


### PR DESCRIPTION
We've been investigating flaky tests in the MSVC-internal test harness, and a few tests in the legacy `tr1` test suite were especially flaky. While we haven't seen sporadic failures in the GitHub test harness, this is likely due to machine configuration and other environment issues. We've seen in the past that the `tr1` multithreading tests weren't written with strict attention to detail for being timing-insensitive (i.e. a multithreading test should *never* sporadically fail, regardless of how scheduling is performed).

As we have better coverage in `std` and `libcxx`, I'm not worried about the loss of test coverage here.

Internal test harness results
---
I ran `std`, `tr1`, and `libcxx` 100 times in the internal test harness, which will rerun a failing test up to 10 times before reporting it as failed (this is wrong and bad, so we're working on fixing it; our GitHub test harness doesn't have retry logic). Here are the test directories that showed up as performing any number of retries. As the Notes mention, out of these 100 runs, 2 tests failed their 10 retries and reported failure/timeout.

| Retries | Suite  | Test | Notes |
|--------:|--------|------|-------|
|       9 | libcxx | utilities\variant\variant.visit
|       1 | libcxx | containers\associative\map\map.special
|       1 | libcxx | containers\sequences\vector.bool
|       1 | libcxx | containers\sequences\vector\vector.modifiers
|       1 | libcxx | containers\unord\unord.map
|       1 | libcxx | input.output\stream.buffers\streambuf\streambuf.protected\streambuf.put.area
|       1 | libcxx | language.support\support.types\byteops
|       1 | libcxx | numerics\numarray\template.valarray\valarray.members
|       1 | libcxx | numerics\numarray\valarray.nonmembers\valarray.comparison
|       1 | libcxx | numerics\rand\rand.dis\rand.dist.samp\rand.dist.samp.plinear
|       1 | libcxx | numerics\rand\rand.eng\rand.eng.lcong
|       1 | libcxx | strings\char.traits\char.traits.specializations\char.traits.specializations.char32_t
|       1 | libcxx | thread
|       1 | libcxx | thread\thread.semaphore
|       1 | libcxx | utilities\memory\allocator.tag
|       1 | libcxx | utilities\meta\meta.unary\meta.unary.comp
|       1 | libcxx | utilities\smartptr\unique.ptr\unique.ptr.class\unique.ptr.modifiers
|     --- | ---    | --- |
|       2 | std    | tests\Dev11_0485243_condition_variable_crash
|       2 | std    | tests\VSO_0000000_instantiate_algorithms_int_2
|       1 | std    | tests\P0896R4_ranges_alg_mismatch
|       1 | std    | tests\VSO_0000000_instantiate_algorithms_64_difference_type_2
|     --- | ---    | --- |
|     240 | tr1    | tests\condition_variable | **1 timeout**
|     119 | tr1    | tests\atomic1            |
|      61 | tr1    | tests\atomic4            |
|      35 | tr1    | tests\atomic2            | **1 timeout**
|       1 | tr1    | tests\fstream1           |
|       1 | tr1    | tests\fstream2           |

Given these results, I decided to skip all of the double-digit retries, which were limited to `tr1` multithreading tests. A few of the other tests looked like they might contain inherent flakiness from their names (notably `libcxx` `thread` and `thread\thread.semaphore`, and `std` `Dev11_0485243_condition_variable_crash`), but the individual retries weren't enough for me to distinguish true flakiness from compilation timeouts or internal infrastructure issues. Some of the other retries (especially `libcxx` `utilities\variant\variant.visit` and the other `std` tests) appear to be tests that take a long time to compile, which reached our fairly aggressive timeouts on too-heavily-loaded VMs. For those, I'll be increasing the internal timeouts; if problems persist, we may need to decompose the tests further (for `std`) or investigate skipping (for `libcxx`).