### PR TITLE
Workaround ExceptionFlags change in NT

### DIFF
--- a/tests/std/tests/VSO_0000000_exception_ptr_rethrow_seh/test.cpp
+++ b/tests/std/tests/VSO_0000000_exception_ptr_rethrow_seh/test.cpp
@@ -36,7 +36,7 @@ std::exception_ptr GetContinuableException() {
 
 void AssertExceptionRecordOk(const EXCEPTION_POINTERS* const pointers) {
     assert(pointers->ExceptionRecord->ExceptionCode == 1234);
-    assert(pointers->ExceptionRecord->ExceptionFlags == EXCEPTION_NONCONTINUABLE);
+    assert((pointers->ExceptionRecord->ExceptionFlags & EXCEPTION_NONCONTINUABLE) == EXCEPTION_NONCONTINUABLE);
     assert(pointers->ExceptionRecord->ExceptionRecord == nullptr);
     assert(pointers->ExceptionRecord->ExceptionAddress != nullptr);
     assert(pointers->ExceptionRecord->NumberParameters == 2);

--- a/tests/std/tests/VSO_0104705_throwing_copy_in_current_exception_seh/test.cpp
+++ b/tests/std/tests/VSO_0104705_throwing_copy_in_current_exception_seh/test.cpp
@@ -44,7 +44,7 @@ struct EvilException : LifetimeTracker {
 
 void AssertExceptionRecordOk(const EXCEPTION_POINTERS* const pointers) {
     assert(pointers->ExceptionRecord->ExceptionCode == 1234);
-    assert(pointers->ExceptionRecord->ExceptionFlags == EXCEPTION_NONCONTINUABLE);
+    assert((pointers->ExceptionRecord->ExceptionFlags & EXCEPTION_NONCONTINUABLE) == EXCEPTION_NONCONTINUABLE);
     assert(pointers->ExceptionRecord->ExceptionRecord == nullptr);
     assert(pointers->ExceptionRecord->ExceptionAddress != nullptr);
     assert(pointers->ExceptionRecord->NumberParameters == 2);


### PR DESCRIPTION
...by allowing flags other than `EXCEPTION_NONCONTINUABLE` to be set by `RaiseException`. This should unblock CI on the new Server 2022 VMs, for which `RaiseException` sets a new flag indicating that the exception originated in software. (This also reproduces locally for me on Windows 11.)

This mirrors the STL changes from the internal MSVC-PR-356899.

(Tagging this as high priority since we already merged the internal PR to unblock CI.)