### PR TITLE
Reject time point parse with 60 seconds unless H:M == 23:59

### DIFF
--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -3385,9 +3385,10 @@ namespace chrono {
                                  | (_Can_rep_day ? _F_doy : 0)};
 
             const auto _Used{_Used_fields()};
-            const auto _Time_out_of_range{
-                _For_time_point
-                && (_Out_of_range(_Second, 0, 60) || _Out_of_range(_Minute, 0, 59) || _Out_of_range(_Hour_24, 0, 23))};
+            const auto _Max_seconds{(_Hour_24 == 23 && _Minute == 59) ? 60 : 59};
+            const auto _Time_out_of_range{_For_time_point
+                                          && (_Out_of_range(_Second, 0, _Max_seconds) || _Out_of_range(_Minute, 0, 59)
+                                              || _Out_of_range(_Hour_24, 0, 23))};
 
             if (_Time_out_of_range || !_Test_bits(_Used, _Required, _Optional)) {
                 return false;

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_io/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_io/test.cpp
@@ -375,6 +375,16 @@ void parse_other_duration() {
     test_parse("00:34:04", "%T", time);
     assert(time == 34min + 4s);
 
+    // GH-2698: For duration parsing, ensure 60 seconds is allowed, even when hours and minutes don't equal 23 and 59.
+    test_parse("00:00:60", "%T", time);
+    assert(time == 60s);
+    test_parse("23:00:60", "%T", time);
+    assert(time == 23h + 60s);
+    test_parse("00:59:60", "%T", time);
+    assert(time == 59min + 60s);
+    test_parse("23:59:60", "%T", time);
+    assert(time == 23h + 59min + 60s);
+
     milliseconds time_milli;
     test_parse("12:34:56.789", "%T", time_milli);
     assert(time_milli == 12h + 34min + 56s + 789ms);
@@ -1066,6 +1076,9 @@ void parse_timepoints() {
     ut_ref = utc_clock::from_sys(sys_days{1d / July / 1992y}) - 1s;
     test_parse("june 30 23:59:60 1992", "%c", ut);
     assert(ut == ut_ref);
+    // GH-2698: leap second insertion should only be considered at 23:59.
+    fail_parse("june 30 23:00:60 1992", "%c", ut);
+    fail_parse("june 30 00:59:60 1992", "%c", ut);
 
     // not leap-second aware
     fail_parse("june 30 23:59:60 1972", "%c", st);


### PR DESCRIPTION
Fixes #2698.