### PR TITLE
`<memory>`: Add `nullptr` check in `std::allocator`

### DIFF
--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -826,7 +826,7 @@ public:
     _CONSTEXPR20 allocator& operator=(const allocator&) = default;
 
     _CONSTEXPR20 void deallocate(_Ty* const _Ptr, const size_t _Count) {
-        _STL_ASSERT(_Ptr != nullptr || _Count == 0, "You can't deallocate a bunch of memory at nullptr");
+        _STL_ASSERT(_Ptr != nullptr || _Count == 0, "null pointer cannot point to a block of non-zero size");
         // no overflow check on the following multiply; we assume _Allocate did that check
         _Deallocate<_New_alignof<_Ty>>(_Ptr, sizeof(_Ty) * _Count);
     }

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -826,6 +826,7 @@ public:
     _CONSTEXPR20 allocator& operator=(const allocator&) = default;
 
     _CONSTEXPR20 void deallocate(_Ty* const _Ptr, const size_t _Count) {
+        _STL_ASSERT(_Ptr != nullptr || _Count == 0, "You can't deallocate a bunch of memory at nullptr");
         // no overflow check on the following multiply; we assume _Allocate did that check
         _Deallocate<_New_alignof<_Ty>>(_Ptr, sizeof(_Ty) * _Count);
     }

--- a/tests/std/tests/Dev09_126254_persistent_aux_allocators/test.cpp
+++ b/tests/std/tests/Dev09_126254_persistent_aux_allocators/test.cpp
@@ -104,8 +104,9 @@ struct alignas(64) OverAlignedInt {
 };
 
 void test_gh_2362() {
-    // user suggests to add a debug-only nullptr assertion inside std::allocator<T>::deallocate, checking the pointer
-    // parameter. Passing nullptr to this member function is undefined behavior when the passed size is non-zero
+    // @hannes-harnisch suggests to add a debug-only nullptr assertion inside std::allocator<T>::deallocate, checking
+    // the pointer parameter. And deallocate must handle all return values of allocate, so if allocate(0) can return
+    // nullptr, then deallocate(nullptr, 0) must work.
     {
         allocator<int> al;
         int* ptr = al.allocate(0);

--- a/tests/std/tests/Dev09_126254_persistent_aux_allocators/test.cpp
+++ b/tests/std/tests/Dev09_126254_persistent_aux_allocators/test.cpp
@@ -101,7 +101,6 @@ void dump_map() {
 void test_gh_2362() {
     allocator<int> al;
     int* ptr = al.allocate(0);
-    assert(ptr == nullptr);
     al.deallocate(ptr, 0);
 }
 

--- a/tests/std/tests/Dev09_126254_persistent_aux_allocators/test.cpp
+++ b/tests/std/tests/Dev09_126254_persistent_aux_allocators/test.cpp
@@ -98,10 +98,24 @@ void dump_map() {
     }
 }
 
+struct alignas(64) OverAlignedInt {
+    int x;
+#pragma warning(suppress : 4324) // structure was padded due to alignment specifier
+};
+
 void test_gh_2362() {
-    allocator<int> al;
-    int* ptr = al.allocate(0);
-    al.deallocate(ptr, 0);
+    // user suggests to add a debug-only nullptr assertion inside std::allocator<T>::deallocate, checking the pointer
+    // parameter. Passing nullptr to this member function is undefined behavior when the passed size is non-zero
+    {
+        allocator<int> al;
+        int* ptr = al.allocate(0);
+        al.deallocate(ptr, 0);
+    }
+    {
+        allocator<OverAlignedInt> al;
+        OverAlignedInt* ptr = al.allocate(0);
+        al.deallocate(ptr, 0);
+    }
 }
 
 int main() {

--- a/tests/std/tests/Dev09_126254_persistent_aux_allocators/test.cpp
+++ b/tests/std/tests/Dev09_126254_persistent_aux_allocators/test.cpp
@@ -98,6 +98,13 @@ void dump_map() {
     }
 }
 
+void test_gh_2362() {
+    allocator<int> al;
+    int* ptr = al.allocate(0);
+    assert(ptr == nullptr);
+    al.deallocate(ptr, 0);
+}
+
 int main() {
     {
         vector<double, MyAllocator<double>> v;
@@ -120,4 +127,6 @@ int main() {
             abort();
         }
     }
+
+    test_gh_2362();
 }


### PR DESCRIPTION
Fixes #2362 