### PR TITLE
Cleanups 2: Exception handling

### DIFF
--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -1610,6 +1610,11 @@ namespace chrono {
 #endif // ^^^ workaround ^^^
     };
 
+    template <class _Duration>
+    [[noreturn]] void _Throw_nonexistent_local_time(const local_time<_Duration>& _Tp, const local_info& _Info) {
+        _THROW((nonexistent_local_time{_Tp, _Info}));
+    }
+
     class ambiguous_local_time : public runtime_error {
     public:
         template <class _Duration>
@@ -1627,6 +1632,11 @@ namespace chrono {
         }
 #endif // ^^^ workaround ^^^
     };
+
+    template <class _Duration>
+    [[noreturn]] void _Throw_ambiguous_local_time(const local_time<_Duration>& _Tp, const local_info& _Info) {
+        _THROW((ambiguous_local_time{_Tp, _Info}));
+    }
 
     // [time.zone.timezone]
 
@@ -1715,9 +1725,9 @@ namespace chrono {
         _NODISCARD sys_time<common_type_t<_Duration, seconds>> to_sys(const local_time<_Duration>& _Local) const {
             const auto _Info = get_info(_Local);
             if (_Info.result == local_info::nonexistent) {
-                _THROW(nonexistent_local_time(_Local, _Info));
+                _Throw_nonexistent_local_time(_Local, _Info);
             } else if (_Info.result == local_info::ambiguous) {
-                _THROW(ambiguous_local_time(_Local, _Info));
+                _Throw_ambiguous_local_time(_Local, _Info);
             }
 
             return sys_time<common_type_t<_Duration, seconds>>{_Local.time_since_epoch() - _Info.first.offset};

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -4656,7 +4656,7 @@ public:
     // same as _Specs_setter
     constexpr void _On_fill(basic_string_view<_CharT> _Sv) {
         if (_Sv.size() > _STD size(_Specs._Fill)) {
-            _THROW(format_error("Invalid fill (too long)."));
+            _Throw_format_error("Invalid fill (too long).");
         }
 
         const auto _Pos = _STD _Copy_unchecked(_Sv._Unchecked_begin(), _Sv._Unchecked_end(), _Specs._Fill);
@@ -4697,11 +4697,11 @@ public:
     constexpr void _On_conversion_spec(char _Modifier, _CharT _Type) {
         // NOTE: same performance note from _Basic_format_specs also applies here
         if (_Modifier != '\0' && _Modifier != 'E' && _Modifier != 'O') {
-            _THROW(format_error("Invalid modifier specification."));
+            _Throw_format_error("Invalid modifier specification.");
         }
 
         if (_Type < 0 || _Type > (numeric_limits<signed char>::max)()) {
-            _THROW(format_error("Invalid type specification."));
+            _Throw_format_error("Invalid type specification.");
         }
 
         _Chrono_spec<_CharT> _Conv_spec{._Modifier = _Modifier, ._Type = static_cast<char>(_Type)};
@@ -4719,7 +4719,7 @@ private:
 
     _NODISCARD static constexpr int _Verify_dynamic_arg_index_in_range(const size_t _Idx) {
         if (_Idx > static_cast<size_t>((numeric_limits<int>::max)())) {
-            _THROW(format_error("Dynamic width or precision index too large."));
+            _Throw_format_error("Dynamic width or precision index too large.");
         }
 
         return static_cast<int>(_Idx);
@@ -4731,7 +4731,7 @@ template <class _CharT, _Chrono_parse_spec_callbacks<_CharT> _Callbacks_type>
 _NODISCARD constexpr const _CharT* _Parse_conversion_specs(
     const _CharT* _Begin, const _CharT* _End, _Callbacks_type&& _Callbacks) {
     if (_Begin == _End || *_Begin == '}') {
-        _THROW(format_error("Invalid format string."));
+        _Throw_format_error("Invalid format string.");
     }
 
     char _Mod  = '\0';
@@ -4741,7 +4741,7 @@ _NODISCARD constexpr const _CharT* _Parse_conversion_specs(
         _Mod = static_cast<char>(_Ch);
         ++_Begin;
         if (_Begin == _End || *_Begin == '}') {
-            _THROW(format_error("Invalid format string - missing type after modifier."));
+            _Throw_format_error("Invalid format string - missing type after modifier.");
         }
     }
 
@@ -4784,14 +4784,14 @@ _NODISCARD constexpr const _CharT* _Parse_chrono_format_specs(
     }
 
     if (*_Begin != '}' && *_Begin != '%') {
-        _THROW(format_error("Invalid format string - chrono-specs must begin with conversion-spec"));
+        _Throw_format_error("Invalid format string - chrono-specs must begin with conversion-spec");
     }
 
     // chrono-spec
     while (_Begin != _End && *_Begin != '}') {
         if (*_Begin == '%') { // conversion-spec
             if (++_Begin == _End) {
-                _THROW(format_error("Invalid format string - missing type after %"));
+                _Throw_format_error("Invalid format string - missing type after %");
             }
 
             switch (*_Begin) {
@@ -5188,7 +5188,7 @@ namespace chrono {
             const auto _Res_iter = _Parse_ctx.begin() + (_It - _Parse_ctx._Unchecked_begin());
 
             if (_It != _Parse_ctx._Unchecked_end() && *_It != '}') {
-                _THROW(format_error("Missing '}' in format string."));
+                _Throw_format_error("Missing '}' in format string.");
             }
 
             if constexpr (_Is_specialization_v<_Ty, duration>) {
@@ -5207,7 +5207,7 @@ namespace chrono {
 
             for (const auto& _Spec : _Specs._Chrono_specs_list) {
                 if (_Spec._Type != '\0' && !_Is_valid_type<_Ty>(_Spec._Type)) {
-                    _THROW(format_error("Invalid type."));
+                    _Throw_format_error("Invalid type.");
                 }
                 _Check_modifier(_Spec._Type, _Spec._Modifier);
             }
@@ -5257,7 +5257,7 @@ namespace chrono {
                 }
             }
 
-            _THROW(format_error("Incompatible modifier for type"));
+            _Throw_format_error("Incompatible modifier for type");
         }
 
         template <class _Ty>
@@ -5355,7 +5355,7 @@ namespace chrono {
             basic_ostream<_CharT>& _Os, const _Chrono_spec<_CharT>& _Spec, const tm& _Time, const _Ty& _Val) const {
             if constexpr (is_same_v<_Ty, local_info>) {
                 if (_Val.result != local_info::unique) {
-                    _THROW(format_error("Cannot print non-unique local_info"));
+                    _Throw_format_error("Cannot print non-unique local_info");
                 }
             }
 
@@ -5368,7 +5368,7 @@ namespace chrono {
                 // Most months have a proper last day, but February depends on the year.
                 if constexpr (is_same_v<_Ty, month_day_last>) {
                     if (_Val.month() == February) {
-                        _THROW(format_error("Cannot print the last day of February without a year"));
+                        _Throw_format_error("Cannot print the last day of February without a year");
                     }
 
                     if (!_Val.ok()) {
@@ -5389,12 +5389,12 @@ namespace chrono {
             case 'G':
                 if constexpr (is_same_v<_Ty, year_month>) {
                     if (_Val.month() == January || _Val.month() == December) {
-                        _THROW(format_error(
-                            "The ISO week-based year for a year_month of January or December is ambiguous."));
+                        _Throw_format_error(
+                            "The ISO week-based year for a year_month of January or December is ambiguous.");
                     }
 
                     if (!_Val.ok()) {
-                        _THROW(format_error("The ISO week-based year for an out-of-bounds year_month is ambiguous."));
+                        _Throw_format_error("The ISO week-based year for an out-of-bounds year_month is ambiguous.");
                     }
 
                     const char _Gregorian_type = _Spec._Type == 'g' ? 'y' : 'Y';
@@ -5503,7 +5503,7 @@ namespace chrono {
                     _Os << _Widen_string<_CharT>(_Val.first.abbrev);
                 } else if constexpr (_Is_specialization_v<_Ty, _Local_time_format_t>) {
                     if (_Val._Abbrev == nullptr) {
-                        _THROW(format_error("Cannot print local-time-format-t with null abbrev."));
+                        _Throw_format_error("Cannot print local-time-format-t with null abbrev.");
                     }
                     _Os << _Widen_string<_CharT>(*_Val._Abbrev);
                 } else {
@@ -5520,7 +5520,7 @@ namespace chrono {
                         _Offset = hh_mm_ss<seconds>{_Val.first.offset};
                     } else if constexpr (_Is_specialization_v<_Ty, _Local_time_format_t>) {
                         if (_Val._Offset_sec == nullptr) {
-                            _THROW(format_error("Cannot print local-time-format-t with null offset_sec."));
+                            _Throw_format_error("Cannot print local-time-format-t with null offset_sec.");
                         }
                         _Offset = hh_mm_ss<seconds>{*_Val._Offset_sec};
                     } else {
@@ -5549,7 +5549,7 @@ namespace chrono {
 
             if constexpr (_Is_specialization_v<_Ty, hh_mm_ss>) {
                 if (_Spec._Type == 'H' && _Val.hours() >= hours{24}) {
-                    _THROW(format_error("Cannot localize hh_mm_ss with an absolute value of 24 hours or more."));
+                    _Throw_format_error("Cannot localize hh_mm_ss with an absolute value of 24 hours or more.");
                 }
                 return;
             }
@@ -5621,7 +5621,7 @@ namespace chrono {
                 case 'j':
                     if constexpr (is_same_v<_Ty, month_day>) {
                         if (_Val.month() > February) {
-                            _THROW(format_error("The day of year for a month_day past February is ambiguous."));
+                            _Throw_format_error("The day of year for a month_day past February is ambiguous.");
                         }
                         return true;
                     } else if constexpr (is_same_v<_Ty, month_day_last>) {
@@ -5655,7 +5655,7 @@ namespace chrono {
                 return false;
             };
             if (!_Validate()) {
-                _THROW(format_error("Cannot localize out-of-bounds time point."));
+                _Throw_format_error("Cannot localize out-of-bounds time point.");
             }
         }
 

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -77,6 +77,10 @@ class format_error : public runtime_error {
     using runtime_error::runtime_error;
 };
 
+[[noreturn]] inline void _Throw_format_error(const char* const _Message) {
+    _THROW(format_error{_Message});
+}
+
 enum class _Fmt_align : uint8_t { _None, _Left, _Right, _Center };
 
 enum class _Fmt_sign : uint8_t { _None, _Plus, _Minus, _Space };
@@ -586,7 +590,7 @@ public:
     // _Next_arg_id < 0 means manual
     _NODISCARD constexpr size_t next_arg_id() {
         if (_Next_arg_id < 0) {
-            _THROW(format_error("Can not switch from manual to automatic indexing"));
+            _Throw_format_error("Can not switch from manual to automatic indexing");
         }
 
         if (_STD is_constant_evaluated()) {
@@ -606,7 +610,7 @@ public:
         }
 
         if (_Next_arg_id > 0) {
-            _THROW(format_error("Can not switch from automatic to manual indexing"));
+            _Throw_format_error("Can not switch from automatic to manual indexing");
         }
         _Next_arg_id = -1;
     }
@@ -766,7 +770,7 @@ _NODISCARD constexpr const _CharT* _Parse_nonnegative_integer(
     } while (_First != _Last && '0' <= *_First && *_First <= '9');
 
     if (_Value > _Max_int) {
-        _THROW(format_error("Number is too big"));
+        _Throw_format_error("Number is too big");
     }
 
     return _First;
@@ -809,14 +813,14 @@ _NODISCARD constexpr const _CharT* _Parse_arg_id(
         // The only things permitted after the index are the end of the replacement field ('}')
         // or the beginning of the format spec (':').
         if (_First == _Last || (*_First != '}' && *_First != ':')) {
-            _THROW(format_error("Invalid format string."));
+            _Throw_format_error("Invalid format string.");
         }
 
         _Callbacks._On_manual_id(_Index);
         return _First;
     }
     // This is where we would parse named arg ids if std::format were to support them.
-    _THROW(format_error("Invalid format string."));
+    _Throw_format_error("Invalid format string.");
 }
 
 _NODISCARD constexpr bool _Is_execution_charset_self_synchronizing() {
@@ -934,7 +938,7 @@ public:
             while (_First != _Last && *_First != _Val) {
                 const int _Units = this->_Double_byte_encoding_code_units_in_next_character(_First, _Last);
                 if (_Units < 0) {
-                    _THROW(format_error("Invalid encoded character in format string."));
+                    _Throw_format_error("Invalid encoded character in format string.");
                 }
                 _First += _Units;
             }
@@ -1014,7 +1018,7 @@ _NODISCARD constexpr const _CharT* _Parse_align(
 
     const int _Units = _Get_fmt_codec<_CharT>()._Units_in_next_character(_First, _Last);
     if (_Units < 0) { // invalid fill character encoding
-        _THROW(format_error("Invalid format string."));
+        _Throw_format_error("Invalid format string.");
     }
     auto _Align_pt = _First + _Units;
 
@@ -1038,7 +1042,7 @@ _NODISCARD constexpr const _CharT* _Parse_align(
         if (_Parsed_align != _Fmt_align::_None) {
             if (_Align_pt != _First) {
                 if (*_First == '{') {
-                    _THROW(format_error("invalid fill character '{'"));
+                    _Throw_format_error("invalid fill character '{'");
                 }
                 _Callbacks._On_fill({_First, static_cast<size_t>(_Align_pt - _First)});
                 _First = _Align_pt + 1;
@@ -1123,7 +1127,7 @@ _NODISCARD constexpr const _CharT* _Parse_width(
         }
 
         if (_First == _Last || *_First != '}') {
-            _THROW(format_error("Invalid format string."));
+            _Throw_format_error("Invalid format string.");
         }
         ++_First;
     }
@@ -1150,11 +1154,11 @@ _NODISCARD constexpr const _CharT* _Parse_precision(
         }
 
         if (_First == _Last || *_First != '}') {
-            _THROW(format_error("Invalid format string."));
+            _Throw_format_error("Invalid format string.");
         }
         ++_First;
     } else {
-        _THROW(format_error("Missing precision specifier."));
+        _Throw_format_error("Missing precision specifier.");
     }
 
     return _First;
@@ -1245,7 +1249,7 @@ _NODISCARD constexpr const _CharT* _Parse_replacement_field(
     const _CharT* _First, const _CharT* _Last, _HandlerT&& _Handler) {
     ++_First;
     if (_First == _Last) {
-        _THROW(format_error("Invalid format string."));
+        _Throw_format_error("Invalid format string.");
     }
 
     if (*_First == '}') {
@@ -1267,10 +1271,10 @@ _NODISCARD constexpr const _CharT* _Parse_replacement_field(
         } else if (_Ch == ':') {
             _First = _Handler._On_format_specs(_Adapter._Arg_id, _First + 1, _Last);
             if (_First == _Last || *_First != '}') {
-                _THROW(format_error("Unknown format specifier."));
+                _Throw_format_error("Unknown format specifier.");
             }
         } else {
-            _THROW(format_error("Missing '}' in format string."));
+            _Throw_format_error("Missing '}' in format string.");
         }
     }
 
@@ -1301,7 +1305,7 @@ constexpr void _Parse_format_string(basic_string_view<_CharT> _Format_str, _Hand
                 // the above condition was not met.
                 ++_ClosingCurl;
                 if (_ClosingCurl == _OpeningCurl || *_ClosingCurl != '}') {
-                    _THROW(format_error("Unmatched '}' in format string."));
+                    _Throw_format_error("Unmatched '}' in format string.");
                 }
                 // We found two closing curls, so output only one of them
                 _Handler._On_text(_First, _ClosingCurl);
@@ -1356,7 +1360,7 @@ public:
 
     constexpr void _On_fill(const basic_string_view<_CharT> _Sv) {
         if (_Sv.size() > _STD size(_Specs._Fill)) {
-            _THROW(format_error("Invalid fill (too long)."));
+            _Throw_format_error("Invalid fill (too long).");
         }
 
         const auto _Pos = _STD _Copy_unchecked(_Sv._Unchecked_begin(), _Sv._Unchecked_end(), _Specs._Fill);
@@ -1403,7 +1407,7 @@ _NODISCARD constexpr basic_format_arg<_Context> _Get_arg(const _Context& _Ctx, c
     // id or a named id (which we do not support in std::format)
     auto _Arg = _Ctx.arg(_Arg_id);
     if (!_Arg) {
-        _THROW(format_error("Argument not found."));
+        _Throw_format_error("Argument not found.");
     }
 
     return _Arg;
@@ -1424,11 +1428,11 @@ public:
             }
 
             if (!_Positive) {
-                _THROW(format_error("width is not positive."));
+                _Throw_format_error("width is not positive.");
             }
             return static_cast<unsigned long long>(_Value);
         } else {
-            _THROW(format_error("Width is not an integer."));
+            _Throw_format_error("Width is not an integer.");
         }
     }
 };
@@ -1442,12 +1446,12 @@ public:
         if constexpr (is_integral_v<_Ty>) {
             if constexpr (is_signed_v<_Ty>) {
                 if (_Value < 0) {
-                    _THROW(format_error("Negative precision."));
+                    _Throw_format_error("Negative precision.");
                 }
             }
             return static_cast<unsigned long long>(_Value);
         } else {
-            _THROW(format_error("Precision is not an integer."));
+            _Throw_format_error("Precision is not an integer.");
         }
     }
 };
@@ -1460,7 +1464,7 @@ _NODISCARD constexpr int _Get_dynamic_specs(const _FormatArg _Arg) {
     _STL_INTERNAL_STATIC_ASSERT(_Is_any_of_v<_Handler, _Width_checker, _Precision_checker>);
     const unsigned long long _Val = _STD visit_format_arg(_Handler{}, _Arg);
     if (_Val > static_cast<unsigned long long>((numeric_limits<int>::max)())) {
-        _THROW(format_error("Number is too big."));
+        _Throw_format_error("Number is too big.");
     }
 
     return static_cast<int>(_Val);
@@ -1534,7 +1538,7 @@ private:
 
     _NODISCARD static constexpr int _Verify_dynamic_arg_index_in_range(const size_t _Idx) {
         if (_Idx > static_cast<size_t>((numeric_limits<int>::max)())) {
-            _THROW(format_error("Dynamic width or precision index too large."));
+            _Throw_format_error("Dynamic width or precision index too large.");
         }
 
         return static_cast<int>(_Idx);
@@ -1559,13 +1563,13 @@ public:
 
     constexpr void _Require_numeric_argument() const {
         if (!_Is_arithmetic_fmt_type(_Arg_type)) {
-            _THROW(format_error("Format specifier requires numeric argument."));
+            _Throw_format_error("Format specifier requires numeric argument.");
         }
     }
 
     constexpr void _Check_precision() const {
         if (_Is_integral_fmt_type(_Arg_type) || _Arg_type == _Basic_format_arg_type::_Pointer_type) {
-            _THROW(format_error("Precision not allowed for this argument type."));
+            _Throw_format_error("Precision not allowed for this argument type.");
         }
     }
 
@@ -1608,7 +1612,7 @@ public:
     template <class _CharT>
     constexpr void _On_type(_CharT _Type) {
         if (_Type < 0 || _Type > (numeric_limits<signed char>::max)()) {
-            _THROW(format_error("Invalid type specification."));
+            _Throw_format_error("Invalid type specification.");
         }
         const char _Narrow_type = static_cast<char>(_Type);
         enum class _Presentation_type_category { _Default, _Integer, _Floating, _String, _Pointer, _Char };
@@ -1644,7 +1648,7 @@ public:
             _Cat = _Presentation_type_category::_Pointer;
             break;
         default:
-            _THROW(format_error("Invalid presentation type specifier"));
+            _Throw_format_error("Invalid presentation type specifier");
         }
 
         switch (_Arg_type) {
@@ -1657,7 +1661,7 @@ public:
             }
             // note, we don't get a call if there isn't a type, but none is valid for everything.
             if (_Cat != _Presentation_type_category::_String && _Cat != _Presentation_type_category::_Integer) {
-                _THROW(format_error("Invalid presentation type for bool"));
+                _Throw_format_error("Invalid presentation type for bool");
             }
             break;
         case _Basic_format_arg_type::_Char_type:
@@ -1666,7 +1670,7 @@ public:
             }
 
             if (_Cat != _Presentation_type_category::_Char && _Cat != _Presentation_type_category::_Integer) {
-                _THROW(format_error("Invalid presentation type for char/wchar_t"));
+                _Throw_format_error("Invalid presentation type for char/wchar_t");
             }
             break;
         case _Basic_format_arg_type::_Int_type:
@@ -1678,7 +1682,7 @@ public:
             }
 
             if (_Cat != _Presentation_type_category::_Integer && _Cat != _Presentation_type_category::_Char) {
-                _THROW(format_error("Invalid presentation type for integer"));
+                _Throw_format_error("Invalid presentation type for integer");
             }
             break;
         case _Basic_format_arg_type::_Float_type:
@@ -1689,7 +1693,7 @@ public:
             }
 
             if (_Cat != _Presentation_type_category::_Floating) {
-                _THROW(format_error("Invalid presentation type for floating-point"));
+                _Throw_format_error("Invalid presentation type for floating-point");
             }
             break;
         case _Basic_format_arg_type::_CString_type:
@@ -1699,7 +1703,7 @@ public:
             }
 
             if (_Cat != _Presentation_type_category::_String) {
-                _THROW(format_error("Invalid presentation type for string"));
+                _Throw_format_error("Invalid presentation type for string");
             }
             break;
         case _Basic_format_arg_type::_Pointer_type:
@@ -1708,7 +1712,7 @@ public:
             }
 
             if (_Cat != _Presentation_type_category::_Pointer) {
-                _THROW(format_error("Invalid presentation type for pointer"));
+                _Throw_format_error("Invalid presentation type for pointer");
             }
             break;
         case _Basic_format_arg_type::_Custom_type:
@@ -1720,7 +1724,7 @@ public:
 
         if (_Need_arithmetic_presentation_type && _Cat != _Presentation_type_category::_Integer
             && _Cat != _Presentation_type_category::_Floating) {
-            _THROW(format_error("Modifier requires an integer presentation type for bool"));
+            _Throw_format_error("Modifier requires an integer presentation type for bool");
         }
         _Handler::_On_type(_Type);
     }
@@ -2334,7 +2338,7 @@ _NODISCARD _OutputIt _Fmt_write(_OutputIt _Out, const void* const _Value) {
 template <class _CharT, class _OutputIt>
 _NODISCARD _OutputIt _Fmt_write(_OutputIt _Out, const _CharT* _Value) {
     if (!_Value) {
-        _THROW(format_error("String pointer is null."));
+        _Throw_format_error("String pointer is null.");
     }
 
     while (*_Value) {
@@ -2545,7 +2549,7 @@ _NODISCARD _OutputIt _Write_integral(
     _OutputIt _Out, const _Integral _Value, _Basic_format_specs<_CharT> _Specs, _Lazy_locale _Locale) {
     if (_Specs._Type == 'c') {
         if (!_In_bounds<_CharT>(_Value)) {
-            _THROW(format_error("integral cannot be stored in charT"));
+            _Throw_format_error("integral cannot be stored in charT");
         }
         _Specs._Alt = false;
         return _Fmt_write(_STD move(_Out), static_cast<_CharT>(_Value), _Specs, _Locale);
@@ -3230,7 +3234,7 @@ struct _Format_handler {
             _Arg._Active_state);
         _First = _Parse_format_specs(_First, _Last, _Handler);
         if (_First == _Last || *_First != '}') {
-            _THROW(format_error("Missing '}' in format string."));
+            _Throw_format_error("Missing '}' in format string.");
         }
 
         _Ctx.advance_to(_STD visit_format_arg(
@@ -3256,7 +3260,7 @@ struct _Formatter_base {
         _Specs_checker<_Dynamic_specs_handler<_Pc>> _Handler(_Dynamic_specs_handler<_Pc>{_Specs, _ParseCtx}, _ArgType);
         const auto _It = _Parse_format_specs(_ParseCtx._Unchecked_begin(), _ParseCtx._Unchecked_end(), _Handler);
         if (_It != _ParseCtx._Unchecked_end() && *_It != '}') {
-            _THROW(format_error("Missing '}' in format string."));
+            _Throw_format_error("Missing '}' in format string.");
         }
         return _ParseCtx.begin() + (_It - _ParseCtx._Unchecked_begin());
     }

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -1670,7 +1670,11 @@ public:
             }
 
             if (_Cat != _Presentation_type_category::_Char && _Cat != _Presentation_type_category::_Integer) {
-                _Throw_format_error("Invalid presentation type for char/wchar_t");
+                if constexpr (is_same_v<_CharT, char>) {
+                    _Throw_format_error("Invalid presentation type for char");
+                } else {
+                    _Throw_format_error("Invalid presentation type for wchar_t");
+                }
             }
             break;
         case _Basic_format_arg_type::_Int_type:
@@ -2549,7 +2553,11 @@ _NODISCARD _OutputIt _Write_integral(
     _OutputIt _Out, const _Integral _Value, _Basic_format_specs<_CharT> _Specs, _Lazy_locale _Locale) {
     if (_Specs._Type == 'c') {
         if (!_In_bounds<_CharT>(_Value)) {
-            _Throw_format_error("integral cannot be stored in char/wchar_t");
+            if constexpr (is_same_v<_CharT, char>) {
+                _Throw_format_error("integral cannot be stored in char");
+            } else {
+                _Throw_format_error("integral cannot be stored in wchar_t");
+            }
         }
         _Specs._Alt = false;
         return _Fmt_write(_STD move(_Out), static_cast<_CharT>(_Value), _Specs, _Locale);

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -2549,7 +2549,7 @@ _NODISCARD _OutputIt _Write_integral(
     _OutputIt _Out, const _Integral _Value, _Basic_format_specs<_CharT> _Specs, _Lazy_locale _Locale) {
     if (_Specs._Type == 'c') {
         if (!_In_bounds<_CharT>(_Value)) {
-            _Throw_format_error("integral cannot be stored in charT");
+            _Throw_format_error("integral cannot be stored in char/wchar_t");
         }
         _Specs._Alt = false;
         return _Fmt_write(_STD move(_Out), static_cast<_CharT>(_Value), _Specs, _Locale);

--- a/stl/inc/future
+++ b/stl/inc/future
@@ -85,12 +85,12 @@ struct is_error_code_enum<future_errc> : true_type {};
 
 _NODISCARD const error_category& future_category() noexcept;
 
-_NODISCARD inline error_code make_error_code(future_errc _Errno) noexcept {
-    return error_code(static_cast<int>(_Errno), _STD future_category());
+_NODISCARD inline error_code make_error_code(future_errc _Ec) noexcept {
+    return error_code(static_cast<int>(_Ec), _STD future_category());
 }
 
-_NODISCARD inline error_condition make_error_condition(future_errc _Errno) noexcept {
-    return error_condition(static_cast<int>(_Errno), _STD future_category());
+_NODISCARD inline error_condition make_error_condition(future_errc _Ec) noexcept {
+    return error_condition(static_cast<int>(_Ec), _STD future_category());
 }
 
 inline const char* _Future_error_map(int _Errcode) noexcept { // convert to name of future error
@@ -117,7 +117,7 @@ public:
     explicit future_error(error_code _Errcode) // internal, TRANSITION, will be removed
         : logic_error(""), _Mycode(_Errcode) {}
 
-    explicit future_error(future_errc _Errno) : logic_error(""), _Mycode(_STD make_error_code(_Errno)) {}
+    explicit future_error(future_errc _Ec) : logic_error(""), _Mycode(_STD make_error_code(_Ec)) {}
 
     _NODISCARD const error_code& code() const noexcept {
         return _Mycode;
@@ -139,8 +139,8 @@ private:
 };
 
 // TRANSITION, ABI: remove `2` suffix
-[[noreturn]] inline void _Throw_future_error2(const future_errc _Errno) {
-    _THROW(future_error{_Errno});
+[[noreturn]] inline void _Throw_future_error2(const future_errc _Ec) {
+    _THROW(future_error{_Ec});
 }
 
 class _Future_error_category2 : public error_category { // categorize a future error

--- a/stl/inc/future
+++ b/stl/inc/future
@@ -138,8 +138,8 @@ private:
     error_code _Mycode; // the stored error code
 };
 
-// TRANSITION, ABI: remove `_v2` suffix
-[[noreturn]] inline void _Throw_future_error_v2(const future_errc _Errno) {
+// TRANSITION, ABI: remove `2` suffix
+[[noreturn]] inline void _Throw_future_error2(const future_errc _Errno) {
     _THROW(future_error{_Errno});
 }
 
@@ -280,7 +280,7 @@ public:
     virtual _Ty& _Get_value(bool _Get_only_once) {
         unique_lock<mutex> _Lock(_Mtx);
         if (_Get_only_once && _Retrieved) {
-            _Throw_future_error_v2(future_errc::future_already_retrieved);
+            _Throw_future_error2(future_errc::future_already_retrieved);
         }
 
         if (_Exception) {
@@ -325,7 +325,7 @@ public:
     void _Set_value_raw(const _Ty& _Val, unique_lock<mutex>* _Lock,
         bool _At_thread_exit) { // store a result while inside a locked block
         if (_Already_has_stored_result()) {
-            _Throw_future_error_v2(future_errc::promise_already_satisfied);
+            _Throw_future_error2(future_errc::promise_already_satisfied);
         }
 
         _Emplace_result(_Val);
@@ -340,7 +340,7 @@ public:
     void _Set_value_raw(_Ty&& _Val, unique_lock<mutex>* _Lock,
         bool _At_thread_exit) { // store a result while inside a locked block
         if (_Already_has_stored_result()) {
-            _Throw_future_error_v2(future_errc::promise_already_satisfied);
+            _Throw_future_error2(future_errc::promise_already_satisfied);
         }
 
         _Emplace_result(_STD forward<_Ty>(_Val));
@@ -355,7 +355,7 @@ public:
     void _Set_exception_raw(exception_ptr _Exc, unique_lock<mutex>* _Lock,
         bool _At_thread_exit) { // store a result while inside a locked block
         if (_Already_has_stored_result()) {
-            _Throw_future_error_v2(future_errc::promise_already_satisfied);
+            _Throw_future_error2(future_errc::promise_already_satisfied);
         }
 
         _STL_ASSERT(_Exc != nullptr, "promise<T>::set_exception/set_exception_at_thread_exit called with a null "
@@ -766,7 +766,7 @@ public:
 
     void wait() const { // wait for signal
         if (!valid()) {
-            _Throw_future_error_v2(future_errc::no_state);
+            _Throw_future_error2(future_errc::no_state);
         }
 
         _Assoc_state->_Wait();
@@ -775,7 +775,7 @@ public:
     template <class _Rep, class _Per>
     future_status wait_for(const chrono::duration<_Rep, _Per>& _Rel_time) const { // wait for duration
         if (!valid()) {
-            _Throw_future_error_v2(future_errc::no_state);
+            _Throw_future_error2(future_errc::no_state);
         }
 
         return _Assoc_state->_Wait_for(_Rel_time);
@@ -787,7 +787,7 @@ public:
         static_assert(chrono::is_clock_v<_Clock>, "Clock type required");
 #endif // _HAS_CXX20
         if (!valid()) {
-            _Throw_future_error_v2(future_errc::no_state);
+            _Throw_future_error2(future_errc::no_state);
         }
 
         return _Assoc_state->_Wait_until(_Abs_time);
@@ -795,7 +795,7 @@ public:
 
     _Ty& _Get_value() const {
         if (!valid()) {
-            _Throw_future_error_v2(future_errc::no_state);
+            _Throw_future_error2(future_errc::no_state);
         }
 
         return _Assoc_state->_Get_value(_Get_only_once);
@@ -803,7 +803,7 @@ public:
 
     void _Set_value(const _Ty& _Val, bool _Defer) { // store a result
         if (!valid()) {
-            _Throw_future_error_v2(future_errc::no_state);
+            _Throw_future_error2(future_errc::no_state);
         }
 
         _Assoc_state->_Set_value(_Val, _Defer);
@@ -811,7 +811,7 @@ public:
 
     void _Set_value(_Ty&& _Val, bool _Defer) { // store a result
         if (!valid()) {
-            _Throw_future_error_v2(future_errc::no_state);
+            _Throw_future_error2(future_errc::no_state);
         }
 
         _Assoc_state->_Set_value(_STD forward<_Ty>(_Val), _Defer);
@@ -825,7 +825,7 @@ public:
 
     void _Set_exception(exception_ptr _Exc, bool _Defer) { // store a result
         if (!valid()) {
-            _Throw_future_error_v2(future_errc::no_state);
+            _Throw_future_error2(future_errc::no_state);
         }
 
         _Assoc_state->_Set_exception(_Exc, _Defer);
@@ -1120,7 +1120,7 @@ public:
 
     _State_manager<_Ty>& _Get_state_for_set() {
         if (!_State.valid()) {
-            _Throw_future_error_v2(future_errc::no_state);
+            _Throw_future_error2(future_errc::no_state);
         }
 
         return _State;
@@ -1128,11 +1128,11 @@ public:
 
     _State_manager<_Ty>& _Get_state_for_future() {
         if (!_State.valid()) {
-            _Throw_future_error_v2(future_errc::no_state);
+            _Throw_future_error2(future_errc::no_state);
         }
 
         if (_Future_retrieved) {
-            _Throw_future_error_v2(future_errc::future_already_retrieved);
+            _Throw_future_error2(future_errc::future_already_retrieved);
         }
 
         _Future_retrieved = true;
@@ -1403,7 +1403,7 @@ public:
 
     void operator()(_ArgTypes... _Args) {
         if (_MyPromise._Is_ready()) {
-            _Throw_future_error_v2(future_errc::promise_already_satisfied);
+            _Throw_future_error2(future_errc::promise_already_satisfied);
         }
 
         _MyStateManagerType& _State = _MyPromise._Get_state_for_set();
@@ -1413,12 +1413,12 @@ public:
 
     void make_ready_at_thread_exit(_ArgTypes... _Args) {
         if (_MyPromise._Is_ready()) {
-            _Throw_future_error_v2(future_errc::promise_already_satisfied);
+            _Throw_future_error2(future_errc::promise_already_satisfied);
         }
 
         _MyStateManagerType& _State = _MyPromise._Get_state_for_set();
         if (_State._Ptr()->_Already_has_stored_result()) {
-            _Throw_future_error_v2(future_errc::promise_already_satisfied);
+            _Throw_future_error2(future_errc::promise_already_satisfied);
         }
 
         _MyStateType* _Ptr = static_cast<_MyStateType*>(_State._Ptr());

--- a/stl/inc/future
+++ b/stl/inc/future
@@ -80,9 +80,6 @@ enum class future_status { // names for timed wait function returns
     deferred
 };
 
-[[noreturn]] _CRTIMP2_PURE void __CLRCALL_PURE_OR_CDECL _Throw_future_error(const error_code& _Code);
-[[noreturn]] _CRTIMP2_PURE void __CLRCALL_PURE_OR_CDECL _Rethrow_future_exception(exception_ptr _Ptr);
-
 template <>
 struct is_error_code_enum<future_errc> : true_type {};
 
@@ -140,6 +137,11 @@ protected:
 private:
     error_code _Mycode; // the stored error code
 };
+
+// TRANSITION, ABI: remove `_v2` suffix
+[[noreturn]] inline void _Throw_future_error_v2(const future_errc _Errno) {
+    _THROW(future_error{_Errno});
+}
 
 class _Future_error_category2 : public error_category { // categorize a future error
 public:
@@ -278,11 +280,11 @@ public:
     virtual _Ty& _Get_value(bool _Get_only_once) {
         unique_lock<mutex> _Lock(_Mtx);
         if (_Get_only_once && _Retrieved) {
-            _Throw_future_error(make_error_code(future_errc::future_already_retrieved));
+            _Throw_future_error_v2(future_errc::future_already_retrieved);
         }
 
         if (_Exception) {
-            _Rethrow_future_exception(_Exception);
+            _STD rethrow_exception(_Exception);
         }
 
         // TRANSITION: `_Retrieved` should be assigned before `_Exception` is thrown so that a `future::get`
@@ -294,7 +296,7 @@ public:
         }
 
         if (_Exception) {
-            _Rethrow_future_exception(_Exception);
+            _STD rethrow_exception(_Exception);
         }
 
         if constexpr (is_default_constructible_v<_Ty>) {
@@ -323,7 +325,7 @@ public:
     void _Set_value_raw(const _Ty& _Val, unique_lock<mutex>* _Lock,
         bool _At_thread_exit) { // store a result while inside a locked block
         if (_Already_has_stored_result()) {
-            _Throw_future_error(make_error_code(future_errc::promise_already_satisfied));
+            _Throw_future_error_v2(future_errc::promise_already_satisfied);
         }
 
         _Emplace_result(_Val);
@@ -338,7 +340,7 @@ public:
     void _Set_value_raw(_Ty&& _Val, unique_lock<mutex>* _Lock,
         bool _At_thread_exit) { // store a result while inside a locked block
         if (_Already_has_stored_result()) {
-            _Throw_future_error(make_error_code(future_errc::promise_already_satisfied));
+            _Throw_future_error_v2(future_errc::promise_already_satisfied);
         }
 
         _Emplace_result(_STD forward<_Ty>(_Val));
@@ -353,7 +355,7 @@ public:
     void _Set_exception_raw(exception_ptr _Exc, unique_lock<mutex>* _Lock,
         bool _At_thread_exit) { // store a result while inside a locked block
         if (_Already_has_stored_result()) {
-            _Throw_future_error(make_error_code(future_errc::promise_already_satisfied));
+            _Throw_future_error_v2(future_errc::promise_already_satisfied);
         }
 
         _STL_ASSERT(_Exc != nullptr, "promise<T>::set_exception/set_exception_at_thread_exit called with a null "
@@ -764,7 +766,7 @@ public:
 
     void wait() const { // wait for signal
         if (!valid()) {
-            _Throw_future_error(make_error_code(future_errc::no_state));
+            _Throw_future_error_v2(future_errc::no_state);
         }
 
         _Assoc_state->_Wait();
@@ -773,7 +775,7 @@ public:
     template <class _Rep, class _Per>
     future_status wait_for(const chrono::duration<_Rep, _Per>& _Rel_time) const { // wait for duration
         if (!valid()) {
-            _Throw_future_error(make_error_code(future_errc::no_state));
+            _Throw_future_error_v2(future_errc::no_state);
         }
 
         return _Assoc_state->_Wait_for(_Rel_time);
@@ -785,7 +787,7 @@ public:
         static_assert(chrono::is_clock_v<_Clock>, "Clock type required");
 #endif // _HAS_CXX20
         if (!valid()) {
-            _Throw_future_error(make_error_code(future_errc::no_state));
+            _Throw_future_error_v2(future_errc::no_state);
         }
 
         return _Assoc_state->_Wait_until(_Abs_time);
@@ -793,7 +795,7 @@ public:
 
     _Ty& _Get_value() const {
         if (!valid()) {
-            _Throw_future_error(make_error_code(future_errc::no_state));
+            _Throw_future_error_v2(future_errc::no_state);
         }
 
         return _Assoc_state->_Get_value(_Get_only_once);
@@ -801,7 +803,7 @@ public:
 
     void _Set_value(const _Ty& _Val, bool _Defer) { // store a result
         if (!valid()) {
-            _Throw_future_error(make_error_code(future_errc::no_state));
+            _Throw_future_error_v2(future_errc::no_state);
         }
 
         _Assoc_state->_Set_value(_Val, _Defer);
@@ -809,7 +811,7 @@ public:
 
     void _Set_value(_Ty&& _Val, bool _Defer) { // store a result
         if (!valid()) {
-            _Throw_future_error(make_error_code(future_errc::no_state));
+            _Throw_future_error_v2(future_errc::no_state);
         }
 
         _Assoc_state->_Set_value(_STD forward<_Ty>(_Val), _Defer);
@@ -823,7 +825,7 @@ public:
 
     void _Set_exception(exception_ptr _Exc, bool _Defer) { // store a result
         if (!valid()) {
-            _Throw_future_error(make_error_code(future_errc::no_state));
+            _Throw_future_error_v2(future_errc::no_state);
         }
 
         _Assoc_state->_Set_exception(_Exc, _Defer);
@@ -1118,7 +1120,7 @@ public:
 
     _State_manager<_Ty>& _Get_state_for_set() {
         if (!_State.valid()) {
-            _Throw_future_error(make_error_code(future_errc::no_state));
+            _Throw_future_error_v2(future_errc::no_state);
         }
 
         return _State;
@@ -1126,11 +1128,11 @@ public:
 
     _State_manager<_Ty>& _Get_state_for_future() {
         if (!_State.valid()) {
-            _Throw_future_error(make_error_code(future_errc::no_state));
+            _Throw_future_error_v2(future_errc::no_state);
         }
 
         if (_Future_retrieved) {
-            _Throw_future_error(make_error_code(future_errc::future_already_retrieved));
+            _Throw_future_error_v2(future_errc::future_already_retrieved);
         }
 
         _Future_retrieved = true;
@@ -1401,7 +1403,7 @@ public:
 
     void operator()(_ArgTypes... _Args) {
         if (_MyPromise._Is_ready()) {
-            _Throw_future_error(make_error_code(future_errc::promise_already_satisfied));
+            _Throw_future_error_v2(future_errc::promise_already_satisfied);
         }
 
         _MyStateManagerType& _State = _MyPromise._Get_state_for_set();
@@ -1411,12 +1413,12 @@ public:
 
     void make_ready_at_thread_exit(_ArgTypes... _Args) {
         if (_MyPromise._Is_ready()) {
-            _Throw_future_error(make_error_code(future_errc::promise_already_satisfied));
+            _Throw_future_error_v2(future_errc::promise_already_satisfied);
         }
 
         _MyStateManagerType& _State = _MyPromise._Get_state_for_set();
         if (_State._Ptr()->_Already_has_stored_result()) {
-            _Throw_future_error(make_error_code(future_errc::promise_already_satisfied));
+            _Throw_future_error_v2(future_errc::promise_already_satisfied);
         }
 
         _MyStateType* _Ptr = static_cast<_MyStateType*>(_State._Ptr());

--- a/stl/inc/system_error
+++ b/stl/inc/system_error
@@ -385,20 +385,20 @@ _NODISCARD inline error_condition error_code::default_error_condition() const no
     return category().default_error_condition(value());
 }
 
-_NODISCARD inline error_code make_error_code(errc _Errno) noexcept {
-    return error_code(static_cast<int>(_Errno), _STD generic_category());
+_NODISCARD inline error_code make_error_code(errc _Ec) noexcept {
+    return error_code(static_cast<int>(_Ec), _STD generic_category());
 }
 
-_NODISCARD inline error_code make_error_code(io_errc _Errno) noexcept {
-    return error_code(static_cast<int>(_Errno), _STD iostream_category());
+_NODISCARD inline error_code make_error_code(io_errc _Ec) noexcept {
+    return error_code(static_cast<int>(_Ec), _STD iostream_category());
 }
 
-_NODISCARD inline error_condition make_error_condition(errc _Errno) noexcept {
-    return error_condition(static_cast<int>(_Errno), _STD generic_category());
+_NODISCARD inline error_condition make_error_condition(errc _Ec) noexcept {
+    return error_condition(static_cast<int>(_Ec), _STD generic_category());
 }
 
-_NODISCARD inline error_condition make_error_condition(io_errc _Errno) noexcept {
-    return error_condition(static_cast<int>(_Errno), _STD iostream_category());
+_NODISCARD inline error_condition make_error_condition(io_errc _Ec) noexcept {
+    return error_condition(static_cast<int>(_Ec), _STD iostream_category());
 }
 
 template <>
@@ -470,8 +470,8 @@ protected:
 #endif // !_HAS_EXCEPTIONS
 };
 
-[[noreturn]] inline void _Throw_system_error(const errc _Errno) {
-    _THROW(system_error{_STD make_error_code(_Errno)});
+[[noreturn]] inline void _Throw_system_error(const errc _Ec) {
+    _THROW(system_error{_STD make_error_code(_Ec)});
 }
 
 _CRTIMP2_PURE const char* __CLRCALL_PURE_OR_CDECL _Syserror_map(int);

--- a/stl/src/future.cpp
+++ b/stl/src/future.cpp
@@ -6,10 +6,12 @@
 
 _STD_BEGIN
 
+// TRANSITION, ABI: preserved for binary compatibility
 [[noreturn]] _CRTIMP2_PURE void __CLRCALL_PURE_OR_CDECL _Throw_future_error(const error_code& _Code) {
     _THROW(future_error(_Code));
 }
 
+// TRANSITION, ABI: preserved for binary compatibility
 [[noreturn]] _CRTIMP2_PURE void __CLRCALL_PURE_OR_CDECL _Rethrow_future_exception(exception_ptr _Ptr) {
     _STD rethrow_exception(_Ptr);
 }


### PR DESCRIPTION
* `<future>`: Bypass `_Throw_future_error`, `_Rethrow_future_exception`.
  + We don't need separately compiled functions for this (I believe we were imitating older code that was avoiding header circularity issues). We can add a header-only `_Throw_future_error2()` that's more convenient to call directly with a `future_errc`, and we can call `_STD rethrow_exception()` directly.
  + `future.cpp`: Mark the unused functions as preserved for bincompat. (No redist change.)
* `<chrono>`: Add `_Throw_nonexistent_local_time()`, `_Throw_ambiguous_local_time()`. We need extra parens for the macro, due to direct-list-init.
* `<format>`, `<chrono>`: Add `_Throw_format_error()`.
* Change `"charT"` to either `"char"` or `"wchar_t"` when throwing `format_error`.
* Rename `meow_errc _Errno` to `_Ec`.

In addition to following our conventions, these `[[noreturn]]` helpers can improve codegen by helping the compiler see that the EH-throwing paths are unlikely, thus separating out their large codegen and allowing the remaining small codegen (for the success path) to be potentially inlined.