### PR TITLE
Vectorize `swap` and `ranges::swap` for arrays

### DIFF
--- a/stl/inc/concepts
+++ b/stl/inc/concepts
@@ -152,19 +152,19 @@ namespace ranges {
                 noexcept(noexcept((*this)(__t[0], __u[0])))
                 requires requires { (*this)(__t[0], __u[0]); } {
 #if _USE_STD_VECTOR_ALGORITHMS
-    if constexpr (is_same_v<_Ty1, _Ty2> && _Is_trivially_swappable_v<_Ty1>) {
-        const auto _First1 = __t;
-        const auto _First2 = __u;
+                if constexpr (is_same_v<_Ty1, _Ty2> && _Is_trivially_swappable_v<_Ty1>) {
+                    const auto _First1 = __t;
+                    const auto _First2 = __u;
 
-        if (_First1 == _First2) {
-            return;
-        }
+                    if (_First1 == _First2) {
+                        return;
+                    }
 
-        if (!_STD is_constant_evaluated()) {
-            __std_swap_ranges_trivially_swappable_noalias(_First1, _First1 + _Size, _First2);
-            return;
-        }
-    }
+                    if (!_STD is_constant_evaluated()) {
+                        __std_swap_ranges_trivially_swappable_noalias(_First1, _First1 + _Size, _First2);
+                        return;
+                    }
+                }
 #endif // _USE_STD_VECTOR_ALGORITHMS
 
                 for (size_t __i = 0; __i < _Size; ++__i) {

--- a/stl/inc/concepts
+++ b/stl/inc/concepts
@@ -151,6 +151,22 @@ namespace ranges {
             constexpr void operator()(_Ty1 (&__t)[_Size], _Ty2 (&__u)[_Size]) const
                 noexcept(noexcept((*this)(__t[0], __u[0])))
                 requires requires { (*this)(__t[0], __u[0]); } {
+#if _USE_STD_VECTOR_ALGORITHMS
+    if constexpr (is_same_v<_Ty1, _Ty2> && _Is_trivially_swappable_v<_Ty1>) {
+        const auto _First1 = __t;
+        const auto _First2 = __u;
+
+        if (_First1 == _First2) {
+            return;
+        }
+
+        if (!_STD is_constant_evaluated()) {
+            __std_swap_ranges_trivially_swappable_noalias(_First1, _First1 + _Size, _First2);
+            return;
+        }
+    }
+#endif // _USE_STD_VECTOR_ALGORITHMS
+
                 for (size_t __i = 0; __i < _Size; ++__i) {
                     (*this)(__t[__i], __u[__i]);
                 }

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -18,6 +18,39 @@ _STL_DISABLE_CLANG_WARNINGS
 #pragma push_macro("new")
 #undef new
 
+// Note: Defining _USE_STD_VECTOR_ALGORITHMS to 0 may be necessary to use "core" headers
+// without linking to the STL's separately compiled code.
+
+#if defined(_CRTBLD) && defined(CRTDLL2)
+// TRANSITION, ABI: The vector algorithms are compiled into the import lib, so we disable their usage when building
+// the DLL. (We could additionally link them into the DLL - not as exports, just for internal usage - but we
+// haven't chosen to do that yet.) When we can break ABI and export the vector algorithms from the DLL,
+// this preprocessor case should be removed.
+#ifndef _USE_STD_VECTOR_ALGORITHMS
+#define _USE_STD_VECTOR_ALGORITHMS 0
+#elif _USE_STD_VECTOR_ALGORITHMS
+#error Vector algorithms are not supported when building msvcp140.dll, but _USE_STD_VECTOR_ALGORITHMS is set.
+#endif // _USE_STD_VECTOR_ALGORITHMS
+#elif (defined(_M_IX86) || defined(_M_X64)) && !defined(_M_CEE_PURE) && !defined(_M_HYBRID) && !defined(_M_ARM64EC)
+#ifndef _USE_STD_VECTOR_ALGORITHMS
+#define _USE_STD_VECTOR_ALGORITHMS 1
+#endif // _USE_STD_VECTOR_ALGORITHMS
+#else // ^^^ arch supports vector algorithms / no support for vector algorithms vvv
+#ifndef _USE_STD_VECTOR_ALGORITHMS
+#define _USE_STD_VECTOR_ALGORITHMS 0
+#elif _USE_STD_VECTOR_ALGORITHMS
+#error Vector algorithms are not supported on this architecture, but _USE_STD_VECTOR_ALGORITHMS is set.
+#endif // _USE_STD_VECTOR_ALGORITHMS
+#endif // ^^^ no support for vector algorithms ^^^
+
+#if _USE_STD_VECTOR_ALGORITHMS
+_EXTERN_C
+// See the important comment about the "noalias" attribute in <xutility>.
+__declspec(noalias) void __cdecl __std_swap_ranges_trivially_swappable_noalias(
+    void* _First1, void* _Last1, void* _First2) noexcept;
+_END_EXTERN_C
+#endif // _USE_STD_VECTOR_ALGORITHMS
+
 _STD_BEGIN
 template <class _Ty, _Ty... _Vals>
 struct integer_sequence { // sequence of integer parameters

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -110,13 +110,13 @@ _CONSTEXPR20 void iter_swap(_FwdIt1 _Left, _FwdIt2 _Right) { // swap *_Left and 
 
 template <class _Ty, size_t _Size, enable_if_t<_Is_swappable<_Ty>::value, int> _Enabled>
 _CONSTEXPR20 void swap(_Ty (&_Left)[_Size], _Ty (&_Right)[_Size]) noexcept(_Is_nothrow_swappable<_Ty>::value) {
-    if (&_Left == &_Right) {
-        return;
-    }
-
     _Ty* _First1 = _Left;
     _Ty* _Last1  = _First1 + _Size;
     _Ty* _First2 = _Right;
+
+    if (_First1 == _First2) {
+        return;
+    }
 
 #if _USE_STD_VECTOR_ALGORITHMS
     if constexpr (_Is_trivially_swappable_v<_Ty>) {

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -26,6 +26,36 @@ _STL_DISABLE_CLANG_WARNINGS
 #pragma push_macro("new")
 #undef new
 
+#if defined(_CRTBLD) && defined(CRTDLL2)
+// TRANSITION, ABI: The vector algorithms are compiled into the import lib, so we disable their usage when building
+// the DLL. (We could additionally link them into the DLL - not as exports, just for internal usage - but we
+// haven't chosen to do that yet.) When we can break ABI and export the vector algorithms from the DLL,
+// this preprocessor case should be removed.
+#ifndef _USE_STD_VECTOR_ALGORITHMS
+#define _USE_STD_VECTOR_ALGORITHMS 0
+#elif _USE_STD_VECTOR_ALGORITHMS
+#error Vector algorithms are not supported when building msvcp140.dll, but _USE_STD_VECTOR_ALGORITHMS is set.
+#endif // _USE_STD_VECTOR_ALGORITHMS
+#elif (defined(_M_IX86) || defined(_M_X64)) && !defined(_M_CEE_PURE) && !defined(_M_HYBRID) && !defined(_M_ARM64EC)
+#ifndef _USE_STD_VECTOR_ALGORITHMS
+#define _USE_STD_VECTOR_ALGORITHMS 1
+#endif // _USE_STD_VECTOR_ALGORITHMS
+#else // ^^^ arch supports vector algorithms / no support for vector algorithms vvv
+#ifndef _USE_STD_VECTOR_ALGORITHMS
+#define _USE_STD_VECTOR_ALGORITHMS 0
+#elif _USE_STD_VECTOR_ALGORITHMS
+#error Vector algorithms are not supported on this architecture, but _USE_STD_VECTOR_ALGORITHMS is set.
+#endif // _USE_STD_VECTOR_ALGORITHMS
+#endif // ^^^ no support for vector algorithms ^^^
+
+#if _USE_STD_VECTOR_ALGORITHMS
+_EXTERN_C
+// See the important comment about the "noalias" attribute in <xutility>.
+__declspec(noalias) void __cdecl __std_swap_ranges_trivially_swappable_noalias(
+    void* _First1, void* _Last1, void* _First2) noexcept;
+_END_EXTERN_C
+#endif // _USE_STD_VECTOR_ALGORITHMS
+
 _STD_BEGIN
 template <class _Ty, class _Pr>
 _NODISCARD constexpr const _Ty&(max) (const _Ty& _Left, const _Ty& _Right, _Pr _Pred) noexcept(
@@ -80,13 +110,28 @@ _CONSTEXPR20 void iter_swap(_FwdIt1 _Left, _FwdIt2 _Right) { // swap *_Left and 
 
 template <class _Ty, size_t _Size, enable_if_t<_Is_swappable<_Ty>::value, int> _Enabled>
 _CONSTEXPR20 void swap(_Ty (&_Left)[_Size], _Ty (&_Right)[_Size]) noexcept(_Is_nothrow_swappable<_Ty>::value) {
-    if (&_Left != &_Right) {
-        _Ty* _First1 = _Left;
-        _Ty* _Last1  = _First1 + _Size;
-        _Ty* _First2 = _Right;
-        for (; _First1 != _Last1; ++_First1, ++_First2) {
-            _STD iter_swap(_First1, _First2);
+    if (&_Left == &_Right) {
+        return;
+    }
+
+    _Ty* _First1 = _Left;
+    _Ty* _Last1  = _First1 + _Size;
+    _Ty* _First2 = _Right;
+
+#if _USE_STD_VECTOR_ALGORITHMS
+    if constexpr (_Is_trivially_swappable_v<_Ty>) {
+#if _HAS_CXX20
+        if (!_STD is_constant_evaluated())
+#endif // _HAS_CXX20
+        {
+            __std_swap_ranges_trivially_swappable_noalias(_First1, _Last1, _First2);
+            return;
         }
+    }
+#endif // _USE_STD_VECTOR_ALGORITHMS
+
+    for (; _First1 != _Last1; ++_First1, ++_First2) {
+        _STD iter_swap(_First1, _First2);
     }
 }
 

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -26,36 +26,6 @@ _STL_DISABLE_CLANG_WARNINGS
 #pragma push_macro("new")
 #undef new
 
-#if defined(_CRTBLD) && defined(CRTDLL2)
-// TRANSITION, ABI: The vector algorithms are compiled into the import lib, so we disable their usage when building
-// the DLL. (We could additionally link them into the DLL - not as exports, just for internal usage - but we
-// haven't chosen to do that yet.) When we can break ABI and export the vector algorithms from the DLL,
-// this preprocessor case should be removed.
-#ifndef _USE_STD_VECTOR_ALGORITHMS
-#define _USE_STD_VECTOR_ALGORITHMS 0
-#elif _USE_STD_VECTOR_ALGORITHMS
-#error Vector algorithms are not supported when building msvcp140.dll, but _USE_STD_VECTOR_ALGORITHMS is set.
-#endif // _USE_STD_VECTOR_ALGORITHMS
-#elif (defined(_M_IX86) || defined(_M_X64)) && !defined(_M_CEE_PURE) && !defined(_M_HYBRID) && !defined(_M_ARM64EC)
-#ifndef _USE_STD_VECTOR_ALGORITHMS
-#define _USE_STD_VECTOR_ALGORITHMS 1
-#endif // _USE_STD_VECTOR_ALGORITHMS
-#else // ^^^ arch supports vector algorithms / no support for vector algorithms vvv
-#ifndef _USE_STD_VECTOR_ALGORITHMS
-#define _USE_STD_VECTOR_ALGORITHMS 0
-#elif _USE_STD_VECTOR_ALGORITHMS
-#error Vector algorithms are not supported on this architecture, but _USE_STD_VECTOR_ALGORITHMS is set.
-#endif // _USE_STD_VECTOR_ALGORITHMS
-#endif // ^^^ no support for vector algorithms ^^^
-
-#if _USE_STD_VECTOR_ALGORITHMS
-_EXTERN_C
-// See the important comment about the "noalias" attribute in <xutility>.
-__declspec(noalias) void __cdecl __std_swap_ranges_trivially_swappable_noalias(
-    void* _First1, void* _Last1, void* _First2) noexcept;
-_END_EXTERN_C
-#endif // _USE_STD_VECTOR_ALGORITHMS
-
 _STD_BEGIN
 template <class _Ty, class _Pr>
 _NODISCARD constexpr const _Ty&(max) (const _Ty& _Left, const _Ty& _Right, _Pr _Pred) noexcept(

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -21,28 +21,6 @@ _STL_DISABLE_CLANG_WARNINGS
 #pragma push_macro("new")
 #undef new
 
-#if defined(_CRTBLD) && defined(CRTDLL2)
-// TRANSITION, ABI: The vector algorithms are compiled into the import lib, so we disable their usage when building
-// the DLL. (We could additionally link them into the DLL - not as exports, just for internal usage - but we
-// haven't chosen to do that yet.) When we can break ABI and export the vector algorithms from the DLL,
-// this preprocessor case should be removed.
-#ifndef _USE_STD_VECTOR_ALGORITHMS
-#define _USE_STD_VECTOR_ALGORITHMS 0
-#elif _USE_STD_VECTOR_ALGORITHMS
-#error Vector algorithms are not supported when building msvcp140.dll, but _USE_STD_VECTOR_ALGORITHMS is set.
-#endif // _USE_STD_VECTOR_ALGORITHMS
-#elif (defined(_M_IX86) || defined(_M_X64)) && !defined(_M_CEE_PURE) && !defined(_M_HYBRID) && !defined(_M_ARM64EC)
-#ifndef _USE_STD_VECTOR_ALGORITHMS
-#define _USE_STD_VECTOR_ALGORITHMS 1
-#endif // _USE_STD_VECTOR_ALGORITHMS
-#else // ^^^ arch supports vector algorithms / no support for vector algorithms vvv
-#ifndef _USE_STD_VECTOR_ALGORITHMS
-#define _USE_STD_VECTOR_ALGORITHMS 0
-#elif _USE_STD_VECTOR_ALGORITHMS
-#error Vector algorithms are not supported on this architecture, but _USE_STD_VECTOR_ALGORITHMS is set.
-#endif // _USE_STD_VECTOR_ALGORITHMS
-#endif // ^^^ no support for vector algorithms ^^^
-
 #ifdef __CUDACC__
 #define _CONSTEXPR_BIT_CAST inline
 #else // ^^^ workaround ^^^ / vvv no workaround vvv
@@ -62,8 +40,6 @@ __declspec(noalias) void __cdecl __std_reverse_trivially_swappable_1(void* _Firs
 __declspec(noalias) void __cdecl __std_reverse_trivially_swappable_2(void* _First, void* _Last) noexcept;
 __declspec(noalias) void __cdecl __std_reverse_trivially_swappable_4(void* _First, void* _Last) noexcept;
 __declspec(noalias) void __cdecl __std_reverse_trivially_swappable_8(void* _First, void* _Last) noexcept;
-__declspec(noalias) void __cdecl __std_swap_ranges_trivially_swappable_noalias(
-    void* _First1, void* _Last1, void* _First2) noexcept;
 
 __declspec(noalias) size_t
     __stdcall __std_count_trivial_1(const void* _First, const void* _Last, uint8_t _Val) noexcept;

--- a/tests/std/tests/VSO_0000000_vector_algorithms/test.cpp
+++ b/tests/std/tests/VSO_0000000_vector_algorithms/test.cpp
@@ -12,6 +12,10 @@
 #include <type_traits>
 #include <vector>
 
+#ifdef __cpp_lib_concepts
+#include <concepts>
+#endif // __cpp_lib_concepts
+
 using namespace std;
 
 #if (defined(_M_IX86) || defined(_M_X64)) && !defined(_M_CEE_PURE)
@@ -184,6 +188,13 @@ void test_swap_arrays(mt19937_64& gen) {
 
     assert(equal(begin(left), end(left), origRight.begin(), origRight.end()));
     assert(equal(begin(right), end(right), origLeft.begin(), origLeft.end()));
+
+#ifdef __cpp_lib_concepts
+    ranges::swap(left, right);
+
+    assert(equal(begin(left), end(left), origLeft.begin(), origLeft.end()));
+    assert(equal(begin(right), end(right), origRight.begin(), origRight.end()));
+#endif // __cpp_lib_concepts
 }
 
 void test_vector_algorithms() {

--- a/tests/std/tests/VSO_0000000_vector_algorithms/test.cpp
+++ b/tests/std/tests/VSO_0000000_vector_algorithms/test.cpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <assert.h>
 #include <cstddef>
+#include <cstdint>
 #include <deque>
 #include <isa_availability.h>
 #include <list>
@@ -167,6 +168,24 @@ void test_swap_ranges(mt19937_64& gen) {
     }
 }
 
+// GH-2683 "std::swap of arrays, why is there no specialization for trivial types"
+template <class T, size_t N>
+void test_swap_arrays(mt19937_64& gen) {
+    const auto fn = [&]() { return static_cast<T>(gen()); };
+    T left[N];
+    T right[N];
+    generate(begin(left), end(left), fn);
+    generate(begin(right), end(right), fn);
+
+    const vector<T> origLeft(begin(left), end(left));
+    const vector<T> origRight(begin(right), end(right));
+
+    swap(left, right);
+
+    assert(equal(begin(left), end(left), origRight.begin(), origRight.end()));
+    assert(equal(begin(right), end(right), origLeft.begin(), origLeft.end()));
+}
+
 void test_vector_algorithms() {
     mt19937_64 gen(1729);
 
@@ -221,6 +240,21 @@ void test_vector_algorithms() {
     test_swap_ranges<int>(gen);
     test_swap_ranges<unsigned int>(gen);
     test_swap_ranges<unsigned long long>(gen);
+
+    test_swap_arrays<uint8_t, 1>(gen);
+    test_swap_arrays<uint16_t, 1>(gen);
+    test_swap_arrays<uint32_t, 1>(gen);
+    test_swap_arrays<uint64_t, 1>(gen);
+
+    test_swap_arrays<uint8_t, 47>(gen);
+    test_swap_arrays<uint16_t, 47>(gen);
+    test_swap_arrays<uint32_t, 47>(gen);
+    test_swap_arrays<uint64_t, 47>(gen);
+
+    test_swap_arrays<uint8_t, 512>(gen);
+    test_swap_arrays<uint16_t, 512>(gen);
+    test_swap_arrays<uint32_t, 512>(gen);
+    test_swap_arrays<uint64_t, 512>(gen);
 }
 
 template <typename Container1, typename Container2>


### PR DESCRIPTION
Fixes #2683.

The (minor) main difficulty here is that the vectorized machinery was defined in `<xutility>`, but `swap()` for arrays is defined in its parent header `<utility>`, and `ranges::swap` is defined in `<concepts>`. To solve this, I'm moving the definition of `_USE_STD_VECTOR_ALGORITHMS` up to `<type_traits>` (unchanged), then extracting only the declaration of `__std_swap_ranges_trivially_swappable_noalias()`, with a comment directing the reader to `<xutility>`. (Any merge conflicts with vectorization PRs in flight should be trivial to resolve.)

Because `<utility>` and `<concepts>` are "core" headers, I'm also adding a comment that if users want to use them without linking to the STL, they might need to disable our use of vectorized algorithms.

Since we've already extensively tested this implementation, I'm adding a small amount of incremental test coverage. This covers various element sizes and array lengths (from 1 element of 1 byte, to 512 elements of 8 bytes).

Small cleanup in `<utility>`: Because the control flow is becoming more complicated, I'm changing the `if (&_Left != &_Right)` self-swap guard to an `if (_First1 == _First2)` early return. This uses the named pointers we already need, instead of taking the addresses of the arrays.

In `<concepts>`, I'm using `const auto` to decay the arrays; I felt that this looked simpler than saying `_Ty1` here even though we know that it's the same as `_Ty2`. Then, we need to defend `__std_swap_ranges_trivially_swappable_noalias` with a self-swap check; I believe that it should be within the "we're eligible for vectorization" preprocessor and `if constexpr` checks (because the condition is rare), but that it didn't need to be within the "we're at runtime" codepath (it's okay for constant evaluation to perform the self-swap check).