### PR TITLE
`<xmemory>`: `_Uninitialized_copy` doesn't assign, it constructs

### DIFF
--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -1684,7 +1684,7 @@ _CONSTEXPR20 _Alloc_ptr_t<_Alloc> _Uninitialized_copy(
     auto _UFirst = _Get_unwrapped(_STD move(_First));
     auto _ULast  = _Get_unwrapped(_STD move(_Last));
 
-    constexpr bool _Can_memmove = _Sent_copy_cat<decltype(_UFirst), decltype(_ULast), _Ptrval>::_Bitcopy_assignable //
+    constexpr bool _Can_memmove = _Sent_copy_cat<decltype(_UFirst), decltype(_ULast), _Ptrval>::_Bitcopy_constructible
                                && _Uses_default_construct<_Alloc, _Ptrval, decltype(*_UFirst)>::value;
 
     if constexpr (_Can_memmove) {

--- a/tests/std/tests/P1206R7_vector_from_range/test.cpp
+++ b/tests/std/tests/P1206R7_vector_from_range/test.cpp
@@ -144,12 +144,15 @@ struct counted_item {
 
 int counted_item::count = 0;
 
+static_assert(!is_trivially_copy_constructible_v<counted_item>);
+static_assert(is_trivially_copy_assignable_v<counted_item>);
+
 void test_vso1591034() {
-    // _Uninitialized_copy was using incorrectly using memcpy for types that are
+    // _Uninitialized_copy was incorrectly using memmove for types that are
     // trivially assignable but not trivially constructible.
 
     counted_item::count = 0;
-    std::vector<counted_item> vec;
+    vector<counted_item> vec;
 
     for (int j = 0; j != 6; ++j) {
         vec.push_back(counted_item());

--- a/tests/std/tests/P1206R7_vector_from_range/test.cpp
+++ b/tests/std/tests/P1206R7_vector_from_range/test.cpp
@@ -124,6 +124,40 @@ void test_lvalue_forward_list() {
     }
 }
 
+struct counted_item {
+    static int count;
+
+    counted_item() {
+        ++count;
+    }
+
+    counted_item(const counted_item&) {
+        ++count;
+    }
+
+    counted_item& operator=(const counted_item&) = default;
+
+    ~counted_item() {
+        --count;
+    }
+};
+
+int counted_item::count = 0;
+
+void test_vso1591034() {
+    // _Uninitialized_copy was using incorrectly using memcpy for types that are
+    // trivially assignable but not trivially constructible.
+
+    counted_item::count = 0;
+    std::vector<counted_item> vec;
+
+    for (int j = 0; j != 6; ++j) {
+        vec.push_back(counted_item());
+    }
+
+    assert(counted_item::count == 6);
+}
+
 int main() {
     // Validate views
     test_copyable_views();
@@ -143,4 +177,6 @@ int main() {
 
     test_in<vector_instantiator, const int>();
     test_in<vector_boo_instantiator, const int>();
+
+    test_vso1591034();
 }


### PR DESCRIPTION
... so the `memmove` optimization should check `_Bitcopy_constructible` and not `_Bitcopy_assignable`.

Fixes VSO-1591034/AB#1591034, fixes VSO-1590866/AB#1590866.

Credit to StephanTLavavej for the minimal repro.