### PR TITLE
Fix `ranges::is_permutation`'s helper lambdas

### DIFF
--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -957,7 +957,7 @@ namespace ranges {
                 // We've trimmed matching prefixes and matching suffixes.
                 // Now we need to compare each range's prefix to the other range's suffix.
 
-                const auto _ProjectedPred = [&]<class _Ty1, class _Ty2>(_Ty1&& _Left, _Ty2&& _Right) {
+                const auto _ProjectedPred = [&]<class _Ty1, class _Ty2>(_Ty1&& _Left, _Ty2&& _Right) -> bool {
                     return _STD invoke(_Pred, _STD invoke(_Proj1, _STD forward<_Ty1>(_Left)),
                         _STD invoke(_Proj2, _STD forward<_Ty2>(_Right)));
                 };
@@ -1046,7 +1046,7 @@ namespace ranges {
                 // We've trimmed matching prefixes and matching suffixes.
                 // Now we need to compare each range's prefix to the other range's suffix.
 
-                const auto _ProjectedPred = [&]<class _Ty1, class _Ty2>(_Ty1&& _Left, _Ty2&& _Right) {
+                const auto _ProjectedPred = [&]<class _Ty1, class _Ty2>(_Ty1&& _Left, _Ty2&& _Right) -> bool {
                     return _STD invoke(_Pred, _STD invoke(_Proj1, _STD forward<_Ty1>(_Left)),
                         _STD invoke(_Proj2, _STD forward<_Ty2>(_Right)));
                 };

--- a/tests/std/tests/P0896R4_ranges_alg_is_permutation/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_is_permutation/test.cpp
@@ -138,7 +138,7 @@ struct instantiator {
             struct NonCopyableBool {
                 constexpr operator bool() {
                     return true;
-                };
+                }
 
                 NonCopyableBool()                       = default;
                 NonCopyableBool(const NonCopyableBool&) = delete;

--- a/tests/std/tests/P0896R4_ranges_alg_is_permutation/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_is_permutation/test.cpp
@@ -134,6 +134,17 @@ struct instantiator {
             assert(ranges::is_permutation(
                 r1, r2, {}, [](int n) { return n + 1; }, [](int n) { return n - 1; }));
         }
+        { // Test GH-2888: `<algorithm>`: `ranges::is_permutation`'s helper lambda does not specify return type
+            struct NonCopyableBool {
+                constexpr operator bool() {
+                    return true;
+                };
+
+                NonCopyableBool()                       = default;
+                NonCopyableBool(const NonCopyableBool&) = delete;
+            } b;
+            assert(ranges::is_permutation(range2, range2, [&](auto, auto) -> NonCopyableBool& { return b; }));
+        }
     }
 };
 


### PR DESCRIPTION
Fixes #2888.

<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
