### PR TITLE
Strike "with concepts support" from the GH-1814 messages

### DIFF
--- a/stl/inc/format
+++ b/stl/inc/format
@@ -40,7 +40,7 @@
 #include <yvals_core.h>
 #if _STL_COMPILER_PREPROCESSOR
 #ifndef __cpp_lib_format
-#pragma message("The contents of <format> are available only in c++latest mode with concepts support;")
+#pragma message("The contents of <format> are available only in c++latest mode;")
 #pragma message("see https://github.com/microsoft/STL/issues/1814 for details.")
 #else // ^^^ !defined(__cpp_lib_format) / defined(__cpp_lib_format) vvv
 

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -9,7 +9,7 @@
 #include <yvals_core.h>
 #if _STL_COMPILER_PREPROCESSOR
 #ifndef __cpp_lib_ranges
-#pragma message("The contents of <ranges> are available only in c++latest mode with concepts support;")
+#pragma message("The contents of <ranges> are available only in c++latest mode;")
 #pragma message("see https://github.com/microsoft/STL/issues/1814 for details.")
 #else // ^^^ !defined(__cpp_lib_ranges) / defined(__cpp_lib_ranges) vvv
 #include <iosfwd>


### PR DESCRIPTION
Our supported C++latest frontends (clang-cl and msvc) both have concepts support, so this appears redundant.

Fixes DevCom-1603100
Closes VSO-1445646 / AB#1445646