### PR TITLE
`<random>`: Improvements around `static constexpr` member variables

### DIFF
--- a/stl/inc/random
+++ b/stl/inc/random
@@ -790,14 +790,6 @@ protected:
     typename _Swc_Traits::_Cy_t _Carry;
 };
 
-#if !_HAS_CXX17
-template <class _Ty, size_t _Sx, size_t _Rx, class _Swc_Traits>
-const size_t _Swc_base<_Ty, _Sx, _Rx, _Swc_Traits>::short_lag;
-
-template <class _Ty, size_t _Sx, size_t _Rx, class _Swc_Traits>
-const size_t _Swc_base<_Ty, _Sx, _Rx, _Swc_Traits>::long_lag;
-#endif // !_HAS_CXX17
-
 template <class _Ty, _Ty _Mx, size_t _Nw>
 struct _Swc_traits { // traits for subtract_with_carry generator
     using _Cy_t   = int;
@@ -1076,20 +1068,6 @@ private:
     static constexpr unsigned long _Mask = ~((~0UL) << (_Wx % 32));
 };
 
-#if !_HAS_CXX17
-template <class _Ty, size_t _Wx, size_t _Rx>
-const typename _Swc_01_traits<_Ty, _Wx, _Rx>::_Cy_t _Swc_01_traits<_Ty, _Wx, _Rx>::_Cy;
-
-template <class _Ty, size_t _Wx, size_t _Rx>
-const typename _Swc_01_traits<_Ty, _Wx, _Rx>::_Mod_t _Swc_01_traits<_Ty, _Wx, _Rx>::_Mod;
-
-template <class _Ty, size_t _Wx, size_t _Rx>
-const _Ty _Swc_01_traits<_Ty, _Wx, _Rx>::_Max;
-
-template <class _Ty, size_t _Wx, size_t _Rx>
-const _Ty _Swc_01_traits<_Ty, _Wx, _Rx>::_Scale1;
-#endif // !_HAS_CXX17
-
 template <class _Ty, size_t _Wx, size_t _Sx, size_t _Rx>
 class _DEPRECATE_TR1_NAMESPACE subtract_with_carry_01
     : public _Swc_base<_Ty, _Sx, _Rx, _Swc_01_traits<_Ty, _Wx, _Rx>> { // subtract_with_carry_01 generator
@@ -1105,14 +1083,6 @@ public:
     template <class _Gen, _Enable_if_seed_seq_t<_Gen, subtract_with_carry_01> = 0>
     subtract_with_carry_01(_Gen& _Gx) : _Mybase(_Gx) {}
 };
-
-#if !_HAS_CXX17
-_STL_DISABLE_DEPRECATED_WARNING
-template <class _Ty, size_t _Wx, size_t _Sx, size_t _Rx>
-const size_t subtract_with_carry_01<_Ty, _Wx, _Sx, _Rx>::word_size;
-_STL_RESTORE_DEPRECATED_WARNING
-#endif // !_HAS_CXX17
-
 #endif // _HAS_TR1_NAMESPACE
 
 template <class _Ty, int _Wx, int _Nx, int _Mx, int _Rx, _Ty _Px, int _Ux, int _Sx, _Ty _Bx, int _Tx, _Ty _Cx, int _Lx>
@@ -1458,14 +1428,6 @@ private:
     base_type _Eng;
     int _Nx;
 };
-
-#if !_HAS_CXX17
-template <class _Engine, int _Px, int _Rx>
-const int discard_block<_Engine, _Px, _Rx>::block_size;
-
-template <class _Engine, int _Px, int _Rx>
-const int discard_block<_Engine, _Px, _Rx>::used_block;
-#endif // !_HAS_CXX17
 
 template <class _Engine, size_t _Px, size_t _Rx>
 class discard_block_engine : public discard_block<_Engine, _Px, _Rx> { // discard_block_engine compound engine

--- a/stl/inc/random
+++ b/stl/inc/random
@@ -1026,8 +1026,7 @@ struct _Swc_01_traits { // traits for subtract_with_carry_01 generator
     using _Mod_t  = _Ty;
     using _Seed_t = unsigned int;
 
-    static constexpr _Cy_t _Cy = static_cast<_Cy_t>(
-        _Cx_ldexp_one(static_cast<int>(-static_cast<ptrdiff_t>(_Wx))));
+    static constexpr _Cy_t _Cy   = static_cast<_Cy_t>(_Cx_ldexp_one(static_cast<int>(-static_cast<ptrdiff_t>(_Wx))));
     static constexpr _Mod_t _Mod = 1;
     static constexpr _Ty _Max    = 1;
     static constexpr int _Nwords = (_Wx + 31) / 32;

--- a/stl/inc/random
+++ b/stl/inc/random
@@ -1076,7 +1076,7 @@ private:
     static constexpr unsigned long _Mask = ~((~0UL) << (_Wx % 32));
 };
 
-#if _HAS_CXX17
+#if !_HAS_CXX17
 template <class _Ty, size_t _Wx, size_t _Rx>
 const typename _Swc_01_traits<_Ty, _Wx, _Rx>::_Cy_t _Swc_01_traits<_Ty, _Wx, _Rx>::_Cy;
 

--- a/stl/inc/random
+++ b/stl/inc/random
@@ -790,11 +790,13 @@ protected:
     typename _Swc_Traits::_Cy_t _Carry;
 };
 
+#if !_HAS_CXX17
 template <class _Ty, size_t _Sx, size_t _Rx, class _Swc_Traits>
 const size_t _Swc_base<_Ty, _Sx, _Rx, _Swc_Traits>::short_lag;
 
 template <class _Ty, size_t _Sx, size_t _Rx, class _Swc_Traits>
 const size_t _Swc_base<_Ty, _Sx, _Rx, _Swc_Traits>::long_lag;
+#endif // !_HAS_CXX17
 
 template <class _Ty, _Ty _Mx, size_t _Nw>
 struct _Swc_traits { // traits for subtract_with_carry generator
@@ -1005,6 +1007,18 @@ public:
 };
 
 #if _HAS_TR1_NAMESPACE
+_CONSTEVAL double _Cx_ldexp_one(const int _Exp) noexcept {
+    double _Ret = 1.0;
+    for (int _Count = _Exp; _Count > 0; --_Count) {
+        _Ret *= 2.0;
+    }
+    for (int _Count = _Exp; _Count < 0; ++_Count) {
+        _Ret *= 0.5;
+    }
+
+    return _Ret;
+}
+
 template <class _Ty, size_t _Wx, size_t _Rx>
 struct _Swc_01_traits { // traits for subtract_with_carry_01 generator
     using _Cy_t   = _Ty;
@@ -1012,9 +1026,10 @@ struct _Swc_01_traits { // traits for subtract_with_carry_01 generator
     using _Mod_t  = _Ty;
     using _Seed_t = unsigned int;
 
-    static const _Cy_t _Cy;
-    static const _Mod_t _Mod;
-    static const _Ty _Max;
+    static constexpr _Cy_t _Cy = static_cast<_Cy_t>(
+        _Cx_ldexp_one(static_cast<int>(-static_cast<ptrdiff_t>(_Wx))));
+    static constexpr _Mod_t _Mod = 1;
+    static constexpr _Ty _Max    = 1;
     static constexpr int _Nwords = (_Wx + 31) / 32;
 
     template <class _Gen>
@@ -1058,23 +1073,23 @@ struct _Swc_01_traits { // traits for subtract_with_carry_01 generator
     }
 
 private:
-    static const _Ty _Scale1;
+    static constexpr _Ty _Scale1         = static_cast<_Ty>(_Cx_ldexp_one(_Wx % 32));
     static constexpr unsigned long _Mask = ~((~0UL) << (_Wx % 32));
 };
 
+#if _HAS_CXX17
 template <class _Ty, size_t _Wx, size_t _Rx>
-const typename _Swc_01_traits<_Ty, _Wx, _Rx>::_Cy_t
-    _Swc_01_traits<_Ty, _Wx, _Rx>::_Cy = static_cast<typename _Swc_01_traits<_Ty, _Wx, _Rx>::_Cy_t>(
-        _CSTD ldexp(1.0, static_cast<int>(-static_cast<ptrdiff_t>(_Wx))));
+const typename _Swc_01_traits<_Ty, _Wx, _Rx>::_Cy_t _Swc_01_traits<_Ty, _Wx, _Rx>::_Cy;
 
 template <class _Ty, size_t _Wx, size_t _Rx>
-const typename _Swc_01_traits<_Ty, _Wx, _Rx>::_Mod_t _Swc_01_traits<_Ty, _Wx, _Rx>::_Mod = 1;
+const typename _Swc_01_traits<_Ty, _Wx, _Rx>::_Mod_t _Swc_01_traits<_Ty, _Wx, _Rx>::_Mod;
 
 template <class _Ty, size_t _Wx, size_t _Rx>
-const _Ty _Swc_01_traits<_Ty, _Wx, _Rx>::_Max = 1;
+const _Ty _Swc_01_traits<_Ty, _Wx, _Rx>::_Max;
 
 template <class _Ty, size_t _Wx, size_t _Rx>
-const _Ty _Swc_01_traits<_Ty, _Wx, _Rx>::_Scale1 = static_cast<_Ty>(_CSTD ldexp(1.0, _Wx % 32));
+const _Ty _Swc_01_traits<_Ty, _Wx, _Rx>::_Scale1;
+#endif // !_HAS_CXX17
 
 template <class _Ty, size_t _Wx, size_t _Sx, size_t _Rx>
 class _DEPRECATE_TR1_NAMESPACE subtract_with_carry_01
@@ -1092,10 +1107,12 @@ public:
     subtract_with_carry_01(_Gen& _Gx) : _Mybase(_Gx) {}
 };
 
+#if !_HAS_CXX17
 _STL_DISABLE_DEPRECATED_WARNING
 template <class _Ty, size_t _Wx, size_t _Sx, size_t _Rx>
 const size_t subtract_with_carry_01<_Ty, _Wx, _Sx, _Rx>::word_size;
 _STL_RESTORE_DEPRECATED_WARNING
+#endif // !_HAS_CXX17
 
 #endif // _HAS_TR1_NAMESPACE
 
@@ -1443,11 +1460,13 @@ private:
     int _Nx;
 };
 
+#if !_HAS_CXX17
 template <class _Engine, int _Px, int _Rx>
 const int discard_block<_Engine, _Px, _Rx>::block_size;
 
 template <class _Engine, int _Px, int _Rx>
 const int discard_block<_Engine, _Px, _Rx>::used_block;
+#endif // !_HAS_CXX17
 
 template <class _Engine, size_t _Px, size_t _Rx>
 class discard_block_engine : public discard_block<_Engine, _Px, _Rx> { // discard_block_engine compound engine

--- a/stl/inc/random
+++ b/stl/inc/random
@@ -999,7 +999,7 @@ public:
 };
 
 #if _HAS_TR1_NAMESPACE
-_CONSTEVAL double _Cx_ldexp_one(const int _Exp) noexcept {
+_CONSTEVAL double _Cx_exp2(const int _Exp) noexcept {
     double _Ret = 1.0;
     for (int _Count = _Exp; _Count > 0; --_Count) {
         _Ret *= 2.0;
@@ -1018,7 +1018,7 @@ struct _Swc_01_traits { // traits for subtract_with_carry_01 generator
     using _Mod_t  = _Ty;
     using _Seed_t = unsigned int;
 
-    static constexpr _Cy_t _Cy   = static_cast<_Cy_t>(_Cx_ldexp_one(static_cast<int>(-static_cast<ptrdiff_t>(_Wx))));
+    static constexpr _Cy_t _Cy   = static_cast<_Cy_t>(_Cx_exp2(static_cast<int>(-static_cast<ptrdiff_t>(_Wx))));
     static constexpr _Mod_t _Mod = 1;
     static constexpr _Ty _Max    = 1;
     static constexpr int _Nwords = (_Wx + 31) / 32;
@@ -1064,7 +1064,7 @@ struct _Swc_01_traits { // traits for subtract_with_carry_01 generator
     }
 
 private:
-    static constexpr _Ty _Scale1         = static_cast<_Ty>(_Cx_ldexp_one(_Wx % 32));
+    static constexpr _Ty _Scale1         = static_cast<_Ty>(_Cx_exp2(_Wx % 32));
     static constexpr unsigned long _Mask = ~((~0UL) << (_Wx % 32));
 };
 


### PR DESCRIPTION
This PR proposes the following improvements for some static member variables in `<random>`:

1. `_Swc_01_traits` will have all of its static member variables statically initialized.
2. No redeclarations (since C++17, definitions in C++14 and former revisions) of constexpr static member variables will ever exist, even if one attempt to revive `tr1` in C++17 (and later modes). They are deprecated in C++17, even though warnings seem to be silenced.
3. (According to the suggestion) Out-of-class definitions will also be removed in C++14 mode.

The first should be reverted if changing from dynamic initialization to static one or removal of odr-using breaks ABI.