### PR TITLE
Make `<xatomic.h>`, `<xbit_ops.h>`, and `<xerrc.h>` core headers

### DIFF
--- a/stl/inc/xatomic.h
+++ b/stl/inc/xatomic.h
@@ -1,4 +1,4 @@
-// xatomic.h internal header
+// xatomic.h internal header (core)
 
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -6,7 +6,7 @@
 #pragma once
 #ifndef _XATOMIC_H
 #define _XATOMIC_H
-#include <yvals.h>
+#include <yvals_core.h>
 #if _STL_COMPILER_PREPROCESSOR
 
 #include <intrin0.h>

--- a/stl/inc/xbit_ops.h
+++ b/stl/inc/xbit_ops.h
@@ -1,4 +1,4 @@
-// xbit_ops.h internal header
+// xbit_ops.h internal header (core)
 
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -6,7 +6,7 @@
 #pragma once
 #ifndef _XBIT_OPS_H
 #define _XBIT_OPS_H
-#include <yvals.h>
+#include <yvals_core.h>
 #if _STL_COMPILER_PREPROCESSOR
 
 #include <cstdint>

--- a/stl/inc/xerrc.h
+++ b/stl/inc/xerrc.h
@@ -1,4 +1,4 @@
-// xerrc.h internal header
+// xerrc.h internal header (core)
 
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -6,7 +6,7 @@
 #pragma once
 #ifndef _XERRC_H
 #define _XERRC_H
-#include <yvals.h>
+#include <yvals_core.h>
 #if _STL_COMPILER_PREPROCESSOR
 
 #pragma pack(push, _CRT_PACKING)

--- a/tests/std/tests/GH_001411_core_headers/test.cpp
+++ b/tests/std/tests/GH_001411_core_headers/test.cpp
@@ -8,16 +8,21 @@
 
 // Also test GH-3103 "<xatomic.h>: Investigate making this a core header" and other internal core headers
 #include <__msvc_int128.hpp>
-// <__msvc_iter_core.hpp> is included by <tuple>
 #include <__msvc_system_error_abi.hpp>
 #include <__msvc_xlocinfo_types.hpp>
 #include <xatomic.h>
 #include <xbit_ops.h>
 #include <xerrc.h>
+
+#if _HAS_CXX17
 #include <xfilesystem_abi.h>
+#endif // _HAS_CXX17
+
+// <__msvc_iter_core.hpp> is included by <tuple>
 // <xkeycheck.h> should not be included outside of <yvals_core.h>
 // <xstddef> is included by <type_traits>
 // <xtr1common> is included by <cstddef>
+// <yvals_core.h> is included by every public core header
 
 #ifdef _YVALS
 #error Core headers should not include <yvals.h>.

--- a/tests/std/tests/GH_001411_core_headers/test.cpp
+++ b/tests/std/tests/GH_001411_core_headers/test.cpp
@@ -6,6 +6,19 @@
 
 #include <__msvc_all_public_headers.hpp>
 
+// Also test GH-3103 "<xatomic.h>: Investigate making this a core header" and other internal core headers
+#include <__msvc_int128.hpp>
+// <__msvc_iter_core.hpp> is included by <tuple>
+#include <__msvc_system_error_abi.hpp>
+#include <__msvc_xlocinfo_types.hpp>
+#include <xatomic.h>
+#include <xbit_ops.h>
+#include <xerrc.h>
+#include <xfilesystem_abi.h>
+// <xkeycheck.h> should not be included outside of <yvals_core.h>
+// <xstddef> is included by <type_traits>
+// <xtr1common> is included by <cstddef>
+
 #ifdef _YVALS
 #error Core headers should not include <yvals.h>.
 #endif


### PR DESCRIPTION
And add test coverage for internal core headers in `std/tests/GH_001411_core_headers`.

Some internal core headers are not separatedly tested because they are included by standard core headers.

Fixes #3103.