### PR TITLE
LWG-3610: `iota_view::size` sometimes rejects integer-class types

### DIFF
--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -1265,7 +1265,7 @@ namespace ranges {
         // clang-format off
         _NODISCARD constexpr auto size() const noexcept(noexcept(_Bound - _Value)) /* strengthened */
             requires (same_as<_Wi, _Bo> && _Advanceable<_Wi>)
-                || (integral<_Wi> && integral<_Bo>)
+                || (_Integer_like<_Wi> && _Integer_like<_Bo>)
                 || sized_sentinel_for<_Bo, _Wi> {
             // clang-format on
             if constexpr (_Integer_like<_Wi> && _Integer_like<_Bo>) {

--- a/tests/std/test.lst
+++ b/tests/std/test.lst
@@ -196,6 +196,7 @@ tests\LWG3018_shared_ptr_function
 tests\LWG3146_excessive_unwrapping_ref_cref
 tests\LWG3422_seed_seq_ctors
 tests\LWG3480_directory_iterator_range
+tests\LWG3610_iota_view_size_and_integer_class
 tests\P0019R8_atomic_ref
 tests\P0024R2_parallel_algorithms_adjacent_difference
 tests\P0024R2_parallel_algorithms_adjacent_find

--- a/tests/std/tests/LWG3610_iota_view_size_and_integer_class/env.lst
+++ b/tests/std/tests/LWG3610_iota_view_size_and_integer_class/env.lst
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+RUNALL_INCLUDE ..\concepts_20_matrix.lst

--- a/tests/std/tests/LWG3610_iota_view_size_and_integer_class/test.compile.pass.cpp
+++ b/tests/std/tests/LWG3610_iota_view_size_and_integer_class/test.compile.pass.cpp
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <ranges>
+
+using namespace std;
+
+template <class R>
+concept CanSize = requires(R& r) {
+    ranges::size(r);
+};
+
+int main() {
+    // Validate standard signed integer types
+    static_assert(CanSize<ranges::iota_view<signed char, _Signed128>>);
+    static_assert(CanSize<ranges::iota_view<signed char, _Unsigned128>>);
+    static_assert(CanSize<ranges::iota_view<short, _Signed128>>);
+    static_assert(CanSize<ranges::iota_view<short, _Unsigned128>>);
+    static_assert(CanSize<ranges::iota_view<int, _Signed128>>);
+    static_assert(CanSize<ranges::iota_view<int, _Unsigned128>>);
+    static_assert(CanSize<ranges::iota_view<long, _Signed128>>);
+    static_assert(CanSize<ranges::iota_view<long, _Unsigned128>>);
+    static_assert(CanSize<ranges::iota_view<long long, _Signed128>>);
+    static_assert(CanSize<ranges::iota_view<long long, _Unsigned128>>);
+
+    // Validate standard unsigned integer types
+    static_assert(CanSize<ranges::iota_view<unsigned char, _Signed128>>);
+    static_assert(CanSize<ranges::iota_view<unsigned char, _Unsigned128>>);
+    static_assert(CanSize<ranges::iota_view<unsigned short, _Signed128>>);
+    static_assert(CanSize<ranges::iota_view<unsigned short, _Unsigned128>>);
+    static_assert(CanSize<ranges::iota_view<unsigned int, _Signed128>>);
+    static_assert(CanSize<ranges::iota_view<unsigned int, _Unsigned128>>);
+    static_assert(CanSize<ranges::iota_view<unsigned long, _Signed128>>);
+    static_assert(CanSize<ranges::iota_view<unsigned long, _Unsigned128>>);
+    static_assert(CanSize<ranges::iota_view<unsigned long long, _Signed128>>);
+    static_assert(CanSize<ranges::iota_view<unsigned long long, _Unsigned128>>);
+
+    // Validate other integer types (other than bool)
+    static_assert(CanSize<ranges::iota_view<char, _Signed128>>);
+    static_assert(CanSize<ranges::iota_view<char, _Unsigned128>>);
+    static_assert(CanSize<ranges::iota_view<wchar_t, _Signed128>>);
+    static_assert(CanSize<ranges::iota_view<wchar_t, _Signed128>>);
+#ifdef __cpp_char8_t
+    static_assert(CanSize<ranges::iota_view<char8_t, _Signed128>>);
+    static_assert(CanSize<ranges::iota_view<char8_t, _Unsigned128>>);
+#endif // __cpp_char8_t
+    static_assert(CanSize<ranges::iota_view<char16_t, _Signed128>>);
+    static_assert(CanSize<ranges::iota_view<char16_t, _Unsigned128>>);
+    static_assert(CanSize<ranges::iota_view<char32_t, _Signed128>>);
+    static_assert(CanSize<ranges::iota_view<char32_t, _Unsigned128>>);
+}


### PR DESCRIPTION
Implements the proposed resolution of LWG-3610.

Only tests the cases where an integer-class type is used as the bound type, because MSVC STL currently has no integer-class type satisfying `weakly_incrementable`.