### PR TITLE
LWG-3661: `constinit` `atomic<shared_ptr<T>>` a(nullptr); should work

### DIFF
--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -3953,6 +3953,8 @@ public:
 
     constexpr atomic() noexcept = default;
 
+    constexpr atomic(nullptr_t) noexcept : atomic() {}
+
     atomic(const shared_ptr<_Ty> _Value) noexcept : _Base(_Value._Ptr, _Value._Rep) {
         _Value._Incref();
     }

--- a/tests/std/tests/P0718R2_atomic_smart_ptrs/test.cpp
+++ b/tests/std/tests/P0718R2_atomic_smart_ptrs/test.cpp
@@ -222,6 +222,11 @@ void ensure_nonmember_calls_compile() {
     }
 }
 
+#ifndef __EDG__ // TRANSITION, DevCom-1656924
+// LWG-3661: constinit atomic<shared_ptr<T>> a(nullptr); should work
+constinit atomic<shared_ptr<bool>> a(nullptr);
+#endif // __EDG__
+
 int main() {
     // These values for is_always_lock_free are not required by the standard, but they are true for our implementation.
     static_assert(atomic<shared_ptr<int>>::is_always_lock_free == false);

--- a/tests/std/tests/P0718R2_atomic_smart_ptrs/test.cpp
+++ b/tests/std/tests/P0718R2_atomic_smart_ptrs/test.cpp
@@ -224,7 +224,8 @@ void ensure_nonmember_calls_compile() {
 
 #ifndef __EDG__ // TRANSITION, DevCom-1656924
 // LWG-3661: constinit atomic<shared_ptr<T>> a(nullptr); should work
-constinit atomic<shared_ptr<bool>> a(nullptr);
+constinit atomic<shared_ptr<bool>> a{};
+constinit atomic<shared_ptr<bool>> b{nullptr};
 #endif // __EDG__
 
 int main() {


### PR DESCRIPTION
Implements the proposed resolution of LWG-3661

partially addressed #2527