### PR TITLE
Mark constants as `_INLINE_VAR constexpr`.

### DIFF
--- a/stl/inc/functional
+++ b/stl/inc/functional
@@ -722,7 +722,7 @@ private:
     virtual const void* _Get() const noexcept = 0;
 };
 
-constexpr size_t _Space_size = (_Small_object_num_ptrs - 1) * sizeof(void*);
+_INLINE_VAR constexpr size_t _Space_size = (_Small_object_num_ptrs - 1) * sizeof(void*);
 
 template <class _Impl> // determine whether _Impl must be dynamically allocated
 _INLINE_VAR constexpr bool _Is_large = sizeof(_Impl) > _Space_size || alignof(_Impl) > alignof(max_align_t)

--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -1155,16 +1155,16 @@ _NODISCARD bool operator!=(const match_results<_BidIt, _Alloc>& _Left, const mat
 }
 #endif // !_HAS_CXX20
 
-const unsigned int _BRE_MAX_GRP = 9U;
+_INLINE_VAR constexpr unsigned int _BRE_MAX_GRP = 9U;
 
-const unsigned int _Bmp_max   = 256U; // must fit in an unsigned int
-const unsigned int _Bmp_shift = 3U;
-const unsigned int _Bmp_chrs  = 1U << _Bmp_shift; // # of bits to be stored in each char
-const unsigned int _Bmp_mask  = _Bmp_chrs - 1U;
-const unsigned int _Bmp_size  = (_Bmp_max + _Bmp_chrs - 1U) / _Bmp_chrs;
+_INLINE_VAR constexpr unsigned int _Bmp_max   = 256U; // must fit in an unsigned int
+_INLINE_VAR constexpr unsigned int _Bmp_shift = 3U;
+_INLINE_VAR constexpr unsigned int _Bmp_chrs  = 1U << _Bmp_shift; // # of bits to be stored in each char
+_INLINE_VAR constexpr unsigned int _Bmp_mask  = _Bmp_chrs - 1U;
+_INLINE_VAR constexpr unsigned int _Bmp_size  = (_Bmp_max + _Bmp_chrs - 1U) / _Bmp_chrs;
 
-const unsigned int _Buf_incr        = 16U;
-const unsigned int _ARRAY_THRESHOLD = 4U;
+_INLINE_VAR constexpr unsigned int _Buf_incr        = 16U;
+_INLINE_VAR constexpr unsigned int _ARRAY_THRESHOLD = 4U;
 
 enum _Node_flags : int { // flags for nfa nodes with special properties
     _Fl_none    = 0x00,

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -2109,8 +2109,9 @@ vector(_Iter, _Iter, _Alloc = _Alloc()) -> vector<_Iter_value_t<_Iter>, _Alloc>;
 template <class _Alloc>
 class vector<bool, _Alloc>;
 
-using _Vbase         = unsigned int; // word type for vector<bool> representation
-constexpr int _VBITS = 8 * sizeof(_Vbase); // at least CHAR_BITS bits per word
+using _Vbase = unsigned int; // word type for vector<bool> representation
+
+_INLINE_VAR constexpr int _VBITS = 8 * sizeof(_Vbase); // at least CHAR_BITS bits per word
 
 template <class _Ty, class _Alloc>
 _NODISCARD _CONSTEXPR20 bool operator==(const vector<_Ty, _Alloc>& _Left, const vector<_Ty, _Alloc>& _Right) {

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -2324,8 +2324,9 @@ public:
     size_type _Myres  = 0; // current storage reserved for string
 };
 
+// get _Ty's size after being EBCO'd
 template <class _Ty>
-constexpr size_t _Size_after_ebco_v = is_empty_v<_Ty> ? 0 : sizeof(_Ty); // get _Ty's size after being EBCO'd
+_INLINE_VAR constexpr size_t _Size_after_ebco_v = is_empty_v<_Ty> ? 0 : sizeof(_Ty);
 
 struct _String_constructor_concat_tag {
     // tag to select constructors used by basic_string's concatenation operators (operator+)


### PR DESCRIPTION
@cdacamar explained why he's implementing a new compiler warning:

> I have been tightening up c1xx's modules implementation by making the compiler more strict and correct when it comes to assigning out linkage to entities emitted into associated .objs.

This warning will complain about non-`inline` constants in headers. We're *almost* completely consistent about using `inline` in C++17-and-later (or `_INLINE_VAR` in potentially-C++14), but Cameron found our inconsistent occurrences:

```
C:\msvc\binaries\x86chk\inc\vector(2113): warning C5260: the constant variable 'std::_VBITS' has internal linkage in an included header file context, but external linkage in imported header unit context; consider declaring it 'inline' as well if it will be shared across translation units, or 'static' to express intent to use it local to this translation unit
C:\msvc\binaries\x86chk\inc\regex(1166): warning C5260: the constant variable 'std::_Buf_incr' has internal linkage in an included header file context, but external linkage in imported header unit context; consider declaring it 'inline' as well if it will be shared across translation units, or 'static' to express intent to use it local to this translation unit
C:\msvc\binaries\x86chk\inc\functional(725): warning C5260: the constant variable 'std::_Space_size' has internal linkage in an included header file context, but external linkage in imported header unit context; consider declaring it 'inline' as well if it will be shared across translation units, or 'static' to express intent to use it local to this translation unit
C:\msvc\binaries\x86chk\inc\regex(1158): warning C5260: the constant variable 'std::_BRE_MAX_GRP' has internal linkage in an included header file context, but external linkage in imported header unit context; consider declaring it 'inline' as well if it will be shared across translation units, or 'static' to express intent to use it local to this translation unit
C:\msvc\binaries\x86chk\inc\regex(1160): warning C5260: the constant variable 'std::_Bmp_max' has internal linkage in an included header file context, but external linkage in imported header unit context; consider declaring it 'inline' as well if it will be shared across translation units, or 'static' to express intent to use it local to this translation unit
C:\msvc\binaries\x86chk\inc\regex(1161): warning C5260: the constant variable 'std::_Bmp_shift' has internal linkage in an included header file context, but external linkage in imported header unit context; consider declaring it 'inline' as well if it will be shared across translation units, or 'static' to express intent to use it local to this translation unit
C:\msvc\binaries\x86chk\inc\regex(1162): warning C5260: the constant variable 'std::_Bmp_chrs' has internal linkage in an included header file context, but external linkage in imported header unit context; consider declaring it 'inline' as well if it will be shared across translation units, or 'static' to express intent to use it local to this translation unit
C:\msvc\binaries\x86chk\inc\regex(1163): warning C5260: the constant variable 'std::_Bmp_mask' has internal linkage in an included header file context, but external linkage in imported header unit context; consider declaring it 'inline' as well if it will be shared across translation units, or 'static' to express intent to use it local to this translation unit
C:\msvc\binaries\x86chk\inc\regex(1164): warning C5260: the constant variable 'std::_Bmp_size' has internal linkage in an included header file context, but external linkage in imported header unit context; consider declaring it 'inline' as well if it will be shared across translation units, or 'static' to express intent to use it local to this translation unit
C:\msvc\binaries\x86chk\inc\regex(1167): warning C5260: the constant variable 'std::_ARRAY_THRESHOLD' has internal linkage in an included header file context, but external linkage in imported header unit context; consider declaring it 'inline' as well if it will be shared across translation units, or 'static' to express intent to use it local to this translation unit
```

* This fixes all of these occurrences, plus another that I found, `_Size_after_ebco_v` in `<xstring>`.
  + I need to detach the comment there due to wrapping.
* All are potentially C++14, so they need to use `_INLINE_VAR`.
* In `<regex>`, I'm upgrading `const` to `constexpr`.
* In `<vector>`, I'm adding a newline to avoid `=` alignment, and because typedefs and constants are different.