### PR TITLE
Fix cross-PR contamination by cleaning after checkout

### DIFF
--- a/azure-devops/checkout-sources.yml
+++ b/azure-devops/checkout-sources.yml
@@ -48,7 +48,7 @@ steps:
     git fetch --filter=tree:0 --depth=1 llvm $(${{ parameters.llvmSHAVar }})
     git sparse-checkout set --cone --sparse-index libcxx/test libcxx/utils/libcxx llvm/utils/lit
     git reset --quiet --hard FETCH_HEAD
-    git clean --quiet -x -d -f
+    git clean --quiet -x -d -f -f
   displayName: "Checkout LLVM source"
 - script: |
     cd $(Build.SourcesDirectory)
@@ -69,5 +69,5 @@ steps:
 
     git fetch --filter=tree:0 --depth=1 boostorg $(${{ parameters.boostMathSHAVar }})
     git reset --quiet --hard FETCH_HEAD
-    git clean --quiet -x -d -f
+    git clean --quiet -x -d -f -f
   displayName: "Checkout boost-math source"

--- a/azure-devops/checkout-sources.yml
+++ b/azure-devops/checkout-sources.yml
@@ -12,6 +12,10 @@ steps:
 - checkout: self
   clean: true
   submodules: false
+- script: |
+    cd $(Build.SourcesDirectory)
+    git clean --quiet -x -d -f -f
+  displayName: 'Clean after checkout'
 - task: PowerShell@2
   displayName: 'Get submodule SHAs'
   timeoutInMinutes: 1

--- a/azure-devops/checkout-sources.yml
+++ b/azure-devops/checkout-sources.yml
@@ -68,5 +68,6 @@ steps:
     )
 
     git fetch --filter=tree:0 --depth=1 boostorg $(${{ parameters.boostMathSHAVar }})
-    git checkout -f FETCH_HEAD
+    git reset --quiet --hard FETCH_HEAD
+    git clean --quiet -x -d -f
   displayName: "Checkout boost-math source"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,6 +27,10 @@ stages:
             clean: true
             submodules: false
           - script: |
+              cd $(Build.SourcesDirectory)
+              git clean --quiet -x -d -f -f
+            displayName: 'Clean after checkout'
+          - script: |
               call "%ProgramFiles%\Microsoft Visual Studio\2022\Preview\Common7\Tools\VsDevCmd.bat" ^
                 -host_arch=amd64 -arch=amd64 -no_logo
               cmake -G Ninja -S $(Build.SourcesDirectory)/tools -B $(tmpDir)/format-validate-build


### PR DESCRIPTION
This should fix #396 - see my analysis there.

I initially wanted to annihilate the entire workspace with `workspace: clean: all`. While I believe that would be effective and simpler to reason about (making reused machines perform completely fresh clones), it would be slower when machines are reused. Even though the actual time savings are rather small (~15 seconds), the total machine time across many VMs is more significant.

This uses `git clean --quiet -x -d -f -f` with two force options because we want to clean up any leftover submodules; git will refuse to do that if there's only one force option. (`--quiet` suppresses potentially voluminous log output which we aren't interested in.)

This also makes a vaguely related change to the submodule checkout scripts. They now use two force options for consistency (even though we aren't worried about nested submodules), and this changes boost-math to follow llvm-project's commands more closely. It replaces `git checkout -f FETCH_HEAD` with `git reset --quiet --hard FETCH_HEAD`; they have the same effect, but the latter avoids emitting the "detached HEAD" warning. It also adds a `clean` command.