### PR TITLE
update `boost-math` and fix `std::ellint_2`

### DIFF
--- a/tests/std/tests/LWG3234_math_special_overloads/test.cpp
+++ b/tests/std/tests/LWG3234_math_special_overloads/test.cpp
@@ -548,6 +548,15 @@ void test_sph_neumann() {
     assert(expect_epsilons(sph_neumann(1, 1), -cos(1) - sin(1), 2));
 }
 
+void assert_close(const double f, const double g) {
+    assert(abs(f - g) < 0.01);
+}
+
+// Also test GH-3076 <cmath>: Invalid output for incomplete elliptic integral of the second kind with k = 1
+void test_gh_3076() {
+    assert_close(ellint_2(1, 6.2831853071795862), 4.0);
+}
+
 int main() {
     test_assoc_laguerre();
     test_assoc_legendre();
@@ -570,4 +579,6 @@ int main() {
     test_sph_bessel();
     test_sph_legendre();
     test_sph_neumann();
+
+    test_gh_3076();
 }


### PR DESCRIPTION
Fixes #3076 

I updated `boost-math` submodule to 1.80, https://github.com/boostorg/math/releases/tag/boost-1.80.0

I copied `assert_close` from: https://github.com/microsoft/STL/blob/f9697fc439f863c444c729ad6ffbddd574797cda/tests/std/tests/Dev09_158181_tr1_unordered_meow_swap/test.cpp#L22-L24


Do we need to update something else like these hashes https://github.com/microsoft/STL/pull/2598 ?

Am I correct that this change is a `affects redist` change and it is blocked for now?