### PR TITLE
Toolset update: VS 2022 17.3 Preview 2, CUDA 11.6.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 project(msvc_standard_libraries LANGUAGES CXX)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,7 @@ add_compile_definitions(
     _CRT_DECLARE_NONSTDC_NAMES=1 _WIN32_WINNT=0x0A00 NTDDI_VERSION=NTDDI_WIN10_CO)
 
 add_compile_options(/WX /Gy
-    "$<$<COMPILE_LANGUAGE:CXX>:/diagnostics:caret;/W4;/w14265;/w15038;/d1FastFail;/guard:cf;/Z7;/Zp8;/std:c++latest;/permissive-;/Zc:threadSafeInit-;/Zl>"
+    "$<$<COMPILE_LANGUAGE:CXX>:/diagnostics:caret;/W4;/w14265;/w15038;/fastfail;/guard:cf;/Z7;/Zp8;/std:c++latest;/permissive-;/Zc:threadSafeInit-;/Zl>"
     # note that /Zi generates debug info inside the object file, it's the same as /Z7 for msvc
     "$<$<COMPILE_LANGUAGE:ASM_MASM>:/Zi;/W3;/nologo>")
 

--- a/README.md
+++ b/README.md
@@ -140,11 +140,11 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With The Visual Studio IDE
 
-1. Install Visual Studio 2022 17.3 Preview 1 or later.
+1. Install Visual Studio 2022 17.3 Preview 2 or later.
     * Select "Windows 11 SDK (10.0.22000.0)" in the VS Installer.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
-    * Otherwise, install [CMake][] 3.22 or later, and [Ninja][] 1.10.2 or later.
+    * Otherwise, install [CMake][] 3.23 or later, and [Ninja][] 1.10.2 or later.
     * We recommend selecting "Python 3 64-bit" in the VS Installer.
     * Otherwise, make sure [Python][] 3.9 or later is available to CMake.
 2. Open Visual Studio, and choose the "Clone or check out code" option. Enter the URL of this repository,
@@ -156,11 +156,11 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With A Native Tools Command Prompt
 
-1. Install Visual Studio 2022 17.3 Preview 1 or later.
+1. Install Visual Studio 2022 17.3 Preview 2 or later.
     * Select "Windows 11 SDK (10.0.22000.0)" in the VS Installer.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
-    * Otherwise, install [CMake][] 3.22 or later, and [Ninja][] 1.10.2 or later.
+    * Otherwise, install [CMake][] 3.23 or later, and [Ninja][] 1.10.2 or later.
     * We recommend selecting "Python 3 64-bit" in the VS Installer.
     * Otherwise, make sure [Python][] 3.9 or later is available to CMake.
 2. Open a command prompt.

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -143,13 +143,7 @@ $Sku = 'Enterprise'
 $VisualStudioBootstrapperUrl = 'https://aka.ms/vs/17/pre/vs_enterprise.exe'
 $PythonUrl = 'https://www.python.org/ftp/python/3.10.5/python-3.10.5-amd64.exe'
 
-$CudaUrl = `
-  'https://developer.download.nvidia.com/compute/cuda/10.1/Prod/local_installers/cuda_10.1.243_426.00_win10.exe'
-$CudaFeatures = 'nvcc_10.1 cuobjdump_10.1 nvprune_10.1 cupti_10.1 gpu_library_advisor_10.1 memcheck_10.1 ' + `
-  'nvdisasm_10.1 nvprof_10.1 visual_profiler_10.1 visual_studio_integration_10.1 cublas_10.1 cublas_dev_10.1 ' + `
-  'cudart_10.1 cufft_10.1 cufft_dev_10.1 curand_10.1 curand_dev_10.1 cusolver_10.1 cusolver_dev_10.1 cusparse_10.1 ' + `
-  'cusparse_dev_10.1 nvgraph_10.1 nvgraph_dev_10.1 npp_10.1 npp_dev_10.1 nvrtc_10.1 nvrtc_dev_10.1 nvml_dev_10.1 ' + `
-  'occupancy_calculator_10.1 fortran_examples_10.1'
+$CudaUrl = 'https://developer.download.nvidia.com/compute/cuda/11.6.0/local_installers/cuda_11.6.0_511.23_windows.exe'
 
 $ErrorActionPreference = 'Stop'
 $ProgressPreference = 'SilentlyContinue'
@@ -272,19 +266,14 @@ Function InstallPython {
 Installs NVIDIA's CUDA Toolkit.
 
 .DESCRIPTION
-InstallCuda installs the CUDA Toolkit with the features specified as a
-space-separated list of strings in $Features.
+InstallCuda installs the CUDA Toolkit.
 
 .PARAMETER Url
 The URL of the CUDA installer.
-
-.PARAMETER Features
-A space-separated list of features to install.
 #>
 Function InstallCuda {
   Param(
-    [String]$Url,
-    [String]$Features
+    [String]$Url
   )
 
   try {
@@ -292,7 +281,7 @@ Function InstallCuda {
     [string]$installerPath = Get-TempFilePath -Extension 'exe'
     curl.exe -L -o $installerPath -s -S $Url
     Write-Host 'Installing CUDA...'
-    $proc = Start-Process -FilePath $installerPath -ArgumentList @('-s ' + $Features) -Wait -PassThru
+    $proc = Start-Process -FilePath $installerPath -ArgumentList @('-s') -Wait -PassThru
     $exitCode = $proc.ExitCode
     if ($exitCode -eq 0) {
       Write-Host 'Installation successful!'
@@ -347,7 +336,7 @@ Add-MpPreference -ExclusionProcess python.exe
 
 InstallPython $PythonUrl
 InstallVisualStudio -Workloads $Workloads -BootstrapperUrl $VisualStudioBootstrapperUrl
-InstallCuda -Url $CudaUrl -Features $CudaFeatures
+InstallCuda -Url $CudaUrl
 
 Write-Host 'Updating PATH...'
 

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -141,7 +141,7 @@ $Workloads = @(
 $ReleaseInPath = 'Preview'
 $Sku = 'Enterprise'
 $VisualStudioBootstrapperUrl = 'https://aka.ms/vs/17/pre/vs_enterprise.exe'
-$PythonUrl = 'https://www.python.org/ftp/python/3.10.4/python-3.10.4-amd64.exe'
+$PythonUrl = 'https://www.python.org/ftp/python/3.10.5/python-3.10.5-amd64.exe'
 
 $CudaUrl = `
   'https://developer.download.nvidia.com/compute/cuda/10.1/Prod/local_installers/cuda_10.1.243_426.00_win10.exe'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ variables:
   tmpDir: 'D:\Temp'
   buildOutputLocation: 'D:\build'
 
-pool: 'StlBuild-2022-06-01-T1839'
+pool: 'StlBuild-2022-06-14-T1744'
 
 stages:
   - stage: Code_Format

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -3351,16 +3351,8 @@ template <_Format_supported_charT _CharT, class _Traits>
 struct formatter<basic_string_view<_CharT, _Traits>, _CharT>
     : _Formatter_base<basic_string_view<_CharT, _Traits>, _CharT, _Basic_format_arg_type::_String_type> {};
 
-// TRANSITION, VSO-1444086 (remove _STL_DECLSPEC_NOINITALL)
-#if defined(__clang__) || defined(__CUDACC__) || defined(__INTEL_COMPILER) || defined(__EDG__)
-#define _STL_DECLSPEC_NOINITALL
-#else // ^^^ not MSVC / MSVC vvv
-#define _STL_DECLSPEC_NOINITALL \
-    _Pragma("warning(push)") _Pragma("warning(disable : 4845)") __declspec(no_init_all) _Pragma("warning(pop)")
-#endif // ^^^ MSVC ^^^
-
 template <class _CharT, class... _Args>
-struct _STL_DECLSPEC_NOINITALL _Basic_format_string {
+struct _Basic_format_string {
     basic_string_view<_CharT> _Str;
 
     template <class _Ty>
@@ -3371,8 +3363,6 @@ struct _STL_DECLSPEC_NOINITALL _Basic_format_string {
         }
     }
 };
-
-#undef _STL_DECLSPEC_NOINITALL
 
 template <class... _Args>
 using _Fmt_string = _Basic_format_string<char, type_identity_t<_Args>...>;

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -2048,13 +2048,12 @@ private:
         _Iterator_base12** _Pnext = &_Mypair._Myval2._Myproxy->_Myfirstiter;
         while (*_Pnext) {
             const auto _Pnextptr = static_cast<const_iterator&>(**_Pnext)._Ptr;
+            const auto _Temp     = *_Pnext;
             if (_Pnextptr < _First || _Last < _Pnextptr) { // skip the iterator
-                const auto _Temp = *_Pnext; // TRANSITION, VSO-1269037
-                _Pnext           = &_Temp->_Mynextiter;
+                _Pnext = &_Temp->_Mynextiter;
             } else { // orphan the iterator
-                const auto _Temp = *_Pnext; // TRANSITION, VSO-1269037
-                _Temp->_Myproxy  = nullptr;
-                *_Pnext          = _Temp->_Mynextiter;
+                _Temp->_Myproxy = nullptr;
+                *_Pnext         = _Temp->_Mynextiter;
             }
         }
     }
@@ -3280,7 +3279,7 @@ public:
         _Iterator_base12** _Pnext = &this->_Myproxy->_Myfirstiter;
         while (*_Pnext) { // test offset from beginning of vector
             const auto& _Pnextiter = static_cast<const_iterator&>(**_Pnext);
-            const auto _Temp       = *_Pnext; // TRANSITION, VSO-1269037
+            const auto _Temp       = *_Pnext;
             if (!_Pnextiter._Myptr) { // orphan the iterator
                 _Temp->_Myproxy = nullptr;
                 *_Pnext         = _Temp->_Mynextiter;

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -1230,7 +1230,7 @@ _CONSTEXPR20 void _Container_base12::_Orphan_all_unlocked_v3() noexcept {
     }
 
     // proxy allocated, drain it
-    for (auto& _Pnext = _Myproxy->_Myfirstiter; _Pnext; _Pnext = _Pnext->_Mynextiter) {
+    for (auto _Pnext = _STD exchange(_Myproxy->_Myfirstiter, nullptr); _Pnext; _Pnext = _Pnext->_Mynextiter) {
         _Pnext->_Myproxy = nullptr;
     }
 }

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -1233,7 +1233,6 @@ _CONSTEXPR20 void _Container_base12::_Orphan_all_unlocked_v3() noexcept {
     for (auto& _Pnext = _Myproxy->_Myfirstiter; _Pnext; _Pnext = _Pnext->_Mynextiter) {
         _Pnext->_Myproxy = nullptr;
     }
-    _Myproxy->_Myfirstiter = nullptr;
 }
 
 _CONSTEXPR20 void _Container_base12::_Orphan_all() noexcept {

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -1209,8 +1209,7 @@ private:
         // adopted, remove self from list
         _Iterator_base12** _Pnext = &_Myproxy->_Myfirstiter;
         while (*_Pnext && *_Pnext != this) {
-            const auto _Temp = *_Pnext; // TRANSITION, VSO-1269037
-            _Pnext           = &_Temp->_Mynextiter;
+            _Pnext = &(*_Pnext)->_Mynextiter;
         }
 
         _STL_VERIFY(*_Pnext, "ITERATOR LIST CORRUPTED!");
@@ -1231,7 +1230,7 @@ _CONSTEXPR20 void _Container_base12::_Orphan_all_unlocked_v3() noexcept {
     }
 
     // proxy allocated, drain it
-    for (auto& _Pnext = _Myproxy->_Myfirstiter; _Pnext; _Pnext = _Pnext->_Mynextiter) { // TRANSITION, VSO-1269037
+    for (auto& _Pnext = _Myproxy->_Myfirstiter; _Pnext; _Pnext = _Pnext->_Mynextiter) {
         _Pnext->_Myproxy = nullptr;
     }
     _Myproxy->_Myfirstiter = nullptr;

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -1614,9 +1614,5 @@ compiler option, or define _ALLOW_RTCc_IN_STL to acknowledge that you have recei
 #define _STL_INTERNAL_STATIC_ASSERT(...)
 #endif // _ENABLE_STL_INTERNAL_CHECK
 
-#ifndef _MSVC_CONSTEXPR // TRANSITION, VS2022v17.3p2
-#define _MSVC_CONSTEXPR
-#endif
-
 #endif // _STL_COMPILER_PREPROCESSOR
 #endif // _YVALS_CORE_H_

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -622,10 +622,8 @@
 
 #ifndef _ALLOW_COMPILER_AND_STL_VERSION_MISMATCH
 #if defined(__CUDACC__) && defined(__CUDACC_VER_MAJOR__)
-#if __CUDACC_VER_MAJOR__ < 10      \
-    || (__CUDACC_VER_MAJOR__ == 10 \
-        && (__CUDACC_VER_MINOR__ < 1 || (__CUDACC_VER_MINOR__ == 1 && __CUDACC_VER_BUILD__ < 243)))
-#error STL1002: Unexpected compiler version, expected CUDA 10.1 Update 2 or newer.
+#if __CUDACC_VER_MAJOR__ < 11 || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ < 6)
+#error STL1002: Unexpected compiler version, expected CUDA 11.6 or newer.
 #endif // ^^^ old CUDA ^^^
 #elif defined(__EDG__)
 // not attempting to detect __EDG_VERSION__ being less than expected

--- a/tests/std/include/timezone_data.hpp
+++ b/tests/std/include/timezone_data.hpp
@@ -157,21 +157,7 @@ namespace LA {
 template <class TestFunction>
 void run_tz_test(TestFunction test_function) {
     try {
-#ifdef _MSVC_INTERNAL_TESTING
-        try {
-            (void) get_tzdb();
-        } catch (const system_error& ex) {
-            if (ex.code() == error_code{126 /* ERROR_MOD_NOT_FOUND */, system_category()}) {
-                // Skip testing when we can't load icu.dll on an internal test machine running an older OS.
-                exit(EXIT_SUCCESS);
-            }
-
-            throw; // Report any other errors.
-        }
-#endif // _MSVC_INTERNAL_TESTING
-
         test_function();
-
     } catch (const system_error& ex) {
         cerr << "Test threw system_error: " << ex.what() << "\n";
         cerr << "With error_code: " << ex.code() << "\n";

--- a/tests/std/tests/GH_000639_nvcc_include_all/env.lst
+++ b/tests/std/tests/GH_000639_nvcc_include_all/env.lst
@@ -1,8 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// TRANSITION, CUDA 10.1 Update 2 rejected VS 2022 as unsupported, so we need --allow-unsupported-compiler
-PM_COMPILER="nvcc" PM_CL="--x cu -Xcompiler -Od,-EHsc,-nologo,-W4,-WX,-openmp --allow-unsupported-compiler"
+PM_COMPILER="nvcc" PM_CL="--x cu -Xcompiler -Od,-EHsc,-nologo,-W4,-WX,-openmp"
 RUNALL_CROSSLIST
 PM_CL="-Xcompiler -MT"
 PM_CL="--debug -Xcompiler -MTd"

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
@@ -1101,10 +1101,8 @@ void test() {
 
 #if !defined(_DLL) || _ITERATOR_DEBUG_LEVEL == DEFAULT_IDL_SETTING
     test_locale<wchar_t>();
-#ifndef _MSVC_INTERNAL_TESTING // TRANSITION, the Windows version on Contest VMs doesn't always understand ".UTF-8"
     assert(setlocale(LC_ALL, ".UTF-8") != nullptr);
     test_locale<char>();
-#endif // _MSVC_INTERNAL_TESTING
 #endif // !defined(_DLL) || _ITERATOR_DEBUG_LEVEL == DEFAULT_IDL_SETTING
 }
 

--- a/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
@@ -1336,14 +1336,12 @@ void libfmt_formatter_test_runtime_precision() {
 
 template <class charT>
 void test_locale_specific_formatting_without_locale() {
-#ifndef _MSVC_INTERNAL_TESTING // TRANSITION, the Windows version on Contest VMs doesn't always understand ".UTF-8"
 #if !defined(_DLL) || _ITERATOR_DEBUG_LEVEL == DEFAULT_IDL_SETTING
     locale loc("en-US.UTF-8");
     locale::global(loc);
     assert(format(STR("{:L}"), 12345) == STR("12,345"));
     locale::global(locale::classic());
 #endif // !defined(_DLL) || _ITERATOR_DEBUG_LEVEL == DEFAULT_IDL_SETTING
-#endif // _MSVC_INTERNAL_TESTING
 }
 
 template <class charT>

--- a/tests/std/tests/P0645R10_text_formatting_utf8/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_utf8/test.cpp
@@ -156,8 +156,6 @@ int main() {
     assert(setlocale(LC_ALL, ".932") != nullptr);
     run_tests();
 
-#ifndef _MSVC_INTERNAL_TESTING // TRANSITION, the Windows version on Contest VMs doesn't always understand ".UTF-8"
     assert(setlocale(LC_ALL, ".UTF-8") != nullptr);
     run_tests();
-#endif
 }

--- a/tests/std/tests/P1502R1_standard_library_header_units/test.cpp
+++ b/tests/std/tests/P1502R1_standard_library_header_units/test.cpp
@@ -343,7 +343,6 @@ __declspec(dllexport) // for <stacktrace> test export main to have it named even
         static_assert(b(3) == 33);
     }
 
-#if defined(_MSVC_INTERNAL_TESTING) || defined(TEST_TOPO_SORT) // TRANSITION, VSO-1496084 fixed in 17.3 Preview 2
     {
         puts("Testing <future>.");
         promise<int> p{};
@@ -353,7 +352,6 @@ __declspec(dllexport) // for <stacktrace> test export main to have it named even
         assert(f.wait_for(chrono::seconds{0}) == future_status::ready);
         assert(f.get() == 1729);
     }
-#endif // ^^^ no workaround ^^^
 
     {
         puts("Testing <initializer_list>.");
@@ -799,7 +797,6 @@ __declspec(dllexport) // for <stacktrace> test export main to have it named even
         assert(caught_puppies);
     }
 
-#if defined(_MSVC_INTERNAL_TESTING) || defined(TEST_TOPO_SORT) // TRANSITION, VSO-1496084 fixed in 17.3 Preview 2
     {
         puts("Testing <stop_token>.");
         vector<int> vec;
@@ -835,7 +832,6 @@ __declspec(dllexport) // for <stacktrace> test export main to have it named even
             160, 80, 40, 20, 10, 5, 16, 8, 4, 2, 1, -1000};
         assert(equal(vec.begin(), vec.end(), begin(expected_val), end(expected_val)));
     }
-#endif // ^^^ no workaround ^^^
 
     {
         puts("Testing <streambuf>.");

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
 project(msvc_standard_libraries_tools LANGUAGES CXX)
 
 add_subdirectory(format)

--- a/tools/format/CMakeLists.txt
+++ b/tools/format/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
 project(msvc_standard_libraries_format NONE)
 
 set(did_search OFF)

--- a/tools/validate/CMakeLists.txt
+++ b/tools/validate/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.23)
 project(msvc_standard_libraries_validate LANGUAGES CXX)
 
 add_executable(validate-binary validate.cpp)


### PR DESCRIPTION
This updates the toolset to:

* VS 2022 17.3 Preview 2.
  + Required in the README, but not in `<yvals_core.h>` because the internal build still uses 19.32.
* CMake 3.23.
  + Required in the README and `CMakeLists.txt`.
* Python 3.10.5.
  + We still require Python 3.9 because the VS Installer still has 3.9.7.
* CUDA 11.6.0.
  + `azure-devops/provision-image.ps1` now installs all CUDA features, which is much easier than enumerating almost all of them.
  + Required in `<yvals_core.h>`.
    - CUDA 11.6.0 was the first release that officially supported VS 2022, so this aligns our support.
    - Approved by our boss and double boss, who are awesome! :smile_cat:

Then we can remove workarounds:

* `tests/std/tests/GH_000639_nvcc_include_all/env.lst`
  + Drop `--allow-unsupported-compiler`, now that we're using a CUDA-supported scenario.
* `tests/std/tests/P1502R1_standard_library_header_units/test.cpp`
  + Remove workarounds for VSO-1496084 "Standard Library Header Units: Splitting `<chrono>` emits fatal error C1116: unrecoverable error importing header unit `'<chrono>'`".
* Remove workarounds for VSO-1269037 "Compiler ICE on reference to pointer in `constexpr`".
  + `<vector>` 2051-2056: This is clearer with the workaround as `_Temp` is used repeatedly, but we can extract it.
  + `<vector>` 3282: This is clearer with the workaround as `_Temp` is used repeatedly.
  + `<xmemory>` 1212: Remove the workaround as `_Temp` is used only once.
  + `<xmemory>` 1233-1236: The original code used pointers-to-pointers, which were difficult to read. The workaround was significantly clearer, but still had subtle behavior - it was writing to `auto& _Pnext` repeatedly, ultimately nulling it out (so the separate assignment was redundant). As @CaseyCarter observed, we can avoid the subtlety by using `exchange()` to null out `_Myproxy->_Myfirstiter` immediately, and then the rest of the loop can use a non-reference variable.
* `<format>`
  + Remove workaround for VSO-1444086 "`consteval` + `/presetPadding` error".
* Remove workarounds for internal test machines running older OSes.
  + There is a slight chance that I'll need to drop this (I am informed that the PR/CI system upgrade to "1ES Phase 5" makes this unnecessary, but we may still want/need to retain this for the internal Contest pool).
* `<yvals_core.h>`
  + Remove the `_MSVC_CONSTEXPR` fallback definition. This is related to #2658, where MSVC-PR-391437 added this to VCRuntime.
* `CMakeLists.txt`
  + Change `/d1FastFail` to `/fastfail`. This is documented by `cl /?`, and was added in VS 2019 16.1 by MSVC-PR-162175.

I am planning a followup PR to address #1301 by removing `_HAS_CONDITIONAL_EXPLICIT` now that CUDA 11.6.0 supports it; this should be separate because the change is large and may need to be reverted.