### PR TITLE
Use `_NODISCARD_FRIEND` everywhere

### DIFF
--- a/stl/inc/charconv
+++ b/stl/inc/charconv
@@ -208,7 +208,7 @@ struct from_chars_result {
     const char* ptr;
     errc ec;
 #if _HAS_CXX20
-    _NODISCARD friend bool operator==(const from_chars_result&, const from_chars_result&) = default;
+    _NODISCARD_FRIEND bool operator==(const from_chars_result&, const from_chars_result&) = default;
 #endif // _HAS_CXX20
 };
 

--- a/stl/inc/compare
+++ b/stl/inc/compare
@@ -41,52 +41,52 @@ struct partial_ordering {
     static const partial_ordering greater;
     static const partial_ordering unordered;
 
-    _NODISCARD friend constexpr bool operator==(const partial_ordering _Val, _Literal_zero) noexcept {
+    _NODISCARD_FRIEND constexpr bool operator==(const partial_ordering _Val, _Literal_zero) noexcept {
         return _Val._Value == 0;
     }
 
-    _NODISCARD friend constexpr bool operator==(partial_ordering, partial_ordering) noexcept = default;
+    _NODISCARD_FRIEND constexpr bool operator==(partial_ordering, partial_ordering) noexcept = default;
 
-    _NODISCARD friend constexpr bool operator<(const partial_ordering _Val, _Literal_zero) noexcept {
+    _NODISCARD_FRIEND constexpr bool operator<(const partial_ordering _Val, _Literal_zero) noexcept {
         return _Val._Value == static_cast<_Compare_t>(_Compare_ord::less);
     }
 
-    _NODISCARD friend constexpr bool operator>(const partial_ordering _Val, _Literal_zero) noexcept {
+    _NODISCARD_FRIEND constexpr bool operator>(const partial_ordering _Val, _Literal_zero) noexcept {
         return _Val._Value > 0;
     }
 
-    _NODISCARD friend constexpr bool operator<=(const partial_ordering _Val, _Literal_zero) noexcept {
+    _NODISCARD_FRIEND constexpr bool operator<=(const partial_ordering _Val, _Literal_zero) noexcept {
         // The stored value is either less (0xff), equivalent (0x00), greater (0x01), or unordered (0x80).
         // Subtracting from 0 produces either 0x01, 0x00, 0xff, or 0x80. The result is greater than or equal to 0
         // if and only if the initial value was less or equivalent, for which we want to return true.
         return static_cast<signed char>(0 - static_cast<unsigned int>(_Val._Value)) >= 0;
     }
 
-    _NODISCARD friend constexpr bool operator>=(const partial_ordering _Val, _Literal_zero) noexcept {
+    _NODISCARD_FRIEND constexpr bool operator>=(const partial_ordering _Val, _Literal_zero) noexcept {
         return _Val._Value >= 0;
     }
 
-    _NODISCARD friend constexpr bool operator<(_Literal_zero, const partial_ordering _Val) noexcept {
+    _NODISCARD_FRIEND constexpr bool operator<(_Literal_zero, const partial_ordering _Val) noexcept {
         return _Val > 0;
     }
 
-    _NODISCARD friend constexpr bool operator>(_Literal_zero, const partial_ordering _Val) noexcept {
+    _NODISCARD_FRIEND constexpr bool operator>(_Literal_zero, const partial_ordering _Val) noexcept {
         return _Val < 0;
     }
 
-    _NODISCARD friend constexpr bool operator<=(_Literal_zero, const partial_ordering _Val) noexcept {
+    _NODISCARD_FRIEND constexpr bool operator<=(_Literal_zero, const partial_ordering _Val) noexcept {
         return _Val >= 0;
     }
 
-    _NODISCARD friend constexpr bool operator>=(_Literal_zero, const partial_ordering _Val) noexcept {
+    _NODISCARD_FRIEND constexpr bool operator>=(_Literal_zero, const partial_ordering _Val) noexcept {
         return _Val <= 0;
     }
 
-    _NODISCARD friend constexpr partial_ordering operator<=>(const partial_ordering _Val, _Literal_zero) noexcept {
+    _NODISCARD_FRIEND constexpr partial_ordering operator<=>(const partial_ordering _Val, _Literal_zero) noexcept {
         return _Val;
     }
 
-    _NODISCARD friend constexpr partial_ordering operator<=>(_Literal_zero, const partial_ordering _Val) noexcept {
+    _NODISCARD_FRIEND constexpr partial_ordering operator<=>(_Literal_zero, const partial_ordering _Val) noexcept {
         // The stored value is either less (0xff), equivalent (0x00), greater (0x01), or unordered (0x80).
         // Subtracting from 0 produces either 0x01, 0x00, 0xff, or 0x80. Note that the effect is to
         // exchange less for greater (and vice versa), while leaving equivalent and unordered unchanged.
@@ -110,49 +110,49 @@ struct weak_ordering {
         return {static_cast<_Compare_t>(_Value)};
     }
 
-    _NODISCARD friend constexpr bool operator==(const weak_ordering _Val, _Literal_zero) noexcept {
+    _NODISCARD_FRIEND constexpr bool operator==(const weak_ordering _Val, _Literal_zero) noexcept {
         return _Val._Value == 0;
     }
 
-    _NODISCARD friend constexpr bool operator==(weak_ordering, weak_ordering) noexcept = default;
+    _NODISCARD_FRIEND constexpr bool operator==(weak_ordering, weak_ordering) noexcept = default;
 
-    _NODISCARD friend constexpr bool operator<(const weak_ordering _Val, _Literal_zero) noexcept {
+    _NODISCARD_FRIEND constexpr bool operator<(const weak_ordering _Val, _Literal_zero) noexcept {
         return _Val._Value < 0;
     }
 
-    _NODISCARD friend constexpr bool operator>(const weak_ordering _Val, _Literal_zero) noexcept {
+    _NODISCARD_FRIEND constexpr bool operator>(const weak_ordering _Val, _Literal_zero) noexcept {
         return _Val._Value > 0;
     }
 
-    _NODISCARD friend constexpr bool operator<=(const weak_ordering _Val, _Literal_zero) noexcept {
+    _NODISCARD_FRIEND constexpr bool operator<=(const weak_ordering _Val, _Literal_zero) noexcept {
         return _Val._Value <= 0;
     }
 
-    _NODISCARD friend constexpr bool operator>=(const weak_ordering _Val, _Literal_zero) noexcept {
+    _NODISCARD_FRIEND constexpr bool operator>=(const weak_ordering _Val, _Literal_zero) noexcept {
         return _Val._Value >= 0;
     }
 
-    _NODISCARD friend constexpr bool operator<(_Literal_zero, const weak_ordering _Val) noexcept {
+    _NODISCARD_FRIEND constexpr bool operator<(_Literal_zero, const weak_ordering _Val) noexcept {
         return _Val > 0;
     }
 
-    _NODISCARD friend constexpr bool operator>(_Literal_zero, const weak_ordering _Val) noexcept {
+    _NODISCARD_FRIEND constexpr bool operator>(_Literal_zero, const weak_ordering _Val) noexcept {
         return _Val < 0;
     }
 
-    _NODISCARD friend constexpr bool operator<=(_Literal_zero, const weak_ordering _Val) noexcept {
+    _NODISCARD_FRIEND constexpr bool operator<=(_Literal_zero, const weak_ordering _Val) noexcept {
         return _Val >= 0;
     }
 
-    _NODISCARD friend constexpr bool operator>=(_Literal_zero, const weak_ordering _Val) noexcept {
+    _NODISCARD_FRIEND constexpr bool operator>=(_Literal_zero, const weak_ordering _Val) noexcept {
         return _Val <= 0;
     }
 
-    _NODISCARD friend constexpr weak_ordering operator<=>(const weak_ordering _Val, _Literal_zero) noexcept {
+    _NODISCARD_FRIEND constexpr weak_ordering operator<=>(const weak_ordering _Val, _Literal_zero) noexcept {
         return _Val;
     }
 
-    _NODISCARD friend constexpr weak_ordering operator<=>(_Literal_zero, const weak_ordering _Val) noexcept {
+    _NODISCARD_FRIEND constexpr weak_ordering operator<=>(_Literal_zero, const weak_ordering _Val) noexcept {
         return {static_cast<_Compare_t>(-_Val._Value)};
     }
 
@@ -177,49 +177,49 @@ struct strong_ordering {
         return {static_cast<_Compare_t>(_Value)};
     }
 
-    _NODISCARD friend constexpr bool operator==(const strong_ordering _Val, _Literal_zero) noexcept {
+    _NODISCARD_FRIEND constexpr bool operator==(const strong_ordering _Val, _Literal_zero) noexcept {
         return _Val._Value == 0;
     }
 
-    _NODISCARD friend constexpr bool operator==(strong_ordering, strong_ordering) noexcept = default;
+    _NODISCARD_FRIEND constexpr bool operator==(strong_ordering, strong_ordering) noexcept = default;
 
-    _NODISCARD friend constexpr bool operator<(const strong_ordering _Val, _Literal_zero) noexcept {
+    _NODISCARD_FRIEND constexpr bool operator<(const strong_ordering _Val, _Literal_zero) noexcept {
         return _Val._Value < 0;
     }
 
-    _NODISCARD friend constexpr bool operator>(const strong_ordering _Val, _Literal_zero) noexcept {
+    _NODISCARD_FRIEND constexpr bool operator>(const strong_ordering _Val, _Literal_zero) noexcept {
         return _Val._Value > 0;
     }
 
-    _NODISCARD friend constexpr bool operator<=(const strong_ordering _Val, _Literal_zero) noexcept {
+    _NODISCARD_FRIEND constexpr bool operator<=(const strong_ordering _Val, _Literal_zero) noexcept {
         return _Val._Value <= 0;
     }
 
-    _NODISCARD friend constexpr bool operator>=(const strong_ordering _Val, _Literal_zero) noexcept {
+    _NODISCARD_FRIEND constexpr bool operator>=(const strong_ordering _Val, _Literal_zero) noexcept {
         return _Val._Value >= 0;
     }
 
-    _NODISCARD friend constexpr bool operator<(_Literal_zero, const strong_ordering _Val) noexcept {
+    _NODISCARD_FRIEND constexpr bool operator<(_Literal_zero, const strong_ordering _Val) noexcept {
         return _Val > 0;
     }
 
-    _NODISCARD friend constexpr bool operator>(_Literal_zero, const strong_ordering _Val) noexcept {
+    _NODISCARD_FRIEND constexpr bool operator>(_Literal_zero, const strong_ordering _Val) noexcept {
         return _Val < 0;
     }
 
-    _NODISCARD friend constexpr bool operator<=(_Literal_zero, const strong_ordering _Val) noexcept {
+    _NODISCARD_FRIEND constexpr bool operator<=(_Literal_zero, const strong_ordering _Val) noexcept {
         return _Val >= 0;
     }
 
-    _NODISCARD friend constexpr bool operator>=(_Literal_zero, const strong_ordering _Val) noexcept {
+    _NODISCARD_FRIEND constexpr bool operator>=(_Literal_zero, const strong_ordering _Val) noexcept {
         return _Val <= 0;
     }
 
-    _NODISCARD friend constexpr strong_ordering operator<=>(const strong_ordering _Val, _Literal_zero) noexcept {
+    _NODISCARD_FRIEND constexpr strong_ordering operator<=>(const strong_ordering _Val, _Literal_zero) noexcept {
         return _Val;
     }
 
-    _NODISCARD friend constexpr strong_ordering operator<=>(_Literal_zero, const strong_ordering _Val) noexcept {
+    _NODISCARD_FRIEND constexpr strong_ordering operator<=>(_Literal_zero, const strong_ordering _Val) noexcept {
         return {static_cast<_Compare_t>(-_Val._Value)};
     }
 

--- a/stl/inc/exception
+++ b/stl/inc/exception
@@ -260,28 +260,28 @@ public:
         __ExceptionPtrSwap(&_Lhs, &_Rhs);
     }
 
-    _NODISCARD friend bool operator==(const exception_ptr& _Lhs, const exception_ptr& _Rhs) noexcept {
+    _NODISCARD_FRIEND bool operator==(const exception_ptr& _Lhs, const exception_ptr& _Rhs) noexcept {
         return __ExceptionPtrCompare(&_Lhs, &_Rhs);
     }
 
-    _NODISCARD friend bool operator==(const exception_ptr& _Lhs, nullptr_t) noexcept {
+    _NODISCARD_FRIEND bool operator==(const exception_ptr& _Lhs, nullptr_t) noexcept {
         return !_Lhs;
     }
 
 #if !_HAS_CXX20
-    _NODISCARD friend bool operator==(nullptr_t, const exception_ptr& _Rhs) noexcept {
+    _NODISCARD_FRIEND bool operator==(nullptr_t, const exception_ptr& _Rhs) noexcept {
         return !_Rhs;
     }
 
-    _NODISCARD friend bool operator!=(const exception_ptr& _Lhs, const exception_ptr& _Rhs) noexcept {
+    _NODISCARD_FRIEND bool operator!=(const exception_ptr& _Lhs, const exception_ptr& _Rhs) noexcept {
         return !(_Lhs == _Rhs);
     }
 
-    _NODISCARD friend bool operator!=(const exception_ptr& _Lhs, nullptr_t _Rhs) noexcept {
+    _NODISCARD_FRIEND bool operator!=(const exception_ptr& _Lhs, nullptr_t _Rhs) noexcept {
         return !(_Lhs == _Rhs);
     }
 
-    _NODISCARD friend bool operator!=(nullptr_t _Lhs, const exception_ptr& _Rhs) noexcept {
+    _NODISCARD_FRIEND bool operator!=(nullptr_t _Lhs, const exception_ptr& _Rhs) noexcept {
         return !(_Lhs == _Rhs);
     }
 #endif // !_HAS_CXX20

--- a/stl/inc/filesystem
+++ b/stl/inc/filesystem
@@ -1395,37 +1395,37 @@ namespace filesystem {
             return _Istr;
         }
 
-        _NODISCARD friend bool operator==(const path& _Left, const path& _Right) noexcept {
+        _NODISCARD_FRIEND bool operator==(const path& _Left, const path& _Right) noexcept {
             return _Left.compare(_Right._Text) == 0;
         }
 
 #if _HAS_CXX20
-        _NODISCARD friend strong_ordering operator<=>(const path& _Left, const path& _Right) noexcept {
+        _NODISCARD_FRIEND strong_ordering operator<=>(const path& _Left, const path& _Right) noexcept {
             return _Left.compare(_Right._Text) <=> 0;
         }
 #else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
-        _NODISCARD friend bool operator!=(const path& _Left, const path& _Right) noexcept {
+        _NODISCARD_FRIEND bool operator!=(const path& _Left, const path& _Right) noexcept {
             return _Left.compare(_Right) != 0;
         }
 
-        _NODISCARD friend bool operator<(const path& _Left, const path& _Right) noexcept {
+        _NODISCARD_FRIEND bool operator<(const path& _Left, const path& _Right) noexcept {
             return _Left.compare(_Right) < 0;
         }
 
-        _NODISCARD friend bool operator>(const path& _Left, const path& _Right) noexcept {
+        _NODISCARD_FRIEND bool operator>(const path& _Left, const path& _Right) noexcept {
             return _Left.compare(_Right) > 0;
         }
 
-        _NODISCARD friend bool operator<=(const path& _Left, const path& _Right) noexcept {
+        _NODISCARD_FRIEND bool operator<=(const path& _Left, const path& _Right) noexcept {
             return _Left.compare(_Right) <= 0;
         }
 
-        _NODISCARD friend bool operator>=(const path& _Left, const path& _Right) noexcept {
+        _NODISCARD_FRIEND bool operator>=(const path& _Left, const path& _Right) noexcept {
             return _Left.compare(_Right) >= 0;
         }
 #endif // !_HAS_CXX20
 
-        _NODISCARD friend path operator/(const path& _Left, const path& _Right) { // append a pair of paths together
+        _NODISCARD_FRIEND path operator/(const path& _Left, const path& _Right) { // append a pair of paths together
             path _Tmp = _Left;
             _Tmp /= _Right;
             return _Tmp;
@@ -1596,12 +1596,12 @@ namespace filesystem {
             return _Tmp;
         }
 
-        _NODISCARD friend bool operator==(const _Path_iterator& _Lhs, const _Path_iterator& _Rhs) {
+        _NODISCARD_FRIEND bool operator==(const _Path_iterator& _Lhs, const _Path_iterator& _Rhs) {
             return _Lhs._Position == _Rhs._Position;
         }
 
 #if !_HAS_CXX20
-        _NODISCARD friend bool operator!=(const _Path_iterator& _Lhs, const _Path_iterator& _Rhs) {
+        _NODISCARD_FRIEND bool operator!=(const _Path_iterator& _Lhs, const _Path_iterator& _Rhs) {
             return _Lhs._Position != _Rhs._Position;
         }
 #endif // !_HAS_CXX20
@@ -1972,7 +1972,7 @@ namespace filesystem {
         }
 
 #if _HAS_CXX20
-        _NODISCARD friend bool operator==(const file_status& _Lhs, const file_status& _Rhs) noexcept {
+        _NODISCARD_FRIEND bool operator==(const file_status& _Lhs, const file_status& _Rhs) noexcept {
             return _Lhs._Myftype == _Rhs._Myftype && _Lhs._Myperms == _Rhs._Myperms;
         }
 #endif // _HAS_CXX20
@@ -3630,7 +3630,7 @@ namespace filesystem {
         uintmax_t available;
 
 #if _HAS_CXX20
-        _NODISCARD friend constexpr bool operator==(const space_info&, const space_info&) noexcept = default;
+        _NODISCARD_FRIEND constexpr bool operator==(const space_info&, const space_info&) noexcept = default;
 #endif // _HAS_CXX20
     };
 

--- a/stl/inc/functional
+++ b/stl/inc/functional
@@ -1844,7 +1844,7 @@ public:
         _Fn1._Swap(_Fn2);
     }
 
-    _NODISCARD friend bool operator==(const move_only_function& _This, nullptr_t) noexcept {
+    _NODISCARD_FRIEND bool operator==(const move_only_function& _This, nullptr_t) noexcept {
         return _This._Is_null();
     }
 };

--- a/stl/inc/iosfwd
+++ b/stl/inc/iosfwd
@@ -105,12 +105,12 @@ public:
     }
 
     template <class _Int, enable_if_t<is_integral_v<_Int>, int> = 0>
-    _NODISCARD friend bool operator==(const fpos& _Left, const _Int _Right) {
+    _NODISCARD_FRIEND bool operator==(const fpos& _Left, const _Int _Right) {
         return static_cast<streamoff>(_Left) == _Right;
     }
 
     template <class _Int, enable_if_t<is_integral_v<_Int>, int> = 0>
-    _NODISCARD friend bool operator==(const _Int _Left, const fpos& _Right) {
+    _NODISCARD_FRIEND bool operator==(const _Int _Left, const fpos& _Right) {
         return _Left == static_cast<streamoff>(_Right);
     }
 
@@ -119,12 +119,12 @@ public:
     }
 
     template <class _Int, enable_if_t<is_integral_v<_Int>, int> = 0>
-    _NODISCARD friend bool operator!=(const fpos& _Left, const _Int _Right) {
+    _NODISCARD_FRIEND bool operator!=(const fpos& _Left, const _Int _Right) {
         return static_cast<streamoff>(_Left) != _Right;
     }
 
     template <class _Int, enable_if_t<is_integral_v<_Int>, int> = 0>
-    _NODISCARD friend bool operator!=(const _Int _Left, const fpos& _Right) {
+    _NODISCARD_FRIEND bool operator!=(const _Int _Left, const fpos& _Right) {
         return _Left != static_cast<streamoff>(_Right);
     }
 

--- a/stl/inc/iterator
+++ b/stl/inc/iterator
@@ -271,7 +271,7 @@ public:
     }
 
 #ifdef __cpp_lib_concepts
-    _NODISCARD friend bool operator==(const istream_iterator& _Left, default_sentinel_t) noexcept /* strengthened */ {
+    _NODISCARD_FRIEND bool operator==(const istream_iterator& _Left, default_sentinel_t) noexcept /* strengthened */ {
         return !_Left._Myistr;
     }
 #endif // __cpp_lib_concepts
@@ -434,7 +434,7 @@ public:
     }
 
 #ifdef __cpp_lib_concepts
-    _NODISCARD friend bool operator==(const istreambuf_iterator& _Left, default_sentinel_t) {
+    _NODISCARD_FRIEND bool operator==(const istreambuf_iterator& _Left, default_sentinel_t) {
         if (!_Left._Got) {
             _Left._Peek();
         }
@@ -948,7 +948,7 @@ public:
     // clang-format off
     template <class _OIter, sentinel_for<_Iter> _OSe>
         requires sentinel_for<_Se, _OIter>
-    _NODISCARD friend constexpr
+    _NODISCARD_FRIEND constexpr
     bool operator==(const common_iterator& _Left, const common_iterator<_OIter, _OSe>& _Right) {
         // clang-format on
         auto& _Right_val = _Right._Get_val();
@@ -980,7 +980,7 @@ public:
     // clang-format off
     template <sized_sentinel_for<_Iter> _OIter, sized_sentinel_for<_Iter> _OSe>
         requires sized_sentinel_for<_Se, _OIter>
-    _NODISCARD friend constexpr iter_difference_t<_OIter> operator-(
+    _NODISCARD_FRIEND constexpr iter_difference_t<_OIter> operator-(
         const common_iterator& _Left, const common_iterator<_OIter, _OSe>& _Right) {
         // clang-format on
         auto& _Right_val = _Right._Get_val();
@@ -1005,7 +1005,7 @@ public:
         }
     }
 
-    _NODISCARD friend constexpr iter_rvalue_reference_t<_Iter> iter_move(const common_iterator& _Right) noexcept(
+    _NODISCARD_FRIEND constexpr iter_rvalue_reference_t<_Iter> iter_move(const common_iterator& _Right) noexcept(
         noexcept(_RANGES iter_move(_Right._Val._Iterator))) requires input_iterator<_Iter> {
 #if _ITERATOR_DEBUG_LEVEL != 0
         _STL_VERIFY(_Right._Val._Contains == _Variantish_state::_Holds_iter,
@@ -1225,7 +1225,7 @@ public:
         return counted_iterator{_Current + _Diff, static_cast<iter_difference_t<_Iter>>(_Length - _Diff)};
     }
 
-    _NODISCARD friend constexpr counted_iterator operator+(
+    _NODISCARD_FRIEND constexpr counted_iterator operator+(
         const iter_difference_t<_Iter> _Diff, const counted_iterator& _Right) requires random_access_iterator<_Iter> {
         return counted_iterator{_Right._Current + _Diff, static_cast<iter_difference_t<_Iter>>(_Right._Length - _Diff)};
     }
@@ -1246,7 +1246,7 @@ public:
     }
 
     template <common_with<_Iter> _Other>
-    _NODISCARD friend constexpr iter_difference_t<_Other> operator-(
+    _NODISCARD_FRIEND constexpr iter_difference_t<_Other> operator-(
         const counted_iterator& _Left, const counted_iterator<_Other>& _Right) noexcept /* strengthened */ {
 #if _ITERATOR_DEBUG_LEVEL != 0
         _Same_sequence(_Left, _Right);
@@ -1254,12 +1254,12 @@ public:
         return _Right.count() - _Left._Length;
     }
 
-    _NODISCARD friend constexpr iter_difference_t<_Iter> operator-(
+    _NODISCARD_FRIEND constexpr iter_difference_t<_Iter> operator-(
         const counted_iterator& _Left, default_sentinel_t) noexcept /* strengthened */ {
         return -_Left._Length;
     }
 
-    _NODISCARD friend constexpr iter_difference_t<_Iter> operator-(
+    _NODISCARD_FRIEND constexpr iter_difference_t<_Iter> operator-(
         default_sentinel_t, const counted_iterator& _Right) noexcept /* strengthened */ {
         return _Right._Length;
     }
@@ -1276,7 +1276,7 @@ public:
 
     // [counted.iter.cmp]
     template <common_with<_Iter> _Other>
-    _NODISCARD friend constexpr bool operator==(
+    _NODISCARD_FRIEND constexpr bool operator==(
         const counted_iterator& _Left, const counted_iterator<_Other>& _Right) noexcept /* strengthened */ {
 #if _ITERATOR_DEBUG_LEVEL != 0
         _Same_sequence(_Left, _Right);
@@ -1284,13 +1284,13 @@ public:
         return _Left._Length == _Right.count();
     }
 
-    _NODISCARD friend constexpr bool operator==(const counted_iterator& _Left, default_sentinel_t) noexcept
+    _NODISCARD_FRIEND constexpr bool operator==(const counted_iterator& _Left, default_sentinel_t) noexcept
     /* strengthened */ {
         return _Left._Length == 0;
     }
 
     template <common_with<_Iter> _Other>
-    _NODISCARD friend constexpr strong_ordering operator<=>(
+    _NODISCARD_FRIEND constexpr strong_ordering operator<=>(
         const counted_iterator& _Left, const counted_iterator<_Other>& _Right) noexcept /* strengthened */ {
 #if _ITERATOR_DEBUG_LEVEL != 0
         _Same_sequence(_Left, _Right);
@@ -1299,7 +1299,7 @@ public:
     }
 
     // [counted.iter.cust]
-    _NODISCARD friend constexpr iter_rvalue_reference_t<_Iter> iter_move(const counted_iterator& _Right) noexcept(
+    _NODISCARD_FRIEND constexpr iter_rvalue_reference_t<_Iter> iter_move(const counted_iterator& _Right) noexcept(
         noexcept(_RANGES iter_move(_Right._Current))) requires input_iterator<_Iter> {
         return _RANGES iter_move(_Right._Current);
     }

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -1130,53 +1130,53 @@ namespace ranges {
             }
         }
 
-        _NODISCARD friend constexpr bool operator==(const _Ioterator& _Left, const _Ioterator& _Right) noexcept(
+        _NODISCARD_FRIEND constexpr bool operator==(const _Ioterator& _Left, const _Ioterator& _Right) noexcept(
             noexcept(_Left._Current == _Right._Current)) requires equality_comparable<_Wi> {
             return _Left._Current == _Right._Current;
         }
 
-        _NODISCARD friend constexpr bool operator<(const _Ioterator& _Left, const _Ioterator& _Right) noexcept(
+        _NODISCARD_FRIEND constexpr bool operator<(const _Ioterator& _Left, const _Ioterator& _Right) noexcept(
             noexcept(_Left._Current < _Right._Current)) /* strengthened */ requires totally_ordered<_Wi> {
             return _Left._Current < _Right._Current;
         }
-        _NODISCARD friend constexpr bool operator>(const _Ioterator& _Left, const _Ioterator& _Right) noexcept(
+        _NODISCARD_FRIEND constexpr bool operator>(const _Ioterator& _Left, const _Ioterator& _Right) noexcept(
             noexcept(_Right._Current < _Left._Current)) /* strengthened */ requires totally_ordered<_Wi> {
             return _Right._Current < _Left._Current;
         }
-        _NODISCARD friend constexpr bool operator<=(const _Ioterator& _Left, const _Ioterator& _Right) noexcept(
+        _NODISCARD_FRIEND constexpr bool operator<=(const _Ioterator& _Left, const _Ioterator& _Right) noexcept(
             noexcept(!(_Right._Current < _Left._Current))) /* strengthened */ requires totally_ordered<_Wi> {
             return !(_Right._Current < _Left._Current);
         }
-        _NODISCARD friend constexpr bool operator>=(const _Ioterator& _Left, const _Ioterator& _Right) noexcept(
+        _NODISCARD_FRIEND constexpr bool operator>=(const _Ioterator& _Left, const _Ioterator& _Right) noexcept(
             noexcept(!(_Left._Current < _Right._Current))) /* strengthened */ requires totally_ordered<_Wi> {
             return !(_Left._Current < _Right._Current);
         }
 
-        _NODISCARD friend constexpr auto operator<=>(const _Ioterator& _Left, const _Ioterator& _Right) noexcept(
+        _NODISCARD_FRIEND constexpr auto operator<=>(const _Ioterator& _Left, const _Ioterator& _Right) noexcept(
             noexcept(_Left._Current <=> _Right._Current)) requires totally_ordered<_Wi> && three_way_comparable<_Wi> {
             return _Left._Current <=> _Right._Current;
         }
 
-        _NODISCARD friend constexpr _Ioterator operator+(_Ioterator _It, const difference_type _Off) noexcept(
+        _NODISCARD_FRIEND constexpr _Ioterator operator+(_Ioterator _It, const difference_type _Off) noexcept(
             is_nothrow_move_constructible_v<_Ioterator>&& noexcept(
                 _It += _Off)) /* strengthened */ requires _Advanceable<_Wi> {
             _It += _Off;
             return _It;
         }
-        _NODISCARD friend constexpr _Ioterator operator+(const difference_type _Off, _Ioterator _It) noexcept(
+        _NODISCARD_FRIEND constexpr _Ioterator operator+(const difference_type _Off, _Ioterator _It) noexcept(
             is_nothrow_move_constructible_v<_Wi>&& noexcept(
                 static_cast<_Wi>(_It._Current + _Off))) /* strengthened */ requires _Advanceable<_Wi> {
             return _Ioterator{static_cast<_Wi>(_It._Current + _Off)};
         }
 
-        _NODISCARD friend constexpr _Ioterator operator-(_Ioterator _It, const difference_type _Off) noexcept(
+        _NODISCARD_FRIEND constexpr _Ioterator operator-(_Ioterator _It, const difference_type _Off) noexcept(
             is_nothrow_move_constructible_v<_Ioterator>&& noexcept(
                 _It -= _Off)) /* strengthened */ requires _Advanceable<_Wi> {
             _It -= _Off;
             return _It;
         }
 
-        _NODISCARD friend constexpr difference_type
+        _NODISCARD_FRIEND constexpr difference_type
             operator-(const _Ioterator& _Left, const _Ioterator& _Right) noexcept(
                 noexcept(_Left._Current - _Right._Current)) /* strengthened */ requires _Advanceable<_Wi> {
             if constexpr (_Integer_like<_Wi>) {
@@ -1214,17 +1214,17 @@ namespace ranges {
     public:
         /* [[no_unique_address]] */ _Bo _Last{};
 
-        _NODISCARD friend constexpr bool operator==(const _It& _Left, const _Iotinel& _Right) noexcept(
+        _NODISCARD_FRIEND constexpr bool operator==(const _It& _Left, const _Iotinel& _Right) noexcept(
             noexcept(_Right._Equal(_Left))) /* strengthened */ {
             return _Right._Equal(_Left);
         }
 
-        _NODISCARD friend constexpr iter_difference_t<_Wi> operator-(const _It& _Left, const _Iotinel& _Right) noexcept(
+        _NODISCARD_FRIEND constexpr iter_difference_t<_Wi> operator-(const _It& _Left, const _Iotinel& _Right) noexcept(
             noexcept(_Right._Delta(_Left))) /* strengthened */ requires sized_sentinel_for<_Bo, _Wi> {
             return -_Right._Delta(_Left);
         }
 
-        _NODISCARD friend constexpr iter_difference_t<_Wi> operator-(const _Iotinel& _Left, const _It& _Right) noexcept(
+        _NODISCARD_FRIEND constexpr iter_difference_t<_Wi> operator-(const _Iotinel& _Left, const _It& _Right) noexcept(
             noexcept(_Left._Delta(_Right))) /* strengthened */ requires sized_sentinel_for<_Bo, _Wi> {
             return _Left._Delta(_Right);
         }
@@ -1384,7 +1384,7 @@ namespace ranges {
                 return _Parent->_Val;
             }
 
-            _NODISCARD friend bool operator==(const _Iterator& _Left, default_sentinel_t) noexcept /* strengthened */ {
+            _NODISCARD_FRIEND bool operator==(const _Iterator& _Left, default_sentinel_t) noexcept /* strengthened */ {
                 return _Left._Parent->_Stream_at_end();
             }
         };
@@ -1747,7 +1747,7 @@ namespace ranges {
                 return _Tmp;
             }
 
-            _NODISCARD friend constexpr bool operator==(
+            _NODISCARD_FRIEND constexpr bool operator==(
                 const _Iterator& _Left, const _Iterator& _Right) requires equality_comparable<iterator_t<_Vw>> {
 #if _ITERATOR_DEBUG_LEVEL != 0
                 _STL_VERIFY(
@@ -1756,7 +1756,7 @@ namespace ranges {
                 return _Left._Current == _Right._Current;
             }
 
-            _NODISCARD friend constexpr range_rvalue_reference_t<_Vw> iter_move(const _Iterator& _It) noexcept(
+            _NODISCARD_FRIEND constexpr range_rvalue_reference_t<_Vw> iter_move(const _Iterator& _It) noexcept(
                 noexcept(_RANGES iter_move(_It._Current))) {
 #if _ITERATOR_DEBUG_LEVEL != 0
                 _It._Check_dereference();
@@ -1795,7 +1795,7 @@ namespace ranges {
                 return _Last;
             }
 
-            _NODISCARD friend constexpr bool operator==(const _Iterator& _It, const _Sentinel& _Se) noexcept(
+            _NODISCARD_FRIEND constexpr bool operator==(const _Iterator& _It, const _Sentinel& _Se) noexcept(
                 noexcept(_It._Equal(_Se._Last))) /* strengthened */ {
                 return _It._Equal(_Se._Last);
             }
@@ -2089,7 +2089,7 @@ namespace ranges {
                 return _STD invoke(*_Parent->_Fun, _Current[_Idx]);
             }
 
-            _NODISCARD friend constexpr bool operator==(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+            _NODISCARD_FRIEND constexpr bool operator==(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                 noexcept(_Left._Current
                          == _Right._Current)) /* strengthened */ requires equality_comparable<iterator_t<_Base>> {
 #if _ITERATOR_DEBUG_LEVEL != 0
@@ -2098,27 +2098,27 @@ namespace ranges {
                 return _Left._Current == _Right._Current;
             }
 
-            _NODISCARD friend constexpr bool operator<(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+            _NODISCARD_FRIEND constexpr bool operator<(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                 noexcept(_Left._Current < _Right._Current)) /* strengthened */ requires random_access_range<_Base> {
 #if _ITERATOR_DEBUG_LEVEL != 0
                 _Left._Same_range(_Right);
 #endif // _ITERATOR_DEBUG_LEVEL != 0
                 return _Left._Current < _Right._Current;
             }
-            _NODISCARD friend constexpr bool operator>(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+            _NODISCARD_FRIEND constexpr bool operator>(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                 noexcept(_Left._Current < _Right._Current)) /* strengthened */ requires random_access_range<_Base> {
                 return _Right < _Left;
             }
-            _NODISCARD friend constexpr bool operator<=(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+            _NODISCARD_FRIEND constexpr bool operator<=(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                 noexcept(_Left._Current < _Right._Current)) /* strengthened */ requires random_access_range<_Base> {
                 return !(_Right < _Left);
             }
-            _NODISCARD friend constexpr bool operator>=(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+            _NODISCARD_FRIEND constexpr bool operator>=(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                 noexcept(_Left._Current < _Right._Current)) /* strengthened */ requires random_access_range<_Base> {
                 return !(_Left < _Right);
             }
             // clang-format off
-            _NODISCARD friend constexpr auto operator<=>(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+            _NODISCARD_FRIEND constexpr auto operator<=>(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                 noexcept(_Left._Current <=> _Right._Current)) /* strengthened */
                 requires random_access_range<_Base> && three_way_comparable<iterator_t<_Base>> {
                 // clang-format on
@@ -2128,7 +2128,7 @@ namespace ranges {
                 return _Left._Current <=> _Right._Current;
             }
 
-            _NODISCARD friend constexpr _Iterator operator+(_Iterator _It, difference_type _Off)
+            _NODISCARD_FRIEND constexpr _Iterator operator+(_Iterator _It, difference_type _Off)
                 _NOEXCEPT_IDL0(noexcept(_It._Current += _Off)) /* strengthened */ requires random_access_range<_Base> {
 #if _ITERATOR_DEBUG_LEVEL != 0
                 _It._Verify_offset(_Off);
@@ -2136,7 +2136,7 @@ namespace ranges {
                 _It._Current += _Off;
                 return _It;
             }
-            _NODISCARD friend constexpr _Iterator operator+(difference_type _Off, _Iterator _It)
+            _NODISCARD_FRIEND constexpr _Iterator operator+(difference_type _Off, _Iterator _It)
                 _NOEXCEPT_IDL0(noexcept(_It._Current += _Off)) /* strengthened */ requires random_access_range<_Base> {
 #if _ITERATOR_DEBUG_LEVEL != 0
                 _It._Verify_offset(_Off);
@@ -2145,7 +2145,7 @@ namespace ranges {
                 return _It;
             }
 
-            _NODISCARD friend constexpr _Iterator operator-(_Iterator _It, difference_type _Off)
+            _NODISCARD_FRIEND constexpr _Iterator operator-(_Iterator _It, difference_type _Off)
                 _NOEXCEPT_IDL0(noexcept(_It._Current -= _Off)) /* strengthened */ requires random_access_range<_Base> {
 #if _ITERATOR_DEBUG_LEVEL != 0
                 _It._Verify_offset(-_Off);
@@ -2154,7 +2154,7 @@ namespace ranges {
                 return _It;
             }
 
-            _NODISCARD friend constexpr difference_type operator-(const _Iterator& _Left,
+            _NODISCARD_FRIEND constexpr difference_type operator-(const _Iterator& _Left,
                 const _Iterator& _Right) noexcept(noexcept(_Left._Current - _Right._Current)) /* strengthened */
                 requires sized_sentinel_for<iterator_t<_Base>, iterator_t<_Base>> {
 #if _ITERATOR_DEBUG_LEVEL != 0
@@ -2208,14 +2208,14 @@ namespace ranges {
             // clang-format off
             template <bool _OtherConst>
                 requires sentinel_for<sentinel_t<_Base>, _Maybe_const_iter<_OtherConst>>
-            _NODISCARD friend constexpr bool operator==(const _Iterator<_OtherConst>& _Left,
+            _NODISCARD_FRIEND constexpr bool operator==(const _Iterator<_OtherConst>& _Left,
                 const _Sentinel& _Right) noexcept(noexcept(_Get_current(_Left) == _Right._Last)) /* strengthened */ {
                 return _Get_current(_Left) == _Right._Last;
             }
 
             template <bool _OtherConst>
                 requires sized_sentinel_for<sentinel_t<_Base>, _Maybe_const_iter<_OtherConst>>
-            _NODISCARD friend constexpr range_difference_t<_Maybe_const<_OtherConst, _Vw>>
+            _NODISCARD_FRIEND constexpr range_difference_t<_Maybe_const<_OtherConst, _Vw>>
                 operator-(const _Iterator<_OtherConst>& _Left, const _Sentinel& _Right) noexcept(
                     noexcept(_Get_current(_Left) - _Right._Last)) /* strengthened */ {
                 return _Get_current(_Left) - _Right._Last;
@@ -2223,7 +2223,7 @@ namespace ranges {
 
             template <bool _OtherConst>
                 requires sized_sentinel_for<sentinel_t<_Base>, _Maybe_const_iter<_OtherConst>>
-            _NODISCARD friend constexpr range_difference_t<_Maybe_const<_OtherConst, _Vw>>
+            _NODISCARD_FRIEND constexpr range_difference_t<_Maybe_const<_OtherConst, _Vw>>
                 operator-(const _Sentinel& _Left, const _Iterator<_OtherConst>& _Right) noexcept(
                     noexcept(_Left._Last - _Get_current(_Right))) /* strengthened */ {
                 return _Left._Last - _Get_current(_Right);
@@ -2372,14 +2372,14 @@ namespace ranges {
                 return _Last;
             }
 
-            _NODISCARD friend constexpr bool operator==(const _Counted_iter<_Const>& _Left, const _Sentinel& _Right) {
+            _NODISCARD_FRIEND constexpr bool operator==(const _Counted_iter<_Const>& _Left, const _Sentinel& _Right) {
                 return _Left.count() == 0 || _Left.base() == _Right._Last;
             }
 
             // clang-format off
             template <bool _OtherConst = !_Const>
                 requires sentinel_for<_Base_sentinel, _Base_iterator<_OtherConst>>
-            _NODISCARD friend constexpr bool operator==(
+            _NODISCARD_FRIEND constexpr bool operator==(
                 const _Counted_iter<_OtherConst>& _Left, const _Sentinel& _Right) {
                 // clang-format on
                 return _Left.count() == 0 || _Left.base() == _Right._Last;
@@ -2628,14 +2628,14 @@ namespace ranges {
                 return _Last;
             }
 
-            _NODISCARD friend constexpr bool operator==(const _Base_iterator& _Left, const _Sentinel& _Right) {
+            _NODISCARD_FRIEND constexpr bool operator==(const _Base_iterator& _Left, const _Sentinel& _Right) {
                 return _Right._Last == _Left || !_STD invoke(*_Right._Pred, *_Left);
             }
 
             // clang-format off
             template <bool _OtherConst = !_Const>
                 requires sentinel_for<_Base_sentinel, _Maybe_const_iter<_OtherConst>>
-            _NODISCARD friend constexpr bool operator==(
+            _NODISCARD_FRIEND constexpr bool operator==(
                 const _Maybe_const_iter<_OtherConst>& _Left, const _Sentinel& _Right) {
                 // clang-format on
                 return _Right._Last == _Left || !_STD invoke(*_Right._Pred, *_Left);
@@ -3256,7 +3256,7 @@ namespace ranges {
             }
 
             // clang-format off
-            _NODISCARD friend constexpr bool operator==(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+            _NODISCARD_FRIEND constexpr bool operator==(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                 noexcept(_Implicitly_convert_to<bool>(_Left._Outer == _Right._Outer
                     && _Left._Inner == _Right._Inner))) /* strengthened */
                 requires _Deref_is_glvalue && equality_comparable<_OuterIter> && equality_comparable<_InnerIter> {
@@ -3267,7 +3267,7 @@ namespace ranges {
                 return _Left._Outer == _Right._Outer && _Left._Inner == _Right._Inner;
             }
 
-            _NODISCARD friend constexpr decltype(auto) iter_move(const _Iterator& _It) noexcept(
+            _NODISCARD_FRIEND constexpr decltype(auto) iter_move(const _Iterator& _It) noexcept(
                 noexcept(_RANGES iter_move(*_It._Inner))) {
 #if _ITERATOR_DEBUG_LEVEL != 0
                 _It._Check_dereference();
@@ -3328,7 +3328,7 @@ namespace ranges {
 
             template <bool _OtherConst>
                 requires sentinel_for<sentinel_t<_Base>, _Maybe_const_iter<_OtherConst>>
-            _NODISCARD friend constexpr bool operator==(const _Iterator<_OtherConst>& _Left,
+            _NODISCARD_FRIEND constexpr bool operator==(const _Iterator<_OtherConst>& _Left,
                 const _Sentinel& _Right) noexcept(noexcept(_Right._Equal(_Left))) /* strengthened */ {
                 // clang-format on
                 return _Right._Equal(_Left);
@@ -3595,11 +3595,11 @@ namespace ranges {
                 }
             }
 
-            _NODISCARD friend constexpr bool operator==(const _Outer_iter& _Left, const _Outer_iter& _Right) noexcept(
+            _NODISCARD_FRIEND constexpr bool operator==(const _Outer_iter& _Left, const _Outer_iter& _Right) noexcept(
                 noexcept(_Left._Current == _Right._Current)) /* strengthened */ requires forward_range<_BaseTy> {
                 return _Left._Current == _Right._Current && _Left._Trailing_empty == _Right._Trailing_empty;
             }
-            _NODISCARD friend constexpr bool operator==(const _Outer_iter& _Left, default_sentinel_t) noexcept(
+            _NODISCARD_FRIEND constexpr bool operator==(const _Outer_iter& _Left, default_sentinel_t) noexcept(
                 noexcept(_Left._At_end())) /* strengthened */ {
                 return _Left._At_end() && !_Left._Trailing_empty;
             }
@@ -3723,16 +3723,16 @@ namespace ranges {
                 }
             }
 
-            _NODISCARD friend constexpr bool operator==(
+            _NODISCARD_FRIEND constexpr bool operator==(
                 const _Inner_iter& _Left, const _Inner_iter& _Right) requires forward_range<_BaseTy> {
                 return _Left._Equal(_Right);
             }
 
-            _NODISCARD friend constexpr bool operator==(const _Inner_iter& _Left, default_sentinel_t) {
+            _NODISCARD_FRIEND constexpr bool operator==(const _Inner_iter& _Left, default_sentinel_t) {
                 return _Left._At_end();
             }
 
-            _NODISCARD friend constexpr decltype(auto) iter_move(const _Inner_iter& _Iter) noexcept(
+            _NODISCARD_FRIEND constexpr decltype(auto) iter_move(const _Inner_iter& _Iter) noexcept(
                 noexcept(_RANGES iter_move(_Iter._Get_current()))) {
                 return _RANGES iter_move(_Iter._Get_current());
             }
@@ -3911,7 +3911,7 @@ namespace ranges {
                 return _Tmp;
             }
 
-            _NODISCARD friend constexpr bool operator==(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+            _NODISCARD_FRIEND constexpr bool operator==(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                 noexcept(_Left._Current == _Right._Current)) /* strengthened */ {
                 return _Left._Current == _Right._Current && _Left._Trailing_empty == _Right._Trailing_empty;
             }
@@ -3933,7 +3933,7 @@ namespace ranges {
                 && is_nothrow_move_constructible_v<sentinel_t<_Vw>>) // strengthened
                 : _Last(_RANGES end(_Parent._Range)) {}
 
-            _NODISCARD friend constexpr bool operator==(const _Iterator& _It, const _Sentinel& _Se) noexcept(
+            _NODISCARD_FRIEND constexpr bool operator==(const _Iterator& _It, const _Sentinel& _Se) noexcept(
                 noexcept(_Se._Equal(_It))) /* strengthened */ {
                 return _Se._Equal(_It);
             }
@@ -4516,38 +4516,38 @@ namespace ranges {
                 return static_cast<_ElemTy>(_STD get<_Index>(*(_Current + _Idx)));
             }
 
-            _NODISCARD friend constexpr bool operator==(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+            _NODISCARD_FRIEND constexpr bool operator==(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                 noexcept(_Left._Current == _Right._Current)) /* strengthened */
                 requires equality_comparable<iterator_t<_Base>> {
                 return _Left._Current == _Right._Current;
             }
 
-            _NODISCARD friend constexpr bool operator<(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+            _NODISCARD_FRIEND constexpr bool operator<(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                 noexcept(_Left._Current < _Right._Current)) /* strengthened */ requires random_access_range<_Base> {
                 return _Left._Current < _Right._Current;
             }
-            _NODISCARD friend constexpr bool operator>(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+            _NODISCARD_FRIEND constexpr bool operator>(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                 noexcept(_Left._Current < _Right._Current)) /* strengthened */ requires random_access_range<_Base> {
                 return _Right < _Left;
             }
-            _NODISCARD friend constexpr bool operator<=(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+            _NODISCARD_FRIEND constexpr bool operator<=(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                 noexcept(_Left._Current < _Right._Current)) /* strengthened */ requires random_access_range<_Base> {
                 return !(_Right < _Left);
             }
-            _NODISCARD friend constexpr bool operator>=(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+            _NODISCARD_FRIEND constexpr bool operator>=(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                 noexcept(_Left._Current < _Right._Current)) /* strengthened */ requires random_access_range<_Base> {
                 return !(_Left < _Right);
             }
 
             // clang-format off
-            _NODISCARD friend constexpr auto operator<=>(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+            _NODISCARD_FRIEND constexpr auto operator<=>(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                 noexcept(_Left._Current <=> _Right._Current)) /* strengthened */
                 requires random_access_range<_Base> && three_way_comparable<iterator_t<_Base>> {
                 // clang-format on
                 return _Left._Current <=> _Right._Current;
             }
 
-            _NODISCARD friend constexpr _Iterator operator+(const _Iterator& _It, const difference_type _Off) noexcept(
+            _NODISCARD_FRIEND constexpr _Iterator operator+(const _Iterator& _It, const difference_type _Off) noexcept(
                 noexcept(_STD declval<iterator_t<_Base>&>() += _Off)
                 && is_nothrow_copy_constructible_v<iterator_t<_Base>>) /* strengthened */
                 requires random_access_range<_Base> {
@@ -4559,7 +4559,7 @@ namespace ranges {
                 return _Copy;
             }
 
-            _NODISCARD friend constexpr _Iterator operator+(const difference_type _Off, const _Iterator& _It) noexcept(
+            _NODISCARD_FRIEND constexpr _Iterator operator+(const difference_type _Off, const _Iterator& _It) noexcept(
                 noexcept(_STD declval<iterator_t<_Base>&>() += _Off)
                 && is_nothrow_copy_constructible_v<iterator_t<_Base>>) /* strengthened */
                 requires random_access_range<_Base> {
@@ -4571,7 +4571,7 @@ namespace ranges {
                 return _Copy;
             }
 
-            _NODISCARD friend constexpr _Iterator operator-(const _Iterator& _It, const difference_type _Off) noexcept(
+            _NODISCARD_FRIEND constexpr _Iterator operator-(const _Iterator& _It, const difference_type _Off) noexcept(
                 noexcept(_STD declval<iterator_t<_Base>&>() -= _Off)
                 && is_nothrow_copy_constructible_v<iterator_t<_Base>>) /* strengthened */
                 requires random_access_range<_Base> {
@@ -4583,7 +4583,7 @@ namespace ranges {
                 return _Copy;
             }
 
-            _NODISCARD friend constexpr difference_type operator-(const _Iterator& _Left,
+            _NODISCARD_FRIEND constexpr difference_type operator-(const _Iterator& _Left,
                 const _Iterator& _Right) noexcept(noexcept(_Left._Current - _Right._Current)) /* strengthened */
                 requires sized_sentinel_for<iterator_t<_Base>, iterator_t<_Base>> {
                 return _Left._Current - _Right._Current;
@@ -4629,7 +4629,7 @@ namespace ranges {
             // clang-format off
             template <bool _OtherConst>
                 requires sentinel_for<sentinel_t<_Base>, _Maybe_const_iter<_OtherConst>>
-            _NODISCARD friend constexpr bool operator==(const _Iterator<_OtherConst>& _Left,
+            _NODISCARD_FRIEND constexpr bool operator==(const _Iterator<_OtherConst>& _Left,
                 const _Sentinel& _Right) noexcept(noexcept(_Get_current(_Left) == _Right._Last)) /* strengthened */ {
                 // clang-format on
                 return _Get_current(_Left) == _Right._Last;
@@ -4638,7 +4638,7 @@ namespace ranges {
             // clang-format off
             template <bool _OtherConst>
                 requires sized_sentinel_for<sentinel_t<_Base>, _Maybe_const_iter<_OtherConst>>
-            _NODISCARD friend constexpr range_difference_t<_Maybe_const<_OtherConst, _Vw>> operator-(
+            _NODISCARD_FRIEND constexpr range_difference_t<_Maybe_const<_OtherConst, _Vw>> operator-(
                 const _Iterator<_OtherConst>& _Left, const _Sentinel& _Right) noexcept(
                 noexcept(_Get_current(_Left) - _Right._Last)) /* strengthened */ {
                 // clang-format on
@@ -4648,7 +4648,7 @@ namespace ranges {
             // clang-format off
             template <bool _OtherConst>
                 requires sized_sentinel_for<sentinel_t<_Base>, _Maybe_const_iter<_OtherConst>>
-            _NODISCARD friend constexpr range_difference_t<_Maybe_const<_OtherConst, _Vw>> operator-(
+            _NODISCARD_FRIEND constexpr range_difference_t<_Maybe_const<_OtherConst, _Vw>> operator-(
                 const _Sentinel& _Left, const _Iterator<_OtherConst>& _Right) noexcept(
                 noexcept(_Left._Last - _Get_current(_Right))) /* strengthened */ {
                 // clang-format on
@@ -4817,12 +4817,12 @@ namespace ranges {
                 return _Tmp;
             }
 
-            _NODISCARD friend constexpr bool operator==(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+            _NODISCARD_FRIEND constexpr bool operator==(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                 noexcept(_Implicitly_convert_to<bool>(_Left._Current == _Right._Current))) /* strengthened */ {
                 return _Left._Current == _Right._Current;
             }
 
-            _NODISCARD friend constexpr bool operator==(const _Iterator& _Left, default_sentinel_t) noexcept(
+            _NODISCARD_FRIEND constexpr bool operator==(const _Iterator& _Left, default_sentinel_t) noexcept(
                 noexcept(_Implicitly_convert_to<bool>(_Left._Current == _Left._Next))) /* strengthened */ {
                 return _Left._Current == _Left._Next;
             }

--- a/stl/inc/span
+++ b/stl/inc/span
@@ -114,7 +114,7 @@ struct _Span_iterator {
         return _Tmp;
     }
 
-    _NODISCARD friend constexpr _Span_iterator operator+(const difference_type _Off, _Span_iterator _Next) noexcept {
+    _NODISCARD_FRIEND constexpr _Span_iterator operator+(const difference_type _Off, _Span_iterator _Next) noexcept {
         _Next += _Off;
         return _Next;
     }

--- a/stl/inc/stop_token
+++ b/stl/inc/stop_token
@@ -163,7 +163,7 @@ public:
         return _Local != nullptr && _Local->_Stop_possible();
     }
 
-    _NODISCARD friend bool operator==(const stop_token& _Lhs, const stop_token& _Rhs) noexcept = default;
+    _NODISCARD_FRIEND bool operator==(const stop_token& _Lhs, const stop_token& _Rhs) noexcept = default;
 
     friend void swap(stop_token& _Lhs, stop_token& _Rhs) noexcept {
         _STD swap(_Lhs._State, _Rhs._State);
@@ -235,7 +235,7 @@ public:
         return _Local && _Local->_Request_stop();
     }
 
-    _NODISCARD friend bool operator==(const stop_source& _Lhs, const stop_source& _Rhs) noexcept = default;
+    _NODISCARD_FRIEND bool operator==(const stop_source& _Lhs, const stop_source& _Rhs) noexcept = default;
 
     friend void swap(stop_source& _Lhs, stop_source& _Rhs) noexcept {
         _STD swap(_Lhs._State, _Rhs._State);

--- a/stl/inc/system_error
+++ b/stl/inc/system_error
@@ -172,41 +172,41 @@ public:
     }
 
 #if _STL_OPTIMIZE_SYSTEM_ERROR_OPERATORS
-    _NODISCARD friend bool operator==(const error_code& _Left, const error_code& _Right) noexcept {
+    _NODISCARD_FRIEND bool operator==(const error_code& _Left, const error_code& _Right) noexcept {
         return _Left.category() == _Right.category() && _Left.value() == _Right.value();
     }
 
-    _NODISCARD friend bool operator==(const error_code& _Left, const error_condition& _Right) noexcept {
+    _NODISCARD_FRIEND bool operator==(const error_code& _Left, const error_condition& _Right) noexcept {
         return _System_error_equal(_Left, _Right);
     }
 
 #ifdef __cpp_lib_concepts
-    _NODISCARD friend strong_ordering operator<=>(const error_code& _Left, const error_code& _Right) noexcept {
+    _NODISCARD_FRIEND strong_ordering operator<=>(const error_code& _Left, const error_code& _Right) noexcept {
         if (const auto _Result = _Left.category() <=> _Right.category(); _Result != 0) {
             return _Result;
         }
         return _Left.value() <=> _Right.value();
     }
 #else // ^^^ defined(__cpp_lib_concepts) / !defined(__cpp_lib_concepts) vvv
-    _NODISCARD friend bool operator<(const error_code& _Left, const error_code& _Right) noexcept {
+    _NODISCARD_FRIEND bool operator<(const error_code& _Left, const error_code& _Right) noexcept {
         return _Left.category() < _Right.category()
             || (_Left.category() == _Right.category() && _Left.value() < _Right.value());
     }
 #endif // ^^^ !defined(__cpp_lib_concepts) ^^^
 #if !_HAS_CXX20
-    _NODISCARD friend bool operator==(const error_condition& _Left, const error_code& _Right) noexcept {
+    _NODISCARD_FRIEND bool operator==(const error_condition& _Left, const error_code& _Right) noexcept {
         return _System_error_equal(_Right, _Left);
     }
 
-    _NODISCARD friend bool operator!=(const error_code& _Left, const error_code& _Right) noexcept {
+    _NODISCARD_FRIEND bool operator!=(const error_code& _Left, const error_code& _Right) noexcept {
         return !(_Left == _Right);
     }
 
-    _NODISCARD friend bool operator!=(const error_code& _Left, const error_condition& _Right) noexcept {
+    _NODISCARD_FRIEND bool operator!=(const error_code& _Left, const error_condition& _Right) noexcept {
         return !_System_error_equal(_Left, _Right);
     }
 
-    _NODISCARD friend bool operator!=(const error_condition& _Left, const error_code& _Right) noexcept {
+    _NODISCARD_FRIEND bool operator!=(const error_condition& _Left, const error_code& _Right) noexcept {
         return !_System_error_equal(_Right, _Left);
     }
 #endif // !_HAS_CXX20
@@ -261,12 +261,12 @@ public:
     }
 
 #if _STL_OPTIMIZE_SYSTEM_ERROR_OPERATORS
-    _NODISCARD friend bool operator==(const error_condition& _Left, const error_condition& _Right) noexcept {
+    _NODISCARD_FRIEND bool operator==(const error_condition& _Left, const error_condition& _Right) noexcept {
         return _Left.category() == _Right.category() && _Left.value() == _Right.value();
     }
 
 #ifdef __cpp_lib_concepts
-    _NODISCARD friend strong_ordering operator<=>(
+    _NODISCARD_FRIEND strong_ordering operator<=>(
         const error_condition& _Left, const error_condition& _Right) noexcept {
         if (const auto _Result = _Left.category() <=> _Right.category(); _Result != 0) {
             return _Result;
@@ -274,13 +274,13 @@ public:
         return _Left.value() <=> _Right.value();
     }
 #else // ^^^ defined(__cpp_lib_concepts) / !defined(__cpp_lib_concepts) vvv
-    _NODISCARD friend bool operator<(const error_condition& _Left, const error_condition& _Right) noexcept {
+    _NODISCARD_FRIEND bool operator<(const error_condition& _Left, const error_condition& _Right) noexcept {
         return _Left.category() < _Right.category()
             || (_Left.category() == _Right.category() && _Left.value() < _Right.value());
     }
 #endif // ^^^ !defined(__cpp_lib_concepts) ^^^
 #if !_HAS_CXX20
-    _NODISCARD friend bool operator!=(const error_condition& _Left, const error_condition& _Right) noexcept {
+    _NODISCARD_FRIEND bool operator!=(const error_condition& _Left, const error_condition& _Right) noexcept {
         return !(_Left == _Right);
     }
 #endif // !_HAS_CXX20

--- a/stl/inc/valarray
+++ b/stl/inc/valarray
@@ -1381,7 +1381,7 @@ public:
     }
 
 #if _HAS_CXX20
-    _NODISCARD friend bool operator==(const slice& _Left, const slice& _Right) noexcept /* strengthened */ {
+    _NODISCARD_FRIEND bool operator==(const slice& _Left, const slice& _Right) noexcept /* strengthened */ {
         return _Left.start() == _Right.start() && _Left.size() == _Right.size() && _Left.stride() == _Right.stride();
     }
 #endif // _HAS_CXX20

--- a/stl/inc/xcharconv.h
+++ b/stl/inc/xcharconv.h
@@ -38,7 +38,7 @@ struct to_chars_result {
     char* ptr;
     errc ec;
 #if _HAS_CXX20
-    _NODISCARD friend bool operator==(const to_chars_result&, const to_chars_result&) = default;
+    _NODISCARD_FRIEND bool operator==(const to_chars_result&, const to_chars_result&) = default;
 #endif // _HAS_CXX20
 };
 

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -1674,7 +1674,7 @@ public:
     }
 
 #ifdef __cpp_lib_concepts
-    _NODISCARD friend constexpr iter_rvalue_reference_t<_BidIt> iter_move(const reverse_iterator& _It) noexcept(
+    _NODISCARD_FRIEND constexpr iter_rvalue_reference_t<_BidIt> iter_move(const reverse_iterator& _It) noexcept(
         is_nothrow_copy_constructible_v<_BidIt>&& noexcept(_RANGES iter_move(--_STD declval<_BidIt&>()))) {
         auto _Tmp = _It.current;
         --_Tmp;
@@ -3728,23 +3728,23 @@ public:
 
 #ifdef __cpp_lib_concepts
     template <sentinel_for<_Iter> _Sent>
-    _NODISCARD friend constexpr bool operator==(const move_iterator& _Left, const move_sentinel<_Sent>& _Right) {
+    _NODISCARD_FRIEND constexpr bool operator==(const move_iterator& _Left, const move_sentinel<_Sent>& _Right) {
         return _Left._Current == _Right._Get_last();
     }
 
     template <sized_sentinel_for<_Iter> _Sent>
-    _NODISCARD friend constexpr difference_type operator-(
+    _NODISCARD_FRIEND constexpr difference_type operator-(
         const move_sentinel<_Sent>& _Left, const move_iterator& _Right) {
         return _Left._Get_last() - _Right._Current;
     }
 
     template <sized_sentinel_for<_Iter> _Sent>
-    _NODISCARD friend constexpr difference_type operator-(
+    _NODISCARD_FRIEND constexpr difference_type operator-(
         const move_iterator& _Left, const move_sentinel<_Sent>& _Right) {
         return _Left._Current - _Right._Get_last();
     }
 
-    _NODISCARD friend constexpr reference iter_move(const move_iterator& _It)
+    _NODISCARD_FRIEND constexpr reference iter_move(const move_iterator& _It)
 #ifdef __EDG__ // TRANSITION, VSO-1222776
         noexcept(noexcept(_RANGES iter_move(_STD declval<const _Iter&>())))
 #else // ^^^ workaround / no workaround vvv
@@ -3904,7 +3904,7 @@ struct unreachable_sentinel_t;
 namespace _Unreachable_sentinel_detail {
     struct _Base {
         template <weakly_incrementable _Winc>
-        _NODISCARD friend constexpr bool operator==(const unreachable_sentinel_t&, const _Winc&) noexcept {
+        _NODISCARD_FRIEND constexpr bool operator==(const unreachable_sentinel_t&, const _Winc&) noexcept {
             return false;
         }
     };


### PR DESCRIPTION
Thanks to @MattStephanson in #2208, we now have `_NODISCARD_FRIEND`, a centralized workaround for a bug that affects CUDA.

In theory, we could restrict usage of `_NODISCARD_FRIEND` to C++14 (and possibly C++17 - I'm not sure if the newer CUDA versions that accept C++17 are affected by this bug). However, we've already accumulated some usage in C++20 code: https://github.com/microsoft/STL/blob/27877181dc50fc5f0dc9d679703437eb105e2b9f/stl/inc/__msvc_int128.hpp#L298

As the macro is exactly the same number of characters, it seems simpler to use it everywhere.

This should fix DevCom-1555597 / VSO-1426765 "VS2019 standard exception headers: warning C5240: 'nodiscard': attribute is ignored in this syntactic position".