### PR TITLE
P2393R1 Cleaning Up Integer-Class Types

### DIFF
--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -3342,7 +3342,8 @@ namespace ranges {
         // [[no_unique_address]] conditional_t<_Store_size, _Size_type, _Nil> _Size{};
 
         template <class _Rng>
-        constexpr subrange(true_type, _Rng&& _Val) : subrange(_STD forward<_Rng>(_Val), _RANGES size(_Val)) {
+        constexpr subrange(true_type, _Rng&& _Val)
+            : subrange(_STD forward<_Rng>(_Val), static_cast<_Size_type>(_RANGES size(_Val))) {
             // delegation target for subrange(_Rng&&) when we must store the range size
             _STL_INTERNAL_STATIC_ASSERT(_Store_size);
         }

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -224,7 +224,6 @@
 // P1456R1 Move-Only Views
 // P1474R1 Helpful Pointers For contiguous_iterator
 // P1522R1 Iterator Difference Type And Integer Overflow
-//     (technically conforming, but it would be nice to implement a 65-bit integer-like type)
 // P1523R1 Views And Size Types
 // P1612R1 Relocating endian To <bit>
 // P1614R2 Adding Spaceship <=> To The Library
@@ -266,6 +265,7 @@
 // P2328R1 join_view Should Join All views Of ranges
 // P2367R0 Remove Misuses Of List-Initialization From Clause 24 Ranges
 // P2372R3 Fixing Locale Handling In chrono Formatters
+// P2393R1 Cleaning Up Integer-Class Types
 // P2415R2 What Is A view?
 // P2418R2 Add Support For std::generator-like Types To std::format
 // P2432R1 Fix istream_view


### PR DESCRIPTION
Our integer-class types (`_Signed128` and `_Unsigned128`) were implemented to the revised wording, so they require no changes.

We _do_ need the `subrange` constructor change.

We don't need the `drop_view`, `take_view`, `views::counted`, and `views::take` changes. We already implement them or something functionally equivalent.

Update `<yvals_core.h>` to indicate that P2393R1 is implemented in C++20 (and later) modes.

Drive-by: Indicate that P1522 is now fully implemented in `<yvals_core.h>`.

Fixes #2254

There's no test coverage here because it just seems silly to write two ranges with custom iterators just to verify the presence of one `static_cast`. As always, reviewers - yell at me if you disagree.