### PR TITLE
Status Chart: Modern modules, fix minor issues, weekly update

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,7 +97,7 @@
                     ...get_hidden('cxx20'),
                 },
                 {
-                    data: get_values(weekly_table, 'cxx23').concat(get_values(daily_table, 'cxx23')),
+                    data: get_values(daily_table, 'cxx23'),
                     label: 'C++23 Features',
                     borderColor: '#9966FF',
                     backgroundColor: '#9966FF',
@@ -487,13 +487,13 @@
 
             for (const field of ['cxx20', 'cxx23', 'lwg', 'pr', 'bug', 'issue', 'avg_age', 'avg_wait', 'sum_age',
                 'sum_wait', 'merged']) {
-                const value = daily_table[daily_table.length - 1][field];
-                document.getElementById(`currentValue-${field}`).textContent = value;
+                const value = daily_table[daily_table.length - 1][field] ?? 0;
+                document.getElementById(`currentValue-${field}`).textContent = value.toString();
             }
 
             for (const field of ['vso', 'libcxx']) {
                 const value = weekly_table[weekly_table.length - 1][field];
-                document.getElementById(`currentValue-${field}`).textContent = value;
+                document.getElementById(`currentValue-${field}`).textContent = value.toString();
             }
         };
     </script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,12 +12,12 @@
         "@octokit/graphql": "^4.8.0",
         "@types/cli-progress": "^3.9.2",
         "@types/luxon": "^2.0.9",
-        "@types/node": "^17.0.8",
+        "@types/node": "^17.0.10",
         "@types/yargs": "^17.0.8",
         "cli-progress": "^3.10.0",
-        "dotenv": "^12.0.3",
+        "dotenv": "^14.2.0",
         "luxon": "^2.3.0",
-        "typescript": "^4.5.4",
+        "typescript": "^4.5.5",
         "yargs": "^17.3.1"
       }
     },
@@ -91,9 +91,9 @@
       "integrity": "sha512-ZuzIc7aN+i2ZDMWIiSmMdubR9EMMSTdEzF6R+FckP4p6xdnOYKqknTo/k+xXQvciSXlNGIwA4OPU5X7JIFzYdA=="
     },
     "node_modules/@types/node": {
-      "version": "17.0.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.8.tgz",
-      "integrity": "sha512-YofkM6fGv4gDJq78g4j0mMuGMkZVxZDgtU0JRdx6FgiJDG+0fY0GKVolOV8WqVmEhLCXkQRjwDdKyPxJp/uucg=="
+      "version": "17.0.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.10.tgz",
+      "integrity": "sha512-S/3xB4KzyFxYGCppyDt68yzBU9ysL88lSdIah4D6cptdcltc4NCPCAMc0+PCpg/lLIyC7IPvj2Z52OJWeIUkog=="
     },
     "node_modules/@types/yargs": {
       "version": "17.0.8",
@@ -173,9 +173,9 @@
       "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
     },
     "node_modules/dotenv": {
-      "version": "12.0.3",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-12.0.3.tgz",
-      "integrity": "sha512-RlOysyzyGiABgDFgITo5fRnMV1QStdoVvkXhnxQc5Or/CiQo52s2Bh6DVMvzZsmFQ9IrNxYHOC/gdpNwHsitnQ==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-14.2.0.tgz",
+      "integrity": "sha512-05POuPJyPpO6jqzTNweQFfAyMSD4qa4lvsMOWyTRTdpHKy6nnnN+IYWaXF+lHivhBH/ufDKlR4IWCAN3oPnHuw==",
       "engines": {
         "node": ">=12"
       }
@@ -282,9 +282,9 @@
       "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
     },
     "node_modules/typescript": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -438,9 +438,9 @@
       "integrity": "sha512-ZuzIc7aN+i2ZDMWIiSmMdubR9EMMSTdEzF6R+FckP4p6xdnOYKqknTo/k+xXQvciSXlNGIwA4OPU5X7JIFzYdA=="
     },
     "@types/node": {
-      "version": "17.0.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.8.tgz",
-      "integrity": "sha512-YofkM6fGv4gDJq78g4j0mMuGMkZVxZDgtU0JRdx6FgiJDG+0fY0GKVolOV8WqVmEhLCXkQRjwDdKyPxJp/uucg=="
+      "version": "17.0.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.10.tgz",
+      "integrity": "sha512-S/3xB4KzyFxYGCppyDt68yzBU9ysL88lSdIah4D6cptdcltc4NCPCAMc0+PCpg/lLIyC7IPvj2Z52OJWeIUkog=="
     },
     "@types/yargs": {
       "version": "17.0.8",
@@ -505,9 +505,9 @@
       "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
     },
     "dotenv": {
-      "version": "12.0.3",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-12.0.3.tgz",
-      "integrity": "sha512-RlOysyzyGiABgDFgITo5fRnMV1QStdoVvkXhnxQc5Or/CiQo52s2Bh6DVMvzZsmFQ9IrNxYHOC/gdpNwHsitnQ=="
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-14.2.0.tgz",
+      "integrity": "sha512-05POuPJyPpO6jqzTNweQFfAyMSD4qa4lvsMOWyTRTdpHKy6nnnN+IYWaXF+lHivhBH/ufDKlR4IWCAN3oPnHuw=="
     },
     "emoji-regex": {
       "version": "8.0.0",
@@ -584,9 +584,9 @@
       "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
     },
     "typescript": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg=="
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA=="
     },
     "universal-user-agent": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -29,12 +29,12 @@
     "@octokit/graphql": "^4.8.0",
     "@types/cli-progress": "^3.9.2",
     "@types/luxon": "^2.0.9",
-    "@types/node": "^17.0.8",
+    "@types/node": "^17.0.10",
     "@types/yargs": "^17.0.8",
     "cli-progress": "^3.10.0",
-    "dotenv": "^12.0.3",
+    "dotenv": "^14.2.0",
     "luxon": "^2.3.0",
-    "typescript": "^4.5.4",
+    "typescript": "^4.5.5",
     "yargs": "^17.3.1"
   }
 }

--- a/src/gather_stats.ts
+++ b/src/gather_stats.ts
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-import * as fs from 'fs';
+import fs from 'fs';
 
-import * as cliProgress from 'cli-progress';
-import * as dotenv from 'dotenv';
+import cliProgress from 'cli-progress';
+import dotenv from 'dotenv';
 import { DateTime, Duration, Settings } from 'luxon';
 import { graphql } from '@octokit/graphql';
-import * as yargs from 'yargs';
+import yargs from 'yargs';
 
 Settings.defaultZone = 'America/Los_Angeles';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
         "target": "ES2020",
         "allowUnreachableCode": false,
         "allowUnusedLabels": false,
+        "esModuleInterop": true,
         "exactOptionalPropertyTypes": true,
         "strict": true,
         "forceConsistentCasingInFileNames": true,

--- a/weekly_table.js
+++ b/weekly_table.js
@@ -242,4 +242,5 @@ const weekly_table = [
     { date: '2021-12-31', vso: 177, libcxx: 590 },
     { date: '2022-01-07', vso: 180, libcxx: 590 },
     { date: '2022-01-14', vso: 182, libcxx: 590 },
+    { date: '2022-01-21', vso: 183, libcxx: 587 },
 ];


### PR DESCRIPTION
* Enable `esModuleInterop`.
  + This is a highly recommended modern option that disables legacy behavior. See the [compiler option docs](https://www.typescriptlang.org/tsconfig#esModuleInterop) and the [TypeScript 2.7 changelog](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-7.html#support-for-import-d-from-cjs-from-commonjs-modules-with---esmoduleinterop) when this was added.
* Fix issues found by TypeScript (that conversion is a work in progress, not present here).
  + The `weekly_table` lacks `'cxx23'`, so `get_values()` wasn't getting anything.
  + The `daily_table`'s current values can be `null` (when lines reach 0 and disappear), causing nothing to be printed. (It would look like "() C++20 STL features".) We need to detect this and print 0.
  + The current values are numbers, but `textContent` is a string. JavaScript will implicitly convert, but TypeScript will complain. We should explicitly call `toString()`.
* `weekly_table.js` updates.
* `npm install [dependencies]@latest`

:chart_with_downwards_trend: Live preview: [stephantlavavej.github.io/STL/](https://stephantlavavej.github.io/STL/)
===