### PR TITLE
Untag dispatch `get` for `pair`

### DIFF
--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -651,23 +651,14 @@ struct _MSVC_KNOWN_SEMANTICS tuple_element<_Idx, pair<_Ty1, _Ty2>> {
     using type = conditional_t<_Idx == 0, _Ty1, _Ty2>;
 };
 
-template <class _Ret, class _Pair>
-constexpr _Ret _Pair_get(_Pair& _Pr, integral_constant<size_t, 0>) noexcept {
-    // get reference to element 0 in pair _Pr
-    return _Pr.first;
-}
-
-template <class _Ret, class _Pair>
-constexpr _Ret _Pair_get(_Pair& _Pr, integral_constant<size_t, 1>) noexcept {
-    // get reference to element 1 in pair _Pr
-    return _Pr.second;
-}
-
 template <size_t _Idx, class _Ty1, class _Ty2>
 _NODISCARD constexpr tuple_element_t<_Idx, pair<_Ty1, _Ty2>>& get(pair<_Ty1, _Ty2>& _Pr) noexcept {
     // get reference to element at _Idx in pair _Pr
-    using _Rtype = tuple_element_t<_Idx, pair<_Ty1, _Ty2>>&;
-    return _Pair_get<_Rtype>(_Pr, integral_constant<size_t, _Idx>{});
+    if constexpr (_Idx == 0) {
+        return _Pr.first;
+    } else {
+        return _Pr.second;
+    }
 }
 
 template <class _Ty1, class _Ty2>
@@ -685,8 +676,11 @@ _NODISCARD constexpr _Ty2& get(pair<_Ty1, _Ty2>& _Pr) noexcept {
 template <size_t _Idx, class _Ty1, class _Ty2>
 _NODISCARD constexpr const tuple_element_t<_Idx, pair<_Ty1, _Ty2>>& get(const pair<_Ty1, _Ty2>& _Pr) noexcept {
     // get const reference to element at _Idx in pair _Pr
-    using _Ctype = const tuple_element_t<_Idx, pair<_Ty1, _Ty2>>&;
-    return _Pair_get<_Ctype>(_Pr, integral_constant<size_t, _Idx>{});
+    if constexpr (_Idx == 0) {
+        return _Pr.first;
+    } else {
+        return _Pr.second;
+    }
 }
 
 template <class _Ty1, class _Ty2>

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -664,13 +664,13 @@ _NODISCARD constexpr tuple_element_t<_Idx, pair<_Ty1, _Ty2>>& get(pair<_Ty1, _Ty
 template <class _Ty1, class _Ty2>
 _NODISCARD constexpr _Ty1& get(pair<_Ty1, _Ty2>& _Pr) noexcept {
     // get reference to element _Ty1 in pair _Pr
-    return _STD get<0>(_Pr);
+    return _Pr.first;
 }
 
 template <class _Ty2, class _Ty1>
 _NODISCARD constexpr _Ty2& get(pair<_Ty1, _Ty2>& _Pr) noexcept {
     // get reference to element _Ty2 in pair _Pr
-    return _STD get<1>(_Pr);
+    return _Pr.second;
 }
 
 template <size_t _Idx, class _Ty1, class _Ty2>
@@ -686,51 +686,57 @@ _NODISCARD constexpr const tuple_element_t<_Idx, pair<_Ty1, _Ty2>>& get(const pa
 template <class _Ty1, class _Ty2>
 _NODISCARD constexpr const _Ty1& get(const pair<_Ty1, _Ty2>& _Pr) noexcept {
     // get const reference to element _Ty1 in pair _Pr
-    return _STD get<0>(_Pr);
+    return _Pr.first;
 }
 
 template <class _Ty2, class _Ty1>
 _NODISCARD constexpr const _Ty2& get(const pair<_Ty1, _Ty2>& _Pr) noexcept {
     // get const reference to element _Ty2 in pair _Pr
-    return _STD get<1>(_Pr);
+    return _Pr.second;
 }
 
 template <size_t _Idx, class _Ty1, class _Ty2>
 _NODISCARD constexpr tuple_element_t<_Idx, pair<_Ty1, _Ty2>>&& get(pair<_Ty1, _Ty2>&& _Pr) noexcept {
     // get rvalue reference to element at _Idx in pair _Pr
-    using _RRtype = tuple_element_t<_Idx, pair<_Ty1, _Ty2>>&&;
-    return _STD forward<_RRtype>(_STD get<_Idx>(_Pr));
+    if constexpr (_Idx == 0) {
+        return _STD forward<_Ty1>(_Pr.first);
+    } else {
+        return _STD forward<_Ty2>(_Pr.second);
+    }
 }
 
 template <class _Ty1, class _Ty2>
 _NODISCARD constexpr _Ty1&& get(pair<_Ty1, _Ty2>&& _Pr) noexcept {
     // get rvalue reference to element _Ty1 in pair _Pr
-    return _STD get<0>(_STD move(_Pr));
+    return _STD forward<_Ty1>(_Pr.first);
 }
 
 template <class _Ty2, class _Ty1>
 _NODISCARD constexpr _Ty2&& get(pair<_Ty1, _Ty2>&& _Pr) noexcept {
     // get rvalue reference to element _Ty2 in pair _Pr
-    return _STD get<1>(_STD move(_Pr));
+    return _STD forward<_Ty2>(_Pr.second);
 }
 
 template <size_t _Idx, class _Ty1, class _Ty2>
 _NODISCARD constexpr const tuple_element_t<_Idx, pair<_Ty1, _Ty2>>&& get(const pair<_Ty1, _Ty2>&& _Pr) noexcept {
     // get const rvalue reference to element at _Idx in pair _Pr
-    using _RRtype = const tuple_element_t<_Idx, pair<_Ty1, _Ty2>>&&;
-    return _STD forward<_RRtype>(_STD get<_Idx>(_Pr));
+    if constexpr (_Idx == 0) {
+        return _STD forward<const _Ty1>(_Pr.first);
+    } else {
+        return _STD forward<const _Ty2>(_Pr.second);
+    }
 }
 
 template <class _Ty1, class _Ty2>
 _NODISCARD constexpr const _Ty1&& get(const pair<_Ty1, _Ty2>&& _Pr) noexcept {
     // get const rvalue reference to element _Ty1 in pair _Pr
-    return _STD get<0>(_STD move(_Pr));
+    return _STD forward<const _Ty1>(_Pr.first);
 }
 
 template <class _Ty2, class _Ty1>
 _NODISCARD constexpr const _Ty2&& get(const pair<_Ty1, _Ty2>&& _Pr) noexcept {
     // get const rvalue reference to element _Ty2 in pair _Pr
-    return _STD get<1>(_STD move(_Pr));
+    return _STD forward<const _Ty2>(_Pr.second);
 }
 
 template <class _Ty, class _Other = _Ty>


### PR DESCRIPTION
Towards #189.

Error message is emitted by `tuple_element_t` if `_Idx >= 2`, so it is not needed to be repeated in `get`.