### PR TITLE
P2446R2: `views::as_rvalue`

### DIFF
--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -1635,10 +1635,10 @@ namespace ranges {
         /* [[no_unique_address]] */ _Vw _Range{};
 
         template <range _Rng>
-        static constexpr bool _Is_end_nothrow_v = noexcept(move_sentinel{_RANGES end(_STD declval<_Rng>())});
+        static constexpr bool _Is_end_nothrow_v = noexcept(move_sentinel{_RANGES end(_STD declval<_Rng&>())});
 
         template <common_range _Rng>
-        static constexpr bool _Is_end_nothrow_v<_Rng> = noexcept(move_iterator{_RANGES end(_STD declval<_Rng>())});
+        static constexpr bool _Is_end_nothrow_v<_Rng> = noexcept(move_iterator{_RANGES end(_STD declval<_Rng&>())});
 
     public:
         // clang-format off

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -1708,7 +1708,7 @@ namespace ranges {
             as_rvalue_view{static_cast<_Rng&&>(__r)};
         };
 
-        struct _As_rvalue_fn : _Pipe::_Base<_As_rvalue_fn> {
+        class _As_rvalue_fn : public _Pipe::_Base<_As_rvalue_fn> {
         private:
             enum class _St { _None, _All, _As_rvalue };
 

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -1627,6 +1627,124 @@ namespace ranges {
         using all_t = decltype(all(_STD declval<_Rng>()));
     } // namespace views
 
+#if _HAS_CXX23
+    template <input_range _Vw>
+        requires view<_Vw>
+    class as_rvalue_view : public view_interface<as_rvalue_view<_Vw>> {
+    private:
+        /* [[no_unique_address]] */ _Vw _Range{};
+
+        template <range _Rng>
+        static constexpr bool _Is_end_nothrow_v = noexcept(move_sentinel{_RANGES end(_STD declval<_Rng>())});
+
+        template <common_range _Rng>
+        static constexpr bool _Is_end_nothrow_v<_Rng> = noexcept(move_iterator{_RANGES end(_STD declval<_Rng>())});
+
+    public:
+        // clang-format off
+        as_rvalue_view() requires default_initializable<_Vw> = default;
+        // clang-format on
+
+        constexpr explicit as_rvalue_view(_Vw _Range_) noexcept(is_nothrow_move_constructible_v<_Vw>) // strengthened
+            : _Range(_STD move(_Range_)) {}
+
+        _NODISCARD constexpr _Vw base() const& noexcept(is_nothrow_copy_constructible_v<_Vw>) // strengthened
+            requires copy_constructible<_Vw> {
+            return _Range;
+        }
+
+        _NODISCARD constexpr _Vw base() && noexcept(is_nothrow_move_constructible_v<_Vw>) /* strengthened */ {
+            return _STD move(_Range);
+        }
+
+        _NODISCARD constexpr auto begin() noexcept(noexcept(move_iterator{_RANGES begin(_Range)})) // strengthened
+            requires(!_Simple_view<_Vw>) {
+            return move_iterator{_RANGES begin(_Range)};
+        }
+
+        _NODISCARD constexpr auto begin() const noexcept(noexcept(move_iterator{_RANGES begin(_Range)})) // strengthened
+            requires range<const _Vw> {
+            return move_iterator{_RANGES begin(_Range)};
+        }
+
+        _NODISCARD constexpr auto end() noexcept(_Is_end_nothrow_v<_Vw>) // strengthened
+            requires(!_Simple_view<_Vw>) {
+            if constexpr (common_range<_Vw>) {
+                return move_iterator{_RANGES end(_Range)};
+            } else {
+                return move_sentinel{_RANGES end(_Range)};
+            }
+        }
+
+        _NODISCARD constexpr auto end() const noexcept(_Is_end_nothrow_v<const _Vw>) // strengthened
+            requires range<const _Vw> {
+            if constexpr (common_range<const _Vw>) {
+                return move_iterator{_RANGES end(_Range)};
+            } else {
+                return move_sentinel{_RANGES end(_Range)};
+            }
+        }
+
+        _NODISCARD constexpr auto size() noexcept(noexcept(_RANGES size(_Range))) // strengthened
+            requires sized_range<_Vw> {
+            return _RANGES size(_Range);
+        }
+
+        _NODISCARD constexpr auto size() const noexcept(noexcept(_RANGES size(_Range))) // strengthened
+            requires sized_range<const _Vw> {
+            return _RANGES size(_Range);
+        }
+    };
+
+    template <class _Rng>
+    as_rvalue_view(_Rng&&) -> as_rvalue_view<views::all_t<_Rng>>;
+
+    template <class _Rng>
+    inline constexpr bool enable_borrowed_range<as_rvalue_view<_Rng>> = enable_borrowed_range<_Rng>;
+
+    namespace views {
+        template <class _Rng>
+        concept _Can_as_rvalue = requires(_Rng&& __r) {
+            as_rvalue_view{static_cast<_Rng&&>(__r)};
+        };
+
+        struct _As_rvalue_fn : _Pipe::_Base<_As_rvalue_fn> {
+        private:
+            enum class _St { _None, _All, _As_rvalue };
+
+            template <class _Rng>
+            _NODISCARD static _CONSTEVAL _Choice_t<_St> _Choose() noexcept {
+                if constexpr (same_as<range_rvalue_reference_t<_Rng>, range_reference_t<_Rng>>) {
+                    return {_St::_All, noexcept(views::all(_STD declval<_Rng>()))};
+                } else if constexpr (_Can_as_rvalue<_Rng>) {
+                    return {_St::_As_rvalue, noexcept(as_rvalue_view{_STD declval<_Rng>()})};
+                } else {
+                    return {_St::_None};
+                }
+            }
+
+            template <class _Rng>
+            static constexpr _Choice_t<_St> _Choice = _Choose<_Rng>();
+
+        public:
+            template <viewable_range _Rng>
+                requires(_Choice<_Rng>._Strategy != _St::_None)
+            _NODISCARD constexpr auto operator()(_Rng&& _Range) const noexcept(_Choice<_Rng>._No_throw) {
+                constexpr _St _Strat = _Choice<_Rng>._Strategy;
+                if constexpr (_Strat == _St::_All) {
+                    return views::all(_STD forward<_Rng>(_Range));
+                } else if constexpr (_Strat == _St::_As_rvalue) {
+                    return as_rvalue_view{_STD forward<_Rng>(_Range)};
+                } else {
+                    static_assert(_Always_false<_Rng>, "Should be unreachable");
+                }
+            }
+        };
+
+        inline constexpr _As_rvalue_fn as_rvalue;
+    } // namespace views
+#endif // _HAS_CXX23
+
     template <input_range _Vw, indirect_unary_predicate<iterator_t<_Vw>> _Pr>
         requires view<_Vw> && is_object_v<_Pr>
     class filter_view : public _Cached_position_t<forward_range<_Vw>, _Vw, filter_view<_Vw, _Pr>> {

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -329,6 +329,7 @@
 // P2442R1 Windowing Range Adaptors: views::chunk, views::slide
 // P2443R1 views::chunk_by
 // P2445R1 forward_like()
+// P2446R2 views::as_rvalue
 // P2499R0 string_view Range Constructor Should Be explicit
 // P2549R0 unexpected<E>::error()
 
@@ -1511,6 +1512,7 @@ _EMIT_STL_ERROR(STL1004, "C++98 unexpected() is incompatible with C++23 unexpect
 
 #ifdef __cpp_lib_concepts
 #define __cpp_lib_out_ptr                 202106L
+#define __cpp_lib_ranges_as_rvalue        202207L
 #define __cpp_lib_ranges_chunk            202202L
 #define __cpp_lib_ranges_chunk_by         202202L
 #define __cpp_lib_ranges_contains         202207L

--- a/tests/std/test.lst
+++ b/tests/std/test.lst
@@ -552,6 +552,7 @@ tests\P2442R1_views_slide
 tests\P2443R1_views_chunk_by
 tests\P2443R1_views_chunk_by_death
 tests\P2445R1_forward_like
+tests\P2446R2_views_as_rvalue
 tests\P2517R1_apply_conditional_noexcept
 tests\VSO_0000000_allocator_propagation
 tests\VSO_0000000_any_calling_conventions

--- a/tests/std/tests/P2446R2_views_as_rvalue/env.lst
+++ b/tests/std/tests/P2446R2_views_as_rvalue/env.lst
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst

--- a/tests/std/tests/P2446R2_views_as_rvalue/env.lst
+++ b/tests/std/tests/P2446R2_views_as_rvalue/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_latest_matrix.lst

--- a/tests/std/tests/P2446R2_views_as_rvalue/test.cpp
+++ b/tests/std/tests/P2446R2_views_as_rvalue/test.cpp
@@ -443,7 +443,7 @@ int main() {
         STATIC_ASSERT(test_one(views::iota(0, 10), views::iota(0, 10)));
         test_one(views::iota(0, 10), views::iota(0, 10));
 
-        const string some_strings[] = {"0"s, "3"s, "6"s, "9"s, "12"s, "15"s};
+        const string some_strings[] = {"0", "3", "6", "9", "12", "15"};
         auto transformed            = some_ints | views::transform([](int x) { return to_string(x); });
         test_one(transformed, some_strings);
     }

--- a/tests/std/tests/P2446R2_views_as_rvalue/test.cpp
+++ b/tests/std/tests/P2446R2_views_as_rvalue/test.cpp
@@ -215,6 +215,7 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
         if (!is_empty) {
             assert(*i == *begin(expected));
         }
+
         if constexpr (copy_constructible<V>) {
             auto r2                              = r;
             const same_as<iterator_t<R>> auto i2 = r2.begin();
@@ -231,6 +232,7 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
         if (!is_empty) {
             assert(*ci == *begin(expected));
         }
+
         if constexpr (copy_constructible<V>) {
             const auto cr2                              = r;
             const same_as<iterator_t<const R>> auto ci2 = cr2.begin();
@@ -250,6 +252,7 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
             if (!is_empty) {
                 assert(*prev(s) == *prev(end(expected)));
             }
+
             if constexpr (copy_constructible<V>) {
                 auto r2 = r;
                 if (!is_empty) {
@@ -269,6 +272,7 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
             if (!is_empty) {
                 assert(*prev(cs) == *prev(end(expected)));
             }
+
             if constexpr (copy_constructible<V>) {
                 const auto r2 = r;
                 if (!is_empty) {

--- a/tests/std/tests/P2446R2_views_as_rvalue/test.cpp
+++ b/tests/std/tests/P2446R2_views_as_rvalue/test.cpp
@@ -409,8 +409,8 @@ void test_example_from_p2446r2() {
     ranges::copy(words | views::as_rvalue, back_inserter(new_words)); // moves each string from words into new_words
 
     assert(ranges::equal(new_words, pattern));
-    assert(words.size() == pattern.size()); // size of words in preserved
-    assert(ranges::all_of(words, ranges::empty)); // all strings from words are empty
+    assert(words.size() == pattern.size()); // size of words is preserved
+    assert(ranges::all_of(words, ranges::empty)); // all strings from words are empty (implementation assumption)
 }
 
 int main() {

--- a/tests/std/tests/P2446R2_views_as_rvalue/test.cpp
+++ b/tests/std/tests/P2446R2_views_as_rvalue/test.cpp
@@ -1,0 +1,430 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <cassert>
+#include <forward_list>
+#include <ranges>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include <range_algorithm_support.hpp>
+
+using namespace std;
+
+template <class Rng>
+concept CanViewAsRvalue = requires(Rng&& r) {
+    views::as_rvalue(forward<Rng>(r));
+};
+
+template <ranges::input_range R1, ranges::input_range R2>
+constexpr bool test_equal(R1&& r1, R2&& r2) { // TRANSITION, GH-3009
+    auto first1 = ranges::begin(r1);
+    auto last1  = ranges::end(r1);
+    auto first2 = ranges::begin(r2);
+    auto last2  = ranges::end(r2);
+    while (true) {
+        if (first1 == last1) {
+            return first2 == last2;
+        } else if (first2 == last2 || *first1 != *first2) {
+            return false;
+        }
+        ++first1;
+        ++first2;
+    }
+}
+
+template <ranges::input_range Rng, class Expected>
+constexpr bool test_one(Rng&& rng, Expected&& expected) {
+    using ranges::as_rvalue_view, ranges::begin, ranges::end, ranges::iterator_t, ranges::sentinel_t, ranges::prev;
+    using ranges::forward_range, ranges::bidirectional_range, ranges::random_access_range, ranges::common_range,
+        ranges::sized_range;
+
+    [[maybe_unused]] constexpr bool is_view = ranges::view<remove_cvref_t<Rng>>;
+
+    using V                          = views::all_t<Rng>;
+    constexpr bool is_already_rvalue = same_as<ranges::range_rvalue_reference_t<V>, ranges::range_reference_t<V>>;
+    using R                          = as_rvalue_view<V>;
+
+    STATIC_ASSERT(ranges::view<R>);
+    STATIC_ASSERT(ranges::input_range<R> == ranges::input_range<V>);
+    STATIC_ASSERT(ranges::forward_range<R> == ranges::forward_range<V>);
+    STATIC_ASSERT(ranges::bidirectional_range<R> == ranges::bidirectional_range<V>);
+    STATIC_ASSERT(ranges::random_access_range<R> == ranges::random_access_range<V>);
+    STATIC_ASSERT(!ranges::contiguous_range<R>);
+
+    // Validate default-initializability
+    STATIC_ASSERT(default_initializable<R> == default_initializable<V>);
+
+    // Validate borrowed_range
+    STATIC_ASSERT(ranges::borrowed_range<R> == ranges::borrowed_range<V>);
+
+    // Validate range adaptor object
+    if constexpr (!is_already_rvalue) { // range adaptor results in as_rvalue_view
+        // ... with lvalue argument
+        STATIC_ASSERT(CanViewAsRvalue<Rng&> == (!is_view || copy_constructible<V>) );
+        if constexpr (CanViewAsRvalue<Rng&>) {
+            constexpr bool is_noexcept = !is_view || is_nothrow_copy_constructible_v<V>;
+
+            STATIC_ASSERT(same_as<decltype(views::as_rvalue(std::forward<Rng>(rng))), R>);
+            STATIC_ASSERT(noexcept(views::as_rvalue(std::forward<Rng>(rng))) == is_noexcept);
+
+            STATIC_ASSERT(same_as<decltype(std::forward<Rng>(rng) | views::as_rvalue), R>);
+            STATIC_ASSERT(noexcept(std::forward<Rng>(rng) | views::as_rvalue) == is_noexcept);
+        }
+
+        // ... with const lvalue argument
+        STATIC_ASSERT(CanViewAsRvalue<const remove_reference_t<Rng>&> == (!is_view || copy_constructible<V>) );
+        if constexpr (CanViewAsRvalue<const remove_reference_t<Rng>&>) {
+            using RC                   = as_rvalue_view<views::all_t<const remove_reference_t<Rng>&>>;
+            constexpr bool is_noexcept = !is_view || is_nothrow_copy_constructible_v<V>;
+
+            STATIC_ASSERT(same_as<decltype(views::as_rvalue(as_const(rng))), RC>);
+            STATIC_ASSERT(noexcept(views::as_rvalue(as_const(rng))) == is_noexcept);
+
+            STATIC_ASSERT(same_as<decltype(as_const(rng) | views::as_rvalue), RC>);
+            STATIC_ASSERT(noexcept(as_const(rng) | views::as_rvalue) == is_noexcept);
+        }
+
+        // ... with rvalue argument
+        STATIC_ASSERT(CanViewAsRvalue<remove_reference_t<Rng>> == (is_view || movable<remove_reference_t<Rng>>) );
+        if constexpr (CanViewAsRvalue<remove_reference_t<Rng>>) {
+            using RS                   = as_rvalue_view<views::all_t<remove_reference_t<Rng>>>;
+            constexpr bool is_noexcept = is_nothrow_move_constructible_v<V>;
+
+            STATIC_ASSERT(same_as<decltype(views::as_rvalue(std::move(rng))), RS>);
+            STATIC_ASSERT(noexcept(views::as_rvalue(std::move(rng))) == is_noexcept);
+
+            STATIC_ASSERT(same_as<decltype(std::move(rng) | views::as_rvalue), RS>);
+            STATIC_ASSERT(noexcept(std::move(rng) | views::as_rvalue) == is_noexcept);
+        }
+
+        // ... with const rvalue argument
+        STATIC_ASSERT(CanViewAsRvalue<const remove_reference_t<Rng>> == (is_view && copy_constructible<V>) );
+        if constexpr (CanViewAsRvalue<const remove_reference_t<Rng>>) {
+            constexpr bool is_noexcept = is_nothrow_copy_constructible_v<V>;
+
+            STATIC_ASSERT(same_as<decltype(views::as_rvalue(std::move(as_const(rng)))), R>);
+            STATIC_ASSERT(noexcept(views::as_rvalue(std::move(as_const(rng)))) == is_noexcept);
+
+            STATIC_ASSERT(same_as<decltype(std::move(as_const(rng)) | views::as_rvalue), R>);
+            STATIC_ASSERT(noexcept(std::move(as_const(rng)) | views::as_rvalue) == is_noexcept);
+        }
+    } else { // range adaptor results in views::all_t
+        // ... with lvalue argument
+        STATIC_ASSERT(CanViewAsRvalue<Rng&> == (!is_view || copy_constructible<V>) );
+        if constexpr (CanViewAsRvalue<Rng&>) {
+            constexpr bool is_noexcept = !is_view || is_nothrow_copy_constructible_v<V>;
+
+            STATIC_ASSERT(same_as<decltype(views::as_rvalue(std::forward<Rng>(rng))), V>);
+            STATIC_ASSERT(noexcept(views::as_rvalue(std::forward<Rng>(rng))) == is_noexcept);
+
+            STATIC_ASSERT(same_as<decltype(std::forward<Rng>(rng) | views::as_rvalue), V>);
+            STATIC_ASSERT(noexcept(std::forward<Rng>(rng) | views::as_rvalue) == is_noexcept);
+        }
+
+        // ... with const lvalue argument
+        STATIC_ASSERT(CanViewAsRvalue<const remove_reference_t<Rng>&> == (!is_view || copy_constructible<V>) );
+        if constexpr (CanViewAsRvalue<const remove_reference_t<Rng>&>) {
+            using VC                   = views::all_t<const remove_reference_t<Rng>&>;
+            constexpr bool is_noexcept = !is_view || is_nothrow_copy_constructible_v<V>;
+
+            STATIC_ASSERT(same_as<decltype(views::as_rvalue(as_const(rng))), VC>);
+            STATIC_ASSERT(noexcept(views::as_rvalue(as_const(rng))) == is_noexcept);
+
+            STATIC_ASSERT(same_as<decltype(as_const(rng) | views::as_rvalue), VC>);
+            STATIC_ASSERT(noexcept(as_const(rng) | views::as_rvalue) == is_noexcept);
+        }
+
+        // ... with rvalue argument
+        STATIC_ASSERT(CanViewAsRvalue<remove_reference_t<Rng>> == (is_view || movable<remove_reference_t<Rng>>) );
+        if constexpr (CanViewAsRvalue<remove_reference_t<Rng>>) {
+            using VS                   = views::all_t<remove_reference_t<Rng>>;
+            constexpr bool is_noexcept = is_nothrow_move_constructible_v<V>;
+
+            STATIC_ASSERT(same_as<decltype(views::as_rvalue(std::move(rng))), VS>);
+            STATIC_ASSERT(noexcept(views::as_rvalue(std::move(rng))) == is_noexcept);
+
+            STATIC_ASSERT(same_as<decltype(std::move(rng) | views::as_rvalue), VS>);
+            STATIC_ASSERT(noexcept(std::move(rng) | views::as_rvalue) == is_noexcept);
+        }
+
+        // ... with const rvalue argument
+        STATIC_ASSERT(CanViewAsRvalue<const remove_reference_t<Rng>> == (is_view && copy_constructible<V>) );
+        if constexpr (CanViewAsRvalue<const remove_reference_t<Rng>>) {
+            constexpr bool is_noexcept = is_nothrow_copy_constructible_v<V>;
+
+            STATIC_ASSERT(same_as<decltype(views::as_rvalue(std::move(as_const(rng)))), V>);
+            STATIC_ASSERT(noexcept(views::as_rvalue(std::move(as_const(rng)))) == is_noexcept);
+
+            STATIC_ASSERT(same_as<decltype(std::move(as_const(rng)) | views::as_rvalue), V>);
+            STATIC_ASSERT(noexcept(std::move(as_const(rng)) | views::as_rvalue) == is_noexcept);
+        }
+    }
+
+    // Validate deduction guide
+    same_as<R> auto r = as_rvalue_view{std::forward<Rng>(rng)};
+
+    // Validate as_const_view::size
+    STATIC_ASSERT(CanMemberSize<R> == sized_range<V>);
+    if constexpr (CanMemberSize<R>) {
+        same_as<ranges::range_size_t<V>> auto s = r.size();
+        assert(_To_unsigned_like(s) == ranges::size(expected));
+        STATIC_ASSERT(noexcept(r.size()) == noexcept(ranges::size(rng)));
+    }
+
+    // Validate as_const_view::size (const)
+    STATIC_ASSERT(CanMemberSize<const R> == sized_range<const V>);
+    if constexpr (CanMemberSize<const R>) {
+        same_as<ranges::range_size_t<const V>> auto s = as_const(r).size();
+        assert(_To_unsigned_like(s) == ranges::size(expected));
+        STATIC_ASSERT(noexcept(as_const(r).size()) == noexcept(ranges::size(rng)));
+    }
+
+    const bool is_empty = ranges::empty(expected);
+
+    // Validate view_interface::empty and operator bool
+    STATIC_ASSERT(CanMemberEmpty<R> == (forward_range<V> || sized_range<V>) );
+    STATIC_ASSERT(CanBool<R> == CanEmpty<R>);
+    if constexpr (CanMemberEmpty<R>) {
+        assert(r.empty() == is_empty);
+        assert(static_cast<bool>(r) == !is_empty);
+    }
+
+    // Validate view_interface::empty and operator bool (const)
+    STATIC_ASSERT(CanMemberEmpty<const R> == (forward_range<const Rng> || sized_range<const V>) );
+    STATIC_ASSERT(CanBool<const R> == CanEmpty<const R>);
+    if constexpr (CanMemberEmpty<const R>) {
+        assert(as_const(r).empty() == is_empty);
+        assert(static_cast<bool>(as_const(r)) == !is_empty);
+    }
+
+    assert(test_equal(r, expected)); // TRANSITION, GH-3009 (use ranges::equal)
+    if (!forward_range<V>) { // intentionally not if constexpr
+        return true;
+    }
+
+    // Validate as_rvalue_view::begin
+    STATIC_ASSERT(CanMemberBegin<R>);
+    {
+        const same_as<iterator_t<R>> auto i = r.begin();
+        if (!is_empty) {
+            assert(*i == *begin(expected));
+        }
+        if constexpr (copy_constructible<V>) {
+            auto r2                              = r;
+            const same_as<iterator_t<R>> auto i2 = r2.begin();
+            if (!is_empty) {
+                assert(*i2 == *i);
+            }
+        }
+    }
+
+    // Validate as_rvalue_view::begin (const)
+    STATIC_ASSERT(CanMemberBegin<const R> == ranges::range<const V>);
+    if constexpr (CanMemberBegin<const R>) {
+        const same_as<iterator_t<const R>> auto ci = as_const(r).begin();
+        if (!is_empty) {
+            assert(*ci == *begin(expected));
+        }
+        if constexpr (copy_constructible<V>) {
+            const auto cr2                              = r;
+            const same_as<iterator_t<const R>> auto ci2 = cr2.begin();
+            if (!is_empty) {
+                assert(*ci2 == *ci);
+            }
+        }
+    }
+
+    // Validate as_rvalue_view::end
+    STATIC_ASSERT(CanMemberEnd<R>);
+    {
+        const same_as<sentinel_t<R>> auto s = r.end();
+        assert((r.begin() == s) == is_empty);
+        STATIC_ASSERT(common_range<R> == common_range<V>);
+        if constexpr (common_range<R> && bidirectional_range<V>) {
+            if (!is_empty) {
+                assert(*prev(s) == *prev(end(expected)));
+            }
+            if constexpr (copy_constructible<V>) {
+                auto r2 = r;
+                if (!is_empty) {
+                    assert(*prev(r2.end()) == *prev(end(expected)));
+                }
+            }
+        }
+    }
+
+    // Validate as_rvalue_view::end (const)
+    STATIC_ASSERT(CanMemberEnd<const R> == ranges::range<const V>);
+    if constexpr (CanMemberEnd<const R>) {
+        const same_as<sentinel_t<const R>> auto cs = as_const(r).end();
+        assert((as_const(r).begin() == cs) == is_empty);
+        STATIC_ASSERT(common_range<const R> == common_range<const V>);
+        if constexpr (common_range<const R> && bidirectional_range<const V>) {
+            if (!is_empty) {
+                assert(*prev(cs) == *prev(end(expected)));
+            }
+            if constexpr (copy_constructible<V>) {
+                const auto r2 = r;
+                if (!is_empty) {
+                    assert(*prev(r2.end()) == *prev(end(expected)));
+                }
+            }
+        }
+    }
+
+    // Validate view_interface::data
+    STATIC_ASSERT(!CanData<R>);
+    STATIC_ASSERT(!CanData<const R>);
+
+    if (!is_empty) {
+        // Validate view_interface::operator[]
+        STATIC_ASSERT(CanIndex<R> == random_access_range<V>);
+        if constexpr (CanIndex<R>) {
+            assert(r[0] == expected[0]);
+        }
+
+        // Validate view_interface::operator[] (const)
+        STATIC_ASSERT(CanIndex<const R> == random_access_range<const V>);
+        if constexpr (CanIndex<const R>) {
+            assert(as_const(r)[0] == expected[0]);
+        }
+
+        // Validate view_interface::front
+        STATIC_ASSERT(CanMemberFront<R> == forward_range<V>);
+        if constexpr (CanMemberFront<R>) {
+            assert(r.front() == *begin(expected));
+        }
+
+        // Validate view_interface::front (const)
+        STATIC_ASSERT(CanMemberFront<const R> == forward_range<const V>);
+        if constexpr (CanMemberFront<const R>) {
+            assert(as_const(r).front() == *begin(expected));
+        }
+
+        // Validate view_interface::back
+        STATIC_ASSERT(CanMemberBack<R> == (bidirectional_range<V> && common_range<V>) );
+        if constexpr (CanMemberBack<R>) {
+            assert(r.back() == *prev(end(expected)));
+        }
+
+        // Validate view_interface::back (const)
+        STATIC_ASSERT(CanMemberBack<const R> == (bidirectional_range<const V> && common_range<const V>) );
+        if constexpr (CanMemberBack<const R>) {
+            assert(as_const(r).back() == *prev(end(expected)));
+        }
+    }
+
+    // Validate as_rvalue_view::base() const&
+    STATIC_ASSERT(CanMemberBase<const R&> == copy_constructible<V>);
+    if constexpr (copy_constructible<V>) {
+        same_as<V> auto b1 = as_const(r).base();
+        STATIC_ASSERT(noexcept(as_const(r).base()) == is_nothrow_copy_constructible_v<V>);
+        if (!is_empty) {
+            assert(*b1.begin() == *begin(expected));
+        }
+    }
+
+    // Validate as_rvalue::base() &&
+    same_as<V> auto b2 = std::move(r).base();
+    STATIC_ASSERT(noexcept(std::move(r).base()) == is_nothrow_move_constructible_v<V>);
+    if (!is_empty) {
+        assert(*b2.begin() == *begin(expected));
+    }
+
+    return true;
+}
+
+constexpr int some_ints[] = {0, 3, 6, 9, 12, 15};
+
+struct instantiator {
+    template <ranges::input_range R>
+    static constexpr void call() {
+        R r{some_ints};
+        test_one(r, span{some_ints});
+    }
+};
+
+template <class Category, test::Common IsCommon, test::Sized IsSized>
+using test_range =
+    test::range<Category, const int, IsSized, test::CanDifference{derived_from<Category, random_access_iterator_tag>},
+        IsCommon, test::CanCompare{derived_from<Category, forward_iterator_tag> || IsCommon == test::Common::yes},
+        test::ProxyRef{!derived_from<Category, contiguous_iterator_tag>}>;
+
+constexpr bool instantiation_test() {
+#ifdef TEST_EVERYTHING
+    test_in<instantiator, const int>();
+#else // ^^^ test all input permutations / test only "interesting" permutations vvv
+    using test::Common, test::Sized;
+
+    // The view is sensitive to category, commonality, and size, but oblivious to differencing and proxyness
+    instantiator::call<test_range<input_iterator_tag, Common::no, Sized::yes>>();
+    instantiator::call<test_range<input_iterator_tag, Common::no, Sized::no>>();
+    instantiator::call<test_range<input_iterator_tag, Common::yes, Sized::yes>>();
+    instantiator::call<test_range<input_iterator_tag, Common::yes, Sized::no>>();
+
+    instantiator::call<test_range<forward_iterator_tag, Common::no, Sized::yes>>();
+    instantiator::call<test_range<forward_iterator_tag, Common::no, Sized::no>>();
+    instantiator::call<test_range<forward_iterator_tag, Common::yes, Sized::yes>>();
+    instantiator::call<test_range<forward_iterator_tag, Common::yes, Sized::no>>();
+
+    instantiator::call<test_range<bidirectional_iterator_tag, Common::no, Sized::yes>>();
+    instantiator::call<test_range<bidirectional_iterator_tag, Common::no, Sized::no>>();
+    instantiator::call<test_range<bidirectional_iterator_tag, Common::yes, Sized::yes>>();
+    instantiator::call<test_range<bidirectional_iterator_tag, Common::yes, Sized::no>>();
+
+    instantiator::call<test_range<random_access_iterator_tag, Common::no, Sized::yes>>();
+    instantiator::call<test_range<random_access_iterator_tag, Common::no, Sized::no>>();
+    instantiator::call<test_range<random_access_iterator_tag, Common::yes, Sized::yes>>();
+    instantiator::call<test_range<random_access_iterator_tag, Common::yes, Sized::no>>();
+
+    instantiator::call<test_range<contiguous_iterator_tag, Common::no, Sized::yes>>();
+    instantiator::call<test_range<contiguous_iterator_tag, Common::no, Sized::no>>();
+    instantiator::call<test_range<contiguous_iterator_tag, Common::yes, Sized::yes>>();
+    instantiator::call<test_range<contiguous_iterator_tag, Common::yes, Sized::no>>();
+#endif // TEST_EVERYTHING
+
+    return true;
+}
+
+template <class Category, test::Common IsCommon, bool is_random = derived_from<Category, random_access_iterator_tag>>
+using move_only_view = test::range<Category, const int, test::Sized{is_random}, test::CanDifference{is_random},
+    IsCommon, test::CanCompare::yes, test::ProxyRef{!derived_from<Category, contiguous_iterator_tag>},
+    test::CanView::yes, test::Copyability::move_only>;
+
+int main() {
+    { // Validate views
+        // ... copyable
+        constexpr span<const int> s{some_ints};
+        STATIC_ASSERT(test_one(s, some_ints));
+        test_one(s, some_ints);
+    }
+
+    { // ... move-only
+        test_one(move_only_view<input_iterator_tag, test::Common::no>{some_ints}, some_ints);
+        test_one(move_only_view<input_iterator_tag, test::Common::yes>{some_ints}, some_ints);
+        test_one(move_only_view<forward_iterator_tag, test::Common::no>{some_ints}, some_ints);
+        test_one(move_only_view<forward_iterator_tag, test::Common::yes>{some_ints}, some_ints);
+        test_one(move_only_view<bidirectional_iterator_tag, test::Common::no>{some_ints}, some_ints);
+        test_one(move_only_view<bidirectional_iterator_tag, test::Common::yes>{some_ints}, some_ints);
+        test_one(move_only_view<random_access_iterator_tag, test::Common::no>{some_ints}, some_ints);
+        test_one(move_only_view<random_access_iterator_tag, test::Common::yes>{some_ints}, some_ints);
+    }
+
+    { // Validate non-views
+        STATIC_ASSERT(test_one(some_ints, some_ints));
+        test_one(some_ints, some_ints);
+        test_one(some_ints | ranges::to<vector>(), some_ints);
+        test_one(some_ints | ranges::to<forward_list>(), some_ints);
+    }
+
+    { // empty range
+        using Span = span<string_view>;
+        STATIC_ASSERT(test_one(Span{}, Span{}));
+        test_one(Span{}, Span{});
+    }
+
+    STATIC_ASSERT(instantiation_test());
+    instantiation_test();
+}

--- a/tests/std/tests/P2446R2_views_as_rvalue/test.cpp
+++ b/tests/std/tests/P2446R2_views_as_rvalue/test.cpp
@@ -210,6 +210,7 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
 
     // Validate as_rvalue_view::begin
     STATIC_ASSERT(CanMemberBegin<R>);
+    STATIC_ASSERT(same_as<iterator_t<R>, move_iterator<iterator_t<V>>>);
     {
         const same_as<iterator_t<R>> auto i = r.begin();
         if (!is_empty) {
@@ -244,6 +245,12 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
 
     // Validate as_rvalue_view::end
     STATIC_ASSERT(CanMemberEnd<R>);
+    if constexpr (common_range<V>) {
+        STATIC_ASSERT(same_as<sentinel_t<R>, move_iterator<iterator_t<V>>>);
+    } else {
+        STATIC_ASSERT(same_as<sentinel_t<R>, move_sentinel<sentinel_t<V>>>);
+    }
+
     {
         const same_as<sentinel_t<R>> auto s = r.end();
         assert((r.begin() == s) == is_empty);

--- a/tests/std/tests/P2446R2_views_as_rvalue/test.cpp
+++ b/tests/std/tests/P2446R2_views_as_rvalue/test.cpp
@@ -4,8 +4,11 @@
 #include <algorithm>
 #include <cassert>
 #include <forward_list>
+#include <iterator>
 #include <ranges>
+#include <span>
 #include <string>
+#include <string_view>
 #include <type_traits>
 #include <utility>
 #include <vector>

--- a/tests/std/tests/P2446R2_views_as_rvalue/test.cpp
+++ b/tests/std/tests/P2446R2_views_as_rvalue/test.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include <algorithm>
 #include <cassert>
 #include <forward_list>
 #include <ranges>
@@ -392,6 +393,18 @@ using move_only_view = test::range<Category, const int, test::Sized{is_random}, 
     IsCommon, test::CanCompare::yes, test::ProxyRef{!derived_from<Category, contiguous_iterator_tag>},
     test::CanView::yes, test::Copyability::move_only>;
 
+void test_example_from_p2446r2() {
+    const vector<string> pattern = {"the", "quick", "brown", "fox", "ate", "a", "pterodactyl"};
+
+    vector<string> words = pattern;
+    vector<string> new_words;
+    ranges::copy(words | views::as_rvalue, back_inserter(new_words)); // moves each string from words into new_words
+
+    assert(ranges::equal(new_words, pattern));
+    assert(words.size() == pattern.size()); // size of words in preserved
+    assert(ranges::all_of(words, ranges::empty)); // all strings from words are empty
+}
+
 int main() {
     { // Validate views
         // ... copyable
@@ -435,4 +448,6 @@ int main() {
 
     STATIC_ASSERT(instantiation_test());
     instantiation_test();
+
+    test_example_from_p2446r2();
 }

--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
@@ -1455,6 +1455,20 @@ STATIC_ASSERT(__cpp_lib_ranges == 202110L);
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
+#ifndef __cpp_lib_ranges_as_rvalue
+#error __cpp_lib_ranges_as_rvalue is not defined
+#elif __cpp_lib_ranges_as_rvalue != 202207L
+#error __cpp_lib_ranges_as_rvalue is not 202207L
+#else
+STATIC_ASSERT(__cpp_lib_ranges_as_rvalue == 202207L);
+#endif
+#else
+#ifdef __cpp_lib_ranges_as_rvalue
+#error __cpp_lib_ranges_as_rvalue is defined
+#endif
+#endif
+
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
 #ifndef __cpp_lib_ranges_chunk
 #error __cpp_lib_ranges_chunk is not defined
 #elif __cpp_lib_ranges_chunk != 202202L


### PR DESCRIPTION
Implements [P2446R2](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p2446r2.html) - `views::as_rvalue`. Closes #2929.

Notes:
* ~~Marked as draft - I'm unable to implement full test coverage due to iterator unwrapping problems.~~ Not anymore - I've implemented custom `test_equal` function that should be replaced with `ranges::equal` after #3009 is fixed,
* Just like in #2981: 
  > I've `std::`-qualified all calls to `std::forward` and `std::move` in tests, because next Clang release (15) is going to [warn about "unqualified std cast calls"](https://clang.llvm.org/docs/DiagnosticsReference.html#wunqualified-std-cast-call).