### PR TITLE
Fix LWG-3699 `lexically_relative` on UNC drive paths (`\\?\C:\...`) results in a default-constructed value

### DIFF
--- a/stl/inc/filesystem
+++ b/stl/inc/filesystem
@@ -1693,9 +1693,10 @@ namespace filesystem {
         // LWG-3699: `lexically_relative` on UNC drive paths (`\\?\C:\...`) results in a default-constructed value
         // This avoids doing any unnecessary copies;
         // the return value of `relative_path()` is lifetime-extended if necessary.
-        const path& _This = _Is_drive_prefix_with_slash_slash_question(_Text) ? relative_path() : *this;
-        const path& _Base =
-            _Is_drive_prefix_with_slash_slash_question(_Base_raw._Text) ? _Base_raw.relative_path() : _Base_raw;
+        const bool _Both_unc_paths = _Is_drive_prefix_with_slash_slash_question(_Text)
+                                  && _Is_drive_prefix_with_slash_slash_question(_Base_raw._Text);
+        const path& _This = _Both_unc_paths ? relative_path() : *this;
+        const path& _Base = _Both_unc_paths ? _Base_raw.relative_path() : _Base_raw;
 
         path _Result;
 

--- a/stl/inc/filesystem
+++ b/stl/inc/filesystem
@@ -1686,23 +1686,33 @@ namespace filesystem {
         return false;
     }
 
-    _NODISCARD inline path path::lexically_relative(const path& _Base) const {
+    _NODISCARD inline path path::lexically_relative(const path& _Base_) const {
+        // N4868 [fs.path.gen]
+
         constexpr wstring_view _Dot     = L"."sv;
         constexpr wstring_view _Dot_dot = L".."sv;
 
+        // LWG-3699: `lexically_relative` on UNC drive paths (`\\?\C:\...`) results in a default-constructed value
+        // This avoids doing any unnecessary copies;
+        // the return value of `relative_path()` is lifetime extended if necessary.
+        const path& _This = _Is_drive_prefix_with_slash_slash_question(native()) ? relative_path() : *this;
+        const path& _Base =
+            _Is_drive_prefix_with_slash_slash_question(_Base_.native()) ? _Base_.relative_path() : _Base_;
+
         path _Result;
 
-        if (root_name() != _Base.root_name() || is_absolute() != _Base.is_absolute()
-            || (!has_root_directory() && _Base.has_root_directory()) || _Relative_path_contains_root_name(*this)
-            || _Relative_path_contains_root_name(_Base)) {
+        if (_This.root_name() != _Base.root_name() || _This.is_absolute() != _Base.is_absolute()
+            || (!_This.has_root_directory() && _Base.has_root_directory())
+            || (_Relative_path_contains_root_name(_This) || _Relative_path_contains_root_name(_Base))) {
             return _Result;
         }
 
-        const iterator _This_end   = end();
+
+        const iterator _This_end   = _This.end();
         const iterator _Base_begin = _Base.begin();
         const iterator _Base_end   = _Base.end();
 
-        auto _Mismatched  = _STD mismatch(begin(), _This_end, _Base_begin, _Base_end);
+        auto _Mismatched  = _STD mismatch(_This.begin(), _This_end, _Base_begin, _Base_end);
         iterator& _A_iter = _Mismatched.first;
         iterator& _B_iter = _Mismatched.second;
 

--- a/stl/inc/filesystem
+++ b/stl/inc/filesystem
@@ -1686,18 +1686,16 @@ namespace filesystem {
         return false;
     }
 
-    _NODISCARD inline path path::lexically_relative(const path& _Base_) const {
-        // N4868 [fs.path.gen]
-
+    _NODISCARD inline path path::lexically_relative(const path& _Base_raw) const {
         constexpr wstring_view _Dot     = L"."sv;
         constexpr wstring_view _Dot_dot = L".."sv;
 
         // LWG-3699: `lexically_relative` on UNC drive paths (`\\?\C:\...`) results in a default-constructed value
         // This avoids doing any unnecessary copies;
-        // the return value of `relative_path()` is lifetime extended if necessary.
-        const path& _This = _Is_drive_prefix_with_slash_slash_question(native()) ? relative_path() : *this;
+        // the return value of `relative_path()` is lifetime-extended if necessary.
+        const path& _This = _Is_drive_prefix_with_slash_slash_question(_Text) ? relative_path() : *this;
         const path& _Base =
-            _Is_drive_prefix_with_slash_slash_question(_Base_.native()) ? _Base_.relative_path() : _Base_;
+            _Is_drive_prefix_with_slash_slash_question(_Base_raw._Text) ? _Base_raw.relative_path() : _Base_raw;
 
         path _Result;
 

--- a/tests/std/tests/P0218R1_filesystem/test.cpp
+++ b/tests/std/tests/P0218R1_filesystem/test.cpp
@@ -3148,9 +3148,11 @@ void test_lexically_relative() {
 
     // LWG-3699
     EXPECT(path(LR"(\\?\a:\meow)"sv).lexically_relative(LR"(\\?\a:\meow)"sv).native() == LR"(.)"sv);
-    EXPECT(path(LR"(a:\meow)"sv).lexically_relative(LR"(\\?\a:\meow)"sv).native() == LR"(.)"sv);
-    EXPECT(path(LR"(\\?\a:\meow)"sv).lexically_relative(LR"(a:\meow)"sv).native() == LR"(.)"sv);
-    EXPECT(path(LR"(\\?\a:\meow\purr\nyan)"sv).lexically_relative(LR"(a:\meow)"sv).native() == LR"(purr\nyan)"sv);
+    EXPECT(path(LR"(\\?\a:\meow\purr\nyan)"sv).lexically_relative(LR"(\\?\a:\meow)"sv).native() == LR"(purr\nyan)"sv);
+    EXPECT(path(LR"(\\?\a:\meow)"sv).lexically_relative(LR"(\\?\a:\meow\purr\nyan)"sv).native() == LR"(..\..)"sv);
+    // UNC/DOS together should return an empty path
+    EXPECT(path(LR"(a:\meow)"sv).lexically_relative(LR"(\\?\a:\meow)"sv).native().empty());
+    EXPECT(path(LR"(\\?\a:\meow)"sv).lexically_relative(LR"(a:\meow)"sv).native().empty());
 }
 
 void test_lexically_proximate() {

--- a/tests/std/tests/P0218R1_filesystem/test.cpp
+++ b/tests/std/tests/P0218R1_filesystem/test.cpp
@@ -3145,6 +3145,12 @@ void test_lexically_relative() {
 
     // LWG-3070
     EXPECT(path(LR"(\a:\b:)"sv).lexically_relative(LR"(\a:\c:)"sv).native() == LR"()"sv);
+
+    // LWG-3699
+    EXPECT(path(LR"(\\?\a:\foo)"sv).lexically_relative(LR"(\\?\a:\foo)"sv).native() == LR"(.)"sv);
+    EXPECT(path(LR"(a:\foo)"sv).lexically_relative(LR"(\\?\a:\foo)"sv).native() == LR"(.)"sv);
+    EXPECT(path(LR"(\\?\a:\foo)"sv).lexically_relative(LR"(a:\foo)"sv).native() == LR"(.)"sv);
+    EXPECT(path(LR"(\\?\a:\foo\bar\baz)"sv).lexically_relative(LR"(a:\foo)"sv).native() == LR"(bar\baz)"sv);
 }
 
 void test_lexically_proximate() {

--- a/tests/std/tests/P0218R1_filesystem/test.cpp
+++ b/tests/std/tests/P0218R1_filesystem/test.cpp
@@ -3147,10 +3147,10 @@ void test_lexically_relative() {
     EXPECT(path(LR"(\a:\b:)"sv).lexically_relative(LR"(\a:\c:)"sv).native() == LR"()"sv);
 
     // LWG-3699
-    EXPECT(path(LR"(\\?\a:\foo)"sv).lexically_relative(LR"(\\?\a:\foo)"sv).native() == LR"(.)"sv);
-    EXPECT(path(LR"(a:\foo)"sv).lexically_relative(LR"(\\?\a:\foo)"sv).native() == LR"(.)"sv);
-    EXPECT(path(LR"(\\?\a:\foo)"sv).lexically_relative(LR"(a:\foo)"sv).native() == LR"(.)"sv);
-    EXPECT(path(LR"(\\?\a:\foo\bar\baz)"sv).lexically_relative(LR"(a:\foo)"sv).native() == LR"(bar\baz)"sv);
+    EXPECT(path(LR"(\\?\a:\meow)"sv).lexically_relative(LR"(\\?\a:\meow)"sv).native() == LR"(.)"sv);
+    EXPECT(path(LR"(a:\meow)"sv).lexically_relative(LR"(\\?\a:\meow)"sv).native() == LR"(.)"sv);
+    EXPECT(path(LR"(\\?\a:\meow)"sv).lexically_relative(LR"(a:\meow)"sv).native() == LR"(.)"sv);
+    EXPECT(path(LR"(\\?\a:\meow\purr\nyan)"sv).lexically_relative(LR"(a:\meow)"sv).native() == LR"(purr\nyan)"sv);
 }
 
 void test_lexically_proximate() {


### PR DESCRIPTION
Fixes #2256 and LWG-3699

This is one choice of how to implement this; it makes `lexically_relative` treat `\\?\<drive letter>:\` as equivalent to `<drive letter>:\`; another option would _just_ be to allow `\\?\<drive letter>:\` and not have them be equivalent.