### PR TITLE
Implement LWG-3648: `format` should not print `bool` with `'c'`

### DIFF
--- a/stl/inc/format
+++ b/stl/inc/format
@@ -1369,8 +1369,7 @@ public:
                 _Cat = _Presentation_type_category::_String;
             }
             // note, we don't get a call if there isn't a type, but none is valid for everything.
-            if (_Cat != _Presentation_type_category::_String && _Cat != _Presentation_type_category::_Integer
-                && _Cat != _Presentation_type_category::_Char) {
+            if (_Cat != _Presentation_type_category::_String && _Cat != _Presentation_type_category::_Integer) {
                 _THROW(format_error("Invalid presentation type for bool"));
             }
             break;

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -31,12 +31,6 @@ std/language.support/support.exception/propagation/rethrow_exception.pass.cpp FA
 # Testing nonstandard behavior
 std/utilities/template.bitset/bitset.cons/string_ctor.pass.cpp FAIL
 
-# libc++ doesn't implement LWG-3648: "format should not print bool with 'c'"
-std/utilities/format/format.functions/vformat_to.locale.pass.cpp FAIL
-std/utilities/format/format.functions/vformat_to.pass.cpp FAIL
-std/utilities/format/format.functions/vformat.locale.pass.cpp FAIL
-std/utilities/format/format.functions/vformat.pass.cpp FAIL
-
 # Tests with undefined behavior under N4842 [basic.start.term]/6 (detached threads)
 std/thread/futures/futures.task/futures.task.members/dtor.pass.cpp SKIPPED
 std/thread/futures/futures.unique_future/wait_until.pass.cpp SKIPPED
@@ -85,6 +79,12 @@ std/iterators/predef.iterators/reverse.iterators/reverse.iter.cons/assign.pass.c
 # optional's comparisons aren't portably constrained (https://reviews.llvm.org/D116884)
 std/concepts/concepts.compare/concepts.totallyordered/totally_ordered.pass.cpp FAIL
 std/concepts/concepts.compare/concept.equalitycomparable/equality_comparable.compile.pass.cpp FAIL
+
+# libc++ doesn't implement LWG-3648: "format should not print bool with 'c'"
+std/utilities/format/format.functions/vformat_to.locale.pass.cpp FAIL
+std/utilities/format/format.functions/vformat_to.pass.cpp FAIL
+std/utilities/format/format.functions/vformat.locale.pass.cpp FAIL
+std/utilities/format/format.functions/vformat.pass.cpp FAIL
 
 
 # *** INTERACTIONS WITH CONTEST / C1XX THAT UPSTREAM LIKELY WON'T FIX ***

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -34,6 +34,7 @@ std/utilities/template.bitset/bitset.cons/string_ctor.pass.cpp FAIL
 # libc++ doesn't implement LWG-3648: "format should not print bool with 'c'"
 std/utilities/format/format.functions/vformat_to.locale.pass.cpp FAIL
 std/utilities/format/format.functions/vformat_to.pass.cpp FAIL
+std/utilities/format/format.functions/vformat.locale.pass.cpp FAIL
 std/utilities/format/format.functions/vformat.pass.cpp FAIL
 
 # Tests with undefined behavior under N4842 [basic.start.term]/6 (detached threads)

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -31,6 +31,11 @@ std/language.support/support.exception/propagation/rethrow_exception.pass.cpp FA
 # Testing nonstandard behavior
 std/utilities/template.bitset/bitset.cons/string_ctor.pass.cpp FAIL
 
+# libc++ doesn't implement LWG-3648: "format should not print bool with 'c'"
+std/utilities/format/format.functions/vformat_to.locale.pass.cpp FAIL
+std/utilities/format/format.functions/vformat_to.pass.cpp FAIL
+std/utilities/format/format.functions/vformat.pass.cpp FAIL
+
 # Tests with undefined behavior under N4842 [basic.start.term]/6 (detached threads)
 std/thread/futures/futures.task/futures.task.members/dtor.pass.cpp SKIPPED
 std/thread/futures/futures.unique_future/wait_until.pass.cpp SKIPPED

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -34,6 +34,7 @@ utilities\template.bitset\bitset.cons\string_ctor.pass.cpp
 # libc++ doesn't implement LWG-3648: "format should not print bool with 'c'"
 utilities\format\format.functions\vformat_to.locale.pass.cpp
 utilities\format\format.functions\vformat_to.pass.cpp
+utilities\format\format.functions\vformat.locale.pass.cpp
 utilities\format\format.functions\vformat.pass.cpp
 
 # Tests with undefined behavior under N4842 [basic.start.term]/6 (detached threads)

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -31,12 +31,6 @@ language.support\support.exception\propagation\rethrow_exception.pass.cpp
 # Testing nonstandard behavior
 utilities\template.bitset\bitset.cons\string_ctor.pass.cpp
 
-# libc++ doesn't implement LWG-3648: "format should not print bool with 'c'"
-utilities\format\format.functions\vformat_to.locale.pass.cpp
-utilities\format\format.functions\vformat_to.pass.cpp
-utilities\format\format.functions\vformat.locale.pass.cpp
-utilities\format\format.functions\vformat.pass.cpp
-
 # Tests with undefined behavior under N4842 [basic.start.term]/6 (detached threads)
 thread\futures\futures.task\futures.task.members\dtor.pass.cpp
 thread\futures\futures.unique_future\wait_until.pass.cpp
@@ -85,6 +79,12 @@ iterators\predef.iterators\reverse.iterators\reverse.iter.cons\assign.pass.cpp
 # optional's comparisons aren't portably constrained (https://reviews.llvm.org/D116884)
 concepts\concepts.compare\concepts.totallyordered\totally_ordered.pass.cpp
 concepts\concepts.compare\concept.equalitycomparable\equality_comparable.compile.pass.cpp
+
+# libc++ doesn't implement LWG-3648: "format should not print bool with 'c'"
+utilities\format\format.functions\vformat_to.locale.pass.cpp
+utilities\format\format.functions\vformat_to.pass.cpp
+utilities\format\format.functions\vformat.locale.pass.cpp
+utilities\format\format.functions\vformat.pass.cpp
 
 
 # *** INTERACTIONS WITH CONTEST / C1XX THAT UPSTREAM LIKELY WON'T FIX ***

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -31,6 +31,11 @@ language.support\support.exception\propagation\rethrow_exception.pass.cpp
 # Testing nonstandard behavior
 utilities\template.bitset\bitset.cons\string_ctor.pass.cpp
 
+# libc++ doesn't implement LWG-3648: "format should not print bool with 'c'"
+utilities\format\format.functions\vformat_to.locale.pass.cpp
+utilities\format\format.functions\vformat_to.pass.cpp
+utilities\format\format.functions\vformat.pass.cpp
+
 # Tests with undefined behavior under N4842 [basic.start.term]/6 (detached threads)
 thread\futures\futures.task\futures.task.members\dtor.pass.cpp
 thread\futures\futures.unique_future\wait_until.pass.cpp

--- a/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
@@ -1395,8 +1395,10 @@ void test_sane_c_specifier() {
     throw_helper(STR("{:+}"), true);
     throw_helper(STR("{:+c}"), true);
     assert(format(STR("{:^}"), true) == STR("true"));
+    throw_helper(STR("{:^c}"), true);
     throw_helper(STR("{:0}"), true);
     throw_helper(STR("{:0c}"), true);
+    throw_helper(STR("{:c}"), true);
 
     throw_helper(STR("{:#}"), 'c');
     throw_helper(STR("{:#c}"), 'c');

--- a/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
@@ -632,7 +632,6 @@ void test_bool_specs() {
 
     test_type(STR("{:b}"), true);
     test_type(STR("{:B}"), true);
-    test_type(STR("{:c}"), true);
     test_type(STR("{:d}"), true);
     test_type(STR("{:o}"), true);
     test_type(STR("{:x}"), true);
@@ -640,7 +639,6 @@ void test_bool_specs() {
 
     test_type(STR("{:b}"), false);
     test_type(STR("{:B}"), false);
-    test_type(STR("{:c}"), false);
     test_type(STR("{:d}"), false);
     test_type(STR("{:o}"), false);
     test_type(STR("{:x}"), false);
@@ -1397,10 +1395,8 @@ void test_sane_c_specifier() {
     throw_helper(STR("{:+}"), true);
     throw_helper(STR("{:+c}"), true);
     assert(format(STR("{:^}"), true) == STR("true"));
-    assert(format(STR("{:^c}"), true) == STR("\x1"));
     throw_helper(STR("{:0}"), true);
     throw_helper(STR("{:0c}"), true);
-    assert(format(STR("{:c}"), true) == STR("\x1"));
 
     throw_helper(STR("{:#}"), 'c');
     throw_helper(STR("{:#c}"), 'c');


### PR DESCRIPTION
Fixes #2555