### PR TITLE
Compile TypeScript in `update-status-chart.yml`

### DIFF
--- a/.github/workflows/update-status-chart.yml
+++ b/.github/workflows/update-status-chart.yml
@@ -19,10 +19,15 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ">=16.0.0"
-      - name: Run gather_stats.js
+      - name: Install Packages
         run: |
           npm ci
-          SECRET_GITHUB_PERSONAL_ACCESS_TOKEN="${{ github.token }}" node gather_stats.js
+      - name: Compile gather_stats.ts
+        run: |
+          npx tsc
+      - name: Run gather_stats.js
+        run: |
+          SECRET_GITHUB_PERSONAL_ACCESS_TOKEN="${{ github.token }}" node built/gather_stats.js
       - name: Commit Changes
         run: |
           git config user.name "github-actions[bot]"


### PR DESCRIPTION
This PR targeting `main` is a companion to #2283 targeting `gh-pages`.

It teaches the Update Status Chart workflow how to invoke the TypeScript compiler and run the output. For clarity, it now performs Install Packages, Compile, and Run as separate steps (so if something fails, it will be slightly clearer, although it's not a big deal).

I have verified this by manually invoking this workflow in my fork.