### PR TITLE
`<charconv>`: `_Divide` can trim `_Big_integer_flt` more efficiently

### DIFF
--- a/stl/inc/charconv
+++ b/stl/inc/charconv
@@ -1032,10 +1032,6 @@ _NODISCARD inline uint64_t _Divide(_Big_integer_flt& _Numerator, const _Big_inte
     }
 
     // Trim the remainder:
-    for (uint32_t _Ix = _Max_numerator_element_index + 1; _Ix < _Numerator._Myused; ++_Ix) {
-        _Numerator._Mydata[_Ix] = 0;
-    }
-
     uint32_t _Used = _Max_numerator_element_index + 1;
 
     while (_Used != 0 && _Numerator._Mydata[_Used - 1] == 0) {


### PR DESCRIPTION
We have a comment explaining how `_Big_integer_flt` accesses only `[0, _Myused)` and tolerates all other elements being garbage:

https://github.com/microsoft/STL/blob/27877181dc50fc5f0dc9d679703437eb105e2b9f/stl/inc/charconv#L366-L369

Now, look at the following code at the end of `_Divide`:

https://github.com/microsoft/STL/blob/27877181dc50fc5f0dc9d679703437eb105e2b9f/stl/inc/charconv#L1034-L1045

I claim that the first loop is unnecessary. It's zeroing out elements in the range `[_Max_numerator_element_index + 1, original _Myused)`. Then, the following code updates `_Myused` to *at most* `_Max_numerator_element_index + 1`. (Possibly less, if we discover that there are more zero elements at the end of this range.)

According to `_Big_integer_flt`'s invariants, the `_Myused` update already makes the contents of the range `[_Max_numerator_element_index + 1, original _Myused)` irrelevant - thus we don't need to spend extra time zeroing them out.

Noticed while working on #2366.