### PR TITLE
Fix two `<format>` bugs:

### DIFF
--- a/stl/inc/format
+++ b/stl/inc/format
@@ -1289,8 +1289,6 @@ struct _Format_arg_traits {
             return bool{};
         } else if constexpr (is_same_v<_Ty, _Char_type>) {
             return _Char_type{};
-        } else if constexpr (is_same_v<_Ty, char> && is_same_v<_Char_type, wchar_t>) {
-            return _Char_type{};
         } else if constexpr (signed_integral<_Ty> && sizeof(_Ty) <= sizeof(int)) {
             return int{};
         } else if constexpr (unsigned_integral<_Ty> && sizeof(_Ty) <= sizeof(unsigned int)) {

--- a/tests/std/tests/P0645R10_text_formatting_args/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_args/test.cpp
@@ -145,9 +145,11 @@ void test_format_arg_store() {
 
     test_empty_format_arg<Context>();
 
-    test_single_format_arg<Context, char, Arg_type::char_type>(42);
     if constexpr (is_same_v<char_type, wchar_t>) {
+        test_single_format_arg<Context, char, Arg_type::int_type>(42);
         test_single_format_arg<Context, wchar_t, Arg_type::char_type>(42);
+    } else {
+        test_single_format_arg<Context, char, Arg_type::char_type>(42);
     }
     test_single_format_arg<Context, unsigned char, Arg_type::unsigned_type>(42);
     test_single_format_arg<Context, signed char, Arg_type::int_type>(42);


### PR DESCRIPTION
* `format(L"{}", c)` for a `char` `c` renders the single wide character `wchar_t{c}` when it should instead format `c` as an integer.
* `format(L"{:d}", c)` for a `char` `c` formats `65536 + c` instead of `c` when `c < 0`. This seems to be a defect in the Standard for platforms with signed `char`.

Fixes #2320
