### PR TITLE
Guard use of custom attributes against macroization

### DIFF
--- a/stl/inc/system_error
+++ b/stl/inc/system_error
@@ -623,7 +623,7 @@ struct _Constexpr_immortalize_impl {
     _Constexpr_immortalize_impl(const _Constexpr_immortalize_impl&) = delete;
     _Constexpr_immortalize_impl& operator=(const _Constexpr_immortalize_impl&) = delete;
 
-    [[msvc::noop_dtor]] ~_Constexpr_immortalize_impl() {
+    _MSVC_NOOP_DTOR ~_Constexpr_immortalize_impl() {
         // do nothing, allowing _Ty to be used during shutdown
     }
 };

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -435,6 +435,13 @@
 #define _NODISCARD_FRIEND _NODISCARD friend
 #endif // TRANSITION, VSO-568006
 
+#pragma push_macro("msvc")
+#pragma push_macro("known_semantics")
+#pragma push_macro("noop_dtor")
+#undef msvc
+#undef known_semantics
+#undef noop_dtor
+
 // Determine if we should use [[msvc::known_semantics]] to communicate to the compiler
 // that certain type trait specializations have the standard-mandated semantics
 #ifndef __has_cpp_attribute
@@ -446,6 +453,12 @@
 #else
 #define _MSVC_KNOWN_SEMANTICS
 #endif
+
+#define _MSVC_NOOP_DTOR [[msvc::noop_dtor]]
+
+#pragma pop_macro("noop_dtor")
+#pragma pop_macro("known_semantics")
+#pragma pop_macro("msvc")
 
 // Controls whether the STL uses "conditional explicit" internally
 #ifndef _HAS_CONDITIONAL_EXPLICIT

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -442,20 +442,31 @@
 #undef known_semantics
 #undef noop_dtor
 
-// Determine if we should use [[msvc::known_semantics]] to communicate to the compiler
-// that certain type trait specializations have the standard-mandated semantics
 #ifndef __has_cpp_attribute
-#define _MSVC_KNOWN_SEMANTICS
+#define _HAS_MSVC_ATTRIBUTE(x) 0
 #elif defined(__CUDACC__) // TRANSITION, CUDA - warning: attribute namespace "msvc" is unrecognized
-#define _MSVC_KNOWN_SEMANTICS
-#elif __has_cpp_attribute(msvc::known_semantics)
+#define _HAS_MSVC_ATTRIBUTE(x) 0
+#else
+#define _HAS_MSVC_ATTRIBUTE(x) __has_cpp_attribute(msvc::x)
+#endif
+
+// Should we use [[msvc::known_semantics]] to tell the compiler that certain
+// type trait specializations have the standard-mandated semantics?
+#if _HAS_MSVC_ATTRIBUTE(known_semantics)
 #define _MSVC_KNOWN_SEMANTICS [[msvc::known_semantics]]
 #else
 #define _MSVC_KNOWN_SEMANTICS
 #endif
 
+// Should we use [[msvc::noop_dtor]] to tell the compiler that some non-trivial
+// destructors have no effects?
+#if _HAS_MSVC_ATTRIBUTE(noop_dtor)
 #define _MSVC_NOOP_DTOR [[msvc::noop_dtor]]
+#else
+#define _MSVC_NOOP_DTOR
+#endif
 
+#undef _HAS_MSVC_ATTRIBUTE
 #pragma pop_macro("noop_dtor")
 #pragma pop_macro("known_semantics")
 #pragma pop_macro("msvc")

--- a/stl/src/excptptr.cpp
+++ b/stl/src/excptptr.cpp
@@ -55,7 +55,7 @@ namespace {
         _Constexpr_excptptr_immortalize_impl(const _Constexpr_excptptr_immortalize_impl&) = delete;
         _Constexpr_excptptr_immortalize_impl& operator=(const _Constexpr_excptptr_immortalize_impl&) = delete;
 
-        [[msvc::noop_dtor]] ~_Constexpr_excptptr_immortalize_impl() {
+        _MSVC_NOOP_DTOR ~_Constexpr_excptptr_immortalize_impl() {
             // do nothing, allowing _Ty to be used during shutdown
         }
     };


### PR DESCRIPTION
Define `_MSVC_MEOW` macro in `<yvals_core.h>`for each `[[msvc::meow]]` custom attribute with surrounding push_macro/pop_macro guards.

Fixes #2645
