### PR TITLE
Status Chart: Weekly update, TypeScript 4.8

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,8 +7,8 @@
     <!-- SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception -->
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>STL Status Chart</title>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@primer/css@20.4.2/dist/primer.min.css" />
-    <script async src="https://cdn.jsdelivr.net/npm/es-module-shims@1.5.16/dist/es-module-shims.min.js"
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@primer/css@20.4.3/dist/primer.min.css" />
+    <script async src="https://cdn.jsdelivr.net/npm/es-module-shims@1.5.17/dist/es-module-shims.min.js"
         crossorigin="anonymous"></script>
     <script type="importmap">
         { "imports": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,9 +67,9 @@
       }
     },
     "node_modules/@octokit/openapi-types": {
-      "version": "13.2.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-13.2.0.tgz",
-      "integrity": "sha512-1BhjsVrCe2cyE36Rorpeq331bcYzdb9ksCpkFdAN6RVtW67YdO3Pl4YXDC5dF2D1ia76MssJdn5RV+Gj9Fu7dQ=="
+      "version": "13.4.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-13.4.0.tgz",
+      "integrity": "sha512-2mVzW0X1+HDO3jF80/+QFZNzJiTefELKbhMu6yaBYbp/1gSMkVDm4rT472gJljTokWUlXaaE63m7WrWENhMDLw=="
     },
     "node_modules/@octokit/request": {
       "version": "6.2.1",
@@ -101,11 +101,11 @@
       }
     },
     "node_modules/@octokit/types": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-7.1.0.tgz",
-      "integrity": "sha512-+ClA0jRc9zGFj5mfQeQNfgTlelzhpAexbAueQG1t2Xn8yhgnsjkF8bgLcUUpwrpqkv296uXyiGwkqXRSU7KYzQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-7.1.1.tgz",
+      "integrity": "sha512-Dx6cNTORyVaKY0Yeb9MbHksk79L8GXsihbG6PtWqTpkyA2TY1qBWE26EQXVG3dHwY9Femdd/WEeRUEiD0+H3TQ==",
       "dependencies": {
-        "@octokit/openapi-types": "^13.1.0"
+        "@octokit/openapi-types": "^13.4.0"
       }
     },
     "node_modules/@types/cli-progress": {
@@ -122,9 +122,9 @@
       "integrity": "sha512-Lx+EZoJxUKw4dp8uei9XiUVNlgkYmax5+ovqt6Xf3LzJOnWhlfJw/jLBmqfGVwOP/pDr4HT8bI1WtxK0IChMLw=="
     },
     "node_modules/@types/node": {
-      "version": "18.7.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.6.tgz",
-      "integrity": "sha512-EdxgKRXgYsNITy5mjjXjVE/CS8YENSdhiagGrLqjG0pvA2owgJ6i4l7wy/PFZGC0B1/H20lWKN7ONVDNYDZm7A=="
+      "version": "18.7.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.13.tgz",
+      "integrity": "sha512-46yIhxSe5xEaJZXWdIBP7GU4HDTG8/eo0qd9atdiL+lFpA03y8KS+lkTN834TWJj5767GbWv4n/P6efyTFt1Dw=="
     },
     "node_modules/@types/yargs": {
       "version": "17.0.11",
@@ -997,9 +997,9 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "node_modules/typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
+      "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -1137,9 +1137,9 @@
       }
     },
     "@octokit/openapi-types": {
-      "version": "13.2.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-13.2.0.tgz",
-      "integrity": "sha512-1BhjsVrCe2cyE36Rorpeq331bcYzdb9ksCpkFdAN6RVtW67YdO3Pl4YXDC5dF2D1ia76MssJdn5RV+Gj9Fu7dQ=="
+      "version": "13.4.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-13.4.0.tgz",
+      "integrity": "sha512-2mVzW0X1+HDO3jF80/+QFZNzJiTefELKbhMu6yaBYbp/1gSMkVDm4rT472gJljTokWUlXaaE63m7WrWENhMDLw=="
     },
     "@octokit/request": {
       "version": "6.2.1",
@@ -1165,11 +1165,11 @@
       }
     },
     "@octokit/types": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-7.1.0.tgz",
-      "integrity": "sha512-+ClA0jRc9zGFj5mfQeQNfgTlelzhpAexbAueQG1t2Xn8yhgnsjkF8bgLcUUpwrpqkv296uXyiGwkqXRSU7KYzQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-7.1.1.tgz",
+      "integrity": "sha512-Dx6cNTORyVaKY0Yeb9MbHksk79L8GXsihbG6PtWqTpkyA2TY1qBWE26EQXVG3dHwY9Femdd/WEeRUEiD0+H3TQ==",
       "requires": {
-        "@octokit/openapi-types": "^13.1.0"
+        "@octokit/openapi-types": "^13.4.0"
       }
     },
     "@types/cli-progress": {
@@ -1186,9 +1186,9 @@
       "integrity": "sha512-Lx+EZoJxUKw4dp8uei9XiUVNlgkYmax5+ovqt6Xf3LzJOnWhlfJw/jLBmqfGVwOP/pDr4HT8bI1WtxK0IChMLw=="
     },
     "@types/node": {
-      "version": "18.7.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.6.tgz",
-      "integrity": "sha512-EdxgKRXgYsNITy5mjjXjVE/CS8YENSdhiagGrLqjG0pvA2owgJ6i4l7wy/PFZGC0B1/H20lWKN7ONVDNYDZm7A=="
+      "version": "18.7.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.13.tgz",
+      "integrity": "sha512-46yIhxSe5xEaJZXWdIBP7GU4HDTG8/eo0qd9atdiL+lFpA03y8KS+lkTN834TWJj5767GbWv4n/P6efyTFt1Dw=="
     },
     "@types/yargs": {
       "version": "17.0.11",
@@ -1726,9 +1726,9 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
+      "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw=="
     },
     "union": {
       "version": "0.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@octokit/graphql": "^5.0.1",
         "@types/cli-progress": "^3.11.0",
         "@types/luxon": "^3.0.0",
-        "@types/node": "^18.7.6",
+        "@types/node": "^18.7.13",
         "@types/yargs": "^17.0.11",
         "chart.js": "^3.9.1",
         "chartjs-adapter-luxon": "^1.2.0",
@@ -21,7 +21,7 @@
         "esbuild": "^0.15.5",
         "http-server": "^14.1.1",
         "luxon": "^3.0.1",
-        "typescript": "^4.7.4",
+        "typescript": "^4.8.2",
         "yargs": "^17.5.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@octokit/graphql": "^5.0.1",
     "@types/cli-progress": "^3.11.0",
     "@types/luxon": "^3.0.0",
-    "@types/node": "^18.7.6",
+    "@types/node": "^18.7.13",
     "@types/yargs": "^17.0.11",
     "chart.js": "^3.9.1",
     "chartjs-adapter-luxon": "^1.2.0",
@@ -42,7 +42,7 @@
     "esbuild": "^0.15.5",
     "http-server": "^14.1.1",
     "luxon": "^3.0.1",
-    "typescript": "^4.7.4",
+    "typescript": "^4.8.2",
     "yargs": "^17.5.1"
   }
 }

--- a/src/weekly_table.ts
+++ b/src/weekly_table.ts
@@ -281,4 +281,5 @@ export const weekly_table: WeeklyRow[] = [
     { date: '2022-08-05', vso: 175, libcxx: 584 },
     { date: '2022-08-12', vso: 178, libcxx: 584 },
     { date: '2022-08-19', vso: 182, libcxx: 582 },
+    { date: '2022-08-26', vso: 181, libcxx: 582 },
 ];

--- a/src_gather/gather_stats.ts
+++ b/src_gather/gather_stats.ts
@@ -100,6 +100,43 @@ type RawNodes = {
     rate_limit: RateLimit;
 };
 
+type ResponseTotalCounts = {
+    rateLimit: {
+        cost: number;
+        limit: number;
+    };
+    repository: {
+        pullRequests: {
+            totalCount: number;
+        };
+        issues: {
+            totalCount: number;
+        };
+    };
+};
+
+type PageInfo = {
+    hasNextPage: boolean;
+    endCursor: string;
+};
+
+type ResponsePRsAndIssues = {
+    rateLimit: {
+        cost: number;
+        remaining: number;
+    };
+    repository: {
+        pullRequests: {
+            nodes: RawPRNode[];
+            pageInfo: PageInfo;
+        };
+        issues: {
+            nodes: RawIssueNode[];
+            pageInfo: PageInfo;
+        };
+    };
+};
+
 async function retrieve_nodes_from_network() {
     const progress = {
         multi_bar: new cliProgress.MultiBar(
@@ -132,7 +169,7 @@ async function retrieve_nodes_from_network() {
                     pullRequests: { totalCount: total_prs },
                     issues: { totalCount: total_issues },
                 },
-            } = await authorized_graphql(query_total_counts);
+            } = (await authorized_graphql(query_total_counts)) as ResponseTotalCounts;
 
             spent = rateLimit.cost;
             limit = rateLimit.limit;
@@ -157,7 +194,7 @@ async function retrieve_nodes_from_network() {
             const {
                 rateLimit,
                 repository: { pullRequests, issues },
-            } = await authorized_graphql(variables);
+            } = (await authorized_graphql(variables)) as ResponsePRsAndIssues;
 
             spent += rateLimit.cost;
             remaining = rateLimit.remaining;


### PR DESCRIPTION
This week, in addition to the usual dependency updates, TypeScript 4.8 is performing stricter type checking. Now we need to immediately apply the type system to GraphQL responses, so I'm adding `ResponseTotalCounts`, `PageInfo`, and `ResponsePRsAndIssues`, completing the types that were started with `RawPRNode` etc.

As usual, this contains a "DROP BEFORE MERGING: Regen `built/status_chart.mjs`." commit to make the live preview work, which will accumulate merge conflicts.

:chart_with_downwards_trend: Live preview: [stephantlavavej.github.io/STL/](https://stephantlavavej.github.io/STL/)
===