### PR TITLE
Move barrier macros from `<atomic>` to `<xatomic.h>`

### DIFF
--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -94,18 +94,6 @@ extern "C" inline void _Check_memory_order(const unsigned int _Order) noexcept {
     }
 }
 
-#define _Compiler_barrier() _STL_DISABLE_DEPRECATED_WARNING _ReadWriteBarrier() _STL_RESTORE_DEPRECATED_WARNING
-
-#if defined(_M_ARM) || defined(_M_ARM64) || defined(_M_ARM64EC)
-#define _Memory_barrier()             __dmb(0xB) // inner shared data memory barrier
-#define _Compiler_or_memory_barrier() _Memory_barrier()
-#elif defined(_M_IX86) || defined(_M_X64)
-// x86/x64 hardware only emits memory barriers inside _Interlocked intrinsics
-#define _Compiler_or_memory_barrier() _Compiler_barrier()
-#else // ^^^ x86/x64 / unsupported hardware vvv
-#error Unsupported hardware
-#endif // hardware
-
 #if defined(_M_IX86) || (defined(_M_X64) && !defined(_M_ARM64EC))
 #define _ATOMIC_CHOOSE_INTRINSIC(_Order, _Result, _Intrinsic, ...) \
     _Check_memory_order(_Order);                                   \

--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -2970,9 +2970,6 @@ _STD_END
 
 #undef _STD_COMPARE_EXCHANGE_128
 #undef _INVALID_MEMORY_ORDER
-#undef _Compiler_or_memory_barrier
-#undef _Memory_barrier
-#undef _Compiler_barrier
 
 #pragma pop_macro("new")
 _STL_RESTORE_CLANG_WARNINGS

--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -365,23 +365,23 @@ struct _Atomic_padded {
 #else // ^^^ don't break ABI / break ABI vvv
 template <class _Ty>
 struct _Atomic_storage_traits { // properties for how _Ty is stored in an atomic
-    static constexpr size_t _Storage_size = sizeof(_Ty) == 1  ? 1
-                                          : sizeof(_Ty) == 2  ? 2
-                                          : sizeof(_Ty) <= 4  ? 4
-                                          : sizeof(_Ty) <= 8  ? 8
+    static constexpr size_t _Storage_size = sizeof(_Ty) == 1 ? 1
+                                          : sizeof(_Ty) == 2 ? 2
+                                          : sizeof(_Ty) <= 4 ? 4
+                                          : sizeof(_Ty) <= 8 ? 8
 #if defined(_M_X64) || defined(_M_ARM64) || defined(_M_ARM64EC)
                                           : sizeof(_Ty) <= 16 ? 16
 #endif // 64 bits
                                                               : sizeof(_Ty);
 
     static constexpr size_t _Padding_size = _Storage_size - sizeof(_Ty);
-    static constexpr bool _Uses_padding   = _Padding_size != 0;
+    static constexpr bool _Uses_padding = _Padding_size != 0;
 };
 
 template <class _Ty>
 struct _Atomic_storage_traits<_Ty&> { // properties for how _Ty is stored in an atomic_ref
     static constexpr size_t _Storage_size = sizeof(_Ty);
-    static constexpr bool _Uses_padding   = false;
+    static constexpr bool _Uses_padding = false;
 };
 
 template <class _Ty, bool = _Atomic_storage_traits<_Ty>::_Uses_padding>

--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -16,13 +16,7 @@
 
 #if _HAS_CXX20
 #include <atomic>
-#else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
-#include <xatomic.h>
-
-#undef _Compiler_or_memory_barrier
-#undef _Memory_barrier
-#undef _Compiler_barrier
-#endif // ^^^ !_HAS_CXX20 ^^^
+#endif // _HAS_CXX20
 
 #pragma pack(push, _CRT_PACKING)
 #pragma warning(push, _STL_WARNING_LEVEL)

--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -16,7 +16,13 @@
 
 #if _HAS_CXX20
 #include <atomic>
-#endif
+#else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
+#include <xatomic.h>
+
+#undef _Compiler_or_memory_barrier
+#undef _Memory_barrier
+#undef _Compiler_barrier
+#endif // ^^^ !_HAS_CXX20 ^^^
 
 #pragma pack(push, _CRT_PACKING)
 #pragma warning(push, _STL_WARNING_LEVEL)

--- a/stl/inc/xatomic.h
+++ b/stl/inc/xatomic.h
@@ -51,7 +51,7 @@ _STL_DISABLE_CLANG_WARNINGS
 #define _MT_DECR(x) _INTRIN_ACQ_REL(_InterlockedDecrement)(reinterpret_cast<volatile long*>(&x))
 
 // The following macros are SHARED with vcruntime and any updates should be mirrored.
-// Also: if any macros are added they should be #undefed in vcruntime, <atomic>, and <memory> as well.
+// Also: if any macros are added they should be #undefed in vcruntime, <atomic>, and <xmemory> as well.
 #define _Compiler_barrier() _STL_DISABLE_DEPRECATED_WARNING _ReadWriteBarrier() _STL_RESTORE_DEPRECATED_WARNING
 
 #if defined(_M_ARM) || defined(_M_ARM64) || defined(_M_ARM64EC)

--- a/stl/inc/xatomic.h
+++ b/stl/inc/xatomic.h
@@ -51,7 +51,7 @@ _STL_DISABLE_CLANG_WARNINGS
 #define _MT_DECR(x) _INTRIN_ACQ_REL(_InterlockedDecrement)(reinterpret_cast<volatile long*>(&x))
 
 // The following macros are SHARED with vcruntime and any updates should be mirrored.
-// Also: if any macros are added they should be #undefed in vcruntime and <atomic> as well.
+// Also: if any macros are added they should be #undefed in vcruntime as well.
 #define _Compiler_barrier() _STL_DISABLE_DEPRECATED_WARNING _ReadWriteBarrier() _STL_RESTORE_DEPRECATED_WARNING
 
 #if defined(_M_ARM) || defined(_M_ARM64) || defined(_M_ARM64EC)

--- a/stl/inc/xatomic.h
+++ b/stl/inc/xatomic.h
@@ -51,7 +51,7 @@ _STL_DISABLE_CLANG_WARNINGS
 #define _MT_DECR(x) _INTRIN_ACQ_REL(_InterlockedDecrement)(reinterpret_cast<volatile long*>(&x))
 
 // The following macros are SHARED with vcruntime and any updates should be mirrored.
-// Also: if any macros are added they should be #undefed in vcruntime, <atomic>, and <xmemory> as well.
+// Also: if any macros are added they should be #undefed in vcruntime and <atomic> as well.
 #define _Compiler_barrier() _STL_DISABLE_DEPRECATED_WARNING _ReadWriteBarrier() _STL_RESTORE_DEPRECATED_WARNING
 
 #if defined(_M_ARM) || defined(_M_ARM64) || defined(_M_ARM64EC)

--- a/stl/inc/xatomic.h
+++ b/stl/inc/xatomic.h
@@ -51,7 +51,7 @@ _STL_DISABLE_CLANG_WARNINGS
 #define _MT_DECR(x) _INTRIN_ACQ_REL(_InterlockedDecrement)(reinterpret_cast<volatile long*>(&x))
 
 // The following macros are SHARED with vcruntime and any updates should be mirrored.
-// Also: if any macros are added they should be #undefed in vcruntime and <atomic> as well.
+// Also: if any macros are added they should be #undefed in vcruntime, <atomic>, and <memory> as well.
 #define _Compiler_barrier() _STL_DISABLE_DEPRECATED_WARNING _ReadWriteBarrier() _STL_RESTORE_DEPRECATED_WARNING
 
 #if defined(_M_ARM) || defined(_M_ARM64) || defined(_M_ARM64EC)

--- a/stl/inc/xatomic.h
+++ b/stl/inc/xatomic.h
@@ -50,7 +50,7 @@ _STL_DISABLE_CLANG_WARNINGS
 #define _MT_INCR(x) _INTRIN_RELAXED(_InterlockedIncrement)(reinterpret_cast<volatile long*>(&x))
 #define _MT_DECR(x) _INTRIN_ACQ_REL(_InterlockedDecrement)(reinterpret_cast<volatile long*>(&x))
 
-// The following macros are SHARED with vcruntime and any updates should be mirrored. 
+// The following macros are SHARED with vcruntime and any updates should be mirrored.
 // Also: if any macros are added they should be #undefed in vcruntime and <atomic> as well.
 #define _Compiler_barrier() _STL_DISABLE_DEPRECATED_WARNING _ReadWriteBarrier() _STL_RESTORE_DEPRECATED_WARNING
 

--- a/stl/inc/xatomic.h
+++ b/stl/inc/xatomic.h
@@ -50,6 +50,20 @@ _STL_DISABLE_CLANG_WARNINGS
 #define _MT_INCR(x) _INTRIN_RELAXED(_InterlockedIncrement)(reinterpret_cast<volatile long*>(&x))
 #define _MT_DECR(x) _INTRIN_ACQ_REL(_InterlockedDecrement)(reinterpret_cast<volatile long*>(&x))
 
+// The following macros are SHARED with vcruntime and any updates should be mirrored. 
+// Also: if any macros are added they should be #undefed in vcruntime and <atomic> as well.
+#define _Compiler_barrier() _STL_DISABLE_DEPRECATED_WARNING _ReadWriteBarrier() _STL_RESTORE_DEPRECATED_WARNING
+
+#if defined(_M_ARM) || defined(_M_ARM64) || defined(_M_ARM64EC)
+#define _Memory_barrier()             __dmb(0xB) // inner shared data memory barrier
+#define _Compiler_or_memory_barrier() _Memory_barrier()
+#elif defined(_M_IX86) || defined(_M_X64)
+// x86/x64 hardware only emits memory barriers inside _Interlocked intrinsics
+#define _Compiler_or_memory_barrier() _Compiler_barrier()
+#else // ^^^ x86/x64 / unsupported hardware vvv
+#error Unsupported hardware
+#endif // hardware
+
 _STD_BEGIN
 
 #if _HAS_CXX20

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -2412,10 +2412,6 @@ _EXPORT_STD inline void* align(size_t _Bound, size_t _Size, void*& _Ptr, size_t&
 }
 _STD_END
 
-#undef _Compiler_or_memory_barrier
-#undef _Memory_barrier
-#undef _Compiler_barrier
-
 #pragma pop_macro("new")
 _STL_RESTORE_CLANG_WARNINGS
 #pragma warning(pop)

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -12,7 +12,12 @@
 #include <cstdlib>
 #include <limits>
 #include <new>
+#include <xatomic.h>
 #include <xutility>
+
+#undef _Compiler_or_memory_barrier
+#undef _Memory_barrier
+#undef _Compiler_barrier
 
 #if _HAS_CXX20
 #include <tuple>

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -15,10 +15,6 @@
 #include <xatomic.h>
 #include <xutility>
 
-#undef _Compiler_or_memory_barrier
-#undef _Memory_barrier
-#undef _Compiler_barrier
-
 #if _HAS_CXX20
 #include <tuple>
 #endif // _HAS_CXX20
@@ -2415,6 +2411,10 @@ _EXPORT_STD inline void* align(size_t _Bound, size_t _Size, void*& _Ptr, size_t&
     return _Ptr;
 }
 _STD_END
+
+#undef _Compiler_or_memory_barrier
+#undef _Memory_barrier
+#undef _Compiler_barrier
 
 #pragma pop_macro("new")
 _STL_RESTORE_CLANG_WARNINGS

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -12,7 +12,6 @@
 #include <cstdlib>
 #include <limits>
 #include <new>
-#include <xatomic.h>
 #include <xutility>
 
 #if _HAS_CXX20


### PR DESCRIPTION
Towards #3048.

@MattStephanson @barcharcraz

I think we can include `<xatomic.h>` in `locale0.cpp` once this PR gets merged as `<xatomic.h>` has been made a core header, and avoid the third copy of these macro definitions. This should have no undesired impact on the size of import library.

~I guess these macros should still be `#undef`ed in `<atomic>`, so I copied the comments in `<atomic>` with modifications.~

The separated `#undef` directives in `<atomic>` are being removed.