### PR TITLE
`syserror.cpp`: update `_Syserror_map`

### DIFF
--- a/stl/inc/system_error
+++ b/stl/inc/system_error
@@ -501,12 +501,7 @@ public:
     }
 
     _NODISCARD string message(int _Errcode) const override {
-        // TRANSITION, GH-2561, move the logic to syserror.cpp
-        if (_Errcode == 0) {
-            return "success";
-        } else {
-            return _Syserror_map(_Errcode);
-        }
+        return _Syserror_map(_Errcode);
     }
 };
 

--- a/stl/src/syserror.cpp
+++ b/stl/src/syserror.cpp
@@ -112,6 +112,7 @@ namespace {
 
     constexpr _Sys_errtab_t _Sys_errtab[] = {
         // table of Posix code/name pairs
+        {static_cast<errc>(0), "success"},
         {errc::address_family_not_supported, "address family not supported"},
         {errc::address_in_use, "address in use"},
         {errc::address_not_available, "address not available"},
@@ -218,10 +219,6 @@ _CRTIMP2_PURE unsigned long __CLRCALL_PURE_OR_CDECL _Winerror_message(
 }
 
 _CRTIMP2_PURE const char* __CLRCALL_PURE_OR_CDECL _Syserror_map(int _Errcode) { // convert to name of generic error
-    if (_Errcode == 0) {
-        return "success";
-    }
-
     for (const auto& _Entry : _Sys_errtab) {
         if (static_cast<int>(_Entry._Errcode) == _Errcode) {
             return _Entry._Name;

--- a/stl/src/syserror.cpp
+++ b/stl/src/syserror.cpp
@@ -218,6 +218,10 @@ _CRTIMP2_PURE unsigned long __CLRCALL_PURE_OR_CDECL _Winerror_message(
 }
 
 _CRTIMP2_PURE const char* __CLRCALL_PURE_OR_CDECL _Syserror_map(int _Errcode) { // convert to name of generic error
+    if (_Errcode == 0) {
+        return "success";
+    }
+
     for (const auto& _Entry : _Sys_errtab) {
         if (static_cast<int>(_Entry._Errcode) == _Errcode) {
             return _Entry._Name;


### PR DESCRIPTION
Fixes #2561 

This PR affects redist.

It is expected that the fix can be included in VS 2022 17.4 Preview 2.

The changes is tested via: https://github.com/microsoft/STL/blob/60decd0d829e68666b556780002c83605d748d80/tests/std/tests/Dev11_0493504_error_category_lifetime/test.cpp#L31-L40