### PR TITLE
support utf8 languages in `std::chrono::time_zone::get_info`

### DIFF
--- a/stl/src/tzdb.cpp
+++ b/stl/src/tzdb.cpp
@@ -196,9 +196,8 @@ namespace {
 
     _NODISCARD const char* _Allocate_wide_to_narrow(
         const char16_t* const _Input, const int _Input_len, __std_tzdb_error& _Err) noexcept {
-        const auto _Code_page      = __std_fs_code_page();
         const auto _Input_as_wchar = reinterpret_cast<const wchar_t*>(_Input);
-        const auto _Count_result = __std_fs_convert_wide_to_narrow(_Code_page, _Input_as_wchar, _Input_len, nullptr, 0);
+        const auto _Count_result = __std_fs_convert_wide_to_narrow(__std_code_page::_Utf8, _Input_as_wchar, _Input_len, nullptr, 0);
         if (_Count_result._Err != __std_win_error::_Success) {
             _Err = __std_tzdb_error::_Win_error;
             return nullptr;

--- a/stl/src/tzdb.cpp
+++ b/stl/src/tzdb.cpp
@@ -197,7 +197,8 @@ namespace {
     _NODISCARD const char* _Allocate_wide_to_narrow(
         const char16_t* const _Input, const int _Input_len, __std_tzdb_error& _Err) noexcept {
         const auto _Input_as_wchar = reinterpret_cast<const wchar_t*>(_Input);
-        const auto _Count_result = __std_fs_convert_wide_to_narrow(__std_code_page::_Utf8, _Input_as_wchar, _Input_len, nullptr, 0);
+        const auto _Count_result =
+            __std_fs_convert_wide_to_narrow(__std_code_page::_Utf8, _Input_as_wchar, _Input_len, nullptr, 0);
         if (_Count_result._Err != __std_win_error::_Success) {
             _Err = __std_tzdb_error::_Win_error;
             return nullptr;

--- a/stl/src/tzdb.cpp
+++ b/stl/src/tzdb.cpp
@@ -211,8 +211,8 @@ namespace {
 
         _Data[_Count_result._Len] = '\0';
 
-        const auto _Result =
-            __std_fs_convert_wide_to_narrow(__std_code_page::_Utf8, _Input_as_wchar, _Input_len, _Data.get(), _Count_result._Len);
+        const auto _Result = __std_fs_convert_wide_to_narrow(
+                __std_code_page::_Utf8, _Input_as_wchar, _Input_len, _Data.get(), _Count_result._Len);
         if (_Result._Err != __std_win_error::_Success) {
             _Err = __std_tzdb_error::_Win_error;
             return nullptr;

--- a/stl/src/tzdb.cpp
+++ b/stl/src/tzdb.cpp
@@ -212,7 +212,7 @@ namespace {
         _Data[_Count_result._Len] = '\0';
 
         const auto _Result = __std_fs_convert_wide_to_narrow(
-                __std_code_page::_Utf8, _Input_as_wchar, _Input_len, _Data.get(), _Count_result._Len);
+            __std_code_page::_Utf8, _Input_as_wchar, _Input_len, _Data.get(), _Count_result._Len);
         if (_Result._Err != __std_win_error::_Success) {
             _Err = __std_tzdb_error::_Win_error;
             return nullptr;

--- a/stl/src/tzdb.cpp
+++ b/stl/src/tzdb.cpp
@@ -211,7 +211,7 @@ namespace {
         _Data[_Count_result._Len] = '\0';
 
         const auto _Result =
-            __std_fs_convert_wide_to_narrow(_Code_page, _Input_as_wchar, _Input_len, _Data.get(), _Count_result._Len);
+            __std_fs_convert_wide_to_narrow(__std_code_page::_Utf8, _Input_as_wchar, _Input_len, _Data.get(), _Count_result._Len);
         if (_Result._Err != __std_win_error::_Success) {
             _Err = __std_tzdb_error::_Win_error;
             return nullptr;


### PR DESCRIPTION
 use `__std_code_page::_Utf8` instead of `__std_fs_code_page()` to support languages like Arabic. This is like what is used by `u8path`.
This should fix https://github.com/microsoft/STL/issues/3097
