### PR TITLE
`<xutility>`: Some fixes around `std::ranges::enable_view`

### DIFF
--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -2352,8 +2352,8 @@ namespace ranges {
     void _Derived_from_specialization_impl(const _Template<_Args...>&);
 
     template <class _Ty, template <class...> class _Template>
-    concept _Derived_from_specialization_of = requires(const _Ty& _Obj) {
-        _Derived_from_specialization_impl<_Template>(_Obj);
+    concept _Derived_from_specialization_of = is_object_v<_Ty> && requires(const _Ty& _Obj) {
+        _RANGES _Derived_from_specialization_impl<_Template>(_Obj);
     };
 
     template <class _Derived>

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -2353,7 +2353,7 @@ namespace ranges {
 
     template <class _Ty, template <class...> class _Template>
     concept _Derived_from_specialization_of = is_object_v<_Ty> && requires(const _Ty& _Obj) {
-        _RANGES _Derived_from_specialization_impl<_Template>(_Obj); // qualified to avoid ADL, handle incomplete types
+        _RANGES _Derived_from_specialization_impl<_Template>(_Obj); // qualified: avoid ADL, handle incompletable types
     };
 
     template <class _Derived>

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -2353,7 +2353,7 @@ namespace ranges {
 
     template <class _Ty, template <class...> class _Template>
     concept _Derived_from_specialization_of = is_object_v<_Ty> && requires(const _Ty& _Obj) {
-        _RANGES _Derived_from_specialization_impl<_Template>(_Obj);
+        _RANGES _Derived_from_specialization_impl<_Template>(_Obj); // qualified to avoid ADL, handle incomplete types
     };
 
     template <class _Derived>

--- a/tests/std/tests/P0896R4_ranges_range_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_range_machinery/test.cpp
@@ -1610,6 +1610,7 @@ STATIC_ASSERT(!std::is_base_of_v<std::ranges::view_base, ranges::view_interface<
 STATIC_ASSERT(!std::is_base_of_v<std::ranges::view_base, ranges::view_interface<strange_view5>>);
 
 // Verify that enable_view<T&> or enable_view<T&&> is never true
+STATIC_ASSERT(ranges::enable_view<strange_view4>);
 STATIC_ASSERT(!ranges::enable_view<strange_view4&>);
 STATIC_ASSERT(!ranges::enable_view<const strange_view4&>);
 STATIC_ASSERT(!ranges::enable_view<strange_view4&&>);

--- a/tests/std/tests/P0896R4_ranges_range_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_range_machinery/test.cpp
@@ -1609,6 +1609,22 @@ struct strange_view5 : strange_view4, ranges::view_interface<strange_view5> {
 STATIC_ASSERT(!std::is_base_of_v<std::ranges::view_base, ranges::view_interface<strange_view4>>);
 STATIC_ASSERT(!std::is_base_of_v<std::ranges::view_base, ranges::view_interface<strange_view5>>);
 
+// Verify that enable_view<T&> or enable_view<T&&> is never true
+STATIC_ASSERT(!ranges::enable_view<strange_view4&>);
+STATIC_ASSERT(!ranges::enable_view<const strange_view4&>);
+STATIC_ASSERT(!ranges::enable_view<strange_view4&&>);
+STATIC_ASSERT(!ranges::enable_view<const strange_view4&&>);
+
+// Verify that the derived-from-view_interface mechanism can handle uses of incomplete types whenever possible
+struct incomplet;
+
+template <class T>
+struct value_holder {
+    T t;
+};
+
+STATIC_ASSERT(!ranges::enable_view<value_holder<incomplet>*>);
+
 template <>
 inline constexpr bool ranges::enable_view<strange_view> = true;
 template <>


### PR DESCRIPTION
Currently the implementation of `std::ranges::enable_view` in MSVC STL doesn't reject reference types.
```C++
static_assert(std::ranges::enable_view<std::ranges::empty_view<int>&>); // currently passes, but should not
```

And it doesn't handle incomplete types whenever possible due to ADL.
```C++
struct Incomplet;

template <class T>
struct Holder {
    T t;
};

static_assert(!std::ranges::enable_view<Holder<Incomplet>*>); // hard error, should be avoided
```

These bugs are revealed by the libc++ test `std/ranges/range.req/range.view/enable_view.compile.pass.cpp`.

The fixes are
- requiring the type to be an object type in the derive-from-`view_interface` mechanism, and
- using qualified call to avoid ADL.