### PR TITLE
Toolset update: VS 2022 17.3 Preview 3, Clang 14

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-# https://releases.llvm.org/13.0.0/tools/clang/docs/ClangFormatStyleOptions.html
+# https://releases.llvm.org/14.0.0/tools/clang/docs/ClangFormatStyleOptions.html
 
 ---
 # Language:        Cpp
@@ -25,7 +25,6 @@ AlignOperands: AlignAfterOperator
 # AlignTrailingComments: true
 AlignTrailingComments: false
 # AllowAllArgumentsOnNextLine: true
-# AllowAllConstructorInitializersOnNextLine: true
 # AllowAllParametersOfDeclarationOnNextLine: true
 # AllowShortEnumsOnASingleLine: true
 # AllowShortBlocksOnASingleLine: Never
@@ -77,8 +76,8 @@ BreakBeforeBinaryOperators: NonAssignment
 # ColumnLimit:     80
 ColumnLimit:     120
 # CommentPragmas:  '^ IWYU pragma:'
+# QualifierAlignment: Leave
 # CompactNamespaces: false
-# ConstructorInitializerAllOnOneLineOrOnePerLine: false
 # ConstructorInitializerIndentWidth: 4
 # ContinuationIndentWidth: 4
 # Cpp11BracedListStyle: true
@@ -89,6 +88,10 @@ DeriveLineEnding: false
 # EmptyLineAfterAccessModifier: Never
 # EmptyLineBeforeAccessModifier: LogicalBlock
 # ExperimentalAutoDetectBinPacking: false
+# PackConstructorInitializers: BinPack
+# BasedOnStyle:    ''
+# ConstructorInitializerAllOnOneLineOrOnePerLine: false
+# AllowAllConstructorInitializersOnNextLine: true
 # FixNamespaceComments: true
 # ForEachMacros:
 #   - foreach
@@ -162,6 +165,7 @@ NamespaceIndentation: All
 # PenaltyBreakBeforeFirstCallParameter: 19
 # PenaltyBreakComment: 300
 # PenaltyBreakFirstLessLess: 120
+# PenaltyBreakOpenParenthesis: 0
 # PenaltyBreakString: 1000
 # PenaltyBreakTemplateDeclaration: 10
 # PenaltyExcessCharacter: 1000000
@@ -172,6 +176,8 @@ PointerAlignment: Left
 # PPIndentWidth:   -1
 # ReferenceAlignment: Pointer
 # ReflowComments:  true
+# RemoveBracesLLVM: false
+# SeparateDefinitionBlocks: Leave
 # ShortNamespaceLines: 1
 # SortIncludes:    CaseSensitive
 # SortJavaStaticImport: Before
@@ -186,6 +192,14 @@ SpaceAfterCStyleCast: true
 # SpaceBeforeCtorInitializerColon: true
 # SpaceBeforeInheritanceColon: true
 # SpaceBeforeParens: ControlStatements
+# SpaceBeforeParensOptions:
+#   AfterControlStatements: true
+#   AfterForeachMacros: true
+#   AfterFunctionDefinitionName: false
+#   AfterFunctionDeclarationName: false
+#   AfterIfMacros:   true
+#   AfterOverloadedOperator: false
+#   BeforeNonEmptyParentheses: false
 # SpaceAroundPointerQualifiers: Default
 # SpaceBeforeRangeBasedForLoopColon: true
 # SpaceInEmptyBlock: false

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With The Visual Studio IDE
 
-1. Install Visual Studio 2022 17.3 Preview 2 or later.
+1. Install Visual Studio 2022 17.3 Preview 3 or later.
     * Select "Windows 11 SDK (10.0.22000.0)" in the VS Installer.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
@@ -157,7 +157,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With A Native Tools Command Prompt
 
-1. Install Visual Studio 2022 17.3 Preview 2 or later.
+1. Install Visual Studio 2022 17.3 Preview 3 or later.
     * Select "Windows 11 SDK (10.0.22000.0)" in the VS Installer.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ variables:
   tmpDir: 'D:\Temp'
   buildOutputLocation: 'D:\build'
 
-pool: 'StlBuild-2022-06-28-T1518'
+pool: 'StlBuild-2022-07-12-T1418'
 
 stages:
   - stage: Code_Format

--- a/stl/inc/__msvc_all_public_headers.hpp
+++ b/stl/inc/__msvc_all_public_headers.hpp
@@ -143,7 +143,9 @@
 #include <barrier>
 #include <latch>
 #include <semaphore>
+#ifndef __clang__ // TRANSITION, GH-2862
 #include <stdatomic.h>
+#endif // TRANSITION, GH-2862
 #include <stop_token>
 #endif // _M_CEE_PURE
 

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -155,7 +155,7 @@ struct _Optimistic_temporary_buffer { // temporary storage with _alloca-like att
         _Capacity = _Optimistic_count;
     }
 
-    _Optimistic_temporary_buffer(const _Optimistic_temporary_buffer&) = delete;
+    _Optimistic_temporary_buffer(const _Optimistic_temporary_buffer&)            = delete;
     _Optimistic_temporary_buffer& operator=(const _Optimistic_temporary_buffer&) = delete;
 
     ~_Optimistic_temporary_buffer() noexcept {

--- a/stl/inc/array
+++ b/stl/inc/array
@@ -831,7 +831,7 @@ _NODISCARD constexpr array<remove_cv_t<_Ty>, _Size> _To_array_lvalue_impl(
 
 template <class _Ty, size_t _Size, size_t... _Idx>
 _NODISCARD constexpr array<remove_cv_t<_Ty>, _Size> _To_array_rvalue_impl(
-    _Ty(&&_Array)[_Size], index_sequence<_Idx...>) {
+    _Ty (&&_Array)[_Size], index_sequence<_Idx...>) {
     return {{_STD move(_Array[_Idx])...}};
 }
 
@@ -845,7 +845,7 @@ _NODISCARD constexpr array<remove_cv_t<_Ty>, _Size> to_array(_Ty (&_Array)[_Size
 }
 
 template <class _Ty, size_t _Size>
-_NODISCARD constexpr array<remove_cv_t<_Ty>, _Size> to_array(_Ty(&&_Array)[_Size]) {
+_NODISCARD constexpr array<remove_cv_t<_Ty>, _Size> to_array(_Ty (&&_Array)[_Size]) {
     static_assert(!is_array_v<_Ty>, "N4830 [array.creation]/4: "
                                     "to_array does not accept multidimensional arrays.");
     static_assert(is_move_constructible_v<_Ty>, "N4830 [array.creation]/4: "

--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -137,8 +137,8 @@ struct _Storage_for {
     // uninitialized space to store a _Ty
     alignas(_Ty) unsigned char _Storage[sizeof(_Ty)];
 
-    _Storage_for()                    = default;
-    _Storage_for(const _Storage_for&) = delete;
+    _Storage_for()                               = default;
+    _Storage_for(const _Storage_for&)            = delete;
     _Storage_for& operator=(const _Storage_for&) = delete;
 
 #if _CMPXCHG_MASK_OUT_PADDING_BITS
@@ -445,7 +445,7 @@ public:
         _Atomic_lock_release(_Spinlock);
     }
 
-    _Atomic_lock_guard(const _Atomic_lock_guard&) = delete;
+    _Atomic_lock_guard(const _Atomic_lock_guard&)            = delete;
     _Atomic_lock_guard& operator=(const _Atomic_lock_guard&) = delete;
 
 private:
@@ -2102,7 +2102,7 @@ public:
 
     constexpr atomic() noexcept(is_nothrow_default_constructible_v<_Ty>) : _Base() {}
 
-    atomic(const atomic&) = delete;
+    atomic(const atomic&)            = delete;
     atomic& operator=(const atomic&) = delete;
 
 #if _HAS_CXX17
@@ -2910,7 +2910,7 @@ public:
     constexpr _Locked_pointer() noexcept : _Storage{} {}
     explicit _Locked_pointer(_Ty* const _Ptr) noexcept : _Storage{reinterpret_cast<uintptr_t>(_Ptr)} {}
 
-    _Locked_pointer(const _Locked_pointer&) = delete;
+    _Locked_pointer(const _Locked_pointer&)            = delete;
     _Locked_pointer& operator=(const _Locked_pointer&) = delete;
 
     _NODISCARD _Ty* _Lock_and_load() noexcept {

--- a/stl/inc/barrier
+++ b/stl/inc/barrier
@@ -85,7 +85,7 @@ public:
             "Precondition: expected >= 0 and expected <= max() (N4861 [thread.barrier.class]/9)");
     }
 
-    barrier(const barrier&) = delete;
+    barrier(const barrier&)            = delete;
     barrier& operator=(const barrier&) = delete;
 
     _NODISCARD static constexpr ptrdiff_t(max)() noexcept {

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -1675,7 +1675,7 @@ namespace chrono {
     public:
         explicit time_zone(string_view _Name_) : _Name(_Name_) {}
 
-        time_zone(time_zone&&) = default;
+        time_zone(time_zone&&)            = default;
         time_zone& operator=(time_zone&&) = default;
 
         _NODISCARD string_view name() const noexcept {
@@ -1836,7 +1836,7 @@ namespace chrono {
 
     class leap_second {
     public:
-        leap_second(const leap_second&) = default;
+        leap_second(const leap_second&)            = default;
         leap_second& operator=(const leap_second&) = default;
 
         constexpr leap_second(
@@ -1931,7 +1931,7 @@ namespace chrono {
     public:
         explicit time_zone_link(string_view _Name_, string_view _Target_) : _Name(_Name_), _Target(_Target_) {}
 
-        time_zone_link(time_zone_link&&) = default;
+        time_zone_link(time_zone_link&&)            = default;
         time_zone_link& operator=(time_zone_link&&) = default;
 
         _NODISCARD string_view name() const noexcept {
@@ -2119,7 +2119,7 @@ namespace chrono {
     public:
         using const_iterator = _ListType::const_iterator;
 
-        tzdb_list(const tzdb_list&) = delete;
+        tzdb_list(const tzdb_list&)            = delete;
         tzdb_list& operator=(const tzdb_list&) = delete;
 
         tzdb_list() {
@@ -2193,7 +2193,7 @@ namespace chrono {
                 _Smtx_lock_shared(_Mtx);
             }
 
-            _Shared_lock(const _Shared_lock&) = delete;
+            _Shared_lock(const _Shared_lock&)            = delete;
             _Shared_lock& operator=(const _Shared_lock&) = delete;
 
             ~_Shared_lock() {
@@ -2208,7 +2208,7 @@ namespace chrono {
                 _Smtx_lock_exclusive(_Mtx);
             }
 
-            _Unique_lock(const _Unique_lock&) = delete;
+            _Unique_lock(const _Unique_lock&)            = delete;
             _Unique_lock& operator=(const _Unique_lock&) = delete;
 
             ~_Unique_lock() {
@@ -2316,7 +2316,7 @@ namespace chrono {
 
         template <class _Traits2 = _Traits, class = void_t<decltype(_Traits2::default_zone())>>
         zoned_time() : _Zone{_Traits::default_zone()} {}
-        zoned_time(const zoned_time&) = default;
+        zoned_time(const zoned_time&)            = default;
         zoned_time& operator=(const zoned_time&) = default;
 
         template <class _Traits2 = _Traits, class = void_t<decltype(_Traits2::default_zone())>>

--- a/stl/inc/compare
+++ b/stl/inc/compare
@@ -774,7 +774,7 @@ concept _Can_partial_order = requires(_Ty1& _Left, _Ty2& _Right) {
 
 namespace _Compare_partial_order_fallback {
     template <class _Ty1, class _Ty2>
-    concept _Can_fallback_eq_lt_twice = requires(_Ty1 & _Left, _Ty2 & _Right) {
+    concept _Can_fallback_eq_lt_twice = requires(_Ty1& _Left, _Ty2& _Right) {
         { _Left == _Right } -> _Implicitly_convertible_to<bool>;
         { _Left < _Right } -> _Implicitly_convertible_to<bool>;
         { _Right < _Left } -> _Implicitly_convertible_to<bool>;

--- a/stl/inc/condition_variable
+++ b/stl/inc/condition_variable
@@ -42,7 +42,7 @@ struct _NODISCARD _Unlock_guard {
         _Mtx.lock();
     }
 
-    _Unlock_guard(const _Unlock_guard&) = delete;
+    _Unlock_guard(const _Unlock_guard&)            = delete;
     _Unlock_guard& operator=(const _Unlock_guard&) = delete;
 
 private:
@@ -59,7 +59,7 @@ public:
         _Cnd_destroy_in_situ(_Mycnd());
     }
 
-    condition_variable_any(const condition_variable_any&) = delete;
+    condition_variable_any(const condition_variable_any&)            = delete;
     condition_variable_any& operator=(const condition_variable_any&) = delete;
 
     void notify_one() noexcept { // wake up one waiter
@@ -162,7 +162,7 @@ private:
 
         explicit _Cv_any_notify_all(condition_variable_any* _This_) : _This{_This_} {}
 
-        _Cv_any_notify_all(const _Cv_any_notify_all&) = delete;
+        _Cv_any_notify_all(const _Cv_any_notify_all&)            = delete;
         _Cv_any_notify_all& operator=(const _Cv_any_notify_all&) = delete;
 
         void operator()() const noexcept {

--- a/stl/inc/cvt/wbuffer
+++ b/stl/inc/cvt/wbuffer
@@ -124,7 +124,7 @@ namespace stdext {
                 return _State;
             }
 
-            wbuffer_convert(const wbuffer_convert&) = delete;
+            wbuffer_convert(const wbuffer_convert&)            = delete;
             wbuffer_convert& operator=(const wbuffer_convert&) = delete;
 
         protected:

--- a/stl/inc/cvt/wstring
+++ b/stl/inc/cvt/wstring
@@ -65,7 +65,7 @@ namespace stdext {
 
             virtual ~wstring_convert() noexcept {}
 
-            wstring_convert(const wstring_convert&) = delete;
+            wstring_convert(const wstring_convert&)            = delete;
             wstring_convert& operator=(const wstring_convert&) = delete;
 
             _NODISCARD size_t converted() const noexcept { // get conversion count

--- a/stl/inc/exception
+++ b/stl/inc/exception
@@ -328,7 +328,7 @@ class nested_exception { // wrap an exception_ptr
 public:
     nested_exception() noexcept : _Exc(_STD current_exception()) {}
 
-    nested_exception(const nested_exception&) noexcept = default;
+    nested_exception(const nested_exception&) noexcept            = default;
     nested_exception& operator=(const nested_exception&) noexcept = default;
     virtual ~nested_exception() noexcept {}
 

--- a/stl/inc/execution
+++ b/stl/inc/execution
@@ -193,7 +193,7 @@ public:
         }
     }
 
-    _Work_ptr(const _Work_ptr&) = delete;
+    _Work_ptr(const _Work_ptr&)            = delete;
     _Work_ptr& operator=(const _Work_ptr&) = delete;
 
     ~_Work_ptr() noexcept {
@@ -548,8 +548,8 @@ class alignas(hardware_destructive_interference_size) _Work_stealing_deque {
     // of the queue, and any thread access to the "top" of the queue. Originally described in the paper
     // "Dynamic Circular Work-Stealing Deque" by David Chase and Yossi Lev
 public:
-    _Work_stealing_deque()                            = default;
-    _Work_stealing_deque(const _Work_stealing_deque&) = delete;
+    _Work_stealing_deque()                                       = default;
+    _Work_stealing_deque(const _Work_stealing_deque&)            = delete;
     _Work_stealing_deque& operator=(const _Work_stealing_deque&) = delete;
 
     ~_Work_stealing_deque() noexcept {

--- a/stl/inc/expected
+++ b/stl/inc/expected
@@ -121,11 +121,11 @@ public:
     }
 
 protected:
-    bad_expected_access()                           = default;
-    bad_expected_access(const bad_expected_access&) = default;
-    bad_expected_access(bad_expected_access&&)      = default;
+    bad_expected_access()                                      = default;
+    bad_expected_access(const bad_expected_access&)            = default;
+    bad_expected_access(bad_expected_access&&)                 = default;
     bad_expected_access& operator=(const bad_expected_access&) = default;
-    bad_expected_access& operator=(bad_expected_access&&) = default;
+    bad_expected_access& operator=(bad_expected_access&&)      = default;
 
 #if !_HAS_EXCEPTIONS
     void _Doraise() const override { // perform class-specific exception handling

--- a/stl/inc/experimental/filesystem
+++ b/stl/inc/experimental/filesystem
@@ -128,10 +128,10 @@ public:
     explicit file_status(file_type _Ftype = file_type::none, perms _Prms = perms::unknown) noexcept
         : _Myftype(_Ftype), _Myperms(_Prms) {}
 
-    file_status(const file_status&) noexcept = default;
+    file_status(const file_status&) noexcept            = default;
     file_status& operator=(const file_status&) noexcept = default;
 
-    file_status(file_status&&) = default;
+    file_status(file_status&&)            = default;
     file_status& operator=(file_status&&) = default;
 
     _NODISCARD file_type type() const noexcept {
@@ -1317,7 +1317,7 @@ public:
         return _Mypval2;
     }
 
-    filesystem_error(const filesystem_error&) = default;
+    filesystem_error(const filesystem_error&)            = default;
     filesystem_error& operator=(const filesystem_error&) = default;
 
 private:
@@ -1342,10 +1342,10 @@ public:
 
     directory_entry() : _Mystat(), _Mysymstat() {}
 
-    directory_entry(const directory_entry&) = default;
+    directory_entry(const directory_entry&)            = default;
     directory_entry& operator=(const directory_entry&) = default;
 
-    directory_entry(directory_entry&&) = default;
+    directory_entry(directory_entry&&)            = default;
     directory_entry& operator=(directory_entry&&) = default;
 
     explicit directory_entry(
@@ -1473,10 +1473,10 @@ public:
         _Code = error_code(_Errno, _STD system_category());
     }
 
-    _Directory_iterator(const _Directory_iterator&) = default;
+    _Directory_iterator(const _Directory_iterator&)            = default;
     _Directory_iterator& operator=(const _Directory_iterator&) = default;
 
-    _Directory_iterator(_Directory_iterator&&) = default;
+    _Directory_iterator(_Directory_iterator&&)            = default;
     _Directory_iterator& operator=(_Directory_iterator&&) = default;
 
     _NODISCARD const value_type& operator*() const {
@@ -1617,10 +1617,10 @@ public:
         _Get();
     }
 
-    recursive_directory_iterator(const recursive_directory_iterator&) = default;
+    recursive_directory_iterator(const recursive_directory_iterator&)            = default;
     recursive_directory_iterator& operator=(const recursive_directory_iterator&) = default;
 
-    recursive_directory_iterator(recursive_directory_iterator&&) = default;
+    recursive_directory_iterator(recursive_directory_iterator&&)            = default;
     recursive_directory_iterator& operator=(recursive_directory_iterator&&) = default;
 
     _NODISCARD directory_options options() const {

--- a/stl/inc/experimental/generator
+++ b/stl/inc/experimental/generator
@@ -37,9 +37,9 @@ namespace experimental {
     struct generator {
         struct promise_type {
             const _Ty* _Value;
-#ifdef _CPPUNWIND // TRANSITION, VSO-1172852
+#ifdef _CPPUNWIND
             exception_ptr _Exception;
-#endif // TRANSITION, VSO-1172852
+#endif // _CPPUNWIND
 
             generator get_return_object() noexcept {
                 return generator{*this};
@@ -55,27 +55,21 @@ namespace experimental {
 
 #ifndef _KERNEL_MODE
 #ifdef _CPPUNWIND
-#if 1 // TRANSITION, VSO-1172852
             void unhandled_exception() noexcept {
                 _Exception = _STD current_exception();
             }
-#else // ^^^ workaround / no workaround vvv
-            void unhandled_exception() {
-                throw;
-            }
-#endif // TRANSITION, VSO-1172852
 #else // ^^^ defined(_CPPUNWIND) / !defined(_CPPUNWIND) vvv
             void unhandled_exception() noexcept {}
 #endif // _CPPUNWIND
 #endif // _KERNEL_MODE
 
-#ifdef _CPPUNWIND // TRANSITION, VSO-1172852
+#ifdef _CPPUNWIND
             void _Rethrow_if_exception() {
                 if (_Exception) {
                     _STD rethrow_exception(_Exception);
                 }
             }
-#endif // TRANSITION, VSO-1172852
+#endif // _CPPUNWIND
 
             suspend_always yield_value(const _Ty& _Val) noexcept {
                 _Value = _STD addressof(_Val);
@@ -124,11 +118,11 @@ namespace experimental {
             iterator& operator++() {
                 _Coro.resume();
                 if (_Coro.done()) {
-#ifdef _CPPUNWIND // TRANSITION, VSO-1172852
+#ifdef _CPPUNWIND
                     _STD exchange(_Coro, nullptr).promise()._Rethrow_if_exception();
-#else // ^^^ workaround / no workaround vvv
+#else // ^^^ defined(_CPPUNWIND) / !defined(_CPPUNWIND) vvv
                     _Coro = nullptr;
-#endif // TRANSITION, VSO-1172852
+#endif // _CPPUNWIND
                 }
 
                 return *this;
@@ -161,9 +155,9 @@ namespace experimental {
             if (_Coro) {
                 _Coro.resume();
                 if (_Coro.done()) {
-#ifdef _CPPUNWIND // TRANSITION, VSO-1172852
+#ifdef _CPPUNWIND
                     _Coro.promise()._Rethrow_if_exception();
-#endif // TRANSITION, VSO-1172852
+#endif // _CPPUNWIND
                     return {};
                 }
             }

--- a/stl/inc/filesystem
+++ b/stl/inc/filesystem
@@ -680,11 +680,11 @@ namespace filesystem {
 
         enum format { auto_format, native_format, generic_format };
 
-        path()            = default;
-        path(const path&) = default;
-        path(path&&)      = default;
-        ~path()           = default;
-        path& operator=(const path&) = default;
+        path()                           = default;
+        path(const path&)                = default;
+        path(path&&)                     = default;
+        ~path()                          = default;
+        path& operator=(const path&)     = default;
         path& operator=(path&&) noexcept = default;
 
         path(string_type&& _Source) : _Text(_STD move(_Source)) {}
@@ -1458,10 +1458,10 @@ namespace filesystem {
         _Path_iterator(const _Base_iter& _Position_, wstring_view _Element_text, const path* _Mypath_)
             : _Position(_Position_), _Element(_Element_text), _Mypath(_Mypath_) {}
 
-        _Path_iterator(const _Path_iterator&) = default;
-        _Path_iterator(_Path_iterator&&)      = default;
+        _Path_iterator(const _Path_iterator&)            = default;
+        _Path_iterator(_Path_iterator&&)                 = default;
         _Path_iterator& operator=(const _Path_iterator&) = default;
-        _Path_iterator& operator=(_Path_iterator&&) = default;
+        _Path_iterator& operator=(_Path_iterator&&)      = default;
 
         _NODISCARD reference operator*() const noexcept {
             return _Element;
@@ -1946,7 +1946,7 @@ namespace filesystem {
 
         // assignments
         file_status& operator=(const file_status&) noexcept = default;
-        file_status& operator=(file_status&&) noexcept = default;
+        file_status& operator=(file_status&&) noexcept      = default;
 
         // [fs.file_status.mods], modifiers
         void type(file_type _Ft) noexcept {
@@ -2134,7 +2134,7 @@ namespace filesystem {
         ~directory_entry() = default;
 
         // assignments
-        directory_entry& operator=(const directory_entry&) = default;
+        directory_entry& operator=(const directory_entry&)     = default;
         directory_entry& operator=(directory_entry&&) noexcept = default;
 
         // [fs.dir.entry.mods], modifiers
@@ -2679,7 +2679,7 @@ namespace filesystem {
         ~directory_iterator() noexcept                         = default;
 
         directory_iterator& operator=(const directory_iterator&) noexcept = default; // strengthened
-        directory_iterator& operator=(directory_iterator&&) noexcept = default;
+        directory_iterator& operator=(directory_iterator&&) noexcept      = default;
 
         _NODISCARD const directory_entry& operator*() const noexcept /* strengthened */ {
             return _Impl->_Entry;
@@ -2922,7 +2922,7 @@ namespace filesystem {
         }
 
         // [fs.rec.dir.itr.members], modifiers
-        recursive_directory_iterator& operator=(recursive_directory_iterator&&) noexcept = default;
+        recursive_directory_iterator& operator=(recursive_directory_iterator&&) noexcept      = default;
         recursive_directory_iterator& operator=(const recursive_directory_iterator&) noexcept = default; // strengthened
 
         recursive_directory_iterator& operator++() {

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -850,9 +850,7 @@ _NODISCARD constexpr bool _Is_execution_charset_self_synchronizing() {
     default:
         return false;
     }
-#elif defined(__clang__) // ^^^ no workaround / Clang workaround vvv
-    return string_view{__clang_literal_encoding__} == "UTF-8"; // TRANSITION, Clang 14
-#else // ^^^ Clang workaround / EDG workaround vvv
+#else // ^^^ no workaround / EDG workaround vvv
     return false; // TRANSITION, VSO-1468747 (EDG) - safe fallback response
 #endif // ^^^ EDG workaround ^^^
 }
@@ -907,7 +905,6 @@ protected:
 #ifdef _MSVC_EXECUTION_CHARACTER_SET
         constexpr __std_code_page _Format_codepage{_MSVC_EXECUTION_CHARACTER_SET};
 #else // ^^^ no workaround / workaround vvv
-      // TRANSITION, Clang 14 - only utf-8 is supported
       // TRANSITION, VSO-1468747 (EDG) - constructor isn't constexpr, so value is unimportant
         constexpr __std_code_page _Format_codepage{65001};
 #endif // ^^^ workaround ^^^

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -560,7 +560,7 @@ public:
         const basic_string_view<_CharT> _Fmt, const size_t _Num_args_ = 0) noexcept
         : _Format_string(_Fmt), _Num_args(_Num_args_) {}
 
-    basic_format_parse_context(const basic_format_parse_context&) = delete;
+    basic_format_parse_context(const basic_format_parse_context&)            = delete;
     basic_format_parse_context& operator=(const basic_format_parse_context&) = delete;
 
     _NODISCARD constexpr const_iterator begin() const noexcept {
@@ -2078,7 +2078,7 @@ protected:
 public:
     using value_type = _Ty;
 
-    _Fmt_buffer(const _Fmt_buffer&) = delete;
+    _Fmt_buffer(const _Fmt_buffer&)    = delete;
     void operator=(const _Fmt_buffer&) = delete;
 
     _NODISCARD _Ty* begin() noexcept {
@@ -3257,8 +3257,8 @@ struct _Format_handler {
 // makes it "disabled" as per N4885 [format.formatter.spec]/5
 template <class _Ty, class _CharT>
 struct formatter {
-    formatter()                 = delete;
-    formatter(const formatter&) = delete;
+    formatter()                           = delete;
+    formatter(const formatter&)           = delete;
     formatter operator=(const formatter&) = delete;
 };
 

--- a/stl/inc/forward_list
+++ b/stl/inc/forward_list
@@ -244,8 +244,8 @@ struct _Flist_node { // forward_list node
     _Nodeptr _Next;
     _Value_type _Myval = _Returns_exactly<_Value_type>(); // fake a viable constructor to workaround GH-2749
 
-    _Flist_node()                   = default;
-    _Flist_node(const _Flist_node&) = delete;
+    _Flist_node()                              = default;
+    _Flist_node(const _Flist_node&)            = delete;
     _Flist_node& operator=(const _Flist_node&) = delete;
 
     template <class _Alnode>
@@ -418,7 +418,7 @@ struct _Flist_insert_after_op2 {
 
     explicit _Flist_insert_after_op2(_Alnode& _Al_) : _Al(_Al_), _Tail() {}
 
-    _Flist_insert_after_op2(const _Flist_insert_after_op2&) = delete;
+    _Flist_insert_after_op2(const _Flist_insert_after_op2&)            = delete;
     _Flist_insert_after_op2& operator=(const _Flist_insert_after_op2&) = delete;
 
     template <class... _CArgT>
@@ -1117,7 +1117,7 @@ public:
         explicit _Flist_node_remove_op(forward_list& _List_) noexcept
             : _List(_List_), _Head(), _Tail(_STD addressof(_Head)) {}
 
-        _Flist_node_remove_op(const _Flist_node_remove_op&) = delete;
+        _Flist_node_remove_op(const _Flist_node_remove_op&)            = delete;
         _Flist_node_remove_op& operator=(const _Flist_node_remove_op&) = delete;
 
         _Nodeptr _Transfer_back(const _Nodeptr _Predecessor) noexcept {

--- a/stl/inc/fstream
+++ b/stl/inc/fstream
@@ -267,7 +267,7 @@ public:
         }
     }
 
-    basic_filebuf(const basic_filebuf&) = delete;
+    basic_filebuf(const basic_filebuf&)            = delete;
     basic_filebuf& operator=(const basic_filebuf&) = delete;
 
     enum _Initfl { // reasons for a call to _Init
@@ -878,7 +878,7 @@ public:
         }
     }
 
-    basic_ifstream(const basic_ifstream&) = delete;
+    basic_ifstream(const basic_ifstream&)            = delete;
     basic_ifstream& operator=(const basic_ifstream&) = delete;
 
     void open(
@@ -1061,7 +1061,7 @@ public:
         }
     }
 
-    basic_ofstream(const basic_ofstream&) = delete;
+    basic_ofstream(const basic_ofstream&)            = delete;
     basic_ofstream& operator=(const basic_ofstream&) = delete;
 
     void open(
@@ -1249,7 +1249,7 @@ public:
         }
     }
 
-    basic_fstream(const basic_fstream&) = delete;
+    basic_fstream(const basic_fstream&)            = delete;
     basic_fstream& operator=(const basic_fstream&) = delete;
 
     void open(const wchar_t* _Filename, ios_base::openmode _Mode = ios_base::in | ios_base::out,

--- a/stl/inc/functional
+++ b/stl/inc/functional
@@ -713,8 +713,8 @@ public:
     }
 #endif // _HAS_STATIC_RTTI
 
-    _Func_base()                  = default;
-    _Func_base(const _Func_base&) = delete;
+    _Func_base()                             = default;
+    _Func_base(const _Func_base&)            = delete;
     _Func_base& operator=(const _Func_base&) = delete;
     // dtor non-virtual due to _Delete_this()
 

--- a/stl/inc/future
+++ b/stl/inc/future
@@ -178,7 +178,7 @@ template <class _Ty, class _Derived, class _Alloc>
 struct _State_deleter : _Deleter_base<_Ty> { // manage allocator and deletion state objects
     _State_deleter(const _Alloc& _Al) : _My_alloc(_Al) {}
 
-    _State_deleter(const _State_deleter&) = delete;
+    _State_deleter(const _State_deleter&)            = delete;
     _State_deleter& operator=(const _State_deleter&) = delete;
 
     void _Delete(_Associated_state<_Ty>* _State) override;
@@ -449,7 +449,7 @@ private:
     _Mydel* _Deleter;
 
 public:
-    _Associated_state(const _Associated_state&) = delete;
+    _Associated_state(const _Associated_state&)            = delete;
     _Associated_state& operator=(const _Associated_state&) = delete;
 };
 
@@ -916,7 +916,7 @@ public:
         return shared_future<_Ty>(_STD move(*this));
     }
 
-    future(const future&) = delete;
+    future(const future&)            = delete;
     future& operator=(const future&) = delete;
 };
 
@@ -950,7 +950,7 @@ public:
         return shared_future<_Ty&>(_STD move(*this));
     }
 
-    future(const future&) = delete;
+    future(const future&)            = delete;
     future& operator=(const future&) = delete;
 };
 
@@ -982,7 +982,7 @@ public:
 
     _NODISCARD shared_future<void> share() noexcept;
 
-    future(const future&) = delete;
+    future(const future&)            = delete;
     future& operator=(const future&) = delete;
 };
 
@@ -1151,7 +1151,7 @@ public:
         return _State._Is_ready_at_thread_exit();
     }
 
-    _Promise(const _Promise&) = delete;
+    _Promise(const _Promise&)            = delete;
     _Promise& operator=(const _Promise&) = delete;
 
 private:
@@ -1217,7 +1217,7 @@ public:
         _MyPromise._Get_state_for_set()._Set_exception(_Exc, true);
     }
 
-    promise(const promise&) = delete;
+    promise(const promise&)            = delete;
     promise& operator=(const promise&) = delete;
 
 private:
@@ -1271,7 +1271,7 @@ public:
         _MyPromise._Get_state_for_set()._Set_exception(_Exc, true);
     }
 
-    promise(const promise&) = delete;
+    promise(const promise&)            = delete;
     promise& operator=(const promise&) = delete;
 
 private:
@@ -1325,7 +1325,7 @@ public:
         _MyPromise._Get_state_for_set()._Set_exception(_Exc, true);
     }
 
-    promise(const promise&) = delete;
+    promise(const promise&)            = delete;
     promise& operator=(const promise&) = delete;
 
 private:
@@ -1434,7 +1434,7 @@ public:
         _MyPromise._Swap(_New_promise);
     }
 
-    packaged_task(const packaged_task&) = delete;
+    packaged_task(const packaged_task&)            = delete;
     packaged_task& operator=(const packaged_task&) = delete;
 
 private:
@@ -1494,9 +1494,9 @@ public:
         _STD terminate(); // Very Bad Things
     }
 
-    _Fake_no_copy_callable_adapter(_Fake_no_copy_callable_adapter&& _Other) = default;
+    _Fake_no_copy_callable_adapter(_Fake_no_copy_callable_adapter&& _Other)          = default;
     _Fake_no_copy_callable_adapter& operator=(const _Fake_no_copy_callable_adapter&) = delete;
-    _Fake_no_copy_callable_adapter& operator=(_Fake_no_copy_callable_adapter&&) = delete;
+    _Fake_no_copy_callable_adapter& operator=(_Fake_no_copy_callable_adapter&&)      = delete;
 
     auto operator()() -> decltype(_Invoke_stored(_STD move(_STD declval<_Storaget&>()))) {
         return _Invoke_stored(_STD move(_Storage));

--- a/stl/inc/ios
+++ b/stl/inc/ios
@@ -165,7 +165,7 @@ private:
     _Elem _Fillch; // the fill character
 
 public:
-    __CLR_OR_THIS_CALL basic_ios(const basic_ios&) = delete;
+    __CLR_OR_THIS_CALL basic_ios(const basic_ios&)            = delete;
     basic_ios& __CLR_OR_THIS_CALL operator=(const basic_ios&) = delete;
 };
 

--- a/stl/inc/istream
+++ b/stl/inc/istream
@@ -65,7 +65,7 @@ protected:
     }
 
 public:
-    __CLR_OR_THIS_CALL basic_istream(const basic_istream&) = delete;
+    __CLR_OR_THIS_CALL basic_istream(const basic_istream&)            = delete;
     basic_istream& __CLR_OR_THIS_CALL operator=(const basic_istream&) = delete;
 
     __CLR_OR_THIS_CALL ~basic_istream() noexcept override {}
@@ -104,7 +104,7 @@ public:
             return _Ok;
         }
 
-        __CLR_OR_THIS_CALL sentry(const sentry&) = delete;
+        __CLR_OR_THIS_CALL sentry(const sentry&)            = delete;
         sentry& __CLR_OR_THIS_CALL operator=(const sentry&) = delete;
 
     private:
@@ -755,7 +755,7 @@ protected:
     }
 
 public:
-    __CLR_OR_THIS_CALL basic_iostream(const basic_iostream&) = delete;
+    __CLR_OR_THIS_CALL basic_iostream(const basic_iostream&)            = delete;
     basic_iostream& __CLR_OR_THIS_CALL operator=(const basic_iostream&) = delete;
 
     __CLR_OR_THIS_CALL ~basic_iostream() noexcept override {}

--- a/stl/inc/latch
+++ b/stl/inc/latch
@@ -39,7 +39,7 @@ public:
         _STL_VERIFY(_Expected >= 0, "Precondition: expected >= 0 (N4861 [thread.latch.class]/4)");
     }
 
-    latch(const latch&) = delete;
+    latch(const latch&)            = delete;
     latch& operator=(const latch&) = delete;
 
     void count_down(const ptrdiff_t _Update = 1) noexcept /* strengthened */ {

--- a/stl/inc/list
+++ b/stl/inc/list
@@ -292,8 +292,8 @@ struct _List_node { // list node
     _Value_type _Myval = // the stored value, unused if head
         _Returns_exactly<_Value_type>(); // fake a viable constructor to workaround GH-2749
 
-    _List_node()                  = default;
-    _List_node(const _List_node&) = delete;
+    _List_node()                             = default;
+    _List_node(const _List_node&)            = delete;
     _List_node& operator=(const _List_node&) = delete;
 
     template <class _Alnode>
@@ -592,7 +592,7 @@ struct _List_node_emplace_op2 : _Alloc_construct_ptr<_Alnode> {
         }
     }
 
-    _List_node_emplace_op2(const _List_node_emplace_op2&) = delete;
+    _List_node_emplace_op2(const _List_node_emplace_op2&)            = delete;
     _List_node_emplace_op2& operator=(const _List_node_emplace_op2&) = delete;
 
     pointer _Transfer_before(const pointer _Insert_before) noexcept {
@@ -617,7 +617,7 @@ struct _List_node_insert_op2 {
 
     explicit _List_node_insert_op2(_Alnode& _Al_) : _Al(_Al_), _Added(0) {}
 
-    _List_node_insert_op2(const _List_node_insert_op2&) = delete;
+    _List_node_insert_op2(const _List_node_insert_op2&)            = delete;
     _List_node_insert_op2& operator=(const _List_node_insert_op2&) = delete;
 
     template <class... _CArgT>
@@ -1520,7 +1520,7 @@ public:
 
         explicit _List_node_remove_op(list& _List_) noexcept : _List(_List_), _Head(), _Tail(_STD addressof(_Head)) {}
 
-        _List_node_remove_op(const _List_node_remove_op&) = delete;
+        _List_node_remove_op(const _List_node_remove_op&)            = delete;
         _List_node_remove_op& operator=(const _List_node_remove_op&) = delete;
 
         _Nodeptr _Transfer_back(const _Nodeptr _Removed) noexcept {

--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -1072,7 +1072,7 @@ protected:
     constexpr _Ref_count_base() noexcept = default; // non-atomic initializations
 
 public:
-    _Ref_count_base(const _Ref_count_base&) = delete;
+    _Ref_count_base(const _Ref_count_base&)            = delete;
     _Ref_count_base& operator=(const _Ref_count_base&) = delete;
 
     virtual ~_Ref_count_base() noexcept {} // TRANSITION, should be non-virtual
@@ -1258,7 +1258,7 @@ public:
         return _Rep < _Right._Rep;
     }
 
-    _Ptr_base(const _Ptr_base&) = delete;
+    _Ptr_base(const _Ptr_base&)            = delete;
     _Ptr_base& operator=(const _Ptr_base&) = delete;
 
 protected:
@@ -1466,7 +1466,7 @@ struct _Temporary_owner {
     _Ux* _Ptr;
 
     explicit _Temporary_owner(_Ux* const _Ptr_) noexcept : _Ptr(_Ptr_) {}
-    _Temporary_owner(const _Temporary_owner&) = delete;
+    _Temporary_owner(const _Temporary_owner&)            = delete;
     _Temporary_owner& operator=(const _Temporary_owner&) = delete;
     ~_Temporary_owner() {
         delete _Ptr;
@@ -1480,7 +1480,7 @@ struct _Temporary_owner_del {
     bool _Call_deleter = true;
 
     explicit _Temporary_owner_del(const _UxptrOrNullptr _Ptr_, _Dx& _Dt_) noexcept : _Ptr(_Ptr_), _Dt(_Dt_) {}
-    _Temporary_owner_del(const _Temporary_owner_del&) = delete;
+    _Temporary_owner_del(const _Temporary_owner_del&)            = delete;
     _Temporary_owner_del& operator=(const _Temporary_owner_del&) = delete;
     ~_Temporary_owner_del() {
         if (_Call_deleter) {
@@ -2130,7 +2130,7 @@ struct _NODISCARD _Uninitialized_rev_destroying_backout {
 
     explicit _Uninitialized_rev_destroying_backout(_NoThrowIt _Dest) noexcept : _First(_Dest), _Last(_Dest) {}
 
-    _Uninitialized_rev_destroying_backout(const _Uninitialized_rev_destroying_backout&) = delete;
+    _Uninitialized_rev_destroying_backout(const _Uninitialized_rev_destroying_backout&)            = delete;
     _Uninitialized_rev_destroying_backout& operator=(const _Uninitialized_rev_destroying_backout&) = delete;
 
     ~_Uninitialized_rev_destroying_backout() {
@@ -2493,7 +2493,7 @@ public:
     _Uninitialized_rev_destroying_backout_al(pointer _Dest, _Alloc& _Al_) noexcept
         : _First(_Dest), _Last(_Dest), _Al(_Al_) {}
 
-    _Uninitialized_rev_destroying_backout_al(const _Uninitialized_rev_destroying_backout_al&) = delete;
+    _Uninitialized_rev_destroying_backout_al(const _Uninitialized_rev_destroying_backout_al&)            = delete;
     _Uninitialized_rev_destroying_backout_al& operator=(const _Uninitialized_rev_destroying_backout_al&) = delete;
 
     ~_Uninitialized_rev_destroying_backout_al() {
@@ -2861,7 +2861,7 @@ struct _Allocate_n_ptr {
         }
     }
 
-    _Allocate_n_ptr(const _Allocate_n_ptr&) = delete;
+    _Allocate_n_ptr(const _Allocate_n_ptr&)            = delete;
     _Allocate_n_ptr& operator=(const _Allocate_n_ptr&) = delete;
 };
 
@@ -3288,7 +3288,7 @@ public:
         }
     }
 
-    unique_ptr(const unique_ptr&) = delete;
+    unique_ptr(const unique_ptr&)            = delete;
     unique_ptr& operator=(const unique_ptr&) = delete;
 
 private:
@@ -3421,7 +3421,7 @@ public:
         }
     }
 
-    unique_ptr(const unique_ptr&) = delete;
+    unique_ptr(const unique_ptr&)            = delete;
     unique_ptr& operator=(const unique_ptr&) = delete;
 
 private:
@@ -3981,7 +3981,7 @@ public:
         _Value._Incref();
     }
 
-    atomic(const atomic&) = delete;
+    atomic(const atomic&)         = delete;
     void operator=(const atomic&) = delete;
 
     void operator=(shared_ptr<_Ty> _Value) noexcept {
@@ -4098,7 +4098,7 @@ public:
         _Value._Incwref();
     }
 
-    atomic(const atomic&) = delete;
+    atomic(const atomic&)         = delete;
     void operator=(const atomic&) = delete;
 
     void operator=(weak_ptr<_Ty> _Value) noexcept {

--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -1425,7 +1425,7 @@ struct _Can_scalar_delete<_Yty, void_t<decltype(delete _STD declval<_Yty*>())>> 
 template <class _Yty, class = void>
 struct _Can_array_delete : false_type {};
 template <class _Yty>
-struct _Can_array_delete<_Yty, void_t<decltype(delete[] _STD declval<_Yty*>())>> : true_type {};
+struct _Can_array_delete<_Yty, void_t<decltype(delete[] _STD declval<_Yty*>())>> : true_type{};
 
 template <class _Fx, class _Arg, class = void>
 struct _Can_call_function_object : false_type {};

--- a/stl/inc/memory_resource
+++ b/stl/inc/memory_resource
@@ -119,7 +119,7 @@ namespace pmr {
             // initialize this list to the empty state
         }
 
-        _Intrusive_list(const _Intrusive_list&) = delete;
+        _Intrusive_list(const _Intrusive_list&)            = delete;
         _Intrusive_list& operator=(const _Intrusive_list&) = delete;
 
         static constexpr _Link_type* _As_link(_Ty* const _Ptr) noexcept {
@@ -249,7 +249,7 @@ namespace pmr {
             _Setup_options();
         }
 
-        unsynchronized_pool_resource(const unsynchronized_pool_resource&) = delete;
+        unsynchronized_pool_resource(const unsynchronized_pool_resource&)            = delete;
         unsynchronized_pool_resource& operator=(const unsynchronized_pool_resource&) = delete;
 
         ~unsynchronized_pool_resource() noexcept override {
@@ -396,7 +396,7 @@ namespace pmr {
                     // initialize a chunk of _Capacity blocks, all initially free
                 }
 
-                _Chunk(const _Chunk&) = delete;
+                _Chunk(const _Chunk&)            = delete;
                 _Chunk& operator=(const _Chunk&) = delete;
             };
 
@@ -623,7 +623,7 @@ namespace pmr {
             release();
         }
 
-        monotonic_buffer_resource(const monotonic_buffer_resource&) = delete;
+        monotonic_buffer_resource(const monotonic_buffer_resource&)            = delete;
         monotonic_buffer_resource& operator=(const monotonic_buffer_resource&) = delete;
 
         void release() noexcept /* strengthened */ {

--- a/stl/inc/mutex
+++ b/stl/inc/mutex
@@ -43,7 +43,7 @@ public:
         _Mtx_destroy_in_situ(_Mymtx());
     }
 
-    _Mutex_base(const _Mutex_base&) = delete;
+    _Mutex_base(const _Mutex_base&)            = delete;
     _Mutex_base& operator=(const _Mutex_base&) = delete;
 
     void lock() {
@@ -88,7 +88,7 @@ public:
     /* constexpr */ mutex() noexcept // TRANSITION, ABI
         : _Mutex_base() {}
 
-    mutex(const mutex&) = delete;
+    mutex(const mutex&)            = delete;
     mutex& operator=(const mutex&) = delete;
 };
 
@@ -100,7 +100,7 @@ public:
         return _Mutex_base::try_lock();
     }
 
-    recursive_mutex(const recursive_mutex&) = delete;
+    recursive_mutex(const recursive_mutex&)            = delete;
     recursive_mutex& operator=(const recursive_mutex&) = delete;
 };
 #endif // _M_CEE
@@ -186,7 +186,7 @@ public:
         }
     }
 
-    unique_lock(const unique_lock&) = delete;
+    unique_lock(const unique_lock&)            = delete;
     unique_lock& operator=(const unique_lock&) = delete;
 
     void lock() { // lock the mutex
@@ -433,7 +433,7 @@ public:
         _MyMutex.unlock();
     }
 
-    lock_guard(const lock_guard&) = delete;
+    lock_guard(const lock_guard&)            = delete;
     lock_guard& operator=(const lock_guard&) = delete;
 
 private:
@@ -454,7 +454,7 @@ public:
         _STD apply([](_Mutexes&... _Mtxes) { (..., (void) _Mtxes.unlock()); }, _MyMutexes);
     }
 
-    scoped_lock(const scoped_lock&) = delete;
+    scoped_lock(const scoped_lock&)            = delete;
     scoped_lock& operator=(const scoped_lock&) = delete;
 
 private:
@@ -476,7 +476,7 @@ public:
         _MyMutex.unlock();
     }
 
-    scoped_lock(const scoped_lock&) = delete;
+    scoped_lock(const scoped_lock&)            = delete;
     scoped_lock& operator=(const scoped_lock&) = delete;
 
 private:
@@ -490,7 +490,7 @@ public:
     explicit scoped_lock(adopt_lock_t) {}
     ~scoped_lock() noexcept {}
 
-    scoped_lock(const scoped_lock&) = delete;
+    scoped_lock(const scoped_lock&)            = delete;
     scoped_lock& operator=(const scoped_lock&) = delete;
 };
 #endif // _HAS_CXX17
@@ -582,7 +582,7 @@ public:
         _Cnd_destroy_in_situ(_Mycnd());
     }
 
-    condition_variable(const condition_variable&) = delete;
+    condition_variable(const condition_variable&)            = delete;
     condition_variable& operator=(const condition_variable&) = delete;
 
     void notify_one() noexcept { // wake up one waiter
@@ -748,7 +748,7 @@ class timed_mutex { // class for timed mutual exclusion
 public:
     timed_mutex() noexcept : _My_locked(0) {}
 
-    timed_mutex(const timed_mutex&) = delete;
+    timed_mutex(const timed_mutex&)            = delete;
     timed_mutex& operator=(const timed_mutex&) = delete;
 
     void lock() { // lock the mutex
@@ -818,7 +818,7 @@ class recursive_timed_mutex { // class for recursive timed mutual exclusion
 public:
     recursive_timed_mutex() noexcept : _My_locked(0) {}
 
-    recursive_timed_mutex(const recursive_timed_mutex&) = delete;
+    recursive_timed_mutex(const recursive_timed_mutex&)            = delete;
     recursive_timed_mutex& operator=(const recursive_timed_mutex&) = delete;
 
     void lock() { // lock the mutex

--- a/stl/inc/optional
+++ b/stl/inc/optional
@@ -118,10 +118,10 @@ struct _Optional_destruct_base<_Ty, false> { // either contains a value of _Ty o
         : _Value(_STD invoke(_STD forward<_Fn>(_Func), _STD forward<_Ux>(_Arg))), _Has_value{true} {}
 #endif // _HAS_CXX23
 
-    _Optional_destruct_base(const _Optional_destruct_base&) = default;
-    _Optional_destruct_base(_Optional_destruct_base&&)      = default;
+    _Optional_destruct_base(const _Optional_destruct_base&)            = default;
+    _Optional_destruct_base(_Optional_destruct_base&&)                 = default;
     _Optional_destruct_base& operator=(const _Optional_destruct_base&) = default;
-    _Optional_destruct_base& operator=(_Optional_destruct_base&&) = default;
+    _Optional_destruct_base& operator=(_Optional_destruct_base&&)      = default;
 
     _CONSTEXPR20 void reset() noexcept {
         if (_Has_value) {

--- a/stl/inc/ostream
+++ b/stl/inc/ostream
@@ -56,7 +56,7 @@ protected:
     }
 
 public:
-    __CLR_OR_THIS_CALL basic_ostream(const basic_ostream&) = delete;
+    __CLR_OR_THIS_CALL basic_ostream(const basic_ostream&)            = delete;
     basic_ostream& __CLR_OR_THIS_CALL operator=(const basic_ostream&) = delete;
 
     __CLR_OR_THIS_CALL ~basic_ostream() noexcept override {}
@@ -124,7 +124,7 @@ public:
             return _Ok;
         }
 
-        __CLR_OR_THIS_CALL sentry(const sentry&) = delete;
+        __CLR_OR_THIS_CALL sentry(const sentry&)            = delete;
         sentry& __CLR_OR_THIS_CALL operator=(const sentry&) = delete;
 
     private:

--- a/stl/inc/random
+++ b/stl/inc/random
@@ -224,7 +224,7 @@ public:
         return _Myvec.size();
     }
 
-    seed_seq(const seed_seq&) = delete;
+    seed_seq(const seed_seq&)       = delete;
     void operator=(const seed_seq&) = delete;
 
 private:
@@ -4981,7 +4981,7 @@ public:
         return _Random_device();
     }
 
-    random_device(const random_device&) = delete;
+    random_device(const random_device&)            = delete;
     random_device& operator=(const random_device&) = delete;
 };
 

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -231,7 +231,7 @@ namespace ranges {
         ~_Cached_position() = default;
 
         // Offsets are oblivious to copying, so cache values _do_ propagate via copying.
-        _Cached_position(const _Cached_position&) = default;
+        _Cached_position(const _Cached_position&)            = default;
         _Cached_position& operator=(const _Cached_position&) = default;
 
         // Offsets are potentially invalidated by move, so source caches are invalidated after move
@@ -1358,7 +1358,7 @@ namespace ranges {
             _Iterator(_Iterator&&)      = default;
 
             _Iterator& operator=(const _Iterator&) = delete;
-            _Iterator& operator=(_Iterator&&) = default;
+            _Iterator& operator=(_Iterator&&)      = default;
 
             _Iterator& operator++() {
 #if _ITERATOR_DEBUG_LEVEL != 0
@@ -1503,7 +1503,7 @@ namespace ranges {
         constexpr owning_view(_Rng&& _Range_) noexcept(is_nothrow_move_constructible_v<_Rng>) // strengthened
             : _Range(_STD move(_Range_)) {}
 
-        owning_view(owning_view&&) = default;
+        owning_view(owning_view&&)            = default;
         owning_view& operator=(owning_view&&) = default;
 
         _NODISCARD constexpr _Rng& base() & noexcept {
@@ -5275,7 +5275,7 @@ namespace ranges {
             using difference_type  = range_difference_t<_Vw>;
             using value_type       = range_value_t<_Vw>;
 
-            _Inner_iterator(_Inner_iterator&&) = default;
+            _Inner_iterator(_Inner_iterator&&)            = default;
             _Inner_iterator& operator=(_Inner_iterator&&) = default;
 
             _NODISCARD constexpr const iterator_t<_Vw>& base() const& noexcept /* strengthened */ {
@@ -5384,7 +5384,7 @@ namespace ranges {
                 }
             };
 
-            _Outer_iterator(_Outer_iterator&&) = default;
+            _Outer_iterator(_Outer_iterator&&)            = default;
             _Outer_iterator& operator=(_Outer_iterator&&) = default;
 
             _NODISCARD constexpr value_type operator*() const noexcept /* strengthened */ {

--- a/stl/inc/scoped_allocator
+++ b/stl/inc/scoped_allocator
@@ -80,10 +80,10 @@ struct _Scoped_base<_Outer, _Inner0, _Inner...> : _Outer { // nest of allocators
         // also handles rebinding
     }
 
-    _Scoped_base(const _Scoped_base&) = default;
-    _Scoped_base(_Scoped_base&&)      = default;
+    _Scoped_base(const _Scoped_base&)            = default;
+    _Scoped_base(_Scoped_base&&)                 = default;
     _Scoped_base& operator=(const _Scoped_base&) = default;
-    _Scoped_base& operator=(_Scoped_base&&) = default;
+    _Scoped_base& operator=(_Scoped_base&&)      = default;
 
     _NODISCARD _Myadaptor select_on_container_copy_construction() const { // make new adaptor
         return _Myadaptor(_Secret_scoped_allocator_construct_tag{},
@@ -110,10 +110,10 @@ struct _Scoped_base<_Outer> : _Outer { // nest of allocators, one deep
     template <class _Other1, enable_if_t<!is_base_of_v<_Scoped_base, decay_t<_Other1>>, int> = 0>
     _Scoped_base(_Other1&& _Outer_arg) : _Outer(_STD forward<_Other1>(_Outer_arg)) {} // also handles rebinding
 
-    _Scoped_base(const _Scoped_base&) = default;
-    _Scoped_base(_Scoped_base&&)      = default;
+    _Scoped_base(const _Scoped_base&)            = default;
+    _Scoped_base(_Scoped_base&&)                 = default;
     _Scoped_base& operator=(const _Scoped_base&) = default;
-    _Scoped_base& operator=(_Scoped_base&&) = default;
+    _Scoped_base& operator=(_Scoped_base&&)      = default;
 
     _NODISCARD _Myadaptor select_on_container_copy_construction() const { // make new adaptor
         return _Myadaptor(
@@ -188,7 +188,7 @@ public:
         : _Mybase(_Outer_arg, _Inner_arg) {}
 
     scoped_allocator_adaptor& operator=(const scoped_allocator_adaptor&) = default;
-    scoped_allocator_adaptor& operator=(scoped_allocator_adaptor&&) = default;
+    scoped_allocator_adaptor& operator=(scoped_allocator_adaptor&&)      = default;
 
     _NODISCARD inner_allocator_type& inner_allocator() noexcept { // get reference to inner allocator
         return this->_Get_inner_object(*this);

--- a/stl/inc/semaphore
+++ b/stl/inc/semaphore
@@ -68,7 +68,7 @@ public:
             "Precondition: desired >= 0, and desired <= max() (N4861 [thread.sema.cnt]/5)");
     }
 
-    counting_semaphore(const counting_semaphore&) = delete;
+    counting_semaphore(const counting_semaphore&)            = delete;
     counting_semaphore& operator=(const counting_semaphore&) = delete;
 
     void release(ptrdiff_t _Update = 1) noexcept /* strengthened */ {
@@ -217,7 +217,7 @@ public:
                                           "(N4861 [thread.sema.cnt]/5)");
     }
 
-    counting_semaphore(const counting_semaphore&) = delete;
+    counting_semaphore(const counting_semaphore&)            = delete;
     counting_semaphore& operator=(const counting_semaphore&) = delete;
 
     void release(const ptrdiff_t _Update = 1) noexcept /* strengthened */ {

--- a/stl/inc/shared_mutex
+++ b/stl/inc/shared_mutex
@@ -64,7 +64,7 @@ public:
         return &_Myhandle;
     }
 
-    shared_mutex(const shared_mutex&) = delete;
+    shared_mutex(const shared_mutex&)            = delete;
     shared_mutex& operator=(const shared_mutex&) = delete;
 
 private:
@@ -218,7 +218,7 @@ public:
         }
     }
 
-    shared_timed_mutex(const shared_timed_mutex&) = delete;
+    shared_timed_mutex(const shared_timed_mutex&)            = delete;
     shared_timed_mutex& operator=(const shared_timed_mutex&) = delete;
 
 private:
@@ -289,7 +289,7 @@ public:
         return *this;
     }
 
-    shared_lock(const shared_lock&) = delete;
+    shared_lock(const shared_lock&)            = delete;
     shared_lock& operator=(const shared_lock&) = delete;
 
     void lock() { // lock the mutex

--- a/stl/inc/sstream
+++ b/stl/inc/sstream
@@ -103,7 +103,7 @@ public:
         }
     }
 
-    basic_stringbuf(const basic_stringbuf&) = delete;
+    basic_stringbuf(const basic_stringbuf&)            = delete;
     basic_stringbuf& operator=(const basic_stringbuf&) = delete;
 
     ~basic_stringbuf() noexcept override {
@@ -596,7 +596,7 @@ public:
         }
     }
 
-    basic_istringstream(const basic_istringstream&) = delete;
+    basic_istringstream(const basic_istringstream&)            = delete;
     basic_istringstream& operator=(const basic_istringstream&) = delete;
 
     ~basic_istringstream() noexcept override {}
@@ -715,7 +715,7 @@ public:
         }
     }
 
-    basic_ostringstream(const basic_ostringstream&) = delete;
+    basic_ostringstream(const basic_ostringstream&)            = delete;
     basic_ostringstream& operator=(const basic_ostringstream&) = delete;
 
     ~basic_ostringstream() noexcept override {}
@@ -840,7 +840,7 @@ public:
         }
     }
 
-    basic_stringstream(const basic_stringstream&) = delete;
+    basic_stringstream(const basic_stringstream&)            = delete;
     basic_stringstream& operator=(const basic_stringstream&) = delete;
 
     ~basic_stringstream() noexcept override {}

--- a/stl/inc/stacktrace
+++ b/stl/inc/stacktrace
@@ -77,8 +77,8 @@ class stacktrace_entry {
 public:
     using native_handle_type = void*;
 
-    constexpr stacktrace_entry() noexcept                        = default;
-    constexpr stacktrace_entry(const stacktrace_entry&) noexcept = default;
+    constexpr stacktrace_entry() noexcept                                   = default;
+    constexpr stacktrace_entry(const stacktrace_entry&) noexcept            = default;
     constexpr stacktrace_entry& operator=(const stacktrace_entry&) noexcept = default;
 
     ~stacktrace_entry() = default;
@@ -191,7 +191,7 @@ public:
     basic_stacktrace(basic_stacktrace&& _Other, const allocator_type& _Al)
         : _Frames(_STD move(_Other._Frames), _Al), _Hash(_Other._Hash) {}
 
-    basic_stacktrace& operator=(const basic_stacktrace&) = default;
+    basic_stacktrace& operator=(const basic_stacktrace&)                 = default;
     basic_stacktrace& operator=(basic_stacktrace&&) noexcept(_Noex_move) = default;
 
     ~basic_stacktrace() = default;

--- a/stl/inc/stop_token
+++ b/stl/inc/stop_token
@@ -43,7 +43,7 @@ private:
 public:
     explicit _Stop_callback_base(const _Callback_fn _Fn_) noexcept : _Fn{_Fn_} {}
 
-    _Stop_callback_base(const _Stop_callback_base&) = delete;
+    _Stop_callback_base(const _Stop_callback_base&)            = delete;
     _Stop_callback_base& operator=(const _Stop_callback_base&) = delete;
 
 protected:

--- a/stl/inc/system_error
+++ b/stl/inc/system_error
@@ -106,7 +106,7 @@ public:
     }
 #endif // ^^^ !defined(__cpp_lib_concepts) ^^^
 
-    error_category(const error_category&) = delete;
+    error_category(const error_category&)            = delete;
     error_category& operator=(const error_category&) = delete;
 
 protected:
@@ -484,7 +484,7 @@ struct _System_error_message {
     explicit _System_error_message(const unsigned long _Ec) noexcept
         : _Str(nullptr), _Length(_CSTD __std_system_error_allocate_message(_Ec, &_Str)) {}
 
-    _System_error_message(const _System_error_message&) = delete;
+    _System_error_message(const _System_error_message&)            = delete;
     _System_error_message& operator=(const _System_error_message&) = delete;
 
     ~_System_error_message() {
@@ -615,7 +615,7 @@ struct _Constexpr_immortalize_impl {
 
     constexpr _Constexpr_immortalize_impl() noexcept : _Storage{} {}
 
-    _Constexpr_immortalize_impl(const _Constexpr_immortalize_impl&) = delete;
+    _Constexpr_immortalize_impl(const _Constexpr_immortalize_impl&)            = delete;
     _Constexpr_immortalize_impl& operator=(const _Constexpr_immortalize_impl&) = delete;
 
     _MSVC_NOOP_DTOR ~_Constexpr_immortalize_impl() {

--- a/stl/inc/thread
+++ b/stl/inc/thread
@@ -107,7 +107,7 @@ public:
         return *this;
     }
 
-    thread(const thread&) = delete;
+    thread(const thread&)            = delete;
     thread& operator=(const thread&) = delete;
 
     void swap(thread& _Other) noexcept {
@@ -307,8 +307,8 @@ public:
         _Try_cancel_and_join();
     }
 
-    jthread(const jthread&)     = delete;
-    jthread(jthread&&) noexcept = default;
+    jthread(const jthread&)            = delete;
+    jthread(jthread&&) noexcept        = default;
     jthread& operator=(const jthread&) = delete;
 
     jthread& operator=(jthread&& _Other) noexcept {

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -2166,11 +2166,11 @@ struct _Conditionally_enabled_hash { // conditionally enabled hash base
 
 template <class _Kty>
 struct _Conditionally_enabled_hash<_Kty, false> { // conditionally disabled hash base
-    _Conditionally_enabled_hash()                                   = delete;
-    _Conditionally_enabled_hash(const _Conditionally_enabled_hash&) = delete;
-    _Conditionally_enabled_hash(_Conditionally_enabled_hash&&)      = delete;
+    _Conditionally_enabled_hash()                                              = delete;
+    _Conditionally_enabled_hash(const _Conditionally_enabled_hash&)            = delete;
+    _Conditionally_enabled_hash(_Conditionally_enabled_hash&&)                 = delete;
     _Conditionally_enabled_hash& operator=(const _Conditionally_enabled_hash&) = delete;
-    _Conditionally_enabled_hash& operator=(_Conditionally_enabled_hash&&) = delete;
+    _Conditionally_enabled_hash& operator=(_Conditionally_enabled_hash&&)      = delete;
 };
 
 template <class _Kty>

--- a/stl/inc/variant
+++ b/stl/inc/variant
@@ -922,7 +922,7 @@ using _Variant_destroy_layer = conditional_t<conjunction_v<is_trivially_destruct
 #if _HAS_CXX20
 // build Ti x[] = {std::forward<T>(t)};
 template <size_t _Idx, class _TargetType>
-auto _Construct_array(_TargetType(&&)[1]) -> _Meta_list<integral_constant<size_t, _Idx>, _TargetType>;
+auto _Construct_array(_TargetType (&&)[1]) -> _Meta_list<integral_constant<size_t, _Idx>, _TargetType>;
 
 template <size_t _Idx, class _TargetType, class _InitializerType>
 using _Variant_type_resolver = decltype(_Construct_array<_Idx, _TargetType>({_STD declval<_InitializerType>()}));

--- a/stl/inc/variant
+++ b/stl/inc/variant
@@ -459,9 +459,9 @@ public:
         is_nothrow_constructible_v<_Variant_storage<_Rest...>, integral_constant<size_t, _Idx - 1>, _Types...>)
         : _Tail(integral_constant<size_t, _Idx - 1>{}, static_cast<_Types&&>(_Args)...) {} // initialize _Tail (recurse)
 
-    _Variant_storage_(_Variant_storage_&&)      = default;
-    _Variant_storage_(const _Variant_storage_&) = default;
-    _Variant_storage_& operator=(_Variant_storage_&&) = default;
+    _Variant_storage_(_Variant_storage_&&)                 = default;
+    _Variant_storage_(const _Variant_storage_&)            = default;
+    _Variant_storage_& operator=(_Variant_storage_&&)      = default;
     _Variant_storage_& operator=(const _Variant_storage_&) = default;
 
     _NODISCARD constexpr _First& _Get() & noexcept {
@@ -516,9 +516,9 @@ public:
         is_nothrow_constructible_v<_Variant_storage<_Rest...>, integral_constant<size_t, _Idx - 1>, _Types...>)
         : _Tail(integral_constant<size_t, _Idx - 1>{}, static_cast<_Types&&>(_Args)...) {} // initialize _Tail (recurse)
 
-    _Variant_storage_(_Variant_storage_&&)      = default;
-    _Variant_storage_(const _Variant_storage_&) = default;
-    _Variant_storage_& operator=(_Variant_storage_&&) = default;
+    _Variant_storage_(_Variant_storage_&&)                 = default;
+    _Variant_storage_(const _Variant_storage_&)            = default;
+    _Variant_storage_& operator=(_Variant_storage_&&)      = default;
     _Variant_storage_& operator=(const _Variant_storage_&) = default;
 
     _NODISCARD constexpr _First ^ &_Get() & noexcept {
@@ -897,11 +897,11 @@ struct _Variant_destroy_layer_ : _Variant_base<_Types...> { // destruction behav
         this->_Destroy();
     }
 
-    _Variant_destroy_layer_()                               = default;
-    _Variant_destroy_layer_(const _Variant_destroy_layer_&) = default;
-    _Variant_destroy_layer_(_Variant_destroy_layer_&&)      = default;
+    _Variant_destroy_layer_()                                          = default;
+    _Variant_destroy_layer_(const _Variant_destroy_layer_&)            = default;
+    _Variant_destroy_layer_(_Variant_destroy_layer_&&)                 = default;
     _Variant_destroy_layer_& operator=(const _Variant_destroy_layer_&) = default;
-    _Variant_destroy_layer_& operator=(_Variant_destroy_layer_&&) = default;
+    _Variant_destroy_layer_& operator=(_Variant_destroy_layer_&&)      = default;
 };
 
 template <class... _Types>

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -602,7 +602,7 @@ private:
 
     class _NODISCARD _Asan_extend_guard {
     public:
-        _Asan_extend_guard(const _Asan_extend_guard&) = delete;
+        _Asan_extend_guard(const _Asan_extend_guard&)            = delete;
         _Asan_extend_guard& operator=(const _Asan_extend_guard&) = delete;
 
         constexpr explicit _Asan_extend_guard(vector* _Myvec_, size_type _Target_size_) noexcept
@@ -633,7 +633,7 @@ private:
 
     class _NODISCARD _Asan_create_guard {
     public:
-        _Asan_create_guard(const _Asan_create_guard&) = delete;
+        _Asan_create_guard(const _Asan_create_guard&)            = delete;
         _Asan_create_guard& operator=(const _Asan_create_guard&) = delete;
 
         constexpr explicit _Asan_create_guard(const vector& _Myvec_) noexcept : _Myvec(_Myvec_) {}

--- a/stl/inc/xcall_once.h
+++ b/stl/inc/xcall_once.h
@@ -20,7 +20,7 @@ _STD_BEGIN
 struct once_flag { // opaque data structure for call_once()
     constexpr once_flag() noexcept : _Opaque(nullptr) {}
 
-    once_flag(const once_flag&) = delete;
+    once_flag(const once_flag&)            = delete;
     once_flag& operator=(const once_flag&) = delete;
 
     void* _Opaque;
@@ -36,7 +36,7 @@ _CRTIMP2_PURE int __CLRCALL_PURE_OR_CDECL _Execute_once(
 template <class _Ty>
 union _Immortalizer_impl { // constructs _Ty, never destroys
     constexpr _Immortalizer_impl() noexcept : _Storage{} {}
-    _Immortalizer_impl(const _Immortalizer_impl&) = delete;
+    _Immortalizer_impl(const _Immortalizer_impl&)            = delete;
     _Immortalizer_impl& operator=(const _Immortalizer_impl&) = delete;
     ~_Immortalizer_impl() {
         // do nothing

--- a/stl/inc/xfilesystem_abi.h
+++ b/stl/inc/xfilesystem_abi.h
@@ -348,7 +348,7 @@ struct _Fs_file {
         *_Err = __std_fs_open_handle(&_Raw, _File_name, _Desired_access, _Flags);
     }
 
-    _Fs_file(const _Fs_file&) = delete;
+    _Fs_file(const _Fs_file&)            = delete;
     _Fs_file& operator=(const _Fs_file&) = delete;
 
     ~_Fs_file() {

--- a/stl/inc/xhash
+++ b/stl/inc/xhash
@@ -215,7 +215,7 @@ struct _List_head_construct_ptr {
         _Mycont._Myhead = _Newhead;
     }
 
-    _List_head_construct_ptr(const _List_head_construct_ptr&) = delete;
+    _List_head_construct_ptr(const _List_head_construct_ptr&)            = delete;
     _List_head_construct_ptr& operator=(const _List_head_construct_ptr&) = delete;
 
     _NODISCARD pointer _Release() noexcept {
@@ -257,7 +257,7 @@ struct _Hash_vec {
         _Mypair._Myval2._Alloc_proxy(_GET_PROXY_ALLOCATOR(_Aliter, _Mypair._Get_first()));
     }
 
-    _Hash_vec(const _Hash_vec&) = delete;
+    _Hash_vec(const _Hash_vec&)            = delete;
     _Hash_vec& operator=(const _Hash_vec&) = delete;
 
     _NODISCARD size_type size() const noexcept {
@@ -467,7 +467,7 @@ private:
 
         explicit _Clear_guard(_Hash* const _Target_) : _Target(_Target_) {}
 
-        _Clear_guard(const _Clear_guard&) = delete;
+        _Clear_guard(const _Clear_guard&)            = delete;
         _Clear_guard& operator=(const _Clear_guard&) = delete;
 
         ~_Clear_guard() {
@@ -483,7 +483,7 @@ private:
 
         explicit _Check_container_invariants_guard(const _Hash& _Target_) : _Target(_Target_) {}
 
-        _Check_container_invariants_guard(const _Check_container_invariants_guard&) = delete;
+        _Check_container_invariants_guard(const _Check_container_invariants_guard&)            = delete;
         _Check_container_invariants_guard& operator=(const _Check_container_invariants_guard&) = delete;
 
         ~_Check_container_invariants_guard() {
@@ -959,7 +959,7 @@ private:
     }
 
     struct _Range_eraser {
-        _Range_eraser(const _Range_eraser&) = delete;
+        _Range_eraser(const _Range_eraser&)            = delete;
         _Range_eraser& operator=(const _Range_eraser&) = delete;
 
 #if _ITERATOR_DEBUG_LEVEL == 2

--- a/stl/inc/xiosbase
+++ b/stl/inc/xiosbase
@@ -551,7 +551,7 @@ private:
     static void __CLRCALL_PURE_OR_CDECL _Ios_base_dtor(ios_base*);
 
 public:
-    ios_base(const ios_base&) = delete;
+    ios_base(const ios_base&)            = delete;
     ios_base& operator=(const ios_base&) = delete;
 };
 _STD_END

--- a/stl/inc/xkeycheck.h
+++ b/stl/inc/xkeycheck.h
@@ -145,19 +145,19 @@ Enable warning C4005 to find the forbidden define.
 Enable warning C4005 to find the forbidden define.
 #endif // continue
 
-#if defined(co_await) && _HAS_CXX20
+#if defined(co_await ) && _HAS_CXX20
 #define co_await EMIT WARNING C4005
 #error The C++ Standard Library forbids macroizing the keyword "co_await". \
 Enable warning C4005 to find the forbidden define.
 #endif // co_await
 
-#if defined(co_return) && _HAS_CXX20
+#if defined(co_return ) && _HAS_CXX20
 #define co_return EMIT WARNING C4005
 #error The C++ Standard Library forbids macroizing the keyword "co_return". \
 Enable warning C4005 to find the forbidden define.
 #endif // co_return
 
-#if defined(co_yield) && _HAS_CXX20
+#if defined(co_yield ) && _HAS_CXX20
 #define co_yield EMIT WARNING C4005
 #error The C++ Standard Library forbids macroizing the keyword "co_yield". \
 Enable warning C4005 to find the forbidden define.

--- a/stl/inc/xlocale
+++ b/stl/inc/xlocale
@@ -95,7 +95,7 @@ public:
     public:
         __CLR_OR_THIS_CALL id(size_t _Val = 0) : _Id(_Val) {}
 
-        id(const id&) = delete;
+        id(const id&)            = delete;
         id& operator=(const id&) = delete;
 
         __CLR_OR_THIS_CALL operator size_t() { // get stamp, with lazy allocation
@@ -151,7 +151,7 @@ public:
         __CLR_OR_THIS_CALL ~facet() noexcept override {}
 
     public:
-        __CLR_OR_THIS_CALL facet(const facet&) = delete;
+        __CLR_OR_THIS_CALL facet(const facet&)            = delete;
         facet& __CLR_OR_THIS_CALL operator=(const facet&) = delete;
     };
 
@@ -1386,7 +1386,7 @@ struct _NODISCARD _Codecvt_guard {
     _Codecvt_guard(const _From* const& _First1_, const _From*& _Mid1_, _To* const& _First2_, _To*& _Mid2_)
         : _First1{_First1_}, _Mid1{_Mid1_}, _First2{_First2_}, _Mid2{_Mid2_} {}
 
-    _Codecvt_guard(const _Codecvt_guard&) = delete;
+    _Codecvt_guard(const _Codecvt_guard&)            = delete;
     _Codecvt_guard& operator=(const _Codecvt_guard&) = delete;
 
     ~_Codecvt_guard() {

--- a/stl/inc/xlocbuf
+++ b/stl/inc/xlocbuf
@@ -109,7 +109,7 @@ public:
         return _State;
     }
 
-    wbuffer_convert(const wbuffer_convert&) = delete;
+    wbuffer_convert(const wbuffer_convert&)            = delete;
     wbuffer_convert& operator=(const wbuffer_convert&) = delete;
 
 protected:
@@ -482,7 +482,7 @@ public:
         return _Bstr;
     }
 
-    wstring_convert(const wstring_convert&) = delete;
+    wstring_convert(const wstring_convert&)            = delete;
     wstring_convert& operator=(const wstring_convert&) = delete;
 
 private:

--- a/stl/inc/xlocinfo
+++ b/stl/inc/xlocinfo
@@ -381,7 +381,7 @@ public:
         return reinterpret_cast<const unsigned short*>(_Ret);
     }
 
-    _Locinfo(const _Locinfo&) = delete;
+    _Locinfo(const _Locinfo&)            = delete;
     _Locinfo& operator=(const _Locinfo&) = delete;
 
 private:

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -821,7 +821,7 @@ public:
     constexpr allocator(const allocator&) noexcept = default;
     template <class _Other>
     constexpr allocator(const allocator<_Other>&) noexcept {}
-    _CONSTEXPR20 ~allocator()       = default;
+    _CONSTEXPR20 ~allocator()                           = default;
     _CONSTEXPR20 allocator& operator=(const allocator&) = default;
 
     _CONSTEXPR20 void deallocate(_Ty* const _Ptr, const size_t _Count) {
@@ -1018,7 +1018,7 @@ struct _Alloc_construct_ptr { // pointer used to help construct 1 _Alloc::value_
         }
     }
 
-    _Alloc_construct_ptr(const _Alloc_construct_ptr&) = delete;
+    _Alloc_construct_ptr(const _Alloc_construct_ptr&)            = delete;
     _Alloc_construct_ptr& operator=(const _Alloc_construct_ptr&) = delete;
 };
 
@@ -1053,7 +1053,7 @@ struct _Container_base12 {
 public:
     _CONSTEXPR20 _Container_base12() noexcept = default;
 
-    _Container_base12(const _Container_base12&) = delete;
+    _Container_base12(const _Container_base12&)            = delete;
     _Container_base12& operator=(const _Container_base12&) = delete;
 
     _CONSTEXPR20 void _Orphan_all() noexcept;
@@ -1288,7 +1288,7 @@ struct _Leave_proxy_unbound {
 }; // tag to indicate that a proxy is being allocated before it is safe to bind to a _Container_base12
 
 struct _Fake_proxy_ptr_impl { // fake replacement for a container proxy smart pointer when no container proxy is in use
-    _Fake_proxy_ptr_impl(const _Fake_proxy_ptr_impl&) = delete;
+    _Fake_proxy_ptr_impl(const _Fake_proxy_ptr_impl&)            = delete;
     _Fake_proxy_ptr_impl& operator=(const _Fake_proxy_ptr_impl&) = delete;
     _CONSTEXPR20 _Fake_proxy_ptr_impl(const _Fake_allocator&, _Leave_proxy_unbound) noexcept {}
     _CONSTEXPR20 _Fake_proxy_ptr_impl(const _Fake_allocator&, const _Container_base0&) noexcept {}
@@ -1463,7 +1463,7 @@ struct _NODISCARD _Uninitialized_backout {
 
     constexpr _Uninitialized_backout(_NoThrowFwdIt _First_, _NoThrowFwdIt _Last_) : _First(_First_), _Last(_Last_) {}
 
-    _Uninitialized_backout(const _Uninitialized_backout&) = delete;
+    _Uninitialized_backout(const _Uninitialized_backout&)            = delete;
     _Uninitialized_backout& operator=(const _Uninitialized_backout&) = delete;
 
     _CONSTEXPR20 ~_Uninitialized_backout() {
@@ -1650,7 +1650,7 @@ private:
 public:
     _CONSTEXPR20 _Uninitialized_backout_al(pointer _Dest, _Alloc& _Al_) : _First(_Dest), _Last(_Dest), _Al(_Al_) {}
 
-    _Uninitialized_backout_al(const _Uninitialized_backout_al&) = delete;
+    _Uninitialized_backout_al(const _Uninitialized_backout_al&)            = delete;
     _Uninitialized_backout_al& operator=(const _Uninitialized_backout_al&) = delete;
 
     _CONSTEXPR20 ~_Uninitialized_backout_al() {
@@ -1975,7 +1975,7 @@ struct _Alloc_temporary2 {
         _Traits::construct(_Al, _STD addressof(_Get_value()), _STD forward<_Args>(_Vals)...);
     }
 
-    _Alloc_temporary2(const _Alloc_temporary2&) = delete;
+    _Alloc_temporary2(const _Alloc_temporary2&)            = delete;
     _Alloc_temporary2& operator=(const _Alloc_temporary2&) = delete;
 
     _CONSTEXPR20 ~_Alloc_temporary2() {

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -66,9 +66,7 @@ _NODISCARD constexpr size_t _Get_size_of_n(const size_t _Count) {
 }
 
 template <class _Ty>
-_INLINE_VAR constexpr size_t _New_alignof = (_STD max)(alignof(_Ty),
-    static_cast<size_t>(__STDCPP_DEFAULT_NEW_ALIGNMENT__) // TRANSITION, VSO-522105
-);
+_INLINE_VAR constexpr size_t _New_alignof = (_STD max)(alignof(_Ty), __STDCPP_DEFAULT_NEW_ALIGNMENT__);
 
 struct _Default_allocate_traits {
     __declspec(allocator) static

--- a/stl/inc/xsmf_control.h
+++ b/stl/inc/xsmf_control.h
@@ -29,9 +29,9 @@ struct _Non_trivial_copy : _Base { // non-trivial copy construction facade
         noexcept(_Base::_Construct_from(static_cast<const _Base&>(_That)))) {
         _Base::_Construct_from(static_cast<const _Base&>(_That));
     }
-    _Non_trivial_copy(_Non_trivial_copy&&) = default;
+    _Non_trivial_copy(_Non_trivial_copy&&)                 = default;
     _Non_trivial_copy& operator=(const _Non_trivial_copy&) = default;
-    _Non_trivial_copy& operator=(_Non_trivial_copy&&) = default;
+    _Non_trivial_copy& operator=(_Non_trivial_copy&&)      = default;
 };
 
 template <class _Base, class... _Types>
@@ -52,7 +52,7 @@ struct _Non_trivial_move : _SMF_control_copy<_Base, _Types...> { // non-trivial 
         _Mybase::_Construct_from(static_cast<_Base&&>(_That));
     }
     _Non_trivial_move& operator=(const _Non_trivial_move&) = default;
-    _Non_trivial_move& operator=(_Non_trivial_move&&) = default;
+    _Non_trivial_move& operator=(_Non_trivial_move&&)      = default;
 };
 
 template <class _Base, class... _Types>
@@ -83,11 +83,11 @@ struct _Deleted_copy_assign : _SMF_control_move<_Base, _Types...> { // deleted c
     using _Mybase = _SMF_control_move<_Base, _Types...>;
     using _Mybase::_Mybase;
 
-    _Deleted_copy_assign()                            = default;
-    _Deleted_copy_assign(const _Deleted_copy_assign&) = default;
-    _Deleted_copy_assign(_Deleted_copy_assign&&)      = default;
+    _Deleted_copy_assign()                                       = default;
+    _Deleted_copy_assign(const _Deleted_copy_assign&)            = default;
+    _Deleted_copy_assign(_Deleted_copy_assign&&)                 = default;
     _Deleted_copy_assign& operator=(const _Deleted_copy_assign&) = delete;
-    _Deleted_copy_assign& operator=(_Deleted_copy_assign&&) = default;
+    _Deleted_copy_assign& operator=(_Deleted_copy_assign&&)      = default;
 };
 
 template <class _Base, class... _Types>
@@ -104,9 +104,9 @@ struct _Non_trivial_move_assign : _SMF_control_copy_assign<_Base, _Types...> { /
     using _Mybase = _SMF_control_copy_assign<_Base, _Types...>;
     using _Mybase::_Mybase;
 
-    _Non_trivial_move_assign()                                = default;
-    _Non_trivial_move_assign(const _Non_trivial_move_assign&) = default;
-    _Non_trivial_move_assign(_Non_trivial_move_assign&&)      = default;
+    _Non_trivial_move_assign()                                           = default;
+    _Non_trivial_move_assign(const _Non_trivial_move_assign&)            = default;
+    _Non_trivial_move_assign(_Non_trivial_move_assign&&)                 = default;
     _Non_trivial_move_assign& operator=(const _Non_trivial_move_assign&) = default;
 
     _CONSTEXPR20 _Non_trivial_move_assign& operator=(_Non_trivial_move_assign&& _That) noexcept(
@@ -121,11 +121,11 @@ struct _Deleted_move_assign : _SMF_control_copy_assign<_Base, _Types...> { // de
     using _Mybase = _SMF_control_copy_assign<_Base, _Types...>;
     using _Mybase::_Mybase;
 
-    _Deleted_move_assign()                            = default;
-    _Deleted_move_assign(const _Deleted_move_assign&) = default;
-    _Deleted_move_assign(_Deleted_move_assign&&)      = default;
+    _Deleted_move_assign()                                       = default;
+    _Deleted_move_assign(const _Deleted_move_assign&)            = default;
+    _Deleted_move_assign(_Deleted_move_assign&&)                 = default;
     _Deleted_move_assign& operator=(const _Deleted_move_assign&) = default;
-    _Deleted_move_assign& operator=(_Deleted_move_assign&&) = delete;
+    _Deleted_move_assign& operator=(_Deleted_move_assign&&)      = delete;
 };
 
 template <class _Base, class... _Types>

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -1220,7 +1220,7 @@ public:
 
     constexpr basic_string_view() noexcept : _Mydata(), _Mysize(0) {}
 
-    constexpr basic_string_view(const basic_string_view&) noexcept = default;
+    constexpr basic_string_view(const basic_string_view&) noexcept            = default;
     constexpr basic_string_view& operator=(const basic_string_view&) noexcept = default;
 
     /* implicit */ constexpr basic_string_view(_In_z_ const const_pointer _Ntcts) noexcept // strengthened

--- a/stl/inc/xtree
+++ b/stl/inc/xtree
@@ -336,8 +336,8 @@ struct _Tree_node {
         _Black
     };
 
-    _Tree_node()                  = default;
-    _Tree_node(const _Tree_node&) = delete;
+    _Tree_node()                             = default;
+    _Tree_node(const _Tree_node&)            = delete;
     _Tree_node& operator=(const _Tree_node&) = delete;
 
     template <class _Alloc>
@@ -786,7 +786,7 @@ struct _Tree_temp_node_alloc : _Alloc_construct_ptr<_Alnode> {
         _Alloc_construct_ptr<_Alnode>::_Allocate();
     }
 
-    _Tree_temp_node_alloc(const _Tree_temp_node_alloc&) = delete;
+    _Tree_temp_node_alloc(const _Tree_temp_node_alloc&)            = delete;
     _Tree_temp_node_alloc& operator=(const _Tree_temp_node_alloc&) = delete;
 };
 
@@ -812,7 +812,7 @@ struct _Tree_temp_node : _Tree_temp_node_alloc<_Alnode> {
         this->_Ptr->_Isnil = false;
     }
 
-    _Tree_temp_node(const _Tree_temp_node&) = delete;
+    _Tree_temp_node(const _Tree_temp_node&)            = delete;
     _Tree_temp_node& operator=(const _Tree_temp_node&) = delete;
 
     ~_Tree_temp_node() {

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -2403,7 +2403,7 @@ namespace ranges {
 
         constexpr explicit _Not_quite_object(_Construct_tag) noexcept {}
 
-        _Not_quite_object(const _Not_quite_object&) = delete;
+        _Not_quite_object(const _Not_quite_object&)            = delete;
         _Not_quite_object& operator=(const _Not_quite_object&) = delete;
 
         void operator&() const = delete;
@@ -5740,7 +5740,7 @@ public:
         return _Ret;
     }
 
-    _Rng_from_urng(const _Rng_from_urng&) = delete;
+    _Rng_from_urng(const _Rng_from_urng&)            = delete;
     _Rng_from_urng& operator=(const _Rng_from_urng&) = delete;
 
 private:

--- a/stl/inc/yvals.h
+++ b/stl/inc/yvals.h
@@ -375,7 +375,7 @@ private:
     static void __cdecl _Lockit_dtor(_Lockit*) noexcept;
 
 public:
-    __CLR_OR_THIS_CALL _Lockit(const _Lockit&) = delete;
+    __CLR_OR_THIS_CALL _Lockit(const _Lockit&)            = delete;
     _Lockit& __CLR_OR_THIS_CALL operator=(const _Lockit&) = delete;
 
 private:

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -622,12 +622,12 @@
 #elif defined(__EDG__)
 // not attempting to detect __EDG_VERSION__ being less than expected
 #elif defined(__clang__)
-#if __clang_major__ < 13
-#error STL1000: Unexpected compiler version, expected Clang 13.0.0 or newer.
+#if __clang_major__ < 14
+#error STL1000: Unexpected compiler version, expected Clang 14.0.0 or newer.
 #endif // ^^^ old Clang ^^^
 #elif defined(_MSC_VER)
-#if _MSC_VER < 1932 // Coarse-grained, not inspecting _MSC_FULL_VER
-#error STL1001: Unexpected compiler version, expected MSVC 19.32 or newer.
+#if _MSC_VER < 1933 // Coarse-grained, not inspecting _MSC_FULL_VER
+#error STL1001: Unexpected compiler version, expected MSVC 19.33 or newer.
 #endif // ^^^ old MSVC ^^^
 #else // vvv other compilers vvv
 // not attempting to detect other compilers

--- a/stl/src/atomic_wait.cpp
+++ b/stl/src/atomic_wait.cpp
@@ -37,7 +37,7 @@ namespace {
             _Prev->_Next           = _Next_local;
         }
 
-        _Guarded_wait_context(const _Guarded_wait_context&) = delete;
+        _Guarded_wait_context(const _Guarded_wait_context&)            = delete;
         _Guarded_wait_context& operator=(const _Guarded_wait_context&) = delete;
     };
 
@@ -51,7 +51,7 @@ namespace {
             ReleaseSRWLockExclusive(_Locked);
         }
 
-        _SrwLock_guard(const _SrwLock_guard&) = delete;
+        _SrwLock_guard(const _SrwLock_guard&)            = delete;
         _SrwLock_guard& operator=(const _SrwLock_guard&) = delete;
 
     private:

--- a/stl/src/excptptr.cpp
+++ b/stl/src/excptptr.cpp
@@ -52,7 +52,7 @@ namespace {
 
         constexpr _Constexpr_excptptr_immortalize_impl() noexcept : _Storage{} {}
 
-        _Constexpr_excptptr_immortalize_impl(const _Constexpr_excptptr_immortalize_impl&) = delete;
+        _Constexpr_excptptr_immortalize_impl(const _Constexpr_excptptr_immortalize_impl&)            = delete;
         _Constexpr_excptptr_immortalize_impl& operator=(const _Constexpr_excptptr_immortalize_impl&) = delete;
 
         _MSVC_NOOP_DTOR ~_Constexpr_excptptr_immortalize_impl() {

--- a/stl/src/primitives.hpp
+++ b/stl/src/primitives.hpp
@@ -34,8 +34,8 @@ namespace Concurrency {
                 InitializeSRWLock(&m_srw_lock);
             }
 
-            ~stl_critical_section_win7()                                = delete;
-            stl_critical_section_win7(const stl_critical_section_win7&) = delete;
+            ~stl_critical_section_win7()                                           = delete;
+            stl_critical_section_win7(const stl_critical_section_win7&)            = delete;
             stl_critical_section_win7& operator=(const stl_critical_section_win7&) = delete;
 
             void destroy() override {}
@@ -71,8 +71,8 @@ namespace Concurrency {
                 InitializeConditionVariable(&m_condition_variable);
             }
 
-            ~stl_condition_variable_win7()                                  = delete;
-            stl_condition_variable_win7(const stl_condition_variable_win7&) = delete;
+            ~stl_condition_variable_win7()                                             = delete;
+            stl_condition_variable_win7(const stl_condition_variable_win7&)            = delete;
             stl_condition_variable_win7& operator=(const stl_condition_variable_win7&) = delete;
 
             void destroy() override {}

--- a/stl/src/stacktrace.cpp
+++ b/stl/src/stacktrace.cpp
@@ -44,7 +44,7 @@ namespace {
             ReleaseSRWLockExclusive(&srw);
         }
 
-        dbg_eng_data(const dbg_eng_data&) = delete;
+        dbg_eng_data(const dbg_eng_data&)            = delete;
         dbg_eng_data& operator=(const dbg_eng_data&) = delete;
 
         void uninitialize() noexcept {

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -294,40 +294,6 @@ std/concepts/concepts.compare/concept.equalitycomparable/equality_comparable_wit
 # LLVM-46207 Clang's tgmath.h interferes with the UCRT's tgmath.h
 std/depr/depr.c.headers/tgmath_h.pass.cpp:1 FAIL
 
-# Clang doesn't implement the common coroutine ABI until LLVM 14
-std/language.support/support.coroutines/coroutine.handle/coroutine.handle.capacity/operator_bool.pass.cpp:1 FAIL
-std/language.support/support.coroutines/coroutine.handle/coroutine.handle.compare/equal_comp.pass.cpp:1 FAIL
-std/language.support/support.coroutines/coroutine.handle/coroutine.handle.compare/less_comp.pass.cpp:1 FAIL
-std/language.support/support.coroutines/coroutine.handle/coroutine.handle.completion/done.pass.cpp:1 FAIL
-std/language.support/support.coroutines/coroutine.handle/coroutine.handle.con/assign.pass.cpp:1 FAIL
-std/language.support/support.coroutines/coroutine.handle/coroutine.handle.con/construct.pass.cpp:1 FAIL
-std/language.support/support.coroutines/coroutine.handle/coroutine.handle.export/address.pass.cpp:1 FAIL
-std/language.support/support.coroutines/coroutine.handle/coroutine.handle.export/from_address.pass.cpp:1 FAIL
-std/language.support/support.coroutines/coroutine.handle/coroutine.handle.hash/hash.pass.cpp:1 FAIL
-std/language.support/support.coroutines/coroutine.handle/coroutine.handle.noop/noop_coroutine.pass.cpp:1 FAIL
-std/language.support/support.coroutines/coroutine.handle/coroutine.handle.prom/promise.pass.cpp:1 FAIL
-std/language.support/support.coroutines/coroutine.handle/coroutine.handle.resumption/destroy.pass.cpp:1 FAIL
-std/language.support/support.coroutines/coroutine.handle/coroutine.handle.resumption/resume.pass.cpp:1 FAIL
-std/language.support/support.coroutines/coroutine.handle/void_handle.pass.cpp:1 FAIL
-std/language.support/support.coroutines/coroutine.traits/promise_type.pass.cpp:1 FAIL
-std/language.support/support.coroutines/coroutine.trivial.awaitables/suspend_always.pass.cpp:1 FAIL
-std/language.support/support.coroutines/coroutine.trivial.awaitables/suspend_never.pass.cpp:1 FAIL
-std/language.support/support.coroutines/end.to.end/await_result.pass.cpp:1 FAIL
-std/language.support/support.coroutines/end.to.end/bool_await_suspend.pass.cpp:1 FAIL
-std/language.support/support.coroutines/end.to.end/expected.pass.cpp:1 FAIL
-std/language.support/support.coroutines/end.to.end/fullexpr-dtor.pass.cpp:1 FAIL
-std/language.support/support.coroutines/end.to.end/generator.pass.cpp:1 FAIL
-std/language.support/support.coroutines/end.to.end/go.pass.cpp:1 FAIL
-std/language.support/support.coroutines/end.to.end/multishot_func.pass.cpp:1 FAIL
-std/language.support/support.coroutines/end.to.end/oneshot_func.pass.cpp:1 FAIL
-std/language.support/support.limits/support.limits.general/coroutine.version.pass.cpp:1 FAIL
-
-# LLVM-52970 SFINAEing p.x on a pointer wrongly tries to complete the pointee's type
-std/ranges/range.access/begin.pass.cpp:1 FAIL
-std/ranges/range.access/data.pass.cpp:1 FAIL
-std/ranges/range.access/end.pass.cpp:1 FAIL
-std/ranges/range.req/range.range/range.compile.pass.cpp:1 FAIL
-
 # Clang doesn't yet implement P0960 "Initializing Aggregates With Parentheses"
 std/ranges/range.factories/range.iota.view/sentinel/ctor.value.pass.cpp:1 FAIL
 
@@ -915,9 +881,6 @@ std/containers/sequences/vector/vector.cons/deduct.pass.cpp FAIL
 std/iterators/iterator.primitives/iterator.operations/advance.pass.cpp SKIPPED
 
 # Not yet analyzed. Maybe Clang over-eagerly instantiating noexcept-specifier?
-std/ranges/range.access/empty.pass.cpp:1 FAIL
-std/ranges/range.access/size.pass.cpp:1 FAIL
-std/ranges/range.access/ssize.pass.cpp:1 FAIL
 std/utilities/memory/unique.ptr/iterator_concept_conformance.compile.pass.cpp:1 SKIPPED
 
 # Not yet analyzed. Assertion failed: std::abs((kurtosis - x_kurtosis) / x_kurtosis) < VARIOUS_VALUES

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -294,40 +294,6 @@ concepts\concepts.compare\concept.equalitycomparable\equality_comparable_with.co
 # LLVM-46207 Clang's tgmath.h interferes with the UCRT's tgmath.h
 depr\depr.c.headers\tgmath_h.pass.cpp
 
-# Clang doesn't implement the common coroutine ABI until LLVM 14
-language.support\support.coroutines\coroutine.handle\coroutine.handle.capacity\operator_bool.pass.cpp
-language.support\support.coroutines\coroutine.handle\coroutine.handle.compare\equal_comp.pass.cpp
-language.support\support.coroutines\coroutine.handle\coroutine.handle.compare\less_comp.pass.cpp
-language.support\support.coroutines\coroutine.handle\coroutine.handle.completion\done.pass.cpp
-language.support\support.coroutines\coroutine.handle\coroutine.handle.con\assign.pass.cpp
-language.support\support.coroutines\coroutine.handle\coroutine.handle.con\construct.pass.cpp
-language.support\support.coroutines\coroutine.handle\coroutine.handle.export\address.pass.cpp
-language.support\support.coroutines\coroutine.handle\coroutine.handle.export\from_address.pass.cpp
-language.support\support.coroutines\coroutine.handle\coroutine.handle.hash\hash.pass.cpp
-language.support\support.coroutines\coroutine.handle\coroutine.handle.noop\noop_coroutine.pass.cpp
-language.support\support.coroutines\coroutine.handle\coroutine.handle.prom\promise.pass.cpp
-language.support\support.coroutines\coroutine.handle\coroutine.handle.resumption\destroy.pass.cpp
-language.support\support.coroutines\coroutine.handle\coroutine.handle.resumption\resume.pass.cpp
-language.support\support.coroutines\coroutine.handle\void_handle.pass.cpp
-language.support\support.coroutines\coroutine.traits\promise_type.pass.cpp
-language.support\support.coroutines\coroutine.trivial.awaitables\suspend_always.pass.cpp
-language.support\support.coroutines\coroutine.trivial.awaitables\suspend_never.pass.cpp
-language.support\support.coroutines\end.to.end\await_result.pass.cpp
-language.support\support.coroutines\end.to.end\bool_await_suspend.pass.cpp
-language.support\support.coroutines\end.to.end\expected.pass.cpp
-language.support\support.coroutines\end.to.end\fullexpr-dtor.pass.cpp
-language.support\support.coroutines\end.to.end\generator.pass.cpp
-language.support\support.coroutines\end.to.end\go.pass.cpp
-language.support\support.coroutines\end.to.end\multishot_func.pass.cpp
-language.support\support.coroutines\end.to.end\oneshot_func.pass.cpp
-language.support\support.limits\support.limits.general\coroutine.version.pass.cpp
-
-# LLVM-52970 SFINAEing p.x on a pointer wrongly tries to complete the pointee's type
-ranges\range.access\begin.pass.cpp
-ranges\range.access\data.pass.cpp
-ranges\range.access\end.pass.cpp
-ranges\range.req\range.range\range.compile.pass.cpp
-
 # Clang doesn't yet implement P0960 "Initializing Aggregates With Parentheses"
 ranges\range.factories\range.iota.view\sentinel\ctor.value.pass.cpp
 
@@ -911,9 +877,6 @@ containers\sequences\vector\vector.cons\deduct.pass.cpp
 iterators\iterator.primitives\iterator.operations\advance.pass.cpp
 
 # Not yet analyzed. Maybe Clang over-eagerly instantiating noexcept-specifier?
-ranges\range.access\empty.pass.cpp
-ranges\range.access\size.pass.cpp
-ranges\range.access\ssize.pass.cpp
 utilities\memory\unique.ptr\iterator_concept_conformance.compile.pass.cpp
 
 # Not yet analyzed. Assertion failed: std::abs((kurtosis - x_kurtosis) / x_kurtosis) < VARIOUS_VALUES

--- a/tests/std/include/fenv_prefix.hpp
+++ b/tests/std/include/fenv_prefix.hpp
@@ -54,7 +54,7 @@ struct fenv_initializer_t {
 
     ~fenv_initializer_t() = default;
 
-    fenv_initializer_t(const fenv_initializer_t&) = delete;
+    fenv_initializer_t(const fenv_initializer_t&)            = delete;
     fenv_initializer_t& operator=(const fenv_initializer_t&) = delete;
 };
 

--- a/tests/std/include/input_iterator.hpp
+++ b/tests/std/include/input_iterator.hpp
@@ -26,10 +26,10 @@ namespace std_testing {
         using my_iter           = const_unchecked_input_iterator;
 
         explicit const_unchecked_input_iterator(const T* val) : m_val(const_cast<T*>(val)) {}
-        const_unchecked_input_iterator(const const_unchecked_input_iterator&) = default;
-        const_unchecked_input_iterator(const_unchecked_input_iterator&&)      = default;
+        const_unchecked_input_iterator(const const_unchecked_input_iterator&)            = default;
+        const_unchecked_input_iterator(const_unchecked_input_iterator&&)                 = default;
         const_unchecked_input_iterator& operator=(const const_unchecked_input_iterator&) = default;
-        const_unchecked_input_iterator& operator=(const_unchecked_input_iterator&&) = default;
+        const_unchecked_input_iterator& operator=(const_unchecked_input_iterator&&)      = default;
 
         reference operator*() const {
             return *m_val;
@@ -70,10 +70,10 @@ namespace std_testing {
         using my_iter           = unchecked_input_iterator;
 
         explicit unchecked_input_iterator(T* val) : const_unchecked_input_iterator<T>(val) {}
-        unchecked_input_iterator(const unchecked_input_iterator&) = default;
-        unchecked_input_iterator(unchecked_input_iterator&&)      = default;
+        unchecked_input_iterator(const unchecked_input_iterator&)            = default;
+        unchecked_input_iterator(unchecked_input_iterator&&)                 = default;
         unchecked_input_iterator& operator=(const unchecked_input_iterator&) = default;
-        unchecked_input_iterator& operator=(unchecked_input_iterator&&) = default;
+        unchecked_input_iterator& operator=(unchecked_input_iterator&&)      = default;
 
         reference operator*() const {
             return *this->m_val;
@@ -101,10 +101,10 @@ namespace std_testing {
         using my_iter           = const_checked_input_iterator;
 
         explicit const_checked_input_iterator(const T* val) : const_unchecked_input_iterator<T>(val) {}
-        const_checked_input_iterator(const const_checked_input_iterator&) = default;
-        const_checked_input_iterator(const_checked_input_iterator&&)      = default;
+        const_checked_input_iterator(const const_checked_input_iterator&)            = default;
+        const_checked_input_iterator(const_checked_input_iterator&&)                 = default;
         const_checked_input_iterator& operator=(const const_checked_input_iterator&) = default;
-        const_checked_input_iterator& operator=(const_checked_input_iterator&&) = default;
+        const_checked_input_iterator& operator=(const_checked_input_iterator&&)      = default;
 
         void _Seek_to(const_unchecked_input_iterator<T> right) {
             this->m_val = right.m_val;
@@ -134,10 +134,10 @@ namespace std_testing {
         using my_iter           = checked_input_iterator;
 
         explicit checked_input_iterator(T* val) : unchecked_input_iterator<T>(val) {}
-        checked_input_iterator(const checked_input_iterator&) = default;
-        checked_input_iterator(checked_input_iterator&&)      = default;
+        checked_input_iterator(const checked_input_iterator&)            = default;
+        checked_input_iterator(checked_input_iterator&&)                 = default;
         checked_input_iterator& operator=(const checked_input_iterator&) = default;
-        checked_input_iterator& operator=(checked_input_iterator&&) = default;
+        checked_input_iterator& operator=(checked_input_iterator&&)      = default;
 
         void _Seek_to(unchecked_input_iterator<T> right) {
             this->m_val = right.m_val;
@@ -174,10 +174,10 @@ namespace std_testing {
         input_iterator_container(std::initializer_list<T> init_list)
             : input_iterator_container(init_list.begin(), init_list.end()) {}
 
-        input_iterator_container(const input_iterator_container&) = default;
-        input_iterator_container(input_iterator_container&&)      = default;
+        input_iterator_container(const input_iterator_container&)            = default;
+        input_iterator_container(input_iterator_container&&)                 = default;
         input_iterator_container& operator=(const input_iterator_container&) = default;
-        input_iterator_container& operator=(input_iterator_container&&) = default;
+        input_iterator_container& operator=(input_iterator_container&&)      = default;
 
         const_iterator begin() const {
             return const_iterator{reinterpret_cast<const T*>(m_val.data())};

--- a/tests/std/include/instantiate_algorithms.hpp
+++ b/tests/std/include/instantiate_algorithms.hpp
@@ -42,17 +42,17 @@ namespace std_testing {
         // mode perf.
 
         struct Immobile {
-            Immobile()                = default;
-            Immobile(const Immobile&) = delete;
+            Immobile()                           = default;
+            Immobile(const Immobile&)            = delete;
             Immobile& operator=(const Immobile&) = delete;
         };
 
         struct MoveOnly {
-            MoveOnly()                = default;
-            MoveOnly(const MoveOnly&) = delete;
-            MoveOnly(MoveOnly&&)      = default;
+            MoveOnly()                           = default;
+            MoveOnly(const MoveOnly&)            = delete;
+            MoveOnly(MoveOnly&&)                 = default;
             MoveOnly& operator=(const MoveOnly&) = delete;
-            MoveOnly& operator=(MoveOnly&&) = delete;
+            MoveOnly& operator=(MoveOnly&&)      = delete;
         };
 
         template <typename T>

--- a/tests/std/include/instantiate_algorithms_op_deref.hpp
+++ b/tests/std/include/instantiate_algorithms_op_deref.hpp
@@ -50,11 +50,11 @@ namespace Meow {
         using reference         = Evil&;
 
         BasicInIt(int, int) {}
-        BasicInIt(const BasicInIt&) = default;
-        BasicInIt(BasicInIt&&)      = default;
+        BasicInIt(const BasicInIt&)            = default;
+        BasicInIt(BasicInIt&&)                 = default;
         BasicInIt& operator=(const BasicInIt&) = default;
-        BasicInIt& operator=(BasicInIt&&) = default;
-        ~BasicInIt()                      = default;
+        BasicInIt& operator=(BasicInIt&&)      = default;
+        ~BasicInIt()                           = default;
 
         Evil& operator*() const {
             static Evil val{};
@@ -91,12 +91,12 @@ namespace Meow {
         using pointer           = Evil*;
         using reference         = Evil&;
 
-        BasicFwdIt()                  = default;
-        BasicFwdIt(const BasicFwdIt&) = default;
-        BasicFwdIt(BasicFwdIt&&)      = default;
+        BasicFwdIt()                             = default;
+        BasicFwdIt(const BasicFwdIt&)            = default;
+        BasicFwdIt(BasicFwdIt&&)                 = default;
         BasicFwdIt& operator=(const BasicFwdIt&) = default;
-        BasicFwdIt& operator=(BasicFwdIt&&) = default;
-        ~BasicFwdIt()                       = default;
+        BasicFwdIt& operator=(BasicFwdIt&&)      = default;
+        ~BasicFwdIt()                            = default;
 
         Evil& operator*() const {
             static Evil val{};
@@ -133,12 +133,12 @@ namespace Meow {
         using pointer           = Evil*;
         using reference         = Evil&;
 
-        BasicBidIt()                  = default;
-        BasicBidIt(const BasicBidIt&) = default;
-        BasicBidIt(BasicBidIt&&)      = default;
+        BasicBidIt()                             = default;
+        BasicBidIt(const BasicBidIt&)            = default;
+        BasicBidIt(BasicBidIt&&)                 = default;
         BasicBidIt& operator=(const BasicBidIt&) = default;
-        BasicBidIt& operator=(BasicBidIt&&) = default;
-        ~BasicBidIt()                       = default;
+        BasicBidIt& operator=(BasicBidIt&&)      = default;
+        ~BasicBidIt()                            = default;
 
         Evil& operator*() const {
             static Evil val{};
@@ -181,12 +181,12 @@ namespace Meow {
         using pointer           = Evil*;
         using reference         = Evil&;
 
-        BasicRanIt()                  = default;
-        BasicRanIt(const BasicRanIt&) = default;
-        BasicRanIt(BasicRanIt&&)      = default;
+        BasicRanIt()                             = default;
+        BasicRanIt(const BasicRanIt&)            = default;
+        BasicRanIt(BasicRanIt&&)                 = default;
         BasicRanIt& operator=(const BasicRanIt&) = default;
-        BasicRanIt& operator=(BasicRanIt&&) = default;
-        ~BasicRanIt()                       = default;
+        BasicRanIt& operator=(BasicRanIt&&)      = default;
+        ~BasicRanIt()                            = default;
 
         Evil& operator*() const {
             static Evil val{};
@@ -268,11 +268,11 @@ namespace Meow {
         using reference         = void;
 
         BasicOutIt(int, int) {}
-        BasicOutIt(const BasicOutIt&) = default;
-        BasicOutIt(BasicOutIt&&)      = default;
+        BasicOutIt(const BasicOutIt&)            = default;
+        BasicOutIt(BasicOutIt&&)                 = default;
         BasicOutIt& operator=(const BasicOutIt&) = default;
-        BasicOutIt& operator=(BasicOutIt&&) = default;
-        ~BasicOutIt()                       = default;
+        BasicOutIt& operator=(BasicOutIt&&)      = default;
+        ~BasicOutIt()                            = default;
 
         Evil& operator*() const {
             static Evil val{};

--- a/tests/std/include/range_algorithm_support.hpp
+++ b/tests/std/include/range_algorithm_support.hpp
@@ -650,7 +650,7 @@ namespace test {
             range_base() = delete;
             constexpr explicit range_base(span<Element> elements) noexcept : elements_{elements} {}
 
-            range_base(const range_base&) = delete;
+            range_base(const range_base&)            = delete;
             range_base& operator=(const range_base&) = delete;
 
         protected:
@@ -697,7 +697,7 @@ namespace test {
             constexpr range_base() = default;
             constexpr explicit range_base(span<Element> elements) noexcept : elements_{elements} {}
 
-            constexpr range_base(const range_base&) = default;
+            constexpr range_base(const range_base&)            = default;
             constexpr range_base& operator=(const range_base&) = default;
 
             constexpr range_base(range_base&& that) noexcept

--- a/tests/std/include/test_regex_support.hpp
+++ b/tests/std/include/test_regex_support.hpp
@@ -189,7 +189,7 @@ public:
         std::regex_constants::syntax_option_type syntax = std::regex_constants::ECMAScript)
         : fixture(fixture), pattern(pattern), syntax(syntax), r(pattern, syntax) {}
 
-    test_regex(const test_regex&) = delete;
+    test_regex(const test_regex&)            = delete;
     test_regex& operator=(const test_regex&) = delete;
 
     void should_search_match(const std::string& subject, const std::string& expected,
@@ -252,7 +252,7 @@ public:
         std::regex_constants::syntax_option_type syntax = std::regex_constants::ECMAScript)
         : fixture(fixture), pattern(pattern), syntax(syntax), r(pattern, syntax) {}
 
-    test_wregex(const test_wregex&) = delete;
+    test_wregex(const test_wregex&)            = delete;
     test_wregex& operator=(const test_wregex&) = delete;
 
     void should_search_match(const std::wstring& subject, const std::wstring& expected,

--- a/tests/std/tests/Dev09_052961_has_iterator_debugging_0/test.cpp
+++ b/tests/std/tests/Dev09_052961_has_iterator_debugging_0/test.cpp
@@ -66,7 +66,7 @@ union uninit_vector {
     vector<int> storage;
 
     constexpr uninit_vector() : bytes{} {}
-    uninit_vector(const uninit_vector&) = delete;
+    uninit_vector(const uninit_vector&)            = delete;
     uninit_vector& operator=(const uninit_vector&) = delete;
     ~uninit_vector() {}
 };

--- a/tests/std/tests/Dev10_709168_marking_iterators_as_checked/test.compile.pass.cpp
+++ b/tests/std/tests/Dev10_709168_marking_iterators_as_checked/test.compile.pass.cpp
@@ -223,12 +223,12 @@ struct SimpleBidIt {
     using pointer           = int*;
     using reference         = int&;
 
-    SimpleBidIt()                   = default;
-    SimpleBidIt(const SimpleBidIt&) = default;
-    SimpleBidIt(SimpleBidIt&&)      = default;
+    SimpleBidIt()                              = default;
+    SimpleBidIt(const SimpleBidIt&)            = default;
+    SimpleBidIt(SimpleBidIt&&)                 = default;
     SimpleBidIt& operator=(const SimpleBidIt&) = default;
-    SimpleBidIt& operator=(SimpleBidIt&&) = default;
-    ~SimpleBidIt()                        = default;
+    SimpleBidIt& operator=(SimpleBidIt&&)      = default;
+    ~SimpleBidIt()                             = default;
 
     int& operator*() const {
         static int val{};
@@ -275,12 +275,12 @@ struct FancyBidIt {
     using pointer           = int*;
     using reference         = int&;
 
-    FancyBidIt()                  = default;
-    FancyBidIt(const FancyBidIt&) = default;
-    FancyBidIt(FancyBidIt&&)      = default;
+    FancyBidIt()                             = default;
+    FancyBidIt(const FancyBidIt&)            = default;
+    FancyBidIt(FancyBidIt&&)                 = default;
     FancyBidIt& operator=(const FancyBidIt&) = default;
-    FancyBidIt& operator=(FancyBidIt&&) = default;
-    ~FancyBidIt()                       = default;
+    FancyBidIt& operator=(FancyBidIt&&)      = default;
+    ~FancyBidIt()                            = default;
 
     int& operator*() const {
         static int val{};

--- a/tests/std/tests/Dev10_722102_shared_ptr_nullptr/test.cpp
+++ b/tests/std/tests/Dev10_722102_shared_ptr_nullptr/test.cpp
@@ -51,8 +51,8 @@ struct NullptrDeleter {
 };
 
 struct ImmobileDeleter {
-    ImmobileDeleter()                  = default;
-    ImmobileDeleter(ImmobileDeleter&&) = delete;
+    ImmobileDeleter()                             = default;
+    ImmobileDeleter(ImmobileDeleter&&)            = delete;
     ImmobileDeleter& operator=(ImmobileDeleter&&) = delete;
 
     void operator()(void*) const {}
@@ -216,8 +216,8 @@ namespace unique_ptr_ {
         fancy_deleter()                = default;
         fancy_deleter(fancy_deleter&&) = default;
 
-        fancy_deleter(const fancy_deleter&) = delete;
-        fancy_deleter& operator=(fancy_deleter&&) = delete;
+        fancy_deleter(const fancy_deleter&)            = delete;
+        fancy_deleter& operator=(fancy_deleter&&)      = delete;
         fancy_deleter& operator=(const fancy_deleter&) = delete;
     };
 

--- a/tests/std/tests/Dev11_0000000_user_defined_literals/test.cpp
+++ b/tests/std/tests/Dev11_0000000_user_defined_literals/test.cpp
@@ -386,11 +386,11 @@ int main() {
         // expensive, and even for relatively cheap to copy function objects we care (somewhat) about debug
         // mode perf.
         struct no_copy {
-            no_copy()               = default;
-            no_copy(const no_copy&) = delete;
-            no_copy(no_copy&&)      = default;
+            no_copy()                          = default;
+            no_copy(const no_copy&)            = delete;
+            no_copy(no_copy&&)                 = default;
             no_copy& operator=(const no_copy&) = delete;
-            no_copy& operator=(no_copy&&) = delete;
+            no_copy& operator=(no_copy&&)      = delete;
         };
 
         struct is_vowel : no_copy {
@@ -543,11 +543,11 @@ int main() {
         // expensive, and even for relatively cheap to copy function objects we care (somewhat) about debug
         // mode perf.
         struct no_copy {
-            no_copy()               = default;
-            no_copy(const no_copy&) = delete;
-            no_copy(no_copy&&)      = default;
+            no_copy()                          = default;
+            no_copy(const no_copy&)            = delete;
+            no_copy(no_copy&&)                 = default;
             no_copy& operator=(const no_copy&) = delete;
-            no_copy& operator=(no_copy&&) = delete;
+            no_copy& operator=(no_copy&&)      = delete;
         };
 
         struct is_vowel : no_copy {

--- a/tests/std/tests/Dev11_0235721_async_and_packaged_task/test.cpp
+++ b/tests/std/tests/Dev11_0235721_async_and_packaged_task/test.cpp
@@ -169,10 +169,10 @@ struct move_only_functor_type {
 
     move_only_functor_type() = delete;
     move_only_functor_type(int, int) {}
-    move_only_functor_type(const move_only_functor_type&) = delete;
-    move_only_functor_type(move_only_functor_type&&)      = default;
+    move_only_functor_type(const move_only_functor_type&)            = delete;
+    move_only_functor_type(move_only_functor_type&&)                 = default;
     move_only_functor_type& operator=(const move_only_functor_type&) = delete;
-    move_only_functor_type& operator=(move_only_functor_type&&) = delete;
+    move_only_functor_type& operator=(move_only_functor_type&&)      = delete;
 };
 
 void test_VSO_112570() {

--- a/tests/std/tests/Dev11_0437519_container_requirements/test.compile.pass.cpp
+++ b/tests/std/tests/Dev11_0437519_container_requirements/test.compile.pass.cpp
@@ -91,8 +91,8 @@ struct faux_compare {
 
 template <typename T>
 struct default_constructible_compare {
-    default_constructible_compare()                                     = default;
-    default_constructible_compare(default_constructible_compare const&) = default;
+    default_constructible_compare()                                                = default;
+    default_constructible_compare(default_constructible_compare const&)            = default;
     default_constructible_compare& operator=(default_constructible_compare const&) = delete;
 
     bool operator()(T const&, T const&) const noexcept {
@@ -104,7 +104,7 @@ template <typename T>
 struct copy_constructible_compare {
     copy_constructible_compare() = delete;
     copy_constructible_compare(key) {}
-    copy_constructible_compare(copy_constructible_compare const&) = default;
+    copy_constructible_compare(copy_constructible_compare const&)            = default;
     copy_constructible_compare& operator=(copy_constructible_compare const&) = delete;
 
     bool operator()(T const&, T const&) const noexcept {
@@ -121,8 +121,8 @@ struct faux_hash {
 
 template <typename T>
 struct default_constructible_hash {
-    default_constructible_hash()                                  = default;
-    default_constructible_hash(default_constructible_hash const&) = default;
+    default_constructible_hash()                                             = default;
+    default_constructible_hash(default_constructible_hash const&)            = default;
     default_constructible_hash& operator=(default_constructible_hash const&) = delete;
 
     bool operator()(T const&, T const&) const noexcept {
@@ -134,7 +134,7 @@ template <typename T>
 struct copy_constructible_hash {
     copy_constructible_hash() = delete;
     copy_constructible_hash(key) {}
-    copy_constructible_hash(copy_constructible_hash const&) = default;
+    copy_constructible_hash(copy_constructible_hash const&)            = default;
     copy_constructible_hash& operator=(copy_constructible_hash const&) = delete;
 
     std::size_t operator()(T const&) const noexcept {
@@ -160,8 +160,8 @@ struct input_iterator_base {
     typedef std::input_iterator_tag iterator_category;
     typedef std::ptrdiff_t difference_type;
 
-    input_iterator_base()                           = default;
-    input_iterator_base(input_iterator_base const&) = default;
+    input_iterator_base()                                      = default;
+    input_iterator_base(input_iterator_base const&)            = default;
     input_iterator_base& operator=(input_iterator_base const&) = default;
 
     I& operator++() {

--- a/tests/std/tests/Dev11_0535636_functional_overhaul/test.cpp
+++ b/tests/std/tests/Dev11_0535636_functional_overhaul/test.cpp
@@ -730,7 +730,7 @@ struct BaseMeow {
     BaseMeow() {}
     virtual ~BaseMeow() {}
 
-    BaseMeow(const BaseMeow&) = delete;
+    BaseMeow(const BaseMeow&)            = delete;
     BaseMeow& operator=(const BaseMeow&) = delete;
 
     virtual int operator()(int, int) = 0;
@@ -2245,10 +2245,10 @@ struct TestNotFn {
 
     constexpr explicit TestNotFn(const int x) : m_x(x) {}
 
-    TestNotFn(const TestNotFn&) = delete;
-    TestNotFn(TestNotFn&&)      = default;
+    TestNotFn(const TestNotFn&)            = delete;
+    TestNotFn(TestNotFn&&)                 = default;
     TestNotFn& operator=(const TestNotFn&) = delete;
-    TestNotFn& operator=(TestNotFn&&) = delete;
+    TestNotFn& operator=(TestNotFn&&)      = delete;
 
     constexpr bool operator()(const int i) & {
         return i < m_x + 100;
@@ -2270,10 +2270,10 @@ struct TestNotFn {
 struct EmptyTestNotFn {
     constexpr explicit EmptyTestNotFn(int) {}
 
-    EmptyTestNotFn(const EmptyTestNotFn&)      = delete;
-    constexpr EmptyTestNotFn(EmptyTestNotFn&&) = default;
+    EmptyTestNotFn(const EmptyTestNotFn&)            = delete;
+    constexpr EmptyTestNotFn(EmptyTestNotFn&&)       = default;
     EmptyTestNotFn& operator=(const EmptyTestNotFn&) = delete;
-    EmptyTestNotFn& operator=(EmptyTestNotFn&&) = delete;
+    EmptyTestNotFn& operator=(EmptyTestNotFn&&)      = delete;
 
     constexpr bool operator()(const int i) & {
         return i < 1500;

--- a/tests/std/tests/Dev11_0579795_inplace_merge_out_of_memory/test.cpp
+++ b/tests/std/tests/Dev11_0579795_inplace_merge_out_of_memory/test.cpp
@@ -113,8 +113,8 @@ void test_more() {
 
 struct int_ish {
     /* implicit */ int_ish(int init) : value(init) {}
-    int_ish(const int_ish&) = delete;
-    int_ish(int_ish&&)      = default;
+    int_ish(const int_ish&)            = delete;
+    int_ish(int_ish&&)                 = default;
     int_ish& operator=(const int_ish&) = delete;
 
     int_ish& operator=(int_ish&& rhs) {

--- a/tests/std/tests/Dev11_0579795_inplace_merge_out_of_memory/test.cpp
+++ b/tests/std/tests/Dev11_0579795_inplace_merge_out_of_memory/test.cpp
@@ -186,7 +186,7 @@ void test_stability() {
         const auto partitionPoint         = stable_partition(a.begin(), a.end(), [&](const int_ish& x) {
             ++predCalls;
             return x.value < 50;
-                });
+        });
         const array<int_ish, 100> correct = {
             {20, 13, 29, 28, 17, 44, 48, 26, 47, 43, 20, 19, 35, 42, 39, 18, 33, 26, 40, 16, 27, 11, 16, 28, 21, 30, 21,
                 37, 20, 41, 15, 42, 26, 47, 41, 46, 41, 58, 85, 91, 99, 64, 60, 86, 89, 51, 96, 66, 75, 65, 99, 80, 66,

--- a/tests/std/tests/Dev11_0863628_atomic_compare_exchange/test.cpp
+++ b/tests/std/tests/Dev11_0863628_atomic_compare_exchange/test.cpp
@@ -451,7 +451,7 @@ void test_compare_exchange_relaxed_memory_orders() {
 struct non_default_ctor_able {
     non_default_ctor_able() = delete;
     explicit non_default_ctor_able(int) {}
-    non_default_ctor_able(const non_default_ctor_able&) = default;
+    non_default_ctor_able(const non_default_ctor_able&)            = default;
     non_default_ctor_able& operator=(const non_default_ctor_able&) = default;
     ~non_default_ctor_able()                                       = default;
 };

--- a/tests/std/tests/Dev11_1066589_shared_ptr_atomic_deadlock/test.cpp
+++ b/tests/std/tests/Dev11_1066589_shared_ptr_atomic_deadlock/test.cpp
@@ -21,7 +21,7 @@ struct Noisy {
         (void) atomic_load(&g_sp);
     }
 
-    Noisy(const Noisy&) = delete;
+    Noisy(const Noisy&)            = delete;
     Noisy& operator=(const Noisy&) = delete;
 };
 

--- a/tests/std/tests/Dev11_1114006_condition_variable_pred/test.cpp
+++ b/tests/std/tests/Dev11_1114006_condition_variable_pred/test.cpp
@@ -21,10 +21,10 @@ struct Pred {
     // to ensure we don't copy them, because copying some functors (e.g. std::function) is comparatively
     // expensive, and even for relatively cheap to copy function objects we care (somewhat) about debug
     // mode perf.
-    Pred(const Pred&) = delete;
-    Pred(Pred&& o)    = default;
+    Pred(const Pred&)            = delete;
+    Pred(Pred&& o)               = default;
     Pred& operator=(const Pred&) = delete;
-    Pred& operator=(Pred&&) = delete;
+    Pred& operator=(Pred&&)      = delete;
 
     bool operator()() {
         switch (counter_) {

--- a/tests/std/tests/Dev11_1131212_uncaught_exceptions/test.cpp
+++ b/tests/std/tests/Dev11_1131212_uncaught_exceptions/test.cpp
@@ -29,7 +29,7 @@ public:
     }
 
 private:
-    check_uncaught_exceptions_count(check_uncaught_exceptions_count const&) = delete;
+    check_uncaught_exceptions_count(check_uncaught_exceptions_count const&)            = delete;
     check_uncaught_exceptions_count& operator=(check_uncaught_exceptions_count const&) = delete;
 
     int _remaining;

--- a/tests/std/tests/Dev11_1137366_nested_exception/test.cpp
+++ b/tests/std/tests/Dev11_1137366_nested_exception/test.cpp
@@ -46,7 +46,7 @@ struct AlreadyNested : nested_exception {};
 struct PolymorphicInt {
     explicit PolymorphicInt(const int n) : m_n(n) {}
 
-    PolymorphicInt(const PolymorphicInt&) = default;
+    PolymorphicInt(const PolymorphicInt&)            = default;
     PolymorphicInt& operator=(const PolymorphicInt&) = default;
     virtual ~PolymorphicInt()                        = default;
 

--- a/tests/std/tests/Dev11_1140665_unique_ptr_array_conversions/test.cpp
+++ b/tests/std/tests/Dev11_1140665_unique_ptr_array_conversions/test.cpp
@@ -20,7 +20,7 @@ struct X {
         --g_objects;
     }
 
-    X(const X&) = delete;
+    X(const X&)            = delete;
     X& operator=(const X&) = delete;
 };
 
@@ -120,8 +120,8 @@ namespace lwg_2905 {
         using T       = int;
         using pointer = int*;
         struct Immobile {
-            Immobile()                = default;
-            Immobile(Immobile const&) = delete;
+            Immobile()                           = default;
+            Immobile(Immobile const&)            = delete;
             Immobile& operator=(Immobile const&) = delete;
 
             void operator()(int*) const {}

--- a/tests/std/tests/GH_000431_copy_move_family/test.cpp
+++ b/tests/std/tests/GH_000431_copy_move_family/test.cpp
@@ -54,10 +54,10 @@ struct TriviallyMovableStruct {
     int i;
     TriviallyMovableStruct() {}
     TriviallyMovableStruct(int j) : i(j) {}
-    TriviallyMovableStruct(const TriviallyMovableStruct&) = delete;
-    TriviallyMovableStruct(TriviallyMovableStruct&&)      = default;
+    TriviallyMovableStruct(const TriviallyMovableStruct&)            = delete;
+    TriviallyMovableStruct(TriviallyMovableStruct&&)                 = default;
     TriviallyMovableStruct& operator=(const TriviallyMovableStruct&) = delete;
-    TriviallyMovableStruct& operator=(TriviallyMovableStruct&&) = default;
+    TriviallyMovableStruct& operator=(TriviallyMovableStruct&&)      = default;
 
     bool operator==(const TriviallyMovableStruct& right) const {
         return i == right.i;

--- a/tests/std/tests/GH_000431_iter_copy_move_cat/test.compile.pass.cpp
+++ b/tests/std/tests/GH_000431_iter_copy_move_cat/test.compile.pass.cpp
@@ -182,10 +182,10 @@ STATIC_ASSERT(!is_trivial_v<TriviallyCopyableStruct>);
 struct TriviallyMovableStruct {
     int i;
     TriviallyMovableStruct();
-    TriviallyMovableStruct(const TriviallyMovableStruct&) = delete;
-    TriviallyMovableStruct(TriviallyMovableStruct&&)      = default;
+    TriviallyMovableStruct(const TriviallyMovableStruct&)            = delete;
+    TriviallyMovableStruct(TriviallyMovableStruct&&)                 = default;
     TriviallyMovableStruct& operator=(const TriviallyMovableStruct&) = delete;
-    TriviallyMovableStruct& operator=(TriviallyMovableStruct&&) = default;
+    TriviallyMovableStruct& operator=(TriviallyMovableStruct&&)      = default;
 };
 STATIC_ASSERT(is_trivially_copyable_v<TriviallyMovableStruct>);
 STATIC_ASSERT(!is_trivial_v<TriviallyMovableStruct>);
@@ -213,7 +213,7 @@ struct TriviallyAssignableStruct {
     TriviallyAssignableStruct(TriviallyAssignableStruct&&);
 
     TriviallyAssignableStruct& operator=(const TriviallyAssignableStruct&) = default;
-    TriviallyAssignableStruct& operator=(TriviallyAssignableStruct&&) = default;
+    TriviallyAssignableStruct& operator=(TriviallyAssignableStruct&&)      = default;
 };
 STATIC_ASSERT(!is_trivially_copy_constructible_v<TriviallyAssignableStruct>);
 STATIC_ASSERT(!is_trivially_move_constructible_v<TriviallyAssignableStruct>);

--- a/tests/std/tests/GH_000545_include_compare/test_coroutine.cpp
+++ b/tests/std/tests/GH_000545_include_compare/test_coroutine.cpp
@@ -1,15 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include <version> // TRANSITION, Clang 14 coroutine support
-#ifdef __cpp_lib_coroutine // TRANSITION, Clang 14 coroutine support
-
 #include <coroutine>
 
 // Testing LWG-3330 "Include <compare> from most library headers" by intentionally NOT including <compare>
 
 static_assert(std::is_eq(std::partial_ordering::equivalent));
-
-#endif // TRANSITION, Clang 14 coroutine support
 
 void test_coroutine() {}

--- a/tests/std/tests/GH_000935_complex_numerical_accuracy/floating_point_utils.hpp
+++ b/tests/std/tests/GH_000935_complex_numerical_accuracy/floating_point_utils.hpp
@@ -99,7 +99,7 @@ namespace fputil {
             assert(result == 0);
         }
 
-        rounding_guard(const rounding_guard&) = delete;
+        rounding_guard(const rounding_guard&)            = delete;
         rounding_guard& operator=(const rounding_guard&) = delete;
 
     private:
@@ -118,7 +118,7 @@ namespace fputil {
 
         ~rounding_guard() = default;
 
-        rounding_guard(const rounding_guard&) = delete;
+        rounding_guard(const rounding_guard&)            = delete;
         rounding_guard& operator=(const rounding_guard&) = delete;
     };
 

--- a/tests/std/tests/GH_001086_partial_sort_copy/test.cpp
+++ b/tests/std/tests/GH_001086_partial_sort_copy/test.cpp
@@ -28,7 +28,7 @@ struct source : wrapper {
 
     using wrapper::wrapper;
 
-    source(const source&) = delete;
+    source(const source&)            = delete;
     source& operator=(const source&) = delete;
 };
 
@@ -37,7 +37,7 @@ struct target : wrapper {
 
     using wrapper::wrapper;
 
-    target(target&&) = default;
+    target(target&&)            = default;
     target& operator=(target&&) = default;
 
     target& operator=(const source& w) {

--- a/tests/std/tests/P0024R2_parallel_algorithms_exclusive_scan/test.cpp
+++ b/tests/std/tests/P0024R2_parallel_algorithms_exclusive_scan/test.cpp
@@ -111,14 +111,14 @@ void test_case_exclusive_scan_bop_parallel_associative_in_place(const size_t tes
 struct inputType {
     inputType() = delete;
     /* implicit */ inputType(int) {} // so that the test can make an array
-    inputType(const inputType&) = delete;
+    inputType(const inputType&)            = delete;
     inputType& operator=(const inputType&) = delete;
 };
 
 struct bopResult {
     bopResult() = delete;
     /* implicit */ bopResult(int) {}
-    bopResult(const bopResult&) = delete;
+    bopResult(const bopResult&)            = delete;
     bopResult& operator=(const bopResult&) = delete;
 };
 
@@ -127,10 +127,10 @@ struct intermediateType {
     explicit intermediateType(int) {} // so that the test can make one of these
     explicit intermediateType(inputType&) {} // Intermediate tmp(*first)
     explicit intermediateType(bopResult&&) {} // Intermediate tmp(binary_op((one of tmp, move(tmp), *first), *first))
-    intermediateType(const intermediateType&) = delete;
-    intermediateType(intermediateType&&)      = default; // tmp = move(tmp)
+    intermediateType(const intermediateType&)            = delete;
+    intermediateType(intermediateType&&)                 = default; // tmp = move(tmp)
     intermediateType& operator=(const intermediateType&) = delete;
-    intermediateType& operator=(intermediateType&&) = default; // for the exclusive versions only
+    intermediateType& operator=(intermediateType&&)      = default; // for the exclusive versions only
     // tmp = binary_op((one of tmp, move(tmp), *first), *first)
     intermediateType& operator=(bopResult&&) {
         return *this;
@@ -140,9 +140,9 @@ struct intermediateType {
 struct outputType {
     outputType() = delete;
     /* implicit */ outputType(int) {} // so that the test can make an array
-    outputType(const outputType&) = delete;
+    outputType(const outputType&)            = delete;
     outputType& operator=(const outputType&) = delete;
-    outputType& operator=(outputType&&) = delete;
+    outputType& operator=(outputType&&)      = delete;
 
     // in the first pass
     outputType& operator=(intermediateType&) {

--- a/tests/std/tests/P0024R2_parallel_algorithms_for_each/test.cpp
+++ b/tests/std/tests/P0024R2_parallel_algorithms_for_each/test.cpp
@@ -19,11 +19,11 @@ int g_forEachNCalls = 0;
 struct for_each_n_tester {
     int calledCount = 0;
 
-    for_each_n_tester()                         = default;
-    for_each_n_tester(const for_each_n_tester&) = delete;
-    for_each_n_tester(for_each_n_tester&&)      = default;
+    for_each_n_tester()                                    = default;
+    for_each_n_tester(const for_each_n_tester&)            = delete;
+    for_each_n_tester(for_each_n_tester&&)                 = default;
     for_each_n_tester& operator=(const for_each_n_tester&) = delete;
-    for_each_n_tester& operator=(for_each_n_tester&&) = delete;
+    for_each_n_tester& operator=(for_each_n_tester&&)      = delete;
 
     void operator()(const int x) {
         assert(calledCount == g_forEachNCalls);

--- a/tests/std/tests/P0024R2_parallel_algorithms_inclusive_scan/test.cpp
+++ b/tests/std/tests/P0024R2_parallel_algorithms_inclusive_scan/test.cpp
@@ -120,14 +120,14 @@ void test_case_inclusive_scan_bop_init_parallel_associative_in_place(const size_
 struct inputType {
     inputType() = delete;
     /* implicit */ inputType(int) {} // so that the test can make an array
-    inputType(const inputType&) = delete;
+    inputType(const inputType&)            = delete;
     inputType& operator=(const inputType&) = delete;
 };
 
 struct bopResult {
     bopResult() = delete;
     /* implicit */ bopResult(int) {}
-    bopResult(const bopResult&) = delete;
+    bopResult(const bopResult&)            = delete;
     bopResult& operator=(const bopResult&) = delete;
 };
 
@@ -136,10 +136,10 @@ struct intermediateType {
     explicit intermediateType(int) {} // so that the test can make one of these
     explicit intermediateType(inputType&) {} // Intermediate tmp(*first)
     explicit intermediateType(bopResult&&) {} // Intermediate tmp(binary_op((one of tmp, move(tmp), *first), *first))
-    intermediateType(const intermediateType&) = delete;
-    intermediateType(intermediateType&&)      = default; // tmp = move(tmp)
+    intermediateType(const intermediateType&)            = delete;
+    intermediateType(intermediateType&&)                 = default; // tmp = move(tmp)
     intermediateType& operator=(const intermediateType&) = delete;
-    intermediateType& operator=(intermediateType&&) = delete;
+    intermediateType& operator=(intermediateType&&)      = delete;
     // tmp = binary_op((one of tmp, move(tmp), *first), *first)
     intermediateType& operator=(bopResult&&) {
         return *this;
@@ -149,9 +149,9 @@ struct intermediateType {
 struct outputType {
     outputType() = delete;
     /* implicit */ outputType(int) {} // so that the test can make an array
-    outputType(const outputType&) = delete;
+    outputType(const outputType&)            = delete;
     outputType& operator=(const outputType&) = delete;
-    outputType& operator=(outputType&&) = delete;
+    outputType& operator=(outputType&&)      = delete;
 
     // in the first pass
     outputType& operator=(intermediateType&) {

--- a/tests/std/tests/P0024R2_parallel_algorithms_remove/test.cpp
+++ b/tests/std/tests/P0024R2_parallel_algorithms_remove/test.cpp
@@ -35,10 +35,10 @@ struct movable_uint {
 
     movable_uint() : value{} {}
     /* implicit */ movable_uint(unsigned int x) : value(x) {}
-    movable_uint(const movable_uint&) = delete;
-    movable_uint(movable_uint&&)      = default;
+    movable_uint(const movable_uint&)            = delete;
+    movable_uint(movable_uint&&)                 = default;
     movable_uint& operator=(const movable_uint&) = delete;
-    movable_uint& operator=(movable_uint&&) = default;
+    movable_uint& operator=(movable_uint&&)      = default;
 };
 
 const auto is_odd  = [](unsigned int i) { return (i & 0x1u) != 0; };

--- a/tests/std/tests/P0024R2_parallel_algorithms_transform_exclusive_scan/test.cpp
+++ b/tests/std/tests/P0024R2_parallel_algorithms_transform_exclusive_scan/test.cpp
@@ -93,21 +93,21 @@ void test_case_transform_exclusive_scan_bop_parallel_associative_in_place(const 
 struct inputType {
     inputType() = delete;
     /* implicit */ inputType(int) {} // so that the test can make an array
-    inputType(const inputType&) = delete;
+    inputType(const inputType&)            = delete;
     inputType& operator=(const inputType&) = delete;
 };
 
 struct transformedType {
     transformedType() = delete;
     /* implicit */ transformedType(int) {}
-    transformedType(const transformedType&) = delete;
+    transformedType(const transformedType&)            = delete;
     transformedType& operator=(const transformedType&) = delete;
 };
 
 struct bopResult {
     bopResult() = delete;
     /* implicit */ bopResult(int) {}
-    bopResult(const bopResult&) = delete;
+    bopResult(const bopResult&)            = delete;
     bopResult& operator=(const bopResult&) = delete;
 };
 
@@ -117,10 +117,10 @@ struct intermediateType {
     explicit intermediateType(transformedType&&) {} // Intermediate tmp(unary_op(*first))
     // Intermediate tmp(binary_op((one of tmp, move(tmp), unary_op(*first)), unary_op(*first)))
     explicit intermediateType(bopResult&&) {}
-    intermediateType(const intermediateType&) = delete;
-    intermediateType(intermediateType&&)      = default; // tmp = move(tmp)
+    intermediateType(const intermediateType&)            = delete;
+    intermediateType(intermediateType&&)                 = default; // tmp = move(tmp)
     intermediateType& operator=(const intermediateType&) = delete;
-    intermediateType& operator=(intermediateType&&) = default;
+    intermediateType& operator=(intermediateType&&)      = default;
     // tmp = binary_op((one of tmp, move(tmp), *first), *first)
     intermediateType& operator=(bopResult&&) {
         return *this;
@@ -130,9 +130,9 @@ struct intermediateType {
 struct outputType {
     outputType() = delete;
     /* implicit */ outputType(int) {} // so that the test can make an array
-    outputType(const outputType&) = delete;
+    outputType(const outputType&)            = delete;
     outputType& operator=(const outputType&) = delete;
-    outputType& operator=(outputType&&) = delete;
+    outputType& operator=(outputType&&)      = delete;
 
     // in the first pass
     outputType& operator=(intermediateType&) {

--- a/tests/std/tests/P0024R2_parallel_algorithms_transform_inclusive_scan/test.cpp
+++ b/tests/std/tests/P0024R2_parallel_algorithms_transform_inclusive_scan/test.cpp
@@ -117,21 +117,21 @@ void test_case_transform_inclusive_scan_init_parallel_associative_in_place(const
 struct inputType {
     inputType() = delete;
     /* implicit */ inputType(int) {} // so that the test can make an array
-    inputType(const inputType&) = delete;
+    inputType(const inputType&)            = delete;
     inputType& operator=(const inputType&) = delete;
 };
 
 struct transformedType {
     transformedType() = delete;
     /* implicit */ transformedType(int) {}
-    transformedType(const transformedType&) = delete;
+    transformedType(const transformedType&)            = delete;
     transformedType& operator=(const transformedType&) = delete;
 };
 
 struct bopResult {
     bopResult() = delete;
     /* implicit */ bopResult(int) {}
-    bopResult(const bopResult&) = delete;
+    bopResult(const bopResult&)            = delete;
     bopResult& operator=(const bopResult&) = delete;
 };
 
@@ -141,10 +141,10 @@ struct intermediateType {
     explicit intermediateType(transformedType&&) {} // Intermediate tmp(unary_op(*first))
     // Intermediate tmp(binary_op((one of tmp, move(tmp), unary_op(*first)), unary_op(*first)))
     explicit intermediateType(bopResult&&) {}
-    intermediateType(const intermediateType&) = delete;
-    intermediateType(intermediateType&&)      = default; // tmp = move(tmp)
+    intermediateType(const intermediateType&)            = delete;
+    intermediateType(intermediateType&&)                 = default; // tmp = move(tmp)
     intermediateType& operator=(const intermediateType&) = delete;
-    intermediateType& operator=(intermediateType&&) = delete;
+    intermediateType& operator=(intermediateType&&)      = delete;
     // tmp = binary_op((one of tmp, move(tmp), *first), *first)
     intermediateType& operator=(bopResult&&) {
         return *this;
@@ -154,9 +154,9 @@ struct intermediateType {
 struct outputType {
     outputType() = delete;
     /* implicit */ outputType(int) {} // so that the test can make an array
-    outputType(const outputType&) = delete;
+    outputType(const outputType&)            = delete;
     outputType& operator=(const outputType&) = delete;
-    outputType& operator=(outputType&&) = delete;
+    outputType& operator=(outputType&&)      = delete;
 
     // in the first pass
     outputType& operator=(intermediateType&) {

--- a/tests/std/tests/P0040R3_extending_memory_management_tools/test.cpp
+++ b/tests/std/tests/P0040R3_extending_memory_management_tools/test.cpp
@@ -173,7 +173,7 @@ struct alive_counter {
     alive_counter() {
         ++g_alive;
     }
-    alive_counter(const alive_counter&) = delete;
+    alive_counter(const alive_counter&)            = delete;
     alive_counter& operator=(const alive_counter&) = delete;
     ~alive_counter() {
         --g_alive;

--- a/tests/std/tests/P0053R7_cpp_synchronized_buffered_ostream/test.cpp
+++ b/tests/std/tests/P0053R7_cpp_synchronized_buffered_ostream/test.cpp
@@ -31,7 +31,7 @@ public:
 
     test_syncbuf(streambuf_type* strbuf, const Alloc& al) : Mybase(strbuf, al) {}
 
-    test_syncbuf(test_syncbuf&&) = default;
+    test_syncbuf(test_syncbuf&&)            = default;
     test_syncbuf& operator=(test_syncbuf&&) = default;
     ~test_syncbuf()                         = default;
 
@@ -42,7 +42,7 @@ public:
         return static_cast<size_type>(pptr() - pbase());
     }
 
-    test_syncbuf(const test_syncbuf&) = delete;
+    test_syncbuf(const test_syncbuf&)            = delete;
     test_syncbuf& operator=(const test_syncbuf&) = delete;
 };
 

--- a/tests/std/tests/P0088R3_variant/test.cpp
+++ b/tests/std/tests/P0088R3_variant/test.cpp
@@ -6582,8 +6582,8 @@ namespace msvc {
 
     template <class Fn>
     struct immobile_visitor : mobile_visitor<Fn> {
-        immobile_visitor()                        = default;
-        immobile_visitor(const immobile_visitor&) = delete;
+        immobile_visitor()                                   = default;
+        immobile_visitor(const immobile_visitor&)            = delete;
         immobile_visitor& operator=(const immobile_visitor&) = delete;
     };
 
@@ -6961,7 +6961,7 @@ namespace msvc {
 
         struct immobile_data : mobile_data {
             using mobile_data::mobile_data;
-            immobile_data(const immobile_data&) = delete;
+            immobile_data(const immobile_data&)            = delete;
             immobile_data& operator=(const immobile_data&) = delete;
         };
 

--- a/tests/std/tests/P0156R2_scoped_lock/test.cpp
+++ b/tests/std/tests/P0156R2_scoped_lock/test.cpp
@@ -108,7 +108,7 @@ public:
         cout << "Started thread " << this->t.get_id() << endl;
     }
 
-    logging_thread(logging_thread const&) = delete;
+    logging_thread(logging_thread const&)            = delete;
     logging_thread& operator=(logging_thread const&) = delete;
 
     ~logging_thread() {

--- a/tests/std/tests/P0218R1_filesystem/test.cpp
+++ b/tests/std/tests/P0218R1_filesystem/test.cpp
@@ -35,8 +35,8 @@ using namespace std::filesystem;
 
 constexpr wstring_view badPath = L"// ?? ?? ///// ?? ?? ? ////"sv;
 const path nonexistentPaths[]  = {
-    L"C:/This/Path/Should/Not/Exist"sv,
-    L"//this_path_does_not_exist_on_the_network_e9da301701f70ead24c65bd30f600d15/docs"sv,
+     L"C:/This/Path/Should/Not/Exist"sv,
+     L"//this_path_does_not_exist_on_the_network_e9da301701f70ead24c65bd30f600d15/docs"sv,
 };
 constexpr wstring_view longSuffix =
     LR"(really\long\path\longer\than\max_path\goes\here\and it just goes)"

--- a/tests/std/tests/P0220R1_optional/test.cpp
+++ b/tests/std/tests/P0220R1_optional/test.cpp
@@ -7367,9 +7367,9 @@ namespace msvc {
         struct nontrivial_copy {
             nontrivial_copy() = default;
             nontrivial_copy(const nontrivial_copy&) {}
-            nontrivial_copy(nontrivial_copy&&) = default;
+            nontrivial_copy(nontrivial_copy&&)                 = default;
             nontrivial_copy& operator=(const nontrivial_copy&) = default;
-            nontrivial_copy& operator=(nontrivial_copy&&) = default;
+            nontrivial_copy& operator=(nontrivial_copy&&)      = default;
         };
 
         const std::optional<nontrivial_copy> s;

--- a/tests/std/tests/P0220R1_polymorphic_memory_resources/test.cpp
+++ b/tests/std/tests/P0220R1_polymorphic_memory_resources/test.cpp
@@ -252,7 +252,7 @@ namespace {
             CHECK(allocations_.empty());
         }
 
-        recording_resource(recording_resource const&) = delete;
+        recording_resource(recording_resource const&)            = delete;
         recording_resource& operator=(recording_resource const&) = delete;
 
         void release() noexcept {
@@ -956,7 +956,7 @@ namespace {
                     ~S() {
                         destroy_ref = true;
                     }
-                    S(const S&) = delete;
+                    S(const S&)            = delete;
                     S& operator=(const S&) = delete;
                 };
                 std::pmr::polymorphic_allocator<S> a{};

--- a/tests/std/tests/P0220R1_searchers/test.cpp
+++ b/tests/std/tests/P0220R1_searchers/test.cpp
@@ -164,7 +164,7 @@ void test_case_searcher(const Args... args) {
 struct FancyHash {
     FancyHash() = delete;
     explicit FancyHash(int) {}
-    FancyHash(const FancyHash&) = default;
+    FancyHash(const FancyHash&)            = default;
     FancyHash& operator=(const FancyHash&) = delete;
 
     size_t operator()(const char c) const {
@@ -175,7 +175,7 @@ struct FancyHash {
 struct FancyEqual {
     FancyEqual() = delete;
     explicit FancyEqual(int) {}
-    FancyEqual(const FancyEqual&) = default;
+    FancyEqual(const FancyEqual&)            = default;
     FancyEqual& operator=(const FancyEqual&) = delete;
 
     bool operator()(const char lhs, const char rhs) const {

--- a/tests/std/tests/P0288R9_move_only_function/test.cpp
+++ b/tests/std/tests/P0288R9_move_only_function/test.cpp
@@ -363,7 +363,7 @@ void test_inplace_list() {
             }
         }
 
-        in_place_list_constructible(const in_place_list_constructible&) = delete;
+        in_place_list_constructible(const in_place_list_constructible&)            = delete;
         in_place_list_constructible& operator=(const in_place_list_constructible&) = delete;
 
         int operator()(int i) {

--- a/tests/std/tests/P0323R12_expected/test.cpp
+++ b/tests/std/tests/P0323R12_expected/test.cpp
@@ -229,7 +229,7 @@ namespace test_expected {
         constexpr bool should_be_noexcept = should_be_trivial || IsYes(nothrowCopyConstructible);
 
         struct payload_copy_constructor {
-            payload_copy_constructor()        = default;
+            payload_copy_constructor()                                           = default;
             payload_copy_constructor& operator=(const payload_copy_constructor&) = delete;
             constexpr payload_copy_constructor(const payload_copy_constructor&) noexcept(should_be_noexcept) //
                 requires(!should_be_trivial)
@@ -320,8 +320,8 @@ namespace test_expected {
         constexpr bool should_be_noexcept = should_be_trivial || IsYes(nothrowMoveConstructible);
 
         struct payload_move_constructor {
-            payload_move_constructor()                                = default;
-            payload_move_constructor(const payload_move_constructor&) = default;
+            payload_move_constructor()                                      = default;
+            payload_move_constructor(const payload_move_constructor&)       = default;
             payload_move_constructor& operator=(payload_move_constructor&&) = delete;
             constexpr payload_move_constructor(payload_move_constructor&&) noexcept(should_be_noexcept) //
                 requires(!should_be_trivial)

--- a/tests/std/tests/P0325R4_to_array/test.cpp
+++ b/tests/std/tests/P0325R4_to_array/test.cpp
@@ -16,10 +16,7 @@ using namespace std;
 template <class T, class E, size_t N>
 constexpr void assert_equal(T&& actual, const array<E, N>& expected) {
     STATIC_ASSERT(is_same_v<T, array<E, N>>);
-    // TRANSITION, P1023R0 "constexpr comparison operators for std::array"
-    for (auto it1 = cbegin(actual), it2 = cbegin(expected); it1 != cend(actual); ++it1, ++it2) {
-        assert(*it1 == *it2);
-    }
+    assert(actual == expected);
 }
 
 struct A {

--- a/tests/std/tests/P0414R2_shared_ptr_for_arrays/test.cpp
+++ b/tests/std/tests/P0414R2_shared_ptr_for_arrays/test.cpp
@@ -907,7 +907,7 @@ struct BaseX {
     BaseX()          = default;
     virtual ~BaseX() = default;
 
-    BaseX(const BaseX&) = delete;
+    BaseX(const BaseX&)            = delete;
     BaseX& operator=(const BaseX&) = delete;
 };
 
@@ -917,7 +917,7 @@ struct BaseY {
     BaseY()          = default;
     virtual ~BaseY() = default;
 
-    BaseY(const BaseY&) = delete;
+    BaseY(const BaseY&)            = delete;
     BaseY& operator=(const BaseY&) = delete;
 };
 

--- a/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
@@ -74,7 +74,7 @@ struct move_only_back_inserter {
     move_only_back_inserter() = default;
     explicit move_only_back_inserter(basic_string<charT>& str) : it{str} {}
 
-    move_only_back_inserter(const move_only_back_inserter&) = delete;
+    move_only_back_inserter(const move_only_back_inserter&)            = delete;
     move_only_back_inserter& operator=(const move_only_back_inserter&) = delete;
 
     move_only_back_inserter(move_only_back_inserter&& other) : it(other.it) {

--- a/tests/std/tests/P0660R10_stop_token/test.cpp
+++ b/tests/std/tests/P0660R10_stop_token/test.cpp
@@ -34,7 +34,7 @@ struct call_counting_functor {
 
     call_counting_functor(atomic<int>* state_) : state(state_) {}
 
-    call_counting_functor(const call_counting_functor&) = delete;
+    call_counting_functor(const call_counting_functor&)            = delete;
     call_counting_functor& operator=(const call_counting_functor&) = delete;
 
     void operator()() && {
@@ -46,7 +46,7 @@ struct cb_destroying_functor {
     optional<stop_callback<cb_destroying_functor>>& owner;
     cb_destroying_functor(optional<stop_callback<cb_destroying_functor>>& owner_) : owner(owner_) {}
 
-    cb_destroying_functor(const cb_destroying_functor&) = delete;
+    cb_destroying_functor(const cb_destroying_functor&)            = delete;
     cb_destroying_functor& operator=(const cb_destroying_functor&) = delete;
 
     void operator()() && {

--- a/tests/std/tests/P0674R1_make_shared_for_arrays/test.cpp
+++ b/tests/std/tests/P0674R1_make_shared_for_arrays/test.cpp
@@ -312,7 +312,7 @@ struct ConstructConstrainingAllocator {
     ConstructConstrainingAllocator() = default;
     template <class Other>
     ConstructConstrainingAllocator(const ConstructConstrainingAllocator<Other, ConstructAssert>&) {}
-    ConstructConstrainingAllocator(const ConstructConstrainingAllocator&) = default;
+    ConstructConstrainingAllocator(const ConstructConstrainingAllocator&)            = default;
     ConstructConstrainingAllocator& operator=(const ConstructConstrainingAllocator&) = delete;
 
     T* allocate(size_t n) {

--- a/tests/std/tests/P0718R2_atomic_smart_ptrs/test.cpp
+++ b/tests/std/tests/P0718R2_atomic_smart_ptrs/test.cpp
@@ -576,11 +576,9 @@ void ensure_member_calls_compile() {
     }
 }
 
-#ifndef __EDG__ // TRANSITION, DevCom-1656924
 // LWG-3661: constinit atomic<shared_ptr<T>> a(nullptr); should work
 constinit atomic<shared_ptr<bool>> a{};
 constinit atomic<shared_ptr<bool>> b{nullptr};
-#endif // __EDG__
 
 int main() {
     // These values for is_always_lock_free are not required by the standard, but they are true for our implementation.

--- a/tests/std/tests/P0769R2_shift_left_shift_right/test.cpp
+++ b/tests/std/tests/P0769R2_shift_left_shift_right/test.cpp
@@ -21,7 +21,7 @@ struct MoveOnly {
     MoveOnly(MoveOnly&&)      = default;
 
     MoveOnly& operator=(const MoveOnly&) = delete;
-    MoveOnly& operator=(MoveOnly&&) = default;
+    MoveOnly& operator=(MoveOnly&&)      = default;
 
     MoveOnly& operator=(const ptrdiff_t x) {
         value = x;

--- a/tests/std/tests/P0784R7_library_machinery/test.cpp
+++ b/tests/std/tests/P0784R7_library_machinery/test.cpp
@@ -23,7 +23,7 @@ struct int_wrapper_copy {
         return *this;
     }
 
-    int_wrapper_copy(int_wrapper_copy&&) = delete;
+    int_wrapper_copy(int_wrapper_copy&&)            = delete;
     int_wrapper_copy& operator=(int_wrapper_copy&&) = delete;
 
     constexpr bool operator==(const int_wrapper_copy&) const = default;
@@ -35,7 +35,7 @@ struct int_wrapper_move {
     constexpr int_wrapper_move() = default;
     constexpr int_wrapper_move(const int v) : _val(v) {}
 
-    int_wrapper_move(const int_wrapper_move&) = delete;
+    int_wrapper_move(const int_wrapper_move&)            = delete;
     int_wrapper_move& operator=(const int_wrapper_move&) = delete;
 
     constexpr int_wrapper_move(int_wrapper_move&& other) : _val(exchange(other._val, -1)) {}

--- a/tests/std/tests/P0798R8_monadic_operations_for_std_optional/test.cpp
+++ b/tests/std/tests/P0798R8_monadic_operations_for_std_optional/test.cpp
@@ -10,10 +10,10 @@ using namespace std;
 
 struct Immovable {
     constexpr Immovable(int x) : v(x) {}
-    Immovable(const Immovable&) = delete;
-    Immovable(Immovable&&)      = delete;
+    Immovable(const Immovable&)            = delete;
+    Immovable(Immovable&&)                 = delete;
     Immovable& operator=(const Immovable&) = delete;
-    Immovable& operator=(Immovable&&) = delete;
+    Immovable& operator=(Immovable&&)      = delete;
     constexpr ~Immovable() {}
 
     int v;

--- a/tests/std/tests/P0811R3_midpoint_lerp/test.cpp
+++ b/tests/std/tests/P0811R3_midpoint_lerp/test.cpp
@@ -48,7 +48,7 @@ public:
         checked_fesetround(newRound);
     }
 
-    RoundGuard(const RoundGuard&) = delete;
+    RoundGuard(const RoundGuard&)            = delete;
     RoundGuard& operator=(const RoundGuard&) = delete;
 
     ~RoundGuard() {
@@ -75,7 +75,7 @@ public:
         checked_feholdexcept(&env);
     }
 
-    ExceptGuard(const ExceptGuard&) = delete;
+    ExceptGuard(const ExceptGuard&)            = delete;
     ExceptGuard& operator=(const ExceptGuard&) = delete;
 
     ~ExceptGuard() {
@@ -94,7 +94,7 @@ class ExceptGuard {
 public:
     ExceptGuard() {}
 
-    ExceptGuard(const ExceptGuard&) = delete;
+    ExceptGuard(const ExceptGuard&)            = delete;
     ExceptGuard& operator=(const ExceptGuard&) = delete;
 
     ~ExceptGuard() {}

--- a/tests/std/tests/P0896R4_P1614R2_comparisons/test.cpp
+++ b/tests/std/tests/P0896R4_P1614R2_comparisons/test.cpp
@@ -79,8 +79,8 @@ STATIC_ASSERT(is_trivially_constexpr<ranges::greater_equal>());
 // Validate three_way_comparable
 template <int I, class Category>
 struct three_way_archetype {
-    three_way_archetype()                           = delete;
-    three_way_archetype(three_way_archetype const&) = delete;
+    three_way_archetype()                                      = delete;
+    three_way_archetype(three_way_archetype const&)            = delete;
     three_way_archetype& operator=(three_way_archetype const&) = delete;
     ~three_way_archetype()                                     = delete;
     // clang-format off
@@ -500,7 +500,7 @@ constexpr void ordering_test_cases() {
 
         constexpr explicit partially_ordered_class(int x) noexcept : i{x} {}
 
-        partially_ordered_class(partially_ordered_class const&) = delete;
+        partially_ordered_class(partially_ordered_class const&)            = delete;
         partially_ordered_class& operator=(partially_ordered_class const&) = delete;
 
         constexpr bool operator==(partially_ordered_class const& that) const {
@@ -523,7 +523,7 @@ constexpr void ordering_test_cases() {
 
         constexpr explicit weakly_ordered_class(int x) noexcept : i{x} {}
 
-        weakly_ordered_class(weakly_ordered_class const&) = delete;
+        weakly_ordered_class(weakly_ordered_class const&)            = delete;
         weakly_ordered_class& operator=(weakly_ordered_class const&) = delete;
 
         constexpr bool operator==(weakly_ordered_class const& that) const {
@@ -538,7 +538,7 @@ constexpr void ordering_test_cases() {
 
         constexpr explicit strongly_ordered_class(int x) noexcept : i{x} {}
 
-        strongly_ordered_class(strongly_ordered_class const&) = delete;
+        strongly_ordered_class(strongly_ordered_class const&)            = delete;
         strongly_ordered_class& operator=(strongly_ordered_class const&) = delete;
 
         auto operator<=>(strongly_ordered_class const&) const = default;
@@ -556,7 +556,7 @@ constexpr void ordering_test_cases() {
 
         constexpr explicit equality_comparable_class(int x) noexcept : i{x} {}
 
-        equality_comparable_class(equality_comparable_class const&) = delete;
+        equality_comparable_class(equality_comparable_class const&)            = delete;
         equality_comparable_class& operator=(equality_comparable_class const&) = delete;
 
         constexpr boolish operator==(equality_comparable_class const& that) const {

--- a/tests/std/tests/P0896R4_ranges_alg_merge/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_merge/test.cpp
@@ -30,7 +30,7 @@ struct instantiator {
     static constexpr P elements1[] = {{0, 10}, {0, 11}, {0, 12}, {1, 10}, {1, 11}, {3, 10}};
     static constexpr P elements2[] = {{13, 0}, {14, 0}, {10, 2}, {11, 3}, {12, 3}};
     static constexpr P expected[]  = {
-        {0, 10}, {0, 11}, {0, 12}, {13, 0}, {14, 0}, {1, 10}, {1, 11}, {10, 2}, {3, 10}, {11, 3}, {12, 3}};
+         {0, 10}, {0, 11}, {0, 12}, {13, 0}, {14, 0}, {1, 10}, {1, 11}, {10, 2}, {3, 10}, {11, 3}, {12, 3}};
 
     static constexpr auto counting_compare(size_t& counter) {
         return [&counter](auto&& x, auto&& y) {

--- a/tests/std/tests/P0896R4_ranges_alg_minmax/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_minmax/test.cpp
@@ -351,7 +351,7 @@ void test_gh_1893() {
           [&projection_count](const auto& x) -> decltype(auto) {
             ++projection_count;
             return x.get();
-          });
+        });
     (void) clamped;
 #ifdef _DEBUG
     ASSERT(projection_count == 5);

--- a/tests/std/tests/P0896R4_ranges_alg_move_backward/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_move_backward/test.cpp
@@ -95,7 +95,7 @@ constexpr void test_memmove() {
 
         constexpr S() = default;
         constexpr S(int x) : val{x} {}
-        constexpr S(S&&)     = default;
+        constexpr S(S&&)                 = default;
         constexpr S& operator=(S&&)      = default;
         auto operator<=>(const S&) const = default;
     };

--- a/tests/std/tests/P0896R4_ranges_alg_uninitialized_default_construct/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_uninitialized_default_construct/test.cpp
@@ -53,17 +53,11 @@ struct holder {
     }
 };
 
-template <class R>
-void not_ranges_destroy(R&& r) { // TRANSITION, ranges::destroy
-    for (auto& e : r) {
-        destroy_at(&e);
-    }
-}
-
 struct instantiator {
     template <ranges::forward_range Write>
     static void call() {
-        using ranges::uninitialized_default_construct, ranges::equal, ranges::equal_to, ranges::iterator_t;
+        using ranges::uninitialized_default_construct, ranges::destroy, ranges::equal, ranges::equal_to,
+            ranges::iterator_t;
 
         { // Validate range overload
             holder<int_wrapper, 3> mem;
@@ -74,7 +68,7 @@ struct instantiator {
             assert(int_wrapper::constructions == 3);
             assert(int_wrapper::destructions == 0);
             assert(result == wrapped_input.end());
-            not_ranges_destroy(wrapped_input);
+            destroy(wrapped_input);
             assert(int_wrapper::constructions == 3);
             assert(int_wrapper::destructions == 3);
         }
@@ -89,7 +83,7 @@ struct instantiator {
             assert(int_wrapper::constructions == 3);
             assert(int_wrapper::destructions == 0);
             assert(result == wrapped_input.end());
-            not_ranges_destroy(wrapped_input);
+            destroy(wrapped_input);
             assert(int_wrapper::constructions == 3);
             assert(int_wrapper::destructions == 3);
         }

--- a/tests/std/tests/P0896R4_ranges_alg_uninitialized_default_construct_n/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_uninitialized_default_construct_n/test.cpp
@@ -49,17 +49,11 @@ struct holder {
     }
 };
 
-template <class R>
-void not_ranges_destroy(R&& r) { // TRANSITION, ranges::destroy
-    for (auto& e : r) {
-        destroy_at(&e);
-    }
-}
-
 struct instantiator {
     template <ranges::forward_range Write>
     static void call() {
-        using ranges::uninitialized_default_construct_n, ranges::equal, ranges::equal_to, ranges::iterator_t;
+        using ranges::uninitialized_default_construct_n, ranges::destroy, ranges::equal, ranges::equal_to,
+            ranges::iterator_t;
 
         holder<int_wrapper, 3> mem;
         Write wrapped_input{mem.as_span()};
@@ -69,7 +63,7 @@ struct instantiator {
         assert(int_wrapper::constructions == 3);
         assert(int_wrapper::destructions == 0);
         assert(result == wrapped_input.end());
-        not_ranges_destroy(wrapped_input);
+        destroy(wrapped_input);
         assert(int_wrapper::constructions == 3);
         assert(int_wrapper::destructions == 3);
     }

--- a/tests/std/tests/P0896R4_ranges_alg_uninitialized_fill/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_uninitialized_fill/test.cpp
@@ -56,19 +56,12 @@ struct holder {
     }
 };
 
-template <class R>
-void not_ranges_destroy(R&& r) { // TRANSITION, ranges::destroy
-    for (auto& e : r) {
-        destroy_at(&e);
-    }
-}
-
 struct instantiator {
     static constexpr int expected[3] = {42, 42, 42};
 
     template <ranges::forward_range Write>
     static void call() {
-        using ranges::uninitialized_fill, ranges::equal, ranges::equal_to, ranges::iterator_t;
+        using ranges::uninitialized_fill, ranges::destroy, ranges::equal, ranges::equal_to, ranges::iterator_t;
 
         { // Validate range overload
             holder<int_wrapper, 3> mem;
@@ -80,7 +73,7 @@ struct instantiator {
             assert(int_wrapper::destructions == 0);
             assert(result == wrapped_input.end());
             assert(equal(wrapped_input, expected, equal_to{}, &int_wrapper::val));
-            not_ranges_destroy(wrapped_input);
+            destroy(wrapped_input);
             assert(int_wrapper::constructions == 3);
             assert(int_wrapper::destructions == 3);
         }
@@ -96,7 +89,7 @@ struct instantiator {
             assert(int_wrapper::destructions == 0);
             assert(result == wrapped_input.end());
             assert(equal(wrapped_input, expected, equal_to{}, &int_wrapper::val));
-            not_ranges_destroy(wrapped_input);
+            destroy(wrapped_input);
             assert(int_wrapper::constructions == 3);
             assert(int_wrapper::destructions == 3);
         }

--- a/tests/std/tests/P0896R4_ranges_alg_uninitialized_fill_n/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_uninitialized_fill_n/test.cpp
@@ -52,19 +52,12 @@ struct holder {
     }
 };
 
-template <class R>
-void not_ranges_destroy(R&& r) { // TRANSITION, ranges::destroy
-    for (auto& e : r) {
-        destroy_at(&e);
-    }
-}
-
 struct instantiator {
     static constexpr int expected[3] = {42, 42, 42};
 
     template <ranges::forward_range Write>
     static void call() {
-        using ranges::uninitialized_fill_n, ranges::equal, ranges::equal_to, ranges::iterator_t;
+        using ranges::uninitialized_fill_n, ranges::destroy, ranges::equal, ranges::equal_to, ranges::iterator_t;
 
         {
             holder<int_wrapper, 3> mem;
@@ -76,7 +69,7 @@ struct instantiator {
             assert(int_wrapper::destructions == 0);
             assert(result == wrapped_input.end());
             assert(equal(wrapped_input, expected, equal_to{}, &int_wrapper::val));
-            not_ranges_destroy(wrapped_input);
+            destroy(wrapped_input);
             assert(int_wrapper::constructions == 3);
             assert(int_wrapper::destructions == 3);
         }

--- a/tests/std/tests/P0896R4_ranges_alg_uninitialized_value_construct/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_uninitialized_value_construct/test.cpp
@@ -53,19 +53,13 @@ struct holder {
     }
 };
 
-template <class R>
-void not_ranges_destroy(R&& r) { // TRANSITION, ranges::destroy
-    for (auto& e : r) {
-        destroy_at(&e);
-    }
-}
-
 struct instantiator {
     static constexpr int expected[3] = {10, 10, 10};
 
     template <ranges::forward_range Write>
     static void call() {
-        using ranges::uninitialized_value_construct, ranges::equal, ranges::equal_to, ranges::iterator_t;
+        using ranges::uninitialized_value_construct, ranges::destroy, ranges::equal, ranges::equal_to,
+            ranges::iterator_t;
 
         { // Validate range overload
             holder<int_wrapper, 3> mem;
@@ -77,7 +71,7 @@ struct instantiator {
             assert(int_wrapper::destructions == 0);
             assert(result == wrapped_input.end());
             assert(equal(wrapped_input, expected, equal_to{}, &int_wrapper::val));
-            not_ranges_destroy(wrapped_input);
+            destroy(wrapped_input);
             assert(int_wrapper::constructions == 3);
             assert(int_wrapper::destructions == 3);
         }
@@ -93,7 +87,7 @@ struct instantiator {
             assert(int_wrapper::destructions == 0);
             assert(result == wrapped_input.end());
             assert(equal(wrapped_input, expected, equal_to{}, &int_wrapper::val));
-            not_ranges_destroy(wrapped_input);
+            destroy(wrapped_input);
             assert(int_wrapper::constructions == 3);
             assert(int_wrapper::destructions == 3);
         }

--- a/tests/std/tests/P0896R4_ranges_alg_uninitialized_value_construct_n/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_uninitialized_value_construct_n/test.cpp
@@ -49,19 +49,13 @@ struct holder {
     }
 };
 
-template <class R>
-void not_ranges_destroy(R&& r) { // TRANSITION, ranges::destroy
-    for (auto& e : r) {
-        destroy_at(&e);
-    }
-}
-
 struct instantiator {
     static constexpr int expected[3] = {10, 10, 10};
 
     template <ranges::forward_range Write>
     static void call() {
-        using ranges::uninitialized_value_construct_n, ranges::equal, ranges::equal_to, ranges::iterator_t;
+        using ranges::uninitialized_value_construct_n, ranges::destroy, ranges::equal, ranges::equal_to,
+            ranges::iterator_t;
 
         { // Validate iterator overload
             holder<int_wrapper, 3> mem;
@@ -73,7 +67,7 @@ struct instantiator {
             assert(int_wrapper::destructions == 0);
             assert(result == wrapped_input.end());
             assert(equal(wrapped_input, expected, equal_to{}, &int_wrapper::val));
-            not_ranges_destroy(wrapped_input);
+            destroy(wrapped_input);
             assert(int_wrapper::constructions == 3);
             assert(int_wrapper::destructions == 3);
         }

--- a/tests/std/tests/P0896R4_ranges_algorithm_machinery/test.compile.pass.cpp
+++ b/tests/std/tests/P0896R4_ranges_algorithm_machinery/test.compile.pass.cpp
@@ -719,8 +719,8 @@ namespace permutable_test {
         using difference_type = int;
 
         struct proxy {
-            proxy()             = default;
-            proxy(proxy const&) = delete;
+            proxy()                        = default;
+            proxy(proxy const&)            = delete;
             proxy& operator=(proxy const&) = delete;
 
             operator int() const;

--- a/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
@@ -1072,7 +1072,7 @@ namespace iterator_cust_move_test {
 #if defined(__clang__) || defined(__EDG__) // TRANSITION, VSO-1008447
     STATIC_ASSERT(same_as<iter_rvalue_reference_t<int (*)(int)>, int (&)(int)>);
 #else // ^^^ no workaround / workaround vvv
-    STATIC_ASSERT(same_as<iter_rvalue_reference_t<int (*)(int)>, int(&&)(int)>);
+    STATIC_ASSERT(same_as<iter_rvalue_reference_t<int (*)(int)>, int (&&)(int)>);
 #endif // TRANSITION, VSO-1008447
     STATIC_ASSERT(ranges::iter_move (&f)(42) == 43);
     STATIC_ASSERT(noexcept(ranges::iter_move(&f)));

--- a/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
@@ -67,8 +67,8 @@ struct empty_type {
 };
 
 struct move_only {
-    move_only()            = default;
-    move_only(move_only&&) = default;
+    move_only()                       = default;
+    move_only(move_only&&)            = default;
     move_only& operator=(move_only&&) = default;
 };
 
@@ -3215,11 +3215,11 @@ namespace move_iterator_test {
             }
         };
 
-        input_iter()                                   = default;
-        input_iter(input_iter const&) requires CanCopy = default;
-        input_iter(input_iter&&)                       = default;
+        input_iter()                                              = default;
+        input_iter(input_iter const&) requires CanCopy            = default;
+        input_iter(input_iter&&)                                  = default;
         input_iter& operator=(input_iter const&) requires CanCopy = default;
-        input_iter& operator=(input_iter&&) = default;
+        input_iter& operator=(input_iter&&)                       = default;
 
         reference operator*() const;
         input_iter& operator++();
@@ -3338,8 +3338,8 @@ namespace move_iterator_test {
         typename move_sentinel<T>;
     };
     struct moveonly {
-        moveonly()           = default;
-        moveonly(moveonly&&) = default;
+        moveonly()                      = default;
+        moveonly(moveonly&&)            = default;
         moveonly& operator=(moveonly&&) = default;
     };
     STATIC_ASSERT(!CanMoveSentinel<void>);

--- a/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
@@ -1131,7 +1131,7 @@ namespace iterator_cust_swap_test {
         void iter_swap(T, U) = delete;
 
         template <class T, class U = T>
-        concept bullet1 = requires(T && t, U && u) {
+        concept bullet1 = requires(T&& t, U&& u) {
             iter_swap(std::forward<T>(t), std::forward<U>(u));
         };
     } // namespace adl_barrier

--- a/tests/std/tests/P0896R4_ranges_range_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_range_machinery/test.cpp
@@ -1543,8 +1543,8 @@ namespace borrowed_range_testing {
 
 template <bool AllowNonConst, bool AllowConst, bool AllowSize>
 struct arbitrary_range {
-    arbitrary_range()                  = default;
-    arbitrary_range(arbitrary_range&&) = default;
+    arbitrary_range()                             = default;
+    arbitrary_range(arbitrary_range&&)            = default;
     arbitrary_range& operator=(arbitrary_range&&) = default;
 
     int* begin() requires AllowNonConst;
@@ -1565,8 +1565,8 @@ using immutable_sized_range      = arbitrary_range<false, true, true>;
 
 template <class Base>
 struct badsized_range : Base { // size() launches the missiles.
-    badsized_range()                 = default;
-    badsized_range(badsized_range&&) = default;
+    badsized_range()                            = default;
+    badsized_range(badsized_range&&)            = default;
     badsized_range& operator=(badsized_range&&) = default;
 
     [[noreturn]] int size() const {
@@ -1587,8 +1587,8 @@ constexpr bool ranges::disable_sized_range<badsized_range<T>> = true;
 
 // "strange" in that const-ness affects the iterator type
 struct strange_view {
-    strange_view()               = default;
-    strange_view(strange_view&&) = default;
+    strange_view()                          = default;
+    strange_view(strange_view&&)            = default;
     strange_view& operator=(strange_view&&) = default;
 
     int* begin();

--- a/tests/std/tests/P0896R4_ranges_subrange/test.compile.pass.cpp
+++ b/tests/std/tests/P0896R4_ranges_subrange/test.compile.pass.cpp
@@ -1079,7 +1079,7 @@ namespace test_subrange {
             iterator() = default;
             iterator(iterator<!IsConst>) requires IsConst;
 
-            iterator(iterator&&) = default;
+            iterator(iterator&&)            = default;
             iterator& operator=(iterator&&) = default;
 
             int operator*() const;

--- a/tests/std/tests/P0896R4_views_counted/test.cpp
+++ b/tests/std/tests/P0896R4_views_counted/test.cpp
@@ -24,7 +24,7 @@ struct convertible_difference {
     constexpr operator iter_difference_t<Iter>() const noexcept {
         return iter_difference_t<Iter>{_val};
     }
-    convertible_difference(convertible_difference&&) = delete;
+    convertible_difference(convertible_difference&&)            = delete;
     convertible_difference& operator=(convertible_difference&&) = delete;
 
     int _val = 0;

--- a/tests/std/tests/P0896R4_views_join/test.cpp
+++ b/tests/std/tests/P0896R4_views_join/test.cpp
@@ -560,33 +560,25 @@ int main() {
     { // P2328 range of prvalue vector using global function
         static constexpr int result[] = {1, 2, 3, 4, 5};
         assert(ranges::equal(views::iota(0, 5) | views::transform(ToVector) | views::join, result));
-#if defined(__clang__) || defined(__EDG__) // TRANSITION, VSO-934264
         static_assert(ranges::equal(views::iota(0, 5) | views::transform(ToVector) | views::join, result));
-#endif // not MSVC
     }
 
     { // P2328 range of prvalue vector using lambda
         static constexpr int result[] = {1, 2, 3, 4, 5};
-        auto ToVectorLambda           = [](const int i) { return vector{i + 1}; };
+        constexpr auto ToVectorLambda = [](const int i) { return vector{i + 1}; };
         assert(ranges::equal(views::iota(0, 5) | views::transform(ToVectorLambda) | views::join, result));
-#if defined(__clang__) || defined(__EDG__) // TRANSITION, VSO-934264
         static_assert(ranges::equal(views::iota(0, 5) | views::transform(ToVectorLambda) | views::join, result));
-#endif // not MSVC
     }
 
     { // P2328 range of prvalue string using global function
         assert(ranges::equal(views::iota(0u, 5u) | views::transform(ToString) | views::join, expected));
-#if defined(__clang__) || defined(__EDG__) // TRANSITION, VSO-934264
         static_assert(ranges::equal(views::iota(0u, 5u) | views::transform(ToString) | views::join, expected));
-#endif // not MSVC
     }
 
     { // P2328 range of prvalue string using lambda
-        auto ToStringLambda = [](const size_t i) { return string{prvalue_input[i]}; };
+        constexpr auto ToStringLambda = [](const size_t i) { return string{prvalue_input[i]}; };
         assert(ranges::equal(views::iota(0u, 5u) | views::transform(ToStringLambda) | views::join, expected));
-#if defined(__clang__) || defined(__EDG__) // TRANSITION, VSO-934264
         static_assert(ranges::equal(views::iota(0u, 5u) | views::transform(ToStringLambda) | views::join, expected));
-#endif // not MSVC
     }
 
     { // Immovable type

--- a/tests/std/tests/P0896R4_views_join/test.cpp
+++ b/tests/std/tests/P0896R4_views_join/test.cpp
@@ -466,11 +466,11 @@ constexpr auto ToString(const size_t val) {
 }
 
 struct Immovable {
-    Immovable()                 = default;
-    Immovable(const Immovable&) = delete;
-    Immovable(Immovable&&)      = delete;
+    Immovable()                            = default;
+    Immovable(const Immovable&)            = delete;
+    Immovable(Immovable&&)                 = delete;
     Immovable& operator=(const Immovable&) = delete;
-    Immovable& operator=(Immovable&&) = delete;
+    Immovable& operator=(Immovable&&)      = delete;
 };
 
 // Validate that the _Defaultabox primary template works when fed with a non-trivially-destructible type

--- a/tests/std/tests/P0896R4_views_lazy_split/test.cpp
+++ b/tests/std/tests/P0896R4_views_lazy_split/test.cpp
@@ -319,15 +319,13 @@ constexpr bool instantiation_test() {
     // 3. Commonality
     // 4. Length of delimiter pattern (0/static 1/dynamic) [covered in instantiator::call]
 
-    if (!is_constant_evaluated()) { // TRANSITION, P2231R1
-        instantiator::call<test_range<input_iterator_tag, Common::no, CanView::no, Copyability::immobile>>();
-        instantiator::call<test_range<input_iterator_tag, Common::no, CanView::yes, Copyability::move_only>>();
-        instantiator::call<test_range<input_iterator_tag, Common::no, CanView::yes, Copyability::copyable>>();
+    instantiator::call<test_range<input_iterator_tag, Common::no, CanView::no, Copyability::immobile>>();
+    instantiator::call<test_range<input_iterator_tag, Common::no, CanView::yes, Copyability::move_only>>();
+    instantiator::call<test_range<input_iterator_tag, Common::no, CanView::yes, Copyability::copyable>>();
 
-        instantiator::call<test_range<input_iterator_tag, Common::yes, CanView::no, Copyability::immobile>>();
-        instantiator::call<test_range<input_iterator_tag, Common::yes, CanView::yes, Copyability::move_only>>();
-        instantiator::call<test_range<input_iterator_tag, Common::yes, CanView::yes, Copyability::copyable>>();
-    }
+    instantiator::call<test_range<input_iterator_tag, Common::yes, CanView::no, Copyability::immobile>>();
+    instantiator::call<test_range<input_iterator_tag, Common::yes, CanView::yes, Copyability::move_only>>();
+    instantiator::call<test_range<input_iterator_tag, Common::yes, CanView::yes, Copyability::copyable>>();
 
     instantiator::call<test_range<forward_iterator_tag, Common::no, CanView::no, Copyability::immobile>>();
     instantiator::call<test_range<forward_iterator_tag, Common::no, CanView::yes, Copyability::move_only>>();

--- a/tests/std/tests/P0896R4_views_lazy_split/test.cpp
+++ b/tests/std/tests/P0896R4_views_lazy_split/test.cpp
@@ -254,8 +254,8 @@ struct instantiator {
         "This"sv, "is"sv, "a"sv, "test,"sv, "this"sv, "is"sv, "only"sv, "a"sv, "test."sv};
     static constexpr string_view expected_range[]    = {"Th"sv, " "sv, " a test, th"sv, " "sv, " only a test."sv};
     static constexpr string_view expected_empty[]    = {"T"sv, "h"sv, "i"sv, "s"sv, " "sv, "i"sv, "s"sv, " "sv, "a"sv,
-        " "sv, "t"sv, "e"sv, "s"sv, "t"sv, ","sv, " "sv, "t"sv, "h"sv, "i"sv, "s"sv, " "sv, "i"sv, "s"sv, " "sv, "o"sv,
-        "n"sv, "l"sv, "y"sv, " "sv, "a"sv, " "sv, "t"sv, "e"sv, "s"sv, "t"sv, "."sv};
+           " "sv, "t"sv, "e"sv, "s"sv, "t"sv, ","sv, " "sv, "t"sv, "h"sv, "i"sv, "s"sv, " "sv, "i"sv, "s"sv, " "sv, //
+           "o"sv, "n"sv, "l"sv, "y"sv, " "sv, "a"sv, " "sv, "t"sv, "e"sv, "s"sv, "t"sv, "."sv};
     static constexpr string_view expected_trailing[] = {"test"sv, ""sv};
     static constexpr string_view expected_lwg3505[]  = {"x"sv, "x"sv, "x"sv};
 

--- a/tests/std/tests/P0896R4_views_single/test.cpp
+++ b/tests/std/tests/P0896R4_views_single/test.cpp
@@ -146,7 +146,7 @@ void test_non_trivially_destructible_type() { // COMPILE-ONLY
         ~non_trivially_destructible() {}
 
         // To test the correct specialization of _Copyable_box, this type must not be copy assignable.
-        non_trivially_destructible(const non_trivially_destructible&) = default;
+        non_trivially_destructible(const non_trivially_destructible&)            = default;
         non_trivially_destructible& operator=(const non_trivially_destructible&) = delete;
     };
 

--- a/tests/std/tests/P0896R4_views_split/test.cpp
+++ b/tests/std/tests/P0896R4_views_split/test.cpp
@@ -212,8 +212,8 @@ struct instantiator {
         "This"sv, "is"sv, "a"sv, "test,"sv, "this"sv, "is"sv, "only"sv, "a"sv, "test."sv};
     static constexpr string_view expected_range[]    = {"Th"sv, " "sv, " a test, th"sv, " "sv, " only a test."sv};
     static constexpr string_view expected_empty[]    = {"T"sv, "h"sv, "i"sv, "s"sv, " "sv, "i"sv, "s"sv, " "sv, "a"sv,
-        " "sv, "t"sv, "e"sv, "s"sv, "t"sv, ","sv, " "sv, "t"sv, "h"sv, "i"sv, "s"sv, " "sv, "i"sv, "s"sv, " "sv, "o"sv,
-        "n"sv, "l"sv, "y"sv, " "sv, "a"sv, " "sv, "t"sv, "e"sv, "s"sv, "t"sv, "."sv};
+           " "sv, "t"sv, "e"sv, "s"sv, "t"sv, ","sv, " "sv, "t"sv, "h"sv, "i"sv, "s"sv, " "sv, "i"sv, "s"sv, " "sv, //
+           "o"sv, "n"sv, "l"sv, "y"sv, " "sv, "a"sv, " "sv, "t"sv, "e"sv, "s"sv, "t"sv, "."sv};
     static constexpr string_view expected_trailing[] = {"test"sv, ""sv};
     static constexpr string_view expected_lwg3505[]  = {"x"sv, "x"sv, "x"sv};
 

--- a/tests/std/tests/P0896R4_views_split/test.cpp
+++ b/tests/std/tests/P0896R4_views_split/test.cpp
@@ -331,8 +331,8 @@ constexpr bool test_devcom_1559808() {
 constexpr bool test_LWG_3590() {
     // LWG-3590: "split_view::base() const & is overconstrained"
     struct weird_view : ranges::view_interface<weird_view> {
-        weird_view()                  = default;
-        weird_view(const weird_view&) = default;
+        weird_view()                        = default;
+        weird_view(const weird_view&)       = default;
         weird_view& operator=(weird_view&&) = default;
 
         constexpr const int* begin() const {

--- a/tests/std/tests/P0898R3_concepts/test.cpp
+++ b/tests/std/tests/P0898R3_concepts/test.cpp
@@ -541,8 +541,8 @@ namespace test_convertible_to {
     STATIC_ASSERT(convertible_to<int volatile (&)[42], int volatile (&)[42]>);
     STATIC_ASSERT(convertible_to<int volatile (&)[42][13], int volatile (&)[42][13]>);
 #endif // TRANSITION, DevCom-1627396
-    STATIC_ASSERT(convertible_to<int volatile(&&)[42], int volatile(&&)[42]>);
-    STATIC_ASSERT(convertible_to<int volatile(&&)[42][13], int volatile(&&)[42][13]>);
+    STATIC_ASSERT(convertible_to<int volatile (&&)[42], int volatile (&&)[42]>);
+    STATIC_ASSERT(convertible_to<int volatile (&&)[42][13], int volatile (&&)[42][13]>);
 
 
     // char
@@ -724,8 +724,8 @@ namespace test_common_reference_with {
     STATIC_ASSERT(test<int volatile (&)[42], int volatile (&)[42]>());
     STATIC_ASSERT(test<int volatile (&)[42][13], int volatile (&)[42][13]>());
 #endif // TRANSITION, DevCom-1627396
-    STATIC_ASSERT(test<int volatile(&&)[42], int volatile(&&)[42]>());
-    STATIC_ASSERT(test<int volatile(&&)[42][13], int volatile(&&)[42][13]>());
+    STATIC_ASSERT(test<int volatile (&&)[42], int volatile (&&)[42]>());
+    STATIC_ASSERT(test<int volatile (&&)[42][13], int volatile (&&)[42][13]>());
 } // namespace test_common_reference_with
 
 namespace test_common_with {
@@ -1327,10 +1327,10 @@ namespace test_constructible_from {
 
     STATIC_ASSERT(test<void (&)(), void()>());
     STATIC_ASSERT(test<void (&)(), void (&)()>());
-    STATIC_ASSERT(test<void (&)(), void(&&)()>());
-    STATIC_ASSERT(test<void(&&)(), void()>());
-    STATIC_ASSERT(test<void(&&)(), void (&)()>());
-    STATIC_ASSERT(test<void(&&)(), void(&&)()>());
+    STATIC_ASSERT(test<void (&)(), void (&&)()>());
+    STATIC_ASSERT(test<void (&&)(), void()>());
+    STATIC_ASSERT(test<void (&&)(), void (&)()>());
+    STATIC_ASSERT(test<void (&&)(), void (&&)()>());
 
     STATIC_ASSERT(test<int&&, double&>());
 
@@ -1657,10 +1657,10 @@ namespace test_ranges_swap {
     STATIC_ASSERT(!can_swap<int()>);
     STATIC_ASSERT(!can_swap<int() const>);
     STATIC_ASSERT(!can_swap<int (&)()>);
-    STATIC_ASSERT(!can_swap<int(&&)()>);
+    STATIC_ASSERT(!can_swap<int (&&)()>);
 
     STATIC_ASSERT(!can_swap<int (&)[]>);
-    STATIC_ASSERT(!can_swap<int(&&)[]>);
+    STATIC_ASSERT(!can_swap<int (&&)[]>);
 
     STATIC_ASSERT(can_nothrow_swap<int (&)[42]>);
     STATIC_ASSERT(can_nothrow_swap<int (&)[42][13]>);
@@ -1672,10 +1672,10 @@ namespace test_ranges_swap {
     STATIC_ASSERT(can_nothrow_swap<int volatile (&)[42][13]>);
     STATIC_ASSERT(!can_swap<int const volatile (&)[42][13]>);
 
-    STATIC_ASSERT(!can_swap<int(&&)[42]>);
-    STATIC_ASSERT(!can_swap<int(&&)[42][13]>);
+    STATIC_ASSERT(!can_swap<int (&&)[42]>);
+    STATIC_ASSERT(!can_swap<int (&&)[42][13]>);
 
-    STATIC_ASSERT(!can_swap<int(&&)[42][13], int(&&)[13][42]>);
+    STATIC_ASSERT(!can_swap<int (&&)[42][13], int (&&)[13][42]>);
 
     struct SemithrowCopyOnly {
         SemithrowCopyOnly()                                  = default;
@@ -1752,9 +1752,9 @@ namespace test_ranges_swap {
     STATIC_ASSERT(!can_swap<Unswappable (&)[42][13]>);
     STATIC_ASSERT(!can_swap<Unswappable (&)[42][13], Unswappable (&)[13][42]>);
 
-    STATIC_ASSERT(!can_swap<Unswappable(&&)[42]>);
-    STATIC_ASSERT(!can_swap<Unswappable(&&)[42][13]>);
-    STATIC_ASSERT(!can_swap<Unswappable(&&)[42][13], Unswappable(&&)[13][42]>);
+    STATIC_ASSERT(!can_swap<Unswappable (&&)[42]>);
+    STATIC_ASSERT(!can_swap<Unswappable (&&)[42][13]>);
+    STATIC_ASSERT(!can_swap<Unswappable (&&)[42][13], Unswappable (&&)[13][42]>);
 
     // The wording allows customization of swap for unions as well
     union U {

--- a/tests/std/tests/P0898R3_concepts/test.cpp
+++ b/tests/std/tests/P0898R3_concepts/test.cpp
@@ -1808,7 +1808,7 @@ namespace test_ranges_swap {
         friend constexpr void swap(DoNotUseFallback&, DoNotUseFallback&) noexcept {}
     };
 
-    constexpr auto for_each_232 = [](auto (&array)[2][3][2], auto f) {
+    constexpr auto for_each_232 = [](auto(&array)[2][3][2], auto f) {
         for (int i = 0; i < 2; ++i) {
             for (int j = 0; j < 3; ++j) {
                 for (int k = 0; k < 2; ++k) {

--- a/tests/std/tests/P0898R3_concepts/test.cpp
+++ b/tests/std/tests/P0898R3_concepts/test.cpp
@@ -62,23 +62,23 @@ struct DoNotInstantiate {
 };
 
 struct Immobile {
-    Immobile()                = default;
-    Immobile(Immobile const&) = delete;
+    Immobile()                           = default;
+    Immobile(Immobile const&)            = delete;
     Immobile& operator=(Immobile const&) = delete;
 };
 
 struct MoveOnly {
-    MoveOnly()           = default;
-    MoveOnly(MoveOnly&&) = default;
+    MoveOnly()                      = default;
+    MoveOnly(MoveOnly&&)            = default;
     MoveOnly& operator=(MoveOnly&&) = default;
 };
 
 struct CopyOnlyAbomination {
-    CopyOnlyAbomination()                           = default;
-    CopyOnlyAbomination(CopyOnlyAbomination const&) = default;
-    CopyOnlyAbomination(CopyOnlyAbomination&&)      = delete;
+    CopyOnlyAbomination()                                      = default;
+    CopyOnlyAbomination(CopyOnlyAbomination const&)            = default;
+    CopyOnlyAbomination(CopyOnlyAbomination&&)                 = delete;
     CopyOnlyAbomination& operator=(CopyOnlyAbomination const&) = default;
-    CopyOnlyAbomination& operator=(CopyOnlyAbomination&&) = delete;
+    CopyOnlyAbomination& operator=(CopyOnlyAbomination&&)      = delete;
 };
 
 struct CopyableType {
@@ -1701,31 +1701,31 @@ namespace test_ranges_swap {
     STATIC_ASSERT(!can_nothrow_swap<SemithrowMoveOnly (&)[42]>);
 
     struct NothrowMoveOnly {
-        NothrowMoveOnly()                           = default;
-        NothrowMoveOnly(NothrowMoveOnly&&) noexcept = default;
+        NothrowMoveOnly()                                      = default;
+        NothrowMoveOnly(NothrowMoveOnly&&) noexcept            = default;
         NothrowMoveOnly& operator=(NothrowMoveOnly&&) noexcept = default;
     };
     STATIC_ASSERT(can_nothrow_swap<NothrowMoveOnly&>);
     STATIC_ASSERT(can_nothrow_swap<NothrowMoveOnly (&)[42]>);
 
     struct NotMoveConstructible {
-        NotMoveConstructible()                       = default;
-        NotMoveConstructible(NotMoveConstructible&&) = delete;
+        NotMoveConstructible()                                  = default;
+        NotMoveConstructible(NotMoveConstructible&&)            = delete;
         NotMoveConstructible& operator=(NotMoveConstructible&&) = default;
     };
     STATIC_ASSERT(!can_swap<NotMoveConstructible&>);
     STATIC_ASSERT(!can_swap<NotMoveConstructible (&)[42]>);
 
     struct NotMoveAssignable {
-        NotMoveAssignable(NotMoveAssignable&&) = default;
+        NotMoveAssignable(NotMoveAssignable&&)            = default;
         NotMoveAssignable& operator=(NotMoveAssignable&&) = delete;
     };
     STATIC_ASSERT(!can_swap<NotMoveAssignable&>);
     STATIC_ASSERT(!can_swap<NotMoveAssignable (&)[42]>);
 
     struct ImmobileNothrowSwap {
-        ImmobileNothrowSwap()                      = default;
-        ImmobileNothrowSwap(ImmobileNothrowSwap&&) = delete;
+        ImmobileNothrowSwap()                                 = default;
+        ImmobileNothrowSwap(ImmobileNothrowSwap&&)            = delete;
         ImmobileNothrowSwap& operator=(ImmobileNothrowSwap&&) = delete;
         friend void swap(ImmobileNothrowSwap&, ImmobileNothrowSwap&) noexcept {}
     };
@@ -1758,7 +1758,7 @@ namespace test_ranges_swap {
 
     // The wording allows customization of swap for unions as well
     union U {
-        U(U const&) = delete;
+        U(U const&)            = delete;
         U& operator=(U const&) = delete;
 
         friend void swap(U&, U&) {}

--- a/tests/std/tests/P0898R3_identity/test.cpp
+++ b/tests/std/tests/P0898R3_identity/test.cpp
@@ -10,8 +10,8 @@ using namespace std;
 #define STATIC_ASSERT(...) static_assert(__VA_ARGS__, #__VA_ARGS__)
 
 struct S {
-    S()         = delete;
-    S(const S&) = delete;
+    S()                    = delete;
+    S(const S&)            = delete;
     S& operator=(const S&) = delete;
 };
 

--- a/tests/std/tests/P0912R5_coroutine/test.cpp
+++ b/tests/std/tests/P0912R5_coroutine/test.cpp
@@ -87,6 +87,7 @@ struct Task {
     coroutine_handle<Promise> coro;
 };
 
+#if !(defined(__clang__) && defined(_M_IX86)) // TRANSITION, LLVM-56507
 Task triangular_number(const int n) {
     if (n == 0) {
         co_return 0;
@@ -94,6 +95,7 @@ Task triangular_number(const int n) {
 
     co_return n + co_await triangular_number(n - 1);
 }
+#endif // TRANSITION, LLVM-56507
 
 void test_noop_handle() { // Validate noop_coroutine_handle
     const noop_coroutine_handle noop = noop_coroutine();
@@ -153,6 +155,7 @@ void test_noop_handle() { // Validate noop_coroutine_handle
 }
 
 int main() {
+#if !(defined(__clang__) && defined(_M_IX86)) // TRANSITION, LLVM-56507
     assert(g_tasks_destroyed == 0);
 
     {
@@ -177,6 +180,7 @@ int main() {
     }
 
     assert(g_tasks_destroyed == 11); // triangular_number() called for [0, 10]
+#endif // TRANSITION, LLVM-56507
 
     {
         // Also test GH-1422: hash<coroutine_handle<>>::operator() must be const

--- a/tests/std/tests/P0912R5_coroutine/test.cpp
+++ b/tests/std/tests/P0912R5_coroutine/test.cpp
@@ -1,9 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include <version> // TRANSITION, Clang 14 coroutine support
-#ifdef __cpp_lib_coroutine // TRANSITION, Clang 14 coroutine support
-
 #include <assert.h>
 #include <coroutine>
 #include <exception>
@@ -180,7 +177,3 @@ int main() {
 
     test_noop_handle();
 }
-
-#else // ^^^ test <coroutine> ^^^ / vvv don't test <coroutine> vvv
-int main() {}
-#endif // TRANSITION, Clang 14 coroutine support

--- a/tests/std/tests/P0912R5_coroutine/test.cpp
+++ b/tests/std/tests/P0912R5_coroutine/test.cpp
@@ -132,7 +132,16 @@ void test_noop_handle() { // Validate noop_coroutine_handle
 
     assert(noop);
     assert(as_void);
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-undefined-compare"
+#endif // __clang__
+    // Clang notices that this is always true and warns: "reference cannot be bound to dereferenced null pointer
+    // in well-defined C++ code; comparison may be assumed to always evaluate to true"
     assert(&noop.promise() != nullptr);
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif // __clang__
     STATIC_ASSERT(noexcept(noop.promise()));
 
     assert(noop);

--- a/tests/std/tests/P0919R3_heterogeneous_unordered_lookup/test.cpp
+++ b/tests/std/tests/P0919R3_heterogeneous_unordered_lookup/test.cpp
@@ -28,7 +28,7 @@ public:
         g_prohibit_allocations = value;
     }
 
-    prohibit_allocations(const prohibit_allocations&) = delete;
+    prohibit_allocations(const prohibit_allocations&)            = delete;
     prohibit_allocations& operator=(const prohibit_allocations&) = delete;
 
     ~prohibit_allocations() {
@@ -46,7 +46,7 @@ struct test_allocator {
     test_allocator() = default;
     template <typename U>
     test_allocator(const test_allocator<U>&) {}
-    test_allocator(const test_allocator&) = default;
+    test_allocator(const test_allocator&)            = default;
     test_allocator& operator=(const test_allocator&) = default;
 
     T* allocate(const size_t n) {

--- a/tests/std/tests/P0943R6_stdatomic_h/test.compile.pass.cpp
+++ b/tests/std/tests/P0943R6_stdatomic_h/test.compile.pass.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#ifndef __clang__ // TRANSITION, GH-2862
 #include <stdatomic.h>
 
 static_assert(ATOMIC_BOOL_LOCK_FREE == 2);
@@ -113,5 +114,6 @@ namespace test {
 
 static_assert(std::atomic_thread_fence == atomic_thread_fence);
 static_assert(std::atomic_signal_fence == atomic_signal_fence);
+#endif // TRANSITION, GH-2862
 
 int main() {} // COMPILE-ONLY

--- a/tests/std/tests/P1135R6_barrier/test.cpp
+++ b/tests/std/tests/P1135R6_barrier/test.cpp
@@ -120,7 +120,7 @@ void test_functor_types() {
 
         f1(int, int, int) {}
 
-        f1(f1&&) noexcept = default;
+        f1(f1&&) noexcept   = default;
         f1& operator=(f1&&) = delete;
     };
     std::barrier b1{1, f1{0, 0, 0}};

--- a/tests/std/tests/P1502R1_standard_library_header_units/test.cpp
+++ b/tests/std/tests/P1502R1_standard_library_header_units/test.cpp
@@ -28,9 +28,7 @@ import <coroutine>;
 import <deque>;
 import <exception>;
 import <execution>;
-#ifdef _MSVC_INTERNAL_TESTING // TRANSITION, VSO-1543660 fixed in 17.3 Preview 3
 import <expected>;
-#endif // ^^^ no workaround ^^^
 import <filesystem>;
 import <format>;
 import <forward_list>;
@@ -296,13 +294,11 @@ __declspec(dllexport) // for <stacktrace> test export main to have it named even
         assert(count(execution::par, begin(arr), end(arr), 0) == 4);
     }
 
-#ifdef _MSVC_INTERNAL_TESTING // TRANSITION, VSO-1543660 fixed in 17.3 Preview 3
     {
         puts("Testing <expected>.");
         constexpr expected<double, int> test{unexpect, 42};
         assert(test.error() == 42);
     }
-#endif // ^^^ no workaround ^^^
 
     {
         puts("Testing <filesystem>.");

--- a/tests/std/tests/P2321R2_proxy_reference/test.cpp
+++ b/tests/std/tests/P2321R2_proxy_reference/test.cpp
@@ -30,7 +30,7 @@ struct Meow {
     constexpr Meow(Meow&&) : state(State::move_construct) {}
     constexpr Meow(const Meow&&) : state(State::move_construct_from_const) {}
 
-    constexpr Meow& operator=(Meow&) = delete;
+    constexpr Meow& operator=(Meow&)             = delete;
     constexpr const Meow& operator=(Meow&) const = delete;
 
     constexpr Meow& operator=(const Meow&) {
@@ -50,7 +50,7 @@ struct Meow {
         return *this;
     }
 
-    constexpr Meow& operator=(const Meow&&) = delete;
+    constexpr Meow& operator=(const Meow&&)             = delete;
     constexpr const Meow& operator=(const Meow&&) const = delete;
 
     friend constexpr void swap(Meow& left, Meow&) {

--- a/tests/std/tests/VSO_0000000_fancy_pointers/test.compile.pass.cpp
+++ b/tests/std/tests/VSO_0000000_fancy_pointers/test.compile.pass.cpp
@@ -320,10 +320,10 @@ struct fancy_allocator {
     // operator!=(a1, a2) ditto
     // operator==(a, b) ditto
     // operator!=(a, b) ditto
-    fancy_allocator(const fancy_allocator&) = default;
-    fancy_allocator(fancy_allocator&&)      = default;
+    fancy_allocator(const fancy_allocator&)            = default;
+    fancy_allocator(fancy_allocator&&)                 = default;
     fancy_allocator& operator=(const fancy_allocator&) = delete;
-    fancy_allocator& operator=(fancy_allocator&&) = delete;
+    fancy_allocator& operator=(fancy_allocator&&)      = delete;
 
     template <typename U>
     explicit fancy_allocator(const fancy_allocator<U>&) {}

--- a/tests/std/tests/VSO_0000000_initialize_everything/test.cpp
+++ b/tests/std/tests/VSO_0000000_initialize_everything/test.cpp
@@ -68,7 +68,7 @@ struct garbage_data {
         memset(&data, 0xCC, sizeof(data));
     }
 
-    garbage_data(const garbage_data&) = delete;
+    garbage_data(const garbage_data&)            = delete;
     garbage_data& operator=(const garbage_data&) = delete;
 
     T& get() {

--- a/tests/std/tests/VSO_0000000_list_iterator_debugging/test.cpp
+++ b/tests/std/tests/VSO_0000000_list_iterator_debugging/test.cpp
@@ -115,7 +115,7 @@ void test_case_empty_target_bad() {
 struct throw_cmp_less_int {
     size_t remainingCompares;
     explicit throw_cmp_less_int(size_t remainingCompares_) : remainingCompares(remainingCompares_) {}
-    throw_cmp_less_int(const throw_cmp_less_int&) = delete;
+    throw_cmp_less_int(const throw_cmp_less_int&)            = delete;
     throw_cmp_less_int& operator=(const throw_cmp_less_int&) = delete;
 
     bool operator()(int a, int b) /* neither const nor noexcept */ {
@@ -234,8 +234,8 @@ template <class T>
 struct liveness_allocator {
     using value_type = T;
 
-    liveness_allocator()                          = default;
-    liveness_allocator(const liveness_allocator&) = default;
+    liveness_allocator()                                     = default;
+    liveness_allocator(const liveness_allocator&)            = default;
     liveness_allocator& operator=(const liveness_allocator&) = default;
     template <class U, enable_if_t<!is_same_v<T, U>, int> = 0>
     liveness_allocator(const liveness_allocator<U>&) {}

--- a/tests/std/tests/VSO_0000000_more_pair_tuple_sfinae/test.cpp
+++ b/tests/std/tests/VSO_0000000_more_pair_tuple_sfinae/test.cpp
@@ -115,20 +115,20 @@ template <typename T>
 constexpr bool IsBraceAssignableV = IsBraceAssignable<T>::value;
 
 struct Copyable {
-    Copyable()                  = default;
-    Copyable(const ::Copyable&) = default;
+    Copyable()                             = default;
+    Copyable(const ::Copyable&)            = default;
     Copyable& operator=(const ::Copyable&) = default;
 };
 
 struct Movable {
-    Movable()            = default;
-    Movable(::Movable&&) = default;
+    Movable()                       = default;
+    Movable(::Movable&&)            = default;
     Movable& operator=(::Movable&&) = default;
 };
 
 struct NonCopyable {
-    NonCopyable()                   = default;
-    NonCopyable(const NonCopyable&) = delete;
+    NonCopyable()                              = default;
+    NonCopyable(const NonCopyable&)            = delete;
     NonCopyable& operator=(const NonCopyable&) = delete;
 };
 

--- a/tests/std/tests/VSO_0000000_type_traits/test.cpp
+++ b/tests/std/tests/VSO_0000000_type_traits/test.cpp
@@ -450,7 +450,7 @@ struct test_abc1 {
     test_abc1();
     virtual ~test_abc1();
     test_abc1(const test_abc1&);
-    test_abc1& operator  =(const test_abc1&);
+    test_abc1& operator=(const test_abc1&);
     virtual void meow()  = 0;
     virtual void meow2() = 0;
 };

--- a/tests/std/tests/VSO_0000000_type_traits/test.cpp
+++ b/tests/std/tests/VSO_0000000_type_traits/test.cpp
@@ -729,8 +729,8 @@ namespace swappable_trait_tests {
 
     template <bool Throws>
     struct type<implicitly_unswappable, Throws> {
-        type()        = default;
-        type(type&&)  = delete;
+        type()                  = default;
+        type(type&&)            = delete;
         type& operator=(type&&) = delete;
     };
 
@@ -744,7 +744,7 @@ namespace swappable_trait_tests {
         type& operator=(type&&) noexcept(!Throws) {
             return *this;
         }
-        type(const type&) = default;
+        type(const type&)            = default;
         type& operator=(const type&) = default;
     };
 
@@ -842,7 +842,7 @@ namespace swappable_trait_tests {
 struct Immovable {
     Immovable() {}
     ~Immovable() {}
-    Immovable(const Immovable&) = delete;
+    Immovable(const Immovable&)            = delete;
     Immovable& operator=(const Immovable&) = delete;
 };
 
@@ -1291,8 +1291,8 @@ namespace {
     constexpr bool is_permissive = detail::Derived<int>::test();
 
     struct move_only {
-        move_only()            = default;
-        move_only(move_only&&) = default;
+        move_only()                       = default;
+        move_only(move_only&&)            = default;
         move_only& operator=(move_only&&) = default;
     };
 

--- a/tests/std/tests/VSO_0000000_type_traits/test.cpp
+++ b/tests/std/tests/VSO_0000000_type_traits/test.cpp
@@ -292,8 +292,8 @@ STATIC_ASSERT(is_array_v<const volatile int[]>);
 // lvalue/rvalue references aren't arrays.
 STATIC_ASSERT(!is_array_v<int (&)[3]>);
 STATIC_ASSERT(!is_array_v<int (&)[]>);
-STATIC_ASSERT(!is_array_v<int(&&)[3]>);
-STATIC_ASSERT(!is_array_v<int(&&)[]>);
+STATIC_ASSERT(!is_array_v<int (&&)[3]>);
+STATIC_ASSERT(!is_array_v<int (&&)[]>);
 
 #if _HAS_CXX20
 STATIC_ASSERT(is_bounded_array_v<int[3]>);
@@ -319,12 +319,12 @@ STATIC_ASSERT(is_unbounded_array_v<const volatile int[]>);
 // lvalue/rvalue references aren't bounded/unbounded arrays.
 STATIC_ASSERT(!is_bounded_array_v<int (&)[3]>);
 STATIC_ASSERT(!is_bounded_array_v<int (&)[]>);
-STATIC_ASSERT(!is_bounded_array_v<int(&&)[3]>);
-STATIC_ASSERT(!is_bounded_array_v<int(&&)[]>);
+STATIC_ASSERT(!is_bounded_array_v<int (&&)[3]>);
+STATIC_ASSERT(!is_bounded_array_v<int (&&)[]>);
 STATIC_ASSERT(!is_unbounded_array_v<int (&)[3]>);
 STATIC_ASSERT(!is_unbounded_array_v<int (&)[]>);
-STATIC_ASSERT(!is_unbounded_array_v<int(&&)[3]>);
-STATIC_ASSERT(!is_unbounded_array_v<int(&&)[]>);
+STATIC_ASSERT(!is_unbounded_array_v<int (&&)[3]>);
+STATIC_ASSERT(!is_unbounded_array_v<int (&&)[]>);
 #endif // _HAS_CXX20
 
 
@@ -1355,9 +1355,9 @@ STATIC_ASSERT(is_same_v<common_reference_t<int const&>, int const&>);
 STATIC_ASSERT(is_same_v<common_reference_t<int const&&>, int const&&>);
 STATIC_ASSERT(is_same_v<common_reference_t<int volatile[]>, int volatile[]>);
 STATIC_ASSERT(is_same_v<common_reference_t<int volatile (&)[]>, int volatile (&)[]>);
-STATIC_ASSERT(is_same_v<common_reference_t<int volatile(&&)[]>, int volatile(&&)[]>);
+STATIC_ASSERT(is_same_v<common_reference_t<int volatile (&&)[]>, int volatile (&&)[]>);
 STATIC_ASSERT(is_same_v<common_reference_t<void (&)()>, void (&)()>);
-STATIC_ASSERT(is_same_v<common_reference_t<void(&&)()>, void(&&)()>);
+STATIC_ASSERT(is_same_v<common_reference_t<void (&&)()>, void (&&)()>);
 STATIC_ASSERT(is_same_v<common_reference_t<void() volatile>, void() volatile>);
 STATIC_ASSERT(is_same_v<common_reference_t<void() &&>, void() &&>);
 
@@ -1396,14 +1396,14 @@ STATIC_ASSERT(is_same_v<common_reference_t<simple_base const&&, simple_derived c
 // FAIL IF AND WHEN EDG STARTS BEHAVING CORRECTLY. We can then remove the non-workaround to defend against
 // regression.
 STATIC_ASSERT(!is_same_v<common_reference_t<int (&)(), int (&)()>, int (&)()>);
-STATIC_ASSERT(!is_same_v<common_reference_t<int(&&)(), int (&)()>, int (&)()>);
-STATIC_ASSERT(!is_same_v<common_reference_t<int (&)(), int(&&)()>, int (&)()>);
-STATIC_ASSERT(!is_same_v<common_reference_t<int(&&)(), int(&&)()>, int(&&)()>);
+STATIC_ASSERT(!is_same_v<common_reference_t<int (&&)(), int (&)()>, int (&)()>);
+STATIC_ASSERT(!is_same_v<common_reference_t<int (&)(), int (&&)()>, int (&)()>);
+STATIC_ASSERT(!is_same_v<common_reference_t<int (&&)(), int (&&)()>, int (&&)()>);
 #else // ^^^ EDG / not EDG vvv
 STATIC_ASSERT(is_same_v<common_reference_t<int (&)(), int (&)()>, int (&)()>);
-STATIC_ASSERT(is_same_v<common_reference_t<int(&&)(), int (&)()>, int (&)()>);
-STATIC_ASSERT(is_same_v<common_reference_t<int (&)(), int(&&)()>, int (&)()>);
-STATIC_ASSERT(is_same_v<common_reference_t<int(&&)(), int(&&)()>, int(&&)()>);
+STATIC_ASSERT(is_same_v<common_reference_t<int (&&)(), int (&)()>, int (&)()>);
+STATIC_ASSERT(is_same_v<common_reference_t<int (&)(), int (&&)()>, int (&)()>);
+STATIC_ASSERT(is_same_v<common_reference_t<int (&&)(), int (&&)()>, int (&&)()>);
 #endif // __EDG__
 
 STATIC_ASSERT(is_same_v<common_reference_t<int const volatile&&, int volatile&&>, int const volatile&&>);

--- a/tests/std/tests/VSO_0121440_is_iterator_iterator_traits/test.cpp
+++ b/tests/std/tests/VSO_0121440_is_iterator_iterator_traits/test.cpp
@@ -17,7 +17,7 @@ class int_iterator // models InputIterator
 public:
     explicit int_iterator(int* start) : m_ptr(start) {}
 
-    int_iterator(const int_iterator&) = default;
+    int_iterator(const int_iterator&)            = default;
     int_iterator& operator=(const int_iterator&) = default;
 
     int_iterator& operator++() { // prefix

--- a/tests/std/tests/VSO_0131167_associative_emplacement_allocations/test.cpp
+++ b/tests/std/tests/VSO_0131167_associative_emplacement_allocations/test.cpp
@@ -21,8 +21,8 @@ template <class T>
 struct TestAlloc {
     using value_type = T;
 
-    TestAlloc()                 = default;
-    TestAlloc(const TestAlloc&) = default;
+    TestAlloc()                            = default;
+    TestAlloc(const TestAlloc&)            = default;
     TestAlloc& operator=(const TestAlloc&) = default;
 
     template <class U>
@@ -53,7 +53,7 @@ struct NoAllocGuard {
         g_allow_allocations = false;
     }
 
-    NoAllocGuard(const NoAllocGuard&) = delete;
+    NoAllocGuard(const NoAllocGuard&)            = delete;
     NoAllocGuard& operator=(const NoAllocGuard&) = delete;
 
     ~NoAllocGuard() {

--- a/tests/std/tests/VSO_0180466_algorithm_overhauls/test.cpp
+++ b/tests/std/tests/VSO_0180466_algorithm_overhauls/test.cpp
@@ -22,10 +22,10 @@ struct move_only {
     int val;
 
     move_only(int val_) : val(val_) {}
-    move_only(const move_only&) = delete;
-    move_only(move_only&&)      = default;
+    move_only(const move_only&)            = delete;
+    move_only(move_only&&)                 = default;
     move_only& operator=(const move_only&) = delete;
-    move_only& operator=(move_only&&) = default;
+    move_only& operator=(move_only&&)      = default;
 };
 
 bool operator==(const move_only& lhs, const move_only& rhs) {

--- a/tests/std/tests/VSO_0191296_allocator_construct/test.compile.pass.cpp
+++ b/tests/std/tests/VSO_0191296_allocator_construct/test.compile.pass.cpp
@@ -61,8 +61,8 @@ struct faux_compare {
 
 template <typename T>
 struct default_constructible_compare {
-    default_constructible_compare()                                     = default;
-    default_constructible_compare(default_constructible_compare const&) = default;
+    default_constructible_compare()                                                = default;
+    default_constructible_compare(default_constructible_compare const&)            = default;
     default_constructible_compare& operator=(default_constructible_compare const&) = delete;
 
     bool operator()(T const&, T const&) const {
@@ -74,7 +74,7 @@ template <typename T>
 struct copy_constructible_compare {
     copy_constructible_compare() = delete;
     copy_constructible_compare(key) {}
-    copy_constructible_compare(copy_constructible_compare const&) = default;
+    copy_constructible_compare(copy_constructible_compare const&)            = default;
     copy_constructible_compare& operator=(copy_constructible_compare const&) = delete;
 
     bool operator()(T const&, T const&) const {
@@ -91,8 +91,8 @@ struct faux_hash {
 
 template <typename T>
 struct default_constructible_hash {
-    default_constructible_hash()                                  = default;
-    default_constructible_hash(default_constructible_hash const&) = default;
+    default_constructible_hash()                                             = default;
+    default_constructible_hash(default_constructible_hash const&)            = default;
     default_constructible_hash& operator=(default_constructible_hash const&) = delete;
 
     bool operator()(T const&, T const&) const {
@@ -104,7 +104,7 @@ template <typename T>
 struct copy_constructible_hash {
     copy_constructible_hash() = delete;
     copy_constructible_hash(key) {}
-    copy_constructible_hash(copy_constructible_hash const&) = default;
+    copy_constructible_hash(copy_constructible_hash const&)            = default;
     copy_constructible_hash& operator=(copy_constructible_hash const&) = delete;
 
     std::size_t operator()(T const&) const {

--- a/tests/std/tests/VSO_0224478_scoped_allocator/test.cpp
+++ b/tests/std/tests/VSO_0224478_scoped_allocator/test.cpp
@@ -67,7 +67,7 @@ struct min_alloc {
     min_alloc() = default;
     template <typename U>
     min_alloc(const min_alloc<U>&) {}
-    min_alloc(const min_alloc&) = default;
+    min_alloc(const min_alloc&)            = default;
     min_alloc& operator=(const min_alloc&) = default;
 
     value_type* allocate(size_t n) {

--- a/tests/std/tests/VSO_0644691_utf_8_codecvt/test.cpp
+++ b/tests/std/tests/VSO_0644691_utf_8_codecvt/test.cpp
@@ -253,14 +253,13 @@ void test_codecvt_encoding(const codecvt<wchar_t, char, mbstate_t>& f) {
 }
 
 int main() {
-#if 0 // TRANSITION, VSO-801237
     try {
-        locale loc("en-US.utf8");
+        locale loc("en-US.UTF-8");
         test_fstream(loc);
         test_codecvt_encoding(use_facet<codecvt<wchar_t, char, mbstate_t>>(loc));
     } catch (const exception& ex) {
-        puts("Warning, could not test UTF-8 on this platform, newer Windows 10 required.");
+        puts("Could not test UTF-8 on this platform, newer Windows 10 required.");
         puts(ex.what());
+        assert(false);
     }
-#endif // TRANSITION, VSO-801237
 }

--- a/tests/std/tests/VSO_0677157_flist_merge_edge_cases/test.cpp
+++ b/tests/std/tests/VSO_0677157_flist_merge_edge_cases/test.cpp
@@ -113,7 +113,7 @@ void test_case_empty_target_bad() {
 struct throw_cmp_less_int {
     size_t remainingCompares;
     explicit throw_cmp_less_int(size_t remainingCompares_) : remainingCompares(remainingCompares_) {}
-    throw_cmp_less_int(const throw_cmp_less_int&) = delete;
+    throw_cmp_less_int(const throw_cmp_less_int&)            = delete;
     throw_cmp_less_int& operator=(const throw_cmp_less_int&) = delete;
 
     bool operator()(int a, int b) /* neither const nor noexcept */ {

--- a/tests/std/tests/VSO_0961751_hash_range_erase/test.cpp
+++ b/tests/std/tests/VSO_0961751_hash_range_erase/test.cpp
@@ -24,8 +24,8 @@ template <class T>
 struct liveness_allocator {
     using value_type = T;
 
-    liveness_allocator()                          = default;
-    liveness_allocator(const liveness_allocator&) = default;
+    liveness_allocator()                                     = default;
+    liveness_allocator(const liveness_allocator&)            = default;
     liveness_allocator& operator=(const liveness_allocator&) = default;
     template <class U, enable_if_t<!is_same_v<T, U>, int> = 0>
     liveness_allocator(const liveness_allocator<U>&) {}

--- a/tests/std/tests/VSO_0971246_legacy_await_headers/test.cpp
+++ b/tests/std/tests/VSO_0971246_legacy_await_headers/test.cpp
@@ -75,7 +75,7 @@ struct Immovable {
 
     explicit Immovable(int v) : val(v) {}
 
-    Immovable(Immovable const&) = delete;
+    Immovable(Immovable const&)            = delete;
     Immovable& operator=(Immovable const&) = delete;
 };
 

--- a/tests/tr1/include/tdefs.h
+++ b/tests/tr1/include/tdefs.h
@@ -520,7 +520,7 @@ public:
         return val < x.val;
     }
 
-    Movable_int(const Movable_int&) = delete;
+    Movable_int(const Movable_int&)            = delete;
     Movable_int& operator=(const Movable_int&) = delete;
 };
 #endif // __cplusplus

--- a/tests/tr1/tests/cvt/wstring/test.cpp
+++ b/tests/tr1/tests/cvt/wstring/test.cpp
@@ -91,7 +91,7 @@ void test_to_bytes() { // test wstring_convert from wide to bytes
     // check error handling
     const char* mesg = "to_bytes didn't throw";
     wchar_t bad[]    = {
-        // bad two-word sequence
+           // bad two-word sequence
         (wchar_t) 0xd800, // first of two words
         (wchar_t) 0xd800, // not second word
         0,

--- a/tests/tr1/tests/future1/test.cpp
+++ b/tests/tr1/tests/future1/test.cpp
@@ -16,7 +16,7 @@ class future_tester_base { // base class for testing future types with set and g
 public:
     future_tester_base() = default;
 
-    future_tester_base(const future_tester_base&) = delete;
+    future_tester_base(const future_tester_base&)            = delete;
     future_tester_base& operator=(const future_tester_base&) = delete;
     virtual ~future_tester_base() {}
 

--- a/tests/tr1/tests/limits/test.cpp
+++ b/tests/tr1/tests/limits/test.cpp
@@ -24,7 +24,7 @@ struct Mytype { // wrap an int
 void test_main() { // test basic workings of limits definitions
     static const STD float_denorm_style fds[] = {STD denorm_indeterminate, STD denorm_absent, STD denorm_present};
     static const STD float_round_style frs[]  = {STD round_indeterminate, STD round_toward_zero, STD round_to_nearest,
-        STD round_toward_infinity, STD round_toward_neg_infinity};
+         STD round_toward_infinity, STD round_toward_neg_infinity};
     int i, j, ok;
 
     for (ok = 1, i = sizeof(fds) / sizeof(fds[0]); 0 < i;)

--- a/tests/tr1/tests/locale8/test.cpp
+++ b/tests/tr1/tests/locale8/test.cpp
@@ -93,7 +93,7 @@ void test_to_bytes() { // test wstring_convert from wide to bytes
     // check error handling
     const char* mesg = "to_bytes didn't throw";
     wchar_t bad[]    = {
-        // bad two-word sequence
+           // bad two-word sequence
         (wchar_t) 0xd800, // first of two words
         (wchar_t) 0xd800, // not second word
         0,

--- a/tools/validate/validate.cpp
+++ b/tools/validate/validate.cpp
@@ -46,7 +46,7 @@ public:
         }
     }
 
-    BinaryFile(const BinaryFile&) = delete;
+    BinaryFile(const BinaryFile&)            = delete;
     BinaryFile& operator=(const BinaryFile&) = delete;
 
 private:


### PR DESCRIPTION
As a whole, this is best reviewed by ignoring whitespace. I've also arranged it as a series of well-structured commits.

# :toolbox: Toolset update
* New pool: VS 2022 17.3 Preview 3, Clang 14, July 2022's Patch Tuesday.
* README.md: Mention 17.3 Preview 3.
* Require Clang 14 and MSVC 19.33.
  + The internal build now uses MSVC 19.33.

# :rocket: Clang 14 coroutines
* Remove workarounds now that Clang 14 supports coroutines.
  + Fixes #1223 by enabling `<coroutine>` test coverage for Clang.
* Unskip libcxx tests that are passing with Clang 14 (mostly coroutines).
* Silence a valid but innocuous Clang warning in `P0912R5_coroutine`.
* Work around LLVM-56507 "clang 14.0.5 i686-pc-windows-msvc `<coroutine>` ICE: failed to perform tail call elimination on a call site marked musttail".

# :adhesive_bandage: Workaround removals
* Remove workaround for VSO-1543660 "Standard Library Header Units: `<expected>` ICEs with Assertion failed: `IsInClassDefn()`"
* Remove workarounds now that Clang 14 supports `_MSVC_EXECUTION_CHARACTER_SET`.
* Remove workaround for VSO-522105 "REPORTED: `__STDCPP_DEFAULT_NEW_ALIGNMENT__` should have `size_t` type", resolved on 2018-01-02.
* Remove workaround now that we've implemented P2231R1 Completing `constexpr` In `optional` And `variant` (#2005).
* Remove workaround for DevCom-1656924 "EDG works wrong with `constinit`", fixed in 17.2.
* Remove workaround now that we've implemented P1023R0 `constexpr` For `std::array` Comparisons (#599).
* Remove `not_ranges_destroy()` workarounds now that we've implemented `ranges::destroy` (#1313).
* Remove `TRANSITION, VSO-1172852` ("Coroutine not at final suspend point after throwing from `unhandled_exception`") in `<experimental/generator>` as this is permanent.
* Remove workaround for VSO-801237 "Issue calling `WideCharToMultiByte` from `_Wcrtomb` with `CP_UTF8`", as our tests now assume modern OSes.
  + Adjust the locale name to `"en-US.UTF-8"`, for consistency with other tests.
  + If an exception is thrown, the message is no longer a warning - the test will fail.
* Partially remove workarounds for VSO-934264 "Explicitly-defaulted inherited default constructor is not correctly implicitly `constexpr`".
  + This bug is still active.
  + Perma-workaround: Mark the lambdas as `constexpr`, for consistency with other lambdas here.

# :page_facing_up: clang-format 14
* Update clang-format 14 defaults, no customizations.
* Reformatting commits:
  + clang-format aligning `= default`/`= delete`, no manual changes.
  + clang-format adding spaces to rvalue references to arrays/functions, all good, no manual changes.
  + clang-format removing spurious spaces in `requires` reference parameters, all good, no manual changes.
  + clang-format removing spurious spaces in an assignment operator, all good, no manual changes.
  + clang-format adjusting indentation, good/neutral, no manual changes.
  + clang-format adjusting indentation, needs manual wrapping to avoid exceeding 120.
  + clang-format removing spaces, weird but not worth adjusting, no manual changes.
  + clang-format adding spaces, weird but not worth adjusting, no manual changes.
