### PR TITLE
`<bit>`: fix `countl_zero` on arm64

### DIFF
--- a/stl/inc/bit
+++ b/stl/inc/bit
@@ -255,7 +255,7 @@ _NODISCARD int _Checked_arm_arm64_countl_zero(const _Ty _Val) noexcept {
     if constexpr (_Digits <= 32) {
         return static_cast<int>(_CountLeadingZeros(_Val)) - (numeric_limits<unsigned long>::digits - _Digits);
     } else {
-        return static_cast<int>(_CountLeadingZeros64(_Val)) - (numeric_limits<unsigned long long>::digits - _Digits);
+        return static_cast<int>(_CountLeadingZeros64(_Val));
     }
 #endif // TRANSITION, GH-1586
 }

--- a/stl/inc/bit
+++ b/stl/inc/bit
@@ -253,9 +253,11 @@ _NODISCARD int _Checked_arm_arm64_countl_zero(const _Ty _Val) noexcept {
     }
 #else // ^^^ workaround / no workaround vvv
     if constexpr (_Digits <= 32) {
-        return static_cast<int>(_CountLeadingZeros(_Val));
+        return static_cast<int>(_CountLeadingZeros(_Val))
+            - (numeric_limits<unsigned long>::digits - _Digits);
     } else {
-        return static_cast<int>(_CountLeadingZeros64(_Val));
+        return static_cast<int>(_CountLeadingZeros64(_Val))
+            - (numeric_limits<unsigned long long>::digits - _Digits);
     }
 #endif // TRANSITION, GH-1586
 }

--- a/stl/inc/bit
+++ b/stl/inc/bit
@@ -253,11 +253,9 @@ _NODISCARD int _Checked_arm_arm64_countl_zero(const _Ty _Val) noexcept {
     }
 #else // ^^^ workaround / no workaround vvv
     if constexpr (_Digits <= 32) {
-        return static_cast<int>(_CountLeadingZeros(_Val))
-            - (numeric_limits<unsigned long>::digits - _Digits);
+        return static_cast<int>(_CountLeadingZeros(_Val)) - (numeric_limits<unsigned long>::digits - _Digits);
     } else {
-        return static_cast<int>(_CountLeadingZeros64(_Val))
-            - (numeric_limits<unsigned long long>::digits - _Digits);
+        return static_cast<int>(_CountLeadingZeros64(_Val)) - (numeric_limits<unsigned long long>::digits - _Digits);
     }
 #endif // TRANSITION, GH-1586
 }


### PR DESCRIPTION
 Fix countl_zero on arm64 to properly subtract the zeros resulting from widening.

Because of a lack of test coverage, we forgot that `_CountLeadingZeros` takes `unsigned long`, and thus for types shorter than that we need to subtract the extra zeros from the result.