### PR TITLE
Implement LWG-3660 for `iterator_traits<common_iterator>::pointer`

### DIFF
--- a/stl/inc/iterator
+++ b/stl/inc/iterator
@@ -1037,14 +1037,17 @@ struct incrementable_traits<common_iterator<_Iter, _Se>> {
     using difference_type = iter_difference_t<_Iter>;
 };
 
-template <class>
+template <class, class>
 struct _Common_iterator_pointer_type {
     using pointer = void;
 };
 
-template <_Has_member_arrow _Iter>
-struct _Common_iterator_pointer_type<_Iter> {
-    using pointer = decltype(_STD declval<_Iter&>().operator->());
+// clang-format off
+template <class _Iter, class _Se>
+    requires _Has_member_arrow<const common_iterator<_Iter, _Se>&> //
+struct _Common_iterator_pointer_type<_Iter, _Se> {
+    // clang-format on
+    using pointer = decltype(_STD declval<const common_iterator<_Iter, _Se>&>().operator->());
 };
 
 template <class _Iter>
@@ -1059,7 +1062,7 @@ struct iterator_traits<common_iterator<_Iter, _Se>> {
     using iterator_category = conditional_t<_Has_forward_category<_Iter>, forward_iterator_tag, input_iterator_tag>;
     using value_type        = iter_value_t<_Iter>;
     using difference_type   = iter_difference_t<_Iter>;
-    using pointer           = typename _Common_iterator_pointer_type<_Iter>::pointer;
+    using pointer           = typename _Common_iterator_pointer_type<_Iter, _Se>::pointer;
     using reference         = iter_reference_t<_Iter>;
 };
 

--- a/stl/inc/iterator
+++ b/stl/inc/iterator
@@ -806,7 +806,7 @@ public:
 // clang-format off
 template <class _Iter>
 concept _Use_postfix_proxy = !requires(_Iter& __it) { { *__it++ } -> _Can_reference; }
-    && indirectly_readable<_Iter> // Per LWG-3601
+    && indirectly_readable<_Iter>
     && constructible_from<iter_value_t<_Iter>, iter_reference_t<_Iter>>
     && move_constructible<iter_value_t<_Iter>>;
 

--- a/stl/inc/syncstream
+++ b/stl/inc/syncstream
@@ -306,7 +306,7 @@ private:
 };
 
 template <class _Elem, class _Traits, class _Alloc>
-void swap(basic_syncbuf<_Elem, _Traits, _Alloc>& _Left, basic_syncbuf<_Elem, _Traits, _Alloc>& _Right) { // LWG-3616
+void swap(basic_syncbuf<_Elem, _Traits, _Alloc>& _Left, basic_syncbuf<_Elem, _Traits, _Alloc>& _Right) {
     _Left.swap(_Right);
 }
 

--- a/tests/std/tests/P0896R4_common_iterator/test.cpp
+++ b/tests/std/tests/P0896R4_common_iterator/test.cpp
@@ -11,15 +11,18 @@
 using namespace std;
 using P = pair<int, int>;
 
-// clang-format off
 template <class Iter>
 concept CanDifference = requires(Iter it) {
-    { it - it };
+    {it - it};
 };
 
 template <class Iter>
 concept HasProxy = !is_reference_v<iter_reference_t<Iter>>;
-// clang-format on
+
+template <class Iter>
+concept CanArrow = requires(const Iter& i) {
+    {i.operator->()};
+};
 
 struct instantiator {
     template <input_or_output_iterator Iter>
@@ -49,8 +52,8 @@ struct instantiator {
                 }
 
                 using ipointer = typename iterator_traits<Cit>::pointer;
-                if constexpr (_Has_member_arrow<Iter>) {
-                    STATIC_ASSERT(same_as<ipointer, decltype(declval<const Iter&>().operator->())>);
+                if constexpr (CanArrow<Cit>) {
+                    STATIC_ASSERT(same_as<ipointer, decltype(declval<const Cit&>().operator->())>);
                 } else {
                     STATIC_ASSERT(same_as<ipointer, void>);
                 }


### PR DESCRIPTION
LWG-3660 "`iterator_traits<common_iterator>::pointer` should conform to [iterator.traits]" requires a tweak to `iterator_traits` so it always agrees with `operator->()`.

Also removes comments for LWG-3601 and LWG-3616 which have been voted into the Standard, see #2527.