### PR TITLE
Add unwrapping to move_sentinel

### DIFF
--- a/stl/inc/iterator
+++ b/stl/inc/iterator
@@ -213,6 +213,23 @@ public:
         return _Last;
     }
 
+    using _Prevent_inheriting_unwrap = move_sentinel;
+
+    // clang-format off
+    _NODISCARD constexpr move_sentinel<_Unwrapped_t<const _Se&>> _Unwrapped() const&
+        noexcept(noexcept(move_sentinel<_Unwrapped_t<const _Se&>>(_Last._Unwrapped())))
+        requires _Weakly_unwrappable_sentinel<_Se> {
+        // clang-format on
+        return move_sentinel<_Unwrapped_t<const _Se&>>(_Last._Unwrapped());
+    }
+    // clang-format off
+    _NODISCARD constexpr move_sentinel<_Unwrapped_t<_Se>> _Unwrapped() &&
+        noexcept(noexcept(move_sentinel<_Unwrapped_t<_Se>>(_Last._Unwrapped())))
+        requires _Weakly_unwrappable_sentinel<_Se> {
+        // clang-format on
+        return move_sentinel<_Unwrapped_t<_Se>>(_STD move(_Last)._Unwrapped());
+    }
+
 private:
     _Se _Last{};
 };

--- a/stl/inc/iterator
+++ b/stl/inc/iterator
@@ -217,17 +217,17 @@ public:
 
     // clang-format off
     _NODISCARD constexpr move_sentinel<_Unwrapped_t<const _Se&>> _Unwrapped() const&
-        noexcept(noexcept(move_sentinel<_Unwrapped_t<const _Se&>>(_Last._Unwrapped())))
+        noexcept(noexcept(move_sentinel<_Unwrapped_t<const _Se&>>{_Last._Unwrapped()}))
         requires _RANGES _Weakly_unwrappable_sentinel<_Se> {
         // clang-format on
-        return move_sentinel<_Unwrapped_t<const _Se&>>(_Last._Unwrapped());
+        return move_sentinel<_Unwrapped_t<const _Se&>>{_Last._Unwrapped()};
     }
     // clang-format off
     _NODISCARD constexpr move_sentinel<_Unwrapped_t<_Se>> _Unwrapped() &&
-        noexcept(noexcept(move_sentinel<_Unwrapped_t<_Se>>(_Last._Unwrapped())))
+        noexcept(noexcept(move_sentinel<_Unwrapped_t<_Se>>{_STD move(_Last)._Unwrapped()}))
         requires _RANGES _Weakly_unwrappable_sentinel<_Se> {
         // clang-format on
-        return move_sentinel<_Unwrapped_t<_Se>>(_STD move(_Last)._Unwrapped());
+        return move_sentinel<_Unwrapped_t<_Se>>{_STD move(_Last)._Unwrapped()};
     }
 
 private:

--- a/stl/inc/iterator
+++ b/stl/inc/iterator
@@ -218,14 +218,14 @@ public:
     // clang-format off
     _NODISCARD constexpr move_sentinel<_Unwrapped_t<const _Se&>> _Unwrapped() const&
         noexcept(noexcept(move_sentinel<_Unwrapped_t<const _Se&>>(_Last._Unwrapped())))
-        requires _Weakly_unwrappable_sentinel<_Se> {
+        requires _RANGES _Weakly_unwrappable_sentinel<_Se> {
         // clang-format on
         return move_sentinel<_Unwrapped_t<const _Se&>>(_Last._Unwrapped());
     }
     // clang-format off
     _NODISCARD constexpr move_sentinel<_Unwrapped_t<_Se>> _Unwrapped() &&
         noexcept(noexcept(move_sentinel<_Unwrapped_t<_Se>>(_Last._Unwrapped())))
-        requires _Weakly_unwrappable_sentinel<_Se> {
+        requires _RANGES _Weakly_unwrappable_sentinel<_Se> {
         // clang-format on
         return move_sentinel<_Unwrapped_t<_Se>>(_STD move(_Last)._Unwrapped());
     }

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -1846,13 +1846,30 @@ namespace ranges {
     template <range _Rng>
     using sentinel_t = decltype(_RANGES end(_STD declval<_Rng&>()));
 
+    template <class _Wrapped>
+    concept _Weakly_unwrappable =
+        same_as<typename remove_cvref_t<_Wrapped>::_Prevent_inheriting_unwrap, remove_cvref_t<_Wrapped>> //
+        && requires(_Wrapped&& _Wr) {
+        _STD forward<_Wrapped>(_Wr)._Unwrapped();
+    };
+
+    // clang-format off
+    template <class _Sent>
+    concept _Weakly_unwrappable_sentinel = _Weakly_unwrappable<const remove_reference_t<_Sent>&>;
+    // clang-format on
+
+    template <class _Iter>
+    concept _Weakly_unwrappable_iterator = //
+        _Weakly_unwrappable<_Iter> //
+        && requires(_Iter&& _It, remove_cvref_t<_Iter>& _MutIt) {
+        _MutIt._Seek_to(_STD forward<_Iter>(_It)._Unwrapped());
+    };
+
     template <class _Sent, class _Iter>
     concept _Unwrappable_sentinel_for = //
-        same_as<typename remove_cvref_t<_Sent>::_Prevent_inheriting_unwrap, remove_cvref_t<_Sent>> //
-        && same_as<typename remove_cvref_t<_Iter>::_Prevent_inheriting_unwrap, remove_cvref_t<_Iter>> //
-        && requires(_Iter&& _It, remove_cvref_t<_Iter>& _MutIt, const remove_reference_t<_Sent>& _Se) {
-        _STD forward<_Iter>(_It)._Unwrapped();
-        _MutIt._Seek_to(_STD forward<_Iter>(_It)._Unwrapped());
+        _Weakly_unwrappable_sentinel<_Sent> //
+        && _Weakly_unwrappable_iterator<_Iter> //
+        && requires(_Iter&& _It, const remove_reference_t<_Sent>& _Se) {
         { _Se._Unwrapped() } -> sentinel_for<decltype(_STD forward<_Iter>(_It)._Unwrapped())>;
     };
 

--- a/tests/std/tests/GH_002992_unwrappable_iter_sent_pairs/test.compile.pass.cpp
+++ b/tests/std/tests/GH_002992_unwrappable_iter_sent_pairs/test.compile.pass.cpp
@@ -39,8 +39,11 @@ void test_algorithms(Rng& rng) {
     }
 }
 
-template <class It, class Se>
-void test_unwrappable_pair() {
+template <class Rng>
+void test_unwrappable_range() {
+    using It = ranges::iterator_t<Rng>;
+    using Se = ranges::sentinel_t<Rng>;
+
     constexpr bool is_const_unwrappable = requires(const It& ci) {
         ci._Unwrapped();
     };
@@ -70,12 +73,15 @@ void test_unwrappable_pair() {
         noexcept(ranges::_Unwrap_sent<It>(declval<const Se&>())) == noexcept(declval<const Se&>()._Unwrapped()));
 
     // instantiate without calling
-    void (*p)(ranges::subrange<It, Se>&) = test_algorithms<ranges::subrange<It, Se>>;
+    void (*p)(Rng&) = test_algorithms<Rng>;
     (void) p;
 }
 
-template <class It, class Se>
-void test_not_unwrappable_pair() {
+template <class Rng>
+void test_not_unwrappable_range() {
+    using It = ranges::iterator_t<Rng>;
+    using Se = ranges::sentinel_t<Rng>;
+
     STATIC_ASSERT(!ranges::_Unwrappable_sentinel_for<Se, It>);
     STATIC_ASSERT(same_as<ranges::_Unwrap_iter_t<It, Se>, It>);
     STATIC_ASSERT(same_as<ranges::_Unwrap_iter_t<const It&, Se>, It>);
@@ -90,14 +96,14 @@ void test_not_unwrappable_pair() {
     STATIC_ASSERT(noexcept(ranges::_Unwrap_sent<It>(declval<const Se&>())));
 
     // instantiate without calling
-    void (*p)(ranges::subrange<It, Se>&) = test_algorithms<ranges::subrange<It, Se>>;
+    void (*p)(Rng&) = test_algorithms<Rng>;
     (void) p;
 }
 
 template <class Rng>
 void test_classic_range() {
-    test_unwrappable_pair<ranges::iterator_t<Rng>, ranges::sentinel_t<Rng>>();
-    test_unwrappable_pair<ranges::iterator_t<const Rng>, ranges::sentinel_t<const Rng>>();
+    test_unwrappable_range<Rng>();
+    test_unwrappable_range<const Rng>();
 }
 void test_classic_ranges() {
     test_classic_range<string>();
@@ -113,6 +119,10 @@ void test_classic_ranges() {
     test_classic_range<unordered_map<int, int>>();
     test_classic_range<vector<int>>();
     test_classic_range<filesystem::path>();
+
+#if _HAS_CXX23
+    test_classic_range<ranges::as_rvalue_view<string_view>>();
+#endif
 }
 
 struct Nontrivial {
@@ -130,23 +140,45 @@ struct Nontrivial {
     bool operator==(const Nontrivial&) const noexcept = default;
 };
 
+template <class Iter, class Sent>
+void test_unwrappable_views() {
+    using R = ranges::subrange<Iter, Sent>;
+
+    test_unwrappable_range<R>();
+
+#if _HAS_CXX23
+    test_unwrappable_range<ranges::as_rvalue_view<R>>();
+#endif
+}
+
+template <class Iter, class Sent>
+void test_not_unwrappable_views() {
+    using R = ranges::subrange<Iter, Sent>;
+
+    test_not_unwrappable_range<R>();
+
+#if _HAS_CXX23
+    test_not_unwrappable_range<ranges::as_rvalue_view<R>>();
+#endif
+}
+
 void test_both_unwrappable() {
     using test::contiguous, test::random, test::bidi, test::fwd, test::input;
 
     using sent_int = test::sentinel<int>;
     using sent_nt  = test::sentinel<Nontrivial>;
 
-    test_unwrappable_pair<test::iterator<contiguous, int>, sent_int>();
-    test_unwrappable_pair<test::iterator<random, int>, sent_int>();
-    test_unwrappable_pair<test::iterator<bidi, int>, sent_int>();
-    test_unwrappable_pair<test::iterator<fwd, int>, sent_int>();
-    test_unwrappable_pair<test::iterator<input, int>, sent_int>();
+    test_unwrappable_views<test::iterator<contiguous, int>, sent_int>();
+    test_unwrappable_views<test::iterator<random, int>, sent_int>();
+    test_unwrappable_views<test::iterator<bidi, int>, sent_int>();
+    test_unwrappable_views<test::iterator<fwd, int>, sent_int>();
+    test_unwrappable_views<test::iterator<input, int>, sent_int>();
 
-    test_unwrappable_pair<test::iterator<contiguous, Nontrivial>, sent_nt>();
-    test_unwrappable_pair<test::iterator<random, Nontrivial>, sent_nt>();
-    test_unwrappable_pair<test::iterator<bidi, Nontrivial>, sent_nt>();
-    test_unwrappable_pair<test::iterator<fwd, Nontrivial>, sent_nt>();
-    test_unwrappable_pair<test::iterator<input, Nontrivial>, sent_nt>();
+    test_unwrappable_views<test::iterator<contiguous, Nontrivial>, sent_nt>();
+    test_unwrappable_views<test::iterator<random, Nontrivial>, sent_nt>();
+    test_unwrappable_views<test::iterator<bidi, Nontrivial>, sent_nt>();
+    test_unwrappable_views<test::iterator<fwd, Nontrivial>, sent_nt>();
+    test_unwrappable_views<test::iterator<input, Nontrivial>, sent_nt>();
 }
 
 void test_iter_unwrappable() {
@@ -155,17 +187,17 @@ void test_iter_unwrappable() {
     using sent_int = test::sentinel<int, test::WrappedState::ignorant>;
     using sent_nt  = test::sentinel<Nontrivial, test::WrappedState::ignorant>;
 
-    test_not_unwrappable_pair<test::iterator<contiguous, int>, sent_int>();
-    test_not_unwrappable_pair<test::iterator<random, int>, sent_int>();
-    test_not_unwrappable_pair<test::iterator<bidi, int>, sent_int>();
-    test_not_unwrappable_pair<test::iterator<fwd, int>, sent_int>();
-    test_not_unwrappable_pair<test::iterator<input, int>, sent_int>();
+    test_not_unwrappable_views<test::iterator<contiguous, int>, sent_int>();
+    test_not_unwrappable_views<test::iterator<random, int>, sent_int>();
+    test_not_unwrappable_views<test::iterator<bidi, int>, sent_int>();
+    test_not_unwrappable_views<test::iterator<fwd, int>, sent_int>();
+    test_not_unwrappable_views<test::iterator<input, int>, sent_int>();
 
-    test_not_unwrappable_pair<test::iterator<contiguous, Nontrivial>, sent_nt>();
-    test_not_unwrappable_pair<test::iterator<random, Nontrivial>, sent_nt>();
-    test_not_unwrappable_pair<test::iterator<bidi, Nontrivial>, sent_nt>();
-    test_not_unwrappable_pair<test::iterator<fwd, Nontrivial>, sent_nt>();
-    test_not_unwrappable_pair<test::iterator<input, Nontrivial>, sent_nt>();
+    test_not_unwrappable_views<test::iterator<contiguous, Nontrivial>, sent_nt>();
+    test_not_unwrappable_views<test::iterator<random, Nontrivial>, sent_nt>();
+    test_not_unwrappable_views<test::iterator<bidi, Nontrivial>, sent_nt>();
+    test_not_unwrappable_views<test::iterator<fwd, Nontrivial>, sent_nt>();
+    test_not_unwrappable_views<test::iterator<input, Nontrivial>, sent_nt>();
 }
 
 void test_sent_unwrappable() {
@@ -174,17 +206,17 @@ void test_sent_unwrappable() {
     using sent_int = test::sentinel<int>;
     using sent_nt  = test::sentinel<Nontrivial>;
 
-    test_not_unwrappable_pair<test::iterator<contiguous, int>::unwrapping_ignorant, sent_int>();
-    test_not_unwrappable_pair<test::iterator<random, int>::unwrapping_ignorant, sent_int>();
-    test_not_unwrappable_pair<test::iterator<bidi, int>::unwrapping_ignorant, sent_int>();
-    test_not_unwrappable_pair<test::iterator<fwd, int>::unwrapping_ignorant, sent_int>();
-    test_not_unwrappable_pair<test::iterator<input, int>::unwrapping_ignorant, sent_int>();
+    test_not_unwrappable_views<test::iterator<contiguous, int>::unwrapping_ignorant, sent_int>();
+    test_not_unwrappable_views<test::iterator<random, int>::unwrapping_ignorant, sent_int>();
+    test_not_unwrappable_views<test::iterator<bidi, int>::unwrapping_ignorant, sent_int>();
+    test_not_unwrappable_views<test::iterator<fwd, int>::unwrapping_ignorant, sent_int>();
+    test_not_unwrappable_views<test::iterator<input, int>::unwrapping_ignorant, sent_int>();
 
-    test_not_unwrappable_pair<test::iterator<contiguous, Nontrivial>::unwrapping_ignorant, sent_nt>();
-    test_not_unwrappable_pair<test::iterator<random, Nontrivial>::unwrapping_ignorant, sent_nt>();
-    test_not_unwrappable_pair<test::iterator<bidi, Nontrivial>::unwrapping_ignorant, sent_nt>();
-    test_not_unwrappable_pair<test::iterator<fwd, Nontrivial>::unwrapping_ignorant, sent_nt>();
-    test_not_unwrappable_pair<test::iterator<input, Nontrivial>::unwrapping_ignorant, sent_nt>();
+    test_not_unwrappable_views<test::iterator<contiguous, Nontrivial>::unwrapping_ignorant, sent_nt>();
+    test_not_unwrappable_views<test::iterator<random, Nontrivial>::unwrapping_ignorant, sent_nt>();
+    test_not_unwrappable_views<test::iterator<bidi, Nontrivial>::unwrapping_ignorant, sent_nt>();
+    test_not_unwrappable_views<test::iterator<fwd, Nontrivial>::unwrapping_ignorant, sent_nt>();
+    test_not_unwrappable_views<test::iterator<input, Nontrivial>::unwrapping_ignorant, sent_nt>();
 }
 
 void test_neither_unwrappable() {
@@ -193,17 +225,17 @@ void test_neither_unwrappable() {
     using sent_int = test::sentinel<int, test::WrappedState::ignorant>;
     using sent_nt  = test::sentinel<Nontrivial, test::WrappedState::ignorant>;
 
-    test_not_unwrappable_pair<test::iterator<contiguous, int>::unwrapping_ignorant, sent_int>();
-    test_not_unwrappable_pair<test::iterator<random, int>::unwrapping_ignorant, sent_int>();
-    test_not_unwrappable_pair<test::iterator<bidi, int>::unwrapping_ignorant, sent_int>();
-    test_not_unwrappable_pair<test::iterator<fwd, int>::unwrapping_ignorant, sent_int>();
-    test_not_unwrappable_pair<test::iterator<input, int>::unwrapping_ignorant, sent_int>();
+    test_not_unwrappable_views<test::iterator<contiguous, int>::unwrapping_ignorant, sent_int>();
+    test_not_unwrappable_views<test::iterator<random, int>::unwrapping_ignorant, sent_int>();
+    test_not_unwrappable_views<test::iterator<bidi, int>::unwrapping_ignorant, sent_int>();
+    test_not_unwrappable_views<test::iterator<fwd, int>::unwrapping_ignorant, sent_int>();
+    test_not_unwrappable_views<test::iterator<input, int>::unwrapping_ignorant, sent_int>();
 
-    test_not_unwrappable_pair<test::iterator<contiguous, Nontrivial>::unwrapping_ignorant, sent_nt>();
-    test_not_unwrappable_pair<test::iterator<random, Nontrivial>::unwrapping_ignorant, sent_nt>();
-    test_not_unwrappable_pair<test::iterator<bidi, Nontrivial>::unwrapping_ignorant, sent_nt>();
-    test_not_unwrappable_pair<test::iterator<fwd, Nontrivial>::unwrapping_ignorant, sent_nt>();
-    test_not_unwrappable_pair<test::iterator<input, Nontrivial>::unwrapping_ignorant, sent_nt>();
+    test_not_unwrappable_views<test::iterator<contiguous, Nontrivial>::unwrapping_ignorant, sent_nt>();
+    test_not_unwrappable_views<test::iterator<random, Nontrivial>::unwrapping_ignorant, sent_nt>();
+    test_not_unwrappable_views<test::iterator<bidi, Nontrivial>::unwrapping_ignorant, sent_nt>();
+    test_not_unwrappable_views<test::iterator<fwd, Nontrivial>::unwrapping_ignorant, sent_nt>();
+    test_not_unwrappable_views<test::iterator<input, Nontrivial>::unwrapping_ignorant, sent_nt>();
 }
 
 int main() {} // COMPILE-ONLY

--- a/tests/std/tests/GH_002992_unwrappable_iter_sent_pairs/test.compile.pass.cpp
+++ b/tests/std/tests/GH_002992_unwrappable_iter_sent_pairs/test.compile.pass.cpp
@@ -9,6 +9,7 @@
 #include <map>
 #include <set>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>


### PR DESCRIPTION
fixes #3009 

There are two new concepts - `_Weakly_unwrappable_sentinel` and `_Weakly_unwrappable_iterator` - these are useful for implementation of wrapper types which are unwrappable when their underlying type is unwrappable (like `move_iterator`/`move_sentinel`)