### PR TITLE
Pass rvalues to `_Seek_to` in `ranges::uninitialized_(copy|move)_n`

### DIFF
--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -178,8 +178,8 @@ namespace ranges {
                 _OFirst = _Backout._Release();
             }
 
-            _Seek_wrapped(_First1, _IFirst);
-            _Seek_wrapped(_First2, _OFirst);
+            _Seek_wrapped(_First1, _STD move(_IFirst));
+            _Seek_wrapped(_First2, _STD move(_OFirst));
             return {_STD move(_First1), _STD move(_First2)};
         }
     };
@@ -317,8 +317,8 @@ namespace ranges {
                 _OFirst = _Backout._Release();
             }
 
-            _Seek_wrapped(_First1, _IFirst);
-            _Seek_wrapped(_First2, _OFirst);
+            _Seek_wrapped(_First1, _STD move(_IFirst));
+            _Seek_wrapped(_First2, _STD move(_OFirst));
             return {_STD move(_First1), _STD move(_First2)};
         }
     };

--- a/tests/std/tests/P0896R4_ranges_alg_uninitialized_copy/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_uninitialized_copy/test.cpp
@@ -275,7 +275,7 @@ struct memcpy_test {
 
 template <test::ProxyRef IsProxy>
 using test_input  = test::range<test::input, int_wrapper, test::Sized::no, test::CanDifference::no, test::Common::no,
-    test::CanCompare::yes, IsProxy>;
+    test::CanCompare::no, IsProxy>;
 using test_output = test::range<test::fwd, int_wrapper, test::Sized::no, test::CanDifference::no, test::Common::no,
     test::CanCompare::yes, test::ProxyRef::no>;
 

--- a/tests/std/tests/P0896R4_ranges_alg_uninitialized_copy_n/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_uninitialized_copy_n/test.cpp
@@ -239,7 +239,7 @@ struct memcpy_test {
 
 template <test::ProxyRef IsProxy>
 using test_input  = test::range<test::input, int_wrapper, test::Sized::no, test::CanDifference::no, test::Common::no,
-    test::CanCompare::yes, IsProxy>;
+    test::CanCompare::no, IsProxy>;
 using test_output = test::range<test::fwd, int_wrapper, test::Sized::no, test::CanDifference::no, test::Common::no,
     test::CanCompare::yes, test::ProxyRef::no>;
 

--- a/tests/std/tests/P0896R4_ranges_alg_uninitialized_move/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_uninitialized_move/test.cpp
@@ -265,7 +265,7 @@ struct memcpy_test {
 
 template <test::ProxyRef IsProxy>
 using test_input  = test::range<test::input, int_wrapper, test::Sized::no, test::CanDifference::no, test::Common::no,
-    test::CanCompare::yes, IsProxy>;
+    test::CanCompare::no, IsProxy>;
 using test_output = test::range<test::fwd, int_wrapper, test::Sized::no, test::CanDifference::no, test::Common::no,
     test::CanCompare::yes, test::ProxyRef::no>;
 

--- a/tests/std/tests/P0896R4_ranges_alg_uninitialized_move_n/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_uninitialized_move_n/test.cpp
@@ -240,7 +240,7 @@ struct memcpy_test {
 
 template <test::ProxyRef IsProxy>
 using test_input  = test::range<test::input, int_wrapper, test::Sized::no, test::CanDifference::no, test::Common::no,
-    test::CanCompare::yes, IsProxy>;
+    test::CanCompare::no, IsProxy>;
 using test_output = test::range<test::fwd, int_wrapper, test::Sized::no, test::CanDifference::no, test::Common::no,
     test::CanCompare::yes, test::ProxyRef::no>;
 


### PR DESCRIPTION
...as is necessary to properly unwrap-and-rewrap input iterators. Test `ranges::uninitialized_(copy|move)(_n)?` with iterators that require rvalues to unwrap properly which would have caught this bug.

Fixes #2962.