### PR TITLE
Rearrange feature test macros

### DIFF
--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -1349,6 +1349,42 @@
 #define __cpp_lib_unwrap_ref    201811L
 #endif // _HAS_CXX20
 
+#if defined(__cpp_impl_coroutine) || defined(_DOWNLEVEL_COROUTINES_SUPPORTED) // TRANSITION, Clang coroutine support
+#define __cpp_lib_coroutine 201902L
+#endif // __cpp_impl_coroutine
+
+// C++23
+#if _HAS_CXX23
+#define __cpp_lib_adaptor_iterator_pair_constructor 202106L
+
+#ifdef __cpp_lib_concepts
+#define __cpp_lib_allocate_at_least 202106L
+#endif // __cpp_lib_concepts
+
+#define __cpp_lib_associative_heterogeneous_erasure 202110L
+#define __cpp_lib_byteswap                          202110L
+#define __cpp_lib_invoke_r                          202106L
+#define __cpp_lib_is_scoped_enum                    202011L
+
+#ifdef __cpp_lib_concepts
+#define __cpp_lib_monadic_optional 202110L
+#endif // __cpp_lib_concepts
+
+#define __cpp_lib_move_only_function 202110L
+
+#ifdef __cpp_lib_concepts
+#define __cpp_lib_out_ptr                 202106L
+#define __cpp_lib_ranges_starts_ends_with 202106L
+#endif // __cpp_lib_concepts
+
+#define __cpp_lib_spanstream                  202106L
+#define __cpp_lib_stdatomic_h                 202011L
+#define __cpp_lib_string_contains             202011L
+#define __cpp_lib_string_resize_and_overwrite 202110L
+#define __cpp_lib_to_underlying               202102L
+#endif // _HAS_CXX23
+
+// macros with language mode sensitivity
 #if _HAS_CXX20
 #define __cpp_lib_array_constexpr 201811L // P1032R1 Miscellaneous constexpr
 #elif _HAS_CXX17 // ^^^ _HAS_CXX20 / _HAS_CXX17 vvv
@@ -1388,41 +1424,6 @@
 #elif _HAS_CXX17 // ^^^ _HAS_CXX20 / _HAS_CXX17 vvv
 #define __cpp_lib_variant 202102L // P2162R2 Inheriting From variant
 #endif // _HAS_CXX17
-
-#if defined(__cpp_impl_coroutine) || defined(_DOWNLEVEL_COROUTINES_SUPPORTED) // TRANSITION, Clang coroutine support
-#define __cpp_lib_coroutine 201902L
-#endif // __cpp_impl_coroutine
-
-// C++23
-#if _HAS_CXX23
-#define __cpp_lib_adaptor_iterator_pair_constructor 202106L
-
-#ifdef __cpp_lib_concepts
-#define __cpp_lib_allocate_at_least 202106L
-#endif // __cpp_lib_concepts
-
-#define __cpp_lib_associative_heterogeneous_erasure 202110L
-#define __cpp_lib_byteswap                          202110L
-#define __cpp_lib_invoke_r                          202106L
-#define __cpp_lib_is_scoped_enum                    202011L
-
-#ifdef __cpp_lib_concepts
-#define __cpp_lib_monadic_optional 202110L
-#endif // __cpp_lib_concepts
-
-#define __cpp_lib_move_only_function 202110L
-
-#ifdef __cpp_lib_concepts
-#define __cpp_lib_out_ptr                 202106L
-#define __cpp_lib_ranges_starts_ends_with 202106L
-#endif // __cpp_lib_concepts
-
-#define __cpp_lib_spanstream                  202106L
-#define __cpp_lib_stdatomic_h                 202011L
-#define __cpp_lib_string_contains             202011L
-#define __cpp_lib_string_resize_and_overwrite 202110L
-#define __cpp_lib_to_underlying               202102L
-#endif // _HAS_CXX23
 
 #define __cpp_lib_experimental_erase_if   201411L
 #define __cpp_lib_experimental_filesystem 201406L

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -1365,10 +1365,14 @@
 
 #if _HAS_CXX20
 #define __cpp_lib_optional 202106L // P2231R1 Completing constexpr In optional And variant
-#define __cpp_lib_variant  202106L // P2231R1 Completing constexpr In optional And variant
 #elif _HAS_CXX17 // ^^^ _HAS_CXX20 / _HAS_CXX17 vvv
 #define __cpp_lib_optional 201606L // P0307R2 Making Optional Greater Equal Again
-#define __cpp_lib_variant  202102L // P2162R2 Inheriting From variant
+#endif // _HAS_CXX17
+
+#if _HAS_CXX20
+#define __cpp_lib_variant 202106L // P2231R1 Completing constexpr In optional And variant
+#elif _HAS_CXX17 // ^^^ _HAS_CXX20 / _HAS_CXX17 vvv
+#define __cpp_lib_variant 202102L // P2162R2 Inheriting From variant
 #endif // _HAS_CXX17
 
 #if _HAS_CXX20 && defined(__cpp_lib_concepts) // TRANSITION, GH-395

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -1349,30 +1349,10 @@
 #define __cpp_lib_unwrap_ref    201811L
 #endif // _HAS_CXX20
 
-#ifndef _M_CEE
-#if _HAS_CXX20
-#define __cpp_lib_execution 201902L // P1001R2 execution::unseq
-#elif _HAS_CXX17
-#define __cpp_lib_execution 201603L // P0024R2 Parallel Algorithms
-#endif // language mode
-#endif // _M_CEE
-
 #if _HAS_CXX20
 #define __cpp_lib_array_constexpr 201811L // P1032R1 Miscellaneous constexpr
 #elif _HAS_CXX17 // ^^^ _HAS_CXX20 / _HAS_CXX17 vvv
 #define __cpp_lib_array_constexpr 201803L // P0858R0 Constexpr Iterator Requirements
-#endif // _HAS_CXX17
-
-#if _HAS_CXX20
-#define __cpp_lib_optional 202106L // P2231R1 Completing constexpr In optional And variant
-#elif _HAS_CXX17 // ^^^ _HAS_CXX20 / _HAS_CXX17 vvv
-#define __cpp_lib_optional 201606L // P0307R2 Making Optional Greater Equal Again
-#endif // _HAS_CXX17
-
-#if _HAS_CXX20
-#define __cpp_lib_variant 202106L // P2231R1 Completing constexpr In optional And variant
-#elif _HAS_CXX17 // ^^^ _HAS_CXX20 / _HAS_CXX17 vvv
-#define __cpp_lib_variant 202102L // P2162R2 Inheriting From variant
 #endif // _HAS_CXX17
 
 #if _HAS_CXX20 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
@@ -1383,11 +1363,31 @@
 #define __cpp_lib_chrono 201510L // P0092R1 <chrono> floor(), ceil(), round(), abs()
 #endif // _HAS_CXX17
 
+#ifndef _M_CEE
+#if _HAS_CXX20
+#define __cpp_lib_execution 201902L // P1001R2 execution::unseq
+#elif _HAS_CXX17
+#define __cpp_lib_execution 201603L // P0024R2 Parallel Algorithms
+#endif // language mode
+#endif // _M_CEE
+
+#if _HAS_CXX20
+#define __cpp_lib_optional 202106L // P2231R1 Completing constexpr In optional And variant
+#elif _HAS_CXX17 // ^^^ _HAS_CXX20 / _HAS_CXX17 vvv
+#define __cpp_lib_optional 201606L // P0307R2 Making Optional Greater Equal Again
+#endif // _HAS_CXX17
+
 #if _HAS_CXX20
 #define __cpp_lib_shared_ptr_arrays 201707L // P0674R1 make_shared() For Arrays
 #else // _HAS_CXX20
 #define __cpp_lib_shared_ptr_arrays 201611L // P0497R0 Fixing shared_ptr For Arrays
 #endif // _HAS_CXX20
+
+#if _HAS_CXX20
+#define __cpp_lib_variant 202106L // P2231R1 Completing constexpr In optional And variant
+#elif _HAS_CXX17 // ^^^ _HAS_CXX20 / _HAS_CXX17 vvv
+#define __cpp_lib_variant 202102L // P2162R2 Inheriting From variant
+#endif // _HAS_CXX17
 
 #if defined(__cpp_impl_coroutine) || defined(_DOWNLEVEL_COROUTINES_SUPPORTED) // TRANSITION, Clang coroutine support
 #define __cpp_lib_coroutine 201902L

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -1253,6 +1253,10 @@
 // C++20
 #define __cpp_lib_atomic_value_initialization 201911L
 
+#ifdef __cpp_impl_coroutine
+#define __cpp_lib_coroutine 201902L
+#endif // __cpp_impl_coroutine
+
 #if _HAS_CXX20
 #define __cpp_lib_assume_aligned                201811L
 #define __cpp_lib_atomic_flag_test              201907L
@@ -1348,10 +1352,6 @@
 #define __cpp_lib_type_identity 201806L
 #define __cpp_lib_unwrap_ref    201811L
 #endif // _HAS_CXX20
-
-#if defined(__cpp_impl_coroutine) || defined(_DOWNLEVEL_COROUTINES_SUPPORTED) // TRANSITION, Clang coroutine support
-#define __cpp_lib_coroutine 201902L
-#endif // __cpp_impl_coroutine
 
 // C++23
 #if _HAS_CXX23


### PR DESCRIPTION
Fixes #2135.

Note: I noticed that cl defines `__cpp_impl_coroutine` when `/await:strict` is on, so I believe that there's no need to check `defined(_DOWNLEVEL_COROUTINES_SUPPORTED)`. I also relocated the definition of `__cpp_lib_coroutine` to make it next to the other C++20 feature-test macro that's not guarded by `_HAS_CXX20`.