### PR TITLE
Optimize reverse for 8 and 16-bit trivial types

### DIFF
--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -20,7 +20,6 @@
 #include <intrin0.h>
 #endif // defined(_M_ARM64EC)
 #include <isa_availability.h>
-#include <stdlib.h>
 
 extern "C" long __isa_enabled;
 

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -399,7 +399,10 @@ __declspec(noalias) void __cdecl __std_reverse_copy_trivially_copyable_1(
     if (_Byte_length(_First, _Last) >= 16 && _bittest(&__isa_enabled, __ISA_AVAILABLE_SSE42)) {
         const __m128i _Reverse_char_sse = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
         const void* _Stop_at            = _Dest;
-        _Advance_bytes(_Stop_at, _Byte_length(_First, _Last) >> 4 << 4);
+        const size_t _Size              = _Byte_length(_First, _Last);
+        void* _Final_dest               = _Dest;
+        _Advance_bytes(_Final_dest, _Size - 16);
+        _Advance_bytes(_Stop_at, _Size >> 4 << 4);
         do {
             _Advance_bytes(_Last, -16);
             const __m128i _Block          = _mm_loadu_si128(static_cast<const __m128i*>(_Last));
@@ -407,6 +410,12 @@ __declspec(noalias) void __cdecl __std_reverse_copy_trivially_copyable_1(
             _mm_storeu_si128(static_cast<__m128i*>(_Dest), _Block_reversed);
             _Advance_bytes(_Dest, 16);
         } while (_Dest != _Stop_at);
+
+        const __m128i _Block          = _mm_loadu_si128(static_cast<const __m128i*>(_First));
+        const __m128i _Block_reversed = _mm_shuffle_epi8(_Block, _Reverse_char_sse);
+        _mm_storeu_si128(static_cast<__m128i*>(_Final_dest), _Block_reversed);
+
+        return;
     }
 
     _Reverse_copy_tail(static_cast<const unsigned char*>(_First), static_cast<const unsigned char*>(_Last),
@@ -436,7 +445,10 @@ __declspec(noalias) void __cdecl __std_reverse_copy_trivially_copyable_2(
     if (_Byte_length(_First, _Last) >= 16 && _bittest(&__isa_enabled, __ISA_AVAILABLE_SSE42)) {
         const __m128i _Reverse_short_sse = _mm_set_epi8(1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14);
         const void* _Stop_at             = _Dest;
-        _Advance_bytes(_Stop_at, _Byte_length(_First, _Last) >> 4 << 4);
+        const size_t _Size               = _Byte_length(_First, _Last);
+        void* _Final_dest                = _Dest;
+        _Advance_bytes(_Final_dest, _Size - 16);
+        _Advance_bytes(_Stop_at, _Size >> 4 << 4);
         do {
             _Advance_bytes(_Last, -16);
             const __m128i _Block          = _mm_loadu_si128(static_cast<const __m128i*>(_Last));
@@ -444,6 +456,12 @@ __declspec(noalias) void __cdecl __std_reverse_copy_trivially_copyable_2(
             _mm_storeu_si128(static_cast<__m128i*>(_Dest), _Block_reversed);
             _Advance_bytes(_Dest, 16);
         } while (_Dest != _Stop_at);
+
+        const __m128i _Block          = _mm_loadu_si128(static_cast<const __m128i*>(_First));
+        const __m128i _Block_reversed = _mm_shuffle_epi8(_Block, _Reverse_short_sse);
+        _mm_storeu_si128(static_cast<__m128i*>(_Final_dest), _Block_reversed);
+
+        return;
     }
 
     _Reverse_copy_tail(static_cast<const unsigned short*>(_First), static_cast<const unsigned short*>(_Last),

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -20,6 +20,7 @@
 #include <intrin0.h>
 #endif // defined(_M_ARM64EC)
 #include <isa_availability.h>
+#include <stdlib.h>
 
 extern "C" long __isa_enabled;
 
@@ -177,6 +178,19 @@ __declspec(noalias) void __cdecl __std_reverse_trivially_swappable_1(void* _Firs
         } while (_First != _Stop_at);
     }
 
+    if (_Byte_length(_First, _Last) >= 8) {
+        const void* _Stop_at = _First;
+        _Advance_bytes(_Stop_at, _Byte_length(_First, _Last) >> 3 << 2);
+        do {
+            _Advance_bytes(_Last, -4);
+            unsigned long _Left                  = _byteswap_ulong(*static_cast<unsigned long*>(_First));
+            unsigned long _Right                 = _byteswap_ulong(*static_cast<unsigned long*>(_Last));
+            *static_cast<unsigned long*>(_First) = _Right;
+            *static_cast<unsigned long*>(_Last)  = _Left;
+            _Advance_bytes(_First, 4);
+        } while (_First != _Stop_at);
+    }
+
     _Reverse_tail(static_cast<unsigned char*>(_First), static_cast<unsigned char*>(_Last));
 }
 
@@ -216,6 +230,19 @@ __declspec(noalias) void __cdecl __std_reverse_trivially_swappable_2(void* _Firs
             _mm_storeu_si128(static_cast<__m128i*>(_First), _Right_reversed);
             _mm_storeu_si128(static_cast<__m128i*>(_Last), _Left_reversed);
             _Advance_bytes(_First, 16);
+        } while (_First != _Stop_at);
+    }
+
+    if (_Byte_length(_First, _Last) >= 8) {
+        const void* _Stop_at = _First;
+        _Advance_bytes(_Stop_at, _Byte_length(_First, _Last) >> 3 << 2);
+        do {
+            _Advance_bytes(_Last, -4);
+            unsigned long _Left                  = _rotl(*static_cast<unsigned long*>(_First), 16);
+            unsigned long _Right                 = _rotl(*static_cast<unsigned long*>(_Last), 16);
+            *static_cast<unsigned long*>(_First) = _Right;
+            *static_cast<unsigned long*>(_Last)  = _Left;
+            _Advance_bytes(_First, 4);
         } while (_First != _Stop_at);
     }
 
@@ -337,6 +364,18 @@ __declspec(noalias) void __cdecl __std_reverse_copy_trivially_copyable_1(
         } while (_Dest != _Stop_at);
     }
 
+    if (_Byte_length(_First, _Last) >= 4) {
+        const void* _Stop_at = _Dest;
+        _Advance_bytes(_Stop_at, _Byte_length(_First, _Last) >> 2 << 2);
+        do {
+            _Advance_bytes(_Last, -4);
+            unsigned long _Block                = *static_cast<const unsigned long*>(_Last);
+            unsigned long _Block_reversed       = _byteswap_ulong(_Block);
+            *static_cast<unsigned long*>(_Dest) = _Block_reversed;
+            _Advance_bytes(_Dest, 4);
+        } while (_Dest != _Stop_at);
+    }
+
     _Reverse_copy_tail(static_cast<const unsigned char*>(_First), static_cast<const unsigned char*>(_Last),
         static_cast<unsigned char*>(_Dest));
 }
@@ -371,6 +410,18 @@ __declspec(noalias) void __cdecl __std_reverse_copy_trivially_copyable_2(
             const __m128i _Block_reversed = _mm_shuffle_epi8(_Block, _Reverse_short_sse); // SSSE3
             _mm_storeu_si128(static_cast<__m128i*>(_Dest), _Block_reversed);
             _Advance_bytes(_Dest, 16);
+        } while (_Dest != _Stop_at);
+    }
+
+    if (_Byte_length(_First, _Last) >= 4) {
+        const void* _Stop_at = _Dest;
+        _Advance_bytes(_Stop_at, _Byte_length(_First, _Last) >> 2 << 2);
+        do {
+            _Advance_bytes(_Last, -4);
+            unsigned long _Block                = *static_cast<const unsigned long*>(_Last);
+            unsigned long _Block_reversed       = _rotl(_Block, 16);
+            *static_cast<unsigned long*>(_Dest) = _Block_reversed;
+            _Advance_bytes(_Dest, 4);
         } while (_Dest != _Stop_at);
     }
 


### PR DESCRIPTION
Faster reverse tail.

The benchmark uses random lengths:
```c++
#include <cstdint>
#include <chrono>
#include <iostream>
#include <random>

constexpr std::size_t N = 2048;
constexpr std::size_t NS = 8192;
constexpr std::size_t R = 10'000;

alignas(64) std::uint8_t    a8[N];
alignas(64) std::uint16_t   a16[N / 2];
alignas(64) std::uint32_t   a32[N / 4];
alignas(64) std::uint64_t   a64[N / 8];

alignas(64) std::uint8_t    d8[N];
alignas(64) std::uint16_t   d16[N / 2];
alignas(64) std::uint32_t   d32[N / 4];
alignas(64) std::uint64_t   d64[N / 8];

template<typename T, std::size_t S>
void rev(bool c, T(&a)[S], T(&d)[S], const char* name) {
    std::mt19937 gen(65521);
    std::uniform_int_distribution<std::size_t> dis(0, S);
    std::size_t sizes[NS];
    for (auto& s : sizes) {
        s = dis(gen);
    }

    auto t1 = std::chrono::steady_clock::now();
    if (c) {
        for (std::size_t i = 0; i < R; i++) {
            for (std::size_t s = 0; s < NS; s++) {
                std::reverse_copy(std::begin(a), std::begin(a) + sizes[s], std::begin(d));
            }
        }
    }
    else {
        for (std::size_t i = 0; i < R; i++) {
            for (std::size_t s = 0; s < NS; s++) {
                std::reverse(std::begin(a), std::begin(a) + sizes[s]);
            }
        }
    }
    auto t2 = std::chrono::steady_clock::now();
    std::cout << name << ":\t" << std::chrono::duration_cast<std::chrono::duration<double>>(t2 - t1).count() << "s\n";
}

int main()
{
    rev(false, a8, d8, "reverse 8");
    rev(false, a16, d16, "reverse 16");
    rev(false, a32, d32, "reverse 32");
    rev(false, a64, d64, "reverse 64");
    rev(true, a8, d8, "rev. copy 8");
    rev(true, a16, d16, "rev. copy 16");
    rev(true, a32, d32, "rev. copy 32");
    rev(true, a64, d64, "rev. copy 64");
}

````

On my Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz 

|Name        |Before  |After    |Before JCC mtg|After JCC mtg|
|------------|--------|---------|--------------|-------------|
|reverse 8   |3.46938s|2.45349s | 2.74506s     | 2.41771s    |
|reverse 16  |2.91174s|2.49834s | 2.5235s      | 2.36707s    |
|reverse 32  |2.44931s|2.46176s | 2.4739s      | 2.50781s    |
|reverse 64  |2.18105s|2.32562s | 2.21836s     | 2.22949s    |
|rev. copy 8:|2.80264s|2.4998s  | 2.81799s     | 2.51851s    |
|rev. copy 16|2.83642s|2.4392s  | 2.71336s     | 2.43827s    |
|rev. copy 32|2.56736s|2.71499s | 2.46718s     | 2.468s      |
|rev. copy 64|2.21659s|2.32269s | 2.21912s     | 2.21747s    |

JCC mtg = added `/QIntel-jcc-erratum` to root makefile
