### PR TITLE
Fix vectorized `min/max/minmax_element` for 64-bit types on x86

### DIFF
--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -789,8 +789,9 @@ namespace {
 
         static _Signed_t _Get_any(const __m128i _Cur) noexcept {
 #ifdef _M_IX86
-            return static_cast<_Signed_t>((static_cast<_Unsigned_t>(_mm_extract_epi32(_Cur, 1)) << 32)
-                                          | static_cast<_Unsigned_t>(_mm_cvtsi128_si32(_Cur)));
+            return static_cast<_Signed_t>(
+                (static_cast<_Unsigned_t>(static_cast<uint32_t>(_mm_extract_epi32(_Cur, 1))) << 32)
+                | static_cast<_Unsigned_t>(static_cast<uint32_t>(_mm_cvtsi128_si32(_Cur))));
 #else // ^^^ x86 ^^^ / vvv x64 vvv
             return static_cast<_Signed_t>(_mm_cvtsi128_si64(_Cur));
 #endif // ^^^ x64 ^^^

--- a/tests/std/tests/VSO_0000000_vector_algorithms/test.cpp
+++ b/tests/std/tests/VSO_0000000_vector_algorithms/test.cpp
@@ -25,6 +25,7 @@ using namespace std;
 void initialize_randomness(mt19937_64& gen) {
     constexpr size_t n = mt19937_64::state_size;
     constexpr size_t w = mt19937_64::word_size;
+    static_assert(w % 32 == 0, "w should be evenly divisible by 32");
     constexpr size_t k = w / 32;
 
     vector<uint32_t> vec(n * k);

--- a/tests/std/tests/VSO_0000000_vector_algorithms/test.cpp
+++ b/tests/std/tests/VSO_0000000_vector_algorithms/test.cpp
@@ -366,6 +366,13 @@ void test_vector_algorithms() {
     test_min_max_element_special_cases<int8_t, 32>(); // AVX2 vectors
     test_min_max_element_special_cases<int8_t, 64>(); // AVX512 vectors
 
+    // Test VSO-1558536, a regression caused by GH-2447 that was specific to 64-bit types on x86.
+    test_case_min_max_element(vector<uint64_t>{10, 0x8000'0000ULL, 20, 30});
+    test_case_min_max_element(vector<uint64_t>{10, 20, 0xD000'0000'B000'0000ULL, 30, 0xC000'0000'A000'0000ULL});
+    test_case_min_max_element(vector<int64_t>{10, 0x8000'0000LL, 20, 30});
+    test_case_min_max_element(
+        vector<int64_t>{-6604286336755016904, -4365366089374418225, 6104371530830675888, -8582621853879131834});
+
     test_reverse<char>(gen);
     test_reverse<signed char>(gen);
     test_reverse<unsigned char>(gen);

--- a/tests/std/tests/VSO_0000000_vector_algorithms/test.cpp
+++ b/tests/std/tests/VSO_0000000_vector_algorithms/test.cpp
@@ -198,18 +198,9 @@ void test_case_min_max_element(const vector<T>& input) {
 
 template <class T>
 void test_min_max_element(mt19937_64& gen) {
-    static constexpr T Min = numeric_limits<T>::min();
-    static constexpr T Max = numeric_limits<T>::max();
+    using Limits = numeric_limits<T>;
 
-    auto dis = [] {
-        if constexpr (is_floating_point_v<T>) {
-            return uniform_real_distribution<T>{-Max / 2, Max / 2};
-        } else if constexpr (sizeof(T) > 1) {
-            return uniform_int_distribution<T>{Min, Max};
-        } else {
-            return uniform_int_distribution<int>{Min, Max};
-        }
-    }();
+    uniform_int_distribution<conditional_t<sizeof(T) == 1, int, T>> dis(Limits::min(), Limits::max());
 
     vector<T> input;
     input.reserve(dataCount);
@@ -396,9 +387,6 @@ void test_vector_algorithms(mt19937_64& gen) {
     test_min_max_element<unsigned int>(gen);
     test_min_max_element<long long>(gen);
     test_min_max_element<unsigned long long>(gen);
-    test_min_max_element<float>(gen);
-    test_min_max_element<double>(gen);
-    test_min_max_element<long double>(gen);
 
     test_min_max_element_pointers(gen);
 


### PR DESCRIPTION
This fixes a regression caused by #2447 that was specific to 64-bit types on x86, reported by internal VSO-1558536 "[RWC][prod/fe][Regression][x86] LLVM one test 'Profile/c-counter-overflows.c' failed".

Thanks to @AlexGuteniev for finding the root cause and providing the fix. The problem is that `_mm_extract_epi32` and `_mm_cvtsi128_si32` both return `int`. By directly casting to `_Unsigned_t`, i.e. `uint64_t` in `_Minmax_traits_8`, high-bit values were being sign-extended, but the desired behavior was zero-extension. Adding initial casts of `static_cast<uint32_t>` fixes this.

Then, I'm enhancing the test coverage:

* Adding a few specific test cases that failed.
* Truly randomizing the test, so that every run provides unique coverage.
* Using wider distributions of values for the min/max testing, since the limited `[1, 20]` range concealed this bug. Now, integers use the full range, while floating-point values use a large range centered around 0. (Unfortunately, `uniform_real_distribution` requires `b - a <= max`, so we can't generate a full range without extra work. As floating-point is not yet vectorized, I felt that this was sufficient for now.)

Fortunately, this regression has not yet shipped in a Preview.