### PR TITLE
Specially handle `array<T, 0>` for non-default-constructible `T`

### DIFF
--- a/stl/inc/array
+++ b/stl/inc/array
@@ -615,6 +615,8 @@ template <class _First, class... _Rest>
 array(_First, _Rest...) -> array<typename _Enforce_same<_First, _Rest...>::type, 1 + sizeof...(_Rest)>;
 #endif // _HAS_CXX17
 
+struct _Empty_array_element {};
+
 template <class _Ty>
 class array<_Ty, 0> {
 public:
@@ -783,7 +785,7 @@ public:
         _Xout_of_range("invalid array<T, 0> subscript");
     }
 
-    conditional_t<is_default_constructible_v<_Ty>, _Ty, char> _Elems[1];
+    conditional_t<_Is_implicitly_default_constructible<_Ty>::value, _Ty, _Empty_array_element> _Elems[1];
 };
 
 template <class _Ty, size_t _Size, enable_if_t<_Size == 0 || _Is_swappable<_Ty>::value, int> = 0>

--- a/stl/inc/array
+++ b/stl/inc/array
@@ -728,7 +728,7 @@ public:
         _STL_REPORT_ERROR("array subscript out of range");
 #endif // _CONTAINER_DEBUG_LEVEL > 0
 
-        return _Elems[0];
+        return *data();
     }
 
     _NODISCARD const_reference operator[](size_type) const noexcept /* strengthened */ {
@@ -736,7 +736,7 @@ public:
         _STL_REPORT_ERROR("array subscript out of range");
 #endif // _CONTAINER_DEBUG_LEVEL > 0
 
-        return _Elems[0];
+        return *data();
     }
 
     _NODISCARD reference front() noexcept /* strengthened */ {
@@ -744,7 +744,7 @@ public:
         _STL_REPORT_ERROR("array<T, 0>::front() invalid");
 #endif // _CONTAINER_DEBUG_LEVEL > 0
 
-        return _Elems[0];
+        return *data();
     }
 
     _NODISCARD const_reference front() const noexcept /* strengthened */ {
@@ -752,7 +752,7 @@ public:
         _STL_REPORT_ERROR("array<T, 0>::front() invalid");
 #endif // _CONTAINER_DEBUG_LEVEL > 0
 
-        return _Elems[0];
+        return *data();
     }
 
     _NODISCARD reference back() noexcept /* strengthened */ {
@@ -760,7 +760,7 @@ public:
         _STL_REPORT_ERROR("array<T, 0>::back() invalid");
 #endif // _CONTAINER_DEBUG_LEVEL > 0
 
-        return _Elems[0];
+        return *data();
     }
 
     _NODISCARD const_reference back() const noexcept /* strengthened */ {
@@ -768,7 +768,7 @@ public:
         _STL_REPORT_ERROR("array<T, 0>::back() invalid");
 #endif // _CONTAINER_DEBUG_LEVEL > 0
 
-        return _Elems[0];
+        return *data();
     }
 
     _NODISCARD _CONSTEXPR17 _Ty* data() noexcept {
@@ -783,7 +783,7 @@ public:
         _Xout_of_range("invalid array<T, 0> subscript");
     }
 
-    _Ty _Elems[1];
+    conditional_t<is_default_constructible_v<_Ty>, _Ty, char> _Elems[1];
 };
 
 template <class _Ty, size_t _Size, enable_if_t<_Size == 0 || _Is_swappable<_Ty>::value, int> = 0>

--- a/stl/inc/array
+++ b/stl/inc/array
@@ -785,7 +785,9 @@ public:
         _Xout_of_range("invalid array<T, 0> subscript");
     }
 
-    conditional_t<_Is_implicitly_default_constructible<_Ty>::value, _Ty, _Empty_array_element> _Elems[1];
+    conditional_t<disjunction_v<is_default_constructible<_Ty>, _Is_implicitly_default_constructible<_Ty>>, _Ty,
+        _Empty_array_element>
+        _Elems[1];
 };
 
 template <class _Ty, size_t _Size, enable_if_t<_Size == 0 || _Is_swappable<_Ty>::value, int> = 0>

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -69,6 +69,9 @@ std/language.support/support.limits/support.limits.general/concepts.version.pass
 # Bogus test believes that optional<non_constexpr_destructor> cannot be a literal type
 std/utilities/optional/optional.object/optional.object.dtor/dtor.pass.cpp:0 FAIL
 
+# Bogus test believes that copyability of array<T, 0> must be the same as array<T, 1>
+std/containers/sequences/array/array.cons/implicit_copy.pass.cpp FAIL
+
 
 # *** INTERACTIONS WITH CONTEST / C1XX THAT UPSTREAM LIKELY WON'T FIX ***
 # Tracked by VSO-593630 "<filesystem> Enable libcxx filesystem tests"
@@ -347,13 +350,6 @@ std/input.output/file.streams/fstreams/filebuf.virtuals/underflow.pass.cpp FAIL
 # GH-1295 <array>: array<const T, 0> allows fill() and swap()
 std/containers/sequences/array/array.fill/fill.fail.cpp FAIL
 std/containers/sequences/array/array.swap/swap.fail.cpp FAIL
-
-# GH-942 <array>: std::array<T,0> doesn't compile - when type is not default constructible
-std/containers/sequences/array/array.cons/implicit_copy.pass.cpp FAIL
-std/containers/sequences/array/array.cons/initialization.pass.cpp FAIL
-std/containers/sequences/array/array.data/data_const.pass.cpp FAIL
-std/containers/sequences/array/array.data/data.pass.cpp FAIL
-std/containers/sequences/array/iterators.pass.cpp FAIL
 
 # GH-1006 <algorithm>: debug checks for predicates are observable
 std/algorithms/alg.sorting/alg.merge/inplace_merge_comp.pass.cpp FAIL

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -69,6 +69,9 @@ language.support\support.limits\support.limits.general\concepts.version.pass.cpp
 # Bogus test believes that optional<non_constexpr_destructor> cannot be a literal type
 utilities\optional\optional.object\optional.object.dtor\dtor.pass.cpp
 
+# Bogus test believes that copyability of array<T, 0> must be the same as array<T, 1>
+containers\sequences\array\array.cons\implicit_copy.pass.cpp
+
 
 # *** INTERACTIONS WITH CONTEST / C1XX THAT UPSTREAM LIKELY WON'T FIX ***
 # Tracked by VSO-593630 "<filesystem> Enable libcxx filesystem tests"
@@ -347,13 +350,6 @@ input.output\file.streams\fstreams\filebuf.virtuals\underflow.pass.cpp
 # GH-1295 <array>: array<const T, 0> allows fill() and swap()
 containers\sequences\array\array.fill\fill.fail.cpp
 containers\sequences\array\array.swap\swap.fail.cpp
-
-# GH-942 <array>: std::array<T,0> doesn't compile - when type is not default constructible
-containers\sequences\array\array.cons\implicit_copy.pass.cpp
-containers\sequences\array\array.cons\initialization.pass.cpp
-containers\sequences\array\array.data\data_const.pass.cpp
-containers\sequences\array\array.data\data.pass.cpp
-containers\sequences\array\iterators.pass.cpp
 
 # GH-1006 <algorithm>: debug checks for predicates are observable
 algorithms\alg.sorting\alg.merge\inplace_merge_comp.pass.cpp


### PR DESCRIPTION
Previously, these types were non-instantiable; we can't break ABI for something that doesn't compile. (Why do I always end up coding the PRs that fire salvos at the ODR?)

Fixes #942
Fixes VSO-207715 / AB#207715.

Note that the proposed resolution of LWG-2157 clarifies how `array<T, 0>` should behave. It hasn't been merged yet due to many of us despising the bit about "When `a` and `b` are distinct objects of the same zero-sized array type, `a.begin()` and `b.begin()` are not iterators over the same underlying sequence. [Note: Therefore `begin()` does not return a value-initialized iterator — end note]". If `begin` and `end` cannot return a value-initialized iterator (either a `nullptr` or a wrapper around a `nullptr`) it's not clear how they are to be implemented so as to be usable in `constexpr` context.

After applying this change, we will (at least in some cases) agree with the behavior of libc++ and libstdc++ which both return `iterator{data()}` with `data()` being `nullptr`. I will use this as evidence that the implementations don't agree with the cited bit of LWG-2157 and hopefully convince LWG to yoink that and merge the rest.