### PR TITLE
Update counted_iterator's "same sequence" definition

### DIFF
--- a/stl/inc/iterator
+++ b/stl/inc/iterator
@@ -1305,9 +1305,9 @@ public:
     template <common_with<_Iter> _Other>
     friend constexpr void _Same_sequence(
         const counted_iterator& _Left, const counted_iterator<_Other>& _Right) noexcept {
-        // Per N4861 [counted.iterator]/2, two counted_iterators x and y refer to elements of the same sequence iff
-        // next(x.base(), x.count()) and next(y.base(), y.count()) "refer to the same element." Iterator equality is a
-        // fair proxy for this condition.
+        // Per N4901 [counted.iterator]/3, two counted_iterators x and y refer to elements of the same sequence iff
+        // for some integer n, next(x.base(), x.count() + n) and next(y.base(), y.count() + n) "refer to the same
+        // element." Iterator equality is a fair proxy for the vaguely-defined "refer to the same element".
         if constexpr (forward_iterator<_Iter> && forward_iterator<_Other>) {
             using _CIter = common_type_t<_Iter, _Other>;
             using _CDiff = common_type_t<iter_difference_t<_Iter>, iter_difference_t<_Other>>;
@@ -1316,11 +1316,11 @@ public:
             if (_Diff < 0) {
                 _STL_VERIFY(
                     static_cast<_CIter>(_Left._Current) == _RANGES next(static_cast<_CIter>(_Right.base()), -_Diff),
-                    "counted_iterators from different ranges");
+                    "counted_iterators are from different ranges");
             } else {
                 _STL_VERIFY(
                     _RANGES next(static_cast<_CIter>(_Left._Current), _Diff) == static_cast<_CIter>(_Right.base()),
-                    "counted_iterators from different ranges");
+                    "counted_iterators are from different ranges");
             }
         }
     }

--- a/stl/inc/iterator
+++ b/stl/inc/iterator
@@ -1306,8 +1306,9 @@ public:
     friend constexpr void _Same_sequence(
         const counted_iterator& _Left, const counted_iterator<_Other>& _Right) noexcept {
         // Per N4901 [counted.iterator]/3, two counted_iterators x and y refer to elements of the same sequence iff
-        // for some integer n, next(x.base(), x.count() + n) and next(y.base(), y.count() + n) "refer to the same
-        // element." Iterator equality is a fair proxy for the vaguely-defined "refer to the same element".
+        // for some integer n, next(x.base(), x.count() + n) and next(y.base(), y.count() + n)
+        // "refer to the same (possibly past-the-end) element".
+        // Iterator equality is a fair proxy for the vaguely-defined "refer to the same element".
         if constexpr (forward_iterator<_Iter> && forward_iterator<_Other>) {
             using _CIter = common_type_t<_Iter, _Other>;
             using _CDiff = common_type_t<iter_difference_t<_Iter>, iter_difference_t<_Other>>;


### PR DESCRIPTION
Per LWG-3543. (This is _almost_ a pure non-functional change, but I added a word to the error message we emit on failure.)

Fixes #2184
