### PR TITLE
Implement P2419R2 Clarify Handling Of Encodings In Localized Formatting Of `chrono` Types

### DIFF
--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -5418,7 +5418,7 @@ namespace chrono {
 
                     _Validate_specifiers(_Spec, _Val);
 
-#if defined(_MSVC_EXECUTION_CHARACTER_SET) && _MSVC_EXECUTION_CHARACTER_SET == 65001
+#if defined(_MSVC_EXECUTION_CHARACTER_SET) && _MSVC_EXECUTION_CHARACTER_SET == 65001 // TRANSITION, VSO-1468747 (EDG)
                     if constexpr (is_same_v<_CharT, char>) {
                         if (_Specs._Localized) {
                             wostringstream _Wstream;

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -10,6 +10,12 @@
 #if _STL_COMPILER_PREPROCESSOR
 #include <__msvc_chrono.hpp>
 
+#if _HAS_CXX17
+#include <system_error>
+#include <xfilesystem_abi.h>
+#include <xstring>
+#endif // _HAS_CXX17
+
 #if _HAS_CXX20
 #include <__msvc_tzdb.hpp>
 #include <algorithm>
@@ -45,6 +51,55 @@ _STL_DISABLE_CLANG_WARNINGS
 #undef new
 
 _STD_BEGIN
+#if _HAS_CXX17
+// We would really love to use the proper way of building error_code by specializing
+// is_error_code_enum and make_error_code for __std_win_error, but because:
+//   1. We would like to keep the definition of __std_win_error in xfilesystem_abi.h
+//   2. and xfilesystem_abi.h cannot include <system_error>
+//   3. and specialization of is_error_code_enum and overload of make_error_code
+//      need to be kept together with the enum (see limerick in N4810 [temp.expl.spec]/7)
+// we resort to using this _Make_ec helper.
+_NODISCARD inline error_code _Make_ec(__std_win_error _Errno) noexcept { // make an error_code
+    return {static_cast<int>(_Errno), _STD system_category()};
+}
+
+[[noreturn]] inline void _Throw_system_error_from_std_win_error(const __std_win_error _Errno) {
+    _THROW(system_error{_Make_ec(_Errno)});
+}
+
+_NODISCARD inline int _Check_convert_result(const __std_fs_convert_result _Result) {
+    if (_Result._Err != __std_win_error::_Success) {
+        _Throw_system_error_from_std_win_error(_Result._Err);
+    }
+
+    return _Result._Len;
+}
+
+template <class _Traits, class _Alloc>
+_NODISCARD basic_string<typename _Traits::char_type, _Traits, _Alloc> _Convert_wide_to_narrow(
+    const __std_code_page _Code_page, const wstring_view _Input, const _Alloc& _Al) {
+    basic_string<typename _Traits::char_type, _Traits, _Alloc> _Output(_Al);
+
+    if (!_Input.empty()) {
+        if (_Input.size() > static_cast<size_t>(INT_MAX)) {
+            _Throw_system_error(errc::invalid_argument);
+        }
+
+        const int _Len = _Check_convert_result(
+            __std_fs_convert_wide_to_narrow(_Code_page, _Input.data(), static_cast<int>(_Input.size()), nullptr, 0));
+
+        _Output.resize(static_cast<size_t>(_Len));
+
+        const auto _Data_as_char = reinterpret_cast<char*>(_Output.data());
+
+        (void) _Check_convert_result(__std_fs_convert_wide_to_narrow(
+            _Code_page, _Input.data(), static_cast<int>(_Input.size()), _Data_as_char, _Len));
+    }
+
+    return _Output;
+}
+#endif // _HAS_CXX17
+
 #if _HAS_CXX20
 namespace chrono {
     // [time.duration.io]

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -5245,6 +5245,18 @@ namespace chrono {
     }
 
     template <class _CharT>
+    _NODISCARD const _CharT* _Fmt_string(const _Chrono_spec<_CharT>& _Spec, _CharT (&_Fmt_str)[4]) {
+        size_t _Next_idx      = 0;
+        _Fmt_str[_Next_idx++] = _CharT{'%'};
+        if (_Spec._Modifier != '\0') {
+            _Fmt_str[_Next_idx++] = static_cast<_CharT>(_Spec._Modifier);
+        }
+        _Fmt_str[_Next_idx++] = static_cast<_CharT>(_Spec._Type);
+        _Fmt_str[_Next_idx]   = _CharT{'\0'};
+        return _Fmt_str;
+    }
+
+    template <class _CharT>
     struct _Chrono_formatter {
         _Chrono_formatter() = default;
 
@@ -5405,6 +5417,24 @@ namespace chrono {
                     }
 
                     _Validate_specifiers(_Spec, _Val);
+
+#if defined(_MSVC_EXECUTION_CHARACTER_SET) && _MSVC_EXECUTION_CHARACTER_SET == 65001
+                    if constexpr (is_same_v<_CharT, char>) {
+                        if (_Specs._Localized) {
+                            wostringstream _Wstream;
+                            _Wstream.imbue(_FormatCtx.locale());
+
+                            wchar_t _Fmt_str[4];
+                            _Chrono_spec<wchar_t> _Wspec{._Modifier = _Spec._Modifier, ._Type = _Spec._Type};
+                            _Wstream << _STD put_time<wchar_t>(&_Time, _Fmt_string(_Wspec, _Fmt_str));
+
+                            _Stream << _Convert_wide_to_narrow<char_traits<char>>(
+                                __std_code_page::_Utf8, _Wstream.view(), allocator<char>{});
+
+                            continue;
+                        }
+                    }
+#endif // defined(_MSVC_EXECUTION_CHARACTER_SET) && _MSVC_EXECUTION_CHARACTER_SET == 65001
 
                     _CharT _Fmt_str[4];
                     _Stream << _STD put_time<_CharT>(&_Time, _Fmt_string(_Spec, _Fmt_str));
@@ -5728,17 +5758,6 @@ namespace chrono {
             if (!_Validate()) {
                 _Throw_format_error("Cannot localize out-of-bounds time point.");
             }
-        }
-
-        _NODISCARD static const _CharT* _Fmt_string(const _Chrono_spec<_CharT>& _Spec, _CharT (&_Fmt_str)[4]) {
-            size_t _Next_idx      = 0;
-            _Fmt_str[_Next_idx++] = _CharT{'%'};
-            if (_Spec._Modifier != '\0') {
-                _Fmt_str[_Next_idx++] = static_cast<_CharT>(_Spec._Modifier);
-            }
-            _Fmt_str[_Next_idx++] = static_cast<_CharT>(_Spec._Type);
-            _Fmt_str[_Next_idx]   = _CharT{'\0'};
-            return _Fmt_str;
         }
 
         _Chrono_format_specs<_CharT> _Specs{};

--- a/stl/inc/filesystem
+++ b/stl/inc/filesystem
@@ -19,12 +19,8 @@
 #include <list>
 #include <locale>
 #include <memory>
-#include <string_view>
-#include <system_error>
 #include <utility>
 #include <vector>
-#include <xfilesystem_abi.h>
-#include <xstring>
 
 #if _HAS_CXX20
 #include <compare>
@@ -39,29 +35,6 @@ _STL_DISABLE_CLANG_WARNINGS
 
 _STD_BEGIN
 namespace filesystem {
-    // We would really love to use the proper way of building error_code by specializing
-    // is_error_code_enum and make_error_code for __std_win_error, but because:
-    //   1. We would like to keep the definition of __std_win_error in xfilesystem_abi.h
-    //   2. and xfilesystem_abi.h cannot include <system_error>
-    //   3. and specialization of is_error_code_enum and overload of make_error_code
-    //      need to be kept together with the enum (see limerick in N4810 [temp.expl.spec]/7)
-    // we resort to using this _Make_ec helper.
-    _NODISCARD inline error_code _Make_ec(__std_win_error _Errno) noexcept { // make an error_code
-        return {static_cast<int>(_Errno), _STD system_category()};
-    }
-
-    [[noreturn]] inline void _Throw_system_error_from_std_win_error(const __std_win_error _Errno) {
-        _THROW(system_error{_Make_ec(_Errno)});
-    }
-
-    _NODISCARD inline int _Check_convert_result(const __std_fs_convert_result _Result) {
-        if (_Result._Err != __std_win_error::_Success) {
-            _Throw_system_error_from_std_win_error(_Result._Err);
-        }
-
-        return _Result._Len;
-    }
-
     _NODISCARD inline wstring _Convert_narrow_to_wide(const __std_code_page _Code_page, const string_view _Input) {
         wstring _Output;
 
@@ -77,30 +50,6 @@ namespace filesystem {
 
             (void) _Check_convert_result(__std_fs_convert_narrow_to_wide(
                 _Code_page, _Input.data(), static_cast<int>(_Input.size()), _Output.data(), _Len));
-        }
-
-        return _Output;
-    }
-
-    template <class _Traits, class _Alloc>
-    _NODISCARD basic_string<typename _Traits::char_type, _Traits, _Alloc> _Convert_wide_to_narrow(
-        const __std_code_page _Code_page, const wstring_view _Input, const _Alloc& _Al) {
-        basic_string<typename _Traits::char_type, _Traits, _Alloc> _Output(_Al);
-
-        if (!_Input.empty()) {
-            if (_Input.size() > static_cast<size_t>(INT_MAX)) {
-                _Throw_system_error(errc::invalid_argument);
-            }
-
-            const int _Len = _Check_convert_result(__std_fs_convert_wide_to_narrow(
-                _Code_page, _Input.data(), static_cast<int>(_Input.size()), nullptr, 0));
-
-            _Output.resize(static_cast<size_t>(_Len));
-
-            const auto _Data_as_char = reinterpret_cast<char*>(_Output.data());
-
-            (void) _Check_convert_result(__std_fs_convert_wide_to_narrow(
-                _Code_page, _Input.data(), static_cast<int>(_Input.size()), _Data_as_char, _Len));
         }
 
         return _Output;

--- a/stl/inc/filesystem
+++ b/stl/inc/filesystem
@@ -19,8 +19,11 @@
 #include <list>
 #include <locale>
 #include <memory>
+#include <system_error>
 #include <utility>
 #include <vector>
+#include <xfilesystem_abi.h>
+#include <xstring>
 
 #if _HAS_CXX20
 #include <compare>

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -67,7 +67,6 @@
 // P1165R1 Consistently Propagating Stateful Allocators In basic_string's operator+()
 // P1902R1 Missing Feature-Test Macros 2017-2019
 // P2401R0 Conditional noexcept For exchange()
-// P2419R2 Clarify Handling Of Encodings In Localized Formatting Of chrono Types
 
 // _HAS_CXX17 directly controls:
 // P0005R4 not_fn()
@@ -273,6 +272,7 @@
 // P2393R1 Cleaning Up Integer-Class Types
 // P2415R2 What Is A view?
 // P2418R2 Add Support For std::generator-like Types To std::format
+// P2419R2 Clarify Handling Of Encodings In Localized Formatting Of chrono Types
 // P2432R1 Fix istream_view
 
 // _HAS_CXX20 indirectly controls:

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -67,6 +67,7 @@
 // P1165R1 Consistently Propagating Stateful Allocators In basic_string's operator+()
 // P1902R1 Missing Feature-Test Macros 2017-2019
 // P2401R0 Conditional noexcept For exchange()
+// P2419R2 Clarify Handling Of Encodings In Localized Formatting Of chrono Types
 
 // _HAS_CXX17 directly controls:
 // P0005R4 not_fn()

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
@@ -1119,6 +1119,7 @@ void test() {
 
 #if !defined(_DLL) || _ITERATOR_DEBUG_LEVEL == DEFAULT_IDL_SETTING
     test_locale<wchar_t>();
+    test_locale<char>();
     assert(setlocale(LC_ALL, ".UTF-8") != nullptr);
     test_locale<char>();
 #endif // !defined(_DLL) || _ITERATOR_DEBUG_LEVEL == DEFAULT_IDL_SETTING


### PR DESCRIPTION
Fixes #2927.

When the literal encoding is UTF-8, This ensures that the strings produced by chrono formatters are always encoded in UTF-8, by first formatting with `wchar_t`, then converting the output to UTF-8. (Is there a better way?)

I didn't convert the output of `_Custom_write`, because it seems that `_Custom_write` generally does not deal with localized formatting.