### PR TITLE
Implement P2408R5: Ranges Iterators As Inputs To Non-Ranges Algorithms

### DIFF
--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -647,8 +647,8 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, _Enable_if_execution_policy
 _NODISCARD pair<_FwdIt1, _FwdIt2> mismatch(
     _ExPo&& _Exec, const _FwdIt1 _First1, const _FwdIt1 _Last1, const _FwdIt2 _First2) noexcept /* terminates */ {
     // return [_First1, _Last1)/[_First2, ...) mismatch
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
     return _STD mismatch(_STD forward<_ExPo>(_Exec), _First1, _Last1, _First2, equal_to{});
 }
 #endif // _HAS_CXX17
@@ -663,7 +663,7 @@ _NODISCARD _CONSTEXPR20 pair<_InIt1, _InIt2> mismatch(
     auto _ULast1       = _Get_unwrapped(_Last1);
     auto _UFirst2      = _Get_unwrapped(_First2);
     const auto _ULast2 = _Get_unwrapped(_Last2);
-    if constexpr (_Is_random_iter_v<_InIt1> && _Is_random_iter_v<_InIt2>) {
+    if constexpr (_Is_ranges_random_iter_v<_InIt1> && _Is_ranges_random_iter_v<_InIt2>) {
         using _CT         = _Common_diff_t<_InIt1, _InIt2>;
         const _CT _Count1 = _ULast1 - _UFirst1;
         const _CT _Count2 = _ULast2 - _UFirst2;
@@ -702,8 +702,8 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, _Enable_if_execution_policy
 _NODISCARD pair<_FwdIt1, _FwdIt2> mismatch(
     _ExPo&& _Exec, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2, _FwdIt2 _Last2) noexcept /* terminates */ {
     // return [_First1, _Last1)/[_First2, _Last2) mismatch
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
     return _STD mismatch(_STD forward<_ExPo>(_Exec), _First1, _Last1, _First2, _Last2, equal_to{});
 }
 #endif // _HAS_CXX17
@@ -853,7 +853,7 @@ _NODISCARD _CONSTEXPR20 bool is_permutation(
     auto _ULast1  = _Get_unwrapped(_Last1);
     auto _UFirst2 = _Get_unwrapped(_First2);
     auto _ULast2  = _Get_unwrapped(_Last2);
-    if constexpr (_Is_random_iter_v<_FwdIt1> && _Is_random_iter_v<_FwdIt2>) {
+    if constexpr (_Is_ranges_random_iter_v<_FwdIt1> && _Is_ranges_random_iter_v<_FwdIt2>) {
         if (_ULast1 - _UFirst1 != _ULast2 - _UFirst2) {
             return false;
         }
@@ -1448,8 +1448,8 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, class _Pr, _Enable_if_execu
 _FwdIt2 copy_if(_ExPo&&, _FwdIt1 _First, _FwdIt1 _Last, _FwdIt2 _Dest, _Pr _Pred) noexcept /* terminates */ {
     // copy each satisfying _Pred
     // not parallelized at present, parallelism expected to be feasible in a future release
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt2);
     return _STD copy_if(_First, _Last, _Dest, _Pass_fn(_Pred));
 }
 #endif // _HAS_CXX17
@@ -1637,9 +1637,9 @@ pair<_FwdIt2, _FwdIt3> partition_copy(_ExPo&&, _FwdIt1 _First, _FwdIt1 _Last, _F
     _Pr _Pred) noexcept /* terminates */ {
     // copy true partition to _Dest_true, false to _Dest_false
     // not parallelized at present, parallelism expected to be feasible in a future release
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt2);
-    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt3);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt2);
+    _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt3);
     return _STD partition_copy(_First, _Last, _Dest_true, _Dest_false, _Pass_fn(_Pred));
 }
 
@@ -1947,7 +1947,7 @@ _NODISCARD _CONSTEXPR20 _FwdItHaystack search(_FwdItHaystack _First1, _FwdItHays
     const auto _ULast1  = _Get_unwrapped(_Last1);
     const auto _UFirst2 = _Get_unwrapped(_First2);
     const auto _ULast2  = _Get_unwrapped(_Last2);
-    if constexpr (_Is_random_iter_v<_FwdItHaystack> && _Is_random_iter_v<_FwdItPat>) {
+    if constexpr (_Is_ranges_random_iter_v<_FwdItHaystack> && _Is_ranges_random_iter_v<_FwdItPat>) {
         const _Iter_diff_t<_FwdItPat> _Count2 = _ULast2 - _UFirst2;
         if (_ULast1 - _UFirst1 >= _Count2) {
             const auto _Last_possible = _ULast1 - static_cast<_Iter_diff_t<_FwdItHaystack>>(_Count2);
@@ -2027,7 +2027,7 @@ _NODISCARD _CONSTEXPR20 _FwdIt search_n(
     _Adl_verify_range(_First, _Last);
     auto _UFirst      = _Get_unwrapped(_First);
     const auto _ULast = _Get_unwrapped(_Last);
-    if constexpr (_Is_random_iter_v<_FwdIt>) {
+    if constexpr (_Is_ranges_random_iter_v<_FwdIt>) {
         const auto _Count_diff = static_cast<_Iter_diff_t<_FwdIt>>(_Count);
         auto _UOld_first       = _UFirst;
         for (_Iter_diff_t<_FwdIt> _Inc = 0; _Count_diff <= _ULast - _UOld_first;) { // enough room, look for a match
@@ -2569,7 +2569,7 @@ _NODISCARD _CONSTEXPR20 _FwdIt1 find_end(
     const auto _ULast1  = _Get_unwrapped(_Last1);
     const auto _UFirst2 = _Get_unwrapped(_First2);
     const auto _ULast2  = _Get_unwrapped(_Last2);
-    if constexpr (_Is_random_iter_v<_FwdIt1> && _Is_random_iter_v<_FwdIt2>) {
+    if constexpr (_Is_ranges_random_iter_v<_FwdIt1> && _Is_ranges_random_iter_v<_FwdIt2>) {
         const _Iter_diff_t<_FwdIt2> _Count2 = _ULast2 - _UFirst2;
         if (_Count2 > 0 && _Count2 <= _ULast1 - _UFirst1) {
             for (auto _UCandidate = _ULast1 - static_cast<_Iter_diff_t<_FwdIt1>>(_Count2);; --_UCandidate) {
@@ -2585,7 +2585,7 @@ _NODISCARD _CONSTEXPR20 _FwdIt1 find_end(
         }
 
         return _Last1;
-    } else if constexpr (_Is_bidi_iter_v<_FwdIt1> && _Is_bidi_iter_v<_FwdIt2>) {
+    } else if constexpr (_Is_ranges_bidi_iter_v<_FwdIt1> && _Is_ranges_bidi_iter_v<_FwdIt2>) {
         for (auto _UCandidate = _ULast1;; --_UCandidate) { // try a match at _UCandidate
             auto _UNext1 = _UCandidate;
             auto _UNext2 = _ULast2;
@@ -3369,8 +3369,8 @@ _FwdIt2 replace_copy(_ExPo&&, _FwdIt1 _First, _FwdIt1 _Last, _FwdIt2 _Dest, cons
     const _Ty& _Newval) noexcept /* terminates */ {
     // copy replacing each matching _Oldval with _Newval
     // not parallelized at present, parallelism expected to be feasible in a future release
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt2);
     return _STD replace_copy(_First, _Last, _Dest, _Oldval, _Newval);
 }
 #endif // _HAS_CXX17
@@ -3464,8 +3464,8 @@ _FwdIt2 replace_copy_if(_ExPo&&, _FwdIt1 _First, _FwdIt1 _Last, _FwdIt2 _Dest, _
 /* terminates */ {
     // copy replacing each satisfying _Pred with _Val
     // not parallelized at present, parallelism expected to be feasible in a future release
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt2);
     return _STD replace_copy_if(_First, _Last, _Dest, _Pass_fn(_Pred), _Val);
 }
 #endif // _HAS_CXX17
@@ -3683,7 +3683,7 @@ template <class _ExPo, class _FwdIt, class _Diff, class _Fn, _Enable_if_executio
 _FwdIt generate_n(_ExPo&&, const _FwdIt _Dest, const _Diff _Count_raw, _Fn _Func) noexcept /* terminates */ {
     // replace [_Dest, _Dest + _Count) with _Func()
     // not parallelized at present due to unclear parallelism requirements on _Func
-    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt);
+    _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt);
     return _STD generate_n(_Dest, _Count_raw, _Pass_fn(_Func));
 }
 #endif // _HAS_CXX17
@@ -3711,8 +3711,8 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, class _Ty, _Enable_if_execu
 _FwdIt2 remove_copy(_ExPo&&, _FwdIt1 _First, _FwdIt1 _Last, _FwdIt2 _Dest, const _Ty& _Val) noexcept /* terminates */ {
     // copy omitting each matching _Val
     // not parallelized at present, parallelism expected to be feasible in a future release
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt2);
     return _STD remove_copy(_First, _Last, _Dest, _Val);
 }
 #endif // _HAS_CXX17
@@ -3740,8 +3740,8 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, class _Pr, _Enable_if_execu
 _FwdIt2 remove_copy_if(_ExPo&&, _FwdIt1 _First, _FwdIt1 _Last, _FwdIt2 _Dest, _Pr _Pred) noexcept /* terminates */ {
     // copy omitting each element satisfying _Pred
     // not parallelized at present, parallelism expected to be feasible in a future release
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt2);
     return _STD remove_copy_if(_First, _Last, _Dest, _Pass_fn(_Pred));
 }
 #endif // _HAS_CXX17
@@ -4102,8 +4102,7 @@ concept
 #else
 _INLINE_VAR constexpr bool
 #endif
-    _Can_reread_dest = _Is_fwd_iter_v<_OutIt> //
-    && is_same_v<_Iter_value_t<_InIt>, _Iter_value_t<_OutIt>>;
+    _Can_reread_dest = _Is_cpp17_fwd_iter_v<_OutIt> && is_same_v<_Iter_value_t<_InIt>, _Iter_value_t<_OutIt>>;
 
 template <class _InIt, class _OutIt, class _Pr>
 _CONSTEXPR20 _OutIt unique_copy(_InIt _First, _InIt _Last, _OutIt _Dest, _Pr _Pred) {
@@ -4171,8 +4170,8 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, class _Pr, _Enable_if_execu
 _FwdIt2 unique_copy(_ExPo&&, _FwdIt1 _First, _FwdIt1 _Last, _FwdIt2 _Dest, _Pr _Pred) noexcept /* terminates */ {
     // copy compressing pairs that match
     // not parallelized at present, parallelism expected to be feasible in a future release
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt2);
     return _STD unique_copy(_First, _Last, _Dest, _Pass_fn(_Pred));
 }
 
@@ -4180,8 +4179,8 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, _Enable_if_execution_policy
 _FwdIt2 unique_copy(_ExPo&&, _FwdIt1 _First, _FwdIt1 _Last, _FwdIt2 _Dest) noexcept /* terminates */ {
     // copy compressing pairs that match
     // not parallelized at present, parallelism expected to be feasible in a future release
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt2);
     return _STD unique_copy(_First, _Last, _Dest);
 }
 #endif // _HAS_CXX17
@@ -4408,8 +4407,8 @@ template <class _ExPo, class _BidIt, class _FwdIt, _Enable_if_execution_policy_t
 _FwdIt reverse_copy(_ExPo&&, _BidIt _First, _BidIt _Last, _FwdIt _Dest) noexcept /* terminates */ {
     // copy reversing elements in [_First, _Last)
     // not parallelized as benchmarks show it isn't worth it
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_BidIt);
-    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt);
+    _REQUIRE_PARALLEL_ITERATOR(_BidIt);
+    _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt);
     return _STD reverse_copy(_First, _Last, _Dest);
 }
 
@@ -4624,8 +4623,8 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, _Enable_if_execution_policy
 _FwdIt2 rotate_copy(_ExPo&&, _FwdIt1 _First, _FwdIt1 _Mid, _FwdIt1 _Last, _FwdIt2 _Dest) noexcept /* terminates */ {
     // copy rotating [_First, _Last)
     // not parallelized as benchmarks show it isn't worth it
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt2);
     return _STD rotate_copy(_First, _Mid, _Last, _Dest);
 }
 
@@ -4729,8 +4728,8 @@ _SampleIt _Sample_selection_unchecked(
 template <class _PopIt, class _SampleIt, class _Diff, class _Urng>
 _SampleIt sample(_PopIt _First, _PopIt _Last, _SampleIt _Dest, _Diff _Count, _Urng&& _Func) {
     // randomly select _Count elements from [_First, _Last) into _Dest
-    static_assert(_Is_ranges_fwd_iter_v<_PopIt> || _Is_random_iter_v<_SampleIt>,
-        "If the source range is not forward, the destination range must be random-access.");
+    static_assert(_Is_ranges_fwd_iter_v<_PopIt> || _Is_cpp17_random_iter_v<_SampleIt>,
+        "If the source range is not forward, the destination range must be a Cpp17RandomAccessIterator.");
 
     static_assert(is_integral_v<_Diff>, "The sample size must have an integer type.");
     _Adl_verify_range(_First, _Last);
@@ -4749,12 +4748,11 @@ _SampleIt sample(_PopIt _First, _PopIt _Last, _SampleIt _Dest, _Diff _Count, _Ur
 
             _Seek_wrapped(_Dest,
                 _Sample_selection_unchecked(_UFirst, _Pop_size, _Get_unwrapped_n(_Dest, _Count), _Count, _RngFunc));
-        } else if constexpr (_Is_input_iter_v<_PopIt>) {
+        } else {
+            static_assert(_Is_ranges_input_iter_v<_PopIt>, "Source iterators must be at least input iterators");
             // source is input: use reservoir sampling (unstable)
             _Seek_wrapped(_Dest,
                 _Sample_reservoir_unchecked(_UFirst, _ULast, _Get_unwrapped_unverified(_Dest), _Count, _RngFunc));
-        } else {
-            static_assert(_Always_false<_PopIt>, "Source iterators must be at least input iterators");
         }
     }
 
@@ -5001,6 +4999,7 @@ template <class _FwdIt>
 constexpr _FwdIt shift_left(_FwdIt _First, const _FwdIt _Last, _Iter_diff_t<_FwdIt> _Pos_to_shift) {
     // shift [_First, _Last) left by _Pos_to_shift
     // positions; returns the end of the resulting range
+    _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt);
     _STL_ASSERT(_Pos_to_shift >= 0, "shift count must be non-negative (N4910 [alg.shift]/1)");
 
     _Adl_verify_range(_First, _Last);
@@ -5013,7 +5012,7 @@ constexpr _FwdIt shift_left(_FwdIt _First, const _FwdIt _Last, _Iter_diff_t<_Fwd
     const auto _ULast  = _Get_unwrapped(_Last);
     auto _Start_at     = _UFirst;
 
-    if constexpr (_Is_random_iter_v<_FwdIt>) {
+    if constexpr (_Is_cpp17_random_iter_v<_FwdIt>) {
         if (_Pos_to_shift >= _ULast - _UFirst) {
             return _First;
         }
@@ -5042,6 +5041,7 @@ template <class _FwdIt>
 constexpr _FwdIt shift_right(_FwdIt _First, const _FwdIt _Last, _Iter_diff_t<_FwdIt> _Pos_to_shift) {
     // shift [_First, _Last) right by _Pos_to_shift
     // positions; returns the beginning of the resulting range
+    _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt);
     _STL_ASSERT(_Pos_to_shift >= 0, "shift count must be non-negative (N4910 [alg.shift]/5)");
 
     _Adl_verify_range(_First, _Last);
@@ -5053,9 +5053,9 @@ constexpr _FwdIt shift_right(_FwdIt _First, const _FwdIt _Last, _Iter_diff_t<_Fw
     const auto _UFirst = _Get_unwrapped(_First);
     const auto _ULast  = _Get_unwrapped(_Last);
 
-    if constexpr (_Is_bidi_iter_v<_FwdIt>) {
+    if constexpr (_Is_cpp17_bidi_iter_v<_FwdIt>) {
         auto _UEnd_at = _ULast;
-        if constexpr (_Is_random_iter_v<_FwdIt>) {
+        if constexpr (_Is_cpp17_random_iter_v<_FwdIt>) {
             if (_Pos_to_shift >= _ULast - _UFirst) {
                 return _Last;
             }
@@ -5353,10 +5353,11 @@ namespace ranges {
 template <class _FwdIt, class _Pr>
 _CONSTEXPR20 _FwdIt partition(_FwdIt _First, const _FwdIt _Last, _Pr _Pred) {
     // move elements satisfying _Pred to beginning of sequence
+    _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt);
     _Adl_verify_range(_First, _Last);
     auto _UFirst = _Get_unwrapped(_First);
     auto _ULast  = _Get_unwrapped(_Last);
-    if constexpr (_Is_bidi_iter_v<_FwdIt>) {
+    if constexpr (_Is_cpp17_bidi_iter_v<_FwdIt>) {
         for (;;) { // find any out-of-order pair
             for (;;) { // skip in-place elements at beginning
                 if (_UFirst == _ULast) {
@@ -6771,9 +6772,9 @@ _FwdIt3 merge(_ExPo&&, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2, _FwdIt2
     _Pr _Pred) noexcept /* terminates */ {
     // copy merging ranges
     // not parallelized at present, parallelism expected to be feasible in a future release
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt2);
-    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt3);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt3);
     return _STD merge(_First1, _Last1, _First2, _Last2, _Dest, _Pass_fn(_Pred));
 }
 
@@ -6782,9 +6783,9 @@ _FwdIt3 merge(_ExPo&&, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2, _FwdIt2
 /* terminates */ {
     // copy merging ranges
     // not parallelized at present, parallelism expected to be feasible in a future release
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt2);
-    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt3);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt3);
     return _STD merge(_First1, _Last1, _First2, _Last2, _Dest);
 }
 
@@ -8472,8 +8473,8 @@ _RanIt partial_sort_copy(_ExPo&&, _FwdIt _First1, _FwdIt _Last1, _RanIt _First2,
 /* terminates */ {
     // copy [_First1, _Last1) into [_First2, _Last2)
     // parallelism suspected to be infeasible
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt);
-    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_RanIt);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt);
+    _REQUIRE_CPP17_MUTABLE_ITERATOR(_RanIt);
     return _STD partial_sort_copy(_First1, _Last1, _First2, _Last2, _Pass_fn(_Pred));
 }
 
@@ -8482,8 +8483,8 @@ _RanIt partial_sort_copy(_ExPo&&, _FwdIt _First1, _FwdIt _Last1, _RanIt _First2,
 /* terminates */ {
     // copy [_First1, _Last1) into [_First2, _Last2)
     // parallelism suspected to be infeasible
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt);
-    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_RanIt);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt);
+    _REQUIRE_CPP17_MUTABLE_ITERATOR(_RanIt);
     return _STD partial_sort_copy(_First1, _Last1, _First2, _Last2);
 }
 
@@ -8740,8 +8741,8 @@ _NODISCARD bool includes(_ExPo&&, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _Firs
 /* terminates */ {
     // test if every element in sorted [_First2, _Last2) is in sorted [_First1, _Last1)
     // not parallelized at present, parallelism expected to be feasible in a future release
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
     return _STD includes(_First1, _Last1, _First2, _Last2, _Pass_fn(_Pred));
 }
 
@@ -8750,8 +8751,8 @@ _NODISCARD bool includes(_ExPo&&, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _Firs
 /* terminates */ {
     // test if every element in sorted [_First2, _Last2) is in sorted [_First1, _Last1)
     // not parallelized at present, parallelism expected to be feasible in a future release
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
     return _STD includes(_First1, _Last1, _First2, _Last2);
 }
 
@@ -8871,9 +8872,9 @@ _FwdIt3 set_union(_ExPo&&, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2, _Fw
     _Pr _Pred) noexcept /* terminates */ {
     // OR sets [_First1, _Last1) and [_First2, _Last2)
     // not parallelized at present, parallelism expected to be feasible in a future release
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt2);
-    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt3);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt3);
     return _STD set_union(_First1, _Last1, _First2, _Last2, _Dest, _Pass_fn(_Pred));
 }
 
@@ -8882,9 +8883,9 @@ _FwdIt3 set_union(_ExPo&&, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2, _Fw
 /* terminates */ {
     // OR sets [_First1, _Last1) and [_First2, _Last2)
     // not parallelized at present, parallelism expected to be feasible in a future release
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt2);
-    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt3);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt3);
     return _STD set_union(_First1, _Last1, _First2, _Last2, _Dest);
 }
 
@@ -9269,9 +9270,9 @@ _FwdIt3 set_symmetric_difference(_ExPo&&, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdI
     _FwdIt3 _Dest, _Pr _Pred) noexcept /* terminates */ {
     // XOR sets [_First1, _Last1) and [_First2, _Last2)
     // not parallelized at present, parallelism expected to be feasible in a future release
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt2);
-    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt3);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt3);
     return _STD set_symmetric_difference(_First1, _Last1, _First2, _Last2, _Dest, _Pass_fn(_Pred));
 }
 
@@ -9280,9 +9281,9 @@ _FwdIt3 set_symmetric_difference(_ExPo&&, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdI
     _FwdIt3 _Dest) noexcept /* terminates */ {
     // XOR sets [_First1, _Last1) and [_First2, _Last2)
     // not parallelized at present, parallelism expected to be feasible in a future release
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt2);
-    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt3);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt3);
     return _STD set_symmetric_difference(_First1, _Last1, _First2, _Last2, _Dest);
 }
 

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -4097,12 +4097,12 @@ namespace ranges {
 #endif // __cpp_lib_concepts
 
 template <class _InIt, class _OutIt>
-#if defined(__cpp_lib_concepts)
-concept _Can_reread_dest
+#ifdef __cpp_lib_concepts
+concept
 #else
-_INLINE_VAR constexpr bool _Can_reread_dest
+_INLINE_VAR constexpr bool
 #endif
-    = _Is_fwd_iter_v<_OutIt> //
+    _Can_reread_dest = _Is_fwd_iter_v<_OutIt> //
     && is_same_v<_Iter_value_t<_InIt>, _Iter_value_t<_OutIt>>;
 
 template <class _InIt, class _OutIt, class _Pr>

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -4097,7 +4097,12 @@ namespace ranges {
 #endif // __cpp_lib_concepts
 
 template <class _InIt, class _OutIt>
-_INLINE_VAR constexpr bool _Can_reread_dest = _Is_fwd_iter_v<_OutIt> //
+#if defined(__cpp_lib_concepts)
+concept _Can_reread_dest
+#else
+_INLINE_VAR constexpr bool _Can_reread_dest
+#endif
+    = _Is_fwd_iter_v<_OutIt> //
     && is_same_v<_Iter_value_t<_InIt>, _Iter_value_t<_OutIt>>;
 
 template <class _InIt, class _OutIt, class _Pr>

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -866,7 +866,9 @@ _NODISCARD _CONSTEXPR20 bool is_permutation(
         }
 
         return true;
-    } else if constexpr (_Is_fwd_iter_v<_FwdIt1> && _Is_fwd_iter_v<_FwdIt2>) {
+    } else {
+        static_assert(_Is_ranges_fwd_iter_v<_FwdIt1> && _Is_ranges_fwd_iter_v<_FwdIt2>,
+            "Iterators must be at least forward iterators");
         for (;; ++_UFirst1, (void) ++_UFirst2) { // trim matching prefix
             if (_UFirst1 == _ULast1) {
                 return _UFirst2 == _ULast2;
@@ -896,8 +898,6 @@ _NODISCARD _CONSTEXPR20 bool is_permutation(
                 return false; // sequence 1 is longer than sequence 2, not a permutation
             }
         }
-    } else {
-        static_assert(_Always_false<_FwdIt1>, "Iterators must be at least forward iterators");
     }
 }
 
@@ -4096,14 +4096,9 @@ namespace ranges {
 } // namespace ranges
 #endif // __cpp_lib_concepts
 
-#ifdef __cpp_lib_concepts
-template <class _InIt, class _OutIt>
-concept _Can_reread_dest = forward_iterator<_OutIt> && same_as<iter_value_t<_InIt>, iter_value_t<_OutIt>>;
-#else // ^^^ defined(__cpp_lib_concepts) / !defined(__cpp_lib_concepts) vvv
 template <class _InIt, class _OutIt>
 _INLINE_VAR constexpr bool _Can_reread_dest = _Is_fwd_iter_v<_OutIt> //
     && is_same_v<_Iter_value_t<_InIt>, _Iter_value_t<_OutIt>>;
-#endif // __cpp_lib_concepts
 
 template <class _InIt, class _OutIt, class _Pr>
 _CONSTEXPR20 _OutIt unique_copy(_InIt _First, _InIt _Last, _OutIt _Dest, _Pr _Pred) {
@@ -4119,7 +4114,7 @@ _CONSTEXPR20 _OutIt unique_copy(_InIt _First, _InIt _Last, _OutIt _Dest, _Pr _Pr
 
     auto _UDest = _Get_unwrapped_unverified(_Dest);
 
-    if constexpr (_Is_fwd_iter_v<_InIt>) { // can reread the source for comparison
+    if constexpr (_Is_ranges_fwd_iter_v<_InIt>) { // can reread the source for comparison
         auto _Firstb = _UFirst;
 
         *_UDest = *_Firstb;
@@ -4728,8 +4723,9 @@ _SampleIt _Sample_selection_unchecked(
 template <class _PopIt, class _SampleIt, class _Diff, class _Urng>
 _SampleIt sample(_PopIt _First, _PopIt _Last, _SampleIt _Dest, _Diff _Count, _Urng&& _Func) {
     // randomly select _Count elements from [_First, _Last) into _Dest
-    static_assert(_Is_fwd_iter_v<_PopIt> || _Is_random_iter_v<_SampleIt>,
+    static_assert(_Is_ranges_fwd_iter_v<_PopIt> || _Is_random_iter_v<_SampleIt>,
         "If the source range is not forward, the destination range must be random-access.");
+
     static_assert(is_integral_v<_Diff>, "The sample size must have an integer type.");
     _Adl_verify_range(_First, _Last);
     if (0 < _Count) {
@@ -4737,7 +4733,7 @@ _SampleIt sample(_PopIt _First, _PopIt _Last, _SampleIt _Dest, _Diff _Count, _Ur
         auto _ULast    = _Get_unwrapped(_Last);
         using _PopDiff = _Iter_diff_t<_PopIt>;
         _Rng_from_urng<_PopDiff, remove_reference_t<_Urng>> _RngFunc(_Func);
-        if constexpr (_Is_fwd_iter_v<_PopIt>) {
+        if constexpr (_Is_ranges_fwd_iter_v<_PopIt>) {
             // source is forward: use selection sampling (stable)
             using _CT            = common_type_t<_Diff, _PopDiff>;
             const auto _Pop_size = _STD distance(_UFirst, _ULast);

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -4408,6 +4408,7 @@ template <class _ExPo, class _BidIt, class _FwdIt, _Enable_if_execution_policy_t
 _FwdIt reverse_copy(_ExPo&&, _BidIt _First, _BidIt _Last, _FwdIt _Dest) noexcept /* terminates */ {
     // copy reversing elements in [_First, _Last)
     // not parallelized as benchmarks show it isn't worth it
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_BidIt);
     _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt);
     return _STD reverse_copy(_First, _Last, _Dest);
 }

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -4999,7 +4999,6 @@ template <class _FwdIt>
 constexpr _FwdIt shift_left(_FwdIt _First, const _FwdIt _Last, _Iter_diff_t<_FwdIt> _Pos_to_shift) {
     // shift [_First, _Last) left by _Pos_to_shift
     // positions; returns the end of the resulting range
-    _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt);
     _STL_ASSERT(_Pos_to_shift >= 0, "shift count must be non-negative (N4910 [alg.shift]/1)");
 
     _Adl_verify_range(_First, _Last);
@@ -5041,7 +5040,6 @@ template <class _FwdIt>
 constexpr _FwdIt shift_right(_FwdIt _First, const _FwdIt _Last, _Iter_diff_t<_FwdIt> _Pos_to_shift) {
     // shift [_First, _Last) right by _Pos_to_shift
     // positions; returns the beginning of the resulting range
-    _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt);
     _STL_ASSERT(_Pos_to_shift >= 0, "shift count must be non-negative (N4910 [alg.shift]/5)");
 
     _Adl_verify_range(_First, _Last);
@@ -5353,7 +5351,6 @@ namespace ranges {
 template <class _FwdIt, class _Pr>
 _CONSTEXPR20 _FwdIt partition(_FwdIt _First, const _FwdIt _Last, _Pr _Pred) {
     // move elements satisfying _Pred to beginning of sequence
-    _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt);
     _Adl_verify_range(_First, _Last);
     auto _UFirst = _Get_unwrapped(_First);
     auto _ULast  = _Get_unwrapped(_Last);

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -647,8 +647,8 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, _Enable_if_execution_policy
 _NODISCARD pair<_FwdIt1, _FwdIt2> mismatch(
     _ExPo&& _Exec, const _FwdIt1 _First1, const _FwdIt1 _Last1, const _FwdIt2 _First2) noexcept /* terminates */ {
     // return [_First1, _Last1)/[_First2, ...) mismatch
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt2);
     return _STD mismatch(_STD forward<_ExPo>(_Exec), _First1, _Last1, _First2, equal_to{});
 }
 #endif // _HAS_CXX17
@@ -702,8 +702,8 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, _Enable_if_execution_policy
 _NODISCARD pair<_FwdIt1, _FwdIt2> mismatch(
     _ExPo&& _Exec, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2, _FwdIt2 _Last2) noexcept /* terminates */ {
     // return [_First1, _Last1)/[_First2, _Last2) mismatch
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt2);
     return _STD mismatch(_STD forward<_ExPo>(_Exec), _First1, _Last1, _First2, _Last2, equal_to{});
 }
 #endif // _HAS_CXX17
@@ -1448,8 +1448,8 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, class _Pr, _Enable_if_execu
 _FwdIt2 copy_if(_ExPo&&, _FwdIt1 _First, _FwdIt1 _Last, _FwdIt2 _Dest, _Pr _Pred) noexcept /* terminates */ {
     // copy each satisfying _Pred
     // not parallelized at present, parallelism expected to be feasible in a future release
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt2);
     return _STD copy_if(_First, _Last, _Dest, _Pass_fn(_Pred));
 }
 #endif // _HAS_CXX17
@@ -1637,9 +1637,9 @@ pair<_FwdIt2, _FwdIt3> partition_copy(_ExPo&&, _FwdIt1 _First, _FwdIt1 _Last, _F
     _Pr _Pred) noexcept /* terminates */ {
     // copy true partition to _Dest_true, false to _Dest_false
     // not parallelized at present, parallelism expected to be feasible in a future release
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt3);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt3);
     return _STD partition_copy(_First, _Last, _Dest_true, _Dest_false, _Pass_fn(_Pred));
 }
 
@@ -3369,8 +3369,8 @@ _FwdIt2 replace_copy(_ExPo&&, _FwdIt1 _First, _FwdIt1 _Last, _FwdIt2 _Dest, cons
     const _Ty& _Newval) noexcept /* terminates */ {
     // copy replacing each matching _Oldval with _Newval
     // not parallelized at present, parallelism expected to be feasible in a future release
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt2);
     return _STD replace_copy(_First, _Last, _Dest, _Oldval, _Newval);
 }
 #endif // _HAS_CXX17
@@ -3464,8 +3464,8 @@ _FwdIt2 replace_copy_if(_ExPo&&, _FwdIt1 _First, _FwdIt1 _Last, _FwdIt2 _Dest, _
 /* terminates */ {
     // copy replacing each satisfying _Pred with _Val
     // not parallelized at present, parallelism expected to be feasible in a future release
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt2);
     return _STD replace_copy_if(_First, _Last, _Dest, _Pass_fn(_Pred), _Val);
 }
 #endif // _HAS_CXX17
@@ -3683,7 +3683,7 @@ template <class _ExPo, class _FwdIt, class _Diff, class _Fn, _Enable_if_executio
 _FwdIt generate_n(_ExPo&&, const _FwdIt _Dest, const _Diff _Count_raw, _Fn _Func) noexcept /* terminates */ {
     // replace [_Dest, _Dest + _Count) with _Func()
     // not parallelized at present due to unclear parallelism requirements on _Func
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt);
+    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt);
     return _STD generate_n(_Dest, _Count_raw, _Pass_fn(_Func));
 }
 #endif // _HAS_CXX17
@@ -3711,8 +3711,8 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, class _Ty, _Enable_if_execu
 _FwdIt2 remove_copy(_ExPo&&, _FwdIt1 _First, _FwdIt1 _Last, _FwdIt2 _Dest, const _Ty& _Val) noexcept /* terminates */ {
     // copy omitting each matching _Val
     // not parallelized at present, parallelism expected to be feasible in a future release
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt2);
     return _STD remove_copy(_First, _Last, _Dest, _Val);
 }
 #endif // _HAS_CXX17
@@ -3740,8 +3740,8 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, class _Pr, _Enable_if_execu
 _FwdIt2 remove_copy_if(_ExPo&&, _FwdIt1 _First, _FwdIt1 _Last, _FwdIt2 _Dest, _Pr _Pred) noexcept /* terminates */ {
     // copy omitting each element satisfying _Pred
     // not parallelized at present, parallelism expected to be feasible in a future release
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt2);
     return _STD remove_copy_if(_First, _Last, _Dest, _Pass_fn(_Pred));
 }
 #endif // _HAS_CXX17
@@ -4171,8 +4171,8 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, class _Pr, _Enable_if_execu
 _FwdIt2 unique_copy(_ExPo&&, _FwdIt1 _First, _FwdIt1 _Last, _FwdIt2 _Dest, _Pr _Pred) noexcept /* terminates */ {
     // copy compressing pairs that match
     // not parallelized at present, parallelism expected to be feasible in a future release
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt2);
     return _STD unique_copy(_First, _Last, _Dest, _Pass_fn(_Pred));
 }
 
@@ -4180,8 +4180,8 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, _Enable_if_execution_policy
 _FwdIt2 unique_copy(_ExPo&&, _FwdIt1 _First, _FwdIt1 _Last, _FwdIt2 _Dest) noexcept /* terminates */ {
     // copy compressing pairs that match
     // not parallelized at present, parallelism expected to be feasible in a future release
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt2);
     return _STD unique_copy(_First, _Last, _Dest);
 }
 #endif // _HAS_CXX17
@@ -4408,7 +4408,7 @@ template <class _ExPo, class _BidIt, class _FwdIt, _Enable_if_execution_policy_t
 _FwdIt reverse_copy(_ExPo&&, _BidIt _First, _BidIt _Last, _FwdIt _Dest) noexcept /* terminates */ {
     // copy reversing elements in [_First, _Last)
     // not parallelized as benchmarks show it isn't worth it
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt);
+    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt);
     return _STD reverse_copy(_First, _Last, _Dest);
 }
 
@@ -4623,7 +4623,8 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, _Enable_if_execution_policy
 _FwdIt2 rotate_copy(_ExPo&&, _FwdIt1 _First, _FwdIt1 _Mid, _FwdIt1 _Last, _FwdIt2 _Dest) noexcept /* terminates */ {
     // copy rotating [_First, _Last)
     // not parallelized as benchmarks show it isn't worth it
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt2);
     return _STD rotate_copy(_First, _Mid, _Last, _Dest);
 }
 
@@ -6768,9 +6769,9 @@ _FwdIt3 merge(_ExPo&&, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2, _FwdIt2
     _Pr _Pred) noexcept /* terminates */ {
     // copy merging ranges
     // not parallelized at present, parallelism expected to be feasible in a future release
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt3);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt3);
     return _STD merge(_First1, _Last1, _First2, _Last2, _Dest, _Pass_fn(_Pred));
 }
 
@@ -6779,9 +6780,9 @@ _FwdIt3 merge(_ExPo&&, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2, _FwdIt2
 /* terminates */ {
     // copy merging ranges
     // not parallelized at present, parallelism expected to be feasible in a future release
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt3);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt3);
     return _STD merge(_First1, _Last1, _First2, _Last2, _Dest);
 }
 
@@ -8469,7 +8470,8 @@ _RanIt partial_sort_copy(_ExPo&&, _FwdIt _First1, _FwdIt _Last1, _RanIt _First2,
 /* terminates */ {
     // copy [_First1, _Last1) into [_First2, _Last2)
     // parallelism suspected to be infeasible
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt);
+    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_RanIt);
     return _STD partial_sort_copy(_First1, _Last1, _First2, _Last2, _Pass_fn(_Pred));
 }
 
@@ -8478,7 +8480,8 @@ _RanIt partial_sort_copy(_ExPo&&, _FwdIt _First1, _FwdIt _Last1, _RanIt _First2,
 /* terminates */ {
     // copy [_First1, _Last1) into [_First2, _Last2)
     // parallelism suspected to be infeasible
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt);
+    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_RanIt);
     return _STD partial_sort_copy(_First1, _Last1, _First2, _Last2);
 }
 
@@ -8735,8 +8738,8 @@ _NODISCARD bool includes(_ExPo&&, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _Firs
 /* terminates */ {
     // test if every element in sorted [_First2, _Last2) is in sorted [_First1, _Last1)
     // not parallelized at present, parallelism expected to be feasible in a future release
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt2);
     return _STD includes(_First1, _Last1, _First2, _Last2, _Pass_fn(_Pred));
 }
 
@@ -8745,8 +8748,8 @@ _NODISCARD bool includes(_ExPo&&, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _Firs
 /* terminates */ {
     // test if every element in sorted [_First2, _Last2) is in sorted [_First1, _Last1)
     // not parallelized at present, parallelism expected to be feasible in a future release
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt2);
     return _STD includes(_First1, _Last1, _First2, _Last2);
 }
 
@@ -8866,9 +8869,9 @@ _FwdIt3 set_union(_ExPo&&, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2, _Fw
     _Pr _Pred) noexcept /* terminates */ {
     // OR sets [_First1, _Last1) and [_First2, _Last2)
     // not parallelized at present, parallelism expected to be feasible in a future release
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt3);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt3);
     return _STD set_union(_First1, _Last1, _First2, _Last2, _Dest, _Pass_fn(_Pred));
 }
 
@@ -8877,9 +8880,9 @@ _FwdIt3 set_union(_ExPo&&, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2, _Fw
 /* terminates */ {
     // OR sets [_First1, _Last1) and [_First2, _Last2)
     // not parallelized at present, parallelism expected to be feasible in a future release
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt3);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt3);
     return _STD set_union(_First1, _Last1, _First2, _Last2, _Dest);
 }
 
@@ -9264,9 +9267,9 @@ _FwdIt3 set_symmetric_difference(_ExPo&&, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdI
     _FwdIt3 _Dest, _Pr _Pred) noexcept /* terminates */ {
     // XOR sets [_First1, _Last1) and [_First2, _Last2)
     // not parallelized at present, parallelism expected to be feasible in a future release
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt3);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt3);
     return _STD set_symmetric_difference(_First1, _Last1, _First2, _Last2, _Dest, _Pass_fn(_Pred));
 }
 
@@ -9275,9 +9278,9 @@ _FwdIt3 set_symmetric_difference(_ExPo&&, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdI
     _FwdIt3 _Dest) noexcept /* terminates */ {
     // XOR sets [_First1, _Last1) and [_First2, _Last2)
     // not parallelized at present, parallelism expected to be feasible in a future release
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt3);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt3);
     return _STD set_symmetric_difference(_First1, _Last1, _First2, _Last2, _Dest);
 }
 

--- a/stl/inc/execution
+++ b/stl/inc/execution
@@ -3397,7 +3397,6 @@ _FwdIt _Partition_merge(const _FwdIt _False_first, const _FwdIt _True_first, con
     const _Iter_diff_t<_FwdIt> _Count1, const _Iter_diff_t<_FwdIt> _Count2) {
     // Merge partition ranges where [_False_first, _True_first) are falses, [_True_first, _True_last) are trues
     // pre: _Count1 == distance(_False_first, _True_first) && _Count2 == distance(_True_first, _True_last)
-    _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt);
     if (_Count1 < _Count2) { // move the false range to the end of the true range
         const _Iter_diff_t<_FwdIt> _Offset = _Count2 - _Count1;
         auto _Result                       = _True_first;

--- a/stl/inc/execution
+++ b/stl/inc/execution
@@ -1112,7 +1112,7 @@ bool _All_of_family_parallel(_FwdIt _First, const _FwdIt _Last, _Pr _Pred) {
 template <class _ExPo, class _FwdIt, class _Pr, _Enable_if_execution_policy_t<_ExPo> /* = 0 */>
 _NODISCARD bool all_of(_ExPo&&, _FwdIt _First, _FwdIt _Last, _Pr _Pred) noexcept /* terminates */ {
     // test if all elements in [_First, _Last) satisfy _Pred with the indicated execution policy
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt);
     _Adl_verify_range(_First, _Last);
     auto _UFirst      = _Get_unwrapped(_First);
     const auto _ULast = _Get_unwrapped(_Last);
@@ -1126,7 +1126,7 @@ _NODISCARD bool all_of(_ExPo&&, _FwdIt _First, _FwdIt _Last, _Pr _Pred) noexcept
 template <class _ExPo, class _FwdIt, class _Pr, _Enable_if_execution_policy_t<_ExPo> /* = 0 */>
 _NODISCARD bool any_of(_ExPo&&, const _FwdIt _First, const _FwdIt _Last, _Pr _Pred) noexcept /* terminates */ {
     // test if any element in [_First, _Last) satisfies _Pred with the indicated execution policy
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt);
     _Adl_verify_range(_First, _Last);
     auto _UFirst      = _Get_unwrapped(_First);
     const auto _ULast = _Get_unwrapped(_Last);
@@ -1140,7 +1140,7 @@ _NODISCARD bool any_of(_ExPo&&, const _FwdIt _First, const _FwdIt _Last, _Pr _Pr
 template <class _ExPo, class _FwdIt, class _Pr, _Enable_if_execution_policy_t<_ExPo> /* = 0 */>
 _NODISCARD bool none_of(_ExPo&&, const _FwdIt _First, const _FwdIt _Last, _Pr _Pred) noexcept /* terminates */ {
     // test if no element in [_First, _Last) satisfies _Pred with the indicated execution policy
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt);
     _Adl_verify_range(_First, _Last);
     auto _UFirst      = _Get_unwrapped(_First);
     const auto _ULast = _Get_unwrapped(_Last);
@@ -1189,7 +1189,7 @@ struct _Static_partitioned_for_each2 { // for_each task scheduled on the system 
 template <class _ExPo, class _FwdIt, class _Fn, _Enable_if_execution_policy_t<_ExPo> /* = 0 */>
 void for_each(_ExPo&&, _FwdIt _First, _FwdIt _Last, _Fn _Func) noexcept /* terminates */ {
     // perform function for each element [_First, _Last) with the indicated execution policy
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt);
+    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt);
     _Adl_verify_range(_First, _Last);
     auto _UFirst      = _Get_unwrapped(_First);
     const auto _ULast = _Get_unwrapped(_Last);
@@ -1235,7 +1235,7 @@ _FwdIt _For_each_n_ivdep(_FwdIt _First, _Diff _Count, _Fn _Func) {
 template <class _ExPo, class _FwdIt, class _Diff, class _Fn, _Enable_if_execution_policy_t<_ExPo> /* = 0 */>
 _FwdIt for_each_n(_ExPo&&, _FwdIt _First, const _Diff _Count_raw, _Fn _Func) noexcept /* terminates */ {
     // perform function for each element [_First, _First + _Count)
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt);
+    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt);
     _Algorithm_int_t<_Diff> _Count = _Count_raw;
     if (0 < _Count) {
         auto _UFirst = _Get_unwrapped_n(_First, _Count);
@@ -1337,7 +1337,7 @@ _FwdIt _Find_parallel_unchecked(_ExPo&&, const _FwdIt _First, const _FwdIt _Last
 template <class _ExPo, class _FwdIt, class _Ty, _Enable_if_execution_policy_t<_ExPo> /* = 0 */>
 _NODISCARD _FwdIt find(_ExPo&& _Exec, _FwdIt _First, const _FwdIt _Last, const _Ty& _Val) noexcept /* terminates */ {
     // find first matching _Val
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt);
     using _UFwdIt = _Unwrapped_t<const _FwdIt&>;
     _Adl_verify_range(_First, _Last);
     _Seek_wrapped(_First,
@@ -1349,7 +1349,7 @@ _NODISCARD _FwdIt find(_ExPo&& _Exec, _FwdIt _First, const _FwdIt _Last, const _
 template <class _ExPo, class _FwdIt, class _Pr, _Enable_if_execution_policy_t<_ExPo> /* = 0 */>
 _NODISCARD _FwdIt find_if(_ExPo&& _Exec, _FwdIt _First, const _FwdIt _Last, _Pr _Pred) noexcept /* terminates */ {
     // find first satisfying _Pred
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt);
     using _UFwdIt = _Unwrapped_t<const _FwdIt&>;
     _Adl_verify_range(_First, _Last);
     auto _Pass_pred = _Pass_fn(_Pred);
@@ -1362,7 +1362,7 @@ _NODISCARD _FwdIt find_if(_ExPo&& _Exec, _FwdIt _First, const _FwdIt _Last, _Pr 
 template <class _ExPo, class _FwdIt, class _Pr, _Enable_if_execution_policy_t<_ExPo> /* = 0 */>
 _NODISCARD _FwdIt find_if_not(_ExPo&& _Exec, _FwdIt _First, const _FwdIt _Last, _Pr _Pred) noexcept /* terminates */ {
     // find first satisfying !_Pred
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt);
     using _UFwdIt = _Unwrapped_t<const _FwdIt&>;
     _Adl_verify_range(_First, _Last);
     auto _Pass_pred = _Pass_fn(_Pred);
@@ -1576,7 +1576,7 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, class _Pr, _Enable_if_execu
 _NODISCARD _FwdIt1 find_first_of(_ExPo&& _Exec, const _FwdIt1 _First1, _FwdIt1 _Last1, const _FwdIt2 _First2,
     const _FwdIt2 _Last2, _Pr _Pred) noexcept /* terminates */ {
     // look for one of [_First2, _Last2) that matches element
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
     using _UFwdIt1 = _Unwrapped_t<const _FwdIt1&>;
     _Adl_verify_range(_First1, _Last1);
     _Adl_verify_range(_First2, _Last2);
@@ -1700,7 +1700,7 @@ template <class _ExPo, class _FwdIt, class _Pr, _Enable_if_execution_policy_t<_E
 _NODISCARD _Iter_diff_t<_FwdIt> count_if(_ExPo&&, const _FwdIt _First, const _FwdIt _Last, _Pr _Pred) noexcept
 /* terminates */ {
     // count elements satisfying _Pred
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt);
     _Adl_verify_range(_First, _Last);
     auto _UFirst      = _Get_unwrapped(_First);
     const auto _ULast = _Get_unwrapped(_Last);
@@ -1735,7 +1735,7 @@ template <class _ExPo, class _FwdIt, class _Ty, _Enable_if_execution_policy_t<_E
 _NODISCARD _Iter_diff_t<_FwdIt> count(_ExPo&& _Exec, const _FwdIt _First, const _FwdIt _Last, const _Ty& _Val) noexcept
 /* terminates */ {
     // count elements that match _Val
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt);
     _Adl_verify_range(_First, _Last);
     return _STD count_if(_STD forward<_ExPo>(_Exec), _Get_unwrapped(_First), _Get_unwrapped(_Last),
         [&_Val](auto&& _Iter_val) { return _STD forward<decltype(_Iter_val)>(_Iter_val) == _Val; });
@@ -1862,8 +1862,8 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, class _Pr, _Enable_if_execu
 _NODISCARD pair<_FwdIt1, _FwdIt2> mismatch(
     _ExPo&&, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2, _Pr _Pred) noexcept /* terminates */ {
     // return [_First1, _Last1)/[_First2, ...) mismatch
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt2);
     _Adl_verify_range(_First1, _Last1);
     const auto _UFirst1 = _Get_unwrapped(_First1);
     const auto _ULast1  = _Get_unwrapped(_Last1);
@@ -1904,8 +1904,8 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, class _Pr, _Enable_if_execu
 _NODISCARD pair<_FwdIt1, _FwdIt2> mismatch(
     _ExPo&&, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2, _FwdIt2 _Last2, _Pr _Pred) noexcept /* terminates */ {
     // return [_First1, _Last1)/[_First2, _Last2) mismatch
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt2);
     _Adl_verify_range(_First1, _Last1);
     _Adl_verify_range(_First2, _Last2);
     const auto _UFirst1 = _Get_unwrapped(_First1);
@@ -1981,8 +1981,8 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, class _Pr, _Enable_if_execu
 _NODISCARD bool equal(_ExPo&&, const _FwdIt1 _First1, const _FwdIt1 _Last1, const _FwdIt2 _First2, _Pr _Pred) noexcept
 /* terminates */ {
     // compare [_First1, _Last1) to [_First2, ...)
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt2);
     _Adl_verify_range(_First1, _Last1);
     const auto _UFirst1 = _Get_unwrapped(_First1);
     const auto _ULast1  = _Get_unwrapped(_Last1);
@@ -2014,8 +2014,8 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, class _Pr, _Enable_if_execu
 _NODISCARD bool equal(_ExPo&&, const _FwdIt1 _First1, const _FwdIt1 _Last1, const _FwdIt2 _First2, const _FwdIt2 _Last2,
     _Pr _Pred) noexcept /* terminates */ {
     // compare [_First1, _Last1) to [_First2, _Last2)
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt2);
     _Adl_verify_range(_First1, _Last1);
     _Adl_verify_range(_First2, _Last2);
     const auto _UFirst1 = _Get_unwrapped(_First1);
@@ -2303,8 +2303,8 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, class _Fn, _Enable_if_execu
 _FwdIt2 transform(_ExPo&&, const _FwdIt1 _First, const _FwdIt1 _Last, _FwdIt2 _Dest, _Fn _Func) noexcept
 /* terminates */ {
     // transform [_First, _Last) with _Func
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt2);
     _Adl_verify_range(_First, _Last);
     auto _UFirst      = _Get_unwrapped(_First);
     const auto _ULast = _Get_unwrapped(_Last);
@@ -2382,9 +2382,9 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, class _FwdIt3, class _Fn,
 _FwdIt3 transform(_ExPo&&, const _FwdIt1 _First1, const _FwdIt1 _Last1, const _FwdIt2 _First2, _FwdIt3 _Dest,
     _Fn _Func) noexcept /* terminates */ {
     // transform [_First1, _Last1) and [_First2, ...) with _Func
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt3);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt3);
     _Adl_verify_range(_First1, _Last1);
     const auto _UFirst1 = _Get_unwrapped(_First1);
     const auto _ULast1  = _Get_unwrapped(_Last1);
@@ -2427,7 +2427,7 @@ template <class _ExPo, class _FwdIt, class _Ty, _Enable_if_execution_policy_t<_E
 void replace(_ExPo&& _Exec, const _FwdIt _First, const _FwdIt _Last, const _Ty& _Oldval, const _Ty& _Newval) noexcept
 /* terminates */ {
     // replace each matching _Oldval with _Newval
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt);
+    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt);
     _STD for_each(_STD forward<_ExPo>(_Exec), _First, _Last, [&](auto&& _Value) {
         if (_STD forward<decltype(_Value)>(_Value) == _Oldval) {
             _STD forward<decltype(_Value)>(_Value) = _Newval;
@@ -2439,7 +2439,7 @@ template <class _ExPo, class _FwdIt, class _Pr, class _Ty, _Enable_if_execution_
 void replace_if(_ExPo&& _Exec, const _FwdIt _First, const _FwdIt _Last, _Pr _Pred, const _Ty& _Val) noexcept
 /* terminates */ {
     // replace each satisfying _Pred with _Val
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt);
+    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt);
     _STD for_each(
         _STD forward<_ExPo>(_Exec), _First, _Last, [&_Val, _Lambda_pred = _Pass_fn(_Pred)](auto&& _Value) mutable {
             if (_Lambda_pred(_STD forward<decltype(_Value)>(_Value))) {
@@ -3044,7 +3044,7 @@ struct _Static_partitioned_is_sorted_until {
 template <class _ExPo, class _FwdIt, class _Pr, _Enable_if_execution_policy_t<_ExPo> /* = 0 */>
 _NODISCARD _FwdIt is_sorted_until(_ExPo&&, _FwdIt _First, _FwdIt _Last, _Pr _Pred) noexcept /* terminates */ {
     // find extent of range that is ordered by predicate
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt);
     _Adl_verify_range(_First, _Last);
     const auto _UFirst = _Get_unwrapped(_First);
     const auto _ULast  = _Get_unwrapped(_Last);
@@ -3198,7 +3198,7 @@ struct _Static_partitioned_is_partitioned {
 template <class _ExPo, class _FwdIt, class _Pr, _Enable_if_execution_policy_t<_ExPo> /* = 0 */>
 _NODISCARD bool is_partitioned(_ExPo&&, const _FwdIt _First, const _FwdIt _Last, _Pr _Pred) noexcept /* terminates */ {
     // test if [_First, _Last) is partitioned by _Pred
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt);
     _Adl_verify_range(_First, _Last);
     const auto _UFirst = _Get_unwrapped(_First);
     const auto _ULast  = _Get_unwrapped(_Last);
@@ -3270,7 +3270,7 @@ struct _Static_partitioned_is_heap_until {
 template <class _ExPo, class _RanIt, class _Pr, _Enable_if_execution_policy_t<_ExPo> /* = 0 */>
 _NODISCARD _RanIt is_heap_until(_ExPo&&, _RanIt _First, _RanIt _Last, _Pr _Pred) noexcept /* terminates */ {
     // find extent of range that is a heap
-    _REQUIRE_PARALLEL_ITERATOR(_RanIt);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_RanIt);
     _Adl_verify_range(_First, _Last);
     const auto _UFirst = _Get_unwrapped(_First);
     const auto _ULast  = _Get_unwrapped(_Last);
@@ -3850,9 +3850,9 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, class _FwdIt3, class _Pr,
 _FwdIt3 set_intersection(_ExPo&&, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2, _FwdIt2 _Last2, _FwdIt3 _Dest,
     _Pr _Pred) noexcept /* terminates */ {
     // AND sets [_First1, _Last1) and [_First2, _Last2)
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt3);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt3);
     _Adl_verify_range(_First1, _Last1);
     _Adl_verify_range(_First2, _Last2);
     auto _UFirst1      = _Get_unwrapped(_First1);
@@ -3940,9 +3940,9 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, class _FwdIt3, class _Pr,
 _FwdIt3 set_difference(_ExPo&&, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2, _FwdIt2 _Last2, _FwdIt3 _Dest,
     _Pr _Pred) noexcept /* terminates */ {
     // take set [_First2, _Last2) from [_First1, _Last1)
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt3);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt3);
     _Adl_verify_range(_First1, _Last1);
     _Adl_verify_range(_First2, _Last2);
     auto _UFirst1      = _Get_unwrapped(_First1);
@@ -4042,7 +4042,7 @@ template <class _ExPo, class _FwdIt, class _Ty, class _BinOp, _Enable_if_executi
 _NODISCARD _Ty reduce(_ExPo&&, const _FwdIt _First, const _FwdIt _Last, _Ty _Val, _BinOp _Reduce_op) noexcept
 /* terminates */ {
     // return commutative and associative reduction of _Val and [_First, _Last), using _Reduce_op
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt);
     _Adl_verify_range(_First, _Last);
     auto _UFirst      = _Get_unwrapped(_First);
     const auto _ULast = _Get_unwrapped(_Last);
@@ -4142,8 +4142,8 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, class _Ty, class _BinOp1, c
 _NODISCARD _Ty transform_reduce(_ExPo&&, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2, _Ty _Val, _BinOp1 _Reduce_op,
     _BinOp2 _Transform_op) noexcept /* terminates */ {
     // return commutative and associative transform-reduction of sequences, using _Reduce_op and _Transform_op
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt2);
     _Adl_verify_range(_First1, _Last1);
     auto _UFirst1      = _Get_unwrapped(_First1);
     const auto _ULast1 = _Get_unwrapped(_Last1);
@@ -4238,7 +4238,7 @@ template <class _ExPo, class _FwdIt, class _Ty, class _BinOp, class _UnaryOp,
 _NODISCARD _Ty transform_reduce(_ExPo&&, const _FwdIt _First, const _FwdIt _Last, _Ty _Val, _BinOp _Reduce_op,
     _UnaryOp _Transform_op) noexcept /* terminates */ {
     // return commutative and associative reduction of transformed sequence, using _Reduce_op and _Transform_op
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt);
     _Adl_verify_range(_First, _Last);
     auto _UFirst      = _Get_unwrapped(_First);
     const auto _ULast = _Get_unwrapped(_Last);
@@ -4388,8 +4388,8 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, class _Ty, class _BinOp,
 _FwdIt2 exclusive_scan(_ExPo&&, const _FwdIt1 _First, const _FwdIt1 _Last, _FwdIt2 _Dest, _Ty _Val,
     _BinOp _Reduce_op) noexcept /* terminates */ {
     // set each value in [_Dest, _Dest + (_Last - _First)) to the associative reduction of predecessors and _Val
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt2);
     _Adl_verify_range(_First, _Last);
     const auto _UFirst = _Get_unwrapped(_First);
     const auto _ULast  = _Get_unwrapped(_Last);
@@ -4517,8 +4517,8 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, class _BinOp, class _Ty,
 _FwdIt2 inclusive_scan(_ExPo&&, _FwdIt1 _First, _FwdIt1 _Last, _FwdIt2 _Dest, _BinOp _Reduce_op, _Ty _Val) noexcept
 /* terminates */ {
     // compute partial noncommutative and associative reductions including _Val into _Dest, using _Reduce_op
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt2);
     _Adl_verify_range(_First, _Last);
     const auto _UFirst = _Get_unwrapped(_First);
     const auto _ULast  = _Get_unwrapped(_Last);
@@ -4560,8 +4560,8 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, class _BinOp, _Enable_if_ex
 _FwdIt2 inclusive_scan(_ExPo&&, _FwdIt1 _First, _FwdIt1 _Last, _FwdIt2 _Dest, _BinOp _Reduce_op) noexcept
 /* terminates */ {
     // compute partial noncommutative and associative reductions into _Dest, using _Reduce_op
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt2);
     _Adl_verify_range(_First, _Last);
     const auto _UFirst = _Get_unwrapped(_First);
     const auto _ULast  = _Get_unwrapped(_Last);
@@ -4704,8 +4704,8 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, class _Ty, class _BinOp, cl
 _FwdIt2 transform_exclusive_scan(_ExPo&&, const _FwdIt1 _First, const _FwdIt1 _Last, _FwdIt2 _Dest, _Ty _Val,
     _BinOp _Reduce_op, _UnaryOp _Transform_op) noexcept /* terminates */ {
     // set each value in [_Dest, _Dest + (_Last - _First)) to the associative reduction of transformed predecessors
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt2);
     _Adl_verify_range(_First, _Last);
     const auto _UFirst = _Get_unwrapped(_First);
     const auto _ULast  = _Get_unwrapped(_Last);
@@ -4835,8 +4835,8 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, class _Ty, class _BinOp, cl
 _FwdIt2 transform_inclusive_scan(_ExPo&&, const _FwdIt1 _First, const _FwdIt1 _Last, _FwdIt2 _Dest, _BinOp _Reduce_op,
     _UnaryOp _Transform_op, _Ty _Val) noexcept /* terminates */ {
     // compute partial noncommutative and associative transformed reductions including _Val into _Dest
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt2);
     _Adl_verify_range(_First, _Last);
     const auto _UFirst = _Get_unwrapped(_First);
     const auto _ULast  = _Get_unwrapped(_Last);
@@ -4881,8 +4881,8 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, class _BinOp, class _UnaryO
 _FwdIt2 transform_inclusive_scan(_ExPo&&, const _FwdIt1 _First, const _FwdIt1 _Last, _FwdIt2 _Dest, _BinOp _Reduce_op,
     _UnaryOp _Transform_op) noexcept /* terminates */ {
     // compute partial noncommutative and associative transformed reductions into _Dest
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt2);
     _Adl_verify_range(_First, _Last);
     const auto _UFirst = _Get_unwrapped(_First);
     const auto _ULast  = _Get_unwrapped(_Last);
@@ -4982,8 +4982,8 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, class _BinOp, _Enable_if_ex
 _FwdIt2 adjacent_difference(_ExPo&&, const _FwdIt1 _First, const _FwdIt1 _Last, _FwdIt2 _Dest, _BinOp _Diff_op) noexcept
 /* terminates */ {
     // compute adjacent differences into _Dest
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt2);
     _Adl_verify_range(_First, _Last);
     auto _UFirst      = _Get_unwrapped(_First);
     const auto _ULast = _Get_unwrapped(_Last);

--- a/stl/inc/execution
+++ b/stl/inc/execution
@@ -3302,7 +3302,6 @@ _NODISCARD _RanIt is_heap_until(_ExPo&&, _RanIt _First, _RanIt _Last, _Pr _Pred)
 
 template <class _FwdIt, class _Pr>
 pair<_FwdIt, _Iter_diff_t<_FwdIt>> _Partition_with_count_unchecked(_FwdIt _First, _FwdIt _Last, _Pr _Pred) {
-    _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt);
     // move elements satisfying _Pred to front and track how many elements satisfy _Pred
     if constexpr (_Is_cpp17_random_iter_v<_FwdIt>) {
         auto _Mid = _STD partition(_First, _Last, _Pred);
@@ -3366,7 +3365,6 @@ pair<_FwdIt, _Iter_diff_t<_FwdIt>> _Partition_swap_backward(
     _FwdIt _First, _FwdIt _Last, _FwdIt _Beginning_of_falses, _Pr _Pred) {
     // Swap elements in [_First, _Last) satisfying _Pred with elements from _Beginning_of_falses.
     // Pre: _Beginning_of_falses < _First
-    _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt);
     _Iter_diff_t<_FwdIt> _Trues{};
     if constexpr (_Is_cpp17_bidi_iter_v<_FwdIt>) {
         while (_First != _Last) {

--- a/stl/inc/execution
+++ b/stl/inc/execution
@@ -353,7 +353,7 @@ struct _Atomic_is_usually_lock_free : bool_constant<atomic<_Ty>::is_always_lock_
 };
 
 template <class _FwdIt>
-inline constexpr bool _Use_atomic_iterator = conjunction_v<bool_constant<_Is_random_iter_v<_FwdIt>>,
+inline constexpr bool _Use_atomic_iterator = conjunction_v<bool_constant<_Is_ranges_random_iter_v<_FwdIt>>,
     is_trivially_copyable<_FwdIt>, _Atomic_is_usually_lock_free<_FwdIt>>;
 
 template <class _Ty>
@@ -823,7 +823,7 @@ struct _Iterator_range { // record of a partition of work
     _FwdIt _Last;
 };
 
-template <class _FwdIt, class _Diff = _Iter_diff_t<_FwdIt>, bool = _Is_random_iter_v<_FwdIt>>
+template <class _FwdIt, class _Diff = _Iter_diff_t<_FwdIt>, bool = _Is_ranges_random_iter_v<_FwdIt>>
 struct _Static_partition_range;
 
 template <class _RanIt, class _Diff>
@@ -943,7 +943,7 @@ struct _Static_partition_range<_FwdIt, _Diff, false> {
     }
 };
 
-template <class _BidIt, class _Diff = _Iter_diff_t<_BidIt>, bool = _Is_random_iter_v<_BidIt>>
+template <class _BidIt, class _Diff = _Iter_diff_t<_BidIt>, bool = _Is_ranges_random_iter_v<_BidIt>>
 struct _Static_partition_range_backward;
 
 template <class _RanIt, class _Diff>
@@ -1003,9 +1003,9 @@ struct _Static_partition_range_backward<_BidIt, _Diff, false> {
 template <class _InIt1, class _InIt2>
 _Common_diff_t<_InIt1, _InIt2> _Distance_any(_InIt1 _First1, _InIt1 _Last1, _InIt2 _First2, _InIt2 _Last2) {
     // get the distance from 2 ranges which should have identical lengths
-    if constexpr (_Is_random_iter_v<_InIt1>) {
+    if constexpr (_Is_ranges_random_iter_v<_InIt1>) {
         return _Last1 - _First1;
-    } else if constexpr (_Is_random_iter_v<_InIt2>) {
+    } else if constexpr (_Is_ranges_random_iter_v<_InIt2>) {
         return _Last2 - _First2;
     } else {
         return _STD distance(_First1, _Last1);
@@ -1017,16 +1017,16 @@ _Common_diff_t<_InIt1, _InIt2> _Distance_min(_InIt1 _First1, const _InIt1 _Last1
     // get min(distance(_First1, _Last1), distance(_First2, _Last2))
     using _CT = _Common_diff_t<_InIt1, _InIt2>;
     _CT _Result{};
-    if constexpr (_Is_random_iter_v<_InIt1> && _Is_random_iter_v<_InIt2>) {
+    if constexpr (_Is_ranges_random_iter_v<_InIt1> && _Is_ranges_random_iter_v<_InIt2>) {
         const _CT _Count1 = _Last1 - _First1;
         const _CT _Count2 = _Last2 - _First2;
         _Result           = (_STD min)(_Count1, _Count2);
-    } else if constexpr (_Is_random_iter_v<_InIt1>) {
+    } else if constexpr (_Is_ranges_random_iter_v<_InIt1>) {
         for (auto _Count1 = _Last1 - _First1; 0 < _Count1 && _First2 != _Last2; --_Count1) {
             ++_First2;
             ++_Result;
         }
-    } else if constexpr (_Is_random_iter_v<_InIt2>) {
+    } else if constexpr (_Is_ranges_random_iter_v<_InIt2>) {
         for (auto _Count2 = _Last2 - _First2; 0 < _Count2 && _First1 != _Last1; --_Count2) {
             ++_First1;
             ++_Result;
@@ -1112,7 +1112,7 @@ bool _All_of_family_parallel(_FwdIt _First, const _FwdIt _Last, _Pr _Pred) {
 template <class _ExPo, class _FwdIt, class _Pr, _Enable_if_execution_policy_t<_ExPo> /* = 0 */>
 _NODISCARD bool all_of(_ExPo&&, _FwdIt _First, _FwdIt _Last, _Pr _Pred) noexcept /* terminates */ {
     // test if all elements in [_First, _Last) satisfy _Pred with the indicated execution policy
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt);
     _Adl_verify_range(_First, _Last);
     auto _UFirst      = _Get_unwrapped(_First);
     const auto _ULast = _Get_unwrapped(_Last);
@@ -1126,7 +1126,7 @@ _NODISCARD bool all_of(_ExPo&&, _FwdIt _First, _FwdIt _Last, _Pr _Pred) noexcept
 template <class _ExPo, class _FwdIt, class _Pr, _Enable_if_execution_policy_t<_ExPo> /* = 0 */>
 _NODISCARD bool any_of(_ExPo&&, const _FwdIt _First, const _FwdIt _Last, _Pr _Pred) noexcept /* terminates */ {
     // test if any element in [_First, _Last) satisfies _Pred with the indicated execution policy
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt);
     _Adl_verify_range(_First, _Last);
     auto _UFirst      = _Get_unwrapped(_First);
     const auto _ULast = _Get_unwrapped(_Last);
@@ -1140,7 +1140,7 @@ _NODISCARD bool any_of(_ExPo&&, const _FwdIt _First, const _FwdIt _Last, _Pr _Pr
 template <class _ExPo, class _FwdIt, class _Pr, _Enable_if_execution_policy_t<_ExPo> /* = 0 */>
 _NODISCARD bool none_of(_ExPo&&, const _FwdIt _First, const _FwdIt _Last, _Pr _Pred) noexcept /* terminates */ {
     // test if no element in [_First, _Last) satisfies _Pred with the indicated execution policy
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt);
     _Adl_verify_range(_First, _Last);
     auto _UFirst      = _Get_unwrapped(_First);
     const auto _ULast = _Get_unwrapped(_Last);
@@ -1189,7 +1189,7 @@ struct _Static_partitioned_for_each2 { // for_each task scheduled on the system 
 template <class _ExPo, class _FwdIt, class _Fn, _Enable_if_execution_policy_t<_ExPo> /* = 0 */>
 void for_each(_ExPo&&, _FwdIt _First, _FwdIt _Last, _Fn _Func) noexcept /* terminates */ {
     // perform function for each element [_First, _Last) with the indicated execution policy
-    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt);
+    _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt);
     _Adl_verify_range(_First, _Last);
     auto _UFirst      = _Get_unwrapped(_First);
     const auto _ULast = _Get_unwrapped(_Last);
@@ -1235,7 +1235,7 @@ _FwdIt _For_each_n_ivdep(_FwdIt _First, _Diff _Count, _Fn _Func) {
 template <class _ExPo, class _FwdIt, class _Diff, class _Fn, _Enable_if_execution_policy_t<_ExPo> /* = 0 */>
 _FwdIt for_each_n(_ExPo&&, _FwdIt _First, const _Diff _Count_raw, _Fn _Func) noexcept /* terminates */ {
     // perform function for each element [_First, _First + _Count)
-    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt);
+    _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt);
     _Algorithm_int_t<_Diff> _Count = _Count_raw;
     if (0 < _Count) {
         auto _UFirst = _Get_unwrapped_n(_First, _Count);
@@ -1274,13 +1274,13 @@ using _Parallel_find_results = conditional_t<_Use_atomic_iterator<_FwdIt>, _Para
     _Parallel_choose_min_chunk<_FwdIt>>;
 
 template <class _FwdIt, class _Find_fx>
-struct _Static_partitioned_find2 {
+struct _Static_partitioned_find3 {
     _Static_partition_team<_Iter_diff_t<_FwdIt>> _Team;
     _Static_partition_range<_FwdIt> _Basis;
     _Parallel_find_results<_FwdIt> _Results;
     _Find_fx _Fx;
 
-    _Static_partitioned_find2(
+    _Static_partitioned_find3(
         const size_t _Hw_threads, const _Iter_diff_t<_FwdIt> _Count, const _FwdIt _Last, const _Find_fx _Fx_)
         : _Team{_Count, _Get_chunked_work_chunk_count(_Hw_threads, _Count)}, _Basis{}, _Results(_Last), _Fx(_Fx_) {}
 
@@ -1307,7 +1307,7 @@ struct _Static_partitioned_find2 {
 
     static void __stdcall _Threadpool_callback(
         __std_PTP_CALLBACK_INSTANCE, void* const _Context, __std_PTP_WORK) noexcept /* terminates */ {
-        _Run_available_chunked_work(*static_cast<_Static_partitioned_find2*>(_Context));
+        _Run_available_chunked_work(*static_cast<_Static_partitioned_find3*>(_Context));
     }
 };
 
@@ -1320,7 +1320,7 @@ _FwdIt _Find_parallel_unchecked(_ExPo&&, const _FwdIt _First, const _FwdIt _Last
             const auto _Count = _STD distance(_First, _Last);
             if (_Count >= 2) {
                 _TRY_BEGIN
-                _Static_partitioned_find2 _Operation{_Hw_threads, _Count, _Last, _Fx};
+                _Static_partitioned_find3 _Operation{_Hw_threads, _Count, _Last, _Fx};
                 _Operation._Basis._Populate(_Operation._Team, _First);
                 _Run_chunked_parallel_work(_Hw_threads, _Operation);
                 return _Operation._Results._Get_result();
@@ -1337,7 +1337,7 @@ _FwdIt _Find_parallel_unchecked(_ExPo&&, const _FwdIt _First, const _FwdIt _Last
 template <class _ExPo, class _FwdIt, class _Ty, _Enable_if_execution_policy_t<_ExPo> /* = 0 */>
 _NODISCARD _FwdIt find(_ExPo&& _Exec, _FwdIt _First, const _FwdIt _Last, const _Ty& _Val) noexcept /* terminates */ {
     // find first matching _Val
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt);
     using _UFwdIt = _Unwrapped_t<const _FwdIt&>;
     _Adl_verify_range(_First, _Last);
     _Seek_wrapped(_First,
@@ -1349,7 +1349,7 @@ _NODISCARD _FwdIt find(_ExPo&& _Exec, _FwdIt _First, const _FwdIt _Last, const _
 template <class _ExPo, class _FwdIt, class _Pr, _Enable_if_execution_policy_t<_ExPo> /* = 0 */>
 _NODISCARD _FwdIt find_if(_ExPo&& _Exec, _FwdIt _First, const _FwdIt _Last, _Pr _Pred) noexcept /* terminates */ {
     // find first satisfying _Pred
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt);
     using _UFwdIt = _Unwrapped_t<const _FwdIt&>;
     _Adl_verify_range(_First, _Last);
     auto _Pass_pred = _Pass_fn(_Pred);
@@ -1362,7 +1362,7 @@ _NODISCARD _FwdIt find_if(_ExPo&& _Exec, _FwdIt _First, const _FwdIt _Last, _Pr 
 template <class _ExPo, class _FwdIt, class _Pr, _Enable_if_execution_policy_t<_ExPo> /* = 0 */>
 _NODISCARD _FwdIt find_if_not(_ExPo&& _Exec, _FwdIt _First, const _FwdIt _Last, _Pr _Pred) noexcept /* terminates */ {
     // find first satisfying !_Pred
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt);
     using _UFwdIt = _Unwrapped_t<const _FwdIt&>;
     _Adl_verify_range(_First, _Last);
     auto _Pass_pred = _Pass_fn(_Pred);
@@ -1396,7 +1396,7 @@ _Iter_diff_t<_FwdIt1> _Get_find_end_forward_partition_size(
 }
 
 template <class _FwdIt1, class _FwdIt2, class _Pr>
-struct _Static_partitioned_find_end_forward {
+struct _Static_partitioned_find_end_forward2 {
     _Static_partition_team<_Iter_diff_t<_FwdIt1>> _Team;
     _Static_partition_range<_FwdIt1> _Basis;
     _Iterator_range<_FwdIt2> _Range2;
@@ -1405,7 +1405,7 @@ struct _Static_partitioned_find_end_forward {
         _Parallel_choose_max_chunk<_FwdIt1>>
         _Results;
 
-    _Static_partitioned_find_end_forward(const size_t _Hw_threads, const _Iter_diff_t<_FwdIt1> _Count,
+    _Static_partitioned_find_end_forward2(const size_t _Hw_threads, const _Iter_diff_t<_FwdIt1> _Count,
         const _FwdIt1 _Last1, const _FwdIt2 _First2, const _FwdIt2 _Last2, const _Pr _Pred_)
         : _Team{_Count, _Get_chunked_work_chunk_count(_Hw_threads, _Count)}, _Basis{}, _Range2{_First2, _Last2},
           _Pred{_Pred_}, _Results(_Last1) {}
@@ -1434,7 +1434,7 @@ struct _Static_partitioned_find_end_forward {
 
     static void __stdcall _Threadpool_callback(
         __std_PTP_CALLBACK_INSTANCE, void* const _Context, __std_PTP_WORK) noexcept /* terminates */ {
-        (void) static_cast<_Static_partitioned_find_end_forward*>(_Context)->_Process_chunk();
+        (void) static_cast<_Static_partitioned_find_end_forward2*>(_Context)->_Process_chunk();
     }
 };
 
@@ -1442,7 +1442,7 @@ template <class _BidIt1, class _FwdIt2>
 _BidIt1 _Get_find_end_backward_partition_start(
     const _BidIt1 _First1, _BidIt1 _Last1, _FwdIt2 _First2, const _FwdIt2 _Last2) {
     // gets the end of the range of possible matches for a find_end operation
-    if constexpr (_Is_random_iter_v<_BidIt1> && _Is_random_iter_v<_FwdIt2>) {
+    if constexpr (_Is_ranges_random_iter_v<_BidIt1> && _Is_ranges_random_iter_v<_FwdIt2>) {
         using _CT         = _Common_diff_t<_BidIt1, _FwdIt2>;
         const _CT _Count1 = _Last1 - _First1;
         const _CT _Count2 = _Last2 - _First2;
@@ -1472,7 +1472,7 @@ _BidIt1 _Get_find_end_backward_partition_start(
 }
 
 template <class _BidIt1, class _FwdIt2, class _Pr>
-struct _Static_partitioned_find_end_backward2 {
+struct _Static_partitioned_find_end_backward3 {
     _Static_partition_team<_Iter_diff_t<_BidIt1>> _Team;
     _Static_partition_range_backward<_BidIt1> _Basis;
     conditional_t<_Use_atomic_iterator<_BidIt1>, _Parallel_choose_max_result<_BidIt1>,
@@ -1481,7 +1481,7 @@ struct _Static_partitioned_find_end_backward2 {
     _Iterator_range<_FwdIt2> _Range2;
     _Pr _Pred;
 
-    _Static_partitioned_find_end_backward2(const size_t _Hw_threads, const _Iter_diff_t<_BidIt1> _Count,
+    _Static_partitioned_find_end_backward3(const size_t _Hw_threads, const _Iter_diff_t<_BidIt1> _Count,
         const _BidIt1 _Last1, const _FwdIt2 _First2, const _FwdIt2 _Last2, const _Pr _Pred_)
         : _Team{_Count, _Get_chunked_work_chunk_count(_Hw_threads, _Count)}, _Basis{},
           _Results(_Last1), _Range2{_First2, _Last2}, _Pred{_Pred_} {}
@@ -1512,7 +1512,7 @@ struct _Static_partitioned_find_end_backward2 {
 
     static void __stdcall _Threadpool_callback(
         __std_PTP_CALLBACK_INSTANCE, void* const _Context, __std_PTP_WORK) noexcept /* terminates */ {
-        _Run_available_chunked_work(*static_cast<_Static_partitioned_find_end_backward2*>(_Context));
+        _Run_available_chunked_work(*static_cast<_Static_partitioned_find_end_backward3*>(_Context));
     }
 };
 
@@ -1520,6 +1520,8 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, class _Pr, _Enable_if_execu
 _NODISCARD _FwdIt1 find_end(_ExPo&&, _FwdIt1 _First1, const _FwdIt1 _Last1, const _FwdIt2 _First2, const _FwdIt2 _Last2,
     _Pr _Pred) noexcept /* terminates */ {
     // find last [_First2, _Last2) satisfying _Pred
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
     _Adl_verify_range(_First1, _Last1);
     _Adl_verify_range(_First2, _Last2);
     const auto _UFirst1 = _Get_unwrapped(_First1);
@@ -1529,7 +1531,7 @@ _NODISCARD _FwdIt1 find_end(_ExPo&&, _FwdIt1 _First1, const _FwdIt1 _Last1, cons
     if constexpr (remove_reference_t<_ExPo>::_Parallelize) {
         const size_t _Hw_threads = __std_parallel_algorithms_hw_threads();
         if (_Hw_threads > 1) {
-            if constexpr (_Is_bidi_iter_v<_FwdIt1>) {
+            if constexpr (_Is_ranges_bidi_iter_v<_FwdIt1>) {
                 const auto _Partition_start =
                     _Get_find_end_backward_partition_start(_UFirst1, _ULast1, _UFirst2, _ULast2);
                 if (_UFirst1 == _Partition_start) {
@@ -1540,7 +1542,7 @@ _NODISCARD _FwdIt1 find_end(_ExPo&&, _FwdIt1 _First1, const _FwdIt1 _Last1, cons
                 const auto _Count = _STD distance(_UFirst1, _Partition_start);
                 if (_Count >= 2) {
                     _TRY_BEGIN
-                    _Static_partitioned_find_end_backward2 _Operation{
+                    _Static_partitioned_find_end_backward3 _Operation{
                         _Hw_threads, _Count, _ULast1, _UFirst2, _ULast2, _Pass_fn(_Pred)};
                     _Operation._Basis._Populate(_Operation._Team, _Partition_start);
                     _Run_chunked_parallel_work(_Hw_threads, _Operation);
@@ -1554,7 +1556,7 @@ _NODISCARD _FwdIt1 find_end(_ExPo&&, _FwdIt1 _First1, const _FwdIt1 _Last1, cons
                 const auto _Count = _Get_find_end_forward_partition_size(_UFirst1, _ULast1, _UFirst2, _ULast2);
                 if (_Count >= 2) {
                     _TRY_BEGIN
-                    _Static_partitioned_find_end_forward _Operation{
+                    _Static_partitioned_find_end_forward2 _Operation{
                         _Hw_threads, _Count, _ULast1, _UFirst2, _ULast2, _Pass_fn(_Pred)};
                     _Operation._Basis._Populate(_Operation._Team, _UFirst1);
                     _Run_chunked_parallel_work(_Hw_threads, _Operation);
@@ -1576,8 +1578,8 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, class _Pr, _Enable_if_execu
 _NODISCARD _FwdIt1 find_first_of(_ExPo&& _Exec, const _FwdIt1 _First1, _FwdIt1 _Last1, const _FwdIt2 _First2,
     const _FwdIt2 _Last2, _Pr _Pred) noexcept /* terminates */ {
     // look for one of [_First2, _Last2) that matches element
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
     using _UFwdIt1 = _Unwrapped_t<const _FwdIt1&>;
     _Adl_verify_range(_First1, _Last1);
     _Adl_verify_range(_First2, _Last2);
@@ -1596,13 +1598,13 @@ _NODISCARD _FwdIt1 find_first_of(_ExPo&& _Exec, const _FwdIt1 _First1, _FwdIt1 _
 }
 
 template <class _FwdIt, class _Pr>
-struct _Static_partitioned_adjacent_find2 {
+struct _Static_partitioned_adjacent_find3 {
     _Static_partition_team<_Iter_diff_t<_FwdIt>> _Team;
     _Static_partition_range<_FwdIt> _Basis;
     _Parallel_find_results<_FwdIt> _Results;
     _Pr _Pred;
 
-    _Static_partitioned_adjacent_find2(
+    _Static_partitioned_adjacent_find3(
         const size_t _Hw_threads, const _Iter_diff_t<_FwdIt> _Count, const _FwdIt _Last, const _Pr _Pred_)
         : _Team{_Count, _Get_chunked_work_chunk_count(_Hw_threads, _Count)}, _Basis{}, _Results{_Last}, _Pred{_Pred_} {}
 
@@ -1635,7 +1637,7 @@ struct _Static_partitioned_adjacent_find2 {
 
     static void __stdcall _Threadpool_callback(
         __std_PTP_CALLBACK_INSTANCE, void* const _Context, __std_PTP_WORK) noexcept /* terminates */ {
-        _Run_available_chunked_work(*static_cast<_Static_partitioned_adjacent_find2*>(_Context));
+        _Run_available_chunked_work(*static_cast<_Static_partitioned_adjacent_find3*>(_Context));
     }
 };
 
@@ -1651,7 +1653,7 @@ _NODISCARD _FwdIt adjacent_find(_ExPo&&, _FwdIt _First, _FwdIt _Last, _Pr _Pred)
             const auto _Count = static_cast<_Iter_diff_t<_FwdIt>>(_STD distance(_UFirst, _ULast) - 1);
             if (_Count >= 2) {
                 _TRY_BEGIN
-                _Static_partitioned_adjacent_find2 _Operation{_Hw_threads, _Count, _ULast, _Pass_fn(_Pred)};
+                _Static_partitioned_adjacent_find3 _Operation{_Hw_threads, _Count, _ULast, _Pass_fn(_Pred)};
                 _Operation._Basis._Populate(_Operation._Team, _UFirst);
                 _Run_chunked_parallel_work(_Hw_threads, _Operation);
                 _Seek_wrapped(_Last, _Operation._Results._Get_result());
@@ -1701,7 +1703,7 @@ template <class _ExPo, class _FwdIt, class _Pr, _Enable_if_execution_policy_t<_E
 _NODISCARD _Iter_diff_t<_FwdIt> count_if(_ExPo&&, const _FwdIt _First, const _FwdIt _Last, _Pr _Pred) noexcept
 /* terminates */ {
     // count elements satisfying _Pred
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt);
     _Adl_verify_range(_First, _Last);
     auto _UFirst      = _Get_unwrapped(_First);
     const auto _ULast = _Get_unwrapped(_Last);
@@ -1736,15 +1738,15 @@ template <class _ExPo, class _FwdIt, class _Ty, _Enable_if_execution_policy_t<_E
 _NODISCARD _Iter_diff_t<_FwdIt> count(_ExPo&& _Exec, const _FwdIt _First, const _FwdIt _Last, const _Ty& _Val) noexcept
 /* terminates */ {
     // count elements that match _Val
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt);
     _Adl_verify_range(_First, _Last);
     return _STD count_if(_STD forward<_ExPo>(_Exec), _Get_unwrapped(_First), _Get_unwrapped(_Last),
         [&_Val](auto&& _Iter_val) { return _STD forward<decltype(_Iter_val)>(_Iter_val) == _Val; });
 }
 
 template <class _FwdIt1, class _FwdIt2,
-    bool = _Use_atomic_iterator<_Unwrapped_t<const _FwdIt1&>>&& _Is_random_iter_v<_FwdIt2>,
-    bool = _Use_atomic_iterator<_Unwrapped_t<const _FwdIt2&>>&& _Is_random_iter_v<_FwdIt1>>
+    bool = _Use_atomic_iterator<_Unwrapped_t<const _FwdIt1&>>&& _Is_ranges_random_iter_v<_FwdIt2>,
+    bool = _Use_atomic_iterator<_Unwrapped_t<const _FwdIt2&>>&& _Is_ranges_random_iter_v<_FwdIt1>>
 struct _Static_partitioned_mismatch_results;
 
 template <class _FwdIt1, class _FwdIt2, bool _Unused>
@@ -1805,7 +1807,7 @@ struct _Static_partitioned_mismatch_results<_FwdIt1, _FwdIt2, false, false> {
 };
 
 template <class _FwdIt1, class _FwdIt2, class _Pr>
-struct _Static_partitioned_mismatch2 {
+struct _Static_partitioned_mismatch3 {
     using _Diff = _Common_diff_t<_FwdIt1, _FwdIt2>;
     _Static_partition_team<_Diff> _Team;
     _Static_partition_range<_FwdIt1, _Diff> _Basis1;
@@ -1813,7 +1815,7 @@ struct _Static_partitioned_mismatch2 {
     _Static_partitioned_mismatch_results<_FwdIt1, _FwdIt2> _Results;
     _Pr _Pred;
 
-    _Static_partitioned_mismatch2(
+    _Static_partitioned_mismatch3(
         const size_t _Hw_threads, const _Diff _Count, const _FwdIt1 _First1, const _FwdIt2 _First2, const _Pr _Pred_)
         : _Team{_Count, _Get_chunked_work_chunk_count(_Hw_threads, _Count)}, _Basis1{}, _Basis2{},
           _Results(
@@ -1852,7 +1854,7 @@ struct _Static_partitioned_mismatch2 {
 
     static void __stdcall _Threadpool_callback(
         __std_PTP_CALLBACK_INSTANCE, void* const _Context, __std_PTP_WORK) noexcept /* terminates */ {
-        _Run_available_chunked_work(*static_cast<_Static_partitioned_mismatch2*>(_Context));
+        _Run_available_chunked_work(*static_cast<_Static_partitioned_mismatch3*>(_Context));
     }
 };
 
@@ -1863,8 +1865,8 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, class _Pr, _Enable_if_execu
 _NODISCARD pair<_FwdIt1, _FwdIt2> mismatch(
     _ExPo&&, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2, _Pr _Pred) noexcept /* terminates */ {
     // return [_First1, _Last1)/[_First2, ...) mismatch
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
     _Adl_verify_range(_First1, _Last1);
     const auto _UFirst1 = _Get_unwrapped(_First1);
     const auto _ULast1  = _Get_unwrapped(_Last1);
@@ -1875,7 +1877,7 @@ _NODISCARD pair<_FwdIt1, _FwdIt2> mismatch(
             const auto _UFirst2 = _Get_unwrapped_n(_First2, _Count);
             if (_Count >= 2) {
                 _TRY_BEGIN
-                _Static_partitioned_mismatch2 _Operation{_Hw_threads, _Count, _UFirst1, _UFirst2, _Pass_fn(_Pred)};
+                _Static_partitioned_mismatch3 _Operation{_Hw_threads, _Count, _UFirst1, _UFirst2, _Pass_fn(_Pred)};
                 _Run_chunked_parallel_work(_Hw_threads, _Operation);
                 const auto _Result = _Operation._Results._Get_result(_UFirst1, _UFirst2);
                 _Seek_wrapped(_First2, _Result.second);
@@ -1905,8 +1907,8 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, class _Pr, _Enable_if_execu
 _NODISCARD pair<_FwdIt1, _FwdIt2> mismatch(
     _ExPo&&, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2, _FwdIt2 _Last2, _Pr _Pred) noexcept /* terminates */ {
     // return [_First1, _Last1)/[_First2, _Last2) mismatch
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
     _Adl_verify_range(_First1, _Last1);
     _Adl_verify_range(_First2, _Last2);
     const auto _UFirst1 = _Get_unwrapped(_First1);
@@ -1919,7 +1921,7 @@ _NODISCARD pair<_FwdIt1, _FwdIt2> mismatch(
             const auto _Count = static_cast<_Iter_diff_t<_FwdIt1>>(_Distance_min(_UFirst1, _ULast1, _UFirst2, _ULast2));
             if (_Count >= 2) {
                 _TRY_BEGIN
-                _Static_partitioned_mismatch2 _Operation{_Hw_threads, _Count, _UFirst1, _UFirst2, _Pass_fn(_Pred)};
+                _Static_partitioned_mismatch3 _Operation{_Hw_threads, _Count, _UFirst1, _UFirst2, _Pass_fn(_Pred)};
                 _Run_chunked_parallel_work(_Hw_threads, _Operation);
                 const auto _Result = _Operation._Results._Get_result(_UFirst1, _UFirst2);
                 _Seek_wrapped(_First2, _Result.second);
@@ -1982,8 +1984,8 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, class _Pr, _Enable_if_execu
 _NODISCARD bool equal(_ExPo&&, const _FwdIt1 _First1, const _FwdIt1 _Last1, const _FwdIt2 _First2, _Pr _Pred) noexcept
 /* terminates */ {
     // compare [_First1, _Last1) to [_First2, ...)
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
     _Adl_verify_range(_First1, _Last1);
     const auto _UFirst1 = _Get_unwrapped(_First1);
     const auto _ULast1  = _Get_unwrapped(_Last1);
@@ -2015,8 +2017,8 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, class _Pr, _Enable_if_execu
 _NODISCARD bool equal(_ExPo&&, const _FwdIt1 _First1, const _FwdIt1 _Last1, const _FwdIt2 _First2, const _FwdIt2 _Last2,
     _Pr _Pred) noexcept /* terminates */ {
     // compare [_First1, _Last1) to [_First2, _Last2)
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
     _Adl_verify_range(_First1, _Last1);
     _Adl_verify_range(_First2, _Last2);
     const auto _UFirst1 = _Get_unwrapped(_First1);
@@ -2053,7 +2055,7 @@ _NODISCARD bool equal(_ExPo&&, const _FwdIt1 _First1, const _FwdIt1 _Last1, cons
 }
 
 template <class _FwdItHaystack, class _FwdItPat, class _Pr>
-struct _Static_partitioned_search2 {
+struct _Static_partitioned_search3 {
     _Static_partition_team<_Iter_diff_t<_FwdItHaystack>> _Team;
     _Static_partition_range<_FwdItHaystack> _Basis;
     _Parallel_find_results<_FwdItHaystack> _Results;
@@ -2061,7 +2063,7 @@ struct _Static_partitioned_search2 {
     _FwdItPat _Last2;
     _Pr _Pred;
 
-    _Static_partitioned_search2(const size_t _Hw_threads, const _Iter_diff_t<_FwdItHaystack> _Count,
+    _Static_partitioned_search3(const size_t _Hw_threads, const _Iter_diff_t<_FwdItHaystack> _Count,
         const _FwdItHaystack _First1, const _FwdItHaystack _Last1, const _FwdItPat _First2_, const _FwdItPat _Last2_,
         _Pr _Pred_)
         : _Team{_Count, _Get_chunked_work_chunk_count(_Hw_threads, _Count)}, _Basis{}, _Results(_Last1),
@@ -2093,7 +2095,7 @@ struct _Static_partitioned_search2 {
 
     static void __stdcall _Threadpool_callback(
         __std_PTP_CALLBACK_INSTANCE, void* const _Context, __std_PTP_WORK) noexcept /* terminates */ {
-        _Run_available_chunked_work(*static_cast<_Static_partitioned_search2*>(_Context));
+        _Run_available_chunked_work(*static_cast<_Static_partitioned_search3*>(_Context));
     }
 };
 
@@ -2101,6 +2103,8 @@ template <class _ExPo, class _FwdItHaystack, class _FwdItPat, class _Pr, _Enable
 _NODISCARD _FwdItHaystack search(_ExPo&&, const _FwdItHaystack _First1, _FwdItHaystack _Last1, const _FwdItPat _First2,
     const _FwdItPat _Last2, _Pr _Pred) noexcept /* terminates */ {
     // find first [_First2, _Last2) match
+    _REQUIRE_PARALLEL_ITERATOR(_FwdItHaystack);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdItPat);
     _Adl_verify_range(_First2, _Last2);
     const auto _UFirst2 = _Get_unwrapped(_First2);
     const auto _ULast2  = _Get_unwrapped(_Last2);
@@ -2116,7 +2120,7 @@ _NODISCARD _FwdItHaystack search(_ExPo&&, const _FwdItHaystack _First1, _FwdItHa
         const size_t _Hw_threads = __std_parallel_algorithms_hw_threads();
         if (_Hw_threads > 1) {
             _Iter_diff_t<_FwdItHaystack> _Count;
-            if constexpr (_Is_random_iter_v<_FwdItHaystack> && _Is_random_iter_v<_FwdItPat>) {
+            if constexpr (_Is_ranges_random_iter_v<_FwdItHaystack> && _Is_ranges_random_iter_v<_FwdItPat>) {
                 const auto _HaystackDist = _ULast1 - _UFirst1;
                 const auto _NeedleDist   = _ULast2 - _UFirst2;
                 if (_NeedleDist > _HaystackDist) { // needle is longer than haystack, no match possible
@@ -2156,7 +2160,7 @@ _NODISCARD _FwdItHaystack search(_ExPo&&, const _FwdItHaystack _First1, _FwdItHa
             }
 
             _TRY_BEGIN
-            _Static_partitioned_search2 _Operation{
+            _Static_partitioned_search3 _Operation{
                 _Hw_threads, _Count, _UFirst1, _ULast1, _UFirst2, _ULast2, _Pass_fn(_Pred)};
             _Run_chunked_parallel_work(_Hw_threads, _Operation);
             _Seek_wrapped(_Last1, _Operation._Results._Get_result());
@@ -2172,7 +2176,7 @@ _NODISCARD _FwdItHaystack search(_ExPo&&, const _FwdItHaystack _First1, _FwdItHa
 }
 
 template <class _FwdIt, class _Ty, class _Pr>
-struct _Static_partitioned_search_n2 {
+struct _Static_partitioned_search_n3 {
     _Static_partition_team<_Iter_diff_t<_FwdIt>> _Team;
     _Static_partition_range<_FwdIt> _Basis;
     _Parallel_find_results<_FwdIt> _Results;
@@ -2180,7 +2184,7 @@ struct _Static_partitioned_search_n2 {
     const _Ty& _Val;
     _Pr _Pred;
 
-    _Static_partitioned_search_n2(const size_t _Hw_threads, const _Iter_diff_t<_FwdIt> _Candidates, const _FwdIt _First,
+    _Static_partitioned_search_n3(const size_t _Hw_threads, const _Iter_diff_t<_FwdIt> _Candidates, const _FwdIt _First,
         const _FwdIt _Last, const _Iter_diff_t<_FwdIt> _Target_count_, const _Ty& _Val_, _Pr _Pred_)
         : _Team{_Candidates, _Get_chunked_work_chunk_count(_Hw_threads, _Candidates)}, _Basis{}, _Results(_Last),
           _Target_count(_Target_count_), _Val(_Val_), _Pred(_Pred_) {
@@ -2220,7 +2224,7 @@ struct _Static_partitioned_search_n2 {
 
     static void __stdcall _Threadpool_callback(
         __std_PTP_CALLBACK_INSTANCE, void* const _Context, __std_PTP_WORK) noexcept /* terminates */ {
-        _Run_available_chunked_work(*static_cast<_Static_partitioned_search_n2*>(_Context));
+        _Run_available_chunked_work(*static_cast<_Static_partitioned_search_n3*>(_Context));
     }
 };
 
@@ -2253,7 +2257,7 @@ _NODISCARD _FwdIt search_n(_ExPo&&, const _FwdIt _First, _FwdIt _Last, const _Di
             // +1 can't overflow because _Count > 0
             const auto _Candidates = static_cast<_Iter_diff_t<_FwdIt>>(_Haystack_count - _Count + 1);
             _TRY_BEGIN
-            _Static_partitioned_search_n2 _Operation{_Hw_threads, _Candidates, _UFirst, _ULast,
+            _Static_partitioned_search_n3 _Operation{_Hw_threads, _Candidates, _UFirst, _ULast,
                 static_cast<_Iter_diff_t<_FwdIt>>(_Count), _Val, _Pass_fn(_Pred)};
             _Run_chunked_parallel_work(_Hw_threads, _Operation);
             _Seek_wrapped(_Last, _Operation._Results._Get_result());
@@ -2304,8 +2308,8 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, class _Fn, _Enable_if_execu
 _FwdIt2 transform(_ExPo&&, const _FwdIt1 _First, const _FwdIt1 _Last, _FwdIt2 _Dest, _Fn _Func) noexcept
 /* terminates */ {
     // transform [_First, _Last) with _Func
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt2);
     _Adl_verify_range(_First, _Last);
     auto _UFirst      = _Get_unwrapped(_First);
     const auto _ULast = _Get_unwrapped(_Last);
@@ -2383,9 +2387,9 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, class _FwdIt3, class _Fn,
 _FwdIt3 transform(_ExPo&&, const _FwdIt1 _First1, const _FwdIt1 _Last1, const _FwdIt2 _First2, _FwdIt3 _Dest,
     _Fn _Func) noexcept /* terminates */ {
     // transform [_First1, _Last1) and [_First2, ...) with _Func
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt2);
-    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt3);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt3);
     _Adl_verify_range(_First1, _Last1);
     const auto _UFirst1 = _Get_unwrapped(_First1);
     const auto _ULast1  = _Get_unwrapped(_Last1);
@@ -2428,7 +2432,7 @@ template <class _ExPo, class _FwdIt, class _Ty, _Enable_if_execution_policy_t<_E
 void replace(_ExPo&& _Exec, const _FwdIt _First, const _FwdIt _Last, const _Ty& _Oldval, const _Ty& _Newval) noexcept
 /* terminates */ {
     // replace each matching _Oldval with _Newval
-    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt);
+    _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt);
     _STD for_each(_STD forward<_ExPo>(_Exec), _First, _Last, [&](auto&& _Value) {
         if (_STD forward<decltype(_Value)>(_Value) == _Oldval) {
             _STD forward<decltype(_Value)>(_Value) = _Newval;
@@ -2440,7 +2444,7 @@ template <class _ExPo, class _FwdIt, class _Pr, class _Ty, _Enable_if_execution_
 void replace_if(_ExPo&& _Exec, const _FwdIt _First, const _FwdIt _Last, _Pr _Pred, const _Ty& _Val) noexcept
 /* terminates */ {
     // replace each satisfying _Pred with _Val
-    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt);
+    _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt);
     _STD for_each(
         _STD forward<_ExPo>(_Exec), _First, _Last, [&_Val, _Lambda_pred = _Pass_fn(_Pred)](auto&& _Value) mutable {
             if (_Lambda_pred(_STD forward<decltype(_Value)>(_Value))) {
@@ -2997,14 +3001,14 @@ void stable_sort(_ExPo&&, const _BidIt _First, const _BidIt _Last, _Pr _Pred) no
 }
 
 template <class _FwdIt, class _Pr>
-struct _Static_partitioned_is_sorted_until {
+struct _Static_partitioned_is_sorted_until2 {
     _Static_partition_team<_Iter_diff_t<_FwdIt>> _Team;
     // note offset partitioning:
     _Static_partition_range<_FwdIt> _Basis; // contains partition of [_First, _Last - 1)
     _Pr _Pred;
     _Parallel_find_results<_FwdIt> _Results;
 
-    _Static_partitioned_is_sorted_until(
+    _Static_partitioned_is_sorted_until2(
         _FwdIt _First, _FwdIt _Last, const size_t _Hw_threads, const _Iter_diff_t<_FwdIt> _Count, _Pr _Pred_)
         : _Team{_Count, _Get_chunked_work_chunk_count(_Hw_threads, _Count)}, _Basis{}, _Pred(_Pred_), _Results(_Last) {
         _Basis._Populate(_Team, _First);
@@ -3038,14 +3042,14 @@ struct _Static_partitioned_is_sorted_until {
 
     static void __stdcall _Threadpool_callback(
         __std_PTP_CALLBACK_INSTANCE, void* const _Context, __std_PTP_WORK) noexcept /* terminates */ {
-        _Run_available_chunked_work(*static_cast<_Static_partitioned_is_sorted_until*>(_Context));
+        _Run_available_chunked_work(*static_cast<_Static_partitioned_is_sorted_until2*>(_Context));
     }
 };
 
 template <class _ExPo, class _FwdIt, class _Pr, _Enable_if_execution_policy_t<_ExPo> /* = 0 */>
 _NODISCARD _FwdIt is_sorted_until(_ExPo&&, _FwdIt _First, _FwdIt _Last, _Pr _Pred) noexcept /* terminates */ {
     // find extent of range that is ordered by predicate
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt);
     _Adl_verify_range(_First, _Last);
     const auto _UFirst = _Get_unwrapped(_First);
     const auto _ULast  = _Get_unwrapped(_Last);
@@ -3056,7 +3060,7 @@ _NODISCARD _FwdIt is_sorted_until(_ExPo&&, _FwdIt _First, _FwdIt _Last, _Pr _Pre
             if (_Count >= 3) { // ... with at least 3 elements
                 _TRY_BEGIN
                 --_Count; // note unusual offset partitioning
-                _Static_partitioned_is_sorted_until _Operation{_UFirst, _ULast, _Hw_threads, _Count, _Pass_fn(_Pred)};
+                _Static_partitioned_is_sorted_until2 _Operation{_UFirst, _ULast, _Hw_threads, _Count, _Pass_fn(_Pred)};
                 _Run_chunked_parallel_work(_Hw_threads, _Operation);
                 _Seek_wrapped(_First, _Operation._Results._Get_result());
                 return _First;
@@ -3199,7 +3203,7 @@ struct _Static_partitioned_is_partitioned {
 template <class _ExPo, class _FwdIt, class _Pr, _Enable_if_execution_policy_t<_ExPo> /* = 0 */>
 _NODISCARD bool is_partitioned(_ExPo&&, const _FwdIt _First, const _FwdIt _Last, _Pr _Pred) noexcept /* terminates */ {
     // test if [_First, _Last) is partitioned by _Pred
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt);
     _Adl_verify_range(_First, _Last);
     const auto _UFirst = _Get_unwrapped(_First);
     const auto _ULast  = _Get_unwrapped(_Last);
@@ -3224,14 +3228,14 @@ _NODISCARD bool is_partitioned(_ExPo&&, const _FwdIt _First, const _FwdIt _Last,
 }
 
 template <class _RanIt, class _Pr>
-struct _Static_partitioned_is_heap_until {
+struct _Static_partitioned_is_heap_until2 {
     using _Diff = _Iter_diff_t<_RanIt>;
     _Static_partition_team<_Diff> _Team;
     _RanIt _Range_first;
     _Pr _Pred;
     _Parallel_find_results<_RanIt> _Results;
 
-    _Static_partitioned_is_heap_until(
+    _Static_partitioned_is_heap_until2(
         _RanIt _First, _RanIt _Last, const size_t _Hw_threads, const _Diff _Count, _Pr _Pred_)
         : _Team{_Count, _Get_chunked_work_chunk_count(_Hw_threads, _Count)}, _Range_first(_First), _Pred(_Pred_),
           _Results(_Last) {}
@@ -3264,14 +3268,14 @@ struct _Static_partitioned_is_heap_until {
 
     static void __stdcall _Threadpool_callback(
         __std_PTP_CALLBACK_INSTANCE, void* const _Context, __std_PTP_WORK) noexcept /* terminates */ {
-        _Run_available_chunked_work(*static_cast<_Static_partitioned_is_heap_until*>(_Context));
+        _Run_available_chunked_work(*static_cast<_Static_partitioned_is_heap_until2*>(_Context));
     }
 };
 
 template <class _ExPo, class _RanIt, class _Pr, _Enable_if_execution_policy_t<_ExPo> /* = 0 */>
 _NODISCARD _RanIt is_heap_until(_ExPo&&, _RanIt _First, _RanIt _Last, _Pr _Pred) noexcept /* terminates */ {
     // find extent of range that is a heap
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_RanIt);
+    _REQUIRE_PARALLEL_ITERATOR(_RanIt);
     _Adl_verify_range(_First, _Last);
     const auto _UFirst = _Get_unwrapped(_First);
     const auto _ULast  = _Get_unwrapped(_Last);
@@ -3281,7 +3285,7 @@ _NODISCARD _RanIt is_heap_until(_ExPo&&, _RanIt _First, _RanIt _Last, _Pr _Pred)
             const auto _Count = _ULast - _UFirst;
             if (_Count >= 3) { // ... with at least 3 elements
                 _TRY_BEGIN
-                _Static_partitioned_is_heap_until _Operation{_UFirst, _ULast, _Hw_threads, _Count, _Pass_fn(_Pred)};
+                _Static_partitioned_is_heap_until2 _Operation{_UFirst, _ULast, _Hw_threads, _Count, _Pass_fn(_Pred)};
                 _Run_chunked_parallel_work(_Hw_threads, _Operation);
                 _Seek_wrapped(_First, _Operation._Results._Get_result());
                 return _First;
@@ -3298,11 +3302,12 @@ _NODISCARD _RanIt is_heap_until(_ExPo&&, _RanIt _First, _RanIt _Last, _Pr _Pred)
 
 template <class _FwdIt, class _Pr>
 pair<_FwdIt, _Iter_diff_t<_FwdIt>> _Partition_with_count_unchecked(_FwdIt _First, _FwdIt _Last, _Pr _Pred) {
+    _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt);
     // move elements satisfying _Pred to front and track how many elements satisfy _Pred
-    if constexpr (_Is_random_iter_v<_FwdIt>) {
+    if constexpr (_Is_cpp17_random_iter_v<_FwdIt>) {
         auto _Mid = _STD partition(_First, _Last, _Pred);
         return {_Mid, _Mid - _First};
-    } else if constexpr (_Is_bidi_iter_v<_FwdIt>) {
+    } else if constexpr (_Is_cpp17_bidi_iter_v<_FwdIt>) {
         _Iter_diff_t<_FwdIt> _Trues{};
         for (;;) { // find any out-of-order pair
             for (;;) { // skip in-place elements at beginning
@@ -3361,8 +3366,9 @@ pair<_FwdIt, _Iter_diff_t<_FwdIt>> _Partition_swap_backward(
     _FwdIt _First, _FwdIt _Last, _FwdIt _Beginning_of_falses, _Pr _Pred) {
     // Swap elements in [_First, _Last) satisfying _Pred with elements from _Beginning_of_falses.
     // Pre: _Beginning_of_falses < _First
+    _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt);
     _Iter_diff_t<_FwdIt> _Trues{};
-    if constexpr (_Is_bidi_iter_v<_FwdIt>) {
+    if constexpr (_Is_cpp17_bidi_iter_v<_FwdIt>) {
         while (_First != _Last) {
             --_Last;
             if (_Pred(*_Last)) {
@@ -3393,12 +3399,13 @@ _FwdIt _Partition_merge(const _FwdIt _False_first, const _FwdIt _True_first, con
     const _Iter_diff_t<_FwdIt> _Count1, const _Iter_diff_t<_FwdIt> _Count2) {
     // Merge partition ranges where [_False_first, _True_first) are falses, [_True_first, _True_last) are trues
     // pre: _Count1 == distance(_False_first, _True_first) && _Count2 == distance(_True_first, _True_last)
+    _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt);
     if (_Count1 < _Count2) { // move the false range to the end of the true range
         const _Iter_diff_t<_FwdIt> _Offset = _Count2 - _Count1;
         auto _Result                       = _True_first;
-        if constexpr (_Is_random_iter_v<_FwdIt>) {
+        if constexpr (_Is_cpp17_random_iter_v<_FwdIt>) {
             _Result += _Offset;
-        } else if constexpr (_Is_bidi_iter_v<_FwdIt>) {
+        } else if constexpr (_Is_cpp17_bidi_iter_v<_FwdIt>) {
             if (_Count1 < _Offset) {
                 _Result = _True_last;
                 _STD advance(_Result, -_Count1);
@@ -3851,9 +3858,9 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, class _FwdIt3, class _Pr,
 _FwdIt3 set_intersection(_ExPo&&, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2, _FwdIt2 _Last2, _FwdIt3 _Dest,
     _Pr _Pred) noexcept /* terminates */ {
     // AND sets [_First1, _Last1) and [_First2, _Last2)
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt2);
-    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt3);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt3);
     _Adl_verify_range(_First1, _Last1);
     _Adl_verify_range(_First2, _Last2);
     auto _UFirst1      = _Get_unwrapped(_First1);
@@ -3862,8 +3869,10 @@ _FwdIt3 set_intersection(_ExPo&&, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _Firs
     const auto _ULast2 = _Get_unwrapped(_Last2);
     auto _UDest        = _Get_unwrapped_unverified(_Dest);
     using _Diff        = _Common_diff_t<_FwdIt1, _FwdIt2, _FwdIt3>;
-    if constexpr (remove_reference_t<_ExPo>::_Parallelize
-                  && _Is_random_iter_v<_FwdIt1> && _Is_random_iter_v<_FwdIt2> && _Is_random_iter_v<_FwdIt3>) {
+    if constexpr (remove_reference_t<_ExPo>::_Parallelize //
+                  && _Is_ranges_random_iter_v<_FwdIt1> //
+                  && _Is_ranges_random_iter_v<_FwdIt2> //
+                  && _Is_cpp17_random_iter_v<_FwdIt3>) {
         // only parallelize if desired, and all of the iterators given are random access
         const size_t _Hw_threads = __std_parallel_algorithms_hw_threads();
         if (_Hw_threads > 1) { // parallelize on multiprocessor machines
@@ -3941,9 +3950,9 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, class _FwdIt3, class _Pr,
 _FwdIt3 set_difference(_ExPo&&, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2, _FwdIt2 _Last2, _FwdIt3 _Dest,
     _Pr _Pred) noexcept /* terminates */ {
     // take set [_First2, _Last2) from [_First1, _Last1)
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt2);
-    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt3);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt3);
     _Adl_verify_range(_First1, _Last1);
     _Adl_verify_range(_First2, _Last2);
     auto _UFirst1      = _Get_unwrapped(_First1);
@@ -3952,8 +3961,10 @@ _FwdIt3 set_difference(_ExPo&&, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2
     const auto _ULast2 = _Get_unwrapped(_Last2);
     auto _UDest        = _Get_unwrapped_unverified(_Dest);
     using _Diff        = _Common_diff_t<_FwdIt1, _FwdIt2, _FwdIt3>;
-    if constexpr (remove_reference_t<_ExPo>::_Parallelize
-                  && _Is_random_iter_v<_FwdIt1> && _Is_random_iter_v<_FwdIt2> && _Is_random_iter_v<_FwdIt3>) {
+    if constexpr (remove_reference_t<_ExPo>::_Parallelize //
+                  && _Is_ranges_random_iter_v<_FwdIt1> //
+                  && _Is_ranges_random_iter_v<_FwdIt2> //
+                  && _Is_cpp17_random_iter_v<_FwdIt3>) {
         // only parallelize if desired, and all of the iterators given are random access
         const size_t _Hw_threads = __std_parallel_algorithms_hw_threads();
         if (_Hw_threads > 1) { // parallelize on multiprocessor machines
@@ -4043,7 +4054,7 @@ template <class _ExPo, class _FwdIt, class _Ty, class _BinOp, _Enable_if_executi
 _NODISCARD _Ty reduce(_ExPo&&, const _FwdIt _First, const _FwdIt _Last, _Ty _Val, _BinOp _Reduce_op) noexcept
 /* terminates */ {
     // return commutative and associative reduction of _Val and [_First, _Last), using _Reduce_op
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt);
     _Adl_verify_range(_First, _Last);
     auto _UFirst      = _Get_unwrapped(_First);
     const auto _ULast = _Get_unwrapped(_Last);
@@ -4143,8 +4154,8 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, class _Ty, class _BinOp1, c
 _NODISCARD _Ty transform_reduce(_ExPo&&, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2, _Ty _Val, _BinOp1 _Reduce_op,
     _BinOp2 _Transform_op) noexcept /* terminates */ {
     // return commutative and associative transform-reduction of sequences, using _Reduce_op and _Transform_op
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
     _Adl_verify_range(_First1, _Last1);
     auto _UFirst1      = _Get_unwrapped(_First1);
     const auto _ULast1 = _Get_unwrapped(_Last1);
@@ -4239,7 +4250,7 @@ template <class _ExPo, class _FwdIt, class _Ty, class _BinOp, class _UnaryOp,
 _NODISCARD _Ty transform_reduce(_ExPo&&, const _FwdIt _First, const _FwdIt _Last, _Ty _Val, _BinOp _Reduce_op,
     _UnaryOp _Transform_op) noexcept /* terminates */ {
     // return commutative and associative reduction of transformed sequence, using _Reduce_op and _Transform_op
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt);
     _Adl_verify_range(_First, _Last);
     auto _UFirst      = _Get_unwrapped(_First);
     const auto _ULast = _Get_unwrapped(_Last);
@@ -4389,8 +4400,8 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, class _Ty, class _BinOp,
 _FwdIt2 exclusive_scan(_ExPo&&, const _FwdIt1 _First, const _FwdIt1 _Last, _FwdIt2 _Dest, _Ty _Val,
     _BinOp _Reduce_op) noexcept /* terminates */ {
     // set each value in [_Dest, _Dest + (_Last - _First)) to the associative reduction of predecessors and _Val
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt2);
     _Adl_verify_range(_First, _Last);
     const auto _UFirst = _Get_unwrapped(_First);
     const auto _ULast  = _Get_unwrapped(_Last);
@@ -4518,8 +4529,8 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, class _BinOp, class _Ty,
 _FwdIt2 inclusive_scan(_ExPo&&, _FwdIt1 _First, _FwdIt1 _Last, _FwdIt2 _Dest, _BinOp _Reduce_op, _Ty _Val) noexcept
 /* terminates */ {
     // compute partial noncommutative and associative reductions including _Val into _Dest, using _Reduce_op
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt2);
     _Adl_verify_range(_First, _Last);
     const auto _UFirst = _Get_unwrapped(_First);
     const auto _ULast  = _Get_unwrapped(_Last);
@@ -4561,8 +4572,8 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, class _BinOp, _Enable_if_ex
 _FwdIt2 inclusive_scan(_ExPo&&, _FwdIt1 _First, _FwdIt1 _Last, _FwdIt2 _Dest, _BinOp _Reduce_op) noexcept
 /* terminates */ {
     // compute partial noncommutative and associative reductions into _Dest, using _Reduce_op
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt2);
     _Adl_verify_range(_First, _Last);
     const auto _UFirst = _Get_unwrapped(_First);
     const auto _ULast  = _Get_unwrapped(_Last);
@@ -4705,8 +4716,8 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, class _Ty, class _BinOp, cl
 _FwdIt2 transform_exclusive_scan(_ExPo&&, const _FwdIt1 _First, const _FwdIt1 _Last, _FwdIt2 _Dest, _Ty _Val,
     _BinOp _Reduce_op, _UnaryOp _Transform_op) noexcept /* terminates */ {
     // set each value in [_Dest, _Dest + (_Last - _First)) to the associative reduction of transformed predecessors
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt2);
     _Adl_verify_range(_First, _Last);
     const auto _UFirst = _Get_unwrapped(_First);
     const auto _ULast  = _Get_unwrapped(_Last);
@@ -4836,8 +4847,8 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, class _Ty, class _BinOp, cl
 _FwdIt2 transform_inclusive_scan(_ExPo&&, const _FwdIt1 _First, const _FwdIt1 _Last, _FwdIt2 _Dest, _BinOp _Reduce_op,
     _UnaryOp _Transform_op, _Ty _Val) noexcept /* terminates */ {
     // compute partial noncommutative and associative transformed reductions including _Val into _Dest
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt2);
     _Adl_verify_range(_First, _Last);
     const auto _UFirst = _Get_unwrapped(_First);
     const auto _ULast  = _Get_unwrapped(_Last);
@@ -4882,8 +4893,8 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, class _BinOp, class _UnaryO
 _FwdIt2 transform_inclusive_scan(_ExPo&&, const _FwdIt1 _First, const _FwdIt1 _Last, _FwdIt2 _Dest, _BinOp _Reduce_op,
     _UnaryOp _Transform_op) noexcept /* terminates */ {
     // compute partial noncommutative and associative transformed reductions into _Dest
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt2);
     _Adl_verify_range(_First, _Last);
     const auto _UFirst = _Get_unwrapped(_First);
     const auto _ULast  = _Get_unwrapped(_Last);
@@ -4983,8 +4994,8 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, class _BinOp, _Enable_if_ex
 _FwdIt2 adjacent_difference(_ExPo&&, const _FwdIt1 _First, const _FwdIt1 _Last, _FwdIt2 _Dest, _BinOp _Diff_op) noexcept
 /* terminates */ {
     // compute adjacent differences into _Dest
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt2);
     _Adl_verify_range(_First, _Last);
     auto _UFirst      = _Get_unwrapped(_First);
     const auto _ULast = _Get_unwrapped(_Last);

--- a/stl/inc/execution
+++ b/stl/inc/execution
@@ -1577,6 +1577,7 @@ _NODISCARD _FwdIt1 find_first_of(_ExPo&& _Exec, const _FwdIt1 _First1, _FwdIt1 _
     const _FwdIt2 _Last2, _Pr _Pred) noexcept /* terminates */ {
     // look for one of [_First2, _Last2) that matches element
     _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt2);
     using _UFwdIt1 = _Unwrapped_t<const _FwdIt1&>;
     _Adl_verify_range(_First1, _Last1);
     _Adl_verify_range(_First2, _Last2);
@@ -4389,7 +4390,7 @@ _FwdIt2 exclusive_scan(_ExPo&&, const _FwdIt1 _First, const _FwdIt1 _Last, _FwdI
     _BinOp _Reduce_op) noexcept /* terminates */ {
     // set each value in [_Dest, _Dest + (_Last - _First)) to the associative reduction of predecessors and _Val
     _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt2);
     _Adl_verify_range(_First, _Last);
     const auto _UFirst = _Get_unwrapped(_First);
     const auto _ULast  = _Get_unwrapped(_Last);

--- a/stl/inc/functional
+++ b/stl/inc/functional
@@ -2204,7 +2204,9 @@ _CONSTEXPR20 pair<_FwdItHaystack, _FwdItHaystack> _Search_pair_unchecked(
         }
 
         return {_Last1, _Last1};
-    } else if constexpr (_Is_fwd_iter_v<_FwdItHaystack> && _Is_fwd_iter_v<_FwdItPat>) {
+    } else {
+        static_assert(_Is_ranges_fwd_iter_v<_FwdItHaystack> && _Is_ranges_fwd_iter_v<_FwdItPat>,
+            "Iterators must be at least forward iterators");
         for (;; ++_First1) { // loop until match or end of a sequence
             _FwdItHaystack _Mid1 = _First1;
             for (_FwdItPat _Mid2 = _First2;; ++_Mid1, (void) ++_Mid2) {
@@ -2221,8 +2223,6 @@ _CONSTEXPR20 pair<_FwdItHaystack, _FwdItHaystack> _Search_pair_unchecked(
                 }
             }
         }
-    } else {
-        static_assert(_Always_false<_FwdItHaystack>, "Iterators must be at least forward iterators");
     }
 }
 

--- a/stl/inc/functional
+++ b/stl/inc/functional
@@ -2186,7 +2186,7 @@ template <class _FwdItHaystack, class _FwdItPat, class _Pred_eq>
 _CONSTEXPR20 pair<_FwdItHaystack, _FwdItHaystack> _Search_pair_unchecked(
     _FwdItHaystack _First1, _FwdItHaystack _Last1, _FwdItPat _First2, _FwdItPat _Last2, _Pred_eq& _Eq) {
     // find first [_First2, _Last2) satisfying _Eq
-    if constexpr (_Is_random_iter_v<_FwdItHaystack> && _Is_random_iter_v<_FwdItPat>) {
+    if constexpr (_Is_ranges_random_iter_v<_FwdItHaystack> && _Is_ranges_random_iter_v<_FwdItPat>) {
         _Iter_diff_t<_FwdItHaystack> _Count1 = _Last1 - _First1;
         _Iter_diff_t<_FwdItPat> _Count2      = _Last2 - _First2;
 

--- a/stl/inc/numeric
+++ b/stl/inc/numeric
@@ -108,7 +108,7 @@ _NODISCARD _Ty reduce(_ExPo&& _Exec, _FwdIt _First, _FwdIt _Last, _Ty _Val, _Bin
 template <class _ExPo, class _FwdIt, class _Ty, _Enable_if_execution_policy_t<_ExPo> = 0>
 _NODISCARD _Ty reduce(_ExPo&& _Exec, const _FwdIt _First, const _FwdIt _Last, _Ty _Val) noexcept /* terminates */ {
     // return commutative and associative reduction of _Val and [_First, _Last)
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt);
     return _STD reduce(_STD forward<_ExPo>(_Exec), _First, _Last, _STD move(_Val), plus{});
 }
 
@@ -117,7 +117,7 @@ _NODISCARD _Iter_value_t<_FwdIt> reduce(_ExPo&& _Exec, const _FwdIt _First, cons
 /* terminates */ {
     // return commutative and associative reduction of
     // iterator_traits<_FwdIt>::value_type{} and [_First, _Last)
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt);
     return _STD reduce(_STD forward<_ExPo>(_Exec), _First, _Last, _Iter_value_t<_FwdIt>{}, plus{});
 }
 #endif // _HAS_CXX17
@@ -228,8 +228,8 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, class _Ty, _Enable_if_execu
 _NODISCARD _Ty transform_reduce(_ExPo&& _Exec, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2, _Ty _Val) noexcept
 /* terminates */ {
     // return commutative and associative transform-reduction of sequences
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
     return _STD transform_reduce(
         _STD forward<_ExPo>(_Exec), _First1, _Last1, _First2, _STD move(_Val), plus{}, multiplies{});
 }

--- a/stl/inc/numeric
+++ b/stl/inc/numeric
@@ -108,7 +108,7 @@ _NODISCARD _Ty reduce(_ExPo&& _Exec, _FwdIt _First, _FwdIt _Last, _Ty _Val, _Bin
 template <class _ExPo, class _FwdIt, class _Ty, _Enable_if_execution_policy_t<_ExPo> = 0>
 _NODISCARD _Ty reduce(_ExPo&& _Exec, const _FwdIt _First, const _FwdIt _Last, _Ty _Val) noexcept /* terminates */ {
     // return commutative and associative reduction of _Val and [_First, _Last)
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt);
     return _STD reduce(_STD forward<_ExPo>(_Exec), _First, _Last, _STD move(_Val), plus{});
 }
 
@@ -117,7 +117,7 @@ _NODISCARD _Iter_value_t<_FwdIt> reduce(_ExPo&& _Exec, const _FwdIt _First, cons
 /* terminates */ {
     // return commutative and associative reduction of
     // iterator_traits<_FwdIt>::value_type{} and [_First, _Last)
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt);
     return _STD reduce(_STD forward<_ExPo>(_Exec), _First, _Last, _Iter_value_t<_FwdIt>{}, plus{});
 }
 #endif // _HAS_CXX17
@@ -228,8 +228,8 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, class _Ty, _Enable_if_execu
 _NODISCARD _Ty transform_reduce(_ExPo&& _Exec, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2, _Ty _Val) noexcept
 /* terminates */ {
     // return commutative and associative transform-reduction of sequences
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt2);
     return _STD transform_reduce(
         _STD forward<_ExPo>(_Exec), _First1, _Last1, _First2, _STD move(_Val), plus{}, multiplies{});
 }

--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -1985,7 +1985,7 @@ private:
     template <class _InIt>
     void _Reset(_InIt _First, _InIt _Last, flag_type _Flags) {
         // build regular expression from iterator range
-        if constexpr (_Is_fwd_iter_v<_InIt>) {
+        if constexpr (_Is_ranges_fwd_iter_v<_InIt>) {
 #if _ENHANCED_REGEX_VISUALIZER
             _Visualization.assign(_First, _Last);
 #endif // _ENHANCED_REGEX_VISUALIZER
@@ -1994,7 +1994,7 @@ private:
             _Root_node* _Rx = _Prs._Compile();
             _Reset(_Rx);
         } else {
-            static_assert(_Is_input_iter_v<_InIt>, "Iterators must be at least input iterators");
+            static_assert(_Is_ranges_input_iter_v<_InIt>, "Iterators must be at least input iterators");
 
             basic_string<_Iter_value_t<_InIt>> _Str(_First, _Last);
 

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -694,7 +694,7 @@ public:
         _Adl_verify_range(_First, _Last);
         auto _UFirst = _Get_unwrapped(_First);
         auto _ULast  = _Get_unwrapped(_Last);
-        if constexpr (_Is_ranges_fwd_iter_v<_Iter>) {
+        if constexpr (_Is_fwd_iter_v<_Iter>) {
             const auto _Count = _Convert_size<size_type>(static_cast<size_t>(_STD distance(_UFirst, _ULast)));
             _Construct_n(_Count, _STD move(_UFirst), _STD move(_ULast));
 #ifdef __cpp_lib_concepts
@@ -3135,7 +3135,7 @@ public:
     _CONSTEXPR20 iterator insert(const_iterator _Where, _Iter _First, _Iter _Last) {
         const difference_type _Saved_offset = _Where - begin();
 
-        if constexpr (_Is_ranges_fwd_iter_v<_Iter>) {
+        if constexpr (_Is_fwd_iter_v<_Iter>) {
             _Adl_verify_range(_First, _Last);
             const auto _Count    = _Convert_size<size_type>(static_cast<size_t>(_STD distance(_First, _Last)));
             const size_type _Off = _Insert_x(_Where, _Count);

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -694,7 +694,7 @@ public:
         _Adl_verify_range(_First, _Last);
         auto _UFirst = _Get_unwrapped(_First);
         auto _ULast  = _Get_unwrapped(_Last);
-        if constexpr (_Is_fwd_iter_v<_Iter>) {
+        if constexpr (_Is_ranges_fwd_iter_v<_Iter>) {
             const auto _Count = _Convert_size<size_type>(static_cast<size_t>(_STD distance(_UFirst, _ULast)));
             _Construct_n(_Count, _STD move(_UFirst), _STD move(_ULast));
 #ifdef __cpp_lib_concepts
@@ -1206,12 +1206,7 @@ public:
 
         _Adl_verify_range(_First, _Last);
         const auto _Whereoff = static_cast<size_type>(_Whereptr - _Oldfirst);
-#ifdef __cpp_lib_concepts
-        constexpr bool _Is_fwd = _Is_fwd_iter_v<_Iter> || forward_iterator<_Iter>;
-#else // ^^^ __cpp_lib_concepts ^^^ / vvv !__cpp_lib_concepts vvv
-        constexpr bool _Is_fwd = _Is_fwd_iter_v<_Iter>;
-#endif // ^^^ !__cpp_lib_concepts ^^^
-        if constexpr (_Is_fwd) {
+        if constexpr (_Is_ranges_fwd_iter_v<_Iter>) {
             _Insert_forward_range(_Where, _Get_unwrapped(_First), _Get_unwrapped(_Last));
         } else {
             _Insert_input_range(_Where, _Get_unwrapped(_First), _Get_unwrapped(_Last));
@@ -1362,12 +1357,7 @@ public:
     template <class _Iter, enable_if_t<_Is_iterator_v<_Iter>, int> = 0>
     _CONSTEXPR20 void assign(_Iter _First, _Iter _Last) {
         _Adl_verify_range(_First, _Last);
-#ifdef __cpp_lib_concepts
-        constexpr bool _Is_fwd = _Is_fwd_iter_v<_Iter> || forward_iterator<_Iter>;
-#else // ^^^ __cpp_lib_concepts ^^^ / vvv !__cpp_lib_concepts vvv
-        constexpr bool _Is_fwd = _Is_fwd_iter_v<_Iter>;
-#endif // ^^^ !__cpp_lib_concepts ^^^
-        if constexpr (_Is_fwd) {
+        if constexpr (_Is_ranges_fwd_iter_v<_Iter>) {
             _Assign_forward_range(_Get_unwrapped(_First), _Get_unwrapped(_Last));
         } else {
             _Assign_input_range(_Get_unwrapped(_First), _Get_unwrapped(_Last));
@@ -3145,7 +3135,7 @@ public:
     _CONSTEXPR20 iterator insert(const_iterator _Where, _Iter _First, _Iter _Last) {
         const difference_type _Saved_offset = _Where - begin();
 
-        if constexpr (_Is_fwd_iter_v<_Iter>) {
+        if constexpr (_Is_ranges_fwd_iter_v<_Iter>) {
             _Adl_verify_range(_First, _Last);
             const auto _Count    = _Convert_size<size_type>(static_cast<size_t>(_STD distance(_First, _Last)));
             const size_type _Off = _Insert_x(_Where, _Count);

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -694,7 +694,7 @@ public:
         _Adl_verify_range(_First, _Last);
         auto _UFirst = _Get_unwrapped(_First);
         auto _ULast  = _Get_unwrapped(_Last);
-        if constexpr (_Is_fwd_iter_v<_Iter>) {
+        if constexpr (_Is_ranges_fwd_iter_v<_Iter>) {
             const auto _Count = _Convert_size<size_type>(static_cast<size_t>(_STD distance(_UFirst, _ULast)));
             _Construct_n(_Count, _STD move(_UFirst), _STD move(_ULast));
 #ifdef __cpp_lib_concepts
@@ -3135,7 +3135,7 @@ public:
     _CONSTEXPR20 iterator insert(const_iterator _Where, _Iter _First, _Iter _Last) {
         const difference_type _Saved_offset = _Where - begin();
 
-        if constexpr (_Is_fwd_iter_v<_Iter>) {
+        if constexpr (_Is_ranges_fwd_iter_v<_Iter>) {
             _Adl_verify_range(_First, _Last);
             const auto _Count    = _Convert_size<size_type>(static_cast<size_t>(_STD distance(_First, _Last)));
             const size_type _Off = _Insert_x(_Where, _Count);

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -2754,7 +2754,7 @@ private:
         _My_data._Mysize = 0;
         _My_data._Myres  = _BUF_SIZE - 1;
 
-        if constexpr (_Is_fwd_iter_v<_Iter>) {
+        if constexpr (_Is_ranges_fwd_iter_v<_Iter>) {
             const auto _Count = _Convert_size<size_type>(static_cast<size_t>(_STD distance(_First, _Last)));
             if (_Count > max_size()) {
                 _Xlen_string(); // result too long
@@ -2776,7 +2776,7 @@ private:
 
         _Tidy_deallocate_guard<basic_string> _Guard{this};
         for (; _First != _Last; ++_First) {
-            if constexpr (!_Is_fwd_iter_v<_Iter>) {
+            if constexpr (!_Is_ranges_fwd_iter_v<_Iter>) {
                 if (_My_data._Mysize == _My_data._Myres) { // Need to grow
                     if (_My_data._Mysize == max_size()) {
                         _Xlen_string(); // result too long

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -863,7 +863,7 @@ _INLINE_VAR constexpr bool _Is_ranges_bidi_iter_v =
 #if defined(__cpp_lib_concepts)
     bidirectional_iterator<_Iter> ||
 #endif
-    _Is_ranges_bidi_iter_v<_Iter>;
+    _Is_bidi_iter_v<_Iter>;
 
 template <class _Iter>
 _INLINE_VAR constexpr bool _Is_random_iter_v = is_convertible_v<_Iter_cat_t<_Iter>, random_access_iterator_tag>;

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -843,30 +843,49 @@ template <class _Ty>
 struct _Is_iterator : bool_constant<_Is_iterator_v<_Ty>> {};
 
 template <class _Iter>
-_INLINE_VAR constexpr bool _Is_input_iter_v = is_convertible_v<_Iter_cat_t<_Iter>, input_iterator_tag>;
+_INLINE_VAR constexpr bool _Is_cpp17_input_iter_v = is_convertible_v<_Iter_cat_t<_Iter>, input_iterator_tag>;
 
 template <class _Iter>
-_INLINE_VAR constexpr bool _Is_fwd_iter_v = is_convertible_v<_Iter_cat_t<_Iter>, forward_iterator_tag>;
+_INLINE_VAR constexpr bool _Is_ranges_input_iter_v =
+#ifdef __cpp_lib_concepts
+    (input_iterator<_Iter> && sentinel_for<_Iter, _Iter>) ||
+#endif
+    _Is_cpp17_input_iter_v<_Iter>;
+
+template <class _Iter>
+_INLINE_VAR constexpr bool _Is_cpp17_fwd_iter_v = is_convertible_v<_Iter_cat_t<_Iter>, forward_iterator_tag>;
 
 template <class _Iter>
 _INLINE_VAR constexpr bool _Is_ranges_fwd_iter_v =
 #ifdef __cpp_lib_concepts
     forward_iterator<_Iter> ||
 #endif
-    _Is_fwd_iter_v<_Iter>;
+    _Is_cpp17_fwd_iter_v<_Iter>;
 
 template <class _Iter>
-_INLINE_VAR constexpr bool _Is_bidi_iter_v = is_convertible_v<_Iter_cat_t<_Iter>, bidirectional_iterator_tag>;
+_INLINE_VAR constexpr bool _Is_cpp17_bidi_iter_v = is_convertible_v<_Iter_cat_t<_Iter>, bidirectional_iterator_tag>;
 
 template <class _Iter>
 _INLINE_VAR constexpr bool _Is_ranges_bidi_iter_v =
 #ifdef __cpp_lib_concepts
     bidirectional_iterator<_Iter> ||
 #endif
-    _Is_bidi_iter_v<_Iter>;
+    _Is_cpp17_bidi_iter_v<_Iter>;
 
 template <class _Iter>
-_INLINE_VAR constexpr bool _Is_random_iter_v = is_convertible_v<_Iter_cat_t<_Iter>, random_access_iterator_tag>;
+_INLINE_VAR constexpr bool _Is_cpp17_random_iter_v = is_convertible_v<_Iter_cat_t<_Iter>, random_access_iterator_tag>;
+
+template <class _Iter>
+_INLINE_VAR constexpr bool _Is_ranges_random_iter_v =
+#if defined(__cpp_lib_concepts)
+    random_access_iterator<_Iter> ||
+#endif
+    _Is_cpp17_random_iter_v<_Iter>;
+
+#define _REQUIRE_CPP17_MUTABLE_ITERATOR(_Iter) \
+    static_assert(_Is_cpp17_fwd_iter_v<_Iter>, \
+        "Non-ranges algorithms require that mutable iterators be Cpp17ForwardIterators or stronger.")
+
 
 template <class, class = void>
 struct _Is_checked_helper {}; // default definition, no longer used, retained due to pseudo-documentation
@@ -1050,10 +1069,7 @@ inline constexpr bool is_execution_policy_v = is_execution_policy<_Ty>::value;
 template <class _ExPo>
 using _Enable_if_execution_policy_t = typename remove_reference_t<_ExPo>::_Standard_execution_policy;
 
-#define _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_Iter) \
-    static_assert(_Is_fwd_iter_v<_Iter>,          \
-        "Parallel algorithms require that mutable iterators be Cpp17ForwardIterators or stronger.")
-#define _REQUIRE_CONST_PARALLEL_ITERATOR(_Iter) \
+#define _REQUIRE_PARALLEL_ITERATOR(_Iter) \
     static_assert(_Is_ranges_fwd_iter_v<_Iter>, "Parallel algorithms require forward iterators or stronger.")
 
 #endif // _HAS_CXX17
@@ -1061,7 +1077,7 @@ using _Enable_if_execution_policy_t = typename remove_reference_t<_ExPo>::_Stand
 template <class _Checked, class _Iter>
 _NODISCARD constexpr auto _Idl_distance(const _Iter& _First, const _Iter& _Last) {
     // tries to get the distance between _First and _Last if they are random-access iterators
-    if constexpr (_Is_random_iter_v<_Iter>) {
+    if constexpr (_Is_ranges_random_iter_v<_Iter>) {
         return static_cast<_Iter_diff_t<_Checked>>(_Last - _First);
     } else {
         return _Distance_unknown{};
@@ -1136,17 +1152,17 @@ constexpr void _Debug_order_set_unchecked(_InIt _First, _InIt _Last, _Pr&& _Pred
 // from <iterator>
 template <class _InIt, class _Diff>
 _CONSTEXPR17 void advance(_InIt& _Where, _Diff _Off) { // increment iterator by offset
-    if constexpr (_Is_random_iter_v<_InIt>) {
+    if constexpr (_Is_ranges_random_iter_v<_InIt>) {
         _Where += _Off;
     } else {
-        if constexpr (is_signed_v<_Diff> && !_Is_bidi_iter_v<_InIt>) {
+        if constexpr (is_signed_v<_Diff> && !_Is_ranges_bidi_iter_v<_InIt>) {
             _STL_ASSERT(_Off >= 0, "negative advance of non-bidirectional iterator");
         }
 
         decltype(auto) _UWhere      = _Get_unwrapped_n(_STD move(_Where), _Off);
         constexpr bool _Need_rewrap = !is_reference_v<decltype(_Get_unwrapped_n(_STD move(_Where), _Off))>;
 
-        if constexpr (is_signed_v<_Diff> && _Is_bidi_iter_v<_InIt>) {
+        if constexpr (is_signed_v<_Diff> && _Is_ranges_bidi_iter_v<_InIt>) {
             for (; _Off < 0; ++_Off) {
                 --_UWhere;
             }
@@ -1164,7 +1180,7 @@ _CONSTEXPR17 void advance(_InIt& _Where, _Diff _Off) { // increment iterator by 
 
 template <class _InIt>
 _NODISCARD _CONSTEXPR17 _Iter_diff_t<_InIt> distance(_InIt _First, _InIt _Last) {
-    if constexpr (_Is_random_iter_v<_InIt>) {
+    if constexpr (_Is_ranges_random_iter_v<_InIt>) {
         return _Last - _First; // assume the iterator will do debug checking
     } else {
         _Adl_verify_range(_First, _Last);
@@ -1186,7 +1202,7 @@ constexpr _InIt _Next_iter(_InIt _First) { // increment iterator
 
 template <class _InIt>
 _NODISCARD _CONSTEXPR17 _InIt next(_InIt _First, _Iter_diff_t<_InIt> _Off = 1) { // increment iterator
-    static_assert(_Is_input_iter_v<_InIt>, "next requires input iterator");
+    static_assert(_Is_ranges_input_iter_v<_InIt>, "next requires input iterator");
 
     _STD advance(_First, _Off);
     return _First;
@@ -3704,8 +3720,8 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, _Enable_if_execution_policy
 _FwdIt2 copy(_ExPo&&, _FwdIt1 _First, _FwdIt1 _Last, _FwdIt2 _Dest) noexcept /* terminates */ {
     // copy [_First, _Last) to [_Dest, ...)
     // not parallelized as benchmarks show it isn't worth it
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt2);
     return _STD copy(_First, _Last, _Dest);
 }
 #endif // _HAS_CXX17
@@ -3844,8 +3860,8 @@ template <class _ExPo, class _FwdIt1, class _Diff, class _FwdIt2, _Enable_if_exe
 _FwdIt2 copy_n(_ExPo&&, _FwdIt1 _First, _Diff _Count_raw, _FwdIt2 _Dest) noexcept /* terminates */ {
     // copy [_First, _First + _Count) to [_Dest, ...)
     // not parallelized as benchmarks show it isn't worth it
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt2);
     return _STD copy_n(_First, _Count_raw, _Dest);
 }
 #endif // _HAS_CXX17
@@ -3939,8 +3955,8 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, _Enable_if_execution_policy
 _FwdIt2 move(_ExPo&&, _FwdIt1 _First, _FwdIt1 _Last, _FwdIt2 _Dest) noexcept /* terminates */ {
     // move [_First, _Last) to [_Dest, ...)
     // not parallelized as benchmarks show it isn't worth it
-    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt1);
+    _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt2);
     return _STD move(_First, _Last, _Dest);
 }
 #endif // _HAS_CXX17
@@ -4085,7 +4101,7 @@ template <class _ExPo, class _FwdIt, class _Ty, _Enable_if_execution_policy_t<_E
 void fill(_ExPo&&, _FwdIt _First, _FwdIt _Last, const _Ty& _Val) noexcept /* terminates */ {
     // copy _Val through [_First, _Last)
     // not parallelized as benchmarks show it isn't worth it
-    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt);
+    _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt);
     return _STD fill(_First, _Last, _Val);
 }
 #endif // _HAS_CXX17
@@ -4133,7 +4149,7 @@ template <class _ExPo, class _FwdIt, class _Diff, class _Ty, _Enable_if_executio
 _FwdIt fill_n(_ExPo&&, _FwdIt _Dest, _Diff _Count_raw, const _Ty& _Val) noexcept /* terminates */ {
     // copy _Val _Count times through [_Dest, ...)
     // not parallelized as benchmarks show it isn't worth it
-    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt);
+    _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt);
     return _STD fill_n(_Dest, _Count_raw, _Val);
 }
 #endif // _HAS_CXX17
@@ -4332,7 +4348,7 @@ _NODISCARD _CONSTEXPR20 bool equal(
     const auto _ULast1 = _Get_unwrapped(_Last1);
     auto _UFirst2      = _Get_unwrapped(_First2);
     const auto _ULast2 = _Get_unwrapped(_Last2);
-    if constexpr (_Is_random_iter_v<_InIt1> && _Is_random_iter_v<_InIt2>) {
+    if constexpr (_Is_ranges_random_iter_v<_InIt1> && _Is_ranges_random_iter_v<_InIt2>) {
         if (_ULast1 - _UFirst1 != _ULast2 - _UFirst2) {
             return false;
         }
@@ -4626,8 +4642,8 @@ _NODISCARD bool lexicographical_compare(_ExPo&&, const _FwdIt1 _First1, const _F
     const _FwdIt2 _Last2, _Pr _Pred) noexcept /* terminates */ {
     // order [_First1, _Last1) vs. [_First2, _Last2)
     // not parallelized at present, parallelism expected to be feasible in a future release
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
     return _STD lexicographical_compare(_First1, _Last1, _First2, _Last2, _Pass_fn(_Pred));
 }
 
@@ -4636,8 +4652,8 @@ _NODISCARD bool lexicographical_compare(_ExPo&&, const _FwdIt1 _First1, const _F
     const _FwdIt2 _Last2) noexcept /* terminates */ {
     // order [_First1, _Last1) vs. [_First2, _Last2)
     // not parallelized at present, parallelism expected to be feasible in a future release
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
     return _STD lexicographical_compare(_First1, _Last1, _First2, _Last2);
 }
 #endif // _HAS_CXX17
@@ -5136,7 +5152,7 @@ _NODISCARD _CONSTEXPR20 bool _Check_match_counts(
     // test if [_First1, _Last1) == permuted [_First2, _Last2), after matching prefix removal
     _STL_INTERNAL_CHECK(!_Pred(*_First1, *_First2));
     _STL_INTERNAL_CHECK(_STD distance(_First1, _Last1) == _STD distance(_First2, _Last2));
-    if constexpr (_Is_bidi_iter_v<_FwdIt1> && _Is_bidi_iter_v<_FwdIt2>) {
+    if constexpr (_Is_ranges_bidi_iter_v<_FwdIt1> && _Is_ranges_bidi_iter_v<_FwdIt2>) {
         do { // find last inequality
             --_Last1;
             --_Last2;
@@ -5236,6 +5252,7 @@ _CONSTEXPR20 _FwdIt rotate(_FwdIt _First, _FwdIt _Mid, _FwdIt _Last) {
     // exchange the ranges [_First, _Mid) and [_Mid, _Last)
     // that is, rotates [_First, _Last) left by distance(_First, _Mid) positions
     // returns the iterator pointing at *_First's new home
+    _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt);
     _Adl_verify_range(_First, _Mid);
     _Adl_verify_range(_Mid, _Last);
     auto _UFirst      = _Get_unwrapped(_First);
@@ -5249,12 +5266,12 @@ _CONSTEXPR20 _FwdIt rotate(_FwdIt _First, _FwdIt _Mid, _FwdIt _Last) {
         return _First;
     }
 
-    if constexpr (_Is_random_iter_v<_FwdIt>) {
+    if constexpr (_Is_cpp17_random_iter_v<_FwdIt>) {
         _STD reverse(_UFirst, _UMid);
         _STD reverse(_UMid, _ULast);
         _STD reverse(_UFirst, _ULast);
         _Seek_wrapped(_First, _UFirst + (_ULast - _UMid));
-    } else if constexpr (_Is_bidi_iter_v<_FwdIt>) {
+    } else if constexpr (_Is_cpp17_bidi_iter_v<_FwdIt>) {
         _STD reverse(_UFirst, _UMid);
         _STD reverse(_UMid, _ULast);
         auto _Tmp = _Reverse_until_sentinel_unchecked(_UFirst, _UMid, _ULast);

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -850,7 +850,7 @@ _INLINE_VAR constexpr bool _Is_fwd_iter_v = is_convertible_v<_Iter_cat_t<_Iter>,
 
 template <class _Iter>
 _INLINE_VAR constexpr bool _Is_ranges_fwd_iter_v =
-#if defined(__cpp_lib_concepts)
+#ifdef __cpp_lib_concepts
     forward_iterator<_Iter> ||
 #endif
     _Is_fwd_iter_v<_Iter>;
@@ -860,7 +860,7 @@ _INLINE_VAR constexpr bool _Is_bidi_iter_v = is_convertible_v<_Iter_cat_t<_Iter>
 
 template <class _Iter>
 _INLINE_VAR constexpr bool _Is_ranges_bidi_iter_v =
-#if defined(__cpp_lib_concepts)
+#ifdef __cpp_lib_concepts
     bidirectional_iterator<_Iter> ||
 #endif
     _Is_bidi_iter_v<_Iter>;

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -860,6 +860,14 @@ template <class _Iter>
 _INLINE_VAR constexpr bool _Is_bidi_iter_v = is_convertible_v<_Iter_cat_t<_Iter>, bidirectional_iterator_tag>;
 
 template <class _Iter>
+_INLINE_VAR constexpr bool _Is_ranges_bidi_iter_v =
+#if defined(__cpp_lib_concepts)
+    bidirectional_iterator<_Iter>;
+#else
+    is_convertible_v<_Iter_cat_t<_Iter>, bidirectional_iterator_tag>;
+#endif
+
+template <class _Iter>
 _INLINE_VAR constexpr bool _Is_random_iter_v = is_convertible_v<_Iter_cat_t<_Iter>, random_access_iterator_tag>;
 
 template <class, class = void>
@@ -1109,7 +1117,7 @@ constexpr bool _Debug_lt_pred(_Pr&& _Pred, _Ty1&& _Left, _Ty2&& _Right) noexcept
 template <class _InIt, class _Sentinel, class _Pr>
 constexpr void _Debug_order_unchecked(_InIt _First, _Sentinel _Last, _Pr&& _Pred) {
     // test if range is ordered by predicate
-    if constexpr (_Is_fwd_iter_v<_InIt>) {
+    if constexpr (_Is_ranges_fwd_iter_v<_InIt>) {
         if (_First != _Last) {
             for (auto _Next = _First; ++_Next != _Last; _First = _Next) {
                 _STL_VERIFY(!static_cast<bool>(_Pred(*_Next, *_First)), "sequence not ordered");
@@ -1121,7 +1129,7 @@ constexpr void _Debug_order_unchecked(_InIt _First, _Sentinel _Last, _Pr&& _Pred
 template <class _OtherIt, class _InIt, class _Pr>
 constexpr void _Debug_order_set_unchecked(_InIt _First, _InIt _Last, _Pr&& _Pred) {
     // test if range is ordered by predicate
-    if constexpr (is_same_v<_Iter_value_t<_OtherIt>, _Iter_value_t<_InIt>> && _Is_fwd_iter_v<_InIt>) {
+    if constexpr (is_same_v<_Iter_value_t<_OtherIt>, _Iter_value_t<_InIt>>) {
         _Debug_order_unchecked(_First, _Last, _Pred);
     }
 }
@@ -1193,7 +1201,7 @@ constexpr _BidIt _Prev_iter(_BidIt _First) { // decrement iterator
 
 template <class _BidIt>
 _NODISCARD _CONSTEXPR17 _BidIt prev(_BidIt _First, _Iter_diff_t<_BidIt> _Off = 1) { // decrement iterator
-    static_assert(_Is_bidi_iter_v<_BidIt>, "prev requires bidirectional iterator");
+    static_assert(_Is_ranges_bidi_iter_v<_BidIt>, "prev requires bidirectional iterator");
 
     _STD advance(_First, -_Off);
     return _First;

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -853,7 +853,7 @@ _INLINE_VAR constexpr bool _Is_ranges_fwd_iter_v =
 #if defined(__cpp_lib_concepts)
     forward_iterator<_Iter> ||
 #endif
-    is_convertible_v<_Iter_cat_t<_Iter>, forward_iterator_tag>;
+    _Is_fwd_iter_v<_Iter>;
 
 template <class _Iter>
 _INLINE_VAR constexpr bool _Is_bidi_iter_v = is_convertible_v<_Iter_cat_t<_Iter>, bidirectional_iterator_tag>;
@@ -863,7 +863,7 @@ _INLINE_VAR constexpr bool _Is_ranges_bidi_iter_v =
 #if defined(__cpp_lib_concepts)
     bidirectional_iterator<_Iter> ||
 #endif
-    is_convertible_v<_Iter_cat_t<_Iter>, bidirectional_iterator_tag>;
+    _Is_ranges_bidi_iter_v<_Iter>;
 
 template <class _Iter>
 _INLINE_VAR constexpr bool _Is_random_iter_v = is_convertible_v<_Iter_cat_t<_Iter>, random_access_iterator_tag>;

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -886,7 +886,6 @@ _INLINE_VAR constexpr bool _Is_ranges_random_iter_v =
     static_assert(_Is_cpp17_fwd_iter_v<_Iter>, \
         "Non-ranges algorithms require that mutable iterators be Cpp17ForwardIterators or stronger.")
 
-
 template <class, class = void>
 struct _Is_checked_helper {}; // default definition, no longer used, retained due to pseudo-documentation
 
@@ -5252,7 +5251,6 @@ _CONSTEXPR20 _FwdIt rotate(_FwdIt _First, _FwdIt _Mid, _FwdIt _Last) {
     // exchange the ranges [_First, _Mid) and [_Mid, _Last)
     // that is, rotates [_First, _Last) left by distance(_First, _Mid) positions
     // returns the iterator pointing at *_First's new home
-    _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt);
     _Adl_verify_range(_First, _Mid);
     _Adl_verify_range(_Mid, _Last);
     auto _UFirst      = _Get_unwrapped(_First);

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -851,10 +851,9 @@ _INLINE_VAR constexpr bool _Is_fwd_iter_v = is_convertible_v<_Iter_cat_t<_Iter>,
 template <class _Iter>
 _INLINE_VAR constexpr bool _Is_ranges_fwd_iter_v =
 #if defined(__cpp_lib_concepts)
-    forward_iterator<_Iter>;
-#else
-    is_convertible_v<_Iter_cat_t<_Iter>, forward_iterator_tag>;
+    forward_iterator<_Iter> ||
 #endif
+    is_convertible_v<_Iter_cat_t<_Iter>, forward_iterator_tag>;
 
 template <class _Iter>
 _INLINE_VAR constexpr bool _Is_bidi_iter_v = is_convertible_v<_Iter_cat_t<_Iter>, bidirectional_iterator_tag>;
@@ -862,10 +861,9 @@ _INLINE_VAR constexpr bool _Is_bidi_iter_v = is_convertible_v<_Iter_cat_t<_Iter>
 template <class _Iter>
 _INLINE_VAR constexpr bool _Is_ranges_bidi_iter_v =
 #if defined(__cpp_lib_concepts)
-    bidirectional_iterator<_Iter>;
-#else
-    is_convertible_v<_Iter_cat_t<_Iter>, bidirectional_iterator_tag>;
+    bidirectional_iterator<_Iter> ||
 #endif
+    is_convertible_v<_Iter_cat_t<_Iter>, bidirectional_iterator_tag>;
 
 template <class _Iter>
 _INLINE_VAR constexpr bool _Is_random_iter_v = is_convertible_v<_Iter_cat_t<_Iter>, random_access_iterator_tag>;

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -849,6 +849,14 @@ template <class _Iter>
 _INLINE_VAR constexpr bool _Is_fwd_iter_v = is_convertible_v<_Iter_cat_t<_Iter>, forward_iterator_tag>;
 
 template <class _Iter>
+_INLINE_VAR constexpr bool _Is_ranges_fwd_iter_v =
+#if defined(__cpp_lib_concepts)
+    forward_iterator<_Iter>;
+#else
+    is_convertible_v<_Iter_cat_t<_Iter>, forward_iterator_tag>;
+#endif
+
+template <class _Iter>
 _INLINE_VAR constexpr bool _Is_bidi_iter_v = is_convertible_v<_Iter_cat_t<_Iter>, bidirectional_iterator_tag>;
 
 template <class _Iter>
@@ -1036,8 +1044,11 @@ inline constexpr bool is_execution_policy_v = is_execution_policy<_Ty>::value;
 template <class _ExPo>
 using _Enable_if_execution_policy_t = typename remove_reference_t<_ExPo>::_Standard_execution_policy;
 
-#define _REQUIRE_PARALLEL_ITERATOR(_Iter) \
-    static_assert(_Is_fwd_iter_v<_Iter>, "Parallel algorithms require forward iterators or stronger.")
+#define _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_Iter) \
+    static_assert(_Is_fwd_iter_v<_Iter>,          \
+        "Parallel algorithms require that mutable iterators be Cpp17ForwardIterators or stronger.")
+#define _REQUIRE_CONST_PARALLEL_ITERATOR(_Iter) \
+    static_assert(_Is_ranges_fwd_iter_v<_Iter>, "Parallel algorithms require forward iterators or stronger.")
 
 #endif // _HAS_CXX17
 
@@ -3687,8 +3698,8 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, _Enable_if_execution_policy
 _FwdIt2 copy(_ExPo&&, _FwdIt1 _First, _FwdIt1 _Last, _FwdIt2 _Dest) noexcept /* terminates */ {
     // copy [_First, _Last) to [_Dest, ...)
     // not parallelized as benchmarks show it isn't worth it
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt2);
     return _STD copy(_First, _Last, _Dest);
 }
 #endif // _HAS_CXX17
@@ -3827,8 +3838,8 @@ template <class _ExPo, class _FwdIt1, class _Diff, class _FwdIt2, _Enable_if_exe
 _FwdIt2 copy_n(_ExPo&&, _FwdIt1 _First, _Diff _Count_raw, _FwdIt2 _Dest) noexcept /* terminates */ {
     // copy [_First, _First + _Count) to [_Dest, ...)
     // not parallelized as benchmarks show it isn't worth it
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt2);
     return _STD copy_n(_First, _Count_raw, _Dest);
 }
 #endif // _HAS_CXX17
@@ -3922,8 +3933,8 @@ template <class _ExPo, class _FwdIt1, class _FwdIt2, _Enable_if_execution_policy
 _FwdIt2 move(_ExPo&&, _FwdIt1 _First, _FwdIt1 _Last, _FwdIt2 _Dest) noexcept /* terminates */ {
     // move [_First, _Last) to [_Dest, ...)
     // not parallelized as benchmarks show it isn't worth it
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt2);
     return _STD move(_First, _Last, _Dest);
 }
 #endif // _HAS_CXX17
@@ -4068,7 +4079,7 @@ template <class _ExPo, class _FwdIt, class _Ty, _Enable_if_execution_policy_t<_E
 void fill(_ExPo&&, _FwdIt _First, _FwdIt _Last, const _Ty& _Val) noexcept /* terminates */ {
     // copy _Val through [_First, _Last)
     // not parallelized as benchmarks show it isn't worth it
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt);
+    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt);
     return _STD fill(_First, _Last, _Val);
 }
 #endif // _HAS_CXX17
@@ -4116,7 +4127,7 @@ template <class _ExPo, class _FwdIt, class _Diff, class _Ty, _Enable_if_executio
 _FwdIt fill_n(_ExPo&&, _FwdIt _Dest, _Diff _Count_raw, const _Ty& _Val) noexcept /* terminates */ {
     // copy _Val _Count times through [_Dest, ...)
     // not parallelized as benchmarks show it isn't worth it
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt);
+    _REQUIRE_MUTABLE_PARALLEL_ITERATOR(_FwdIt);
     return _STD fill_n(_Dest, _Count_raw, _Val);
 }
 #endif // _HAS_CXX17
@@ -4609,8 +4620,8 @@ _NODISCARD bool lexicographical_compare(_ExPo&&, const _FwdIt1 _First1, const _F
     const _FwdIt2 _Last2, _Pr _Pred) noexcept /* terminates */ {
     // order [_First1, _Last1) vs. [_First2, _Last2)
     // not parallelized at present, parallelism expected to be feasible in a future release
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt2);
     return _STD lexicographical_compare(_First1, _Last1, _First2, _Last2, _Pass_fn(_Pred));
 }
 
@@ -4619,8 +4630,8 @@ _NODISCARD bool lexicographical_compare(_ExPo&&, const _FwdIt1 _First1, const _F
     const _FwdIt2 _Last2) noexcept /* terminates */ {
     // order [_First1, _Last1) vs. [_First2, _Last2)
     // not parallelized at present, parallelism expected to be feasible in a future release
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt1);
-    _REQUIRE_PARALLEL_ITERATOR(_FwdIt2);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt1);
+    _REQUIRE_CONST_PARALLEL_ITERATOR(_FwdIt2);
     return _STD lexicographical_compare(_First1, _Last1, _First2, _Last2);
 }
 #endif // _HAS_CXX17

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -270,6 +270,7 @@
 // P2367R0 Remove Misuses Of List-Initialization From Clause 24 Ranges
 // P2372R3 Fixing Locale Handling In chrono Formatters
 // P2393R1 Cleaning Up Integer-Class Types
+// P2408R5 Ranges Iterators As Inputs To Non-Ranges Algorithms
 // P2415R2 What Is A view?
 // P2418R2 Add Support For std::generator-like Types To std::format
 // P2432R1 Fix istream_view

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -1349,6 +1349,14 @@
 #endif // __cpp_impl_coroutine
 
 #if _HAS_CXX20
+#if !defined(__EDG__) || defined(__INTELLISENSE__) // TRANSITION, EDG concepts support
+#define __cpp_lib_concepts 202002L
+#endif // !defined(__EDG__) || defined(__INTELLISENSE__)
+
+#if defined(__cpp_lib_concepts)
+#define __cpp_lib_algorithm_iterator_requirements 202207L
+#endif
+
 #define __cpp_lib_assume_aligned                201811L
 #define __cpp_lib_atomic_flag_test              201907L
 #define __cpp_lib_atomic_float                  201711L
@@ -1361,10 +1369,6 @@
 #define __cpp_lib_bit_cast                      201806L
 #define __cpp_lib_bitops                        201907L
 #define __cpp_lib_bounded_array_traits          201902L
-
-#if !defined(__EDG__) || defined(__INTELLISENSE__) // TRANSITION, EDG concepts support
-#define __cpp_lib_concepts 202002L
-#endif // !defined(__EDG__) || defined(__INTELLISENSE__)
 
 #define __cpp_lib_constexpr_algorithms    201806L
 #define __cpp_lib_constexpr_complex       201711L

--- a/tests/std/test.lst
+++ b/tests/std/test.lst
@@ -488,6 +488,7 @@ tests\P2231R1_complete_constexpr_optional_variant
 tests\P2273R3_constexpr_unique_ptr
 tests\P2321R2_proxy_reference
 tests\P2401R0_conditional_noexcept_for_exchange
+tests\P2408R5_ranges_iterators_to_classic_algorithms
 tests\P2415R2_owning_view
 tests\P2440R1_ranges_alg_shift_left
 tests\P2440R1_ranges_alg_shift_right

--- a/tests/std/tests/P2408R5_ranges_iterators_to_classic_algorithms/env.lst
+++ b/tests/std/tests/P2408R5_ranges_iterators_to_classic_algorithms/env.lst
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+RUNALL_INCLUDE ..\strict_concepts_20_matrix.lst

--- a/tests/std/tests/P2408R5_ranges_iterators_to_classic_algorithms/test.cpp
+++ b/tests/std/tests/P2408R5_ranges_iterators_to_classic_algorithms/test.cpp
@@ -18,7 +18,7 @@ struct iterator_adaptor {
     iterator_adaptor(initializer_list<int> il) : v(il) {}
 
     using iterator       = I;
-    using const_iterator = I::Consterator;
+    using const_iterator = typename I::Consterator;
 
     iterator begin() {
         return iterator{v.data()};

--- a/tests/std/tests/P2408R5_ranges_iterators_to_classic_algorithms/test.cpp
+++ b/tests/std/tests/P2408R5_ranges_iterators_to_classic_algorithms/test.cpp
@@ -93,7 +93,7 @@ struct unary_algorithms {
 template <class I1, class I2>
 struct binary_algorithms {
     static void call() {
-        if constexpr (forward_iterator<I1> || _Is_fwd_iter_v<I2>) {
+        if constexpr (forward_iterator<I1> || _Is_cpp17_fwd_iter_v<I2>) {
             helper<I1, I2> h({0, 0, 1, 2, 3, 3, 4, 5});
             array exp{0, 1, 2, 3, 4, 5};
             auto it = unique_copy(hcbegin<0>(h), hcend<0>(h), hbegin<1>(h));
@@ -115,7 +115,7 @@ struct binary_algorithms {
                 assert(*pr.first == 2);
                 assert(*pr.second == 3);
             }
-            if constexpr (_Is_fwd_iter_v<I2>) {
+            if constexpr (_Is_cpp17_fwd_iter_v<I2>) {
                 helper<I1, I2> h{{0, 1, 2, 3, 4, 5}};
                 array expected{0, 1, 2, 4, 5};
                 auto it = copy_if(seq, hcbegin<0>(h), hcend<0>(h), hbegin<1>(h), [](int x) { return x != 3; });
@@ -131,7 +131,7 @@ struct ternary_algorithms {
         if constexpr (forward_iterator<I1> && forward_iterator<I2> && forward_iterator<I3>) {
             // parallel algorithms
             using execution::seq;
-            if constexpr (_Is_fwd_iter_v<I2> && _Is_fwd_iter_v<I3>) {
+            if constexpr (_Is_cpp17_fwd_iter_v<I2> && _Is_cpp17_fwd_iter_v<I3>) {
                 helper<I1, I2, I3> h{{0, 1, 2, 3, 4, 5}};
                 array exp1{0, 1};
                 array exp2{2, 3, 4, 5};
@@ -156,13 +156,13 @@ using cpp17_random_iter = test::iterator<random_access_iterator_tag, int, test::
     test::CanCompare::yes, test::ProxyRef::no>;
 
 // Sanity checks
-static_assert(!_Is_fwd_iter_v<input_iter> && !forward_iterator<input_iter>);
-static_assert(!_Is_fwd_iter_v<fwd_iter> && forward_iterator<fwd_iter>);
-static_assert(!_Is_fwd_iter_v<bidi_iter> && bidirectional_iterator<bidi_iter>);
-static_assert(!_Is_fwd_iter_v<random_iter> && random_access_iterator<random_iter>);
-static_assert(_Is_fwd_iter_v<cpp17_fwd_iter> && forward_iterator<cpp17_fwd_iter>);
-static_assert(_Is_bidi_iter_v<cpp17_bidi_iter> && bidirectional_iterator<cpp17_bidi_iter>);
-static_assert(_Is_random_iter_v<cpp17_random_iter> && random_access_iterator<cpp17_random_iter>);
+static_assert(!_Is_cpp17_fwd_iter_v<input_iter> && !forward_iterator<input_iter>);
+static_assert(!_Is_cpp17_fwd_iter_v<fwd_iter> && forward_iterator<fwd_iter>);
+static_assert(!_Is_cpp17_fwd_iter_v<bidi_iter> && bidirectional_iterator<bidi_iter>);
+static_assert(!_Is_cpp17_fwd_iter_v<random_iter> && random_access_iterator<random_iter>);
+static_assert(_Is_cpp17_fwd_iter_v<cpp17_fwd_iter> && forward_iterator<cpp17_fwd_iter>);
+static_assert(_Is_cpp17_bidi_iter_v<cpp17_bidi_iter> && bidirectional_iterator<cpp17_bidi_iter>);
+static_assert(_Is_cpp17_random_iter_v<cpp17_random_iter> && random_access_iterator<cpp17_random_iter>);
 
 template <template <class...> class C>
 struct instantiator {

--- a/tests/std/tests/P2408R5_ranges_iterators_to_classic_algorithms/test.cpp
+++ b/tests/std/tests/P2408R5_ranges_iterators_to_classic_algorithms/test.cpp
@@ -1,0 +1,116 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <algorithm>
+#include <execution>
+#include <ranges>
+
+#include <range_algorithm_support.hpp>
+
+using namespace std;
+
+template <class T, class U>
+using second = U;
+
+template <forward_iterator I>
+struct iterator_adaptor {
+    std::vector<int> v;
+    iterator_adaptor(initializer_list<int> il) : v(il) {}
+
+    using iterator       = I;
+    using const_iterator = I::Consterator;
+
+    iterator begin() {
+        return iterator{v.data()};
+    }
+    iterator end() {
+        return iterator{v.data() + v.size()};
+    }
+
+    const_iterator cbegin() const {
+        return const_iterator{v.data()};
+    }
+    const_iterator cend() const {
+        return const_iterator{v.data() + v.size()};
+    }
+};
+
+template <forward_iterator... Is>
+struct helper {
+    helper(second<Is, initializer_list<int>>... ils) : tup(ils...) {}
+
+    std::tuple<iterator_adaptor<Is>...> tup;
+};
+
+template <size_t Idx, forward_iterator... Is>
+auto hbegin(helper<Is...>& h) {
+    return get<Idx>(h.tup).begin();
+}
+template <size_t Idx, forward_iterator... Is>
+auto hend(helper<Is...>& h) {
+    return get<Idx>(h.tup).end();
+}
+
+template <size_t Idx, forward_iterator... Is>
+auto hcbegin(const helper<Is...>& h) {
+    return get<Idx>(h.tup).cbegin();
+}
+template <size_t Idx, forward_iterator... Is>
+auto hcend(const helper<Is...>& h) {
+    return get<Idx>(h.tup).cend();
+}
+
+template <forward_iterator I1, forward_iterator I2>
+void test_algorithms() {
+    using execution::seq;
+    {
+        helper<I1, I2> h{{0, 1, 2, 3, 4, 5}, {0, 1, 3, 4, 5}};
+        auto pr = mismatch(seq, hcbegin<0>(h), hcend<0>(h), hcbegin<1>(h));
+        assert(distance(hcbegin<0>(h), pr.first) == 2);
+        assert(*pr.first == 2);
+        assert(*pr.second == 3);
+    }
+    if constexpr (_Is_fwd_iter_v<I2>) {
+        helper<I1, I2> h{{0, 1, 2, 3, 4, 5}, {0, 0, 0, 0, 0, 0}};
+        initializer_list expected{0, 1, 2, 4, 5};
+        auto it = copy_if(seq, hcbegin<0>(h), hcend<0>(h), hbegin<1>(h), [](int x) { return x != 3; });
+        assert(std::equal(hbegin<1>(h), it, expected.begin(), expected.end()));
+    }
+}
+
+using fwd_iter    = test::iterator<forward_iterator_tag, int>;
+using bidi_iter   = test::iterator<bidirectional_iterator_tag, int>;
+using random_iter = test::iterator<random_access_iterator_tag, int>;
+using cpp17_fwd_iter =
+    test::iterator<forward_iterator_tag, int, test::CanDifference::no, test::CanCompare::yes, test::ProxyRef::no>;
+using cpp17_bidi_iter =
+    test::iterator<bidirectional_iterator_tag, int, test::CanDifference::no, test::CanCompare::yes, test::ProxyRef::no>;
+using cpp17_random_iter = test::iterator<random_access_iterator_tag, int, test::CanDifference::yes,
+    test::CanCompare::yes, test::ProxyRef::no>;
+static_assert(!_Is_fwd_iter_v<fwd_iter> && forward_iterator<fwd_iter>);
+static_assert(!_Is_fwd_iter_v<bidi_iter> && bidirectional_iterator<bidi_iter>);
+static_assert(!_Is_fwd_iter_v<random_iter> && random_access_iterator<random_iter>);
+static_assert(_Is_fwd_iter_v<cpp17_fwd_iter> && forward_iterator<cpp17_fwd_iter>);
+static_assert(_Is_bidi_iter_v<cpp17_bidi_iter> && bidirectional_iterator<cpp17_bidi_iter>);
+static_assert(_Is_random_iter_v<cpp17_random_iter> && random_access_iterator<cpp17_random_iter>);
+
+
+template <class I2>
+void inst() {
+    test_algorithms<fwd_iter, I2>();
+    test_algorithms<bidi_iter, I2>();
+    test_algorithms<random_iter, I2>();
+    test_algorithms<cpp17_fwd_iter, I2>();
+    test_algorithms<cpp17_bidi_iter, I2>();
+    test_algorithms<cpp17_random_iter, I2>();
+};
+
+
+int main() {
+    inst<fwd_iter>();
+    inst<bidi_iter>();
+    inst<random_iter>();
+    inst<cpp17_fwd_iter>();
+    inst<cpp17_bidi_iter>();
+    inst<cpp17_random_iter>();
+}

--- a/tests/std/tests/P2408R5_ranges_iterators_to_classic_algorithms/test.cpp
+++ b/tests/std/tests/P2408R5_ranges_iterators_to_classic_algorithms/test.cpp
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include <algorithm>
+#include <array>
 #include <execution>
+#include <initializer_list>
 #include <ranges>
 
 #include <range_algorithm_support.hpp>
@@ -89,7 +91,7 @@ struct binary_algorithms {
     static void call() {
         if constexpr (forward_iterator<I1> || _Is_fwd_iter_v<I2>) {
             helper<I1, I2> h({0, 0, 1, 2, 3, 3, 4, 5});
-            initializer_list exp{0, 1, 2, 3, 4, 5};
+            array exp{0, 1, 2, 3, 4, 5};
             auto it = unique_copy(hcbegin<0>(h), hcend<0>(h), hbegin<1>(h));
             assert(equal(hbegin<1>(h), it, exp.begin(), exp.end()));
         }
@@ -111,7 +113,7 @@ struct binary_algorithms {
             }
             if constexpr (_Is_fwd_iter_v<I2>) {
                 helper<I1, I2> h{{0, 1, 2, 3, 4, 5}};
-                initializer_list expected{0, 1, 2, 4, 5};
+                array expected{0, 1, 2, 4, 5};
                 auto it = copy_if(seq, hcbegin<0>(h), hcend<0>(h), hbegin<1>(h), [](int x) { return x != 3; });
                 assert(equal(hbegin<1>(h), it, expected.begin(), expected.end()));
             }
@@ -127,8 +129,8 @@ struct ternary_algorithms {
             using execution::seq;
             if constexpr (_Is_fwd_iter_v<I2> && _Is_fwd_iter_v<I3>) {
                 helper<I1, I2, I3> h{{0, 1, 2, 3, 4, 5}};
-                initializer_list exp1{0, 1};
-                initializer_list exp2{2, 3, 4, 5};
+                array exp1{0, 1};
+                array exp2{2, 3, 4, 5};
                 auto pr = partition_copy(
                     seq, hcbegin<0>(h), hcend<0>(h), hbegin<1>(h), hbegin<2>(h), [](int x) { return x < 2; });
                 assert(equal(hbegin<1>(h), pr.first, exp1.begin(), exp1.end()));
@@ -174,7 +176,7 @@ struct instantiator {
             C<cpp17_random_iter, Its...>::call();
         }
     };
-    using curry = curry_t<>::curry;
+    using curry = typename curry_t<>::curry;
 
     static void call() {
         curry_t<>::call();

--- a/tests/std/tests/P2408R5_ranges_iterators_to_classic_algorithms/test.cpp
+++ b/tests/std/tests/P2408R5_ranges_iterators_to_classic_algorithms/test.cpp
@@ -11,11 +11,16 @@ using namespace std;
 
 template <class T, class U>
 using second = U;
+template <class, class Input>
+Input second_v(Input x) {
+    return x;
+}
 
-template <forward_iterator I>
+template <class I>
 struct iterator_adaptor {
     std::vector<int> v;
     iterator_adaptor(initializer_list<int> il) : v(il) {}
+    iterator_adaptor(size_t n) : v(n) {}
 
     using iterator       = I;
     using const_iterator = typename I::Consterator;
@@ -35,49 +40,105 @@ struct iterator_adaptor {
     }
 };
 
-template <forward_iterator... Is>
+template <class... Is>
 struct helper {
     helper(second<Is, initializer_list<int>>... ils) : tup(ils...) {}
+
+    helper(initializer_list<int> il) requires(sizeof...(Is) > 1) : tup(second_v<Is>(il.size())...) {
+        get<0>(tup).v.assign(il);
+    }
 
     std::tuple<iterator_adaptor<Is>...> tup;
 };
 
-template <size_t Idx, forward_iterator... Is>
+template <size_t Idx, class... Is>
 auto hbegin(helper<Is...>& h) {
     return get<Idx>(h.tup).begin();
 }
-template <size_t Idx, forward_iterator... Is>
+template <size_t Idx, class... Is>
 auto hend(helper<Is...>& h) {
     return get<Idx>(h.tup).end();
 }
 
-template <size_t Idx, forward_iterator... Is>
+template <size_t Idx, class... Is>
 auto hcbegin(const helper<Is...>& h) {
     return get<Idx>(h.tup).cbegin();
 }
-template <size_t Idx, forward_iterator... Is>
+template <size_t Idx, class... Is>
 auto hcend(const helper<Is...>& h) {
     return get<Idx>(h.tup).cend();
 }
 
-template <forward_iterator I1, forward_iterator I2>
-void test_algorithms() {
-    using execution::seq;
-    {
-        helper<I1, I2> h{{0, 1, 2, 3, 4, 5}, {0, 1, 3, 4, 5}};
-        auto pr = mismatch(seq, hcbegin<0>(h), hcend<0>(h), hcbegin<1>(h));
-        assert(distance(hcbegin<0>(h), pr.first) == 2);
-        assert(*pr.first == 2);
-        assert(*pr.second == 3);
+template <class It>
+struct unary_algorithms {
+    static void call() {
+        if constexpr (forward_iterator<It>) {
+            // parallel algorithms
+            using execution::seq;
+            {
+                helper<It> h({1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
+                auto res = reduce(seq, hcbegin<0>(h), hcend<0>(h), 0);
+                assert(res == 55);
+            }
+        }
     }
-    if constexpr (_Is_fwd_iter_v<I2>) {
-        helper<I1, I2> h{{0, 1, 2, 3, 4, 5}, {0, 0, 0, 0, 0, 0}};
-        initializer_list expected{0, 1, 2, 4, 5};
-        auto it = copy_if(seq, hcbegin<0>(h), hcend<0>(h), hbegin<1>(h), [](int x) { return x != 3; });
-        assert(std::equal(hbegin<1>(h), it, expected.begin(), expected.end()));
-    }
-}
+};
 
+template <class I1, class I2>
+struct binary_algorithms {
+    static void call() {
+        if constexpr (forward_iterator<I1> || _Is_fwd_iter_v<I2>) {
+            helper<I1, I2> h({0, 0, 1, 2, 3, 3, 4, 5});
+            initializer_list exp{0, 1, 2, 3, 4, 5};
+            auto it = unique_copy(hcbegin<0>(h), hcend<0>(h), hbegin<1>(h));
+            assert(equal(hbegin<1>(h), it, exp.begin(), exp.end()));
+        }
+
+        if constexpr (forward_iterator<I1> && forward_iterator<I2>) {
+            {
+                helper<I1, I2> h{{0, 1, 2, 3, 4, 5}, {5, 4, 3, 2, 1, 0}};
+                assert(is_permutation(hcbegin<0>(h), hcend<0>(h), hcbegin<1>(h), hcend<1>(h)));
+            }
+
+            // parallel algorithms
+            using execution::seq;
+            {
+                helper<I1, I2> h{{0, 1, 2, 3, 4, 5}, {0, 1, 3, 4, 5}};
+                auto pr = mismatch(seq, hcbegin<0>(h), hcend<0>(h), hcbegin<1>(h), hcend<1>(h));
+                assert(distance(hcbegin<0>(h), pr.first) == 2);
+                assert(*pr.first == 2);
+                assert(*pr.second == 3);
+            }
+            if constexpr (_Is_fwd_iter_v<I2>) {
+                helper<I1, I2> h{{0, 1, 2, 3, 4, 5}};
+                initializer_list expected{0, 1, 2, 4, 5};
+                auto it = copy_if(seq, hcbegin<0>(h), hcend<0>(h), hbegin<1>(h), [](int x) { return x != 3; });
+                assert(equal(hbegin<1>(h), it, expected.begin(), expected.end()));
+            }
+        }
+    }
+};
+
+template <class I1, class I2, class I3>
+struct ternary_algorithms {
+    static void call() {
+        if constexpr (forward_iterator<I1> && forward_iterator<I2> && forward_iterator<I3>) {
+            // parallel algorithms
+            using execution::seq;
+            if constexpr (_Is_fwd_iter_v<I2> && _Is_fwd_iter_v<I3>) {
+                helper<I1, I2, I3> h{{0, 1, 2, 3, 4, 5}};
+                initializer_list exp1{0, 1};
+                initializer_list exp2{2, 3, 4, 5};
+                auto pr = partition_copy(
+                    seq, hcbegin<0>(h), hcend<0>(h), hbegin<1>(h), hbegin<2>(h), [](int x) { return x < 2; });
+                assert(equal(hbegin<1>(h), pr.first, exp1.begin(), exp1.end()));
+                assert(equal(hbegin<2>(h), pr.second, exp2.begin(), exp2.end()));
+            }
+        }
+    }
+};
+
+using input_iter  = test::iterator<input_iterator_tag, int, test::CanDifference::no, test::CanCompare::yes>;
 using fwd_iter    = test::iterator<forward_iterator_tag, int>;
 using bidi_iter   = test::iterator<bidirectional_iterator_tag, int>;
 using random_iter = test::iterator<random_access_iterator_tag, int>;
@@ -87,6 +148,9 @@ using cpp17_bidi_iter =
     test::iterator<bidirectional_iterator_tag, int, test::CanDifference::no, test::CanCompare::yes, test::ProxyRef::no>;
 using cpp17_random_iter = test::iterator<random_access_iterator_tag, int, test::CanDifference::yes,
     test::CanCompare::yes, test::ProxyRef::no>;
+
+// Sanity checks
+static_assert(!_Is_fwd_iter_v<input_iter> && !forward_iterator<input_iter>);
 static_assert(!_Is_fwd_iter_v<fwd_iter> && forward_iterator<fwd_iter>);
 static_assert(!_Is_fwd_iter_v<bidi_iter> && bidirectional_iterator<bidi_iter>);
 static_assert(!_Is_fwd_iter_v<random_iter> && random_access_iterator<random_iter>);
@@ -94,23 +158,31 @@ static_assert(_Is_fwd_iter_v<cpp17_fwd_iter> && forward_iterator<cpp17_fwd_iter>
 static_assert(_Is_bidi_iter_v<cpp17_bidi_iter> && bidirectional_iterator<cpp17_bidi_iter>);
 static_assert(_Is_random_iter_v<cpp17_random_iter> && random_access_iterator<cpp17_random_iter>);
 
+template <template <class...> class C>
+struct instantiator {
+    template <class... Its>
+    struct curry_t {
+        using curry = instantiator<curry_t>;
 
-template <class I2>
-void inst() {
-    test_algorithms<fwd_iter, I2>();
-    test_algorithms<bidi_iter, I2>();
-    test_algorithms<random_iter, I2>();
-    test_algorithms<cpp17_fwd_iter, I2>();
-    test_algorithms<cpp17_bidi_iter, I2>();
-    test_algorithms<cpp17_random_iter, I2>();
+        static void call() {
+            C<input_iter, Its...>::call();
+            C<fwd_iter, Its...>::call();
+            C<bidi_iter, Its...>::call();
+            C<random_iter, Its...>::call();
+            C<cpp17_fwd_iter, Its...>::call();
+            C<cpp17_bidi_iter, Its...>::call();
+            C<cpp17_random_iter, Its...>::call();
+        }
+    };
+    using curry = curry_t<>::curry;
+
+    static void call() {
+        curry_t<>::call();
+    }
 };
 
-
 int main() {
-    inst<fwd_iter>();
-    inst<bidi_iter>();
-    inst<random_iter>();
-    inst<cpp17_fwd_iter>();
-    inst<cpp17_bidi_iter>();
-    inst<cpp17_random_iter>();
+    instantiator<unary_algorithms>::call();
+    instantiator<binary_algorithms>::curry::call();
+    instantiator<ternary_algorithms>::curry::curry::call();
 }

--- a/tests/std/tests/P2408R5_ranges_iterators_to_classic_algorithms/test.cpp
+++ b/tests/std/tests/P2408R5_ranges_iterators_to_classic_algorithms/test.cpp
@@ -3,9 +3,13 @@
 
 #include <algorithm>
 #include <array>
+#include <cassert>
+#include <cstddef>
 #include <execution>
 #include <initializer_list>
 #include <ranges>
+#include <tuple>
+#include <vector>
 
 #include <range_algorithm_support.hpp>
 
@@ -20,7 +24,7 @@ Input second_v(Input x) {
 
 template <class I>
 struct iterator_adaptor {
-    std::vector<int> v;
+    vector<int> v;
     iterator_adaptor(initializer_list<int> il) : v(il) {}
     iterator_adaptor(size_t n) : v(n) {}
 
@@ -50,7 +54,7 @@ struct helper {
         get<0>(tup).v.assign(il);
     }
 
-    std::tuple<iterator_adaptor<Is>...> tup;
+    tuple<iterator_adaptor<Is>...> tup;
 };
 
 template <size_t Idx, class... Is>

--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
@@ -30,7 +30,7 @@ STATIC_ASSERT(__cpp_lib_adaptor_iterator_pair_constructor == 202106L);
 STATIC_ASSERT(__cpp_lib_addressof_constexpr == 201603L);
 #endif
 
-#if _HAS_CXX20 && defined(__cpp_lib_concepts)
+#if _HAS_CXX20 && !defined(__EDG__) // TRANSITION, EDG concepts support
 #ifndef __cpp_lib_algorithm_iterator_requirements
 #error __cpp_lib_algorithm_iterator_requirements is not defined
 #elif __cpp_lib_algorithm_iterator_requirements != 202207L

--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
@@ -38,6 +38,10 @@ STATIC_ASSERT(__cpp_lib_addressof_constexpr == 201603L);
 #else
 STATIC_ASSERT(__cpp_lib_algorithm_iterator_requirements == 202207L);
 #endif
+#else
+#ifdef __cpp_lib_algorithm_iterator_requirements
+#error __cpp_lib_algorithm_iterator_requirements is defined
+#endif
 #endif
 
 #if _HAS_CXX23 && !defined(__EDG__) // TRANSITION, EDG concepts support
@@ -955,6 +959,10 @@ STATIC_ASSERT(__cpp_lib_invoke == 201411L);
 #error __cpp_lib_invoke_r is not 202106L
 #else
 STATIC_ASSERT(__cpp_lib_invoke_r == 202106L);
+#endif
+#else
+#ifdef __cpp_lib_invoke_r
+#error __cpp_lib_invoke_r is defined
 #endif
 #endif
 

--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
@@ -30,6 +30,16 @@ STATIC_ASSERT(__cpp_lib_adaptor_iterator_pair_constructor == 202106L);
 STATIC_ASSERT(__cpp_lib_addressof_constexpr == 201603L);
 #endif
 
+#if _HAS_CXX20 && defined(__cpp_lib_concepts)
+#ifndef __cpp_lib_algorithm_iterator_requirements
+#error __cpp_lib_algorithm_iterator_requirements is not defined
+#elif __cpp_lib_algorithm_iterator_requirements != 202207L
+#error __cpp_lib_algorithm_iterator_requirements is not 202207L
+#else
+STATIC_ASSERT(__cpp_lib_algorithm_iterator_requirements == 202207L);
+#endif
+#endif
+
 #if _HAS_CXX23 && !defined(__EDG__) // TRANSITION, EDG concepts support
 #ifndef __cpp_lib_allocate_at_least
 #error __cpp_lib_allocate_at_least is not defined


### PR DESCRIPTION
Fixes #2925 

Changes from paper:

* parallel algorithms: require `forward_iterator<FwdIt>` when in concepts mode for read-only iterators
* other algorithms: if there is a `static_assert(_Is_blah_iter_v)`, turn it into a `static_assert(_Is_ranges_blah_iter_v)`, when the iterator is non-mutable
* `sample`: check for `_Is_ranges_fwd_iter_v` 
* `unique_copy`: check for `_Is_ranges_fwd_iter_v`

Other changes, not explicitly specified in the paper:

* many algorithms: if there is a check for different `_Is_blah_iter_v`, and the iterator in question is non-mutable, check `_Is_ranges_blah_iter_v`
  * for example, check for `_Is_ranges_random_iter_v` in `advance`
* `prev`: check for `_Is_ranges_bidi_iter_v`
* `_Use_atomic_iterators` -> check for `_Is_ranges_random_iter_v` - this has ABI impact

Drive by:

* fixes `_Can_reread_dest` to correctly use `_Is_fwd_iter_v`, not checking for `forward_iterator`, as it is a mutable iterator
* add a missed check in `rotate_copy(ExPo)`

Renamings:
* `_REQUIRE_PARALLEL_ITERATOR` becomes two macros:
   + `_REQUIRE_PARALLEL_ITERATOR` checks for `forward_iterator` now, and is used for read-only iterators
   + `_REQUIRE_CPP17_MUTABLE_ITERATOR` checks for `_Is_fwd_iter_v` (like the old `_REQUIRE_PARALLEL_ITERATOR`), but has a new message
* `_Is_blah_iter_v` -> `_Is_cpp17_blah_iter_v` - makes it more obvious that we're checking for classic iterators
* ABI impact from `_Use_atomic_iterators`
   + `_Static_partitioned_find2` -> `_Static_partitioned_find3`
   + `_Static_partitioned_find_end_forward` -> `_Static_partitioned_find_end_forward2`
   + `_Static_partitioned_find_end_backward2` -> `_Static_partitioned_find_end_backward3`
   + `_Static_partitioned_adjacent_find2` -> `_Static_partitioned_adjacent_find3`
   + `_Static_partitioned_mismatch2` -> `_Static_partitioned_mismatch3`
   + `_Static_partitioned_search2` -> `_Static_partitioned_search3`
   + `_Static_partitioned_search_n2` -> `_Static_partitioned_search_n3`
   + `_Static_partitioned_is_sorted_until` -> `_Static_partitioned_is_sorted_until2`
   + `_Static_partitioned_is_heap_until` -> `_Static_partitioned_is_heap_until2`