### PR TITLE
Suppress narrowing warnings in `piecewise_constant_distribution::densities`

### DIFF
--- a/stl/inc/random
+++ b/stl/inc/random
@@ -4756,10 +4756,13 @@ public:
             return _Bvec;
         }
 
+#pragma warning(push)
+#pragma warning(disable : 4244) // '%s': conversion from '%s' to '%s', possible loss of data
         _NODISCARD vector<_Ty> densities() const {
             vector<_Ty> _Ans(this->_Pvec.begin(), this->_Pvec.end());
             return _Ans;
         }
+#pragma warning(pop)
 
         _NODISCARD double _Piece_probability(const size_t _Idx) const {
             return 0.5 * (this->_Pvec[_Idx] + this->_Pvec[_Idx + 1])

--- a/stl/inc/random
+++ b/stl/inc/random
@@ -4559,6 +4559,8 @@ public:
             return _Bvec;
         }
 
+#pragma warning(push)
+#pragma warning(disable : 4244) // '%s': conversion from '%s' to '%s', possible loss of data
         _NODISCARD vector<_Ty> densities() const {
             vector<_Ty> _Ans(this->_Pvec.begin(), this->_Pvec.end());
 
@@ -4568,6 +4570,7 @@ public:
 
             return _Ans;
         }
+#pragma warning(pop)
 
         void _Init() { // initialize
             _Mypbase::_Init();

--- a/tests/std/test.lst
+++ b/tests/std/test.lst
@@ -214,6 +214,7 @@ tests\GH_002789_Hash_vec_Tidy
 tests\GH_002989_nothrow_unwrappable
 tests\GH_002992_unwrappable_iter_sent_pairs
 tests\GH_003022_substr_allocator
+tests\GH_003105_piecewise_densities
 tests\LWG2597_complex_branch_cut
 tests\LWG3018_shared_ptr_function
 tests\LWG3121_constrained_tuple_forwarding_ctor

--- a/tests/std/tests/GH_003105_piecewise_densities/env.lst
+++ b/tests/std/tests/GH_003105_piecewise_densities/env.lst
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+RUNALL_INCLUDE ..\usual_matrix.lst

--- a/tests/std/tests/GH_003105_piecewise_densities/test.compile.pass.cpp
+++ b/tests/std/tests/GH_003105_piecewise_densities/test.compile.pass.cpp
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <random>
+
+int main() {} // COMPILE-ONLY
+
+void test() {
+    // GH-3105 "<random>: std::piecewise_constant_distribution<float>::densities() gives warning C4244"
+    (void) std::piecewise_constant_distribution<float>{}.densities();
+
+    // Also affected:
+    (void) std::piecewise_linear_distribution<float>{}.densities();
+
+    // Not affected, but tested just in case:
+    (void) std::piecewise_constant_distribution<float>{}.intervals();
+    (void) std::piecewise_linear_distribution<float>{}.intervals();
+}

--- a/tests/std/tests/GH_003105_piecewise_densities/test.cpp
+++ b/tests/std/tests/GH_003105_piecewise_densities/test.cpp
@@ -1,8 +1,0 @@
-// Copyright (c) Microsoft Corporation.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-
-#include <random>
-
-int main() {
-    (void) std::piecewise_constant_distribution<float>{}.densities();
-}

--- a/tests/std/tests/GH_003105_piecewise_densities/test.cpp
+++ b/tests/std/tests/GH_003105_piecewise_densities/test.cpp
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <random>
+
+int main() {
+    (void) std::piecewise_constant_distribution<float>{}.densities();
+}


### PR DESCRIPTION
This function converts a `vector` of `double` to a `vector` of `_Ty`, which is a narrowing conversion when `Ty` is `float`. It's silly to warn about this when the Standard makes it clear that the narrowing will occur, and the user has asked for such explicitly by calling `piecewise_constant_distrubution<float>::densities`.

Fixes #3105.
