### PR TITLE
Add scripts to set the environment up to use just-built artifacts

### DIFF
--- a/stl/CMakeLists.txt
+++ b/stl/CMakeLists.txt
@@ -560,3 +560,6 @@ add_stl_statics("d1" "_DEBUG;_ITERATOR_DEBUG_LEVEL=1" "${VCLIBS_DEBUG_OPTIONS}")
 add_stl_statics("d0" "_DEBUG;_ITERATOR_DEBUG_LEVEL=0" "${VCLIBS_DEBUG_OPTIONS}")
 
 add_library(stl_asan STATIC ${ASAN_SOURCES})
+
+configure_file(set_environment.bat.in "${PROJECT_BINARY_DIR}/set_environment.bat" @ONLY)
+configure_file(set_environment.ps1.in "${PROJECT_BINARY_DIR}/set_environment.ps1" @ONLY)

--- a/stl/set_environment.bat.in
+++ b/stl/set_environment.bat.in
@@ -1,3 +1,6 @@
-@set PATH="%~dp0out\bin\@VCLIBS_I386_OR_AMD64@;%PATH%"
-@set INCLUDE="%~dp0out\inc;%INCLUDE%"
-@set LIB="%~dp0\out\lib\@VCLIBS_I386_OR_AMD64@;%LIB%"
+:: Copyright (c) Microsoft Corporation.
+:: SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+@set PATH=%~dp0out\bin\@VCLIBS_I386_OR_AMD64@;%PATH%
+@set INCLUDE=%~dp0out\inc;%INCLUDE%
+@set LIB=%~dp0out\lib\@VCLIBS_I386_OR_AMD64@;%LIB%

--- a/stl/set_environment.bat.in
+++ b/stl/set_environment.bat.in
@@ -1,0 +1,3 @@
+@set PATH="%~dp0out\bin\@VCLIBS_I386_OR_AMD64@;%PATH%"
+@set INCLUDE="%~dp0out\inc;%INCLUDE%"
+@set LIB="%~dp0\out\lib\@VCLIBS_I386_OR_AMD64@;%LIB%"

--- a/stl/set_environment.ps1.in
+++ b/stl/set_environment.ps1.in
@@ -1,3 +1,6 @@
-$env:PATH="$PSScriptRoot\bin\@VCLIBS_I386_OR_AMD64@;$env:PATH"
-$env:INCLUDE="$PSScriptRoot\inc;$env:INCLUDE"
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+$env:PATH="$PSScriptRoot\out\bin\@VCLIBS_I386_OR_AMD64@;$env:PATH"
+$env:INCLUDE="$PSScriptRoot\out\inc;$env:INCLUDE"
 $env:LIB="$PSScriptRoot\out\lib\@VCLIBS_I386_OR_AMD64@;$env:LIB"

--- a/stl/set_environment.ps1.in
+++ b/stl/set_environment.ps1.in
@@ -1,0 +1,3 @@
+$env:PATH="$PSScriptRoot\bin\@VCLIBS_I386_OR_AMD64@;$env:PATH"
+$env:INCLUDE="$PSScriptRoot\inc;$env:INCLUDE"
+$env:LIB="$PSScriptRoot\out\lib\@VCLIBS_I386_OR_AMD64@;$env:LIB"


### PR DESCRIPTION
These are intended for development,
because I kept forgetting to add in the arch prefix

This is a github-only change, there's nothing that will touch the internal build, and
the files are copied over outside the "output" directory.