### PR TITLE
Fix Efficient access to streambuf buffer

### DIFF
--- a/stl/inc/sstream
+++ b/stl/inc/sstream
@@ -189,6 +189,7 @@ public:
                 _Mystate &= ~_Allocated;
             }
         }
+
         _Tidy();
         return _Result;
     }
@@ -457,29 +458,27 @@ protected:
 
 #if _HAS_CXX20
     void _Init_string_inplace(_Mystr&& _Str, int _State) {
-        _State |= _From_rvalue;
-
-        auto [_Ptr, _Size, _Res] = _Str._Release_to_buffer(_Al);
-        _Elem* const _Pnew       = _Unfancy(_Ptr);
-        if (_Res != 0 && (_State & (_Noread | _Constant)) != (_Noread | _Constant)) {
-            // finite buffer that can be read or written, set it up
-            _Seekhigh        = _Pnew + _Size;
-            auto _End_buffer = _Pnew + _Res;
-
-            _Mysb::setp(_Pnew, (_State & (_Atend | _Append)) ? _Seekhigh : _Pnew, _End_buffer);
-
-            if (_State & _Noread) { // maintain "_Allocated == eback() points to buffer base" invariant
-                _Mysb::setg(_Pnew, nullptr, _Pnew);
-            } else {
-                _Mysb::setg(_Pnew, _Pnew, _Seekhigh);
-            }
-
-            _State |= _Allocated;
-        } else {
+        if ((_State & _Noread) && (_State & _Constant)) { // Cannot read / write buffer, do nothing
             _Seekhigh = nullptr;
+            _Mystate  = _State | _From_rvalue;
+            return;
         }
 
-        _Mystate = _State;
+        // finite buffer that can be read or written, set it up
+        auto [_Ptr, _Size, _Res] = _Str._Release_to_buffer(_Al);
+        _Elem* const _Pnew       = _Unfancy(_Ptr);
+        _Seekhigh                = _Pnew + _Size;
+        auto _Next               = (_State & (_Atend | _Append)) ? _Seekhigh : _Pnew;
+        auto _End_buffer         = _Pnew + _Res;
+
+        _Mysb::setp(_Pnew, _Next, _End_buffer);
+        if (_State & _Noread) { // maintain "_Allocated == eback() points to buffer base" invariant
+            _Mysb::setg(_Pnew, nullptr, _Pnew);
+        } else {
+            _Mysb::setg(_Pnew, _Pnew, _Seekhigh);
+        }
+
+        _Mystate = _State | _Allocated | _From_rvalue;
     }
 #endif // _HAS_CXX20
 

--- a/tests/std/tests/P0408R7_efficient_access_to_stringbuf_buffer/test.cpp
+++ b/tests/std/tests/P0408R7_efficient_access_to_stringbuf_buffer/test.cpp
@@ -23,9 +23,25 @@ constexpr char large_string[] =
 template <typename Stream>
 struct test_rvalue {
     void operator()(const string& init_value) {
+        test(init_value, ios_base::in);
+        test(init_value, ios_base::out);
+        test(init_value, ios_base::app);
+        test(init_value, ios_base::ate);
+    }
+
+    void test(const string& init_value, const ios_base::openmode mode) {
         string buffer{init_value};
         size_t res = buffer.capacity();
-        Stream stream{move(buffer)};
+        Stream stream{move(buffer), mode};
+
+        // If the stream cannot be written or read we do nothing
+        const auto buffer_view = stream.rdbuf()->_Get_buffer_view();
+        if (!buffer_view._Ptr) {
+            assert(!(mode & ios_base::in) && !(mode & ios_base::out));
+            assert(buffer == init_value);
+            return;
+        }
+
         assert(stream.view() == init_value);
         assert(stream.str() == init_value);
         assert(stream.view() == init_value);


### PR DESCRIPTION
Currently we were always taking the buffer from the moved in string, but would only store it when the buffer could be read or written to.

Consequently if that was not the case we would leak the allocated memory.

Also simplify the code a bit, we know that the capacity `_Res` will always be nonzero due to the way `_Release_to_buffer` works

Also add tests for the error cases

@BRevzin