### PR TITLE
Fix `pair::swap(const pair&)` and `tuple::swap(const tuple&)` errors with `__declspec(dllexport)`

### DIFF
--- a/stl/inc/tuple
+++ b/stl/inc/tuple
@@ -582,6 +582,7 @@ public:
     }
 
 #if _HAS_CXX23
+    template <int = 0> // see GH-3013
     constexpr void swap(const tuple& _Right) const
         noexcept(conjunction_v<is_nothrow_swappable<const _This>, is_nothrow_swappable<const _Rest>...>) {
         _Swap_adl(_Myfirst._Val, _Right._Myfirst._Val);

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -329,6 +329,7 @@ struct pair { // store a pair of values
     }
 
 #if _HAS_CXX23
+    template <int = 0> // see GH-3013
     constexpr void swap(const pair& _Right) const
         noexcept(is_nothrow_swappable_v<const _Ty1>&& is_nothrow_swappable_v<const _Ty2>) {
         if (this != _STD addressof(_Right)) {

--- a/tests/std/tests/GH_001638_dllexport_derived_classes/test.compile.pass.cpp
+++ b/tests/std/tests/GH_001638_dllexport_derived_classes/test.compile.pass.cpp
@@ -9,8 +9,10 @@
 #include <queue>
 #include <set>
 #include <stack>
+#include <tuple>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 #if _HAS_CXX20
@@ -50,3 +52,7 @@ struct __declspec(dllexport) ExportedStack : stack<int> {};
 struct __declspec(dllexport) ExportedSpan : span<int> {};
 struct __declspec(dllexport) ExportedSpanThree : span<int, 3> {};
 #endif // _HAS_CXX20
+
+// Test GH-3013 "<utility>: pair::swap(const pair&) interacts badly with __declspec(dllexport)"
+struct __declspec(dllexport) ExportedPair : pair<int, int> {};
+struct __declspec(dllexport) ExportedTuple : tuple<int, int, int> {};


### PR DESCRIPTION
Fixes #3013, a high-priority customer-reported bug (see DevCom-10109884).

Normally, member functions of class templates are instantiated "on demand". (I like to remember this rule by thinking of `list<T>`, which does not require `T` to be less-than comparable until `list<T>::sort()` is called.) However, if a user derives from a Standard Library class (which we don't encourage, but which is widely done) and then dllexports their derived class, that attempts to instantiate all member functions (that are not templated themselves).

By adding member functions (as required by the Standard) that won't compile when force-instantiated like this, #2687 regressed this scenario. The fix is simple (and something we've used elsewhere): add `template <int = 0>` to make instantiation truly on-demand. Conveniently, we already have a test we can expand.

(Note: I explored using `requires` to fix this, but that's more verbose and ran into other compiler errors.)