### PR TITLE
Compiler type trait optimizations

### DIFF
--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -1317,7 +1317,7 @@ struct _Identity {
     using type = _Ty;
 };
 template <class _Ty>
-using _Identity_t = typename _Identity<_Ty>::type;
+using _Identity_t _MSVC_KNOWN_SEMANTICS = typename _Identity<_Ty>::type;
 
 #if _HAS_CXX20
 template <class _Ty>

--- a/stl/inc/xtr1common
+++ b/stl/inc/xtr1common
@@ -220,7 +220,7 @@ template <class _Ty>
 using _Const_thru_ref = typename remove_reference<_Ty>::_Const_thru_ref_type;
 
 template <class _Ty>
-using _Remove_cvref_t = remove_cv_t<remove_reference_t<_Ty>>;
+using _Remove_cvref_t _MSVC_KNOWN_SEMANTICS = remove_cv_t<remove_reference_t<_Ty>>;
 
 #if _HAS_CXX20
 template <class _Ty>


### PR DESCRIPTION
This ports @xiangfan-ms's MSVC-PR-360974, which was merged on 2021-10-29 but we forgot to mirror it.

Xiang optimized the MSVC compiler front-end to recognize `type_identity_t` and `_Identity_t`, which became heavily used after we merged #2032 implementing [P1518R2](https://wg21.link/P1518R2) Stop Overconstraining Allocators In Container Deduction Guides.

As part of this work, our internal aliases `_Identity_t` and `_Remove_cvref_t` need to be marked with the attribute `_MSVC_KNOWN_SEMANTICS`:
https://github.com/microsoft/STL/blob/18019346af33d90fab4e65a2f2a2efe741ec050b/stl/inc/yvals_core.h#L424-L434
