### PR TITLE
<system_error>: explicitly pass the system locale ID for system_category messages

### DIFF
--- a/stl/src/syserror_import_lib.cpp
+++ b/stl/src/syserror_import_lib.cpp
@@ -47,7 +47,7 @@ _NODISCARD size_t __CLRCALL_PURE_OR_STDCALL __std_system_error_allocate_message(
     // pre: *_Ptr_str == nullptr
     const unsigned long _Chars =
         FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-            nullptr, _Message_id, 0, reinterpret_cast<char*>(_Ptr_str), 0, nullptr);
+            nullptr, _Message_id, GetSystemDefaultLangID(), reinterpret_cast<char*>(_Ptr_str), 0, nullptr);
 
     return _CSTD __std_get_string_size_without_trailing_whitespace(*_Ptr_str, _Chars);
 }

--- a/stl/src/syserror_import_lib.cpp
+++ b/stl/src/syserror_import_lib.cpp
@@ -42,15 +42,15 @@ _NODISCARD size_t __CLRCALL_PURE_OR_STDCALL __std_get_string_size_without_traili
 
 _NODISCARD size_t __CLRCALL_PURE_OR_STDCALL __std_system_error_allocate_message(
     const unsigned long _Message_id, char** const _Ptr_str) noexcept {
+    // convert to name of Windows error, return 0 for failure, otherwise return number of chars in buffer
+    // __std_system_error_deallocate_message should be called even if 0 is returned
+    // pre: *_Ptr_str == nullptr
     DWORD _Lang_id;
     const int _Ret = GetLocaleInfoEx(LOCALE_NAME_SYSTEM_DEFAULT, LOCALE_ILANGUAGE | LOCALE_RETURN_NUMBER,
         reinterpret_cast<LPWSTR>(&_Lang_id), sizeof(_Lang_id) / sizeof(wchar_t));
     if (_Ret == 0) {
         _Lang_id = 0;
     }
-    // convert to name of Windows error, return 0 for failure, otherwise return number of chars in buffer
-    // __std_system_error_deallocate_message should be called even if 0 is returned
-    // pre: *_Ptr_str == nullptr
     const unsigned long _Chars =
         FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
             nullptr, _Message_id, _Lang_id, reinterpret_cast<char*>(_Ptr_str), 0, nullptr);

--- a/stl/src/syserror_import_lib.cpp
+++ b/stl/src/syserror_import_lib.cpp
@@ -42,12 +42,18 @@ _NODISCARD size_t __CLRCALL_PURE_OR_STDCALL __std_get_string_size_without_traili
 
 _NODISCARD size_t __CLRCALL_PURE_OR_STDCALL __std_system_error_allocate_message(
     const unsigned long _Message_id, char** const _Ptr_str) noexcept {
+    DWORD _Lang_id;
+    const int _Ret = GetLocaleInfoEx(LOCALE_NAME_SYSTEM_DEFAULT, LOCALE_ILANGUAGE | LOCALE_RETURN_NUMBER,
+        reinterpret_cast<LPWSTR>(&_Lang_id), sizeof(_Lang_id) / sizeof(wchar_t));
+    if (_Ret == 0) {
+        _Lang_id = 0;
+    }
     // convert to name of Windows error, return 0 for failure, otherwise return number of chars in buffer
     // __std_system_error_deallocate_message should be called even if 0 is returned
     // pre: *_Ptr_str == nullptr
     const unsigned long _Chars =
         FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-            nullptr, _Message_id, GetSystemDefaultLangID(), reinterpret_cast<char*>(_Ptr_str), 0, nullptr);
+            nullptr, _Message_id, _Lang_id, reinterpret_cast<char*>(_Ptr_str), 0, nullptr);
 
     return _CSTD __std_get_string_size_without_trailing_whitespace(*_Ptr_str, _Chars);
 }


### PR DESCRIPTION
Fixes #2451 

```c++
type main.cpp
#include <clocale>
#include <iostream>
#include <string>

#include <Windows.h>

int main() {
    setlocale(LC_ALL, "");
    auto file_handle(CreateFile(
        L"D:\\non_exist_file.txt", GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL));
    if (file_handle == INVALID_HANDLE_VALUE) {
        const auto error_code = GetLastError();
        std::string errmsg    = std::system_category().message(error_code); // Sometimes the string only contains "???"
        std::cout << errmsg << '\n';
    }
}
```

If we have different “user language id” and “system language id” (this is how we can reach it: https://github.com/microsoft/STL/issues/2451#issuecomment-1107744166) FormatMessageA can choose “user language id” instead of “system language id” if we pass 0.

Before
```
>main
??????? ?? ??????? ????? ????????? ????.
```
After
```
>main
The system cannot find the path specified.
```