### PR TITLE
Don't deallocate nullptr in _Hash_vec::_Tidy

### DIFF
--- a/stl/inc/xhash
+++ b/stl/inc/xhash
@@ -300,11 +300,13 @@ struct _Hash_vec {
     }
 
     void _Tidy() noexcept {
-        _Destroy_range(_Mypair._Myval2._Myfirst, _Mypair._Myval2._Mylast);
-        _Mypair._Get_first().deallocate(_Mypair._Myval2._Myfirst, capacity());
-        _Mypair._Myval2._Myfirst = nullptr;
-        _Mypair._Myval2._Mylast  = nullptr;
-        _Mypair._Myval2._Myend   = nullptr;
+        if (_Mypair._Myval2._Myfirst != nullptr) {
+            _Destroy_range(_Mypair._Myval2._Myfirst, _Mypair._Myval2._Mylast);
+            _Mypair._Get_first().deallocate(_Mypair._Myval2._Myfirst, capacity());
+            _Mypair._Myval2._Myfirst = nullptr;
+            _Mypair._Myval2._Mylast  = nullptr;
+            _Mypair._Myval2._Myend   = nullptr;
+        }
     }
 
     ~_Hash_vec() {

--- a/tests/std/test.lst
+++ b/tests/std/test.lst
@@ -206,6 +206,7 @@ tests\GH_002655_alternate_name_broke_linker
 tests\GH_002711_Zc_alignedNew-
 tests\GH_002760_syncstream_memory_leak
 tests\GH_002769_handle_deque_block_pointers
+tests\GH_002789_Hash_vec_Tidy
 tests\LWG2597_complex_branch_cut
 tests\LWG3018_shared_ptr_function
 tests\LWG3121_constrained_tuple_forwarding_ctor

--- a/tests/std/tests/GH_002789_Hash_vec_Tidy/env.lst
+++ b/tests/std/tests/GH_002789_Hash_vec_Tidy/env.lst
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+RUNALL_INCLUDE ..\usual_matrix.lst

--- a/tests/std/tests/GH_002789_Hash_vec_Tidy/test.cpp
+++ b/tests/std/tests/GH_002789_Hash_vec_Tidy/test.cpp
@@ -5,6 +5,7 @@
 #include <cstddef>
 #include <functional>
 #include <memory>
+#include <new>
 #include <unordered_set>
 
 using namespace std;
@@ -61,8 +62,8 @@ struct countdown_alloc {
 
 int main() {
     try {
-        (void) unordered_set<int, hash<int>, equal_to<int>, countdown_alloc<int>>();
+        (void) unordered_set<int, hash<int>, equal_to<int>, countdown_alloc<int>>{};
         assert(false);
-    } catch (const std::bad_alloc&) {
+    } catch (const bad_alloc&) {
     }
 }

--- a/tests/std/tests/GH_002789_Hash_vec_Tidy/test.cpp
+++ b/tests/std/tests/GH_002789_Hash_vec_Tidy/test.cpp
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <cassert>
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <unordered_set>
+
+using namespace std;
+
+// Defend against regression of GH-2789, which bug resulted in deallocating
+// a nullptr when unordered_meow creation fails due to OOM on the first call
+// to `_Hash_vec::_Assign_grow`. (This test relies on counting the number of
+// allocations to inject a failure in the right spot, so it's inherently
+// fragile.)
+
+#if _ITERATOR_DEBUG_LEVEL != 0
+static size_t alloc_count = 3;
+#else
+static size_t alloc_count = 1;
+#endif
+
+template <class T>
+struct countdown_alloc {
+    using value_type = T;
+
+    countdown_alloc() = default;
+    template <class U>
+    countdown_alloc(const countdown_alloc<U>&) {}
+
+    T* allocate(const size_t n) {
+        if (n == 0) { // allocate never returns nullptr...
+            return allocator<T>{}.allocate(1);
+        } else if (alloc_count > 0) {
+            --alloc_count;
+            return allocator<T>{}.allocate(n);
+        }
+
+        throw bad_alloc{};
+    }
+
+    void deallocate(T* const p, const size_t n) {
+        assert(p != nullptr); // ... so deallocate need not tolerate nullptr.
+        if (n == 0) {
+            allocator<T>{}.deallocate(p, 1);
+        } else {
+            allocator<T>{}.deallocate(p, n);
+        }
+    }
+
+    template <class B>
+    friend bool operator==(const countdown_alloc&, const countdown_alloc<B>&) noexcept {
+        return true;
+    }
+    template <class B>
+    friend bool operator!=(const countdown_alloc&, const countdown_alloc<B>&) noexcept {
+        return false;
+    }
+};
+
+int main() {
+    try {
+        (void) unordered_set<int, hash<int>, equal_to<int>, countdown_alloc<int>>();
+        assert(false);
+    } catch (const std::bad_alloc&) {
+    }
+}


### PR DESCRIPTION
... since we probably didn't get `nullptr` from an allocator, and user-defined allocators aren't required to tolerate dellocating `nullptr`.

Fixes #2789.
