### PR TITLE
Remove improper use of __declspec(allocator)

### DIFF
--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -832,8 +832,7 @@ public:
     }
 
 #if _HAS_CXX23
-    _NODISCARD constexpr __declspec(allocator) allocation_result<_Ty*> allocate_at_least(
-        _CRT_GUARDOVERFLOW const size_t _Count) {
+    _NODISCARD constexpr allocation_result<_Ty*> allocate_at_least(_CRT_GUARDOVERFLOW const size_t _Count) {
         return {allocate(_Count), _Count};
     }
 #endif // _HAS_CXX23


### PR DESCRIPTION
... on `std::allocator::allocate_at_least`. This attribute may only be used to annotate functions that return pointers.

I'm not adding test coverage since (1) doing so would require disabling the global suppression of C4494 which, although possible, is a bit invasive and feels fragile, and (2) I think we're unlikely to regress.

Thanks to @Hannes-Harnisch for reporting the bug on Discord.