### PR TITLE
Move machinery from `inc/ymath.h` to `src/xmath.hpp`

### DIFF
--- a/stl/inc/ymath.h
+++ b/stl/inc/ymath.h
@@ -18,50 +18,21 @@ _STL_DISABLE_CLANG_WARNINGS
 _EXTERN_C_UNLESS_PURE
 
 // macros for _Dtest return (0 => ZERO)
-#define _DENORM  (-2) // C9X only
-#define _FINITE  (-1)
 #define _INFCODE 1
 #define _NANCODE 2
 
-void __CLRCALL_PURE_OR_CDECL _Feraise(int);
-
-union _Dconst { // pun float types as integer array
-    unsigned short _Word[8]; // TRANSITION, ABI: Twice as large as necessary.
-    float _Float;
-    double _Double;
-    long double _Long_double;
-};
-
 _CRTIMP2_PURE double __CLRCALL_PURE_OR_CDECL _Cosh(double, double);
-_CRTIMP2_PURE short __CLRCALL_PURE_OR_CDECL _Dtest(double*);
 _CRTIMP2_PURE double __CLRCALL_PURE_OR_CDECL _Sinh(double, double);
-
 _CRTIMP2_PURE short __CLRCALL_PURE_OR_CDECL _Exp(double*, double, short);
-extern _CRTIMP2_PURE_IMPORT _Dconst _Denorm;
-extern _CRTIMP2_PURE_IMPORT _Dconst _Hugeval;
-extern _CRTIMP2_PURE_IMPORT _Dconst _Inf;
-extern _CRTIMP2_PURE_IMPORT _Dconst _Nan;
-extern _CRTIMP2_PURE_IMPORT _Dconst _Snan;
 
 _CRTIMP2_PURE float __CLRCALL_PURE_OR_CDECL _FCosh(float, float);
-_CRTIMP2_PURE short __CLRCALL_PURE_OR_CDECL _FDtest(float*);
 _CRTIMP2_PURE float __CLRCALL_PURE_OR_CDECL _FSinh(float, float);
-
 _CRTIMP2_PURE short __CLRCALL_PURE_OR_CDECL _FExp(float*, float, short);
-extern _CRTIMP2_PURE_IMPORT _Dconst _FDenorm;
-extern _CRTIMP2_PURE_IMPORT _Dconst _FInf;
-extern _CRTIMP2_PURE_IMPORT _Dconst _FNan;
-extern _CRTIMP2_PURE_IMPORT _Dconst _FSnan;
 
 _CRTIMP2_PURE long double __CLRCALL_PURE_OR_CDECL _LCosh(long double, long double);
 _CRTIMP2_PURE short __CLRCALL_PURE_OR_CDECL _LDtest(long double*);
 _CRTIMP2_PURE long double __CLRCALL_PURE_OR_CDECL _LSinh(long double, long double);
-
 _CRTIMP2_PURE short __CLRCALL_PURE_OR_CDECL _LExp(long double*, long double, short);
-extern _CRTIMP2_PURE_IMPORT _Dconst _LDenorm;
-extern _CRTIMP2_PURE_IMPORT _Dconst _LInf;
-extern _CRTIMP2_PURE_IMPORT _Dconst _LNan;
-extern _CRTIMP2_PURE_IMPORT _Dconst _LSnan;
 
 _END_EXTERN_C_UNLESS_PURE
 

--- a/stl/src/xmath.hpp
+++ b/stl/src/xmath.hpp
@@ -66,23 +66,23 @@ union _Dconst { // pun float types as integer array
 
 _CRTIMP2_PURE short __CLRCALL_PURE_OR_CDECL _Dtest(double*);
 
-extern _CRTIMP2_PURE_IMPORT _Dconst _Denorm;
-extern _CRTIMP2_PURE_IMPORT _Dconst _Hugeval;
-extern _CRTIMP2_PURE_IMPORT _Dconst _Inf;
-extern _CRTIMP2_PURE_IMPORT _Dconst _Nan;
-extern _CRTIMP2_PURE_IMPORT _Dconst _Snan;
+extern _CRTIMP2_PURE _Dconst _Denorm;
+extern _CRTIMP2_PURE _Dconst _Hugeval;
+extern _CRTIMP2_PURE _Dconst _Inf;
+extern _CRTIMP2_PURE _Dconst _Nan;
+extern _CRTIMP2_PURE _Dconst _Snan;
 
 _CRTIMP2_PURE short __CLRCALL_PURE_OR_CDECL _FDtest(float*);
 
-extern _CRTIMP2_PURE_IMPORT _Dconst _FDenorm;
-extern _CRTIMP2_PURE_IMPORT _Dconst _FInf;
-extern _CRTIMP2_PURE_IMPORT _Dconst _FNan;
-extern _CRTIMP2_PURE_IMPORT _Dconst _FSnan;
+extern _CRTIMP2_PURE _Dconst _FDenorm;
+extern _CRTIMP2_PURE _Dconst _FInf;
+extern _CRTIMP2_PURE _Dconst _FNan;
+extern _CRTIMP2_PURE _Dconst _FSnan;
 
-extern _CRTIMP2_PURE_IMPORT _Dconst _LDenorm;
-extern _CRTIMP2_PURE_IMPORT _Dconst _LInf;
-extern _CRTIMP2_PURE_IMPORT _Dconst _LNan;
-extern _CRTIMP2_PURE_IMPORT _Dconst _LSnan;
+extern _CRTIMP2_PURE _Dconst _LDenorm;
+extern _CRTIMP2_PURE _Dconst _LInf;
+extern _CRTIMP2_PURE _Dconst _LNan;
+extern _CRTIMP2_PURE _Dconst _LSnan;
 
 int _Stopfx(const char**, char**);
 _In_range_(0, maxsig) int _Stoflt(

--- a/stl/src/xmath.hpp
+++ b/stl/src/xmath.hpp
@@ -49,7 +49,40 @@
 #define FL_NAN 4
 #define FL_NEG 8
 
+// macros for _Dtest return (0 => ZERO)
+#define _DENORM (-2) // C9X only
+#define _FINITE (-1)
+
 _EXTERN_C_UNLESS_PURE
+
+void __CLRCALL_PURE_OR_CDECL _Feraise(int);
+
+union _Dconst { // pun float types as integer array
+    unsigned short _Word[8]; // TRANSITION, ABI: Twice as large as necessary.
+    float _Float;
+    double _Double;
+    long double _Long_double;
+};
+
+_CRTIMP2_PURE short __CLRCALL_PURE_OR_CDECL _Dtest(double*);
+
+extern _CRTIMP2_PURE_IMPORT _Dconst _Denorm;
+extern _CRTIMP2_PURE_IMPORT _Dconst _Hugeval;
+extern _CRTIMP2_PURE_IMPORT _Dconst _Inf;
+extern _CRTIMP2_PURE_IMPORT _Dconst _Nan;
+extern _CRTIMP2_PURE_IMPORT _Dconst _Snan;
+
+_CRTIMP2_PURE short __CLRCALL_PURE_OR_CDECL _FDtest(float*);
+
+extern _CRTIMP2_PURE_IMPORT _Dconst _FDenorm;
+extern _CRTIMP2_PURE_IMPORT _Dconst _FInf;
+extern _CRTIMP2_PURE_IMPORT _Dconst _FNan;
+extern _CRTIMP2_PURE_IMPORT _Dconst _FSnan;
+
+extern _CRTIMP2_PURE_IMPORT _Dconst _LDenorm;
+extern _CRTIMP2_PURE_IMPORT _Dconst _LInf;
+extern _CRTIMP2_PURE_IMPORT _Dconst _LNan;
+extern _CRTIMP2_PURE_IMPORT _Dconst _LSnan;
 
 int _Stopfx(const char**, char**);
 _In_range_(0, maxsig) int _Stoflt(


### PR DESCRIPTION
While looking at the STL's separately compiled machinery for modules, I noticed that `inc/ymath.h` was declaring a bunch of stuff that isn't needed by any other header in `inc`. We can move this to `src/xmath.hpp` (which is being included by everything in `src` that needs it) without disrupting users or affecting ABI. (That is, the exported machinery in `src` will still be exported; there's no reason to declare it as imported in `inc` if we aren't going to use it there.)

This is theoretically an extremely slight throughput improvement (fewer things being declared), but realistically it just makes the codebase easier to understand - fewer spurious connections between `inc` and `src`.

---

I'm changing one thing while moving this from `inc` to `src`: changing `_CRTIMP2_PURE_IMPORT` to `_CRTIMP2_PURE`. Within `src`, they are exactly identical (and we don't use `_CRTIMP2_PURE_IMPORT` except for `_Yarn` - that one is trying to match the header stylistically, although it could be changed).

<details>
<summary>Click to expand macro definitions:</summary>

https://github.com/microsoft/STL/blob/ad80eb79ba4953e7529d15b1bc8d0b540150bf7d/stl/inc/yvals.h#L281-L297

`<crtdefs.h>`:
```cpp
#ifndef _CRTIMP2
    #if defined CRTDLL2 && defined _CRTBLD
        #define _CRTIMP2 __declspec(dllexport)
    #else
        #define _CRTIMP2
    #endif
#endif
```

https://github.com/microsoft/STL/blob/ad80eb79ba4953e7529d15b1bc8d0b540150bf7d/stl/inc/yvals.h#L265-L271
</details>

The only difference between `_CRTIMP2_PURE_IMPORT` and `_CRTIMP2_PURE` is when building user code using the STL as a DLL (`/MD` and `/MDd`), in which case the former expands to `__declspec(dllimport)`. That's impossible for `stl/src`, and we don't need to match any other declarations, so we should use plain `_CRTIMP2_PURE` like everything else.

---

We have export validation in the internal build, but I also verified this manually.

First, notice that `_Feraise` wasn't marked `_CRTIMP2_PURE`, so it wasn't being imported/exported at all! With `main`, it doesn't appear in the export surface:

```
D:\GitHub\STL\out\build\x64\out\bin\amd64>dumpbin /exports msvcp140_oss.dll | grep -P _Feraise

D:\GitHub\STL\out\build\x64\out\bin\amd64>
```

With this PR, everything else is still being exported:

```
D:\GitHub\STL\out\build\x64\out\bin\amd64>dumpbin /exports msvcp140_oss.dll | grep -P "\b(_Dtest|_FDtest|_Denorm|_Hugeval|_Inf|_Nan|_Snan|_FDenorm|_FInf|_FNan|_FSnan|_LDenorm|_LInf|_LNan|_LSnan)\b"
       1371  55A 00082198 _Denorm = _Denorm
       1372  55B 00046670 _Dtest = _Dtest
       1376  55F 00082108 _FDenorm = _FDenorm
       1377  560 00046EB0 _FDtest = _FDtest
       1379  562 000820E8 _FInf = _FInf
       1380  563 000820F8 _FNan = _FNan
       1382  565 00082118 _FSnan = _FSnan
       1391  56E 00082178 _Hugeval = _Hugeval
       1392  56F 000821A8 _Inf = _Inf
       1394  571 00082148 _LDenorm = _LDenorm
       1397  574 00082128 _LInf = _LInf
       1398  575 00082138 _LNan = _LNan
       1400  577 00082158 _LSnan = _LSnan
       1423  58E 00082168 _Nan = _Nan
       1433  598 00082188 _Snan = _Snan
```
