### PR TITLE
`<chrono>`: `chrono::abs` incorrectly uses `?:` with expressions that don't always have a common type

### DIFF
--- a/stl/inc/__msvc_chrono.hpp
+++ b/stl/inc/__msvc_chrono.hpp
@@ -502,8 +502,12 @@ namespace chrono {
     template <class _Rep, class _Period, enable_if_t<numeric_limits<_Rep>::is_signed, int> = 0>
     _NODISCARD constexpr duration<_Rep, _Period> abs(const duration<_Rep, _Period> _Dur) noexcept(
         is_arithmetic_v<_Rep>) /* strengthened */ {
-        // create a duration with count() the absolute value of _Dur.count()
-        return _Dur < duration<_Rep, _Period>::zero() ? duration<_Rep, _Period>::zero() - _Dur : _Dur;
+        // create a duration whose count() is the absolute value of _Dur.count()
+        if (_Dur < duration<_Rep, _Period>::zero()) {
+            return duration<_Rep, _Period>::zero() - _Dur;
+        } else {
+            return _Dur;
+        }
     }
 
     using nanoseconds  = duration<long long, nano>;

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -791,9 +791,6 @@ std/localization/locale.categories/category.ctype/locale.codecvt/locale.codecvt.
 std/localization/locale.categories/category.ctype/locale.codecvt/locale.codecvt.members/char32_t_encoding.pass.cpp FAIL
 std/localization/locale.categories/category.ctype/locale.codecvt/locale.codecvt.members/char32_t_max_length.pass.cpp FAIL
 
-# Likely STL bug in <chrono>: "result type of conditional expression is ambiguous"
-std/utilities/time/time.duration/time.duration.alg/abs.pass.cpp FAIL
-
 # Likely STL bug in <format>: we check argument ids at compiletime in next_arg_id
 std/utilities/format/format.formatter/format.parse.ctx/next_arg_id.pass.cpp FAIL
 

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -787,9 +787,6 @@ localization\locale.categories\category.ctype\locale.codecvt\locale.codecvt.memb
 localization\locale.categories\category.ctype\locale.codecvt\locale.codecvt.members\char32_t_encoding.pass.cpp
 localization\locale.categories\category.ctype\locale.codecvt\locale.codecvt.members\char32_t_max_length.pass.cpp
 
-# Likely STL bug in <chrono>: "result type of conditional expression is ambiguous"
-utilities\time\time.duration\time.duration.alg\abs.pass.cpp
-
 # Likely STL bug in <format>: we check argument ids at compiletime in next_arg_id
 utilities\format\format.formatter\format.parse.ctx\next_arg_id.pass.cpp
 


### PR DESCRIPTION
...by avoiding ill-formed uses of the conditional operator in `std::chrono::abs`.

Fixes #2839
