### PR TITLE
add nonblocking stdio functions to namespace std

### DIFF
--- a/stl/inc/cstdio
+++ b/stl/inc/cstdio
@@ -87,6 +87,20 @@ using _CSTD vfscanf;
 using _CSTD vscanf;
 using _CSTD vsscanf;
 
+#if defined _CRT_DISABLE_PERFCRIT_LOCKS && !defined _DLL
+using _CSTD _fclose_nolock;
+using _CSTD _fflush_nolock;
+using _CSTD _fgetc_nolock;
+using _CSTD _fputc_nolock;
+using _CSTD _fread_nolock;
+using _CSTD _fseek_nolock;
+using _CSTD _ftell_nolock;
+using _CSTD _fwrite_nolock;
+using _CSTD _getc_nolock;
+using _CSTD _putc_nolock;
+using _CSTD _ungetc_nolock;
+#endif // defined _CRT_DISABLE_PERFCRIT_LOCKS && !defined _DLL
+
 #pragma warning(pop)
 _STD_END
 

--- a/tests/std/test.lst
+++ b/tests/std/test.lst
@@ -187,6 +187,7 @@ tests\GH_001914_cached_position
 tests\GH_002039_byte_is_not_trivially_swappable
 tests\GH_002058_debug_iterator_race
 tests\GH_002120_streambuf_seekpos_and_seekoff
+tests\GH_002227_cstdio_CRT_DISABLE_PERFCRIT_LOCKS
 tests\LWG2597_complex_branch_cut
 tests\LWG3018_shared_ptr_function
 tests\P0019R8_atomic_ref

--- a/tests/std/tests/GH_002227_cstdio_CRT_DISABLE_PERFCRIT_LOCKS/env.lst
+++ b/tests/std/tests/GH_002227_cstdio_CRT_DISABLE_PERFCRIT_LOCKS/env.lst
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+RUNALL_INCLUDE ..\usual_matrix.lst

--- a/tests/std/tests/GH_002227_cstdio_CRT_DISABLE_PERFCRIT_LOCKS/test.compile.pass.cpp
+++ b/tests/std/tests/GH_002227_cstdio_CRT_DISABLE_PERFCRIT_LOCKS/test.compile.pass.cpp
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#define _CRT_DISABLE_PERFCRIT_LOCKS
+#include <cstdio>
+
+// We intentionally didn't write "using namespace std;"
+void testNonLocking(std::FILE* file, char* buf, std::size_t size) {
+    std::fflush(file);
+    std::fgetc(file);
+    std::fputc('a', file);
+    std::fread(buf, 1, size, file);
+    std::fseek(file, 0, SEEK_SET);
+    (void) std::ftell(file);
+    std::fwrite(buf, 1, size, file);
+    (void) std::getc(file);
+    std::putc('a', file);
+    std::ungetc('b', file);
+    std::fclose(file);
+}
+
+int main() {} // COMPILE-ONLY


### PR DESCRIPTION
they are `_Ugly`, so it should be fine...

Fixes #2227 

We usually do: `defined (MEOW)` but CRT has

```
    #if defined _CRT_DISABLE_PERFCRIT_LOCKS && !defined _DLL
        #define fclose(_Stream)                                           _fclose_nolock(_Stream)
        #define fflush(_Stream)                                           _fflush_nolock(_Stream)
        #define fgetc(_Stream)                                            _fgetc_nolock(_Stream)
        #define fputc(_Ch, _Stream)                                       _fputc_nolock(_Ch, _Stream)
        #define fread(_DstBuf, _ElementSize, _Count, _Stream)             _fread_nolock(_DstBuf, _ElementSize, _Count, _Stream)
        #define fread_s(_DstBuf, _DstSize, _ElementSize, _Count, _Stream) _fread_nolock_s(_DstBuf, _DstSize, _ElementSize, _Count, _Stream)
        #define fseek(_Stream, _Offset, _Origin)                          _fseek_nolock(_Stream, _Offset, _Origin)
        #define _fseeki64(_Stream, _Offset, _Origin)                      _fseeki64_nolock(_Stream, _Offset, _Origin)
        #define ftell(_Stream)                                            _ftell_nolock(_Stream)
        #define _ftelli64(_Stream)                                        _ftelli64_nolock(_Stream)
        #define fwrite(_SrcBuf, _ElementSize, _Count, _Stream)            _fwrite_nolock(_SrcBuf, _ElementSize, _Count, _Stream)
        #define getc(_Stream)                                             _getc_nolock(_Stream)
        #define putc(_Ch, _Stream)                                        _putc_nolock(_Ch, _Stream)
        #define ungetc(_Ch, _Stream)                                      _ungetc_nolock(_Ch, _Stream)
    #endif
```

So I decided to use the CRT style `defined MEOW` for the `#if`
