### PR TITLE
More various cleanups

### DIFF
--- a/.github/workflows/update-status-chart.yml
+++ b/.github/workflows/update-status-chart.yml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout gh-pages
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: gh-pages
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: ">=17.5.0"
+          node-version: ">=17.8.0"
       - name: Install Packages
         run: |
           npm ci

--- a/stl/inc/charconv
+++ b/stl/inc/charconv
@@ -31,7 +31,7 @@ _STL_DISABLE_CLANG_WARNINGS
 _STD_BEGIN
 inline constexpr char _Charconv_digits[] = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e',
     'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z'};
-static_assert(_STD size(_Charconv_digits) == 36);
+_STL_INTERNAL_STATIC_ASSERT(_STD size(_Charconv_digits) == 36);
 
 template <class _RawTy>
 _NODISCARD to_chars_result _Integer_to_chars(
@@ -226,7 +226,7 @@ _NODISCARD inline unsigned char _Digit_from_char(const char _Ch) noexcept {
         255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
         255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
         255, 255, 255, 255, 255, 255, 255, 255, 255};
-    static_assert(_STD size(_Digit_from_byte) == 256);
+    _STL_INTERNAL_STATIC_ASSERT(_STD size(_Digit_from_byte) == 256);
 
     return _Digit_from_byte[static_cast<unsigned char>(_Ch)];
 }

--- a/stl/inc/codecvt
+++ b/stl/inc/codecvt
@@ -216,6 +216,7 @@ protected:
 template <class _Elem, unsigned long _Mymax = 0x10ffff, codecvt_mode _Mymode = codecvt_mode{}>
 class _CXX17_DEPRECATE_CODECVT_HEADER codecvt_utf16 : public codecvt<_Elem, char, _Statype> {
     // facet for converting between _Elem and UTF-16 multibyte sequences
+private:
     enum { _Bytes_per_word = 2 };
 
 public:

--- a/stl/inc/cwctype
+++ b/stl/inc/cwctype
@@ -18,7 +18,7 @@ _STL_DISABLE_CLANG_WARNINGS
 #pragma push_macro("new")
 #undef new
 
-// remove any (improper) macro overrides
+// TRANSITION, /clr:pure (see corecrt_wctype.h): remove any (improper) macro overrides
 #undef iswalnum
 #undef iswalpha
 #undef iswblank

--- a/stl/inc/future
+++ b/stl/inc/future
@@ -884,6 +884,7 @@ class shared_future;
 template <class _Ty>
 class future : public _State_manager<_Ty> {
     // class that defines a non-copyable asynchronous return object that holds a value
+private:
     using _Mybase = _State_manager<_Ty>;
 
 public:
@@ -920,6 +921,7 @@ public:
 template <class _Ty>
 class future<_Ty&> : public _State_manager<_Ty*> {
     // class that defines a non-copyable asynchronous return object that holds a reference
+private:
     using _Mybase = _State_manager<_Ty*>;
 
 public:
@@ -953,6 +955,7 @@ public:
 template <>
 class future<void> : public _State_manager<int> {
     // class that defines a non-copyable asynchronous return object that does not hold a value
+private:
     using _Mybase = _State_manager<int>;
 
 public:
@@ -984,6 +987,7 @@ public:
 template <class _Ty>
 class shared_future : public _State_manager<_Ty> {
     // class that defines a copyable asynchronous return object that holds a value
+private:
     using _Mybase = _State_manager<_Ty>;
 
 public:
@@ -1019,6 +1023,7 @@ public:
 template <class _Ty>
 class shared_future<_Ty&> : public _State_manager<_Ty*> {
     // class that defines a copyable asynchronous return object that holds a reference
+private:
     using _Mybase = _State_manager<_Ty*>;
 
 public:
@@ -1051,6 +1056,7 @@ public:
 template <>
 class shared_future<void> : public _State_manager<int> {
     // class that defines a copyable asynchronous return object that does not hold a value
+private:
     using _Mybase = _State_manager<int>;
 
 public:
@@ -1473,6 +1479,7 @@ class _Fake_no_copy_callable_adapter {
     // std::function, which requires that things be copyable. We can't fix this in an
     // update, so this adapter turns copies into terminate(). When VSO-153581 is
     // fixed, remove this adapter.
+private:
     using _Storaget = tuple<decay_t<_Types>...>;
 
 public:

--- a/stl/inc/shared_mutex
+++ b/stl/inc/shared_mutex
@@ -74,6 +74,7 @@ private:
 // shared_timed_mutex is not supported under /clr
 #ifndef _M_CEE
 class shared_timed_mutex { // class for mutual exclusion shared across threads
+private:
     using _Read_cnt_t = unsigned int;
 
     static constexpr _Read_cnt_t _Max_readers = static_cast<_Read_cnt_t>(-1);

--- a/stl/inc/sstream
+++ b/stl/inc/sstream
@@ -420,7 +420,6 @@ protected:
         return pos_type(_Off);
     }
 
-protected:
     void _Init(const _Elem* _Ptr, _Mysize_type _Count, int _State) {
         // initialize buffer to [_Ptr, _Ptr + _Count), set state
         _State &= ~_From_rvalue;

--- a/stl/inc/variant
+++ b/stl/inc/variant
@@ -1472,7 +1472,6 @@ struct _Variant_dispatcher<index_sequence<_Is...>> {
     template <class _Ret, class _Callable, class... _Types, bool _Any_valueless = ((_Is == 0) || ...)>
     _NODISCARD static constexpr _Ret _Dispatch2(_Callable&& _Obj, _Types&&... _Args) {
         if constexpr (_Any_valueless) {
-            ((void) _Args, ...); // TRANSITION, DevCom-1004719
             _Throw_bad_variant_access();
         }
 #if _HAS_CXX20

--- a/stl/inc/variant
+++ b/stl/inc/variant
@@ -1472,6 +1472,7 @@ struct _Variant_dispatcher<index_sequence<_Is...>> {
     template <class _Ret, class _Callable, class... _Types, bool _Any_valueless = ((_Is == 0) || ...)>
     _NODISCARD static constexpr _Ret _Dispatch2(_Callable&& _Obj, _Types&&... _Args) {
         if constexpr (_Any_valueless) {
+            ((void) _Args, ...); // TRANSITION, VSO-1513409
             _Throw_bad_variant_access();
         }
 #if _HAS_CXX20

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -2246,6 +2246,7 @@ public:
 template <class _Alvbase_wrapped>
 class _Vb_reference : public _Vb_iter_base<_Alvbase_wrapped> {
     // reference to a bit within a base word
+private:
     using _Mybase          = _Vb_iter_base<_Alvbase_wrapped>;
     using _Mycont          = typename _Mybase::_Mycont;
     using _Difference_type = typename _Mybase::_Difference_type;

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -1639,6 +1639,7 @@ namespace ranges {
 template <class _Alloc>
 class _NODISCARD _Uninitialized_backout_al {
     // struct to undo partially constructed ranges in _Uninitialized_xxx_al algorithms
+private:
     using pointer = _Alloc_ptr_t<_Alloc>;
 
 public:

--- a/stl/inc/xtree
+++ b/stl/inc/xtree
@@ -933,7 +933,6 @@ public:
         _Swap_val_excluding_comp(_Right);
     }
 
-public:
     _Tree& operator=(_Tree&& _Right) noexcept(
         _Choose_pocma_v<_Alnode> == _Pocma_values::_Equal_allocators && is_nothrow_move_assignable_v<key_compare>) {
         if (this == _STD addressof(_Right)) {

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -932,13 +932,13 @@ std/containers/sequences/forwardlist/forwardlist.cons/deduct.pass.cpp FAIL
 std/containers/sequences/vector/vector.cons/deduct.pass.cpp FAIL
 
 # Not yet analyzed. Seems to force a sign conversion error?
-std/iterators/iterator.primitives/iterator.operations/advance.pass.cpp FAIL
+std/iterators/iterator.primitives/iterator.operations/advance.pass.cpp SKIPPED
 
 # Not yet analyzed. Maybe Clang over-eagerly instantiating noexcept-specifier?
 std/ranges/range.access/empty.pass.cpp:1 FAIL
 std/ranges/range.access/size.pass.cpp:1 FAIL
 std/ranges/range.access/ssize.pass.cpp:1 FAIL
-std/utilities/memory/unique.ptr/iterator_concept_conformance.compile.pass.cpp:1 FAIL
+std/utilities/memory/unique.ptr/iterator_concept_conformance.compile.pass.cpp:1 SKIPPED
 
 # *** XFAILs WHICH PASS ***
 # Nothing here! :-)


### PR DESCRIPTION
Some of these are things I've noticed while reading every line of the STL's headers for Standard Library Modules, but they aren't blocking anything.

* In `tests/libcxx/expected_results.txt`, change 2 tests from `FAIL` to `SKIPPED`. This avoids unexpected passes when running `set_environment` before running the tests. (Because `set_environment` puts the freshly-built STL on the `INCLUDE` path, Clang suppresses warnings from those "system headers", so if tests are expected to `FAIL` due to such warnings, they will instead unexpectedly pass.)
  + This is a quality-of-life improvement for myself, as I always run `set_environment`.
* Update `.github/workflows/update-status-chart.yml` as new versions of `actions/checkout` and `actions/setup-node` are now available. Also update `node-version` (as usual, it's not critical to keep this constantly updated.)
  + Tested in my fork.
* In `<variant>`, DevCom-1004719 "Bogus warning C4100 'unreferenced formal parameter' emitted by `if constexpr`" was resolved as fixed, but it still repros in the compiler's own sources. I've filed VSO-1513409 internally with a preprocessed file, so we should update the bug citation.
* Several `class`es were implicitly using `private` access control. We conventionally say `private` explicitly. (With exceptions for `friend` declarations and `static_assert`s where the access control doesn't matter.)
  + Initially noticed while reading all headers, then audited via regex, so this list is fairly comprehensive (didn't bother looking outside STL headers).
* We were unnecessarily repeating access specifiers in `<sstream>` and `<xtree>`.
  + Noticed while folding class members in VSCode - I don't have a more automated way to scan for this.
* In `<charconv>`, we should use `_STL_INTERNAL_STATIC_ASSERT` for our internal array sizes - there's no reason to perform such validation during user compilations. (The static assertions themselves are probably overly paranoid.)
* Comment the `<cwctype>` `#undef`s.
  + At first, I thought we could remove them like in #2147, but after I looked at the UCRT, they appear to be needed for `/clr:pure` :crying_cat_face:, so we should record this for vNext.