### PR TITLE
Make `filter_view::iterator` unwrappable

### DIFF
--- a/stl/inc/filesystem
+++ b/stl/inc/filesystem
@@ -1455,8 +1455,10 @@ namespace filesystem {
         _Path_iterator(const _Base_iter& _Position_, const path* _Mypath_) noexcept
             : _Position(_Position_), _Element(), _Mypath(_Mypath_) {}
 
-        _Path_iterator(const _Base_iter& _Position_, wstring_view _Element_text, const path* _Mypath_)
-            : _Position(_Position_), _Element(_Element_text), _Mypath(_Mypath_) {}
+        _Path_iterator(const _Base_iter& _Position_, const path& _Element_, const path* _Mypath_)
+            : _Position(_Position_), _Element(_Element_), _Mypath(_Mypath_) {}
+        _Path_iterator(const _Base_iter& _Position_, path&& _Element_, const path* _Mypath_)
+            : _Position(_Position_), _Element(_STD move(_Element_)), _Mypath(_Mypath_) {}
 
         _Path_iterator(const _Path_iterator&)            = default;
         _Path_iterator(_Path_iterator&&)                 = default;
@@ -1600,8 +1602,13 @@ namespace filesystem {
         using _Prevent_inheriting_unwrap = _Path_iterator;
 
         template <class _Iter2 = _Base_iter, enable_if_t<_Unwrappable_v<const _Iter2&>, int> = 0>
-        _NODISCARD _Path_iterator<_Unwrapped_t<const _Iter2&>> _Unwrapped() const {
-            return {_Position._Unwrapped(), _Element.native(), _Mypath};
+        _NODISCARD _Path_iterator<_Unwrapped_t<const _Iter2&>> _Unwrapped() const& noexcept(false) {
+            return {_Position._Unwrapped(), _Element, _Mypath};
+        }
+        template <class _Iter2 = _Base_iter, enable_if_t<_Unwrappable_v<_Iter2>, int> = 0>
+        _NODISCARD _Path_iterator<_Unwrapped_t<_Iter2>> _Unwrapped() && noexcept {
+            _STL_INTERNAL_STATIC_ASSERT(noexcept(_Is_nothrow_unwrappable_v<_Iter2>));
+            return {_Position._Unwrapped(), _STD move(_Element), _Mypath};
         }
 
         static constexpr bool _Unwrap_when_unverified = _Do_unwrap_when_unverified_v<_Base_iter>;

--- a/stl/inc/iterator
+++ b/stl/inc/iterator
@@ -1371,12 +1371,19 @@ public:
 
     using _Prevent_inheriting_unwrap = counted_iterator;
 
-    _NODISCARD constexpr counted_iterator<_Unwrapped_t<const _Iter&>>
-        _Unwrapped() const& requires _Unwrappable_v<const _Iter&> {
+    // clang-format off
+    _NODISCARD constexpr counted_iterator<_Unwrapped_t<const _Iter&>> _Unwrapped() const&
+        noexcept(noexcept(counted_iterator<_Unwrapped_t<const _Iter&>>{_Current._Unwrapped(), _Length}))
+        requires _Unwrappable_v<const _Iter&> {
+        // clang-format on
         return counted_iterator<_Unwrapped_t<const _Iter&>>{_Current._Unwrapped(), _Length};
     }
 
-    _NODISCARD constexpr counted_iterator<_Unwrapped_t<_Iter>> _Unwrapped() && requires _Unwrappable_v<_Iter> {
+    // clang-format off
+    _NODISCARD constexpr counted_iterator<_Unwrapped_t<_Iter>> _Unwrapped() &&
+        noexcept(noexcept(counted_iterator<_Unwrapped_t<_Iter>>{_STD move(_Current)._Unwrapped(), _Length}))
+        requires _Unwrappable_v<_Iter> {
+        // clang-format on
         return counted_iterator<_Unwrapped_t<_Iter>>{_STD move(_Current)._Unwrapped(), _Length};
     }
 

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -1917,18 +1917,19 @@ namespace ranges {
                 input_iterator_tag>;
         };
 
-        template <bool _Const>
+        template <bool _Const, bool _Is_unwrapped = false>
         class _Iterator : public _Category_base<_Const> {
         private:
-            template <bool>
+            template <bool, bool>
             friend class _Iterator;
             template <bool>
             friend class _Sentinel;
 
-            using _Parent_t = _Maybe_const<_Const, transform_view>;
-            using _Base     = _Maybe_const<_Const, _Vw>;
+            using _Parent_t  = _Maybe_const<_Const, transform_view>;
+            using _Base      = _Maybe_const<_Const, _Vw>;
+            using _Base_iter = _Maybe_unwrapped_iterator_t<_Base, _Is_unwrapped>;
 
-            iterator_t<_Base> _Current{};
+            _Base_iter _Current{};
             _Parent_t* _Parent{};
 
 #if _ITERATOR_DEBUG_LEVEL != 0
@@ -1952,11 +1953,11 @@ namespace ranges {
             using difference_type = range_difference_t<_Base>;
 
             // clang-format off
-            _Iterator() requires default_initializable<iterator_t<_Base>> = default;
+            _Iterator() requires default_initializable<_Base_iter> = default;
             // clang-format on
 
-            constexpr _Iterator(_Parent_t& _Parent_, iterator_t<_Base> _Current_) noexcept(
-                is_nothrow_move_constructible_v<iterator_t<_Base>>) // strengthened
+            constexpr _Iterator(_Parent_t& _Parent_, _Base_iter _Current_) noexcept(
+                is_nothrow_move_constructible_v<_Base_iter>) // strengthened
                 : _Current{_STD move(_Current_)}, _Parent{_STD addressof(_Parent_)} {
 #if _ITERATOR_DEBUG_LEVEL != 0
                 _Adl_verify_range(_Current, _RANGES end(_Parent_._Range));
@@ -1967,17 +1968,18 @@ namespace ranges {
             }
 
             // clang-format off
-            constexpr _Iterator(_Iterator<!_Const> _It)
-                noexcept(is_nothrow_constructible_v<iterator_t<_Base>, iterator_t<_Vw>>) // strengthened
-                requires _Const && convertible_to<iterator_t<_Vw>, iterator_t<_Base>>
+            constexpr _Iterator(_Iterator<!_Const, _Is_unwrapped> _It)
+                noexcept(is_nothrow_constructible_v<_Base_iter, _Base_iter>) // strengthened
+                requires _Const
+                    && convertible_to<_Maybe_unwrapped_iterator_t<_Vw, _Is_unwrapped>, _Base_iter>
                 : _Current{_STD move(_It._Current)}, _Parent{_It._Parent} {}
             // clang-format on
 
-            _NODISCARD constexpr const iterator_t<_Base>& base() const& noexcept {
+            _NODISCARD constexpr const _Base_iter& base() const& noexcept {
                 return _Current;
             }
-            _NODISCARD constexpr iterator_t<_Base> base() && noexcept(
-                is_nothrow_move_constructible_v<iterator_t<_Base>>) /* strengthened */ {
+            _NODISCARD constexpr _Base_iter base() && noexcept(
+                is_nothrow_move_constructible_v<_Base_iter>) /* strengthened */ {
                 return _STD move(_Current);
             }
 
@@ -2003,7 +2005,7 @@ namespace ranges {
 
             constexpr decltype(auto) operator++(int) noexcept(
                 noexcept(++_Current)
-                && (!forward_range<_Base> || is_nothrow_copy_constructible_v<iterator_t<_Base>>) ) /* strengthened */ {
+                && (!forward_range<_Base> || is_nothrow_copy_constructible_v<_Base_iter>) ) /* strengthened */ {
                 if constexpr (forward_range<_Base>) {
                     auto _Tmp = *this;
                     ++*this;
@@ -2026,7 +2028,7 @@ namespace ranges {
                 return *this;
             }
             constexpr _Iterator operator--(int) noexcept(
-                noexcept(--_Current) && is_nothrow_copy_constructible_v<iterator_t<_Base>>) /* strengthened */
+                noexcept(--_Current) && is_nothrow_copy_constructible_v<_Base_iter>) /* strengthened */
                 requires bidirectional_range<_Base> {
                 auto _Tmp = *this;
                 --*this;
@@ -2039,20 +2041,19 @@ namespace ranges {
 #else // ^^^ _ITERATOR_DEBUG_LEVEL == 0 / _ITERATOR_DEBUG_LEVEL != 0 vvv
                 _STL_VERIFY(_Off == 0 || _Parent, "cannot seek value-initialized transform_view iterator");
 
-                if constexpr (_Offset_verifiable_v<iterator_t<_Base>>) {
+                if constexpr (_Offset_verifiable_v<_Base_iter>) {
                     _Current._Verify_offset(_Off);
                 } else {
                     if (_Off < 0) {
-                        if constexpr (sized_sentinel_for<iterator_t<_Base>, iterator_t<_Base>>) {
+                        if constexpr (sized_sentinel_for<_Base_iter, _Base_iter>) {
                             _STL_VERIFY(_Off >= _RANGES begin(_Parent->_Range) - _Current,
                                 "cannot seek transform_view iterator before begin");
                         }
                     } else if (_Off > 0) {
-                        if constexpr (sized_sentinel_for<sentinel_t<_Base>, iterator_t<_Base>>) {
+                        if constexpr (sized_sentinel_for<sentinel_t<_Base>, _Base_iter>) {
                             _STL_VERIFY(_Off <= _RANGES end(_Parent->_Range) - _Current,
                                 "cannot seek transform_view iterator after end");
-                        } else if constexpr (sized_sentinel_for<iterator_t<_Base>,
-                                                 iterator_t<_Base>> && sized_range<_Base>) {
+                        } else if constexpr (sized_sentinel_for<_Base_iter, _Base_iter> && sized_range<_Base>) {
                             const auto _Size = _RANGES distance(_Parent->_Range);
                             _STL_VERIFY(_Off <= _Size - (_Current - _RANGES begin(_Parent->_Range)),
                                 "cannot seek transform_view iterator after end");
@@ -2091,8 +2092,8 @@ namespace ranges {
             }
 
             _NODISCARD_FRIEND constexpr bool operator==(const _Iterator& _Left, const _Iterator& _Right) noexcept(
-                noexcept(_Left._Current
-                         == _Right._Current)) /* strengthened */ requires equality_comparable<iterator_t<_Base>> {
+                noexcept(
+                    _Left._Current == _Right._Current)) /* strengthened */ requires equality_comparable<_Base_iter> {
 #if _ITERATOR_DEBUG_LEVEL != 0
                 _Left._Same_range(_Right);
 #endif // _ITERATOR_DEBUG_LEVEL != 0
@@ -2121,7 +2122,7 @@ namespace ranges {
             // clang-format off
             _NODISCARD_FRIEND constexpr auto operator<=>(const _Iterator& _Left, const _Iterator& _Right) noexcept(
                 noexcept(_Left._Current <=> _Right._Current)) /* strengthened */
-                requires random_access_range<_Base> && three_way_comparable<iterator_t<_Base>> {
+                requires random_access_range<_Base> && three_way_comparable<_Base_iter> {
                 // clang-format on
 #if _ITERATOR_DEBUG_LEVEL != 0
                 _Left._Same_range(_Right);
@@ -2157,11 +2158,40 @@ namespace ranges {
 
             _NODISCARD_FRIEND constexpr difference_type operator-(const _Iterator& _Left,
                 const _Iterator& _Right) noexcept(noexcept(_Left._Current - _Right._Current)) /* strengthened */
-                requires sized_sentinel_for<iterator_t<_Base>, iterator_t<_Base>> {
+                requires sized_sentinel_for<_Base_iter, _Base_iter> {
 #if _ITERATOR_DEBUG_LEVEL != 0
                 _Left._Same_range(_Right);
 #endif // _ITERATOR_DEBUG_LEVEL != 0
                 return _Left._Current - _Right._Current;
+            }
+
+            using _Prevent_inheriting_unwrap =
+                conditional_t<!_Is_unwrapped && _Unwrappable_v<_Base_iter>, _Iterator, void>;
+
+            // clang-format off
+            _Iterator<_Const, true> _Unwrapped() const&
+                noexcept(noexcept(_Iterator<_Const, true>{*_Parent, _Current._Unwrapped()}))
+                requires _Unwrappable_v<const _Base_iter&>
+            {
+                // clang-format on
+                return _Iterator<_Const, true>{*_Parent, _Current._Unwrapped()};
+            }
+            // clang-format off
+            _Iterator<_Const, true> _Unwrapped() &&
+                noexcept(noexcept(_Iterator<_Const, true>{*_Parent, _STD move(_Current)._Unwrapped()}))
+                requires _Unwrappable_v<_Base_iter>
+            {
+                // clang-format on
+                return _Iterator<_Const, true>{*_Parent, _STD move(_Current)._Unwrapped()};
+            }
+
+            // clang-format off
+            void _Seek_to(_Iterator<_Const, true> _Other)
+                noexcept(noexcept(_Current._Seek_to(_Other._Current)))
+                requires _Unwrappable_v<_Base_iter>
+            {
+                // clang-format on
+                _Current._Seek_to(_Other._Current);
             }
         };
 

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -2390,12 +2390,15 @@ namespace ranges {
 
             // clang-format off
             _NODISCARD constexpr auto _Unwrapped() const&
+                noexcept(noexcept(_Sentinel<_Const, false>{_Get_unwrapped(_Last)}))
                 requires _Wrapped && _Unwrappable_v<const iterator_t<_Base_t>&> {
                 // clang-format on
                 return _Sentinel<_Const, false>{_Get_unwrapped(_Last)};
             }
             // clang-format off
-            _NODISCARD constexpr auto _Unwrapped() && requires _Wrapped && _Unwrappable_v<iterator_t<_Base_t>> {
+            _NODISCARD constexpr auto _Unwrapped() &&
+                noexcept(noexcept(_Sentinel<_Const, false>{_Get_unwrapped(_STD move(_Last))}))
+                requires _Wrapped && _Unwrappable_v<iterator_t<_Base_t>> {
                 // clang-format on
                 return _Sentinel<_Const, false>{_Get_unwrapped(_STD move(_Last))};
             }
@@ -2646,12 +2649,15 @@ namespace ranges {
 
             // clang-format off
             _NODISCARD constexpr auto _Unwrapped() const&
+                noexcept(noexcept(_Sentinel<_Const, false>{_Get_unwrapped(_Last), _Pred}))
                 requires _Wrapped && _Unwrappable_v<const iterator_t<_Base_t>&> {
                 // clang-format on
                 return _Sentinel<_Const, false>{_Get_unwrapped(_Last), _Pred};
             }
             // clang-format off
-            _NODISCARD constexpr auto _Unwrapped() && requires _Wrapped && _Unwrappable_v<iterator_t<_Base_t>> {
+            _NODISCARD constexpr auto _Unwrapped() &&
+                noexcept(noexcept(_Sentinel<_Const, false>{_Get_unwrapped(_STD move(_Last)), _Pred}))
+                requires _Wrapped && _Unwrappable_v<iterator_t<_Base_t>> {
                 // clang-format on
                 return _Sentinel<_Const, false>{_Get_unwrapped(_STD move(_Last)), _Pred};
             }

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -1935,7 +1935,8 @@ namespace ranges {
 #if _ITERATOR_DEBUG_LEVEL != 0
             constexpr void _Check_dereference() const noexcept {
                 _STL_VERIFY(_Parent != nullptr, "cannot dereference value-initialized transform_view iterator");
-                _STL_VERIFY(_Current != _RANGES end(_Parent->_Range), "cannot dereference end transform_view iterator");
+                _STL_VERIFY(_Current != _Get_maybe_unwrapped<_Is_unwrapped>(_RANGES end(_Parent->_Range)),
+                    "cannot dereference end transform_view iterator");
             }
 #endif // _ITERATOR_DEBUG_LEVEL != 0
 
@@ -1960,9 +1961,9 @@ namespace ranges {
                 is_nothrow_move_constructible_v<_Base_iter>) // strengthened
                 : _Current{_STD move(_Current_)}, _Parent{_STD addressof(_Parent_)} {
 #if _ITERATOR_DEBUG_LEVEL != 0
-                _Adl_verify_range(_Current, _RANGES end(_Parent_._Range));
+                _Adl_verify_range(_Current, _Get_maybe_unwrapped<_Is_unwrapped>(_RANGES end(_Parent_._Range)));
                 if constexpr (forward_range<_Base>) {
-                    _Adl_verify_range(_RANGES begin(_Parent_._Range), _Current);
+                    _Adl_verify_range(_Get_maybe_unwrapped<_Is_unwrapped>(_RANGES begin(_Parent_._Range)), _Current);
                 }
 #endif // _ITERATOR_DEBUG_LEVEL != 0
             }
@@ -1996,8 +1997,8 @@ namespace ranges {
             constexpr _Iterator& operator++() noexcept(noexcept(++_Current)) /* strengthened */ {
 #if _ITERATOR_DEBUG_LEVEL != 0
                 _STL_VERIFY(_Parent != nullptr, "Cannot increment value-initialized transform_view iterator");
-                _STL_VERIFY(
-                    _Current != _RANGES end(_Parent->_Range), "Cannot increment transform_view iterator past end");
+                _STL_VERIFY(_Current != _Get_maybe_unwrapped<_Is_unwrapped>(_RANGES end(_Parent->_Range)),
+                    "Cannot increment transform_view iterator past end");
 #endif // _ITERATOR_DEBUG_LEVEL != 0
                 ++_Current;
                 return *this;
@@ -2020,7 +2021,7 @@ namespace ranges {
 #if _ITERATOR_DEBUG_LEVEL != 0
                 _STL_VERIFY(_Parent != nullptr, "Cannot decrement value-initialized transform_view iterator");
                 if constexpr (forward_range<_Vw>) {
-                    _STL_VERIFY(_Current != _RANGES begin(_Parent->_Range),
+                    _STL_VERIFY(_Current != _Get_maybe_unwrapped<_Is_unwrapped>(_RANGES begin(_Parent->_Range)),
                         "Cannot decrement transform_view iterator before begin");
                 }
 #endif // _ITERATOR_DEBUG_LEVEL != 0
@@ -2046,17 +2047,21 @@ namespace ranges {
                 } else {
                     if (_Off < 0) {
                         if constexpr (sized_sentinel_for<_Base_iter, _Base_iter>) {
-                            _STL_VERIFY(_Off >= _RANGES begin(_Parent->_Range) - _Current,
+                            _STL_VERIFY(
+                                _Off >= _Get_maybe_unwrapped<_Is_unwrapped>(_RANGES begin(_Parent->_Range)) - _Current,
                                 "cannot seek transform_view iterator before begin");
                         }
                     } else if (_Off > 0) {
                         if constexpr (sized_sentinel_for<sentinel_t<_Base>, _Base_iter>) {
-                            _STL_VERIFY(_Off <= _RANGES end(_Parent->_Range) - _Current,
+                            _STL_VERIFY(
+                                _Off <= _Get_maybe_unwrapped<_Is_unwrapped>(_RANGES end(_Parent->_Range)) - _Current,
                                 "cannot seek transform_view iterator after end");
                         } else if constexpr (sized_sentinel_for<_Base_iter, _Base_iter> && sized_range<_Base>) {
                             const auto _Size = _RANGES distance(_Parent->_Range);
-                            _STL_VERIFY(_Off <= _Size - (_Current - _RANGES begin(_Parent->_Range)),
-                                "cannot seek transform_view iterator after end");
+                            const auto _Distance_to_begin =
+                                _Current - _Get_maybe_unwrapped<_Is_unwrapped>(_RANGES begin(_Parent->_Range));
+
+                            _STL_VERIFY(_Off <= _Size - _Distance_to_begin), "cannot seek transform_view iterator after end");
                         }
                     }
                 }
@@ -2169,7 +2174,7 @@ namespace ranges {
                 conditional_t<!_Is_unwrapped && _Unwrappable_v<_Base_iter>, _Iterator, void>;
 
             // clang-format off
-            _Iterator<_Const, true> _Unwrapped() const&
+            constexpr _Iterator<_Const, true> _Unwrapped() const&
                 noexcept(noexcept(_Iterator<_Const, true>{*_Parent, _Current._Unwrapped()}))
                 requires _Unwrappable_v<const _Base_iter&>
             {
@@ -2177,7 +2182,7 @@ namespace ranges {
                 return _Iterator<_Const, true>{*_Parent, _Current._Unwrapped()};
             }
             // clang-format off
-            _Iterator<_Const, true> _Unwrapped() &&
+            constexpr _Iterator<_Const, true> _Unwrapped() &&
                 noexcept(noexcept(_Iterator<_Const, true>{*_Parent, _STD move(_Current)._Unwrapped()}))
                 requires _Unwrappable_v<_Base_iter>
             {
@@ -2186,7 +2191,7 @@ namespace ranges {
             }
 
             // clang-format off
-            void _Seek_to(_Iterator<_Const, true> _Other)
+            constexpr void _Seek_to(_Iterator<_Const, true> _Other)
                 noexcept(noexcept(_Current._Seek_to(_Other._Current)))
                 requires _Unwrappable_v<_Base_iter>
             {

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -931,10 +931,22 @@ _NODISCARD constexpr decltype(auto) _Get_unwrapped(_Iter&& _It) noexcept(
     }
 }
 
+template <bool _Do_unwrap, class _Iter>
+_NODISCARD constexpr decltype(auto) _Get_maybe_unwrapped(_Iter&& _It) noexcept(
+    !_Do_unwrap || !_Unwrappable_v<_Iter> || _Is_nothrow_unwrappable_v<_Iter>) {
+    if constexpr (is_pointer_v<decay_t<_Iter>>) {
+        return _It + 0;
+    } else if constexpr (_Do_unwrap && _Unwrappable_v<_Iter>) {
+        return static_cast<_Iter&&>(_It)._Unwrapped();
+    } else {
+        return static_cast<_Iter&&>(_It);
+    }
+}
+
 template <class _Iter>
 using _Unwrapped_t = _Remove_cvref_t<decltype(_Get_unwrapped(_STD declval<_Iter>()))>;
-template <class _Iter, bool _Is_unwrapped>
-using _Maybe_unwrapped_t = conditional_t<_Is_unwrapped, _Unwrapped_t<_Iter>, _Remove_cvref_t<_Iter>>;
+template <class _Iter, bool _Do_unwrap>
+using _Maybe_unwrapped_t = _Remove_cvref_t<decltype(_Get_maybe_unwrapped<_Do_unwrap>(_STD declval<_Iter>()))>;
 
 template <class _Iter, class = bool>
 _INLINE_VAR constexpr bool _Do_unwrap_when_unverified_v = false;

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -912,8 +912,14 @@ _INLINE_VAR constexpr bool _Unwrappable_v<_Iter,
     void_t<decltype(_STD declval<_Remove_cvref_t<_Iter>&>()._Seek_to(_STD declval<_Iter>()._Unwrapped()))>> =
     _Allow_inheriting_unwrap_v<_Remove_cvref_t<_Iter>>;
 
+template <class _Iter, bool _Unwrappable = _Unwrappable_v<_Iter>>
+_INLINE_VAR constexpr bool _Is_nothrow_unwrappable_v = false;
+
 template <class _Iter>
-_NODISCARD constexpr decltype(auto) _Get_unwrapped(_Iter&& _It) {
+_INLINE_VAR constexpr bool _Is_nothrow_unwrappable_v<_Iter, true> = noexcept(declval<_Iter>()._Unwrapped());
+
+template <class _Iter>
+_NODISCARD constexpr decltype(auto) _Get_unwrapped(_Iter&& _It) noexcept(!_Unwrappable_v<_Iter> || _Is_nothrow_unwrappable_v<_Iter>) {
     // unwrap an iterator previously subjected to _Adl_verify_range or otherwise validated
     if constexpr (is_pointer_v<decay_t<_Iter>>) { // special-case pointers and arrays
         return _It + 0;
@@ -1363,8 +1369,14 @@ public:
     }
 
     template <class _BidIt2 = _BidIt, enable_if_t<_Unwrappable_v<const _BidIt2&>, int> = 0>
-    _NODISCARD constexpr reverse_iterator<_Unwrapped_t<const _BidIt2&>> _Unwrapped() const {
+    _NODISCARD constexpr reverse_iterator<_Unwrapped_t<const _BidIt2&>> _Unwrapped() const& noexcept(
+        noexcept(static_cast<reverse_iterator<_Unwrapped_t<const _BidIt2&>>>(current._Unwrapped()))) {
         return static_cast<reverse_iterator<_Unwrapped_t<const _BidIt2&>>>(current._Unwrapped());
+    }
+    template <class _BidIt2 = _BidIt, enable_if_t<_Unwrappable_v<_BidIt2>, int> = 0>
+    _NODISCARD constexpr reverse_iterator<_Unwrapped_t<_BidIt2>> _Unwrapped() && noexcept(
+        noexcept(static_cast<reverse_iterator<_Unwrapped_t<_BidIt2>>>(_STD move(current)._Unwrapped()))) {
+        return static_cast<reverse_iterator<_Unwrapped_t<_BidIt2>>>(_STD move(current)._Unwrapped());
     }
 
     static constexpr bool _Unwrap_when_unverified = _Do_unwrap_when_unverified_v<_BidIt>;
@@ -3435,11 +3447,13 @@ public:
     }
 
     template <class _Iter2 = iterator_type, enable_if_t<_Unwrappable_v<const _Iter2&>, int> = 0>
-    _NODISCARD constexpr move_iterator<_Unwrapped_t<const _Iter2&>> _Unwrapped() const& {
+    _NODISCARD constexpr move_iterator<_Unwrapped_t<const _Iter2&>> _Unwrapped() const& noexcept(
+        noexcept(static_cast<move_iterator<_Unwrapped_t<const _Iter2&>>>(_Current._Unwrapped()))) {
         return static_cast<move_iterator<_Unwrapped_t<const _Iter2&>>>(_Current._Unwrapped());
     }
     template <class _Iter2 = iterator_type, enable_if_t<_Unwrappable_v<_Iter2>, int> = 0>
-    _NODISCARD constexpr move_iterator<_Unwrapped_t<_Iter2>> _Unwrapped() && {
+    _NODISCARD constexpr move_iterator<_Unwrapped_t<_Iter2>> _Unwrapped() && noexcept(
+        noexcept(static_cast<move_iterator<_Unwrapped_t<_Iter2>>>(_STD move(_Current)._Unwrapped()))) {
         return static_cast<move_iterator<_Unwrapped_t<_Iter2>>>(_STD move(_Current)._Unwrapped());
     }
 

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -919,7 +919,8 @@ template <class _Iter>
 _INLINE_VAR constexpr bool _Is_nothrow_unwrappable_v<_Iter, true> = noexcept(declval<_Iter>()._Unwrapped());
 
 template <class _Iter>
-_NODISCARD constexpr decltype(auto) _Get_unwrapped(_Iter&& _It) noexcept(!_Unwrappable_v<_Iter> || _Is_nothrow_unwrappable_v<_Iter>) {
+_NODISCARD constexpr decltype(auto) _Get_unwrapped(_Iter&& _It) noexcept(
+    !_Unwrappable_v<_Iter> || _Is_nothrow_unwrappable_v<_Iter>) {
     // unwrap an iterator previously subjected to _Adl_verify_range or otherwise validated
     if constexpr (is_pointer_v<decay_t<_Iter>>) { // special-case pointers and arrays
         return _It + 0;
@@ -932,6 +933,8 @@ _NODISCARD constexpr decltype(auto) _Get_unwrapped(_Iter&& _It) noexcept(!_Unwra
 
 template <class _Iter>
 using _Unwrapped_t = _Remove_cvref_t<decltype(_Get_unwrapped(_STD declval<_Iter>()))>;
+template <class _Iter, bool _Is_unwrapped>
+using _Maybe_unwrapped_t = conditional_t<_Is_unwrapped, _Unwrapped_t<_Iter>, _Remove_cvref_t<_Iter>>;
 
 template <class _Iter, class = bool>
 _INLINE_VAR constexpr bool _Do_unwrap_when_unverified_v = false;
@@ -1740,6 +1743,10 @@ namespace ranges {
 
     template <class _Ty>
     using iterator_t = decltype(_RANGES begin(_STD declval<_Ty&>()));
+    template <class _Ty>
+    using _Unwrapped_iterator_t = _Unwrapped_t<iterator_t<_Ty>>;
+    template <class _Ty, bool _Is_unwrapped>
+    using _Maybe_unwrapped_iterator_t = _Maybe_unwrapped_t<iterator_t<_Ty>, _Is_unwrapped>;
 
     namespace _Unchecked_begin {
         template <class _Ty>

--- a/tests/std/test.lst
+++ b/tests/std/test.lst
@@ -209,6 +209,7 @@ tests\GH_002711_Zc_alignedNew-
 tests\GH_002760_syncstream_memory_leak
 tests\GH_002769_handle_deque_block_pointers
 tests\GH_002789_Hash_vec_Tidy
+tests\GH_002989_nothrow_unwrappable
 tests\LWG2597_complex_branch_cut
 tests\LWG3018_shared_ptr_function
 tests\LWG3121_constrained_tuple_forwarding_ctor

--- a/tests/std/test.lst
+++ b/tests/std/test.lst
@@ -210,6 +210,7 @@ tests\GH_002760_syncstream_memory_leak
 tests\GH_002769_handle_deque_block_pointers
 tests\GH_002789_Hash_vec_Tidy
 tests\GH_002989_nothrow_unwrappable
+tests\GH_002997_unwrapped_view_iterators
 tests\LWG2597_complex_branch_cut
 tests\LWG3018_shared_ptr_function
 tests\LWG3121_constrained_tuple_forwarding_ctor

--- a/tests/std/tests/GH_002989_nothrow_unwrappable/env.lst
+++ b/tests/std/tests/GH_002989_nothrow_unwrappable/env.lst
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+RUNALL_INCLUDE ..\usual_17_matrix.lst

--- a/tests/std/tests/GH_002989_nothrow_unwrappable/test.cpp
+++ b/tests/std/tests/GH_002989_nothrow_unwrappable/test.cpp
@@ -1,0 +1,129 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <filesystem>
+#include <list>
+#include <type_traits>
+#include <vector>
+#include <xutility>
+
+#if _HAS_CXX20
+#include <ranges>
+#endif
+
+using namespace std;
+using filesystem::path;
+
+#define STATIC_ASSERT(...) static_assert(__VA_ARGS__, #__VA_ARGS__)
+
+struct Predicate {
+    template <class T>
+    bool operator()(const T&) const {
+        return true;
+    }
+};
+
+template <class It, bool CopyUnwrapNothrow = true>
+void do_single_test() {
+    if constexpr (_Unwrappable_v<It>) {
+        STATIC_ASSERT(_Is_nothrow_unwrappable_v<It>);
+        STATIC_ASSERT(_Is_nothrow_unwrappable_v<It&&>);
+    }
+    STATIC_ASSERT(noexcept(_Get_unwrapped(declval<It>())));
+
+    if constexpr (_Unwrappable_v<const It&>) {
+        STATIC_ASSERT(_Is_nothrow_unwrappable_v<const It&> == CopyUnwrapNothrow);
+        STATIC_ASSERT(_Is_nothrow_unwrappable_v<const It&&> == CopyUnwrapNothrow);
+    }
+    STATIC_ASSERT(noexcept(_Get_unwrapped(declval<const It&>())) == CopyUnwrapNothrow);
+    STATIC_ASSERT(noexcept(_Get_unwrapped(declval<const It&&>())) == CopyUnwrapNothrow);
+}
+
+template <class It, bool CopyUnwrapNothrow = true>
+void do_full_test() {
+    do_single_test<It, CopyUnwrapNothrow>();
+    do_single_test<reverse_iterator<It>, CopyUnwrapNothrow>();
+    do_single_test<move_iterator<It>, CopyUnwrapNothrow>();
+
+#ifdef __cpp_lib_concepts // TRANSITION, GH-395
+    using R = ranges::subrange<It, It>;
+
+    do_single_test<ranges::iterator_t<R>, CopyUnwrapNothrow>();
+
+    // TRANSITION, GH-2997
+    do_single_test<ranges::iterator_t<ranges::filter_view<R, Predicate>>, true>();
+    // TRANSITION, GH-2997
+    do_single_test<ranges::iterator_t<ranges::transform_view<R, Predicate>>, true>();
+    if constexpr (ranges::bidirectional_range<R>) {
+        do_single_test<ranges::iterator_t<ranges::reverse_view<R>>, CopyUnwrapNothrow>();
+    }
+#endif // __cpp_lib_concepts
+}
+
+struct BidiIterUnwrapThrowing : vector<int>::iterator {
+    using _Base = vector<int>::iterator;
+
+    using _Base::_Base;
+    using _Base::iterator_category;
+
+#ifdef __cpp_lib_concepts // TRANSITION, GH-395
+    using _Base::iterator_concept;
+#endif
+
+    using _Base::pointer;
+    using _Base::reference;
+    using _Base::value_type;
+
+    friend bool operator==(const BidiIterUnwrapThrowing& lhs, const BidiIterUnwrapThrowing& rhs) noexcept {
+        return static_cast<const _Base&>(lhs) == static_cast<const _Base&>(rhs);
+    }
+    friend bool operator!=(const BidiIterUnwrapThrowing& lhs, const BidiIterUnwrapThrowing& rhs) noexcept {
+        return static_cast<const _Base&>(lhs) != static_cast<const _Base&>(rhs);
+    }
+
+    BidiIterUnwrapThrowing& operator++() {
+        _Base::operator++();
+        return *this;
+    }
+    BidiIterUnwrapThrowing operator++(int) {
+        auto res = *this;
+        _Base::operator++();
+        return res;
+    }
+    BidiIterUnwrapThrowing& operator--() {
+        _Base::operator--();
+        return *this;
+    }
+    BidiIterUnwrapThrowing operator--(int) {
+        auto res = *this;
+        _Base::operator--();
+        return res;
+    }
+
+    using _Prevent_inheriting_unwrap = BidiIterUnwrapThrowing;
+
+    int* _Unwrapped() const& noexcept(false) {
+        return _Base::_Unwrapped();
+    }
+    int* _Unwrapped() && noexcept {
+        return std::move(*this)._Base::_Unwrapped();
+    }
+
+    void _Seek_to(int* p) & noexcept {
+        _Base::_Seek_to(p);
+    }
+};
+
+int main() {
+    do_single_test<int>();
+    do_full_test<int*>();
+    do_single_test<int[]>();
+
+    do_full_test<vector<int>::iterator>();
+    do_full_test<vector<int>::const_iterator>();
+    do_full_test<list<int>::iterator>();
+    do_full_test<list<int>::const_iterator>();
+
+    do_full_test<path::iterator, false>();
+    do_full_test<BidiIterUnwrapThrowing, false>();
+}

--- a/tests/std/tests/GH_002989_nothrow_unwrappable/test.cpp
+++ b/tests/std/tests/GH_002989_nothrow_unwrappable/test.cpp
@@ -52,8 +52,7 @@ void do_full_test() {
 
     // TRANSITION, GH-2997
     do_single_test<ranges::iterator_t<ranges::filter_view<R, Predicate>>, true>();
-    // TRANSITION, GH-2997
-    do_single_test<ranges::iterator_t<ranges::transform_view<R, Predicate>>, true>();
+    do_single_test<ranges::iterator_t<ranges::transform_view<R, Predicate>>, CopyUnwrapNothrow>();
     if constexpr (ranges::bidirectional_range<R>) {
         do_single_test<ranges::iterator_t<ranges::reverse_view<R>>, CopyUnwrapNothrow>();
     }

--- a/tests/std/tests/GH_002997_unwrapped_view_iterators/env.lst
+++ b/tests/std/tests/GH_002997_unwrapped_view_iterators/env.lst
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+RUNALL_INCLUDE ..\strict_concepts_20_matrix.lst

--- a/tests/std/tests/GH_002997_unwrapped_view_iterators/test.cpp
+++ b/tests/std/tests/GH_002997_unwrapped_view_iterators/test.cpp
@@ -1,0 +1,124 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <ranges>
+#include <vector>
+#include <xutility>
+
+using namespace std;
+
+#define STATIC_ASSERT(...) static_assert(__VA_ARGS__, #__VA_ARGS__)
+
+template <class Derived, bool MoveOnly>
+struct UnwrappableBase : vector<int>::iterator {
+    using _Base = vector<int>::iterator;
+
+    using _Base::_Base;
+
+    Derived& operator++() {
+        _Base::operator++();
+        return static_cast<Derived&>(*this);
+    }
+    Derived operator++(int) {
+        auto res = static_cast<Derived&>(*this);
+        _Base::operator++();
+        return res;
+    }
+    Derived& operator--() {
+        _Base::operator--();
+        return static_cast<Derived&>(*this);
+    }
+    Derived operator--(int) {
+        auto res = static_cast<Derived&>(*this);
+        _Base::operator--();
+        return res;
+    }
+
+    using _Prevent_inheriting_unwrap = Derived;
+    int* _Unwrapped() const& noexcept(false) requires !MoveOnly {
+        return _Base::_Unwrapped();
+    }
+    int* _Unwrapped() && noexcept {
+        return _Base::_Unwrapped();
+    }
+    void _Seek_to(int* _It) noexcept {
+        _Base::_Seek_to(_It);
+    }
+
+    bool operator==(const UnwrappableBase&) const  = default;
+    auto operator<=>(const UnwrappableBase&) const = default;
+};
+
+struct ThrowingUnwrappable : UnwrappableBase<ThrowingUnwrappable, false> {
+    using UnwrappableBase<ThrowingUnwrappable, false>::UnwrappableBase;
+
+    bool operator==(const ThrowingUnwrappable&) const  = default;
+    auto operator<=>(const ThrowingUnwrappable&) const = default;
+};
+struct MoveUnwrappable : UnwrappableBase<MoveUnwrappable, true> {
+    using UnwrappableBase<MoveUnwrappable, true>::UnwrappableBase;
+
+    bool operator==(const MoveUnwrappable&) const  = default;
+    auto operator<=>(const MoveUnwrappable&) const = default;
+};
+
+template <template <class...> class V, class It, class... Args>
+using view_iter_t = ranges::iterator_t<V<ranges::subrange<It, It>, Args...>>;
+
+template <template <class...> class V, class... Args>
+void do_test() {
+    using nothrow_unwrappable_t  = view_iter_t<V, vector<int>::iterator, Args...>;
+    using throwing_unwrappable_t = view_iter_t<V, ThrowingUnwrappable, Args...>;
+    using move_unwrappable_t     = view_iter_t<V, MoveUnwrappable, Args...>;
+    using not_unwrappable_t      = view_iter_t<V, int*, Args...>;
+
+    STATIC_ASSERT(_Unwrappable_v<nothrow_unwrappable_t>);
+    STATIC_ASSERT(_Unwrappable_v<const nothrow_unwrappable_t&>);
+    STATIC_ASSERT(!_Unwrappable_v<_Unwrapped_t<nothrow_unwrappable_t>>);
+    STATIC_ASSERT(_Is_nothrow_unwrappable_v<nothrow_unwrappable_t>);
+    STATIC_ASSERT(_Is_nothrow_unwrappable_v<const nothrow_unwrappable_t&>);
+    STATIC_ASSERT(is_same_v<decltype(declval<nothrow_unwrappable_t>().base()), vector<int>::iterator>);
+    STATIC_ASSERT(is_same_v<decltype(declval<_Unwrapped_t<nothrow_unwrappable_t>>().base()), int*>);
+    STATIC_ASSERT(is_same_v<decltype(declval<_Unwrapped_t<const nothrow_unwrappable_t&>>().base()), int*>);
+    STATIC_ASSERT(noexcept(_Get_unwrapped(declval<nothrow_unwrappable_t>())));
+    STATIC_ASSERT(noexcept(_Get_unwrapped(declval<const nothrow_unwrappable_t&>())));
+
+    STATIC_ASSERT(_Unwrappable_v<throwing_unwrappable_t>);
+    STATIC_ASSERT(_Unwrappable_v<const throwing_unwrappable_t&>);
+    STATIC_ASSERT(!_Unwrappable_v<_Unwrapped_t<nothrow_unwrappable_t>>);
+    STATIC_ASSERT(_Is_nothrow_unwrappable_v<throwing_unwrappable_t>);
+    STATIC_ASSERT(!_Is_nothrow_unwrappable_v<const throwing_unwrappable_t&>);
+    STATIC_ASSERT(is_same_v<decltype(declval<throwing_unwrappable_t>().base()), ThrowingUnwrappable>);
+    STATIC_ASSERT(is_same_v<decltype(declval<_Unwrapped_t<throwing_unwrappable_t>>().base()), int*>);
+    STATIC_ASSERT(is_same_v<decltype(declval<_Unwrapped_t<const throwing_unwrappable_t&>>().base()), int*>);
+    STATIC_ASSERT(noexcept(_Get_unwrapped(declval<throwing_unwrappable_t>())));
+    STATIC_ASSERT(!noexcept(_Get_unwrapped(declval<const throwing_unwrappable_t&>())));
+
+    STATIC_ASSERT(_Unwrappable_v<move_unwrappable_t>);
+    STATIC_ASSERT(!_Unwrappable_v<const move_unwrappable_t&>);
+    STATIC_ASSERT(!_Unwrappable_v<_Unwrapped_t<nothrow_unwrappable_t>>);
+    STATIC_ASSERT(_Is_nothrow_unwrappable_v<move_unwrappable_t>);
+    STATIC_ASSERT(!_Is_nothrow_unwrappable_v<const move_unwrappable_t&>);
+    STATIC_ASSERT(is_same_v<decltype(declval<move_unwrappable_t>().base()), MoveUnwrappable>);
+    STATIC_ASSERT(is_same_v<decltype(declval<_Unwrapped_t<move_unwrappable_t>>().base()), int*>);
+    STATIC_ASSERT(noexcept(_Get_unwrapped(declval<move_unwrappable_t>())));
+
+    STATIC_ASSERT(!_Unwrappable_v<not_unwrappable_t>);
+    STATIC_ASSERT(!_Unwrappable_v<const not_unwrappable_t&>);
+    STATIC_ASSERT(!_Is_nothrow_unwrappable_v<not_unwrappable_t>);
+    STATIC_ASSERT(!_Is_nothrow_unwrappable_v<const not_unwrappable_t&>);
+    STATIC_ASSERT(is_same_v<decltype(declval<not_unwrappable_t>().base()), int*>);
+    STATIC_ASSERT(noexcept(_Get_unwrapped(declval<not_unwrappable_t>())));
+    STATIC_ASSERT(noexcept(_Get_unwrapped(declval<not_unwrappable_t>())));
+}
+
+struct Predicate {
+    template <class T>
+    bool operator()(T&&) {
+        return true;
+    }
+};
+
+int main() {
+    do_test<ranges::transform_view, Predicate>();
+}


### PR DESCRIPTION
This is an example of what we might do; it definitely requires discussion.

In theory, with more work, fixes #2997

Based on #2991 