### PR TITLE
Render keys_view and values_view useless per LWG-3563

### DIFF
--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -4717,9 +4717,9 @@ namespace ranges {
     inline constexpr bool enable_borrowed_range<elements_view<_Rng, _Index>> = enable_borrowed_range<_Rng>;
 
     template <class _Rng>
-    using keys_view = elements_view<views::all_t<_Rng>, 0>;
+    using keys_view = elements_view<_Rng, 0>;
     template <class _Rng>
-    using values_view = elements_view<views::all_t<_Rng>, 1>;
+    using values_view = elements_view<_Rng, 1>;
 
     namespace views {
         template <size_t _Index>

--- a/tests/std/tests/P0896R4_views_elements/test.cpp
+++ b/tests/std/tests/P0896R4_views_elements/test.cpp
@@ -186,11 +186,11 @@ constexpr bool test_one(Rng&& rng) {
     // Validate content
     assert(ranges::equal(r, expected_keys));
 
-    // Validate keys_view and values_view
-    STATIC_ASSERT(same_as<ranges::keys_view<Rng>, R>);
-    STATIC_ASSERT(same_as<ranges::values_view<Rng>, elements_view<V, 1>>);
+    // Validate views::keys and views::values
+    STATIC_ASSERT(same_as<decltype(views::keys(rng)), R>);
+    STATIC_ASSERT(same_as<decltype(views::values(rng)), elements_view<V, 1>>);
     if constexpr (forward_range<Rng> && is_lvalue_reference_v<Rng>) {
-        assert(ranges::equal(ranges::values_view<Rng>{rng}, expected_values));
+        assert(ranges::equal(views::values(rng), expected_values));
     }
 
     // Validate elements_view::begin


### PR DESCRIPTION
(There's an argument to be made that they were useless before when they named the result type of `views::keys(declval<Rng>())` and `views::values(declval<Rng>())`, but they certainly are now.) Change our test coverage to `views::keys` and `views::values`, the intended UX for extracting fields from ranges.

Fixes #2389
