### PR TITLE
Add a tag to the Azure resource group

### DIFF
--- a/azure-devops/create-vmss.ps1
+++ b/azure-devops/create-vmss.ps1
@@ -154,7 +154,9 @@ Write-Progress `
 
 $ResourceGroupName = Find-ResourceGroupName $Prefix
 $AdminPW = New-Password
-New-AzResourceGroup -Name $ResourceGroupName -Location $Location | Out-Null
+# TRANSITION, this opt-in tag should be unnecessary after 2022-09-30.
+$SimplySecureV2OptInTag = @{"NRMSV2OptIn"=(Get-Date -Format 'yyyyMMdd')}
+New-AzResourceGroup -Name $ResourceGroupName -Location $Location -Tag $SimplySecureV2OptInTag | Out-Null
 $AdminPWSecure = ConvertTo-SecureString $AdminPW -AsPlainText -Force
 $Credential = New-Object System.Management.Automation.PSCredential ('AdminUser', $AdminPWSecure)
 

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -91,7 +91,7 @@ if ([string]::IsNullOrEmpty($AdminUserPassword)) {
   $PsExecPath = Join-Path $ExtractedPsToolsPath 'PsExec64.exe'
 
   # https://github.com/PowerShell/PowerShell/releases/latest
-  $PowerShellZipUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.2.4/PowerShell-7.2.4-win-x64.zip'
+  $PowerShellZipUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.2.5/PowerShell-7.2.5-win-x64.zip'
   Write-Host "Downloading: $PowerShellZipUrl"
   $ExtractedPowerShellPath = DownloadAndExtractZip -Url $PowerShellZipUrl
   $PwshPath = Join-Path $ExtractedPowerShellPath 'pwsh.exe'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ variables:
   tmpDir: 'D:\Temp'
   buildOutputLocation: 'D:\build'
 
-pool: 'StlBuild-2022-06-14-T1744'
+pool: 'StlBuild-2022-06-28-T1518'
 
 stages:
   - stage: Code_Format


### PR DESCRIPTION
This is to follow an internal security policy. We should be able to remove this tag in a few months. I verified that the tag is being properly applied by inspecting the Azure UI.

(I believe that we could add the tag to existing resource groups via the Azure UI, but we should be good kitties by driving our process with scripts. :smile_cat: Only bad kitties jump up on the table where they're not allowed and perform modifying actions through web UIs when there's an automated alternative. :smirk_cat:)

As this is regenerating the VMSS, I'm updating `azure-devops/provision-image.ps1` to use PowerShell 7.2.5.