### PR TITLE
Update filesystem library to use GetTempPath2 on Windows 11

### DIFF
--- a/stl/src/awint.hpp
+++ b/stl/src/awint.hpp
@@ -23,11 +23,6 @@ _CRTIMP2 void __cdecl __crtGetSystemTimePreciseAsFileTime(_Out_ LPFILETIME lpSys
 
 #endif // _STL_WIN32_WINNT >= _WIN32_WINNT_WIN8
 
-// Note that GetTempPath2W is defined as of Win11, but there is no "_WIN32_WINNT_WIN11" constant,
-// so we will always dynamically load it
-_CRTIMP2 DWORD __cdecl __crtGetTempPath2W(
-    _In_ DWORD BufferLength, _Out_writes_to_opt_(BufferLength, return +1) LPWSTR Buffer);
-
 _CRTIMP2 int __cdecl __crtCompareStringA(_In_z_ LPCWSTR _LocaleName, _In_ DWORD _DwCmpFlags,
     _In_reads_(_CchCount1) LPCSTR _LpString1, _In_ int _CchCount1, _In_reads_(_CchCount2) LPCSTR _LpString2,
     _In_ int _CchCount2, _In_ int _CodePage);

--- a/stl/src/awint.hpp
+++ b/stl/src/awint.hpp
@@ -23,6 +23,11 @@ _CRTIMP2 void __cdecl __crtGetSystemTimePreciseAsFileTime(_Out_ LPFILETIME lpSys
 
 #endif // _STL_WIN32_WINNT >= _WIN32_WINNT_WIN8
 
+// Note that GetTempPath2W is defined as of Win11, but there is no "_WIN32_WINNT_WIN11" constant,
+// so we will always dynamically load it
+_CRTIMP2 DWORD __cdecl __crtGetTempPath2W(
+    _In_ DWORD BufferLength, _Out_writes_to_opt_(BufferLength, return +1) LPWSTR Buffer);
+
 _CRTIMP2 int __cdecl __crtCompareStringA(_In_z_ LPCWSTR _LocaleName, _In_ DWORD _DwCmpFlags,
     _In_reads_(_CchCount1) LPCSTR _LpString1, _In_ int _CchCount1, _In_reads_(_CchCount2) LPCSTR _LpString2,
     _In_ int _CchCount2, _In_ int _CodePage);

--- a/stl/src/filesys.cpp
+++ b/stl/src/filesys.cpp
@@ -15,6 +15,9 @@
 
 #include <Windows.h>
 
+extern "C" DWORD __cdecl __crtGetTempPath2W(
+    _In_ DWORD BufferLength, _Out_writes_to_opt_(BufferLength, return +1) LPWSTR Buffer);
+
 _FS_BEGIN
 static file_type _Map_mode(int _Mode) { // map Windows file attributes to file_status
     constexpr int _File_attribute_regular =

--- a/stl/src/filesys.cpp
+++ b/stl/src/filesys.cpp
@@ -162,7 +162,7 @@ _FS_DLL wchar_t* __CLRCALL_PURE_OR_CDECL _Symlink_get(wchar_t (&_Dest)[_MAX_FILE
 _FS_DLL wchar_t* __CLRCALL_PURE_OR_CDECL _Temp_get(wchar_t (&_Dest)[_MAX_FILESYS_NAME]) {
     // get temp directory
     wchar_t _Dentry[MAX_PATH];
-    return _Strcpy(_Dest, GetTempPathW(MAX_PATH, _Dentry) != 0 ? _Dentry : L".");
+    return _Strcpy(_Dest, __crtGetTempPath2W(MAX_PATH, _Dentry) == 0 ? L"." : _Dentry);
 }
 
 

--- a/stl/src/filesys.cpp
+++ b/stl/src/filesys.cpp
@@ -15,8 +15,8 @@
 
 #include <Windows.h>
 
-extern "C" DWORD __cdecl __crtGetTempPath2W(
-    _In_ DWORD BufferLength, _Out_writes_to_opt_(BufferLength, return +1) LPWSTR Buffer);
+extern "C" _Success_(return > 0 && return < BufferLength) DWORD
+    __stdcall __crtGetTempPath2W(_In_ DWORD BufferLength, _Out_writes_to_opt_(BufferLength, return +1) LPWSTR Buffer);
 
 _FS_BEGIN
 static file_type _Map_mode(int _Mode) { // map Windows file attributes to file_status
@@ -165,7 +165,7 @@ _FS_DLL wchar_t* __CLRCALL_PURE_OR_CDECL _Symlink_get(wchar_t (&_Dest)[_MAX_FILE
 _FS_DLL wchar_t* __CLRCALL_PURE_OR_CDECL _Temp_get(wchar_t (&_Dest)[_MAX_FILESYS_NAME]) {
     // get temp directory
     wchar_t _Dentry[MAX_PATH];
-    return _Strcpy(_Dest, __crtGetTempPath2W(MAX_PATH, _Dentry) == 0 ? L"." : _Dentry);
+    return _Strcpy(_Dest, __crtGetTempPath2W(MAX_PATH, _Dentry) != 0 ? _Dentry : L".");
 }
 
 

--- a/stl/src/filesys.cpp
+++ b/stl/src/filesys.cpp
@@ -15,8 +15,12 @@
 
 #include <Windows.h>
 
+#ifdef _M_CEE_PURE
+#define __crtGetTempPath2W(BufferLength, Buffer) GetTempPathW(BufferLength, Buffer)
+#else // vvv !defined(_M_CEE_PURE) vvv
 extern "C" _Success_(return > 0 && return < BufferLength) DWORD
     __stdcall __crtGetTempPath2W(_In_ DWORD BufferLength, _Out_writes_to_opt_(BufferLength, return +1) LPWSTR Buffer);
+#endif // ^^^ !defined(_M_CEE_PURE) ^^^
 
 _FS_BEGIN
 static file_type _Map_mode(int _Mode) { // map Windows file attributes to file_status

--- a/stl/src/filesystem.cpp
+++ b/stl/src/filesystem.cpp
@@ -762,28 +762,30 @@ _Success_(return == __std_win_error::_Success) __std_win_error
     return __std_win_error{GetLastError()};
 }
 
-static _Success_(return > 0 && return < nBufferLength) DWORD WINAPI
-    _Stl_GetTempPath2W(_In_ DWORD nBufferLength, _Out_writes_to_opt_(nBufferLength, return +1) LPWSTR lpBuffer) {
-    using _Fun_ptr = decltype(&::GetTempPath2W);
+namespace {
+    _Success_(return > 0 && return < nBufferLength) DWORD WINAPI
+        _Stl_GetTempPath2W(_In_ DWORD nBufferLength, _Out_writes_to_opt_(nBufferLength, return +1) LPWSTR lpBuffer) {
+        using _Fun_ptr = decltype(&::GetTempPath2W);
 
-    _Fun_ptr _PfGetTempPath2W;
-    {
-        static _STD atomic<_Fun_ptr> _Static{nullptr};
+        _Fun_ptr _PfGetTempPath2W;
+        {
+            static _STD atomic<_Fun_ptr> _Static{nullptr};
 
-        _PfGetTempPath2W = _Static.load(_STD memory_order_relaxed);
-        if (!_PfGetTempPath2W) {
-            const auto _Kernel32 = ::GetModuleHandleW(L"kernel32.dll");
-            _Analysis_assume_(_Kernel32);
-            _PfGetTempPath2W = reinterpret_cast<_Fun_ptr>(::GetProcAddress(_Kernel32, "GetTempPath2W"));
+            _PfGetTempPath2W = _Static.load(_STD memory_order_relaxed);
             if (!_PfGetTempPath2W) {
-                _PfGetTempPath2W = &::GetTempPathW;
+                const auto _Kernel32 = ::GetModuleHandleW(L"kernel32.dll");
+                _Analysis_assume_(_Kernel32);
+                _PfGetTempPath2W = reinterpret_cast<_Fun_ptr>(::GetProcAddress(_Kernel32, "GetTempPath2W"));
+                if (!_PfGetTempPath2W) {
+                    _PfGetTempPath2W = &::GetTempPathW;
+                }
+                _Static.store(_PfGetTempPath2W, _STD memory_order_relaxed); // overwriting with the same value is okay
             }
-            _Static.store(_PfGetTempPath2W, _STD memory_order_relaxed); // overwriting with the same value is okay
         }
-    }
 
-    return _PfGetTempPath2W(nBufferLength, lpBuffer);
-}
+        return _PfGetTempPath2W(nBufferLength, lpBuffer);
+    }
+} // unnamed namespace
 
 [[nodiscard]] _Success_(return._Error == __std_win_error::_Success) __std_ulong_and_error
     __stdcall __std_fs_get_temp_path(_Out_writes_z_(__std_fs_temp_path_max) wchar_t* const _Target) noexcept {

--- a/stl/src/filesystem.cpp
+++ b/stl/src/filesystem.cpp
@@ -764,17 +764,17 @@ _Success_(return == __std_win_error::_Success) __std_win_error
 
 static _Success_(return > 0 && return < nBufferLength) DWORD WINAPI
     _Stl_GetTempPath2W(_In_ DWORD nBufferLength, _Out_writes_to_opt_(nBufferLength, return +1) LPWSTR lpBuffer) {
+    using _Fun_ptr = decltype(&::GetTempPath2W);
 
-    decltype(&::GetTempPath2W) _PfGetTempPath2W;
+    _Fun_ptr _PfGetTempPath2W;
     {
-        static _STD atomic<decltype(&::GetTempPath2W)> _Static{nullptr};
+        static _STD atomic<_Fun_ptr> _Static{nullptr};
 
         _PfGetTempPath2W = _Static.load(_STD memory_order_relaxed);
         if (!_PfGetTempPath2W) {
             const auto _Kernel32 = ::GetModuleHandleW(L"kernel32.dll");
             _Analysis_assume_(_Kernel32);
-            _PfGetTempPath2W =
-                reinterpret_cast<decltype(&::GetTempPath2W)>(::GetProcAddress(_Kernel32, "GetTempPath2W"));
+            _PfGetTempPath2W = reinterpret_cast<_Fun_ptr>(::GetProcAddress(_Kernel32, "GetTempPath2W"));
             if (!_PfGetTempPath2W) {
                 _PfGetTempPath2W = &::GetTempPathW;
             }

--- a/stl/src/filesystem.cpp
+++ b/stl/src/filesystem.cpp
@@ -19,6 +19,8 @@
 #include <Windows.h>
 #include <winioctl.h>
 
+#include "awint.hpp"
+
 // We have several switches that do not have case statements for every possible enum value.
 // Hence, disabling this warning.
 #pragma warning(disable : 4061) // enumerator '__std_win_error::_Success' in switch of enum
@@ -763,11 +765,11 @@ _Success_(return == __std_win_error::_Success) __std_win_error
 
 [[nodiscard]] _Success_(return._Error == __std_win_error::_Success) __std_ulong_and_error
     __stdcall __std_fs_get_temp_path(_Out_writes_z_(__std_fs_temp_path_max) wchar_t* const _Target) noexcept {
-    // calls GetTempPathW
+    // calls GetTempPath2W
     // If getting the path failed, returns 0 size; otherwise, returns the size of the
     // expected directory. If the path could be resolved to an existing directory,
     // returns __std_win_error::_Success; otherwise, returns __std_win_error::_Max.
-    const auto _Size = GetTempPathW(__std_fs_temp_path_max, _Target);
+    const auto _Size = __crtGetTempPath2W(__std_fs_temp_path_max, _Target);
     if (_Size == 0) {
         return {0, __std_win_error{GetLastError()}};
     }

--- a/stl/src/winapisupp.cpp
+++ b/stl/src/winapisupp.cpp
@@ -27,6 +27,8 @@ namespace {
         eGetSystemTimePreciseAsFileTime,
 #endif // _STL_WIN32_WINNT < _WIN32_WINNT_WIN8
 
+        eGetTempPath2W,
+
         eMaxKernel32Function
     };
 
@@ -386,7 +388,7 @@ extern "C" void __cdecl __crtGetSystemTimePreciseAsFileTime(_Out_ LPFILETIME lpS
 
 extern "C" DWORD __cdecl __crtGetTempPath2W(
     _In_ DWORD BufferLength, _Out_writes_to_opt_(BufferLength, return +1) LPWSTR Buffer) {
-    // use GetTempPath2 if it is available (only on Windows 11+)...
+    // use GetTempPath2W if it is available (only on Windows 11+)...
     IFDYNAMICGETCACHEDFUNCTION(GetTempPath2W) {
         return pfGetTempPath2W(BufferLength, Buffer);
     }
@@ -416,6 +418,8 @@ static int __cdecl initialize_pointers() {
     STOREFUNCTIONPOINTER(hKernel32, GetSystemTimePreciseAsFileTime);
 #endif // _STL_WIN32_WINNT < _WIN32_WINNT_WIN8
 
+    // Note that GetTempPath2W is defined as of Windows 10 Build 20348 (a server release) or Windows 11,
+    // but there is no "_WIN32_WINNT_WIN11" constant, so we will always dynamically load it
     STOREFUNCTIONPOINTER(hKernel32, GetTempPath2W);
 
     return 0;

--- a/stl/src/winapisupp.cpp
+++ b/stl/src/winapisupp.cpp
@@ -384,6 +384,17 @@ extern "C" void __cdecl __crtGetSystemTimePreciseAsFileTime(_Out_ LPFILETIME lpS
 
 #endif // _STL_WIN32_WINNT < _WIN32_WINNT_WIN8
 
+extern "C" DWORD __cdecl __crtGetTempPath2W(
+    _In_ DWORD BufferLength, _Out_writes_to_opt_(BufferLength, return +1) LPWSTR Buffer) {
+    // use GetTempPath2 if it is available (only on Windows 11+)...
+    IFDYNAMICGETCACHEDFUNCTION(GetTempPath2W) {
+        return pfGetTempPath2W(BufferLength, Buffer);
+    }
+
+    // ...otherwise use GetTempPathW.
+    return GetTempPathW(BufferLength, Buffer);
+}
+
 
 // Helper to load all necessary Win32 API function pointers
 
@@ -404,6 +415,8 @@ static int __cdecl initialize_pointers() {
 #if _STL_WIN32_WINNT < _WIN32_WINNT_WIN8
     STOREFUNCTIONPOINTER(hKernel32, GetSystemTimePreciseAsFileTime);
 #endif // _STL_WIN32_WINNT < _WIN32_WINNT_WIN8
+
+    STOREFUNCTIONPOINTER(hKernel32, GetTempPath2W);
 
     return 0;
 }

--- a/stl/src/winapisupp.cpp
+++ b/stl/src/winapisupp.cpp
@@ -388,10 +388,12 @@ extern "C" void __cdecl __crtGetSystemTimePreciseAsFileTime(_Out_ LPFILETIME lpS
 
 extern "C" _Success_(return > 0 && return < BufferLength) DWORD
     __stdcall __crtGetTempPath2W(_In_ DWORD BufferLength, _Out_writes_to_opt_(BufferLength, return +1) LPWSTR Buffer) {
+#if !defined(_ONECORE)
     // use GetTempPath2W if it is available (only on Windows 11+)...
     IFDYNAMICGETCACHEDFUNCTION(GetTempPath2W) {
         return pfGetTempPath2W(BufferLength, Buffer);
     }
+#endif // ^^^ !defined(_ONECORE) ^^^
 
     // ...otherwise use GetTempPathW.
     return GetTempPathW(BufferLength, Buffer);

--- a/stl/src/winapisupp.cpp
+++ b/stl/src/winapisupp.cpp
@@ -32,7 +32,7 @@ namespace {
         eMaxKernel32Function
     };
 
-    PVOID __KERNEL32Functions[eMaxKernel32Function > 0 ? eMaxKernel32Function : 1]{};
+    PVOID __KERNEL32Functions[eMaxKernel32Function]{};
 
 // Use this macro for caching a function pointer from a DLL
 #define STOREFUNCTIONPOINTER(instance, function_name) \
@@ -386,8 +386,8 @@ extern "C" void __cdecl __crtGetSystemTimePreciseAsFileTime(_Out_ LPFILETIME lpS
 
 #endif // _STL_WIN32_WINNT < _WIN32_WINNT_WIN8
 
-extern "C" DWORD __cdecl __crtGetTempPath2W(
-    _In_ DWORD BufferLength, _Out_writes_to_opt_(BufferLength, return +1) LPWSTR Buffer) {
+extern "C" _Success_(return > 0 && return < BufferLength) DWORD
+    __stdcall __crtGetTempPath2W(_In_ DWORD BufferLength, _Out_writes_to_opt_(BufferLength, return +1) LPWSTR Buffer) {
     // use GetTempPath2W if it is available (only on Windows 11+)...
     IFDYNAMICGETCACHEDFUNCTION(GetTempPath2W) {
         return pfGetTempPath2W(BufferLength, Buffer);


### PR DESCRIPTION
As a security measure, Windows 11 introduces a new temporary directory API, GetTempPath2.
When the calling process is running as SYSTEM, a separate temporary directory
will be returned inaccessible to non-SYSTEM processes. For non-SYSTEM processes
the behavior will be the same as before.

This can help mitigate against attacks such as this one:
https://medium.com/csis-techblog/cve-2020-1088-yet-another-arbitrary-delete-eop-a00b97d8c3e2

This PR updates the filesystem library to call into this new API when available.
Note that there is a small possible compatibility impact if software relies on temporary files to
communicate between SYSTEM and non-SYSTEM processes and one uses GetTempPath (prior to this change)
and the other GetTempPath2. In many cases, such patterns may be vulnerable to the very attacks the new
API was introduced to harden against. The standard itself requires only that this API should return
"an unspecified directory path suitable for temporary files," though GetTempPath is mentioned as an
example implementation.

How tested: Sample program printing out the value of std::filesystem::temp_directory_path()
run through psexec (from SysInternals) on Win10 and Win11.

On Win10:
C:\test>psexec -s C:\test\main.exe
<...>
Temp directory is "C:\\WINDOWS\\TEMP\\"

On Win11:
C:\test>psexec -s C:\test\main.exe
<...>
Temp directory is "C:\\Windows\\SystemTemp\\"
