### PR TITLE
Cleanup product code uses of feature-test macros

### DIFF
--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -35,12 +35,9 @@
 
 #ifdef __cpp_lib_concepts
 #include <concepts>
-#endif // defined(__cpp_lib_concepts)
-
-#ifdef __cpp_lib_format
 #include <format>
 #include <iomanip>
-#endif // defined(__cpp_lib_format)
+#endif // __cpp_lib_concepts
 #endif // _HAS_CXX20
 
 #pragma pack(push, _CRT_PACKING)
@@ -1683,7 +1680,7 @@ namespace chrono {
             : runtime_error(_Make_string(_Tp, _Info)) {}
 
     private:
-#ifdef __cpp_lib_format
+#ifdef __cpp_lib_concepts
         template <class _Duration>
         _NODISCARD static string _Make_string(const local_time<_Duration>& _Tp, const local_info& _Info);
 #else // ^^^ no workaround / workaround vvv
@@ -1706,7 +1703,7 @@ namespace chrono {
             : runtime_error(_Make_string(_Tp, _Info)) {}
 
     private:
-#ifdef __cpp_lib_format
+#ifdef __cpp_lib_concepts
         template <class _Duration>
         _NODISCARD static string _Make_string(const local_time<_Duration>& _Tp, const local_info& _Info);
 #else // ^^^ no workaround / workaround vvv
@@ -4653,7 +4650,7 @@ namespace chrono {
     }
 } // namespace chrono
 
-#ifdef __cpp_lib_format
+#ifdef __cpp_lib_concepts
   // [time.format]
 
 template <class _CharT>
@@ -5984,7 +5981,7 @@ namespace chrono {
         return _STD move(_Os).str();
     }
 } // namespace chrono
-#endif // __cpp_lib_format
+#endif // __cpp_lib_concepts
 
 inline namespace literals {
     inline namespace chrono_literals {

--- a/stl/inc/deque
+++ b/stl/inc/deque
@@ -673,7 +673,7 @@ public:
         _Proxy._Release();
     }
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
     template <_Container_compatible_range<_Ty> _Rng>
     deque(from_range_t, _Rng&& _Range) : _Mypair(_Zero_then_variadic_args_t{}) {
         _Alproxy_ty _Alproxy(_Getal());
@@ -689,7 +689,7 @@ public:
         _Construct(_RANGES _Ubegin(_Range), _RANGES _Uend(_Range));
         _Proxy._Release();
     }
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 
 private:
     template <class _Iter, class _Sent>
@@ -790,7 +790,7 @@ public:
         emplace_front(_STD move(_Val));
     }
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
     template <_Container_compatible_range<_Ty> _Rng>
     void prepend_range(_Rng&& _Range) {
         _Orphan_all();
@@ -815,14 +815,14 @@ public:
         }
         _Guard._Container = nullptr;
     }
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 
     void push_back(_Ty&& _Val) {
         _Orphan_all();
         _Emplace_back_internal(_STD move(_Val));
     }
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
     template <_Container_compatible_range<_Ty> _Rng>
     void append_range(_Rng&& _Range) {
         _Orphan_all();
@@ -837,7 +837,7 @@ public:
         }
         _Guard._Container = nullptr;
     }
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 
     iterator insert(const_iterator _Where, _Ty&& _Val) {
         return emplace(_Where, _STD move(_Val));
@@ -1240,12 +1240,12 @@ public:
         _Assign_range(_Get_unwrapped(_First), _Get_unwrapped(_Last));
     }
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
     template <_Container_compatible_range<_Ty> _Rng>
     void assign_range(_Rng&& _Range) {
         _Assign_range(_RANGES _Ubegin(_Range), _RANGES _Uend(_Range));
     }
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 
     void assign(_CRT_GUARDOVERFLOW size_type _Count, const _Ty& _Val) { // assign _Count * _Val
         _Orphan_all();
@@ -1381,7 +1381,7 @@ public:
             _Off, _Get_unwrapped(_First), _Get_unwrapped(_Last));
     }
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
     template <_Container_compatible_range<_Ty> _Rng>
     iterator insert_range(const_iterator _Where, _Rng&& _Range) {
         const size_type _Off = static_cast<size_type>(_Where - begin());
@@ -1393,7 +1393,7 @@ public:
             return _Insert_range<_Is_bidi::_No>(_Off, _RANGES _Ubegin(_Range), _RANGES _Uend(_Range));
         }
     }
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 
     iterator erase(const_iterator _Where) noexcept(is_nothrow_move_assignable_v<value_type>) /* strengthened */ {
         return erase(_Where, _Next_iter(_Where));
@@ -1690,11 +1690,11 @@ template <class _Iter, class _Alloc = allocator<_Iter_value_t<_Iter>>,
 deque(_Iter, _Iter, _Alloc = _Alloc()) -> deque<_Iter_value_t<_Iter>, _Alloc>;
 #endif // _HAS_CXX17
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
 template <_RANGES input_range _Rng, class _Alloc = allocator<_RANGES range_value_t<_Rng>>,
     enable_if_t<_Is_allocator<_Alloc>::value, int> = 0>
 deque(from_range_t, _Rng&&, _Alloc = _Alloc()) -> deque<_RANGES range_value_t<_Rng>, _Alloc>;
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 
 template <class _Ty, class _Alloc>
 void swap(deque<_Ty, _Alloc>& _Left, deque<_Ty, _Alloc>& _Right) noexcept /* strengthened */ {

--- a/stl/inc/expected
+++ b/stl/inc/expected
@@ -8,9 +8,9 @@
 #define _EXPECTED_
 #include <yvals.h>
 #if _STL_COMPILER_PREPROCESSOR
-#ifndef __cpp_lib_expected
+#if !_HAS_CXX23 || !defined(__cpp_lib_concepts) // TRANSITION, GH-395
 _EMIT_STL_WARNING(STL4038, "The contents of <expected> are available only with C++23 or later.");
-#else // ^^^ !__cpp_lib_expected / __cpp_lib_expected vvv
+#else // ^^^ not supported / supported language mode vvv
 #include <exception>
 #include <initializer_list>
 #include <type_traits>
@@ -1083,6 +1083,6 @@ _STD_END
 _STL_RESTORE_CLANG_WARNINGS
 #pragma warning(pop)
 #pragma pack(pop)
-#endif // __cpp_lib_expected
+#endif // ^^^ supported language mode ^^^
 #endif // _STL_COMPILER_PREPROCESSOR
 #endif // _EXPECTED_

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -39,9 +39,9 @@
 #define _FORMAT_
 #include <yvals_core.h>
 #if _STL_COMPILER_PREPROCESSOR
-#ifndef __cpp_lib_format
+#ifndef __cpp_lib_concepts
 _EMIT_STL_WARNING(STL4038, "The contents of <format> are available only with C++20 or later.");
-#else // ^^^ !defined(__cpp_lib_format) / defined(__cpp_lib_format) vvv
+#else // ^^^ !defined(__cpp_lib_concepts) / defined(__cpp_lib_concepts) vvv
 
 #include <__msvc_format_ucd_tables.hpp>
 #include <algorithm>
@@ -3606,6 +3606,6 @@ _STL_RESTORE_CLANG_WARNINGS
 #pragma warning(pop)
 #pragma pack(pop)
 
-#endif // __cpp_lib_format
+#endif // __cpp_lib_concepts
 #endif // _STL_COMPILER_PREPROCESSOR
 #endif // _FORMAT_

--- a/stl/inc/forward_list
+++ b/stl/inc/forward_list
@@ -607,7 +607,7 @@ public:
         _Insert_op._Attach_after(_Mypair._Myval2._Before_head());
     }
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
     template <_Container_compatible_range<_Ty> _Rng>
     forward_list(from_range_t, _Rng&& _Range) : _Mypair(_Zero_then_variadic_args_t{}) {
         _Flist_insert_after_op2<_Alnode> _Insert_op(_Getal());
@@ -623,7 +623,7 @@ public:
         _Alloc_proxy();
         _Insert_op._Attach_after(_Mypair._Myval2._Before_head());
     }
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 
     forward_list(forward_list&& _Right) noexcept // strengthened
         : _Mypair(_One_then_variadic_args_t{}, _STD move(_Right._Getal())) {
@@ -915,12 +915,12 @@ public:
         _Insert_after(_Mypair._Myval2._Before_head(), _Val);
     }
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
     template <_Container_compatible_range<_Ty> _Rng>
     void prepend_range(_Rng&& _Range) {
         _Insert_range_after(_Mypair._Myval2._Before_head(), _RANGES _Ubegin(_Range), _RANGES _Uend(_Range));
     }
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 
     void pop_front() noexcept /* strengthened */ {
         _Erase_after(_Mypair._Myval2._Before_head());
@@ -960,12 +960,12 @@ public:
         _Assign_unchecked(_Get_unwrapped(_First), _Get_unwrapped(_Last));
     }
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
     template <_Container_compatible_range<_Ty> _Rng>
     void assign_range(_Rng&& _Range) {
         _Assign_unchecked(_RANGES _Ubegin(_Range), _RANGES _Uend(_Range));
     }
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 
     void assign(_CRT_GUARDOVERFLOW size_type _Count, const _Ty& _Val) {
         clear();
@@ -1022,7 +1022,7 @@ public:
         return _Insert_range_after(_Where._Ptr, _Get_unwrapped(_First), _Get_unwrapped(_Last));
     }
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
     template <_Container_compatible_range<_Ty> _Rng>
     iterator insert_range_after(const_iterator _Where, _Rng&& _Range) {
 #if _ITERATOR_DEBUG_LEVEL == 2
@@ -1031,7 +1031,7 @@ public:
 #endif // _ITERATOR_DEBUG_LEVEL == 2
         return _Insert_range_after(_Where._Ptr, _RANGES _Ubegin(_Range), _RANGES _Uend(_Range));
     }
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 
 private:
     void _Erase_after(_Nodeptr _Pnode) noexcept { // erase element after _Pnode
@@ -1555,11 +1555,11 @@ template <class _Iter, class _Alloc = allocator<_Iter_value_t<_Iter>>,
 forward_list(_Iter, _Iter, _Alloc = _Alloc()) -> forward_list<_Iter_value_t<_Iter>, _Alloc>;
 #endif // _HAS_CXX17
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
 template <_RANGES input_range _Rng, class _Alloc = allocator<_RANGES range_value_t<_Rng>>,
     enable_if_t<_Is_allocator<_Alloc>::value, int> = 0>
 forward_list(from_range_t, _Rng&&, _Alloc = _Alloc()) -> forward_list<_RANGES range_value_t<_Rng>, _Alloc>;
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 
 template <class _Ty, class _Alloc>
 void swap(forward_list<_Ty, _Alloc>& _Left, forward_list<_Ty, _Alloc>& _Right) noexcept /* strengthened */ {

--- a/stl/inc/list
+++ b/stl/inc/list
@@ -882,7 +882,7 @@ public:
         _Construct_range_unchecked(_Get_unwrapped(_First), _Get_unwrapped(_Last));
     }
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
     template <_Container_compatible_range<_Ty> _Rng>
     list(from_range_t, _Rng&& _Range) : _Mypair(_Zero_then_variadic_args_t{}) {
         _Construct_range_unchecked(_RANGES _Ubegin(_Range), _RANGES _Uend(_Range));
@@ -892,7 +892,7 @@ public:
     list(from_range_t, _Rng&& _Range, const _Alloc& _Al) : _Mypair(_One_then_variadic_args_t{}, _Al) {
         _Construct_range_unchecked(_RANGES _Ubegin(_Range), _RANGES _Uend(_Range));
     }
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 
     list(list&& _Right) : _Mypair(_One_then_variadic_args_t{}, _STD move(_Right._Getal())) {
         _Alloc_sentinel_and_proxy();
@@ -1235,14 +1235,14 @@ public:
         _Emplace(_Mypair._Myval2._Myhead->_Next, _Val);
     }
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
     template <_Container_compatible_range<_Ty> _Rng>
     void prepend_range(_Rng&& _Range) {
         _List_node_insert_op2<_Alnode> _Op(_Getal());
         _Op._Append_range_unchecked(_RANGES _Ubegin(_Range), _RANGES _Uend(_Range));
         _Op._Attach_before(_Mypair._Myval2, _Mypair._Myval2._Myhead->_Next);
     }
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 
     void pop_front() noexcept /* strengthened */ {
 #if _CONTAINER_DEBUG_LEVEL > 0
@@ -1256,14 +1256,14 @@ public:
         _Emplace(_Mypair._Myval2._Myhead, _Val);
     }
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
     template <_Container_compatible_range<_Ty> _Rng>
     void append_range(_Rng&& _Range) {
         _List_node_insert_op2<_Alnode> _Op(_Getal());
         _Op._Append_range_unchecked(_RANGES _Ubegin(_Range), _RANGES _Uend(_Range));
         _Op._Attach_at_end(_Mypair._Myval2);
     }
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 
     void pop_back() noexcept /* strengthened */ {
 #if _CONTAINER_DEBUG_LEVEL > 0
@@ -1333,12 +1333,12 @@ public:
         _Assign_unchecked(_Get_unwrapped(_First), _Get_unwrapped(_Last));
     }
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
     template <_Container_compatible_range<_Ty> _Rng>
     void assign_range(_Rng&& _Range) {
         _Assign_unchecked(_RANGES _Ubegin(_Range), _RANGES _Uend(_Range));
     }
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 
     void assign(_CRT_GUARDOVERFLOW size_type _Count, const _Ty& _Val) { // assign _Count * _Val
         const auto _Myend = _Mypair._Myval2._Myhead;
@@ -1392,7 +1392,7 @@ public:
         return _Make_iter(_Op._Attach_before(_Mypair._Myval2, _Where._Ptr));
     }
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
     template <_Container_compatible_range<_Ty> _Rng>
     iterator insert_range(const_iterator _Where, _Rng&& _Range) {
 #if _ITERATOR_DEBUG_LEVEL == 2
@@ -1402,7 +1402,7 @@ public:
         _Op._Append_range_unchecked(_RANGES _Ubegin(_Range), _RANGES _Uend(_Range));
         return _Make_iter(_Op._Attach_before(_Mypair._Myval2, _Where._Ptr));
     }
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 
     iterator erase(const const_iterator _Where) noexcept /* strengthened */ {
 #if _ITERATOR_DEBUG_LEVEL == 2
@@ -1858,11 +1858,11 @@ template <class _Iter, class _Alloc = allocator<_Iter_value_t<_Iter>>,
 list(_Iter, _Iter, _Alloc = _Alloc()) -> list<_Iter_value_t<_Iter>, _Alloc>;
 #endif // _HAS_CXX17
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
 template <_RANGES input_range _Rng, class _Alloc = allocator<_RANGES range_value_t<_Rng>>,
     enable_if_t<_Is_allocator<_Alloc>::value, int> = 0>
 list(from_range_t, _Rng&&, _Alloc = _Alloc()) -> list<_RANGES range_value_t<_Rng>, _Alloc>;
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 
 template <class _Ty, class _Alloc>
 void swap(list<_Ty, _Alloc>& _Left, list<_Ty, _Alloc>& _Right) noexcept /* strengthened */ {

--- a/stl/inc/map
+++ b/stl/inc/map
@@ -134,7 +134,7 @@ public:
         insert(_First, _Last);
     }
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
     template <_Container_compatible_range<value_type> _Rng>
     map(from_range_t, _Rng&& _Range) : _Mybase(key_compare()) {
         this->_Insert_range_unchecked(_RANGES _Ubegin(_Range), _RANGES _Uend(_Range));
@@ -154,7 +154,7 @@ public:
     map(from_range_t, _Rng&& _Range, const allocator_type& _Al) : _Mybase(key_compare(), _Al) {
         this->_Insert_range_unchecked(_RANGES _Ubegin(_Range), _RANGES _Uend(_Range));
     }
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 
     map& operator=(const map& _Right) {
         _Mybase::operator=(_Right);
@@ -382,7 +382,7 @@ map(_Iter, _Iter, _Alloc) -> map<_Guide_key_t<_Iter>, _Guide_val_t<_Iter>, less<
 template <class _Kty, class _Ty, class _Alloc, enable_if_t<_Is_allocator<_Alloc>::value, int> = 0>
 map(initializer_list<pair<_Kty, _Ty>>, _Alloc) -> map<_Kty, _Ty, less<_Kty>, _Alloc>;
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
 template <_RANGES input_range _Rng, class _Pr = less<_Range_key_type<_Rng>>,
     class _Alloc = allocator<_Range_to_alloc_type<_Rng>>,
     enable_if_t<conjunction_v<negation<_Is_allocator<_Pr>>, _Is_allocator<_Alloc>>, int> = 0>
@@ -392,7 +392,7 @@ map(from_range_t, _Rng&&, _Pr = _Pr(), _Alloc = _Alloc())
 template <_RANGES input_range _Rng, class _Alloc, enable_if_t<_Is_allocator<_Alloc>::value, int> = 0>
 map(from_range_t, _Rng&&, _Alloc)
     -> map<_Range_key_type<_Rng>, _Range_mapped_type<_Rng>, less<_Range_key_type<_Rng>>, _Alloc>;
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 #endif // _HAS_CXX17
 
 template <class _Kty, class _Ty, class _Pr, class _Alloc>
@@ -512,7 +512,7 @@ public:
         insert(_First, _Last);
     }
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
     template <_Container_compatible_range<value_type> _Rng>
     multimap(from_range_t, _Rng&& _Range) : _Mybase(key_compare()) {
         this->_Insert_range_unchecked(_RANGES _Ubegin(_Range), _RANGES _Uend(_Range));
@@ -532,7 +532,7 @@ public:
     multimap(from_range_t, _Rng&& _Range, const allocator_type& _Al) : _Mybase(key_compare(), _Al) {
         this->_Insert_range_unchecked(_RANGES _Ubegin(_Range), _RANGES _Uend(_Range));
     }
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 
     multimap& operator=(const multimap& _Right) {
         _Mybase::operator=(_Right);
@@ -613,7 +613,7 @@ multimap(_Iter, _Iter, _Alloc) -> multimap<_Guide_key_t<_Iter>, _Guide_val_t<_It
 template <class _Kty, class _Ty, class _Alloc, enable_if_t<_Is_allocator<_Alloc>::value, int> = 0>
 multimap(initializer_list<pair<_Kty, _Ty>>, _Alloc) -> multimap<_Kty, _Ty, less<_Kty>, _Alloc>;
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
 template <_RANGES input_range _Rng, class _Pr = less<_Range_key_type<_Rng>>,
     class _Alloc = allocator<_Range_to_alloc_type<_Rng>>,
     enable_if_t<conjunction_v<negation<_Is_allocator<_Pr>>, _Is_allocator<_Alloc>>, int> = 0>
@@ -623,7 +623,7 @@ multimap(from_range_t, _Rng&&, _Pr = _Pr(), _Alloc = _Alloc())
 template <_RANGES input_range _Rng, class _Alloc, enable_if_t<_Is_allocator<_Alloc>::value, int> = 0>
 multimap(from_range_t, _Rng&&, _Alloc)
     -> multimap<_Range_key_type<_Rng>, _Range_mapped_type<_Rng>, less<_Range_key_type<_Rng>>, _Alloc>;
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 #endif // _HAS_CXX17
 
 template <class _Kty, class _Ty, class _Pr, class _Alloc>

--- a/stl/inc/queue
+++ b/stl/inc/queue
@@ -47,10 +47,10 @@ public:
     queue(_InIt _First, _InIt _Last) noexcept(is_nothrow_constructible_v<_Container, _InIt, _InIt>) // strengthened
         : c(_STD move(_First), _STD move(_Last)) {}
 
-#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
+#ifdef __cpp_lib_concepts
     template <_Container_compatible_range<_Ty> _Rng>
     queue(from_range_t, _Rng&& _Range) : c(_RANGES to<_Container>(_STD forward<_Rng>(_Range))) {}
-#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
+#endif // __cpp_lib_concepts
 #endif // _HAS_CXX23
 
     template <class _Alloc, enable_if_t<uses_allocator_v<_Container, _Alloc>, int> = 0>
@@ -80,11 +80,11 @@ public:
         is_nothrow_constructible_v<_Container, _InIt, _InIt, const _Alloc&>) // strengthened
         : c(_STD move(_First), _STD move(_Last), _Al) {}
 
-#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
+#if __cpp_lib_concepts
     template <_Container_compatible_range<_Ty> _Rng, class _Alloc>
     queue(from_range_t, _Rng&& _Range, const _Alloc& _Al)
         : c(_RANGES to<_Container>(_STD forward<_Rng>(_Range), _Al)) {}
-#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
+#endif // __cpp_lib_concepts
 #endif // _HAS_CXX23
 
     _NODISCARD bool empty() const noexcept(noexcept(c.empty())) /* strengthened */ {
@@ -169,12 +169,12 @@ template <class _InIt, class _Alloc = allocator<_Iter_value_t<_InIt>>,
     enable_if_t<conjunction_v<_Is_iterator<_InIt>, _Is_allocator<_Alloc>>, int> = 0>
 queue(_InIt, _InIt, _Alloc = _Alloc()) -> queue<_Iter_value_t<_InIt>, deque<_Iter_value_t<_InIt>, _Alloc>>;
 
-#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
+#if __cpp_lib_concepts
 template <_RANGES input_range _Rng, class _Alloc = allocator<_RANGES range_value_t<_Rng>>,
     enable_if_t<_Is_allocator<_Alloc>::value, int> = 0>
 queue(from_range_t, _Rng&&, _Alloc = _Alloc())
     -> queue<_RANGES range_value_t<_Rng>, deque<_RANGES range_value_t<_Rng>, _Alloc>>;
-#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
+#endif // __cpp_lib_concepts
 #endif // _HAS_CXX23
 
 template <class _Ty, class _Container>

--- a/stl/inc/queue
+++ b/stl/inc/queue
@@ -80,7 +80,7 @@ public:
         is_nothrow_constructible_v<_Container, _InIt, _InIt, const _Alloc&>) // strengthened
         : c(_STD move(_First), _STD move(_Last), _Al) {}
 
-#if __cpp_lib_concepts
+#ifdef __cpp_lib_concepts
     template <_Container_compatible_range<_Ty> _Rng, class _Alloc>
     queue(from_range_t, _Rng&& _Range, const _Alloc& _Al)
         : c(_RANGES to<_Container>(_STD forward<_Rng>(_Range), _Al)) {}
@@ -169,7 +169,7 @@ template <class _InIt, class _Alloc = allocator<_Iter_value_t<_InIt>>,
     enable_if_t<conjunction_v<_Is_iterator<_InIt>, _Is_allocator<_Alloc>>, int> = 0>
 queue(_InIt, _InIt, _Alloc = _Alloc()) -> queue<_Iter_value_t<_InIt>, deque<_Iter_value_t<_InIt>, _Alloc>>;
 
-#if __cpp_lib_concepts
+#ifdef __cpp_lib_concepts
 template <_RANGES input_range _Rng, class _Alloc = allocator<_RANGES range_value_t<_Rng>>,
     enable_if_t<_Is_allocator<_Alloc>::value, int> = 0>
 queue(from_range_t, _Rng&&, _Alloc = _Alloc())

--- a/stl/inc/queue
+++ b/stl/inc/queue
@@ -12,9 +12,9 @@
 #include <deque>
 #include <vector>
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
 #include <ranges>
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 
 #pragma pack(push, _CRT_PACKING)
 #pragma warning(push, _STL_WARNING_LEVEL)
@@ -47,10 +47,10 @@ public:
     queue(_InIt _First, _InIt _Last) noexcept(is_nothrow_constructible_v<_Container, _InIt, _InIt>) // strengthened
         : c(_STD move(_First), _STD move(_Last)) {}
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
     template <_Container_compatible_range<_Ty> _Rng>
     queue(from_range_t, _Rng&& _Range) : c(_RANGES to<_Container>(_STD forward<_Rng>(_Range))) {}
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 #endif // _HAS_CXX23
 
     template <class _Alloc, enable_if_t<uses_allocator_v<_Container, _Alloc>, int> = 0>
@@ -80,11 +80,11 @@ public:
         is_nothrow_constructible_v<_Container, _InIt, _InIt, const _Alloc&>) // strengthened
         : c(_STD move(_First), _STD move(_Last), _Al) {}
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
     template <_Container_compatible_range<_Ty> _Rng, class _Alloc>
     queue(from_range_t, _Rng&& _Range, const _Alloc& _Al)
         : c(_RANGES to<_Container>(_STD forward<_Rng>(_Range), _Al)) {}
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 #endif // _HAS_CXX23
 
     _NODISCARD bool empty() const noexcept(noexcept(c.empty())) /* strengthened */ {
@@ -119,7 +119,7 @@ public:
         c.push_back(_STD move(_Val));
     }
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
     template <_Container_compatible_range<_Ty> _Rng>
     void push_range(_Rng&& _Range) {
         if constexpr (requires { c.append_range(_Range); }) {
@@ -128,7 +128,7 @@ public:
             _RANGES copy(_Range, back_insert_iterator{c});
         }
     }
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 
     template <class... _Valty>
     decltype(auto) emplace(_Valty&&... _Val) {
@@ -169,12 +169,12 @@ template <class _InIt, class _Alloc = allocator<_Iter_value_t<_InIt>>,
     enable_if_t<conjunction_v<_Is_iterator<_InIt>, _Is_allocator<_Alloc>>, int> = 0>
 queue(_InIt, _InIt, _Alloc = _Alloc()) -> queue<_Iter_value_t<_InIt>, deque<_Iter_value_t<_InIt>, _Alloc>>;
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
 template <_RANGES input_range _Rng, class _Alloc = allocator<_RANGES range_value_t<_Rng>>,
     enable_if_t<_Is_allocator<_Alloc>::value, int> = 0>
 queue(from_range_t, _Rng&&, _Alloc = _Alloc())
     -> queue<_RANGES range_value_t<_Rng>, deque<_RANGES range_value_t<_Rng>, _Alloc>>;
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 #endif // _HAS_CXX23
 
 template <class _Ty, class _Container>
@@ -271,13 +271,13 @@ public:
         _STD make_heap(c.begin(), c.end(), comp);
     }
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
     template <_Container_compatible_range<_Ty> _Rng>
     priority_queue(from_range_t, _Rng&& _Range, const _Pr& _Pred = _Pr())
         : c(_RANGES to<_Container>(_STD forward<_Rng>(_Range))), comp(_Pred) {
         _STD make_heap(c.begin(), c.end(), comp);
     }
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 
     template <class _Alloc, enable_if_t<uses_allocator_v<_Container, _Alloc>, int> = 0>
     explicit priority_queue(const _Alloc& _Al) noexcept(is_nothrow_constructible_v<_Container, const _Alloc&>&&
@@ -337,7 +337,7 @@ public:
         _STD make_heap(c.begin(), c.end(), comp);
     }
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
     template <_Container_compatible_range<_Ty> _Rng, class _Alloc,
         enable_if_t<uses_allocator_v<_Container, _Alloc>, int> = 0>
     priority_queue(from_range_t, _Rng&& _Range, const _Pr& _Pred, const _Alloc& _Al)
@@ -351,7 +351,7 @@ public:
         : c(_RANGES to<_Container>(_STD forward<_Rng>(_Range), _Al)), comp() {
         _STD make_heap(c.begin(), c.end(), comp);
     }
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 
     _NODISCARD bool empty() const noexcept(noexcept(c.empty())) /* strengthened */ {
         return c.empty();
@@ -375,7 +375,7 @@ public:
         _STD push_heap(c.begin(), c.end(), comp);
     }
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
     template <_Container_compatible_range<_Ty> _Rng>
     void push_range(_Rng&& _Range) { // per LWG-3723
         if constexpr (requires { c.append_range(_Range); }) {
@@ -386,7 +386,7 @@ public:
 
         _STD make_heap(c.begin(), c.end(), comp);
     }
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 
     template <class... _Valty>
     void emplace(_Valty&&... _Val) {
@@ -440,7 +440,7 @@ template <class _Iter, class _Compare, class _Container, class _Alloc,
 priority_queue(_Iter, _Iter, _Compare, _Container, _Alloc)
     -> priority_queue<typename _Container::value_type, _Container, _Compare>;
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
 template <_RANGES input_range _Rng, class _Pr = less<_RANGES range_value_t<_Rng>>,
     enable_if_t<!_Is_allocator<_Pr>::value, int> = 0>
 priority_queue(from_range_t, _Rng&&, _Pr = _Pr())
@@ -454,7 +454,7 @@ priority_queue(from_range_t, _Rng&&, _Pr, _Alloc)
 template <_RANGES input_range _Rng, class _Alloc, enable_if_t<_Is_allocator<_Alloc>::value, int> = 0>
 priority_queue(from_range_t, _Rng&&, _Alloc)
     -> priority_queue<_RANGES range_value_t<_Rng>, vector<_RANGES range_value_t<_Rng>, _Alloc>>;
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 #endif // _HAS_CXX17
 
 template <class _Ty, class _Container, class _Pr,

--- a/stl/inc/set
+++ b/stl/inc/set
@@ -111,7 +111,7 @@ public:
         this->insert(_First, _Last);
     }
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
     template <_Container_compatible_range<value_type> _Rng>
     set(from_range_t, _Rng&& _Range) : _Mybase(key_compare()) {
         this->_Insert_range_unchecked(_RANGES _Ubegin(_Range), _RANGES _Uend(_Range));
@@ -131,7 +131,7 @@ public:
     set(from_range_t, _Rng&& _Range, const allocator_type& _Al) : _Mybase(key_compare(), _Al) {
         this->_Insert_range_unchecked(_RANGES _Ubegin(_Range), _RANGES _Uend(_Range));
     }
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 
     set& operator=(const set& _Right) {
         _Mybase::operator=(_Right);
@@ -193,7 +193,7 @@ set(_Iter, _Iter, _Alloc) -> set<_Iter_value_t<_Iter>, less<_Iter_value_t<_Iter>
 template <class _Kty, class _Alloc, enable_if_t<_Is_allocator<_Alloc>::value, int> = 0>
 set(initializer_list<_Kty>, _Alloc) -> set<_Kty, less<_Kty>, _Alloc>;
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
 template <_RANGES input_range _Rng, class _Pr = less<_RANGES range_value_t<_Rng>>,
     class _Alloc = allocator<_RANGES range_value_t<_Rng>>,
     enable_if_t<conjunction_v<negation<_Is_allocator<_Pr>>, _Is_allocator<_Alloc>>, int> = 0>
@@ -201,7 +201,7 @@ set(from_range_t, _Rng&&, _Pr = _Pr(), _Alloc = _Alloc()) -> set<_RANGES range_v
 
 template <_RANGES input_range _Rng, class _Alloc, enable_if_t<_Is_allocator<_Alloc>::value, int> = 0>
 set(from_range_t, _Rng&&, _Alloc) -> set<_RANGES range_value_t<_Rng>, less<_RANGES range_value_t<_Rng>>, _Alloc>;
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 #endif // _HAS_CXX17
 
 template <class _Kty, class _Pr, class _Alloc>
@@ -319,7 +319,7 @@ public:
         this->insert(_First, _Last);
     }
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
     template <_Container_compatible_range<value_type> _Rng>
     multiset(from_range_t, _Rng&& _Range) : _Mybase(key_compare()) {
         this->_Insert_range_unchecked(_RANGES _Ubegin(_Range), _RANGES _Uend(_Range));
@@ -339,7 +339,7 @@ public:
     multiset(from_range_t, _Rng&& _Range, const allocator_type& _Al) : _Mybase(key_compare(), _Al) {
         this->_Insert_range_unchecked(_RANGES _Ubegin(_Range), _RANGES _Uend(_Range));
     }
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 
     multiset& operator=(const multiset& _Right) {
         _Mybase::operator=(_Right);
@@ -407,7 +407,7 @@ multiset(_Iter, _Iter, _Alloc) -> multiset<_Iter_value_t<_Iter>, less<_Iter_valu
 template <class _Kty, class _Alloc, enable_if_t<_Is_allocator<_Alloc>::value, int> = 0>
 multiset(initializer_list<_Kty>, _Alloc) -> multiset<_Kty, less<_Kty>, _Alloc>;
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
 template <_RANGES input_range _Rng, class _Pr = less<_RANGES range_value_t<_Rng>>,
     class _Alloc = allocator<_RANGES range_value_t<_Rng>>,
     enable_if_t<conjunction_v<negation<_Is_allocator<_Pr>>, _Is_allocator<_Alloc>>, int> = 0>
@@ -416,7 +416,7 @@ multiset(from_range_t, _Rng&&, _Pr = _Pr(), _Alloc = _Alloc()) -> multiset<_RANG
 template <_RANGES input_range _Rng, class _Alloc, enable_if_t<_Is_allocator<_Alloc>::value, int> = 0>
 multiset(from_range_t, _Rng&&, _Alloc)
     -> multiset<_RANGES range_value_t<_Rng>, less<_RANGES range_value_t<_Rng>>, _Alloc>;
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 #endif // _HAS_CXX17
 
 template <class _Kty, class _Pr, class _Alloc>

--- a/stl/inc/stack
+++ b/stl/inc/stack
@@ -45,10 +45,10 @@ public:
     stack(_InIt _First, _InIt _Last) noexcept(is_nothrow_constructible_v<_Container, _InIt, _InIt>) // strengthened
         : c(_STD move(_First), _STD move(_Last)) {}
 
-#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
+#ifdef __cpp_lib_concepts
     template <_Container_compatible_range<_Ty> _Rng>
     stack(from_range_t, _Rng&& _Range) : c(_RANGES to<_Container>(_STD forward<_Rng>(_Range))) {}
-#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
+#endif // __cpp_lib_concepts
 #endif // _HAS_CXX23
 
     template <class _Alloc, enable_if_t<uses_allocator_v<_Container, _Alloc>, int> = 0>
@@ -78,11 +78,11 @@ public:
         is_nothrow_constructible_v<_Container, _InIt, _InIt, const _Alloc&>) // strengthened
         : c(_STD move(_First), _STD move(_Last), _Al) {}
 
-#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
+#ifdef __cpp_lib_concepts
     template <_Container_compatible_range<_Ty> _Rng, class _Alloc>
     stack(from_range_t, _Rng&& _Range, const _Alloc& _Al)
         : c(_RANGES to<_Container>(_STD forward<_Rng>(_Range), _Al)) {}
-#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
+#endif // __cpp_lib_concepts
 #endif // _HAS_CXX23
 
     _NODISCARD bool empty() const noexcept(noexcept(c.empty())) /* strengthened */ {
@@ -159,13 +159,13 @@ template <class _InIt, class _Alloc = allocator<_Iter_value_t<_InIt>>,
     enable_if_t<conjunction_v<_Is_iterator<_InIt>, _Is_allocator<_Alloc>>, int> = 0>
 stack(_InIt, _InIt, _Alloc = _Alloc()) -> stack<_Iter_value_t<_InIt>, deque<_Iter_value_t<_InIt>, _Alloc>>;
 
-#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
+#ifdef __cpp_lib_concepts
 template <_RANGES input_range _Rng>
 stack(from_range_t, _Rng&&) -> stack<_RANGES range_value_t<_Rng>>;
 
 template <_RANGES input_range _Rng, class _Alloc, enable_if_t<_Is_allocator<_Alloc>::value, int> = 0>
 stack(from_range_t, _Rng&&, _Alloc) -> stack<_RANGES range_value_t<_Rng>, deque<_RANGES range_value_t<_Rng>, _Alloc>>;
-#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
+#endif // __cpp_lib_concepts
 #endif // _HAS_CXX23
 
 template <class _Ty, class _Container>

--- a/stl/inc/stack
+++ b/stl/inc/stack
@@ -10,9 +10,9 @@
 #if _STL_COMPILER_PREPROCESSOR
 #include <deque>
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
 #include <ranges>
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 
 #pragma pack(push, _CRT_PACKING)
 #pragma warning(push, _STL_WARNING_LEVEL)
@@ -45,10 +45,10 @@ public:
     stack(_InIt _First, _InIt _Last) noexcept(is_nothrow_constructible_v<_Container, _InIt, _InIt>) // strengthened
         : c(_STD move(_First), _STD move(_Last)) {}
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
     template <_Container_compatible_range<_Ty> _Rng>
     stack(from_range_t, _Rng&& _Range) : c(_RANGES to<_Container>(_STD forward<_Rng>(_Range))) {}
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 #endif // _HAS_CXX23
 
     template <class _Alloc, enable_if_t<uses_allocator_v<_Container, _Alloc>, int> = 0>
@@ -78,11 +78,11 @@ public:
         is_nothrow_constructible_v<_Container, _InIt, _InIt, const _Alloc&>) // strengthened
         : c(_STD move(_First), _STD move(_Last), _Al) {}
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
     template <_Container_compatible_range<_Ty> _Rng, class _Alloc>
     stack(from_range_t, _Rng&& _Range, const _Alloc& _Al)
         : c(_RANGES to<_Container>(_STD forward<_Rng>(_Range), _Al)) {}
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 #endif // _HAS_CXX23
 
     _NODISCARD bool empty() const noexcept(noexcept(c.empty())) /* strengthened */ {
@@ -109,7 +109,7 @@ public:
         c.push_back(_STD move(_Val));
     }
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
     template <_Container_compatible_range<_Ty> _Rng>
     void push_range(_Rng&& _Range) {
         if constexpr (requires { c.append_range(_Range); }) {
@@ -118,7 +118,7 @@ public:
             _RANGES copy(_Range, back_insert_iterator{c});
         }
     }
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 
     template <class... _Valty>
     decltype(auto) emplace(_Valty&&... _Val) {
@@ -159,13 +159,13 @@ template <class _InIt, class _Alloc = allocator<_Iter_value_t<_InIt>>,
     enable_if_t<conjunction_v<_Is_iterator<_InIt>, _Is_allocator<_Alloc>>, int> = 0>
 stack(_InIt, _InIt, _Alloc = _Alloc()) -> stack<_Iter_value_t<_InIt>, deque<_Iter_value_t<_InIt>, _Alloc>>;
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
 template <_RANGES input_range _Rng>
 stack(from_range_t, _Rng&&) -> stack<_RANGES range_value_t<_Rng>>;
 
 template <_RANGES input_range _Rng, class _Alloc, enable_if_t<_Is_allocator<_Alloc>::value, int> = 0>
 stack(from_range_t, _Rng&&, _Alloc) -> stack<_RANGES range_value_t<_Rng>, deque<_RANGES range_value_t<_Rng>, _Alloc>>;
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 #endif // _HAS_CXX23
 
 template <class _Ty, class _Container>

--- a/stl/inc/system_error
+++ b/stl/inc/system_error
@@ -71,10 +71,7 @@ public:
         _Addr = reinterpret_cast<uintptr_t>(this);
     }
 
-#ifdef __cpp_constexpr_dynamic_alloc
-    constexpr
-#endif
-        virtual ~error_category() noexcept = default;
+    _CONSTEXPR20 virtual ~error_category() noexcept = default;
 
     _NODISCARD virtual const char* name() const noexcept = 0;
 
@@ -566,8 +563,8 @@ public:
 // * can't use magic statics in standard modes, because that would inject a .TLS section into all binaries using
 //   <system_error> and would likely put borderline programs over the TLS slot count limit, and would destroy the
 //   variable during DLL unload
-// * can't declare the error_category as an ordinary constexpr variable for most compilers, because error_category
-//   has a virtual destructor (TRANSITION, __cpp_constexpr_dynamic_alloc)
+// * can't declare the error_category as an ordinary constexpr variable for most compilers before C++20, because
+//   error_category has a virtual destructor
 // * can't declare the error_category as an ordinary non-constexpr variable even with a constexpr constructor, because
 //   the compiler will emit code to destroy it which invalidates its use in these DLL shutdown scenarios
 //
@@ -594,7 +591,7 @@ _NODISCARD const _Ty& _Immortalize_memcpy_image() noexcept {
     /* MAGIC */ static _Immortalizer_impl<_Ty> _Static;
     return _Static._Storage;
 }
-#elif defined(__cpp_constexpr_dynamic_alloc)
+#elif _HAS_CXX20
 template <class _Ty>
 _NODISCARD const _Ty& _Immortalize_memcpy_image() noexcept {
     static constexpr _Ty _Static;

--- a/stl/inc/unordered_map
+++ b/stl/inc/unordered_map
@@ -190,7 +190,7 @@ public:
         insert(_First, _Last);
     }
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
     template <_Container_compatible_range<value_type> _Rng>
     unordered_map(from_range_t, _Rng&& _Range) : _Mybase(_Key_compare(), allocator_type()) {
         this->_Insert_range_unchecked(_RANGES _Ubegin(_Range), _RANGES _Uend(_Range));
@@ -242,7 +242,7 @@ public:
         _Mybase::rehash(_Buckets);
         this->_Insert_range_unchecked(_RANGES _Ubegin(_Range), _RANGES _Uend(_Range));
     }
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 
     unordered_map& operator=(const unordered_map& _Right) {
         _Mybase::operator=(_Right);
@@ -499,7 +499,7 @@ template <class _Kty, class _Ty, class _Hasher, class _Alloc,
 unordered_map(initializer_list<pair<_Kty, _Ty>>, _Guide_size_type_t<_Alloc>, _Hasher, _Alloc)
     -> unordered_map<_Kty, _Ty, _Hasher, equal_to<_Kty>, _Alloc>;
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
 template <_RANGES input_range _Rng, class _Hasher = hash<_Range_key_type<_Rng>>,
     class _Keyeq = equal_to<_Range_key_type<_Rng>>, class _Alloc = allocator<_Range_to_alloc_type<_Rng>>,
     enable_if_t<conjunction_v<_Is_hasher<_Hasher>, negation<_Is_allocator<_Keyeq>>, _Is_allocator<_Alloc>>, int> = 0>
@@ -518,7 +518,7 @@ template <_RANGES input_range _Rng, class _Hasher, class _Alloc,
     enable_if_t<conjunction_v<_Is_hasher<_Hasher>, _Is_allocator<_Alloc>>, int> = 0>
 unordered_map(from_range_t, _Rng&&, _Guide_size_type_t<_Alloc>, _Hasher, _Alloc)
     -> unordered_map<_Range_key_type<_Rng>, _Range_mapped_type<_Rng>, _Hasher, equal_to<_Range_key_type<_Rng>>, _Alloc>;
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 #endif // _HAS_CXX17
 
 template <class _Kty, class _Ty, class _Hasher, class _Keyeq, class _Alloc>
@@ -674,7 +674,7 @@ public:
         insert(_First, _Last);
     }
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
     template <_Container_compatible_range<value_type> _Rng>
     unordered_multimap(from_range_t, _Rng&& _Range) : _Mybase(_Key_compare(), allocator_type()) {
         this->_Insert_range_unchecked(_RANGES _Ubegin(_Range), _RANGES _Uend(_Range));
@@ -727,7 +727,7 @@ public:
         _Mybase::rehash(_Buckets);
         this->_Insert_range_unchecked(_RANGES _Ubegin(_Range), _RANGES _Uend(_Range));
     }
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 
     unordered_multimap& operator=(const unordered_multimap& _Right) {
         _Mybase::operator=(_Right);
@@ -866,7 +866,7 @@ template <class _Kty, class _Ty, class _Hasher, class _Alloc,
 unordered_multimap(initializer_list<pair<_Kty, _Ty>>, _Guide_size_type_t<_Alloc>, _Hasher, _Alloc)
     -> unordered_multimap<_Kty, _Ty, _Hasher, equal_to<_Kty>, _Alloc>;
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
 template <_RANGES input_range _Rng, class _Hasher = hash<_Range_key_type<_Rng>>,
     class _Keyeq = equal_to<_Range_key_type<_Rng>>, class _Alloc = allocator<_Range_to_alloc_type<_Rng>>,
     enable_if_t<conjunction_v<_Is_hasher<_Hasher>, negation<_Is_allocator<_Keyeq>>, _Is_allocator<_Alloc>>, int> = 0>
@@ -887,7 +887,7 @@ template <_RANGES input_range _Rng, class _Hasher, class _Alloc,
 unordered_multimap(from_range_t, _Rng&&, _Guide_size_type_t<_Alloc>, _Hasher, _Alloc)
     -> unordered_multimap<_Range_key_type<_Rng>, _Range_mapped_type<_Rng>, _Hasher, equal_to<_Range_key_type<_Rng>>,
         _Alloc>;
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 #endif // _HAS_CXX17
 
 template <class _Kty, class _Ty, class _Hasher, class _Keyeq, class _Alloc>

--- a/stl/inc/unordered_set
+++ b/stl/inc/unordered_set
@@ -184,7 +184,7 @@ public:
         this->insert(_First, _Last);
     }
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
     template <_Container_compatible_range<value_type> _Rng>
     unordered_set(from_range_t, _Rng&& _Range) : _Mybase(_Key_compare(), allocator_type()) {
         this->_Insert_range_unchecked(_RANGES _Ubegin(_Range), _RANGES _Uend(_Range));
@@ -236,7 +236,7 @@ public:
         _Mybase::rehash(_Buckets);
         this->_Insert_range_unchecked(_RANGES _Ubegin(_Range), _RANGES _Uend(_Range));
     }
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 
     unordered_set& operator=(const unordered_set& _Right) {
         _Mybase::operator=(_Right);
@@ -353,7 +353,7 @@ template <class _Kty, class _Hasher, class _Alloc,
 unordered_set(initializer_list<_Kty>, _Guide_size_type_t<_Alloc>, _Hasher, _Alloc)
     -> unordered_set<_Kty, _Hasher, equal_to<_Kty>, _Alloc>;
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
 template <_RANGES input_range _Rng, class _Hasher = hash<_RANGES range_value_t<_Rng>>,
     class _Keyeq = equal_to<_RANGES range_value_t<_Rng>>, class _Alloc = allocator<_RANGES range_value_t<_Rng>>,
     enable_if_t<conjunction_v<_Is_hasher<_Hasher>, negation<_Is_allocator<_Keyeq>>, _Is_allocator<_Alloc>>, int> = 0>
@@ -372,7 +372,7 @@ template <_RANGES input_range _Rng, class _Hasher, class _Alloc,
     enable_if_t<conjunction_v<_Is_hasher<_Hasher>, _Is_allocator<_Alloc>>, int> = 0>
 unordered_set(from_range_t, _Rng&&, _Guide_size_type_t<_Alloc>, _Hasher, _Alloc)
     -> unordered_set<_RANGES range_value_t<_Rng>, _Hasher, equal_to<_RANGES range_value_t<_Rng>>, _Alloc>;
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 #endif // _HAS_CXX17
 
 template <class _Kty, class _Hasher, class _Keyeq, class _Alloc>
@@ -530,7 +530,7 @@ public:
 
     unordered_multiset(unordered_multiset&& _Right, const allocator_type& _Al) : _Mybase(_STD move(_Right), _Al) {}
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
     template <_Container_compatible_range<value_type> _Rng>
     unordered_multiset(from_range_t, _Rng&& _Range) : _Mybase(_Key_compare(), allocator_type()) {
         this->_Insert_range_unchecked(_RANGES _Ubegin(_Range), _RANGES _Uend(_Range));
@@ -583,7 +583,7 @@ public:
         _Mybase::rehash(_Buckets);
         this->_Insert_range_unchecked(_RANGES _Ubegin(_Range), _RANGES _Uend(_Range));
     }
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 
     unordered_multiset& operator=(unordered_multiset&& _Right) noexcept(_Alnode_traits::is_always_equal::value&&
             is_nothrow_move_assignable_v<_Hasher>&& is_nothrow_move_assignable_v<_Keyeq>) {
@@ -692,7 +692,7 @@ template <class _Kty, class _Hasher, class _Alloc,
 unordered_multiset(initializer_list<_Kty>, _Guide_size_type_t<_Alloc>, _Hasher, _Alloc)
     -> unordered_multiset<_Kty, _Hasher, equal_to<_Kty>, _Alloc>;
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
 template <_RANGES input_range _Rng, class _Hasher = hash<_RANGES range_value_t<_Rng>>,
     class _Keyeq = equal_to<_RANGES range_value_t<_Rng>>, class _Alloc = allocator<_RANGES range_value_t<_Rng>>,
     enable_if_t<conjunction_v<_Is_hasher<_Hasher>, negation<_Is_allocator<_Keyeq>>, _Is_allocator<_Alloc>>, int> = 0>
@@ -712,7 +712,7 @@ template <_RANGES input_range _Rng, class _Hasher, class _Alloc,
     enable_if_t<conjunction_v<_Is_hasher<_Hasher>, _Is_allocator<_Alloc>>, int> = 0>
 unordered_multiset(from_range_t, _Rng&&, _Guide_size_type_t<_Alloc>, _Hasher, _Alloc)
     -> unordered_multiset<_RANGES range_value_t<_Rng>, _Hasher, equal_to<_RANGES range_value_t<_Rng>>, _Alloc>;
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 #endif // _HAS_CXX17
 
 template <class _Kty, class _Hasher, class _Keyeq, class _Alloc>

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -721,7 +721,7 @@ public:
         _Construct_n(_Convert_size<size_type>(_Ilist.size()), _Ilist.begin(), _Ilist.end());
     }
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
     template <_Container_compatible_range<_Ty> _Rng>
     constexpr vector(from_range_t, _Rng&& _Range, const _Alloc& _Al = _Alloc())
         : _Mypair(_One_then_variadic_args_t{}, _Al) {
@@ -740,7 +740,7 @@ public:
             _Proxy._Release();
         }
     }
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 
     _CONSTEXPR20 vector(const vector& _Right)
         : _Mypair(_One_then_variadic_args_t{}, _Alty_traits::select_on_container_copy_construction(_Right._Getal())) {
@@ -955,7 +955,7 @@ private:
         }
     }
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
     template <class _Iter>
     _CONSTEXPR20 void _Append_counted_range(_Iter _First, const size_type _Count) {
         // insert counted range _First + [0, _Count) at end
@@ -1012,10 +1012,10 @@ private:
             _Orphan_range(_Oldlast, _Oldlast);
         }
     }
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 
 public:
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
     template <_Container_compatible_range<_Ty> _Rng>
     constexpr void append_range(_Rng&& _Range) {
         if constexpr (_RANGES forward_range<_Rng> || _RANGES sized_range<_Rng>) {
@@ -1026,7 +1026,7 @@ public:
             _Append_uncounted_range(_RANGES _Ubegin(_Range), _RANGES _Uend(_Range));
         }
     }
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 
     template <class... _Valty>
     _CONSTEXPR20 iterator emplace(const_iterator _Where, _Valty&&... _Val) {
@@ -1316,7 +1316,7 @@ public:
         return _Make_iterator_offset(_Whereoff);
     }
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
     template <_Container_compatible_range<_Ty> _Rng>
     constexpr iterator insert_range(const_iterator _Where, _Rng&& _Range) {
         const pointer _Whereptr = _Where._Ptr;
@@ -1338,7 +1338,7 @@ public:
         }
         return _Make_iterator_offset(_Whereoff);
     }
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 
     _CONSTEXPR20 iterator insert(const_iterator _Where, initializer_list<_Ty> _Ilist) {
         const pointer _Whereptr = _Where._Ptr;
@@ -1524,7 +1524,7 @@ public:
         }
     }
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
     template <_Container_compatible_range<_Ty> _Rng>
     constexpr void assign_range(_Rng&& _Range) {
         if constexpr (_RANGES sized_range<_Rng> || _RANGES forward_range<_Rng>) {
@@ -1535,7 +1535,7 @@ public:
             _Assign_uncounted_range(_RANGES _Ubegin(_Range), _RANGES _Uend(_Range));
         }
     }
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 
     _CONSTEXPR20 void assign(const initializer_list<_Ty> _Ilist) {
         const auto _Count = _Convert_size<size_type>(_Ilist.size());
@@ -2267,11 +2267,11 @@ template <class _Iter, class _Alloc = allocator<_Iter_value_t<_Iter>>,
 vector(_Iter, _Iter, _Alloc = _Alloc()) -> vector<_Iter_value_t<_Iter>, _Alloc>;
 #endif // _HAS_CXX17
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
 template <_RANGES input_range _Rng, class _Alloc = allocator<_RANGES range_value_t<_Rng>>,
     enable_if_t<_Is_allocator<_Alloc>::value, int> = 0>
 vector(from_range_t, _Rng&&, _Alloc = _Alloc()) -> vector<_RANGES range_value_t<_Rng>, _Alloc>;
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 
 template <class _Alloc>
 class vector<bool, _Alloc>;
@@ -2967,7 +2967,7 @@ public:
         insert(begin(), _First, _Last);
     }
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
     template <_Container_compatible_range<bool> _Rng>
     constexpr vector(from_range_t, _Rng&& _Range, const _Alloc& _Al = _Alloc()) : _Mybase(_Al) {
         if constexpr (_RANGES forward_range<_Rng> || _RANGES sized_range<_Rng>) {
@@ -2978,7 +2978,7 @@ public:
             _Assign_uncounted_range(_RANGES _Ubegin(_Range), _RANGES _Uend(_Range));
         }
     }
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 
     _CONSTEXPR20 vector(vector&& _Right) noexcept(is_nothrow_move_constructible_v<_Mybase>) // strengthened
         : _Mybase(_STD move(_Right)) {
@@ -3304,12 +3304,12 @@ public:
         insert(end(), _Val);
     }
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
     template <_Container_compatible_range<bool> _Rng>
     constexpr void append_range(_Rng&& _Range) {
         insert_range(end(), _STD forward<_Rng>(_Range));
     }
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 
     _CONSTEXPR20 void pop_back() noexcept /* strengthened */ {
         erase(end() - 1);
@@ -3321,7 +3321,7 @@ public:
         insert(begin(), _First, _Last);
     }
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
     template <class _Iter>
     constexpr void _Assign_counted_range(_Iter _First, const size_type _Count) {
         _STL_INTERNAL_CHECK(this->_Myvec.empty());
@@ -3379,7 +3379,7 @@ public:
             _Assign_uncounted_range(_RANGES _Ubegin(_Range), _RANGES _Uend(_Range));
         }
     }
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 
     _CONSTEXPR20 void assign(_CRT_GUARDOVERFLOW size_type _Count, const bool& _Val) {
         clear();
@@ -3427,7 +3427,7 @@ public:
         return begin() + _Saved_offset;
     }
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
     template <_Container_compatible_range<bool> _Rng>
     constexpr iterator insert_range(const_iterator _Where, _Rng&& _Range) {
         const difference_type _Old_off = _Where - begin();
@@ -3452,7 +3452,7 @@ public:
 
         return begin() + _Old_off;
     }
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 
     _CONSTEXPR20 iterator erase(const_iterator _Where_arg) noexcept /* strengthened */ {
         iterator _Where      = _Make_iter(_Where_arg);

--- a/stl/inc/xhash
+++ b/stl/inc/xhash
@@ -960,12 +960,12 @@ public:
         _Insert_range_unchecked(_Get_unwrapped(_First), _Get_unwrapped(_Last));
     }
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
     template <_Container_compatible_range<value_type> _Rng>
     void insert_range(_Rng&& _Range) {
         _Insert_range_unchecked(_RANGES _Ubegin(_Range), _RANGES _Uend(_Range));
     }
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 
     void insert(initializer_list<value_type> _Ilist) {
         _Insert_range_unchecked(_Ilist.begin(), _Ilist.end());

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -2317,7 +2317,7 @@ constexpr _Ty* uninitialized_construct_using_allocator(_Ty* _Ptr, const _Alloc& 
 }
 #endif // _HAS_CXX20
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
 struct from_range_t {
     explicit from_range_t() = default;
 };
@@ -2336,7 +2336,7 @@ using _Range_mapped_type = typename _RANGES range_value_t<_Rng>::second_type;
 template <_RANGES input_range _Rng>
 using _Range_to_alloc_type =
     pair<const typename _RANGES range_value_t<_Rng>::first_type, typename _RANGES range_value_t<_Rng>::second_type>;
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 
 template <class _Ty,
     bool = is_empty_v<_Ty> && !is_final_v<_Ty>>

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -2417,11 +2417,11 @@ _INLINE_VAR constexpr bool _Has_minimum_allocation_alignment_string<_String,
 #pragma detect_mismatch("annotate_string", "0")
 #endif // !_INSERT_STRING_ANNOTATION
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
 template <class _Rng, class _Ty>
 concept _Contiguous_range_of =
     _RANGES contiguous_range<_Rng> && same_as<remove_cvref_t<_RANGES range_reference_t<_Rng>>, _Ty>;
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 
 template <class _Elem, class _Traits = char_traits<_Elem>, class _Alloc = allocator<_Elem>>
 class basic_string { // null-terminated transparent array of elements
@@ -2836,7 +2836,7 @@ private:
     }
 
 public:
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
     template <_Container_compatible_range<_Elem> _Rng>
     constexpr basic_string(from_range_t, _Rng&& _Range, const _Alloc& _Al = _Alloc())
         : _Mypair(_One_then_variadic_args_t{}, _Al) {
@@ -2852,7 +2852,7 @@ public:
             _Construct_from_iter(_RANGES _Ubegin(_Range), _RANGES _Uend(_Range));
         }
     }
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 
     _CONSTEXPR20 basic_string(basic_string&& _Right) noexcept
         : _Mypair(_One_then_variadic_args_t{}, _STD move(_Right._Getal())) {
@@ -3428,7 +3428,7 @@ public:
         }
     }
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
     template <_Container_compatible_range<_Elem> _Rng>
     constexpr basic_string& append_range(_Rng&& _Range) {
         if constexpr (_RANGES sized_range<_Rng> && _Contiguous_range_of<_Rng, _Elem>) {
@@ -3439,7 +3439,7 @@ public:
             return append(_Right._Mypair._Myval2._Myptr(), _Right._Mypair._Myval2._Mysize);
         }
     }
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 
     _CONSTEXPR20 basic_string& assign(const basic_string& _Right) {
         *this = _Right;
@@ -3533,7 +3533,7 @@ public:
         }
     }
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
     template <_Container_compatible_range<_Elem> _Rng>
     constexpr basic_string& assign_range(_Rng&& _Range) {
         if constexpr (_RANGES sized_range<_Rng> && _Contiguous_range_of<_Rng, _Elem>) {
@@ -3550,7 +3550,7 @@ public:
             }
         }
     }
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 
     _CONSTEXPR20 basic_string& insert(const size_type _Off, const basic_string& _Right) {
         // insert _Right at _Off
@@ -3702,7 +3702,7 @@ public:
         return begin() + static_cast<difference_type>(_Off);
     }
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
     template <_Container_compatible_range<_Elem> _Rng>
     constexpr iterator insert_range(const const_iterator _Where, _Rng&& _Range) {
 #if _ITERATOR_DEBUG_LEVEL != 0
@@ -3720,7 +3720,7 @@ public:
 
         return begin() + static_cast<difference_type>(_Off);
     }
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 
     _CONSTEXPR20 basic_string& erase(const size_type _Off = 0) { // erase elements [_Off, ...)
         _Mypair._Myval2._Check_offset(_Off);
@@ -3986,7 +3986,7 @@ public:
         }
     }
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
     template <_Container_compatible_range<_Elem> _Rng>
     constexpr basic_string& replace_with_range(const const_iterator _First, const const_iterator _Last, _Rng&& _Range) {
         _Adl_verify_range(_First, _Last);
@@ -4004,7 +4004,7 @@ public:
             return replace(_Off, _Length, _Right._Mypair._Myval2._Myptr(), _Right._Mypair._Myval2._Mysize);
         }
     }
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 
     _NODISCARD _CONSTEXPR20 iterator begin() noexcept {
         return iterator(_Refancy<pointer>(_Mypair._Myval2._Myptr()), _STD addressof(_Mypair._Myval2));
@@ -4991,12 +4991,12 @@ template <class _Elem, class _Traits, class _Alloc = allocator<_Elem>,
 basic_string(basic_string_view<_Elem, _Traits>, _Guide_size_type_t<_Alloc>, _Guide_size_type_t<_Alloc>,
     const _Alloc& = _Alloc()) -> basic_string<_Elem, _Traits, _Alloc>;
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
 template <_RANGES input_range _Rng, class _Alloc = allocator<_RANGES range_value_t<_Rng>>,
     enable_if_t<_Is_allocator<_Alloc>::value, int> = 0>
 basic_string(from_range_t, _Rng&&, _Alloc = _Alloc())
     -> basic_string<_RANGES range_value_t<_Rng>, char_traits<_RANGES range_value_t<_Rng>>, _Alloc>;
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 #endif // _HAS_CXX17
 
 template <class _Elem, class _Traits, class _Alloc>

--- a/stl/inc/xtree
+++ b/stl/inc/xtree
@@ -1268,12 +1268,12 @@ public:
         _Insert_range_unchecked(_Get_unwrapped(_First), _Get_unwrapped(_Last));
     }
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
     template <_Container_compatible_range<value_type> _Rng>
     void insert_range(_Rng&& _Range) {
         _Insert_range_unchecked(_RANGES _Ubegin(_Range), _RANGES _Uend(_Range));
     }
-#endif // __cpp_lib_containers_ranges
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 
     void insert(initializer_list<value_type> _Ilist) {
         _Insert_range_unchecked(_Ilist.begin(), _Ilist.end());

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -1538,7 +1538,7 @@ _EMIT_STL_ERROR(STL1004, "C++98 unexpected() is incompatible with C++23 unexpect
 #define __cpp_lib_array_constexpr 201803L // P0858R0 Constexpr Iterator Requirements
 #endif // _HAS_CXX17
 
-#if _HAS_CXX20 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
+#ifdef __cpp_lib_concepts
 #define __cpp_lib_chrono 201907L // P1466R3 Miscellaneous Minor Fixes For <chrono>
 #elif _HAS_CXX17
 #define __cpp_lib_chrono 201611L // P0505R0 constexpr For <chrono> (Again)

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -1394,7 +1394,7 @@ _EMIT_STL_ERROR(STL1004, "C++98 unexpected() is incompatible with C++23 unexpect
 #define __cpp_lib_concepts 202002L
 #endif // !defined(__EDG__) || defined(__INTELLISENSE__)
 
-#ifdef __cpp_lib_concepts // TRANSITION, GH-395
+#ifdef __cpp_lib_concepts
 #define __cpp_lib_algorithm_iterator_requirements 202207L
 #endif // __cpp_lib_concepts
 
@@ -1426,7 +1426,7 @@ _EMIT_STL_ERROR(STL1004, "C++98 unexpected() is incompatible with C++23 unexpect
 #define __cpp_lib_endian                  201907L
 #define __cpp_lib_erase_if                202002L
 
-#ifdef __cpp_lib_concepts // TRANSITION, GH-395
+#ifdef __cpp_lib_concepts
 #define __cpp_lib_format 202110L
 #endif // __cpp_lib_concepts
 
@@ -1455,7 +1455,7 @@ _EMIT_STL_ERROR(STL1004, "C++98 unexpected() is incompatible with C++23 unexpect
 #define __cpp_lib_list_remove_return_type 201806L
 #define __cpp_lib_math_constants          201907L
 
-#ifdef __cpp_lib_concepts // TRANSITION, GH-395
+#ifdef __cpp_lib_concepts
 #define __cpp_lib_move_iterator_concept 202207L
 #endif // __cpp_lib_concepts
 
@@ -1474,7 +1474,7 @@ _EMIT_STL_ERROR(STL1004, "C++98 unexpected() is incompatible with C++23 unexpect
 #define __cpp_lib_starts_ends_with 201711L
 #define __cpp_lib_syncbuf          201803L
 
-#ifdef __cpp_lib_concepts // TRANSITION, GH-395
+#ifdef __cpp_lib_concepts
 #define __cpp_lib_three_way_comparison 201907L
 #endif // __cpp_lib_concepts
 

--- a/tests/std/tests/GH_000545_include_compare/test_ranges.cpp
+++ b/tests/std/tests/GH_000545_include_compare/test_ranges.cpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include <version> // TRANSITION, GH-395
-#ifdef __cpp_lib_concepts // TRANSITION, GH-395
+#ifdef __cpp_lib_concepts
 
 #include <ranges>
 
@@ -10,6 +10,6 @@
 
 static_assert(std::is_eq(std::partial_ordering::equivalent));
 
-#endif // TRANSITION, GH-395
+#endif // __cpp_lib_concepts
 
 void test_ranges() {}

--- a/tests/std/tests/GH_002989_nothrow_unwrappable/test.cpp
+++ b/tests/std/tests/GH_002989_nothrow_unwrappable/test.cpp
@@ -49,7 +49,7 @@ void do_full_test() {
     do_single_test<reverse_iterator<It>, CopyUnwrapNothrow>();
     do_single_test<move_iterator<It>, CopyUnwrapNothrow>();
 
-#ifdef __cpp_lib_concepts // TRANSITION, GH-395
+#ifdef __cpp_lib_concepts
     using R = ranges::subrange<It, It>;
 
     // TRANSITION, GH-2997

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_clocks/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_clocks/test.cpp
@@ -154,7 +154,7 @@ constexpr bool test_leap_second() {
     static_assert(noexcept(equal >= leap));
     static_assert(noexcept(leap >= equal));
 
-#ifdef __cpp_lib_concepts // TRANSITION, GH-395
+#ifdef __cpp_lib_concepts
     static_assert(is_eq(leap <=> equal));
     static_assert(is_lt(leap <=> larger));
     static_assert(is_gt(leap <=> smaller));

--- a/tests/std/tests/P0433R2_deduction_guides/test.cpp
+++ b/tests/std/tests/P0433R2_deduction_guides/test.cpp
@@ -507,13 +507,13 @@ void test_basic_string() {
     static_assert(is_same_v<decltype(str17), basic_string<wchar_t, char_traits<wchar_t>, MyAlloc<wchar_t>>>);
     static_assert(is_same_v<decltype(str18), basic_string<wchar_t, char_traits<wchar_t>, MyAlloc<wchar_t>>>);
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
     basic_string str19(from_range, first);
     basic_string str20(from_range, first, myal);
 
     static_assert(is_same_v<decltype(str19), wstring>);
     static_assert(is_same_v<decltype(str20), basic_string<wchar_t, char_traits<wchar_t>, MyAlloc<wchar_t>>>);
-#endif // __cpp_lib_containers_ranges
+#endif // TRANSITION, GH-395
 }
 
 void test_basic_string_view() {
@@ -573,13 +573,13 @@ void test_sequence_container() {
     static_assert(is_same_v<decltype(c6), Sequence<long, MyAlloc<long>>>);
     static_assert(is_same_v<decltype(c7), Sequence<long, MyAlloc<long>>>);
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
     Sequence c8(from_range, first);
     Sequence c9(from_range, first, myal);
 
     static_assert(is_same_v<decltype(c8), Sequence<long>>);
     static_assert(is_same_v<decltype(c9), Sequence<long, MyAlloc<long>>>);
-#endif // __cpp_lib_containers_ranges
+#endif // TRANSITION, GH-395
 }
 
 void test_vector_bool() {
@@ -604,13 +604,13 @@ void test_vector_bool() {
     static_assert(is_same_v<decltype(vb6), vector<bool, MyAlloc<bool>>>);
     static_assert(is_same_v<decltype(vb7), vector<bool, MyAlloc<bool>>>);
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
     vector vb8(from_range, first);
     vector vb9(from_range, first, myal);
 
     static_assert(is_same_v<decltype(vb8), vector<bool>>);
     static_assert(is_same_v<decltype(vb9), vector<bool, MyAlloc<bool>>>);
-#endif // __cpp_lib_containers_ranges
+#endif // TRANSITION, GH-395
 }
 
 template <template <typename K, typename V, typename C = less<K>, typename A = allocator<pair<const K, V>>> typename M>
@@ -647,7 +647,7 @@ void test_map_or_multimap() {
     static_assert(is_same_v<decltype(m12), M<long, char, MyGreater, MyAlloc<CPurr>>>);
     static_assert(is_same_v<decltype(m13), M<long, char, less<long>, MyAlloc<CPurr>>>);
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
     M m14(from_range, first);
     M m15(from_range, first, gt);
     M m16(from_range, first, gt, myal);
@@ -657,7 +657,7 @@ void test_map_or_multimap() {
     static_assert(is_same_v<decltype(m15), M<long, char, MyGreater>>);
     static_assert(is_same_v<decltype(m16), M<long, char, MyGreater, MyAlloc<CPurr>>>);
     static_assert(is_same_v<decltype(m17), M<long, char, less<long>, MyAlloc<CPurr>>>);
-#endif // __cpp_lib_containers_ranges
+#endif // TRANSITION, GH-395
 }
 
 template <template <typename K, typename C = less<K>, typename A = allocator<K>> typename S>
@@ -688,7 +688,7 @@ void test_set_or_multiset() {
     static_assert(is_same_v<decltype(s8), S<long, less<long>, MyAlloc<long>>>);
     static_assert(is_same_v<decltype(s9), S<long, less<long>, MyAlloc<long>>>);
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
     S s10(from_range, first);
     S s11(from_range, first, gt);
     S s12(from_range, first, gt, myal);
@@ -698,7 +698,7 @@ void test_set_or_multiset() {
     static_assert(is_same_v<decltype(s11), S<long, MyGreater>>);
     static_assert(is_same_v<decltype(s12), S<long, MyGreater, MyAlloc<long>>>);
     static_assert(is_same_v<decltype(s13), S<long, less<long>, MyAlloc<long>>>);
-#endif // __cpp_lib_containers_ranges
+#endif // TRANSITION, GH-395
 }
 
 template <template <typename K, typename V, typename H = hash<K>, typename P = equal_to<K>,
@@ -752,7 +752,7 @@ void test_unordered_map_or_unordered_multimap() {
     static_assert(is_same_v<decltype(um24), UM<long, char, hash<long>, equal_to<long>, MyAlloc<CPurr>>>);
     static_assert(is_same_v<decltype(um25), UM<long, char, MyHash, equal_to<long>, MyAlloc<CPurr>>>);
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
     UM um26(from_range, first);
     UM um27(from_range, first, 7);
     UM um28(from_range, first, 7, hf);
@@ -770,7 +770,7 @@ void test_unordered_map_or_unordered_multimap() {
     static_assert(is_same_v<decltype(um31), UM<long, char, hash<long>, equal_to<long>, MyAlloc<CPurr>>>);
     static_assert(is_same_v<decltype(um32), UM<long, char, hash<long>, equal_to<long>, MyAlloc<CPurr>>>);
     static_assert(is_same_v<decltype(um33), UM<long, char, MyHash, equal_to<long>, MyAlloc<CPurr>>>);
-#endif // __cpp_lib_containers_ranges
+#endif // TRANSITION, GH-395
 }
 
 template <template <typename K, typename H = hash<K>, typename P = equal_to<K>, typename A = allocator<K>> typename US>
@@ -814,7 +814,7 @@ void test_unordered_set_or_unordered_multiset() {
     static_assert(is_same_v<decltype(us14), US<long, MyHash, equal_to<long>, MyAlloc<long>>>);
     static_assert(is_same_v<decltype(us15), US<long, MyHash, MyEqual, MyAlloc<long>>>);
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
     US us16(from_range, first);
     US us17(from_range, first, 7);
     US us18(from_range, first, 7, hf);
@@ -830,7 +830,7 @@ void test_unordered_set_or_unordered_multiset() {
     static_assert(is_same_v<decltype(us20), US<long, MyHash, MyEqual, MyAlloc<long>>>);
     static_assert(is_same_v<decltype(us21), US<long, hash<long>, equal_to<long>, MyAlloc<long>>>);
     static_assert(is_same_v<decltype(us22), US<long, MyHash, equal_to<long>, MyAlloc<long>>>);
-#endif // __cpp_lib_containers_ranges
+#endif // TRANSITION, GH-395
 }
 
 void test_queue_and_stack() {
@@ -855,13 +855,13 @@ void test_queue_and_stack() {
     static_assert(is_same_v<decltype(q4), queue<long>>);
     static_assert(is_same_v<decltype(q5), queue<long, deque<long, MyAlloc<long>>>>);
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
     queue q6(from_range, first);
     queue q7(from_range, first, myal);
 
     static_assert(is_same_v<decltype(q6), queue<long>>);
     static_assert(is_same_v<decltype(q7), queue<long, deque<long, MyAlloc<long>>>>);
-#endif // __cpp_lib_containers_ranges
+#endif // TRANSITION, GH-395
 #endif // _HAS_CXX23
 
     stack s1(lst);
@@ -879,13 +879,13 @@ void test_queue_and_stack() {
     static_assert(is_same_v<decltype(s4), stack<long>>);
     static_assert(is_same_v<decltype(s5), stack<long, deque<long, MyAlloc<long>>>>);
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
     stack s6(from_range, first);
     stack s7(from_range, first, myal);
 
     static_assert(is_same_v<decltype(s6), stack<long>>);
     static_assert(is_same_v<decltype(s7), stack<long, deque<long, MyAlloc<long>>>>);
-#endif // __cpp_lib_containers_ranges
+#endif // TRANSITION, GH-395
 #endif // _HAS_CXX23
 }
 
@@ -916,7 +916,7 @@ void test_priority_queue() {
     static_assert(is_same_v<decltype(pq8), priority_queue<long, deque<long, MyAlloc<long>>, MyGreater>>);
     static_assert(is_same_v<decltype(pq9), priority_queue<long, deque<long, MyAlloc<long>>, MyGreater>>);
 
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
     priority_queue pq10(from_range, first);
     priority_queue pq11(from_range, first, gt);
     priority_queue pq12(from_range, first, gt, myal);
@@ -926,7 +926,7 @@ void test_priority_queue() {
     static_assert(is_same_v<decltype(pq11), priority_queue<long, vector<long>, MyGreater>>);
     static_assert(is_same_v<decltype(pq12), priority_queue<long, vector<long, MyAlloc<long>>, MyGreater>>);
     static_assert(is_same_v<decltype(pq13), priority_queue<long, vector<long, MyAlloc<long>>>>);
-#endif // __cpp_lib_containers_ranges
+#endif // TRANSITION, GH-395
 }
 
 void test_iterator_adaptors() {

--- a/tests/std/tests/P0433R2_deduction_guides/test.cpp
+++ b/tests/std/tests/P0433R2_deduction_guides/test.cpp
@@ -513,7 +513,7 @@ void test_basic_string() {
 
     static_assert(is_same_v<decltype(str19), wstring>);
     static_assert(is_same_v<decltype(str20), basic_string<wchar_t, char_traits<wchar_t>, MyAlloc<wchar_t>>>);
-#endif // TRANSITION, GH-395
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 }
 
 void test_basic_string_view() {
@@ -579,7 +579,7 @@ void test_sequence_container() {
 
     static_assert(is_same_v<decltype(c8), Sequence<long>>);
     static_assert(is_same_v<decltype(c9), Sequence<long, MyAlloc<long>>>);
-#endif // TRANSITION, GH-395
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 }
 
 void test_vector_bool() {
@@ -610,7 +610,7 @@ void test_vector_bool() {
 
     static_assert(is_same_v<decltype(vb8), vector<bool>>);
     static_assert(is_same_v<decltype(vb9), vector<bool, MyAlloc<bool>>>);
-#endif // TRANSITION, GH-395
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 }
 
 template <template <typename K, typename V, typename C = less<K>, typename A = allocator<pair<const K, V>>> typename M>
@@ -657,7 +657,7 @@ void test_map_or_multimap() {
     static_assert(is_same_v<decltype(m15), M<long, char, MyGreater>>);
     static_assert(is_same_v<decltype(m16), M<long, char, MyGreater, MyAlloc<CPurr>>>);
     static_assert(is_same_v<decltype(m17), M<long, char, less<long>, MyAlloc<CPurr>>>);
-#endif // TRANSITION, GH-395
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 }
 
 template <template <typename K, typename C = less<K>, typename A = allocator<K>> typename S>
@@ -698,7 +698,7 @@ void test_set_or_multiset() {
     static_assert(is_same_v<decltype(s11), S<long, MyGreater>>);
     static_assert(is_same_v<decltype(s12), S<long, MyGreater, MyAlloc<long>>>);
     static_assert(is_same_v<decltype(s13), S<long, less<long>, MyAlloc<long>>>);
-#endif // TRANSITION, GH-395
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 }
 
 template <template <typename K, typename V, typename H = hash<K>, typename P = equal_to<K>,
@@ -770,7 +770,7 @@ void test_unordered_map_or_unordered_multimap() {
     static_assert(is_same_v<decltype(um31), UM<long, char, hash<long>, equal_to<long>, MyAlloc<CPurr>>>);
     static_assert(is_same_v<decltype(um32), UM<long, char, hash<long>, equal_to<long>, MyAlloc<CPurr>>>);
     static_assert(is_same_v<decltype(um33), UM<long, char, MyHash, equal_to<long>, MyAlloc<CPurr>>>);
-#endif // TRANSITION, GH-395
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 }
 
 template <template <typename K, typename H = hash<K>, typename P = equal_to<K>, typename A = allocator<K>> typename US>
@@ -830,7 +830,7 @@ void test_unordered_set_or_unordered_multiset() {
     static_assert(is_same_v<decltype(us20), US<long, MyHash, MyEqual, MyAlloc<long>>>);
     static_assert(is_same_v<decltype(us21), US<long, hash<long>, equal_to<long>, MyAlloc<long>>>);
     static_assert(is_same_v<decltype(us22), US<long, MyHash, equal_to<long>, MyAlloc<long>>>);
-#endif // TRANSITION, GH-395
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 }
 
 void test_queue_and_stack() {
@@ -855,13 +855,13 @@ void test_queue_and_stack() {
     static_assert(is_same_v<decltype(q4), queue<long>>);
     static_assert(is_same_v<decltype(q5), queue<long, deque<long, MyAlloc<long>>>>);
 
-#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
+#ifdef __cpp_lib_concepts
     queue q6(from_range, first);
     queue q7(from_range, first, myal);
 
     static_assert(is_same_v<decltype(q6), queue<long>>);
     static_assert(is_same_v<decltype(q7), queue<long, deque<long, MyAlloc<long>>>>);
-#endif // TRANSITION, GH-395
+#endif // __cpp_lib_concepts
 #endif // _HAS_CXX23
 
     stack s1(lst);
@@ -879,13 +879,13 @@ void test_queue_and_stack() {
     static_assert(is_same_v<decltype(s4), stack<long>>);
     static_assert(is_same_v<decltype(s5), stack<long, deque<long, MyAlloc<long>>>>);
 
-#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
+#ifdef __cpp_lib_concepts
     stack s6(from_range, first);
     stack s7(from_range, first, myal);
 
     static_assert(is_same_v<decltype(s6), stack<long>>);
     static_assert(is_same_v<decltype(s7), stack<long, deque<long, MyAlloc<long>>>>);
-#endif // TRANSITION, GH-395
+#endif // __cpp_lib_concepts
 #endif // _HAS_CXX23
 }
 
@@ -926,7 +926,7 @@ void test_priority_queue() {
     static_assert(is_same_v<decltype(pq11), priority_queue<long, vector<long>, MyGreater>>);
     static_assert(is_same_v<decltype(pq12), priority_queue<long, vector<long, MyAlloc<long>>, MyGreater>>);
     static_assert(is_same_v<decltype(pq13), priority_queue<long, vector<long, MyAlloc<long>>>>);
-#endif // TRANSITION, GH-395
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 }
 
 void test_iterator_adaptors() {

--- a/tests/std/tests/P0980R1_constexpr_strings/test.cpp
+++ b/tests/std/tests/P0980R1_constexpr_strings/test.cpp
@@ -165,9 +165,10 @@ struct string_view_convertible {
     }
 };
 
+// TRANSITION, GH-395 (equalRanges should be replaced by direct calls to ranges::equal)
 template <class Range1, class Range2>
 constexpr bool equalRanges(const Range1& range1, const Range2& range2) noexcept {
-#ifdef __cpp_lib_concepts // TRANSITION, GH-395 (equalRanges should be replaced by direct calls to ranges::equal)
+#ifdef __cpp_lib_concepts
     return ranges::equal(range1, range2);
 #else // ^^^ __cpp_lib_concepts ^^^ / vvv !__cpp_lib_concepts vvv
     return equal(begin(range1), end(range1), begin(range2), end(range2));

--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
@@ -30,7 +30,7 @@ STATIC_ASSERT(__cpp_lib_adaptor_iterator_pair_constructor == 202106L);
 STATIC_ASSERT(__cpp_lib_addressof_constexpr == 201603L);
 #endif
 
-#ifdef __cpp_lib_concepts // TRANSITION, GH-395
+#ifdef __cpp_lib_concepts
 #ifndef __cpp_lib_algorithm_iterator_requirements
 #error __cpp_lib_algorithm_iterator_requirements is not defined
 #elif __cpp_lib_algorithm_iterator_requirements != 202207L
@@ -408,7 +408,7 @@ STATIC_ASSERT(__cpp_lib_char8_t == 201907L);
 
 #ifndef __cpp_lib_chrono
 #error __cpp_lib_chrono is not defined
-#elif defined(__cpp_lib_concepts) // TRANSITION, GH-395
+#elif defined(__cpp_lib_concepts)
 #if __cpp_lib_chrono != 201907L
 #error __cpp_lib_chrono is not 201907L
 #else
@@ -828,7 +828,7 @@ STATIC_ASSERT(__cpp_lib_filesystem == 201703L);
 #endif
 #endif
 
-#ifdef __cpp_lib_concepts // TRANSITION, GH-395
+#ifdef __cpp_lib_concepts
 #ifndef __cpp_lib_format
 #error __cpp_lib_format is not defined
 #elif __cpp_lib_format != 202110L
@@ -1302,7 +1302,7 @@ STATIC_ASSERT(__cpp_lib_memory_resource == 201603L);
 #endif
 #endif
 
-#ifdef __cpp_lib_concepts // TRANSITION, GH-395
+#ifdef __cpp_lib_concepts
 #ifndef __cpp_lib_move_iterator_concept
 #error __cpp_lib_move_iterator_concept is not defined
 #elif __cpp_lib_move_iterator_concept != 202207L
@@ -1462,7 +1462,7 @@ STATIC_ASSERT(__cpp_lib_quoted_string_io == 201304L);
 #else
 STATIC_ASSERT(__cpp_lib_ranges == 202202L);
 #endif
-#elif defined(__cpp_lib_concepts) // TRANSITION, GH-395
+#elif defined(__cpp_lib_concepts)
 #ifndef __cpp_lib_ranges
 #error __cpp_lib_ranges is not defined
 #elif __cpp_lib_ranges != 202110L
@@ -1956,7 +1956,7 @@ STATIC_ASSERT(__cpp_lib_syncbuf == 201803L);
 #endif
 #endif
 
-#ifdef __cpp_lib_concepts // TRANSITION, GH-395
+#ifdef __cpp_lib_concepts
 #ifndef __cpp_lib_three_way_comparison
 #error __cpp_lib_three_way_comparison is not defined
 #elif __cpp_lib_three_way_comparison != 201907L

--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
@@ -30,7 +30,7 @@ STATIC_ASSERT(__cpp_lib_adaptor_iterator_pair_constructor == 202106L);
 STATIC_ASSERT(__cpp_lib_addressof_constexpr == 201603L);
 #endif
 
-#if _HAS_CXX20 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
+#ifdef __cpp_lib_concepts // TRANSITION, GH-395
 #ifndef __cpp_lib_algorithm_iterator_requirements
 #error __cpp_lib_algorithm_iterator_requirements is not defined
 #elif __cpp_lib_algorithm_iterator_requirements != 202207L
@@ -408,7 +408,7 @@ STATIC_ASSERT(__cpp_lib_char8_t == 201907L);
 
 #ifndef __cpp_lib_chrono
 #error __cpp_lib_chrono is not defined
-#elif _HAS_CXX20 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
+#elif defined(__cpp_lib_concepts) // TRANSITION, GH-395
 #if __cpp_lib_chrono != 201907L
 #error __cpp_lib_chrono is not 201907L
 #else
@@ -685,7 +685,7 @@ STATIC_ASSERT(__cpp_lib_constexpr_vector == 201907L);
 STATIC_ASSERT(__cpp_lib_containers_ranges == 202202L);
 #endif
 #else
-#ifdef __cpp_lib_containers_ranges
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
 #error __cpp_lib_containers_ranges is defined
 #endif
 #endif
@@ -828,7 +828,7 @@ STATIC_ASSERT(__cpp_lib_filesystem == 201703L);
 #endif
 #endif
 
-#if _HAS_CXX20 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
+#ifdef __cpp_lib_concepts // TRANSITION, GH-395
 #ifndef __cpp_lib_format
 #error __cpp_lib_format is not defined
 #elif __cpp_lib_format != 202110L
@@ -1302,7 +1302,7 @@ STATIC_ASSERT(__cpp_lib_memory_resource == 201603L);
 #endif
 #endif
 
-#if _HAS_CXX20 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
+#ifdef __cpp_lib_concepts // TRANSITION, GH-395
 #ifndef __cpp_lib_move_iterator_concept
 #error __cpp_lib_move_iterator_concept is not defined
 #elif __cpp_lib_move_iterator_concept != 202207L
@@ -1462,7 +1462,7 @@ STATIC_ASSERT(__cpp_lib_quoted_string_io == 201304L);
 #else
 STATIC_ASSERT(__cpp_lib_ranges == 202202L);
 #endif
-#elif _HAS_CXX20 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
+#elif defined(__cpp_lib_concepts) // TRANSITION, GH-395
 #ifndef __cpp_lib_ranges
 #error __cpp_lib_ranges is not defined
 #elif __cpp_lib_ranges != 202110L
@@ -1956,7 +1956,7 @@ STATIC_ASSERT(__cpp_lib_syncbuf == 201803L);
 #endif
 #endif
 
-#if _HAS_CXX20 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
+#ifdef __cpp_lib_concepts // TRANSITION, GH-395
 #ifndef __cpp_lib_three_way_comparison
 #error __cpp_lib_three_way_comparison is not defined
 #elif __cpp_lib_three_way_comparison != 201907L


### PR DESCRIPTION
We should try to minimize the number of feature-test macros used to guard conditionally-compiled product code, so that readers aren't required to memorize the content of SD-6 in order to comprehend the STL. Consequently, feature-test macros should only be used in product code when their values are not implied by language mode or a conjunction of language mode and some other feature-test macro. We should instead test `_HAS_CXXYY && defined(__other_feature_macro)` directly. Feature-test macros whose values vary according to compiler flags other than language modes, or for features that aren't yet implemented by all compilers should be tested directly (although latter will eventually be replace by langage mode tests when the minimum required versions of all supported compilers implement the feature).

Some consequences of these rules:

* `_HAS_CXX20 && defined(__cpp_lib_concepts)` is redundant since `defined(__cpp_lib_concepts)` implies `_HAS_CXX20`.

* `_HAS_CXX20` implies `__cpp_constexpr_dynamic_alloc` now that all supported C++20 front ends implement that feature

* `defined(__cpp_lib_concepts)` implies `defined(__cpp_lib_format)`

* `_HAS_CXX23 && defined(__cpp_lib_concepts)` implies `defined(__cpp_expected)` and `defined(__cpp_lib_containers_ranges)`

Note that we don't annotate plain `defined(__cpp_lib_concepts)` with `// TRANSITION, GH-395` in product because GH-395 clearly indicates that all such tests should be replaced and we don't want to churn just to add the annotation. I could be convinced to apply such annotations and remove the special case if people really want to review another few hundred mechanical changes, but for now I have instead stripped such transition comments from the few places they did appear.
