### PR TITLE
Various cleanups

### DIFF
--- a/stl/inc/forward_list
+++ b/stl/inc/forward_list
@@ -649,7 +649,6 @@ public:
         _Take_head(_Right);
     }
 
-public:
     forward_list& operator=(forward_list&& _Right) noexcept(
         _Choose_pocma_v<_Alnode> != _Pocma_values::_No_propagate_allocators) /* strengthened */ {
         if (this == _STD addressof(_Right)) {
@@ -757,7 +756,6 @@ public:
 #endif // _ITERATOR_DEBUG_LEVEL != 0
     }
 
-public:
     forward_list& operator=(const forward_list& _Right) {
         if (this == _STD addressof(_Right)) {
             return *this;

--- a/stl/inc/list
+++ b/stl/inc/list
@@ -912,7 +912,6 @@ public:
         _Swap_val(_Right);
     }
 
-public:
     list& operator=(list&& _Right) noexcept(
         _Choose_pocma_v<_Alnode> == _Pocma_values::_Equal_allocators) /* strengthened */ {
         if (this == _STD addressof(_Right)) {
@@ -1405,7 +1404,6 @@ public:
     }
 #endif // __cpp_lib_containers_ranges
 
-public:
     iterator erase(const const_iterator _Where) noexcept /* strengthened */ {
 #if _ITERATOR_DEBUG_LEVEL == 2
         _STL_VERIFY(_Where._Getcont() == _STD addressof(_Mypair._Myval2), "list erase iterator outside range");

--- a/stl/inc/variant
+++ b/stl/inc/variant
@@ -35,9 +35,8 @@ template <class _First, class... _Rest>
 struct _All_same<_First, _Rest...> : bool_constant<conjunction_v<is_same<_First, _Rest>...>> {}; // variadic is_same
 
 template <class _To, class... _From>
-struct _Convertible_from_all : bool_constant<conjunction_v<_Invoke_convertible<_From, _To>...>> {
-    // variadic _Invoke_convertible
-};
+using _Convertible_from_all =
+    bool_constant<conjunction_v<_Invoke_convertible<_From, _To>...>>; // variadic _Invoke_convertible
 
 template <class...>
 struct _Meta_list {}; // a sequence of types

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -1531,7 +1531,6 @@ public:
         _Assign_counted_range(_Ilist.begin(), _Count);
     }
 
-public:
     _CONSTEXPR20 vector& operator=(const vector& _Right) {
         if (this == _STD addressof(_Right)) {
             return *this;
@@ -2987,7 +2986,6 @@ public:
         this->_Swap_proxy_and_iterators(_Right);
     }
 
-public:
     _CONSTEXPR20 vector& operator=(vector&& _Right) noexcept(is_nothrow_move_assignable_v<_Mybase>) {
         if (this == _STD addressof(_Right)) {
             return *this;
@@ -3071,7 +3069,6 @@ public:
 
     _CONSTEXPR20 ~vector() noexcept {}
 
-public:
     _CONSTEXPR20 vector& operator=(const vector& _Right) {
         if (this == _STD addressof(_Right)) {
             return *this;

--- a/stl/inc/yvals.h
+++ b/stl/inc/yvals.h
@@ -453,6 +453,7 @@ private:
 #define _RELIABILITY_CONTRACT
 #endif // _M_CEE
 
+#ifdef _CRTBLD
 class _CRTIMP2_PURE_IMPORT _Init_locks { // initialize mutexes
 public:
 #ifdef _M_CEE_PURE
@@ -473,6 +474,7 @@ private:
     static void __cdecl _Init_locks_ctor(_Init_locks*) noexcept;
     static void __cdecl _Init_locks_dtor(_Init_locks*) noexcept;
 };
+#endif // _CRTBLD
 
 #if _HAS_EXCEPTIONS
 #define _TRY_BEGIN try {

--- a/stl/src/filesystem.cpp
+++ b/stl/src/filesystem.cpp
@@ -147,7 +147,7 @@ namespace {
         BY_HANDLE_FILE_INFORMATION _Info;
         if (GetFileInformationByHandle(_Handle, &_Info)) {
             _Id->VolumeSerialNumber = _Info.dwVolumeSerialNumber;
-            _CSTD memcpy(&_Id->FileId.Identifier[0], &_Info.nFileIndexHigh, 8);
+            _CSTD memcpy(&_Id->FileId.Identifier[0], &_Info.nFileIndexHigh, 8); // copying from 2 consecutive DWORDs
             _CSTD memset(&_Id->FileId.Identifier[8], 0, 8);
             return __std_win_error::_Success;
         }

--- a/stl/src/xdateord.cpp
+++ b/stl/src/xdateord.cpp
@@ -9,7 +9,7 @@
 
 _EXTERN_C_UNLESS_PURE
 
-int __CLRCALL_PURE_OR_CDECL _Getdateorder() { // return date order for current locale
+_CRTIMP2_PURE int __CLRCALL_PURE_OR_CDECL _Getdateorder() { // return date order for current locale
     wchar_t buf[2] = {0};
     GetLocaleInfoEx(___lc_locale_name_func()[LC_TIME], LOCALE_ILDATE, buf, sizeof(buf) / sizeof(buf[0]));
 

--- a/stl/src/xrngdev.cpp
+++ b/stl/src/xrngdev.cpp
@@ -7,8 +7,6 @@
 
 //  #include <random>
 _STD_BEGIN
-_CRTIMP2_PURE unsigned int __CLRCALL_PURE_OR_CDECL _Random_device();
-
 _CRTIMP2_PURE unsigned int __CLRCALL_PURE_OR_CDECL _Random_device() { // return a random value
     unsigned int ans;
     if (_CSTD rand_s(&ans)) {

--- a/stl/src/xrngdev.cpp
+++ b/stl/src/xrngdev.cpp
@@ -3,9 +3,9 @@
 
 // implement random_device
 
-#include <stdexcept> // for out_of_range
+#include <cstdlib>
+#include <xutility>
 
-//  #include <random>
 _STD_BEGIN
 _CRTIMP2_PURE unsigned int __CLRCALL_PURE_OR_CDECL _Random_device() { // return a random value
     unsigned int ans;

--- a/stl/src/xtime.cpp
+++ b/stl/src/xtime.cpp
@@ -47,7 +47,7 @@ constexpr long _Nsec100_per_sec = _Nsec_per_sec / 100;
 
 _EXTERN_C
 
-long long _Xtime_get_ticks() { // get system time in 100-nanosecond intervals since the epoch
+_CRTIMP2_PURE long long __cdecl _Xtime_get_ticks() { // get system time in 100-nanosecond intervals since the epoch
     FILETIME ft;
     __crtGetSystemTimePreciseAsFileTime(&ft);
     return ((static_cast<long long>(ft.dwHighDateTime)) << 32) + static_cast<long long>(ft.dwLowDateTime) - _Epoch;
@@ -59,18 +59,18 @@ static void sys_get_time(xtime* xt) { // get system time with nanosecond resolut
     xt->nsec               = static_cast<long>(now % _Nsec100_per_sec) * 100;
 }
 
-long _Xtime_diff_to_millis2(const xtime* xt1, const xtime* xt2) { // convert time to milliseconds
+_CRTIMP2_PURE long __cdecl _Xtime_diff_to_millis2(const xtime* xt1, const xtime* xt2) { // convert time to milliseconds
     xtime diff = xtime_diff(xt1, xt2);
     return static_cast<long>(diff.sec * _Msec_per_sec + (diff.nsec + _Nsec_per_msec - 1) / _Nsec_per_msec);
 }
 
-long _Xtime_diff_to_millis(const xtime* xt) { // convert time to milliseconds
+_CRTIMP2_PURE long __cdecl _Xtime_diff_to_millis(const xtime* xt) { // convert time to milliseconds
     xtime now;
     xtime_get(&now, TIME_UTC);
     return _Xtime_diff_to_millis2(xt, &now);
 }
 
-int xtime_get(xtime* xt, int type) { // get current time
+_CRTIMP2_PURE int __cdecl xtime_get(xtime* xt, int type) { // get current time
     if (type != TIME_UTC || xt == nullptr) {
         type = 0;
     } else {

--- a/tests/std/tests/P0220R1_polymorphic_memory_resources/test.cpp
+++ b/tests/std/tests/P0220R1_polymorphic_memory_resources/test.cpp
@@ -286,7 +286,7 @@ namespace {
     };
 
     void analyze_geometric_growth(size_t const* first, size_t const n) {
-        // http://mathworld.wolfram.com/LeastSquaresFittingExponential.html
+        // https://mathworld.wolfram.com/LeastSquaresFittingExponential.html
         // https://en.wikipedia.org/wiki/Pearson_correlation_coefficient#For_a_sample
         double sum_of_x           = 0;
         double sum_of_y           = 0;

--- a/tools/validate/CMakeLists.txt
+++ b/tools/validate/CMakeLists.txt
@@ -9,7 +9,7 @@ add_executable(validate-binary validate.cpp)
 target_compile_options(validate-binary PRIVATE /W4 /WX /analyze)
 set_target_properties(validate-binary
     PROPERTIES
-        CXX_STANDARD 20
+        CXX_STANDARD 23
         CXX_EXTENSIONS OFF
         CXX_STANDARD_REQUIRED ON
         # statically link the standard library


### PR DESCRIPTION
* `<forward_list>`, `<list>`, `<vector>`: Drop redundant access control.
* `<variant>`: `_Convertible_from_all` can be an alias template.
* `src/xrngdev.cpp`: Drop totally redundant declaration of `_Random_device()`.
* `src/xrngdev.cpp`: Include less machinery.
  + We don't need all of `<stdexcept>`, and we don't need `<random>` commented-out.
  + We need `<cstdlib>` for `rand_s()` and `<xutility>` for `_Xout_of_range()`.
* `P0220R1_polymorphic_memory_resources/test.cpp`: Use https URL.
* `tools/validate/CMakeLists.txt`: Use C++23.
* `src/xdateord.cpp`: Repeat `_CRTIMP2_PURE` from the declaration in `<xlocinfo>`.
* `src/xtime.cpp`: Add `_CRTIMP2_PURE` and `__cdecl` to match declarations in `<xtimec.h>`.
* `src/filesystem.cpp`: Comment "copying from 2 consecutive DWORDs".
* `<yvals.h>`: Guard `_Init_locks` with `_CRTBLD`, nothing in `stl/inc` needs it.
