### PR TITLE
`<xstring>`: Restrict enabled `hash` specializations as required by the standard

### DIFF
--- a/stl/inc/filesystem
+++ b/stl/inc/filesystem
@@ -211,21 +211,6 @@ namespace filesystem {
         }
     }
 
-    template <class>
-    inline constexpr bool _Is_EcharT = false;
-    template <>
-    inline constexpr bool _Is_EcharT<char> = true;
-    template <>
-    inline constexpr bool _Is_EcharT<wchar_t> = true;
-#ifdef __cpp_char8_t
-    template <>
-    inline constexpr bool _Is_EcharT<char8_t> = true;
-#endif // __cpp_char8_t
-    template <>
-    inline constexpr bool _Is_EcharT<char16_t> = true;
-    template <>
-    inline constexpr bool _Is_EcharT<char32_t> = true;
-
     template <class _Ty, class = void>
     inline constexpr bool _Is_Source_impl = false;
 

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -917,6 +917,31 @@ constexpr size_t _Traits_rfind_not_ch(_In_reads_(_Hay_size) const _Traits_ptr_t<
     return static_cast<size_t>(-1); // no match
 }
 
+template <class>
+_INLINE_VAR constexpr bool _Is_EcharT = false;
+template <>
+_INLINE_VAR constexpr bool _Is_EcharT<char> = true;
+template <>
+_INLINE_VAR constexpr bool _Is_EcharT<wchar_t> = true;
+#ifdef __cpp_char8_t
+template <>
+_INLINE_VAR constexpr bool _Is_EcharT<char8_t> = true;
+#endif // __cpp_char8_t
+template <>
+_INLINE_VAR constexpr bool _Is_EcharT<char16_t> = true;
+template <>
+_INLINE_VAR constexpr bool _Is_EcharT<char32_t> = true;
+
+template <class _Alloc, class _Elem>
+_INLINE_VAR constexpr bool _Is_enabled_allocator_for = false;
+
+template <class _Elem>
+_INLINE_VAR constexpr bool _Is_enabled_allocator_for<allocator<_Elem>, _Elem> = true;
+
+#if _HAS_CXX17
+template <class _Elem>
+inline constexpr bool _Is_enabled_allocator_for<pmr::polymorphic_allocator<_Elem>, _Elem> = true;
+#endif // _HAS_CXX17
 
 #if _HAS_CXX17
 template <class _Elem, class _Traits = char_traits<_Elem>>
@@ -1825,11 +1850,10 @@ using wstring_view   = basic_string_view<wchar_t>;
 
 
 template <class _Elem, class _Traits>
-struct hash<basic_string_view<_Elem, _Traits>> {
-    _CXX17_DEPRECATE_ADAPTOR_TYPEDEFS typedef basic_string_view<_Elem, _Traits> _ARGUMENT_TYPE_NAME;
-    _CXX17_DEPRECATE_ADAPTOR_TYPEDEFS typedef size_t _RESULT_TYPE_NAME;
-
-    _NODISCARD size_t operator()(const basic_string_view<_Elem, _Traits> _Keyval) const noexcept {
+struct hash<basic_string_view<_Elem, _Traits>>
+    : _Conditionally_enabled_hash<basic_string_view<_Elem, _Traits>,
+          _Is_EcharT<_Elem> && is_same_v<_Traits, char_traits<_Elem>>> {
+    _NODISCARD static size_t _Do_hash()(const basic_string_view<_Elem, _Traits> _Keyval) noexcept {
         return _Hash_array_representation(_Keyval.data(), _Keyval.size());
     }
 };
@@ -5192,11 +5216,10 @@ using u16string = basic_string<char16_t, char_traits<char16_t>, allocator<char16
 using u32string = basic_string<char32_t, char_traits<char32_t>, allocator<char32_t>>;
 
 template <class _Elem, class _Traits, class _Alloc>
-struct hash<basic_string<_Elem, _Traits, _Alloc>> {
-    _CXX17_DEPRECATE_ADAPTOR_TYPEDEFS typedef basic_string<_Elem, _Traits, _Alloc> _ARGUMENT_TYPE_NAME;
-    _CXX17_DEPRECATE_ADAPTOR_TYPEDEFS typedef size_t _RESULT_TYPE_NAME;
-
-    _NODISCARD size_t operator()(const basic_string<_Elem, _Traits, _Alloc>& _Keyval) const noexcept {
+struct hash<basic_string<_Elem, _Traits, _Alloc>>
+    ：_Conditionally_enabled_hash<basic_string<_Elem, _Traits, _Alloc>,
+          _Is_EcharT<_Elem> && is_same_v<_Traits, char_traits<_Elem>> && _Is_enabled_allocator_for<_Alloc, _Elem>> {
+    _NODISCARD static size_t _Do_hash()(const basic_string<_Elem, _Traits, _Alloc>& _Keyval) noexcept {
         return _Hash_array_representation(_Keyval.c_str(), _Keyval.size());
     }
 };

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -1850,9 +1850,8 @@ using wstring_view   = basic_string_view<wchar_t>;
 
 
 template <class _Elem, class _Traits>
-struct hash<basic_string_view<_Elem, _Traits>>
-    : _Conditionally_enabled_hash<basic_string_view<_Elem, _Traits>,
-          _Is_EcharT<_Elem> && is_same_v<_Traits, char_traits<_Elem>>> {
+struct hash<basic_string_view<_Elem, _Traits>> : _Conditionally_enabled_hash<basic_string_view<_Elem, _Traits>,
+                                                     _Is_EcharT<_Elem> && is_same_v<_Traits, char_traits<_Elem>>> {
     _NODISCARD static size_t _Do_hash()(const basic_string_view<_Elem, _Traits> _Keyval) noexcept {
         return _Hash_array_representation(_Keyval.data(), _Keyval.size());
     }

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -924,17 +924,6 @@ _INLINE_VAR constexpr bool _Is_EcharT = _Is_any_of_v<_Ty, char, wchar_t,
 #endif // __cpp_char8_t
     char16_t, char32_t>;
 
-template <class _Alloc, class _Elem>
-_INLINE_VAR constexpr bool _Is_enabled_allocator_for = false;
-
-template <class _Elem>
-_INLINE_VAR constexpr bool _Is_enabled_allocator_for<allocator<_Elem>, _Elem> = true;
-
-#if _HAS_CXX17
-template <class _Elem>
-inline constexpr bool _Is_enabled_allocator_for<pmr::polymorphic_allocator<_Elem>, _Elem> = true;
-#endif // _HAS_CXX17
-
 #if _HAS_CXX17
 template <class _Elem, class _Traits = char_traits<_Elem>>
 class basic_string_view;
@@ -5207,8 +5196,7 @@ using u32string = basic_string<char32_t, char_traits<char32_t>, allocator<char32
 
 template <class _Elem, class _Alloc>
 struct hash<basic_string<_Elem, char_traits<_Elem>, _Alloc>>
-    : _Conditionally_enabled_hash<basic_string<_Elem, char_traits<_Elem>, _Alloc>,
-          _Is_EcharT<_Elem> && _Is_enabled_allocator_for<_Alloc, _Elem>> {
+    : _Conditionally_enabled_hash<basic_string<_Elem, char_traits<_Elem>, _Alloc>, _Is_EcharT<_Elem>> { // per LWG-3705
     _NODISCARD static size_t _Do_hash(const basic_string<_Elem, char_traits<_Elem>, _Alloc>& _Keyval) noexcept {
         return _Hash_array_representation(_Keyval.c_str(), _Keyval.size());
     }

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -1852,7 +1852,7 @@ using wstring_view   = basic_string_view<wchar_t>;
 template <class _Elem, class _Traits>
 struct hash<basic_string_view<_Elem, _Traits>> : _Conditionally_enabled_hash<basic_string_view<_Elem, _Traits>,
                                                      _Is_EcharT<_Elem> && is_same_v<_Traits, char_traits<_Elem>>> {
-    _NODISCARD static size_t _Do_hash()(const basic_string_view<_Elem, _Traits> _Keyval) noexcept {
+    _NODISCARD static size_t _Do_hash(const basic_string_view<_Elem, _Traits> _Keyval) noexcept {
         return _Hash_array_representation(_Keyval.data(), _Keyval.size());
     }
 };
@@ -5218,7 +5218,7 @@ template <class _Elem, class _Traits, class _Alloc>
 struct hash<basic_string<_Elem, _Traits, _Alloc>>
     : _Conditionally_enabled_hash<basic_string<_Elem, _Traits, _Alloc>,
           _Is_EcharT<_Elem> && is_same_v<_Traits, char_traits<_Elem>> && _Is_enabled_allocator_for<_Alloc, _Elem>> {
-    _NODISCARD static size_t _Do_hash()(const basic_string<_Elem, _Traits, _Alloc>& _Keyval) noexcept {
+    _NODISCARD static size_t _Do_hash(const basic_string<_Elem, _Traits, _Alloc>& _Keyval) noexcept {
         return _Hash_array_representation(_Keyval.c_str(), _Keyval.size());
     }
 };

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -917,20 +917,12 @@ constexpr size_t _Traits_rfind_not_ch(_In_reads_(_Hay_size) const _Traits_ptr_t<
     return static_cast<size_t>(-1); // no match
 }
 
-template <class>
-_INLINE_VAR constexpr bool _Is_EcharT = false;
-template <>
-_INLINE_VAR constexpr bool _Is_EcharT<char> = true;
-template <>
-_INLINE_VAR constexpr bool _Is_EcharT<wchar_t> = true;
+template <class _Ty>
+_INLINE_VAR constexpr bool _Is_EcharT = _Is_any_of_v<_Ty, char, wchar_t,
 #ifdef __cpp_char8_t
-template <>
-_INLINE_VAR constexpr bool _Is_EcharT<char8_t> = true;
+    char8_t,
 #endif // __cpp_char8_t
-template <>
-_INLINE_VAR constexpr bool _Is_EcharT<char16_t> = true;
-template <>
-_INLINE_VAR constexpr bool _Is_EcharT<char32_t> = true;
+    char16_t, char32_t>;
 
 template <class _Alloc, class _Elem>
 _INLINE_VAR constexpr bool _Is_enabled_allocator_for = false;

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -1841,10 +1841,9 @@ using u32string_view = basic_string_view<char32_t>;
 using wstring_view   = basic_string_view<wchar_t>;
 
 
-template <class _Elem, class _Traits>
-struct hash<basic_string_view<_Elem, _Traits>> : _Conditionally_enabled_hash<basic_string_view<_Elem, _Traits>,
-                                                     _Is_EcharT<_Elem> && is_same_v<_Traits, char_traits<_Elem>>> {
-    _NODISCARD static size_t _Do_hash(const basic_string_view<_Elem, _Traits> _Keyval) noexcept {
+template <class _Elem>
+struct hash<basic_string_view<_Elem>> : _Conditionally_enabled_hash<basic_string_view<_Elem>, _Is_EcharT<_Elem>> {
+    _NODISCARD static size_t _Do_hash(const basic_string_view<_Elem> _Keyval) noexcept {
         return _Hash_array_representation(_Keyval.data(), _Keyval.size());
     }
 };
@@ -5206,11 +5205,11 @@ using u8string = basic_string<char8_t, char_traits<char8_t>, allocator<char8_t>>
 using u16string = basic_string<char16_t, char_traits<char16_t>, allocator<char16_t>>;
 using u32string = basic_string<char32_t, char_traits<char32_t>, allocator<char32_t>>;
 
-template <class _Elem, class _Traits, class _Alloc>
-struct hash<basic_string<_Elem, _Traits, _Alloc>>
-    : _Conditionally_enabled_hash<basic_string<_Elem, _Traits, _Alloc>,
-          _Is_EcharT<_Elem> && is_same_v<_Traits, char_traits<_Elem>> && _Is_enabled_allocator_for<_Alloc, _Elem>> {
-    _NODISCARD static size_t _Do_hash(const basic_string<_Elem, _Traits, _Alloc>& _Keyval) noexcept {
+template <class _Elem, class _Alloc>
+struct hash<basic_string<_Elem, char_traits<_Elem>, _Alloc>>
+    : _Conditionally_enabled_hash<basic_string<_Elem, char_traits<_Elem>, _Alloc>,
+          _Is_EcharT<_Elem> && _Is_enabled_allocator_for<_Alloc, _Elem>> {
+    _NODISCARD static size_t _Do_hash(const basic_string<_Elem, char_traits<_Elem>, _Alloc>& _Keyval) noexcept {
         return _Hash_array_representation(_Keyval.c_str(), _Keyval.size());
     }
 };

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -5217,7 +5217,7 @@ using u32string = basic_string<char32_t, char_traits<char32_t>, allocator<char32
 
 template <class _Elem, class _Traits, class _Alloc>
 struct hash<basic_string<_Elem, _Traits, _Alloc>>
-    ：_Conditionally_enabled_hash<basic_string<_Elem, _Traits, _Alloc>,
+    : _Conditionally_enabled_hash<basic_string<_Elem, _Traits, _Alloc>,
           _Is_EcharT<_Elem> && is_same_v<_Traits, char_traits<_Elem>> && _Is_enabled_allocator_for<_Alloc, _Elem>> {
     _NODISCARD static size_t _Do_hash()(const basic_string<_Elem, _Traits, _Alloc>& _Keyval) noexcept {
         return _Hash_array_representation(_Keyval.c_str(), _Keyval.size());

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -412,10 +412,6 @@ std/diagnostics/syserr/syserr.errcat/syserr.errcat.nonvirtuals/default_ctor.pass
 # GH-1190 <future>: incorrectly used copy assignment instead of copy construction in set_value
 std/thread/futures/futures.promise/set_value_const.pass.cpp FAIL
 
-# GH-757 <xstring>: Too many enabled hash specializations
-std/strings/basic.string.hash/char_type_hash.fail.cpp FAIL
-std/strings/string.view/string.view.hash/char_type.hash.fail.cpp FAIL
-
 # GH-784 <type_traits>: aligned_storage has incorrect alignment defaults
 std/utilities/meta/meta.trans/meta.trans.other/aligned_storage.pass.cpp FAIL
 

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -412,10 +412,6 @@ diagnostics\syserr\syserr.errcat\syserr.errcat.nonvirtuals\default_ctor.pass.cpp
 # GH-1190 <future>: incorrectly used copy assignment instead of copy construction in set_value
 thread\futures\futures.promise\set_value_const.pass.cpp
 
-# GH-757 <xstring>: Too many enabled hash specializations
-strings\basic.string.hash\char_type_hash.fail.cpp
-strings\string.view\string.view.hash\char_type.hash.fail.cpp
-
 # GH-784 <type_traits>: aligned_storage has incorrect alignment defaults
 utilities\meta\meta.trans\meta.trans.other\aligned_storage.pass.cpp
 


### PR DESCRIPTION
Fixes #757. Perhaps libcxx tests are enough.

I also move `_Is_EcharT` to `<xstring>` because I think its usage may be more general.