### PR TITLE
add `__forceinline` to `std::unreachable` instead of `inline`

### DIFF
--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -813,7 +813,7 @@ _NODISCARD constexpr underlying_type_t<_Ty> to_underlying(_Ty _Value) noexcept {
     return static_cast<underlying_type_t<_Ty>>(_Value);
 }
 
-[[noreturn]] inline void unreachable() noexcept /* strengthened */ {
+[[noreturn]] __forceinline void unreachable() noexcept /* strengthened */ {
     _STL_UNREACHABLE;
 #ifdef _DEBUG
     _CSTD abort(); // likely to be called in debug mode, but can't be relied upon - already entered the UB territory


### PR DESCRIPTION
Co-authored-by: Alexander Bessonov <alexbav@hhdsoftware.com>

From https://github.com/microsoft/STL/discussions/3051

And we already use `__forceinline` there: https://github.com/microsoft/STL/blob/febb6430ac48a6650b174d567a335afcc0db8dc8/stl/inc/xcharconv_ryu.h#L166