### PR TITLE
Implement LWG-3701: Make `formatter<remove_cvref_t<const charT[N]>, charT>` requirement explicit

### DIFF
--- a/stl/inc/format
+++ b/stl/inc/format
@@ -3337,6 +3337,9 @@ struct formatter<const _CharT*, _CharT>
     : _Formatter_base<const _CharT*, _CharT, _Basic_format_arg_type::_CString_type> {};
 
 template <_Format_supported_charT _CharT, size_t _Nx>
+struct formatter<_CharT[_Nx], _CharT> : _Formatter_base<_CharT[_Nx], _CharT, _Basic_format_arg_type::_CString_type> {};
+
+template <_Format_supported_charT _CharT, size_t _Nx>
 struct formatter<const _CharT[_Nx], _CharT>
     : _Formatter_base<const _CharT[_Nx], _CharT, _Basic_format_arg_type::_CString_type> {};
 

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -3341,7 +3341,7 @@ struct formatter<_CharT[_Nx], _CharT> : _Formatter_base<_CharT[_Nx], _CharT, _Ba
 
 template <_Format_supported_charT _CharT, size_t _Nx>
 struct formatter<const _CharT[_Nx], _CharT>
-    : _Formatter_base<const _CharT[_Nx], _CharT, _Basic_format_arg_type::_CString_type> {};
+    : _Formatter_base<_CharT[_Nx], _CharT, _Basic_format_arg_type::_CString_type> {};
 
 template <_Format_supported_charT _CharT, class _Traits, class _Allocator>
 struct formatter<basic_string<_CharT, _Traits, _Allocator>, _CharT>


### PR DESCRIPTION
Fixes #2953 
