### PR TITLE
Prefer `friend constexpr` to `constexpr friend`

### DIFF
--- a/stl/inc/iterator
+++ b/stl/inc/iterator
@@ -752,7 +752,7 @@ public:
     }
 
     // clang-format off
-    constexpr friend void swap(_Variantish& _Left, _Variantish& _Right) noexcept(
+    friend constexpr void swap(_Variantish& _Left, _Variantish& _Right) noexcept(
         is_nothrow_move_constructible_v<_It> && is_nothrow_move_constructible_v<_Se>
             && is_nothrow_swappable_v<_It> && is_nothrow_swappable_v<_Se>)
         requires (!_Is_trivially_swappable_v<_It> || !_Is_trivially_swappable_v<_Se>) {

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -38,8 +38,9 @@ std/language.support/support.exception/except.nested/rethrow_if_nested.pass.cpp 
 # Testing nonstandard behavior
 std/utilities/template.bitset/bitset.cons/string_ctor.pass.cpp FAIL
 
-# This test has undefined behavior under N4842 [basic.start.term]/6
+# Tests with undefined behavior under N4842 [basic.start.term]/6 (detached threads)
 std/thread/futures/futures.task/futures.task.members/dtor.pass.cpp SKIPPED
+std/thread/futures/futures.unique_future/wait_until.pass.cpp SKIPPED
 
 # libcxx is incorrect on what the type passed to allocator construct should be
 # See https://reviews.llvm.org/D61364

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -38,8 +38,9 @@ language.support\support.exception\except.nested\rethrow_if_nested.pass.cpp
 # Testing nonstandard behavior
 utilities\template.bitset\bitset.cons\string_ctor.pass.cpp
 
-# This test has undefined behavior under N4842 [basic.start.term]/6
+# Tests with undefined behavior under N4842 [basic.start.term]/6 (detached threads)
 thread\futures\futures.task\futures.task.members\dtor.pass.cpp
+thread\futures\futures.unique_future\wait_until.pass.cpp
 
 # libcxx is incorrect on what the type passed to allocator construct should be
 # See https://reviews.llvm.org/D61364

--- a/tests/std/include/range_algorithm_support.hpp
+++ b/tests/std/include/range_algorithm_support.hpp
@@ -453,11 +453,11 @@ namespace test {
             ++ptr_;
         }
 
-        [[nodiscard]] constexpr friend Element&& iter_move(iterator const& i) requires at_least<input> {
+        [[nodiscard]] friend constexpr Element&& iter_move(iterator const& i) requires at_least<input> {
             return std::move(*i.ptr_);
         }
 
-        constexpr friend void iter_swap(iterator const& x, iterator const& y)
+        friend constexpr void iter_swap(iterator const& x, iterator const& y)
             noexcept(std::is_nothrow_swappable_v<Element>) requires at_least<input> && std::swappable<Element> {
             ranges::swap(*x.ptr_, *y.ptr_);
         }

--- a/tests/std/tests/P0896R4_ranges_alg_copy_if/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_copy_if/test.cpp
@@ -20,7 +20,7 @@ struct not_pair {
     auto operator<=>(not_pair const&) const = default;
 
     template <size_t I>
-    constexpr friend auto&& get(not_pair& np) noexcept {
+    friend constexpr auto&& get(not_pair& np) noexcept {
         if constexpr (I == 0) {
             return np.first;
         } else {
@@ -29,7 +29,7 @@ struct not_pair {
         }
     }
     template <size_t I>
-    constexpr friend auto&& get(not_pair const& np) noexcept {
+    friend constexpr auto&& get(not_pair const& np) noexcept {
         if constexpr (I == 0) {
             return np.first;
         } else {
@@ -38,7 +38,7 @@ struct not_pair {
         }
     }
     template <size_t I>
-    constexpr friend auto&& get(not_pair&& np) noexcept {
+    friend constexpr auto&& get(not_pair&& np) noexcept {
         if constexpr (I == 0) {
             return move(np).first;
         } else {
@@ -47,7 +47,7 @@ struct not_pair {
         }
     }
     template <size_t I>
-    constexpr friend auto&& get(not_pair const&& np) noexcept {
+    friend constexpr auto&& get(not_pair const&& np) noexcept {
         if constexpr (I == 0) {
             return move(np).first;
         } else {

--- a/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
@@ -3107,7 +3107,7 @@ namespace move_iterator_test {
         input_iter& operator++();
         void operator++(int);
 
-        constexpr friend rvalue_reference iter_move(input_iter const&) noexcept {
+        friend constexpr rvalue_reference iter_move(input_iter const&) noexcept {
             return {};
         }
         friend void iter_swap(input_iter const&, input_iter const&) noexcept {}


### PR DESCRIPTION
We've had a few of the latter sneak in - let's correct them now.

Totally unrelated drive-by: Skip flaky libcxx test that detaches threads. (See https://dev.azure.com/vclibs/STL/_build/results?buildId=9815&view=ms.vss-test-web.build-test-results-tab&runId=1172522&resultId=101145&paneView=debug)