### PR TITLE
`<filesystem>` support junctions in `read_symlink`

### DIFF
--- a/stl/inc/filesystem
+++ b/stl/inc/filesystem
@@ -2062,11 +2062,11 @@ namespace filesystem {
         case file_type::regular:
         case file_type::directory:
         case file_type::symlink:
-        case file_type::junction:
             return false;
         case file_type::block:
         case file_type::character:
         case file_type::fifo:
+        case file_type::junction:
         case file_type::socket:
         case file_type::unknown:
         default:
@@ -2086,7 +2086,7 @@ namespace filesystem {
 
     _NODISCARD inline bool is_symlink(const file_status _Status) noexcept {
         // tests whether _Status indicates a symlink
-        return _Status.type() == file_type::symlink || _Status.type() == file_type::junction;
+        return _Status.type() == file_type::symlink;
     }
 
     struct _File_status_and_error {
@@ -3194,7 +3194,7 @@ namespace filesystem {
         }
     }
 
-    _NODISCARD inline __std_win_error _Read_symlink_reparse_data(
+    _NODISCARD inline __std_win_error _Read_reparse_data(
         const _Fs_file& _Handle, unique_ptr<char[]>& _Buffer_unique_ptr) noexcept {
         constexpr auto _Buffer_size = 16 * 1024 + sizeof(wchar_t); // MAXIMUM_REPARSE_DATA_BUFFER_SIZE + sizeof(wchar_t)
 
@@ -3222,7 +3222,7 @@ namespace filesystem {
                 return _Err;
             }
 
-            _Err = _Read_symlink_reparse_data(_Handle, _Buffer_unique_ptr);
+            _Err = _Read_reparse_data(_Handle, _Buffer_unique_ptr);
             if (_Err != __std_win_error::_Success) {
                 return _Err;
             }
@@ -3269,7 +3269,7 @@ namespace filesystem {
                 return _Err;
             }
 
-            _Err = _Read_symlink_reparse_data(_Handle, _Buffer_unique_ptr);
+            _Err = _Read_reparse_data(_Handle, _Buffer_unique_ptr);
             if (_Err != __std_win_error::_Success) {
                 return _Err;
             }
@@ -3284,6 +3284,12 @@ namespace filesystem {
         } // Close _Handle
 
         const auto _Buffer = reinterpret_cast<__std_fs_reparse_data_buffer*>(_Buffer_unique_ptr.get());
+
+        if (__std_fs_is_junction_from_reparse_data_buffer(_Buffer)) {
+            _Err = __std_win_error::_Reparse_tag_invalid;
+            return _Err;
+        }
+
         unsigned short _Length;
         wchar_t* _Offset;
         _Err = __std_fs_read_name_from_reparse_data_buffer(_Buffer, &_Offset, &_Length);
@@ -3297,6 +3303,59 @@ namespace filesystem {
             _Err = __std_fs_create_directory_symbolic_link(_New_symlink.c_str(), _Offset);
         } else {
             _Err = __std_fs_create_symbolic_link(_New_symlink.c_str(), _Offset);
+        }
+
+        return _Err;
+    }
+
+    _NODISCARD inline __std_win_error _Copy_junction(const path& _Junction, const path& _New_junction) noexcept {
+        __std_win_error _Err;
+        unique_ptr<char[]> _Buffer_unique_ptr;
+        {
+            const _Fs_file _Handle(_Junction.c_str(), __std_access_rights::_File_read_attributes,
+                __std_fs_file_flags::_Backup_semantics | __std_fs_file_flags::_Open_reparse_point, &_Err);
+            if (_Err != __std_win_error::_Success) {
+                return _Err;
+            }
+
+            _Err = _Read_reparse_data(_Handle, _Buffer_unique_ptr);
+            if (_Err != __std_win_error::_Success) {
+                return _Err;
+            }
+        } // Close _Handle
+
+        const auto _Buffer = reinterpret_cast<__std_fs_reparse_data_buffer*>(_Buffer_unique_ptr.get());
+
+        auto _Create_dir_res = __std_fs_create_directory(_New_junction.c_str());
+
+        if (_Create_dir_res._Error != __std_win_error::_Success) {
+            return _Create_dir_res._Error;
+        } else if (!_Create_dir_res._Created) {
+            return __std_win_error::_Already_exists;
+        }
+
+        struct _Delete_directory_scope_guard {
+            const wchar_t* _Path;
+            ~_Delete_directory_scope_guard() {
+                if (_Path) {
+                    (void) __std_fs_remove(_Path);
+                }
+            }
+        } _Delete_directory{_New_junction.c_str()};
+
+        _Fs_file _To_handle{
+            _New_junction.c_str(),
+            __std_access_rights::_File_write_attributes,
+            __std_fs_file_flags::_Backup_semantics,
+            &_Err,
+        };
+        if (_Err != __std_win_error::_Success) {
+            return _Err;
+        }
+        _Err = __std_fs_write_reparse_data_buffer(_To_handle._Raw, _Buffer);
+        if (_Err == __std_win_error::_Success) {
+            // don't delete the directory if we succeeded in making it a junction
+            _Delete_directory._Path = nullptr;
         }
 
         return _Err;
@@ -4207,8 +4266,12 @@ namespace filesystem {
             }
         }
 
-        if (_STD filesystem::is_other(_Fstat._Status) || _STD filesystem::is_other(_Tstat._Status)) {
-            // report an error if is_other(f) || is_other(t) is true
+        bool _Fstat_is_other =
+            _STD filesystem::is_other(_Fstat._Status) && _Fstat._Status.type() != file_type::junction;
+        bool _Tstat_is_other =
+            _STD filesystem::is_other(_Tstat._Status) && _Tstat._Status.type() != file_type::junction;
+        if (_Fstat_is_other || _Tstat_is_other) {
+            // report an error if is_other(f) || is_other(t) is true, and it's not a junction
             _Ec = _STD make_error_code(errc::operation_not_supported);
             return;
         }
@@ -4219,14 +4282,26 @@ namespace filesystem {
             return;
         }
 
+        if (_Fstat._Status.type() == file_type::junction) {
+            if ((_Options & copy_options::skip_symlinks) != copy_options::none) {
+                return;
+            }
+
+            // _Options includes copy_options::copy_symlinks,
+            // since _Fstat is only allowed to be a symbolic link when either skip_symlinks or copy_symlinks
+            if (!_STD filesystem::exists(_Tstat._Status)) {
+                _Ec = _Make_ec(_Copy_junction(_From, _To));
+            }
+        }
+
         if (_STD filesystem::is_symlink(_Fstat._Status)) {
             if ((_Options & copy_options::skip_symlinks) != copy_options::none) {
                 return;
             }
 
-            if (!_STD filesystem::exists(_Tstat._Status)
-                && (_Options & copy_options::copy_symlinks) != copy_options::none) {
-                // if (condition) then copy_symlink(from, to)
+            // _Options includes copy_options::copy_symlinks,
+            // since _Fstat is only allowed to be a symbolic link when either skip_symlinks or copy_symlinks
+            if (!_STD filesystem::exists(_Tstat._Status)) {
                 _STD filesystem::copy_symlink(_From, _To, _Ec);
                 return;
             }

--- a/stl/inc/filesystem
+++ b/stl/inc/filesystem
@@ -2062,13 +2062,13 @@ namespace filesystem {
         case file_type::regular:
         case file_type::directory:
         case file_type::symlink:
+        case file_type::junction:
             return false;
         case file_type::block:
         case file_type::character:
         case file_type::fifo:
         case file_type::socket:
         case file_type::unknown:
-        case file_type::junction:
         default:
             return true;
         }
@@ -2086,7 +2086,7 @@ namespace filesystem {
 
     _NODISCARD inline bool is_symlink(const file_status _Status) noexcept {
         // tests whether _Status indicates a symlink
-        return _Status.type() == file_type::symlink;
+        return _Status.type() == file_type::symlink || _Status.type() == file_type::junction;
     }
 
     struct _File_status_and_error {

--- a/stl/inc/filesystem
+++ b/stl/inc/filesystem
@@ -2066,9 +2066,9 @@ namespace filesystem {
         case file_type::block:
         case file_type::character:
         case file_type::fifo:
-        case file_type::junction:
         case file_type::socket:
         case file_type::unknown:
+        case file_type::junction:
         default:
             return true;
         }
@@ -3285,6 +3285,8 @@ namespace filesystem {
 
         const auto _Buffer = reinterpret_cast<__std_fs_reparse_data_buffer*>(_Buffer_unique_ptr.get());
 
+        // LWG-3744: `copy_symlink(junction, new_symlink)`'s behavior is unclear
+        // `read_symlink(junction)` should be allowed, but `copy_symlink(junction)` is not.
         if (__std_fs_is_junction_from_reparse_data_buffer(_Buffer)) {
             _Err = __std_win_error::_Reparse_tag_invalid;
             return _Err;

--- a/stl/inc/filesystem
+++ b/stl/inc/filesystem
@@ -3328,7 +3328,7 @@ namespace filesystem {
 
         const auto _Buffer = reinterpret_cast<__std_fs_reparse_data_buffer*>(_Buffer_unique_ptr.get());
 
-        auto _Create_dir_res = __std_fs_create_directory(_New_junction.c_str());
+        const auto _Create_dir_res = __std_fs_create_directory(_New_junction.c_str());
 
         if (_Create_dir_res._Error != __std_win_error::_Success) {
             return _Create_dir_res._Error;
@@ -3336,21 +3336,18 @@ namespace filesystem {
             return __std_win_error::_Already_exists;
         }
 
-        struct _Delete_directory_scope_guard {
+        struct _NODISCARD _Delete_directory_scope_guard {
             const wchar_t* _Path;
             ~_Delete_directory_scope_guard() {
                 if (_Path) {
                     (void) __std_fs_remove(_Path);
                 }
             }
-        } _Delete_directory{_New_junction.c_str()};
-
-        _Fs_file _To_handle{
-            _New_junction.c_str(),
-            __std_access_rights::_File_write_attributes,
-            __std_fs_file_flags::_Backup_semantics,
-            &_Err,
         };
+        _Delete_directory_scope_guard _Delete_directory{_New_junction.c_str()};
+
+        _Fs_file _To_handle{_New_junction.c_str(), __std_access_rights::_File_write_attributes,
+            __std_fs_file_flags::_Backup_semantics, &_Err};
         if (_Err != __std_win_error::_Success) {
             return _Err;
         }
@@ -4268,9 +4265,9 @@ namespace filesystem {
             }
         }
 
-        bool _Fstat_is_other =
+        const bool _Fstat_is_other =
             _STD filesystem::is_other(_Fstat._Status) && _Fstat._Status.type() != file_type::junction;
-        bool _Tstat_is_other =
+        const bool _Tstat_is_other =
             _STD filesystem::is_other(_Tstat._Status) && _Tstat._Status.type() != file_type::junction;
         if (_Fstat_is_other || _Tstat_is_other) {
             // report an error if is_other(f) || is_other(t) is true, and it's not a junction

--- a/stl/inc/xfilesystem_abi.h
+++ b/stl/inc/xfilesystem_abi.h
@@ -41,6 +41,7 @@ enum class __std_win_error : unsigned long {
     _Already_exists            = 183, // #define ERROR_ALREADY_EXISTS             183L
     _Filename_exceeds_range    = 206, // #define ERROR_FILENAME_EXCED_RANGE       206L
     _Directory_name_is_invalid = 267, // #define ERROR_DIRECTORY                  267L
+    _Reparse_tag_invalid       = 4393L, // #define ERROR_REPARSE_TAG_INVALID        4393L
     _Max                       = ~0UL // sentinel not used by Win32
 };
 
@@ -308,6 +309,12 @@ _NODISCARD __std_win_error __stdcall __std_fs_create_symbolic_link(
 
 _NODISCARD __std_win_error __stdcall __std_fs_read_reparse_data_buffer(_In_ __std_fs_file_handle _Handle,
     _Out_writes_bytes_(_Buffer_size) void* _Buffer, _In_ unsigned long _Buffer_size) noexcept;
+
+_NODISCARD __std_win_error __stdcall __std_fs_write_reparse_data_buffer(
+    _In_ __std_fs_file_handle _Handle, _In_ const __std_fs_reparse_data_buffer* const _Buffer) noexcept;
+
+[[nodiscard]] bool __stdcall __std_fs_is_junction_from_reparse_data_buffer(
+    _In_ const __std_fs_reparse_data_buffer* const _Buffer) noexcept;
 
 _NODISCARD _Success_(return == __std_win_error::_Success) __std_win_error
     __stdcall __std_fs_read_name_from_reparse_data_buffer(

--- a/stl/inc/xfilesystem_abi.h
+++ b/stl/inc/xfilesystem_abi.h
@@ -311,10 +311,10 @@ _NODISCARD __std_win_error __stdcall __std_fs_read_reparse_data_buffer(_In_ __st
     _Out_writes_bytes_(_Buffer_size) void* _Buffer, _In_ unsigned long _Buffer_size) noexcept;
 
 _NODISCARD __std_win_error __stdcall __std_fs_write_reparse_data_buffer(
-    _In_ __std_fs_file_handle _Handle, _In_ const __std_fs_reparse_data_buffer* const _Buffer) noexcept;
+    _In_ __std_fs_file_handle _Handle, _In_ const __std_fs_reparse_data_buffer* _Buffer) noexcept;
 
-[[nodiscard]] bool __stdcall __std_fs_is_junction_from_reparse_data_buffer(
-    _In_ const __std_fs_reparse_data_buffer* const _Buffer) noexcept;
+_NODISCARD bool __stdcall __std_fs_is_junction_from_reparse_data_buffer(
+    _In_ const __std_fs_reparse_data_buffer* _Buffer) noexcept;
 
 _NODISCARD _Success_(return == __std_win_error::_Success) __std_win_error
     __stdcall __std_fs_read_name_from_reparse_data_buffer(

--- a/stl/src/filesystem.cpp
+++ b/stl/src/filesystem.cpp
@@ -492,7 +492,7 @@ _Success_(return == __std_win_error::_Success) __std_win_error
 [[nodiscard]] _Success_(return == __std_win_error::_Success) __std_win_error
     __stdcall __std_fs_read_name_from_reparse_data_buffer(_In_ __std_fs_reparse_data_buffer* const _Buffer,
         _Out_ wchar_t** const _Offset, _Out_ unsigned short* const _Length) noexcept {
-    // this is a symlink (IO_REPARSE_TAG_SYMLINK) or junctino (IO_REPARSE_TAG_MOUNT_POINT)
+    // this is a symlink (IO_REPARSE_TAG_SYMLINK) or junction (IO_REPARSE_TAG_MOUNT_POINT)
     if (_Buffer->_Reparse_tag == IO_REPARSE_TAG_SYMLINK || _Buffer->_Reparse_tag == IO_REPARSE_TAG_MOUNT_POINT) {
         auto& _Symlink_buffer             = _Buffer->_Symbolic_link_reparse_buffer;
         const unsigned short _Temp_length = _Symlink_buffer._Print_name_length / sizeof(wchar_t);

--- a/stl/src/filesystem.cpp
+++ b/stl/src/filesystem.cpp
@@ -492,7 +492,8 @@ _Success_(return == __std_win_error::_Success) __std_win_error
 [[nodiscard]] _Success_(return == __std_win_error::_Success) __std_win_error
     __stdcall __std_fs_read_name_from_reparse_data_buffer(_In_ __std_fs_reparse_data_buffer* const _Buffer,
         _Out_ wchar_t** const _Offset, _Out_ unsigned short* const _Length) noexcept {
-    if (_Buffer->_Reparse_tag == IO_REPARSE_TAG_SYMLINK) {
+    // this is a symlink (IO_REPARSE_TAG_SYMLINK) or junctino (IO_REPARSE_TAG_MOUNT_POINT)
+    if (_Buffer->_Reparse_tag == IO_REPARSE_TAG_SYMLINK || _Buffer->_Reparse_tag == IO_REPARSE_TAG_MOUNT_POINT) {
         auto& _Symlink_buffer             = _Buffer->_Symbolic_link_reparse_buffer;
         const unsigned short _Temp_length = _Symlink_buffer._Print_name_length / sizeof(wchar_t);
 

--- a/tests/std/tests/P0218R1_filesystem/test.cpp
+++ b/tests/std/tests/P0218R1_filesystem/test.cpp
@@ -2882,7 +2882,6 @@ void test_status() {
     EXPECT(!is_other(file_status{file_type::not_found}));
     EXPECT(is_other(file_status{file_type::block}));
     EXPECT(is_other(file_status{file_type::character}));
-    EXPECT(is_other(file_status{file_type::junction}));
     EXPECT(is_other(file_status{file_type::socket}));
     EXPECT(is_other(file_status{file_type::unknown}));
     EXPECT(!is_regular_file(file_status{}));
@@ -2891,6 +2890,7 @@ void test_status() {
     EXPECT(is_socket(file_status{file_type::socket}));
     EXPECT(!is_symlink(file_status{}));
     EXPECT(is_symlink(file_status{file_type::symlink}));
+    EXPECT(is_symlink(file_status{file_type::junction}));
 
     for (auto&& nonexistent : nonexistentPaths) {
         EXPECT(!exists(nonexistent));

--- a/tests/std/tests/P0218R1_filesystem/test.cpp
+++ b/tests/std/tests/P0218R1_filesystem/test.cpp
@@ -2882,6 +2882,7 @@ void test_status() {
     EXPECT(!is_other(file_status{file_type::not_found}));
     EXPECT(is_other(file_status{file_type::block}));
     EXPECT(is_other(file_status{file_type::character}));
+    EXPECT(is_other(file_status{file_type::junction}));
     EXPECT(is_other(file_status{file_type::socket}));
     EXPECT(is_other(file_status{file_type::unknown}));
     EXPECT(!is_regular_file(file_status{}));
@@ -2890,7 +2891,6 @@ void test_status() {
     EXPECT(is_socket(file_status{file_type::socket}));
     EXPECT(!is_symlink(file_status{}));
     EXPECT(is_symlink(file_status{file_type::symlink}));
-    EXPECT(is_symlink(file_status{file_type::junction}));
 
     for (auto&& nonexistent : nonexistentPaths) {
         EXPECT(!exists(nonexistent));


### PR DESCRIPTION
* `is_symlink(junction)` is still `false`
* `read_symlink(junction)` works and does the obvious thing
* `copy_symlink(junction)` doesn't work - creating a directory symlink is bad, and creating a junction is not _really_ supported by the windows API (and also a junction is not a symlink)
* `copy(junction)` works and does the obvious thing

Fixes #2818