### PR TITLE
Update `variant` "all types same/convertible" metaprogramming

### DIFF
--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -1619,11 +1619,12 @@ template <class _From, class _To, class = void>
 struct _Invoke_convertible : false_type {};
 
 template <class _From, class _To>
-struct _Invoke_convertible<_From, _To, void_t<decltype(_Fake_copy_init<_To>(_Returns_exactly<_From>()))>> : true_type {
-};
+struct _Invoke_convertible<_From, _To, void_t<decltype(_STD _Fake_copy_init<_To>(_STD _Returns_exactly<_From>()))>>
+    : true_type {};
 
 template <class _From, class _To>
-struct _Invoke_nothrow_convertible : bool_constant<noexcept(_Fake_copy_init<_To>(_Returns_exactly<_From>()))> {};
+struct _Invoke_nothrow_convertible
+    : bool_constant<noexcept(_STD _Fake_copy_init<_To>(_STD _Returns_exactly<_From>()))> {};
 
 template <class _Result, bool _Nothrow>
 struct _Invoke_traits_common {

--- a/stl/inc/variant
+++ b/stl/inc/variant
@@ -108,14 +108,14 @@ using _Meta_apply =
     typename _Meta_apply_<_Fn, _List>::type;
 
 template <class _Fn, template <class...> class _List, class... _Types>
-struct _Meta_apply_<_Fn,
-    _List<_Types...>> { // invoke meta-callable _Fn with the parameters of a template specialization
+struct _Meta_apply_<_Fn, _List<_Types...>> {
+    // invoke meta-callable _Fn with the parameters of a template specialization
     using type = _Meta_invoke<_Fn, _Types...>;
 };
 
 template <class _Fn, class _Ty, _Ty... _Idxs>
-struct _Meta_apply_<_Fn,
-    integer_sequence<_Ty, _Idxs...>> { // invoke meta-callable _Fn with the elements of an integer_sequence
+struct _Meta_apply_<_Fn, integer_sequence<_Ty, _Idxs...>> {
+    // invoke meta-callable _Fn with the elements of an integer_sequence
     using type = _Meta_invoke<_Fn, integral_constant<_Ty, _Idxs>...>;
 };
 
@@ -188,8 +188,8 @@ using _Meta_find_index =
     // find the index of the first occurrence of _Ty in _List
     typename _Meta_find_index_<_List, _Ty>::type;
 
-constexpr size_t _Meta_find_index_i_(const bool* const _Ptr, const size_t _Count,
-    size_t _Idx = 0) { // return the index of the first true in the _Count bools at _Ptr, or _Meta_npos if all are false
+constexpr size_t _Meta_find_index_i_(const bool* const _Ptr, const size_t _Count, size_t _Idx = 0) {
+    // return the index of the first true in the _Count bools at _Ptr, or _Meta_npos if all are false
     for (; _Idx < _Count; ++_Idx) {
         if (_Ptr[_Idx]) {
             return _Idx;
@@ -214,14 +214,13 @@ using _Meta_find_unique_index =
     // The index of _Ty in _List if it occurs exactly once, otherwise _Meta_npos
     typename _Meta_find_unique_index_<_List, _Ty>::type;
 
-constexpr size_t _Meta_find_unique_index_i_2(const bool* const _Ptr, const size_t _Count,
-    const size_t
-        _First) { // return _First if there is no _First < j < _Count such that _Ptr[j] is true, otherwise _Meta_npos
+constexpr size_t _Meta_find_unique_index_i_2(const bool* const _Ptr, const size_t _Count, const size_t _First) {
+    // return _First if there is no _First < j < _Count such that _Ptr[j] is true, otherwise _Meta_npos
     return _First != _Meta_npos && _Meta_find_index_i_(_Ptr, _Count, _First + 1) == _Meta_npos ? _First : _Meta_npos;
 }
 
-constexpr size_t _Meta_find_unique_index_i_(const bool* const _Ptr,
-    const size_t _Count) { // Pass the smallest i such that _Ptr[i] is true to _Meta_find_unique_index_i_2
+constexpr size_t _Meta_find_unique_index_i_(const bool* const _Ptr, const size_t _Count) {
+    // Pass the smallest i such that _Ptr[i] is true to _Meta_find_unique_index_i_2
     return _Meta_find_unique_index_i_2(_Ptr, _Count, _Meta_find_index_i_(_Ptr, _Count));
 }
 
@@ -239,14 +238,14 @@ using _Meta_as_list =
     typename _Meta_as_list_<_Ty>::type;
 
 template <template <class...> class _List, class... _Types>
-struct _Meta_as_list_<_List<_Types...>> { // convert the parameters of an arbitrary template specialization to a
-                                          // _Meta_list of types
+struct _Meta_as_list_<_List<_Types...>> {
+    // convert the parameters of an arbitrary template specialization to a _Meta_list of types
     using type = _Meta_list<_Types...>;
 };
 
 template <class _Ty, _Ty... _Idxs>
-struct _Meta_as_list_<integer_sequence<_Ty, _Idxs...>> { // convert an integer_sequence to a _Meta_list of
-                                                         // integral_constants
+struct _Meta_as_list_<integer_sequence<_Ty, _Idxs...>> {
+    // convert an integer_sequence to a _Meta_list of integral_constants
     using type = _Meta_list<integral_constant<_Ty, _Idxs>...>;
 };
 
@@ -536,8 +535,8 @@ public:
 #endif // __cplusplus_winrt
 
 template <size_t _Idx, class _Storage>
-_NODISCARD constexpr decltype(auto) _Variant_raw_get(
-    _Storage&& _Obj) noexcept { // access the _Idx-th element of a _Variant_storage
+_NODISCARD constexpr decltype(auto) _Variant_raw_get(_Storage&& _Obj) noexcept {
+    // access the _Idx-th element of a _Variant_storage
     if constexpr (_Idx == 0) {
         return static_cast<_Storage&&>(_Obj)._Get();
     } else if constexpr (_Idx == 1) {
@@ -616,8 +615,8 @@ template <class _Fn, class _Storage,
 struct _Variant_raw_dispatch_table1; // undefined
 
 template <class _Fn, class _Storage, size_t... _Idxs>
-struct _Variant_raw_dispatch_table1<_Fn, _Storage,
-    index_sequence<_Idxs...>> { // map from canonical index to visitation target
+struct _Variant_raw_dispatch_table1<_Fn, _Storage, index_sequence<_Idxs...>> {
+    // map from canonical index to visitation target
     using _Dispatch_t = _Variant_raw_visit_t<_Fn, _Storage> (*)(_Fn&&, _Storage&&) noexcept(
         _Variant_raw_visit_noexcept<_Fn, _Storage>);
     static constexpr _Dispatch_t _Array[] = {
@@ -1200,8 +1199,8 @@ private:
 };
 
 template <class _Ty, class... _Types>
-_NODISCARD constexpr bool holds_alternative(
-    const variant<_Types...>& _Var) noexcept { // true iff _Var holds alternative _Ty
+_NODISCARD constexpr bool holds_alternative(const variant<_Types...>& _Var) noexcept {
+    // true iff _Var holds alternative _Ty
     constexpr size_t _Idx = _Meta_find_unique_index<variant<_Types...>, _Ty>::value;
     static_assert(_Idx != _Meta_npos, "holds_alternative<T>(const variant<Types...>&) requires T to occur exactly "
                                       "once in Types. (N4835 [variant.get]/1)");
@@ -1431,9 +1430,9 @@ _NODISCARD constexpr size_t _Variant_visit_index1(const size_t _Acc) noexcept {
     return _Acc;
 }
 template <class _FirstTy, class... _RestTys>
-_NODISCARD constexpr size_t _Variant_visit_index1(size_t _Acc, const _FirstTy& _First,
-    const _RestTys&... _Rest) noexcept { // calculate a canonical index from the biased indices of the variants _First
-                                         // and _Rest...
+_NODISCARD constexpr size_t _Variant_visit_index1(
+    size_t _Acc, const _FirstTy& _First, const _RestTys&... _Rest) noexcept {
+    // calculate a canonical index from the biased indices of the variants _First and _Rest...
     _Acc += (_First.index() + 1) * _Variant_total_states<_RestTys...>;
     return _Variant_visit_index1(_Acc, _Rest...);
 }
@@ -1470,8 +1469,8 @@ template <class _Ret, class _Ordinals, class _Callable, class _Variants>
 struct _Variant_dispatch_table; // undefined
 
 template <class _Ret, class... _Ordinals, class _Callable, class... _Variants>
-struct _Variant_dispatch_table<_Ret, _Meta_list<_Ordinals...>, _Callable,
-    _Meta_list<_Variants...>> { // map from canonical index to visitation target
+struct _Variant_dispatch_table<_Ret, _Meta_list<_Ordinals...>, _Callable, _Meta_list<_Variants...>> {
+    // map from canonical index to visitation target
     using _Dispatch_t                     = _Ret (*)(_Callable&&, _Variants&&...);
     static constexpr _Dispatch_t _Array[] = {
         &_Variant_dispatcher<_Ordinals>::template _Dispatch2<_Ret, _Callable, _Variants...>...};
@@ -1481,9 +1480,8 @@ template <class _Callable, class _IndexSequence, class... _Variants>
 struct _Variant_single_visit_result; // undefined
 
 template <class _Callable, size_t... _Idxs, class... _Variants>
-struct _Variant_single_visit_result<_Callable, index_sequence<_Idxs...>,
-    _Variants...> { // result type/category from invoking _Callable with the elements of
-                    // _Variants... at (_Idxs - 1)...
+struct _Variant_single_visit_result<_Callable, index_sequence<_Idxs...>, _Variants...> {
+    // result type/category from invoking _Callable with the elements of _Variants... at (_Idxs - 1)...
     using type = decltype(_STD invoke(_STD declval<_Callable>(),
         _Variant_raw_get<_Idxs == 0 ? 0 : _Idxs - 1>(_STD declval<_Variants>()._Storage())...));
 };
@@ -1513,8 +1511,8 @@ template <int _Strategy>
 struct _Visit_strategy;
 
 template <>
-struct _Visit_strategy<-1> { // Fallback strategy for visitations with too many total states for the
-                             // following "switch" strategies.
+struct _Visit_strategy<-1> {
+    // Fallback strategy for visitations with too many total states for the following "switch" strategies.
     template <class _Ret, class _ListOfIndexVectors, class _Callable, class... _Variants>
     static constexpr _Ret _Visit2(
         size_t _Idx, _Callable&& _Obj, _Variants&&... _Args) { // dispatch a visitation with many potential states
@@ -1559,8 +1557,8 @@ struct _Visit_strategy<0> {
 template <>
 struct _Visit_strategy<1> {
     template <class _Ret, class _ListOfIndexVectors, class _Callable, class... _Variants>
-    static constexpr _Ret _Visit2(
-        size_t _Idx, _Callable&& _Obj, _Variants&&... _Args) { // dispatch a visitation with 4^1 potential states
+    static constexpr _Ret _Visit2(size_t _Idx, _Callable&& _Obj, _Variants&&... _Args) {
+        // dispatch a visitation with 4^1 potential states
         _STL_STAMP(4, _STL_VISIT_STAMP);
     }
 };
@@ -1568,8 +1566,8 @@ struct _Visit_strategy<1> {
 template <>
 struct _Visit_strategy<2> {
     template <class _Ret, class _ListOfIndexVectors, class _Callable, class... _Variants>
-    static constexpr _Ret _Visit2(
-        size_t _Idx, _Callable&& _Obj, _Variants&&... _Args) { // dispatch a visitation with 4^2 potential states
+    static constexpr _Ret _Visit2(size_t _Idx, _Callable&& _Obj, _Variants&&... _Args) {
+        // dispatch a visitation with 4^2 potential states
         _STL_STAMP(16, _STL_VISIT_STAMP);
     }
 };
@@ -1577,8 +1575,8 @@ struct _Visit_strategy<2> {
 template <>
 struct _Visit_strategy<3> {
     template <class _Ret, class _ListOfIndexVectors, class _Callable, class... _Variants>
-    static constexpr _Ret _Visit2(
-        size_t _Idx, _Callable&& _Obj, _Variants&&... _Args) { // dispatch a visitation with 4^3 potential states
+    static constexpr _Ret _Visit2(size_t _Idx, _Callable&& _Obj, _Variants&&... _Args) {
+        // dispatch a visitation with 4^3 potential states
         _STL_STAMP(64, _STL_VISIT_STAMP);
     }
 };
@@ -1586,8 +1584,8 @@ struct _Visit_strategy<3> {
 template <>
 struct _Visit_strategy<4> {
     template <class _Ret, class _ListOfIndexVectors, class _Callable, class... _Variants>
-    static constexpr _Ret _Visit2(
-        size_t _Idx, _Callable&& _Obj, _Variants&&... _Args) { // dispatch a visitation with 4^4 potential states
+    static constexpr _Ret _Visit2(size_t _Idx, _Callable&& _Obj, _Variants&&... _Args) {
+        // dispatch a visitation with 4^4 potential states
         _STL_STAMP(256, _STL_VISIT_STAMP);
     }
 };

--- a/stl/inc/variant
+++ b/stl/inc/variant
@@ -31,7 +31,6 @@ _STD_BEGIN
 
 template <class...>
 struct _Meta_list; // a sequence of types (not defined)
-struct _Meta_nil {};
 
 template <class _List>
 struct _Meta_front_;
@@ -1467,16 +1466,6 @@ struct _Variant_dispatch_table<_Ret, _Meta_list<_Ordinals...>, _Callable, _Meta_
         &_Variant_dispatcher<_Ordinals>::template _Dispatch2<_Ret, _Callable, _Variants...>...};
 };
 
-template <class _Callable, class _IndexSequence, class... _Variants>
-struct _Variant_single_visit_result; // undefined
-
-template <class _Callable, size_t... _Idxs, class... _Variants>
-struct _Variant_single_visit_result<_Callable, index_sequence<_Idxs...>, _Variants...> {
-    // result type/category from invoking _Callable with the elements of _Variants... at (_Idxs - 1)...
-    using type = decltype(_STD invoke(_STD declval<_Callable>(),
-        _STD _Variant_raw_get<_Idxs == 0 ? 0 : _Idxs - 1>(_STD declval<_Variants>()._Storage())...));
-};
-
 template <int _Strategy>
 struct _Visit_strategy;
 
@@ -1593,7 +1582,7 @@ inline constexpr bool _Variant_all_visit_results_same = false;
 
 template <class _Expected, class _Callable, class... _Args>
 inline constexpr bool _Variant_all_visit_results_same<_Expected, _Callable, _Meta_list<_Args...>> =
-    is_same_v<decltype(_STD declval<_Callable>()(_STD declval<_Args>()...)), _Expected>;
+    is_same_v<decltype(_STD invoke(_STD declval<_Callable>(), _STD declval<_Args>()...)), _Expected>;
 
 template <class _Expected, class _Callable, class... _Args, class... _Types, class... _Rest>
 inline constexpr bool
@@ -1638,7 +1627,7 @@ inline constexpr bool _Variant_all_visit_results_convertible = false;
 
 template <class _Expected, class _Callable, class... _Args>
 inline constexpr bool _Variant_all_visit_results_convertible<_Expected, _Callable, _Meta_list<_Args...>> =
-    _Invoke_convertible<decltype(_STD declval<_Callable>()(_STD declval<_Args>()...)), _Expected>::value;
+    _Invoke_convertible<decltype(_STD invoke(_STD declval<_Callable>(), _STD declval<_Args>()...)), _Expected>::value;
 
 template <class _Expected, class _Callable, class... _Args, class... _Types, class... _Rest>
 inline constexpr bool

--- a/stl/inc/variant
+++ b/stl/inc/variant
@@ -39,7 +39,7 @@ using _Convertible_from_all =
     bool_constant<conjunction_v<_Invoke_convertible<_From, _To>...>>; // variadic _Invoke_convertible
 
 template <class...>
-struct _Meta_list {}; // a sequence of types
+struct _Meta_list; // a sequence of types (not defined)
 struct _Meta_nil {};
 
 template <class _List>

--- a/stl/inc/variant
+++ b/stl/inc/variant
@@ -30,15 +30,6 @@ _STL_DISABLE_CLANG_WARNINGS
 _STD_BEGIN
 
 template <class...>
-struct _All_same : true_type {};
-template <class _First, class... _Rest>
-struct _All_same<_First, _Rest...> : bool_constant<conjunction_v<is_same<_First, _Rest>...>> {}; // variadic is_same
-
-template <class _To, class... _From>
-using _Convertible_from_all =
-    bool_constant<conjunction_v<_Invoke_convertible<_From, _To>...>>; // variadic _Invoke_convertible
-
-template <class...>
 struct _Meta_list; // a sequence of types (not defined)
 struct _Meta_nil {};
 
@@ -1486,27 +1477,6 @@ struct _Variant_single_visit_result<_Callable, index_sequence<_Idxs...>, _Varian
         _Variant_raw_get<_Idxs == 0 ? 0 : _Idxs - 1>(_STD declval<_Variants>()._Storage())...));
 };
 
-template <class _Callable, class _ListOfIndexVectors, class... _Variants>
-struct _Variant_all_visit_results_same; // undefined
-
-template <class _Callable, class... _IndexVectors, class... _Variants>
-struct _Variant_all_visit_results_same<_Callable, _Meta_list<_IndexVectors...>, _Variants...>
-    : _All_same<typename _Variant_single_visit_result<_Callable, _IndexVectors,
-          _Variants...>::type...>::type { // true_type iff invocation of _Callable on the elements of _Variants with all
-                                          // sequences of indices in _IndexVectors has the same type and value category.
-};
-
-template <class _To, class _Callable, class _ListOfIndexVectors, class... _Variants>
-struct _Variant_all_visit_results_implicitly_convertible; // undefined
-
-template <class _To, class _Callable, class... _IndexVectors, class... _Variants>
-struct _Variant_all_visit_results_implicitly_convertible<_To, _Callable, _Meta_list<_IndexVectors...>, _Variants...>
-    : _Convertible_from_all<_To,
-          typename _Variant_single_visit_result<_Callable, _IndexVectors, _Variants...>::type...>::type {
-    // true_type if invocation of _Callable on the elements of _Variants with all sequences of indices in _IndexVectors
-    // is implicitly convertible to _To.
-};
-
 template <int _Strategy>
 struct _Visit_strategy;
 
@@ -1618,6 +1588,33 @@ constexpr _Ret _Visit_impl(_Callable&& _Obj, _Variants&&... _Args) {
         static_cast<_As_variant<_Variants>&&>(_Args)...);
 }
 
+template <class _Expected, class _Callable, class _ArgList, class... _Variants>
+inline constexpr bool _Variant_all_visit_results_same = false;
+
+template <class _Expected, class _Callable, class... _Args>
+inline constexpr bool _Variant_all_visit_results_same<_Expected, _Callable, _Meta_list<_Args...>> =
+    is_same_v<decltype(_STD declval<_Callable>()(_STD declval<_Args>()...)), _Expected>;
+
+template <class _Expected, class _Callable, class... _Args, class... _Types, class... _Rest>
+inline constexpr bool
+    _Variant_all_visit_results_same<_Expected, _Callable, _Meta_list<_Args...>, variant<_Types...>&, _Rest...> =
+        (_Variant_all_visit_results_same<_Expected, _Callable, _Meta_list<_Args..., _Types&>, _Rest...> && ...);
+
+template <class _Expected, class _Callable, class... _Args, class... _Types, class... _Rest>
+inline constexpr bool
+    _Variant_all_visit_results_same<_Expected, _Callable, _Meta_list<_Args...>, const variant<_Types...>&, _Rest...> =
+        (_Variant_all_visit_results_same<_Expected, _Callable, _Meta_list<_Args..., const _Types&>, _Rest...> && ...);
+
+template <class _Expected, class _Callable, class... _Args, class... _Types, class... _Rest>
+inline constexpr bool
+    _Variant_all_visit_results_same<_Expected, _Callable, _Meta_list<_Args...>, variant<_Types...>&&, _Rest...> =
+        (_Variant_all_visit_results_same<_Expected, _Callable, _Meta_list<_Args..., _Types>, _Rest...> && ...);
+
+template <class _Expected, class _Callable, class... _Args, class... _Types, class... _Rest>
+inline constexpr bool
+    _Variant_all_visit_results_same<_Expected, _Callable, _Meta_list<_Args...>, const variant<_Types...>&&, _Rest...> =
+        (_Variant_all_visit_results_same<_Expected, _Callable, _Meta_list<_Args..., const _Types>, _Rest...> && ...);
+
 template <class _Callable, class... _Variants, class = void_t<_As_variant<_Variants>...>>
 constexpr _Variant_visit_result_t<_Callable, _As_variant<_Variants>...> visit(_Callable&& _Obj, _Variants&&... _Args) {
     // Invoke _Obj with the contained values of _Args...
@@ -1627,7 +1624,7 @@ constexpr _Variant_visit_result_t<_Callable, _As_variant<_Variants>...> visit(_C
     using _ListOfIndexVectors =
         _Meta_transform<_Meta_quote<_Meta_as_integer_sequence>, _Meta_cartesian_product<_ListOfIndexLists>>;
     using _Ret = _Variant_visit_result_t<_Callable, _As_variant<_Variants>...>;
-    static_assert(_Variant_all_visit_results_same<_Callable, _ListOfIndexVectors, _As_variant<_Variants>...>::value,
+    static_assert(_Variant_all_visit_results_same<_Ret, _Callable, _Meta_list<>, _As_variant<_Variants>...>,
         "visit() requires the result of all potential invocations to have the same type and value category "
         "(N4835 [variant.visit]/2).");
 
@@ -1636,6 +1633,33 @@ constexpr _Variant_visit_result_t<_Callable, _As_variant<_Variants>...> visit(_C
 }
 
 #if _HAS_CXX20
+template <class _Expected, class _Callable, class _ArgList, class... _Variants>
+inline constexpr bool _Variant_all_visit_results_convertible = false;
+
+template <class _Expected, class _Callable, class... _Args>
+inline constexpr bool _Variant_all_visit_results_convertible<_Expected, _Callable, _Meta_list<_Args...>> =
+    _Invoke_convertible<decltype(_STD declval<_Callable>()(_STD declval<_Args>()...)), _Expected>::value;
+
+template <class _Expected, class _Callable, class... _Args, class... _Types, class... _Rest>
+inline constexpr bool
+    _Variant_all_visit_results_convertible<_Expected, _Callable, _Meta_list<_Args...>, variant<_Types...>&, _Rest...> =
+        (_Variant_all_visit_results_convertible<_Expected, _Callable, _Meta_list<_Args..., _Types&>, _Rest...> && ...);
+
+template <class _Expected, class _Callable, class... _Args, class... _Types, class... _Rest>
+inline constexpr bool _Variant_all_visit_results_convertible<_Expected, _Callable, _Meta_list<_Args...>,
+    const variant<_Types...>&, _Rest...> = (_Variant_all_visit_results_convertible<_Expected, _Callable,
+                                                _Meta_list<_Args..., const _Types&>, _Rest...> && ...);
+
+template <class _Expected, class _Callable, class... _Args, class... _Types, class... _Rest>
+inline constexpr bool
+    _Variant_all_visit_results_convertible<_Expected, _Callable, _Meta_list<_Args...>, variant<_Types...>&&, _Rest...> =
+        (_Variant_all_visit_results_convertible<_Expected, _Callable, _Meta_list<_Args..., _Types>, _Rest...> && ...);
+
+template <class _Expected, class _Callable, class... _Args, class... _Types, class... _Rest>
+inline constexpr bool _Variant_all_visit_results_convertible<_Expected, _Callable, _Meta_list<_Args...>,
+    const variant<_Types...>&&, _Rest...> =
+    (_Variant_all_visit_results_convertible<_Expected, _Callable, _Meta_list<_Args..., const _Types>, _Rest...> && ...);
+
 template <class _Ret, class _Callable, class... _Variants, class = void_t<_As_variant<_Variants>...>>
 constexpr _Ret visit(_Callable&& _Obj, _Variants&&... _Args) {
     constexpr auto _Size = _Variant_total_states<_Remove_cvref_t<_As_variant<_Variants>>...>;
@@ -1644,8 +1668,7 @@ constexpr _Ret visit(_Callable&& _Obj, _Variants&&... _Args) {
     using _ListOfIndexVectors =
         _Meta_transform<_Meta_quote<_Meta_as_integer_sequence>, _Meta_cartesian_product<_ListOfIndexLists>>;
     if constexpr (!is_void_v<_Ret>) {
-        static_assert(_Variant_all_visit_results_implicitly_convertible<_Ret, _Callable, _ListOfIndexVectors,
-                          _As_variant<_Variants>...>::value,
+        static_assert(_Variant_all_visit_results_convertible<_Ret, _Callable, _Meta_list<>, _As_variant<_Variants>...>,
             "visit<R>() requires the result of all potential invocations to be implicitly convertible to R "
             "(N4835 [variant.visit]/2).");
     }

--- a/stl/inc/variant
+++ b/stl/inc/variant
@@ -1564,16 +1564,16 @@ struct _Visit_strategy<4> {
 #undef _STL_CASE
 
 template <class... _Types>
-variant<_Types...>& _As_variant_(variant<_Types...>&);
+variant<_Types...>& _As_variant_impl(variant<_Types...>&);
 template <class... _Types>
-const variant<_Types...>& _As_variant_(const variant<_Types...>&);
+const variant<_Types...>& _As_variant_impl(const variant<_Types...>&);
 template <class... _Types>
-variant<_Types...>&& _As_variant_(variant<_Types...>&&);
+variant<_Types...>&& _As_variant_impl(variant<_Types...>&&);
 template <class... _Types>
-const variant<_Types...>&& _As_variant_(const variant<_Types...>&&);
+const variant<_Types...>&& _As_variant_impl(const variant<_Types...>&&);
 template <class _Ty>
 using _As_variant = // Deduce variant specialization from a derived type
-    decltype(_As_variant_(_STD declval<_Ty>()));
+    decltype(_As_variant_impl(_STD declval<_Ty>()));
 
 template <size_t _Size, class _Ret, class _ListOfIndexVectors, class _Callable, class... _Variants>
 constexpr _Ret _Visit_impl(_Callable&& _Obj, _Variants&&... _Args) {

--- a/stl/inc/variant
+++ b/stl/inc/variant
@@ -630,12 +630,12 @@ struct _Variant_raw_visit1<-1> { // Fallback case for variants too large for any
     }
 };
 
-#define _STL_CASE(n)                                                                                         \
-    case (n) + 1:                                                                                            \
-        if constexpr ((n) < _Size) {                                                                         \
-            return static_cast<_Fn&&>(_Func)(                                                                \
-                _Variant_tagged_ref_t<_Storage, (n)>{_Variant_raw_get<(n)>(static_cast<_Storage&&>(_Obj))}); \
-        }                                                                                                    \
+#define _STL_CASE(n)                                                                                              \
+    case (n) + 1:                                                                                                 \
+        if constexpr ((n) < _Size) {                                                                              \
+            return static_cast<_Fn&&>(_Func)(                                                                     \
+                _Variant_tagged_ref_t<_Storage, (n)>{_STD _Variant_raw_get<(n)>(static_cast<_Storage&&>(_Obj))}); \
+        }                                                                                                         \
         _STL_UNREACHABLE
 
 #define _STL_VISIT_STAMP(stamper, n)                                                                        \
@@ -1425,12 +1425,12 @@ _NODISCARD constexpr size_t _Variant_visit_index1(
     size_t _Acc, const _FirstTy& _First, const _RestTys&... _Rest) noexcept {
     // calculate a canonical index from the biased indices of the variants _First and _Rest...
     _Acc += (_First.index() + 1) * _Variant_total_states<_RestTys...>;
-    return _Variant_visit_index1(_Acc, _Rest...);
+    return _STD _Variant_visit_index1(_Acc, _Rest...);
 }
 
 template <class _Callable, class... _Types>
 using _Variant_visit_result_t =
-    decltype(_STD invoke(_STD declval<_Callable>(), _Variant_raw_get<0>(_STD declval<_Types>()._Storage())...));
+    decltype(_STD invoke(_STD declval<_Callable>(), _STD _Variant_raw_get<0>(_STD declval<_Types>()._Storage())...));
 
 template <class>
 struct _Variant_dispatcher;
@@ -1445,13 +1445,13 @@ struct _Variant_dispatcher<index_sequence<_Is...>> {
         }
 #if _HAS_CXX20
         else if constexpr (is_void_v<_Ret>) {
-            static_cast<void>(_STD invoke(
-                static_cast<_Callable&&>(_Obj), _Variant_raw_get<_Is - 1>(static_cast<_Types&&>(_Args)._Storage())...));
+            static_cast<void>(_STD invoke(static_cast<_Callable&&>(_Obj),
+                _STD _Variant_raw_get<_Is - 1>(static_cast<_Types&&>(_Args)._Storage())...));
         }
 #endif // _HAS_CXX20
         else {
-            return _STD invoke(
-                static_cast<_Callable&&>(_Obj), _Variant_raw_get<_Is - 1>(static_cast<_Types&&>(_Args)._Storage())...);
+            return _STD invoke(static_cast<_Callable&&>(_Obj),
+                _STD _Variant_raw_get<_Is - 1>(static_cast<_Types&&>(_Args)._Storage())...);
         }
     }
 };
@@ -1474,7 +1474,7 @@ template <class _Callable, size_t... _Idxs, class... _Variants>
 struct _Variant_single_visit_result<_Callable, index_sequence<_Idxs...>, _Variants...> {
     // result type/category from invoking _Callable with the elements of _Variants... at (_Idxs - 1)...
     using type = decltype(_STD invoke(_STD declval<_Callable>(),
-        _Variant_raw_get<_Idxs == 0 ? 0 : _Idxs - 1>(_STD declval<_Variants>()._Storage())...));
+        _STD _Variant_raw_get<_Idxs == 0 ? 0 : _Idxs - 1>(_STD declval<_Variants>()._Storage())...));
 };
 
 template <int _Strategy>
@@ -1573,7 +1573,7 @@ template <class... _Types>
 const variant<_Types...>&& _As_variant_impl(const variant<_Types...>&&);
 template <class _Ty>
 using _As_variant = // Deduce variant specialization from a derived type
-    decltype(_As_variant_impl(_STD declval<_Ty>()));
+    decltype(_STD _As_variant_impl(_STD declval<_Ty>()));
 
 template <size_t _Size, class _Ret, class _ListOfIndexVectors, class _Callable, class... _Variants>
 constexpr _Ret _Visit_impl(_Callable&& _Obj, _Variants&&... _Args) {
@@ -1584,7 +1584,7 @@ constexpr _Ret _Visit_impl(_Callable&& _Obj, _Variants&&... _Args) {
                             : _Size <= 256 ? 4
                                            : -1;
     return _Visit_strategy<_Strategy>::template _Visit2<_Ret, _ListOfIndexVectors>(
-        _Variant_visit_index1(0, static_cast<_As_variant<_Variants>&>(_Args)...), static_cast<_Callable&&>(_Obj),
+        _STD _Variant_visit_index1(0, static_cast<_As_variant<_Variants>&>(_Args)...), static_cast<_Callable&&>(_Obj),
         static_cast<_As_variant<_Variants>&&>(_Args)...);
 }
 
@@ -1628,7 +1628,7 @@ constexpr _Variant_visit_result_t<_Callable, _As_variant<_Variants>...> visit(_C
         "visit() requires the result of all potential invocations to have the same type and value category "
         "(N4835 [variant.visit]/2).");
 
-    return _Visit_impl<_Size, _Ret, _ListOfIndexVectors>(
+    return _STD _Visit_impl<_Size, _Ret, _ListOfIndexVectors>(
         static_cast<_Callable&&>(_Obj), static_cast<_Variants&&>(_Args)...);
 }
 
@@ -1673,7 +1673,7 @@ constexpr _Ret visit(_Callable&& _Obj, _Variants&&... _Args) {
             "(N4835 [variant.visit]/2).");
     }
 
-    return _Visit_impl<_Size, _Ret, _ListOfIndexVectors>(
+    return _STD _Visit_impl<_Size, _Ret, _ListOfIndexVectors>(
         static_cast<_Callable&&>(_Obj), static_cast<_Variants&&>(_Args)...);
 }
 #endif // _HAS_CXX20

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -846,7 +846,6 @@ std/strings/basic.string/string.modifiers/robust_against_adl.pass.cpp FAIL
 std/thread/thread.threads/thread.thread.class/thread.thread.constr/robust_against_adl.pass.cpp FAIL
 std/utilities/function.objects/func.wrap/func.wrap.func/robust_against_adl.pass.cpp FAIL
 std/utilities/function.objects/refwrap/refwrap.invoke/robust_against_adl.pass.cpp FAIL
-std/utilities/variant/variant.visit/robust_against_adl.pass.cpp FAIL
 
 # Not yet analyzed. Possibly C1XX constexpr bug.
 std/utilities/function.objects/func.invoke/invoke_constexpr.pass.cpp:0 FAIL

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -842,7 +842,6 @@ strings\basic.string\string.modifiers\robust_against_adl.pass.cpp
 thread\thread.threads\thread.thread.class\thread.thread.constr\robust_against_adl.pass.cpp
 utilities\function.objects\func.wrap\func.wrap.func\robust_against_adl.pass.cpp
 utilities\function.objects\refwrap\refwrap.invoke\robust_against_adl.pass.cpp
-utilities\variant\variant.visit\robust_against_adl.pass.cpp
 
 # Not yet analyzed. Possibly C1XX constexpr bug.
 utilities\function.objects\func.invoke\invoke_constexpr.pass.cpp

--- a/tests/std/tests/P0088R3_variant/test.cpp
+++ b/tests/std/tests/P0088R3_variant/test.cpp
@@ -7061,14 +7061,12 @@ namespace msvc {
         };
 
         void run_test() {
-            {
-                using V = std::variant<base, derived>;
-                assert(std::visit(&base::x, V{base{13}}) == 13);
-                assert(std::visit(&base::x, V{derived{{42}, 29}}) == 42);
+            using V = std::variant<base, derived>;
+            assert(std::visit(&base::x, V{base{13}}) == 13);
+            assert(std::visit(&base::x, V{derived{{42}, 29}}) == 42);
 
-                assert(std::visit(&base::f, V{base{13}}) == 13);
-                assert(std::visit(&base::f, V{derived{{42}, 29}}) == 42);
-            }
+            assert(std::visit(&base::f, V{base{13}}) == 13);
+            assert(std::visit(&base::f, V{derived{{42}, 29}}) == 42);
         }
     } // namespace visit_pointer_to_member
 

--- a/tests/std/tests/P0088R3_variant/test.cpp
+++ b/tests/std/tests/P0088R3_variant/test.cpp
@@ -7048,6 +7048,30 @@ namespace msvc {
 #endif // _HAS_CXX20
     } // namespace visit_R
 
+    namespace visit_pointer_to_member {
+        struct base {
+            int x;
+
+            int f() const {
+                return x;
+            }
+        };
+        struct derived : base {
+            int y;
+        };
+
+        void run_test() {
+            {
+                using V = std::variant<base, derived>;
+                assert(std::visit(&base::x, V{base{13}}) == 13);
+                assert(std::visit(&base::x, V{derived{{42}, 29}}) == 42);
+
+                assert(std::visit(&base::f, V{base{13}}) == 13);
+                assert(std::visit(&base::f, V{derived{{42}, 29}}) == 42);
+            }
+        }
+    } // namespace visit_pointer_to_member
+
     template <class, class = void>
     inline constexpr bool has_type = false;
     template <class T>
@@ -7198,6 +7222,7 @@ int main() {
     msvc::derived_variant::run_test();
     msvc::visit::run_test();
     msvc::visit_R::run_test();
+    msvc::visit_pointer_to_member::run_test();
 
     msvc::vso468746::run_test();
     msvc::vso508126::run_test();

--- a/tests/std/tests/P0088R3_variant/test.cpp
+++ b/tests/std/tests/P0088R3_variant/test.cpp
@@ -7122,6 +7122,25 @@ namespace msvc {
             Overload(42);
         }
     } // namespace DevCom1031281
+
+    namespace gh2770 {
+        // Previous metaprogramming to validate the type requirements for std::visit required typelists too long for
+        // Clang.
+        struct S {
+            template <class T0, class T1, class T2, class T3, class T4>
+            int operator()(T0, T1, T2, T3, T4) const {
+                return 1729;
+            }
+        };
+
+        void run_test() {
+            using V = std::variant<char, int, long, long long>;
+            assert(std::visit(S{}, V{'a'}, V{'b'}, V{10}, V{20L}, V{30LL}) == 1729);
+#if _HAS_CXX20
+            assert(std::visit<int>(S{}, V{'a'}, V{'b'}, V{10}, V{20L}, V{30LL}) == 1729);
+#endif // _HAS_CXX20
+        }
+    } // namespace gh2770
 } // namespace msvc
 
 int main() {
@@ -7184,4 +7203,5 @@ int main() {
     msvc::vso508126::run_test();
     msvc::vso492097::run_test();
     msvc::DevCom1031281::run_test();
+    msvc::gh2770::run_test();
 }


### PR DESCRIPTION
And a few other minor changes while we're here. I've separated changes out by commit for ease of review, but this should be squash merged. The most significant change here - others are self-explanatory - replaces the metaprogramming used to enforce the Standard's requirements that "For each valid pack m, e(m) is a valid expression. All such expressions are of the same type
and value category" ([variant.visit]/5). 

here are different mechanisms to validate the requirement for `visit<R>` and for plain `visit`. Previously, we created a single typelist where each type represented one possible configuration of the set of argument variants to a visit call, and then folded over a single giant pack expansion of visitor evaluations ensuring they had the same type and value category (or are all convertible to `R` for `visit<R>`). This was enormously expensive for throughput when the number of possible states is large since the compilers burn a lot of memory maintaining long typelists. The new version uses tree evaluation, where each internal node of the tree `and`s together the result of evaluating its child nodes, which each correspond to a possible state of a single argument variant. Leaves correspond to potential calls and have a boolean value indicating whether that potential call has the same type and value category as the first valid configuration (has a type and value category convertible to the result type for `visit<R>`).

The resulting speedup for the long-pole `/analyze` configs of the `visit` tests in the "Update LLVM" PR is around 50%.

Fixes #2770. 
Unblocks #2976.
