### PR TITLE
Implement workaround for LLVM-46269 by ensuring that constrained destructor appears after the unconstrained one

### DIFF
--- a/stl/inc/iterator
+++ b/stl/inc/iterator
@@ -618,15 +618,14 @@ public:
         }
     }
 
-    // clang-format off
-    constexpr ~_Variantish() requires is_trivially_destructible_v<_It> && is_trivially_destructible_v<_Se> = default;
-    // clang-format on
-
     constexpr ~_Variantish() {
         _Raw_clear();
     }
 
+    // TRANSITION, LLVM-46269, destructor order is significant
     // clang-format off
+    constexpr ~_Variantish() requires is_trivially_destructible_v<_It> && is_trivially_destructible_v<_Se> = default;
+
     constexpr _Variantish& operator=(const _Variantish&) requires is_trivially_destructible_v<_It>
         && is_trivially_destructible_v<_Se>
         && is_trivially_copy_constructible_v<_It>

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -271,17 +271,16 @@ namespace ranges {
             is_nothrow_constructible_v<_Ty, _Types...>) // strengthened
             : _Val(_STD forward<_Types>(_Args)...), _Engaged{true} {}
 
-        // clang-format off
-        ~_Copyable_box() requires is_trivially_destructible_v<_Ty> = default;
-        // clang-format on
-
         constexpr ~_Copyable_box() {
             if (_Engaged) {
                 _Val.~_Ty();
             }
         }
 
+        // TRANSITION, LLVM-46269, destructor order is significant
         // clang-format off
+        ~_Copyable_box() requires is_trivially_destructible_v<_Ty> = default;
+
         _Copyable_box(const _Copyable_box&) requires is_trivially_copy_constructible_v<_Ty> = default;
         // clang-format on
 
@@ -474,17 +473,16 @@ namespace ranges {
     public:
         constexpr _Defaultabox() noexcept {}
 
-        // clang-format off
-        ~_Defaultabox() requires is_trivially_destructible_v<_Ty> = default;
-        // clang-format on
-
         constexpr ~_Defaultabox() {
             if (_Engaged) {
                 _Val.~_Ty();
             }
         }
 
+        // TRANSITION, LLVM-46269, destructor order is significant
         // clang-format off
+        ~_Defaultabox() requires is_trivially_destructible_v<_Ty> = default;
+
         _Defaultabox(const _Defaultabox&)
             requires copy_constructible<_Ty> && is_trivially_copy_constructible_v<_Ty> = default;
         // clang-format on
@@ -693,6 +691,7 @@ namespace ranges {
             }
         }
 
+        // TRANSITION, LLVM-46269, destructor order is significant
         // clang-format off
         ~_Non_propagating_cache() requires is_trivially_destructible_v<_Ty> = default;
         // clang-format on

--- a/tests/std/tests/P0896R4_common_iterator/test.cpp
+++ b/tests/std/tests/P0896R4_common_iterator/test.cpp
@@ -311,6 +311,31 @@ constexpr bool test_lwg_3574() {
     return true;
 }
 
+// Validate that _Variant works when fed with a non-trivially-destructible type
+struct non_trivially_destructible_input_iterator {
+    constexpr ~non_trivially_destructible_input_iterator() {}
+
+    using difference_type = int;
+    using value_type      = int;
+
+    constexpr non_trivially_destructible_input_iterator& operator++() {
+        return *this;
+    }
+    constexpr void operator++(int) {
+        ++*this;
+    }
+    constexpr int operator*() const {
+        return 0;
+    }
+    constexpr bool operator==(default_sentinel_t) const {
+        return true;
+    }
+};
+
+void test_non_trivially_destructible_type() { // COMPILE-ONLY
+    [[maybe_unused]] common_iterator<non_trivially_destructible_input_iterator, default_sentinel_t> it;
+}
+
 int main() {
     with_writable_iterators<instantiator, P>::call();
     static_assert(with_writable_iterators<instantiator, P>::call());

--- a/tests/std/tests/P0896R4_common_iterator/test.cpp
+++ b/tests/std/tests/P0896R4_common_iterator/test.cpp
@@ -311,29 +311,27 @@ constexpr bool test_lwg_3574() {
     return true;
 }
 
-// Validate that _Variant works when fed with a non-trivially-destructible type
-struct non_trivially_destructible_input_iterator {
-    constexpr ~non_trivially_destructible_input_iterator() {}
-
-    using difference_type = int;
-    using value_type      = int;
-
-    constexpr non_trivially_destructible_input_iterator& operator++() {
-        return *this;
-    }
-    constexpr void operator++(int) {
-        ++*this;
-    }
-    constexpr int operator*() const {
-        return 0;
-    }
-    constexpr bool operator==(default_sentinel_t) const {
-        return true;
-    }
-};
-
+// Validate that _Variantish works when fed with a non-trivially-destructible type
 void test_non_trivially_destructible_type() { // COMPILE-ONLY
-    [[maybe_unused]] common_iterator<non_trivially_destructible_input_iterator, default_sentinel_t> it;
+    struct non_trivially_destructible_input_iterator {
+        using difference_type = int;
+        using value_type      = int;
+
+        ~non_trivially_destructible_input_iterator() {}
+
+        non_trivially_destructible_input_iterator& operator++() {
+            return *this;
+        }
+        void operator++(int) {}
+        int operator*() const {
+            return 0;
+        }
+        bool operator==(default_sentinel_t) const {
+            return true;
+        }
+    };
+
+    common_iterator<non_trivially_destructible_input_iterator, default_sentinel_t> it;
 }
 
 int main() {

--- a/tests/std/tests/P0896R4_views_join/test.cpp
+++ b/tests/std/tests/P0896R4_views_join/test.cpp
@@ -472,31 +472,28 @@ struct Immovable {
 };
 
 // Validate that the _Defaultabox primary template works when fed with a non-trivially-destructible type
-struct non_trivially_destructible_input_iterator {
-    constexpr ~non_trivially_destructible_input_iterator() {}
-
-    // When the type is default constructible, the partial specialization is used.
-    // Avoid that so we can test what we want to test.
-    non_trivially_destructible_input_iterator() = delete;
-
-    using difference_type = int;
-    using value_type      = int;
-
-    constexpr non_trivially_destructible_input_iterator& operator++() {
-        return *this;
-    }
-    constexpr void operator++(int) {
-        ++*this;
-    }
-    constexpr int operator*() const {
-        return 0;
-    }
-    constexpr bool operator==(default_sentinel_t) const {
-        return true;
-    }
-};
-
 void test_non_trivially_destructible_type() { // COMPILE-ONLY
+    struct non_trivially_destructible_input_iterator {
+        using difference_type = int;
+        using value_type      = int;
+
+        ~non_trivially_destructible_input_iterator() {}
+
+        // To test the correct specialization of _Defaultabox, this type must not be default constructible.
+        non_trivially_destructible_input_iterator() = delete;
+
+        non_trivially_destructible_input_iterator& operator++() {
+            return *this;
+        }
+        void operator++(int) {}
+        int operator*() const {
+            return 0;
+        }
+        bool operator==(default_sentinel_t) const {
+            return true;
+        }
+    };
+
     using Inner = ranges::subrange<non_trivially_destructible_input_iterator, default_sentinel_t>;
 
     auto r = views::empty<Inner> | views::join;

--- a/tests/std/tests/P0896R4_views_single/test.cpp
+++ b/tests/std/tests/P0896R4_views_single/test.cpp
@@ -139,6 +139,21 @@ static_assert(same_as<ranges::single_view<const char*>, decltype(views::single("
 void double_function(double);
 static_assert(same_as<ranges::single_view<void (*)(double)>, decltype(views::single(double_function))>);
 
+// Validate that the copyable-box primary template works when fed with a non-trivially-destructible type
+struct non_trivially_destructible {
+    constexpr non_trivially_destructible() = default;
+    constexpr ~non_trivially_destructible() {}
+
+    // When the type is copy assignable, the partial specialization may be used.
+    // Avoid that so we can test what we want to test.
+    non_trivially_destructible(const non_trivially_destructible&) = default;
+    non_trivially_destructible& operator=(const non_trivially_destructible&) = delete;
+};
+
+void test_non_trivially_destructible_type() { // COMPILE-ONLY
+    (void) views::single(non_trivially_destructible{});
+}
+
 int main() {
     static_assert(test_one_type(42, 42));
     test_one_type(42, 42);

--- a/tests/std/tests/P0896R4_views_single/test.cpp
+++ b/tests/std/tests/P0896R4_views_single/test.cpp
@@ -139,18 +139,17 @@ static_assert(same_as<ranges::single_view<const char*>, decltype(views::single("
 void double_function(double);
 static_assert(same_as<ranges::single_view<void (*)(double)>, decltype(views::single(double_function))>);
 
-// Validate that the copyable-box primary template works when fed with a non-trivially-destructible type
-struct non_trivially_destructible {
-    constexpr non_trivially_destructible() = default;
-    constexpr ~non_trivially_destructible() {}
-
-    // When the type is copy assignable, the partial specialization may be used.
-    // Avoid that so we can test what we want to test.
-    non_trivially_destructible(const non_trivially_destructible&) = default;
-    non_trivially_destructible& operator=(const non_trivially_destructible&) = delete;
-};
-
+// Validate that the _Copyable_box primary template works when fed with a non-trivially-destructible type
 void test_non_trivially_destructible_type() { // COMPILE-ONLY
+    struct non_trivially_destructible {
+        non_trivially_destructible() = default;
+        ~non_trivially_destructible() {}
+
+        // To test the correct specialization of _Copyable_box, this type must not be copy assignable.
+        non_trivially_destructible(const non_trivially_destructible&) = default;
+        non_trivially_destructible& operator=(const non_trivially_destructible&) = delete;
+    };
+
     (void) views::single(non_trivially_destructible{});
 }
 


### PR DESCRIPTION
This implements workaround for LLVM-46269 ("Only first destructor is considered when constraints are used").

If the constrained (and defaulted) destructor comes first, clang-cl uses it unconditionally, even if its constraints are not satisfied. This leads to an error when the defaulted destructor is implicitly deleted (due to a non-trivially-destructible member).

By moving the constrained destructor after the unconstrained one (which is always valid, but is non-trivial), this patch sidesteps the abovementioned error.

This is suboptimal, because this makes the affected types never trivially destructible when compiled with clang-cl. A perfect fix would need to use something akin to the existing [`_Optional_destruct_base`], which I assume that we want to avoid.

[`_Optional_destruct_base`]: https://github.com/microsoft/STL/blob/27877181dc50fc5f0dc9d679703437eb105e2b9f/stl/inc/optional#L70