### PR TITLE
Delete unused, non-exported xmath machinery

### DIFF
--- a/stl/src/xdtest.cpp
+++ b/stl/src/xdtest.cpp
@@ -21,10 +21,6 @@ _CRTIMP2_PURE short __CLRCALL_PURE_OR_CDECL _Dtest(double* px) { // categorize *
     }
 }
 
-unsigned short* _Plsw(double* px) { // get pointer to lsw
-    return &reinterpret_cast<_Dval*>(px)->_Sh[_Dg];
-}
-
 unsigned short* _Pmsw(double* px) { // get pointer to msw
     return &reinterpret_cast<_Dval*>(px)->_Sh[_D0];
 }

--- a/stl/src/xfdtest.cpp
+++ b/stl/src/xfdtest.cpp
@@ -19,10 +19,6 @@ _CRTIMP2_PURE short __CLRCALL_PURE_OR_CDECL _FDtest(float* px) { // categorize *
     }
 }
 
-unsigned short* _FPlsw(float* px) { // get pointer to lsw
-    return &reinterpret_cast<_Fval*>(px)->_Sh[_Fg];
-}
-
 unsigned short* _FPmsw(float* px) { // get pointer to msw
     return &reinterpret_cast<_Fval*>(px)->_Sh[_F0];
 }

--- a/stl/src/xldtest.cpp
+++ b/stl/src/xldtest.cpp
@@ -11,10 +11,6 @@ _CRTIMP2_PURE short __CLRCALL_PURE_OR_CDECL _LDtest(long double* px) { // catego
     return _Dtest(reinterpret_cast<double*>(px));
 }
 
-unsigned short* _LPlsw(long double* px) { // get pointer to lsw
-    return &reinterpret_cast<_Lval*>(px)->_Sh[_L3];
-}
-
 unsigned short* _LPmsw(long double* px) { // get pointer to msw
     return &reinterpret_cast<_Lval*>(px)->_Sh[_L0];
 }

--- a/stl/src/xmath.hpp
+++ b/stl/src/xmath.hpp
@@ -10,7 +10,6 @@
 
 // macros for _Feraise argument
 #define _FE_DIVBYZERO 0x04
-#define _FE_INEXACT   0x20
 #define _FE_INVALID   0x01
 #define _FE_OVERFLOW  0x08
 #define _FE_UNDERFLOW 0x10
@@ -42,9 +41,6 @@
 #define FSIGN(x) (reinterpret_cast<_Fval*>(&(x))->_Sh[_F0] & _FSIGN)
 #define LSIGN(x) (reinterpret_cast<_Lval*>(&(x))->_Sh[_L0] & _LSIGN)
 
-#define _Fg _F1 // least-significant 16-bit word
-#define _Dg _D3
-
 // return values for _Stopfx/_Stoflt
 #define FL_ERR 0
 #define FL_DEC 1
@@ -72,7 +68,6 @@ union _Dval { // pun floating type as integer array
     double _Val;
 };
 
-unsigned short* _Plsw(double*);
 unsigned short* _Pmsw(double*);
 
 short _Dint(double*, short);
@@ -93,11 +88,8 @@ double* _Xp_addh(double*, int, double);
 double* _Xp_mulh(double*, int, double);
 double* _Xp_movx(double*, int, const double*);
 double* _Xp_addx(double*, int, const double*, int);
-double* _Xp_subx(double*, int, const double*, int);
 double* _Xp_ldexpx(double*, int, int);
 double* _Xp_mulx(double*, int, const double*, int, double*);
-double* _Xp_invx(double*, int, double*);
-double* _Xp_sqrtx(double*, int, double*);
 
 // float declarations
 union _Fval { // pun floating type as integer array
@@ -105,7 +97,6 @@ union _Fval { // pun floating type as integer array
     float _Val;
 };
 
-unsigned short* _FPlsw(float*);
 unsigned short* _FPmsw(float*);
 
 short _FDint(float*, short);
@@ -126,11 +117,8 @@ float* _FXp_addh(float*, int, float);
 float* _FXp_mulh(float*, int, float);
 float* _FXp_movx(float*, int, const float*);
 float* _FXp_addx(float*, int, const float*, int);
-float* _FXp_subx(float*, int, const float*, int);
 float* _FXp_ldexpx(float*, int, int);
 float* _FXp_mulx(float*, int, const float*, int, float*);
-float* _FXp_invx(float*, int, float*);
-float* _FXp_sqrtx(float*, int, float*);
 
 // long double declarations
 union _Lval { // pun floating type as integer array
@@ -138,7 +126,6 @@ union _Lval { // pun floating type as integer array
     long double _Val;
 };
 
-unsigned short* _LPlsw(long double*);
 unsigned short* _LPmsw(long double*);
 
 short _LDint(long double*, short);
@@ -158,11 +145,8 @@ long double* _LXp_addh(long double*, int, long double);
 long double* _LXp_mulh(long double*, int, long double);
 long double* _LXp_movx(long double*, int, const long double*);
 long double* _LXp_addx(long double*, int, const long double*, int);
-long double* _LXp_subx(long double*, int, const long double*, int);
 long double* _LXp_ldexpx(long double*, int, int);
 long double* _LXp_mulx(long double*, int, const long double*, int, long double*);
-long double* _LXp_invx(long double*, int, long double*);
-long double* _LXp_sqrtx(long double*, int, long double*);
 
 _END_EXTERN_C_UNLESS_PURE
 

--- a/stl/src/xxxprec.hpp
+++ b/stl/src/xxxprec.hpp
@@ -310,16 +310,6 @@ FTYPE* FNAME(Xp_addx)(FTYPE* p, int n, const FTYPE* q, int m) { // add an extend
     return p;
 }
 
-FTYPE* FNAME(Xp_subx)(FTYPE* p, int n, const FTYPE* q, int m) { // subtract an extended precision value
-    int k;
-
-    for (k = 0; k < m && q[k] != FLIT(0.0); ++k) {
-        FNAME(Xp_addh)(p, n, -q[k]);
-    }
-
-    return p;
-}
-
 FTYPE* FNAME(Xp_ldexpx)(FTYPE* p, int n, int m) { // scale an extended precision value
     int k;
     for (k = 0; k < n; ++k) {
@@ -354,80 +344,6 @@ FTYPE* FNAME(Xp_mulx)(FTYPE* p, int n, const FTYPE* q, int m, FTYPE* ptemp2) {
     return p;
 }
 
-FTYPE* FNAME(Xp_invx)(FTYPE* p, int n, FTYPE* ptemp4) { // invert an extended precision value (needs 4 * n temp)
-    short errx;
-
-    if (n != 0) {
-        if (0 <= (errx = FNAME(Dtest)(&p[0]))) { // not finite, return special value
-            if (errx == _INFCODE) {
-                p[0] = FLIT(0.0); // 1/Inf == 0
-            } else if (errx == 0) {
-                p[0] = FCONST(Inf); // 1/0 == Inf
-            }
-            // else 1/NaN == NaN
-        } else { // p[0] is finite nonzero, invert it
-            FTYPE* pac    = ptemp4;
-            FTYPE* py     = ptemp4 + n;
-            FTYPE* ptemp2 = py + n;
-            FTYPE x0      = p[0];
-            int k;
-
-            FNAME(Xp_movx)(py, n, p);
-            FNAME(Xp_mulh)(py, n, -FLIT(1.0)); // py = -x
-
-            if (1 < n) {
-                x0 += p[1];
-            }
-
-            FNAME(Xp_setw)(p, n, FLIT(1.0) / x0); // p = y
-            for (k = 1; k < n; k <<= 1) { // iterate to double previous precision of 1/x
-                FNAME(Xp_movx)(pac, n, p);
-                FNAME(Xp_mulx)(pac, n, py, n, ptemp2);
-                FNAME(Xp_addh)(pac, n, FLIT(1.0)); // 1 - x * y
-                FNAME(Xp_mulx)(pac, n, p, n, ptemp2); // y * (1 - x * y)
-                FNAME(Xp_addx)(p, n, pac, n); // y += y * (1 - x * y)
-            }
-        }
-    }
-
-    return p;
-}
-
-FTYPE* FNAME(Xp_sqrtx)(FTYPE* p, int n, FTYPE* ptemp4) {
-    // find square root of an extended precision value (needs 4 * n temp)
-    if (n != 0) {
-        if (0 <= FNAME(Dtest)(&p[0]) || p[0] < FLIT(0.0)) { // not finite nonnegative, return special value
-            if (p[0] < FLIT(0.0)) { // sqrt(negative), report domain error
-                _Feraise(_FE_INVALID);
-                p[0] = FCONST(Nan);
-            }
-        } else { // worth iterating, compute x * sqrt(1/x)
-            FTYPE* pac    = ptemp4;
-            FTYPE* py     = ptemp4 + n;
-            FTYPE* ptemp2 = py + n;
-            FTYPE x0      = p[0];
-            int k;
-
-            if (1 < n) {
-                x0 += p[1];
-            }
-
-            FNAME(Xp_setw)(py, n, static_cast<FTYPE>(FLIT(1.0) / FFUN(sqrt)(x0))); // py = y
-            for (k = 2; k < n; k <<= 1) { // iterate to double previous precision of sqrt(1/x)
-                FNAME(Xp_movx)(pac, n, py);
-                FNAME(Xp_mulh)(pac, n, -FLIT(0.5));
-                FNAME(Xp_mulx)(pac, n, p, n, ptemp2);
-                FNAME(Xp_mulx)(pac, n, py, n, ptemp2);
-                FNAME(Xp_addh)(pac, n, FLIT(1.5)); // 3/2 - x * y * y / 2
-                FNAME(Xp_mulx)(py, n, pac, n, ptemp2); // y *= 3/2 - x * y * y / 2
-            }
-
-            FNAME(Xp_mulx)(p, n, py, n, ptemp2); // x * sqrt(1/x)
-        }
-    }
-
-    return p;
-}
 #if !defined(MRTDLL)
 _END_EXTERN_C
 #endif // !defined(MRTDLL)


### PR DESCRIPTION
This xmath machinery in `stl/src` was neither dllexported nor mentioned by `stl/inc`, so it can be safely removed.

There is no change to the DLL sizes, not even a single byte, because we ask the linker to drop unreferenced code, even for the debug DLLs: https://github.com/microsoft/STL/blob/ea32e86deed6e8a8cd6116dc275e358a901d2b50/stl/CMakeLists.txt#L559-L560

The static libs shrink slightly (all IDL flavors). For example, the x64 static libs shrink like this:

| File | Old size<br>(bytes) | New size<br>(bytes) | Improvement<br>(bytes) |
|:----:|:-------------------:|:-------------------:|:----------------------:|
| `libcpmt.lib`  | 35,544,492 | 35,522,704 | 21,788 |
| `libcpmtd.lib` | 36,858,914 | 36,840,400 | 18,514 |
