### PR TITLE
Annotate some functions `_MSVC_CONSTEXPR`

### DIFF
--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -474,7 +474,7 @@ namespace ranges {
             noexcept(noexcept(::new (const_cast<void*>(static_cast<const volatile void*>(_Location)))
                     _Ty(_STD forward<_Types>(_Args)...))) /* strengthened */ {
             // clang-format on
-            return ::new (const_cast<void*>(static_cast<const volatile void*>(_Location)))
+            _MSVC_CONSTEXPR return ::new (const_cast<void*>(static_cast<const volatile void*>(_Location)))
                 _Ty(_STD forward<_Types>(_Args)...);
         }
     };

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -222,7 +222,7 @@ template <class _Ty, class... _Types,
     class = void_t<decltype(::new (_STD declval<void*>()) _Ty(_STD declval<_Types>()...))>>
 constexpr _Ty* construct_at(_Ty* const _Location, _Types&&... _Args) noexcept(
     noexcept(::new (_Voidify_iter(_Location)) _Ty(_STD forward<_Types>(_Args)...))) /* strengthened */ {
-    return ::new (_Voidify_iter(_Location)) _Ty(_STD forward<_Types>(_Args)...);
+    _MSVC_CONSTEXPR return ::new (_Voidify_iter(_Location)) _Ty(_STD forward<_Types>(_Args)...);
 }
 #endif // _HAS_CXX20
 

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -1546,5 +1546,9 @@ compiler option, or define _ALLOW_RTCc_IN_STL to acknowledge that you have recei
 #define _STL_INTERNAL_STATIC_ASSERT(...)
 #endif // _ENABLE_STL_INTERNAL_CHECK
 
+#ifndef _MSVC_CONSTEXPR // TRANSITION, VS2022v17.3p2
+#define _MSVC_CONSTEXPR
+#endif
+
 #endif // _STL_COMPILER_PREPROCESSOR
 #endif // _YVALS_CORE_H_


### PR DESCRIPTION
Which is meaningless now, but will eventually become `[[msvc::constexpr]]` when VCRuntime changes (and the corresponding compiler) ship.

This mirrors internal MSVC-PR-391437.
