### PR TITLE
Implement LWG-3470: `convertible-to-non-slicing` seems to reject valid case

### DIFF
--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -3246,10 +3246,10 @@ _NODISCARD constexpr const tuple_element_t<_Index, tuple<_Types...>>&& get(const
 
 namespace ranges {
     // clang-format off
-    template<class _From, class _To>
+    template <class _From, class _To>
     concept _Uses_nonqualification_pointer_conversion =
-      is_pointer_v<_From> && is_pointer_v<_To> &&
-      !convertible_to<remove_pointer_t<_From>(*)[], remove_pointer_t<_To>(*)[]>;
+        is_pointer_v<_From> && is_pointer_v<_To>
+        && !convertible_to<remove_pointer_t<_From>(*)[], remove_pointer_t<_To>(*)[]>;
 
     template <class _From, class _To>
     concept _Convertible_to_non_slicing = convertible_to<_From, _To>

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -3246,11 +3246,14 @@ _NODISCARD constexpr const tuple_element_t<_Index, tuple<_Types...>>&& get(const
 
 namespace ranges {
     // clang-format off
+    template<class _From, class _To>
+    concept _Uses_nonqualification_pointer_conversion =
+      is_pointer_v<_From> && is_pointer_v<_To> &&
+      !convertible_to<remove_pointer_t<_From>(*)[], remove_pointer_t<_To>(*)[]>;
+
     template <class _From, class _To>
     concept _Convertible_to_non_slicing = convertible_to<_From, _To>
-        && !(is_pointer_v<decay_t<_From>>
-            && is_pointer_v<decay_t<_To>>
-            && _Not_same_as<remove_pointer_t<decay_t<_From>>, remove_pointer_t<decay_t<_To>>>);
+        && !_Uses_nonqualification_pointer_conversion<decay_t<_From>, decay_t<_To>>;
 
     template <class _Ty>
     concept _Pair_like = !is_reference_v<_Ty> && requires(_Ty __t) {

--- a/tests/std/tests/P0896R4_ranges_subrange/test.compile.pass.cpp
+++ b/tests/std/tests/P0896R4_ranges_subrange/test.compile.pass.cpp
@@ -23,6 +23,12 @@ using std::output_iterator_tag, std::input_iterator_tag, std::forward_iterator_t
 
 int main() {} // COMPILE-ONLY
 
+void test_LWG_3470() {
+    int a[3]                = {1, 2, 3};
+    int* b[3]               = {&a[2], &a[0], &a[1]};
+    [[maybe_unused]] auto c = std::ranges::subrange<const int* const*>(b);
+}
+
 struct empty {};
 
 namespace test_view_interface {

--- a/tests/std/tests/P0896R4_ranges_subrange/test.compile.pass.cpp
+++ b/tests/std/tests/P0896R4_ranges_subrange/test.compile.pass.cpp
@@ -24,8 +24,8 @@ using std::output_iterator_tag, std::input_iterator_tag, std::forward_iterator_t
 int main() {} // COMPILE-ONLY
 
 void test_LWG_3470() {
-    int a[3]                = {1, 2, 3};
-    int* b[3]               = {&a[2], &a[0], &a[1]};
+    int a[]                 = {1, 2, 3};
+    int* b[]                = {&a[2], &a[0], &a[1]};
     [[maybe_unused]] auto c = std::ranges::subrange<const int* const*>(b);
 }
 


### PR DESCRIPTION
Fixes #2393