### PR TITLE
Implement LWG-3707: `chunk_view::outer-iterator::value_type::size` should return unsigned type

### DIFF
--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -5380,7 +5380,8 @@ namespace ranges {
                 _NODISCARD constexpr auto size() const
                     noexcept(noexcept(_RANGES end(_Parent->_Range) - *_Parent->_Current)) /* strengthened */
                     requires sized_sentinel_for<sentinel_t<_Vw>, iterator_t<_Vw>> {
-                    return (_STD min)(_Parent->_Remainder, _RANGES end(_Parent->_Range) - *_Parent->_Current);
+                    return _To_unsigned_like(
+                        (_STD min)(_Parent->_Remainder, _RANGES end(_Parent->_Range) - *_Parent->_Current));
                 }
             };
 

--- a/tests/std/tests/P2442R1_views_chunk/test.cpp
+++ b/tests/std/tests/P2442R1_views_chunk/test.cpp
@@ -460,7 +460,8 @@ constexpr bool test_input(Rng&& rng, Expected&& expected) {
 
     auto val_ty = *outer_iter;
     if constexpr (sized_sentinel_for<sentinel_t<Rng>, iterator_t<Rng>>) {
-        assert(val_ty.size() == 2);
+        const same_as<_Make_unsigned_like_t<ranges::range_difference_t<V>>> auto s = val_ty.size(); // test LWG-3707
+        assert(s == 2);
     }
 
     auto inner_iter                            = val_ty.begin();


### PR DESCRIPTION
<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
Implements [LWG-3707](https://cplusplus.github.io/LWG/issue3707).

Towards https://github.com/microsoft/STL/issues/2872.