### PR TITLE
Update `P1208R6_source_location` for a compiler fix

### DIFF
--- a/tests/std/tests/P1208R6_source_location/test.cpp
+++ b/tests/std/tests/P1208R6_source_location/test.cpp
@@ -66,7 +66,7 @@ constexpr void sloc_constructor_test() {
     const s x;
     assert(x.loc.line() == __LINE__ - 1);
 #ifdef _PREFAST_
-    assert(x.loc.column() == 14);
+    assert(x.loc.column() == 14 || x.loc.column() == 13); // TRANSITION, 17.4 Preview 3
 #else // _PREFAST_
     assert(x.loc.column() == 13);
 #endif // _PREFAST_
@@ -90,7 +90,7 @@ constexpr void sub_member_test() {
     const s2 s;
     assert(s.x.loc.line() == __LINE__ - 1);
 #ifdef _PREFAST_
-    assert(s.x.loc.column() == 15);
+    assert(s.x.loc.column() == 15 || s.x.loc.column() == 14); // TRANSITION, 17.4 Preview 3
 #else // _PREFAST_
     assert(s.x.loc.column() == 14);
 #endif // _PREFAST_


### PR DESCRIPTION
The compiler team just merged MSVC-PR-418361, fixing the behavior of `source_location::column()` under `/analyze`. Accordingly, `P1208R6_source_location` needs to be updated to accept both the old and new behavior until VS 2022 17.4 Preview 3 ships.