### PR TITLE
`tests/tr1`: Fix sporadic failures caused by `tmpnam`/`_tempnam`

### DIFF
--- a/tests/tr1/include/temp_file_name.h
+++ b/tests/tr1/include/temp_file_name.h
@@ -8,11 +8,11 @@
 
 [[nodiscard]] inline std::string temp_file_name() {
     std::string ret{"temp_file_"};
-
+    std::uniform_int_distribution<int> dist{0, 15};
     std::random_device rd;
 
     for (int i = 0; i < 64; ++i) { // 64 hexits = 256 bits of entropy
-        ret.push_back("0123456789ABCDEF"[rd() % 16]);
+        ret.push_back("0123456789ABCDEF"[dist(rd)]);
     }
 
     ret += ".tmp";

--- a/tests/tr1/include/temp_file_name.h
+++ b/tests/tr1/include/temp_file_name.h
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#pragma once
+
+#include <random>
+#include <string>
+
+[[nodiscard]] inline std::string temp_file_name() {
+    std::string ret{"temp_file_"};
+
+    std::random_device rd;
+
+    for (int i = 0; i < 64; ++i) { // 64 hexits = 256 bits of entropy
+        ret.push_back("0123456789ABCDEF"[rd() % 16]);
+    }
+
+    ret += ".tmp";
+
+    return ret;
+}

--- a/tests/tr1/tests/cstdio/test.cpp
+++ b/tests/tr1/tests/cstdio/test.cpp
@@ -126,20 +126,17 @@ void test_cpp() { // test C++ header
     }
 
     { // test character I/O
-        const char* tmpbuff;
         char tname[L_tmpnam];
-        const char* tmpbuf;
+        char tn[100];
         STDx FILE* pf;
-        char tn[100] = {0};
 
         const auto temp_name1 = temp_file_name();
-        tmpbuf                = temp_name1.c_str();
-        CHECK(CSTD strlen(tmpbuf) < L_tmpnam);
-        const auto temp_name2 = temp_file_name();
-        tmpbuff               = temp_name2.c_str();
+        CHECK(temp_name1.size() < sizeof(tname));
+        CSTD strcpy_s(tname, sizeof(tname), temp_name1.c_str());
 
-        CSTD strcpy_s(tn, sizeof(tn), tmpbuff);
-        CSTD strcpy_s(tname, sizeof(tname), tmpbuf);
+        const auto temp_name2 = temp_file_name();
+        CHECK(temp_name2.size() < sizeof(tn));
+        CSTD strcpy_s(tn, sizeof(tn), temp_name2.c_str());
 
         CHECK(CSTD strcmp(tn, tname) != 0);
         assert((pf = STDx fopen(tname, "w")) != nullptr);

--- a/tests/tr1/tests/cstdio/test.cpp
+++ b/tests/tr1/tests/cstdio/test.cpp
@@ -5,6 +5,7 @@
 #define TEST_NAMEX "<cstdio>"
 
 #include "tdefs.h"
+#include "temp_file_name.h"
 #include <assert.h>
 #include <cstdio>
 #include <errno.h>
@@ -91,7 +92,8 @@ void test_cpp() { // test C++ header
         int in1;
         long off;
 
-        assert((tn = STDx tmpnam((char*) nullptr)) != nullptr);
+        const auto temp_name = temp_file_name();
+        assert((tn = temp_name.c_str()) != nullptr);
         assert((pf = STDx fopen(tn, "w+")) != nullptr);
 
         STDx setbuf(pf, (char*) nullptr);
@@ -126,13 +128,15 @@ void test_cpp() { // test C++ header
     { // test character I/O
         const char* tmpbuff;
         char tname[L_tmpnam];
-        char tmpbuf[L_tmpnam];
+        const char* tmpbuf;
         STDx FILE* pf;
         char tn[100] = {0};
 
-        assert(STDx tmpnam(tmpbuf) == tmpbuf);
+        const auto temp_name1 = temp_file_name();
+        assert((tmpbuf = temp_name1.c_str()) != nullptr);
         CHECK(CSTD strlen(tmpbuf) < L_tmpnam);
-        assert((tmpbuff = STDx tmpnam((char*) nullptr)) != nullptr);
+        const auto temp_name2 = temp_file_name();
+        assert((tmpbuff = temp_name2.c_str()) != nullptr);
 
         CSTD strcpy_s(tn, sizeof(tn), tmpbuff);
         CSTD strcpy_s(tname, sizeof(tname), tmpbuf);

--- a/tests/tr1/tests/cstdio/test.cpp
+++ b/tests/tr1/tests/cstdio/test.cpp
@@ -93,7 +93,7 @@ void test_cpp() { // test C++ header
         long off;
 
         const auto temp_name = temp_file_name();
-        assert((tn = temp_name.c_str()) != nullptr);
+        tn                   = temp_name.c_str();
         assert((pf = STDx fopen(tn, "w+")) != nullptr);
 
         STDx setbuf(pf, (char*) nullptr);
@@ -133,10 +133,10 @@ void test_cpp() { // test C++ header
         char tn[100] = {0};
 
         const auto temp_name1 = temp_file_name();
-        assert((tmpbuf = temp_name1.c_str()) != nullptr);
+        tmpbuf                = temp_name1.c_str();
         CHECK(CSTD strlen(tmpbuf) < L_tmpnam);
         const auto temp_name2 = temp_file_name();
-        assert((tmpbuff = temp_name2.c_str()) != nullptr);
+        tmpbuff               = temp_name2.c_str();
 
         CSTD strcpy_s(tn, sizeof(tn), tmpbuff);
         CSTD strcpy_s(tname, sizeof(tname), tmpbuf);

--- a/tests/tr1/tests/cwchar1/test.cpp
+++ b/tests/tr1/tests/cwchar1/test.cpp
@@ -13,7 +13,6 @@
 
 #pragma warning(disable : 4793) // function compiled as native
 
-#define NO_TMPNAM_TESTS 1
 #undef tmpnam
 #define tmpnam(x) _tempnam(".", "")
 
@@ -141,17 +140,10 @@ void test_cpp() { // test C++ header
 
         CHECK(wmacs[1] < wmacs[0]);
 
-#if NO_TMPNAM_TESTS
         char *tname, *tn;
         assert((tn = CSTD tmpnam((char*) nullptr)) != nullptr);
         tname = (char*) CSTD malloc(CSTD strlen(tn) + 1);
         CSTD strcpy(tname, tn);
-
-#else // NO_TMPNAM_TESTS
-        char tname[L_tmpnam], *tn;
-        CHECK_PTR(CSTD tmpnam(tname), tname);
-        assert(CSTD strlen(tname) < L_tmpnam);
-#endif // NO_TMPNAM_TESTS
 
         assert((tn = CSTD tmpnam((char*) nullptr)) != nullptr);
         CHECK(CSTD strcmp(tn, tname) != 0);

--- a/tests/tr1/tests/cwchar1/test.cpp
+++ b/tests/tr1/tests/cwchar1/test.cpp
@@ -100,7 +100,7 @@ void test_cpp() { // test C++ header
         long off;
 
         const auto temp_name = temp_file_name();
-        assert((tn = temp_name.c_str()) != nullptr);
+        tn                   = temp_name.c_str();
         assert((pf = CSTD fopen(tn, "w+")) != nullptr);
         CHECK_INT(STDx fwide(pf, 0), 0);
         CHECK_INT(STDx fwprintf(pf, L"123\n"), 4);
@@ -143,12 +143,12 @@ void test_cpp() { // test C++ header
         char* tname;
         const char* tn;
         const auto temp_name1 = temp_file_name();
-        assert((tn = temp_name1.c_str()) != nullptr);
-        tname = (char*) CSTD malloc(CSTD strlen(tn) + 1);
+        tn                    = temp_name1.c_str();
+        tname                 = (char*) CSTD malloc(CSTD strlen(tn) + 1);
         CSTD strcpy(tname, tn);
 
         const auto temp_name2 = temp_file_name();
-        assert((tn = temp_name2.c_str()) != nullptr);
+        tn                    = temp_name2.c_str();
         CHECK(CSTD strcmp(tn, tname) != 0);
         assert((pf = CSTD fopen(tname, "w")) != nullptr);
         CHECK_INT(STDx fgetwc(pf), wintval);

--- a/tests/tr1/tests/cwchar1/test.cpp
+++ b/tests/tr1/tests/cwchar1/test.cpp
@@ -5,6 +5,7 @@
 #define TEST_NAMEX "<cwchar>, part 1"
 
 #include "tdefs.h"
+#include "temp_file_name.h"
 #include <assert.h>
 #include <cwchar>
 #include <stdarg.h>
@@ -98,7 +99,8 @@ void test_cpp() { // test C++ header
         int in1;
         long off;
 
-        assert((tn = CSTD _tempnam(".", "")) != nullptr);
+        const auto temp_name = temp_file_name();
+        assert((tn = temp_name.c_str()) != nullptr);
         assert((pf = CSTD fopen(tn, "w+")) != nullptr);
         CHECK_INT(STDx fwide(pf, 0), 0);
         CHECK_INT(STDx fwprintf(pf, L"123\n"), 4);
@@ -138,12 +140,15 @@ void test_cpp() { // test C++ header
 
         CHECK(wmacs[1] < wmacs[0]);
 
-        char *tname, *tn;
-        assert((tn = CSTD _tempnam(".", "")) != nullptr);
+        char* tname;
+        const char* tn;
+        const auto temp_name1 = temp_file_name();
+        assert((tn = temp_name1.c_str()) != nullptr);
         tname = (char*) CSTD malloc(CSTD strlen(tn) + 1);
         CSTD strcpy(tname, tn);
 
-        assert((tn = CSTD _tempnam(".", "")) != nullptr);
+        const auto temp_name2 = temp_file_name();
+        assert((tn = temp_name2.c_str()) != nullptr);
         CHECK(CSTD strcmp(tn, tname) != 0);
         assert((pf = CSTD fopen(tname, "w")) != nullptr);
         CHECK_INT(STDx fgetwc(pf), wintval);

--- a/tests/tr1/tests/cwchar1/test.cpp
+++ b/tests/tr1/tests/cwchar1/test.cpp
@@ -13,8 +13,6 @@
 
 #pragma warning(disable : 4793) // function compiled as native
 
-#undef tmpnam
-#define tmpnam(x) _tempnam(".", "")
 
 #undef clearerr // tested in stdio2.c
 #undef feof
@@ -100,7 +98,7 @@ void test_cpp() { // test C++ header
         int in1;
         long off;
 
-        assert((tn = CSTD tmpnam((char*) nullptr)) != nullptr);
+        assert((tn = CSTD _tempnam(".", "")) != nullptr);
         assert((pf = CSTD fopen(tn, "w+")) != nullptr);
         CHECK_INT(STDx fwide(pf, 0), 0);
         CHECK_INT(STDx fwprintf(pf, L"123\n"), 4);
@@ -141,11 +139,11 @@ void test_cpp() { // test C++ header
         CHECK(wmacs[1] < wmacs[0]);
 
         char *tname, *tn;
-        assert((tn = CSTD tmpnam((char*) nullptr)) != nullptr);
+        assert((tn = CSTD _tempnam(".", "")) != nullptr);
         tname = (char*) CSTD malloc(CSTD strlen(tn) + 1);
         CSTD strcpy(tname, tn);
 
-        assert((tn = CSTD tmpnam((char*) nullptr)) != nullptr);
+        assert((tn = CSTD _tempnam(".", "")) != nullptr);
         CHECK(CSTD strcmp(tn, tname) != 0);
         assert((pf = CSTD fopen(tname, "w")) != nullptr);
         CHECK_INT(STDx fgetwc(pf), wintval);

--- a/tests/tr1/tests/fstream1/test.cpp
+++ b/tests/tr1/tests/fstream1/test.cpp
@@ -9,11 +9,8 @@
 #include <fstream>
 #include <string>
 
-#undef tmpnam
-#define tmpnam(x) _tempnam(".", "")
-
 void test_main() { // test basic workings of char fstream definitions
-    const char* tn = CSTD tmpnam(0);
+    const char* tn = CSTD _tempnam(".", "");
 
     assert(tn != nullptr);
 

--- a/tests/tr1/tests/fstream1/test.cpp
+++ b/tests/tr1/tests/fstream1/test.cpp
@@ -5,12 +5,14 @@
 #define TEST_NAME "<fstream>, part 1"
 
 #include "tdefs.h"
+#include "temp_file_name.h"
 #include <assert.h>
 #include <fstream>
 #include <string>
 
 void test_main() { // test basic workings of char fstream definitions
-    const char* tn = CSTD _tempnam(".", "");
+    const auto temp_name = temp_file_name();
+    const char* tn       = temp_name.c_str();
 
     assert(tn != nullptr);
 

--- a/tests/tr1/tests/fstream1/test.cpp
+++ b/tests/tr1/tests/fstream1/test.cpp
@@ -11,10 +11,8 @@
 #include <string>
 
 void test_main() { // test basic workings of char fstream definitions
-    const auto temp_name = temp_file_name();
-    const char* tn       = temp_name.c_str();
-
-    STD string tn_str(tn);
+    STD string tn_str = temp_file_name();
+    const char* tn    = tn_str.c_str();
 
     // test output file opening
     STD ofstream ofs(tn);

--- a/tests/tr1/tests/fstream1/test.cpp
+++ b/tests/tr1/tests/fstream1/test.cpp
@@ -14,8 +14,6 @@ void test_main() { // test basic workings of char fstream definitions
     const auto temp_name = temp_file_name();
     const char* tn       = temp_name.c_str();
 
-    assert(tn != nullptr);
-
     STD string tn_str(tn);
 
     // test output file opening

--- a/tests/tr1/tests/fstream2/test.cpp
+++ b/tests/tr1/tests/fstream2/test.cpp
@@ -9,11 +9,8 @@
 #include <fstream>
 #include <wchar.h>
 
-#undef tmpnam
-#define tmpnam(x) _tempnam(".", "")
-
 void test_main() { // test basic workings of wide fstream definitions
-    const char* tn = CSTD tmpnam(0);
+    const char* tn = CSTD _tempnam(".", "");
 
     assert(tn != nullptr);
 

--- a/tests/tr1/tests/fstream2/test.cpp
+++ b/tests/tr1/tests/fstream2/test.cpp
@@ -5,12 +5,14 @@
 #define TEST_NAME "<fstream>, part 2"
 
 #include "tdefs.h"
+#include "temp_file_name.h"
 #include <assert.h>
 #include <fstream>
 #include <wchar.h>
 
 void test_main() { // test basic workings of wide fstream definitions
-    const char* tn = CSTD _tempnam(".", "");
+    const auto temp_name = temp_file_name();
+    const char* tn       = temp_name.c_str();
 
     assert(tn != nullptr);
 

--- a/tests/tr1/tests/fstream2/test.cpp
+++ b/tests/tr1/tests/fstream2/test.cpp
@@ -14,8 +14,6 @@ void test_main() { // test basic workings of wide fstream definitions
     const auto temp_name = temp_file_name();
     const char* tn       = temp_name.c_str();
 
-    assert(tn != nullptr);
-
     // test output file opening
     STD wofstream ofs(tn);
     CHECK(ofs.is_open());


### PR DESCRIPTION
While investigating failures that @mnatsuhara encountered in the internal test harness, @CaseyCarter encountered sporadic failures in the `tr1` legacy test suite:

<details><summary>Click to expand test failure output from tests/tr1/tests/fstream1 and fstream2.</summary>

```
RUN.PM line 750:  Executing: "fstream1.exe".
FAIL test 061 at line 247 in .\test.cpp: nfs.is_open()
FAIL test 062 at line 248 in .\test.cpp: nfs.good()
GOT "" != "this is a test"
FAIL test 063 at line 253 in .\test.cpp: buf == "this is a test"
GOT "" != "this is only a test"
FAIL test 064 at line 255 in .\test.cpp: buf == "this is only a test"
GOT "" != "this is still just a test"
FAIL test 065 at line 257 in .\test.cpp: buf == "this is still just a test"
GOT "" != "one last test"
FAIL test 066 at line 259 in .\test.cpp: buf == "one last test"
GOT "" != "one more last test"
FAIL test 067 at line 261 in .\test.cpp: buf == "one more last test"
FINISHED testing <fstream>, part 1
```

```
RUN.PM line 750:  Executing: "fstream2.exe". 
GOT L"this is still just a test" != L"one more last test" 
FAIL test 063 at line 232 in .\test.cpp: buf == L"one more last test"
```
</details>

The problem appears to be that `tr1` uses [`tmpnam`](https://en.cppreference.com/w/cpp/io/c/tmpnam) and [`_tempnam`](https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/tempnam-wtempnam-tmpnam-wtmpnam?view=msvc-160) to generate temporary file names. By default, these functions generate temporary file names in the user-global temp directory, and they're either short enough to be collision-prone, or sequential. :scream_cat: This is a problem when tests are run in parallel:

<details><summary>Click to expand example output from tmpnam and _tempnam, plus the new function being added in this PR.</summary>

```
C:\Temp>type meow.cpp
```
```cpp
#include "temp_file_name.h"
#include <filesystem>
#include <stdio.h>

using namespace std;
using namespace std::filesystem;

int main() {
    printf("             tmpnam: %s\n", tmpnam(nullptr));
    printf("           _tempnam: %s\n", _tempnam(".", ""));
    printf("temp_directory_path: %s\n", temp_directory_path().string().c_str());
    printf("     temp_file_name: %s\n", temp_file_name().c_str());
}
```
```
C:\Temp>cl /EHsc /nologo /W4 /std:c++17 /D_CRT_SECURE_NO_WARNINGS /ID:\GitHub\STL\tests\tr1\include meow.cpp && meow
meow.cpp
             tmpnam: C:\Users\stl\AppData\Local\Temp\s890.0
           _tempnam: C:\Users\stl\AppData\Local\Temp\2
temp_directory_path: C:\Users\stl\AppData\Local\Temp\
     temp_file_name: temp_file_4C2A015E48E7C09E7CCC8EC2913CE7B60AC451786E8B4995F7B96E478B3B7DBA.tmp
```
</details>

@cbezault explained that the GitHub test harness works around this problem by setting the `TMP` environment variable to a unique directory for each configuration of each test:

https://github.com/microsoft/STL/blob/d6f9987d7ec694b8599fe21e87e3653c36566223/tests/utils/stl/test/format.py#L149-L152

We didn't realize this was a problem for the internal test harness because it had an overall high level of flakiness (which we're trying to improve now), and because it reruns failed tests up to 10 times before logging the failure.

I believe we should permanently avoid this by generating truly unique names in the local directory. I'm adding a new header to generate names of the form `"temp_file_<64 hexits>.tmp"` and replacing all of `tr1`'s calls to `tmpnam` and `_tempnam`. (I checked `std` and `tr1` for calls to the more modern `temp_directory_path()`, and none of those were problematic.)

Note that because `tr1` is the legacy test suite, I am not attempting to refactor/cleanup nearby code, even though I see many things that could be improved/simplified. The only cleanups I'm performing are eliminating `NO_TMPNAM_TESTS` and `tmpnam` macroization, to make it easier to see what needs to be changed.

The new filenames that I'm generating are comfortably below the `100` and `L_tmpnam` (`260`) limits in the source code.

I checked to see if any additional changes were needed, and I don't believe so. `tmpnam` either writes into a provided buffer, or returns a pointer to an internal buffer (thus, replacing it with a pointer into a named `string` is always fine). `_tempnam` allocates memory with `malloc` that should be `free`d, and the tests were simply leaking this, so there are no `free` calls that need to be removed.

I chose to use `std::` qualification in `temp_file_name.h` instead of including `tr1`'s central headers and using its `STD` macro.