### PR TITLE
1ES Hosted Pools: Use spot VMs

### DIFF
--- a/azure-devops/create-1es-hosted-pool.ps1
+++ b/azure-devops/create-1es-hosted-pool.ps1
@@ -398,7 +398,7 @@ $PoolName = $ResourceGroupName + '-Pool'
 $PoolProperties = @{
   'organization' = 'https://dev.azure.com/vclibs'
   'projects' = @('STL')
-  'sku' = @{ 'name' = $VMSize; 'tier' = 'StandardSSD'; }
+  'sku' = @{ 'name' = $VMSize; 'tier' = 'StandardSSD'; 'enableSpot' = $true; }
   'images' = @(@{ 'imageName' = $ImageName; 'poolBufferPercentage' = '100'; })
   'maxPoolSize' = 64
   'agentProfile' = @{ 'type' = 'Stateless'; }

--- a/azure-devops/create-1es-hosted-pool.ps1
+++ b/azure-devops/create-1es-hosted-pool.ps1
@@ -24,7 +24,7 @@ $ImageOffer = 'WindowsServer'
 $ImageSku = '2022-datacenter-g2'
 
 $ProgressActivity = 'Preparing STL CI pool'
-$TotalProgress = 24
+$TotalProgress = 25
 $CurrentProgress = 1
 
 <#
@@ -131,7 +131,7 @@ Set-AzContext `
 Display-ProgressBar -Status 'Creating resource group'
 
 $ResourceGroupName = 'StlBuild-' + $CurrentDate.ToString('yyyy-MM-ddTHHmm')
-$AdminPW = New-Password
+
 # TRANSITION, this opt-in tag should be unnecessary after 2022-09-30.
 $SimplySecureV2OptInTag = @{ 'NRMSV2OptIn' = $CurrentDate.ToString('yyyyMMdd'); }
 
@@ -140,6 +140,10 @@ New-AzResourceGroup `
   -Location $Location `
   -Tag $SimplySecureV2OptInTag | Out-Null
 
+####################################################################################################
+Display-ProgressBar -Status 'Creating credentials'
+
+$AdminPW = New-Password
 $AdminPWSecure = ConvertTo-SecureString $AdminPW -AsPlainText -Force
 $Credential = New-Object System.Management.Automation.PSCredential ('AdminUser', $AdminPWSecure)
 

--- a/azure-devops/create-1es-hosted-pool.ps1
+++ b/azure-devops/create-1es-hosted-pool.ps1
@@ -24,7 +24,7 @@ $ImageOffer = 'WindowsServer'
 $ImageSku = '2022-datacenter-g2'
 
 $ProgressActivity = 'Preparing STL CI pool'
-$TotalProgress = 23
+$TotalProgress = 24
 $CurrentProgress = 1
 
 <#
@@ -216,7 +216,7 @@ $VirtualNetwork = New-AzVirtualNetwork `
   -Subnet $Subnet
 
 ####################################################################################################
-Display-ProgressBar -Status 'Creating prototype VM'
+Display-ProgressBar -Status 'Creating network interface'
 
 $NicName = $ResourceGroupName + '-NIC'
 $Nic = New-AzNetworkInterface `
@@ -224,6 +224,9 @@ $Nic = New-AzNetworkInterface `
   -ResourceGroupName $ResourceGroupName `
   -Location $Location `
   -Subnet $VirtualNetwork.Subnets[0]
+
+####################################################################################################
+Display-ProgressBar -Status 'Creating prototype VM'
 
 $VM = New-AzVMConfig `
   -Name $ProtoVMName `

--- a/azure-devops/create-1es-hosted-pool.ps1
+++ b/azure-devops/create-1es-hosted-pool.ps1
@@ -447,4 +447,5 @@ Remove-AzNetworkSecurityGroup `
 ####################################################################################################
 Write-Progress -Activity $ProgressActivity -Completed
 
+Write-Host "Elapsed time: $(((Get-Date) - $CurrentDate).ToString('hh\:mm\:ss'))"
 Write-Host "Finished creating pool: $PoolName"

--- a/azure-devops/create-1es-hosted-pool.ps1
+++ b/azure-devops/create-1es-hosted-pool.ps1
@@ -150,60 +150,11 @@ $Credential = New-Object System.Management.Automation.PSCredential ('AdminUser',
 ####################################################################################################
 Display-ProgressBar -Status 'Creating virtual network'
 
-$allowHttp = New-AzNetworkSecurityRuleConfig `
-  -Name AllowHTTP `
-  -Description 'Allow HTTP(S)' `
-  -Access Allow `
-  -Protocol Tcp `
-  -Direction Outbound `
-  -Priority 1000 `
-  -SourceAddressPrefix * `
-  -SourcePortRange * `
-  -DestinationAddressPrefix * `
-  -DestinationPortRange @(80, 443)
-
-$allowQuic = New-AzNetworkSecurityRuleConfig `
-  -Name AllowQUIC `
-  -Description 'Allow QUIC' `
-  -Access Allow `
-  -Protocol Udp `
-  -Direction Outbound `
-  -Priority 1010 `
-  -SourceAddressPrefix * `
-  -SourcePortRange * `
-  -DestinationAddressPrefix * `
-  -DestinationPortRange 443
-
-$allowDns = New-AzNetworkSecurityRuleConfig `
-  -Name AllowDNS `
-  -Description 'Allow DNS' `
-  -Access Allow `
-  -Protocol * `
-  -Direction Outbound `
-  -Priority 1020 `
-  -SourceAddressPrefix * `
-  -SourcePortRange * `
-  -DestinationAddressPrefix * `
-  -DestinationPortRange 53
-
-$denyEverythingElse = New-AzNetworkSecurityRuleConfig `
-  -Name DenyElse `
-  -Description 'Deny everything else' `
-  -Access Deny `
-  -Protocol * `
-  -Direction Outbound `
-  -Priority 2000 `
-  -SourceAddressPrefix * `
-  -SourcePortRange * `
-  -DestinationAddressPrefix * `
-  -DestinationPortRange *
-
 $NetworkSecurityGroupName = $ResourceGroupName + '-NetworkSecurity'
 $NetworkSecurityGroup = New-AzNetworkSecurityGroup `
   -Name $NetworkSecurityGroupName `
   -ResourceGroupName $ResourceGroupName `
-  -Location $Location `
-  -SecurityRules @($allowHttp, $allowQuic, $allowDns, $denyEverythingElse)
+  -Location $Location
 
 $SubnetName = $ResourceGroupName + '-Subnet'
 $Subnet = New-AzVirtualNetworkSubnetConfig `

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@ variables:
   buildOutputLocation: 'D:\build'
 
 pool:
-  name: 'StlBuild-2022-08-25T1435-Pool'
+  name: 'StlBuild-2022-09-01T2216-Pool'
   demands: EnableSpotVM -equals true
 
 stages:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,9 @@ variables:
   tmpDir: 'D:\Temp'
   buildOutputLocation: 'D:\build'
 
-pool: 'StlBuild-2022-08-25T1435-Pool'
+pool:
+  name: 'StlBuild-2022-08-25T1435-Pool'
+  demands: EnableSpotVM -equals true
 
 stages:
   - stage: Code_Format


### PR DESCRIPTION
This updates our 1ES Hosted Pools (#3054) to use spot VMs, like our old Virtual Machine Scale Sets did. The tradeoff is the same: they are occasionally subject to eviction due to fluctuating capacity, but they're cheaper.

To do this, we need to pass an `'enableSpot' = $true;` property in `create-1es-hosted-pool.ps1`, and then we need to [specify demands](https://docs.microsoft.com/en-us/azure/devops/pipelines/process/demands?view=azure-devops&tabs=yaml) in `azure-pipelines.yml`.

Also, some script improvements/refactorings (as usual, apologies for mixing this into a PR with a behavioral change, but it's cleanly factored into separate commits, and updating the pool is a big enough production that I don't want to create a separate PR for this).

* Print elapsed time.
  + This is so I can notice if the guidance in the wiki is out of date. (Currently the wiki says to expect 40 minutes and this took 41 minutes.)
* Add progress status 'Creating network interface'.
* Group commands, add progress status 'Creating credentials'.
* Drop network security rules.
  + This wasn't really achieving anything, and I suspect that it has no effect with 1ES Hosted Pools (I haven't investigated this, but it may be the case that the virtual network is essentially "lost" when the VM image is generalized and captured; note that we now delete the virtual network components at the end of the script).