### PR TITLE
Parallel for_each iterators don't have to be mutable

### DIFF
--- a/stl/inc/execution
+++ b/stl/inc/execution
@@ -1189,7 +1189,7 @@ struct _Static_partitioned_for_each2 { // for_each task scheduled on the system 
 template <class _ExPo, class _FwdIt, class _Fn, _Enable_if_execution_policy_t<_ExPo> /* = 0 */>
 void for_each(_ExPo&&, _FwdIt _First, _FwdIt _Last, _Fn _Func) noexcept /* terminates */ {
     // perform function for each element [_First, _Last) with the indicated execution policy
-    _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt);
     _Adl_verify_range(_First, _Last);
     auto _UFirst      = _Get_unwrapped(_First);
     const auto _ULast = _Get_unwrapped(_Last);

--- a/stl/inc/execution
+++ b/stl/inc/execution
@@ -1235,7 +1235,7 @@ _FwdIt _For_each_n_ivdep(_FwdIt _First, _Diff _Count, _Fn _Func) {
 template <class _ExPo, class _FwdIt, class _Diff, class _Fn, _Enable_if_execution_policy_t<_ExPo> /* = 0 */>
 _FwdIt for_each_n(_ExPo&&, _FwdIt _First, const _Diff _Count_raw, _Fn _Func) noexcept /* terminates */ {
     // perform function for each element [_First, _First + _Count)
-    _REQUIRE_CPP17_MUTABLE_ITERATOR(_FwdIt);
+    _REQUIRE_PARALLEL_ITERATOR(_FwdIt);
     _Algorithm_int_t<_Diff> _Count = _Count_raw;
     if (0 < _Count) {
         auto _UFirst = _Get_unwrapped_n(_First, _Count);


### PR DESCRIPTION
The overloads of `for_each` and `for_each_n` that take an execution policy argument do not require that the iterator arguments always be mutable iterators.  Whether or not the iterators need to be mutable depends on what the function object does.  `for_each` and `for_each_n` are unusual, if not unique, in this regard; for all other algorithms the mutability of the iterators is specified by the algorithm.  See http://eel.is/c++draft/alg.foreach#7 , though I admit that the wording is not particularly clear about this.

Since the compiler can't reliably figure out whether or not the function object modifies the elements in the sequence, `for_each` and `for_each_n` should only check for constant iterators (`_REQUIRE_PARALLEL_ITERATOR`), not mutable iterators (`_REQUIRE_CPP17_MUTABLE_ITERATOR`).

This bug was introduced by https://github.com/microsoft/STL/pull/2960 .  That PR should not have changed `for_each` or `for_each_n`.
