### PR TITLE
<format>: all nans are "nan"

### DIFF
--- a/stl/inc/format
+++ b/stl/inc/format
@@ -2305,8 +2305,25 @@ _NODISCARD _OutputIt _Fmt_write(_OutputIt _Out, const _Arithmetic _Value) {
     // clang-format on
     // TRANSITION, Reusable buffer
     char _Buffer[_Format_min_buffer_length];
-    const auto [_End, _Ec] = _STD to_chars(_Buffer, _STD end(_Buffer), _Value);
-    _STL_ASSERT(_Ec == errc{}, "to_chars failed");
+    char* _End = _Buffer;
+
+    if constexpr (is_floating_point_v<_Arithmetic>) {
+        if ((_STD isnan)(_Value)) {
+            if ((_STD signbit)(_Value)) {
+                *_End++ = '-';
+            }
+
+            memcpy(_End, "nan", 3);
+            _End += 3;
+        }
+    }
+
+    if (_End == _Buffer) {
+        const to_chars_result _Result = _STD to_chars(_Buffer, _STD end(_Buffer), _Value);
+        _STL_ASSERT(_Result.ec == errc{}, "to_chars failed");
+        _End = _Result.ptr;
+    }
+
     return _RANGES transform(_Buffer, _End, _STD move(_Out), _Widen_char<_CharT>{}).out;
 }
 
@@ -2773,18 +2790,28 @@ _NODISCARD _OutputIt _Fmt_write(
         _Precision       = _Max_precision;
     }
 
-    if (_Precision == -1) {
-        _Result = _STD to_chars(_Buffer, _STD end(_Buffer), _Value, _Format);
-    } else {
-        _Result = _STD to_chars(_Buffer, _STD end(_Buffer), _Value, _Format, _Precision);
-    }
+    const auto _Is_negative = (_STD signbit)(_Value);
 
-    _STL_ASSERT(_Result.ec == errc{}, "to_chars failed");
+    if ((_STD isnan)(_Value)) {
+        _Result.ptr = _Buffer;
+        if (_Is_negative) {
+            ++_Result.ptr; // pretend to skip over a '-' that to_chars would put in _Buffer[0]
+        }
+
+        memcpy(_Result.ptr, "nan", 3);
+        _Result.ptr += 3;
+    } else {
+        if (_Precision == -1) {
+            _Result = _STD to_chars(_Buffer, _STD end(_Buffer), _Value, _Format);
+        } else {
+            _Result = _STD to_chars(_Buffer, _STD end(_Buffer), _Value, _Format, _Precision);
+        }
+
+        _STL_ASSERT(_Result.ec == errc{}, "to_chars failed");
+    }
 
     auto _Buffer_start = _Buffer;
     auto _Width        = static_cast<int>(_Result.ptr - _Buffer_start);
-
-    const auto _Is_negative = (_STD signbit)(_Value);
 
     if (_Is_negative) {
         // Remove the '-', it will be dealt with directly

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -2313,7 +2313,7 @@ _NODISCARD _OutputIt _Fmt_write(_OutputIt _Out, const _Arithmetic _Value) {
                 *_End++ = '-';
             }
 
-            memcpy(_End, "nan", 3);
+            _CSTD memcpy(_End, "nan", 3);
             _End += 3;
         }
     }
@@ -2798,7 +2798,7 @@ _NODISCARD _OutputIt _Fmt_write(
             ++_Result.ptr; // pretend to skip over a '-' that to_chars would put in _Buffer[0]
         }
 
-        memcpy(_Result.ptr, "nan", 3);
+        _CSTD memcpy(_Result.ptr, "nan", 3);
         _Result.ptr += 3;
     } else {
         if (_Precision == -1) {

--- a/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
@@ -881,6 +881,7 @@ void test_float_specs() {
     assert(format(STR("{:06}"), nan) == STR("   nan"));
     assert(format(STR("{:06}"), -nan) == STR("  -nan"));
     assert(format(STR("{:06}"), inf) == STR("   inf"));
+    assert(format(STR("{:06}"), -inf) == STR("  -inf"));
 
     // Locale
 #if !defined(_DLL) || _ITERATOR_DEBUG_LEVEL == DEFAULT_IDL_SETTING
@@ -893,6 +894,7 @@ void test_float_specs() {
     assert(format(locale{"en-US"}, STR("{:L}"), nan) == STR("nan"));
     assert(format(locale{"en-US"}, STR("{:L}"), -nan) == STR("-nan"));
     assert(format(locale{"en-US"}, STR("{:L}"), inf) == STR("inf"));
+    assert(format(locale{"en-US"}, STR("{:L}"), -inf) == STR("-inf"));
 
     assert(format(locale{"de-DE"}, STR("{:Lf}"), Float{0}) == STR("0,000000"));
 #endif // !defined(_DLL) || _ITERATOR_DEBUG_LEVEL == DEFAULT_IDL_SETTING

--- a/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
@@ -361,6 +361,11 @@ void test_simple_replacement_field() {
     assert(output_string == STR("nan"));
 
     output_string.clear();
+    vformat_to(back_insert_iterator{output_string}, locale::classic(), STR("{}"),
+        make_testing_format_args<charT>(-numeric_limits<float>::quiet_NaN()));
+    assert(output_string == STR("-nan"));
+
+    output_string.clear();
     vformat_to(back_insert_iterator{output_string}, locale::classic(), STR("{}"), make_testing_format_args<charT>(0.f));
     assert(output_string == STR("0"));
 
@@ -414,6 +419,11 @@ void test_simple_replacement_field() {
     vformat_to(back_insert_iterator{output_string}, locale::classic(), STR("{}"),
         make_testing_format_args<charT>(numeric_limits<double>::quiet_NaN()));
     assert(output_string == STR("nan"));
+
+    output_string.clear();
+    vformat_to(back_insert_iterator{output_string}, locale::classic(), STR("{}"),
+        make_testing_format_args<charT>(-numeric_limits<double>::quiet_NaN()));
+    assert(output_string == STR("-nan"));
 
     output_string.clear();
     vformat_to(back_insert_iterator{output_string}, locale::classic(), STR("{}"), make_testing_format_args<charT>(0.0));
@@ -724,6 +734,10 @@ void test_float_specs() {
     assert(format(STR("{:+}"), nan) == STR("+nan"));
     assert(format(STR("{:-}"), nan) == STR("nan"));
 
+    assert(format(STR("{: }"), -nan) == STR("-nan"));
+    assert(format(STR("{:+}"), -nan) == STR("-nan"));
+    assert(format(STR("{:-}"), -nan) == STR("-nan"));
+
     // Alternate form
     assert(format(STR("{:#}"), Float{0}) == STR("0."));
     assert(format(STR("{:#a}"), Float{0}) == STR("0.p+0"));
@@ -760,6 +774,16 @@ void test_float_specs() {
     assert(format(STR("{:#F} {:#F}"), inf, nan) == STR("INF NAN"));
     assert(format(STR("{:#g} {:#g}"), inf, nan) == STR("inf nan"));
     assert(format(STR("{:#G} {:#G}"), inf, nan) == STR("INF NAN"));
+
+    assert(format(STR("{:#} {:#}"), -inf, -nan) == STR("-inf -nan"));
+    assert(format(STR("{:#a} {:#a}"), -inf, -nan) == STR("-inf -nan"));
+    assert(format(STR("{:#A} {:#A}"), -inf, -nan) == STR("-INF -NAN"));
+    assert(format(STR("{:#e} {:#e}"), -inf, -nan) == STR("-inf -nan"));
+    assert(format(STR("{:#E} {:#E}"), -inf, -nan) == STR("-INF -NAN"));
+    assert(format(STR("{:#f} {:#f}"), -inf, -nan) == STR("-inf -nan"));
+    assert(format(STR("{:#F} {:#F}"), -inf, -nan) == STR("-INF -NAN"));
+    assert(format(STR("{:#g} {:#g}"), -inf, -nan) == STR("-inf -nan"));
+    assert(format(STR("{:#G} {:#G}"), -inf, -nan) == STR("-INF -NAN"));
 
     // Width
     assert(format(STR("{:3}"), Float{0}) == STR("  0"));
@@ -855,6 +879,7 @@ void test_float_specs() {
     assert(format(STR("{:06}"), Float{0}) == STR("000000"));
     assert(format(STR("{:06}"), Float{1.2}) == STR("0001.2"));
     assert(format(STR("{:06}"), nan) == STR("   nan"));
+    assert(format(STR("{:06}"), -nan) == STR("  -nan"));
     assert(format(STR("{:06}"), inf) == STR("   inf"));
 
     // Locale
@@ -866,6 +891,7 @@ void test_float_specs() {
     assert(format(locale{"en-US"}, STR("{:.4Lf}"), value) == STR("1,234.5273"));
     assert(format(locale{"en-US"}, STR("{:#.4Lg}"), Float{0}) == STR("0.000"));
     assert(format(locale{"en-US"}, STR("{:L}"), nan) == STR("nan"));
+    assert(format(locale{"en-US"}, STR("{:L}"), -nan) == STR("-nan"));
     assert(format(locale{"en-US"}, STR("{:L}"), inf) == STR("inf"));
 
     assert(format(locale{"de-DE"}, STR("{:Lf}"), Float{0}) == STR("0,000000"));
@@ -892,6 +918,15 @@ void test_float_specs() {
     assert(format(STR("{:F} {:F}"), inf, nan) == STR("INF NAN"));
     assert(format(STR("{:g} {:g}"), inf, nan) == STR("inf nan"));
     assert(format(STR("{:G} {:G}"), inf, nan) == STR("INF NAN"));
+
+    assert(format(STR("{:a} {:a}"), -inf, -nan) == STR("-inf -nan"));
+    assert(format(STR("{:A} {:A}"), -inf, -nan) == STR("-INF -NAN"));
+    assert(format(STR("{:e} {:e}"), -inf, -nan) == STR("-inf -nan"));
+    assert(format(STR("{:E} {:E}"), -inf, -nan) == STR("-INF -NAN"));
+    assert(format(STR("{:f} {:f}"), -inf, -nan) == STR("-inf -nan"));
+    assert(format(STR("{:F} {:F}"), -inf, -nan) == STR("-INF -NAN"));
+    assert(format(STR("{:g} {:g}"), -inf, -nan) == STR("-inf -nan"));
+    assert(format(STR("{:G} {:G}"), -inf, -nan) == STR("-INF -NAN"));
 }
 
 template <class charT>


### PR DESCRIPTION
... per [[format.string.std]/22](http://eel.is/c++draft/format#string.std-22).

Reported by Mark de Wever after we tried to break their perfectly good test with https://reviews.llvm.org/D131336.