### PR TITLE
Implement LWG-3719: Directory iterators should be usable with default sentinel

### DIFF
--- a/stl/inc/filesystem
+++ b/stl/inc/filesystem
@@ -2710,7 +2710,7 @@ namespace filesystem {
 
 #ifdef __cpp_lib_concepts
         _NODISCARD bool operator==(default_sentinel_t) const noexcept {
-            return *this == directory_iterator{};
+            return !_Impl;
         }
 #endif // __cpp_lib_concepts
 
@@ -2966,7 +2966,7 @@ namespace filesystem {
 
 #ifdef __cpp_lib_concepts
         _NODISCARD bool operator==(default_sentinel_t) const noexcept {
-            return *this == recursive_directory_iterator{};
+            return !_Impl;
         }
 #endif // __cpp_lib_concepts
 

--- a/stl/inc/filesystem
+++ b/stl/inc/filesystem
@@ -2708,6 +2708,12 @@ namespace filesystem {
         }
 #endif // !_HAS_CXX20
 
+#ifdef __cpp_lib_concepts
+        _NODISCARD bool operator==(default_sentinel_t) const noexcept {
+            return *this == directory_iterator{};
+        }
+#endif // __cpp_lib_concepts
+
         _Directory_entry_proxy operator++(int) {
             _Directory_entry_proxy _Proxy(**this);
             ++*this;
@@ -2957,6 +2963,12 @@ namespace filesystem {
             return _Impl != _Rhs._Impl;
         }
 #endif // !_HAS_CXX20
+
+#ifdef __cpp_lib_concepts
+        _NODISCARD bool operator==(default_sentinel_t) const noexcept {
+            return *this == recursive_directory_iterator{};
+        }
+#endif // __cpp_lib_concepts
 
         _Directory_entry_proxy operator++(int) {
             _Directory_entry_proxy _Proxy(**this);

--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -2417,6 +2417,12 @@ public:
     }
 #endif // !_HAS_CXX20
 
+#ifdef __cpp_lib_concepts
+    _NODISCARD bool operator==(default_sentinel_t) const {
+        return *this == regex_iterator{};
+    }
+#endif // __cpp_lib_concepts
+
     _NODISCARD const value_type& operator*() const {
 #if _ITERATOR_DEBUG_LEVEL != 0
         _STL_VERIFY(_MyRe, "regex_iterator not dereferenceable");
@@ -2600,6 +2606,12 @@ public:
         return !(*this == _Right);
     }
 #endif // !_HAS_CXX20
+
+#ifdef __cpp_lib_concepts
+    _NODISCARD bool operator==(default_sentinel_t) const {
+        return *this == regex_token_iterator{};
+    }
+#endif // __cpp_lib_concepts
 
     _NODISCARD const value_type& operator*() const {
 #if _ITERATOR_DEBUG_LEVEL != 0

--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -2419,7 +2419,7 @@ public:
 
 #ifdef __cpp_lib_concepts
     _NODISCARD bool operator==(default_sentinel_t) const {
-        return *this == regex_iterator{};
+        return !_MyRe;
     }
 #endif // __cpp_lib_concepts
 
@@ -2609,7 +2609,7 @@ public:
 
 #ifdef __cpp_lib_concepts
     _NODISCARD bool operator==(default_sentinel_t) const {
-        return *this == regex_token_iterator{};
+        return !_Res;
     }
 #endif // __cpp_lib_concepts
 

--- a/tests/std/tests/P0896R4_stream_iterators/test.cpp
+++ b/tests/std/tests/P0896R4_stream_iterators/test.cpp
@@ -107,74 +107,105 @@ void test_ostreambuf_iterator(basic_ostream<CharT, Traits>& os) {
 #endif // __cpp_lib_concepts
 }
 
-template <class BidIt, class CharT = typename iterator_traits<BidIt>::value_type, class Traits = regex_traits<CharT>>
-void test_regex_iterator() {
-    using I = regex_iterator<BidIt, CharT, Traits>;
-    STATIC_ASSERT(is_same_v<typename I::difference_type, ptrdiff_t>);
-    STATIC_ASSERT(is_same_v<typename I::iterator_category, forward_iterator_tag>);
+template <class C>
+constexpr auto statically_widen_impl(const char* narrow_str, const wchar_t* wide_str) noexcept {
+    if constexpr (is_same_v<C, char>) {
+        return narrow_str;
+    } else {
+        return wide_str;
+    }
+}
 
+#define STATICALLY_WIDEN(C, S) statically_widen_impl<C>(S, L##S)
+
+template <class Sequence>
+void test_regex_iterator(const Sequence& seq) {
 #ifdef __cpp_lib_concepts
-    const I i{};
+    using SequenceIter = decltype(cbegin(seq));
+    using CharT = remove_cv_t<iter_value_t<SequenceIter>>;
+    using I = regex_iterator<SequenceIter>;
 
-    assert(i == default_sentinel);
-    assert(default_sentinel == i);
-    assert(!(i != default_sentinel));
-    assert(!(default_sentinel != i));
+    const I end_it{};
+    assert(end_it == default_sentinel);
+    assert(default_sentinel == end_it);
+    assert(!(end_it != default_sentinel));
+    assert(!(default_sentinel != end_it));
 
-    STATIC_ASSERT(forward_iterator<I>);
+    basic_regex<CharT> re(STATICALLY_WIDEN(CharT, "[a-z]"));
+    const I begin_it{cbegin(seq), cend(seq), re};
+    assert(begin_it != default_sentinel);
+    assert(default_sentinel != begin_it);
+    assert(!(begin_it == default_sentinel));
+    assert(!(default_sentinel == begin_it));
 #endif // __cpp_lib_concepts
 }
 
-template <class BidIt, class CharT = typename iterator_traits<BidIt>::value_type, class Traits = regex_traits<CharT>>
-void test_regex_token_iterator() {
-    using I = regex_token_iterator<BidIt, CharT, Traits>;
-    STATIC_ASSERT(is_same_v<typename I::difference_type, ptrdiff_t>);
-    STATIC_ASSERT(is_same_v<typename I::iterator_category, forward_iterator_tag>);
-
+template <class Sequence>
+void test_regex_token_iterator(const Sequence& seq) {
 #ifdef __cpp_lib_concepts
-    const I i{};
+    using SequenceIter = decltype(cbegin(seq));
+    using CharT = remove_cv_t<iter_value_t<SequenceIter>>;
+    using I = regex_token_iterator<SequenceIter>;
 
-    assert(i == default_sentinel);
-    assert(default_sentinel == i);
-    assert(!(i != default_sentinel));
-    assert(!(default_sentinel != i));
+    const I end_it{};
+    assert(end_it == default_sentinel);
+    assert(default_sentinel == end_it);
+    assert(!(end_it != default_sentinel));
+    assert(!(default_sentinel != end_it));
 
-    STATIC_ASSERT(forward_iterator<I>);
+    basic_regex<CharT> re(STATICALLY_WIDEN(CharT, "[a-z]"));
+    const I begin_it{cbegin(seq), cend(seq), re};
+    assert(begin_it != default_sentinel);
+    assert(default_sentinel != begin_it);
+    assert(!(begin_it == default_sentinel));
+    assert(!(default_sentinel == begin_it));
 #endif // __cpp_lib_concepts
 }
 
 #if _HAS_CXX17
 void test_directory_iterator() {
-    using I = filesystem::directory_iterator;
-    STATIC_ASSERT(is_same_v<typename I::difference_type, ptrdiff_t>);
-    STATIC_ASSERT(is_same_v<typename I::iterator_category, input_iterator_tag>);
-
 #ifdef __cpp_lib_concepts
-    const I i{};
+    using I = filesystem::directory_iterator;
 
-    assert(i == default_sentinel);
-    assert(default_sentinel == i);
-    assert(!(i != default_sentinel));
-    assert(!(default_sentinel != i));
+    const I end_it{};
+    STATIC_ASSERT(noexcept(end_it == default_sentinel));
+    STATIC_ASSERT(noexcept(end_it != default_sentinel));
+    STATIC_ASSERT(noexcept(default_sentinel == end_it));
+    STATIC_ASSERT(noexcept(default_sentinel != end_it));
 
-    STATIC_ASSERT(input_iterator<I>);
+    assert(end_it == default_sentinel);
+    assert(default_sentinel == end_it);
+    assert(!(end_it != default_sentinel));
+    assert(!(default_sentinel != end_it));
+
+    I begin_it{filesystem::path{L"."}};
+    assert(begin_it != default_sentinel);
+    assert(default_sentinel != begin_it);
+    assert(!(begin_it == default_sentinel));
+    assert(!(default_sentinel == begin_it));
 #endif // __cpp_lib_concepts
 }
 
 void test_recursive_directory_iterator() {
-    using I = filesystem::recursive_directory_iterator;
-    STATIC_ASSERT(is_same_v<typename I::difference_type, ptrdiff_t>);
-    STATIC_ASSERT(is_same_v<typename I::iterator_category, input_iterator_tag>);
-
 #ifdef __cpp_lib_concepts
-    const I i{};
+    using I = filesystem::recursive_directory_iterator;
 
-    assert(i == default_sentinel);
-    assert(default_sentinel == i);
-    assert(!(i != default_sentinel));
-    assert(!(default_sentinel != i));
+    const I end_it{};
+    STATIC_ASSERT(noexcept(end_it == default_sentinel));
+    STATIC_ASSERT(noexcept(end_it != default_sentinel));
+    STATIC_ASSERT(noexcept(default_sentinel == end_it));
+    STATIC_ASSERT(noexcept(default_sentinel != end_it));
 
-    STATIC_ASSERT(input_iterator<I>);
+    assert(end_it == default_sentinel);
+    assert(default_sentinel == end_it);
+    assert(!(end_it != default_sentinel));
+    assert(!(default_sentinel != end_it));
+
+    I begin_it{filesystem::path{L"."}};
+    assert(begin_it != default_sentinel);
+    assert(default_sentinel != begin_it);
+    assert(!(begin_it == default_sentinel));
+    assert(!(default_sentinel == begin_it));
 #endif // __cpp_lib_concepts
 }
 #endif // _HAS_CXX17
@@ -196,15 +227,15 @@ int main() {
     test_ostreambuf_iterator(cout);
     test_ostreambuf_iterator(wcout);
 
-    test_regex_iterator<const char*>();
-    test_regex_iterator<const wchar_t*>();
-    test_regex_iterator<string::const_iterator>();
-    test_regex_iterator<wstring::const_iterator>();
+    test_regex_iterator("hello world");
+    test_regex_iterator(L"hello world");
+    test_regex_iterator(string("hello world"));
+    test_regex_iterator(wstring(L"hello world"));
 
-    test_regex_token_iterator<const char*>();
-    test_regex_token_iterator<const wchar_t*>();
-    test_regex_token_iterator<string::const_iterator>();
-    test_regex_token_iterator<wstring::const_iterator>();
+    test_regex_token_iterator("hello world");
+    test_regex_token_iterator(L"hello world");
+    test_regex_token_iterator(string("hello world"));
+    test_regex_token_iterator(wstring(L"hello world"));
 
 #if _HAS_CXX17
     test_directory_iterator();

--- a/tests/std/tests/P0896R4_stream_iterators/test.cpp
+++ b/tests/std/tests/P0896R4_stream_iterators/test.cpp
@@ -134,7 +134,7 @@ void test_regex_iterator(const Sequence& seq) {
     assert(!(default_sentinel != end_it));
 
     basic_regex<CharT> re(STATICALLY_WIDEN(CharT, "[a-z]"));
-    const I begin_it{cbegin(seq), cend(seq), re};
+    I begin_it{cbegin(seq), cend(seq), re};
     assert(begin_it != default_sentinel);
     assert(default_sentinel != begin_it);
     assert(!(begin_it == default_sentinel));
@@ -157,11 +157,17 @@ void test_regex_token_iterator(const Sequence& seq) {
     assert(!(default_sentinel != end_it));
 
     basic_regex<CharT> re(STATICALLY_WIDEN(CharT, "[a-z]"));
-    const I begin_it{cbegin(seq), cend(seq), re};
+    I begin_it{cbegin(seq), cend(seq), re};
     assert(begin_it != default_sentinel);
     assert(default_sentinel != begin_it);
     assert(!(begin_it == default_sentinel));
     assert(!(default_sentinel == begin_it));
+
+    ranges::advance(begin_it, end_it);
+    assert(begin_it == default_sentinel);
+    assert(default_sentinel == begin_it);
+    assert(!(begin_it != default_sentinel));
+    assert(!(default_sentinel != begin_it));
 #endif // __cpp_lib_concepts
 }
 
@@ -186,6 +192,12 @@ void test_directory_iterator() {
     assert(default_sentinel != begin_it);
     assert(!(begin_it == default_sentinel));
     assert(!(default_sentinel == begin_it));
+
+    ranges::advance(begin_it, end_it);
+    assert(begin_it == default_sentinel);
+    assert(default_sentinel == begin_it);
+    assert(!(begin_it != default_sentinel));
+    assert(!(default_sentinel != begin_it));
 #endif // __cpp_lib_concepts
 }
 
@@ -209,6 +221,12 @@ void test_recursive_directory_iterator() {
     assert(default_sentinel != begin_it);
     assert(!(begin_it == default_sentinel));
     assert(!(default_sentinel == begin_it));
+
+    ranges::advance(begin_it, end_it);
+    assert(begin_it == default_sentinel);
+    assert(default_sentinel == begin_it);
+    assert(!(begin_it != default_sentinel));
+    assert(!(default_sentinel != begin_it));
 #endif // __cpp_lib_concepts
 }
 #endif // _HAS_CXX17

--- a/tests/std/tests/P0896R4_stream_iterators/test.cpp
+++ b/tests/std/tests/P0896R4_stream_iterators/test.cpp
@@ -120,6 +120,7 @@ constexpr auto statically_widen_impl(const char* narrow_str, const wchar_t* wide
 
 template <class Sequence>
 void test_regex_iterator(const Sequence& seq) {
+    (void) seq;
 #ifdef __cpp_lib_concepts
     using SequenceIter = decltype(cbegin(seq));
     using CharT        = remove_cv_t<iter_value_t<SequenceIter>>;
@@ -142,6 +143,7 @@ void test_regex_iterator(const Sequence& seq) {
 
 template <class Sequence>
 void test_regex_token_iterator(const Sequence& seq) {
+    (void) seq;
 #ifdef __cpp_lib_concepts
     using SequenceIter = decltype(cbegin(seq));
     using CharT        = remove_cv_t<iter_value_t<SequenceIter>>;

--- a/tests/std/tests/P0896R4_stream_iterators/test.cpp
+++ b/tests/std/tests/P0896R4_stream_iterators/test.cpp
@@ -107,13 +107,14 @@ void test_ostreambuf_iterator(basic_ostream<CharT, Traits>& os) {
 #endif // __cpp_lib_concepts
 }
 
-template <class C>
-constexpr auto statically_widen_impl(const char* narrow_str, const wchar_t* wide_str) noexcept {
-    if constexpr (is_same_v<C, char>) {
-        return narrow_str;
-    } else {
-        return wide_str;
-    }
+template <class C, enable_if_t<is_same_v<C, char>, int> = 0>
+constexpr auto statically_widen_impl(const char* narrow_str, const wchar_t*) noexcept {
+    return narrow_str;
+}
+
+template <class C, enable_if_t<!is_same_v<C, char>, int> = 0>
+constexpr auto statically_widen_impl(const char*, const wchar_t* wide_str) noexcept {
+    return wide_str;
 }
 
 #define STATICALLY_WIDEN(C, S) statically_widen_impl<C>(S, L##S)

--- a/tests/std/tests/P0896R4_stream_iterators/test.cpp
+++ b/tests/std/tests/P0896R4_stream_iterators/test.cpp
@@ -2,14 +2,20 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 // Covers Ranges changes to istream_iterator, ostream_iterator, istreambuf_iterator, and ostreambuf_iterator
+// and LWG-3719 changes for directory_iterator, recursive_directory_iterator, regex_iterator, and regex_token_iterator
 
 #include <cassert>
 #include <cstddef>
 #include <iostream>
 #include <iterator>
+#include <regex>
 #include <string>
 #include <type_traits>
 #include <utility>
+
+#if _HAS_CXX17
+#include <filesystem>
+#endif // _HAS_CXX17
 
 using namespace std;
 
@@ -101,6 +107,78 @@ void test_ostreambuf_iterator(basic_ostream<CharT, Traits>& os) {
 #endif // __cpp_lib_concepts
 }
 
+template <class BidIt, class CharT = typename iterator_traits<BidIt>::value_type, class Traits = regex_traits<CharT>>
+void test_regex_iterator() {
+    using I = regex_iterator<BidIt, CharT, Traits>;
+    STATIC_ASSERT(is_same_v<typename I::difference_type, ptrdiff_t>);
+    STATIC_ASSERT(is_same_v<typename I::iterator_category, forward_iterator_tag>);
+
+#ifdef __cpp_lib_concepts
+    const I i{};
+
+    assert(i == default_sentinel);
+    assert(default_sentinel == i);
+    assert(!(i != default_sentinel));
+    assert(!(default_sentinel != i));
+
+    STATIC_ASSERT(forward_iterator<I>);
+#endif // __cpp_lib_concepts
+}
+
+template <class BidIt, class CharT = typename iterator_traits<BidIt>::value_type, class Traits = regex_traits<CharT>>
+void test_regex_token_iterator() {
+    using I = regex_token_iterator<BidIt, CharT, Traits>;
+    STATIC_ASSERT(is_same_v<typename I::difference_type, ptrdiff_t>);
+    STATIC_ASSERT(is_same_v<typename I::iterator_category, forward_iterator_tag>);
+
+#ifdef __cpp_lib_concepts
+    const I i{};
+
+    assert(i == default_sentinel);
+    assert(default_sentinel == i);
+    assert(!(i != default_sentinel));
+    assert(!(default_sentinel != i));
+
+    STATIC_ASSERT(forward_iterator<I>);
+#endif // __cpp_lib_concepts
+}
+
+#if _HAS_CXX17
+void test_directory_iterator() {
+    using I = filesystem::directory_iterator;
+    STATIC_ASSERT(is_same_v<typename I::difference_type, ptrdiff_t>);
+    STATIC_ASSERT(is_same_v<typename I::iterator_category, input_iterator_tag>);
+
+#ifdef __cpp_lib_concepts
+    const I i{};
+
+    assert(i == default_sentinel);
+    assert(default_sentinel == i);
+    assert(!(i != default_sentinel));
+    assert(!(default_sentinel != i));
+
+    STATIC_ASSERT(input_iterator<I>);
+#endif // __cpp_lib_concepts
+}
+
+void test_recursive_directory_iterator() {
+    using I = filesystem::recursive_directory_iterator;
+    STATIC_ASSERT(is_same_v<typename I::difference_type, ptrdiff_t>);
+    STATIC_ASSERT(is_same_v<typename I::iterator_category, input_iterator_tag>);
+
+#ifdef __cpp_lib_concepts
+    const I i{};
+
+    assert(i == default_sentinel);
+    assert(default_sentinel == i);
+    assert(!(i != default_sentinel));
+    assert(!(default_sentinel != i));
+
+    STATIC_ASSERT(input_iterator<I>);
+#endif // __cpp_lib_concepts
+}
+#endif // _HAS_CXX17
+
 int main() {
     test_istream_iterator<int>();
     test_istream_iterator<string>();
@@ -117,4 +195,19 @@ int main() {
 
     test_ostreambuf_iterator(cout);
     test_ostreambuf_iterator(wcout);
+
+    test_regex_iterator<const char*>();
+    test_regex_iterator<const wchar_t*>();
+    test_regex_iterator<string::const_iterator>();
+    test_regex_iterator<wstring::const_iterator>();
+
+    test_regex_token_iterator<const char*>();
+    test_regex_token_iterator<const wchar_t*>();
+    test_regex_token_iterator<string::const_iterator>();
+    test_regex_token_iterator<wstring::const_iterator>();
+
+#if _HAS_CXX17
+    test_directory_iterator();
+    test_recursive_directory_iterator();
+#endif // _HAS_CXX17
 }

--- a/tests/std/tests/P0896R4_stream_iterators/test.cpp
+++ b/tests/std/tests/P0896R4_stream_iterators/test.cpp
@@ -122,8 +122,8 @@ template <class Sequence>
 void test_regex_iterator(const Sequence& seq) {
 #ifdef __cpp_lib_concepts
     using SequenceIter = decltype(cbegin(seq));
-    using CharT = remove_cv_t<iter_value_t<SequenceIter>>;
-    using I = regex_iterator<SequenceIter>;
+    using CharT        = remove_cv_t<iter_value_t<SequenceIter>>;
+    using I            = regex_iterator<SequenceIter>;
 
     const I end_it{};
     assert(end_it == default_sentinel);
@@ -144,8 +144,8 @@ template <class Sequence>
 void test_regex_token_iterator(const Sequence& seq) {
 #ifdef __cpp_lib_concepts
     using SequenceIter = decltype(cbegin(seq));
-    using CharT = remove_cv_t<iter_value_t<SequenceIter>>;
-    using I = regex_token_iterator<SequenceIter>;
+    using CharT        = remove_cv_t<iter_value_t<SequenceIter>>;
+    using I            = regex_token_iterator<SequenceIter>;
 
     const I end_it{};
     assert(end_it == default_sentinel);

--- a/tests/std/tests/P0896R4_stream_iterators/test.cpp
+++ b/tests/std/tests/P0896R4_stream_iterators/test.cpp
@@ -139,6 +139,12 @@ void test_regex_iterator(const Sequence& seq) {
     assert(default_sentinel != begin_it);
     assert(!(begin_it == default_sentinel));
     assert(!(default_sentinel == begin_it));
+
+    ranges::advance(begin_it, end_it);
+    assert(begin_it == default_sentinel);
+    assert(default_sentinel == begin_it);
+    assert(!(begin_it != default_sentinel));
+    assert(!(default_sentinel != begin_it));
 #endif // __cpp_lib_concepts
 }
 
@@ -250,13 +256,13 @@ int main() {
 
     test_regex_iterator("hello world");
     test_regex_iterator(L"hello world");
-    test_regex_iterator(string("hello world"));
-    test_regex_iterator(wstring(L"hello world"));
+    test_regex_iterator(string{"hello world"});
+    test_regex_iterator(wstring{L"hello world"});
 
     test_regex_token_iterator("hello world");
     test_regex_token_iterator(L"hello world");
-    test_regex_token_iterator(string("hello world"));
-    test_regex_token_iterator(wstring(L"hello world"));
+    test_regex_token_iterator(string{"hello world"});
+    test_regex_token_iterator(wstring{L"hello world"});
 
 #if _HAS_CXX17
     test_directory_iterator();


### PR DESCRIPTION
Towards #2872. Adding test coverage to the test file for stream iterators and `default_sentinel_t`.