### PR TITLE
Add diagnostics for sporadic failures in a `<format>` test

### DIFF
--- a/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
@@ -7,6 +7,7 @@
 #include <cstdio>
 #include <exception>
 #include <format>
+#include <iostream>
 #include <iterator>
 #include <limits>
 #include <list>
@@ -817,6 +818,18 @@ void test_float_specs() {
         assert(format("{:.2000}", value) == expected);
 
         expected = {buffer, to_chars(begin(buffer), end(buffer), value, chars_format::hex, 2000).ptr};
+
+        // TRANSITION, extra diagnostics for GH-2449:
+        if (const string str1 = format("{:.2000a}", value); str1 != expected) {
+            cerr << "Encountered sporadic failure GH-2449!\n";
+            cerr << "    str1: \"" << str1 << "\"\n";
+            cerr << "expected: \"" << expected << "\"\n";
+            cerr << "DO NOT IGNORE/RERUN THIS FAILURE.\n";
+            cerr << "You must report it to the STL maintainers.\n";
+            assert(false);
+        }
+
+        // Keep the original assertion, just in case GH-2449 involves very specific codegen:
         assert(format("{:.2000a}", value) == expected);
 
         expected = {buffer, to_chars(begin(buffer), end(buffer), value, chars_format::scientific, 2000).ptr};
@@ -833,6 +846,18 @@ void test_float_specs() {
         assert(format("{:.2000}", 1.0) == expected);
 
         expected = {buffer, to_chars(begin(buffer), end(buffer), 1.0, chars_format::hex, 2000).ptr};
+
+        // TRANSITION, extra diagnostics for GH-2449:
+        if (const string str2 = format("{:.2000a}", 1.0); str2 != expected) {
+            cerr << "Encountered sporadic failure GH-2449!\n";
+            cerr << "    str2: \"" << str2 << "\"\n";
+            cerr << "expected: \"" << expected << "\"\n";
+            cerr << "DO NOT IGNORE/RERUN THIS FAILURE.\n";
+            cerr << "You must report it to the STL maintainers.\n";
+            assert(false);
+        }
+
+        // Keep the original assertion, just in case GH-2449 involves very specific codegen:
         assert(format("{:.2000a}", 1.0) == expected);
 
         expected = {buffer, to_chars(begin(buffer), end(buffer), 1.0, chars_format::scientific, 2000).ptr};


### PR DESCRIPTION
The sporadic failure mentioned in #2449 has happened twice, in unrelated PRs, affecting both x86 and x64 (but curiously affecting clang-cl both times). We can't figure out why this is happening, so printing the return value of `format()` might help.

The output will look like this (with 2,000 zeroes, and there will be some difference between the strings):

```
Encountered sporadic failure GH-2449!
    str1: "1.34a1c000...000p+10"
expected: "1.34a1c000...000p+10"
DO NOT IGNORE/RERUN THIS FAILURE.
You must report it to the STL maintainers.
Assertion failed: false, file D:\GitHub\STL\tests\std\tests\P0645R10_text_formatting_formatting\test.cpp, line 829
```
