### PR TITLE
Add `$schema` to `cgmanifest.json`

### DIFF
--- a/docs/cgmanifest.json
+++ b/docs/cgmanifest.json
@@ -1,51 +1,51 @@
 {
-  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
-  "Registrations": [
-    {
-      "component": {
-        "type": "git",
-        "git": {
-          "repositoryUrl": "https://github.com/boostorg/boost",
-          "commitHash": "b143a5b72075f47307a23e680889d8434c8afc54"
+    "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+    "Registrations": [
+        {
+            "component": {
+                "type": "git",
+                "git": {
+                    "repositoryUrl": "https://github.com/boostorg/boost",
+                    "commitHash": "b143a5b72075f47307a23e680889d8434c8afc54"
+                }
+            }
+        },
+        {
+            "component": {
+                "type": "git",
+                "git": {
+                    "repositoryUrl": "https://github.com/llvm/llvm-project.git",
+                    "commitHash": "b8d38e8b4fcab071c5c4cb698e154023d06de69e"
+                }
+            }
+        },
+        {
+            "component": {
+                "type": "git",
+                "git": {
+                    "repositoryUrl": "https://github.com/microsoft/STL.git",
+                    "commitHash": "9bf8f3f9b03ff71ea83baff189eb1d6a46dd48e1"
+                }
+            }
+        },
+        {
+            "component": {
+                "type": "git",
+                "git": {
+                    "repositoryUrl": "https://github.com/fmtlib/fmt",
+                    "commitHash": "273d8865e31659f69528623754c1742b2819ad26"
+                }
+            }
+        },
+        {
+            "component": {
+                "type": "git",
+                "git": {
+                    "repositoryUrl": "https://github.com/ulfjack/ryu.git",
+                    "commitHash": "59661c3f883dfd39cef6dc8eaf2fcbaae53597e8"
+                }
+            }
         }
-      }
-    },
-    {
-      "component": {
-        "type": "git",
-        "git": {
-          "repositoryUrl": "https://github.com/llvm/llvm-project.git",
-          "commitHash": "b8d38e8b4fcab071c5c4cb698e154023d06de69e"
-        }
-      }
-    },
-    {
-      "component": {
-        "type": "git",
-        "git": {
-          "repositoryUrl": "https://github.com/microsoft/STL.git",
-          "commitHash": "9bf8f3f9b03ff71ea83baff189eb1d6a46dd48e1"
-        }
-      }
-    },
-    {
-      "component": {
-        "type": "git",
-        "git": {
-          "repositoryUrl": "https://github.com/fmtlib/fmt",
-          "commitHash": "273d8865e31659f69528623754c1742b2819ad26"
-        }
-      }
-    },
-    {
-      "component": {
-        "type": "git",
-        "git": {
-          "repositoryUrl": "https://github.com/ulfjack/ryu.git",
-          "commitHash": "59661c3f883dfd39cef6dc8eaf2fcbaae53597e8"
-        }
-      }
-    }
-  ],
-  "Version": 1
+    ],
+    "Version": 1
 }

--- a/docs/cgmanifest.json
+++ b/docs/cgmanifest.json
@@ -1,50 +1,51 @@
 {
-    "Registrations": [
-        {
-            "component": {
-                "type": "git",
-                "git": {
-                    "repositoryUrl": "https://github.com/boostorg/boost",
-                    "commitHash": "b143a5b72075f47307a23e680889d8434c8afc54"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "git",
-                "git": {
-                    "repositoryUrl": "https://github.com/llvm/llvm-project.git",
-                    "commitHash": "b8d38e8b4fcab071c5c4cb698e154023d06de69e"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "git",
-                "git": {
-                    "repositoryUrl": "https://github.com/microsoft/STL.git",
-                    "commitHash": "9bf8f3f9b03ff71ea83baff189eb1d6a46dd48e1"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "git",
-                "git": {
-                    "repositoryUrl": "https://github.com/fmtlib/fmt",
-                    "commitHash": "273d8865e31659f69528623754c1742b2819ad26"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "git",
-                "git": {
-                    "repositoryUrl": "https://github.com/ulfjack/ryu.git",
-                    "commitHash": "59661c3f883dfd39cef6dc8eaf2fcbaae53597e8"
-                }
-            }
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://github.com/boostorg/boost",
+          "commitHash": "b143a5b72075f47307a23e680889d8434c8afc54"
         }
-    ],
-    "Version": 1
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://github.com/llvm/llvm-project.git",
+          "commitHash": "b8d38e8b4fcab071c5c4cb698e154023d06de69e"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://github.com/microsoft/STL.git",
+          "commitHash": "9bf8f3f9b03ff71ea83baff189eb1d6a46dd48e1"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://github.com/fmtlib/fmt",
+          "commitHash": "273d8865e31659f69528623754c1742b2819ad26"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://github.com/ulfjack/ryu.git",
+          "commitHash": "59661c3f883dfd39cef6dc8eaf2fcbaae53597e8"
+        }
+      }
+    }
+  ],
+  "Version": 1
 }


### PR DESCRIPTION
This pull request adds the JSON schema for `cgmanifest.json`.

## FAQ

### Why?

A JSON schema helps you to ensure that your `cgmanifest.json` file is valid.
JSON schema validation is a build-in feature in most modern IDEs like Visual Studio and Visual Studio Code.
Most modern IDEs also provide code-completion for JSON schemas.

### How can I validate my `cgmanifest.json` file?

Most modern IDEs like Visual Studio and Visual Studio Code have a built-in feature to validate JSON files.
You can also use [this small script](https://github.com/JamieMagee/verify-cgmanifest) to validate your `cgmanifest.json` file.

### Why does it suggest camel case for the properties?

Component Detection is able to read camel case and pascal case properties.
However, the JSON schema doesn't have a case-insensitive mode.
We therefore suggest camel case as it's the most common format for JSON.

### Why is the diff so large?

To deserialize the `cgmanifest.json` file, we use [`JSON.parse()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse).
However, to serialize the JSON again we use [`prettier`](https://prettier.io/).
We found that, in general, it gave smaller diffs than the default [`JSON.stringify()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) function.