### PR TITLE
P1899R3: `views::stride`

### DIFF
--- a/stl/debugger/STL.natvis
+++ b/stl/debugger/STL.natvis
@@ -1881,6 +1881,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
     <AlternativeType Name="std::ranges::filter_view&lt;*&gt;"/>
     <AlternativeType Name="std::ranges::owning_view&lt;*&gt;"/>
     <AlternativeType Name="std::ranges::chunk_by_view&lt;*&gt;"/>
+    <AlternativeType Name="std::ranges::stride_view&lt;*&gt;"/>
     <DisplayString>{_Range}</DisplayString>
     <Expand>
       <Item Optional="true" Name="pred">_Pred</Item>
@@ -1888,6 +1889,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
       <Item Optional="true" Name="count">_Count</Item>
       <Item Optional="true" Name="function">_Fun</Item>
       <Item Optional="true" Name="pattern">_Pattern</Item>
+      <Item Optional="true" Name="stride">_Stride</Item>
     </Expand>
   </Type>
 

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -6425,7 +6425,7 @@ namespace ranges {
 #if _ITERATOR_DEBUG_LEVEL != 0
                 _STL_VERIFY(_Current != _End, "cannot increment stride_view end iterator");
 #endif // _ITERATOR_DEBUG_LEVEL != 0
-                _Missing = ranges::advance(_Current, _Stride, _End);
+                _Missing = _RANGES advance(_Current, _Stride, _End);
                 return *this;
             }
 

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -6341,6 +6341,354 @@ namespace ranges {
 
         inline constexpr _Chunk_by_fn chunk_by;
     } // namespace views
+
+    template <view _Vw>
+        requires input_range<_Vw>
+    class stride_view : public view_interface<stride_view<_Vw>> {
+    private:
+        /* [[no_unique_address]] */ _Vw _Range;
+        range_difference_t<_Vw> _Stride;
+
+        template <class _BaseTy>
+        class _Iterator_base {};
+
+        template <forward_range _BaseTy>
+        class _Iterator_base<_BaseTy> {
+        private:
+            using _BaseCategory = typename iterator_traits<iterator_t<_BaseTy>>::iterator_category;
+
+        public:
+            using iterator_category = conditional_t<derived_from<_BaseCategory, random_access_iterator_tag>,
+                random_access_iterator_tag, _BaseCategory>;
+        };
+
+        template <bool _Const>
+        class _Iterator : public _Iterator_base<_Maybe_const<_Const, _Vw>> {
+        private:
+            friend stride_view;
+
+            using _ParentTy      = _Maybe_const<_Const, stride_view>;
+            using _Base          = _Maybe_const<_Const, _Vw>;
+            using _Base_iterator = iterator_t<_Base>;
+            using _Base_sentinel = sentinel_t<_Base>;
+
+            /* [[no_unique_address]] */ _Base_iterator _Current{};
+            /* [[no_unique_address]] */ _Base_sentinel _End{};
+            range_difference_t<_Base> _Stride  = 0;
+            range_difference_t<_Base> _Missing = 0;
+
+            constexpr _Iterator(_ParentTy* _Parent, _Base_iterator _Current_,
+                range_difference_t<_Base> _Missing_ = 0) //
+                noexcept(noexcept(_RANGES end(_Parent->_Range)) && is_nothrow_move_constructible_v<_Base_iterator> //
+                         && is_nothrow_move_constructible_v<_Base_sentinel>) // strengthened
+                : _Current(_STD move(_Current_)), _End(_RANGES end(_Parent->_Range)), _Stride(_Parent->_Stride),
+                  _Missing(_Missing_) {}
+
+        public:
+            using difference_type  = range_difference_t<_Base>;
+            using value_type       = range_value_t<_Base>;
+            using iterator_concept = conditional_t<random_access_range<_Base>, random_access_iterator_tag,
+                conditional_t<bidirectional_range<_Base>, bidirectional_iterator_tag,
+                    conditional_t<forward_range<_Base>, forward_iterator_tag, input_iterator_tag>>>;
+
+            // clang-format off
+            _Iterator() requires default_initializable<_Base_iterator> = default;
+            // clang-format on
+
+            constexpr _Iterator(_Iterator<!_Const> _Other) noexcept(
+                is_nothrow_constructible_v<_Base_iterator, iterator_t<_Vw>> //
+                    && is_nothrow_constructible_v<_Base_sentinel, sentinel_t<_Vw>> //
+                ) /* strengthened */ requires _Const
+                && convertible_to<iterator_t<_Vw>, _Base_iterator> && convertible_to<sentinel_t<_Vw>, _Base_sentinel>
+                : _Current(_STD move(_Other._Current)),
+                  _End(_STD move(_Other._End)),
+                  _Stride(_Other._Stride),
+                  _Missing(_Other._Missing) {}
+
+            _NODISCARD constexpr _Base_iterator base() && noexcept(
+                is_nothrow_move_constructible_v<_Base_iterator>) /* strengthened */ {
+                return _STD move(_Current);
+            }
+
+            _NODISCARD constexpr const _Base_iterator& base() const& noexcept {
+                return _Current;
+            }
+
+            _NODISCARD constexpr decltype(auto) operator*() const noexcept(noexcept(*_Current)) /* strengthened */ {
+#if _ITERATOR_DEBUG_LEVEL != 0
+                _STL_VERIFY(_Current != _End, "cannot dereference stride_view end iterator");
+#endif // _ITERATOR_DEBUG_LEVEL != 0
+                return *_Current;
+            }
+
+            constexpr _Iterator& operator++() {
+#if _ITERATOR_DEBUG_LEVEL != 0
+                _STL_VERIFY(_Current != _End, "cannot increment stride_view end iterator");
+#endif // _ITERATOR_DEBUG_LEVEL != 0
+                _Missing = ranges::advance(_Current, _Stride, _End);
+                return *this;
+            }
+
+            constexpr void operator++(int) {
+                ++*this;
+            }
+
+            constexpr _Iterator operator++(int) requires forward_range<_Base> {
+                auto _Tmp = *this;
+                ++*this;
+                return _Tmp;
+            }
+
+            constexpr _Iterator& operator--() requires bidirectional_range<_Base> {
+                _RANGES advance(_Current, _Missing - _Stride);
+                _Missing = 0;
+                return *this;
+            }
+
+            constexpr _Iterator operator--(int) requires bidirectional_range<_Base> {
+                auto _Tmp = *this;
+                --*this;
+                return _Tmp;
+            }
+
+            constexpr _Iterator& operator+=(const difference_type _Off) requires random_access_range<_Base> {
+                if (_Off > 0) {
+#if _ITERATOR_DEBUG_LEVEL != 0
+                    _STL_VERIFY(_Off == 1 || _Stride <= (numeric_limits<difference_type>::max)() / (_Off - 1),
+                        "cannot advance stride_view iterator past end (integer overflow)");
+                    _STL_VERIFY(_RANGES distance(_Current, _End) > _Stride * (_Off - 1),
+                        "cannot advance stride_view iterator past end");
+#endif // _ITERATOR_DEBUG_LEVEL != 0
+                    _Missing = _RANGES advance(_Current, _Stride * _Off, _End);
+                } else if (_Off < 0) {
+                    _RANGES advance(_Current, _Stride * _Off + _Missing);
+                    _Missing = 0;
+                }
+                return *this;
+            }
+
+            constexpr _Iterator& operator-=(const difference_type _Off) requires random_access_range<_Base> {
+                return *this += -_Off;
+            }
+
+            _NODISCARD constexpr decltype(auto) operator[](const difference_type _Off) const
+                noexcept(noexcept(*(*this + _Off))) /* strengthened */ requires random_access_range<_Base> {
+                return *(*this + _Off);
+            }
+
+            _NODISCARD_FRIEND constexpr bool operator==(const _Iterator& _It, default_sentinel_t) noexcept(
+                noexcept(_Implicitly_convert_to<bool>(_It._Current == _It._End))) /* strengthened */ {
+                return _It._Current == _It._End;
+            }
+
+            _NODISCARD_FRIEND constexpr bool operator==(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+                noexcept(_Implicitly_convert_to<bool>(_Left._Current == _Right._Current))) // strengthened
+                requires equality_comparable<_Base_iterator> {
+                return _Left._Current == _Right._Current;
+            }
+
+            _NODISCARD_FRIEND constexpr bool operator<(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+                noexcept(_Implicitly_convert_to<bool>(_Left._Current < _Right._Current))) // strengthened
+                requires random_access_range<_Base> {
+                return _Left._Current < _Right._Current;
+            }
+
+            _NODISCARD_FRIEND constexpr bool operator>(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+                noexcept(_Implicitly_convert_to<bool>(_Right._Current < _Left._Current))) // strengthened
+                requires random_access_range<_Base> {
+                return _Right._Current < _Left._Current;
+            }
+
+            _NODISCARD_FRIEND constexpr bool operator<=(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+                noexcept(_Implicitly_convert_to<bool>(!(_Right._Current < _Left._Current)))) // strengthened
+                requires random_access_range<_Base> {
+                return !(_Right._Current < _Left._Current);
+            }
+
+            _NODISCARD_FRIEND constexpr bool operator>=(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+                noexcept(_Implicitly_convert_to<bool>(!(_Left._Current < _Right._Current)))) // strengthened
+                requires random_access_range<_Base> {
+                return !(_Left._Current < _Right._Current);
+            }
+
+            _NODISCARD_FRIEND constexpr auto operator<=>(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+                noexcept(_Left._Current <=> _Right._Current)) // strengthened
+                requires random_access_range<_Base> && three_way_comparable<_Base_iterator> {
+                return _Left._Current <=> _Right._Current;
+            }
+
+            _NODISCARD_FRIEND constexpr _Iterator operator+(const _Iterator& _It, const difference_type _Off) //
+                requires random_access_range<_Base> {
+                auto _Copy = _It;
+                _Copy += _Off;
+                return _Copy;
+            }
+
+            _NODISCARD_FRIEND constexpr _Iterator operator+(const difference_type _Off, const _Iterator& _It) //
+                requires random_access_range<_Base> {
+                auto _Copy = _It;
+                _Copy += _Off;
+                return _Copy;
+            }
+
+            _NODISCARD_FRIEND constexpr _Iterator operator-(const _Iterator& _It, const difference_type _Off) //
+                requires random_access_range<_Base> {
+                auto _Copy = _It;
+                _Copy -= _Off;
+                return _Copy;
+            }
+
+            _NODISCARD_FRIEND constexpr difference_type operator-(const _Iterator& _Left, const _Iterator& _Right) //
+                noexcept(noexcept(_Left._Current - _Right._Current)) // strengthened
+                requires sized_sentinel_for<_Base_iterator, _Base_iterator> {
+                const auto _Diff = _Left._Current - _Right._Current;
+                if constexpr (forward_range<_Base>) {
+                    return (_Diff + _Left._Missing - _Right._Missing) / _Left._Stride;
+                } else {
+                    if (_Diff < 0) {
+                        return -_Div_ceil(-_Diff, _Left._Stride);
+                    } else {
+                        return _Div_ceil(_Diff, _Left._Stride);
+                    }
+                }
+            }
+
+            _NODISCARD_FRIEND constexpr difference_type operator-(default_sentinel_t, const _Iterator& _It) noexcept(
+                noexcept(_It._End - _It._Current)) // strengthened
+                requires sized_sentinel_for<_Base_sentinel, _Base_iterator> {
+                return _Div_ceil(_It._End - _It._Current, _It._Stride);
+            }
+
+            _NODISCARD_FRIEND constexpr difference_type operator-(const _Iterator& _It, default_sentinel_t) noexcept(
+                noexcept(_It._End - _It._Current)) // strengthened
+                requires sized_sentinel_for<_Base_sentinel, _Base_iterator> {
+                return -_Div_ceil(_It._End - _It._Current, _It._Stride);
+            }
+
+            _NODISCARD_FRIEND constexpr range_rvalue_reference_t<_Base> iter_move(const _Iterator& _It) noexcept(
+                noexcept(_RANGES iter_move(_It._Current))) {
+                return _RANGES iter_move(_It._Current);
+            }
+
+            friend constexpr void iter_swap(const _Iterator& _Left, const _Iterator& _Right) noexcept(
+                noexcept(_RANGES iter_swap(_Left._Current, _Right._Current))) //
+                requires indirectly_swappable<_Base_iterator> {
+                return _RANGES iter_swap(_Left._Current, _Right._Current);
+            }
+        };
+
+    public:
+        constexpr explicit stride_view(_Vw _Range_, range_difference_t<_Vw> _Stride_) noexcept(
+            is_nothrow_move_constructible_v<_Vw>) // strengthened
+            : _Range(_STD move(_Range_)), _Stride(_Stride_) {
+#if _CONTAINER_DEBUG_LEVEL > 0
+            _STL_VERIFY(_Stride > 0, "stride must be greater than 0");
+#endif // _CONTAINER_DEBUG_LEVEL > 0
+        }
+
+        _NODISCARD constexpr _Vw base() const& noexcept(is_nothrow_copy_constructible_v<_Vw>) // strengthened
+            requires copy_constructible<_Vw> {
+            return _Range;
+        }
+
+        _NODISCARD constexpr _Vw base() && noexcept(is_nothrow_move_constructible_v<_Vw>) /* strengthened */ {
+            return _STD move(_Range);
+        }
+
+        _NODISCARD constexpr range_difference_t<_Vw> stride() const noexcept {
+            return _Stride;
+        }
+
+        _NODISCARD constexpr auto begin() noexcept(
+            noexcept(_RANGES begin(_Range)) && is_nothrow_move_constructible_v<iterator_t<_Vw>>) // strengthened
+            requires(!_Simple_view<_Vw>) {
+            return _Iterator<false>{this, _RANGES begin(_Range)};
+        }
+
+        _NODISCARD constexpr auto begin() const noexcept(
+            noexcept(_RANGES begin(_Range)) && is_nothrow_move_constructible_v<iterator_t<const _Vw>>) // strengthened
+            requires range<const _Vw> {
+            return _Iterator<true>{this, _RANGES begin(_Range)};
+        }
+
+        _NODISCARD constexpr auto end() noexcept(noexcept(_RANGES distance(_Range)) && noexcept(_RANGES end(_Range))
+                                                 && is_nothrow_move_constructible_v<iterator_t<_Vw>>) // strengthened
+            requires(!_Simple_view<_Vw>) {
+            if constexpr (common_range<_Vw> && sized_range<_Vw> && forward_range<_Vw>) {
+                const auto _Missing =
+                    static_cast<range_difference_t<_Vw>>(_Stride - _RANGES distance(_Range) % _Stride);
+                if (_Missing == _Stride) {
+                    return _Iterator<false>{this, _RANGES end(_Range)};
+                } else {
+                    return _Iterator<false>{this, _RANGES end(_Range), _Missing};
+                }
+            } else if constexpr (common_range<_Vw> && !bidirectional_range<_Vw>) {
+                return _Iterator<false>{this, _RANGES end(_Range)};
+            } else {
+                return default_sentinel;
+            }
+        }
+
+        _NODISCARD constexpr auto end() const
+            noexcept(noexcept(_RANGES distance(_Range)) && noexcept(_RANGES end(_Range))
+                     && is_nothrow_move_constructible_v<iterator_t<const _Vw>>) // strengthened
+            requires range<const _Vw> {
+            if constexpr (common_range<const _Vw> && sized_range<const _Vw> && forward_range<const _Vw>) {
+                const auto _Missing =
+                    static_cast<range_difference_t<_Vw>>(_Stride - _RANGES distance(_Range) % _Stride);
+                if (_Missing == _Stride) {
+                    return _Iterator<true>{this, _RANGES end(_Range)};
+                } else {
+                    return _Iterator<true>{this, _RANGES end(_Range), _Missing};
+                }
+            } else if constexpr (common_range<const _Vw> && !bidirectional_range<const _Vw>) {
+                return _Iterator<true>{this, _RANGES end(_Range)};
+            } else {
+                return default_sentinel;
+            }
+        }
+
+        _NODISCARD constexpr auto size() noexcept(noexcept(_RANGES distance(_Range))) // strengthened
+            requires sized_range<_Vw> {
+            return _To_unsigned_like(_Div_ceil(_RANGES distance(_Range), _Stride));
+        }
+
+        _NODISCARD constexpr auto size() const noexcept(noexcept(_RANGES distance(_Range))) // strengthened
+            requires sized_range<const _Vw> {
+            return _To_unsigned_like(_Div_ceil(_RANGES distance(_Range), _Stride));
+        }
+    };
+
+    template <class _Rng>
+    stride_view(_Rng&&, range_difference_t<_Rng>) -> stride_view<views::all_t<_Rng>>;
+
+    template <class _Vw>
+    inline constexpr bool enable_borrowed_range<stride_view<_Vw>> = enable_borrowed_range<_Vw>;
+
+    namespace views {
+        struct _Stride_fn {
+            // clang-format off
+            template <viewable_range _Rng>
+            _NODISCARD constexpr auto operator()(_Rng&& _Range, const range_difference_t<_Rng> _Stride) const noexcept(
+                noexcept(stride_view(_STD forward<_Rng>(_Range), _Stride))) requires requires {
+                stride_view(_STD forward<_Rng>(_Range), _Stride);
+            } {
+                // clang-format on
+                return stride_view(_STD forward<_Rng>(_Range), _Stride);
+            }
+
+            // clang-format off
+            template <class _Ty>
+                requires constructible_from<decay_t<_Ty>, _Ty>
+            _NODISCARD constexpr auto operator()(_Ty&& _Stride) const
+                noexcept(is_nothrow_constructible_v<decay_t<_Ty>, _Ty>) {
+                // clang-format on
+                return _Range_closure<_Stride_fn, decay_t<_Ty>>{_STD forward<_Ty>(_Stride)};
+            }
+        };
+
+        inline constexpr _Stride_fn stride;
+    } // namespace views
 #endif // _HAS_CXX23
 } // namespace ranges
 

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -6342,18 +6342,18 @@ namespace ranges {
         inline constexpr _Chunk_by_fn chunk_by;
     } // namespace views
 
-    template <view _Vw>
-        requires input_range<_Vw>
+    template <input_range _Vw>
+        requires view<_Vw>
     class stride_view : public view_interface<stride_view<_Vw>> {
     private:
         /* [[no_unique_address]] */ _Vw _Range;
         range_difference_t<_Vw> _Stride;
 
         template <class _BaseTy>
-        class _Iterator_base {};
+        class _Category_base {};
 
         template <forward_range _BaseTy>
-        class _Iterator_base<_BaseTy> {
+        class _Category_base<_BaseTy> {
         private:
             using _BaseCategory = typename iterator_traits<iterator_t<_BaseTy>>::iterator_category;
 
@@ -6363,7 +6363,7 @@ namespace ranges {
         };
 
         template <bool _Const>
-        class _Iterator : public _Iterator_base<_Maybe_const<_Const, _Vw>> {
+        class _Iterator : public _Category_base<_Maybe_const<_Const, _Vw>> {
         private:
             friend stride_view;
 

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -302,6 +302,7 @@
 // P1659R3 ranges::starts_with, ranges::ends_with
 // P1679R3 contains() For basic_string/basic_string_view
 // P1682R3 to_underlying() For Enumerations
+// P1899R3 views::stride
 // P1951R1 Default Template Arguments For pair's Forwarding Constructor
 // P1989R2 Range Constructor For string_view
 // P2077R3 Heterogeneous Erasure Overloads For Associative Containers
@@ -1475,6 +1476,7 @@
 #define __cpp_lib_ranges_join_with        202202L
 #define __cpp_lib_ranges_slide            202202L
 #define __cpp_lib_ranges_starts_ends_with 202106L
+#define __cpp_lib_ranges_stride           202207L
 #endif // __cpp_lib_concepts
 
 #define __cpp_lib_spanstream                  202106L

--- a/tests/std/test.lst
+++ b/tests/std/test.lst
@@ -481,6 +481,7 @@ tests\P1645R1_constexpr_numeric
 tests\P1659R3_ranges_alg_ends_with
 tests\P1659R3_ranges_alg_starts_with
 tests\P1682R3_to_underlying
+tests\P1899R3_views_stride_death
 tests\P1951R1_default_arguments_pair_forward_ctor
 tests\P2136R3_invoke_r
 tests\P2162R2_std_visit_for_derived_classes_from_variant

--- a/tests/std/test.lst
+++ b/tests/std/test.lst
@@ -481,6 +481,7 @@ tests\P1645R1_constexpr_numeric
 tests\P1659R3_ranges_alg_ends_with
 tests\P1659R3_ranges_alg_starts_with
 tests\P1682R3_to_underlying
+tests\P1899R3_views_stride
 tests\P1899R3_views_stride_death
 tests\P1951R1_default_arguments_pair_forward_ctor
 tests\P2136R3_invoke_r

--- a/tests/std/tests/P1899R3_views_stride/env.lst
+++ b/tests/std/tests/P1899R3_views_stride/env.lst
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst

--- a/tests/std/tests/P1899R3_views_stride/test.cpp
+++ b/tests/std/tests/P1899R3_views_stride/test.cpp
@@ -215,7 +215,7 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
                 assert(*prev(cs) == *prev(end(expected)));
             }
 
-            if constexpr (copy_constructible<const V>) {
+            if constexpr (copy_constructible<V>) {
                 const auto r2 = r;
                 if (!is_empty) {
                     assert(*prev(r2.end()) == *prev(end(expected)));

--- a/tests/std/tests/P1899R3_views_stride/test.cpp
+++ b/tests/std/tests/P1899R3_views_stride/test.cpp
@@ -1,0 +1,609 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <algorithm>
+#include <cassert>
+#include <forward_list>
+#include <ranges>
+#include <span>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include <range_algorithm_support.hpp>
+
+using namespace std;
+
+template <class Rng>
+concept CanViewStride = requires(Rng&& r) {
+    views::stride(forward<Rng>(r), 3);
+};
+
+template <ranges::input_range Rng, class Expected>
+constexpr bool test_one(Rng&& rng, Expected&& expected) {
+    using ranges::forward_range, ranges::bidirectional_range, ranges::random_access_range, ranges::common_range,
+        ranges::sized_range;
+    using ranges::stride_view, ranges::begin, ranges::end, ranges::iterator_t, ranges::sentinel_t, ranges::prev;
+
+    constexpr bool is_view = ranges::view<remove_cvref_t<Rng>>;
+
+    using V = views::all_t<Rng>;
+    using R = stride_view<V>;
+
+    STATIC_ASSERT(ranges::view<R>);
+    STATIC_ASSERT(ranges::input_range<R>);
+    STATIC_ASSERT(forward_range<R> == forward_range<Rng>);
+    STATIC_ASSERT(bidirectional_range<R> == bidirectional_range<Rng>);
+    STATIC_ASSERT(random_access_range<R> == random_access_range<Rng>);
+    STATIC_ASSERT(!ranges::contiguous_range<R>);
+
+    // Validate non-default-initializability
+    STATIC_ASSERT(!is_default_constructible_v<R>);
+
+    // Validate borrowed_range
+    STATIC_ASSERT(ranges::borrowed_range<R> == ranges::borrowed_range<V>);
+
+    // Validate range adaptor object and range adaptor closure
+    constexpr auto closure = views::stride(3);
+
+    // ... with lvalue argument
+    STATIC_ASSERT(CanViewStride<Rng&> == (!is_view || copy_constructible<V>) );
+    if constexpr (CanViewStride<Rng&>) {
+        constexpr bool is_noexcept = !is_view || is_nothrow_copy_constructible_v<V>;
+
+        STATIC_ASSERT(same_as<decltype(views::stride(rng, 3)), R>);
+        STATIC_ASSERT(noexcept(views::stride(rng, 3)) == is_noexcept);
+
+        STATIC_ASSERT(same_as<decltype(rng | closure), R>);
+        STATIC_ASSERT(noexcept(rng | closure) == is_noexcept);
+    }
+
+    // ... with const lvalue argument
+    STATIC_ASSERT(CanViewStride<const remove_reference_t<Rng>&> == (!is_view || copy_constructible<V>) );
+    if constexpr (CanViewStride<const remove_reference_t<Rng>&>) {
+        using RC                   = stride_view<views::all_t<const remove_reference_t<Rng>&>>;
+        constexpr bool is_noexcept = !is_view || is_nothrow_copy_constructible_v<V>;
+
+        STATIC_ASSERT(same_as<decltype(views::stride(as_const(rng), 3)), RC>);
+        STATIC_ASSERT(noexcept(views::stride(as_const(rng), 3)) == is_noexcept);
+
+        STATIC_ASSERT(same_as<decltype(as_const(rng) | closure), RC>);
+        STATIC_ASSERT(noexcept(as_const(rng) | closure) == is_noexcept);
+    }
+
+    // ... with rvalue argument
+    STATIC_ASSERT(CanViewStride<remove_reference_t<Rng>> == (is_view || movable<remove_reference_t<Rng>>) );
+    if constexpr (CanViewStride<remove_reference_t<Rng>>) {
+        using RS                   = stride_view<views::all_t<remove_reference_t<Rng>>>;
+        constexpr bool is_noexcept = is_nothrow_move_constructible_v<V>;
+
+        STATIC_ASSERT(same_as<decltype(views::stride(std::move(rng), 3)), RS>);
+        STATIC_ASSERT(noexcept(views::stride(std::move(rng), 3)) == is_noexcept);
+
+        STATIC_ASSERT(same_as<decltype(std::move(rng) | closure), RS>);
+        STATIC_ASSERT(noexcept(std::move(rng) | closure) == is_noexcept);
+    }
+
+    // ... with const rvalue argument
+    STATIC_ASSERT(CanViewStride<const remove_reference_t<Rng>> == (is_view && copy_constructible<V>) );
+    if constexpr (CanViewStride<const remove_reference_t<Rng>>) {
+        constexpr bool is_noexcept = is_nothrow_copy_constructible_v<V>;
+
+        STATIC_ASSERT(same_as<decltype(views::stride(std::move(as_const(rng)), 3)), R>);
+        STATIC_ASSERT(noexcept(views::stride(std::move(as_const(rng)), 3)) == is_noexcept);
+
+        STATIC_ASSERT(same_as<decltype(std::move(as_const(rng)) | closure), R>);
+        STATIC_ASSERT(noexcept(std::move(as_const(rng)) | closure) == is_noexcept);
+    }
+
+    // Validate deduction guide
+    same_as<R> auto r = stride_view{std::forward<Rng>(rng), 3};
+
+    // Validate stride_view::stride
+    {
+        const same_as<ranges::range_difference_t<V>> auto s = as_const(r).stride();
+        assert(s == 3);
+        STATIC_ASSERT(noexcept(as_const(r).stride()));
+    }
+
+    // Validate stride_view::size
+    STATIC_ASSERT(CanMemberSize<R> == sized_range<V>);
+    if constexpr (CanMemberSize<R>) {
+        same_as<_Make_unsigned_like_t<ranges::range_difference_t<V>>> auto s = r.size();
+        assert(s == ranges::size(expected));
+        STATIC_ASSERT(noexcept(r.size()) == noexcept(ranges::distance(rng)));
+    }
+
+    // Validate stride_view::size (const)
+    STATIC_ASSERT(CanMemberSize<const R> == sized_range<const V>);
+    if constexpr (CanMemberSize<const R>) {
+        same_as<_Make_unsigned_like_t<ranges::range_difference_t<const V>>> auto s = as_const(r).size();
+        assert(s == ranges::size(expected));
+        STATIC_ASSERT(noexcept(as_const(r).size()) == noexcept(ranges::distance(rng)));
+    }
+
+    const bool is_empty = ranges::empty(expected);
+
+    // Validate view_interface::empty and operator bool
+    STATIC_ASSERT(CanMemberEmpty<R> == (forward_range<V> || sized_range<V>) );
+    STATIC_ASSERT(CanBool<R> == CanEmpty<R>);
+    if constexpr (CanMemberEmpty<R>) {
+        assert(r.empty() == is_empty);
+        assert(static_cast<bool>(r) == !is_empty);
+    }
+
+    // Validate view_interface::empty and operator bool (const)
+    STATIC_ASSERT(CanMemberEmpty<const R> == (forward_range<const Rng> || sized_range<const V>) );
+    STATIC_ASSERT(CanBool<const R> == CanEmpty<const R>);
+    if constexpr (CanMemberEmpty<const R>) {
+        assert(as_const(r).empty() == is_empty);
+        assert(static_cast<bool>(as_const(r)) == !is_empty);
+    }
+
+    // Validate content
+    assert(ranges::equal(r, expected));
+    if (!forward_range<V>) { // intentionally not if constexpr
+        return true;
+    }
+
+    // Validate stride_view::begin
+    STATIC_ASSERT(CanMemberBegin<R>);
+    {
+        const same_as<iterator_t<R>> auto i = r.begin();
+        if (!is_empty) {
+            assert(*i == *begin(expected));
+        }
+
+        if constexpr (copy_constructible<V>) {
+            auto r2                              = r;
+            const same_as<iterator_t<R>> auto i2 = r2.begin();
+            if (!is_empty) {
+                assert(*i2 == *i);
+            }
+        }
+    }
+
+    // Validate stride_view::begin (const)
+    STATIC_ASSERT(CanMemberBegin<const R> == ranges::range<const V>);
+    if constexpr (CanMemberBegin<const R>) {
+        const same_as<iterator_t<const R>> auto ci = as_const(r).begin();
+        if (!is_empty) {
+            assert(*ci == *begin(expected));
+        }
+
+        if constexpr (copy_constructible<V>) {
+            const auto cr2                              = r;
+            const same_as<iterator_t<const R>> auto ci2 = cr2.begin();
+            if (!is_empty) {
+                assert(*ci2 == *ci);
+            }
+        }
+    }
+
+    // Validate stride_view::end
+    STATIC_ASSERT(CanMemberEnd<R>);
+    {
+        const same_as<sentinel_t<R>> auto s = r.end();
+        assert((r.begin() == s) == is_empty);
+        STATIC_ASSERT(common_range<R> == (common_range<V> && (sized_range<V> || !bidirectional_range<V>) ));
+        if constexpr (common_range<R> && bidirectional_range<V>) {
+            if (!is_empty) {
+                assert(*prev(s) == *prev(end(expected)));
+            }
+
+            if constexpr (copy_constructible<V>) {
+                auto r2 = r;
+                if (!is_empty) {
+                    assert(*prev(r2.end()) == *prev(end(expected)));
+                }
+            }
+        }
+        if constexpr (!common_range<R>) {
+            STATIC_ASSERT(same_as<sentinel_t<R>, default_sentinel_t>);
+        }
+    }
+
+    // Validate stride_view::end (const)
+    STATIC_ASSERT(CanMemberEnd<const R> == ranges::range<const V>);
+    if constexpr (CanMemberEnd<const R>) {
+        const same_as<sentinel_t<const R>> auto cs = as_const(r).end();
+        assert((as_const(r).begin() == cs) == is_empty);
+        STATIC_ASSERT(common_range<const R> == //
+                      (common_range<const V> && (sized_range<const V> || !bidirectional_range<const V>) ));
+        if constexpr (common_range<const R> && bidirectional_range<const V>) {
+            if (!is_empty) {
+                assert(*prev(cs) == *prev(end(expected)));
+            }
+
+            if constexpr (copy_constructible<const V>) {
+                const auto r2 = r;
+                if (!is_empty) {
+                    assert(*prev(r2.end()) == *prev(end(expected)));
+                }
+            }
+        }
+        if constexpr (!common_range<const R>) {
+            STATIC_ASSERT(same_as<sentinel_t<const R>, default_sentinel_t>);
+        }
+    }
+
+    // Validate view_interface::data
+    STATIC_ASSERT(!CanData<R>);
+    STATIC_ASSERT(!CanData<const R>);
+
+    if (is_empty) {
+        return true;
+    }
+
+    // Validate view_interface::operator[]
+    STATIC_ASSERT(CanIndex<R> == random_access_range<V>);
+    if constexpr (CanIndex<R>) {
+        assert(r[0] == expected[0]);
+    }
+
+    // Validate view_interface::operator[] (const)
+    STATIC_ASSERT(CanIndex<const R> == random_access_range<const V>);
+    if constexpr (CanIndex<const R>) {
+        assert(as_const(r)[0] == expected[0]);
+    }
+
+    // Validate view_interface::front
+    STATIC_ASSERT(CanMemberFront<R> == forward_range<V>);
+    if constexpr (CanMemberFront<R>) {
+        assert(r.front() == *begin(expected));
+    }
+
+    // Validate view_interface::front (const)
+    STATIC_ASSERT(CanMemberFront<const R> == forward_range<const V>);
+    if constexpr (CanMemberFront<const R>) {
+        assert(as_const(r).front() == *begin(expected));
+    }
+
+    // Validate view_interface::back
+    STATIC_ASSERT(CanMemberBack<R> == (bidirectional_range<V> && common_range<V> && sized_range<V>) );
+    if constexpr (CanMemberBack<R>) {
+        assert(r.back() == *prev(end(expected)));
+    }
+
+    // Validate view_interface::back (const)
+    STATIC_ASSERT(
+        CanMemberBack<const R> == (bidirectional_range<const V> && common_range<const V> && sized_range<const V>) );
+    if constexpr (CanMemberBack<const R>) {
+        assert(as_const(r).back() == *prev(end(expected)));
+    }
+
+    // Validate stride_view::iterator<not const>
+    {
+        // Check iterator_category
+        if constexpr (forward_range<R>) {
+            using IterCat = typename iterator_t<R>::iterator_category;
+            using C       = typename iterator_traits<iterator_t<V>>::iterator_category;
+            STATIC_ASSERT((derived_from<C, random_access_iterator_tag> && same_as<IterCat, random_access_iterator_tag>)
+                          || same_as<IterCat, C>);
+        }
+
+        if constexpr (forward_range<R>) {
+            [[maybe_unused]] const iterator_t<R> defaulted;
+        }
+        same_as<iterator_t<R>> auto i = r.begin();
+
+        // Comparisons with std::default_sentinel_t
+        assert(i != default_sentinel);
+        if constexpr (forward_range<R>) {
+            assert(ranges::next(i, r.end()) == default_sentinel);
+        }
+
+        // Equality operators
+        if constexpr (equality_comparable<iterator_t<V>>) {
+            assert(i == i);
+            if constexpr (forward_range<R>) {
+                assert(i != ranges::next(i, 1));
+            }
+        }
+
+        if constexpr (forward_range<R>) {
+            assert(*i++ == expected[0]);
+        } else {
+            STATIC_ASSERT(is_void_v<decltype(i++)>);
+        }
+        assert(*++i == expected[2]);
+
+        if constexpr (bidirectional_range<R>) {
+            assert(*i-- == expected[2]);
+            assert(*--i == expected[0]);
+        }
+
+        if constexpr (random_access_range<R>) {
+            i += 2;
+            assert(*i == expected[2]);
+
+            i -= 2;
+            assert(*i == expected[0]);
+
+            assert(i[2] == expected[2]);
+
+            const auto i2 = i + 2;
+            assert(*i2 == expected[2]);
+
+            const auto i3 = 2 + i;
+            assert(*i3 == expected[2]);
+
+            const auto i4 = i3 - 2;
+            assert(*i4 == expected[0]);
+
+            const same_as<ranges::range_difference_t<V>> auto diff1 = i2 - i;
+            assert(diff1 == 2);
+
+            const same_as<ranges::range_difference_t<V>> auto diff2 = i - i2;
+            assert(diff2 == -2);
+
+            // Comparisons
+            assert(i < i2);
+            assert(i2 <= i3);
+            assert(i3 > i4);
+            assert(i4 >= i);
+            if constexpr (three_way_comparable<iterator_t<V>>) {
+                assert(i <=> i2 == strong_ordering::less);
+                assert(i <=> i4 == strong_ordering::equal);
+                assert(i2 <=> i == strong_ordering::greater);
+            }
+        }
+
+        if constexpr (sized_sentinel_for<sentinel_t<V>, iterator_t<V>>) {
+            const auto i2   = r.begin();
+            const auto sen  = r.end();
+            const auto size = ranges::ssize(expected);
+
+            const same_as<ranges::range_difference_t<V>> auto diff3 = i2 - sen;
+            assert(diff3 == -size);
+
+            const same_as<ranges::range_difference_t<V>> auto diff4 = sen - i2;
+            assert(diff4 == size);
+        }
+
+        [[maybe_unused]] same_as<const iterator_t<V>&> decltype(auto) base_ref = as_const(i).base();
+        STATIC_ASSERT(noexcept(i.base()));
+        [[maybe_unused]] same_as<iterator_t<V>> decltype(auto) base_ref2 = std::move(i).base();
+    }
+
+    // Validate stride_view::iterator<const>
+    if constexpr (CanMemberBegin<const R>) {
+        // Check iterator_category
+        if constexpr (forward_range<const R>) {
+            using IterCat = typename iterator_t<const R>::iterator_category;
+            using C       = typename iterator_traits<iterator_t<const V>>::iterator_category;
+            STATIC_ASSERT((derived_from<C, random_access_iterator_tag> && same_as<IterCat, random_access_iterator_tag>)
+                          || same_as<IterCat, C>);
+        }
+
+        constexpr bool constructible_from_nonconst = convertible_to<iterator_t<V>, iterator_t<const V>> && //
+                                                     convertible_to<sentinel_t<V>, sentinel_t<const V>>;
+
+        if constexpr (forward_range<const R>) {
+            [[maybe_unused]] const iterator_t<const R> const_defaulted;
+        }
+        auto i                               = r.begin();
+        same_as<iterator_t<const R>> auto ci = as_const(r).begin();
+
+        // Comparisons with std::default_sentinel_t
+        assert(ci != default_sentinel);
+        if constexpr (forward_range<const R>) {
+            assert(ranges::next(ci, r.end()) == default_sentinel);
+        }
+
+        // Equality operators
+        if constexpr (equality_comparable<iterator_t<const V>>) {
+            assert(ci == ci);
+            if constexpr (forward_range<const R>) {
+                assert(ci != ranges::next(ci, 1));
+            }
+
+            if constexpr (constructible_from_nonconst) {
+                assert(ci == i);
+                if constexpr (forward_range<const R>) {
+                    assert(ci != ranges::next(i, 1));
+                }
+            }
+        }
+
+        if constexpr (forward_range<const R>) {
+            assert(*ci++ == expected[0]);
+        } else {
+            STATIC_ASSERT(is_void_v<decltype(i++)>);
+        }
+        assert(*++ci == expected[2]);
+
+        if constexpr (bidirectional_range<const R>) {
+            assert(*ci-- == expected[2]);
+            assert(*--ci == expected[0]);
+        }
+
+        if constexpr (random_access_range<const R>) {
+            ci += 2;
+            assert(*ci == expected[2]);
+
+            ci -= 2;
+            assert(*ci == expected[0]);
+
+            assert(ci[2] == expected[2]);
+
+            const auto ci2 = ci + 2;
+            assert(*ci2 == expected[2]);
+
+            const auto ci3 = 2 + ci;
+            assert(*ci3 == expected[2]);
+
+            const auto ci4 = ci3 - 2;
+            assert(*ci4 == expected[0]);
+
+            const same_as<ranges::range_difference_t<V>> auto diff1 = ci2 - ci;
+            assert(diff1 == 2);
+
+            const same_as<ranges::range_difference_t<V>> auto diff2 = ci - ci2;
+            assert(diff2 == -2);
+
+            // Comparisons
+            assert(ci < ci2);
+            assert(ci <= ci2);
+            assert(ci2 > ci);
+            assert(ci2 >= ci);
+            if constexpr (three_way_comparable<iterator_t<const V>>) {
+                assert(ci <=> ci4 == strong_ordering::equal);
+                assert(ci <=> ci2 == strong_ordering::less);
+                assert(ci2 <=> ci == strong_ordering::greater);
+            }
+
+            // Cross comparisons
+            if constexpr (constructible_from_nonconst) {
+                assert(i < ci2);
+                assert(i <= ci2);
+                assert(ci2 > i);
+                assert(ci2 >= i);
+                if constexpr (three_way_comparable<iterator_t<const V>>) {
+                    assert(ci <=> ci2 == strong_ordering::less);
+                    assert(ci <=> ci4 == strong_ordering::equal);
+                    assert(ci2 <=> ci == strong_ordering::greater);
+                }
+            }
+        }
+
+        if constexpr (sized_sentinel_for<sentinel_t<const V>, iterator_t<const V>>) {
+            const auto i2   = as_const(r).begin();
+            const auto sen  = as_const(r).end();
+            const auto size = ranges::ssize(expected);
+
+            const same_as<ranges::range_difference_t<const V>> auto diff3 = i2 - sen;
+            assert(diff3 == -size);
+
+            const same_as<ranges::range_difference_t<const V>> auto diff4 = sen - i2;
+            assert(diff4 == size);
+        }
+
+        [[maybe_unused]] same_as<const iterator_t<const V>&> decltype(auto) base_ref = as_const(ci).base();
+        STATIC_ASSERT(noexcept(ci.base()));
+        [[maybe_unused]] same_as<iterator_t<const V>> decltype(auto) base_ref2 = std::move(ci).base();
+    }
+
+    // Validate stride_view::base() const&
+    STATIC_ASSERT(CanMemberBase<const R&> == copy_constructible<V>);
+    if constexpr (copy_constructible<V>) {
+        same_as<V> auto b1 = as_const(r).base();
+        STATIC_ASSERT(noexcept(as_const(r).base()) == is_nothrow_copy_constructible_v<V>);
+        assert(*b1.begin() == *begin(expected));
+    }
+
+    // Validate stride_view::base() &&
+    same_as<V> auto b2 = std::move(r).base();
+    STATIC_ASSERT(noexcept(std::move(r).base()) == is_nothrow_move_constructible_v<V>);
+    if (!is_empty) {
+        assert(*b2.begin() == *begin(expected));
+    }
+
+    return true;
+}
+
+static constexpr int some_ints[]     = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
+static constexpr int stride_result[] = {0, 3, 6, 9};
+
+struct instantiator {
+    template <ranges::input_range R>
+    static constexpr void call() {
+        R r{some_ints};
+        test_one(r, stride_result);
+    }
+};
+
+template <test::CanDifference Difference>
+using test_input_range = test::range<input_iterator_tag, const int, test::Sized::yes, Difference, test::Common::yes,
+    test::CanCompare::yes, test::ProxyRef::no>;
+
+template <class Category, test::Common IsCommon, test::Sized IsSized>
+using test_range =
+    test::range<Category, const int, IsSized, test::CanDifference{derived_from<Category, random_access_iterator_tag>},
+        IsCommon, test::CanCompare{derived_from<Category, forward_iterator_tag> || IsCommon == test::Common::yes},
+        test::ProxyRef{!derived_from<Category, contiguous_iterator_tag>}>;
+
+constexpr void instantiation_test() {
+#ifdef TEST_EVERYTHING
+    test_in<instantiator, const int>();
+#else // ^^^ test all input and forward range permutations / test only "interesting" permutations vvv
+    using test::Common, test::Sized;
+
+    // When the base range is an input range, the view is sensitive to differencing
+    instantiator::call<test_input_range<test::CanDifference::yes>>();
+    instantiator::call<test_input_range<test::CanDifference::no>>();
+
+    // The view is sensitive to category, commonality, and size, but oblivious to differencing and proxyness
+    instantiator::call<test_range<input_iterator_tag, Common::no, Sized::yes>>();
+    instantiator::call<test_range<input_iterator_tag, Common::no, Sized::no>>();
+    instantiator::call<test_range<input_iterator_tag, Common::yes, Sized::yes>>();
+    instantiator::call<test_range<input_iterator_tag, Common::yes, Sized::no>>();
+
+    instantiator::call<test_range<forward_iterator_tag, Common::no, Sized::yes>>();
+    instantiator::call<test_range<forward_iterator_tag, Common::no, Sized::no>>();
+    instantiator::call<test_range<forward_iterator_tag, Common::yes, Sized::yes>>();
+    instantiator::call<test_range<forward_iterator_tag, Common::yes, Sized::no>>();
+
+    instantiator::call<test_range<bidirectional_iterator_tag, Common::no, Sized::yes>>();
+    instantiator::call<test_range<bidirectional_iterator_tag, Common::no, Sized::no>>();
+    instantiator::call<test_range<bidirectional_iterator_tag, Common::yes, Sized::yes>>();
+    instantiator::call<test_range<bidirectional_iterator_tag, Common::yes, Sized::no>>();
+
+    instantiator::call<test_range<random_access_iterator_tag, Common::no, Sized::yes>>();
+    instantiator::call<test_range<random_access_iterator_tag, Common::no, Sized::no>>();
+    instantiator::call<test_range<random_access_iterator_tag, Common::yes, Sized::yes>>();
+    instantiator::call<test_range<random_access_iterator_tag, Common::yes, Sized::no>>();
+
+    instantiator::call<test_range<contiguous_iterator_tag, Common::no, Sized::yes>>();
+    instantiator::call<test_range<contiguous_iterator_tag, Common::no, Sized::no>>();
+    instantiator::call<test_range<contiguous_iterator_tag, Common::yes, Sized::yes>>();
+    instantiator::call<test_range<contiguous_iterator_tag, Common::yes, Sized::no>>();
+#endif // TEST_EVERYTHING
+}
+
+template <class Category, test::Common IsCommon, bool is_random = derived_from<Category, random_access_iterator_tag>>
+using move_only_view = test::range<Category, const int, test::Sized{is_random}, test::CanDifference{is_random},
+    IsCommon, test::CanCompare::yes, test::ProxyRef{!derived_from<Category, contiguous_iterator_tag>},
+    test::CanView::yes, test::Copyability::move_only>;
+
+int main() {
+    { // Validate views
+        // ... copyable
+        constexpr span<const int> s{some_ints};
+        STATIC_ASSERT(test_one(s, stride_result));
+        test_one(s, stride_result);
+    }
+
+    { // ... move-only
+        test_one(move_only_view<input_iterator_tag, test::Common::no>{some_ints}, stride_result);
+        test_one(move_only_view<input_iterator_tag, test::Common::yes>{some_ints}, stride_result);
+        test_one(move_only_view<forward_iterator_tag, test::Common::no>{some_ints}, stride_result);
+        test_one(move_only_view<forward_iterator_tag, test::Common::yes>{some_ints}, stride_result);
+        test_one(move_only_view<bidirectional_iterator_tag, test::Common::no>{some_ints}, stride_result);
+        test_one(move_only_view<bidirectional_iterator_tag, test::Common::yes>{some_ints}, stride_result);
+        test_one(move_only_view<random_access_iterator_tag, test::Common::no>{some_ints}, stride_result);
+        test_one(move_only_view<random_access_iterator_tag, test::Common::yes>{some_ints}, stride_result);
+    }
+
+    { // Validate non-views
+        STATIC_ASSERT(test_one(some_ints, stride_result));
+        test_one(some_ints, stride_result);
+    }
+    {
+        vector vec(ranges::begin(some_ints), ranges::end(some_ints));
+        test_one(vec, stride_result);
+    }
+    {
+        forward_list lst(ranges::begin(some_ints), ranges::end(some_ints));
+        test_one(lst, stride_result);
+    }
+
+    { // empty range
+        using Span = span<const int>;
+        STATIC_ASSERT(test_one(Span{}, Span{}));
+        test_one(Span{}, Span{});
+    }
+
+    STATIC_ASSERT((instantiation_test(), true));
+    instantiation_test();
+}

--- a/tests/std/tests/P1899R3_views_stride/test.cpp
+++ b/tests/std/tests/P1899R3_views_stride/test.cpp
@@ -448,8 +448,8 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
             assert(ci2 > ci);
             assert(ci2 >= ci);
             if constexpr (three_way_comparable<iterator_t<const V>>) {
-                assert(ci <=> ci4 == strong_ordering::equal);
                 assert(ci <=> ci2 == strong_ordering::less);
+                assert(ci <=> ci4 == strong_ordering::equal);
                 assert(ci2 <=> ci == strong_ordering::greater);
             }
 
@@ -460,9 +460,9 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
                 assert(ci2 > i);
                 assert(ci2 >= i);
                 if constexpr (three_way_comparable<iterator_t<const V>>) {
-                    assert(ci <=> ci2 == strong_ordering::less);
-                    assert(ci <=> ci4 == strong_ordering::equal);
-                    assert(ci2 <=> ci == strong_ordering::greater);
+                    assert(i <=> ci2 == strong_ordering::less);
+                    assert(i <=> ci4 == strong_ordering::equal);
+                    assert(ci2 <=> i == strong_ordering::greater);
                 }
             }
         }

--- a/tests/std/tests/P1899R3_views_stride_death/env.lst
+++ b/tests/std/tests/P1899R3_views_stride_death/env.lst
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst

--- a/tests/std/tests/P1899R3_views_stride_death/test.cpp
+++ b/tests/std/tests/P1899R3_views_stride_death/test.cpp
@@ -3,6 +3,7 @@
 
 #define _CONTAINER_DEBUG_LEVEL 1
 
+#include <cstddef>
 #include <limits>
 #include <ranges>
 

--- a/tests/std/tests/P1899R3_views_stride_death/test.cpp
+++ b/tests/std/tests/P1899R3_views_stride_death/test.cpp
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#define _CONTAINER_DEBUG_LEVEL 1
+
+#include <limits>
+#include <ranges>
+
+#include <test_death.hpp>
+
+using namespace std;
+
+static constexpr int some_ints[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+
+void test_view_negative_stride() {
+    [[maybe_unused]] auto v = ranges::stride_view(some_ints, -1); // stride must be greater than 0
+}
+
+void test_iterator_dereference_at_end() {
+    auto v  = ranges::stride_view(some_ints, 3);
+    auto it = v.end();
+    (void) *it; // cannot dereference stride_view end iterator
+}
+
+void test_iterator_preincrement_past_end() {
+    auto v  = ranges::stride_view(some_ints, 3);
+    auto it = v.end();
+    ++it; // cannot increment stride_view end iterator
+}
+
+void test_iterator_postincrement_past_end() {
+    auto v  = ranges::stride_view(some_ints, 3);
+    auto it = v.end();
+    it++; // cannot increment stride_view end iterator
+}
+
+void test_iterator_advance_past_end() {
+    auto v  = ranges::stride_view(some_ints, 3);
+    auto it = v.begin();
+    it += 5; // cannot advance stride_view iterator past end
+}
+
+void test_iterator_advance_past_end_with_integer_overflow() {
+    auto v  = ranges::stride_view(some_ints, 3);
+    auto it = v.begin();
+    it += (numeric_limits<ptrdiff_t>::max)() / 2; // cannot advance stride_view iterator past end (integer overflow)
+}
+
+int main(int argc, char* argv[]) {
+    std_testing::death_test_executive exec;
+
+#if _ITERATOR_DEBUG_LEVEL != 0
+    exec.add_death_tests({
+        test_view_negative_stride,
+        test_iterator_dereference_at_end,
+        test_iterator_preincrement_past_end,
+        test_iterator_postincrement_past_end,
+        test_iterator_advance_past_end,
+        test_iterator_advance_past_end_with_integer_overflow,
+    });
+#else // ^^^ test everything / test only _CONTAINER_DEBUG_LEVEL case vvv
+    exec.add_death_tests({
+        test_view_negative_stride,
+    });
+#endif // _ITERATOR_DEBUG_LEVEL != 0
+
+    return exec.run(argc, argv);
+}

--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
@@ -1478,11 +1478,11 @@ STATIC_ASSERT(__cpp_lib_ranges_starts_ends_with == 202106L);
 #endif
 #endif
 
-#if _HAS_CXX23 && !defined(__EDG__) // TRANSITION, EDG concepts support
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
 #ifndef __cpp_lib_ranges_stride
 #error __cpp_lib_ranges_stride is not defined
 #elif __cpp_lib_ranges_stride != 202207L
-#error __cpp_lib_ranges_stride is not 202107L
+#error __cpp_lib_ranges_stride is not 202207L
 #else
 STATIC_ASSERT(__cpp_lib_ranges_stride == 202207L);
 #endif

--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
@@ -1478,6 +1478,20 @@ STATIC_ASSERT(__cpp_lib_ranges_starts_ends_with == 202106L);
 #endif
 #endif
 
+#if _HAS_CXX23 && !defined(__EDG__) // TRANSITION, EDG concepts support
+#ifndef __cpp_lib_ranges_stride
+#error __cpp_lib_ranges_stride is not defined
+#elif __cpp_lib_ranges_stride != 202207L
+#error __cpp_lib_ranges_stride is not 202107L
+#else
+STATIC_ASSERT(__cpp_lib_ranges_stride == 202207L);
+#endif
+#else
+#ifdef __cpp_lib_ranges_stride
+#error __cpp_lib_ranges_stride is defined
+#endif
+#endif
+
 #if _HAS_CXX17
 #ifndef __cpp_lib_raw_memory_algorithms
 #error __cpp_lib_raw_memory_algorithms is not defined


### PR DESCRIPTION
Implements [P1899R3](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p1899r3.html) - `stride_view`. Closes #2915.

<details>
  <summary>Note(s)</summary>

  * I've `std::`-qualified all calls to `std::forward` and `std::move` in tests, because next Clang release (15) is going to [warn about "unqualified std cast calls"](https://clang.llvm.org/docs/DiagnosticsReference.html#wunqualified-std-cast-call).
</details>