### PR TITLE
`<ranges>`: Fix `views::reverse` for `ranges::reverse_view` lvalues

### DIFF
--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -4167,24 +4167,24 @@ namespace ranges {
 
             template <class _Rng>
             _NODISCARD static _CONSTEVAL _Choice_t<_St> _Choose() noexcept {
-                if constexpr (bidirectional_range<_Rng>) {
-                    if constexpr (_Is_specialization_v<_Rng, reverse_view>) {
-                        if constexpr (_Can_extract_base<_Rng>) {
-                            return {_St::_Base, noexcept(_STD declval<_Rng>().base())};
-                        }
-                    } else if constexpr (_Reversed_subrange<remove_cvref_t<_Rng>> == 0) {
-                        using _It = decltype(_STD declval<_Rng&>().begin().base());
-                        return {_St::_Subrange_unsized,
-                            noexcept(subrange<_It, _It, subrange_kind::unsized>{
-                                _STD declval<_Rng&>().end().base(), _STD declval<_Rng&>().begin().base()})};
-                    } else if constexpr (_Reversed_subrange<remove_cvref_t<_Rng>> == 1) {
-                        using _It = decltype(_STD declval<_Rng&>().begin().base());
-                        return {_St::_Subrange_sized,
-                            noexcept(subrange<_It, _It, subrange_kind::sized>{_STD declval<_Rng&>().end().base(),
-                                _STD declval<_Rng&>().begin().base(), _STD declval<_Rng&>().size()})};
-                    } else if constexpr (_Can_reverse<_Rng>) {
-                        return {_St::_Reverse, noexcept(reverse_view{_STD declval<_Rng>()})};
+                using _Ty = remove_cvref_t<_Rng>;
+
+                if constexpr (_Is_specialization_v<_Ty, reverse_view>) {
+                    if constexpr (_Can_extract_base<_Rng>) {
+                        return {_St::_Base, noexcept(_STD declval<_Rng>().base())};
                     }
+                } else if constexpr (_Reversed_subrange<_Ty> == 0) {
+                    using _It = decltype(_STD declval<_Rng&>().begin().base());
+                    return {_St::_Subrange_unsized,
+                        noexcept(subrange<_It, _It, subrange_kind::unsized>{
+                            _STD declval<_Rng&>().end().base(), _STD declval<_Rng&>().begin().base()})};
+                } else if constexpr (_Reversed_subrange<_Ty> == 1) {
+                    using _It = decltype(_STD declval<_Rng&>().begin().base());
+                    return {_St::_Subrange_sized,
+                        noexcept(subrange<_It, _It, subrange_kind::sized>{_STD declval<_Rng&>().end().base(),
+                            _STD declval<_Rng&>().begin().base(), _STD declval<_Rng&>().size()})};
+                } else if constexpr (_Can_reverse<_Rng>) {
+                    return {_St::_Reverse, noexcept(reverse_view{_STD declval<_Rng>()})};
                 }
 
                 return {_St::_None};

--- a/tests/std/tests/P0896R4_views_reverse/test.cpp
+++ b/tests/std/tests/P0896R4_views_reverse/test.cpp
@@ -317,6 +317,13 @@ using move_only_view = test::range<Category, const int, test::Sized{is_random}, 
     IsCommon, test::CanCompare{derived_from<Category, forward_iterator_tag>},
     test::ProxyRef{!derived_from<Category, contiguous_iterator_tag>}, test::CanView::yes, test::Copyability::move_only>;
 
+void test_gh2312() {
+    using X = ranges::iota_view<int, int>;
+    ranges::reverse_view<X> view;
+    static_assert( same_as<decltype(view | views::reverse), X>);
+    static_assert(!same_as<decltype(view | views::reverse), ranges::reverse_view<X>>);
+}
+
 int main() {
     static constexpr int some_ints[]     = {0, 1, 2};
     static constexpr int reversed_ints[] = {2, 1, 0};

--- a/tests/std/tests/P0896R4_views_reverse/test.cpp
+++ b/tests/std/tests/P0896R4_views_reverse/test.cpp
@@ -317,7 +317,7 @@ using move_only_view = test::range<Category, const int, test::Sized{is_random}, 
     IsCommon, test::CanCompare{derived_from<Category, forward_iterator_tag>},
     test::ProxyRef{!derived_from<Category, contiguous_iterator_tag>}, test::CanView::yes, test::Copyability::move_only>;
 
-void test_gh2312() {
+void test_gh2312() { // COMPILE-ONLY
     using X = ranges::iota_view<int, int>;
     ranges::reverse_view<X> view;
     static_assert(same_as<decltype(view | views::reverse), X>);

--- a/tests/std/tests/P0896R4_views_reverse/test.cpp
+++ b/tests/std/tests/P0896R4_views_reverse/test.cpp
@@ -320,8 +320,7 @@ using move_only_view = test::range<Category, const int, test::Sized{is_random}, 
 void test_gh2312() {
     using X = ranges::iota_view<int, int>;
     ranges::reverse_view<X> view;
-    static_assert( same_as<decltype(view | views::reverse), X>);
-    static_assert(!same_as<decltype(view | views::reverse), ranges::reverse_view<X>>);
+    static_assert(same_as<decltype(view | views::reverse), X>);
 }
 
 int main() {


### PR DESCRIPTION
Fixes #2312