### PR TITLE
allow `%x` for formatting `year_month_day`

### DIFF
--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -5281,8 +5281,8 @@ namespace chrono {
             } else if constexpr (_Is_any_of_v<_Ty, year_month_day, year_month_day_last, year_month_weekday,
                                      year_month_weekday_last>) {
                 return _Type == 'D' || _Type == 'F' || _Type == 'g' || _Type == 'G' || _Type == 'j' || _Type == 'U'
-                    || _Type == 'V' || _Type == 'W' || _Is_valid_type<year>(_Type) || _Is_valid_type<month>(_Type)
-                    || _Is_valid_type<day>(_Type) || _Is_valid_type<weekday>(_Type);
+                    || _Type == 'V' || _Type == 'W' || _Type == 'x' || _Is_valid_type<year>(_Type)
+                    || _Is_valid_type<month>(_Type) || _Is_valid_type<day>(_Type) || _Is_valid_type<weekday>(_Type);
             } else if constexpr (_Is_specialization_v<_Ty, hh_mm_ss>) {
                 return _Type == 'H' || _Type == 'I' || _Type == 'M' || _Type == 'S' || _Type == 'r' || _Type == 'R'
                     || _Type == 'T' || _Type == 'p';
@@ -5294,7 +5294,7 @@ namespace chrono {
                         return true;
                     }
                 }
-                return _Type == 'c' || _Type == 'x' || _Type == 'X' || _Is_valid_type<year_month_day>(_Type)
+                return _Type == 'c' || _Type == 'X' || _Is_valid_type<year_month_day>(_Type)
                     || _Is_valid_type<hh_mm_ss<seconds>>(_Type);
             } else if constexpr (_Is_specialization_v<_Ty, _Local_time_format_t>) {
                 return _Type == 'z' || _Type == 'Z' || _Is_valid_type<decltype(_Ty::_Time)>(_Type);

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
@@ -663,6 +663,9 @@ void test_year_month_day_last_formatter() {
     throw_helper(STR("{:%j}"), year{1900} / month{13} / last);
 
     assert(format(STR("{:%g %G %U %V %W}"), 2010y / May / last) == STR("10 2010 22 22 22"));
+
+    // GH-2761, formatter<chrono::year_month_day> is not fully implemented
+    assert(format(STR("{:%x}"), ymdl1) == STR("04/30/21"));
 }
 
 template <typename CharT>
@@ -694,6 +697,9 @@ void test_year_month_weekday_formatter() {
     throw_helper(STR("{:%j}"), invalid1);
 
     assert(format(STR("{:%g %G %U %V %W}"), 2010y / May / Monday[5]) == STR("10 2010 22 22 22"));
+
+    // GH-2761, formatter<chrono::year_month_day> is not fully implemented
+    assert(format(STR("{:%x}"), ymwd1) == STR("04/30/21"));
 }
 
 template <typename CharT>
@@ -723,6 +729,9 @@ void test_year_month_weekday_last_formatter() {
     throw_helper(STR("{:%j}"), invalid1);
 
     assert(format(STR("{:%g %G %U %V %W}"), 2010y / May / Monday[last]) == STR("10 2010 22 22 22"));
+
+    // GH-2761, formatter<chrono::year_month_day> is not fully implemented
+    assert(format(STR("{:%x}"), ymwdl1) == STR("04/30/21"));
 }
 
 template <typename CharT>

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
@@ -634,6 +634,9 @@ void test_year_month_day_formatter() {
     assert(format(STR("{:%g %G %U %V %W}"), 2010y / December / 29) == STR("10 2010 52 52 52"));
     assert(format(STR("{:%g %G %U %V %W}"), 2010y / December / 30) == STR("10 2010 52 52 52"));
     assert(format(STR("{:%g %G %U %V %W}"), 2010y / December / 31) == STR("10 2010 52 52 52"));
+
+    // GH-2761, formatter<chrono::year_month_day> is not fully implemented
+    assert(format(STR("{:%x}"), year_month_day{year{2010}, month{5}, day{6}}) == STR("05/06/10"));
 }
 
 template <typename CharT>


### PR DESCRIPTION
Fixes #2761

I'm not sure if it's correct.

C++ standard is unclear: https://eel.is/c++draft/time.format#6

But cppreference says that `%x` is supported for [year_month_day](https://en.cppreference.com/w/cpp/chrono/year_month_day/formatter), [year_month_day_last](https://en.cppreference.com/w/cpp/chrono/year_month_day_last/formatter), [year_month_weekday](https://en.cppreference.com/w/cpp/chrono/year_month_weekday/formatter) and [year_month_weekday_last](https://en.cppreference.com/w/cpp/chrono/year_month_weekday_last/formatter)