### PR TITLE
`allocator::is_always_equal` is deprecated, not removed, in C++20

### DIFF
--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -798,11 +798,10 @@ public:
     using size_type       = size_t;
     using difference_type = ptrdiff_t;
 
-    using propagate_on_container_move_assignment = true_type;
+    using propagate_on_container_move_assignment           = true_type;
+    using is_always_equal _CXX20_DEPRECATE_IS_ALWAYS_EQUAL = true_type;
 
 #if _HAS_DEPRECATED_ALLOCATOR_MEMBERS
-    using is_always_equal _CXX17_DEPRECATE_OLD_ALLOCATOR_MEMBERS = true_type;
-
     template <class _Other>
     struct _CXX17_DEPRECATE_OLD_ALLOCATOR_MEMBERS rebind {
         using other = allocator<_Other>;
@@ -876,11 +875,10 @@ public:
     using size_type       = size_t;
     using difference_type = ptrdiff_t;
 
-    using propagate_on_container_move_assignment = true_type;
+    using propagate_on_container_move_assignment           = true_type;
+    using is_always_equal _CXX20_DEPRECATE_IS_ALWAYS_EQUAL = true_type;
 
 #if _HAS_DEPRECATED_ALLOCATOR_MEMBERS
-    using is_always_equal _CXX17_DEPRECATE_OLD_ALLOCATOR_MEMBERS = true_type;
-
     template <class _Other>
     struct _CXX17_DEPRECATE_OLD_ALLOCATOR_MEMBERS rebind {
         using other = allocator<_Other>;

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -1081,7 +1081,19 @@
 #define _CXX17_DEPRECATE_POLYMORPHIC_ALLOCATOR_DESTROY
 #endif // ^^^ warning disabled ^^^
 
-// next warning number: STL4033
+#if _HAS_CXX20 && !defined(_SILENCE_CXX20_IS_ALWAYS_EQUAL_DEPRECATION_WARNING) \
+    && !defined(_SILENCE_ALL_CXX20_DEPRECATION_WARNINGS)
+#define _CXX20_DEPRECATE_IS_ALWAYS_EQUAL                                                \
+    [[deprecated("warning STL4033: "                                                    \
+                 "std::allocator::is_always_equal is deprecated in C++20 by LWG-3170. " \
+                 "Prefer std::allocator_traits<allocator<T>>::is_always_equal. "        \
+                 "You can define _SILENCE_CXX20_IS_ALWAYS_EQUAL_DEPRECATION_WARNING "   \
+                 "or _SILENCE_ALL_CXX20_DEPRECATION_WARNINGS to acknowledge that you have received this warning.")]]
+#else // ^^^ warning enabled / warning disabled vvv
+#define _CXX20_DEPRECATE_IS_ALWAYS_EQUAL
+#endif // ^^^ warning disabled ^^^
+
+// next warning number: STL4034
 
 // P0619R4 Removing C++17-Deprecated Features
 #ifndef _HAS_FEATURES_REMOVED_IN_CXX20


### PR DESCRIPTION
...by LWG-3170. We improperly reused the "allocator features deprecated in C++17" deprecation warning macro instead of devising a new macro name, and therefore incorrectly "promoted" `is_always_equal` to "removed" when the other such marked features were removed for C++20.

Fixes #2422
