### PR TITLE
Even rvalue `empty_view`s are `borrowed_range`s

### DIFF
--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -875,6 +875,9 @@ namespace ranges {
         }
     };
 
+    template <class _Ty>
+    inline constexpr bool enable_borrowed_range<empty_view<_Ty>> = true;
+
     namespace views {
         template <class _Ty>
         inline constexpr empty_view<_Ty> empty;

--- a/tests/std/tests/P0896R4_views_empty/test.cpp
+++ b/tests/std/tests/P0896R4_views_empty/test.cpp
@@ -18,6 +18,7 @@ constexpr bool test_one_type() {
     // validate type properties
     using R = ranges::empty_view<T>;
     static_assert(ranges::view<R> && ranges::contiguous_range<R> && ranges::sized_range<R> && ranges::common_range<R>);
+    static_assert(ranges::borrowed_range<R>);
     static_assert(same_as<const R, decltype(views::empty<T>)>);
     auto& r = views::empty<T>;
 


### PR DESCRIPTION
....which we somehow missed when implementing P1870R1 "`forwarding-range<T>` is too subtle".
