### PR TITLE
fix hash_* visualizer issue

### DIFF
--- a/stl/debugger/STL.natvis
+++ b/stl/debugger/STL.natvis
@@ -1444,14 +1444,25 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
   </Type>
 
   <!-- VC 2015 - must have higher priority -->
+  <Type Name="stdext::hash_map&lt;*&gt;" Priority="Medium">
+      <AlternativeType Name="stdext::hash_multimap&lt;*&gt;" />
+      <AlternativeType Name="stdext::hash_set&lt;*&gt;" />
+      <AlternativeType Name="stdext::hash_multiset&lt;*&gt;" />
+      <DisplayString>{_List}</DisplayString>
+      <Expand>
+          <Item Name="[bucket_count]" IncludeView="detailed">_Maxidx</Item>
+          <Item Name="[load_factor]" IncludeView="detailed">((float)_List._Mypair._Myval2._Mysize) / ((float)_Maxidx)</Item>
+          <Item Name="[max_load_factor]" IncludeView="detailed">_Traitsobj._Max_buckets</Item>
+          <Item Name="[allocator]" ExcludeView="simple">_List._Mypair</Item>
+          <ExpandedItem>_List,view(simple)</ExpandedItem>
+      </Expand>
+  </Type>
+
+  <!-- VC 2015 - must have higher priority -->
   <Type Name="std::unordered_map&lt;*&gt;" Priority="Medium">
       <AlternativeType Name="std::unordered_multimap&lt;*&gt;" />
       <AlternativeType Name="std::unordered_set&lt;*&gt;" />
       <AlternativeType Name="std::unordered_multiset&lt;*&gt;" />
-      <AlternativeType Name="stdext::hash_map&lt;*&gt;" />
-      <AlternativeType Name="stdext::hash_multimap&lt;*&gt;" />
-      <AlternativeType Name="stdext::hash_set&lt;*&gt;" />
-      <AlternativeType Name="stdext::hash_multiset&lt;*&gt;" />
       <DisplayString>{_List}</DisplayString>
       <Expand>
           <Item Name="[bucket_count]" IncludeView="detailed">_Maxidx</Item>


### PR DESCRIPTION
Fixes #2783

test:
```c++
#define _SILENCE_STDEXT_HASH_DEPRECATION_WARNINGS
#include <hash_set>
#include <hash_map>
using namespace std;
int main() {
	stdext::hash_set<int> hs = { 1,2,3 };
	stdext::hash_multiset<int> hms = { 1,1,2,3 };
	stdext::hash_map<int, char> hm = { {1, 'a'}, {2,'b'} };
	stdext::hash_multimap<int, char> hmm = { {1, 'a'}, {1, 'c'}, {2,'b'} };
}
```
![изображение](https://user-images.githubusercontent.com/4289847/173226911-3a34d9c5-413a-4d07-883b-02f096dbf10b.png)

_Traitsobj class: https://github.com/microsoft/STL/blob/e178ea2c5219b00ae8e0d1d5fd0c0ad7186cff7a/stl/inc/hash_map#L41-L110
_Tr class: https://github.com/microsoft/STL/blob/37b51205fbac24c1cc839bd3aa793c341229acf4/stl/inc/xhash#L59-L87

So we don't visualize `[hash_function]` and `[key_eq]`, we could visualize `[comp]` but it doesn't seem useful...