### PR TITLE
Implement `(chunk_view<forward>|stride_view)::iterator::operator(\+=|-=)` in O(1)

### DIFF
--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -5569,7 +5569,7 @@ namespace ranges {
                     _STL_VERIFY(_Count <= (numeric_limits<difference_type>::max)() / _Off,
                         "cannot advance chunk_view iterator past end (integer overflow)");
                     if constexpr (sized_sentinel_for<_Base_sentinel, _Base_iterator>) {
-                        _STL_VERIFY(_RANGES distance(_Current, _End) > _Count * (_Off - 1),
+                        _STL_VERIFY(_End - _Current > _Count * (_Off - 1), //
                             "cannot advance chunk_view iterator past end");
                     }
 #endif // _ITERATOR_DEBUG_LEVEL != 0
@@ -6473,7 +6473,7 @@ namespace ranges {
                     _STL_VERIFY(_Stride <= (numeric_limits<difference_type>::max)() / _Off,
                         "cannot advance stride_view iterator past end (integer overflow)");
                     if constexpr (sized_sentinel_for<_Base_sentinel, _Base_iterator>) {
-                        _STL_VERIFY(_RANGES distance(_Current, _End) > _Stride * (_Off - 1),
+                        _STL_VERIFY(_End - _Current > _Stride * (_Off - 1), //
                             "cannot advance stride_view iterator past end");
                     }
 #endif // _ITERATOR_DEBUG_LEVEL != 0

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -5578,11 +5578,11 @@ namespace ranges {
                     if constexpr (sized_sentinel_for<_Base_sentinel, _Base_iterator>) {
                         _Missing = _RANGES advance(_Current, _Count * _Off, _End);
                     } else {
-                        _Current += _Count * (_Off - 1);
+                        _Current += static_cast<difference_type>(_Count * (_Off - 1));
                         _Missing = _RANGES advance(_Current, _Count, _End);
                     }
                 } else if (_Off < 0) {
-                    _Current += _Count * _Off + _Missing;
+                    _Current += static_cast<difference_type>(_Count * _Off + _Missing);
                     _Missing = 0;
                 }
                 return *this;
@@ -6482,11 +6482,11 @@ namespace ranges {
                     if constexpr (sized_sentinel_for<_Base_sentinel, _Base_iterator>) {
                         _Missing = _RANGES advance(_Current, _Stride * _Off, _End);
                     } else {
-                        _Current += _Stride * static_cast<difference_type>(_Off - 1);
+                        _Current += static_cast<difference_type>(_Stride * (_Off - 1));
                         _Missing = _RANGES advance(_Current, _Stride, _End);
                     }
                 } else if (_Off < 0) {
-                    _Current += _Stride * _Off + _Missing;
+                    _Current += static_cast<difference_type>(_Stride * _Off + _Missing);
                     _Missing = 0;
                 }
                 return *this;

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -5566,35 +5566,35 @@ namespace ranges {
                 requires random_access_range<_Base> {
                 if (_Off > 0) {
 #if _ITERATOR_DEBUG_LEVEL != 0
-                    _STL_VERIFY(_Off == 1 || _Count <= (numeric_limits<difference_type>::max)() / (_Off - 1),
+                    _STL_VERIFY(_Count <= (numeric_limits<difference_type>::max)() / _Off,
                         "cannot advance chunk_view iterator past end (integer overflow)");
-                    _STL_VERIFY(_RANGES distance(_Current, _End) > _Count * (_Off - 1),
-                        "cannot advance chunk_view iterator past end");
+                    if constexpr (sized_sentinel_for<_Base_sentinel, _Base_iterator>) {
+                        _STL_VERIFY(_RANGES distance(_Current, _End) > _Count * (_Off - 1),
+                            "cannot advance chunk_view iterator past end");
+                    }
 #endif // _ITERATOR_DEBUG_LEVEL != 0
-                    _Missing = _RANGES advance(_Current, _Count * _Off, _End);
+
+                    // Per to-be-filed LWG issue (See GH-2995)
+                    if constexpr (sized_sentinel_for<_Base_sentinel, _Base_iterator>) {
+                        _Missing = _RANGES advance(_Current, _Count * _Off, _End);
+                    } else {
+                        _Current += _Count * (_Off - 1);
+                        _Missing = _RANGES advance(_Current, _Count, _End);
+                    }
                 } else if (_Off < 0) {
-                    _RANGES advance(_Current, _Count * _Off + _Missing);
+                    _Current += _Count * _Off + _Missing;
                     _Missing = 0;
                 }
                 return *this;
             }
 
-            constexpr _Iterator& operator-=(const difference_type _Raw_off) /* not strengthened, see _RANGES advance */
+            constexpr _Iterator& operator-=(const difference_type _Off) /* not strengthened, see _RANGES advance */
                 requires random_access_range<_Base> {
-                const difference_type _Off = -_Raw_off;
-                if (_Off > 0) {
 #if _ITERATOR_DEBUG_LEVEL != 0
-                    _STL_VERIFY(_Off == 1 || _Count <= (numeric_limits<difference_type>::max)() / (_Off - 1),
-                        "cannot advance chunk_view iterator past end (integer overflow)");
-                    _STL_VERIFY(_RANGES distance(_Current, _End) > _Count * (_Off - 1),
-                        "cannot advance chunk_view iterator past end");
+                _STL_VERIFY(_Off != (numeric_limits<difference_type>::min)(),
+                    "cannot advance chunk_view iterator past end (integer overflow)");
 #endif // _ITERATOR_DEBUG_LEVEL != 0
-                    _Missing = _RANGES advance(_Current, _Count * _Off, _End);
-                } else if (_Off < 0) {
-                    _RANGES advance(_Current, _Count * _Off + _Missing);
-                    _Missing = 0;
-                }
-                return *this;
+                return *this += -_Off;
             }
 
             _NODISCARD constexpr value_type operator[](const difference_type _Off) const
@@ -6470,20 +6470,33 @@ namespace ranges {
             constexpr _Iterator& operator+=(const difference_type _Off) requires random_access_range<_Base> {
                 if (_Off > 0) {
 #if _ITERATOR_DEBUG_LEVEL != 0
-                    _STL_VERIFY(_Off == 1 || _Stride <= (numeric_limits<difference_type>::max)() / (_Off - 1),
+                    _STL_VERIFY(_Stride <= (numeric_limits<difference_type>::max)() / _Off,
                         "cannot advance stride_view iterator past end (integer overflow)");
-                    _STL_VERIFY(_RANGES distance(_Current, _End) > _Stride * (_Off - 1),
-                        "cannot advance stride_view iterator past end");
+                    if constexpr (sized_sentinel_for<_Base_sentinel, _Base_iterator>) {
+                        _STL_VERIFY(_RANGES distance(_Current, _End) > _Stride * (_Off - 1),
+                            "cannot advance stride_view iterator past end");
+                    }
 #endif // _ITERATOR_DEBUG_LEVEL != 0
-                    _Missing = _RANGES advance(_Current, _Stride * _Off, _End);
+
+                    // Per to-be-filed LWG issue (See GH-2995)
+                    if constexpr (sized_sentinel_for<_Base_sentinel, _Base_iterator>) {
+                        _Missing = _RANGES advance(_Current, _Stride * _Off, _End);
+                    } else {
+                        _Current += _Stride * static_cast<difference_type>(_Off - 1);
+                        _Missing = _RANGES advance(_Current, _Stride, _End);
+                    }
                 } else if (_Off < 0) {
-                    _RANGES advance(_Current, _Stride * _Off + _Missing);
+                    _Current += _Stride * _Off + _Missing;
                     _Missing = 0;
                 }
                 return *this;
             }
 
             constexpr _Iterator& operator-=(const difference_type _Off) requires random_access_range<_Base> {
+#if _ITERATOR_DEBUG_LEVEL != 0
+                _STL_VERIFY(_Off != (numeric_limits<difference_type>::min)(),
+                    "cannot advance stride_view iterator past end (integer overflow)");
+#endif // _ITERATOR_DEBUG_LEVEL != 0
                 return *this += -_Off;
             }
 

--- a/tests/std/tests/P1899R3_views_stride_death/test.cpp
+++ b/tests/std/tests/P1899R3_views_stride_death/test.cpp
@@ -47,6 +47,12 @@ void test_iterator_advance_past_end_with_integer_overflow() {
     it += (numeric_limits<ptrdiff_t>::max)() / 2; // cannot advance stride_view iterator past end (integer overflow)
 }
 
+void test_iterator_advance_negative_min() {
+    auto v  = ranges::stride_view(some_ints, 3);
+    auto it = v.begin();
+    it -= (numeric_limits<ptrdiff_t>::min)(); // cannot advance stride_view iterator past end (integer overflow)
+}
+
 int main(int argc, char* argv[]) {
     std_testing::death_test_executive exec;
 
@@ -58,6 +64,7 @@ int main(int argc, char* argv[]) {
         test_iterator_postincrement_past_end,
         test_iterator_advance_past_end,
         test_iterator_advance_past_end_with_integer_overflow,
+        test_iterator_advance_negative_min,
     });
 #else // ^^^ test everything / test only _CONTAINER_DEBUG_LEVEL case vvv
     exec.add_death_tests({

--- a/tests/std/tests/P2442R1_views_chunk_death/test.cpp
+++ b/tests/std/tests/P2442R1_views_chunk_death/test.cpp
@@ -75,6 +75,24 @@ void test_inner_iterator_dereference_at_end() {
     (void) *it; // cannot dereference chunk_view end iterator
 }
 
+void test_fwd_iterator_advance_past_end() {
+    auto v  = chunk_view{span{some_ints}, 2};
+    auto it = v.begin();
+    it += 5; // cannot advance chunk_view iterator past end
+}
+
+void test_fwd_iterator_advance_past_end_with_integer_overflow() {
+    auto v  = chunk_view{span{some_ints}, 2};
+    auto it = v.begin();
+    it += (numeric_limits<ptrdiff_t>::max)() / 2; // cannot advance chunk_view iterator past end (integer overflow)
+}
+
+void test_fwd_iterator_advance_negative_min() {
+    auto v  = chunk_view{span{some_ints}, 2};
+    auto it = v.begin();
+    it -= (numeric_limits<ptrdiff_t>::min)(); // cannot advance chunk_view iterator past end (integer overflow)
+}
+
 int main(int argc, char* argv[]) {
     std_testing::death_test_executive exec;
 
@@ -88,6 +106,9 @@ int main(int argc, char* argv[]) {
         test_inner_iterator_postincrement_past_end,
         test_outer_iterator_dereference_at_end,
         test_inner_iterator_dereference_at_end,
+        test_fwd_iterator_advance_past_end,
+        test_fwd_iterator_advance_past_end_with_integer_overflow,
+        test_fwd_iterator_advance_negative_min,
     });
 #else // ^^^ test everything / test only _CONTAINER_DEBUG_LEVEL cases vvv
     exec.add_death_tests({


### PR DESCRIPTION
Speculatively implements what will be the proposed resolution of an LWG issue filed per GH-2995 once the new working draft is out with `stride_view` and `chunk_view`. Also avoid checking the precondition when it can't be done in O(1).

Drive-by:
* inline `ranges::advance(i, n)` since it's simply `i += n` for random-access iterators
* check for overflow of `-n` when calling `*this += -n` in `operator-=`

Partially addresses #2995

<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
