### PR TITLE
Implement P2445R1 `forward_like()`

### DIFF
--- a/stl/inc/__msvc_iter_core.hpp
+++ b/stl/inc/__msvc_iter_core.hpp
@@ -33,14 +33,6 @@ struct random_access_iterator_tag : bidirectional_iterator_tag {};
 struct contiguous_iterator_tag : random_access_iterator_tag {};
 
 template <class _Ty>
-using _With_reference = _Ty&;
-
-template <class _Ty>
-concept _Can_reference = requires {
-    typename _With_reference<_Ty>;
-};
-
-template <class _Ty>
 concept _Dereferenceable = requires(_Ty& __t) {
     { *__t } -> _Can_reference;
 };

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -788,6 +788,22 @@ _NODISCARD constexpr bool in_range(const _Ty _Value) noexcept {
 
     return true;
 }
+
+#ifdef __cpp_lib_concepts
+template <class _Ty>
+using _With_reference = _Ty&;
+
+template <class _Ty>
+concept _Can_reference = requires {
+    typename _With_reference<_Ty>;
+};
+#else
+template <class _Ty, class = void>
+inline constexpr bool _Can_reference = false;
+
+template <class _Ty>
+inline constexpr bool _Can_reference<_Ty, void_t<_Ty&>> = true;
+#endif // __cpp_lib_concepts
 #endif // _HAS_CXX20
 
 #if _HAS_CXX23
@@ -801,6 +817,27 @@ _NODISCARD constexpr underlying_type_t<_Ty> to_underlying(_Ty _Value) noexcept {
 #ifdef _DEBUG
     _CSTD abort(); // likely to be called in debug mode, but can't be relied upon - already entered the UB territory
 #endif // _DEBUG
+}
+
+template <class _Ty, class _Uty>
+constexpr auto&& forward_like(_Uty&& _Ux) noexcept {
+    static_assert(_Can_reference<_Ty>,
+        "The first template parameter of std::forward_like must be a referenceable type.");
+
+    if constexpr (is_lvalue_reference_v<_Ty>) {
+        if constexpr (is_const_v<remove_reference_t<_Ty>>) {
+            return static_cast<const _Uty&>(_Ux);
+        } else {
+            return static_cast<_Uty&>(_Ux);
+        }
+    } else {
+        using _UnrefU = remove_reference_t<_Uty>;
+        if constexpr (is_const_v<remove_reference_t<_Ty>>) {
+            return static_cast<const _UnrefU&&>(_Ux);
+        } else {
+            return static_cast<_UnrefU&&>(_Ux);
+        }
+    }
 }
 #endif // _HAS_CXX23
 

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -821,8 +821,8 @@ _NODISCARD constexpr underlying_type_t<_Ty> to_underlying(_Ty _Value) noexcept {
 
 template <class _Ty, class _Uty>
 constexpr auto&& forward_like(_Uty&& _Ux) noexcept {
-    static_assert(_Can_reference<_Ty>,
-        "The first template parameter of std::forward_like must be a referenceable type.");
+    static_assert(
+        _Can_reference<_Ty>, "The first template parameter of std::forward_like must be a referenceable type.");
 
     using _UnrefU = remove_reference_t<_Uty>;
     if constexpr (is_lvalue_reference_v<_Ty>) {

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -823,16 +823,17 @@ template <class _Ty, class _Uty>
 _NODISCARD constexpr auto&& forward_like(_Uty&& _Ux) noexcept {
     static_assert(_Can_reference<_Ty>, "std::forward_like's first template argument must be a referenceable type.");
 
+    using _UnrefT = remove_reference_t<_Ty>;
     using _UnrefU = remove_reference_t<_Uty>;
-    if constexpr (is_lvalue_reference_v<_Ty>) {
-        if constexpr (is_const_v<remove_reference_t<_Ty>>) {
+    if constexpr (is_const_v<_UnrefT>) {
+        if constexpr (is_lvalue_reference_v<_Ty>) {
             return static_cast<const _UnrefU&>(_Ux);
         } else {
-            return static_cast<_UnrefU&>(_Ux);
+            return static_cast<const _UnrefU&&>(_Ux);
         }
     } else {
-        if constexpr (is_const_v<remove_reference_t<_Ty>>) {
-            return static_cast<const _UnrefU&&>(_Ux);
+        if constexpr (is_lvalue_reference_v<_Ty>) {
+            return static_cast<_UnrefU&>(_Ux);
         } else {
             return static_cast<_UnrefU&&>(_Ux);
         }

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -820,9 +820,8 @@ _NODISCARD constexpr underlying_type_t<_Ty> to_underlying(_Ty _Value) noexcept {
 }
 
 template <class _Ty, class _Uty>
-constexpr auto&& forward_like(_Uty&& _Ux) noexcept {
-    static_assert(
-        _Can_reference<_Ty>, "The first template parameter of std::forward_like must be a referenceable type.");
+_NODISCARD constexpr auto&& forward_like(_Uty&& _Ux) noexcept {
+    static_assert(_Can_reference<_Ty>, "std::forward_like's first template argument must be a referenceable type.");
 
     using _UnrefU = remove_reference_t<_Uty>;
     if constexpr (is_lvalue_reference_v<_Ty>) {

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -824,14 +824,14 @@ constexpr auto&& forward_like(_Uty&& _Ux) noexcept {
     static_assert(_Can_reference<_Ty>,
         "The first template parameter of std::forward_like must be a referenceable type.");
 
+    using _UnrefU = remove_reference_t<_Uty>;
     if constexpr (is_lvalue_reference_v<_Ty>) {
         if constexpr (is_const_v<remove_reference_t<_Ty>>) {
-            return static_cast<const _Uty&>(_Ux);
+            return static_cast<const _UnrefU&>(_Ux);
         } else {
-            return static_cast<_Uty&>(_Ux);
+            return static_cast<_UnrefU&>(_Ux);
         }
     } else {
-        using _UnrefU = remove_reference_t<_Uty>;
         if constexpr (is_const_v<remove_reference_t<_Ty>>) {
             return static_cast<const _UnrefU&&>(_Ux);
         } else {

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -797,7 +797,7 @@ template <class _Ty>
 concept _Can_reference = requires {
     typename _With_reference<_Ty>;
 };
-#else
+#else // __cpp_lib_concepts
 template <class _Ty, class = void>
 inline constexpr bool _Can_reference = false;
 

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -316,6 +316,7 @@
 // P2441R2 views::join_with
 // P2442R1 Windowing Range Adaptors: views::chunk, views::slide
 // P2443R1 views::chunk_by
+// P2445R1 forward_like()
 // P2499R0 string_view Range Constructor Should Be explicit
 // P2549R0 unexpected<E>::error()
 
@@ -1462,6 +1463,7 @@
 #define __cpp_lib_expected 202202L
 #endif // __cpp_lib_concepts
 
+#define __cpp_lib_forward_like       202207L
 #define __cpp_lib_invoke_r           202106L
 #define __cpp_lib_is_scoped_enum     202011L
 #define __cpp_lib_move_only_function 202110L

--- a/tests/std/test.lst
+++ b/tests/std/test.lst
@@ -500,6 +500,7 @@ tests\P2442R1_views_chunk_death
 tests\P2442R1_views_slide
 tests\P2443R1_views_chunk_by
 tests\P2443R1_views_chunk_by_death
+tests\P2445R1_forward_like
 tests\VSO_0000000_allocator_propagation
 tests\VSO_0000000_any_calling_conventions
 tests\VSO_0000000_c_math_functions

--- a/tests/std/tests/P2445R1_forward_like/env.lst
+++ b/tests/std/tests/P2445R1_forward_like/env.lst
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+RUNALL_INCLUDE ..\usual_latest_matrix.lst

--- a/tests/std/tests/P2445R1_forward_like/test.compile.pass.cpp
+++ b/tests/std/tests/P2445R1_forward_like/test.compile.pass.cpp
@@ -11,49 +11,49 @@ using CU = const U;
 using T  = int;
 using CT = const T;
 
-U t{};
-const U& ct = t;
+U u{};
+const U& cu = u;
 
 static_assert(is_same_v<decltype(forward_like<T>(U{})), U&&>);
 static_assert(is_same_v<decltype(forward_like<T>(CU{})), CU&&>);
-static_assert(is_same_v<decltype(forward_like<T>(t)), U&&>);
-static_assert(is_same_v<decltype(forward_like<T>(ct)), CU&&>);
-static_assert(is_same_v<decltype(forward_like<T>(move(t))), U&&>);
-static_assert(is_same_v<decltype(forward_like<T>(move(ct))), CU&&>);
+static_assert(is_same_v<decltype(forward_like<T>(u)), U&&>);
+static_assert(is_same_v<decltype(forward_like<T>(cu)), CU&&>);
+static_assert(is_same_v<decltype(forward_like<T>(move(u))), U&&>);
+static_assert(is_same_v<decltype(forward_like<T>(move(cu))), CU&&>);
 
 static_assert(is_same_v<decltype(forward_like<CT>(U{})), CU&&>);
 static_assert(is_same_v<decltype(forward_like<CT>(CU{})), CU&&>);
-static_assert(is_same_v<decltype(forward_like<CT>(t)), CU&&>);
-static_assert(is_same_v<decltype(forward_like<CT>(ct)), CU&&>);
-static_assert(is_same_v<decltype(forward_like<CT>(move(t))), CU&&>);
-static_assert(is_same_v<decltype(forward_like<CT>(move(ct))), CU&&>);
+static_assert(is_same_v<decltype(forward_like<CT>(u)), CU&&>);
+static_assert(is_same_v<decltype(forward_like<CT>(cu)), CU&&>);
+static_assert(is_same_v<decltype(forward_like<CT>(move(u))), CU&&>);
+static_assert(is_same_v<decltype(forward_like<CT>(move(cu))), CU&&>);
 
 static_assert(is_same_v<decltype(forward_like<T&>(U{})), U&>);
 static_assert(is_same_v<decltype(forward_like<T&>(CU{})), CU&>);
-static_assert(is_same_v<decltype(forward_like<T&>(t)), U&>);
-static_assert(is_same_v<decltype(forward_like<T&>(ct)), CU&>);
-static_assert(is_same_v<decltype(forward_like<T&>(move(t))), U&>);
-static_assert(is_same_v<decltype(forward_like<T&>(move(ct))), CU&>);
+static_assert(is_same_v<decltype(forward_like<T&>(u)), U&>);
+static_assert(is_same_v<decltype(forward_like<T&>(cu)), CU&>);
+static_assert(is_same_v<decltype(forward_like<T&>(move(u))), U&>);
+static_assert(is_same_v<decltype(forward_like<T&>(move(cu))), CU&>);
 
 static_assert(is_same_v<decltype(forward_like<CT&>(U{})), CU&>);
 static_assert(is_same_v<decltype(forward_like<CT&>(CU{})), CU&>);
-static_assert(is_same_v<decltype(forward_like<CT&>(t)), CU&>);
-static_assert(is_same_v<decltype(forward_like<CT&>(ct)), CU&>);
-static_assert(is_same_v<decltype(forward_like<CT&>(move(t))), CU&>);
-static_assert(is_same_v<decltype(forward_like<CT&>(move(ct))), CU&>);
+static_assert(is_same_v<decltype(forward_like<CT&>(u)), CU&>);
+static_assert(is_same_v<decltype(forward_like<CT&>(cu)), CU&>);
+static_assert(is_same_v<decltype(forward_like<CT&>(move(u))), CU&>);
+static_assert(is_same_v<decltype(forward_like<CT&>(move(cu))), CU&>);
 
 static_assert(is_same_v<decltype(forward_like<T&&>(U{})), U&&>);
 static_assert(is_same_v<decltype(forward_like<T&&>(CU{})), CU&&>);
-static_assert(is_same_v<decltype(forward_like<T&&>(t)), U&&>);
-static_assert(is_same_v<decltype(forward_like<T&&>(ct)), CU&&>);
-static_assert(is_same_v<decltype(forward_like<T&&>(move(t))), U&&>);
-static_assert(is_same_v<decltype(forward_like<T&&>(move(ct))), CU&&>);
+static_assert(is_same_v<decltype(forward_like<T&&>(u)), U&&>);
+static_assert(is_same_v<decltype(forward_like<T&&>(cu)), CU&&>);
+static_assert(is_same_v<decltype(forward_like<T&&>(move(u))), U&&>);
+static_assert(is_same_v<decltype(forward_like<T&&>(move(cu))), CU&&>);
 
 static_assert(is_same_v<decltype(forward_like<CT&&>(U{})), CU&&>);
 static_assert(is_same_v<decltype(forward_like<CT&&>(CU{})), CU&&>);
-static_assert(is_same_v<decltype(forward_like<CT&&>(t)), CU&&>);
-static_assert(is_same_v<decltype(forward_like<CT&&>(ct)), CU&&>);
-static_assert(is_same_v<decltype(forward_like<CT&&>(move(t))), CU&&>);
-static_assert(is_same_v<decltype(forward_like<CT&&>(move(ct))), CU&&>);
+static_assert(is_same_v<decltype(forward_like<CT&&>(u)), CU&&>);
+static_assert(is_same_v<decltype(forward_like<CT&&>(cu)), CU&&>);
+static_assert(is_same_v<decltype(forward_like<CT&&>(move(u))), CU&&>);
+static_assert(is_same_v<decltype(forward_like<CT&&>(move(cu))), CU&&>);
 
 int main() {} // COMPILE-ONLY

--- a/tests/std/tests/P2445R1_forward_like/test.compile.pass.cpp
+++ b/tests/std/tests/P2445R1_forward_like/test.compile.pass.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include <cassert>
 #include <type_traits>
 #include <utility>
 
@@ -55,5 +56,17 @@ static_assert(is_same_v<decltype(forward_like<CT&&>(u)), CU&&>);
 static_assert(is_same_v<decltype(forward_like<CT&&>(cu)), CU&&>);
 static_assert(is_same_v<decltype(forward_like<CT&&>(move(u))), CU&&>);
 static_assert(is_same_v<decltype(forward_like<CT&&>(move(cu))), CU&&>);
+
+static_assert(noexcept(forward_like<T>(u)));
+
+constexpr bool test() {
+    int val       = 1729;
+    auto&& result = forward_like<const double&>(val);
+    static_assert(is_same_v<decltype(result), const int&>);
+    assert(&result == &val);
+    return true;
+}
+
+static_assert(test());
 
 int main() {} // COMPILE-ONLY

--- a/tests/std/tests/P2445R1_forward_like/test.compile.pass.cpp
+++ b/tests/std/tests/P2445R1_forward_like/test.compile.pass.cpp
@@ -6,54 +6,54 @@
 
 using namespace std;
 
-struct T {}; // class type so const-qualification is not stripped from a prvalue
-using CT = const T;
-using U  = int;
+struct U {}; // class type so const-qualification is not stripped from a prvalue
 using CU = const U;
+using T  = int;
+using CT = const T;
 
-T t{};
-const T& ct = t;
+U t{};
+const U& ct = t;
 
-static_assert(is_same_v<decltype(forward_like<U>(T{})), T&&>);
-static_assert(is_same_v<decltype(forward_like<U>(CT{})), CT&&>);
-static_assert(is_same_v<decltype(forward_like<U>(t)), T&&>);
-static_assert(is_same_v<decltype(forward_like<U>(ct)), CT&&>);
-static_assert(is_same_v<decltype(forward_like<U>(move(t))), T&&>);
-static_assert(is_same_v<decltype(forward_like<U>(move(ct))), CT&&>);
+static_assert(is_same_v<decltype(forward_like<T>(U{})), U&&>);
+static_assert(is_same_v<decltype(forward_like<T>(CU{})), CU&&>);
+static_assert(is_same_v<decltype(forward_like<T>(t)), U&&>);
+static_assert(is_same_v<decltype(forward_like<T>(ct)), CU&&>);
+static_assert(is_same_v<decltype(forward_like<T>(move(t))), U&&>);
+static_assert(is_same_v<decltype(forward_like<T>(move(ct))), CU&&>);
 
-static_assert(is_same_v<decltype(forward_like<CU>(T{})), CT&&>);
-static_assert(is_same_v<decltype(forward_like<CU>(CT{})), CT&&>);
-static_assert(is_same_v<decltype(forward_like<CU>(t)), CT&&>);
-static_assert(is_same_v<decltype(forward_like<CU>(ct)), CT&&>);
-static_assert(is_same_v<decltype(forward_like<CU>(move(t))), CT&&>);
-static_assert(is_same_v<decltype(forward_like<CU>(move(ct))), CT&&>);
+static_assert(is_same_v<decltype(forward_like<CT>(U{})), CU&&>);
+static_assert(is_same_v<decltype(forward_like<CT>(CU{})), CU&&>);
+static_assert(is_same_v<decltype(forward_like<CT>(t)), CU&&>);
+static_assert(is_same_v<decltype(forward_like<CT>(ct)), CU&&>);
+static_assert(is_same_v<decltype(forward_like<CT>(move(t))), CU&&>);
+static_assert(is_same_v<decltype(forward_like<CT>(move(ct))), CU&&>);
 
-static_assert(is_same_v<decltype(forward_like<U&>(T{})), T&>);
-static_assert(is_same_v<decltype(forward_like<U&>(CT{})), CT&>);
-static_assert(is_same_v<decltype(forward_like<U&>(t)), T&>);
-static_assert(is_same_v<decltype(forward_like<U&>(ct)), CT&>);
-static_assert(is_same_v<decltype(forward_like<U&>(move(t))), T&>);
-static_assert(is_same_v<decltype(forward_like<U&>(move(ct))), CT&>);
+static_assert(is_same_v<decltype(forward_like<T&>(U{})), U&>);
+static_assert(is_same_v<decltype(forward_like<T&>(CU{})), CU&>);
+static_assert(is_same_v<decltype(forward_like<T&>(t)), U&>);
+static_assert(is_same_v<decltype(forward_like<T&>(ct)), CU&>);
+static_assert(is_same_v<decltype(forward_like<T&>(move(t))), U&>);
+static_assert(is_same_v<decltype(forward_like<T&>(move(ct))), CU&>);
 
-static_assert(is_same_v<decltype(forward_like<CU&>(T{})), CT&>);
-static_assert(is_same_v<decltype(forward_like<CU&>(CT{})), CT&>);
-static_assert(is_same_v<decltype(forward_like<CU&>(t)), CT&>);
-static_assert(is_same_v<decltype(forward_like<CU&>(ct)), CT&>);
-static_assert(is_same_v<decltype(forward_like<CU&>(move(t))), CT&>);
-static_assert(is_same_v<decltype(forward_like<CU&>(move(ct))), CT&>);
+static_assert(is_same_v<decltype(forward_like<CT&>(U{})), CU&>);
+static_assert(is_same_v<decltype(forward_like<CT&>(CU{})), CU&>);
+static_assert(is_same_v<decltype(forward_like<CT&>(t)), CU&>);
+static_assert(is_same_v<decltype(forward_like<CT&>(ct)), CU&>);
+static_assert(is_same_v<decltype(forward_like<CT&>(move(t))), CU&>);
+static_assert(is_same_v<decltype(forward_like<CT&>(move(ct))), CU&>);
 
-static_assert(is_same_v<decltype(forward_like<U&&>(T{})), T&&>);
-static_assert(is_same_v<decltype(forward_like<U&&>(CT{})), CT&&>);
-static_assert(is_same_v<decltype(forward_like<U&&>(t)), T&&>);
-static_assert(is_same_v<decltype(forward_like<U&&>(ct)), CT&&>);
-static_assert(is_same_v<decltype(forward_like<U&&>(move(t))), T&&>);
-static_assert(is_same_v<decltype(forward_like<U&&>(move(ct))), CT&&>);
+static_assert(is_same_v<decltype(forward_like<T&&>(U{})), U&&>);
+static_assert(is_same_v<decltype(forward_like<T&&>(CU{})), CU&&>);
+static_assert(is_same_v<decltype(forward_like<T&&>(t)), U&&>);
+static_assert(is_same_v<decltype(forward_like<T&&>(ct)), CU&&>);
+static_assert(is_same_v<decltype(forward_like<T&&>(move(t))), U&&>);
+static_assert(is_same_v<decltype(forward_like<T&&>(move(ct))), CU&&>);
 
-static_assert(is_same_v<decltype(forward_like<CU&&>(T{})), CT&&>);
-static_assert(is_same_v<decltype(forward_like<CU&&>(CT{})), CT&&>);
-static_assert(is_same_v<decltype(forward_like<CU&&>(t)), CT&&>);
-static_assert(is_same_v<decltype(forward_like<CU&&>(ct)), CT&&>);
-static_assert(is_same_v<decltype(forward_like<CU&&>(move(t))), CT&&>);
-static_assert(is_same_v<decltype(forward_like<CU&&>(move(ct))), CT&&>);
+static_assert(is_same_v<decltype(forward_like<CT&&>(U{})), CU&&>);
+static_assert(is_same_v<decltype(forward_like<CT&&>(CU{})), CU&&>);
+static_assert(is_same_v<decltype(forward_like<CT&&>(t)), CU&&>);
+static_assert(is_same_v<decltype(forward_like<CT&&>(ct)), CU&&>);
+static_assert(is_same_v<decltype(forward_like<CT&&>(move(t))), CU&&>);
+static_assert(is_same_v<decltype(forward_like<CT&&>(move(ct))), CU&&>);
 
 int main() {} // COMPILE-ONLY

--- a/tests/std/tests/P2445R1_forward_like/test.compile.pass.cpp
+++ b/tests/std/tests/P2445R1_forward_like/test.compile.pass.cpp
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <type_traits>
+#include <utility>
+
+using namespace std;
+
+struct owner_type {
+    inline static constinit int imut = 0;
+    static constexpr int iconst      = 0;
+
+    int m_mutobj    = 0;
+    int& m_mutlref  = imut;
+    int&& m_mutrref = move(imut);
+
+    const int m_cobj    = 0;
+    const int& m_clref  = iconst;
+    const int&& m_crref = move(iconst);
+};
+
+constinit owner_type owner{};
+constexpr owner_type& owner_lref  = owner;
+constexpr owner_type&& owner_rref = move(owner);
+
+constexpr owner_type owner_c{};
+constexpr const owner_type& owner_clref  = owner_c;
+constexpr const owner_type&& owner_crref = move(owner_c);
+
+static_assert(is_same_v<decltype(forward_like<decltype(owner)>(owner.m_mutobj)), int&&>);
+static_assert(is_same_v<decltype(forward_like<decltype(owner)>(owner.m_mutlref)), int&&>);
+static_assert(is_same_v<decltype(forward_like<decltype(owner)>(owner.m_mutrref)), int&&>);
+
+static_assert(is_same_v<decltype(forward_like<decltype(owner)>(owner.m_cobj)), const int&&>);
+static_assert(is_same_v<decltype(forward_like<decltype(owner)>(owner.m_clref)), const int&&>);
+static_assert(is_same_v<decltype(forward_like<decltype(owner)>(owner.m_crref)), const int&&>);
+
+static_assert(is_same_v<decltype(forward_like<decltype(owner_lref)>(owner_lref.m_mutobj)), int&>);
+static_assert(is_same_v<decltype(forward_like<decltype(owner_lref)>(owner_lref.m_mutlref)), int&>);
+static_assert(is_same_v<decltype(forward_like<decltype(owner_lref)>(owner_lref.m_mutrref)), int&>);
+
+static_assert(is_same_v<decltype(forward_like<decltype(owner_lref)>(owner_lref.m_cobj)), const int&>);
+static_assert(is_same_v<decltype(forward_like<decltype(owner_lref)>(owner_lref.m_clref)), const int&>);
+static_assert(is_same_v<decltype(forward_like<decltype(owner_lref)>(owner_lref.m_crref)), const int&>);
+
+static_assert(is_same_v<decltype(forward_like<decltype(owner_rref)>(owner_rref.m_mutobj)), int&&>);
+static_assert(is_same_v<decltype(forward_like<decltype(owner_rref)>(owner_rref.m_mutlref)), int&&>);
+static_assert(is_same_v<decltype(forward_like<decltype(owner_rref)>(owner_rref.m_mutrref)), int&&>);
+
+static_assert(is_same_v<decltype(forward_like<decltype(owner_rref)>(owner_rref.m_cobj)), const int&&>);
+static_assert(is_same_v<decltype(forward_like<decltype(owner_rref)>(owner_rref.m_clref)), const int&&>);
+static_assert(is_same_v<decltype(forward_like<decltype(owner_rref)>(owner_rref.m_crref)), const int&&>);
+
+static_assert(is_same_v<decltype(forward_like<decltype(owner_c)>(owner_c.m_mutobj)), const int&&>);
+static_assert(is_same_v<decltype(forward_like<decltype(owner_c)>(owner_c.m_mutlref)), const int&&>);
+static_assert(is_same_v<decltype(forward_like<decltype(owner_c)>(owner_c.m_mutrref)), const int&&>);
+
+static_assert(is_same_v<decltype(forward_like<decltype(owner_c)>(owner_c.m_cobj)), const int&&>);
+static_assert(is_same_v<decltype(forward_like<decltype(owner_c)>(owner_c.m_clref)), const int&&>);
+static_assert(is_same_v<decltype(forward_like<decltype(owner_c)>(owner_c.m_crref)), const int&&>);
+
+static_assert(is_same_v<decltype(forward_like<decltype(owner_clref)>(owner_clref.m_mutobj)), const int&>);
+static_assert(is_same_v<decltype(forward_like<decltype(owner_clref)>(owner_clref.m_mutlref)), const int&>);
+static_assert(is_same_v<decltype(forward_like<decltype(owner_clref)>(owner_clref.m_mutrref)), const int&>);
+
+static_assert(is_same_v<decltype(forward_like<decltype(owner_clref)>(owner_clref.m_cobj)), const int&>);
+static_assert(is_same_v<decltype(forward_like<decltype(owner_clref)>(owner_clref.m_clref)), const int&>);
+static_assert(is_same_v<decltype(forward_like<decltype(owner_clref)>(owner_clref.m_crref)), const int&>);
+
+static_assert(is_same_v<decltype(forward_like<decltype(owner_crref)>(owner_crref.m_mutobj)), const int&&>);
+static_assert(is_same_v<decltype(forward_like<decltype(owner_crref)>(owner_crref.m_mutlref)), const int&&>);
+static_assert(is_same_v<decltype(forward_like<decltype(owner_crref)>(owner_crref.m_mutrref)), const int&&>);
+
+static_assert(is_same_v<decltype(forward_like<decltype(owner_crref)>(owner_crref.m_cobj)), const int&&>);
+static_assert(is_same_v<decltype(forward_like<decltype(owner_crref)>(owner_crref.m_clref)), const int&&>);
+static_assert(is_same_v<decltype(forward_like<decltype(owner_crref)>(owner_crref.m_crref)), const int&&>);
+
+int main() {} // COMPILE-ONLY

--- a/tests/std/tests/P2445R1_forward_like/test.compile.pass.cpp
+++ b/tests/std/tests/P2445R1_forward_like/test.compile.pass.cpp
@@ -6,115 +6,54 @@
 
 using namespace std;
 
-struct owner_type {
-    inline static constinit int imut = 0;
-    static constexpr int iconst      = 0;
+struct T {}; // class type so const-qualification is not stripped from a prvalue
+using CT = const T;
+using U  = int;
+using CU = const U;
 
-    int m_mutobj    = 0;
-    int& m_mutlref  = imut;
-    int&& m_mutrref = move(imut);
+T t{};
+const T& ct = t;
 
-    const int m_cobj    = 0;
-    const int& m_clref  = iconst;
-    const int&& m_crref = move(iconst);
-};
+static_assert(is_same_v<decltype(forward_like<U>(T{})), T&&>);
+static_assert(is_same_v<decltype(forward_like<U>(CT{})), CT&&>);
+static_assert(is_same_v<decltype(forward_like<U>(t)), T&&>);
+static_assert(is_same_v<decltype(forward_like<U>(ct)), CT&&>);
+static_assert(is_same_v<decltype(forward_like<U>(move(t))), T&&>);
+static_assert(is_same_v<decltype(forward_like<U>(move(ct))), CT&&>);
 
-owner_type owner{};
-constexpr owner_type& owner_lref  = owner;
-constexpr owner_type&& owner_rref = move(owner);
+static_assert(is_same_v<decltype(forward_like<CU>(T{})), CT&&>);
+static_assert(is_same_v<decltype(forward_like<CU>(CT{})), CT&&>);
+static_assert(is_same_v<decltype(forward_like<CU>(t)), CT&&>);
+static_assert(is_same_v<decltype(forward_like<CU>(ct)), CT&&>);
+static_assert(is_same_v<decltype(forward_like<CU>(move(t))), CT&&>);
+static_assert(is_same_v<decltype(forward_like<CU>(move(ct))), CT&&>);
 
-constexpr owner_type owner_c{};
-constexpr const owner_type& owner_clref  = owner_c;
-constexpr const owner_type&& owner_crref = move(owner_c);
+static_assert(is_same_v<decltype(forward_like<U&>(T{})), T&>);
+static_assert(is_same_v<decltype(forward_like<U&>(CT{})), CT&>);
+static_assert(is_same_v<decltype(forward_like<U&>(t)), T&>);
+static_assert(is_same_v<decltype(forward_like<U&>(ct)), CT&>);
+static_assert(is_same_v<decltype(forward_like<U&>(move(t))), T&>);
+static_assert(is_same_v<decltype(forward_like<U&>(move(ct))), CT&>);
 
-using owner_t              = decltype(owner);
-using mutobj_from_owner_t  = decltype(forward_like<owner_t>(owner.m_mutobj));
-using mutlref_from_owner_t = decltype(forward_like<owner_t>(owner.m_mutlref));
-using mutrref_from_owner_t = decltype(forward_like<owner_t>(owner.m_mutrref));
-using cobj_from_owner_t    = decltype(forward_like<owner_t>(owner.m_cobj));
-using clref_from_owner_t   = decltype(forward_like<owner_t>(owner.m_clref));
-using crref_from_owner_t   = decltype(forward_like<owner_t>(owner.m_crref));
+static_assert(is_same_v<decltype(forward_like<CU&>(T{})), CT&>);
+static_assert(is_same_v<decltype(forward_like<CU&>(CT{})), CT&>);
+static_assert(is_same_v<decltype(forward_like<CU&>(t)), CT&>);
+static_assert(is_same_v<decltype(forward_like<CU&>(ct)), CT&>);
+static_assert(is_same_v<decltype(forward_like<CU&>(move(t))), CT&>);
+static_assert(is_same_v<decltype(forward_like<CU&>(move(ct))), CT&>);
 
-static_assert(is_same_v<mutobj_from_owner_t, int&&>);
-static_assert(is_same_v<mutlref_from_owner_t, int&&>);
-static_assert(is_same_v<mutrref_from_owner_t, int&&>);
-static_assert(is_same_v<cobj_from_owner_t, const int&&>);
-static_assert(is_same_v<clref_from_owner_t, const int&&>);
-static_assert(is_same_v<crref_from_owner_t, const int&&>);
+static_assert(is_same_v<decltype(forward_like<U&&>(T{})), T&&>);
+static_assert(is_same_v<decltype(forward_like<U&&>(CT{})), CT&&>);
+static_assert(is_same_v<decltype(forward_like<U&&>(t)), T&&>);
+static_assert(is_same_v<decltype(forward_like<U&&>(ct)), CT&&>);
+static_assert(is_same_v<decltype(forward_like<U&&>(move(t))), T&&>);
+static_assert(is_same_v<decltype(forward_like<U&&>(move(ct))), CT&&>);
 
-using owner_lref_t              = decltype(owner_lref);
-using mutobj_from_owner_lref_t  = decltype(forward_like<owner_lref_t>(owner_lref.m_mutobj));
-using mutlref_from_owner_lref_t = decltype(forward_like<owner_lref_t>(owner_lref.m_mutlref));
-using mutrref_from_owner_lref_t = decltype(forward_like<owner_lref_t>(owner_lref.m_mutrref));
-using cobj_from_owner_lref_t    = decltype(forward_like<owner_lref_t>(owner_lref.m_cobj));
-using clref_from_owner_lref_t   = decltype(forward_like<owner_lref_t>(owner_lref.m_clref));
-using crref_from_owner_lref_t   = decltype(forward_like<owner_lref_t>(owner_lref.m_crref));
-
-static_assert(is_same_v<mutobj_from_owner_lref_t, int&>);
-static_assert(is_same_v<mutlref_from_owner_lref_t, int&>);
-static_assert(is_same_v<mutrref_from_owner_lref_t, int&>);
-static_assert(is_same_v<cobj_from_owner_lref_t, const int&>);
-static_assert(is_same_v<clref_from_owner_lref_t, const int&>);
-static_assert(is_same_v<crref_from_owner_lref_t, const int&>);
-
-using owner_rref_t              = decltype(owner_rref);
-using mutobj_from_owner_rref_t  = decltype(forward_like<owner_rref_t>(owner_rref.m_mutobj));
-using mutlref_from_owner_rref_t = decltype(forward_like<owner_rref_t>(owner_rref.m_mutlref));
-using mutrref_from_owner_rref_t = decltype(forward_like<owner_rref_t>(owner_rref.m_mutrref));
-using cobj_from_owner_rref_t    = decltype(forward_like<owner_rref_t>(owner_rref.m_cobj));
-using clref_from_owner_rref_t   = decltype(forward_like<owner_rref_t>(owner_rref.m_clref));
-using crref_from_owner_rref_t   = decltype(forward_like<owner_rref_t>(owner_rref.m_crref));
-
-static_assert(is_same_v<mutobj_from_owner_rref_t, int&&>);
-static_assert(is_same_v<mutlref_from_owner_rref_t, int&&>);
-static_assert(is_same_v<mutrref_from_owner_rref_t, int&&>);
-static_assert(is_same_v<cobj_from_owner_rref_t, const int&&>);
-static_assert(is_same_v<clref_from_owner_rref_t, const int&&>);
-static_assert(is_same_v<crref_from_owner_rref_t, const int&&>);
-
-using owner_c_t              = decltype(owner_c);
-using mutobj_from_owner_c_t  = decltype(forward_like<owner_c_t>(owner_c.m_mutobj));
-using mutlref_from_owner_c_t = decltype(forward_like<owner_c_t>(owner_c.m_mutlref));
-using mutrref_from_owner_c_t = decltype(forward_like<owner_c_t>(owner_c.m_mutrref));
-using cobj_from_owner_c_t    = decltype(forward_like<owner_c_t>(owner_c.m_cobj));
-using clref_from_owner_c_t   = decltype(forward_like<owner_c_t>(owner_c.m_clref));
-using crref_from_owner_c_t   = decltype(forward_like<owner_c_t>(owner_c.m_crref));
-
-static_assert(is_same_v<mutobj_from_owner_c_t, const int&&>);
-static_assert(is_same_v<mutlref_from_owner_c_t, const int&&>);
-static_assert(is_same_v<mutrref_from_owner_c_t, const int&&>);
-static_assert(is_same_v<cobj_from_owner_c_t, const int&&>);
-static_assert(is_same_v<clref_from_owner_c_t, const int&&>);
-static_assert(is_same_v<crref_from_owner_c_t, const int&&>);
-
-using owner_clref_t              = decltype(owner_clref);
-using mutobj_from_owner_clref_t  = decltype(forward_like<owner_clref_t>(owner_clref.m_mutobj));
-using mutlref_from_owner_clref_t = decltype(forward_like<owner_clref_t>(owner_clref.m_mutlref));
-using mutrref_from_owner_clref_t = decltype(forward_like<owner_clref_t>(owner_clref.m_mutrref));
-using cobj_from_owner_clref_t    = decltype(forward_like<owner_clref_t>(owner_clref.m_cobj));
-using clref_from_owner_clref_t   = decltype(forward_like<owner_clref_t>(owner_clref.m_clref));
-using crref_from_owner_clref_t   = decltype(forward_like<owner_clref_t>(owner_clref.m_crref));
-
-static_assert(is_same_v<mutobj_from_owner_clref_t, const int&>);
-static_assert(is_same_v<mutlref_from_owner_clref_t, const int&>);
-static_assert(is_same_v<mutrref_from_owner_clref_t, const int&>);
-static_assert(is_same_v<cobj_from_owner_clref_t, const int&>);
-static_assert(is_same_v<clref_from_owner_clref_t, const int&>);
-static_assert(is_same_v<crref_from_owner_clref_t, const int&>);
-
-using owner_crref_t              = decltype(owner_crref);
-using mutobj_from_owner_crref_t  = decltype(forward_like<owner_crref_t>(owner_crref.m_mutobj));
-using mutlref_from_owner_crref_t = decltype(forward_like<owner_crref_t>(owner_crref.m_mutlref));
-using mutrref_from_owner_crref_t = decltype(forward_like<owner_crref_t>(owner_crref.m_mutrref));
-using cobj_from_owner_crref_t    = decltype(forward_like<owner_crref_t>(owner_crref.m_cobj));
-using clref_from_owner_crref_t   = decltype(forward_like<owner_crref_t>(owner_crref.m_clref));
-using crref_from_owner_crref_t   = decltype(forward_like<owner_crref_t>(owner_crref.m_crref));
-
-static_assert(is_same_v<mutobj_from_owner_crref_t, const int&&>);
-static_assert(is_same_v<mutlref_from_owner_crref_t, const int&&>);
-static_assert(is_same_v<mutrref_from_owner_crref_t, const int&&>);
-static_assert(is_same_v<cobj_from_owner_crref_t, const int&&>);
-static_assert(is_same_v<clref_from_owner_crref_t, const int&&>);
-static_assert(is_same_v<crref_from_owner_crref_t, const int&&>);
+static_assert(is_same_v<decltype(forward_like<CU&&>(T{})), CT&&>);
+static_assert(is_same_v<decltype(forward_like<CU&&>(CT{})), CT&&>);
+static_assert(is_same_v<decltype(forward_like<CU&&>(t)), CT&&>);
+static_assert(is_same_v<decltype(forward_like<CU&&>(ct)), CT&&>);
+static_assert(is_same_v<decltype(forward_like<CU&&>(move(t))), CT&&>);
+static_assert(is_same_v<decltype(forward_like<CU&&>(move(ct))), CT&&>);
 
 int main() {} // COMPILE-ONLY

--- a/tests/std/tests/P2445R1_forward_like/test.compile.pass.cpp
+++ b/tests/std/tests/P2445R1_forward_like/test.compile.pass.cpp
@@ -27,52 +27,94 @@ constexpr owner_type owner_c{};
 constexpr const owner_type& owner_clref  = owner_c;
 constexpr const owner_type&& owner_crref = move(owner_c);
 
-static_assert(is_same_v<decltype(forward_like<decltype(owner)>(owner.m_mutobj)), int&&>);
-static_assert(is_same_v<decltype(forward_like<decltype(owner)>(owner.m_mutlref)), int&&>);
-static_assert(is_same_v<decltype(forward_like<decltype(owner)>(owner.m_mutrref)), int&&>);
+using owner_t              = decltype(owner);
+using mutobj_from_owner_t  = decltype(forward_like<owner_t>(owner.m_mutobj));
+using mutlref_from_owner_t = decltype(forward_like<owner_t>(owner.m_mutlref));
+using mutrref_from_owner_t = decltype(forward_like<owner_t>(owner.m_mutrref));
+using cobj_from_owner_t    = decltype(forward_like<owner_t>(owner.m_cobj));
+using clref_from_owner_t   = decltype(forward_like<owner_t>(owner.m_clref));
+using crref_from_owner_t   = decltype(forward_like<owner_t>(owner.m_crref));
 
-static_assert(is_same_v<decltype(forward_like<decltype(owner)>(owner.m_cobj)), const int&&>);
-static_assert(is_same_v<decltype(forward_like<decltype(owner)>(owner.m_clref)), const int&&>);
-static_assert(is_same_v<decltype(forward_like<decltype(owner)>(owner.m_crref)), const int&&>);
+static_assert(is_same_v<mutobj_from_owner_t, int&&>);
+static_assert(is_same_v<mutlref_from_owner_t, int&&>);
+static_assert(is_same_v<mutrref_from_owner_t, int&&>);
+static_assert(is_same_v<cobj_from_owner_t, const int&&>);
+static_assert(is_same_v<clref_from_owner_t, const int&&>);
+static_assert(is_same_v<crref_from_owner_t, const int&&>);
 
-static_assert(is_same_v<decltype(forward_like<decltype(owner_lref)>(owner_lref.m_mutobj)), int&>);
-static_assert(is_same_v<decltype(forward_like<decltype(owner_lref)>(owner_lref.m_mutlref)), int&>);
-static_assert(is_same_v<decltype(forward_like<decltype(owner_lref)>(owner_lref.m_mutrref)), int&>);
+using owner_lref_t              = decltype(owner_lref);
+using mutobj_from_owner_lref_t  = decltype(forward_like<owner_lref_t>(owner_lref.m_mutobj));
+using mutlref_from_owner_lref_t = decltype(forward_like<owner_lref_t>(owner_lref.m_mutlref));
+using mutrref_from_owner_lref_t = decltype(forward_like<owner_lref_t>(owner_lref.m_mutrref));
+using cobj_from_owner_lref_t    = decltype(forward_like<owner_lref_t>(owner_lref.m_cobj));
+using clref_from_owner_lref_t   = decltype(forward_like<owner_lref_t>(owner_lref.m_clref));
+using crref_from_owner_lref_t   = decltype(forward_like<owner_lref_t>(owner_lref.m_crref));
 
-static_assert(is_same_v<decltype(forward_like<decltype(owner_lref)>(owner_lref.m_cobj)), const int&>);
-static_assert(is_same_v<decltype(forward_like<decltype(owner_lref)>(owner_lref.m_clref)), const int&>);
-static_assert(is_same_v<decltype(forward_like<decltype(owner_lref)>(owner_lref.m_crref)), const int&>);
+static_assert(is_same_v<mutobj_from_owner_lref_t, int&>);
+static_assert(is_same_v<mutlref_from_owner_lref_t, int&>);
+static_assert(is_same_v<mutrref_from_owner_lref_t, int&>);
+static_assert(is_same_v<cobj_from_owner_lref_t, const int&>);
+static_assert(is_same_v<clref_from_owner_lref_t, const int&>);
+static_assert(is_same_v<crref_from_owner_lref_t, const int&>);
 
-static_assert(is_same_v<decltype(forward_like<decltype(owner_rref)>(owner_rref.m_mutobj)), int&&>);
-static_assert(is_same_v<decltype(forward_like<decltype(owner_rref)>(owner_rref.m_mutlref)), int&&>);
-static_assert(is_same_v<decltype(forward_like<decltype(owner_rref)>(owner_rref.m_mutrref)), int&&>);
+using owner_rref_t              = decltype(owner_rref);
+using mutobj_from_owner_rref_t  = decltype(forward_like<owner_rref_t>(owner_rref.m_mutobj));
+using mutlref_from_owner_rref_t = decltype(forward_like<owner_rref_t>(owner_rref.m_mutlref));
+using mutrref_from_owner_rref_t = decltype(forward_like<owner_rref_t>(owner_rref.m_mutrref));
+using cobj_from_owner_rref_t    = decltype(forward_like<owner_rref_t>(owner_rref.m_cobj));
+using clref_from_owner_rref_t   = decltype(forward_like<owner_rref_t>(owner_rref.m_clref));
+using crref_from_owner_rref_t   = decltype(forward_like<owner_rref_t>(owner_rref.m_crref));
 
-static_assert(is_same_v<decltype(forward_like<decltype(owner_rref)>(owner_rref.m_cobj)), const int&&>);
-static_assert(is_same_v<decltype(forward_like<decltype(owner_rref)>(owner_rref.m_clref)), const int&&>);
-static_assert(is_same_v<decltype(forward_like<decltype(owner_rref)>(owner_rref.m_crref)), const int&&>);
+static_assert(is_same_v<mutobj_from_owner_rref_t, int&&>);
+static_assert(is_same_v<mutlref_from_owner_rref_t, int&&>);
+static_assert(is_same_v<mutrref_from_owner_rref_t, int&&>);
+static_assert(is_same_v<cobj_from_owner_rref_t, const int&&>);
+static_assert(is_same_v<clref_from_owner_rref_t, const int&&>);
+static_assert(is_same_v<crref_from_owner_rref_t, const int&&>);
 
-static_assert(is_same_v<decltype(forward_like<decltype(owner_c)>(owner_c.m_mutobj)), const int&&>);
-static_assert(is_same_v<decltype(forward_like<decltype(owner_c)>(owner_c.m_mutlref)), const int&&>);
-static_assert(is_same_v<decltype(forward_like<decltype(owner_c)>(owner_c.m_mutrref)), const int&&>);
+using owner_c_t              = decltype(owner_c);
+using mutobj_from_owner_c_t  = decltype(forward_like<owner_c_t>(owner_c.m_mutobj));
+using mutlref_from_owner_c_t = decltype(forward_like<owner_c_t>(owner_c.m_mutlref));
+using mutrref_from_owner_c_t = decltype(forward_like<owner_c_t>(owner_c.m_mutrref));
+using cobj_from_owner_c_t    = decltype(forward_like<owner_c_t>(owner_c.m_cobj));
+using clref_from_owner_c_t   = decltype(forward_like<owner_c_t>(owner_c.m_clref));
+using crref_from_owner_c_t   = decltype(forward_like<owner_c_t>(owner_c.m_crref));
 
-static_assert(is_same_v<decltype(forward_like<decltype(owner_c)>(owner_c.m_cobj)), const int&&>);
-static_assert(is_same_v<decltype(forward_like<decltype(owner_c)>(owner_c.m_clref)), const int&&>);
-static_assert(is_same_v<decltype(forward_like<decltype(owner_c)>(owner_c.m_crref)), const int&&>);
+static_assert(is_same_v<mutobj_from_owner_c_t, const int&&>);
+static_assert(is_same_v<mutlref_from_owner_c_t, const int&&>);
+static_assert(is_same_v<mutrref_from_owner_c_t, const int&&>);
+static_assert(is_same_v<cobj_from_owner_c_t, const int&&>);
+static_assert(is_same_v<clref_from_owner_c_t, const int&&>);
+static_assert(is_same_v<crref_from_owner_c_t, const int&&>);
 
-static_assert(is_same_v<decltype(forward_like<decltype(owner_clref)>(owner_clref.m_mutobj)), const int&>);
-static_assert(is_same_v<decltype(forward_like<decltype(owner_clref)>(owner_clref.m_mutlref)), const int&>);
-static_assert(is_same_v<decltype(forward_like<decltype(owner_clref)>(owner_clref.m_mutrref)), const int&>);
+using owner_clref_t              = decltype(owner_clref);
+using mutobj_from_owner_clref_t  = decltype(forward_like<owner_clref_t>(owner_clref.m_mutobj));
+using mutlref_from_owner_clref_t = decltype(forward_like<owner_clref_t>(owner_clref.m_mutlref));
+using mutrref_from_owner_clref_t = decltype(forward_like<owner_clref_t>(owner_clref.m_mutrref));
+using cobj_from_owner_clref_t    = decltype(forward_like<owner_clref_t>(owner_clref.m_cobj));
+using clref_from_owner_clref_t   = decltype(forward_like<owner_clref_t>(owner_clref.m_clref));
+using crref_from_owner_clref_t   = decltype(forward_like<owner_clref_t>(owner_clref.m_crref));
 
-static_assert(is_same_v<decltype(forward_like<decltype(owner_clref)>(owner_clref.m_cobj)), const int&>);
-static_assert(is_same_v<decltype(forward_like<decltype(owner_clref)>(owner_clref.m_clref)), const int&>);
-static_assert(is_same_v<decltype(forward_like<decltype(owner_clref)>(owner_clref.m_crref)), const int&>);
+static_assert(is_same_v<mutobj_from_owner_clref_t, const int&>);
+static_assert(is_same_v<mutlref_from_owner_clref_t, const int&>);
+static_assert(is_same_v<mutrref_from_owner_clref_t, const int&>);
+static_assert(is_same_v<cobj_from_owner_clref_t, const int&>);
+static_assert(is_same_v<clref_from_owner_clref_t, const int&>);
+static_assert(is_same_v<crref_from_owner_clref_t, const int&>);
 
-static_assert(is_same_v<decltype(forward_like<decltype(owner_crref)>(owner_crref.m_mutobj)), const int&&>);
-static_assert(is_same_v<decltype(forward_like<decltype(owner_crref)>(owner_crref.m_mutlref)), const int&&>);
-static_assert(is_same_v<decltype(forward_like<decltype(owner_crref)>(owner_crref.m_mutrref)), const int&&>);
+using owner_crref_t              = decltype(owner_crref);
+using mutobj_from_owner_crref_t  = decltype(forward_like<owner_crref_t>(owner_crref.m_mutobj));
+using mutlref_from_owner_crref_t = decltype(forward_like<owner_crref_t>(owner_crref.m_mutlref));
+using mutrref_from_owner_crref_t = decltype(forward_like<owner_crref_t>(owner_crref.m_mutrref));
+using cobj_from_owner_crref_t    = decltype(forward_like<owner_crref_t>(owner_crref.m_cobj));
+using clref_from_owner_crref_t   = decltype(forward_like<owner_crref_t>(owner_crref.m_clref));
+using crref_from_owner_crref_t   = decltype(forward_like<owner_crref_t>(owner_crref.m_crref));
 
-static_assert(is_same_v<decltype(forward_like<decltype(owner_crref)>(owner_crref.m_cobj)), const int&&>);
-static_assert(is_same_v<decltype(forward_like<decltype(owner_crref)>(owner_crref.m_clref)), const int&&>);
-static_assert(is_same_v<decltype(forward_like<decltype(owner_crref)>(owner_crref.m_crref)), const int&&>);
+static_assert(is_same_v<mutobj_from_owner_crref_t, const int&&>);
+static_assert(is_same_v<mutlref_from_owner_crref_t, const int&&>);
+static_assert(is_same_v<mutrref_from_owner_crref_t, const int&&>);
+static_assert(is_same_v<cobj_from_owner_crref_t, const int&&>);
+static_assert(is_same_v<clref_from_owner_crref_t, const int&&>);
+static_assert(is_same_v<crref_from_owner_crref_t, const int&&>);
 
 int main() {} // COMPILE-ONLY

--- a/tests/std/tests/P2445R1_forward_like/test.compile.pass.cpp
+++ b/tests/std/tests/P2445R1_forward_like/test.compile.pass.cpp
@@ -19,7 +19,7 @@ struct owner_type {
     const int&& m_crref = move(iconst);
 };
 
-constinit owner_type owner{};
+owner_type owner{};
 constexpr owner_type& owner_lref  = owner;
 constexpr owner_type&& owner_rref = move(owner);
 

--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
@@ -786,6 +786,20 @@ STATIC_ASSERT(__cpp_lib_format == 202110L);
 #endif
 #endif
 
+#if _HAS_CXX23
+#ifndef __cpp_lib_forward_like
+#error __cpp_lib_forward_like is not defined
+#elif __cpp_lib_forward_like != 202207L
+#error __cpp_lib_forward_like is not 202207L
+#else
+STATIC_ASSERT(__cpp_lib_forward_like == 202207L);
+#endif
+#else
+#ifdef __cpp_lib_forward_like
+#error __cpp_lib_forward_like is defined
+#endif
+#endif
+
 #if _HAS_CXX17
 #ifndef __cpp_lib_gcd_lcm
 #error __cpp_lib_gcd_lcm is not defined


### PR DESCRIPTION
Fixes #2931.

Intentionally don't call `std::move`, `std::forward`, or `std::as_const`. Also move `_Can_reference` to `<utility>` for error message.