### PR TITLE
Remove unnecessary copy of _clr DLLS from internal build

### DIFF
--- a/stl/msbuild/stl_1/msvcp_1.settings.targets
+++ b/stl/msbuild/stl_1/msvcp_1.settings.targets
@@ -76,10 +76,6 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
            $(LinkOutputFile);
            $(LinkProgramDataBaseFileName);
         "/>
-        <CopyFilesForNetFx Condition="'$(MsvcpFlavor)' == 'netfx'" Include="
-           $(LinkOutputFile);
-           $(LinkProgramDataBaseFileName);
-        "/>
     </ItemGroup>
 
     <Import Project="$(MSBuildThisFileDirectory)\stl_1.files.settings.targets"/>

--- a/stl/msbuild/stl_2/msvcp_2.settings.targets
+++ b/stl/msbuild/stl_2/msvcp_2.settings.targets
@@ -76,10 +76,6 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
            $(LinkOutputFile);
            $(LinkProgramDataBaseFileName);
         "/>
-        <CopyFilesForNetFx Condition="'$(MsvcpFlavor)' == 'netfx'" Include="
-           $(LinkOutputFile);
-           $(LinkProgramDataBaseFileName);
-        "/>
     </ItemGroup>
 
     <Import Project="$(MSBuildThisFileDirectory)\stl_2.files.settings.targets"/>

--- a/stl/msbuild/stl_atomic_wait/msvcp_atomic_wait.settings.targets
+++ b/stl/msbuild/stl_atomic_wait/msvcp_atomic_wait.settings.targets
@@ -77,10 +77,6 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
            $(LinkOutputFile);
            $(LinkProgramDataBaseFileName);
         "/>
-        <CopyFilesForNetFx Condition="'$(MsvcpFlavor)' == 'netfx'" Include="
-           $(LinkOutputFile);
-           $(LinkProgramDataBaseFileName);
-        "/>
     </ItemGroup>
 
     <Import Project="$(MSBuildThisFileDirectory)\stl_atomic_wait.files.settings.targets"/>

--- a/stl/msbuild/stl_base/msvcp.settings.targets
+++ b/stl/msbuild/stl_base/msvcp.settings.targets
@@ -81,10 +81,6 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
            $(LinkOutputFile);
            $(LinkProgramDataBaseFileName);
         "/>
-        <CopyFilesForNetFx Condition="'$(MsvcpFlavor)' == 'netfx'" Include="
-           $(LinkOutputFile);
-           $(LinkProgramDataBaseFileName);
-        "/>
     </ItemGroup>
 
     <Import Project="$(MSBuildThisFileDirectory)\stl.files.settings.targets"/>

--- a/stl/msbuild/stl_codecvt_ids/msvcp_codecvt_ids.settings.targets
+++ b/stl/msbuild/stl_codecvt_ids/msvcp_codecvt_ids.settings.targets
@@ -76,10 +76,6 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
            $(LinkOutputFile);
            $(LinkProgramDataBaseFileName);
         "/>
-        <CopyFilesForNetFx Condition="'$(MsvcpFlavor)' == 'netfx'" Include="
-           $(LinkOutputFile);
-           $(LinkProgramDataBaseFileName);
-        "/>
     </ItemGroup>
 
     <Import Project="$(MSBuildThisFileDirectory)\stl_codecvt_ids.files.settings.targets"/>


### PR DESCRIPTION
Doesn't affect the OSS build at all. (I don't think anything here is worth Changlelogging, shout if you disagree.)

Mirror of MSVC-PR-398691
