### PR TITLE
<format> use _MSVC_EXECUTION_CHARACTER_SET

### DIFF
--- a/stl/inc/format
+++ b/stl/inc/format
@@ -443,10 +443,7 @@ _NODISCARD constexpr const _CharT* _Parse_arg_id(
 }
 #ifdef __clang__ // TRANSITION: LLVM-52549 (clang-cl 14 will define _MSVC_EXECUTION_CHARACTER_SET)
 _NODISCARD constexpr bool _Is_execution_charset_self_synchronizing() {
-    if (string_view{__clang_literal_encoding__} == "UTF-8") {
-        return true;
-    }
-    return false;
+    return string_view{__clang_literal_encoding__} == "UTF-8"
 }
 #else // ^^^ clang / msvc vvv
 _NODISCARD constexpr bool _Is_execution_charset_self_synchronizing() {

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -441,21 +441,37 @@ _NODISCARD constexpr const _CharT* _Parse_arg_id(
     // This is where we would parse named arg ids if std::format were to support them.
     _THROW(format_error("Invalid format string."));
 }
-
-_NODISCARD constexpr bool _Is_execution_charset_utf8() {
-#pragma warning(push)
-#pragma warning(disable : 4309) // 'initializing' : truncation of constant value
-#pragma warning(disable : 4566) // character represented by universal-character-name '\u4E00' cannot be represented in
-                                // the current code page
-#pragma warning(disable : 6201) // Index '2' is out of valid index range '0' to '1' for possibly stack allocated buffer
-                                // '_Test_char'
-#pragma warning(disable : 6239) // (<non-zero constant> && <expression>) always evaluates to the result of <expression>.
-                                // Did you intend to use the bitwise-and operator?
-    constexpr char _Test_char[] = "\u4e00";
-    return sizeof(_Test_char) == 4 && _Test_char[0] == '\xe4' && _Test_char[1] == '\xb8' && _Test_char[2] == '\x80';
-#pragma warning(pop)
+#ifdef __clang__ // TRANSITION: LLVM-52549 (clang-cl 14 will define _MSVC_EXECUTION_CHARACTER_SET)
+_NODISCARD constexpr bool _Is_execution_charset_self_synchronizing() {
+    if(string_view{__clang_literal_encoding__} == "UTF-8") {
+        return true;
+    }
+    return false;
 }
+#else // ^^^ clang / msvc vvv
+_NODISCARD constexpr bool _Is_execution_charset_self_synchronizing() {
 
+    // charset codes (as reported by _MSVC_EXECUTION_CHARACTER_SET) that are
+    // self-synchronizing (and "narrow" so 1200 (utf-16) and 1201 (unicodeFFFE) are not listed)
+    // we care about this because if a charset is self-synchronizing then we can search through it
+    // for formatting control characters _without_ generally decoding the format string.
+    switch(_MSVC_EXECUTION_CHARACTER_SET) {
+        case 1250: //  ANSI Central European; Central European (Windows)
+        case 1251: //  ANSI Cyrillic; Cyrillic (Windows)
+        case 1252: //  ANSI Latin 1; Western European (Windows)
+        case 1253: //  ANSI Greek; Greek (Windows)
+        case 1254: //  ANSI Turkish; Turkish (Windows)
+        case 1255: //  ANSI Hebrew; Hebrew (Windows)
+        case 1256: //  ANSI Arabic; Arabic (Windows)
+        case 1257: //  ANSI Baltic; Baltic (Windows)
+        case 1258: //  ANSI/OEM Vietnamese; Vietnamese (Windows)
+        case 65001: // Unicode (UTF-8)
+            return true;
+        default:
+            return false;
+    };
+}
+#endif // ^^^ msvc
 inline constexpr char16_t _Width_estimate_low_intervals[] = { // Per N4885 [format.string.std]/11
     0x1100u, 0x1160u, 0x2329u, 0x232Bu, 0x2E80u, 0x303Fu, 0x3040u, 0xA4D0u, 0xAC00u, 0xD7A4u, 0xF900u, 0xFB00u, 0xFE10u,
     0xFE1Au, 0xFE30u, 0xFE70u, 0xFF00u, 0xFF61u, 0xFFE0u, 0xFFE7u};
@@ -476,8 +492,7 @@ _NODISCARD constexpr int _Unicode_width_estimate(const char32_t _Ch) noexcept {
 
     return 1;
 }
-
-template <class _CharT, bool _Statically_Utf8 = _Is_execution_charset_utf8()>
+template <class _CharT, bool _Statically_Utf8 = _Is_execution_charset_self_synchronizing()>
 class _Fmt_codec;
 
 template <bool _Statically_Utf8>
@@ -507,7 +522,11 @@ protected:
 
     _Fmt_codec_base() {
 #ifndef _FORMAT_CODEPAGE
-#define _FORMAT_CODEPAGE __std_code_page::_Acp
+#ifdef __clang__ // TRANSITION, LLVM-52549
+#define _FORMAT_CODEPAGE static_cast<__std_code_page>(65001) // clang only supports utf-8
+#else // ^^^ clang / msvc vvv
+#define _FORMAT_CODEPAGE static_cast<__std_code_page>(_MSVC_EXECUTION_CHARACTER_SET)
+#endif // ^^^ msvc
 #endif // _FORMAT_CODEPAGE
         [[maybe_unused]] const __std_win_error _Result = __std_get_cvt(_FORMAT_CODEPAGE, &_Cvt);
         _STL_INTERNAL_CHECK(_Result == __std_win_error::_Success);
@@ -2930,7 +2949,7 @@ struct _Basic_format_string {
     template <class _Ty>
         requires convertible_to<const _Ty&, basic_string_view<_CharT>>
     consteval _Basic_format_string(const _Ty& _Str_val) : _Str(_Str_val) {
-        if (_Is_execution_charset_utf8()) {
+        if (_Is_execution_charset_self_synchronizing()) {
             _Parse_format_string(_Str, _Format_checker<_CharT, remove_cvref_t<_Args>...>{_Str});
         }
     }

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -374,7 +374,7 @@ _NODISCARD constexpr const _CharT* _Parse_nonnegative_integer(
     const _CharT* _First, const _CharT* _Last, unsigned int& _Value) {
     _STL_INTERNAL_CHECK(_First != _Last && '0' <= *_First && *_First <= '9');
 
-    constexpr auto _Max_int = static_cast<unsigned int>((numeric_limits<int>::max) ());
+    constexpr auto _Max_int = static_cast<unsigned int>((numeric_limits<int>::max)());
     constexpr auto _Big_int = _Max_int / 10u;
 
     _Value = 0;
@@ -443,7 +443,7 @@ _NODISCARD constexpr const _CharT* _Parse_arg_id(
 }
 #ifdef __clang__ // TRANSITION: LLVM-52549 (clang-cl 14 will define _MSVC_EXECUTION_CHARACTER_SET)
 _NODISCARD constexpr bool _Is_execution_charset_self_synchronizing() {
-    if(string_view{__clang_literal_encoding__} == "UTF-8") {
+    if (string_view{__clang_literal_encoding__} == "UTF-8") {
         return true;
     }
     return false;
@@ -455,20 +455,20 @@ _NODISCARD constexpr bool _Is_execution_charset_self_synchronizing() {
     // self-synchronizing (and "narrow" so 1200 (utf-16) and 1201 (unicodeFFFE) are not listed)
     // we care about this because if a charset is self-synchronizing then we can search through it
     // for formatting control characters _without_ generally decoding the format string.
-    switch(_MSVC_EXECUTION_CHARACTER_SET) {
-        case 1250: //  ANSI Central European; Central European (Windows)
-        case 1251: //  ANSI Cyrillic; Cyrillic (Windows)
-        case 1252: //  ANSI Latin 1; Western European (Windows)
-        case 1253: //  ANSI Greek; Greek (Windows)
-        case 1254: //  ANSI Turkish; Turkish (Windows)
-        case 1255: //  ANSI Hebrew; Hebrew (Windows)
-        case 1256: //  ANSI Arabic; Arabic (Windows)
-        case 1257: //  ANSI Baltic; Baltic (Windows)
-        case 1258: //  ANSI/OEM Vietnamese; Vietnamese (Windows)
-        case 65001: // Unicode (UTF-8)
-            return true;
-        default:
-            return false;
+    switch (_MSVC_EXECUTION_CHARACTER_SET) {
+    case 1250: //  ANSI Central European; Central European (Windows)
+    case 1251: //  ANSI Cyrillic; Cyrillic (Windows)
+    case 1252: //  ANSI Latin 1; Western European (Windows)
+    case 1253: //  ANSI Greek; Greek (Windows)
+    case 1254: //  ANSI Turkish; Turkish (Windows)
+    case 1255: //  ANSI Hebrew; Hebrew (Windows)
+    case 1256: //  ANSI Arabic; Arabic (Windows)
+    case 1257: //  ANSI Baltic; Baltic (Windows)
+    case 1258: //  ANSI/OEM Vietnamese; Vietnamese (Windows)
+    case 65001: // Unicode (UTF-8)
+        return true;
+    default:
+        return false;
     };
 }
 #endif // ^^^ msvc
@@ -1155,7 +1155,7 @@ template <class _Handler, class _FormatArg>
 _NODISCARD constexpr int _Get_dynamic_specs(const _FormatArg _Arg) {
     _STL_INTERNAL_STATIC_ASSERT(_Is_any_of_v<_Handler, _Width_checker, _Precision_checker>);
     const unsigned long long _Val = _STD visit_format_arg(_Handler{}, _Arg);
-    if (_Val > static_cast<unsigned long long>((numeric_limits<int>::max) ())) {
+    if (_Val > static_cast<unsigned long long>((numeric_limits<int>::max)())) {
         _THROW(format_error("Number is too big."));
     }
 
@@ -1229,7 +1229,7 @@ private:
     _ParseContext& _Parse_ctx;
 
     _NODISCARD static constexpr int _Verify_dynamic_arg_index_in_range(const size_t _Idx) {
-        if (_Idx > static_cast<size_t>((numeric_limits<int>::max) ())) {
+        if (_Idx > static_cast<size_t>((numeric_limits<int>::max)())) {
             _THROW(format_error("Dynamic width or precision index too large."));
         }
 
@@ -1303,7 +1303,7 @@ public:
 
     template <class _CharT>
     constexpr void _On_type(_CharT _Type) {
-        if (_Type < 0 || _Type > (numeric_limits<signed char>::max) ()) {
+        if (_Type < 0 || _Type > (numeric_limits<signed char>::max)()) {
             _THROW(format_error("Invalid type specification."));
         }
         const char _Narrow_type = static_cast<char>(_Type);
@@ -2330,7 +2330,7 @@ _NODISCARD _OutputIt _Write_integral(
 
         if (_Separators > 0) {
             return _Write_separated_integer(_Buffer_start, _End, _Groups,
-                _STD use_facet<numpunct<_CharT>>(_Locale._Get()).thousands_sep(), _Separators, _STD move(_Out));
+                                    _STD use_facet<numpunct<_CharT>>(_Locale._Get()).thousands_sep(), _Separators, _STD move(_Out));
         }
         return _RANGES _Copy_unchecked(_Buffer_start, _End, _STD move(_Out)).out;
     };
@@ -2482,7 +2482,7 @@ _NODISCARD _OutputIt _Fmt_write(
     auto _Buffer_start = _Buffer;
     auto _Width        = static_cast<int>(_Result.ptr - _Buffer_start);
 
-    const auto _Is_negative = (_STD signbit) (_Value);
+    const auto _Is_negative = (_STD signbit)(_Value);
 
     if (_Is_negative) {
         // Remove the '-', it will be dealt with directly
@@ -2498,7 +2498,7 @@ _NODISCARD _OutputIt _Fmt_write(
         _Exponent = static_cast<char>(_CSTD toupper(_Exponent));
     }
 
-    const auto _Is_finite = (_STD isfinite) (_Value);
+    const auto _Is_finite = (_STD isfinite)(_Value);
 
     auto _Append_decimal   = false;
     auto _Exponent_start   = _Result.ptr;
@@ -2517,7 +2517,7 @@ _NODISCARD _OutputIt _Fmt_write(
                     _Exponent_start = _It;
                 }
             }
-            _Integral_end = (_STD min) (_Radix_point, _Exponent_start);
+            _Integral_end = (_STD min)(_Radix_point, _Exponent_start);
 
             if (_Specs._Alt && _Radix_point == _Result.ptr) {
                 // TRANSITION, decimal point may be wider
@@ -2584,7 +2584,7 @@ _NODISCARD _OutputIt _Fmt_write(
         if (_Specs._Localized) {
             const auto& _Facet = _STD use_facet<numpunct<_CharT>>(_Locale._Get());
             _Out               = _Write_separated_integer(
-                _Buffer_start, _Integral_end, _Groups, _Facet.thousands_sep(), _Separators, _STD move(_Out));
+                              _Buffer_start, _Integral_end, _Groups, _Facet.thousands_sep(), _Separators, _STD move(_Out));
             if (_Radix_point != _Result.ptr || _Append_decimal) {
                 *_Out++         = _Facet.decimal_point();
                 _Append_decimal = false;
@@ -2654,7 +2654,7 @@ _NODISCARD const _CharT* _Measure_string_prefix(const basic_string_view<_CharT> 
     const auto _Last     = _Pos + _Value.size();
     int _Estimated_width = 0; // the estimated width of [_Value.data(), _Pos)
     const _Fmt_codec<_CharT> _Codec;
-    constexpr auto _Max_int = (numeric_limits<int>::max) ();
+    constexpr auto _Max_int = (numeric_limits<int>::max)();
 
     while (_Pos != _Last) {
         if (_Estimated_width == _Max_width && _Max_width >= 0) {

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -493,6 +493,7 @@ _NODISCARD constexpr int _Unicode_width_estimate(const char32_t _Ch) noexcept {
 
     return 1;
 }
+
 template <class _CharT, bool _Statically_Utf8 = _Is_execution_charset_self_synchronizing()>
 class _Fmt_codec;
 

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -458,11 +458,7 @@ _NODISCARD constexpr const _CharT* _Parse_arg_id(
 }
 
 _NODISCARD constexpr bool _Is_execution_charset_self_synchronizing() {
-#ifdef __clang__ // TRANSITION, LLVM-52549 (clang-cl 14 will define _MSVC_EXECUTION_CHARACTER_SET)
-    return string_view{__clang_literal_encoding__} == "UTF-8";
-#elif defined(__EDG__) // TRANSITION, VSO-1468747
-    return false; // safe fallback response
-#else // ^^^ EDG / MSVC vvv
+#ifdef _MSVC_EXECUTION_CHARACTER_SET
     // This is a list of charset codes (as reported by _MSVC_EXECUTION_CHARACTER_SET) that are
     // self-synchronizing (and "narrow" so 1200 (utf-16) and 1201 (unicodeFFFE) are not listed).
     // We care about this because if a charset is self-synchronizing then we can search through it
@@ -484,7 +480,11 @@ _NODISCARD constexpr bool _Is_execution_charset_self_synchronizing() {
     default:
         return false;
     }
-#endif // ^^^ MSVC ^^^
+#elif defined(__clang__) // ^^^ no workaround / Clang workaround vvv
+    return string_view{__clang_literal_encoding__} == "UTF-8"; // TRANSITION, Clang 14
+#else // ^^^ Clang workaround / EDG workaround vvv
+    return false; // TRANSITION, VSO-1468747 (EDG) - safe fallback response
+#endif // ^^^ EDG workaround ^^^
 }
 
 inline constexpr char16_t _Width_estimate_low_intervals[] = { // Per N4885 [format.string.std]/11
@@ -537,13 +537,13 @@ protected:
     }
 
     _Fmt_codec_base() {
-#ifdef __clang__ // TRANSITION, LLVM-52549
-        constexpr __std_code_page _Format_codepage{65001}; // clang only supports utf-8
-#elif defined(__EDG__) // TRANSITION, VSO-1468747
-        constexpr __std_code_page _Format_codepage{65001}; // constructor isn't constexpr, so value is unimportant
-#else // ^^^ EDG / MSVC vvv
+#ifdef _MSVC_EXECUTION_CHARACTER_SET
         constexpr __std_code_page _Format_codepage{_MSVC_EXECUTION_CHARACTER_SET};
-#endif // ^^^ MSVC ^^^
+#else // ^^^ no workaround / workaround vvv
+      // TRANSITION, Clang 14 - only utf-8 is supported
+      // TRANSITION, VSO-1468747 (EDG) - constructor isn't constexpr, so value is unimportant
+        constexpr __std_code_page _Format_codepage{65001};
+#endif // ^^^ workaround ^^^
         [[maybe_unused]] const __std_win_error _Result = __std_get_cvt(_Format_codepage, &_Cvt);
         _STL_INTERNAL_CHECK(_Result == __std_win_error::_Success);
     }

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -443,7 +443,7 @@ _NODISCARD constexpr const _CharT* _Parse_arg_id(
 }
 #ifdef __clang__ // TRANSITION: LLVM-52549 (clang-cl 14 will define _MSVC_EXECUTION_CHARACTER_SET)
 _NODISCARD constexpr bool _Is_execution_charset_self_synchronizing() {
-    return string_view{__clang_literal_encoding__} == "UTF-8"
+    return string_view{__clang_literal_encoding__} == "UTF-8";
 }
 #else // ^^^ clang / msvc vvv
 _NODISCARD constexpr bool _Is_execution_charset_self_synchronizing() {
@@ -453,15 +453,16 @@ _NODISCARD constexpr bool _Is_execution_charset_self_synchronizing() {
     // we care about this because if a charset is self-synchronizing then we can search through it
     // for formatting control characters _without_ generally decoding the format string.
     switch (_MSVC_EXECUTION_CHARACTER_SET) {
-    case 1250: //  ANSI Central European; Central European (Windows)
-    case 1251: //  ANSI Cyrillic; Cyrillic (Windows)
-    case 1252: //  ANSI Latin 1; Western European (Windows)
-    case 1253: //  ANSI Greek; Greek (Windows)
-    case 1254: //  ANSI Turkish; Turkish (Windows)
-    case 1255: //  ANSI Hebrew; Hebrew (Windows)
-    case 1256: //  ANSI Arabic; Arabic (Windows)
-    case 1257: //  ANSI Baltic; Baltic (Windows)
-    case 1258: //  ANSI/OEM Vietnamese; Vietnamese (Windows)
+    case 874: // Thai (Windows)
+    case 1250: // ANSI Central European; Central European (Windows)
+    case 1251: // ANSI Cyrillic; Cyrillic (Windows)
+    case 1252: // ANSI Latin 1; Western European (Windows)
+    case 1253: // ANSI Greek; Greek (Windows)
+    case 1254: // ANSI Turkish; Turkish (Windows)
+    case 1255: // ANSI Hebrew; Hebrew (Windows)
+    case 1256: // ANSI Arabic; Arabic (Windows)
+    case 1257: // ANSI Baltic; Baltic (Windows)
+    case 1258: // ANSI/OEM Vietnamese; Vietnamese (Windows)
     case 65001: // Unicode (UTF-8)
         return true;
     default:

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -456,18 +456,19 @@ _NODISCARD constexpr const _CharT* _Parse_arg_id(
     // This is where we would parse named arg ids if std::format were to support them.
     _THROW(format_error("Invalid format string."));
 }
-#ifdef __clang__ // TRANSITION: LLVM-52549 (clang-cl 14 will define _MSVC_EXECUTION_CHARACTER_SET)
-_NODISCARD constexpr bool _Is_execution_charset_self_synchronizing() {
-    return string_view{__clang_literal_encoding__} == "UTF-8";
-}
-#else // ^^^ clang / msvc vvv
-_NODISCARD constexpr bool _Is_execution_charset_self_synchronizing() {
 
-    // charset codes (as reported by _MSVC_EXECUTION_CHARACTER_SET) that are
-    // self-synchronizing (and "narrow" so 1200 (utf-16) and 1201 (unicodeFFFE) are not listed)
-    // we care about this because if a charset is self-synchronizing then we can search through it
+_NODISCARD constexpr bool _Is_execution_charset_self_synchronizing() {
+#ifdef __clang__ // TRANSITION, LLVM-52549 (clang-cl 14 will define _MSVC_EXECUTION_CHARACTER_SET)
+    return string_view{__clang_literal_encoding__} == "UTF-8";
+#elif defined(__EDG__) // TRANSITION, VSO-1468747
+    return false; // safe fallback response
+#else // ^^^ EDG / MSVC vvv
+    // This is a list of charset codes (as reported by _MSVC_EXECUTION_CHARACTER_SET) that are
+    // self-synchronizing (and "narrow" so 1200 (utf-16) and 1201 (unicodeFFFE) are not listed).
+    // We care about this because if a charset is self-synchronizing then we can search through it
     // for formatting control characters _without_ generally decoding the format string.
     switch (_MSVC_EXECUTION_CHARACTER_SET) {
+    // See: https://docs.microsoft.com/en-us/windows/win32/intl/code-page-identifiers
     case 874: // Thai (Windows)
     case 1250: // ANSI Central European; Central European (Windows)
     case 1251: // ANSI Cyrillic; Cyrillic (Windows)
@@ -482,9 +483,9 @@ _NODISCARD constexpr bool _Is_execution_charset_self_synchronizing() {
         return true;
     default:
         return false;
-    };
+    }
+#endif // ^^^ MSVC ^^^
 }
-#endif // ^^^ msvc
 
 inline constexpr char16_t _Width_estimate_low_intervals[] = { // Per N4885 [format.string.std]/11
     0x1100u, 0x1160u, 0x2329u, 0x232Bu, 0x2E80u, 0x303Fu, 0x3040u, 0xA4D0u, 0xAC00u, 0xD7A4u, 0xF900u, 0xFB00u, 0xFE10u,
@@ -536,16 +537,15 @@ protected:
     }
 
     _Fmt_codec_base() {
-#ifndef _FORMAT_CODEPAGE
 #ifdef __clang__ // TRANSITION, LLVM-52549
-#define _FORMAT_CODEPAGE static_cast<__std_code_page>(65001) // clang only supports utf-8
-#else // ^^^ clang / msvc vvv
-#define _FORMAT_CODEPAGE static_cast<__std_code_page>(_MSVC_EXECUTION_CHARACTER_SET)
-#endif // ^^^ msvc
-#endif // _FORMAT_CODEPAGE
-        [[maybe_unused]] const __std_win_error _Result = __std_get_cvt(_FORMAT_CODEPAGE, &_Cvt);
+        constexpr __std_code_page _Format_codepage{65001}; // clang only supports utf-8
+#elif defined(__EDG__) // TRANSITION, VSO-1468747
+        constexpr __std_code_page _Format_codepage{65001}; // constructor isn't constexpr, so value is unimportant
+#else // ^^^ EDG / MSVC vvv
+        constexpr __std_code_page _Format_codepage{_MSVC_EXECUTION_CHARACTER_SET};
+#endif // ^^^ MSVC ^^^
+        [[maybe_unused]] const __std_win_error _Result = __std_get_cvt(_Format_codepage, &_Cvt);
         _STL_INTERNAL_CHECK(_Result == __std_win_error::_Success);
-#undef _FORMAT_CODEPAGE
     }
 };
 

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -472,6 +472,7 @@ _NODISCARD constexpr bool _Is_execution_charset_self_synchronizing() {
     };
 }
 #endif // ^^^ msvc
+
 inline constexpr char16_t _Width_estimate_low_intervals[] = { // Per N4885 [format.string.std]/11
     0x1100u, 0x1160u, 0x2329u, 0x232Bu, 0x2E80u, 0x303Fu, 0x3040u, 0xA4D0u, 0xAC00u, 0xD7A4u, 0xF900u, 0xFB00u, 0xFE10u,
     0xFE1Au, 0xFE30u, 0xFE70u, 0xFF00u, 0xFF61u, 0xFFE0u, 0xFFE7u};

--- a/tests/std/tests/P0645R10_text_formatting_legacy_text_encoding/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_legacy_text_encoding/test.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#define _FORMAT_CODEPAGE (__std_code_page{932})
-
 #include <cassert>
 #include <clocale>
 #include <format>


### PR DESCRIPTION
This should drastically increase format's performance in the "default" case (still need to rerun my toy benchmarks though)

For clang use ____clang_literal_encoding__, clang 14 will learn
_MSVC_EXECUTION_CHARACTER_SET, but ____clang_literal_encoding__
is in clang 13.

Additionally for the "slow path" get the "format codepage" using
these new macros (at compile-time) rather than assuming the
active codepage is the same as the execution character set.

ABI Impact:

This changes which versions of some templates get used, and could cause ODR violations, but in general should make people's ABI situation better rather than worse.

In particular windows 1251 will now use the "fast path" on msvc, so if you link clang code (which always used the fast path) to
non-clang code you no longer have an ODR violation in std::foramt (although your codepages differ, so there are probably still relatively benign ODR violations elsewhere). 


fixes: #2342 