### PR TITLE
Azure Pipelines: Upload test logs as artifacts

### DIFF
--- a/azure-devops/cross-build.yml
+++ b/azure-devops/cross-build.yml
@@ -45,4 +45,3 @@ jobs:
       targetPlatform: ${{ parameters.targetPlatform }}
       targetArch: ${{ parameters.vsDevCmdArch }}
       displayName: 'Build Tests'
-      publishArtifact: false # disabled due to GH-1653

--- a/azure-devops/run-tests.yml
+++ b/azure-devops/run-tests.yml
@@ -14,9 +14,6 @@ parameters:
 - name: displayName
   type: string
   default: 'Run Tests'
-- name: publishArtifact
-  type: boolean
-  default: false
 steps:
 - task: CmdLine@2
   displayName: ${{ parameters.displayName }}
@@ -38,11 +35,7 @@ steps:
     testResultsFormat: JUnit
     testResultsFiles: '**/test-results.xml'
     testRunTitle: 'test-${{ parameters.targetPlatform }}-$(System.JobPositionInPhase)'
-- publish: $(${{ parameters.buildOutPutLocationVar }})/out
-  artifact: '${{ parameters.targetPlatform }}-$(System.JobPositionInPhase)-libs-$(System.JobId)'
-  condition: ${{ parameters.publishArtifact }}
-  displayName: 'Publish Libs and Headers Artifact'
-- publish: $(${{ parameters.buildOutPutLocationVar }})/tests
-  artifact: '${{ parameters.targetPlatform }}-$(System.JobPositionInPhase)-tests-$(System.JobId)'
-  condition: ${{ parameters.publishArtifact }}
-  displayName: 'Publish Tests Artifact'
+- publish: $(${{ parameters.buildOutputLocationVar }})/test-results.xml
+  artifact: '${{ parameters.targetPlatform }}-$(System.JobPositionInPhase)-xml-$(System.JobId)'
+  condition: failed()
+  displayName: 'Publish XML Artifact'

--- a/tools/scripts/print_failures.py
+++ b/tools/scripts/print_failures.py
@@ -1,23 +1,37 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-# This script prints the output of test failures that were recorded by `stl-lit.py -o TEST_LOG_FILENAME`.
+# This script prints the output of test failures that were recorded by `stl-lit.py -o TEST_LOG_FILENAME`
+# or `stl-lit.py --xunit-xml-output=TEST_RESULTS.xml`.
 
 import json
+import os
 import sys
+import xml.dom.minidom
 
 if len(sys.argv) != 2:
-    sys.exit(f"Usage: python {sys.argv[0]} TEST_LOG_FILENAME")
+    sys.exit(f"Usage: python {sys.argv[0]} [TEST_LOG_FILENAME|TEST_RESULTS.xml]")
 
-with open(sys.argv[1]) as file:
-    test_log = json.load(file)
-    for result in test_log["tests"]:
-        if not result["code"] in ["PASS", "UNSUPPORTED", "XFAIL"]:
-            print("code: {}".format(result["code"]))
-            # Ignore result["elapsed"].
-            print("name: {}".format(result["name"]))
-            # The JSON contains embedded CRLFs (which aren't affected by opening the file in text mode).
-            # If we don't replace these CRLFs with LFs here, this script will appear to be okay in the console,
-            # but redirecting it to a file will result in ugly double newlines.
-            print("output: {}".format(result["output"].replace("\r\n", "\n")))
-            print("==================================================")
+filename = sys.argv[1]
+extension = os.path.splitext(filename)[1]
+
+with open(filename) as file:
+    if extension.casefold() == ".xml".casefold():
+        test_xml = xml.dom.minidom.parse(file)
+        for testcase_elem in test_xml.getElementsByTagName("testcase"):
+            for failure_elem in testcase_elem.getElementsByTagName("failure"):
+                print("name: {}".format(testcase_elem.getAttribute("classname")))
+                print("output: {}".format(failure_elem.firstChild.data))
+                print("==================================================")
+    else:
+        test_log = json.load(file)
+        for result in test_log["tests"]:
+            if not result["code"] in ["PASS", "UNSUPPORTED", "XFAIL"]:
+                print("code: {}".format(result["code"]))
+                # Ignore result["elapsed"].
+                print("name: {}".format(result["name"]))
+                # The JSON contains embedded CRLFs (which aren't affected by opening the file in text mode).
+                # If we don't replace these CRLFs with LFs here, this script will appear to be okay in the console,
+                # but redirecting it to a file will result in ugly double newlines.
+                print("output: {}".format(result["output"].replace("\r\n", "\n")))
+                print("==================================================")


### PR DESCRIPTION
Fixes #2557.

* Extend `tools/scripts/print_failures.py` to understand the XML produced by `--xunit-xml-output`. This detects `.xml` versus any other extension and acts accordingly. Like the JSON codepath, success is silence. Note that a `"testcase"` element can have 0 or 1 `"failure"` elements; looping with `for failure_elem` was the most elegant way to handle this optionality. I checked `lit`'s generation logic to make sure that I wasn't missing any potential forms of output (AFAICT, both unexpected failures and unexpected passes are reported with `"failure"` here.) The CRLF replacement needed for JSON doesn't appear to be needed for XML.
* Remove dead logic - `publishArtifact` was disabled a year ago due to #1653.
* Add a new `publish` step, that will upload `test-results.xml`. This is set to happen only if a previous step `failed()` (but not if the run is cancelled).
  + I've verified that this uploads artifacts for both compiletime and runtime failures, and they're easily downloadable as ZIP files. I've also verified that no artifacts are uploaded when a shard succeeds.

We'll still be able to rely on the error output that's immediately visible in Azure Pipelines for most failures, but if we encounter lengthy output (in scenarios like #2449, or for header units where the command lines are extremely long), then the XML output will be available for easy investigation.