### PR TITLE
Various header cleanups

### DIFF
--- a/stl/inc/array
+++ b/stl/inc/array
@@ -767,7 +767,7 @@ public:
 
 template <class _Ty, size_t _Size, enable_if_t<_Size == 0 || _Is_swappable<_Ty>::value, int> = 0>
 _CONSTEXPR20 void swap(array<_Ty, _Size>& _Left, array<_Ty, _Size>& _Right) noexcept(noexcept(_Left.swap(_Right))) {
-    return _Left.swap(_Right);
+    _Left.swap(_Right);
 }
 
 template <class _Ty, size_t _Size>

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -4621,9 +4621,9 @@ concept _Has_ok = requires(_Ty _At) {
 // A chrono spec is either a type (with an optional modifier), OR a literal character, never both.
 template <class _CharT>
 struct _Chrono_spec {
-    _CharT _Lit_char = _CharT{'\0'}; // any character other than '{', '}', or '%'
-    char _Modifier   = '\0'; // either 'E' or 'O'
-    char _Type       = '\0';
+    _CharT _Lit_char{'\0'}; // any character other than '{', '}', or '%'
+    char _Modifier = '\0'; // either 'E' or 'O'
+    char _Type     = '\0';
 };
 
 template <class _CharT>

--- a/stl/inc/complex
+++ b/stl/inc/complex
@@ -315,8 +315,8 @@ namespace _Math_algorithms {
         }
 
         if (_Hypot_leg_tiny<_Ty> < _Av && _Av < _Hypot_leg_huge<_Ty>) { // no overflow or harmful underflow
-            constexpr _Ty _Norm_small = _Ty{0.5};
-            constexpr _Ty _Norm_big   = _Ty{3.0};
+            constexpr _Ty _Norm_small{0.5};
+            constexpr _Ty _Norm_big{3.0};
 
             const _Ty _Bv_sqr = _Bv * _Bv;
 

--- a/stl/inc/cvt/ebcdic
+++ b/stl/inc/cvt/ebcdic
@@ -23,9 +23,8 @@ namespace stdext {
         using _Statype = _CSTD mbstate_t;
 
         template <class _Elem, unsigned char _Maxcode = 0xff>
-        class codecvt_ebcdic
-            : public _STD
-                  codecvt<_Elem, char, _Statype> { // facet for converting between ISO-8859-1 _Elem and EBCDIC bytes
+        class codecvt_ebcdic : public _STD codecvt<_Elem, char, _Statype> {
+            // facet for converting between ISO-8859-1 _Elem and EBCDIC bytes
             static const unsigned char _Atoe[0x100];
             static const unsigned char _Etoa[0x100];
 

--- a/stl/inc/cvt/one_one
+++ b/stl/inc/cvt/one_one
@@ -27,9 +27,8 @@ namespace stdext {
         _STL_DISABLE_DEPRECATED_WARNING
         template <class _Elem, unsigned long _Maxcode = 0xffffffff, _STD codecvt_mode _Mode = _STD codecvt_mode{},
             size_t _Bytes_per_word = sizeof(_Elem)>
-        class codecvt_one_one
-            : public _STD
-                  codecvt<_Elem, char, _Statype> { // facet for converting between _Elem and serialized byte sequences
+        class codecvt_one_one : public _STD codecvt<_Elem, char, _Statype> {
+            // facet for converting between _Elem and serialized byte sequences
         public:
             static_assert(_Bytes_per_word >= 1 && _Bytes_per_word <= 4, "bad byte count parameter");
 

--- a/stl/inc/cvt/utf16
+++ b/stl/inc/cvt/utf16
@@ -25,9 +25,8 @@ namespace stdext {
 
         _STL_DISABLE_DEPRECATED_WARNING
         template <class _Elem, unsigned long _Maxcode = 0x10ffff, _STD codecvt_mode _Mode = _STD codecvt_mode{}>
-        class codecvt_utf16
-            : public _STD
-                  codecvt<_Elem, char, _Statype> { // facet for converting between _Elem and UTF-16 multibyte sequences
+        class codecvt_utf16 : public _STD codecvt<_Elem, char, _Statype> {
+            // facet for converting between _Elem and UTF-16 multibyte sequences
             enum { _Bytes_per_word = 2 };
 
         public:

--- a/stl/inc/cvt/utf8
+++ b/stl/inc/cvt/utf8
@@ -26,9 +26,8 @@ namespace stdext {
 
         _STL_DISABLE_DEPRECATED_WARNING
         template <class _Elem, unsigned long _Maxcode = 0xffffffff, _STD codecvt_mode _Mode = _STD codecvt_mode{}>
-        class codecvt_utf8
-            : public _STD
-                  codecvt<_Elem, char, _Statype> { // facet for converting between _Elem and UTF-8 byte sequences
+        class codecvt_utf8 : public _STD codecvt<_Elem, char, _Statype> {
+            // facet for converting between _Elem and UTF-8 byte sequences
         public:
             using _Mybase     = _STD codecvt<_Elem, char, _Statype>;
             using result      = typename _Mybase::result;

--- a/stl/inc/cvt/utf8_utf16
+++ b/stl/inc/cvt/utf8_utf16
@@ -27,9 +27,8 @@ namespace stdext {
         _STL_DISABLE_DEPRECATED_WARNING
         template <class _Elem, unsigned long _Maxcode = 0x10ffff, _STD codecvt_mode _Mode = _STD codecvt_mode{},
             class _Statype = _Mbstatype>
-        class codecvt_utf8_utf16
-            : public _STD
-                  codecvt<_Elem, char, _Statype> { // facet for converting between UTF-16 _Elem and UTF-8 byte sequences
+        class codecvt_utf8_utf16 : public _STD codecvt<_Elem, char, _Statype> {
+            // facet for converting between UTF-16 _Elem and UTF-8 byte sequences
         public:
             using _Mybase     = _STD codecvt<_Elem, char, _Statype>;
             using result      = typename _Mybase::result;

--- a/stl/inc/cvt/xjis
+++ b/stl/inc/cvt/xjis
@@ -30,9 +30,8 @@ namespace stdext {
 #define _ESC_CODE 0x1b
 
         template <class _Elem, unsigned long _Maxcode = 0xffff>
-        class codecvt_jis
-            : public _STD
-                  codecvt<_Elem, char, _Statype> { // facet for converting between JIS-X0208 _Elem and UCS-2 bytes
+        class codecvt_jis : public _STD codecvt<_Elem, char, _Statype> {
+            // facet for converting between JIS-X0208 _Elem and UCS-2 bytes
             using _Table = _tab_jis<int>;
 
             bool _Jis_to_ucs(unsigned short& _Ch) const { // convert _Ch from JIS-X0208 to UCS-2

--- a/stl/inc/cvt/xtwo_byte
+++ b/stl/inc/cvt/xtwo_byte
@@ -24,9 +24,8 @@ namespace stdext {
         using _Statype = _CSTD mbstate_t;
 
         template <class _Elem, class _Table, unsigned long _Maxcode = 0xffff>
-        class _Cvt_two_byte
-            : public _STD
-                  codecvt<_Elem, char, _Statype> { // facet for converting between _Elem and one- or two-byte sequences
+        class _Cvt_two_byte : public _STD codecvt<_Elem, char, _Statype> {
+            // facet for converting between _Elem and one- or two-byte sequences
         public:
             using _Mybase     = _STD codecvt<_Elem, char, _Statype>;
             using result      = typename _Mybase::result;

--- a/stl/inc/deque
+++ b/stl/inc/deque
@@ -1466,7 +1466,7 @@ private:
             _Uninitialized_value_construct_n_unchecked1(_Myptr, _Count); // clear rest to initial block
         }
 
-        if (_Map() != _Mapptr()) {
+        if (_Map() != nullptr) {
             _Destroy_range(_Map(), _Map() + _Mapsize());
             _Almap.deallocate(_Map(), _Mapsize()); // free storage for old
         }
@@ -1483,7 +1483,7 @@ private:
             pop_back();
         }
 
-        if (_Map() != _Mapptr()) {
+        if (_Map() != nullptr) {
             for (size_type _Block = _Mapsize(); _Block > 0;) { // free storage for a block and destroy pointer
                 if (_Map()[--_Block]) { // free block
                     _Getal().deallocate(_Map()[_Block], _Block_size);
@@ -1495,7 +1495,7 @@ private:
         }
 
         _Mapsize() = 0;
-        _Map()     = _Mapptr();
+        _Map()     = nullptr;
     }
 
 #if _ITERATOR_DEBUG_LEVEL == 2

--- a/stl/inc/experimental/filesystem
+++ b/stl/inc/experimental/filesystem
@@ -1008,13 +1008,7 @@ public:
         return _Path_cvt<value_type, char16_t>::_Cvt(_Str, _Mystr.c_str(), _Mystr.size());
     }
 
-    _STD u32string u32string() const = delete; // TRANSITION, ABI
-#if 0
-                { // return path as basic_string<char32_t> UTF32
-                    _STD u32string _Str;
-                    return _Path_cvt<value_type, char32_t>::_Cvt(_Str, _Mystr.c_str(), _Mystr.size());
-                }
-#endif // 0
+    _STD u32string u32string() const = delete;
 
     string_type _Make_generic() const { // copy and convert any '\' to '/'
         string_type _Str = _Mystr;
@@ -1055,14 +1049,7 @@ public:
         return _Path_cvt<value_type, char16_t>::_Cvt(_Str, _Genstr.c_str(), _Genstr.size());
     }
 
-    _STD u32string generic_u32string() const = delete; // TRANSITION, ABI
-#if 0
-                { // return path as basic_string<char32_t> UTF32
-                    _STD u32string _Str;
-                    const string_type _Genstr = _Make_generic();
-                    return _Path_cvt<value_type, char32_t>::_Cvt(_Str, _Genstr.c_str(), _Genstr.size());
-                }
-#endif // 0
+    _STD u32string generic_u32string() const = delete;
 
     _NODISCARD int compare(const path& _Path) const noexcept { // compare native() to _Path.native()
         return _Mystr.compare(_Path._Mystr);

--- a/stl/inc/filesystem
+++ b/stl/inc/filesystem
@@ -254,7 +254,7 @@ namespace filesystem {
     _NODISCARD wstring _Convert_stringoid_to_wide(const wstring_view _Input, _Conversion) {
         static_assert(
             is_same_v<_Conversion, _Normal_conversion>, "invalid value_type, see N4810 D.17 [depr.fs.path.factory]/1");
-        return wstring(_Input);
+        return wstring{_Input};
     }
 
 #ifdef __cpp_char8_t
@@ -271,7 +271,7 @@ namespace filesystem {
     _NODISCARD wstring _Convert_stringoid_to_wide(const u16string_view _Input, _Conversion) {
         static_assert(
             is_same_v<_Conversion, _Normal_conversion>, "invalid value_type, see N4810 D.17 [depr.fs.path.factory]/1");
-        return wstring(_Input.data(), _Input.data() + _Input.size());
+        return wstring{_Input.data(), _Input.data() + _Input.size()};
     }
 
     template <class _Conversion>

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -1264,8 +1264,8 @@ _NODISCARD constexpr const _CharT* _Parse_replacement_field(
         _Handler._On_text(_First, _First + 1);
     } else {
         _Id_adapter<_CharT> _Adapter{_Handler._Parse_context};
-        _First     = _Parse_arg_id(_First, _Last, _Adapter);
-        _CharT _Ch = _CharT{};
+        _First = _Parse_arg_id(_First, _Last, _Adapter);
+        _CharT _Ch{};
         if (_First != _Last) {
             _Ch = *_First;
         }

--- a/stl/inc/forward_list
+++ b/stl/inc/forward_list
@@ -1126,7 +1126,7 @@ public:
             // snip the node out
             const auto _Removed = _Predecessor->_Next;
             const auto _Next    = _Removed->_Next;
-            _Removed->_Next     = _Nodeptr();
+            _Removed->_Next     = nullptr;
             _Predecessor->_Next = _Next;
 
             *_Tail = _Removed;

--- a/stl/inc/future
+++ b/stl/inc/future
@@ -322,8 +322,8 @@ public:
         _Set_value_raw(_Val, &_Lock, _At_thread_exit);
     }
 
-    void _Set_value_raw(const _Ty& _Val, unique_lock<mutex>* _Lock,
-        bool _At_thread_exit) { // store a result while inside a locked block
+    void _Set_value_raw(const _Ty& _Val, unique_lock<mutex>* _Lock, bool _At_thread_exit) {
+        // store a result while inside a locked block
         if (_Already_has_stored_result()) {
             _Throw_future_error2(future_errc::promise_already_satisfied);
         }
@@ -337,8 +337,8 @@ public:
         _Set_value_raw(_STD forward<_Ty>(_Val), &_Lock, _At_thread_exit);
     }
 
-    void _Set_value_raw(_Ty&& _Val, unique_lock<mutex>* _Lock,
-        bool _At_thread_exit) { // store a result while inside a locked block
+    void _Set_value_raw(_Ty&& _Val, unique_lock<mutex>* _Lock, bool _At_thread_exit) {
+        // store a result while inside a locked block
         if (_Already_has_stored_result()) {
             _Throw_future_error2(future_errc::promise_already_satisfied);
         }
@@ -352,8 +352,8 @@ public:
         _Set_exception_raw(_Exc, &_Lock, _At_thread_exit);
     }
 
-    void _Set_exception_raw(exception_ptr _Exc, unique_lock<mutex>* _Lock,
-        bool _At_thread_exit) { // store a result while inside a locked block
+    void _Set_exception_raw(exception_ptr _Exc, unique_lock<mutex>* _Lock, bool _At_thread_exit) {
+        // store a result while inside a locked block
         if (_Already_has_stored_result()) {
             _Throw_future_error2(future_errc::promise_already_satisfied);
         }
@@ -454,8 +454,8 @@ public:
 };
 
 template <class _Ty, class _Derived, class _Alloc>
-void _State_deleter<_Ty, _Derived, _Alloc>::_Delete(
-    _Associated_state<_Ty>* _State) { // delete _State and this using stored allocator
+void _State_deleter<_Ty, _Derived, _Alloc>::_Delete(_Associated_state<_Ty>* _State) {
+    // delete _State and this using stored allocator
     using _State_allocator = _Rebind_alloc_t<_Alloc, _Derived>;
     _State_allocator _St_alloc(_My_alloc);
 
@@ -1507,8 +1507,8 @@ private:
 };
 
 template <class _Ret, class _Fty>
-_Associated_state<typename _P_arg_type<_Ret>::type>* _Get_associated_state(
-    launch _Psync, _Fty&& _Fnarg) { // construct associated asynchronous state object for the launch type
+_Associated_state<typename _P_arg_type<_Ret>::type>* _Get_associated_state(launch _Psync, _Fty&& _Fnarg) {
+    // construct associated asynchronous state object for the launch type
     switch (_Psync) { // select launch type
     case launch::deferred:
         return new _Deferred_async_state<_Ret>(_STD forward<_Fty>(_Fnarg));

--- a/stl/inc/list
+++ b/stl/inc/list
@@ -1528,14 +1528,14 @@ public:
 
             // snip the node out
             --_List._Mypair._Myval2._Mysize;
-            const auto _Next = _STD exchange(_Removed->_Next, _Nodeptr());
+            const auto _Next = _STD exchange(_Removed->_Next, nullptr);
             const auto _Prev = _Removed->_Prev;
             _Prev->_Next     = _Next;
             _Next->_Prev     = _Prev;
 
 #if _ITERATOR_DEBUG_LEVEL == 2
             // mark removed node for IDL to snip out later
-            _Removed->_Prev = _Nodeptr();
+            _Removed->_Prev = nullptr;
 #endif // _ITERATOR_DEBUG_LEVEL == 2
 
             *_Tail = _Removed;
@@ -1578,7 +1578,7 @@ public:
         }
 
         list& _List;
-        _Nodeptr _Head; // singly linked list of nodes to remove; their _Prev pointers set to _Nodeptr()
+        _Nodeptr _Head; // singly linked list of nodes to remove; their _Prev pointers set to nullptr
         _Nodeptr* _Tail;
     };
 

--- a/stl/inc/locale
+++ b/stl/inc/locale
@@ -31,13 +31,13 @@ public:
     using char_type   = _Elem;
     using string_type = basic_string<_Elem, char_traits<_Elem>, allocator<_Elem>>;
 
-    _NODISCARD int compare(const _Elem* _First1, const _Elem* _Last1, const _Elem* _First2,
-        const _Elem* _Last2) const { // compare [_First1, _Last1) to [_First2, _Last2)
+    _NODISCARD int compare(const _Elem* _First1, const _Elem* _Last1, const _Elem* _First2, const _Elem* _Last2) const {
+        // compare [_First1, _Last1) to [_First2, _Last2)
         return do_compare(_First1, _Last1, _First2, _Last2);
     }
 
-    _NODISCARD string_type transform(
-        const _Elem* _First, const _Elem* _Last) const { // transform [_First, _Last) to key string
+    _NODISCARD string_type transform(const _Elem* _First, const _Elem* _Last) const {
+        // transform [_First, _Last) to key string
         return do_transform(_First, _Last);
     }
 
@@ -80,17 +80,17 @@ protected:
         _Coll = _Lobj._Getcoll();
     }
 
-    _NODISCARD virtual int __CLR_OR_THIS_CALL do_compare(const _Elem* _First1, const _Elem* _Last1,
-        const _Elem* _First2,
-        const _Elem* _Last2) const { // compare [_First1, _Last1) to [_First2, _Last2)
+    _NODISCARD virtual int __CLR_OR_THIS_CALL do_compare(
+        const _Elem* _First1, const _Elem* _Last1, const _Elem* _First2, const _Elem* _Last2) const {
+        // compare [_First1, _Last1) to [_First2, _Last2)
         _Adl_verify_range(_First1, _Last1);
         _Adl_verify_range(_First2, _Last2);
         int _Ans = _LStrcoll(_First1, _Last1, _First2, _Last2, &_Coll);
         return _Ans < 0 ? -1 : _Ans == 0 ? 0 : +1;
     }
 
-    _NODISCARD virtual string_type __CLR_OR_THIS_CALL do_transform(const _Elem* _First,
-        const _Elem* _Last) const { // transform [_First, _Last) to key string
+    _NODISCARD virtual string_type __CLR_OR_THIS_CALL do_transform(const _Elem* _First, const _Elem* _Last) const {
+        // transform [_First, _Last) to key string
         _Adl_verify_range(_First, _Last);
         size_t _Count;
         string_type _Str;
@@ -106,8 +106,8 @@ protected:
         return _Str;
     }
 
-    _NODISCARD virtual long __CLR_OR_THIS_CALL do_hash(
-        const _Elem* _First, const _Elem* _Last) const { // compute hash code for [_First, _Last)
+    _NODISCARD virtual long __CLR_OR_THIS_CALL do_hash(const _Elem* _First, const _Elem* _Last) const {
+        // compute hash code for [_First, _Last)
         _Adl_verify_range(_First, _Last);
         return static_cast<long>(_Hash_array_representation(_First, static_cast<size_t>(_Last - _First)));
     }

--- a/stl/inc/memory_resource
+++ b/stl/inc/memory_resource
@@ -315,8 +315,8 @@ namespace pmr {
         }
 
     private:
-        struct _Oversized_header
-            : _Double_link<> { // tracks an allocation that was obtained directly from the upstream resource
+        struct _Oversized_header : _Double_link<> {
+            // tracks an allocation that was obtained directly from the upstream resource
             size_t _Size;
             size_t _Align;
 
@@ -383,8 +383,8 @@ namespace pmr {
         }
 
         struct _Pool { // manager for a collection of chunks comprised of blocks of a single size
-            struct _Chunk
-                : _Single_link<> { // a memory allocation consisting of a number of fixed-size blocks to be parceled out
+            struct _Chunk : _Single_link<> {
+                // a memory allocation consisting of a number of fixed-size blocks to be parceled out
                 _Intrusive_stack<_Single_link<>> _Free_blocks{}; // list of free blocks
                 size_t _Free_count; // # of unallocated blocks
                 size_t _Capacity; // total # of blocks

--- a/stl/inc/memory_resource
+++ b/stl/inc/memory_resource
@@ -204,9 +204,9 @@ namespace pmr {
 
         constexpr void _Remove(_Ty* const _Item) noexcept {
             const auto _Ptr = _As_link(_Item);
-            for (_Link_type** _Foo = &_Head; *_Foo; _Foo = &(*_Foo)->_Next) {
-                if (*_Foo == _Ptr) {
-                    *_Foo = _Ptr->_Next;
+            for (_Link_type** _Pnext = &_Head; *_Pnext; _Pnext = &(*_Pnext)->_Next) {
+                if (*_Pnext == _Ptr) {
+                    *_Pnext = _Ptr->_Next;
                     break;
                 }
             }

--- a/stl/inc/memory_resource
+++ b/stl/inc/memory_resource
@@ -204,7 +204,7 @@ namespace pmr {
 
         constexpr void _Remove(_Ty* const _Item) noexcept {
             const auto _Ptr = _As_link(_Item);
-            for (_Link_type** _Foo = _STD addressof(_Head); *_Foo; _Foo = _STD addressof((*_Foo)->_Next)) {
+            for (_Link_type** _Foo = &_Head; *_Foo; _Foo = &(*_Foo)->_Next) {
                 if (*_Foo == _Ptr) {
                     *_Foo = _Ptr->_Next;
                     break;

--- a/stl/inc/memory_resource
+++ b/stl/inc/memory_resource
@@ -110,8 +110,10 @@ namespace pmr {
     };
 
     template <class _Ty, class _Tag = void>
-    struct _Intrusive_list { // intrusive circular list of _Ty (which must derive from _Double_link<_Tag>)
+    struct _Intrusive_list { // intrusive circular list of _Ty, which must derive from _Double_link<_Tag>
         using _Link_type = _Double_link<_Tag>;
+
+        _STL_INTERNAL_STATIC_ASSERT(is_base_of_v<_Link_type, _Ty>);
 
         constexpr _Intrusive_list() noexcept { // TRANSITION, VSO-517878
             // initialize this list to the empty state
@@ -122,17 +124,14 @@ namespace pmr {
 
         static constexpr _Link_type* _As_link(_Ty* const _Ptr) noexcept {
             // extract the link from the item denoted by _Ptr
-            static_assert(is_base_of_v<_Link_type, _Ty>);
             return static_cast<_Link_type*>(_Ptr);
         }
 
         static constexpr _Ty* _As_item(_Link_type* const _Ptr) noexcept { // get the item whose link is denoted by _Ptr
-            static_assert(is_base_of_v<_Link_type, _Ty>);
             return static_cast<_Ty*>(_Ptr);
         }
 
         constexpr void _Push_front(_Ty* const _Item) noexcept { // insert _Item at the head of this list
-            static_assert(is_base_of_v<_Link_type, _Ty>);
             const auto _Ptr    = static_cast<_Link_type*>(_Item);
             _Ptr->_Next        = _Head._Next;
             _Head._Next->_Prev = _Ptr;
@@ -141,7 +140,6 @@ namespace pmr {
         }
 
         static constexpr void _Remove(_Ty* const _Item) noexcept { // unlink _Item from this list
-            static_assert(is_base_of_v<_Link_type, _Ty>);
             const auto _Ptr    = static_cast<_Link_type*>(_Item);
             _Ptr->_Next->_Prev = _Ptr->_Prev;
             _Ptr->_Prev->_Next = _Ptr->_Next;
@@ -164,6 +162,8 @@ namespace pmr {
     struct _Intrusive_stack { // intrusive stack of _Ty, which must derive from _Single_link<_Tag>
         using _Link_type = _Single_link<_Tag>;
 
+        _STL_INTERNAL_STATIC_ASSERT(is_base_of_v<_Link_type, _Ty>);
+
         constexpr _Intrusive_stack() noexcept = default;
         constexpr _Intrusive_stack(_Intrusive_stack&& _That) noexcept : _Head{_That._Head} {
             _That._Head = nullptr;
@@ -175,12 +175,10 @@ namespace pmr {
         }
 
         static constexpr _Link_type* _As_link(_Ty* const _Ptr) noexcept {
-            static_assert(is_base_of_v<_Link_type, _Ty>);
             return static_cast<_Link_type*>(_Ptr);
         }
 
         static constexpr _Ty* _As_item(_Link_type* const _Ptr) noexcept {
-            static_assert(is_base_of_v<_Link_type, _Ty>);
             return static_cast<_Ty*>(_Ptr);
         }
 

--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -345,7 +345,7 @@ public:
 
     template <class _FwdIt>
     string_type lookup_collatename(_FwdIt _First, _FwdIt _Last) const { // map [_First, _Last) to collation element
-        return string_type(_First, _Last);
+        return string_type{_First, _Last};
     }
 
     locale_type imbue(locale_type _Lx) { // store locale object
@@ -611,7 +611,7 @@ public:
 
     _NODISCARD string_type str() const { // convert matched text to string
         const _Mybase _Range(_Effective_range());
-        return string_type(_Range.first, _Range.second);
+        return string_type{_Range.first, _Range.second};
     }
 
     _NODISCARD int compare(const sub_match& _Right) const { // compare *this to _Right
@@ -1008,7 +1008,7 @@ public:
     }
 
     _NODISCARD string_type str(size_type _Sub = 0) const {
-        return string_type((*this)[_Sub]);
+        return string_type{(*this)[_Sub]};
     }
 
     _NODISCARD const_reference operator[](size_type _Sub) const noexcept /* strengthened */ {

--- a/stl/inc/system_error
+++ b/stl/inc/system_error
@@ -522,7 +522,7 @@ public:
         if (_Errcode == static_cast<int>(io_errc::stream)) {
             static constexpr char _Iostream_error[] = "iostream stream error";
             constexpr size_t _Iostream_error_length = sizeof(_Iostream_error) - 1; // TRANSITION, DevCom-906503
-            return string(_Iostream_error, _Iostream_error_length);
+            return string{_Iostream_error, _Iostream_error_length};
         } else {
             return _Syserror_map(_Errcode);
         }
@@ -542,9 +542,9 @@ public:
         if (_Msg._Length == 0) {
             static constexpr char _Unknown_error[] = "unknown error";
             constexpr size_t _Unknown_error_length = sizeof(_Unknown_error) - 1; // TRANSITION, DevCom-906503
-            return string(_Unknown_error, _Unknown_error_length);
+            return string{_Unknown_error, _Unknown_error_length};
         } else {
-            return string(_Msg._Str, _Msg._Length);
+            return string{_Msg._Str, _Msg._Length};
         }
     }
 

--- a/stl/inc/tuple
+++ b/stl/inc/tuple
@@ -950,14 +950,14 @@ _NODISCARD constexpr bool operator<=(const tuple<_Types1...>& _Left, const tuple
 
 template <class... _Types, enable_if_t<conjunction_v<_Is_swappable<_Types>...>, int> = 0>
 _CONSTEXPR20 void swap(tuple<_Types...>& _Left, tuple<_Types...>& _Right) noexcept(noexcept(_Left.swap(_Right))) {
-    return _Left.swap(_Right);
+    _Left.swap(_Right);
 }
 
 #if _HAS_CXX23
 template <class... _Types, enable_if_t<conjunction_v<is_swappable<const _Types>...>, int> = 0>
 constexpr void swap(const tuple<_Types...>& _Left, const tuple<_Types...>& _Right) noexcept(
     noexcept(_Left.swap(_Right))) {
-    return _Left.swap(_Right);
+    _Left.swap(_Right);
 }
 #endif // _HAS_CXX23
 

--- a/stl/inc/xlocale
+++ b/stl/inc/xlocale
@@ -358,7 +358,7 @@ public:
     }
 
     string name() const {
-        return _Ptr ? _Ptr->_Name.c_str() : string();
+        return _Ptr ? _Ptr->_Name.c_str() : string{};
     }
 
     _Ret_z_ const char* c_str() const {

--- a/stl/inc/xlocmon
+++ b/stl/inc/xlocmon
@@ -166,19 +166,19 @@ protected:
     }
 
     virtual string __CLR_OR_THIS_CALL do_grouping() const {
-        return string(_Grouping);
+        return string{_Grouping};
     }
 
     virtual string_type __CLR_OR_THIS_CALL do_curr_symbol() const {
-        return string_type(_Currencysign);
+        return string_type{_Currencysign};
     }
 
     virtual string_type __CLR_OR_THIS_CALL do_positive_sign() const {
-        return string_type(_Plussign);
+        return string_type{_Plussign};
     }
 
     virtual string_type __CLR_OR_THIS_CALL do_negative_sign() const {
-        return string_type(_Minussign);
+        return string_type{_Minussign};
     }
 
     virtual int __CLR_OR_THIS_CALL do_frac_digits() const {

--- a/stl/inc/xlocnum
+++ b/stl/inc/xlocnum
@@ -201,15 +201,15 @@ protected:
     }
 
     virtual string __CLR_OR_THIS_CALL do_grouping() const {
-        return string(_Grouping);
+        return string{_Grouping};
     }
 
     virtual string_type __CLR_OR_THIS_CALL do_falsename() const {
-        return string_type(_Falsename);
+        return string_type{_Falsename};
     }
 
     virtual string_type __CLR_OR_THIS_CALL do_truename() const {
-        return string_type(_Truename);
+        return string_type{_Truename};
     }
 
 private:

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -4617,7 +4617,7 @@ public:
 
     _NODISCARD _CONSTEXPR20 basic_string substr(const size_type _Off = 0, const size_type _Count = npos) const {
         // return [_Off, _Off + _Count) as new string
-        return basic_string(*this, _Off, _Count, get_allocator());
+        return basic_string{*this, _Off, _Count, get_allocator()};
     }
 
     _CONSTEXPR20 bool _Equal(const basic_string& _Right) const noexcept {
@@ -5268,25 +5268,25 @@ inline namespace literals {
 #endif // ^^^ no workaround ^^^
 
         _NODISCARD _CONSTEXPR20_STRING_LITERALS string operator"" s(const char* _Str, size_t _Len) {
-            return string(_Str, _Len);
+            return string{_Str, _Len};
         }
 
         _NODISCARD _CONSTEXPR20_STRING_LITERALS wstring operator"" s(const wchar_t* _Str, size_t _Len) {
-            return wstring(_Str, _Len);
+            return wstring{_Str, _Len};
         }
 
 #ifdef __cpp_char8_t
         _NODISCARD _CONSTEXPR20_STRING_LITERALS basic_string<char8_t> operator"" s(const char8_t* _Str, size_t _Len) {
-            return basic_string<char8_t>(_Str, _Len);
+            return basic_string<char8_t>{_Str, _Len};
         }
 #endif // __cpp_char8_t
 
         _NODISCARD _CONSTEXPR20_STRING_LITERALS u16string operator"" s(const char16_t* _Str, size_t _Len) {
-            return u16string(_Str, _Len);
+            return u16string{_Str, _Len};
         }
 
         _NODISCARD _CONSTEXPR20_STRING_LITERALS u32string operator"" s(const char32_t* _Str, size_t _Len) {
-            return u32string(_Str, _Len);
+            return u32string{_Str, _Len};
         }
 
 #undef _CONSTEXPR20_STRING_LITERALS // TRANSITION, VSO-1273381


### PR DESCRIPTION
* `<deque>`, `<forward_list>`, `<list>`: Use `nullptr` instead of `_Mapptr()` and `_Nodeptr()`.
  + At first, I was going to change these empty parens to empty braces for consistency with our modern conventions (braces make it clear when we're constructing a temporary instead of calling a function), but `nullptr` is even clearer.
  + This is guaranteed to work because they're "nullable pointers", and we're already using `nullptr` with these types:
    https://github.com/microsoft/STL/blob/ea32e86deed6e8a8cd6116dc275e358a901d2b50/stl/inc/deque#L771
    https://github.com/microsoft/STL/blob/ea32e86deed6e8a8cd6116dc275e358a901d2b50/stl/inc/forward_list#L841
    https://github.com/microsoft/STL/blob/ea32e86deed6e8a8cd6116dc275e358a901d2b50/stl/inc/list#L445
* `<array>`, `<tuple>`: We don't need `return` after calling `_Left.swap(_Right);`.
* `<chrono>`, `<complex>`, `<format>`: Use direct-init instead of `Type var = Type{init};` which repeats the `Type` unnecessarily.
* Several headers: Detach comments.
  + As usual, this isn't attempting to be comprehensive. I just noticed a few cases of ugly wrapping (including when function parameters are unnecessarily wrapped).
* `<memory_resource>`:
  + Use centralized `_STL_INTERNAL_STATIC_ASSERT`s instead of user-visible `static_assert`s before every `static_cast`. (This is internal machinery, so we're just checking our own work here. I believe that this code may have predated the introduction of `_STL_INTERNAL_STATIC_ASSERT`.)
  + Also slightly update the `_Intrusive_list` comment for consistency with `_Intrusive_stack`.
  + In `_Remove()`, we don't need `addressof()` for raw pointers.
  + Rename `_Foo` (a meaningless name, which we conventionally avoid, especially in product code) to `_Pnext` (which is used in similar loops, and is actually somewhat descriptive here - except at the very beginning, it is pointing to a `_Next`).
* `<experimental/filesystem>`: Drop `// TRANSITION, ABI`, `#if 0` code.
  + IIRC, attempting to use `_Path_cvt<value_type, char32_t>` resulted in compiler errors, which we had hopes of someday fixing, or which perhaps were actually fixed by the codecvt_ids overhaul. In any event, there is no reason to attempt to enable these functions now. In vNext, we will simply eradicate `<experimental/filesystem>`.
* Several headers: Construct temporary strings with braces.
  + Note that `string_type(1, _FS_PREF)` cannot be changed, as that would attempt to construct a sequence of 2 characters (guess how I found out): https://github.com/microsoft/STL/blob/ea32e86deed6e8a8cd6116dc275e358a901d2b50/stl/inc/experimental/filesystem#L1086
