### PR TITLE
Toolset update: VS 2022 17.0 Preview 4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.21)
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 project(msvc_standard_libraries LANGUAGES CXX)
 

--- a/README.md
+++ b/README.md
@@ -140,10 +140,10 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With The Visual Studio IDE
 
-1. Install Visual Studio 2022 17.0 Preview 3 or later.
+1. Install Visual Studio 2022 17.0 Preview 4 or later.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
-    * Otherwise, install [CMake][] 3.20 or later, and [Ninja][] 1.10.2 or later.
+    * Otherwise, install [CMake][] 3.21 or later, and [Ninja][] 1.10.2 or later.
     * We recommend selecting "Python 3 64-bit" in the VS Installer.
     * Otherwise, make sure [Python][] 3.9 or later is available to CMake.
 2. Open Visual Studio, and choose the "Clone or check out code" option. Enter the URL of this repository,
@@ -155,10 +155,10 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With A Native Tools Command Prompt
 
-1. Install Visual Studio 2022 17.0 Preview 3 or later.
+1. Install Visual Studio 2022 17.0 Preview 4 or later.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
-    * Otherwise, install [CMake][] 3.20 or later, and [Ninja][] 1.10.2 or later.
+    * Otherwise, install [CMake][] 3.21 or later, and [Ninja][] 1.10.2 or later.
     * We recommend selecting "Python 3 64-bit" in the VS Installer.
     * Otherwise, make sure [Python][] 3.9 or later is available to CMake.
 2. Open a command prompt.

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -91,7 +91,7 @@ if ([string]::IsNullOrEmpty($AdminUserPassword)) {
   $PsExecPath = Join-Path $ExtractedPsToolsPath 'PsExec64.exe'
 
   # https://github.com/PowerShell/PowerShell/releases/latest
-  $PowerShellZipUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.1.3/PowerShell-7.1.3-win-x64.zip'
+  $PowerShellZipUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.1.4/PowerShell-7.1.4-win-x64.zip'
   Write-Host "Downloading: $PowerShellZipUrl"
   $ExtractedPowerShellPath = DownloadAndExtractZip -Url $PowerShellZipUrl
   $PwshPath = Join-Path $ExtractedPowerShellPath 'pwsh.exe'
@@ -141,7 +141,7 @@ $Workloads = @(
 $ReleaseInPath = 'Preview'
 $Sku = 'Enterprise'
 $VisualStudioBootstrapperUrl = 'https://aka.ms/vs/17/pre/vs_enterprise.exe'
-$PythonUrl = 'https://www.python.org/ftp/python/3.9.6/python-3.9.6-amd64.exe'
+$PythonUrl = 'https://www.python.org/ftp/python/3.9.7/python-3.9.7-amd64.exe'
 
 # https://docs.microsoft.com/en-us/windows-hardware/drivers/download-the-wdk
 $WindowsDriverKitUrl = 'https://go.microsoft.com/fwlink/?linkid=2128854'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ variables:
   tmpDir: 'D:\Temp'
   buildOutputLocation: 'D:\build'
 
-pool: 'StlBuild-2021-08-11'
+pool: 'StlBuild-2021-09-14'
 
 stages:
   - stage: Code_Format

--- a/stl/inc/xstddef
+++ b/stl/inc/xstddef
@@ -267,11 +267,7 @@ _NODISCARD constexpr _Ty* _Unfancy(_Ty* _Ptr) noexcept { // do nothing for plain
 }
 _STD_END
 
-#if defined(__EDG__) && defined(_M_X64) // TRANSITION, VSO-1356169
-#define _EMIT_CDECL(FUNC, OPT1, OPT2, OPT3) FUNC(_EMPTY_ARGUMENT, OPT1, OPT2, OPT3)
-#else // ^^^ workaround / no workaround vvv
 #define _EMIT_CDECL(FUNC, OPT1, OPT2, OPT3) FUNC(__cdecl, OPT1, OPT2, OPT3)
-#endif // ^^^ no workaround ^^^
 
 #ifdef _M_CEE
 #define _EMIT_CLRCALL(FUNC, OPT1, OPT2, OPT3) FUNC(__clrcall, OPT1, OPT2, OPT3)

--- a/tests/std/tests/P0122R7_span/test.cpp
+++ b/tests/std/tests/P0122R7_span/test.cpp
@@ -991,10 +991,8 @@ constexpr bool test() {
         assert(*sp_dyn.begin() == 10);
         assert(*sp_nine.begin() == 10);
 
-#if !(defined(__EDG__) && defined(_M_X64)) // TRANSITION, VSO-1356637
         assert(sp_dyn.end()[-2] == 80);
         assert(sp_nine.end()[-2] == 80);
-#endif // TRANSITION, VSO-1356637
 
         assert(*sp_dyn.rbegin() == 90);
         assert(*sp_nine.rbegin() == 90);

--- a/tests/std/tests/P0220R1_string_view/test.cpp
+++ b/tests/std/tests/P0220R1_string_view/test.cpp
@@ -404,11 +404,7 @@ constexpr bool test_case_iterators() {
     assert(*testIterator == static_cast<CharT>('h'));
     testIterator += 8;
     assert(*testIterator == static_cast<CharT>('r'));
-#if defined(__EDG__) && defined(_M_X64) // TRANSITION, VSO-1356637
-    testIterator -= 4;
-#else // ^^^ workaround / no workaround vvv
     testIterator += -4;
-#endif // ^^^ no workaround ^^^
     assert(*testIterator == static_cast<CharT>('o'));
 
     assert(*(testIterator + 6) == static_cast<CharT>('d'));

--- a/tests/std/tests/P1004R2_constexpr_vector/test.cpp
+++ b/tests/std/tests/P1004R2_constexpr_vector/test.cpp
@@ -236,7 +236,6 @@ constexpr bool test_interface() {
         static_assert(is_same_v<remove_const_t<decltype(cb2)>, vec::const_iterator>);
         assert(*cb2 == 0);
 
-#if !(defined(__EDG__) && defined(_M_X64)) // TRANSITION, VSO-1356637
         const auto e = range_constructed.end();
         static_assert(is_same_v<remove_const_t<decltype(e)>, vec::iterator>);
         assert(*prev(e) == 5);
@@ -248,7 +247,6 @@ constexpr bool test_interface() {
         const auto ce2 = const_range_constructed.end();
         static_assert(is_same_v<remove_const_t<decltype(ce2)>, vec::const_iterator>);
         assert(*prev(ce2) == 5);
-#endif // TRANSITION, VSO-1356637
 
         const auto rb = range_constructed.rbegin();
         static_assert(is_same_v<remove_const_t<decltype(rb)>, reverse_iterator<vec::iterator>>);
@@ -315,7 +313,6 @@ constexpr bool test_interface() {
         static_assert(is_same_v<remove_const_t<decltype(cf)>, int>);
         assert(cf == 0);
 
-#if !(defined(__EDG__) && defined(_M_X64)) // TRANSITION, VSO-1356637
         const auto b = range_constructed.back();
         static_assert(is_same_v<remove_const_t<decltype(b)>, int>);
         assert(b == 5);
@@ -323,7 +320,6 @@ constexpr bool test_interface() {
         const auto cb = const_range_constructed.back();
         static_assert(is_same_v<remove_const_t<decltype(cb)>, int>);
         assert(cb == 5);
-#endif // TRANSITION, VSO-1356637
 
         const auto d = range_constructed.data();
         static_assert(is_same_v<remove_const_t<decltype(d)>, int*>);
@@ -555,7 +551,6 @@ constexpr bool test_iterators() {
         assert(*cit == 4);
     }
 
-#if !(defined(__EDG__) && defined(_M_X64)) // TRANSITION, VSO-1356637
     { // advance back
         auto it = range_constructed.end() - 2;
         assert(*it == 4);
@@ -567,7 +562,6 @@ constexpr bool test_iterators() {
         cit -= 2;
         assert(*cit == 2);
     }
-#endif // TRANSITION, VSO-1356637
 
     { // difference
         const auto it1 = range_constructed.begin();

--- a/tests/std/tests/P1502R1_standard_library_header_units/test.cpp
+++ b/tests/std/tests/P1502R1_standard_library_header_units/test.cpp
@@ -709,7 +709,7 @@ int main() {
             assert(read == expected);
         }
 
-#if 0 // TRANSITION, DevCom-1511903
+#ifdef MSVC_INTERNAL_TESTING // TRANSITION, DevCom-1511903
         const char const_buffer[] = "1 2 3 4 5";
         basic_ispanstream<char> is_const_buffer{span<const char>{const_buffer}};
         read = 0;

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.21)
 project(msvc_standard_libraries_tools LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 20)


### PR DESCRIPTION
* Update the toolset to VS 2022 17.0 Preview 4, which contains CMake 3.21.
* Build the toolset with PowerShell 7.1.4, and upgrade to Python 3.9.7.
* Remove workarounds for internally reported bugs fixed in 17.0 Preview 4:
  + VSO-1356169 "EDG x64 is confused by overloads for `__cdecl` and `__vectorcall` PMFs"
  + VSO-1356637 "REPORTED: EDG x64 ICE with negative pointer indexing"
* Guard workarounds with `MSVC_INTERNAL_TESTING` for bugs fixed in 17.1 Preview 1:
  + DevCom-1511903 "Standard Library Header Units: Bogus error C2440 when `convertible_to` constrains a constructor"
  + I've verified that this succeeds in the internal test harness.
