### PR TITLE
make _Get_unwrapped noexcept when possible

### DIFF
--- a/stl/inc/filesystem
+++ b/stl/inc/filesystem
@@ -1455,8 +1455,10 @@ namespace filesystem {
         _Path_iterator(const _Base_iter& _Position_, const path* _Mypath_) noexcept
             : _Position(_Position_), _Element(), _Mypath(_Mypath_) {}
 
-        _Path_iterator(const _Base_iter& _Position_, wstring_view _Element_text, const path* _Mypath_)
-            : _Position(_Position_), _Element(_Element_text), _Mypath(_Mypath_) {}
+        _Path_iterator(const _Base_iter& _Position_, const path& _Element_, const path* _Mypath_)
+            : _Position(_Position_), _Element(_Element_), _Mypath(_Mypath_) {}
+        _Path_iterator(const _Base_iter& _Position_, path&& _Element_, const path* _Mypath_)
+            : _Position(_Position_), _Element(_STD move(_Element_)), _Mypath(_Mypath_) {}
 
         _Path_iterator(const _Path_iterator&)            = default;
         _Path_iterator(_Path_iterator&&)                 = default;
@@ -1600,8 +1602,13 @@ namespace filesystem {
         using _Prevent_inheriting_unwrap = _Path_iterator;
 
         template <class _Iter2 = _Base_iter, enable_if_t<_Unwrappable_v<const _Iter2&>, int> = 0>
-        _NODISCARD _Path_iterator<_Unwrapped_t<const _Iter2&>> _Unwrapped() const {
-            return {_Position._Unwrapped(), _Element.native(), _Mypath};
+        _NODISCARD _Path_iterator<_Unwrapped_t<const _Iter2&>> _Unwrapped() const& noexcept(false) {
+            return {_Position._Unwrapped(), _Element, _Mypath};
+        }
+        template <class _Iter2 = _Base_iter, enable_if_t<_Unwrappable_v<_Iter2>, int> = 0>
+        _NODISCARD _Path_iterator<_Unwrapped_t<_Iter2>> _Unwrapped() && noexcept {
+            _STL_INTERNAL_STATIC_ASSERT(noexcept(_Is_nothrow_unwrappable_v<_Iter2>));
+            return {_Position._Unwrapped(), _STD move(_Element), _Mypath};
         }
 
         static constexpr bool _Unwrap_when_unverified = _Do_unwrap_when_unverified_v<_Base_iter>;

--- a/stl/inc/filesystem
+++ b/stl/inc/filesystem
@@ -1602,12 +1602,12 @@ namespace filesystem {
         using _Prevent_inheriting_unwrap = _Path_iterator;
 
         template <class _Iter2 = _Base_iter, enable_if_t<_Unwrappable_v<const _Iter2&>, int> = 0>
-        _NODISCARD _Path_iterator<_Unwrapped_t<const _Iter2&>> _Unwrapped() const& noexcept(false) {
+        _NODISCARD _Path_iterator<_Unwrapped_t<const _Iter2&>> _Unwrapped() const& {
             return {_Position._Unwrapped(), _Element, _Mypath};
         }
         template <class _Iter2 = _Base_iter, enable_if_t<_Unwrappable_v<_Iter2>, int> = 0>
         _NODISCARD _Path_iterator<_Unwrapped_t<_Iter2>> _Unwrapped() && noexcept {
-            _STL_INTERNAL_STATIC_ASSERT(noexcept(_Is_nothrow_unwrappable_v<_Iter2>));
+            _STL_INTERNAL_STATIC_ASSERT(_Is_nothrow_unwrappable_v<_Iter2>);
             return {_Position._Unwrapped(), _STD move(_Element), _Mypath};
         }
 

--- a/stl/inc/iterator
+++ b/stl/inc/iterator
@@ -1371,12 +1371,19 @@ public:
 
     using _Prevent_inheriting_unwrap = counted_iterator;
 
-    _NODISCARD constexpr counted_iterator<_Unwrapped_t<const _Iter&>>
-        _Unwrapped() const& requires _Unwrappable_v<const _Iter&> {
+    // clang-format off
+    _NODISCARD constexpr counted_iterator<_Unwrapped_t<const _Iter&>> _Unwrapped() const&
+        noexcept(noexcept(counted_iterator<_Unwrapped_t<const _Iter&>>{_Current._Unwrapped(), _Length})
+        requires _Unwrappable_v<const _Iter&> {
+        // clang-format on
         return counted_iterator<_Unwrapped_t<const _Iter&>>{_Current._Unwrapped(), _Length};
     }
 
-    _NODISCARD constexpr counted_iterator<_Unwrapped_t<_Iter>> _Unwrapped() && requires _Unwrappable_v<_Iter> {
+    // clang-format off
+    _NODISCARD constexpr counted_iterator<_Unwrapped_t<_Iter>> _Unwrapped() &&
+        noexcept(noexcept(counted_iterator<_Unwrapped_t<_Iter>>{_STD move(_Current)._Unwrapped(), _Length})
+        requires _Unwrappable_v<_Iter> {
+        // clang-format on
         return counted_iterator<_Unwrapped_t<_Iter>>{_STD move(_Current)._Unwrapped(), _Length};
     }
 

--- a/stl/inc/iterator
+++ b/stl/inc/iterator
@@ -1373,7 +1373,7 @@ public:
 
     // clang-format off
     _NODISCARD constexpr counted_iterator<_Unwrapped_t<const _Iter&>> _Unwrapped() const&
-        noexcept(noexcept(counted_iterator<_Unwrapped_t<const _Iter&>>{_Current._Unwrapped(), _Length})
+        noexcept(noexcept(counted_iterator<_Unwrapped_t<const _Iter&>>{_Current._Unwrapped(), _Length}))
         requires _Unwrappable_v<const _Iter&> {
         // clang-format on
         return counted_iterator<_Unwrapped_t<const _Iter&>>{_Current._Unwrapped(), _Length};
@@ -1381,7 +1381,7 @@ public:
 
     // clang-format off
     _NODISCARD constexpr counted_iterator<_Unwrapped_t<_Iter>> _Unwrapped() &&
-        noexcept(noexcept(counted_iterator<_Unwrapped_t<_Iter>>{_STD move(_Current)._Unwrapped(), _Length})
+        noexcept(noexcept(counted_iterator<_Unwrapped_t<_Iter>>{_STD move(_Current)._Unwrapped(), _Length}))
         requires _Unwrappable_v<_Iter> {
         // clang-format on
         return counted_iterator<_Unwrapped_t<_Iter>>{_STD move(_Current)._Unwrapped(), _Length};

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -2388,12 +2388,15 @@ namespace ranges {
 
             // clang-format off
             _NODISCARD constexpr auto _Unwrapped() const&
+                noexcept(noexcept(_Sentinel<_Const, false>{_Get_unwrapped(_Last)}))
                 requires _Wrapped && _Unwrappable_v<const iterator_t<_Base_t>&> {
                 // clang-format on
                 return _Sentinel<_Const, false>{_Get_unwrapped(_Last)};
             }
             // clang-format off
-            _NODISCARD constexpr auto _Unwrapped() && requires _Wrapped && _Unwrappable_v<iterator_t<_Base_t>> {
+            _NODISCARD constexpr auto _Unwrapped() &&
+                noexcept(noexcept(_Sentinel<_Const, false>{_Get_unwrapped(_STD move(_Last))}))
+                requires _Wrapped && _Unwrappable_v<iterator_t<_Base_t>> {
                 // clang-format on
                 return _Sentinel<_Const, false>{_Get_unwrapped(_STD move(_Last))};
             }
@@ -2644,12 +2647,15 @@ namespace ranges {
 
             // clang-format off
             _NODISCARD constexpr auto _Unwrapped() const&
+                noexcept(noexcept(_Sentinel<_Const, false>{_Get_unwrapped(_Last), _Pred}))
                 requires _Wrapped && _Unwrappable_v<const iterator_t<_Base_t>&> {
                 // clang-format on
                 return _Sentinel<_Const, false>{_Get_unwrapped(_Last), _Pred};
             }
             // clang-format off
-            _NODISCARD constexpr auto _Unwrapped() && requires _Wrapped && _Unwrappable_v<iterator_t<_Base_t>> {
+            _NODISCARD constexpr auto _Unwrapped() &&
+                noexcept(noexcept(_Sentinel<_Const, false>{_Get_unwrapped(_STD move(_Last)), _Pred}))
+                requires _Wrapped && _Unwrappable_v<iterator_t<_Base_t>> {
                 // clang-format on
                 return _Sentinel<_Const, false>{_Get_unwrapped(_STD move(_Last)), _Pred};
             }

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -896,8 +896,14 @@ _INLINE_VAR constexpr bool _Unwrappable_v<_Iter,
     void_t<decltype(_STD declval<_Remove_cvref_t<_Iter>&>()._Seek_to(_STD declval<_Iter>()._Unwrapped()))>> =
     _Allow_inheriting_unwrap_v<_Remove_cvref_t<_Iter>>;
 
+template <class _Iter, bool _Unwrappable = _Unwrappable_v<_Iter>>
+_INLINE_VAR constexpr bool _Is_nothrow_unwrappable_v = true;
+
 template <class _Iter>
-_NODISCARD constexpr decltype(auto) _Get_unwrapped(_Iter&& _It) {
+_INLINE_VAR constexpr bool _Is_nothrow_unwrappable_v<_Iter, true> = noexcept(declval<_Iter>()._Unwrapped());
+
+template <class _Iter>
+_NODISCARD constexpr decltype(auto) _Get_unwrapped(_Iter&& _It) noexcept(_Is_nothrow_unwrappable_v<_Iter>) {
     // unwrap an iterator previously subjected to _Adl_verify_range or otherwise validated
     if constexpr (is_pointer_v<decay_t<_Iter>>) { // special-case pointers and arrays
         return _It + 0;
@@ -1347,7 +1353,8 @@ public:
     }
 
     template <class _BidIt2 = _BidIt, enable_if_t<_Unwrappable_v<const _BidIt2&>, int> = 0>
-    _NODISCARD constexpr reverse_iterator<_Unwrapped_t<const _BidIt2&>> _Unwrapped() const {
+    _NODISCARD constexpr reverse_iterator<_Unwrapped_t<const _BidIt2&>> _Unwrapped() const
+        noexcept(noexcept(static_cast<reverse_iterator<_Unwrapped_t<const _BidIt2&>>>(current._Unwrapped()))) {
         return static_cast<reverse_iterator<_Unwrapped_t<const _BidIt2&>>>(current._Unwrapped());
     }
 
@@ -3404,11 +3411,13 @@ public:
     }
 
     template <class _Iter2 = iterator_type, enable_if_t<_Unwrappable_v<const _Iter2&>, int> = 0>
-    _NODISCARD constexpr move_iterator<_Unwrapped_t<const _Iter2&>> _Unwrapped() const& {
+    _NODISCARD constexpr move_iterator<_Unwrapped_t<const _Iter2&>> _Unwrapped() const& noexcept(
+        noexcept(static_cast<move_iterator<_Unwrapped_t<const _Iter2&>>>(_Current._Unwrapped()))) {
         return static_cast<move_iterator<_Unwrapped_t<const _Iter2&>>>(_Current._Unwrapped());
     }
     template <class _Iter2 = iterator_type, enable_if_t<_Unwrappable_v<_Iter2>, int> = 0>
-    _NODISCARD constexpr move_iterator<_Unwrapped_t<_Iter2>> _Unwrapped() && {
+    _NODISCARD constexpr move_iterator<_Unwrapped_t<_Iter2>> _Unwrapped() && noexcept(
+        noexcept(static_cast<move_iterator<_Unwrapped_t<_Iter2>>>(_STD move(_Current)._Unwrapped()))) {
         return static_cast<move_iterator<_Unwrapped_t<_Iter2>>>(_STD move(_Current)._Unwrapped());
     }
 

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -897,13 +897,14 @@ _INLINE_VAR constexpr bool _Unwrappable_v<_Iter,
     _Allow_inheriting_unwrap_v<_Remove_cvref_t<_Iter>>;
 
 template <class _Iter, bool _Unwrappable = _Unwrappable_v<_Iter>>
-_INLINE_VAR constexpr bool _Is_nothrow_unwrappable_v = true;
+_INLINE_VAR constexpr bool _Is_nothrow_unwrappable_v = noexcept(_STD declval<_Iter>()._Unwrapped());
 
 template <class _Iter>
-_INLINE_VAR constexpr bool _Is_nothrow_unwrappable_v<_Iter, true> = noexcept(declval<_Iter>()._Unwrapped());
+_INLINE_VAR constexpr bool _Is_nothrow_unwrappable_v<_Iter, false> = false;
 
 template <class _Iter>
-_NODISCARD constexpr decltype(auto) _Get_unwrapped(_Iter&& _It) noexcept(_Is_nothrow_unwrappable_v<_Iter>) {
+_NODISCARD constexpr decltype(auto) _Get_unwrapped(_Iter&& _It) noexcept(
+    !_Unwrappable_v<_Iter> || _Is_nothrow_unwrappable_v<_Iter>) {
     // unwrap an iterator previously subjected to _Adl_verify_range or otherwise validated
     if constexpr (is_pointer_v<decay_t<_Iter>>) { // special-case pointers and arrays
         return _It + 0;

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -1353,9 +1353,14 @@ public:
     }
 
     template <class _BidIt2 = _BidIt, enable_if_t<_Unwrappable_v<const _BidIt2&>, int> = 0>
-    _NODISCARD constexpr reverse_iterator<_Unwrapped_t<const _BidIt2&>> _Unwrapped() const
-        noexcept(noexcept(static_cast<reverse_iterator<_Unwrapped_t<const _BidIt2&>>>(current._Unwrapped()))) {
+    _NODISCARD constexpr reverse_iterator<_Unwrapped_t<const _BidIt2&>> _Unwrapped() const& noexcept(
+        noexcept(static_cast<reverse_iterator<_Unwrapped_t<const _BidIt2&>>>(current._Unwrapped()))) {
         return static_cast<reverse_iterator<_Unwrapped_t<const _BidIt2&>>>(current._Unwrapped());
+    }
+    template <class _BidIt2 = _BidIt, enable_if_t<_Unwrappable_v<_BidIt2>, int> = 0>
+    _NODISCARD constexpr reverse_iterator<_Unwrapped_t<_BidIt2>> _Unwrapped() && noexcept(
+        noexcept(static_cast<reverse_iterator<_Unwrapped_t<_BidIt2>>>(_STD move(current)._Unwrapped()))) {
+        return static_cast<reverse_iterator<_Unwrapped_t<_BidIt2>>>(_STD move(current)._Unwrapped());
     }
 
     static constexpr bool _Unwrap_when_unverified = _Do_unwrap_when_unverified_v<_BidIt>;

--- a/tests/std/test.lst
+++ b/tests/std/test.lst
@@ -209,6 +209,7 @@ tests\GH_002711_Zc_alignedNew-
 tests\GH_002760_syncstream_memory_leak
 tests\GH_002769_handle_deque_block_pointers
 tests\GH_002789_Hash_vec_Tidy
+tests\GH_002989_nothrow_unwrappable
 tests\LWG2597_complex_branch_cut
 tests\LWG3018_shared_ptr_function
 tests\LWG3121_constrained_tuple_forwarding_ctor

--- a/tests/std/tests/GH_002989_nothrow_unwrappable/env.lst
+++ b/tests/std/tests/GH_002989_nothrow_unwrappable/env.lst
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+RUNALL_INCLUDE ..\usual_17_matrix.lst

--- a/tests/std/tests/GH_002989_nothrow_unwrappable/env.lst
+++ b/tests/std/tests/GH_002989_nothrow_unwrappable/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\usual_17_matrix.lst
+RUNALL_INCLUDE ..\usual_matrix.lst

--- a/tests/std/tests/GH_002989_nothrow_unwrappable/test.cpp
+++ b/tests/std/tests/GH_002989_nothrow_unwrappable/test.cpp
@@ -1,11 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include <filesystem>
 #include <list>
 #include <type_traits>
 #include <vector>
 #include <xutility>
+
+#if _HAS_CXX17
+#include <filesystem>
+#endif
 
 #if _HAS_CXX20
 #include <ranges>
@@ -60,43 +63,43 @@ void do_full_test() {
 }
 
 struct BidiIterUnwrapThrowing : vector<int>::iterator {
-    using _Base = vector<int>::iterator;
+    using Base = vector<int>::iterator;
 
-    using _Base::_Base;
+    using Base::Base;
 
     using iterator_concept  = bidirectional_iterator_tag;
     using iterator_category = bidirectional_iterator_tag;
 
     BidiIterUnwrapThrowing& operator++() {
-        _Base::operator++();
+        Base::operator++();
         return *this;
     }
     BidiIterUnwrapThrowing operator++(int) {
         auto res = *this;
-        _Base::operator++();
+        Base::operator++();
         return res;
     }
     BidiIterUnwrapThrowing& operator--() {
-        _Base::operator--();
+        Base::operator--();
         return *this;
     }
     BidiIterUnwrapThrowing operator--(int) {
         auto res = *this;
-        _Base::operator--();
+        Base::operator--();
         return res;
     }
 
     using _Prevent_inheriting_unwrap = BidiIterUnwrapThrowing;
 
     int* _Unwrapped() const& noexcept(false) {
-        return _Base::_Unwrapped();
+        return Base::_Unwrapped();
     }
     int* _Unwrapped() && noexcept {
-        return move(*this)._Base::_Unwrapped();
+        return move(*this).Base::_Unwrapped();
     }
 
     void _Seek_to(int* p) & noexcept {
-        _Base::_Seek_to(p);
+        Base::_Seek_to(p);
     }
 };
 

--- a/tests/std/tests/GH_002989_nothrow_unwrappable/test.cpp
+++ b/tests/std/tests/GH_002989_nothrow_unwrappable/test.cpp
@@ -30,8 +30,8 @@ template <class It, bool CopyUnwrapNothrow = true>
 void do_single_test() {
     // !a || b is equivalent to a => b (a implies b)
     // This is written this way to avoid `if constexpr` in C++14 mode.
-    STATIC_ASSERT(!_Unwrappable_v<It> == _Is_nothrow_unwrappable_v<It>);
-    STATIC_ASSERT(!_Unwrappable_v<It> == _Is_nothrow_unwrappable_v<It&&>);
+    STATIC_ASSERT(_Unwrappable_v<It> == _Is_nothrow_unwrappable_v<It>);
+    STATIC_ASSERT(_Unwrappable_v<It> == _Is_nothrow_unwrappable_v<It&&>);
     STATIC_ASSERT(noexcept(_Get_unwrapped(declval<It>())));
 
     STATIC_ASSERT(!_Unwrappable_v<It> || (_Is_nothrow_unwrappable_v<const It&> == CopyUnwrapNothrow));

--- a/tests/std/tests/GH_002989_nothrow_unwrappable/test.cpp
+++ b/tests/std/tests/GH_002989_nothrow_unwrappable/test.cpp
@@ -34,8 +34,8 @@ void do_single_test() {
     STATIC_ASSERT(_Unwrappable_v<It> == _Is_nothrow_unwrappable_v<It&&>);
     STATIC_ASSERT(noexcept(_Get_unwrapped(declval<It>())));
 
-    STATIC_ASSERT(!_Unwrappable_v<It> || (_Is_nothrow_unwrappable_v<const It&> == CopyUnwrapNothrow));
-    STATIC_ASSERT(!_Unwrappable_v<It> || (_Is_nothrow_unwrappable_v<const It&&> == CopyUnwrapNothrow));
+    STATIC_ASSERT(!_Unwrappable_v<It> || _Is_nothrow_unwrappable_v<const It&> == CopyUnwrapNothrow);
+    STATIC_ASSERT(!_Unwrappable_v<It> || _Is_nothrow_unwrappable_v<const It&&> == CopyUnwrapNothrow);
     STATIC_ASSERT(noexcept(_Get_unwrapped(declval<const It&>())) == CopyUnwrapNothrow);
     STATIC_ASSERT(noexcept(_Get_unwrapped(declval<const It&&>())) == CopyUnwrapNothrow);
 }

--- a/tests/std/tests/GH_002989_nothrow_unwrappable/test.cpp
+++ b/tests/std/tests/GH_002989_nothrow_unwrappable/test.cpp
@@ -30,12 +30,12 @@ template <class It, bool CopyUnwrapNothrow = true>
 void do_single_test() {
     // !a || b is equivalent to a => b (a implies b)
     // This is written this way to avoid `if constexpr` in C++14 mode.
-    STATIC_ASSERT(!_Unwrappable_v<It> || _Is_nothrow_unwrappable_v<It>);
-    STATIC_ASSERT(!_Unwrappable_v<It> || _Is_nothrow_unwrappable_v<It&&>);
+    STATIC_ASSERT(!_Unwrappable_v<It> == _Is_nothrow_unwrappable_v<It>);
+    STATIC_ASSERT(!_Unwrappable_v<It> == _Is_nothrow_unwrappable_v<It&&>);
     STATIC_ASSERT(noexcept(_Get_unwrapped(declval<It>())));
 
-    STATIC_ASSERT(!_Unwrappable_v<It> || _Is_nothrow_unwrappable_v<const It&> == CopyUnwrapNothrow);
-    STATIC_ASSERT(!_Unwrappable_v<It> || _Is_nothrow_unwrappable_v<const It&&> == CopyUnwrapNothrow);
+    STATIC_ASSERT(!_Unwrappable_v<It> || (_Is_nothrow_unwrappable_v<const It&> == CopyUnwrapNothrow));
+    STATIC_ASSERT(!_Unwrappable_v<It> || (_Is_nothrow_unwrappable_v<const It&&> == CopyUnwrapNothrow));
     STATIC_ASSERT(noexcept(_Get_unwrapped(declval<const It&>())) == CopyUnwrapNothrow);
     STATIC_ASSERT(noexcept(_Get_unwrapped(declval<const It&&>())) == CopyUnwrapNothrow);
 }

--- a/tests/std/tests/GH_002989_nothrow_unwrappable/test.cpp
+++ b/tests/std/tests/GH_002989_nothrow_unwrappable/test.cpp
@@ -26,23 +26,16 @@ struct Predicate {
     }
 };
 
-#pragma warning(disable : 4984) // 'if constexpr' is a C++17 language extension
-#ifdef __clang__
-#pragma clang diagnostic ignored "-Wc++17-extensions" // constexpr if is a C++17 extension
-#endif
-
 template <class It, bool CopyUnwrapNothrow = true>
 void do_single_test() {
-    if constexpr (_Unwrappable_v<It>) {
-        STATIC_ASSERT(_Is_nothrow_unwrappable_v<It>);
-        STATIC_ASSERT(_Is_nothrow_unwrappable_v<It&&>);
-    }
+    // !a || b is equivalent to a => b (a implies b)
+    // This is written this way to avoid `if constexpr` in C++14 mode.
+    STATIC_ASSERT(!_Unwrappable_v<It> || _Is_nothrow_unwrappable_v<It>);
+    STATIC_ASSERT(!_Unwrappable_v<It> || _Is_nothrow_unwrappable_v<It&&>);
     STATIC_ASSERT(noexcept(_Get_unwrapped(declval<It>())));
 
-    if constexpr (_Unwrappable_v<const It&>) {
-        STATIC_ASSERT(_Is_nothrow_unwrappable_v<const It&> == CopyUnwrapNothrow);
-        STATIC_ASSERT(_Is_nothrow_unwrappable_v<const It&&> == CopyUnwrapNothrow);
-    }
+    STATIC_ASSERT(!_Unwrappable_v<It> || _Is_nothrow_unwrappable_v<const It&> == CopyUnwrapNothrow);
+    STATIC_ASSERT(!_Unwrappable_v<It> || _Is_nothrow_unwrappable_v<const It&&> == CopyUnwrapNothrow);
     STATIC_ASSERT(noexcept(_Get_unwrapped(declval<const It&>())) == CopyUnwrapNothrow);
     STATIC_ASSERT(noexcept(_Get_unwrapped(declval<const It&&>())) == CopyUnwrapNothrow);
 }
@@ -73,7 +66,6 @@ struct BidiIterUnwrapThrowing : vector<int>::iterator {
 
     using iterator_concept  = bidirectional_iterator_tag;
     using iterator_category = bidirectional_iterator_tag;
-
 
     BidiIterUnwrapThrowing& operator++() {
         _Base::operator++();

--- a/tests/std/tests/GH_002989_nothrow_unwrappable/test.cpp
+++ b/tests/std/tests/GH_002989_nothrow_unwrappable/test.cpp
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <filesystem>
+#include <list>
+#include <type_traits>
+#include <vector>
+#include <xutility>
+
+using namespace std;
+
+#define STATIC_ASSERT(...) static_assert(__VA_ARGS__, #__VA_ARGS__)
+
+template <class T, bool CopyUnwrapNothrow = true>
+void do_test() {
+    STATIC_ASSERT(_Is_nothrow_unwrappable_v<T>);
+    STATIC_ASSERT(_Is_nothrow_unwrappable_v<T&&>);
+    STATIC_ASSERT(noexcept(_Get_unwrapped(declval<T>())));
+
+    STATIC_ASSERT(_Is_nothrow_unwrappable_v<const T&> == CopyUnwrapNothrow);
+    STATIC_ASSERT(noexcept(_Get_unwrapped(declval<const T&>())) == CopyUnwrapNothrow);
+    STATIC_ASSERT(_Is_nothrow_unwrappable_v<const T&&> == CopyUnwrapNothrow);
+    STATIC_ASSERT(noexcept(_Get_unwrapped(declval<const T&&>())) == CopyUnwrapNothrow);
+}
+
+int main() {
+    do_test<int>();
+    do_test<int*>();
+    do_test<int[]>();
+
+    do_test<vector<int>::iterator>();
+    do_test<vector<int>::const_iterator>();
+    do_test<list<int>::iterator>();
+    do_test<list<int>::const_iterator>();
+
+    do_test<filesystem::path::iterator, false>();
+}

--- a/tests/std/tests/GH_002989_nothrow_unwrappable/test.cpp
+++ b/tests/std/tests/GH_002989_nothrow_unwrappable/test.cpp
@@ -7,31 +7,65 @@
 #include <vector>
 #include <xutility>
 
+#if _HAS_CXX20
+#include <ranges>
+#endif
+
 using namespace std;
+using filesystem::path;
 
 #define STATIC_ASSERT(...) static_assert(__VA_ARGS__, #__VA_ARGS__)
 
-template <class T, bool CopyUnwrapNothrow = true>
-void do_test() {
-    STATIC_ASSERT(_Is_nothrow_unwrappable_v<T>);
-    STATIC_ASSERT(_Is_nothrow_unwrappable_v<T&&>);
-    STATIC_ASSERT(noexcept(_Get_unwrapped(declval<T>())));
+struct Predicate {
+    template <class T>
+    bool operator()(const T&) const {
+        return true;
+    }
+};
 
-    STATIC_ASSERT(_Is_nothrow_unwrappable_v<const T&> == CopyUnwrapNothrow);
-    STATIC_ASSERT(noexcept(_Get_unwrapped(declval<const T&>())) == CopyUnwrapNothrow);
-    STATIC_ASSERT(_Is_nothrow_unwrappable_v<const T&&> == CopyUnwrapNothrow);
-    STATIC_ASSERT(noexcept(_Get_unwrapped(declval<const T&&>())) == CopyUnwrapNothrow);
+template <class It, bool CopyUnwrapNothrow = true>
+void do_single_test() {
+    STATIC_ASSERT(_Is_nothrow_unwrappable_v<It>);
+    STATIC_ASSERT(_Is_nothrow_unwrappable_v<It&&>);
+    STATIC_ASSERT(noexcept(_Get_unwrapped(declval<It>())));
+
+    STATIC_ASSERT(_Is_nothrow_unwrappable_v<const It&> == CopyUnwrapNothrow);
+    STATIC_ASSERT(noexcept(_Get_unwrapped(declval<const It&>())) == CopyUnwrapNothrow);
+    STATIC_ASSERT(_Is_nothrow_unwrappable_v<const It&&> == CopyUnwrapNothrow);
+    STATIC_ASSERT(noexcept(_Get_unwrapped(declval<const It&&>())) == CopyUnwrapNothrow);
+}
+
+template <class It, bool CopyUnwrapNothrow = true>
+void do_full_test() {
+    do_single_test<It, CopyUnwrapNothrow>();
+    do_single_test<reverse_iterator<It>, CopyUnwrapNothrow>();
+    do_single_test<move_iterator<It>, CopyUnwrapNothrow>();
+
+#ifdef __cpp_lib_concepts // TRANSITION, GH-395
+    using R = ranges::subrange<It, It>;
+
+    do_single_test<ranges::iterator_t<R>, CopyUnwrapNothrow>();
+
+    // iterator_t<filter_view> does not define _Unwrapped
+    do_single_test<ranges::iterator_t<ranges::filter_view<R, Predicate>>, true>();
+    // iterator_t<transform_view> does not define _Unwrapped
+    do_single_test<ranges::iterator_t<ranges::transform_view<R, Predicate>>, true>();
+    if constexpr (ranges::bidirectional_range<R>) {
+        // iterator_t<reverse_view> does not define _Unwrapped
+        do_single_test<ranges::iterator_t<ranges::reverse_view<R>>, true>();
+    }
+#endif // __cpp_lib_concepts
 }
 
 int main() {
-    do_test<int>();
-    do_test<int*>();
-    do_test<int[]>();
+    do_single_test<int>();
+    do_full_test<int*>();
+    do_single_test<int[]>();
 
-    do_test<vector<int>::iterator>();
-    do_test<vector<int>::const_iterator>();
-    do_test<list<int>::iterator>();
-    do_test<list<int>::const_iterator>();
+    do_full_test<vector<int>::iterator>();
+    do_full_test<vector<int>::const_iterator>();
+    do_full_test<list<int>::iterator>();
+    do_full_test<list<int>::const_iterator>();
 
-    do_test<filesystem::path::iterator, false>();
+    do_full_test<path::iterator, false>();
 }


### PR DESCRIPTION
additionally:

* add `_Unwrapped() && noexcept` to `path::iterator`
* add `_Unwrapped() &&` to `reverse_iterator`
* add conditional noexcepts to:
   - `counted_iterator`
   - `take_view::_Sentinel`
   - `take_while_view::_Sentinel`
   - `move_iterator`

Fixes #2989

~~Requires testing~~