### PR TITLE
<xmemory>: Make sure _Ty in allocator is class type

### DIFF
--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -779,6 +779,7 @@ class allocator {
 public:
     static_assert(!is_const_v<_Ty>, "The C++ Standard forbids containers of const elements "
                                     "because allocator<const T> is ill-formed.");
+    static_assert(is_class_v<_Ty>);
 
     using _From_primary = allocator;
 


### PR DESCRIPTION
<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->

Unless this is done, we'd be able to do things such as the following:
```
    std::allocator<std::vector<int> const&> my_allocator;
```

Which'd lead to `error C2528: '_Ptr': pointer to reference is illegal` and `error C2528: 'allocate': pointer to reference is illegal`.