### PR TITLE
constexpr all the generate_canonical parameters

### DIFF
--- a/stl/inc/random
+++ b/stl/inc/random
@@ -238,7 +238,7 @@ private:
     vector<result_type> _Myvec;
 };
 
-constexpr int _Generate_canonical_iterations(const int _Bits, const uint64_t _Gmin, const uint64_t _Gmax) {
+_NODISCARD constexpr int _Generate_canonical_iterations(const int _Bits, const uint64_t _Gmin, const uint64_t _Gmax) {
     // For a URBG type `G` with range == `(G::max() - G::min()) + 1`, returns the number of calls to generate at least
     // _Bits bits of entropy. Specifically, max(1, ceil(_Bits / log2(range))).
 
@@ -288,6 +288,14 @@ _NODISCARD _Real generate_canonical(_Gen& _Gx) { // build a floating-point value
     return _Ans / _Factor;
 }
 
+template <class _Gen, class = void>
+struct _Has_static_min_max : false_type {};
+
+// This checks a requirement of N4901 [rand.req.urng] `concept uniform_random_bit_generator` but doesn't attempt
+// to implement the whole concept - we just need to distinguish Standard machinery from tr1 machinery.
+template <class _Gen>
+struct _Has_static_min_max<_Gen, void_t<decltype(bool_constant<(_Gen::min)() < (_Gen::max)()>::value)>> : true_type {};
+
 template <class _Real, class _Gen>
 _NODISCARD _Real _Nrand_impl(_Gen& _Gx) { // build a floating-point value from random sequence
     _RNG_REQUIRE_REALTYPE(_Nrand_impl, _Real);
@@ -296,10 +304,9 @@ _NODISCARD _Real _Nrand_impl(_Gen& _Gx) { // build a floating-point value from r
     constexpr auto _Bits    = ~size_t{0};
     constexpr auto _Minbits = _Digits < _Bits ? _Digits : _Bits;
 
-    if constexpr (_Select_invoke_traits<decltype(&_Gen::min)>::_Is_invocable::value
-                  && _Select_invoke_traits<decltype(&_Gen::max)>::_Is_invocable::value && _Minbits <= 64) {
+    if constexpr (_Has_static_min_max<_Gen>::value && _Minbits <= 64) {
         return _STD generate_canonical<_Real, _Minbits>(_Gx);
-    } else {
+    } else { // TRANSITION, for tr1 machinery only; Standard machinery can call generate_canonical directly
         const _Real _Gxmin = static_cast<_Real>((_Gx.min)());
         const _Real _Gxmax = static_cast<_Real>((_Gx.max)());
         const _Real _Rx    = (_Gxmax - _Gxmin) + _Real{1};

--- a/stl/inc/random
+++ b/stl/inc/random
@@ -244,28 +244,24 @@ constexpr int _Generate_canonical_iterations(const int _Bits, const uint64_t _Gm
 
     _STL_INTERNAL_CHECK(0 <= _Bits && _Bits <= 64);
 
-    if (_Bits == 0) {
+    if (_Bits == 0 || (_Gmax == UINT64_MAX && _Gmin == 0)) {
         return 1;
     }
 
-    const auto _Range = (_Gmax - _Gmin) + 1;
-    if ((_Range & (_Range - 1)) == 0) {
-        return (_Bits - 1) / _Countr_zero(_Range) + 1;
-    } else {
-        const auto _Target = ~uint64_t{0} >> (64 - _Bits);
-        uint64_t _Prod     = 1;
-        int _Ceil          = 0;
-        while (_Prod <= _Target) {
-            ++_Ceil;
-            if (_Prod > UINT64_MAX / _Range) {
-                break;
-            }
-
-            _Prod *= _Range;
+    const auto _Range  = (_Gmax - _Gmin) + 1;
+    const auto _Target = ~uint64_t{0} >> (64 - _Bits);
+    uint64_t _Prod     = 1;
+    int _Ceil          = 0;
+    while (_Prod <= _Target) {
+        ++_Ceil;
+        if (_Prod > UINT64_MAX / _Range) {
+            break;
         }
 
-        return _Ceil;
+        _Prod *= _Range;
     }
+
+    return _Ceil;
 }
 
 template <class _Real, size_t _Bits, class _Gen>

--- a/stl/inc/random
+++ b/stl/inc/random
@@ -238,19 +238,48 @@ private:
     vector<result_type> _Myvec;
 };
 
+constexpr int _Generate_canonical_iterations(const int _Bits, const uint64_t _Gmin, const uint64_t _Gmax) {
+    // For a URBG type `G` with range == `(G::max() - G::min()) + 1`, returns the number of calls to generate at least
+    // _Bits bits of entropy. Specifically, max(1, ceil(_Bits / log2(range))).
+
+    int _Ceil = 0;
+    if (_Bits == 0) {
+        ;
+    } else if (_Gmax == UINT64_MAX && _Gmin == 0) {
+        _Ceil = ((_Bits - 1) / 64) + 1;
+    } else {
+        const auto _Range = (_Gmax - _Gmin) + 1;
+        if ((_Range & (_Range - 1)) == 0) {
+            _Ceil = (_Bits - 1) / _Countr_zero(_Range) + 1;
+        } else {
+            const auto _Target = ~uint64_t{0} >> (64 - _Bits);
+            uint64_t _Prod     = 1;
+            while (_Prod <= _Target) {
+                if (_Prod > UINT64_MAX / _Range) {
+                    ++_Ceil;
+                    break;
+                }
+                _Prod *= _Range;
+                ++_Ceil;
+            }
+        }
+    }
+
+    return _Ceil < 1 ? 1 : _Ceil;
+}
+
 template <class _Real, size_t _Bits, class _Gen>
 _NODISCARD _Real generate_canonical(_Gen& _Gx) { // build a floating-point value from random sequence
     _RNG_REQUIRE_REALTYPE(generate_canonical, _Real);
 
-    const size_t _Digits  = static_cast<size_t>(numeric_limits<_Real>::digits);
-    const size_t _Minbits = _Digits < _Bits ? _Digits : _Bits;
+    constexpr auto _Digits  = static_cast<size_t>(numeric_limits<_Real>::digits);
+    constexpr auto _Minbits = static_cast<int>(_Digits < _Bits ? _Digits : _Bits);
 
-    const _Real _Gxmin = static_cast<_Real>((_Gx.min)());
-    const _Real _Gxmax = static_cast<_Real>((_Gx.max)());
-    const _Real _Rx    = (_Gxmax - _Gxmin) + _Real{1};
+    constexpr auto _Gxmin = static_cast<_Real>((_Gen::min)());
+    constexpr auto _Gxmax = static_cast<_Real>((_Gen::max)());
+    constexpr auto _Rx    = (_Gxmax - _Gxmin) + _Real{1};
 
-    const int _Ceil = static_cast<int>(_STD ceil(static_cast<_Real>(_Minbits) / _STD log2(_Rx)));
-    const int _Kx   = _Ceil < 1 ? 1 : _Ceil;
+    constexpr int _Kx = _Generate_canonical_iterations(_Minbits, (_Gen::min)(), (_Gen::max)());
 
     _Real _Ans{0};
     _Real _Factor{1};
@@ -263,7 +292,38 @@ _NODISCARD _Real generate_canonical(_Gen& _Gx) { // build a floating-point value
     return _Ans / _Factor;
 }
 
-#define _NRAND(eng, resty) (_STD generate_canonical<resty, static_cast<size_t>(-1)>(eng))
+template <class _Real, class _Gen>
+_NODISCARD _Real _Nrand_impl(_Gen& _Gx) { // build a floating-point value from random sequence
+    _RNG_REQUIRE_REALTYPE(_Nrand_impl, _Real);
+
+    constexpr auto _Digits  = static_cast<size_t>(numeric_limits<_Real>::digits);
+    constexpr auto _Bits    = ~size_t{0};
+    constexpr auto _Minbits = _Digits < _Bits ? _Digits : _Bits;
+
+    if constexpr (_Select_invoke_traits<decltype(&_Gen::min)>::_Is_invocable::value
+                  && _Select_invoke_traits<decltype(&_Gen::max)>::_Is_invocable::value && _Minbits <= 64) {
+        return _STD generate_canonical<_Real, _Minbits>(_Gx);
+    } else {
+        const _Real _Gxmin = static_cast<_Real>((_Gx.min)());
+        const _Real _Gxmax = static_cast<_Real>((_Gx.max)());
+        const _Real _Rx    = (_Gxmax - _Gxmin) + _Real{1};
+
+        const int _Ceil = static_cast<int>(_STD ceil(static_cast<_Real>(_Minbits) / _STD log2(_Rx)));
+        const int _Kx   = _Ceil < 1 ? 1 : _Ceil;
+
+        _Real _Ans{0};
+        _Real _Factor{1};
+
+        for (int _Idx = 0; _Idx < _Kx; ++_Idx) { // add in another set of bits
+            _Ans += (static_cast<_Real>(_Gx()) - _Gxmin) * _Factor;
+            _Factor *= _Rx;
+        }
+
+        return _Ans / _Factor;
+    }
+}
+
+#define _NRAND(eng, resty) (_Nrand_impl<resty>(eng))
 
 _INLINE_VAR constexpr int _MP_len = 5;
 using _MP_arr                     = uint64_t[_MP_len];

--- a/stl/inc/random
+++ b/stl/inc/random
@@ -242,30 +242,30 @@ constexpr int _Generate_canonical_iterations(const int _Bits, const uint64_t _Gm
     // For a URBG type `G` with range == `(G::max() - G::min()) + 1`, returns the number of calls to generate at least
     // _Bits bits of entropy. Specifically, max(1, ceil(_Bits / log2(range))).
 
-    int _Ceil = 0;
+    _STL_INTERNAL_CHECK(0 <= _Bits && _Bits <= 64);
+
     if (_Bits == 0) {
-        ;
-    } else if (_Gmax == UINT64_MAX && _Gmin == 0) {
-        _Ceil = ((_Bits - 1) / 64) + 1;
-    } else {
-        const auto _Range = (_Gmax - _Gmin) + 1;
-        if ((_Range & (_Range - 1)) == 0) {
-            _Ceil = (_Bits - 1) / _Countr_zero(_Range) + 1;
-        } else {
-            const auto _Target = ~uint64_t{0} >> (64 - _Bits);
-            uint64_t _Prod     = 1;
-            while (_Prod <= _Target) {
-                if (_Prod > UINT64_MAX / _Range) {
-                    ++_Ceil;
-                    break;
-                }
-                _Prod *= _Range;
-                ++_Ceil;
-            }
-        }
+        return 1;
     }
 
-    return _Ceil < 1 ? 1 : _Ceil;
+    const auto _Range = (_Gmax - _Gmin) + 1;
+    if ((_Range & (_Range - 1)) == 0) {
+        return (_Bits - 1) / _Countr_zero(_Range) + 1;
+    } else {
+        const auto _Target = ~uint64_t{0} >> (64 - _Bits);
+        uint64_t _Prod     = 1;
+        int _Ceil          = 0;
+        while (_Prod <= _Target) {
+            ++_Ceil;
+            if (_Prod > UINT64_MAX / _Range) {
+                break;
+            }
+
+            _Prod *= _Range;
+        }
+
+        return _Ceil;
+    }
 }
 
 template <class _Real, size_t _Bits, class _Gen>

--- a/tests/std/test.lst
+++ b/tests/std/test.lst
@@ -186,6 +186,7 @@ tests\GH_001638_dllexport_derived_classes
 tests\GH_001850_clog_tied_to_cout
 tests\GH_001858_iostream_exception
 tests\GH_001914_cached_position
+tests\GH_001964_constexpr_generate_canonical
 tests\GH_002030_asan_annotate_vector
 tests\GH_002039_byte_is_not_trivially_swappable
 tests\GH_002058_debug_iterator_race

--- a/tests/std/tests/GH_001964_constexpr_generate_canonical/env.lst
+++ b/tests/std/tests/GH_001964_constexpr_generate_canonical/env.lst
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+RUNALL_INCLUDE ..\usual_latest_matrix.lst

--- a/tests/std/tests/GH_001964_constexpr_generate_canonical/env.lst
+++ b/tests/std/tests/GH_001964_constexpr_generate_canonical/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\usual_latest_matrix.lst
+RUNALL_INCLUDE ..\usual_matrix.lst

--- a/tests/std/tests/GH_001964_constexpr_generate_canonical/test.cpp
+++ b/tests/std/tests/GH_001964_constexpr_generate_canonical/test.cpp
@@ -18,8 +18,8 @@ int naive_iterations(const int bits, const uint64_t gmin, const uint64_t gmax) {
 void test(const int target_bits) {
     // Increase the range until the number of iterations repeats.
     uint64_t range = 2;
-    int k        = 0;
-    int prev_k   = -1;
+    int k          = 0;
+    int prev_k     = -1;
     while (k != prev_k) {
         prev_k       = exchange(k, naive_iterations(target_bits, 1, range));
         const int k1 = _Generate_canonical_iterations(target_bits, 1, range);

--- a/tests/std/tests/GH_001964_constexpr_generate_canonical/test.cpp
+++ b/tests/std/tests/GH_001964_constexpr_generate_canonical/test.cpp
@@ -6,7 +6,7 @@
 
 using namespace std;
 
-int naive_iterations(const int bits, const size_t gmin, const size_t gmax) {
+int naive_iterations(const int bits, const uint64_t gmin, const uint64_t gmax) {
     // Naive implementation of [rand.util.canonical]. Note that for large values of range, it's possible that
     // log2(range) == bits when range < 2^bits. This can lead to incorrect results, so we can't use this function as
     // a reference for all values.
@@ -15,9 +15,9 @@ int naive_iterations(const int bits, const size_t gmin, const size_t gmax) {
     return static_cast<int>(ceil(static_cast<double>(bits) / log2(static_cast<double>(range))));
 }
 
-bool test(const int target_bits) {
+void test(const int target_bits) {
     // Increase the range until the number of iterations repeats.
-    size_t range = 2;
+    uint64_t range = 2;
     int k        = 0;
     int prev_k   = -1;
     while (k != prev_k) {
@@ -33,9 +33,9 @@ bool test(const int target_bits) {
     for (; k > 0; --k) {
         // The largest range such that k iterations generating [1,range] produces less than target_bits bits.
         if (k == 1) {
-            range = ~size_t{0} >> (64 - target_bits);
+            range = ~uint64_t{0} >> (64 - target_bits);
         } else {
-            range = static_cast<size_t>(ceil(pow(2.0, static_cast<double>(target_bits) / k))) - 1;
+            range = static_cast<uint64_t>(ceil(pow(2.0, static_cast<double>(target_bits) / k))) - 1;
         }
 
         int k0 = (k == 1) ? 2 : naive_iterations(target_bits, 1, range);

--- a/tests/std/tests/GH_001964_constexpr_generate_canonical/test.cpp
+++ b/tests/std/tests/GH_001964_constexpr_generate_canonical/test.cpp
@@ -1,0 +1,58 @@
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <random>
+#include <utility>
+
+using namespace std;
+
+int naive_iterations(const int bits, const size_t gmin, const size_t gmax) {
+    // Naive implementation of [rand.util.canonical]. Note that for large values of range, it's possible that
+    // log2(range) == bits when range < 2^bits. This can lead to incorrect results, so we can't use this function as
+    // a reference for all values.
+
+    const double range = static_cast<double>(gmax) - static_cast<double>(gmin) + 1.0;
+    return static_cast<int>(ceil(static_cast<double>(bits) / log2(static_cast<double>(range))));
+}
+
+bool test(const int target_bits) {
+    // Increase the range until the number of iterations repeats.
+    size_t range = 2;
+    int k        = 0;
+    int prev_k   = -1;
+    while (k != prev_k) {
+        prev_k       = exchange(k, naive_iterations(target_bits, 1, range));
+        const int k1 = _Generate_canonical_iterations(target_bits, 1, range);
+        assert(k == k1);
+        ++range;
+    }
+
+    // Now only check the crossover points, where incrementing the range actually causes the number of iterations to
+    // increase.
+    --k;
+    for (; k > 0; --k) {
+        // The largest range such that k iterations generating [1,range] produces less than target_bits bits.
+        if (k == 1) {
+            range = ~size_t{0} >> (64 - target_bits);
+        } else {
+            range = static_cast<size_t>(ceil(pow(2.0, static_cast<double>(target_bits) / k))) - 1;
+        }
+
+        int k0 = (k == 1) ? 2 : naive_iterations(target_bits, 1, range);
+        int k1 = _Generate_canonical_iterations(target_bits, 1, range);
+        assert(k0 == k1 && k1 == k + 1);
+
+        k0 = (k == 1) ? 1 : naive_iterations(target_bits, 0, range);
+        k1 = _Generate_canonical_iterations(target_bits, 0, range);
+        assert(k0 == k1 && k1 == k);
+    }
+}
+
+int main() {
+    static_assert(_Generate_canonical_iterations(53, 1, uint64_t{1} << 32) == 2);
+    static_assert(_Generate_canonical_iterations(64, 0, ~uint64_t{0}) == 1);
+
+    for (int bits = 1; bits <= 64; ++bits) {
+        test(bits);
+    }
+}

--- a/tests/std/tests/GH_001964_constexpr_generate_canonical/test.cpp
+++ b/tests/std/tests/GH_001964_constexpr_generate_canonical/test.cpp
@@ -12,7 +12,7 @@ int naive_iterations(const int bits, const uint64_t gmin, const uint64_t gmax) {
     // a reference for all values.
 
     const double range = static_cast<double>(gmax) - static_cast<double>(gmin) + 1.0;
-    return static_cast<int>(ceil(static_cast<double>(bits) / log2(static_cast<double>(range))));
+    return max(1, static_cast<int>(ceil(static_cast<double>(bits) / log2(static_cast<double>(range)))));
 }
 
 void test(const int target_bits) {
@@ -51,7 +51,7 @@ int main() {
     static_assert(_Generate_canonical_iterations(53, 1, uint64_t{1} << 32) == 2, "");
     static_assert(_Generate_canonical_iterations(64, 0, ~uint64_t{0}) == 1, "");
 
-    for (int bits = 1; bits <= 64; ++bits) {
+    for (int bits = 0; bits <= 64; ++bits) {
         test(bits);
     }
 }

--- a/tests/std/tests/GH_001964_constexpr_generate_canonical/test.cpp
+++ b/tests/std/tests/GH_001964_constexpr_generate_canonical/test.cpp
@@ -29,8 +29,7 @@ void test(const int target_bits) {
 
     // Now only check the crossover points, where incrementing the range actually causes the number of iterations to
     // increase.
-    --k;
-    for (; k > 0; --k) {
+    while (--k) {
         // The largest range such that k iterations generating [1,range] produces less than target_bits bits.
         if (k == 1) {
             range = ~uint64_t{0} >> (64 - target_bits);
@@ -49,8 +48,8 @@ void test(const int target_bits) {
 }
 
 int main() {
-    static_assert(_Generate_canonical_iterations(53, 1, uint64_t{1} << 32) == 2);
-    static_assert(_Generate_canonical_iterations(64, 0, ~uint64_t{0}) == 1);
+    static_assert(_Generate_canonical_iterations(53, 1, uint64_t{1} << 32) == 2, "");
+    static_assert(_Generate_canonical_iterations(64, 0, ~uint64_t{0}) == 1, "");
 
     for (int bits = 1; bits <= 64; ++bits) {
         test(bits);

--- a/tests/std/tests/GH_001964_constexpr_generate_canonical/test.cpp
+++ b/tests/std/tests/GH_001964_constexpr_generate_canonical/test.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
 #include <cassert>
 #include <cmath>
 #include <cstdint>
@@ -6,13 +9,15 @@
 
 using namespace std;
 
+#define STATIC_ASSERT(...) static_assert(__VA_ARGS__, #__VA_ARGS__)
+
 int naive_iterations(const int bits, const uint64_t gmin, const uint64_t gmax) {
     // Naive implementation of [rand.util.canonical]. Note that for large values of range, it's possible that
     // log2(range) == bits when range < 2^bits. This can lead to incorrect results, so we can't use this function as
     // a reference for all values.
 
     const double range = static_cast<double>(gmax) - static_cast<double>(gmin) + 1.0;
-    return max(1, static_cast<int>(ceil(static_cast<double>(bits) / log2(static_cast<double>(range)))));
+    return max(1, static_cast<int>(ceil(static_cast<double>(bits) / log2(range))));
 }
 
 void test(const int target_bits) {
@@ -29,7 +34,7 @@ void test(const int target_bits) {
 
     // Now only check the crossover points, where incrementing the range actually causes the number of iterations to
     // increase.
-    while (--k) {
+    while (--k != 0) {
         // The largest range such that k iterations generating [1,range] produces less than target_bits bits.
         if (k == 1) {
             range = ~uint64_t{0} >> (64 - target_bits);
@@ -39,17 +44,19 @@ void test(const int target_bits) {
 
         int k0 = (k == 1) ? 2 : naive_iterations(target_bits, 1, range);
         int k1 = _Generate_canonical_iterations(target_bits, 1, range);
-        assert(k0 == k1 && k1 == k + 1);
+        assert(k0 == k1);
+        assert(k1 == k + 1);
 
         k0 = (k == 1) ? 1 : naive_iterations(target_bits, 0, range);
         k1 = _Generate_canonical_iterations(target_bits, 0, range);
-        assert(k0 == k1 && k1 == k);
+        assert(k0 == k1);
+        assert(k1 == k);
     }
 }
 
 int main() {
-    static_assert(_Generate_canonical_iterations(53, 1, uint64_t{1} << 32) == 2, "");
-    static_assert(_Generate_canonical_iterations(64, 0, ~uint64_t{0}) == 1, "");
+    STATIC_ASSERT(_Generate_canonical_iterations(53, 1, uint64_t{1} << 32) == 2);
+    STATIC_ASSERT(_Generate_canonical_iterations(64, 0, ~uint64_t{0}) == 1);
 
     for (int bits = 0; bits <= 64; ++bits) {
         test(bits);


### PR DESCRIPTION
...up to 64 bits of entropy. Leave the original implementation for
more bits and naughty generators (I'm looking at you, tr1) whose
min and max functions aren't static.

Fixes #1964. Alternative to #2452.

A slightly modified version of @CaseyCarter's release (`/O2 /fp:strict` for me) codegen test:

```cpp
#include <random>

template <size_t kMax>
struct Engine {
    using result_type = size_t;

    static constexpr result_type min() noexcept {
        return 0;
    }
    static constexpr result_type max() noexcept {
        return kMax;
    }

    result_type operator()() noexcept;
};

template <class R, class G>
R meow(G& g) {
    return std::generate_canonical < R, ~std::size_t{ 0 } > (g);
}

template double meow(Engine<10'000>&);
template double meow(Engine<~size_t{0}>&);
```

<details>
<summary>asm diff</summary>

```diff
diff --git a/before.asm b/after.asm
index 5a4e672e..a5d6f74f 100644
--- a/before.asm
+++ b/after.asm
@@ -12,102 +12,43 @@ PUBLIC	??$meow@NU?$Engine@$0CHBA@@@@@YANAEAU?$Engine@$0CHBA@@@@Z ; meow<double,E
 PUBLIC	??$meow@NU?$Engine@$0?0@@@@YANAEAU?$Engine@$0?0@@@Z ; meow<double,Engine<-1> >
 PUBLIC	??$generate_canonical@N$0?0U?$Engine@$0CHBA@@@@std@@YANAEAU?$Engine@$0CHBA@@@@Z ; std::generate_canonical<double,-1,Engine<10000> >
 PUBLIC	??$generate_canonical@N$0?0U?$Engine@$0?0@@@std@@YANAEAU?$Engine@$0?0@@@Z ; std::generate_canonical<double,-1,Engine<-1> >
-PUBLIC	?min@?$Engine@$0CHBA@@@SA_KXZ			; Engine<10000>::min
-PUBLIC	?max@?$Engine@$0CHBA@@@SA_KXZ			; Engine<10000>::max
-PUBLIC	?min@?$Engine@$0?0@@SA_KXZ			; Engine<-1>::min
-PUBLIC	?max@?$Engine@$0?0@@SA_KXZ			; Engine<-1>::max
 PUBLIC	__real@3ff0000000000000
-PUBLIC	__real@404a800000000000
-PUBLIC	__real@40c3880000000000
+PUBLIC	__real@40c3888000000000
 PUBLIC	__real@43f0000000000000
-EXTRN	ceil:PROC
-EXTRN	log2:PROC
 EXTRN	??R?$Engine@$0CHBA@@@QEAA_KXZ:PROC		; Engine<10000>::operator()
 EXTRN	??R?$Engine@$0?0@@QEAA_KXZ:PROC			; Engine<-1>::operator()
 EXTRN	_fltused:DWORD
 ;	COMDAT pdata
 pdata	SEGMENT
 $pdata$??$meow@NU?$Engine@$0CHBA@@@@@YANAEAU?$Engine@$0CHBA@@@@Z DD imagerel $LN15
-	DD	imagerel $LN15+112
+	DD	imagerel $LN15+172
 	DD	imagerel $unwind$??$meow@NU?$Engine@$0CHBA@@@@@YANAEAU?$Engine@$0CHBA@@@@Z
 pdata	ENDS
 ;	COMDAT pdata
 pdata	SEGMENT
-$pdata$0$??$meow@NU?$Engine@$0CHBA@@@@@YANAEAU?$Engine@$0CHBA@@@@Z DD imagerel $LN15+112
-	DD	imagerel $LN15+192
-	DD	imagerel $chain$0$??$meow@NU?$Engine@$0CHBA@@@@@YANAEAU?$Engine@$0CHBA@@@@Z
-pdata	ENDS
-;	COMDAT pdata
-pdata	SEGMENT
-$pdata$1$??$meow@NU?$Engine@$0CHBA@@@@@YANAEAU?$Engine@$0CHBA@@@@Z DD imagerel $LN15+192
-	DD	imagerel $LN15+227
-	DD	imagerel $chain$1$??$meow@NU?$Engine@$0CHBA@@@@@YANAEAU?$Engine@$0CHBA@@@@Z
-pdata	ENDS
-;	COMDAT pdata
-pdata	SEGMENT
 $pdata$??$meow@NU?$Engine@$0?0@@@@YANAEAU?$Engine@$0?0@@@Z DD imagerel $LN15
-	DD	imagerel $LN15+112
+	DD	imagerel $LN15+69
 	DD	imagerel $unwind$??$meow@NU?$Engine@$0?0@@@@YANAEAU?$Engine@$0?0@@@Z
 pdata	ENDS
 ;	COMDAT pdata
 pdata	SEGMENT
-$pdata$0$??$meow@NU?$Engine@$0?0@@@@YANAEAU?$Engine@$0?0@@@Z DD imagerel $LN15+112
-	DD	imagerel $LN15+192
-	DD	imagerel $chain$0$??$meow@NU?$Engine@$0?0@@@@YANAEAU?$Engine@$0?0@@@Z
-pdata	ENDS
-;	COMDAT pdata
-pdata	SEGMENT
-$pdata$1$??$meow@NU?$Engine@$0?0@@@@YANAEAU?$Engine@$0?0@@@Z DD imagerel $LN15+192
-	DD	imagerel $LN15+227
-	DD	imagerel $chain$1$??$meow@NU?$Engine@$0?0@@@@YANAEAU?$Engine@$0?0@@@Z
-pdata	ENDS
-;	COMDAT pdata
-pdata	SEGMENT
 $pdata$??$generate_canonical@N$0?0U?$Engine@$0CHBA@@@@std@@YANAEAU?$Engine@$0CHBA@@@@Z DD imagerel $LN13
-	DD	imagerel $LN13+112
+	DD	imagerel $LN13+172
 	DD	imagerel $unwind$??$generate_canonical@N$0?0U?$Engine@$0CHBA@@@@std@@YANAEAU?$Engine@$0CHBA@@@@Z
 pdata	ENDS
 ;	COMDAT pdata
 pdata	SEGMENT
-$pdata$0$??$generate_canonical@N$0?0U?$Engine@$0CHBA@@@@std@@YANAEAU?$Engine@$0CHBA@@@@Z DD imagerel $LN13+112
-	DD	imagerel $LN13+192
-	DD	imagerel $chain$0$??$generate_canonical@N$0?0U?$Engine@$0CHBA@@@@std@@YANAEAU?$Engine@$0CHBA@@@@Z
-pdata	ENDS
-;	COMDAT pdata
-pdata	SEGMENT
-$pdata$1$??$generate_canonical@N$0?0U?$Engine@$0CHBA@@@@std@@YANAEAU?$Engine@$0CHBA@@@@Z DD imagerel $LN13+192
-	DD	imagerel $LN13+227
-	DD	imagerel $chain$1$??$generate_canonical@N$0?0U?$Engine@$0CHBA@@@@std@@YANAEAU?$Engine@$0CHBA@@@@Z
-pdata	ENDS
-;	COMDAT pdata
-pdata	SEGMENT
 $pdata$??$generate_canonical@N$0?0U?$Engine@$0?0@@@std@@YANAEAU?$Engine@$0?0@@@Z DD imagerel $LN13
-	DD	imagerel $LN13+112
+	DD	imagerel $LN13+69
 	DD	imagerel $unwind$??$generate_canonical@N$0?0U?$Engine@$0?0@@@std@@YANAEAU?$Engine@$0?0@@@Z
 pdata	ENDS
-;	COMDAT pdata
-pdata	SEGMENT
-$pdata$0$??$generate_canonical@N$0?0U?$Engine@$0?0@@@std@@YANAEAU?$Engine@$0?0@@@Z DD imagerel $LN13+112
-	DD	imagerel $LN13+192
-	DD	imagerel $chain$0$??$generate_canonical@N$0?0U?$Engine@$0?0@@@std@@YANAEAU?$Engine@$0?0@@@Z
-pdata	ENDS
-;	COMDAT pdata
-pdata	SEGMENT
-$pdata$1$??$generate_canonical@N$0?0U?$Engine@$0?0@@@std@@YANAEAU?$Engine@$0?0@@@Z DD imagerel $LN13+192
-	DD	imagerel $LN13+227
-	DD	imagerel $chain$1$??$generate_canonical@N$0?0U?$Engine@$0?0@@@std@@YANAEAU?$Engine@$0?0@@@Z
-pdata	ENDS
 ;	COMDAT __real@43f0000000000000
 CONST	SEGMENT
 __real@43f0000000000000 DQ 043f0000000000000r	; 1.84467e+19
 CONST	ENDS
-;	COMDAT __real@40c3880000000000
-CONST	SEGMENT
-__real@40c3880000000000 DQ 040c3880000000000r	; 10000
-CONST	ENDS
-;	COMDAT __real@404a800000000000
+;	COMDAT __real@40c3888000000000
 CONST	SEGMENT
-__real@404a800000000000 DQ 0404a800000000000r	; 53
+__real@40c3888000000000 DQ 040c3888000000000r	; 10001
 CONST	ENDS
 ;	COMDAT __real@3ff0000000000000
 CONST	SEGMENT
@@ -115,187 +56,44 @@ __real@3ff0000000000000 DQ 03ff0000000000000r	; 1
 CONST	ENDS
 ;	COMDAT xdata
 xdata	SEGMENT
-$chain$1$??$generate_canonical@N$0?0U?$Engine@$0?0@@@std@@YANAEAU?$Engine@$0?0@@@Z DD 021H
-	DD	imagerel $LN13
-	DD	imagerel $LN13+112
-	DD	imagerel $unwind$??$generate_canonical@N$0?0U?$Engine@$0?0@@@std@@YANAEAU?$Engine@$0?0@@@Z
-xdata	ENDS
-;	COMDAT xdata
-xdata	SEGMENT
-$chain$0$??$generate_canonical@N$0?0U?$Engine@$0?0@@@std@@YANAEAU?$Engine@$0?0@@@Z DD 020521H
-	DD	0e3405H
-	DD	imagerel $LN13
-	DD	imagerel $LN13+112
-	DD	imagerel $unwind$??$generate_canonical@N$0?0U?$Engine@$0?0@@@std@@YANAEAU?$Engine@$0?0@@@Z
+$unwind$??$generate_canonical@N$0?0U?$Engine@$0?0@@@std@@YANAEAU?$Engine@$0?0@@@Z DD 010401H
+	DD	04204H
 xdata	ENDS
 ;	COMDAT xdata
 xdata	SEGMENT
-$unwind$??$generate_canonical@N$0?0U?$Engine@$0?0@@@std@@YANAEAU?$Engine@$0?0@@@Z DD 0a3001H
-	DD	029830H
-	DD	038821H
-	DD	04781bH
-	DD	05680bH
-	DD	07002b206H
+$unwind$??$generate_canonical@N$0?0U?$Engine@$0CHBA@@@@std@@YANAEAU?$Engine@$0CHBA@@@@Z DD 0c3701H
+	DD	029837H
+	DD	03882dH
+	DD	047817H
+	DD	05680fH
+	DD	0e340aH
+	DD	07006b20aH
 xdata	ENDS
 ;	COMDAT xdata
 xdata	SEGMENT
-$chain$1$??$generate_canonical@N$0?0U?$Engine@$0CHBA@@@@std@@YANAEAU?$Engine@$0CHBA@@@@Z DD 021H
-	DD	imagerel $LN13
-	DD	imagerel $LN13+112
-	DD	imagerel $unwind$??$generate_canonical@N$0?0U?$Engine@$0CHBA@@@@std@@YANAEAU?$Engine@$0CHBA@@@@Z
+$unwind$??$meow@NU?$Engine@$0?0@@@@YANAEAU?$Engine@$0?0@@@Z DD 010401H
+	DD	04204H
 xdata	ENDS
 ;	COMDAT xdata
 xdata	SEGMENT
-$chain$0$??$generate_canonical@N$0?0U?$Engine@$0CHBA@@@@std@@YANAEAU?$Engine@$0CHBA@@@@Z DD 020521H
-	DD	0e3405H
-	DD	imagerel $LN13
-	DD	imagerel $LN13+112
-	DD	imagerel $unwind$??$generate_canonical@N$0?0U?$Engine@$0CHBA@@@@std@@YANAEAU?$Engine@$0CHBA@@@@Z
+$unwind$??$meow@NU?$Engine@$0CHBA@@@@@YANAEAU?$Engine@$0CHBA@@@@Z DD 0c3701H
+	DD	029837H
+	DD	03882dH
+	DD	047817H
+	DD	05680fH
+	DD	0e340aH
+	DD	07006b20aH
 xdata	ENDS
-;	COMDAT xdata
-xdata	SEGMENT
-$unwind$??$generate_canonical@N$0?0U?$Engine@$0CHBA@@@@std@@YANAEAU?$Engine@$0CHBA@@@@Z DD 0a3001H
-	DD	029830H
-	DD	038821H
-	DD	04781bH
-	DD	05680bH
-	DD	07002b206H
-xdata	ENDS
-;	COMDAT xdata
-xdata	SEGMENT
-$chain$1$??$meow@NU?$Engine@$0?0@@@@YANAEAU?$Engine@$0?0@@@Z DD 021H
-	DD	imagerel $LN15
-	DD	imagerel $LN15+112
-	DD	imagerel $unwind$??$meow@NU?$Engine@$0?0@@@@YANAEAU?$Engine@$0?0@@@Z
-xdata	ENDS
-;	COMDAT xdata
-xdata	SEGMENT
-$chain$0$??$meow@NU?$Engine@$0?0@@@@YANAEAU?$Engine@$0?0@@@Z DD 020521H
-	DD	0e3405H
-	DD	imagerel $LN15
-	DD	imagerel $LN15+112
-	DD	imagerel $unwind$??$meow@NU?$Engine@$0?0@@@@YANAEAU?$Engine@$0?0@@@Z
-xdata	ENDS
-;	COMDAT xdata
-xdata	SEGMENT
-$unwind$??$meow@NU?$Engine@$0?0@@@@YANAEAU?$Engine@$0?0@@@Z DD 0a3001H
-	DD	029830H
-	DD	038821H
-	DD	04781bH
-	DD	05680bH
-	DD	07002b206H
-xdata	ENDS
-;	COMDAT xdata
-xdata	SEGMENT
-$chain$1$??$meow@NU?$Engine@$0CHBA@@@@@YANAEAU?$Engine@$0CHBA@@@@Z DD 021H
-	DD	imagerel $LN15
-	DD	imagerel $LN15+112
-	DD	imagerel $unwind$??$meow@NU?$Engine@$0CHBA@@@@@YANAEAU?$Engine@$0CHBA@@@@Z
-xdata	ENDS
-;	COMDAT xdata
-xdata	SEGMENT
-$chain$0$??$meow@NU?$Engine@$0CHBA@@@@@YANAEAU?$Engine@$0CHBA@@@@Z DD 020521H
-	DD	0e3405H
-	DD	imagerel $LN15
-	DD	imagerel $LN15+112
-	DD	imagerel $unwind$??$meow@NU?$Engine@$0CHBA@@@@@YANAEAU?$Engine@$0CHBA@@@@Z
-xdata	ENDS
-;	COMDAT xdata
-xdata	SEGMENT
-$unwind$??$meow@NU?$Engine@$0CHBA@@@@@YANAEAU?$Engine@$0CHBA@@@@Z DD 0a3001H
-	DD	029830H
-	DD	038821H
-	DD	04781bH
-	DD	05680bH
-	DD	07002b206H
-xdata	ENDS
-; Function compile flags: /Ogtpy
-;	COMDAT ?max@?$Engine@$0?0@@SA_KXZ
-_TEXT	SEGMENT
-?max@?$Engine@$0?0@@SA_KXZ PROC				; Engine<-1>::max, COMDAT
-; File c:\Users\Matt\source\repos\STL\stl\inc\gen-can-test.cpp
-; Line 11
-	mov	rax, -1
-; Line 12
-	ret	0
-?max@?$Engine@$0?0@@SA_KXZ ENDP				; Engine<-1>::max
-_TEXT	ENDS
-; Function compile flags: /Ogtpy
-;	COMDAT ?min@?$Engine@$0?0@@SA_KXZ
-_TEXT	SEGMENT
-?min@?$Engine@$0?0@@SA_KXZ PROC				; Engine<-1>::min, COMDAT
-; File c:\Users\Matt\source\repos\STL\stl\inc\gen-can-test.cpp
-; Line 8
-	xor	eax, eax
-; Line 9
-	ret	0
-?min@?$Engine@$0?0@@SA_KXZ ENDP				; Engine<-1>::min
-_TEXT	ENDS
-; Function compile flags: /Ogtpy
-;	COMDAT ?max@?$Engine@$0CHBA@@@SA_KXZ
-_TEXT	SEGMENT
-?max@?$Engine@$0CHBA@@@SA_KXZ PROC			; Engine<10000>::max, COMDAT
-; File c:\Users\Matt\source\repos\STL\stl\inc\gen-can-test.cpp
-; Line 11
-	mov	eax, 10000				; 00002710H
-; Line 12
-	ret	0
-?max@?$Engine@$0CHBA@@@SA_KXZ ENDP			; Engine<10000>::max
-_TEXT	ENDS
-; Function compile flags: /Ogtpy
-;	COMDAT ?min@?$Engine@$0CHBA@@@SA_KXZ
-_TEXT	SEGMENT
-?min@?$Engine@$0CHBA@@@SA_KXZ PROC			; Engine<10000>::min, COMDAT
-; File c:\Users\Matt\source\repos\STL\stl\inc\gen-can-test.cpp
-; Line 8
-	xor	eax, eax
-; Line 9
-	ret	0
-?min@?$Engine@$0CHBA@@@SA_KXZ ENDP			; Engine<10000>::min
-_TEXT	ENDS
 ; Function compile flags: /Ogtpy
 ;	COMDAT ??$generate_canonical@N$0?0U?$Engine@$0?0@@@std@@YANAEAU?$Engine@$0?0@@@Z
 _TEXT	SEGMENT
-_Gx$ = 112
+_Gx$ = 48
 ??$generate_canonical@N$0?0U?$Engine@$0?0@@@std@@YANAEAU?$Engine@$0?0@@@Z PROC ; std::generate_canonical<double,-1,Engine<-1> >, COMDAT
 ; File C:\Users\Matt\source\repos\STL\stl\inc\random
-; Line 242
+; Line 272
 $LN13:
-	push	rdi
-	sub	rsp, 96					; 00000060H
-	movaps	XMMWORD PTR [rsp+80], xmm6
-	mov	rdi, rcx
-; Line 250
-	movsd	xmm6, QWORD PTR __real@3ff0000000000000
-	movaps	XMMWORD PTR [rsp+64], xmm7
-	movaps	XMMWORD PTR [rsp+48], xmm8
-	movsd	xmm8, QWORD PTR __real@43f0000000000000
-	movaps	XMMWORD PTR [rsp+32], xmm9
-	xorps	xmm9, xmm9
-	subsd	xmm8, xmm9
-	addsd	xmm8, xmm6
-; Line 252
-	movaps	xmm0, xmm8
-	call	log2
-	movsd	xmm1, QWORD PTR __real@404a800000000000
-	divsd	xmm1, xmm0
-	movaps	xmm0, xmm1
-	call	ceil
-	cvttsd2si eax, xmm0
-; Line 253
-	mov	ecx, 1
-	xorps	xmm7, xmm7
-	cmp	eax, ecx
-	cmovl	eax, ecx
-; Line 258
-	test	eax, eax
-	jle	SHORT $LN3@generate_c
-; Line 250
-	mov	QWORD PTR [rsp+112], rbx
-	mov	ebx, eax
-$LL4@generate_c:
-; Line 259
-	mov	rcx, rdi
+	sub	rsp, 40					; 00000028H
+; Line 288
 	call	??R?$Engine@$0?0@@QEAA_KXZ		; Engine<-1>::operator()
 	mov	rcx, rax
 	xorps	xmm0, xmm0
@@ -310,25 +108,13 @@ $LN10@generate_c:
 	cvtsi2sd xmm0, rax
 	addsd	xmm0, xmm0
 $LN11@generate_c:
-	subsd	xmm0, xmm9
-	mulsd	xmm0, xmm6
-; Line 260
-	mulsd	xmm6, xmm8
-	addsd	xmm7, xmm0
-	sub	rbx, 1
-	jne	SHORT $LL4@generate_c
-; Line 258
-	mov	rbx, QWORD PTR [rsp+112]
-$LN3@generate_c:
-; Line 264
-	movaps	xmm8, XMMWORD PTR [rsp+48]
-	movaps	xmm9, XMMWORD PTR [rsp+32]
-	divsd	xmm7, xmm6
-	movaps	xmm6, XMMWORD PTR [rsp+80]
-	movaps	xmm0, xmm7
-	movaps	xmm7, XMMWORD PTR [rsp+64]
-	add	rsp, 96					; 00000060H
-	pop	rdi
+	xorps	xmm1, xmm1
+	subsd	xmm0, xmm1
+	addsd	xmm0, xmm1
+; Line 292
+	divsd	xmm0, QWORD PTR __real@43f0000000000000
+; Line 293
+	add	rsp, 40					; 00000028H
 	ret	0
 ??$generate_canonical@N$0?0U?$Engine@$0?0@@@std@@YANAEAU?$Engine@$0?0@@@Z ENDP ; std::generate_canonical<double,-1,Engine<-1> >
 _TEXT	ENDS
@@ -338,45 +124,27 @@ _TEXT	SEGMENT
 _Gx$ = 112
 ??$generate_canonical@N$0?0U?$Engine@$0CHBA@@@@std@@YANAEAU?$Engine@$0CHBA@@@@Z PROC ; std::generate_canonical<double,-1,Engine<10000> >, COMDAT
 ; File C:\Users\Matt\source\repos\STL\stl\inc\random
-; Line 242
+; Line 272
 $LN13:
+	mov	QWORD PTR [rsp+8], rbx
 	push	rdi
 	sub	rsp, 96					; 00000060H
 	movaps	XMMWORD PTR [rsp+80], xmm6
 	mov	rdi, rcx
-; Line 250
-	movsd	xmm6, QWORD PTR __real@3ff0000000000000
 	movaps	XMMWORD PTR [rsp+64], xmm7
+	xorps	xmm6, xmm6
+; Line 285
+	movsd	xmm7, QWORD PTR __real@3ff0000000000000
+	mov	ebx, 4
 	movaps	XMMWORD PTR [rsp+48], xmm8
-	movsd	xmm8, QWORD PTR __real@40c3880000000000
+	xorps	xmm8, xmm8
 	movaps	XMMWORD PTR [rsp+32], xmm9
-	xorps	xmm9, xmm9
-	subsd	xmm8, xmm9
-	addsd	xmm8, xmm6
-; Line 252
-	movaps	xmm0, xmm8
-	call	log2
-	movsd	xmm1, QWORD PTR __real@404a800000000000
-	divsd	xmm1, xmm0
-	movaps	xmm0, xmm1
-	call	ceil
-	cvttsd2si eax, xmm0
-; Line 253
-	mov	ecx, 1
-	xorps	xmm7, xmm7
-	cmp	eax, ecx
-	cmovl	eax, ecx
-; Line 258
-	test	eax, eax
-	jle	SHORT $LN3@generate_c
-; Line 250
-	mov	QWORD PTR [rsp+112], rbx
-	mov	ebx, eax
+	movsd	xmm9, QWORD PTR __real@40c3888000000000
 $LL4@generate_c:
-; Line 259
+; Line 288
 	mov	rcx, rdi
 	call	??R?$Engine@$0CHBA@@@QEAA_KXZ		; Engine<10000>::operator()
-	mov	rcx, rax
+	mov	rdx, rax
 	xorps	xmm0, xmm0
 	test	rax, rax
 	js	SHORT $LN10@generate_c
@@ -384,28 +152,26 @@ $LL4@generate_c:
 	jmp	SHORT $LN11@generate_c
 $LN10@generate_c:
 	shr	rax, 1
-	and	ecx, 1
-	or	rax, rcx
+	and	edx, 1
+	or	rax, rdx
 	cvtsi2sd xmm0, rax
 	addsd	xmm0, xmm0
 $LN11@generate_c:
-	subsd	xmm0, xmm9
-	mulsd	xmm0, xmm6
-; Line 260
-	mulsd	xmm6, xmm8
-	addsd	xmm7, xmm0
+	subsd	xmm0, xmm8
+	mulsd	xmm0, xmm7
+; Line 289
+	mulsd	xmm7, xmm9
+	addsd	xmm6, xmm0
 	sub	rbx, 1
 	jne	SHORT $LL4@generate_c
-; Line 258
+; Line 293
 	mov	rbx, QWORD PTR [rsp+112]
-$LN3@generate_c:
-; Line 264
 	movaps	xmm8, XMMWORD PTR [rsp+48]
 	movaps	xmm9, XMMWORD PTR [rsp+32]
-	divsd	xmm7, xmm6
-	movaps	xmm6, XMMWORD PTR [rsp+80]
-	movaps	xmm0, xmm7
+	divsd	xmm6, xmm7
 	movaps	xmm7, XMMWORD PTR [rsp+64]
+	movaps	xmm0, xmm6
+	movaps	xmm6, XMMWORD PTR [rsp+80]
 	add	rsp, 96					; 00000060H
 	pop	rdi
 	ret	0
@@ -414,47 +180,14 @@ _TEXT	ENDS
 ; Function compile flags: /Ogtpy
 ;	COMDAT ??$meow@NU?$Engine@$0?0@@@@YANAEAU?$Engine@$0?0@@@Z
 _TEXT	SEGMENT
-g$ = 112
+g$ = 48
 ??$meow@NU?$Engine@$0?0@@@@YANAEAU?$Engine@$0?0@@@Z PROC ; meow<double,Engine<-1> >, COMDAT
 ; File c:\Users\Matt\source\repos\STL\stl\inc\gen-can-test.cpp
 ; Line 18
 $LN15:
-	push	rdi
-	sub	rsp, 96					; 00000060H
-	movaps	XMMWORD PTR [rsp+80], xmm6
-	mov	rdi, rcx
+	sub	rsp, 40					; 00000028H
 ; File C:\Users\Matt\source\repos\STL\stl\inc\random
-; Line 250
-	movsd	xmm6, QWORD PTR __real@3ff0000000000000
-	movaps	XMMWORD PTR [rsp+64], xmm7
-	movaps	XMMWORD PTR [rsp+48], xmm8
-	movsd	xmm8, QWORD PTR __real@43f0000000000000
-	movaps	XMMWORD PTR [rsp+32], xmm9
-	xorps	xmm9, xmm9
-	subsd	xmm8, xmm9
-	addsd	xmm8, xmm6
-; Line 252
-	movaps	xmm0, xmm8
-	call	log2
-	movsd	xmm1, QWORD PTR __real@404a800000000000
-	divsd	xmm1, xmm0
-	movaps	xmm0, xmm1
-	call	ceil
-	cvttsd2si eax, xmm0
-; Line 253
-	mov	ecx, 1
-	xorps	xmm7, xmm7
-	cmp	eax, ecx
-	cmovl	eax, ecx
-; Line 258
-	test	eax, eax
-	jle	SHORT $LN5@meow
-; Line 250
-	mov	QWORD PTR [rsp+112], rbx
-	mov	ebx, eax
-$LL6@meow:
-; Line 259
-	mov	rcx, rdi
+; Line 288
 	call	??R?$Engine@$0?0@@QEAA_KXZ		; Engine<-1>::operator()
 	mov	rcx, rax
 	xorps	xmm0, xmm0
@@ -469,30 +202,14 @@ $LN12@meow:
 	cvtsi2sd xmm0, rax
 	addsd	xmm0, xmm0
 $LN13@meow:
-	subsd	xmm0, xmm9
-	mulsd	xmm0, xmm6
-; Line 260
-	mulsd	xmm6, xmm8
-	addsd	xmm7, xmm0
-	sub	rbx, 1
-	jne	SHORT $LL6@meow
-; Line 258
-	mov	rbx, QWORD PTR [rsp+112]
-$LN5@meow:
+	xorps	xmm1, xmm1
+	subsd	xmm0, xmm1
+	addsd	xmm0, xmm1
+; Line 292
+	divsd	xmm0, QWORD PTR __real@43f0000000000000
 ; File c:\Users\Matt\source\repos\STL\stl\inc\gen-can-test.cpp
 ; Line 20
-	movaps	xmm8, XMMWORD PTR [rsp+48]
-	movaps	xmm9, XMMWORD PTR [rsp+32]
-; File C:\Users\Matt\source\repos\STL\stl\inc\random
-; Line 263
-	divsd	xmm7, xmm6
-; File c:\Users\Matt\source\repos\STL\stl\inc\gen-can-test.cpp
-; Line 20
-	movaps	xmm6, XMMWORD PTR [rsp+80]
-	movaps	xmm0, xmm7
-	movaps	xmm7, XMMWORD PTR [rsp+64]
-	add	rsp, 96					; 00000060H
-	pop	rdi
+	add	rsp, 40					; 00000028H
 	ret	0
 ??$meow@NU?$Engine@$0?0@@@@YANAEAU?$Engine@$0?0@@@Z ENDP ; meow<double,Engine<-1> >
 _TEXT	ENDS
@@ -504,44 +221,26 @@ g$ = 112
 ; File c:\Users\Matt\source\repos\STL\stl\inc\gen-can-test.cpp
 ; Line 18
 $LN15:
+	mov	QWORD PTR [rsp+8], rbx
 	push	rdi
 	sub	rsp, 96					; 00000060H
 	movaps	XMMWORD PTR [rsp+80], xmm6
 	mov	rdi, rcx
-; File C:\Users\Matt\source\repos\STL\stl\inc\random
-; Line 250
-	movsd	xmm6, QWORD PTR __real@3ff0000000000000
 	movaps	XMMWORD PTR [rsp+64], xmm7
+	xorps	xmm6, xmm6
+; File C:\Users\Matt\source\repos\STL\stl\inc\random
+; Line 285
+	movsd	xmm7, QWORD PTR __real@3ff0000000000000
+	mov	ebx, 4
 	movaps	XMMWORD PTR [rsp+48], xmm8
-	movsd	xmm8, QWORD PTR __real@40c3880000000000
+	xorps	xmm8, xmm8
 	movaps	XMMWORD PTR [rsp+32], xmm9
-	xorps	xmm9, xmm9
-	subsd	xmm8, xmm9
-	addsd	xmm8, xmm6
-; Line 252
-	movaps	xmm0, xmm8
-	call	log2
-	movsd	xmm1, QWORD PTR __real@404a800000000000
-	divsd	xmm1, xmm0
-	movaps	xmm0, xmm1
-	call	ceil
-	cvttsd2si eax, xmm0
-; Line 253
-	mov	ecx, 1
-	xorps	xmm7, xmm7
-	cmp	eax, ecx
-	cmovl	eax, ecx
-; Line 258
-	test	eax, eax
-	jle	SHORT $LN5@meow
-; Line 250
-	mov	QWORD PTR [rsp+112], rbx
-	mov	ebx, eax
+	movsd	xmm9, QWORD PTR __real@40c3888000000000
 $LL6@meow:
-; Line 259
+; Line 288
 	mov	rcx, rdi
 	call	??R?$Engine@$0CHBA@@@QEAA_KXZ		; Engine<10000>::operator()
-	mov	rcx, rax
+	mov	rdx, rax
 	xorps	xmm0, xmm0
 	test	rax, rax
 	js	SHORT $LN12@meow
@@ -549,33 +248,31 @@ $LL6@meow:
 	jmp	SHORT $LN13@meow
 $LN12@meow:
 	shr	rax, 1
-	and	ecx, 1
-	or	rax, rcx
+	and	edx, 1
+	or	rax, rdx
 	cvtsi2sd xmm0, rax
 	addsd	xmm0, xmm0
 $LN13@meow:
-	subsd	xmm0, xmm9
-	mulsd	xmm0, xmm6
-; Line 260
-	mulsd	xmm6, xmm8
-	addsd	xmm7, xmm0
+	subsd	xmm0, xmm8
+	mulsd	xmm0, xmm7
+; Line 289
+	mulsd	xmm7, xmm9
+	addsd	xmm6, xmm0
 	sub	rbx, 1
 	jne	SHORT $LL6@meow
-; Line 258
-	mov	rbx, QWORD PTR [rsp+112]
-$LN5@meow:
 ; File c:\Users\Matt\source\repos\STL\stl\inc\gen-can-test.cpp
 ; Line 20
+	mov	rbx, QWORD PTR [rsp+112]
 	movaps	xmm8, XMMWORD PTR [rsp+48]
 	movaps	xmm9, XMMWORD PTR [rsp+32]
 ; File C:\Users\Matt\source\repos\STL\stl\inc\random
-; Line 263
-	divsd	xmm7, xmm6
+; Line 292
+	divsd	xmm6, xmm7
 ; File c:\Users\Matt\source\repos\STL\stl\inc\gen-can-test.cpp
 ; Line 20
-	movaps	xmm6, XMMWORD PTR [rsp+80]
-	movaps	xmm0, xmm7
 	movaps	xmm7, XMMWORD PTR [rsp+64]
+	movaps	xmm0, xmm6
+	movaps	xmm6, XMMWORD PTR [rsp+80]
 	add	rsp, 96					; 00000060H
 	pop	rdi
 	ret	0
```
</details>

Note that in the case when the range is 10,001, not a power-of-two, the number of iterations is a hard-coded 4.