### PR TITLE
P1328R1 `constexpr` `type_info::operator==()`

### DIFF
--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -295,6 +295,7 @@
 // P1132R7 out_ptr(), inout_ptr()
 // P1147R1 Printing volatile Pointers
 // P1272R4 byteswap()
+// P1328R1 constexpr type_info::operator==()
 // P1413R3 Deprecate aligned_storage And aligned_union
 // P1425R4 Iterator Pair Constructors For stack And queue
 // P1659R3 ranges::starts_with, ranges::ends_with
@@ -1456,6 +1457,7 @@
 
 #define __cpp_lib_associative_heterogeneous_erasure 202110L
 #define __cpp_lib_byteswap                          202110L
+#define __cpp_lib_constexpr_typeinfo                202106L
 
 #ifdef __cpp_lib_concepts
 #define __cpp_lib_expected 202202L

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -234,9 +234,6 @@ std/utilities/meta/meta.unary/meta.unary.prop/is_literal_type.deprecated.fail.cp
 std/language.support/support.limits/support.limits.general/tuple.version.pass.cpp FAIL
 std/language.support/support.limits/support.limits.general/utility.version.pass.cpp FAIL
 
-# P1328R1 constexpr type_info::operator==()
-std/language.support/support.limits/support.limits.general/typeinfo.version.pass.cpp FAIL
-
 
 # *** MISSING COMPILER FEATURES ***
 # Nothing here! :-)

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -234,9 +234,6 @@ utilities\meta\meta.unary\meta.unary.prop\is_literal_type.deprecated.fail.cpp
 language.support\support.limits\support.limits.general\tuple.version.pass.cpp
 language.support\support.limits\support.limits.general\utility.version.pass.cpp
 
-# P1328R1 constexpr type_info::operator==()
-language.support\support.limits\support.limits.general\typeinfo.version.pass.cpp
-
 
 # *** MISSING COMPILER FEATURES ***
 # Nothing here! :-)

--- a/tests/std/tests/P2273R3_constexpr_unique_ptr/test.compile.pass.cpp
+++ b/tests/std/tests/P2273R3_constexpr_unique_ptr/test.compile.pass.cpp
@@ -3,6 +3,7 @@
 
 #include <cassert>
 #include <memory>
+#include <typeinfo>
 #include <utility>
 
 using namespace std;
@@ -13,7 +14,7 @@ struct Dummy {
     }
 };
 
-constexpr bool test() {
+constexpr bool test_P2273R3_constexpr_unique_ptr() {
     // [memory.syn]
     {
         auto p1 = make_unique<int>(42);
@@ -126,6 +127,20 @@ constexpr bool test() {
     return true;
 }
 
-static_assert(test());
+static_assert(test_P2273R3_constexpr_unique_ptr());
+
+// Also test P1328R1 constexpr type_info::operator==()
+constexpr bool test_P1328R1_constexpr_type_info_equality() {
+    assert(typeid(int) == typeid(int));
+    assert(typeid(int) != typeid(double));
+
+    assert(typeid(int) == typeid(int&)); // N4910 [expr.typeid]/5
+    assert(typeid(int) == typeid(const int&)); // N4910 [expr.typeid]/5
+    assert(typeid(int) == typeid(const int)); // N4910 [expr.typeid]/6
+
+    return true;
+}
+
+static_assert(test_P1328R1_constexpr_type_info_equality());
 
 int main() {} // COMPILE-ONLY

--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
@@ -592,6 +592,20 @@ STATIC_ASSERT(__cpp_lib_constexpr_tuple == 201811L);
 #endif
 #endif
 
+#if _HAS_CXX23
+#ifndef __cpp_lib_constexpr_typeinfo
+#error __cpp_lib_constexpr_typeinfo is not defined
+#elif __cpp_lib_constexpr_typeinfo != 202106L
+#error __cpp_lib_constexpr_typeinfo is not 202106L
+#else
+STATIC_ASSERT(__cpp_lib_constexpr_typeinfo == 202106L);
+#endif
+#else
+#ifdef __cpp_lib_constexpr_typeinfo
+#error __cpp_lib_constexpr_typeinfo is defined
+#endif
+#endif
+
 #if _HAS_CXX20
 #ifndef __cpp_lib_constexpr_utility
 #error __cpp_lib_constexpr_utility is not defined


### PR DESCRIPTION
Fixes #1972.

I updated `<vcruntime_typeinfo.h>` in internal MSVC-PR-392482, which we just picked up in toolset update #2791. All that remains is to add it to our comment-list of implemented features, add the feature-test macro, and add some test coverage (which doesn't have to be especially thorough; the compiler is doing all of the hard work here, and the library's involvement is just a pointer comparison).