### PR TITLE
No more 'operation completed successfully' in `time_zone::get_info`

### DIFF
--- a/stl/src/tzdb.cpp
+++ b/stl/src/tzdb.cpp
@@ -200,6 +200,7 @@ namespace {
         const auto _Input_as_wchar = reinterpret_cast<const wchar_t*>(_Input);
         const auto _Count_result = __std_fs_convert_wide_to_narrow(_Code_page, _Input_as_wchar, _Input_len, nullptr, 0);
         if (_Count_result._Err != __std_win_error::_Success) {
+            SetLastError(static_cast<DWORD>(_Count_result._Err));
             _Err = __std_tzdb_error::_Win_error;
             return nullptr;
         }
@@ -214,6 +215,7 @@ namespace {
         const auto _Result =
             __std_fs_convert_wide_to_narrow(_Code_page, _Input_as_wchar, _Input_len, _Data.get(), _Count_result._Len);
         if (_Result._Err != __std_win_error::_Success) {
+            SetLastError(static_cast<DWORD>(_Result._Err));
             _Err = __std_tzdb_error::_Win_error;
             return nullptr;
         }


### PR DESCRIPTION
When no mapping for a Unicode character existed in the target multi-byte code page, we just returned that error from
`__std_fs_convert_wide_to_narrow`; instead, we additionally needed to `SetLastError()` after that call.

Fixes #3097 (kind of)

The issue was that if the language of the system was not representable by the current code page, we would throw `GetLastError()`; however, last error was never actually set.