### PR TITLE
Fail time parsing if input is insufficient to supply all fields

### DIFF
--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -4616,6 +4616,7 @@ namespace chrono {
             while (*_Fmt != '\0' && (_State & ~ios_base::eofbit) == ios_base::goodbit) {
                 if (_First == _Last) {
                     _State |= ios_base::failbit | ios_base::eofbit;
+                    break;
                 } else if (*_Fmt == '%') {
                     _First = _Parse_time_field(_First, _Iosbase, _State, *++_Fmt, '\0', 0, _Subsecond_precision);
                 } else if (_Ctype_fac.narrow(*_First++) != *_Fmt) {

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -4615,7 +4615,7 @@ namespace chrono {
 
             while (*_Fmt != '\0' && (_State & ~ios_base::eofbit) == ios_base::goodbit) {
                 if (_First == _Last) {
-                    _State |= ios_base::failbit;
+                    _State |= ios_base::failbit | ios_base::eofbit;
                 } else if (*_Fmt == '%') {
                     _First = _Parse_time_field(_First, _Iosbase, _State, *++_Fmt, '\0', 0, _Subsecond_precision);
                 } else if (_Ctype_fac.narrow(*_First++) != *_Fmt) {

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -4613,8 +4613,10 @@ namespace chrono {
             const _Ctype& _Ctype_fac{_STD use_facet<_Ctype>(_Iosbase.getloc())};
             constexpr _InIt _Last{};
 
-            while (*_Fmt != '\0' && _First != _Last && _State == ios_base::goodbit) {
-                if (*_Fmt == '%') {
+            while (*_Fmt != '\0' && (_State & ~ios_base::eofbit) == ios_base::goodbit) {
+                if (_First == _Last) {
+                    _State |= ios_base::failbit;
+                } else if (*_Fmt == '%') {
                     _First = _Parse_time_field(_First, _Iosbase, _State, *++_Fmt, '\0', 0, _Subsecond_precision);
                 } else if (_Ctype_fac.narrow(*_First++) != *_Fmt) {
                     _State |= ios_base::failbit;
@@ -4847,7 +4849,7 @@ namespace chrono {
 
             if (_Ok) {
                 _TRY_IO_BEGIN
-                for (; _FmtFirst != _FmtLast && _State == ios_base::goodbit; ++_FmtFirst) {
+                for (; _FmtFirst != _FmtLast && (_State & ~ios_base::eofbit) == ios_base::goodbit; ++_FmtFirst) {
                     if (_First == _Last) {
                         // EOF is not an error if the remaining flags can match zero characters.
                         for (; _FmtFirst != _FmtLast; ++_FmtFirst) {

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_io/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_io/test.cpp
@@ -163,13 +163,13 @@ ios_base::iostate parse_state(const CharT* str, const CStringOrStdString& fmt, P
 template <class CharT, class CStringOrStdString, class Parsable>
 void test_parse(const CharT* str, const CStringOrStdString& fmt, Parsable& p,
     type_identity_t<basic_string<CharT>*> abbrev = nullptr, minutes* offset = nullptr) {
-    assert((parse_state(str, fmt, p, abbrev, offset) & ~ios_base::eofbit) == 0);
+    assert((parse_state(str, fmt, p, abbrev, offset) & ~ios_base::eofbit) == ios_base::goodbit);
 }
 
 template <class CharT, class CStringOrStdString, class Parsable>
 void fail_parse(const CharT* str, const CStringOrStdString& fmt, Parsable& p,
     type_identity_t<basic_string<CharT>*> abbrev = nullptr, minutes* offset = nullptr) {
-    assert((parse_state(str, fmt, p, abbrev, offset) & ~ios_base::eofbit) != 0);
+    assert((parse_state(str, fmt, p, abbrev, offset) & ~ios_base::eofbit) != ios_base::goodbit);
 }
 
 template <class TimeType, class IntType = int>

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_io/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_io/test.cpp
@@ -878,6 +878,24 @@ void parse_other_week_date() {
     assert(ymd == 2022y / January / 1d);
 }
 
+void parse_incomplete() {
+    // Parsing should fail if the input is insufficient to supply all fields of the format string, even if the input is
+    // sufficient to supply all fields of the parsable.
+    // Check both explicit and shorthand format strings, since the code path is different.
+    year_month ym;
+    fail_parse("2021-01", "%Y-%m-%d", ym);
+    fail_parse("2022-02", "%F", ym);
+
+    seconds time;
+    fail_parse("01:59", "%H:%M:%S", time);
+    fail_parse("03:23", "%T", time);
+    fail_parse("04", "%R", time);
+
+    // However, it is OK to omit seconds from the format when parsing a duration to seconds precision.
+    test_parse("05:24", "%H:%M", time);
+    test_parse("06:25", "%R", time);
+}
+
 void parse_whitespace() {
     seconds time;
     fail_parse("ab", "a%nb", time);
@@ -1213,6 +1231,7 @@ void test_parse() {
     parse_calendar_types_basic();
     parse_iso_week_date();
     parse_other_week_date();
+    parse_incomplete();
     parse_whitespace();
     parse_timepoints();
     test_io_manipulator<char, const char*>();

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_io/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_io/test.cpp
@@ -127,7 +127,7 @@ void test_duration_output() {
 
 
 template <class CharT, class CStringOrStdString, class Parsable>
-std::ios_base::iostate parse_state(const CharT* str, const CStringOrStdString& fmt, Parsable& p,
+ios_base::iostate parse_state(const CharT* str, const CStringOrStdString& fmt, Parsable& p,
     type_identity_t<basic_string<CharT>*> abbrev = nullptr, minutes* offset = nullptr) {
     p = Parsable{};
     if (abbrev) {
@@ -163,13 +163,13 @@ std::ios_base::iostate parse_state(const CharT* str, const CStringOrStdString& f
 template <class CharT, class CStringOrStdString, class Parsable>
 void test_parse(const CharT* str, const CStringOrStdString& fmt, Parsable& p,
     type_identity_t<basic_string<CharT>*> abbrev = nullptr, minutes* offset = nullptr) {
-    assert((parse_state(str, fmt, p, abbrev, offset) & ~std::ios_base::eofbit) == 0);
+    assert((parse_state(str, fmt, p, abbrev, offset) & ~ios_base::eofbit) == 0);
 }
 
 template <class CharT, class CStringOrStdString, class Parsable>
 void fail_parse(const CharT* str, const CStringOrStdString& fmt, Parsable& p,
     type_identity_t<basic_string<CharT>*> abbrev = nullptr, minutes* offset = nullptr) {
-    assert((parse_state(str, fmt, p, abbrev, offset) & ~std::ios_base::eofbit) != 0);
+    assert((parse_state(str, fmt, p, abbrev, offset) & ~ios_base::eofbit) != 0);
 }
 
 template <class TimeType, class IntType = int>
@@ -861,10 +861,10 @@ void parse_incomplete() {
     // sufficient to supply all fields of the parsable.
     // Check both explicit and shorthand format strings, since the code path is different.
     year_month ym;
-    assert(parse_state("2021-01", "%Y-%m-%d", ym) == (std::ios_base::eofbit | std::ios_base::failbit));
-    assert(parse_state("2022-02", "%F", ym) == (std::ios_base::eofbit | std::ios_base::failbit));
-    assert(parse_state("2021-", "%Y-%m-%d", ym) == (std::ios_base::eofbit | std::ios_base::failbit));
-    assert(parse_state("2022-", "%F", ym) == (std::ios_base::eofbit | std::ios_base::failbit));
+    assert(parse_state("2021-01", "%Y-%m-%d", ym) == (ios_base::eofbit | ios_base::failbit));
+    assert(parse_state("2022-02", "%F", ym) == (ios_base::eofbit | ios_base::failbit));
+    assert(parse_state("2021-", "%Y-%m-%d", ym) == (ios_base::eofbit | ios_base::failbit));
+    assert(parse_state("2022-", "%F", ym) == (ios_base::eofbit | ios_base::failbit));
 
     seconds time;
     fail_parse("01:59", "%H:%M:%S", time);


### PR DESCRIPTION
(and literals) of the format spec, even if it is sufficient to fully
specify the parsable argument.

For example "23:59" is not a valid input for "%H:%M:%S" (or for "%T").

https://eel.is/c++draft/time.parse#17.sentence-1

> If the from_stream overload fails to parse everything specified by
> the format string, or if insufficient information is parsed to specify a
> complete duration, time point, or calendrical data structure,
> setstate(ios_base::failbit) is called on the basic_istream.

<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
