### PR TITLE
Fix/improve intrinsics usage for ARM64EC

### DIFF
--- a/stl/inc/limits
+++ b/stl/inc/limits
@@ -16,7 +16,7 @@
 #include <xstddef>
 
 // TRANSITION, GH-2129, move down to _Arm64_popcount
-#if defined(_M_ARM64) && !defined(_M_ARM64EC) && !defined(_M_CEE_PURE) && !defined(__CUDACC__) \
+#if (defined(_M_ARM64) || defined(_M_ARM64EC)) && !defined(_M_CEE_PURE) && !defined(__CUDACC__) \
     && !defined(__INTEL_COMPILER) && !defined(__clang__) // TRANSITION, LLVM-51488
 #define _HAS_NEON_INTRINSICS 1
 #else // ^^^ intrinsics available ^^^ / vvv intrinsics unavailable vvv
@@ -1051,7 +1051,7 @@ _NODISCARD constexpr int _Popcount_fallback(_Ty _Val) noexcept {
     return static_cast<int>(_Val >> (_Digits - 8));
 }
 
-#if defined(_M_IX86) || defined(_M_X64)
+#if defined(_M_IX86) || (defined(_M_X64) && !defined(_M_ARM64EC))
 extern "C" {
 extern int __isa_available;
 #ifdef __clang__
@@ -1101,7 +1101,7 @@ _NODISCARD int _Checked_x86_x64_countr_zero(const _Ty _Val) noexcept {
 }
 #undef _TZCNT_U32
 #undef _TZCNT_U64
-#endif // defined(_M_IX86) || defined(_M_X64)
+#endif // defined(_M_IX86) || (defined(_M_X64) && !defined(_M_ARM64EC))
 
 #if (defined(_M_IX86) || (defined(_M_X64) && !defined(_M_ARM64EC))) && !defined(_M_CEE_PURE) && !defined(__CUDACC__) \
     && !defined(__INTEL_COMPILER)
@@ -1152,13 +1152,13 @@ constexpr bool _Is_standard_unsigned_integer =
 
 template <class _Ty, enable_if_t<_Is_standard_unsigned_integer<_Ty>, int> = 0>
 _NODISCARD constexpr int _Countr_zero(const _Ty _Val) noexcept {
-#if defined(_M_IX86) || defined(_M_X64)
+#if defined(_M_IX86) || (defined(_M_X64) && !defined(_M_ARM64EC))
 #if _HAS_CXX20
     if (!_STD is_constant_evaluated()) {
         return _Checked_x86_x64_countr_zero(_Val);
     }
 #endif // _HAS_CXX20
-#endif // defined(_M_IX86) || defined(_M_X64)
+#endif // defined(_M_IX86) || (defined(_M_X64) && !defined(_M_ARM64EC))
     // C++17 constexpr gcd() calls this function, so it should be constexpr unless we detect runtime evaluation.
     return _Countr_zero_fallback(_Val);
 }


### PR DESCRIPTION
This mirrors Ben Niu's MSVC-PR-361004 "Disable x64 code paths that use tzcnt for ARM64EC, and enable NEON paths for ARM64EC".

The `_HAS_NEON_INTRINSICS` change is a performance improvement - ARM64EC has access to these ARM64 intrinsics.

The `tzcnt` change is a bugfix (fixing broken builds) - ARM64EC does not have access to this x86/x64 intrinsic.