### PR TITLE
`<syncstream>`: fix `std::osyncstream` memory leak

### DIFF
--- a/stl/inc/syncstream
+++ b/stl/inc/syncstream
@@ -223,7 +223,9 @@ protected:
 
         _Elem* const _New_ptr = _Unfancy(_Al.allocate(_New_capacity));
         _Traits::copy(_New_ptr, _Old_ptr, _Old_data_size);
-        _Al.deallocate(_Refancy<_Pointer>(_Old_ptr), _Old_data_size);
+        if (0 < _Buf_size) {
+            _Al.deallocate(_Refancy<_Pointer>(_Old_ptr), _Buf_size);
+        }
 
         streambuf_type::setp(_New_ptr, _New_ptr + _Old_data_size, _New_ptr + _New_capacity);
         streambuf_type::sputc(_Traits::to_char_type(_Current_elem));

--- a/stl/inc/syncstream
+++ b/stl/inc/syncstream
@@ -218,11 +218,12 @@ protected:
         }
 
         const _Size_type _New_capacity  = _Calculate_growth(_Buf_size, _Buf_size + 1, _Max_allocation);
-        const _Elem* const _Old_ptr     = streambuf_type::pbase();
+        _Elem* const _Old_ptr           = streambuf_type::pbase();
         const _Size_type _Old_data_size = _Get_data_size();
 
         _Elem* const _New_ptr = _Unfancy(_Al.allocate(_New_capacity));
         _Traits::copy(_New_ptr, _Old_ptr, _Old_data_size);
+        _Getal().deallocate(_Refancy<_Pointer>(_Old_ptr), _Old_data_size);
 
         streambuf_type::setp(_New_ptr, _New_ptr + _Old_data_size, _New_ptr + _New_capacity);
         streambuf_type::sputc(_Traits::to_char_type(_Current_elem));

--- a/stl/inc/syncstream
+++ b/stl/inc/syncstream
@@ -223,7 +223,7 @@ protected:
 
         _Elem* const _New_ptr = _Unfancy(_Al.allocate(_New_capacity));
         _Traits::copy(_New_ptr, _Old_ptr, _Old_data_size);
-        _Getal().deallocate(_Refancy<_Pointer>(_Old_ptr), _Old_data_size);
+        _Al.deallocate(_Refancy<_Pointer>(_Old_ptr), _Old_data_size);
 
         streambuf_type::setp(_New_ptr, _New_ptr + _Old_data_size, _New_ptr + _New_capacity);
         streambuf_type::sputc(_Traits::to_char_type(_Current_elem));

--- a/tests/std/test.lst
+++ b/tests/std/test.lst
@@ -204,6 +204,7 @@ tests\GH_002558_format_presetPadding
 tests\GH_002581_common_reference_workaround
 tests\GH_002655_alternate_name_broke_linker
 tests\GH_002711_Zc_alignedNew-
+tests\GH_002760_syncstream_memory_leak
 tests\LWG2597_complex_branch_cut
 tests\LWG3018_shared_ptr_function
 tests\LWG3121_constrained_tuple_forwarding_ctor

--- a/tests/std/tests/GH_002760_syncstream_memory_leak/env.lst
+++ b/tests/std/tests/GH_002760_syncstream_memory_leak/env.lst
@@ -1,0 +1,20 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# This is usual_20_matrix.lst but only with Debug CRT
+
+RUNALL_INCLUDE ..\prefix.lst
+RUNALL_CROSSLIST
+PM_CL="/w14640 /Zc:threadSafeInit- /EHsc"
+RUNALL_CROSSLIST
+PM_CL="/MDd /D_ITERATOR_DEBUG_LEVEL=0 /std:c++latest /permissive- /Zc:wchar_t- /Zc:preprocessor"
+PM_CL="/MDd /D_ITERATOR_DEBUG_LEVEL=1 /std:c++latest /permissive-"
+PM_CL="/MDd /D_ITERATOR_DEBUG_LEVEL=2 /std:c++20 /permissive- /fp:except /Zc:preprocessor"
+PM_CL="/MT /D_ITERATOR_DEBUG_LEVEL=0 /std:c++latest /permissive- /analyze:only /analyze:autolog-"
+PM_CL="/MTd /D_ITERATOR_DEBUG_LEVEL=0 /std:c++latest /permissive- /fp:strict"
+PM_CL="/MTd /D_ITERATOR_DEBUG_LEVEL=1 /std:c++latest /permissive-"
+PM_CL="/MTd /D_ITERATOR_DEBUG_LEVEL=2 /std:c++latest /permissive"
+PM_CL="/MTd /D_ITERATOR_DEBUG_LEVEL=2 /std:c++latest /permissive- /analyze:only /analyze:autolog-"
+PM_CL="/BE /c /MD /std:c++20 /permissive-"
+PM_CL="/BE /c /MTd /std:c++latest /permissive-"
+PM_COMPILER="clang-cl" PM_CL="-fno-ms-compatibility -fno-delayed-template-parsing /std:c++latest /permissive- /MTd /fp:strict"

--- a/tests/std/tests/GH_002760_syncstream_memory_leak/env.lst
+++ b/tests/std/tests/GH_002760_syncstream_memory_leak/env.lst
@@ -1,20 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-# This is usual_20_matrix.lst but only with Debug CRT
-
-RUNALL_INCLUDE ..\prefix.lst
-RUNALL_CROSSLIST
-PM_CL="/w14640 /Zc:threadSafeInit- /EHsc"
-RUNALL_CROSSLIST
-PM_CL="/MDd /D_ITERATOR_DEBUG_LEVEL=0 /std:c++latest /permissive- /Zc:wchar_t- /Zc:preprocessor"
-PM_CL="/MDd /D_ITERATOR_DEBUG_LEVEL=1 /std:c++latest /permissive-"
-PM_CL="/MDd /D_ITERATOR_DEBUG_LEVEL=2 /std:c++20 /permissive- /fp:except /Zc:preprocessor"
-PM_CL="/MT /D_ITERATOR_DEBUG_LEVEL=0 /std:c++latest /permissive- /analyze:only /analyze:autolog-"
-PM_CL="/MTd /D_ITERATOR_DEBUG_LEVEL=0 /std:c++latest /permissive- /fp:strict"
-PM_CL="/MTd /D_ITERATOR_DEBUG_LEVEL=1 /std:c++latest /permissive-"
-PM_CL="/MTd /D_ITERATOR_DEBUG_LEVEL=2 /std:c++latest /permissive"
-PM_CL="/MTd /D_ITERATOR_DEBUG_LEVEL=2 /std:c++latest /permissive- /analyze:only /analyze:autolog-"
-PM_CL="/BE /c /MD /std:c++20 /permissive-"
-PM_CL="/BE /c /MTd /std:c++latest /permissive-"
-PM_COMPILER="clang-cl" PM_CL="-fno-ms-compatibility -fno-delayed-template-parsing /std:c++latest /permissive- /MTd /fp:strict"
+RUNALL_INCLUDE ..\usual_20_matrix.lst

--- a/tests/std/tests/GH_002760_syncstream_memory_leak/test.cpp
+++ b/tests/std/tests/GH_002760_syncstream_memory_leak/test.cpp
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#define _CRTDBG_MAP_ALLOC
+#include <cassert>
+#include <crtdbg.h>
+#include <cstdlib>
+#include <iostream>
+#include <sstream>
+#include <syncstream>
+
+using namespace std;
+
+int main() {
+    _CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF);
+    _CrtMemState start, end, diff;
+    _CrtMemCheckpoint(&start);
+    {
+        stringstream s;
+        osyncstream bout(s);
+        bout << "Hello, this line is long, LEAK incoming" << '\n';
+    }
+    _CrtMemCheckpoint(&end);
+    assert(_CrtMemDifference(&diff, &start, &end) == 0);
+}

--- a/tests/std/tests/GH_002760_syncstream_memory_leak/test.cpp
+++ b/tests/std/tests/GH_002760_syncstream_memory_leak/test.cpp
@@ -2,10 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #define _CRTDBG_MAP_ALLOC
-#include <cassert>
-#include <crtdbg.h>
 #include <cstdlib>
-#include <iostream>
+//
+#include <crtdbg.h>
+//
+#include <cassert>
 #include <sstream>
 #include <syncstream>
 

--- a/tests/std/tests/GH_002760_syncstream_memory_leak/test.cpp
+++ b/tests/std/tests/GH_002760_syncstream_memory_leak/test.cpp
@@ -11,7 +11,7 @@
 #include <syncstream>
 
 using namespace std;
-
+// GH-2760, <syncstream>: std::osyncstream memory leak
 int main() {
     _CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF);
     _CrtMemState start, end, diff;

--- a/tests/std/tests/GH_002760_syncstream_memory_leak/test.cpp
+++ b/tests/std/tests/GH_002760_syncstream_memory_leak/test.cpp
@@ -1,25 +1,25 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#define _CRTDBG_MAP_ALLOC
-#include <cstdlib>
-//
-#include <crtdbg.h>
-//
+// REQUIRES: debug_CRT
+
 #include <cassert>
+#include <cstdlib>
 #include <sstream>
 #include <syncstream>
-
 using namespace std;
+
 // GH-2760, <syncstream>: std::osyncstream memory leak
 int main() {
     _CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF);
-    _CrtMemState start, end, diff;
+    [[maybe_unused]] _CrtMemState start;
+    [[maybe_unused]] _CrtMemState end;
+    [[maybe_unused]] _CrtMemState diff;
     _CrtMemCheckpoint(&start);
     {
         stringstream s;
         osyncstream bout(s);
-        bout << "Hello, this line is long, LEAK incoming" << '\n';
+        bout << "Hello, this line is long, which previously leaked memory" << '\n';
     }
     _CrtMemCheckpoint(&end);
     assert(_CrtMemDifference(&diff, &start, &end) == 0);

--- a/tests/std/tests/usual_20_matrix.lst
+++ b/tests/std/tests/usual_20_matrix.lst
@@ -1,6 +1,8 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+# When updating this file, also update tests\GH_002760_syncstream_memory_leak\env.lst to match
+
 RUNALL_INCLUDE .\prefix.lst
 RUNALL_CROSSLIST
 PM_CL="/w14640 /Zc:threadSafeInit- /EHsc"

--- a/tests/std/tests/usual_20_matrix.lst
+++ b/tests/std/tests/usual_20_matrix.lst
@@ -1,8 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-# When updating this file, also update tests\GH_002760_syncstream_memory_leak\env.lst to match
-
 RUNALL_INCLUDE .\prefix.lst
 RUNALL_CROSSLIST
 PM_CL="/w14640 /Zc:threadSafeInit- /EHsc"


### PR DESCRIPTION
Fixes #2760