### PR TITLE
Changed _Unfancy_maybe_null() to _Unfancy()

### DIFF
--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -560,10 +560,10 @@ private:
             return;
         }
 
-        const auto _First    = reinterpret_cast<const char*>(_Unfancy_maybe_null(_First_));
-        const auto _End      = reinterpret_cast<const char*>(_Unfancy_maybe_null(_End_));
-        const auto _Old_last = reinterpret_cast<const char*>(_Unfancy_maybe_null(_Old_last_));
-        const auto _New_last = reinterpret_cast<const char*>(_Unfancy_maybe_null(_New_last_));
+        const auto _First    = reinterpret_cast<const char*>(_Unfancy(_First_));
+        const auto _End      = reinterpret_cast<const char*>(_Unfancy(_End_));
+        const auto _Old_last = reinterpret_cast<const char*>(_Unfancy(_Old_last_));
+        const auto _New_last = reinterpret_cast<const char*>(_Unfancy(_New_last_));
         if constexpr (_Has_minimum_allocation_alignment<vector>) {
             __sanitizer_annotate_contiguous_container(_First, _End, _Old_last, _New_last);
         } else {

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -550,6 +550,11 @@ private:
 
     static _CONSTEXPR20 void _Apply_annotation(
         pointer _First_, pointer _End_, pointer _Old_last_, pointer _New_last_) noexcept {
+        _STL_INTERNAL_CHECK(_First_ != nullptr);
+        _STL_INTERNAL_CHECK(_End_ != nullptr);
+        _STL_INTERNAL_CHECK(_Old_last_ != nullptr);
+        _STL_INTERNAL_CHECK(_New_last_ != nullptr);
+
 #if _HAS_CXX20
         if (_STD is_constant_evaluated()) {
             return;


### PR DESCRIPTION
<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->

Fixes #2470 and changes instances of `_Unfancy_maybe_null()` to `_Unfancy()`.
