### PR TITLE
Fix test suite issues discovered by Clang 15

### DIFF
--- a/tests/std/tests/P0898R3_concepts/test.cpp
+++ b/tests/std/tests/P0898R3_concepts/test.cpp
@@ -810,7 +810,7 @@ namespace test_integral_concepts {
         enum class is { not_integral, integral, signed_integral, unsigned_integral, ull };
 
         template <class T>
-        constexpr is f(T&&) {
+        constexpr is f(T) {
             return is::not_integral;
         }
         template <integral T>

--- a/tests/tr1/include/tspec_random.h
+++ b/tests/tr1/include/tspec_random.h
@@ -42,8 +42,7 @@ public:
 
         // collect random sample data from given distribution
         mt19937 gen;
-        i     = 0;
-        int n = 0;
+        i = 0;
         for (; i < BINSIZE; ++i)
             got_count[i] = 0;
 
@@ -59,7 +58,6 @@ public:
             Ty zero = (Ty) 0; // to quiet diagnostics
             if (zero <= rand_value && rand_value < (Ty) BINSIZE) { // increase the count of the proper bin
                 got_count[(int) rand_value]++;
-                ++n;
             } else if (rand_value < zero)
                 ++under_bin;
             else if ((Ty) (BINSIZE - 1) < rand_value)


### PR DESCRIPTION
I validated the STL against Clang 15.0.1, which may be shipping Soon(TM) with Visual Studio.

* Clang's "initialized but unused variable" warning got smarter, and noticed that `do_random_test::gen_data` in `tests/tr1/include/tspec_random.h` initialized `int n = 0`, incremented `n` some number of times, and never used the resulting value. I've removed the offending variable.

* Clang diagnosed the subsumption test in `tests/std/P0898R3_concepts` as ill-formed due to ambiguity. The test does something like: ```c++ constexpr bool f(auto&&) { return false; } constexpr bool f(integral auto) { return true; } static_assert(f(42)); ``` intending that `f(integral auto)` is called with the belief that its contraints subsume those of `f(auto&&)`. This was derived from similar subsumption tests I wrote for concepts in cmcstl2 and range-v3 which GCC's TS-era concepts implementation once accepted, but current GCC and Clang both reject it. I suspect MSVC and Clang 14 were wrong to accept the code and the call _should_ be ambiguous, but I need to dig into the wording for partial ordering of function templates before filing a bug against MSVC. In any case, we can change `f(auto&&)` to `f(auto)` without impacting the test - the arguments used in the test all have scalar types - so let's do so.

* Clang diagnosed hundreds of unqualified calls to `move` and `forward` in our tests thanks to a new `unqualified-std-cast-call` warning. I don't address these in this PR, I've instead opened #3134 for us to discuss precisely how we do want to address it.
