### PR TITLE
Status Chart: Fix CSS loading race

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <!-- SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception -->
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>STL Status Chart</title>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@primer/css@20.2.4/dist/primer.min.css" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@primer/css@20.4.0/dist/primer.min.css" />
     <script async src="https://cdn.jsdelivr.net/npm/es-module-shims@1.5.9/dist/es-module-shims.min.js"
         crossorigin="anonymous"></script>
     <script type="importmap">

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
         crossorigin="anonymous"></script>
     <script type="importmap">
         { "imports": {
-            "chart.js": "https://cdn.jsdelivr.net/npm/chart.js@3.8.0/dist/chart.esm.min.js",
+            "chart.js": "https://cdn.jsdelivr.net/npm/chart.js@3.8.2/dist/chart.esm.min.js",
             "chartjs-adapter-luxon": "https://cdn.jsdelivr.net/npm/chartjs-adapter-luxon@1.1.0/dist/chartjs-adapter-luxon.esm.min.js",
             "luxon": "https://cdn.jsdelivr.net/npm/luxon@2.5.0/+esm"
         } }

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>STL Status Chart</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@primer/css@20.2.4/dist/primer.min.css" />
-    <script async src="https://cdn.jsdelivr.net/npm/es-module-shims@1.5.8/dist/es-module-shims.min.js"
+    <script async src="https://cdn.jsdelivr.net/npm/es-module-shims@1.5.9/dist/es-module-shims.min.js"
         crossorigin="anonymous"></script>
     <script type="importmap">
         { "imports": {

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
         { "imports": {
             "chart.js": "https://cdn.jsdelivr.net/npm/chart.js@3.8.0/dist/chart.esm.min.js",
             "chartjs-adapter-luxon": "https://cdn.jsdelivr.net/npm/chartjs-adapter-luxon@1.1.0/dist/chartjs-adapter-luxon.esm.min.js",
-            "luxon": "https://cdn.jsdelivr.net/npm/luxon@2.4.0/+esm"
+            "luxon": "https://cdn.jsdelivr.net/npm/luxon@2.5.0/+esm"
         } }
     </script>
     <script type="module" src="built/status_chart.mjs"></script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,40 +9,46 @@
       "version": "1.0.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
-        "@octokit/graphql": "^4.8.0",
+        "@octokit/graphql": "^5.0.0",
         "@types/cli-progress": "^3.11.0",
-        "@types/luxon": "^2.3.2",
-        "@types/node": "^18.0.2",
+        "@types/luxon": "^3.0.0",
+        "@types/node": "^18.6.2",
         "@types/yargs": "^17.0.10",
-        "chart.js": "^3.8.0",
+        "chart.js": "^3.8.2",
         "chartjs-adapter-luxon": "^1.1.0",
         "cli-progress": "^3.11.2",
         "dotenv": "^16.0.1",
-        "esbuild": "^0.14.48",
+        "esbuild": "^0.14.51",
         "http-server": "^14.1.1",
-        "luxon": "^2.4.0",
+        "luxon": "^2.5.0",
         "typescript": "^4.7.4",
         "yargs": "^17.5.1"
       }
     },
     "node_modules/@octokit/endpoint": {
-      "version": "6.0.12",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.12.tgz",
-      "integrity": "sha512-lF3puPwkQWGfkMClXb4k/eUT/nZKQfxinRWJrdZaJO85Dqwo/G0yOC434Jr2ojwafWJMYqFGFa5ms4jJUgujdA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.0.tgz",
+      "integrity": "sha512-Kz/mIkOTjs9rV50hf/JK9pIDl4aGwAtT8pry6Rpy+hVXkAPhXanNQRxMoq6AeRgDCZR6t/A1zKniY2V1YhrzlQ==",
       "dependencies": {
         "@octokit/types": "^6.0.3",
         "is-plain-object": "^5.0.0",
         "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/@octokit/graphql": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.8.0.tgz",
-      "integrity": "sha512-0gv+qLSBLKF0z8TKaSKTsS39scVKF9dbMxJpj3U0vC7wjNWFuIpL/z76Qe2fiuCbDRcJSavkXsVtMS6/dtQQsg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-5.0.0.tgz",
+      "integrity": "sha512-1ZZ8tX4lUEcLPvHagfIVu5S2xpHYXAmgN0+95eAOPoaVPzCfUXJtA5vASafcpWcO86ze0Pzn30TAx72aB2aguQ==",
       "dependencies": {
-        "@octokit/request": "^5.6.0",
+        "@octokit/request": "^6.0.0",
         "@octokit/types": "^6.0.3",
         "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/@octokit/openapi-types": {
@@ -51,26 +57,32 @@
       "integrity": "sha512-VsXyi8peyRq9PqIz/tpqiL2w3w80OgVMwBHltTml3LmVvXiphgeqmY9mvBw9Wu7e0QWk/fqD37ux8yP5uVekyQ=="
     },
     "node_modules/@octokit/request": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.3.tgz",
-      "integrity": "sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-6.2.0.tgz",
+      "integrity": "sha512-7IAmHnaezZrgUqtRShMlByJK33MT9ZDnMRgZjnRrRV9a/jzzFwKGz0vxhFU6i7VMLraYcQ1qmcAOin37Kryq+Q==",
       "dependencies": {
-        "@octokit/endpoint": "^6.0.1",
-        "@octokit/request-error": "^2.1.0",
+        "@octokit/endpoint": "^7.0.0",
+        "@octokit/request-error": "^3.0.0",
         "@octokit/types": "^6.16.1",
         "is-plain-object": "^5.0.0",
         "node-fetch": "^2.6.7",
         "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/@octokit/request-error": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.1.0.tgz",
-      "integrity": "sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-3.0.0.tgz",
+      "integrity": "sha512-WBtpzm9lR8z4IHIMtOqr6XwfkGvMOOILNLxsWvDwtzm/n7f5AWuqJTXQXdDtOvPfTDrH4TPhEvW2qMlR4JFA2w==",
       "dependencies": {
         "@octokit/types": "^6.0.3",
         "deprecation": "^2.0.0",
         "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/@octokit/types": {
@@ -90,9 +102,9 @@
       }
     },
     "node_modules/@types/luxon": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-2.4.0.tgz",
-      "integrity": "sha512-oCavjEjRXuR6URJEtQm0eBdfsBiEcGBZbq21of8iGkeKxU1+1xgKuFPClaBZl2KB8ZZBSWlgk61tH6Mf+nvZVw=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.0.0.tgz",
+      "integrity": "sha512-Lx+EZoJxUKw4dp8uei9XiUVNlgkYmax5+ovqt6Xf3LzJOnWhlfJw/jLBmqfGVwOP/pDr4HT8bI1WtxK0IChMLw=="
     },
     "node_modules/@types/node": {
       "version": "18.6.2",
@@ -1083,9 +1095,9 @@
   },
   "dependencies": {
     "@octokit/endpoint": {
-      "version": "6.0.12",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.12.tgz",
-      "integrity": "sha512-lF3puPwkQWGfkMClXb4k/eUT/nZKQfxinRWJrdZaJO85Dqwo/G0yOC434Jr2ojwafWJMYqFGFa5ms4jJUgujdA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.0.tgz",
+      "integrity": "sha512-Kz/mIkOTjs9rV50hf/JK9pIDl4aGwAtT8pry6Rpy+hVXkAPhXanNQRxMoq6AeRgDCZR6t/A1zKniY2V1YhrzlQ==",
       "requires": {
         "@octokit/types": "^6.0.3",
         "is-plain-object": "^5.0.0",
@@ -1093,11 +1105,11 @@
       }
     },
     "@octokit/graphql": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.8.0.tgz",
-      "integrity": "sha512-0gv+qLSBLKF0z8TKaSKTsS39scVKF9dbMxJpj3U0vC7wjNWFuIpL/z76Qe2fiuCbDRcJSavkXsVtMS6/dtQQsg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-5.0.0.tgz",
+      "integrity": "sha512-1ZZ8tX4lUEcLPvHagfIVu5S2xpHYXAmgN0+95eAOPoaVPzCfUXJtA5vASafcpWcO86ze0Pzn30TAx72aB2aguQ==",
       "requires": {
-        "@octokit/request": "^5.6.0",
+        "@octokit/request": "^6.0.0",
         "@octokit/types": "^6.0.3",
         "universal-user-agent": "^6.0.0"
       }
@@ -1108,12 +1120,12 @@
       "integrity": "sha512-VsXyi8peyRq9PqIz/tpqiL2w3w80OgVMwBHltTml3LmVvXiphgeqmY9mvBw9Wu7e0QWk/fqD37ux8yP5uVekyQ=="
     },
     "@octokit/request": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.3.tgz",
-      "integrity": "sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-6.2.0.tgz",
+      "integrity": "sha512-7IAmHnaezZrgUqtRShMlByJK33MT9ZDnMRgZjnRrRV9a/jzzFwKGz0vxhFU6i7VMLraYcQ1qmcAOin37Kryq+Q==",
       "requires": {
-        "@octokit/endpoint": "^6.0.1",
-        "@octokit/request-error": "^2.1.0",
+        "@octokit/endpoint": "^7.0.0",
+        "@octokit/request-error": "^3.0.0",
         "@octokit/types": "^6.16.1",
         "is-plain-object": "^5.0.0",
         "node-fetch": "^2.6.7",
@@ -1121,9 +1133,9 @@
       }
     },
     "@octokit/request-error": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.1.0.tgz",
-      "integrity": "sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-3.0.0.tgz",
+      "integrity": "sha512-WBtpzm9lR8z4IHIMtOqr6XwfkGvMOOILNLxsWvDwtzm/n7f5AWuqJTXQXdDtOvPfTDrH4TPhEvW2qMlR4JFA2w==",
       "requires": {
         "@octokit/types": "^6.0.3",
         "deprecation": "^2.0.0",
@@ -1147,9 +1159,9 @@
       }
     },
     "@types/luxon": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-2.4.0.tgz",
-      "integrity": "sha512-oCavjEjRXuR6URJEtQm0eBdfsBiEcGBZbq21of8iGkeKxU1+1xgKuFPClaBZl2KB8ZZBSWlgk61tH6Mf+nvZVw=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.0.0.tgz",
+      "integrity": "sha512-Lx+EZoJxUKw4dp8uei9XiUVNlgkYmax5+ovqt6Xf3LzJOnWhlfJw/jLBmqfGVwOP/pDr4HT8bI1WtxK0IChMLw=="
     },
     "@types/node": {
       "version": "18.6.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,9 +46,9 @@
       }
     },
     "node_modules/@octokit/openapi-types": {
-      "version": "12.8.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-12.8.0.tgz",
-      "integrity": "sha512-ydcKLs2KKcxlhpdWLzJxEBDEk/U5MUeqtqkXlrtAUXXFPs6vLl1PEGghFC/BbpleosB7iXs0Z4P2DGe7ZT5ZNg=="
+      "version": "12.11.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-12.11.0.tgz",
+      "integrity": "sha512-VsXyi8peyRq9PqIz/tpqiL2w3w80OgVMwBHltTml3LmVvXiphgeqmY9mvBw9Wu7e0QWk/fqD37ux8yP5uVekyQ=="
     },
     "node_modules/@octokit/request": {
       "version": "5.6.3",
@@ -74,11 +74,11 @@
       }
     },
     "node_modules/@octokit/types": {
-      "version": "6.39.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.39.0.tgz",
-      "integrity": "sha512-Mq4N9sOAYCitTsBtDdRVrBE80lIrMBhL9Jbrw0d+j96BAzlq4V+GLHFJbHokEsVvO/9tQupQdoFdgVYhD2C8UQ==",
+      "version": "6.41.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.41.0.tgz",
+      "integrity": "sha512-eJ2jbzjdijiL3B4PrSQaSjuF2sPEQPVCPzBvTHJD9Nz+9dw2SGH4K4xeQJ77YfTq5bRQ+bD8wT11JbeDPmxmGg==",
       "dependencies": {
-        "@octokit/openapi-types": "^12.7.0"
+        "@octokit/openapi-types": "^12.11.0"
       }
     },
     "node_modules/@types/cli-progress": {
@@ -90,14 +90,14 @@
       }
     },
     "node_modules/@types/luxon": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-2.3.2.tgz",
-      "integrity": "sha512-WOehptuhKIXukSUUkRgGbj2c997Uv/iUgYgII8U7XLJqq9W2oF0kQ6frEznRQbdurioz+L/cdaIm4GutTQfgmA=="
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-2.4.0.tgz",
+      "integrity": "sha512-oCavjEjRXuR6URJEtQm0eBdfsBiEcGBZbq21of8iGkeKxU1+1xgKuFPClaBZl2KB8ZZBSWlgk61tH6Mf+nvZVw=="
     },
     "node_modules/@types/node": {
-      "version": "18.0.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.2.tgz",
-      "integrity": "sha512-b947SdS4GH+g2W33wf5FzUu1KLj5FcSIiNWbU1ZyMvt/X7w48ZsVcsQoirIgE/Oq03WT5Qbn/dkY0hePi4ZXcQ=="
+      "version": "18.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.2.tgz",
+      "integrity": "sha512-KcfkBq9H4PI6Vpu5B/KoPeuVDAbmi+2mDBqGPGUgoL7yXQtcWGu2vJWmmRkneWK3Rh0nIAX192Aa87AqKHYChQ=="
     },
     "node_modules/@types/yargs": {
       "version": "17.0.10",
@@ -181,9 +181,9 @@
       }
     },
     "node_modules/chart.js": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-3.8.0.tgz",
-      "integrity": "sha512-cr8xhrXjLIXVLOBZPkBZVF6NDeiVIrPLHcMhnON7UufudL+CNeRrD+wpYanswlm8NpudMdrt3CHoLMQMxJhHRg=="
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-3.8.2.tgz",
+      "integrity": "sha512-7rqSlHWMUKFyBDOJvmFGW2lxULtcwaPLegDjX/Nu5j6QybY+GCiQkEY+6cqHw62S5tcwXMD8Y+H5OBGoR7d+ZQ=="
     },
     "node_modules/chartjs-adapter-luxon": {
       "version": "1.1.0",
@@ -266,9 +266,9 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "node_modules/esbuild": {
-      "version": "0.14.48",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.48.tgz",
-      "integrity": "sha512-w6N1Yn5MtqK2U1/WZTX9ZqUVb8IOLZkZ5AdHkT6x3cHDMVsYWC7WPdiLmx19w3i4Rwzy5LqsEMtVihG3e4rFzA==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.51.tgz",
+      "integrity": "sha512-+CvnDitD7Q5sT7F+FM65sWkF8wJRf+j9fPcprxYV4j+ohmzVj2W7caUqH2s5kCaCJAfcAICjSlKhDCcvDpU7nw==",
       "hasInstallScript": true,
       "bin": {
         "esbuild": "bin/esbuild"
@@ -277,32 +277,32 @@
         "node": ">=12"
       },
       "optionalDependencies": {
-        "esbuild-android-64": "0.14.48",
-        "esbuild-android-arm64": "0.14.48",
-        "esbuild-darwin-64": "0.14.48",
-        "esbuild-darwin-arm64": "0.14.48",
-        "esbuild-freebsd-64": "0.14.48",
-        "esbuild-freebsd-arm64": "0.14.48",
-        "esbuild-linux-32": "0.14.48",
-        "esbuild-linux-64": "0.14.48",
-        "esbuild-linux-arm": "0.14.48",
-        "esbuild-linux-arm64": "0.14.48",
-        "esbuild-linux-mips64le": "0.14.48",
-        "esbuild-linux-ppc64le": "0.14.48",
-        "esbuild-linux-riscv64": "0.14.48",
-        "esbuild-linux-s390x": "0.14.48",
-        "esbuild-netbsd-64": "0.14.48",
-        "esbuild-openbsd-64": "0.14.48",
-        "esbuild-sunos-64": "0.14.48",
-        "esbuild-windows-32": "0.14.48",
-        "esbuild-windows-64": "0.14.48",
-        "esbuild-windows-arm64": "0.14.48"
+        "esbuild-android-64": "0.14.51",
+        "esbuild-android-arm64": "0.14.51",
+        "esbuild-darwin-64": "0.14.51",
+        "esbuild-darwin-arm64": "0.14.51",
+        "esbuild-freebsd-64": "0.14.51",
+        "esbuild-freebsd-arm64": "0.14.51",
+        "esbuild-linux-32": "0.14.51",
+        "esbuild-linux-64": "0.14.51",
+        "esbuild-linux-arm": "0.14.51",
+        "esbuild-linux-arm64": "0.14.51",
+        "esbuild-linux-mips64le": "0.14.51",
+        "esbuild-linux-ppc64le": "0.14.51",
+        "esbuild-linux-riscv64": "0.14.51",
+        "esbuild-linux-s390x": "0.14.51",
+        "esbuild-netbsd-64": "0.14.51",
+        "esbuild-openbsd-64": "0.14.51",
+        "esbuild-sunos-64": "0.14.51",
+        "esbuild-windows-32": "0.14.51",
+        "esbuild-windows-64": "0.14.51",
+        "esbuild-windows-arm64": "0.14.51"
       }
     },
     "node_modules/esbuild-android-64": {
-      "version": "0.14.48",
-      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.48.tgz",
-      "integrity": "sha512-3aMjboap/kqwCUpGWIjsk20TtxVoKck8/4Tu19rubh7t5Ra0Yrpg30Mt1QXXlipOazrEceGeWurXKeFJgkPOUg==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.51.tgz",
+      "integrity": "sha512-6FOuKTHnC86dtrKDmdSj2CkcKF8PnqkaIXqvgydqfJmqBazCPdw+relrMlhGjkvVdiiGV70rpdnyFmA65ekBCQ==",
       "cpu": [
         "x64"
       ],
@@ -315,9 +315,9 @@
       }
     },
     "node_modules/esbuild-android-arm64": {
-      "version": "0.14.48",
-      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.48.tgz",
-      "integrity": "sha512-vptI3K0wGALiDq+EvRuZotZrJqkYkN5282iAfcffjI5lmGG9G1ta/CIVauhY42MBXwEgDJkweiDcDMRLzBZC4g==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.51.tgz",
+      "integrity": "sha512-vBtp//5VVkZWmYYvHsqBRCMMi1MzKuMIn5XDScmnykMTu9+TD9v0NMEDqQxvtFToeYmojdo5UCV2vzMQWJcJ4A==",
       "cpu": [
         "arm64"
       ],
@@ -330,9 +330,9 @@
       }
     },
     "node_modules/esbuild-darwin-64": {
-      "version": "0.14.48",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.48.tgz",
-      "integrity": "sha512-gGQZa4+hab2Va/Zww94YbshLuWteyKGD3+EsVon8EWTWhnHFRm5N9NbALNbwi/7hQ/hM1Zm4FuHg+k6BLsl5UA==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.51.tgz",
+      "integrity": "sha512-YFmXPIOvuagDcwCejMRtCDjgPfnDu+bNeh5FU2Ryi68ADDVlWEpbtpAbrtf/lvFTWPexbgyKgzppNgsmLPr8PA==",
       "cpu": [
         "x64"
       ],
@@ -345,9 +345,9 @@
       }
     },
     "node_modules/esbuild-darwin-arm64": {
-      "version": "0.14.48",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.48.tgz",
-      "integrity": "sha512-bFjnNEXjhZT+IZ8RvRGNJthLWNHV5JkCtuOFOnjvo5pC0sk2/QVk0Qc06g2PV3J0TcU6kaPC3RN9yy9w2PSLEA==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.51.tgz",
+      "integrity": "sha512-juYD0QnSKwAMfzwKdIF6YbueXzS6N7y4GXPDeDkApz/1RzlT42mvX9jgNmyOlWKN7YzQAYbcUEJmZJYQGdf2ow==",
       "cpu": [
         "arm64"
       ],
@@ -360,9 +360,9 @@
       }
     },
     "node_modules/esbuild-freebsd-64": {
-      "version": "0.14.48",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.48.tgz",
-      "integrity": "sha512-1NOlwRxmOsnPcWOGTB10JKAkYSb2nue0oM1AfHWunW/mv3wERfJmnYlGzL3UAOIUXZqW8GeA2mv+QGwq7DToqA==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.51.tgz",
+      "integrity": "sha512-cLEI/aXjb6vo5O2Y8rvVSQ7smgLldwYY5xMxqh/dQGfWO+R1NJOFsiax3IS4Ng300SVp7Gz3czxT6d6qf2cw0g==",
       "cpu": [
         "x64"
       ],
@@ -375,9 +375,9 @@
       }
     },
     "node_modules/esbuild-freebsd-arm64": {
-      "version": "0.14.48",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.48.tgz",
-      "integrity": "sha512-gXqKdO8wabVcYtluAbikDH2jhXp+Klq5oCD5qbVyUG6tFiGhrC9oczKq3vIrrtwcxDQqK6+HDYK8Zrd4bCA9Gw==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.51.tgz",
+      "integrity": "sha512-TcWVw/rCL2F+jUgRkgLa3qltd5gzKjIMGhkVybkjk6PJadYInPtgtUBp1/hG+mxyigaT7ib+od1Xb84b+L+1Mg==",
       "cpu": [
         "arm64"
       ],
@@ -390,9 +390,9 @@
       }
     },
     "node_modules/esbuild-linux-32": {
-      "version": "0.14.48",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.48.tgz",
-      "integrity": "sha512-ghGyDfS289z/LReZQUuuKq9KlTiTspxL8SITBFQFAFRA/IkIvDpnZnCAKTCjGXAmUqroMQfKJXMxyjJA69c/nQ==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.51.tgz",
+      "integrity": "sha512-RFqpyC5ChyWrjx8Xj2K0EC1aN0A37H6OJfmUXIASEqJoHcntuV3j2Efr9RNmUhMfNE6yEj2VpYuDteZLGDMr0w==",
       "cpu": [
         "ia32"
       ],
@@ -405,9 +405,9 @@
       }
     },
     "node_modules/esbuild-linux-64": {
-      "version": "0.14.48",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.48.tgz",
-      "integrity": "sha512-vni3p/gppLMVZLghI7oMqbOZdGmLbbKR23XFARKnszCIBpEMEDxOMNIKPmMItQrmH/iJrL1z8Jt2nynY0bE1ug==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.51.tgz",
+      "integrity": "sha512-dxjhrqo5i7Rq6DXwz5v+MEHVs9VNFItJmHBe1CxROWNf4miOGoQhqSG8StStbDkQ1Mtobg6ng+4fwByOhoQoeA==",
       "cpu": [
         "x64"
       ],
@@ -420,9 +420,9 @@
       }
     },
     "node_modules/esbuild-linux-arm": {
-      "version": "0.14.48",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.48.tgz",
-      "integrity": "sha512-+VfSV7Akh1XUiDNXgqgY1cUP1i2vjI+BmlyXRfVz5AfV3jbpde8JTs5Q9sYgaoq5cWfuKfoZB/QkGOI+QcL1Tw==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.51.tgz",
+      "integrity": "sha512-LsJynDxYF6Neg7ZC7748yweCDD+N8ByCv22/7IAZglIEniEkqdF4HCaa49JNDLw1UQGlYuhOB8ZT/MmcSWzcWg==",
       "cpu": [
         "arm"
       ],
@@ -435,9 +435,9 @@
       }
     },
     "node_modules/esbuild-linux-arm64": {
-      "version": "0.14.48",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.48.tgz",
-      "integrity": "sha512-3CFsOlpoxlKPRevEHq8aAntgYGYkE1N9yRYAcPyng/p4Wyx0tPR5SBYsxLKcgPB9mR8chHEhtWYz6EZ+H199Zw==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.51.tgz",
+      "integrity": "sha512-D9rFxGutoqQX3xJPxqd6o+kvYKeIbM0ifW2y0bgKk5HPgQQOo2k9/2Vpto3ybGYaFPCE5qTGtqQta9PoP6ZEzw==",
       "cpu": [
         "arm64"
       ],
@@ -450,9 +450,9 @@
       }
     },
     "node_modules/esbuild-linux-mips64le": {
-      "version": "0.14.48",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.48.tgz",
-      "integrity": "sha512-cs0uOiRlPp6ymknDnjajCgvDMSsLw5mST2UXh+ZIrXTj2Ifyf2aAP3Iw4DiqgnyYLV2O/v/yWBJx+WfmKEpNLA==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.51.tgz",
+      "integrity": "sha512-vS54wQjy4IinLSlb5EIlLoln8buh1yDgliP4CuEHumrPk4PvvP4kTRIG4SzMXm6t19N0rIfT4bNdAxzJLg2k6A==",
       "cpu": [
         "mips64el"
       ],
@@ -465,9 +465,9 @@
       }
     },
     "node_modules/esbuild-linux-ppc64le": {
-      "version": "0.14.48",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.48.tgz",
-      "integrity": "sha512-+2F0vJMkuI0Wie/wcSPDCqXvSFEELH7Jubxb7mpWrA/4NpT+/byjxDz0gG6R1WJoeDefcrMfpBx4GFNN1JQorQ==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.51.tgz",
+      "integrity": "sha512-xcdd62Y3VfGoyphNP/aIV9LP+RzFw5M5Z7ja+zdpQHHvokJM7d0rlDRMN+iSSwvUymQkqZO+G/xjb4/75du8BQ==",
       "cpu": [
         "ppc64"
       ],
@@ -480,9 +480,9 @@
       }
     },
     "node_modules/esbuild-linux-riscv64": {
-      "version": "0.14.48",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.48.tgz",
-      "integrity": "sha512-BmaK/GfEE+5F2/QDrIXteFGKnVHGxlnK9MjdVKMTfvtmudjY3k2t8NtlY4qemKSizc+QwyombGWTBDc76rxePA==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.51.tgz",
+      "integrity": "sha512-syXHGak9wkAnFz0gMmRBoy44JV0rp4kVCEA36P5MCeZcxFq8+fllBC2t6sKI23w3qd8Vwo9pTADCgjTSf3L3rA==",
       "cpu": [
         "riscv64"
       ],
@@ -495,9 +495,9 @@
       }
     },
     "node_modules/esbuild-linux-s390x": {
-      "version": "0.14.48",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.48.tgz",
-      "integrity": "sha512-tndw/0B9jiCL+KWKo0TSMaUm5UWBLsfCKVdbfMlb3d5LeV9WbijZ8Ordia8SAYv38VSJWOEt6eDCdOx8LqkC4g==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.51.tgz",
+      "integrity": "sha512-kFAJY3dv+Wq8o28K/C7xkZk/X34rgTwhknSsElIqoEo8armCOjMJ6NsMxm48KaWY2h2RUYGtQmr+RGuUPKBhyw==",
       "cpu": [
         "s390x"
       ],
@@ -510,9 +510,9 @@
       }
     },
     "node_modules/esbuild-netbsd-64": {
-      "version": "0.14.48",
-      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.48.tgz",
-      "integrity": "sha512-V9hgXfwf/T901Lr1wkOfoevtyNkrxmMcRHyticybBUHookznipMOHoF41Al68QBsqBxnITCEpjjd4yAos7z9Tw==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.51.tgz",
+      "integrity": "sha512-ZZBI7qrR1FevdPBVHz/1GSk1x5GDL/iy42Zy8+neEm/HA7ma+hH/bwPEjeHXKWUDvM36CZpSL/fn1/y9/Hb+1A==",
       "cpu": [
         "x64"
       ],
@@ -525,9 +525,9 @@
       }
     },
     "node_modules/esbuild-openbsd-64": {
-      "version": "0.14.48",
-      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.48.tgz",
-      "integrity": "sha512-+IHf4JcbnnBl4T52egorXMatil/za0awqzg2Vy6FBgPcBpisDWT2sVz/tNdrK9kAqj+GZG/jZdrOkj7wsrNTKA==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.51.tgz",
+      "integrity": "sha512-7R1/p39M+LSVQVgDVlcY1KKm6kFKjERSX1lipMG51NPcspJD1tmiZSmmBXoY5jhHIu6JL1QkFDTx94gMYK6vfA==",
       "cpu": [
         "x64"
       ],
@@ -540,9 +540,9 @@
       }
     },
     "node_modules/esbuild-sunos-64": {
-      "version": "0.14.48",
-      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.48.tgz",
-      "integrity": "sha512-77m8bsr5wOpOWbGi9KSqDphcq6dFeJyun8TA+12JW/GAjyfTwVtOnN8DOt6DSPUfEV+ltVMNqtXUeTeMAxl5KA==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.51.tgz",
+      "integrity": "sha512-HoHaCswHxLEYN8eBTtyO0bFEWvA3Kdb++hSQ/lLG7TyKF69TeSG0RNoBRAs45x/oCeWaTDntEZlYwAfQlhEtJA==",
       "cpu": [
         "x64"
       ],
@@ -555,9 +555,9 @@
       }
     },
     "node_modules/esbuild-windows-32": {
-      "version": "0.14.48",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.48.tgz",
-      "integrity": "sha512-EPgRuTPP8vK9maxpTGDe5lSoIBHGKO/AuxDncg5O3NkrPeLNdvvK8oywB0zGaAZXxYWfNNSHskvvDgmfVTguhg==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.51.tgz",
+      "integrity": "sha512-4rtwSAM35A07CBt1/X8RWieDj3ZUHQqUOaEo5ZBs69rt5WAFjP4aqCIobdqOy4FdhYw1yF8Z0xFBTyc9lgPtEg==",
       "cpu": [
         "ia32"
       ],
@@ -570,9 +570,9 @@
       }
     },
     "node_modules/esbuild-windows-64": {
-      "version": "0.14.48",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.48.tgz",
-      "integrity": "sha512-YmpXjdT1q0b8ictSdGwH3M8VCoqPpK1/UArze3X199w6u8hUx3V8BhAi1WjbsfDYRBanVVtduAhh2sirImtAvA==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.51.tgz",
+      "integrity": "sha512-HoN/5HGRXJpWODprGCgKbdMvrC3A2gqvzewu2eECRw2sYxOUoh2TV1tS+G7bHNapPGI79woQJGV6pFH7GH7qnA==",
       "cpu": [
         "x64"
       ],
@@ -585,9 +585,9 @@
       }
     },
     "node_modules/esbuild-windows-arm64": {
-      "version": "0.14.48",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.48.tgz",
-      "integrity": "sha512-HHaOMCsCXp0rz5BT2crTka6MPWVno121NKApsGs/OIW5QC0ggC69YMGs1aJct9/9FSUF4A1xNE/cLvgB5svR4g==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.51.tgz",
+      "integrity": "sha512-JQDqPjuOH7o+BsKMSddMfmVJXrnYZxXDHsoLHc0xgmAZkOOCflRmC43q31pk79F9xuyWY45jDBPolb5ZgGOf9g==",
       "cpu": [
         "arm64"
       ],
@@ -778,9 +778,9 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/luxon": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-2.4.0.tgz",
-      "integrity": "sha512-w+NAwWOUL5hO0SgwOHsMBAmZ15SoknmQXhSO0hIbJCAmPKSsGeK8MlmhYh2w6Iib38IxN2M+/ooXWLbeis7GuA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-2.5.0.tgz",
+      "integrity": "sha512-IDkEPB80Rb6gCAU+FEib0t4FeJ4uVOuX1CQ9GsvU3O+JAGIgu0J7sf1OarXKaKDygTZIoJyU6YdZzTFRu+YR0A==",
       "engines": {
         "node": ">=12"
       }
@@ -1103,9 +1103,9 @@
       }
     },
     "@octokit/openapi-types": {
-      "version": "12.8.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-12.8.0.tgz",
-      "integrity": "sha512-ydcKLs2KKcxlhpdWLzJxEBDEk/U5MUeqtqkXlrtAUXXFPs6vLl1PEGghFC/BbpleosB7iXs0Z4P2DGe7ZT5ZNg=="
+      "version": "12.11.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-12.11.0.tgz",
+      "integrity": "sha512-VsXyi8peyRq9PqIz/tpqiL2w3w80OgVMwBHltTml3LmVvXiphgeqmY9mvBw9Wu7e0QWk/fqD37ux8yP5uVekyQ=="
     },
     "@octokit/request": {
       "version": "5.6.3",
@@ -1131,11 +1131,11 @@
       }
     },
     "@octokit/types": {
-      "version": "6.39.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.39.0.tgz",
-      "integrity": "sha512-Mq4N9sOAYCitTsBtDdRVrBE80lIrMBhL9Jbrw0d+j96BAzlq4V+GLHFJbHokEsVvO/9tQupQdoFdgVYhD2C8UQ==",
+      "version": "6.41.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.41.0.tgz",
+      "integrity": "sha512-eJ2jbzjdijiL3B4PrSQaSjuF2sPEQPVCPzBvTHJD9Nz+9dw2SGH4K4xeQJ77YfTq5bRQ+bD8wT11JbeDPmxmGg==",
       "requires": {
-        "@octokit/openapi-types": "^12.7.0"
+        "@octokit/openapi-types": "^12.11.0"
       }
     },
     "@types/cli-progress": {
@@ -1147,14 +1147,14 @@
       }
     },
     "@types/luxon": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-2.3.2.tgz",
-      "integrity": "sha512-WOehptuhKIXukSUUkRgGbj2c997Uv/iUgYgII8U7XLJqq9W2oF0kQ6frEznRQbdurioz+L/cdaIm4GutTQfgmA=="
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-2.4.0.tgz",
+      "integrity": "sha512-oCavjEjRXuR6URJEtQm0eBdfsBiEcGBZbq21of8iGkeKxU1+1xgKuFPClaBZl2KB8ZZBSWlgk61tH6Mf+nvZVw=="
     },
     "@types/node": {
-      "version": "18.0.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.2.tgz",
-      "integrity": "sha512-b947SdS4GH+g2W33wf5FzUu1KLj5FcSIiNWbU1ZyMvt/X7w48ZsVcsQoirIgE/Oq03WT5Qbn/dkY0hePi4ZXcQ=="
+      "version": "18.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.2.tgz",
+      "integrity": "sha512-KcfkBq9H4PI6Vpu5B/KoPeuVDAbmi+2mDBqGPGUgoL7yXQtcWGu2vJWmmRkneWK3Rh0nIAX192Aa87AqKHYChQ=="
     },
     "@types/yargs": {
       "version": "17.0.10",
@@ -1217,9 +1217,9 @@
       }
     },
     "chart.js": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-3.8.0.tgz",
-      "integrity": "sha512-cr8xhrXjLIXVLOBZPkBZVF6NDeiVIrPLHcMhnON7UufudL+CNeRrD+wpYanswlm8NpudMdrt3CHoLMQMxJhHRg=="
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-3.8.2.tgz",
+      "integrity": "sha512-7rqSlHWMUKFyBDOJvmFGW2lxULtcwaPLegDjX/Nu5j6QybY+GCiQkEY+6cqHw62S5tcwXMD8Y+H5OBGoR7d+ZQ=="
     },
     "chartjs-adapter-luxon": {
       "version": "1.1.0",
@@ -1287,150 +1287,150 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "esbuild": {
-      "version": "0.14.48",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.48.tgz",
-      "integrity": "sha512-w6N1Yn5MtqK2U1/WZTX9ZqUVb8IOLZkZ5AdHkT6x3cHDMVsYWC7WPdiLmx19w3i4Rwzy5LqsEMtVihG3e4rFzA==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.51.tgz",
+      "integrity": "sha512-+CvnDitD7Q5sT7F+FM65sWkF8wJRf+j9fPcprxYV4j+ohmzVj2W7caUqH2s5kCaCJAfcAICjSlKhDCcvDpU7nw==",
       "requires": {
-        "esbuild-android-64": "0.14.48",
-        "esbuild-android-arm64": "0.14.48",
-        "esbuild-darwin-64": "0.14.48",
-        "esbuild-darwin-arm64": "0.14.48",
-        "esbuild-freebsd-64": "0.14.48",
-        "esbuild-freebsd-arm64": "0.14.48",
-        "esbuild-linux-32": "0.14.48",
-        "esbuild-linux-64": "0.14.48",
-        "esbuild-linux-arm": "0.14.48",
-        "esbuild-linux-arm64": "0.14.48",
-        "esbuild-linux-mips64le": "0.14.48",
-        "esbuild-linux-ppc64le": "0.14.48",
-        "esbuild-linux-riscv64": "0.14.48",
-        "esbuild-linux-s390x": "0.14.48",
-        "esbuild-netbsd-64": "0.14.48",
-        "esbuild-openbsd-64": "0.14.48",
-        "esbuild-sunos-64": "0.14.48",
-        "esbuild-windows-32": "0.14.48",
-        "esbuild-windows-64": "0.14.48",
-        "esbuild-windows-arm64": "0.14.48"
+        "esbuild-android-64": "0.14.51",
+        "esbuild-android-arm64": "0.14.51",
+        "esbuild-darwin-64": "0.14.51",
+        "esbuild-darwin-arm64": "0.14.51",
+        "esbuild-freebsd-64": "0.14.51",
+        "esbuild-freebsd-arm64": "0.14.51",
+        "esbuild-linux-32": "0.14.51",
+        "esbuild-linux-64": "0.14.51",
+        "esbuild-linux-arm": "0.14.51",
+        "esbuild-linux-arm64": "0.14.51",
+        "esbuild-linux-mips64le": "0.14.51",
+        "esbuild-linux-ppc64le": "0.14.51",
+        "esbuild-linux-riscv64": "0.14.51",
+        "esbuild-linux-s390x": "0.14.51",
+        "esbuild-netbsd-64": "0.14.51",
+        "esbuild-openbsd-64": "0.14.51",
+        "esbuild-sunos-64": "0.14.51",
+        "esbuild-windows-32": "0.14.51",
+        "esbuild-windows-64": "0.14.51",
+        "esbuild-windows-arm64": "0.14.51"
       }
     },
     "esbuild-android-64": {
-      "version": "0.14.48",
-      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.48.tgz",
-      "integrity": "sha512-3aMjboap/kqwCUpGWIjsk20TtxVoKck8/4Tu19rubh7t5Ra0Yrpg30Mt1QXXlipOazrEceGeWurXKeFJgkPOUg==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.51.tgz",
+      "integrity": "sha512-6FOuKTHnC86dtrKDmdSj2CkcKF8PnqkaIXqvgydqfJmqBazCPdw+relrMlhGjkvVdiiGV70rpdnyFmA65ekBCQ==",
       "optional": true
     },
     "esbuild-android-arm64": {
-      "version": "0.14.48",
-      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.48.tgz",
-      "integrity": "sha512-vptI3K0wGALiDq+EvRuZotZrJqkYkN5282iAfcffjI5lmGG9G1ta/CIVauhY42MBXwEgDJkweiDcDMRLzBZC4g==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.51.tgz",
+      "integrity": "sha512-vBtp//5VVkZWmYYvHsqBRCMMi1MzKuMIn5XDScmnykMTu9+TD9v0NMEDqQxvtFToeYmojdo5UCV2vzMQWJcJ4A==",
       "optional": true
     },
     "esbuild-darwin-64": {
-      "version": "0.14.48",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.48.tgz",
-      "integrity": "sha512-gGQZa4+hab2Va/Zww94YbshLuWteyKGD3+EsVon8EWTWhnHFRm5N9NbALNbwi/7hQ/hM1Zm4FuHg+k6BLsl5UA==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.51.tgz",
+      "integrity": "sha512-YFmXPIOvuagDcwCejMRtCDjgPfnDu+bNeh5FU2Ryi68ADDVlWEpbtpAbrtf/lvFTWPexbgyKgzppNgsmLPr8PA==",
       "optional": true
     },
     "esbuild-darwin-arm64": {
-      "version": "0.14.48",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.48.tgz",
-      "integrity": "sha512-bFjnNEXjhZT+IZ8RvRGNJthLWNHV5JkCtuOFOnjvo5pC0sk2/QVk0Qc06g2PV3J0TcU6kaPC3RN9yy9w2PSLEA==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.51.tgz",
+      "integrity": "sha512-juYD0QnSKwAMfzwKdIF6YbueXzS6N7y4GXPDeDkApz/1RzlT42mvX9jgNmyOlWKN7YzQAYbcUEJmZJYQGdf2ow==",
       "optional": true
     },
     "esbuild-freebsd-64": {
-      "version": "0.14.48",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.48.tgz",
-      "integrity": "sha512-1NOlwRxmOsnPcWOGTB10JKAkYSb2nue0oM1AfHWunW/mv3wERfJmnYlGzL3UAOIUXZqW8GeA2mv+QGwq7DToqA==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.51.tgz",
+      "integrity": "sha512-cLEI/aXjb6vo5O2Y8rvVSQ7smgLldwYY5xMxqh/dQGfWO+R1NJOFsiax3IS4Ng300SVp7Gz3czxT6d6qf2cw0g==",
       "optional": true
     },
     "esbuild-freebsd-arm64": {
-      "version": "0.14.48",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.48.tgz",
-      "integrity": "sha512-gXqKdO8wabVcYtluAbikDH2jhXp+Klq5oCD5qbVyUG6tFiGhrC9oczKq3vIrrtwcxDQqK6+HDYK8Zrd4bCA9Gw==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.51.tgz",
+      "integrity": "sha512-TcWVw/rCL2F+jUgRkgLa3qltd5gzKjIMGhkVybkjk6PJadYInPtgtUBp1/hG+mxyigaT7ib+od1Xb84b+L+1Mg==",
       "optional": true
     },
     "esbuild-linux-32": {
-      "version": "0.14.48",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.48.tgz",
-      "integrity": "sha512-ghGyDfS289z/LReZQUuuKq9KlTiTspxL8SITBFQFAFRA/IkIvDpnZnCAKTCjGXAmUqroMQfKJXMxyjJA69c/nQ==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.51.tgz",
+      "integrity": "sha512-RFqpyC5ChyWrjx8Xj2K0EC1aN0A37H6OJfmUXIASEqJoHcntuV3j2Efr9RNmUhMfNE6yEj2VpYuDteZLGDMr0w==",
       "optional": true
     },
     "esbuild-linux-64": {
-      "version": "0.14.48",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.48.tgz",
-      "integrity": "sha512-vni3p/gppLMVZLghI7oMqbOZdGmLbbKR23XFARKnszCIBpEMEDxOMNIKPmMItQrmH/iJrL1z8Jt2nynY0bE1ug==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.51.tgz",
+      "integrity": "sha512-dxjhrqo5i7Rq6DXwz5v+MEHVs9VNFItJmHBe1CxROWNf4miOGoQhqSG8StStbDkQ1Mtobg6ng+4fwByOhoQoeA==",
       "optional": true
     },
     "esbuild-linux-arm": {
-      "version": "0.14.48",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.48.tgz",
-      "integrity": "sha512-+VfSV7Akh1XUiDNXgqgY1cUP1i2vjI+BmlyXRfVz5AfV3jbpde8JTs5Q9sYgaoq5cWfuKfoZB/QkGOI+QcL1Tw==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.51.tgz",
+      "integrity": "sha512-LsJynDxYF6Neg7ZC7748yweCDD+N8ByCv22/7IAZglIEniEkqdF4HCaa49JNDLw1UQGlYuhOB8ZT/MmcSWzcWg==",
       "optional": true
     },
     "esbuild-linux-arm64": {
-      "version": "0.14.48",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.48.tgz",
-      "integrity": "sha512-3CFsOlpoxlKPRevEHq8aAntgYGYkE1N9yRYAcPyng/p4Wyx0tPR5SBYsxLKcgPB9mR8chHEhtWYz6EZ+H199Zw==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.51.tgz",
+      "integrity": "sha512-D9rFxGutoqQX3xJPxqd6o+kvYKeIbM0ifW2y0bgKk5HPgQQOo2k9/2Vpto3ybGYaFPCE5qTGtqQta9PoP6ZEzw==",
       "optional": true
     },
     "esbuild-linux-mips64le": {
-      "version": "0.14.48",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.48.tgz",
-      "integrity": "sha512-cs0uOiRlPp6ymknDnjajCgvDMSsLw5mST2UXh+ZIrXTj2Ifyf2aAP3Iw4DiqgnyYLV2O/v/yWBJx+WfmKEpNLA==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.51.tgz",
+      "integrity": "sha512-vS54wQjy4IinLSlb5EIlLoln8buh1yDgliP4CuEHumrPk4PvvP4kTRIG4SzMXm6t19N0rIfT4bNdAxzJLg2k6A==",
       "optional": true
     },
     "esbuild-linux-ppc64le": {
-      "version": "0.14.48",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.48.tgz",
-      "integrity": "sha512-+2F0vJMkuI0Wie/wcSPDCqXvSFEELH7Jubxb7mpWrA/4NpT+/byjxDz0gG6R1WJoeDefcrMfpBx4GFNN1JQorQ==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.51.tgz",
+      "integrity": "sha512-xcdd62Y3VfGoyphNP/aIV9LP+RzFw5M5Z7ja+zdpQHHvokJM7d0rlDRMN+iSSwvUymQkqZO+G/xjb4/75du8BQ==",
       "optional": true
     },
     "esbuild-linux-riscv64": {
-      "version": "0.14.48",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.48.tgz",
-      "integrity": "sha512-BmaK/GfEE+5F2/QDrIXteFGKnVHGxlnK9MjdVKMTfvtmudjY3k2t8NtlY4qemKSizc+QwyombGWTBDc76rxePA==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.51.tgz",
+      "integrity": "sha512-syXHGak9wkAnFz0gMmRBoy44JV0rp4kVCEA36P5MCeZcxFq8+fllBC2t6sKI23w3qd8Vwo9pTADCgjTSf3L3rA==",
       "optional": true
     },
     "esbuild-linux-s390x": {
-      "version": "0.14.48",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.48.tgz",
-      "integrity": "sha512-tndw/0B9jiCL+KWKo0TSMaUm5UWBLsfCKVdbfMlb3d5LeV9WbijZ8Ordia8SAYv38VSJWOEt6eDCdOx8LqkC4g==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.51.tgz",
+      "integrity": "sha512-kFAJY3dv+Wq8o28K/C7xkZk/X34rgTwhknSsElIqoEo8armCOjMJ6NsMxm48KaWY2h2RUYGtQmr+RGuUPKBhyw==",
       "optional": true
     },
     "esbuild-netbsd-64": {
-      "version": "0.14.48",
-      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.48.tgz",
-      "integrity": "sha512-V9hgXfwf/T901Lr1wkOfoevtyNkrxmMcRHyticybBUHookznipMOHoF41Al68QBsqBxnITCEpjjd4yAos7z9Tw==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.51.tgz",
+      "integrity": "sha512-ZZBI7qrR1FevdPBVHz/1GSk1x5GDL/iy42Zy8+neEm/HA7ma+hH/bwPEjeHXKWUDvM36CZpSL/fn1/y9/Hb+1A==",
       "optional": true
     },
     "esbuild-openbsd-64": {
-      "version": "0.14.48",
-      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.48.tgz",
-      "integrity": "sha512-+IHf4JcbnnBl4T52egorXMatil/za0awqzg2Vy6FBgPcBpisDWT2sVz/tNdrK9kAqj+GZG/jZdrOkj7wsrNTKA==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.51.tgz",
+      "integrity": "sha512-7R1/p39M+LSVQVgDVlcY1KKm6kFKjERSX1lipMG51NPcspJD1tmiZSmmBXoY5jhHIu6JL1QkFDTx94gMYK6vfA==",
       "optional": true
     },
     "esbuild-sunos-64": {
-      "version": "0.14.48",
-      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.48.tgz",
-      "integrity": "sha512-77m8bsr5wOpOWbGi9KSqDphcq6dFeJyun8TA+12JW/GAjyfTwVtOnN8DOt6DSPUfEV+ltVMNqtXUeTeMAxl5KA==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.51.tgz",
+      "integrity": "sha512-HoHaCswHxLEYN8eBTtyO0bFEWvA3Kdb++hSQ/lLG7TyKF69TeSG0RNoBRAs45x/oCeWaTDntEZlYwAfQlhEtJA==",
       "optional": true
     },
     "esbuild-windows-32": {
-      "version": "0.14.48",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.48.tgz",
-      "integrity": "sha512-EPgRuTPP8vK9maxpTGDe5lSoIBHGKO/AuxDncg5O3NkrPeLNdvvK8oywB0zGaAZXxYWfNNSHskvvDgmfVTguhg==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.51.tgz",
+      "integrity": "sha512-4rtwSAM35A07CBt1/X8RWieDj3ZUHQqUOaEo5ZBs69rt5WAFjP4aqCIobdqOy4FdhYw1yF8Z0xFBTyc9lgPtEg==",
       "optional": true
     },
     "esbuild-windows-64": {
-      "version": "0.14.48",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.48.tgz",
-      "integrity": "sha512-YmpXjdT1q0b8ictSdGwH3M8VCoqPpK1/UArze3X199w6u8hUx3V8BhAi1WjbsfDYRBanVVtduAhh2sirImtAvA==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.51.tgz",
+      "integrity": "sha512-HoN/5HGRXJpWODprGCgKbdMvrC3A2gqvzewu2eECRw2sYxOUoh2TV1tS+G7bHNapPGI79woQJGV6pFH7GH7qnA==",
       "optional": true
     },
     "esbuild-windows-arm64": {
-      "version": "0.14.48",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.48.tgz",
-      "integrity": "sha512-HHaOMCsCXp0rz5BT2crTka6MPWVno121NKApsGs/OIW5QC0ggC69YMGs1aJct9/9FSUF4A1xNE/cLvgB5svR4g==",
+      "version": "0.14.51",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.51.tgz",
+      "integrity": "sha512-JQDqPjuOH7o+BsKMSddMfmVJXrnYZxXDHsoLHc0xgmAZkOOCflRmC43q31pk79F9xuyWY45jDBPolb5ZgGOf9g==",
       "optional": true
     },
     "escalade": {
@@ -1553,9 +1553,9 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "luxon": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-2.4.0.tgz",
-      "integrity": "sha512-w+NAwWOUL5hO0SgwOHsMBAmZ15SoknmQXhSO0hIbJCAmPKSsGeK8MlmhYh2w6Iib38IxN2M+/ooXWLbeis7GuA=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-2.5.0.tgz",
+      "integrity": "sha512-IDkEPB80Rb6gCAU+FEib0t4FeJ4uVOuX1CQ9GsvU3O+JAGIgu0J7sf1OarXKaKDygTZIoJyU6YdZzTFRu+YR0A=="
     },
     "mime": {
       "version": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -30,18 +30,18 @@
     "tabWidth": 4
   },
   "dependencies": {
-    "@octokit/graphql": "^4.8.0",
+    "@octokit/graphql": "^5.0.0",
     "@types/cli-progress": "^3.11.0",
-    "@types/luxon": "^2.3.2",
-    "@types/node": "^18.0.2",
+    "@types/luxon": "^3.0.0",
+    "@types/node": "^18.6.2",
     "@types/yargs": "^17.0.10",
-    "chart.js": "^3.8.0",
+    "chart.js": "^3.8.2",
     "chartjs-adapter-luxon": "^1.1.0",
     "cli-progress": "^3.11.2",
     "dotenv": "^16.0.1",
-    "esbuild": "^0.14.48",
+    "esbuild": "^0.14.51",
     "http-server": "^14.1.1",
-    "luxon": "^2.4.0",
+    "luxon": "^2.5.0",
     "typescript": "^4.7.4",
     "yargs": "^17.5.1"
   }

--- a/src/status_chart.ts
+++ b/src/status_chart.ts
@@ -9,409 +9,409 @@ import { DailyRow, daily_table } from './daily_table';
 import { WeeklyRow, weekly_table } from './weekly_table';
 import { MonthlyRow, monthly_table } from './monthly_table';
 
-type StlDataPoint = {
-    x: string;
-    y: number | null;
-};
-
-function get_values<TimelyRow extends DailyRow | WeeklyRow | MonthlyRow>(
-    table: TimelyRow[],
-    get_y: (row: TimelyRow) => number | null | undefined
-) {
-    const datapoints: StlDataPoint[] = [];
-    for (const row of table) {
-        const y = get_y(row);
-        if (y !== undefined) {
-            datapoints.push({ x: row.date, y: y });
-        }
-    }
-    return datapoints;
-}
-
-function get_daily_values(key: Exclude<keyof DailyRow, 'date'>) {
-    return get_values(daily_table, row => row[key]);
-}
-
-function get_weekly_values(key: Exclude<keyof WeeklyRow, 'date'>) {
-    return get_values(weekly_table, row => row[key]);
-}
-
-function get_monthly_values(key: Exclude<keyof MonthlyRow, 'date'>) {
-    return get_values(monthly_table, row => row[key]);
-}
-
-type AxisID = `${string}Axis`;
-
-type ColorName = `--color-${string}`;
-
-class DatasetInfo {
-    url_key: string;
-    chart_label: string;
-    yAxisID: AxisID;
-    color_name: ColorName;
-    default_hidden: boolean;
-
-    constructor(
-        url_key: string,
-        chart_label: string,
-        yAxisID: AxisID,
-        color_name: ColorName,
-        default_hidden: boolean = false
-    ) {
-        this.url_key = url_key;
-        this.chart_label = chart_label;
-        this.yAxisID = yAxisID;
-        this.color_name = color_name;
-        this.default_hidden = default_hidden;
-    }
-}
-
-class DatasetInfoMaps {
-    static url_key = new Map<string, DatasetInfo>();
-    static chart_label = new Map<string, DatasetInfo>();
-
-    static {
-        const arr = [
-            new DatasetInfo('cxx17', 'C++17 Features', 'smallAxis', '--color-severe-emphasis'),
-            new DatasetInfo('cxx20', 'C++20 Features', 'smallAxis', '--color-sponsors-emphasis'),
-            new DatasetInfo('cxx23', 'C++23 Features', 'smallAxis', '--color-done-emphasis'),
-            new DatasetInfo('lwg', 'LWG Resolutions', 'smallAxis', '--color-success-emphasis'),
-            new DatasetInfo('pr', 'Pull Requests', 'smallAxis', '--color-accent-emphasis'),
-            new DatasetInfo('vso', 'Old Bugs', 'largeAxis', '--color-scale-red-7'),
-            new DatasetInfo('bug', 'GitHub Bugs', 'largeAxis', '--color-danger-emphasis'),
-            new DatasetInfo('issue', 'GitHub Issues', 'largeAxis', '--color-neutral-emphasis'),
-            new DatasetInfo('libcxx', 'Skipped Libcxx Tests', 'largeAxis', '--color-attention-emphasis'),
-
-            new DatasetInfo('avg_age', 'Average Age', 'leftAxis', '--color-neutral-emphasis', true),
-            new DatasetInfo('avg_wait', 'Average Wait', 'leftAxis', '--color-sponsors-emphasis', true),
-            new DatasetInfo('sum_age', 'Combined Age', 'rightAxis', '--color-fg-default'),
-            new DatasetInfo('sum_wait', 'Combined Wait', 'rightAxis', '--color-done-emphasis'),
-
-            new DatasetInfo('merged', 'Line: Sliding Window', 'mergeAxis', '--color-accent-emphasis'),
-            new DatasetInfo('merge_bar', 'Bars: Calendar Months', 'mergeAxis', '--color-border-default'),
-        ];
-
-        for (const elem of arr) {
-            this.url_key.set(elem.url_key, elem);
-            this.chart_label.set(elem.chart_label, elem);
-        }
-    }
-
-    static lookup(field: 'url_key' | 'chart_label', value: string) {
-        const ret = this[field].get(value);
-
-        if (ret === undefined) {
-            throw new Error('DatasetInfoMaps.lookup() should always find the value.');
-        }
-
-        return ret;
-    }
-}
-
-const url_search_params = new URLSearchParams(window.location.search);
-const hide_string = 'n';
-const show_string = 'y';
-
-const css_style_declaration = window.getComputedStyle(document.documentElement);
-
-function get_css_property(property_name: string) {
-    return css_style_declaration.getPropertyValue(property_name);
-}
-
-function get_dataset_properties(url_key: string) {
-    const { chart_label, yAxisID, color_name, default_hidden } = DatasetInfoMaps.lookup('url_key', url_key);
-
-    let hidden: boolean;
-
-    const value = url_search_params.get(url_key);
-
-    if (value === hide_string) {
-        hidden = true;
-    } else if (value === show_string) {
-        hidden = false;
-    } else {
-        hidden = default_hidden;
-    }
-
-    const color = get_css_property(color_name);
-
-    return {
-        label: chart_label,
-        yAxisID: yAxisID,
-        borderColor: color,
-        backgroundColor: color,
-        hidden: hidden,
-    };
-}
-
-function update_url() {
-    let url = window.location.pathname;
-
-    const params_string = `${url_search_params}`;
-
-    if (params_string.length > 0) {
-        url += `?${params_string}`;
-    }
-
-    window.history.replaceState({}, '', url);
-}
-
-const status_data = {
-    datasets: [
-        {
-            data: get_weekly_values('cxx17'),
-            ...get_dataset_properties('cxx17'),
-        },
-        {
-            data: get_weekly_values('cxx20').concat(get_daily_values('cxx20')),
-            ...get_dataset_properties('cxx20'),
-        },
-        {
-            data: get_daily_values('cxx23'),
-            ...get_dataset_properties('cxx23'),
-        },
-        {
-            data: get_weekly_values('lwg').concat(get_daily_values('lwg')),
-            ...get_dataset_properties('lwg'),
-        },
-        {
-            data: get_daily_values('pr'),
-            ...get_dataset_properties('pr'),
-        },
-        {
-            data: get_weekly_values('vso'),
-            ...get_dataset_properties('vso'),
-        },
-        {
-            data: get_daily_values('bug'),
-            ...get_dataset_properties('bug'),
-        },
-        {
-            data: get_daily_values('issue'),
-            ...get_dataset_properties('issue'),
-        },
-        {
-            data: get_weekly_values('libcxx'),
-            ...get_dataset_properties('libcxx'),
-        },
-    ],
-};
-
-const age_data = {
-    datasets: [
-        {
-            data: get_daily_values('avg_age'),
-            ...get_dataset_properties('avg_age'),
-        },
-        {
-            data: get_daily_values('avg_wait'),
-            ...get_dataset_properties('avg_wait'),
-        },
-        {
-            data: get_daily_values('sum_age'),
-            ...get_dataset_properties('sum_age'),
-        },
-        {
-            data: get_daily_values('sum_wait'),
-            ...get_dataset_properties('sum_wait'),
-        },
-    ],
-};
-
-const merge_data = {
-    datasets: [
-        {
-            data: get_daily_values('merged'),
-            ...get_dataset_properties('merged'),
-        },
-        {
-            type: 'bar' as const,
-            data: get_monthly_values('merge_bar'),
-            ...get_dataset_properties('merge_bar'),
-        },
-    ],
-};
-
-type Timeframe = {
-    min: string;
-    time: { unit: TimeUnit };
-};
-
-const timeframe_all: Timeframe = {
-    min: '2017-06-09',
-    time: { unit: 'year' },
-};
-const timeframe_github: Timeframe = {
-    min: '2019-09-20', // first Friday after 2019-09-16
-    time: { unit: 'year' },
-};
-const timeframe_2021: Timeframe = {
-    min: '2021-01-01',
-    time: { unit: 'quarter' },
-};
-const timeframes = [timeframe_all, timeframe_github, timeframe_2021];
-const timeframe_github_idx = 1;
-let timeframe_idx = timeframe_github_idx;
-
-function legend_click_handler(_event: ChartEvent, legend_item: LegendItem, legend: LegendElement<'bar' | 'line'>) {
-    const ch = legend.chart;
-    const index = legend_item.datasetIndex;
-
-    const becoming_hidden = ch.isDatasetVisible(index);
-
-    if (becoming_hidden) {
-        ch.hide(index);
-    } else {
-        ch.show(index);
-    }
-
-    legend_item.hidden = becoming_hidden;
-
-    const { url_key, default_hidden } = DatasetInfoMaps.lookup('chart_label', legend_item.text);
-
-    if (becoming_hidden === default_hidden) {
-        url_search_params.delete(url_key);
-    } else {
-        url_search_params.set(url_key, becoming_hidden ? hide_string : show_string);
-        url_search_params.sort();
-    }
-
-    update_url();
-}
-
-function make_common_options() {
-    return {
-        animation: {
-            duration: 0,
-        },
-        elements: {
-            line: {
-                borderCapStyle: 'round' as const,
-                borderJoinStyle: 'round' as const,
-                fill: false,
-                spanGaps: false,
-            },
-            point: {
-                radius: 0,
-            },
-        },
-        hover: {
-            mode: 'nearest' as const,
-        },
-        plugins: {
-            legend: {
-                display: true,
-                labels: {
-                    color: get_css_property('--color-fg-default'),
-                },
-                onClick: legend_click_handler,
-            },
-            tooltip: {
-                mode: 'nearest' as const,
-                intersect: false,
-            },
-        },
-        onResize: (chart: Chart, size: { width: number; height: number }) => {
-            if (chart.options.plugins?.legend === undefined) {
-                throw new Error('onResize was surprised by chart.options.');
-            }
-            chart.options.plugins.legend.display = size.width > 670;
-        },
-    };
-}
-
-function make_xAxis(timeframe: Timeframe) {
-    return {
-        type: 'time' as const,
-        min: timeframe.min,
-        max: daily_table[daily_table.length - 1].date,
-        grid: {
-            borderColor: get_css_property('--color-border-default'),
-            color: get_css_property('--color-border-default'),
-            offset: false,
-        },
-        offset: false,
-        title: {
-            color: get_css_property('--color-fg-default'),
-        },
-        ticks: {
-            color: get_css_property('--color-fg-default'),
-        },
-        time: {
-            parser: 'yyyy-MM-dd',
-            tooltipFormat: 'MMM d, yyyy',
-            unit: timeframe.time.unit,
-            displayFormats: {
-                quarter: 'MMM yyyy',
-            },
-        },
-    };
-}
-
-function make_yAxis(position: 'left' | 'right', title_text: string, min: number, max: number, stepSize: number) {
-    return {
-        type: 'linear' as const,
-        display: 'auto' as const,
-        position: position,
-        title: {
-            color: get_css_property('--color-fg-default'),
-            display: true,
-            text: title_text,
-        },
-        min: min,
-        max: max,
-        grid: {
-            borderColor: get_css_property('--color-border-default'),
-            color: get_css_property('--color-border-default'),
-        },
-        ticks: {
-            color: get_css_property('--color-fg-default'),
-            stepSize: stepSize,
-        },
-    };
-}
-
-const status_options = {
-    ...make_common_options(),
-    scales: {
-        x: make_xAxis(timeframes[timeframe_idx]),
-        largeAxis: make_yAxis('left', 'Bugs, Issues, Skipped Libcxx Tests', 0, 800, 100),
-        smallAxis: make_yAxis('right', 'Features, LWG Resolutions, Pull Requests', 0, 80, 10),
-    },
-};
-
-const age_options = {
-    ...make_common_options(),
-    scales: {
-        x: make_xAxis(timeframe_github),
-        leftAxis: make_yAxis('left', 'Average Age, Average Wait (days)', 0, 500, 100),
-        rightAxis: make_yAxis('right', 'Combined Age, Combined Wait (PR-months)', 0, 500, 100),
-    },
-};
-
-const merge_options = {
-    ...make_common_options(),
-    scales: {
-        x: make_xAxis(timeframe_github),
-        mergeAxis: make_yAxis('right', 'PRs / month', 0, 80, 10),
-    },
-};
-
-function getElementByIdAs<Type extends HTMLElement>(id: string, type: new () => Type) {
-    const element = document.getElementById(id);
-
-    if (element === null) {
-        throw new Error(`document.getElementById('${id}') returned null.`);
-    }
-
-    if (element instanceof type) {
-        return element as Type;
-    }
-
-    throw new Error(`document.getElementById('${id}') returned an unexpected type.`);
-}
-
 function load_charts() {
+    type StlDataPoint = {
+        x: string;
+        y: number | null;
+    };
+
+    function get_values<TimelyRow extends DailyRow | WeeklyRow | MonthlyRow>(
+        table: TimelyRow[],
+        get_y: (row: TimelyRow) => number | null | undefined
+    ) {
+        const datapoints: StlDataPoint[] = [];
+        for (const row of table) {
+            const y = get_y(row);
+            if (y !== undefined) {
+                datapoints.push({ x: row.date, y: y });
+            }
+        }
+        return datapoints;
+    }
+
+    function get_daily_values(key: Exclude<keyof DailyRow, 'date'>) {
+        return get_values(daily_table, row => row[key]);
+    }
+
+    function get_weekly_values(key: Exclude<keyof WeeklyRow, 'date'>) {
+        return get_values(weekly_table, row => row[key]);
+    }
+
+    function get_monthly_values(key: Exclude<keyof MonthlyRow, 'date'>) {
+        return get_values(monthly_table, row => row[key]);
+    }
+
+    type AxisID = `${string}Axis`;
+
+    type ColorName = `--color-${string}`;
+
+    class DatasetInfo {
+        url_key: string;
+        chart_label: string;
+        yAxisID: AxisID;
+        color_name: ColorName;
+        default_hidden: boolean;
+
+        constructor(
+            url_key: string,
+            chart_label: string,
+            yAxisID: AxisID,
+            color_name: ColorName,
+            default_hidden: boolean = false
+        ) {
+            this.url_key = url_key;
+            this.chart_label = chart_label;
+            this.yAxisID = yAxisID;
+            this.color_name = color_name;
+            this.default_hidden = default_hidden;
+        }
+    }
+
+    class DatasetInfoMaps {
+        static url_key = new Map<string, DatasetInfo>();
+        static chart_label = new Map<string, DatasetInfo>();
+
+        static {
+            const arr = [
+                new DatasetInfo('cxx17', 'C++17 Features', 'smallAxis', '--color-severe-emphasis'),
+                new DatasetInfo('cxx20', 'C++20 Features', 'smallAxis', '--color-sponsors-emphasis'),
+                new DatasetInfo('cxx23', 'C++23 Features', 'smallAxis', '--color-done-emphasis'),
+                new DatasetInfo('lwg', 'LWG Resolutions', 'smallAxis', '--color-success-emphasis'),
+                new DatasetInfo('pr', 'Pull Requests', 'smallAxis', '--color-accent-emphasis'),
+                new DatasetInfo('vso', 'Old Bugs', 'largeAxis', '--color-scale-red-7'),
+                new DatasetInfo('bug', 'GitHub Bugs', 'largeAxis', '--color-danger-emphasis'),
+                new DatasetInfo('issue', 'GitHub Issues', 'largeAxis', '--color-neutral-emphasis'),
+                new DatasetInfo('libcxx', 'Skipped Libcxx Tests', 'largeAxis', '--color-attention-emphasis'),
+
+                new DatasetInfo('avg_age', 'Average Age', 'leftAxis', '--color-neutral-emphasis', true),
+                new DatasetInfo('avg_wait', 'Average Wait', 'leftAxis', '--color-sponsors-emphasis', true),
+                new DatasetInfo('sum_age', 'Combined Age', 'rightAxis', '--color-fg-default'),
+                new DatasetInfo('sum_wait', 'Combined Wait', 'rightAxis', '--color-done-emphasis'),
+
+                new DatasetInfo('merged', 'Line: Sliding Window', 'mergeAxis', '--color-accent-emphasis'),
+                new DatasetInfo('merge_bar', 'Bars: Calendar Months', 'mergeAxis', '--color-border-default'),
+            ];
+
+            for (const elem of arr) {
+                this.url_key.set(elem.url_key, elem);
+                this.chart_label.set(elem.chart_label, elem);
+            }
+        }
+
+        static lookup(field: 'url_key' | 'chart_label', value: string) {
+            const ret = this[field].get(value);
+
+            if (ret === undefined) {
+                throw new Error('DatasetInfoMaps.lookup() should always find the value.');
+            }
+
+            return ret;
+        }
+    }
+
+    const url_search_params = new URLSearchParams(window.location.search);
+    const hide_string = 'n';
+    const show_string = 'y';
+
+    const css_style_declaration = window.getComputedStyle(document.documentElement);
+
+    function get_css_property(property_name: string) {
+        return css_style_declaration.getPropertyValue(property_name);
+    }
+
+    function get_dataset_properties(url_key: string) {
+        const { chart_label, yAxisID, color_name, default_hidden } = DatasetInfoMaps.lookup('url_key', url_key);
+
+        let hidden: boolean;
+
+        const value = url_search_params.get(url_key);
+
+        if (value === hide_string) {
+            hidden = true;
+        } else if (value === show_string) {
+            hidden = false;
+        } else {
+            hidden = default_hidden;
+        }
+
+        const color = get_css_property(color_name);
+
+        return {
+            label: chart_label,
+            yAxisID: yAxisID,
+            borderColor: color,
+            backgroundColor: color,
+            hidden: hidden,
+        };
+    }
+
+    function update_url() {
+        let url = window.location.pathname;
+
+        const params_string = `${url_search_params}`;
+
+        if (params_string.length > 0) {
+            url += `?${params_string}`;
+        }
+
+        window.history.replaceState({}, '', url);
+    }
+
+    const status_data = {
+        datasets: [
+            {
+                data: get_weekly_values('cxx17'),
+                ...get_dataset_properties('cxx17'),
+            },
+            {
+                data: get_weekly_values('cxx20').concat(get_daily_values('cxx20')),
+                ...get_dataset_properties('cxx20'),
+            },
+            {
+                data: get_daily_values('cxx23'),
+                ...get_dataset_properties('cxx23'),
+            },
+            {
+                data: get_weekly_values('lwg').concat(get_daily_values('lwg')),
+                ...get_dataset_properties('lwg'),
+            },
+            {
+                data: get_daily_values('pr'),
+                ...get_dataset_properties('pr'),
+            },
+            {
+                data: get_weekly_values('vso'),
+                ...get_dataset_properties('vso'),
+            },
+            {
+                data: get_daily_values('bug'),
+                ...get_dataset_properties('bug'),
+            },
+            {
+                data: get_daily_values('issue'),
+                ...get_dataset_properties('issue'),
+            },
+            {
+                data: get_weekly_values('libcxx'),
+                ...get_dataset_properties('libcxx'),
+            },
+        ],
+    };
+
+    const age_data = {
+        datasets: [
+            {
+                data: get_daily_values('avg_age'),
+                ...get_dataset_properties('avg_age'),
+            },
+            {
+                data: get_daily_values('avg_wait'),
+                ...get_dataset_properties('avg_wait'),
+            },
+            {
+                data: get_daily_values('sum_age'),
+                ...get_dataset_properties('sum_age'),
+            },
+            {
+                data: get_daily_values('sum_wait'),
+                ...get_dataset_properties('sum_wait'),
+            },
+        ],
+    };
+
+    const merge_data = {
+        datasets: [
+            {
+                data: get_daily_values('merged'),
+                ...get_dataset_properties('merged'),
+            },
+            {
+                type: 'bar' as const,
+                data: get_monthly_values('merge_bar'),
+                ...get_dataset_properties('merge_bar'),
+            },
+        ],
+    };
+
+    type Timeframe = {
+        min: string;
+        time: { unit: TimeUnit };
+    };
+
+    const timeframe_all: Timeframe = {
+        min: '2017-06-09',
+        time: { unit: 'year' },
+    };
+    const timeframe_github: Timeframe = {
+        min: '2019-09-20', // first Friday after 2019-09-16
+        time: { unit: 'year' },
+    };
+    const timeframe_2021: Timeframe = {
+        min: '2021-01-01',
+        time: { unit: 'quarter' },
+    };
+    const timeframes = [timeframe_all, timeframe_github, timeframe_2021];
+    const timeframe_github_idx = 1;
+    let timeframe_idx = timeframe_github_idx;
+
+    function legend_click_handler(_event: ChartEvent, legend_item: LegendItem, legend: LegendElement<'bar' | 'line'>) {
+        const ch = legend.chart;
+        const index = legend_item.datasetIndex;
+
+        const becoming_hidden = ch.isDatasetVisible(index);
+
+        if (becoming_hidden) {
+            ch.hide(index);
+        } else {
+            ch.show(index);
+        }
+
+        legend_item.hidden = becoming_hidden;
+
+        const { url_key, default_hidden } = DatasetInfoMaps.lookup('chart_label', legend_item.text);
+
+        if (becoming_hidden === default_hidden) {
+            url_search_params.delete(url_key);
+        } else {
+            url_search_params.set(url_key, becoming_hidden ? hide_string : show_string);
+            url_search_params.sort();
+        }
+
+        update_url();
+    }
+
+    function make_common_options() {
+        return {
+            animation: {
+                duration: 0,
+            },
+            elements: {
+                line: {
+                    borderCapStyle: 'round' as const,
+                    borderJoinStyle: 'round' as const,
+                    fill: false,
+                    spanGaps: false,
+                },
+                point: {
+                    radius: 0,
+                },
+            },
+            hover: {
+                mode: 'nearest' as const,
+            },
+            plugins: {
+                legend: {
+                    display: true,
+                    labels: {
+                        color: get_css_property('--color-fg-default'),
+                    },
+                    onClick: legend_click_handler,
+                },
+                tooltip: {
+                    mode: 'nearest' as const,
+                    intersect: false,
+                },
+            },
+            onResize: (chart: Chart, size: { width: number; height: number }) => {
+                if (chart.options.plugins?.legend === undefined) {
+                    throw new Error('onResize was surprised by chart.options.');
+                }
+                chart.options.plugins.legend.display = size.width > 670;
+            },
+        };
+    }
+
+    function make_xAxis(timeframe: Timeframe) {
+        return {
+            type: 'time' as const,
+            min: timeframe.min,
+            max: daily_table[daily_table.length - 1].date,
+            grid: {
+                borderColor: get_css_property('--color-border-default'),
+                color: get_css_property('--color-border-default'),
+                offset: false,
+            },
+            offset: false,
+            title: {
+                color: get_css_property('--color-fg-default'),
+            },
+            ticks: {
+                color: get_css_property('--color-fg-default'),
+            },
+            time: {
+                parser: 'yyyy-MM-dd',
+                tooltipFormat: 'MMM d, yyyy',
+                unit: timeframe.time.unit,
+                displayFormats: {
+                    quarter: 'MMM yyyy',
+                },
+            },
+        };
+    }
+
+    function make_yAxis(position: 'left' | 'right', title_text: string, min: number, max: number, stepSize: number) {
+        return {
+            type: 'linear' as const,
+            display: 'auto' as const,
+            position: position,
+            title: {
+                color: get_css_property('--color-fg-default'),
+                display: true,
+                text: title_text,
+            },
+            min: min,
+            max: max,
+            grid: {
+                borderColor: get_css_property('--color-border-default'),
+                color: get_css_property('--color-border-default'),
+            },
+            ticks: {
+                color: get_css_property('--color-fg-default'),
+                stepSize: stepSize,
+            },
+        };
+    }
+
+    const status_options = {
+        ...make_common_options(),
+        scales: {
+            x: make_xAxis(timeframes[timeframe_idx]),
+            largeAxis: make_yAxis('left', 'Bugs, Issues, Skipped Libcxx Tests', 0, 800, 100),
+            smallAxis: make_yAxis('right', 'Features, LWG Resolutions, Pull Requests', 0, 80, 10),
+        },
+    };
+
+    const age_options = {
+        ...make_common_options(),
+        scales: {
+            x: make_xAxis(timeframe_github),
+            leftAxis: make_yAxis('left', 'Average Age, Average Wait (days)', 0, 500, 100),
+            rightAxis: make_yAxis('right', 'Combined Age, Combined Wait (PR-months)', 0, 500, 100),
+        },
+    };
+
+    const merge_options = {
+        ...make_common_options(),
+        scales: {
+            x: make_xAxis(timeframe_github),
+            mergeAxis: make_yAxis('right', 'PRs / month', 0, 80, 10),
+        },
+    };
+
+    function getElementByIdAs<Type extends HTMLElement>(id: string, type: new () => Type) {
+        const element = document.getElementById(id);
+
+        if (element === null) {
+            throw new Error(`document.getElementById('${id}') returned null.`);
+        }
+
+        if (element instanceof type) {
+            return element as Type;
+        }
+
+        throw new Error(`document.getElementById('${id}') returned an unexpected type.`);
+    }
+
     const status_chart = new Chart('statusChart', {
         type: 'line',
         data: status_data,
@@ -540,4 +540,4 @@ function load_charts() {
     }
 }
 
-load_charts();
+window.addEventListener('load', _event => load_charts()); // wait for stylesheets to finish loading

--- a/src/status_chart.ts
+++ b/src/status_chart.ts
@@ -258,6 +258,10 @@ function load_charts() {
         const ch = legend.chart;
         const index = legend_item.datasetIndex;
 
+        if (index === undefined) {
+            throw new Error('legend_click_handler() was surprised by legend_item.datasetIndex.');
+        }
+
         const becoming_hidden = ch.isDatasetVisible(index);
 
         if (becoming_hidden) {

--- a/src/weekly_table.ts
+++ b/src/weekly_table.ts
@@ -274,4 +274,8 @@ export const weekly_table: WeeklyRow[] = [
     { date: '2022-06-17', vso: 173, libcxx: 614 },
     { date: '2022-06-24', vso: 177, libcxx: 614 },
     { date: '2022-07-01', vso: 175, libcxx: 614 },
+    { date: '2022-07-08', vso: 174, libcxx: 614 },
+    { date: '2022-07-15', vso: 173, libcxx: 581 },
+    { date: '2022-07-22', vso: 172, libcxx: 581 },
+    { date: '2022-07-29', vso: 174, libcxx: 584 },
 ];


### PR DESCRIPTION
Fixes #2963.

* Weekly updates.
* Update dependencies:
  + es-module-shims 1.5.9.
  + Primer CSS 20.4.0.
  + luxon 2.5.0.
    - Not 3.x yet - https://github.com/chartjs/chartjs-adapter-luxon/issues/61 has been fixed, but we need a new release.
  + chart.js 3.8.2.
* Ensure that we have `legend_item.datasetIndex`.
  - This reacts to a breaking change in chart.js 3.8.1 caused by https://github.com/chartjs/Chart.js/pull/10436.
* Wait for stylesheets to finish loading.
  - Ignore whitespace when reviewing.

As usual, this contains a "DROP BEFORE MERGING: Regen `built/status_chart.mjs`." commit to make the live preview work.

:chart_with_downwards_trend: Live preview: [stephantlavavej.github.io/STL/](https://stephantlavavej.github.io/STL/)
===