### PR TITLE
Cleanups 3: Simple changes

### DIFF
--- a/stl/inc/array
+++ b/stl/inc/array
@@ -83,21 +83,9 @@ public:
         return *this;
     }
 
-    _NODISCARD _CONSTEXPR17 _Array_const_iterator operator+(const ptrdiff_t _Off) const noexcept {
-        _Array_const_iterator _Tmp = *this;
-        _Tmp += _Off;
-        return _Tmp;
-    }
-
     _CONSTEXPR17 _Array_const_iterator& operator-=(const ptrdiff_t _Off) noexcept {
         _Ptr -= _Off;
         return *this;
-    }
-
-    _NODISCARD _CONSTEXPR17 _Array_const_iterator operator-(const ptrdiff_t _Off) const noexcept {
-        _Array_const_iterator _Tmp = *this;
-        _Tmp -= _Off;
-        return _Tmp;
     }
 
     _NODISCARD _CONSTEXPR17 ptrdiff_t operator-(const _Array_const_iterator& _Right) const noexcept {
@@ -117,24 +105,8 @@ public:
         return _Ptr <=> _Right._Ptr;
     }
 #else // ^^^ _HAS_CXX20 ^^^ / vvv !_HAS_CXX20 vvv
-    _NODISCARD _CONSTEXPR17 bool operator!=(const _Array_const_iterator& _Right) const noexcept {
-        return !(*this == _Right);
-    }
-
     _NODISCARD _CONSTEXPR17 bool operator<(const _Array_const_iterator& _Right) const noexcept {
         return _Ptr < _Right._Ptr;
-    }
-
-    _NODISCARD _CONSTEXPR17 bool operator>(const _Array_const_iterator& _Right) const noexcept {
-        return _Right < *this;
-    }
-
-    _NODISCARD _CONSTEXPR17 bool operator<=(const _Array_const_iterator& _Right) const noexcept {
-        return !(_Right < *this);
-    }
-
-    _NODISCARD _CONSTEXPR17 bool operator>=(const _Array_const_iterator& _Right) const noexcept {
-        return !(*this < _Right);
     }
 #endif // !_HAS_CXX20
 
@@ -214,20 +186,8 @@ private:
         return *this;
     }
 
-    _NODISCARD _CONSTEXPR17 _Array_const_iterator operator+(const ptrdiff_t _Off) const noexcept {
-        _Array_const_iterator _Tmp = *this;
-        _Tmp += _Off;
-        return _Tmp;
-    }
-
     _CONSTEXPR17 _Array_const_iterator& operator-=(const ptrdiff_t _Off) noexcept {
         return *this += -_Off;
-    }
-
-    _NODISCARD _CONSTEXPR17 _Array_const_iterator operator-(const ptrdiff_t _Off) const noexcept {
-        _Array_const_iterator _Tmp = *this;
-        _Tmp -= _Off;
-        return _Tmp;
     }
 
     _NODISCARD _CONSTEXPR17 ptrdiff_t operator-(const _Array_const_iterator& _Right) const noexcept {
@@ -250,25 +210,9 @@ private:
         return _Idx <=> _Right._Idx;
     }
 #else // ^^^ _HAS_CXX20 ^^^ / vvv !_HAS_CXX20 vvv
-    _NODISCARD _CONSTEXPR17 bool operator!=(const _Array_const_iterator& _Right) const noexcept {
-        return !(*this == _Right);
-    }
-
     _NODISCARD _CONSTEXPR17 bool operator<(const _Array_const_iterator& _Right) const noexcept {
         _Compat(_Right);
         return _Idx < _Right._Idx;
-    }
-
-    _NODISCARD _CONSTEXPR17 bool operator>(const _Array_const_iterator& _Right) const noexcept {
-        return _Right < *this;
-    }
-
-    _NODISCARD _CONSTEXPR17 bool operator<=(const _Array_const_iterator& _Right) const noexcept {
-        return !(_Right < *this);
-    }
-
-    _NODISCARD _CONSTEXPR17 bool operator>=(const _Array_const_iterator& _Right) const noexcept {
-        return !(*this < _Right);
     }
 #endif // !_HAS_CXX20
 
@@ -295,6 +239,37 @@ private:
     pointer _Ptr; // beginning of array
     size_t _Idx; // offset into array
 #endif // _ITERATOR_DEBUG_LEVEL == 0
+
+public:
+    _NODISCARD _CONSTEXPR17 _Array_const_iterator operator+(const ptrdiff_t _Off) const noexcept {
+        _Array_const_iterator _Tmp = *this;
+        _Tmp += _Off;
+        return _Tmp;
+    }
+
+    _NODISCARD _CONSTEXPR17 _Array_const_iterator operator-(const ptrdiff_t _Off) const noexcept {
+        _Array_const_iterator _Tmp = *this;
+        _Tmp -= _Off;
+        return _Tmp;
+    }
+
+#if !_HAS_CXX20
+    _NODISCARD _CONSTEXPR17 bool operator!=(const _Array_const_iterator& _Right) const noexcept {
+        return !(*this == _Right);
+    }
+
+    _NODISCARD _CONSTEXPR17 bool operator>(const _Array_const_iterator& _Right) const noexcept {
+        return _Right < *this;
+    }
+
+    _NODISCARD _CONSTEXPR17 bool operator<=(const _Array_const_iterator& _Right) const noexcept {
+        return !(_Right < *this);
+    }
+
+    _NODISCARD _CONSTEXPR17 bool operator>=(const _Array_const_iterator& _Right) const noexcept {
+        return !(*this < _Right);
+    }
+#endif // !_HAS_CXX20
 };
 
 #if _ITERATOR_DEBUG_LEVEL != 0

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -2183,7 +2183,7 @@ namespace chrono {
     inline atomic<tzdb_list*> _Global_tzdb_list;
 
     _NODISCARD inline tzdb_list& get_tzdb_list() {
-        auto* _Tzdb_ptr = _Global_tzdb_list.load();
+        auto _Tzdb_ptr = _Global_tzdb_list.load();
         if (_Tzdb_ptr != nullptr) {
             return *_Tzdb_ptr;
         }

--- a/stl/inc/complex
+++ b/stl/inc/complex
@@ -1502,9 +1502,7 @@ template <class _Ty>
 _NODISCARD constexpr bool operator==(const _Ty& _Left, const complex<_Ty>& _Right) {
     return _Left == _Right.real() && 0 == _Right.imag();
 }
-#endif // !_HAS_CXX20
 
-#if !_HAS_CXX20
 template <class _Ty>
 _NODISCARD constexpr bool operator!=(const complex<_Ty>& _Left, const complex<_Ty>& _Right) {
     return !(_Left == _Right);

--- a/stl/inc/exception
+++ b/stl/inc/exception
@@ -114,7 +114,6 @@ public:
 protected:
     virtual void __CLR_OR_THIS_CALL _Doraise() const {} // perform class-specific exception handling
 
-protected:
     const char* _Ptr; // the message pointer
 };
 

--- a/stl/inc/execution
+++ b/stl/inc/execution
@@ -2675,7 +2675,7 @@ struct _Sort_operation { // context for background threads
 
     static void __stdcall _Threadpool_callback(
         __std_PTP_CALLBACK_INSTANCE, void* const _Context, const __std_PTP_WORK _Work) noexcept /* terminates */ {
-        auto* const _This = static_cast<_Sort_operation*>(_Context);
+        const auto _This  = static_cast<_Sort_operation*>(_Context);
         const auto _Basis = _This->_Basis;
         const auto _Pred  = _This->_Pred;
         auto& _Team       = _This->_Team;

--- a/stl/inc/future
+++ b/stl/inc/future
@@ -96,7 +96,7 @@ _NODISCARD inline error_condition make_error_condition(future_errc _Errno) noexc
     return error_condition(static_cast<int>(_Errno), _STD future_category());
 }
 
-inline const char* _Future_error_map(int _Errcode) noexcept { // convert to name of future error
+_NODISCARD inline const char* _Future_error_map(int _Errcode) noexcept { // convert to name of future error
     switch (static_cast<future_errc>(_Errcode)) { // switch on error code value
     case future_errc::broken_promise:
         return "broken promise";

--- a/stl/inc/memory_resource
+++ b/stl/inc/memory_resource
@@ -277,7 +277,7 @@ namespace pmr {
             _Pools.clear();
             _Pools.shrink_to_fit();
 
-            auto* _Ptr = _Chunks._Head._Next;
+            auto _Ptr = _Chunks._Head._Next;
             _Chunks._Clear();
             memory_resource* const _Resource = upstream_resource();
             while (_Ptr != &_Chunks._Head) {

--- a/stl/inc/scoped_allocator
+++ b/stl/inc/scoped_allocator
@@ -123,6 +123,7 @@ struct _Scoped_base<_Outer> : _Outer { // nest of allocators, one deep
 
 template <class _Outer, class... _Inner>
 class scoped_allocator_adaptor : public _Scoped_base<_Outer, _Inner...> { // nest of allocators
+private:
     using _Mybase       = _Scoped_base<_Outer, _Inner...>;
     using _Outer_traits = allocator_traits<_Outer>;
 

--- a/stl/inc/typeinfo
+++ b/stl/inc/typeinfo
@@ -25,7 +25,7 @@ _STL_DISABLE_CLANG_WARNINGS
 _STD_BEGIN
 
 // size in pointers of std::function and std::any (roughly 3 pointers larger than std::string when building debug)
-constexpr int _Small_object_num_ptrs = 6 + 16 / sizeof(void*);
+_INLINE_VAR constexpr int _Small_object_num_ptrs = 6 + 16 / sizeof(void*);
 
 #if !_HAS_EXCEPTIONS
 

--- a/stl/inc/xlocbuf
+++ b/stl/inc/xlocbuf
@@ -22,6 +22,7 @@ _STL_DISABLE_DEPRECATED_WARNING
 template <class _Codecvt, class _Elem = wchar_t, class _Traits = char_traits<_Elem>>
 class _CXX17_DEPRECATE_CODECVT_HEADER wbuffer_convert
     : public basic_streambuf<_Elem, _Traits> { // stream buffer associated with a codecvt facet
+private:
     enum _Mode { _Unused, _Wrote, _Need, _Got, _Eof };
     enum { _STRING_INC = 8 };
 
@@ -299,6 +300,7 @@ private:
 
 template <class _Codecvt, class _Elem = wchar_t, class _Walloc = allocator<_Elem>, class _Balloc = allocator<char>>
 class _CXX17_DEPRECATE_CODECVT_HEADER wstring_convert { // converts between _Elem (wide) and char (byte) strings
+private:
     enum { _BUF_INC = 8, _BUF_MAX = 16 };
     void _Init(const _Codecvt* _Pcvt_arg = new _Codecvt) { // initialize the object
         _State = state_type{};

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -107,9 +107,11 @@ constexpr bool _Is_pow_2(const size_t _Value) noexcept {
 _INLINE_VAR constexpr size_t _Big_allocation_threshold = 4096;
 _INLINE_VAR constexpr size_t _Big_allocation_alignment = 32;
 
-static_assert(2 * sizeof(void*) <= _Big_allocation_alignment,
-    "Big allocation alignment should at least match vector register alignment");
-static_assert(_Is_pow_2(_Big_allocation_alignment), "Big allocation alignment must be a power of two");
+// Big allocation alignment should at least match vector register alignment
+_STL_INTERNAL_STATIC_ASSERT(2 * sizeof(void*) <= _Big_allocation_alignment);
+
+// Big allocation alignment must be a power of two
+_STL_INTERNAL_STATIC_ASSERT(_Is_pow_2(_Big_allocation_alignment));
 
 #ifdef _DEBUG
 _INLINE_VAR constexpr size_t _Non_user_size = 2 * sizeof(void*) + _Big_allocation_alignment - 1;

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -104,23 +104,23 @@ constexpr bool _Is_pow_2(const size_t _Value) noexcept {
 }
 
 #if defined(_M_IX86) || defined(_M_X64)
-constexpr size_t _Big_allocation_threshold = 4096;
-constexpr size_t _Big_allocation_alignment = 32;
+_INLINE_VAR constexpr size_t _Big_allocation_threshold = 4096;
+_INLINE_VAR constexpr size_t _Big_allocation_alignment = 32;
 
 static_assert(2 * sizeof(void*) <= _Big_allocation_alignment,
     "Big allocation alignment should at least match vector register alignment");
 static_assert(_Is_pow_2(_Big_allocation_alignment), "Big allocation alignment must be a power of two");
 
 #ifdef _DEBUG
-constexpr size_t _Non_user_size = 2 * sizeof(void*) + _Big_allocation_alignment - 1;
+_INLINE_VAR constexpr size_t _Non_user_size = 2 * sizeof(void*) + _Big_allocation_alignment - 1;
 #else // _DEBUG
-constexpr size_t _Non_user_size           = sizeof(void*) + _Big_allocation_alignment - 1;
+_INLINE_VAR constexpr size_t _Non_user_size           = sizeof(void*) + _Big_allocation_alignment - 1;
 #endif // _DEBUG
 
 #ifdef _WIN64
-constexpr size_t _Big_allocation_sentinel = 0xFAFAFAFAFAFAFAFAULL;
+_INLINE_VAR constexpr size_t _Big_allocation_sentinel = 0xFAFAFAFAFAFAFAFAULL;
 #else // ^^^ _WIN64 ^^^ // vvv !_WIN64 vvv
-constexpr size_t _Big_allocation_sentinel = 0xFAFAFAFAUL;
+_INLINE_VAR constexpr size_t _Big_allocation_sentinel = 0xFAFAFAFAUL;
 #endif // _WIN64
 
 template <class _Traits>

--- a/stl/src/tzdb.cpp
+++ b/stl/src/tzdb.cpp
@@ -385,7 +385,7 @@ _NODISCARD __std_tzdb_time_zones_info* __stdcall __std_tzdb_get_time_zones() noe
 
     for (size_t _Name_idx = 0; _Name_idx < _Info->_Num_time_zones; ++_Name_idx) {
         int32_t _Elem_len{};
-        const auto* const _Elem = __icu_uenum_unext(_Enum.get(), &_Elem_len, &_UErr);
+        const auto _Elem = __icu_uenum_unext(_Enum.get(), &_Elem_len, &_UErr);
         if (U_FAILURE(_UErr) || _Elem == nullptr) {
             return _Report_error(_Info, __std_tzdb_error::_Icu_error);
         }

--- a/tests/std/tests/P0753R2_manipulators_for_cpp_synchronized_buffered_ostream/test.cpp
+++ b/tests/std/tests/P0753R2_manipulators_for_cpp_synchronized_buffered_ostream/test.cpp
@@ -48,7 +48,7 @@ void test_osyncstream_manipulators(
 
     assert(addressof(emit_on_flush(os)) == addressof(os));
     if constexpr (is_base_of_v<basic_osyncstream<char_type, traits_type, Alloc>, Ty>) {
-        auto* aSyncbuf = static_cast<basic_syncbuf<char_type, traits_type, Alloc>*>(os.rdbuf());
+        const auto aSyncbuf = static_cast<basic_syncbuf<char_type, traits_type, Alloc>*>(os.rdbuf());
         assert(aSyncbuf->_Stl_internal_check_get_emit_on_sync() == true);
         if (buf) {
             assert(buf->str == "");
@@ -77,7 +77,7 @@ void test_osyncstream_manipulators(
 
     assert(addressof(noemit_on_flush(os)) == addressof(os));
     if constexpr (is_base_of_v<basic_osyncstream<char_type, traits_type, Alloc>, Ty>) {
-        auto* aSyncbuf = static_cast<basic_syncbuf<char_type, traits_type, Alloc>*>(os.rdbuf());
+        const auto aSyncbuf = static_cast<basic_syncbuf<char_type, traits_type, Alloc>*>(os.rdbuf());
         assert(aSyncbuf->_Stl_internal_check_get_emit_on_sync() == false);
     }
 

--- a/tests/std/tests/VSO_0000000_initialize_everything/test.cpp
+++ b/tests/std/tests/VSO_0000000_initialize_everything/test.cpp
@@ -320,7 +320,7 @@ void test_weak_ptr_construction() {
 
     int i = 42;
     shared_ptr<int> x(shared_ptr<int>{}, &i);
-    const auto all_zero = [](const auto* const ptr) {
+    const auto all_zero = [](const auto ptr) {
         const auto first = reinterpret_cast<const char*>(ptr);
         const auto last  = reinterpret_cast<const char*>(ptr + 1);
         return all_of(first, last, [](const auto x) { return x == 0; });


### PR DESCRIPTION
* `<complex>`: Fuse `#if !_HAS_CXX20` sections.
* `<xlocbuf>`: `wbuffer_convert` and `wstring_convert` were using implicit `private:`.
* `<scoped_allocator>`: `scoped_allocator_adaptor` was using implicit `private:`.
* `<exception>`: Remove repeated `protected:`.
* `<typeinfo>`: Mark `_Small_object_num_ptrs` as `_INLINE_VAR`.
* `<xmemory>`: Mark constants as `_INLINE_VAR`.
  + We conventionally mark constants as `_INLINE_VAR` (or `inline` in C++17+) even when there's no real risk of odr-using them.
* `<xmemory>`: Use `_STL_INTERNAL_STATIC_ASSERT` for `_Big_allocation_alignment`.
  + This is a constant that we control, so there's no reason to evaluate these `static_assert`s for user code.
* `<future>`: Mark `_Future_error_map` as `_NODISCARD`.
* `<array>`: Extract `_Array_const_iterator` members that are IDL-independent.
  + This reduces repetition, and will make it easier to move `n + iter` to be a hidden friend (currently blocked by a compiler bug until 17.3 Preview 2).
* Avoid various uses of `auto*`.
