### PR TITLE
implement LWG-3471: `polymorphic_allocator::allocate` does not satisfy Cpp17Allocator requirements

### DIFF
--- a/stl/inc/xpolymorphic_allocator.h
+++ b/stl/inc/xpolymorphic_allocator.h
@@ -144,7 +144,8 @@ namespace pmr {
         _NODISCARD __declspec(allocator) void* allocate(_CRT_GUARDOVERFLOW const size_t _Bytes,
             const size_t _Align = alignof(max_align_t)) { // allocate _Bytes bytes of memory with alignment _Align
             _STL_ASSERT(_Is_pow_2(_Align), "memory_resource::allocate(): Alignment must be a power of two.");
-            return do_allocate(_Bytes, _Align);
+            void* _Ptr = do_allocate(_Bytes, _Align);
+            return launder(new (_Ptr) byte[_Bytes]);
         }
 
         void deallocate(void* const _Ptr, const size_t _Bytes, const size_t _Align = alignof(max_align_t)) {


### PR DESCRIPTION
Fixes #2550 

I saw that the changes were in "Previous resolution [SUPERSEDED]" but as far as I understand the new resolution is needed because of changing the wording and the proposed implementation stays the same.

`std::launder` is in `<new>`

`<xmemory>` includes `<new>`

`<xpolymorphic_allocator.h>` includes `<xmemory>`