### PR TITLE
Implement LWG-3657 `std::hash<std::filesystem::path>` is not enabled

### DIFF
--- a/stl/inc/filesystem
+++ b/stl/inc/filesystem
@@ -4338,6 +4338,15 @@ namespace filesystem {
     }
 } // namespace filesystem
 
+template <>
+struct hash<filesystem::path> {
+    _CXX17_DEPRECATE_ADAPTOR_TYPEDEFS typedef filesystem::path _ARGUMENT_TYPE_NAME;
+    _CXX17_DEPRECATE_ADAPTOR_TYPEDEFS typedef size_t _RESULT_TYPE_NAME;
+    _NODISCARD size_t operator()(const filesystem::path& _Path) const noexcept {
+        return _STD filesystem::hash_value(_Path);
+    }
+};
+
 #ifdef __cpp_lib_concepts
 namespace ranges {
     template <>

--- a/tests/std/tests/P0218R1_filesystem/test.cpp
+++ b/tests/std/tests/P0218R1_filesystem/test.cpp
@@ -483,11 +483,16 @@ bool run_compare_test_case(const compare_test_case& testCase) {
     const path leftPath(testCase.left);
     const path rightPath(testCase.right);
     const int actualCmp = leftPath.compare(testCase.right); // string_view
+    const size_t leftPathHash = hash_value(leftPath);
+    const size_t rightPathHash = hash_value(rightPath);
     // technically the standard only requires that these agree in sign, but our implementation
     // wants to always return the same value
     EXPECT(leftPath.compare(rightPath) == actualCmp); // const path&
     EXPECT(leftPath.compare(rightPath.native()) == actualCmp); // const string_type&
     EXPECT(leftPath.compare(rightPath.c_str()) == actualCmp); // const value_type *
+    // LWG-3657: hash<filesystem::path>::operator() returns the same value as filesystem::hash_value
+    EXPECT(hash<path>{}(leftPath) == leftPathHash);
+    EXPECT(hash<path>{}(rightPath) == rightPathHash);
     compare_result actual;
     if (actualCmp < 0) {
         actual = compare_result::less;
@@ -498,7 +503,7 @@ bool run_compare_test_case(const compare_test_case& testCase) {
         EXPECT(!(leftPath > rightPath));
         EXPECT(leftPath <= rightPath);
         EXPECT(!(leftPath >= rightPath));
-        EXPECT(hash_value(leftPath) != hash_value(rightPath)); // not required, but desirable
+        EXPECT(leftPathHash != rightPathHash); // not required, but desirable
     } else if (actualCmp > 0) {
         actual = compare_result::greater;
         EXPECT(rightPath.compare(testCase.left) < 0);
@@ -508,7 +513,7 @@ bool run_compare_test_case(const compare_test_case& testCase) {
         EXPECT(leftPath > rightPath);
         EXPECT(!(leftPath <= rightPath));
         EXPECT(leftPath >= rightPath);
-        EXPECT(hash_value(leftPath) != hash_value(rightPath)); // not required, but desirable
+        EXPECT(leftPathHash != rightPathHash); // not required, but desirable
     } else {
         actual = compare_result::equal;
         EXPECT(leftPath == rightPath);
@@ -517,7 +522,7 @@ bool run_compare_test_case(const compare_test_case& testCase) {
         EXPECT(!(leftPath > rightPath));
         EXPECT(leftPath <= rightPath);
         EXPECT(leftPath >= rightPath);
-        EXPECT(hash_value(leftPath) == hash_value(rightPath));
+        EXPECT(leftPathHash == rightPathHash);
     }
 
     if (testCase.expected == actual) {

--- a/tests/std/tests/P0218R1_filesystem/test.cpp
+++ b/tests/std/tests/P0218R1_filesystem/test.cpp
@@ -482,8 +482,8 @@ constexpr compare_test_case compareTestCases[] = {
 bool run_compare_test_case(const compare_test_case& testCase) {
     const path leftPath(testCase.left);
     const path rightPath(testCase.right);
-    const int actualCmp = leftPath.compare(testCase.right); // string_view
-    const size_t leftPathHash = hash_value(leftPath);
+    const int actualCmp        = leftPath.compare(testCase.right); // string_view
+    const size_t leftPathHash  = hash_value(leftPath);
     const size_t rightPathHash = hash_value(rightPath);
     // technically the standard only requires that these agree in sign, but our implementation
     // wants to always return the same value


### PR DESCRIPTION
Fixes #2556 