### PR TITLE
Cleanups 7: Unnecessary guard around `new_handler`

### DIFF
--- a/stl/inc/new
+++ b/stl/inc/new
@@ -43,10 +43,7 @@ inline constexpr size_t hardware_destructive_interference_size  = 64;
 
 #endif // _HAS_CXX17
 
-#if !defined(_INC_NEW) || !defined(_MSC_EXTENSIONS)
-// handler for operator new failures
 using new_handler = void(__CLRCALL_PURE_OR_CDECL*)();
-#endif // !defined(_INC_NEW) || !defined(_MSC_EXTENSIONS)
 
 _CRTIMP2 new_handler __cdecl set_new_handler(_In_opt_ new_handler) noexcept;
 _NODISCARD _CRTIMP2 new_handler __cdecl get_new_handler() noexcept;


### PR DESCRIPTION
This removes the (very strange) guard `#if !defined(_INC_NEW) || !defined(_MSC_EXTENSIONS)` around the `new_handler` typedef.

It appears that this guard may have been intended to avoid duplicate typedefs because `<new.h>` can include `<new>` (weirdly). However, duplicate typedefs have always been possible - if `<new>` was included first, `!defined(_INC_NEW)` would be true, so `<new>` would emit `new_handler`. Then if `<new.h>` is included, with the default of `/Ze`, `#if defined _MSC_EXTENSIONS && !defined _CORECRT_BUILD` would be true, so it would also emit `new_handler` within `namespace std`. (See `C:\Program Files (x86)\Windows Kits\10\Include\10.0.22000.0\ucrt\new.h`.) There's no conflict as long as the typedefs are identical.

With this removal, there is no conflict regardless of inclusion order or `/Za`:

```
C:\Temp>type meow.cpp
```
```cpp
// clang-format off
#if defined(ONLY_NEW_H)
#include <new.h>
#elif defined(ONLY_STD_NEW)
#include <new>
#elif defined(NEW_H_FIRST)
#include <new.h>
#include <new>
#elif defined(STD_NEW_FIRST)
#include <new>
#include <new.h>
#else
#error WOOF
#endif
// clang-format on
#include <type_traits>
static_assert(std::is_same_v<std::new_handler, void (*)()>, "WOOF");
int main() {}
```
```
C:\Temp>cl /EHsc /nologo /W4 /DONLY_NEW_H meow.cpp
meow.cpp

C:\Temp>cl /EHsc /nologo /W4 /DONLY_STD_NEW meow.cpp
meow.cpp

C:\Temp>cl /EHsc /nologo /W4 /DNEW_H_FIRST meow.cpp
meow.cpp

C:\Temp>cl /EHsc /nologo /W4 /DSTD_NEW_FIRST meow.cpp
meow.cpp

C:\Temp>cl /EHsc /nologo /W4 /Za /DONLY_NEW_H meow.cpp
meow.cpp

C:\Temp>cl /EHsc /nologo /W4 /Za /DONLY_STD_NEW meow.cpp
meow.cpp

C:\Temp>cl /EHsc /nologo /W4 /Za /DNEW_H_FIRST meow.cpp
meow.cpp

C:\Temp>cl /EHsc /nologo /W4 /Za /DSTD_NEW_FIRST meow.cpp
meow.cpp

C:\Temp>
```

This also removes an unnecessary comment (that essentially repeats the type; it's not like the comment alone would teach people how to use this machinery).