### PR TITLE
`<variant>`: Make `visit<R>` correctly handle conversions to non-movable types

### DIFF
--- a/stl/inc/variant
+++ b/stl/inc/variant
@@ -35,8 +35,8 @@ template <class _First, class... _Rest>
 struct _All_same<_First, _Rest...> : bool_constant<conjunction_v<is_same<_First, _Rest>...>> {}; // variadic is_same
 
 template <class _To, class... _From>
-struct _Convertible_from_all : bool_constant<conjunction_v<is_convertible<_From, _To>...>> {
-    // variadic is_convertible
+struct _Convertible_from_all : bool_constant<conjunction_v<_Invoke_convertible<_From, _To>...>> {
+    // variadic _Invoke_convertible
 };
 
 template <class...>

--- a/tests/std/tests/P0088R3_variant/test.cpp
+++ b/tests/std/tests/P0088R3_variant/test.cpp
@@ -6971,6 +6971,23 @@ namespace msvc {
                 using R = immobile_data;
                 assert(std::visit<R>(std::identity{}, std::variant<int, short>{13}).x == 13);
                 assert(std::visit<R>(std::identity{}, std::variant<int, short>{short{42}}).x == 42);
+
+                // Verify that conversions to an object is not copied/moved are correctly handeled
+                struct convertible_to_immobile_one {
+                     operator immobile_data() const {
+                         return immobile_data{1729};
+                     }
+                };
+
+                struct convertible_to_immobile_other {
+                     operator immobile_data() const {
+                         return immobile_data{1138};
+                     }
+                };
+
+                using VarTestConv = std::variant<convertible_to_immobile_one, convertible_to_immobile_other>;
+                assert(std::visit<R>(std::identity{}, VarTestConv{convertible_to_immobile_one{}}).x == 1729);
+                assert(std::visit<R>(std::identity{}, VarTestConv{convertible_to_immobile_other{}}).x == 1138);
             }
             {
                 // Verify that a returned object is not copied/moved/modified

--- a/tests/std/tests/P0088R3_variant/test.cpp
+++ b/tests/std/tests/P0088R3_variant/test.cpp
@@ -6986,9 +6986,10 @@ namespace msvc {
                 };
 
                 using VarTestConv = std::variant<convertible_to_immobile_one, convertible_to_immobile_other>;
-                // TRANSITION, DevCom-10024578
-                // assert(std::visit<R>(std::identity{}, VarTestConv{convertible_to_immobile_one{}}).x == 1729);
-                // assert(std::visit<R>(std::identity{}, VarTestConv{convertible_to_immobile_other{}}).x == 1138);
+#if defined(__clang__) || defined(__EDG__) // TRANSITION, DevCom-10111923
+                assert(std::visit<R>(std::identity{}, VarTestConv{convertible_to_immobile_one{}}).x == 1729);
+                assert(std::visit<R>(std::identity{}, VarTestConv{convertible_to_immobile_other{}}).x == 1138);
+#endif // TRANSITION, DevCom-10111923
                 auto immobile_converter = [](auto src) -> immobile_data { return src; };
                 assert(std::visit<R>(immobile_converter, VarTestConv{convertible_to_immobile_one{}}).x == 1729);
                 assert(std::visit<R>(immobile_converter, VarTestConv{convertible_to_immobile_other{}}).x == 1138);

--- a/tests/std/tests/P0088R3_variant/test.cpp
+++ b/tests/std/tests/P0088R3_variant/test.cpp
@@ -6972,7 +6972,7 @@ namespace msvc {
                 assert(std::visit<R>(std::identity{}, std::variant<int, short>{13}).x == 13);
                 assert(std::visit<R>(std::identity{}, std::variant<int, short>{short{42}}).x == 42);
 
-                // Verify that conversions to an object is not copied/moved are correctly handeled
+                // Verify that conversions to an object that can't be copied/moved are correctly handled
                 struct convertible_to_immobile_one {
                     operator immobile_data() const {
                         return immobile_data{1729};

--- a/tests/std/tests/P0088R3_variant/test.cpp
+++ b/tests/std/tests/P0088R3_variant/test.cpp
@@ -6986,10 +6986,10 @@ namespace msvc {
                 };
 
                 using VarTestConv = std::variant<convertible_to_immobile_one, convertible_to_immobile_other>;
-#if defined(__clang__) || defined(__EDG__) // TRANSITION, DevCom-10111923
+#if defined(__clang__) || defined(__EDG__) // TRANSITION, DevCom-10112408
                 assert(std::visit<R>(std::identity{}, VarTestConv{convertible_to_immobile_one{}}).x == 1729);
                 assert(std::visit<R>(std::identity{}, VarTestConv{convertible_to_immobile_other{}}).x == 1138);
-#endif // TRANSITION, DevCom-10111923
+#endif // TRANSITION, DevCom-10112408
                 auto immobile_converter = [](auto src) -> immobile_data { return src; };
                 assert(std::visit<R>(immobile_converter, VarTestConv{convertible_to_immobile_one{}}).x == 1729);
                 assert(std::visit<R>(immobile_converter, VarTestConv{convertible_to_immobile_other{}}).x == 1138);

--- a/tests/std/tests/P0088R3_variant/test.cpp
+++ b/tests/std/tests/P0088R3_variant/test.cpp
@@ -6986,8 +6986,12 @@ namespace msvc {
                 };
 
                 using VarTestConv = std::variant<convertible_to_immobile_one, convertible_to_immobile_other>;
-                assert(std::visit<R>(std::identity{}, VarTestConv{convertible_to_immobile_one{}}).x == 1729);
-                assert(std::visit<R>(std::identity{}, VarTestConv{convertible_to_immobile_other{}}).x == 1138);
+                // TRANSITION, DevCom-10024578
+                // assert(std::visit<R>(std::identity{}, VarTestConv{convertible_to_immobile_one{}}).x == 1729);
+                // assert(std::visit<R>(std::identity{}, VarTestConv{convertible_to_immobile_other{}}).x == 1138);
+                auto immobile_converter = [](auto src) -> immobile_data { return src; };
+                assert(std::visit<R>(immobile_converter, VarTestConv{convertible_to_immobile_one{}}).x == 1729);
+                assert(std::visit<R>(immobile_converter, VarTestConv{convertible_to_immobile_other{}}).x == 1138);
             }
             {
                 // Verify that a returned object is not copied/moved/modified

--- a/tests/std/tests/P0088R3_variant/test.cpp
+++ b/tests/std/tests/P0088R3_variant/test.cpp
@@ -6974,15 +6974,15 @@ namespace msvc {
 
                 // Verify that conversions to an object is not copied/moved are correctly handeled
                 struct convertible_to_immobile_one {
-                     operator immobile_data() const {
-                         return immobile_data{1729};
-                     }
+                    operator immobile_data() const {
+                        return immobile_data{1729};
+                    }
                 };
 
                 struct convertible_to_immobile_other {
-                     operator immobile_data() const {
-                         return immobile_data{1138};
-                     }
+                    operator immobile_data() const {
+                        return immobile_data{1138};
+                    }
                 };
 
                 using VarTestConv = std::variant<convertible_to_immobile_one, convertible_to_immobile_other>;


### PR DESCRIPTION
Fixes #2970.

`std::visit<R>` may need similar strategy to `std::is_invocable_r` to handle conversions to non-movable types.