### PR TITLE
cache `__std_get_cvt` output

### DIFF
--- a/stl/inc/format
+++ b/stl/inc/format
@@ -536,15 +536,20 @@ protected:
     }
 
     _Fmt_codec_base() {
+        static const _Cvtvec _Cvt_cache = [] {
 #ifdef _MSVC_EXECUTION_CHARACTER_SET
-        constexpr __std_code_page _Format_codepage{_MSVC_EXECUTION_CHARACTER_SET};
+            constexpr __std_code_page _Format_codepage{_MSVC_EXECUTION_CHARACTER_SET};
 #else // ^^^ no workaround / workaround vvv
       // TRANSITION, Clang 14 - only utf-8 is supported
       // TRANSITION, VSO-1468747 (EDG) - constructor isn't constexpr, so value is unimportant
-        constexpr __std_code_page _Format_codepage{65001};
+            constexpr __std_code_page _Format_codepage{65001};
 #endif // ^^^ workaround ^^^
-        [[maybe_unused]] const __std_win_error _Result = __std_get_cvt(_Format_codepage, &_Cvt);
-        _STL_INTERNAL_CHECK(_Result == __std_win_error::_Success);
+            _Cvtvec _Cvt_temp;
+            [[maybe_unused]] const __std_win_error _Result = __std_get_cvt(_Format_codepage, &_Cvt_temp);
+            _STL_INTERNAL_CHECK(_Result == __std_win_error::_Success);
+            return _Cvt_temp;
+        }();
+        _Cvt = _Cvt_cache;
     }
 };
 

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -536,7 +536,9 @@ protected:
     }
 
     _Fmt_codec_base() {
-        thread_local const _Cvtvec _Cvt_cache = [] {
+#pragma warning(push)
+#pragma warning(disable : 4640) // '_Cvt_cache': construction of local static object is not thread-safe
+        static const _Cvtvec _Cvt_cache = [] {
 #ifdef _MSVC_EXECUTION_CHARACTER_SET
             constexpr __std_code_page _Format_codepage{_MSVC_EXECUTION_CHARACTER_SET};
 #else // ^^^ no workaround / workaround vvv
@@ -549,6 +551,7 @@ protected:
             _STL_INTERNAL_CHECK(_Result == __std_win_error::_Success);
             return _Cvt_temp;
         }();
+#pragma warning(pop)
         _Cvt = _Cvt_cache;
     }
 };

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -536,7 +536,7 @@ protected:
     }
 
     _Fmt_codec_base() {
-        static const _Cvtvec _Cvt_cache = [] {
+        thread_local const _Cvtvec _Cvt_cache = [] {
 #ifdef _MSVC_EXECUTION_CHARACTER_SET
             constexpr __std_code_page _Format_codepage{_MSVC_EXECUTION_CHARACTER_SET};
 #else // ^^^ no workaround / workaround vvv


### PR DESCRIPTION
Fixes #2594

Is the warning C4640 correct at all?

>If multiple threads attempt to initialize the same static local variable concurrently, the initialization occurs exactly once (since C++11)

https://en.cppreference.com/w/cpp/language/storage_duration#Static_local_variables
