### PR TITLE
`<format>`: fix single byte out of bounds access

### DIFF
--- a/stl/inc/format
+++ b/stl/inc/format
@@ -2541,8 +2541,8 @@ _NODISCARD _OutputIt _Fmt_write(
         case chars_format::hex:
         case chars_format::scientific:
             if (_Extra_precision != 0) {
-                while (*_Exponent_start != _Exponent) { // Trailing zeroes are in front of the exponent
-                    --_Exponent_start;
+                // Trailing zeroes are in front of the exponent
+                while (*--_Exponent_start != _Exponent) {
                 }
             }
             [[fallthrough]];


### PR DESCRIPTION
`format` would access uninitialized stack when trying to find the position of the exponent. When the junk in `_Buffer` (or past it, if `to_chars` used up all available space in the buffer) happened to be `'p'` in `hex` mode (or `'e'` in `scientific` mode, or their uppercased forms), this produced incorrect results.

Fixes #2449. Thanks to @statementreply for investigating!