### PR TITLE
Remove parallel `copy_backward()` and `move_backward()`

### DIFF
--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -4257,15 +4257,6 @@ _CONSTEXPR20 _BidIt2 copy_backward(_BidIt1 _First, _BidIt1 _Last, _BidIt2 _Dest)
     return _Dest;
 }
 
-#if _HAS_CXX17
-template <class _ExPo, class _BidIt1, class _BidIt2, _Enable_if_execution_policy_t<_ExPo> = 0>
-_BidIt2 copy_backward(_ExPo&&, _BidIt1 _First, _BidIt1 _Last, _BidIt2 _Dest) noexcept /* terminates */ {
-    // copy [_First, _Last) backwards to [..., _Dest)
-    // not parallelized as benchmarks show it isn't worth it
-    return _STD copy_backward(_First, _Last, _Dest);
-}
-#endif // _HAS_CXX17
-
 template <class _InIt, class _OutIt>
 _CONSTEXPR20 _OutIt _Move_unchecked(_InIt _First, _InIt _Last, _OutIt _Dest) {
     // move [_First, _Last) to [_Dest, ...)
@@ -4338,15 +4329,6 @@ _CONSTEXPR20 _BidIt2 move_backward(_BidIt1 _First, _BidIt1 _Last, _BidIt2 _Dest)
     _Seek_wrapped(_Dest, _Move_backward_unchecked(_UFirst, _ULast, _UDest));
     return _Dest;
 }
-
-#if _HAS_CXX17
-template <class _ExPo, class _BidIt1, class _BidIt2, _Enable_if_execution_policy_t<_ExPo> = 0>
-_BidIt2 move_backward(_ExPo&&, _BidIt1 _First, _BidIt1 _Last, _BidIt2 _Dest) noexcept /* terminates */ {
-    // move [_First, _Last) backwards to [..., _Dest)
-    // not parallelized as benchmarks show it isn't worth it
-    return _STD move_backward(_First, _Last, _Dest);
-}
-#endif // _HAS_CXX17
 
 
 template <class _Ty>

--- a/tests/std/include/instantiate_algorithms.hpp
+++ b/tests/std/include/instantiate_algorithms.hpp
@@ -582,27 +582,9 @@ namespace std_testing {
 #endif // _HAS_CXX17
         }
 
-#if HAS_PARALLEL_ALGORITHMS
-        template <typename Bid1, typename Bid2, typename ExecutionPolicy>
-        void test_exec_bid1_bid2_xxx_backward(ExecutionPolicy&& exec, Bid1 bid1, Bid2 bid2) {
-            // SPLIT_MODE 2
-            std::copy_backward(std::forward<ExecutionPolicy>(exec), bid1, bid1, bid2);
-            std::move_backward(std::forward<ExecutionPolicy>(exec), bid1, bid1, bid2);
-        }
-#endif // HAS_PARALLEL_ALGORITHMS
-
         template <typename Bid1, typename Bid2>
         void test_bid1_bid2_xxx_backward(Bid1 bid1, Bid2 bid2) {
             // SPLIT_MODE 2
-#if HAS_PARALLEL_ALGORITHMS
-            test_exec_bid1_bid2_xxx_backward(std::execution::seq, bid1, bid2);
-            test_exec_bid1_bid2_xxx_backward(std::execution::par, bid1, bid2);
-            test_exec_bid1_bid2_xxx_backward(std::execution::par_unseq, bid1, bid2);
-#if _HAS_CXX20
-            test_exec_bid1_bid2_xxx_backward(std::execution::unseq, bid1, bid2);
-#endif // _HAS_CXX20
-#endif // HAS_PARALLEL_ALGORITHMS
-
             std::copy_backward(bid1, bid1, bid2);
             std::move_backward(bid1, bid1, bid2);
         }

--- a/tests/std/tests/Dev11_0253803_debug_pointer/test.cpp
+++ b/tests/std/tests/Dev11_0253803_debug_pointer/test.cpp
@@ -321,9 +321,7 @@ int main() {
     copy(par, nil, nil, nil);
     copy_if(par, nil, nil, nil, pred);
     copy_n(par, nil, zero, nil);
-    copy_backward(par, nil, nil, nil);
     move(par, nil, nil, nil);
-    move_backward(par, nil, nil, nil);
     swap_ranges(par, nil, nil, nil);
     transform(par, nil, nil, nil, unop);
     transform(par, nil, nil, nil, nil, binop);


### PR DESCRIPTION
Fixes #2626.

On Discord, @CaseyCarter additionally explained why these don't exist:

> The only reason to use `meow_backward` over `meow` is to avoid aliasing issues when the head of the destination overlaps the tail of the source. Since the parallel algorithms all forbid overlapping, parallel `meow_backward` would be useless.