### PR TITLE
WIP: <format> Reserve some space in ABI sensitive types

### DIFF
--- a/stl/inc/format
+++ b/stl/inc/format
@@ -1011,8 +1011,8 @@ struct _Basic_format_specs {
     bool _Localized       = false;
     bool _Leading_zero    = false;
     uint8_t _Fill_length  = 1;
-    uint8_t _Reserved1 = 0;
-    uintptr_t _Reserved2 = 0;
+    uint8_t _Reserved0 = 0;
+    uintptr_t _Reserved1 = 0;
     // At most one codepoint (so one char32_t or four utf-8 char8_t).
     _CharT _Fill[4 / sizeof(_CharT)] = {_CharT{' '}};
 };
@@ -2875,6 +2875,7 @@ struct _Formatter_base {
 
 private:
     _Dynamic_format_specs<_CharT> _Specs;
+    uintptr_t _Reserved0;
 };
 
 #define _FORMAT_SPECIALIZE_FOR(_Type, _ArgType) \

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -1015,8 +1015,10 @@ struct _Basic_format_specs {
     // At most one codepoint (so one char32_t or four utf-8 char8_t).
     _CharT _Fill[4 / sizeof(_CharT)] = {_CharT{' '}};
 
-    ~_Basic_format_specs() {
-        delete reinterpret_cast<void*>(_Reserved);
+    constexpr ~_Basic_format_specs() {
+        if(!_STD is_constant_evaluated()) {
+            ::operator delete(reinterpret_cast<void*>(_Reserved));
+        }
     }
 };
 
@@ -2876,8 +2878,10 @@ struct _Formatter_base {
             basic_format_arg<_FormatContext>{_Val});
     }
 
-    ~_Formatter_base() {
-        delete reinterpret_cast<void*>(_Reserved)
+    constexpr ~_Formatter_base() {
+        if(!_STD is_constant_evaluated()) {
+            ::operator delete(reinterpret_cast<void*>(_Reserved));
+        }
     }
 
 private:

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -1011,6 +1011,8 @@ struct _Basic_format_specs {
     bool _Localized       = false;
     bool _Leading_zero    = false;
     uint8_t _Fill_length  = 1;
+    uint8_t _Reserved = 0;
+    uintptr_t _Reserved2 = 0;
     // At most one codepoint (so one char32_t or four utf-8 char8_t).
     _CharT _Fill[4 / sizeof(_CharT)] = {_CharT{' '}};
 };

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -1011,7 +1011,7 @@ struct _Basic_format_specs {
     bool _Localized       = false;
     bool _Leading_zero    = false;
     uint8_t _Fill_length  = 1;
-    uint8_t _Reserved = 0;
+    uint8_t _Reserved1 = 0;
     uintptr_t _Reserved2 = 0;
     // At most one codepoint (so one char32_t or four utf-8 char8_t).
     _CharT _Fill[4 / sizeof(_CharT)] = {_CharT{' '}};

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -1002,6 +1002,7 @@ constexpr void _Parse_format_string(basic_string_view<_CharT> _Format_str, _Hand
 
 template <class _CharT>
 struct _Basic_format_specs {
+    uintptr_t _Reserved = 0;
     int _Width            = 0;
     int _Precision        = -1;
     char _Type            = '\0';
@@ -1011,10 +1012,12 @@ struct _Basic_format_specs {
     bool _Localized       = false;
     bool _Leading_zero    = false;
     uint8_t _Fill_length  = 1;
-    uint8_t _Reserved0 = 0;
-    uintptr_t _Reserved1 = 0;
     // At most one codepoint (so one char32_t or four utf-8 char8_t).
     _CharT _Fill[4 / sizeof(_CharT)] = {_CharT{' '}};
+
+    ~_Basic_format_specs() {
+        delete reinterpret_cast<void*>(_Reserved);
+    }
 };
 
 // Adds width and precision references to _Basic_format_specs.
@@ -2873,9 +2876,13 @@ struct _Formatter_base {
             basic_format_arg<_FormatContext>{_Val});
     }
 
+    ~_Formatter_base() {
+        delete reinterpret_cast<void*>(_Reserved)
+    }
+
 private:
+    uintptr_t _Reserved = 0;
     _Dynamic_format_specs<_CharT> _Specs;
-    uintptr_t _Reserved0 = 0;
 };
 
 #define _FORMAT_SPECIALIZE_FOR(_Type, _ArgType) \

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -1002,7 +1002,7 @@ constexpr void _Parse_format_string(basic_string_view<_CharT> _Format_str, _Hand
 
 template <class _CharT>
 struct _Basic_format_specs {
-    uintptr_t _Reserved = 0;
+    uintptr_t _Reserved   = 0;
     int _Width            = 0;
     int _Precision        = -1;
     char _Type            = '\0';
@@ -1016,7 +1016,7 @@ struct _Basic_format_specs {
     _CharT _Fill[4 / sizeof(_CharT)] = {_CharT{' '}};
 
     constexpr ~_Basic_format_specs() {
-        if(!_STD is_constant_evaluated()) {
+        if (!_STD is_constant_evaluated()) {
             ::operator delete(reinterpret_cast<void*>(_Reserved));
         }
     }
@@ -2879,7 +2879,7 @@ struct _Formatter_base {
     }
 
     constexpr ~_Formatter_base() {
-        if(!_STD is_constant_evaluated()) {
+        if (!_STD is_constant_evaluated()) {
             ::operator delete(reinterpret_cast<void*>(_Reserved));
         }
     }

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -2875,7 +2875,7 @@ struct _Formatter_base {
 
 private:
     _Dynamic_format_specs<_CharT> _Specs;
-    uintptr_t _Reserved0;
+    uintptr_t _Reserved0 = 0;
 };
 
 #define _FORMAT_SPECIALIZE_FOR(_Type, _ArgType) \


### PR DESCRIPTION
I called the branch chicken bits, but that's not really what these are.

Adds a uintptr_t to _Basic_format_specs and another to _Formatter_base, additionally gives both a destructor that "deletes" that pointer.

The idea is that if we ever need to add stuff that would extend these (very user-visible) types we can allocate memory when the new feature requiring more data is used, and even if the linker decides to pick "old" code in the event of an ODR violation that memory will still get freed. If we never need this then the destructors just run "delete 0" and all is well in the world.

It's possible that reinterpret cast should be to volatile void, or the data member should be volatile, to avoid the compiler figuring out that _Reserved is never written and optimizing the destructor away (this is valid, as when having this destructor saves our hide there is an ODR violation by definition.

Destructor does nothing when running at compile time. If we need to use this facility, we can keep things constexpr using constexpr allocation, or just use the extended information directly at compile time (but not runtime, where we'd still use some indirection to avoid breakage).

I'm not sure this is worth doing but wanted to allow discussion.