### PR TITLE
Check `make_format_args`'s preconditions

### DIFF
--- a/stl/inc/format
+++ b/stl/inc/format
@@ -3397,11 +3397,15 @@ using wformat_args = basic_format_args<wformat_context>;
 
 template <class _Context = format_context, class... _Args>
 _NODISCARD auto make_format_args(_Args&&... _Vals) {
+    static_assert((_Has_formatter<_Args, _Context> && ...),
+        "Cannot format an argument. To make type T formattable, provide a formatter<T> specialization.");
     return _Format_arg_store<_Context, _Args...>{_Vals...};
 }
 
 template <class... _Args>
 _NODISCARD auto make_wformat_args(_Args&&... _Vals) {
+    static_assert((_Has_formatter<_Args, wformat_context> && ...),
+        "Cannot format an argument. To make type T formattable, provide a formatter<T> specialization.");
     return _Format_arg_store<wformat_context, _Args...>{_Vals...};
 }
 

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -3398,14 +3398,16 @@ using wformat_args = basic_format_args<wformat_context>;
 template <class _Context = format_context, class... _Args>
 _NODISCARD auto make_format_args(_Args&&... _Vals) {
     static_assert((_Has_formatter<_Args, _Context> && ...),
-        "Cannot format an argument. To make type T formattable, provide a formatter<T> specialization.");
+        "Cannot format an argument. To make type T formattable, provide a formatter<T> specialization. "
+        "See N4917 [format.arg.store]/2 and [formatter.requirements].");
     return _Format_arg_store<_Context, _Args...>{_Vals...};
 }
 
 template <class... _Args>
 _NODISCARD auto make_wformat_args(_Args&&... _Vals) {
     static_assert((_Has_formatter<_Args, wformat_context> && ...),
-        "Cannot format an argument. To make type T formattable, provide a formatter<T> specialization.");
+        "Cannot format an argument. To make type T formattable, provide a formatter<T> specialization. "
+        "See N4917 [format.arg.store]/2 and [formatter.requirements].");
     return _Format_arg_store<wformat_context, _Args...>{_Vals...};
 }
 


### PR DESCRIPTION
[[format.arg.store]](http://eel.is/c++draft/format.arg.store#2)

> *Preconditions*: The type <code>typename Context​::​template formatter_­type<T<sub>i</sub>></code> meets the *BasicFormatter* requirements ([[formatter.requirements]](http://eel.is/c++draft/formatter.requirements)) for each <code>T<sub>i</sub></code> in `Args`.

Currently, this precondition isn't checked. If an user passes an unformattable type, the error message will likely start with "'std::_Format_arg_traits<_Context>::_Phony_basic_format_arg_constructor': none of the 5 overloads could convert all the argument types", which isn't quite helpful.

Before LWG-3701, It was impractical to check this precondition, because even `std::format("Hello {}!\n", "world")` was a precondition violation. This is no longer a concern after LWG-3701 lands.

The error message was copied from fmtlib (https://github.com/fmtlib/fmt/blob/1feb430faaac6bd8094e996861d6025f9903d34e/include/fmt/core.h#L1771-L1772).