### PR TITLE
 <yvals_core.h>: Update _MSVC_STL_UPDATE to June 2022

### DIFF
--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -615,7 +615,7 @@
 
 #define _CPPLIB_VER       650
 #define _MSVC_STL_VERSION 143
-#define _MSVC_STL_UPDATE  202205L
+#define _MSVC_STL_UPDATE  202206L
 
 #ifndef _ALLOW_COMPILER_AND_STL_VERSION_MISMATCH
 #if defined(__CUDACC__) && defined(__CUDACC_VER_MAJOR__)


### PR DESCRIPTION
Resolves #2752 