### PR TITLE
P0849R8 `auto(x)`: `decay-copy` In The Language

### DIFF
--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -190,6 +190,7 @@
 // P0784R7 Library Support For More constexpr Containers
 // P0811R3 midpoint(), lerp()
 // P0849R8 auto(x): decay-copy In The Language
+//     (library part only)
 // P0879R0 constexpr For Swapping Functions
 // P0887R1 type_identity
 // P0896R4 Ranges

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -189,6 +189,7 @@
 // P0769R2 shift_left(), shift_right()
 // P0784R7 Library Support For More constexpr Containers
 // P0811R3 midpoint(), lerp()
+// P0849R8 auto(x): decay-copy In The Language
 // P0879R0 constexpr For Swapping Functions
 // P0887R1 type_identity
 // P0896R4 Ranges


### PR DESCRIPTION
Fixes #2243. Thanks to @frederick-vs-ja and @CaseyCarter for analyzing the issue (see their comments there).

We implemented this in C++20 mode:

https://github.com/microsoft/STL/blob/7f04137880e1c3df5125c1baf808f16f399dee2e/stl/inc/xutility#L1698
https://github.com/microsoft/STL/blob/7f04137880e1c3df5125c1baf808f16f399dee2e/stl/inc/xutility#L1829
https://github.com/microsoft/STL/blob/7f04137880e1c3df5125c1baf808f16f399dee2e/stl/inc/xutility#L2003
https://github.com/microsoft/STL/blob/7f04137880e1c3df5125c1baf808f16f399dee2e/stl/inc/xutility#L2072

While this is theoretically observable, it would require some effort to test, and the risk of damaging this is extremely low, so I have chosen the lazy kitty path of "comment the feature as done, then flop over". :cat2: