### PR TITLE
Compare the _W_decimal_point of the localeconv, not the decimal_point of said localeconv

### DIFF
--- a/stl/src/xstoxflt.cpp
+++ b/stl/src/xstoxflt.cpp
@@ -24,8 +24,8 @@ _In_range_(0, maxsig) int _Stoxflt(
     int seen = 0; // any valid field characters seen
 
     const char* pd;
-    static const char digits[] = "0123456789abcdefABCDEF";
-    static const char vals[]   = {// values of hex digits
+    static constexpr char digits[] = "0123456789abcdefABCDEF";
+    static constexpr char vals[]   = {// values of hex digits
         0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 10, 11, 12, 13, 14, 15};
 
     maxsig *= _Ndig; // convert word count to digit count

--- a/stl/src/xstoxflt.cpp
+++ b/stl/src/xstoxflt.cpp
@@ -24,9 +24,9 @@ _In_range_(0, maxsig) int _Stoxflt(
     int seen = 0; // any valid field characters seen
 
     const char* pd;
-    static constexpr char digits[] = "0123456789abcdefABCDEF";
-    static constexpr char vals[]   = {// values of hex digits
-        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 10, 11, 12, 13, 14, 15};
+    static constexpr char digits[] = "0123456789abcdefABCDEF"; // hex digits in both cases
+    static constexpr char vals[]   = {
+          0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 10, 11, 12, 13, 14, 15}; // values of hex digits
 
     maxsig *= _Ndig; // convert word count to digit count
     if (_Maxsig < maxsig) {

--- a/stl/src/xstoxflt.cpp
+++ b/stl/src/xstoxflt.cpp
@@ -22,7 +22,6 @@ _In_range_(0, maxsig) int _Stoxflt(
     char buf[_Maxsig + 1]; // worst case, with room for rounding digit
     int nsig = 0; // number of significant digits seen
     int seen = 0; // any valid field characters seen
-    int word = 0; // current long word to fill
 
     const char* pd;
     static const char digits[] = "0123456789abcdefABCDEF";
@@ -88,6 +87,9 @@ _In_range_(0, maxsig) int _Stoxflt(
     }
 
     lo[0] <<= 2; // change hex exponent to binary exponent
+
+    int word; // current long word to fill
+
     if (seen) { // convert digit sequence to words
         int bufidx  = 0; // next digit in buffer
         int wordidx = _Ndig - nsig % _Ndig; // next digit in word (% _Ndig)

--- a/stl/src/xstoxflt.cpp
+++ b/stl/src/xstoxflt.cpp
@@ -62,11 +62,14 @@ _In_range_(0, maxsig) int _Stoxflt(
         }
     }
 
-    for (; (pd = static_cast<const char*>(memchr(&digits[0], *s, 22))) != nullptr; ++s, seen = 1) {
+    while ((pd = static_cast<const char*>(memchr(&digits[0], *s, 22))) != nullptr) {
         if (nsig <= maxsig) { // accumulate a fraction digit
             buf[nsig++] = vals[pd - digits];
             --lo[0];
         }
+
+        ++s;
+        seen = 1;
     }
 
     if (maxsig < nsig) { // discard excess digit after rounding up

--- a/stl/src/xstoxflt.cpp
+++ b/stl/src/xstoxflt.cpp
@@ -122,9 +122,7 @@ _In_range_(0, maxsig) int _Stoxflt(
                 s = ssav; // roll back if incomplete exponent
             }
         }
-    }
-
-    if (!seen) {
+    } else {
         word = 0; // return zero if bad parse
     }
 

--- a/stl/src/xwstoxfl.cpp
+++ b/stl/src/xwstoxfl.cpp
@@ -22,13 +22,13 @@ _In_range_(0, maxsig) int _WStoxflt(const wchar_t* s0, const wchar_t* s, wchar_t
     char buf[_Maxsig + 1]; // worst case, with room for rounding digit
     int nsig = 0; // number of significant digits seen
     int seen = 0; // any valid field characters seen
-    int word = 0; // current long word to fill
+    int word; // current long word to fill
 
     const wchar_t* pd;
-    static const wchar_t digits[] = {// hex digits in both cases
+    static constexpr wchar_t digits[] = {// hex digits in both cases
         L'0', L'1', L'2', L'3', L'4', L'5', L'6', L'7', L'8', L'9', L'a', L'b', L'c', L'd', L'e', L'f', L'A', L'B',
         L'C', L'D', L'E', L'F', L'\0'};
-    static const char vals[]      = {// values of hex digits
+    static const char vals[]          = {// values of hex digits
         0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 10, 11, 12, 13, 14, 15};
 
     maxsig *= _Ndig; // convert word count to digit count
@@ -55,7 +55,7 @@ _In_range_(0, maxsig) int _WStoxflt(const wchar_t* s0, const wchar_t* s, wchar_t
         seen = 1;
     }
 
-    if (*s == localeconv()->decimal_point[0]) {
+    if (*s == localeconv()->_W_decimal_point[0]) {
         ++s;
     }
 
@@ -129,7 +129,7 @@ _In_range_(0, maxsig) int _WStoxflt(const wchar_t* s0, const wchar_t* s, wchar_t
         }
     }
 
-    if (!seen) {
+    else {
         word = 0; // return zero if bad parse
     }
 

--- a/stl/src/xwstoxfl.cpp
+++ b/stl/src/xwstoxfl.cpp
@@ -22,7 +22,6 @@ _In_range_(0, maxsig) int _WStoxflt(const wchar_t* s0, const wchar_t* s, wchar_t
     char buf[_Maxsig + 1]; // worst case, with room for rounding digit
     int nsig = 0; // number of significant digits seen
     int seen = 0; // any valid field characters seen
-    int word; // current long word to fill
 
     const wchar_t* pd;
     static constexpr wchar_t digits[] = {// hex digits in both cases
@@ -93,6 +92,9 @@ _In_range_(0, maxsig) int _WStoxflt(const wchar_t* s0, const wchar_t* s, wchar_t
     }
 
     lo[0] <<= 2; // change hex exponent to binary exponent
+
+    int word; // current long word to fill
+
     if (seen) { // convert digit sequence to words
         int bufidx  = 0; // next digit in buffer
         int wordidx = _Ndig - nsig % _Ndig; // next digit in word (% _Ndig)

--- a/stl/src/xwstoxfl.cpp
+++ b/stl/src/xwstoxfl.cpp
@@ -24,11 +24,9 @@ _In_range_(0, maxsig) int _WStoxflt(const wchar_t* s0, const wchar_t* s, wchar_t
     int seen = 0; // any valid field characters seen
 
     const wchar_t* pd;
-    static constexpr wchar_t digits[] = {// hex digits in both cases
-        L'0', L'1', L'2', L'3', L'4', L'5', L'6', L'7', L'8', L'9', L'a', L'b', L'c', L'd', L'e', L'f', L'A', L'B',
-        L'C', L'D', L'E', L'F', L'\0'};
-    static constexpr char vals[]      = {// values of hex digits
-        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 10, 11, 12, 13, 14, 15};
+    static constexpr wchar_t digits[] = L"0123456789abcdefABCDEF"; // hex digits in both cases
+    static constexpr char vals[]      = {
+             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 10, 11, 12, 13, 14, 15}; // values of hex digits
 
     maxsig *= _Ndig; // convert word count to digit count
     if (_Maxsig < maxsig) {

--- a/stl/src/xwstoxfl.cpp
+++ b/stl/src/xwstoxfl.cpp
@@ -129,9 +129,7 @@ _In_range_(0, maxsig) int _WStoxflt(const wchar_t* s0, const wchar_t* s, wchar_t
                 s = ssav; // roll back if incomplete exponent
             }
         }
-    }
-
-    else {
+    } else {
         word = 0; // return zero if bad parse
     }
 

--- a/stl/src/xwstoxfl.cpp
+++ b/stl/src/xwstoxfl.cpp
@@ -27,7 +27,7 @@ _In_range_(0, maxsig) int _WStoxflt(const wchar_t* s0, const wchar_t* s, wchar_t
     static constexpr wchar_t digits[] = {// hex digits in both cases
         L'0', L'1', L'2', L'3', L'4', L'5', L'6', L'7', L'8', L'9', L'a', L'b', L'c', L'd', L'e', L'f', L'A', L'B',
         L'C', L'D', L'E', L'F', L'\0'};
-    static const char vals[]          = {// values of hex digits
+    static constexpr char vals[]      = {// values of hex digits
         0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 10, 11, 12, 13, 14, 15};
 
     maxsig *= _Ndig; // convert word count to digit count


### PR DESCRIPTION
Since `s` is a pointer to a `wchar_t`, it makes more sense to use the `wchar_t` field of the localeconv struct returned. `decimal_point` and `_W_decimal_point` are identical for all supported locales, so this is not a behavioral change.

Additional cleanups, keeping narrow `xstoxflt.cpp` and wide `xwstoxfl.cpp` in sync:

* Move the definition of `int word;` down; it doesn't need to be initialized because it's always assigned.
* Upgrade `digits` and `vals` to `constexpr`. Consistently comment them at the end. Consistently use a string literal to initialize `digits`, which provides a null terminator.
* Narrow `xstoxflt.cpp` should use a `while`-loop, as wide `xwstoxfl.cpp` was already doing.
  + This is doing something complicated and less structured, so the `while`-loop is more appropriate.
* `if (seen) { ... }` followed by `if (!seen) { ... }` can simply use `else`, as we don't modify `seen` here.