### PR TITLE
Implement LWG-3146: Excessive unwrapping in `std::ref`/`cref` 

### DIFF
--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -1842,7 +1842,7 @@ void ref(const _Ty&&) = delete;
 
 template <class _Ty>
 _NODISCARD _CONSTEXPR20 reference_wrapper<_Ty> ref(reference_wrapper<_Ty> _Val) noexcept {
-    return _STD ref(_Val.get());
+    return _Val;
 }
 
 template <class _Ty>
@@ -1855,7 +1855,7 @@ void cref(const _Ty&&) = delete;
 
 template <class _Ty>
 _NODISCARD _CONSTEXPR20 reference_wrapper<const _Ty> cref(reference_wrapper<_Ty> _Val) noexcept {
-    return _STD cref(_Val.get());
+    return _Val;
 }
 
 #if _HAS_CXX20

--- a/tests/std/test.lst
+++ b/tests/std/test.lst
@@ -192,6 +192,7 @@ tests\GH_002058_debug_iterator_race
 tests\GH_002120_streambuf_seekpos_and_seekoff
 tests\LWG2597_complex_branch_cut
 tests\LWG3018_shared_ptr_function
+tests\LWG3146_excessive_unwrapping_ref_cref
 tests\LWG3422_seed_seq_ctors
 tests\LWG3480_directory_iterator_range
 tests\P0019R8_atomic_ref

--- a/tests/std/tests/LWG3146_excessive_unwrapping_ref_cref/env.lst
+++ b/tests/std/tests/LWG3146_excessive_unwrapping_ref_cref/env.lst
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+RUNALL_INCLUDE ..\usual_matrix.lst

--- a/tests/std/tests/LWG3146_excessive_unwrapping_ref_cref/test.compile.pass.cpp
+++ b/tests/std/tests/LWG3146_excessive_unwrapping_ref_cref/test.compile.pass.cpp
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <functional>
+#include <type_traits>
+
+using namespace std;
+
+void test_LWG_3146() {
+    int i = 0;
+    reference_wrapper<int> ri(i);
+    reference_wrapper<reference_wrapper<int>> rri(ri);
+
+    auto reference       = ref(rri);
+    auto const_reference = cref(rri);
+
+    static_assert(
+        is_same_v<decltype(reference), reference_wrapper<reference_wrapper<int>>>, "LWG-3146 is not implemented");
+    static_assert(is_same_v<decltype(const_reference), reference_wrapper<const reference_wrapper<int>>>,
+        "LWG-3146 is not implemented");
+}
+
+int main() {} // COMPILE-ONLY

--- a/tests/tr1/tests/functional9/test.cpp
+++ b/tests/tr1/tests/functional9/test.cpp
@@ -60,21 +60,6 @@ static void t_invoke() { // test invoke
     CHECK_INT(STD invoke(sum4, 1, 3, 5, 7), 16);
 }
 
-// COMPILE-ONLY
-void test_LWG_3146() {
-    int i = 0;
-    STD reference_wrapper<int> ri(i);
-    STD reference_wrapper<STD reference_wrapper<int>> rri(ri);
-
-    auto reference       = STD ref(rri);
-    auto const_reference = STD cref(rri);
-
-    static_assert(STD is_same_v<decltype(reference), STD reference_wrapper<STD reference_wrapper<int>>>,
-        "LWG-3146 is not implemented");
-    static_assert(STD is_same_v<decltype(const_reference), STD reference_wrapper<const STD reference_wrapper<int>>>,
-        "LWG-3146 is not implemented");
-}
-
 void test_main() { // test header <functional>
     // reference_wrapper::operator() with rvalues
     call1(STD cref(fake_lvalue(&f1)));

--- a/tests/tr1/tests/functional9/test.cpp
+++ b/tests/tr1/tests/functional9/test.cpp
@@ -60,6 +60,19 @@ static void t_invoke() { // test invoke
     CHECK_INT(STD invoke(sum4, 1, 3, 5, 7), 16);
 }
 
+// COMPILE-ONLY
+void test_LWG_3146() {
+    int i = 0;
+    STD reference_wrapper<int> ri(i);
+    STD reference_wrapper<STD reference_wrapper<int>> rri(ri);
+
+    auto reference       = STD ref(rri);
+    auto const_reference = STD cref(rri);
+
+    (void) reference;
+    (void) const_reference;
+}
+
 void test_main() { // test header <functional>
     // reference_wrapper::operator() with rvalues
     call1(STD cref(fake_lvalue(&f1)));

--- a/tests/tr1/tests/functional9/test.cpp
+++ b/tests/tr1/tests/functional9/test.cpp
@@ -69,8 +69,10 @@ void test_LWG_3146() {
     auto reference       = STD ref(rri);
     auto const_reference = STD cref(rri);
 
-    (void) reference;
-    (void) const_reference;
+    static_assert(STD is_same_v<decltype(reference), STD reference_wrapper<STD reference_wrapper<int>>>,
+        "LWG-3146 is not implemented");
+    static_assert(STD is_same_v<decltype(const_reference), STD reference_wrapper<const STD reference_wrapper<int>>>,
+        "LWG-3146 is not implemented");
 }
 
 void test_main() { // test header <functional>


### PR DESCRIPTION
Fixes #2391 