### PR TITLE
workaround for `std::source_location::current()`

### DIFF
--- a/stl/inc/source_location
+++ b/stl/inc/source_location
@@ -26,7 +26,7 @@ struct source_location {
     _NODISCARD static consteval source_location current(const uint_least32_t _Line_ = __builtin_LINE(),
         const uint_least32_t _Column_ = __builtin_COLUMN(), const char* const _File_ = __builtin_FILE(),
         const char* const _Function_ = __builtin_FUNCTION()) noexcept {
-        source_location _Result;
+        source_location _Result{};
         _Result._Line     = _Line_;
         _Result._Column   = _Column_;
         _Result._File     = _File_;

--- a/tests/std/tests/P1208R6_source_location/test.cpp
+++ b/tests/std/tests/P1208R6_source_location/test.cpp
@@ -4,6 +4,7 @@
 #if defined(__cpp_consteval) && !defined(__EDG__) // TRANSITION, VSO-1285779
 #include "header.h"
 #include <cassert>
+#include <functional>
 #include <source_location>
 #include <string_view>
 #include <type_traits>
@@ -148,6 +149,12 @@ constexpr bool test() {
     function_template_test();
     header_test();
     return true;
+}
+
+// Also test GH-2822 Failed to specialize std::invoke on operator() with default argument
+// std::source_location::current()
+void test_gh_2822() { // COMPILE-ONLY
+    invoke([](source_location = source_location::current()) {});
 }
 
 int main() {


### PR DESCRIPTION
Fixes #2822 