### PR TITLE
`<xhash>` should avoid including `<xstring>`

### DIFF
--- a/stl/inc/xhash
+++ b/stl/inc/xhash
@@ -9,13 +9,16 @@
 #include <yvals_core.h>
 #if _STL_COMPILER_PREPROCESSOR
 #include <cmath>
-#include <cstring>
-#include <cwchar>
 #include <list>
 #include <tuple>
 #include <vector>
 #include <xbit_ops.h>
+
+#ifdef _SILENCE_STDEXT_HASH_DEPRECATION_WARNINGS
+#include <cstring>
+#include <cwchar>
 #include <xstring>
+#endif // _SILENCE_STDEXT_HASH_DEPRECATION_WARNINGS
 
 #if _HAS_CXX17
 #include <xnode_handle.h>
@@ -28,6 +31,7 @@ _STL_DISABLE_CLANG_WARNINGS
 #pragma push_macro("new")
 #undef new
 
+#ifdef _SILENCE_STDEXT_HASH_DEPRECATION_WARNINGS
 namespace stdext {
     using _STD basic_string;
     using _STD less;
@@ -86,6 +90,7 @@ namespace stdext {
         _Pr comp{}; // the comparator object
     };
 } // namespace stdext
+#endif // _SILENCE_STDEXT_HASH_DEPRECATION_WARNINGS
 
 _STD_BEGIN
 template <class _Kty, class _Hasher, class _Keyeq, class = void>

--- a/stl/inc/xhash
+++ b/stl/inc/xhash
@@ -88,8 +88,6 @@ namespace stdext {
 } // namespace stdext
 
 _STD_BEGIN
-using stdext::hash_compare; // TRANSITION, protobuf used this until v3.7.0, released Feb 28, 2019
-
 template <class _Kty, class _Hasher, class _Keyeq, class = void>
 struct _Uhash_choose_transparency {
     // transparency selector for non-transparent hashed containers


### PR DESCRIPTION
Reported by: https://www.reddit.com/r/cpp/comments/wgb8xo/fun_times_with_msvc_functional/

This does two things:

* `<xhash>` includes `<xstring>` for `basic_string`, `<cstring>` for `strlen`, and `<cwchar>` for `wcslen`, because it's defining non-Standard `stdext` machinery for `<hash_map>` and `<hash_set>`. This throughput cost is paid by everyone who drags in `<xhash>`, including highly indirect routes like `<functional>`. There's a simple way to avoid this (i.e. without adding a new sub-header to be included by `<hash_meow>`). Because we hard-deprecated `<hash_meow>` with an error-and-escape-hatch, we can guard the `stdext` machinery with that same escape hatch. Result: the `stdext` machinery and `<xstring>` etc. dependencies disappear for the vast majority of users, and are still available unchanged when activating the escape hatch.
  + This throughput improvement is inherently a source-breaking change for anyone who assumed that `<unordered_meow>` would make most of `<string>` available. As usual, the fix is to simply include `<string>`. Let's be daring and try to see if we can do this without totally breaking the world.
* We were dragging `stdext::hash_compare` into `std`, contrary to our goal of keeping non-Standard identifiers out of `std`. The project that needed this, [protobuf](https://github.com/protocolbuffers/protobuf), was fixed almost 3.5 years ago. We should be able to eliminate this now.