### PR TITLE
`<string_view>`: suppress warning about annotation 'NullTerminated'

### DIFF
--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -1191,6 +1191,10 @@ struct pointer_traits<_String_view_iterator<_Traits>> {
 };
 #endif // _HAS_CXX20
 
+#pragma warning(push)
+// Invalid annotation: 'NullTerminated' property may only be used on buffers whose elements are of integral or pointer
+// type
+#pragma warning(disable : 6510)
 
 template <class _Elem, class _Traits>
 class basic_string_view { // wrapper for any kind of contiguous character buffer
@@ -1223,7 +1227,7 @@ public:
     constexpr basic_string_view(const basic_string_view&) noexcept            = default;
     constexpr basic_string_view& operator=(const basic_string_view&) noexcept = default;
 
-    /* implicit */ constexpr basic_string_view(const const_pointer _Ntcts) noexcept // strengthened
+    /* implicit */ constexpr basic_string_view(_In_z_ const const_pointer _Ntcts) noexcept // strengthened
         : _Mydata(_Ntcts), _Mysize(_Traits::length(_Ntcts)) {}
 
 #if _HAS_CXX23
@@ -1655,6 +1659,8 @@ private:
     const_pointer _Mydata;
     size_type _Mysize;
 };
+
+#pragma warning(pop)
 
 #ifdef __cpp_lib_concepts
 template <contiguous_iterator _Iter, sized_sentinel_for<_Iter> _Sent>

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -1223,7 +1223,7 @@ public:
     constexpr basic_string_view(const basic_string_view&) noexcept            = default;
     constexpr basic_string_view& operator=(const basic_string_view&) noexcept = default;
 
-    /* implicit */ constexpr basic_string_view(_In_z_ const const_pointer _Ntcts) noexcept // strengthened
+    /* implicit */ constexpr basic_string_view(const const_pointer _Ntcts) noexcept // strengthened
         : _Mydata(_Ntcts), _Mysize(_Traits::length(_Ntcts)) {}
 
 #if _HAS_CXX23

--- a/tests/std/tests/P0220R1_string_view/test.cpp
+++ b/tests/std/tests/P0220R1_string_view/test.cpp
@@ -1267,16 +1267,16 @@ struct std::char_traits<char_wrapper> {
 
     static size_t length(const char_wrapper* a) {
         static_assert(sizeof(char_wrapper) == 1, "strlen requires this");
-        return std::strlen(reinterpret_cast<const char*>(a));
+        return strlen(reinterpret_cast<const char*>(a));
     }
 
-    static int compare(const char_wrapper* lhs, const char_wrapper* rhs, std::size_t count) {
-        return std::char_traits<char>::compare(
+    static int compare(const char_wrapper* lhs, const char_wrapper* rhs, size_t count) {
+        return char_traits<char>::compare(
             reinterpret_cast<const char*>(lhs), reinterpret_cast<const char*>(rhs), count);
     }
 };
 
-using WrappedSV = std::basic_string_view<char_wrapper, std::char_traits<char_wrapper>>;
+using WrappedSV = basic_string_view<char_wrapper, char_traits<char_wrapper>>;
 
 void test_C6510_warning() { // compile-only
     char_wrapper a[] = {{'a'}, {'b'}, {'c'}, {'\0'}};

--- a/tests/std/tests/P0220R1_string_view/test.cpp
+++ b/tests/std/tests/P0220R1_string_view/test.cpp
@@ -4,6 +4,7 @@
 #include <array>
 #include <cassert>
 #include <cstdlib>
+#include <cstring>
 #include <deque>
 #include <sstream>
 #include <stdexcept>
@@ -1250,6 +1251,38 @@ static_assert(!is_constructible_v<string_view, nullptr_t>, "constructing string_
 static_assert(!is_constructible_v<string, nullptr_t>, "constructing string from nullptr_t is prohibited");
 static_assert(!is_assignable_v<string&, nullptr_t>, "assigning nullptr_t to string is prohibited");
 #endif // _HAS_CXX23
+
+// Also test that no C6510 warning
+struct char_wrapper {
+    char c;
+};
+
+template <>
+struct std::char_traits<char_wrapper> {
+    using char_type = char_wrapper;
+
+    static bool eq(char_wrapper lhs, char_wrapper rhs) {
+        return lhs.c == rhs.c;
+    }
+
+    static size_t length(const char_wrapper* a) {
+        static_assert(sizeof(char_wrapper) == 1, "strlen requires this");
+        return std::strlen(reinterpret_cast<const char*>(a));
+    }
+
+    static int compare(const char_wrapper* lhs, const char_wrapper* rhs, std::size_t count) {
+        return std::char_traits<char>::compare(
+            reinterpret_cast<const char*>(lhs), reinterpret_cast<const char*>(rhs), count);
+    }
+};
+
+using WrappedSV = std::basic_string_view<char_wrapper, std::char_traits<char_wrapper>>;
+
+void test_C6510_warning() { // compile-only
+    char_wrapper a[] = {{'a'}, {'b'}, {'c'}, {'\0'}};
+    WrappedSV sv(a);
+    (void) sv;
+}
 
 int main() {
     test_case_default_constructor();


### PR DESCRIPTION
Fixes warning C6510: Invalid annotation: 'NullTerminated' property may only be used on buffers whose elements are of integral or pointer type: Function `'{ctor}' _Param_(1)`.

https://gcc.godbolt.org/z/bPqs167he

Can we do something else and don't remove the annotation but fix the warning?
Found in one of LLVM tests.