### PR TITLE
Cleanups 1: Comments and formatting

### DIFF
--- a/stl/inc/complex
+++ b/stl/inc/complex
@@ -1856,10 +1856,10 @@ _NODISCARD complex<_Ty> exp(const complex<_Ty>& _Left) {
 }
 
 template <class _Ty>
-_Ty _Fabs(const complex<_Ty>& _Left, int* _Pexp) { // Used by sqrt(), return magnitude and scale factor.
-                                                   // Returns a non-zero even integer in *_Pexp when _Left is finite
-                                                   // and non-zero.
-                                                   // Returns 0 in *_Pexp when _Left is zero, infinity, or NaN.
+_Ty _Fabs(const complex<_Ty>& _Left, int* _Pexp) {
+    // Used by sqrt(), return magnitude and scale factor.
+    // Returns a non-zero even integer in *_Pexp when _Left is finite and non-zero.
+    // Returns 0 in *_Pexp when _Left is zero, infinity, or NaN.
     *_Pexp  = 0;
     _Ty _Av = _Ctraits<_Ty>::_Abs(_STD real(_Left));
     _Ty _Bv = _Ctraits<_Ty>::_Abs(_STD imag(_Left));

--- a/stl/inc/cstddef
+++ b/stl/inc/cstddef
@@ -28,63 +28,64 @@ using max_align_t = double; // most aligned type
 enum class byte : unsigned char {};
 
 template <class _IntType, enable_if_t<is_integral_v<_IntType>, int> = 0>
-_NODISCARD constexpr byte operator<<(
-    const byte _Arg, const _IntType _Shift) noexcept { // bitwise LEFT SHIFT, every static_cast is intentional
+_NODISCARD constexpr byte operator<<(const byte _Arg, const _IntType _Shift) noexcept {
+    // every static_cast is intentional
     return static_cast<byte>(static_cast<unsigned char>(static_cast<unsigned int>(_Arg) << _Shift));
 }
 
 template <class _IntType, enable_if_t<is_integral_v<_IntType>, int> = 0>
-_NODISCARD constexpr byte operator>>(
-    const byte _Arg, const _IntType _Shift) noexcept { // bitwise RIGHT SHIFT, every static_cast is intentional
+_NODISCARD constexpr byte operator>>(const byte _Arg, const _IntType _Shift) noexcept {
+    // every static_cast is intentional
     return static_cast<byte>(static_cast<unsigned char>(static_cast<unsigned int>(_Arg) >> _Shift));
 }
 
-_NODISCARD constexpr byte operator|(
-    const byte _Left, const byte _Right) noexcept { // bitwise OR, every static_cast is intentional
+_NODISCARD constexpr byte operator|(const byte _Left, const byte _Right) noexcept {
+    // every static_cast is intentional
     return static_cast<byte>(
         static_cast<unsigned char>(static_cast<unsigned int>(_Left) | static_cast<unsigned int>(_Right)));
 }
 
-_NODISCARD constexpr byte operator&(
-    const byte _Left, const byte _Right) noexcept { // bitwise AND, every static_cast is intentional
+_NODISCARD constexpr byte operator&(const byte _Left, const byte _Right) noexcept {
+    // every static_cast is intentional
     return static_cast<byte>(
         static_cast<unsigned char>(static_cast<unsigned int>(_Left) & static_cast<unsigned int>(_Right)));
 }
 
-_NODISCARD constexpr byte operator^(
-    const byte _Left, const byte _Right) noexcept { // bitwise XOR, every static_cast is intentional
+_NODISCARD constexpr byte operator^(const byte _Left, const byte _Right) noexcept {
+    // every static_cast is intentional
     return static_cast<byte>(
         static_cast<unsigned char>(static_cast<unsigned int>(_Left) ^ static_cast<unsigned int>(_Right)));
 }
 
-_NODISCARD constexpr byte operator~(const byte _Arg) noexcept { // bitwise NOT, every static_cast is intentional
+_NODISCARD constexpr byte operator~(const byte _Arg) noexcept {
+    // every static_cast is intentional
     return static_cast<byte>(static_cast<unsigned char>(~static_cast<unsigned int>(_Arg)));
 }
 
 template <class _IntType, enable_if_t<is_integral_v<_IntType>, int> = 0>
-constexpr byte& operator<<=(byte& _Arg, const _IntType _Shift) noexcept { // bitwise LEFT SHIFT
+constexpr byte& operator<<=(byte& _Arg, const _IntType _Shift) noexcept {
     return _Arg = _Arg << _Shift;
 }
 
 template <class _IntType, enable_if_t<is_integral_v<_IntType>, int> = 0>
-constexpr byte& operator>>=(byte& _Arg, const _IntType _Shift) noexcept { // bitwise RIGHT SHIFT
+constexpr byte& operator>>=(byte& _Arg, const _IntType _Shift) noexcept {
     return _Arg = _Arg >> _Shift;
 }
 
-constexpr byte& operator|=(byte& _Left, const byte _Right) noexcept { // bitwise OR
+constexpr byte& operator|=(byte& _Left, const byte _Right) noexcept {
     return _Left = _Left | _Right;
 }
 
-constexpr byte& operator&=(byte& _Left, const byte _Right) noexcept { // bitwise AND
+constexpr byte& operator&=(byte& _Left, const byte _Right) noexcept {
     return _Left = _Left & _Right;
 }
 
-constexpr byte& operator^=(byte& _Left, const byte _Right) noexcept { // bitwise XOR
+constexpr byte& operator^=(byte& _Left, const byte _Right) noexcept {
     return _Left = _Left ^ _Right;
 }
 
 template <class _IntType, enable_if_t<is_integral_v<_IntType>, int> = 0>
-_NODISCARD constexpr _IntType to_integer(const byte _Arg) noexcept { // convert byte to integer
+_NODISCARD constexpr _IntType to_integer(const byte _Arg) noexcept {
     return static_cast<_IntType>(_Arg);
 }
 #endif // __cpp_lib_byte

--- a/stl/inc/exception
+++ b/stl/inc/exception
@@ -40,7 +40,8 @@ using ::terminate;
 using ::set_terminate;
 using ::terminate_handler;
 
-_NODISCARD inline terminate_handler __CRTDECL get_terminate() noexcept { // get current terminate handler
+_NODISCARD inline terminate_handler __CRTDECL get_terminate() noexcept {
+    // get current terminate handler
     return _get_terminate();
 }
 #endif // _M_CEE_PURE
@@ -52,7 +53,8 @@ using ::unexpected;
 using ::set_unexpected;
 using ::unexpected_handler;
 
-_NODISCARD inline unexpected_handler __CRTDECL get_unexpected() noexcept { // get current unexpected handler
+_NODISCARD inline unexpected_handler __CRTDECL get_unexpected() noexcept {
+    // get current unexpected handler
     return _get_unexpected();
 }
 #endif // _M_CEE_PURE
@@ -159,28 +161,33 @@ _STDEXT_END
 _STD_BEGIN
 using terminate_handler = void(__cdecl*)();
 
-inline terminate_handler __CRTDECL set_terminate(terminate_handler) noexcept { // register a terminate handler
+inline terminate_handler __CRTDECL set_terminate(terminate_handler) noexcept {
+    // register a terminate handler
     return nullptr;
 }
 
-[[noreturn]] inline void __CRTDECL terminate() noexcept { // handle exception termination
+[[noreturn]] inline void __CRTDECL terminate() noexcept {
+    // handle exception termination
     _CSTD abort();
 }
 
-_NODISCARD inline terminate_handler __CRTDECL get_terminate() noexcept { // get current terminate handler
+_NODISCARD inline terminate_handler __CRTDECL get_terminate() noexcept {
+    // get current terminate handler
     return nullptr;
 }
 
 #if _HAS_UNEXPECTED
 using unexpected_handler = void(__cdecl*)();
 
-inline unexpected_handler __CRTDECL set_unexpected(unexpected_handler) noexcept { // register an unexpected handler
+inline unexpected_handler __CRTDECL set_unexpected(unexpected_handler) noexcept {
+    // register an unexpected handler
     return nullptr;
 }
 
 inline void __CRTDECL unexpected() {} // handle unexpected exception
 
-_NODISCARD inline unexpected_handler __CRTDECL get_unexpected() noexcept { // get current unexpected handler
+_NODISCARD inline unexpected_handler __CRTDECL get_unexpected() noexcept {
+    // get current unexpected handler
     return nullptr;
 }
 #endif // _HAS_UNEXPECTED
@@ -349,7 +356,8 @@ struct _With_nested : _Uty, nested_exception { // glue user exception to nested_
 };
 
 template <class _Ty>
-[[noreturn]] void throw_with_nested(_Ty&& _Arg) { // throw user exception, glued to nested_exception if possible
+[[noreturn]] void throw_with_nested(_Ty&& _Arg) {
+    // throw user exception, glued to nested_exception if possible
     using _Uty = decay_t<_Ty>;
 
     if constexpr (is_class_v<_Uty> && !is_base_of_v<nested_exception, _Uty> && !is_final_v<_Uty>) {
@@ -364,7 +372,8 @@ template <class _Ty>
 
 #ifdef _CPPRTTI
 template <class _Ty>
-void rethrow_if_nested(const _Ty& _Arg) { // detect nested_exception inheritance
+void rethrow_if_nested(const _Ty& _Arg) {
+    // detect nested_exception inheritance
     constexpr bool _Can_use_dynamic_cast =
         is_polymorphic_v<_Ty> && (!is_base_of_v<nested_exception, _Ty> || is_convertible_v<_Ty*, nested_exception*>);
 

--- a/stl/inc/filesystem
+++ b/stl/inc/filesystem
@@ -2019,8 +2019,8 @@ namespace filesystem {
         perms _Myperms     = perms::unknown;
     };
 
-    _NODISCARD inline bool exists(
-        const file_status _Status) noexcept { // tests whether _Status indicates an existing file
+    _NODISCARD inline bool exists(const file_status _Status) noexcept {
+        // tests whether _Status indicates an existing file
         switch (_Status.type()) {
         case file_type::none:
         case file_type::not_found:
@@ -3449,7 +3449,8 @@ namespace filesystem {
         return _Error;
     }
 
-    _NODISCARD inline uintmax_t hard_link_count(const path& _Target) { // get the number of hard links to _Target
+    _NODISCARD inline uintmax_t hard_link_count(const path& _Target) {
+        // get the number of hard links to _Target
         uintmax_t _Result;
         const auto _Err = _Hard_link_count(_Target.c_str(), _Result);
         if (_Err != __std_win_error::_Success) {
@@ -3488,7 +3489,8 @@ namespace filesystem {
         return false; // note status sets _Ec to an error on nonexistent input
     }
 
-    _NODISCARD inline bool is_directory(const path& _Path) { // tests whether _Path is a directory
+    _NODISCARD inline bool is_directory(const path& _Path) {
+        // tests whether _Path is a directory
         return _STD filesystem::is_directory(_STD filesystem::status(_Path));
     }
 
@@ -3538,7 +3540,8 @@ namespace filesystem {
         return false; // note status sets _Ec to an error on nonexistent input
     }
 
-    _NODISCARD inline bool is_other(const path& _Path) { // tests whether _Path is an other file (such as a junction)
+    _NODISCARD inline bool is_other(const path& _Path) {
+        // tests whether _Path is an other file (such as a junction)
         return _STD filesystem::is_other(_STD filesystem::status(_Path));
     }
 
@@ -3547,7 +3550,8 @@ namespace filesystem {
         return _STD filesystem::is_other(_STD filesystem::status(_Path, _Ec));
     }
 
-    _NODISCARD inline bool is_regular_file(const path& _Path) { // tests whether _Path is a regular file
+    _NODISCARD inline bool is_regular_file(const path& _Path) {
+        // tests whether _Path is a regular file
         return _STD filesystem::is_regular_file(_STD filesystem::status(_Path));
     }
 
@@ -3567,11 +3571,13 @@ namespace filesystem {
         return false; // note status sets _Ec to an error on nonexistent input
     }
 
-    _NODISCARD inline bool is_symlink(const path& _Path) { // tests whether _Path is a symlink
+    _NODISCARD inline bool is_symlink(const path& _Path) {
+        // tests whether _Path is a symlink
         return _STD filesystem::is_symlink(_STD filesystem::symlink_status(_Path));
     }
 
-    _NODISCARD inline bool is_symlink(const path& _Path, error_code& _Ec) noexcept { // tests whether _Path is a symlink
+    _NODISCARD inline bool is_symlink(const path& _Path, error_code& _Ec) noexcept {
+        // tests whether _Path is a symlink
         return _STD filesystem::is_symlink(_STD filesystem::symlink_status(_Path, _Ec));
     }
 
@@ -3846,7 +3852,8 @@ namespace filesystem {
         }
     }
 
-    inline uintmax_t remove_all(const path& _Path, error_code& _Ec) { // remove _Path, including any contents
+    inline uintmax_t remove_all(const path& _Path, error_code& _Ec) {
+        // remove _Path, including any contents
         _Ec.clear(); // for exception safety
         const auto _First_remove_result = __std_fs_remove(_Path.c_str());
         uintmax_t _Removed_count        = _First_remove_result._Removed;

--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -3448,13 +3448,14 @@ void make_unique(_Types&&...) = delete;
 
 #if _HAS_CXX20
 template <class _Ty, enable_if_t<!is_array_v<_Ty>, int> = 0>
-_NODISCARD _CONSTEXPR23 unique_ptr<_Ty> make_unique_for_overwrite() { // make a unique_ptr with default initialization
+_NODISCARD _CONSTEXPR23 unique_ptr<_Ty> make_unique_for_overwrite() {
+    // make a unique_ptr with default initialization
     return unique_ptr<_Ty>(new _Ty);
 }
 
 template <class _Ty, enable_if_t<is_unbounded_array_v<_Ty>, int> = 0>
-_NODISCARD _CONSTEXPR23 unique_ptr<_Ty> make_unique_for_overwrite(
-    const size_t _Size) { // make a unique_ptr with default initialization
+_NODISCARD _CONSTEXPR23 unique_ptr<_Ty> make_unique_for_overwrite(const size_t _Size) {
+    // make a unique_ptr with default initialization
     using _Elem = remove_extent_t<_Ty>;
     return unique_ptr<_Ty>(new _Elem[_Size]);
 }

--- a/stl/inc/ostream
+++ b/stl/inc/ostream
@@ -163,17 +163,19 @@ public:
     }
 
 #ifdef _M_CEE_PURE
-    basic_ostream& __CLR_OR_THIS_CALL operator<<(
-        basic_ostream&(__clrcall* _Pfn)(basic_ostream&) ) { // call basic_ostream manipulator
+    basic_ostream& __CLR_OR_THIS_CALL operator<<(basic_ostream&(__clrcall* _Pfn)(basic_ostream&) ) {
+        // call basic_ostream manipulator
         return _Pfn(*this);
     }
 
-    basic_ostream& __CLR_OR_THIS_CALL operator<<(_Myios&(__clrcall* _Pfn)(_Myios&) ) { // call basic_ios manipulator
+    basic_ostream& __CLR_OR_THIS_CALL operator<<(_Myios&(__clrcall* _Pfn)(_Myios&) ) {
+        // call basic_ios manipulator
         _Pfn(*this);
         return *this;
     }
 
-    basic_ostream& __CLR_OR_THIS_CALL operator<<(ios_base&(__clrcall* _Pfn)(ios_base&) ) { // call ios_base manipulator
+    basic_ostream& __CLR_OR_THIS_CALL operator<<(ios_base&(__clrcall* _Pfn)(ios_base&) ) {
+        // call ios_base manipulator
         _Pfn(*this);
         return *this;
     }
@@ -184,12 +186,14 @@ public:
         return _Pfn(*this);
     }
 
-    basic_ostream& __CLR_OR_THIS_CALL operator<<(_Myios&(__cdecl* _Pfn)(_Myios&) ) { // call basic_ios manipulator
+    basic_ostream& __CLR_OR_THIS_CALL operator<<(_Myios&(__cdecl* _Pfn)(_Myios&) ) {
+        // call basic_ios manipulator
         _Pfn(*this);
         return *this;
     }
 
-    basic_ostream& __CLR_OR_THIS_CALL operator<<(ios_base&(__cdecl* _Pfn)(ios_base&) ) { // call ios_base manipulator
+    basic_ostream& __CLR_OR_THIS_CALL operator<<(ios_base&(__cdecl* _Pfn)(ios_base&) ) {
+        // call ios_base manipulator
         _Pfn(*this);
         return *this;
     }

--- a/stl/inc/random
+++ b/stl/inc/random
@@ -4218,10 +4218,8 @@ public:
         }
 
         void _Init(_Ty _Kx0, double _Px0) { // initialize
-            _STL_ASSERT(0.0 < _Kx0, "invalid max argument for "
-                                    "negative_binomial_distribution");
-            _STL_ASSERT(0.0 < _Px0 && _Px0 <= 1.0, "invalid probability argument for "
-                                                   "negative_binomial_distribution");
+            _STL_ASSERT(0.0 < _Kx0, "invalid max argument for negative_binomial_distribution");
+            _STL_ASSERT(0.0 < _Px0 && _Px0 <= 1.0, "invalid probability argument for negative_binomial_distribution");
             _Kx = _Kx0;
             _Px = _Px0;
         }
@@ -4799,16 +4797,13 @@ public:
                 } else { // normalize probabilities
                     double _Sum = 0;
 
-                    _STL_ASSERT(0.0 <= this->_Pvec[0], "invalid probability for "
-                                                       "piecewise_linear_distribution");
+                    _STL_ASSERT(0.0 <= this->_Pvec[0], "invalid probability for piecewise_linear_distribution");
                     for (_Idx = 1; _Idx < _Size; ++_Idx) { // sum all probabilities
-                        _STL_ASSERT(0.0 <= this->_Pvec[_Idx], "invalid probability for "
-                                                              "piecewise_linear_distribution");
+                        _STL_ASSERT(0.0 <= this->_Pvec[_Idx], "invalid probability for piecewise_linear_distribution");
                         _Sum += _Piece_probability(_Idx - 1);
                     }
 
-                    _STL_ASSERT(0.0 < _Sum, "invalid probability vector for "
-                                            "piecewise_linear_distribution");
+                    _STL_ASSERT(0.0 < _Sum, "invalid probability vector for piecewise_linear_distribution");
                     if (_Sum != 1.0) {
                         for (_Idx = 0; _Idx < _Size; ++_Idx) {
                             this->_Pvec[_Idx] /= _Sum;

--- a/stl/inc/random
+++ b/stl/inc/random
@@ -4892,7 +4892,6 @@ public:
         piecewise_linear_distribution& _Dist) { // read state from _Istr
         static_cast<piecewise_linear_distribution::_Mypbase&>(_Dist._Par)._Read(_Istr);
 
-
         _Dist._Par._Bvec.clear();
         for (size_t _Idx = _Dist._Par._Pvec.size(); 0 < _Idx; --_Idx) { // get a value and add to intervals vector
             double _Val;

--- a/stl/inc/string
+++ b/stl/inc/string
@@ -84,7 +84,6 @@ basic_istream<_Elem, _Traits>& getline(basic_istream<_Elem, _Traits>& _Istr,
 }
 
 _NODISCARD inline int stoi(const string& _Str, size_t* _Idx = nullptr, int _Base = 10) {
-    // convert string to int
     int& _Errno_ref  = errno; // Nonzero cost, pay it once
     const char* _Ptr = _Str.c_str();
     char* _Eptr;
@@ -107,7 +106,6 @@ _NODISCARD inline int stoi(const string& _Str, size_t* _Idx = nullptr, int _Base
 }
 
 _NODISCARD inline long stol(const string& _Str, size_t* _Idx = nullptr, int _Base = 10) {
-    // convert string to long
     int& _Errno_ref  = errno; // Nonzero cost, pay it once
     const char* _Ptr = _Str.c_str();
     char* _Eptr;
@@ -130,7 +128,6 @@ _NODISCARD inline long stol(const string& _Str, size_t* _Idx = nullptr, int _Bas
 }
 
 _NODISCARD inline unsigned long stoul(const string& _Str, size_t* _Idx = nullptr, int _Base = 10) {
-    // convert string to unsigned long
     int& _Errno_ref  = errno; // Nonzero cost, pay it once
     const char* _Ptr = _Str.c_str();
     char* _Eptr;
@@ -153,7 +150,6 @@ _NODISCARD inline unsigned long stoul(const string& _Str, size_t* _Idx = nullptr
 }
 
 _NODISCARD inline long long stoll(const string& _Str, size_t* _Idx = nullptr, int _Base = 10) {
-    // convert string to long long
     int& _Errno_ref  = errno; // Nonzero cost, pay it once
     const char* _Ptr = _Str.c_str();
     char* _Eptr;
@@ -176,7 +172,6 @@ _NODISCARD inline long long stoll(const string& _Str, size_t* _Idx = nullptr, in
 }
 
 _NODISCARD inline unsigned long long stoull(const string& _Str, size_t* _Idx = nullptr, int _Base = 10) {
-    // convert string to unsigned long long
     int& _Errno_ref  = errno; // Nonzero cost, pay it once
     const char* _Ptr = _Str.c_str();
     char* _Eptr;
@@ -198,7 +193,7 @@ _NODISCARD inline unsigned long long stoull(const string& _Str, size_t* _Idx = n
     return _Ans;
 }
 
-_NODISCARD inline float stof(const string& _Str, size_t* _Idx = nullptr) { // convert string to float
+_NODISCARD inline float stof(const string& _Str, size_t* _Idx = nullptr) {
     int& _Errno_ref  = errno; // Nonzero cost, pay it once
     const char* _Ptr = _Str.c_str();
     char* _Eptr;
@@ -220,7 +215,7 @@ _NODISCARD inline float stof(const string& _Str, size_t* _Idx = nullptr) { // co
     return _Ans;
 }
 
-_NODISCARD inline double stod(const string& _Str, size_t* _Idx = nullptr) { // convert string to double
+_NODISCARD inline double stod(const string& _Str, size_t* _Idx = nullptr) {
     int& _Errno_ref  = errno; // Nonzero cost, pay it once
     const char* _Ptr = _Str.c_str();
     char* _Eptr;
@@ -242,7 +237,7 @@ _NODISCARD inline double stod(const string& _Str, size_t* _Idx = nullptr) { // c
     return _Ans;
 }
 
-_NODISCARD inline long double stold(const string& _Str, size_t* _Idx = nullptr) { // convert string to long double
+_NODISCARD inline long double stold(const string& _Str, size_t* _Idx = nullptr) {
     int& _Errno_ref  = errno; // Nonzero cost, pay it once
     const char* _Ptr = _Str.c_str();
     char* _Eptr;
@@ -265,7 +260,6 @@ _NODISCARD inline long double stold(const string& _Str, size_t* _Idx = nullptr) 
 }
 
 _NODISCARD inline int stoi(const wstring& _Str, size_t* _Idx = nullptr, int _Base = 10) {
-    // convert wstring to int
     int& _Errno_ref     = errno; // Nonzero cost, pay it once
     const wchar_t* _Ptr = _Str.c_str();
     wchar_t* _Eptr;
@@ -288,7 +282,6 @@ _NODISCARD inline int stoi(const wstring& _Str, size_t* _Idx = nullptr, int _Bas
 }
 
 _NODISCARD inline long stol(const wstring& _Str, size_t* _Idx = nullptr, int _Base = 10) {
-    // convert wstring to long
     int& _Errno_ref     = errno; // Nonzero cost, pay it once
     const wchar_t* _Ptr = _Str.c_str();
     wchar_t* _Eptr;
@@ -311,7 +304,6 @@ _NODISCARD inline long stol(const wstring& _Str, size_t* _Idx = nullptr, int _Ba
 }
 
 _NODISCARD inline unsigned long stoul(const wstring& _Str, size_t* _Idx = nullptr, int _Base = 10) {
-    // convert wstring to unsigned long
     int& _Errno_ref     = errno; // Nonzero cost, pay it once
     const wchar_t* _Ptr = _Str.c_str();
     wchar_t* _Eptr;
@@ -334,7 +326,6 @@ _NODISCARD inline unsigned long stoul(const wstring& _Str, size_t* _Idx = nullpt
 }
 
 _NODISCARD inline long long stoll(const wstring& _Str, size_t* _Idx = nullptr, int _Base = 10) {
-    // convert wstring to long long
     int& _Errno_ref     = errno; // Nonzero cost, pay it once
     const wchar_t* _Ptr = _Str.c_str();
     wchar_t* _Eptr;
@@ -357,7 +348,6 @@ _NODISCARD inline long long stoll(const wstring& _Str, size_t* _Idx = nullptr, i
 }
 
 _NODISCARD inline unsigned long long stoull(const wstring& _Str, size_t* _Idx = nullptr, int _Base = 10) {
-    // convert wstring to unsigned long long
     int& _Errno_ref     = errno; // Nonzero cost, pay it once
     const wchar_t* _Ptr = _Str.c_str();
     wchar_t* _Eptr;
@@ -379,7 +369,7 @@ _NODISCARD inline unsigned long long stoull(const wstring& _Str, size_t* _Idx = 
     return _Ans;
 }
 
-_NODISCARD inline float stof(const wstring& _Str, size_t* _Idx = nullptr) { // convert wstring to float
+_NODISCARD inline float stof(const wstring& _Str, size_t* _Idx = nullptr) {
     int& _Errno_ref     = errno; // Nonzero cost, pay it once
     const wchar_t* _Ptr = _Str.c_str();
     wchar_t* _Eptr;
@@ -401,7 +391,7 @@ _NODISCARD inline float stof(const wstring& _Str, size_t* _Idx = nullptr) { // c
     return _Ans;
 }
 
-_NODISCARD inline double stod(const wstring& _Str, size_t* _Idx = nullptr) { // convert wstring to double
+_NODISCARD inline double stod(const wstring& _Str, size_t* _Idx = nullptr) {
     int& _Errno_ref     = errno; // Nonzero cost, pay it once
     const wchar_t* _Ptr = _Str.c_str();
     wchar_t* _Eptr;
@@ -423,7 +413,7 @@ _NODISCARD inline double stod(const wstring& _Str, size_t* _Idx = nullptr) { // 
     return _Ans;
 }
 
-_NODISCARD inline long double stold(const wstring& _Str, size_t* _Idx = nullptr) { // convert wstring to long double
+_NODISCARD inline long double stold(const wstring& _Str, size_t* _Idx = nullptr) {
     int& _Errno_ref     = errno; // Nonzero cost, pay it once
     const wchar_t* _Ptr = _Str.c_str();
     wchar_t* _Eptr;

--- a/stl/inc/string
+++ b/stl/inc/string
@@ -23,9 +23,9 @@ _STL_DISABLE_CLANG_WARNINGS
 
 _STD_BEGIN
 template <class _Elem, class _Traits, class _Alloc>
-basic_istream<_Elem, _Traits>& getline(basic_istream<_Elem, _Traits>&& _Istr,
-    basic_string<_Elem, _Traits, _Alloc>& _Str,
-    const _Elem _Delim) { // get characters into string, discard delimiter
+basic_istream<_Elem, _Traits>& getline(
+    basic_istream<_Elem, _Traits>&& _Istr, basic_string<_Elem, _Traits, _Alloc>& _Str, const _Elem _Delim) {
+    // get characters into string, discard delimiter
     using _Myis = basic_istream<_Elem, _Traits>;
 
     typename _Myis::iostate _State = _Myis::goodbit;
@@ -66,20 +66,23 @@ basic_istream<_Elem, _Traits>& getline(basic_istream<_Elem, _Traits>&& _Istr,
 }
 
 template <class _Elem, class _Traits, class _Alloc>
-basic_istream<_Elem, _Traits>& getline(basic_istream<_Elem, _Traits>&& _Istr,
-    basic_string<_Elem, _Traits, _Alloc>& _Str) { // get characters into string, discard newline
+basic_istream<_Elem, _Traits>& getline(
+    basic_istream<_Elem, _Traits>&& _Istr, basic_string<_Elem, _Traits, _Alloc>& _Str) {
+    // get characters into string, discard newline
     return getline(_Istr, _Str, _Istr.widen('\n'));
 }
 
 template <class _Elem, class _Traits, class _Alloc>
-basic_istream<_Elem, _Traits>& getline(basic_istream<_Elem, _Traits>& _Istr, basic_string<_Elem, _Traits, _Alloc>& _Str,
-    const _Elem _Delim) { // get characters into string, discard delimiter
+basic_istream<_Elem, _Traits>& getline(
+    basic_istream<_Elem, _Traits>& _Istr, basic_string<_Elem, _Traits, _Alloc>& _Str, const _Elem _Delim) {
+    // get characters into string, discard delimiter
     return getline(_STD move(_Istr), _Str, _Delim);
 }
 
 template <class _Elem, class _Traits, class _Alloc>
-basic_istream<_Elem, _Traits>& getline(basic_istream<_Elem, _Traits>& _Istr,
-    basic_string<_Elem, _Traits, _Alloc>& _Str) { // get characters into string, discard newline
+basic_istream<_Elem, _Traits>& getline(
+    basic_istream<_Elem, _Traits>& _Istr, basic_string<_Elem, _Traits, _Alloc>& _Str) {
+    // get characters into string, discard newline
     return getline(_STD move(_Istr), _Str, _Istr.widen('\n'));
 }
 
@@ -436,7 +439,8 @@ _NODISCARD inline long double stold(const wstring& _Str, size_t* _Idx = nullptr)
 }
 
 template <class _Elem, class _UTy>
-_NODISCARD _Elem* _UIntegral_to_buff(_Elem* _RNext, _UTy _UVal) { // format _UVal into buffer *ending at* _RNext
+_NODISCARD _Elem* _UIntegral_to_buff(_Elem* _RNext, _UTy _UVal) {
+    // format _UVal into buffer *ending at* _RNext
     static_assert(is_unsigned_v<_UTy>, "_UTy must be unsigned");
 
 #ifdef _WIN64
@@ -467,7 +471,8 @@ _NODISCARD _Elem* _UIntegral_to_buff(_Elem* _RNext, _UTy _UVal) { // format _UVa
 }
 
 template <class _Elem, class _Ty>
-_NODISCARD basic_string<_Elem> _Integral_to_string(const _Ty _Val) { // convert _Val to string
+_NODISCARD basic_string<_Elem> _Integral_to_string(const _Ty _Val) {
+    // convert _Val to string
     static_assert(is_integral_v<_Ty>, "_Ty must be integral");
     using _UTy = make_unsigned_t<_Ty>;
     _Elem _Buff[21]; // can hold -2^63 and 2^64 - 1, plus NUL
@@ -486,7 +491,8 @@ _NODISCARD basic_string<_Elem> _Integral_to_string(const _Ty _Val) { // convert 
 
 // TRANSITION, CUDA - warning: pointless comparison of unsigned integer with zero
 template <class _Elem, class _Ty>
-_NODISCARD basic_string<_Elem> _UIntegral_to_string(const _Ty _Val) { // convert _Val to string
+_NODISCARD basic_string<_Elem> _UIntegral_to_string(const _Ty _Val) {
+    // convert _Val to string
     static_assert(is_integral_v<_Ty>, "_Ty must be integral");
     static_assert(is_unsigned_v<_Ty>, "_Ty must be unsigned");
     _Elem _Buff[21]; // can hold 2^64 - 1, plus NUL

--- a/stl/inc/string
+++ b/stl/inc/string
@@ -505,81 +505,81 @@ _NODISCARD basic_string<_Elem> _UIntegral_to_string(const _Ty _Val) { // convert
     return basic_string<_Elem>(_RNext, _Buff_end);
 }
 
-_NODISCARD inline string to_string(int _Val) { // convert int to string
+_NODISCARD inline string to_string(int _Val) {
     return _Integral_to_string<char>(_Val);
 }
 
-_NODISCARD inline string to_string(unsigned int _Val) { // convert unsigned int to string
+_NODISCARD inline string to_string(unsigned int _Val) {
     return _UIntegral_to_string<char>(_Val);
 }
 
-_NODISCARD inline string to_string(long _Val) { // convert long to string
+_NODISCARD inline string to_string(long _Val) {
     return _Integral_to_string<char>(_Val);
 }
 
-_NODISCARD inline string to_string(unsigned long _Val) { // convert unsigned long to string
+_NODISCARD inline string to_string(unsigned long _Val) {
     return _UIntegral_to_string<char>(_Val);
 }
 
-_NODISCARD inline string to_string(long long _Val) { // convert long long to string
+_NODISCARD inline string to_string(long long _Val) {
     return _Integral_to_string<char>(_Val);
 }
 
-_NODISCARD inline string to_string(unsigned long long _Val) { // convert unsigned long long to string
+_NODISCARD inline string to_string(unsigned long long _Val) {
     return _UIntegral_to_string<char>(_Val);
 }
 
-_NODISCARD inline string to_string(double _Val) { // convert double to string
+_NODISCARD inline string to_string(double _Val) {
     const auto _Len = static_cast<size_t>(_CSTD _scprintf("%f", _Val));
     string _Str(_Len, '\0');
     _CSTD sprintf_s(&_Str[0], _Len + 1, "%f", _Val);
     return _Str;
 }
 
-_NODISCARD inline string to_string(float _Val) { // convert float to string
+_NODISCARD inline string to_string(float _Val) {
     return _STD to_string(static_cast<double>(_Val));
 }
 
-_NODISCARD inline string to_string(long double _Val) { // convert long double to string
+_NODISCARD inline string to_string(long double _Val) {
     return _STD to_string(static_cast<double>(_Val));
 }
 
-_NODISCARD inline wstring to_wstring(int _Val) { // convert int to wstring
+_NODISCARD inline wstring to_wstring(int _Val) {
     return _Integral_to_string<wchar_t>(_Val);
 }
 
-_NODISCARD inline wstring to_wstring(unsigned int _Val) { // convert unsigned int to wstring
+_NODISCARD inline wstring to_wstring(unsigned int _Val) {
     return _UIntegral_to_string<wchar_t>(_Val);
 }
 
-_NODISCARD inline wstring to_wstring(long _Val) { // convert long to wstring
+_NODISCARD inline wstring to_wstring(long _Val) {
     return _Integral_to_string<wchar_t>(_Val);
 }
 
-_NODISCARD inline wstring to_wstring(unsigned long _Val) { // convert unsigned long to wstring
+_NODISCARD inline wstring to_wstring(unsigned long _Val) {
     return _UIntegral_to_string<wchar_t>(_Val);
 }
 
-_NODISCARD inline wstring to_wstring(long long _Val) { // convert long long to wstring
+_NODISCARD inline wstring to_wstring(long long _Val) {
     return _Integral_to_string<wchar_t>(_Val);
 }
 
-_NODISCARD inline wstring to_wstring(unsigned long long _Val) { // convert unsigned long long to wstring
+_NODISCARD inline wstring to_wstring(unsigned long long _Val) {
     return _UIntegral_to_string<wchar_t>(_Val);
 }
 
-_NODISCARD inline wstring to_wstring(double _Val) { // convert double to wstring
+_NODISCARD inline wstring to_wstring(double _Val) {
     const auto _Len = static_cast<size_t>(_CSTD _scwprintf(L"%f", _Val));
     wstring _Str(_Len, L'\0');
     _CSTD swprintf_s(&_Str[0], _Len + 1, L"%f", _Val);
     return _Str;
 }
 
-_NODISCARD inline wstring to_wstring(float _Val) { // convert float to wstring
+_NODISCARD inline wstring to_wstring(float _Val) {
     return _STD to_wstring(static_cast<double>(_Val));
 }
 
-_NODISCARD inline wstring to_wstring(long double _Val) { // convert long double to wstring
+_NODISCARD inline wstring to_wstring(long double _Val) {
     return _STD to_wstring(static_cast<double>(_Val));
 }
 _STD_END

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -1827,7 +1827,7 @@ using _Weak_types = conditional_t<is_function_v<remove_pointer_t<_Ty>>, _Functio
     conditional_t<is_member_function_pointer_v<_Ty>, _Is_memfunptr<remove_cv_t<_Ty>>, _Weak_binary_args<_Ty>>>;
 
 template <class _Ty>
-void _Refwrap_ctor_fun(_Identity_t<_Ty&>) noexcept;
+void _Refwrap_ctor_fun(_Identity_t<_Ty&>) noexcept; // not defined
 template <class _Ty>
 void _Refwrap_ctor_fun(_Identity_t<_Ty&&>) = delete;
 

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -519,84 +519,90 @@ struct _MSVC_KNOWN_SEMANTICS tuple_element<_Idx, pair<_Ty1, _Ty2>> {
 };
 
 template <class _Ret, class _Pair>
-constexpr _Ret _Pair_get(_Pair& _Pr, integral_constant<size_t, 0>) noexcept { // get reference to element 0 in pair _Pr
+constexpr _Ret _Pair_get(_Pair& _Pr, integral_constant<size_t, 0>) noexcept {
+    // get reference to element 0 in pair _Pr
     return _Pr.first;
 }
 
 template <class _Ret, class _Pair>
-constexpr _Ret _Pair_get(_Pair& _Pr, integral_constant<size_t, 1>) noexcept { // get reference to element 1 in pair _Pr
+constexpr _Ret _Pair_get(_Pair& _Pr, integral_constant<size_t, 1>) noexcept {
+    // get reference to element 1 in pair _Pr
     return _Pr.second;
 }
 
 template <size_t _Idx, class _Ty1, class _Ty2>
-_NODISCARD constexpr tuple_element_t<_Idx, pair<_Ty1, _Ty2>>& get(
-    pair<_Ty1, _Ty2>& _Pr) noexcept { // get reference to element at _Idx in pair _Pr
+_NODISCARD constexpr tuple_element_t<_Idx, pair<_Ty1, _Ty2>>& get(pair<_Ty1, _Ty2>& _Pr) noexcept {
+    // get reference to element at _Idx in pair _Pr
     using _Rtype = tuple_element_t<_Idx, pair<_Ty1, _Ty2>>&;
     return _Pair_get<_Rtype>(_Pr, integral_constant<size_t, _Idx>{});
 }
 
 template <class _Ty1, class _Ty2>
-_NODISCARD constexpr _Ty1& get(pair<_Ty1, _Ty2>& _Pr) noexcept { // get reference to element _Ty1 in pair _Pr
+_NODISCARD constexpr _Ty1& get(pair<_Ty1, _Ty2>& _Pr) noexcept {
+    // get reference to element _Ty1 in pair _Pr
     return _STD get<0>(_Pr);
 }
 
 template <class _Ty2, class _Ty1>
-_NODISCARD constexpr _Ty2& get(pair<_Ty1, _Ty2>& _Pr) noexcept { // get reference to element _Ty2 in pair _Pr
+_NODISCARD constexpr _Ty2& get(pair<_Ty1, _Ty2>& _Pr) noexcept {
+    // get reference to element _Ty2 in pair _Pr
     return _STD get<1>(_Pr);
 }
 
 template <size_t _Idx, class _Ty1, class _Ty2>
-_NODISCARD constexpr const tuple_element_t<_Idx, pair<_Ty1, _Ty2>>& get(
-    const pair<_Ty1, _Ty2>& _Pr) noexcept { // get const reference to element at _Idx in pair _Pr
+_NODISCARD constexpr const tuple_element_t<_Idx, pair<_Ty1, _Ty2>>& get(const pair<_Ty1, _Ty2>& _Pr) noexcept {
+    // get const reference to element at _Idx in pair _Pr
     using _Ctype = const tuple_element_t<_Idx, pair<_Ty1, _Ty2>>&;
     return _Pair_get<_Ctype>(_Pr, integral_constant<size_t, _Idx>{});
 }
 
 template <class _Ty1, class _Ty2>
-_NODISCARD constexpr const _Ty1& get(
-    const pair<_Ty1, _Ty2>& _Pr) noexcept { // get const reference to element _Ty1 in pair _Pr
+_NODISCARD constexpr const _Ty1& get(const pair<_Ty1, _Ty2>& _Pr) noexcept {
+    // get const reference to element _Ty1 in pair _Pr
     return _STD get<0>(_Pr);
 }
 
 template <class _Ty2, class _Ty1>
-_NODISCARD constexpr const _Ty2& get(
-    const pair<_Ty1, _Ty2>& _Pr) noexcept { // get const reference to element _Ty2 in pair _Pr
+_NODISCARD constexpr const _Ty2& get(const pair<_Ty1, _Ty2>& _Pr) noexcept {
+    // get const reference to element _Ty2 in pair _Pr
     return _STD get<1>(_Pr);
 }
 
 template <size_t _Idx, class _Ty1, class _Ty2>
-_NODISCARD constexpr tuple_element_t<_Idx, pair<_Ty1, _Ty2>>&& get(
-    pair<_Ty1, _Ty2>&& _Pr) noexcept { // get rvalue reference to element at _Idx in pair _Pr
+_NODISCARD constexpr tuple_element_t<_Idx, pair<_Ty1, _Ty2>>&& get(pair<_Ty1, _Ty2>&& _Pr) noexcept {
+    // get rvalue reference to element at _Idx in pair _Pr
     using _RRtype = tuple_element_t<_Idx, pair<_Ty1, _Ty2>>&&;
     return _STD forward<_RRtype>(_STD get<_Idx>(_Pr));
 }
 
 template <class _Ty1, class _Ty2>
-_NODISCARD constexpr _Ty1&& get(pair<_Ty1, _Ty2>&& _Pr) noexcept { // get rvalue reference to element _Ty1 in pair _Pr
+_NODISCARD constexpr _Ty1&& get(pair<_Ty1, _Ty2>&& _Pr) noexcept {
+    // get rvalue reference to element _Ty1 in pair _Pr
     return _STD get<0>(_STD move(_Pr));
 }
 
 template <class _Ty2, class _Ty1>
-_NODISCARD constexpr _Ty2&& get(pair<_Ty1, _Ty2>&& _Pr) noexcept { // get rvalue reference to element _Ty2 in pair _Pr
+_NODISCARD constexpr _Ty2&& get(pair<_Ty1, _Ty2>&& _Pr) noexcept {
+    // get rvalue reference to element _Ty2 in pair _Pr
     return _STD get<1>(_STD move(_Pr));
 }
 
 template <size_t _Idx, class _Ty1, class _Ty2>
-_NODISCARD constexpr const tuple_element_t<_Idx, pair<_Ty1, _Ty2>>&& get(
-    const pair<_Ty1, _Ty2>&& _Pr) noexcept { // get const rvalue reference to element at _Idx in pair _Pr
+_NODISCARD constexpr const tuple_element_t<_Idx, pair<_Ty1, _Ty2>>&& get(const pair<_Ty1, _Ty2>&& _Pr) noexcept {
+    // get const rvalue reference to element at _Idx in pair _Pr
     using _RRtype = const tuple_element_t<_Idx, pair<_Ty1, _Ty2>>&&;
     return _STD forward<_RRtype>(_STD get<_Idx>(_Pr));
 }
 
 template <class _Ty1, class _Ty2>
-_NODISCARD constexpr const _Ty1&& get(
-    const pair<_Ty1, _Ty2>&& _Pr) noexcept { // get const rvalue reference to element _Ty1 in pair _Pr
+_NODISCARD constexpr const _Ty1&& get(const pair<_Ty1, _Ty2>&& _Pr) noexcept {
+    // get const rvalue reference to element _Ty1 in pair _Pr
     return _STD get<0>(_STD move(_Pr));
 }
 
 template <class _Ty2, class _Ty1>
-_NODISCARD constexpr const _Ty2&& get(
-    const pair<_Ty1, _Ty2>&& _Pr) noexcept { // get const rvalue reference to element _Ty2 in pair _Pr
+_NODISCARD constexpr const _Ty2&& get(const pair<_Ty1, _Ty2>&& _Pr) noexcept {
+    // get const rvalue reference to element _Ty2 in pair _Pr
     return _STD get<1>(_STD move(_Pr));
 }
 

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -1199,26 +1199,24 @@ concept indirectly_swappable = indirectly_readable<_It1> && indirectly_readable<
         _RANGES iter_swap(__i1, __i2);
         _RANGES iter_swap(__i2, __i1);
     };
+// clang-format on
 
 template <class _It1, class _It2, class _Rel, class _Proj1 = identity, class _Proj2 = identity>
-concept indirectly_comparable =
-    indirect_binary_predicate<_Rel,
-        projected<_It1, _Proj1>,
-        projected<_It2, _Proj2>>;
+concept indirectly_comparable = indirect_binary_predicate<_Rel, projected<_It1, _Proj1>, projected<_It2, _Proj2>>;
 
 template <class _It>
-concept permutable = forward_iterator<_It>
-    && indirectly_movable_storable<_It, _It>
-    && indirectly_swappable<_It, _It>;
+concept permutable = forward_iterator<_It> && indirectly_movable_storable<_It, _It> && indirectly_swappable<_It, _It>;
 
-namespace ranges { struct less; }
+namespace ranges {
+    struct less;
+}
+
 template <class _It1, class _It2, class _Out, class _Pr = ranges::less, class _Pj1 = identity, class _Pj2 = identity>
-concept mergeable = input_iterator<_It1> && input_iterator<_It2>
-    && weakly_incrementable<_Out>
-    && indirectly_copyable<_It1, _Out>
-    && indirectly_copyable<_It2, _Out>
+concept mergeable = input_iterator<_It1> && input_iterator<_It2> //
+    && weakly_incrementable<_Out> //
+    && indirectly_copyable<_It1, _Out> //
+    && indirectly_copyable<_It2, _Out> //
     && indirect_strict_weak_order<_Pr, projected<_It1, _Pj1>, projected<_It2, _Pj2>>;
-// clang-format on
 
 template <class _It, class _Pr = ranges::less, class _Proj = identity>
 concept sortable = permutable<_It> && indirect_strict_weak_order<_Pr, projected<_It, _Proj>>;


### PR DESCRIPTION
* Detach comments.
  + This isn't attempting to be a global cleanup. Many of these will prevent the addition of `_EXPORT_STD` from causing wrapping, some fix wrapping that's already bad, some are for local consistency.
* `<string>`: Remove unnecessary comments for `to_string()`, `to_wstring()`, and `stoi()` etc. - they're just repeating the function names.
  + A few (like `stold()`) would also cause wrapping with `_EXPORT_STD`.
* `<cstddef>`: Remove SHOUTY RELICS and unnecessary comments, detach remaining comments.
* `<type_traits>`: Comment `_Refwrap_ctor_fun` as `// not defined`.
* `<random>`: Remove extra newline.
* `<random>`: Unwrap string literals for assertions.
* `<xutility>`: Shrink `clang-format off` region, add newline after declaring `ranges::less`.