### PR TITLE
`<tuple>`: Overhaul `tuple_cat()` for simplicity and less special-casing

### DIFF
--- a/stl/inc/tuple
+++ b/stl/inc/tuple
@@ -838,34 +838,38 @@ _NODISCARD constexpr _Ty&& get(array<_Ty, _Size>&& _Arr) noexcept;
 template <size_t _Idx, class _Ty, size_t _Size>
 _NODISCARD constexpr const _Ty&& get(const array<_Ty, _Size>&& _Arr) noexcept;
 
-template <class _Kx_arg, class _Ix_arg, size_t _Ix_next, class... _Sequences>
-struct _Tuple_cat2 {
-    _STL_INTERNAL_STATIC_ASSERT(sizeof...(_Sequences) == 0);
-    using _Kx_seq = _Kx_arg;
-    using _Ix_seq = _Ix_arg;
+template <class _Ty, class _Kx_arg, class _Ix_arg, size_t _Ix_next, class... _Sequences>
+struct _Tuple_cat2;
+
+template <class _Ty, size_t... _Kx, size_t... _Ix, size_t _Ix_next>
+struct _Tuple_cat2<_Ty, index_sequence<_Kx...>, index_sequence<_Ix...>, _Ix_next> {
+    using _Ret    = tuple<tuple_element_t<_Kx, _Remove_cvref_t<tuple_element_t<_Ix, _Ty>>>...>;
+    using _Kx_seq = index_sequence<_Kx...>;
+    using _Ix_seq = index_sequence<_Ix...>;
 };
 
-template <size_t... _Kx, size_t... _Ix, size_t _Ix_next, size_t... _Kx_next, class... _Rest>
-struct _Tuple_cat2<index_sequence<_Kx...>, index_sequence<_Ix...>, _Ix_next, index_sequence<_Kx_next...>, _Rest...>
-    : _Tuple_cat2<index_sequence<_Kx..., _Kx_next...>,
+template <class _Ty, size_t... _Kx, size_t... _Ix, size_t _Ix_next, size_t... _Kx_next, class... _Rest>
+struct _Tuple_cat2<_Ty, index_sequence<_Kx...>, index_sequence<_Ix...>, _Ix_next, index_sequence<_Kx_next...>, _Rest...>
+    : _Tuple_cat2<_Ty, index_sequence<_Kx..., _Kx_next...>,
           index_sequence<_Ix..., (_Ix_next + 0 * _Kx_next)...>, // repeat _Ix_next, ignoring the elements of _Kx_next
           _Ix_next + 1, _Rest...> {};
 
-template <size_t... _Nx>
-using _Tuple_cat1 = _Tuple_cat2<index_sequence<>, index_sequence<>, 0, make_index_sequence<_Nx>...>;
+template <class... _Tuples>
+using _Tuple_cat1 = _Tuple_cat2<tuple<_Tuples&&...>, index_sequence<>, index_sequence<>, 0,
+    make_index_sequence<tuple_size_v<_Remove_cvref_t<_Tuples>>>...>;
 
-template <size_t... _Kx, size_t... _Ix, class _Ty>
-constexpr auto _Tuple_cat(index_sequence<_Kx...>, index_sequence<_Ix...>, _Ty _Arg) {
-    using _Ret = tuple<tuple_element_t<_Kx, _Remove_cvref_t<tuple_element_t<_Ix, _Ty>>>...>;
+template <class _Ret, size_t... _Kx, size_t... _Ix, class _Ty>
+constexpr _Ret _Tuple_cat(index_sequence<_Kx...>, index_sequence<_Ix...>, _Ty _Arg) {
     return _Ret{_STD get<_Kx>(_STD get<_Ix>(_STD move(_Arg)))...};
 }
 
 template <class... _Tuples>
-_NODISCARD constexpr auto tuple_cat(_Tuples&&... _Tpls) { // concatenate tuples
-    using _Cat1   = _Tuple_cat1<tuple_size_v<_Remove_cvref_t<_Tuples>>...>;
+_NODISCARD constexpr typename _Tuple_cat1<_Tuples...>::_Ret tuple_cat(_Tuples&&... _Tpls) { // concatenate tuples
+    using _Cat1   = _Tuple_cat1<_Tuples...>;
+    using _Ret    = typename _Cat1::_Ret;
     using _Kx_seq = typename _Cat1::_Kx_seq;
     using _Ix_seq = typename _Cat1::_Ix_seq;
-    return _Tuple_cat(_Kx_seq{}, _Ix_seq{}, _STD forward_as_tuple(_STD forward<_Tuples>(_Tpls)...));
+    return _Tuple_cat<_Ret>(_Kx_seq{}, _Ix_seq{}, _STD forward_as_tuple(_STD forward<_Tuples>(_Tpls)...));
 }
 
 #if _HAS_CXX17

--- a/stl/inc/tuple
+++ b/stl/inc/tuple
@@ -839,35 +839,32 @@ template <size_t _Idx, class _Ty, size_t _Size>
 _NODISCARD constexpr const _Ty&& get(const array<_Ty, _Size>&& _Arr) noexcept;
 
 template <class _Kx_arg, class _Ix_arg, size_t _Ix_next, class... _Sequences>
-struct _Tuple_cat2 { // determine tuple_cat's _Kx/_Ix indices
+struct _Tuple_cat2 {
     _STL_INTERNAL_STATIC_ASSERT(sizeof...(_Sequences) == 0);
-    using _Kx_arg_seq = _Kx_arg;
-    using _Ix_arg_seq = _Ix_arg;
+    using _Kx_seq = _Kx_arg;
+    using _Ix_seq = _Ix_arg;
 };
 
 template <size_t... _Kx, size_t... _Ix, size_t _Ix_next, size_t... _Kx_next, class... _Rest>
 struct _Tuple_cat2<index_sequence<_Kx...>, index_sequence<_Ix...>, _Ix_next, index_sequence<_Kx_next...>, _Rest...>
-    : _Tuple_cat2<index_sequence<_Kx..., _Kx_next...>, // TEMPORARILY WRAP
-          index_sequence<_Ix..., (_Ix_next + (0 * _Kx_next))...>, _Ix_next + 1,
-          _Rest...> { // determine tuple_cat's _Kx/_Ix indices
-};
+    : _Tuple_cat2<index_sequence<_Kx..., _Kx_next...>, index_sequence<_Ix..., (_Ix_next + (0 * _Kx_next))...>,
+          _Ix_next + 1, _Rest...> {};
 
 template <size_t... _Nx>
-using _Tuple_cat1 = _Tuple_cat2<index_sequence<>, index_sequence<>, 0,
-    make_index_sequence<_Nx>...>; // prepare to determine tuple_cat's
-                                  // _Kx/_Ix indices
+using _Tuple_cat1 = _Tuple_cat2<index_sequence<>, index_sequence<>, 0, make_index_sequence<_Nx>...>;
 
 template <size_t... _Kx, size_t... _Ix, class _Ty>
-constexpr auto _Tuple_cat(index_sequence<_Kx...>, index_sequence<_Ix...>, _Ty&& _Arg) { // concatenate tuples
+constexpr auto _Tuple_cat(index_sequence<_Kx...>, index_sequence<_Ix...>, _Ty&& _Arg) {
     using _Ret = tuple<tuple_element_t<_Kx, _Remove_cvref_t<tuple_element_t<_Ix, _Ty>>>...>;
     return _Ret(_STD get<_Kx>(_STD get<_Ix>(_STD forward<_Ty>(_Arg)))...);
 }
 
 template <class... _Tuples>
 _NODISCARD constexpr auto tuple_cat(_Tuples&&... _Tpls) { // concatenate tuples
-    using _Cat1 = _Tuple_cat1<tuple_size_v<_Remove_cvref_t<_Tuples>>...>;
-    return _Tuple_cat(typename _Cat1::_Kx_arg_seq{}, typename _Cat1::_Ix_arg_seq{},
-        _STD forward_as_tuple(_STD forward<_Tuples>(_Tpls)...));
+    using _Cat1   = _Tuple_cat1<tuple_size_v<_Remove_cvref_t<_Tuples>>...>;
+    using _Kx_seq = typename _Cat1::_Kx_seq;
+    using _Ix_seq = typename _Cat1::_Ix_seq;
+    return _Tuple_cat(_Kx_seq{}, _Ix_seq{}, _STD forward_as_tuple(_STD forward<_Tuples>(_Tpls)...));
 }
 
 #if _HAS_CXX17

--- a/stl/inc/tuple
+++ b/stl/inc/tuple
@@ -891,8 +891,8 @@ struct _Tuple_cat2<_Kx_arg, index_sequence<_Ix...>, _Ix_next, tuple<_Types2...>,
 
 template <class... _Tuples>
 struct _Tuple_cat1 : _Tuple_cat2<index_sequence<>, index_sequence<>, 0,
-                         typename _View_as_tuple<decay_t<_Tuples>>::type...> { // prepare to determine tuple_cat's
-                                                                               // _Kx/_Ix indices
+                         typename _View_as_tuple<_Tuples>::type...> { // prepare to determine tuple_cat's
+                                                                      // _Kx/_Ix indices
 };
 
 template <size_t... _Kx, size_t... _Ix, class _Ty>
@@ -903,7 +903,7 @@ constexpr auto _Tuple_cat(index_sequence<_Kx...>, index_sequence<_Ix...>, _Ty&& 
 
 template <class... _Tuples>
 _NODISCARD constexpr auto tuple_cat(_Tuples&&... _Tpls) { // concatenate tuples
-    using _Cat1 = _Tuple_cat1<_Tuples...>;
+    using _Cat1 = _Tuple_cat1<_Remove_cvref_t<_Tuples>...>;
     return _Tuple_cat(typename _Cat1::_Kx_arg_seq{}, typename _Cat1::_Ix_arg_seq{},
         _STD forward_as_tuple(_STD forward<_Tuples>(_Tpls)...));
 }

--- a/stl/inc/tuple
+++ b/stl/inc/tuple
@@ -823,15 +823,6 @@ _NODISCARD constexpr tuple<_Types&&...> forward_as_tuple(_Types&&... _Args) noex
     return tuple<_Types&&...>(_STD forward<_Types>(_Args)...);
 }
 
-template <class _Seq_type1, class _Seq_type2>
-struct _Cat_sequences;
-
-template <size_t... _Indexes1, size_t... _Indexes2>
-struct _Cat_sequences<index_sequence<_Indexes1...>,
-    index_sequence<_Indexes2...>> { // concatenates two index_sequence types
-    using type = index_sequence<_Indexes1..., _Indexes2...>;
-};
-
 template <class _Ty, size_t _Size>
 class array;
 
@@ -847,52 +838,24 @@ _NODISCARD constexpr _Ty&& get(array<_Ty, _Size>&& _Arr) noexcept;
 template <size_t _Idx, class _Ty, size_t _Size>
 _NODISCARD constexpr const _Ty&& get(const array<_Ty, _Size>&& _Arr) noexcept;
 
-template <class _Ty, class... _For_array>
-struct _View_as_tuple { // tuple_cat() supports only tuples, pairs, and arrays
-    static_assert(_Always_false<_Ty>, "Unsupported tuple_cat arguments.");
-};
-
-template <class... _Types>
-struct _View_as_tuple<tuple<_Types...>> { // view a tuple as a tuple
-    using type = tuple<_Types...>;
-};
-
-template <class _Ty1, class _Ty2>
-struct _View_as_tuple<pair<_Ty1, _Ty2>> { // view a pair as a tuple
-    using type = tuple<_Ty1, _Ty2>;
-};
-
-template <class _Ty, class... _Types>
-struct _View_as_tuple<array<_Ty, 0>, _Types...> { // view an array as a tuple; ends recursion at 0
-    using type = tuple<_Types...>;
-};
-
-template <class _Ty, size_t _Size, class... _Types>
-struct _View_as_tuple<array<_Ty, _Size>, _Types...>
-    : _View_as_tuple<array<_Ty, _Size - 1>, _Ty, _Types...> { // view an array as a tuple; counts down to 0
-};
-
-template <size_t _Nx, class _Ty>
-struct _Repeat_for : integral_constant<size_t, _Nx> {}; // repeats _Nx for each _Ty in a parameter pack
-
-template <class _Kx_arg, class _Ix_arg, size_t _Ix_next, class... _Tuples>
+template <class _Kx_arg, class _Ix_arg, size_t _Ix_next, class... _Sequences>
 struct _Tuple_cat2 { // determine tuple_cat's _Kx/_Ix indices
-    static_assert(sizeof...(_Tuples) == 0, "Unsupported tuple_cat arguments.");
+    static_assert(sizeof...(_Sequences) == 0, "Unsupported tuple_cat arguments.");
     using _Kx_arg_seq = _Kx_arg;
     using _Ix_arg_seq = _Ix_arg;
 };
 
-template <size_t... _Kx, size_t... _Ix, size_t _Ix_next, class... _Types2, class... _Rest>
-struct _Tuple_cat2<index_sequence<_Kx...>, index_sequence<_Ix...>, _Ix_next, tuple<_Types2...>, _Rest...>
-    : _Tuple_cat2<typename _Cat_sequences<index_sequence<_Kx...>, index_sequence_for<_Types2...>>::type,
-          index_sequence<_Ix..., _Repeat_for<_Ix_next, _Types2>::value...>, _Ix_next + 1,
+template <size_t... _Kx, size_t... _Ix, size_t _Ix_next, size_t... _Kx_next, class... _Rest>
+struct _Tuple_cat2<index_sequence<_Kx...>, index_sequence<_Ix...>, _Ix_next, index_sequence<_Kx_next...>, _Rest...>
+    : _Tuple_cat2<index_sequence<_Kx..., _Kx_next...>, // TEMPORARILY WRAP
+          index_sequence<_Ix..., (_Ix_next + (0 * _Kx_next))...>, _Ix_next + 1,
           _Rest...> { // determine tuple_cat's _Kx/_Ix indices
 };
 
-template <class... _Tuples>
+template <size_t... _Nx>
 struct _Tuple_cat1 : _Tuple_cat2<index_sequence<>, index_sequence<>, 0,
-                         typename _View_as_tuple<_Tuples>::type...> { // prepare to determine tuple_cat's
-                                                                      // _Kx/_Ix indices
+                         make_index_sequence<_Nx>...> { // prepare to determine tuple_cat's
+                                                        // _Kx/_Ix indices
 };
 
 template <size_t... _Kx, size_t... _Ix, class _Ty>
@@ -903,7 +866,7 @@ constexpr auto _Tuple_cat(index_sequence<_Kx...>, index_sequence<_Ix...>, _Ty&& 
 
 template <class... _Tuples>
 _NODISCARD constexpr auto tuple_cat(_Tuples&&... _Tpls) { // concatenate tuples
-    using _Cat1 = _Tuple_cat1<_Remove_cvref_t<_Tuples>...>;
+    using _Cat1 = _Tuple_cat1<tuple_size_v<_Remove_cvref_t<_Tuples>>...>;
     return _Tuple_cat(typename _Cat1::_Kx_arg_seq{}, typename _Cat1::_Ix_arg_seq{},
         _STD forward_as_tuple(_STD forward<_Tuples>(_Tpls)...));
 }

--- a/stl/inc/tuple
+++ b/stl/inc/tuple
@@ -882,9 +882,9 @@ struct _Tuple_cat2 { // determine tuple_cat's _Kx/_Ix indices
     using _Ix_arg_seq = _Ix_arg;
 };
 
-template <class _Kx_arg, size_t... _Ix, size_t _Ix_next, class... _Types2, class... _Rest>
-struct _Tuple_cat2<_Kx_arg, index_sequence<_Ix...>, _Ix_next, tuple<_Types2...>, _Rest...>
-    : _Tuple_cat2<typename _Cat_sequences<_Kx_arg, index_sequence_for<_Types2...>>::type,
+template <size_t... _Kx, size_t... _Ix, size_t _Ix_next, class... _Types2, class... _Rest>
+struct _Tuple_cat2<index_sequence<_Kx...>, index_sequence<_Ix...>, _Ix_next, tuple<_Types2...>, _Rest...>
+    : _Tuple_cat2<typename _Cat_sequences<index_sequence<_Kx...>, index_sequence_for<_Types2...>>::type,
           index_sequence<_Ix..., _Repeat_for<_Ix_next, _Types2>::value...>, _Ix_next + 1,
           _Rest...> { // determine tuple_cat's _Kx/_Ix indices
 };

--- a/stl/inc/tuple
+++ b/stl/inc/tuple
@@ -847,16 +847,17 @@ struct _Tuple_cat2 {
 
 template <size_t... _Kx, size_t... _Ix, size_t _Ix_next, size_t... _Kx_next, class... _Rest>
 struct _Tuple_cat2<index_sequence<_Kx...>, index_sequence<_Ix...>, _Ix_next, index_sequence<_Kx_next...>, _Rest...>
-    : _Tuple_cat2<index_sequence<_Kx..., _Kx_next...>, index_sequence<_Ix..., (_Ix_next + 0 * _Kx_next)...>,
+    : _Tuple_cat2<index_sequence<_Kx..., _Kx_next...>,
+          index_sequence<_Ix..., (_Ix_next + 0 * _Kx_next)...>, // repeat _Ix_next, ignoring the elements of _Kx_next
           _Ix_next + 1, _Rest...> {};
 
 template <size_t... _Nx>
 using _Tuple_cat1 = _Tuple_cat2<index_sequence<>, index_sequence<>, 0, make_index_sequence<_Nx>...>;
 
 template <size_t... _Kx, size_t... _Ix, class _Ty>
-constexpr auto _Tuple_cat(index_sequence<_Kx...>, index_sequence<_Ix...>, _Ty&& _Arg) {
+constexpr auto _Tuple_cat(index_sequence<_Kx...>, index_sequence<_Ix...>, _Ty _Arg) {
     using _Ret = tuple<tuple_element_t<_Kx, _Remove_cvref_t<tuple_element_t<_Ix, _Ty>>>...>;
-    return _Ret(_STD get<_Kx>(_STD get<_Ix>(_STD forward<_Ty>(_Arg)))...);
+    return _Ret{_STD get<_Kx>(_STD get<_Ix>(_STD move(_Arg)))...};
 }
 
 template <class... _Tuples>

--- a/stl/inc/tuple
+++ b/stl/inc/tuple
@@ -875,36 +875,36 @@ struct _View_as_tuple<array<_Ty, _Size>, _Types...>
 template <size_t _Nx, class _Ty>
 struct _Repeat_for : integral_constant<size_t, _Nx> {}; // repeats _Nx for each _Ty in a parameter pack
 
-template <class _Ret, class _Kx_arg, class _Ix_arg, size_t _Ix_next, class... _Tuples>
-struct _Tuple_cat2 { // determine tuple_cat's return type and _Kx/_Ix indices
+template <class _Kx_arg, class _Ix_arg, size_t _Ix_next, class... _Tuples>
+struct _Tuple_cat2 { // determine tuple_cat's _Kx/_Ix indices
     static_assert(sizeof...(_Tuples) == 0, "Unsupported tuple_cat arguments.");
-    using type        = _Ret;
     using _Kx_arg_seq = _Kx_arg;
     using _Ix_arg_seq = _Ix_arg;
 };
 
-template <class... _Types1, class _Kx_arg, size_t... _Ix, size_t _Ix_next, class... _Types2, class... _Rest>
-struct _Tuple_cat2<tuple<_Types1...>, _Kx_arg, index_sequence<_Ix...>, _Ix_next, tuple<_Types2...>, _Rest...>
-    : _Tuple_cat2<tuple<_Types1..., _Types2...>, typename _Cat_sequences<_Kx_arg, index_sequence_for<_Types2...>>::type,
+template <class _Kx_arg, size_t... _Ix, size_t _Ix_next, class... _Types2, class... _Rest>
+struct _Tuple_cat2<_Kx_arg, index_sequence<_Ix...>, _Ix_next, tuple<_Types2...>, _Rest...>
+    : _Tuple_cat2<typename _Cat_sequences<_Kx_arg, index_sequence_for<_Types2...>>::type,
           index_sequence<_Ix..., _Repeat_for<_Ix_next, _Types2>::value...>, _Ix_next + 1,
-          _Rest...> { // determine tuple_cat's return type and _Kx/_Ix indices
+          _Rest...> { // determine tuple_cat's _Kx/_Ix indices
 };
 
 template <class... _Tuples>
-struct _Tuple_cat1 : _Tuple_cat2<tuple<>, index_sequence<>, index_sequence<>, 0,
+struct _Tuple_cat1 : _Tuple_cat2<index_sequence<>, index_sequence<>, 0,
                          typename _View_as_tuple<decay_t<_Tuples>>::type...> { // prepare to determine tuple_cat's
-                                                                               // return type and _Kx/_Ix indices
+                                                                               // _Kx/_Ix indices
 };
 
-template <class _Ret, size_t... _Kx, size_t... _Ix, class _Ty>
-constexpr _Ret _Tuple_cat(index_sequence<_Kx...>, index_sequence<_Ix...>, _Ty&& _Arg) { // concatenate tuples
+template <size_t... _Kx, size_t... _Ix, class _Ty>
+constexpr auto _Tuple_cat(index_sequence<_Kx...>, index_sequence<_Ix...>, _Ty&& _Arg) { // concatenate tuples
+    using _Ret = tuple<tuple_element_t<_Kx, _Remove_cvref_t<tuple_element_t<_Ix, _Ty>>>...>;
     return _Ret(_STD get<_Kx>(_STD get<_Ix>(_STD forward<_Ty>(_Arg)))...);
 }
 
 template <class... _Tuples>
-_NODISCARD constexpr typename _Tuple_cat1<_Tuples...>::type tuple_cat(_Tuples&&... _Tpls) { // concatenate tuples
+_NODISCARD constexpr auto tuple_cat(_Tuples&&... _Tpls) { // concatenate tuples
     using _Cat1 = _Tuple_cat1<_Tuples...>;
-    return _Tuple_cat<typename _Cat1::type>(typename _Cat1::_Kx_arg_seq{}, typename _Cat1::_Ix_arg_seq{},
+    return _Tuple_cat(typename _Cat1::_Kx_arg_seq{}, typename _Cat1::_Ix_arg_seq{},
         _STD forward_as_tuple(_STD forward<_Tuples>(_Tpls)...));
 }
 

--- a/stl/inc/tuple
+++ b/stl/inc/tuple
@@ -853,10 +853,9 @@ struct _Tuple_cat2<index_sequence<_Kx...>, index_sequence<_Ix...>, _Ix_next, ind
 };
 
 template <size_t... _Nx>
-struct _Tuple_cat1 : _Tuple_cat2<index_sequence<>, index_sequence<>, 0,
-                         make_index_sequence<_Nx>...> { // prepare to determine tuple_cat's
-                                                        // _Kx/_Ix indices
-};
+using _Tuple_cat1 = _Tuple_cat2<index_sequence<>, index_sequence<>, 0,
+    make_index_sequence<_Nx>...>; // prepare to determine tuple_cat's
+                                  // _Kx/_Ix indices
 
 template <size_t... _Kx, size_t... _Ix, class _Ty>
 constexpr auto _Tuple_cat(index_sequence<_Kx...>, index_sequence<_Ix...>, _Ty&& _Arg) { // concatenate tuples

--- a/stl/inc/tuple
+++ b/stl/inc/tuple
@@ -840,7 +840,7 @@ _NODISCARD constexpr const _Ty&& get(const array<_Ty, _Size>&& _Arr) noexcept;
 
 template <class _Kx_arg, class _Ix_arg, size_t _Ix_next, class... _Sequences>
 struct _Tuple_cat2 { // determine tuple_cat's _Kx/_Ix indices
-    static_assert(sizeof...(_Sequences) == 0, "Unsupported tuple_cat arguments.");
+    _STL_INTERNAL_STATIC_ASSERT(sizeof...(_Sequences) == 0);
     using _Kx_arg_seq = _Kx_arg;
     using _Ix_arg_seq = _Ix_arg;
 };

--- a/stl/inc/tuple
+++ b/stl/inc/tuple
@@ -847,7 +847,7 @@ struct _Tuple_cat2 {
 
 template <size_t... _Kx, size_t... _Ix, size_t _Ix_next, size_t... _Kx_next, class... _Rest>
 struct _Tuple_cat2<index_sequence<_Kx...>, index_sequence<_Ix...>, _Ix_next, index_sequence<_Kx_next...>, _Rest...>
-    : _Tuple_cat2<index_sequence<_Kx..., _Kx_next...>, index_sequence<_Ix..., (_Ix_next + (0 * _Kx_next))...>,
+    : _Tuple_cat2<index_sequence<_Kx..., _Kx_next...>, index_sequence<_Ix..., (_Ix_next + 0 * _Kx_next)...>,
           _Ix_next + 1, _Rest...> {};
 
 template <size_t... _Nx>

--- a/tests/std/tests/Dev11_0000000_tuple_cat/test.cpp
+++ b/tests/std/tests/Dev11_0000000_tuple_cat/test.cpp
@@ -14,6 +14,41 @@ using namespace std;
 
 #define STATIC_ASSERT(...) static_assert(__VA_ARGS__, #__VA_ARGS__)
 
+template <template <typename...> class PairOrTuple>
+void test_value_categories() {
+    int n1       = 10;
+    const int n2 = 20;
+    int n3       = 30;
+    const int n4 = 40;
+
+    PairOrTuple<char, long> obj('x', 50);
+    PairOrTuple<int&, const int&> lv(n1, n2);
+    PairOrTuple<int&&, const int&&> rv(move(n3), move(n4));
+
+    // For rvalue reference elements, we must pass the tuple-like containers as rvalues,
+    // otherwise the concatenated tuple can't be constructed.
+    {
+        auto cat1 = tuple_cat(obj, lv);
+        STATIC_ASSERT(is_same_v<decltype(cat1), tuple<char, long, int&, const int&>>);
+        assert(cat1 == make_tuple('x', 50, 10, 20));
+    }
+    {
+        auto cat2 = tuple_cat(as_const(obj), as_const(lv));
+        STATIC_ASSERT(is_same_v<decltype(cat2), tuple<char, long, int&, const int&>>);
+        assert(cat2 == make_tuple('x', 50, 10, 20));
+    }
+    {
+        auto cat3 = tuple_cat(move(obj), move(lv), move(rv));
+        STATIC_ASSERT(is_same_v<decltype(cat3), tuple<char, long, int&, const int&, int&&, const int&&>>);
+        assert(cat3 == make_tuple('x', 50, 10, 20, 30, 40));
+    }
+    {
+        auto cat4 = tuple_cat(move(as_const(obj)), move(as_const(lv)), move(as_const(rv)));
+        STATIC_ASSERT(is_same_v<decltype(cat4), tuple<char, long, int&, const int&, int&&, const int&&>>);
+        assert(cat4 == make_tuple('x', 50, 10, 20, 30, 40));
+    }
+}
+
 int main() {
     {
         tuple<> x;
@@ -167,6 +202,26 @@ int main() {
             const tuple<int, int, unsigned int, const char*, int, long, long, char, char, char, long long>>);
 
         assert(t == make_tuple(11, 22, 33U, s, 40, 50L, 60L, 'x', 'y', 'z', 1234LL));
+    }
+
+    test_value_categories<pair>();
+    test_value_categories<tuple>();
+
+    {
+        array<int, 3> a1{{-1, -2, -3}};
+        const array<char, 4> a2{{'C', 'A', 'T', 'S'}};
+
+        {
+            auto cat5 = tuple_cat(a1, a2);
+            STATIC_ASSERT(is_same_v<decltype(cat5), tuple<int, int, int, char, char, char, char>>);
+            assert(cat5 == make_tuple(-1, -2, -3, 'C', 'A', 'T', 'S'));
+        }
+
+        {
+            auto cat6 = tuple_cat(move(a1), move(a2));
+            STATIC_ASSERT(is_same_v<decltype(cat6), tuple<int, int, int, char, char, char, char>>);
+            assert(cat6 == make_tuple(-1, -2, -3, 'C', 'A', 'T', 'S'));
+        }
     }
 
 // Also test C++17 apply() and make_from_tuple().


### PR DESCRIPTION
Resolves #260. Inspired by @ArtemSarmini's #461, although this takes a different approach. See https://github.com/microsoft/STL/pull/461#issuecomment-1169541206 for rationale: despite the issue's title, this PR is not generalizing `tuple_cat()` beyond `pair` and `array` at this time (except for `ranges::subrange`), nor is it using `get` as a customization point.

This PR can be viewed as a series of transformations (see individual commits, each of which build and pass tests), but it's simpler to explain as an overall before-and-after change:

* This removes `_Cat_sequences`, `_View_as_tuple`, and `_Repeat_for`. We'll achieve the same results in different ways.
* `tuple_cat()`:
  + The return type is now a `_Ret` typedef instead of `type`, for increased consistency.
  + The tag types are being renamed to reduce verbosity ("arg" was meaningless here).
  + All of the types are being extracted as aliases, so that the `return` statement fits on a single line and is easier to read.
* `_Tuple_cat()`:
  + The function argument is `forward_as_tuple()`, so it's always a modifiable rvalue. Thus we can take `_Ty _Arg` and pass `_STD move(_Arg)`, there's no need to forward it.
  + For style, construct `_Ret` with braces.
* `_Tuple_cat1`:
  + Is now an alias template, since we don't need a more expensive `struct` here.
  + Now it passes `tuple<_Tuples&&...>` to `_Tuple_cat2`; this is the type of the meta-tuple (what `forward_as_tuple()` returns). There it will be referred to as `_Ty`, exactly matching `_Ty _Arg`.
  + It also feeds `make_index_sequence<SIZES>...` to `_Tuple_cat2`, which will work (almost) purely with index sequences. These sequences (patterns like `<0, 1, 2>`, `<0, 1, 2, 3, 4>`, `<0, 1>`, etc.) will be concatenated to form the `_Kx` sequence. They are also transformed to form the `_Ix` sequence.
  + The sizes are `tuple_size_v<_Remove_cvref_t<_Tuples>>`. This is part of how we're replacing `_View_as_tuple`, by viewing the arguments through the lens of `tuple_size_v`. The `_Tuples` are being perfectly forwarded, so we need to remove references (and we may as well remove cv-qualifiers, since the `_Remove_cvref_t` helper is optimized, even though `tuple_size_v` would ignore them). We don't need the full power of decay, as arrays and functions aren't interesting here.
  + The insight here is that the `_Kx` and `_Ix` indices, combined with the meta-`tuple` `_Ty`, are sufficient to determine the return type. This significantly simplifies that machinery.
* `_Tuple_cat2`'s primary template:
  + Takes `_Ty` (used at the very end of recursion).
  + `class _Kx_arg, class _Ix_arg, size_t _Ix_next` have the same meanings as before.
  + Takes `_Sequences` instead of `_Tuples`.
  + This "always succeeds" so we don't need a `static_assert` (non-tuple-like inputs would have been rejected at the `tuple_size_v` layer).
* `_Tuple_cat2` has a specialization to handle empty `_Sequences` when recursion is done.
  + As mentioned, we compute `_Ret` from `_Kx`, `_Ix`, and `_Ty`.
  + The meta-`tuple` is a modifiable rvalue, so we can directly say `tuple_element_t<_Ix, _Ty>`.
  + The elements of the meta-`tuple` will be lvalue references or rvalue references (that's what `forward_as_tuple()` does), which we need to remove. They can also be cv-qualified (depending on the original `_Tuples`), and we *must* remove that, or `tuple_element_t` will "helpfully" propagate cv-qualifiers. (That is, `is_same_v<tuple_element_t<0, const tuple<int>>, const int>` is true, but we don't want such propagation here.) However, we don't need the full power of `decay_t` which we were using earlier.
  + Using `tuple_element_t` to determine `_Ret` completes the replacement of `_View_as_tuple` - as long as `tuple_size_v` reports the size of a tuple-like "container" and `tuple_element_t` extracts the element type, this will work.
* `_Tuple_cat2`'s recursion specialization:
  + Is (hopefully) easier to understand, since it's doing less work than before (no `_Ret` computation until the end, so it doesn't have to mention `tuple` a bunch of times), and is directly doing the remaining work.
  + To concatenate the `_Kx` indices, we can directly say `index_sequence<_Kx..., _Kx_next...>`.
  + To form the `_Ix` indices, now that we have a pack of `_Kx_next` values (instead of types), we can expand directly instead of using `_Repeat_for` to ignore the types. All we need is an expression that results in `_Ix_next` repeatedly, and "depends on" `_Kx_next` to drive the expansion but ignores its values. `(_Ix_next + 0 * _Kx_next)...` makes this clear, while avoiding any "conditional expression is constant" warnings.

I believe that the result is significantly simpler to understand, and prepares `tuple_cat()` for possible future developments where `tuple_size_v` and `tuple_element_t` handle more types.

`Dev11_0000000_tuple_cat` provides coverage of different-length `tuple`s, `pair` and `array` inputs, reference elements, and even had some coverage of cv-qualification and value categories for the tuple-like objects. However, because the return type logic is the biggest change in this PR, and needed `_Remove_cvref_t` to handle such scenarios, I am adding extra validation (to ensure that the return type is not influenced by the cv-quals and value categories of the tuple-like objects, and purely concatenates the element types within).

@CaseyCarter noted that this automatically works with `ranges::subrange` which supports the tuple protocol; I am adding test coverage for that.