### PR TITLE
Skip Azure Pipelines for draft PRs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,6 +11,9 @@ pool:
   name: 'StlBuild-2022-09-01T2216-Pool'
   demands: EnableSpotVM -equals true
 
+pr:
+  drafts: false
+
 stages:
   - stage: Code_Format
     displayName: 'Code Format'

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -1532,21 +1532,20 @@ _EMIT_STL_ERROR(STL1004, "C++98 unexpected() is incompatible with C++23 unexpect
 #define __cpp_lib_bit_cast                      201806L
 #define __cpp_lib_bitops                        201907L
 #define __cpp_lib_bounded_array_traits          201902L
-
-#define __cpp_lib_constexpr_algorithms    201806L
-#define __cpp_lib_constexpr_complex       201711L
-#define __cpp_lib_constexpr_dynamic_alloc 201907L
-#define __cpp_lib_constexpr_functional    201907L
-#define __cpp_lib_constexpr_iterator      201811L
-#define __cpp_lib_constexpr_numeric       201911L
-#define __cpp_lib_constexpr_string        201907L
-#define __cpp_lib_constexpr_string_view   201811L
-#define __cpp_lib_constexpr_tuple         201811L
-#define __cpp_lib_constexpr_utility       201811L
-#define __cpp_lib_constexpr_vector        201907L
-#define __cpp_lib_destroying_delete       201806L
-#define __cpp_lib_endian                  201907L
-#define __cpp_lib_erase_if                202002L
+#define __cpp_lib_constexpr_algorithms          201806L
+#define __cpp_lib_constexpr_complex             201711L
+#define __cpp_lib_constexpr_dynamic_alloc       201907L
+#define __cpp_lib_constexpr_functional          201907L
+#define __cpp_lib_constexpr_iterator            201811L
+#define __cpp_lib_constexpr_numeric             201911L
+#define __cpp_lib_constexpr_string              201907L
+#define __cpp_lib_constexpr_string_view         201811L
+#define __cpp_lib_constexpr_tuple               201811L
+#define __cpp_lib_constexpr_utility             201811L
+#define __cpp_lib_constexpr_vector              201907L
+#define __cpp_lib_destroying_delete             201806L
+#define __cpp_lib_endian                        201907L
+#define __cpp_lib_erase_if                      202002L
 
 #ifdef __cpp_lib_concepts
 #define __cpp_lib_format 202110L
@@ -1581,8 +1580,7 @@ _EMIT_STL_ERROR(STL1004, "C++98 unexpected() is incompatible with C++23 unexpect
 #define __cpp_lib_move_iterator_concept 202207L
 #endif // __cpp_lib_concepts
 
-#define __cpp_lib_polymorphic_allocator 201902L
-
+#define __cpp_lib_polymorphic_allocator   201902L
 #define __cpp_lib_remove_cvref            201711L
 #define __cpp_lib_semaphore               201907L
 #define __cpp_lib_smart_ptr_for_overwrite 202002L


### PR DESCRIPTION
# Documentation

* [Build GitHub repositories: Draft PR validation](https://docs.microsoft.com/en-us/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#draft-pr-validation)
  > By default, pull request triggers fire on draft pull requests and pull requests that are ready for review. To disable pull request triggers for draft pull requests, set the `drafts` property to `false`.
* [YAML schema: pr definition](https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema/pr?view=azure-pipelines#pr-autocancel-branches-paths-drafts)

# Experience

## Creating a draft PR: no checks

As desired, creating a draft PR doesn't run checks (except for the CLA check, which is independent). The experience is that microsoft.STL remains "Expected -- Waiting for status to be reported". Internally, nothing appears in the logs for the agent pool in Azure DevOps, or the 1ES Hosted Pool in Azure Portal - which is good, as that indicates that no resources will be consumed.

<details>
<summary>Click to expand screenshot:</summary>

<img width="871" alt="draft-prs" src="https://user-images.githubusercontent.com/4231088/188337973-23b64230-812d-4fe0-bb5b-d48db25e7f91.png">
</details>

## Marking a PR as ready for review: still no checks

:warning: Here's the one potential surprise in the experience. If a draft PR is marked as ready for review, that does *not* run checks:

<details>
<summary>Click to expand screenshot:</summary>

<img width="870" alt="draft-prs-2" src="https://user-images.githubusercontent.com/4231088/188337980-56405293-ff68-4c68-a149-4bc598f1875b.png">
</details>

microsoft.STL is still "Expected -- Waiting for status to be reported". Apparently, Azure Pipelines can't or won't detect this state transition.

This seems simple to explain to contributors. It should also be simple to deal with - when finishing changes to a PR, first set it to ready for review, then push the new commits. If this is done out of order, either a trivial commit can be pushed (like a merge with `main`, or a comment/whitespace change), or a maintainer can manually run checks.

## Pushing commits after ready for review: checks run normally

Finally, to test the experience, I pushed an additional commit to this PR (consolidating the `yvals_core.h` feature-test macros by removing a couple of empty lines that had accumulated). That started checks normally, proving that a PR which was created in draft state and then set to "ready for review" will behave as usual.

(I haven't bothered to check what happens if a ready-for-review PR is moved back to draft state and then additional commits are pushed, but I am 99% sure that the YAML will be respected and no checks will run.)

