### PR TITLE
Add escape hatches for source-breaking throughput improvements

### DIFF
--- a/stl/inc/functional
+++ b/stl/inc/functional
@@ -14,6 +14,9 @@
 #include <xmemory>
 #include <xstddef>
 #if _HAS_CXX17
+#ifdef _LEGACY_CODE_ASSUMES_FUNCTIONAL_INCLUDES_MEMORY
+#include <memory>
+#endif // _LEGACY_CODE_ASSUMES_FUNCTIONAL_INCLUDES_MEMORY
 #include <unordered_map>
 #endif // _HAS_CXX17
 #ifdef __cpp_lib_concepts

--- a/stl/inc/xhash
+++ b/stl/inc/xhash
@@ -90,6 +90,11 @@ namespace stdext {
         _Pr comp{}; // the comparator object
     };
 } // namespace stdext
+
+_STD_BEGIN
+using stdext::hash_compare; // Non-Standard, for legacy source compatibility
+_STD_END
+
 #endif // _SILENCE_STDEXT_HASH_DEPRECATION_WARNINGS
 
 _STD_BEGIN


### PR DESCRIPTION
Originally, `_SILENCE_STDEXT_HASH_DEPRECATION_WARNINGS` was the escape hatch to allow `<hash_map>` and `<hash_set>` to be included. #2996 extended this to restore `<xhash>`'s inclusion of `<cstring>`/`<cwchar>`/`<xstring>` and defining common `stdext` machinery. However, I attempted to unconditionally remove the non-Standard using-declaration that provided `std::hash_compare`. Unfortunately, there are still projects depending on this. :crying_cat_face: We can preserve the throughput improvement and give affected projects a way out by extending the escape hatch to also provide the using-declaration.

Also, #2998 got `<functional>` to stop including `<memory>` in C++17 mode. We're seeing at least one affected project (Qt5) where fixing the source may be difficult. We can add a targeted escape hatch for this inclusion, again preserving the throughput improvement by default.