### PR TITLE
`<xloctime>`: apply two-digit year logic only if exactly two digits are read

### DIFF
--- a/stl/inc/xloctime
+++ b/stl/inc/xloctime
@@ -416,7 +416,7 @@ protected:
 
         _State |= _Res; // pass on eofbit and failbit
         if (!(_Res & ios_base::failbit)) {
-            if (_Digits_read == 2) {
+            if (_Digits_read <= 2) {
                 if (_Ans < 69) {
                     _Pt->tm_year = _Ans + 100; // [00, 68] parsed as [2000, 2068]
                 } else if (_Ans < 100) {
@@ -555,7 +555,10 @@ protected:
             break;
 
         case 'Y':
-            _First = get_year(_First, _Last, _Iosbase, _State, _Pt);
+            _State |= _Getint(_First, _Last, 0, 9999, _Ans, _Ctype_fac);
+            if (!(_State & ios_base::failbit)) {
+                _Pt->tm_year = _Ans - 1900;
+            }
             break;
 
         default:

--- a/stl/inc/xloctime
+++ b/stl/inc/xloctime
@@ -598,8 +598,8 @@ protected:
 
 private:
     ios_base::iostate __CLRCALL_OR_CDECL _Getint(_InIt& _First, _InIt& _Last, int _Lo, int _Hi, int& _Val,
-        // TRANSITION, ABI
         const _Ctype& _Ctype_fac) const { // get integer in range [_Lo, _Hi] from [_First, _Last)
+        // TRANSITION, ABI
         int _Digits_read;
         return _Getint_v2(_First, _Last, _Lo, _Hi, _Val, _Digits_read, _Ctype_fac);
     }

--- a/stl/inc/xloctime
+++ b/stl/inc/xloctime
@@ -47,9 +47,8 @@ ios_base::iostate _Getint_v2(_InIt& _First, _InIt& _Last, int _Lo, int _Hi, int&
         }
     }
 
-    for (; _First != _Last && _Digits_read < _Hi_digits && _Ctype_fac.narrow(*_First) == '0';
-         ++_First) { // strip leading zeros
-        ++_Digits_read;
+    for (; _First != _Last && _Digits_read < _Hi_digits && _Ctype_fac.narrow(*_First) == '0'; ++_First) {
+        ++_Digits_read; // strip leading zeros
     }
 
     if (_Digits_read > 0) {

--- a/stl/inc/xloctime
+++ b/stl/inc/xloctime
@@ -20,7 +20,7 @@ _STL_DISABLE_CLANG_WARNINGS
 #undef new
 
 _STD_BEGIN
-template <class _InIt, class _Elem = typename iterator_traits<_InIt>::value_type>
+template <class _InIt, class _Elem>
 ios_base::iostate _Getint_v2(_InIt& _First, _InIt& _Last, int _Lo, int _Hi, int& _Val, int& _Digits_read,
     const ctype<_Elem>& _Ctype_fac) { // get integer in range [_Lo, _Hi] from [_First, _Last)
     _STL_INTERNAL_CHECK(0 <= _Hi && _Hi <= 9999);

--- a/stl/inc/xloctime
+++ b/stl/inc/xloctime
@@ -20,9 +20,9 @@ _STL_DISABLE_CLANG_WARNINGS
 #undef new
 
 _STD_BEGIN
-template <class _InIt>
+template <class _InIt, class _Elem = typename iterator_traits<_InIt>::value_type>
 ios_base::iostate _Getint_v2(_InIt& _First, _InIt& _Last, int _Lo, int _Hi, int& _Val, int& _Digits_read,
-    const ctype<typename _InIt::value_type>& _Ctype_fac) { // get integer in range [_Lo, _Hi] from [_First, _Last)
+    const ctype<_Elem>& _Ctype_fac) { // get integer in range [_Lo, _Hi] from [_First, _Last)
     _STL_INTERNAL_CHECK(0 <= _Hi && _Hi <= 9999);
     const int _Hi_digits = (_Hi <= 9 ? 1 : _Hi <= 99 ? 2 : _Hi <= 999 ? 3 : 4);
     char _Ac[_MAX_INT_DIG];

--- a/stl/inc/xloctime
+++ b/stl/inc/xloctime
@@ -20,6 +20,73 @@ _STL_DISABLE_CLANG_WARNINGS
 #undef new
 
 _STD_BEGIN
+template <class _InIt>
+ios_base::iostate _Getint_v2(_InIt& _First, _InIt& _Last, int _Lo, int _Hi, int& _Val, int& _Digits_read,
+    const ctype<typename _InIt::value_type>& _Ctype_fac) { // get integer in range [_Lo, _Hi] from [_First, _Last)
+    _STL_INTERNAL_CHECK(0 <= _Hi && _Hi <= 9999);
+    const int _Hi_digits = (_Hi <= 9 ? 1 : _Hi <= 99 ? 2 : _Hi <= 999 ? 3 : 4);
+    char _Ac[_MAX_INT_DIG];
+    char* _Ep;
+    char* _Ptr = _Ac;
+    char _Ch;
+
+    _Digits_read = 0;
+
+    while (_First != _Last && _Digits_read < _Hi_digits && _Ctype_fac.is(ctype_base::space, *_First)) {
+        ++_First;
+        ++_Digits_read;
+    }
+
+    if (_First != _Last && _Digits_read < _Hi_digits) {
+        if ((_Ch = _Ctype_fac.narrow(*_First)) == '+') { // copy plus sign
+            *_Ptr++ = '+';
+            ++_First;
+        } else if (_Ch == '-') { // copy minus sign
+            *_Ptr++ = '-';
+            ++_First;
+        }
+    }
+
+    for (; _First != _Last && _Digits_read < _Hi_digits && _Ctype_fac.narrow(*_First) == '0';
+         ++_First) { // strip leading zeros
+        ++_Digits_read;
+    }
+
+    if (_Digits_read > 0) {
+        *_Ptr++ = '0'; // replace one or more with single zero
+    }
+
+    for (char* const _Pe = &_Ac[_MAX_INT_DIG - 1];
+         _First != _Last && '0' <= (_Ch = _Ctype_fac.narrow(*_First)) && _Ch <= '9' && _Digits_read < _Hi_digits;
+         ++_Digits_read, (void) ++_First) { // copy digits
+        *_Ptr = _Ch;
+        if (_Ptr < _Pe) {
+            ++_Ptr; // drop trailing digits if already too large
+        }
+    }
+
+    if (_Digits_read == 0) {
+        _Ptr = _Ac;
+    }
+
+    *_Ptr                    = '\0';
+    int _Errno               = 0;
+    const long _Ans          = _CSTD _Stolx(_Ac, &_Ep, 10, &_Errno);
+    ios_base::iostate _State = ios_base::goodbit;
+
+    if (_First == _Last) {
+        _State |= ios_base::eofbit;
+    }
+
+    if (_Ep == _Ac || _Errno != 0 || _Ans < _Lo || _Hi < _Ans) {
+        _State |= ios_base::failbit; // bad conversion
+    } else {
+        _Val = _Ans; // store valid result
+    }
+
+    return _State;
+}
+
 struct _CRTIMP2_PURE_IMPORT time_base : locale::facet { // base class for time_get
     enum dateorder { // constants for different orders of date components
         no_order,
@@ -343,17 +410,20 @@ protected:
         ios_base::iostate& _State, tm* _Pt) const { // get year from [_First, _Last) into _Pt
         const _Ctype& _Ctype_fac = _STD use_facet<_Ctype>(_Iosbase.getloc());
 
-        int _Ans               = 0;
-        ios_base::iostate _Res = _Getint(_First, _Last, 0, 9999, _Ans, _Ctype_fac);
+        int _Ans = 0;
+        int _Digits_read;
+        ios_base::iostate _Res = _Getint_v2(_First, _Last, 0, 9999, _Ans, _Digits_read, _Ctype_fac);
 
         _State |= _Res; // pass on eofbit and failbit
         if (!(_Res & ios_base::failbit)) {
-            if (_Ans < 69) {
-                _Pt->tm_year = _Ans + 100; // [0, 68] parsed as [2000, 2068]
-            } else if (_Ans < 100) {
-                _Pt->tm_year = _Ans; // [69, 99] parsed as [1969, 1999]
+            if (_Digits_read == 2) {
+                if (_Ans < 69) {
+                    _Pt->tm_year = _Ans + 100; // [00, 68] parsed as [2000, 2068]
+                } else if (_Ans < 100) {
+                    _Pt->tm_year = _Ans; // [69, 99] parsed as [1969, 1999]
+                }
             } else {
-                _Pt->tm_year = _Ans - 1900; // [100, 9999] parsed literally
+                _Pt->tm_year = _Ans - 1900; // parsed literally
             }
         }
 
@@ -528,69 +598,10 @@ protected:
 
 private:
     ios_base::iostate __CLRCALL_OR_CDECL _Getint(_InIt& _First, _InIt& _Last, int _Lo, int _Hi, int& _Val,
+        // TRANSITION, ABI
         const _Ctype& _Ctype_fac) const { // get integer in range [_Lo, _Hi] from [_First, _Last)
-        _STL_INTERNAL_CHECK(0 <= _Hi && _Hi <= 9999);
-        const int _Hi_digits = (_Hi <= 9 ? 1 : _Hi <= 99 ? 2 : _Hi <= 999 ? 3 : 4);
-        char _Ac[_MAX_INT_DIG];
-        char* _Ep;
-        char* _Ptr = _Ac;
-        char _Ch;
-
-        int _Digits_seen = 0;
-
-        while (_First != _Last && _Digits_seen < _Hi_digits && _Ctype_fac.is(ctype_base::space, *_First)) {
-            ++_First;
-            ++_Digits_seen;
-        }
-
-        if (_First != _Last && _Digits_seen < _Hi_digits) {
-            if ((_Ch = _Ctype_fac.narrow(*_First)) == '+') { // copy plus sign
-                *_Ptr++ = '+';
-                ++_First;
-            } else if (_Ch == '-') { // copy minus sign
-                *_Ptr++ = '-';
-                ++_First;
-            }
-        }
-
-        for (; _First != _Last && _Digits_seen < _Hi_digits && _Ctype_fac.narrow(*_First) == '0';
-             ++_First) { // strip leading zeros
-            ++_Digits_seen;
-        }
-
-        if (_Digits_seen > 0) {
-            *_Ptr++ = '0'; // replace one or more with single zero
-        }
-
-        for (char* const _Pe = &_Ac[_MAX_INT_DIG - 1];
-             _First != _Last && '0' <= (_Ch = _Ctype_fac.narrow(*_First)) && _Ch <= '9' && _Digits_seen < _Hi_digits;
-             ++_Digits_seen, (void) ++_First) { // copy digits
-            *_Ptr = _Ch;
-            if (_Ptr < _Pe) {
-                ++_Ptr; // drop trailing digits if already too large
-            }
-        }
-
-        if (_Digits_seen == 0) {
-            _Ptr = _Ac;
-        }
-
-        *_Ptr                    = '\0';
-        int _Errno               = 0;
-        const long _Ans          = _CSTD _Stolx(_Ac, &_Ep, 10, &_Errno);
-        ios_base::iostate _State = ios_base::goodbit;
-
-        if (_First == _Last) {
-            _State |= ios_base::eofbit;
-        }
-
-        if (_Ep == _Ac || _Errno != 0 || _Ans < _Lo || _Hi < _Ans) {
-            _State |= ios_base::failbit; // bad conversion
-        } else {
-            _Val = _Ans; // store valid result
-        }
-
-        return _State;
+        int _Digits_read;
+        return _Getint_v2(_First, _Last, _Lo, _Hi, _Val, _Digits_read, _Ctype_fac);
     }
 
     void __CLR_OR_THIS_CALL _Tidy() noexcept { // free all storage

--- a/tests/std/tests/Dev11_0836436_get_time/test.cpp
+++ b/tests/std/tests/Dev11_0836436_get_time/test.cpp
@@ -18,7 +18,7 @@ using namespace std;
 // DevDiv-821672 "<locale>: visual studio.net 2013 time libraries buggy (%x %X) - time_get"
 // DevDiv-836436 "<iomanip>: get_time()'s AM/PM parsing is broken"
 // DevDiv-872926 "<locale>: time_get::get parsing format string gets tm::tm_hour wrong [libcxx]"
-// DevDiv-1259138/GH-2618 "<xloctime>: get_time does not return correct year in tm.tm_year if year is 1"
+// VSO-1259138/GH-2618 "<xloctime>: get_time does not return correct year in tm.tm_year if year is 1"
 
 tm helper(const char* const s, const char* const fmt) {
     tm t{};
@@ -851,7 +851,7 @@ void test_gh_2618() {
         }
     };
 
-    // 4-digit strings: 'y' should only read the first two digits, 'Y' and  `get_year` should agree
+    // 4-digit strings: 'y' should only read the first two digits, 'Y' and `get_year` should agree
     TestTimeGetYear("0001", 2000, 1, 1);
     TestTimeGetYear("0080", 2000, 80, 80);
     TestTimeGetYear("1995", 2019, 1995, 1995);


### PR DESCRIPTION
Fixes #2618.

ABI note: this replaces a call to the separately-compiled function `_Getint` with a call to the header-only function `_Getint_v2`. The two functions are virtually identical, so `_Getint` is rewritten as a wrapper that discards the number of digits read. I think both of these changes are safe, but want to highlight them for closer scrutiny.