### PR TITLE
Fix begin/end for valarray crashing on empty instance

### DIFF
--- a/stl/inc/valarray
+++ b/stl/inc/valarray
@@ -57,7 +57,7 @@ using _Sizarray  = valarray<size_t>;
 
 template <class _Ty>
 class valarray { // store array with various indexing options
-private:
+public:
     friend _Tidy_deallocate_guard<valarray>;
 
     template <class _Ty2>
@@ -72,7 +72,6 @@ private:
     template <class _Ty2>
     friend const _Ty2* end(const valarray<_Ty2>& _Array);
 
-public:
     using value_type = _Ty;
 
     valarray() { // construct empty valarray

--- a/stl/inc/valarray
+++ b/stl/inc/valarray
@@ -60,6 +60,18 @@ class valarray { // store array with various indexing options
 private:
     friend _Tidy_deallocate_guard<valarray>;
 
+    template <class _Ty2>
+    friend _Ty2* begin(valarray<_Ty2>& _Array);
+
+    template <class _Ty2>
+    friend const _Ty2* begin(const valarray<_Ty2>& _Array);
+
+    template <class _Ty2>
+    friend _Ty2* end(valarray<_Ty2>& _Array);
+
+    template <class _Ty2>
+    friend const _Ty2* end(const valarray<_Ty2>& _Array);
+
 public:
     using value_type = _Ty;
 
@@ -591,22 +603,22 @@ void swap(valarray<_Ty>& _Left, valarray<_Ty>& _Right) noexcept {
 
 template <class _Ty>
 _NODISCARD _Ty* begin(valarray<_Ty>& _Array) {
-    return &_Array[0];
+    return _Array._Myptr;
 }
 
 template <class _Ty>
 _NODISCARD const _Ty* begin(const valarray<_Ty>& _Array) {
-    return &_Array[0];
+    return _Array._Myptr;
 }
 
 template <class _Ty>
 _NODISCARD _Ty* end(valarray<_Ty>& _Array) {
-    return &_Array[0] + _Array.size();
+    return _Array._Myptr + _Array.size();
 }
 
 template <class _Ty>
 _NODISCARD const _Ty* end(const valarray<_Ty>& _Array) {
-    return &_Array[0] + _Array.size();
+    return _Array._Myptr + _Array.size();
 }
 
 template <class _Ty>

--- a/tests/tr1/tests/valarray/test.cpp
+++ b/tests/tr1/tests/valarray/test.cpp
@@ -340,5 +340,24 @@ void test_main() { // test basic workings of valarray definitions
     CHECK_INT(v0.max(), 4);
     CHECK_INT(v0.min(), 2);
 
+    // test range-based for
+    v0 = Mycont();
+    for (char c : v0) {
+        (void)c;
+        CHECK(false);
+    }
+
+    v0 = Mycont("\1\1\1", 3);
+    for (char c : v0) {
+        CHECK_INT(c, 1);
+    }
+
+    v0  = Mycont("\1\2\3", 3);
+    val = 0;
+    for (char c : v0) {
+        val += c;
+    }
+    CHECK_INT(val, 6);
+
     test_math();
 }

--- a/tests/tr1/tests/valarray/test.cpp
+++ b/tests/tr1/tests/valarray/test.cpp
@@ -343,7 +343,7 @@ void test_main() { // test basic workings of valarray definitions
     // test range-based for
     v0 = Mycont();
     for (char c : v0) {
-        (void)c;
+        (void) c;
         CHECK(false);
     }
 


### PR DESCRIPTION
This issue also causes range-based for loops to break for empty valarrays.

I also added regression tests, which I hope are fine.

If there's anything wrong just tell me and I'll happily adjust!