### PR TITLE
Remove bogus warning workaround

### DIFF
--- a/stl/inc/variant
+++ b/stl/inc/variant
@@ -1472,7 +1472,6 @@ struct _Variant_dispatcher<index_sequence<_Is...>> {
     template <class _Ret, class _Callable, class... _Types, bool _Any_valueless = ((_Is == 0) || ...)>
     _NODISCARD static constexpr _Ret _Dispatch2(_Callable&& _Obj, _Types&&... _Args) {
         if constexpr (_Any_valueless) {
-            ((void) _Args, ...); // TRANSITION, DevCom-1004719
             _Throw_bad_variant_access();
         }
 #if _HAS_CXX20


### PR DESCRIPTION
Bogus warning C4100 "unreferenced formal parameter"
emitted by `if constexpr`