### PR TITLE
fix `format` a `long` value with `formatter`

### DIFF
--- a/stl/inc/format
+++ b/stl/inc/format
@@ -1776,7 +1776,7 @@ struct _Format_arg_traits {
         -> basic_string_view<_Char_type>; // not defined
 
     template <class _Traits, class _Alloc>
-    static auto _Phony_basic_format_arg_constructor(const basic_string<_Char_type, _Traits, _Alloc>&)
+    static auto _Phony_basic_format_arg_constructor(basic_string<_Char_type, _Traits, _Alloc>)
         -> basic_string_view<_Char_type>; // not defined
 
     static auto _Phony_basic_format_arg_constructor(nullptr_t) -> const void*; // not defined

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -3286,11 +3286,18 @@ struct _Formatter_base {
                 _FormatCtx.arg(static_cast<size_t>(_Specs._Dynamic_precision_index)));
         }
 
-        return _STD visit_format_arg(
-            _Arg_formatter<typename _FormatContext::iterator, _CharT>{
-                ._Ctx = _STD addressof(_FormatCtx), ._Specs = _STD addressof(_Format_specs)},
-            basic_format_arg<_FormatContext>{
-                static_cast<typename _Format_arg_traits<_FormatContext>::template _Storage_type<_Ty>>(_Val)});
+        using _Storage_type = typename _Format_arg_traits<_FormatContext>::template _Storage_type<_Ty>;
+        if constexpr (is_same_v<typename basic_format_arg<_FormatContext>::handle, _Storage_type>) {
+            return _STD visit_format_arg(
+                _Arg_formatter<typename _FormatContext::iterator, _CharT>{
+                    ._Ctx = _STD addressof(_FormatCtx), ._Specs = _STD addressof(_Format_specs)},
+                basic_format_arg<_FormatContext>{_Val});
+        } else {
+            return _STD visit_format_arg(
+                _Arg_formatter<typename _FormatContext::iterator, _CharT>{
+                    ._Ctx = _STD addressof(_FormatCtx), ._Specs = _STD addressof(_Format_specs)},
+                basic_format_arg<_FormatContext>{static_cast<_Storage_type>(_Val)});
+        }
     }
 
 private:

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -3289,7 +3289,8 @@ struct _Formatter_base {
         return _STD visit_format_arg(
             _Arg_formatter<typename _FormatContext::iterator, _CharT>{
                 ._Ctx = _STD addressof(_FormatCtx), ._Specs = _STD addressof(_Format_specs)},
-            basic_format_arg<_FormatContext>{_Val});
+            basic_format_arg<_FormatContext>{
+                static_cast<typename _Format_arg_traits<_FormatContext>::template _Storage_type<_Ty>>(_Val)});
     }
 
 private:

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -666,6 +666,10 @@ public:
         : _Active_state(_Basic_format_arg_type::_Int_type), _Int_state(_Val) {}
     explicit basic_format_arg(const unsigned int _Val) noexcept
         : _Active_state(_Basic_format_arg_type::_UInt_type), _UInt_state(_Val) {}
+    explicit basic_format_arg(const long _Val) noexcept
+        : _Active_state(_Basic_format_arg_type::_Int_type), _Int_state(_Val) {}
+    explicit basic_format_arg(const unsigned long _Val) noexcept
+        : _Active_state(_Basic_format_arg_type::_UInt_type), _UInt_state(_Val) {}
     explicit basic_format_arg(const long long _Val) noexcept
         : _Active_state(_Basic_format_arg_type::_Long_long_type), _Long_long_state(_Val) {}
     explicit basic_format_arg(const unsigned long long _Val) noexcept
@@ -1769,6 +1773,7 @@ struct _Format_arg_traits {
     static auto _Phony_basic_format_arg_constructor(double) -> double; // not defined
     static auto _Phony_basic_format_arg_constructor(long double) -> long double; // not defined
 
+    static auto _Phony_basic_format_arg_constructor(_Char_type*) -> const _Char_type*; // not defined
     static auto _Phony_basic_format_arg_constructor(const _Char_type*) -> const _Char_type*; // not defined
 
     template <class _Traits>
@@ -3286,15 +3291,10 @@ struct _Formatter_base {
                 _FormatCtx.arg(static_cast<size_t>(_Specs._Dynamic_precision_index)));
         }
 
-        _Arg_formatter<typename _FormatContext::iterator, _CharT> _Arg_fmt{
-            ._Ctx = _STD addressof(_FormatCtx), ._Specs = _STD addressof(_Format_specs)};
-
-        using _Storage_type = typename _Format_arg_traits<_FormatContext>::template _Storage_type<_Ty>;
-        if constexpr (is_same_v<typename basic_format_arg<_FormatContext>::handle, _Storage_type>) {
-            return _STD visit_format_arg(_Arg_fmt, basic_format_arg<_FormatContext>{_Val});
-        } else {
-            return _STD visit_format_arg(_Arg_fmt, basic_format_arg<_FormatContext>{static_cast<_Storage_type>(_Val)});
-        }
+        return _STD visit_format_arg(
+            _Arg_formatter<typename _FormatContext::iterator, _CharT>{
+                ._Ctx = _STD addressof(_FormatCtx), ._Specs = _STD addressof(_Format_specs)},
+            basic_format_arg<_FormatContext>{_Val});
     }
 
 private:

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -3286,17 +3286,14 @@ struct _Formatter_base {
                 _FormatCtx.arg(static_cast<size_t>(_Specs._Dynamic_precision_index)));
         }
 
+        _Arg_formatter<typename _FormatContext::iterator, _CharT> _Arg_fmt{
+            ._Ctx = _STD addressof(_FormatCtx), ._Specs = _STD addressof(_Format_specs)};
+
         using _Storage_type = typename _Format_arg_traits<_FormatContext>::template _Storage_type<_Ty>;
         if constexpr (is_same_v<typename basic_format_arg<_FormatContext>::handle, _Storage_type>) {
-            return _STD visit_format_arg(
-                _Arg_formatter<typename _FormatContext::iterator, _CharT>{
-                    ._Ctx = _STD addressof(_FormatCtx), ._Specs = _STD addressof(_Format_specs)},
-                basic_format_arg<_FormatContext>{_Val});
+            return _STD visit_format_arg(_Arg_fmt, basic_format_arg<_FormatContext>{_Val});
         } else {
-            return _STD visit_format_arg(
-                _Arg_formatter<typename _FormatContext::iterator, _CharT>{
-                    ._Ctx = _STD addressof(_FormatCtx), ._Specs = _STD addressof(_Format_specs)},
-                basic_format_arg<_FormatContext>{static_cast<_Storage_type>(_Val)});
+            return _STD visit_format_arg(_Arg_fmt, basic_format_arg<_FormatContext>{static_cast<_Storage_type>(_Val)});
         }
     }
 

--- a/tests/std/tests/P0645R10_text_formatting_args/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_args/test.cpp
@@ -215,6 +215,8 @@ static_assert(is_same_v<_Format_arg_traits<format_context>::_Storage_type<void*>
 
 static_assert(is_same_v<_Format_arg_traits<format_context>::_Storage_type<string>, string_view>);
 static_assert(is_same_v<_Format_arg_traits<format_context>::_Storage_type<const string>, string_view>);
+static_assert(is_same_v<_Format_arg_traits<format_context>::_Storage_type<char*>, const char*>);
+static_assert(is_same_v<_Format_arg_traits<format_context>::_Storage_type<const char*>, const char*>);
 
 template <class Context>
 void test_visit_monostate() {

--- a/tests/std/tests/P0645R10_text_formatting_args/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_args/test.cpp
@@ -7,6 +7,7 @@
 #include <cstdint>
 #include <format>
 #include <memory>
+#include <string>
 #include <string_view>
 #include <type_traits>
 #include <variant>
@@ -211,6 +212,9 @@ void test_format_arg_store() {
 
 static_assert(sizeof(_Format_arg_index) == sizeof(size_t));
 static_assert(is_same_v<_Format_arg_traits<format_context>::_Storage_type<void*>, const void*>);
+
+static_assert(is_same_v<_Format_arg_traits<format_context>::_Storage_type<string>, string_view>);
+static_assert(is_same_v<_Format_arg_traits<format_context>::_Storage_type<const string>, string_view>);
 
 template <class Context>
 void test_visit_monostate() {

--- a/tests/std/tests/P0645R10_text_formatting_args/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_args/test.cpp
@@ -218,6 +218,12 @@ static_assert(is_same_v<_Format_arg_traits<format_context>::_Storage_type<const 
 static_assert(is_same_v<_Format_arg_traits<format_context>::_Storage_type<char*>, const char*>);
 static_assert(is_same_v<_Format_arg_traits<format_context>::_Storage_type<const char*>, const char*>);
 
+// we rely on the _Storage_type<long> to be int in:
+// explicit basic_format_arg(const long _Val) noexcept
+//     : _Active_state(_Basic_format_arg_type::_Int_type), _Int_state(_Val) {}
+static_assert(is_same_v<_Format_arg_traits<format_context>::_Storage_type<long>, int>);
+static_assert(is_same_v<_Format_arg_traits<format_context>::_Storage_type<unsigned long>, unsigned int>);
+
 template <class Context>
 void test_visit_monostate() {
     assert(visit_format_arg(visitor<Context>, basic_format_arg<Context>()) == Arg_type::none);

--- a/tests/std/tests/P0645R10_text_formatting_custom_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_custom_formatting/test.cpp
@@ -172,8 +172,10 @@ void test_format_family_overloads() {
 template <class charT>
 void test_custom_formattable_type() {
     test_numeric_custom_formattable_type<int, charT>();
+    test_numeric_custom_formattable_type<long, charT>();
     test_numeric_custom_formattable_type<long long, charT>();
     test_numeric_custom_formattable_type<unsigned int, charT>();
+    test_numeric_custom_formattable_type<unsigned long, charT>();
     test_numeric_custom_formattable_type<unsigned long long, charT>();
     test_numeric_custom_formattable_type<short, charT>();
 #ifdef _NATIVE_WCHAR_T_DEFINED
@@ -181,13 +183,16 @@ void test_custom_formattable_type() {
 #endif
     test_numeric_custom_formattable_type<float, charT>();
     test_numeric_custom_formattable_type<double, charT>();
+    test_numeric_custom_formattable_type<long double, charT>();
 }
 
 template <class charT>
 void test_mixed_custom_formattable_type() {
     test_numeric_mixed_args_custom_formattable_type<int, charT>();
+    test_numeric_mixed_args_custom_formattable_type<long, charT>();
     test_numeric_mixed_args_custom_formattable_type<long long, charT>();
     test_numeric_mixed_args_custom_formattable_type<unsigned int, charT>();
+    test_numeric_mixed_args_custom_formattable_type<unsigned long, charT>();
     test_numeric_mixed_args_custom_formattable_type<unsigned long long, charT>();
     test_numeric_mixed_args_custom_formattable_type<short, charT>();
 #ifdef _NATIVE_WCHAR_T_DEFINED
@@ -195,6 +200,7 @@ void test_mixed_custom_formattable_type() {
 #endif
     test_numeric_mixed_args_custom_formattable_type<float, charT>();
     test_numeric_mixed_args_custom_formattable_type<double, charT>();
+    test_numeric_mixed_args_custom_formattable_type<long double, charT>();
 }
 
 int main() {

--- a/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
@@ -1470,6 +1470,27 @@ void test() {
     test_localized_char<wchar_t, wchar_t>();
 }
 
+template <class T>
+struct Box {
+    T value;
+};
+
+template <class T, class CharT>
+struct std::formatter<Box<T>, CharT> : std::formatter<T, CharT> {
+    template <class FormatContext>
+    auto format(Box<T> t, FormatContext& fc) const {
+        return formatter<T, CharT>::format(t.value, fc);
+    }
+};
+
+// Also test GH-2765 "<format>: Cannot format a long value with formatter"
+void test_gh_2765() {
+    Box<long> v = {42};
+    assert(format("{:#x}", v) == "0x2a"s);
+}
+
 int main() {
     test();
+
+    test_gh_2765();
 }

--- a/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
@@ -1485,7 +1485,7 @@ struct std::formatter<Box<T>, CharT> : std::formatter<T, CharT> {
 
 // Also test GH-2765 "<format>: Cannot format a long value with formatter"
 void test_gh_2765() {
-    Box<long> v = {42};
+    Box<long> v = {42L};
     assert(format("{:#x}", v) == "0x2a"s);
 }
 

--- a/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
@@ -1392,6 +1392,26 @@ void test_localized_char() {
     assert(format(STR("{:Lc}"), T('c')) == STR("c"));
 }
 
+template <class T>
+struct Box {
+    T value;
+};
+
+template <class T, class charT>
+struct std::formatter<Box<T>, charT> : std::formatter<T, charT> {
+    template <class FormatContext>
+    auto format(Box<T> t, FormatContext& fc) const {
+        return formatter<T, charT>::format(t.value, fc);
+    }
+};
+
+// Also test GH-2765 "<format>: Cannot format a long value with formatter"
+template <class charT>
+void test_gh_2765() {
+    Box<long> v = {42L};
+    assert(format(STR("{:#x}"), v) == STR("0x2a"));
+}
+
 void test() {
     test_simple_formatting<char>();
     test_simple_formatting<wchar_t>();
@@ -1468,29 +1488,11 @@ void test() {
     test_localized_char<char, char>();
     test_localized_char<wchar_t, char>();
     test_localized_char<wchar_t, wchar_t>();
-}
 
-template <class T>
-struct Box {
-    T value;
-};
-
-template <class T, class CharT>
-struct std::formatter<Box<T>, CharT> : std::formatter<T, CharT> {
-    template <class FormatContext>
-    auto format(Box<T> t, FormatContext& fc) const {
-        return formatter<T, CharT>::format(t.value, fc);
-    }
-};
-
-// Also test GH-2765 "<format>: Cannot format a long value with formatter"
-void test_gh_2765() {
-    Box<long> v = {42L};
-    assert(format("{:#x}", v) == "0x2a"s);
+    test_gh_2765<char>();
+    test_gh_2765<wchar_t>();
 }
 
 int main() {
     test();
-
-    test_gh_2765();
 }

--- a/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
@@ -1392,26 +1392,6 @@ void test_localized_char() {
     assert(format(STR("{:Lc}"), T('c')) == STR("c"));
 }
 
-template <class T>
-struct Box {
-    T value;
-};
-
-template <class T, class charT>
-struct std::formatter<Box<T>, charT> : std::formatter<T, charT> {
-    template <class FormatContext>
-    auto format(Box<T> t, FormatContext& fc) const {
-        return formatter<T, charT>::format(t.value, fc);
-    }
-};
-
-// Also test GH-2765 "<format>: Cannot format a long value with formatter"
-template <class charT>
-void test_gh_2765() {
-    Box<long> v = {42L};
-    assert(format(STR("{:#x}"), v) == STR("0x2a"));
-}
-
 void test() {
     test_simple_formatting<char>();
     test_simple_formatting<wchar_t>();
@@ -1488,9 +1468,6 @@ void test() {
     test_localized_char<char, char>();
     test_localized_char<wchar_t, char>();
     test_localized_char<wchar_t, wchar_t>();
-
-    test_gh_2765<char>();
-    test_gh_2765<wchar_t>();
 }
 
 int main() {


### PR DESCRIPTION
Fixes #2765

Although @cpplearner wrote everything in the issue, I was able to write  
```c++
typename _Format_arg_traits<_FormatContext>::template _Storage_type<_Ty>
``` 
correctly only the third time :)