### PR TITLE
`<complex>`: avoid unnecessary conversion of real arguments to complex

### DIFF
--- a/stl/inc/complex
+++ b/stl/inc/complex
@@ -1402,7 +1402,7 @@ _NODISCARD _CONSTEXPR20 complex<_Ty> operator+(const complex<_Ty>& _Left, const 
 template <class _Ty>
 _NODISCARD _CONSTEXPR20 complex<_Ty> operator+(const complex<_Ty>& _Left, const _Ty& _Right) {
     complex<_Ty> _Tmp(_Left);
-    _Tmp.real(_Tmp.real() + _Right);
+    _Tmp += _Right;
     return _Tmp;
 }
 
@@ -1444,8 +1444,7 @@ _NODISCARD _CONSTEXPR20 complex<_Ty> operator*(const complex<_Ty>& _Left, const 
 template <class _Ty>
 _NODISCARD _CONSTEXPR20 complex<_Ty> operator*(const complex<_Ty>& _Left, const _Ty& _Right) {
     complex<_Ty> _Tmp(_Left);
-    _Tmp.real(_Tmp.real() * _Right);
-    _Tmp.imag(_Tmp.imag() * _Right);
+    _Tmp *= _Right;
     return _Tmp;
 }
 

--- a/stl/inc/complex
+++ b/stl/inc/complex
@@ -1408,8 +1408,8 @@ _NODISCARD _CONSTEXPR20 complex<_Ty> operator+(const complex<_Ty>& _Left, const 
 
 template <class _Ty>
 _NODISCARD _CONSTEXPR20 complex<_Ty> operator+(const _Ty& _Left, const complex<_Ty>& _Right) {
-    complex<_Ty> _Tmp(_Left);
-    _Tmp += _Right;
+    complex<_Ty> _Tmp(_Right);
+    _Tmp += _Left;
     return _Tmp;
 }
 
@@ -1451,8 +1451,8 @@ _NODISCARD _CONSTEXPR20 complex<_Ty> operator*(const complex<_Ty>& _Left, const 
 
 template <class _Ty>
 _NODISCARD _CONSTEXPR20 complex<_Ty> operator*(const _Ty& _Left, const complex<_Ty>& _Right) {
-    complex<_Ty> _Tmp(_Left);
-    _Tmp *= _Right;
+    complex<_Ty> _Tmp(_Right);
+    _Tmp *= _Left;
     return _Tmp;
 }
 

--- a/stl/inc/complex
+++ b/stl/inc/complex
@@ -1423,7 +1423,7 @@ _NODISCARD _CONSTEXPR20 complex<_Ty> operator-(const complex<_Ty>& _Left, const 
 template <class _Ty>
 _NODISCARD _CONSTEXPR20 complex<_Ty> operator-(const complex<_Ty>& _Left, const _Ty& _Right) {
     complex<_Ty> _Tmp(_Left);
-    _Tmp.real(_Tmp.real() - _Right);
+    _Tmp -= _Right;
     return _Tmp;
 }
 
@@ -1465,8 +1465,7 @@ _NODISCARD _CONSTEXPR20 complex<_Ty> operator/(const complex<_Ty>& _Left, const 
 template <class _Ty>
 _NODISCARD _CONSTEXPR20 complex<_Ty> operator/(const complex<_Ty>& _Left, const _Ty& _Right) {
     complex<_Ty> _Tmp(_Left);
-    _Tmp.real(_Tmp.real() / _Right);
-    _Tmp.imag(_Tmp.imag() / _Right);
+    _Tmp /= _Right;
     return _Tmp;
 }
 


### PR DESCRIPTION
Mixed real/complex multiplication and addition are commutative (and I don't think there are any observable side effects), so it's unnecessary to strictly follow the *Returns* clauses in [[complex.ops]/2](https://eel.is/c++draft/complex.ops#2) and [[complex.ops]/5](https://eel.is/c++draft/complex.ops#5). Converting a real parameter on the LHS to `complex` results in a full complex/complex operation that the optimizer is unable to clean up.

https://godbolt.org/z/KW3sWE6YY

<details>
<summary>Multiplication codegen</summary>

```asm
std::complex<double> Mult(double const &,std::complex<double> const &) PROC   ; Mult, COMDAT
        movups  xmm0, XMMWORD PTR [r8]
        mov     rax, rcx
        movsd   xmm1, QWORD PTR [rdx]
        unpcklpd xmm1, xmm1
        mulpd   xmm1, xmm0
        movups  XMMWORD PTR [rcx], xmm1
        ret     0
std::complex<double> Mult(double const &,std::complex<double> const &) ENDP   ; Mult

std::complex<double> std::operator*<double>(double const &,std::complex<double> const &) PROC       ; std::operator*<double>, COMDAT
        movsd   xmm5, QWORD PTR [rdx]
        xorps   xmm2, xmm2
        movsd   xmm4, QWORD PTR [r8+8]
        movaps  xmm1, xmm5
        movsd   xmm0, QWORD PTR [r8]
        mov     rax, rcx
        mulsd   xmm5, QWORD PTR [r8]
        mulsd   xmm1, xmm4
        mulsd   xmm4, xmm2
        mulsd   xmm0, xmm2
        subsd   xmm5, xmm4
        addsd   xmm1, xmm0
        movsd   QWORD PTR [rcx], xmm5
        movsd   QWORD PTR [rcx+8], xmm1
        ret     0
std::complex<double> std::operator*<double>(double const &,std::complex<double> const &) ENDP       ; std::operator*<double>
```
</details>

<details>
<summary>Addition codegen</summary>

```asm
std::complex<double> Add(double const &,std::complex<double> const &) PROC      ; Add, COMDAT
        movups  xmm0, XMMWORD PTR [r8]
        mov     rax, rcx
        movups  XMMWORD PTR [rcx], xmm0
        addsd   xmm0, QWORD PTR [rdx]
        movsd   QWORD PTR [rcx], xmm0
        ret     0
std::complex<double> Add(double const &,std::complex<double> const &) ENDP      ; Add

std::complex<double> std::operator+<double>(double const &,std::complex<double> const &) PROC       ; std::operator+<double>, COMDAT
        movsd   xmm0, QWORD PTR [rdx]
        mov     rax, rcx
        addsd   xmm0, QWORD PTR [r8]
        movsd   xmm1, QWORD PTR [r8+8]
        movsd   QWORD PTR [rcx], xmm0
        xorps   xmm0, xmm0
        addsd   xmm1, xmm0
        movsd   QWORD PTR [rcx+8], xmm1
        ret     0
std::complex<double> std::operator+<double>(double const &,std::complex<double> const &) ENDP       ; std::operator+<double>
```
</details>