### PR TITLE
Various source cleanups, especially `ushMEOW.cpp` and `fiopen.cpp`

### DIFF
--- a/stl/src/fiopen.cpp
+++ b/stl/src/fiopen.cpp
@@ -5,8 +5,6 @@
 
 #include <fstream>
 
-#include <Windows.h>
-
 _STD_BEGIN
 
 FILE* _Xfsopen(_In_z_ const char* filename, _In_ int mode, _In_ int prot) {

--- a/stl/src/fiopen.cpp
+++ b/stl/src/fiopen.cpp
@@ -5,85 +5,89 @@
 
 #include <fstream>
 
-_STD_BEGIN
+namespace {
+    using _STD ios_base;
 
-FILE* _Xfsopen(_In_z_ const char* filename, _In_ int mode, _In_ int prot) {
-    static const char* const mods[] = {// fopen mode strings corresponding to valid[i]
-        "r", "w", "w", "a", "rb", "wb", "wb", "ab", "r+", "w+", "a+", "r+b", "w+b", "a+b", nullptr};
+    FILE* _Xfsopen(_In_z_ const char* filename, _In_ int mode, _In_ int prot) {
+        static const char* const mods[] = {// fopen mode strings corresponding to valid[i]
+            "r", "w", "w", "a", "rb", "wb", "wb", "ab", "r+", "w+", "a+", "r+b", "w+b", "a+b", nullptr};
 
-    return _fsopen(filename, mods[mode], prot);
-}
-
-FILE* _Xfsopen(_In_z_ const wchar_t* filename, _In_ int mode, _In_ int prot) {
-    static const wchar_t* const mods[] = {// fopen mode strings corresponding to valid[i]
-        L"r", L"w", L"w", L"a", L"rb", L"wb", L"wb", L"ab", L"r+", L"w+", L"a+", L"r+b", L"w+b", L"a+b", nullptr};
-
-    return _wfsopen(filename, mods[mode], prot);
-}
-
-template <class CharT>
-FILE* _Xfiopen(const CharT* filename, ios_base::openmode mode, int prot) {
-    static const ios_base::openmode valid[] = {
-        // valid combinations of open flags
-        ios_base::in,
-        ios_base::out,
-        ios_base::out | ios_base::trunc,
-        ios_base::out | ios_base::app,
-        ios_base::in | ios_base::binary,
-        ios_base::out | ios_base::binary,
-        ios_base::out | ios_base::trunc | ios_base::binary,
-        ios_base::out | ios_base::app | ios_base::binary,
-        ios_base::in | ios_base::out,
-        ios_base::in | ios_base::out | ios_base::trunc,
-        ios_base::in | ios_base::out | ios_base::app,
-        ios_base::in | ios_base::out | ios_base::binary,
-        ios_base::in | ios_base::out | ios_base::trunc | ios_base::binary,
-        ios_base::in | ios_base::out | ios_base::app | ios_base::binary,
-    };
-
-    FILE* fp                     = nullptr;
-    ios_base::openmode atendflag = mode & ios_base::ate;
-    ios_base::openmode norepflag = mode & ios_base::_Noreplace;
-
-    if (mode & ios_base::_Nocreate) {
-        mode |= ios_base::in; // file must exist
+        return _fsopen(filename, mods[mode], prot);
     }
 
-    if (mode & ios_base::app) {
-        mode |= ios_base::out; // extension -- app implies out
+    FILE* _Xfsopen(_In_z_ const wchar_t* filename, _In_ int mode, _In_ int prot) {
+        static const wchar_t* const mods[] = {// fopen mode strings corresponding to valid[i]
+            L"r", L"w", L"w", L"a", L"rb", L"wb", L"wb", L"ab", L"r+", L"w+", L"a+", L"r+b", L"w+b", L"a+b", nullptr};
+
+        return _wfsopen(filename, mods[mode], prot);
     }
 
-    mode &= ~(ios_base::ate | ios_base::_Nocreate | ios_base::_Noreplace);
+    template <class CharT>
+    FILE* _Xfiopen(const CharT* filename, ios_base::openmode mode, int prot) {
+        static const ios_base::openmode valid[] = {
+            // valid combinations of open flags
+            ios_base::in,
+            ios_base::out,
+            ios_base::out | ios_base::trunc,
+            ios_base::out | ios_base::app,
+            ios_base::in | ios_base::binary,
+            ios_base::out | ios_base::binary,
+            ios_base::out | ios_base::trunc | ios_base::binary,
+            ios_base::out | ios_base::app | ios_base::binary,
+            ios_base::in | ios_base::out,
+            ios_base::in | ios_base::out | ios_base::trunc,
+            ios_base::in | ios_base::out | ios_base::app,
+            ios_base::in | ios_base::out | ios_base::binary,
+            ios_base::in | ios_base::out | ios_base::trunc | ios_base::binary,
+            ios_base::in | ios_base::out | ios_base::app | ios_base::binary,
+        };
 
-    // look for a valid mode
-    int n = 0;
-    while (valid[n] != mode) {
-        if (++n == static_cast<int>(_STD size(valid))) {
-            return nullptr; // no valid mode
+        FILE* fp                     = nullptr;
+        ios_base::openmode atendflag = mode & ios_base::ate;
+        ios_base::openmode norepflag = mode & ios_base::_Noreplace;
+
+        if (mode & ios_base::_Nocreate) {
+            mode |= ios_base::in; // file must exist
         }
-    }
 
-    if (norepflag && (mode & (ios_base::out | ios_base::app))
-        && (fp = _Xfsopen(filename, 0, prot)) != nullptr) { // file must not exist, close and fail
-        fclose(fp);
-        return nullptr;
-    }
+        if (mode & ios_base::app) {
+            mode |= ios_base::out; // extension -- app implies out
+        }
 
-    if (fp != nullptr && fclose(fp) != 0) {
-        return nullptr; // can't close after test open
-    }
+        mode &= ~(ios_base::ate | ios_base::_Nocreate | ios_base::_Noreplace);
 
-    if ((fp = _Xfsopen(filename, n, prot)) == nullptr) {
-        return nullptr; // open failed
-    }
+        // look for a valid mode
+        int n = 0;
+        while (valid[n] != mode) {
+            if (++n == static_cast<int>(_STD size(valid))) {
+                return nullptr; // no valid mode
+            }
+        }
 
-    if (atendflag && fseek(fp, 0, SEEK_END) != 0) {
-        fclose(fp); // can't position at end
-        return nullptr;
-    }
+        if (norepflag && (mode & (ios_base::out | ios_base::app))
+            && (fp = _Xfsopen(filename, 0, prot)) != nullptr) { // file must not exist, close and fail
+            fclose(fp);
+            return nullptr;
+        }
 
-    return fp; // no need to seek to end, or seek succeeded
-}
+        if (fp != nullptr && fclose(fp) != 0) {
+            return nullptr; // can't close after test open
+        }
+
+        if ((fp = _Xfsopen(filename, n, prot)) == nullptr) {
+            return nullptr; // open failed
+        }
+
+        if (atendflag && fseek(fp, 0, SEEK_END) != 0) {
+            fclose(fp); // can't position at end
+            return nullptr;
+        }
+
+        return fp; // no need to seek to end, or seek succeeded
+    }
+} // unnamed namespace
+
+_STD_BEGIN
 
 _CRTIMP2_PURE FILE* __CLRCALL_PURE_OR_CDECL _Fiopen(
     const char* filename, ios_base::openmode mode, int prot) { // open wide-named file with byte name

--- a/stl/src/fiopen.cpp
+++ b/stl/src/fiopen.cpp
@@ -97,11 +97,9 @@ _CRTIMP2_PURE FILE* __CLRCALL_PURE_OR_CDECL _Fiopen(
     return _Xfiopen(filename, mode, prot);
 }
 
-#ifdef _NATIVE_WCHAR_T_DEFINED
 _CRTIMP2_PURE FILE* __CLRCALL_PURE_OR_CDECL _Fiopen(
     const unsigned short* _Filename, ios_base::openmode _Mode, int _Prot) { // open file with wide name
     return _Fiopen(reinterpret_cast<const wchar_t*>(_Filename), _Mode, _Prot);
 }
-#endif
 
 _STD_END

--- a/stl/src/locale.cpp
+++ b/stl/src/locale.cpp
@@ -71,9 +71,7 @@ locale::_Locimp* __CLRCALL_OR_CDECL locale::_Locimp::_Makeloc(
     ADDFAC(_Tc5, cat, ptrimp, ptrloc);
     _Locimp::_Makexloc(lobj, cat, ptrimp, ptrloc);
     _Locimp::_Makewloc(lobj, cat, ptrimp, ptrloc);
-#ifdef _NATIVE_WCHAR_T_DEFINED
     _Locimp::_Makeushloc(lobj, cat, ptrimp, ptrloc);
-#endif
     ptrimp->_Catmask |= cat;
     ptrimp->_Name = lobj._Getname();
     return ptrimp;

--- a/stl/src/locale0.cpp
+++ b/stl/src/locale0.cpp
@@ -131,12 +131,9 @@ __PURE_APPDOMAIN_GLOBAL locale::id ctype<wchar_t>::id(0);
 
 __PURE_APPDOMAIN_GLOBAL locale::id codecvt<wchar_t, char, mbstate_t>::id(0);
 
-#ifdef _NATIVE_WCHAR_T_DEFINED
 __PURE_APPDOMAIN_GLOBAL locale::id ctype<unsigned short>::id(0);
 
 __PURE_APPDOMAIN_GLOBAL locale::id codecvt<unsigned short, char, mbstate_t>::id(0);
-
-#endif // _NATIVE_WCHAR_T_DEFINED
 
 _MRTIMP2_PURE const locale& __CLRCALL_PURE_OR_CDECL locale::classic() { // get reference to "C" locale
     _Init();

--- a/stl/src/ushcerr.cpp
+++ b/stl/src/ushcerr.cpp
@@ -3,7 +3,6 @@
 
 // initialize standard wide error stream (unsigned short version)
 
-#ifdef _NATIVE_WCHAR_T_DEFINED
 #include <fstream>
 
 _STD_BEGIN
@@ -31,4 +30,3 @@ _STD_END
 
 #include "wcerr.cpp"
 #include <iostream>
-#endif

--- a/stl/src/ushcerr.cpp
+++ b/stl/src/ushcerr.cpp
@@ -13,7 +13,6 @@ using ushfilebuf = basic_filebuf<unsigned short, char_traits<unsigned short>>;
 
 _STD_END
 
-#ifndef wistream
 #define wistream    ushistream
 #define wostream    ushostream
 #define wfilebuf    ushfilebuf
@@ -26,7 +25,6 @@ _STD_END
 #define init_wclog  init_ushclog
 #define init_wcin   init_ushcin
 #define _Winit      _UShinit
-#endif
 
 #include "wcerr.cpp"
 #include <iostream>

--- a/stl/src/ushcerr.cpp
+++ b/stl/src/ushcerr.cpp
@@ -17,13 +17,7 @@ _STD_END
 #define wostream    ushostream
 #define wfilebuf    ushfilebuf
 #define _Init_wcerr _Init_ushcerr
-#define _Init_wcout _Init_ushcout
-#define _Init_wclog _Init_ushclog
-#define _Init_wcin  _Init_ushcin
 #define init_wcerr  init_ushcerr
-#define init_wcout  init_ushcout
-#define init_wclog  init_ushclog
-#define init_wcin   init_ushcin
 #define _Winit      _UShinit
 
 #include "wcerr.cpp"

--- a/stl/src/ushcerr.cpp
+++ b/stl/src/ushcerr.cpp
@@ -21,4 +21,3 @@ _STD_END
 #define _Winit      _UShinit
 
 #include "wcerr.cpp"
-#include <iostream>

--- a/stl/src/ushcin.cpp
+++ b/stl/src/ushcin.cpp
@@ -13,18 +13,12 @@ using ushfilebuf = basic_filebuf<unsigned short, char_traits<unsigned short>>;
 
 _STD_END
 
-#define wistream    ushistream
-#define wostream    ushostream
-#define wfilebuf    ushfilebuf
-#define _Init_wcerr _Init_ushcerr
-#define _Init_wcout _Init_ushcout
-#define _Init_wclog _Init_ushclog
-#define _Init_wcin  _Init_ushcin
-#define _Winit      _UShinit
-#define init_wcerr  init_ushcerr
-#define init_wcout  init_ushcout
-#define init_wclog  init_ushclog
-#define init_wcin   init_ushcin
+#define wistream   ushistream
+#define wostream   ushostream
+#define wfilebuf   ushfilebuf
+#define _Init_wcin _Init_ushcin
+#define _Winit     _UShinit
+#define init_wcin  init_ushcin
 
 #include "wcin.cpp"
 #include <iostream>

--- a/stl/src/ushcin.cpp
+++ b/stl/src/ushcin.cpp
@@ -13,7 +13,6 @@ using ushfilebuf = basic_filebuf<unsigned short, char_traits<unsigned short>>;
 
 _STD_END
 
-#ifndef wistream
 #define wistream    ushistream
 #define wostream    ushostream
 #define wfilebuf    ushfilebuf
@@ -26,7 +25,6 @@ _STD_END
 #define init_wcout  init_ushcout
 #define init_wclog  init_ushclog
 #define init_wcin   init_ushcin
-#endif
 
 #include "wcin.cpp"
 #include <iostream>

--- a/stl/src/ushcin.cpp
+++ b/stl/src/ushcin.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// initialize standard wide error stream (unsigned short version)
+// initialize standard wide input stream (unsigned short version)
 
 #include <fstream>
 

--- a/stl/src/ushcin.cpp
+++ b/stl/src/ushcin.cpp
@@ -21,4 +21,3 @@ _STD_END
 #define _Winit     _UShinit
 
 #include "wcin.cpp"
-#include <iostream>

--- a/stl/src/ushcin.cpp
+++ b/stl/src/ushcin.cpp
@@ -3,7 +3,6 @@
 
 // initialize standard wide error stream (unsigned short version)
 
-#ifdef _NATIVE_WCHAR_T_DEFINED
 #include <fstream>
 
 _STD_BEGIN
@@ -31,4 +30,3 @@ _STD_END
 
 #include "wcin.cpp"
 #include <iostream>
-#endif

--- a/stl/src/ushcin.cpp
+++ b/stl/src/ushcin.cpp
@@ -17,8 +17,8 @@ _STD_END
 #define wostream   ushostream
 #define wfilebuf   ushfilebuf
 #define _Init_wcin _Init_ushcin
-#define _Winit     _UShinit
 #define init_wcin  init_ushcin
+#define _Winit     _UShinit
 
 #include "wcin.cpp"
 #include <iostream>

--- a/stl/src/ushclog.cpp
+++ b/stl/src/ushclog.cpp
@@ -21,4 +21,3 @@ _STD_END
 #define _Winit      _UShinit
 
 #include "wclog.cpp"
-#include <iostream>

--- a/stl/src/ushclog.cpp
+++ b/stl/src/ushclog.cpp
@@ -16,15 +16,9 @@ _STD_END
 #define wistream    ushistream
 #define wostream    ushostream
 #define wfilebuf    ushfilebuf
-#define _Init_wcerr _Init_ushcerr
-#define _Init_wcout _Init_ushcout
 #define _Init_wclog _Init_ushclog
-#define _Init_wcin  _Init_ushcin
 #define _Winit      _UShinit
-#define init_wcerr  init_ushcerr
-#define init_wcout  init_ushcout
 #define init_wclog  init_ushclog
-#define init_wcin   init_ushcin
 
 #include "wclog.cpp"
 #include <iostream>

--- a/stl/src/ushclog.cpp
+++ b/stl/src/ushclog.cpp
@@ -3,7 +3,6 @@
 
 // initialize standard wide error stream (unsigned short version)
 
-#ifdef _NATIVE_WCHAR_T_DEFINED
 #include <fstream>
 
 _STD_BEGIN
@@ -31,4 +30,3 @@ _STD_END
 
 #include "wclog.cpp"
 #include <iostream>
-#endif

--- a/stl/src/ushclog.cpp
+++ b/stl/src/ushclog.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// initialize standard wide error stream (unsigned short version)
+// initialize standard wide log stream (unsigned short version)
 
 #include <fstream>
 

--- a/stl/src/ushclog.cpp
+++ b/stl/src/ushclog.cpp
@@ -17,8 +17,8 @@ _STD_END
 #define wostream    ushostream
 #define wfilebuf    ushfilebuf
 #define _Init_wclog _Init_ushclog
-#define _Winit      _UShinit
 #define init_wclog  init_ushclog
+#define _Winit      _UShinit
 
 #include "wclog.cpp"
 #include <iostream>

--- a/stl/src/ushclog.cpp
+++ b/stl/src/ushclog.cpp
@@ -13,7 +13,6 @@ using ushfilebuf = basic_filebuf<unsigned short, char_traits<unsigned short>>;
 
 _STD_END
 
-#ifndef wistream
 #define wistream    ushistream
 #define wostream    ushostream
 #define wfilebuf    ushfilebuf
@@ -26,7 +25,6 @@ _STD_END
 #define init_wcout  init_ushcout
 #define init_wclog  init_ushclog
 #define init_wcin   init_ushcin
-#endif
 
 #include "wclog.cpp"
 #include <iostream>

--- a/stl/src/ushcout.cpp
+++ b/stl/src/ushcout.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// initialize standard wide error stream (unsigned short version)
+// initialize standard wide output stream (unsigned short version)
 
 #include <fstream>
 

--- a/stl/src/ushcout.cpp
+++ b/stl/src/ushcout.cpp
@@ -21,4 +21,3 @@ _STD_END
 #define _Winit      _UShinit
 
 #include "wcout.cpp"
-#include <iostream>

--- a/stl/src/ushcout.cpp
+++ b/stl/src/ushcout.cpp
@@ -16,15 +16,9 @@ _STD_END
 #define wistream    ushistream
 #define wostream    ushostream
 #define wfilebuf    ushfilebuf
-#define _Init_wcerr _Init_ushcerr
 #define _Init_wcout _Init_ushcout
-#define _Init_wclog _Init_ushclog
-#define _Init_wcin  _Init_ushcin
 #define _Winit      _UShinit
-#define init_wcerr  init_ushcerr
 #define init_wcout  init_ushcout
-#define init_wclog  init_ushclog
-#define init_wcin   init_ushcin
 
 #include "wcout.cpp"
 #include <iostream>

--- a/stl/src/ushcout.cpp
+++ b/stl/src/ushcout.cpp
@@ -17,8 +17,8 @@ _STD_END
 #define wostream    ushostream
 #define wfilebuf    ushfilebuf
 #define _Init_wcout _Init_ushcout
-#define _Winit      _UShinit
 #define init_wcout  init_ushcout
+#define _Winit      _UShinit
 
 #include "wcout.cpp"
 #include <iostream>

--- a/stl/src/ushcout.cpp
+++ b/stl/src/ushcout.cpp
@@ -3,7 +3,6 @@
 
 // initialize standard wide error stream (unsigned short version)
 
-#ifdef _NATIVE_WCHAR_T_DEFINED
 #include <fstream>
 
 _STD_BEGIN
@@ -31,4 +30,3 @@ _STD_END
 
 #include "wcout.cpp"
 #include <iostream>
-#endif

--- a/stl/src/ushcout.cpp
+++ b/stl/src/ushcout.cpp
@@ -13,7 +13,6 @@ using ushfilebuf = basic_filebuf<unsigned short, char_traits<unsigned short>>;
 
 _STD_END
 
-#ifndef wistream
 #define wistream    ushistream
 #define wostream    ushostream
 #define wfilebuf    ushfilebuf
@@ -26,7 +25,6 @@ _STD_END
 #define init_wcout  init_ushcout
 #define init_wclog  init_ushclog
 #define init_wcin   init_ushcin
-#endif
 
 #include "wcout.cpp"
 #include <iostream>

--- a/stl/src/ushiostr.cpp
+++ b/stl/src/ushiostr.cpp
@@ -3,7 +3,6 @@
 
 // _UShinit members (unsigned short version)
 
-#ifdef _NATIVE_WCHAR_T_DEFINED
 #include <fstream>
 
 _STD_BEGIN
@@ -40,5 +39,4 @@ __PURE_APPDOMAIN_GLOBAL extern _CRTDATA2_IMPORT wostream* _Ptr_wcerr = nullptr;
 __PURE_APPDOMAIN_GLOBAL extern _CRTDATA2_IMPORT wostream* _Ptr_wclog = nullptr;
 _STD_END
 #include "wiostrea.cpp"
-#endif
 #endif

--- a/stl/src/ushiostr.cpp
+++ b/stl/src/ushiostr.cpp
@@ -13,14 +13,10 @@ using ushfilebuf = basic_filebuf<unsigned short, char_traits<unsigned short>>;
 
 _STD_END
 
-#define wistream    ushistream
-#define wostream    ushostream
-#define wfilebuf    ushfilebuf
-#define _Init_wcerr _Init_ushcerr
-#define _Init_wcout _Init_ushcout
-#define _Init_wclog _Init_ushclog
-#define _Init_wcin  _Init_ushcin
-#define _Winit      _UShinit
+#define wistream ushistream
+#define wostream ushostream
+#define wfilebuf ushfilebuf
+#define _Winit   _UShinit
 
 #include <iostream>
 

--- a/stl/src/wlocale.cpp
+++ b/stl/src/wlocale.cpp
@@ -55,7 +55,6 @@ void __CLRCALL_OR_CDECL locale::_Locimp::_Makewloc(const _Locinfo& lobj, locale:
     ADDFAC(_Tw13, cat, ptrimp, ptrloc);
 }
 
-#ifdef _NATIVE_WCHAR_T_DEFINED
 // moved from locale to ease subsetting
 using _Tu1  = ctype<unsigned short>;
 using _Tu2  = num_get<unsigned short>;
@@ -87,6 +86,5 @@ void __CLRCALL_OR_CDECL locale::_Locimp::_Makeushloc(const _Locinfo& lobj, local
     ADDFAC(_Tu12, cat, ptrimp, ptrloc);
     ADDFAC(_Tu13, cat, ptrimp, ptrloc);
 }
-#endif // _NATIVE_WCHAR_T_DEFINED
 
 _STD_END


### PR DESCRIPTION
This is structured as a series of commits for easier reviewing.

* `stl/src` is always built with real `wchar_t`, so we don't need to test `#ifdef _NATIVE_WCHAR_T_DEFINED`.
* `ushMEOW.cpp` cleanups:
  + Only the `ushMEOW.cpp` files `#define wistream`, so we don't need to test `#ifndef wistream`.
  + Each `ushMEOW.cpp` only needs to macroize its corresponding `_Init_wMEOW` and `init_wMEOW`.
  + Consistency: `ushMEOW.cpp` should `#define _Winit` last (as `ushcerr.cpp` already did).
  + Each `wMEOW.cpp` already includes `<iostream>`, so `ushMEOW.cpp` doesn't need to do so explicitly.
  + Fix copy-pasted comments in `ushMEOW.cpp` (only `ushcerr.cpp` was correct).
* `fiopen.cpp` cleanups:
  + `fiopen.cpp` doesn't need to include `<Windows.h>` at all.
  + Move `fiopen.cpp` helpers into an unnamed namespace.
    - Ignore whitespace when viewing this commit.
    - Precedent for the `using`-declaration: https://github.com/microsoft/STL/blob/ea32e86deed6e8a8cd6116dc275e358a901d2b50/stl/src/syserror.cpp#L17-L18
    - These helpers were neither dllexported nor mentioned by `stl/inc`, so they're safe to move into an unnamed namespace. (This makes it clear that they're internal helpers that aren't needed by other source files, and slightly helps static linking by avoiding symbols with external linkage that no user code will ever need to look for.)