### PR TITLE
Status Chart: Optimize, chart.js 3.7.0, weekly updates

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,5 +11,6 @@
     },
     "files.insertFinalNewline": true,
     "files.trimFinalNewlines": true,
-    "files.trimTrailingWhitespace": true
+    "files.trimTrailingWhitespace": true,
+    "terminal.integrated.cwd": "${workspaceFolder}",
 }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This branch generates the STL's [Status Chart][].
 
 # Getting Started: Repo
 
-1. Install [Node.js][] 17.0.1 or newer.
+1. Install [Node.js][] 17.3.1 or newer.
     + You can accept all of the installer's default options.
 2. Open a new Command Prompt.
     + You can run `node --version` to verify that Node.js was successfully installed.

--- a/index.html
+++ b/index.html
@@ -337,7 +337,7 @@
                         text: 'Bugs, Issues, Skipped Libcxx Tests',
                     },
                     min: 0,
-                    max: 800,
+                    max: 900,
                     ticks: {
                         stepSize: 100,
                     },
@@ -351,7 +351,7 @@
                         text: 'Features, LWG Resolutions, Pull Requests',
                     },
                     min: 0,
-                    max: 80,
+                    max: 90,
                     ticks: {
                         stepSize: 10,
                     },
@@ -379,7 +379,7 @@
                         text: 'Average Age, Average Wait (days)',
                     },
                     min: 0,
-                    max: 400,
+                    max: 450,
                     ticks: {
                         stepSize: 50,
                     },
@@ -393,7 +393,7 @@
                         text: 'Combined Age, Combined Wait (PR-months)',
                     },
                     min: 0,
-                    max: 400,
+                    max: 450,
                     ticks: {
                         stepSize: 50,
                     },

--- a/index.html
+++ b/index.html
@@ -26,8 +26,8 @@
             font-weight: bold;
         }
     </style>
-    <script src="https://cdn.jsdelivr.net/npm/chart.js@3.6.2/dist/chart.min.js"
-        integrity="sha256-D2tkh/3EROq+XuDEmgxOLW1oNxf0rLNlOwsPIUX+co4=" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@3.7.0/dist/chart.min.js"
+        integrity="sha256-Y26AMvaIfrZ1EQU49pf6H4QzVTrOI8m9wQYKkftBt4s=" crossorigin="anonymous"></script>
     <script
         src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns@2.0.0/dist/chartjs-adapter-date-fns.bundle.min.js"
         integrity="sha256-xlxh4PaMDyZ72hWQ7f/37oYI0E2PrBbtzi1yhvnG+/E=" crossorigin="anonymous"></script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,14 +11,14 @@
       "dependencies": {
         "@octokit/graphql": "^4.8.0",
         "@types/cli-progress": "^3.9.2",
-        "@types/luxon": "^2.0.8",
-        "@types/node": "^17.0.0",
-        "@types/yargs": "^17.0.7",
-        "cli-progress": "^3.9.1",
-        "dotenv": "^10.0.0",
-        "luxon": "^2.2.0",
+        "@types/luxon": "^2.0.9",
+        "@types/node": "^17.0.8",
+        "@types/yargs": "^17.0.8",
+        "cli-progress": "^3.10.0",
+        "dotenv": "^12.0.3",
+        "luxon": "^2.3.0",
         "typescript": "^4.5.4",
-        "yargs": "^17.3.0"
+        "yargs": "^17.3.1"
       }
     },
     "node_modules/@octokit/endpoint": {
@@ -86,19 +86,19 @@
       }
     },
     "node_modules/@types/luxon": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-2.0.8.tgz",
-      "integrity": "sha512-lGmxL6hMEVqXr8w9bL52RUWXVu90o7vH8WQSutQssr2e+w0TNttXx2Zfw2V2lHHHWfW6OGqB8bXDvtKocv19qQ=="
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-2.0.9.tgz",
+      "integrity": "sha512-ZuzIc7aN+i2ZDMWIiSmMdubR9EMMSTdEzF6R+FckP4p6xdnOYKqknTo/k+xXQvciSXlNGIwA4OPU5X7JIFzYdA=="
     },
     "node_modules/@types/node": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.0.tgz",
-      "integrity": "sha512-eMhwJXc931Ihh4tkU+Y7GiLzT/y/DBNpNtr4yU9O2w3SYBsr9NaOPhQlLKRmoWtI54uNwuo0IOUFQjVOTZYRvw=="
+      "version": "17.0.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.8.tgz",
+      "integrity": "sha512-YofkM6fGv4gDJq78g4j0mMuGMkZVxZDgtU0JRdx6FgiJDG+0fY0GKVolOV8WqVmEhLCXkQRjwDdKyPxJp/uucg=="
     },
     "node_modules/@types/yargs": {
-      "version": "17.0.7",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.7.tgz",
-      "integrity": "sha512-OvLKmpKdea1aWtqHv9bxVVcMoT6syAeK+198dfETIFkAevYRGwqh4H+KFxfjUETZuUuE5sQCAFwdOdoHUdo8eg==",
+      "version": "17.0.8",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.8.tgz",
+      "integrity": "sha512-wDeUwiUmem9FzsyysEwRukaEdDNcwbROvQ9QGRKaLI6t+IltNzbn4/i4asmB10auvZGQCzSQ6t0GSczEThlUXw==",
       "dependencies": {
         "@types/yargs-parser": "*"
       }
@@ -131,11 +131,10 @@
       }
     },
     "node_modules/cli-progress": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.9.1.tgz",
-      "integrity": "sha512-AXxiCe2a0Lm0VN+9L0jzmfQSkcZm5EYspfqXKaSIQKqIk+0hnkZ3/v1E9B39mkD6vYhKih3c/RPsJBSwq9O99Q==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.10.0.tgz",
+      "integrity": "sha512-kLORQrhYCAtUPLZxqsAt2YJGOvRdt34+O6jl5cQGb7iF3dM55FQZlTR+rQyIK9JUcO9bBMwZsTlND+3dmFU2Cw==",
       "dependencies": {
-        "colors": "^1.1.2",
         "string-width": "^4.2.0"
       },
       "engines": {
@@ -168,25 +167,17 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
-    "node_modules/colors": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-      "engines": {
-        "node": ">=0.1.90"
-      }
-    },
     "node_modules/deprecation": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
       "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
     },
     "node_modules/dotenv": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
-      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-12.0.3.tgz",
+      "integrity": "sha512-RlOysyzyGiABgDFgITo5fRnMV1QStdoVvkXhnxQc5Or/CiQo52s2Bh6DVMvzZsmFQ9IrNxYHOC/gdpNwHsitnQ==",
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/emoji-regex": {
@@ -227,9 +218,9 @@
       }
     },
     "node_modules/luxon": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-2.2.0.tgz",
-      "integrity": "sha512-LwmknessH4jVIseCsizUgveIHwlLv/RQZWC2uDSMfGJs7w8faPUi2JFxfyfMcTPrpNbChTem3Uz6IKRtn+LcIA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-2.3.0.tgz",
+      "integrity": "sha512-gv6jZCV+gGIrVKhO90yrsn8qXPKD8HYZJtrUDSfEbow8Tkw84T9OnCyJhWvnJIaIF/tBuiAjZuQHUt1LddX2mg==",
       "engines": {
         "node": ">=12"
       }
@@ -351,9 +342,9 @@
       }
     },
     "node_modules/yargs": {
-      "version": "17.3.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.0.tgz",
-      "integrity": "sha512-GQl1pWyDoGptFPJx9b9L6kmR33TGusZvXIZUT+BOz9f7X2L94oeAskFYLEg/FkhV06zZPBYLvLZRWeYId29lew==",
+      "version": "17.3.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.1.tgz",
+      "integrity": "sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==",
       "dependencies": {
         "cliui": "^7.0.2",
         "escalade": "^3.1.1",
@@ -442,19 +433,19 @@
       }
     },
     "@types/luxon": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-2.0.8.tgz",
-      "integrity": "sha512-lGmxL6hMEVqXr8w9bL52RUWXVu90o7vH8WQSutQssr2e+w0TNttXx2Zfw2V2lHHHWfW6OGqB8bXDvtKocv19qQ=="
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-2.0.9.tgz",
+      "integrity": "sha512-ZuzIc7aN+i2ZDMWIiSmMdubR9EMMSTdEzF6R+FckP4p6xdnOYKqknTo/k+xXQvciSXlNGIwA4OPU5X7JIFzYdA=="
     },
     "@types/node": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.0.tgz",
-      "integrity": "sha512-eMhwJXc931Ihh4tkU+Y7GiLzT/y/DBNpNtr4yU9O2w3SYBsr9NaOPhQlLKRmoWtI54uNwuo0IOUFQjVOTZYRvw=="
+      "version": "17.0.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.8.tgz",
+      "integrity": "sha512-YofkM6fGv4gDJq78g4j0mMuGMkZVxZDgtU0JRdx6FgiJDG+0fY0GKVolOV8WqVmEhLCXkQRjwDdKyPxJp/uucg=="
     },
     "@types/yargs": {
-      "version": "17.0.7",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.7.tgz",
-      "integrity": "sha512-OvLKmpKdea1aWtqHv9bxVVcMoT6syAeK+198dfETIFkAevYRGwqh4H+KFxfjUETZuUuE5sQCAFwdOdoHUdo8eg==",
+      "version": "17.0.8",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.8.tgz",
+      "integrity": "sha512-wDeUwiUmem9FzsyysEwRukaEdDNcwbROvQ9QGRKaLI6t+IltNzbn4/i4asmB10auvZGQCzSQ6t0GSczEThlUXw==",
       "requires": {
         "@types/yargs-parser": "*"
       }
@@ -478,11 +469,10 @@
       }
     },
     "cli-progress": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.9.1.tgz",
-      "integrity": "sha512-AXxiCe2a0Lm0VN+9L0jzmfQSkcZm5EYspfqXKaSIQKqIk+0hnkZ3/v1E9B39mkD6vYhKih3c/RPsJBSwq9O99Q==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.10.0.tgz",
+      "integrity": "sha512-kLORQrhYCAtUPLZxqsAt2YJGOvRdt34+O6jl5cQGb7iF3dM55FQZlTR+rQyIK9JUcO9bBMwZsTlND+3dmFU2Cw==",
       "requires": {
-        "colors": "^1.1.2",
         "string-width": "^4.2.0"
       }
     },
@@ -509,20 +499,15 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
-    "colors": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
-    },
     "deprecation": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
       "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
     },
     "dotenv": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
-      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-12.0.3.tgz",
+      "integrity": "sha512-RlOysyzyGiABgDFgITo5fRnMV1QStdoVvkXhnxQc5Or/CiQo52s2Bh6DVMvzZsmFQ9IrNxYHOC/gdpNwHsitnQ=="
     },
     "emoji-regex": {
       "version": "8.0.0",
@@ -550,9 +535,9 @@
       "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
     },
     "luxon": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-2.2.0.tgz",
-      "integrity": "sha512-LwmknessH4jVIseCsizUgveIHwlLv/RQZWC2uDSMfGJs7w8faPUi2JFxfyfMcTPrpNbChTem3Uz6IKRtn+LcIA=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-2.3.0.tgz",
+      "integrity": "sha512-gv6jZCV+gGIrVKhO90yrsn8qXPKD8HYZJtrUDSfEbow8Tkw84T9OnCyJhWvnJIaIF/tBuiAjZuQHUt1LddX2mg=="
     },
     "node-fetch": {
       "version": "2.6.6",
@@ -643,9 +628,9 @@
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
     },
     "yargs": {
-      "version": "17.3.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.0.tgz",
-      "integrity": "sha512-GQl1pWyDoGptFPJx9b9L6kmR33TGusZvXIZUT+BOz9f7X2L94oeAskFYLEg/FkhV06zZPBYLvLZRWeYId29lew==",
+      "version": "17.3.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.1.tgz",
+      "integrity": "sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==",
       "requires": {
         "cliui": "^7.0.2",
         "escalade": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -28,13 +28,13 @@
   "dependencies": {
     "@octokit/graphql": "^4.8.0",
     "@types/cli-progress": "^3.9.2",
-    "@types/luxon": "^2.0.8",
-    "@types/node": "^17.0.0",
-    "@types/yargs": "^17.0.7",
-    "cli-progress": "^3.9.1",
-    "dotenv": "^10.0.0",
-    "luxon": "^2.2.0",
+    "@types/luxon": "^2.0.9",
+    "@types/node": "^17.0.8",
+    "@types/yargs": "^17.0.8",
+    "cli-progress": "^3.10.0",
+    "dotenv": "^12.0.3",
+    "luxon": "^2.3.0",
     "typescript": "^4.5.4",
-    "yargs": "^17.3.0"
+    "yargs": "^17.3.1"
   }
 }

--- a/weekly_table.js
+++ b/weekly_table.js
@@ -238,4 +238,8 @@ const weekly_table = [
     { date: '2021-12-03', vso: 174, libcxx: 588 },
     { date: '2021-12-10', vso: 174, libcxx: 588 },
     { date: '2021-12-17', vso: 174, libcxx: 590 },
+    { date: '2021-12-24', vso: 176, libcxx: 590 },
+    { date: '2021-12-31', vso: 177, libcxx: 590 },
+    { date: '2022-01-07', vso: 180, libcxx: 590 },
+    { date: '2022-01-14', vso: 182, libcxx: 590 },
 ];


### PR DESCRIPTION
* `npm install [dependencies]@latest`
  + This removes an indirect dependency on `colors`, a package which has had problems recently.
* chart.js 3.7.0.
  + No visual differences.
* Set terminal.integrated.cwd.
  + This is for personal convenience, so the integrated terminal opens in the workspace folder.
* Update Node.js version.
  + This contains npm 8.3.0 which supports `overrides`, which we might need in the future (not right now though).
* weekly_table.js updates.
* Increase chart limits.
  + Hopefully, as activity picks up after the holidays, we'll be able to keep the lines from rising.
* Optimize gather_stats.ts with events.
  + There's a comment explaining the strategy.
  + To further improve things, I now allow cooked PR/issue nodes to contain `null` for closed/merged dates. This allows us to entirely skip processing events for them. (The previous technique was to fill in imaginary far-future dates.)
    - TypeScript *really* paid off here, making this refactoring easy by detecting all places where `null` had to be handled.
  + We don't need `calculate_wait()` anymore, now that we generate events when PRs are reviewed, updating their "last reviewed" date.
  + Introduce a `sliding_window` constant of 40 days, so we can avoid a magic number later.
  + We can use `map()` and `reduce()` to calculate PR stats. Now, `combined_pr_age` and `combined_pr_wait` use the same logic on different data. (I didn't extract this into a helper function as there were only 2 occurrences.)

As of right now, we have to analyze 1291 PRs and 1144 issues over 863 days. (1291 + 1144) * 863 = 2.1M iterations was taking a noticeable amount of time. The new event-based algorithm speeds up the analysis step by at least **6.4x (times, not percent) from 2.727s to 0.427s**, and because it has lower algorithmic complexity, it will be even more valuable in the future. (That excludes network time by loading saved responses from a JSON file, but includes the time taken to read that file.)

This results in generating the exact same tables. In theory, I suspect that there are potential minor differences in corner cases when events occur on exact day boundaries - I didn't attempt to match the previous behavior with clever use of less-than versus less-equal. I'm totally fine with such potential differences happening in the future as they won't be visually observable - the important thing is that right now, the generated tables won't mysteriously change in large ways.

:chart_with_downwards_trend: Live preview: [stephantlavavej.github.io/STL/](https://stephantlavavej.github.io/STL/)
===