### PR TITLE
Status Chart: Weekly updates, increase PR Age

### DIFF
--- a/index.html
+++ b/index.html
@@ -379,9 +379,9 @@
                         text: 'Average Age, Average Wait (days)',
                     },
                     min: 0,
-                    max: 300,
+                    max: 400,
                     ticks: {
-                        stepSize: 30,
+                        stepSize: 50,
                     },
                 },
                 rightAxis: {
@@ -393,9 +393,9 @@
                         text: 'Combined Age, Combined Wait (PR-months)',
                     },
                     min: 0,
-                    max: 300,
+                    max: 400,
                     ticks: {
-                        stepSize: 30,
+                        stepSize: 50,
                     },
                 },
             },

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,13 +11,13 @@
       "dependencies": {
         "@octokit/graphql": "^4.8.0",
         "@types/cli-progress": "^3.9.2",
-        "@types/luxon": "^2.0.5",
-        "@types/node": "^16.11.6",
-        "@types/yargs": "^17.0.5",
+        "@types/luxon": "^2.0.7",
+        "@types/node": "^16.11.9",
+        "@types/yargs": "^17.0.7",
         "cli-progress": "^3.9.1",
         "dotenv": "^10.0.0",
-        "luxon": "^2.0.2",
-        "typescript": "^4.4.4",
+        "luxon": "^2.1.1",
+        "typescript": "^4.5.2",
         "yargs": "^17.2.1"
       }
     },
@@ -86,19 +86,19 @@
       }
     },
     "node_modules/@types/luxon": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-2.0.5.tgz",
-      "integrity": "sha512-GKrG5v16BOs9XGpouu33hOkAFaiSDi3ZaDXG9F2yAoyzHRBtksZnI60VWY5aM/yAENCccBejrxw8jDY+9OVlxw=="
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-2.0.7.tgz",
+      "integrity": "sha512-AxiYycfO+/M4VIH0ribSr2iPFC+APewpJIaQSydwVnzorK3mjSFXkA3HmhQidGx44MpwaatFyEkbW/WD4zdDaQ=="
     },
     "node_modules/@types/node": {
-      "version": "16.11.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.6.tgz",
-      "integrity": "sha512-ua7PgUoeQFjmWPcoo9khiPum3Pd60k4/2ZGXt18sm2Slk0W0xZTqt5Y0Ny1NyBiN1EVQ/+FaF9NcY4Qe6rwk5w=="
+      "version": "16.11.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.9.tgz",
+      "integrity": "sha512-MKmdASMf3LtPzwLyRrFjtFFZ48cMf8jmX5VRYrDQiJa8Ybu5VAmkqBWqKU8fdCwD8ysw4mQ9nrEHvzg6gunR7A=="
     },
     "node_modules/@types/yargs": {
-      "version": "17.0.5",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.5.tgz",
-      "integrity": "sha512-4HNq144yhaVjJs+ON6A07NEoi9Hh0Rhl/jI9Nt/l/YRjt+T6St/QK3meFARWZ8IgkzoD1LC0PdTdJenlQQi2WQ==",
+      "version": "17.0.7",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.7.tgz",
+      "integrity": "sha512-OvLKmpKdea1aWtqHv9bxVVcMoT6syAeK+198dfETIFkAevYRGwqh4H+KFxfjUETZuUuE5sQCAFwdOdoHUdo8eg==",
       "dependencies": {
         "@types/yargs-parser": "*"
       }
@@ -227,11 +227,11 @@
       }
     },
     "node_modules/luxon": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-2.0.2.tgz",
-      "integrity": "sha512-ZRioYLCgRHrtTORaZX1mx+jtxKtKuI5ZDvHNAmqpUzGqSrR+tL4FVLn/CUGMA3h0+AKD1MAxGI5GnCqR5txNqg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-2.1.1.tgz",
+      "integrity": "sha512-6VQVNw7+kQu3hL1ZH5GyOhnk8uZm21xS7XJ/6vDZaFNcb62dpFDKcH8TI5NkoZOdMRxr7af7aYGrJlE/Wv0i1w==",
       "engines": {
-        "node": "*"
+        "node": ">=12"
       }
     },
     "node_modules/node-fetch": {
@@ -291,9 +291,9 @@
       "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
     },
     "node_modules/typescript": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
-      "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz",
+      "integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -442,19 +442,19 @@
       }
     },
     "@types/luxon": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-2.0.5.tgz",
-      "integrity": "sha512-GKrG5v16BOs9XGpouu33hOkAFaiSDi3ZaDXG9F2yAoyzHRBtksZnI60VWY5aM/yAENCccBejrxw8jDY+9OVlxw=="
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-2.0.7.tgz",
+      "integrity": "sha512-AxiYycfO+/M4VIH0ribSr2iPFC+APewpJIaQSydwVnzorK3mjSFXkA3HmhQidGx44MpwaatFyEkbW/WD4zdDaQ=="
     },
     "@types/node": {
-      "version": "16.11.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.6.tgz",
-      "integrity": "sha512-ua7PgUoeQFjmWPcoo9khiPum3Pd60k4/2ZGXt18sm2Slk0W0xZTqt5Y0Ny1NyBiN1EVQ/+FaF9NcY4Qe6rwk5w=="
+      "version": "16.11.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.9.tgz",
+      "integrity": "sha512-MKmdASMf3LtPzwLyRrFjtFFZ48cMf8jmX5VRYrDQiJa8Ybu5VAmkqBWqKU8fdCwD8ysw4mQ9nrEHvzg6gunR7A=="
     },
     "@types/yargs": {
-      "version": "17.0.5",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.5.tgz",
-      "integrity": "sha512-4HNq144yhaVjJs+ON6A07NEoi9Hh0Rhl/jI9Nt/l/YRjt+T6St/QK3meFARWZ8IgkzoD1LC0PdTdJenlQQi2WQ==",
+      "version": "17.0.7",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.7.tgz",
+      "integrity": "sha512-OvLKmpKdea1aWtqHv9bxVVcMoT6syAeK+198dfETIFkAevYRGwqh4H+KFxfjUETZuUuE5sQCAFwdOdoHUdo8eg==",
       "requires": {
         "@types/yargs-parser": "*"
       }
@@ -550,9 +550,9 @@
       "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
     },
     "luxon": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-2.0.2.tgz",
-      "integrity": "sha512-ZRioYLCgRHrtTORaZX1mx+jtxKtKuI5ZDvHNAmqpUzGqSrR+tL4FVLn/CUGMA3h0+AKD1MAxGI5GnCqR5txNqg=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-2.1.1.tgz",
+      "integrity": "sha512-6VQVNw7+kQu3hL1ZH5GyOhnk8uZm21xS7XJ/6vDZaFNcb62dpFDKcH8TI5NkoZOdMRxr7af7aYGrJlE/Wv0i1w=="
     },
     "node-fetch": {
       "version": "2.6.6",
@@ -599,9 +599,9 @@
       "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
     },
     "typescript": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
-      "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA=="
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz",
+      "integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw=="
     },
     "universal-user-agent": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -28,13 +28,13 @@
   "dependencies": {
     "@octokit/graphql": "^4.8.0",
     "@types/cli-progress": "^3.9.2",
-    "@types/luxon": "^2.0.5",
-    "@types/node": "^16.11.6",
-    "@types/yargs": "^17.0.5",
+    "@types/luxon": "^2.0.7",
+    "@types/node": "^16.11.9",
+    "@types/yargs": "^17.0.7",
     "cli-progress": "^3.9.1",
     "dotenv": "^10.0.0",
-    "luxon": "^2.0.2",
-    "typescript": "^4.4.4",
+    "luxon": "^2.1.1",
+    "typescript": "^4.5.2",
     "yargs": "^17.2.1"
   }
 }

--- a/weekly_table.js
+++ b/weekly_table.js
@@ -232,4 +232,6 @@ const weekly_table = [
     { date: '2021-10-22', vso: 169, libcxx: 595 },
     { date: '2021-10-29', vso: 170, libcxx: 595 },
     { date: '2021-11-05', vso: 170, libcxx: 595 },
+    { date: '2021-11-12', vso: 169, libcxx: 588 },
+    { date: '2021-11-19', vso: 171, libcxx: 588 },
 ];


### PR DESCRIPTION
* 2 weekly updates.
* Update dependencies. I've verified that the generator's output is unchanged.
* Increase the PR Age `max` and `stepSize`. We've been prioritizing C++20/23 PRs so the total age has been increasing. We're trying to drain the backlog, but the holidays will reduce throughput.

:chart_with_upwards_trend: Live preview: [stephantlavavej.github.io/STL/](https://stephantlavavej.github.io/STL/)
===