### PR TITLE
Coordinated fix for capturing continuation context for tasks in Desktop apps

### DIFF
--- a/stl/CMakeLists.txt
+++ b/stl/CMakeLists.txt
@@ -458,11 +458,11 @@ function(add_stl_dlls D_SUFFIX THIS_CONFIG_DEFINITIONS THIS_CONFIG_COMPILE_OPTIO
     target_compile_options(msvcp${D_SUFFIX}_eha_objects PRIVATE "${THIS_CONFIG_COMPILE_OPTIONS};${GL_FLAG};/EHa")
 
     add_library(msvcp${D_SUFFIX} SHARED)
-    target_link_libraries(msvcp${D_SUFFIX} PRIVATE msvcp${D_SUFFIX}_eha_objects msvcp${D_SUFFIX}_objects msvcp${D_SUFFIX}_init_objects "${TOOLSET_LIB}/vcruntime${D_SUFFIX}.lib" "${TOOLSET_LIB}/msvcrt${D_SUFFIX}.lib" "ucrt${D_SUFFIX}.lib")
+    target_link_libraries(msvcp${D_SUFFIX} PRIVATE msvcp${D_SUFFIX}_eha_objects msvcp${D_SUFFIX}_objects msvcp${D_SUFFIX}_init_objects "${TOOLSET_LIB}/vcruntime${D_SUFFIX}.lib" "${TOOLSET_LIB}/msvcrt${D_SUFFIX}.lib" "ucrt${D_SUFFIX}.lib" "ole32.lib" "delayimp.lib")
     set_target_properties(msvcp${D_SUFFIX} PROPERTIES ARCHIVE_OUTPUT_NAME "msvcp140_base${D_SUFFIX}${VCLIBS_SUFFIX}")
     set_target_properties(msvcp${D_SUFFIX} PROPERTIES ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
     set_target_properties(msvcp${D_SUFFIX} PROPERTIES OUTPUT_NAME "msvcp140${D_SUFFIX}${VCLIBS_SUFFIX}")
-    target_link_options(msvcp${D_SUFFIX} PRIVATE "${THIS_CONFIG_LINK_OPTIONS}")
+    target_link_options(msvcp${D_SUFFIX} PRIVATE "${THIS_CONFIG_LINK_OPTIONS}" "-delayload:ole32.dll")
 
     # import library 'statics'
     add_library(msvcp${D_SUFFIX}_implib_objects OBJECT ${IMPLIB_SOURCES})

--- a/stl/CMakeLists.txt
+++ b/stl/CMakeLists.txt
@@ -458,11 +458,11 @@ function(add_stl_dlls D_SUFFIX THIS_CONFIG_DEFINITIONS THIS_CONFIG_COMPILE_OPTIO
     target_compile_options(msvcp${D_SUFFIX}_eha_objects PRIVATE "${THIS_CONFIG_COMPILE_OPTIONS};${GL_FLAG};/EHa")
 
     add_library(msvcp${D_SUFFIX} SHARED)
-    target_link_libraries(msvcp${D_SUFFIX} PRIVATE msvcp${D_SUFFIX}_eha_objects msvcp${D_SUFFIX}_objects msvcp${D_SUFFIX}_init_objects "${TOOLSET_LIB}/vcruntime${D_SUFFIX}.lib" "${TOOLSET_LIB}/msvcrt${D_SUFFIX}.lib" "ucrt${D_SUFFIX}.lib" "ole32.lib" "delayimp.lib")
+    target_link_libraries(msvcp${D_SUFFIX} PRIVATE msvcp${D_SUFFIX}_eha_objects msvcp${D_SUFFIX}_objects msvcp${D_SUFFIX}_init_objects "${TOOLSET_LIB}/vcruntime${D_SUFFIX}.lib" "${TOOLSET_LIB}/msvcrt${D_SUFFIX}.lib" "ucrt${D_SUFFIX}.lib" "ole32.lib")
     set_target_properties(msvcp${D_SUFFIX} PROPERTIES ARCHIVE_OUTPUT_NAME "msvcp140_base${D_SUFFIX}${VCLIBS_SUFFIX}")
     set_target_properties(msvcp${D_SUFFIX} PROPERTIES ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
     set_target_properties(msvcp${D_SUFFIX} PROPERTIES OUTPUT_NAME "msvcp140${D_SUFFIX}${VCLIBS_SUFFIX}")
-    target_link_options(msvcp${D_SUFFIX} PRIVATE "${THIS_CONFIG_LINK_OPTIONS}" "-delayload:ole32.dll")
+    target_link_options(msvcp${D_SUFFIX} PRIVATE "${THIS_CONFIG_LINK_OPTIONS}")
 
     # import library 'statics'
     add_library(msvcp${D_SUFFIX}_implib_objects OBJECT ${IMPLIB_SOURCES})

--- a/stl/msbuild/stl_base/msvcp.settings.targets
+++ b/stl/msbuild/stl_base/msvcp.settings.targets
@@ -50,6 +50,8 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         <LinkAdditionalOptions Condition="$(DebugBuild) == 'true'">-opt:ref,noicf $(LinkAdditionalOptions)</LinkAdditionalOptions>
         <LinkAdditionalOptions>-nodefaultlib:libcpmt$(BuildSuffix).lib $(LinkAdditionalOptions)</LinkAdditionalOptions>
         <LinkAdditionalOptions>-nodefaultlib:$(LibOutputFile) $(LinkAdditionalOptions)</LinkAdditionalOptions>
+        <LinkingWithMinCore Condition="'$(MsvcpFlavor)' == 'app' or '$(MsvcpFlavor)' == 'onecore'">true</LinkingWithMinCore>
+        <LinkAdditionalOptions Condition="'$(LinkingWithMinCore)' != 'true'">ole32.lib $(LinkAdditionalOptions)</LinkAdditionalOptions>
 
         <LinkGenerateMapFile>true</LinkGenerateMapFile>
         <LinkRelease>true</LinkRelease>

--- a/stl/src/ppltasks.cpp
+++ b/stl/src/ppltasks.cpp
@@ -234,7 +234,7 @@ namespace Concurrency {
             } else {
                 ComCallData callData;
                 ZeroMemory(&callData, sizeof(callData));
-                callData.pUserDefined = reinterpret_cast<void*>(&_Func);
+                callData.pUserDefined = &_Func;
 
                 HRESULT hresult = static_cast<IContextCallback*>(_M_context._M_pContextCallback)
                                       ->ContextCallback(&_PPLTaskContextCallbackBridge, &callData,

--- a/stl/src/ppltasks.cpp
+++ b/stl/src/ppltasks.cpp
@@ -7,7 +7,6 @@
 
 #include <Windows.h>
 
-#if defined(_CRT_APP) || defined(UNDOCKED_WINDOWS_UCRT)
 #ifndef UNDOCKED_WINDOWS_UCRT
 #pragma warning(push)
 #pragma warning(disable : 4265) // non-virtual destructor in base class
@@ -19,7 +18,8 @@
 #include <ctxtcall.h>
 #include <mutex>
 #include <windows.foundation.diagnostics.h>
-#endif
+
+#pragma comment(lib, "ole32")
 
 // This IID is exported by ole32.dll; we cannot depend on ole32.dll on OneCore.
 static GUID const Local_IID_ICallbackWithNoReentrancyToApplicationSTA = {
@@ -217,7 +217,6 @@ namespace Concurrency {
         _CRTIMP2 void __thiscall _TaskEventLogger::_LogWorkItemCompleted() {}
 #endif
 
-#if defined(_CRT_APP) || defined(UNDOCKED_WINDOWS_UCRT)
         using namespace ABI::Windows::Foundation;
         using namespace ABI::Windows::Foundation::Diagnostics;
         using namespace Microsoft::WRL;
@@ -235,7 +234,7 @@ namespace Concurrency {
             } else {
                 ComCallData callData;
                 ZeroMemory(&callData, sizeof(callData));
-                callData.pUserDefined = &_Func;
+                callData.pUserDefined = reinterpret_cast<void*>(&_Func);
 
                 HRESULT hresult = static_cast<IContextCallback*>(_M_context._M_pContextCallback)
                                       ->ContextCallback(&_PPLTaskContextCallbackBridge, &callData,
@@ -317,26 +316,6 @@ namespace Concurrency {
             }
             return false;
         }
-
-#else
-        _CRTIMP2 void __thiscall _ContextCallback::_CallInContext(_CallbackFunction _Func, bool) const {
-            _Func();
-        }
-
-        _CRTIMP2 void __thiscall _ContextCallback::_Capture() {}
-
-        _CRTIMP2 void __thiscall _ContextCallback::_Reset() {}
-
-        _CRTIMP2 void __thiscall _ContextCallback::_Assign(void*) {}
-
-        _CRTIMP2 bool __cdecl _ContextCallback::_IsCurrentOriginSTA() {
-            return false;
-        }
-
-        _CRTIMP2 bool __cdecl _Task_impl_base::_IsNonBlockingThread() {
-            return false;
-        }
-#endif
     } // namespace details
 
 #ifdef _CRT_APP


### PR DESCRIPTION
With the adoption of WinUI3 (via Windows App SDK), Desktop Xaml apps are now supported. However, ppltasks client code in a Desktop app would fail to capture the apartment context for continuation callbacks, by default (globally, without needing to pass an explicit task_continuation_context to every continuation). This PR fixes that bug.

For C++/CX client code (which may be in process of migration to Desktop C++/WinRT code), no other changes are needed.

For ISO C++ client code, this fix builds on work to recover ppltasks functionality lost during the UCRT migration (see https://www.osgwiki.com/wiki/Universal_CRT#PPL_Tasks  for details), which requires adding
`#define PPL_TASK_CONTEXT_ERROR_CONTROL 1 `
to opt into using context callbacks and error reporting (UWP behavior).

Note that C++/CLI does not support ppltasks.h: fatal error C1189: #error: <condition_variable> is not supported when compiling with /clr or /clr:pure

If previous behavior is desired (callbacks on an arbitrary continuation thread), code can add
`#define PPL_TASK_CONTEXT_DEFAULT_ARBITRARY 1`
C++/CX code can also explicitly pass concurrency::task_continuation_context::use_arbitrary() to then().

The fix requires CoGetApartmentType and CoGetObjectContext, in turn requiring Windows 7 or later. This dependency is handled by a #pragma comment ( lib, "ole32" ) in ppltasks.cpp. In addition, msvcp140.dll is built with delay-loaded ole32, so that applications can continue to be deployed to Vista, if this code is not used. Support for OneCore SKUs is assumed to be handled by ApiSet reverse-forwarding from the ole32.dll linkage. No compile time checks against WINVER/_WIN32_WINNT have been added, as the docs officially state Windows 7 as the base supported version for Visual Studio.