### PR TITLE
Fix ill-formed primary template in P0896R4_ranges_subrange

### DIFF
--- a/tests/std/tests/P0896R4_ranges_subrange/test.compile.pass.cpp
+++ b/tests/std/tests/P0896R4_ranges_subrange/test.compile.pass.cpp
@@ -807,7 +807,12 @@ namespace test_subrange {
     inline constexpr bool is_subrange<subrange<I, S, K>> = true;
 
     template <class T>
-    inline constexpr auto kind_of = illformed<T>();
+    struct ill_formed {
+        static_assert(always_false<T>);
+    };
+
+    template <class T>
+    inline constexpr auto kind_of = ill_formed<T>{};
     template <class I, class S, subrange_kind K>
     inline constexpr auto kind_of<subrange<I, S, K>> = K;
 

--- a/tests/std/tests/P0896R4_ranges_subrange/test.compile.pass.cpp
+++ b/tests/std/tests/P0896R4_ranges_subrange/test.compile.pass.cpp
@@ -807,12 +807,12 @@ namespace test_subrange {
     inline constexpr bool is_subrange<subrange<I, S, K>> = true;
 
     template <class T>
-    struct ill_formed {
+    struct illformed {
         static_assert(always_false<T>);
     };
 
     template <class T>
-    inline constexpr auto kind_of = ill_formed<T>{};
+    inline constexpr auto kind_of = illformed<T>{};
     template <class I, class S, subrange_kind K>
     inline constexpr auto kind_of<subrange<I, S, K>> = K;
 


### PR DESCRIPTION
The intent is that `illformed<T>()` be ill-formed so the primary `kind_of` template fails instantiation, but unfortunately it's ill-formed with no diagnostic required since no specialization of this template could be valid. (Unqualified lookup for `illformed` finds nothing, and ADL can find nothing since there are no arguments and therefore no associated namespaces.)

Reported internally by the FE team. This is the STL-specific portion of MSVC-PR-425776.
