### PR TITLE
Status Chart: Colorized counters, mobile-optimized

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,40 +37,45 @@
     <ul>
         <li>Right axis:
             <ul>
-                <li><span class="Counter">0</span>
+                <li><span class="Counter color-bg-severe-emphasis color-fg-on-emphasis">0</span>
                     C++17 STL features remaining to be implemented. This reached zero when we implemented
                     <a href="https://www.reddit.com/r/cpp/comments/dgj89g/cppcon_2019_stephan_t_lavavej_floatingpoint/"
                         rel="nofollow"><code>&lt;charconv&gt;</code>, C++17's final boss</a>.
                 </li>
-                <li><span class="Counter" id="currentValue-cxx20"></span>
+                <li><span class="Counter color-bg-sponsors-emphasis color-fg-on-emphasis"
+                        id="currentValue-cxx20"></span>
                     <a href="https://github.com/microsoft/STL/issues?q=is%3Aopen+is%3Aissue+label%3Acxx20">
                         C++20 STL features remaining to be implemented.</a>
                     This increased whenever more features were voted into the Working Paper at
                     <a href="https://isocpp.org/std/meetings-and-participation" rel="nofollow">WG21 meetings</a>.
                 </li>
-                <li><span class="Counter" id="currentValue-cxx23"></span>
+                <li><span class="Counter color-bg-done-emphasis color-fg-on-emphasis" id="currentValue-cxx23"></span>
                     <a href="https://github.com/microsoft/STL/issues?q=is%3Aopen+is%3Aissue+label%3Acxx23">
                         C++23 STL features remaining to be implemented.</a> Also increases after WG21 meetings.
                 </li>
-                <li><span class="Counter" id="currentValue-lwg"></span> <a
+                <li><span class="Counter color-bg-success-emphasis color-fg-on-emphasis" id="currentValue-lwg"></span>
+                    <a
                         href="https://github.com/microsoft/STL/issues?q=is%3Aopen+is%3Aissue+label%3ALWG+-label%3AvNext+-label%3Ablocked">
-                        LWG issue resolutions remaining to be implemented.</a> Also increases after WG21 meetings.</li>
-                <li><span class="Counter" id="currentValue-pr"></span>
+                        LWG issue resolutions remaining to be implemented.</a> Also increases after WG21 meetings.
+                </li>
+                <li><span class="Counter color-bg-accent-emphasis color-fg-on-emphasis" id="currentValue-pr"></span>
                     <a href="https://github.com/microsoft/STL/pulls">Open pull requests.</a>
                 </li>
             </ul>
         </li>
         <li>Left axis:
             <ul>
-                <li><span class="Counter" id="currentValue-vso"></span>
+                <li><span class="Counter color-fg-on-emphasis"
+                        style="background-color:var(--color-scale-red-7) !important" id="currentValue-vso"></span>
                     Active "old bugs" in our Microsoft-internal database. We're keeping them active while
                     porting them to GitHub, unless they're discovered to be duplicates or already fixed.</li>
-                <li><span class="Counter" id="currentValue-bug"></span>
+                <li><span class="Counter color-bg-danger-emphasis color-fg-on-emphasis" id="currentValue-bug"></span>
                     <a href="https://github.com/microsoft/STL/issues?q=is%3Aopen+is%3Aissue+label%3Abug">
                         Open GitHub bugs.</a> That is, only GitHub issues that have
                     <span class="Label Label--danger">bug</span> labels.
                 </li>
-                <li><span class="Counter" id="currentValue-issue"></span> <a
+                <li><span class="Counter Counter--primary" id="currentValue-issue"></span>
+                    <a
                         href="https://github.com/microsoft/STL/issues?q=is%3Aopen+is%3Aissue+-label%3Acxx20+-label%3Acxx23+-label%3ALWG">
                         Open GitHub issues.</a> That is, all GitHub issues including
                     <span class="Label Label--danger">bug</span>,
@@ -80,7 +85,8 @@
                     <span class="Label Label--severe">cxx23</span>, and
                     <span class="Label Label--success">LWG</span> to avoid double-counting.
                 </li>
-                <li><span class="Counter" id="currentValue-libcxx"></span>
+                <li><span class="Counter color-bg-attention-emphasis color-fg-on-emphasis"
+                        id="currentValue-libcxx"></span>
                     <a href="https://github.com/microsoft/STL/blob/main/tests/libcxx/expected_results.txt">
                         Skipped/failing tests in the libcxx test suite.</a> There are many reasons for such tests:
                     STL bugs, test bugs, compiler bugs, missing STL features, missing compiler features, etc.
@@ -105,19 +111,22 @@
     <ul>
         <li>Left axis:
             <ul>
-                <li><span class="Counter" id="currentValue-avg_age"></span>
+                <li><span class="Counter Counter--primary" id="currentValue-avg_age"></span>
                     The average age of open pull requests, in days.</li>
-                <li><span class="Counter" id="currentValue-avg_wait"></span>
+                <li><span class="Counter color-bg-sponsors-emphasis color-fg-on-emphasis"
+                        id="currentValue-avg_wait"></span>
                     The average "waiting time" of open pull requests, in days. This measures how long it's been since a
                     maintainer submitted a review requesting changes. Any other activity doesn't reset this clock.</li>
             </ul>
         </li>
         <li>Right axis:
             <ul>
-                <li><span class="Counter" id="currentValue-sum_age"></span>
+                <li><span class="Counter"
+                        style="background-color:var(--color-fg-default) !important; color: var(--color-canvas-default) !important;"
+                        id="currentValue-sum_age"></span>
                     The combined age of open pull requests. The unit is PR-months (like kilowatt-hours);
                     for example, 5 PRs that were all opened 2 months ago have a combined age of 10 PR-months.</li>
-                <li><span class="Counter" id="currentValue-sum_wait"></span>
+                <li><span class="Counter color-bg-done-emphasis color-fg-on-emphasis" id="currentValue-sum_wait"></span>
                     The combined "waiting time" of open pull requests, in PR-months.</li>
             </ul>
         </li>
@@ -133,7 +142,7 @@
         and excludes PRs that were closed without being merged, which are rare.</p>
 
     <ul>
-        <li><span class="Counter" id="currentValue-merged"></span>
+        <li><span class="Counter color-bg-accent-emphasis color-fg-on-emphasis" id="currentValue-merged"></span>
             Line: How many PRs have been merged over the past month.
             This uses a "30 day" sliding window, with some smoothing:
             <ul>

--- a/index.html
+++ b/index.html
@@ -20,12 +20,13 @@
     <script type="module" src="built/status_chart.mjs"></script>
 </head>
 
-<body class="container-xl markdown-body pt-2 px-3 pb-3">
+<body class="container-xl markdown-body p-3">
+    <h1 id="status">STL Status Chart</h1>
     <canvas id="statusChart"></canvas>
     <button class="btn" id="moreHistory" type="button">More History</button>
     <button class="btn" id="lessHistory" type="button">Less History</button>
 
-    <h1>Explanation</h1>
+    <h2>Explanation</h2>
     <p>This tracks the progress of the <a href="https://github.com/microsoft/STL">microsoft/STL</a> repo.
         For more info, read the <a href="https://github.com/microsoft/STL/wiki/Changelog">Changelog</a>.</p>
 
@@ -97,9 +98,10 @@
 
     <hr />
 
+    <h1 id="age">Pull Request Age</h1>
     <canvas id="ageChart"></canvas>
 
-    <h1>Explanation</h1>
+    <h2>Explanation</h2>
     <ul>
         <li>Left axis:
             <ul>
@@ -123,9 +125,10 @@
 
     <hr />
 
+    <h1 id="merge">Monthly Merged PRs</h1>
     <canvas id="mergeChart"></canvas>
 
-    <h1>Explanation</h1>
+    <h2>Explanation</h2>
     <p>For this chart, more is better. It includes merges into any branch
         and excludes PRs that were closed without being merged, which are rare.</p>
 

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <meta charset="utf-8" />
     <!-- Copyright (c) Microsoft Corporation. -->
     <!-- SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception -->
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>STL Status Chart</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@primer/css@20.2.4/dist/primer.min.css" />
     <script async src="https://cdn.jsdelivr.net/npm/es-module-shims@1.5.8/dist/es-module-shims.min.js"

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <!-- Copyright (c) Microsoft Corporation. -->
     <!-- SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception -->
     <title>STL Status Chart</title>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@primer/css@20.2.3/dist/primer.min.css" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@primer/css@20.2.4/dist/primer.min.css" />
     <script async src="https://cdn.jsdelivr.net/npm/es-module-shims@1.5.8/dist/es-module-shims.min.js"
         crossorigin="anonymous"></script>
     <script type="importmap">

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,9 +46,9 @@
       }
     },
     "node_modules/@octokit/openapi-types": {
-      "version": "12.5.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-12.5.0.tgz",
-      "integrity": "sha512-VatvE5wtRkJq6hAWGTBZ62WkrdlCiy0G0u27cVOYTfAWVZi7QqTurVcjpsyc5+9hXLPRP5O/DaNEs4TgAp4Mqg=="
+      "version": "12.8.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-12.8.0.tgz",
+      "integrity": "sha512-ydcKLs2KKcxlhpdWLzJxEBDEk/U5MUeqtqkXlrtAUXXFPs6vLl1PEGghFC/BbpleosB7iXs0Z4P2DGe7ZT5ZNg=="
     },
     "node_modules/@octokit/request": {
       "version": "5.6.3",
@@ -74,11 +74,11 @@
       }
     },
     "node_modules/@octokit/types": {
-      "version": "6.38.1",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.38.1.tgz",
-      "integrity": "sha512-kWMohLCIvnwApRmxRFDOqve7puiNNdtVfgwdDOm6QyJNorWOgKv2/AodCcGqx63o28kF7Dr4/nJCatrwwqhULg==",
+      "version": "6.39.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.39.0.tgz",
+      "integrity": "sha512-Mq4N9sOAYCitTsBtDdRVrBE80lIrMBhL9Jbrw0d+j96BAzlq4V+GLHFJbHokEsVvO/9tQupQdoFdgVYhD2C8UQ==",
       "dependencies": {
-        "@octokit/openapi-types": "^12.5.0"
+        "@octokit/openapi-types": "^12.7.0"
       }
     },
     "node_modules/@types/cli-progress": {
@@ -95,9 +95,9 @@
       "integrity": "sha512-WOehptuhKIXukSUUkRgGbj2c997Uv/iUgYgII8U7XLJqq9W2oF0kQ6frEznRQbdurioz+L/cdaIm4GutTQfgmA=="
     },
     "node_modules/@types/node": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.0.tgz",
-      "integrity": "sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA=="
+      "version": "18.0.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.2.tgz",
+      "integrity": "sha512-b947SdS4GH+g2W33wf5FzUu1KLj5FcSIiNWbU1ZyMvt/X7w48ZsVcsQoirIgE/Oq03WT5Qbn/dkY0hePi4ZXcQ=="
     },
     "node_modules/@types/yargs": {
       "version": "17.0.10",
@@ -1103,9 +1103,9 @@
       }
     },
     "@octokit/openapi-types": {
-      "version": "12.5.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-12.5.0.tgz",
-      "integrity": "sha512-VatvE5wtRkJq6hAWGTBZ62WkrdlCiy0G0u27cVOYTfAWVZi7QqTurVcjpsyc5+9hXLPRP5O/DaNEs4TgAp4Mqg=="
+      "version": "12.8.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-12.8.0.tgz",
+      "integrity": "sha512-ydcKLs2KKcxlhpdWLzJxEBDEk/U5MUeqtqkXlrtAUXXFPs6vLl1PEGghFC/BbpleosB7iXs0Z4P2DGe7ZT5ZNg=="
     },
     "@octokit/request": {
       "version": "5.6.3",
@@ -1131,11 +1131,11 @@
       }
     },
     "@octokit/types": {
-      "version": "6.38.1",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.38.1.tgz",
-      "integrity": "sha512-kWMohLCIvnwApRmxRFDOqve7puiNNdtVfgwdDOm6QyJNorWOgKv2/AodCcGqx63o28kF7Dr4/nJCatrwwqhULg==",
+      "version": "6.39.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.39.0.tgz",
+      "integrity": "sha512-Mq4N9sOAYCitTsBtDdRVrBE80lIrMBhL9Jbrw0d+j96BAzlq4V+GLHFJbHokEsVvO/9tQupQdoFdgVYhD2C8UQ==",
       "requires": {
-        "@octokit/openapi-types": "^12.5.0"
+        "@octokit/openapi-types": "^12.7.0"
       }
     },
     "@types/cli-progress": {
@@ -1152,9 +1152,9 @@
       "integrity": "sha512-WOehptuhKIXukSUUkRgGbj2c997Uv/iUgYgII8U7XLJqq9W2oF0kQ6frEznRQbdurioz+L/cdaIm4GutTQfgmA=="
     },
     "@types/node": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.0.tgz",
-      "integrity": "sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA=="
+      "version": "18.0.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.2.tgz",
+      "integrity": "sha512-b947SdS4GH+g2W33wf5FzUu1KLj5FcSIiNWbU1ZyMvt/X7w48ZsVcsQoirIgE/Oq03WT5Qbn/dkY0hePi4ZXcQ=="
     },
     "@types/yargs": {
       "version": "17.0.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@octokit/graphql": "^4.8.0",
         "@types/cli-progress": "^3.11.0",
         "@types/luxon": "^2.3.2",
-        "@types/node": "^18.0.0",
+        "@types/node": "^18.0.2",
         "@types/yargs": "^17.0.10",
         "chart.js": "^3.8.0",
         "chartjs-adapter-luxon": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@octokit/graphql": "^4.8.0",
     "@types/cli-progress": "^3.11.0",
     "@types/luxon": "^2.3.2",
-    "@types/node": "^18.0.0",
+    "@types/node": "^18.0.2",
     "@types/yargs": "^17.0.10",
     "chart.js": "^3.8.0",
     "chartjs-adapter-luxon": "^1.1.0",

--- a/src/status_chart.ts
+++ b/src/status_chart.ts
@@ -279,7 +279,7 @@ function legend_click_handler(_event: ChartEvent, legend_item: LegendItem, legen
     update_url();
 }
 
-function make_common_options(title_text: string) {
+function make_common_options() {
     return {
         animation: {
             duration: 0,
@@ -309,14 +309,6 @@ function make_common_options(title_text: string) {
             tooltip: {
                 mode: 'nearest' as const,
                 intersect: false,
-            },
-            title: {
-                color: get_css_property('--color-fg-default'),
-                display: true,
-                font: {
-                    size: 24,
-                },
-                text: title_text,
             },
         },
         onResize: (chart: Chart, size: { width: number; height: number }) => {
@@ -380,7 +372,7 @@ function make_yAxis(position: 'left' | 'right', title_text: string, min: number,
 }
 
 const status_options = {
-    ...make_common_options('STL Status Chart'),
+    ...make_common_options(),
     scales: {
         x: make_xAxis(timeframes[timeframe_idx]),
         largeAxis: make_yAxis('left', 'Bugs, Issues, Skipped Libcxx Tests', 0, 800, 100),
@@ -389,7 +381,7 @@ const status_options = {
 };
 
 const age_options = {
-    ...make_common_options('Pull Request Age'),
+    ...make_common_options(),
     scales: {
         x: make_xAxis(timeframe_github),
         leftAxis: make_yAxis('left', 'Average Age, Average Wait (days)', 0, 500, 100),
@@ -398,7 +390,7 @@ const age_options = {
 };
 
 const merge_options = {
-    ...make_common_options('Monthly Merged PRs'),
+    ...make_common_options(),
     scales: {
         x: make_xAxis(timeframe_github),
         mergeAxis: make_yAxis('right', 'PRs / month', 0, 80, 10),
@@ -443,16 +435,11 @@ function load_charts() {
         const color_border_default = get_css_property('--color-border-default');
 
         for (const chart of [status_chart, age_chart, merge_chart]) {
-            if (
-                chart.options.plugins?.legend?.labels === undefined ||
-                chart.options.plugins?.title === undefined ||
-                chart.options.scales === undefined
-            ) {
+            if (chart.options.plugins?.legend?.labels === undefined || chart.options.scales === undefined) {
                 throw new Error('update_dark_mode() was surprised by chart.options.');
             }
 
             chart.options.plugins.legend.labels.color = color_fg_default;
-            chart.options.plugins.title.color = color_fg_default;
 
             for (const [scaleId, scale] of Object.entries(chart.options.scales)) {
                 if (scale?.title === undefined || scale?.ticks === undefined || scale?.grid === undefined) {

--- a/src/status_chart.ts
+++ b/src/status_chart.ts
@@ -376,8 +376,8 @@ const status_options = {
     ...make_common_options('STL Status Chart'),
     scales: {
         x: make_xAxis(timeframes[timeframe_idx]),
-        largeAxis: make_yAxis('left', 'Bugs, Issues, Skipped Libcxx Tests', 0, 900, 100),
-        smallAxis: make_yAxis('right', 'Features, LWG Resolutions, Pull Requests', 0, 90, 10),
+        largeAxis: make_yAxis('left', 'Bugs, Issues, Skipped Libcxx Tests', 0, 800, 100),
+        smallAxis: make_yAxis('right', 'Features, LWG Resolutions, Pull Requests', 0, 80, 10),
     },
 };
 
@@ -385,8 +385,8 @@ const age_options = {
     ...make_common_options('Pull Request Age'),
     scales: {
         x: make_xAxis(timeframe_github),
-        leftAxis: make_yAxis('left', 'Average Age, Average Wait (days)', 0, 600, 100),
-        rightAxis: make_yAxis('right', 'Combined Age, Combined Wait (PR-months)', 0, 600, 100),
+        leftAxis: make_yAxis('left', 'Average Age, Average Wait (days)', 0, 500, 100),
+        rightAxis: make_yAxis('right', 'Combined Age, Combined Wait (PR-months)', 0, 500, 100),
     },
 };
 

--- a/src/status_chart.ts
+++ b/src/status_chart.ts
@@ -300,6 +300,7 @@ function make_common_options(title_text: string) {
         },
         plugins: {
             legend: {
+                display: true,
                 labels: {
                     color: get_css_property('--color-fg-default'),
                 },
@@ -317,6 +318,12 @@ function make_common_options(title_text: string) {
                 },
                 text: title_text,
             },
+        },
+        onResize: (chart: Chart, size: { width: number; height: number }) => {
+            if (chart.options.plugins?.legend === undefined) {
+                throw new Error('onResize was surprised by chart.options.');
+            }
+            chart.options.plugins.legend.display = size.width > 670;
         },
     };
 }

--- a/src/status_chart.ts
+++ b/src/status_chart.ts
@@ -243,7 +243,7 @@ const timeframe_all: Timeframe = {
 };
 const timeframe_github: Timeframe = {
     min: '2019-09-20', // first Friday after 2019-09-16
-    time: { unit: 'quarter' },
+    time: { unit: 'year' },
 };
 const timeframe_2021: Timeframe = {
     min: '2021-01-01',

--- a/src/weekly_table.ts
+++ b/src/weekly_table.ts
@@ -273,4 +273,5 @@ export const weekly_table: WeeklyRow[] = [
     { date: '2022-06-10', vso: 172, libcxx: 614 },
     { date: '2022-06-17', vso: 173, libcxx: 614 },
     { date: '2022-06-24', vso: 177, libcxx: 614 },
+    { date: '2022-07-01', vso: 175, libcxx: 614 },
 ];


### PR DESCRIPTION
* Major appearance improvements:
  + Colorize counters to match datasets.
    - As in #2835, styles like `color-bg-severe-emphasis` have no inherent meaning, and are being used for their colors only.
    - Four counters need special treatment. The Old Bugs need to manually specify `--color-scale-red-7`. The GitHub Issues and Average Age datasets are gray lines, so `Counter--primary` results in a readable gray for both dark mode and light mode. Finally, the Combined Age dataset uses the default foreground color (i.e. text color), so for its counter we use inverted colors: the counter's background is the default foreground color, while the counter's foreground is the default canvas color.
    - I believe this significantly helps readability.
  + Use a mobile-optimized viewport.
    - Thanks to @cpplearner for mentioning this technique.
    - After #2835, the Status Chart rendered with extremely tiny fonts for phones in portrait modes. Using this mobile-optimized viewport incantation [as recommended by MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag), combined with Primer CSS, results in readable fonts.
    - However, this results in a different challenge for the chart - it's effectively being drawn with a much thinner width for phones in portrait modes, so we need a couple more changes:
  + Hide the legend when the chart is too narrow.
    - The threshold of 670 was determined experimentally (it's between portrait and landscape for my phone, and I believe virtually all modern phones). Below this threshold, the legend wraps, and occupies too much vertical space, so I simply hide it. Note that the chart continues to respect any hidden/shown lines (and the phone can be rotated into landscape to set those). Also, the colorized counters help to identify which line is which.
    - I experimented with other solutions - HTML legends require far too much code and have problematic interactions with Primer CSS. There are probably other alternatives (e.g. restrict the legend to a certain height, or modify the chart's aspect ratio as it gets thinner), but this seems like a reasonable solution for now.
    - The chart doesn't look *perfect* on phones (the lines are a bit too thick, and the axis titles are truncated), but they're sufficiently readable.
  + Extract chart titles to HTML.
    - This makes the page look more consistent, and gives more vertical space to the charts, which helps readability (especially on mobile).
    - As the page now begins with an `<h1>`, I use `p-3` padding for all sides. (Previously, I reduced padding on the top, because the Status Chart had a bit of blank space above its title.)
* Minor appearance improvements:
  + Adjust bounds.
    - The PR backlog peaked at exactly 80 and the combined age never exceeded 500 PR-months, so we can reclaim that space and make the charts more readable.
  + Switch the GitHub timeframe to years.
    - The quarterly ticks were getting crowded, especially on mobile.
    - In the future I may investigate major and minor gridlines (I believe that Chart.js has this ability, but it requires a bit of work).
* Normal updates:
  + Weekly updates.
  + Primer CSS 20.2.4.
  + `npm update`
  + `npm install [dependencies]@latest`
* As usual, this contains a "DROP BEFORE MERGING: Regen `built/status_chart.mjs`" commit to make the live preview work, which will accumulate merge conflicts.

# :chart_with_downwards_trend: Live preview: [stephantlavavej.github.io/STL/](https://stephantlavavej.github.io/STL/)

# :camera_flash: Screenshots

## :night_with_stars: Dark mode

<img width="235" alt="dark_status" src="https://user-images.githubusercontent.com/4231088/177463276-4f15c37d-ea4e-4ac4-9e26-755fbeb63639.png">
<img width="241" alt="dark_age" src="https://user-images.githubusercontent.com/4231088/177463263-afff806e-6171-4ca1-823a-5bff9f936d6c.png">
<img width="200" alt="dark_merge" src="https://user-images.githubusercontent.com/4231088/177463271-3d4b5f7f-5c01-4a83-8ed0-915722dec938.png">

## :cityscape: Light mode

<img width="232" alt="light_status" src="https://user-images.githubusercontent.com/4231088/177463306-9ed97c25-1a36-463c-9e72-afc23a90dc48.png">
<img width="232" alt="light_age" src="https://user-images.githubusercontent.com/4231088/177463295-7bd62185-6c2f-4a7a-9e10-5defea2ade11.png">
<img width="197" alt="light_merge" src="https://user-images.githubusercontent.com/4231088/177463301-9d8a8ff3-bd6d-4b83-adbb-10292185eedd.png">
