### PR TITLE
Toolset update: VS 2022 17.1 Preview 5, CMake 3.22, sparse index

### DIFF
--- a/.github/ISSUE_TEMPLATE/cxx23-feature.md
+++ b/.github/ISSUE_TEMPLATE/cxx23-feature.md
@@ -21,9 +21,6 @@ and the publication of the papers. When the papers are available,
 the https://wg21.link redirector will start working.
 
 Feature-test macro:
-`#define MACRO_NAME MACRO_VALUE`
-
-Note: We're still working on finishing C++20. Until we're done
-with that (and the compiler implements distinct `/std:c++20` and
-`/std:c++latest` options), we won't be able to review PRs for
-C++23 features.
+```cpp
+#define MACRO_NAME MACRO_VALUE
+```

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.21)
+cmake_minimum_required(VERSION 3.22)
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 project(msvc_standard_libraries LANGUAGES CXX)
 

--- a/README.md
+++ b/README.md
@@ -140,10 +140,10 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With The Visual Studio IDE
 
-1. Install Visual Studio 2022 17.1 Preview 4 or later.
+1. Install Visual Studio 2022 17.1 Preview 5 or later.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
-    * Otherwise, install [CMake][] 3.21 or later, and [Ninja][] 1.10.2 or later.
+    * Otherwise, install [CMake][] 3.22 or later, and [Ninja][] 1.10.2 or later.
     * We recommend selecting "Python 3 64-bit" in the VS Installer.
     * Otherwise, make sure [Python][] 3.9 or later is available to CMake.
 2. Open Visual Studio, and choose the "Clone or check out code" option. Enter the URL of this repository,
@@ -155,10 +155,10 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With A Native Tools Command Prompt
 
-1. Install Visual Studio 2022 17.1 Preview 4 or later.
+1. Install Visual Studio 2022 17.1 Preview 5 or later.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
-    * Otherwise, install [CMake][] 3.21 or later, and [Ninja][] 1.10.2 or later.
+    * Otherwise, install [CMake][] 3.22 or later, and [Ninja][] 1.10.2 or later.
     * We recommend selecting "Python 3 64-bit" in the VS Installer.
     * Otherwise, make sure [Python][] 3.9 or later is available to CMake.
 2. Open a command prompt.

--- a/azure-devops/checkout-sources.yml
+++ b/azure-devops/checkout-sources.yml
@@ -43,8 +43,7 @@ steps:
     )
 
     git fetch --filter=tree:0 --depth=1 llvm $(${{ parameters.llvmSHAVar }})
-    git sparse-checkout init --cone
-    git sparse-checkout set libcxx/test libcxx/utils/libcxx llvm/utils/lit
+    git sparse-checkout set --cone --sparse-index libcxx/test libcxx/utils/libcxx llvm/utils/lit
     git reset --quiet --hard FETCH_HEAD
     git clean --quiet -x -d -f
   displayName: "Checkout LLVM source"

--- a/azure-devops/checkout-sources.yml
+++ b/azure-devops/checkout-sources.yml
@@ -39,7 +39,6 @@ steps:
     git remote get-url llvm
     if errorlevel 1 (
       git remote add llvm https://github.com/llvm/llvm-project.git
-      git config --local extensions.partialClone llvm
     )
 
     git fetch --filter=tree:0 --depth=1 llvm $(${{ parameters.llvmSHAVar }})
@@ -62,7 +61,6 @@ steps:
     git remote get-url boostorg
     if errorlevel 1 (
       git remote add boostorg https://github.com/boostorg/math.git
-      git config --local extensions.partialClone boostorg
     )
 
     git fetch --filter=tree:0 --depth=1 boostorg $(${{ parameters.boostMathSHAVar }})

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ variables:
   tmpDir: 'D:\Temp'
   buildOutputLocation: 'D:\build'
 
-pool: 'StlBuild-2022-01-25-T1318'
+pool: 'StlBuild-2022-02-02-T1344'
 
 stages:
   - stage: Code_Format

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ variables:
   tmpDir: 'D:\Temp'
   buildOutputLocation: 'D:\build'
 
-pool: 'StlBuild-2022-02-02-T1344'
+pool: 'StlBuild-2022-02-08-T1334'
 
 stages:
   - stage: Code_Format

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.21)
+cmake_minimum_required(VERSION 3.22)
 project(msvc_standard_libraries_tools LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 20)


### PR DESCRIPTION
Update the toolset to VS 2022 17.1 Preview 5 containing CMake 3.22 (now required).

Use `--sparse-index` when checking out libcxx from llvm-project. See GitHub's blog post [Make your monorepo feel small with Git's sparse index](https://github.blog/2021-11-10-make-your-monorepo-feel-small-with-gits-sparse-index/).

git 2.36 is expected to improve `git clean` performance with the sparse index, but AFAIK there are no correctness concerns.

Also, `git sparse-checkout init` has been deprecated and fused into `git sparse-checkout set`. See GitHub's blog post [Highlights from Git 2.35](https://github.blog/2022-01-24-highlights-from-git-2-35/) and Git's [documentation](https://git-scm.com/docs/git-sparse-checkout#Documentation/git-sparse-checkout.txt-eminitem).

Tested with:

```
git clone https://github.com/microsoft/STL.git
cd STL\llvm-project
git init
git remote add llvm https://github.com/llvm/llvm-project.git
git config --local extensions.partialClone llvm
git fetch --filter=tree:0 --depth=1 llvm 605751790418ca4fb1df1e94dfbac34cfcc1b96f
git sparse-checkout set --cone --sparse-index libcxx/test libcxx/utils/libcxx llvm/utils/lit
git reset --quiet --hard FETCH_HEAD
git clean --quiet -x -d -f
```

This shrinks `llvm-project\.git` from 20,234,297 bytes to 9,109,231 bytes and shrinks `llvm-project` from 42,340,692 bytes to 31,215,626 bytes.