### PR TITLE
Toolset update: VS 2022 17.1 Preview 4, ARM64EC

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With The Visual Studio IDE
 
-1. Install Visual Studio 2022 17.1 Preview 2 or later.
+1. Install Visual Studio 2022 17.1 Preview 4 or later.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
     * Otherwise, install [CMake][] 3.21 or later, and [Ninja][] 1.10.2 or later.
@@ -155,7 +155,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With A Native Tools Command Prompt
 
-1. Install Visual Studio 2022 17.1 Preview 2 or later.
+1. Install Visual Studio 2022 17.1 Preview 4 or later.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
     * Otherwise, install [CMake][] 3.21 or later, and [Ninja][] 1.10.2 or later.

--- a/azure-devops/create-vmss.ps1
+++ b/azure-devops/create-vmss.ps1
@@ -35,33 +35,6 @@ $CurrentProgress = 1
 
 <#
 .SYNOPSIS
-Returns whether there's a name collision in the resource group.
-
-.DESCRIPTION
-Find-ResourceGroupNameCollision takes a list of resources, and checks if $Test
-collides names with any of the resources.
-
-.PARAMETER Test
-The name to test.
-
-.PARAMETER Resources
-The list of resources.
-#>
-function Find-ResourceGroupNameCollision {
-  [CmdletBinding()]
-  Param([string]$Test, $Resources)
-
-  foreach ($resource in $Resources) {
-    if ($resource.ResourceGroupName -eq $Test) {
-      return $true
-    }
-  }
-
-  return $false
-}
-
-<#
-.SYNOPSIS
 Attempts to find a name that does not collide with any resources in the resource group.
 
 .DESCRIPTION
@@ -76,10 +49,10 @@ function Find-ResourceGroupName {
   [CmdletBinding()]
   Param([string] $Prefix)
 
-  $resources = Get-AzResourceGroup
+  $existingNames = (Get-AzResourceGroup).ResourceGroupName
   $result = $Prefix
   $suffix = 0
-  while (Find-ResourceGroupNameCollision -Test $result -Resources $resources) {
+  while ($result -in $existingNames) {
     $suffix++
     $result = "$Prefix-$suffix"
   }

--- a/azure-devops/create-vmss.ps1
+++ b/azure-devops/create-vmss.ps1
@@ -196,11 +196,23 @@ $allowHttp = New-AzNetworkSecurityRuleConfig `
   -Access Allow `
   -Protocol Tcp `
   -Direction Outbound `
-  -Priority 1008 `
+  -Priority 1000 `
   -SourceAddressPrefix * `
   -SourcePortRange * `
   -DestinationAddressPrefix * `
   -DestinationPortRange @(80, 443)
+
+$allowQuic = New-AzNetworkSecurityRuleConfig `
+  -Name AllowQUIC `
+  -Description 'Allow QUIC' `
+  -Access Allow `
+  -Protocol Udp `
+  -Direction Outbound `
+  -Priority 1010 `
+  -SourceAddressPrefix * `
+  -SourcePortRange * `
+  -DestinationAddressPrefix * `
+  -DestinationPortRange 443
 
 $allowDns = New-AzNetworkSecurityRuleConfig `
   -Name AllowDNS `
@@ -208,7 +220,7 @@ $allowDns = New-AzNetworkSecurityRuleConfig `
   -Access Allow `
   -Protocol * `
   -Direction Outbound `
-  -Priority 1009 `
+  -Priority 1020 `
   -SourceAddressPrefix * `
   -SourcePortRange * `
   -DestinationAddressPrefix * `
@@ -220,7 +232,7 @@ $denyEverythingElse = New-AzNetworkSecurityRuleConfig `
   -Access Deny `
   -Protocol * `
   -Direction Outbound `
-  -Priority 1010 `
+  -Priority 2000 `
   -SourceAddressPrefix * `
   -SourcePortRange * `
   -DestinationAddressPrefix * `
@@ -231,7 +243,7 @@ $NetworkSecurityGroup = New-AzNetworkSecurityGroup `
   -Name $NetworkSecurityGroupName `
   -ResourceGroupName $ResourceGroupName `
   -Location $Location `
-  -SecurityRules @($allowHttp, $allowDns, $denyEverythingElse)
+  -SecurityRules @($allowHttp, $allowQuic, $allowDns, $denyEverythingElse)
 
 $SubnetName = $ResourceGroupName + '-Subnet'
 $Subnet = New-AzVirtualNetworkSubnetConfig `

--- a/azure-devops/create-vmss.ps1
+++ b/azure-devops/create-vmss.ps1
@@ -171,6 +171,7 @@ Write-Progress `
   -PercentComplete (100 / $TotalProgress * $CurrentProgress++)
 
 $IgnoredAzureContext = Set-AzContext -SubscriptionName CPP_STL_GitHub
+az account set --subscription CPP_STL_GitHub
 
 ####################################################################################################
 Write-Progress `

--- a/azure-devops/create-vmss.ps1
+++ b/azure-devops/create-vmss.ps1
@@ -143,7 +143,7 @@ Write-Progress `
   -Status 'Setting the subscription context' `
   -PercentComplete (100 / $TotalProgress * $CurrentProgress++)
 
-$IgnoredAzureContext = Set-AzContext -SubscriptionName CPP_STL_GitHub
+Set-AzContext -SubscriptionName CPP_STL_GitHub | Out-Null
 az account set --subscription CPP_STL_GitHub
 
 ####################################################################################################
@@ -154,7 +154,7 @@ Write-Progress `
 
 $ResourceGroupName = Find-ResourceGroupName $Prefix
 $AdminPW = New-Password
-$IgnoredResourceGroup = New-AzResourceGroup -Name $ResourceGroupName -Location $Location
+New-AzResourceGroup -Name $ResourceGroupName -Location $Location | Out-Null
 $AdminPWSecure = ConvertTo-SecureString $AdminPW -AsPlainText -Force
 $Credential = New-Object System.Management.Automation.PSCredential ('AdminUser', $AdminPWSecure)
 
@@ -263,10 +263,10 @@ $VM = Set-AzVMSourceImage `
   -Version latest
 
 $VM = Set-AzVMBootDiagnostic -VM $VM -Disable
-$IgnoredAzureOperationResponse = New-AzVm `
+New-AzVm `
   -ResourceGroupName $ResourceGroupName `
   -Location $Location `
-  -VM $VM
+  -VM $VM | Out-Null
 
 ####################################################################################################
 Write-Progress `
@@ -289,7 +289,7 @@ Write-Progress `
   -Status 'Restarting VM' `
   -PercentComplete (100 / $TotalProgress * $CurrentProgress++)
 
-$IgnoredComputeLongRunningOperation = Restart-AzVM -ResourceGroupName $ResourceGroupName -Name $ProtoVMName
+Restart-AzVM -ResourceGroupName $ResourceGroupName -Name $ProtoVMName | Out-Null
 
 ####################################################################################################
 Write-Progress `
@@ -307,11 +307,11 @@ Write-Progress `
   -Status 'Running provisioning script sysprep.ps1 in VM' `
   -PercentComplete (100 / $TotalProgress * $CurrentProgress++)
 
-$IgnoredRunCommandResult = Invoke-AzVMRunCommand `
+Invoke-AzVMRunCommand `
   -ResourceGroupName $ResourceGroupName `
   -VMName $ProtoVMName `
   -CommandId 'RunPowerShellScript' `
-  -ScriptPath "$PSScriptRoot\sysprep.ps1"
+  -ScriptPath "$PSScriptRoot\sysprep.ps1" | Out-Null
 
 ####################################################################################################
 Write-Progress `
@@ -327,15 +327,15 @@ Write-Progress `
   -Status 'Converting VM to Image' `
   -PercentComplete (100 / $TotalProgress * $CurrentProgress++)
 
-$IgnoredComputeLongRunningOperation = Stop-AzVM `
+Stop-AzVM `
   -ResourceGroupName $ResourceGroupName `
   -Name $ProtoVMName `
-  -Force
+  -Force | Out-Null
 
-$IgnoredComputeLongRunningOperation = Set-AzVM `
+Set-AzVM `
   -ResourceGroupName $ResourceGroupName `
   -Name $ProtoVMName `
-  -Generalized
+  -Generalized | Out-Null
 
 $VM = Get-AzVM -ResourceGroupName $ResourceGroupName -Name $ProtoVMName
 $PrototypeOSDiskName = $VM.StorageProfile.OsDisk.Name
@@ -348,11 +348,11 @@ Write-Progress `
   -Status 'Deleting unused VM and disk' `
   -PercentComplete (100 / $TotalProgress * $CurrentProgress++)
 
-$IgnoredComputeLongRunningOperation = Remove-AzVM -Id $VM.ID -Force
-$IgnoredOperationStatusResponse = Remove-AzDisk `
+Remove-AzVM -Id $VM.ID -Force | Out-Null
+Remove-AzDisk `
   -ResourceGroupName $ResourceGroupName `
   -DiskName $PrototypeOSDiskName `
-  -Force
+  -Force | Out-Null
 
 ####################################################################################################
 Write-Progress `

--- a/azure-devops/create-vmss.ps1
+++ b/azure-devops/create-vmss.ps1
@@ -21,7 +21,7 @@ $ErrorActionPreference = 'Stop'
 $Env:SuppressAzurePowerShellBreakingChangeWarnings = 'true'
 
 $Location = 'westus2'
-$Prefix = 'StlBuild-' + (Get-Date -Format 'yyyy-MM-dd')
+$Prefix = 'StlBuild-' + (Get-Date -Format 'yyyy-MM-dd-THHmm')
 $VMSize = 'Standard_D32ads_v5'
 $ProtoVMName = 'PROTOTYPE'
 $LiveVMPrefix = 'BUILD'

--- a/azure-devops/create-vmss.ps1
+++ b/azure-devops/create-vmss.ps1
@@ -25,9 +25,9 @@ $Prefix = 'StlBuild-' + (Get-Date -Format 'yyyy-MM-dd-THHmm')
 $VMSize = 'Standard_D32ads_v5'
 $ProtoVMName = 'PROTOTYPE'
 $LiveVMPrefix = 'BUILD'
-$ImagePublisher = 'MicrosoftWindowsDesktop'
-$ImageOffer = 'windows-11'
-$ImageSku = 'win11-21h2-ent'
+$ImagePublisher = 'MicrosoftWindowsServer'
+$ImageOffer = 'WindowsServer'
+$ImageSku = '2022-datacenter-g2'
 
 $ProgressActivity = 'Creating Scale Set'
 $TotalProgress = 14

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -142,7 +142,7 @@ $Workloads = @(
 $ReleaseInPath = 'Preview'
 $Sku = 'Enterprise'
 $VisualStudioBootstrapperUrl = 'https://aka.ms/vs/17/pre/vs_enterprise.exe'
-$PythonUrl = 'https://www.python.org/ftp/python/3.10.1/python-3.10.1-amd64.exe'
+$PythonUrl = 'https://www.python.org/ftp/python/3.10.2/python-3.10.2-amd64.exe'
 
 $CudaUrl = `
   'https://developer.download.nvidia.com/compute/cuda/10.1/Prod/local_installers/cuda_10.1.243_426.00_win10.exe'

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -133,6 +133,7 @@ $Workloads = @(
   'Microsoft.VisualStudio.Component.VC.Runtimes.x86.x64.Spectre',
   'Microsoft.VisualStudio.Component.VC.Tools.ARM',
   'Microsoft.VisualStudio.Component.VC.Tools.ARM64',
+  'Microsoft.VisualStudio.Component.VC.Tools.ARM64EC',
   'Microsoft.VisualStudio.Component.VC.Tools.x86.x64',
   # TRANSITION, LLVM-51128 (Clang 12 targeting ARM64 is incompatible with WinSDK 10.0.20348.0)
   'Microsoft.VisualStudio.Component.Windows10SDK.19041'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ variables:
   tmpDir: 'D:\Temp'
   buildOutputLocation: 'D:\build'
 
-pool: 'StlBuild-2022-01-13-2'
+pool: 'StlBuild-2022-01-25-T1318'
 
 stages:
   - stage: Code_Format

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -3033,47 +3033,37 @@ _OutputIt format_to(_OutputIt _Out, const locale& _Loc, const _Fmt_wstring<_Type
     return _STD vformat_to(_STD move(_Out), _Loc, _Fmt._Str, _STD make_wformat_args(_Args...));
 }
 
-#if defined(__clang__) || defined(__EDG__) // TRANSITION, VSO-1433873
-#define _TEMPLATE_INT_0_NODISCARD                             \
-    template <int = 0> /* improves throughput, see GH-2329 */ \
-    _NODISCARD
-#else // ^^^ no workaround / workaround vvv
-#define _TEMPLATE_INT_0_NODISCARD _NODISCARD inline
-#endif // ^^^ workaround ^^^
-
-_TEMPLATE_INT_0_NODISCARD
-string vformat(const string_view _Fmt, const format_args _Args) {
+template <int = 0> // improves throughput, see GH-2329
+_NODISCARD string vformat(const string_view _Fmt, const format_args _Args) {
     string _Str;
     _Str.reserve(_Fmt.size() + _Args._Estimate_required_capacity());
     _STD vformat_to(back_insert_iterator{_Str}, _Fmt, _Args);
     return _Str;
 }
 
-_TEMPLATE_INT_0_NODISCARD
-wstring vformat(const wstring_view _Fmt, const wformat_args _Args) {
+template <int = 0> // improves throughput, see GH-2329
+_NODISCARD wstring vformat(const wstring_view _Fmt, const wformat_args _Args) {
     wstring _Str;
     _Str.reserve(_Fmt.size() + _Args._Estimate_required_capacity());
     _STD vformat_to(back_insert_iterator{_Str}, _Fmt, _Args);
     return _Str;
 }
 
-_TEMPLATE_INT_0_NODISCARD
-string vformat(const locale& _Loc, const string_view _Fmt, const format_args _Args) {
+template <int = 0> // improves throughput, see GH-2329
+_NODISCARD string vformat(const locale& _Loc, const string_view _Fmt, const format_args _Args) {
     string _Str;
     _Str.reserve(_Fmt.size() + _Args._Estimate_required_capacity());
     _STD vformat_to(back_insert_iterator{_Str}, _Loc, _Fmt, _Args);
     return _Str;
 }
 
-_TEMPLATE_INT_0_NODISCARD
-wstring vformat(const locale& _Loc, const wstring_view _Fmt, const wformat_args _Args) {
+template <int = 0> // improves throughput, see GH-2329
+_NODISCARD wstring vformat(const locale& _Loc, const wstring_view _Fmt, const wformat_args _Args) {
     wstring _Str;
     _Str.reserve(_Fmt.size() + _Args._Estimate_required_capacity());
     _STD vformat_to(back_insert_iterator{_Str}, _Loc, _Fmt, _Args);
     return _Str;
 }
-
-#undef _TEMPLATE_INT_0_NODISCARD // TRANSITION, VSO-1433873
 
 template <class... _Types>
 _NODISCARD string format(const _Fmt_string<_Types...> _Fmt, const _Types&... _Args) {

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -2302,7 +2302,7 @@ _NODISCARD _OutputIt _Write_integral(
 #pragma warning(disable : 4296) // '<': expression is always false
         _Out = _Write_sign(_STD move(_Out), _Specs._Sgn, _Value < _Integral{0});
 #pragma warning(pop)
-        _Out = _RANGES transform(_Prefix.begin(), _Prefix.end(), _STD move(_Out), _Widen_char<_CharT>{}).out;
+        _Out = _RANGES transform(_Prefix, _STD move(_Out), _Widen_char<_CharT>{}).out;
         if (_Write_leading_zeroes && _Width < _Specs._Width) {
             _Out = _RANGES fill_n(_STD move(_Out), _Specs._Width - _Width, _CharT{'0'});
         }

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -2304,7 +2304,7 @@ _NODISCARD _OutputIt _Write_integral(
 #pragma warning(pop)
         _Out = _RANGES _Copy_unchecked(_Prefix.begin(), _Prefix.end(), _STD move(_Out)).out;
         if (_Write_leading_zeroes && _Width < _Specs._Width) {
-            _Out = _RANGES fill_n(_STD move(_Out), _Specs._Width - _Width, '0');
+            _Out = _RANGES fill_n(_STD move(_Out), _Specs._Width - _Width, _CharT{'0'});
         }
 
         if (_Separators > 0) {
@@ -2558,7 +2558,7 @@ _NODISCARD _OutputIt _Fmt_write(
         _Out = _Write_sign(_STD move(_Out), _Sgn, _Is_negative);
 
         if (_Write_leading_zeroes && _Width < _Specs._Width) {
-            _Out = _RANGES fill_n(_STD move(_Out), _Specs._Width - _Width, '0');
+            _Out = _RANGES fill_n(_STD move(_Out), _Specs._Width - _Width, _CharT{'0'});
         }
 
         if (_Specs._Localized) {

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -44,6 +44,7 @@
 #pragma message("see https://github.com/microsoft/STL/issues/1814 for details.")
 #else // ^^^ !defined(__cpp_lib_format) / defined(__cpp_lib_format) vvv
 
+#include <algorithm>
 #include <charconv>
 #include <concepts>
 #include <cstdint>
@@ -1967,8 +1968,13 @@ _NODISCARD _OutputIt _Fmt_write(_OutputIt _Out, const _CharT* _Value);
 template <class _CharT, class _OutputIt>
 _NODISCARD _OutputIt _Fmt_write(_OutputIt _Out, basic_string_view<_CharT> _Value);
 
-#pragma warning(push)
-#pragma warning(disable : 4365) // 'argument': conversion from 'char' to 'const wchar_t', signed/unsigned mismatch
+template <class _CharT>
+struct _Widen_char {
+    _NODISCARD _CharT operator()(const char _Ch) const noexcept {
+        return static_cast<_CharT>(_Ch);
+    }
+};
+
 // clang-format off
 template <class _CharT, class _OutputIt, class _Arithmetic>
     requires (is_arithmetic_v<_Arithmetic> && !_CharT_or_bool<_Arithmetic, _CharT>)
@@ -1978,9 +1984,8 @@ _NODISCARD _OutputIt _Fmt_write(_OutputIt _Out, const _Arithmetic _Value) {
     char _Buffer[_Format_min_buffer_length];
     const auto [_End, _Ec] = _STD to_chars(_Buffer, _STD end(_Buffer), _Value);
     _STL_ASSERT(_Ec == errc{}, "to_chars failed");
-    return _RANGES _Copy_unchecked(_Buffer, _End, _STD move(_Out)).out;
+    return _RANGES transform(_Buffer, _End, _STD move(_Out), _Widen_char<_CharT>{}).out;
 }
-#pragma warning(pop)
 
 template <class _CharT, class _OutputIt>
 _NODISCARD _OutputIt _Fmt_write(_OutputIt _Out, const bool _Value) {
@@ -1997,8 +2002,6 @@ _NODISCARD _OutputIt _Fmt_write(_OutputIt _Out, const _CharT _Value) {
     return _Out;
 }
 
-#pragma warning(push)
-#pragma warning(disable : 4365) // 'argument': conversion from 'char' to 'const wchar_t', signed/unsigned mismatch
 template <class _CharT, class _OutputIt>
 _NODISCARD _OutputIt _Fmt_write(_OutputIt _Out, const void* const _Value) {
     // TRANSITION, Reusable buffer
@@ -2007,9 +2010,8 @@ _NODISCARD _OutputIt _Fmt_write(_OutputIt _Out, const void* const _Value) {
     _STL_ASSERT(_Ec == errc{}, "to_chars failed");
     *_Out++ = '0';
     *_Out++ = 'x';
-    return _RANGES _Copy_unchecked(_Buffer, _End, _STD move(_Out)).out;
+    return _RANGES transform(_Buffer, _End, _STD move(_Out), _Widen_char<_CharT>{}).out;
 }
-#pragma warning(pop)
 
 template <class _CharT, class _OutputIt>
 _NODISCARD _OutputIt _Fmt_write(_OutputIt _Out, const _CharT* _Value) {
@@ -2161,7 +2163,7 @@ _NODISCARD _OutputIt _Write_separated_integer(const char* _First, const char* co
             ++_Repeats;
         }
     }
-    _Out   = _RANGES _Copy_unchecked(_First, _Last - _Grouped, _STD move(_Out)).out;
+    _Out   = _RANGES transform(_First, _Last - _Grouped, _STD move(_Out), _Widen_char<_CharT>{}).out;
     _First = _Last - _Grouped;
 
     for (; _Separators > 0; --_Separators) {
@@ -2172,7 +2174,7 @@ _NODISCARD _OutputIt _Write_separated_integer(const char* _First, const char* co
         }
 
         *_Out++ = _Separator;
-        _Out    = _RANGES _Copy_unchecked(_First, _First + *_Group_it, _STD move(_Out)).out;
+        _Out    = _RANGES transform(_First, _First + *_Group_it, _STD move(_Out), _Widen_char<_CharT>{}).out;
         _First += *_Group_it;
     }
     _STL_INTERNAL_CHECK(_First == _Last);
@@ -2220,8 +2222,6 @@ template <class _CharT, class _OutputIt>
 _NODISCARD _OutputIt _Fmt_write(
     _OutputIt _Out, basic_string_view<_CharT> _Value, const _Basic_format_specs<_CharT>& _Specs, _Lazy_locale);
 
-#pragma warning(push)
-#pragma warning(disable : 4365) // 'argument': conversion from 'char' to 'const wchar_t', signed/unsigned mismatch
 template <class _CharT, class _OutputIt, integral _Integral>
 _NODISCARD _OutputIt _Write_integral(
     _OutputIt _Out, const _Integral _Value, _Basic_format_specs<_CharT> _Specs, _Lazy_locale _Locale) {
@@ -2302,7 +2302,7 @@ _NODISCARD _OutputIt _Write_integral(
 #pragma warning(disable : 4296) // '<': expression is always false
         _Out = _Write_sign(_STD move(_Out), _Specs._Sgn, _Value < _Integral{0});
 #pragma warning(pop)
-        _Out = _RANGES _Copy_unchecked(_Prefix.begin(), _Prefix.end(), _STD move(_Out)).out;
+        _Out = _RANGES transform(_Prefix.begin(), _Prefix.end(), _STD move(_Out), _Widen_char<_CharT>{}).out;
         if (_Write_leading_zeroes && _Width < _Specs._Width) {
             _Out = _RANGES fill_n(_STD move(_Out), _Specs._Width - _Width, _CharT{'0'});
         }
@@ -2312,7 +2312,7 @@ _NODISCARD _OutputIt _Write_integral(
                                     _STD use_facet<numpunct<_CharT>>(_Locale._Get()).thousands_sep(), //
                                     _Separators, _STD move(_Out));
         }
-        return _RANGES _Copy_unchecked(_Buffer_start, _End, _STD move(_Out)).out;
+        return _RANGES transform(_Buffer_start, _End, _STD move(_Out), _Widen_char<_CharT>{}).out;
     };
 
     if (_Write_leading_zeroes) {
@@ -2321,7 +2321,6 @@ _NODISCARD _OutputIt _Write_integral(
 
     return _Write_aligned(_STD move(_Out), _Width, _Specs, _Fmt_align::_Right, _Writer);
 }
-#pragma warning(pop)
 
 // clang-format off
 template <class _CharT, class _OutputIt, integral _Integral>
@@ -2371,8 +2370,6 @@ _NODISCARD _OutputIt _Fmt_write(
     return _Fmt_write(_STD move(_Out), basic_string_view<_CharT>{&_Value, 1}, _Specs, _Locale);
 }
 
-#pragma warning(push)
-#pragma warning(disable : 4365) // 'argument': conversion from 'char' to 'const wchar_t', signed/unsigned mismatch
 template <class _CharT, class _OutputIt, floating_point _Float>
 _NODISCARD _OutputIt _Fmt_write(
     _OutputIt _Out, const _Float _Value, const _Basic_format_specs<_CharT>& _Specs, _Lazy_locale _Locale) {
@@ -2576,7 +2573,7 @@ _NODISCARD _OutputIt _Fmt_write(
             }
         }
 
-        _Out = _RANGES _Copy_unchecked(_Buffer_start, _Exponent_start, _STD move(_Out)).out;
+        _Out = _RANGES transform(_Buffer_start, _Exponent_start, _STD move(_Out), _Widen_char<_CharT>{}).out;
         if (_Specs._Alt && _Append_decimal) {
             *_Out++ = '.';
         }
@@ -2585,7 +2582,7 @@ _NODISCARD _OutputIt _Fmt_write(
             *_Out++ = '0';
         }
 
-        return _RANGES _Copy_unchecked(_Exponent_start, _Result.ptr, _STD move(_Out)).out;
+        return _RANGES transform(_Exponent_start, _Result.ptr, _STD move(_Out), _Widen_char<_CharT>{}).out;
     };
 
     if (_Write_leading_zeroes) {
@@ -2594,7 +2591,6 @@ _NODISCARD _OutputIt _Fmt_write(
 
     return _Write_aligned(_STD move(_Out), _Width, _Specs, _Fmt_align::_Right, _Writer);
 }
-#pragma warning(pop)
 
 template <class _CharT, class _OutputIt>
 _NODISCARD _OutputIt _Fmt_write(

--- a/stl/inc/functional
+++ b/stl/inc/functional
@@ -1532,7 +1532,7 @@ class _Move_only_function_call {
 };
 
 // A script to generate the specializations is at
-// /tools/move_only_function_specializations/move_only_function_specializations.py
+// /tools/scripts/move_only_function_specializations.py
 // (Avoiding C++ preprocessor for better IDE navigation and debugging experience)
 
 template <class _Rx, class... _Types>

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -3331,16 +3331,6 @@ namespace ranges {
         // clang-format off
         subrange() requires default_initializable<_It> = default;
 
-#if !defined(_MSVC_INTERNAL_TESTING) && !defined(__clang__) && !defined(__EDG__) // TRANSITION, VS 17.1p3
-        // This was originally annotated as a workaround for DevCom-1331017, but the problem it corrects continued to
-        // manifest after that bug was fixed. We reduced a repro to file an additional bug, but the underlying issue had
-        // already been fixed in the internal compiler (see GH-2326).
-        constexpr subrange(const subrange&) = default;
-        constexpr subrange(subrange&&)      = default;
-        constexpr subrange& operator=(const subrange&) = default;
-        constexpr subrange& operator=(subrange&&) = default;
-#endif // ^^^ workaround ^^^
-
         template <_Convertible_to_non_slicing<_It> _It2>
         constexpr subrange(_It2 _First_, _Se _Last_) requires (!_Store_size)
             : _First(_STD move(_First_)), _Last(_STD move(_Last_)) {}

--- a/tests/std/tests/P0220R1_optional/test.cpp
+++ b/tests/std/tests/P0220R1_optional/test.cpp
@@ -696,9 +696,7 @@ int run_test()
     {
         optional<B> opt;
         ASSERT_NOT_NOEXCEPT(std::hash<optional<B>>()(opt));
-#ifndef __EDG__ // TRANSITION, DevCom-1633478 / VSO-1460046
         ASSERT_NOT_NOEXCEPT(std::hash<optional<const B>>()(opt));
-#endif // ^^^ no workaround ^^^
     }
 
     {

--- a/tools/scripts/move_only_function_specializations.py
+++ b/tools/scripts/move_only_function_specializations.py
@@ -1,6 +1,8 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+# This script generates the partial specializations of _Move_only_function_call in <functional>.
+
 def specialization(cv, ref, ref_inv, noex, noex_val, callable):
     return f"""template <class _Rx, class... _Types>
 class _Move_only_function_call<_Rx(_Types...) {cv} {ref} {noex}>

--- a/tools/scripts/print_failures.py
+++ b/tools/scripts/print_failures.py
@@ -1,0 +1,23 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# This script prints the output of test failures that were recorded by `stl-lit.py -o TEST_LOG_FILENAME`.
+
+import json
+import sys
+
+if len(sys.argv) != 2:
+    sys.exit(f"Usage: python {sys.argv[0]} TEST_LOG_FILENAME")
+
+test_log = json.load(open(sys.argv[1]))
+
+for result in test_log["tests"]:
+    if not result["code"] in ["PASS", "UNSUPPORTED", "XFAIL"]:
+        print("code: {}".format(result["code"]))
+        # Ignore result["elapsed"].
+        print("name: {}".format(result["name"]))
+        # The JSON contains embedded CRLFs (which aren't affected by opening the file in text mode).
+        # If we don't replace these CRLFs with LFs here, this script will appear to be okay in the console,
+        # but redirecting it to a file will result in ugly double newlines.
+        print("output: {}".format(result["output"].replace("\r\n", "\n")))
+        print("==================================================")


### PR DESCRIPTION
* Rename `tools/move_only_function_specializations` to `tools/scripts`.
  + Now we can add other scripts to this directory, and it avoids repeating the filename `move_only_function_specializations.py`.
  + Update the comment in `<functional>` accordingly.
  + Add a comment to `move_only_function_specializations.py` explaining what it does - even though the filename and code are fairly self-explanatory, as we accumulate scripts, it will be helpful for each of them to briefly mention what they do, so we don't need to deduce their intent from their code.
* Add `tools/scripts/print_failures.py`.
  + This automates the process of searching through test logs to find `FAIL` and `XPASS` tests, then decoding their JSON with search-and-replace (replacing CRLFs and LFs with newlines, unescaping double quotes and backslashes).
* Remove workaround for VSO-1460046 in `P0220R1_optional/test.cpp`.
  + This was "EDG rejects `hash<optional<const B>>` called with `optional<B>`".
* Remove compiler workaround in `subrange`.
* Remove workaround for VSO-1433873 in `<format>`.
  + This was "Standard Library Header Units: Adding `template <int = 0>` to `vformat()` emits warnings C4265 and C4365".
* Fix C4365 sign conversion warnings in `<format>`'s use of `fill_n`.
  + Filling with `'0'` can convert `char` to `wchar_t`. `_CharT{'0'}` forms the same type, avoiding the warning.
* Perma-workaround VSO-1464637 C4365 sign conversion warnings in `<format>`.
  + This is "Standard Library Header Units: `#pragma warning` doesn't always suppress warnings in templates", which @cdacamar has fixed in VS 2022 17.2 Preview 2.
  + Instead of copying `char` to `char/wchar_t` and silencing the warnings, we can use a function object to `transform()` with a `static_cast`. This is more elegant than silencing warnings, and should result in identical release codegen. (Debug mode has more function calls, but avoiding them isn't all-important.)
* Followup simplification: `ranges::transform()` can directly take `string_view`.
* `create-vmss.ps1`: Allow QUIC, renumber priorities.
  + QUIC was standardized as the transport layer for HTTP/3, and will presumably be used by tools in the future. Let's permit outbound connections now.
  + Priority values are arbitrary - [New-AzNetworkSecurityRuleConfig documentation][] says that a priority needs to be "An integer between 100 and 4096." To make future changes a bit easier, I'm following the QBASIC pattern for Allow rules (1000, 1010, 1020), and leaving lots of room before the Deny rule at 2000.
* Add `'Microsoft.VisualStudio.Component.VC.Tools.ARM64EC'` for #2491.
* Python 3.10.2.
* `create-vmss.ps1`: Also set the Azure CLI subscription.
  + This is the robust thing to do (although I haven't seen issues with the subscription getting set to something else, I realized that it was a potential issue).
  + Long-term, I'll investigate whether we can replace our usage of Azure CLI with Azure PowerShell as I've learned more.
* `create-vmss.ps1`: Use [member enumeration][] and the `-in` [containment operator][], making `Find-ResourceGroupNameCollision` unnecessary.
* Add `'THHmm'` to VMSS names.
  + This is a quality of life improvement when frequently creating and deleting resource groups, as it generates unique names with unique logs in the Azure portal.
  + I've kept the `-1`, `-2`, etc. suffix logic as it's theoretically needed, although in practice it should never appear. (Note that I tested the suffix logic changes before adding these timestamp changes.)
* Fix VMSS diagnostics.
  + I discovered that the diagnostics extension was failing (by logging into the VMs through Azure Bastion), apparently due to SAS token parsing. Through extensive searching, I found https://github.com/Azure/azure-cli/issues/8108#issuecomment-451625173 which helped me understand this. That issue resulted in an update to the [az vm diagnostics][] documentation - we're using [az vmss diagnostics][] whose documentation wasn't updated, but it's equally applicable.
  + I've updated the [Checklist for Toolset Updates][] accordingly, simplifying it - we don't need to manually prepare `vmss-config.json` and `vmss-protected.json` anymore!
  + This limits the permissions etc. for the SAS token, and adds `--https-only`, exactly following the documentation. (I think `--https-only` might have been the actual fix, but I didn't confirm that.)
  + This also replaces `'__DIAGNOSTIC_STORAGE_ACCOUNT__'` and `'__VM_OR_VMSS_RESOURCE_ID__'` in `vmss-config.json`, following the documentation. (I wasn't previously instructed that this was necessary, but in retrospect these strings are obviously placeholders.)
  + We can pass JSON directly to `--protected-settings`, avoiding saving the SAS token to disk. I'm leaving `/azure-devops/vmss-protected.json` mentioned in `.gitignore`.
  + Note that `vmss-config.json` is too big to pass on the command line, so it must be saved to a file.
  + The documentation doesn't depict the leading question mark being added to the SAS token in the JSON, but I believe that's a mistake, so I am adding it.
* `create-vmss.ps1`: Use `Out-Null` instead of ignored variables.
  + I just learned this existed.
* Use 2022-datacenter-g2, fixing the problems we've had with preparing toolset updates.
  + Thanks to @BillyONeal for mentioning that vcpkg had successfully performed a toolset update recently, which led me to think about any potential differences between our setups.
  + I've updated the [Checklist for Toolset Updates][] accordingly, simplifying the displayed SKU/version information with my increased knowledge of Azure PowerShell.
* New pool: VS 2022 17.1 Preview 4, ARM64EC, Server.
* Mention VS 2022 17.1 Preview 4 in `README.md`.

[New-AzNetworkSecurityRuleConfig documentation]: https://docs.microsoft.com/en-us/powershell/module/az.network/new-aznetworksecurityruleconfig?view=azps-7.1.0
[member enumeration]: https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_arrays?view=powershell-7.2#member-enumeration
[containment operator]: https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_comparison_operators?view=powershell-7.2
[az vm diagnostics]: https://docs.microsoft.com/en-us/cli/azure/vm/diagnostics?view=azure-cli-latest
[az vmss diagnostics]: https://docs.microsoft.com/en-us/cli/azure/vmss/diagnostics?view=azure-cli-latest
[Checklist for Toolset Updates]: https://github.com/microsoft/STL/wiki/Checklist-for-Toolset-Updates
