### PR TITLE
Move u*streampos to iosfwd

### DIFF
--- a/stl/inc/iosfwd
+++ b/stl/inc/iosfwd
@@ -136,6 +136,11 @@ private:
 
 using streampos  = fpos<_Mbstatet>;
 using wstreampos = streampos;
+#ifdef __cpp_lib_char8_t
+using u8streampos = streampos;
+#endif // __cpp_lib_char8_t
+using u16streampos = streampos;
+using u32streampos = streampos;
 
 class locale;
 template <class _Facet>

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -330,12 +330,8 @@ struct char_traits : _Char_traits<_Elem, long> {}; // properties of a string or 
 template <>
 struct char_traits<char16_t> : _WChar_traits<char16_t> {};
 
-using u16streampos = streampos;
-
 template <>
 struct char_traits<char32_t> : _Char_traits<char32_t, unsigned int> {};
-
-using u32streampos = streampos;
 
 template <>
 struct char_traits<wchar_t> : _WChar_traits<wchar_t> {};
@@ -476,10 +472,6 @@ struct char_traits<char> : _Narrow_char_traits<char, int> {}; // properties of a
 #ifdef __cpp_char8_t
 template <>
 struct char_traits<char8_t> : _Narrow_char_traits<char8_t, unsigned int> {};
-
-#ifdef __cpp_lib_char8_t
-using u8streampos = streampos;
-#endif // __cpp_lib_char8_t
 #endif // __cpp_char8_t
 
 template <class _Elem, class _Traits, class _SizeT>

--- a/tests/std/tests/P0448R4_iosfwd/test.compile.pass.cpp
+++ b/tests/std/tests/P0448R4_iosfwd/test.compile.pass.cpp
@@ -7,6 +7,11 @@ using namespace std;
 
 // Needs to be separately declared as a simple alias of streampos
 void test_forward_declaration(wstreampos*);
+#ifdef __cpp_lib_char8_t
+void test_forward_declaration(u8streampos*);
+#endif // __cpp_lib_char8_t
+void test_forward_declaration(u16streampos*);
+void test_forward_declaration(u32streampos*);
 
 struct test_aliases {
     static void test_forward_declaration(streampos*);


### PR DESCRIPTION
[P1148R0](https://wg21.link/p1148r0) says `u16streampos` and `u32streampos` are defined in `<iosfwd>` (before P1148R0, their abode was unspecified). [P0482R6](https://wg21.link/p0482r6) adds `u8streampos` to `<iosfwd>`.