### PR TITLE
Remove LWG comments

### DIFF
--- a/stl/inc/optional
+++ b/stl/inc/optional
@@ -642,7 +642,7 @@ _NODISCARD constexpr bool operator>=(const _Ty1& _Left, const optional<_Ty2>& _R
 #ifdef __cpp_lib_concepts
 // clang-format off
 template <class _Ty1, class _Ty2>
-    requires (!_Is_specialization_v<_Ty2, optional>) // LWG-3566
+    requires (!_Is_specialization_v<_Ty2, optional>)
         && three_way_comparable_with<_Ty1, _Ty2>
 _NODISCARD constexpr compare_three_way_result_t<_Ty1, _Ty2>
     operator<=>(const optional<_Ty1>& _Left, const _Ty2& _Right) {

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -1352,7 +1352,7 @@ namespace ranges {
         };
 
         basic_istream<_Elem, _Traits>* _Stream;
-        _Ty _Val = _Ty{}; // Per LWG issue submitted but unnumbered as of 2021-06-15
+        _Ty _Val = _Ty{};
 
     public:
         constexpr explicit basic_istream_view(basic_istream<_Elem, _Traits>& _Stream_) noexcept(
@@ -2434,7 +2434,6 @@ namespace ranges {
                     _Count            = (_STD min) (_RANGES distance(_Range), _Count);
                     const auto _First = _RANGES begin(_Range);
 
-                    // The following are all per the proposed resolution of LWG-3407
                     if constexpr (_Strat == _St::_Reconstruct_span) {
                         return span(_First, _First + _Count);
                     } else if constexpr (_Strat == _St::_Reconstruct_string_view) {
@@ -2804,7 +2803,6 @@ namespace ranges {
                     // it's a "reconstructible range"; return the same kind of range with a restricted extent
                     _Count = (_STD min) (_RANGES distance(_Range), _Count);
 
-                    // The following are all per the proposed resolution of LWG-3407
                     if constexpr (_Strat == _St::_Reconstruct_span) {
                         return span(_Ubegin(_Range) + _Count, _Uend(_Range));
                     } else if constexpr (_Strat == _St::_Reconstruct_subrange) {
@@ -2964,7 +2962,7 @@ namespace ranges {
         template <forward_range _Outer, forward_range _Inner>
         struct _Category_base<_Outer, _Inner, true> {
             using iterator_category =
-                conditional_t<common_range<_Inner> // per LWG-3535
+                conditional_t<common_range<_Inner> //
                                   && derived_from<_Iter_cat_t<iterator_t<_Outer>>, bidirectional_iterator_tag> //
                                   && derived_from<_Iter_cat_t<iterator_t<_Inner>>, bidirectional_iterator_tag>,
                     bidirectional_iterator_tag,
@@ -2991,7 +2989,7 @@ namespace ranges {
             static constexpr bool _Deref_is_glvalue = is_reference_v<_InnerRng<_Const>>;
 
             /* [[no_unique_address]] */ _OuterIter _Outer{};
-            /* [[no_unique_address]] */ _Defaultabox<_InnerIter> _Inner{}; // per LWG issue unfiled as of 2021-06-14
+            /* [[no_unique_address]] */ _Defaultabox<_InnerIter> _Inner{}; // per LWG-3569
             _Parent_t* _Parent{};
 
             constexpr auto&& _Update_inner() {
@@ -3036,7 +3034,6 @@ namespace ranges {
 
         public:
             // clang-format off
-            // Per LWG issue unnumbered as of 2021-03-16
             using iterator_concept = conditional_t<_Deref_is_glvalue
                 && bidirectional_range<_Base> && bidirectional_range<_InnerRng<_Const>>
                 && common_range<_InnerRng<_Const>>, bidirectional_iterator_tag,

--- a/stl/inc/syncstream
+++ b/stl/inc/syncstream
@@ -56,7 +56,7 @@ protected:
         _Swap(_Right);
     }
 
-    void _Swap(_Basic_syncbuf_impl& _Right) { // see LWG-3498 regarding noexcept
+    void _Swap(_Basic_syncbuf_impl& _Right) {
         _Mysb::swap(_Right);
         _STD swap(_Emit_on_sync, _Right._Emit_on_sync);
         _STD swap(_Sync_recorded, _Right._Sync_recorded);
@@ -106,7 +106,7 @@ public:
         _Tidy();
     }
 
-    basic_syncbuf& operator=(basic_syncbuf&& _Right) { // see LWG-3498 regarding noexcept
+    basic_syncbuf& operator=(basic_syncbuf&& _Right) {
         emit();
         if (this != _STD addressof(_Right)) {
             _Move_assign(_STD move(_Right), _Choose_pocma<_Alloc>{});
@@ -114,7 +114,7 @@ public:
         return *this;
     }
 
-    void swap(basic_syncbuf& _Right) { // see LWG-3498 regarding noexcept
+    void swap(basic_syncbuf& _Right) {
         if (this != _STD addressof(_Right)) {
             _Pocs(_Getal(), _Right._Getal());
             _Swap_except_al(_Right);
@@ -221,19 +221,19 @@ private:
         }
     }
 
-    void _Move_assign(basic_syncbuf&& _Right, _Equal_allocators) { // see LWG-3498 regarding noexcept
+    void _Move_assign(basic_syncbuf&& _Right, _Equal_allocators) {
         _Tidy();
         _Pocma(_Getal(), _Right._Getal());
         _Swap_except_al(_Right);
     }
 
-    void _Move_assign(basic_syncbuf&& _Right, _Propagate_allocators) { // see LWG-3498 regarding noexcept
+    void _Move_assign(basic_syncbuf&& _Right, _Propagate_allocators) {
         _Tidy();
         _Pocma(_Getal(), _Right._Getal());
         _Swap_except_al(_Right);
     }
 
-    void _Move_assign(basic_syncbuf&& _Right, _No_propagate_allocators) { // see LWG-3498 regarding noexcept
+    void _Move_assign(basic_syncbuf&& _Right, _No_propagate_allocators) {
         auto& _Al = _Getal();
         if (_Al == _Right._Getal()) {
             _Move_assign(_STD move(_Right), _Equal_allocators{});
@@ -258,7 +258,7 @@ private:
         }
     }
 
-    void _Swap_except_al(basic_syncbuf& _Right) { // see LWG-3498 regarding noexcept
+    void _Swap_except_al(basic_syncbuf& _Right) {
         _Mybase::_Swap(_Right);
         _STD swap(_Wrapped, _Right._Wrapped);
         _STD swap(_Get_mutex(), _Right._Get_mutex());
@@ -313,7 +313,7 @@ private:
 
 template <class _Elem, class _Traits, class _Alloc>
 void swap(basic_syncbuf<_Elem, _Traits, _Alloc>& _Left,
-    basic_syncbuf<_Elem, _Traits, _Alloc>& _Right) { // see LWG-3498 regarding noexcept
+    basic_syncbuf<_Elem, _Traits, _Alloc>& _Right) { // LWG-3616
     _Left.swap(_Right);
 }
 

--- a/stl/inc/syncstream
+++ b/stl/inc/syncstream
@@ -312,8 +312,7 @@ private:
 };
 
 template <class _Elem, class _Traits, class _Alloc>
-void swap(basic_syncbuf<_Elem, _Traits, _Alloc>& _Left,
-    basic_syncbuf<_Elem, _Traits, _Alloc>& _Right) { // LWG-3616
+void swap(basic_syncbuf<_Elem, _Traits, _Alloc>& _Left, basic_syncbuf<_Elem, _Traits, _Alloc>& _Right) { // LWG-3616
     _Left.swap(_Right);
 }
 

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -1284,7 +1284,7 @@ public:
 #if _HAS_CXX23
     // clang-format off
     template <class _Range>
-        requires (!same_as<remove_cvref_t<_Range>, basic_string_view> // per LWG-3581
+        requires (!same_as<remove_cvref_t<_Range>, basic_string_view>
             && _RANGES contiguous_range<_Range>
             && _RANGES sized_range<_Range>
             && same_as<_RANGES range_value_t<_Range>, _Elem>
@@ -1293,7 +1293,6 @@ public:
                 _Rng.operator _STD basic_string_view<_Elem, _Traits>();
             })
             && (!requires {
-                // per editorial or LWG issue not yet filed as of 2021-06-10
                 typename remove_reference_t<_Range>::traits_type;
             } || same_as<typename remove_reference_t<_Range>::traits_type, _Traits>))
     constexpr basic_string_view(_Range&& _Rng) noexcept(

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -3862,7 +3862,7 @@ _NODISCARD _CONSTEXPR17 move_iterator<_Iter> operator+(
 #ifdef __cpp_lib_concepts
     // clang-format off
     requires requires {
-        { _Right.base() + _Off } -> same_as<_Iter>; // LWG-3293
+        { _Right.base() + _Off } -> same_as<_Iter>;
     }
 // clang-format on
 #endif // __cpp_lib_concepts


### PR DESCRIPTION
Remove comments that cite:

*  LWG-3566 Constraint recursion for `operator<=>(optional<T>, U)`
*  "LWG issue submitted but unnumbered as of 2021-06-15" (which is LWG-3568 `basic_istream_view` needs to initialize *`value_`*)
*  LWG-3407 Some problems with the wording changes of P1739R4
*  LWG-3535 `join_view::`*`iterator`*`::iterator_category` and `::iterator_concept` lie (appears once with the number, and once as "LWG issue unnumbered as of 2021-03-16")
*  LWG-3498 Inconsistent `noexcept`-specifiers for `basic_syncbuf`
*  LWG-3581 The range constructor makes `basic_string_view` not trivially move constructible
*  LWG-3293 `move_iterator operator+()` has incorrect constraints

Several drive-by changes:

* A "per LWG issue unfiled as of 2021-06-14" comment in `join_view::_Iterator` is updated with the issue number (which is LWG-3569 "`join_view` fails to support ranges of ranges with non-`default_initializable` iterators")
* A new comment is added to cite LWG-3616 "LWG-3498 seems to miss the non-member `swap` for `basic_syncbuf`"
* A "per editorial or LWG issue not yet filed as of 2021-06-10" comment in `<xstring>` is removed. I believe that the comment refers to the bug that was fixed in https://github.com/cplusplus/draft/commit/c3c40a39caab2421f2445805e6d495b25f11a0d4.