### PR TITLE
Workaround Devcom-1559808 in ranges::sort

### DIFF
--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -179,34 +179,6 @@ namespace ranges {
         }
     };
 
-    template <class _Result, class _Wrapped, class _Unwrapped>
-    _NODISCARD constexpr _Result _Rewrap_subrange(_Wrapped& _Val, subrange<_Unwrapped>&& _UResult) {
-        // conditionally computes a wrapped subrange from a wrapped iterator or range and unwrapped subrange
-        if constexpr (is_same_v<_Result, dangling>) {
-            return dangling{};
-        } else if constexpr (is_same_v<_Result, subrange<_Unwrapped>>) {
-            return _STD move(_UResult);
-        } else if constexpr (range<_Wrapped>) {
-            _STL_INTERNAL_STATIC_ASSERT(forward_range<_Wrapped>);
-            _STL_INTERNAL_STATIC_ASSERT(is_same_v<_Unwrapped, _Unwrapped_t<iterator_t<_Wrapped>>>);
-            _STL_INTERNAL_STATIC_ASSERT(is_same_v<_Result, subrange<iterator_t<_Wrapped>>>);
-
-            auto _First = _RANGES begin(_Val);
-            auto _Last  = _First;
-            _First._Seek_to(_UResult.begin());
-            _Last._Seek_to(_UResult.end());
-            return _Result{_STD move(_First), _STD move(_Last)};
-        } else {
-            _STL_INTERNAL_STATIC_ASSERT(is_same_v<_Unwrapped, _Unwrapped_t<_Wrapped>>);
-            _STL_INTERNAL_STATIC_ASSERT(is_same_v<_Result, subrange<_Wrapped>>);
-
-            auto _Last = _Val;
-            _Val._Seek_to(_UResult.begin());
-            _Last._Seek_to(_UResult.end());
-            return _Result{_STD move(_Val), _STD move(_Last)};
-        }
-    }
-
     template <forward_iterator _Wrapped, sentinel_for<_Wrapped> _Se>
     _NODISCARD constexpr auto _Get_final_iterator_unwrapped(const _Unwrapped_t<_Wrapped>& _UFirst, _Se&& _Last) {
         // find the iterator in [_UFirst, _Get_unwrapped(_Last)) which equals _Get_unwrapped(_Last) [possibly O(N)]

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -7660,7 +7660,13 @@ namespace ranges {
                 }
 
                 // divide and conquer by quicksort
+#if defined(__clang__) || defined(__EDG__) // TRANSITION, DevCom-1559808
                 auto [_Mid_first, _Mid_last] = _Partition_by_median_guess_common(_First, _Last, _Pred, _Proj);
+#else // ^^^ no workaround // workaround vvv
+                auto _Mid       = _Partition_by_median_guess_common(_First, _Last, _Pred, _Proj);
+                auto _Mid_first = _Mid.begin();
+                auto _Mid_last  = _Mid.end();
+#endif // TRANSITION, DevCom-1559808
 
                 _Ideal = (_Ideal >> 1) + (_Ideal >> 2); // allow 1.5 log2(N) divisions
 

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -3777,7 +3777,13 @@ namespace ranges {
                     return *this;
                 }
 
+#if defined(__clang__) || defined(__EDG__) // TRANSITION, DevCom-1559808
                 auto [_Begin, _End] = _RANGES search(subrange{_Current, _Last}, _Parent->_Pattern);
+#else // ^^^ no workaround / workaround vvv
+                auto _Match = _RANGES search(subrange{_Current, _Last}, _Parent->_Pattern);
+                auto _Begin = _Match.begin();
+                auto _End = _Match.end();
+#endif // TRANSITION, DevCom-1559808
                 if (_Begin != _Last && _RANGES empty(_Parent->_Pattern)) {
                     ++_Begin;
                     ++_End;
@@ -3823,7 +3829,13 @@ namespace ranges {
 
         constexpr subrange<iterator_t<_Vw>> _Find_next(iterator_t<_Vw> _It) {
             const auto _Last    = _RANGES end(_Range);
+#if defined(__clang__) || defined(__EDG__) // TRANSITION, DevCom-1559808
             auto [_Begin, _End] = _RANGES search(subrange{_It, _Last}, _Pattern);
+#else // ^^^ no workaround / workaround vvv
+            auto _Match = _RANGES search(subrange{_It, _Last}, _Pattern);
+            auto _Begin = _Match.begin();
+            auto _End = _Match.end();
+#endif // TRANSITION, DevCom-1559808
             if (_Begin != _Last && _RANGES empty(_Pattern)) {
                 ++_Begin;
                 ++_End;

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -5520,6 +5520,34 @@ _NODISCARD _CONSTEXPR20 _InIt find_if(_InIt _First, const _InIt _Last, _Pr _Pred
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
+    template <class _Result, class _Wrapped, class _Unwrapped>
+    _NODISCARD constexpr _Result _Rewrap_subrange(_Wrapped& _Val, subrange<_Unwrapped>&& _UResult) {
+        // conditionally computes a wrapped subrange from a wrapped iterator or range and unwrapped subrange
+        if constexpr (is_same_v<_Result, dangling>) {
+            return dangling{};
+        } else if constexpr (is_same_v<_Result, subrange<_Unwrapped>>) {
+            return _STD move(_UResult);
+        } else if constexpr (range<_Wrapped>) {
+            _STL_INTERNAL_STATIC_ASSERT(forward_range<_Wrapped>);
+            _STL_INTERNAL_STATIC_ASSERT(is_same_v<_Unwrapped, _Unwrapped_t<iterator_t<_Wrapped>>>);
+            _STL_INTERNAL_STATIC_ASSERT(is_same_v<_Result, subrange<iterator_t<_Wrapped>>>);
+
+            auto _First = _RANGES begin(_Val);
+            auto _Last  = _First;
+            _First._Seek_to(_UResult.begin());
+            _Last._Seek_to(_UResult.end());
+            return _Result{_STD move(_First), _STD move(_Last)};
+        } else {
+            _STL_INTERNAL_STATIC_ASSERT(is_same_v<_Unwrapped, _Unwrapped_t<_Wrapped>>);
+            _STL_INTERNAL_STATIC_ASSERT(is_same_v<_Result, subrange<_Wrapped>>);
+
+            auto _Last = _Val;
+            _Val._Seek_to(_UResult.begin());
+            _Last._Seek_to(_UResult.end());
+            return _Result{_STD move(_Val), _STD move(_Last)};
+        }
+    }
+
     // concept-constrained for strict enforcement as it is used by several algorithms
     template <input_iterator _It, sentinel_for<_It> _Se, class _Pj, indirect_unary_predicate<projected<_It, _Pj>> _Pr>
     _NODISCARD constexpr _It _Find_if_unchecked(_It _First, const _Se _Last, _Pr _Pred, _Pj _Proj) {

--- a/tests/std/tests/P0896R4_ranges_alg_find_end/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_find_end/test.cpp
@@ -8,6 +8,7 @@
 #include <ranges>
 #include <span>
 #include <utility>
+#include <vector>
 
 #include <range_algorithm_support.hpp>
 
@@ -71,9 +72,29 @@ constexpr void smoke_test() {
     }
 }
 
+constexpr void test_1559808() {
+    // Regression test for DevCom-1559808, an interaction between vector and the
+    // use of structured bindings in the constexpr evaluator.
+
+    std::vector<int> haystack(33, 42), needle(8, 42); // No particular significance to any numbers in this function
+    using size_type = std::vector<int>::size_type;
+
+    auto result = ranges::find_end(haystack, needle);
+    assert(static_cast<size_type>(result.begin() - haystack.begin()) == haystack.size() - needle.size());
+    assert(result.end() == haystack.end());
+
+    needle.assign(6, 1729);
+    result = ranges::find_end(haystack, needle);
+    assert(result.begin() == haystack.end());
+    assert(result.end() == haystack.end());
+}
+
 int main() {
     STATIC_ASSERT((smoke_test(), true));
     smoke_test();
+
+    STATIC_ASSERT((test_1559808(), true));
+    test_1559808();
 }
 
 #ifndef _PREFAST_ // TRANSITION, GH-1030

--- a/tests/std/tests/P0896R4_ranges_alg_find_end/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_find_end/test.cpp
@@ -72,11 +72,12 @@ constexpr void smoke_test() {
     }
 }
 
-constexpr void test_1559808() {
+constexpr void test_devcom_1559808() {
     // Regression test for DevCom-1559808, an interaction between vector and the
     // use of structured bindings in the constexpr evaluator.
 
-    std::vector<int> haystack(33, 42), needle(8, 42); // No particular significance to any numbers in this function
+    std::vector<int> haystack(33, 42); // No particular significance to any numbers in this function
+    std::vector<int> needle(8, 42);
     using size_type = std::vector<int>::size_type;
 
     auto result = ranges::find_end(haystack, needle);
@@ -93,8 +94,8 @@ int main() {
     STATIC_ASSERT((smoke_test(), true));
     smoke_test();
 
-    STATIC_ASSERT((test_1559808(), true));
-    test_1559808();
+    STATIC_ASSERT((test_devcom_1559808(), true));
+    test_devcom_1559808();
 }
 
 #ifndef _PREFAST_ // TRANSITION, GH-1030

--- a/tests/std/tests/P0896R4_ranges_alg_search/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_search/test.cpp
@@ -169,11 +169,12 @@ constexpr bool run_tests() {
     return true;
 }
 
-constexpr void test_1559808() {
+constexpr void test_devcom_1559808() {
     // Regression test for DevCom-1559808, an interaction between vector and the
     // use of structured bindings in the constexpr evaluator.
 
-    std::vector<int> haystack(33, 42), needle(8, 42); // No particular significance to any numbers in this function
+    vector<int> haystack(33, 42); // No particular significance to any numbers in this function
+    vector<int> needle(8, 42);
 
     auto result = ranges::search(haystack, needle);
     assert(result.begin() == haystack.begin());
@@ -189,7 +190,7 @@ int main() {
     STATIC_ASSERT(run_tests());
     run_tests();
 
-    STATIC_ASSERT((test_1559808(), true));
-    test_1559808();
+    STATIC_ASSERT((test_devcom_1559808(), true));
+    test_devcom_1559808();
 }
 #endif // TEST_EVERYTHING

--- a/tests/std/tests/P0896R4_ranges_alg_search/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_search/test.cpp
@@ -8,6 +8,7 @@
 #include <ranges>
 #include <span>
 #include <utility>
+#include <vector>
 
 #include <range_algorithm_support.hpp>
 
@@ -168,8 +169,27 @@ constexpr bool run_tests() {
     return true;
 }
 
+constexpr void test_1559808() {
+    // Regression test for DevCom-1559808, an interaction between vector and the
+    // use of structured bindings in the constexpr evaluator.
+
+    std::vector<int> haystack(33, 42), needle(8, 42); // No particular significance to any numbers in this function
+
+    auto result = ranges::search(haystack, needle);
+    assert(result.begin() == haystack.begin());
+    assert(result.end() == haystack.begin() + ranges::ssize(needle));
+
+    needle.assign(6, 1729);
+    result = ranges::search(haystack, needle);
+    assert(result.begin() == haystack.end());
+    assert(result.end() == haystack.end());
+}
+
 int main() {
     STATIC_ASSERT(run_tests());
     run_tests();
+
+    STATIC_ASSERT((test_1559808(), true));
+    test_1559808();
 }
 #endif // TEST_EVERYTHING

--- a/tests/std/tests/P0896R4_ranges_alg_sort/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_sort/test.cpp
@@ -8,6 +8,7 @@
 #include <ranges>
 #include <span>
 #include <utility>
+#include <vector>
 
 #include <range_algorithm_support.hpp>
 
@@ -51,7 +52,31 @@ struct instantiator {
     }
 };
 
+constexpr void test_1559808() {
+    // Regression test for DevCom-1559808, a bad interaction between constexpr vector and the use of structured bindings
+    // in the implemenation of ranges::sort.
+
+    auto collatz = [](int n) {
+        vector<int> vec = {n};
+        while (n != 1) {
+            if (n % 2 == 0) {
+                n /= 2;
+            } else {
+                n = n * 3 + 1;
+            }
+            vec.push_back(n);
+        }
+        ranges::sort(vec);
+        return vec.back();
+    };
+
+    assert(collatz(27) == 9232);
+}
+
 int main() {
     STATIC_ASSERT((test_random<instantiator, P>(), true));
     test_random<instantiator, P>();
+
+    STATIC_ASSERT((test_1559808(), true));
+    test_1559808();
 }

--- a/tests/std/tests/P0896R4_ranges_alg_sort/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_sort/test.cpp
@@ -54,23 +54,11 @@ struct instantiator {
 
 constexpr void test_1559808() {
     // Regression test for DevCom-1559808, a bad interaction between constexpr vector and the use of structured bindings
-    // in the implemenation of ranges::sort.
+    // in the implementation of ranges::sort.
 
-    auto collatz = [](int n) {
-        vector<int> vec = {n};
-        while (n != 1) {
-            if (n % 2 == 0) {
-                n /= 2;
-            } else {
-                n = n * 3 + 1;
-            }
-            vec.push_back(n);
-        }
-        ranges::sort(vec);
-        return vec.back();
-    };
-
-    assert(collatz(27) == 9232);
+    vector<int> vec(33, 42); // NB: 33 > std::_ISORT_MAX
+    ranges::sort(vec);
+    assert(vec.back() == 42);
 }
 
 int main() {

--- a/tests/std/tests/P0896R4_ranges_alg_sort/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_sort/test.cpp
@@ -52,7 +52,7 @@ struct instantiator {
     }
 };
 
-constexpr void test_1559808() {
+constexpr void test_devcom_1559808() {
     // Regression test for DevCom-1559808, a bad interaction between constexpr vector and the use of structured bindings
     // in the implementation of ranges::sort.
 
@@ -65,6 +65,6 @@ int main() {
     STATIC_ASSERT((test_random<instantiator, P>(), true));
     test_random<instantiator, P>();
 
-    STATIC_ASSERT((test_1559808(), true));
-    test_1559808();
+    STATIC_ASSERT((test_devcom_1559808(), true));
+    test_devcom_1559808();
 }

--- a/tests/std/tests/P0896R4_views_split/test.cpp
+++ b/tests/std/tests/P0896R4_views_split/test.cpp
@@ -321,7 +321,7 @@ constexpr bool instantiation_test() {
     return true;
 }
 
-constexpr bool test_1559808() {
+constexpr bool test_devcom_1559808() {
     // Regression test for DevCom-1559808, an interaction between vector and the
     // use of structured bindings in the constexpr evaluator.
 
@@ -345,8 +345,8 @@ int main() {
     STATIC_ASSERT(instantiation_test());
     instantiation_test();
 
-#if defined(__clang__) || defined(__EDG__) // TRANSITION, DevDiv-1516290
-    STATIC_ASSERT(test_1559808());
-#endif // TRANSITION, DevDiv-1516290
-    test_1559808();
+#if defined(__clang__) || defined(__EDG__) // TRANSITION, DevCom-1516290
+    STATIC_ASSERT(test_devcom_1559808());
+#endif // TRANSITION, DevCom-1516290
+    test_devcom_1559808();
 }

--- a/tests/std/tests/P0896R4_views_split/test.cpp
+++ b/tests/std/tests/P0896R4_views_split/test.cpp
@@ -10,6 +10,7 @@
 #include <system_error>
 #include <type_traits>
 #include <utility>
+#include <vector>
 
 #include <range_algorithm_support.hpp>
 using namespace std;
@@ -320,7 +321,32 @@ constexpr bool instantiation_test() {
     return true;
 }
 
+constexpr bool test_1559808() {
+    // Regression test for DevCom-1559808, an interaction between vector and the
+    // use of structured bindings in the constexpr evaluator.
+
+    vector<char> letters{'T', 'h', 'i', 's', ' ', 'i', 's', ' ', 'a', ' ', 't', 'e', 's', 't'};
+    auto r = views::split(letters, ' ');
+    auto i = r.begin();
+    assert(*(*i).begin() == 'T');
+    ++i;
+    assert(*(*i).begin() == 'i');
+    ++i;
+    assert(*(*i).begin() == 'a');
+    ++i;
+    assert(*(*i).begin() == 't');
+    ++i;
+    assert(i == r.end());
+
+    return true;
+}
+
 int main() {
     STATIC_ASSERT(instantiation_test());
     instantiation_test();
+
+#if defined(__clang__) || defined(__EDG__) // TRANSITION, DevDiv-1516290
+    STATIC_ASSERT(test_1559808());
+#endif // TRANSITION, DevDiv-1516290
+    test_1559808();
 }


### PR DESCRIPTION
If there's one thing that _must_ work in C++, it's sorting `vector` =)

For ease of review: DevCom-1559808.

This also moves `_Rewrap_subrange` to `<xutility>` because it's already being used there:
https://github.com/microsoft/STL/blob/ee5a216b516ef033d9153b324842369eee7653d1/stl/inc/xutility#L5674
