### PR TITLE
Move `<ranges>` and `<format>` into C++20

### DIFF
--- a/stl/CMakeLists.txt
+++ b/stl/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 set(HEADERS
     ${CMAKE_CURRENT_LIST_DIR}/inc/__msvc_all_public_headers.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/inc/__msvc_int128.hpp
     ${CMAKE_CURRENT_LIST_DIR}/inc/__msvc_system_error_abi.hpp
     ${CMAKE_CURRENT_LIST_DIR}/inc/__msvc_tzdb.hpp
     ${CMAKE_CURRENT_LIST_DIR}/inc/__msvc_xlocinfo_types.hpp

--- a/stl/inc/__msvc_int128.hpp
+++ b/stl/inc/__msvc_int128.hpp
@@ -16,10 +16,6 @@
 #include <cstdint>
 #include <intrin.h> // TRANSITION, GH-2520
 
-#if 1 // FIXME: comment out _STL_INTERNAL_CHECKs and remove to make this core
-#include <yvals.h>
-#endif
-
 #pragma pack(push, _CRT_PACKING)
 #pragma warning(push, _STL_WARNING_LEVEL)
 #pragma warning(disable : _STL_DISABLED_WARNINGS)
@@ -49,7 +45,7 @@ struct
     uint64_t _Word[2];
 
     constexpr void _Left_shift(const unsigned char _Count) noexcept {
-        _STL_INTERNAL_CHECK(_Count < 128);
+        // _STL_INTERNAL_CHECK(_Count < 128);
         if (_Count == 0) {
             return;
         }
@@ -73,7 +69,7 @@ struct
     }
 
     constexpr void _Right_shift(const unsigned char _Count) noexcept {
-        _STL_INTERNAL_CHECK(_Count < 128);
+        // _STL_INTERNAL_CHECK(_Count < 128);
         if (_Count == 0) {
             return;
         }
@@ -98,7 +94,7 @@ struct
 
     static constexpr unsigned char _AddCarry64(
         unsigned char _Carry, uint64_t _Left, uint64_t _Right, uint64_t& _Result) noexcept {
-        _STL_INTERNAL_CHECK(_Carry < 2);
+        // _STL_INTERNAL_CHECK(_Carry < 2);
 #if _STL_128_INTRINSICS
         if (!_STD is_constant_evaluated()) {
             return _addcarry_u64(_Carry, _Left, _Right, &_Result);
@@ -112,7 +108,7 @@ struct
 
     static constexpr unsigned char _SubBorrow64(
         unsigned char _Carry, uint64_t _Left, uint64_t _Right, uint64_t& _Result) noexcept {
-        _STL_INTERNAL_CHECK(_Carry < 2);
+        // _STL_INTERNAL_CHECK(_Carry < 2);
 #if _STL_128_INTRINSICS
         if (!_STD is_constant_evaluated()) {
             return _subborrow_u64(_Carry, _Left, _Right, &_Result);
@@ -127,9 +123,11 @@ struct
     template <size_t __m, size_t __n>
     static constexpr void _Knuth_4_3_1_M(
         const uint32_t (&__u)[__m], const uint32_t (&__v)[__n], uint32_t (&__w)[__n + __m]) noexcept {
+#ifdef _ENABLE_STL_INTERNAL_CHECK
         constexpr auto _Int_max = size_t{(numeric_limits<int>::max)()};
         _STL_INTERNAL_STATIC_ASSERT(__m <= _Int_max);
         _STL_INTERNAL_STATIC_ASSERT(__n <= _Int_max);
+#endif
 
         for (auto& _Elem : __w) {
             _Elem = 0;
@@ -175,13 +173,13 @@ struct
     static constexpr void _Knuth_4_3_1_D(uint32_t* const __u, const size_t __u_size, const uint32_t* const __v,
         const size_t __v_size, uint32_t* const __q) noexcept {
         // Pre: __u + [0, __u_size), __v + [0, __v_size), and __q + [0, __u_size - __v_size) are all valid ranges
-        constexpr auto _Int_max = size_t{(numeric_limits<int>::max)()};
-        _STL_INTERNAL_CHECK(__v_size <= _Int_max);
+        // constexpr auto _Int_max = size_t{(numeric_limits<int>::max)()};
+        // _STL_INTERNAL_CHECK(__v_size <= _Int_max);
         const auto __n = static_cast<int>(__v_size);
-        _STL_INTERNAL_CHECK(__u_size > __v_size);
-        _STL_INTERNAL_CHECK(__u_size <= _Int_max);
+        // _STL_INTERNAL_CHECK(__u_size > __v_size);
+        // _STL_INTERNAL_CHECK(__u_size <= _Int_max);
         const auto __m = static_cast<int>(__u_size - __v_size - 1);
-        _STL_INTERNAL_CHECK(__v[__n - 1] >> 31 != 0); // Arguments are already normalized
+        // _STL_INTERNAL_CHECK(__v[__n - 1] >> 31 != 0); // Arguments are already normalized
 
         for (auto __j = static_cast<int>(__m); __j >= 0; --__j) {
             const auto _Two_digits = (static_cast<uint64_t>(__u[__j + __n]) << 32) | __u[__j + __n - 1];
@@ -227,7 +225,7 @@ struct
 
     _NODISCARD static constexpr uint64_t _UDiv128(
         uint64_t _High, uint64_t _Low, uint64_t _Div, uint64_t& _Remainder) noexcept {
-        _STL_INTERNAL_CHECK(_High < _Div);
+        // _STL_INTERNAL_CHECK(_High < _Div);
 
 #if _STL_128_DIV_INTRINSICS
         if (!_STD is_constant_evaluated()) {
@@ -264,12 +262,12 @@ struct
         uint32_t __q[3];
 
         _Knuth_4_3_1_D(__u, 5, __v, 2, __q);
-        _STL_INTERNAL_CHECK(__u[4] == 0);
-        _STL_INTERNAL_CHECK(__u[3] == 0);
-        _STL_INTERNAL_CHECK(__u[2] == 0);
+        // _STL_INTERNAL_CHECK(__u[4] == 0);
+        // _STL_INTERNAL_CHECK(__u[3] == 0);
+        // _STL_INTERNAL_CHECK(__u[2] == 0);
         _Remainder = (static_cast<uint64_t>(__u[1]) << (32 - __d)) | (__u[0] >> __d);
 
-        _STL_INTERNAL_CHECK(__q[2] == 0);
+        // _STL_INTERNAL_CHECK(__q[2] == 0);
         return (static_cast<uint64_t>(__q[1]) << 32) | __q[0];
     }
 
@@ -412,8 +410,8 @@ struct
 
 #if _STL_128_INTRINSICS
         // Knuth 4.3.1D, 2-digit by 2-digit divide in base 2^64
-        _STL_INTERNAL_CHECK(_Den._Word[1] != 0);
-        _STL_INTERNAL_CHECK(_Num._Word[1] > _Den._Word[1]);
+        // _STL_INTERNAL_CHECK(_Den._Word[1] != 0);
+        // _STL_INTERNAL_CHECK(_Num._Word[1] > _Den._Word[1]);
         // Normalize by shifting both left until _Den's high bit is set (So _Den's high digit is >= b / 2)
         const auto __d = _STD countl_zero(_Den._Word[1]);
         _Den <<= __d;
@@ -444,7 +442,7 @@ struct
             }
             __rhat = _Sum;
         }
-        _STL_INTERNAL_CHECK(__qhat._Word[1] == 0);
+        // _STL_INTERNAL_CHECK(__qhat._Word[1] == 0);
 
         // [_High_digit | _Num] -= __qhat * _Den [Since __qhat < b, this is 3-digit - 1-digit * 2-digit]
         uint64_t _Prod0_hi;
@@ -537,8 +535,8 @@ struct
 
 #if _STL_128_INTRINSICS
         // Knuth 4.3.1D, 2-digit by 2-digit divide in base 2^64
-        _STL_INTERNAL_CHECK(_Den._Word[1] != 0);
-        _STL_INTERNAL_CHECK(_Num._Word[1] > _Den._Word[1]);
+        // _STL_INTERNAL_CHECK(_Den._Word[1] != 0);
+        // _STL_INTERNAL_CHECK(_Num._Word[1] > _Den._Word[1]);
         // Normalize by shifting both left until _Den's high bit is set (So _Den's high digit is >= b / 2)
         const auto __d = _STD countl_zero(_Den._Word[1]);
         _Den <<= __d;
@@ -571,7 +569,7 @@ struct
             __rhat = _Sum;
             // The addition didn't overflow, so `__rhat < b` holds
         }
-        _STL_INTERNAL_CHECK(__qhat_high == 0);
+        // _STL_INTERNAL_CHECK(__qhat_high == 0);
 
         // [_High_digit | _Num] -= __qhat * _Den [3-digit - 1-digit * 2-digit]
         uint64_t _Prod0_hi;
@@ -613,12 +611,12 @@ struct
         if (_Three_word_den) {
             // 4-digit by 3-digit base 2^32 division
             _Knuth_4_3_1_D(__u, 5, __v, 3, __q);
-            _STL_INTERNAL_CHECK(__u[3] == 0);
+            // _STL_INTERNAL_CHECK(__u[3] == 0);
         } else {
             // 4-digit by 4-digit base 2^32 division
             _Knuth_4_3_1_D(__u, 5, __v, 4, __q);
         }
-        _STL_INTERNAL_CHECK(__u[4] == 0);
+        // _STL_INTERNAL_CHECK(__u[4] == 0);
 
         _Num._Word[0] = (static_cast<uint64_t>(__u[1]) << 32) | __u[0];
         _Num._Word[1] = (static_cast<uint64_t>(__u[3]) << 32) | __u[2];

--- a/stl/inc/__msvc_int128.hpp
+++ b/stl/inc/__msvc_int128.hpp
@@ -68,7 +68,7 @@ struct
         _Word[0] <<= _Count;
     }
 
-    constexpr void _Right_shift(const unsigned char _Count) noexcept {
+    constexpr void _Unsigned_right_shift(const unsigned char _Count) noexcept {
         // _STL_INTERNAL_CHECK(_Count < 128);
         if (_Count == 0) {
             return;
@@ -325,7 +325,8 @@ struct
         return _Left >> _Right._Word[0];
     }
 
-    constexpr _Base128& operator<<=(const integral auto _Count) noexcept {
+    template <integral _Ty>
+    constexpr _Base128& operator<<=(const _Ty _Count) noexcept {
         _Left_shift(static_cast<unsigned char>(_Count));
         return *this;
     }
@@ -336,8 +337,9 @@ struct
         return _Left;
     }
 
-    constexpr _Base128& operator>>=(const integral auto _Count) noexcept {
-        _Right_shift(static_cast<unsigned char>(_Count));
+    template <integral _Ty>
+    constexpr _Base128& operator>>=(const _Ty _Count) noexcept {
+        _Unsigned_right_shift(static_cast<unsigned char>(_Count));
         return *this;
     }
 
@@ -683,7 +685,8 @@ struct _Uint128 : _Base128 {
         return _Tmp;
     }
 
-    constexpr _Uint128& operator<<=(const integral auto _Count) noexcept {
+    template <integral _Ty>
+    constexpr _Uint128& operator<<=(const _Ty _Count) noexcept {
         _Left_shift(static_cast<unsigned char>(_Count));
         return *this;
     }
@@ -694,16 +697,17 @@ struct _Uint128 : _Base128 {
 
     _NODISCARD_FRIEND constexpr _Uint128 operator>>(const _Uint128& _Left, const _Base128& _Right) noexcept {
         auto _Tmp{_Left};
-        _Tmp._Right_shift(static_cast<unsigned char>(_Right._Word[0]));
+        _Tmp._Unsigned_right_shift(static_cast<unsigned char>(_Right._Word[0]));
         return _Tmp;
     }
 
-    constexpr _Uint128& operator>>=(const integral auto _Count) noexcept {
-        _Right_shift(static_cast<unsigned char>(_Count));
+    template <integral _Ty>
+    constexpr _Uint128& operator>>=(const _Ty _Count) noexcept {
+        _Unsigned_right_shift(static_cast<unsigned char>(_Count));
         return *this;
     }
     constexpr _Uint128& operator>>=(const _Base128& _Count) noexcept {
-        _Right_shift(static_cast<unsigned char>(_Count._Word[0]));
+        _Unsigned_right_shift(static_cast<unsigned char>(_Count._Word[0]));
         return *this;
     }
 
@@ -980,7 +984,8 @@ struct _Int128 : _Base128 {
         return _Tmp;
     }
 
-    constexpr _Int128& operator<<=(const integral auto _Count) noexcept {
+    template <integral _Ty>
+    constexpr _Int128& operator<<=(const _Ty _Count) noexcept {
         _Left_shift(static_cast<unsigned char>(_Count));
         return *this;
     }
@@ -989,7 +994,7 @@ struct _Int128 : _Base128 {
         return *this;
     }
 
-    constexpr void _Right_shift(const unsigned char _Count) noexcept {
+    constexpr void _Signed_right_shift(const unsigned char _Count) noexcept {
         if (_Count == 0) {
             return;
         }
@@ -1014,17 +1019,17 @@ struct _Int128 : _Base128 {
 
     _NODISCARD_FRIEND constexpr _Int128 operator>>(const _Int128& _Left, const _Base128& _Right) noexcept {
         auto _Tmp{_Left};
-        _Tmp._Right_shift(static_cast<unsigned char>(_Right._Word[0]));
+        _Tmp._Signed_right_shift(static_cast<unsigned char>(_Right._Word[0]));
         return _Tmp;
     }
 
-
-    constexpr _Int128& operator>>=(const integral auto _Count) noexcept {
-        _Right_shift(static_cast<unsigned char>(_Count));
+    template <integral _Ty>
+    constexpr _Int128& operator>>=(const _Ty _Count) noexcept {
+        _Signed_right_shift(static_cast<unsigned char>(_Count));
         return *this;
     }
     constexpr _Int128& operator>>=(const _Base128& _Count) noexcept {
-        _Right_shift(static_cast<unsigned char>(_Count._Word[0]));
+        _Signed_right_shift(static_cast<unsigned char>(_Count._Word[0]));
         return *this;
     }
 
@@ -1311,6 +1316,15 @@ struct common_type<_Ty, _Int128> {
 template <integral _Ty>
 struct common_type<_Int128, _Ty> {
     using type = _Int128;
+};
+
+template <>
+struct common_type<_Int128, _Uint128> {
+    using type = _Uint128;
+};
+template <>
+struct common_type<_Uint128, _Int128> {
+    using type = _Uint128;
 };
 
 #undef _STL_128_INTRINSICS

--- a/stl/inc/__msvc_int128.hpp
+++ b/stl/inc/__msvc_int128.hpp
@@ -35,8 +35,8 @@ _STD_BEGIN
 #define _STL_128_DIV_INTRINSICS 0
 #else // ^^^ Clang / other vvv
 #define _STL_128_DIV_INTRINSICS 1
-#endif
-#else // ^^^ X64 / other vvv
+#endif // ^^^ detect _udiv128 / _div128 ^^^
+#else // ^^^ x64 / other vvv
 #define _STL_128_INTRINSICS     0
 #define _STL_128_DIV_INTRINSICS 0
 #endif // defined(_M_X64) && !defined(_M_ARM64EC)
@@ -901,7 +901,7 @@ struct _Int128 : _Uint128 {
         return _Left;
     }
 
-    _NODISCARD_FRIEND constexpr _Int128 operator>>(const _Int128& _Left, const _Int128& _Right) noexcept {
+    _NODISCARD_FRIEND constexpr _Int128 operator>>(const _Int128& _Left, const _Uint128& _Right) noexcept {
         auto _Tmp{_Left};
         _Tmp._Right_shift(static_cast<unsigned char>(_Right._Word[0]));
         return _Tmp;

--- a/stl/inc/__msvc_int128.hpp
+++ b/stl/inc/__msvc_int128.hpp
@@ -43,7 +43,11 @@ _STD_BEGIN
 
 struct _Int128;
 
-struct alignas(16) _Uint128 {
+struct
+#ifndef _M_ARM
+    alignas(16)
+#endif
+        _Uint128 {
     uint64_t _Word[2];
 
     using _Signed_type   = _Int128;

--- a/stl/inc/__msvc_int128.hpp
+++ b/stl/inc/__msvc_int128.hpp
@@ -392,12 +392,10 @@ struct
         // establish _Den < _Num and _Num._Word[1] > 0
         if (_Den._Word[1] >= _Num._Word[1]) {
             if (_Den._Word[1] > _Num._Word[1]) {
-                return {};
+                return 0;
             }
 
-            if (_Den._Word[1] == _Num._Word[1]) {
-                return {_Num._Word[1] == 0 ? _Num._Word[0] / _Den._Word[0] : _Num._Word[0] >= _Den._Word[0]};
-            }
+            return _Num._Word[1] == 0 ? _Num._Word[0] / _Den._Word[0] : _Num._Word[0] >= _Den._Word[0];
         }
 
         // establish _Den has more than 1 non-zero "digit"
@@ -494,7 +492,7 @@ struct
             __q[1] = 0;
         }
 
-        return {static_cast<uint64_t>(__q[1]) << 32 | __q[0]};
+        return static_cast<uint64_t>(__q[1]) << 32 | __q[0];
 #endif // _STL_128_INTRINSICS
     }
 
@@ -503,13 +501,13 @@ struct
         uint64_t _Rem = _Num._Word[1];
         _Rem          = ((_Rem % _Den) << 32) | (_Num._Word[0] >> 32);
         _Rem          = ((_Rem % _Den) << 32) | static_cast<uint32_t>(_Num._Word[0]);
-        return _Uint128_base{_Rem % _Den};
+        return _Rem % _Den;
     }
 #endif // !_STL_128_DIV_INTRINSICS
     _NODISCARD static constexpr _Uint128_base _Modulo(const _Uint128_base& _Num, const uint64_t _Den) noexcept {
         uint64_t _Rem;
         (void) _UDiv128(_Num._Word[1] % _Den, _Num._Word[0], _Den, _Rem);
-        return _Uint128_base{_Rem};
+        return _Rem;
     }
     _NODISCARD static constexpr _Uint128_base _Modulo(_Uint128_base _Num, _Uint128_base _Den) noexcept {
         // establish _Den < _Num and _Num._Word[1] > 0
@@ -518,14 +516,11 @@ struct
                 return _Num;
             }
 
-            if (_Den._Word[1] == _Num._Word[1]) {
-                if (_Den._Word[0] <= _Num._Word[0]) {
-                    return _Uint128_base{
-                        _Num._Word[1] == 0 ? _Num._Word[0] % _Den._Word[0] : _Num._Word[0] - _Den._Word[0]};
-                }
-
-                return _Num;
+            if (_Den._Word[0] <= _Num._Word[0]) {
+                return _Num._Word[1] == 0 ? _Num._Word[0] % _Den._Word[0] : _Num._Word[0] - _Den._Word[0];
             }
+
+            return _Num;
         }
 
         // establish _Den has more than 1 non-zero "digit"

--- a/stl/inc/__msvc_int128.hpp
+++ b/stl/inc/__msvc_int128.hpp
@@ -454,12 +454,14 @@ struct
 
     _NODISCARD_FRIEND constexpr _Uint128 operator/(_Uint128 _Num, _Uint128 _Den) noexcept {
         // establish _Den < _Num and _Num._Word[1] > 0
-        if (_Den._Word[1] > _Num._Word[1]) {
-            return _Uint128{};
-        }
+        if (_Den._Word[1] >= _Num._Word[1]) {
+            if (_Den._Word[1] > _Num._Word[1]) {
+                return _Uint128{};
+            }
 
-        if (_Den._Word[1] == _Num._Word[1]) {
-            return _Uint128{_Num._Word[1] == 0 ? _Num._Word[0] / _Den._Word[0] : _Num._Word[0] >= _Den._Word[0]};
+            if (_Den._Word[1] == _Num._Word[1]) {
+                return _Uint128{_Num._Word[1] == 0 ? _Num._Word[0] / _Den._Word[0] : _Num._Word[0] >= _Den._Word[0]};
+            }
         }
 
         // establish _Den has more than 1 non-zero "digit"
@@ -599,16 +601,18 @@ struct
     }
     _NODISCARD_FRIEND constexpr _Uint128 operator%(_Uint128 _Num, _Uint128 _Den) noexcept {
         // establish _Den < _Num and _Num._Word[1] > 0
-        if (_Den._Word[1] > _Num._Word[1]) {
-            return _Num;
-        }
-
-        if (_Den._Word[1] == _Num._Word[1]) {
-            if (_Den._Word[0] <= _Num._Word[0]) {
-                return _Uint128{_Num._Word[0] - _Den._Word[0]};
+        if (_Den._Word[1] >= _Num._Word[1]) {
+            if (_Den._Word[1] > _Num._Word[1]) {
+                return _Num;
             }
 
-            return _Num;
+            if (_Den._Word[1] == _Num._Word[1]) {
+                if (_Den._Word[0] <= _Num._Word[0]) {
+                    return _Uint128{_Num._Word[1] == 0 ? _Num._Word[0] % _Den._Word[0] : _Num._Word[0] - _Den._Word[0]};
+                }
+
+                return _Num;
+            }
         }
 
         // establish _Den has more than 1 non-zero "digit"

--- a/stl/inc/__msvc_int128.hpp
+++ b/stl/inc/__msvc_int128.hpp
@@ -657,21 +657,22 @@ struct
     }
 };
 
-struct _Int128;
+struct _Signed128;
 
-struct _Uint128 : _Base128 {
-    using _Signed_type   = _Int128;
-    using _Unsigned_type = _Uint128;
+struct _Unsigned128 : _Base128 {
+    using _Signed_type   = _Signed128;
+    using _Unsigned_type = _Unsigned128;
 
     using _Base128::_Base128;
-    constexpr explicit _Uint128(const _Base128& _That) noexcept : _Base128{_That} {}
+    constexpr explicit _Unsigned128(const _Base128& _That) noexcept : _Base128{_That} {}
 
-    constexpr _Uint128& operator=(const _Base128& _That) noexcept {
+    constexpr _Unsigned128& operator=(const _Base128& _That) noexcept {
         _Base128::operator=(_That);
         return *this;
     }
 
-    _NODISCARD_FRIEND constexpr strong_ordering operator<=>(const _Uint128& _Left, const _Uint128& _Right) noexcept {
+    _NODISCARD_FRIEND constexpr strong_ordering operator<=>(
+        const _Unsigned128& _Left, const _Unsigned128& _Right) noexcept {
         strong_ordering _Ord = _Left._Word[1] <=> _Right._Word[1];
         if (_Ord == strong_ordering::equal) {
             _Ord = _Left._Word[0] <=> _Right._Word[0];
@@ -679,157 +680,157 @@ struct _Uint128 : _Base128 {
         return _Ord;
     }
 
-    _NODISCARD_FRIEND constexpr _Uint128 operator<<(const _Uint128& _Left, const _Base128& _Right) noexcept {
+    _NODISCARD_FRIEND constexpr _Unsigned128 operator<<(const _Unsigned128& _Left, const _Base128& _Right) noexcept {
         auto _Tmp{_Left};
         _Tmp._Left_shift(static_cast<unsigned char>(_Right._Word[0]));
         return _Tmp;
     }
 
     template <integral _Ty>
-    constexpr _Uint128& operator<<=(const _Ty _Count) noexcept {
+    constexpr _Unsigned128& operator<<=(const _Ty _Count) noexcept {
         _Left_shift(static_cast<unsigned char>(_Count));
         return *this;
     }
-    constexpr _Uint128& operator<<=(const _Base128& _Count) noexcept {
+    constexpr _Unsigned128& operator<<=(const _Base128& _Count) noexcept {
         _Left_shift(static_cast<unsigned char>(_Count._Word[0]));
         return *this;
     }
 
-    _NODISCARD_FRIEND constexpr _Uint128 operator>>(const _Uint128& _Left, const _Base128& _Right) noexcept {
+    _NODISCARD_FRIEND constexpr _Unsigned128 operator>>(const _Unsigned128& _Left, const _Base128& _Right) noexcept {
         auto _Tmp{_Left};
         _Tmp._Unsigned_right_shift(static_cast<unsigned char>(_Right._Word[0]));
         return _Tmp;
     }
 
     template <integral _Ty>
-    constexpr _Uint128& operator>>=(const _Ty _Count) noexcept {
+    constexpr _Unsigned128& operator>>=(const _Ty _Count) noexcept {
         _Unsigned_right_shift(static_cast<unsigned char>(_Count));
         return *this;
     }
-    constexpr _Uint128& operator>>=(const _Base128& _Count) noexcept {
+    constexpr _Unsigned128& operator>>=(const _Base128& _Count) noexcept {
         _Unsigned_right_shift(static_cast<unsigned char>(_Count._Word[0]));
         return *this;
     }
 
-    constexpr _Uint128& operator++() noexcept {
+    constexpr _Unsigned128& operator++() noexcept {
         if (++_Word[0] == 0) {
             ++_Word[1];
         }
         return *this;
     }
-    constexpr _Uint128 operator++(int) noexcept {
+    constexpr _Unsigned128 operator++(int) noexcept {
         auto _Tmp = *this;
         ++*this;
         return _Tmp;
     }
 
-    constexpr _Uint128& operator--() noexcept {
+    constexpr _Unsigned128& operator--() noexcept {
         if (_Word[0]-- == 0) {
             --_Word[1];
         }
         return *this;
     }
-    constexpr _Uint128 operator--(int) noexcept {
+    constexpr _Unsigned128 operator--(int) noexcept {
         auto _Tmp = *this;
         --*this;
         return _Tmp;
     }
 
-    _NODISCARD constexpr _Uint128 operator+() const noexcept {
+    _NODISCARD constexpr _Unsigned128 operator+() const noexcept {
         return *this;
     }
 
-    _NODISCARD constexpr _Uint128 operator-() const noexcept {
-        return _Uint128{} - *this;
+    _NODISCARD constexpr _Unsigned128 operator-() const noexcept {
+        return _Unsigned128{} - *this;
     }
 
-    _NODISCARD constexpr _Uint128 operator~() const noexcept {
-        return _Uint128{~_Word[0], ~_Word[1]};
+    _NODISCARD constexpr _Unsigned128 operator~() const noexcept {
+        return _Unsigned128{~_Word[0], ~_Word[1]};
     }
 
-    _NODISCARD_FRIEND constexpr _Uint128 operator+(const _Base128& _Left, const _Base128& _Right) noexcept {
-        _Uint128 _Result;
+    _NODISCARD_FRIEND constexpr _Unsigned128 operator+(const _Base128& _Left, const _Base128& _Right) noexcept {
+        _Unsigned128 _Result;
         const auto _Carry = _AddCarry64(0, _Left._Word[0], _Right._Word[0], _Result._Word[0]);
         _AddCarry64(_Carry, _Left._Word[1], _Right._Word[1], _Result._Word[1]);
         return _Result;
     }
 
-    constexpr _Uint128& operator+=(const _Base128& _That) noexcept {
+    constexpr _Unsigned128& operator+=(const _Base128& _That) noexcept {
         const auto _Carry = _AddCarry64(0, _Word[0], _That._Word[0], _Word[0]);
         _AddCarry64(_Carry, _Word[1], _That._Word[1], _Word[1]);
         return *this;
     }
     template <integral _Ty>
-    friend constexpr _Ty& operator+=(_Ty& _Left, const _Uint128& _Right) noexcept {
+    friend constexpr _Ty& operator+=(_Ty& _Left, const _Unsigned128& _Right) noexcept {
         _Left += _Right._Word[0];
         return _Left;
     }
 
-    _NODISCARD_FRIEND constexpr _Uint128 operator-(const _Base128& _Left, const _Base128& _Right) noexcept {
-        _Uint128 _Result;
+    _NODISCARD_FRIEND constexpr _Unsigned128 operator-(const _Base128& _Left, const _Base128& _Right) noexcept {
+        _Unsigned128 _Result;
         const auto _Borrow = _SubBorrow64(0, _Left._Word[0], _Right._Word[0], _Result._Word[0]);
         _SubBorrow64(_Borrow, _Left._Word[1], _Right._Word[1], _Result._Word[1]);
         return _Result;
     }
 
-    constexpr _Uint128& operator-=(const _Base128& _That) noexcept {
+    constexpr _Unsigned128& operator-=(const _Base128& _That) noexcept {
         const auto _Borrow = _SubBorrow64(0, _Word[0], _That._Word[0], _Word[0]);
         _SubBorrow64(_Borrow, _Word[1], _That._Word[1], _Word[1]);
         return *this;
     }
     template <integral _Ty>
-    friend constexpr _Ty& operator-=(_Ty& _Left, const _Uint128& _Right) noexcept {
+    friend constexpr _Ty& operator-=(_Ty& _Left, const _Unsigned128& _Right) noexcept {
         _Left -= _Right._Word[0];
         return _Left;
     }
 
-    _NODISCARD_FRIEND constexpr _Uint128 operator*(const _Base128& _Left, const _Base128& _Right) noexcept {
-        return _Uint128{_Base128::_Multiply(_Left, _Right)};
+    _NODISCARD_FRIEND constexpr _Unsigned128 operator*(const _Base128& _Left, const _Base128& _Right) noexcept {
+        return _Unsigned128{_Base128::_Multiply(_Left, _Right)};
     }
 
-    constexpr _Uint128& operator*=(const _Base128& _That) noexcept {
+    constexpr _Unsigned128& operator*=(const _Base128& _That) noexcept {
         *this = *this * _That;
         return *this;
     }
     template <integral _Ty>
-    friend constexpr _Ty& operator*=(_Ty& _Left, const _Uint128& _Right) noexcept {
+    friend constexpr _Ty& operator*=(_Ty& _Left, const _Unsigned128& _Right) noexcept {
         _Left *= _Right._Word[0];
         return _Left;
     }
 
     template <integral _Ty>
-    _NODISCARD_FRIEND constexpr _Uint128 operator/(const _Uint128& _Num, const _Ty _Den) noexcept {
+    _NODISCARD_FRIEND constexpr _Unsigned128 operator/(const _Unsigned128& _Num, const _Ty _Den) noexcept {
 #if !_STL_128_DIV_INTRINSICS
         if constexpr (sizeof(_Ty) <= 4) {
-            return _Uint128{_Base128::_Divide(_Num, static_cast<uint32_t>(_Den))};
+            return _Unsigned128{_Base128::_Divide(_Num, static_cast<uint32_t>(_Den))};
         } else
 #endif // !_STL_128_DIV_INTRINSICS
         {
-            return _Uint128{_Base128::_Divide(_Num, static_cast<uint64_t>(_Den))};
+            return _Unsigned128{_Base128::_Divide(_Num, static_cast<uint64_t>(_Den))};
         }
     }
-    _NODISCARD_FRIEND constexpr _Uint128 operator/(const _Base128& _Num, const _Base128& _Den) noexcept {
-        return _Uint128{_Base128::_Divide(_Num, _Den)};
+    _NODISCARD_FRIEND constexpr _Unsigned128 operator/(const _Base128& _Num, const _Base128& _Den) noexcept {
+        return _Unsigned128{_Base128::_Divide(_Num, _Den)};
     }
 
     template <integral _Ty>
-    constexpr _Uint128& operator/=(const _Ty _That) noexcept {
+    constexpr _Unsigned128& operator/=(const _Ty _That) noexcept {
 #if !_STL_128_DIV_INTRINSICS
         if constexpr (sizeof(_Ty) <= 4) {
-            *this = _Uint128{_Base128::_Divide(*this, static_cast<uint32_t>(_That))};
+            *this = _Unsigned128{_Base128::_Divide(*this, static_cast<uint32_t>(_That))};
         } else
 #endif // !_STL_128_DIV_INTRINSICS
         {
-            *this = _Uint128{_Base128::_Divide(*this, static_cast<uint64_t>(_That))};
+            *this = _Unsigned128{_Base128::_Divide(*this, static_cast<uint64_t>(_That))};
         }
         return *this;
     }
-    constexpr _Uint128& operator/=(const _Base128& _That) noexcept {
-        *this = _Uint128{_Base128::_Divide(*this, _That)};
+    constexpr _Unsigned128& operator/=(const _Base128& _That) noexcept {
+        *this = _Unsigned128{_Base128::_Divide(*this, _That)};
         return *this;
     }
     template <integral _Ty>
-    friend constexpr _Ty& operator/=(_Ty& _Left, const _Uint128& _Right) noexcept {
+    friend constexpr _Ty& operator/=(_Ty& _Left, const _Unsigned128& _Right) noexcept {
         if (_Right._Word[1] != 0) {
             _Left = 0;
         } else {
@@ -839,62 +840,62 @@ struct _Uint128 : _Base128 {
     }
 
     template <integral _Ty>
-    _NODISCARD_FRIEND constexpr _Uint128 operator%(const _Base128& _Num, const _Ty _Den) noexcept {
+    _NODISCARD_FRIEND constexpr _Unsigned128 operator%(const _Base128& _Num, const _Ty _Den) noexcept {
 #if !_STL_128_DIV_INTRINSICS
         if constexpr (sizeof(_Ty) <= 4) {
-            return _Uint128{_Base128::_Modulo(_Num, static_cast<uint32_t>(_Den))};
+            return _Unsigned128{_Base128::_Modulo(_Num, static_cast<uint32_t>(_Den))};
         } else
 #endif // !_STL_128_DIV_INTRINSICS
         {
-            return _Uint128{_Base128::_Modulo(_Num, static_cast<uint64_t>(_Den))};
+            return _Unsigned128{_Base128::_Modulo(_Num, static_cast<uint64_t>(_Den))};
         }
     }
-    _NODISCARD_FRIEND constexpr _Uint128 operator%(const _Base128& _Num, const _Base128& _Den) noexcept {
-        return _Uint128{_Base128::_Modulo(_Num, _Den)};
+    _NODISCARD_FRIEND constexpr _Unsigned128 operator%(const _Base128& _Num, const _Base128& _Den) noexcept {
+        return _Unsigned128{_Base128::_Modulo(_Num, _Den)};
     }
 
     template <integral _Ty>
-    constexpr _Uint128& operator%=(const _Ty _Den) noexcept {
+    constexpr _Unsigned128& operator%=(const _Ty _Den) noexcept {
         *this = *this % _Den;
         return *this;
     }
-    constexpr _Uint128& operator%=(const _Base128& _Den) noexcept {
+    constexpr _Unsigned128& operator%=(const _Base128& _Den) noexcept {
         *this = *this % _Den;
         return *this;
     }
     template <integral _Ty>
-    friend constexpr _Ty& operator%=(_Ty& _Left, const _Uint128& _Right) noexcept {
+    friend constexpr _Ty& operator%=(_Ty& _Left, const _Unsigned128& _Right) noexcept {
         if (_Right._Word[1] == 0) {
             _Left %= _Right._Word[0];
         }
         return _Left;
     }
 
-    _NODISCARD_FRIEND constexpr _Uint128 operator&(const _Base128& _Left, const _Base128& _Right) noexcept {
-        return _Uint128{_Left._Word[0] & _Right._Word[0], _Left._Word[1] & _Right._Word[1]};
+    _NODISCARD_FRIEND constexpr _Unsigned128 operator&(const _Base128& _Left, const _Base128& _Right) noexcept {
+        return _Unsigned128{_Left._Word[0] & _Right._Word[0], _Left._Word[1] & _Right._Word[1]};
     }
 
-    constexpr _Uint128& operator&=(const _Base128& _That) noexcept {
+    constexpr _Unsigned128& operator&=(const _Base128& _That) noexcept {
         _Word[0] &= _That._Word[0];
         _Word[1] &= _That._Word[1];
         return *this;
     }
 
-    _NODISCARD_FRIEND constexpr _Uint128 operator^(const _Base128& _Left, const _Base128& _Right) noexcept {
-        return _Uint128{_Left._Word[0] ^ _Right._Word[0], _Left._Word[1] ^ _Right._Word[1]};
+    _NODISCARD_FRIEND constexpr _Unsigned128 operator^(const _Base128& _Left, const _Base128& _Right) noexcept {
+        return _Unsigned128{_Left._Word[0] ^ _Right._Word[0], _Left._Word[1] ^ _Right._Word[1]};
     }
 
-    constexpr _Uint128& operator^=(const _Base128& _That) noexcept {
+    constexpr _Unsigned128& operator^=(const _Base128& _That) noexcept {
         _Word[0] ^= _That._Word[0];
         _Word[1] ^= _That._Word[1];
         return *this;
     }
 
-    _NODISCARD_FRIEND constexpr _Uint128 operator|(const _Base128& _Left, const _Base128& _Right) noexcept {
-        return _Uint128{_Left._Word[0] | _Right._Word[0], _Left._Word[1] | _Right._Word[1]};
+    _NODISCARD_FRIEND constexpr _Unsigned128 operator|(const _Base128& _Left, const _Base128& _Right) noexcept {
+        return _Unsigned128{_Left._Word[0] | _Right._Word[0], _Left._Word[1] | _Right._Word[1]};
     }
 
-    constexpr _Uint128& operator|=(const _Base128& _That) noexcept {
+    constexpr _Unsigned128& operator|=(const _Base128& _That) noexcept {
         _Word[0] |= _That._Word[0];
         _Word[1] |= _That._Word[1];
         return *this;
@@ -904,41 +905,41 @@ struct _Uint128 : _Base128 {
 template <class>
 class numeric_limits;
 template <>
-class numeric_limits<_Uint128> : public _Num_int_base {
+class numeric_limits<_Unsigned128> : public _Num_int_base {
 public:
-    _NODISCARD static constexpr _Uint128(min)() noexcept {
+    _NODISCARD static constexpr _Unsigned128(min)() noexcept {
         return 0;
     }
 
-    _NODISCARD static constexpr _Uint128(max)() noexcept {
-        return _Uint128{~0ull, ~0ull};
+    _NODISCARD static constexpr _Unsigned128(max)() noexcept {
+        return _Unsigned128{~0ull, ~0ull};
     }
 
-    _NODISCARD static constexpr _Uint128 lowest() noexcept {
+    _NODISCARD static constexpr _Unsigned128 lowest() noexcept {
         return (min) ();
     }
 
-    _NODISCARD static constexpr _Uint128 epsilon() noexcept {
+    _NODISCARD static constexpr _Unsigned128 epsilon() noexcept {
         return 0;
     }
 
-    _NODISCARD static constexpr _Uint128 round_error() noexcept {
+    _NODISCARD static constexpr _Unsigned128 round_error() noexcept {
         return 0;
     }
 
-    _NODISCARD static constexpr _Uint128 denorm_min() noexcept {
+    _NODISCARD static constexpr _Unsigned128 denorm_min() noexcept {
         return 0;
     }
 
-    _NODISCARD static constexpr _Uint128 infinity() noexcept {
+    _NODISCARD static constexpr _Unsigned128 infinity() noexcept {
         return 0;
     }
 
-    _NODISCARD static constexpr _Uint128 quiet_NaN() noexcept {
+    _NODISCARD static constexpr _Unsigned128 quiet_NaN() noexcept {
         return 0;
     }
 
-    _NODISCARD static constexpr _Uint128 signaling_NaN() noexcept {
+    _NODISCARD static constexpr _Unsigned128 signaling_NaN() noexcept {
         return 0;
     }
 
@@ -950,27 +951,28 @@ public:
 template <class...>
 struct common_type;
 template <integral _Ty>
-struct common_type<_Ty, _Uint128> {
-    using type = _Uint128;
+struct common_type<_Ty, _Unsigned128> {
+    using type = _Unsigned128;
 };
 template <integral _Ty>
-struct common_type<_Uint128, _Ty> {
-    using type = _Uint128;
+struct common_type<_Unsigned128, _Ty> {
+    using type = _Unsigned128;
 };
 
-struct _Int128 : _Base128 {
-    using _Signed_type   = _Int128;
-    using _Unsigned_type = _Uint128;
+struct _Signed128 : _Base128 {
+    using _Signed_type   = _Signed128;
+    using _Unsigned_type = _Unsigned128;
 
     using _Base128::_Base128;
-    constexpr explicit _Int128(const _Base128& _That) noexcept : _Base128{_That} {}
+    constexpr explicit _Signed128(const _Base128& _That) noexcept : _Base128{_That} {}
 
-    constexpr _Int128& operator=(const _Base128& _That) noexcept {
+    constexpr _Signed128& operator=(const _Base128& _That) noexcept {
         _Base128::operator=(_That);
         return *this;
     }
 
-    _NODISCARD_FRIEND constexpr strong_ordering operator<=>(const _Int128& _Left, const _Int128& _Right) noexcept {
+    _NODISCARD_FRIEND constexpr strong_ordering operator<=>(
+        const _Signed128& _Left, const _Signed128& _Right) noexcept {
         strong_ordering _Ord = static_cast<int64_t>(_Left._Word[1]) <=> static_cast<int64_t>(_Right._Word[1]);
         if (_Ord == strong_ordering::equal) {
             _Ord = _Left._Word[0] <=> _Right._Word[0];
@@ -978,18 +980,18 @@ struct _Int128 : _Base128 {
         return _Ord;
     }
 
-    _NODISCARD_FRIEND constexpr _Int128 operator<<(const _Int128& _Left, const _Base128& _Right) noexcept {
+    _NODISCARD_FRIEND constexpr _Signed128 operator<<(const _Signed128& _Left, const _Base128& _Right) noexcept {
         auto _Tmp{_Left};
         _Tmp._Left_shift(static_cast<unsigned char>(_Right._Word[0]));
         return _Tmp;
     }
 
     template <integral _Ty>
-    constexpr _Int128& operator<<=(const _Ty _Count) noexcept {
+    constexpr _Signed128& operator<<=(const _Ty _Count) noexcept {
         _Left_shift(static_cast<unsigned char>(_Count));
         return *this;
     }
-    constexpr _Int128& operator<<=(const _Base128& _Count) noexcept {
+    constexpr _Signed128& operator<<=(const _Base128& _Count) noexcept {
         _Left_shift(static_cast<unsigned char>(_Count._Word[0]));
         return *this;
     }
@@ -1017,91 +1019,91 @@ struct _Int128 : _Base128 {
         _Word[1] = static_cast<uint64_t>(static_cast<int64_t>(_Word[1]) >> _Count);
     }
 
-    _NODISCARD_FRIEND constexpr _Int128 operator>>(const _Int128& _Left, const _Base128& _Right) noexcept {
+    _NODISCARD_FRIEND constexpr _Signed128 operator>>(const _Signed128& _Left, const _Base128& _Right) noexcept {
         auto _Tmp{_Left};
         _Tmp._Signed_right_shift(static_cast<unsigned char>(_Right._Word[0]));
         return _Tmp;
     }
 
     template <integral _Ty>
-    constexpr _Int128& operator>>=(const _Ty _Count) noexcept {
+    constexpr _Signed128& operator>>=(const _Ty _Count) noexcept {
         _Signed_right_shift(static_cast<unsigned char>(_Count));
         return *this;
     }
-    constexpr _Int128& operator>>=(const _Base128& _Count) noexcept {
+    constexpr _Signed128& operator>>=(const _Base128& _Count) noexcept {
         _Signed_right_shift(static_cast<unsigned char>(_Count._Word[0]));
         return *this;
     }
 
-    constexpr _Int128& operator++() noexcept {
+    constexpr _Signed128& operator++() noexcept {
         if (++_Word[0] == 0) {
             ++_Word[1];
         }
         return *this;
     }
-    constexpr _Int128 operator++(int) noexcept {
+    constexpr _Signed128 operator++(int) noexcept {
         auto _Tmp = *this;
         ++*this;
         return _Tmp;
     }
 
-    constexpr _Int128& operator--() noexcept {
+    constexpr _Signed128& operator--() noexcept {
         if (_Word[0]-- == 0) {
             --_Word[1];
         }
         return *this;
     }
-    constexpr _Int128 operator--(int) noexcept {
+    constexpr _Signed128 operator--(int) noexcept {
         auto _Tmp = *this;
         --*this;
         return _Tmp;
     }
 
-    _NODISCARD constexpr _Int128 operator+() const noexcept {
+    _NODISCARD constexpr _Signed128 operator+() const noexcept {
         return *this;
     }
 
-    _NODISCARD constexpr _Int128 operator-() const noexcept {
-        return _Int128{} - *this;
+    _NODISCARD constexpr _Signed128 operator-() const noexcept {
+        return _Signed128{} - *this;
     }
 
-    _NODISCARD constexpr _Int128 operator~() const noexcept {
-        return _Int128{~_Word[0], ~_Word[1]};
+    _NODISCARD constexpr _Signed128 operator~() const noexcept {
+        return _Signed128{~_Word[0], ~_Word[1]};
     }
 
-    _NODISCARD_FRIEND constexpr _Int128 operator+(const _Int128& _Left, const _Int128& _Right) noexcept {
-        _Int128 _Result;
+    _NODISCARD_FRIEND constexpr _Signed128 operator+(const _Signed128& _Left, const _Signed128& _Right) noexcept {
+        _Signed128 _Result;
         const auto _Carry = _AddCarry64(0, _Left._Word[0], _Right._Word[0], _Result._Word[0]);
         _AddCarry64(_Carry, _Left._Word[1], _Right._Word[1], _Result._Word[1]);
         return _Result;
     }
 
-    constexpr _Int128& operator+=(const _Base128& _That) noexcept {
+    constexpr _Signed128& operator+=(const _Base128& _That) noexcept {
         const auto _Carry = _AddCarry64(0, _Word[0], _That._Word[0], _Word[0]);
         _AddCarry64(_Carry, _Word[1], _That._Word[1], _Word[1]);
         return *this;
     }
     template <integral _Ty>
-    friend constexpr _Ty& operator+=(_Ty& _Left, const _Int128& _Right) noexcept {
-        _Left = static_cast<_Ty>(_Int128{_Left} + _Right);
+    friend constexpr _Ty& operator+=(_Ty& _Left, const _Signed128& _Right) noexcept {
+        _Left = static_cast<_Ty>(_Signed128{_Left} + _Right);
         return _Left;
     }
 
-    _NODISCARD_FRIEND constexpr _Int128 operator-(const _Int128& _Left, const _Int128& _Right) noexcept {
-        _Int128 _Result;
+    _NODISCARD_FRIEND constexpr _Signed128 operator-(const _Signed128& _Left, const _Signed128& _Right) noexcept {
+        _Signed128 _Result;
         const auto _Borrow = _SubBorrow64(0, _Left._Word[0], _Right._Word[0], _Result._Word[0]);
         _SubBorrow64(_Borrow, _Left._Word[1], _Right._Word[1], _Result._Word[1]);
         return _Result;
     }
 
-    constexpr _Int128& operator-=(const _Base128& _That) noexcept {
+    constexpr _Signed128& operator-=(const _Base128& _That) noexcept {
         const auto _Borrow = _SubBorrow64(0, _Word[0], _That._Word[0], _Word[0]);
         _SubBorrow64(_Borrow, _Word[1], _That._Word[1], _Word[1]);
         return *this;
     }
     template <integral _Ty>
-    friend constexpr _Ty& operator-=(_Ty& _Left, const _Int128& _Right) noexcept {
-        _Left = static_cast<_Ty>(_Int128{_Left} - _Right);
+    friend constexpr _Ty& operator-=(_Ty& _Left, const _Signed128& _Right) noexcept {
+        _Left = static_cast<_Ty>(_Signed128{_Left} - _Right);
         return _Left;
     }
 
@@ -1112,11 +1114,11 @@ struct _Int128 : _Base128 {
         }
     }
 
-    _NODISCARD_FRIEND constexpr _Int128 operator*(_Int128 _Left, _Int128 _Right) noexcept {
+    _NODISCARD_FRIEND constexpr _Signed128 operator*(_Signed128 _Left, _Signed128 _Right) noexcept {
         bool _Negative = false;
         _Left._Strip_negative(_Negative);
         _Right._Strip_negative(_Negative);
-        _Int128 _Result{_Base128::_Multiply(_Left, _Right)};
+        _Signed128 _Result{_Base128::_Multiply(_Left, _Right)};
         if (_Negative) {
             _Result = -_Result;
         }
@@ -1124,26 +1126,26 @@ struct _Int128 : _Base128 {
     }
 
     template <integral _Ty>
-    constexpr _Int128& operator*=(const _Ty _That) noexcept {
+    constexpr _Signed128& operator*=(const _Ty _That) noexcept {
         *this = *this * _That;
         return *this;
     }
-    constexpr _Int128& operator*=(const _Int128& _That) noexcept {
+    constexpr _Signed128& operator*=(const _Signed128& _That) noexcept {
         *this = *this * _That;
         return *this;
     }
-    constexpr _Int128& operator*=(const _Uint128& _That) noexcept {
-        *this = _Int128{static_cast<const _Base128&>(*this) * _That};
+    constexpr _Signed128& operator*=(const _Unsigned128& _That) noexcept {
+        *this = _Signed128{static_cast<const _Base128&>(*this) * _That};
         return *this;
     }
     template <integral _Ty>
-    friend constexpr _Ty& operator*=(_Ty& _Left, const _Int128& _Right) noexcept {
-        _Left = static_cast<_Ty>(_Int128{_Left} * _Right);
+    friend constexpr _Ty& operator*=(_Ty& _Left, const _Signed128& _Right) noexcept {
+        _Left = static_cast<_Ty>(_Signed128{_Left} * _Right);
         return _Left;
     }
 
     template <integral _Ty>
-    _NODISCARD_FRIEND constexpr _Int128 operator/(_Int128 _Num, _Ty _Den) noexcept {
+    _NODISCARD_FRIEND constexpr _Signed128 operator/(_Signed128 _Num, _Ty _Den) noexcept {
         bool _Negative = false;
         _Num._Strip_negative(_Negative);
         if constexpr (is_signed_v<_Ty>) {
@@ -1153,14 +1155,14 @@ struct _Int128 : _Base128 {
             }
         }
 
-        _Int128 _Result;
+        _Signed128 _Result;
 #if !_STL_128_DIV_INTRINSICS
         if constexpr (sizeof(_Ty) <= 4) {
-            _Result = _Int128{_Base128::_Divide(_Num, static_cast<uint32_t>(_Den))};
+            _Result = _Signed128{_Base128::_Divide(_Num, static_cast<uint32_t>(_Den))};
         } else
 #endif // !_STL_128_DIV_INTRINSICS
         {
-            _Result = _Int128{_Base128::_Divide(_Num, static_cast<uint64_t>(_Den))};
+            _Result = _Signed128{_Base128::_Divide(_Num, static_cast<uint64_t>(_Den))};
         }
 
         if (_Negative) {
@@ -1168,11 +1170,11 @@ struct _Int128 : _Base128 {
         }
         return _Result;
     }
-    _NODISCARD_FRIEND constexpr _Int128 operator/(_Int128 _Num, _Int128 _Den) noexcept {
+    _NODISCARD_FRIEND constexpr _Signed128 operator/(_Signed128 _Num, _Signed128 _Den) noexcept {
         bool _Negative = false;
         _Num._Strip_negative(_Negative);
         _Den._Strip_negative(_Negative);
-        _Int128 _Result{_Base128::_Divide(_Num, _Den)};
+        _Signed128 _Result{_Base128::_Divide(_Num, _Den)};
         if (_Negative) {
             _Result = -_Result;
         }
@@ -1180,25 +1182,25 @@ struct _Int128 : _Base128 {
     }
 
     template <integral _Ty>
-    constexpr _Int128& operator/=(const _Ty _That) noexcept {
+    constexpr _Signed128& operator/=(const _Ty _That) noexcept {
         *this = *this / _That;
         return *this;
     }
-    constexpr _Int128& operator/=(const _Int128& _That) noexcept {
+    constexpr _Signed128& operator/=(const _Signed128& _That) noexcept {
         *this = *this / _That;
         return *this;
     }
-    constexpr _Int128& operator/=(const _Uint128& _That) noexcept {
-        *this = _Int128{static_cast<_Base128&>(*this) / _That};
+    constexpr _Signed128& operator/=(const _Unsigned128& _That) noexcept {
+        *this = _Signed128{static_cast<_Base128&>(*this) / _That};
         return *this;
     }
     template <integral _Ty>
-    friend constexpr _Ty& operator/=(_Ty& _Left, const _Int128& _Right) noexcept {
-        _Left = static_cast<_Ty>(_Int128{_Left} / _Right);
+    friend constexpr _Ty& operator/=(_Ty& _Left, const _Signed128& _Right) noexcept {
+        _Left = static_cast<_Ty>(_Signed128{_Left} / _Right);
         return _Left;
     }
 
-    _NODISCARD_FRIEND constexpr _Int128 operator%(_Int128 _Left, _Int128 _Right) noexcept {
+    _NODISCARD_FRIEND constexpr _Signed128 operator%(_Signed128 _Left, _Signed128 _Right) noexcept {
         bool _Negative = false;
         _Left._Strip_negative(_Negative);
 
@@ -1207,57 +1209,57 @@ struct _Int128 : _Base128 {
             // intentionally not flipping _Negative
         }
 
-        _Uint128 _Result{_Base128::_Modulo(_Left, _Right)};
+        _Unsigned128 _Result{_Base128::_Modulo(_Left, _Right)};
         if (_Negative) {
             _Result = -_Result;
         }
-        return _Int128{_Result};
+        return _Signed128{_Result};
     }
 
     template <integral _Ty>
-    constexpr _Int128& operator%=(const _Ty _That) noexcept {
+    constexpr _Signed128& operator%=(const _Ty _That) noexcept {
         *this = *this % _That;
         return *this;
     }
-    constexpr _Int128& operator%=(const _Int128& _That) noexcept {
+    constexpr _Signed128& operator%=(const _Signed128& _That) noexcept {
         *this = *this % _That;
         return *this;
     }
-    constexpr _Int128& operator%=(const _Uint128& _That) noexcept {
+    constexpr _Signed128& operator%=(const _Unsigned128& _That) noexcept {
         *this = static_cast<const _Base128&>(*this) % _That;
         return *this;
     }
     template <integral _Ty>
-    friend constexpr _Ty& operator%=(_Ty& _Left, const _Int128& _Right) noexcept {
-        _Left = static_cast<_Ty>(_Int128{_Left} % _Right);
+    friend constexpr _Ty& operator%=(_Ty& _Left, const _Signed128& _Right) noexcept {
+        _Left = static_cast<_Ty>(_Signed128{_Left} % _Right);
         return _Left;
     }
 
-    _NODISCARD_FRIEND constexpr _Int128 operator&(const _Int128& _Left, const _Int128& _Right) noexcept {
-        return _Int128{_Left._Word[0] & _Right._Word[0], _Left._Word[1] & _Right._Word[1]};
+    _NODISCARD_FRIEND constexpr _Signed128 operator&(const _Signed128& _Left, const _Signed128& _Right) noexcept {
+        return _Signed128{_Left._Word[0] & _Right._Word[0], _Left._Word[1] & _Right._Word[1]};
     }
 
-    constexpr _Int128& operator&=(const _Base128& _That) noexcept {
+    constexpr _Signed128& operator&=(const _Base128& _That) noexcept {
         _Word[0] &= _That._Word[0];
         _Word[1] &= _That._Word[1];
         return *this;
     }
 
-    _NODISCARD_FRIEND constexpr _Int128 operator^(const _Int128& _Left, const _Int128& _Right) noexcept {
-        return _Int128{_Left._Word[0] ^ _Right._Word[0], _Left._Word[1] ^ _Right._Word[1]};
+    _NODISCARD_FRIEND constexpr _Signed128 operator^(const _Signed128& _Left, const _Signed128& _Right) noexcept {
+        return _Signed128{_Left._Word[0] ^ _Right._Word[0], _Left._Word[1] ^ _Right._Word[1]};
     }
 
-    constexpr _Int128& operator^=(const _Base128& _That) noexcept {
+    constexpr _Signed128& operator^=(const _Base128& _That) noexcept {
         _Word[0] ^= _That._Word[0];
         _Word[1] ^= _That._Word[1];
         return *this;
     }
 
-    _NODISCARD_FRIEND constexpr _Int128 operator|(const _Int128& _Left, const _Int128& _Right) noexcept {
-        return _Int128{_Left._Word[0] | _Right._Word[0], _Left._Word[1] | _Right._Word[1]};
+    _NODISCARD_FRIEND constexpr _Signed128 operator|(const _Signed128& _Left, const _Signed128& _Right) noexcept {
+        return _Signed128{_Left._Word[0] | _Right._Word[0], _Left._Word[1] | _Right._Word[1]};
     }
 
-    constexpr _Int128& operator|=(const _Base128& _That) noexcept {
+    constexpr _Signed128& operator|=(const _Base128& _That) noexcept {
         _Word[0] |= _That._Word[0];
         _Word[1] |= _That._Word[1];
         return *this;
@@ -1267,41 +1269,41 @@ struct _Int128 : _Base128 {
 template <class>
 class numeric_limits;
 template <>
-class numeric_limits<_Int128> : public _Num_int_base {
+class numeric_limits<_Signed128> : public _Num_int_base {
 public:
-    _NODISCARD static constexpr _Int128(min)() noexcept {
-        return _Int128{0ull, 1ull << 63};
+    _NODISCARD static constexpr _Signed128(min)() noexcept {
+        return _Signed128{0ull, 1ull << 63};
     }
 
-    _NODISCARD static constexpr _Int128(max)() noexcept {
-        return _Int128{~0ull, ~0ull >> 1};
+    _NODISCARD static constexpr _Signed128(max)() noexcept {
+        return _Signed128{~0ull, ~0ull >> 1};
     }
 
-    _NODISCARD static constexpr _Int128 lowest() noexcept {
+    _NODISCARD static constexpr _Signed128 lowest() noexcept {
         return (min) ();
     }
 
-    _NODISCARD static constexpr _Int128 epsilon() noexcept {
+    _NODISCARD static constexpr _Signed128 epsilon() noexcept {
         return 0;
     }
 
-    _NODISCARD static constexpr _Int128 round_error() noexcept {
+    _NODISCARD static constexpr _Signed128 round_error() noexcept {
         return 0;
     }
 
-    _NODISCARD static constexpr _Int128 denorm_min() noexcept {
+    _NODISCARD static constexpr _Signed128 denorm_min() noexcept {
         return 0;
     }
 
-    _NODISCARD static constexpr _Int128 infinity() noexcept {
+    _NODISCARD static constexpr _Signed128 infinity() noexcept {
         return 0;
     }
 
-    _NODISCARD static constexpr _Int128 quiet_NaN() noexcept {
+    _NODISCARD static constexpr _Signed128 quiet_NaN() noexcept {
         return 0;
     }
 
-    _NODISCARD static constexpr _Int128 signaling_NaN() noexcept {
+    _NODISCARD static constexpr _Signed128 signaling_NaN() noexcept {
         return 0;
     }
 
@@ -1310,21 +1312,21 @@ public:
 };
 
 template <integral _Ty>
-struct common_type<_Ty, _Int128> {
-    using type = _Int128;
+struct common_type<_Ty, _Signed128> {
+    using type = _Signed128;
 };
 template <integral _Ty>
-struct common_type<_Int128, _Ty> {
-    using type = _Int128;
+struct common_type<_Signed128, _Ty> {
+    using type = _Signed128;
 };
 
 template <>
-struct common_type<_Int128, _Uint128> {
-    using type = _Uint128;
+struct common_type<_Signed128, _Unsigned128> {
+    using type = _Unsigned128;
 };
 template <>
-struct common_type<_Uint128, _Int128> {
-    using type = _Uint128;
+struct common_type<_Unsigned128, _Signed128> {
+    using type = _Unsigned128;
 };
 
 #undef _STL_128_INTRINSICS

--- a/stl/inc/__msvc_int128.hpp
+++ b/stl/inc/__msvc_int128.hpp
@@ -41,17 +41,12 @@ _STD_BEGIN
 #define _STL_128_DIV_INTRINSICS 0
 #endif // defined(_M_X64) && !defined(_M_ARM64EC)
 
-struct _Int128;
-
 struct
 #ifndef _M_ARM
     alignas(16)
 #endif
-        _Uint128 {
+        _Uint128_base {
     uint64_t _Word[2];
-
-    using _Signed_type   = _Int128;
-    using _Unsigned_type = _Uint128;
 
     constexpr void _Left_shift(const unsigned char _Count) noexcept {
         _STL_INTERNAL_CHECK(_Count < 128);
@@ -278,10 +273,10 @@ struct
         return (static_cast<uint64_t>(__q[1]) << 32) | __q[0];
     }
 
-    constexpr _Uint128() noexcept : _Word{} {}
+    constexpr _Uint128_base() noexcept : _Word{} {}
 
     template <integral _Ty>
-    constexpr _Uint128(const _Ty _Val) noexcept : _Word{static_cast<uint64_t>(_Val)} {
+    constexpr _Uint128_base(const _Ty _Val) noexcept : _Word{static_cast<uint64_t>(_Val)} {
         if constexpr (signed_integral<_Ty>) {
             if (_Val < 0) {
                 _Word[1] = ~0ull;
@@ -289,7 +284,7 @@ struct
         }
     }
 
-    constexpr explicit _Uint128(const uint64_t _Low, const uint64_t _High) noexcept : _Word{_Low, _High} {}
+    constexpr explicit _Uint128_base(const uint64_t _Low, const uint64_t _High) noexcept : _Word{_Low, _High} {}
 
     template <integral _Ty>
     _NODISCARD constexpr explicit operator _Ty() const noexcept {
@@ -300,141 +295,84 @@ struct
         return (_Word[0] | _Word[1]) != 0;
     }
 
-    _NODISCARD_FRIEND constexpr bool operator==(const _Uint128&, const _Uint128&) noexcept = default;
+    _NODISCARD_FRIEND constexpr bool operator==(const _Uint128_base&, const _Uint128_base&) noexcept = default;
 
-    _NODISCARD_FRIEND constexpr strong_ordering operator<=>(const _Uint128& _Left, const _Uint128& _Right) noexcept {
-        strong_ordering _Ord = _Left._Word[1] <=> _Right._Word[1];
-        if (_Ord == strong_ordering::equal) {
-            _Ord = _Left._Word[0] <=> _Right._Word[0];
+    _NODISCARD_FRIEND constexpr bool operator<(const _Uint128_base& _Left, const _Uint128_base& _Right) noexcept {
+        if (_Left._Word[1] < _Right._Word[1]) {
+            return true;
         }
-        return _Ord;
+        if (_Left._Word[1] > _Right._Word[1]) {
+            return false;
+        }
+        return _Left._Word[0] < _Right._Word[0];
+    }
+    _NODISCARD_FRIEND constexpr bool operator>(const _Uint128_base& _Left, const _Uint128_base& _Right) noexcept {
+        return _Right < _Left;
+    }
+    _NODISCARD_FRIEND constexpr bool operator<=(const _Uint128_base& _Left, const _Uint128_base& _Right) noexcept {
+        return !(_Right < _Left);
+    }
+    _NODISCARD_FRIEND constexpr bool operator>=(const _Uint128_base& _Left, const _Uint128_base& _Right) noexcept {
+        return !(_Left < _Right);
     }
 
-    _NODISCARD_FRIEND constexpr _Uint128 operator<<(const _Uint128& _Left, const _Uint128& _Right) noexcept {
-        auto _Tmp{_Left};
-        _Tmp._Left_shift(static_cast<unsigned char>(_Right._Word[0]));
-        return _Tmp;
-    }
-
-    constexpr _Uint128& operator<<=(const _Uint128& _Count) noexcept {
-        _Left_shift(static_cast<unsigned char>(_Count._Word[0]));
+    constexpr _Uint128_base& operator<<=(const integral auto _Count) noexcept {
+        _Left_shift(static_cast<unsigned char>(_Count));
         return *this;
     }
+    constexpr _Uint128_base& operator>>=(const integral auto _Count) noexcept {
+        _Right_shift(static_cast<unsigned char>(_Count));
+        return *this;
+    }
+
     template <integral _Ty>
-    friend constexpr _Ty& operator<<=(_Ty& _Left, const _Uint128& _Right) noexcept {
+    friend constexpr _Ty& operator<<=(_Ty& _Left, const _Uint128_base& _Right) noexcept {
         _Left <<= _Right._Word[0];
         return _Left;
     }
 
-    _NODISCARD_FRIEND constexpr _Uint128 operator>>(const _Uint128& _Left, const _Uint128& _Right) noexcept {
-        auto _Tmp{_Left};
-        _Tmp._Right_shift(static_cast<unsigned char>(_Right._Word[0]));
-        return _Tmp;
-    }
-
-    constexpr _Uint128& operator>>=(const _Uint128& _Count) noexcept {
-        _Right_shift(static_cast<unsigned char>(_Count._Word[0]));
-        return *this;
-    }
     template <integral _Ty>
-    friend constexpr _Ty& operator>>=(_Ty& _Left, const _Uint128& _Right) noexcept {
+    friend constexpr _Ty& operator>>=(_Ty& _Left, const _Uint128_base& _Right) noexcept {
         _Left >>= _Right._Word[0];
         return _Left;
     }
 
-    constexpr _Uint128& operator++() noexcept {
+    constexpr _Uint128_base& operator++() noexcept {
         if (++_Word[0] == 0) {
             ++_Word[1];
         }
         return *this;
     }
-    constexpr _Uint128 operator++(int) noexcept {
+    constexpr _Uint128_base operator++(int) noexcept {
         auto _Tmp = *this;
         ++*this;
         return _Tmp;
     }
 
-    constexpr _Uint128& operator--() noexcept {
+    constexpr _Uint128_base& operator--() noexcept {
         if (_Word[0]-- == 0) {
             --_Word[1];
         }
         return *this;
     }
-    constexpr _Uint128 operator--(int) noexcept {
+    constexpr _Uint128_base operator--(int) noexcept {
         auto _Tmp = *this;
         --*this;
         return _Tmp;
     }
 
-    _NODISCARD constexpr _Uint128 operator+() const noexcept {
-        return *this;
-    }
-
-    _NODISCARD constexpr _Uint128 operator-() const noexcept {
-        return _Uint128{} - *this;
-    }
-
-    _NODISCARD constexpr _Uint128 operator~() const noexcept {
-        return _Uint128{~_Word[0], ~_Word[1]};
-    }
-
-    _NODISCARD_FRIEND constexpr _Uint128 operator+(const _Uint128& _Left, const _Uint128& _Right) noexcept {
-        _Uint128 _Result;
-        const auto _Carry = _AddCarry64(0, _Left._Word[0], _Right._Word[0], _Result._Word[0]);
-        _AddCarry64(_Carry, _Left._Word[1], _Right._Word[1], _Result._Word[1]);
-        return _Result;
-    }
-
-    constexpr _Uint128& operator+=(const _Uint128& _That) noexcept {
-        const auto _Carry = _AddCarry64(0, _Word[0], _That._Word[0], _Word[0]);
-        _AddCarry64(_Carry, _Word[1], _That._Word[1], _Word[1]);
-        return *this;
-    }
-    template <integral _Ty>
-    friend constexpr _Ty& operator+=(_Ty& _Left, const _Uint128& _Right) noexcept {
-        _Left += _Right._Word[0];
-        return _Left;
-    }
-
-    _NODISCARD_FRIEND constexpr _Uint128 operator-(const _Uint128& _Left, const _Uint128& _Right) noexcept {
-        _Uint128 _Result;
-        const auto _Borrow = _SubBorrow64(0, _Left._Word[0], _Right._Word[0], _Result._Word[0]);
-        _SubBorrow64(_Borrow, _Left._Word[1], _Right._Word[1], _Result._Word[1]);
-        return _Result;
-    }
-
-    constexpr _Uint128& operator-=(const _Uint128& _That) noexcept {
-        const auto _Borrow = _SubBorrow64(0, _Word[0], _That._Word[0], _Word[0]);
-        _SubBorrow64(_Borrow, _Word[1], _That._Word[1], _Word[1]);
-        return *this;
-    }
-    template <integral _Ty>
-    friend constexpr _Ty& operator-=(_Ty& _Left, const _Uint128& _Right) noexcept {
-        _Left -= _Right._Word[0];
-        return _Left;
-    }
-
-    _NODISCARD_FRIEND constexpr _Uint128 operator*(const _Uint128& _Left, const _Uint128& _Right) noexcept {
-        _Uint128 _Result;
+    _NODISCARD static constexpr _Uint128_base _Multiply(
+        const _Uint128_base& _Left, const _Uint128_base& _Right) noexcept {
+        _Uint128_base _Result;
         _Result._Word[0] = _UMul128(_Left._Word[0], _Right._Word[0], _Result._Word[1]);
         _Result._Word[1] += _Left._Word[0] * _Right._Word[1];
         _Result._Word[1] += _Left._Word[1] * _Right._Word[0];
         return _Result;
     }
 
-    constexpr _Uint128& operator*=(const _Uint128& _That) noexcept {
-        *this = *this * _That;
-        return *this;
-    }
-    template <integral _Ty>
-    friend constexpr _Ty& operator*=(_Ty& _Left, const _Uint128& _Right) noexcept {
-        _Left *= _Right._Word[0];
-        return _Left;
-    }
-
 #if !_STL_128_DIV_INTRINSICS
-    _NODISCARD_FRIEND constexpr _Uint128 operator/(const _Uint128& _Num, const uint32_t _Den) noexcept {
-        _Uint128 _Result;
+    _NODISCARD static constexpr _Uint128_base _Divide(const _Uint128_base& _Num, const uint32_t _Den) noexcept {
+        _Uint128_base _Result;
         _Result._Word[1] = _Num._Word[1] / _Den;
         uint64_t _Rem    = ((_Num._Word[1] % _Den) << 32) | (_Num._Word[0] >> 32);
         _Result._Word[0] = (_Rem / _Den) << 32;
@@ -443,24 +381,22 @@ struct
         return _Result;
     }
 #endif // !_STL_128_DIV_INTRINSICS
-
-    _NODISCARD_FRIEND constexpr _Uint128 operator/(const _Uint128& _Num, const uint64_t _Den) noexcept {
-        _Uint128 _Result;
+    _NODISCARD static constexpr _Uint128_base _Divide(const _Uint128_base& _Num, const uint64_t _Den) noexcept {
+        _Uint128_base _Result;
         _Result._Word[1] = _Num._Word[1] / _Den;
         uint64_t _Rem    = _Num._Word[1] % _Den;
         _Result._Word[0] = _UDiv128(_Rem, _Num._Word[0], _Den, _Rem);
         return _Result;
     }
-
-    _NODISCARD_FRIEND constexpr _Uint128 operator/(_Uint128 _Num, _Uint128 _Den) noexcept {
+    _NODISCARD static constexpr _Uint128_base _Divide(_Uint128_base _Num, _Uint128_base _Den) noexcept {
         // establish _Den < _Num and _Num._Word[1] > 0
         if (_Den._Word[1] >= _Num._Word[1]) {
             if (_Den._Word[1] > _Num._Word[1]) {
-                return _Uint128{};
+                return {};
             }
 
             if (_Den._Word[1] == _Num._Word[1]) {
-                return _Uint128{_Num._Word[1] == 0 ? _Num._Word[0] / _Den._Word[0] : _Num._Word[0] >= _Den._Word[0]};
+                return {_Num._Word[1] == 0 ? _Num._Word[0] / _Den._Word[0] : _Num._Word[0] >= _Den._Word[0]};
             }
         }
 
@@ -468,11 +404,11 @@ struct
         if (_Den._Word[1] == 0) {
 #if !_STL_128_DIV_INTRINSICS
             if (_Den._Word[0] < (1ull << 32)) {
-                return operator/(_Num, static_cast<uint32_t>(_Den._Word[0]));
+                return _Divide(_Num, static_cast<uint32_t>(_Den._Word[0]));
             } else
 #endif // !_STL_128_DIV_INTRINSICS
             {
-                return operator/(_Num, _Den._Word[0]);
+                return _Divide(_Num, _Den._Word[0]);
             }
         }
 
@@ -486,7 +422,7 @@ struct
         auto _High_digit = __d == 0 ? 0 : _Num._Word[1] >> (64 - __d); // This creates a third digit for _Num
         _Num <<= __d;
 
-        _Uint128 __qhat;
+        _Uint128_base __qhat;
         __qhat._Word[1] = _High_digit >= _Den._Word[1];
         uint64_t __rhat;
         __qhat._Word[0] = _UDiv128(_High_digit >= _Den._Word[1] ? _High_digit - _Den._Word[1] : _High_digit,
@@ -496,9 +432,9 @@ struct
             if (__qhat._Word[1] > 0) {
                 --__qhat;
             } else {
-                _Uint128 _Prod;
+                _Uint128_base _Prod;
                 _Prod._Word[0] = _UMul128(__qhat._Word[0], _Den._Word[0], _Prod._Word[1]);
-                if (_Prod <= _Uint128{_Num._Word[0], __rhat}) {
+                if (_Prod <= _Uint128_base{_Num._Word[0], __rhat}) {
                     break;
                 }
                 --__qhat._Word[0];
@@ -558,48 +494,24 @@ struct
             __q[1] = 0;
         }
 
-        return _Uint128{static_cast<uint64_t>(__q[1]) << 32 | __q[0]};
+        return {static_cast<uint64_t>(__q[1]) << 32 | __q[0]};
 #endif // _STL_128_INTRINSICS
     }
 
 #if !_STL_128_DIV_INTRINSICS
-    constexpr _Uint128& operator/=(const uint32_t _That) noexcept {
-        *this = *this / _That;
-        return *this;
-    }
-#endif // !_STL_128_DIV_INTRINSICS
-    constexpr _Uint128& operator/=(const uint64_t _That) noexcept {
-        *this = *this / _That;
-        return *this;
-    }
-    constexpr _Uint128& operator/=(const _Uint128& _That) noexcept {
-        *this = *this / _That;
-        return *this;
-    }
-    template <integral _Ty>
-    friend constexpr _Ty& operator/=(_Ty& _Left, const _Uint128& _Right) noexcept {
-        if (_Right._Word[1] != 0) {
-            _Left = 0;
-        } else {
-            _Left /= _Right._Word[0];
-        }
-        return _Left;
-    }
-
-#if !_STL_128_DIV_INTRINSICS
-    _NODISCARD_FRIEND constexpr _Uint128 operator%(const _Uint128& _Num, const uint32_t _Den) noexcept {
+    _NODISCARD static constexpr _Uint128_base _Modulo(const _Uint128_base& _Num, const uint32_t _Den) noexcept {
         uint64_t _Rem = _Num._Word[1];
         _Rem          = ((_Rem % _Den) << 32) | (_Num._Word[0] >> 32);
         _Rem          = ((_Rem % _Den) << 32) | static_cast<uint32_t>(_Num._Word[0]);
-        return _Uint128{_Rem % _Den};
+        return _Uint128_base{_Rem % _Den};
     }
 #endif // !_STL_128_DIV_INTRINSICS
-    _NODISCARD_FRIEND constexpr _Uint128 operator%(const _Uint128& _Num, const uint64_t _Den) noexcept {
+    _NODISCARD static constexpr _Uint128_base _Modulo(const _Uint128_base& _Num, const uint64_t _Den) noexcept {
         uint64_t _Rem;
         (void) _UDiv128(_Num._Word[1] % _Den, _Num._Word[0], _Den, _Rem);
-        return _Uint128{_Rem};
+        return _Uint128_base{_Rem};
     }
-    _NODISCARD_FRIEND constexpr _Uint128 operator%(_Uint128 _Num, _Uint128 _Den) noexcept {
+    _NODISCARD static constexpr _Uint128_base _Modulo(_Uint128_base _Num, _Uint128_base _Den) noexcept {
         // establish _Den < _Num and _Num._Word[1] > 0
         if (_Den._Word[1] >= _Num._Word[1]) {
             if (_Den._Word[1] > _Num._Word[1]) {
@@ -608,7 +520,8 @@ struct
 
             if (_Den._Word[1] == _Num._Word[1]) {
                 if (_Den._Word[0] <= _Num._Word[0]) {
-                    return _Uint128{_Num._Word[1] == 0 ? _Num._Word[0] % _Den._Word[0] : _Num._Word[0] - _Den._Word[0]};
+                    return _Uint128_base{
+                        _Num._Word[1] == 0 ? _Num._Word[0] % _Den._Word[0] : _Num._Word[0] - _Den._Word[0]};
                 }
 
                 return _Num;
@@ -619,11 +532,11 @@ struct
         if (_Den._Word[1] == 0) {
 #if !_STL_128_DIV_INTRINSICS
             if (_Den._Word[0] < (1ull << 32)) {
-                return operator%(_Num, static_cast<uint32_t>(_Den._Word[0]));
+                return _Modulo(_Num, static_cast<uint32_t>(_Den._Word[0]));
             } else
 #endif // !_STL_128_DIV_INTRINSICS
             {
-                return operator%(_Num, _Den._Word[0]);
+                return _Modulo(_Num, _Den._Word[0]);
             }
         }
 
@@ -648,9 +561,9 @@ struct
                     --__qhat_high;
                 }
             } else {
-                _Uint128 _Prod;
+                _Uint128_base _Prod;
                 _Prod._Word[0] = _UMul128(__qhat, _Den._Word[0], _Prod._Word[1]);
-                if (_Prod <= _Uint128{_Num._Word[0], __rhat}) {
+                if (_Prod <= _Uint128_base{_Num._Word[0], __rhat}) {
                     break;
                 }
                 --__qhat;
@@ -719,6 +632,198 @@ struct
         return _Num;
     }
 
+    template <integral _Ty>
+    friend constexpr _Ty& operator&=(_Ty& _Left, const _Uint128_base& _Right) noexcept {
+        _Left &= _Right._Word[0];
+        return _Left;
+    }
+
+    template <integral _Ty>
+    friend constexpr _Ty& operator^=(_Ty& _Left, const _Uint128_base& _Right) noexcept {
+        _Left ^= _Right._Word[0];
+        return _Left;
+    }
+
+    template <integral _Ty>
+    friend constexpr _Ty& operator|=(_Ty& _Left, const _Uint128_base& _Right) noexcept {
+        _Left |= _Right._Word[0];
+        return _Left;
+    }
+};
+
+struct _Int128;
+
+struct _Uint128 : _Uint128_base {
+    using _Signed_type   = _Int128;
+    using _Unsigned_type = _Uint128;
+
+    using _Uint128_base::_Uint128_base;
+    constexpr explicit _Uint128(const _Uint128_base& _That) noexcept : _Uint128_base{_That} {}
+
+    _NODISCARD_FRIEND constexpr strong_ordering operator<=>(const _Uint128& _Left, const _Uint128& _Right) noexcept {
+        strong_ordering _Ord = _Left._Word[1] <=> _Right._Word[1];
+        if (_Ord == strong_ordering::equal) {
+            _Ord = _Left._Word[0] <=> _Right._Word[0];
+        }
+        return _Ord;
+    }
+
+    _NODISCARD_FRIEND constexpr _Uint128 operator<<(const _Uint128& _Left, const _Uint128_base& _Right) noexcept {
+        auto _Tmp{_Left};
+        _Tmp._Left_shift(static_cast<unsigned char>(_Right._Word[0]));
+        return _Tmp;
+    }
+
+    constexpr _Uint128& operator<<=(const _Uint128_base& _Count) noexcept {
+        _Left_shift(static_cast<unsigned char>(_Count._Word[0]));
+        return *this;
+    }
+
+    _NODISCARD_FRIEND constexpr _Uint128 operator>>(const _Uint128& _Left, const _Uint128_base& _Right) noexcept {
+        auto _Tmp{_Left};
+        _Tmp._Right_shift(static_cast<unsigned char>(_Right._Word[0]));
+        return _Tmp;
+    }
+
+    constexpr _Uint128& operator>>=(const _Uint128_base& _Count) noexcept {
+        _Right_shift(static_cast<unsigned char>(_Count._Word[0]));
+        return *this;
+    }
+
+    constexpr _Uint128& operator++() noexcept {
+        if (++_Word[0] == 0) {
+            ++_Word[1];
+        }
+        return *this;
+    }
+    constexpr _Uint128 operator++(int) noexcept {
+        auto _Tmp = *this;
+        ++*this;
+        return _Tmp;
+    }
+
+    constexpr _Uint128& operator--() noexcept {
+        if (_Word[0]-- == 0) {
+            --_Word[1];
+        }
+        return *this;
+    }
+    constexpr _Uint128 operator--(int) noexcept {
+        auto _Tmp = *this;
+        --*this;
+        return _Tmp;
+    }
+
+    _NODISCARD constexpr _Uint128 operator+() const noexcept {
+        return *this;
+    }
+
+    _NODISCARD constexpr _Uint128 operator-() const noexcept {
+        return _Uint128{} - *this;
+    }
+
+    _NODISCARD constexpr _Uint128 operator~() const noexcept {
+        return _Uint128{~_Word[0], ~_Word[1]};
+    }
+
+    _NODISCARD_FRIEND constexpr _Uint128 operator+(const _Uint128_base& _Left, const _Uint128_base& _Right) noexcept {
+        _Uint128 _Result;
+        const auto _Carry = _AddCarry64(0, _Left._Word[0], _Right._Word[0], _Result._Word[0]);
+        _AddCarry64(_Carry, _Left._Word[1], _Right._Word[1], _Result._Word[1]);
+        return _Result;
+    }
+
+    constexpr _Uint128& operator+=(const _Uint128_base& _That) noexcept {
+        const auto _Carry = _AddCarry64(0, _Word[0], _That._Word[0], _Word[0]);
+        _AddCarry64(_Carry, _Word[1], _That._Word[1], _Word[1]);
+        return *this;
+    }
+    template <integral _Ty>
+    friend constexpr _Ty& operator+=(_Ty& _Left, const _Uint128_base& _Right) noexcept {
+        _Left += _Right._Word[0];
+        return _Left;
+    }
+
+    _NODISCARD_FRIEND constexpr _Uint128 operator-(const _Uint128_base& _Left, const _Uint128_base& _Right) noexcept {
+        _Uint128 _Result;
+        const auto _Borrow = _SubBorrow64(0, _Left._Word[0], _Right._Word[0], _Result._Word[0]);
+        _SubBorrow64(_Borrow, _Left._Word[1], _Right._Word[1], _Result._Word[1]);
+        return _Result;
+    }
+
+    constexpr _Uint128& operator-=(const _Uint128_base& _That) noexcept {
+        const auto _Borrow = _SubBorrow64(0, _Word[0], _That._Word[0], _Word[0]);
+        _SubBorrow64(_Borrow, _Word[1], _That._Word[1], _Word[1]);
+        return *this;
+    }
+    template <integral _Ty>
+    friend constexpr _Ty& operator-=(_Ty& _Left, const _Uint128& _Right) noexcept {
+        _Left -= _Right._Word[0];
+        return _Left;
+    }
+
+    _NODISCARD_FRIEND constexpr _Uint128 operator*(const _Uint128_base& _Left, const _Uint128_base& _Right) noexcept {
+        return _Uint128{_Uint128_base::_Multiply(_Left, _Right)};
+    }
+
+    constexpr _Uint128& operator*=(const _Uint128_base& _That) noexcept {
+        *this = *this * _That;
+        return *this;
+    }
+    template <integral _Ty>
+    friend constexpr _Ty& operator*=(_Ty& _Left, const _Uint128& _Right) noexcept {
+        _Left *= _Right._Word[0];
+        return _Left;
+    }
+
+#if !_STL_128_DIV_INTRINSICS
+    _NODISCARD_FRIEND constexpr _Uint128 operator/(const _Uint128& _Num, const uint32_t _Den) noexcept {
+        return _Uint128{_Uint128_base::_Divide(_Num, _Den)};
+    }
+#endif // !_STL_128_DIV_INTRINSICS
+    _NODISCARD_FRIEND constexpr _Uint128 operator/(const _Uint128& _Num, const uint64_t _Den) noexcept {
+        return _Uint128{_Uint128_base::_Divide(_Num, _Den)};
+    }
+    _NODISCARD_FRIEND constexpr _Uint128 operator/(const _Uint128_base& _Num, const _Uint128_base& _Den) noexcept {
+        return _Uint128{_Uint128_base::_Divide(_Num, _Den)};
+    }
+
+#if !_STL_128_DIV_INTRINSICS
+    constexpr _Uint128& operator/=(const uint32_t _That) noexcept {
+        *this = *this / _That;
+        return *this;
+    }
+#endif // !_STL_128_DIV_INTRINSICS
+    constexpr _Uint128& operator/=(const uint64_t _That) noexcept {
+        *this = *this / _That;
+        return *this;
+    }
+    constexpr _Uint128& operator/=(const _Uint128_base& _That) noexcept {
+        *this = *this / _That;
+        return *this;
+    }
+    template <integral _Ty>
+    friend constexpr _Ty& operator/=(_Ty& _Left, const _Uint128& _Right) noexcept {
+        if (_Right._Word[1] != 0) {
+            _Left = 0;
+        } else {
+            _Left /= _Right._Word[0];
+        }
+        return _Left;
+    }
+
+#if !_STL_128_DIV_INTRINSICS
+    _NODISCARD_FRIEND constexpr _Uint128 operator%(const _Uint128_base& _Num, const uint32_t _Den) noexcept {
+        return _Uint128{_Uint128_base::_Modulo(_Num, _Den)};
+    }
+#endif // !_STL_128_DIV_INTRINSICS
+    _NODISCARD_FRIEND constexpr _Uint128 operator%(const _Uint128_base& _Num, const uint64_t _Den) noexcept {
+        return _Uint128{_Uint128_base::_Modulo(_Num, _Den)};
+    }
+    _NODISCARD_FRIEND constexpr _Uint128 operator%(const _Uint128_base& _Num, const _Uint128_base& _Den) noexcept {
+        return _Uint128{_Uint128_base::_Modulo(_Num, _Den)};
+    }
+
     constexpr _Uint128& operator%=(const uint32_t _Den) noexcept {
         *this = *this % _Den;
         return *this;
@@ -727,7 +832,7 @@ struct
         *this = *this % _Den;
         return *this;
     }
-    constexpr _Uint128& operator%=(const _Uint128& _Den) noexcept {
+    constexpr _Uint128& operator%=(const _Uint128_base& _Den) noexcept {
         *this = *this % _Den;
         return *this;
     }
@@ -739,49 +844,34 @@ struct
         return _Left;
     }
 
-    _NODISCARD_FRIEND constexpr _Uint128 operator&(const _Uint128& _Left, const _Uint128& _Right) noexcept {
+    _NODISCARD_FRIEND constexpr _Uint128 operator&(const _Uint128_base& _Left, const _Uint128_base& _Right) noexcept {
         return _Uint128{_Left._Word[0] & _Right._Word[0], _Left._Word[1] & _Right._Word[1]};
     }
 
-    constexpr _Uint128& operator&=(const _Uint128& _That) noexcept {
+    constexpr _Uint128& operator&=(const _Uint128_base& _That) noexcept {
         _Word[0] &= _That._Word[0];
         _Word[1] &= _That._Word[1];
         return *this;
     }
-    template <integral _Ty>
-    friend constexpr _Ty& operator&=(_Ty& _Left, const _Uint128& _Right) noexcept {
-        _Left &= _Right._Word[0];
-        return _Left;
-    }
 
-    _NODISCARD_FRIEND constexpr _Uint128 operator^(const _Uint128& _Left, const _Uint128& _Right) noexcept {
+    _NODISCARD_FRIEND constexpr _Uint128 operator^(const _Uint128_base& _Left, const _Uint128_base& _Right) noexcept {
         return _Uint128{_Left._Word[0] ^ _Right._Word[0], _Left._Word[1] ^ _Right._Word[1]};
     }
 
-    constexpr _Uint128& operator^=(const _Uint128& _That) noexcept {
+    constexpr _Uint128& operator^=(const _Uint128_base& _That) noexcept {
         _Word[0] ^= _That._Word[0];
         _Word[1] ^= _That._Word[1];
         return *this;
     }
-    template <integral _Ty>
-    friend constexpr _Ty& operator^=(_Ty& _Left, const _Uint128& _Right) noexcept {
-        _Left ^= _Right._Word[0];
-        return _Left;
-    }
 
-    _NODISCARD_FRIEND constexpr _Uint128 operator|(const _Uint128& _Left, const _Uint128& _Right) noexcept {
+    _NODISCARD_FRIEND constexpr _Uint128 operator|(const _Uint128_base& _Left, const _Uint128_base& _Right) noexcept {
         return _Uint128{_Left._Word[0] | _Right._Word[0], _Left._Word[1] | _Right._Word[1]};
     }
 
-    constexpr _Uint128& operator|=(const _Uint128& _That) noexcept {
+    constexpr _Uint128& operator|=(const _Uint128_base& _That) noexcept {
         _Word[0] |= _That._Word[0];
         _Word[1] |= _That._Word[1];
         return *this;
-    }
-    template <integral _Ty>
-    friend constexpr _Ty& operator|=(_Ty& _Left, const _Uint128& _Right) noexcept {
-        _Left |= _Right._Word[0];
-        return _Left;
     }
 };
 
@@ -842,40 +932,12 @@ struct common_type<_Uint128, _Ty> {
     using type = _Uint128;
 };
 
-struct _Int128 : _Uint128 {
+struct _Int128 : _Uint128_base {
     using _Signed_type   = _Int128;
     using _Unsigned_type = _Uint128;
 
-    constexpr void _Strip_negative(bool& _Flip) noexcept {
-        if ((_Word[1] & (1ull << 63)) != 0) {
-            *this = -*this;
-            _Flip = !_Flip;
-        }
-    }
-
-    constexpr void _Right_shift(const unsigned char _Count) noexcept {
-        if (_Count >= 64) {
-            _Word[0] = static_cast<uint64_t>(static_cast<int64_t>(_Word[1]) >> (_Count % 64));
-            _Word[1] = (_Word[1] & (1ull << 63)) == 0 ? 0 : ~0ull;
-            return;
-        }
-
-        if (_Count != 0) {
-#if _STL_128_INTRINSICS
-            if (!_STD is_constant_evaluated()) {
-                _Word[0] = __shiftright128(_Word[0], _Word[1], _Count);
-            } else
-#endif // _STL_128_INTRINSICS
-            {
-                _Word[0] = (_Word[0] >> _Count) | (_Word[1] << (64 - _Count));
-            }
-
-            _Word[1] = static_cast<uint64_t>(static_cast<int64_t>(_Word[1]) >> _Count);
-        }
-    }
-
-    using _Uint128::_Uint128;
-    constexpr explicit _Int128(const _Uint128& _That) noexcept : _Uint128{_That} {}
+    using _Uint128_base::_Uint128_base;
+    constexpr explicit _Int128(const _Uint128_base& _That) noexcept : _Uint128_base{_That} {}
 
     _NODISCARD_FRIEND constexpr strong_ordering operator<=>(const _Int128& _Left, const _Int128& _Right) noexcept {
         strong_ordering _Ord = static_cast<int64_t>(_Left._Word[1]) <=> static_cast<int64_t>(_Right._Word[1]);
@@ -885,40 +947,55 @@ struct _Int128 : _Uint128 {
         return _Ord;
     }
 
-    _NODISCARD_FRIEND constexpr _Int128 operator<<(const _Int128& _Left, const _Uint128& _Right) noexcept {
+    _NODISCARD_FRIEND constexpr _Int128 operator<<(const _Int128& _Left, const _Uint128_base& _Right) noexcept {
         auto _Tmp{_Left};
         _Tmp._Left_shift(static_cast<unsigned char>(_Right._Word[0]));
         return _Tmp;
     }
 
-    constexpr _Int128& operator<<=(const _Uint128& _Count) noexcept {
+    constexpr _Int128& operator<<=(const _Uint128_base& _Count) noexcept {
         _Left_shift(static_cast<unsigned char>(_Count._Word[0]));
         return *this;
     }
-    template <integral _Ty>
-    friend constexpr _Ty& operator<<=(_Ty& _Left, const _Int128& _Right) noexcept {
-        _Left = static_cast<_Ty>(_Int128{_Left} << _Right);
-        return _Left;
+
+    constexpr void _Right_shift(const unsigned char _Count) noexcept {
+        if (_Count == 0) {
+            return;
+        }
+
+        if (_Count >= 64) {
+            _Word[0] = static_cast<uint64_t>(static_cast<int64_t>(_Word[1]) >> (_Count % 64));
+            _Word[1] = (_Word[1] & (1ull << 63)) == 0 ? 0 : ~0ull;
+            return;
+        }
+
+#if _STL_128_INTRINSICS
+        if (!_STD is_constant_evaluated()) {
+            _Word[0] = __shiftright128(_Word[0], _Word[1], _Count);
+        } else
+#endif // _STL_128_INTRINSICS
+        {
+            _Word[0] = (_Word[0] >> _Count) | (_Word[1] << (64 - _Count));
+        }
+
+        _Word[1] = static_cast<uint64_t>(static_cast<int64_t>(_Word[1]) >> _Count);
     }
 
-    _NODISCARD_FRIEND constexpr _Int128 operator>>(const _Int128& _Left, const _Uint128& _Right) noexcept {
+    _NODISCARD_FRIEND constexpr _Int128 operator>>(const _Int128& _Left, const _Uint128_base& _Right) noexcept {
         auto _Tmp{_Left};
         _Tmp._Right_shift(static_cast<unsigned char>(_Right._Word[0]));
         return _Tmp;
     }
 
-    constexpr _Int128& operator>>=(const _Uint128& _Count) noexcept {
+    constexpr _Int128& operator>>=(const _Uint128_base& _Count) noexcept {
         _Right_shift(static_cast<unsigned char>(_Count._Word[0]));
         return *this;
     }
-    template <integral _Ty>
-    friend constexpr _Ty& operator>>=(_Ty& _Left, const _Int128& _Right) noexcept {
-        _Left = static_cast<_Ty>(_Int128{_Left} >> _Right);
-        return _Left;
-    }
 
     constexpr _Int128& operator++() noexcept {
-        _Uint128::operator++();
+        if (++_Word[0] == 0) {
+            ++_Word[1];
+        }
         return *this;
     }
     constexpr _Int128 operator++(int) noexcept {
@@ -928,7 +1005,9 @@ struct _Int128 : _Uint128 {
     }
 
     constexpr _Int128& operator--() noexcept {
-        _Uint128::operator--();
+        if (_Word[0]-- == 0) {
+            --_Word[1];
+        }
         return *this;
     }
     constexpr _Int128 operator--(int) noexcept {
@@ -942,7 +1021,7 @@ struct _Int128 : _Uint128 {
     }
 
     _NODISCARD constexpr _Int128 operator-() const noexcept {
-        return _Int128{_Uint128::operator-()};
+        return _Int128{} - *this;
     }
 
     _NODISCARD constexpr _Int128 operator~() const noexcept {
@@ -950,10 +1029,15 @@ struct _Int128 : _Uint128 {
     }
 
     _NODISCARD_FRIEND constexpr _Int128 operator+(const _Int128& _Left, const _Int128& _Right) noexcept {
-        return _Int128{static_cast<const _Uint128&>(_Left) + static_cast<const _Uint128&>(_Right)};
+        _Int128 _Result;
+        const auto _Carry = _AddCarry64(0, _Left._Word[0], _Right._Word[0], _Result._Word[0]);
+        _AddCarry64(_Carry, _Left._Word[1], _Right._Word[1], _Result._Word[1]);
+        return _Result;
     }
-    constexpr _Int128& operator+=(const _Int128& _That) noexcept {
-        _Uint128::operator+=(static_cast<const _Uint128&>(_That));
+
+    constexpr _Int128& operator+=(const _Uint128_base& _That) noexcept {
+        const auto _Carry = _AddCarry64(0, _Word[0], _That._Word[0], _Word[0]);
+        _AddCarry64(_Carry, _Word[1], _That._Word[1], _Word[1]);
         return *this;
     }
     template <integral _Ty>
@@ -963,11 +1047,15 @@ struct _Int128 : _Uint128 {
     }
 
     _NODISCARD_FRIEND constexpr _Int128 operator-(const _Int128& _Left, const _Int128& _Right) noexcept {
-        return _Int128{static_cast<const _Uint128&>(_Left) - static_cast<const _Uint128&>(_Right)};
+        _Int128 _Result;
+        const auto _Borrow = _SubBorrow64(0, _Left._Word[0], _Right._Word[0], _Result._Word[0]);
+        _SubBorrow64(_Borrow, _Left._Word[1], _Right._Word[1], _Result._Word[1]);
+        return _Result;
     }
 
-    constexpr _Int128& operator-=(const _Int128& _That) noexcept {
-        _Uint128::operator-=(static_cast<const _Uint128&>(_That));
+    constexpr _Int128& operator-=(const _Uint128_base& _That) noexcept {
+        const auto _Borrow = _SubBorrow64(0, _Word[0], _That._Word[0], _Word[0]);
+        _SubBorrow64(_Borrow, _Word[1], _That._Word[1], _Word[1]);
         return *this;
     }
     template <integral _Ty>
@@ -976,19 +1064,30 @@ struct _Int128 : _Uint128 {
         return _Left;
     }
 
+    constexpr void _Strip_negative(bool& _Flip) noexcept {
+        if ((_Word[1] & (1ull << 63)) != 0) {
+            *this = -*this;
+            _Flip = !_Flip;
+        }
+    }
+
     _NODISCARD_FRIEND constexpr _Int128 operator*(_Int128 _Left, _Int128 _Right) noexcept {
         bool _Negative = false;
         _Left._Strip_negative(_Negative);
         _Right._Strip_negative(_Negative);
-        _Uint128 _Result = static_cast<_Uint128&>(_Left) * static_cast<_Uint128&>(_Right);
+        _Int128 _Result{_Uint128_base::_Multiply(_Left, _Right)};
         if (_Negative) {
             _Result = -_Result;
         }
-        return _Int128{_Result};
+        return _Result;
     }
 
     constexpr _Int128& operator*=(const _Int128& _That) noexcept {
         *this = *this * _That;
+        return *this;
+    }
+    constexpr _Int128& operator*=(const _Uint128& _That) noexcept {
+        *this = _Int128{_That * static_cast<const _Uint128_base&>(*this)};
         return *this;
     }
     template <integral _Ty>
@@ -997,36 +1096,36 @@ struct _Int128 : _Uint128 {
         return _Left;
     }
 
-    _NODISCARD_FRIEND constexpr _Int128 operator/(_Int128 _Num, _Int128 _Den) noexcept {
-        bool _Negative = false;
-        _Num._Strip_negative(_Negative);
-        _Den._Strip_negative(_Negative);
-        _Uint128 _Result = static_cast<_Uint128&>(_Num) / static_cast<_Uint128&>(_Den);
-        if (_Negative) {
-            _Result = -_Result;
-        }
-        return _Int128{_Result};
-    }
-    _NODISCARD_FRIEND constexpr _Int128 operator/(_Int128 _Num, const uint64_t _Den) noexcept {
-        bool _Negative = false;
-        _Num._Strip_negative(_Negative);
-        _Uint128 _Result = static_cast<_Uint128&>(_Num) / _Den;
-        if (_Negative) {
-            _Result = -_Result;
-        }
-        return _Int128{_Result};
-    }
 #if !_STL_128_DIV_INTRINSICS
     _NODISCARD_FRIEND constexpr _Int128 operator/(_Int128 _Num, const uint32_t _Den) noexcept {
         bool _Negative = false;
         _Num._Strip_negative(_Negative);
-        _Uint128 _Result = static_cast<_Uint128&>(_Num) / _Den;
+        _Int128 _Result{_Uint128_base::_Divide(_Num, _Den)};
         if (_Negative) {
             _Result = -_Result;
         }
-        return _Int128{_Result};
+        return _Result;
     }
 #endif // !_STL_128_DIV_INTRINSICS
+    _NODISCARD_FRIEND constexpr _Int128 operator/(_Int128 _Num, const uint64_t _Den) noexcept {
+        bool _Negative = false;
+        _Num._Strip_negative(_Negative);
+        _Int128 _Result{_Uint128_base::_Divide(_Num, _Den)};
+        if (_Negative) {
+            _Result = -_Result;
+        }
+        return _Result;
+    }
+    _NODISCARD_FRIEND constexpr _Int128 operator/(_Int128 _Num, _Int128 _Den) noexcept {
+        bool _Negative = false;
+        _Num._Strip_negative(_Negative);
+        _Den._Strip_negative(_Negative);
+        _Int128 _Result{_Uint128_base::_Divide(_Num, _Den)};
+        if (_Negative) {
+            _Result = -_Result;
+        }
+        return _Result;
+    }
 
     constexpr _Int128& operator/=(const _Int128& _That) noexcept {
         *this = *this / _That;
@@ -1047,7 +1146,7 @@ struct _Int128 : _Uint128 {
             // intentionally not flipping _Negative
         }
 
-        _Uint128 _Result = static_cast<_Uint128&>(_Left) % static_cast<_Uint128&>(_Right);
+        _Uint128 _Result{_Uint128_base::_Modulo(_Left, _Right)};
         if (_Negative) {
             _Result = -_Result;
         }
@@ -1068,45 +1167,30 @@ struct _Int128 : _Uint128 {
         return _Int128{_Left._Word[0] & _Right._Word[0], _Left._Word[1] & _Right._Word[1]};
     }
 
-    constexpr _Int128& operator&=(const _Int128& _That) noexcept {
+    constexpr _Int128& operator&=(const _Uint128_base& _That) noexcept {
         _Word[0] &= _That._Word[0];
         _Word[1] &= _That._Word[1];
         return *this;
-    }
-    template <integral _Ty>
-    friend constexpr _Ty& operator&=(_Ty& _Left, const _Int128& _Right) noexcept {
-        _Left &= _Right._Word[0];
-        return _Left;
     }
 
     _NODISCARD_FRIEND constexpr _Int128 operator^(const _Int128& _Left, const _Int128& _Right) noexcept {
         return _Int128{_Left._Word[0] ^ _Right._Word[0], _Left._Word[1] ^ _Right._Word[1]};
     }
 
-    constexpr _Int128& operator^=(const _Int128& _That) noexcept {
+    constexpr _Int128& operator^=(const _Uint128_base& _That) noexcept {
         _Word[0] ^= _That._Word[0];
         _Word[1] ^= _That._Word[1];
         return *this;
-    }
-    template <integral _Ty>
-    friend constexpr _Ty& operator^=(_Ty& _Left, const _Int128& _Right) noexcept {
-        _Left ^= _Right._Word[0];
-        return _Left;
     }
 
     _NODISCARD_FRIEND constexpr _Int128 operator|(const _Int128& _Left, const _Int128& _Right) noexcept {
         return _Int128{_Left._Word[0] | _Right._Word[0], _Left._Word[1] | _Right._Word[1]};
     }
 
-    constexpr _Int128& operator|=(const _Int128& _That) noexcept {
+    constexpr _Int128& operator|=(const _Uint128_base& _That) noexcept {
         _Word[0] |= _That._Word[0];
         _Word[1] |= _That._Word[1];
         return *this;
-    }
-    template <integral _Ty>
-    friend constexpr _Ty& operator|=(_Ty& _Left, const _Int128& _Right) noexcept {
-        _Left |= _Right._Word[0];
-        return _Left;
     }
 };
 

--- a/stl/inc/__msvc_int128.hpp
+++ b/stl/inc/__msvc_int128.hpp
@@ -132,8 +132,9 @@ struct
     template <size_t __m, size_t __n>
     static constexpr void _Knuth_4_3_1_M(
         const uint32_t (&__u)[__m], const uint32_t (&__v)[__n], uint32_t (&__w)[__n + __m]) noexcept {
-        _STL_INTERNAL_STATIC_ASSERT(__m <= size_t{(numeric_limits<int>::max)()});
-        _STL_INTERNAL_STATIC_ASSERT(__n <= size_t{(numeric_limits<int>::max)()});
+        constexpr auto _Int_max = size_t{(numeric_limits<int>::max)()};
+        _STL_INTERNAL_STATIC_ASSERT(__m <= _Int_max);
+        _STL_INTERNAL_STATIC_ASSERT(__n <= _Int_max);
 
         for (auto& _Elem : __w) {
             _Elem = 0;
@@ -179,10 +180,11 @@ struct
     static constexpr void _Knuth_4_3_1_D(uint32_t* const __u, const size_t __u_size, const uint32_t* const __v,
         const size_t __v_size, uint32_t* const __q) noexcept {
         // Pre: __u + [0, __u_size), __v + [0, __v_size), and __q + [0, __u_size - __v_size) are all valid ranges
-        _STL_INTERNAL_CHECK(__v_size <= uint32_t{(numeric_limits<int>::max)()});
+        constexpr auto _Int_max = size_t{(numeric_limits<int>::max)()};
+        _STL_INTERNAL_CHECK(__v_size <= _Int_max);
         const auto __n = static_cast<int>(__v_size);
         _STL_INTERNAL_CHECK(__u_size > __v_size);
-        _STL_INTERNAL_CHECK(__u_size <= uint32_t{(numeric_limits<int>::max)()});
+        _STL_INTERNAL_CHECK(__u_size <= _Int_max);
         const auto __m = static_cast<int>(__u_size - __v_size - 1);
         _STL_INTERNAL_CHECK(__v[__n - 1] >> 31 != 0); // Arguments are already normalized
 

--- a/stl/inc/__msvc_int128.hpp
+++ b/stl/inc/__msvc_int128.hpp
@@ -1,0 +1,1155 @@
+// __msvc_int128 internal header (core)
+
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#pragma once
+#ifndef __MSVC_INT128_HPP
+#define __MSVC_INT128_HPP
+
+#include <yvals_core.h>
+#if _STL_COMPILER_PREPROCESSOR
+#ifdef __cpp_lib_concepts
+#include <bit>
+#include <compare>
+#include <concepts>
+#include <cstdint>
+#include <intrin.h> // TODO: move things we need to intrin0
+
+#if 1 // FIXME: comment out _STL_INTERNAL_CHECKs and remove to make this core
+#include <yvals.h>
+#endif
+
+#pragma pack(push, _CRT_PACKING)
+#pragma warning(push, _STL_WARNING_LEVEL)
+#pragma warning(disable : _STL_DISABLED_WARNINGS)
+_STL_DISABLE_CLANG_WARNINGS
+#pragma push_macro("new")
+#undef new
+
+_STD_BEGIN
+
+struct _Int128;
+
+struct alignas(16) _Uint128 {
+    uint64_t _Word[2];
+
+    using _Signed_type   = _Int128;
+    using _Unsigned_type = _Uint128;
+
+    constexpr void _Left_shift(const unsigned char _Count) noexcept {
+        if (_Count >= 64) {
+            _Word[1] = _Word[0] << (_Count % 64);
+            _Word[0] = 0;
+            return;
+        }
+
+        if (_Count != 0) {
+#if defined(_M_X64) && !defined(_M_ARM64EC)
+            if (!_STD is_constant_evaluated()) {
+                _Word[1] = __shiftleft128(_Word[0], _Word[1], _Count);
+            } else
+#endif // defined(_M_X64) && !defined(_M_ARM64EC)
+            {
+                _Word[1] = (_Word[1] << _Count) | (_Word[0] >> (64 - _Count));
+            }
+
+            _Word[0] <<= _Count;
+        }
+    }
+
+    constexpr void _Right_shift(const unsigned char _Count) noexcept {
+        if (_Count >= 64) {
+            _Word[0] = _Word[1] >> (_Count % 64);
+            _Word[1] = 0;
+            return;
+        }
+
+        if (_Count != 0) {
+#if defined(_M_X64) && !defined(_M_ARM64EC)
+            if (!_STD is_constant_evaluated()) {
+                _Word[0] = __shiftright128(_Word[0], _Word[1], _Count);
+            } else
+#endif // defined(_M_X64) && !defined(_M_ARM64EC)
+            {
+                _Word[0] = (_Word[0] >> _Count) | (_Word[1] << (64 - _Count));
+            }
+
+            _Word[1] >>= _Count;
+        }
+    }
+
+    static constexpr unsigned char _AddCarry64(
+        unsigned char _Carry, uint64_t _Left, uint64_t _Right, uint64_t& _Result) noexcept {
+        _STL_INTERNAL_CHECK(_Carry < 2);
+#if defined(_M_X64) && !defined(_M_ARM64EC)
+        if (!_STD is_constant_evaluated()) {
+            return _addcarry_u64(_Carry, _Left, _Right, &_Result);
+        }
+#endif // defined(_M_X64) && !defined(_M_ARM64EC)
+
+        const uint64_t _Sum = _Left + _Right + _Carry;
+        _Result             = _Sum;
+        return _Carry ? _Sum <= _Left : _Sum < _Left;
+    }
+
+    static constexpr unsigned char _SubBorrow64(
+        unsigned char _Carry, uint64_t _Left, uint64_t _Right, uint64_t& _Result) noexcept {
+#if defined(_M_X64) && !defined(_M_ARM64EC)
+        if (!_STD is_constant_evaluated()) {
+            return _subborrow_u64(_Carry, _Left, _Right, &_Result);
+        }
+#endif // defined(_M_X64) && !defined(_M_ARM64EC)
+        const auto _Difference = _Left - _Right - _Carry;
+        _Result                = _Difference;
+        return _Carry ? _Difference >= _Left : _Difference > _Left;
+    }
+
+    template <size_t __m, size_t __n>
+    static constexpr void _Knuth_4_3_1_M(
+        const uint32_t (&__u)[__m], const uint32_t (&__v)[__n], uint32_t (&__w)[__n + __m]) noexcept {
+        _STL_INTERNAL_STATIC_ASSERT(__m <= numeric_limits<int>::max());
+        _STL_INTERNAL_STATIC_ASSERT(__n <= numeric_limits<int>::max());
+
+        for (auto& _Elem : __w) {
+            _Elem = 0;
+        }
+
+        for (int __j = 0; __j < static_cast<int>(__n); ++__j) {
+            // stash Knuth's `k` in the lower 32 bits of __t
+            uint64_t __t = 0;
+            for (int __i = 0; __i < static_cast<int>(__m); ++__i) {
+                __t += static_cast<uint64_t>(__u[__i]) * __v[__j] + __w[__i + __j];
+                __w[__i + __j] = static_cast<uint32_t>(__t);
+                __t >>= 32;
+            }
+            __w[__j + __m] = static_cast<uint32_t>(__t);
+        }
+    }
+
+    _NODISCARD static constexpr uint64_t _UMul128(
+        const uint64_t _Left, const uint64_t _Right, uint64_t& _High_result) noexcept {
+#if defined(_M_X64) && !defined(_M_ARM64EC)
+        if (!_STD is_constant_evaluated()) {
+            return _umul128(_Left, _Right, &_High_result);
+        }
+#endif // defined(_M_X64) && !defined(_M_ARM64EC)
+
+        const uint32_t __u[2] = {
+            static_cast<uint32_t>(_Left),
+            static_cast<uint32_t>(_Left >> 32),
+        };
+        const uint32_t __v[2] = {
+            static_cast<uint32_t>(_Right),
+            static_cast<uint32_t>(_Right >> 32),
+        };
+        uint32_t __w[4];
+
+        // multiply 2-digit numbers with 4-digit result in base 2^32
+        _Knuth_4_3_1_M(__u, __v, __w);
+
+        _High_result = (static_cast<uint64_t>(__w[3]) << 32) | __w[2];
+        return (static_cast<uint64_t>(__w[1]) << 32) | __w[0];
+    }
+
+    static constexpr void _Knuth_4_3_1_D_impl(uint32_t __u[/* __n + __m + 1 */], const uint32_t __v[/* __n */],
+        uint32_t __q[/* __m + 1 */], const size_t __n, const size_t __m) noexcept {
+        _STL_INTERNAL_CHECK(__v[__n - 1] >> 31 != 0); // Arguments are already normalized
+        _STL_INTERNAL_CHECK(__m <= numeric_limits<int>::max());
+        _STL_INTERNAL_CHECK(__n <= numeric_limits<int>::max());
+
+        for (auto __j = static_cast<int>(__m); __j >= 0; --__j) {
+            const auto _Two_digits = (static_cast<uint64_t>(__u[__j + __n]) << 32) | __u[__j + __n - 1];
+            auto __qhat            = _Two_digits / __v[__n - 1];
+            auto __rhat            = _Two_digits % __v[__n - 1];
+
+            while ((__qhat >> 32) != 0
+                   || static_cast<uint32_t>(__qhat) * static_cast<uint64_t>(__v[__n - 2])
+                          > ((__rhat << 32) | __u[__j + __n - 2])) {
+                --__qhat;
+                __rhat += __v[__n - 1];
+                if ((__rhat >> 32) != 0) {
+                    break;
+                }
+            }
+
+            int64_t __k = 0;
+            int64_t __t;
+            for (int __i = 0; __i < static_cast<int>(__n); ++__i) {
+                const auto _Prod = static_cast<uint32_t>(__qhat) * static_cast<uint64_t>(__v[__i]);
+                __t              = __u[__i + __j] - __k - static_cast<uint32_t>(_Prod);
+                __u[__i + __j]   = static_cast<uint32_t>(__t);
+                __k              = static_cast<int64_t>((_Prod >> 32)) - (__t >> 32);
+            }
+            __t            = __u[__j + __n] - __k;
+            __u[__j + __n] = static_cast<uint32_t>(__t);
+
+            __q[__j] = static_cast<uint32_t>(__qhat);
+            if (__t < 0) {
+                --__q[__j];
+                __k = 0;
+                for (int __i = 0; __i < static_cast<int>(__n); ++__i) {
+                    __t            = __u[__i + __j] + __k + __v[__i];
+                    __u[__i + __j] = static_cast<uint32_t>(__t);
+                    __k            = __t >> 32;
+                }
+                __u[__j + __n] += static_cast<int32_t>(__k);
+            }
+        }
+
+        // quotient is in __q, normalized remainder is in __u
+    }
+
+    template <size_t __m_plus_n_plus_one, size_t __n>
+    static constexpr void _Knuth_4_3_1_D(uint32_t (&__u)[__m_plus_n_plus_one], const uint32_t (&__v)[__n],
+        uint32_t (&__q)[__m_plus_n_plus_one - __n]) noexcept {
+        _Knuth_4_3_1_D_impl(__u, __v, __q, __n, __m_plus_n_plus_one - (__n + 1));
+    }
+
+    _NODISCARD static constexpr uint64_t _UDiv128(
+        uint64_t _High, uint64_t _Low, uint64_t _Div, uint64_t& _Remainder) noexcept {
+        _STL_INTERNAL_CHECK(_High < _Div);
+
+#if !defined(__clang__) && defined(_M_X64) && !defined(_M_ARM64EC)
+        if (!_STD is_constant_evaluated()) {
+            return _udiv128(_High, _Low, _Div, &_Remainder);
+        }
+#endif // !defined(__clang__) && defined(_M_X64) && !defined(_M_ARM64EC)
+
+        const auto __d = _STD countl_zero(static_cast<uint32_t>(_Div >> 32));
+        if (__d >= 32) { // _Div < 2^32
+            auto _Rem    = (_High << 32) | (_Low >> 32);
+            auto _Result = _Rem / static_cast<uint32_t>(_Div);
+            _Rem         = (_Rem % static_cast<uint32_t>(_Div) << 32) | static_cast<uint32_t>(_Low);
+            _Result      = _Result << 32 | _Rem / static_cast<uint32_t>(_Div);
+            _Remainder   = _Rem % static_cast<uint32_t>(_Div);
+            return _Result;
+        }
+
+        uint32_t __u[5] = {
+            static_cast<uint32_t>(_Low << __d),
+            static_cast<uint32_t>(_Low >> (32 - __d)),
+            static_cast<uint32_t>(_High << __d),
+            static_cast<uint32_t>(_High >> (32 - __d)),
+            0,
+        };
+        if (__d != 0) {
+            __u[2] |= static_cast<uint32_t>(_Low >> (64 - __d));
+            __u[4] = static_cast<uint32_t>(_High >> (64 - __d));
+        }
+        uint32_t __v[2] = {
+            static_cast<uint32_t>(_Div << __d),
+            static_cast<uint32_t>(_Div >> (32 - __d)),
+        };
+        uint32_t __q[3];
+
+        _Knuth_4_3_1_D(__u, __v, __q);
+        _STL_INTERNAL_CHECK(__u[4] == 0);
+        _STL_INTERNAL_CHECK(__u[3] == 0);
+        _STL_INTERNAL_CHECK(__u[2] == 0);
+        _Remainder = (static_cast<uint64_t>(__u[1]) << (32 - __d)) | (__u[0] >> __d);
+
+        _STL_INTERNAL_CHECK(__q[2] == 0);
+        return static_cast<uint64_t>(__q[1]) << 32 | __q[0];
+    }
+
+    constexpr _Uint128() noexcept : _Word{} {}
+
+    constexpr _Uint128(const integral auto _Val) noexcept : _Word{static_cast<uint64_t>(_Val)} {
+        if constexpr (signed_integral<decltype(_Val)>) {
+            if (_Val < 0) {
+                _Word[1] = ~0ull;
+            }
+        }
+    }
+
+    explicit constexpr _Uint128(const uint64_t _Low, const uint64_t _High) noexcept : _Word{_Low, _High} {}
+
+    template <integral _Ty>
+    _NODISCARD explicit constexpr operator _Ty() const noexcept {
+        return static_cast<_Ty>(_Word[0]);
+    }
+
+    _NODISCARD explicit constexpr operator bool() const noexcept {
+        return (_Word[0] | _Word[1]) != 0;
+    }
+
+    _NODISCARD constexpr friend bool operator==(const _Uint128& _Left, const _Uint128& _Right) noexcept {
+        return _Left._Word[0] == _Right._Word[0] && _Left._Word[1] == _Right._Word[1];
+    }
+
+    _NODISCARD constexpr friend strong_ordering operator<=>(const _Uint128& _Left, const _Uint128& _Right) noexcept {
+        strong_ordering _Ord = _Left._Word[1] <=> _Right._Word[1];
+        if (_Ord == strong_ordering::equal) {
+            _Ord = _Left._Word[0] <=> _Right._Word[0];
+        }
+        return _Ord;
+    }
+
+    _NODISCARD friend constexpr _Uint128 operator<<(const _Uint128& _Left, const _Uint128& _Right) noexcept {
+        auto _Tmp{_Left};
+        _Tmp._Left_shift(static_cast<unsigned char>(_Right._Word[0]));
+        return _Tmp;
+    }
+
+    constexpr _Uint128& operator<<=(const _Uint128& _Count) noexcept {
+        _Left_shift(static_cast<unsigned char>(_Count._Word[0]));
+        return *this;
+    }
+    template <integral _Ty>
+    friend constexpr _Ty& operator<<=(_Ty& _Left, const _Uint128& _Right) noexcept {
+        _Left = static_cast<_Ty>(_Uint128{_Left} << _Right);
+        return _Left;
+    }
+
+    _NODISCARD friend constexpr _Uint128 operator>>(const _Uint128& _Left, const _Uint128& _Right) noexcept {
+        auto _Tmp{_Left};
+        _Tmp._Right_shift(static_cast<unsigned char>(_Right));
+        return _Tmp;
+    }
+
+    constexpr _Uint128& operator>>=(const _Uint128& _Count) noexcept {
+        _Right_shift(static_cast<unsigned char>(_Count._Word[0]));
+        return *this;
+    }
+    template <integral _Ty>
+    friend constexpr _Ty& operator>>=(_Ty& _Left, const _Uint128& _Right) noexcept {
+        _Left = static_cast<_Ty>(_Uint128{_Left} >> _Right);
+        return _Left;
+    }
+
+    constexpr _Uint128& operator++() noexcept {
+        if (++_Word[0] == 0) {
+            ++_Word[1];
+        }
+        return *this;
+    }
+    constexpr _Uint128 operator++(int) noexcept {
+        auto _Tmp = *this;
+        ++*this;
+        return _Tmp;
+    }
+
+    constexpr _Uint128& operator--() noexcept {
+        if (_Word[0]-- == 0) {
+            --_Word[1];
+        }
+        return *this;
+    }
+    constexpr _Uint128 operator--(int) noexcept {
+        auto _Tmp = *this;
+        --*this;
+        return _Tmp;
+    }
+
+    constexpr _Uint128 operator+() const noexcept {
+        return *this;
+    }
+
+    constexpr _Uint128 operator-() const noexcept {
+        return _Uint128{} - *this;
+    }
+
+    constexpr _Uint128 operator~() const noexcept {
+        return _Uint128{~_Word[0], ~_Word[1]};
+    }
+
+    _NODISCARD friend constexpr _Uint128 operator+(const _Uint128& _Left, const _Uint128& _Right) noexcept {
+        _Uint128 _Result;
+        const auto _Carry = _AddCarry64(0, _Left._Word[0], _Right._Word[0], _Result._Word[0]);
+        _AddCarry64(_Carry, _Left._Word[1], _Right._Word[1], _Result._Word[1]);
+        return _Result;
+    }
+
+    constexpr _Uint128& operator+=(const _Uint128& _That) noexcept {
+        const auto _Carry = _AddCarry64(0, _Word[0], _That._Word[0], _Word[0]);
+        _AddCarry64(_Carry, _Word[1], _That._Word[1], _Word[1]);
+        return *this;
+    }
+    template <integral _Ty>
+    friend constexpr _Ty& operator+=(_Ty& _Left, const _Uint128& _Right) noexcept {
+        _Left = static_cast<_Ty>(_Uint128{_Left} + _Right);
+        return _Left;
+    }
+
+    _NODISCARD friend constexpr _Uint128 operator-(const _Uint128& _Left, const _Uint128& _Right) noexcept {
+        _Uint128 _Result;
+        const auto _Borrow = _SubBorrow64(0, _Left._Word[0], _Right._Word[0], _Result._Word[0]);
+        _SubBorrow64(_Borrow, _Left._Word[1], _Right._Word[1], _Result._Word[1]);
+        return _Result;
+    }
+
+    constexpr _Uint128& operator-=(const _Uint128& _That) noexcept {
+        const auto _Borrow = _SubBorrow64(0, _Word[0], _That._Word[0], _Word[0]);
+        _SubBorrow64(_Borrow, _Word[1], _That._Word[1], _Word[1]);
+        return *this;
+    }
+    template <integral _Ty>
+    friend constexpr _Ty& operator-=(_Ty& _Left, const _Uint128& _Right) noexcept {
+        _Left = static_cast<_Ty>(_Uint128{_Left} - _Right);
+        return _Left;
+    }
+
+    _NODISCARD friend constexpr _Uint128 operator*(const _Uint128& _Left, const _Uint128& _Right) noexcept {
+        _Uint128 _Result;
+        _Result._Word[0] = _UMul128(_Left._Word[0], _Right._Word[0], _Result._Word[1]);
+        _Result._Word[1] += _Left._Word[0] * _Right._Word[1];
+        _Result._Word[1] += _Left._Word[1] * _Right._Word[0];
+        return _Result;
+    }
+
+    constexpr _Uint128& operator*=(const _Uint128& _That) noexcept {
+        *this = *this * _That;
+        return *this;
+    }
+    template <integral _Ty>
+    friend constexpr _Ty& operator*=(_Ty& _Left, const _Uint128& _Right) noexcept {
+        _Left = static_cast<_Ty>(_Uint128{_Left} * _Right);
+        return _Left;
+    }
+
+    _NODISCARD friend constexpr _Uint128 operator/(const _Uint128& _Num, const uint32_t _Den) noexcept {
+        _Uint128 _Result;
+        _Result._Word[1] = _Num._Word[1] / _Den;
+        uint64_t _Rem    = (_Num._Word[1] % _Den) << 32 | (_Num._Word[0] >> 32);
+        _Result._Word[0] = (_Rem / _Den) << 32;
+        _Rem             = (_Rem % _Den) << 32 | static_cast<uint32_t>(_Num._Word[0]);
+        _Result._Word[0] |= static_cast<uint32_t>(_Rem / _Den);
+        return _Result;
+    }
+
+
+    _NODISCARD friend constexpr _Uint128 operator/(const _Uint128& _Num, const uint64_t _Den) noexcept {
+        _Uint128 _Result;
+        _Result._Word[1] = _Num._Word[1] / _Den;
+        uint64_t _Rem    = _Num._Word[1] % _Den;
+        _Result._Word[0] = _UDiv128(_Rem, _Num._Word[0], _Den, _Rem);
+        return _Result;
+    }
+
+    _NODISCARD friend constexpr _Uint128 operator/(_Uint128 _Num, _Uint128 _Den) noexcept {
+        // establish _Den < _Num and _Num._Word[1] > 0
+        if (_Den._Word[1] > _Num._Word[1]) {
+            return _Uint128{};
+        }
+        if (_Den._Word[1] == _Num._Word[1]) {
+            return _Uint128{_Num._Word[1] == 0 ? _Num._Word[0] / _Den._Word[0] : _Num._Word[0] >= _Den._Word[0]};
+        }
+
+        // establish _Den has more than 1 non-zero "digit"
+        if (_Den._Word[1] == 0) {
+            if (_Den._Word[0] < (1ull << 32)) {
+                return operator/(_Num, static_cast<uint32_t>(_Den._Word[0]));
+            } else {
+                return operator/(_Num, _Den._Word[0]);
+            }
+        }
+
+#if defined(_M_X64) && !defined(_M_ARM64EC)
+        // Knuth 4.3.1D, 2-digit by 2-digit divide in base 2^64
+        _STL_INTERNAL_CHECK(_Den._Word[1] != 0);
+        _STL_INTERNAL_CHECK(_Num._Word[1] > _Den._Word[1]);
+        // Normalize by shifting both left until _Den's high bit is set (So _Den's high digit is >= b / 2)
+        const auto __d = _STD countl_zero(_Den._Word[1]);
+        _Den <<= __d;
+        auto _High_digit = __d == 0 ? 0 : _Num._Word[1] >> (64 - __d); // This creates a third digit for _Num
+        _Num <<= __d;
+
+        _Uint128 __qhat;
+        __qhat._Word[1] = _High_digit >= _Den._Word[1];
+        uint64_t __rhat;
+        __qhat._Word[0] = _UDiv128(_High_digit >= _Den._Word[1] ? _High_digit - _Den._Word[1] : _High_digit,
+            _Num._Word[1], _Den._Word[1], __rhat);
+
+        for (;;) {
+            if (__qhat._Word[1] > 0) {
+                --__qhat;
+            } else {
+                _Uint128 _Prod;
+                _Prod._Word[0] = _UMul128(__qhat._Word[0], _Den._Word[0], _Prod._Word[1]);
+                if (_Prod <= _Uint128{_Num._Word[0], __rhat}) {
+                    break;
+                }
+                --__qhat._Word[0];
+            }
+
+            const auto _Sum = __rhat + _Den._Word[1];
+            if (__rhat > _Sum) {
+                break;
+            }
+            __rhat = _Sum;
+        }
+        _STL_INTERNAL_CHECK(__qhat._Word[1] == 0);
+
+        // [_High_digit | _Num] -= __qhat * _Den [Since __qhat < b, this is 3-digit - 1-digit * 2-digit]
+        uint64_t _Prod0_hi;
+        uint64_t _Prod_lo = _UMul128(__qhat._Word[0], _Den._Word[0], _Prod0_hi);
+        auto _Borrow      = _SubBorrow64(0, _Num._Word[0], _Prod_lo, _Num._Word[0]);
+        uint64_t _Prod1_hi;
+        _Prod_lo = _UMul128(__qhat._Word[0], _Den._Word[1], _Prod1_hi);
+        _Prod1_hi += _AddCarry64(0, _Prod_lo, _Prod0_hi, _Prod_lo);
+        _Borrow = _SubBorrow64(_Borrow, _Num._Word[1], _Prod_lo, _Num._Word[1]);
+        _Borrow = _SubBorrow64(_Borrow, _High_digit, _Prod1_hi, _High_digit);
+        if (_Borrow) {
+            --__qhat._Word[0];
+        }
+        return __qhat;
+#else // ^^^ 128-bit intrinsics / no such intrinsics vvv
+        const auto __d             = _STD countl_zero(_Den._Word[1]);
+        const bool _Three_word_den = __d >= 32;
+        __d &= 31;
+        uint32_t __u[5]{
+            static_cast<uint32_t>(_Num._Word[0] << __d),
+            static_cast<uint32_t>(_Num._Word[0] >> (32 - __d)),
+            static_cast<uint32_t>(_Num._Word[1] << __d),
+            static_cast<uint32_t>(_Num._Word[1] >> (32 - __d)),
+            0,
+        };
+        uint32_t __v[4] = {
+            static_cast<uint32_t>(_Den._Word[0] << __d),
+            static_cast<uint32_t>(_Den._Word[0] >> (32 - __d)),
+            static_cast<uint32_t>(_Den._Word[1] << __d),
+            static_cast<uint32_t>(_Den._Word[1] >> (32 - __d)),
+        };
+        if (__d != 0) {
+            __u[2] |= _Num._Word[0] >> (64 - __d);
+            __v[2] |= _Den._Word[0] >> (64 - __d);
+        }
+
+        uint32_t __q[2];
+        if (_Three_word_den) {
+            // 4-digit by 3-digit base 2^32 division
+            _Knuth_4_3_1_D(__u, reinterpret_cast<uint(&)[3]>(__v), __q);
+        } else {
+            // 4-digit by 4-digit base 2^32 division
+            _Knuth_4_3_1_D(__u, __v, reinterpret_cast<uint32_t(&)[1]>(__q));
+            __q[1] = 0;
+        }
+
+        return _Uint128{static_cast<uint64_t>(__q[1]) << 32 | __q[0]};
+#endif // defined(_M_X64) && !defined(_M_ARM64EC)
+    }
+
+    constexpr _Uint128& operator/=(const uint32_t _That) noexcept {
+        *this = *this / _That;
+        return *this;
+    }
+    constexpr _Uint128& operator/=(const uint64_t _That) noexcept {
+        *this = *this / _That;
+        return *this;
+    }
+    constexpr _Uint128& operator/=(const _Uint128& _That) noexcept {
+        *this = *this / _That;
+        return *this;
+    }
+    template <integral _Ty>
+    friend constexpr _Ty& operator/=(_Ty& _Left, const _Uint128& _Right) noexcept {
+        _Left = static_cast<_Ty>(_Uint128{_Left} / _Right);
+        return _Left;
+    }
+
+    _NODISCARD friend constexpr _Uint128 operator%(const _Uint128& _Num, const uint32_t _Den) noexcept {
+        uint64_t _Rem = _Num._Word[1];
+        _Rem          = (_Rem % _Den) << 32 | (_Num._Word[0] >> 32);
+        _Rem          = (_Rem % _Den) << 32 | static_cast<uint32_t>(_Num._Word[0]);
+        return _Uint128{_Rem % _Den};
+    }
+
+    _NODISCARD friend constexpr _Uint128 operator%(const _Uint128& _Num, const uint64_t _Den) noexcept {
+        uint64_t _Rem;
+        (void) _UDiv128(_Num._Word[1] % _Den, _Num._Word[0], _Den, _Rem);
+        return _Uint128{_Rem};
+    }
+
+    _NODISCARD friend constexpr _Uint128 operator%(_Uint128 _Num, _Uint128 _Den) noexcept {
+        // establish _Den < _Num and _Num._Word[1] > 0
+        if (_Den._Word[1] > _Num._Word[1]) {
+            return _Num;
+        }
+        if (_Den._Word[1] == _Num._Word[1]) {
+            if (_Den._Word[0] < _Num._Word[0]) {
+                return _Uint128{_Num._Word[0] - _Den._Word[0]};
+            }
+
+            return _Num;
+        }
+
+        // establish _Den has more than 1 non-zero "digit"
+        if (_Den._Word[1] == 0) {
+            if ((_Den._Word[0] >> 32) == 0) {
+                return operator%(_Num, static_cast<uint32_t>(_Den._Word[0]));
+            } else {
+                return operator%(_Num, _Den._Word[0]);
+            }
+        }
+
+#if defined(_M_X64) && !defined(_M_ARM64EC)
+        // Knuth 4.3.1D, 2-digit by 2-digit divide in base 2^64
+        _STL_INTERNAL_CHECK(_Den._Word[1] != 0);
+        _STL_INTERNAL_CHECK(_Num._Word[1] > _Den._Word[1]);
+        // Normalize by shifting both left until _Den's high bit is set (So _Den's high digit is >= b / 2)
+        const auto __d = _STD countl_zero(_Den._Word[1]);
+        _Den <<= __d;
+        auto _High_digit = __d == 0 ? 0 : _Num._Word[1] >> (64 - __d); // This creates a third digit for _Num
+        _Num <<= __d;
+
+        uint64_t __qhat_high = _High_digit >= _Den._Word[1];
+        uint64_t __rhat;
+        uint64_t __qhat = _UDiv128(_High_digit >= _Den._Word[1] ? _High_digit - _Den._Word[1] : _High_digit,
+            _Num._Word[1], _Den._Word[1], __rhat);
+
+        for (;;) {
+            if (__qhat_high > 0) {
+                if (__qhat-- == 0) {
+                    --__qhat_high;
+                }
+            } else {
+                _Uint128 _Prod;
+                _Prod._Word[0] = _UMul128(__qhat, _Den._Word[0], _Prod._Word[1]);
+                if (_Prod <= _Uint128{_Num._Word[0], __rhat}) {
+                    break;
+                }
+                --__qhat;
+            }
+
+            const auto _Sum = __rhat + _Den._Word[1];
+            if (__rhat > _Sum) {
+                break;
+            }
+            __rhat = _Sum;
+            // The addition didn't overflow, so `__rhat < b` holds
+        }
+        _STL_INTERNAL_CHECK(__qhat_high == 0);
+
+        // [_High_digit | _Num] -= __qhat * _Den [3-digit - 1-digit * 2-digit]
+        uint64_t _Prod0_hi;
+        uint64_t _Prod_lo = _UMul128(__qhat, _Den._Word[0], _Prod0_hi);
+        auto _Borrow      = _SubBorrow64(0, _Num._Word[0], _Prod_lo, _Num._Word[0]);
+        uint64_t _Prod1_hi;
+        _Prod_lo = _UMul128(__qhat, _Den._Word[1], _Prod1_hi);
+        _Prod1_hi += _AddCarry64(0, _Prod_lo, _Prod0_hi, _Prod_lo);
+        _Borrow = _SubBorrow64(_Borrow, _Num._Word[1], _Prod_lo, _Num._Word[1]);
+        _Borrow = _SubBorrow64(_Borrow, _High_digit, _Prod1_hi, _High_digit);
+        if (_Borrow) {
+            auto _Carry = _AddCarry64(0, _Num._Word[0], _Den._Word[0], _Num._Word[0]);
+            (void) _AddCarry64(_Carry, _Num._Word[1], _Den._Word[1], _Num._Word[1]);
+        }
+#else // ^^^ 128-bit intrinsics / no such intrinsics vvv
+        const auto __d             = _STD countl_zero(_Den._Word[1]);
+        const bool _Three_word_den = __d >= 32;
+        __d &= 31;
+        uint32_t __u[5]{
+            static_cast<uint32_t>(_Num._Word[0] << __d),
+            static_cast<uint32_t>(_Num._Word[0] >> (32 - __d)),
+            static_cast<uint32_t>(_Num._Word[1] << __d),
+            static_cast<uint32_t>(_Num._Word[1] >> (32 - __d)),
+            0,
+        };
+        if (__d != 0) {
+            __u[3] |= _Num._Word[0] >> (64 - __d);
+        }
+
+        uint32_t _Quotient[2];
+        if (_Three_word_den) {
+            // 4-digit by 3-digit base 2^32 division
+            uint32_t __v[3] = {
+                static_cast<uint32_t>(_Den._Word[0] << __d),
+                static_cast<uint32_t>(_Den._Word[0] >> (32 - __d)),
+                static_cast<uint32_t>(_Den._Word[1] << __d),
+            };
+            if (__d != 0) {
+                __v[2] |= _Den._Word[0] >> (64 - __d);
+            }
+
+            _Knuth_4_3_1_D(__u, __v, _Quotient);
+            _STL_INTERNAL_CHECK(__u[3] == 0);
+        } else {
+            // 4-digit by 4-digit base 2^32 division
+            uint32_t __v[4] = {
+                static_cast<uint32_t>(_Den._Word[0] << __d),
+                static_cast<uint32_t>(_Den._Word[0] >> (32 - __d)),
+                static_cast<uint32_t>(_Den._Word[1] << __d),
+                static_cast<uint32_t>(_Den._Word[1] >> (32 - __d)),
+            };
+            if (__d != 0) {
+                __v[2] |= _Den._Word[0] >> (64 - __d);
+            }
+            auto& __q = reinterpret_cast<uint32_t(&)[1]>(_Quotient);
+
+            _Knuth_4_3_1_D(__u, __v, __q);
+        }
+        _STL_INTERNAL_CHECK(__u[4] == 0);
+
+        _Num._Word[0] = static_cast<uint64_t>(__u[1]) << 32 | __u[0];
+        _Num._Word[1] = static_cast<uint64_t>(__u[3]) << 32 | __u[2];
+#endif // defined(_M_X64) && !defined(_M_ARM64EC)
+        _Num >>= __d;
+        return _Num;
+    }
+
+    constexpr _Uint128& operator%=(const uint32_t _Den) noexcept {
+        *this = *this % _Den;
+        return *this;
+    }
+    constexpr _Uint128& operator%=(const uint64_t _Den) noexcept {
+        *this = *this % _Den;
+        return *this;
+    }
+    constexpr _Uint128& operator%=(const _Uint128& _Den) noexcept {
+        *this = *this % _Den;
+        return *this;
+    }
+    template <integral _Ty>
+    friend constexpr _Ty& operator%=(_Ty& _Left, const _Uint128& _Right) noexcept {
+        _Left = static_cast<_Ty>(_Uint128{_Left} % _Right);
+        return _Left;
+    }
+
+    _NODISCARD friend constexpr _Uint128 operator&(const _Uint128& _Left, const _Uint128& _Right) noexcept {
+        return _Uint128{_Left._Word[0] & _Right._Word[0], _Left._Word[1] & _Right._Word[1]};
+    }
+
+    constexpr _Uint128& operator&=(const _Uint128& _That) noexcept {
+        _Word[0] &= _That._Word[0];
+        _Word[1] &= _That._Word[1];
+        return *this;
+    }
+    template <integral _Ty>
+    friend constexpr _Ty& operator&=(_Ty& _Left, const _Uint128& _Right) noexcept {
+        _Left = static_cast<_Ty>(_Uint128{_Left} & _Right);
+        return _Left;
+    }
+
+    _NODISCARD friend constexpr _Uint128 operator^(const _Uint128& _Left, const _Uint128& _Right) noexcept {
+        return _Uint128{_Left._Word[0] ^ _Right._Word[0], _Left._Word[1] ^ _Right._Word[1]};
+    }
+
+    constexpr _Uint128& operator^=(const _Uint128& _That) noexcept {
+        _Word[0] ^= _That._Word[0];
+        _Word[1] ^= _That._Word[1];
+        return *this;
+    }
+    template <integral _Ty>
+    friend constexpr _Ty& operator^=(_Ty& _Left, const _Uint128& _Right) noexcept {
+        _Left = static_cast<_Ty>(_Uint128{_Left} ^ _Right);
+        return _Left;
+    }
+
+    _NODISCARD friend constexpr _Uint128 operator|(const _Uint128& _Left, const _Uint128& _Right) noexcept {
+        return _Uint128{_Left._Word[0] | _Right._Word[0], _Left._Word[1] | _Right._Word[1]};
+    }
+
+    constexpr _Uint128& operator|=(const _Uint128& _That) noexcept {
+        _Word[0] |= _That._Word[0];
+        _Word[1] |= _That._Word[1];
+        return *this;
+    }
+    template <integral _Ty>
+    friend constexpr _Ty& operator|=(_Ty& _Left, const _Uint128& _Right) noexcept {
+        _Left = static_cast<_Ty>(_Uint128{_Left} | _Right);
+        return _Left;
+    }
+};
+
+template <class>
+class numeric_limits;
+template <>
+class numeric_limits<_Uint128> : public _Num_int_base {
+public:
+    _NODISCARD static constexpr _Uint128(min)() noexcept {
+        return 0;
+    }
+
+    _NODISCARD static constexpr _Uint128(max)() noexcept {
+        return _Uint128{~0ull, ~0ull};
+    }
+
+    _NODISCARD static constexpr _Uint128 lowest() noexcept {
+        return (min) ();
+    }
+
+    _NODISCARD static constexpr _Uint128 epsilon() noexcept {
+        return 0;
+    }
+
+    _NODISCARD static constexpr _Uint128 round_error() noexcept {
+        return 0;
+    }
+
+    _NODISCARD static constexpr _Uint128 denorm_min() noexcept {
+        return 0;
+    }
+
+    _NODISCARD static constexpr _Uint128 infinity() noexcept {
+        return 0;
+    }
+
+    _NODISCARD static constexpr _Uint128 quiet_NaN() noexcept {
+        return 0;
+    }
+
+    _NODISCARD static constexpr _Uint128 signaling_NaN() noexcept {
+        return 0;
+    }
+
+    static constexpr bool is_modulo = true;
+    static constexpr int digits     = 128;
+    static constexpr int digits10   = 38;
+};
+
+template <class...>
+struct common_type;
+template <integral _Ty>
+struct common_type<_Ty, _Uint128> {
+    using type = _Uint128;
+};
+template <integral _Ty>
+struct common_type<_Uint128, _Ty> {
+    using type = _Uint128;
+};
+
+struct _Int128 : _Uint128 {
+    using _Signed_type   = _Int128;
+    using _Unsigned_type = _Uint128;
+
+    constexpr void _Right_shift(const unsigned char _Count) noexcept {
+        if (_Count >= 64) {
+            _Word[0] = static_cast<uint64_t>(static_cast<int64_t>(_Word[1]) >> (_Count % 64));
+            _Word[1] = (_Word[1] & (1ull << 63)) == 0 ? 0 : ~0ull;
+            return;
+        }
+
+        if (_Count != 0) {
+#if defined(_M_X64) && !defined(_M_ARM64EC)
+            if (!_STD is_constant_evaluated()) {
+                _Word[0] = __shiftright128(_Word[0], _Word[1], _Count);
+            } else
+#endif // defined(_M_X64) && !defined(_M_ARM64EC)
+            {
+                _Word[0] = (_Word[0] >> _Count) | (_Word[1] << (64 - _Count));
+            }
+
+            _Word[1] = static_cast<uint64_t>(static_cast<int64_t>(_Word[1]) >> _Count);
+        }
+    }
+
+    using _Uint128::_Uint128;
+    constexpr explicit _Int128(const _Uint128& _That) noexcept : _Uint128{_That} {}
+
+    _NODISCARD constexpr friend strong_ordering operator<=>(const _Int128& _Left, const _Int128& _Right) noexcept {
+        strong_ordering _Ord = static_cast<int64_t>(_Left._Word[1]) <=> static_cast<int64_t>(_Right._Word[1]);
+        if (_Ord == strong_ordering::equal) {
+            _Ord = _Left._Word[0] <=> _Right._Word[0];
+        }
+        return _Ord;
+    }
+
+    _NODISCARD friend constexpr _Int128 operator<<(const _Int128& _Left, const _Int128& _Right) noexcept {
+        auto _Tmp{_Left};
+        _Tmp._Left_shift(static_cast<unsigned char>(_Right._Word[0]));
+        return _Tmp;
+    }
+
+    constexpr _Int128& operator<<=(const _Uint128& _Count) noexcept {
+        _Left_shift(static_cast<unsigned char>(_Count._Word[0]));
+        return *this;
+    }
+    template <integral _Ty>
+    friend constexpr _Ty& operator<<=(_Ty& _Left, const _Int128& _Right) noexcept {
+        _Left = static_cast<_Ty>(_Int128{_Left} << _Right);
+        return _Left;
+    }
+
+    _NODISCARD friend constexpr _Int128 operator>>(const _Int128& _Left, const _Int128& _Right) noexcept {
+        auto _Tmp{_Left};
+        _Tmp._Right_shift(static_cast<unsigned char>(_Right._Word[0]));
+        return _Tmp;
+    }
+
+    constexpr _Int128& operator>>=(const _Uint128& _Count) noexcept {
+        _Right_shift(static_cast<unsigned char>(_Count._Word[0]));
+        return *this;
+    }
+    template <integral _Ty>
+    friend constexpr _Ty& operator>>=(_Ty& _Left, const _Int128& _Right) noexcept {
+        _Left = static_cast<_Ty>(_Int128{_Left} >> _Right);
+        return _Left;
+    }
+
+    constexpr _Int128& operator++() noexcept {
+        _Uint128::operator++();
+        return *this;
+    }
+    constexpr _Int128 operator++(int) noexcept {
+        auto _Tmp = *this;
+        ++*this;
+        return _Tmp;
+    }
+
+    constexpr _Int128& operator--() noexcept {
+        _Uint128::operator--();
+        return *this;
+    }
+    constexpr _Int128 operator--(int) noexcept {
+        auto _Tmp = *this;
+        --*this;
+        return _Tmp;
+    }
+
+    constexpr _Int128 operator+() const noexcept {
+        return *this;
+    }
+
+    constexpr _Int128 operator-() const noexcept {
+        return _Int128{_Uint128::operator-()};
+    }
+
+    constexpr _Int128 operator~() const noexcept {
+        return _Int128{~_Word[0], ~_Word[1]};
+    }
+
+    _NODISCARD friend constexpr _Int128 operator+(const _Int128& _Left, const _Int128& _Right) noexcept {
+        return _Int128{static_cast<const _Uint128&>(_Left) + static_cast<const _Uint128&>(_Right)};
+    }
+    constexpr _Int128& operator+=(const _Int128& _That) noexcept {
+        _Uint128::operator+=(static_cast<const _Uint128&>(_That));
+        return *this;
+    }
+    template <integral _Ty>
+    friend constexpr _Ty& operator+=(_Ty& _Left, const _Int128& _Right) noexcept {
+        _Left = static_cast<_Ty>(_Int128{_Left} + _Right);
+        return _Left;
+    }
+
+    _NODISCARD friend constexpr _Int128 operator-(const _Int128& _Left, const _Int128& _Right) noexcept {
+        return _Int128{static_cast<const _Uint128&>(_Left) - static_cast<const _Uint128&>(_Right)};
+    }
+
+    constexpr _Int128& operator-=(const _Int128& _That) noexcept {
+        _Uint128::operator-=(static_cast<const _Uint128&>(_That));
+        return *this;
+    }
+    template <integral _Ty>
+    friend constexpr _Ty& operator-=(_Ty& _Left, const _Int128& _Right) noexcept {
+        _Left = static_cast<_Ty>(_Int128{_Left} - _Right);
+        return _Left;
+    }
+
+    _NODISCARD friend constexpr _Int128 operator*(_Int128 _Left, _Int128 _Right) noexcept {
+        bool _Negative = false;
+        if ((_Left._Word[1] & (1ull << 63)) != 0) {
+            _Left     = -_Left;
+            _Negative = true;
+        }
+        if ((_Right._Word[1] & (1ull << 63)) != 0) {
+            _Right    = -_Right;
+            _Negative = !_Negative;
+        }
+
+        _Uint128 _Result = static_cast<_Uint128&>(_Left) * static_cast<_Uint128&>(_Right);
+        if (_Negative) {
+            _Result = -_Result;
+        }
+        return _Int128{_Result};
+    }
+
+    constexpr _Int128& operator*=(const _Int128& _That) noexcept {
+        *this = *this * _That;
+        return *this;
+    }
+    template <integral _Ty>
+    friend constexpr _Ty& operator*=(_Ty& _Left, const _Int128& _Right) noexcept {
+        _Left = static_cast<_Ty>(_Int128{_Left} * _Right);
+        return _Left;
+    }
+
+    _NODISCARD friend constexpr _Int128 operator/(_Int128 _Num, _Int128 _Den) noexcept {
+        bool _Negative = false;
+        if ((_Num._Word[1] & (1ull << 63)) != 0) {
+            _Num      = -_Num;
+            _Negative = true;
+        }
+        if ((_Den._Word[1] & (1ull << 63)) != 0) {
+            _Den      = -_Den;
+            _Negative = !_Negative;
+        }
+
+        _Uint128 _Result = static_cast<_Uint128&>(_Num) / static_cast<_Uint128&>(_Den);
+        if (_Negative) {
+            _Result = -_Result;
+        }
+        return _Int128{_Result};
+    }
+    _NODISCARD friend constexpr _Int128 operator/(_Int128 _Num, const uint64_t _Den) noexcept {
+        bool _Negative = false;
+        if ((_Num._Word[1] & (1ull << 63)) != 0) {
+            _Num      = -_Num;
+            _Negative = true;
+        }
+
+        _Uint128 _Result = static_cast<_Uint128&>(_Num) / _Den;
+        if (_Negative) {
+            _Result = -_Result;
+        }
+        return _Int128{_Result};
+    }
+    _NODISCARD friend constexpr _Int128 operator/(_Int128 _Num, const uint32_t _Den) noexcept {
+        bool _Negative = false;
+        if ((_Num._Word[1] & (1ull << 63)) != 0) {
+            _Num      = -_Num;
+            _Negative = true;
+        }
+
+        _Uint128 _Result = static_cast<_Uint128&>(_Num) / _Den;
+        if (_Negative) {
+            _Result = -_Result;
+        }
+        return _Int128{_Result};
+    }
+
+    constexpr _Int128& operator/=(const _Int128& _That) noexcept {
+        *this = *this / _That;
+        return *this;
+    }
+    template <integral _Ty>
+    friend constexpr _Ty& operator/=(_Ty& _Left, const _Int128& _Right) noexcept {
+        _Left = static_cast<_Ty>(_Int128{_Left} / _Right);
+        return _Left;
+    }
+
+    _NODISCARD friend constexpr _Int128 operator%(_Int128 _Left, _Int128 _Right) noexcept {
+        bool _Negative = false;
+        if ((_Left._Word[1] & (1ull << 63)) != 0) {
+            _Left     = -_Left;
+            _Negative = true;
+        }
+        if ((_Right._Word[1] & (1ull << 63)) != 0) {
+            _Right = -_Right;
+        }
+
+        _Uint128 _Result = static_cast<_Uint128&>(_Left) % static_cast<_Uint128&>(_Right);
+        if (_Negative) {
+            _Result = -_Result;
+        }
+        return _Int128{_Result};
+    }
+
+    constexpr _Int128& operator%=(const _Int128& _That) noexcept {
+        *this = *this % _That;
+        return *this;
+    }
+    template <integral _Ty>
+    friend constexpr _Ty& operator%=(_Ty& _Left, const _Int128& _Right) noexcept {
+        _Left = static_cast<_Ty>(_Int128{_Left} % _Right);
+        return _Left;
+    }
+
+    _NODISCARD friend constexpr _Int128 operator&(const _Int128& _Left, const _Int128& _Right) noexcept {
+        return _Int128{_Left._Word[0] & _Right._Word[0], _Left._Word[1] & _Right._Word[1]};
+    }
+
+    constexpr _Int128& operator&=(const _Int128& _That) noexcept {
+        _Word[0] &= _That._Word[0];
+        _Word[1] &= _That._Word[1];
+        return *this;
+    }
+    template <integral _Ty>
+    friend constexpr _Ty& operator&=(_Ty& _Left, const _Int128& _Right) noexcept {
+        _Left = static_cast<_Ty>(_Int128{_Left} & _Right);
+        return _Left;
+    }
+
+    _NODISCARD friend constexpr _Int128 operator^(const _Int128& _Left, const _Int128& _Right) noexcept {
+        return _Int128{_Left._Word[0] ^ _Right._Word[0], _Left._Word[1] ^ _Right._Word[1]};
+    }
+
+    constexpr _Int128& operator^=(const _Int128& _That) noexcept {
+        _Word[0] ^= _That._Word[0];
+        _Word[1] ^= _That._Word[1];
+        return *this;
+    }
+    template <integral _Ty>
+    friend constexpr _Ty& operator^=(_Ty& _Left, const _Int128& _Right) noexcept {
+        _Left = static_cast<_Ty>(_Int128{_Left} ^ _Right);
+        return _Left;
+    }
+
+    _NODISCARD friend constexpr _Int128 operator|(const _Int128& _Left, const _Int128& _Right) noexcept {
+        return _Int128{_Left._Word[0] | _Right._Word[0], _Left._Word[1] | _Right._Word[1]};
+    }
+
+    constexpr _Int128& operator|=(const _Int128& _That) noexcept {
+        _Word[0] |= _That._Word[0];
+        _Word[1] |= _That._Word[1];
+        return *this;
+    }
+    template <integral _Ty>
+    friend constexpr _Ty& operator|=(_Ty& _Left, const _Int128& _Right) noexcept {
+        _Left = static_cast<_Ty>(_Int128{_Left} | _Right);
+        return _Left;
+    }
+};
+
+template <class>
+class numeric_limits;
+template <>
+class numeric_limits<_Int128> : public _Num_int_base {
+public:
+    _NODISCARD static constexpr _Int128(min)() noexcept {
+        return _Int128{0ull, 1ull << 63};
+    }
+
+    _NODISCARD static constexpr _Int128(max)() noexcept {
+        return _Int128{~0ull, ~0ull >> 1};
+    }
+
+    _NODISCARD static constexpr _Int128 lowest() noexcept {
+        return (min) ();
+    }
+
+    _NODISCARD static constexpr _Int128 epsilon() noexcept {
+        return 0;
+    }
+
+    _NODISCARD static constexpr _Int128 round_error() noexcept {
+        return 0;
+    }
+
+    _NODISCARD static constexpr _Int128 denorm_min() noexcept {
+        return 0;
+    }
+
+    _NODISCARD static constexpr _Int128 infinity() noexcept {
+        return 0;
+    }
+
+    _NODISCARD static constexpr _Int128 quiet_NaN() noexcept {
+        return 0;
+    }
+
+    _NODISCARD static constexpr _Int128 signaling_NaN() noexcept {
+        return 0;
+    }
+
+    static constexpr int digits   = 128;
+    static constexpr int digits10 = 38;
+};
+
+template <integral _Ty>
+struct common_type<_Ty, _Int128> {
+    using type = _Int128;
+};
+template <integral _Ty>
+struct common_type<_Int128, _Ty> {
+    using type = _Int128;
+};
+
+_STD_END
+
+#pragma pop_macro("new")
+_STL_RESTORE_CLANG_WARNINGS
+#pragma warning(pop)
+#pragma pack(pop)
+#endif // __cpp_lib_concepts
+#endif // _STL_COMPILER_PREPROCESSOR
+#endif // __MSVC_INT128_HPP

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -40,8 +40,7 @@
 #include <yvals_core.h>
 #if _STL_COMPILER_PREPROCESSOR
 #ifndef __cpp_lib_format
-#pragma message("The contents of <format> are available only in c++latest mode;")
-#pragma message("see https://github.com/microsoft/STL/issues/1814 for details.")
+#pragma message("The contents of <format> are available only with C++20 or later.")
 #else // ^^^ !defined(__cpp_lib_format) / defined(__cpp_lib_format) vvv
 
 #include <algorithm>

--- a/stl/inc/header-units.json
+++ b/stl/inc/header-units.json
@@ -5,6 +5,7 @@
     "Version": "1.0",
     "BuildAsHeaderUnits": [
         // "__msvc_all_public_headers.hpp", // for testing, not production
+        "__msvc_int128.hpp",
         "__msvc_system_error_abi.hpp",
         "__msvc_tzdb.hpp",
         "__msvc_xlocinfo_types.hpp",

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -983,7 +983,7 @@ namespace ranges {
     };
 
     template <incrementable _Wi>
-        requires integral<_Iota_diff_t<_Wi>> // TRANSITION, as yet unnumbered LWG issue
+        requires integral<_Iota_diff_t<_Wi>> // TRANSITION, LWG-3670
     struct _Ioterator_category_base<_Wi> {
         using iterator_category = input_iterator_tag;
 

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -955,7 +955,7 @@ namespace ranges {
     template <class _Ty>
     using _Iota_diff_t = conditional_t<is_integral_v<_Ty>,
         conditional_t<sizeof(_Ty) < sizeof(int), int,
-            conditional_t<sizeof(_Ty) < sizeof(long long), long long, _Int128>>,
+            conditional_t<sizeof(_Ty) < sizeof(long long), long long, _Signed128>>,
         iter_difference_t<_Ty>>;
 
     // clang-format off

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -12,6 +12,7 @@
 #pragma message("The contents of <ranges> are available only in c++latest mode;")
 #pragma message("see https://github.com/microsoft/STL/issues/1814 for details.")
 #else // ^^^ !defined(__cpp_lib_ranges) / defined(__cpp_lib_ranges) vvv
+#include <__msvc_int128.hpp>
 #include <iosfwd>
 #include <iterator>
 #include <limits>
@@ -953,7 +954,9 @@ namespace ranges {
     } // namespace views
 
     template <class _Ty>
-    using _Iota_diff_t = conditional_t<is_integral_v<_Ty>, conditional_t<(sizeof(_Ty) < sizeof(int)), int, long long>,
+    using _Iota_diff_t = conditional_t<is_integral_v<_Ty>,
+        conditional_t<sizeof(_Ty) < sizeof(int), int,
+            conditional_t<sizeof(_Ty) < sizeof(long long), long long, _Int128>>,
         iter_difference_t<_Ty>>;
 
     // clang-format off
@@ -981,6 +984,7 @@ namespace ranges {
     };
 
     template <incrementable _Wi>
+        requires integral<_Iota_diff_t<_Wi>> // TODO: LWG issue
     struct _Ioterator_category_base<_Wi> {
         using iterator_category = input_iterator_tag;
 

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -9,8 +9,7 @@
 #include <yvals_core.h>
 #if _STL_COMPILER_PREPROCESSOR
 #ifndef __cpp_lib_ranges
-#pragma message("The contents of <ranges> are available only in c++latest mode;")
-#pragma message("see https://github.com/microsoft/STL/issues/1814 for details.")
+#pragma message("The contents of <ranges> are available only with C++20 or later.")
 #else // ^^^ !defined(__cpp_lib_ranges) / defined(__cpp_lib_ranges) vvv
 #include <__msvc_int128.hpp>
 #include <iosfwd>
@@ -984,7 +983,7 @@ namespace ranges {
     };
 
     template <incrementable _Wi>
-        requires integral<_Iota_diff_t<_Wi>> // TODO: LWG issue
+        requires integral<_Iota_diff_t<_Wi>> // TRANSITION, as yet unnumbered LWG issue
     struct _Ioterator_category_base<_Wi> {
         using iterator_category = input_iterator_tag;
 

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -2725,10 +2725,8 @@ namespace ranges {
     inline constexpr bool enable_view =
         derived_from<_Ty, view_base> || _Derived_from_specialization_of<_Ty, view_interface>;
 
-#ifdef __cpp_lib_ranges // TRANSITION, GH-1814
     template <class _Ty>
     concept view = range<_Ty> && movable<_Ty> && enable_view<_Ty>;
-#endif // TRANSITION, GH-1814
 
     template <class _Rng, class _Ty>
     concept output_range = range<_Rng> && output_iterator<iterator_t<_Rng>, _Ty>;
@@ -3060,20 +3058,16 @@ namespace ranges {
         _NODISCARD constexpr _Derived& _Cast() noexcept {
             static_assert(derived_from<_Derived, view_interface>,
                 "view_interface's template argument D must derive from view_interface<D> (N4849 [view.interface]/2).");
-#ifdef __cpp_lib_ranges // TRANSITION, GH-1814
             static_assert(view<_Derived>,
                 "view_interface's template argument must model the view concept (N4849 [view.interface]/2).");
-#endif // TRANSITION, GH-1814
             return static_cast<_Derived&>(*this);
         }
 
         _NODISCARD constexpr const _Derived& _Cast() const noexcept {
             static_assert(derived_from<_Derived, view_interface>,
                 "view_interface's template argument D must derive from view_interface<D> (N4849 [view.interface]/2).");
-#ifdef __cpp_lib_ranges // TRANSITION, GH-1814
             static_assert(view<_Derived>,
                 "view_interface's template argument must model the view concept (N4849 [view.interface]/2).");
-#endif // TRANSITION, GH-1814
             return static_cast<const _Derived&>(*this);
         }
 

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -740,21 +740,49 @@ concept indirectly_writable = requires(_It&& __i, _Ty&& __t) {
 };
 
 template <class _Ty>
-concept _Integer_like = _Is_nonbool_integral<remove_cv_t<_Ty>>;
+inline constexpr bool _Integer_class = requires {
+    typename _Ty::_Signed_type;
+    typename _Ty::_Unsigned_type;
+};
+
+template <class _Ty>
+concept _Integer_like = _Is_nonbool_integral<remove_cv_t<_Ty>> || _Integer_class<_Ty>;
 
 template <class _Ty>
 concept _Signed_integer_like = _Integer_like<_Ty> && static_cast<_Ty>(-1) < static_cast<_Ty>(0);
 
+template <bool _Is_integer_class>
+struct _Make_unsigned_like_impl {
+    template <class _Ty>
+    using _Apply = typename _Ty::_Unsigned_type;
+};
+template <>
+struct _Make_unsigned_like_impl<false> {
+    template <class _Ty>
+    using _Apply = make_unsigned_t<_Ty>;
+};
+
 template <class _Ty>
-using _Make_unsigned_like_t = make_unsigned_t<_Ty>;
+using _Make_unsigned_like_t = typename _Make_unsigned_like_impl<_Integer_class<_Ty>>::template _Apply<_Ty>;
 
 template <_Integer_like _Ty>
 _NODISCARD constexpr auto _To_unsigned_like(const _Ty _Value) noexcept {
     return static_cast<_Make_unsigned_like_t<_Ty>>(_Value);
 }
 
+template <bool _Is_integer_class>
+struct _Make_signed_like_impl {
+    template <class _Ty>
+    using _Apply = typename _Ty::_Signed_type;
+};
+template <>
+struct _Make_signed_like_impl<false> {
+    template <class _Ty>
+    using _Apply = make_signed_t<_Ty>;
+};
+
 template <class _Ty>
-using _Make_signed_like_t = make_signed_t<_Ty>;
+using _Make_signed_like_t = typename _Make_signed_like_impl<_Integer_class<_Ty>>::template _Apply<_Ty>;
 
 template <_Integer_like _Ty>
 _NODISCARD constexpr auto _To_signed_like(const _Ty _Value) noexcept {

--- a/stl/inc/yvals.h
+++ b/stl/inc/yvals.h
@@ -206,11 +206,9 @@ _STL_DISABLE_CLANG_WARNINGS
 #endif // _DEBUG
 
 #ifdef _ENABLE_STL_INTERNAL_CHECK
-#define _STL_INTERNAL_CHECK(...)         _STL_VERIFY(__VA_ARGS__, "STL internal check: " #__VA_ARGS__)
-#define _STL_INTERNAL_STATIC_ASSERT(...) static_assert(__VA_ARGS__, #__VA_ARGS__)
+#define _STL_INTERNAL_CHECK(...) _STL_VERIFY(__VA_ARGS__, "STL internal check: " #__VA_ARGS__)
 #else // ^^^ _ENABLE_STL_INTERNAL_CHECK ^^^ // vvv !_ENABLE_STL_INTERNAL_CHECK vvv
 #define _STL_INTERNAL_CHECK(...) _Analysis_assume_(__VA_ARGS__)
-#define _STL_INTERNAL_STATIC_ASSERT(...)
 #endif // _ENABLE_STL_INTERNAL_CHECK
 
 #ifndef _ENABLE_ATOMIC_REF_ALIGNMENT_CHECK

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -1498,5 +1498,11 @@ compiler option, or define _ALLOW_RTCc_IN_STL to acknowledge that you have recei
 #define _STL_UNREACHABLE __assume(false)
 #endif // __clang__
 
+#ifdef _ENABLE_STL_INTERNAL_CHECK
+#define _STL_INTERNAL_STATIC_ASSERT(...) static_assert(__VA_ARGS__, #__VA_ARGS__)
+#else // ^^^ _ENABLE_STL_INTERNAL_CHECK ^^^ // vvv !_ENABLE_STL_INTERNAL_CHECK vvv
+#define _STL_INTERNAL_STATIC_ASSERT(...)
+#endif // _ENABLE_STL_INTERNAL_CHECK
+
 #endif // _STL_COMPILER_PREPROCESSOR
 #endif // _YVALS_CORE_H_

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -1291,9 +1291,9 @@
 #define __cpp_lib_endian                  201907L
 #define __cpp_lib_erase_if                202002L
 
-#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395 and GH-1814
+#if defined(__cpp_lib_concepts) // TRANSITION, GH-395
 #define __cpp_lib_format 202110L
-#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
+#endif // defined(__cpp_lib_concepts)
 
 #define __cpp_lib_generic_unordered_lookup     201811L
 #define __cpp_lib_int_pow2                     202002L
@@ -1321,9 +1321,9 @@
 #define __cpp_lib_math_constants          201907L
 #define __cpp_lib_polymorphic_allocator   201902L
 
-#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395 and GH-1814
+#if defined(__cpp_lib_concepts) // TRANSITION, GH-395
 #define __cpp_lib_ranges 202110L
-#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
+#endif // defined(__cpp_lib_concepts)
 
 #define __cpp_lib_remove_cvref            201711L
 #define __cpp_lib_semaphore               201907L

--- a/tests/std/test.lst
+++ b/tests/std/test.lst
@@ -449,6 +449,7 @@ tests\P1423R3_char8_t_remediation
 tests\P1425R4_queue_stack_constructors
 tests\P1502R1_standard_library_header_units
 tests\P1518R2_stop_overconstraining_allocators
+tests\P1522R1_difference_type
 tests\P1614R2_spaceship
 tests\P1645R1_constexpr_numeric
 tests\P1659R3_ranges_alg_ends_with

--- a/tests/std/tests/GH_000545_include_compare/env.lst
+++ b/tests/std/tests/GH_000545_include_compare/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\usual_latest_matrix.lst
+RUNALL_INCLUDE ..\usual_20_matrix.lst

--- a/tests/std/tests/GH_001914_cached_position/env.lst
+++ b/tests/std/tests/GH_001914_cached_position/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_20_matrix.lst

--- a/tests/std/tests/LWG3480_directory_iterator_range/env.lst
+++ b/tests/std/tests/LWG3480_directory_iterator_range/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_20_matrix.lst

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/env.lst
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/env.lst
@@ -1,6 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_20_matrix.lst
 RUNALL_CROSSLIST
 PM_CL="/utf-8"

--- a/tests/std/tests/P0645R10_text_formatting_args/env.lst
+++ b/tests/std/tests/P0645R10_text_formatting_args/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_20_matrix.lst

--- a/tests/std/tests/P0645R10_text_formatting_custom_formatting/env.lst
+++ b/tests/std/tests/P0645R10_text_formatting_custom_formatting/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_20_matrix.lst

--- a/tests/std/tests/P0645R10_text_formatting_death/env.lst
+++ b/tests/std/tests/P0645R10_text_formatting_death/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_winsdk_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\strict_winsdk_concepts_20_matrix.lst

--- a/tests/std/tests/P0645R10_text_formatting_formatting/env.lst
+++ b/tests/std/tests/P0645R10_text_formatting_formatting/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_20_matrix.lst

--- a/tests/std/tests/P0645R10_text_formatting_legacy_text_encoding/env.lst
+++ b/tests/std/tests/P0645R10_text_formatting_legacy_text_encoding/env.lst
@@ -1,29 +1,29 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-# This is `concepts_latest_matrix.lst` with `/execution-charset:.932` added.
+# This is `concepts_20_matrix.lst` with `/execution-charset:.932` added.
 # clang is excluded since it doesn't support non-UTF-8 execution charsets.
 
 RUNALL_INCLUDE ..\prefix.lst
 RUNALL_CROSSLIST
-PM_CL="/w14640 /Zc:threadSafeInit- /EHsc /std:c++latest /execution-charset:.932"
+PM_CL="/w14640 /Zc:threadSafeInit- /EHsc /execution-charset:.932"
 RUNALL_CROSSLIST
-PM_CL="/MD /D_ITERATOR_DEBUG_LEVEL=0 /permissive- /Zc:noexceptTypes-"
-PM_CL="/MD /D_ITERATOR_DEBUG_LEVEL=1 /permissive-"
-PM_CL="/MD /D_ITERATOR_DEBUG_LEVEL=0 /permissive- /Zc:char8_t- /Zc:preprocessor"
-PM_CL="/MDd /D_ITERATOR_DEBUG_LEVEL=0 /permissive- /Zc:wchar_t-"
-PM_CL="/MDd /D_ITERATOR_DEBUG_LEVEL=1 /permissive-"
-PM_CL="/MDd /D_ITERATOR_DEBUG_LEVEL=2 /permissive- /fp:except /Zc:preprocessor"
-PM_CL="/MT /D_ITERATOR_DEBUG_LEVEL=0 /permissive-"
-PM_CL="/MT /D_ITERATOR_DEBUG_LEVEL=0 /permissive- /analyze:only /analyze:autolog-"
-PM_CL="/MT /D_ITERATOR_DEBUG_LEVEL=1 /permissive-"
-PM_CL="/MTd /D_ITERATOR_DEBUG_LEVEL=0 /permissive- /fp:strict"
-PM_CL="/MTd /D_ITERATOR_DEBUG_LEVEL=1 /permissive-"
-PM_CL="/MTd /D_ITERATOR_DEBUG_LEVEL=2 /permissive"
-PM_CL="/MTd /D_ITERATOR_DEBUG_LEVEL=2 /permissive- /analyze:only /analyze:autolog-"
-PM_CL="/permissive- /Za /MD"
-PM_CL="/permissive- /Za /MDd"
-# PM_CL="/permissive- /BE /c /MD"
-# PM_CL="/permissive- /BE /c /MTd"
-# PM_COMPILER="clang-cl" PM_CL="-fno-ms-compatibility -fno-delayed-template-parsing /permissive- /D_HAS_CXX23 /MD"
-# PM_COMPILER="clang-cl" PM_CL="-fno-ms-compatibility -fno-delayed-template-parsing /permissive- /D_HAS_CXX23 /MTd /fp:strict"
+PM_CL="/MD /D_ITERATOR_DEBUG_LEVEL=0 /std:c++20 /permissive- /Zc:noexceptTypes-"
+PM_CL="/MD /D_ITERATOR_DEBUG_LEVEL=1 /std:c++latest /permissive-"
+PM_CL="/MD /D_ITERATOR_DEBUG_LEVEL=0 /std:c++latest /permissive- /Zc:char8_t- /Zc:preprocessor"
+PM_CL="/MDd /D_ITERATOR_DEBUG_LEVEL=0 /std:c++latest /permissive- /Zc:wchar_t-"
+PM_CL="/MDd /D_ITERATOR_DEBUG_LEVEL=1 /std:c++latest /permissive-"
+PM_CL="/MDd /D_ITERATOR_DEBUG_LEVEL=2 /std:c++20 /permissive- /fp:except /Zc:preprocessor"
+PM_CL="/MT /D_ITERATOR_DEBUG_LEVEL=0 /std:c++latest /permissive-"
+PM_CL="/MT /D_ITERATOR_DEBUG_LEVEL=0 /std:c++latest /permissive- /analyze:only /analyze:autolog-"
+PM_CL="/MT /D_ITERATOR_DEBUG_LEVEL=1 /std:c++latest /permissive-"
+PM_CL="/MTd /D_ITERATOR_DEBUG_LEVEL=0 /std:c++latest /permissive- /fp:strict"
+PM_CL="/MTd /D_ITERATOR_DEBUG_LEVEL=1 /std:c++latest /permissive-"
+PM_CL="/MTd /D_ITERATOR_DEBUG_LEVEL=2 /std:c++latest /permissive"
+PM_CL="/MTd /D_ITERATOR_DEBUG_LEVEL=2 /std:c++latest /permissive- /analyze:only /analyze:autolog-"
+PM_CL="/std:c++20 /permissive- /Za /MD"
+PM_CL="/std:c++latest /permissive- /Za /MDd"
+# PM_CL="/std:c++20 /permissive- /BE /c /MD"
+# PM_CL="/std:c++latest /permissive- /BE /c /MTd"
+# PM_COMPILER="clang-cl" PM_CL="-fno-ms-compatibility -fno-delayed-template-parsing /std:c++latest /permissive- /MD"
+# PM_COMPILER="clang-cl" PM_CL="-fno-ms-compatibility -fno-delayed-template-parsing /std:c++latest /permissive- /D_HAS_CXX23 /MTd /fp:strict"

--- a/tests/std/tests/P0645R10_text_formatting_parse_contexts/env.lst
+++ b/tests/std/tests/P0645R10_text_formatting_parse_contexts/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_20_matrix.lst

--- a/tests/std/tests/P0645R10_text_formatting_parsing/env.lst
+++ b/tests/std/tests/P0645R10_text_formatting_parsing/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_20_matrix.lst

--- a/tests/std/tests/P0645R10_text_formatting_utf8/env.lst
+++ b/tests/std/tests/P0645R10_text_formatting_utf8/env.lst
@@ -1,6 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_20_matrix.lst
 RUNALL_CROSSLIST
 PM_CL="/utf-8"

--- a/tests/std/tests/P0896R4_istream_view/env.lst
+++ b/tests/std/tests/P0896R4_istream_view/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_20_matrix.lst

--- a/tests/std/tests/P0896R4_istream_view_death/env.lst
+++ b/tests/std/tests/P0896R4_istream_view_death/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_winsdk_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\strict_winsdk_concepts_20_matrix.lst

--- a/tests/std/tests/P0896R4_ranges_alg_uninitialized_copy_n/env.lst
+++ b/tests/std/tests/P0896R4_ranges_alg_uninitialized_copy_n/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_20_matrix.lst

--- a/tests/std/tests/P0896R4_ranges_alg_uninitialized_move_n/env.lst
+++ b/tests/std/tests/P0896R4_ranges_alg_uninitialized_move_n/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_20_matrix.lst

--- a/tests/std/tests/P0896R4_ranges_range_machinery/env.lst
+++ b/tests/std/tests/P0896R4_ranges_range_machinery/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_20_matrix.lst

--- a/tests/std/tests/P0896R4_ranges_ref_view/env.lst
+++ b/tests/std/tests/P0896R4_ranges_ref_view/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_20_matrix.lst

--- a/tests/std/tests/P0896R4_ranges_subrange/env.lst
+++ b/tests/std/tests/P0896R4_ranges_subrange/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_20_matrix.lst

--- a/tests/std/tests/P0896R4_views_all/env.lst
+++ b/tests/std/tests/P0896R4_views_all/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_20_matrix.lst

--- a/tests/std/tests/P0896R4_views_common/env.lst
+++ b/tests/std/tests/P0896R4_views_common/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\strict_concepts_20_matrix.lst

--- a/tests/std/tests/P0896R4_views_counted/env.lst
+++ b/tests/std/tests/P0896R4_views_counted/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\strict_concepts_20_matrix.lst

--- a/tests/std/tests/P0896R4_views_counted_death/env.lst
+++ b/tests/std/tests/P0896R4_views_counted_death/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_winsdk_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\strict_winsdk_concepts_20_matrix.lst

--- a/tests/std/tests/P0896R4_views_drop/env.lst
+++ b/tests/std/tests/P0896R4_views_drop/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\strict_concepts_20_matrix.lst

--- a/tests/std/tests/P0896R4_views_drop_while/env.lst
+++ b/tests/std/tests/P0896R4_views_drop_while/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_20_matrix.lst

--- a/tests/std/tests/P0896R4_views_drop_while_death/env.lst
+++ b/tests/std/tests/P0896R4_views_drop_while_death/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_winsdk_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\strict_winsdk_concepts_20_matrix.lst

--- a/tests/std/tests/P0896R4_views_elements/env.lst
+++ b/tests/std/tests/P0896R4_views_elements/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\strict_concepts_20_matrix.lst

--- a/tests/std/tests/P0896R4_views_empty/env.lst
+++ b/tests/std/tests/P0896R4_views_empty/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_20_matrix.lst

--- a/tests/std/tests/P0896R4_views_filter/env.lst
+++ b/tests/std/tests/P0896R4_views_filter/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\strict_concepts_20_matrix.lst

--- a/tests/std/tests/P0896R4_views_filter_death/env.lst
+++ b/tests/std/tests/P0896R4_views_filter_death/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_winsdk_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\strict_winsdk_concepts_20_matrix.lst

--- a/tests/std/tests/P0896R4_views_filter_iterator/env.lst
+++ b/tests/std/tests/P0896R4_views_filter_iterator/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\strict_concepts_20_matrix.lst

--- a/tests/std/tests/P0896R4_views_iota/env.lst
+++ b/tests/std/tests/P0896R4_views_iota/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\strict_concepts_20_matrix.lst

--- a/tests/std/tests/P0896R4_views_iota/test.cpp
+++ b/tests/std/tests/P0896R4_views_iota/test.cpp
@@ -54,7 +54,7 @@ constexpr void test_integral() {
         } else if constexpr (sizeof(T) < sizeof(long long)) {
             static_assert(same_as<ranges::range_difference_t<R>, long long>);
         } else {
-            static_assert(same_as<ranges::range_difference_t<R>, std::_Int128>);
+            static_assert(same_as<ranges::range_difference_t<R>, std::_Signed128>);
         }
 
         // iota_view is always a simple-view, i.e., const and non-const are always valid ranges with the same iterators:
@@ -220,7 +220,7 @@ constexpr void test_integral() {
         } else if constexpr (sizeof(T) < sizeof(long long)) {
             static_assert(same_as<ranges::range_difference_t<R>, long long>);
         } else {
-            static_assert(same_as<ranges::range_difference_t<R>, std::_Int128>);
+            static_assert(same_as<ranges::range_difference_t<R>, std::_Signed128>);
         }
 
         {

--- a/tests/std/tests/P0896R4_views_iota/test.cpp
+++ b/tests/std/tests/P0896R4_views_iota/test.cpp
@@ -10,6 +10,8 @@
 
 using namespace std;
 
+static_assert(ranges::_Advanceable<long long>);
+
 template <class W, class B>
 concept CanViewIota = requires(W w, B b) {
     views::iota(w, b);
@@ -49,8 +51,10 @@ constexpr void test_integral() {
 
         if constexpr (sizeof(T) < sizeof(int)) {
             static_assert(same_as<ranges::range_difference_t<R>, int>);
-        } else {
+        } else if constexpr (sizeof(T) < sizeof(long long)) {
             static_assert(same_as<ranges::range_difference_t<R>, long long>);
+        } else {
+            static_assert(same_as<ranges::range_difference_t<R>, std::_Int128>);
         }
 
         // iota_view is always a simple-view, i.e., const and non-const are always valid ranges with the same iterators:
@@ -73,7 +77,9 @@ constexpr void test_integral() {
 
         using I = ranges::iterator_t<R>;
         static_assert(same_as<typename I::iterator_concept, random_access_iterator_tag>);
-        static_assert(same_as<typename iterator_traits<I>::iterator_category, input_iterator_tag>);
+        if constexpr (integral<iter_difference_t<I>>) {
+            static_assert(same_as<typename iterator_traits<I>::iterator_category, input_iterator_tag>);
+        }
 
         assert(I{} == I{T{0}});
         static_assert(is_nothrow_default_constructible_v<I>);
@@ -211,8 +217,10 @@ constexpr void test_integral() {
 
         if constexpr (sizeof(T) < sizeof(int)) {
             static_assert(same_as<ranges::range_difference_t<R>, int>);
-        } else {
+        } else if constexpr (sizeof(T) < sizeof(long long)) {
             static_assert(same_as<ranges::range_difference_t<R>, long long>);
+        } else {
+            static_assert(same_as<ranges::range_difference_t<R>, std::_Int128>);
         }
 
         {

--- a/tests/std/tests/P0896R4_views_join/env.lst
+++ b/tests/std/tests/P0896R4_views_join/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\strict_concepts_20_matrix.lst

--- a/tests/std/tests/P0896R4_views_lazy_split/env.lst
+++ b/tests/std/tests/P0896R4_views_lazy_split/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\strict_concepts_20_matrix.lst

--- a/tests/std/tests/P0896R4_views_reverse/env.lst
+++ b/tests/std/tests/P0896R4_views_reverse/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\strict_concepts_20_matrix.lst

--- a/tests/std/tests/P0896R4_views_single/env.lst
+++ b/tests/std/tests/P0896R4_views_single/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_20_matrix.lst

--- a/tests/std/tests/P0896R4_views_split/env.lst
+++ b/tests/std/tests/P0896R4_views_split/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\strict_concepts_20_matrix.lst

--- a/tests/std/tests/P0896R4_views_split/test.cpp
+++ b/tests/std/tests/P0896R4_views_split/test.cpp
@@ -285,7 +285,7 @@ constexpr bool instantiation_test() {
     instantiator::call<test_range<forward_iterator_tag, Common::yes, CanView::yes, Copyability::copyable>>();
 
     { // ensure we get something contiguous
-        for (string_view sv : "127..0..0..1"sv | views::split(".."sv)) {
+        for (ranges::contiguous_range auto sv : "127..0..0..1"sv | views::split(".."sv)) {
             assert(!sv.empty());
         }
     }

--- a/tests/std/tests/P0896R4_views_take/env.lst
+++ b/tests/std/tests/P0896R4_views_take/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\strict_concepts_20_matrix.lst

--- a/tests/std/tests/P0896R4_views_take_while/env.lst
+++ b/tests/std/tests/P0896R4_views_take_while/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\strict_concepts_20_matrix.lst

--- a/tests/std/tests/P0896R4_views_take_while_death/env.lst
+++ b/tests/std/tests/P0896R4_views_take_while_death/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_winsdk_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\strict_winsdk_concepts_20_matrix.lst

--- a/tests/std/tests/P0896R4_views_transform/env.lst
+++ b/tests/std/tests/P0896R4_views_transform/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\strict_concepts_20_matrix.lst

--- a/tests/std/tests/P0896R4_views_transform_death/env.lst
+++ b/tests/std/tests/P0896R4_views_transform_death/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_winsdk_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\strict_winsdk_concepts_20_matrix.lst

--- a/tests/std/tests/P1522R1_difference_type/env.lst
+++ b/tests/std/tests/P1522R1_difference_type/env.lst
@@ -1,0 +1,4 @@
+# Copyright(c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+RUNALL_INCLUDE ..\concepts_20_matrix.lst

--- a/tests/std/tests/P1522R1_difference_type/env.lst
+++ b/tests/std/tests/P1522R1_difference_type/env.lst
@@ -1,4 +1,4 @@
-# Copyright(c) Microsoft Corporation.
+# Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 RUNALL_INCLUDE ..\concepts_20_matrix.lst

--- a/tests/std/tests/P1522R1_difference_type/env.lst
+++ b/tests/std/tests/P1522R1_difference_type/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\concepts_20_matrix.lst
+RUNALL_INCLUDE ..\strict_concepts_20_matrix.lst

--- a/tests/std/tests/P1522R1_difference_type/test.cpp
+++ b/tests/std/tests/P1522R1_difference_type/test.cpp
@@ -10,8 +10,8 @@
 #include <limits>
 #include <type_traits>
 
-using std::_Int128;
-using std::_Uint128;
+using std::_Signed128;
+using std::_Unsigned128;
 
 constexpr void check_equal(const auto& x) {
     assert(x == x);
@@ -43,76 +43,76 @@ constexpr void check_order(const auto& x, const auto& y, const std::strong_order
 }
 
 constexpr bool test_unsigned() {
-    static_assert(std::regular<_Uint128>);
-    static_assert(std::three_way_comparable<_Uint128, std::strong_ordering>);
+    static_assert(std::regular<_Unsigned128>);
+    static_assert(std::three_way_comparable<_Unsigned128, std::strong_ordering>);
 
-    static_assert(std::numeric_limits<_Uint128>::min() == 0);
-    static_assert(std::numeric_limits<_Uint128>::max() == ~_Uint128{});
-    static_assert(std::numeric_limits<_Uint128>::digits == 128);
-    static_assert(std::numeric_limits<_Uint128>::is_modulo);
+    static_assert(std::numeric_limits<_Unsigned128>::min() == 0);
+    static_assert(std::numeric_limits<_Unsigned128>::max() == ~_Unsigned128{});
+    static_assert(std::numeric_limits<_Unsigned128>::digits == 128);
+    static_assert(std::numeric_limits<_Unsigned128>::is_modulo);
 
-    static_assert(std::same_as<std::common_type_t<bool, _Uint128>, _Uint128>);
-    static_assert(std::same_as<std::common_type_t<char, _Uint128>, _Uint128>);
-    static_assert(std::same_as<std::common_type_t<signed char, _Uint128>, _Uint128>);
-    static_assert(std::same_as<std::common_type_t<unsigned char, _Uint128>, _Uint128>);
-    static_assert(std::same_as<std::common_type_t<wchar_t, _Uint128>, _Uint128>);
+    static_assert(std::same_as<std::common_type_t<bool, _Unsigned128>, _Unsigned128>);
+    static_assert(std::same_as<std::common_type_t<char, _Unsigned128>, _Unsigned128>);
+    static_assert(std::same_as<std::common_type_t<signed char, _Unsigned128>, _Unsigned128>);
+    static_assert(std::same_as<std::common_type_t<unsigned char, _Unsigned128>, _Unsigned128>);
+    static_assert(std::same_as<std::common_type_t<wchar_t, _Unsigned128>, _Unsigned128>);
 #ifdef __cpp_char8_t
-    static_assert(std::same_as<std::common_type_t<char8_t, _Uint128>, _Uint128>);
+    static_assert(std::same_as<std::common_type_t<char8_t, _Unsigned128>, _Unsigned128>);
 #endif // __cpp_char8_t
-    static_assert(std::same_as<std::common_type_t<char16_t, _Uint128>, _Uint128>);
-    static_assert(std::same_as<std::common_type_t<char32_t, _Uint128>, _Uint128>);
-    static_assert(std::same_as<std::common_type_t<short, _Uint128>, _Uint128>);
-    static_assert(std::same_as<std::common_type_t<unsigned short, _Uint128>, _Uint128>);
-    static_assert(std::same_as<std::common_type_t<int, _Uint128>, _Uint128>);
-    static_assert(std::same_as<std::common_type_t<unsigned int, _Uint128>, _Uint128>);
-    static_assert(std::same_as<std::common_type_t<long, _Uint128>, _Uint128>);
-    static_assert(std::same_as<std::common_type_t<unsigned long, _Uint128>, _Uint128>);
-    static_assert(std::same_as<std::common_type_t<long long, _Uint128>, _Uint128>);
-    static_assert(std::same_as<std::common_type_t<unsigned long long, _Uint128>, _Uint128>);
-    static_assert(std::same_as<std::common_type_t<_Int128, _Uint128>, _Uint128>);
+    static_assert(std::same_as<std::common_type_t<char16_t, _Unsigned128>, _Unsigned128>);
+    static_assert(std::same_as<std::common_type_t<char32_t, _Unsigned128>, _Unsigned128>);
+    static_assert(std::same_as<std::common_type_t<short, _Unsigned128>, _Unsigned128>);
+    static_assert(std::same_as<std::common_type_t<unsigned short, _Unsigned128>, _Unsigned128>);
+    static_assert(std::same_as<std::common_type_t<int, _Unsigned128>, _Unsigned128>);
+    static_assert(std::same_as<std::common_type_t<unsigned int, _Unsigned128>, _Unsigned128>);
+    static_assert(std::same_as<std::common_type_t<long, _Unsigned128>, _Unsigned128>);
+    static_assert(std::same_as<std::common_type_t<unsigned long, _Unsigned128>, _Unsigned128>);
+    static_assert(std::same_as<std::common_type_t<long long, _Unsigned128>, _Unsigned128>);
+    static_assert(std::same_as<std::common_type_t<unsigned long long, _Unsigned128>, _Unsigned128>);
+    static_assert(std::same_as<std::common_type_t<_Signed128, _Unsigned128>, _Unsigned128>);
 
-    static_assert(std::same_as<std::common_type_t<_Uint128, bool>, _Uint128>);
-    static_assert(std::same_as<std::common_type_t<_Uint128, char>, _Uint128>);
-    static_assert(std::same_as<std::common_type_t<_Uint128, signed char>, _Uint128>);
-    static_assert(std::same_as<std::common_type_t<_Uint128, unsigned char>, _Uint128>);
-    static_assert(std::same_as<std::common_type_t<_Uint128, wchar_t>, _Uint128>);
+    static_assert(std::same_as<std::common_type_t<_Unsigned128, bool>, _Unsigned128>);
+    static_assert(std::same_as<std::common_type_t<_Unsigned128, char>, _Unsigned128>);
+    static_assert(std::same_as<std::common_type_t<_Unsigned128, signed char>, _Unsigned128>);
+    static_assert(std::same_as<std::common_type_t<_Unsigned128, unsigned char>, _Unsigned128>);
+    static_assert(std::same_as<std::common_type_t<_Unsigned128, wchar_t>, _Unsigned128>);
 #ifdef __cpp_char8_t
-    static_assert(std::same_as<std::common_type_t<_Uint128, char8_t>, _Uint128>);
+    static_assert(std::same_as<std::common_type_t<_Unsigned128, char8_t>, _Unsigned128>);
 #endif // __cpp_char8_t
-    static_assert(std::same_as<std::common_type_t<_Uint128, char16_t>, _Uint128>);
-    static_assert(std::same_as<std::common_type_t<_Uint128, char32_t>, _Uint128>);
-    static_assert(std::same_as<std::common_type_t<_Uint128, short>, _Uint128>);
-    static_assert(std::same_as<std::common_type_t<_Uint128, unsigned short>, _Uint128>);
-    static_assert(std::same_as<std::common_type_t<_Uint128, int>, _Uint128>);
-    static_assert(std::same_as<std::common_type_t<_Uint128, unsigned int>, _Uint128>);
-    static_assert(std::same_as<std::common_type_t<_Uint128, long>, _Uint128>);
-    static_assert(std::same_as<std::common_type_t<_Uint128, unsigned long>, _Uint128>);
-    static_assert(std::same_as<std::common_type_t<_Uint128, long long>, _Uint128>);
-    static_assert(std::same_as<std::common_type_t<_Uint128, unsigned long long>, _Uint128>);
-    static_assert(std::same_as<std::common_type_t<_Uint128, _Int128>, _Uint128>);
+    static_assert(std::same_as<std::common_type_t<_Unsigned128, char16_t>, _Unsigned128>);
+    static_assert(std::same_as<std::common_type_t<_Unsigned128, char32_t>, _Unsigned128>);
+    static_assert(std::same_as<std::common_type_t<_Unsigned128, short>, _Unsigned128>);
+    static_assert(std::same_as<std::common_type_t<_Unsigned128, unsigned short>, _Unsigned128>);
+    static_assert(std::same_as<std::common_type_t<_Unsigned128, int>, _Unsigned128>);
+    static_assert(std::same_as<std::common_type_t<_Unsigned128, unsigned int>, _Unsigned128>);
+    static_assert(std::same_as<std::common_type_t<_Unsigned128, long>, _Unsigned128>);
+    static_assert(std::same_as<std::common_type_t<_Unsigned128, unsigned long>, _Unsigned128>);
+    static_assert(std::same_as<std::common_type_t<_Unsigned128, long long>, _Unsigned128>);
+    static_assert(std::same_as<std::common_type_t<_Unsigned128, unsigned long long>, _Unsigned128>);
+    static_assert(std::same_as<std::common_type_t<_Unsigned128, _Signed128>, _Unsigned128>);
 
-    static_assert(std::_Integer_class<_Uint128>);
-    static_assert(std::_Integer_like<_Uint128>);
-    static_assert(!std::_Signed_integer_like<_Uint128>);
-    static_assert(std::same_as<std::_Make_unsigned_like_t<_Uint128>, _Uint128>);
-    static_assert(std::same_as<std::_Make_signed_like_t<_Uint128>, _Int128>);
+    static_assert(std::_Integer_class<_Unsigned128>);
+    static_assert(std::_Integer_like<_Unsigned128>);
+    static_assert(!std::_Signed_integer_like<_Unsigned128>);
+    static_assert(std::same_as<std::_Make_unsigned_like_t<_Unsigned128>, _Unsigned128>);
+    static_assert(std::same_as<std::_Make_signed_like_t<_Unsigned128>, _Signed128>);
 
-    check_equal(_Uint128{});
-    check_equal(_Uint128{42});
-    check_equal(_Uint128{-42});
-    check_equal(_Uint128{0x11111111'11111111, 0x22222222'22222222});
+    check_equal(_Unsigned128{});
+    check_equal(_Unsigned128{42});
+    check_equal(_Unsigned128{-42});
+    check_equal(_Unsigned128{0x11111111'11111111, 0x22222222'22222222});
 
-    check_order(_Uint128{42}, _Uint128{-42}, std::strong_ordering::less);
-    check_order(_Uint128{0, 42}, _Uint128{0, 52}, std::strong_ordering::less); // ordered only by MSW
-    check_order(_Uint128{42}, _Uint128{52}, std::strong_ordering::less); // ordered only by LSW
-    check_order(_Uint128{0x11111111'11111111, 0x22222222'22222222}, _Uint128{0x01010101'01010101, 0x01010101'01010101},
-        std::strong_ordering::greater);
+    check_order(_Unsigned128{42}, _Unsigned128{-42}, std::strong_ordering::less);
+    check_order(_Unsigned128{0, 42}, _Unsigned128{0, 52}, std::strong_ordering::less); // ordered only by MSW
+    check_order(_Unsigned128{42}, _Unsigned128{52}, std::strong_ordering::less); // ordered only by LSW
+    check_order(_Unsigned128{0x11111111'11111111, 0x22222222'22222222},
+        _Unsigned128{0x01010101'01010101, 0x01010101'01010101}, std::strong_ordering::greater);
 
     {
-        _Uint128 u{42};
+        _Unsigned128 u{42};
         assert(u._Word[0] == 42);
         assert(u._Word[1] == 0);
-        u += _Uint128{0};
+        u += _Unsigned128{0};
         assert(u._Word[0] == 42);
         assert(u._Word[1] == 0);
 
@@ -126,7 +126,7 @@ constexpr bool test_unsigned() {
         assert(static_cast<std::int16_t>(u) == 42);
         assert(static_cast<std::int8_t>(u) == 42);
 
-        _Uint128 nu{-42};
+        _Unsigned128 nu{-42};
         assert(nu._Word[0] == 0ull - 42);
         assert(nu._Word[1] == ~0ull);
 
@@ -140,7 +140,7 @@ constexpr bool test_unsigned() {
         assert(static_cast<std::int16_t>(nu) == -42);
         assert(static_cast<std::int8_t>(nu) == -42);
         {
-            _Uint128 sum = u + nu;
+            _Unsigned128 sum = u + nu;
             assert(sum._Word[0] == 0);
             assert(sum._Word[1] == 0);
 
@@ -158,7 +158,7 @@ constexpr bool test_unsigned() {
             assert(sum._Word[1] == 0);
         }
         {
-            _Uint128 product = u * u;
+            _Unsigned128 product = u * u;
             assert(product._Word[0] == 42 * 42);
             assert(product._Word[1] == 0);
 
@@ -166,23 +166,23 @@ constexpr bool test_unsigned() {
             assert(product._Word[0] == 42 * 42);
             assert(product._Word[1] == 0);
 
-            product = _Uint128{0x01010101'01010101, 0x01010101'01010101} * 5;
+            product = _Unsigned128{0x01010101'01010101, 0x01010101'01010101} * 5;
             assert(product._Word[0] == 0x05050505'05050505);
             assert(product._Word[1] == 0x05050505'05050505);
 
-            product = 5 * _Uint128{0x01010101'01010101, 0x01010101'01010101};
+            product = 5 * _Unsigned128{0x01010101'01010101, 0x01010101'01010101};
             assert(product._Word[0] == 0x05050505'05050505);
             assert(product._Word[1] == 0x05050505'05050505);
 
-            product = _Uint128{0x01010101'01010101, 0x01010101'01010101};
+            product = _Unsigned128{0x01010101'01010101, 0x01010101'01010101};
             product *= product;
             assert(product._Word[0] == 0x08070605'04030201);
             assert(product._Word[1] == 0x100f0e0d'0c0b0a09);
             assert(+product == product);
             assert(-product + product == 0);
 
-            product =
-                _Uint128{0x01020304'05060708, 0x090a0b0c'0d0e0f00} * _Uint128{0x000f0e0d'0c0b0a09, 0x08070605'04030201};
+            product = _Unsigned128{0x01020304'05060708, 0x090a0b0c'0d0e0f00}
+                    * _Unsigned128{0x000f0e0d'0c0b0a09, 0x08070605'04030201};
             assert(product._Word[0] == 0x6dc18e55'16d48f48);
             assert(product._Word[1] == 0xdc1b6bce'43cd6c21);
             assert(+product == product);
@@ -202,88 +202,89 @@ constexpr bool test_unsigned() {
         }
     }
     {
-        _Uint128 q = _Uint128{13} / _Uint128{4};
+        _Unsigned128 q = _Unsigned128{13} / _Unsigned128{4};
         assert(q._Word[0] == 3);
         assert(q._Word[1] == 0);
 
-        q = _Uint128{4} / _Uint128{13};
+        q = _Unsigned128{4} / _Unsigned128{13};
         assert(q._Word[0] == 0);
         assert(q._Word[1] == 0);
 
-        q = _Uint128{0x01010101'01010101, 0x01010101'01010101} / _Uint128{13};
+        q = _Unsigned128{0x01010101'01010101, 0x01010101'01010101} / _Unsigned128{13};
         assert(q._Word[0] == 0xc50013c5'0013c500);
         assert(q._Word[1] == 0x0013c500'13c50013);
 
-        q = _Uint128{0x22222222'22222222, 0x22222222'22222222} / _Uint128{0x11111111'11111111, 0x11111111'11111111};
+        q = _Unsigned128{0x22222222'22222222, 0x22222222'22222222}
+          / _Unsigned128{0x11111111'11111111, 0x11111111'11111111};
         assert(q._Word[0] == 2);
         assert(q._Word[1] == 0);
 
-        q = (_Uint128{1} << 66) / (_Uint128{1} << 13);
+        q = (_Unsigned128{1} << 66) / (_Unsigned128{1} << 13);
         assert(q._Word[0] == 1ull << 53);
         assert(q._Word[1] == 0);
     }
     {
-        auto tmp = ~_Uint128{};
+        auto tmp = ~_Unsigned128{};
         assert(tmp._Word[0] == ~0ull);
         assert(tmp._Word[1] == ~0ull);
         auto q = tmp / std::uint32_t{1};
         assert(q == tmp);
         q = tmp / std::uint64_t{1};
         assert(q == tmp);
-        q = tmp / _Uint128{1};
+        q = tmp / _Unsigned128{1};
         assert(q == tmp);
 
-        q = tmp / _Uint128{1ull << 32};
+        q = tmp / _Unsigned128{1ull << 32};
         assert(q._Word[0] == ~0ull);
         assert(q._Word[1] == 0xffffffff);
     }
     {
-        _Uint128 result{0x01010101'01010101, 0x01010101'01010101};
-        _Uint128 tmp;
+        _Unsigned128 result{0x01010101'01010101, 0x01010101'01010101};
+        _Unsigned128 tmp;
         for (tmp = 0xffu; static_cast<bool>(tmp); tmp <<= 8, result >>= 8) {
-            auto q = ~_Uint128{} / tmp;
+            auto q = ~_Unsigned128{} / tmp;
             assert(q == result);
-            auto m    = ~_Uint128{} % tmp;
+            auto m    = ~_Unsigned128{} % tmp;
             auto p    = q * tmp;
-            auto diff = ~_Uint128{} - p;
+            auto diff = ~_Unsigned128{} - p;
             assert(m == diff);
         }
         assert(tmp == 0);
     }
     {
-        _Uint128 tmp;
+        _Unsigned128 tmp;
         for (tmp = 1; static_cast<bool>(tmp); tmp <<= 1) {
             assert(tmp % tmp == 0);
         }
         assert(tmp == 0);
     }
     {
-        const _Uint128 x{0x01020304'02030405, 0x03040506'04050607};
-        const _Uint128 y{0x07060504'06050403, 0x05040302'04030101};
-        assert(((x & y) == _Uint128{0x01020104'02010401, 0x01040102'04010001}));
+        const _Unsigned128 x{0x01020304'02030405, 0x03040506'04050607};
+        const _Unsigned128 y{0x07060504'06050403, 0x05040302'04030101};
+        assert(((x & y) == _Unsigned128{0x01020104'02010401, 0x01040102'04010001}));
         auto tmp = x;
         tmp &= y;
         assert(tmp == (x & y));
 
-        assert(((x | y) == _Uint128{0x07060704'06070407, 0x07040706'04070707}));
+        assert(((x | y) == _Unsigned128{0x07060704'06070407, 0x07040706'04070707}));
         tmp = x;
         tmp |= y;
         assert(tmp == (x | y));
 
-        assert(((x ^ y) == _Uint128{0x06040600'04060006, 0x06000604'00060706}));
+        assert(((x ^ y) == _Unsigned128{0x06040600'04060006, 0x06000604'00060706}));
         tmp = x;
         tmp ^= y;
         assert(tmp == (x ^ y));
     }
     {
-        _Uint128 x{};
+        _Unsigned128 x{};
         assert(++x == 1);
         assert(--x == 0);
-        assert(x == std::numeric_limits<_Uint128>::min());
+        assert(x == std::numeric_limits<_Unsigned128>::min());
         --x;
         assert(x._Word[0] == ~0ull);
         assert(x._Word[1] == ~0ull);
-        assert(x == std::numeric_limits<_Uint128>::max());
+        assert(x == std::numeric_limits<_Unsigned128>::max());
         --x;
         assert(x._Word[0] == (~0ull << 1));
         assert(x._Word[1] == ~0ull);
@@ -312,95 +313,95 @@ constexpr bool test_unsigned() {
 }
 
 constexpr bool test_signed() {
-    static_assert(std::regular<_Int128>);
-    static_assert(std::three_way_comparable<_Int128, std::strong_ordering>);
+    static_assert(std::regular<_Signed128>);
+    static_assert(std::three_way_comparable<_Signed128, std::strong_ordering>);
 
-    static_assert(std::numeric_limits<_Int128>::min() == _Int128{0, 1ull << 63});
-    static_assert(std::numeric_limits<_Int128>::max() == _Int128{~0ull, ~0ull >> 1});
-    static_assert(std::numeric_limits<_Int128>::digits == 127);
-    static_assert(!std::numeric_limits<_Int128>::is_modulo);
+    static_assert(std::numeric_limits<_Signed128>::min() == _Signed128{0, 1ull << 63});
+    static_assert(std::numeric_limits<_Signed128>::max() == _Signed128{~0ull, ~0ull >> 1});
+    static_assert(std::numeric_limits<_Signed128>::digits == 127);
+    static_assert(!std::numeric_limits<_Signed128>::is_modulo);
 
-    static_assert(std::same_as<std::common_type_t<bool, _Int128>, _Int128>);
-    static_assert(std::same_as<std::common_type_t<char, _Int128>, _Int128>);
-    static_assert(std::same_as<std::common_type_t<signed char, _Int128>, _Int128>);
-    static_assert(std::same_as<std::common_type_t<unsigned char, _Int128>, _Int128>);
-    static_assert(std::same_as<std::common_type_t<wchar_t, _Int128>, _Int128>);
+    static_assert(std::same_as<std::common_type_t<bool, _Signed128>, _Signed128>);
+    static_assert(std::same_as<std::common_type_t<char, _Signed128>, _Signed128>);
+    static_assert(std::same_as<std::common_type_t<signed char, _Signed128>, _Signed128>);
+    static_assert(std::same_as<std::common_type_t<unsigned char, _Signed128>, _Signed128>);
+    static_assert(std::same_as<std::common_type_t<wchar_t, _Signed128>, _Signed128>);
 #ifdef __cpp_char8_t
-    static_assert(std::same_as<std::common_type_t<char8_t, _Int128>, _Int128>);
+    static_assert(std::same_as<std::common_type_t<char8_t, _Signed128>, _Signed128>);
 #endif // __cpp_char8_t
-    static_assert(std::same_as<std::common_type_t<char16_t, _Int128>, _Int128>);
-    static_assert(std::same_as<std::common_type_t<char32_t, _Int128>, _Int128>);
-    static_assert(std::same_as<std::common_type_t<short, _Int128>, _Int128>);
-    static_assert(std::same_as<std::common_type_t<unsigned short, _Int128>, _Int128>);
-    static_assert(std::same_as<std::common_type_t<int, _Int128>, _Int128>);
-    static_assert(std::same_as<std::common_type_t<unsigned int, _Int128>, _Int128>);
-    static_assert(std::same_as<std::common_type_t<long, _Int128>, _Int128>);
-    static_assert(std::same_as<std::common_type_t<unsigned long, _Int128>, _Int128>);
-    static_assert(std::same_as<std::common_type_t<long long, _Int128>, _Int128>);
-    static_assert(std::same_as<std::common_type_t<unsigned long long, _Int128>, _Int128>);
+    static_assert(std::same_as<std::common_type_t<char16_t, _Signed128>, _Signed128>);
+    static_assert(std::same_as<std::common_type_t<char32_t, _Signed128>, _Signed128>);
+    static_assert(std::same_as<std::common_type_t<short, _Signed128>, _Signed128>);
+    static_assert(std::same_as<std::common_type_t<unsigned short, _Signed128>, _Signed128>);
+    static_assert(std::same_as<std::common_type_t<int, _Signed128>, _Signed128>);
+    static_assert(std::same_as<std::common_type_t<unsigned int, _Signed128>, _Signed128>);
+    static_assert(std::same_as<std::common_type_t<long, _Signed128>, _Signed128>);
+    static_assert(std::same_as<std::common_type_t<unsigned long, _Signed128>, _Signed128>);
+    static_assert(std::same_as<std::common_type_t<long long, _Signed128>, _Signed128>);
+    static_assert(std::same_as<std::common_type_t<unsigned long long, _Signed128>, _Signed128>);
 
-    static_assert(std::same_as<std::common_type_t<_Int128, bool>, _Int128>);
-    static_assert(std::same_as<std::common_type_t<_Int128, char>, _Int128>);
-    static_assert(std::same_as<std::common_type_t<_Int128, signed char>, _Int128>);
-    static_assert(std::same_as<std::common_type_t<_Int128, unsigned char>, _Int128>);
-    static_assert(std::same_as<std::common_type_t<_Int128, wchar_t>, _Int128>);
+    static_assert(std::same_as<std::common_type_t<_Signed128, bool>, _Signed128>);
+    static_assert(std::same_as<std::common_type_t<_Signed128, char>, _Signed128>);
+    static_assert(std::same_as<std::common_type_t<_Signed128, signed char>, _Signed128>);
+    static_assert(std::same_as<std::common_type_t<_Signed128, unsigned char>, _Signed128>);
+    static_assert(std::same_as<std::common_type_t<_Signed128, wchar_t>, _Signed128>);
 #ifdef __cpp_char8_t
-    static_assert(std::same_as<std::common_type_t<_Int128, char8_t>, _Int128>);
+    static_assert(std::same_as<std::common_type_t<_Signed128, char8_t>, _Signed128>);
 #endif // __cpp_char8_t
-    static_assert(std::same_as<std::common_type_t<_Int128, char16_t>, _Int128>);
-    static_assert(std::same_as<std::common_type_t<_Int128, char32_t>, _Int128>);
-    static_assert(std::same_as<std::common_type_t<_Int128, short>, _Int128>);
-    static_assert(std::same_as<std::common_type_t<_Int128, unsigned short>, _Int128>);
-    static_assert(std::same_as<std::common_type_t<_Int128, int>, _Int128>);
-    static_assert(std::same_as<std::common_type_t<_Int128, unsigned int>, _Int128>);
-    static_assert(std::same_as<std::common_type_t<_Int128, long>, _Int128>);
-    static_assert(std::same_as<std::common_type_t<_Int128, unsigned long>, _Int128>);
-    static_assert(std::same_as<std::common_type_t<_Int128, long long>, _Int128>);
-    static_assert(std::same_as<std::common_type_t<_Int128, unsigned long long>, _Int128>);
+    static_assert(std::same_as<std::common_type_t<_Signed128, char16_t>, _Signed128>);
+    static_assert(std::same_as<std::common_type_t<_Signed128, char32_t>, _Signed128>);
+    static_assert(std::same_as<std::common_type_t<_Signed128, short>, _Signed128>);
+    static_assert(std::same_as<std::common_type_t<_Signed128, unsigned short>, _Signed128>);
+    static_assert(std::same_as<std::common_type_t<_Signed128, int>, _Signed128>);
+    static_assert(std::same_as<std::common_type_t<_Signed128, unsigned int>, _Signed128>);
+    static_assert(std::same_as<std::common_type_t<_Signed128, long>, _Signed128>);
+    static_assert(std::same_as<std::common_type_t<_Signed128, unsigned long>, _Signed128>);
+    static_assert(std::same_as<std::common_type_t<_Signed128, long long>, _Signed128>);
+    static_assert(std::same_as<std::common_type_t<_Signed128, unsigned long long>, _Signed128>);
 
-    static_assert(std::_Integer_class<_Int128>);
-    static_assert(std::_Integer_like<_Int128>);
-    static_assert(std::_Signed_integer_like<_Int128>);
-    static_assert(std::same_as<std::_Make_unsigned_like_t<_Int128>, _Uint128>);
-    static_assert(std::same_as<std::_Make_signed_like_t<_Int128>, _Int128>);
+    static_assert(std::_Integer_class<_Signed128>);
+    static_assert(std::_Integer_like<_Signed128>);
+    static_assert(std::_Signed_integer_like<_Signed128>);
+    static_assert(std::same_as<std::_Make_unsigned_like_t<_Signed128>, _Unsigned128>);
+    static_assert(std::same_as<std::_Make_signed_like_t<_Signed128>, _Signed128>);
 
-    check_equal(_Int128{});
-    check_equal(_Int128{42});
-    check_equal(_Int128{-42});
-    check_equal(_Int128{0x11111111'11111111, 0x22222222'22222222});
+    check_equal(_Signed128{});
+    check_equal(_Signed128{42});
+    check_equal(_Signed128{-42});
+    check_equal(_Signed128{0x11111111'11111111, 0x22222222'22222222});
 
-    check_order(_Int128{42}, _Int128{-42}, std::strong_ordering::greater);
-    check_order(_Int128{0x11111111'11111111, 0x22222222'22222222}, _Int128{0x01010101'01010101, 0x01010101'01010101},
-        std::strong_ordering::greater);
-    check_order(_Int128{~0ull, ~0ull}, _Int128{-1}, std::strong_ordering::equal);
+    check_order(_Signed128{42}, _Signed128{-42}, std::strong_ordering::greater);
+    check_order(_Signed128{0x11111111'11111111, 0x22222222'22222222},
+        _Signed128{0x01010101'01010101, 0x01010101'01010101}, std::strong_ordering::greater);
+    check_order(_Signed128{~0ull, ~0ull}, _Signed128{-1}, std::strong_ordering::equal);
 
-    check_order(_Int128{-2}, _Int128{-1}, std::strong_ordering::less);
-    check_order(_Int128{-2}, _Int128{1}, std::strong_ordering::less);
-    check_order(_Int128{2}, _Int128{-1}, std::strong_ordering::greater);
-    check_order(_Int128{2}, _Int128{1}, std::strong_ordering::greater);
+    check_order(_Signed128{-2}, _Signed128{-1}, std::strong_ordering::less);
+    check_order(_Signed128{-2}, _Signed128{1}, std::strong_ordering::less);
+    check_order(_Signed128{2}, _Signed128{-1}, std::strong_ordering::greater);
+    check_order(_Signed128{2}, _Signed128{1}, std::strong_ordering::greater);
 
-    check_equal(_Int128{0, 0});
-    check_order(_Int128{0, (1ull << 63)}, _Int128{0, 0}, std::strong_ordering::less);
-    check_order(_Int128{0, (1ull << 63)}, _Int128{0, (1ull << 63)}, std::strong_ordering::equal);
-    check_order(_Int128{0, 0}, _Int128{1, 0}, std::strong_ordering::less);
-    check_order(_Int128{0, (1ull << 63)}, _Int128{1, 0}, std::strong_ordering::less);
-    check_order(_Int128{0, (1ull << 63)}, _Int128{1, (1ull << 63)}, std::strong_ordering::less);
-    check_order(_Int128{0, 0}, _Int128{0, 1}, std::strong_ordering::less);
-    check_order(_Int128{0, (1ull << 63)}, _Int128{0, 1}, std::strong_ordering::less);
-    check_order(_Int128{0, (1ull << 63)}, _Int128{0, 1 | (1ull << 63)}, std::strong_ordering::less);
-    check_order(_Int128{0, 0}, _Int128{1, 1}, std::strong_ordering::less);
-    check_order(_Int128{0, (1ull << 63)}, _Int128{1, 1}, std::strong_ordering::less);
-    check_order(_Int128{0, (1ull << 63)}, _Int128{1, 1 | (1ull << 63)}, std::strong_ordering::less);
+    check_equal(_Signed128{0, 0});
+    check_order(_Signed128{0, (1ull << 63)}, _Signed128{0, 0}, std::strong_ordering::less);
+    check_order(_Signed128{0, (1ull << 63)}, _Signed128{0, (1ull << 63)}, std::strong_ordering::equal);
+    check_order(_Signed128{0, 0}, _Signed128{1, 0}, std::strong_ordering::less);
+    check_order(_Signed128{0, (1ull << 63)}, _Signed128{1, 0}, std::strong_ordering::less);
+    check_order(_Signed128{0, (1ull << 63)}, _Signed128{1, (1ull << 63)}, std::strong_ordering::less);
+    check_order(_Signed128{0, 0}, _Signed128{0, 1}, std::strong_ordering::less);
+    check_order(_Signed128{0, (1ull << 63)}, _Signed128{0, 1}, std::strong_ordering::less);
+    check_order(_Signed128{0, (1ull << 63)}, _Signed128{0, 1 | (1ull << 63)}, std::strong_ordering::less);
+    check_order(_Signed128{0, 0}, _Signed128{1, 1}, std::strong_ordering::less);
+    check_order(_Signed128{0, (1ull << 63)}, _Signed128{1, 1}, std::strong_ordering::less);
+    check_order(_Signed128{0, (1ull << 63)}, _Signed128{1, 1 | (1ull << 63)}, std::strong_ordering::less);
 
-    assert((_Int128{-2} == _Uint128{0ull - 2, ~0ull}));
-    assert((_Uint128{_Int128{-2}} == _Uint128{0ull - 2, ~0ull}));
-    assert((_Int128{-2} == _Int128{_Uint128{0ull - 2, ~0ull}}));
+    assert((_Signed128{-2} == _Unsigned128{0ull - 2, ~0ull}));
+    assert((_Unsigned128{_Signed128{-2}} == _Unsigned128{0ull - 2, ~0ull}));
+    assert((_Signed128{-2} == _Signed128{_Unsigned128{0ull - 2, ~0ull}}));
 
     {
-        _Int128 u{42};
+        _Signed128 u{42};
         assert(u._Word[0] == 42);
         assert(u._Word[1] == 0);
-        u += _Int128{0};
+        u += _Signed128{0};
         assert(u._Word[0] == 42);
         assert(u._Word[1] == 0);
 
@@ -415,7 +416,7 @@ constexpr bool test_signed() {
         assert(static_cast<std::int8_t>(u) == 42);
     }
     {
-        _Int128 nu{-42};
+        _Signed128 nu{-42};
         assert(nu._Word[0] == 0ull - 42);
         assert(nu._Word[1] == ~0ull);
 
@@ -431,10 +432,10 @@ constexpr bool test_signed() {
     }
 
     {
-        _Int128 u{42};
-        _Int128 v{13};
+        _Signed128 u{42};
+        _Signed128 v{13};
         {
-            _Int128 sum = u + v;
+            _Signed128 sum = u + v;
             assert(sum._Word[0] == 55);
             assert(sum._Word[1] == 0);
             sum = v + u;
@@ -442,7 +443,7 @@ constexpr bool test_signed() {
             assert(sum._Word[1] == 0);
         }
         {
-            _Int128 diff = u - v;
+            _Signed128 diff = u - v;
             assert(diff._Word[0] == 29);
             assert(diff._Word[1] == 0);
             diff = v - u;
@@ -450,8 +451,8 @@ constexpr bool test_signed() {
             assert(diff._Word[1] == ~0ull);
         }
         {
-            u           = -u;
-            _Int128 sum = u + v;
+            u              = -u;
+            _Signed128 sum = u + v;
             assert(sum._Word[0] == 0ull - 29);
             assert(sum._Word[1] == ~0ull);
             sum = v + u;
@@ -459,7 +460,7 @@ constexpr bool test_signed() {
             assert(sum._Word[1] == ~0ull);
         }
         {
-            _Int128 diff = u - v;
+            _Signed128 diff = u - v;
             assert(diff._Word[0] == 0ull - 55);
             assert(diff._Word[1] == ~0ull);
             diff = v - u;
@@ -467,8 +468,8 @@ constexpr bool test_signed() {
             assert(diff._Word[1] == 0);
         }
         {
-            u               = -u;
-            _Int128 product = u * v;
+            u                  = -u;
+            _Signed128 product = u * v;
             assert(product._Word[0] == 42 * 13);
             assert(product._Word[1] == 0);
             product = v * u;
@@ -476,8 +477,8 @@ constexpr bool test_signed() {
             assert(product._Word[1] == 0);
         }
         {
-            v               = -v;
-            _Int128 product = u * v;
+            v                  = -v;
+            _Signed128 product = u * v;
             assert(product._Word[0] == 0ull - (42 * 13));
             assert(product._Word[1] == ~0ull);
             product = v * u;
@@ -485,8 +486,8 @@ constexpr bool test_signed() {
             assert(product._Word[1] == ~0ull);
         }
         {
-            u               = -u;
-            _Int128 product = u * v;
+            u                  = -u;
+            _Signed128 product = u * v;
             assert(product._Word[0] == 42 * 13);
             assert(product._Word[1] == 0);
             product = v * u;
@@ -495,16 +496,16 @@ constexpr bool test_signed() {
         }
     }
     {
-        auto product = _Int128{0x01010101'01010101, 0x01010101'01010101} * 5;
+        auto product = _Signed128{0x01010101'01010101, 0x01010101'01010101} * 5;
         assert(product._Word[0] == 0x05050505'05050505);
         assert(product._Word[1] == 0x05050505'05050505);
 
-        product = 5 * _Int128{0x01010101'01010101, 0x01010101'01010101};
+        product = 5 * _Signed128{0x01010101'01010101, 0x01010101'01010101};
         assert(product._Word[0] == 0x05050505'05050505);
         assert(product._Word[1] == 0x05050505'05050505);
     }
     {
-        auto product = _Int128{0x01010101'01010101, 0x01010101'01010101};
+        auto product = _Signed128{0x01010101'01010101, 0x01010101'01010101};
         product *= product;
         assert(product._Word[0] == 0x08070605'04030201);
         assert(product._Word[1] == 0x100f0e0d'0c0b0a09);
@@ -513,7 +514,7 @@ constexpr bool test_signed() {
     }
     {
         auto product =
-            _Int128{0x01020304'05060708, 0x090a0b0c'0d0e0f00} * _Int128{0x000f0e0d'0c0b0a09, 0x08070605'04030201};
+            _Signed128{0x01020304'05060708, 0x090a0b0c'0d0e0f00} * _Signed128{0x000f0e0d'0c0b0a09, 0x08070605'04030201};
         assert(product._Word[0] == 0x6dc18e55'16d48f48);
         assert(product._Word[1] == 0xdc1b6bce'43cd6c21);
         assert(+product == product);
@@ -532,147 +533,147 @@ constexpr bool test_signed() {
         assert(-product + product == 0);
     }
     {
-        _Int128 q = _Int128{13} / _Int128{4};
+        _Signed128 q = _Signed128{13} / _Signed128{4};
         assert(q._Word[0] == 3);
         assert(q._Word[1] == 0);
 
-        q = _Int128{4} / _Int128{13};
+        q = _Signed128{4} / _Signed128{13};
         assert(q._Word[0] == 0);
         assert(q._Word[1] == 0);
 
-        q = _Int128{13} / _Int128{-4};
+        q = _Signed128{13} / _Signed128{-4};
         assert(q._Word[0] == 0ull - 3);
         assert(q._Word[1] == ~0ull);
 
-        q = _Int128{-4} / _Int128{13};
+        q = _Signed128{-4} / _Signed128{13};
         assert(q._Word[0] == 0);
         assert(q._Word[1] == 0);
 
-        q = _Int128{-13} / _Int128{4};
+        q = _Signed128{-13} / _Signed128{4};
         assert(q._Word[0] == 0ull - 3);
         assert(q._Word[1] == ~0ull);
 
-        q = _Int128{4} / _Int128{-13};
+        q = _Signed128{4} / _Signed128{-13};
         assert(q._Word[0] == 0);
         assert(q._Word[1] == 0);
 
-        q = _Int128{-13} / _Int128{-4};
+        q = _Signed128{-13} / _Signed128{-4};
         assert(q._Word[0] == 3);
         assert(q._Word[1] == 0);
 
-        q = _Int128{-4} / _Int128{-13};
+        q = _Signed128{-4} / _Signed128{-13};
         assert(q._Word[0] == 0);
         assert(q._Word[1] == 0);
 
-        q = _Int128{0x01010101'01010101, 0x01010101'01010101} / _Int128{13};
+        q = _Signed128{0x01010101'01010101, 0x01010101'01010101} / _Signed128{13};
         assert(q._Word[0] == 0xc50013c5'0013c500);
         assert(q._Word[1] == 0x0013c500'13c50013);
 
-        q = _Int128{0x22222222'22222222, 0x22222222'22222222} / _Int128{0x11111111'11111111, 0x11111111'11111111};
+        q = _Signed128{0x22222222'22222222, 0x22222222'22222222} / _Signed128{0x11111111'11111111, 0x11111111'11111111};
         assert(q._Word[0] == 2);
         assert(q._Word[1] == 0);
 
-        q = (_Int128{1} << 66) / (_Int128{1} << 13);
+        q = (_Signed128{1} << 66) / (_Signed128{1} << 13);
         assert(q._Word[0] == 1ull << 53);
         assert(q._Word[1] == 0);
     }
     {
-        auto tmp = ~_Int128{};
+        auto tmp = ~_Signed128{};
         assert(tmp._Word[0] == ~0ull);
         assert(tmp._Word[1] == ~0ull);
-        _Int128 q = tmp / std::uint32_t{1};
+        _Signed128 q = tmp / std::uint32_t{1};
         assert(q == tmp);
         q = tmp / std::uint64_t{1};
         assert(q == tmp);
-        q = tmp / _Int128{1};
+        q = tmp / _Signed128{1};
         assert(q == tmp);
 
-        q = tmp / _Int128{1ull << 32};
+        q = tmp / _Signed128{1ull << 32};
         assert(q._Word[0] == 0);
         assert(q._Word[1] == 0);
     }
     {
-        _Int128 result{0x80808080'80808080, 0x00808080'80808080};
-        for (_Int128 tmp = 0xffu; tmp > 0; tmp <<= 8, result >>= 8) {
-            auto q = std::numeric_limits<_Int128>::max() / tmp;
+        _Signed128 result{0x80808080'80808080, 0x00808080'80808080};
+        for (_Signed128 tmp = 0xffu; tmp > 0; tmp <<= 8, result >>= 8) {
+            auto q = std::numeric_limits<_Signed128>::max() / tmp;
             assert(q == result);
-            auto m    = std::numeric_limits<_Int128>::max() % tmp;
+            auto m    = std::numeric_limits<_Signed128>::max() % tmp;
             auto p    = q * tmp;
-            auto diff = std::numeric_limits<_Int128>::max() - p;
+            auto diff = std::numeric_limits<_Signed128>::max() - p;
             assert(m == diff);
         }
     }
     {
-        _Int128 result = _Int128{0x7f7f7f7f'7f7f7f80, 0xff7f7f7f'7f7f7f7f};
-        for (_Int128 tmp = 0xffu; tmp > 0; tmp <<= 8, result = (result >> 8) + 1) {
-            auto q = std::numeric_limits<_Int128>::min() / tmp;
+        _Signed128 result = _Signed128{0x7f7f7f7f'7f7f7f80, 0xff7f7f7f'7f7f7f7f};
+        for (_Signed128 tmp = 0xffu; tmp > 0; tmp <<= 8, result = (result >> 8) + 1) {
+            auto q = std::numeric_limits<_Signed128>::min() / tmp;
             assert(q == result);
-            auto m    = std::numeric_limits<_Int128>::min() % tmp;
+            auto m    = std::numeric_limits<_Signed128>::min() % tmp;
             auto p    = q * tmp;
-            auto diff = std::numeric_limits<_Int128>::min() - p;
+            auto diff = std::numeric_limits<_Signed128>::min() - p;
             assert(m == diff);
         }
     }
     {
-        _Int128 tmp;
+        _Signed128 tmp;
         for (tmp = 1; static_cast<bool>(tmp); tmp <<= 1) {
             assert(tmp % tmp == 0);
         }
         assert(tmp == 0);
     }
     {
-        _Int128 r = _Int128{13} % _Int128{4};
+        _Signed128 r = _Signed128{13} % _Signed128{4};
         assert(r._Word[0] == 1);
         assert(r._Word[1] == 0);
 
-        r = _Int128{4} % _Int128{13};
+        r = _Signed128{4} % _Signed128{13};
         assert(r._Word[0] == 4);
         assert(r._Word[1] == 0);
 
-        r = _Int128{13} % _Int128{-4};
+        r = _Signed128{13} % _Signed128{-4};
         assert(r._Word[0] == 1);
         assert(r._Word[1] == 0);
 
-        r = _Int128{-4} % _Int128{13};
+        r = _Signed128{-4} % _Signed128{13};
         assert(r._Word[0] == 0ull - 4);
         assert(r._Word[1] == ~0ull);
 
-        r = _Int128{-13} % _Int128{4};
+        r = _Signed128{-13} % _Signed128{4};
         assert(r._Word[0] == 0ull - 1);
         assert(r._Word[1] == ~0ull);
 
-        r = _Int128{4} % _Int128{-13};
+        r = _Signed128{4} % _Signed128{-13};
         assert(r._Word[0] == 4);
         assert(r._Word[1] == 0);
 
-        r = _Int128{-13} % _Int128{-4};
+        r = _Signed128{-13} % _Signed128{-4};
         assert(r._Word[0] == 0ull - 1);
         assert(r._Word[1] == ~0ull);
 
-        r = _Int128{-4} % _Int128{-13};
+        r = _Signed128{-4} % _Signed128{-13};
         assert(r._Word[0] == 0ull - 4);
         assert(r._Word[1] == ~0ull);
     }
     {
-        const _Int128 x{0x01020304'02030405, 0x03040506'04050607};
-        const _Int128 y{0x07060504'06050403, 0x05040302'04030101};
-        assert(((x & y) == _Int128{0x01020104'02010401, 0x01040102'04010001}));
+        const _Signed128 x{0x01020304'02030405, 0x03040506'04050607};
+        const _Signed128 y{0x07060504'06050403, 0x05040302'04030101};
+        assert(((x & y) == _Signed128{0x01020104'02010401, 0x01040102'04010001}));
         auto tmp = x;
         tmp &= y;
         assert(tmp == (x & y));
 
-        assert(((x | y) == _Int128{0x07060704'06070407, 0x07040706'04070707}));
+        assert(((x | y) == _Signed128{0x07060704'06070407, 0x07040706'04070707}));
         tmp = x;
         tmp |= y;
         assert(tmp == (x | y));
 
-        assert(((x ^ y) == _Int128{0x06040600'04060006, 0x06000604'00060706}));
+        assert(((x ^ y) == _Signed128{0x06040600'04060006, 0x06000604'00060706}));
         tmp = x;
         tmp ^= y;
         assert(tmp == (x ^ y));
     }
     {
-        _Int128 x{};
+        _Signed128 x{};
         assert(++x == 1);
         assert(--x == 0);
         --x;
@@ -697,11 +698,11 @@ constexpr bool test_signed() {
         ++x;
         assert(x._Word[0] == 0);
         assert(x._Word[1] == static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::min()));
-        assert(x == std::numeric_limits<_Int128>::min());
+        assert(x == std::numeric_limits<_Signed128>::min());
         --x;
         assert(x._Word[0] == ~0ull);
         assert(x._Word[1] == static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max()));
-        assert(x == std::numeric_limits<_Int128>::max());
+        assert(x == std::numeric_limits<_Signed128>::max());
     }
 
     return true;
@@ -729,83 +730,83 @@ constexpr bool test_cross() {
     // With mixed operands, binary arithmetic operators convert the signed
     // operand to unsigned, producing an unsigned result.
 
-    TEST(_Uint128{42} + _Int128{-43}, _Uint128{-1});
-    TEST(_Int128{42} + _Uint128{-43}, _Uint128{-1});
-    TEST(_Uint128{42} - _Int128{-43}, _Uint128{42 + 43});
-    TEST(_Int128{42} - _Uint128{-43}, _Uint128{42 + 43});
-    TEST(_Uint128{42} * _Int128{-43}, _Uint128{42 * -43});
-    TEST(_Int128{42} * _Uint128{-43}, _Uint128{42 * -43});
-    TEST(_Uint128{42} / _Int128{-43}, _Uint128{0});
-    TEST(_Int128{42} / _Uint128{-43}, _Uint128{0});
-    TEST(_Uint128{42} % _Int128{-43}, _Uint128{42});
-    TEST(_Int128{42} % _Uint128{-43}, _Uint128{42});
-    TEST(_Uint128{42} & _Int128{43}, _Uint128{42});
-    TEST(_Int128{42} & _Uint128{43}, _Uint128{42});
-    TEST(_Uint128{42} | _Int128{43}, _Uint128{43});
-    TEST(_Int128{42} | _Uint128{43}, _Uint128{43});
-    TEST(_Uint128{42} ^ _Int128{43}, _Uint128{1});
-    TEST(_Int128{42} ^ _Uint128{43}, _Uint128{1});
+    TEST(_Unsigned128{42} + _Signed128{-43}, _Unsigned128{-1});
+    TEST(_Signed128{42} + _Unsigned128{-43}, _Unsigned128{-1});
+    TEST(_Unsigned128{42} - _Signed128{-43}, _Unsigned128{42 + 43});
+    TEST(_Signed128{42} - _Unsigned128{-43}, _Unsigned128{42 + 43});
+    TEST(_Unsigned128{42} * _Signed128{-43}, _Unsigned128{42 * -43});
+    TEST(_Signed128{42} * _Unsigned128{-43}, _Unsigned128{42 * -43});
+    TEST(_Unsigned128{42} / _Signed128{-43}, _Unsigned128{0});
+    TEST(_Signed128{42} / _Unsigned128{-43}, _Unsigned128{0});
+    TEST(_Unsigned128{42} % _Signed128{-43}, _Unsigned128{42});
+    TEST(_Signed128{42} % _Unsigned128{-43}, _Unsigned128{42});
+    TEST(_Unsigned128{42} & _Signed128{43}, _Unsigned128{42});
+    TEST(_Signed128{42} & _Unsigned128{43}, _Unsigned128{42});
+    TEST(_Unsigned128{42} | _Signed128{43}, _Unsigned128{43});
+    TEST(_Signed128{42} | _Unsigned128{43}, _Unsigned128{43});
+    TEST(_Unsigned128{42} ^ _Signed128{43}, _Unsigned128{1});
+    TEST(_Signed128{42} ^ _Unsigned128{43}, _Unsigned128{1});
 
     // Shifts yield a result of the left operand's type.
 
-    TEST(_Uint128{1} << _Int128{43}, _Uint128{1ull << 43});
-    TEST(_Int128{1} << _Uint128{43}, _Int128{1ull << 43});
-    TEST(_Uint128{-1} << _Int128{43}, (_Uint128{0ull - (1ull << 43), ~0ull}));
-    TEST(_Int128{-1} << _Uint128{43}, (_Int128{0ull - (1ull << 43), ~0ull}));
+    TEST(_Unsigned128{1} << _Signed128{43}, _Unsigned128{1ull << 43});
+    TEST(_Signed128{1} << _Unsigned128{43}, _Signed128{1ull << 43});
+    TEST(_Unsigned128{-1} << _Signed128{43}, (_Unsigned128{0ull - (1ull << 43), ~0ull}));
+    TEST(_Signed128{-1} << _Unsigned128{43}, (_Signed128{0ull - (1ull << 43), ~0ull}));
 
-    TEST((_Uint128{0, 1}) >> _Int128{43}, _Uint128{1ull << 21});
-    TEST((_Int128{0, 1}) >> _Uint128{43}, _Int128{1ull << 21});
-    TEST((_Uint128{0, ~0ull} >> _Int128{43}), (_Uint128{~((1ull << 21) - 1), (1ull << 21) - 1}));
-    TEST((_Int128{0, ~0ull} >> _Uint128{43}), (_Int128{~((1ull << 21) - 1), ~0ull}));
+    TEST((_Unsigned128{0, 1}) >> _Signed128{43}, _Unsigned128{1ull << 21});
+    TEST((_Signed128{0, 1}) >> _Unsigned128{43}, _Signed128{1ull << 21});
+    TEST((_Unsigned128{0, ~0ull} >> _Signed128{43}), (_Unsigned128{~((1ull << 21) - 1), (1ull << 21) - 1}));
+    TEST((_Signed128{0, ~0ull} >> _Unsigned128{43}), (_Signed128{~((1ull << 21) - 1), ~0ull}));
 
     // Integer-class types are explicitly convertible to integer-like (the union
     // of integer-class and integral) types. Integer-class types are implicitly
     // convertible only to wider types, or types of the same width and
     // signedness. Consequently, the conditional operator should reject integer-
     // class operands with the same width but differing signedness.
-    static_assert(!CanConditional<_Uint128, _Int128>);
-    static_assert(!CanConditional<_Int128, _Uint128>);
+    static_assert(!CanConditional<_Unsigned128, _Signed128>);
+    static_assert(!CanConditional<_Signed128, _Unsigned128>);
 
     // Conversions between integer-class types with the same width and differing
     // signedness are narrowing, so the three-way comparison operator should
     // reject mixed operands of such types.
-    static_assert(!std::three_way_comparable_with<_Uint128, _Int128>);
-    static_assert(!std::three_way_comparable_with<_Int128, _Uint128>);
+    static_assert(!std::three_way_comparable_with<_Unsigned128, _Signed128>);
+    static_assert(!std::three_way_comparable_with<_Signed128, _Unsigned128>);
 
     // Other comparison operators behave as they do for operands of mixed
     // integral types; when the operands have the same width, the signed operand
     // converts to unsigned and the comparison is made.
 
-    TEST(_Uint128{42} == _Int128{0}, false);
-    TEST(_Int128{42} == _Uint128{42}, true);
-    TEST(_Uint128{42} != _Int128{0}, true);
-    TEST(_Int128{42} != _Uint128{42}, false);
+    TEST(_Unsigned128{42} == _Signed128{0}, false);
+    TEST(_Signed128{42} == _Unsigned128{42}, true);
+    TEST(_Unsigned128{42} != _Signed128{0}, true);
+    TEST(_Signed128{42} != _Unsigned128{42}, false);
 
-    TEST(_Uint128{42} < _Int128{-43}, true);
-    TEST(_Int128{42} < _Uint128{-43}, true);
-    TEST(_Uint128{42} > _Int128{-43}, false);
-    TEST(_Int128{42} > _Uint128{-43}, false);
-    TEST(_Uint128{42} <= _Int128{-43}, true);
-    TEST(_Int128{42} <= _Uint128{-43}, true);
-    TEST(_Uint128{42} >= _Int128{-43}, false);
-    TEST(_Int128{42} >= _Uint128{-43}, false);
+    TEST(_Unsigned128{42} < _Signed128{-43}, true);
+    TEST(_Signed128{42} < _Unsigned128{-43}, true);
+    TEST(_Unsigned128{42} > _Signed128{-43}, false);
+    TEST(_Signed128{42} > _Unsigned128{-43}, false);
+    TEST(_Unsigned128{42} <= _Signed128{-43}, true);
+    TEST(_Signed128{42} <= _Unsigned128{-43}, true);
+    TEST(_Unsigned128{42} >= _Signed128{-43}, false);
+    TEST(_Signed128{42} >= _Unsigned128{-43}, false);
 
     // The logical binary operators behave just like they do for integral types;
     // the individual operands are converted to bool and the operation performed
     // normally.
 
-    TEST(_Uint128{42} && _Int128{0}, false);
-    TEST(_Int128{42} && _Uint128{0}, false);
-    TEST(_Uint128{42} || _Int128{0}, true);
-    TEST(_Int128{42} || _Uint128{0}, true);
+    TEST(_Unsigned128{42} && _Signed128{0}, false);
+    TEST(_Signed128{42} && _Unsigned128{0}, false);
+    TEST(_Unsigned128{42} || _Signed128{0}, true);
+    TEST(_Signed128{42} || _Unsigned128{0}, true);
 
     // Assignments convert the RHS to the type of the LHS, just as for integral
     // types.
     {
-        _Uint128 u{};
-        _Uint128 x{42};
-        _Int128 i{42};
-        _Int128 y{13};
+        _Unsigned128 u{};
+        _Unsigned128 x{42};
+        _Signed128 i{42};
+        _Signed128 y{13};
         TEST(u = i, x);
         u = 13;
         TEST(i = u, y);
@@ -821,44 +822,44 @@ constexpr bool test_cross() {
         TEST(i -= u, y);
 
         x = -26;
-        TEST(u *= _Int128{2}, x);
+        TEST(u *= _Signed128{2}, x);
         y = 104;
-        TEST(i *= _Uint128{2}, y);
+        TEST(i *= _Unsigned128{2}, y);
 
-        x = _Uint128{0x55555555'5555554c, 0x55555555'55555555};
-        TEST(u /= _Int128{3}, x); // Yes, u is still unsigned =)
+        x = _Unsigned128{0x55555555'5555554c, 0x55555555'55555555};
+        TEST(u /= _Signed128{3}, x); // Yes, u is still unsigned =)
         y = 34;
-        TEST(i /= _Uint128{3}, y);
+        TEST(i /= _Unsigned128{3}, y);
 
         x = 4;
-        TEST(u %= _Int128{8}, x);
+        TEST(u %= _Signed128{8}, x);
         y = 2;
-        TEST(i %= _Uint128{8}, y);
+        TEST(i %= _Unsigned128{8}, y);
 
         x = 16;
-        TEST(u <<= _Int128{2}, x);
+        TEST(u <<= _Signed128{2}, x);
         y = 8;
-        TEST(i <<= _Uint128{2}, y);
+        TEST(i <<= _Unsigned128{2}, y);
 
         x = 8;
-        TEST(u >>= _Int128{1}, x);
+        TEST(u >>= _Signed128{1}, x);
         y = 4;
-        TEST(i >>= _Uint128{1}, y);
+        TEST(i >>= _Unsigned128{1}, y);
 
         x = 9;
-        TEST(u |= _Int128{1}, x);
+        TEST(u |= _Signed128{1}, x);
         y = 5;
-        TEST(i |= _Uint128{1}, y);
+        TEST(i |= _Unsigned128{1}, y);
 
         x = 9;
-        TEST(u &= _Int128{59}, x);
+        TEST(u &= _Signed128{59}, x);
         y = 1;
-        TEST(i &= _Uint128{59}, y);
+        TEST(i &= _Unsigned128{59}, y);
 
         x = 12;
-        TEST(u ^= _Int128{5}, x);
+        TEST(u ^= _Signed128{5}, x);
         y = 4;
-        TEST(i ^= _Uint128{5}, y);
+        TEST(i ^= _Unsigned128{5}, y);
     }
 
     //////// Mixed integer and integer-class operands
@@ -866,120 +867,120 @@ constexpr bool test_cross() {
     // With mixed operands, binary arithmetic operators convert the signed
     // operand to unsigned, producing an unsigned result.
 
-    TEST(_Uint128{42} + -43, _Uint128{-1});
-    TEST(_Int128{42} + -43, _Int128{-1});
-    TEST(42 + _Int128{-43}, _Int128{-1});
-    TEST(42 + _Uint128{-43}, _Uint128{-1});
-    TEST(_Uint128{42} - -43, _Uint128{42 + 43});
-    TEST(_Int128{42} - -43, _Int128{42 + 43});
-    TEST(42 - _Int128{-43}, _Int128{42 + 43});
-    TEST(42 - _Uint128{-43}, _Uint128{42 + 43});
-    TEST(_Uint128{42} * -43, _Uint128{42 * -43});
-    TEST(_Int128{42} * -43, _Int128{42 * -43});
-    TEST(42 * _Int128{-43}, _Int128{42 * -43});
-    TEST(42 * _Uint128{-43}, _Uint128{42 * -43});
-    TEST(_Uint128{42} / -43, _Uint128{0});
-    TEST(_Int128{42} / -43, _Int128{0});
-    TEST(42 / _Int128{-43}, _Int128{0});
-    TEST(42 / _Uint128{-43}, _Uint128{0});
-    TEST(_Uint128{42} % -43, _Uint128{42});
-    TEST(_Int128{42} % -43, _Int128{42});
-    TEST(42 % _Int128{-43}, _Int128{42});
-    TEST(42 % _Uint128{-43}, _Uint128{42});
-    TEST(_Uint128{42} & 43, _Uint128{42});
-    TEST(_Int128{42} & 43, _Int128{42});
-    TEST(42 & _Int128{43}, _Int128{42});
-    TEST(42 & _Uint128{43}, _Uint128{42});
-    TEST(_Uint128{42} | 43, _Uint128{43});
-    TEST(_Int128{42} | 43, _Int128{43});
-    TEST(42 | _Int128{43}, _Int128{43});
-    TEST(42 | _Uint128{43}, _Uint128{43});
-    TEST(_Uint128{42} ^ 43, _Uint128{1});
-    TEST(_Int128{42} ^ 43, _Int128{1});
-    TEST(42 ^ _Int128{43}, _Int128{1});
-    TEST(42 ^ _Uint128{43}, _Uint128{1});
+    TEST(_Unsigned128{42} + -43, _Unsigned128{-1});
+    TEST(_Signed128{42} + -43, _Signed128{-1});
+    TEST(42 + _Signed128{-43}, _Signed128{-1});
+    TEST(42 + _Unsigned128{-43}, _Unsigned128{-1});
+    TEST(_Unsigned128{42} - -43, _Unsigned128{42 + 43});
+    TEST(_Signed128{42} - -43, _Signed128{42 + 43});
+    TEST(42 - _Signed128{-43}, _Signed128{42 + 43});
+    TEST(42 - _Unsigned128{-43}, _Unsigned128{42 + 43});
+    TEST(_Unsigned128{42} * -43, _Unsigned128{42 * -43});
+    TEST(_Signed128{42} * -43, _Signed128{42 * -43});
+    TEST(42 * _Signed128{-43}, _Signed128{42 * -43});
+    TEST(42 * _Unsigned128{-43}, _Unsigned128{42 * -43});
+    TEST(_Unsigned128{42} / -43, _Unsigned128{0});
+    TEST(_Signed128{42} / -43, _Signed128{0});
+    TEST(42 / _Signed128{-43}, _Signed128{0});
+    TEST(42 / _Unsigned128{-43}, _Unsigned128{0});
+    TEST(_Unsigned128{42} % -43, _Unsigned128{42});
+    TEST(_Signed128{42} % -43, _Signed128{42});
+    TEST(42 % _Signed128{-43}, _Signed128{42});
+    TEST(42 % _Unsigned128{-43}, _Unsigned128{42});
+    TEST(_Unsigned128{42} & 43, _Unsigned128{42});
+    TEST(_Signed128{42} & 43, _Signed128{42});
+    TEST(42 & _Signed128{43}, _Signed128{42});
+    TEST(42 & _Unsigned128{43}, _Unsigned128{42});
+    TEST(_Unsigned128{42} | 43, _Unsigned128{43});
+    TEST(_Signed128{42} | 43, _Signed128{43});
+    TEST(42 | _Signed128{43}, _Signed128{43});
+    TEST(42 | _Unsigned128{43}, _Unsigned128{43});
+    TEST(_Unsigned128{42} ^ 43, _Unsigned128{1});
+    TEST(_Signed128{42} ^ 43, _Signed128{1});
+    TEST(42 ^ _Signed128{43}, _Signed128{1});
+    TEST(42 ^ _Unsigned128{43}, _Unsigned128{1});
 
     // Shifts yield a result of the left operand's type.
 
-    TEST(_Uint128{1} << 4, _Uint128{1ull << 4});
-    TEST(_Int128{1} << 4, _Int128{1ull << 4});
-    TEST(1 << _Int128{4}, 16);
-    TEST(1 << _Uint128{4}, 16);
+    TEST(_Unsigned128{1} << 4, _Unsigned128{1ull << 4});
+    TEST(_Signed128{1} << 4, _Signed128{1ull << 4});
+    TEST(1 << _Signed128{4}, 16);
+    TEST(1 << _Unsigned128{4}, 16);
 
-    TEST((_Uint128{0, 1}) >> 3, _Uint128{1ull << 61});
-    TEST((_Int128{0, 1}) >> 3, _Int128{1ull << 61});
-    TEST(256 >> _Int128{3}, 32);
-    TEST(256 >> _Uint128{3}, 32);
+    TEST((_Unsigned128{0, 1}) >> 3, _Unsigned128{1ull << 61});
+    TEST((_Signed128{0, 1}) >> 3, _Signed128{1ull << 61});
+    TEST(256 >> _Signed128{3}, 32);
+    TEST(256 >> _Unsigned128{3}, 32);
 
-    TEST(true ? _Uint128{42} : 13, _Uint128{42});
-    TEST(true ? _Int128{42} : 13, _Int128{42});
-    TEST(true ? 42 : _Int128{13}, _Int128{42});
-    TEST(true ? 42 : _Uint128{13}, _Uint128{42});
+    TEST(true ? _Unsigned128{42} : 13, _Unsigned128{42});
+    TEST(true ? _Signed128{42} : 13, _Signed128{42});
+    TEST(true ? 42 : _Signed128{13}, _Signed128{42});
+    TEST(true ? 42 : _Unsigned128{13}, _Unsigned128{42});
 
     // (meow <=> 0) here is a hack to get prvalues
-    TEST(4 <=> _Uint128{3}, (std::strong_ordering::greater <=> 0));
-    TEST(4 <=> _Int128{3}, (std::strong_ordering::greater <=> 0));
-    TEST(_Int128{4} <=> 3, (std::strong_ordering::greater <=> 0));
-    TEST(_Uint128{4} <=> 3, (std::strong_ordering::greater <=> 0));
-    TEST(3 <=> _Uint128{3}, (std::strong_ordering::equal <=> 0));
-    TEST(3 <=> _Int128{3}, (std::strong_ordering::equal <=> 0));
-    TEST(_Int128{3} <=> 3, (std::strong_ordering::equal <=> 0));
-    TEST(_Uint128{3} <=> 3, (std::strong_ordering::equal <=> 0));
-    TEST(-3 <=> _Uint128{3}, (std::strong_ordering::greater <=> 0));
-    TEST(-3 <=> _Int128{3}, (std::strong_ordering::less <=> 0));
-    TEST(_Int128{-3} <=> 3, (std::strong_ordering::less <=> 0));
-    TEST(_Uint128{-3} <=> 3, (std::strong_ordering::greater <=> 0));
+    TEST(4 <=> _Unsigned128{3}, (std::strong_ordering::greater <=> 0));
+    TEST(4 <=> _Signed128{3}, (std::strong_ordering::greater <=> 0));
+    TEST(_Signed128{4} <=> 3, (std::strong_ordering::greater <=> 0));
+    TEST(_Unsigned128{4} <=> 3, (std::strong_ordering::greater <=> 0));
+    TEST(3 <=> _Unsigned128{3}, (std::strong_ordering::equal <=> 0));
+    TEST(3 <=> _Signed128{3}, (std::strong_ordering::equal <=> 0));
+    TEST(_Signed128{3} <=> 3, (std::strong_ordering::equal <=> 0));
+    TEST(_Unsigned128{3} <=> 3, (std::strong_ordering::equal <=> 0));
+    TEST(-3 <=> _Unsigned128{3}, (std::strong_ordering::greater <=> 0));
+    TEST(-3 <=> _Signed128{3}, (std::strong_ordering::less <=> 0));
+    TEST(_Signed128{-3} <=> 3, (std::strong_ordering::less <=> 0));
+    TEST(_Unsigned128{-3} <=> 3, (std::strong_ordering::greater <=> 0));
 
     // Other comparison operators behave as they do for operands of mixed
     // integral types; when the operands have the same width, the signed operand
     // converts to unsigned and the comparison is made.
 
-    TEST(_Uint128{42} == 0, false);
-    TEST(_Int128{42} == 42, true);
-    TEST(42 == _Int128{0}, false);
-    TEST(42 == _Uint128{42}, true);
-    TEST(_Uint128{42} != 0, true);
-    TEST(_Int128{42} != 42, false);
-    TEST(42 != _Int128{0}, true);
-    TEST(42 != _Uint128{42}, false);
+    TEST(_Unsigned128{42} == 0, false);
+    TEST(_Signed128{42} == 42, true);
+    TEST(42 == _Signed128{0}, false);
+    TEST(42 == _Unsigned128{42}, true);
+    TEST(_Unsigned128{42} != 0, true);
+    TEST(_Signed128{42} != 42, false);
+    TEST(42 != _Signed128{0}, true);
+    TEST(42 != _Unsigned128{42}, false);
 
-    TEST(_Uint128{42} < -43, true);
-    TEST(_Int128{42} < -43, false);
-    TEST(42 < _Int128{-43}, false);
-    TEST(42 < _Uint128{-43}, true);
-    TEST(_Uint128{42} > -43, false);
-    TEST(_Int128{42} > -43, true);
-    TEST(42 > _Int128{-43}, true);
-    TEST(42 > _Uint128{-43}, false);
-    TEST(_Uint128{42} <= -43, true);
-    TEST(_Int128{42} <= -43, false);
-    TEST(42 <= _Int128{-43}, false);
-    TEST(42 <= _Uint128{-43}, true);
-    TEST(_Uint128{42} >= -43, false);
-    TEST(_Int128{42} >= -43, true);
-    TEST(42 >= _Int128{-43}, true);
-    TEST(42 >= _Uint128{-43}, false);
+    TEST(_Unsigned128{42} < -43, true);
+    TEST(_Signed128{42} < -43, false);
+    TEST(42 < _Signed128{-43}, false);
+    TEST(42 < _Unsigned128{-43}, true);
+    TEST(_Unsigned128{42} > -43, false);
+    TEST(_Signed128{42} > -43, true);
+    TEST(42 > _Signed128{-43}, true);
+    TEST(42 > _Unsigned128{-43}, false);
+    TEST(_Unsigned128{42} <= -43, true);
+    TEST(_Signed128{42} <= -43, false);
+    TEST(42 <= _Signed128{-43}, false);
+    TEST(42 <= _Unsigned128{-43}, true);
+    TEST(_Unsigned128{42} >= -43, false);
+    TEST(_Signed128{42} >= -43, true);
+    TEST(42 >= _Signed128{-43}, true);
+    TEST(42 >= _Unsigned128{-43}, false);
 
     // The logical binary operators behave just like they do for integral types;
     // the individual operands are converted to bool and the operation performed
     // normally.
 
-    TEST(_Uint128{42} && 0, false);
-    TEST(_Int128{42} && 0, false);
-    TEST(42 && _Int128{0}, false);
-    TEST(42 && _Uint128{0}, false);
-    TEST(_Uint128{42} || 0, true);
-    TEST(_Int128{42} || 0, true);
-    TEST(42 || _Int128{0}, true);
-    TEST(42 || _Uint128{0}, true);
+    TEST(_Unsigned128{42} && 0, false);
+    TEST(_Signed128{42} && 0, false);
+    TEST(42 && _Signed128{0}, false);
+    TEST(42 && _Unsigned128{0}, false);
+    TEST(_Unsigned128{42} || 0, true);
+    TEST(_Signed128{42} || 0, true);
+    TEST(42 || _Signed128{0}, true);
+    TEST(42 || _Unsigned128{0}, true);
 
     // Assignments convert the RHS to the type of the LHS, just as for integral
     // types.
     {
-        _Uint128 u;
-        _Int128 i;
-        _Uint128 x = 42;
-        _Int128 y  = 13;
+        _Unsigned128 u;
+        _Signed128 i;
+        _Unsigned128 x = 42;
+        _Signed128 y   = 13;
         TEST(u = 42, x);
         TEST(i = 13, y);
 
@@ -998,7 +999,7 @@ constexpr bool test_cross() {
         y = 12;
         TEST(i *= -2, y);
 
-        x = _Uint128{0x55555555'5555554c, 0x55555555'55555555};
+        x = _Unsigned128{0x55555555'5555554c, 0x55555555'55555555};
         TEST(u /= 3, x); // Yes, u is still unsigned =)
         y = 4;
         TEST(i /= 3, y);

--- a/tests/std/tests/P1522R1_difference_type/test.cpp
+++ b/tests/std/tests/P1522R1_difference_type/test.cpp
@@ -421,30 +421,60 @@ constexpr bool test_signed() {
         assert(static_cast<std::int32_t>(nu) == -42);
         assert(static_cast<std::int16_t>(nu) == -42);
         assert(static_cast<std::int8_t>(nu) == -42);
+    }
 
-        _Int128 sum = u + nu;
-        assert(sum._Word[0] == 0);
+    {
+        _Int128 u{42};
+        _Int128 v{13};
+        _Int128 sum = u + v;
+        assert(sum._Word[0] == 55);
         assert(sum._Word[1] == 0);
-
-        --sum;
-        assert(sum._Word[0] == 0ull - 1);
-        assert(sum._Word[1] == 0ull - 1);
-        --sum;
-        assert(sum._Word[0] == 0ull - 2);
-        assert(sum._Word[1] == 0ull - 1);
-        ++sum;
-        assert(sum._Word[0] == 0ull - 1);
-        assert(sum._Word[1] == 0ull - 1);
-        ++sum;
-        assert(sum._Word[0] == 0);
+        sum = v + u;
+        assert(sum._Word[0] == 55);
         assert(sum._Word[1] == 0);
+        _Int128 diff = u - v;
+        assert(diff._Word[0] == 29);
+        assert(diff._Word[1] == 0);
+        diff = v - u;
+        assert(diff._Word[0] == 0ull - 29);
+        assert(diff._Word[1] == ~0ull);
 
-        _Int128 product = u * u;
-        assert(product._Word[0] == 42 * 42);
+        u   = -u;
+        sum = u + v;
+        assert(diff._Word[0] == 0ull - 29);
+        assert(diff._Word[1] == ~0ull);
+        sum = v + u;
+        assert(diff._Word[0] == 0ull - 29);
+        assert(diff._Word[1] == ~0ull);
+        diff = u - v;
+        assert(diff._Word[0] == 0ull - 55);
+        assert(diff._Word[1] == ~0ull);
+        diff = v - u;
+        assert(diff._Word[0] == 55);
+        assert(diff._Word[1] == 0);
+
+        u               = -u;
+        _Int128 product = u * v;
+        assert(product._Word[0] == 42 * 13);
+        assert(product._Word[1] == 0);
+        product = v * u;
+        assert(product._Word[0] == 42 * 13);
         assert(product._Word[1] == 0);
 
-        product = nu * nu;
-        assert(product._Word[0] == 42 * 42);
+        v       = -v;
+        product = u * v;
+        assert(product._Word[0] == 0ull - (42 * 13));
+        assert(product._Word[1] == ~0ull);
+        product = v * u;
+        assert(product._Word[0] == 0ull - (42 * 13));
+        assert(product._Word[1] == ~0ull);
+
+        u       = -u;
+        product = u * v;
+        assert(product._Word[0] == 42 * 13);
+        assert(product._Word[1] == 0);
+        product = v * u;
+        assert(product._Word[0] == 42 * 13);
         assert(product._Word[1] == 0);
 
         product = _Int128{0x01010101'01010101, 0x01010101'01010101} * 5;
@@ -487,6 +517,30 @@ constexpr bool test_signed() {
         assert(q._Word[1] == 0);
 
         q = _Int128{4} / _Int128{13};
+        assert(q._Word[0] == 0);
+        assert(q._Word[1] == 0);
+
+        q = _Int128{13} / _Int128{-4};
+        assert(q._Word[0] == 0ull - 3);
+        assert(q._Word[1] == ~0ull);
+
+        q = _Int128{-4} / _Int128{13};
+        assert(q._Word[0] == 0);
+        assert(q._Word[1] == 0);
+
+        q = _Int128{-13} / _Int128{4};
+        assert(q._Word[0] == 0ull - 3);
+        assert(q._Word[1] == ~0ull);
+
+        q = _Int128{4} / _Int128{-13};
+        assert(q._Word[0] == 0);
+        assert(q._Word[1] == 0);
+
+        q = _Int128{-13} / _Int128{-4};
+        assert(q._Word[0] == 3);
+        assert(q._Word[1] == 0);
+
+        q = _Int128{-4} / _Int128{-13};
         assert(q._Word[0] == 0);
         assert(q._Word[1] == 0);
 
@@ -540,6 +594,38 @@ constexpr bool test_signed() {
             assert(tmp % tmp == 0);
         }
         assert(tmp == 0);
+
+        _Int128 r = _Int128{13} % _Int128{4};
+        assert(r._Word[0] == 1);
+        assert(r._Word[1] == 0);
+
+        r = _Int128{4} % _Int128{13};
+        assert(r._Word[0] == 4);
+        assert(r._Word[1] == 0);
+
+        r = _Int128{13} % _Int128{-4};
+        assert(r._Word[0] == 1);
+        assert(r._Word[1] == 0);
+
+        r = _Int128{-4} % _Int128{13};
+        assert(r._Word[0] == 0ull - 4);
+        assert(r._Word[1] == ~0ull);
+
+        r = _Int128{-13} % _Int128{4};
+        assert(r._Word[0] == 0ull - 1);
+        assert(r._Word[1] == ~0ull);
+
+        r = _Int128{4} % _Int128{-13};
+        assert(r._Word[0] == 4);
+        assert(r._Word[1] == 0);
+
+        r = _Int128{-13} % _Int128{-4};
+        assert(r._Word[0] == 0ull - 1);
+        assert(r._Word[1] == ~0ull);
+
+        r = _Int128{-4} % _Int128{-13};
+        assert(r._Word[0] == 0ull - 4);
+        assert(r._Word[1] == ~0ull);
     }
 
     {
@@ -662,5 +748,5 @@ int main() {
     test_signed();
     static_assert(test_signed());
     test_cross();
-    // FIXME static_assert(test_cross());
+    static_assert(test_cross());
 }

--- a/tests/std/tests/P1522R1_difference_type/test.cpp
+++ b/tests/std/tests/P1522R1_difference_type/test.cpp
@@ -69,6 +69,7 @@ constexpr bool test_unsigned() {
     static_assert(std::same_as<std::common_type_t<unsigned long, _Uint128>, _Uint128>);
     static_assert(std::same_as<std::common_type_t<long long, _Uint128>, _Uint128>);
     static_assert(std::same_as<std::common_type_t<unsigned long long, _Uint128>, _Uint128>);
+    static_assert(std::same_as<std::common_type_t<_Int128, _Uint128>, _Uint128>);
 
     static_assert(std::same_as<std::common_type_t<_Uint128, bool>, _Uint128>);
     static_assert(std::same_as<std::common_type_t<_Uint128, char>, _Uint128>);
@@ -88,6 +89,7 @@ constexpr bool test_unsigned() {
     static_assert(std::same_as<std::common_type_t<_Uint128, unsigned long>, _Uint128>);
     static_assert(std::same_as<std::common_type_t<_Uint128, long long>, _Uint128>);
     static_assert(std::same_as<std::common_type_t<_Uint128, unsigned long long>, _Uint128>);
+    static_assert(std::same_as<std::common_type_t<_Uint128, _Int128>, _Uint128>);
 
     static_assert(std::_Integer_class<_Uint128>);
     static_assert(std::_Integer_like<_Uint128>);
@@ -137,67 +139,68 @@ constexpr bool test_unsigned() {
         assert(static_cast<std::int32_t>(nu) == -42);
         assert(static_cast<std::int16_t>(nu) == -42);
         assert(static_cast<std::int8_t>(nu) == -42);
+        {
+            _Uint128 sum = u + nu;
+            assert(sum._Word[0] == 0);
+            assert(sum._Word[1] == 0);
 
-        _Uint128 sum = u + nu;
-        assert(sum._Word[0] == 0);
-        assert(sum._Word[1] == 0);
+            --sum;
+            assert(sum._Word[0] == 0ull - 1);
+            assert(sum._Word[1] == 0ull - 1);
+            --sum;
+            assert(sum._Word[0] == 0ull - 2);
+            assert(sum._Word[1] == 0ull - 1);
+            ++sum;
+            assert(sum._Word[0] == 0ull - 1);
+            assert(sum._Word[1] == 0ull - 1);
+            ++sum;
+            assert(sum._Word[0] == 0);
+            assert(sum._Word[1] == 0);
+        }
+        {
+            _Uint128 product = u * u;
+            assert(product._Word[0] == 42 * 42);
+            assert(product._Word[1] == 0);
 
-        --sum;
-        assert(sum._Word[0] == 0ull - 1);
-        assert(sum._Word[1] == 0ull - 1);
-        --sum;
-        assert(sum._Word[0] == 0ull - 2);
-        assert(sum._Word[1] == 0ull - 1);
-        ++sum;
-        assert(sum._Word[0] == 0ull - 1);
-        assert(sum._Word[1] == 0ull - 1);
-        ++sum;
-        assert(sum._Word[0] == 0);
-        assert(sum._Word[1] == 0);
+            product = nu * nu;
+            assert(product._Word[0] == 42 * 42);
+            assert(product._Word[1] == 0);
 
-        _Uint128 product = u * u;
-        assert(product._Word[0] == 42 * 42);
-        assert(product._Word[1] == 0);
+            product = _Uint128{0x01010101'01010101, 0x01010101'01010101} * 5;
+            assert(product._Word[0] == 0x05050505'05050505);
+            assert(product._Word[1] == 0x05050505'05050505);
 
-        product = nu * nu;
-        assert(product._Word[0] == 42 * 42);
-        assert(product._Word[1] == 0);
+            product = 5 * _Uint128{0x01010101'01010101, 0x01010101'01010101};
+            assert(product._Word[0] == 0x05050505'05050505);
+            assert(product._Word[1] == 0x05050505'05050505);
 
-        product = _Uint128{0x01010101'01010101, 0x01010101'01010101} * 5;
-        assert(product._Word[0] == 0x05050505'05050505);
-        assert(product._Word[1] == 0x05050505'05050505);
+            product = _Uint128{0x01010101'01010101, 0x01010101'01010101};
+            product *= product;
+            assert(product._Word[0] == 0x08070605'04030201);
+            assert(product._Word[1] == 0x100f0e0d'0c0b0a09);
+            assert(+product == product);
+            assert(-product + product == 0);
 
-        product = 5 * _Uint128{0x01010101'01010101, 0x01010101'01010101};
-        assert(product._Word[0] == 0x05050505'05050505);
-        assert(product._Word[1] == 0x05050505'05050505);
+            product =
+                _Uint128{0x01020304'05060708, 0x090a0b0c'0d0e0f00} * _Uint128{0x000f0e0d'0c0b0a09, 0x08070605'04030201};
+            assert(product._Word[0] == 0x6dc18e55'16d48f48);
+            assert(product._Word[1] == 0xdc1b6bce'43cd6c21);
+            assert(+product == product);
+            assert(-product + product == 0);
 
-        product = _Uint128{0x01010101'01010101, 0x01010101'01010101};
-        product *= product;
-        assert(product._Word[0] == 0x08070605'04030201);
-        assert(product._Word[1] == 0x100f0e0d'0c0b0a09);
-        assert(+product == product);
-        assert(-product + product == 0);
+            product <<= 11;
+            assert(product._Word[0] == 0x0c72a8b6'a47a4000);
+            assert(product._Word[1] == 0xdb5e721e'6b610b6e);
+            assert(+product == product);
+            assert(-product + product == 0);
 
-        product =
-            _Uint128{0x01020304'05060708, 0x090a0b0c'0d0e0f00} * _Uint128{0x000f0e0d'0c0b0a09, 0x08070605'04030201};
-        assert(product._Word[0] == 0x6dc18e55'16d48f48);
-        assert(product._Word[1] == 0xdc1b6bce'43cd6c21);
-        assert(+product == product);
-        assert(-product + product == 0);
-
-        product <<= 11;
-        assert(product._Word[0] == 0x0c72a8b6'a47a4000);
-        assert(product._Word[1] == 0xdb5e721e'6b610b6e);
-        assert(+product == product);
-        assert(-product + product == 0);
-
-        product >>= 17;
-        assert(product._Word[0] == 0x85b70639'545b523d);
-        assert(product._Word[1] == 0x00006daf'390f35b0);
-        assert(+product == product);
-        assert(-product + product == 0);
+            product >>= 17;
+            assert(product._Word[0] == 0x85b70639'545b523d);
+            assert(product._Word[1] == 0x00006daf'390f35b0);
+            assert(+product == product);
+            assert(-product + product == 0);
+        }
     }
-
     {
         _Uint128 q = _Uint128{13} / _Uint128{4};
         assert(q._Word[0] == 3);
@@ -218,11 +221,12 @@ constexpr bool test_unsigned() {
         q = (_Uint128{1} << 66) / (_Uint128{1} << 13);
         assert(q._Word[0] == 1ull << 53);
         assert(q._Word[1] == 0);
-
+    }
+    {
         auto tmp = ~_Uint128{};
         assert(tmp._Word[0] == ~0ull);
         assert(tmp._Word[1] == ~0ull);
-        q = tmp / std::uint32_t{1};
+        auto q = tmp / std::uint32_t{1};
         assert(q == tmp);
         q = tmp / std::uint64_t{1};
         assert(q == tmp);
@@ -232,10 +236,12 @@ constexpr bool test_unsigned() {
         q = tmp / _Uint128{1ull << 32};
         assert(q._Word[0] == ~0ull);
         assert(q._Word[1] == 0xffffffff);
-
+    }
+    {
         _Uint128 result{0x01010101'01010101, 0x01010101'01010101};
+        _Uint128 tmp;
         for (tmp = 0xffu; static_cast<bool>(tmp); tmp <<= 8, result >>= 8) {
-            q = ~_Uint128{} / tmp;
+            auto q = ~_Uint128{} / tmp;
             assert(q == result);
             auto m    = ~_Uint128{} % tmp;
             auto p    = q * tmp;
@@ -243,13 +249,14 @@ constexpr bool test_unsigned() {
             assert(m == diff);
         }
         assert(tmp == 0);
-
+    }
+    {
+        _Uint128 tmp;
         for (tmp = 1; static_cast<bool>(tmp); tmp <<= 1) {
             assert(tmp % tmp == 0);
         }
         assert(tmp == 0);
     }
-
     {
         const _Uint128 x{0x01020304'02030405, 0x03040506'04050607};
         const _Uint128 y{0x07060504'06050403, 0x05040302'04030101};
@@ -268,7 +275,6 @@ constexpr bool test_unsigned() {
         tmp ^= y;
         assert(tmp == (x ^ y));
     }
-
     {
         _Uint128 x{};
         assert(++x == 1);
@@ -407,7 +413,8 @@ constexpr bool test_signed() {
         assert(static_cast<std::int32_t>(u) == 42);
         assert(static_cast<std::int16_t>(u) == 42);
         assert(static_cast<std::int8_t>(u) == 42);
-
+    }
+    {
         _Int128 nu{-42};
         assert(nu._Word[0] == 0ull - 42);
         assert(nu._Word[1] == ~0ull);
@@ -426,73 +433,87 @@ constexpr bool test_signed() {
     {
         _Int128 u{42};
         _Int128 v{13};
-        _Int128 sum = u + v;
-        assert(sum._Word[0] == 55);
-        assert(sum._Word[1] == 0);
-        sum = v + u;
-        assert(sum._Word[0] == 55);
-        assert(sum._Word[1] == 0);
-        _Int128 diff = u - v;
-        assert(diff._Word[0] == 29);
-        assert(diff._Word[1] == 0);
-        diff = v - u;
-        assert(diff._Word[0] == 0ull - 29);
-        assert(diff._Word[1] == ~0ull);
-
-        u   = -u;
-        sum = u + v;
-        assert(diff._Word[0] == 0ull - 29);
-        assert(diff._Word[1] == ~0ull);
-        sum = v + u;
-        assert(diff._Word[0] == 0ull - 29);
-        assert(diff._Word[1] == ~0ull);
-        diff = u - v;
-        assert(diff._Word[0] == 0ull - 55);
-        assert(diff._Word[1] == ~0ull);
-        diff = v - u;
-        assert(diff._Word[0] == 55);
-        assert(diff._Word[1] == 0);
-
-        u               = -u;
-        _Int128 product = u * v;
-        assert(product._Word[0] == 42 * 13);
-        assert(product._Word[1] == 0);
-        product = v * u;
-        assert(product._Word[0] == 42 * 13);
-        assert(product._Word[1] == 0);
-
-        v       = -v;
-        product = u * v;
-        assert(product._Word[0] == 0ull - (42 * 13));
-        assert(product._Word[1] == ~0ull);
-        product = v * u;
-        assert(product._Word[0] == 0ull - (42 * 13));
-        assert(product._Word[1] == ~0ull);
-
-        u       = -u;
-        product = u * v;
-        assert(product._Word[0] == 42 * 13);
-        assert(product._Word[1] == 0);
-        product = v * u;
-        assert(product._Word[0] == 42 * 13);
-        assert(product._Word[1] == 0);
-
-        product = _Int128{0x01010101'01010101, 0x01010101'01010101} * 5;
+        {
+            _Int128 sum = u + v;
+            assert(sum._Word[0] == 55);
+            assert(sum._Word[1] == 0);
+            sum = v + u;
+            assert(sum._Word[0] == 55);
+            assert(sum._Word[1] == 0);
+        }
+        {
+            _Int128 diff = u - v;
+            assert(diff._Word[0] == 29);
+            assert(diff._Word[1] == 0);
+            diff = v - u;
+            assert(diff._Word[0] == 0ull - 29);
+            assert(diff._Word[1] == ~0ull);
+        }
+        {
+            u           = -u;
+            _Int128 sum = u + v;
+            assert(sum._Word[0] == 0ull - 29);
+            assert(sum._Word[1] == ~0ull);
+            sum = v + u;
+            assert(sum._Word[0] == 0ull - 29);
+            assert(sum._Word[1] == ~0ull);
+        }
+        {
+            _Int128 diff = u - v;
+            assert(diff._Word[0] == 0ull - 55);
+            assert(diff._Word[1] == ~0ull);
+            diff = v - u;
+            assert(diff._Word[0] == 55);
+            assert(diff._Word[1] == 0);
+        }
+        {
+            u               = -u;
+            _Int128 product = u * v;
+            assert(product._Word[0] == 42 * 13);
+            assert(product._Word[1] == 0);
+            product = v * u;
+            assert(product._Word[0] == 42 * 13);
+            assert(product._Word[1] == 0);
+        }
+        {
+            v               = -v;
+            _Int128 product = u * v;
+            assert(product._Word[0] == 0ull - (42 * 13));
+            assert(product._Word[1] == ~0ull);
+            product = v * u;
+            assert(product._Word[0] == 0ull - (42 * 13));
+            assert(product._Word[1] == ~0ull);
+        }
+        {
+            u               = -u;
+            _Int128 product = u * v;
+            assert(product._Word[0] == 42 * 13);
+            assert(product._Word[1] == 0);
+            product = v * u;
+            assert(product._Word[0] == 42 * 13);
+            assert(product._Word[1] == 0);
+        }
+    }
+    {
+        auto product = _Int128{0x01010101'01010101, 0x01010101'01010101} * 5;
         assert(product._Word[0] == 0x05050505'05050505);
         assert(product._Word[1] == 0x05050505'05050505);
 
         product = 5 * _Int128{0x01010101'01010101, 0x01010101'01010101};
         assert(product._Word[0] == 0x05050505'05050505);
         assert(product._Word[1] == 0x05050505'05050505);
-
-        product = _Int128{0x01010101'01010101, 0x01010101'01010101};
+    }
+    {
+        auto product = _Int128{0x01010101'01010101, 0x01010101'01010101};
         product *= product;
         assert(product._Word[0] == 0x08070605'04030201);
         assert(product._Word[1] == 0x100f0e0d'0c0b0a09);
         assert(+product == product);
         assert(-product + product == 0);
-
-        product = _Int128{0x01020304'05060708, 0x090a0b0c'0d0e0f00} * _Int128{0x000f0e0d'0c0b0a09, 0x08070605'04030201};
+    }
+    {
+        auto product =
+            _Int128{0x01020304'05060708, 0x090a0b0c'0d0e0f00} * _Int128{0x000f0e0d'0c0b0a09, 0x08070605'04030201};
         assert(product._Word[0] == 0x6dc18e55'16d48f48);
         assert(product._Word[1] == 0xdc1b6bce'43cd6c21);
         assert(+product == product);
@@ -510,7 +531,6 @@ constexpr bool test_signed() {
         assert(+product == product);
         assert(-product + product == 0);
     }
-
     {
         _Int128 q = _Int128{13} / _Int128{4};
         assert(q._Word[0] == 3);
@@ -555,11 +575,12 @@ constexpr bool test_signed() {
         q = (_Int128{1} << 66) / (_Int128{1} << 13);
         assert(q._Word[0] == 1ull << 53);
         assert(q._Word[1] == 0);
-
+    }
+    {
         auto tmp = ~_Int128{};
         assert(tmp._Word[0] == ~0ull);
         assert(tmp._Word[1] == ~0ull);
-        q = tmp / std::uint32_t{1};
+        _Int128 q = tmp / std::uint32_t{1};
         assert(q == tmp);
         q = tmp / std::uint64_t{1};
         assert(q == tmp);
@@ -569,32 +590,37 @@ constexpr bool test_signed() {
         q = tmp / _Int128{1ull << 32};
         assert(q._Word[0] == 0);
         assert(q._Word[1] == 0);
-
+    }
+    {
         _Int128 result{0x80808080'80808080, 0x00808080'80808080};
-        for (tmp = 0xffu; tmp > 0; tmp <<= 8, result >>= 8) {
-            q = std::numeric_limits<_Int128>::max() / tmp;
+        for (_Int128 tmp = 0xffu; tmp > 0; tmp <<= 8, result >>= 8) {
+            auto q = std::numeric_limits<_Int128>::max() / tmp;
             assert(q == result);
             auto m    = std::numeric_limits<_Int128>::max() % tmp;
             auto p    = q * tmp;
             auto diff = std::numeric_limits<_Int128>::max() - p;
             assert(m == diff);
         }
-
-        result = _Int128{0x7f7f7f7f'7f7f7f80, 0xff7f7f7f'7f7f7f7f};
-        for (tmp = 0xffu; tmp > 0; tmp <<= 8, result = (result >> 8) + 1) {
-            q = std::numeric_limits<_Int128>::min() / tmp;
+    }
+    {
+        _Int128 result = _Int128{0x7f7f7f7f'7f7f7f80, 0xff7f7f7f'7f7f7f7f};
+        for (_Int128 tmp = 0xffu; tmp > 0; tmp <<= 8, result = (result >> 8) + 1) {
+            auto q = std::numeric_limits<_Int128>::min() / tmp;
             assert(q == result);
             auto m    = std::numeric_limits<_Int128>::min() % tmp;
             auto p    = q * tmp;
             auto diff = std::numeric_limits<_Int128>::min() - p;
             assert(m == diff);
         }
-
+    }
+    {
+        _Int128 tmp;
         for (tmp = 1; static_cast<bool>(tmp); tmp <<= 1) {
             assert(tmp % tmp == 0);
         }
         assert(tmp == 0);
-
+    }
+    {
         _Int128 r = _Int128{13} % _Int128{4};
         assert(r._Word[0] == 1);
         assert(r._Word[1] == 0);
@@ -627,7 +653,6 @@ constexpr bool test_signed() {
         assert(r._Word[0] == 0ull - 4);
         assert(r._Word[1] == ~0ull);
     }
-
     {
         const _Int128 x{0x01020304'02030405, 0x03040506'04050607};
         const _Int128 y{0x07060504'06050403, 0x05040302'04030101};
@@ -646,7 +671,6 @@ constexpr bool test_signed() {
         tmp ^= y;
         assert(tmp == (x ^ y));
     }
-
     {
         _Int128 x{};
         assert(++x == 1);
@@ -777,64 +801,65 @@ constexpr bool test_cross() {
 
     // Assignments convert the RHS to the type of the LHS, just as for integral
     // types.
+    {
+        _Uint128 u{};
+        _Uint128 x{42};
+        _Int128 i{42};
+        _Int128 y{13};
+        TEST(u = i, x);
+        u = 13;
+        TEST(i = u, y);
 
-    _Uint128 u{};
-    _Uint128 x{42};
-    _Int128 i{42};
-    _Int128 y{13};
-    TEST(u = i, x);
-    u = 13;
-    TEST(i = u, y);
+        x = 26;
+        TEST(u += i, x);
+        y = 39;
+        TEST(i += u, y);
 
-    x = 26;
-    TEST(u += i, x);
-    y = 39;
-    TEST(i += u, y);
+        x = -13;
+        TEST(u -= i, x);
+        y = 52;
+        TEST(i -= u, y);
 
-    x = -13;
-    TEST(u -= i, x);
-    y = 52;
-    TEST(i -= u, y);
+        x = -26;
+        TEST(u *= _Int128{2}, x);
+        y = 104;
+        TEST(i *= _Uint128{2}, y);
 
-    x = -26;
-    TEST(u *= _Int128{2}, x);
-    y = 104;
-    TEST(i *= _Uint128{2}, y);
+        x = _Uint128{0x55555555'5555554c, 0x55555555'55555555};
+        TEST(u /= _Int128{3}, x); // Yes, u is still unsigned =)
+        y = 34;
+        TEST(i /= _Uint128{3}, y);
 
-    x = _Uint128{0x55555555'5555554c, 0x55555555'55555555};
-    TEST(u /= _Int128{3}, x); // Yes, u is still unsigned =)
-    y = 34;
-    TEST(i /= _Uint128{3}, y);
+        x = 4;
+        TEST(u %= _Int128{8}, x);
+        y = 2;
+        TEST(i %= _Uint128{8}, y);
 
-    x = 4;
-    TEST(u %= _Int128{8}, x);
-    y = 2;
-    TEST(i %= _Uint128{8}, y);
+        x = 16;
+        TEST(u <<= _Int128{2}, x);
+        y = 8;
+        TEST(i <<= _Uint128{2}, y);
 
-    x = 16;
-    TEST(u <<= _Int128{2}, x);
-    y = 8;
-    TEST(i <<= _Uint128{2}, y);
+        x = 8;
+        TEST(u >>= _Int128{1}, x);
+        y = 4;
+        TEST(i >>= _Uint128{1}, y);
 
-    x = 8;
-    TEST(u >>= _Int128{1}, x);
-    y = 4;
-    TEST(i >>= _Uint128{1}, y);
+        x = 9;
+        TEST(u |= _Int128{1}, x);
+        y = 5;
+        TEST(i |= _Uint128{1}, y);
 
-    x = 9;
-    TEST(u |= _Int128{1}, x);
-    y = 5;
-    TEST(i |= _Uint128{1}, y);
+        x = 9;
+        TEST(u &= _Int128{59}, x);
+        y = 1;
+        TEST(i &= _Uint128{59}, y);
 
-    x = 9;
-    TEST(u &= _Int128{59}, x);
-    y = 1;
-    TEST(i &= _Uint128{59}, y);
-
-    x = 12;
-    TEST(u ^= _Int128{5}, x);
-    y = 4;
-    TEST(i ^= _Uint128{5}, y);
+        x = 12;
+        TEST(u ^= _Int128{5}, x);
+        y = 4;
+        TEST(i ^= _Uint128{5}, y);
+    }
 
     //////// Mixed integer and integer-class operands
 
@@ -950,62 +975,64 @@ constexpr bool test_cross() {
 
     // Assignments convert the RHS to the type of the LHS, just as for integral
     // types.
+    {
+        _Uint128 u;
+        _Int128 i;
+        _Uint128 x = 42;
+        _Int128 y  = 13;
+        TEST(u = 42, x);
+        TEST(i = 13, y);
 
-    x = 42;
-    y = 13;
-    TEST(u = 42, x);
-    TEST(i = 13, y);
+        x = 55;
+        TEST(u += 13, x);
+        y = 26;
+        TEST(i += 13, y);
 
-    x = 55;
-    TEST(u += 13, x);
-    y = 26;
-    TEST(i += 13, y);
+        x = -13;
+        TEST(u -= 68, x);
+        y = -6;
+        TEST(i -= 32, y);
 
-    x = -13;
-    TEST(u -= 68, x);
-    y = -6;
-    TEST(i -= 32, y);
+        x = -26;
+        TEST(u *= 2, x);
+        y = 12;
+        TEST(i *= -2, y);
 
-    x = -26;
-    TEST(u *= 2, x);
-    y = 12;
-    TEST(i *= -2, y);
+        x = _Uint128{0x55555555'5555554c, 0x55555555'55555555};
+        TEST(u /= 3, x); // Yes, u is still unsigned =)
+        y = 4;
+        TEST(i /= 3, y);
 
-    x = _Uint128{0x55555555'5555554c, 0x55555555'55555555};
-    TEST(u /= 3, x); // Yes, u is still unsigned =)
-    y = 4;
-    TEST(i /= 3, y);
+        x = 4;
+        TEST(u %= 8, x);
+        y = 4;
+        TEST(i %= 8, y);
 
-    x = 4;
-    TEST(u %= 8, x);
-    y = 4;
-    TEST(i %= 8, y);
+        x = 16;
+        TEST(u <<= 2, x);
+        y = 16;
+        TEST(i <<= 2, y);
 
-    x = 16;
-    TEST(u <<= 2, x);
-    y = 16;
-    TEST(i <<= 2, y);
+        x = 8;
+        TEST(u >>= 1, x);
+        y = 8;
+        TEST(i >>= 1, y);
 
-    x = 8;
-    TEST(u >>= 1, x);
-    y = 8;
-    TEST(i >>= 1, y);
+        x = 9;
+        TEST(u |= 9, x);
+        y = 10;
+        TEST(i |= 2, y);
 
-    x = 9;
-    TEST(u |= 9, x);
-    y = 10;
-    TEST(i |= 2, y);
+        x = 9;
+        TEST(u &= 59, x);
+        y = 10;
+        TEST(i &= 59, y);
 
-    x = 9;
-    TEST(u &= 59, x);
-    y = 10;
-    TEST(i &= 59, y);
-
-    x = 12;
-    TEST(u ^= 5, x);
-    y = 15;
-    TEST(i ^= 5, y);
-
+        x = 12;
+        TEST(u ^= 5, x);
+        y = 15;
+        TEST(i ^= 5, y);
+    }
 #undef TEST
 
     return true;

--- a/tests/std/tests/P1522R1_difference_type/test.cpp
+++ b/tests/std/tests/P1522R1_difference_type/test.cpp
@@ -711,6 +711,13 @@ constexpr bool test_cross() {
 
     TEST(_Uint128{1} << _Int128{43}, _Uint128{1ull << 43});
     TEST(_Int128{1} << _Uint128{43}, _Int128{1ull << 43});
+    TEST(_Uint128{-1} << _Int128{43}, _Uint128(0ull - (1ull << 43), ~0ull));
+    TEST(_Int128{-1} << _Uint128{43}, _Int128(0ull - (1ull << 43), ~0ull));
+
+    TEST(_Uint128(0, 1) >> _Int128{43}, _Uint128(1ull << 21));
+    TEST(_Int128(0, 1) >> _Uint128{43}, _Int128(1ull << 21));
+    TEST(_Uint128(0, ~0ull) >> _Int128{43}, _Uint128(~((1ull << 21) - 1), (1ull << 21) - 1));
+    TEST(_Int128(0, ~0ull) >> _Uint128{43}, _Int128(~((1ull << 21) - 1), ~0ull));
 
     TEST(false ? _Uint128{42} : _Int128{-43}, _Uint128{-43});
     TEST(true ? _Uint128{42} : _Int128{-43}, _Uint128{42});
@@ -748,5 +755,5 @@ int main() {
     test_signed();
     static_assert(test_signed());
     test_cross();
-    static_assert(test_cross());
+    // FIXME static_assert(test_cross());
 }

--- a/tests/std/tests/P1522R1_difference_type/test.cpp
+++ b/tests/std/tests/P1522R1_difference_type/test.cpp
@@ -683,6 +683,14 @@ constexpr bool test_signed() {
     return true;
 }
 
+template <class T>
+T val() noexcept;
+
+template <class T, class U>
+concept CanConditional = requires {
+    true ? val<T>() : val<U>();
+};
+
 constexpr bool test_cross() {
 #define TEST(expr, result)                                                                  \
     do {                                                                                    \
@@ -719,8 +727,8 @@ constexpr bool test_cross() {
     TEST(_Uint128(0, ~0ull) >> _Int128{43}, _Uint128(~((1ull << 21) - 1), (1ull << 21) - 1));
     TEST(_Int128(0, ~0ull) >> _Uint128{43}, _Int128(~((1ull << 21) - 1), ~0ull));
 
-    TEST(false ? _Uint128{42} : _Int128{-43}, _Uint128{-43});
-    TEST(true ? _Uint128{42} : _Int128{-43}, _Uint128{42});
+    static_assert(!CanConditional<_Uint128, _Int128>);
+    static_assert(!CanConditional<_Int128, _Uint128>);
 
     TEST(_Uint128{42} && _Int128{0}, false);
     TEST(_Int128{42} && _Uint128{0}, false);
@@ -732,8 +740,8 @@ constexpr bool test_cross() {
     TEST(_Uint128{42} != _Int128{0}, true);
     TEST(_Int128{42} != _Uint128{42}, false);
 
-    TEST(_Uint128{42} <=> _Int128{-43}, std::strong_ordering::less);
-    TEST(_Int128{42} <=> _Uint128{-43}, std::strong_ordering::less);
+    static_assert(!std::three_way_comparable_with<_Uint128, _Int128>);
+    static_assert(!std::three_way_comparable_with<_Int128, _Uint128>);
 
     TEST(_Uint128{42} < _Int128{-43}, true);
     TEST(_Int128{42} < _Uint128{-43}, true);

--- a/tests/std/tests/P1522R1_difference_type/test.cpp
+++ b/tests/std/tests/P1522R1_difference_type/test.cpp
@@ -719,13 +719,13 @@ constexpr bool test_cross() {
 
     TEST(_Uint128{1} << _Int128{43}, _Uint128{1ull << 43});
     TEST(_Int128{1} << _Uint128{43}, _Int128{1ull << 43});
-    TEST(_Uint128{-1} << _Int128{43}, _Uint128(0ull - (1ull << 43), ~0ull));
-    TEST(_Int128{-1} << _Uint128{43}, _Int128(0ull - (1ull << 43), ~0ull));
+    TEST(_Uint128{-1} << _Int128{43}, (_Uint128{0ull - (1ull << 43), ~0ull}));
+    TEST(_Int128{-1} << _Uint128{43}, (_Int128{0ull - (1ull << 43), ~0ull}));
 
-    TEST(_Uint128(0, 1) >> _Int128{43}, _Uint128(1ull << 21));
-    TEST(_Int128(0, 1) >> _Uint128{43}, _Int128(1ull << 21));
-    TEST(_Uint128(0, ~0ull) >> _Int128{43}, _Uint128(~((1ull << 21) - 1), (1ull << 21) - 1));
-    TEST(_Int128(0, ~0ull) >> _Uint128{43}, _Int128(~((1ull << 21) - 1), ~0ull));
+    TEST((_Uint128{0, 1}) >> _Int128{43}, _Uint128{1ull << 21});
+    TEST((_Int128{0, 1}) >> _Uint128{43}, _Int128{1ull << 21});
+    TEST((_Uint128{0, ~0ull} >> _Int128{43}), (_Uint128{~((1ull << 21) - 1), (1ull << 21) - 1}));
+    TEST((_Int128{0, ~0ull} >> _Uint128{43}), (_Int128{~((1ull << 21) - 1), ~0ull}));
 
     static_assert(!CanConditional<_Uint128, _Int128>);
     static_assert(!CanConditional<_Int128, _Uint128>);
@@ -763,5 +763,5 @@ int main() {
     test_signed();
     static_assert(test_signed());
     test_cross();
-    // FIXME static_assert(test_cross());
+    static_assert(test_cross());
 }

--- a/tests/std/tests/P1522R1_difference_type/test.cpp
+++ b/tests/std/tests/P1522R1_difference_type/test.cpp
@@ -269,6 +269,39 @@ constexpr bool test_unsigned() {
         assert(tmp == (x ^ y));
     }
 
+    {
+        _Uint128 x{};
+        assert(++x == 1);
+        assert(--x == 0);
+        assert(x == std::numeric_limits<_Uint128>::min());
+        --x;
+        assert(x._Word[0] == ~0ull);
+        assert(x._Word[1] == ~0ull);
+        assert(x == std::numeric_limits<_Uint128>::max());
+        --x;
+        assert(x._Word[0] == (~0ull << 1));
+        assert(x._Word[1] == ~0ull);
+        x._Word[0] = 0;
+        x._Word[1] = 1;
+        --x;
+        assert(x._Word[0] == ~0ull);
+        assert(x._Word[1] == 0);
+        ++x;
+        assert(x._Word[0] == 0);
+        assert(x._Word[1] == 1);
+        ++x;
+        assert(x._Word[0] == 1);
+        assert(x._Word[1] == 1);
+        x._Word[0] = ~0ull;
+        x._Word[1] = static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max());
+        ++x;
+        assert(x._Word[0] == 0);
+        assert(x._Word[1] == static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::min()));
+        --x;
+        assert(x._Word[0] == ~0ull);
+        assert(x._Word[1] == static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max()));
+    }
+
     return true;
 }
 
@@ -526,6 +559,39 @@ constexpr bool test_signed() {
         tmp = x;
         tmp ^= y;
         assert(tmp == (x ^ y));
+    }
+
+    {
+        _Int128 x{};
+        assert(++x == 1);
+        assert(--x == 0);
+        --x;
+        assert(x._Word[0] == ~0ull);
+        assert(x._Word[1] == ~0ull);
+        --x;
+        assert(x._Word[0] == (~0ull << 1));
+        assert(x._Word[1] == ~0ull);
+        x._Word[0] = 0;
+        x._Word[1] = 1;
+        --x;
+        assert(x._Word[0] == ~0ull);
+        assert(x._Word[1] == 0);
+        ++x;
+        assert(x._Word[0] == 0);
+        assert(x._Word[1] == 1);
+        ++x;
+        assert(x._Word[0] == 1);
+        assert(x._Word[1] == 1);
+        x._Word[0] = ~0ull;
+        x._Word[1] = static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max());
+        ++x;
+        assert(x._Word[0] == 0);
+        assert(x._Word[1] == static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::min()));
+        assert(x == std::numeric_limits<_Int128>::min());
+        --x;
+        assert(x._Word[0] == ~0ull);
+        assert(x._Word[1] == static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max()));
+        assert(x == std::numeric_limits<_Int128>::max());
     }
 
     return true;

--- a/tests/std/tests/P1522R1_difference_type/test.cpp
+++ b/tests/std/tests/P1522R1_difference_type/test.cpp
@@ -1,0 +1,529 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <__msvc_int128.hpp>
+#include <cassert>
+#include <compare>
+#include <concepts>
+#include <xutility>
+
+using std::_Int128;
+using std::_Uint128;
+
+constexpr void check_equal(const _Uint128& _Left) {
+    assert(_Left == _Left);
+    assert(!(_Left != _Left));
+    assert(!(_Left < _Left));
+    assert(!(_Left > _Left));
+    assert(_Left <= _Left);
+    assert(_Left >= _Left);
+    assert(_Left <=> _Left == 0);
+}
+
+constexpr void check_order(const _Uint128& _Left, const _Uint128& _Right, const std::strong_ordering _Ord) {
+    assert((_Left == _Right) == (_Ord == std::strong_ordering::equal));
+    assert((_Left != _Right) == (_Ord != std::strong_ordering::equal));
+    assert((_Left < _Right) == (_Ord == std::strong_ordering::less));
+    assert((_Left > _Right) == (_Ord == std::strong_ordering::greater));
+    assert((_Left <= _Right) == (_Ord != std::strong_ordering::greater));
+    assert((_Left >= _Right) == (_Ord != std::strong_ordering::less));
+
+    assert((_Right == _Left) == (_Ord == std::strong_ordering::equal));
+    assert((_Right != _Left) == (_Ord != std::strong_ordering::equal));
+    assert((_Right < _Left) == (_Ord == std::strong_ordering::greater));
+    assert((_Right > _Left) == (_Ord == std::strong_ordering::less));
+    assert((_Right <= _Left) == (_Ord != std::strong_ordering::less));
+    assert((_Right >= _Left) == (_Ord != std::strong_ordering::greater));
+}
+
+constexpr bool test_unsigned() {
+    static_assert(std::regular<_Uint128>);
+    static_assert(std::three_way_comparable<_Uint128, std::strong_ordering>);
+
+    static_assert(std::numeric_limits<_Uint128>::min() == 0);
+    static_assert(std::numeric_limits<_Uint128>::max() == ~_Uint128{});
+    static_assert(std::numeric_limits<_Uint128>::digits == 128);
+    static_assert(std::numeric_limits<_Uint128>::is_modulo);
+
+    static_assert(std::same_as<std::common_type_t<bool, _Uint128>, _Uint128>);
+    static_assert(std::same_as<std::common_type_t<char, _Uint128>, _Uint128>);
+    static_assert(std::same_as<std::common_type_t<signed char, _Uint128>, _Uint128>);
+    static_assert(std::same_as<std::common_type_t<unsigned char, _Uint128>, _Uint128>);
+#ifdef __cpp_char8_t
+    static_assert(std::same_as<std::common_type_t<char8_t, _Uint128>, _Uint128>);
+#endif // __cpp_char8_t
+    static_assert(std::same_as<std::common_type_t<char16_t, _Uint128>, _Uint128>);
+    static_assert(std::same_as<std::common_type_t<char32_t, _Uint128>, _Uint128>);
+    static_assert(std::same_as<std::common_type_t<short, _Uint128>, _Uint128>);
+    static_assert(std::same_as<std::common_type_t<unsigned short, _Uint128>, _Uint128>);
+    static_assert(std::same_as<std::common_type_t<int, _Uint128>, _Uint128>);
+    static_assert(std::same_as<std::common_type_t<unsigned int, _Uint128>, _Uint128>);
+    static_assert(std::same_as<std::common_type_t<long, _Uint128>, _Uint128>);
+    static_assert(std::same_as<std::common_type_t<unsigned long, _Uint128>, _Uint128>);
+    static_assert(std::same_as<std::common_type_t<long long, _Uint128>, _Uint128>);
+    static_assert(std::same_as<std::common_type_t<unsigned long long, _Uint128>, _Uint128>);
+
+    static_assert(std::same_as<std::common_type_t<_Uint128, bool>, _Uint128>);
+    static_assert(std::same_as<std::common_type_t<_Uint128, char>, _Uint128>);
+    static_assert(std::same_as<std::common_type_t<_Uint128, signed char>, _Uint128>);
+    static_assert(std::same_as<std::common_type_t<_Uint128, unsigned char>, _Uint128>);
+#ifdef __cpp_char8_t
+    static_assert(std::same_as<std::common_type_t<_Uint128, char8_t>, _Uint128>);
+#endif // __cpp_char8_t
+    static_assert(std::same_as<std::common_type_t<_Uint128, char16_t>, _Uint128>);
+    static_assert(std::same_as<std::common_type_t<_Uint128, char32_t>, _Uint128>);
+    static_assert(std::same_as<std::common_type_t<_Uint128, short>, _Uint128>);
+    static_assert(std::same_as<std::common_type_t<_Uint128, unsigned short>, _Uint128>);
+    static_assert(std::same_as<std::common_type_t<_Uint128, int>, _Uint128>);
+    static_assert(std::same_as<std::common_type_t<_Uint128, unsigned int>, _Uint128>);
+    static_assert(std::same_as<std::common_type_t<_Uint128, long>, _Uint128>);
+    static_assert(std::same_as<std::common_type_t<_Uint128, unsigned long>, _Uint128>);
+    static_assert(std::same_as<std::common_type_t<_Uint128, long long>, _Uint128>);
+    static_assert(std::same_as<std::common_type_t<_Uint128, unsigned long long>, _Uint128>);
+
+    static_assert(std::_Integer_class<_Uint128>);
+    static_assert(std::_Integer_like<_Uint128>);
+    static_assert(!std::_Signed_integer_like<_Uint128>);
+    static_assert(std::same_as<std::_Make_unsigned_like_t<_Uint128>, _Uint128>);
+    static_assert(std::same_as<std::_Make_signed_like_t<_Uint128>, _Int128>);
+
+    check_equal(_Uint128{});
+    check_equal(_Uint128{42});
+    check_equal(_Uint128{-42});
+    check_equal(_Uint128{0x11111111'11111111, 0x22222222'22222222});
+
+    check_order(_Uint128{42}, _Uint128{-42}, std::strong_ordering::less);
+    check_order(_Uint128{0x11111111'11111111, 0x22222222'22222222}, _Uint128{0x01010101'01010101, 0x01010101'01010101},
+        std::strong_ordering::greater);
+
+    {
+        _Uint128 u{42};
+        assert(u._Word[0] == 42);
+        assert(u._Word[1] == 0);
+        u += _Uint128{0};
+        assert(u._Word[0] == 42);
+        assert(u._Word[1] == 0);
+
+        assert(static_cast<std::uint64_t>(u) == 42);
+        assert(static_cast<std::uint32_t>(u) == 42);
+        assert(static_cast<std::uint16_t>(u) == 42);
+        assert(static_cast<std::uint8_t>(u) == 42);
+
+        assert(static_cast<std::int64_t>(u) == 42);
+        assert(static_cast<std::int32_t>(u) == 42);
+        assert(static_cast<std::int16_t>(u) == 42);
+        assert(static_cast<std::int8_t>(u) == 42);
+
+        _Uint128 nu{-42};
+        assert(nu._Word[0] == 0ull - 42);
+        assert(nu._Word[1] == ~0ull);
+
+        assert(static_cast<std::uint64_t>(nu) == 0ull - 42);
+        assert(static_cast<std::uint32_t>(nu) == 0u - 42);
+        assert(static_cast<std::uint16_t>(nu) == 65536 - 42);
+        assert(static_cast<std::uint8_t>(nu) == 256 - 42);
+
+        assert(static_cast<std::int64_t>(nu) == -42);
+        assert(static_cast<std::int32_t>(nu) == -42);
+        assert(static_cast<std::int16_t>(nu) == -42);
+        assert(static_cast<std::int8_t>(nu) == -42);
+
+        _Uint128 sum = u + nu;
+        assert(sum._Word[0] == 0);
+        assert(sum._Word[1] == 0);
+
+        --sum;
+        assert(sum._Word[0] == 0ull - 1);
+        assert(sum._Word[1] == 0ull - 1);
+        --sum;
+        assert(sum._Word[0] == 0ull - 2);
+        assert(sum._Word[1] == 0ull - 1);
+        ++sum;
+        assert(sum._Word[0] == 0ull - 1);
+        assert(sum._Word[1] == 0ull - 1);
+        ++sum;
+        assert(sum._Word[0] == 0);
+        assert(sum._Word[1] == 0);
+
+        _Uint128 product = u * u;
+        assert(product._Word[0] == 42 * 42);
+        assert(product._Word[1] == 0);
+
+        product = nu * nu;
+        assert(product._Word[0] == 42 * 42);
+        assert(product._Word[1] == 0);
+
+        product = _Uint128{0x01010101'01010101, 0x01010101'01010101} * 5;
+        assert(product._Word[0] == 0x05050505'05050505);
+        assert(product._Word[1] == 0x05050505'05050505);
+
+        product = 5 * _Uint128{0x01010101'01010101, 0x01010101'01010101};
+        assert(product._Word[0] == 0x05050505'05050505);
+        assert(product._Word[1] == 0x05050505'05050505);
+
+        product = _Uint128{0x01010101'01010101, 0x01010101'01010101};
+        product *= product;
+        assert(product._Word[0] == 0x08070605'04030201);
+        assert(product._Word[1] == 0x100f0e0d'0c0b0a09);
+        assert(+product == product);
+        assert(-product + product == 0);
+
+        product =
+            _Uint128{0x01020304'05060708, 0x090a0b0c'0d0e0f00} * _Uint128{0x000f0e0d'0c0b0a09, 0x08070605'04030201};
+        assert(product._Word[0] == 0x6dc18e55'16d48f48);
+        assert(product._Word[1] == 0xdc1b6bce'43cd6c21);
+        assert(+product == product);
+        assert(-product + product == 0);
+
+        product <<= 11;
+        assert(product._Word[0] == 0x0c72a8b6'a47a4000);
+        assert(product._Word[1] == 0xdb5e721e'6b610b6e);
+        assert(+product == product);
+        assert(-product + product == 0);
+
+        product >>= 17;
+        assert(product._Word[0] == 0x85b70639'545b523d);
+        assert(product._Word[1] == 0x00006daf'390f35b0);
+        assert(+product == product);
+        assert(-product + product == 0);
+    }
+
+    {
+        _Uint128 q = _Uint128{13} / _Uint128{4};
+        assert(q._Word[0] == 3);
+        assert(q._Word[1] == 0);
+
+        q = _Uint128{4} / _Uint128{13};
+        assert(q._Word[0] == 0);
+        assert(q._Word[1] == 0);
+
+        q = _Uint128{0x01010101'01010101, 0x01010101'01010101} / _Uint128{13};
+        assert(q._Word[0] == 0xc50013c5'0013c500);
+        assert(q._Word[1] == 0x13c500'13c50013);
+
+        q = _Uint128{0x22222222'22222222, 0x22222222'22222222} / _Uint128{0x11111111'11111111, 0x11111111'11111111};
+        assert(q._Word[0] == 2);
+        assert(q._Word[1] == 0);
+
+        q = (_Uint128{1} << 66) / (_Uint128{1} << 13);
+        assert(q._Word[0] == 1ull << 53);
+        assert(q._Word[1] == 0);
+
+        auto tmp = ~_Uint128{};
+        assert(tmp._Word[0] == ~0ull);
+        assert(tmp._Word[1] == ~0ull);
+        q = tmp / std::uint32_t{1};
+        assert(q == tmp);
+        q = tmp / std::uint64_t{1};
+        assert(q == tmp);
+        q = tmp / _Uint128{1};
+        assert(q == tmp);
+
+        q = tmp / _Uint128{1ull << 32};
+        assert(q._Word[0] == ~0ull);
+        assert(q._Word[1] == 0xffffffff);
+
+        _Uint128 result{0x01010101'01010101, 0x01010101'01010101};
+        for (tmp = 0xffu; tmp; tmp <<= 8, result >>= 8) {
+            q = ~_Uint128{} / tmp;
+            assert(q == result);
+            auto m    = ~_Uint128{} % tmp;
+            auto p    = q * tmp;
+            auto diff = ~_Uint128{} - p;
+            assert(m == diff);
+        }
+    }
+
+    {
+        const _Uint128 x{0x01020304'02030405, 0x03040506'04050607};
+        const _Uint128 y{0x07060504'06050403, 0x05040302'04030101};
+        assert(((x & y) == _Uint128{0x01020104'02010401, 0x01040102'04010001}));
+        auto tmp = x;
+        tmp &= y;
+        assert(tmp == (x & y));
+
+        assert(((x | y) == _Uint128{0x07060704'06070407, 0x07040706'04070707}));
+        tmp = x;
+        tmp |= y;
+        assert(tmp == (x | y));
+
+        assert(((x ^ y) == _Uint128{0x06040600'04060006, 0x06000604'00060706}));
+        tmp = x;
+        tmp ^= y;
+        assert(tmp == (x ^ y));
+    }
+
+    return true;
+}
+
+constexpr void check_equal(const _Int128& _Left) {
+    assert(_Left == _Left);
+    assert(!(_Left != _Left));
+    assert(!(_Left < _Left));
+    assert(!(_Left > _Left));
+    assert(_Left <= _Left);
+    assert(_Left >= _Left);
+    assert(_Left <=> _Left == 0);
+}
+
+constexpr void check_order(const _Int128& _Left, const _Int128& _Right, const std::strong_ordering _Ord) {
+    assert((_Left == _Right) == (_Ord == std::strong_ordering::equal));
+    assert((_Left != _Right) == (_Ord != std::strong_ordering::equal));
+    assert((_Left < _Right) == (_Ord == std::strong_ordering::less));
+    assert((_Left > _Right) == (_Ord == std::strong_ordering::greater));
+    assert((_Left <= _Right) == (_Ord != std::strong_ordering::greater));
+    assert((_Left >= _Right) == (_Ord != std::strong_ordering::less));
+
+    assert((_Right == _Left) == (_Ord == std::strong_ordering::equal));
+    assert((_Right != _Left) == (_Ord != std::strong_ordering::equal));
+    assert((_Right < _Left) == (_Ord == std::strong_ordering::greater));
+    assert((_Right > _Left) == (_Ord == std::strong_ordering::less));
+    assert((_Right <= _Left) == (_Ord != std::strong_ordering::less));
+    assert((_Right >= _Left) == (_Ord != std::strong_ordering::greater));
+}
+
+constexpr bool test_signed() {
+    static_assert(std::regular<_Int128>);
+    static_assert(std::three_way_comparable<_Int128, std::strong_ordering>);
+
+    static_assert(std::numeric_limits<_Int128>::min() == _Int128{0, 1ull << 63});
+    static_assert(std::numeric_limits<_Int128>::max() == _Int128{~0ull, ~0ull >> 1});
+    static_assert(std::numeric_limits<_Int128>::digits == 128);
+    static_assert(!std::numeric_limits<_Int128>::is_modulo);
+
+    static_assert(std::same_as<std::common_type_t<bool, _Int128>, _Int128>);
+    static_assert(std::same_as<std::common_type_t<char, _Int128>, _Int128>);
+    static_assert(std::same_as<std::common_type_t<signed char, _Int128>, _Int128>);
+    static_assert(std::same_as<std::common_type_t<unsigned char, _Int128>, _Int128>);
+#ifdef __cpp_char8_t
+    static_assert(std::same_as<std::common_type_t<char8_t, _Int128>, _Int128>);
+#endif // __cpp_char8_t
+    static_assert(std::same_as<std::common_type_t<char16_t, _Int128>, _Int128>);
+    static_assert(std::same_as<std::common_type_t<char32_t, _Int128>, _Int128>);
+    static_assert(std::same_as<std::common_type_t<short, _Int128>, _Int128>);
+    static_assert(std::same_as<std::common_type_t<unsigned short, _Int128>, _Int128>);
+    static_assert(std::same_as<std::common_type_t<int, _Int128>, _Int128>);
+    static_assert(std::same_as<std::common_type_t<unsigned int, _Int128>, _Int128>);
+    static_assert(std::same_as<std::common_type_t<long, _Int128>, _Int128>);
+    static_assert(std::same_as<std::common_type_t<unsigned long, _Int128>, _Int128>);
+    static_assert(std::same_as<std::common_type_t<long long, _Int128>, _Int128>);
+    static_assert(std::same_as<std::common_type_t<unsigned long long, _Int128>, _Int128>);
+
+    static_assert(std::same_as<std::common_type_t<_Int128, bool>, _Int128>);
+    static_assert(std::same_as<std::common_type_t<_Int128, char>, _Int128>);
+    static_assert(std::same_as<std::common_type_t<_Int128, signed char>, _Int128>);
+    static_assert(std::same_as<std::common_type_t<_Int128, unsigned char>, _Int128>);
+#ifdef __cpp_char8_t
+    static_assert(std::same_as<std::common_type_t<_Int128, char8_t>, _Int128>);
+#endif // __cpp_char8_t
+    static_assert(std::same_as<std::common_type_t<_Int128, char16_t>, _Int128>);
+    static_assert(std::same_as<std::common_type_t<_Int128, char32_t>, _Int128>);
+    static_assert(std::same_as<std::common_type_t<_Int128, short>, _Int128>);
+    static_assert(std::same_as<std::common_type_t<_Int128, unsigned short>, _Int128>);
+    static_assert(std::same_as<std::common_type_t<_Int128, int>, _Int128>);
+    static_assert(std::same_as<std::common_type_t<_Int128, unsigned int>, _Int128>);
+    static_assert(std::same_as<std::common_type_t<_Int128, long>, _Int128>);
+    static_assert(std::same_as<std::common_type_t<_Int128, unsigned long>, _Int128>);
+    static_assert(std::same_as<std::common_type_t<_Int128, long long>, _Int128>);
+    static_assert(std::same_as<std::common_type_t<_Int128, unsigned long long>, _Int128>);
+
+    static_assert(std::_Integer_class<_Int128>);
+    static_assert(std::_Integer_like<_Int128>);
+    static_assert(std::_Signed_integer_like<_Int128>);
+    static_assert(std::same_as<std::_Make_unsigned_like_t<_Int128>, _Uint128>);
+    static_assert(std::same_as<std::_Make_signed_like_t<_Int128>, _Int128>);
+
+    check_equal(_Int128{});
+    check_equal(_Int128{42});
+    check_equal(_Int128{-42});
+    check_equal(_Int128{0x11111111'11111111, 0x22222222'22222222});
+
+    check_order(_Int128{42}, _Int128{-42}, std::strong_ordering::greater);
+    check_order(_Int128{0x11111111'11111111, 0x22222222'22222222}, _Int128{0x01010101'01010101, 0x01010101'01010101},
+        std::strong_ordering::greater);
+    check_order(_Int128{~0ull, ~0ull}, _Int128{-1}, std::strong_ordering::equal);
+
+    check_order(_Int128{-2}, _Int128{-1}, std::strong_ordering::less);
+    check_order(_Int128{-2}, _Int128{1}, std::strong_ordering::less);
+    check_order(_Int128{2}, _Int128{-1}, std::strong_ordering::greater);
+    check_order(_Int128{2}, _Int128{1}, std::strong_ordering::greater);
+
+    assert((_Int128{-2} == _Uint128{0ull - 2, ~0ull}));
+    assert((_Uint128{_Int128{-2}} == _Uint128{0ull - 2, ~0ull}));
+    assert((_Int128{-2} == _Int128{_Uint128{0ull - 2, ~0ull}}));
+
+    {
+        _Int128 u{42};
+        assert(u._Word[0] == 42);
+        assert(u._Word[1] == 0);
+        u += _Int128{0};
+        assert(u._Word[0] == 42);
+        assert(u._Word[1] == 0);
+
+        assert(static_cast<std::uint64_t>(u) == 42);
+        assert(static_cast<std::uint32_t>(u) == 42);
+        assert(static_cast<std::uint16_t>(u) == 42);
+        assert(static_cast<std::uint8_t>(u) == 42);
+
+        assert(static_cast<std::int64_t>(u) == 42);
+        assert(static_cast<std::int32_t>(u) == 42);
+        assert(static_cast<std::int16_t>(u) == 42);
+        assert(static_cast<std::int8_t>(u) == 42);
+
+        _Int128 nu{-42};
+        assert(nu._Word[0] == 0ull - 42);
+        assert(nu._Word[1] == ~0ull);
+
+        assert(static_cast<std::uint64_t>(nu) == 0ull - 42);
+        assert(static_cast<std::uint32_t>(nu) == 0u - 42);
+        assert(static_cast<std::uint16_t>(nu) == 65536 - 42);
+        assert(static_cast<std::uint8_t>(nu) == 256 - 42);
+
+        assert(static_cast<std::int64_t>(nu) == -42);
+        assert(static_cast<std::int32_t>(nu) == -42);
+        assert(static_cast<std::int16_t>(nu) == -42);
+        assert(static_cast<std::int8_t>(nu) == -42);
+
+        _Int128 sum = u + nu;
+        assert(sum._Word[0] == 0);
+        assert(sum._Word[1] == 0);
+
+        --sum;
+        assert(sum._Word[0] == 0ull - 1);
+        assert(sum._Word[1] == 0ull - 1);
+        --sum;
+        assert(sum._Word[0] == 0ull - 2);
+        assert(sum._Word[1] == 0ull - 1);
+        ++sum;
+        assert(sum._Word[0] == 0ull - 1);
+        assert(sum._Word[1] == 0ull - 1);
+        ++sum;
+        assert(sum._Word[0] == 0);
+        assert(sum._Word[1] == 0);
+
+        _Int128 product = u * u;
+        assert(product._Word[0] == 42 * 42);
+        assert(product._Word[1] == 0);
+
+        product = nu * nu;
+        assert(product._Word[0] == 42 * 42);
+        assert(product._Word[1] == 0);
+
+        product = _Int128{0x01010101'01010101, 0x01010101'01010101} * 5;
+        assert(product._Word[0] == 0x05050505'05050505);
+        assert(product._Word[1] == 0x05050505'05050505);
+
+        product = 5 * _Int128{0x01010101'01010101, 0x01010101'01010101};
+        assert(product._Word[0] == 0x05050505'05050505);
+        assert(product._Word[1] == 0x05050505'05050505);
+
+        product = _Int128{0x01010101'01010101, 0x01010101'01010101};
+        product *= product;
+        assert(product._Word[0] == 0x08070605'04030201);
+        assert(product._Word[1] == 0x100f0e0d'0c0b0a09);
+        assert(+product == product);
+        assert(-product + product == 0);
+
+        product = _Int128{0x01020304'05060708, 0x090a0b0c'0d0e0f00} * _Int128{0x000f0e0d'0c0b0a09, 0x08070605'04030201};
+        assert(product._Word[0] == 0x6dc18e55'16d48f48);
+        assert(product._Word[1] == 0xdc1b6bce'43cd6c21);
+        assert(+product == product);
+        assert(-product + product == 0);
+
+        product <<= 11;
+        assert(product._Word[0] == 0x0c72a8b6'a47a4000);
+        assert(product._Word[1] == 0xdb5e721e'6b610b6e);
+        assert(+product == product);
+        assert(-product + product == 0);
+
+        product >>= 17;
+        assert(product._Word[0] == 0x85b70639'545b523d);
+        assert(product._Word[1] == 0xffffedaf'390f35b0);
+        assert(+product == product);
+        assert(-product + product == 0);
+    }
+
+    {
+        _Int128 q = _Int128{13} / _Int128{4};
+        assert(q._Word[0] == 3);
+        assert(q._Word[1] == 0);
+
+        q = _Int128{4} / _Int128{13};
+        assert(q._Word[0] == 0);
+        assert(q._Word[1] == 0);
+
+        q = _Int128{0x01010101'01010101, 0x01010101'01010101} / _Int128{13};
+        assert(q._Word[0] == 0xc50013c5'0013c500);
+        assert(q._Word[1] == 0x13c500'13c50013);
+
+        q = _Int128{0x22222222'22222222, 0x22222222'22222222} / _Int128{0x11111111'11111111, 0x11111111'11111111};
+        assert(q._Word[0] == 2);
+        assert(q._Word[1] == 0);
+
+        q = (_Int128{1} << 66) / (_Int128{1} << 13);
+        assert(q._Word[0] == 1ull << 53);
+        assert(q._Word[1] == 0);
+
+        auto tmp = ~_Int128{};
+        assert(tmp._Word[0] == ~0ull);
+        assert(tmp._Word[1] == ~0ull);
+        q = tmp / std::uint32_t{1};
+        assert(q == tmp);
+        q = tmp / std::uint64_t{1};
+        assert(q == tmp);
+        q = tmp / _Int128{1};
+        assert(q == tmp);
+
+        q = tmp / _Int128{1ull << 32};
+        assert(q._Word[0] == 0);
+        assert(q._Word[1] == 0);
+
+        _Int128 result{0x80808080'80808080, 0x808080'80808080};
+        for (tmp = 0xffu; tmp > 0; tmp <<= 8, result >>= 8) {
+            q = std::numeric_limits<_Int128>::max() / tmp;
+            assert(q == result);
+            auto m    = std::numeric_limits<_Int128>::max() % tmp;
+            auto p    = q * tmp;
+            auto diff = std::numeric_limits<_Int128>::max() - p;
+            assert(m == diff);
+        }
+
+        result = _Int128{0x7f7f7f7f'7f7f7f80, 0xff7f7f7f'7f7f7f7f};
+        for (tmp = 0xffu; tmp > 0; tmp <<= 8, result = (result >> 8) + 1) {
+            q = std::numeric_limits<_Int128>::min() / tmp;
+            assert(q == result);
+            auto m    = std::numeric_limits<_Int128>::min() % tmp;
+            auto p    = q * tmp;
+            auto diff = std::numeric_limits<_Int128>::min() - p;
+            assert(m == diff);
+        }
+    }
+
+    {
+        const _Int128 x{0x01020304'02030405, 0x03040506'04050607};
+        const _Int128 y{0x07060504'06050403, 0x05040302'04030101};
+        assert(((x & y) == _Int128{0x01020104'02010401, 0x01040102'04010001}));
+        auto tmp = x;
+        tmp &= y;
+        assert(tmp == (x & y));
+
+        assert(((x | y) == _Int128{0x07060704'06070407, 0x07040706'04070707}));
+        tmp = x;
+        tmp |= y;
+        assert(tmp == (x | y));
+
+        assert(((x ^ y) == _Int128{0x06040600'04060006, 0x06000604'00060706}));
+        tmp = x;
+        tmp ^= y;
+        assert(tmp == (x ^ y));
+    }
+
+    return true;
+}
+
+int main() {
+    test_unsigned();
+    static_assert(test_unsigned());
+    test_signed();
+    static_assert(test_signed());
+}

--- a/tests/std/tests/P2415R2_owning_view/env.lst
+++ b/tests/std/tests/P2415R2_owning_view/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_20_matrix.lst

--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
@@ -736,7 +736,7 @@ STATIC_ASSERT(__cpp_lib_filesystem == 201703L);
 #endif
 #endif
 
-#if _HAS_CXX23 && !defined(__EDG__) // TRANSITION, EDG concepts support and GH-1814
+#if _HAS_CXX20 && !defined(__EDG__) // TRANSITION, EDG concepts support
 #ifndef __cpp_lib_format
 #error __cpp_lib_format is not defined
 #elif __cpp_lib_format != 202110L
@@ -1336,7 +1336,7 @@ STATIC_ASSERT(__cpp_lib_polymorphic_allocator == 201902L);
 STATIC_ASSERT(__cpp_lib_quoted_string_io == 201304L);
 #endif
 
-#if _HAS_CXX23 && !defined(__EDG__) // TRANSITION, EDG concepts support and GH-1814
+#if _HAS_CXX20 && !defined(__EDG__) // TRANSITION, EDG concepts support
 #ifndef __cpp_lib_ranges
 #error __cpp_lib_ranges is not defined
 #elif __cpp_lib_ranges != 202110L
@@ -1350,7 +1350,7 @@ STATIC_ASSERT(__cpp_lib_ranges == 202110L);
 #endif
 #endif
 
-#if _HAS_CXX23 && !defined(__EDG__) // TRANSITION, EDG concepts support and GH-1814
+#if _HAS_CXX23 && !defined(__EDG__) // TRANSITION, EDG concepts support
 #ifndef __cpp_lib_ranges_starts_ends_with
 #error __cpp_lib_ranges_starts_ends_with is not defined
 #elif __cpp_lib_ranges_starts_ends_with != 202106L

--- a/tests/std/tests/concepts_latest_matrix.lst
+++ b/tests/std/tests/concepts_latest_matrix.lst
@@ -1,8 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-# When updating this file, also update tests\P0645R10_text_formatting_legacy_text_encoding\env.lst to match
-
 RUNALL_INCLUDE .\prefix.lst
 RUNALL_CROSSLIST
 PM_CL="/w14640 /Zc:threadSafeInit- /EHsc /std:c++latest /D_HAS_CXX23"


### PR DESCRIPTION
and add 128-bit signed and unsigned integer-class types to be the difference of `iota_view<64-bits>`.

* In `<yvals_core.h>`, don't require `_HAS_CXX23` to define `__cpp_lib_format` and `__cpp_lib_ranges`. Change the feature-test macro test consistently.

* Change `env.lst` for all tests that touch `<ranges>` and `<format>` to use `20` matrices instead of `latest`.

* Don't use the `span` constructor added to C++23 by WG21-P1989 in `P0896R4_views_split`, which now must run in C++20 mode where that constructor is unavailable.

Fixes #1814.

For ease of review there are two commits: the first is just the 23-to-20 changes, and the second adds the integer-class type.

## Internal-only changes ##
Reminder for MSVC-internal tasks (the "add new internal header" things):
* [x] Notify `vctowner` that we're adding a new internal header `__msvc_int128.hpp`.
* [x] Run `src/vctools/crt/lkgsync/updatelkgmanifest.cmd`.
* [x] Edit `src/SetupPackages/swix/crt.headers/files.base.swr`.
* [x] Edit `src/vctools/crt/copy_crt/copy_crt.nativeproj`.
* [x] Edit `src/qa/VC/FE/compiler/tests/cxx/modules/dependency-scanning/header-units/deps.cpp`.
* [x] Edit `src/qa/VC/FE/compiler/tests/cxx/modules/dependency-scanning/header-units/stl-header-units.dat`.
