### PR TITLE
run memory leaks tests only with Debug CRT

### DIFF
--- a/tests/std/tests/Dev10_908702_string_memory_leak/test.cpp
+++ b/tests/std/tests/Dev10_908702_string_memory_leak/test.cpp
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// REQUIRES: debug_CRT
+
 #include <assert.h>
 #include <crtdbg.h>
 #include <locale>
@@ -20,9 +22,7 @@ int main() {
         v.insert(v.begin(), 2, "2");
     }
 
-#ifdef _DEBUG
     assert(!_CrtDumpMemoryLeaks());
-#endif
 
     {
         string one("111");
@@ -32,21 +32,17 @@ int main() {
         two = three;
     }
 
-#ifdef _DEBUG
     assert(!_CrtDumpMemoryLeaks());
-#endif
 
     // Also test DevDiv-846054 "<locale>: Spurious memory leaks".
     locale::global(locale(""));
 
-#ifdef _DEBUG
     assert(!_CrtDumpMemoryLeaks());
-#endif
 }
 
 // Also test DevDiv-810608 "<xlocale>: [torino][boost]error C2665:
 // 'std::_Crt_new_delete::operator new' : none of the 2 overloads could convert all the argument types".
-void meow(void* pv) {
+void meow(void* pv) { // COMPILE-ONLY
     // Saying "new" instead of "::new" is intentional here.
     new (pv) locale();
 }

--- a/tests/std/tests/Dev11_0485243_condition_variable_crash/test.cpp
+++ b/tests/std/tests/Dev11_0485243_condition_variable_crash/test.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// REQUIRES: debug_CRT
-
 #include <algorithm>
 #include <assert.h>
 #include <chrono>
@@ -19,9 +17,11 @@
 using namespace std;
 
 void assert_no_leaks() {
+#ifdef _DEBUG
     if (_CrtDumpMemoryLeaks()) {
         abort();
     }
+#endif
 }
 
 void test_484720();

--- a/tests/std/tests/Dev11_0485243_condition_variable_crash/test.cpp
+++ b/tests/std/tests/Dev11_0485243_condition_variable_crash/test.cpp
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// REQUIRES: debug_CRT
+
 #include <algorithm>
 #include <assert.h>
 #include <chrono>
@@ -17,11 +19,9 @@
 using namespace std;
 
 void assert_no_leaks() {
-#ifdef _DEBUG
     if (_CrtDumpMemoryLeaks()) {
         abort();
     }
-#endif
 }
 
 void test_484720();

--- a/tests/std/tests/Dev11_0748972_function_crash_out_of_memory/test.cpp
+++ b/tests/std/tests/Dev11_0748972_function_crash_out_of_memory/test.cpp
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// REQUIRES: debug_CRT
+
 #define _SILENCE_CXX23_ALIGNED_UNION_DEPRECATION_WARNING
 
 #include <assert.h>
@@ -127,11 +129,9 @@ void test(const int num) {
 
         g_allocations_remaining = 1000000;
 
-#ifdef _DEBUG
         if (_CrtDumpMemoryLeaks()) {
             abort();
         }
-#endif
 
         return;
     }


### PR DESCRIPTION
I noticed the tests while changing `<meow.h>` to `<cmeow>`.
Based on the comment: https://github.com/microsoft/STL/pull/2763#discussion_r890671742
We also have another test with `_CrtDumpMemoryLeaks`: `tests\std\tests\P0718R2_atomic_smart_ptrs\test.cpp`
But it seems the test is checking more things and Release CRT tests make sense...