### PR TITLE
format (and friends) should reject volatile arguments

### DIFF
--- a/stl/inc/format
+++ b/stl/inc/format
@@ -1494,10 +1494,10 @@ struct _Format_arg_traits {
     // clang-format on
 
     template <class _Ty>
-    using _Storage_type = decltype(_Phony_basic_format_arg_constructor(_STD declval<_Ty>()));
+    using _Storage_type = decltype(_Phony_basic_format_arg_constructor(_STD declval<_Ty&>()));
 
     template <class _Ty>
-    static constexpr size_t _Storage_size = sizeof(_Storage_type<remove_cvref_t<_Ty>>);
+    static constexpr size_t _Storage_size = sizeof(_Storage_type<_Ty>);
 };
 
 struct _Format_arg_index {
@@ -1559,7 +1559,7 @@ private:
 
     template <class _Ty>
     void _Store(const size_t _Arg_index, _Ty&& _Val) noexcept {
-        using _Erased_type = typename _Traits::template _Storage_type<remove_cvref_t<_Ty>>;
+        using _Erased_type = typename _Traits::template _Storage_type<_Ty>;
 
         _Basic_format_arg_type _Arg_type;
         if constexpr (is_same_v<_Erased_type, bool>) {


### PR DESCRIPTION
... for now, at least. This corrects a defect in our implementation of [[format.args]/4](https://eel.is/c++draft/format.arg#4)'s requirement that:

> ```c++
> typename Context::template formatter_type<remove_cvref_t<T>>()
>   .format(declval<T&>(), declval<Context&>())
> ```

be a valid expression. We were incorrectly stripping cv-qualifiers from `T`.