### PR TITLE
Implement LWG-3590: `split_view::base() const &` is overconstrained

### DIFF
--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -3962,7 +3962,7 @@ namespace ranges {
         // clang-format on
 
         _NODISCARD constexpr _Vw base() const& noexcept(is_nothrow_copy_constructible_v<_Vw>) /* strengthened */
-            requires copyable<_Vw> {
+            requires copy_constructible<_Vw> {
             return _Range;
         }
         _NODISCARD constexpr _Vw base() && noexcept(is_nothrow_move_constructible_v<_Vw>) /* strengthened */ {

--- a/tests/std/tests/P0896R4_views_split/test.cpp
+++ b/tests/std/tests/P0896R4_views_split/test.cpp
@@ -334,10 +334,10 @@ struct CopyConstructibleRange {
     CopyConstructibleRange(const CopyConstructibleRange&) = default;
     CopyConstructibleRange& operator=(const CopyConstructibleRange&) = delete;
     constexpr const int* begin() const {
-        return inner.empty() ? nullptr : &inner[0];
+        return inner.data();
     }
     constexpr const int* end() const {
-        return inner.empty() ? nullptr : (&inner[0] + inner.size());
+        return inner.data() + inner.size();
     }
 
     vector<int> inner;
@@ -345,12 +345,12 @@ struct CopyConstructibleRange {
 
 constexpr bool test_LWG_3590() {
     CopyConstructibleRange r{{1, 2, 3, 4}};
-    auto split_view = views::split(r, 0);
+    const auto split_view = views::split(r, 0);
 
     STATIC_ASSERT(copy_constructible<CopyConstructibleRange>);
     STATIC_ASSERT(!copyable<CopyConstructibleRange>);
 
-    auto ref_view = split_view.base();
+    const auto ref_view = split_view.base();
 
     return ref_view.base().inner == r.inner;
 }

--- a/tests/std/tests/P0896R4_views_split/test.cpp
+++ b/tests/std/tests/P0896R4_views_split/test.cpp
@@ -330,7 +330,7 @@ constexpr bool test_devcom_1559808() {
 }
 
 struct CopyConstructibleRange {
-    constexpr CopyConstructibleRange(vector<int> v) : inner(move(v)) {}
+    constexpr explicit CopyConstructibleRange(vector<int> v) : inner(move(v)) {}
     CopyConstructibleRange(const CopyConstructibleRange&) = default;
     CopyConstructibleRange& operator=(const CopyConstructibleRange&) = delete;
     constexpr const int* begin() const {

--- a/tests/std/tests/P0896R4_views_split/test.cpp
+++ b/tests/std/tests/P0896R4_views_split/test.cpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <cassert>
 #include <charconv>
+#include <concepts>
 #include <ranges>
 #include <span>
 #include <string_view>
@@ -326,6 +327,23 @@ constexpr bool test_devcom_1559808() {
     assert(i == r.end());
 
     return true;
+}
+
+struct CopyConstructibleRange {
+    CopyConstructibleRange(const CopyConstructibleRange&) = default;
+    CopyConstructibleRange& operator=(const CopyConstructibleRange&) = delete;
+    int* begin() const;
+    int* end() const;
+};
+
+// COMPILE-ONLY
+void testLWG3590(const CopyConstructibleRange& r) {
+    auto split_view = views::split(r, 0);
+
+    STATIC_ASSERT(copy_constructible<CopyConstructibleRange>);
+    STATIC_ASSERT(!copyable<CopyConstructibleRange>);
+
+    [[maybe_unused]] auto base = split_view.base();
 }
 
 int main() {


### PR DESCRIPTION
Fixes #2400 