### PR TITLE
Fix non-deterministic test sharding with `--order=lexical`

### DIFF
--- a/azure-devops/cross-build.yml
+++ b/azure-devops/cross-build.yml
@@ -21,7 +21,7 @@ jobs:
     fixedFlags: '--timeout=240;--shuffle'
     parallelismFlag: '-j$(testParallelism)'
     xmlOutputFlag: '--xunit-xml-output=$(${{ parameters.buildOutputLocationVar }})/test-results.xml'
-    shardFlags: '--num-shards=$(System.TotalJobsInPhase);--run-shard=$(System.JobPositionInPhase)'
+    shardFlags: '--order=lexical;--num-shards=$(System.TotalJobsInPhase);--run-shard=$(System.JobPositionInPhase)'
     litFlags: '$(fixedFlags);$(parallelismFlag);$(xmlOutputFlag);$(shardFlags)'
   strategy:
     parallel: ${{ parameters.numShards }}

--- a/azure-devops/native-build-test.yml
+++ b/azure-devops/native-build-test.yml
@@ -18,7 +18,7 @@ jobs:
     fixedFlags: '--timeout=240;--shuffle'
     parallelismFlag: '-j$(testParallelism)'
     xmlOutputFlag: '--xunit-xml-output=$(${{ parameters.buildOutputLocationVar }})/test-results.xml'
-    shardFlags: '--num-shards=$(System.TotalJobsInPhase);--run-shard=$(System.JobPositionInPhase)'
+    shardFlags: '--order=lexical;--num-shards=$(System.TotalJobsInPhase);--run-shard=$(System.JobPositionInPhase)'
     litFlags: '$(fixedFlags);$(parallelismFlag);$(xmlOutputFlag);$(shardFlags)'
   strategy:
     parallel: ${{ parameters.numShards }}


### PR DESCRIPTION
Fixes #2794, which silently degraded our test coverage.

Thanks to @CaseyCarter for investigating the bizarre symptoms and finding [this documented option](https://llvm.org/docs/CommandGuide/lit.html#cmdoption-lit-order).




