### PR TITLE
Improve warning suppressions for header units

### DIFF
--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -4344,7 +4344,6 @@ namespace ranges {
             constexpr bool _Allow_vectorization =
                 conjunction_v<_Is_trivially_swappable<_Elem>, negation<is_volatile<_Elem>>>;
 
-#pragma warning(suppress : 6326) // Potential comparison of a constant with another constant
             if constexpr (_Allow_vectorization && _Nx <= 8 && (_Nx & (_Nx - 1)) == 0) {
                 if (!_STD is_constant_evaluated()) {
                     _Elem* const _First_addr = _STD to_address(_First);
@@ -4414,7 +4413,6 @@ _CONSTEXPR20 _OutIt reverse_copy(_BidIt _First, _BidIt _Last, _OutIt _Dest) {
         negation<is_volatile<_Elem>>>;
     constexpr size_t _Nx                = sizeof(_Elem);
 
-#pragma warning(suppress : 6326) // Potential comparison of a constant with another constant
     if constexpr (_Allow_vectorization && _Nx <= 8 && (_Nx & (_Nx - 1)) == 0) {
 #if _HAS_CXX20
         if (!_STD is_constant_evaluated())
@@ -4503,7 +4501,6 @@ namespace ranges {
                     is_trivially_copyable<_Elem>, negation<is_volatile<_Elem>>>;
                 constexpr size_t _Nx                = sizeof(_Elem);
 
-#pragma warning(suppress : 6326) // Potential comparison of a constant with another constant
                 if constexpr (_Allow_vectorization && _Nx <= 8 && (_Nx & (_Nx - 1)) == 0) {
                     if (!_STD is_constant_evaluated()) {
                         _Elem* const _First_addr      = _STD to_address(_First);

--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -195,6 +195,10 @@ extern "C" inline void _Check_memory_order(const unsigned int _Order) noexcept {
 #endif // x86/x64
 #endif // hardware
 
+#pragma warning(push)
+#pragma warning(disable : 6001) // "Using uninitialized memory '_Guard'"
+#pragma warning(disable : 28113) // "Accessing a local variable _Guard via an Interlocked function: This is an unusual
+                                 // usage which could be reconsidered."
 extern "C" inline void _Atomic_thread_fence(const unsigned int _Order) noexcept {
     if (_Order == _Atomic_memory_order_relaxed) {
         return;
@@ -208,9 +212,6 @@ extern "C" inline void _Atomic_thread_fence(const unsigned int _Order) noexcept 
         // _mm_mfence could have been used, but it is not supported on older x86 CPUs and is slower on some recent CPUs.
         // The memory fence provided by interlocked operations has some exceptions, but this is fine:
         // std::atomic_thread_fence works with respect to other atomics only; it may not be a full fence for all ops.
-#pragma warning(suppress : 6001) // "Using uninitialized memory '_Guard'"
-#pragma warning(suppress : 28113) // "Accessing a local variable _Guard via an Interlocked function: This is an unusual
-                                  // usage which could be reconsidered."
         (void) _InterlockedIncrement(&_Guard);
         _Compiler_barrier();
     }
@@ -220,6 +221,8 @@ extern "C" inline void _Atomic_thread_fence(const unsigned int _Order) noexcept 
 #error Unsupported hardware
 #endif // unsupported hardware
 }
+#pragma warning(pop)
+
 // End of code shared with vcruntime
 
 _EXTERN_C

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -2562,6 +2562,8 @@ template <class _CharT, class _OutputIt>
 _NODISCARD _OutputIt _Fmt_write(
     _OutputIt _Out, basic_string_view<_CharT> _Value, const _Basic_format_specs<_CharT>& _Specs, _Lazy_locale);
 
+#pragma warning(push)
+#pragma warning(disable : 4296) // '<': expression is always false
 template <class _CharT, class _OutputIt, integral _Integral>
 _NODISCARD _OutputIt _Write_integral(
     _OutputIt _Out, const _Integral _Value, _Basic_format_specs<_CharT> _Specs, _Lazy_locale _Locale) {
@@ -2642,10 +2644,7 @@ _NODISCARD _OutputIt _Write_integral(
 
     const bool _Write_leading_zeroes = _Specs._Leading_zero && _Specs._Alignment == _Fmt_align::_None;
     auto _Writer                     = [&, _End = _End](_OutputIt _Out) {
-#pragma warning(push)
-#pragma warning(disable : 4296) // '<': expression is always false
         _Out = _Write_sign(_STD move(_Out), _Specs._Sgn, _Value < _Integral{0});
-#pragma warning(pop)
         _Out = _RANGES transform(_Prefix, _STD move(_Out), _Widen_char<_CharT>{}).out;
         if (_Write_leading_zeroes && _Width < _Specs._Width) {
             _Out = _RANGES fill_n(_STD move(_Out), _Specs._Width - _Width, _CharT{'0'});
@@ -2665,6 +2664,7 @@ _NODISCARD _OutputIt _Write_integral(
 
     return _Write_aligned(_STD move(_Out), _Width, _Specs, _Fmt_align::_Right, _Writer);
 }
+#pragma warning(pop)
 
 // clang-format off
 template <class _CharT, class _OutputIt, integral _Integral>

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -1830,6 +1830,8 @@ private:
     _Format_arg_index _Index_array[_Num_args];
     unsigned char _Storage[_Storage_length];
 
+#pragma warning(push)
+#pragma warning(disable : 6386) // Buffer overrun while writing to '%s' ...
     template <class _Ty>
     void _Store_impl(
         const size_t _Arg_index, const _Basic_format_arg_type _Arg_type, const type_identity_t<_Ty>& _Val) noexcept {
@@ -1841,10 +1843,10 @@ private:
         _Index_array[_Arg_index]._Type(_Arg_type);
         if (_Arg_index + 1 < _Num_args) {
             // Set the starting index of the next arg, as that is dynamic, must be called with increasing index
-#pragma warning(suppress : 6386) // Buffer overrun while writing to '%s' ...
             _Index_array[_Arg_index + 1] = _Format_arg_index{_Store_index + sizeof(_Ty)};
         }
     }
+#pragma warning(pop)
 
     template <class _Ty>
     void _Store(const size_t _Arg_index, _Ty&& _Val) noexcept {

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -1281,6 +1281,8 @@ namespace ranges {
             }
         }
 
+#pragma warning(push)
+#pragma warning(disable : 4146) // unary minus operator applied to unsigned type, result still unsigned
         // clang-format off
         _NODISCARD constexpr auto size() const noexcept(noexcept(_Bound - _Value)) /* strengthened */
             requires (same_as<_Wi, _Bo> && _Advanceable<_Wi>)
@@ -1288,15 +1290,14 @@ namespace ranges {
                 || sized_sentinel_for<_Bo, _Wi> {
             // clang-format on
             if constexpr (_Integer_like<_Wi> && _Integer_like<_Bo>) {
-#pragma warning(suppress : 4146) // unary minus operator applied to unsigned type, result still unsigned
                 return (_Value < 0) ? ((_Bound < 0) ? (_To_unsigned_like(-_Value) - _To_unsigned_like(-_Bound))
-#pragma warning(suppress : 4146) // unary minus operator applied to unsigned type, result still unsigned
                                                     : (_To_unsigned_like(_Bound) + _To_unsigned_like(-_Value)))
                                     : (_To_unsigned_like(_Bound) - _To_unsigned_like(_Value));
             } else {
                 return _To_unsigned_like(_Bound - _Value);
             }
         }
+#pragma warning(pop)
     };
 
     // clang-format off

--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -4475,12 +4475,10 @@ inline void _Calculate_loop_simplicity(_Node_base* _Nx, _Node_base* _Ne, _Node_r
         case _N_end_rep:
             if (_Outer_rep == static_cast<_Node_end_rep*>(_Nx)->_Begin_rep) {
                 // if the _Node_rep is still undetermined when we reach its end, it is simple
-#pragma warning(push)
-#pragma warning(disable : 6011) // Dereferencing NULL pointer
+                _Analysis_assume_(_Outer_rep);
                 if (_Outer_rep->_Simple_loop == -1) {
                     _Outer_rep->_Simple_loop = 1;
                 }
-#pragma warning(pop)
                 _Outer_rep = nullptr;
             }
             break;

--- a/stl/inc/span
+++ b/stl/inc/span
@@ -554,14 +554,16 @@ public:
         return _Mysize;
     }
 
+#pragma warning(push)
+#pragma warning(disable : 4127) // conditional expression is constant
     _NODISCARD constexpr size_type size_bytes() const noexcept {
 #if _CONTAINER_DEBUG_LEVEL > 0
-#pragma warning(suppress : 4127) // conditional expression is constant
         _STL_VERIFY(_Mysize <= dynamic_extent / sizeof(element_type),
             "size of span in bytes exceeds std::numeric_limits<size_t>::max()");
 #endif // _CONTAINER_DEBUG_LEVEL > 0
         return _Mysize * sizeof(element_type);
     }
+#pragma warning(pop)
 
     _NODISCARD constexpr bool empty() const noexcept {
         return _Mysize == 0;
@@ -575,9 +577,10 @@ public:
         return _Mydata[_Off];
     }
 
+#pragma warning(push)
+#pragma warning(disable : 4127) // conditional expression is constant
     _NODISCARD constexpr reference front() const noexcept /* strengthened */ {
 #if _CONTAINER_DEBUG_LEVEL > 0
-#pragma warning(suppress : 4127) // conditional expression is constant
         _STL_VERIFY(_Mysize > 0, "front of empty span");
 #endif // _CONTAINER_DEBUG_LEVEL > 0
         return _Mydata[0];
@@ -585,11 +588,11 @@ public:
 
     _NODISCARD constexpr reference back() const noexcept /* strengthened */ {
 #if _CONTAINER_DEBUG_LEVEL > 0
-#pragma warning(suppress : 4127) // conditional expression is constant
         _STL_VERIFY(_Mysize > 0, "back of empty span");
 #endif // _CONTAINER_DEBUG_LEVEL > 0
         return _Mydata[_Mysize - 1];
     }
+#pragma warning(pop)
 
     _NODISCARD constexpr pointer data() const noexcept {
         return _Mydata;

--- a/stl/inc/thread
+++ b/stl/inc/thread
@@ -62,19 +62,16 @@ private:
         return &_Invoke<_Tuple, _Indices...>;
     }
 
+#pragma warning(push) // pointer or reference to potentially throwing function passed to 'extern "C"' function under
+#pragma warning(disable : 5039) // -EHc. Undefined behavior may occur if this function throws an exception. (/Wall)
     template <class _Fn, class... _Args>
     void _Start(_Fn&& _Fx, _Args&&... _Ax) {
         using _Tuple                 = tuple<decay_t<_Fn>, decay_t<_Args>...>;
         auto _Decay_copied           = _STD make_unique<_Tuple>(_STD forward<_Fn>(_Fx), _STD forward<_Args>(_Ax)...);
         constexpr auto _Invoker_proc = _Get_invoke<_Tuple>(make_index_sequence<1 + sizeof...(_Args)>{});
 
-#pragma warning(push)
-#pragma warning(disable : 5039) // pointer or reference to potentially throwing function passed to
-                                // extern C function under -EHc. Undefined behavior may occur
-                                // if this function throws an exception. (/Wall)
         _Thr._Hnd =
             reinterpret_cast<void*>(_CSTD _beginthreadex(nullptr, 0, _Invoker_proc, _Decay_copied.get(), 0, &_Thr._Id));
-#pragma warning(pop)
 
         if (_Thr._Hnd) { // ownership transferred to the thread
             (void) _Decay_copied.release();
@@ -83,6 +80,7 @@ private:
             _Throw_Cpp_error(_RESOURCE_UNAVAILABLE_TRY_AGAIN);
         }
     }
+#pragma warning(pop)
 
 public:
     template <class _Fn, class... _Args, enable_if_t<!is_same_v<_Remove_cvref_t<_Fn>, thread>, int> = 0>

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -4294,6 +4294,8 @@ public:
     }
 
 #if _HAS_CXX23
+#pragma warning(push)
+#pragma warning(disable : 4018) // '<=': signed/unsigned mismatch (we compare to 0 before _New_size below, so it's safe)
     template <class _Operation>
     constexpr void resize_and_overwrite(_CRT_GUARDOVERFLOW const size_type _New_size, _Operation _Op) {
         if (_Mypair._Myval2._Myres < _New_size) {
@@ -4306,11 +4308,11 @@ public:
         const auto _Result_size = _STD move(_Op)(_Mypair._Myval2._Myptr(), _New_size);
 #if _CONTAINER_DEBUG_LEVEL > 0
         _STL_VERIFY(_Result_size >= 0, "the returned size can't be smaller than 0");
-#pragma warning(suppress : 4018) //  '<=': signed/unsigned mismatch, we already compared with 0, so it's safe
         _STL_VERIFY(_Result_size <= _New_size, "the returned size can't be greater than the passed size");
 #endif // _CONTAINER_DEBUG_LEVEL > 0
         _Eos(static_cast<size_type>(_Result_size));
     }
+#pragma warning(pop)
 #endif // _HAS_CXX23
 
     _NODISCARD _CONSTEXPR20 size_type capacity() const noexcept {

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -5479,7 +5479,6 @@ _CONSTEXPR20 void reverse(const _BidIt _First, const _BidIt _Last) { // reverse 
         _Is_trivially_swappable<_Elem>, negation<is_volatile<_Elem>>>;
     constexpr size_t _Nx                = sizeof(_Elem);
 
-#pragma warning(suppress : 6326) // Potential comparison of a constant with another constant
     if constexpr (_Allow_vectorization && _Nx <= 8 && (_Nx & (_Nx - 1)) == 0) {
 #if _HAS_CXX20
         if (!_STD is_constant_evaluated())


### PR DESCRIPTION
This is a perma-workaround for DevCom-10097021 / VSO-1581774 "C++ STL header `<format>` causes C4296 warning that need to be suppressed every time". @cdacamar is investigating the underlying compiler bug, where `#pragma`s within functions aren't properly stored within an IFC. In the meantime, if we consistently push/disable/pop around a function, we'll avoid this problem.

Most of our push/disable/pops are already outside functions, so only a couple of occurrences need to be changed:

* `<format>`: Move push/disable/pop outside of `_Write_integral`.
* `<thread>`: Move push/disable/pop outside `_Start`.
  + Also update comment to exactly match the printed warning.

And one more occurrence can avoid pragmas entirely (I verified that this continues to suppress the warning):

* `<regex>`: Use `_Analysis_assume_` instead of push/disable/pop.

Next, this isn't being directly motivated by user bug reports, but I'm nervous about the occasional use of `#pragma warning(suppress : NUM)` in the headers. This seems likely to have similar problems with header units, and @AnjuDel recently encountered apparently squirrelly behavior of `suppress` in ATL/MFC. I think we should consistently push/disable/pop outside functions, which is a simple convention (and not too verbose):

* `<ranges>`: Replace 2x suppress with push/disable/pop outside of `iota_view::size`.
* `<span>`: Replace suppress with push/disable/pop outside `size_bytes`, `front`, `back`.
* `<xstring>`: Replace suppress with push/disable/pop outside of `resize_and_overwrite`.
  + Update comment due to the changed context.
* `<atomic>`: Replace suppress with push/disable/pop outside of `_Atomic_thread_fence`.
* `<format>`: Replace suppress with push/disable/pop outside of `_Format_arg_store::_Store_impl`.

Finally, one kind of suppression can be eliminated entirely, due to recent `/analyze` improvements:

* We don't need to suppress C6326 with `if constexpr`.

<details>
<summary>Click to expand example:</summary>

```
D:\GitHub\STL\out\build\x64>type woof.cpp
```
```cpp
template <typename T>
int func() {
    constexpr auto N = sizeof(T);
#ifdef USE_IF_CONSTEXPR
    if constexpr (N < 4) {
#else
    if (N < 4) {
#endif
        return 11;
    } else {
        return 22;
    }
}

int main() {
    (void) func<short>();
    (void) func<double>();
}
```
```
D:\GitHub\STL\out\build\x64>cl /EHsc /nologo /W4 /analyze /std:c++latest /MTd /Od woof.cpp
woof.cpp
woof.cpp(7): warning C4127: conditional expression is constant
woof.cpp(2): note: consider using 'if constexpr' statement instead
woof.cpp(16): note: see reference to function template instantiation 'int func<short>(void)' being compiled
D:\GitHub\STL\out\build\x64\woof.cpp(7) : warning C6326: Potential comparison of a constant with another constant.
D:\GitHub\STL\out\build\x64\woof.cpp(7) : warning C6326: Potential comparison of a constant with another constant.

D:\GitHub\STL\out\build\x64>cl /EHsc /nologo /W4 /analyze /std:c++latest /MTd /Od /DUSE_IF_CONSTEXPR woof.cpp
woof.cpp

D:\GitHub\STL\out\build\x64>
```

Verified this change:

```
D:\GitHub\STL\out\build\x64>type meow.cpp
```
```cpp
#include <algorithm>
#include <iostream>
#include <vector>
using namespace std;

void print(const vector<int>& v) {
    for (const auto& e : v) {
        cout << e << ", ";
    }
    cout << "\n";
}

int main() {
    vector<int> result{-1, -1, -1, -1};

    vector<int> v{11, 22, 33, 44};
    print(v);
    reverse(v.begin(), v.end());
    print(v);
    ranges::reverse(v);
    print(v);

    print(result);
    reverse_copy(v.begin(), v.end(), result.begin());
    print(result);
    ranges::fill(result, -1);
    print(result);
    ranges::reverse_copy(v, result.begin());
    print(result);
}
```
```
D:\GitHub\STL\out\build\x64>cl /EHsc /nologo /W4 /analyze /std:c++latest /MTd /Od /I D:\GitHub\STL\stl\inc meow.cpp && meow
meow.cpp
11, 22, 33, 44,
44, 33, 22, 11,
11, 22, 33, 44,
-1, -1, -1, -1,
44, 33, 22, 11,
-1, -1, -1, -1,
44, 33, 22, 11,
```
</details>