### PR TITLE
Add STL cgmanifest entry for Boost

### DIFF
--- a/docs/cgmanifest.json
+++ b/docs/cgmanifest.json
@@ -4,6 +4,15 @@
             "component": {
                 "type": "git",
                 "git": {
+                    "repositoryUrl": "https://github.com/boostorg/boost",
+                    "commitHash": "b143a5b72075f47307a23e680889d8434c8afc54"
+                }
+            }
+        },
+        {
+            "component": {
+                "type": "git",
+                "git": {
                     "repositoryUrl": "https://github.com/llvm/llvm-project.git",
                     "commitHash": "fc2a5ef9c8754fe3fbdf96483901ca3f13406b35"
                 }


### PR DESCRIPTION
With SHA for the boost-1.66.0 tag, which is the version from which we made the nuget that we use to build the STL's special math function satellite.

This is a dual of MSVC-PR-382487.
