### PR TITLE
Extract `_Bitmask_includes_any()`, `_Bitmask_includes_all()` from `_BITMASK_OPS`

### DIFF
--- a/stl/inc/filesystem
+++ b/stl/inc/filesystem
@@ -1976,13 +1976,13 @@ namespace filesystem {
             if (_Error == __std_win_error::_Success) {
                 const auto _Attrs = _Stats._Attributes;
 
-                if (_Bitmask_includes(_Attrs, __std_fs_file_attr::_Readonly)) {
+                if (_Bitmask_includes_any(_Attrs, __std_fs_file_attr::_Readonly)) {
                     this->permissions(perms::_File_attribute_readonly);
                 } else {
                     this->permissions(perms::all);
                 }
 
-                if (_Bitmask_includes(_Attrs, __std_fs_file_attr::_Reparse_point)) {
+                if (_Bitmask_includes_any(_Attrs, __std_fs_file_attr::_Reparse_point)) {
                     if (_Stats._Reparse_point_tag == __std_fs_reparse_tag::_Symlink) {
                         this->type(file_type::symlink);
                         return;
@@ -1996,7 +1996,7 @@ namespace filesystem {
                     // All other reparse points considered ordinary files or directories
                 }
 
-                if (_Bitmask_includes(_Attrs, __std_fs_file_attr::_Directory)) {
+                if (_Bitmask_includes_any(_Attrs, __std_fs_file_attr::_Directory)) {
                     this->type(file_type::directory);
                 } else {
                     this->type(file_type::regular);
@@ -2177,7 +2177,7 @@ namespace filesystem {
 
     private:
         _NODISCARD bool _Has_cached_attribute(const __std_fs_file_attr _Attrs) const noexcept {
-            return _Bitmask_includes(_Cached_data._Attributes, _Attrs);
+            return _Bitmask_includes_any(_Cached_data._Attributes, _Attrs);
         }
 
     public:
@@ -2275,7 +2275,7 @@ namespace filesystem {
         }
 
         _NODISCARD bool _Available(const __std_fs_stats_flags _Flags) const noexcept {
-            return _Bitmask_includes(_Cached_data._Available, _Flags);
+            return _Bitmask_includes_any(_Cached_data._Available, _Flags);
         }
 
     private:
@@ -2481,7 +2481,7 @@ namespace filesystem {
             _Cached_data._Attributes        = _Data._Attributes;
             _Cached_data._Reparse_point_tag = _Data._Reparse_point_tag;
             _Cached_data._Available         = __std_fs_stats_flags::_Attributes | __std_fs_stats_flags::_Reparse_tag;
-            if (!_Bitmask_includes(_Data._Attributes, __std_fs_file_attr::_Reparse_point)) {
+            if (!_Bitmask_includes_any(_Data._Attributes, __std_fs_file_attr::_Reparse_point)) {
                 _Cached_data._File_size = (static_cast<uintmax_t>(_Data._File_size_high) << 32)
                                         + static_cast<uintmax_t>(_Data._File_size_low);
                 _CSTD memcpy(
@@ -2493,7 +2493,7 @@ namespace filesystem {
         _NODISCARD static __std_win_error _Refresh(__std_fs_stats& _Stats, const filesystem::path& _Path) noexcept {
             const auto _Error = __std_fs_get_stats(_Path.c_str(), &_Stats, __std_fs_stats_flags::_All_data);
             if (_Error == __std_win_error::_Success) {
-                if (_Bitmask_includes(_Stats._Attributes, __std_fs_file_attr::_Reparse_point)) {
+                if (_Bitmask_includes_any(_Stats._Attributes, __std_fs_file_attr::_Reparse_point)) {
                     _Stats._Available = __std_fs_stats_flags::_Attributes | __std_fs_stats_flags::_Reparse_tag;
                 } else {
                     _Stats._Available = __std_fs_stats_flags::_All_data;
@@ -2562,7 +2562,7 @@ namespace filesystem {
             }
 
             if (_Error == __std_win_error::_Access_denied
-                && _Bitmask_includes(_Options_arg, directory_options::skip_permission_denied)) {
+                && _Bitmask_includes_any(_Options_arg, directory_options::skip_permission_denied)) {
                 _Error = __std_win_error::_No_more_files;
             }
 
@@ -2745,7 +2745,7 @@ namespace filesystem {
             __std_win_error _Error = __std_win_error::_Success;
             if (_Recursion_pending) {
                 if (_Entry._Is_symlink_or_junction()) {
-                    if (_Bitmask_includes(_Options, directory_options::follow_directory_symlink)) {
+                    if (_Bitmask_includes_any(_Options, directory_options::follow_directory_symlink)) {
                         // check for broken symlink/junction
                         __std_fs_stats _Target_stats;
                         constexpr auto _Flags =
@@ -2754,10 +2754,10 @@ namespace filesystem {
                             _Entry._Path.c_str(), &_Target_stats, _Flags, _Entry._Cached_data._Attributes);
                         if (_Error == __std_win_error::_Success) {
                             _Should_recurse =
-                                _Bitmask_includes(_Target_stats._Attributes, __std_fs_file_attr::_Directory);
+                                _Bitmask_includes_any(_Target_stats._Attributes, __std_fs_file_attr::_Directory);
                         } else if (__std_is_file_not_found(_Error)
                                    || (_Error == __std_win_error::_Access_denied
-                                       && _Bitmask_includes(_Options, directory_options::skip_permission_denied))) {
+                                       && _Bitmask_includes_any(_Options, directory_options::skip_permission_denied))) {
                             // skip broken symlinks and permission denied (when configured)
                             _Error = __std_win_error::_Success;
                         }

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -2092,7 +2092,7 @@ struct _Is_trivially_swappable : bool_constant<_Is_trivially_swappable_v<_Ty>> {
     }
 
 template <class _Bitmask>
-_NODISCARD constexpr bool _Bitmask_includes(_Bitmask _Left, _Bitmask _Elements) noexcept {
+_NODISCARD constexpr bool _Bitmask_includes_any(_Bitmask _Left, _Bitmask _Elements) noexcept {
     return (_Left & _Elements) != _Bitmask{};
 }
 

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -2058,48 +2058,48 @@ struct _Is_trivially_swappable : bool_constant<_Is_trivially_swappable_v<_Ty>> {
     // true_type if and only if it is valid to swap two _Ty lvalues by exchanging object representations.
 };
 
-#define _BITMASK_OPS(_BITMASK)                                                                                      \
-    _NODISCARD constexpr _BITMASK operator&(_BITMASK _Left, _BITMASK _Right) noexcept { /* return _Left & _Right */ \
-        using _IntTy = _STD underlying_type_t<_BITMASK>;                                                            \
-        return static_cast<_BITMASK>(static_cast<_IntTy>(_Left) & static_cast<_IntTy>(_Right));                     \
-    }                                                                                                               \
-                                                                                                                    \
-    _NODISCARD constexpr _BITMASK operator|(_BITMASK _Left, _BITMASK _Right) noexcept { /* return _Left | _Right */ \
-        using _IntTy = _STD underlying_type_t<_BITMASK>;                                                            \
-        return static_cast<_BITMASK>(static_cast<_IntTy>(_Left) | static_cast<_IntTy>(_Right));                     \
-    }                                                                                                               \
-                                                                                                                    \
-    _NODISCARD constexpr _BITMASK operator^(_BITMASK _Left, _BITMASK _Right) noexcept { /* return _Left ^ _Right */ \
-        using _IntTy = _STD underlying_type_t<_BITMASK>;                                                            \
-        return static_cast<_BITMASK>(static_cast<_IntTy>(_Left) ^ static_cast<_IntTy>(_Right));                     \
-    }                                                                                                               \
-                                                                                                                    \
-    constexpr _BITMASK& operator&=(_BITMASK& _Left, _BITMASK _Right) noexcept { /* return _Left &= _Right */        \
-        return _Left = _Left & _Right;                                                                              \
-    }                                                                                                               \
-                                                                                                                    \
-    constexpr _BITMASK& operator|=(_BITMASK& _Left, _BITMASK _Right) noexcept { /* return _Left |= _Right */        \
-        return _Left = _Left | _Right;                                                                              \
-    }                                                                                                               \
-                                                                                                                    \
-    constexpr _BITMASK& operator^=(_BITMASK& _Left, _BITMASK _Right) noexcept { /* return _Left ^= _Right */        \
-        return _Left = _Left ^ _Right;                                                                              \
-    }                                                                                                               \
-                                                                                                                    \
-    _NODISCARD constexpr _BITMASK operator~(_BITMASK _Left) noexcept { /* return ~_Left */                          \
-        using _IntTy = _STD underlying_type_t<_BITMASK>;                                                            \
-        return static_cast<_BITMASK>(~static_cast<_IntTy>(_Left));                                                  \
-    }                                                                                                               \
-                                                                                                                    \
-    _NODISCARD constexpr bool _Bitmask_includes(                                                                    \
-        _BITMASK _Left, _BITMASK _Elements) noexcept { /* return (_Left & _Elements) != _BITMASK{} */               \
-        return (_Left & _Elements) != _BITMASK{};                                                                   \
-    }                                                                                                               \
-                                                                                                                    \
-    _NODISCARD constexpr bool _Bitmask_includes_all(                                                                \
-        _BITMASK _Left, _BITMASK _Elements) noexcept { /* return (_Left & _Elements) == _Elements */                \
-        return (_Left & _Elements) == _Elements;                                                                    \
+#define _BITMASK_OPS(_BITMASK)                                                                  \
+    _NODISCARD constexpr _BITMASK operator&(_BITMASK _Left, _BITMASK _Right) noexcept {         \
+        using _IntTy = _STD underlying_type_t<_BITMASK>;                                        \
+        return static_cast<_BITMASK>(static_cast<_IntTy>(_Left) & static_cast<_IntTy>(_Right)); \
+    }                                                                                           \
+                                                                                                \
+    _NODISCARD constexpr _BITMASK operator|(_BITMASK _Left, _BITMASK _Right) noexcept {         \
+        using _IntTy = _STD underlying_type_t<_BITMASK>;                                        \
+        return static_cast<_BITMASK>(static_cast<_IntTy>(_Left) | static_cast<_IntTy>(_Right)); \
+    }                                                                                           \
+                                                                                                \
+    _NODISCARD constexpr _BITMASK operator^(_BITMASK _Left, _BITMASK _Right) noexcept {         \
+        using _IntTy = _STD underlying_type_t<_BITMASK>;                                        \
+        return static_cast<_BITMASK>(static_cast<_IntTy>(_Left) ^ static_cast<_IntTy>(_Right)); \
+    }                                                                                           \
+                                                                                                \
+    constexpr _BITMASK& operator&=(_BITMASK& _Left, _BITMASK _Right) noexcept {                 \
+        return _Left = _Left & _Right;                                                          \
+    }                                                                                           \
+                                                                                                \
+    constexpr _BITMASK& operator|=(_BITMASK& _Left, _BITMASK _Right) noexcept {                 \
+        return _Left = _Left | _Right;                                                          \
+    }                                                                                           \
+                                                                                                \
+    constexpr _BITMASK& operator^=(_BITMASK& _Left, _BITMASK _Right) noexcept {                 \
+        return _Left = _Left ^ _Right;                                                          \
+    }                                                                                           \
+                                                                                                \
+    _NODISCARD constexpr _BITMASK operator~(_BITMASK _Left) noexcept {                          \
+        using _IntTy = _STD underlying_type_t<_BITMASK>;                                        \
+        return static_cast<_BITMASK>(~static_cast<_IntTy>(_Left));                              \
     }
+
+template <class _Bitmask>
+_NODISCARD constexpr bool _Bitmask_includes(_Bitmask _Left, _Bitmask _Elements) noexcept {
+    return (_Left & _Elements) != _Bitmask{};
+}
+
+template <class _Bitmask>
+_NODISCARD constexpr bool _Bitmask_includes_all(_Bitmask _Left, _Bitmask _Elements) noexcept {
+    return (_Left & _Elements) == _Elements;
+}
 
 // These FNV-1a utility functions are extremely performance sensitive,
 // check examples like that in VSO-653642 before making changes.

--- a/stl/inc/xfilesystem_abi.h
+++ b/stl/inc/xfilesystem_abi.h
@@ -129,7 +129,7 @@ struct __std_fs_stats {
     __std_fs_stats_flags _Available; // which fields are available
 
     _NODISCARD __std_fs_file_attr _Symlink_hint_attributes() const noexcept {
-        if (_STD _Bitmask_includes(_Available, __std_fs_stats_flags::_Attributes)) {
+        if (_STD _Bitmask_includes_any(_Available, __std_fs_stats_flags::_Attributes)) {
             return _Attributes;
         }
 

--- a/stl/inc/xfilesystem_abi.h
+++ b/stl/inc/xfilesystem_abi.h
@@ -129,7 +129,7 @@ struct __std_fs_stats {
     __std_fs_stats_flags _Available; // which fields are available
 
     _NODISCARD __std_fs_file_attr _Symlink_hint_attributes() const noexcept {
-        if (_Bitmask_includes(_Available, __std_fs_stats_flags::_Attributes)) {
+        if (_STD _Bitmask_includes(_Available, __std_fs_stats_flags::_Attributes)) {
             return _Attributes;
         }
 

--- a/stl/src/filesystem.cpp
+++ b/stl/src/filesystem.cpp
@@ -794,15 +794,15 @@ _Success_(return == __std_win_error::_Success) __std_win_error
 [[nodiscard]] _Success_(return == __std_win_error::_Success) __std_win_error
     __stdcall __std_fs_get_stats(_In_z_ const wchar_t* const _Path, __std_fs_stats* const _Stats,
         _In_ __std_fs_stats_flags _Flags, _In_ const __std_fs_file_attr _Symlink_attribute_hint) noexcept {
-    const bool _Follow_symlinks = _Bitmask_includes(_Flags, __std_fs_stats_flags::_Follow_symlinks);
+    const bool _Follow_symlinks = _STD _Bitmask_includes(_Flags, __std_fs_stats_flags::_Follow_symlinks);
     _Flags &= ~__std_fs_stats_flags::_Follow_symlinks;
-    if (_Follow_symlinks && _Bitmask_includes(_Flags, __std_fs_stats_flags::_Reparse_tag)) {
+    if (_Follow_symlinks && _STD _Bitmask_includes(_Flags, __std_fs_stats_flags::_Reparse_tag)) {
         return __std_win_error::_Invalid_parameter;
     }
 
-    if (_Bitmask_includes(_Flags, __std_fs_stats_flags::_Attributes)
+    if (_STD _Bitmask_includes(_Flags, __std_fs_stats_flags::_Attributes)
         && _Symlink_attribute_hint != __std_fs_file_attr::_Invalid
-        && (!_Bitmask_includes(_Symlink_attribute_hint, __std_fs_file_attr::_Reparse_point)
+        && (!_STD _Bitmask_includes(_Symlink_attribute_hint, __std_fs_file_attr::_Reparse_point)
             || !_Follow_symlinks)) { // if the hint can't be a symlink, we already have the attributes
         _Flags &= ~__std_fs_stats_flags::_Attributes;
         _Stats->_Attributes = _Symlink_attribute_hint;
@@ -814,10 +814,10 @@ _Success_(return == __std_win_error::_Success) __std_win_error
 
     constexpr auto _Get_file_attributes_data =
         __std_fs_stats_flags::_Attributes | __std_fs_stats_flags::_File_size | __std_fs_stats_flags::_Last_write_time;
-    if (_Bitmask_includes(_Flags, _Get_file_attributes_data)) {
+    if (_STD _Bitmask_includes(_Flags, _Get_file_attributes_data)) {
         // caller wants something GetFileAttributesExW/FindFirstFileW might provide
         if (_Symlink_attribute_hint == __std_fs_file_attr::_Invalid
-            || !_Bitmask_includes(_Symlink_attribute_hint, __std_fs_file_attr::_Reparse_point)
+            || !_STD _Bitmask_includes(_Symlink_attribute_hint, __std_fs_file_attr::_Reparse_point)
             || !_Follow_symlinks) { // we might not be a symlink or not following symlinks, so
                                     // GetFileAttributesExW/FindFirstFileW would return the right answer
 
@@ -849,7 +849,7 @@ _Success_(return == __std_win_error::_Success) __std_win_error
             }
 
             const __std_fs_file_attr _Attributes{_Data.dwFileAttributes};
-            if (!_Follow_symlinks || !_Bitmask_includes(_Attributes, __std_fs_file_attr::_Reparse_point)) {
+            if (!_Follow_symlinks || !_STD _Bitmask_includes(_Attributes, __std_fs_file_attr::_Reparse_point)) {
                 // if we aren't following symlinks or can't be a symlink, that data was useful, record
                 _Stats->_Attributes      = _Attributes;
                 _Stats->_File_size       = _Merge_to_ull(_Data.nFileSizeHigh, _Data.nFileSizeLow);
@@ -878,7 +878,7 @@ _Success_(return == __std_win_error::_Success) __std_win_error
     constexpr auto _Basic_info_data    = __std_fs_stats_flags::_Attributes | __std_fs_stats_flags::_Last_write_time;
     constexpr auto _Standard_info_data = __std_fs_stats_flags::_File_size | __std_fs_stats_flags::_Link_count;
 
-    if (_Bitmask_includes(_Flags, _Basic_info_data | __std_fs_stats_flags::_Reparse_tag)) {
+    if (_STD _Bitmask_includes(_Flags, _Basic_info_data | __std_fs_stats_flags::_Reparse_tag)) {
         FILE_BASIC_INFO _Info;
         if (!GetFileInformationByHandleEx(_Handle._Get(), FileBasicInfo, &_Info, sizeof(_Info))) {
             return __std_win_error{GetLastError()};
@@ -887,7 +887,7 @@ _Success_(return == __std_win_error::_Success) __std_win_error
         _Stats->_Attributes      = __std_fs_file_attr{_Info.FileAttributes};
         _Stats->_Last_write_time = _Info.LastWriteTime.QuadPart;
         _Flags &= ~_Basic_info_data;
-        if (_Bitmask_includes(_Flags, __std_fs_stats_flags::_Reparse_tag)) {
+        if (_STD _Bitmask_includes(_Flags, __std_fs_stats_flags::_Reparse_tag)) {
             // Calling GetFileInformationByHandleEx with FileAttributeTagInfo fails on FAT file system with
             // ERROR_INVALID_PARAMETER. We avoid calling this for non-reparse-points.
             if ((_Info.FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) != 0u) {
@@ -904,7 +904,7 @@ _Success_(return == __std_win_error::_Success) __std_win_error
         }
     }
 
-    if (_Bitmask_includes(_Flags, _Standard_info_data)) {
+    if (_STD _Bitmask_includes(_Flags, _Standard_info_data)) {
         FILE_STANDARD_INFO _Info;
         if (!GetFileInformationByHandleEx(_Handle._Get(), FileStandardInfo, &_Info, sizeof(_Info))) {
             return __std_win_error{GetLastError()};
@@ -936,7 +936,7 @@ _Success_(return == __std_win_error::_Success) __std_win_error
         _Last_error = __std_fs_get_stats(
             _New_directory, &_Stats, __std_fs_stats_flags::_Attributes | __std_fs_stats_flags::_Follow_symlinks);
         if (_Last_error == __std_win_error::_Success
-            && !_Bitmask_includes(_Stats._Attributes, __std_fs_file_attr::_Directory)) {
+            && !_STD _Bitmask_includes(_Stats._Attributes, __std_fs_file_attr::_Directory)) {
             _Last_error = __std_win_error::_Already_exists;
         }
     }

--- a/stl/src/filesystem.cpp
+++ b/stl/src/filesystem.cpp
@@ -794,15 +794,15 @@ _Success_(return == __std_win_error::_Success) __std_win_error
 [[nodiscard]] _Success_(return == __std_win_error::_Success) __std_win_error
     __stdcall __std_fs_get_stats(_In_z_ const wchar_t* const _Path, __std_fs_stats* const _Stats,
         _In_ __std_fs_stats_flags _Flags, _In_ const __std_fs_file_attr _Symlink_attribute_hint) noexcept {
-    const bool _Follow_symlinks = _STD _Bitmask_includes(_Flags, __std_fs_stats_flags::_Follow_symlinks);
+    const bool _Follow_symlinks = _STD _Bitmask_includes_any(_Flags, __std_fs_stats_flags::_Follow_symlinks);
     _Flags &= ~__std_fs_stats_flags::_Follow_symlinks;
-    if (_Follow_symlinks && _STD _Bitmask_includes(_Flags, __std_fs_stats_flags::_Reparse_tag)) {
+    if (_Follow_symlinks && _STD _Bitmask_includes_any(_Flags, __std_fs_stats_flags::_Reparse_tag)) {
         return __std_win_error::_Invalid_parameter;
     }
 
-    if (_STD _Bitmask_includes(_Flags, __std_fs_stats_flags::_Attributes)
+    if (_STD _Bitmask_includes_any(_Flags, __std_fs_stats_flags::_Attributes)
         && _Symlink_attribute_hint != __std_fs_file_attr::_Invalid
-        && (!_STD _Bitmask_includes(_Symlink_attribute_hint, __std_fs_file_attr::_Reparse_point)
+        && (!_STD _Bitmask_includes_any(_Symlink_attribute_hint, __std_fs_file_attr::_Reparse_point)
             || !_Follow_symlinks)) { // if the hint can't be a symlink, we already have the attributes
         _Flags &= ~__std_fs_stats_flags::_Attributes;
         _Stats->_Attributes = _Symlink_attribute_hint;
@@ -814,10 +814,10 @@ _Success_(return == __std_win_error::_Success) __std_win_error
 
     constexpr auto _Get_file_attributes_data =
         __std_fs_stats_flags::_Attributes | __std_fs_stats_flags::_File_size | __std_fs_stats_flags::_Last_write_time;
-    if (_STD _Bitmask_includes(_Flags, _Get_file_attributes_data)) {
+    if (_STD _Bitmask_includes_any(_Flags, _Get_file_attributes_data)) {
         // caller wants something GetFileAttributesExW/FindFirstFileW might provide
         if (_Symlink_attribute_hint == __std_fs_file_attr::_Invalid
-            || !_STD _Bitmask_includes(_Symlink_attribute_hint, __std_fs_file_attr::_Reparse_point)
+            || !_STD _Bitmask_includes_any(_Symlink_attribute_hint, __std_fs_file_attr::_Reparse_point)
             || !_Follow_symlinks) { // we might not be a symlink or not following symlinks, so
                                     // GetFileAttributesExW/FindFirstFileW would return the right answer
 
@@ -849,7 +849,7 @@ _Success_(return == __std_win_error::_Success) __std_win_error
             }
 
             const __std_fs_file_attr _Attributes{_Data.dwFileAttributes};
-            if (!_Follow_symlinks || !_STD _Bitmask_includes(_Attributes, __std_fs_file_attr::_Reparse_point)) {
+            if (!_Follow_symlinks || !_STD _Bitmask_includes_any(_Attributes, __std_fs_file_attr::_Reparse_point)) {
                 // if we aren't following symlinks or can't be a symlink, that data was useful, record
                 _Stats->_Attributes      = _Attributes;
                 _Stats->_File_size       = _Merge_to_ull(_Data.nFileSizeHigh, _Data.nFileSizeLow);
@@ -878,7 +878,7 @@ _Success_(return == __std_win_error::_Success) __std_win_error
     constexpr auto _Basic_info_data    = __std_fs_stats_flags::_Attributes | __std_fs_stats_flags::_Last_write_time;
     constexpr auto _Standard_info_data = __std_fs_stats_flags::_File_size | __std_fs_stats_flags::_Link_count;
 
-    if (_STD _Bitmask_includes(_Flags, _Basic_info_data | __std_fs_stats_flags::_Reparse_tag)) {
+    if (_STD _Bitmask_includes_any(_Flags, _Basic_info_data | __std_fs_stats_flags::_Reparse_tag)) {
         FILE_BASIC_INFO _Info;
         if (!GetFileInformationByHandleEx(_Handle._Get(), FileBasicInfo, &_Info, sizeof(_Info))) {
             return __std_win_error{GetLastError()};
@@ -887,7 +887,7 @@ _Success_(return == __std_win_error::_Success) __std_win_error
         _Stats->_Attributes      = __std_fs_file_attr{_Info.FileAttributes};
         _Stats->_Last_write_time = _Info.LastWriteTime.QuadPart;
         _Flags &= ~_Basic_info_data;
-        if (_STD _Bitmask_includes(_Flags, __std_fs_stats_flags::_Reparse_tag)) {
+        if (_STD _Bitmask_includes_any(_Flags, __std_fs_stats_flags::_Reparse_tag)) {
             // Calling GetFileInformationByHandleEx with FileAttributeTagInfo fails on FAT file system with
             // ERROR_INVALID_PARAMETER. We avoid calling this for non-reparse-points.
             if ((_Info.FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) != 0u) {
@@ -904,7 +904,7 @@ _Success_(return == __std_win_error::_Success) __std_win_error
         }
     }
 
-    if (_STD _Bitmask_includes(_Flags, _Standard_info_data)) {
+    if (_STD _Bitmask_includes_any(_Flags, _Standard_info_data)) {
         FILE_STANDARD_INFO _Info;
         if (!GetFileInformationByHandleEx(_Handle._Get(), FileStandardInfo, &_Info, sizeof(_Info))) {
             return __std_win_error{GetLastError()};
@@ -936,7 +936,7 @@ _Success_(return == __std_win_error::_Success) __std_win_error
         _Last_error = __std_fs_get_stats(
             _New_directory, &_Stats, __std_fs_stats_flags::_Attributes | __std_fs_stats_flags::_Follow_symlinks);
         if (_Last_error == __std_win_error::_Success
-            && !_STD _Bitmask_includes(_Stats._Attributes, __std_fs_file_attr::_Directory)) {
+            && !_STD _Bitmask_includes_any(_Stats._Attributes, __std_fs_file_attr::_Directory)) {
             _Last_error = __std_win_error::_Already_exists;
         }
     }


### PR DESCRIPTION
The helper functions `_Bitmask_includes()` and `_Bitmask_includes_all()` can be templates instead of being stamped out for every enum bitmask. These functions are used for only a few types.

We need to add `_STD` qualification to callsites that are outside `namespace std`, as we're no longer stamping out overloads in the global namespace.

Also remove unnecessary comments (ignore whitespace to see this clearly).

Also rename `_Bitmask_includes()` to `_Bitmask_includes_any()` for clarity.

Found while implementing Standard Library Modules, but this was blocked until toolset update #2861 with the fix for internal VSO-1509503 "Standard Library Header Units: Deduplication interferes with ADL for global `operator&`".