### PR TITLE
Block C++98 `unexpected()` from being restored in C++23 mode

### DIFF
--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -684,6 +684,10 @@
 #define _HAS_UNEXPECTED (!_HAS_CXX17)
 #endif // _HAS_UNEXPECTED
 
+#if _HAS_UNEXPECTED && _HAS_CXX23
+#error STL1004: C++98 unexpected() is incompatible with C++23 unexpected<E>.
+#endif // _HAS_UNEXPECTED && _HAS_CXX23
+
 // P0004R1 Removing Deprecated Iostreams Aliases
 #ifndef _HAS_OLD_IOSTREAMS_MEMBERS
 #define _HAS_OLD_IOSTREAMS_MEMBERS (!_HAS_CXX17)


### PR DESCRIPTION
C++98's `unexpected()` was removed by C++17, then C++23 reused the identifier for `<expected>`'s `unexpected<E>` (being implemented in #2643).

We support escape hatches for restoring Standard-removed machinery, but we need to avoid this conflict. Instead of limiting what C++23 provides, we should simply disable this escape hatch when it conflicts with the Standard. (Note that C++98 `unexpected()` and its related functions weren't very useful, *and* MSVC never properly implemented them, thus this is mostly relevant for library test suites. It's a very different situation than `auto_ptr`, for example.)

This PR will be paired with internal changes to VCRuntime, as its `<eh.h>` defines `unexpected()` et al. in the global scope, and we need to prevent that conflict too. We can complete this PR independently of #2643.