### PR TITLE
Update syserror_import_lib.cpp

### DIFF
--- a/stl/src/syserror.cpp
+++ b/stl/src/syserror.cpp
@@ -226,9 +226,10 @@ _CRTIMP2_PURE unsigned long __CLRCALL_PURE_OR_CDECL _Winerror_message(
     // convert to name of Windows error, return 0 for failure, otherwise return number of chars written
     // pre: _Size < INT_MAX
     const unsigned long _Chars = FormatMessageA(
-        FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, nullptr, _Message_id, 0, _Narrow, _Size, nullptr);
+        FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS | FORMAT_MESSAGE_MAX_WIDTH_MASK,
+        nullptr, _Message_id, 0, _Narrow, _Size, nullptr);
 
-    return static_cast<unsigned long>(_CSTD __std_get_string_size_without_trailing_whitespace(_Narrow, _Chars));
+    return _Chars - 1;
 }
 
 _CRTIMP2_PURE const char* __CLRCALL_PURE_OR_CDECL _Syserror_map(int _Errcode) { // convert to name of generic error

--- a/stl/src/syserror.cpp
+++ b/stl/src/syserror.cpp
@@ -228,8 +228,12 @@ _CRTIMP2_PURE unsigned long __CLRCALL_PURE_OR_CDECL _Winerror_message(
     const unsigned long _Chars =
         FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS | FORMAT_MESSAGE_MAX_WIDTH_MASK,
             nullptr, _Message_id, 0, _Narrow, _Size, nullptr);
-
-    return _Chars - 1;
+    
+    if (_Chars == 0) {
+        return 0;
+    } else {
+        return _Chars - 1;
+    }
 }
 
 _CRTIMP2_PURE const char* __CLRCALL_PURE_OR_CDECL _Syserror_map(int _Errcode) { // convert to name of generic error

--- a/stl/src/syserror.cpp
+++ b/stl/src/syserror.cpp
@@ -226,7 +226,8 @@ _CRTIMP2_PURE unsigned long __CLRCALL_PURE_OR_CDECL _Winerror_message(
     // convert to name of Windows error, return 0 for failure, otherwise return number of chars written
     // pre: _Size < INT_MAX
     const unsigned long _Chars = FormatMessageA(
-        FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS | FORMAT_MESSAGE_MAX_WIDTH_MASK,
+        FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS |
+    FORMAT_MESSAGE_MAX_WIDTH_MASK,
         nullptr, _Message_id, 0, _Narrow, _Size, nullptr);
 
     return _Chars - 1;

--- a/stl/src/syserror.cpp
+++ b/stl/src/syserror.cpp
@@ -229,11 +229,7 @@ _CRTIMP2_PURE unsigned long __CLRCALL_PURE_OR_CDECL _Winerror_message(
         FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS | FORMAT_MESSAGE_MAX_WIDTH_MASK,
             nullptr, _Message_id, 0, _Narrow, _Size, nullptr);
     
-    if (_Chars == 0) {
-        return 0;
-    } else {
-        return _Chars - 1;
-    }
+    return (_Chars == 0) ? 0 : _Chars - 1;
 }
 
 _CRTIMP2_PURE const char* __CLRCALL_PURE_OR_CDECL _Syserror_map(int _Errcode) { // convert to name of generic error

--- a/stl/src/syserror_import_lib.cpp
+++ b/stl/src/syserror_import_lib.cpp
@@ -22,14 +22,12 @@ _NODISCARD size_t __CLRCALL_PURE_OR_STDCALL __std_system_error_allocate_message(
         _Lang_id = 0;
     }
     
-    // Flag FORMAT_MESSAGE_MAX_WIDTH_MASK Removes All Trailing \r \n Leaves Only Whitespace Character
-    const unsigned long _Chars = FormatMessageA(
-        FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
-        FORMAT_MESSAGE_IGNORE_INSERTS | FORMAT_MESSAGE_MAX_WIDTH_MASK,
-        nullptr, _Message_id, _Lang_id, reinterpret_cast<char*>(_Ptr_str), 0, nullptr);
+     // Flag FORMAT_MESSAGE_MAX_WIDTH_MASK Removes All Trailing \r \n Leaves Only Whitespace Character
++    const unsigned long _Chars = FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM
++                                                    | FORMAT_MESSAGE_IGNORE_INSERTS | FORMAT_MESSAGE_MAX_WIDTH_MASK,
+     nullptr, _Message_id, _Lang_id, reinterpret_cast<char*>(_Ptr_str), 0, nullptr);
 
-    return _Chars - 1;
-    
+     return _Chars - 1;
 }
 
 void __CLRCALL_PURE_OR_STDCALL __std_system_error_deallocate_message(char* const _Str) noexcept {

--- a/stl/src/syserror_import_lib.cpp
+++ b/stl/src/syserror_import_lib.cpp
@@ -56,12 +56,8 @@ _NODISCARD size_t __CLRCALL_PURE_OR_STDCALL __std_system_error_allocate_message(
     const unsigned long _Chars = FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM
                                                     | FORMAT_MESSAGE_IGNORE_INSERTS | FORMAT_MESSAGE_MAX_WIDTH_MASK,
         nullptr, _Message_id, _Lang_id, reinterpret_cast<char*>(_Ptr_str), 0, nullptr);
-
-    if (_Chars == 0) {
-        return 0;
-    } else {
-        return _Chars - 1;
-    }
+    
+    return (_Chars == 0) ? 0 : _Chars - 1;
 }
 
 void __CLRCALL_PURE_OR_STDCALL __std_system_error_deallocate_message(char* const _Str) noexcept {

--- a/stl/src/syserror_import_lib.cpp
+++ b/stl/src/syserror_import_lib.cpp
@@ -26,7 +26,7 @@ _NODISCARD size_t __CLRCALL_PURE_OR_STDCALL __std_system_error_allocate_message(
     const unsigned long _Chars = FormatMessageA(
         FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
         FORMAT_MESSAGE_IGNORE_INSERTS | FORMAT_MESSAGE_MAX_WIDTH_MASK,
-            nullptr, _Message_id, _Lang_id, reinterpret_cast<char*>(_Ptr_str), 0, nullptr);
+        nullptr, _Message_id, _Lang_id, reinterpret_cast<char*>(_Ptr_str), 0, nullptr);
 
     return _Chars - 1;
     

--- a/stl/src/syserror_import_lib.cpp
+++ b/stl/src/syserror_import_lib.cpp
@@ -51,11 +51,12 @@ _NODISCARD size_t __CLRCALL_PURE_OR_STDCALL __std_system_error_allocate_message(
     if (_Ret == 0) {
         _Lang_id = 0;
     }
+    // Flag FORMAT_MESSAGE_MAX_WIDTH_MASK Removes All Trailing \r \n Leaves Only Whitespace Character
     const unsigned long _Chars =
-        FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+        FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS | FORMAT_MESSAGE_MAX_WIDTH_MASK,
             nullptr, _Message_id, _Lang_id, reinterpret_cast<char*>(_Ptr_str), 0, nullptr);
 
-    return _CSTD __std_get_string_size_without_trailing_whitespace(*_Ptr_str, _Chars);
+    return _Chars - 1;
 }
 
 void __CLRCALL_PURE_OR_STDCALL __std_system_error_deallocate_message(char* const _Str) noexcept {

--- a/stl/src/syserror_import_lib.cpp
+++ b/stl/src/syserror_import_lib.cpp
@@ -6,40 +6,10 @@
 // Do not include or define anything else here.
 // In particular, basic_string must not be included here.
 
+#include <Windows.h>
 #include <__msvc_system_error_abi.hpp>
 
-#include <Windows.h>
-
-/* namespace {
-    struct _Whitespace_bitmap_t {
-        bool _Is_whitespace[256];
-
-        constexpr _Whitespace_bitmap_t() noexcept : _Is_whitespace{} {
-            _Is_whitespace[' ']  = true;
-            _Is_whitespace['\n'] = true;
-            _Is_whitespace['\r'] = true;
-            _Is_whitespace['\t'] = true;
-            _Is_whitespace['\0'] = true;
-        }
-
-        _NODISCARD constexpr bool _Test(const char _Ch) const noexcept {
-            return _Is_whitespace[static_cast<unsigned char>(_Ch)];
-        }
-    };
-
-    constexpr _Whitespace_bitmap_t _Whitespace_bitmap;
-} // unnamed namespace */
-
 _EXTERN_C
-/* _NODISCARD size_t __CLRCALL_PURE_OR_STDCALL __std_get_string_size_without_trailing_whitespace(
-    const char* const _Str, size_t _Size) noexcept {
-    while (_Size != 0 && _Whitespace_bitmap._Test(_Str[_Size - 1])) {
-        --_Size;
-    }
-
-    return _Size;
-} */
-
 _NODISCARD size_t __CLRCALL_PURE_OR_STDCALL __std_system_error_allocate_message(
     const unsigned long _Message_id, char** const _Ptr_str) noexcept {
     // convert to name of Windows error, return 0 for failure, otherwise return number of chars in buffer
@@ -51,12 +21,15 @@ _NODISCARD size_t __CLRCALL_PURE_OR_STDCALL __std_system_error_allocate_message(
     if (_Ret == 0) {
         _Lang_id = 0;
     }
+    
     // Flag FORMAT_MESSAGE_MAX_WIDTH_MASK Removes All Trailing \r \n Leaves Only Whitespace Character
-    const unsigned long _Chars =
-        FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS | FORMAT_MESSAGE_MAX_WIDTH_MASK,
+    const unsigned long _Chars = FormatMessageA(
+        FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
+        FORMAT_MESSAGE_IGNORE_INSERTS | FORMAT_MESSAGE_MAX_WIDTH_MASK,
             nullptr, _Message_id, _Lang_id, reinterpret_cast<char*>(_Ptr_str), 0, nullptr);
 
     return _Chars - 1;
+    
 }
 
 void __CLRCALL_PURE_OR_STDCALL __std_system_error_deallocate_message(char* const _Str) noexcept {

--- a/stl/src/syserror_import_lib.cpp
+++ b/stl/src/syserror_import_lib.cpp
@@ -10,7 +10,7 @@
 
 #include <Windows.h>
 
-namespace {
+/* namespace {
     struct _Whitespace_bitmap_t {
         bool _Is_whitespace[256];
 
@@ -25,12 +25,12 @@ namespace {
         _NODISCARD constexpr bool _Test(const char _Ch) const noexcept {
             return _Is_whitespace[static_cast<unsigned char>(_Ch)];
         }
-    };
+    }; */
 
     constexpr _Whitespace_bitmap_t _Whitespace_bitmap;
 } // unnamed namespace
 
-_EXTERN_C
+/* _EXTERN_C
 _NODISCARD size_t __CLRCALL_PURE_OR_STDCALL __std_get_string_size_without_trailing_whitespace(
     const char* const _Str, size_t _Size) noexcept {
     while (_Size != 0 && _Whitespace_bitmap._Test(_Str[_Size - 1])) {
@@ -38,7 +38,7 @@ _NODISCARD size_t __CLRCALL_PURE_OR_STDCALL __std_get_string_size_without_traili
     }
 
     return _Size;
-}
+} */
 
 _NODISCARD size_t __CLRCALL_PURE_OR_STDCALL __std_system_error_allocate_message(
     const unsigned long _Message_id, char** const _Ptr_str) noexcept {

--- a/stl/src/syserror_import_lib.cpp
+++ b/stl/src/syserror_import_lib.cpp
@@ -25,13 +25,13 @@
         _NODISCARD constexpr bool _Test(const char _Ch) const noexcept {
             return _Is_whitespace[static_cast<unsigned char>(_Ch)];
         }
-    }; */
+    };
 
     constexpr _Whitespace_bitmap_t _Whitespace_bitmap;
-} // unnamed namespace
+} // unnamed namespace */
 
-/* _EXTERN_C
-_NODISCARD size_t __CLRCALL_PURE_OR_STDCALL __std_get_string_size_without_trailing_whitespace(
+_EXTERN_C
+/* _NODISCARD size_t __CLRCALL_PURE_OR_STDCALL __std_get_string_size_without_trailing_whitespace(
     const char* const _Str, size_t _Size) noexcept {
     while (_Size != 0 && _Whitespace_bitmap._Test(_Str[_Size - 1])) {
         --_Size;

--- a/stl/src/syserror_import_lib.cpp
+++ b/stl/src/syserror_import_lib.cpp
@@ -57,7 +57,11 @@ _NODISCARD size_t __CLRCALL_PURE_OR_STDCALL __std_system_error_allocate_message(
                                                     | FORMAT_MESSAGE_IGNORE_INSERTS | FORMAT_MESSAGE_MAX_WIDTH_MASK,
         nullptr, _Message_id, _Lang_id, reinterpret_cast<char*>(_Ptr_str), 0, nullptr);
 
-    return _Chars - 1;
+    if (_Chars == 0) {
+        return 0;
+    } else {
+        return _Chars - 1;
+    }
 }
 
 void __CLRCALL_PURE_OR_STDCALL __std_system_error_deallocate_message(char* const _Str) noexcept {


### PR DESCRIPTION
Flag **FORMAT_MESSAGE_MAX_WIDTH_MASK** Removes All Trailing \r \n and Leaves Only One Whitespace Character At The End

[FormatMessage Article on MSDN](https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-formatmessage)

FORMAT_MESSAGE_MAX_WIDTH_MASK [0x000000FF]
The function ignores regular line breaks in the message definition text. The function stores hard-coded line breaks in the message definition text into the output buffer. The function generates no new line breaks.

<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
