### PR TITLE
Temporarily disable ASAN string annotations

### DIFF
--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -2344,6 +2344,7 @@ struct _String_constructor_rvalue_allocator_tag {
     _Xlength_error("string too long");
 }
 
+#if 0 // TRANSITION, VSO-1586016: String annotations disabled temporarily.
 #if !defined(_M_CEE_PURE) && !defined(_DISABLE_STRING_ANNOTATION)
 #if defined(__SANITIZE_ADDRESS__)
 #define _ACTIVATE_STRING_ANNOTATION
@@ -2363,6 +2364,7 @@ struct _String_constructor_rvalue_allocator_tag {
 #pragma comment(lib, "stl_asan")
 #pragma detect_mismatch("annotate_string", "1")
 #endif // _ACTIVATE_STRING_ANNOTATION
+#endif // TRANSITION, VSO-1586016
 
 #ifdef _INSERT_STRING_ANNOTATION
 extern "C" {

--- a/tests/std/tests/GH_002030_asan_annotate_string/env.lst
+++ b/tests/std/tests/GH_002030_asan_annotate_string/env.lst
@@ -56,7 +56,8 @@ PM_CL="/D_ANNOTATE_STRING /EHsc /MTd /std:c++latest /permissive- /fno-sanitize-a
 PM_CL="/D_ANNOTATE_STRING /Za /EHsc /MD /std:c++latest /permissive- /fno-sanitize-address-vcasan-lib"
 PM_CL="/D_ANNOTATE_STRING /Za /EHsc /MDd /std:c++latest /permissive- /fno-sanitize-address-vcasan-lib"
 # TRANSITION, clang-cl does not support /alternatename so we cannot test /D_ANNOTATE_STRING without -fsanitize=address
-PM_COMPILER="clang-cl" PM_CL="-fsanitize=address -fno-ms-compatibility -fno-delayed-template-parsing /EHsc /MD /std:c++14"
-PM_COMPILER="clang-cl" PM_CL="-fsanitize=address -fno-ms-compatibility -fno-delayed-template-parsing /EHsc /MD /std:c++17"
-PM_COMPILER="clang-cl" PM_CL="-fsanitize=address -fno-ms-compatibility -fno-delayed-template-parsing /EHsc /MT /std:c++latest /permissive-"
-PM_COMPILER="clang-cl" PM_CL="-fsanitize=address -fno-ms-compatibility -fno-delayed-template-parsing /EHsc /MT /std:c++latest /permissive- /D_HAS_CXX23 /fp:strict"
+# TRANSITION, VSO-1586016: String annotations disabled temporarily. clang-cl fails to link with empty main.
+# PM_COMPILER="clang-cl" PM_CL="-fsanitize=address -fno-ms-compatibility -fno-delayed-template-parsing /EHsc /MD /std:c++14"
+# PM_COMPILER="clang-cl" PM_CL="-fsanitize=address -fno-ms-compatibility -fno-delayed-template-parsing /EHsc /MD /std:c++17"
+# PM_COMPILER="clang-cl" PM_CL="-fsanitize=address -fno-ms-compatibility -fno-delayed-template-parsing /EHsc /MT /std:c++latest /permissive-"
+# PM_COMPILER="clang-cl" PM_CL="-fsanitize=address -fno-ms-compatibility -fno-delayed-template-parsing /EHsc /MT /std:c++latest /permissive- /D_HAS_CXX23 /fp:strict"

--- a/tests/std/tests/GH_002030_asan_annotate_string/test.cpp
+++ b/tests/std/tests/GH_002030_asan_annotate_string/test.cpp
@@ -1833,5 +1833,4 @@ int main() {
 }
 #endif // TRANSITION, VSO-1586016
 
-int main() {
-}
+int main() {}

--- a/tests/std/tests/GH_002030_asan_annotate_string/test.cpp
+++ b/tests/std/tests/GH_002030_asan_annotate_string/test.cpp
@@ -3,6 +3,7 @@
 
 // REQUIRES: asan, x64 || x86
 
+#if 0 // TRANSITION, VSO-1586016: String annotations disabled temporarily.
 #pragma warning(disable : 4389) // signed/unsigned mismatch in arithmetic
 #pragma warning(disable : 4984) // 'if constexpr' is a C++17 language extension
 #pragma warning(disable : 6326) // Potential comparison of a constant with another constant.
@@ -1829,4 +1830,8 @@ int main() {
     run_allocator_matrix<char16_t>();
     run_allocator_matrix<char32_t>();
     run_allocator_matrix<wchar_t>();
+}
+#endif // TRANSITION, VSO-1586016
+
+int main() {
 }


### PR DESCRIPTION
Disabling string annotations to unblock ASAN testing. Work to re-enable is ongoing.
