### PR TITLE
Use std::size over sizeof/sizeof

### DIFF
--- a/stl/inc/cvt/wbuffer
+++ b/stl/inc/cvt/wbuffer
@@ -189,7 +189,7 @@ namespace stdext {
             }
 
             int_type pbackfail(int_type _Meta = _Traits::eof()) override { // put an element back to stream
-                if (sizeof(_Myback) / sizeof(_Myback[0]) <= _Nback || _Status == _Wrote) {
+                if (_STD size(_Myback) <= _Nback || _Status == _Wrote) {
                     return _Traits::eof(); // nowhere to put back
                 } else { // enough room, put it back
                     if (!_Traits::eq_int_type(_Traits::eof(), _Meta)) {

--- a/stl/inc/cvt/xjis
+++ b/stl/inc/cvt/xjis
@@ -45,7 +45,7 @@ namespace stdext {
                     }
                 } else { // search for a valid mapping
                     unsigned long _Lo = 0;
-                    unsigned long _Hi = sizeof(_Table::_Dbvalid) / sizeof(_Table::_Dbvalid[0]);
+                    unsigned long _Hi = static_cast<unsigned long>(_STD size(_Table::_Dbvalid));
 
                     while (_Lo < _Hi) { // test midpoint of remaining interval
                         unsigned long _Mid = (_Hi + _Lo) / 2;
@@ -72,7 +72,7 @@ namespace stdext {
 
                 // search for a valid mapping
                 unsigned long _Lo = 0;
-                unsigned long _Hi = sizeof(_Table::_Wvalid) / sizeof(_Table::_Wvalid[0]);
+                unsigned long _Hi = static_cast<unsigned long>(_STD size(_Table::_Wvalid));
 
                 while (_Lo < _Hi) { // test midpoint of remaining interval
                     unsigned long _Mid = (_Hi + _Lo) / 2;

--- a/stl/inc/cvt/xone_byte
+++ b/stl/inc/cvt/xone_byte
@@ -75,7 +75,7 @@ namespace stdext {
                         && (_Widecode >= 0x100
                             || _Table::_Btw[_Widecode - _Table::_Nlow] != _Widecode)) { // search for a valid mapping
                         unsigned long _Lo = 0;
-                        unsigned long _Hi = sizeof(_Table::_Wvalid) / sizeof(_Table::_Wvalid[0]);
+                        unsigned long _Hi = static_cast<unsigned long>(_STD size(_Table::_Wvalid));
 
                         while (_Lo < _Hi) { // test midpoint of remaining interval
                             unsigned long _Mid = (_Hi + _Lo) / 2;

--- a/stl/inc/cvt/xtwo_byte
+++ b/stl/inc/cvt/xtwo_byte
@@ -62,7 +62,7 @@ namespace stdext {
                             _Widecode =
                                 static_cast<unsigned short>(_Bytecode << 8 | static_cast<unsigned char>(*++_Mid1));
                             unsigned long _Lo = 0;
-                            unsigned long _Hi = sizeof(_Table::_Dbvalid) / sizeof(_Table::_Dbvalid[0]);
+                            unsigned long _Hi = static_cast<unsigned long>(_STD size(_Table::_Dbvalid));
 
                             while (_Lo < _Hi) { // test midpoint of remaining interval
                                 unsigned long _Mid = (_Hi + _Lo) / 2;
@@ -110,7 +110,7 @@ namespace stdext {
                         && (_Widecode >= 0x100
                             || _Table::_Btw[_Widecode - _Table::_Nlow] != _Widecode)) { // search for a valid mapping
                         unsigned long _Lo = 0;
-                        unsigned long _Hi = sizeof(_Table::_Wvalid) / sizeof(_Table::_Wvalid[0]);
+                        unsigned long _Hi = static_cast<unsigned long>(_STD size(_Table::_Wvalid));
 
                         while (_Lo < _Hi) { // test midpoint of remaining interval
                             unsigned long _Mid = (_Hi + _Lo) / 2;

--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -300,7 +300,7 @@ public:
     char_class_type lookup_classname(_Iter _First, _Iter _Last, bool _Icase = false) const {
         // map [_First, _Last) to character class mask value
 #define _REGEX_CHAR_CLASS_NAME(n, c) \
-    { n, L##n, sizeof(n) / sizeof(n[0]) - 1, c }
+    { n, L##n, static_cast<unsigned int>(_STD size(n) - 1), c }
         static constexpr _Cl_names _Names[] = {
             // map class names to numeric constants
             _REGEX_CHAR_CLASS_NAME("alnum", _Ch_alnum),

--- a/stl/inc/xlocbuf
+++ b/stl/inc/xlocbuf
@@ -174,7 +174,7 @@ protected:
     }
 
     int_type pbackfail(int_type _Meta = _Traits::eof()) override { // put an element back to stream
-        if (sizeof(_Myback) / sizeof(_Myback[0]) <= _Nback || _Status == _Wrote) {
+        if (_STD size(_Myback) <= _Nback || _Status == _Wrote) {
             return _Traits::eof(); // nowhere to put back
         } else { // enough room, put it back
             if (!_Traits::eq_int_type(_Traits::eof(), _Meta)) {

--- a/stl/src/xdateord.cpp
+++ b/stl/src/xdateord.cpp
@@ -11,7 +11,7 @@ _EXTERN_C_UNLESS_PURE
 
 _CRTIMP2_PURE int __CLRCALL_PURE_OR_CDECL _Getdateorder() { // return date order for current locale
     wchar_t buf[2] = {0};
-    GetLocaleInfoEx(___lc_locale_name_func()[LC_TIME], LOCALE_ILDATE, buf, sizeof(buf) / sizeof(buf[0]));
+    GetLocaleInfoEx(___lc_locale_name_func()[LC_TIME], LOCALE_ILDATE, buf, static_cast<int>(std::size(buf)));
 
     switch (buf[0]) {
     case L'0':

--- a/stl/src/xlsinh.cpp
+++ b/stl/src/xlsinh.cpp
@@ -8,11 +8,11 @@
 _EXTERN_C_UNLESS_PURE
 
 // coefficients
-static const long double p[] = {0.0000000000000028486835L, 0.0000000000007646464279L, 0.0000000001605905091647L,
+static constexpr long double p[] = {0.0000000000000028486835L, 0.0000000000007646464279L, 0.0000000001605905091647L,
     0.0000000250521083436962L, 0.0000027557319224130455L, 0.0001984126984126956009L, 0.0083333333333333336073L,
     0.1666666666666666666564L, 1.0000000000000000000001L};
 
-static constexpr size_t NP = sizeof(p) / sizeof(p[0]) - 1;
+static constexpr size_t NP = std::size(p) - 1;
 
 _CRTIMP2_PURE long double __CLRCALL_PURE_OR_CDECL _LSinh(long double x, long double y) {
     // compute y * sinh(x), |y| <= 1
@@ -40,7 +40,7 @@ _CRTIMP2_PURE long double __CLRCALL_PURE_OR_CDECL _LSinh(long double x, long dou
         if (x < _LRteps._Long_double) {
             x *= y; // x tiny
         } else if (x < 1.0L) {
-            long double w = x * x;
+            const long double w = x * x;
 
             x += x * w * _LPoly(w, p, NP - 1);
             x *= y;

--- a/stl/src/xlsinh.cpp
+++ b/stl/src/xlsinh.cpp
@@ -3,6 +3,8 @@
 
 // _LSinh function
 
+#include <xutility>
+
 #include "xmath.hpp"
 
 _EXTERN_C_UNLESS_PURE

--- a/stl/src/xsinh.cpp
+++ b/stl/src/xsinh.cpp
@@ -11,7 +11,7 @@ _EXTERN_C_UNLESS_PURE
 static constexpr double p[] = {0.0000000001632881, 0.0000000250483893, 0.0000027557344615, 0.0001984126975233,
     0.0083333333334816, 0.1666666666666574, 1.0000000000000001};
 
-static constexpr size_t NP = sizeof(p) / sizeof(p[0]) - 1;
+static constexpr size_t NP = std::size(p) - 1;
 
 _CRTIMP2_PURE double __CLRCALL_PURE_OR_CDECL _Sinh(double x, double y) { // compute y * sinh(x), |y| <= 1
     short neg;

--- a/stl/src/xsinh.cpp
+++ b/stl/src/xsinh.cpp
@@ -3,6 +3,8 @@
 
 // _Sinh function
 
+#include <xutility>
+
 #include "xmath.hpp"
 
 _EXTERN_C_UNLESS_PURE


### PR DESCRIPTION
This is more concise than sizeof/sizeof, and std::size is a constexpr so there shouldn't be any cost.