### PR TITLE
Implement P2432R1 Fix `istream_view`

### DIFF
--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -1328,7 +1328,8 @@ namespace ranges {
             _Iterator& operator++() {
 #if _ITERATOR_DEBUG_LEVEL != 0
                 // Per LWG-3489
-                _STL_VERIFY(!_Parent->_Stream_at_end(), "cannot increment istream_view iterator at end of stream");
+                _STL_VERIFY(
+                    !_Parent->_Stream_at_end(), "cannot increment basic_istream_view iterator at end of stream");
 #endif // _ITERATOR_DEBUG_LEVEL != 0
                 *_Parent->_Stream >> _Parent->_Val;
                 return *this;
@@ -1341,7 +1342,8 @@ namespace ranges {
             _NODISCARD _Ty& operator*() const noexcept /* strengthened */ {
 #if _ITERATOR_DEBUG_LEVEL != 0
                 // Per LWG-3489
-                _STL_VERIFY(!_Parent->_Stream_at_end(), "cannot dereference istream_view iterator at end of stream");
+                _STL_VERIFY(
+                    !_Parent->_Stream_at_end(), "cannot dereference basic_istream_view iterator at end of stream");
 #endif // _ITERATOR_DEBUG_LEVEL != 0
                 return _Parent->_Val;
             }
@@ -1373,11 +1375,28 @@ namespace ranges {
         }
     };
 
-    template <class _Ty, class _Elem, class _Traits>
-    _NODISCARD basic_istream_view<_Ty, _Elem, _Traits> istream_view(basic_istream<_Elem, _Traits>& _Stream) noexcept(
-        is_nothrow_default_constructible_v<_Ty>) /* strengthened */ {
-        return basic_istream_view<_Ty, _Elem, _Traits>{_Stream};
-    }
+    template <class _Ty>
+    using istream_view = basic_istream_view<_Ty, char>;
+    template <class _Ty>
+    using wistream_view = basic_istream_view<_Ty, wchar_t>;
+
+    namespace views {
+        template <class _Ty>
+        struct _Istream_fn {
+            // clang-format off
+            template <class _StreamTy>
+                requires derived_from<_StreamTy,
+                    basic_istream<typename _StreamTy::char_type, typename _StreamTy::traits_type>>
+            _NODISCARD constexpr auto operator()(_StreamTy& _Stream) const
+                noexcept(is_nothrow_default_constructible_v<_Ty>) /* strengthened */ {
+                // clang-format on
+                return basic_istream_view<_Ty, typename _StreamTy::char_type, typename _StreamTy::traits_type>(_Stream);
+            }
+        };
+
+        template <class _Ty>
+        inline constexpr _Istream_fn<_Ty> istream;
+    } // namespace views
 
     // clang-format off
     template <range _Rng>
@@ -3257,9 +3276,8 @@ namespace ranges {
         // clang-format off
         _NODISCARD constexpr auto end() const
             requires input_range<const _Vw> && is_reference_v<_InnerRng<true>> {
-            if constexpr (forward_range<const _Vw> && is_reference_v<_InnerRng<true>>
-                    && forward_range<_InnerRng<true>> && common_range<const _Vw>
-                    && common_range<_InnerRng<true>>) {
+            if constexpr (forward_range<const _Vw> && forward_range<_InnerRng<true>>
+                    && common_range<const _Vw> && common_range<_InnerRng<true>>) {
                 // clang-format on
                 return _Iterator<true>{*this, _RANGES end(_Range)};
             } else {

--- a/tests/std/tests/P0896R4_istream_view/test.cpp
+++ b/tests/std/tests/P0896R4_istream_view/test.cpp
@@ -20,12 +20,13 @@ struct streamable {
     streamable() = default;
     streamable(const int input) : _val(input) {}
 
-    friend istream& operator>>(istream& is, streamable& right) noexcept {
+    template <class CharT, class Traits>
+    friend basic_istream<CharT, Traits>& operator>>(basic_istream<CharT, Traits>& is, streamable& right) noexcept {
         is >> right._val;
         return is;
     }
 
-    friend bool operator==(const streamable& left, const streamable& right) noexcept = default;
+    friend bool operator==(const streamable&, const streamable&) noexcept = default;
 
     int _val = 0;
 };
@@ -73,16 +74,51 @@ void test_one_type() {
     ranges::copy(empty_constructed, input_empty);
     assert(ranges::equal(input_empty, expected_empty));
 
-    istringstream intstream{"0 1 2 3"};
-    T input_value[] = {-1, -1, -1, -1, -1};
-    ranges::copy(basic_istream_view<T, char>{intstream}, input_value);
-    assert(ranges::equal(input_value, expected));
+    { // using ranges::basic_istream_view with wide stream
+        wistringstream wintstream{L"0 1 2 3"};
+        T input_value[] = {-1, -1, -1, -1, -1};
+        ranges::copy(basic_istream_view<T, wchar_t>{wintstream}, input_value);
+        assert(ranges::equal(input_value, expected));
+    }
 
-    istringstream intstream_view{"0 1 2 3"};
-    T input_value_view[] = {-1, -1, -1, -1, -1};
-    ranges::copy(ranges::istream_view<T>(intstream_view), input_value_view);
-    static_assert(noexcept(ranges::istream_view<T>(intstream_view)));
-    assert(ranges::equal(input_value_view, expected));
+    { // using ranges::basic_istream_view with narrow stream
+        istringstream intstream{"0 1 2 3"};
+        T input_value[] = {-1, -1, -1, -1, -1};
+        ranges::copy(basic_istream_view<T, char>{intstream}, input_value);
+        assert(ranges::equal(input_value, expected));
+    }
+
+    { // Using ranges::istream_view
+        istringstream intstream{"0 1 2 3"};
+        T input[] = {-1, -1, -1, -1, -1};
+        ranges::copy(ranges::istream_view<T>(intstream), input);
+        static_assert(noexcept(ranges::istream_view<T>(intstream)));
+        assert(ranges::equal(input, expected));
+    }
+
+    { // Using ranges::wistream_view
+        wistringstream wintstream{L"0 1 2 3"};
+        T input[] = {-1, -1, -1, -1, -1};
+        ranges::copy(ranges::wistream_view<T>(wintstream), input);
+        static_assert(noexcept(ranges::wistream_view<T>(wintstream)));
+        assert(ranges::equal(input, expected));
+    }
+
+    { // Using views::istream with narrow stream
+        istringstream intstream{"0 1 2 3"};
+        T input[] = {-1, -1, -1, -1, -1};
+        ranges::copy(views::istream<T>(intstream), input);
+        static_assert(noexcept(views::istream<T>(intstream)));
+        assert(ranges::equal(input, expected));
+    }
+
+    { // Using views::istream with wide stream
+        wistringstream wintstream{L"0 1 2 3"};
+        T input[] = {-1, -1, -1, -1, -1};
+        ranges::copy(views::istream<T>(wintstream), input);
+        static_assert(noexcept(views::istream<T>(wintstream)));
+        assert(ranges::equal(input, expected));
+    }
 }
 
 istringstream some_stream{"42"};


### PR DESCRIPTION
Drive-by: Drop extraneous `if constexpr` condition in `join_view::end` as suggested by cplusplus/draft#4957.

Fixes #2240
