### PR TITLE
Toolset update: VS 2022 17.2 Preview 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With The Visual Studio IDE
 
-1. Install Visual Studio 2022 17.1 Preview 5 or later.
+1. Install Visual Studio 2022 17.2 Preview 2 or later.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
     * Otherwise, install [CMake][] 3.22 or later, and [Ninja][] 1.10.2 or later.
@@ -155,7 +155,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With A Native Tools Command Prompt
 
-1. Install Visual Studio 2022 17.1 Preview 5 or later.
+1. Install Visual Studio 2022 17.2 Preview 2 or later.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
     * Otherwise, install [CMake][] 3.22 or later, and [Ninja][] 1.10.2 or later.

--- a/azure-devops/cmake-configure-build.yml
+++ b/azure-devops/cmake-configure-build.yml
@@ -21,7 +21,7 @@ steps:
   inputs:
     targetType: inline
     script: |
-      $testParallelism = $env:NUMBER_OF_PROCESSORS - 2
+      $testParallelism = $env:NUMBER_OF_PROCESSORS
       Write-Host "##vso[task.setvariable variable=testParallelism;]$testParallelism"
 - script: |
     if exist "$(${{ parameters.buildOutputLocationVar }})" (

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -91,7 +91,7 @@ if ([string]::IsNullOrEmpty($AdminUserPassword)) {
   $PsExecPath = Join-Path $ExtractedPsToolsPath 'PsExec64.exe'
 
   # https://github.com/PowerShell/PowerShell/releases/latest
-  $PowerShellZipUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.2.1/PowerShell-7.2.1-win-x64.zip'
+  $PowerShellZipUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.2.2/PowerShell-7.2.2-win-x64.zip'
   Write-Host "Downloading: $PowerShellZipUrl"
   $ExtractedPowerShellPath = DownloadAndExtractZip -Url $PowerShellZipUrl
   $PwshPath = Join-Path $ExtractedPowerShellPath 'pwsh.exe'
@@ -142,7 +142,7 @@ $Workloads = @(
 $ReleaseInPath = 'Preview'
 $Sku = 'Enterprise'
 $VisualStudioBootstrapperUrl = 'https://aka.ms/vs/17/pre/vs_enterprise.exe'
-$PythonUrl = 'https://www.python.org/ftp/python/3.10.2/python-3.10.2-amd64.exe'
+$PythonUrl = 'https://www.python.org/ftp/python/3.10.3/python-3.10.3-amd64.exe'
 
 $CudaUrl = `
   'https://developer.download.nvidia.com/compute/cuda/10.1/Prod/local_installers/cuda_10.1.243_426.00_win10.exe'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ variables:
   tmpDir: 'D:\Temp'
   buildOutputLocation: 'D:\build'
 
-pool: 'StlBuild-2022-02-08-T1334'
+pool: 'StlBuild-2022-03-17-T1445'
 
 stages:
   - stage: Code_Format

--- a/stl/inc/bit
+++ b/stl/inc/bit
@@ -98,8 +98,12 @@ _NODISCARD constexpr _Ty rotl(const _Ty _Val, const int _Rotation) noexcept {
             return _rotl64(_Val, _Rotation);
         } else if constexpr (_Digits == 32) {
             return _rotl(_Val, _Rotation);
+        } else if constexpr (_Digits == 16) {
+            return _rotl16(_Val, static_cast<unsigned char>(_Rotation));
+        } else {
+            _STL_INTERNAL_STATIC_ASSERT(_Digits == 8);
+            return _rotl8(_Val, static_cast<unsigned char>(_Rotation));
         }
-        // TRANSITION: fallback to non-intrinsic case until <intrin0.h> changes
     }
 
     const auto _Remainder = _Rotation % _Digits;
@@ -122,8 +126,12 @@ _NODISCARD constexpr _Ty rotr(const _Ty _Val, const int _Rotation) noexcept {
             return _rotr64(_Val, _Rotation);
         } else if constexpr (_Digits == 32) {
             return _rotr(_Val, _Rotation);
+        } else if constexpr (_Digits == 16) {
+            return _rotr16(_Val, static_cast<unsigned char>(_Rotation));
+        } else {
+            _STL_INTERNAL_STATIC_ASSERT(_Digits == 8);
+            return _rotr8(_Val, static_cast<unsigned char>(_Rotation));
         }
-        // TRANSITION: fallback to non-intrinsic case until <intrin0.h> changes
     }
 
     const auto _Remainder = _Rotation % _Digits;

--- a/stl/inc/csignal
+++ b/stl/inc/csignal
@@ -19,14 +19,10 @@ _STL_DISABLE_CLANG_WARNINGS
 #undef new
 
 _STD_BEGIN
+using _CSTD sig_atomic_t;
+using _CSTD raise;
 #ifndef _M_CEE_PURE
-using _CSTD sig_atomic_t;
-using _CSTD raise;
 using _CSTD signal;
-
-#else // _M_CEE_PURE
-using _CSTD sig_atomic_t;
-using _CSTD raise;
 #endif // _M_CEE_PURE
 _STD_END
 

--- a/stl/inc/cstdio
+++ b/stl/inc/cstdio
@@ -34,7 +34,6 @@ _STD_BEGIN
 #pragma warning(push)
 #pragma warning(disable : 4995) // name was marked as #pragma deprecated
 
-using _CSTD FILE;
 using _CSTD _Mbstatet;
 
 using _CSTD size_t;

--- a/tests/std/tests/P1502R1_standard_library_header_units/custom_format.py
+++ b/tests/std/tests/P1502R1_standard_library_header_units/custom_format.py
@@ -81,10 +81,7 @@ class CustomTestFormat(STLTestFormat):
                 with open(os.path.join(outputDir, f'{hdr}.module.json')) as file:
                     jsonObject = json.load(file)
                     objFilenames.append(jsonObject['rules'][0]['primary-output'])
-                    # TRANSITION, VSO-1466711 fixed in VS 2022 17.2 Preview 2
-                    # os.path.basename(req['source-path']) should be req['logical-name']
-                    dep = [os.path.basename(req['source-path']) for req in jsonObject['rules'][0]['requires']]
-                    remainingDependencies[hdr] = dep
+                    remainingDependencies[hdr] = [req['logical-name'] for req in jsonObject['rules'][0]['requires']]
 
             # Build header units in topologically sorted order.
             while len(remainingDependencies) > 0:

--- a/tests/std/tests/P1502R1_standard_library_header_units/test.cpp
+++ b/tests/std/tests/P1502R1_standard_library_header_units/test.cpp
@@ -321,7 +321,6 @@ int main() {
         assert(!f.is_open());
     }
 
-#if !defined(TEST_TOPO_SORT) || defined(_MSVC_INTERNAL_TESTING) // TRANSITION, VSO-1471374 fixed in VS 2022 17.2p2
     {
         puts("Testing <functional>.");
         function<int(int, int)> f{multiplies{}};
@@ -332,7 +331,6 @@ int main() {
         assert(b(3) == 33);
         static_assert(b(3) == 33);
     }
-#endif // ^^^ no workaround ^^^
 
     {
         puts("Testing <future>.");
@@ -865,7 +863,6 @@ int main() {
         assert(this_thread::get_id() != thread::id{});
     }
 
-#if !defined(TEST_TOPO_SORT) || defined(_MSVC_INTERNAL_TESTING) // TRANSITION, VSO-1471374 fixed in VS 2022 17.2p2
     {
         puts("Testing <tuple>.");
         constexpr tuple<int, char, double> t{1729, 'c', 1.25};
@@ -876,7 +873,6 @@ int main() {
         static_assert(get<char>(t) == 'c');
         static_assert(get<double>(t) == 1.25);
     }
-#endif // ^^^ no workaround ^^^
 
     {
         puts("Testing <type_traits>.");

--- a/tests/std/tests/P1502R1_standard_library_header_units/test.cpp
+++ b/tests/std/tests/P1502R1_standard_library_header_units/test.cpp
@@ -958,14 +958,10 @@ int main() {
     {
         puts("Testing <variant>.");
         constexpr const char* cats = "CATS";
-#if 0 // TRANSITION, DevCom-1162647 (constexpr variant stores wrong pointer)
         constexpr variant<int, const char*, double> var{in_place_type<const char*>, cats};
         static_assert(var.index() == 1);
         static_assert(holds_alternative<const char*>(var));
         static_assert(get<const char*>(var) == cats);
-#else // ^^^ no workaround / workaround vvv
-        const variant<int, const char*, double> var{in_place_type<const char*>, cats};
-#endif // ^^^ workaround ^^^
         assert(var.index() == 1);
         assert(holds_alternative<const char*>(var));
         assert(get<const char*>(var) == cats);

--- a/tests/std/tests/P1502R1_standard_library_header_units/test.cpp
+++ b/tests/std/tests/P1502R1_standard_library_header_units/test.cpp
@@ -285,13 +285,11 @@ int main() {
         assert(!ep);
     }
 
-#if !defined(TEST_TOPO_SORT) || defined(_MSVC_INTERNAL_TESTING) // TRANSITION, VSO-1471382 fixed in VS 2022 17.2p2
     {
         puts("Testing <execution>.");
         constexpr int arr[]{11, 0, 22, 0, 33, 0, 44, 0, 55};
         assert(count(execution::par, begin(arr), end(arr), 0) == 4);
     }
-#endif // ^^^ no workaround ^^^
 
     {
         puts("Testing <filesystem>.");


### PR DESCRIPTION
This updates the Azure VMSS pool to StlBuild-2022-03-17-T1445, containing March 2022's Patch Tuesday, VS 2022 17.2 Preview 2, and Python 3.10.3. (Built with PowerShell 7.2.2.)

The CMake/Ninja versions are unchanged. The README still mentions Python 3.9 as the minimum, as that's what the VS Installer still offers. This is not increasing the minimum `_MSC_VER` required as the internal build still uses an older compiler version.

Since switching to Server 2022 in #2496, we've had remarkably well-behaved checks, with virtually no stalled checks. I'd like to try removing the hack of using N - 2 for test parallelism (i.e. 30 for our 32-core VMs).

This removes a number of compiler bug workarounds:

* DevCom-1162647 (`constexpr variant` stores wrong pointer) was fixed in 17.1.
* VSO-1466711 "`/scanDependencies` generates incorrect `"logical-name"` in JSON output" was fixed in 17.2 Preview 2.
* VSO-1471374 "Standard Library Header Units: Deduplication emits `fatal error C1116: unrecoverable error importing module`, with `<concepts>`" was fixed in 17.2 Preview 2.
* VSO-1471382 "Standard Library Header Units: Deduplication emits `error C2672: 'count_if': no matching overloaded function found`" was fixed in 17.2 Preview 2.

Additionally, 17.2 Preview 2 added `_rotl8`, `_rotl16`, `_rotr8`, `_rotr16` to `<intrin0.h>`, so @AlexGuteniev's #2369 can be completed. Note that (unlike the 32/64-bit intrinsics) their second parameters are declared as `unsigned char` so we need to `static_cast`. (Fortunately, the intrinsics have modulo behavior.)

Finally, this adds two unrelated small cleanups found while working on Standard Library Modules:

* Drop duplicate `using _CSTD FILE;` in `<cstdio>`.
* Centralize `using`-declarations in `<csignal>`.
