### PR TITLE
My Little Operator: Friendship Is Magic

### DIFF
--- a/stl/inc/array
+++ b/stl/inc/array
@@ -253,6 +253,12 @@ public:
         return _Tmp;
     }
 
+    _NODISCARD_FRIEND _CONSTEXPR17 _Array_const_iterator operator+(
+        const ptrdiff_t _Off, _Array_const_iterator _Next) noexcept {
+        _Next += _Off;
+        return _Next;
+    }
+
 #if !_HAS_CXX20
     _NODISCARD _CONSTEXPR17 bool operator!=(const _Array_const_iterator& _Right) const noexcept {
         return !(*this == _Right);
@@ -280,13 +286,6 @@ constexpr void _Verify_range(
     _First._Verify_with(_Last);
 }
 #endif // _ITERATOR_DEBUG_LEVEL != 0
-
-template <class _Ty, size_t _Size>
-_NODISCARD _CONSTEXPR17 _Array_const_iterator<_Ty, _Size> operator+(
-    const ptrdiff_t _Off, _Array_const_iterator<_Ty, _Size> _Next) noexcept {
-    _Next += _Off;
-    return _Next;
-}
 
 #if _HAS_CXX20
 template <class _Ty, size_t _Size>
@@ -362,6 +361,11 @@ public:
         return _Tmp;
     }
 
+    _NODISCARD_FRIEND _CONSTEXPR17 _Array_iterator operator+(const ptrdiff_t _Off, _Array_iterator _Next) noexcept {
+        _Next += _Off;
+        return _Next;
+    }
+
     _CONSTEXPR17 _Array_iterator& operator-=(const ptrdiff_t _Off) noexcept {
         _Mybase::operator-=(_Off);
         return *this;
@@ -385,13 +389,6 @@ public:
         return const_cast<pointer>(_Mybase::_Unwrapped());
     }
 };
-
-template <class _Ty, size_t _Size>
-_NODISCARD _CONSTEXPR17 _Array_iterator<_Ty, _Size> operator+(
-    const ptrdiff_t _Off, _Array_iterator<_Ty, _Size> _Next) noexcept {
-    _Next += _Off;
-    return _Next;
-}
 
 #if _HAS_CXX20
 template <class _Ty, size_t _Size>

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -4823,6 +4823,14 @@ namespace chrono {
         local_time<_Duration> _Time;
         const string* _Abbrev      = nullptr;
         const seconds* _Offset_sec = nullptr;
+
+        template <class _CharT, class _Traits>
+        friend basic_ostream<_CharT, _Traits>& operator<<(
+            basic_ostream<_CharT, _Traits>& _Os, const _Local_time_format_t& _Val) {
+            // Doesn't appear in the Standard, but allowed by N4885 [global.functions]/2.
+            // Implements N4885 [time.zone.zonedtime.nonmembers]/2 for zoned_time.
+            return _Os << _STD format(_Os.getloc(), _STATICALLY_WIDEN(_CharT, "{:L%F %T %Z}"), _Val);
+        }
     };
 
     template <class _Duration>
@@ -5153,14 +5161,6 @@ namespace chrono {
     template <class _CharT, class _Traits, class _Duration>
     basic_ostream<_CharT, _Traits>& operator<<(basic_ostream<_CharT, _Traits>& _Os, const local_time<_Duration>& _Val) {
         return _Os << sys_time<_Duration>{_Val.time_since_epoch()};
-    }
-
-    template <class _CharT, class _Traits, class _Duration>
-    basic_ostream<_CharT, _Traits>& operator<<(
-        basic_ostream<_CharT, _Traits>& _Os, const _Local_time_format_t<_Duration>& _Val) {
-        // Doesn't appear in the Standard, but allowed by N4885 [global.functions]/2.
-        // Implements N4885 [time.zone.zonedtime.nonmembers]/2 for zoned_time.
-        return _Os << _STD format(_Os.getloc(), _STATICALLY_WIDEN(_CharT, "{:L%F %T %Z}"), _Val);
     }
 
     template <class _CharT, class _Traits, class _Duration, class _TimeZonePtr>

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -4493,6 +4493,12 @@ namespace chrono {
 
         _Time_parse_iomanip_c_str(_Time_parse_iomanip_c_str&&) = delete;
 
+        friend basic_istream<_CharT, _Traits>& operator>>(
+            basic_istream<_CharT, _Traits>& _Is, _Time_parse_iomanip_c_str&& _Tpi) {
+            from_stream(_Is, _Tpi._Fmt, _Tpi._Tp, _Tpi._Abbrev, _Tpi._Offset); // intentional ADL
+            return _Is;
+        }
+
         const _CharT* _Fmt;
         _Parsable& _Tp;
         basic_string<_CharT, _Traits, _Alloc>* _Abbrev;
@@ -4506,6 +4512,12 @@ namespace chrono {
             : _Fmt{_Fmt_}, _Tp{_Tp_}, _Abbrev{_Abbrev_}, _Offset{_Offset_} {}
 
         _Time_parse_iomanip(_Time_parse_iomanip&&) = delete;
+
+        friend basic_istream<_CharT, _Traits>& operator>>(
+            basic_istream<_CharT, _Traits>& _Is, _Time_parse_iomanip&& _Tpi) {
+            from_stream(_Is, _Tpi._Fmt.c_str(), _Tpi._Tp, _Tpi._Abbrev, _Tpi._Offset); // intentional ADL
+            return _Is;
+        }
 
         const basic_string<_CharT, _Traits, _Alloc>& _Fmt;
         _Parsable& _Tp;
@@ -4568,21 +4580,6 @@ namespace chrono {
         basic_string<_CharT, _Traits, _Alloc>& _Abbrev, minutes& _Offset) {
         return _Time_parse_iomanip{_Fmt, _Tp, _STD addressof(_Abbrev), &_Offset};
     }
-
-    template <class _CharT, class _Traits, class _Alloc, class _Parsable>
-    basic_istream<_CharT, _Traits>& operator>>(
-        basic_istream<_CharT, _Traits>& _Is, _Time_parse_iomanip_c_str<_CharT, _Traits, _Alloc, _Parsable>&& _Tpi) {
-        from_stream(_Is, _Tpi._Fmt, _Tpi._Tp, _Tpi._Abbrev, _Tpi._Offset); // intentional ADL
-        return _Is;
-    }
-
-    template <class _CharT, class _Traits, class _Alloc, class _Parsable>
-    basic_istream<_CharT, _Traits>& operator>>(
-        basic_istream<_CharT, _Traits>& _Is, _Time_parse_iomanip<_CharT, _Traits, _Alloc, _Parsable>&& _Tpi) {
-        from_stream(_Is, _Tpi._Fmt.c_str(), _Tpi._Tp, _Tpi._Abbrev, _Tpi._Offset); // intentional ADL
-        return _Is;
-    }
-
 } // namespace chrono
 
 #ifdef __cpp_lib_format

--- a/stl/inc/deque
+++ b/stl/inc/deque
@@ -85,6 +85,12 @@ public:
         return _Tmp;
     }
 
+    _NODISCARD_FRIEND _Deque_unchecked_const_iterator operator+(
+        const difference_type _Off, _Deque_unchecked_const_iterator _Next) noexcept {
+        _Next += _Off;
+        return _Next;
+    }
+
     _Deque_unchecked_const_iterator& operator-=(const difference_type _Off) noexcept {
         _Myoff -= _Off;
         return *this;
@@ -143,14 +149,6 @@ public:
 };
 
 template <class _Mydeque>
-_NODISCARD _Deque_unchecked_const_iterator<_Mydeque> operator+(
-    typename _Deque_unchecked_const_iterator<_Mydeque>::difference_type _Off,
-    _Deque_unchecked_const_iterator<_Mydeque> _Next) noexcept {
-    _Next += _Off;
-    return _Next;
-}
-
-template <class _Mydeque>
 class _Deque_unchecked_iterator : public _Deque_unchecked_const_iterator<_Mydeque> {
 private:
     using _Size_type = typename _Mydeque::size_type;
@@ -207,6 +205,12 @@ public:
         return _Tmp;
     }
 
+    _NODISCARD_FRIEND _Deque_unchecked_iterator operator+(
+        const difference_type _Off, _Deque_unchecked_iterator _Next) noexcept {
+        _Next += _Off;
+        return _Next;
+    }
+
     _Deque_unchecked_iterator& operator-=(const difference_type _Off) noexcept {
         _Mybase::operator-=(_Off);
         return *this;
@@ -226,14 +230,6 @@ public:
         return const_cast<reference>(_Mybase::operator[](_Off));
     }
 };
-
-template <class _Mydeque>
-_NODISCARD _Deque_unchecked_iterator<_Mydeque> operator+(
-    typename _Deque_unchecked_iterator<_Mydeque>::difference_type _Off,
-    _Deque_unchecked_iterator<_Mydeque> _Next) noexcept {
-    _Next += _Off;
-    return _Next;
-}
 
 template <class _Mydeque>
 class _Deque_const_iterator : public _Iterator_base12 {
@@ -330,6 +326,12 @@ public:
         _Deque_const_iterator _Tmp = *this;
         _Tmp += _Off;
         return _Tmp;
+    }
+
+    _NODISCARD_FRIEND _Deque_const_iterator operator+(
+        const difference_type _Off, _Deque_const_iterator _Next) noexcept {
+        _Next += _Off;
+        return _Next;
     }
 
     _Deque_const_iterator& operator-=(const difference_type _Off) noexcept {
@@ -431,13 +433,6 @@ public:
 };
 
 template <class _Mydeque>
-_NODISCARD _Deque_const_iterator<_Mydeque> operator+(
-    typename _Deque_const_iterator<_Mydeque>::difference_type _Off, _Deque_const_iterator<_Mydeque> _Next) noexcept {
-    _Next += _Off;
-    return _Next;
-}
-
-template <class _Mydeque>
 class _Deque_iterator : public _Deque_const_iterator<_Mydeque> {
 private:
     using _Size_type = typename _Mydeque::size_type;
@@ -495,6 +490,11 @@ public:
         return _Tmp;
     }
 
+    _NODISCARD_FRIEND _Deque_iterator operator+(const difference_type _Off, _Deque_iterator _Next) noexcept {
+        _Next += _Off;
+        return _Next;
+    }
+
     _Deque_iterator& operator-=(const difference_type _Off) noexcept {
         _Mybase::operator-=(_Off);
         return *this;
@@ -518,13 +518,6 @@ public:
         return {this->_Myoff, this->_Getcont()};
     }
 };
-
-template <class _Mydeque>
-_NODISCARD _Deque_iterator<_Mydeque> operator+(
-    typename _Deque_iterator<_Mydeque>::difference_type _Off, _Deque_iterator<_Mydeque> _Next) noexcept {
-    _Next += _Off;
-    return _Next;
-}
 
 template <class _Value_type, class _Size_type, class _Difference_type, class _Pointer, class _Const_pointer,
     class _Reference, class _Const_reference, class _Mapptr_type>

--- a/stl/inc/iomanip
+++ b/stl/inc/iomanip
@@ -191,6 +191,94 @@ struct _Quote_out { // store pointer/length for string
 
     _Quote_out(const _Quote_out&) = default;
 
+    template <class _OsTraits, class _QuTraits = _Traits>
+    friend basic_ostream<_Elem, _OsTraits>& operator<<(
+        basic_ostream<_Elem, _OsTraits>& _Ostr, const _Quote_out& _Manip) {
+        // put quoted string to output stream
+        static_assert(
+            is_void_v<_QuTraits> || is_same_v<_QuTraits, _OsTraits>, "quoted() traits must match basic_ostream traits");
+
+        using _Myos = basic_ostream<_Elem, _OsTraits>;
+
+        const _Elem* const _Last = _Manip._Ptr + _Manip._Size;
+
+        _Sizet _Size = _Manip._Size + 2; // allow for delimiters
+        for (const _Elem* _Ptr = _Manip._Ptr; _Ptr != _Last; ++_Ptr) {
+            if (_OsTraits::eq(*_Ptr, _Manip._Delim) || _OsTraits::eq(*_Ptr, _Manip._Escape)) {
+                ++_Size; // count escapes
+            }
+        }
+
+        ios_base::iostate _State = ios_base::goodbit;
+
+        _Sizet _Pad;
+        if (_Ostr.width() <= 0 || static_cast<_Sizet>(_Ostr.width()) <= _Size) {
+            _Pad = 0;
+        } else {
+            _Pad = static_cast<_Sizet>(_Ostr.width()) - _Size;
+        }
+
+        const typename _Myos::sentry _Ok(_Ostr);
+
+        if (!_Ok) {
+            _State |= ios_base::badbit;
+        } else { // state okay, insert characters
+            _TRY_IO_BEGIN
+            if ((_Ostr.flags() & ios_base::adjustfield) != ios_base::left) {
+                for (; 0 < _Pad; --_Pad) { // pad on left
+                    if (_OsTraits::eq_int_type(_OsTraits::eof(), _Ostr.rdbuf()->sputc(_Ostr.fill()))) {
+                        _State |= ios_base::badbit; // insertion failed, quit
+                        break;
+                    }
+                }
+            }
+
+            if (_State == ios_base::goodbit
+                && _OsTraits::eq_int_type(_OsTraits::eof(),
+                    _Ostr.rdbuf()->sputc(_Manip._Delim))) { // put delimiter
+                _State |= ios_base::badbit;
+            }
+
+            for (const _Elem* _Ptr = _Manip._Ptr; _Ptr != _Last; ++_Ptr) { // put (possibly escaped) element
+                if ((_OsTraits::eq(*_Ptr, _Manip._Delim) || _OsTraits::eq(*_Ptr, _Manip._Escape))
+                    && _State == ios_base::goodbit
+                    && _OsTraits::eq_int_type(_OsTraits::eof(),
+                        _Ostr.rdbuf()->sputc(_Manip._Escape))) { // put escape
+                    _State |= ios_base::badbit; // insertion failed, quit
+                    break;
+                }
+
+                if (_State == ios_base::goodbit
+                    && _OsTraits::eq_int_type(_OsTraits::eof(),
+                        _Ostr.rdbuf()->sputc(*_Ptr))) { // put element
+                    _State |= ios_base::badbit; // insertion failed, quit
+                    break;
+                }
+            }
+
+            if (_State == ios_base::goodbit
+                && _OsTraits::eq_int_type(_OsTraits::eof(),
+                    _Ostr.rdbuf()->sputc(_Manip._Delim))) { // put delimiter
+                _State |= ios_base::badbit;
+            }
+
+            if (_State == ios_base::goodbit) {
+                for (; 0 < _Pad; --_Pad) { // pad on right
+                    if (_OsTraits::eq_int_type(_OsTraits::eof(), _Ostr.rdbuf()->sputc(_Ostr.fill()))) {
+                        _State |= ios_base::badbit; // insertion failed, quit
+                        break;
+                    }
+                }
+            }
+
+            _Ostr.width(0);
+            _CATCH_IO_(ios_base, _Ostr)
+        }
+
+        _Ostr.setstate(_State);
+        return _Ostr;
+    }
+
     const _Elem* _Ptr; // pointer to string
     _Sizet _Size; // length of string
     _Elem _Delim; // delimiter element
@@ -236,92 +324,6 @@ template <class _Elem, class _Traits, class _Alloc>
 _NODISCARD _Quote_in<_Elem, _Traits, _Alloc> quoted(
     basic_string<_Elem, _Traits, _Alloc>& _Str, _Elem _Delim = _Elem('"'), _Elem _Escape = _Elem('\\')) {
     return {_Str, _Delim, _Escape};
-}
-
-template <class _Elem, class _Traits, class _QuTraits, class _Sizet>
-basic_ostream<_Elem, _Traits>& operator<<(basic_ostream<_Elem, _Traits>& _Ostr,
-    const _Quote_out<_Elem, _QuTraits, _Sizet>& _Manip) { // put quoted string to output stream
-    static_assert(
-        is_void_v<_QuTraits> || is_same_v<_QuTraits, _Traits>, "quoted() traits must match basic_ostream traits");
-
-    using _Myos = basic_ostream<_Elem, _Traits>;
-
-    const _Elem* const _Last = _Manip._Ptr + _Manip._Size;
-
-    _Sizet _Size = _Manip._Size + 2; // allow for delimiters
-    for (const _Elem* _Ptr = _Manip._Ptr; _Ptr != _Last; ++_Ptr) {
-        if (_Traits::eq(*_Ptr, _Manip._Delim) || _Traits::eq(*_Ptr, _Manip._Escape)) {
-            ++_Size; // count escapes
-        }
-    }
-
-    ios_base::iostate _State = ios_base::goodbit;
-
-    _Sizet _Pad;
-    if (_Ostr.width() <= 0 || static_cast<_Sizet>(_Ostr.width()) <= _Size) {
-        _Pad = 0;
-    } else {
-        _Pad = static_cast<_Sizet>(_Ostr.width()) - _Size;
-    }
-
-    const typename _Myos::sentry _Ok(_Ostr);
-
-    if (!_Ok) {
-        _State |= ios_base::badbit;
-    } else { // state okay, insert characters
-        _TRY_IO_BEGIN
-        if ((_Ostr.flags() & ios_base::adjustfield) != ios_base::left) {
-            for (; 0 < _Pad; --_Pad) { // pad on left
-                if (_Traits::eq_int_type(_Traits::eof(), _Ostr.rdbuf()->sputc(_Ostr.fill()))) {
-                    _State |= ios_base::badbit; // insertion failed, quit
-                    break;
-                }
-            }
-        }
-
-        if (_State == ios_base::goodbit
-            && _Traits::eq_int_type(_Traits::eof(),
-                _Ostr.rdbuf()->sputc(_Manip._Delim))) { // put delimiter
-            _State |= ios_base::badbit;
-        }
-
-        for (const _Elem* _Ptr = _Manip._Ptr; _Ptr != _Last; ++_Ptr) { // put (possibly escaped) element
-            if ((_Traits::eq(*_Ptr, _Manip._Delim) || _Traits::eq(*_Ptr, _Manip._Escape)) && _State == ios_base::goodbit
-                && _Traits::eq_int_type(_Traits::eof(),
-                    _Ostr.rdbuf()->sputc(_Manip._Escape))) { // put escape
-                _State |= ios_base::badbit; // insertion failed, quit
-                break;
-            }
-
-            if (_State == ios_base::goodbit
-                && _Traits::eq_int_type(_Traits::eof(),
-                    _Ostr.rdbuf()->sputc(*_Ptr))) { // put element
-                _State |= ios_base::badbit; // insertion failed, quit
-                break;
-            }
-        }
-
-        if (_State == ios_base::goodbit
-            && _Traits::eq_int_type(_Traits::eof(),
-                _Ostr.rdbuf()->sputc(_Manip._Delim))) { // put delimiter
-            _State |= ios_base::badbit;
-        }
-
-        if (_State == ios_base::goodbit) {
-            for (; 0 < _Pad; --_Pad) { // pad on right
-                if (_Traits::eq_int_type(_Traits::eof(), _Ostr.rdbuf()->sputc(_Ostr.fill()))) {
-                    _State |= ios_base::badbit; // insertion failed, quit
-                    break;
-                }
-            }
-        }
-
-        _Ostr.width(0);
-        _CATCH_IO_(ios_base, _Ostr)
-    }
-
-    _Ostr.setstate(_State);
-    return _Ostr;
 }
 
 template <class _Elem, class _Traits, class _Alloc>

--- a/stl/inc/iomanip
+++ b/stl/inc/iomanip
@@ -25,30 +25,30 @@ template <class _Elem>
 struct _Fillobj { // store fill character
     _Fillobj(_Elem _Ch) : _Fill(_Ch) {}
 
+    template <class _Elem2, class _Traits>
+    friend basic_istream<_Elem2, _Traits>& operator>>(basic_istream<_Elem2, _Traits>& _Istr, const _Fillobj& _Manip) {
+        // set fill character in input stream
+        static_assert(is_same_v<_Elem, _Elem2>, "wrong character type for setfill");
+
+        _Istr.fill(_Manip._Fill);
+        return _Istr;
+    }
+
+    template <class _Elem2, class _Traits>
+    friend basic_ostream<_Elem2, _Traits>& operator<<(basic_ostream<_Elem2, _Traits>& _Ostr, const _Fillobj& _Manip) {
+        // set fill character in output stream
+        static_assert(is_same_v<_Elem, _Elem2>, "wrong character type for setfill");
+
+        _Ostr.fill(_Manip._Fill);
+        return _Ostr;
+    }
+
     _Elem _Fill; // the fill character
 };
 
 template <class _Elem>
 _NODISCARD _Fillobj<_Elem> setfill(_Elem _Ch) {
     return _Fillobj<_Elem>(_Ch);
-}
-
-template <class _Elem, class _Traits, class _Elem2>
-basic_istream<_Elem, _Traits>& operator>>(basic_istream<_Elem, _Traits>& _Istr,
-    const _Fillobj<_Elem2>& _Manip) { // set fill character in input stream
-    static_assert(is_same_v<_Elem, _Elem2>, "wrong character type for setfill");
-
-    _Istr.fill(_Manip._Fill);
-    return _Istr;
-}
-
-template <class _Elem, class _Traits, class _Elem2>
-basic_ostream<_Elem, _Traits>& operator<<(basic_ostream<_Elem, _Traits>& _Ostr,
-    const _Fillobj<_Elem2>& _Manip) { // set fill character in output stream
-    static_assert(is_same_v<_Elem, _Elem2>, "wrong character type for setfill");
-
-    _Ostr.fill(_Manip._Fill);
-    return _Ostr;
 }
 
 template <class _Money>

--- a/stl/inc/iomanip
+++ b/stl/inc/iomanip
@@ -184,18 +184,6 @@ _NODISCARD _Timeobj<_Elem, const tm*> put_time(const tm* _Tptr_arg, const _Elem*
     return _Timeobj<_Elem, const tm*>(_Tptr_arg, _Fmt_arg);
 }
 
-template <class _Elem, class _Traits, class _Alloc>
-struct _Quote_in { // store reference to string
-    using _Mystr = basic_string<_Elem, _Traits, _Alloc>;
-
-    _Quote_in(_Mystr& _Str_obj, _Elem _Delim_obj, _Elem _Escape_obj)
-        : _Str(_Str_obj), _Delim(_Delim_obj), _Escape(_Escape_obj) {}
-
-    _Mystr& _Str; // reference to string
-    _Elem _Delim; // delimiter element
-    _Elem _Escape; // escape element
-};
-
 template <class _Elem, class _Traits, class _Sizet>
 struct _Quote_out { // store pointer/length for string
     _Quote_out(const _Elem* _Ptr_obj, _Sizet _Size_obj, _Elem _Delim_obj, _Elem _Escape_obj)
@@ -209,6 +197,18 @@ struct _Quote_out { // store pointer/length for string
     _Elem _Escape; // escape element
 
     _Quote_out& operator=(const _Quote_out&) = delete;
+};
+
+template <class _Elem, class _Traits, class _Alloc>
+struct _Quote_in { // store reference to string
+    using _Mystr = basic_string<_Elem, _Traits, _Alloc>;
+
+    _Quote_in(_Mystr& _Str_obj, _Elem _Delim_obj, _Elem _Escape_obj)
+        : _Str(_Str_obj), _Delim(_Delim_obj), _Escape(_Escape_obj) {}
+
+    _Mystr& _Str; // reference to string
+    _Elem _Delim; // delimiter element
+    _Elem _Escape; // escape element
 };
 
 template <class _Elem>

--- a/stl/inc/iomanip
+++ b/stl/inc/iomanip
@@ -294,6 +294,13 @@ struct _Quote_in { // store reference to string
     _Quote_in(_Mystr& _Str_obj, _Elem _Delim_obj, _Elem _Escape_obj)
         : _Str(_Str_obj), _Delim(_Delim_obj), _Escape(_Escape_obj) {}
 
+    friend basic_ostream<_Elem, _Traits>& operator<<(basic_ostream<_Elem, _Traits>& _Ostr, const _Quote_in& _Manip) {
+        // put quoted string to output stream
+        using _Out_type = _Quote_out<_Elem, _Traits, typename _Mystr::size_type>;
+
+        return _Ostr << _Out_type{_Manip._Str.c_str(), _Manip._Str.size(), _Manip._Delim, _Manip._Escape};
+    }
+
     _Mystr& _Str; // reference to string
     _Elem _Delim; // delimiter element
     _Elem _Escape; // escape element
@@ -324,15 +331,6 @@ template <class _Elem, class _Traits, class _Alloc>
 _NODISCARD _Quote_in<_Elem, _Traits, _Alloc> quoted(
     basic_string<_Elem, _Traits, _Alloc>& _Str, _Elem _Delim = _Elem('"'), _Elem _Escape = _Elem('\\')) {
     return {_Str, _Delim, _Escape};
-}
-
-template <class _Elem, class _Traits, class _Alloc>
-basic_ostream<_Elem, _Traits>& operator<<(basic_ostream<_Elem, _Traits>& _Ostr,
-    const _Quote_in<_Elem, _Traits, _Alloc>& _Manip) { // put quoted string to output stream
-    using _Mystr = basic_string<_Elem, _Traits, _Alloc>;
-
-    const _Mystr& _Ref = _Manip._Str;
-    return _Ostr << _STD quoted(_Ref, _Manip._Delim, _Manip._Escape);
 }
 
 template <class _Elem, class _Traits, class _Alloc>

--- a/stl/inc/iomanip
+++ b/stl/inc/iomanip
@@ -384,23 +384,23 @@ template <class _Arg>
 struct _Smanip { // store function pointer and argument value
     _Smanip(void(__cdecl* _Left)(ios_base&, _Arg), _Arg _Val) : _Pfun(_Left), _Manarg(_Val) {}
 
+    template <class _Elem, class _Traits>
+    friend basic_istream<_Elem, _Traits>& operator>>(basic_istream<_Elem, _Traits>& _Istr, const _Smanip& _Manip) {
+        // extract by calling function with input stream and argument
+        (*_Manip._Pfun)(_Istr, _Manip._Manarg);
+        return _Istr;
+    }
+
+    template <class _Elem, class _Traits>
+    friend basic_ostream<_Elem, _Traits>& operator<<(basic_ostream<_Elem, _Traits>& _Ostr, const _Smanip& _Manip) {
+        // insert by calling function with output stream and argument
+        (*_Manip._Pfun)(_Ostr, _Manip._Manarg);
+        return _Ostr;
+    }
+
     void(__cdecl* _Pfun)(ios_base&, _Arg); // the function pointer
     _Arg _Manarg; // the argument value
 };
-
-template <class _Elem, class _Traits, class _Arg>
-basic_istream<_Elem, _Traits>& operator>>(basic_istream<_Elem, _Traits>& _Istr,
-    const _Smanip<_Arg>& _Manip) { // extract by calling function with input stream and argument
-    (*_Manip._Pfun)(_Istr, _Manip._Manarg);
-    return _Istr;
-}
-
-template <class _Elem, class _Traits, class _Arg>
-basic_ostream<_Elem, _Traits>& operator<<(basic_ostream<_Elem, _Traits>& _Ostr,
-    const _Smanip<_Arg>& _Manip) { // insert by calling function with output stream and argument
-    (*_Manip._Pfun)(_Ostr, _Manip._Manarg);
-    return _Ostr;
-}
 
 _NODISCARD _MRTIMP2 _Smanip<ios_base::fmtflags> __cdecl resetiosflags(ios_base::fmtflags);
 _NODISCARD _MRTIMP2 _Smanip<ios_base::fmtflags> __cdecl setiosflags(ios_base::fmtflags);

--- a/stl/inc/iomanip
+++ b/stl/inc/iomanip
@@ -301,6 +301,52 @@ struct _Quote_in { // store reference to string
         return _Ostr << _Out_type{_Manip._Str.c_str(), _Manip._Str.size(), _Manip._Delim, _Manip._Escape};
     }
 
+    friend basic_istream<_Elem, _Traits>& operator>>(basic_istream<_Elem, _Traits>& _Istr, const _Quote_in& _Manip) {
+        // get quoted string from input stream
+        ios_base::iostate _State = ios_base::goodbit;
+        const typename basic_istream<_Elem, _Traits>::sentry _Ok(_Istr);
+
+        if (_Ok) { // state okay, extract characters
+            _TRY_IO_BEGIN
+            const auto _Buf   = _Istr.rdbuf();
+            auto& _Str        = _Manip._Str;
+            const auto _Delim = _Traits::to_int_type(_Manip._Delim);
+            auto _Meta        = _Buf->sgetc();
+
+            if (!_Traits::eq_int_type(_Meta, _Delim)) { // no leading delimiter
+                return _Istr >> _Str;
+            }
+
+            const auto _Escape = _Traits::to_int_type(_Manip._Escape);
+            _Str.clear();
+            for (;;) {
+                _Meta = _Buf->snextc();
+                if (_Traits::eq_int_type(_Traits::eof(), _Meta)) { // no trailing delimiter; fail
+                    _State = ios_base::eofbit | ios_base::failbit;
+                    break;
+                } else if (_Traits::eq_int_type(_Meta, _Escape)) { // escape; read next character literally
+                    _Meta = _Buf->snextc();
+                    if (_Traits::eq_int_type(_Traits::eof(), _Meta)) { // bad escape; fail
+                        _State = ios_base::eofbit | ios_base::failbit;
+                        break;
+                    }
+                } else if (_Traits::eq_int_type(_Meta, _Delim)) { // found trailing delimiter
+                    if (_Traits::eq_int_type(_Traits::eof(), _Buf->sbumpc())) { // consume trailing delimiter
+                        _State = ios_base::eofbit;
+                    }
+
+                    break;
+                }
+
+                _Str.push_back(_Traits::to_char_type(_Meta));
+            }
+            _CATCH_IO_(ios_base, _Istr)
+        }
+
+        _Istr.setstate(_State);
+        return _Istr;
+    }
+
     _Mystr& _Str; // reference to string
     _Elem _Delim; // delimiter element
     _Elem _Escape; // escape element
@@ -331,53 +377,6 @@ template <class _Elem, class _Traits, class _Alloc>
 _NODISCARD _Quote_in<_Elem, _Traits, _Alloc> quoted(
     basic_string<_Elem, _Traits, _Alloc>& _Str, _Elem _Delim = _Elem('"'), _Elem _Escape = _Elem('\\')) {
     return {_Str, _Delim, _Escape};
-}
-
-template <class _Elem, class _Traits, class _Alloc>
-basic_istream<_Elem, _Traits>& operator>>(basic_istream<_Elem, _Traits>& _Istr,
-    const _Quote_in<_Elem, _Traits, _Alloc>& _Manip) { // get quoted string from input stream
-    ios_base::iostate _State = ios_base::goodbit;
-    const typename basic_istream<_Elem, _Traits>::sentry _Ok(_Istr);
-
-    if (_Ok) { // state okay, extract characters
-        _TRY_IO_BEGIN
-        const auto _Buf   = _Istr.rdbuf();
-        auto& _Str        = _Manip._Str;
-        const auto _Delim = _Traits::to_int_type(_Manip._Delim);
-        auto _Meta        = _Buf->sgetc();
-
-        if (!_Traits::eq_int_type(_Meta, _Delim)) { // no leading delimiter
-            return _Istr >> _Str;
-        }
-
-        const auto _Escape = _Traits::to_int_type(_Manip._Escape);
-        _Str.clear();
-        for (;;) {
-            _Meta = _Buf->snextc();
-            if (_Traits::eq_int_type(_Traits::eof(), _Meta)) { // no trailing delimiter; fail
-                _State = ios_base::eofbit | ios_base::failbit;
-                break;
-            } else if (_Traits::eq_int_type(_Meta, _Escape)) { // escape; read next character literally
-                _Meta = _Buf->snextc();
-                if (_Traits::eq_int_type(_Traits::eof(), _Meta)) { // bad escape; fail
-                    _State = ios_base::eofbit | ios_base::failbit;
-                    break;
-                }
-            } else if (_Traits::eq_int_type(_Meta, _Delim)) { // found trailing delimiter
-                if (_Traits::eq_int_type(_Traits::eof(), _Buf->sbumpc())) { // consume trailing delimiter
-                    _State = ios_base::eofbit;
-                }
-
-                break;
-            }
-
-            _Str.push_back(_Traits::to_char_type(_Meta));
-        }
-        _CATCH_IO_(ios_base, _Istr)
-    }
-
-    _Istr.setstate(_State);
-    return _Istr;
 }
 
 template <class _Arg>

--- a/stl/inc/iomanip
+++ b/stl/inc/iomanip
@@ -55,6 +55,50 @@ template <class _Money>
 struct _Monobj { // store reference to monetary amount
     _Monobj(_Money& _Val_arg, bool _Intl_arg) : _Val(_Val_arg), _Intl(_Intl_arg) {}
 
+    template <class _Elem, class _Traits>
+    friend basic_istream<_Elem, _Traits>& operator>>(basic_istream<_Elem, _Traits>& _Istr, const _Monobj& _Manip) {
+        // get monetary amount from input stream
+        using _Myis   = basic_istream<_Elem, _Traits>;
+        using _Iter   = istreambuf_iterator<_Elem, _Traits>;
+        using _Mymget = money_get<_Elem, _Iter>;
+
+        ios_base::iostate _State = ios_base::goodbit;
+        const typename _Myis::sentry _Ok(_Istr);
+
+        if (_Ok) { // state okay, extract monetary amount
+            const _Mymget& _Mget_fac = _STD use_facet<_Mymget>(_Istr.getloc());
+            _TRY_IO_BEGIN
+            _Mget_fac.get(_Iter(_Istr.rdbuf()), _Iter(nullptr), _Manip._Intl, _Istr, _State, _Manip._Val);
+            _CATCH_IO_(ios_base, _Istr)
+        }
+
+        _Istr.setstate(_State);
+        return _Istr;
+    }
+
+    template <class _Elem, class _Traits>
+    friend basic_ostream<_Elem, _Traits>& operator<<(basic_ostream<_Elem, _Traits>& _Ostr, const _Monobj& _Manip) {
+        // put monetary amount to output stream
+        using _Myos   = basic_ostream<_Elem, _Traits>;
+        using _Iter   = ostreambuf_iterator<_Elem, _Traits>;
+        using _Mymput = money_put<_Elem, _Iter>;
+
+        ios_base::iostate _State = ios_base::goodbit;
+        const typename _Myos::sentry _Ok(_Ostr);
+
+        if (_Ok) { // state okay, insert monetary amount
+            const _Mymput& _Mput_fac = _STD use_facet<_Mymput>(_Ostr.getloc());
+            _TRY_IO_BEGIN
+            if (_Mput_fac.put(_Iter(_Ostr.rdbuf()), _Manip._Intl, _Ostr, _Ostr.fill(), _Manip._Val).failed()) {
+                _State |= ios_base::badbit;
+            }
+            _CATCH_IO_(ios_base, _Ostr)
+        }
+
+        _Ostr.setstate(_State);
+        return _Ostr;
+    }
+
     _Money& _Val; // the monetary amount reference
     bool _Intl; // international flag
 };
@@ -64,53 +108,9 @@ _NODISCARD _Monobj<_Money> get_money(_Money& _Val_arg, bool _Intl_arg = false) {
     return _Monobj<_Money>(_Val_arg, _Intl_arg);
 }
 
-template <class _Elem, class _Traits, class _Money>
-basic_istream<_Elem, _Traits>& operator>>(basic_istream<_Elem, _Traits>& _Istr,
-    const _Monobj<_Money>& _Manip) { // get monetary amount from input stream
-    using _Myis   = basic_istream<_Elem, _Traits>;
-    using _Iter   = istreambuf_iterator<_Elem, _Traits>;
-    using _Mymget = money_get<_Elem, _Iter>;
-
-    ios_base::iostate _State = ios_base::goodbit;
-    const typename _Myis::sentry _Ok(_Istr);
-
-    if (_Ok) { // state okay, extract monetary amount
-        const _Mymget& _Mget_fac = _STD use_facet<_Mymget>(_Istr.getloc());
-        _TRY_IO_BEGIN
-        _Mget_fac.get(_Iter(_Istr.rdbuf()), _Iter(nullptr), _Manip._Intl, _Istr, _State, _Manip._Val);
-        _CATCH_IO_(ios_base, _Istr)
-    }
-
-    _Istr.setstate(_State);
-    return _Istr;
-}
-
 template <class _Money>
 _NODISCARD _Monobj<const _Money> put_money(const _Money& _Val_arg, bool _Intl_arg = false) {
     return _Monobj<const _Money>(_Val_arg, _Intl_arg);
-}
-
-template <class _Elem, class _Traits, class _Money>
-basic_ostream<_Elem, _Traits>& operator<<(basic_ostream<_Elem, _Traits>& _Ostr,
-    const _Monobj<_Money>& _Manip) { // put monetary amount to output stream
-    using _Myos   = basic_ostream<_Elem, _Traits>;
-    using _Iter   = ostreambuf_iterator<_Elem, _Traits>;
-    using _Mymput = money_put<_Elem, _Iter>;
-
-    ios_base::iostate _State = ios_base::goodbit;
-    const typename _Myos::sentry _Ok(_Ostr);
-
-    if (_Ok) { // state okay, insert monetary amount
-        const _Mymput& _Mput_fac = _STD use_facet<_Mymput>(_Ostr.getloc());
-        _TRY_IO_BEGIN
-        if (_Mput_fac.put(_Iter(_Ostr.rdbuf()), _Manip._Intl, _Ostr, _Ostr.fill(), _Manip._Val).failed()) {
-            _State |= ios_base::badbit;
-        }
-        _CATCH_IO_(ios_base, _Ostr)
-    }
-
-    _Ostr.setstate(_State);
-    return _Ostr;
 }
 
 template <class _Elem, class _Ptr>

--- a/stl/inc/iomanip
+++ b/stl/inc/iomanip
@@ -120,6 +120,55 @@ struct _Timeobj { // store reference to tm object and format
         }
     }
 
+    template <class _Elem2, class _Traits>
+    friend basic_istream<_Elem2, _Traits>& operator>>(basic_istream<_Elem2, _Traits>& _Istr, const _Timeobj& _Manip) {
+        // get time information from input stream
+        static_assert(is_same_v<_Elem, _Elem2>, "wrong character type for get_time");
+
+        using _Myis   = basic_istream<_Elem, _Traits>;
+        using _Iter   = istreambuf_iterator<_Elem, _Traits>;
+        using _Mytget = time_get<_Elem, _Iter>;
+
+        ios_base::iostate _State = ios_base::goodbit;
+        const typename _Myis::sentry _Ok(_Istr);
+
+        if (_Ok) { // state okay, extract time amounts
+            const _Mytget& _Tget_fac = _STD use_facet<_Mytget>(_Istr.getloc());
+            _TRY_IO_BEGIN
+            _Tget_fac.get(
+                _Iter(_Istr.rdbuf()), _Iter(nullptr), _Istr, _State, _Manip._Tptr, _Manip._Fmtfirst, _Manip._Fmtlast);
+            _CATCH_IO_(ios_base, _Istr)
+        }
+
+        _Istr.setstate(_State);
+        return _Istr;
+    }
+
+    template <class _Elem2, class _Traits>
+    friend basic_ostream<_Elem2, _Traits>& operator<<(basic_ostream<_Elem2, _Traits>& _Ostr, const _Timeobj& _Manip) {
+        // put time information to output stream
+        static_assert(is_same_v<_Elem, _Elem2>, "wrong character type for put_time");
+
+        using _Myos   = basic_ostream<_Elem, _Traits>;
+        using _Iter   = ostreambuf_iterator<_Elem, _Traits>;
+        using _Mytput = time_put<_Elem, _Iter>;
+
+        const typename _Myos::sentry _Ok(_Ostr);
+
+        if (_Ok) { // state okay, insert monetary amount
+            const _Mytput& _Tput_fac = _STD use_facet<_Mytput>(_Ostr.getloc());
+            _TRY_IO_BEGIN
+            if (_Tput_fac
+                    .put(_Iter(_Ostr.rdbuf()), _Ostr, _Ostr.fill(), _Manip._Tptr, _Manip._Fmtfirst, _Manip._Fmtlast)
+                    .failed()) {
+                _Ostr.setstate(ios_base::badbit);
+            }
+            _CATCH_IO_(ios_base, _Ostr)
+        }
+
+        return _Ostr;
+    }
+
     _Ptr _Tptr; // the tm struct pointer
     const _Elem* _Fmtfirst; // format string start
     const _Elem* _Fmtlast; // format string end
@@ -130,57 +179,9 @@ _NODISCARD _Timeobj<_Elem, tm*> get_time(tm* _Tptr_arg, const _Elem* _Fmt_arg) {
     return _Timeobj<_Elem, tm*>(_Tptr_arg, _Fmt_arg);
 }
 
-template <class _Elem, class _Traits, class _Elem2>
-basic_istream<_Elem, _Traits>& operator>>(basic_istream<_Elem, _Traits>& _Istr,
-    const _Timeobj<_Elem2, tm*>& _Manip) { // get time information from input stream
-    using _Myis   = basic_istream<_Elem, _Traits>;
-    using _Iter   = istreambuf_iterator<_Elem, _Traits>;
-    using _Mytget = time_get<_Elem2, _Iter>;
-
-    static_assert(is_same_v<_Elem, _Elem2>, "wrong character type for get_time");
-
-    ios_base::iostate _State = ios_base::goodbit;
-    const typename _Myis::sentry _Ok(_Istr);
-
-    if (_Ok) { // state okay, extract time amounts
-        const _Mytget& _Tget_fac = _STD use_facet<_Mytget>(_Istr.getloc());
-        _TRY_IO_BEGIN
-        _Tget_fac.get(
-            _Iter(_Istr.rdbuf()), _Iter(nullptr), _Istr, _State, _Manip._Tptr, _Manip._Fmtfirst, _Manip._Fmtlast);
-        _CATCH_IO_(ios_base, _Istr)
-    }
-
-    _Istr.setstate(_State);
-    return _Istr;
-}
-
 template <class _Elem>
 _NODISCARD _Timeobj<_Elem, const tm*> put_time(const tm* _Tptr_arg, const _Elem* _Fmt_arg) {
     return _Timeobj<_Elem, const tm*>(_Tptr_arg, _Fmt_arg);
-}
-
-template <class _Elem, class _Traits, class _Elem2>
-basic_ostream<_Elem, _Traits>& operator<<(basic_ostream<_Elem, _Traits>& _Ostr,
-    const _Timeobj<_Elem2, const tm*>& _Manip) { // put time information to output stream
-    using _Myos   = basic_ostream<_Elem, _Traits>;
-    using _Iter   = ostreambuf_iterator<_Elem, _Traits>;
-    using _Mytput = time_put<_Elem2, _Iter>;
-
-    static_assert(is_same_v<_Elem, _Elem2>, "wrong character type for put_time");
-
-    const typename _Myos::sentry _Ok(_Ostr);
-
-    if (_Ok) { // state okay, insert monetary amount
-        const _Mytput& _Tput_fac = _STD use_facet<_Mytput>(_Ostr.getloc());
-        _TRY_IO_BEGIN
-        if (_Tput_fac.put(_Iter(_Ostr.rdbuf()), _Ostr, _Ostr.fill(), _Manip._Tptr, _Manip._Fmtfirst, _Manip._Fmtlast)
-                .failed()) {
-            _Ostr.setstate(ios_base::badbit);
-        }
-        _CATCH_IO_(ios_base, _Ostr)
-    }
-
-    return _Ostr;
 }
 
 template <class _Elem, class _Traits, class _Alloc>

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -126,6 +126,12 @@ public:
         return _Tmp;
     }
 
+    _NODISCARD_FRIEND _CONSTEXPR20 _Vector_const_iterator operator+(
+        const difference_type _Off, _Vector_const_iterator _Next) noexcept {
+        _Next += _Off;
+        return _Next;
+    }
+
     _CONSTEXPR20 _Vector_const_iterator& operator-=(const difference_type _Off) noexcept {
         return *this += -_Off;
     }
@@ -207,13 +213,6 @@ public:
 
     _Tptr _Ptr; // pointer to element in vector
 };
-
-template <class _Myvec>
-_NODISCARD _CONSTEXPR20 _Vector_const_iterator<_Myvec> operator+(
-    typename _Vector_const_iterator<_Myvec>::difference_type _Off, _Vector_const_iterator<_Myvec> _Next) noexcept {
-    _Next += _Off;
-    return _Next;
-}
 
 #if _HAS_CXX20
 template <class _Myvec>
@@ -306,6 +305,12 @@ public:
         return _Tmp;
     }
 
+    _NODISCARD_FRIEND _CONSTEXPR20 _Vector_iterator operator+(
+        const difference_type _Off, _Vector_iterator _Next) noexcept {
+        _Next += _Off;
+        return _Next;
+    }
+
     _CONSTEXPR20 _Vector_iterator& operator-=(const difference_type _Off) noexcept {
         _Mybase::operator-=(_Off);
         return *this;
@@ -329,13 +334,6 @@ public:
         return _Unfancy(this->_Ptr);
     }
 };
-
-template <class _Myvec>
-_NODISCARD _CONSTEXPR20 _Vector_iterator<_Myvec> operator+(
-    typename _Vector_iterator<_Myvec>::difference_type _Off, _Vector_iterator<_Myvec> _Next) noexcept {
-    _Next += _Off;
-    return _Next;
-}
 
 #if _HAS_CXX20
 template <class _Myvec>
@@ -2461,6 +2459,12 @@ public:
         return _Tmp;
     }
 
+    _NODISCARD_FRIEND _CONSTEXPR20 _Vb_const_iterator operator+(
+        const difference_type _Off, _Vb_const_iterator _Right) noexcept {
+        _Right += _Off;
+        return _Right;
+    }
+
     _CONSTEXPR20 _Vb_const_iterator& operator-=(const difference_type _Off) noexcept {
         return *this += -_Off;
     }
@@ -2568,14 +2572,6 @@ public:
 };
 
 template <class _Alvbase_wrapped>
-_NODISCARD _CONSTEXPR20 _Vb_const_iterator<_Alvbase_wrapped> operator+(
-    typename _Vb_const_iterator<_Alvbase_wrapped>::difference_type _Off,
-    _Vb_const_iterator<_Alvbase_wrapped> _Right) noexcept {
-    _Right += _Off;
-    return _Right;
-}
-
-template <class _Alvbase_wrapped>
 class _Vb_iterator : public _Vb_const_iterator<_Alvbase_wrapped> {
 public:
     using _Mybase          = _Vb_const_iterator<_Alvbase_wrapped>;
@@ -2637,6 +2633,11 @@ public:
         return _Tmp;
     }
 
+    _NODISCARD_FRIEND _CONSTEXPR20 _Vb_iterator operator+(const difference_type _Off, _Vb_iterator _Right) noexcept {
+        _Right += _Off;
+        return _Right;
+    }
+
     _CONSTEXPR20 _Vb_iterator& operator-=(const difference_type _Off) noexcept {
         _Mybase::operator-=(_Off);
         return *this;
@@ -2656,13 +2657,6 @@ public:
 
     using _Prevent_inheriting_unwrap = _Vb_iterator;
 };
-
-template <class _Alvbase_wrapped>
-_NODISCARD _CONSTEXPR20 _Vb_iterator<_Alvbase_wrapped> operator+(
-    typename _Vb_iterator<_Alvbase_wrapped>::difference_type _Off, _Vb_iterator<_Alvbase_wrapped> _Right) noexcept {
-    _Right += _Off;
-    return _Right;
-}
 
 template <class _Alloc>
 class _Vb_val : public _Container_base {

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -1043,6 +1043,12 @@ public:
         return _Tmp;
     }
 
+    _NODISCARD_FRIEND constexpr _String_view_iterator operator+(
+        const difference_type _Off, _String_view_iterator _Right) noexcept {
+        _Right += _Off;
+        return _Right;
+    }
+
     constexpr _String_view_iterator& operator-=(const difference_type _Off) noexcept {
 #if _ITERATOR_DEBUG_LEVEL >= 1
         if (_Off != 0) {
@@ -1171,14 +1177,6 @@ private:
     pointer _Myptr = nullptr;
 #endif // _ITERATOR_DEBUG_LEVEL
 };
-
-template <class _Traits>
-_NODISCARD constexpr _String_view_iterator<_Traits> operator+(
-    const typename _String_view_iterator<_Traits>::difference_type _Off,
-    _String_view_iterator<_Traits> _Right) noexcept {
-    _Right += _Off;
-    return _Right;
-}
 
 #if _HAS_CXX20
 template <class _Traits>
@@ -1988,6 +1986,12 @@ public:
         return _Tmp;
     }
 
+    _NODISCARD_FRIEND _CONSTEXPR20 _String_const_iterator operator+(
+        const difference_type _Off, _String_const_iterator _Next) noexcept {
+        _Next += _Off;
+        return _Next;
+    }
+
     _CONSTEXPR20 _String_const_iterator& operator-=(const difference_type _Off) noexcept {
         return *this += -_Off;
     }
@@ -2070,13 +2074,6 @@ public:
 
     pointer _Ptr; // pointer to element in string
 };
-
-template <class _Mystr>
-_NODISCARD _CONSTEXPR20 _String_const_iterator<_Mystr> operator+(
-    typename _String_const_iterator<_Mystr>::difference_type _Off, _String_const_iterator<_Mystr> _Next) noexcept {
-    _Next += _Off;
-    return _Next;
-}
 
 #if _HAS_CXX20
 template <class _Mystr>
@@ -2166,6 +2163,12 @@ public:
         return _Tmp;
     }
 
+    _NODISCARD_FRIEND _CONSTEXPR20 _String_iterator operator+(
+        const difference_type _Off, _String_iterator _Next) noexcept {
+        _Next += _Off;
+        return _Next;
+    }
+
     _CONSTEXPR20 _String_iterator& operator-=(const difference_type _Off) noexcept {
         _Mybase::operator-=(_Off);
         return *this;
@@ -2189,13 +2192,6 @@ public:
         return const_cast<value_type*>(_Unfancy(this->_Ptr));
     }
 };
-
-template <class _Mystr>
-_NODISCARD _CONSTEXPR20 _String_iterator<_Mystr> operator+(
-    typename _String_iterator<_Mystr>::difference_type _Off, _String_iterator<_Mystr> _Next) noexcept {
-    _Next += _Off;
-    return _Next;
-}
 
 #if _HAS_CXX20
 template <class _Mystr>


### PR DESCRIPTION
This changes all of the STL's operators that are required to exist, but that aren't required to be namespace-scope functions, into "hidden friends". (For example, `n + vector::iterator`.)

Hidden friends are great in two different ways:

* They improve **compiler throughput**, because they don't pollute unqualified name lookup. Only argument-dependent lookup finds them when they're needed.
* They automatically work with **named modules**, when their parent class (or a function returning their parent class, etc.) is `export`ed. (Namespace-scope operators would have to be individually `export`ed.)

A few notes:

* `span::iterator` has used hidden friends since #474 and currently says: https://github.com/microsoft/STL/blob/ea32e86deed6e8a8cd6116dc275e358a901d2b50/stl/inc/span#L117
* The `<iomanip>` diff looks horrible, but I've structured it into a series of commits for easier reviewing.
  + The `_Elem` and `_Elem2` template parameters have to "trade places" when becoming hidden friends. We `static_assert` that they're the same, so there is no potential for mistakes.
* `quoted()` needed extra attention due to how its operators referred to each other. I recommend diffing the "before" and "after" parts of each commit.
  + First, I made this easier to deal with by moving `_Quote_out` before `_Quote_in`.
  + In "Use friendship for `_Quote_out`.", I had to rename to `_OsTraits` to avoid a collision, and use `class _QuTraits = _Traits` both for clarity and to delay evaluation of `is_void_v<_QuTraits>`.
  + In "Use friendship for `_Quote_in`, part 1.", instead of calling `quoted()`, I directly construct a `_Quote_out` (thanks to the earlier code movement).
  + Finally, "Use friendship for `_Quote_in`, part 2." is nearly pure code movement.

:horse: :magic_wand: :unicorn:
===