### PR TITLE
Toolset update: VS 2022 17.1 Preview 2, Clang 13

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-# https://releases.llvm.org/12.0.0/tools/clang/docs/ClangFormatStyleOptions.html
+# https://releases.llvm.org/13.0.0/tools/clang/docs/ClangFormatStyleOptions.html
 
 ---
 # Language:        Cpp
@@ -10,6 +10,8 @@ BasedOnStyle:  LLVM
 AccessModifierOffset: -4
 # AlignAfterOpenBracket: Align
 AlignAfterOpenBracket: DontAlign
+# AlignArrayOfStructures: None
+# TRANSITION, LLVM-51935 (try using AlignArrayOfStructures after this crash is fixed)
 # AlignConsecutiveMacros: None
 AlignConsecutiveMacros: Consecutive
 # AlignConsecutiveAssignments: None
@@ -84,6 +86,7 @@ ColumnLimit:     120
 DeriveLineEnding: false
 # DerivePointerAlignment: false
 # DisableFormat:   false
+# EmptyLineAfterAccessModifier: Never
 # EmptyLineBeforeAccessModifier: LogicalBlock
 # ExperimentalAutoDetectBinPacking: false
 # FixNamespaceComments: true
@@ -91,8 +94,8 @@ DeriveLineEnding: false
 #   - foreach
 #   - Q_FOREACH
 #   - BOOST_FOREACH
-# StatementAttributeLikeMacros:
-#   - Q_EMIT
+# IfMacros:
+#   - KJ_IF_MAYBE
 # IncludeBlocks:   Preserve
 IncludeBlocks:   Regroup
 # IncludeCategories:
@@ -125,6 +128,7 @@ IncludeCategories:
     Priority:        2
 # IncludeIsMainRegex: '(Test)?$'
 # IncludeIsMainSourceRegex: ''
+# IndentAccessModifiers: false
 # IndentCaseLabels: false
 # IndentCaseBlocks: false
 IndentCaseBlocks: true
@@ -141,6 +145,7 @@ IndentWrappedFunctionNames: true
 # JavaScriptQuotes: Leave
 # JavaScriptWrapImports: true
 # KeepEmptyLinesAtTheStartOfBlocks: true
+# LambdaBodyIndentation: Signature
 # NOTE: MacroBlockBegin/MacroBlockEnd don't work with _CATCH_ALL.
 # MacroBlockBegin: ''
 # MacroBlockEnd:   ''
@@ -164,8 +169,11 @@ NamespaceIndentation: All
 # PenaltyIndentedWhitespace: 0
 # PointerAlignment: Right
 PointerAlignment: Left
+# PPIndentWidth:   -1
+# ReferenceAlignment: Pointer
 # ReflowComments:  true
-# SortIncludes:    true
+# ShortNamespaceLines: 1
+# SortIncludes:    CaseSensitive
 # SortJavaStaticImport: Before
 # SortUsingDeclarations: true
 # SpaceAfterCStyleCast: false
@@ -183,15 +191,20 @@ SpaceAfterCStyleCast: true
 # SpaceInEmptyBlock: false
 # SpaceInEmptyParentheses: false
 # SpacesBeforeTrailingComments: 1
-# SpacesInAngles:  false
+# SpacesInAngles:  Never
 # SpacesInConditionalStatement: false
 # SpacesInContainerLiterals: true
 # SpacesInCStyleCastParentheses: false
+# SpacesInLineCommentPrefix:
+#   Minimum:         1
+#   Maximum:         -1
 # SpacesInParentheses: false
 # SpacesInSquareBrackets: false
 # SpaceBeforeSquareBrackets: false
 # BitFieldColonSpacing: Both
 # Standard:        Latest
+# StatementAttributeLikeMacros:
+#   - Q_EMIT
 # StatementMacros:
 #   - Q_UNUSED
 #   - QT_REQUIRE_VERSION

--- a/.github/workflows/update-status-chart.yml
+++ b/.github/workflows/update-status-chart.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: ">=16.0.0"
+          node-version: ">=17.3.1"
       - name: Install Packages
         run: |
           npm ci

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With The Visual Studio IDE
 
-1. Install Visual Studio 2022 17.1 Preview 1 or later.
+1. Install Visual Studio 2022 17.1 Preview 2 or later.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
     * Otherwise, install [CMake][] 3.21 or later, and [Ninja][] 1.10.2 or later.
@@ -155,7 +155,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With A Native Tools Command Prompt
 
-1. Install Visual Studio 2022 17.1 Preview 1 or later.
+1. Install Visual Studio 2022 17.1 Preview 2 or later.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
     * Otherwise, install [CMake][] 3.21 or later, and [Ninja][] 1.10.2 or later.

--- a/azure-devops/create-vmss.ps1
+++ b/azure-devops/create-vmss.ps1
@@ -249,7 +249,8 @@ $VirtualNetwork = New-AzVirtualNetwork `
 
 ####################################################################################################
 Write-Progress `
-  -Activity 'Creating prototype VM' `
+  -Activity $ProgressActivity `
+  -Status 'Creating prototype VM' `
   -PercentComplete (100 / $TotalProgress * $CurrentProgress++)
 
 $NicName = $ResourceGroupName + '-NIC'

--- a/azure-devops/create-vmss.ps1
+++ b/azure-devops/create-vmss.ps1
@@ -22,7 +22,7 @@ $Env:SuppressAzurePowerShellBreakingChangeWarnings = 'true'
 
 $Location = 'westus2'
 $Prefix = 'StlBuild-' + (Get-Date -Format 'yyyy-MM-dd')
-$VMSize = 'Standard_D32as_v4'
+$VMSize = 'Standard_D32ads_v5'
 $ProtoVMName = 'PROTOTYPE'
 $LiveVMPrefix = 'BUILD'
 $ImagePublisher = 'MicrosoftWindowsDesktop'

--- a/azure-devops/create-vmss.ps1
+++ b/azure-devops/create-vmss.ps1
@@ -170,7 +170,7 @@ Write-Progress `
   -Status 'Setting the subscription context' `
   -PercentComplete (100 / $TotalProgress * $CurrentProgress++)
 
-Set-AzContext -SubscriptionName CPP_STL_GitHub
+$IgnoredAzureContext = Set-AzContext -SubscriptionName CPP_STL_GitHub
 
 ####################################################################################################
 Write-Progress `
@@ -180,7 +180,7 @@ Write-Progress `
 
 $ResourceGroupName = Find-ResourceGroupName $Prefix
 $AdminPW = New-Password
-New-AzResourceGroup -Name $ResourceGroupName -Location $Location
+$IgnoredResourceGroup = New-AzResourceGroup -Name $ResourceGroupName -Location $Location
 $AdminPWSecure = ConvertTo-SecureString $AdminPW -AsPlainText -Force
 $Credential = New-Object System.Management.Automation.PSCredential ("AdminUser", $AdminPWSecure)
 
@@ -276,7 +276,7 @@ $VM = Set-AzVMSourceImage `
   -Version latest
 
 $VM = Set-AzVMBootDiagnostic -VM $VM -Disable
-New-AzVm `
+$IgnoredAzureOperationResponse = New-AzVm `
   -ResourceGroupName $ResourceGroupName `
   -Location $Location `
   -VM $VM
@@ -302,7 +302,7 @@ Write-Progress `
   -Status 'Restarting VM' `
   -PercentComplete (100 / $TotalProgress * $CurrentProgress++)
 
-Restart-AzVM -ResourceGroupName $ResourceGroupName -Name $ProtoVMName
+$IgnoredComputeLongRunningOperation = Restart-AzVM -ResourceGroupName $ResourceGroupName -Name $ProtoVMName
 
 ####################################################################################################
 Write-Progress `
@@ -320,7 +320,7 @@ Write-Progress `
   -Status 'Running provisioning script sysprep.ps1 in VM' `
   -PercentComplete (100 / $TotalProgress * $CurrentProgress++)
 
-Invoke-AzVMRunCommand `
+$IgnoredRunCommandResult = Invoke-AzVMRunCommand `
   -ResourceGroupName $ResourceGroupName `
   -VMName $ProtoVMName `
   -CommandId 'RunPowerShellScript' `
@@ -340,12 +340,12 @@ Write-Progress `
   -Status 'Converting VM to Image' `
   -PercentComplete (100 / $TotalProgress * $CurrentProgress++)
 
-Stop-AzVM `
+$IgnoredComputeLongRunningOperation = Stop-AzVM `
   -ResourceGroupName $ResourceGroupName `
   -Name $ProtoVMName `
   -Force
 
-Set-AzVM `
+$IgnoredComputeLongRunningOperation = Set-AzVM `
   -ResourceGroupName $ResourceGroupName `
   -Name $ProtoVMName `
   -Generalized
@@ -361,8 +361,11 @@ Write-Progress `
   -Status 'Deleting unused VM and disk' `
   -PercentComplete (100 / $TotalProgress * $CurrentProgress++)
 
-Remove-AzVM -Id $VM.ID -Force
-Remove-AzDisk -ResourceGroupName $ResourceGroupName -DiskName $PrototypeOSDiskName -Force
+$IgnoredComputeLongRunningOperation = Remove-AzVM -Id $VM.ID -Force
+$IgnoredOperationStatusResponse = Remove-AzDisk `
+  -ResourceGroupName $ResourceGroupName `
+  -DiskName $PrototypeOSDiskName `
+  -Force
 
 ####################################################################################################
 Write-Progress `
@@ -405,7 +408,7 @@ $Vmss = Set-AzVmssStorageProfile `
   -OsDiskCaching ReadWrite `
   -ImageReferenceId $Image.Id
 
-New-AzVmss `
+$Vmss = New-AzVmss `
   -ResourceGroupName $ResourceGroupName `
   -Name $VmssName `
   -VirtualMachineScaleSet $Vmss

--- a/azure-devops/create-vmss.ps1
+++ b/azure-devops/create-vmss.ps1
@@ -103,7 +103,7 @@ function New-Password {
 
   # This 64-character alphabet generates 6 bits of entropy per character.
   # The power-of-2 alphabet size allows us to select a character by masking a random Byte with bitwise-AND.
-  $alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-"
+  $alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-'
   $mask = 63
   if ($alphabet.Length -ne 64) {
     throw 'Bad alphabet length'
@@ -158,7 +158,7 @@ function Wait-Shutdown {
       }
     }
 
-    Write-Host "... not stopped yet, sleeping for 10 seconds"
+    Write-Host '... not stopped yet, sleeping for 10 seconds'
     Start-Sleep -Seconds 10
   }
 }
@@ -182,7 +182,7 @@ $ResourceGroupName = Find-ResourceGroupName $Prefix
 $AdminPW = New-Password
 $IgnoredResourceGroup = New-AzResourceGroup -Name $ResourceGroupName -Location $Location
 $AdminPWSecure = ConvertTo-SecureString $AdminPW -AsPlainText -Force
-$Credential = New-Object System.Management.Automation.PSCredential ("AdminUser", $AdminPWSecure)
+$Credential = New-Object System.Management.Automation.PSCredential ('AdminUser', $AdminPWSecure)
 
 ####################################################################################################
 Write-Progress `
@@ -236,7 +236,7 @@ $NetworkSecurityGroup = New-AzNetworkSecurityGroup `
 $SubnetName = $ResourceGroupName + '-Subnet'
 $Subnet = New-AzVirtualNetworkSubnetConfig `
   -Name $SubnetName `
-  -AddressPrefix "10.0.0.0/16" `
+  -AddressPrefix '10.0.0.0/16' `
   -NetworkSecurityGroup $NetworkSecurityGroup
 
 $VirtualNetworkName = $ResourceGroupName + '-Network'
@@ -244,7 +244,7 @@ $VirtualNetwork = New-AzVirtualNetwork `
   -Name $VirtualNetworkName `
   -ResourceGroupName $ResourceGroupName `
   -Location $Location `
-  -AddressPrefix "10.0.0.0/16" `
+  -AddressPrefix '10.0.0.0/16' `
   -Subnet $Subnet
 
 ####################################################################################################

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -352,7 +352,7 @@ InstallCuda -Url $CudaUrl -Features $CudaFeatures
 Write-Host 'Updating PATH...'
 
 # Step 1: Read the system path, which was just updated by installing Python.
-$currentSystemPath = [Environment]::GetEnvironmentVariable("Path", "Machine")
+$currentSystemPath = [Environment]::GetEnvironmentVariable('Path', 'Machine')
 
 # Step 2: Update the local path (for this running script), so PipInstall can run python.exe.
 # Additional directories can be added here (e.g. if we extracted a zip file
@@ -360,7 +360,7 @@ $currentSystemPath = [Environment]::GetEnvironmentVariable("Path", "Machine")
 $Env:PATH="$($currentSystemPath)"
 
 # Step 3: Update the system path, permanently recording any additional directories that were added in the previous step.
-[Environment]::SetEnvironmentVariable("Path", "$Env:PATH", "Machine")
+[Environment]::SetEnvironmentVariable('Path', "$Env:PATH", 'Machine')
 
 Write-Host 'Finished updating PATH!'
 
@@ -374,7 +374,7 @@ Write-Host 'Finished running PipInstall!'
 Write-Host 'Setting other environment variables...'
 
 # The STL's PR/CI builds are totally unrepresentative of customer usage.
-[Environment]::SetEnvironmentVariable("VSCMD_SKIP_SENDTELEMETRY", "1", "Machine")
+[Environment]::SetEnvironmentVariable('VSCMD_SKIP_SENDTELEMETRY', '1', 'Machine')
 
 Write-Host 'Finished setting other environment variables!'
 

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -333,6 +333,9 @@ Function PipInstall {
 
 Write-Host 'AdminUser password not supplied; assuming already running as AdminUser.'
 
+# Print the Windows version, so we can verify whether Patch Tuesday has been picked up.
+cmd /c ver
+
 Write-Host 'Configuring AntiVirus exclusions...'
 Add-MpPreference -ExclusionPath C:\agent
 Add-MpPreference -ExclusionPath D:\

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -91,7 +91,7 @@ if ([string]::IsNullOrEmpty($AdminUserPassword)) {
   $PsExecPath = Join-Path $ExtractedPsToolsPath 'PsExec64.exe'
 
   # https://github.com/PowerShell/PowerShell/releases/latest
-  $PowerShellZipUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.2.0/PowerShell-7.2.0-win-x64.zip'
+  $PowerShellZipUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.2.1/PowerShell-7.2.1-win-x64.zip'
   Write-Host "Downloading: $PowerShellZipUrl"
   $ExtractedPowerShellPath = DownloadAndExtractZip -Url $PowerShellZipUrl
   $PwshPath = Join-Path $ExtractedPowerShellPath 'pwsh.exe'
@@ -141,7 +141,7 @@ $Workloads = @(
 $ReleaseInPath = 'Preview'
 $Sku = 'Enterprise'
 $VisualStudioBootstrapperUrl = 'https://aka.ms/vs/17/pre/vs_enterprise.exe'
-$PythonUrl = 'https://www.python.org/ftp/python/3.10.0/python-3.10.0-amd64.exe'
+$PythonUrl = 'https://www.python.org/ftp/python/3.10.1/python-3.10.1-amd64.exe'
 
 $CudaUrl = `
   'https://developer.download.nvidia.com/compute/cuda/10.1/Prod/local_installers/cuda_10.1.243_426.00_win10.exe'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ variables:
   tmpDir: 'D:\Temp'
   buildOutputLocation: 'D:\build'
 
-pool: 'StlBuild-2021-11-09'
+pool: 'StlBuild-2022-01-13-2'
 
 stages:
   - stage: Code_Format

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -5536,8 +5536,9 @@ namespace ranges {
 
             // _Temp_count + 1 since we work on closed ranges
             const auto _Total_count = static_cast<iter_difference_t<_It>>(_Temp_count + 1);
-            auto _Result            = _Stable_partition_common_buffered(
-                           _STD move(_First), _STD move(_Last), _Pred, _Proj, _Total_count, _Temp_buf._Data, _Temp_buf._Capacity);
+
+            auto _Result = _Stable_partition_common_buffered(
+                _STD move(_First), _STD move(_Last), _Pred, _Proj, _Total_count, _Temp_buf._Data, _Temp_buf._Capacity);
             return {_STD move(_Result.first), _STD move(_Saved_last)};
         }
 

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -47,13 +47,13 @@ template <class _Diff>
 constexpr ptrdiff_t _Temporary_buffer_size(const _Diff _Value) noexcept {
     // convert an iterator difference_type to a ptrdiff_t for use in temporary buffers
     using _CT = common_type_t<ptrdiff_t, _Diff>;
-    return static_cast<ptrdiff_t>((_STD min) (static_cast<_CT>(PTRDIFF_MAX), static_cast<_CT>(_Value)));
+    return static_cast<ptrdiff_t>((_STD min)(static_cast<_CT>(PTRDIFF_MAX), static_cast<_CT>(_Value)));
 }
 
 template <class _Ty>
 struct _Optimistic_temporary_buffer { // temporary storage with _alloca-like attempt
     static constexpr size_t _Optimistic_size  = 4096; // default to ~1 page
-    static constexpr size_t _Optimistic_count = (_STD max) (static_cast<size_t>(1), _Optimistic_size / sizeof(_Ty));
+    static constexpr size_t _Optimistic_count = (_STD max)(static_cast<size_t>(1), _Optimistic_size / sizeof(_Ty));
 
     template <class _Diff>
     explicit _Optimistic_temporary_buffer(const _Diff _Requested_size) noexcept { // get temporary storage
@@ -619,7 +619,7 @@ _NODISCARD _CONSTEXPR20 pair<_InIt1, _InIt2> mismatch(
         using _CT         = _Common_diff_t<_InIt1, _InIt2>;
         const _CT _Count1 = _ULast1 - _UFirst1;
         const _CT _Count2 = _ULast2 - _UFirst2;
-        const auto _Count = static_cast<_Iter_diff_t<_InIt1>>((_STD min) (_Count1, _Count2));
+        const auto _Count = static_cast<_Iter_diff_t<_InIt1>>((_STD min)(_Count1, _Count2));
         _ULast1           = _UFirst1 + _Count;
         while (_UFirst1 != _ULast1 && _Pred(*_UFirst1, *_UFirst2)) {
             ++_UFirst1;
@@ -1998,7 +1998,7 @@ _NODISCARD _CONSTEXPR20 _FwdIt search_n(
         return _First;
     }
 
-    if (static_cast<uintmax_t>(_Count) > static_cast<uintmax_t>((numeric_limits<_Iter_diff_t<_FwdIt>>::max) ())) {
+    if (static_cast<uintmax_t>(_Count) > static_cast<uintmax_t>((numeric_limits<_Iter_diff_t<_FwdIt>>::max)())) {
         // if the number of _Vals searched for is larger than the longest possible sequence, we can't find it
         return _Last;
     }
@@ -2967,7 +2967,7 @@ namespace ranges {
                     const auto _First2_addr   = _STD to_address(_First2);
                     if constexpr (_Is_sized1 && _Is_sized2) {
                         const size_t _Count =
-                            (_STD min) (static_cast<size_t>(_Last1 - _First1), static_cast<size_t>(_Last2 - _First2));
+                            (_STD min)(static_cast<size_t>(_Last1 - _First1), static_cast<size_t>(_Last2 - _First2));
                         const auto _Last1_addr = _First1_addr + _Count;
                         __std_swap_ranges_trivially_swappable_noalias(_First1_addr, _Last1_addr, _First2_addr);
                         return {_First1 + _Count, _First2 + _Count};
@@ -3551,7 +3551,7 @@ namespace ranges {
         template <class _Ty, output_range<const _Ty&> _Rng>
         constexpr borrowed_iterator_t<_Rng> operator()(_Rng&& _Range, const _Ty& _Value) const {
             auto _First = _RANGES begin(_Range);
-            _Seek_wrapped(_First, (*this) (_Get_unwrapped(_STD move(_First)), _Uend(_Range), _Value));
+            _Seek_wrapped(_First, (*this)(_Get_unwrapped(_STD move(_First)), _Uend(_Range), _Value));
             return _First;
         }
     };
@@ -5537,7 +5537,7 @@ namespace ranges {
             // _Temp_count + 1 since we work on closed ranges
             const auto _Total_count = static_cast<iter_difference_t<_It>>(_Temp_count + 1);
             auto _Result            = _Stable_partition_common_buffered(
-                _STD move(_First), _STD move(_Last), _Pred, _Proj, _Total_count, _Temp_buf._Data, _Temp_buf._Capacity);
+                           _STD move(_First), _STD move(_Last), _Pred, _Proj, _Total_count, _Temp_buf._Data, _Temp_buf._Capacity);
             return {_STD move(_Result.first), _STD move(_Saved_last)};
         }
 
@@ -5617,7 +5617,7 @@ namespace ranges {
                     const auto _Right_count = static_cast<_Diff>(_Count - _Mid_offset);
                     const auto _Remaining   = static_cast<_Diff>(_Right_count - _Right_true_count);
                     const auto _High        = _Stable_partition_common_buffered(
-                        _STD move(_Right), _Last, _Pred, _Proj, _Remaining, _Temp_ptr, _Capacity);
+                               _STD move(_Right), _Last, _Pred, _Proj, _Remaining, _Temp_ptr, _Capacity);
                     _Right = _STD move(_High.first);
                     _Right_true_count += _High.second;
                     break;
@@ -6928,7 +6928,7 @@ void inplace_merge(_BidIt _First, _BidIt _Mid, _BidIt _Last, _Pr _Pred) {
     }
 
     const _Diff _Count2 = _STD distance(_UMid, _ULast);
-    _Optimistic_temporary_buffer<_Iter_value_t<_BidIt>> _Temp_buf{(_STD min) (_Count1, _Count2)};
+    _Optimistic_temporary_buffer<_Iter_value_t<_BidIt>> _Temp_buf{(_STD min)(_Count1, _Count2)};
     _Buffered_inplace_merge_unchecked_impl(
         _UFirst, _UMid, _ULast, _Count1, _Count2, _Temp_buf._Data, _Temp_buf._Capacity, _Pass_fn(_Pred));
 }
@@ -7277,7 +7277,7 @@ namespace ranges {
             }
 
             const iter_difference_t<_It> _Count2 = _RANGES distance(_Mid, _Last);
-            _Optimistic_temporary_buffer<iter_value_t<_It>> _Temp_buf{(_STD min) (_Count1, _Count2)};
+            _Optimistic_temporary_buffer<iter_value_t<_It>> _Temp_buf{(_STD min)(_Count1, _Count2)};
             if (_Count1 <= _Count2 && _Count1 <= _Temp_buf._Capacity) {
                 _RANGES _Inplace_merge_buffer_left(_STD move(_First), _STD move(_Mid), _STD move(_Last),
                     _Temp_buf._Data, _Temp_buf._Capacity, _Pred, _Proj);
@@ -7768,7 +7768,7 @@ void _Uninitialized_chunked_merge_unchecked2(
     while (_Count > _Isort_max<_BidIt>) {
         _Count -= _Isort_max<_BidIt>;
         const _BidIt _Mid1 = _STD next(_First, _Isort_max<_BidIt>);
-        const auto _Chunk2 = (_STD min) (_Isort_max<_BidIt>, _Count);
+        const auto _Chunk2 = (_STD min)(_Isort_max<_BidIt>, _Count);
         _Count -= _Chunk2;
         const _BidIt _Mid2 = _STD next(_Mid1, _Chunk2);
         _Backout._Last     = _Uninitialized_merge_move(_First, _Mid1, _Mid2, _Backout._Last, _Pred);
@@ -7788,7 +7788,7 @@ void _Chunked_merge_unchecked(_BidIt _First, const _BidIt _Last, _OutIt _Dest, c
     while (_Chunk < _Count) {
         _Count -= _Chunk;
         const _BidIt _Mid1 = _STD next(_First, _Chunk);
-        const auto _Chunk2 = (_STD min) (_Chunk, _Count);
+        const auto _Chunk2 = (_STD min)(_Chunk, _Count);
         _Count -= _Chunk2;
         const _BidIt _Mid2 = _STD next(_Mid1, _Chunk2);
         _Dest              = _Merge_move(_First, _Mid1, _Mid2, _Dest, _Pred);
@@ -8042,7 +8042,7 @@ namespace ranges {
             const auto _Backout_end = _Dest + _Count;
             while (_Isort_max<_It> < _Count) {
                 _Count -= _Isort_max<_It>;
-                const auto _Chunk2 = (_STD min) (_Isort_max<_It>, _Count);
+                const auto _Chunk2 = (_STD min)(_Isort_max<_It>, _Count);
                 _Count -= _Chunk2;
 
                 auto _Mid1     = _First + _Isort_max<_It>;
@@ -8138,7 +8138,7 @@ namespace ranges {
 
             while (_Chunk_size < _Count) {
                 _Count -= _Chunk_size;
-                const auto _Right_chunk_size = (_STD min) (_Chunk_size, _Count);
+                const auto _Right_chunk_size = (_STD min)(_Chunk_size, _Count);
                 _Count -= _Right_chunk_size;
 
                 auto _Mid1  = _First + _Chunk_size;
@@ -9579,7 +9579,7 @@ _NODISCARD constexpr _Ty(max)(initializer_list<_Ty> _Ilist, _Pr _Pred) {
 template <class _Ty>
 _NODISCARD constexpr _Ty(max)(initializer_list<_Ty> _Ilist) {
     // return leftmost/largest
-    return (_STD max) (_Ilist, less<>{});
+    return (_STD max)(_Ilist, less<>{});
 }
 
 #ifdef __cpp_lib_concepts
@@ -9655,7 +9655,7 @@ _NODISCARD constexpr _Ty(min)(initializer_list<_Ty> _Ilist, _Pr _Pred) {
 template <class _Ty>
 _NODISCARD constexpr _Ty(min)(initializer_list<_Ty> _Ilist) {
     // return leftmost/smallest
-    return (_STD min) (_Ilist, less<>{});
+    return (_STD min)(_Ilist, less<>{});
 }
 
 #ifdef __cpp_lib_concepts
@@ -10294,7 +10294,7 @@ namespace ranges {
                         _Num2 = SIZE_MAX;
                     }
 
-                    const int _Ans = _Memcmp_count(_First1, _First2, (_STD min) (_Num1, _Num2));
+                    const int _Ans = _Memcmp_count(_First1, _First2, (_STD min)(_Num1, _Num2));
                     return _Memcmp_classification_pred{}(_Ans, 0) || (_Ans == 0 && _Num1 < _Num2);
                 }
             }

--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -1306,13 +1306,7 @@ struct _Atomic_integral<_Ty, 1> : _Atomic_storage<_Ty> { // atomic integral oper
     using _Base = _Atomic_storage<_Ty>;
     using typename _Base::_TVal;
 
-#ifdef __cplusplus_winrt // TRANSITION, VSO-1083296
-    _Atomic_integral() = default;
-    /* implicit */ constexpr _Atomic_integral(conditional_t<is_reference_v<_Ty>, _Ty, const _TVal> _Value) noexcept
-        : _Base(_Value) {}
-#else // ^^^ workaround / no workaround vvv
     using _Base::_Base;
-#endif // ^^^ no workaround ^^^
 
     _TVal fetch_add(const _TVal _Operand, const memory_order _Order = memory_order_seq_cst) noexcept {
         char _Result;
@@ -1370,13 +1364,7 @@ struct _Atomic_integral<_Ty, 2> : _Atomic_storage<_Ty> { // atomic integral oper
     using _Base = _Atomic_storage<_Ty>;
     using typename _Base::_TVal;
 
-#ifdef __cplusplus_winrt // TRANSITION, VSO-1083296
-    _Atomic_integral() = default;
-    /* implicit */ constexpr _Atomic_integral(conditional_t<is_reference_v<_Ty>, _Ty, const _TVal> _Value) noexcept
-        : _Base(_Value) {}
-#else // ^^^ workaround / no workaround vvv
     using _Base::_Base;
-#endif // ^^^ no workaround ^^^
 
     _TVal fetch_add(const _TVal _Operand, const memory_order _Order = memory_order_seq_cst) noexcept {
         short _Result;
@@ -1434,13 +1422,7 @@ struct _Atomic_integral<_Ty, 4> : _Atomic_storage<_Ty> { // atomic integral oper
     using _Base = _Atomic_storage<_Ty>;
     using typename _Base::_TVal;
 
-#ifdef __cplusplus_winrt // TRANSITION, VSO-1083296
-    _Atomic_integral() = default;
-    /* implicit */ constexpr _Atomic_integral(conditional_t<is_reference_v<_Ty>, _Ty, const _TVal> _Value) noexcept
-        : _Base(_Value) {}
-#else // ^^^ workaround / no workaround vvv
     using _Base::_Base;
-#endif // ^^^ no workaround ^^^
 
     _TVal fetch_add(const _TVal _Operand, const memory_order _Order = memory_order_seq_cst) noexcept {
         long _Result;
@@ -1498,13 +1480,7 @@ struct _Atomic_integral<_Ty, 8> : _Atomic_storage<_Ty> { // atomic integral oper
     using _Base = _Atomic_storage<_Ty>;
     using typename _Base::_TVal;
 
-#ifdef __cplusplus_winrt // TRANSITION, VSO-1083296
-    _Atomic_integral() = default;
-    /* implicit */ constexpr _Atomic_integral(conditional_t<is_reference_v<_Ty>, _Ty, const _TVal> _Value) noexcept
-        : _Base(_Value) {}
-#else // ^^^ workaround / no workaround vvv
     using _Base::_Base;
-#endif // ^^^ no workaround ^^^
 
 #ifdef _M_IX86
     _TVal fetch_add(const _TVal _Operand, const memory_order _Order = memory_order_seq_cst) noexcept {
@@ -1637,12 +1613,7 @@ struct _Atomic_integral_facade : _Atomic_integral<_Ty> {
     using _Base           = _Atomic_integral<_Ty>;
     using difference_type = _Ty;
 
-#ifdef __cplusplus_winrt // TRANSITION, VSO-1083296
-    _Atomic_integral_facade() = default;
-    /* implicit */ constexpr _Atomic_integral_facade(const _Ty _Value) noexcept : _Base(_Value) {}
-#else // ^^^ workaround / no workaround vvv
     using _Base::_Base;
-#endif // ^^^ no workaround ^^^
 
     // _Deprecate_non_lock_free_volatile is unnecessary here.
 
@@ -1770,12 +1741,7 @@ struct _Atomic_integral_facade<_Ty&> : _Atomic_integral<_Ty&> {
     using _Base           = _Atomic_integral<_Ty&>;
     using difference_type = _Ty;
 
-#ifdef __cplusplus_winrt // TRANSITION, VSO-1083296
-    _Atomic_integral_facade() = default;
-    /* implicit */ constexpr _Atomic_integral_facade(_Ty& _Value) noexcept : _Base(_Value) {}
-#else // ^^^ workaround / no workaround vvv
     using _Base::_Base;
-#endif // ^^^ no workaround ^^^
 
     _NODISCARD static _Ty _Negate(const _Ty _Value) noexcept { // returns two's complement negated value of _Value
         return static_cast<_Ty>(0U - static_cast<make_unsigned_t<_Ty>>(_Value));
@@ -1865,12 +1831,7 @@ struct _Atomic_floating : _Atomic_storage<_Ty> {
     using _Base           = _Atomic_storage<_Ty>;
     using difference_type = _Ty;
 
-#ifdef __cplusplus_winrt // TRANSITION, VSO-1083296
-    _Atomic_floating() = default;
-    /* implicit */ constexpr _Atomic_floating(const _Ty _Value) noexcept : _Base(_Value) {}
-#else // ^^^ workaround / no workaround vvv
     using _Base::_Base;
-#endif // ^^^ no workaround ^^^
 
     _Ty fetch_add(const _Ty _Operand, const memory_order _Order = memory_order_seq_cst) noexcept {
         _Ty _Temp{this->load(memory_order_relaxed)};
@@ -1924,12 +1885,7 @@ struct _Atomic_floating<_Ty&> : _Atomic_storage<_Ty&> {
     using _Base           = _Atomic_storage<_Ty&>;
     using difference_type = _Ty;
 
-#ifdef __cplusplus_winrt // TRANSITION, VSO-1083296
-    _Atomic_floating() = default;
-    /* implicit */ constexpr _Atomic_floating(_Ty& _Value) noexcept : _Base(_Value) {}
-#else // ^^^ workaround / no workaround vvv
     using _Base::_Base;
-#endif // ^^^ no workaround ^^^
 
     _Ty fetch_add(const _Ty _Operand, const memory_order _Order = memory_order_seq_cst) const noexcept {
         _Ty _Temp{this->load(memory_order_relaxed)};
@@ -1964,12 +1920,7 @@ struct _Atomic_pointer : _Atomic_storage<_Ty> {
     using _Base           = _Atomic_storage<_Ty>;
     using difference_type = ptrdiff_t;
 
-#ifdef __cplusplus_winrt // TRANSITION, VSO-1083296
-    _Atomic_pointer() = default;
-    /* implicit */ constexpr _Atomic_pointer(const _Ty _Value) noexcept : _Base(_Value) {}
-#else // ^^^ workaround / no workaround vvv
     using _Base::_Base;
-#endif // ^^^ no workaround ^^^
 
     _Ty fetch_add(const ptrdiff_t _Diff, const memory_order _Order = memory_order_seq_cst) noexcept {
         const ptrdiff_t _Shift_bytes =
@@ -2066,12 +2017,7 @@ struct _Atomic_pointer<_Ty&> : _Atomic_storage<_Ty&> {
     using _Base           = _Atomic_storage<_Ty&>;
     using difference_type = ptrdiff_t;
 
-#ifdef __cplusplus_winrt // TRANSITION, VSO-1083296
-    _Atomic_pointer() = default;
-    /* implicit */ constexpr _Atomic_pointer(_Ty& _Value) noexcept : _Base(_Value) {}
-#else // ^^^ workaround / no workaround vvv
     using _Base::_Base;
-#endif // ^^^ no workaround ^^^
 
     _Ty fetch_add(const ptrdiff_t _Diff, const memory_order _Order = memory_order_seq_cst) const noexcept {
         const ptrdiff_t _Shift_bytes =
@@ -2152,11 +2098,7 @@ public:
 
     using value_type = _Ty;
 
-#ifdef __cplusplus_winrt // TRANSITION, VSO-1083296
-    /* implicit */ constexpr atomic(const _Ty _Value) noexcept : _Base(_Value) {}
-#else // ^^^ workaround / no workaround vvv
     using _Base::_Base;
-#endif // ^^^ no workaround ^^^
 
     constexpr atomic() noexcept(is_nothrow_default_constructible_v<_Ty>) : _Base() {}
 

--- a/stl/inc/charconv
+++ b/stl/inc/charconv
@@ -794,7 +794,7 @@ _NODISCARD inline bool _Multiply_by_power_of_ten(_Big_integer_flt& _Xval, const 
 
     for (uint32_t _Large_power = _Power / 10; _Large_power != 0;) {
         const uint32_t _Current_power =
-            (_STD min) (_Large_power, static_cast<uint32_t>(_STD size(_Large_power_indices)));
+            (_STD min)(_Large_power, static_cast<uint32_t>(_STD size(_Large_power_indices)));
 
         const _Unpack_index& _Index = _Large_power_indices[_Current_power - 1];
         _Big_integer_flt _Multiplier{};
@@ -1477,8 +1477,8 @@ _NODISCARD errc _Convert_decimal_string_to_floating_type(
     // fractional part. If the exponent is positive, then the integer part consists of the first 'exponent' digits,
     // or all present digits if there are fewer digits. If the exponent is zero or negative, then the integer part
     // is empty. In either case, the remaining digits form the fractional part of the mantissa.
-    const uint32_t _Positive_exponent      = static_cast<uint32_t>((_STD max) (0, _Data._Myexponent));
-    const uint32_t _Integer_digits_present = (_STD min) (_Positive_exponent, _Data._Mymantissa_count);
+    const uint32_t _Positive_exponent      = static_cast<uint32_t>((_STD max)(0, _Data._Myexponent));
+    const uint32_t _Integer_digits_present = (_STD min)(_Positive_exponent, _Data._Mymantissa_count);
     const uint32_t _Integer_digits_missing = _Positive_exponent - _Integer_digits_present;
     const uint8_t* const _Integer_first    = _Data._Mymantissa;
     const uint8_t* const _Integer_last     = _Data._Mymantissa + _Integer_digits_present;
@@ -1737,7 +1737,7 @@ _NODISCARD from_chars_result _Ordinary_floating_from_chars(const char* const _Fi
     // For "03333.111", it is 4.
     // For "00000.111", it is 0.
     // For "00000.001", it is -2.
-    int _Exponent_adjustment = static_cast<int>((_STD min) (_Whole_end - _Leading_zero_end, _Maximum_adjustment));
+    int _Exponent_adjustment = static_cast<int>((_STD min)(_Whole_end - _Leading_zero_end, _Maximum_adjustment));
 
     // [_Whole_end, _Dot_end) will contain 0 or 1 '.' characters
     if (_Next != _Last && *_Next == '.') {
@@ -1753,7 +1753,7 @@ _NODISCARD from_chars_result _Ordinary_floating_from_chars(const char* const _Fi
         for (; _Next != _Last && *_Next == '0'; ++_Next) {
         }
 
-        _Exponent_adjustment = static_cast<int>((_STD max) (_Dot_end - _Next, _Minimum_adjustment));
+        _Exponent_adjustment = static_cast<int>((_STD max)(_Dot_end - _Next, _Minimum_adjustment));
     }
 
     // Scan the fractional part of the mantissa:
@@ -2838,7 +2838,7 @@ _NODISCARD inline to_chars_result _Floating_to_chars_general_precision(
         _Table_end   = _Table_begin + _Precision + 5;
     } else {
         _Table_begin = _Tables::_Ordinary_X_table;
-        _Table_end   = _Table_begin + (_STD min) (_Precision, _Tables::_Max_P) + 5;
+        _Table_end   = _Table_begin + (_STD min)(_Precision, _Tables::_Max_P) + 5;
     }
 
     // Profiling indicates that linear search is faster than binary search for small tables.
@@ -2885,13 +2885,13 @@ _NODISCARD inline to_chars_result _Floating_to_chars_general_precision(
     // Write into the local buffer.
     // Clamping _Effective_precision allows _Buffer to be as small as possible, and increases efficiency.
     if (_Use_fixed_notation) {
-        _Effective_precision = (_STD min) (_Precision - (_Scientific_exponent_X + 1), _Max_fixed_precision);
+        _Effective_precision = (_STD min)(_Precision - (_Scientific_exponent_X + 1), _Max_fixed_precision);
         const to_chars_result _Buf_result =
             _Floating_to_chars_fixed_precision(_Buffer, _STD end(_Buffer), _Value, _Effective_precision);
         _STL_INTERNAL_CHECK(_Buf_result.ec == errc{});
         _Significand_last = _Buf_result.ptr;
     } else {
-        _Effective_precision = (_STD min) (_Precision - 1, _Max_scientific_precision);
+        _Effective_precision = (_STD min)(_Precision - 1, _Max_scientific_precision);
         const to_chars_result _Buf_result =
             _Floating_to_chars_scientific_precision(_Buffer, _STD end(_Buffer), _Value, _Effective_precision);
         _STL_INTERNAL_CHECK(_Buf_result.ec == errc{});

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -70,7 +70,7 @@ namespace chrono {
 
         _NODISCARD static constexpr _Rep(max)() noexcept {
             // get largest value
-            return (numeric_limits<_Rep>::max) ();
+            return (numeric_limits<_Rep>::max)();
         }
     };
 
@@ -198,12 +198,12 @@ namespace chrono {
 
         _NODISCARD static constexpr duration(min)() noexcept {
             // get minimum value
-            return duration((duration_values<_Rep>::min) ());
+            return duration((duration_values<_Rep>::min)());
         }
 
         _NODISCARD static constexpr duration(max)() noexcept {
             // get maximum value
-            return duration((duration_values<_Rep>::max) ());
+            return duration((duration_values<_Rep>::max)());
         }
 
     private:
@@ -263,11 +263,11 @@ namespace chrono {
         }
 
         _NODISCARD static constexpr time_point(min)() noexcept {
-            return time_point((_Duration::min) ());
+            return time_point((_Duration::min)());
         }
 
         _NODISCARD static constexpr time_point(max)() noexcept {
-            return time_point((_Duration::max) ());
+            return time_point((_Duration::max)());
         }
 
     private:
@@ -2412,8 +2412,8 @@ namespace chrono {
             return local_time<common_type_t<_Duration, seconds>>{_Sys.time_since_epoch() + _Info.offset};
         }
 
-        static constexpr sys_seconds _Min_seconds{sys_days{(year::min) () / January / 1}};
-        static constexpr sys_seconds _Max_seconds{sys_seconds{sys_days{(year::max) () / December / 32}} - seconds{1}};
+        static constexpr sys_seconds _Min_seconds{sys_days{(year::min)() / January / 1}};
+        static constexpr sys_seconds _Max_seconds{sys_seconds{sys_days{(year::max)() / December / 32}} - seconds{1}};
 
     private:
         template <class _Duration>
@@ -2702,7 +2702,7 @@ namespace chrono {
         // caller knows (_Current_size, 0 on first call) and the _Known_leap_seconds entries.
         constexpr size_t _Pre_2018_count = 27;
         const size_t _Known_post_2018_ls_size =
-            (_STD max) (_Current_size, _STD size(_Known_leap_seconds)) - _Pre_2018_count;
+            (_STD max)(_Current_size, _STD size(_Known_leap_seconds)) - _Pre_2018_count;
 
         size_t _Reg_post_2018_ls_size; // number of post-2018 LSs found in the registry
         unique_ptr<__std_tzdb_leap_info[], _Tzdb_deleter<__std_tzdb_leap_info[]>> _Reg_ls_data{
@@ -4008,7 +4008,7 @@ namespace chrono {
             if constexpr (is_integral_v<_Rep1>) {
                 // Must have _Period1 <= _Period2 and numeric_limits<_Rep1>::max() >= _Period2 / _Period1. For example,
                 // std::days can't represent std::seconds, and duration<int, atto>::max() is ~9.2 seconds.
-                constexpr auto _Max_tick = static_cast<intmax_t>((numeric_limits<make_signed_t<_Rep1>>::max) ());
+                constexpr auto _Max_tick = static_cast<intmax_t>((numeric_limits<make_signed_t<_Rep1>>::max)());
 
                 return ratio_less_equal_v<_Period1, _Period2> //
                     && ratio_greater_equal_v<ratio<_Max_tick, _Period2::num>, ratio_divide<ratio<1>, _Period1>>;
@@ -4652,7 +4652,7 @@ namespace chrono {
                         _Multiplier /= 10;
                         _Subsecond_ += _Digit * _Multiplier;
                     } else {
-                        if (_Second_ > ((numeric_limits<int>::max) () - _Digit) / 10) {
+                        if (_Second_ > ((numeric_limits<int>::max)() - _Digit) / 10) {
                             return ios_base::failbit;
                         }
 
@@ -4893,7 +4893,7 @@ namespace chrono {
                             _Width = static_cast<unsigned int>(_Flag - '0');
                             while (++_FmtFirst != _FmtLast && _Ctype_fac.is(ctype_base::digit, *_FmtFirst)) {
                                 const auto _Digit = static_cast<unsigned int>(_Ctype_fac.narrow(*_FmtFirst) - '0');
-                                if (_Width > ((numeric_limits<unsigned int>::max) () - _Digit) / 10) {
+                                if (_Width > ((numeric_limits<unsigned int>::max)() - _Digit) / 10) {
                                     _State |= ios_base::failbit;
                                     break;
                                 }
@@ -5352,7 +5352,7 @@ public:
             _THROW(format_error("Invalid modifier specification."));
         }
 
-        if (_Type < 0 || _Type > (numeric_limits<signed char>::max) ()) {
+        if (_Type < 0 || _Type > (numeric_limits<signed char>::max)()) {
             _THROW(format_error("Invalid type specification."));
         }
 
@@ -5370,7 +5370,7 @@ private:
     _ParseContext& _Parse_ctx;
 
     _NODISCARD static constexpr int _Verify_dynamic_arg_index_in_range(const size_t _Idx) {
-        if (_Idx > static_cast<size_t>((numeric_limits<int>::max) ())) {
+        if (_Idx > static_cast<size_t>((numeric_limits<int>::max)())) {
             _THROW(format_error("Dynamic width or precision index too large."));
         }
 

--- a/stl/inc/complex
+++ b/stl/inc/complex
@@ -258,7 +258,7 @@ namespace _Math_algorithms {
         }
 
         if (_Xval <= _Ty{-0.5} || _Ty{2.0} <= _Xval) { // naive formula is moderately accurate
-            if (_Xval == (numeric_limits<_Ty>::max) ()) { // avoid overflow
+            if (_Xval == (numeric_limits<_Ty>::max)()) { // avoid overflow
                 return _STD log(_Xval);
             }
 
@@ -371,11 +371,11 @@ public:
     }
 
     static constexpr _Ty _Flt_max() {
-        return (numeric_limits<_Ty>::max) ();
+        return (numeric_limits<_Ty>::max)();
     }
 
     static constexpr _Ty _Flt_norm_min() {
-        return (numeric_limits<_Ty>::min) () > 0 ? (numeric_limits<_Ty>::min) () : 0;
+        return (numeric_limits<_Ty>::min)() > 0 ? (numeric_limits<_Ty>::min)() : 0;
     }
 
     static _Ty _Abs(_Ty _Left) {
@@ -418,7 +418,7 @@ public:
     }
 
     static bool _Signbit(_Ty _Left) {
-        return (_STD signbit) (static_cast<double>(_Left));
+        return (_STD signbit)(static_cast<double>(_Left));
     }
 
     static _Ty _Sinh(_Ty _Left, _Ty _Right) { // return sinh(_Left) * _Right
@@ -508,11 +508,11 @@ public:
     }
 
     static constexpr _Ty _Flt_max() {
-        return (numeric_limits<long double>::max) ();
+        return (numeric_limits<long double>::max)();
     }
 
     static constexpr _Ty _Flt_norm_min() {
-        return (numeric_limits<long double>::min) ();
+        return (numeric_limits<long double>::min)();
     }
 
     static _Ty _Abs(_Ty _Left) {
@@ -561,7 +561,7 @@ public:
 
     static bool _Signbit(_Ty _Left) {
         // testing _Left < 0 would be incorrect when _Left is -0.0
-        return (_STD signbit) (_Left);
+        return (_STD signbit)(_Left);
     }
 
     static _Ty _Sinh(_Ty _Left, _Ty _Right) { // return sinh(_Left) * _Right
@@ -651,11 +651,11 @@ public:
     }
 
     static constexpr _Ty _Flt_max() {
-        return (numeric_limits<double>::max) ();
+        return (numeric_limits<double>::max)();
     }
 
     static constexpr _Ty _Flt_norm_min() {
-        return (numeric_limits<double>::min) ();
+        return (numeric_limits<double>::min)();
     }
 
     static _Ty _Abs(_Ty _Left) {
@@ -696,7 +696,7 @@ public:
 
     static bool _Signbit(_Ty _Left) {
         // testing _Left < 0 would be incorrect when _Left is -0.0
-        return (_STD signbit) (_Left);
+        return (_STD signbit)(_Left);
     }
 
     static _Ty _Sinh(_Ty _Left, _Ty _Right) { // return sinh(_Left) * _Right
@@ -789,11 +789,11 @@ public:
     }
 
     static constexpr _Ty _Flt_max() {
-        return (numeric_limits<float>::max) ();
+        return (numeric_limits<float>::max)();
     }
 
     static constexpr _Ty _Flt_norm_min() {
-        return (numeric_limits<float>::min) ();
+        return (numeric_limits<float>::min)();
     }
 
     static _Ty _Abs(_Ty _Left) {
@@ -834,7 +834,7 @@ public:
 
     static bool _Signbit(_Ty _Left) {
         // testing _Left < 0 would be incorrect when _Left is -0.0
-        return (_STD signbit) (_Left);
+        return (_STD signbit)(_Left);
     }
 
     static _Ty _Sinh(_Ty _Left, _Ty _Right) { // return sinh(_Left) * _Right

--- a/stl/inc/deque
+++ b/stl/inc/deque
@@ -998,8 +998,8 @@ public:
     }
 
     _NODISCARD size_type max_size() const noexcept {
-        return (_STD min) (static_cast<size_type>((numeric_limits<difference_type>::max) ()),
-            _Alty_traits::max_size(_Getal()));
+        return (_STD min)(
+            static_cast<size_type>((numeric_limits<difference_type>::max)()), _Alty_traits::max_size(_Getal()));
     }
 
     _NODISCARD bool empty() const noexcept {
@@ -1181,7 +1181,7 @@ public:
         _Orphan_all();
         auto _Myfirst       = _Unchecked_begin();
         const auto _Oldsize = _Mysize();
-        auto _Assign_count  = (_STD min) (_Count, _Oldsize);
+        auto _Assign_count  = (_STD min)(_Count, _Oldsize);
         for (; 0 < _Assign_count; --_Assign_count) {
             *_Myfirst = _Val;
             ++_Myfirst;

--- a/stl/inc/execution
+++ b/stl/inc/execution
@@ -210,7 +210,7 @@ public:
     }
 
     void _Submit_for_chunks(const size_t _Hw_threads, const size_t _Chunks) const noexcept {
-        _Submit((_STD min) (_Hw_threads * _Oversubmission_multiplier, _Chunks));
+        _Submit((_STD min)(_Hw_threads * _Oversubmission_multiplier, _Chunks));
     }
 
 private:
@@ -246,7 +246,7 @@ constexpr size_t _Get_chunked_work_chunk_count(const size_t _Hw_threads, const _
     // get the number of chunks to break work into to parallelize
     const auto _Size_count = static_cast<size_t>(_Count); // no overflow due to forward iterators
     // we assume _Hw_threads * _Oversubscription_multiplier does not overflow
-    return (_STD min) (_Hw_threads * _Oversubscription_multiplier, _Size_count);
+    return (_STD min)(_Hw_threads * _Oversubscription_multiplier, _Size_count);
 }
 
 template <class _Diff>
@@ -802,7 +802,7 @@ struct _Static_partition_team { // common data for all static partitioned ops
 
     _Diff _Get_chunk_offset(const size_t _This_chunk) const {
         const auto _This_chunk_diff = static_cast<_Diff>(_This_chunk);
-        return _This_chunk_diff * _Chunk_size + (_STD min) (_This_chunk_diff, _Unchunked_items);
+        return _This_chunk_diff * _Chunk_size + (_STD min)(_This_chunk_diff, _Unchunked_items);
     }
 
     _Static_partition_key<_Diff> _Get_next_key() {
@@ -1020,7 +1020,7 @@ _Common_diff_t<_InIt1, _InIt2> _Distance_min(_InIt1 _First1, const _InIt1 _Last1
     if constexpr (_Is_random_iter_v<_InIt1> && _Is_random_iter_v<_InIt2>) {
         const _CT _Count1 = _Last1 - _First1;
         const _CT _Count2 = _Last2 - _First2;
-        _Result           = (_STD min) (_Count1, _Count2);
+        _Result           = (_STD min)(_Count1, _Count2);
     } else if constexpr (_Is_random_iter_v<_InIt1>) {
         for (auto _Count1 = _Last1 - _First1; 0 < _Count1 && _First2 != _Last2; --_Count1) {
             ++_First2;
@@ -2233,7 +2233,7 @@ _NODISCARD _FwdIt search_n(_ExPo&&, const _FwdIt _First, _FwdIt _Last, const _Di
         return _Last;
     }
 
-    if (static_cast<uintmax_t>(_Count) > static_cast<uintmax_t>((numeric_limits<_Iter_diff_t<_FwdIt>>::max) ())) {
+    if (static_cast<uintmax_t>(_Count) > static_cast<uintmax_t>((numeric_limits<_Iter_diff_t<_FwdIt>>::max)())) {
         // if the number of _Vals searched for is larger than the longest possible sequence, we can't find it
         return _Last;
     }
@@ -2764,7 +2764,7 @@ struct _Static_partitioned_temporary_buffer2 {
     ptrdiff_t _Get_offset(const size_t _Chunk_number) {
         // get the offset of the first element of the temporary buffer allocated to chunk _Chunk_number
         auto _Diff_chunk = static_cast<ptrdiff_t>(_Chunk_number);
-        return _Diff_chunk * _Chunk_size + (_STD min) (_Diff_chunk, _Unchunked_items);
+        return _Diff_chunk * _Chunk_size + (_STD min)(_Diff_chunk, _Unchunked_items);
     }
 
     void _Destroy_all() { // destroy each element of the temporary buffer
@@ -2795,13 +2795,13 @@ inline size_t _Get_stable_sort_tree_height(const size_t _Count, const size_t _Hw
 #else // ^^^ _WIN64 ^^^ // vvv !_WIN64 vvv
     const size_t _Max_tree_height = 30;
 #endif // _WIN64
-    const size_t _Clamped_ideal_chunks = (_STD min) (_Max_tree_height, _Log_ideal_chunks);
+    const size_t _Clamped_ideal_chunks = (_STD min)(_Max_tree_height, _Log_ideal_chunks);
 
     // similarly, if _Clamped_ideal_chunks is odd, that would break our 2 to even power invariant,
     // so go to the next higher power of 2
     const auto _Ideal_tree_height = _Clamped_ideal_chunks + (_Clamped_ideal_chunks & 0x1U);
 
-    return (_STD min) (_Count_max_tree_height, _Ideal_tree_height);
+    return (_STD min)(_Count_max_tree_height, _Ideal_tree_height);
 }
 
 struct _Bottom_up_merge_tree {
@@ -3250,7 +3250,7 @@ struct _Static_partitioned_is_heap_until {
         const auto _Chunk_offset     = _Key._Start_at;
         const auto _Last             = _Chunk_offset + _Chunk_range_size;
 
-        const auto _Initial = (_STD max) (_Chunk_offset, _Diff{1});
+        const auto _Initial = (_STD max)(_Chunk_offset, _Diff{1});
         for (_Diff _Off = _Initial; _Off < _Last; ++_Off) {
             if (_DEBUG_LT_PRED(_Pred, *(_Range_first + ((_Off - 1) >> 1)), *(_Range_first + _Off))) {
                 _Results._Imbue(_Key._Chunk_number, _Range_first + _Off);
@@ -3501,7 +3501,7 @@ struct _Static_partitioned_partition2 {
             const auto _Merge_key   = _Team._Get_chunk_key(_Merge_index);
             const auto _Chunk_trues = _Merge_chunk_data._Chunk_trues;
             _Results                = _Partition_merge(_Results, _Basis._Get_first(_Merge_index, _Merge_key._Start_at),
-                _STD exchange(_Merge_chunk_data._Beginning_of_falses, {}), _Results_falses, _Chunk_trues);
+                               _STD exchange(_Merge_chunk_data._Beginning_of_falses, {}), _Results_falses, _Chunk_trues);
             _Results_falses += _Merge_key._Size - _Chunk_trues;
             _Merge_chunk_data._State.store(_Chunk_state::_Done);
         }
@@ -3760,7 +3760,7 @@ struct _Static_partitioned_set_subtraction {
             const auto _Prev_chunk_sum = _Prev_chunk_lookback_data->_Sum._Ref();
             auto _Chunk_specific_dest  = _Dest + static_cast<_Iter_diff_t<_RanIt3>>(_Prev_chunk_sum);
             const auto _Num_results    = _Set_oper_per_chunk._Update_dest(_Range1_chunk_first, _Range1_chunk_last,
-                _Range2_chunk_first, _Range2_chunk_last, _Chunk_specific_dest, _Pred);
+                   _Range2_chunk_first, _Range2_chunk_last, _Chunk_specific_dest, _Pred);
 
             _Chunk_lookback_data->_Sum._Ref() = static_cast<_Diff>(_Num_results + _Prev_chunk_sum);
             _Chunk_lookback_data->_Store_available_state(_Sum_available);
@@ -3773,7 +3773,7 @@ struct _Static_partitioned_set_subtraction {
 
         // Determine the indices of elements that should be in the result from this chunk.
         const auto _Num_results             = _Set_oper_per_chunk._Mark_indices(_Range1_chunk_first, _Range1_chunk_last,
-            _Range2_chunk_first, _Range2_chunk_last, _Index_chunk_first, _Pred);
+                        _Range2_chunk_first, _Range2_chunk_last, _Index_chunk_first, _Pred);
         _Chunk_lookback_data->_Local._Ref() = _Num_results;
         _Chunk_lookback_data->_Store_available_state(_Local_available);
 
@@ -4168,7 +4168,7 @@ _NODISCARD _Ty transform_reduce(_ExPo&&, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt
                         const auto _Chunk1       = _Operation._Basis1._Get_chunk(_Stolen_key);
                         _Val                     = _STD transform_reduce(_Chunk1._First, _Chunk1._Last,
                                                 _Operation._Basis2._Get_first(
-                                _Chunk_number, _Operation._Team._Get_chunk_offset(_Chunk_number)),
+                                                    _Chunk_number, _Operation._Team._Get_chunk_offset(_Chunk_number)),
                                                 _STD move(_Val), _Pass_fn(_Reduce_op), _Pass_fn(_Transform_op));
                     }
                 } // join with _Work_ptr threads

--- a/stl/inc/execution
+++ b/stl/inc/execution
@@ -3500,8 +3500,9 @@ struct _Static_partitioned_partition2 {
 
             const auto _Merge_key   = _Team._Get_chunk_key(_Merge_index);
             const auto _Chunk_trues = _Merge_chunk_data._Chunk_trues;
-            _Results                = _Partition_merge(_Results, _Basis._Get_first(_Merge_index, _Merge_key._Start_at),
-                               _STD exchange(_Merge_chunk_data._Beginning_of_falses, {}), _Results_falses, _Chunk_trues);
+
+            _Results = _Partition_merge(_Results, _Basis._Get_first(_Merge_index, _Merge_key._Start_at),
+                _STD exchange(_Merge_chunk_data._Beginning_of_falses, {}), _Results_falses, _Chunk_trues);
             _Results_falses += _Merge_key._Size - _Chunk_trues;
             _Merge_chunk_data._State.store(_Chunk_state::_Done);
         }

--- a/stl/inc/experimental/filesystem
+++ b/stl/inc/experimental/filesystem
@@ -2398,7 +2398,7 @@ _NODISCARD inline file_time_type last_write_time(const path& _Path, error_code& 
     _Code.clear();
     if (_Ticks == -1) { // report error
         _Code = make_error_code(errc::operation_not_permitted);
-        return (file_time_type::min) ();
+        return (file_time_type::min)();
     }
     return file_time_type(chrono::system_clock::duration(_Ticks));
 }

--- a/stl/inc/filesystem
+++ b/stl/inc/filesystem
@@ -3881,7 +3881,7 @@ namespace filesystem {
         if (_Error == __std_win_error::_Success) {
             _Result = file_time_type{file_time_type::duration{_Stats._Last_write_time}};
         } else {
-            _Result = (file_time_type::min) ();
+            _Result = (file_time_type::min)();
         }
 
         return _Error;

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -2309,7 +2309,8 @@ _NODISCARD _OutputIt _Write_integral(
 
         if (_Separators > 0) {
             return _Write_separated_integer(_Buffer_start, _End, _Groups,
-                                    _STD use_facet<numpunct<_CharT>>(_Locale._Get()).thousands_sep(), _Separators, _STD move(_Out));
+                                    _STD use_facet<numpunct<_CharT>>(_Locale._Get()).thousands_sep(), //
+                                    _Separators, _STD move(_Out));
         }
         return _RANGES _Copy_unchecked(_Buffer_start, _End, _STD move(_Out)).out;
     };
@@ -2562,8 +2563,9 @@ _NODISCARD _OutputIt _Fmt_write(
 
         if (_Specs._Localized) {
             const auto& _Facet = _STD use_facet<numpunct<_CharT>>(_Locale._Get());
-            _Out               = _Write_separated_integer(
-                              _Buffer_start, _Integral_end, _Groups, _Facet.thousands_sep(), _Separators, _STD move(_Out));
+
+            _Out = _Write_separated_integer(
+                _Buffer_start, _Integral_end, _Groups, _Facet.thousands_sep(), _Separators, _STD move(_Out));
             if (_Radix_point != _Result.ptr || _Append_decimal) {
                 *_Out++         = _Facet.decimal_point();
                 _Append_decimal = false;

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -374,7 +374,7 @@ _NODISCARD constexpr const _CharT* _Parse_nonnegative_integer(
     const _CharT* _First, const _CharT* _Last, unsigned int& _Value) {
     _STL_INTERNAL_CHECK(_First != _Last && '0' <= *_First && *_First <= '9');
 
-    constexpr auto _Max_int = static_cast<unsigned int>((numeric_limits<int>::max) ());
+    constexpr auto _Max_int = static_cast<unsigned int>((numeric_limits<int>::max)());
     constexpr auto _Big_int = _Max_int / 10u;
 
     _Value = 0;
@@ -1134,7 +1134,7 @@ template <class _Handler, class _FormatArg>
 _NODISCARD constexpr int _Get_dynamic_specs(const _FormatArg _Arg) {
     _STL_INTERNAL_STATIC_ASSERT(_Is_any_of_v<_Handler, _Width_checker, _Precision_checker>);
     const unsigned long long _Val = _STD visit_format_arg(_Handler{}, _Arg);
-    if (_Val > static_cast<unsigned long long>((numeric_limits<int>::max) ())) {
+    if (_Val > static_cast<unsigned long long>((numeric_limits<int>::max)())) {
         _THROW(format_error("Number is too big."));
     }
 
@@ -1208,7 +1208,7 @@ private:
     _ParseContext& _Parse_ctx;
 
     _NODISCARD static constexpr int _Verify_dynamic_arg_index_in_range(const size_t _Idx) {
-        if (_Idx > static_cast<size_t>((numeric_limits<int>::max) ())) {
+        if (_Idx > static_cast<size_t>((numeric_limits<int>::max)())) {
             _THROW(format_error("Dynamic width or precision index too large."));
         }
 
@@ -1282,7 +1282,7 @@ public:
 
     template <class _CharT>
     constexpr void _On_type(_CharT _Type) {
-        if (_Type < 0 || _Type > (numeric_limits<signed char>::max) ()) {
+        if (_Type < 0 || _Type > (numeric_limits<signed char>::max)()) {
             _THROW(format_error("Invalid type specification."));
         }
         const char _Narrow_type = static_cast<char>(_Type);
@@ -2309,7 +2309,7 @@ _NODISCARD _OutputIt _Write_integral(
 
         if (_Separators > 0) {
             return _Write_separated_integer(_Buffer_start, _End, _Groups,
-                _STD use_facet<numpunct<_CharT>>(_Locale._Get()).thousands_sep(), _Separators, _STD move(_Out));
+                                    _STD use_facet<numpunct<_CharT>>(_Locale._Get()).thousands_sep(), _Separators, _STD move(_Out));
         }
         return _RANGES _Copy_unchecked(_Buffer_start, _End, _STD move(_Out)).out;
     };
@@ -2461,7 +2461,7 @@ _NODISCARD _OutputIt _Fmt_write(
     auto _Buffer_start = _Buffer;
     auto _Width        = static_cast<int>(_Result.ptr - _Buffer_start);
 
-    const auto _Is_negative = (_STD signbit) (_Value);
+    const auto _Is_negative = (_STD signbit)(_Value);
 
     if (_Is_negative) {
         // Remove the '-', it will be dealt with directly
@@ -2477,7 +2477,7 @@ _NODISCARD _OutputIt _Fmt_write(
         _Exponent = static_cast<char>(_CSTD toupper(_Exponent));
     }
 
-    const auto _Is_finite = (_STD isfinite) (_Value);
+    const auto _Is_finite = (_STD isfinite)(_Value);
 
     auto _Append_decimal   = false;
     auto _Exponent_start   = _Result.ptr;
@@ -2496,7 +2496,7 @@ _NODISCARD _OutputIt _Fmt_write(
                     _Exponent_start = _It;
                 }
             }
-            _Integral_end = (_STD min) (_Radix_point, _Exponent_start);
+            _Integral_end = (_STD min)(_Radix_point, _Exponent_start);
 
             if (_Specs._Alt && _Radix_point == _Result.ptr) {
                 // TRANSITION, decimal point may be wider
@@ -2563,7 +2563,7 @@ _NODISCARD _OutputIt _Fmt_write(
         if (_Specs._Localized) {
             const auto& _Facet = _STD use_facet<numpunct<_CharT>>(_Locale._Get());
             _Out               = _Write_separated_integer(
-                _Buffer_start, _Integral_end, _Groups, _Facet.thousands_sep(), _Separators, _STD move(_Out));
+                              _Buffer_start, _Integral_end, _Groups, _Facet.thousands_sep(), _Separators, _STD move(_Out));
             if (_Radix_point != _Result.ptr || _Append_decimal) {
                 *_Out++         = _Facet.decimal_point();
                 _Append_decimal = false;
@@ -2633,7 +2633,7 @@ _NODISCARD const _CharT* _Measure_string_prefix(const basic_string_view<_CharT> 
     const auto _Last     = _Pos + _Value.size();
     int _Estimated_width = 0; // the estimated width of [_Value.data(), _Pos)
     const _Fmt_codec<_CharT> _Codec;
-    constexpr auto _Max_int = (numeric_limits<int>::max) ();
+    constexpr auto _Max_int = (numeric_limits<int>::max)();
 
     while (_Pos != _Last) {
         if (_Estimated_width == _Max_width && _Max_width >= 0) {

--- a/stl/inc/forward_list
+++ b/stl/inc/forward_list
@@ -866,8 +866,8 @@ public:
     }
 
     _NODISCARD size_type max_size() const noexcept {
-        return (_STD min) (static_cast<size_type>((numeric_limits<difference_type>::max) ()),
-            _Alnode_traits::max_size(_Getal()));
+        return (_STD min)(
+            static_cast<size_type>((numeric_limits<difference_type>::max)()), _Alnode_traits::max_size(_Getal()));
     }
 
     _NODISCARD bool empty() const noexcept {

--- a/stl/inc/fstream
+++ b/stl/inc/fstream
@@ -574,7 +574,7 @@ protected:
             const auto _Start_count = _Count;
             const auto _Available   = static_cast<size_t>(_Mysb::_Gnavail());
             if (0 < _Available) { // copy from get area
-                const auto _Read_size = (_STD min) (_Count_s, _Available);
+                const auto _Read_size = (_STD min)(_Count_s, _Available);
                 _Traits::copy(_Ptr, _Mysb::gptr(), _Read_size);
                 _Ptr += _Read_size;
                 _Count_s -= _Read_size;

--- a/stl/inc/functional
+++ b/stl/inc/functional
@@ -2329,7 +2329,7 @@ void _Build_boyer_moore_delta_2_table(_Iter_diff_t<_RanItPat>* const _Shifts, co
         return;
     }
 
-    if ((numeric_limits<_Diff>::max) () - _Pat_size < _Pat_size) {
+    if ((numeric_limits<_Diff>::max)() - _Pat_size < _Pat_size) {
         _Xlength_error("Boyer-Moore pattern is too long");
     }
 
@@ -2345,7 +2345,7 @@ void _Build_boyer_moore_delta_2_table(_Iter_diff_t<_RanItPat>* const _Shifts, co
     for (size_t _Jx = _Mx; _Jx > 0; --_Jx, --_Tx) {
         _Fx[_Jx - 1] = _Tx;
         while (_Tx <= _Mx && !_Eq(_Pat_first[_Jx - 1], _Pat_first[_Tx - 1])) {
-            _Shifts[_Tx - 1] = (_STD min) (_Shifts[_Tx - 1], static_cast<_Diff>(_Mx - _Jx));
+            _Shifts[_Tx - 1] = (_STD min)(_Shifts[_Tx - 1], static_cast<_Diff>(_Mx - _Jx));
             _Tx              = _Fx[_Tx - 1];
         }
     }
@@ -2365,7 +2365,7 @@ void _Build_boyer_moore_delta_2_table(_Iter_diff_t<_RanItPat>* const _Shifts, co
     size_t _Qx1 = 1;
     while (_Qx < _Mx) {
         for (size_t _Kx = _Qx1; _Kx <= _Qx; ++_Kx) {
-            _Shifts[_Kx - 1] = (_STD min) (_Shifts[_Kx - 1], static_cast<_Diff>(_Mx + _Qx - _Kx));
+            _Shifts[_Kx - 1] = (_STD min)(_Shifts[_Kx - 1], static_cast<_Diff>(_Mx + _Qx - _Kx));
         }
         _Qx1 = _Qx + 1;
 
@@ -2409,7 +2409,7 @@ pair<_RanItHaystack, _RanItHaystack> _Boyer_moore_search(
                 --_Idx;
                 --_UFirst;
             } while (_Eq(*_UFirst, _UPat_first[_Idx]));
-            _Shift = (_STD max) (_Delta1._Lookup(*_UFirst), _Delta2[_Idx]);
+            _Shift = (_STD max)(_Delta1._Lookup(*_UFirst), _Delta2[_Idx]);
         }
     }
 

--- a/stl/inc/istream
+++ b/stl/inc/istream
@@ -206,7 +206,7 @@ private:
 
     template <class = void>
     void _Increment_gcount() {
-        if (_Chcount != (numeric_limits<streamsize>::max) ()) {
+        if (_Chcount != (numeric_limits<streamsize>::max)()) {
             ++_Chcount;
         }
     }
@@ -488,7 +488,7 @@ public:
             _TRY_IO_BEGIN
             for (;;) { // get a metacharacter if more room in buffer
                 int_type _Meta;
-                if (_Count != (numeric_limits<streamsize>::max) () && --_Count < 0) {
+                if (_Count != (numeric_limits<streamsize>::max)() && --_Count < 0) {
                     break; // buffer full, quit
                 } else if (_Traits::eq_int_type(_Traits::eof(),
                                _Meta = _Myios::rdbuf()->sbumpc())) { // end of file, quit

--- a/stl/inc/limits
+++ b/stl/inc/limits
@@ -1076,7 +1076,7 @@ extern int __isa_available;
 template <class _Ty>
 _NODISCARD int _Countr_zero_tzcnt(const _Ty _Val) noexcept {
     constexpr int _Digits = numeric_limits<_Ty>::digits;
-    constexpr _Ty _Max    = (numeric_limits<_Ty>::max) ();
+    constexpr _Ty _Max    = (numeric_limits<_Ty>::max)();
 
     if constexpr (_Digits <= 32) {
         // Intended widening to int. This operation means that a narrow 0 will widen
@@ -1104,7 +1104,7 @@ _NODISCARD int _Countr_zero_tzcnt(const _Ty _Val) noexcept {
 template <class _Ty>
 _NODISCARD int _Countr_zero_bsf(const _Ty _Val) noexcept {
     constexpr int _Digits = numeric_limits<_Ty>::digits;
-    constexpr _Ty _Max    = (numeric_limits<_Ty>::max) ();
+    constexpr _Ty _Max    = (numeric_limits<_Ty>::max)();
 
     unsigned long _Result;
     if constexpr (_Digits <= 32) {

--- a/stl/inc/list
+++ b/stl/inc/list
@@ -1175,8 +1175,8 @@ public:
     }
 
     _NODISCARD size_type max_size() const noexcept {
-        return (_STD min) (static_cast<size_type>((numeric_limits<difference_type>::max) ()),
-            _Alnode_traits::max_size(_Getal()));
+        return (_STD min)(
+            static_cast<size_type>((numeric_limits<difference_type>::max)()), _Alnode_traits::max_size(_Getal()));
     }
 
     _NODISCARD bool empty() const noexcept {

--- a/stl/inc/memory_resource
+++ b/stl/inc/memory_resource
@@ -330,7 +330,7 @@ namespace pmr {
 
         static constexpr bool _Prepare_oversized(size_t& _Bytes, size_t& _Align) noexcept {
             // adjust size and alignment to allow for an _Oversized_header
-            _Align = (_STD max) (_Align, alignof(_Oversized_header));
+            _Align = (_STD max)(_Align, alignof(_Oversized_header));
 
             if (_Bytes > SIZE_MAX - sizeof(_Oversized_header) - alignof(_Oversized_header) + 1) {
                 // no room for header + alignment padding
@@ -527,8 +527,8 @@ namespace pmr {
 
                 // scale _Next_capacity by 2, saturating so that _Size_for_capacity(_Next_capacity) cannot overflow
                 _Next_capacity =
-                    (_STD min) (_Next_capacity << 1, (_STD min) ((PTRDIFF_MAX - sizeof(_Chunk)) >> _Log_of_size,
-                                                         _Pool_resource._Options.max_blocks_per_chunk));
+                    (_STD min)(_Next_capacity << 1, (_STD min)((PTRDIFF_MAX - sizeof(_Chunk)) >> _Log_of_size,
+                                                        _Pool_resource._Options.max_blocks_per_chunk));
             }
         };
 
@@ -555,7 +555,7 @@ namespace pmr {
         pair<pmr::vector<_Pool>::iterator, unsigned char> _Find_pool(
             const size_t _Bytes, const size_t _Align) noexcept {
             // find the pool from which to allocate a block with size _Bytes and alignment _Align
-            const size_t _Size      = (_STD max) (_Bytes + sizeof(void*), _Align);
+            const size_t _Size      = (_STD max)(_Bytes + sizeof(void*), _Align);
             const auto _Log_of_size = static_cast<unsigned char>(_Ceiling_of_log_2(_Size));
             return {_STD lower_bound(_Pools.begin(), _Pools.end(), _Log_of_size,
                         [](const _Pool& _Al, const unsigned char _Log) { return _Al._Log_of_size < _Log; }),
@@ -640,7 +640,7 @@ namespace pmr {
             // unscale _Next_buffer_size so the next allocation will be the same size as the most recent allocation
             // (keep synchronized with monotonic_buffer_resource::_Scale)
             const size_t _Unscaled = (_Next_buffer_size / 3 * 2 + alignof(_Header) - 1) & _Max_allocation;
-            _Next_buffer_size      = (_STD max) (_Unscaled, _Min_allocation);
+            _Next_buffer_size      = (_STD max)(_Unscaled, _Min_allocation);
 
             _Intrusive_stack<_Header> _Tmp{};
             _STD swap(_Tmp, _Chunks);
@@ -722,7 +722,7 @@ namespace pmr {
                 _New_size = (_Bytes + sizeof(_Header) + alignof(_Header) - 1) & _Max_allocation;
             }
 
-            const size_t _New_align = (_STD max) (alignof(_Header), _Align);
+            const size_t _New_align = (_STD max)(alignof(_Header), _Align);
 
             void* _New_buffer = _Resource->allocate(_New_size, _New_align);
             _Check_alignment(_New_buffer, _New_align);

--- a/stl/inc/numeric
+++ b/stl/inc/numeric
@@ -562,7 +562,7 @@ _NODISCARD constexpr common_type_t<_Mt, _Nt> gcd(const _Mt _Mx, const _Nt _Nx) n
 
     const auto _Mx_trailing_zeroes = static_cast<unsigned long>(_Countr_zero(_Mx_magnitude));
     const auto _Common_factors_of_2 =
-        (_STD min) (_Mx_trailing_zeroes, static_cast<unsigned long>(_Countr_zero(_Nx_magnitude)));
+        (_STD min)(_Mx_trailing_zeroes, static_cast<unsigned long>(_Countr_zero(_Nx_magnitude)));
     _Nx_magnitude >>= _Common_factors_of_2;
     _Mx_magnitude >>= _Mx_trailing_zeroes;
     do {
@@ -614,7 +614,7 @@ _NODISCARD constexpr _Ty midpoint(const _Ty _Val1, const _Ty _Val2) noexcept {
             }
         }
 
-        constexpr _Ty _High_limit = (numeric_limits<_Ty>::max) () / 2;
+        constexpr _Ty _High_limit = (numeric_limits<_Ty>::max)() / 2;
         const auto _Val1_a        = _Float_abs(_Val1);
         const auto _Val2_a        = _Float_abs(_Val2);
         if (_Val1_a <= _High_limit && _Val2_a <= _High_limit) {
@@ -638,7 +638,7 @@ _NODISCARD constexpr _Ty midpoint(const _Ty _Val1, const _Ty _Val2) noexcept {
 
         // In the default rounding mode this less than one ULP difference will always be rounded away, so under
         // /fp:fast we could avoid these tests if we had some means of detecting it in the caller.
-        constexpr _Ty _Low_limit = (numeric_limits<_Ty>::min) () * 2;
+        constexpr _Ty _Low_limit = (numeric_limits<_Ty>::min)() * 2;
         if (_Val1_a < _Low_limit) {
             return _Val1 + _Val2 / 2;
         }

--- a/stl/inc/random
+++ b/stl/inc/random
@@ -104,7 +104,7 @@ basic_istream<_Elem, _Traits>& _Read(
 template <class _Elem, class _Traits, class _Ty>
 basic_istream<_Elem, _Traits>& _In(basic_istream<_Elem, _Traits>& _Is, _Ty& _Dx) { // read from stream
     long double _Vx;
-    _Ty _Max = (numeric_limits<_Ty>::max) ();
+    _Ty _Max = (numeric_limits<_Ty>::max)();
     _Read(_Is, _Vx);
     if (_CSTD fabsl(_Vx) <= _Max) {
         _Dx = static_cast<_Ty>(_Vx);
@@ -245,8 +245,8 @@ _NODISCARD _Real generate_canonical(_Gen& _Gx) { // build a floating-point value
     const size_t _Digits  = static_cast<size_t>(numeric_limits<_Real>::digits);
     const size_t _Minbits = _Digits < _Bits ? _Digits : _Bits;
 
-    const _Real _Gxmin = static_cast<_Real>((_Gx.min) ());
-    const _Real _Gxmax = static_cast<_Real>((_Gx.max) ());
+    const _Real _Gxmin = static_cast<_Real>((_Gx.min)());
+    const _Real _Gxmax = static_cast<_Real>((_Gx.max)());
     const _Real _Rx    = (_Gxmax - _Gxmin) + _Real{1};
 
     const int _Ceil = static_cast<int>(_STD ceil(static_cast<_Real>(_Minbits) / _STD log2(_Rx)));
@@ -1335,11 +1335,11 @@ public:
     }
 
     _NODISCARD result_type(min)() const {
-        return (_Eng.min) ();
+        return (_Eng.min)();
     }
 
     _NODISCARD result_type(max)() const {
-        return (_Eng.max) ();
+        return (_Eng.max)();
     }
 
     _NODISCARD result_type operator()() {
@@ -1413,11 +1413,11 @@ public:
     explicit discard_block_engine(_Seed_seq& _Seq) : _Mybase(_Seq) {}
 
     _NODISCARD static constexpr typename _Engine::result_type(min)() {
-        return (_Engine::min) ();
+        return (_Engine::min)();
     }
 
     _NODISCARD static constexpr typename _Engine::result_type(max)() {
-        return (_Engine::max) ();
+        return (_Engine::max)();
     }
 };
 
@@ -1487,7 +1487,7 @@ public:
 
         for (; _Idx < _Nx0; ++_Idx) { // pack _Wx0-bit values
             for (;;) { // get a small enough value
-                _Val = _Eng() - (_Engine::min) ();
+                _Val = _Eng() - (_Engine::min)();
                 if (_Val <= _Yx0) {
                     break;
                 }
@@ -1498,7 +1498,7 @@ public:
         _Mask = _Mask << 1 | 1;
         for (; _Idx < _Nx; ++_Idx) { // pack _Wx0+1-bit values
             for (;;) { // get a small enough value
-                _Val = _Eng() - (_Engine::min) ();
+                _Val = _Eng() - (_Engine::min)();
                 if (_Val <= _Yx1) {
                     break;
                 }
@@ -1539,7 +1539,7 @@ public:
 private:
     void _Init() { // compute values for operator()
         size_t _Mx = 0;
-        _Eres _Rx  = (_Engine::max) () - (_Engine::min) () + 1;
+        _Eres _Rx  = (_Engine::max)() - (_Engine::min)() + 1;
 
         _Eres _Tmp = _Rx;
         if (_Tmp == 0) { // all bits used, make _Rx finite
@@ -1624,15 +1624,15 @@ public:
     }
 
     _NODISCARD static constexpr result_type(min)() {
-        return (_Engine::min) ();
+        return (_Engine::min)();
     }
 
     _NODISCARD static constexpr result_type(max)() {
-        return (_Engine::max) ();
+        return (_Engine::max)();
     }
 
     _NODISCARD result_type operator()() {
-        size_t _Idx = static_cast<size_t>(static_cast<double>(_Yx - (_Eng.min) ()) * _Scale);
+        size_t _Idx = static_cast<size_t>(static_cast<double>(_Yx - (_Eng.min)()) * _Scale);
 
         _Yx        = _Arr[_Idx];
         _Arr[_Idx] = _Eng();
@@ -1685,7 +1685,7 @@ private:
 
         _Yx = _Eng();
         _Scale =
-            static_cast<double>(_Kx) / (static_cast<double>((_Eng.max) ()) - static_cast<double>((_Eng.min) ()) + 1.0);
+            static_cast<double>(_Kx) / (static_cast<double>((_Eng.max)()) - static_cast<double>((_Eng.min)()) + 1.0);
     }
 
     _Engine _Eng; // the stored engine
@@ -1851,17 +1851,17 @@ public:
     struct param_type : _Mypbase { // parameter package
         using distribution_type = uniform_int_distribution;
 
-        param_type() : _Mypbase(0, (numeric_limits<_Ty>::max) ()) {}
+        param_type() : _Mypbase(0, (numeric_limits<_Ty>::max)()) {}
 
-        explicit param_type(result_type _Min0, result_type _Max0 = (numeric_limits<_Ty>::max) ())
+        explicit param_type(result_type _Min0, result_type _Max0 = (numeric_limits<_Ty>::max)())
             : _Mypbase(_Min0, _Max0) {}
 
         param_type(const _Mypbase& _Right) : _Mypbase(_Right) {}
     };
 
-    uniform_int_distribution() : _Mybase(0, (numeric_limits<_Ty>::max) ()) {}
+    uniform_int_distribution() : _Mybase(0, (numeric_limits<_Ty>::max)()) {}
 
-    explicit uniform_int_distribution(_Ty _Min0, _Ty _Max0 = (numeric_limits<_Ty>::max) ()) : _Mybase(_Min0, _Max0) {}
+    explicit uniform_int_distribution(_Ty _Min0, _Ty _Max0 = (numeric_limits<_Ty>::max)()) : _Mybase(_Min0, _Max0) {}
 
     explicit uniform_int_distribution(const param_type& _Par0) : _Mybase(_Par0) {}
 
@@ -2092,7 +2092,7 @@ public:
     }
 
     _NODISCARD result_type(max)() const { // get largest possible result
-        return (numeric_limits<result_type>::max) ();
+        return (numeric_limits<result_type>::max)();
     }
 
     void reset() {} // clear internal state
@@ -2137,7 +2137,7 @@ private:
     template <class _Engine>
     result_type _Eval(_Engine& _Eng, const param_type& _Par0) const {
         using _Uty = make_unsigned_t<_Ty>;
-        constexpr auto _Ty_max{(numeric_limits<_Ty>::max) ()};
+        constexpr auto _Ty_max{(numeric_limits<_Ty>::max)()};
         const auto _Ty1_max{_Float_upper_bound<_Ty1>(static_cast<_Uty>(_Ty_max))};
 
         _Ty1 _Val;
@@ -2250,7 +2250,7 @@ public:
     }
 
     _NODISCARD result_type(max)() const { // get largest possible result
-        return (numeric_limits<result_type>::max) ();
+        return (numeric_limits<result_type>::max)();
     }
 
     void reset() {} // clear internal state
@@ -2300,7 +2300,7 @@ private:
 
         for (;;) { // generate and reject
             using _Uty = make_unsigned_t<_Ty>;
-            constexpr auto _Ty_max{(numeric_limits<_Ty>::max) ()};
+            constexpr auto _Ty_max{(numeric_limits<_Ty>::max)()};
             const auto _Ty1_max{_Float_upper_bound<_Ty1>(static_cast<_Uty>(_Ty_max))};
 
             _Ty _Res;
@@ -2483,7 +2483,7 @@ private:
             // inequality gives -1+p*t >= -(1-p)^t, so 1 - (1-p)^t <= p*t = mean. For the other bound, 1-(1-p)^t =
             // 1-(1-p)(1-mean/t)^(t-1) <= 1-(1-p)(1-1/t)^(t-1) <= 1-(1-p)/e.
             const _Ty1 _Ub =
-                (_STD min) (_Par0._Mean, _Ty1{3.678794411714423216e-1} * _Par0._Pp + _Ty1{6.32120558828557678e-1});
+                (_STD min)(_Par0._Mean, _Ty1{3.678794411714423216e-1} * _Par0._Pp + _Ty1{6.32120558828557678e-1});
             if (_Rand > _Ub) {
                 _Res = _Ty{0};
             } else {
@@ -2557,7 +2557,7 @@ public:
         }
 
         void _Init(_Ty _Min0, _Ty _Max0) { // set internal state
-            _STL_ASSERT(_Min0 <= _Max0 && (0 <= _Min0 || _Max0 <= _Min0 + (numeric_limits<_Ty>::max) ()),
+            _STL_ASSERT(_Min0 <= _Max0 && (0 <= _Min0 || _Max0 <= _Min0 + (numeric_limits<_Ty>::max)()),
                 "invalid min and max arguments for uniform_real");
             _Min = _Min0;
             _Max = _Max0;
@@ -2961,7 +2961,7 @@ private:
                 // Bad _Sx value! Very small values will overflow log(_Sx) / _Sx.
                 // Generate a new value based on scaling method.
                 const _Ty _Ln2{_Ty{0.69314718055994530941723212145818}};
-                const _Ty _Maxabs{(_STD max) (_STD abs(_Vx1), _STD abs(_Vx2))};
+                const _Ty _Maxabs{(_STD max)(_STD abs(_Vx1), _STD abs(_Vx2))};
                 const int _ExpMax{_STD ilogb(_Maxabs)};
                 _Vx1   = _STD scalbn(_Vx1, -_ExpMax);
                 _Vx2   = _STD scalbn(_Vx2, -_ExpMax);
@@ -4197,7 +4197,7 @@ public:
     }
 
     _NODISCARD result_type(max)() const { // get largest possible result
-        return (numeric_limits<result_type>::max) ();
+        return (numeric_limits<result_type>::max)();
     }
 
     void reset() {} // clear internal state

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -2466,12 +2466,12 @@ namespace ranges {
 
         _NODISCARD constexpr auto size() requires sized_range<_Vw> {
             const auto _Length = _RANGES size(_Range);
-            return (_STD min) (_Length, static_cast<decltype(_Length)>(_Count));
+            return (_STD min)(_Length, static_cast<decltype(_Length)>(_Count));
         }
 
         _NODISCARD constexpr auto size() const requires sized_range<const _Vw> {
             const auto _Length = _RANGES size(_Range);
-            return (_STD min) (_Length, static_cast<decltype(_Length)>(_Count));
+            return (_STD min)(_Length, static_cast<decltype(_Length)>(_Count));
         }
     };
 
@@ -2539,7 +2539,7 @@ namespace ranges {
                     return take_view(_STD forward<_Rng>(_Range), _Count);
                 } else {
                     // it's a "reconstructible range"; return the same kind of range with a restricted extent
-                    _Count            = (_STD min) (_RANGES distance(_Range), _Count);
+                    _Count            = (_STD min)(_RANGES distance(_Range), _Count);
                     const auto _First = _RANGES begin(_Range);
 
                     if constexpr (_Strat == _St::_Reconstruct_span) {
@@ -2797,7 +2797,7 @@ namespace ranges {
             requires (!(_Simple_view<_Vw> && random_access_range<const _Vw> && sized_range<const _Vw>)) {
             // clang-format on
             if constexpr (sized_range<_Vw> && random_access_range<_Vw>) {
-                const auto _Offset = (_STD min) (_RANGES distance(_Range), _Count);
+                const auto _Offset = (_STD min)(_RANGES distance(_Range), _Count);
                 return _RANGES begin(_Range) + _Offset;
             } else {
                 if constexpr (forward_range<_Vw>) {
@@ -2818,7 +2818,7 @@ namespace ranges {
         _NODISCARD constexpr auto begin() const
             requires random_access_range<const _Vw> && sized_range<const _Vw> {
             // clang-format on
-            const auto _Offset = (_STD min) (_RANGES distance(_Range), _Count);
+            const auto _Offset = (_STD min)(_RANGES distance(_Range), _Count);
             return _RANGES begin(_Range) + _Offset;
         }
 
@@ -2909,7 +2909,7 @@ namespace ranges {
                     return drop_view(_STD forward<_Rng>(_Range), _Count);
                 } else {
                     // it's a "reconstructible range"; return the same kind of range with a restricted extent
-                    _Count = (_STD min) (_RANGES distance(_Range), _Count);
+                    _Count = (_STD min)(_RANGES distance(_Range), _Count);
 
                     if constexpr (_Strat == _St::_Reconstruct_span) {
                         return span(_Ubegin(_Range) + _Count, _Uend(_Range));

--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -553,7 +553,7 @@ int _Iter_compare(_FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2, _FwdIt2 _Las
 
 inline bool _Is_word(unsigned char _UCh) {
     // special casing char to avoid branches for std::regex in this path
-    static constexpr bool _Is_word_table[(numeric_limits<unsigned char>::max) () + 1] = {
+    static constexpr bool _Is_word_table[(numeric_limits<unsigned char>::max)() + 1] = {
         //        X0 X1 X2 X3 X4 X5 X6 X7 X8 X9 XA XB XC XD XE XF
         /* 0X */ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         /* 1X */ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -2911,7 +2911,7 @@ void _Builder<_FwdIt, _Elem, _RxTraits>::_Add_named_class(typename _Regex_traits
     bool _Negate) { // add contents of named class to bracket expression
     _Node_class<_Elem, _RxTraits>* _Node = static_cast<_Node_class<_Elem, _RxTraits>*>(_Current);
     _Add_elts(_Node, _Cl, _Negate);
-    if (_Bmp_max < static_cast<unsigned int>((numeric_limits<_Elem>::max) ())) {
+    if (_Bmp_max < static_cast<unsigned int>((numeric_limits<_Elem>::max)())) {
         _Node->_Classes = static_cast<_Regex_traits_base::char_class_type>(_Node->_Classes | _Cl);
     }
 }
@@ -2958,7 +2958,7 @@ void _Builder<_FwdIt, _Elem, _RxTraits>::_Add_equiv(_FwdIt _First, _FwdIt _Last,
             _Node->_Small->_Mark(_Ch);
         }
     }
-    if (_Bmp_max < static_cast<unsigned int>((numeric_limits<_Elem>::max) ())) { // map range
+    if (_Bmp_max < static_cast<unsigned int>((numeric_limits<_Elem>::max)())) { // map range
         _Sequence<_Elem>** _Cur = _STD addressof(_Node->_Equiv);
         _Char_to_elts(_First, _Last, _Diff, _Cur);
     }
@@ -4273,7 +4273,7 @@ bool _Parser<_FwdIt, _Elem, _RxTraits>::_CharacterEscape() { // check for valid 
         return _IdentityEscape();
     }
 
-    if ((numeric_limits<typename _RxTraits::_Uelem>::max) () < static_cast<unsigned int>(_Val)) {
+    if ((numeric_limits<typename _RxTraits::_Uelem>::max)() < static_cast<unsigned int>(_Val)) {
         _Error(regex_constants::error_escape);
     }
 

--- a/stl/inc/spanstream
+++ b/stl/inc/spanstream
@@ -122,7 +122,7 @@ protected:
                 const auto _Baseoff = (_Mode & ios_base::out) && !(_Mode & ios_base::in)
                                         ? static_cast<off_type>(_Mysb::pptr() - _Mysb::pbase())
                                         : static_cast<off_type>(_Buf.size());
-                if (_Off > (numeric_limits<off_type>::max) () - _Baseoff) { // overflow, _Baseoff is always non-negative
+                if (_Off > (numeric_limits<off_type>::max)() - _Baseoff) { // overflow, _Baseoff is always non-negative
                     return pos_type(off_type(-1)); // report failure
                 }
 

--- a/stl/inc/sstream
+++ b/stl/inc/sstream
@@ -135,7 +135,7 @@ public:
             // writable, make string view from write buffer
             const auto _Base = _Mysb::pbase();
             _Result._Ptr     = _Base;
-            _Result._Size    = static_cast<_Mysize_type>((_STD max) (_Mysb::pptr(), _Seekhigh) - _Base);
+            _Result._Size    = static_cast<_Mysize_type>((_STD max)(_Mysb::pptr(), _Seekhigh) - _Base);
             _Result._Res     = static_cast<_Mysize_type>(_Mysb::epptr() - _Base);
         } else if (!(_Mystate & _Noread) && _Mysb::gptr()) {
             // readable, make string view from read buffer
@@ -317,7 +317,7 @@ protected:
             return _Traits::eof();
         }
 
-        const auto _Local_highwater = (_STD max) (_Seekhigh, _Pptr);
+        const auto _Local_highwater = (_STD max)(_Seekhigh, _Pptr);
         if (_Local_highwater <= _Gptr) { // nothing in the put area to take
             return _Traits::eof();
         }

--- a/stl/inc/thread
+++ b/stl/inc/thread
@@ -163,7 +163,7 @@ _NODISCARD auto _To_absolute_time(const chrono::duration<_Rep, _Period>& _Rel_ti
     const auto _Now                      = chrono::steady_clock::now();
     decltype(_Now + _Rel_time) _Abs_time = _Now; // return common type
     if (_Rel_time > _Zero) {
-        constexpr auto _Forever = (chrono::steady_clock::time_point::max) ();
+        constexpr auto _Forever = (chrono::steady_clock::time_point::max)();
         if (_Abs_time < _Forever - _Rel_time) {
             _Abs_time += _Rel_time;
         } else {

--- a/stl/inc/variant
+++ b/stl/inc/variant
@@ -741,8 +741,8 @@ class _Variant_base;
 
 template <size_t _Count>
 using _Variant_index_t = // signed so that conversion of -1 to size_t can cheaply sign extend
-    conditional_t<(_Count < static_cast<size_t>((numeric_limits<signed char>::max) ())), signed char,
-        conditional_t<(_Count < static_cast<size_t>((numeric_limits<short>::max) ())), short, int>>;
+    conditional_t<(_Count < static_cast<size_t>((numeric_limits<signed char>::max)())), signed char,
+        conditional_t<(_Count < static_cast<size_t>((numeric_limits<short>::max)())), short, int>>;
 
 template <class... _Types>
 struct _Variant_construct_visitor { // visitor that constructs the same alternative in a target _Variant_base as is

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -1711,8 +1711,8 @@ public:
     }
 
     _NODISCARD _CONSTEXPR20 size_type max_size() const noexcept {
-        return (_STD min) (static_cast<size_type>((numeric_limits<difference_type>::max) ()),
-            _Alty_traits::max_size(_Getal()));
+        return (_STD min)(
+            static_cast<size_type>((numeric_limits<difference_type>::max)()), _Alty_traits::max_size(_Getal()));
     }
 
     _NODISCARD _CONSTEXPR20 size_type capacity() const noexcept {
@@ -2121,7 +2121,7 @@ _NODISCARD constexpr _Synth_three_way_result<_Ty> operator<=>(
     const vector<_Ty, _Alloc>& _Left, const vector<_Ty, _Alloc>& _Right) {
     if constexpr (is_same_v<_Ty, bool>) {
         // This optimization works because vector<bool> "trims" its underlying storage by zeroing out unused bits.
-        const auto _Min_word_size = (_STD min) (_Left._Myvec.size(), _Right._Myvec.size());
+        const auto _Min_word_size = (_STD min)(_Left._Myvec.size(), _Right._Myvec.size());
         const auto _Left_words    = _Left._Myvec._Unchecked_begin();
         const auto _Right_words   = _Right._Myvec._Unchecked_begin();
 
@@ -2148,7 +2148,7 @@ _NODISCARD _CONSTEXPR20 bool operator<(const vector<_Ty, _Alloc>& _Left, const v
         auto _First = _Left._Myvec._Unchecked_begin();
         auto _Other = _Right._Myvec._Unchecked_begin();
 
-        const auto _Last = _First + (_STD min) (_Left._Myvec.size(), _Right._Myvec.size());
+        const auto _Last = _First + (_STD min)(_Left._Myvec.size(), _Right._Myvec.size());
 
         for (; _First != _Last; ++_First, (void) ++_Other) {
             using _Comp = _Vbase_compare_three_way<signed char>;
@@ -2966,7 +2966,7 @@ public:
     }
 
     _NODISCARD _CONSTEXPR20 size_type max_size() const noexcept {
-        constexpr auto _Diff_max  = static_cast<size_type>((numeric_limits<difference_type>::max) ());
+        constexpr auto _Diff_max  = static_cast<size_type>((numeric_limits<difference_type>::max)());
         const size_type _Ints_max = this->_Myvec.max_size();
         if (_Ints_max > _Diff_max / _VBITS) { // max_size bound by difference_type limits
             return _Diff_max;

--- a/stl/inc/xhash
+++ b/stl/inc/xhash
@@ -265,7 +265,7 @@ struct _Hash_vec {
     }
 
     _NODISCARD size_type max_size() const noexcept {
-        return (_STD min) (static_cast<size_type>((numeric_limits<difference_type>::max) ()),
+        return (_STD min)(static_cast<size_type>((numeric_limits<difference_type>::max)()),
             _Aliter_traits::max_size(_Mypair._Get_first()));
     }
 
@@ -894,13 +894,13 @@ public:
     }
 
     void max_load_factor(float _Newmax) noexcept /* strengthened */ {
-        _STL_ASSERT(!(_CSTD isnan) (_Newmax) && _Newmax > 0, "invalid hash load factor");
+        _STL_ASSERT(!(_CSTD isnan)(_Newmax) && _Newmax > 0, "invalid hash load factor");
         _Max_bucket_size() = _Newmax;
     }
 
     void rehash(size_type _Buckets) { // rebuild table with at least _Buckets buckets
         // don't violate a.bucket_count() >= a.size() / a.max_load_factor() invariant:
-        _Buckets = (_STD max) (_Min_load_factor_buckets(_List.size()), _Buckets);
+        _Buckets = (_STD max)(_Min_load_factor_buckets(_List.size()), _Buckets);
         if (_Buckets <= _Maxidx) { // we already have enough buckets; nothing to do
             return;
         }
@@ -1656,7 +1656,7 @@ protected:
 
     _NODISCARD size_type _Desired_grow_bucket_count(const size_type _For_size) const noexcept {
         const size_type _Old_buckets = bucket_count();
-        const size_type _Req_buckets = (_STD max) (_Min_buckets, _Min_load_factor_buckets(_For_size));
+        const size_type _Req_buckets = (_STD max)(_Min_buckets, _Min_load_factor_buckets(_For_size));
         if (_Old_buckets >= _Req_buckets) {
             // we already have enough buckets so there's no need to change the count
             return _Old_buckets;

--- a/stl/inc/xlocale
+++ b/stl/inc/xlocale
@@ -768,8 +768,8 @@ protected:
         // return p - _First1, for the largest value p in [_First1, _Last1] such that [_First1, p) successfully
         // converts to at most _Count _Elems
         // assumes 1:1 conversion
-        const auto _Dist = static_cast<size_t>((_STD min) (_Last1 - _First1, ptrdiff_t{INT_MAX}));
-        return static_cast<int>((_STD min) (_Count, _Dist));
+        const auto _Dist = static_cast<size_t>((_STD min)(_Last1 - _First1, ptrdiff_t{INT_MAX}));
+        return static_cast<int>((_STD min)(_Count, _Dist));
     }
 };
 
@@ -811,7 +811,7 @@ _NODISCARD int _Codecvt_do_length(
 
         if (_Result != codecvt_base::ok) {
             if (_Result == codecvt_base::noconv) {
-                _First1 += (_STD min) (static_cast<size_t>(_Last1 - _First1), _Count);
+                _First1 += (_STD min)(static_cast<size_t>(_Last1 - _First1), _Count);
             }
 
             break; // error, noconv, or partial
@@ -824,7 +824,7 @@ _NODISCARD int _Codecvt_do_length(
         _First1 = _Mid1;
     }
 
-    return static_cast<int>((_STD min) (_First1 - _Old_first1, ptrdiff_t{INT_MAX}));
+    return static_cast<int>((_STD min)(_First1 - _Old_first1, ptrdiff_t{INT_MAX}));
 }
 
 enum _Codecvt_mode { _Consume_header = 4, _Generate_header = 2 };
@@ -1643,7 +1643,7 @@ protected:
             _First1 = _Peek;
         }
 
-        return static_cast<int>((_STD min) (_First1 - _Old_first1, ptrdiff_t{INT_MAX}));
+        return static_cast<int>((_STD min)(_First1 - _Old_first1, ptrdiff_t{INT_MAX}));
     }
 
     bool __CLR_OR_THIS_CALL do_always_noconv() const noexcept override {
@@ -1885,7 +1885,7 @@ protected:
             _First1 = _Peek;
         }
 
-        return static_cast<int>((_STD min) (_First1 - _Old_first1, ptrdiff_t{INT_MAX}));
+        return static_cast<int>((_STD min)(_First1 - _Old_first1, ptrdiff_t{INT_MAX}));
     }
 
     bool __CLR_OR_THIS_CALL do_always_noconv() const noexcept override {
@@ -2081,7 +2081,7 @@ protected:
             _First1 += _Bytes;
         }
 
-        return static_cast<int>((_STD min) (_First1 - _Old_first1, ptrdiff_t{INT_MAX}));
+        return static_cast<int>((_STD min)(_First1 - _Old_first1, ptrdiff_t{INT_MAX}));
     }
 
     bool __CLR_OR_THIS_CALL do_always_noconv() const noexcept override {
@@ -2282,7 +2282,7 @@ protected:
             _First1 += _Bytes;
         }
 
-        return static_cast<int>((_STD min) (_First1 - _Old_first1, ptrdiff_t{INT_MAX}));
+        return static_cast<int>((_STD min)(_First1 - _Old_first1, ptrdiff_t{INT_MAX}));
     }
 
     bool __CLR_OR_THIS_CALL do_always_noconv() const noexcept override {

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -66,7 +66,7 @@ _NODISCARD constexpr size_t _Get_size_of_n(const size_t _Count) {
 }
 
 template <class _Ty>
-_INLINE_VAR constexpr size_t _New_alignof = (_STD max) (alignof(_Ty),
+_INLINE_VAR constexpr size_t _New_alignof = (_STD max)(alignof(_Ty),
     static_cast<size_t>(__STDCPP_DEFAULT_NEW_ALIGNMENT__) // TRANSITION, VSO-522105
 );
 
@@ -185,7 +185,7 @@ __declspec(allocator) _CONSTEXPR20 void* _Allocate(const size_t _Bytes) {
 #if defined(_M_IX86) || defined(_M_X64)
         if (_Bytes >= _Big_allocation_threshold) {
             // boost the alignment of big allocations to help autovectorization
-            _Passed_align = (_STD max) (_Align, _Big_allocation_alignment);
+            _Passed_align = (_STD max)(_Align, _Big_allocation_alignment);
         }
 #endif // defined(_M_IX86) || defined(_M_X64)
         return _Traits::_Allocate_aligned(_Bytes, _Passed_align);
@@ -204,7 +204,7 @@ _CONSTEXPR20 void _Deallocate(void* _Ptr, const size_t _Bytes) noexcept {
         size_t _Passed_align = _Align;
 #if defined(_M_IX86) || defined(_M_X64)
         if (_Bytes >= _Big_allocation_threshold) { // boost the alignment of big allocations to help autovectorization
-            _Passed_align = (_STD max) (_Align, _Big_allocation_alignment);
+            _Passed_align = (_STD max)(_Align, _Big_allocation_alignment);
         }
 #endif // defined(_M_IX86) || defined(_M_X64)
         ::operator delete (_Ptr, _Bytes, align_val_t{_Passed_align});
@@ -590,7 +590,7 @@ struct _Normal_allocator_traits { // defines traits for allocators
         if constexpr (_Has_max_size<_Alloc>::value) {
             return _Al.max_size();
         } else {
-            return (numeric_limits<size_type>::max) () / sizeof(value_type);
+            return (numeric_limits<size_type>::max)() / sizeof(value_type);
         }
     }
 
@@ -961,7 +961,7 @@ template <class _Size_type>
 _NODISCARD constexpr _Size_type _Convert_size(const size_t _Len) noexcept(is_same_v<_Size_type, size_t>) {
     // convert size_t to _Size_type, avoiding truncation
     if constexpr (!is_same_v<_Size_type, size_t>) {
-        if (_Len > (numeric_limits<_Size_type>::max) ()) {
+        if (_Len > (numeric_limits<_Size_type>::max)()) {
             _Xlength_error("size_t too long for _Size_type");
         }
     }
@@ -1583,7 +1583,7 @@ namespace ranges {
         const auto _ILast_ch    = const_cast<const char*>(reinterpret_cast<const volatile char*>(_ILastPtr));
         const auto _OFirst_ch   = const_cast<char*>(reinterpret_cast<const volatile char*>(_OFirstPtr));
         const auto _OLast_ch    = const_cast<const char*>(reinterpret_cast<const volatile char*>(_OLastPtr));
-        const auto _Count_bytes = static_cast<size_t>((_STD min) (_ILast_ch - _IFirst_ch, _OLast_ch - _OFirst_ch));
+        const auto _Count_bytes = static_cast<size_t>((_STD min)(_ILast_ch - _IFirst_ch, _OLast_ch - _OFirst_ch));
         _CSTD memcpy(_OFirst_ch, _IFirst_ch, _Count_bytes);
         if constexpr (is_pointer_v<_InIt>) {
             _IFirst = reinterpret_cast<_InIt>(_IFirst_ch + _Count_bytes);

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -582,7 +582,7 @@ template <class _Traits>
 constexpr int _Traits_compare(_In_reads_(_Left_size) const _Traits_ptr_t<_Traits> _Left, const size_t _Left_size,
     _In_reads_(_Right_size) const _Traits_ptr_t<_Traits> _Right, const size_t _Right_size) noexcept {
     // compare [_Left, _Left + _Left_size) to [_Right, _Right + _Right_size) using _Traits
-    const int _Ans = _Traits::compare(_Left, _Right, (_STD min) (_Left_size, _Right_size));
+    const int _Ans = _Traits::compare(_Left, _Right, (_STD min)(_Left_size, _Right_size));
 
     if (_Ans != 0) {
         return _Ans;
@@ -653,11 +653,11 @@ constexpr size_t _Traits_rfind(_In_reads_(_Hay_size) const _Traits_ptr_t<_Traits
     const size_t _Needle_size) noexcept {
     // search [_Haystack, _Haystack + _Hay_size) for [_Needle, _Needle + _Needle_size) beginning before _Start_at
     if (_Needle_size == 0) {
-        return (_STD min) (_Start_at, _Hay_size); // empty string always matches
+        return (_STD min)(_Start_at, _Hay_size); // empty string always matches
     }
 
     if (_Needle_size <= _Hay_size) { // room for match, look for it
-        for (auto _Match_try = _Haystack + (_STD min) (_Start_at, _Hay_size - _Needle_size);; --_Match_try) {
+        for (auto _Match_try = _Haystack + (_STD min)(_Start_at, _Hay_size - _Needle_size);; --_Match_try) {
             if (_Traits::eq(*_Match_try, *_Needle) && _Traits::compare(_Match_try, _Needle, _Needle_size) == 0) {
                 return static_cast<size_t>(_Match_try - _Haystack); // found a match
             }
@@ -676,7 +676,7 @@ constexpr size_t _Traits_rfind_ch(_In_reads_(_Hay_size) const _Traits_ptr_t<_Tra
     const size_t _Start_at, const _Traits_ch_t<_Traits> _Ch) noexcept {
     // search [_Haystack, _Haystack + _Hay_size) for _Ch before _Start_at
     if (_Hay_size != 0) { // room for match, look for it
-        for (auto _Match_try = _Haystack + (_STD min) (_Start_at, _Hay_size - 1);; --_Match_try) {
+        for (auto _Match_try = _Haystack + (_STD min)(_Start_at, _Hay_size - 1);; --_Match_try) {
             if (_Traits::eq(*_Match_try, _Ch)) {
                 return static_cast<size_t>(_Match_try - _Haystack); // found a match
             }
@@ -790,7 +790,7 @@ constexpr size_t _Traits_find_last_of(_In_reads_(_Hay_size) const _Traits_ptr_t<
     // in [_Haystack, _Haystack + _Hay_size), look for last of [_Needle, _Needle + _Needle_size), before _Start_at
     // general algorithm
     if (_Needle_size != 0 && _Hay_size != 0) { // worth searching, do it
-        for (auto _Match_try = _Haystack + (_STD min) (_Start_at, _Hay_size - 1);; --_Match_try) {
+        for (auto _Match_try = _Haystack + (_STD min)(_Start_at, _Hay_size - 1);; --_Match_try) {
             if (_Traits::find(_Needle, _Needle_size, *_Match_try)) {
                 return static_cast<size_t>(_Match_try - _Haystack); // found a match
             }
@@ -817,7 +817,7 @@ constexpr size_t _Traits_find_last_of(_In_reads_(_Hay_size) const _Traits_ptr_t<
             return _Traits_find_last_of<_Traits>(_Haystack, _Hay_size, _Start_at, _Needle, _Needle_size, false_type{});
         }
 
-        for (auto _Match_try = _Haystack + (_STD min) (_Start_at, _Hay_size - 1);; --_Match_try) {
+        for (auto _Match_try = _Haystack + (_STD min)(_Start_at, _Hay_size - 1);; --_Match_try) {
             if (_Matches._Match(*_Match_try)) {
                 return static_cast<size_t>(_Match_try - _Haystack); // found a match
             }
@@ -897,7 +897,7 @@ constexpr size_t _Traits_find_last_not_of(_In_reads_(_Hay_size) const _Traits_pt
     // in [_Haystack, _Haystack + _Hay_size), look for none of [_Needle, _Needle + _Needle_size), before _Start_at
     // general algorithm
     if (_Hay_size != 0) { // worth searching, do it
-        for (auto _Match_try = _Haystack + (_STD min) (_Start_at, _Hay_size - 1);; --_Match_try) {
+        for (auto _Match_try = _Haystack + (_STD min)(_Start_at, _Hay_size - 1);; --_Match_try) {
             if (!_Traits::find(_Needle, _Needle_size, *_Match_try)) {
                 return static_cast<size_t>(_Match_try - _Haystack); // found a match
             }
@@ -925,7 +925,7 @@ constexpr size_t _Traits_find_last_not_of(_In_reads_(_Hay_size) const _Traits_pt
                 _Haystack, _Hay_size, _Start_at, _Needle, _Needle_size, false_type{});
         }
 
-        for (auto _Match_try = _Haystack + (_STD min) (_Start_at, _Hay_size - 1);; --_Match_try) {
+        for (auto _Match_try = _Haystack + (_STD min)(_Start_at, _Hay_size - 1);; --_Match_try) {
             if (!_Matches._Match(*_Match_try)) {
                 return static_cast<size_t>(_Match_try - _Haystack); // found a match
             }
@@ -944,7 +944,7 @@ constexpr size_t _Traits_rfind_not_ch(_In_reads_(_Hay_size) const _Traits_ptr_t<
     const size_t _Hay_size, const size_t _Start_at, const _Traits_ch_t<_Traits> _Ch) noexcept {
     // search [_Haystack, _Haystack + _Hay_size) for any value other than _Ch before _Start_at
     if (_Hay_size != 0) { // room for match, look for it
-        for (auto _Match_try = _Haystack + (_STD min) (_Start_at, _Hay_size - 1);; --_Match_try) {
+        for (auto _Match_try = _Haystack + (_STD min)(_Start_at, _Hay_size - 1);; --_Match_try) {
             if (!_Traits::eq(*_Match_try, _Ch)) {
                 return static_cast<size_t>(_Match_try - _Haystack); // found a match
             }
@@ -1371,7 +1371,7 @@ public:
     _NODISCARD constexpr size_type max_size() const noexcept {
         // bound to PTRDIFF_MAX to make end() - begin() well defined (also makes room for npos)
         // bound to static_cast<size_t>(-1) / sizeof(_Elem) by address space limits
-        return (_STD min) (static_cast<size_t>(PTRDIFF_MAX), static_cast<size_t>(-1) / sizeof(_Elem));
+        return (_STD min)(static_cast<size_t>(PTRDIFF_MAX), static_cast<size_t>(-1) / sizeof(_Elem));
     }
 
     _NODISCARD constexpr const_reference operator[](const size_type _Off) const noexcept /* strengthened */ {
@@ -1694,7 +1694,7 @@ private:
 
     constexpr size_type _Clamp_suffix_size(const size_type _Off, const size_type _Size) const noexcept {
         // trims _Size to the longest it can be assuming a string at/after _Off
-        return (_STD min) (_Size, _Mysize - _Off);
+        return (_STD min)(_Size, _Mysize - _Off);
     }
 
     [[noreturn]] static void _Xran() {
@@ -2357,7 +2357,7 @@ public:
 
     _CONSTEXPR20 size_type _Clamp_suffix_size(const size_type _Off, const size_type _Size) const noexcept {
         // trims _Size to the longest it can be assuming a string at/after _Off
-        return (_STD min) (_Size, _Mysize - _Off);
+        return (_STD min)(_Size, _Mysize - _Off);
     }
 
     union _Bxty { // storage for small buffer or pointer to larger one
@@ -2665,7 +2665,7 @@ public:
 
         if (_Activate_large_mode) {
             // we should never allocate less than _BUF_SIZE space (_New_size could be small if constant evaluated)
-            const size_type _Requested_size = (_STD max) (_New_size, _BUF_SIZE);
+            const size_type _Requested_size = (_STD max)(_New_size, _BUF_SIZE);
             _New_capacity                   = _Calculate_growth(_Requested_size, _BUF_SIZE - 1, max_size());
             const pointer _Fancyptr         = _Getal().allocate(_New_capacity + 1); // throws
             _Ptr                            = _Unfancy(_Fancyptr);
@@ -2945,7 +2945,7 @@ private:
         }
 
         auto& _Al                     = _Getal();
-        const size_type _New_capacity = (_STD min) (_Right_size | _ALLOC_MASK, max_size());
+        const size_type _New_capacity = (_STD min)(_Right_size | _ALLOC_MASK, max_size());
         const pointer _New_array      = _Al.allocate(_New_capacity + 1); // throws
         _Construct_in_place(_My_data._Bx._Ptr, _New_array);
 
@@ -3802,10 +3802,10 @@ public:
             }
         }
 
-        size_type _Target_capacity = (_STD min) (_My_data._Mysize | _ALLOC_MASK, max_size());
+        size_type _Target_capacity = (_STD min)(_My_data._Mysize | _ALLOC_MASK, max_size());
 #if _HAS_CXX20
         // must allocate at least _BUF_SIZE space
-        _Target_capacity = (_STD max) (_Target_capacity, _BUF_SIZE);
+        _Target_capacity = (_STD max)(_Target_capacity, _BUF_SIZE);
 #endif // _HAS_CXX20
 
         if (_Target_capacity < _My_data._Myres) { // worth shrinking, do it
@@ -3943,8 +3943,8 @@ public:
     _NODISCARD _CONSTEXPR20 size_type max_size() const noexcept {
         const size_type _Alloc_max   = _Alty_traits::max_size(_Getal());
         const size_type _Storage_max = // can always store small string
-            (_STD max) (_Alloc_max, static_cast<size_type>(_BUF_SIZE));
-        return (_STD min) (static_cast<size_type>((numeric_limits<difference_type>::max) ()),
+            (_STD max)(_Alloc_max, static_cast<size_type>(_BUF_SIZE));
+        return (_STD min)(static_cast<size_type>((numeric_limits<difference_type>::max)()),
             _Storage_max - 1 // -1 is for null terminator and/or npos
         );
     }
@@ -4518,7 +4518,7 @@ private:
             return _Max;
         }
 
-        return (_STD max) (_Masked, _Old + _Old / 2);
+        return (_STD max)(_Masked, _Old + _Old / 2);
     }
 
     _NODISCARD _CONSTEXPR20 size_type _Calculate_growth(const size_type _Requested) const noexcept {

--- a/stl/inc/xtree
+++ b/stl/inc/xtree
@@ -1196,8 +1196,8 @@ public:
     }
 
     _NODISCARD size_type max_size() const noexcept {
-        return (_STD min) (static_cast<size_type>((numeric_limits<difference_type>::max) ()),
-            _Alnode_traits::max_size(_Getal()));
+        return (_STD min)(
+            static_cast<size_type>((numeric_limits<difference_type>::max)()), _Alnode_traits::max_size(_Getal()));
     }
 
     _NODISCARD bool empty() const noexcept {

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -4953,7 +4953,7 @@ _NODISCARD _CONSTEXPR20 bool lexicographical_compare(
         {
             const auto _Num1 = static_cast<size_t>(_ULast1 - _UFirst1);
             const auto _Num2 = static_cast<size_t>(_ULast2 - _UFirst2);
-            const int _Ans   = _Memcmp_count(_UFirst1, _UFirst2, (_STD min) (_Num1, _Num2));
+            const int _Ans   = _Memcmp_count(_UFirst1, _UFirst2, (_STD min)(_Num1, _Num2));
             return _Memcmp_pred{}(_Ans, 0) || (_Ans == 0 && _Num1 < _Num2);
         }
     }
@@ -5053,7 +5053,7 @@ _NODISCARD constexpr auto lexicographical_compare_three_way(const _InIt1 _First1
         if (!_STD is_constant_evaluated()) {
             const auto _Num1 = static_cast<size_t>(_ULast1 - _UFirst1);
             const auto _Num2 = static_cast<size_t>(_ULast2 - _UFirst2);
-            const int _Ans   = _Memcmp_count(_UFirst1, _UFirst2, (_STD min) (_Num1, _Num2));
+            const int _Ans   = _Memcmp_count(_UFirst1, _UFirst2, (_STD min)(_Num1, _Num2));
             if (_Ans == 0) {
                 return _Num1 <=> _Num2;
             } else {
@@ -5808,7 +5808,7 @@ namespace ranges {
                 const auto _Count1 = _RANGES distance(_Range1);
                 const auto _Count2 = _RANGES distance(_Range2);
                 auto _UResult      = _Search_sized(_Ubegin(_Range1), _Uend(_Range1), _Count1, _Ubegin(_Range2),
-                    _Uend(_Range2), _Count2, _Pass_fn(_Pred), _Pass_fn(_Proj1), _Pass_fn(_Proj2));
+                         _Uend(_Range2), _Count2, _Pass_fn(_Pred), _Pass_fn(_Proj1), _Pass_fn(_Proj2));
                 return _Rewrap_subrange<borrowed_subrange_t<_Rng1>>(_Range1, _STD move(_UResult));
             } else {
                 auto _UResult = _Search_unsized(_Ubegin(_Range1), _Uend(_Range1), _Ubegin(_Range2), _Uend(_Range2),
@@ -5940,7 +5940,7 @@ public:
     using _Udiff = conditional_t<sizeof(_Ty1) < sizeof(_Ty0), _Ty0, _Ty1>;
 
     explicit _Rng_from_urng(_Urng& _Func) : _Ref(_Func), _Bits(CHAR_BIT * sizeof(_Udiff)), _Bmask(_Udiff(-1)) {
-        for (; (_Urng::max) () - (_Urng::min) () < _Bmask; _Bmask >>= 1) {
+        for (; (_Urng::max)() - (_Urng::min)() < _Bmask; _Bmask >>= 1) {
             --_Bits;
         }
     }
@@ -5984,7 +5984,7 @@ public:
 private:
     _Udiff _Get_bits() { // return a random value within [0, _Bmask]
         for (;;) { // repeat until random value is in range
-            _Udiff _Val = _Ref() - (_Urng::min) ();
+            _Udiff _Val = _Ref() - (_Urng::min)();
 
             if (_Val <= _Bmask) {
                 return _Val;

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -593,12 +593,12 @@
 #elif defined(__EDG__)
 // not attempting to detect __EDG_VERSION__ being less than expected
 #elif defined(__clang__)
-#if __clang_major__ < 12
-#error STL1000: Unexpected compiler version, expected Clang 12.0.0 or newer.
+#if __clang_major__ < 13
+#error STL1000: Unexpected compiler version, expected Clang 13.0.0 or newer.
 #endif // ^^^ old Clang ^^^
 #elif defined(_MSC_VER)
-#if _MSC_VER < 1930 // Coarse-grained, not inspecting _MSC_FULL_VER
-#error STL1001: Unexpected compiler version, expected MSVC 19.30 or newer.
+#if _MSC_VER < 1931 // Coarse-grained, not inspecting _MSC_FULL_VER
+#error STL1001: Unexpected compiler version, expected MSVC 19.31 or newer.
 #endif // ^^^ old MSVC ^^^
 #else // vvv other compilers vvv
 // not attempting to detect other compilers

--- a/stl/src/excptptr.cpp
+++ b/stl/src/excptptr.cpp
@@ -142,7 +142,7 @@ namespace {
 
         // copy the number of parameters in use
         constexpr auto _Max_parameters = static_cast<DWORD>(EXCEPTION_MAXIMUM_PARAMETERS);
-        const auto _In_use             = (_STD min) (_Parameters, _Max_parameters);
+        const auto _In_use             = (_STD min)(_Parameters, _Max_parameters);
         _CSTD memcpy(_Dest.ExceptionInformation, _Src.ExceptionInformation, _In_use * sizeof(ULONG_PTR));
         _CSTD memset(&_Dest.ExceptionInformation[_In_use], 0, (_Max_parameters - _In_use) * sizeof(ULONG_PTR));
     }

--- a/stl/src/tzdb.cpp
+++ b/stl/src/tzdb.cpp
@@ -583,7 +583,7 @@ _NODISCARD __std_tzdb_leap_info* __stdcall __std_tzdb_get_leap_seconds(
         try {
             reg_ls_data = new __std_tzdb_leap_info[ls_size];
             status      = RegQueryValueExW(
-                leap_sec_key, reg_subkey_name, nullptr, nullptr, reinterpret_cast<LPBYTE>(reg_ls_data), &byte_size);
+                     leap_sec_key, reg_subkey_name, nullptr, nullptr, reinterpret_cast<LPBYTE>(reg_ls_data), &byte_size);
             if (status != ERROR_SUCCESS) {
                 *current_reg_ls_size = 0;
             }

--- a/stl/src/tzdb.cpp
+++ b/stl/src/tzdb.cpp
@@ -582,8 +582,9 @@ _NODISCARD __std_tzdb_leap_info* __stdcall __std_tzdb_get_leap_seconds(
     if ((status == ERROR_SUCCESS || status == ERROR_MORE_DATA) && ls_size > prev_reg_ls_size) {
         try {
             reg_ls_data = new __std_tzdb_leap_info[ls_size];
-            status      = RegQueryValueExW(
-                     leap_sec_key, reg_subkey_name, nullptr, nullptr, reinterpret_cast<LPBYTE>(reg_ls_data), &byte_size);
+
+            status = RegQueryValueExW(
+                leap_sec_key, reg_subkey_name, nullptr, nullptr, reinterpret_cast<LPBYTE>(reg_ls_data), &byte_size);
             if (status != ERROR_SUCCESS) {
                 *current_reg_ls_size = 0;
             }

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -655,12 +655,6 @@ std/utilities/memory/util.dynamic.safety/get_pointer_safety.pass.cpp FAIL
 std/utilities/memory/util.dynamic.safety/declare_no_pointers.pass.cpp FAIL
 std/utilities/memory/util.dynamic.safety/declare_reachable.pass.cpp FAIL
 
-# Clang 12 emits a warning-as-error; this has likely been fixed upstream already:
-# error: temporary whose address is used as value of local variable 'it2' will be destroyed at the end of the full-expression [-Werror,-Wdangling]
-std/iterators/predef.iterators/reverse.iterators/reverse.iter.ops/reverse.iter.op-=/difference_type.pass.cpp:1 FAIL
-std/iterators/predef.iterators/reverse.iterators/reverse.iter.ops/reverse.iter.op+=/difference_type.pass.cpp:1 FAIL
-std/iterators/predef.iterators/reverse.iterators/reverse.iter.ops/reverse.iter.op=/reverse_iterator.pass.cpp:1 FAIL
-
 
 # *** LIKELY STL BUGS ***
 # Not yet analyzed, likely STL bugs. Assertions and other runtime failures.

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -655,12 +655,6 @@ utilities\memory\util.dynamic.safety\get_pointer_safety.pass.cpp
 utilities\memory\util.dynamic.safety\declare_no_pointers.pass.cpp
 utilities\memory\util.dynamic.safety\declare_reachable.pass.cpp
 
-# Clang 12 emits a warning-as-error; this has likely been fixed upstream already:
-# error: temporary whose address is used as value of local variable 'it2' will be destroyed at the end of the full-expression [-Werror,-Wdangling]
-iterators\predef.iterators\reverse.iterators\reverse.iter.ops\reverse.iter.op-=\difference_type.pass.cpp
-iterators\predef.iterators\reverse.iterators\reverse.iter.ops\reverse.iter.op+=\difference_type.pass.cpp
-iterators\predef.iterators\reverse.iterators\reverse.iter.ops\reverse.iter.op=\reverse_iterator.pass.cpp
-
 
 # *** LIKELY STL BUGS ***
 # Not yet analyzed, likely STL bugs. Assertions and other runtime failures.

--- a/tests/std/include/range_algorithm_support.hpp
+++ b/tests/std/include/range_algorithm_support.hpp
@@ -1340,7 +1340,7 @@ struct get_nth_fn {
         test::proxy_reference<T, Elem> r) const noexcept requires requires {
         (*this)(r.peek());
     }
-    { return (*this) (r.peek()); }
+    { return (*this)(r.peek()); }
 };
 inline constexpr get_nth_fn<0> get_first;
 inline constexpr get_nth_fn<1> get_second;

--- a/tests/std/tests/Dev11_0579795_inplace_merge_out_of_memory/test.cpp
+++ b/tests/std/tests/Dev11_0579795_inplace_merge_out_of_memory/test.cpp
@@ -186,7 +186,7 @@ void test_stability() {
         const auto partitionPoint         = stable_partition(a.begin(), a.end(), [&](const int_ish& x) {
             ++predCalls;
             return x.value < 50;
-        });
+                });
         const array<int_ish, 100> correct = {
             {20, 13, 29, 28, 17, 44, 48, 26, 47, 43, 20, 19, 35, 42, 39, 18, 33, 26, 40, 16, 27, 11, 16, 28, 21, 30, 21,
                 37, 20, 41, 15, 42, 26, 47, 41, 46, 41, 58, 85, 91, 99, 64, 60, 86, 89, 51, 96, 66, 75, 65, 99, 80, 66,

--- a/tests/std/tests/LWG2597_complex_branch_cut/test.cpp
+++ b/tests/std/tests/LWG2597_complex_branch_cut/test.cpp
@@ -59,7 +59,7 @@ void test() {
     constexpr T pi_2     = T{1.5707963267948966};
     constexpr T two      = T{2};
     constexpr T pi       = T{3.141592653589793};
-    constexpr T huge     = (numeric_limits<T>::max) ();
+    constexpr T huge     = (numeric_limits<T>::max)();
     constexpr T inf      = numeric_limits<T>::infinity();
 
     // arg

--- a/tests/std/tests/P0088R3_variant/test.cpp
+++ b/tests/std/tests/P0088R3_variant/test.cpp
@@ -6872,7 +6872,7 @@ namespace msvc {
                 ASSERT_SAME_TYPE(decltype(cb), const simple_base&);
                 assert(cb.x == 42);
                 auto&& rb = std::visit<simple_base&&>(std::identity{}, std::move(v));
-                ASSERT_SAME_TYPE(decltype(rb), simple_base&&);
+                ASSERT_SAME_TYPE(decltype(rb), simple_base &&);
                 assert(rb.x == 42);
                 auto&& crb = std::visit<const simple_base&&>(std::identity{}, std::move(std::as_const(v)));
                 ASSERT_SAME_TYPE(decltype(crb), const simple_base&&);

--- a/tests/std/tests/P0220R1_optional/test.cpp
+++ b/tests/std/tests/P0220R1_optional/test.cpp
@@ -696,7 +696,9 @@ int run_test()
     {
         optional<B> opt;
         ASSERT_NOT_NOEXCEPT(std::hash<optional<B>>()(opt));
+#ifndef __EDG__ // TRANSITION, DevCom-1633478 / VSO-1460046
         ASSERT_NOT_NOEXCEPT(std::hash<optional<const B>>()(opt));
+#endif // ^^^ no workaround ^^^
     }
 
     {

--- a/tests/std/tests/P0896R4_ranges_alg_minmax/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_minmax/test.cpp
@@ -347,11 +347,11 @@ void test_gh_1893() {
     string high          = "n";
     int projection_count = 0;
     const auto clamped   = ranges::clamp(
-        ref(val), ref(low), ref(high), [](auto x, auto y) { return x < y; },
-        [&projection_count](const auto& x) -> decltype(auto) {
+          ref(val), ref(low), ref(high), [](auto x, auto y) { return x < y; },
+          [&projection_count](const auto& x) -> decltype(auto) {
             ++projection_count;
             return x.get();
-        });
+          });
     (void) clamped;
 #ifdef _DEBUG
     ASSERT(projection_count == 5);

--- a/tests/std/tests/P0980R1_constexpr_strings/test.cpp
+++ b/tests/std/tests/P0980R1_constexpr_strings/test.cpp
@@ -668,7 +668,7 @@ constexpr bool test_interface() {
 
         str insert_initializer_list = get_literal_input<CharType>();
         const auto it_ilist         = insert_initializer_list.insert(insert_initializer_list.begin() + 6,
-            {CharType{'c'}, CharType{'u'}, CharType{'t'}, CharType{'e'}, CharType{' '}});
+                    {CharType{'c'}, CharType{'u'}, CharType{'t'}, CharType{'e'}, CharType{' '}});
         assert(it_ilist == insert_initializer_list.begin() + 6);
         assert(equalRanges(insert_initializer_list, "Hello cute fluffy kittens"sv));
 

--- a/tests/tr1/tests/deque/test.cpp
+++ b/tests/tr1/tests/deque/test.cpp
@@ -258,7 +258,7 @@ void test_main() { // test basic workings of deque definitions
     CHECK_INT(*v0.insert(v0.begin(), 2, 'b'), 'b');
     CHECK_INT(v0.front(), 'b');
     CHECK_INT(*++v0.begin(), 'b');
-    CHECK_INT(*++++v0.begin(), 'a');
+    CHECK_INT(*++ ++v0.begin(), 'a');
     CHECK_INT(*v0.insert(v0.end(), v4.begin(), v4.end()), *v4.begin());
     CHECK_INT(v0.back(), v4.back());
     CHECK_INT(*v0.insert(v0.end(), carr, carr + 3), *carr);

--- a/tests/tr1/tests/forward_list/test.cpp
+++ b/tests/tr1/tests/forward_list/test.cpp
@@ -241,7 +241,7 @@ void test_main() { // test basic workings of forward_list definitions
     CHECK(it == ++v0.begin());
     CHECK_INT(v0.front(), 'b');
     CHECK_INT(*++v0.begin(), 'b');
-    CHECK_INT(*++++v0.begin(), 'a');
+    CHECK_INT(*++ ++v0.begin(), 'a');
     it = v0.insert_after(before_end(v0), v4.begin(), v4.end());
     CHECK(++it == v0.end());
     CHECK_INT(back(v0), back(v4));

--- a/tests/tr1/tests/istream1/test.cpp
+++ b/tests/tr1/tests/istream1/test.cpp
@@ -214,7 +214,7 @@ void test_main() { // test basic workings of istream definitions
     char buf[20];
     STD streampos pos = ins.tellg();
 
-    CHECK(pos != (STD streampos) (-1));
+    CHECK(pos != (STD streampos)(-1));
     CHECK_PTR(&ins.ignore(), &ins);
     CHECK_INT(ins.peek(), 'i');
     CHECK_PTR(&ins.putback('l'), &ins);

--- a/tests/tr1/tests/istream2/test.cpp
+++ b/tests/tr1/tests/istream2/test.cpp
@@ -189,7 +189,7 @@ void test_main() { // test basic workings of istream definitions
     wchar_t buf[20];
     STD wstreampos pos = ins.tellg();
 
-    CHECK(pos != (STD wstreampos) (-1));
+    CHECK(pos != (STD wstreampos)(-1));
     CHECK_PTR(&ins.ignore(), &ins);
     CHECK_INT(ins.peek(), L'i');
     CHECK_PTR(&ins.putback(L'l'), &ins);

--- a/tests/tr1/tests/list/test.cpp
+++ b/tests/tr1/tests/list/test.cpp
@@ -255,7 +255,7 @@ void test_main() { // test basic workings of list definitions
     CHECK_INT(*v0.insert(v0.begin(), 2, 'b'), 'b');
     CHECK_INT(v0.front(), 'b');
     CHECK_INT(*++v0.begin(), 'b');
-    CHECK_INT(*++++v0.begin(), 'a');
+    CHECK_INT(*++ ++v0.begin(), 'a');
     CHECK_INT(*v0.insert(v0.end(), v4.begin(), v4.end()), *v4.begin());
     CHECK_INT(v0.back(), v4.back());
     CHECK_INT(*v0.insert(v0.end(), carr, carr + 3), *carr);

--- a/tests/tr1/tests/memory3/test.cpp
+++ b/tests/tr1/tests/memory3/test.cpp
@@ -354,7 +354,7 @@ void t_allocator_traits() { // test allocator_traits
             Mytraits::deallocate(myal, pch, 1);
         }
 
-        CHECK(Mytraits::max_size(myal) == (STD size_t) (-1));
+        CHECK(Mytraits::max_size(myal) == (STD size_t)(-1));
         CHECK(Mytraits::select_on_container_copy_construction(myal) == myal);
     }
 
@@ -385,7 +385,7 @@ void t_allocator_traits() { // test allocator_traits
         CHECK_INT(*pch, 'x');
         Mytraits::destroy(myal, pch);
         Mytraits::deallocate(myal, pch, 1);
-        CHECK(Mytraits::max_size(myal) == (STD size_t) (-1));
+        CHECK(Mytraits::max_size(myal) == (STD size_t)(-1));
         CHECK(Mytraits::select_on_container_copy_construction(myal) == myal);
     }
 }

--- a/tests/tr1/tests/ostream1/test.cpp
+++ b/tests/tr1/tests/ostream1/test.cpp
@@ -337,7 +337,7 @@ void test_main() { // test basic workings of ostream definitions
     outs.str("");
     outs << "some stuff ";
     STD streampos pos = outs.tellp();
-    CHECK(pos != (STD streampos) (-1));
+    CHECK(pos != (STD streampos)(-1));
     outs << istr.rdbuf();
     CHECK_STR(outs.str().c_str(), "some stuff rest of stream\n");
     CHECK_PTR(&outs.seekp(pos), &outs);

--- a/tests/tr1/tests/ostream2/test.cpp
+++ b/tests/tr1/tests/ostream2/test.cpp
@@ -331,7 +331,7 @@ void test_main() { // test basic workings of ostream definitions
     outs.str(L"");
     outs << L"some stuff ";
     STD wstreampos pos = outs.tellp();
-    CHECK(pos != (STD wstreampos) (-1));
+    CHECK(pos != (STD wstreampos)(-1));
     outs << istr.rdbuf();
     CHECK_WSTR(outs.str().c_str(), L"some stuff rest of stream\n");
     CHECK_PTR(&outs.seekp(pos), &outs);

--- a/tests/tr1/tests/regex1/test.cpp
+++ b/tests/tr1/tests/regex1/test.cpp
@@ -363,7 +363,7 @@ static void test_regex() { // test template basic_regex
     CHECK_INT(r3.mark_count(), 1);
 
     STDString arg(T("((d(e))f)"));
-    MyRgx r4(arg, (MyRgx::flag_type) (MyRgx::icase | MyRgx::extended));
+    MyRgx r4(arg, (MyRgx::flag_type)(MyRgx::icase | MyRgx::extended));
     CHECK_INT(r4.flags(), MyRgx::icase | MyRgx::extended);
     CHECK_INT(r4.mark_count(), 3);
 
@@ -444,7 +444,7 @@ static void test_regex() { // test template basic_regex
 
     {
         STD initializer_list<CHR> init{'(', '(', 'd', '(', 'e', ')', ')', 'f', ')'};
-        MyRgx r11(init, (MyRgx::flag_type) (MyRgx::icase | MyRgx::extended));
+        MyRgx r11(init, (MyRgx::flag_type)(MyRgx::icase | MyRgx::extended));
         CHECK_INT(r11.flags(), MyRgx::icase | MyRgx::extended);
         CHECK_INT(r11.mark_count(), 3);
 

--- a/tests/tr1/tests/scoped_allocator/test.cpp
+++ b/tests/tr1/tests/scoped_allocator/test.cpp
@@ -151,7 +151,7 @@ void t_minimal() { // test against minimal allocator
     myal.destroy(pch);
     myal.deallocate(pch, 1);
 
-    CHECK(myal.max_size() == (STD size_t) (-1));
+    CHECK(myal.max_size() == (STD size_t)(-1));
     CHECK(myal.select_on_container_copy_construction() == myal);
 }
 

--- a/tests/tr1/tests/type_traits5/test.cpp
+++ b/tests/tr1/tests/type_traits5/test.cpp
@@ -192,7 +192,7 @@ static void t_make_signed() { // test make_signed<T> for various types
     CHECK_TYPE(STD make_signed<unsigned long long>::type, long long);
 
     color neg = (color) (-3);
-    CHECK_INT((STD make_signed<color>::type) (neg), neg);
+    CHECK_INT((STD make_signed<color>::type)(neg), neg);
 }
 
 static void t_make_unsigned() { // test make_unsigned<T> for various types
@@ -208,7 +208,7 @@ static void t_make_unsigned() { // test make_unsigned<T> for various types
     CHECK_TYPE(STD make_unsigned<unsigned long long>::type, unsigned long long);
 
     color neg = (color) (-3);
-    CHECK_INT((STD make_unsigned<color>::type) (neg), (unsigned int) (neg));
+    CHECK_INT((STD make_unsigned<color>::type)(neg), (unsigned int) (neg));
 }
 
 static void t_is_signed() { // test is_signed<T> for various types

--- a/tests/tr1/tests/unordered_map/test.cpp
+++ b/tests/tr1/tests/unordered_map/test.cpp
@@ -232,7 +232,7 @@ void test_unordered_map() { // test unordered_map
         CHECK_INT(v10.size(), 3);
         CHECK_INT(v10.count('a'), 1);
 
-        v10.reserve((Mycont::size_type) (static_cast<float>(nbuckets) * v10.max_load_factor() + 0.5));
+        v10.reserve((Mycont::size_type)(static_cast<float>(nbuckets) * v10.max_load_factor() + 0.5));
         CHECK_INT(v10.size(), 3);
         CHECK_INT(v10.count('a'), 1);
     }

--- a/tests/tr1/tests/unordered_set/test.cpp
+++ b/tests/tr1/tests/unordered_set/test.cpp
@@ -212,7 +212,7 @@ void test_unordered_set() { // test unordered_set
         CHECK_INT(v10.size(), 3);
         CHECK_INT(v10.count('a'), 1);
 
-        v10.reserve((Mycont::size_type) (static_cast<float>(nbuckets) * v10.max_load_factor() + 0.5));
+        v10.reserve((Mycont::size_type)(static_cast<float>(nbuckets) * v10.max_load_factor() + 0.5));
         CHECK_INT(v10.size(), 3);
         CHECK_INT(v10.count('a'), 1);
     }

--- a/tests/tr1/tests/vector/test.cpp
+++ b/tests/tr1/tests/vector/test.cpp
@@ -226,7 +226,7 @@ void test_main() { // test basic workings of vector definitions
         CHECK_INT(*v0.insert(v0.begin(), 2, 'b'), 'b');
         CHECK_INT(v0.front(), 'b');
         CHECK_INT(*++(p_it = v0.begin()), 'b');
-        CHECK_INT(*++++(p_it = v0.begin()), 'a');
+        CHECK_INT(*++ ++(p_it = v0.begin()), 'a');
         CHECK_INT(*v0.insert(v0.end(), v4.begin(), v4.end()), *v4.begin());
         CHECK_INT(v0.back(), v4.back());
         CHECK_INT(*v0.insert(v0.end(), carr, carr + 3), *carr);


### PR DESCRIPTION
* Remove Clang workarounds for a `-Wdangling` warning that was fixed in Clang 13, as noted by @CaseyCarter in #2266.
* Add EDG workaround for DevCom-1633478 / VSO-1460046 "EDG rejects `hash<optional<const B>>` called with `optional<B>`".
  + This has already been fixed, so we'll be able to remove this workaround in the near future.
* Remove MSVC workarounds for VSO-1083296 "C++/CX conflicting with new atomic."
* Record default settings for clang-format 13.
  + No behavioral changes.
* clang-format all files, no manual changes.
  + The most common change is an improvement: clang-format no longer emits an extra space when calling parenthesized functions (previously it thought they looked like C-style casts). That was introduced by clang-format 12 in #2064.
* Manually fix too-long lines.
  + They can usually be fixed by adding a newline (preventing `=` alignment). In one case I needed an empty comment `//` to force wrapping.
  + This should probably be reported upstream but I was a bad kitty.
* Require MSVC 19.31 and Clang 13.
  + The internal build now uses MSVC 19.31.
* Update `node-version` in `update-status-chart.yml`.
  + This isn't strictly necessary (I believe it always installs the latest), but is for peace of mind. This contains npm 8.3.0, which supports `overrides`, which we might need in the future.
* Update `README.md` to mention VS 2022 17.1 Preview 2.
* `provision-image.ps1`:
  + Upgrade to PowerShell 7.2.1, Python 3.10.1.
  + Print the Windows version, so we can verify whether Patch Tuesday has been picked up. This looks like: `Microsoft Windows [Version 10.0.22000.434]`
* `create-vmss.ps1`:
  + Avoid verbose output. I finally realized that this script was emitting tons of noise because when we call an Azure PowerShell cmdlet and it returns an object, if we don't assign it to a variable, its contents are printed to the console. We can avoid this by assigning all results to variables. I named them `$IgnoredType` (following their documented types, verified through inspection) in case we ever want to stop ignoring them. One exception: I assigned `New-AzVmss` to the existing `$Vmss` variable (which isn't inspected after this command).
  + Fix 'Creating prototype VM' message. We should pass both `-Activity` and `-Status` like all other calls. (This was using a default "Processing" status.)
  + Use Standard_D32ads_v5. This is the latest generation SKU with temporary storage. (There's been a naming change: `as_v4` had temporary storage. `as_v5` doesn't, while `ads_v5` does.)
* PowerShell: Use single quotes when we don't need expansion.
  + I had cleaned this up long ago in #1153 but had forgotten, so we accumulated more occurrences.
* New pool: StlBuild-2022-01-13-2
  + I ate a whole bowl of ice cream after getting this to work. :ice_cream: