### PR TITLE
Atomic wait: zero-initialize wait list head

### DIFF
--- a/stl/src/atomic_wait.cpp
+++ b/stl/src/atomic_wait.cpp
@@ -64,7 +64,9 @@ namespace {
     struct alignas(_STD hardware_destructive_interference_size) _Wait_table_entry {
         SRWLOCK _Lock = SRWLOCK_INIT;
         // Initialize to all zeros, self-link lazily to optimize for space.
-        // Whole zero _Wait_table_entry avoids the need to be stored in the binary and the need to relocate.
+        // Since _Wait_table_entry is initialized to all zero bytes,
+        // _Atomic_wait_table_entry::wait_table will also be all zero bytes.
+        // It can thus can be stored in the .bss section, and not in the actual binary.
         _Wait_context _Wait_list_head = {nullptr, nullptr, nullptr, CONDITION_VARIABLE_INIT};
 
         constexpr _Wait_table_entry() noexcept = default;

--- a/stl/src/atomic_wait.cpp
+++ b/stl/src/atomic_wait.cpp
@@ -266,6 +266,7 @@ void __stdcall __std_atomic_notify_one_indirect(const void* const _Storage) noex
     if (_Context == nullptr) {
         return;
     }
+
     for (; _Context != &_Entry._Wait_list_head; _Context = _Context->_Next) {
         if (_Context->_Storage == _Storage) {
             // Can't move wake outside SRWLOCKed section: SRWLOCK also protects the _Context itself
@@ -282,6 +283,7 @@ void __stdcall __std_atomic_notify_all_indirect(const void* const _Storage) noex
     if (_Context == nullptr) {
         return;
     }
+
     for (; _Context != &_Entry._Wait_list_head; _Context = _Context->_Next) {
         if (_Context->_Storage == _Storage) {
             // Can't move wake outside SRWLOCKed section: SRWLOCK also protects the _Context itself
@@ -299,6 +301,7 @@ int __stdcall __std_atomic_wait_indirect(const void* _Storage, void* _Comparand,
         _Entry._Wait_list_head._Next = &_Entry._Wait_list_head;
         _Entry._Wait_list_head._Prev = &_Entry._Wait_list_head;
     }
+
     _Guarded_wait_context _Context{_Storage, &_Entry._Wait_list_head};
     for (;;) {
         if (!_Are_equal(_Storage, _Comparand, _Size, _Param)) { // note: under lock to prevent lost wakes

--- a/stl/src/atomic_wait.cpp
+++ b/stl/src/atomic_wait.cpp
@@ -63,7 +63,7 @@ namespace {
 #pragma warning(disable : 4324) // structure was padded due to alignment specifier
     struct alignas(_STD hardware_destructive_interference_size) _Wait_table_entry {
         SRWLOCK _Lock                 = SRWLOCK_INIT;
-        _Wait_context _Wait_list_head = {nullptr, &_Wait_list_head, &_Wait_list_head, CONDITION_VARIABLE_INIT};
+        _Wait_context _Wait_list_head = {nullptr, nullptr, nullptr, CONDITION_VARIABLE_INIT};
 
         constexpr _Wait_table_entry() noexcept = default;
     };
@@ -263,6 +263,9 @@ void __stdcall __std_atomic_notify_one_indirect(const void* const _Storage) noex
     auto& _Entry = _Atomic_wait_table_entry(_Storage);
     _SrwLock_guard _Guard(_Entry._Lock);
     _Wait_context* _Context = _Entry._Wait_list_head._Next;
+    if (_Context == nullptr) {
+        return;
+    }
     for (; _Context != &_Entry._Wait_list_head; _Context = _Context->_Next) {
         if (_Context->_Storage == _Storage) {
             // Can't move wake outside SRWLOCKed section: SRWLOCK also protects the _Context itself
@@ -276,6 +279,9 @@ void __stdcall __std_atomic_notify_all_indirect(const void* const _Storage) noex
     auto& _Entry = _Atomic_wait_table_entry(_Storage);
     _SrwLock_guard _Guard(_Entry._Lock);
     _Wait_context* _Context = _Entry._Wait_list_head._Next;
+    if (_Context == nullptr) {
+        return;
+    }
     for (; _Context != &_Entry._Wait_list_head; _Context = _Context->_Next) {
         if (_Context->_Storage == _Storage) {
             // Can't move wake outside SRWLOCKed section: SRWLOCK also protects the _Context itself
@@ -289,6 +295,10 @@ int __stdcall __std_atomic_wait_indirect(const void* _Storage, void* _Comparand,
     auto& _Entry = _Atomic_wait_table_entry(_Storage);
 
     _SrwLock_guard _Guard(_Entry._Lock);
+    if (_Entry._Wait_list_head._Next == nullptr) {
+        _Entry._Wait_list_head._Next = &_Entry._Wait_list_head;
+        _Entry._Wait_list_head._Prev = &_Entry._Wait_list_head;
+    }
     _Guarded_wait_context _Context{_Storage, &_Entry._Wait_list_head};
     for (;;) {
         if (!_Are_equal(_Storage, _Comparand, _Size, _Param)) { // note: under lock to prevent lost wakes


### PR DESCRIPTION
Minimum scope of #2755 - based on https://github.com/microsoft/STL/issues/2755#issuecomment-1145467753 suggestion.

Reduces size of x64 `msvcp140_atomic_wait_oss.dll` from 44.5 KB to 28.0 KB - did not investigate exactly why, but expect reduction of relocation table and initialized data segment.

Full scope of #2755 as initially suggested can be implemented, but there are some complexities:
 * Fallback path
 * Safe de-initialization

Using lazy initialization for list head
 * Single linked list does not look like a good idea, as there's no efficient removal of the current waiter from list
 * Double linked list that is not head is feasible, but it is more complex that the circular one, and, as a consequence, will take more ops at runtime