### PR TITLE
resize_and_overwrite: fix warning C4018

### DIFF
--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -3972,9 +3972,9 @@ public:
         const auto _Result_size = _STD move(_Op)(_Mypair._Myval2._Myptr(), _New_size);
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(_Result_size >= 0, "the returned size can't be smaller than 0");
-        _STL_VERIFY(_Result_size <= _New_size, "the returned size can't be greater than the passed size");
+        _STL_VERIFY(cmp_less_equal(_Result_size, _New_size), "the returned size can't be greater than the passed size");
 #endif // _CONTAINER_DEBUG_LEVEL > 0
-        _Eos(_Result_size);
+        _Eos(static_cast<size_type>(_Result_size));
     }
 #endif // _HAS_CXX23
 

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -3972,7 +3972,8 @@ public:
         const auto _Result_size = _STD move(_Op)(_Mypair._Myval2._Myptr(), _New_size);
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(_Result_size >= 0, "the returned size can't be smaller than 0");
-        _STL_VERIFY(cmp_less_equal(_Result_size, _New_size), "the returned size can't be greater than the passed size");
+#pragma warning(suppress : 4018) //  '<=': signed/unsigned mismatch, we already compared with 0, so it's safe
+        _STL_VERIFY(_Result_size <= _New_size, "the returned size can't be greater than the passed size");
 #endif // _CONTAINER_DEBUG_LEVEL > 0
         _Eos(static_cast<size_type>(_Result_size));
     }

--- a/tests/std/tests/P0980R1_constexpr_strings/test.cpp
+++ b/tests/std/tests/P0980R1_constexpr_strings/test.cpp
@@ -2383,6 +2383,19 @@ constexpr void test_all() {
     static_assert(test_allocator_awareness<CharType>());
 }
 
+#if _HAS_CXX23
+void test_gh_2524() // COMPILE-ONLY
+{
+    // resize_and_overwrite generates warning C4018 when Operation returns int
+    string s;
+    s.resize_and_overwrite(1, [](char* buffer, size_t) {
+        *buffer = 'x';
+        int i   = 1;
+        return i;
+    });
+}
+#endif // _HAS_CXX23
+
 int main() {
     test_all<char>();
 #ifdef __cpp_char8_t


### PR DESCRIPTION
Fixes #2524

`cmp_less_equal` is in `utility`

`xutility` includes `utility`

`xmemory` includes `xutility`

`xstring` includes `xmemory`