### PR TITLE
Implement LWG-3712: `chunk_view` and `slide_view` should not be `default_initializable`

### DIFF
--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -5248,8 +5248,8 @@ namespace ranges {
         requires input_range<_Vw>
     class chunk_view : public view_interface<chunk_view<_Vw>> {
     private:
-        /* [[no_unique_address]] */ _Vw _Range{};
-        range_difference_t<_Vw> _Count     = 0;
+        /* [[no_unique_address]] */ _Vw _Range;
+        range_difference_t<_Vw> _Count;
         range_difference_t<_Vw> _Remainder = 0;
         _Non_propagating_cache<iterator_t<_Vw>> _Current{};
 
@@ -5430,10 +5430,6 @@ namespace ranges {
         };
 
     public:
-        // clang-format off
-        chunk_view() requires default_initializable<_Vw> = default;
-        // clang-format on
-
         constexpr explicit chunk_view(_Vw _Range_, const range_difference_t<_Vw> _Count_) noexcept(
             is_nothrow_move_constructible_v<_Vw>) /* strengthened */
             : _Range(_STD move(_Range_)), _Count{_Count_} {
@@ -5477,8 +5473,8 @@ namespace ranges {
         requires forward_range<_Vw>
     class chunk_view<_Vw> : public view_interface<chunk_view<_Vw>> {
     private:
-        /* [[no_unique_address]] */ _Vw _Range{};
-        range_difference_t<_Vw> _Count = 0;
+        /* [[no_unique_address]] */ _Vw _Range;
+        range_difference_t<_Vw> _Count;
 
         template <bool _Const>
         class _Iterator {
@@ -5690,10 +5686,6 @@ namespace ranges {
         };
 
     public:
-        // clang-format off
-        chunk_view() requires default_initializable<_Vw> = default;
-        // clang-format on
-
         constexpr explicit chunk_view(_Vw _Range_, const range_difference_t<_Vw> _Count_) noexcept(
             is_nothrow_move_constructible_v<_Vw>) /* strengthened */
             : _Range(_STD move(_Range_)), _Count{_Count_} {
@@ -5818,8 +5810,8 @@ namespace ranges {
         requires view<_Vw>
     class slide_view : public _Cached_position_t<!_Slide_caches_nothing<_Vw>, _Vw, slide_view<_Vw>> {
     private:
-        /* [[no_unique_address]] */ _Vw _Range{};
-        range_difference_t<_Vw> _Count = 0;
+        /* [[no_unique_address]] */ _Vw _Range;
+        range_difference_t<_Vw> _Count;
 
         template <class>
         class _Iter_base {};
@@ -6052,10 +6044,6 @@ namespace ranges {
         };
 
     public:
-        // clang-format off
-        slide_view() requires default_initializable<_Vw> = default;
-        // clang-format on
-
         constexpr explicit slide_view(_Vw _Range_, const range_difference_t<_Vw> _Count_) noexcept(
             is_nothrow_move_constructible_v<_Vw>) /* strengthened */
             : _Range(_STD move(_Range_)), _Count{_Count_} {}

--- a/tests/std/tests/P2442R1_views_chunk/test.cpp
+++ b/tests/std/tests/P2442R1_views_chunk/test.cpp
@@ -35,9 +35,10 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
     STATIC_ASSERT(forward_range<R> == forward_range<Rng>);
     STATIC_ASSERT(bidirectional_range<R> == bidirectional_range<Rng>);
     STATIC_ASSERT(random_access_range<R> == random_access_range<Rng>);
+
     // Validate non-default-initializability
     STATIC_ASSERT(!is_default_constructible_v<R>);
-    STATIC_ASSERT(!default_initializable<R>);
+
     // Validate borrowed_range
     STATIC_ASSERT(ranges::borrowed_range<R> == (ranges::borrowed_range<V> && forward_range<V>) );
 
@@ -63,7 +64,6 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
         constexpr bool is_noexcept = !is_view || is_nothrow_copy_constructible_v<V>;
 
         STATIC_ASSERT(!is_default_constructible_v<RC>);
-        STATIC_ASSERT(!default_initializable<RC>);
 
         STATIC_ASSERT(same_as<decltype(views::chunk(as_const(rng), 2)), RC>);
         STATIC_ASSERT(noexcept(views::chunk(as_const(rng), 2)) == is_noexcept);
@@ -79,7 +79,6 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
         constexpr bool is_noexcept = is_nothrow_move_constructible_v<V>;
 
         STATIC_ASSERT(!is_default_constructible_v<RS>);
-        STATIC_ASSERT(!default_initializable<RS>);
 
         STATIC_ASSERT(same_as<decltype(views::chunk(move(rng), 2)), RS>);
         STATIC_ASSERT(noexcept(views::chunk(move(rng), 2)) == is_noexcept);

--- a/tests/std/tests/P2442R1_views_chunk/test.cpp
+++ b/tests/std/tests/P2442R1_views_chunk/test.cpp
@@ -35,7 +35,7 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
     STATIC_ASSERT(forward_range<R> == forward_range<Rng>);
     STATIC_ASSERT(bidirectional_range<R> == bidirectional_range<Rng>);
     STATIC_ASSERT(random_access_range<R> == random_access_range<Rng>);
-    // LWG-3712: Validate non-default-initializability
+    // Validate non-default-initializability
     STATIC_ASSERT(!is_default_constructible_v<R>);
     STATIC_ASSERT(!default_initializable<R>);
     // Validate borrowed_range

--- a/tests/std/tests/P2442R1_views_chunk/test.cpp
+++ b/tests/std/tests/P2442R1_views_chunk/test.cpp
@@ -35,6 +35,9 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
     STATIC_ASSERT(forward_range<R> == forward_range<Rng>);
     STATIC_ASSERT(bidirectional_range<R> == bidirectional_range<Rng>);
     STATIC_ASSERT(random_access_range<R> == random_access_range<Rng>);
+    // LWG-3712: Validate non-default-initializability
+    STATIC_ASSERT(!is_default_constructible_v<R>);
+    STATIC_ASSERT(!default_initializable<R>);
     // Validate borrowed_range
     STATIC_ASSERT(ranges::borrowed_range<R> == (ranges::borrowed_range<V> && forward_range<V>) );
 
@@ -59,6 +62,9 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
         using RC                   = chunk_view<views::all_t<const remove_reference_t<Rng>&>>;
         constexpr bool is_noexcept = !is_view || is_nothrow_copy_constructible_v<V>;
 
+        STATIC_ASSERT(!is_default_constructible_v<RC>);
+        STATIC_ASSERT(!default_initializable<RC>);
+
         STATIC_ASSERT(same_as<decltype(views::chunk(as_const(rng), 2)), RC>);
         STATIC_ASSERT(noexcept(views::chunk(as_const(rng), 2)) == is_noexcept);
 
@@ -71,6 +77,9 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
     if constexpr (CanViewChunk<remove_reference_t<Rng>>) {
         using RS                   = chunk_view<views::all_t<remove_reference_t<Rng>>>;
         constexpr bool is_noexcept = is_nothrow_move_constructible_v<V>;
+
+        STATIC_ASSERT(!is_default_constructible_v<RS>);
+        STATIC_ASSERT(!default_initializable<RS>);
 
         STATIC_ASSERT(same_as<decltype(views::chunk(move(rng), 2)), RS>);
         STATIC_ASSERT(noexcept(views::chunk(move(rng), 2)) == is_noexcept);

--- a/tests/std/tests/P2442R1_views_slide/test.cpp
+++ b/tests/std/tests/P2442R1_views_slide/test.cpp
@@ -39,6 +39,10 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
     STATIC_ASSERT(bidirectional_range<R> == bidirectional_range<Rng>);
     STATIC_ASSERT(random_access_range<R> == random_access_range<Rng>);
 
+    // LWG-3712: Validate non-default-initializability
+    STATIC_ASSERT(!is_default_constructible_v<R>);
+    STATIC_ASSERT(!default_initializable<R>);
+
     // Validate borrowed_range
     static_assert(ranges::borrowed_range<R> == ranges::borrowed_range<V>);
 
@@ -63,6 +67,9 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
         using RC                   = slide_view<views::all_t<const remove_reference_t<Rng>&>>;
         constexpr bool is_noexcept = !is_view || is_nothrow_copy_constructible_v<V>;
 
+        STATIC_ASSERT(!is_default_constructible_v<RC>);
+        STATIC_ASSERT(!default_initializable<RC>);
+
         STATIC_ASSERT(same_as<decltype(views::slide(as_const(rng), 4)), RC>);
         STATIC_ASSERT(noexcept(views::slide(as_const(rng), 4)) == is_noexcept);
 
@@ -75,6 +82,9 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
     if constexpr (CanViewSlide<remove_reference_t<Rng>>) {
         using RS                   = slide_view<views::all_t<remove_reference_t<Rng>>>;
         constexpr bool is_noexcept = is_nothrow_move_constructible_v<V>;
+
+        STATIC_ASSERT(!is_default_constructible_v<RS>);
+        STATIC_ASSERT(!default_initializable<RS>);
 
         STATIC_ASSERT(same_as<decltype(views::slide(move(rng), 4)), RS>);
         STATIC_ASSERT(noexcept(views::slide(move(rng), 4)) == is_noexcept);

--- a/tests/std/tests/P2442R1_views_slide/test.cpp
+++ b/tests/std/tests/P2442R1_views_slide/test.cpp
@@ -41,7 +41,6 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
 
     // Validate non-default-initializability
     STATIC_ASSERT(!is_default_constructible_v<R>);
-    STATIC_ASSERT(!default_initializable<R>);
 
     // Validate borrowed_range
     static_assert(ranges::borrowed_range<R> == ranges::borrowed_range<V>);
@@ -68,7 +67,6 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
         constexpr bool is_noexcept = !is_view || is_nothrow_copy_constructible_v<V>;
 
         STATIC_ASSERT(!is_default_constructible_v<RC>);
-        STATIC_ASSERT(!default_initializable<RC>);
 
         STATIC_ASSERT(same_as<decltype(views::slide(as_const(rng), 4)), RC>);
         STATIC_ASSERT(noexcept(views::slide(as_const(rng), 4)) == is_noexcept);
@@ -84,7 +82,6 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
         constexpr bool is_noexcept = is_nothrow_move_constructible_v<V>;
 
         STATIC_ASSERT(!is_default_constructible_v<RS>);
-        STATIC_ASSERT(!default_initializable<RS>);
 
         STATIC_ASSERT(same_as<decltype(views::slide(move(rng), 4)), RS>);
         STATIC_ASSERT(noexcept(views::slide(move(rng), 4)) == is_noexcept);

--- a/tests/std/tests/P2442R1_views_slide/test.cpp
+++ b/tests/std/tests/P2442R1_views_slide/test.cpp
@@ -39,7 +39,7 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
     STATIC_ASSERT(bidirectional_range<R> == bidirectional_range<Rng>);
     STATIC_ASSERT(random_access_range<R> == random_access_range<Rng>);
 
-    // LWG-3712: Validate non-default-initializability
+    // Validate non-default-initializability
     STATIC_ASSERT(!is_default_constructible_v<R>);
     STATIC_ASSERT(!default_initializable<R>);
 


### PR DESCRIPTION
Towards #2872.