### PR TITLE
codecvt: no conversion for all char-like types of size 1.

### DIFF
--- a/stl/inc/xlocale
+++ b/stl/inc/xlocale
@@ -665,7 +665,6 @@ template <class _Elem, class _Byte>
 _INLINE_VAR constexpr bool _Is_codecvt_do_always_noconv_v =
     is_same_v<_Byte, _Elem> || (_Is_one_byte_char_like_v<_Byte> && _Is_one_byte_char_like_v<_Elem>);
 
-
 template <class _Elem, class _Byte, class _Statype>
 class codecvt : public codecvt_base { // facet for converting between _Elem and _Byte sequences
 public:

--- a/stl/inc/xlocale
+++ b/stl/inc/xlocale
@@ -687,7 +687,11 @@ constexpr bool _One_byte_char_like<char8_t>() {
 
 template <class _Elem, class _Byte>
 constexpr bool _Codecvt_do_always_noconv() {
-    return is_same_v<_Byte, _Elem> || (_One_byte_char_like<_Elem>() && _One_byte_char_like<_Byte>());
+    if constexpr (is_same_v<_Byte, _Elem> || (_One_byte_char_like<_Elem>() && _One_byte_char_like<_Byte>())) {
+        return true;
+    } else {
+        return false;
+    }
 }
 
 template <class _Elem, class _Byte, class _Statype>

--- a/stl/inc/xlocale
+++ b/stl/inc/xlocale
@@ -651,6 +651,16 @@ protected:
     }
 };
 
+template <class _Elem, class _Byte>
+_INLINE_VAR constexpr bool _Codecvt_do_always_noconv = ((sizeof(_Byte) == 1) && (sizeof(_Elem) == 1) &&
+#ifdef __cpp_lib_byte
+                                                           (is_integral_v<_Byte> || is_same_v<_Byte, byte>) && //
+                                                           (is_integral_v<_Elem> || is_same_v<_Elem, byte>) )
+#else // ^^ __cpp_lib_byte / !__cpp_lib_byte vv
+                                                           is_integral_v<_Byte> && is_integral_v<_Elem>)
+#endif // __cpp_lib_byte
+                                                    || is_same_v<_Byte, _Elem>;
+
 template <class _Elem, class _Byte, class _Statype>
 class codecvt : public codecvt_base { // facet for converting between _Elem and _Byte sequences
 public:
@@ -716,14 +726,14 @@ protected:
 
     bool __CLR_OR_THIS_CALL do_always_noconv() const noexcept override {
         // return true if conversions never change input (from codecvt)
-        return is_same_v<_Byte, _Elem>;
+        return _Codecvt_do_always_noconv<_Elem, _Byte>;
     }
 
     virtual result __CLR_OR_THIS_CALL do_in(_Statype&, const _Byte* _First1, const _Byte* _Last1, const _Byte*& _Mid1,
         _Elem* _First2, _Elem* _Last2, _Elem*& _Mid2) const { // convert bytes [_First1, _Last1) to [_First2, _Last2)
         _Mid1 = _First1;
         _Mid2 = _First2;
-        if constexpr (is_same_v<_Byte, _Elem>) {
+        if constexpr (_Codecvt_do_always_noconv<_Elem, _Byte>) {
             return noconv; // convert nothing
         } else {
             // types differ, copy one for one
@@ -742,7 +752,7 @@ protected:
         _Byte* _First2, _Byte* _Last2, _Byte*& _Mid2) const { // convert [_First1, _Last1) to bytes [_First2, _Last2)
         _Mid1 = _First1;
         _Mid2 = _First2;
-        if constexpr (is_same_v<_Byte, _Elem>) {
+        if constexpr (_Codecvt_do_always_noconv<_Elem, _Byte>) {
             return noconv; // convert nothing
         } else {
             // types differ, copy one for one

--- a/stl/inc/xlocale
+++ b/stl/inc/xlocale
@@ -652,7 +652,7 @@ protected:
 };
 
 template <class _Ty>
-_INLINE_VAR constexpr bool _One_byte_char_like = _Is_any_of_v<_Ty, signed char, unsigned char,
+_INLINE_VAR constexpr bool _Is_one_byte_char_like_v = _Is_any_of_v<remove_cv_t<_Ty>, signed char, unsigned char,
 #ifdef __cpp_lib_byte
     byte,
 #endif // __cpp_lib_byte
@@ -662,8 +662,8 @@ _INLINE_VAR constexpr bool _One_byte_char_like = _Is_any_of_v<_Ty, signed char, 
     char>;
 
 template <class _Elem, class _Byte>
-_INLINE_VAR constexpr bool
-    _Codecvt_do_always_noconv = is_same_v<_Byte, _Elem> || (_One_byte_char_like<_Byte> && _One_byte_char_like<_Elem>);
+_INLINE_VAR constexpr bool _Is_codecvt_do_always_noconv_v =
+    is_same_v<_Byte, _Elem> || (_Is_one_byte_char_like_v<_Byte> && _Is_one_byte_char_like_v<_Elem>);
 
 
 template <class _Elem, class _Byte, class _Statype>
@@ -731,14 +731,14 @@ protected:
 
     bool __CLR_OR_THIS_CALL do_always_noconv() const noexcept override {
         // return true if conversions never change input (from codecvt)
-        return _Codecvt_do_always_noconv<_Elem, _Byte>;
+        return _Is_codecvt_do_always_noconv_v<_Elem, _Byte>;
     }
 
     virtual result __CLR_OR_THIS_CALL do_in(_Statype&, const _Byte* _First1, const _Byte* _Last1, const _Byte*& _Mid1,
         _Elem* _First2, _Elem* _Last2, _Elem*& _Mid2) const { // convert bytes [_First1, _Last1) to [_First2, _Last2)
         _Mid1 = _First1;
         _Mid2 = _First2;
-        if constexpr (_Codecvt_do_always_noconv<_Elem, _Byte>) {
+        if constexpr (_Is_codecvt_do_always_noconv_v<_Elem, _Byte>) {
             return noconv; // convert nothing
         } else {
             // types differ, copy one for one
@@ -757,7 +757,7 @@ protected:
         _Byte* _First2, _Byte* _Last2, _Byte*& _Mid2) const { // convert [_First1, _Last1) to bytes [_First2, _Last2)
         _Mid1 = _First1;
         _Mid2 = _First2;
-        if constexpr (_Codecvt_do_always_noconv<_Elem, _Byte>) {
+        if constexpr (_Is_codecvt_do_always_noconv_v<_Elem, _Byte>) {
             return noconv; // convert nothing
         } else {
             // types differ, copy one for one

--- a/stl/inc/xlocale
+++ b/stl/inc/xlocale
@@ -652,30 +652,42 @@ protected:
 };
 
 template <class _Elem>
-_INLINE_VAR constexpr bool _One_byte_char_like = false;
+constexpr bool _One_byte_char_like() {
+    return false;
+}
 
 template <>
-_INLINE_VAR constexpr bool _One_byte_char_like<char> = true;
+constexpr bool _One_byte_char_like<char>() {
+    return true;
+}
 
 template <>
-_INLINE_VAR constexpr bool _One_byte_char_like<signed char> = true;
+constexpr bool _One_byte_char_like<signed char>() {
+    return true;
+}
 
 template <>
-_INLINE_VAR constexpr bool _One_byte_char_like<unsigned char> = true;
+constexpr bool _One_byte_char_like<unsigned char>() {
+    return true;
+}
 
 #ifdef __cpp_lib_byte
 template <>
-_INLINE_VAR constexpr bool _One_byte_char_like<byte> = true;
+constexpr bool _One_byte_char_like<byte>() {
+    return true;
+}
 #endif // __cpp_lib_byte
 
 #ifdef __cpp_char8_t
 template <>
-_INLINE_VAR constexpr bool _One_byte_char_like<char8_t> = true;
+constexpr bool _One_byte_char_like<char8_t>() {
+    return true;
+}
 #endif // __cpp_char8_t
 
 template <class _Elem, class _Byte>
-_INLINE_VAR constexpr bool
-    _Codecvt_do_always_noconv = is_same_v<_Byte, _Elem> || (_One_byte_char_like<_Elem> && _One_byte_char_like<_Byte>);
+_INLINE_VAR constexpr bool _Codecvt_do_always_noconv =
+    is_same_v<_Byte, _Elem> || (_One_byte_char_like<_Elem>() && _One_byte_char_like<_Byte>());
 
 template <class _Elem, class _Byte, class _Statype>
 class codecvt : public codecvt_base { // facet for converting between _Elem and _Byte sequences

--- a/stl/inc/xlocale
+++ b/stl/inc/xlocale
@@ -652,10 +652,9 @@ protected:
 };
 
 template <class _Ty>
-_INLINE_VAR constexpr bool _One_byte_char_like = _Is_any_of_v<_Ty, signed char,
-    unsigned char
+_INLINE_VAR constexpr bool _One_byte_char_like = _Is_any_of_v<_Ty, signed char, unsigned char,
 #ifdef __cpp_lib_byte
-        byte,
+    byte,
 #endif // __cpp_lib_byte
 #ifdef __cpp_char8_t
     char8_t,

--- a/stl/inc/xlocale
+++ b/stl/inc/xlocale
@@ -651,48 +651,20 @@ protected:
     }
 };
 
-template <class _Elem>
-constexpr bool _One_byte_char_like() {
-    return false;
-}
-
-template <>
-constexpr bool _One_byte_char_like<char>() {
-    return true;
-}
-
-template <>
-constexpr bool _One_byte_char_like<signed char>() {
-    return true;
-}
-
-template <>
-constexpr bool _One_byte_char_like<unsigned char>() {
-    return true;
-}
-
+template <class _Ty>
+_INLINE_VAR constexpr bool _One_byte_char_like = _Is_any_of_v<_Ty, char, signed char, unsigned char>
 #ifdef __cpp_lib_byte
-template <>
-constexpr bool _One_byte_char_like<byte>() {
-    return true;
-}
+                                              || is_same_v<_Ty, byte>
 #endif // __cpp_lib_byte
-
 #ifdef __cpp_char8_t
-template <>
-constexpr bool _One_byte_char_like<char8_t>() {
-    return true;
-}
+                                              || is_same_v<_Ty, char8_t>
 #endif // __cpp_char8_t
+    ;
 
 template <class _Elem, class _Byte>
-constexpr bool _Codecvt_do_always_noconv() {
-    if constexpr (is_same_v<_Byte, _Elem> || (_One_byte_char_like<_Elem>() && _One_byte_char_like<_Byte>())) {
-        return true;
-    } else {
-        return false;
-    }
-}
+_INLINE_VAR constexpr bool
+    _Codecvt_do_always_noconv = is_same_v<_Byte, _Elem> || (_One_byte_char_like<_Byte> && _One_byte_char_like<_Elem>);
+
 
 template <class _Elem, class _Byte, class _Statype>
 class codecvt : public codecvt_base { // facet for converting between _Elem and _Byte sequences
@@ -759,14 +731,14 @@ protected:
 
     bool __CLR_OR_THIS_CALL do_always_noconv() const noexcept override {
         // return true if conversions never change input (from codecvt)
-        return _Codecvt_do_always_noconv<_Elem, _Byte>();
+        return _Codecvt_do_always_noconv<_Elem, _Byte>;
     }
 
     virtual result __CLR_OR_THIS_CALL do_in(_Statype&, const _Byte* _First1, const _Byte* _Last1, const _Byte*& _Mid1,
         _Elem* _First2, _Elem* _Last2, _Elem*& _Mid2) const { // convert bytes [_First1, _Last1) to [_First2, _Last2)
         _Mid1 = _First1;
         _Mid2 = _First2;
-        if constexpr (_Codecvt_do_always_noconv<_Elem, _Byte>()) {
+        if constexpr (_Codecvt_do_always_noconv<_Elem, _Byte>) {
             return noconv; // convert nothing
         } else {
             // types differ, copy one for one
@@ -785,7 +757,7 @@ protected:
         _Byte* _First2, _Byte* _Last2, _Byte*& _Mid2) const { // convert [_First1, _Last1) to bytes [_First2, _Last2)
         _Mid1 = _First1;
         _Mid2 = _First2;
-        if constexpr (_Codecvt_do_always_noconv<_Elem, _Byte>()) {
+        if constexpr (_Codecvt_do_always_noconv<_Elem, _Byte>) {
             return noconv; // convert nothing
         } else {
             // types differ, copy one for one

--- a/stl/inc/xlocale
+++ b/stl/inc/xlocale
@@ -651,15 +651,31 @@ protected:
     }
 };
 
-template <class _Elem, class _Byte>
-_INLINE_VAR constexpr bool _Codecvt_do_always_noconv = ((sizeof(_Byte) == 1) && (sizeof(_Elem) == 1) &&
+template <class _Elem>
+_INLINE_VAR constexpr bool _One_byte_char_like = false;
+
+template <>
+_INLINE_VAR constexpr bool _One_byte_char_like<char> = true;
+
+template <>
+_INLINE_VAR constexpr bool _One_byte_char_like<signed char> = true;
+
+template <>
+_INLINE_VAR constexpr bool _One_byte_char_like<unsigned char> = true;
+
 #ifdef __cpp_lib_byte
-                                                           (is_integral_v<_Byte> || is_same_v<_Byte, byte>) && //
-                                                           (is_integral_v<_Elem> || is_same_v<_Elem, byte>) )
-#else // ^^ __cpp_lib_byte / !__cpp_lib_byte vv
-                                                           is_integral_v<_Byte> && is_integral_v<_Elem>)
+template <>
+_INLINE_VAR constexpr bool _One_byte_char_like<byte> = true;
 #endif // __cpp_lib_byte
-                                                    || is_same_v<_Byte, _Elem>;
+
+#ifdef __cpp_char8_t
+template <>
+_INLINE_VAR constexpr bool _One_byte_char_like<char8_t> = true;
+#endif // __cpp_char8_t
+
+template <class _Elem, class _Byte>
+_INLINE_VAR constexpr bool
+    _Codecvt_do_always_noconv = is_same_v<_Byte, _Elem> || (_One_byte_char_like<_Elem> && _One_byte_char_like<_Byte>);
 
 template <class _Elem, class _Byte, class _Statype>
 class codecvt : public codecvt_base { // facet for converting between _Elem and _Byte sequences

--- a/stl/inc/xlocale
+++ b/stl/inc/xlocale
@@ -686,8 +686,9 @@ constexpr bool _One_byte_char_like<char8_t>() {
 #endif // __cpp_char8_t
 
 template <class _Elem, class _Byte>
-_INLINE_VAR constexpr bool _Codecvt_do_always_noconv =
-    is_same_v<_Byte, _Elem> || (_One_byte_char_like<_Elem>() && _One_byte_char_like<_Byte>());
+constexpr bool _Codecvt_do_always_noconv() {
+    return is_same_v<_Byte, _Elem> || (_One_byte_char_like<_Elem>() && _One_byte_char_like<_Byte>());
+}
 
 template <class _Elem, class _Byte, class _Statype>
 class codecvt : public codecvt_base { // facet for converting between _Elem and _Byte sequences
@@ -754,14 +755,14 @@ protected:
 
     bool __CLR_OR_THIS_CALL do_always_noconv() const noexcept override {
         // return true if conversions never change input (from codecvt)
-        return _Codecvt_do_always_noconv<_Elem, _Byte>;
+        return _Codecvt_do_always_noconv<_Elem, _Byte>();
     }
 
     virtual result __CLR_OR_THIS_CALL do_in(_Statype&, const _Byte* _First1, const _Byte* _Last1, const _Byte*& _Mid1,
         _Elem* _First2, _Elem* _Last2, _Elem*& _Mid2) const { // convert bytes [_First1, _Last1) to [_First2, _Last2)
         _Mid1 = _First1;
         _Mid2 = _First2;
-        if constexpr (_Codecvt_do_always_noconv<_Elem, _Byte>) {
+        if constexpr (_Codecvt_do_always_noconv<_Elem, _Byte>()) {
             return noconv; // convert nothing
         } else {
             // types differ, copy one for one
@@ -780,7 +781,7 @@ protected:
         _Byte* _First2, _Byte* _Last2, _Byte*& _Mid2) const { // convert [_First1, _Last1) to bytes [_First2, _Last2)
         _Mid1 = _First1;
         _Mid2 = _First2;
-        if constexpr (_Codecvt_do_always_noconv<_Elem, _Byte>) {
+        if constexpr (_Codecvt_do_always_noconv<_Elem, _Byte>()) {
             return noconv; // convert nothing
         } else {
             // types differ, copy one for one

--- a/stl/inc/xlocale
+++ b/stl/inc/xlocale
@@ -652,14 +652,15 @@ protected:
 };
 
 template <class _Ty>
-_INLINE_VAR constexpr bool _One_byte_char_like = _Is_any_of_v<_Ty, char, signed char, unsigned char>
+_INLINE_VAR constexpr bool _One_byte_char_like = _Is_any_of_v<_Ty, signed char,
+    unsigned char
 #ifdef __cpp_lib_byte
-                                              || is_same_v<_Ty, byte>
+        byte,
 #endif // __cpp_lib_byte
 #ifdef __cpp_char8_t
-                                              || is_same_v<_Ty, char8_t>
+    char8_t,
 #endif // __cpp_char8_t
-    ;
+    char>;
 
 template <class _Elem, class _Byte>
 _INLINE_VAR constexpr bool


### PR DESCRIPTION
Fixes #2109
Fixes #817 