### PR TITLE
<stdatomic.h>: Fix preprocessor logic

### DIFF
--- a/stl/inc/stdatomic.h
+++ b/stl/inc/stdatomic.h
@@ -14,10 +14,12 @@
 #ifndef __cplusplus
 #error <stdatomic.h> is not yet supported when compiling as C, but this is planned for a future release.
 #endif // __cplusplus
-#endif // ^^^ C and C++ compilers ^^^
 
 #include <yvals.h>
-#if _STL_COMPILER_PREPROCESSOR
+// because this header needs to work in C and C++ we do the
+// preprocessor check above, if it's less restrictive than
+// what yvals_core would do then that's a bug.
+_STL_INTERNAL_STATIC_ASSERT(!_STL_COMPILER_PREPROCESSOR);
 
 #ifdef _M_CEE_PURE
 #error <stdatomic.h> is not supported when compiling with /clr:pure.
@@ -135,5 +137,5 @@ _STL_RESTORE_CLANG_WARNINGS
 #pragma pack(pop)
 #endif // ^^^ _HAS_CXX23 ^^^
 
-#endif // _STL_COMPILER_PREPROCESSOR
+#endif // defined(RC_INVOKED) || defined(Q_MOC_RUN) || defined(__midl)
 #endif // _STDATOMIC_H_

--- a/stl/inc/stdatomic.h
+++ b/stl/inc/stdatomic.h
@@ -137,5 +137,5 @@ _STL_RESTORE_CLANG_WARNINGS
 #pragma pack(pop)
 #endif // ^^^ _HAS_CXX23 ^^^
 
-#endif // defined(RC_INVOKED) || defined(Q_MOC_RUN) || defined(__midl)
+#endif // !defined(RC_INVOKED) && !defined(Q_MOC_RUN) && !defined(__midl)
 #endif // _STDATOMIC_H_

--- a/stl/inc/stdatomic.h
+++ b/stl/inc/stdatomic.h
@@ -19,7 +19,7 @@
 // because this header needs to work in C and C++ we do the
 // preprocessor check above, if it's less restrictive than
 // what yvals_core would do then that's a bug.
-_STL_INTERNAL_STATIC_ASSERT(!_STL_COMPILER_PREPROCESSOR);
+_STL_INTERNAL_STATIC_ASSERT(_STL_COMPILER_PREPROCESSOR);
 
 #ifdef _M_CEE_PURE
 #error <stdatomic.h> is not supported when compiling with /clr:pure.

--- a/stl/inc/stdatomic.h
+++ b/stl/inc/stdatomic.h
@@ -7,9 +7,9 @@
 #ifndef _STDATOMIC_H_
 #define _STDATOMIC_H_
 
-#if defined(RC_INVOKED) || defined(Q_MOC_RUN) || defined(__midl)
-// do nothing, see _STL_COMPILER_PREPROCESSOR in yvals_core.h
-#else // ^^^ non-compiler tools / C and C++ compilers vvv
+// do nothing for preprocessors, see _STL_COMPILER_PREPROCESSOR in yvals_core.h
+#if !defined(RC_INVOKED) && !defined(Q_MOC_RUN) && !defined(__midl)
+
 // provide a specific error message for C compilers, before the general error message in yvals_core.h
 #ifndef __cplusplus
 #error <stdatomic.h> is not yet supported when compiling as C, but this is planned for a future release.

--- a/stl/inc/stdatomic.h
+++ b/stl/inc/stdatomic.h
@@ -7,7 +7,7 @@
 #ifndef _STDATOMIC_H_
 #define _STDATOMIC_H_
 
-// do nothing for preprocessors, see _STL_COMPILER_PREPROCESSOR in yvals_core.h
+// see _STL_COMPILER_PREPROCESSOR in yvals_core.h
 #if !defined(RC_INVOKED) && !defined(Q_MOC_RUN) && !defined(__midl)
 
 // provide a specific error message for C compilers, before the general error message in yvals_core.h
@@ -16,10 +16,6 @@
 #endif // __cplusplus
 
 #include <yvals.h>
-// because this header needs to work in C and C++ we do the
-// preprocessor check above, if it's less restrictive than
-// what yvals_core would do then that's a bug.
-_STL_INTERNAL_STATIC_ASSERT(_STL_COMPILER_PREPROCESSOR);
 
 #ifdef _M_CEE_PURE
 #error <stdatomic.h> is not supported when compiling with /clr:pure.


### PR DESCRIPTION
Because this header needs to work in C and C++, we needed to move the check for a non-broken preprocessor outside of yvals_core, but we didn't actually skip the whole header if it failed!

This PR fixes that. In addition, it:

* Reverses the conditional logic to avoid needing to use an "else" branch
* Changes the `#if _STL_COMPILER_PREPROCESSOR` to `_STL_INTERNAL_STATIC_ASSERT(_STL_COMPILER_PREPROCESSOR);`