### PR TITLE
Don't hide format string from the compiler

### DIFF
--- a/tests/tr1/include/tdefs.h
+++ b/tests/tr1/include/tdefs.h
@@ -249,12 +249,11 @@ void check_type(const char* label, const char* file_name, int line_number, const
 #endif // __cplusplus
 
 void check_double(const char* label, const char* file_name, int line_number, double left, double right) {
-    const char* afmtstr = " GOT %a != %a\n";
-    int ans             = left == right;
+    int ans = left == right;
 
     if (!terse && !ans) { // print hex or decimal floating-point
         if (afmt)
-            CSTD printf(afmtstr, left, right);
+            CSTD printf(" GOT %a != %a\n", left, right);
         else
             CSTD printf(" GOT %f != %f\n", left, right);
     }


### PR DESCRIPTION
Apparently previously compiler's static analysis did not understand `%a`, so the string was hidden.

Now let's show it!

It fixes warning C4774: 'printf' : format string expected in argument 1 is not a string literal.
Currently the warning is disabled, as it is a warning disabled by default.

Salvages the useful part from #2142