### PR TITLE
Applied LLVM-47414 workaround to `std::ranges::join_view`

### DIFF
--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -3043,6 +3043,9 @@ namespace ranges {
     };
 
     // clang-format off
+    template <class _Rng> // TRANSITION, LLVM-47414
+    concept _Can_const_join = input_range<const _Rng> && is_reference_v<range_reference_t<_Maybe_const<true, _Rng>>>;
+    
     template <class _Vw>
         requires is_reference_v<range_reference_t<_Vw>>
     class _Join_view_base<_Vw> : public view_interface<join_view<_Vw>> {};
@@ -3340,7 +3343,12 @@ namespace ranges {
 
         // clang-format off
         _NODISCARD constexpr _Iterator<true> begin() const
-            requires input_range<const _Vw> && is_reference_v<_InnerRng<true>> {
+        #ifdef __clang__ // TRANSITION, LLVM-47414
+            requires _Can_const_join<const _Vw>
+        #else // ^^^ workaround / no workaround vvv
+            requires input_range<const _Vw> && is_reference_v<_InnerRng<true>>
+        #endif // TRANSITION, LLVM-47414
+        {
             // clang-format on
             return _Iterator<true>{*this, _RANGES begin(_Range)};
         }
@@ -3356,7 +3364,12 @@ namespace ranges {
 
         // clang-format off
         _NODISCARD constexpr auto end() const
-            requires input_range<const _Vw> && is_reference_v<_InnerRng<true>> {
+        #ifdef __clang__ // TRANSITION, LLVM-47414
+            requires _Can_const_join<const _Vw>
+        #else // ^^^ workaround / no workaround vvv
+            requires input_range<const _Vw> && is_reference_v<_InnerRng<true>>
+        #endif // TRANSITION, LLVM-47414
+        {
             if constexpr (forward_range<const _Vw> && forward_range<_InnerRng<true>>
                     && common_range<const _Vw> && common_range<_InnerRng<true>>) {
                 // clang-format on

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -3344,7 +3344,7 @@ namespace ranges {
         // clang-format off
         _NODISCARD constexpr _Iterator<true> begin() const
         #ifdef __clang__ // TRANSITION, LLVM-47414
-            requires _Can_const_join<const _Vw>
+            requires _Can_const_join<_Vw>
         #else // ^^^ workaround / no workaround vvv
             requires input_range<const _Vw> && is_reference_v<_InnerRng<true>>
         #endif // TRANSITION, LLVM-47414
@@ -3365,7 +3365,7 @@ namespace ranges {
         // clang-format off
         _NODISCARD constexpr auto end() const
         #ifdef __clang__ // TRANSITION, LLVM-47414
-            requires _Can_const_join<const _Vw>
+            requires _Can_const_join<_Vw>
         #else // ^^^ workaround / no workaround vvv
             requires input_range<const _Vw> && is_reference_v<_InnerRng<true>>
         #endif // TRANSITION, LLVM-47414

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -3042,10 +3042,11 @@ namespace ranges {
         /* [[no_unique_address]] */ _Non_propagating_cache<_Cache_wrapper, false> _Inner{};
     };
 
-    // clang-format off
-    template <class _Rng> // TRANSITION, LLVM-47414
-    concept _Can_const_join = input_range<const _Rng> && is_reference_v<range_reference_t<_Maybe_const<true, _Rng>>>;
 
+    template <class _Rng> // TRANSITION, LLVM-47414
+    concept _Can_const_join = input_range<const _Rng> && is_reference_v<range_reference_t<const _Rng>>;
+
+    // clang-format off
     template <class _Vw>
         requires is_reference_v<range_reference_t<_Vw>>
     class _Join_view_base<_Vw> : public view_interface<join_view<_Vw>> {};

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -3045,7 +3045,7 @@ namespace ranges {
     // clang-format off
     template <class _Rng> // TRANSITION, LLVM-47414
     concept _Can_const_join = input_range<const _Rng> && is_reference_v<range_reference_t<_Maybe_const<true, _Rng>>>;
-    
+
     template <class _Vw>
         requires is_reference_v<range_reference_t<_Vw>>
     class _Join_view_base<_Vw> : public view_interface<join_view<_Vw>> {};

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -3042,7 +3042,6 @@ namespace ranges {
         /* [[no_unique_address]] */ _Non_propagating_cache<_Cache_wrapper, false> _Inner{};
     };
 
-
     template <class _Rng> // TRANSITION, LLVM-47414
     concept _Can_const_join = input_range<const _Rng> && is_reference_v<range_reference_t<const _Rng>>;
 

--- a/tests/std/tests/P0896R4_views_join/test.cpp
+++ b/tests/std/tests/P0896R4_views_join/test.cpp
@@ -561,6 +561,14 @@ int main() {
         static_assert(ranges::distance(views::iota(0, 2) | views::transform(ToArrayOfImmovable) | views::join) == 6);
     }
 
+    { // Joining a non-const view without const qualified begin and end methods
+        vector<vector<size_t>> nested_vectors = {{0}, {1, 2, 3}, {99}, {4, 5, 6, 7}, {}, {8, 9, 10}};
+        auto RemoveSmallVectors       = [](const vector<size_t>& inner_vector) { return inner_vector.size() > 2; };
+        auto filted_and_joined        = nested_vectors | views::filter(RemoveSmallVectors) | views::join;
+        static constexpr int result[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+        assert(ranges::equal(filted_and_joined, result));
+    }
+
     STATIC_ASSERT(instantiation_test());
     instantiation_test();
 }

--- a/tests/std/tests/P0896R4_views_join/test.cpp
+++ b/tests/std/tests/P0896R4_views_join/test.cpp
@@ -564,9 +564,9 @@ int main() {
     { // Joining a non-const view without const qualified begin and end methods
         vector<vector<int>> nested_vectors = {{0}, {1, 2, 3}, {99}, {4, 5, 6, 7}, {}, {8, 9, 10}};
         auto RemoveSmallVectors            = [](const vector<int>& inner_vector) { return inner_vector.size() > 2; };
-        auto filted_and_joined             = nested_vectors | views::filter(RemoveSmallVectors) | views::join;
+        auto filtered_and_joined           = nested_vectors | views::filter(RemoveSmallVectors) | views::join;
         static constexpr int result[]      = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-        assert(ranges::equal(filted_and_joined, result));
+        assert(ranges::equal(filtered_and_joined, result));
     }
 
     STATIC_ASSERT(instantiation_test());

--- a/tests/std/tests/P0896R4_views_join/test.cpp
+++ b/tests/std/tests/P0896R4_views_join/test.cpp
@@ -562,10 +562,10 @@ int main() {
     }
 
     { // Joining a non-const view without const qualified begin and end methods
-        vector<vector<size_t>> nested_vectors = {{0}, {1, 2, 3}, {99}, {4, 5, 6, 7}, {}, {8, 9, 10}};
-        auto RemoveSmallVectors       = [](const vector<size_t>& inner_vector) { return inner_vector.size() > 2; };
-        auto filted_and_joined        = nested_vectors | views::filter(RemoveSmallVectors) | views::join;
-        static constexpr int result[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+        vector<vector<int>> nested_vectors = {{0}, {1, 2, 3}, {99}, {4, 5, 6, 7}, {}, {8, 9, 10}};
+        auto RemoveSmallVectors            = [](const vector<int>& inner_vector) { return inner_vector.size() > 2; };
+        auto filted_and_joined             = nested_vectors | views::filter(RemoveSmallVectors) | views::join;
+        static constexpr int result[]      = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
         assert(ranges::equal(filted_and_joined, result));
     }
 


### PR DESCRIPTION
When piping into `std::views::join`, Clang eagerly instantiates the `join_view::_InnerRng` template alias. This alias is used in the requirements of the resulting view's `const` qualified `begin()` and `end()` methods. This check is performed and causes a hard compile error even if the source contains no calls to the `const` qualified methods. 

I used the workaround applied to the same methods of [`std::views::transform_view`](https://github.com/microsoft/STL/blob/3c2fd04d441d46ec9d914d9cbb621a3bac96c3a5/stl/inc/ranges#L1857).

A simplified reproduction of code that fails to compile under Clang can be found [here](https://godbolt.org/z/d8xzj3Gbf). Piping a `filter_view` or a view composed on top of a `filter_view` will cause this erroneous compile error; `filter_view` has no const qualified overloads of `begin()` and `end()`.