### PR TITLE
Fix handling of arrays in two-argument `ranges::distance`

### DIFF
--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -2843,7 +2843,7 @@ namespace ranges {
         using _Not_quite_object::_Not_quite_object;
 
         // clang-format off
-        template <input_or_output_iterator _It, sentinel_for<_It> _Se>
+        template <class _It, sentinel_for<_It> _Se>
             requires (!sized_sentinel_for<_Se, _It>)
         _NODISCARD constexpr iter_difference_t<_It> operator()(_It _First, _Se _Last) const {
             // clang-format on
@@ -2851,8 +2851,8 @@ namespace ranges {
             return _Distance_unchecked(_Get_unwrapped(_STD move(_First)), _Get_unwrapped(_STD move(_Last)));
         }
 
-        template <input_or_output_iterator _It, sized_sentinel_for<_It> _Se>
-        _NODISCARD constexpr iter_difference_t<_It> operator()(const _It& _First, const _Se& _Last) const
+        template <class _It, sized_sentinel_for<decay_t<_It>> _Se>
+        _NODISCARD constexpr iter_difference_t<_It> operator()(const _It& _First, _Se _Last) const
             noexcept(noexcept(_Last - _First)) /* strengthened */ {
             return _Last - _First;
         }

--- a/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
@@ -3474,9 +3474,19 @@ namespace vso1121031 {
     STATIC_ASSERT(!has_member_value_type<indirectly_readable_traits<iterish<float const volatile>>>);
 } // namespace vso1121031
 
+constexpr bool test_lwg_XXX() {
+    int a[3] = {};
+    assert(ranges::distance(a, a + 3) == 3);
+    assert(ranges::distance(a + 3, a) == -3);
+    return true;
+}
+
 int main() {
     iterator_cust_swap_test::test();
     iter_ops::test();
     reverse_iterator_test::test();
     move_iterator_test::test();
+
+    test_lwg_XXX();
+    STATIC_ASSERT(test_lwg_XXX());
 }


### PR DESCRIPTION
.... which was broken by LWG-3392. This implements the proposed resolution of a submitted-but-not-yet-numbered LWG issue.
