### PR TITLE
Avoid an assertion failure in alias.asm

### DIFF
--- a/stl/CMakeLists.txt
+++ b/stl/CMakeLists.txt
@@ -263,7 +263,8 @@ set(IMPLIB_SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/src/syserror_import_lib.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/vector_algorithms.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/xonce2.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/src/alias.asm
+    ${CMAKE_CURRENT_LIST_DIR}/src/alias_init_once_begin_initialize.asm
+    ${CMAKE_CURRENT_LIST_DIR}/src/alias_init_once_complete.asm
 )
 
 # The following files are linked in msvcp140[d][_clr].dll.

--- a/stl/msbuild/stl_base/stl.files.settings.targets
+++ b/stl/msbuild/stl_base/stl.files.settings.targets
@@ -180,7 +180,8 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         <!-- Objs that exist in both libcpmt[d][01].lib and msvcprt[d].lib
              (controlled by IncludeInLink and IncludeInImportLib). -->
         <BuildFiles Include="
-            $(CrtRoot)\github\stl\src\alias.asm;
+            $(CrtRoot)\github\stl\src\alias_init_once_begin_initialize.asm;
+            $(CrtRoot)\github\stl\src\alias_init_once_complete.asm;
             ">
             <BuildAs>asm</BuildAs>
             <IncludeInLink>false</IncludeInLink>

--- a/stl/src/alias.asm
+++ b/stl/src/alias.asm
@@ -10,7 +10,7 @@
 ; IFDEF RAX
 ;   meow
 ; ENDIF
-; will expand to meow on only x64 system, however:
+; will expand to meow on only x64 systems, however:
 ; IFNDEF RAX
 ;   meow
 ; ENDIF

--- a/stl/src/alias.asm
+++ b/stl/src/alias.asm
@@ -3,51 +3,28 @@
 
 ; weak symbol aliases
 
-; Note that while this is a masm file, it contains no code.
-; masm does generate a .text section with zero size.
-
-; Mangle identifiers for stdcall calling convention.
-; On x64 this does nothing, on x86 it adds a leading
-; underscore and trailing @sz, where sz should be the size of the parameters.
-mangle MACRO name, sz
-    ; This checks if we're in x64 mode (using ml64).
-    ; Note that RAX isn't really an assembler symbol,
-    ; and this check only works in the IFDEF direction.
-    ; That is:
-    ; IFDEF RAX
-    ;   meow
-    ; ENDIF
-    ; will expand to meow on only x64 systems, however:
-    ; IFNDEF RAX
-    ;   meow
-    ; ENDIF
-    ; will expand to meow on _BOTH_ x64 and x86 systems.
-    IFDEF RAX
-        EXITM <name>
-    ELSE
-        EXITM <_&name&@&sz&>
-    ENDIF
-ENDM
-
-; Generate the name of the imp symbol for a function.
-imp_name MACRO name, sz
-    EXITM @CatStr(__imp_, mangle(name, sz))
-ENDM
-
-create_alias MACRO oldname, newname, size
-    ; Use "EXTERN name : PROC" instead of "EXTERN name : PROTO ..."
-    ; to avoid masm adding underscores to the names of (object) symbols.
-    ; Note that the MASM symbol always has the name that appears in
-    ; the source file (after macro expansion), but when _using_ the symbol
-    ; masm will add underscores.
-    EXTERN imp_name(newname, size) : PROC
-    ; The documentation for "ALIAS <alias> = <actual-name>" says angle brackets
-    ; are required around the parameters, but this is not the case; it seems to just require
-    ; a single "text item", which both angle brackets and this macro call create.
-    ALIAS imp_name(oldname, size) = imp_name(newname, size)
-ENDM
-
-create_alias __std_init_once_begin_initialize, InitOnceBeginInitialize, 16
-create_alias __std_init_once_complete, InitOnceComplete, 12
+; This checks if we're in x64 mode (using ml64).
+; Note that RAX isn't really an assembler symbol,
+; and this check only works in the IFDEF direction.
+; That is:
+; IFDEF RAX
+;   meow
+; ENDIF
+; will expand to meow on only x64 system, however:
+; IFNDEF RAX
+;   meow
+; ENDIF
+; will expand to meow on _BOTH_ x64 and x86 systems.
+IFDEF RAX
+    EXTERN __imp_InitOnceBeginInitialize : PROC
+    EXTERN __imp_InitOnceComplete : PROC
+    ALIAS <__imp___std_init_once_begin_initialize> = <__imp_InitOnceBeginInitialize>
+    ALIAS <__imp___std_init_once_complete> = <__imp_InitOnceComplete>
+ELSE
+    EXTERN __imp__InitOnceBeginInitialize@16 : PROC
+    EXTERN __imp__InitOnceComplete@12 : PROC
+    ALIAS <__imp____std_init_once_begin_initialize@16> = <__imp__InitOnceBeginInitialize@16>
+    ALIAS <__imp____std_init_once_complete@12> = <__imp__InitOnceComplete@12>
+ENDIF
 
 END

--- a/stl/src/alias_init_once_begin_initialize.asm
+++ b/stl/src/alias_init_once_begin_initialize.asm
@@ -1,0 +1,26 @@
+; Copyright (c) Microsoft Corporation.
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+; weak symbol aliases
+
+; This checks if we're in x64 mode (using ml64).
+; Note that RAX isn't really an assembler symbol,
+; and this check only works in the IFDEF direction.
+; That is:
+; IFDEF RAX
+;   meow
+; ENDIF
+; will expand to meow on only x64 systems, however:
+; IFNDEF RAX
+;   meow
+; ENDIF
+; will expand to meow on _BOTH_ x64 and x86 systems.
+IFDEF RAX
+    EXTERN __imp_InitOnceBeginInitialize : PROC
+    ALIAS <__imp___std_init_once_begin_initialize> = <__imp_InitOnceBeginInitialize>
+ELSE
+    EXTERN __imp__InitOnceBeginInitialize@16 : PROC
+    ALIAS <__imp____std_init_once_begin_initialize@16> = <__imp__InitOnceBeginInitialize@16>
+ENDIF
+
+END

--- a/stl/src/alias_init_once_complete.asm
+++ b/stl/src/alias_init_once_complete.asm
@@ -16,14 +16,10 @@
 ; ENDIF
 ; will expand to meow on _BOTH_ x64 and x86 systems.
 IFDEF RAX
-    EXTERN __imp_InitOnceBeginInitialize : PROC
     EXTERN __imp_InitOnceComplete : PROC
-    ALIAS <__imp___std_init_once_begin_initialize> = <__imp_InitOnceBeginInitialize>
     ALIAS <__imp___std_init_once_complete> = <__imp_InitOnceComplete>
 ELSE
-    EXTERN __imp__InitOnceBeginInitialize@16 : PROC
     EXTERN __imp__InitOnceComplete@12 : PROC
-    ALIAS <__imp____std_init_once_begin_initialize@16> = <__imp__InitOnceBeginInitialize@16>
     ALIAS <__imp____std_init_once_complete@12> = <__imp__InitOnceComplete@12>
 ENDIF
 


### PR DESCRIPTION
Turns out the thing about requiring <> around the parameters of the ALIAS directive was for real. If they are actually needed, I think it's impossible to use macros to generate that directive, so I have removed the macros and duplicated the directives.

This actually makes the file somewhat simpler and easier to read, I think it was overly clever and compressed before.
