### PR TITLE
Internally disable `subrange` workaround

### DIFF
--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -3330,7 +3330,7 @@ namespace ranges {
         // clang-format off
         subrange() requires default_initializable<_It> = default;
 
-#if !defined(MSVC_INTERNAL_TESTING) && !defined(__clang__) && !defined(__EDG__) // TRANSITION, VS 17.1p3
+#if !defined(_MSVC_INTERNAL_TESTING) && !defined(__clang__) && !defined(__EDG__) // TRANSITION, VS 17.1p3
         // This was originally annotated as a workaround for DevCom-1331017, but the problem it corrects continued to
         // manifest after that bug was fixed. We reduced a repro to file an additional bug, but the underlying issue had
         // already been fixed in the internal compiler (see GH-2326).

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -3330,7 +3330,10 @@ namespace ranges {
         // clang-format off
         subrange() requires default_initializable<_It> = default;
 
-#if !defined(__clang__) && !defined(__EDG__) // TRANSITION, GH-2326 (originally DevCom-1331017)
+#if !defined(MSVC_INTERNAL_TESTING) && !defined(__clang__) && !defined(__EDG__) // TRANSITION, VS 17.1p3
+        // This was originally annotated as a workaround for DevCom-1331017, but the problem it corrects continued to
+        // manifest after that bug was fixed. We reduced a repro to file an additional bug, but the underlying issue had
+        // already been fixed in the internal compiler (see GH-2326).
         constexpr subrange(const subrange&) = default;
         constexpr subrange(subrange&&)      = default;
         constexpr subrange& operator=(const subrange&) = default;

--- a/tests/std/include/timezone_data.hpp
+++ b/tests/std/include/timezone_data.hpp
@@ -157,7 +157,7 @@ namespace LA {
 template <class TestFunction>
 void run_tz_test(TestFunction test_function) {
     try {
-#ifdef MSVC_INTERNAL_TESTING
+#ifdef _MSVC_INTERNAL_TESTING
         try {
             (void) get_tzdb();
         } catch (const system_error& ex) {
@@ -168,7 +168,7 @@ void run_tz_test(TestFunction test_function) {
 
             throw; // Report any other errors.
         }
-#endif // MSVC_INTERNAL_TESTING
+#endif // _MSVC_INTERNAL_TESTING
 
         test_function();
 

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
@@ -1092,10 +1092,10 @@ void test() {
 
 #if !defined(_DLL) || _ITERATOR_DEBUG_LEVEL == DEFAULT_IDL_SETTING
     test_locale<wchar_t>();
-#ifndef MSVC_INTERNAL_TESTING // TRANSITION, the Windows version on Contest VMs doesn't always understand ".UTF-8"
+#ifndef _MSVC_INTERNAL_TESTING // TRANSITION, the Windows version on Contest VMs doesn't always understand ".UTF-8"
     assert(setlocale(LC_ALL, ".UTF-8") != nullptr);
     test_locale<char>();
-#endif // MSVC_INTERNAL_TESTING
+#endif // _MSVC_INTERNAL_TESTING
 #endif // !defined(_DLL) || _ITERATOR_DEBUG_LEVEL == DEFAULT_IDL_SETTING
 }
 

--- a/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
@@ -1318,14 +1318,14 @@ void libfmt_formatter_test_runtime_precision() {
 
 template <class charT>
 void test_locale_specific_formatting_without_locale() {
-#ifndef MSVC_INTERNAL_TESTING // TRANSITION, the Windows version on Contest VMs doesn't always understand ".UTF-8"
+#ifndef _MSVC_INTERNAL_TESTING // TRANSITION, the Windows version on Contest VMs doesn't always understand ".UTF-8"
 #if !defined(_DLL) || _ITERATOR_DEBUG_LEVEL == DEFAULT_IDL_SETTING
     locale loc("en-US.UTF-8");
     locale::global(loc);
     assert(format(STR("{:L}"), 12345) == STR("12,345"));
     locale::global(locale::classic());
 #endif // !defined(_DLL) || _ITERATOR_DEBUG_LEVEL == DEFAULT_IDL_SETTING
-#endif // MSVC_INTERNAL_TESTING
+#endif // _MSVC_INTERNAL_TESTING
 }
 
 template <class charT>

--- a/tests/std/tests/P0645R10_text_formatting_utf8/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_utf8/test.cpp
@@ -153,7 +153,7 @@ int main() {
     assert(setlocale(LC_ALL, ".932") != nullptr);
     run_tests();
 
-#ifndef MSVC_INTERNAL_TESTING // TRANSITION, the Windows version on Contest VMs doesn't always understand ".UTF-8"
+#ifndef _MSVC_INTERNAL_TESTING // TRANSITION, the Windows version on Contest VMs doesn't always understand ".UTF-8"
     assert(setlocale(LC_ALL, ".UTF-8") != nullptr);
     run_tests();
 #endif

--- a/tests/std/tests/P0898R3_concepts/test.cpp
+++ b/tests/std/tests/P0898R3_concepts/test.cpp
@@ -1543,7 +1543,7 @@ namespace test_default_initializable {
         int x;
     };
     STATIC_ASSERT(default_initializable<S>);
-#if defined(MSVC_INTERNAL_TESTING) || defined(__clang__) || defined(__EDG__) // TRANSITION, DevCom-952724
+#if defined(_MSVC_INTERNAL_TESTING) || defined(__clang__) || defined(__EDG__) // TRANSITION, DevCom-952724
     STATIC_ASSERT(!default_initializable<S const>);
 #endif // TRANSITION, DevCom-952724
 


### PR DESCRIPTION
The workaround for GH-2326 isn't needed for the internal MSVC compiler; let's ensure it doesn't regress. Since this workaround is in product code let's rename `MSVC_INTERNAL_TESTING` to `_MSVC_INTERNAL_TESTING` (because `_Ugly`). Don't forget to update the name in `$/src/qa/distrib.yml` consistently when merging.

Resolves #2326
