### PR TITLE
`<any>`: Skip the contents when static RTTI is disabled

### DIFF
--- a/stl/inc/any
+++ b/stl/inc/any
@@ -11,9 +11,8 @@
 
 #if !_HAS_CXX17
 _EMIT_STL_WARNING(STL4038, "The contents of <any> are available only with C++17 or later.");
-#else // ^^^ !_HAS_CXX17 / _HAS_CXX17 vvv
-#if !_HAS_STATIC_RTTI
-_EMIT_STL_WARNING(STL4040, "The contents of <any> are available only when RTTI is available.");
+#elif !_HAS_STATIC_RTTI // ^^^ !_HAS_CXX17 / _HAS_CXX17 vvv
+_EMIT_STL_WARNING(STL4040, "The contents of <any> require static RTTI.");
 #else // ^^^ !_HAS_STATIC_RTTI / _HAS_STATIC_RTTI vvv
 #include <initializer_list>
 #include <type_traits>
@@ -443,8 +442,7 @@ _STD_END
 _STL_RESTORE_CLANG_WARNINGS
 #pragma warning(pop)
 #pragma pack(pop)
-#endif // _HAS_STATIC_RTTI
-#endif // _HAS_CXX17
+#endif // ^^^ _HAS_STATIC_RTTI ^^^
 
 #endif // _STL_COMPILER_PREPROCESSOR
 #endif // _ANY_

--- a/stl/inc/any
+++ b/stl/inc/any
@@ -12,15 +12,14 @@
 #if !_HAS_CXX17
 _EMIT_STL_WARNING(STL4038, "The contents of <any> are available only with C++17 or later.");
 #else // ^^^ !_HAS_CXX17 / _HAS_CXX17 vvv
+#if !_HAS_STATIC_RTTI
+_EMIT_STL_WARNING(STL4040, "The contents of <any> are available only when RTTI is available.");
+#else // ^^^ !_HAS_STATIC_RTTI / _HAS_STATIC_RTTI vvv
 #include <initializer_list>
 #include <type_traits>
 #include <typeinfo>
 #include <utility>
 #include <xmemory>
-
-#if !_HAS_STATIC_RTTI
-#error class any requires static RTTI.
-#endif // _HAS_STATIC_RTTI
 
 #pragma pack(push, _CRT_PACKING)
 #pragma warning(push, _STL_WARNING_LEVEL)
@@ -444,6 +443,7 @@ _STD_END
 _STL_RESTORE_CLANG_WARNINGS
 #pragma warning(pop)
 #pragma pack(pop)
+#endif // _HAS_STATIC_RTTI
 #endif // _HAS_CXX17
 
 #endif // _STL_COMPILER_PREPROCESSOR

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -1357,7 +1357,9 @@ _EMIT_STL_ERROR(STL1004, "C++98 unexpected() is incompatible with C++23 unexpect
 
 // STL4039 is used to warn that "The contents of <coroutine> are not available with /await."
 
-// next warning number: STL4040
+// STL4040 is used to warn that "The contents of <meow> are available only when RTTI is available."
+
+// next warning number: STL4041
 
 // next error number: STL1006
 

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -1357,7 +1357,7 @@ _EMIT_STL_ERROR(STL1004, "C++98 unexpected() is incompatible with C++23 unexpect
 
 // STL4039 is used to warn that "The contents of <coroutine> are not available with /await."
 
-// STL4040 is used to warn that "The contents of <meow> are available only when RTTI is available."
+// STL4040 is used to warn that "The contents of <any> require static RTTI."
 
 // next warning number: STL4041
 

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -1478,7 +1478,9 @@ _EMIT_STL_ERROR(STL1004, "C++98 unexpected() is incompatible with C++23 unexpect
 #define __cpp_lib_void_t                           201411L
 
 #if _HAS_CXX17
-#define __cpp_lib_any                        201606L
+#if _HAS_STATIC_RTTI
+#define __cpp_lib_any 201606L
+#endif // _HAS_STATIC_RTTI
 #define __cpp_lib_apply                      201603L
 #define __cpp_lib_atomic_is_always_lock_free 201603L
 #define __cpp_lib_boyer_moore_searcher       201603L

--- a/stl/modules/std.ixx
+++ b/stl/modules/std.ixx
@@ -37,7 +37,9 @@ export module std;
 
 // "C++ library headers" [tab:headers.cpp]
 #include <algorithm>
+#if _HAS_STATIC_RTTI
 #include <any>
+#endif // _HAS_STATIC_RTTI
 #include <array>
 #include <atomic>
 #include <barrier>

--- a/tests/std/include/test_header_units_and_modules.hpp
+++ b/tests/std/include/test_header_units_and_modules.hpp
@@ -20,12 +20,16 @@ void test_algorithm() {
 
 void test_any() {
     using namespace std;
+#if defined(_HAS_STATIC_RTTI) && _HAS_STATIC_RTTI == 0 // intentional: `import std;` can't provide a default definition
+    puts("Nothing to test in <any> when static RTTI is disabled.");
+#else // ^^^ static RTTI is disabled / static RTTI is enabled vvv
     puts("Testing <any>.");
     any a1{1729};
     any a2{7.5};
     a1.swap(a2);
     assert(any_cast<double>(a1) == 7.5);
     assert(any_cast<int>(a2) == 1729);
+#endif // ^^^ static RTTI is enabled ^^^
 }
 
 void test_array() {

--- a/tests/std/tests/P2465R3_standard_library_modules/env.lst
+++ b/tests/std/tests/P2465R3_standard_library_modules/env.lst
@@ -13,6 +13,5 @@ PM_CL="/MD"
 PM_CL="/MDd"
 PM_CL="/MT"
 PM_CL="/MTd"
-RUNALL_CROSSLIST
-PM_CL=""
-PM_CL="/analyze:only /analyze:autolog-"
+PM_CL="/MDd /analyze:only /analyze:autolog-"
+PM_CL="/MDd /GR- /D_HAS_STATIC_RTTI=0"

--- a/tests/std/tests/VSO_0000000_has_static_rtti/test.cpp
+++ b/tests/std/tests/VSO_0000000_has_static_rtti/test.cpp
@@ -11,6 +11,10 @@
 #include <typeinfo>
 #include <utility>
 
+#if _HAS_CXX17
+#include <any>
+#endif // _HAS_CXX17
+
 using namespace std;
 
 #define STATIC_ASSERT(...) static_assert(__VA_ARGS__, #__VA_ARGS__)

--- a/tests/std/tests/VSO_0000000_has_static_rtti/test.cpp
+++ b/tests/std/tests/VSO_0000000_has_static_rtti/test.cpp
@@ -12,7 +12,7 @@
 #include <utility>
 
 #if _HAS_CXX17
-#include <any>
+#include <any> // verify that <any> can be included (with no effect) when static RTTI is disabled
 #endif // _HAS_CXX17
 
 using namespace std;

--- a/tests/std/tests/VSO_0157762_feature_test_macros/env.lst
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/env.lst
@@ -37,6 +37,7 @@ PM_COMPILER="clang-cl" PM_CL="-fno-ms-compatibility -fno-delayed-template-parsin
 
 # The following lines are extras not present in usual_matrix.lst
 PM_CL="/MT /std:c++latest /permissive- /EHsc /D_HAS_STD_BYTE=0"
+PM_CL="/MT /std:c++latest /permissive- /EHsc /GR- /D_HAS_STATIC_RTTI=0"
 PM_CL="/MT /std:c++14 /permissive- /EHsc /await:strict"
 PM_CL="/MT /std:c++14 /permissive- /EHsc /Zc:char8_t"
 PM_CL="/MT /std:c++17 /permissive- /EHsc /Zc:char8_t"

--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
@@ -66,7 +66,7 @@ STATIC_ASSERT(__cpp_lib_allocate_at_least == 202106L);
 STATIC_ASSERT(__cpp_lib_allocator_traits_is_always_equal == 201411L);
 #endif
 
-#if _HAS_CXX17
+#if _HAS_CXX17 && _HAS_STATIC_RTTI
 #ifndef __cpp_lib_any
 #error __cpp_lib_any is not defined
 #elif __cpp_lib_any != 201606L


### PR DESCRIPTION
This PR is making `#include <any>` effectless rather than erroneous when static RTTI is disabled.

Fixes #3114.