### PR TITLE
Use non-strict matrices where possible

### DIFF
--- a/tests/std/tests/GH_002431_byte_range_find_with_unreachable_sentinel/env.lst
+++ b/tests/std/tests/GH_002431_byte_range_find_with_unreachable_sentinel/env.lst
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_20_matrix.lst
+RUNALL_INCLUDE ..\concepts_20_matrix.lst
 RUNALL_CROSSLIST
 PM_CL=""
 PM_CL="/D_USE_STD_VECTOR_ALGORITHMS=0"

--- a/tests/std/tests/GH_002581_common_reference_workaround/env.lst
+++ b/tests/std/tests/GH_002581_common_reference_workaround/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_20_matrix.lst
+RUNALL_INCLUDE ..\concepts_20_matrix.lst

--- a/tests/std/tests/P0645R10_text_formatting_death/env.lst
+++ b/tests/std/tests/P0645R10_text_formatting_death/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_20_matrix.lst
+RUNALL_INCLUDE ..\concepts_20_matrix.lst

--- a/tests/std/tests/P0896R4_common_iterator_death/env.lst
+++ b/tests/std/tests/P0896R4_common_iterator_death/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_20_matrix.lst
+RUNALL_INCLUDE ..\concepts_20_matrix.lst

--- a/tests/std/tests/P0896R4_counted_iterator/env.lst
+++ b/tests/std/tests/P0896R4_counted_iterator/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_20_matrix.lst
+RUNALL_INCLUDE ..\concepts_20_matrix.lst

--- a/tests/std/tests/P0896R4_counted_iterator_death/env.lst
+++ b/tests/std/tests/P0896R4_counted_iterator_death/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_20_matrix.lst
+RUNALL_INCLUDE ..\concepts_20_matrix.lst

--- a/tests/std/tests/P0896R4_istream_view_death/env.lst
+++ b/tests/std/tests/P0896R4_istream_view_death/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_20_matrix.lst
+RUNALL_INCLUDE ..\concepts_20_matrix.lst

--- a/tests/std/tests/P0896R4_views_common/env.lst
+++ b/tests/std/tests/P0896R4_views_common/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_20_matrix.lst
+RUNALL_INCLUDE ..\concepts_20_matrix.lst

--- a/tests/std/tests/P0896R4_views_counted/env.lst
+++ b/tests/std/tests/P0896R4_views_counted/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_20_matrix.lst
+RUNALL_INCLUDE ..\concepts_20_matrix.lst

--- a/tests/std/tests/P0896R4_views_counted_death/env.lst
+++ b/tests/std/tests/P0896R4_views_counted_death/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_20_matrix.lst
+RUNALL_INCLUDE ..\concepts_20_matrix.lst

--- a/tests/std/tests/P0896R4_views_drop_while_death/env.lst
+++ b/tests/std/tests/P0896R4_views_drop_while_death/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_20_matrix.lst
+RUNALL_INCLUDE ..\concepts_20_matrix.lst

--- a/tests/std/tests/P0896R4_views_iota/env.lst
+++ b/tests/std/tests/P0896R4_views_iota/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_20_matrix.lst
+RUNALL_INCLUDE ..\concepts_20_matrix.lst

--- a/tests/std/tests/P0896R4_views_reverse/env.lst
+++ b/tests/std/tests/P0896R4_views_reverse/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_20_matrix.lst
+RUNALL_INCLUDE ..\concepts_20_matrix.lst

--- a/tests/std/tests/P0896R4_views_take_while/env.lst
+++ b/tests/std/tests/P0896R4_views_take_while/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_20_matrix.lst
+RUNALL_INCLUDE ..\concepts_20_matrix.lst

--- a/tests/std/tests/P0896R4_views_take_while_death/env.lst
+++ b/tests/std/tests/P0896R4_views_take_while_death/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_20_matrix.lst
+RUNALL_INCLUDE ..\concepts_20_matrix.lst

--- a/tests/std/tests/P0896R4_views_transform_death/env.lst
+++ b/tests/std/tests/P0896R4_views_transform_death/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_20_matrix.lst
+RUNALL_INCLUDE ..\concepts_20_matrix.lst

--- a/tests/std/tests/P1206R7_deque_append_range/env.lst
+++ b/tests/std/tests/P1206R7_deque_append_range/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_latest_matrix.lst

--- a/tests/std/tests/P1206R7_deque_assign_range/env.lst
+++ b/tests/std/tests/P1206R7_deque_assign_range/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_latest_matrix.lst

--- a/tests/std/tests/P1206R7_deque_from_range/env.lst
+++ b/tests/std/tests/P1206R7_deque_from_range/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_latest_matrix.lst

--- a/tests/std/tests/P1206R7_deque_insert_range/env.lst
+++ b/tests/std/tests/P1206R7_deque_insert_range/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_latest_matrix.lst

--- a/tests/std/tests/P1206R7_deque_prepend_range/env.lst
+++ b/tests/std/tests/P1206R7_deque_prepend_range/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_latest_matrix.lst

--- a/tests/std/tests/P1206R7_forward_list_assign_range/env.lst
+++ b/tests/std/tests/P1206R7_forward_list_assign_range/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_latest_matrix.lst

--- a/tests/std/tests/P1206R7_forward_list_from_range/env.lst
+++ b/tests/std/tests/P1206R7_forward_list_from_range/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_latest_matrix.lst

--- a/tests/std/tests/P1206R7_forward_list_insert_range_after/env.lst
+++ b/tests/std/tests/P1206R7_forward_list_insert_range_after/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_latest_matrix.lst

--- a/tests/std/tests/P1206R7_forward_list_prepend_range/env.lst
+++ b/tests/std/tests/P1206R7_forward_list_prepend_range/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_latest_matrix.lst

--- a/tests/std/tests/P1206R7_from_range/env.lst
+++ b/tests/std/tests/P1206R7_from_range/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_latest_matrix.lst

--- a/tests/std/tests/P1206R7_list_append_range/env.lst
+++ b/tests/std/tests/P1206R7_list_append_range/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_latest_matrix.lst

--- a/tests/std/tests/P1206R7_list_assign_range/env.lst
+++ b/tests/std/tests/P1206R7_list_assign_range/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_latest_matrix.lst

--- a/tests/std/tests/P1206R7_list_from_range/env.lst
+++ b/tests/std/tests/P1206R7_list_from_range/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_latest_matrix.lst

--- a/tests/std/tests/P1206R7_list_insert_range/env.lst
+++ b/tests/std/tests/P1206R7_list_insert_range/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_latest_matrix.lst

--- a/tests/std/tests/P1206R7_list_prepend_range/env.lst
+++ b/tests/std/tests/P1206R7_list_prepend_range/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_latest_matrix.lst

--- a/tests/std/tests/P1206R7_map_from_range/env.lst
+++ b/tests/std/tests/P1206R7_map_from_range/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_latest_matrix.lst

--- a/tests/std/tests/P1206R7_map_insert_range/env.lst
+++ b/tests/std/tests/P1206R7_map_insert_range/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_latest_matrix.lst

--- a/tests/std/tests/P1206R7_multimap_from_range/env.lst
+++ b/tests/std/tests/P1206R7_multimap_from_range/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_latest_matrix.lst

--- a/tests/std/tests/P1206R7_multimap_insert_range/env.lst
+++ b/tests/std/tests/P1206R7_multimap_insert_range/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_latest_matrix.lst

--- a/tests/std/tests/P1206R7_multiset_from_range/env.lst
+++ b/tests/std/tests/P1206R7_multiset_from_range/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_latest_matrix.lst

--- a/tests/std/tests/P1206R7_multiset_insert_range/env.lst
+++ b/tests/std/tests/P1206R7_multiset_insert_range/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_latest_matrix.lst

--- a/tests/std/tests/P1206R7_priority_queue_from_range/env.lst
+++ b/tests/std/tests/P1206R7_priority_queue_from_range/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_latest_matrix.lst

--- a/tests/std/tests/P1206R7_priority_queue_push_range/env.lst
+++ b/tests/std/tests/P1206R7_priority_queue_push_range/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_latest_matrix.lst

--- a/tests/std/tests/P1206R7_queue_from_range/env.lst
+++ b/tests/std/tests/P1206R7_queue_from_range/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_latest_matrix.lst

--- a/tests/std/tests/P1206R7_queue_push_range/env.lst
+++ b/tests/std/tests/P1206R7_queue_push_range/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_latest_matrix.lst

--- a/tests/std/tests/P1206R7_ranges_to/env.lst
+++ b/tests/std/tests/P1206R7_ranges_to/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_latest_matrix.lst

--- a/tests/std/tests/P1206R7_set_from_range/env.lst
+++ b/tests/std/tests/P1206R7_set_from_range/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_latest_matrix.lst

--- a/tests/std/tests/P1206R7_set_insert_range/env.lst
+++ b/tests/std/tests/P1206R7_set_insert_range/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_latest_matrix.lst

--- a/tests/std/tests/P1206R7_stack_from_range/env.lst
+++ b/tests/std/tests/P1206R7_stack_from_range/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_latest_matrix.lst

--- a/tests/std/tests/P1206R7_stack_push_range/env.lst
+++ b/tests/std/tests/P1206R7_stack_push_range/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_latest_matrix.lst

--- a/tests/std/tests/P1206R7_string_append_range/env.lst
+++ b/tests/std/tests/P1206R7_string_append_range/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_latest_matrix.lst

--- a/tests/std/tests/P1206R7_string_assign_range/env.lst
+++ b/tests/std/tests/P1206R7_string_assign_range/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_latest_matrix.lst

--- a/tests/std/tests/P1206R7_string_from_range/env.lst
+++ b/tests/std/tests/P1206R7_string_from_range/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_latest_matrix.lst

--- a/tests/std/tests/P1206R7_string_insert_range/env.lst
+++ b/tests/std/tests/P1206R7_string_insert_range/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_latest_matrix.lst

--- a/tests/std/tests/P1206R7_string_replace_with_range/env.lst
+++ b/tests/std/tests/P1206R7_string_replace_with_range/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_latest_matrix.lst

--- a/tests/std/tests/P1206R7_unordered_map_from_range/env.lst
+++ b/tests/std/tests/P1206R7_unordered_map_from_range/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_latest_matrix.lst

--- a/tests/std/tests/P1206R7_unordered_map_insert_range/env.lst
+++ b/tests/std/tests/P1206R7_unordered_map_insert_range/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_latest_matrix.lst

--- a/tests/std/tests/P1206R7_unordered_multimap_from_range/env.lst
+++ b/tests/std/tests/P1206R7_unordered_multimap_from_range/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_latest_matrix.lst

--- a/tests/std/tests/P1206R7_unordered_multimap_insert_range/env.lst
+++ b/tests/std/tests/P1206R7_unordered_multimap_insert_range/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_latest_matrix.lst

--- a/tests/std/tests/P1206R7_unordered_multiset_from_range/env.lst
+++ b/tests/std/tests/P1206R7_unordered_multiset_from_range/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_latest_matrix.lst

--- a/tests/std/tests/P1206R7_unordered_multiset_insert_range/env.lst
+++ b/tests/std/tests/P1206R7_unordered_multiset_insert_range/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_latest_matrix.lst

--- a/tests/std/tests/P1206R7_unordered_set_from_range/env.lst
+++ b/tests/std/tests/P1206R7_unordered_set_from_range/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_latest_matrix.lst

--- a/tests/std/tests/P1206R7_unordered_set_insert_range/env.lst
+++ b/tests/std/tests/P1206R7_unordered_set_insert_range/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_latest_matrix.lst

--- a/tests/std/tests/P1206R7_vector_append_range/env.lst
+++ b/tests/std/tests/P1206R7_vector_append_range/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_latest_matrix.lst

--- a/tests/std/tests/P1206R7_vector_assign_range/env.lst
+++ b/tests/std/tests/P1206R7_vector_assign_range/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_latest_matrix.lst

--- a/tests/std/tests/P1206R7_vector_from_range/env.lst
+++ b/tests/std/tests/P1206R7_vector_from_range/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_latest_matrix.lst

--- a/tests/std/tests/P1206R7_vector_insert_range/env.lst
+++ b/tests/std/tests/P1206R7_vector_insert_range/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_latest_matrix.lst

--- a/tests/std/tests/P1899R3_views_stride_death/env.lst
+++ b/tests/std/tests/P1899R3_views_stride_death/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_latest_matrix.lst

--- a/tests/std/tests/P2408R5_ranges_iterators_to_classic_algorithms/env.lst
+++ b/tests/std/tests/P2408R5_ranges_iterators_to_classic_algorithms/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_20_matrix.lst
+RUNALL_INCLUDE ..\concepts_20_matrix.lst

--- a/tests/std/tests/P2442R1_views_chunk/env.lst
+++ b/tests/std/tests/P2442R1_views_chunk/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_latest_matrix.lst

--- a/tests/std/tests/P2442R1_views_chunk_death/env.lst
+++ b/tests/std/tests/P2442R1_views_chunk_death/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_latest_matrix.lst

--- a/tests/std/tests/P2442R1_views_slide/env.lst
+++ b/tests/std/tests/P2442R1_views_slide/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_latest_matrix.lst

--- a/tests/std/tests/P2443R1_views_chunk_by/env.lst
+++ b/tests/std/tests/P2443R1_views_chunk_by/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_latest_matrix.lst

--- a/tests/std/tests/P2443R1_views_chunk_by_death/env.lst
+++ b/tests/std/tests/P2443R1_views_chunk_by_death/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_latest_matrix.lst


### PR DESCRIPTION
We've been a bit lax about using the `strict_concepts_meow` test matrices, which omit `/permissive` configs, when we don't really need to. Use the plain `concepts_meow` matrices instead for tests that pass with `/permissive`.

After this, the remaining strict tests are:
 * `P0323R12_expected`
 * `P0896R4_common_iterator`
 * `P0896R4_views_drop`
 * `P0896R4_views_elements`
 * `P0896R4_views_filter`
 * `P0896R4_views_filter_death`
 * `P0896R4_views_filter_iterator`
 * `P0896R4_views_join`
 * `P0896R4_views_lazy_split`
 * `P0896R4_views_split`
 * `P0896R4_views_take`
 * `P0896R4_views_transform`
 * `P1522R1_difference_type`
 * `P1899R3_views_stride`
 * `P2441R2_views_join_with`