### PR TITLE
Port MSBuild refactoring

### DIFF
--- a/stl/msbuild/stl_1/dirs.proj
+++ b/stl/msbuild/stl_1/dirs.proj
@@ -11,5 +11,5 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         <ProjectFile Condition="'$(CrtBuildXMD)' != 'false'" Include="xmd\dirs.proj" />
     </ItemGroup>
 
-    <Import Project="$(_NTDRIVE)$(_NTROOT)\tools\Microsoft.DevDiv.Traversal.targets" />
+    <Import Project="$(RepoSrc)\tools\Microsoft.DevDiv.Traversal.targets" />
 </Project>

--- a/stl/msbuild/stl_1/md/dirs.proj
+++ b/stl/msbuild/stl_1/md/dirs.proj
@@ -8,7 +8,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
     <ItemGroup>
         <ProjectFile Include="msvcp_1_app\msvcp_1.nativeproj" />
-        <ProjectFile Include="msvcp_1_kernel32\msvcp_1.nativeproj" Condition="'$(BuildVCKernel32)' == 'true'" />
+        <ProjectFile Include="msvcp_1_kernel32\msvcp_1.nativeproj" />
         <ProjectFile Include="msvcp_1_onecore\msvcp_1.nativeproj" />
         <ProjectFile Include="msvcp_1_netfx\msvcp_1.nativeproj" Condition="'$(BuildArchitecture)' != 'chpe'" />
     </ItemGroup>

--- a/stl/msbuild/stl_1/md/dirs.proj
+++ b/stl/msbuild/stl_1/md/dirs.proj
@@ -13,5 +13,5 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         <ProjectFile Include="msvcp_1_netfx\msvcp_1.nativeproj" Condition="'$(BuildArchitecture)' != 'chpe'" />
     </ItemGroup>
 
-    <Import Project="$(_NTDRIVE)$(_NTROOT)\tools\Microsoft.DevDiv.Traversal.targets" />
+    <Import Project="$(RepoSrc)\tools\Microsoft.DevDiv.Traversal.targets" />
 </Project>

--- a/stl/msbuild/stl_1/msvcp_1.settings.targets
+++ b/stl/msbuild/stl_1/msvcp_1.settings.targets
@@ -37,10 +37,10 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         <DllDefName>$(LibOutputFileName).$(MsvcpFlavor)</DllDefName>
         <DllDef>$(IntermediateOutputDirectory)\$(DllDefName).def</DllDef>
 
-        <LinkGenerateDebugInformation Condition="'$(BLD_REL_NO_DBINFO)' != '1'">true</LinkGenerateDebugInformation>
-        <LinkProgramDataBaseFileName Condition="'$(BLD_REL_NO_DBINFO)' != '1'">$(OutputPath)\$(OutputName)$(_PDB_VER_NAME_)$(DllPdbFlavorSuffix)</LinkProgramDataBaseFileName>
+        <LinkGenerateDebugInformation>true</LinkGenerateDebugInformation>
+        <LinkProgramDataBaseFileName>$(OutputPath)\$(OutputName)$(_PDB_VER_NAME_)$(DllPdbFlavorSuffix)</LinkProgramDataBaseFileName>
 
-        <LinkAdditionalOptions Condition="'$(BLD_REL_NO_DBINFO)' != '1'">-debugtype:cv,fixup $(LinkAdditionalOptions)</LinkAdditionalOptions>
+        <LinkAdditionalOptions>-debugtype:cv,fixup $(LinkAdditionalOptions)</LinkAdditionalOptions>
         <LinkAdditionalOptions Condition="$(DebugBuild) != 'true'">-opt:ref,icf=3 $(LinkAdditionalOptions)</LinkAdditionalOptions>
         <LinkAdditionalOptions Condition="$(DebugBuild) == 'true'">-opt:ref,noicf $(LinkAdditionalOptions)</LinkAdditionalOptions>
         <LinkAdditionalOptions>-nodefaultlib:libcpmt$(BuildSuffix).lib $(LinkAdditionalOptions)</LinkAdditionalOptions>

--- a/stl/msbuild/stl_1/xmd/dirs.proj
+++ b/stl/msbuild/stl_1/xmd/dirs.proj
@@ -11,7 +11,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
                            '$(Configuration)' == 'chk' or
                            '$(Configuration)' == 'dbg')">
         <ProjectFile Include="msvcp_1_app\msvcp_1.nativeproj" />
-        <ProjectFile Include="msvcp_1_kernel32\msvcp_1.nativeproj" Condition="'$(BuildVCKernel32)' == 'true'" />
+        <ProjectFile Include="msvcp_1_kernel32\msvcp_1.nativeproj" />
         <ProjectFile Include="msvcp_1_onecore\msvcp_1.nativeproj" />
     </ItemGroup>
 

--- a/stl/msbuild/stl_1/xmd/dirs.proj
+++ b/stl/msbuild/stl_1/xmd/dirs.proj
@@ -8,8 +8,8 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
     <ItemGroup Condition="('$(SpectreBuildMode)' == '' or
                            '$(SpectreBuildDebug)' == 'true' or
-                           '$(_BuildType)' == 'chk' or
-                           '$(_BuildType)' == 'dbg')">
+                           '$(Configuration)' == 'chk' or
+                           '$(Configuration)' == 'dbg')">
         <ProjectFile Include="msvcp_1_app\msvcp_1.nativeproj" />
         <ProjectFile Include="msvcp_1_kernel32\msvcp_1.nativeproj" Condition="'$(BuildVCKernel32)' == 'true'" />
         <ProjectFile Include="msvcp_1_onecore\msvcp_1.nativeproj" />
@@ -19,5 +19,5 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         <ProjectFile Include="msvcp_1_netfx\msvcp_1.nativeproj" Condition="'$(BuildArchitecture)' != 'chpe'" />
     </ItemGroup>
 
-    <Import Project="$(_NTDRIVE)$(_NTROOT)\tools\Microsoft.DevDiv.Traversal.targets" />
+    <Import Project="$(RepoSrc)\tools\Microsoft.DevDiv.Traversal.targets" />
 </Project>

--- a/stl/msbuild/stl_2/dirs.proj
+++ b/stl/msbuild/stl_2/dirs.proj
@@ -11,5 +11,5 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         <ProjectFile Condition="'$(CrtBuildXMD)' != 'false'" Include="xmd\dirs.proj" />
     </ItemGroup>
 
-    <Import Project="$(_NTDRIVE)$(_NTROOT)\tools\Microsoft.DevDiv.Traversal.targets" />
+    <Import Project="$(RepoSrc)\tools\Microsoft.DevDiv.Traversal.targets" />
 </Project>

--- a/stl/msbuild/stl_2/md/dirs.proj
+++ b/stl/msbuild/stl_2/md/dirs.proj
@@ -8,7 +8,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
     <ItemGroup>
         <ProjectFile Include="msvcp_2_app\msvcp_2.nativeproj" />
-        <ProjectFile Include="msvcp_2_kernel32\msvcp_2.nativeproj" Condition="'$(BuildVCKernel32)' == 'true'" />
+        <ProjectFile Include="msvcp_2_kernel32\msvcp_2.nativeproj" />
         <ProjectFile Include="msvcp_2_onecore\msvcp_2.nativeproj" />
         <ProjectFile Include="msvcp_2_netfx\msvcp_2.nativeproj" Condition="'$(BuildArchitecture)' != 'chpe'" />
     </ItemGroup>

--- a/stl/msbuild/stl_2/md/dirs.proj
+++ b/stl/msbuild/stl_2/md/dirs.proj
@@ -13,5 +13,5 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         <ProjectFile Include="msvcp_2_netfx\msvcp_2.nativeproj" Condition="'$(BuildArchitecture)' != 'chpe'" />
     </ItemGroup>
 
-    <Import Project="$(_NTDRIVE)$(_NTROOT)\tools\Microsoft.DevDiv.Traversal.targets" />
+    <Import Project="$(RepoSrc)\tools\Microsoft.DevDiv.Traversal.targets" />
 </Project>

--- a/stl/msbuild/stl_2/msvcp_2.settings.targets
+++ b/stl/msbuild/stl_2/msvcp_2.settings.targets
@@ -37,10 +37,10 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         <DllDefName>$(LibOutputFileName).$(MsvcpFlavor)</DllDefName>
         <DllDef>$(IntermediateOutputDirectory)\$(DllDefName).def</DllDef>
 
-        <LinkGenerateDebugInformation Condition="'$(BLD_REL_NO_DBINFO)' != '1'">true</LinkGenerateDebugInformation>
-        <LinkProgramDataBaseFileName Condition="'$(BLD_REL_NO_DBINFO)' != '1'">$(OutputPath)\$(OutputName)$(_PDB_VER_NAME_)$(DllPdbFlavorSuffix)</LinkProgramDataBaseFileName>
+        <LinkGenerateDebugInformation>true</LinkGenerateDebugInformation>
+        <LinkProgramDataBaseFileName>$(OutputPath)\$(OutputName)$(_PDB_VER_NAME_)$(DllPdbFlavorSuffix)</LinkProgramDataBaseFileName>
 
-        <LinkAdditionalOptions Condition="'$(BLD_REL_NO_DBINFO)' != '1'">-debugtype:cv,fixup $(LinkAdditionalOptions)</LinkAdditionalOptions>
+        <LinkAdditionalOptions>-debugtype:cv,fixup $(LinkAdditionalOptions)</LinkAdditionalOptions>
         <LinkAdditionalOptions Condition="$(DebugBuild) != 'true'">-opt:ref,icf=3 $(LinkAdditionalOptions)</LinkAdditionalOptions>
         <LinkAdditionalOptions Condition="$(DebugBuild) == 'true'">-opt:ref,noicf $(LinkAdditionalOptions)</LinkAdditionalOptions>
         <LinkAdditionalOptions>-nodefaultlib:libcpmt$(BuildSuffix).lib $(LinkAdditionalOptions)</LinkAdditionalOptions>

--- a/stl/msbuild/stl_2/xmd/dirs.proj
+++ b/stl/msbuild/stl_2/xmd/dirs.proj
@@ -8,8 +8,8 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
     <ItemGroup Condition="('$(SpectreBuildMode)' == '' or
                            '$(SpectreBuildDebug)' == 'true' or
-                           '$(_BuildType)' == 'chk' or
-                           '$(_BuildType)' == 'dbg')">
+                           '$(Configuration)' == 'chk' or
+                           '$(Configuration)' == 'dbg')">
         <ProjectFile Include="msvcp_2_app\msvcp_2.nativeproj" />
         <ProjectFile Include="msvcp_2_kernel32\msvcp_2.nativeproj" Condition="'$(BuildVCKernel32)' == 'true'" />
         <ProjectFile Include="msvcp_2_onecore\msvcp_2.nativeproj" />
@@ -19,5 +19,5 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         <ProjectFile Include="msvcp_2_netfx\msvcp_2.nativeproj" Condition="'$(BuildArchitecture)' != 'chpe'" />
     </ItemGroup>
 
-    <Import Project="$(_NTDRIVE)$(_NTROOT)\tools\Microsoft.DevDiv.Traversal.targets" />
+    <Import Project="$(RepoSrc)\tools\Microsoft.DevDiv.Traversal.targets" />
 </Project>

--- a/stl/msbuild/stl_2/xmd/dirs.proj
+++ b/stl/msbuild/stl_2/xmd/dirs.proj
@@ -11,7 +11,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
                            '$(Configuration)' == 'chk' or
                            '$(Configuration)' == 'dbg')">
         <ProjectFile Include="msvcp_2_app\msvcp_2.nativeproj" />
-        <ProjectFile Include="msvcp_2_kernel32\msvcp_2.nativeproj" Condition="'$(BuildVCKernel32)' == 'true'" />
+        <ProjectFile Include="msvcp_2_kernel32\msvcp_2.nativeproj" />
         <ProjectFile Include="msvcp_2_onecore\msvcp_2.nativeproj" />
     </ItemGroup>
 

--- a/stl/msbuild/stl_asan/dirs.proj
+++ b/stl/msbuild/stl_asan/dirs.proj
@@ -10,5 +10,5 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         <ProjectFile Include="stl_asan.nativeproj" />
     </ItemGroup>
 
-    <Import Project="$(_NTDRIVE)$(_NTROOT)\tools\Microsoft.DevDiv.Traversal.targets" />
+    <Import Project="$(RepoSrc)\tools\Microsoft.DevDiv.Traversal.targets" />
 </Project>

--- a/stl/msbuild/stl_atomic_wait/dirs.proj
+++ b/stl/msbuild/stl_atomic_wait/dirs.proj
@@ -11,5 +11,5 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         <ProjectFile Condition="'$(CrtBuildXMD)' != 'false'" Include="xmd\dirs.proj" />
     </ItemGroup>
 
-    <Import Project="$(_NTDRIVE)$(_NTROOT)\tools\Microsoft.DevDiv.Traversal.targets" />
+    <Import Project="$(RepoSrc)\tools\Microsoft.DevDiv.Traversal.targets" />
 </Project>

--- a/stl/msbuild/stl_atomic_wait/md/dirs.proj
+++ b/stl/msbuild/stl_atomic_wait/md/dirs.proj
@@ -8,7 +8,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
     <ItemGroup>
         <ProjectFile Include="msvcp_atomic_wait_app\msvcp_atomic_wait.nativeproj" />
-        <ProjectFile Include="msvcp_atomic_wait_kernel32\msvcp_atomic_wait.nativeproj" Condition="'$(BuildVCKernel32)' == 'true'" />
+        <ProjectFile Include="msvcp_atomic_wait_kernel32\msvcp_atomic_wait.nativeproj" />
         <ProjectFile Include="msvcp_atomic_wait_onecore\msvcp_atomic_wait.nativeproj" />
         <ProjectFile Include="msvcp_atomic_wait_netfx\msvcp_atomic_wait.nativeproj" Condition="'$(BuildArchitecture)' != 'chpe'" />
     </ItemGroup>

--- a/stl/msbuild/stl_atomic_wait/md/dirs.proj
+++ b/stl/msbuild/stl_atomic_wait/md/dirs.proj
@@ -13,5 +13,5 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         <ProjectFile Include="msvcp_atomic_wait_netfx\msvcp_atomic_wait.nativeproj" Condition="'$(BuildArchitecture)' != 'chpe'" />
     </ItemGroup>
 
-    <Import Project="$(_NTDRIVE)$(_NTROOT)\tools\Microsoft.DevDiv.Traversal.targets" />
+    <Import Project="$(RepoSrc)\tools\Microsoft.DevDiv.Traversal.targets" />
 </Project>

--- a/stl/msbuild/stl_atomic_wait/msvcp_atomic_wait.settings.targets
+++ b/stl/msbuild/stl_atomic_wait/msvcp_atomic_wait.settings.targets
@@ -37,10 +37,10 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         <DllDefName>$(LibOutputFileName).$(MsvcpFlavor)</DllDefName>
         <DllDef>$(IntermediateOutputDirectory)\$(DllDefName).def</DllDef>
 
-        <LinkGenerateDebugInformation Condition="'$(BLD_REL_NO_DBINFO)' != '1'">true</LinkGenerateDebugInformation>
-        <LinkProgramDataBaseFileName Condition="'$(BLD_REL_NO_DBINFO)' != '1'">$(OutputPath)\$(OutputName)$(_PDB_VER_NAME_)$(DllPdbFlavorSuffix)</LinkProgramDataBaseFileName>
+        <LinkGenerateDebugInformation>true</LinkGenerateDebugInformation>
+        <LinkProgramDataBaseFileName>$(OutputPath)\$(OutputName)$(_PDB_VER_NAME_)$(DllPdbFlavorSuffix)</LinkProgramDataBaseFileName>
 
-        <LinkAdditionalOptions Condition="'$(BLD_REL_NO_DBINFO)' != '1'">-debugtype:cv,fixup $(LinkAdditionalOptions)</LinkAdditionalOptions>
+        <LinkAdditionalOptions>-debugtype:cv,fixup $(LinkAdditionalOptions)</LinkAdditionalOptions>
         <LinkAdditionalOptions Condition="$(DebugBuild) != 'true'">-opt:ref,icf=3 $(LinkAdditionalOptions)</LinkAdditionalOptions>
         <LinkAdditionalOptions Condition="$(DebugBuild) == 'true'">-opt:ref,noicf $(LinkAdditionalOptions)</LinkAdditionalOptions>
         <LinkAdditionalOptions>-nodefaultlib:libcpmt$(BuildSuffix).lib $(LinkAdditionalOptions)</LinkAdditionalOptions>

--- a/stl/msbuild/stl_atomic_wait/xmd/dirs.proj
+++ b/stl/msbuild/stl_atomic_wait/xmd/dirs.proj
@@ -11,7 +11,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
                            '$(Configuration)' == 'chk' or
                            '$(Configuration)' == 'dbg')">
         <ProjectFile Include="msvcp_atomic_wait_app\msvcp_atomic_wait.nativeproj" />
-        <ProjectFile Include="msvcp_atomic_wait_kernel32\msvcp_atomic_wait.nativeproj" Condition="'$(BuildVCKernel32)' == 'true'" />
+        <ProjectFile Include="msvcp_atomic_wait_kernel32\msvcp_atomic_wait.nativeproj" />
         <ProjectFile Include="msvcp_atomic_wait_onecore\msvcp_atomic_wait.nativeproj" />
     </ItemGroup>
 

--- a/stl/msbuild/stl_atomic_wait/xmd/dirs.proj
+++ b/stl/msbuild/stl_atomic_wait/xmd/dirs.proj
@@ -8,8 +8,8 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
     <ItemGroup Condition="('$(SpectreBuildMode)' == '' or
                            '$(SpectreBuildDebug)' == 'true' or
-                           '$(_BuildType)' == 'chk' or
-                           '$(_BuildType)' == 'dbg')">
+                           '$(Configuration)' == 'chk' or
+                           '$(Configuration)' == 'dbg')">
         <ProjectFile Include="msvcp_atomic_wait_app\msvcp_atomic_wait.nativeproj" />
         <ProjectFile Include="msvcp_atomic_wait_kernel32\msvcp_atomic_wait.nativeproj" Condition="'$(BuildVCKernel32)' == 'true'" />
         <ProjectFile Include="msvcp_atomic_wait_onecore\msvcp_atomic_wait.nativeproj" />
@@ -19,5 +19,5 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         <ProjectFile Include="msvcp_atomic_wait_netfx\msvcp_atomic_wait.nativeproj" Condition="'$(BuildArchitecture)' != 'chpe'" />
     </ItemGroup>
 
-    <Import Project="$(_NTDRIVE)$(_NTROOT)\tools\Microsoft.DevDiv.Traversal.targets" />
+    <Import Project="$(RepoSrc)\tools\Microsoft.DevDiv.Traversal.targets" />
 </Project>

--- a/stl/msbuild/stl_base/dirs.proj
+++ b/stl/msbuild/stl_base/dirs.proj
@@ -16,5 +16,5 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         <ProjectFile Condition="'$(CrtBuildXMT)' != 'false' and ('$(SpectreBuildMode)' == '' or '$(SpectreBuildDebug)' == 'true')" Include="xmt1\dirs.proj" />
     </ItemGroup>
 
-    <Import Project="$(_NTDRIVE)$(_NTROOT)\tools\Microsoft.DevDiv.Traversal.targets" />
+    <Import Project="$(RepoSrc)\tools\Microsoft.DevDiv.Traversal.targets" />
 </Project>

--- a/stl/msbuild/stl_base/md/dirs.proj
+++ b/stl/msbuild/stl_base/md/dirs.proj
@@ -8,7 +8,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
     <ItemGroup>
         <ProjectFile Include="msvcp_app\msvcp.nativeproj" />
-        <ProjectFile Include="msvcp_kernel32\msvcp.nativeproj" Condition="'$(BuildVCKernel32)' == 'true'" />
+        <ProjectFile Include="msvcp_kernel32\msvcp.nativeproj" />
         <ProjectFile Include="msvcp_onecore\msvcp.nativeproj" />
         <ProjectFile Include="msvcp_netfx\msvcp.nativeproj" Condition="'$(BuildArchitecture)' != 'chpe'" />
     </ItemGroup>

--- a/stl/msbuild/stl_base/md/dirs.proj
+++ b/stl/msbuild/stl_base/md/dirs.proj
@@ -13,5 +13,5 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         <ProjectFile Include="msvcp_netfx\msvcp.nativeproj" Condition="'$(BuildArchitecture)' != 'chpe'" />
     </ItemGroup>
 
-    <Import Project="$(_NTDRIVE)$(_NTROOT)\tools\Microsoft.DevDiv.Traversal.targets" />
+    <Import Project="$(RepoSrc)\tools\Microsoft.DevDiv.Traversal.targets" />
 </Project>

--- a/stl/msbuild/stl_base/msvcp.settings.targets
+++ b/stl/msbuild/stl_base/msvcp.settings.targets
@@ -42,11 +42,11 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         <DllDef>$(IntermediateOutputDirectory)\$(DllDefName).def</DllDef>
         <ClDefines Condition="'$(DependsOnConcRT)' == 'true'">$(ClDefines);_STL_CONCRT_SUPPORT</ClDefines>
 
-        <LinkGenerateDebugInformation Condition="'$(BLD_REL_NO_DBINFO)' != '1'">true</LinkGenerateDebugInformation>
-        <LinkProgramDataBaseFileName Condition="'$(BLD_REL_NO_DBINFO)' != '1'">$(OutputPath)\$(OutputName)$(_PDB_VER_NAME_)$(DllPdbFlavorSuffix)</LinkProgramDataBaseFileName>
-        <LinkProgramDataBaseFileName Condition="'$(BLD_REL_NO_DBINFO)' != '1' and '$(BuildArchitecture)' =='arm64ec' and '$(_BuildArch)' != '$(BuildArchitecture)'">$(OutputPath)\$(OutputName).arm64$(DllPdbFlavorSuffix)</LinkProgramDataBaseFileName>
+        <LinkGenerateDebugInformation>true</LinkGenerateDebugInformation>
+        <LinkProgramDataBaseFileName>$(OutputPath)\$(OutputName)$(_PDB_VER_NAME_)$(DllPdbFlavorSuffix)</LinkProgramDataBaseFileName>
+        <LinkProgramDataBaseFileName Condition="'$(BuildArchitecture)' =='arm64ec' and '$(Platform)' != '$(BuildArchitecture)'">$(OutputPath)\$(OutputName).arm64$(DllPdbFlavorSuffix)</LinkProgramDataBaseFileName>
 
-        <LinkAdditionalOptions Condition="'$(BLD_REL_NO_DBINFO)' != '1'">-debugtype:cv,fixup $(LinkAdditionalOptions)</LinkAdditionalOptions>
+        <LinkAdditionalOptions>-debugtype:cv,fixup $(LinkAdditionalOptions)</LinkAdditionalOptions>
         <LinkAdditionalOptions Condition="$(DebugBuild) != 'true'">-opt:ref,icf=3 $(LinkAdditionalOptions)</LinkAdditionalOptions>
         <LinkAdditionalOptions Condition="$(DebugBuild) == 'true'">-opt:ref,noicf $(LinkAdditionalOptions)</LinkAdditionalOptions>
         <LinkAdditionalOptions>-nodefaultlib:libcpmt$(BuildSuffix).lib $(LinkAdditionalOptions)</LinkAdditionalOptions>

--- a/stl/msbuild/stl_base/mt/dirs.proj
+++ b/stl/msbuild/stl_base/mt/dirs.proj
@@ -11,5 +11,5 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         <ProjectFile Include="libcpmt_onecore\libcpmt.nativeproj" />
     </ItemGroup>
 
-    <Import Project="$(_NTDRIVE)$(_NTROOT)\tools\Microsoft.DevDiv.Traversal.targets" />
+    <Import Project="$(RepoSrc)\tools\Microsoft.DevDiv.Traversal.targets" />
 </Project>

--- a/stl/msbuild/stl_base/mt1/dirs.proj
+++ b/stl/msbuild/stl_base/mt1/dirs.proj
@@ -11,5 +11,5 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         <ProjectFile Include="libcpmt_onecore\libcpmt.nativeproj" />
     </ItemGroup>
 
-    <Import Project="$(_NTDRIVE)$(_NTROOT)\tools\Microsoft.DevDiv.Traversal.targets" />
+    <Import Project="$(RepoSrc)\tools\Microsoft.DevDiv.Traversal.targets" />
 </Project>

--- a/stl/msbuild/stl_base/xmd/dirs.proj
+++ b/stl/msbuild/stl_base/xmd/dirs.proj
@@ -8,8 +8,8 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
     <ItemGroup Condition="('$(SpectreBuildMode)' == '' or
                            '$(SpectreBuildDebug)' == 'true' or
-                           '$(_BuildType)' == 'chk' or
-                           '$(_BuildType)' == 'dbg')">
+                           '$(Configuration)' == 'chk' or
+                           '$(Configuration)' == 'dbg')">
         <!-- Other components in dbg and chk builds depend on msvcprtd.lib -->
         <ProjectFile Include="msvcp_app\msvcp.nativeproj" />
         <ProjectFile Include="msvcp_kernel32\msvcp.nativeproj" Condition="'$(BuildVCKernel32)' == 'true'" />
@@ -20,5 +20,5 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         <ProjectFile Include="msvcp_netfx\msvcp.nativeproj" Condition="'$(BuildArchitecture)' != 'chpe'" />
     </ItemGroup>
 
-    <Import Project="$(_NTDRIVE)$(_NTROOT)\tools\Microsoft.DevDiv.Traversal.targets" />
+    <Import Project="$(RepoSrc)\tools\Microsoft.DevDiv.Traversal.targets" />
 </Project>

--- a/stl/msbuild/stl_base/xmd/dirs.proj
+++ b/stl/msbuild/stl_base/xmd/dirs.proj
@@ -12,7 +12,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
                            '$(Configuration)' == 'dbg')">
         <!-- Other components in dbg and chk builds depend on msvcprtd.lib -->
         <ProjectFile Include="msvcp_app\msvcp.nativeproj" />
-        <ProjectFile Include="msvcp_kernel32\msvcp.nativeproj" Condition="'$(BuildVCKernel32)' == 'true'" />
+        <ProjectFile Include="msvcp_kernel32\msvcp.nativeproj" />
         <ProjectFile Include="msvcp_onecore\msvcp.nativeproj" />
     </ItemGroup>
 

--- a/stl/msbuild/stl_base/xmt/dirs.proj
+++ b/stl/msbuild/stl_base/xmt/dirs.proj
@@ -9,11 +9,11 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
     <ItemGroup>
         <ProjectFile Condition="'$(SpectreBuildMode)' == '' or
                                 '$(SpectreBuildDebug)' == 'true' or
-                                '$(_BuildType)' == 'chk' or
-                                '$(_BuildType)' == 'dbg'"
+                                '$(Configuration)' == 'chk' or
+                                '$(Configuration)' == 'dbg'"
                      Include="libcpmt_kernel32\libcpmt.nativeproj" />
         <ProjectFile Condition="'$(SpectreBuildMode)' == '' or '$(SpectreBuildDebug)' == 'true'" Include="libcpmt_onecore\libcpmt.nativeproj" />
     </ItemGroup>
 
-    <Import Project="$(_NTDRIVE)$(_NTROOT)\tools\Microsoft.DevDiv.Traversal.targets" />
+    <Import Project="$(RepoSrc)\tools\Microsoft.DevDiv.Traversal.targets" />
 </Project>

--- a/stl/msbuild/stl_base/xmt0/dirs.proj
+++ b/stl/msbuild/stl_base/xmt0/dirs.proj
@@ -11,5 +11,5 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         <ProjectFile Include="libcpmt_onecore\libcpmt.nativeproj" />
     </ItemGroup>
 
-    <Import Project="$(_NTDRIVE)$(_NTROOT)\tools\Microsoft.DevDiv.Traversal.targets" />
+    <Import Project="$(RepoSrc)\tools\Microsoft.DevDiv.Traversal.targets" />
 </Project>

--- a/stl/msbuild/stl_base/xmt1/dirs.proj
+++ b/stl/msbuild/stl_base/xmt1/dirs.proj
@@ -11,5 +11,5 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         <ProjectFile Include="libcpmt_onecore\libcpmt.nativeproj" />
     </ItemGroup>
 
-    <Import Project="$(_NTDRIVE)$(_NTROOT)\tools\Microsoft.DevDiv.Traversal.targets" />
+    <Import Project="$(RepoSrc)\tools\Microsoft.DevDiv.Traversal.targets" />
 </Project>

--- a/stl/msbuild/stl_codecvt_ids/dirs.proj
+++ b/stl/msbuild/stl_codecvt_ids/dirs.proj
@@ -11,5 +11,5 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         <ProjectFile Condition="'$(CrtBuildXMD)' != 'false'" Include="xmd\dirs.proj" />
     </ItemGroup>
 
-    <Import Project="$(_NTDRIVE)$(_NTROOT)\tools\Microsoft.DevDiv.Traversal.targets" />
+    <Import Project="$(RepoSrc)\tools\Microsoft.DevDiv.Traversal.targets" />
 </Project>

--- a/stl/msbuild/stl_codecvt_ids/md/dirs.proj
+++ b/stl/msbuild/stl_codecvt_ids/md/dirs.proj
@@ -13,5 +13,5 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         <ProjectFile Include="msvcp_codecvt_ids_netfx\msvcp_codecvt_ids.nativeproj" Condition="'$(BuildArchitecture)' != 'chpe'" />
     </ItemGroup>
 
-    <Import Project="$(_NTDRIVE)$(_NTROOT)\tools\Microsoft.DevDiv.Traversal.targets" />
+    <Import Project="$(RepoSrc)\tools\Microsoft.DevDiv.Traversal.targets" />
 </Project>

--- a/stl/msbuild/stl_codecvt_ids/md/dirs.proj
+++ b/stl/msbuild/stl_codecvt_ids/md/dirs.proj
@@ -8,7 +8,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
     <ItemGroup>
         <ProjectFile Include="msvcp_codecvt_ids_app\msvcp_codecvt_ids.nativeproj" />
-        <ProjectFile Include="msvcp_codecvt_ids_kernel32\msvcp_codecvt_ids.nativeproj" Condition="'$(BuildVCKernel32)' == 'true'" />
+        <ProjectFile Include="msvcp_codecvt_ids_kernel32\msvcp_codecvt_ids.nativeproj" />
         <ProjectFile Include="msvcp_codecvt_ids_onecore\msvcp_codecvt_ids.nativeproj" />
         <ProjectFile Include="msvcp_codecvt_ids_netfx\msvcp_codecvt_ids.nativeproj" Condition="'$(BuildArchitecture)' != 'chpe'" />
     </ItemGroup>

--- a/stl/msbuild/stl_codecvt_ids/msvcp_codecvt_ids.settings.targets
+++ b/stl/msbuild/stl_codecvt_ids/msvcp_codecvt_ids.settings.targets
@@ -37,10 +37,10 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         <DllDefName>$(LibOutputFileName).$(MsvcpFlavor)</DllDefName>
         <DllDef>$(IntermediateOutputDirectory)\$(DllDefName).def</DllDef>
 
-        <LinkGenerateDebugInformation Condition="'$(BLD_REL_NO_DBINFO)' != '1'">true</LinkGenerateDebugInformation>
-        <LinkProgramDataBaseFileName Condition="'$(BLD_REL_NO_DBINFO)' != '1'">$(OutputPath)\$(OutputName)$(_PDB_VER_NAME_)$(DllPdbFlavorSuffix)</LinkProgramDataBaseFileName>
+        <LinkGenerateDebugInformation>true</LinkGenerateDebugInformation>
+        <LinkProgramDataBaseFileName>$(OutputPath)\$(OutputName)$(_PDB_VER_NAME_)$(DllPdbFlavorSuffix)</LinkProgramDataBaseFileName>
 
-        <LinkAdditionalOptions Condition="'$(BLD_REL_NO_DBINFO)' != '1'">-debugtype:cv,fixup $(LinkAdditionalOptions)</LinkAdditionalOptions>
+        <LinkAdditionalOptions>-debugtype:cv,fixup $(LinkAdditionalOptions)</LinkAdditionalOptions>
         <LinkAdditionalOptions Condition="$(DebugBuild) != 'true'">-opt:ref,icf=3 $(LinkAdditionalOptions)</LinkAdditionalOptions>
         <LinkAdditionalOptions Condition="$(DebugBuild) == 'true'">-opt:ref,noicf $(LinkAdditionalOptions)</LinkAdditionalOptions>
         <LinkAdditionalOptions>-nodefaultlib:libcpmt$(BuildSuffix).lib $(LinkAdditionalOptions)</LinkAdditionalOptions>

--- a/stl/msbuild/stl_codecvt_ids/xmd/dirs.proj
+++ b/stl/msbuild/stl_codecvt_ids/xmd/dirs.proj
@@ -11,7 +11,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
                            '$(Configuration)' == 'chk' or
                            '$(Configuration)' == 'dbg')">
         <ProjectFile Include="msvcp_codecvt_ids_app\msvcp_codecvt_ids.nativeproj" />
-        <ProjectFile Include="msvcp_codecvt_ids_kernel32\msvcp_codecvt_ids.nativeproj" Condition="'$(BuildVCKernel32)' == 'true'" />
+        <ProjectFile Include="msvcp_codecvt_ids_kernel32\msvcp_codecvt_ids.nativeproj" />
         <ProjectFile Include="msvcp_codecvt_ids_onecore\msvcp_codecvt_ids.nativeproj" />
     </ItemGroup>
 

--- a/stl/msbuild/stl_codecvt_ids/xmd/dirs.proj
+++ b/stl/msbuild/stl_codecvt_ids/xmd/dirs.proj
@@ -8,8 +8,8 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
     <ItemGroup Condition="('$(SpectreBuildMode)' == '' or
                            '$(SpectreBuildDebug)' == 'true' or
-                           '$(_BuildType)' == 'chk' or
-                           '$(_BuildType)' == 'dbg')">
+                           '$(Configuration)' == 'chk' or
+                           '$(Configuration)' == 'dbg')">
         <ProjectFile Include="msvcp_codecvt_ids_app\msvcp_codecvt_ids.nativeproj" />
         <ProjectFile Include="msvcp_codecvt_ids_kernel32\msvcp_codecvt_ids.nativeproj" Condition="'$(BuildVCKernel32)' == 'true'" />
         <ProjectFile Include="msvcp_codecvt_ids_onecore\msvcp_codecvt_ids.nativeproj" />
@@ -19,5 +19,5 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         <ProjectFile Include="msvcp_codecvt_ids_netfx\msvcp_codecvt_ids.nativeproj" Condition="'$(BuildArchitecture)' != 'chpe' and '$(BuildArchitecture)' != 'arm64ec'" />
     </ItemGroup>
 
-    <Import Project="$(_NTDRIVE)$(_NTROOT)\tools\Microsoft.DevDiv.Traversal.targets" />
+    <Import Project="$(RepoSrc)\tools\Microsoft.DevDiv.Traversal.targets" />
 </Project>

--- a/stl/msbuild/stl_post/dirs.proj
+++ b/stl/msbuild/stl_post/dirs.proj
@@ -11,5 +11,5 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         <ProjectFile Condition="'$(CrtBuildXMD)' != 'false'" Include="xmd\dirs.proj" />
     </ItemGroup>
 
-    <Import Project="$(_NTDRIVE)$(_NTROOT)\tools\Microsoft.DevDiv.Traversal.targets" />
+    <Import Project="$(RepoSrc)\tools\Microsoft.DevDiv.Traversal.targets" />
 </Project>

--- a/stl/msbuild/stl_post/md/dirs.proj
+++ b/stl/msbuild/stl_post/md/dirs.proj
@@ -8,7 +8,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
     <ItemGroup>
         <ProjectFile Include="msvcp_post_app\msvcp_post.nativeproj" />
-        <ProjectFile Include="msvcp_post_kernel32\msvcp_post.nativeproj" Condition="'$(BuildVCKernel32)' == 'true'" />
+        <ProjectFile Include="msvcp_post_kernel32\msvcp_post.nativeproj" />
         <ProjectFile Include="msvcp_post_onecore\msvcp_post.nativeproj" />
         <ProjectFile Include="msvcp_post_netfx\msvcp_post.nativeproj" Condition="'$(BuildArchitecture)' != 'chpe'" />
     </ItemGroup>

--- a/stl/msbuild/stl_post/md/dirs.proj
+++ b/stl/msbuild/stl_post/md/dirs.proj
@@ -13,5 +13,5 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         <ProjectFile Include="msvcp_post_netfx\msvcp_post.nativeproj" Condition="'$(BuildArchitecture)' != 'chpe'" />
     </ItemGroup>
 
-    <Import Project="$(_NTDRIVE)$(_NTROOT)\tools\Microsoft.DevDiv.Traversal.targets" />
+    <Import Project="$(RepoSrc)\tools\Microsoft.DevDiv.Traversal.targets" />
 </Project>

--- a/stl/msbuild/stl_post/msvcp_post.settings.targets
+++ b/stl/msbuild/stl_post/msvcp_post.settings.targets
@@ -28,10 +28,10 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
         <UseMsvcrt>false</UseMsvcrt>
 
-        <LinkGenerateDebugInformation Condition="'$(BLD_REL_NO_DBINFO)' != '1'">true</LinkGenerateDebugInformation>
-        <LinkProgramDataBaseFileName Condition="'$(BLD_REL_NO_DBINFO)' != '1'">$(OutputPath)\$(OutputName)$(_PDB_VER_NAME_)$(DllPdbFlavorSuffix)</LinkProgramDataBaseFileName>
+        <LinkGenerateDebugInformation>true</LinkGenerateDebugInformation>
+        <LinkProgramDataBaseFileName>$(OutputPath)\$(OutputName)$(_PDB_VER_NAME_)$(DllPdbFlavorSuffix)</LinkProgramDataBaseFileName>
 
-        <LinkAdditionalOptions Condition="'$(BLD_REL_NO_DBINFO)' != '1'">-debugtype:cv,fixup $(LinkAdditionalOptions)</LinkAdditionalOptions>
+        <LinkAdditionalOptions>-debugtype:cv,fixup $(LinkAdditionalOptions)</LinkAdditionalOptions>
         <LinkAdditionalOptions Condition="$(DebugBuild) != 'true'">-opt:ref,icf=3 $(LinkAdditionalOptions)</LinkAdditionalOptions>
         <LinkAdditionalOptions Condition="$(DebugBuild) == 'true'">-opt:ref,noicf $(LinkAdditionalOptions)</LinkAdditionalOptions>
         <LinkAdditionalOptions>-nodefaultlib:libcpmt$(BuildSuffix).lib $(LinkAdditionalOptions)</LinkAdditionalOptions>

--- a/stl/msbuild/stl_post/xmd/dirs.proj
+++ b/stl/msbuild/stl_post/xmd/dirs.proj
@@ -11,7 +11,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
                            '$(Configuration)' == 'chk' or
                            '$(Configuration)' == 'dbg')">
         <ProjectFile Include="msvcp_post_app\msvcp_post.nativeproj" />
-        <ProjectFile Include="msvcp_post_kernel32\msvcp_post.nativeproj" Condition="'$(BuildVCKernel32)' == 'true'" />
+        <ProjectFile Include="msvcp_post_kernel32\msvcp_post.nativeproj" />
         <ProjectFile Include="msvcp_post_onecore\msvcp_post.nativeproj" />
     </ItemGroup>
 

--- a/stl/msbuild/stl_post/xmd/dirs.proj
+++ b/stl/msbuild/stl_post/xmd/dirs.proj
@@ -8,8 +8,8 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
     <ItemGroup Condition="('$(SpectreBuildMode)' == '' or
                            '$(SpectreBuildDebug)' == 'true' or
-                           '$(_BuildType)' == 'chk' or
-                           '$(_BuildType)' == 'dbg')">
+                           '$(Configuration)' == 'chk' or
+                           '$(Configuration)' == 'dbg')">
         <ProjectFile Include="msvcp_post_app\msvcp_post.nativeproj" />
         <ProjectFile Include="msvcp_post_kernel32\msvcp_post.nativeproj" Condition="'$(BuildVCKernel32)' == 'true'" />
         <ProjectFile Include="msvcp_post_onecore\msvcp_post.nativeproj" />
@@ -19,5 +19,5 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         <ProjectFile Include="msvcp_post_netfx\msvcp_post.nativeproj" Condition="'$(BuildArchitecture)' != 'chpe'" />
     </ItemGroup>
 
-    <Import Project="$(_NTDRIVE)$(_NTROOT)\tools\Microsoft.DevDiv.Traversal.targets" />
+    <Import Project="$(RepoSrc)\tools\Microsoft.DevDiv.Traversal.targets" />
 </Project>


### PR DESCRIPTION
This mirrors the `src/vctools/crt/github` changes from Andrew Dean's internal MSVC-PR-422642.

Note that that PR must target `prod/be`, so this will result in temporary divergence between microsoft/STL's GitHub repo and the internal `prod/fe` branch (with which we're usually binary-identical at all times). I believe that this is tolerable because the `stl/msbuild` files change so rarely, and even if we do need to make changes (e.g. adding a new source file), there should be no major conflicts.