### PR TITLE
Cleanups 4: `quoted()`

### DIFF
--- a/stl/inc/iomanip
+++ b/stl/inc/iomanip
@@ -213,11 +213,7 @@ struct _Quote_out { // store pointer/length for string
 template <class _Elem>
 _NODISCARD _Quote_out<_Elem, void, size_t> quoted(
     const _Elem* _Ptr, _Elem _Delim = _Elem('"'), _Elem _Escape = _Elem('\\')) {
-    size_t _Size = 0;
-    while (_Ptr[_Size] != _Elem(0)) {
-        ++_Size;
-    }
-
+    const size_t _Size = char_traits<_Elem>::length(_Ptr);
     return {_Ptr, _Size, _Delim, _Escape};
 }
 

--- a/stl/inc/iomanip
+++ b/stl/inc/iomanip
@@ -218,29 +218,27 @@ _NODISCARD _Quote_out<_Elem, void, size_t> quoted(
         ++_Size;
     }
 
-    return _Quote_out<_Elem, void, size_t>(_Ptr, _Size, _Delim, _Escape);
+    return {_Ptr, _Size, _Delim, _Escape};
 }
 
 template <class _Elem, class _Traits, class _Alloc>
 _NODISCARD _Quote_out<_Elem, _Traits, typename basic_string<_Elem, _Traits, _Alloc>::size_type> quoted(
     const basic_string<_Elem, _Traits, _Alloc>& _Str, _Elem _Delim = _Elem('"'), _Elem _Escape = _Elem('\\')) {
-    using _Qobj = _Quote_out<_Elem, _Traits, typename basic_string<_Elem, _Traits, _Alloc>::size_type>;
-    return _Qobj(_Str.c_str(), _Str.size(), _Delim, _Escape);
+    return {_Str.c_str(), _Str.size(), _Delim, _Escape};
 }
 
 #if _HAS_CXX17
 template <class _Elem, class _Traits>
 _NODISCARD _Quote_out<_Elem, _Traits, size_t> quoted(
     const basic_string_view<_Elem, _Traits> _Str, _Elem _Delim = _Elem('"'), _Elem _Escape = _Elem('\\')) {
-    using _Qobj = _Quote_out<_Elem, _Traits, size_t>;
-    return _Qobj(_Str.data(), _Str.size(), _Delim, _Escape);
+    return {_Str.data(), _Str.size(), _Delim, _Escape};
 }
 #endif // _HAS_CXX17
 
 template <class _Elem, class _Traits, class _Alloc>
 _NODISCARD _Quote_in<_Elem, _Traits, _Alloc> quoted(
     basic_string<_Elem, _Traits, _Alloc>& _Str, _Elem _Delim = _Elem('"'), _Elem _Escape = _Elem('\\')) {
-    return _Quote_in<_Elem, _Traits, _Alloc>(_Str, _Delim, _Escape);
+    return {_Str, _Delim, _Escape};
 }
 
 template <class _Elem, class _Traits, class _QuTraits, class _Sizet>


### PR DESCRIPTION
* Avoid repeating types in `quoted()` by using `return {m,e,o,w};`.
  + The types are verbose, and the constructors are implicit. I considered this slightly more convenient/readable than returning `auto`.
* Use `char_traits::length()` instead of a raw loop in `quoted()`.
  + Please verify my claim that this does not change runtime behavior (we're getting the same answer, number of characters before the null terminator).
  + I think we might have thought that `char_traits` was unavailable, but it is *totally* available here, just through an epic-length chain of dependencies. Using `char_traits` is not only simpler, it has the potential to be faster for `char` (especially) and `wchar_t`.