### PR TITLE
Toolset update: VS 2022 17.2 Preview 3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,7 @@ add_compile_definitions(
     _ALLOW_ITERATOR_DEBUG_LEVEL_MISMATCH WIN32_LEAN_AND_MEAN STRICT _CRT_STDIO_ARBITRARY_WIDE_SPECIFIERS
     _CRT_DECLARE_NONSTDC_NAMES=1 )
 
-add_compile_options(/diagnostics:caret /W4 /WX /w14265 /w15038 /d1FastFail /guard:cf /Z7 /Gm- /Gy /Zp8 /std:c++latest /permissive- /Zc:threadSafeInit- /Zl /ZH:SHA_256)
+add_compile_options(/diagnostics:caret /W4 /WX /w14265 /w15038 /d1FastFail /guard:cf /Z7 /Gy /Zp8 /std:c++latest /permissive- /Zc:threadSafeInit- /Zl)
 
 set(VCLIBS_DEBUG_OPTIONS "/Od")
 set(VCLIBS_RELEASE_OPTIONS "/O2;/Os") # TRANSITION: Potentially remove /Os

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With The Visual Studio IDE
 
-1. Install Visual Studio 2022 17.2 Preview 2 or later.
+1. Install Visual Studio 2022 17.2 Preview 3 or later.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
     * Otherwise, install [CMake][] 3.22 or later, and [Ninja][] 1.10.2 or later.
@@ -155,7 +155,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With A Native Tools Command Prompt
 
-1. Install Visual Studio 2022 17.2 Preview 2 or later.
+1. Install Visual Studio 2022 17.2 Preview 3 or later.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
     * Otherwise, install [CMake][] 3.22 or later, and [Ninja][] 1.10.2 or later.

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -135,14 +135,13 @@ $Workloads = @(
   'Microsoft.VisualStudio.Component.VC.Tools.ARM64',
   'Microsoft.VisualStudio.Component.VC.Tools.ARM64EC',
   'Microsoft.VisualStudio.Component.VC.Tools.x86.x64',
-  # TRANSITION, LLVM-51128 (Clang 12 targeting ARM64 is incompatible with WinSDK 10.0.20348.0)
-  'Microsoft.VisualStudio.Component.Windows10SDK.19041'
+  'Microsoft.VisualStudio.Component.Windows11SDK.22000'
 )
 
 $ReleaseInPath = 'Preview'
 $Sku = 'Enterprise'
 $VisualStudioBootstrapperUrl = 'https://aka.ms/vs/17/pre/vs_enterprise.exe'
-$PythonUrl = 'https://www.python.org/ftp/python/3.10.3/python-3.10.3-amd64.exe'
+$PythonUrl = 'https://www.python.org/ftp/python/3.10.4/python-3.10.4-amd64.exe'
 
 $CudaUrl = `
   'https://developer.download.nvidia.com/compute/cuda/10.1/Prod/local_installers/cuda_10.1.243_426.00_win10.exe'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ variables:
   tmpDir: 'D:\Temp'
   buildOutputLocation: 'D:\build'
 
-pool: 'StlBuild-2022-03-17-T1445'
+pool: 'StlBuild-2022-04-12-T1624'
 
 stages:
   - stage: Code_Format

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -601,8 +601,8 @@
 #error STL1000: Unexpected compiler version, expected Clang 13.0.0 or newer.
 #endif // ^^^ old Clang ^^^
 #elif defined(_MSC_VER)
-#if _MSC_VER < 1931 // Coarse-grained, not inspecting _MSC_FULL_VER
-#error STL1001: Unexpected compiler version, expected MSVC 19.31 or newer.
+#if _MSC_VER < 1932 // Coarse-grained, not inspecting _MSC_FULL_VER
+#error STL1001: Unexpected compiler version, expected MSVC 19.32 or newer.
 #endif // ^^^ old MSVC ^^^
 #else // vvv other compilers vvv
 // not attempting to detect other compilers

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -282,9 +282,6 @@ std/algorithms/robust_re_difference_type.compile.pass.cpp:0 FAIL
 # DevCom-1628714: C1XX refuses nullptr_t == reference-to-function in a requires expression
 std/concepts/concepts.compare/concept.equalitycomparable/equality_comparable_with.compile.pass.cpp:0 FAIL
 
-# DevCom-1629961: ICE testing if function lvalues are comparable with the spaceship operator
-std/language.support/cmp/cmp.concept/three_way_comparable.compile.pass.cpp:0 FAIL
-
 # DevCom-1638496: C1XX doesn't properly reject int <=> unsigned
 std/language.support/cmp/cmp.concept/three_way_comparable_with.compile.pass.cpp:0 FAIL
 std/language.support/cmp/cmp.result/compare_three_way_result.compile.pass.cpp:0 FAIL

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -282,9 +282,6 @@ algorithms\robust_re_difference_type.compile.pass.cpp
 # DevCom-1628714: C1XX refuses nullptr_t == reference-to-function in a requires expression
 concepts\concepts.compare\concept.equalitycomparable\equality_comparable_with.compile.pass.cpp
 
-# DevCom-1629961: ICE testing if function lvalues are comparable with the spaceship operator
-language.support\cmp\cmp.concept\three_way_comparable.compile.pass.cpp
-
 # DevCom-1638496: C1XX doesn't properly reject int <=> unsigned
 language.support\cmp\cmp.concept\three_way_comparable_with.compile.pass.cpp
 language.support\cmp\cmp.result\compare_three_way_result.compile.pass.cpp

--- a/tests/std/tests/P0784R7_library_support_for_more_constexpr_containers/test.cpp
+++ b/tests/std/tests/P0784R7_library_support_for_more_constexpr_containers/test.cpp
@@ -214,11 +214,7 @@ void test_array(const T& val) {
         ranges::construct_at(ptr + i, val);
     }
 
-#if defined(__clang__) || defined(__EDG__) // TRANSITION, VSO-1049320
     ranges::destroy_at(reinterpret_cast<U(*)[N]>(ptr));
-#else // ^^^ no workaround / workaround vvv
-    ranges::destroy_at(reinterpret_cast<T(*)[N]>(const_cast<T*>(ptr)));
-#endif // TRANSITION, VSO-1049320
 #endif // __cpp_lib_concepts
 }
 

--- a/tests/std/tests/P1502R1_standard_library_header_units/test.cpp
+++ b/tests/std/tests/P1502R1_standard_library_header_units/test.cpp
@@ -330,7 +330,7 @@ int main() {
         static_assert(b(3) == 33);
     }
 
-#if defined(_MSVC_INTERNAL_TESTING) || defined(TEST_TOPO_SORT) // TRANSITION, VSO-1496084 fixed in 17.3 Preview 1
+#if defined(_MSVC_INTERNAL_TESTING) || defined(TEST_TOPO_SORT) // TRANSITION, VSO-1496084 fixed in 17.3 Preview 2
     {
         puts("Testing <future>.");
         promise<int> p{};
@@ -771,7 +771,7 @@ int main() {
         assert(caught_puppies);
     }
 
-#if defined(_MSVC_INTERNAL_TESTING) || defined(TEST_TOPO_SORT) // TRANSITION, VSO-1496084 fixed in 17.3 Preview 1
+#if defined(_MSVC_INTERNAL_TESTING) || defined(TEST_TOPO_SORT) // TRANSITION, VSO-1496084 fixed in 17.3 Preview 2
     {
         puts("Testing <stop_token>.");
         vector<int> vec;

--- a/tests/std/tests/P1502R1_standard_library_header_units/test.cpp
+++ b/tests/std/tests/P1502R1_standard_library_header_units/test.cpp
@@ -330,6 +330,7 @@ int main() {
         static_assert(b(3) == 33);
     }
 
+#if defined(_MSVC_INTERNAL_TESTING) || defined(TEST_TOPO_SORT) // TRANSITION, VSO-1496084 fixed in 17.3 Preview 1
     {
         puts("Testing <future>.");
         promise<int> p{};
@@ -339,6 +340,7 @@ int main() {
         assert(f.wait_for(chrono::seconds{0}) == future_status::ready);
         assert(f.get() == 1729);
     }
+#endif // ^^^ no workaround ^^^
 
     {
         puts("Testing <initializer_list>.");
@@ -769,6 +771,7 @@ int main() {
         assert(caught_puppies);
     }
 
+#if defined(_MSVC_INTERNAL_TESTING) || defined(TEST_TOPO_SORT) // TRANSITION, VSO-1496084 fixed in 17.3 Preview 1
     {
         puts("Testing <stop_token>.");
         vector<int> vec;
@@ -804,6 +807,7 @@ int main() {
             80, 40, 20, 10, 5, 16, 8, 4, 2, 1, -1000};
         assert(equal(vec.begin(), vec.end(), begin(expected), end(expected)));
     }
+#endif // ^^^ no workaround ^^^
 
     {
         puts("Testing <streambuf>.");


### PR DESCRIPTION
* Unskip `three_way_comparable.compile.pass.cpp` as it's now passing with 17.2 Preview 3.
* Add workarounds to `P1502R1_standard_library_header_units` for VSO-1496084 "Standard Library Header Units: Splitting `<chrono>` emits fatal error C1116: unrecoverable error importing header unit '`<chrono>`'"
  + This has already been fixed in 17.3 Preview 2, so we can run the affected code when `defined(_MSVC_INTERNAL_TESTING)`.
  + It also repros only for separate header units, so we can run the affected code when `defined(TEST_TOPO_SORT)` (deduplicated header units).
* Remove workaround for VSO-1049320 "conditional operator errors" in `P0784R7_library_support_for_more_constexpr_containers`.
* Toolset update:
  + 17.2 Preview 3 (now required, as the internal toolset has also been updated).
  + Python 3.10.4.
  + This contains Clang 13.0.1, so we can upgrade the WinSDK. The latest is the Windows 11 SDK.
  + Patch Tuesday.
* Remove `/Gm-` and `/ZH:SHA_256`.
  + MSVC-PR-392417 "Remove logic related to `/Gm`": "The flag is ignored starting from 17.0. This PR removes its related logic."
    - We don't need to explicitly disable something that can't be enabled.
  + MSVC-PR-334618 "Make SHA-256 the default source hash algorithm" merged 2021-06-30.
    - https://docs.microsoft.com/en-us/cpp/build/reference/zh?view=msvc-170 says: "`/ZH:SHA_256` Use an SHA-256 hash for the checksum. This option is the default in Visual Studio 2022 version 17.0 and later."
    - `cl /?` was also update: `/ZH:[MD5|SHA1|SHA_256] hash algorithm for calculation of file checksum in debug info (default: SHA_256)`
