### PR TITLE
Remove unneeded static_cast for xexp

### DIFF
--- a/stl/src/xdscale.cpp
+++ b/stl/src/xdscale.cpp
@@ -47,7 +47,8 @@ short _Dscale(double* px, long lexp) { // scale *px by 2^xexp with checking
                 ps->_Sh[_D1] = ps->_Sh[_D0];
                 ps->_Sh[_D0] = 0;
             }
-            if ((xexp = static_cast<short>(-xexp)) != 0) { // scale by bits
+            if (xexp != 0) { // scale by bits
+                xexp         = -xexp;
                 psx          = (ps->_Sh[_D3] << (16 - xexp)) | (psx != 0 ? 1 : 0);
                 ps->_Sh[_D3] = static_cast<unsigned short>(ps->_Sh[_D3] >> xexp | ps->_Sh[_D2] << (16 - xexp));
                 ps->_Sh[_D2] = static_cast<unsigned short>(ps->_Sh[_D2] >> xexp | ps->_Sh[_D1] << (16 - xexp));

--- a/stl/src/xfdscale.cpp
+++ b/stl/src/xfdscale.cpp
@@ -42,7 +42,8 @@ short _FDscale(float* px, long lexp) { // scale *px by 2^xexp with checking
                 ps->_Sh[_F0] = 0;
                 xexp += 16;
             }
-            if ((xexp = static_cast<short>(-xexp)) != 0) { // scale by bits
+            if (xexp != 0) { // scale by bits
+                xexp         = -xexp;
                 psx          = (ps->_Sh[_F1] << (16 - xexp)) | (psx != 0 ? 1 : 0);
                 ps->_Sh[_F1] = static_cast<unsigned short>(ps->_Sh[_F1] >> xexp | ps->_Sh[_F0] << (16 - xexp));
                 ps->_Sh[_F0] >>= xexp;


### PR DESCRIPTION
We can just check for 0 since -0 is just 0