### PR TITLE
`<xstring>`: `basic_string::_Is_elem_cptr` should be a variable template

### DIFF
--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -2471,7 +2471,9 @@ private:
     static constexpr size_t _Memcpy_val_size   = sizeof(_Scary_val) - _Memcpy_val_offset;
 
     template <class _Iter>
-    static constexpr bool _Is_elem_cptr = _Is_any_of_v<_Iter, const _Elem* const, _Elem* const, const _Elem*, _Elem*>;
+    // TRANSITION, /clr:pure is incompatible with templated static constexpr data members
+    //static constexpr bool _Is_elem_cptr =_Is_any_of_v<_Iter, const _Elem* const, _Elem* const, const _Elem*, _Elem*>;
+    using _Is_elem_cptr = bool_constant<_Is_any_of_v<_Iter, const _Elem* const, _Elem* const, const _Elem*, _Elem*>>;
 
 #if _HAS_CXX17
     template <class _StringViewIsh>
@@ -2663,7 +2665,7 @@ public:
             _Mypair._Myval2._Alloc_proxy(_GET_PROXY_ALLOCATOR(_Alty, _Getal()));
             _Tidy_init();
         } else {
-            if constexpr (_Is_elem_cptr<decltype(_UFirst)>) {
+            if constexpr (_Is_elem_cptr<decltype(_UFirst)>::value) {
                 _Construct<_Construct_strategy::_From_ptr>(
                     _UFirst, _Convert_size<size_type>(static_cast<size_t>(_ULast - _UFirst)));
             } else {
@@ -2681,7 +2683,7 @@ private:
         if constexpr (_Strat == _Construct_strategy::_From_char) {
             _STL_INTERNAL_STATIC_ASSERT(is_same_v<_Char_or_ptr, _Elem>);
         } else {
-            _STL_INTERNAL_STATIC_ASSERT(_Is_elem_cptr<_Char_or_ptr>);
+            _STL_INTERNAL_STATIC_ASSERT(_Is_elem_cptr<_Char_or_ptr>::value);
         }
 
         if (_Count > max_size()) {
@@ -3381,7 +3383,7 @@ public:
         _Adl_verify_range(_First, _Last);
         const auto _UFirst = _Get_unwrapped(_First);
         const auto _ULast  = _Get_unwrapped(_Last);
-        if constexpr (_Is_elem_cptr<decltype(_UFirst)>) {
+        if constexpr (_Is_elem_cptr<decltype(_UFirst)>::value) {
             return append(_UFirst, _Convert_size<size_type>(static_cast<size_t>(_ULast - _UFirst)));
         } else {
             const basic_string _Right(_UFirst, _ULast, get_allocator());
@@ -3467,7 +3469,7 @@ public:
         _Adl_verify_range(_First, _Last);
         const auto _UFirst = _Get_unwrapped(_First);
         const auto _ULast  = _Get_unwrapped(_Last);
-        if constexpr (_Is_elem_cptr<decltype(_UFirst)>) {
+        if constexpr (_Is_elem_cptr<decltype(_UFirst)>::value) {
             return assign(_UFirst, _Convert_size<size_type>(static_cast<size_t>(_ULast - _UFirst)));
         } else {
             basic_string _Right(_UFirst, _ULast, get_allocator());
@@ -3621,7 +3623,7 @@ public:
         _Adl_verify_range(_First, _Last);
         const auto _UFirst = _Get_unwrapped(_First);
         const auto _ULast  = _Get_unwrapped(_Last);
-        if constexpr (_Is_elem_cptr<decltype(_UFirst)>) {
+        if constexpr (_Is_elem_cptr<decltype(_UFirst)>::value) {
             insert(_Off, _UFirst, _Convert_size<size_type>(static_cast<size_t>(_ULast - _UFirst)));
         } else {
             const basic_string _Right(_UFirst, _ULast, get_allocator());
@@ -3887,7 +3889,7 @@ public:
         _Adl_verify_range(_First2, _Last2);
         const auto _UFirst2 = _Get_unwrapped(_First2);
         const auto _ULast2  = _Get_unwrapped(_Last2);
-        if constexpr (_Is_elem_cptr<decltype(_UFirst2)>) {
+        if constexpr (_Is_elem_cptr<decltype(_UFirst2)>::value) {
             return replace(_Off, _Length, _UFirst2, _Convert_size<size_type>(static_cast<size_t>(_ULast2 - _UFirst2)));
         } else {
             const basic_string _Right(_UFirst2, _ULast2, get_allocator());

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -2472,7 +2472,7 @@ private:
 
     template <class _Iter>
     // TRANSITION, /clr:pure is incompatible with templated static constexpr data members
-    //static constexpr bool _Is_elem_cptr =_Is_any_of_v<_Iter, const _Elem* const, _Elem* const, const _Elem*, _Elem*>;
+    // static constexpr bool _Is_elem_cptr =_Is_any_of_v<_Iter, const _Elem* const, _Elem* const, const _Elem*, _Elem*>;
     using _Is_elem_cptr = bool_constant<_Is_any_of_v<_Iter, const _Elem* const, _Elem* const, const _Elem*, _Elem*>>;
 
 #if _HAS_CXX17

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -2471,7 +2471,7 @@ private:
     static constexpr size_t _Memcpy_val_size   = sizeof(_Scary_val) - _Memcpy_val_offset;
 
     template <class _Iter>
-    using _Is_elem_cptr = constexpr bool(stuff);
+    static constexpr bool _Is_elem_cptr = bool_constant<_Is_any_of_v<_Iter, const _Elem* const, _Elem* const, const _Elem*, _Elem*>>;;
 
 #if _HAS_CXX17
     template <class _StringViewIsh>
@@ -2663,7 +2663,7 @@ public:
             _Mypair._Myval2._Alloc_proxy(_GET_PROXY_ALLOCATOR(_Alty, _Getal()));
             _Tidy_init();
         } else {
-            if constexpr (_Is_elem_cptr<decltype(_UFirst)>::value) {
+            if constexpr (_Is_elem_cptr<decltype(_UFirst)>) {
                 _Construct<_Construct_strategy::_From_ptr>(
                     _UFirst, _Convert_size<size_type>(static_cast<size_t>(_ULast - _UFirst)));
             } else {
@@ -2681,7 +2681,7 @@ private:
         if constexpr (_Strat == _Construct_strategy::_From_char) {
             _STL_INTERNAL_STATIC_ASSERT(is_same_v<_Char_or_ptr, _Elem>);
         } else {
-            _STL_INTERNAL_STATIC_ASSERT(_Is_elem_cptr<_Char_or_ptr>::value);
+            _STL_INTERNAL_STATIC_ASSERT(_Is_elem_cptr<_Char_or_ptr>);
         }
 
         if (_Count > max_size()) {
@@ -3381,7 +3381,7 @@ public:
         _Adl_verify_range(_First, _Last);
         const auto _UFirst = _Get_unwrapped(_First);
         const auto _ULast  = _Get_unwrapped(_Last);
-        if constexpr (_Is_elem_cptr<decltype(_UFirst)>::value) {
+        if constexpr (_Is_elem_cptr<decltype(_UFirst)>) {
             return append(_UFirst, _Convert_size<size_type>(static_cast<size_t>(_ULast - _UFirst)));
         } else {
             const basic_string _Right(_UFirst, _ULast, get_allocator());
@@ -3467,7 +3467,7 @@ public:
         _Adl_verify_range(_First, _Last);
         const auto _UFirst = _Get_unwrapped(_First);
         const auto _ULast  = _Get_unwrapped(_Last);
-        if constexpr (_Is_elem_cptr<decltype(_UFirst)>::value) {
+        if constexpr (_Is_elem_cptr<decltype(_UFirst)>) {
             return assign(_UFirst, _Convert_size<size_type>(static_cast<size_t>(_ULast - _UFirst)));
         } else {
             basic_string _Right(_UFirst, _ULast, get_allocator());
@@ -3621,7 +3621,7 @@ public:
         _Adl_verify_range(_First, _Last);
         const auto _UFirst = _Get_unwrapped(_First);
         const auto _ULast  = _Get_unwrapped(_Last);
-        if constexpr (_Is_elem_cptr<decltype(_UFirst)>::value) {
+        if constexpr (_Is_elem_cptr<decltype(_UFirst)>) {
             insert(_Off, _UFirst, _Convert_size<size_type>(static_cast<size_t>(_ULast - _UFirst)));
         } else {
             const basic_string _Right(_UFirst, _ULast, get_allocator());
@@ -3887,7 +3887,7 @@ public:
         _Adl_verify_range(_First2, _Last2);
         const auto _UFirst2 = _Get_unwrapped(_First2);
         const auto _ULast2  = _Get_unwrapped(_Last2);
-        if constexpr (_Is_elem_cptr<decltype(_UFirst2)>::value) {
+        if constexpr (_Is_elem_cptr<decltype(_UFirst2)>) {
             return replace(_Off, _Length, _UFirst2, _Convert_size<size_type>(static_cast<size_t>(_ULast2 - _UFirst2)));
         } else {
             const basic_string _Right(_UFirst2, _ULast2, get_allocator());

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -2471,7 +2471,7 @@ private:
     static constexpr size_t _Memcpy_val_size   = sizeof(_Scary_val) - _Memcpy_val_offset;
 
     template <class _Iter>
-    using _Is_elem_cptr = bool_constant<_Is_any_of_v<_Iter, const _Elem* const, _Elem* const, const _Elem*, _Elem*>>;
+    using _Is_elem_cptr = constexpr bool(stuff);
 
 #if _HAS_CXX17
     template <class _StringViewIsh>

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -2471,7 +2471,7 @@ private:
     static constexpr size_t _Memcpy_val_size   = sizeof(_Scary_val) - _Memcpy_val_offset;
 
     template <class _Iter>
-    static constexpr bool _Is_elem_cptr = bool_constant<_Is_any_of_v<_Iter, const _Elem* const, _Elem* const, const _Elem*, _Elem*>>;
+    static constexpr bool _Is_elem_cptr = _Is_any_of_v<_Iter, const _Elem* const, _Elem* const, const _Elem*, _Elem*>;
 
 #if _HAS_CXX17
     template <class _StringViewIsh>

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -2471,7 +2471,7 @@ private:
     static constexpr size_t _Memcpy_val_size   = sizeof(_Scary_val) - _Memcpy_val_offset;
 
     template <class _Iter>
-    static constexpr bool _Is_elem_cptr = bool_constant<_Is_any_of_v<_Iter, const _Elem* const, _Elem* const, const _Elem*, _Elem*>>;;
+    static constexpr bool _Is_elem_cptr = bool_constant<_Is_any_of_v<_Iter, const _Elem* const, _Elem* const, const _Elem*, _Elem*>>;
 
 #if _HAS_CXX17
     template <class _StringViewIsh>


### PR DESCRIPTION
fixes #2898

<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
