### PR TITLE
Use `_Invoke_result_t<_Urng&>` instead of `_Urng::result_type` in `_Rng_from_urng`

### DIFF
--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -5705,7 +5705,7 @@ template <class _Diff, class _Urng>
 class _Rng_from_urng { // wrap a URNG as an RNG
 public:
     using _Ty0 = make_unsigned_t<_Diff>;
-    using _Ty1 = _Invoke_result_t<_Urng>;
+    using _Ty1 = _Invoke_result_t<_Urng&>;
 
     using _Udiff = conditional_t<sizeof(_Ty1) < sizeof(_Ty0), _Ty0, _Ty1>;
 

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -5710,7 +5710,7 @@ public:
     using _Udiff = conditional_t<sizeof(_Ty1) < sizeof(_Ty0), _Ty0, _Ty1>;
 
     explicit _Rng_from_urng(_Urng& _Func) : _Ref(_Func), _Bits(CHAR_BIT * sizeof(_Udiff)), _Bmask(_Udiff(-1)) {
-        for (; (_Urng::max)() - (_Urng::min)() < _Bmask; _Bmask >>= 1) {
+        for (; static_cast<_Udiff>((_Urng::max)() - (_Urng::min)()) < _Bmask; _Bmask >>= 1) {
             --_Bits;
         }
     }

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -5705,7 +5705,7 @@ template <class _Diff, class _Urng>
 class _Rng_from_urng { // wrap a URNG as an RNG
 public:
     using _Ty0 = make_unsigned_t<_Diff>;
-    using _Ty1 = typename _Urng::result_type;
+    using _Ty1 = _Invoke_result_t<_Urng>;
 
     using _Udiff = conditional_t<sizeof(_Ty1) < sizeof(_Ty0), _Ty0, _Ty1>;
 
@@ -5754,7 +5754,7 @@ public:
 private:
     _Udiff _Get_bits() { // return a random value within [0, _Bmask]
         for (;;) { // repeat until random value is in range
-            _Udiff _Val = _Ref() - (_Urng::min)();
+            _Udiff _Val = static_cast<_Udiff>(_Ref() - (_Urng::min)());
 
             if (_Val <= _Bmask) {
                 return _Val;

--- a/tests/std/tests/P0896R4_ranges_alg_shuffle/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_shuffle/test.cpp
@@ -59,7 +59,7 @@ void test_urbg() { // COMPILE-ONLY
         static constexpr bool max() {
             return true;
         }
-        bool operator()() {
+        bool operator()() & {
             return false;
         }
     };

--- a/tests/std/tests/P0896R4_ranges_alg_shuffle/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_shuffle/test.cpp
@@ -51,6 +51,25 @@ struct instantiator {
     }
 };
 
+void test_urbg() { // COMPILE-ONLY
+    struct RandGen {
+        static constexpr bool min() {
+            return false;
+        }
+        static constexpr bool max() {
+            return true;
+        }
+        bool operator()() {
+            return false;
+        }
+    };
+
+    STATIC_ASSERT(uniform_random_bit_generator<RandGen>);
+
+    int arr[1] = {};
+    ranges::shuffle(arr, RandGen{});
+}
+
 int main() {
     printf("Using seed: %u\n", seed);
 


### PR DESCRIPTION
C++20 `uniform_random_bit_generator` does not require the presence of member `result_type`.

This is tested in libc++ tests [`std/algorithms/alg.modifying.operations/alg.random.shuffle/ranges_shuffle.pass.cpp`](https://github.com/llvm/llvm-project/blob/ba0407ba86d0a87f01e1a676f9dc23bae3e9c169/libcxx/test/std/algorithms/alg.modifying.operations/alg.random.shuffle/ranges_shuffle.pass.cpp) and [`std/algorithms/alg.modifying.operations/alg.random.sample/ranges_sample.pass.cpp`](https://github.com/llvm/llvm-project/blob/ba0407ba86d0a87f01e1a676f9dc23bae3e9c169/libcxx/test/std/algorithms/alg.modifying.operations/alg.random.sample/ranges_sample.pass.cpp). Unfortunately they fail even after this change, because they assume that `std::array` iterators are pointers.