### PR TITLE
`winapisupp.cpp`: Dramatically shrink the function pointer table

### DIFF
--- a/stl/src/awint.hpp
+++ b/stl/src/awint.hpp
@@ -28,10 +28,9 @@ _CRTIMP2 void __cdecl __crtGetSystemTimePreciseAsFileTime(_Out_ LPFILETIME lpSys
 #endif // _STL_WIN32_WINNT >= _WIN32_WINNT_WIN8
 
 enum wrapKERNEL32Functions {
-#if defined(_CRT_WINDOWS) || defined(UNDOCKED_WINDOWS_UCRT)
-#else // defined(_CRT_WINDOWS) || defined(UNDOCKED_WINDOWS_UCRT)
+#if !defined(_CRT_WINDOWS) && !defined(UNDOCKED_WINDOWS_UCRT)
     eGetCurrentPackageId,
-#endif // defined(_CRT_WINDOWS) || defined(UNDOCKED_WINDOWS_UCRT)
+#endif // !defined(_CRT_WINDOWS) && !defined(UNDOCKED_WINDOWS_UCRT)
     eGetSystemTimePreciseAsFileTime,
     eMaxKernel32Function
 };

--- a/stl/src/awint.hpp
+++ b/stl/src/awint.hpp
@@ -12,10 +12,6 @@
 
 _CRT_BEGIN_C_HEADER
 
-#if !defined(_CRT_WINDOWS) && !defined(UNDOCKED_WINDOWS_UCRT)
-_CRTIMP2 BOOL __cdecl __crtIsPackagedApp();
-#endif // !defined(_CRT_WINDOWS) && !defined(UNDOCKED_WINDOWS_UCRT)
-
 #if _STL_WIN32_WINNT >= _WIN32_WINNT_WIN8
 
 #define __crtGetSystemTimePreciseAsFileTime(lpSystemTimeAsFileTime) \

--- a/stl/src/awint.hpp
+++ b/stl/src/awint.hpp
@@ -27,60 +27,12 @@ _CRTIMP2 void __cdecl __crtGetSystemTimePreciseAsFileTime(_Out_ LPFILETIME lpSys
 
 #endif // _STL_WIN32_WINNT >= _WIN32_WINNT_WIN8
 
-// This enum should not change, even though some functions are no longer imported dynamically
 enum wrapKERNEL32Functions {
-    eFlsAlloc,
-    eFlsFree,
-    eFlsGetValue,
-    eFlsSetValue,
-    eInitializeCriticalSectionEx,
-    eInitOnceExecuteOnce,
-    eCreateEventExW,
-    eCreateSemaphoreW,
-    eCreateSemaphoreExW,
-    eCreateThreadpoolTimer,
-    eSetThreadpoolTimer,
-    eWaitForThreadpoolTimerCallbacks,
-    eCloseThreadpoolTimer,
-    eCreateThreadpoolWait,
-    eSetThreadpoolWait,
-    eCloseThreadpoolWait,
-    eFlushProcessWriteBuffers,
-    eFreeLibraryWhenCallbackReturns,
-    eGetCurrentProcessorNumber,
-    eCreateSymbolicLinkW,
 #if defined(_CRT_WINDOWS) || defined(UNDOCKED_WINDOWS_UCRT)
-    eSetDefaultDllDirectories,
-    eCompareStringEx,
-    eEnumSystemLocalesEx,
-    eGetLocaleInfoEx,
-    eGetUserDefaultLocaleName,
-    eIsValidLocaleName,
-    eLCMapStringEx,
 #else // defined(_CRT_WINDOWS) || defined(UNDOCKED_WINDOWS_UCRT)
     eGetCurrentPackageId,
 #endif // defined(_CRT_WINDOWS) || defined(UNDOCKED_WINDOWS_UCRT)
-    eGetTickCount64,
-    eGetFileInformationByHandleEx,
-    eSetFileInformationByHandle,
     eGetSystemTimePreciseAsFileTime,
-    eInitializeConditionVariable,
-    eWakeConditionVariable,
-    eWakeAllConditionVariable,
-    eSleepConditionVariableCS,
-    eInitializeSRWLock,
-    eAcquireSRWLockExclusive,
-    eTryAcquireSRWLockExclusive,
-    eReleaseSRWLockExclusive,
-    eSleepConditionVariableSRW,
-    eCreateThreadpoolWork,
-    eSubmitThreadpoolWork,
-    eCloseThreadpoolWork,
-#if !defined(_CRT_WINDOWS) && !defined(UNDOCKED_WINDOWS_UCRT)
-    eCompareStringEx,
-    eGetLocaleInfoEx,
-    eLCMapStringEx,
-#endif // !defined(_CRT_WINDOWS) && !defined(UNDOCKED_WINDOWS_UCRT)
     eMaxKernel32Function
 };
 

--- a/stl/src/awint.hpp
+++ b/stl/src/awint.hpp
@@ -27,30 +27,6 @@ _CRTIMP2 void __cdecl __crtGetSystemTimePreciseAsFileTime(_Out_ LPFILETIME lpSys
 
 #endif // _STL_WIN32_WINNT >= _WIN32_WINNT_WIN8
 
-enum wrapKERNEL32Functions {
-#if !defined(_CRT_WINDOWS) && !defined(UNDOCKED_WINDOWS_UCRT)
-    eGetCurrentPackageId,
-#endif // !defined(_CRT_WINDOWS) && !defined(UNDOCKED_WINDOWS_UCRT)
-    eGetSystemTimePreciseAsFileTime,
-    eMaxKernel32Function
-};
-
-extern PVOID __KERNEL32Functions[eMaxKernel32Function];
-
-using PFNGETSYSTEMTIMEPRECISEASFILETIME = VOID(WINAPI*)(LPFILETIME);
-
-// Use this macro for caching a function pointer from a DLL
-#define STOREFUNCTIONPOINTER(instance, function_name) \
-    __KERNEL32Functions[e##function_name] = reinterpret_cast<PVOID>(GetProcAddress(instance, #function_name));
-
-// Use this macro as a cached function pointer from a DLL
-#define DYNAMICGETCACHEDFUNCTION(function_pointer_type, function_name, variable_name) \
-    const auto variable_name = reinterpret_cast<function_pointer_type>(__KERNEL32Functions[e##function_name])
-
-#define IFDYNAMICGETCACHEDFUNCTION(function_pointer_type, function_name, variable_name) \
-    DYNAMICGETCACHEDFUNCTION(function_pointer_type, function_name, variable_name);      \
-    if (variable_name != nullptr)
-
 _CRTIMP2 int __cdecl __crtCompareStringA(_In_z_ LPCWSTR _LocaleName, _In_ DWORD _DwCmpFlags,
     _In_reads_(_CchCount1) LPCSTR _LpString1, _In_ int _CchCount1, _In_reads_(_CchCount2) LPCSTR _LpString2,
     _In_ int _CchCount2, _In_ int _CodePage);

--- a/stl/src/winapisupp.cpp
+++ b/stl/src/winapisupp.cpp
@@ -376,58 +376,11 @@ static int __cdecl initialize_pointers() {
     HINSTANCE hKernel32 = GetModuleHandleW(L"kernel32.dll");
     _Analysis_assume_(hKernel32);
 
-    STOREFUNCTIONPOINTER(hKernel32, FlsAlloc);
-    STOREFUNCTIONPOINTER(hKernel32, FlsFree);
-    STOREFUNCTIONPOINTER(hKernel32, FlsGetValue);
-    STOREFUNCTIONPOINTER(hKernel32, FlsSetValue);
-    STOREFUNCTIONPOINTER(hKernel32, InitializeCriticalSectionEx);
-    STOREFUNCTIONPOINTER(hKernel32, InitOnceExecuteOnce);
-    STOREFUNCTIONPOINTER(hKernel32, CreateEventExW);
-    STOREFUNCTIONPOINTER(hKernel32, CreateSemaphoreW);
-    STOREFUNCTIONPOINTER(hKernel32, CreateSemaphoreExW);
-    STOREFUNCTIONPOINTER(hKernel32, CreateThreadpoolTimer);
-    STOREFUNCTIONPOINTER(hKernel32, SetThreadpoolTimer);
-    STOREFUNCTIONPOINTER(hKernel32, WaitForThreadpoolTimerCallbacks);
-    STOREFUNCTIONPOINTER(hKernel32, CloseThreadpoolTimer);
-    STOREFUNCTIONPOINTER(hKernel32, CreateThreadpoolWait);
-    STOREFUNCTIONPOINTER(hKernel32, SetThreadpoolWait);
-    STOREFUNCTIONPOINTER(hKernel32, CloseThreadpoolWait);
-    STOREFUNCTIONPOINTER(hKernel32, FlushProcessWriteBuffers);
-    STOREFUNCTIONPOINTER(hKernel32, FreeLibraryWhenCallbackReturns);
-    STOREFUNCTIONPOINTER(hKernel32, GetCurrentProcessorNumber);
-    STOREFUNCTIONPOINTER(hKernel32, CreateSymbolicLinkW);
 #if defined(_CRT_WINDOWS) || defined(UNDOCKED_WINDOWS_UCRT)
-    STOREFUNCTIONPOINTER(hKernel32, SetDefaultDllDirectories);
-    STOREFUNCTIONPOINTER(hKernel32, EnumSystemLocalesEx);
-    STOREFUNCTIONPOINTER(hKernel32, CompareStringEx);
-    STOREFUNCTIONPOINTER(hKernel32, GetLocaleInfoEx);
-    STOREFUNCTIONPOINTER(hKernel32, GetUserDefaultLocaleName);
-    STOREFUNCTIONPOINTER(hKernel32, IsValidLocaleName);
-    STOREFUNCTIONPOINTER(hKernel32, LCMapStringEx);
 #else
     STOREFUNCTIONPOINTER(hKernel32, GetCurrentPackageId);
 #endif
-    STOREFUNCTIONPOINTER(hKernel32, GetTickCount64);
-    STOREFUNCTIONPOINTER(hKernel32, GetFileInformationByHandleEx);
-    STOREFUNCTIONPOINTER(hKernel32, SetFileInformationByHandle);
     STOREFUNCTIONPOINTER(hKernel32, GetSystemTimePreciseAsFileTime);
-    STOREFUNCTIONPOINTER(hKernel32, InitializeConditionVariable);
-    STOREFUNCTIONPOINTER(hKernel32, WakeConditionVariable);
-    STOREFUNCTIONPOINTER(hKernel32, WakeAllConditionVariable);
-    STOREFUNCTIONPOINTER(hKernel32, SleepConditionVariableCS);
-    STOREFUNCTIONPOINTER(hKernel32, InitializeSRWLock);
-    STOREFUNCTIONPOINTER(hKernel32, AcquireSRWLockExclusive);
-    STOREFUNCTIONPOINTER(hKernel32, TryAcquireSRWLockExclusive);
-    STOREFUNCTIONPOINTER(hKernel32, ReleaseSRWLockExclusive);
-    STOREFUNCTIONPOINTER(hKernel32, SleepConditionVariableSRW);
-    STOREFUNCTIONPOINTER(hKernel32, CreateThreadpoolWork);
-    STOREFUNCTIONPOINTER(hKernel32, SubmitThreadpoolWork);
-    STOREFUNCTIONPOINTER(hKernel32, CloseThreadpoolWork);
-#if !defined(_CRT_WINDOWS) && !defined(UNDOCKED_WINDOWS_UCRT)
-    STOREFUNCTIONPOINTER(hKernel32, CompareStringEx);
-    STOREFUNCTIONPOINTER(hKernel32, GetLocaleInfoEx);
-    STOREFUNCTIONPOINTER(hKernel32, LCMapStringEx);
-#endif
 
     return 0;
 }

--- a/stl/src/winapisupp.cpp
+++ b/stl/src/winapisupp.cpp
@@ -23,11 +23,15 @@ namespace {
 #if !defined(_CRT_WINDOWS) && !defined(UNDOCKED_WINDOWS_UCRT)
         eGetCurrentPackageId,
 #endif // !defined(_CRT_WINDOWS) && !defined(UNDOCKED_WINDOWS_UCRT)
+
+#if _STL_WIN32_WINNT < _WIN32_WINNT_WIN8
         eGetSystemTimePreciseAsFileTime,
+#endif // _STL_WIN32_WINNT < _WIN32_WINNT_WIN8
+
         eMaxKernel32Function
     };
 
-    PVOID __KERNEL32Functions[eMaxKernel32Function]{};
+    PVOID __KERNEL32Functions[eMaxKernel32Function > 0 ? eMaxKernel32Function : 1]{};
 
     using PFNGETSYSTEMTIMEPRECISEASFILETIME = VOID(WINAPI*)(LPFILETIME);
 
@@ -407,7 +411,10 @@ static int __cdecl initialize_pointers() {
 #if !defined(_CRT_WINDOWS) && !defined(UNDOCKED_WINDOWS_UCRT)
     STOREFUNCTIONPOINTER(hKernel32, GetCurrentPackageId);
 #endif // !defined(_CRT_WINDOWS) && !defined(UNDOCKED_WINDOWS_UCRT)
+
+#if _STL_WIN32_WINNT < _WIN32_WINNT_WIN8
     STOREFUNCTIONPOINTER(hKernel32, GetSystemTimePreciseAsFileTime);
+#endif // _STL_WIN32_WINNT < _WIN32_WINNT_WIN8
 
     return 0;
 }

--- a/stl/src/winapisupp.cpp
+++ b/stl/src/winapisupp.cpp
@@ -44,8 +44,6 @@ namespace {
 #endif // ^^^ !defined(_ONECORE) ^^^
 
 #if !defined(_CRT_WINDOWS) && !defined(UNDOCKED_WINDOWS_UCRT)
-// GetCurrentPackageId retrieves the current package id, if the app is deployed via a package.
-using PFNGETCURRENTPACKAGEID = LONG(WINAPI*)(UINT32*, BYTE*);
 
 #if !defined _CRT_APP
 #if defined _ONECORE
@@ -80,7 +78,7 @@ extern "C" int __crt_IsPackagedAppHelper() {
         }
 
         auto const get_current_package_id =
-            reinterpret_cast<PFNGETCURRENTPACKAGEID>(GetProcAddress(apiset.Get(), "GetCurrentPackageId"));
+            reinterpret_cast<decltype(&GetCurrentPackageId)>(GetProcAddress(apiset.Get(), "GetCurrentPackageId"));
 
         if (!get_current_package_id) {
             continue;

--- a/stl/src/winapisupp.cpp
+++ b/stl/src/winapisupp.cpp
@@ -52,7 +52,7 @@ namespace {
 
 #if !defined(_CRT_WINDOWS) && !defined(UNDOCKED_WINDOWS_UCRT)
 // GetCurrentPackageId retrieves the current package id, if the app is deployed via a package.
-using PFNGETCURRENTPACKAGEID = BOOL(WINAPI*)(UINT32*, BYTE*);
+using PFNGETCURRENTPACKAGEID = LONG(WINAPI*)(UINT32*, BYTE*);
 
 #if !defined _CRT_APP
 #if defined _ONECORE

--- a/stl/src/winapisupp.cpp
+++ b/stl/src/winapisupp.cpp
@@ -17,19 +17,19 @@
 #include <cstdint>
 
 #if !defined(_ONECORE)
-_CRT_BEGIN_C_HEADER
+namespace {
 
-enum wrapKERNEL32Functions {
+    enum wrapKERNEL32Functions {
 #if !defined(_CRT_WINDOWS) && !defined(UNDOCKED_WINDOWS_UCRT)
-    eGetCurrentPackageId,
+        eGetCurrentPackageId,
 #endif // !defined(_CRT_WINDOWS) && !defined(UNDOCKED_WINDOWS_UCRT)
-    eGetSystemTimePreciseAsFileTime,
-    eMaxKernel32Function
-};
+        eGetSystemTimePreciseAsFileTime,
+        eMaxKernel32Function
+    };
 
-PVOID __KERNEL32Functions[eMaxKernel32Function]{};
+    PVOID __KERNEL32Functions[eMaxKernel32Function]{};
 
-using PFNGETSYSTEMTIMEPRECISEASFILETIME = VOID(WINAPI*)(LPFILETIME);
+    using PFNGETSYSTEMTIMEPRECISEASFILETIME = VOID(WINAPI*)(LPFILETIME);
 
 // Use this macro for caching a function pointer from a DLL
 #define STOREFUNCTIONPOINTER(instance, function_name) \
@@ -43,7 +43,7 @@ using PFNGETSYSTEMTIMEPRECISEASFILETIME = VOID(WINAPI*)(LPFILETIME);
     DYNAMICGETCACHEDFUNCTION(function_pointer_type, function_name, variable_name);      \
     if (variable_name != nullptr)
 
-_CRT_END_C_HEADER
+} // unnamed namespace
 #endif // ^^^ !defined(_ONECORE) ^^^
 
 #if !defined(_CRT_WINDOWS) && !defined(UNDOCKED_WINDOWS_UCRT)

--- a/stl/src/winapisupp.cpp
+++ b/stl/src/winapisupp.cpp
@@ -35,7 +35,7 @@ namespace {
 
 // Use this macro for caching a function pointer from a DLL
 #define STOREFUNCTIONPOINTER(instance, function_name) \
-    __KERNEL32Functions[e##function_name] = reinterpret_cast<PVOID>(GetProcAddress(instance, #function_name));
+    __KERNEL32Functions[e##function_name] = reinterpret_cast<PVOID>(GetProcAddress(instance, #function_name))
 
 // Use this macro for retrieving a cached function pointer from a DLL
 #define IFDYNAMICGETCACHEDFUNCTION(name) \

--- a/stl/src/winapisupp.cpp
+++ b/stl/src/winapisupp.cpp
@@ -38,9 +38,8 @@ namespace {
     __KERNEL32Functions[e##function_name] = reinterpret_cast<PVOID>(GetProcAddress(instance, #function_name));
 
 // Use this macro for retrieving a cached function pointer from a DLL
-#define IFDYNAMICGETCACHEDFUNCTION(function_name)                                                                     \
-    const auto pf##function_name = reinterpret_cast<decltype(&function_name)>(__KERNEL32Functions[e##function_name]); \
-    if (pf##function_name)
+#define IFDYNAMICGETCACHEDFUNCTION(name) \
+    if (const auto pf##name = reinterpret_cast<decltype(&name)>(__KERNEL32Functions[e##name]); pf##name)
 
 } // unnamed namespace
 #endif // ^^^ !defined(_ONECORE) ^^^

--- a/stl/src/winapisupp.cpp
+++ b/stl/src/winapisupp.cpp
@@ -39,13 +39,10 @@ namespace {
 #define STOREFUNCTIONPOINTER(instance, function_name) \
     __KERNEL32Functions[e##function_name] = reinterpret_cast<PVOID>(GetProcAddress(instance, #function_name));
 
-// Use this macro as a cached function pointer from a DLL
-#define DYNAMICGETCACHEDFUNCTION(function_pointer_type, function_name, variable_name) \
-    const auto variable_name = reinterpret_cast<function_pointer_type>(__KERNEL32Functions[e##function_name])
-
-#define IFDYNAMICGETCACHEDFUNCTION(function_pointer_type, function_name, variable_name) \
-    DYNAMICGETCACHEDFUNCTION(function_pointer_type, function_name, variable_name);      \
-    if (variable_name != nullptr)
+// Use this macro for retrieving a cached function pointer from a DLL
+#define IFDYNAMICGETCACHEDFUNCTION(function_pointer_type, function_name, variable_name)                        \
+    const auto variable_name = reinterpret_cast<function_pointer_type>(__KERNEL32Functions[e##function_name]); \
+    if (variable_name)
 
 } // unnamed namespace
 #endif // ^^^ !defined(_ONECORE) ^^^

--- a/stl/src/winapisupp.cpp
+++ b/stl/src/winapisupp.cpp
@@ -73,15 +73,13 @@ extern "C" int __crt_IsPackagedAppHelper() {
         L"appmodel.dll" // LNM implementation DLL
     };
 
-    wchar_t const* const* const first_possible_apiset = possible_apisets;
-    wchar_t const* const* const last_possible_apiset  = possible_apisets + _countof(possible_apisets);
-    for (wchar_t const* const* it = first_possible_apiset; it != last_possible_apiset; ++it) {
-        HMODULEHandle const apiset(LoadLibraryExW(*it, nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32));
+    for (auto& dll : possible_apisets) {
+        HMODULEHandle const apiset(LoadLibraryExW(dll, nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32));
         if (!apiset.IsValid()) {
             continue;
         }
 
-        PFNGETCURRENTPACKAGEID const get_current_package_id =
+        auto const get_current_package_id =
             reinterpret_cast<PFNGETCURRENTPACKAGEID>(GetProcAddress(apiset.Get(), "GetCurrentPackageId"));
 
         if (!get_current_package_id) {

--- a/stl/src/winapisupp.cpp
+++ b/stl/src/winapisupp.cpp
@@ -16,6 +16,34 @@
 #pragma warning(pop)
 #include <cstdint>
 
+_CRT_BEGIN_C_HEADER
+
+enum wrapKERNEL32Functions {
+#if !defined(_CRT_WINDOWS) && !defined(UNDOCKED_WINDOWS_UCRT)
+    eGetCurrentPackageId,
+#endif // !defined(_CRT_WINDOWS) && !defined(UNDOCKED_WINDOWS_UCRT)
+    eGetSystemTimePreciseAsFileTime,
+    eMaxKernel32Function
+};
+
+extern PVOID __KERNEL32Functions[eMaxKernel32Function];
+
+using PFNGETSYSTEMTIMEPRECISEASFILETIME = VOID(WINAPI*)(LPFILETIME);
+
+// Use this macro for caching a function pointer from a DLL
+#define STOREFUNCTIONPOINTER(instance, function_name) \
+    __KERNEL32Functions[e##function_name] = reinterpret_cast<PVOID>(GetProcAddress(instance, #function_name));
+
+// Use this macro as a cached function pointer from a DLL
+#define DYNAMICGETCACHEDFUNCTION(function_pointer_type, function_name, variable_name) \
+    const auto variable_name = reinterpret_cast<function_pointer_type>(__KERNEL32Functions[e##function_name])
+
+#define IFDYNAMICGETCACHEDFUNCTION(function_pointer_type, function_name, variable_name) \
+    DYNAMICGETCACHEDFUNCTION(function_pointer_type, function_name, variable_name);      \
+    if (variable_name != nullptr)
+
+_CRT_END_C_HEADER
+
 #if !defined(_CRT_WINDOWS) && !defined(UNDOCKED_WINDOWS_UCRT)
 // GetCurrentPackageId retrieves the current package id, if the app is deployed via a package.
 using PFNGETCURRENTPACKAGEID = BOOL(WINAPI*)(UINT32*, BYTE*);

--- a/stl/src/winapisupp.cpp
+++ b/stl/src/winapisupp.cpp
@@ -14,7 +14,6 @@
 #pragma warning(disable : 4265) // non-virtual destructor in base class
 #include <wrl/wrappers/corewrappers.h>
 #pragma warning(pop)
-#include <cstdint>
 
 #if !defined(_ONECORE)
 namespace {

--- a/stl/src/winapisupp.cpp
+++ b/stl/src/winapisupp.cpp
@@ -376,10 +376,9 @@ static int __cdecl initialize_pointers() {
     HINSTANCE hKernel32 = GetModuleHandleW(L"kernel32.dll");
     _Analysis_assume_(hKernel32);
 
-#if defined(_CRT_WINDOWS) || defined(UNDOCKED_WINDOWS_UCRT)
-#else
+#if !defined(_CRT_WINDOWS) && !defined(UNDOCKED_WINDOWS_UCRT)
     STOREFUNCTIONPOINTER(hKernel32, GetCurrentPackageId);
-#endif
+#endif // !defined(_CRT_WINDOWS) && !defined(UNDOCKED_WINDOWS_UCRT)
     STOREFUNCTIONPOINTER(hKernel32, GetSystemTimePreciseAsFileTime);
 
     return 0;

--- a/stl/src/winapisupp.cpp
+++ b/stl/src/winapisupp.cpp
@@ -135,7 +135,8 @@ extern "C" int __crt_IsPackagedAppHelper() {
 //
 // Exit:
 //        TRUE if Packaged app, FALSE if not.
-extern "C" BOOL __cdecl __crtIsPackagedApp() {
+// TRANSITION, ABI: preserved for binary compatibility
+extern "C" _CRTIMP2 BOOL __cdecl __crtIsPackagedApp() {
 #ifdef _CRT_APP
     return TRUE;
 #else

--- a/stl/src/winapisupp.cpp
+++ b/stl/src/winapisupp.cpp
@@ -16,6 +16,7 @@
 #pragma warning(pop)
 #include <cstdint>
 
+#if !defined(_ONECORE)
 _CRT_BEGIN_C_HEADER
 
 enum wrapKERNEL32Functions {
@@ -26,7 +27,7 @@ enum wrapKERNEL32Functions {
     eMaxKernel32Function
 };
 
-extern PVOID __KERNEL32Functions[eMaxKernel32Function];
+PVOID __KERNEL32Functions[eMaxKernel32Function]{};
 
 using PFNGETSYSTEMTIMEPRECISEASFILETIME = VOID(WINAPI*)(LPFILETIME);
 
@@ -43,6 +44,7 @@ using PFNGETSYSTEMTIMEPRECISEASFILETIME = VOID(WINAPI*)(LPFILETIME);
     if (variable_name != nullptr)
 
 _CRT_END_C_HEADER
+#endif // ^^^ !defined(_ONECORE) ^^^
 
 #if !defined(_CRT_WINDOWS) && !defined(UNDOCKED_WINDOWS_UCRT)
 // GetCurrentPackageId retrieves the current package id, if the app is deployed via a package.
@@ -397,8 +399,6 @@ extern "C" void __cdecl __crtGetSystemTimePreciseAsFileTime(_Out_ LPFILETIME lpS
 // All APIs are statically available, and we can't call GetModuleHandleW().
 
 #else // defined _ONECORE
-
-extern "C" PVOID __KERNEL32Functions[eMaxKernel32Function] = {nullptr};
 
 static int __cdecl initialize_pointers() {
     HINSTANCE hKernel32 = GetModuleHandleW(L"kernel32.dll");


### PR DESCRIPTION
Now that we've merged #2317, there are only a couple of functions we're dynamically loading.

* Dramatically shrink the `__KERNEL32Functions` table.
  + The only direct uses of `__KERNEL32Functions` are in `STOREFUNCTIONPOINTER` and `DYNAMICGETCACHEDFUNCTION`.
  + The only use of `DYNAMICGETCACHEDFUNCTION` is in `IFDYNAMICGETCACHEDFUNCTION`.
  + There are only two uses of `IFDYNAMICGETCACHEDFUNCTION`, loading `GetCurrentPackageId` and `GetSystemTimePreciseAsFileTime`.
  + Therefore, all other table entries are unused.
  + The comment `// This enum should not change` was introduced by #1194, but we were being overly cautious. The enum and table aren't mentioned outside of `stl/src`. Also, while the table was `extern "C"`, it wasn't exported. Therefore, they're purely internal to the separately compiled STL.
* De Morgan the guards around `GetCurrentPackageId`.
* Move `__KERNEL32Functions` machinery to `winapisupp.cpp`.
  + It was within `_CRT_BEGIN_C_HEADER` / `_CRT_END_C_HEADER`.
* Guard `__KERNEL32Functions` machinery with `#if !defined(_ONECORE)`. Fuse declaration and definition.
  + The definition and initialization of `__KERNEL32Functions` were effectively guarded by `#if !defined(_ONECORE)`, so we should extend that guard to all of the machinery.
  + When fusing the declaration and definition, we're within `_CRT_BEGIN_C_HEADER` so we don't need `extern "C"`. We also don't need `extern` (the definition already has external linkage, and other TUs don't need this anyways).
  + For style, initialize with `{}` instead of ` = {nullptr}`. They have the same effect here, but `{}` emphasizes that we want to value-initialize the entire table.
* Use an unnamed namespace instead of `extern "C"` for the `__KERNEL32Functions` machinery.
  + We don't need this in other TUs. The unnamed namespace emphasizes that it's purely internal.
* Cache `GetSystemTimePreciseAsFileTime` only when we need it.
  + Now we need to guard against `eMaxKernel32Function` being `0`.
* Fix return type in `PFNGETCURRENTPACKAGEID` typedef.
  + See: https://docs.microsoft.com/en-us/windows/win32/api/appmodel/nf-appmodel-getcurrentpackageid
  + Verified that this is now identical to `decltype(&GetCurrentPackageId)`.
* Fuse `DYNAMICGETCACHEDFUNCTION` into `IFDYNAMICGETCACHEDFUNCTION`.
  + Update comment.
  + Style: Directly test the function pointer.
* Always use `decltype` in `IFDYNAMICGETCACHEDFUNCTION`.
  + We no longer need `PFNGETSYSTEMTIMEPRECISEASFILETIME`.
  + Also, always emit `pf##function_name`.
* Use C++17 if-statement with initializer to improve scoping.
* Avoid emitting empty statements after `STOREFUNCTIONPOINTER`.
* `winapisupp.cpp` isn't using `<cstdint>` at all.
* Simplify `__crt_IsPackagedAppHelper()` with range-for and auto.
* `awint.hpp` doesn't need to declare `__crtIsPackagedApp()`.
  + We still need to export it for bincompat.
* We can always use `decltype` for `GetCurrentPackageId`.
  + Verified with an internal build.

This shrinks the STL's DLL by a couple of KB on x64:

|   File Size (bytes) |     Before |      After | Difference |
|--------------------:|-----------:|-----------:|-----------:|
|  `msvcp140_oss.dll` |    551,936 |    549,888 |      2,048 |
| `msvcp140d_oss.dll` |    914,432 |    911,872 |      2,560 |
|       `libcpmt.lib` | 35,669,646 | 35,622,078 |     47,568 |
|      `libcpmtd.lib` | 36,966,642 | 36,926,400 |     40,242 |
