### PR TITLE
`.vscode/settings.json`: Teach Pylance about our paths

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,5 +20,10 @@
     },
     "files.insertFinalNewline": true,
     "files.trimFinalNewlines": true,
-    "files.trimTrailingWhitespace": true
+    "files.trimTrailingWhitespace": true,
+    "python.analysis.extraPaths": [
+        "./llvm-project/libcxx/utils",
+        "./llvm-project/llvm/utils/lit",
+        "./tests/utils"
+    ]
 }


### PR DESCRIPTION
This tells VSCode's Python extension, Pylance, where to find our test support machinery, so that modules can be fully resolved without squiggles.

(I found these paths by the ultra-scientific method of opening all of our `.py` files, and seeing which modules generated squiggles. With these paths, only `psutil` needs to be installed locally in order to resolve one remaining squiggle.)

:snake: