### PR TITLE
`<__msvc_int128.hpp>`: Backport 128-bit integer-class types to C++14 mode

### DIFF
--- a/stl/inc/__msvc_int128.hpp
+++ b/stl/inc/__msvc_int128.hpp
@@ -1453,7 +1453,7 @@ struct common_type<_Unsigned128, _Signed128> {
 
 inline namespace literals {
     inline namespace _Int128_literals {
-        namespace _Detail {
+        namespace _Int128_detail {
             enum class _U128_parse_status : unsigned char {
                 _Valid,
                 _Overflow,
@@ -1530,24 +1530,24 @@ inline namespace literals {
 
             template <char... _Chars>
             _INLINE_VAR constexpr _U128_parse_result _Parsed_u128<'0', _Chars...> = _Parse_u128_impl<8, _Chars...>();
-        } // namespace _Detail
+        } // namespace _Int128_detail
 
         template <char... _Chars>
         _CONSTEVAL _Unsigned128 operator"" __u128() noexcept {
-            constexpr const auto& _Parsed_result = _Detail::_Parsed_u128<_Chars...>;
-            static_assert(_Parsed_result._Status_code != _Detail::_U128_parse_status::_Invalid,
+            constexpr const auto& _Parsed_result = _Int128_detail::_Parsed_u128<_Chars...>;
+            static_assert(_Parsed_result._Status_code != _Int128_detail::_U128_parse_status::_Invalid,
                 "Invalid characters in the integer literal");
-            static_assert(_Parsed_result._Status_code != _Detail::_U128_parse_status::_Overflow,
+            static_assert(_Parsed_result._Status_code != _Int128_detail::_U128_parse_status::_Overflow,
                 "The integer literal is too large for an unsigned 128-bit number");
             return _Parsed_result._Value;
         }
 
         template <char... _Chars>
         _CONSTEVAL _Signed128 operator"" __i128() noexcept {
-            constexpr const auto& _Parsed_result = _Detail::_Parsed_u128<_Chars...>;
-            static_assert(_Parsed_result._Status_code != _Detail::_U128_parse_status::_Invalid,
+            constexpr const auto& _Parsed_result = _Int128_detail::_Parsed_u128<_Chars...>;
+            static_assert(_Parsed_result._Status_code != _Int128_detail::_U128_parse_status::_Invalid,
                 "Invalid characters in the integer literal");
-            static_assert(_Parsed_result._Status_code != _Detail::_U128_parse_status::_Overflow
+            static_assert(_Parsed_result._Status_code != _Int128_detail::_U128_parse_status::_Overflow
                               && _Parsed_result._Value._Word[1] < (static_cast<uint64_t>(1) << 63),
                 "The integer literal is too large for a signed 128-bit number");
             return static_cast<_Signed128>(_Parsed_result._Value);

--- a/stl/inc/__msvc_int128.hpp
+++ b/stl/inc/__msvc_int128.hpp
@@ -735,10 +735,14 @@ struct _Unsigned128 : _Base128 {
     }
 #else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
     _NODISCARD_FRIEND constexpr bool operator<(const _Unsigned128& _Left, const _Unsigned128& _Right) noexcept {
-        if (_Left._Word[1] < _Right._Word[1])
+        if (_Left._Word[1] < _Right._Word[1]) {
             return true;
-        if (_Right._Word[1] < _Left._Word[1])
+        }
+
+        if (_Right._Word[1] < _Left._Word[1]) {
             return false;
+        }
+
         return _Left._Word[0] < _Right._Word[0];
     }
 
@@ -1064,10 +1068,14 @@ struct _Signed128 : _Base128 {
     }
 #else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
     _NODISCARD_FRIEND constexpr bool operator<(const _Signed128& _Left, const _Signed128& _Right) noexcept {
-        if (static_cast<int64_t>(_Left._Word[1]) < static_cast<int64_t>(_Right._Word[1]))
+        if (static_cast<int64_t>(_Left._Word[1]) < static_cast<int64_t>(_Right._Word[1])) {
             return true;
-        if (static_cast<int64_t>(_Right._Word[1]) < static_cast<int64_t>(_Left._Word[1]))
+        }
+
+        if (static_cast<int64_t>(_Right._Word[1]) < static_cast<int64_t>(_Left._Word[1])) {
             return false;
+        }
+
         return _Left._Word[0] < _Right._Word[0];
     }
 
@@ -1458,12 +1466,18 @@ inline namespace literals {
             };
 
             _CONSTEVAL unsigned int _Char_to_digit(const char _Ch) noexcept {
-                if (_Ch >= '0' && _Ch <= '9')
+                if (_Ch >= '0' && _Ch <= '9') {
                     return static_cast<unsigned int>(_Ch - '0');
-                if (_Ch >= 'A' && _Ch <= 'F')
+                }
+
+                if (_Ch >= 'A' && _Ch <= 'F') {
                     return static_cast<unsigned int>(_Ch - 'A' + 10);
-                if (_Ch >= 'a' && _Ch <= 'f')
+                }
+
+                if (_Ch >= 'a' && _Ch <= 'f') {
                     return static_cast<unsigned int>(_Ch - 'a' + 10);
+                }
+
                 return static_cast<unsigned int>(-1);
             }
 

--- a/stl/inc/__msvc_int128.hpp
+++ b/stl/inc/__msvc_int128.hpp
@@ -137,7 +137,7 @@ struct
     static constexpr void _Knuth_4_3_1_M(
         const uint32_t (&__u)[__m], const uint32_t (&__v)[__n], uint32_t (&__w)[__n + __m]) noexcept {
 #ifdef _ENABLE_STL_INTERNAL_CHECK
-        constexpr auto _Int_max = size_t{(numeric_limits<int>::max) ()};
+        constexpr auto _Int_max = size_t{(numeric_limits<int>::max)()};
         _STL_INTERNAL_STATIC_ASSERT(__m <= _Int_max);
         _STL_INTERNAL_STATIC_ASSERT(__n <= _Int_max);
 #endif // _ENABLE_STL_INTERNAL_CHECK

--- a/stl/inc/__msvc_int128.hpp
+++ b/stl/inc/__msvc_int128.hpp
@@ -1500,7 +1500,7 @@ inline namespace literals {
                             return {_U128_parse_status::_Invalid, _Unsigned128{}};
                         }
 
-                        if ((_Val > _U128_max / _Base) || (_Base * _Val > _U128_max - _Digit)) {
+                        if (_Val > _U128_max / _Base || _Base * _Val > _U128_max - _Digit) {
                             return {_U128_parse_status::_Overflow, _Unsigned128{}};
                         }
 

--- a/stl/inc/__msvc_int128.hpp
+++ b/stl/inc/__msvc_int128.hpp
@@ -1465,7 +1465,7 @@ inline namespace literals {
                 _Unsigned128 _Value;
             };
 
-            _CONSTEVAL unsigned int _Char_to_digit(const char _Ch) noexcept {
+            _NODISCARD _CONSTEVAL unsigned int _Char_to_digit(const char _Ch) noexcept {
                 if (_Ch >= '0' && _Ch <= '9') {
                     return static_cast<unsigned int>(_Ch - '0');
                 }
@@ -1482,7 +1482,7 @@ inline namespace literals {
             }
 
             template <unsigned int _Base, char... _Chars>
-            _CONSTEVAL _U128_parse_result _Parse_u128_impl() noexcept {
+            _NODISCARD _CONSTEVAL _U128_parse_result _Parse_u128_impl() noexcept {
                 if constexpr (sizeof...(_Chars) == 0) {
                     return {_U128_parse_status::_Valid, 0};
                 } else {

--- a/stl/inc/__msvc_int128.hpp
+++ b/stl/inc/__msvc_int128.hpp
@@ -1499,6 +1499,7 @@ inline namespace literals {
                         if (_Digit == static_cast<unsigned int>(-1)) {
                             return {_U128_parse_status::_Invalid, _Unsigned128{}};
                         }
+
                         if ((_Val > _U128_max / _Base) || (_Base * _Val > _U128_max - _Digit)) {
                             return {_U128_parse_status::_Overflow, _Unsigned128{}};
                         }

--- a/stl/inc/__msvc_int128.hpp
+++ b/stl/inc/__msvc_int128.hpp
@@ -534,7 +534,7 @@ struct
             __v[2] |= _Den._Word[0] >> (64 - __d);
         }
 
-        uint32_t __q[2];
+        uint32_t __q[2] _ZERO_OR_NO_INIT;
         if (_Three_word_den) {
             // 4-digit by 3-digit base 2^32 division
             _Knuth_4_3_1_D(__u, 5, __v, 3, __q);
@@ -669,7 +669,7 @@ struct
             __v[2] |= _Den._Word[0] >> (64 - __d);
         }
 
-        uint32_t __q[2];
+        uint32_t __q[2] _ZERO_OR_NO_INIT;
         if (_Three_word_den) {
             // 4-digit by 3-digit base 2^32 division
             _Knuth_4_3_1_D(__u, 5, __v, 3, __q);

--- a/stl/inc/__msvc_int128.hpp
+++ b/stl/inc/__msvc_int128.hpp
@@ -296,7 +296,7 @@ struct
 #ifdef __cpp_lib_concepts
         if constexpr (signed_integral<_Ty>)
 #else
-        if constexpr (is_integral_v<_Ty> && is_signed_v<_Ty>)
+        if constexpr (is_signed_v<_Ty>)
 #endif
         {
             if (_Val < 0) {

--- a/stl/inc/__msvc_int128.hpp
+++ b/stl/inc/__msvc_int128.hpp
@@ -1487,7 +1487,7 @@ inline namespace literals {
                     return {_U128_parse_status::_Valid, 0};
                 } else {
                     constexpr char _Char_seq[]{_Chars...};
-                    constexpr auto _U128_max = (_STD numeric_limits<_Unsigned128>::max)();
+                    constexpr auto _U128_max = (numeric_limits<_Unsigned128>::max)();
 
                     _Unsigned128 _Val{};
                     for (const char _Ch : _Char_seq) {

--- a/stl/inc/__msvc_int128.hpp
+++ b/stl/inc/__msvc_int128.hpp
@@ -39,17 +39,18 @@ _STL_DISABLE_CLANG_WARNINGS
 
 _STD_BEGIN
 
-#if defined(_M_X64) && !defined(_M_ARM64EC)
+#if defined(_M_X64) && !defined(_M_ARM64EC) && !defined(_M_CEE_PURE) && !defined(__CUDACC__) \
+    && !defined(__INTEL_COMPILER)
 #define _STL_128_INTRINSICS 1
 #ifdef __clang__ // clang doesn't have _udiv128 / _div128
 #define _STL_128_DIV_INTRINSICS 0
 #else // ^^^ Clang / other vvv
 #define _STL_128_DIV_INTRINSICS 1
 #endif // ^^^ detect _udiv128 / _div128 ^^^
-#else // ^^^ x64 / other vvv
+#else // ^^^ intrinsics available / intrinsics unavailable vvv
 #define _STL_128_INTRINSICS     0
 #define _STL_128_DIV_INTRINSICS 0
-#endif // defined(_M_X64) && !defined(_M_ARM64EC)
+#endif // ^^^ intrinsics unavailable ^^^
 
 struct
 #ifndef _M_ARM

--- a/stl/inc/__msvc_int128.hpp
+++ b/stl/inc/__msvc_int128.hpp
@@ -1534,7 +1534,7 @@ inline namespace literals {
         } // namespace _Int128_detail
 
         template <char... _Chars>
-        _CONSTEVAL _Unsigned128 operator"" __u128() noexcept {
+        _NODISCARD _CONSTEVAL _Unsigned128 operator"" __u128() noexcept {
             constexpr const auto& _Parsed_result = _Int128_detail::_Parsed_u128<_Chars...>;
             static_assert(_Parsed_result._Status_code != _Int128_detail::_U128_parse_status::_Invalid,
                 "Invalid characters in the integer literal");
@@ -1544,7 +1544,7 @@ inline namespace literals {
         }
 
         template <char... _Chars>
-        _CONSTEVAL _Signed128 operator"" __i128() noexcept {
+        _NODISCARD _CONSTEVAL _Signed128 operator"" __i128() noexcept {
             constexpr const auto& _Parsed_result = _Int128_detail::_Parsed_u128<_Chars...>;
             static_assert(_Parsed_result._Status_code != _Int128_detail::_U128_parse_status::_Invalid,
                 "Invalid characters in the integer literal");

--- a/stl/inc/__msvc_int128.hpp
+++ b/stl/inc/__msvc_int128.hpp
@@ -18,17 +18,17 @@
 #include <bit>
 #include <compare>
 #define _ZERO_OR_NO_INIT
-#else // ^^^ _HAS_CXX20 / vvv !_HAS_CXX20
+#else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
 #define _ZERO_OR_NO_INIT \
     {} // Trivial default initialization is not allowed in constexpr functions before C++20.
-#endif // _HAS_CXX20
+#endif // ^^^ !_HAS_CXX20 ^^^
 
 #ifdef __cpp_lib_concepts
 #include <concepts>
 #define _TEMPLATE_CLASS_INTEGRAL(type) template <integral type>
-#else
+#else // ^^^ defined(__cpp_lib_concepts) / !defined(__cpp_lib_concepts) vvv
 #define _TEMPLATE_CLASS_INTEGRAL(type) template <class type, enable_if_t<is_integral_v<type>, int> = 0>
-#endif // __cpp_lib_concepts
+#endif // ^^^ !defined(__cpp_lib_concepts) ^^^
 
 #pragma pack(push, _CRT_PACKING)
 #pragma warning(push, _STL_WARNING_LEVEL)
@@ -249,9 +249,9 @@ struct
 
 #if _HAS_CXX20
         const auto __d = _STD countl_zero(static_cast<uint32_t>(_Div >> 32));
-#else // ^^^ _HAS_CXX20 / vvv !_HAS_CXX20
+#else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
         const auto __d = _Countl_zero_fallback(static_cast<uint32_t>(_Div >> 32));
-#endif // _HAS_CXX20
+#endif // ^^^ !_HAS_CXX20 ^^^
         if (__d >= 32) { // _Div < 2^32
             auto _Rem    = (_High << 32) | (_Low >> 32);
             auto _Result = _Rem / static_cast<uint32_t>(_Div);
@@ -318,7 +318,7 @@ struct
 
 #if _HAS_CXX20
     _NODISCARD_FRIEND constexpr bool operator==(const _Base128&, const _Base128&) noexcept = default;
-#else // ^^^ _HAS_CXX20 / vvv !_HAS_CXX20
+#else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
     _NODISCARD_FRIEND constexpr bool operator==(const _Base128& _Left, const _Base128& _Right) noexcept {
         return _Left._Word[0] == _Right._Word[0] && _Left._Word[1] == _Right._Word[1];
     }
@@ -326,7 +326,7 @@ struct
     _NODISCARD_FRIEND constexpr bool operator!=(const _Base128& _Left, const _Base128& _Right) noexcept {
         return !(_Left == _Right);
     }
-#endif
+#endif // ^^^ !_HAS_CXX20 ^^^
 
     _NODISCARD_FRIEND constexpr bool operator<(const _Base128& _Left, const _Base128& _Right) noexcept {
         if (_Left._Word[1] < _Right._Word[1]) {
@@ -461,9 +461,9 @@ struct
         // Normalize by shifting both left until _Den's high bit is set (So _Den's high digit is >= b / 2)
 #if _HAS_CXX20
         const auto __d = _STD countl_zero(_Den._Word[1]);
-#else // ^^^ _HAS_CXX20 / vvv !_HAS_CXX20
+#else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
         const auto __d = _Countl_zero_fallback(_Den._Word[1]);
-#endif // _HAS_CXX20
+#endif // ^^^ !_HAS_CXX20 ^^^
         _Den <<= __d;
         auto _High_digit = __d == 0 ? 0 : _Num._Word[1] >> (64 - __d); // This creates a third digit for _Num
         _Num <<= __d;
@@ -510,9 +510,9 @@ struct
 #else // ^^^ 128-bit intrinsics / no such intrinsics vvv
 #if _HAS_CXX20
         auto __d = _STD countl_zero(_Den._Word[1]);
-#else // ^^^ _HAS_CXX20 / vvv !_HAS_CXX20
+#else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
         auto __d = _Countl_zero_fallback(_Den._Word[1]);
-#endif // _HAS_CXX20
+#endif // ^^^ !_HAS_CXX20 ^^^
         const bool _Three_word_den = __d >= 32;
         __d &= 31;
         uint32_t __u[5]{
@@ -594,9 +594,9 @@ struct
         // Normalize by shifting both left until _Den's high bit is set (So _Den's high digit is >= b / 2)
 #if _HAS_CXX20
         const auto __d = _STD countl_zero(_Den._Word[1]);
-#else // ^^^ _HAS_CXX20 / vvv !_HAS_CXX20
+#else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
         const auto __d = _Countl_zero_fallback(_Den._Word[1]);
-#endif // _HAS_CXX20
+#endif // ^^^ !_HAS_CXX20 ^^^
         _Den <<= __d;
         auto _High_digit = __d == 0 ? 0 : _Num._Word[1] >> (64 - __d); // This creates a third digit for _Num
         _Num <<= __d;
@@ -645,9 +645,9 @@ struct
 #else // ^^^ 128-bit intrinsics / no such intrinsics vvv
 #if _HAS_CXX20
         auto __d = _STD countl_zero(_Den._Word[1]);
-#else // ^^^ _HAS_CXX20 / vvv !_HAS_CXX20
+#else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
         auto __d = _Countl_zero_fallback(_Den._Word[1]);
-#endif // _HAS_CXX20
+#endif // ^^^ !_HAS_CXX20 ^^^
         const bool _Three_word_den = __d >= 32;
         __d &= 31;
         uint32_t __u[5]{
@@ -733,7 +733,7 @@ struct _Unsigned128 : _Base128 {
         }
         return _Ord;
     }
-#else // ^^^ _HAS_CXX20 / vvv !_HAS_CXX20
+#else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
     _NODISCARD_FRIEND constexpr bool operator<(const _Unsigned128& _Left, const _Unsigned128& _Right) noexcept {
         if (_Left._Word[1] < _Right._Word[1])
             return true;
@@ -753,7 +753,7 @@ struct _Unsigned128 : _Base128 {
     _NODISCARD_FRIEND constexpr bool operator>=(const _Unsigned128& _Left, const _Unsigned128& _Right) noexcept {
         return !(_Left < _Right);
     }
-#endif // _HAS_CXX20
+#endif // ^^^ !_HAS_CXX20 ^^^
 
     _NODISCARD_FRIEND constexpr _Unsigned128 operator<<(const _Unsigned128& _Left, const _Base128& _Right) noexcept {
         auto _Tmp{_Left};
@@ -1030,12 +1030,12 @@ template <integral _Ty>
 struct common_type<_Unsigned128, _Ty> {
     using type = _Unsigned128;
 };
-#else // ^^^ defined(__cpp_lib_concepts) / vvv !defined(__cpp_lib_concepts)
+#else // ^^^ defined(__cpp_lib_concepts) / !defined(__cpp_lib_concepts) vvv
 template <class _Ty>
 struct common_type<_Ty, _Unsigned128> : enable_if<is_integral_v<_Ty>, _Unsigned128> {};
 template <class _Ty>
 struct common_type<_Unsigned128, _Ty> : enable_if<is_integral_v<_Ty>, _Unsigned128> {};
-#endif // __cpp_lib_concepts
+#endif // ^^^ !defined(__cpp_lib_concepts) ^^^
 
 struct _Signed128 : _Base128 {
     using _Signed_type   = _Signed128;
@@ -1062,7 +1062,7 @@ struct _Signed128 : _Base128 {
         }
         return _Ord;
     }
-#else // ^^^ _HAS_CXX20 / vvv !_HAS_CXX20
+#else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
     _NODISCARD_FRIEND constexpr bool operator<(const _Signed128& _Left, const _Signed128& _Right) noexcept {
         if (static_cast<int64_t>(_Left._Word[1]) < static_cast<int64_t>(_Right._Word[1]))
             return true;
@@ -1082,7 +1082,7 @@ struct _Signed128 : _Base128 {
     _NODISCARD_FRIEND constexpr bool operator>=(const _Signed128& _Left, const _Signed128& _Right) noexcept {
         return !(_Left < _Right);
     }
-#endif // _HAS_CXX20
+#endif // ^^^ !_HAS_CXX20 ^^^
 
     _NODISCARD_FRIEND constexpr _Signed128 operator<<(const _Signed128& _Left, const _Base128& _Right) noexcept {
         auto _Tmp{_Left};
@@ -1427,12 +1427,12 @@ template <integral _Ty>
 struct common_type<_Signed128, _Ty> {
     using type = _Signed128;
 };
-#else // ^^^ defined(__cpp_lib_concepts) / vvv !defined(__cpp_lib_concepts)
+#else // ^^^ defined(__cpp_lib_concepts) / !defined(__cpp_lib_concepts) vvv
 template <class _Ty>
 struct common_type<_Ty, _Signed128> : enable_if<is_integral_v<_Ty>, _Signed128> {};
 template <class _Ty>
 struct common_type<_Signed128, _Ty> : enable_if<is_integral_v<_Ty>, _Signed128> {};
-#endif // __cpp_lib_concepts
+#endif // ^^^ !defined(__cpp_lib_concepts) ^^^
 
 template <>
 struct common_type<_Signed128, _Unsigned128> {

--- a/stl/inc/__msvc_int128.hpp
+++ b/stl/inc/__msvc_int128.hpp
@@ -1320,6 +1320,11 @@ struct _Signed128 : _Base128 {
     }
 
     _TEMPLATE_CLASS_INTEGRAL(_Ty)
+    _NODISCARD_FRIEND constexpr _Signed128 operator%(_Signed128 _Left, const _Ty _Right) noexcept {
+        return _Left % _Signed128{_Right};
+    }
+
+    _TEMPLATE_CLASS_INTEGRAL(_Ty)
     constexpr _Signed128& operator%=(const _Ty _That) noexcept {
         *this = *this % _That;
         return *this;
@@ -1463,7 +1468,7 @@ inline namespace literals {
 
             template <unsigned int _Base, char... _Chars>
             _CONSTEVAL _U128_parse_result _Parse_u128_impl() noexcept {
-                constexpr char _Char_seq[]{_Chars...};
+                constexpr char _Char_seq[]{_Chars..., '\0'};
                 constexpr auto _U128_max = (_STD numeric_limits<_Unsigned128>::max)();
 
                 _Unsigned128 _Val{};

--- a/stl/inc/__msvc_int128.hpp
+++ b/stl/inc/__msvc_int128.hpp
@@ -19,7 +19,8 @@
 #include <compare>
 #define _ZERO_OR_NO_INIT
 #else // ^^^ _HAS_CXX20 / vvv !_HAS_CXX20
-#define _ZERO_OR_NO_INIT {} // Trivial default initialization is not allowed in constexpr functions before C++20.
+#define _ZERO_OR_NO_INIT \
+    {} // Trivial default initialization is not allowed in constexpr functions before C++20.
 #endif // _HAS_CXX20
 
 #ifdef __cpp_lib_concepts

--- a/stl/inc/__msvc_int128.hpp
+++ b/stl/inc/__msvc_int128.hpp
@@ -19,14 +19,14 @@
 #include <compare>
 #define _ZERO_OR_NO_INIT
 #else // ^^^ _HAS_CXX20 / vvv !_HAS_CXX20
-#define _ZERO_OR_NO_INIT = {0}
+#define _ZERO_OR_NO_INIT = {0} // Trivial default initialization is not allowed in constexpr functions before C++20.
 #endif // _HAS_CXX20
 
 #ifdef __cpp_lib_concepts
 #include <concepts>
-#define _TEMPLATE_CLASS_INTEGRAL(type) template <integral _Ty>
+#define _TEMPLATE_CLASS_INTEGRAL(type) template <integral type>
 #else
-#define _TEMPLATE_CLASS_INTEGRAL(type) template <class _Ty, enable_if_t<is_integral_v<type>, int> = 0>
+#define _TEMPLATE_CLASS_INTEGRAL(type) template <class type, enable_if_t<is_integral_v<type>, int> = 0>
 #endif // __cpp_lib_concepts
 
 #pragma pack(push, _CRT_PACKING)

--- a/tests/std/tests/P1522R1_difference_type/env.lst
+++ b/tests/std/tests/P1522R1_difference_type/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_20_matrix.lst
+RUNALL_INCLUDE ..\usual_matrix.lst

--- a/tests/std/tests/P1522R1_difference_type/test.cpp
+++ b/tests/std/tests/P1522R1_difference_type/test.cpp
@@ -369,6 +369,8 @@ constexpr bool test_unsigned() {
         STATIC_ASSERT(noexcept(0x2'A__u128));
         STATIC_ASSERT(noexcept(0b101010__u128));
         STATIC_ASSERT(noexcept(0b1'0101'0__u128));
+        STATIC_ASSERT(noexcept(0B101010__u128));
+        STATIC_ASSERT(noexcept(0B1'0101'0__u128));
         STATIC_ASSERT(noexcept(340282366920938463463374607431768211455__u128));
         STATIC_ASSERT(noexcept(0xffffffff'FFFFFFFF'ffffFFFF'FFFFffff__u128));
 
@@ -380,6 +382,8 @@ constexpr bool test_unsigned() {
         STATIC_ASSERT(4'2__u128 == 0X2a__u128);
         STATIC_ASSERT(42__u128 == 0b101010__u128);
         STATIC_ASSERT(4'2__u128 == 0b101010__u128);
+        STATIC_ASSERT(42__u128 == 0B101010__u128);
+        STATIC_ASSERT(4'2__u128 == 0B101010__u128);
         STATIC_ASSERT(
             340'2823'6692'0938'4634'6337'4607'4317'6821'1455__u128 == 0xffffffff'FFFFFFFF'ffffFFFF'FFFFffff__u128);
 
@@ -813,6 +817,8 @@ constexpr bool test_signed() {
         STATIC_ASSERT(noexcept(0x2'A__i128));
         STATIC_ASSERT(noexcept(0b101010__i128));
         STATIC_ASSERT(noexcept(0b1'0101'0__i128));
+        STATIC_ASSERT(noexcept(0B101010__i128));
+        STATIC_ASSERT(noexcept(0B1'0101'0__i128));
         STATIC_ASSERT(noexcept(170141183460469231731687303715884105727__i128));
         STATIC_ASSERT(noexcept(0x7fffffff'FFFFFFFF'ffffFFFF'FFFFffff__i128));
 
@@ -824,6 +830,8 @@ constexpr bool test_signed() {
         STATIC_ASSERT(4'2__i128 == 0X2a__i128);
         STATIC_ASSERT(42__i128 == 0b101010__i128);
         STATIC_ASSERT(4'2__i128 == 0b101010__i128);
+        STATIC_ASSERT(42__i128 == 0B101010__i128);
+        STATIC_ASSERT(4'2__i128 == 0B101010__i128);
         STATIC_ASSERT(
             170'1411'8346'0469'2317'3168'7303'7158'8410'5727__i128 == 0x7fffffff'FFFFFFFF'ffffFFFF'FFFFffff__i128);
 

--- a/tests/std/tests/P1522R1_difference_type/test.cpp
+++ b/tests/std/tests/P1522R1_difference_type/test.cpp
@@ -11,9 +11,9 @@
 #if _HAS_CXX20
 #include <compare>
 
-#if !defined(__EDG__) // TRANSITION, GH-395
+#ifndef __EDG__ // TRANSITION, GH-395
 #include <concepts>
-#endif // !defined(__EDG__)
+#endif // __EDG__
 #endif // _HAS_CXX20
 
 #if _HAS_CXX20 && !defined(__EDG__) // TRANSITION, GH-395

--- a/tests/std/tests/P1522R1_difference_type/test.cpp
+++ b/tests/std/tests/P1522R1_difference_type/test.cpp
@@ -14,7 +14,7 @@
 namespace ordtest {
     using std::strong_ordering;
 }
-#else // ^^^ _HAS_CXX20 / vvv !_HAS_CXX20
+#else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
 namespace ordtest {
     enum class strong_ordering : signed char {
         less       = -1,
@@ -23,15 +23,15 @@ namespace ordtest {
         greater    = 1,
     };
 }
-#endif // _HAS_CXX20
+#endif // ^^^ !_HAS_CXX20 ^^^
 
 #ifdef __cpp_lib_concepts // TRANSITION, GH-395
 #include <concepts>
 
 #define SAME_AS std::same_as
-#else // ^^^ has concepts / vvv has no concepts
+#else // ^^^ has concepts / has no concepts vvv
 #define SAME_AS std::is_same_v
-#endif // __cpp_lib_concepts
+#endif // ^^^ has no concepts ^^^
 
 #define STATIC_ASSERT(...) static_assert(__VA_ARGS__, #__VA_ARGS__)
 
@@ -847,13 +847,13 @@ template <class T, class U>
 concept CanConditional = requires {
     true ? val<T>() : val<U>();
 };
-#else // ^^^ has concepts / vvv has no concepts
+#else // ^^^ has concepts / has no concepts vvv
 template <class T, class U, class = void>
 constexpr bool CanConditional = false;
 
 template <class T, class U>
 constexpr bool CanConditional<T, U, std::void_t<decltype(true ? val<T>() : val<U>())>> = true;
-#endif // __cpp_lib_concepts
+#endif // ^^^ has no concepts ^^^
 
 constexpr bool test_cross() {
     // Test the behavior of cross-type operations.

--- a/tests/std/tests/P1522R1_difference_type/test.cpp
+++ b/tests/std/tests/P1522R1_difference_type/test.cpp
@@ -1152,7 +1152,11 @@ constexpr bool test_cross() {
         x = -26;
         TEST(u *= 2, x);
         y = 12;
+#ifdef _M_CEE // TRANSITION, silent bad codegen, not yet reported
+        i = 12;
+#else // ^^^ workaround / no workaround vvv
         TEST(i *= -2, y);
+#endif // ^^^ no workaround ^^^
 
         x = _Unsigned128{0x55555555'5555554c, 0x55555555'55555555};
         TEST(u /= 3, x); // Yes, u is still unsigned =)

--- a/tests/std/tests/P1522R1_difference_type/test.cpp
+++ b/tests/std/tests/P1522R1_difference_type/test.cpp
@@ -371,6 +371,7 @@ constexpr bool test_unsigned() {
         STATIC_ASSERT(noexcept(0b1'0101'0__u128));
         STATIC_ASSERT(noexcept(0B101010__u128));
         STATIC_ASSERT(noexcept(0B1'0101'0__u128));
+        STATIC_ASSERT(noexcept(0xABCDEF__u128));
         STATIC_ASSERT(noexcept(340282366920938463463374607431768211455__u128));
         STATIC_ASSERT(noexcept(0xffffffff'FFFFFFFF'ffffFFFF'FFFFffff__u128));
 
@@ -384,6 +385,7 @@ constexpr bool test_unsigned() {
         STATIC_ASSERT(4'2__u128 == 0b101010__u128);
         STATIC_ASSERT(42__u128 == 0B101010__u128);
         STATIC_ASSERT(4'2__u128 == 0B101010__u128);
+        STATIC_ASSERT(11259375__u128 == 0xABCDEF__u128);
         STATIC_ASSERT(
             340'2823'6692'0938'4634'6337'4607'4317'6821'1455__u128 == 0xffffffff'FFFFFFFF'ffffFFFF'FFFFffff__u128);
 
@@ -819,6 +821,7 @@ constexpr bool test_signed() {
         STATIC_ASSERT(noexcept(0b1'0101'0__i128));
         STATIC_ASSERT(noexcept(0B101010__i128));
         STATIC_ASSERT(noexcept(0B1'0101'0__i128));
+        STATIC_ASSERT(noexcept(0xABCDEF__i128));
         STATIC_ASSERT(noexcept(170141183460469231731687303715884105727__i128));
         STATIC_ASSERT(noexcept(0x7fffffff'FFFFFFFF'ffffFFFF'FFFFffff__i128));
 
@@ -832,6 +835,7 @@ constexpr bool test_signed() {
         STATIC_ASSERT(4'2__i128 == 0b101010__i128);
         STATIC_ASSERT(42__i128 == 0B101010__i128);
         STATIC_ASSERT(4'2__i128 == 0B101010__i128);
+        STATIC_ASSERT(11259375__i128 == 0xABCDEF__i128);
         STATIC_ASSERT(
             170'1411'8346'0469'2317'3168'7303'7158'8410'5727__i128 == 0x7fffffff'FFFFFFFF'ffffFFFF'FFFFffff__i128);
 

--- a/tests/std/tests/P1522R1_difference_type/test.cpp
+++ b/tests/std/tests/P1522R1_difference_type/test.cpp
@@ -363,13 +363,13 @@ constexpr bool test_unsigned() {
         STATIC_ASSERT(noexcept(0xffffffff'FFFFFFFF'ffffFFFF'FFFFffff__u128));
 
         STATIC_ASSERT(42__u128 == 42);
-        STATIC_ASSERT(42__u128 == 42);
+        STATIC_ASSERT(4'2__u128 == 42);
         STATIC_ASSERT(42__u128 == 052__u128);
-        STATIC_ASSERT(42__u128 == 05'2__u128);
+        STATIC_ASSERT(4'2__u128 == 052__u128);
         STATIC_ASSERT(42__u128 == 0x2a__u128);
-        STATIC_ASSERT(42__u128 == 0X2'a__u128);
+        STATIC_ASSERT(4'2__u128 == 0X2a__u128);
         STATIC_ASSERT(42__u128 == 0b101010__u128);
-        STATIC_ASSERT(42__u128 == 0b101'010__u128);
+        STATIC_ASSERT(4'2__u128 == 0b101010__u128);
         STATIC_ASSERT(
             340'2823'6692'0938'4634'6337'4607'4317'6821'1455__u128 == 0xffffffff'FFFFFFFF'ffffFFFF'FFFFffff__u128);
 
@@ -811,13 +811,13 @@ constexpr bool test_signed() {
         STATIC_ASSERT(noexcept(0x7fffffff'FFFFFFFF'ffffFFFF'FFFFffff__i128));
 
         STATIC_ASSERT(42__i128 == 42);
-        STATIC_ASSERT(42__i128 == 42);
+        STATIC_ASSERT(4'2__i128 == 42);
         STATIC_ASSERT(42__i128 == 052__i128);
-        STATIC_ASSERT(42__i128 == 05'2__i128);
+        STATIC_ASSERT(4'2__i128 == 052__i128);
         STATIC_ASSERT(42__i128 == 0x2a__i128);
-        STATIC_ASSERT(42__i128 == 0X2'a__i128);
+        STATIC_ASSERT(4'2__i128 == 0X2a__i128);
         STATIC_ASSERT(42__i128 == 0b101010__i128);
-        STATIC_ASSERT(42__i128 == 0b101'010__i128);
+        STATIC_ASSERT(4'2__i128 == 0b101010__i128);
         STATIC_ASSERT(
             170'1411'8346'0469'2317'3168'7303'7158'8410'5727__i128 == 0x7fffffff'FFFFFFFF'ffffFFFF'FFFFffff__i128);
 

--- a/tests/std/tests/P1522R1_difference_type/test.cpp
+++ b/tests/std/tests/P1522R1_difference_type/test.cpp
@@ -3,26 +3,45 @@
 
 #include <__msvc_int128.hpp>
 #include <cassert>
-#include <compare>
-#include <concepts>
 #include <cstdint>
 #include <iterator>
 #include <limits>
 #include <type_traits>
 
+#if _HAS_CXX20
+#include <compare>
+
+#if !defined(__EDG__) // TRANSITION, GH-395
+#include <concepts>
+#endif // !defined(__EDG__)
+#endif // _HAS_CXX20
+
+#if _HAS_CXX20 && !defined(__EDG__) // TRANSITION, GH-395
+#define SAME_AS std::same_as
+#else // ^^^ has concepts / vvv has no concepts
+#define SAME_AS std::is_same_v
+#endif // _HAS_CXX20 && !defined(__EDG__)
+
+#define STATIC_ASSERT(...) static_assert(__VA_ARGS__, #__VA_ARGS__)
+
 using std::_Signed128;
 using std::_Unsigned128;
+using namespace std::literals::_Int128_literals;
 
-constexpr void check_equal(const auto& x) {
+template <class I>
+constexpr void check_equal(const I& x) {
     assert(x == x);
     assert(!(x != x));
     assert(!(x < x));
     assert(!(x > x));
     assert(x <= x);
     assert(x >= x);
+#if _HAS_CXX20
     assert(x <=> x == 0);
+#endif // _HAS_CXX20
 }
 
+#if _HAS_CXX20
 constexpr void check_order(const auto& x, const auto& y, const std::strong_ordering ord) {
     assert((x == y) == (ord == std::strong_ordering::equal));
     assert((x != y) == (ord != std::strong_ordering::equal));
@@ -41,72 +60,82 @@ constexpr void check_order(const auto& x, const auto& y, const std::strong_order
     assert((x <=> y) == (ord <=> 0));
     assert((y <=> x) == (0 <=> ord));
 }
+#endif // _HAS_CXX20
 
 constexpr bool test_unsigned() {
-    static_assert(std::regular<_Unsigned128>);
-    static_assert(std::three_way_comparable<_Unsigned128, std::strong_ordering>);
+#if _HAS_CXX20 && !defined(__EDG__) // TRANSITION, GH-395
+    STATIC_ASSERT(std::regular<_Unsigned128>);
+    STATIC_ASSERT(std::three_way_comparable<_Unsigned128, std::strong_ordering>);
+#endif // _HAS_CXX20 && !defined(__EDG__)
 
-    static_assert(std::numeric_limits<_Unsigned128>::min() == 0);
-    static_assert(std::numeric_limits<_Unsigned128>::max() == ~_Unsigned128{});
-    static_assert(std::numeric_limits<_Unsigned128>::digits == 128);
-    static_assert(std::numeric_limits<_Unsigned128>::is_modulo);
+    STATIC_ASSERT(std::numeric_limits<_Unsigned128>::min() == 0);
+    STATIC_ASSERT(std::numeric_limits<_Unsigned128>::max() == ~_Unsigned128{});
+    STATIC_ASSERT(std::numeric_limits<_Unsigned128>::digits == 128);
+    STATIC_ASSERT(std::numeric_limits<_Unsigned128>::is_modulo);
 
-    static_assert(std::same_as<std::common_type_t<bool, _Unsigned128>, _Unsigned128>);
-    static_assert(std::same_as<std::common_type_t<char, _Unsigned128>, _Unsigned128>);
-    static_assert(std::same_as<std::common_type_t<signed char, _Unsigned128>, _Unsigned128>);
-    static_assert(std::same_as<std::common_type_t<unsigned char, _Unsigned128>, _Unsigned128>);
-    static_assert(std::same_as<std::common_type_t<wchar_t, _Unsigned128>, _Unsigned128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<bool, _Unsigned128>, _Unsigned128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<char, _Unsigned128>, _Unsigned128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<signed char, _Unsigned128>, _Unsigned128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<unsigned char, _Unsigned128>, _Unsigned128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<wchar_t, _Unsigned128>, _Unsigned128>);
 #ifdef __cpp_char8_t
-    static_assert(std::same_as<std::common_type_t<char8_t, _Unsigned128>, _Unsigned128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<char8_t, _Unsigned128>, _Unsigned128>);
 #endif // __cpp_char8_t
-    static_assert(std::same_as<std::common_type_t<char16_t, _Unsigned128>, _Unsigned128>);
-    static_assert(std::same_as<std::common_type_t<char32_t, _Unsigned128>, _Unsigned128>);
-    static_assert(std::same_as<std::common_type_t<short, _Unsigned128>, _Unsigned128>);
-    static_assert(std::same_as<std::common_type_t<unsigned short, _Unsigned128>, _Unsigned128>);
-    static_assert(std::same_as<std::common_type_t<int, _Unsigned128>, _Unsigned128>);
-    static_assert(std::same_as<std::common_type_t<unsigned int, _Unsigned128>, _Unsigned128>);
-    static_assert(std::same_as<std::common_type_t<long, _Unsigned128>, _Unsigned128>);
-    static_assert(std::same_as<std::common_type_t<unsigned long, _Unsigned128>, _Unsigned128>);
-    static_assert(std::same_as<std::common_type_t<long long, _Unsigned128>, _Unsigned128>);
-    static_assert(std::same_as<std::common_type_t<unsigned long long, _Unsigned128>, _Unsigned128>);
-    static_assert(std::same_as<std::common_type_t<_Signed128, _Unsigned128>, _Unsigned128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<char16_t, _Unsigned128>, _Unsigned128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<char32_t, _Unsigned128>, _Unsigned128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<short, _Unsigned128>, _Unsigned128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<unsigned short, _Unsigned128>, _Unsigned128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<int, _Unsigned128>, _Unsigned128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<unsigned int, _Unsigned128>, _Unsigned128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<long, _Unsigned128>, _Unsigned128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<unsigned long, _Unsigned128>, _Unsigned128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<long long, _Unsigned128>, _Unsigned128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<unsigned long long, _Unsigned128>, _Unsigned128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<_Signed128, _Unsigned128>, _Unsigned128>);
 
-    static_assert(std::same_as<std::common_type_t<_Unsigned128, bool>, _Unsigned128>);
-    static_assert(std::same_as<std::common_type_t<_Unsigned128, char>, _Unsigned128>);
-    static_assert(std::same_as<std::common_type_t<_Unsigned128, signed char>, _Unsigned128>);
-    static_assert(std::same_as<std::common_type_t<_Unsigned128, unsigned char>, _Unsigned128>);
-    static_assert(std::same_as<std::common_type_t<_Unsigned128, wchar_t>, _Unsigned128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<_Unsigned128, bool>, _Unsigned128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<_Unsigned128, char>, _Unsigned128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<_Unsigned128, signed char>, _Unsigned128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<_Unsigned128, unsigned char>, _Unsigned128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<_Unsigned128, wchar_t>, _Unsigned128>);
 #ifdef __cpp_char8_t
-    static_assert(std::same_as<std::common_type_t<_Unsigned128, char8_t>, _Unsigned128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<_Unsigned128, char8_t>, _Unsigned128>);
 #endif // __cpp_char8_t
-    static_assert(std::same_as<std::common_type_t<_Unsigned128, char16_t>, _Unsigned128>);
-    static_assert(std::same_as<std::common_type_t<_Unsigned128, char32_t>, _Unsigned128>);
-    static_assert(std::same_as<std::common_type_t<_Unsigned128, short>, _Unsigned128>);
-    static_assert(std::same_as<std::common_type_t<_Unsigned128, unsigned short>, _Unsigned128>);
-    static_assert(std::same_as<std::common_type_t<_Unsigned128, int>, _Unsigned128>);
-    static_assert(std::same_as<std::common_type_t<_Unsigned128, unsigned int>, _Unsigned128>);
-    static_assert(std::same_as<std::common_type_t<_Unsigned128, long>, _Unsigned128>);
-    static_assert(std::same_as<std::common_type_t<_Unsigned128, unsigned long>, _Unsigned128>);
-    static_assert(std::same_as<std::common_type_t<_Unsigned128, long long>, _Unsigned128>);
-    static_assert(std::same_as<std::common_type_t<_Unsigned128, unsigned long long>, _Unsigned128>);
-    static_assert(std::same_as<std::common_type_t<_Unsigned128, _Signed128>, _Unsigned128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<_Unsigned128, char16_t>, _Unsigned128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<_Unsigned128, char32_t>, _Unsigned128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<_Unsigned128, short>, _Unsigned128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<_Unsigned128, unsigned short>, _Unsigned128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<_Unsigned128, int>, _Unsigned128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<_Unsigned128, unsigned int>, _Unsigned128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<_Unsigned128, long>, _Unsigned128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<_Unsigned128, unsigned long>, _Unsigned128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<_Unsigned128, long long>, _Unsigned128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<_Unsigned128, unsigned long long>, _Unsigned128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<_Unsigned128, _Signed128>, _Unsigned128>);
 
-    static_assert(std::_Integer_class<_Unsigned128>);
-    static_assert(std::_Integer_like<_Unsigned128>);
-    static_assert(!std::_Signed_integer_like<_Unsigned128>);
-    static_assert(std::same_as<std::_Make_unsigned_like_t<_Unsigned128>, _Unsigned128>);
-    static_assert(std::same_as<std::_Make_signed_like_t<_Unsigned128>, _Signed128>);
+#if _HAS_CXX20 && !defined(__EDG__) // TRANSITION, GH-395
+    STATIC_ASSERT(std::_Integer_class<_Unsigned128>);
+    STATIC_ASSERT(std::_Integer_like<_Unsigned128>);
+    STATIC_ASSERT(!std::_Signed_integer_like<_Unsigned128>);
+    STATIC_ASSERT(SAME_AS<std::_Make_unsigned_like_t<_Unsigned128>, _Unsigned128>);
+    STATIC_ASSERT(SAME_AS<std::_Make_signed_like_t<_Unsigned128>, _Signed128>);
+#endif // _HAS_CXX20 && !defined(__EDG__)
 
     check_equal(_Unsigned128{});
     check_equal(_Unsigned128{42});
     check_equal(_Unsigned128{-42});
     check_equal(_Unsigned128{0x11111111'11111111, 0x22222222'22222222});
+    check_equal(0x22222222'22222222'11111111'11111111__u128);
 
+#if _HAS_CXX20
     check_order(_Unsigned128{42}, _Unsigned128{-42}, std::strong_ordering::less);
     check_order(_Unsigned128{0, 42}, _Unsigned128{0, 52}, std::strong_ordering::less); // ordered only by MSW
     check_order(_Unsigned128{42}, _Unsigned128{52}, std::strong_ordering::less); // ordered only by LSW
     check_order(_Unsigned128{0x11111111'11111111, 0x22222222'22222222},
         _Unsigned128{0x01010101'01010101, 0x01010101'01010101}, std::strong_ordering::greater);
+    check_order(0x22222222'22222222'11111111'11111111__u128, 0x01010101'01010101'01010101'01010101__u128,
+        std::strong_ordering::greater);
+#endif // _HAS_CXX20
 
     {
         _Unsigned128 u{42};
@@ -169,6 +198,7 @@ constexpr bool test_unsigned() {
             product = _Unsigned128{0x01010101'01010101, 0x01010101'01010101} * 5;
             assert(product._Word[0] == 0x05050505'05050505);
             assert(product._Word[1] == 0x05050505'05050505);
+            assert(product == 0x05050505'05050505'05050505'05050505__u128);
 
             product = 5 * _Unsigned128{0x01010101'01010101, 0x01010101'01010101};
             assert(product._Word[0] == 0x05050505'05050505);
@@ -178,6 +208,7 @@ constexpr bool test_unsigned() {
             product *= product;
             assert(product._Word[0] == 0x08070605'04030201);
             assert(product._Word[1] == 0x100f0e0d'0c0b0a09);
+            assert(product == 0x100f0e0d'0c0b0a09'08070605'04030201__u128);
             assert(+product == product);
             assert(-product + product == 0);
 
@@ -185,18 +216,21 @@ constexpr bool test_unsigned() {
                     * _Unsigned128{0x000f0e0d'0c0b0a09, 0x08070605'04030201};
             assert(product._Word[0] == 0x6dc18e55'16d48f48);
             assert(product._Word[1] == 0xdc1b6bce'43cd6c21);
+            assert(product == 0xdc1b6bce'43cd6c21'6dc18e55'16d48f48__u128);
             assert(+product == product);
             assert(-product + product == 0);
 
             product <<= 11;
             assert(product._Word[0] == 0x0c72a8b6'a47a4000);
             assert(product._Word[1] == 0xdb5e721e'6b610b6e);
+            assert(product == 0xdb5e721e'6b610b6e'0c72a8b6'a47a4000__u128);
             assert(+product == product);
             assert(-product + product == 0);
 
             product >>= 17;
             assert(product._Word[0] == 0x85b70639'545b523d);
             assert(product._Word[1] == 0x00006daf'390f35b0);
+            assert(product == 0x00006daf'390f35b0'85b70639'545b523d__u128);
             assert(+product == product);
             assert(-product + product == 0);
         }
@@ -213,6 +247,7 @@ constexpr bool test_unsigned() {
         q = _Unsigned128{0x01010101'01010101, 0x01010101'01010101} / _Unsigned128{13};
         assert(q._Word[0] == 0xc50013c5'0013c500);
         assert(q._Word[1] == 0x0013c500'13c50013);
+        assert(q == 0x0013c500'13c50013'c50013c5'0013c500__u128);
 
         q = _Unsigned128{0x22222222'22222222, 0x22222222'22222222}
           / _Unsigned128{0x11111111'11111111, 0x11111111'11111111};
@@ -262,16 +297,19 @@ constexpr bool test_unsigned() {
         const _Unsigned128 x{0x01020304'02030405, 0x03040506'04050607};
         const _Unsigned128 y{0x07060504'06050403, 0x05040302'04030101};
         assert(((x & y) == _Unsigned128{0x01020104'02010401, 0x01040102'04010001}));
+        assert(((x & y) == 0x01040102'04010001'01020104'02010401__u128));
         auto tmp = x;
         tmp &= y;
         assert(tmp == (x & y));
 
         assert(((x | y) == _Unsigned128{0x07060704'06070407, 0x07040706'04070707}));
+        assert(((x | y) == 0x07040706'04070707'07060704'06070407__u128));
         tmp = x;
         tmp |= y;
         assert(tmp == (x | y));
 
         assert(((x ^ y) == _Unsigned128{0x06040600'04060006, 0x06000604'00060706}));
+        assert(((x ^ y) == 0x06000604'00060706'06040600'04060006__u128));
         tmp = x;
         tmp ^= y;
         assert(tmp == (x ^ y));
@@ -308,79 +346,120 @@ constexpr bool test_unsigned() {
         assert(x._Word[0] == ~0ull);
         assert(x._Word[1] == static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max()));
     }
+    {
+        STATIC_ASSERT(noexcept(0__u128));
+        STATIC_ASSERT(noexcept(42__u128));
+        STATIC_ASSERT(noexcept(4'2__u128));
+        STATIC_ASSERT(noexcept(052__u128));
+        STATIC_ASSERT(noexcept(05'2__u128));
+        STATIC_ASSERT(noexcept(0x2a__u128));
+        STATIC_ASSERT(noexcept(0X2a__u128));
+        STATIC_ASSERT(noexcept(0x2A__u128));
+        STATIC_ASSERT(noexcept(0X2A__u128));
+        STATIC_ASSERT(noexcept(0x2'A__u128));
+        STATIC_ASSERT(noexcept(0b101010__u128));
+        STATIC_ASSERT(noexcept(0b1'0101'0__u128));
+        STATIC_ASSERT(noexcept(340282366920938463463374607431768211455__u128));
+        STATIC_ASSERT(noexcept(0xffffffff'FFFFFFFF'ffffFFFF'FFFFffff__u128));
+
+        STATIC_ASSERT(42__u128 == 42);
+        STATIC_ASSERT(42__u128 == 42);
+        STATIC_ASSERT(42__u128 == 052__u128);
+        STATIC_ASSERT(42__u128 == 05'2__u128);
+        STATIC_ASSERT(42__u128 == 0x2a__u128);
+        STATIC_ASSERT(42__u128 == 0X2'a__u128);
+        STATIC_ASSERT(42__u128 == 0b101010__u128);
+        STATIC_ASSERT(42__u128 == 0b101'010__u128);
+        STATIC_ASSERT(
+            340'2823'6692'0938'4634'6337'4607'4317'6821'1455__u128 == 0xffffffff'FFFFFFFF'ffffFFFF'FFFFffff__u128);
+
+        STATIC_ASSERT(
+            340'282'366'920'938'463'463'374'607'431'768'211'455__u128 == std::numeric_limits<_Unsigned128>::max());
+        STATIC_ASSERT(0xffffffff'ffffffff'ffffffff'ffffffff__u128 == std::numeric_limits<_Unsigned128>::max());
+    }
 
     return true;
 }
 
 constexpr bool test_signed() {
-    static_assert(std::regular<_Signed128>);
-    static_assert(std::three_way_comparable<_Signed128, std::strong_ordering>);
+#if _HAS_CXX20 && !defined(__EDG__) // TRANSITION, GH-395
+    STATIC_ASSERT(std::regular<_Signed128>);
+    STATIC_ASSERT(std::three_way_comparable<_Signed128, std::strong_ordering>);
+#endif // _HAS_CXX20 && !defined(__EDG__)
 
-    static_assert(std::numeric_limits<_Signed128>::min() == _Signed128{0, 1ull << 63});
-    static_assert(std::numeric_limits<_Signed128>::max() == _Signed128{~0ull, ~0ull >> 1});
-    static_assert(std::numeric_limits<_Signed128>::digits == 127);
-    static_assert(!std::numeric_limits<_Signed128>::is_modulo);
+    STATIC_ASSERT(std::numeric_limits<_Signed128>::min() == _Signed128{0, 1ull << 63});
+    STATIC_ASSERT(std::numeric_limits<_Signed128>::max() == _Signed128{~0ull, ~0ull >> 1});
+    STATIC_ASSERT(std::numeric_limits<_Signed128>::digits == 127);
+    STATIC_ASSERT(!std::numeric_limits<_Signed128>::is_modulo);
 
-    static_assert(std::same_as<std::common_type_t<bool, _Signed128>, _Signed128>);
-    static_assert(std::same_as<std::common_type_t<char, _Signed128>, _Signed128>);
-    static_assert(std::same_as<std::common_type_t<signed char, _Signed128>, _Signed128>);
-    static_assert(std::same_as<std::common_type_t<unsigned char, _Signed128>, _Signed128>);
-    static_assert(std::same_as<std::common_type_t<wchar_t, _Signed128>, _Signed128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<bool, _Signed128>, _Signed128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<char, _Signed128>, _Signed128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<signed char, _Signed128>, _Signed128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<unsigned char, _Signed128>, _Signed128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<wchar_t, _Signed128>, _Signed128>);
 #ifdef __cpp_char8_t
-    static_assert(std::same_as<std::common_type_t<char8_t, _Signed128>, _Signed128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<char8_t, _Signed128>, _Signed128>);
 #endif // __cpp_char8_t
-    static_assert(std::same_as<std::common_type_t<char16_t, _Signed128>, _Signed128>);
-    static_assert(std::same_as<std::common_type_t<char32_t, _Signed128>, _Signed128>);
-    static_assert(std::same_as<std::common_type_t<short, _Signed128>, _Signed128>);
-    static_assert(std::same_as<std::common_type_t<unsigned short, _Signed128>, _Signed128>);
-    static_assert(std::same_as<std::common_type_t<int, _Signed128>, _Signed128>);
-    static_assert(std::same_as<std::common_type_t<unsigned int, _Signed128>, _Signed128>);
-    static_assert(std::same_as<std::common_type_t<long, _Signed128>, _Signed128>);
-    static_assert(std::same_as<std::common_type_t<unsigned long, _Signed128>, _Signed128>);
-    static_assert(std::same_as<std::common_type_t<long long, _Signed128>, _Signed128>);
-    static_assert(std::same_as<std::common_type_t<unsigned long long, _Signed128>, _Signed128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<char16_t, _Signed128>, _Signed128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<char32_t, _Signed128>, _Signed128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<short, _Signed128>, _Signed128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<unsigned short, _Signed128>, _Signed128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<int, _Signed128>, _Signed128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<unsigned int, _Signed128>, _Signed128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<long, _Signed128>, _Signed128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<unsigned long, _Signed128>, _Signed128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<long long, _Signed128>, _Signed128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<unsigned long long, _Signed128>, _Signed128>);
 
-    static_assert(std::same_as<std::common_type_t<_Signed128, bool>, _Signed128>);
-    static_assert(std::same_as<std::common_type_t<_Signed128, char>, _Signed128>);
-    static_assert(std::same_as<std::common_type_t<_Signed128, signed char>, _Signed128>);
-    static_assert(std::same_as<std::common_type_t<_Signed128, unsigned char>, _Signed128>);
-    static_assert(std::same_as<std::common_type_t<_Signed128, wchar_t>, _Signed128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<_Signed128, bool>, _Signed128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<_Signed128, char>, _Signed128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<_Signed128, signed char>, _Signed128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<_Signed128, unsigned char>, _Signed128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<_Signed128, wchar_t>, _Signed128>);
 #ifdef __cpp_char8_t
-    static_assert(std::same_as<std::common_type_t<_Signed128, char8_t>, _Signed128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<_Signed128, char8_t>, _Signed128>);
 #endif // __cpp_char8_t
-    static_assert(std::same_as<std::common_type_t<_Signed128, char16_t>, _Signed128>);
-    static_assert(std::same_as<std::common_type_t<_Signed128, char32_t>, _Signed128>);
-    static_assert(std::same_as<std::common_type_t<_Signed128, short>, _Signed128>);
-    static_assert(std::same_as<std::common_type_t<_Signed128, unsigned short>, _Signed128>);
-    static_assert(std::same_as<std::common_type_t<_Signed128, int>, _Signed128>);
-    static_assert(std::same_as<std::common_type_t<_Signed128, unsigned int>, _Signed128>);
-    static_assert(std::same_as<std::common_type_t<_Signed128, long>, _Signed128>);
-    static_assert(std::same_as<std::common_type_t<_Signed128, unsigned long>, _Signed128>);
-    static_assert(std::same_as<std::common_type_t<_Signed128, long long>, _Signed128>);
-    static_assert(std::same_as<std::common_type_t<_Signed128, unsigned long long>, _Signed128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<_Signed128, char16_t>, _Signed128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<_Signed128, char32_t>, _Signed128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<_Signed128, short>, _Signed128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<_Signed128, unsigned short>, _Signed128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<_Signed128, int>, _Signed128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<_Signed128, unsigned int>, _Signed128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<_Signed128, long>, _Signed128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<_Signed128, unsigned long>, _Signed128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<_Signed128, long long>, _Signed128>);
+    STATIC_ASSERT(SAME_AS<std::common_type_t<_Signed128, unsigned long long>, _Signed128>);
 
-    static_assert(std::_Integer_class<_Signed128>);
-    static_assert(std::_Integer_like<_Signed128>);
-    static_assert(std::_Signed_integer_like<_Signed128>);
-    static_assert(std::same_as<std::_Make_unsigned_like_t<_Signed128>, _Unsigned128>);
-    static_assert(std::same_as<std::_Make_signed_like_t<_Signed128>, _Signed128>);
+#if _HAS_CXX20 && !defined(__EDG__) // TRANSITION, GH-395
+    STATIC_ASSERT(std::_Integer_class<_Signed128>);
+    STATIC_ASSERT(std::_Integer_like<_Signed128>);
+    STATIC_ASSERT(std::_Signed_integer_like<_Signed128>);
+    STATIC_ASSERT(SAME_AS<std::_Make_unsigned_like_t<_Signed128>, _Unsigned128>);
+    STATIC_ASSERT(SAME_AS<std::_Make_signed_like_t<_Signed128>, _Signed128>);
+#endif // _HAS_CXX20 && !defined(__EDG__)
 
     check_equal(_Signed128{});
     check_equal(_Signed128{42});
     check_equal(_Signed128{-42});
     check_equal(_Signed128{0x11111111'11111111, 0x22222222'22222222});
+    check_equal(0x22222222'22222222'11111111'11111111__i128);
 
+#if _HAS_CXX20
     check_order(_Signed128{42}, _Signed128{-42}, std::strong_ordering::greater);
     check_order(_Signed128{0x11111111'11111111, 0x22222222'22222222},
         _Signed128{0x01010101'01010101, 0x01010101'01010101}, std::strong_ordering::greater);
+    check_order(0x22222222'22222222'11111111'11111111__i128, 0x01010101'01010101'01010101'01010101__i128,
+        std::strong_ordering::greater);
     check_order(_Signed128{~0ull, ~0ull}, _Signed128{-1}, std::strong_ordering::equal);
 
     check_order(_Signed128{-2}, _Signed128{-1}, std::strong_ordering::less);
     check_order(_Signed128{-2}, _Signed128{1}, std::strong_ordering::less);
     check_order(_Signed128{2}, _Signed128{-1}, std::strong_ordering::greater);
     check_order(_Signed128{2}, _Signed128{1}, std::strong_ordering::greater);
+#endif // _HAS_CXX20
 
     check_equal(_Signed128{0, 0});
+#if _HAS_CXX20
     check_order(_Signed128{0, (1ull << 63)}, _Signed128{0, 0}, std::strong_ordering::less);
     check_order(_Signed128{0, (1ull << 63)}, _Signed128{0, (1ull << 63)}, std::strong_ordering::equal);
     check_order(_Signed128{0, 0}, _Signed128{1, 0}, std::strong_ordering::less);
@@ -392,6 +471,7 @@ constexpr bool test_signed() {
     check_order(_Signed128{0, 0}, _Signed128{1, 1}, std::strong_ordering::less);
     check_order(_Signed128{0, (1ull << 63)}, _Signed128{1, 1}, std::strong_ordering::less);
     check_order(_Signed128{0, (1ull << 63)}, _Signed128{1, 1 | (1ull << 63)}, std::strong_ordering::less);
+#endif // _HAS_CXX20
 
     assert((_Signed128{-2} == _Unsigned128{0ull - 2, ~0ull}));
     assert((_Unsigned128{_Signed128{-2}} == _Unsigned128{0ull - 2, ~0ull}));
@@ -497,16 +577,19 @@ constexpr bool test_signed() {
     }
     {
         auto product = _Signed128{0x01010101'01010101, 0x01010101'01010101} * 5;
+        assert(product == 0x05050505'05050505'05050505'05050505__i128);
         assert(product._Word[0] == 0x05050505'05050505);
         assert(product._Word[1] == 0x05050505'05050505);
 
         product = 5 * _Signed128{0x01010101'01010101, 0x01010101'01010101};
+        assert(product == 0x05050505'05050505'05050505'05050505__i128);
         assert(product._Word[0] == 0x05050505'05050505);
         assert(product._Word[1] == 0x05050505'05050505);
     }
     {
         auto product = _Signed128{0x01010101'01010101, 0x01010101'01010101};
         product *= product;
+        assert(product == 0x100f0e0d'0c0b0a09'08070605'04030201__i128);
         assert(product._Word[0] == 0x08070605'04030201);
         assert(product._Word[1] == 0x100f0e0d'0c0b0a09);
         assert(+product == product);
@@ -515,18 +598,21 @@ constexpr bool test_signed() {
     {
         auto product =
             _Signed128{0x01020304'05060708, 0x090a0b0c'0d0e0f00} * _Signed128{0x000f0e0d'0c0b0a09, 0x08070605'04030201};
+        assert(product == -0x23e49431'bc3293de'923e71aa'e92b70b8__i128);
         assert(product._Word[0] == 0x6dc18e55'16d48f48);
         assert(product._Word[1] == 0xdc1b6bce'43cd6c21);
         assert(+product == product);
         assert(-product + product == 0);
 
         product <<= 11;
+        assert(product == -0x24a18de1'949ef491'f38d5749'5b85c000__i128);
         assert(product._Word[0] == 0x0c72a8b6'a47a4000);
         assert(product._Word[1] == 0xdb5e721e'6b610b6e);
         assert(+product == product);
         assert(-product + product == 0);
 
         product >>= 17;
+        assert(product == -0x00001250'c6f0ca4f'7a48f9c6'aba4adc3__i128);
         assert(product._Word[0] == 0x85b70639'545b523d);
         assert(product._Word[1] == 0xffffedaf'390f35b0);
         assert(+product == product);
@@ -566,6 +652,7 @@ constexpr bool test_signed() {
         assert(q._Word[1] == 0);
 
         q = _Signed128{0x01010101'01010101, 0x01010101'01010101} / _Signed128{13};
+        assert(q == 0x0013c500'13c50013'c50013c5'0013c500__i128);
         assert(q._Word[0] == 0xc50013c5'0013c500);
         assert(q._Word[1] == 0x0013c500'13c50013);
 
@@ -658,16 +745,19 @@ constexpr bool test_signed() {
         const _Signed128 x{0x01020304'02030405, 0x03040506'04050607};
         const _Signed128 y{0x07060504'06050403, 0x05040302'04030101};
         assert(((x & y) == _Signed128{0x01020104'02010401, 0x01040102'04010001}));
+        assert(((x & y) == 0x01040102'04010001'01020104'02010401__i128));
         auto tmp = x;
         tmp &= y;
         assert(tmp == (x & y));
 
         assert(((x | y) == _Signed128{0x07060704'06070407, 0x07040706'04070707}));
+        assert(((x | y) == 0x07040706'04070707'07060704'06070407__i128));
         tmp = x;
         tmp |= y;
         assert(tmp == (x | y));
 
         assert(((x ^ y) == _Signed128{0x06040600'04060006, 0x06000604'00060706}));
+        assert(((x ^ y) == 0x06000604'00060706'06040600'04060006__i128));
         tmp = x;
         tmp ^= y;
         assert(tmp == (x ^ y));
@@ -704,6 +794,41 @@ constexpr bool test_signed() {
         assert(x._Word[1] == static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max()));
         assert(x == std::numeric_limits<_Signed128>::max());
     }
+    {
+        STATIC_ASSERT(noexcept(0__i128));
+        STATIC_ASSERT(noexcept(42__i128));
+        STATIC_ASSERT(noexcept(4'2__i128));
+        STATIC_ASSERT(noexcept(052__i128));
+        STATIC_ASSERT(noexcept(05'2__i128));
+        STATIC_ASSERT(noexcept(0x2a__i128));
+        STATIC_ASSERT(noexcept(0X2a__i128));
+        STATIC_ASSERT(noexcept(0x2A__i128));
+        STATIC_ASSERT(noexcept(0X2A__i128));
+        STATIC_ASSERT(noexcept(0x2'A__i128));
+        STATIC_ASSERT(noexcept(0b101010__i128));
+        STATIC_ASSERT(noexcept(0b1'0101'0__i128));
+        STATIC_ASSERT(noexcept(170141183460469231731687303715884105727__i128));
+        STATIC_ASSERT(noexcept(0x7fffffff'FFFFFFFF'ffffFFFF'FFFFffff__i128));
+
+        STATIC_ASSERT(42__i128 == 42);
+        STATIC_ASSERT(42__i128 == 42);
+        STATIC_ASSERT(42__i128 == 052__i128);
+        STATIC_ASSERT(42__i128 == 05'2__i128);
+        STATIC_ASSERT(42__i128 == 0x2a__i128);
+        STATIC_ASSERT(42__i128 == 0X2'a__i128);
+        STATIC_ASSERT(42__i128 == 0b101010__i128);
+        STATIC_ASSERT(42__i128 == 0b101'010__i128);
+        STATIC_ASSERT(
+            170'1411'8346'0469'2317'3168'7303'7158'8410'5727__i128 == 0x7fffffff'FFFFFFFF'ffffFFFF'FFFFffff__i128);
+
+        STATIC_ASSERT(
+            170'141'183'460'469'231'731'687'303'715'884'105'727__i128 == std::numeric_limits<_Signed128>::max());
+        STATIC_ASSERT(0x7fffffff'ffffffff'ffffffff'ffffffff__i128 == std::numeric_limits<_Signed128>::max());
+
+        STATIC_ASSERT(
+            -170'141'183'460'469'231'731'687'303'715'884'105'727__i128 - 1 == std::numeric_limits<_Signed128>::min());
+        STATIC_ASSERT(-0x7fffffff'ffffffff'ffffffff'ffffffff__i128 - 1 == std::numeric_limits<_Signed128>::min());
+    }
 
     return true;
 }
@@ -711,18 +836,26 @@ constexpr bool test_signed() {
 template <class T>
 T val() noexcept;
 
+#if _HAS_CXX20 && !defined(__EDG__) // TRANSITION, GH-395
 template <class T, class U>
 concept CanConditional = requires {
     true ? val<T>() : val<U>();
 };
+#else // ^^^ has concepts / vvv has no concepts
+template <class T, class U, class = void>
+constexpr bool CanConditional = false;
+
+template <class T, class U>
+constexpr bool CanConditional<T, U, std::void_t<decltype(true ? val<T>() : val<U>())>> = true;
+#endif // _HAS_CXX20 && !defined(__EDG__)
 
 constexpr bool test_cross() {
     // Test the behavior of cross-type operations.
 
-#define TEST(expr, result)                                                                      \
-    do {                                                                                        \
-        static_assert(std::same_as<decltype((expr)), std::remove_const_t<decltype((result))>>); \
-        assert((expr) == (result));                                                             \
+#define TEST(expr, result)                                                                 \
+    do {                                                                                   \
+        STATIC_ASSERT(SAME_AS<decltype((expr)), std::remove_const_t<decltype((result))>>); \
+        assert((expr) == (result));                                                        \
     } while (0)
 
     //////// Mixed integer-class operands
@@ -764,14 +897,16 @@ constexpr bool test_cross() {
     // convertible only to wider types, or types of the same width and
     // signedness. Consequently, the conditional operator should reject integer-
     // class operands with the same width but differing signedness.
-    static_assert(!CanConditional<_Unsigned128, _Signed128>);
-    static_assert(!CanConditional<_Signed128, _Unsigned128>);
+    STATIC_ASSERT(!CanConditional<_Unsigned128, _Signed128>);
+    STATIC_ASSERT(!CanConditional<_Signed128, _Unsigned128>);
 
+#if _HAS_CXX20 && !defined(__EDG__) // TRANSITION, GH-395
     // Conversions between integer-class types with the same width and differing
     // signedness are narrowing, so the three-way comparison operator should
     // reject mixed operands of such types.
-    static_assert(!std::three_way_comparable_with<_Unsigned128, _Signed128>);
-    static_assert(!std::three_way_comparable_with<_Signed128, _Unsigned128>);
+    STATIC_ASSERT(!std::three_way_comparable_with<_Unsigned128, _Signed128>);
+    STATIC_ASSERT(!std::three_way_comparable_with<_Signed128, _Unsigned128>);
+#endif // _HAS_CXX20 && !defined(__EDG__)
 
     // Other comparison operators behave as they do for operands of mixed
     // integral types; when the operands have the same width, the signed operand
@@ -917,6 +1052,7 @@ constexpr bool test_cross() {
     TEST(true ? 42 : _Signed128{13}, _Signed128{42});
     TEST(true ? 42 : _Unsigned128{13}, _Unsigned128{42});
 
+#if _HAS_CXX20
     // (meow <=> 0) here is a hack to get prvalues
     TEST(4 <=> _Unsigned128{3}, (std::strong_ordering::greater <=> 0));
     TEST(4 <=> _Signed128{3}, (std::strong_ordering::greater <=> 0));
@@ -930,6 +1066,7 @@ constexpr bool test_cross() {
     TEST(-3 <=> _Signed128{3}, (std::strong_ordering::less <=> 0));
     TEST(_Signed128{-3} <=> 3, (std::strong_ordering::less <=> 0));
     TEST(_Unsigned128{-3} <=> 3, (std::strong_ordering::greater <=> 0));
+#endif // _HAS_CXX20
 
     // Other comparison operators behave as they do for operands of mixed
     // integral types; when the operands have the same width, the signed operand
@@ -1041,9 +1178,9 @@ constexpr bool test_cross() {
 
 int main() {
     test_unsigned();
-    static_assert(test_unsigned());
+    STATIC_ASSERT(test_unsigned());
     test_signed();
-    static_assert(test_signed());
+    STATIC_ASSERT(test_signed());
     test_cross();
-    static_assert(test_cross());
+    STATIC_ASSERT(test_cross());
 }


### PR DESCRIPTION
Thanks to @MattStephanson for having done the most works in #3012. As mentioned in #3012, having 128-bit integer-like types in all modes is useful for random number generation. 

This PR also provides a library solution for DevCom-879048 with literal suffixes (`__i128` and `__u128`) support.