### PR TITLE
Avoid `<atomic>` in `filesystem.cpp`

### DIFF
--- a/stl/src/filesystem.cpp
+++ b/stl/src/filesystem.cpp
@@ -9,7 +9,6 @@
 // Do not include or define anything else here.
 // In particular, basic_string must not be included here.
 
-#include <atomic>
 #include <clocale>
 #include <corecrt_terminate.h>
 #include <cstdlib>
@@ -796,20 +795,11 @@ namespace {
         _Stl_GetTempPath2W(_In_ DWORD nBufferLength, _Out_writes_to_opt_(nBufferLength, return +1) LPWSTR lpBuffer) {
         using _Fun_ptr = decltype(&::GetTempPath2W);
 
-        _Fun_ptr _PfGetTempPath2W;
-        {
-            static _STD atomic<_Fun_ptr> _Static{nullptr};
-
-            _PfGetTempPath2W = _Static.load(_STD memory_order_relaxed);
-            if (!_PfGetTempPath2W) {
-                const auto _Kernel32 = ::GetModuleHandleW(L"kernel32.dll");
-                _Analysis_assume_(_Kernel32);
-                _PfGetTempPath2W = reinterpret_cast<_Fun_ptr>(::GetProcAddress(_Kernel32, "GetTempPath2W"));
-                if (!_PfGetTempPath2W) {
-                    _PfGetTempPath2W = &::GetTempPathW;
-                }
-                _Static.store(_PfGetTempPath2W, _STD memory_order_relaxed); // overwriting with the same value is okay
-            }
+        const auto _Kernel32 = ::GetModuleHandleW(L"kernel32.dll");
+        _Analysis_assume_(_Kernel32);
+        _Fun_ptr _PfGetTempPath2W = reinterpret_cast<_Fun_ptr>(::GetProcAddress(_Kernel32, "GetTempPath2W"));
+        if (!_PfGetTempPath2W) {
+            _PfGetTempPath2W = &::GetTempPathW;
         }
 
         return _PfGetTempPath2W(nBufferLength, lpBuffer);

--- a/stl/src/filesystem.cpp
+++ b/stl/src/filesystem.cpp
@@ -793,6 +793,8 @@ _Success_(return == __std_win_error::_Success) __std_win_error
 namespace {
     _Success_(return > 0 && return < nBufferLength) DWORD WINAPI
         _Stl_GetTempPath2W(_In_ DWORD nBufferLength, _Out_writes_to_opt_(nBufferLength, return +1) LPWSTR lpBuffer) {
+        // See GH-3011: This is intentionally not attempting to cache the function pointer.
+        // TRANSITION, ABI: This should use __crtGetTempPath2W after this code is moved into the STL's DLL.
         using _Fun_ptr = decltype(&::GetTempPath2W);
 
         const auto _Kernel32 = ::GetModuleHandleW(L"kernel32.dll");


### PR DESCRIPTION
# Background
@zacklj89 found this while updating the STL in Windows. (Thanks Zack, for investigating this for over a week - it wasn't easy! :smile_cat:)

#2302 (merged for VS 2022 17.4 Preview 2) made `filesystem.cpp` (which is injected into the STL's import lib) include `<atomic>` to cache a function pointer. Unfortunately, `<atomic>` is a non-core header, and it's the first non-core header included by `filesystem.cpp`:

https://github.com/microsoft/STL/blob/2263d931f48a4e196036b2523af7a0048bb96b46/stl/inc/atomic#L9

This drags in `_Init_locks`, which is separately compiled and has an implicitly defined assignment operator:

https://github.com/microsoft/STL/blob/2263d931f48a4e196036b2523af7a0048bb96b46/stl/inc/yvals.h#L456-L475

In a certain project, this was leading to linker errors, as the STL's DLL exports `_Init_locks::operator=` and the linker was seeing a duplicate definition in the injected `filesystem.obj`.

# GitHub vs. MSVC difference
Curiously, I'm unable to observe this assignment operator in the import lib produced by microsoft/STL `main`, but I can see it in the MSVC-internal build. I'm not sure this is due to a very recent compiler change, or some difference in the CMake vs. MSBuild build systems. In any event, dragging in this non-core header is risky, and we should avoid it due to the potential for similar linker errors when 17.4 ships.

## microsoft/STL `main`
```
D:\GitHub\STL\out\build\x64\out\lib\amd64>dumpbin /symbols msvcprt.lib | grep -P __std_fs_remove
172 00000000 SECT85 notype ()    External     | __std_fs_remove
258 00000000 SECTC3 notype       Static       | $unwind$__std_fs_remove
25B 00000000 SECTC4 notype       Static       | $pdata$__std_fs_remove

D:\GitHub\STL\out\build\x64\out\lib\amd64>dumpbin /symbols msvcprt.lib | grep -P _Init_locks

D:\GitHub\STL\out\build\x64\out\lib\amd64>
```

## MSVC-internal `prod/fe`
```
C:\Temp>dumpbin /symbols \\vcfs\builds\msvc\fe\20220808.01\binaries.amd64ret\lib\amd64\msvcprt.lib | grep -P __std_fs_remove
179 00000000 SECT88 notype ()    External     | __std_fs_remove
25F 00000000 SECTC6 notype       Static       | $unwind$__std_fs_remove
262 00000000 SECTC7 notype       Static       | $pdata$__std_fs_remove

C:\Temp>dumpbin /symbols \\vcfs\builds\msvc\fe\20220808.01\binaries.amd64ret\lib\amd64\msvcprt.lib | grep -P _Init_locks
12D 00000000 SECT1C notype ()    External     | ??4_Init_locks@std@@QEAAAEAV01@AEBV01@@Z (public: class std::_Init_locks & __cdecl std::_Init_locks::operator=(class std::_Init_locks const &))
3E9 00000000 SECT131 notype ()    External    | ??4_Init_locks@std@@QEAAAEAV01@AEBV01@@Z (public: class std::_Init_locks & __cdecl std::_Init_locks::operator=(class std::_Init_locks const &))
```

# Fix
I believe the proper fix is to simply avoid `<atomic>` entirely. Users should be very rarely calling `temp_directory_path()`, so the performance impact of always calling `GetProcAddress()` should be minimal. Zack has confirmed that this change fixes the affected project in Windows.

Because #2302 was merged for 17.4 Preview 2, if we remove the `<atomic>` dependency for 17.4 Preview 3, it will never have shipped to users for production.

## Size impact
This shrinks the import lib:

File Size (bytes) | `main`    | This PR   | Difference
------------------|-----------|-----------|-----------
`msvcprt.lib`     | 1,843,274 | 1,826,044 | 17,230
`msvcprtd.lib`    | 1,820,744 | 1,799,424 | 21,320
