### PR TITLE
`_Fake_copy_init` unification

### DIFF
--- a/stl/inc/expected
+++ b/stl/inc/expected
@@ -99,7 +99,7 @@ public:
     // [expected.un.eq]
     template <class _UErr>
     _NODISCARD_FRIEND constexpr bool operator==(const unexpected& _Left, const unexpected<_UErr>& _Right) noexcept( //
-        noexcept(_Implicitly_convert_to<bool>(_Left._Unexpected == _Right.error()))) { // strengthened
+        noexcept(_Fake_copy_init<bool>(_Left._Unexpected == _Right.error()))) { // strengthened
         return _Left._Unexpected == _Right.error();
     }
 
@@ -702,8 +702,8 @@ public:
     template <class _Uty, class _UErr>
         requires (!is_void_v<_Uty>)
     _NODISCARD_FRIEND constexpr bool operator==(const expected& _Left, const expected<_Uty, _UErr>& _Right) noexcept(
-        noexcept(_Implicitly_convert_to<bool>(_Left._Value == *_Right)) && noexcept(
-            _Implicitly_convert_to<bool>(_Left._Unexpected == _Right.error()))) { // strengthened
+        noexcept(_Fake_copy_init<bool>(_Left._Value == *_Right)) && noexcept(
+            _Fake_copy_init<bool>(_Left._Unexpected == _Right.error()))) { // strengthened
         // clang-format on
         if (_Left._Has_value != _Right.has_value()) {
             return false;

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -1891,7 +1891,7 @@ namespace ranges {
             }
 
             _NODISCARD constexpr bool _Equal(const sentinel_t<_Vw>& _Last) const
-                noexcept(noexcept(_Implicitly_convert_to<bool>(_Current == _Last))) {
+                noexcept(noexcept(_Fake_copy_init<bool>(_Current == _Last))) {
                 return _Current == _Last;
             }
         };
@@ -3396,7 +3396,7 @@ namespace ranges {
 
             // clang-format off
             _NODISCARD_FRIEND constexpr bool operator==(const _Iterator& _Left, const _Iterator& _Right) noexcept(
-                noexcept(_Implicitly_convert_to<bool>(_Left._Outer == _Right._Outer
+                noexcept(_Fake_copy_init<bool>(_Left._Outer == _Right._Outer
                     && _Left._Inner == _Right._Inner))) /* strengthened */
                 requires _Deref_is_glvalue && equality_comparable<_OuterIter> && equality_comparable<_InnerIter> {
                 // clang-format on
@@ -3447,7 +3447,7 @@ namespace ranges {
             template <bool _OtherConst>
                 requires sentinel_for<sentinel_t<_Base>, _Maybe_const_iter<_OtherConst>>
             _NODISCARD constexpr bool _Equal(const _Iterator<_OtherConst>& _It) const noexcept(
-                    noexcept(_Implicitly_convert_to<bool>(_It._Outer == _Last))) {
+                    noexcept(_Fake_copy_init<bool>(_It._Outer == _Last))) {
                 // clang-format on
                 return _It._Outer == _Last;
             }
@@ -3905,7 +3905,7 @@ namespace ranges {
 
             template <bool _OtherConst>
             _NODISCARD constexpr bool _Equal(const _Iterator<_OtherConst>& _It) const
-                noexcept(noexcept(_Implicitly_convert_to<bool>(_It._Outer_it == _Last))) {
+                noexcept(noexcept(_Fake_copy_init<bool>(_It._Outer_it == _Last))) {
                 _STL_INTERNAL_STATIC_ASSERT(
                     sentinel_for<sentinel_t<_Base>, iterator_t<_Maybe_const<_OtherConst, _Vw>>>);
                 return _It._Outer_it == _Last;
@@ -4113,7 +4113,7 @@ namespace ranges {
             }
 
             _NODISCARD constexpr bool _At_end() const
-                noexcept(noexcept(_Implicitly_convert_to<bool>(_Get_current() == _RANGES end(_Parent->_Range)))) {
+                noexcept(noexcept(_Fake_copy_init<bool>(_Get_current() == _RANGES end(_Parent->_Range)))) {
                 return _Get_current() == _RANGES end(_Parent->_Range);
             }
 
@@ -4534,7 +4534,7 @@ namespace ranges {
             /* [[no_unique_address]] */ sentinel_t<_Vw> _Last{};
 
             _NODISCARD constexpr bool _Equal(const _Iterator& _It) const
-                noexcept(noexcept(_Implicitly_convert_to<bool>(_It._Current == _Last))) {
+                noexcept(noexcept(_Fake_copy_init<bool>(_It._Current == _Last))) {
                 return !_It._Trailing_empty && _It._Current == _Last;
             }
 
@@ -5727,35 +5727,35 @@ namespace ranges {
             }
 
             _NODISCARD_FRIEND constexpr bool operator==(const _Iterator& _Left, const _Iterator& _Right) noexcept(
-                noexcept(_Implicitly_convert_to<bool>(_Left._Current == _Right._Current))) /* strengthened */ {
+                noexcept(_Fake_copy_init<bool>(_Left._Current == _Right._Current))) /* strengthened */ {
                 return _Left._Current == _Right._Current;
             }
 
             _NODISCARD_FRIEND constexpr bool operator==(const _Iterator& _Left, default_sentinel_t) noexcept(
-                noexcept(_Implicitly_convert_to<bool>(_Left._Current == _Left._End))) /* strengthened */ {
+                noexcept(_Fake_copy_init<bool>(_Left._Current == _Left._End))) /* strengthened */ {
                 return _Left._Current == _Left._End;
             }
 
             _NODISCARD_FRIEND constexpr bool operator<(const _Iterator& _Left, const _Iterator& _Right) noexcept(
-                noexcept(_Implicitly_convert_to<bool>(_Left._Current < _Right._Current))) /* strengthened */
+                noexcept(_Fake_copy_init<bool>(_Left._Current < _Right._Current))) /* strengthened */
                 requires random_access_range<_Base> {
                 return _Left._Current < _Right._Current;
             }
 
             _NODISCARD_FRIEND constexpr bool operator>(const _Iterator& _Left, const _Iterator& _Right) noexcept(
-                noexcept(_Implicitly_convert_to<bool>(_Right._Current < _Left._Current))) /* strengthened */
+                noexcept(_Fake_copy_init<bool>(_Right._Current < _Left._Current))) /* strengthened */
                 requires random_access_range<_Base> {
                 return _Right._Current < _Left._Current;
             }
 
             _NODISCARD_FRIEND constexpr bool operator<=(const _Iterator& _Left, const _Iterator& _Right) noexcept(
-                noexcept(_Implicitly_convert_to<bool>(!(_Right._Current < _Left._Current)))) /* strengthened */
+                noexcept(_Fake_copy_init<bool>(!(_Right._Current < _Left._Current)))) /* strengthened */
                 requires random_access_range<_Base> {
                 return !(_Right._Current < _Left._Current);
             }
 
             _NODISCARD_FRIEND constexpr bool operator>=(const _Iterator& _Left, const _Iterator& _Right) noexcept(
-                noexcept(_Implicitly_convert_to<bool>(!(_Left._Current < _Right._Current)))) /* strengthened */
+                noexcept(_Fake_copy_init<bool>(!(_Left._Current < _Right._Current)))) /* strengthened */
                 requires random_access_range<_Base> {
                 return !(_Left._Current < _Right._Current);
             }
@@ -6065,7 +6065,7 @@ namespace ranges {
             }
 
             _NODISCARD_FRIEND constexpr bool operator==(const _Iterator& _Left, const _Iterator& _Right) noexcept(
-                noexcept(_Implicitly_convert_to<bool>(_Left._Current == _Right._Current))) /* strengthened */ {
+                noexcept(_Fake_copy_init<bool>(_Left._Current == _Right._Current))) /* strengthened */ {
                 if constexpr (_Slide_caches_first<_Base>) {
                     return _Left._Last_element == _Right._Last_element;
                 } else {
@@ -6074,25 +6074,25 @@ namespace ranges {
             }
 
             _NODISCARD_FRIEND constexpr bool operator<(const _Iterator& _Left, const _Iterator& _Right) noexcept(
-                noexcept(_Implicitly_convert_to<bool>(_Left._Current < _Right._Current))) /* strengthened */
+                noexcept(_Fake_copy_init<bool>(_Left._Current < _Right._Current))) /* strengthened */
                 requires random_access_range<_Base> {
                 return _Left._Current < _Right._Current;
             }
 
             _NODISCARD_FRIEND constexpr bool operator>(const _Iterator& _Left, const _Iterator& _Right) noexcept(
-                noexcept(_Implicitly_convert_to<bool>(_Right._Current < _Left._Current))) /* strengthened */
+                noexcept(_Fake_copy_init<bool>(_Right._Current < _Left._Current))) /* strengthened */
                 requires random_access_range<_Base> {
                 return _Right._Current < _Left._Current;
             }
 
             _NODISCARD_FRIEND constexpr bool operator<=(const _Iterator& _Left, const _Iterator& _Right) noexcept(
-                noexcept(_Implicitly_convert_to<bool>(!(_Right._Current < _Left._Current)))) /* strengthened */
+                noexcept(_Fake_copy_init<bool>(!(_Right._Current < _Left._Current)))) /* strengthened */
                 requires random_access_range<_Base> {
                 return !(_Right._Current < _Left._Current);
             }
 
             _NODISCARD_FRIEND constexpr bool operator>=(const _Iterator& _Left, const _Iterator& _Right) noexcept(
-                noexcept(_Implicitly_convert_to<bool>(!(_Left._Current < _Right._Current)))) /* strengthened */
+                noexcept(_Fake_copy_init<bool>(!(_Left._Current < _Right._Current)))) /* strengthened */
                 requires random_access_range<_Base> {
                 return !(_Left._Current < _Right._Current);
             }
@@ -6151,8 +6151,8 @@ namespace ranges {
             _Sentinel() = default;
 
             _NODISCARD_FRIEND constexpr bool
-                operator==(const _Iterator<false>& _Left, const _Sentinel& _Right) noexcept(noexcept(
-                    _Implicitly_convert_to<bool>(_Left._Get_last_element() == _Right._Last))) /* strengthened */ {
+                operator==(const _Iterator<false>& _Left, const _Sentinel& _Right) noexcept(
+                    noexcept(_Fake_copy_init<bool>(_Left._Get_last_element() == _Right._Last))) /* strengthened */ {
                 return _Left._Get_last_element() == _Right._Last;
             }
 
@@ -6375,12 +6375,12 @@ namespace ranges {
             }
 
             _NODISCARD_FRIEND constexpr bool operator==(const _Iterator& _Left, const _Iterator& _Right) noexcept(
-                noexcept(_Implicitly_convert_to<bool>(_Left._Current == _Right._Current))) /* strengthened */ {
+                noexcept(_Fake_copy_init<bool>(_Left._Current == _Right._Current))) /* strengthened */ {
                 return _Left._Current == _Right._Current;
             }
 
             _NODISCARD_FRIEND constexpr bool operator==(const _Iterator& _Left, default_sentinel_t) noexcept(
-                noexcept(_Implicitly_convert_to<bool>(_Left._Current == _Left._Next))) /* strengthened */ {
+                noexcept(_Fake_copy_init<bool>(_Left._Current == _Left._Next))) /* strengthened */ {
                 return _Left._Current == _Left._Next;
             }
         };
@@ -6630,36 +6630,36 @@ namespace ranges {
             }
 
             _NODISCARD_FRIEND constexpr bool operator==(const _Iterator& _It, default_sentinel_t) noexcept(
-                noexcept(_Implicitly_convert_to<bool>(_It._Current == _It._End))) /* strengthened */ {
+                noexcept(_Fake_copy_init<bool>(_It._Current == _It._End))) /* strengthened */ {
                 return _It._Current == _It._End;
             }
 
             _NODISCARD_FRIEND constexpr bool operator==(const _Iterator& _Left, const _Iterator& _Right) noexcept(
-                noexcept(_Implicitly_convert_to<bool>(_Left._Current == _Right._Current))) // strengthened
+                noexcept(_Fake_copy_init<bool>(_Left._Current == _Right._Current))) // strengthened
                 requires equality_comparable<_Base_iterator> {
                 return _Left._Current == _Right._Current;
             }
 
             _NODISCARD_FRIEND constexpr bool operator<(const _Iterator& _Left, const _Iterator& _Right) noexcept(
-                noexcept(_Implicitly_convert_to<bool>(_Left._Current < _Right._Current))) // strengthened
+                noexcept(_Fake_copy_init<bool>(_Left._Current < _Right._Current))) // strengthened
                 requires random_access_range<_Base> {
                 return _Left._Current < _Right._Current;
             }
 
             _NODISCARD_FRIEND constexpr bool operator>(const _Iterator& _Left, const _Iterator& _Right) noexcept(
-                noexcept(_Implicitly_convert_to<bool>(_Right._Current < _Left._Current))) // strengthened
+                noexcept(_Fake_copy_init<bool>(_Right._Current < _Left._Current))) // strengthened
                 requires random_access_range<_Base> {
                 return _Right._Current < _Left._Current;
             }
 
             _NODISCARD_FRIEND constexpr bool operator<=(const _Iterator& _Left, const _Iterator& _Right) noexcept(
-                noexcept(_Implicitly_convert_to<bool>(!(_Right._Current < _Left._Current)))) // strengthened
+                noexcept(_Fake_copy_init<bool>(!(_Right._Current < _Left._Current)))) // strengthened
                 requires random_access_range<_Base> {
                 return !(_Right._Current < _Left._Current);
             }
 
             _NODISCARD_FRIEND constexpr bool operator>=(const _Iterator& _Left, const _Iterator& _Right) noexcept(
-                noexcept(_Implicitly_convert_to<bool>(!(_Left._Current < _Right._Current)))) // strengthened
+                noexcept(_Fake_copy_init<bool>(!(_Left._Current < _Right._Current)))) // strengthened
                 requires random_access_range<_Base> {
                 return !(_Left._Current < _Right._Current);
             }

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -1590,19 +1590,9 @@ _CONSTEXPR17 auto invoke(_Callable&& _Obj, _Ty1&& _Arg1, _Types2&&... _Args2) no
 #pragma warning(disable : 4242) // '%s': conversion from '%s' to '%s', possible loss of data (/Wall)
 #pragma warning(disable : 4244) // '%s': conversion from '%s' to '%s', possible loss of data (Yes, duplicated message.)
 #pragma warning(disable : 4365) // '%s': conversion from '%s' to '%s', signed/unsigned mismatch (/Wall)
-#pragma warning(disable : 5215) // '%s' a function parameter with a volatile qualified type is deprecated in C++20
-
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-volatile"
-#endif // __clang__
 
 template <class _From, class _To, bool = is_convertible_v<_From, _To>, bool = is_void_v<_To>>
 _INLINE_VAR constexpr bool _Is_nothrow_convertible_v = noexcept(_Fake_copy_init<_To>(_STD declval<_From>()));
-
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif // __clang__
 
 #pragma warning(pop)
 

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -1597,13 +1597,8 @@ _CONSTEXPR17 auto invoke(_Callable&& _Obj, _Ty1&& _Arg1, _Types2&&... _Args2) no
 #pragma clang diagnostic ignored "-Wdeprecated-volatile"
 #endif // __clang__
 
-// Note that this is equivalent to xstddef's _Fake_copy_init (and _Fake_decay_copy).
-// TRANSITION, replace _Implicitly_convert_to with _Fake_copy_init.
-template <class _To>
-void _Implicitly_convert_to(_To) noexcept; // not defined
-
 template <class _From, class _To, bool = is_convertible_v<_From, _To>, bool = is_void_v<_To>>
-_INLINE_VAR constexpr bool _Is_nothrow_convertible_v = noexcept(_Implicitly_convert_to<_To>(_STD declval<_From>()));
+_INLINE_VAR constexpr bool _Is_nothrow_convertible_v = noexcept(_Fake_copy_init<_To>(_STD declval<_From>()));
 
 #ifdef __clang__
 #pragma clang diagnostic pop
@@ -1634,11 +1629,11 @@ template <class _From, class _To, class = void>
 struct _Invoke_convertible : false_type {};
 
 template <class _From, class _To>
-struct _Invoke_convertible<_From, _To, void_t<decltype(_Implicitly_convert_to<_To>(_Returns_exactly<_From>()))>>
-    : true_type {};
+struct _Invoke_convertible<_From, _To, void_t<decltype(_Fake_copy_init<_To>(_Returns_exactly<_From>()))>> : true_type {
+};
 
 template <class _From, class _To>
-struct _Invoke_nothrow_convertible : bool_constant<noexcept(_Implicitly_convert_to<_To>(_Returns_exactly<_From>()))> {};
+struct _Invoke_nothrow_convertible : bool_constant<noexcept(_Fake_copy_init<_To>(_Returns_exactly<_From>()))> {};
 
 template <class _Result, bool _Nothrow>
 struct _Invoke_traits_common {

--- a/stl/inc/xstddef
+++ b/stl/inc/xstddef
@@ -42,10 +42,8 @@ struct binary_function { // base class for binary functions
 #endif // _HAS_AUTO_PTR_ETC
 
 #pragma warning(push)
-#pragma warning(disable : 4242) // '%s': conversion from '%s' to '%s', possible loss of data (/Wall)
-#pragma warning(disable : 4244) // '%s': conversion from '%s' to '%s', possible loss of data (Yes, duplicated message.)
-#pragma warning(disable : 4365) // '%s': conversion from '%s' to '%s', signed/unsigned mismatch (/Wall)
 #pragma warning(disable : 5215) // '%s' a function parameter with a volatile qualified type is deprecated in C++20
+#pragma warning(disable : 5216) // '%s' a volatile qualified return type is deprecated in C++20
 
 #ifdef __clang__
 #pragma clang diagnostic push

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -1216,7 +1216,7 @@ _INLINE_VAR constexpr bool _Has_nothrow_operator_arrow = _Is_nothrow_convertible
 
 template <class _Iter, class _Pointer>
 _INLINE_VAR constexpr bool _Has_nothrow_operator_arrow<_Iter, _Pointer, false> = noexcept(
-    _Implicitly_convert_to<_Pointer>(_STD declval<_Iter>().operator->()));
+    _Fake_copy_init<_Pointer>(_STD declval<_Iter>().operator->()));
 
 template <class _BidIt>
 class reverse_iterator {
@@ -1339,7 +1339,7 @@ public:
     }
 
     _NODISCARD _CONSTEXPR17 reference operator[](const difference_type _Off) const
-        noexcept(noexcept(_Implicitly_convert_to<reference>(current[_Off]))) /* strengthened */ {
+        noexcept(noexcept(_Fake_copy_init<reference>(current[_Off]))) /* strengthened */ {
         return current[static_cast<difference_type>(-_Off - 1)];
     }
 
@@ -1406,7 +1406,7 @@ protected:
 template <class _BidIt1, class _BidIt2>
 _NODISCARD _CONSTEXPR17 bool
     operator==(const reverse_iterator<_BidIt1>& _Left, const reverse_iterator<_BidIt2>& _Right) noexcept(
-        noexcept(_Implicitly_convert_to<bool>(_Left._Get_current() == _Right._Get_current()))) /* strengthened */
+        noexcept(_Fake_copy_init<bool>(_Left._Get_current() == _Right._Get_current()))) /* strengthened */
 #ifdef __cpp_lib_concepts
     // clang-format off
     requires requires {
@@ -1419,7 +1419,7 @@ _NODISCARD _CONSTEXPR17 bool
 template <class _BidIt1, class _BidIt2>
 _NODISCARD _CONSTEXPR17 bool
     operator!=(const reverse_iterator<_BidIt1>& _Left, const reverse_iterator<_BidIt2>& _Right) noexcept(
-        noexcept(_Implicitly_convert_to<bool>(_Left._Get_current() != _Right._Get_current()))) /* strengthened */
+        noexcept(_Fake_copy_init<bool>(_Left._Get_current() != _Right._Get_current()))) /* strengthened */
 #ifdef __cpp_lib_concepts
     // clang-format off
     requires requires {
@@ -1432,7 +1432,7 @@ _NODISCARD _CONSTEXPR17 bool
 template <class _BidIt1, class _BidIt2>
 _NODISCARD _CONSTEXPR17 bool
     operator<(const reverse_iterator<_BidIt1>& _Left, const reverse_iterator<_BidIt2>& _Right) noexcept(
-        noexcept(_Implicitly_convert_to<bool>(_Left._Get_current() > _Right._Get_current()))) /* strengthened */
+        noexcept(_Fake_copy_init<bool>(_Left._Get_current() > _Right._Get_current()))) /* strengthened */
 #ifdef __cpp_lib_concepts
     // clang-format off
     requires requires {
@@ -1445,7 +1445,7 @@ _NODISCARD _CONSTEXPR17 bool
 template <class _BidIt1, class _BidIt2>
 _NODISCARD _CONSTEXPR17 bool
     operator>(const reverse_iterator<_BidIt1>& _Left, const reverse_iterator<_BidIt2>& _Right) noexcept(
-        noexcept(_Implicitly_convert_to<bool>(_Left._Get_current() < _Right._Get_current()))) /* strengthened */
+        noexcept(_Fake_copy_init<bool>(_Left._Get_current() < _Right._Get_current()))) /* strengthened */
 #ifdef __cpp_lib_concepts
     // clang-format off
     requires requires {
@@ -1458,7 +1458,7 @@ _NODISCARD _CONSTEXPR17 bool
 template <class _BidIt1, class _BidIt2>
 _NODISCARD _CONSTEXPR17 bool
     operator<=(const reverse_iterator<_BidIt1>& _Left, const reverse_iterator<_BidIt2>& _Right) noexcept(
-        noexcept(_Implicitly_convert_to<bool>(_Left._Get_current() >= _Right._Get_current()))) /* strengthened */
+        noexcept(_Fake_copy_init<bool>(_Left._Get_current() >= _Right._Get_current()))) /* strengthened */
 #ifdef __cpp_lib_concepts
     // clang-format off
     requires requires {
@@ -1471,7 +1471,7 @@ _NODISCARD _CONSTEXPR17 bool
 template <class _BidIt1, class _BidIt2>
 _NODISCARD _CONSTEXPR17 bool
     operator>=(const reverse_iterator<_BidIt1>& _Left, const reverse_iterator<_BidIt2>& _Right) noexcept(
-        noexcept(_Implicitly_convert_to<bool>(_Left._Get_current() <= _Right._Get_current()))) /* strengthened */
+        noexcept(_Fake_copy_init<bool>(_Left._Get_current() <= _Right._Get_current()))) /* strengthened */
 #ifdef __cpp_lib_concepts
     // clang-format off
     requires requires {
@@ -1687,15 +1687,6 @@ _NODISCARD constexpr const _Elem* data(initializer_list<_Elem> _Ilist) noexcept 
 }
 
 #ifdef __cpp_lib_concepts
-// Note that this is equivalent to xstddef's _Fake_copy_init (and _Implicitly_convert_to).
-// TRANSITION, replace _Fake_decay_copy with _Fake_copy_init.
-template <class _Ty>
-_NODISCARD _Ty _Fake_decay_copy(_Ty) noexcept;
-// _Fake_decay_copy<T>(E):
-// (1) has type T [decay_t<decltype((E))> if T is deduced],
-// (2) is well-formed if and only if E is implicitly convertible to T and T is destructible, and
-// (3) is non-throwing if and only if both conversion from decltype((E)) to T and destruction of T are non-throwing.
-
 template <class _Ty1, class _Ty2>
 concept _Not_same_as = !same_as<remove_cvref_t<_Ty1>, remove_cvref_t<_Ty2>>;
 
@@ -1723,12 +1714,12 @@ namespace ranges {
 
         template <class _Ty>
         concept _Has_member = requires(_Ty __t) {
-            { _Fake_decay_copy(__t.begin()) } -> input_or_output_iterator;
+            { _Fake_copy_init(__t.begin()) } -> input_or_output_iterator;
         };
 
         template <class _Ty>
         concept _Has_ADL = _Has_class_or_enum_type<_Ty> && requires(_Ty __t) {
-            { _Fake_decay_copy(begin(__t)) } -> input_or_output_iterator;
+            { _Fake_copy_init(begin(__t)) } -> input_or_output_iterator;
         };
 
         class _Cpo {
@@ -1745,9 +1736,9 @@ namespace ranges {
                         "and std::ranges::data do not accept arrays with incomplete element types.");
                     return {_St::_Array, true};
                 } else if constexpr (_Has_member<_Ty>) {
-                    return {_St::_Member, noexcept(_Fake_decay_copy(_STD declval<_Ty>().begin()))};
+                    return {_St::_Member, noexcept(_Fake_copy_init(_STD declval<_Ty>().begin()))};
                 } else if constexpr (_Has_ADL<_Ty>) {
-                    return {_St::_Non_member, noexcept(_Fake_decay_copy(begin(_STD declval<_Ty>())))};
+                    return {_St::_Non_member, noexcept(_Fake_copy_init(begin(_STD declval<_Ty>())))};
                 } else {
                     return {_St::_None};
                 }
@@ -1847,12 +1838,12 @@ namespace ranges {
 
         template <class _Ty>
         concept _Has_member = requires(_Ty __t) {
-            { _Fake_decay_copy(__t.end()) } -> sentinel_for<iterator_t<_Ty>>;
+            { _Fake_copy_init(__t.end()) } -> sentinel_for<iterator_t<_Ty>>;
         };
 
         template <class _Ty>
         concept _Has_ADL = _Has_class_or_enum_type<_Ty> && requires(_Ty __t) {
-            { _Fake_decay_copy(end(__t)) } -> sentinel_for<iterator_t<_Ty>>;
+            { _Fake_copy_init(end(__t)) } -> sentinel_for<iterator_t<_Ty>>;
         };
 
         class _Cpo {
@@ -1875,9 +1866,9 @@ namespace ranges {
                         return {_St::_None};
                     }
                 } else if constexpr (_Has_member<_Ty>) {
-                    return {_St::_Member, noexcept(_Fake_decay_copy(_STD declval<_Ty>().end()))};
+                    return {_St::_Member, noexcept(_Fake_copy_init(_STD declval<_Ty>().end()))};
                 } else if constexpr (_Has_ADL<_Ty>) {
-                    return {_St::_Non_member, noexcept(_Fake_decay_copy(end(_STD declval<_Ty>())))};
+                    return {_St::_Non_member, noexcept(_Fake_copy_init(end(_STD declval<_Ty>())))};
                 } else {
                     return {_St::_None};
                 }
@@ -2028,12 +2019,12 @@ namespace ranges {
 
         template <class _Ty>
         concept _Has_member = requires(_Ty __t) {
-            { _Fake_decay_copy(__t.rbegin()) } -> input_or_output_iterator;
+            { _Fake_copy_init(__t.rbegin()) } -> input_or_output_iterator;
         };
 
         template <class _Ty>
         concept _Has_ADL = _Has_class_or_enum_type<_Ty> && requires(_Ty __t) {
-            { _Fake_decay_copy(rbegin(__t)) } -> input_or_output_iterator;
+            { _Fake_copy_init(rbegin(__t)) } -> input_or_output_iterator;
         };
 
         template <class _Ty>
@@ -2050,9 +2041,9 @@ namespace ranges {
             _NODISCARD static _CONSTEVAL _Choice_t<_St> _Choose() noexcept {
                 _STL_INTERNAL_STATIC_ASSERT(is_lvalue_reference_v<_Ty>);
                 if constexpr (_Has_member<_Ty>) {
-                    return {_St::_Member, noexcept(_Fake_decay_copy(_STD declval<_Ty>().rbegin()))};
+                    return {_St::_Member, noexcept(_Fake_copy_init(_STD declval<_Ty>().rbegin()))};
                 } else if constexpr (_Has_ADL<_Ty>) {
-                    return {_St::_Non_member, noexcept(_Fake_decay_copy(rbegin(_STD declval<_Ty>())))};
+                    return {_St::_Non_member, noexcept(_Fake_copy_init(rbegin(_STD declval<_Ty>())))};
                 } else if constexpr (_Can_make_reverse<_Ty>) {
                     return {_St::_Make_reverse, noexcept(_STD make_reverse_iterator(_RANGES end(_STD declval<_Ty>())))};
                 } else {
@@ -2096,12 +2087,12 @@ namespace ranges {
 
         template <class _Ty>
         concept _Has_member = requires(_Ty __t) {
-            { _Fake_decay_copy(__t.rend()) } -> sentinel_for<decltype(_RANGES rbegin(__t))>;
+            { _Fake_copy_init(__t.rend()) } -> sentinel_for<decltype(_RANGES rbegin(__t))>;
         };
 
         template <class _Ty>
         concept _Has_ADL = _Has_class_or_enum_type<_Ty> && requires(_Ty __t) {
-            { _Fake_decay_copy(rend(__t)) } -> sentinel_for<decltype(_RANGES rbegin(__t))>;
+            { _Fake_copy_init(rend(__t)) } -> sentinel_for<decltype(_RANGES rbegin(__t))>;
         };
 
         template <class _Ty>
@@ -2118,9 +2109,9 @@ namespace ranges {
             _NODISCARD static _CONSTEVAL _Choice_t<_St> _Choose() noexcept {
                 _STL_INTERNAL_STATIC_ASSERT(is_lvalue_reference_v<_Ty>);
                 if constexpr (_Has_member<_Ty>) {
-                    return {_St::_Member, noexcept(_Fake_decay_copy(_STD declval<_Ty>().rend()))};
+                    return {_St::_Member, noexcept(_Fake_copy_init(_STD declval<_Ty>().rend()))};
                 } else if constexpr (_Has_ADL<_Ty>) {
-                    return {_St::_Non_member, noexcept(_Fake_decay_copy(rend(_STD declval<_Ty>())))};
+                    return {_St::_Non_member, noexcept(_Fake_copy_init(rend(_STD declval<_Ty>())))};
                 } else if constexpr (_Can_make_reverse<_Ty>) {
                     return {
                         _St::_Make_reverse, noexcept(_STD make_reverse_iterator(_RANGES begin(_STD declval<_Ty>())))};
@@ -2198,12 +2189,12 @@ namespace ranges {
 
         template <class _Ty, class _UnCV>
         concept _Has_member = !disable_sized_range<_UnCV> && requires(_Ty __t) {
-            { _Fake_decay_copy(__t.size()) } -> _Integer_like;
+            { _Fake_copy_init(__t.size()) } -> _Integer_like;
         };
 
         template <class _Ty, class _UnCV>
         concept _Has_ADL = _Has_class_or_enum_type<_Ty> && !disable_sized_range<_UnCV> && requires(_Ty __t) {
-            { _Fake_decay_copy(size(__t)) } -> _Integer_like;
+            { _Fake_copy_init(size(__t)) } -> _Integer_like;
         };
 
         template <class _Ty>
@@ -2228,9 +2219,9 @@ namespace ranges {
                         return {_St::_None};
                     }
                 } else if constexpr (_Has_member<_Ty, _UnCV>) {
-                    return {_St::_Member, noexcept(_Fake_decay_copy(_STD declval<_Ty>().size()))};
+                    return {_St::_Member, noexcept(_Fake_copy_init(_STD declval<_Ty>().size()))};
                 } else if constexpr (_Has_ADL<_Ty, _UnCV>) {
-                    return {_St::_Non_member, noexcept(_Fake_decay_copy(size(_STD declval<_Ty>())))};
+                    return {_St::_Non_member, noexcept(_Fake_copy_init(size(_STD declval<_Ty>())))};
                 } else if constexpr (_Can_difference<_Ty>) {
                     return {_St::_Subtract,
                         noexcept(_RANGES end(_STD declval<_Ty>()) - _RANGES begin(_STD declval<_Ty>()))};
@@ -2344,7 +2335,7 @@ namespace ranges {
 
         template <class _Ty>
         concept _Has_member = requires(_Ty __t) {
-            { _Fake_decay_copy(__t.data()) } -> _Points_to_object;
+            { _Fake_copy_init(__t.data()) } -> _Points_to_object;
         };
 
         template <class _Ty>
@@ -3446,7 +3437,7 @@ public:
     template <sentinel_for<_Iter> _Sent>
     _NODISCARD_FRIEND constexpr bool
         operator==(const move_iterator& _Left, const move_sentinel<_Sent>& _Right) noexcept(
-            noexcept(_Implicitly_convert_to<bool>(_Left._Current == _Right._Get_last()))) /* strengthened */ {
+            noexcept(_Fake_copy_init<bool>(_Left._Current == _Right._Get_last()))) /* strengthened */ {
         return _Left._Current == _Right._Get_last();
     }
 
@@ -3539,7 +3530,7 @@ private:
 template <class _Iter1, class _Iter2>
 _NODISCARD _CONSTEXPR17 bool
     operator==(const move_iterator<_Iter1>& _Left, const move_iterator<_Iter2>& _Right) noexcept(
-        noexcept(_Implicitly_convert_to<bool>(_Left.base() == _Right.base()))) /* strengthened */
+        noexcept(_Fake_copy_init<bool>(_Left.base() == _Right.base()))) /* strengthened */
 #ifdef __cpp_lib_concepts
     // clang-format off
     requires requires {
@@ -3560,7 +3551,7 @@ _NODISCARD _CONSTEXPR17 bool operator!=(const move_iterator<_Iter1>& _Left,
 template <class _Iter1, class _Iter2>
 _NODISCARD _CONSTEXPR17 bool
     operator<(const move_iterator<_Iter1>& _Left, const move_iterator<_Iter2>& _Right) noexcept(
-        noexcept(_Implicitly_convert_to<bool>(_Left.base() < _Right.base()))) /* strengthened */
+        noexcept(_Fake_copy_init<bool>(_Left.base() < _Right.base()))) /* strengthened */
 #ifdef __cpp_lib_concepts
     // clang-format off
     requires requires {


### PR DESCRIPTION
* Replace `_Implicitly_convert_to` and `_Fake_decay_copy` with `_Fake_copy_init`.
  + Followup to #1937.
* Adjust warning suppressions.
  + In `<type_traits>`, `_Is_nothrow_convertible_v` isn't declaring any functions, so we don't need to suppress the `volatile` deprecation warnings about WG21-N4910 [[depr.volatile.type]/3](https://eel.is/c++draft/depr.volatile.type#3).
  + In `<xstddef>`, we're just declaring `_Fake_copy_init()` but not calling it, so we don't need to suppress truncation/sign-conversion warnings.
  + However, `_Fake_copy_init()` returns `_Ty`, unlike `_Implicitly_convert_to` which returned `void`. There's a different warning number about `volatile` return types that we need to suppress.

As mentioned in #1937's comments, this return type change from `void` to `_Ty` has no other effects - the only usage outside of `noexcept` is already using `void_t`:

https://github.com/microsoft/STL/blob/20db59ee3a4d494304df9e87a00910f024c423a8/stl/inc/type_traits#L1637
