### PR TITLE
Implement LWG-3598 `system_category().default_error_condition(0)`

### DIFF
--- a/stl/inc/system_error
+++ b/stl/inc/system_error
@@ -551,14 +551,14 @@ public:
     _NODISCARD error_condition default_error_condition(int _Errval) const noexcept override {
         if (_Errval == 0) {
             return error_condition(0, _STD generic_category());
+        }
+
+        // make error_condition for error code (generic if possible)
+        const int _Posv = _Winerror_map(_Errval);
+        if (_Posv == 0) {
+            return error_condition(_Errval, _STD system_category());
         } else {
-            // make error_condition for error code (generic if possible)
-            const int _Posv = _Winerror_map(_Errval);
-            if (_Posv == 0) {
-                return error_condition(_Errval, _STD system_category());
-            } else {
-                return error_condition(_Posv, _STD generic_category());
-            }
+            return error_condition(_Posv, _STD generic_category());
         }
     }
 };

--- a/stl/inc/system_error
+++ b/stl/inc/system_error
@@ -501,6 +501,7 @@ public:
     }
 
     _NODISCARD string message(int _Errcode) const override {
+        // TRANSITION, GH-2561, move the logic to syserror.cpp
         if (_Errcode == 0) {
             const _System_error_message _Msg(0);
             return string(_Msg._Str, _Msg._Length);
@@ -549,6 +550,7 @@ public:
     }
 
     _NODISCARD error_condition default_error_condition(int _Errval) const noexcept override {
+        // TRANSITION, GH-2561, move the logic to syserror.cpp
         if (_Errval == 0) {
             return error_condition(0, _STD generic_category());
         } else {

--- a/stl/inc/system_error
+++ b/stl/inc/system_error
@@ -501,7 +501,12 @@ public:
     }
 
     _NODISCARD string message(int _Errcode) const override {
-        return _Syserror_map(_Errcode);
+        if (_Errcode == 0) {
+            const _System_error_message _Msg(0);
+            return string(_Msg._Str, _Msg._Length);
+        } else {
+            return _Syserror_map(_Errcode);
+        }
     }
 };
 
@@ -544,12 +549,16 @@ public:
     }
 
     _NODISCARD error_condition default_error_condition(int _Errval) const noexcept override {
-        // make error_condition for error code (generic if possible)
-        const int _Posv = _Winerror_map(_Errval);
-        if (_Posv == 0) {
-            return error_condition(_Errval, _STD system_category());
+        if (_Errval == 0) {
+            return error_condition(0, _STD generic_category());
         } else {
-            return error_condition(_Posv, _STD generic_category());
+            // make error_condition for error code (generic if possible)
+            const int _Posv = _Winerror_map(_Errval);
+            if (_Posv == 0) {
+                return error_condition(_Errval, _STD system_category());
+            } else {
+                return error_condition(_Posv, _STD generic_category());
+            }
         }
     }
 };

--- a/stl/inc/system_error
+++ b/stl/inc/system_error
@@ -503,8 +503,7 @@ public:
     _NODISCARD string message(int _Errcode) const override {
         // TRANSITION, GH-2561, move the logic to syserror.cpp
         if (_Errcode == 0) {
-            const _System_error_message _Msg(0);
-            return string(_Msg._Str, _Msg._Length);
+            return "success";
         } else {
             return _Syserror_map(_Errcode);
         }
@@ -550,7 +549,6 @@ public:
     }
 
     _NODISCARD error_condition default_error_condition(int _Errval) const noexcept override {
-        // TRANSITION, GH-2561, move the logic to syserror.cpp
         if (_Errval == 0) {
             return error_condition(0, _STD generic_category());
         } else {

--- a/tests/std/tests/Dev11_0493504_error_category_lifetime/test.cpp
+++ b/tests/std/tests/Dev11_0493504_error_category_lifetime/test.cpp
@@ -33,9 +33,7 @@ void test_lwg_3598() {
     error_condition cond = system_category().default_error_condition(0);
 
     assert(cond.category() == generic_category());
-    // generic_category().default_error_condition(0).message() depends on locale
-    // but it was "unknown error" before
-    assert(cond.message() != "unknown error");
+    assert(cond.message() == "success");
     assert(cond.value() == 0);
 
     assert(error_code() == error_condition());

--- a/tests/std/tests/Dev11_0493504_error_category_lifetime/test.cpp
+++ b/tests/std/tests/Dev11_0493504_error_category_lifetime/test.cpp
@@ -28,6 +28,19 @@ struct Global {
 
 Global global;
 
+// Also test LWG-3598: system_category().default_error_condition(0) has a generic category.
+void test_lwg_3598() {
+    error_condition cond = system_category().default_error_condition(0);
+
+    assert(cond.category() == generic_category());
+    // generic_category().default_error_condition(0).message() depends on locale
+    // but it was "unknown error" before
+    assert(cond.message() != "unknown error");
+    assert(cond.value() == 0);
+
+    assert(error_code() == error_condition());
+}
+
 int main() {
     // Also test DevDiv-781294 "<system_error>: Visual C++ 2013 RC system_category().equivalent function does not work".
     const error_code code(ERROR_NOT_ENOUGH_MEMORY, system_category());
@@ -44,6 +57,8 @@ int main() {
     // Also test VSO-649432 <system_error> system_category().message() ends with extra newlines
     const auto msg = code.message();
     assert(!msg.empty() && msg.back() != '\0' && !isspace(static_cast<unsigned char>(msg.back())));
+
+    test_lwg_3598();
 }
 
 

--- a/tests/tr1/tests/system_error/test.cpp
+++ b/tests/tr1/tests/system_error/test.cpp
@@ -133,7 +133,7 @@ void test_main() { // run tests
         CHECK(!(ec1 < ec1));
 
         STD error_condition ec0x, ec1x(ERR too_many_links);
-        CHECK(ec0 != ec0x);
+        CHECK(ec0 == ec0x);
         CHECK(ec0 != ec1x);
         CHECK(!STD is_error_code_enum<ERR_ENUM>::value);
         CHECK(ec1 == STD make_error_code(ERR too_many_links));
@@ -167,7 +167,7 @@ void test_main() { // run tests
         CHECK(!(ec1 < ec1));
 
         STD error_code ec0x, ec1x = STD make_error_code(ERR too_many_links);
-        CHECK(ec0 != ec0x);
+        CHECK(ec0 == ec0x);
         CHECK(ec0 != ec1x);
         CHECK(STD is_error_condition_enum<ERR_ENUM>::value);
         CHECK(ec1 == STD make_error_condition(ERR too_many_links));


### PR DESCRIPTION
Fixes #2552 

Should I add a reminder for moving the fix to syserror.cpp when we will be able to modify the file?

`cond.message()` == `"Операция успешно завершена."` on my PC.

it's definitely something else on your PC so I decided to test with `!=` the fallback.