### PR TITLE
Implement LWG-3721: Allow an arg-id with a value of zero for width in std-format-spec

### DIFF
--- a/stl/inc/format
+++ b/stl/inc/format
@@ -1421,15 +1421,10 @@ public:
     template <class _Ty>
     _NODISCARD constexpr unsigned long long operator()(const _Ty _Value) const {
         if constexpr (is_integral_v<_Ty>) {
-            bool _Negative;
-            if constexpr (same_as<_Ty, bool>) { // avoid "bool < 0", which triggers C4804
-                _Negative = false;
-            } else {
-                _Negative = _Value < 0;
-            }
-
-            if (_Negative) {
-                _Throw_format_error("width is negative.");
+            if constexpr (is_signed_v<_Ty>) {
+                if (_Value < 0) {
+                    _Throw_format_error("Negative width.");
+                }
             }
             return static_cast<unsigned long long>(_Value);
         } else {

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -1421,15 +1421,15 @@ public:
     template <class _Ty>
     _NODISCARD constexpr unsigned long long operator()(const _Ty _Value) const {
         if constexpr (is_integral_v<_Ty>) {
-            bool _Positive;
-            if constexpr (same_as<_Ty, bool>) { // avoid "bool > 0", which triggers C4804
-                _Positive = _Value != 0;
+            bool _Negative;
+            if constexpr (same_as<_Ty, bool>) { // avoid "bool < 0", which triggers C4804
+                _Negative = false;
             } else {
-                _Positive = _Value > 0;
+                _Negative = _Value < 0;
             }
 
-            if (!_Positive) {
-                _Throw_format_error("width is not positive.");
+            if (_Negative) {
+                _Throw_format_error("width is negative.");
             }
             return static_cast<unsigned long long>(_Value);
         } else {

--- a/tests/std/tests/P0645R10_text_formatting_death/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_death/test.cpp
@@ -17,12 +17,17 @@ void test_case_advance_no_range() {
     context.advance_to(other_format_string.begin());
 }
 
+void test_case_negative_dynamic_width() {
+    (void) format("{:{}}", 42, -2);
+}
+
 int main(int argc, char* argv[]) {
     std_testing::death_test_executive exec;
 
 #if _ITERATOR_DEBUG_LEVEL != 0
     exec.add_death_tests({
         test_case_advance_no_range,
+        test_case_negative_dynamic_width,
     });
 #endif // _ITERATOR_DEBUG_LEVEL != 0
 

--- a/tests/std/tests/P0645R10_text_formatting_death/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_death/test.cpp
@@ -17,17 +17,12 @@ void test_case_advance_no_range() {
     context.advance_to(other_format_string.begin());
 }
 
-void test_case_zero_dynamic_width() {
-    (void) format("{:{}}", 42, 0);
-}
-
 int main(int argc, char* argv[]) {
     std_testing::death_test_executive exec;
 
 #if _ITERATOR_DEBUG_LEVEL != 0
     exec.add_death_tests({
         test_case_advance_no_range,
-        test_case_zero_dynamic_width,
     });
 #endif // _ITERATOR_DEBUG_LEVEL != 0
 

--- a/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
@@ -1287,6 +1287,8 @@ void libfmt_formatter_test_runtime_width() {
            == STR("                                               0")); // behavior differs from libfmt, but conforms
     throw_helper(STR("{0:{1}}"), 0, 0.0);
 
+    assert(format(STR("{0:{1}}"), 42, 0) == STR("42")); // LWG-3721: zero dynamic width is OK
+
     assert(format(STR("{0:{1}}"), -42, 4) == STR(" -42"));
     assert(format(STR("{0:{1}}"), 42u, 5) == STR("   42"));
     assert(format(STR("{0:{1}}"), -42l, 6) == STR("   -42"));


### PR DESCRIPTION
Towards #2872.