### PR TITLE
Use conditional `explicit` unconditionally

### DIFF
--- a/stl/inc/optional
+++ b/stl/inc/optional
@@ -232,18 +232,9 @@ public:
     using _AllowDirectConversion = bool_constant<conjunction_v<negation<is_same<_Remove_cvref_t<_Ty2>, optional>>,
         negation<is_same<_Remove_cvref_t<_Ty2>, in_place_t>>, is_constructible<_Ty, _Ty2>>>;
 
-#if _HAS_CONDITIONAL_EXPLICIT
     template <class _Ty2 = _Ty, enable_if_t<_AllowDirectConversion<_Ty2>::value, int> = 0>
     constexpr explicit(!is_convertible_v<_Ty2, _Ty>) optional(_Ty2&& _Right)
         : _Mybase(in_place, _STD forward<_Ty2>(_Right)) {}
-#else // ^^^ _HAS_CONDITIONAL_EXPLICIT ^^^ / vvv !_HAS_CONDITIONAL_EXPLICIT vvv
-    template <class _Ty2                                                                         = _Ty,
-        enable_if_t<conjunction_v<_AllowDirectConversion<_Ty2>, is_convertible<_Ty2, _Ty>>, int> = 0>
-    constexpr optional(_Ty2&& _Right) : _Mybase(in_place, _STD forward<_Ty2>(_Right)) {}
-    template <class _Ty2                                                                                   = _Ty,
-        enable_if_t<conjunction_v<_AllowDirectConversion<_Ty2>, negation<is_convertible<_Ty2, _Ty>>>, int> = 0>
-    constexpr explicit optional(_Ty2&& _Right) : _Mybase(in_place, _STD forward<_Ty2>(_Right)) {}
-#endif // ^^^ !_HAS_CONDITIONAL_EXPLICIT ^^^
 
     template <class _Ty2>
     struct _AllowUnwrapping : bool_constant<!disjunction_v<is_same<_Ty, _Ty2>, is_constructible<_Ty, optional<_Ty2>&>,
@@ -252,7 +243,6 @@ public:
                                   is_convertible<optional<_Ty2>&, _Ty>, is_convertible<const optional<_Ty2>&, _Ty>,
                                   is_convertible<const optional<_Ty2>, _Ty>, is_convertible<optional<_Ty2>, _Ty>>> {};
 
-#if _HAS_CONDITIONAL_EXPLICIT
     template <class _Ty2,
         enable_if_t<conjunction_v<_AllowUnwrapping<_Ty2>, is_constructible<_Ty, const _Ty2&>>, int> = 0>
     _CONSTEXPR20 explicit(!is_convertible_v<const _Ty2&, _Ty>) optional(const optional<_Ty2>& _Right) {
@@ -260,50 +250,13 @@ public:
             this->_Construct(*_Right);
         }
     }
-#else // ^^^ _HAS_CONDITIONAL_EXPLICIT ^^^ / vvv !_HAS_CONDITIONAL_EXPLICIT vvv
-    template <class _Ty2, enable_if_t<conjunction_v<_AllowUnwrapping<_Ty2>, is_constructible<_Ty, const _Ty2&>,
-                                          is_convertible<const _Ty2&, _Ty>>,
-                              int> = 0>
-    optional(const optional<_Ty2>& _Right) {
-        if (_Right) {
-            this->_Construct(*_Right);
-        }
-    }
-    template <class _Ty2, enable_if_t<conjunction_v<_AllowUnwrapping<_Ty2>, is_constructible<_Ty, const _Ty2&>,
-                                          negation<is_convertible<const _Ty2&, _Ty>>>,
-                              int> = 0>
-    explicit optional(const optional<_Ty2>& _Right) {
-        if (_Right) {
-            this->_Construct(*_Right);
-        }
-    }
-#endif // ^^^ !_HAS_CONDITIONAL_EXPLICIT ^^^
 
-#if _HAS_CONDITIONAL_EXPLICIT
     template <class _Ty2, enable_if_t<conjunction_v<_AllowUnwrapping<_Ty2>, is_constructible<_Ty, _Ty2>>, int> = 0>
     _CONSTEXPR20 explicit(!is_convertible_v<_Ty2, _Ty>) optional(optional<_Ty2>&& _Right) {
         if (_Right) {
             this->_Construct(_STD move(*_Right));
         }
     }
-#else // ^^^ _HAS_CONDITIONAL_EXPLICIT ^^^ / vvv !_HAS_CONDITIONAL_EXPLICIT vvv
-    template <class _Ty2,
-        enable_if_t<conjunction_v<_AllowUnwrapping<_Ty2>, is_constructible<_Ty, _Ty2>, is_convertible<_Ty2, _Ty>>,
-            int> = 0>
-    optional(optional<_Ty2>&& _Right) {
-        if (_Right) {
-            this->_Construct(_STD move(*_Right));
-        }
-    }
-    template <class _Ty2, enable_if_t<conjunction_v<_AllowUnwrapping<_Ty2>, is_constructible<_Ty, _Ty2>,
-                                          negation<is_convertible<_Ty2, _Ty>>>,
-                              int> = 0>
-    explicit optional(optional<_Ty2>&& _Right) {
-        if (_Right) {
-            this->_Construct(_STD move(*_Right));
-        }
-    }
-#endif // ^^^ !_HAS_CONDITIONAL_EXPLICIT ^^^
 
 #if _HAS_CXX23
     template <class _Fn, class _Ux>

--- a/stl/inc/tuple
+++ b/stl/inc/tuple
@@ -22,7 +22,6 @@ _STL_DISABLE_CLANG_WARNINGS
 #undef new
 
 _STD_BEGIN
-#if _HAS_CONDITIONAL_EXPLICIT
 template <bool _Same, class _Dest, class... _Srcs>
 _INLINE_VAR constexpr bool _Tuple_conditional_explicit_v0 = false;
 
@@ -33,31 +32,6 @@ _INLINE_VAR constexpr bool _Tuple_conditional_explicit_v0<true, tuple<_Dests...>
 template <class _Dest, class... _Srcs>
 _INLINE_VAR constexpr bool _Tuple_conditional_explicit_v =
     _Tuple_conditional_explicit_v0<tuple_size_v<_Dest> == sizeof...(_Srcs), _Dest, _Srcs...>;
-#else // ^^^ _HAS_CONDITIONAL_EXPLICIT ^^^ / vvv !_HAS_CONDITIONAL_EXPLICIT vvv
-// Constrain tuple's implicit constructors
-template <bool _Same, class _Dest, class... _Srcs>
-_INLINE_VAR constexpr bool _Tuple_implicit_v0 = false;
-
-template <class... _Dests, class... _Srcs>
-_INLINE_VAR constexpr bool _Tuple_implicit_v0<true, tuple<_Dests...>, _Srcs...> =
-    conjunction_v<is_constructible<_Dests, _Srcs>..., is_convertible<_Srcs, _Dests>...>;
-
-template <class _Dest, class... _Srcs>
-struct _Tuple_implicit_val
-    : bool_constant<_Tuple_implicit_v0<tuple_size_v<_Dest> == sizeof...(_Srcs), _Dest, _Srcs...>> {};
-
-// Constrain tuple's explicit constructors
-template <bool _Same, class _Dest, class... _Srcs>
-_INLINE_VAR constexpr bool _Tuple_explicit_v0 = false;
-
-template <class... _Dests, class... _Srcs>
-_INLINE_VAR constexpr bool _Tuple_explicit_v0<true, tuple<_Dests...>, _Srcs...> =
-    conjunction_v<is_constructible<_Dests, _Srcs>..., negation<conjunction<is_convertible<_Srcs, _Dests>...>>>;
-
-template <class _Dest, class... _Srcs>
-struct _Tuple_explicit_val
-    : bool_constant<_Tuple_explicit_v0<tuple_size_v<_Dest> == sizeof...(_Srcs), _Dest, _Srcs...>> {};
-#endif // ^^^ !_HAS_CONDITIONAL_EXPLICIT ^^^
 
 template <bool _Same, class _Dest, class... _Srcs>
 _INLINE_VAR constexpr bool _Tuple_constructible_v0 = false;
@@ -287,7 +261,6 @@ public:
         : tuple(_Alloc_unpack_tuple_t{}, _Al, _STD forward<_Tpl>(_Right),
             make_index_sequence<tuple_size_v<remove_reference_t<_Tpl>>>{}) {}
 
-#if _HAS_CONDITIONAL_EXPLICIT
     template <class _This2 = _This,
         enable_if_t<conjunction_v<_STD is_default_constructible<_This2>, _STD is_default_constructible<_Rest>...>,
             int>           = 0>
@@ -296,48 +269,13 @@ public:
         tuple() noexcept(conjunction_v<is_nothrow_default_constructible<_This2>,
             is_nothrow_default_constructible<_Rest>...>) // strengthened
         : _Mybase(), _Myfirst() {}
-#else // ^^^ _HAS_CONDITIONAL_EXPLICIT ^^^ / vvv !_HAS_CONDITIONAL_EXPLICIT vvv
-    template <class _This2 = _This,
-        enable_if_t<conjunction_v<is_default_constructible<_This2>, is_default_constructible<_Rest>...,
-                        _Is_implicitly_default_constructible<_This2>, _Is_implicitly_default_constructible<_Rest>...>,
-            int>           = 0>
-    constexpr tuple() noexcept(conjunction_v<is_nothrow_default_constructible<_This2>,
-        is_nothrow_default_constructible<_Rest>...>) // strengthened
-        : _Mybase(), _Myfirst() {}
 
-    template <class _This2 = _This,
-        enable_if_t<conjunction_v<is_default_constructible<_This2>, is_default_constructible<_Rest>...,
-                        negation<conjunction<_Is_implicitly_default_constructible<_This2>,
-                            _Is_implicitly_default_constructible<_Rest>...>>>,
-            int>           = 0>
-    constexpr explicit tuple() noexcept(conjunction_v<is_nothrow_default_constructible<_This2>,
-        is_nothrow_default_constructible<_Rest>...>) // strengthened
-        : _Mybase(), _Myfirst() {}
-#endif // ^^^ !_HAS_CONDITIONAL_EXPLICIT ^^^
-
-#if _HAS_CONDITIONAL_EXPLICIT
     template <class _This2 = _This, enable_if_t<_Tuple_constructible_v<tuple, const _This2&, const _Rest&...>, int> = 0>
     constexpr explicit(_Tuple_conditional_explicit_v<tuple, const _This2&, const _Rest&...>) tuple(
         const _This& _This_arg, const _Rest&... _Rest_arg) noexcept(conjunction_v<is_nothrow_copy_constructible<_This2>,
         is_nothrow_copy_constructible<_Rest>...>) // strengthened
         : tuple(_Exact_args_t{}, _This_arg, _Rest_arg...) {}
-#else // ^^^ _HAS_CONDITIONAL_EXPLICIT ^^^ / vvv !_HAS_CONDITIONAL_EXPLICIT vvv
-    template <class _This2                                                                  = _This,
-        enable_if_t<_Tuple_implicit_val<tuple, const _This2&, const _Rest&...>::value, int> = 0>
-    constexpr tuple(const _This& _This_arg, const _Rest&... _Rest_arg) noexcept(
-        conjunction_v<is_nothrow_copy_constructible<_This2>,
-            is_nothrow_copy_constructible<_Rest>...>) // strengthened
-        : tuple(_Exact_args_t{}, _This_arg, _Rest_arg...) {}
 
-    template <class _This2                                                                  = _This,
-        enable_if_t<_Tuple_explicit_val<tuple, const _This2&, const _Rest&...>::value, int> = 0>
-    constexpr explicit tuple(const _This& _This_arg, const _Rest&... _Rest_arg) noexcept(
-        conjunction_v<is_nothrow_copy_constructible<_This2>,
-            is_nothrow_copy_constructible<_Rest>...>) // strengthened
-        : tuple(_Exact_args_t{}, _This_arg, _Rest_arg...) {}
-#endif // ^^^ !_HAS_CONDITIONAL_EXPLICIT ^^^
-
-#if _HAS_CONDITIONAL_EXPLICIT
     template <class _This2, class... _Rest2,
         enable_if_t<conjunction_v<_STD _Tuple_perfect_val<tuple, _This2, _Rest2...>,
                         _STD _Tuple_constructible_val<tuple, _This2, _Rest2...>>,
@@ -345,23 +283,6 @@ public:
     constexpr explicit(_Tuple_conditional_explicit_v<tuple, _This2, _Rest2...>) tuple(_This2&& _This_arg,
         _Rest2&&... _Rest_arg) noexcept(_Tuple_nothrow_constructible_v<tuple, _This2, _Rest2...>) // strengthened
         : tuple(_Exact_args_t{}, _STD forward<_This2>(_This_arg), _STD forward<_Rest2>(_Rest_arg)...) {}
-#else // ^^^ _HAS_CONDITIONAL_EXPLICIT ^^^ / vvv !_HAS_CONDITIONAL_EXPLICIT vvv
-    template <class _This2, class... _Rest2,
-        enable_if_t<
-            conjunction_v<_Tuple_perfect_val<tuple, _This2, _Rest2...>, _Tuple_implicit_val<tuple, _This2, _Rest2...>>,
-            int> = 0>
-    constexpr tuple(_This2&& _This_arg, _Rest2&&... _Rest_arg) noexcept(
-        _Tuple_nothrow_constructible_v<tuple, _This2, _Rest2...>) // strengthened
-        : tuple(_Exact_args_t{}, _STD forward<_This2>(_This_arg), _STD forward<_Rest2>(_Rest_arg)...) {}
-
-    template <class _This2, class... _Rest2,
-        enable_if_t<
-            conjunction_v<_Tuple_perfect_val<tuple, _This2, _Rest2...>, _Tuple_explicit_val<tuple, _This2, _Rest2...>>,
-            int> = 0>
-    constexpr explicit tuple(_This2&& _This_arg, _Rest2&&... _Rest_arg) noexcept(
-        _Tuple_nothrow_constructible_v<tuple, _This2, _Rest2...>) // strengthened
-        : tuple(_Exact_args_t{}, _STD forward<_This2>(_This_arg), _STD forward<_Rest2>(_Rest_arg)...) {}
-#endif // ^^^ !_HAS_CONDITIONAL_EXPLICIT ^^^
 
     tuple(const tuple&) = default;
     tuple(tuple&&)      = default;
@@ -375,7 +296,6 @@ public:
         : tuple(_Unpack_tuple_t{}, _Right) {}
 #endif // _HAS_CXX23
 
-#if _HAS_CONDITIONAL_EXPLICIT
     template <class... _Other, enable_if_t<conjunction_v<_STD _Tuple_constructible_val<tuple, const _Other&...>,
                                                _STD _Tuple_convert_val<tuple, const tuple<_Other...>&, _Other...>>,
                                    int> = 0>
@@ -383,44 +303,13 @@ public:
         tuple(const tuple<_Other...>& _Right) noexcept(
             _Tuple_nothrow_constructible_v<tuple, const _Other&...>) // strengthened
         : tuple(_Unpack_tuple_t{}, _Right) {}
-#else // ^^^ _HAS_CONDITIONAL_EXPLICIT ^^^ / vvv !_HAS_CONDITIONAL_EXPLICIT vvv
-    template <class... _Other, enable_if_t<conjunction_v<_Tuple_implicit_val<tuple, const _Other&...>,
-                                               _Tuple_convert_val<tuple, const tuple<_Other...>&, _Other...>>,
-                                   int> = 0>
-    constexpr tuple(const tuple<_Other...>& _Right) noexcept(
-        _Tuple_nothrow_constructible_v<tuple, const _Other&...>) // strengthened
-        : tuple(_Unpack_tuple_t{}, _Right) {}
 
-    template <class... _Other, enable_if_t<conjunction_v<_Tuple_explicit_val<tuple, const _Other&...>,
-                                               _Tuple_convert_val<tuple, const tuple<_Other...>&, _Other...>>,
-                                   int> = 0>
-    constexpr explicit tuple(const tuple<_Other...>& _Right) noexcept(
-        _Tuple_nothrow_constructible_v<tuple, const _Other&...>) // strengthened
-        : tuple(_Unpack_tuple_t{}, _Right) {}
-#endif // ^^^ !_HAS_CONDITIONAL_EXPLICIT ^^^
-
-#if _HAS_CONDITIONAL_EXPLICIT
     template <class... _Other, enable_if_t<conjunction_v<_STD _Tuple_constructible_val<tuple, _Other...>,
                                                _STD _Tuple_convert_val<tuple, tuple<_Other...>, _Other...>>,
                                    int> = 0>
     constexpr explicit(_Tuple_conditional_explicit_v<tuple, _Other...>)
         tuple(tuple<_Other...>&& _Right) noexcept(_Tuple_nothrow_constructible_v<tuple, _Other...>) // strengthened
         : tuple(_Unpack_tuple_t{}, _STD move(_Right)) {}
-#else // ^^^ _HAS_CONDITIONAL_EXPLICIT ^^^ / vvv !_HAS_CONDITIONAL_EXPLICIT vvv
-    template <class... _Other, enable_if_t<conjunction_v<_Tuple_implicit_val<tuple, _Other...>,
-                                               _Tuple_convert_val<tuple, tuple<_Other...>, _Other...>>,
-                                   int> = 0>
-    constexpr tuple(tuple<_Other...>&& _Right) noexcept(
-        _Tuple_nothrow_constructible_v<tuple, _Other...>) // strengthened
-        : tuple(_Unpack_tuple_t{}, _STD move(_Right)) {}
-
-    template <class... _Other, enable_if_t<conjunction_v<_Tuple_explicit_val<tuple, _Other...>,
-                                               _Tuple_convert_val<tuple, tuple<_Other...>, _Other...>>,
-                                   int> = 0>
-    constexpr explicit tuple(tuple<_Other...>&& _Right) noexcept(
-        _Tuple_nothrow_constructible_v<tuple, _Other...>) // strengthened
-        : tuple(_Unpack_tuple_t{}, _STD move(_Right)) {}
-#endif // ^^^ !_HAS_CONDITIONAL_EXPLICIT ^^^
 
 #if _HAS_CXX23
     template <class... _Other, enable_if_t<conjunction_v<_STD _Tuple_constructible_val<tuple, const _Other...>,
@@ -438,43 +327,17 @@ public:
         : tuple(_Unpack_tuple_t{}, _Right) {}
 #endif // _HAS_CXX23
 
-#if _HAS_CONDITIONAL_EXPLICIT
     template <class _First, class _Second,
         enable_if_t<_Tuple_constructible_v<tuple, const _First&, const _Second&>, int> = 0>
     constexpr explicit(_Tuple_conditional_explicit_v<tuple, const _First&, const _Second&>)
         tuple(const pair<_First, _Second>& _Right) noexcept(
             _Tuple_nothrow_constructible_v<tuple, const _First&, const _Second&>) // strengthened
         : tuple(_Unpack_tuple_t{}, _Right) {}
-#else // ^^^ _HAS_CONDITIONAL_EXPLICIT ^^^ / vvv !_HAS_CONDITIONAL_EXPLICIT vvv
-    template <class _First, class _Second,
-        enable_if_t<_Tuple_implicit_val<tuple, const _First&, const _Second&>::value, int> = 0>
-    constexpr tuple(const pair<_First, _Second>& _Right) noexcept(
-        _Tuple_nothrow_constructible_v<tuple, const _First&, const _Second&>) // strengthened
-        : tuple(_Unpack_tuple_t{}, _Right) {}
 
-    template <class _First, class _Second,
-        enable_if_t<_Tuple_explicit_val<tuple, const _First&, const _Second&>::value, int> = 0>
-    constexpr explicit tuple(const pair<_First, _Second>& _Right) noexcept(
-        _Tuple_nothrow_constructible_v<tuple, const _First&, const _Second&>) // strengthened
-        : tuple(_Unpack_tuple_t{}, _Right) {}
-#endif // ^^^ !_HAS_CONDITIONAL_EXPLICIT ^^^
-
-#if _HAS_CONDITIONAL_EXPLICIT
     template <class _First, class _Second, enable_if_t<_Tuple_constructible_v<tuple, _First, _Second>, int> = 0>
     constexpr explicit(_Tuple_conditional_explicit_v<tuple, _First, _Second>) tuple(
         pair<_First, _Second>&& _Right) noexcept(_Tuple_nothrow_constructible_v<tuple, _First, _Second>) // strengthened
         : tuple(_Unpack_tuple_t{}, _STD move(_Right)) {}
-#else // ^^^ _HAS_CONDITIONAL_EXPLICIT ^^^ / vvv !_HAS_CONDITIONAL_EXPLICIT vvv
-    template <class _First, class _Second, enable_if_t<_Tuple_implicit_val<tuple, _First, _Second>::value, int> = 0>
-    constexpr tuple(pair<_First, _Second>&& _Right) noexcept(
-        _Tuple_nothrow_constructible_v<tuple, _First, _Second>) // strengthened
-        : tuple(_Unpack_tuple_t{}, _STD move(_Right)) {}
-
-    template <class _First, class _Second, enable_if_t<_Tuple_explicit_val<tuple, _First, _Second>::value, int> = 0>
-    constexpr explicit tuple(pair<_First, _Second>&& _Right) noexcept(
-        _Tuple_nothrow_constructible_v<tuple, _First, _Second>) // strengthened
-        : tuple(_Unpack_tuple_t{}, _STD move(_Right)) {}
-#endif // ^^^ !_HAS_CONDITIONAL_EXPLICIT ^^^
 
 #if _HAS_CXX23
     template <class _First, class _Second,
@@ -485,7 +348,6 @@ public:
         : tuple(_Unpack_tuple_t{}, _STD move(_Right)) {}
 #endif // _HAS_CXX23
 
-#if _HAS_CONDITIONAL_EXPLICIT
     template <class _Alloc, class _This2 = _This,
         enable_if_t<conjunction_v<_STD is_default_constructible<_This2>, _STD is_default_constructible<_Rest>...>,
             int> = 0>
@@ -493,42 +355,13 @@ public:
         !conjunction_v<_Is_implicitly_default_constructible<_This2>, _Is_implicitly_default_constructible<_Rest>...>)
         tuple(allocator_arg_t, const _Alloc& _Al)
         : _Mybase(allocator_arg, _Al), _Myfirst(_Al, allocator_arg) {}
-#else // ^^^ _HAS_CONDITIONAL_EXPLICIT ^^^ / vvv !_HAS_CONDITIONAL_EXPLICIT vvv
-    template <class _Alloc, class _This2 = _This,
-        enable_if_t<conjunction_v<is_default_constructible<_This2>, is_default_constructible<_Rest>...,
-                        _Is_implicitly_default_constructible<_This2>, _Is_implicitly_default_constructible<_Rest>...>,
-            int> = 0>
-    _CONSTEXPR20 tuple(allocator_arg_t, const _Alloc& _Al)
-        : _Mybase(allocator_arg, _Al), _Myfirst(_Al, allocator_arg) {}
 
-    template <class _Alloc, class _This2 = _This,
-        enable_if_t<conjunction_v<is_default_constructible<_This2>, is_default_constructible<_Rest>...,
-                        negation<conjunction<_Is_implicitly_default_constructible<_This2>,
-                            _Is_implicitly_default_constructible<_Rest>...>>>,
-            int> = 0>
-    _CONSTEXPR20 explicit tuple(allocator_arg_t, const _Alloc& _Al)
-        : _Mybase(allocator_arg, _Al), _Myfirst(_Al, allocator_arg) {}
-#endif // ^^^ !_HAS_CONDITIONAL_EXPLICIT ^^^
-
-#if _HAS_CONDITIONAL_EXPLICIT
     template <class _Alloc, class _This2 = _This,
         enable_if_t<_Tuple_constructible_v<tuple, const _This2&, const _Rest&...>, int> = 0>
     _CONSTEXPR20 explicit(_Tuple_conditional_explicit_v<tuple, const _This2&, const _Rest&...>)
         tuple(allocator_arg_t, const _Alloc& _Al, const _This& _This_arg, const _Rest&... _Rest_arg)
         : tuple(_Alloc_exact_args_t{}, _Al, _This_arg, _Rest_arg...) {}
-#else // ^^^ _HAS_CONDITIONAL_EXPLICIT ^^^ / vvv !_HAS_CONDITIONAL_EXPLICIT vvv
-    template <class _Alloc, class _This2 = _This,
-        enable_if_t<_Tuple_implicit_val<tuple, const _This2&, const _Rest&...>::value, int> = 0>
-    _CONSTEXPR20 tuple(allocator_arg_t, const _Alloc& _Al, const _This& _This_arg, const _Rest&... _Rest_arg)
-        : tuple(_Alloc_exact_args_t{}, _Al, _This_arg, _Rest_arg...) {}
 
-    template <class _Alloc, class _This2 = _This,
-        enable_if_t<_Tuple_explicit_val<tuple, const _This2&, const _Rest&...>::value, int> = 0>
-    _CONSTEXPR20 explicit tuple(allocator_arg_t, const _Alloc& _Al, const _This& _This_arg, const _Rest&... _Rest_arg)
-        : tuple(_Alloc_exact_args_t{}, _Al, _This_arg, _Rest_arg...) {}
-#endif // ^^^ !_HAS_CONDITIONAL_EXPLICIT ^^^
-
-#if _HAS_CONDITIONAL_EXPLICIT
     template <class _Alloc, class _This2, class... _Rest2,
         enable_if_t<conjunction_v<_STD _Tuple_perfect_val<tuple, _This2, _Rest2...>,
                         _STD _Tuple_constructible_val<tuple, _This2, _Rest2...>>,
@@ -536,21 +369,6 @@ public:
     _CONSTEXPR20 explicit(_Tuple_conditional_explicit_v<tuple, _This2, _Rest2...>)
         tuple(allocator_arg_t, const _Alloc& _Al, _This2&& _This_arg, _Rest2&&... _Rest_arg)
         : tuple(_Alloc_exact_args_t{}, _Al, _STD forward<_This2>(_This_arg), _STD forward<_Rest2>(_Rest_arg)...) {}
-#else // ^^^ _HAS_CONDITIONAL_EXPLICIT ^^^ / vvv !_HAS_CONDITIONAL_EXPLICIT vvv
-    template <class _Alloc, class _This2, class... _Rest2,
-        enable_if_t<
-            conjunction_v<_Tuple_perfect_val<tuple, _This2, _Rest2...>, _Tuple_implicit_val<tuple, _This2, _Rest2...>>,
-            int> = 0>
-    _CONSTEXPR20 tuple(allocator_arg_t, const _Alloc& _Al, _This2&& _This_arg, _Rest2&&... _Rest_arg)
-        : tuple(_Alloc_exact_args_t{}, _Al, _STD forward<_This2>(_This_arg), _STD forward<_Rest2>(_Rest_arg)...) {}
-
-    template <class _Alloc, class _This2, class... _Rest2,
-        enable_if_t<
-            conjunction_v<_Tuple_perfect_val<tuple, _This2, _Rest2...>, _Tuple_explicit_val<tuple, _This2, _Rest2...>>,
-            int> = 0>
-    _CONSTEXPR20 explicit tuple(allocator_arg_t, const _Alloc& _Al, _This2&& _This_arg, _Rest2&&... _Rest_arg)
-        : tuple(_Alloc_exact_args_t{}, _Al, _STD forward<_This2>(_This_arg), _STD forward<_Rest2>(_Rest_arg)...) {}
-#endif // ^^^ !_HAS_CONDITIONAL_EXPLICIT ^^^
 
     template <class _Alloc, class _This2 = _This,
         enable_if_t<_Tuple_constructible_v<tuple, const _This2&, const _Rest&...>, int> = 0>
@@ -571,7 +389,6 @@ public:
         : tuple(_Alloc_unpack_tuple_t{}, _Al, _Right) {}
 #endif // _HAS_CXX23
 
-#if _HAS_CONDITIONAL_EXPLICIT
     template <class _Alloc, class... _Other,
         enable_if_t<conjunction_v<_STD _Tuple_constructible_val<tuple, const _Other&...>,
                         _STD _Tuple_convert_val<tuple, const tuple<_Other...>&, _Other...>>,
@@ -579,23 +396,7 @@ public:
     _CONSTEXPR20 explicit(_Tuple_conditional_explicit_v<tuple, const _Other&...>)
         tuple(allocator_arg_t, const _Alloc& _Al, const tuple<_Other...>& _Right)
         : tuple(_Alloc_unpack_tuple_t{}, _Al, _Right) {}
-#else // ^^^ _HAS_CONDITIONAL_EXPLICIT ^^^ / vvv !_HAS_CONDITIONAL_EXPLICIT vvv
-    template <class _Alloc, class... _Other,
-        enable_if_t<conjunction_v<_Tuple_implicit_val<tuple, const _Other&...>,
-                        _Tuple_convert_val<tuple, const tuple<_Other...>&, _Other...>>,
-            int> = 0>
-    _CONSTEXPR20 tuple(allocator_arg_t, const _Alloc& _Al, const tuple<_Other...>& _Right)
-        : tuple(_Alloc_unpack_tuple_t{}, _Al, _Right) {}
 
-    template <class _Alloc, class... _Other,
-        enable_if_t<conjunction_v<_Tuple_explicit_val<tuple, const _Other&...>,
-                        _Tuple_convert_val<tuple, const tuple<_Other...>&, _Other...>>,
-            int> = 0>
-    _CONSTEXPR20 explicit tuple(allocator_arg_t, const _Alloc& _Al, const tuple<_Other...>& _Right)
-        : tuple(_Alloc_unpack_tuple_t{}, _Al, _Right) {}
-#endif // ^^^ !_HAS_CONDITIONAL_EXPLICIT ^^^
-
-#if _HAS_CONDITIONAL_EXPLICIT
     template <class _Alloc, class... _Other,
         enable_if_t<conjunction_v<_STD _Tuple_constructible_val<tuple, _Other...>,
                         _STD _Tuple_convert_val<tuple, tuple<_Other...>, _Other...>>,
@@ -603,21 +404,6 @@ public:
     _CONSTEXPR20 explicit(_Tuple_conditional_explicit_v<tuple, _Other...>)
         tuple(allocator_arg_t, const _Alloc& _Al, tuple<_Other...>&& _Right)
         : tuple(_Alloc_unpack_tuple_t{}, _Al, _STD move(_Right)) {}
-#else // ^^^ _HAS_CONDITIONAL_EXPLICIT ^^^ / vvv !_HAS_CONDITIONAL_EXPLICIT vvv
-    template <class _Alloc, class... _Other,
-        enable_if_t<conjunction_v<_Tuple_implicit_val<tuple, _Other...>,
-                        _Tuple_convert_val<tuple, tuple<_Other...>, _Other...>>,
-            int> = 0>
-    _CONSTEXPR20 tuple(allocator_arg_t, const _Alloc& _Al, tuple<_Other...>&& _Right)
-        : tuple(_Alloc_unpack_tuple_t{}, _Al, _STD move(_Right)) {}
-
-    template <class _Alloc, class... _Other,
-        enable_if_t<conjunction_v<_Tuple_explicit_val<tuple, _Other...>,
-                        _Tuple_convert_val<tuple, tuple<_Other...>, _Other...>>,
-            int> = 0>
-    _CONSTEXPR20 explicit tuple(allocator_arg_t, const _Alloc& _Al, tuple<_Other...>&& _Right)
-        : tuple(_Alloc_unpack_tuple_t{}, _Al, _STD move(_Right)) {}
-#endif // ^^^ !_HAS_CONDITIONAL_EXPLICIT ^^^
 
 #if _HAS_CXX23
     template <class _Alloc, class... _Other,
@@ -635,41 +421,17 @@ public:
         : tuple(_Alloc_unpack_tuple_t{}, _Al, _Right) {}
 #endif // _HAS_CXX23
 
-#if _HAS_CONDITIONAL_EXPLICIT
     template <class _Alloc, class _First, class _Second,
         enable_if_t<_Tuple_constructible_v<tuple, const _First&, const _Second&>, int> = 0>
     _CONSTEXPR20 explicit(_Tuple_conditional_explicit_v<tuple, const _First&, const _Second&>)
         tuple(allocator_arg_t, const _Alloc& _Al, const pair<_First, _Second>& _Right)
         : tuple(_Alloc_unpack_tuple_t{}, _Al, _Right) {}
-#else // ^^^ _HAS_CONDITIONAL_EXPLICIT ^^^ / vvv !_HAS_CONDITIONAL_EXPLICIT vvv
-    template <class _Alloc, class _First, class _Second,
-        enable_if_t<_Tuple_implicit_val<tuple, const _First&, const _Second&>::value, int> = 0>
-    _CONSTEXPR20 tuple(allocator_arg_t, const _Alloc& _Al, const pair<_First, _Second>& _Right)
-        : tuple(_Alloc_unpack_tuple_t{}, _Al, _Right) {}
 
-    template <class _Alloc, class _First, class _Second,
-        enable_if_t<_Tuple_explicit_val<tuple, const _First&, const _Second&>::value, int> = 0>
-    _CONSTEXPR20 explicit tuple(allocator_arg_t, const _Alloc& _Al, const pair<_First, _Second>& _Right)
-        : tuple(_Alloc_unpack_tuple_t{}, _Al, _Right) {}
-#endif // ^^^ !_HAS_CONDITIONAL_EXPLICIT ^^^
-
-#if _HAS_CONDITIONAL_EXPLICIT
     template <class _Alloc, class _First, class _Second,
         enable_if_t<_Tuple_constructible_v<tuple, _First, _Second>, int> = 0>
     _CONSTEXPR20 explicit(_Tuple_conditional_explicit_v<tuple, _First, _Second>)
         tuple(allocator_arg_t, const _Alloc& _Al, pair<_First, _Second>&& _Right)
         : tuple(_Alloc_unpack_tuple_t{}, _Al, _STD move(_Right)) {}
-#else // ^^^ _HAS_CONDITIONAL_EXPLICIT ^^^ / vvv !_HAS_CONDITIONAL_EXPLICIT vvv
-    template <class _Alloc, class _First, class _Second,
-        enable_if_t<_Tuple_implicit_val<tuple, _First, _Second>::value, int> = 0>
-    _CONSTEXPR20 tuple(allocator_arg_t, const _Alloc& _Al, pair<_First, _Second>&& _Right)
-        : tuple(_Alloc_unpack_tuple_t{}, _Al, _STD move(_Right)) {}
-
-    template <class _Alloc, class _First, class _Second,
-        enable_if_t<_Tuple_explicit_val<tuple, _First, _Second>::value, int> = 0>
-    _CONSTEXPR20 explicit tuple(allocator_arg_t, const _Alloc& _Al, pair<_First, _Second>&& _Right)
-        : tuple(_Alloc_unpack_tuple_t{}, _Al, _STD move(_Right)) {}
-#endif // ^^^ !_HAS_CONDITIONAL_EXPLICIT ^^^
 
 #if _HAS_CXX23
     template <class _Alloc, class _First, class _Second,

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -145,7 +145,6 @@ struct pair { // store a pair of values
     using first_type  = _Ty1;
     using second_type = _Ty2;
 
-#if _HAS_CONDITIONAL_EXPLICIT
     template <class _Uty1 = _Ty1, class _Uty2 = _Ty2,
         enable_if_t<conjunction_v<is_default_constructible<_Uty1>, is_default_constructible<_Uty2>>, int> = 0>
     constexpr explicit(
@@ -153,52 +152,14 @@ struct pair { // store a pair of values
         pair() noexcept(
             is_nothrow_default_constructible_v<_Uty1>&& is_nothrow_default_constructible_v<_Uty2>) // strengthened
         : first(), second() {}
-#else // ^^^ _HAS_CONDITIONAL_EXPLICIT ^^^ / vvv !_HAS_CONDITIONAL_EXPLICIT vvv
-    template <class _Uty1 = _Ty1, class _Uty2 = _Ty2,
-        enable_if_t<conjunction_v<is_default_constructible<_Uty1>, is_default_constructible<_Uty2>,
-                        _Is_implicitly_default_constructible<_Uty1>, _Is_implicitly_default_constructible<_Uty2>>,
-            int> = 0>
-    constexpr pair() noexcept(
-        is_nothrow_default_constructible_v<_Uty1>&& is_nothrow_default_constructible_v<_Uty2>) // strengthened
-        : first(), second() {}
 
-    template <class _Uty1 = _Ty1, class _Uty2 = _Ty2,
-        enable_if_t<conjunction_v<is_default_constructible<_Uty1>, is_default_constructible<_Uty2>,
-                        negation<conjunction<_Is_implicitly_default_constructible<_Uty1>,
-                            _Is_implicitly_default_constructible<_Uty2>>>>,
-            int> = 0>
-    constexpr explicit pair() noexcept(
-        is_nothrow_default_constructible_v<_Uty1>&& is_nothrow_default_constructible_v<_Uty2>) // strengthened
-        : first(), second() {}
-#endif // ^^^ !_HAS_CONDITIONAL_EXPLICIT ^^^
-
-#if _HAS_CONDITIONAL_EXPLICIT
     template <class _Uty1 = _Ty1, class _Uty2 = _Ty2,
         enable_if_t<conjunction_v<is_copy_constructible<_Uty1>, is_copy_constructible<_Uty2>>, int> = 0>
     constexpr explicit(!conjunction_v<is_convertible<const _Uty1&, _Uty1>, is_convertible<const _Uty2&, _Uty2>>)
         pair(const _Ty1& _Val1, const _Ty2& _Val2) noexcept(
             is_nothrow_copy_constructible_v<_Uty1>&& is_nothrow_copy_constructible_v<_Uty2>) // strengthened
         : first(_Val1), second(_Val2) {}
-#else // ^^^ _HAS_CONDITIONAL_EXPLICIT ^^^ / vvv !_HAS_CONDITIONAL_EXPLICIT vvv
-    template <class _Uty1 = _Ty1, class _Uty2 = _Ty2,
-        enable_if_t<conjunction_v<is_copy_constructible<_Uty1>, is_copy_constructible<_Uty2>,
-                        is_convertible<const _Uty1&, _Uty1>, is_convertible<const _Uty2&, _Uty2>>,
-            int> = 0>
-    constexpr pair(const _Ty1& _Val1, const _Ty2& _Val2) noexcept(
-        is_nothrow_copy_constructible_v<_Uty1>&& is_nothrow_copy_constructible_v<_Uty2>) // strengthened
-        : first(_Val1), second(_Val2) {}
 
-    template <class _Uty1 = _Ty1, class _Uty2 = _Ty2,
-        enable_if_t<
-            conjunction_v<is_copy_constructible<_Uty1>, is_copy_constructible<_Uty2>,
-                negation<conjunction<is_convertible<const _Uty1&, _Uty1>, is_convertible<const _Uty2&, _Uty2>>>>,
-            int> = 0>
-    constexpr explicit pair(const _Ty1& _Val1, const _Ty2& _Val2) noexcept(
-        is_nothrow_copy_constructible_v<_Uty1>&& is_nothrow_copy_constructible_v<_Uty2>) // strengthened
-        : first(_Val1), second(_Val2) {}
-#endif // ^^^ !_HAS_CONDITIONAL_EXPLICIT ^^^
-
-#if _HAS_CONDITIONAL_EXPLICIT
 #if _HAS_CXX23
     template <class _Other1 = _Ty1, class _Other2 = _Ty2,
 #else // ^^^ _HAS_CXX23 / !_HAS_CXX23 vvv
@@ -210,23 +171,6 @@ struct pair { // store a pair of values
             is_nothrow_constructible_v<_Ty1, _Other1>&& is_nothrow_constructible_v<_Ty2, _Other2>) // strengthened
         : first(_STD forward<_Other1>(_Val1)), second(_STD forward<_Other2>(_Val2)) {
     }
-#else // ^^^ _HAS_CONDITIONAL_EXPLICIT ^^^ / vvv !_HAS_CONDITIONAL_EXPLICIT vvv
-    template <class _Other1, class _Other2,
-        enable_if_t<conjunction_v<is_constructible<_Ty1, _Other1>, is_constructible<_Ty2, _Other2>,
-                        is_convertible<_Other1, _Ty1>, is_convertible<_Other2, _Ty2>>,
-            int> = 0>
-    constexpr pair(_Other1&& _Val1, _Other2&& _Val2) noexcept(
-        is_nothrow_constructible_v<_Ty1, _Other1>&& is_nothrow_constructible_v<_Ty2, _Other2>) // strengthened
-        : first(_STD forward<_Other1>(_Val1)), second(_STD forward<_Other2>(_Val2)) {}
-
-    template <class _Other1, class _Other2,
-        enable_if_t<conjunction_v<is_constructible<_Ty1, _Other1>, is_constructible<_Ty2, _Other2>,
-                        negation<conjunction<is_convertible<_Other1, _Ty1>, is_convertible<_Other2, _Ty2>>>>,
-            int> = 0>
-    constexpr explicit pair(_Other1&& _Val1, _Other2&& _Val2) noexcept(
-        is_nothrow_constructible_v<_Ty1, _Other1>&& is_nothrow_constructible_v<_Ty2, _Other2>) // strengthened
-        : first(_STD forward<_Other1>(_Val1)), second(_STD forward<_Other2>(_Val2)) {}
-#endif // ^^^ !_HAS_CONDITIONAL_EXPLICIT ^^^
 
     pair(const pair&) = default;
     pair(pair&&)      = default;
@@ -240,7 +184,6 @@ struct pair { // store a pair of values
         : first(_Right.first), second(_Right.second) {}
 #endif // _HAS_CXX23
 
-#if _HAS_CONDITIONAL_EXPLICIT
     template <class _Other1, class _Other2,
         enable_if_t<conjunction_v<is_constructible<_Ty1, const _Other1&>, is_constructible<_Ty2, const _Other2&>>,
             int> = 0>
@@ -248,50 +191,13 @@ struct pair { // store a pair of values
         pair(const pair<_Other1, _Other2>& _Right) noexcept(is_nothrow_constructible_v<_Ty1, const _Other1&>&&
                 is_nothrow_constructible_v<_Ty2, const _Other2&>) // strengthened
         : first(_Right.first), second(_Right.second) {}
-#else // ^^^ _HAS_CONDITIONAL_EXPLICIT ^^^ / vvv !_HAS_CONDITIONAL_EXPLICIT vvv
-    template <class _Other1, class _Other2,
-        enable_if_t<conjunction_v<is_constructible<_Ty1, const _Other1&>, is_constructible<_Ty2, const _Other2&>,
-                        is_convertible<const _Other1&, _Ty1>, is_convertible<const _Other2&, _Ty2>>,
-            int> = 0>
-    constexpr pair(const pair<_Other1, _Other2>& _Right) noexcept(is_nothrow_constructible_v<_Ty1, const _Other1&>&&
-            is_nothrow_constructible_v<_Ty2, const _Other2&>) // strengthened
-        : first(_Right.first), second(_Right.second) {}
 
-    template <class _Other1, class _Other2,
-        enable_if_t<
-            conjunction_v<is_constructible<_Ty1, const _Other1&>, is_constructible<_Ty2, const _Other2&>,
-                negation<conjunction<is_convertible<const _Other1&, _Ty1>, is_convertible<const _Other2&, _Ty2>>>>,
-            int> = 0>
-    constexpr explicit pair(const pair<_Other1, _Other2>& _Right) noexcept(
-        is_nothrow_constructible_v<_Ty1, const _Other1&>&&
-            is_nothrow_constructible_v<_Ty2, const _Other2&>) // strengthened
-        : first(_Right.first), second(_Right.second) {}
-#endif // ^^^ !_HAS_CONDITIONAL_EXPLICIT ^^^
-
-#if _HAS_CONDITIONAL_EXPLICIT
     template <class _Other1, class _Other2,
         enable_if_t<conjunction_v<is_constructible<_Ty1, _Other1>, is_constructible<_Ty2, _Other2>>, int> = 0>
     constexpr explicit(!conjunction_v<is_convertible<_Other1, _Ty1>, is_convertible<_Other2, _Ty2>>)
         pair(pair<_Other1, _Other2>&& _Right) noexcept(
             is_nothrow_constructible_v<_Ty1, _Other1>&& is_nothrow_constructible_v<_Ty2, _Other2>) // strengthened
         : first(_STD forward<_Other1>(_Right.first)), second(_STD forward<_Other2>(_Right.second)) {}
-#else // ^^^ _HAS_CONDITIONAL_EXPLICIT ^^^ / vvv !_HAS_CONDITIONAL_EXPLICIT vvv
-    template <class _Other1, class _Other2,
-        enable_if_t<conjunction_v<is_constructible<_Ty1, _Other1>, is_constructible<_Ty2, _Other2>,
-                        is_convertible<_Other1, _Ty1>, is_convertible<_Other2, _Ty2>>,
-            int> = 0>
-    constexpr pair(pair<_Other1, _Other2>&& _Right) noexcept(
-        is_nothrow_constructible_v<_Ty1, _Other1>&& is_nothrow_constructible_v<_Ty2, _Other2>) // strengthened
-        : first(_STD forward<_Other1>(_Right.first)), second(_STD forward<_Other2>(_Right.second)) {}
-
-    template <class _Other1, class _Other2,
-        enable_if_t<conjunction_v<is_constructible<_Ty1, _Other1>, is_constructible<_Ty2, _Other2>,
-                        negation<conjunction<is_convertible<_Other1, _Ty1>, is_convertible<_Other2, _Ty2>>>>,
-            int> = 0>
-    constexpr explicit pair(pair<_Other1, _Other2>&& _Right) noexcept(
-        is_nothrow_constructible_v<_Ty1, _Other1>&& is_nothrow_constructible_v<_Ty2, _Other2>) // strengthened
-        : first(_STD forward<_Other1>(_Right.first)), second(_STD forward<_Other2>(_Right.second)) {}
-#endif // ^^^ !_HAS_CONDITIONAL_EXPLICIT ^^^
 
 #if _HAS_CXX23
     template <class _Other1, class _Other2,

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -481,17 +481,6 @@
 #pragma pop_macro("known_semantics")
 #pragma pop_macro("msvc")
 
-// Controls whether the STL uses "conditional explicit" internally
-#ifndef _HAS_CONDITIONAL_EXPLICIT
-#ifdef __cpp_conditional_explicit
-#define _HAS_CONDITIONAL_EXPLICIT 1
-#elif defined(__CUDACC__) || defined(__INTEL_COMPILER)
-#define _HAS_CONDITIONAL_EXPLICIT 0 // TRANSITION, CUDA/ICC
-#else // vvv C1XX or Clang or IntelliSense vvv
-#define _HAS_CONDITIONAL_EXPLICIT 1
-#endif // ^^^ C1XX or Clang or IntelliSense ^^^
-#endif // _HAS_CONDITIONAL_EXPLICIT
-
 // warning C4577: 'noexcept' used with no exception handling mode specified;
 // termination on exception is not guaranteed. Specify /EHsc (/Wall)
 #if _HAS_EXCEPTIONS
@@ -508,11 +497,11 @@
 #endif // !_HAS_CXX17
 
 // warning C5053: support for 'explicit(<expr>)' in C++17 and earlier is a vendor extension
-#if !_HAS_CXX20 && _HAS_CONDITIONAL_EXPLICIT
+#if !_HAS_CXX20
 #define _STL_DISABLED_WARNING_C5053 5053
-#else // !_HAS_CXX20 && _HAS_CONDITIONAL_EXPLICIT
+#else // !_HAS_CXX20
 #define _STL_DISABLED_WARNING_C5053
-#endif // !_HAS_CXX20 && _HAS_CONDITIONAL_EXPLICIT
+#endif // !_HAS_CXX20
 
 #ifndef _STL_EXTRA_DISABLED_WARNINGS
 #define _STL_EXTRA_DISABLED_WARNINGS


### PR DESCRIPTION
Fixes #1301. This is possible now that toolset update #2791 requires CUDA 11.6.0.

Thanks to @AlexGuteniev for verifying that CUDA 11.6.0 supports this, and to @cpplearner for verifying the Intel compiler's behavior. :heart_eyes_cat:

This doesn't affect our primary compilers (MSVC, Clang, EDG IntelliSense), as we were already using the Future Technology codepath for them. It's a massive maintainability improvement, and also a throughput improvement for CUDA.

In `<yvals_core.h>`, I opted to keep the `#if !_HAS_CXX20` order, despite our usual preference to avoid negated tests. This is consistent with `#if !_HAS_CXX17` immediately above, and in this case I think the "if we don't have C++20, then suppress the warning" phrasing is easier to understand than the reverse.