### PR TITLE
Implement LWG-3618 Unnecessary `iter_move` for `transform_view::iterator`

### DIFF
--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -1960,7 +1960,7 @@ namespace ranges {
             }
 
             _NODISCARD constexpr decltype(auto) operator*() const
-                _NOEXCEPT_IDL0(noexcept(_STD invoke(*_Parent->_Fun, *_Current))) /* strengthened */ {
+                _NOEXCEPT_IDL0(noexcept(_STD invoke(*_Parent->_Fun, *_Current))) {
 #if _ITERATOR_DEBUG_LEVEL != 0
                 _Check_dereference();
                 _STL_VERIFY(
@@ -2140,14 +2140,6 @@ namespace ranges {
                 _Left._Same_range(_Right);
 #endif // _ITERATOR_DEBUG_LEVEL != 0
                 return _Left._Current - _Right._Current;
-            }
-
-            _NODISCARD friend constexpr decltype(auto) iter_move(const _Iterator& _It) noexcept(noexcept(*_It)) {
-                if constexpr (is_lvalue_reference_v<decltype(*_It)>) {
-                    return _STD move(*_It);
-                } else {
-                    return *_It;
-                }
             }
         };
 

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -1960,9 +1960,13 @@ namespace ranges {
             }
 
             _NODISCARD constexpr decltype(auto) operator*() const
-                _NOEXCEPT_IDL0(noexcept(_STD invoke(*_Parent->_Fun, *_Current))) {
+                noexcept(noexcept(_STD invoke(*_Parent->_Fun, *_Current))) {
 #if _ITERATOR_DEBUG_LEVEL != 0
-                _Check_dereference();
+                try {
+                    _Check_dereference();
+                } catch (...) {
+                    _STL_VERIFY(false, "cannot dereference end transform_view iterator");
+                }
                 _STL_VERIFY(
                     _Parent->_Fun, "Cannot dereference iterator into transform_view with no transformation function");
 #endif // _ITERATOR_DEBUG_LEVEL != 0

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -1910,7 +1910,7 @@ namespace ranges {
             _Parent_t* _Parent{};
 
 #if _ITERATOR_DEBUG_LEVEL != 0
-            constexpr void _Check_dereference() const {
+            constexpr void _Check_dereference() const noexcept {
                 _STL_VERIFY(_Parent != nullptr, "cannot dereference value-initialized transform_view iterator");
                 _STL_VERIFY(_Current != _RANGES end(_Parent->_Range), "cannot dereference end transform_view iterator");
             }
@@ -1962,11 +1962,7 @@ namespace ranges {
             _NODISCARD constexpr decltype(auto) operator*() const
                 noexcept(noexcept(_STD invoke(*_Parent->_Fun, *_Current))) {
 #if _ITERATOR_DEBUG_LEVEL != 0
-                try {
-                    _Check_dereference();
-                } catch (...) {
-                    _STL_VERIFY(false, "cannot dereference end transform_view iterator");
-                }
+                _Check_dereference();
                 _STL_VERIFY(
                     _Parent->_Fun, "Cannot dereference iterator into transform_view with no transformation function");
 #endif // _ITERATOR_DEBUG_LEVEL != 0

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -676,8 +676,6 @@ std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.con
 
 # non-portable test of strengthened noexcept
 std/ranges/range.adaptors/range.drop/ctor.default.pass.cpp FAIL
-std/ranges/range.adaptors/range.transform/iterator/deref.pass.cpp FAIL
-std/ranges/range.adaptors/range.transform/iterator/iter_move.pass.cpp FAIL
 std/ranges/range.adaptors/range.transform/iterator/subscript.pass.cpp FAIL
 std/ranges/range.utility/view.interface/view.interface.pass.cpp FAIL
 

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -676,8 +676,6 @@ utilities\memory\util.smartptr\util.smartptr.shared\util.smartptr.shared.const\u
 
 # non-portable test of strengthened noexcept
 ranges\range.adaptors\range.drop\ctor.default.pass.cpp
-ranges\range.adaptors\range.transform\iterator\deref.pass.cpp
-ranges\range.adaptors\range.transform\iterator\iter_move.pass.cpp
 ranges\range.adaptors\range.transform\iterator\subscript.pass.cpp
 ranges\range.utility\view.interface\view.interface.pass.cpp
 

--- a/tests/std/tests/P0896R4_views_transform/test.cpp
+++ b/tests/std/tests/P0896R4_views_transform/test.cpp
@@ -490,10 +490,10 @@ struct iterator_instantiator {
             auto r0 = make_view();
             auto i0 = r0.begin();
             assert(*i0 == add8(mutable_ints[0]));
-            STATIC_ASSERT(NOEXCEPT_IDL0(*i0));
+            STATIC_ASSERT(noexcept(*i0));
 
             assert(ranges::iter_move(i0) == add8(mutable_ints[0])); // NB: moving from int leaves it unchanged
-            STATIC_ASSERT(NOEXCEPT_IDL0(ranges::iter_move(i0)));
+            STATIC_ASSERT(noexcept(ranges::iter_move(i0)));
 
             STATIC_ASSERT(!CanIterSwap<decltype(i0)>);
         }


### PR DESCRIPTION
Fixes #2554