### PR TITLE
add a visualizer for `_Ref_count_obj_alloc3` and `_Ref_count_obj2`

### DIFF
--- a/stl/debugger/STL.natvis
+++ b/stl/debugger/STL.natvis
@@ -400,6 +400,13 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
       </Expand>
   </Type>
 
+  <Type Name="std::_Ref_count_obj2&lt;*&gt;">
+      <DisplayString>make_shared</DisplayString>
+      <Expand>
+          <Item Condition="_Uses != 0" Name="[original ptr]">($T1 *) &amp;_Storage</Item>
+      </Expand>
+  </Type>
+
   <!-- VC 2013 -->
   <Type Name="std::_Ref_count_obj_alloc&lt;*&gt;" Priority="MediumLow">
       <DisplayString>allocate_shared</DisplayString>
@@ -415,6 +422,14 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
       <Expand>
           <Item Condition="_Uses != 0" Name="[original ptr]">($T1 *) &amp;_Mypair._Myval2</Item>
           <Item Name="[allocator]">_Mypair</Item>
+      </Expand>
+  </Type>
+
+  <Type Name="std::_Ref_count_obj_alloc3&lt;*&gt;">
+      <DisplayString>allocate_shared</DisplayString>
+      <Expand>
+          <Item Condition="_Uses != 0" Name="[original ptr]">($T1 *) &amp;_Storage</Item>
+          <Item Name="[allocator]">*((_Mybase *) this)</Item>
       </Expand>
   </Type>
 

--- a/stl/debugger/STL.natvis
+++ b/stl/debugger/STL.natvis
@@ -429,7 +429,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
   <!-- VS 2019 16.7: _Ref_count_obj_alloc3 -->
   <!-- VS 2019 16.3: _Ref_count_obj_alloc2 -->
   <Type Name="std::_Ref_count_obj_alloc3&lt;*&gt;">
-  <AlternativeType Name="std::_Ref_count_obj_alloc2&lt;*&gt;" />
+      <AlternativeType Name="std::_Ref_count_obj_alloc2&lt;*&gt;" />
       <!-- stateless allocator -->
       <Intrinsic Optional="true" Name="allocator" Expression="*((_Mybase *) this)"/>
       <!-- stateful allocator -->

--- a/stl/debugger/STL.natvis
+++ b/stl/debugger/STL.natvis
@@ -426,8 +426,9 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
       </Expand>
   </Type>
 
-  <!-- VS 2019 16.7 -->
+  <!-- VS 2019 _Ref_count_obj_alloc3 16.7,  _Ref_count_obj_alloc2 16.3 -->
   <Type Name="std::_Ref_count_obj_alloc3&lt;*&gt;">
+  <AlternativeType Name="std::_Ref_count_obj_alloc2&lt;*&gt;" />
       <!-- stateless allocator -->
       <Intrinsic Optional="true" Name="allocator" Expression="*((_Mybase *) this)"/>
       <!-- stateful allocator -->

--- a/stl/debugger/STL.natvis
+++ b/stl/debugger/STL.natvis
@@ -400,6 +400,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
       </Expand>
   </Type>
 
+  <!-- VS 2019 16.3 -->
   <Type Name="std::_Ref_count_obj2&lt;*&gt;">
       <DisplayString>make_shared</DisplayString>
       <Expand>
@@ -425,11 +426,15 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
       </Expand>
   </Type>
 
+  <!-- VS 2019 16.7 -->
   <Type Name="std::_Ref_count_obj_alloc3&lt;*&gt;">
       <DisplayString>allocate_shared</DisplayString>
       <Expand>
           <Item Condition="_Uses != 0" Name="[original ptr]">($T1 *) &amp;_Storage</Item>
-          <Item Name="[allocator]">*((_Mybase *) this)</Item>
+          <!-- stateless allocator -->
+          <Item Name="[allocator]" Optional="true">*((_Mybase *) this)</Item>
+          <!-- stateful allocator -->
+          <Item Name="[allocator]" Optional="true">_Myval</Item>
       </Expand>
   </Type>
 

--- a/stl/debugger/STL.natvis
+++ b/stl/debugger/STL.natvis
@@ -428,13 +428,14 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
   <!-- VS 2019 16.7 -->
   <Type Name="std::_Ref_count_obj_alloc3&lt;*&gt;">
+      <!-- stateless allocator -->
+      <Intrinsic Optional="true" Name="allocator" Expression="*((_Mybase *) this)"/>
+      <!-- stateful allocator -->
+      <Intrinsic Optional="true" Name="allocator" Expression="_Myval"/>
       <DisplayString>allocate_shared</DisplayString>
       <Expand>
           <Item Condition="_Uses != 0" Name="[original ptr]">($T1 *) &amp;_Storage</Item>
-          <!-- stateless allocator -->
-          <Item Name="[allocator]" Optional="true">*((_Mybase *) this)</Item>
-          <!-- stateful allocator -->
-          <Item Name="[allocator]" Optional="true">_Myval</Item>
+          <Item Name="[allocator]">allocator()</Item>
       </Expand>
   </Type>
 

--- a/stl/debugger/STL.natvis
+++ b/stl/debugger/STL.natvis
@@ -426,7 +426,8 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
       </Expand>
   </Type>
 
-  <!-- VS 2019 _Ref_count_obj_alloc3 16.7,  _Ref_count_obj_alloc2 16.3 -->
+  <!-- VS 2019 16.7: _Ref_count_obj_alloc3 -->
+  <!-- VS 2019 16.3: _Ref_count_obj_alloc2 -->
   <Type Name="std::_Ref_count_obj_alloc3&lt;*&gt;">
   <AlternativeType Name="std::_Ref_count_obj_alloc2&lt;*&gt;" />
       <!-- stateless allocator -->


### PR DESCRIPTION
Fixes #2787

test:
```c++
#include <memory>

int main() {
	std::allocator<int> alloc{};
	auto ms = std::make_shared<int>();
	auto as = std::allocate_shared<int>(alloc, 10);
        return 0;
}
```

![изображение](https://user-images.githubusercontent.com/4289847/174868845-22c5a7a4-a38a-45cb-b3cf-46256f797bc9.png)


Do we need some comments for them like `<!-- VC 2019 -->` ?