### PR TITLE
Untag dispatch string constructor

### DIFF
--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -2599,7 +2599,7 @@ public:
 
             // initialize from [_First, _Last), input iterators
             _Tidy_deallocate_guard<basic_string> _Guard{this};
-            for (; _UFirst != _UFirst; ++_UFirst) {
+            for (; _UFirst != _ULast; ++_UFirst) {
                 push_back(*_UFirst);
             }
 

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -2585,7 +2585,7 @@ public:
         auto _UFirst      = _Get_unwrapped(_First);
         const auto _ULast = _Get_unwrapped(_Last);
 
-        if constexpr (_Is_random_iter_v<_Iter> && is_pointer_v<decltype(_UFirst)>) {
+        if constexpr (_Is_random_iter_v<_Iter> && is_same_v<remove_const_t<remove_pointer_t<decltype(_UFirst)>>, _Elem>) {
             if (_UFirst != _ULast) {
                 assign(_UFirst, _Convert_size<size_type>(static_cast<size_t>(_ULast - _UFirst)));
             }

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -2585,7 +2585,7 @@ public:
         auto _UFirst      = _Get_unwrapped(_First);
         const auto _ULast = _Get_unwrapped(_Last);
 
-        if constexpr (_Is_random_iter_v<_Iter> && is_same_v<remove_const_t<remove_pointer_t<decltype(_UFirst)>>, _Elem>) {
+        if constexpr (is_same_v<remove_const_t<remove_pointer_t<decltype(_UFirst)>>, _Elem>) {
             if (_UFirst != _ULast) {
                 assign(_UFirst, _Convert_size<size_type>(static_cast<size_t>(_ULast - _UFirst)));
             }

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -2582,41 +2582,31 @@ public:
         _Container_proxy_ptr<_Alty> _Proxy(_Alproxy, _Mypair._Myval2);
         _Tidy_init();
         _Adl_verify_range(_First, _Last);
-        _Construct(_Get_unwrapped(_First), _Get_unwrapped(_Last), _Iter_cat_t<_Iter>{});
+        auto _UFirst      = _Get_unwrapped(_First);
+        const auto _ULast = _Get_unwrapped(_Last);
+
+        if constexpr (_Is_random_iter_v<_Iter>) {
+            if (_First != _Last) {
+                assign(_UFirst, _Convert_size<size_type>(static_cast<size_t>(_ULast - _UFirst)));
+            }
+        } else {
+            if constexpr (_Is_fwd_iter_v<_Iter>) {
+                const auto _Count = _Convert_size<size_type>(static_cast<size_t>(_STD distance(_UFirst, _ULast)));
+                reserve(_Count);
+            } else {
+                static_assert(_Is_input_iter_v<_Iter>, "Should be at least input iterator");
+            }
+
+            // initialize from [_First, _Last), input iterators
+            _Tidy_deallocate_guard<basic_string> _Guard{this};
+            for (; _UFirst != _UFirst; ++_UFirst) {
+                push_back(*_UFirst);
+            }
+
+            _Guard._Target = nullptr;
+        }
+
         _Proxy._Release();
-    }
-
-    template <class _Iter>
-    _CONSTEXPR20 void _Construct(_Iter _First, const _Iter _Last, input_iterator_tag) {
-        // initialize from [_First, _Last), input iterators
-        _Tidy_deallocate_guard<basic_string> _Guard{this};
-        for (; _First != _Last; ++_First) {
-            push_back(*_First);
-        }
-
-        _Guard._Target = nullptr;
-    }
-
-    template <class _Iter>
-    _CONSTEXPR20 void _Construct(const _Iter _First, const _Iter _Last, forward_iterator_tag) {
-        // initialize from [_First, _Last), forward iterators
-        const size_type _Count = _Convert_size<size_type>(static_cast<size_t>(_STD distance(_First, _Last)));
-        reserve(_Count);
-        _Construct(_First, _Last, input_iterator_tag{});
-    }
-
-    _CONSTEXPR20 void _Construct(_Elem* const _First, _Elem* const _Last, random_access_iterator_tag) {
-        // initialize from [_First, _Last), pointers
-        if (_First != _Last) {
-            assign(_First, _Convert_size<size_type>(static_cast<size_t>(_Last - _First)));
-        }
-    }
-
-    _CONSTEXPR20 void _Construct(const _Elem* const _First, const _Elem* const _Last, random_access_iterator_tag) {
-        // initialize from [_First, _Last), const pointers
-        if (_First != _Last) {
-            assign(_First, _Convert_size<size_type>(static_cast<size_t>(_Last - _First)));
-        }
     }
 
     _CONSTEXPR20 basic_string(basic_string&& _Right) noexcept

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -2585,7 +2585,7 @@ public:
         auto _UFirst      = _Get_unwrapped(_First);
         const auto _ULast = _Get_unwrapped(_Last);
 
-        if constexpr (_Is_random_iter_v<_Iter>) {
+        if constexpr (_Is_random_iter_v<_Iter> && is_pointer_v<decltype(_UFirst)) {
             if (_UFirst != _ULast) {
                 assign(_UFirst, _Convert_size<size_type>(static_cast<size_t>(_ULast - _UFirst)));
             }

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -2586,7 +2586,7 @@ public:
         const auto _ULast = _Get_unwrapped(_Last);
 
         if constexpr (_Is_random_iter_v<_Iter>) {
-            if (_First != _Last) {
+            if (_UFirst != _ULast) {
                 assign(_UFirst, _Convert_size<size_type>(static_cast<size_t>(_ULast - _UFirst)));
             }
         } else {

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -2585,7 +2585,7 @@ public:
         auto _UFirst      = _Get_unwrapped(_First);
         const auto _ULast = _Get_unwrapped(_Last);
 
-        if constexpr (_Is_random_iter_v<_Iter> && is_pointer_v<decltype(_UFirst)) {
+        if constexpr (_Is_random_iter_v<_Iter> && is_pointer_v<decltype(_UFirst)>) {
             if (_UFirst != _ULast) {
                 assign(_UFirst, _Convert_size<size_type>(static_cast<size_t>(_ULast - _UFirst)));
             }


### PR DESCRIPTION
Towards #189

It might be worth to:
 * do assign not only for pointers, but for all contiguous iterators
 * apply an optimization similar to #1794 

Currently it isn't done, only pure untag dispatch.