### PR TITLE
`<vector>`: Correctly pass target size, not size change to ASan annotator

### DIFF
--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -1208,7 +1208,7 @@ public:
                 _ASAN_VECTOR_MODIFY(static_cast<difference_type>(_Newsize - _Oldsize));
                 _Mylast = _Uninitialized_fill_n(_Mylast, _Newsize - _Oldsize, _Val, _Al);
             } else {
-                _ASAN_VECTOR_EXTEND_GUARD(static_cast<difference_type>(_Newsize - _Oldsize));
+                _ASAN_VECTOR_EXTEND_GUARD(_Newsize);
                 _Mylast = _Uninitialized_fill_n(_Mylast, _Newsize - _Oldsize, _Val, _Al);
                 _ASAN_VECTOR_RELEASE_GUARD;
             }
@@ -1290,7 +1290,7 @@ private:
                 _ASAN_VECTOR_MODIFY(static_cast<difference_type>(_Newsize - _Oldsize));
                 _Mylast = _Uninitialized_copy(_Mid, _Last, _Mylast, _Al);
             } else {
-                _ASAN_VECTOR_EXTEND_GUARD(static_cast<difference_type>(_Newsize - _Oldsize));
+                _ASAN_VECTOR_EXTEND_GUARD(_Newsize);
                 _Mylast = _Uninitialized_copy(_Mid, _Last, _Mylast, _Al);
                 _ASAN_VECTOR_RELEASE_GUARD;
             }
@@ -1406,7 +1406,7 @@ private:
                 return;
             }
 
-            _ASAN_VECTOR_EXTEND_GUARD(_Newsize - _Oldsize);
+            _ASAN_VECTOR_EXTEND_GUARD(_Newsize);
             const pointer _Oldlast = _Mylast;
             if constexpr (is_same_v<_Ty2, _Ty>) {
                 _Mylast = _Uninitialized_fill_n(_Oldlast, _Newsize - _Oldsize, _Val, _Al);
@@ -1948,7 +1948,7 @@ private:
                 _ASAN_VECTOR_MODIFY(static_cast<difference_type>(_Newsize - _Oldsize));
                 _Mylast = _Uninitialized_move(_Mid, _Last, _Mylast, _Al);
             } else {
-                _ASAN_VECTOR_EXTEND_GUARD(_Newsize - _Oldsize);
+                _ASAN_VECTOR_EXTEND_GUARD(_Newsize);
                 _Mylast = _Uninitialized_move(_Mid, _Last, _Mylast, _Al);
                 _ASAN_VECTOR_RELEASE_GUARD;
             }

--- a/tests/std/tests/GH_002030_asan_annotate_vector/test.cpp
+++ b/tests/std/tests/GH_002030_asan_annotate_vector/test.cpp
@@ -30,11 +30,22 @@ void __asan_describe_address(void*) noexcept;
 #endif // ASan instrumentation enabled
 
 struct non_trivial_can_throw {
-    non_trivial_can_throw() {}
+    non_trivial_can_throw() {
+        ++i;
+        if (i == 0) {
+            throw i;
+        }
+    }
+
+    int i = 0;
 };
 
 struct non_trivial_cannot_throw {
-    non_trivial_cannot_throw() noexcept {}
+    non_trivial_cannot_throw() noexcept {
+        ++i;
+    }
+
+    int i = 0;
 };
 
 struct throw_on_construction {
@@ -450,6 +461,12 @@ void test_resize() {
     v.resize(N, T());
     assert(verify_vector(v));
     v.resize(1, T());
+    assert(verify_vector(v));
+    v.resize(v.capacity(), T());
+    assert(verify_vector(v));
+    v.resize(v.size() - 1, T());
+    assert(verify_vector(v));
+    v.resize(v.capacity() + N, T());
     assert(verify_vector(v));
 }
 

--- a/tests/std/tests/GH_002030_asan_annotate_vector/test.cpp
+++ b/tests/std/tests/GH_002030_asan_annotate_vector/test.cpp
@@ -37,7 +37,18 @@ struct non_trivial_can_throw {
         }
     }
 
-    int i = 0;
+    non_trivial_can_throw(const non_trivial_can_throw&) {
+        ++i;
+        if (i == 0) {
+            throw i;
+        }
+    }
+
+    non_trivial_can_throw& operator=(const non_trivial_can_throw&) {
+        return *this;
+    }
+
+    unsigned int i = 0;
 };
 
 struct non_trivial_cannot_throw {
@@ -45,7 +56,7 @@ struct non_trivial_cannot_throw {
         ++i;
     }
 
-    int i = 0;
+    unsigned int i = 0;
 };
 
 struct throw_on_construction {
@@ -329,6 +340,23 @@ void test_move_assign() {
     v2 = move(v1);
     assert(verify_vector(v1));
     assert(verify_vector(v2));
+
+    vector<T, Alloc> v3;
+    vector<T, Alloc> v4;
+    assert(verify_vector(v3));
+    assert(verify_vector(v4));
+
+    v3.reserve(v3.capacity() + 1);
+    assert(verify_vector(v3));
+    v3.resize(v3.capacity() + 1, T());
+    assert(verify_vector(v3));
+    v3.reserve(v3.capacity() + 1);
+    assert(verify_vector(v3));
+    v4.resize(v3.capacity(), T());
+    assert(verify_vector(v4));
+    v3 = move(v4);
+    assert(verify_vector(v3));
+    assert(verify_vector(v4));
 }
 
 template <class Alloc>
@@ -431,17 +459,29 @@ void test_assign() {
     assert(verify_vector(v1));
     v1.assign(v3.begin(), v3.end());
     assert(verify_vector(v1));
+    v1.reserve(v1.size() + 1);
+    assert(verify_vector(v1));
+    vector<T, Alloc> larger(v1.capacity());
+    v1.assign(larger.begin(), larger.end());
+    assert(verify_vector(v1));
+
     v1.assign(t1.begin(), t1.end());
     assert(verify_vector(v1));
     v1.assign(t2.begin(), t2.end());
     assert(verify_vector(v1));
     v1.assign(t1.begin(), t1.end());
     assert(verify_vector(v1));
+
     v1.assign(v3.begin(), v3.end());
     assert(verify_vector(v1));
     v1.assign(v2.begin(), v2.end());
     assert(verify_vector(v1));
+
     v1.assign(N, T());
+    assert(verify_vector(v1));
+    v1.reserve(v1.size() + 1);
+    assert(verify_vector(v1));
+    v1.assign(v1.capacity(), T());
     assert(verify_vector(v1));
 
     vector<T, Alloc> v4;


### PR DESCRIPTION
@joemmett experienced ASan errors while attempting to build and run the compiler under ASan after my ASan vector change.
Upon inspection of the failure point @CaseyCarter noticed that we were passing the change of the size to the ASan annotator guard instead of the absolute target size in both `_Resize` and `assign`.

Casey and I also would like to see more vector tests running with ASan turned on but it is difficult to insert `/fsanitize=address` into an arbitrary matrix because it currently only supports the default IDLs and clang-cl currently does not support debug flavors of the CRT.