### PR TITLE
`<ranges>`: Temporarily disable `join_view` for non-`forward_range`s, pending resolution of LWG-3698

### DIFF
--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -3070,7 +3070,7 @@ namespace ranges {
         // clang-format on
 
 #ifndef _USE_JOIN_VIEW_INPUT_RANGE
-        static_assert(forward_range<_Vw> || borrowed_range<_Vw>,
+        static_assert(forward_range<_Vw>,
             "Due to a design flaw, join_view can misbehave "
             "with some input-only ranges (see https://wg21.link/lwg3698). "
             "We believe that WG21 will be unable to fix this problem without breaking ABI. "

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -3068,6 +3068,14 @@ namespace ranges {
         requires view<_Vw> && input_range<range_reference_t<_Vw>>
     class join_view : public _Join_view_base<_Vw> {
         // clang-format on
+
+#ifndef _USE_JOIN_VIEW_INPUT_RANGE
+        static_assert(forward_range<_Vw>,
+            "Using join_view with input-only ranges is temporarily disabled because of a bug that makes join_view "
+            "misbehave for certain ranges. See https://cplusplus.github.io/LWG/issue3698. You can define "
+            "_USE_JOIN_VIEW_INPUT_RANGE to suppress this diagnostic.");
+#endif // _USE_JOIN_VIEW_INPUT_RANGE
+
     private:
         template <bool _Const>
         using _InnerRng = range_reference_t<_Maybe_const<_Const, _Vw>>;

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -3071,8 +3071,8 @@ namespace ranges {
 
 #ifndef _USE_JOIN_VIEW_INPUT_RANGE
         static_assert(forward_range<_Vw>,
-            "Using join_view with input-only ranges is temporarily disabled because of a bug that makes join_view "
-            "misbehave for certain ranges. See https://cplusplus.github.io/LWG/issue3698. You can define "
+            "Using join_view with input-only ranges is temporarily disabled because this can misbehave "
+            "for certain ranges. See https://cplusplus.github.io/LWG/issue3698. You can define "
             "_USE_JOIN_VIEW_INPUT_RANGE to suppress this diagnostic.");
 #endif // _USE_JOIN_VIEW_INPUT_RANGE
 

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -3070,10 +3070,15 @@ namespace ranges {
         // clang-format on
 
 #ifndef _USE_JOIN_VIEW_INPUT_RANGE
-        static_assert(forward_range<_Vw>,
-            "Using join_view with input-only ranges is temporarily disabled because this can misbehave "
-            "for certain ranges. See https://cplusplus.github.io/LWG/issue3698. You can define "
-            "_USE_JOIN_VIEW_INPUT_RANGE to suppress this diagnostic.");
+        static_assert(forward_range<_Vw> || borrowed_range<_Vw>,
+            "Due to a design flaw, join_view can misbehave "
+            "with some input-only ranges (see https://wg21.link/lwg3698). "
+            "We believe that WG21 will be unable to fix this problem without breaking ABI. "
+            "To minimize breakage when a fix is implemented, "
+            "we are temporarily disabling potentially problematic cases. "
+            "You can define _USE_JOIN_VIEW_INPUT_RANGE to suppress this diagnostic, "
+            "but be aware that you will almost certainly need to recompile "
+            "when we release a fix.");
 #endif // _USE_JOIN_VIEW_INPUT_RANGE
 
     private:

--- a/tests/libcxx/usual_matrix.lst
+++ b/tests/libcxx/usual_matrix.lst
@@ -4,7 +4,7 @@
 RUNALL_INCLUDE ..\universal_prefix.lst
 RUNALL_CROSSLIST
 # TRANSITION, LLVM-53957: _SILENCE_ALL_CXX23_DEPRECATION_WARNINGS belongs to llvm-project/libcxx/test/support/msvc_stdlib_force_include.h
-PM_CL="/EHsc /MTd /std:c++latest /permissive- /FImsvc_stdlib_force_include.h /wd4643 /D_STL_CALL_ABORT_INSTEAD_OF_INVALID_PARAMETER /D_SILENCE_ALL_CXX23_DEPRECATION_WARNINGS"
+PM_CL="/EHsc /MTd /std:c++latest /permissive- /FImsvc_stdlib_force_include.h /wd4643 /D_STL_CALL_ABORT_INSTEAD_OF_INVALID_PARAMETER /D_SILENCE_ALL_CXX23_DEPRECATION_WARNINGS /D_USE_JOIN_VIEW_INPUT_RANGE"
 RUNALL_CROSSLIST
 PM_CL="/analyze:autolog- /Zc:preprocessor"
 PM_COMPILER="clang-cl" PM_CL="-fno-ms-compatibility -fno-delayed-template-parsing"

--- a/tests/std/tests/P0896R4_views_join/test.cpp
+++ b/tests/std/tests/P0896R4_views_join/test.cpp
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#define _USE_JOIN_VIEW_INPUT_RANGE
+
 #include <algorithm>
 #include <array>
 #include <cassert>


### PR DESCRIPTION
As pointed out in LWG-3698, `join_view` is currently broken for "stashing iterators" (iterators that return a reference to a member object). The issue mentions that `join_view` would need to store the outer iterator in a non-propagating-cache for input ranges.

The fix might change the layout of `join_view` (and of its iterator type, if we don't want to store a redundant outer iterator). So I believe that it is useful to flag the affected uses of `join_view`.

This requires users to define a macro if they don't depend on the ABI of `join_view` and want to use `join_view` for input ranges. I hope it's not too much of a problem.