### PR TITLE
Toolset update: VS 2022 17.4 Preview 2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.23)
+cmake_minimum_required(VERSION 3.24)
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 project(msvc_standard_libraries LANGUAGES CXX)
 

--- a/README.md
+++ b/README.md
@@ -141,11 +141,11 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With The Visual Studio IDE
 
-1. Install Visual Studio 2022 17.4 Preview 1 or later.
+1. Install Visual Studio 2022 17.4 Preview 2 or later.
     * Select "Windows 11 SDK (10.0.22000.0)" in the VS Installer.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
-    * Otherwise, install [CMake][] 3.23 or later, and [Ninja][] 1.11.0 or later.
+    * Otherwise, install [CMake][] 3.24 or later, and [Ninja][] 1.11.0 or later.
     * We recommend selecting "Python 3 64-bit" in the VS Installer.
     * Otherwise, make sure [Python][] 3.9 or later is available to CMake.
 2. Open Visual Studio, and choose the "Clone or check out code" option. Enter the URL of this repository,
@@ -157,11 +157,11 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With A Native Tools Command Prompt
 
-1. Install Visual Studio 2022 17.4 Preview 1 or later.
+1. Install Visual Studio 2022 17.4 Preview 2 or later.
     * Select "Windows 11 SDK (10.0.22000.0)" in the VS Installer.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
-    * Otherwise, install [CMake][] 3.23 or later, and [Ninja][] 1.11.0 or later.
+    * Otherwise, install [CMake][] 3.24 or later, and [Ninja][] 1.11.0 or later.
     * We recommend selecting "Python 3 64-bit" in the VS Installer.
     * Otherwise, make sure [Python][] 3.9 or later is available to CMake.
 2. Open a command prompt.

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -141,7 +141,7 @@ $Workloads = @(
 $ReleaseInPath = 'Preview'
 $Sku = 'Enterprise'
 $VisualStudioBootstrapperUrl = 'https://aka.ms/vs/17/pre/vs_enterprise.exe'
-$PythonUrl = 'https://www.python.org/ftp/python/3.10.6/python-3.10.6-amd64.exe'
+$PythonUrl = 'https://www.python.org/ftp/python/3.10.7/python-3.10.7-amd64.exe'
 
 $CudaUrl = 'https://developer.download.nvidia.com/compute/cuda/11.6.0/local_installers/cuda_11.6.0_511.23_windows.exe'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@ variables:
   buildOutputLocation: 'D:\build'
 
 pool:
-  name: 'StlBuild-2022-09-01T2216-Pool'
+  name: 'StlBuild-2022-09-14T1332-Pool'
   demands: EnableSpotVM -equals true
 
 pr:

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.23)
+cmake_minimum_required(VERSION 3.24)
 project(msvc_standard_libraries_tools LANGUAGES CXX)
 
 add_subdirectory(format)

--- a/tools/format/CMakeLists.txt
+++ b/tools/format/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.23)
+cmake_minimum_required(VERSION 3.24)
 project(msvc_standard_libraries_format NONE)
 
 set(did_search OFF)

--- a/tools/validate/CMakeLists.txt
+++ b/tools/validate/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.23)
+cmake_minimum_required(VERSION 3.24)
 project(msvc_standard_libraries_validate LANGUAGES CXX)
 
 add_executable(validate-binary validate.cpp)


### PR DESCRIPTION
* Updated build compiler to VS 2022 17.4 Preview 2.
* Updated CMake to 3.24 (now required).
* Updated Python to 3.10.7.

Contains Patch Tuesday.