### PR TITLE
CMakeLists.txt: Check the Windows SDK version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,11 +6,11 @@ set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 project(msvc_standard_libraries LANGUAGES CXX)
 
 include(CheckCXXSourceCompiles)
-check_cxx_source_compiles("
+check_cxx_source_compiles([=[
 #include <sdkddkver.h>
-static_assert(WDK_NTDDI_VERSION >= NTDDI_WIN10_CO, \"Inspecting WDK_NTDDI_VERSION, the Windows SDK version.\");
+static_assert(WDK_NTDDI_VERSION >= NTDDI_WIN10_CO, "Inspecting WDK_NTDDI_VERSION, the Windows SDK version.");
 int main() {}
-" WINDOWS_SDK_VERSION_CHECK)
+]=] WINDOWS_SDK_VERSION_CHECK)
 if(NOT WINDOWS_SDK_VERSION_CHECK)
     message(FATAL_ERROR "To build the STL, select the Windows 11 SDK (10.0.22000.0) in the VS Installer.")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,16 @@ cmake_minimum_required(VERSION 3.22)
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 project(msvc_standard_libraries LANGUAGES CXX)
 
+include(CheckCXXSourceCompiles)
+check_cxx_source_compiles("
+#include <sdkddkver.h>
+static_assert(WDK_NTDDI_VERSION >= NTDDI_WIN10_CO, \"Inspecting WDK_NTDDI_VERSION, the Windows SDK version.\");
+int main() {}
+" WINDOWS_SDK_VERSION_CHECK)
+if(NOT WINDOWS_SDK_VERSION_CHECK)
+    message(FATAL_ERROR "To build the STL, select the Windows 11 SDK (10.0.22000.0) in the VS Installer.")
+endif()
+
 # add the tools subdirectory _before_ we change all the flags
 add_subdirectory(tools EXCLUDE_FROM_ALL)
 # these allow the targets to show up in the top-level

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ static_assert(WDK_NTDDI_VERSION >= NTDDI_WIN10_CO, "Inspecting WDK_NTDDI_VERSION
 int main() {}
 ]=] WINDOWS_SDK_VERSION_CHECK)
 if(NOT WINDOWS_SDK_VERSION_CHECK)
-    message(FATAL_ERROR "To build the STL, select the Windows 11 SDK (10.0.22000.0) in the VS Installer.")
+    message(FATAL_ERROR "The STL must be built with the Windows 11 SDK (10.0.22000.0) or later. Make sure it's available by selecting it in the Individual Components tab of the VS Installer.")
 endif()
 
 # add the tools subdirectory _before_ we change all the flags


### PR DESCRIPTION
Toolset update #2714 began requiring the Windows 11 SDK 22000 to build and test the STL. Although it's mentioned in the README, if a contributor misses this dependency, the resulting error message is incomprehensible (as @miscco discovered). @strega-nil-ms suggested adding a build check.

Fortunately, the Windows SDK provides a macro to identify itself, `WDK_NTDDI_VERSION`. (Unlike `NTDDI_VERSION`, this is not subject to user overrides.) It's present in the default WinSDK, where it was set to "Vibranium", whereas in the latest WinSDK, it's set to "Cobalt":

* `C:\Program Files (x86)\Windows Kits\10\Include\10.0.19041.0\shared\sdkddkver.h`
  + `#define WDK_NTDDI_VERSION                   NTDDI_WIN10_VB /* ABRACADABRA_WIN10_VB */`
* `C:\Program Files (x86)\Windows Kits\10\Include\10.0.22000.0\shared\sdkddkver.h`
  + `#define WDK_NTDDI_VERSION                   NTDDI_WIN10_CO`

I've tested this by changing my installed WinSDK. Here's the user experience:

### :x: Windows 10 SDK 19041, failure:

```
C:\GitHub\STL>cmake -G Ninja -S . -B out\build\x64
-- The CXX compiler identification is MSVC 19.33.31424.0
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: C:/Program Files/Microsoft Visual Studio/2022/Preview/VC/Tools/MSVC/14.33.31424/bin/Hostx64/x64/cl.exe - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Performing Test WINDOWS_SDK_VERSION_CHECK
-- Performing Test WINDOWS_SDK_VERSION_CHECK - Failed
CMake Error at CMakeLists.txt:15 (message):
  The STL must be built with the Windows 11 SDK (10.0.22000.0) or later.
  Make sure it's available by selecting it in the Individual Components tab
  of the VS Installer.


-- Configuring incomplete, errors occurred!
See also "C:/GitHub/STL/out/build/x64/CMakeFiles/CMakeOutput.log".
See also "C:/GitHub/STL/out/build/x64/CMakeFiles/CMakeError.log".
```

### :white_check_mark: Windows 11 SDK 22000, success:

```
C:\GitHub\STL>cmake -G Ninja -S . -B out\build\x64
-- The CXX compiler identification is MSVC 19.33.31424.0
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: C:/Program Files/Microsoft Visual Studio/2022/Preview/VC/Tools/MSVC/14.33.31424/bin/Hostx64/x64/cl.exe - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Performing Test WINDOWS_SDK_VERSION_CHECK
-- Performing Test WINDOWS_SDK_VERSION_CHECK - Success
-- Searching for VS clang-format
-- Searching for VS clang-format - found
-- Boost.Math: standalone mode ON
-- Found Python: C:/Users/stl/AppData/Local/Programs/Python/Python310/python.exe (found suitable version "3.10.4", minimum required is "3.9") found components: Interpreter
-- Configuring done
-- Generating done
-- Build files have been written to: C:/GitHub/STL/out/build/x64
```
