### PR TITLE
LWG-3654: `basic_format_context::arg(size_t)` should be noexcept

### DIFF
--- a/stl/inc/format
+++ b/stl/inc/format
@@ -1733,7 +1733,7 @@ public:
         _Out _OutputIt_, basic_format_args<basic_format_context> _Ctx_args, const _Lazy_locale& _Loc_)
         : _OutputIt(_STD move(_OutputIt_)), _Args(_Ctx_args), _Loc(_Loc_) {}
 
-    _NODISCARD basic_format_arg<basic_format_context> arg(size_t _Id) const {
+    _NODISCARD basic_format_arg<basic_format_context> arg(size_t _Id) const noexcept {
         return _Args.get(_Id);
     }
     _NODISCARD locale locale() {


### PR DESCRIPTION
Implements the proposed resolution of LWG-3654.