### PR TITLE
Implement LWG-3557: The `static_cast` expression in `convertible_to` has the wrong operand

### DIFF
--- a/stl/inc/concepts
+++ b/stl/inc/concepts
@@ -42,7 +42,7 @@ concept derived_from = __is_base_of(_Base, _Derived)
 template <class _From, class _To>
 concept convertible_to = __is_convertible_to(_From, _To)
     && requires {
-        static_cast<_To>(declval<From>());
+        static_cast<_To>(declval<_From>());
     };
 
 template <class _From, class _To>

--- a/stl/inc/concepts
+++ b/stl/inc/concepts
@@ -42,7 +42,7 @@ concept derived_from = __is_base_of(_Base, _Derived)
 template <class _From, class _To>
 concept convertible_to = __is_convertible_to(_From, _To)
     && requires {
-        static_cast<_To>(declval<_From>());
+        static_cast<_To>(_STD declval<_From>());
     };
 
 template <class _From, class _To>

--- a/stl/inc/concepts
+++ b/stl/inc/concepts
@@ -41,8 +41,8 @@ concept derived_from = __is_base_of(_Base, _Derived)
 
 template <class _From, class _To>
 concept convertible_to = __is_convertible_to(_From, _To)
-    && requires(add_rvalue_reference_t<_From> (&_Fn)()) {
-        static_cast<_To>(_Fn());
+    && requires {
+        static_cast<_To>(declval<From>());
     };
 
 template <class _From, class _To>


### PR DESCRIPTION
Fixes #2394 