### PR TITLE
P2372R3: Fix handling of locale in chrono formatters

### DIFF
--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -5232,7 +5232,7 @@ struct _Chrono_spec {
 };
 
 template <class _CharT>
-struct _Chrono_format_specs2 {
+struct _Chrono_format_specs {
     int _Width                   = 0;
     int _Precision               = -1;
     int _Dynamic_width_index     = -1;
@@ -5246,11 +5246,11 @@ struct _Chrono_format_specs2 {
     vector<_Chrono_spec<_CharT>> _Chrono_specs_list;
 };
 
-// Model of _Chrono_parse_spec_callbacks that fills a _Chrono_format_specs2 with the parsed data
+// Model of _Chrono_parse_spec_callbacks that fills a _Chrono_format_specs with the parsed data
 template <class _CharT, class _ParseContext>
 class _Chrono_specs_setter {
 public:
-    constexpr explicit _Chrono_specs_setter(_Chrono_format_specs2<_CharT>& _Specs_, _ParseContext& _Parse_ctx_)
+    constexpr explicit _Chrono_specs_setter(_Chrono_format_specs<_CharT>& _Specs_, _ParseContext& _Parse_ctx_)
         : _Specs(_Specs_), _Parse_ctx(_Parse_ctx_) {}
 
     // same as _Specs_setter
@@ -5319,7 +5319,7 @@ public:
     }
 
 private:
-    _Chrono_format_specs2<_CharT>& _Specs;
+    _Chrono_format_specs<_CharT>& _Specs;
     _ParseContext& _Parse_ctx;
 
     _NODISCARD static constexpr int _Verify_dynamic_arg_index_in_range(const size_t _Idx) {
@@ -5629,7 +5629,7 @@ namespace chrono {
 
     template <class _CharT, class _Traits>
     basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const month_day& _Val) {
-        return _Os << _STD format(_Os.getloc(), _STATICALLY_WIDEN(_CharT, "{:L}/{:L}"), _Val.month(), _Val.day());
+        return _Os << _STD format(_Os.getloc(), _STATICALLY_WIDEN(_CharT, "{:L}/{}"), _Val.month(), _Val.day());
     }
 
     template <class _CharT, class _Traits>
@@ -5651,7 +5651,7 @@ namespace chrono {
 
     template <class _CharT, class _Traits>
     basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const year_month& _Val) {
-        return _Os << _STD format(_Os.getloc(), _STATICALLY_WIDEN(_CharT, "{:L}/{:L}"), _Val.year(), _Val.month());
+        return _Os << _STD format(_Os.getloc(), _STATICALLY_WIDEN(_CharT, "{}/{:L}"), _Val.year(), _Val.month());
     }
 
     template <class _CharT, class _Traits>
@@ -5663,19 +5663,19 @@ namespace chrono {
     template <class _CharT, class _Traits>
     basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const year_month_day_last& _Val) {
         return _Os << _STD format(
-                   _Os.getloc(), _STATICALLY_WIDEN(_CharT, "{:L}/{:L}"), _Val.year(), _Val.month_day_last());
+                   _Os.getloc(), _STATICALLY_WIDEN(_CharT, "{}/{:L}"), _Val.year(), _Val.month_day_last());
     }
 
     template <class _CharT, class _Traits>
     basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const year_month_weekday& _Val) {
-        return _Os << _STD format(_Os.getloc(), _STATICALLY_WIDEN(_CharT, "{:L}/{:L}/{:L}"), _Val.year(), _Val.month(),
+        return _Os << _STD format(_Os.getloc(), _STATICALLY_WIDEN(_CharT, "{}/{:L}/{:L}"), _Val.year(), _Val.month(),
                    _Val.weekday_indexed());
     }
 
     template <class _CharT, class _Traits>
     basic_ostream<_CharT, _Traits>& operator<<(
         basic_ostream<_CharT, _Traits>& _Os, const year_month_weekday_last& _Val) {
-        return _Os << _STD format(_Os.getloc(), _STATICALLY_WIDEN(_CharT, "{:L}/{:L}/{:L}"), _Val.year(), _Val.month(),
+        return _Os << _STD format(_Os.getloc(), _STATICALLY_WIDEN(_CharT, "{}/{:L}/{:L}"), _Val.year(), _Val.month(),
                    _Val.weekday_last());
     }
 
@@ -5730,9 +5730,7 @@ namespace chrono {
         requires (!treat_as_floating_point_v<typename _Duration::rep> && _Duration{1} < days{1})
     basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const sys_time<_Duration>& _Val) {
         // clang-format on
-        const auto _Dp = _CHRONO floor<days>(_Val);
-        return _Os << _STD format(
-                   _Os.getloc(), _STATICALLY_WIDEN(_CharT, "{:L} {:L}"), year_month_day{_Dp}, hh_mm_ss{_Val - _Dp});
+        return _Os << _STD format(_Os.getloc(), _STATICALLY_WIDEN(_CharT, "{:L%F %T}"), _Val);
     }
 
     template <class _CharT, class _Traits>
@@ -6277,7 +6275,7 @@ namespace chrono {
             return _Fmt_str;
         }
 
-        _Chrono_format_specs2<_CharT> _Specs{};
+        _Chrono_format_specs<_CharT> _Specs{};
         basic_string_view<_CharT> _Time_zone_abbreviation{};
     };
 } // namespace chrono

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -5232,24 +5232,25 @@ struct _Chrono_spec {
 };
 
 template <class _CharT>
-struct _Chrono_format_specs {
+struct _Chrono_format_specs2 {
     int _Width                   = 0;
     int _Precision               = -1;
     int _Dynamic_width_index     = -1;
     int _Dynamic_precision_index = -1;
     _Fmt_align _Alignment        = _Fmt_align::_None;
     uint8_t _Fill_length         = 1;
+    bool _Localized              = false;
     // At most one codepoint (so one char32_t or four utf-8 char8_t)
     _CharT _Fill[4 / sizeof(_CharT)] = {_CharT{' '}};
     // recursive definition in grammar, so could have any number of these
     vector<_Chrono_spec<_CharT>> _Chrono_specs_list;
 };
 
-// Model of _Chrono_parse_spec_callbacks that fills a _Chrono_format_specs with the parsed data
+// Model of _Chrono_parse_spec_callbacks that fills a _Chrono_format_specs2 with the parsed data
 template <class _CharT, class _ParseContext>
 class _Chrono_specs_setter {
 public:
-    constexpr explicit _Chrono_specs_setter(_Chrono_format_specs<_CharT>& _Specs_, _ParseContext& _Parse_ctx_)
+    constexpr explicit _Chrono_specs_setter(_Chrono_format_specs2<_CharT>& _Specs_, _ParseContext& _Parse_ctx_)
         : _Specs(_Specs_), _Parse_ctx(_Parse_ctx_) {}
 
     // same as _Specs_setter
@@ -5294,6 +5295,10 @@ public:
         _Specs._Dynamic_precision_index = _Verify_dynamic_arg_index_in_range(_Parse_ctx.next_arg_id());
     }
 
+    constexpr void _On_localized() {
+        _Specs._Localized = true;
+    }
+
     constexpr void _On_conversion_spec(char _Modifier, _CharT _Type) {
         // NOTE: same performance note from _Basic_format_specs also applies here
         if (_Modifier != '\0' && _Modifier != 'E' && _Modifier != 'O') {
@@ -5314,7 +5319,7 @@ public:
     }
 
 private:
-    _Chrono_format_specs<_CharT>& _Specs;
+    _Chrono_format_specs2<_CharT>& _Specs;
     _ParseContext& _Parse_ctx;
 
     _NODISCARD static constexpr int _Verify_dynamic_arg_index_in_range(const size_t _Idx) {
@@ -5370,6 +5375,14 @@ _NODISCARD constexpr const _CharT* _Parse_chrono_format_specs(
 
     if (*_Begin == '.') {
         _Begin = _Parse_precision(_Begin, _End, _Callbacks);
+        if (_Begin == _End) {
+            return _Begin;
+        }
+    }
+
+    if (*_Begin == 'L') {
+        _Callbacks._On_localized();
+        ++_Begin;
         if (_Begin == _End) {
             return _Begin;
         }
@@ -5582,7 +5595,7 @@ namespace chrono {
 
     template <class _CharT, class _Traits>
     basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const month& _Val) {
-        return _Os << (_Val.ok() ? _STD format(_Os.getloc(), _STATICALLY_WIDEN(_CharT, "{:%b}"), _Val)
+        return _Os << (_Val.ok() ? _STD format(_Os.getloc(), _STATICALLY_WIDEN(_CharT, "{:L%b}"), _Val)
                                  : _STD format(_Os.getloc(), _STATICALLY_WIDEN(_CharT, "{} is not a valid month"),
                                      static_cast<unsigned int>(_Val)));
     }
@@ -5595,7 +5608,7 @@ namespace chrono {
 
     template <class _CharT, class _Traits>
     basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const weekday& _Val) {
-        return _Os << (_Val.ok() ? _STD format(_Os.getloc(), _STATICALLY_WIDEN(_CharT, "{:%a}"), _Val)
+        return _Os << (_Val.ok() ? _STD format(_Os.getloc(), _STATICALLY_WIDEN(_CharT, "{:L%a}"), _Val)
                                  : _STD format(_Os.getloc(), _STATICALLY_WIDEN(_CharT, "{} is not a valid weekday"),
                                      _Val.c_encoding()));
     }
@@ -5604,40 +5617,41 @@ namespace chrono {
     basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const weekday_indexed& _Val) {
         const auto _Idx = _Val.index();
         return _Os << (_Idx >= 1 && _Idx <= 5
-                           ? _STD format(_Os.getloc(), _STATICALLY_WIDEN(_CharT, "{}[{}]"), _Val.weekday(), _Idx)
-                           : _STD format(_Os.getloc(), _STATICALLY_WIDEN(_CharT, "{}[{} is not a valid index]"),
+                           ? _STD format(_Os.getloc(), _STATICALLY_WIDEN(_CharT, "{:L}[{}]"), _Val.weekday(), _Idx)
+                           : _STD format(_Os.getloc(), _STATICALLY_WIDEN(_CharT, "{:L}[{} is not a valid index]"),
                                _Val.weekday(), _Idx));
     }
 
     template <class _CharT, class _Traits>
     basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const weekday_last& _Val) {
-        return _Os << _STD format(_Os.getloc(), _STATICALLY_WIDEN(_CharT, "{}[last]"), _Val.weekday());
+        return _Os << _STD format(_Os.getloc(), _STATICALLY_WIDEN(_CharT, "{:L}[last]"), _Val.weekday());
     }
 
     template <class _CharT, class _Traits>
     basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const month_day& _Val) {
-        return _Os << _STD format(_Os.getloc(), _STATICALLY_WIDEN(_CharT, "{}/{}"), _Val.month(), _Val.day());
+        return _Os << _STD format(_Os.getloc(), _STATICALLY_WIDEN(_CharT, "{:L}/{:L}"), _Val.month(), _Val.day());
     }
 
     template <class _CharT, class _Traits>
     basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const month_day_last& _Val) {
-        return _Os << _STD format(_Os.getloc(), _STATICALLY_WIDEN(_CharT, "{}/last"), _Val.month());
+        return _Os << _STD format(_Os.getloc(), _STATICALLY_WIDEN(_CharT, "{:L}/last"), _Val.month());
     }
 
     template <class _CharT, class _Traits>
     basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const month_weekday& _Val) {
         return _Os << _STD format(
-                   _Os.getloc(), _STATICALLY_WIDEN(_CharT, "{}/{}"), _Val.month(), _Val.weekday_indexed());
+                   _Os.getloc(), _STATICALLY_WIDEN(_CharT, "{:L}/{:L}"), _Val.month(), _Val.weekday_indexed());
     }
 
     template <class _CharT, class _Traits>
     basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const month_weekday_last& _Val) {
-        return _Os << _STD format(_Os.getloc(), _STATICALLY_WIDEN(_CharT, "{}/{}"), _Val.month(), _Val.weekday_last());
+        return _Os << _STD format(
+                   _Os.getloc(), _STATICALLY_WIDEN(_CharT, "{:L}/{:L}"), _Val.month(), _Val.weekday_last());
     }
 
     template <class _CharT, class _Traits>
     basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const year_month& _Val) {
-        return _Os << _STD format(_Os.getloc(), _STATICALLY_WIDEN(_CharT, "{}/{}"), _Val.year(), _Val.month());
+        return _Os << _STD format(_Os.getloc(), _STATICALLY_WIDEN(_CharT, "{:L}/{:L}"), _Val.year(), _Val.month());
     }
 
     template <class _CharT, class _Traits>
@@ -5648,25 +5662,26 @@ namespace chrono {
 
     template <class _CharT, class _Traits>
     basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const year_month_day_last& _Val) {
-        return _Os << _STD format(_Os.getloc(), _STATICALLY_WIDEN(_CharT, "{}/{}"), _Val.year(), _Val.month_day_last());
+        return _Os << _STD format(
+                   _Os.getloc(), _STATICALLY_WIDEN(_CharT, "{:L}/{:L}"), _Val.year(), _Val.month_day_last());
     }
 
     template <class _CharT, class _Traits>
     basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const year_month_weekday& _Val) {
-        return _Os << _STD format(_Os.getloc(), _STATICALLY_WIDEN(_CharT, "{}/{}/{}"), _Val.year(), _Val.month(),
+        return _Os << _STD format(_Os.getloc(), _STATICALLY_WIDEN(_CharT, "{:L}/{:L}/{:L}"), _Val.year(), _Val.month(),
                    _Val.weekday_indexed());
     }
 
     template <class _CharT, class _Traits>
     basic_ostream<_CharT, _Traits>& operator<<(
         basic_ostream<_CharT, _Traits>& _Os, const year_month_weekday_last& _Val) {
-        return _Os << _STD format(
-                   _Os.getloc(), _STATICALLY_WIDEN(_CharT, "{}/{}/{}"), _Val.year(), _Val.month(), _Val.weekday_last());
+        return _Os << _STD format(_Os.getloc(), _STATICALLY_WIDEN(_CharT, "{:L}/{:L}/{:L}"), _Val.year(), _Val.month(),
+                   _Val.weekday_last());
     }
 
     template <class _CharT, class _Traits, class _Duration>
     basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const hh_mm_ss<_Duration>& _Val) {
-        return _Os << _STD format(_Os.getloc(), _STATICALLY_WIDEN(_CharT, "{:%T}"), _Val);
+        return _Os << _STD format(_Os.getloc(), _STATICALLY_WIDEN(_CharT, "{:L%T}"), _Val);
     }
 
 #pragma warning(push)
@@ -5717,7 +5732,7 @@ namespace chrono {
         // clang-format on
         const auto _Dp = _CHRONO floor<days>(_Val);
         return _Os << _STD format(
-                   _Os.getloc(), _STATICALLY_WIDEN(_CharT, "{} {}"), year_month_day{_Dp}, hh_mm_ss{_Val - _Dp});
+                   _Os.getloc(), _STATICALLY_WIDEN(_CharT, "{:L} {:L}"), year_month_day{_Dp}, hh_mm_ss{_Val - _Dp});
     }
 
     template <class _CharT, class _Traits>
@@ -5727,22 +5742,22 @@ namespace chrono {
 
     template <class _CharT, class _Traits, class _Duration>
     basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const utc_time<_Duration>& _Val) {
-        return _Os << _STD format(_STATICALLY_WIDEN(_CharT, "{:%F %T}"), _Val);
+        return _Os << _STD format(_Os.getloc(), _STATICALLY_WIDEN(_CharT, "{:L%F %T}"), _Val);
     }
 
     template <class _CharT, class _Traits, class _Duration>
     basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const tai_time<_Duration>& _Val) {
-        return _Os << _STD format(_STATICALLY_WIDEN(_CharT, "{:%F %T}"), _Val);
+        return _Os << _STD format(_Os.getloc(), _STATICALLY_WIDEN(_CharT, "{:L%F %T}"), _Val);
     }
 
     template <class _CharT, class _Traits, class _Duration>
     basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const gps_time<_Duration>& _Val) {
-        return _Os << _STD format(_STATICALLY_WIDEN(_CharT, "{:%F %T}"), _Val);
+        return _Os << _STD format(_Os.getloc(), _STATICALLY_WIDEN(_CharT, "{:L%F %T}"), _Val);
     }
 
     template <class _CharT, class _Traits, class _Duration>
     basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const file_time<_Duration>& _Val) {
-        return _Os << _STD format(_STATICALLY_WIDEN(_CharT, "{:%F %T}"), _Val);
+        return _Os << _STD format(_Os.getloc(), _STATICALLY_WIDEN(_CharT, "{:L%F %T}"), _Val);
     }
 
     template <class _CharT, class _Traits, class _Duration>
@@ -5755,7 +5770,7 @@ namespace chrono {
         basic_ostream<_CharT, _Traits>& _Os, const _Local_time_format_t<_Duration>& _Val) {
         // Doesn't appear in the Standard, but allowed by N4885 [global.functions]/2.
         // Implements N4885 [time.zone.zonedtime.nonmembers]/2 for zoned_time.
-        return _Os << _STD format(_Os.getloc(), _STATICALLY_WIDEN(_CharT, "{:%F %T %Z}"), _Val);
+        return _Os << _STD format(_Os.getloc(), _STATICALLY_WIDEN(_CharT, "{:L%F %T %Z}"), _Val);
     }
 
     template <class _CharT, class _Traits, class _Duration, class _TimeZonePtr>
@@ -5899,10 +5914,10 @@ namespace chrono {
         _NODISCARD auto _Write(_FormatContext& _FormatCtx, const _Ty& _Val, const tm& _Time) {
             basic_ostringstream<_CharT> _Stream;
 
+            _Stream.imbue(_Specs._Localized ? _FormatCtx.locale() : locale::classic());
             if (_Specs._Chrono_specs_list.empty()) {
                 _Stream << _Val; // N4885 [time.format]/6
             } else {
-                _Stream.imbue(_FormatCtx.locale());
                 if constexpr (_Is_specialization_v<_Ty, hh_mm_ss>) {
                     if (_Val.is_negative()) {
                         _Stream << _CharT{'-'};
@@ -6262,7 +6277,7 @@ namespace chrono {
             return _Fmt_str;
         }
 
-        _Chrono_format_specs<_CharT> _Specs{};
+        _Chrono_format_specs2<_CharT> _Specs{};
         basic_string_view<_CharT> _Time_zone_abbreviation{};
     };
 } // namespace chrono

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -1262,7 +1262,7 @@
 #define __cpp_lib_erase_if                202002L
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395 and GH-1814
-#define __cpp_lib_format 201907L
+#define __cpp_lib_format 202110L
 #endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 
 #define __cpp_lib_generic_unordered_lookup     201811L

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -260,6 +260,7 @@
 // P2325R3 Views Should Not Be Required To Be Default Constructible
 // P2328R1 join_view Should Join All views Of ranges
 // P2367R0 Remove Misuses Of List-Initialization From Clause 24 Ranges
+// P2372R3 Fixing Locale Handling In chrono Formatters
 // P2432R1 Fix istream_view
 // P????R? directory_entry::clear_cache()
 

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
@@ -156,6 +156,8 @@ bool test_parse_chrono_format_specs() {
     view_typ s6(STR("%H%"));
     view_typ s7(STR("%H%}"));
     view_typ s8(STR("%nB%tC%%D"));
+    view_typ s9(STR("L"));
+    view_typ s10(STR("L%F"));
 
     vector<chrono_spec> v0{{._Modifier = 'O', ._Type = 'e'}};
     test_parse_helper(parse_chrono_format_specs_fn, s0, false, s0.size(), {.expected_chrono_specs = v0});
@@ -192,6 +194,15 @@ bool test_parse_chrono_format_specs() {
     vector<chrono_spec> v{{._Type = 'H'}}; // we don't throw a format_error until we parse the %H
     test_parse_helper(parse_chrono_format_specs_fn, s6, true, view_typ::npos, {.expected_chrono_specs = v});
     test_parse_helper(parse_chrono_format_specs_fn, s7, true, view_typ::npos, {.expected_chrono_specs = v});
+
+    vector<chrono_spec> v_empty{};
+    test_parse_helper(parse_chrono_format_specs_fn, s9, false, view_typ::npos,
+        {.expected_localized = true, .expected_chrono_specs = v_empty});
+
+    vector<chrono_spec> v6{{._Type = 'F'}};
+    test_parse_helper(parse_chrono_format_specs_fn, s10, false, view_typ::npos,
+        {.expected_localized = true, .expected_chrono_specs = v6});
+
 
     return true;
 }
@@ -914,7 +925,7 @@ void test_locale() {
     assert(format(loc, STR("{:L%S}"), 42ms) == STR("00,042"));
 
     auto stream = [=](auto value) {
-        std::basic_ostringstream<CharT> os;
+        basic_ostringstream<CharT> os;
         os.imbue(loc);
         os << value;
         return os.str();

--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
@@ -725,10 +725,10 @@ STATIC_ASSERT(__cpp_lib_filesystem == 201703L);
 #if _HAS_CXX23 && !defined(__EDG__) // TRANSITION, EDG concepts support and GH-1814
 #ifndef __cpp_lib_format
 #error __cpp_lib_format is not defined
-#elif __cpp_lib_format != 201907L
+#elif __cpp_lib_format != 202110L
 #error __cpp_lib_format is not 201907L
 #else
-STATIC_ASSERT(__cpp_lib_format == 201907L);
+STATIC_ASSERT(__cpp_lib_format == 202110L);
 #endif
 #else
 #ifdef __cpp_lib_format


### PR DESCRIPTION
Continuation of #1892 

In addition to that pull requests content (which is mirrored here, although squashed into one commit) I have

* merged the new tests from #1892 into the tests into some existing locale tests from a subsequent pr (#2017 )
* fixed that PRs new test to use the locale specifier as is now required.

fixes: #2237 

approved by plenary a week ago:
https://github.com/cplusplus/papers/issues/1039