### PR TITLE
Status Chart: Fix mobile Safari

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This branch generates the STL's [Status Chart][].
 
 ## Repo
 
-1. Install [Node.js][] 17.8.0 or newer.
+1. Install [Node.js][] 18.7.0 or newer.
     + You can accept all of the installer's default options.
 2. Open a new Command Prompt.
     + You can run `node --version` to verify that Node.js was successfully installed.

--- a/index.html
+++ b/index.html
@@ -7,8 +7,8 @@
     <!-- SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception -->
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>STL Status Chart</title>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@primer/css@20.4.0/dist/primer.min.css" />
-    <script async src="https://cdn.jsdelivr.net/npm/es-module-shims@1.5.9/dist/es-module-shims.min.js"
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@primer/css@20.4.1/dist/primer.min.css" />
+    <script async src="https://cdn.jsdelivr.net/npm/es-module-shims@1.5.10/dist/es-module-shims.min.js"
         crossorigin="anonymous"></script>
     <script type="importmap">
         { "imports": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@octokit/graphql": "^5.0.0",
         "@types/cli-progress": "^3.11.0",
         "@types/luxon": "^3.0.0",
-        "@types/node": "^18.6.2",
+        "@types/node": "^18.6.3",
         "@types/yargs": "^17.0.10",
         "chart.js": "^3.8.2",
         "chartjs-adapter-luxon": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -107,9 +107,9 @@
       "integrity": "sha512-Lx+EZoJxUKw4dp8uei9XiUVNlgkYmax5+ovqt6Xf3LzJOnWhlfJw/jLBmqfGVwOP/pDr4HT8bI1WtxK0IChMLw=="
     },
     "node_modules/@types/node": {
-      "version": "18.6.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.2.tgz",
-      "integrity": "sha512-KcfkBq9H4PI6Vpu5B/KoPeuVDAbmi+2mDBqGPGUgoL7yXQtcWGu2vJWmmRkneWK3Rh0nIAX192Aa87AqKHYChQ=="
+      "version": "18.6.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.3.tgz",
+      "integrity": "sha512-6qKpDtoaYLM+5+AFChLhHermMQxc3TOEFIDzrZLPRGHPrLEwqFkkT5Kx3ju05g6X7uDPazz3jHbKPX0KzCjntg=="
     },
     "node_modules/@types/yargs": {
       "version": "17.0.10",
@@ -1164,9 +1164,9 @@
       "integrity": "sha512-Lx+EZoJxUKw4dp8uei9XiUVNlgkYmax5+ovqt6Xf3LzJOnWhlfJw/jLBmqfGVwOP/pDr4HT8bI1WtxK0IChMLw=="
     },
     "@types/node": {
-      "version": "18.6.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.2.tgz",
-      "integrity": "sha512-KcfkBq9H4PI6Vpu5B/KoPeuVDAbmi+2mDBqGPGUgoL7yXQtcWGu2vJWmmRkneWK3Rh0nIAX192Aa87AqKHYChQ=="
+      "version": "18.6.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.3.tgz",
+      "integrity": "sha512-6qKpDtoaYLM+5+AFChLhHermMQxc3TOEFIDzrZLPRGHPrLEwqFkkT5Kx3ju05g6X7uDPazz3jHbKPX0KzCjntg=="
     },
     "@types/yargs": {
       "version": "17.0.10",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@octokit/graphql": "^5.0.0",
     "@types/cli-progress": "^3.11.0",
     "@types/luxon": "^3.0.0",
-    "@types/node": "^18.6.2",
+    "@types/node": "^18.6.3",
     "@types/yargs": "^17.0.10",
     "chart.js": "^3.8.2",
     "chartjs-adapter-luxon": "^1.1.0",

--- a/src/status_chart.ts
+++ b/src/status_chart.ts
@@ -544,4 +544,17 @@ function load_charts() {
     }
 }
 
-window.addEventListener('load', _event => load_charts()); // wait for stylesheets to finish loading
+// wait for Primer CSS to finish loading
+function check_css() {
+    const regex = new RegExp('@primer/css');
+    for (const sheet of document.styleSheets) {
+        if (sheet.href !== null && regex.test(sheet.href)) {
+            load_charts();
+            return;
+        }
+    }
+
+    window.setTimeout(check_css, 50 /* milliseconds */);
+}
+
+check_css();


### PR DESCRIPTION
My previous PR #2967 which attempted to address #2963 appeared to solve the problem for desktop Chrome, but broke mobile Safari such that the charts wouldn't even load.

I don't understand the root cause, but I suspect that it has something to do with how es-module-shims has to do actual work for mobile Safari (so perhaps the window is considered "loaded" before the JS finishes executing, and the `addEventListener` did nothing).

This PR uses a different technique that appears to work reliably in both environments. Now I run a function, `check_css()`, that detects whether Primer CSS has loaded. If it hasn't, we'll wait 50ms and check again. (Chosen semi-arbitrarily - we don't need to check every frame, but we do want to notice it quickly.)

This also updates dependencies slightly, including the Node version mentioned in the README.

As usual, this contains a "DROP BEFORE MERGING: Regen `built/status_chart.mjs`." commit to make the live preview work.

:chart_with_downwards_trend: :iphone: Live preview: [stephantlavavej.github.io/STL/](https://stephantlavavej.github.io/STL/)
===