### PR TITLE
Cleanups 6: iostreams: drop `extern`, hide `_Winit`

### DIFF
--- a/stl/inc/fstream
+++ b/stl/inc/fstream
@@ -60,11 +60,11 @@ _INLINE_VAR constexpr bool _Is_any_path = _Is_any_of_v<_Ty
     >;
 // clang-format on
 
-extern _CRTIMP2_PURE FILE* __CLRCALL_PURE_OR_CDECL _Fiopen(const char*, ios_base::openmode, int);
-extern _CRTIMP2_PURE FILE* __CLRCALL_PURE_OR_CDECL _Fiopen(const wchar_t*, ios_base::openmode, int);
+_CRTIMP2_PURE FILE* __CLRCALL_PURE_OR_CDECL _Fiopen(const char*, ios_base::openmode, int);
+_CRTIMP2_PURE FILE* __CLRCALL_PURE_OR_CDECL _Fiopen(const wchar_t*, ios_base::openmode, int);
 
 #ifdef _NATIVE_WCHAR_T_DEFINED
-extern _CRTIMP2_PURE FILE* __CLRCALL_PURE_OR_CDECL _Fiopen(const unsigned short*, ios_base::openmode, int);
+_CRTIMP2_PURE FILE* __CLRCALL_PURE_OR_CDECL _Fiopen(const unsigned short*, ios_base::openmode, int);
 #endif // _NATIVE_WCHAR_T_DEFINED
 
 template <class _Elem>

--- a/stl/inc/iostream
+++ b/stl/inc/iostream
@@ -54,6 +54,7 @@ __PURE_APPDOMAIN_GLOBAL extern _CRTDATA2_IMPORT wostream* _Ptr_wcout;
 __PURE_APPDOMAIN_GLOBAL extern _CRTDATA2_IMPORT wostream* _Ptr_wcerr;
 __PURE_APPDOMAIN_GLOBAL extern _CRTDATA2_IMPORT wostream* _Ptr_wclog;
 
+#ifdef _CRTBLD // TRANSITION, ABI: _Winit appears to be unused
 class _CRTIMP2_PURE_IMPORT _Winit {
 public:
     __thiscall _Winit();
@@ -62,6 +63,8 @@ public:
 private:
     __PURE_APPDOMAIN_GLOBAL static int _Init_cnt;
 };
+#endif // _CRTBLD
+
 #endif // _M_CEE_PURE
 _STD_END
 #pragma pop_macro("new")

--- a/stl/inc/xlocnum
+++ b/stl/inc/xlocnum
@@ -24,19 +24,16 @@ _STL_DISABLE_CLANG_WARNINGS
 
 _EXTERN_C_UNLESS_PURE
 
-extern _CRTIMP2_PURE float __CLRCALL_PURE_OR_CDECL _Stofx(
+_CRTIMP2_PURE float __CLRCALL_PURE_OR_CDECL _Stofx(const char*, _Out_opt_ _Deref_post_opt_valid_ char**, long, int*);
+_CRTIMP2_PURE double __CLRCALL_PURE_OR_CDECL _Stodx(const char*, _Out_opt_ _Deref_post_opt_valid_ char**, long, int*);
+_CRTIMP2_PURE long double __CLRCALL_PURE_OR_CDECL _Stoldx(
     const char*, _Out_opt_ _Deref_post_opt_valid_ char**, long, int*);
-extern _CRTIMP2_PURE double __CLRCALL_PURE_OR_CDECL _Stodx(
-    const char*, _Out_opt_ _Deref_post_opt_valid_ char**, long, int*);
-extern _CRTIMP2_PURE long double __CLRCALL_PURE_OR_CDECL _Stoldx(
-    const char*, _Out_opt_ _Deref_post_opt_valid_ char**, long, int*);
-extern _CRTIMP2_PURE long __CLRCALL_PURE_OR_CDECL _Stolx(
+_CRTIMP2_PURE long __CLRCALL_PURE_OR_CDECL _Stolx(const char*, _Out_opt_ _Deref_post_opt_valid_ char**, int, int*);
+_CRTIMP2_PURE unsigned long __CLRCALL_PURE_OR_CDECL _Stoulx(
     const char*, _Out_opt_ _Deref_post_opt_valid_ char**, int, int*);
-extern _CRTIMP2_PURE unsigned long __CLRCALL_PURE_OR_CDECL _Stoulx(
+_CRTIMP2_PURE long long __CLRCALL_PURE_OR_CDECL _Stollx(
     const char*, _Out_opt_ _Deref_post_opt_valid_ char**, int, int*);
-extern _CRTIMP2_PURE long long __CLRCALL_PURE_OR_CDECL _Stollx(
-    const char*, _Out_opt_ _Deref_post_opt_valid_ char**, int, int*);
-extern _CRTIMP2_PURE unsigned long long __CLRCALL_PURE_OR_CDECL _Stoullx(
+_CRTIMP2_PURE unsigned long long __CLRCALL_PURE_OR_CDECL _Stoullx(
     const char*, _Out_opt_ _Deref_post_opt_valid_ char**, int, int*);
 
 _END_EXTERN_C_UNLESS_PURE


### PR DESCRIPTION
* `<fstream>`, `<xlocnum>`: `_Fiopen()` and the `_Stofx()` family don't need to be declared as `extern` (that's the default, and we don't say `extern` when declaring other separately compiled functions).
  + Noticed while implementing Standard Library Modules, where I'll have to add `extern "C++"` which is different.
* `<iostream>`: Prevent `_Winit` from being seen by users.
  + Nothing else mentions this, so we don't need to declare it for users. We still need to export it to preserve bincompat, but I believe that it is completely dead (nothing constructs an object of this type, nor the macroized `_UShinit`), so I'm adding a comment that it appears to be unused (and thus can be completely removed during vNext).