### PR TITLE
Status Chart: Weekly updates, PR Age max, call `toFixed()` directly

### DIFF
--- a/gather_stats.js
+++ b/gather_stats.js
@@ -420,7 +420,7 @@ function write_daily_table(script_start, all_prs, all_issues) {
         const row = rows[i];
         str += '    { ';
         str += `date: '${row.date.toISODate()}', `;
-        str += `merged: ${Number.parseFloat(row.merged).toFixed(2)}, `;
+        str += `merged: ${row.merged.toFixed(2)}, `;
 
         for (const key of ['pr', 'cxx20', 'cxx23', 'lwg', 'issue', 'bug']) {
             if (should_emit_data_point(rows, i, key)) {
@@ -430,10 +430,10 @@ function write_daily_table(script_start, all_prs, all_issues) {
             }
         }
 
-        str += `avg_age: ${Number.parseFloat(row.avg_age).toFixed(2)}, `;
-        str += `avg_wait: ${Number.parseFloat(row.avg_wait).toFixed(2)}, `;
-        str += `sum_age: ${Number.parseFloat(row.sum_age).toFixed(2)}, `;
-        str += `sum_wait: ${Number.parseFloat(row.sum_wait).toFixed(2)}, `;
+        str += `avg_age: ${row.avg_age.toFixed(2)}, `;
+        str += `avg_wait: ${row.avg_wait.toFixed(2)}, `;
+        str += `sum_age: ${row.sum_age.toFixed(2)}, `;
+        str += `sum_wait: ${row.sum_wait.toFixed(2)}, `;
         str += '},\n';
     }
 
@@ -491,7 +491,7 @@ async function async_main() {
             console.log(`Remaining: ${rate_limit.remaining}/${rate_limit.limit} points`);
         }
 
-        console.log(`Time: ${Number.parseFloat(script_finish.diff(script_start).as('seconds')).toFixed(3)}s`);
+        console.log(`Time: ${script_finish.diff(script_start).as('seconds').toFixed(3)}s`);
     } catch (error) {
         console.log(`ERROR: ${error.message}`);
     }

--- a/index.html
+++ b/index.html
@@ -379,7 +379,7 @@
                         text: 'Average Age, Average Wait (days)',
                     },
                     min: 0,
-                    max: 240,
+                    max: 270,
                     ticks: {
                         stepSize: 30,
                     },
@@ -393,7 +393,7 @@
                         text: 'Combined Age, Combined Wait (PR-months)',
                     },
                     min: 0,
-                    max: 240,
+                    max: 270,
                     ticks: {
                         stepSize: 30,
                     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,10 @@
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@octokit/graphql": "^4.8.0",
-        "cli-progress": "^3.9.0",
+        "cli-progress": "^3.9.1",
         "dotenv": "^10.0.0",
         "luxon": "^2.0.2",
-        "yargs": "^17.1.1"
+        "yargs": "^17.2.1"
       }
     },
     "node_modules/@octokit/endpoint": {
@@ -37,9 +37,9 @@
       }
     },
     "node_modules/@octokit/openapi-types": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-10.1.1.tgz",
-      "integrity": "sha512-ygp/6r25Ezb1CJuVMnFfOsScEtPF0zosdTJDZ7mZ+I8IULl7DP1BS5ZvPRwglcarGPXOvS5sHdR0bjnVDDfQdQ=="
+      "version": "10.6.4",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-10.6.4.tgz",
+      "integrity": "sha512-JVmwWzYTIs6jACYOwD6zu5rdrqGIYsiAsLzTCxdrWIPNKNVjEF6vPTL20shmgJ4qZsq7WPBcLXLsaQD+NLChfg=="
     },
     "node_modules/@octokit/request": {
       "version": "5.6.1",
@@ -65,17 +65,17 @@
       }
     },
     "node_modules/@octokit/types": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.27.0.tgz",
-      "integrity": "sha512-ha27f8DToxXBPEJdzHCCuqpw7AgKfjhWGdNf3yIlBAhAsaexBXTfWw36zNSsncALXGvJq4EjLy1p3Wz45Aqb4A==",
+      "version": "6.31.3",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.31.3.tgz",
+      "integrity": "sha512-IUG3uMpsLHrtEL6sCVXbxCgnbKcgpkS4K7gVEytLDvYYalkK3XcuMCHK1YPD8xJglSJAOAbL4MgXp47rS9G49w==",
       "dependencies": {
-        "@octokit/openapi-types": "^10.1.0"
+        "@octokit/openapi-types": "^10.6.4"
       }
     },
     "node_modules/ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "engines": {
         "node": ">=8"
       }
@@ -95,9 +95,9 @@
       }
     },
     "node_modules/cli-progress": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.9.0.tgz",
-      "integrity": "sha512-g7rLWfhAo/7pF+a/STFH/xPyosaL1zgADhI0OM83hl3c7S43iGvJWEAV2QuDOnQ8i6EMBj/u4+NTd0d5L+4JfA==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.9.1.tgz",
+      "integrity": "sha512-AXxiCe2a0Lm0VN+9L0jzmfQSkcZm5EYspfqXKaSIQKqIk+0hnkZ3/v1E9B39mkD6vYhKih3c/RPsJBSwq9O99Q==",
       "dependencies": {
         "colors": "^1.1.2",
         "string-width": "^4.2.0"
@@ -199,9 +199,12 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.2.tgz",
-      "integrity": "sha512-aLoxToI6RfZ+0NOjmWAgn9+LEd30YCkJKFSyWacNZdEKTit/ZMcKjGkTRo8uWEsnIb/hfKecNPEbln02PdWbcA==",
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.5.tgz",
+      "integrity": "sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
       "engines": {
         "node": "4.x || >=6.0.0"
       }
@@ -223,33 +226,52 @@
       }
     },
     "node_modules/string-width": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-      "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.0"
+        "strip-ansi": "^6.0.1"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/strip-ansi": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dependencies": {
-        "ansi-regex": "^5.0.0"
+        "ansi-regex": "^5.0.1"
       },
       "engines": {
         "node": ">=8"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+    },
     "node_modules/universal-user-agent": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
       "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w=="
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
@@ -281,9 +303,9 @@
       }
     },
     "node_modules/yargs": {
-      "version": "17.1.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.1.1.tgz",
-      "integrity": "sha512-c2k48R0PwKIqKhPMWjeiF6y2xY/gPMUlro0sgxqXpbOIohWiLNXWslsootttv7E1e73QPAMQSg5FeySbVcpsPQ==",
+      "version": "17.2.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.2.1.tgz",
+      "integrity": "sha512-XfR8du6ua4K6uLGm5S6fA+FIJom/MdJcFNVY8geLlp2v8GYbOXD4EB1tPNZsRn4vBzKGMgb5DRZMeWuFc2GO8Q==",
       "dependencies": {
         "cliui": "^7.0.2",
         "escalade": "^3.1.1",
@@ -328,9 +350,9 @@
       }
     },
     "@octokit/openapi-types": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-10.1.1.tgz",
-      "integrity": "sha512-ygp/6r25Ezb1CJuVMnFfOsScEtPF0zosdTJDZ7mZ+I8IULl7DP1BS5ZvPRwglcarGPXOvS5sHdR0bjnVDDfQdQ=="
+      "version": "10.6.4",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-10.6.4.tgz",
+      "integrity": "sha512-JVmwWzYTIs6jACYOwD6zu5rdrqGIYsiAsLzTCxdrWIPNKNVjEF6vPTL20shmgJ4qZsq7WPBcLXLsaQD+NLChfg=="
     },
     "@octokit/request": {
       "version": "5.6.1",
@@ -356,17 +378,17 @@
       }
     },
     "@octokit/types": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.27.0.tgz",
-      "integrity": "sha512-ha27f8DToxXBPEJdzHCCuqpw7AgKfjhWGdNf3yIlBAhAsaexBXTfWw36zNSsncALXGvJq4EjLy1p3Wz45Aqb4A==",
+      "version": "6.31.3",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.31.3.tgz",
+      "integrity": "sha512-IUG3uMpsLHrtEL6sCVXbxCgnbKcgpkS4K7gVEytLDvYYalkK3XcuMCHK1YPD8xJglSJAOAbL4MgXp47rS9G49w==",
       "requires": {
-        "@octokit/openapi-types": "^10.1.0"
+        "@octokit/openapi-types": "^10.6.4"
       }
     },
     "ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
     },
     "ansi-styles": {
       "version": "4.3.0",
@@ -377,9 +399,9 @@
       }
     },
     "cli-progress": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.9.0.tgz",
-      "integrity": "sha512-g7rLWfhAo/7pF+a/STFH/xPyosaL1zgADhI0OM83hl3c7S43iGvJWEAV2QuDOnQ8i6EMBj/u4+NTd0d5L+4JfA==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.9.1.tgz",
+      "integrity": "sha512-AXxiCe2a0Lm0VN+9L0jzmfQSkcZm5EYspfqXKaSIQKqIk+0hnkZ3/v1E9B39mkD6vYhKih3c/RPsJBSwq9O99Q==",
       "requires": {
         "colors": "^1.1.2",
         "string-width": "^4.2.0"
@@ -454,9 +476,12 @@
       "integrity": "sha512-ZRioYLCgRHrtTORaZX1mx+jtxKtKuI5ZDvHNAmqpUzGqSrR+tL4FVLn/CUGMA3h0+AKD1MAxGI5GnCqR5txNqg=="
     },
     "node-fetch": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.2.tgz",
-      "integrity": "sha512-aLoxToI6RfZ+0NOjmWAgn9+LEd30YCkJKFSyWacNZdEKTit/ZMcKjGkTRo8uWEsnIb/hfKecNPEbln02PdWbcA=="
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.5.tgz",
+      "integrity": "sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
     },
     "once": {
       "version": "1.4.0",
@@ -472,27 +497,46 @@
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
     },
     "string-width": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-      "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "requires": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.0"
+        "strip-ansi": "^6.0.1"
       }
     },
     "strip-ansi": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "requires": {
-        "ansi-regex": "^5.0.0"
+        "ansi-regex": "^5.0.1"
       }
+    },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
     },
     "universal-user-agent": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
       "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w=="
+    },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "wrap-ansi": {
       "version": "7.0.0",
@@ -515,9 +559,9 @@
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
     },
     "yargs": {
-      "version": "17.1.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.1.1.tgz",
-      "integrity": "sha512-c2k48R0PwKIqKhPMWjeiF6y2xY/gPMUlro0sgxqXpbOIohWiLNXWslsootttv7E1e73QPAMQSg5FeySbVcpsPQ==",
+      "version": "17.2.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.2.1.tgz",
+      "integrity": "sha512-XfR8du6ua4K6uLGm5S6fA+FIJom/MdJcFNVY8geLlp2v8GYbOXD4EB1tPNZsRn4vBzKGMgb5DRZMeWuFc2GO8Q==",
       "requires": {
         "cliui": "^7.0.2",
         "escalade": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
   },
   "dependencies": {
     "@octokit/graphql": "^4.8.0",
-    "cli-progress": "^3.9.0",
+    "cli-progress": "^3.9.1",
     "dotenv": "^10.0.0",
     "luxon": "^2.0.2",
-    "yargs": "^17.1.1"
+    "yargs": "^17.2.1"
   }
 }

--- a/weekly_table.js
+++ b/weekly_table.js
@@ -224,4 +224,7 @@ const weekly_table = [
     { date: '2021-08-27', vso: 168, libcxx: 604 },
     { date: '2021-09-03', vso: 167, libcxx: 604 },
     { date: '2021-09-10', vso: 168, libcxx: 604 },
+    { date: '2021-09-17', vso: 165, libcxx: 604 },
+    { date: '2021-09-24', vso: 167, libcxx: 604 },
+    { date: '2021-10-01', vso: 167, libcxx: 604 },
 ];


### PR DESCRIPTION
In addition to weekly updates and increasing the PR Age max, this contains a logic improvement in `gather_stats.js`, found during my ongoing TypeScript conversion project. I was originally taking `Number`s, implicitly converting them to `String`s, calling `Number.parseFloat()` to get `Number`s again, and then calling `toFixed()`, because my C++ brain couldn't imagine directly calling a member function on a `Number`. :brain: :joy_cat:

:chart_with_upwards_trend: Live preview: [stephantlavavej.github.io/STL/](https://stephantlavavej.github.io/STL/)
===