### PR TITLE
`_STD`-qualify `_Ugly` non-member function calls in `<variant>`

### DIFF
--- a/stl/inc/variant
+++ b/stl/inc/variant
@@ -192,7 +192,7 @@ constexpr size_t _Meta_find_index_i_(const bool* const _Ptr, const size_t _Count
 template <template <class...> class _List, class _First, class... _Rest, class _Ty>
 struct _Meta_find_index_<_List<_First, _Rest...>, _Ty> {
     static constexpr bool _Bools[] = {is_same_v<_First, _Ty>, is_same_v<_Rest, _Ty>...};
-    using type                     = integral_constant<size_t, _Meta_find_index_i_(_Bools, 1 + sizeof...(_Rest))>;
+    using type                     = integral_constant<size_t, _STD _Meta_find_index_i_(_Bools, 1 + sizeof...(_Rest))>;
 };
 
 template <class _List, class _Ty>
@@ -206,18 +206,19 @@ using _Meta_find_unique_index =
 
 constexpr size_t _Meta_find_unique_index_i_2(const bool* const _Ptr, const size_t _Count, const size_t _First) {
     // return _First if there is no _First < j < _Count such that _Ptr[j] is true, otherwise _Meta_npos
-    return _First != _Meta_npos && _Meta_find_index_i_(_Ptr, _Count, _First + 1) == _Meta_npos ? _First : _Meta_npos;
+    return _First != _Meta_npos && _STD _Meta_find_index_i_(_Ptr, _Count, _First + 1) == _Meta_npos ? _First
+                                                                                                    : _Meta_npos;
 }
 
 constexpr size_t _Meta_find_unique_index_i_(const bool* const _Ptr, const size_t _Count) {
     // Pass the smallest i such that _Ptr[i] is true to _Meta_find_unique_index_i_2
-    return _Meta_find_unique_index_i_2(_Ptr, _Count, _Meta_find_index_i_(_Ptr, _Count));
+    return _STD _Meta_find_unique_index_i_2(_Ptr, _Count, _STD _Meta_find_index_i_(_Ptr, _Count));
 }
 
 template <template <class...> class _List, class _First, class... _Rest, class _Ty>
 struct _Meta_find_unique_index_<_List<_First, _Rest...>, _Ty> {
     using type = integral_constant<size_t,
-        _Meta_find_unique_index_i_(_Meta_find_index_<_List<_First, _Rest...>, _Ty>::_Bools, 1 + sizeof...(_Rest))>;
+        _STD _Meta_find_unique_index_i_(_Meta_find_index_<_List<_First, _Rest...>, _Ty>::_Bools, 1 + sizeof...(_Rest))>;
 };
 
 template <class>
@@ -544,19 +545,19 @@ _NODISCARD constexpr decltype(auto) _Variant_raw_get(_Storage&& _Obj) noexcept {
     } else if constexpr (_Idx == 7) {
         return static_cast<_Storage&&>(_Obj)._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Get();
     } else if constexpr (_Idx < 16) {
-        return _Variant_raw_get<_Idx - 8>(
+        return _STD _Variant_raw_get<_Idx - 8>(
             static_cast<_Storage&&>(_Obj)._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail);
     } else if constexpr (_Idx < 32) {
-        return _Variant_raw_get<_Idx - 16>(
+        return _STD _Variant_raw_get<_Idx - 16>(
             static_cast<_Storage&&>(_Obj)
                 ._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail);
     } else if constexpr (_Idx < 64) {
-        return _Variant_raw_get<_Idx - 32>(
+        return _STD _Variant_raw_get<_Idx - 32>(
             static_cast<_Storage&&>(_Obj)
                 ._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail
                 ._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail);
     } else { // _Idx >= 64
-        return _Variant_raw_get<_Idx - 64>(
+        return _STD _Variant_raw_get<_Idx - 64>(
             static_cast<_Storage&&>(_Obj)
                 ._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail
                 ._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail._Tail
@@ -572,7 +573,7 @@ struct _Tagged { // aggregate a runtime value and a compile-time tag value
 };
 
 template <class _Storage, size_t _Idx>
-using _Variant_tagged_ref_t = _Tagged<decltype(_Variant_raw_get<_Idx>(_STD declval<_Storage>()))&&, _Idx>;
+using _Variant_tagged_ref_t = _Tagged<decltype(_STD _Variant_raw_get<_Idx>(_STD declval<_Storage>()))&&, _Idx>;
 
 template <class _Fn, class _Storage>
 using _Variant_raw_visit_t = decltype(_STD declval<_Fn>()(_STD declval<_Variant_tagged_ref_t<_Storage, 0>>()));
@@ -582,7 +583,7 @@ _NODISCARD constexpr _Variant_raw_visit_t<_Fn, _Storage> _Variant_raw_visit_disp
     _Fn&& _Func, _Storage&& _Var) noexcept(is_nothrow_invocable_v<_Fn, _Variant_tagged_ref_t<_Storage, _Idx>>) {
     // call _Func with the _Idx-th element in _Storage (tagged with _Idx)
     return static_cast<_Fn&&>(_Func)(
-        _Variant_tagged_ref_t<_Storage, _Idx>{_Variant_raw_get<_Idx>(static_cast<_Storage&&>(_Var))});
+        _Variant_tagged_ref_t<_Storage, _Idx>{_STD _Variant_raw_get<_Idx>(static_cast<_Storage&&>(_Var))});
 }
 
 template <class _Fn, class _Storage>
@@ -610,7 +611,7 @@ struct _Variant_raw_dispatch_table1<_Fn, _Storage, index_sequence<_Idxs...>> {
     using _Dispatch_t = _Variant_raw_visit_t<_Fn, _Storage> (*)(_Fn&&, _Storage&&) noexcept(
         _Variant_raw_visit_noexcept<_Fn, _Storage>);
     static constexpr _Dispatch_t _Array[] = {
-        &_Variant_raw_visit_valueless<_Fn, _Storage>, &_Variant_raw_visit_dispatch<_Idxs, _Fn, _Storage>...};
+        &_STD _Variant_raw_visit_valueless<_Fn, _Storage>, &_STD _Variant_raw_visit_dispatch<_Idxs, _Fn, _Storage>...};
 };
 
 template <int _Strategy>
@@ -722,7 +723,8 @@ struct _Variant_construct_visitor { // visitor that constructs the same alternat
         // initialize _Idx-th item in _Self from _Source
         _STL_INTERNAL_CHECK(_Self.valueless_by_exception());
         if constexpr (_Idx != variant_npos) {
-            _Construct_in_place(_Self._Storage(), integral_constant<size_t, _Idx>{}, static_cast<_Ty&&>(_Source._Val));
+            _STD _Construct_in_place(
+                _Self._Storage(), integral_constant<size_t, _Idx>{}, static_cast<_Ty&&>(_Source._Val));
             _Self._Set_index(_Idx);
         }
     }
@@ -746,22 +748,22 @@ struct _Variant_assign_visitor { // visitor that implements assignment for varia
             _Self._Reset();
         } else {
             if (_Self._Which == _Idx) { // same alternative: assign directly
-                auto& _Target = _Variant_raw_get<_Idx>(_Self._Storage());
+                auto& _Target = _STD _Variant_raw_get<_Idx>(_Self._Storage());
                 _Target       = static_cast<_Ty&&>(_Source._Val);
             } else { // different alternative
                 if constexpr (is_lvalue_reference_v<_Ty>) { // RHS is an lvalue: copy
                     if constexpr (_Variant_should_directly_construct_v<_Remove_cvref_t<_Ty>, _Ty>) {
                         // copy is nothrow or move throws; construct in place
                         _Self._Reset();
-                        _Construct_in_place(_Self._Storage(), integral_constant<size_t, _Idx>{}, _Source._Val);
+                        _STD _Construct_in_place(_Self._Storage(), integral_constant<size_t, _Idx>{}, _Source._Val);
                     } else { // copy throws and move does not; move from a temporary copy
                         auto _Temp = _Source._Val;
                         _Self._Reset();
-                        _Construct_in_place(_Self._Storage(), integral_constant<size_t, _Idx>{}, _STD move(_Temp));
+                        _STD _Construct_in_place(_Self._Storage(), integral_constant<size_t, _Idx>{}, _STD move(_Temp));
                     }
                 } else { // RHS is an rvalue: move
                     _Self._Reset();
-                    _Construct_in_place(
+                    _STD _Construct_in_place(
                         _Self._Storage(), integral_constant<size_t, _Idx>{}, static_cast<_Ty&&>(_Source._Val));
                 }
 
@@ -821,15 +823,15 @@ public:
         // destroy the contained value
         // pre: _Idx == index()
         if constexpr (_Idx != variant_npos && !is_trivially_destructible_v<_Meta_at_c<variant<_Types...>, _Idx>>) {
-            _Destroy_in_place(_Variant_raw_get<_Idx>(_Storage()));
+            _STD _Destroy_in_place(_STD _Variant_raw_get<_Idx>(_Storage()));
         }
     }
 
     _CONSTEXPR20 void _Destroy() noexcept { // destroy the contained value, if any
         if constexpr (!conjunction_v<is_trivially_destructible<_Types>...>) {
-            _Variant_raw_visit(index(), _Storage(), [](auto _Ref) noexcept {
+            _STD _Variant_raw_visit(index(), _Storage(), [](auto _Ref) noexcept {
                 if constexpr (decltype(_Ref)::_Idx != variant_npos) {
-                    _Destroy_in_place(_Ref._Val);
+                    _STD _Destroy_in_place(_Ref._Val);
                 }
             });
         }
@@ -854,26 +856,27 @@ public:
         conjunction_v<is_nothrow_copy_constructible<_Types>...>) {
         // copy _That's contained value into *this
         // pre: valueless_by_exception()
-        _Variant_raw_visit(_That.index(), _That._Storage(), _Variant_construct_visitor<_Types...>{*this});
+        _STD _Variant_raw_visit(_That.index(), _That._Storage(), _Variant_construct_visitor<_Types...>{*this});
     }
 
     _CONSTEXPR20 void _Construct_from(_Variant_base&& _That) noexcept(
         conjunction_v<is_nothrow_move_constructible<_Types>...>) {
         // move _That's contained value into *this
         // pre: valueless_by_exception()
-        _Variant_raw_visit(_That.index(), _STD move(_That)._Storage(), _Variant_construct_visitor<_Types...>{*this});
+        _STD _Variant_raw_visit(
+            _That.index(), _STD move(_That)._Storage(), _Variant_construct_visitor<_Types...>{*this});
     }
 
     _CONSTEXPR20 void _Assign_from(const _Variant_base& _That) noexcept(
         conjunction_v<is_nothrow_copy_constructible<_Types>..., is_nothrow_copy_assignable<_Types>...>) {
         // copy assign _That's contained value (if any) into *this
-        _Variant_raw_visit(_That.index(), _That._Storage(), _Variant_assign_visitor<_Types...>{*this});
+        _STD _Variant_raw_visit(_That.index(), _That._Storage(), _Variant_assign_visitor<_Types...>{*this});
     }
 
     _CONSTEXPR20 void _Assign_from(_Variant_base&& _That) noexcept(
         conjunction_v<is_nothrow_move_constructible<_Types>..., is_nothrow_move_assignable<_Types>...>) {
         // move assign _That's contained value (if any) into *this
-        _Variant_raw_visit(_That.index(), _STD move(_That)._Storage(), _Variant_assign_visitor<_Types...>{*this});
+        _STD _Variant_raw_visit(_That.index(), _STD move(_That)._Storage(), _Variant_assign_visitor<_Types...>{*this});
     }
 };
 
@@ -913,7 +916,7 @@ template <size_t _Idx, class _TargetType>
 auto _Construct_array(_TargetType (&&)[1]) -> _Meta_list<integral_constant<size_t, _Idx>, _TargetType>;
 
 template <size_t _Idx, class _TargetType, class _InitializerType>
-using _Variant_type_resolver = decltype(_Construct_array<_Idx, _TargetType>({_STD declval<_InitializerType>()}));
+using _Variant_type_resolver = decltype(_STD _Construct_array<_Idx, _TargetType>({_STD declval<_InitializerType>()}));
 #endif // _HAS_CXX20
 
 template <size_t _Idx, class _TargetType>
@@ -1034,7 +1037,7 @@ public:
         // assign/emplace the alternative chosen by overload resolution of _Obj with f(_Types)...
         constexpr size_t _TargetIdx = _Variant_init_index<_Ty, _Types...>::value;
         if (index() == _TargetIdx) {
-            auto& _Target = _Variant_raw_get<_TargetIdx>(_Storage());
+            auto& _Target = _STD _Variant_raw_get<_TargetIdx>(_Storage());
             _Target       = static_cast<_Ty&&>(_Obj);
         } else {
             using _TargetTy = _Variant_init_type<_Ty, _Types...>;
@@ -1108,10 +1111,10 @@ public:
             _STD swap(static_cast<_BaseTy&>(*this), static_cast<_BaseTy&>(_That));
         } else if constexpr (sizeof...(_Types) < 32) {
             // Limit the size of variants that use this quadratic code size implementation of swap.
-            _Variant_raw_visit(index(), _Storage(),
+            _STD _Variant_raw_visit(index(), _Storage(),
                 [this, &_That](auto _My_ref) noexcept(
                     conjunction_v<is_nothrow_move_constructible<_Types>..., is_nothrow_swappable<_Types>...>) {
-                    _Variant_raw_visit(_That.index(), _That._Storage(),
+                    _STD _Variant_raw_visit(_That.index(), _That._Storage(),
                         [this, &_That, _My_ref](auto _That_ref) noexcept(
                             conjunction_v<is_nothrow_move_constructible<_Types>..., is_nothrow_swappable<_Types>...>) {
                             constexpr size_t _That_idx = decltype(_That_ref)::_Idx;
@@ -1122,7 +1125,8 @@ public:
 #endif // TRANSITION, VSO-657455
                             if constexpr (_My_idx == _That_idx) { // Same alternatives...
                                 if constexpr (_My_idx != variant_npos) { // ...and not valueless, swap directly
-                                    _Swap_adl(_My_ref._Val, _That_ref._Val);
+                                    using _STD swap;
+                                    swap(_My_ref._Val, _That_ref._Val); // intentional ADL
                                 }
                             } else if constexpr (_My_idx == variant_npos) { // *this is valueless, _That is not
                                 this->_Emplace_valueless<_That_idx>(_STD move(_That_ref._Val));
@@ -1146,11 +1150,12 @@ public:
                 });
         } else {
             if (this->_Which == _That._Which) {
-                _Variant_raw_visit(static_cast<size_t>(this->_Which), _That._Storage(),
+                _STD _Variant_raw_visit(static_cast<size_t>(this->_Which), _That._Storage(),
                     [this](auto _Ref) noexcept(conjunction_v<is_nothrow_swappable<_Types>...>) {
                         constexpr size_t _Idx = decltype(_Ref)::_Idx;
                         if constexpr (_Idx != variant_npos) {
-                            _Swap_adl(_Variant_raw_get<_Idx>(this->_Storage()), _Ref._Val);
+                            using _STD swap;
+                            swap(_Variant_raw_get<_Idx>(this->_Storage()), _Ref._Val); // intentional ADL
                         }
                     });
             } else {
@@ -1170,15 +1175,15 @@ private:
         is_nothrow_constructible_v<_Meta_at_c<variant, _Idx>, _ArgTypes...>) {
         // initialize alternative _Idx from _Args...
         _STL_INTERNAL_CHECK(valueless_by_exception());
-        _Construct_in_place(_Storage(), integral_constant<size_t, _Idx>{}, static_cast<_ArgTypes&&>(_Args)...);
+        _STD _Construct_in_place(_Storage(), integral_constant<size_t, _Idx>{}, static_cast<_ArgTypes&&>(_Args)...);
         this->_Set_index(_Idx);
-        return _Variant_raw_get<_Idx>(_Storage());
+        return _STD _Variant_raw_get<_Idx>(_Storage());
     }
 
     _CONSTEXPR20 void _Emplace_from(variant&& _That) noexcept(conjunction_v<is_nothrow_move_constructible<_Types>...>) {
         // steal the contained value from _That
         this->_Reset();
-        _Variant_raw_visit(_That.index(), _That._Storage(),
+        _STD _Variant_raw_visit(_That.index(), _That._Storage(),
             [this](auto _Ref) noexcept(conjunction_v<is_nothrow_move_constructible<_Types>...>) {
                 constexpr size_t _Idx = decltype(_Ref)::_Idx;
                 if constexpr (_Idx != variant_npos) {
@@ -1202,40 +1207,40 @@ _NODISCARD constexpr decltype(auto) get(variant<_Types...>& _Var) {
     // access the contained value of _Var if its _Idx-th alternative is active
     static_assert(_Idx < sizeof...(_Types), "variant index out of bounds");
     if (_Var.index() == _Idx) {
-        return _Variant_raw_get<_Idx>(_Var._Storage());
+        return _STD _Variant_raw_get<_Idx>(_Var._Storage());
     }
 
-    _Throw_bad_variant_access();
+    _STD _Throw_bad_variant_access();
 }
 _EXPORT_STD template <size_t _Idx, class... _Types>
 _NODISCARD constexpr decltype(auto) get(variant<_Types...>&& _Var) {
     // access the contained value of _Var if its _Idx-th alternative is active
     static_assert(_Idx < sizeof...(_Types), "variant index out of bounds");
     if (_Var.index() == _Idx) {
-        return _Variant_raw_get<_Idx>(_STD move(_Var)._Storage());
+        return _STD _Variant_raw_get<_Idx>(_STD move(_Var)._Storage());
     }
 
-    _Throw_bad_variant_access();
+    _STD _Throw_bad_variant_access();
 }
 _EXPORT_STD template <size_t _Idx, class... _Types>
 _NODISCARD constexpr decltype(auto) get(const variant<_Types...>& _Var) {
     // access the contained value of _Var if its _Idx-th alternative is active
     static_assert(_Idx < sizeof...(_Types), "variant index out of bounds");
     if (_Var.index() == _Idx) {
-        return _Variant_raw_get<_Idx>(_Var._Storage());
+        return _STD _Variant_raw_get<_Idx>(_Var._Storage());
     }
 
-    _Throw_bad_variant_access();
+    _STD _Throw_bad_variant_access();
 }
 _EXPORT_STD template <size_t _Idx, class... _Types>
 _NODISCARD constexpr decltype(auto) get(const variant<_Types...>&& _Var) {
     // access the contained value of _Var if its _Idx-th alternative is active
     static_assert(_Idx < sizeof...(_Types), "variant index out of bounds");
     if (_Var.index() == _Idx) {
-        return _Variant_raw_get<_Idx>(_STD move(_Var)._Storage());
+        return _STD _Variant_raw_get<_Idx>(_STD move(_Var)._Storage());
     }
 
-    _Throw_bad_variant_access();
+    _STD _Throw_bad_variant_access();
 }
 
 _EXPORT_STD template <class _Ty, class... _Types>
@@ -1275,13 +1280,13 @@ _EXPORT_STD template <size_t _Idx, class... _Types>
 _NODISCARD constexpr auto get_if(variant<_Types...>* _Ptr) noexcept {
     // get the address of *_Ptr's contained value if it holds alternative _Idx
     static_assert(_Idx < sizeof...(_Types), "variant index out of bounds");
-    return _Ptr && _Ptr->index() == _Idx ? _STD addressof(_Variant_raw_get<_Idx>(_Ptr->_Storage())) : nullptr;
+    return _Ptr && _Ptr->index() == _Idx ? _STD addressof(_STD _Variant_raw_get<_Idx>(_Ptr->_Storage())) : nullptr;
 }
 _EXPORT_STD template <size_t _Idx, class... _Types>
 _NODISCARD constexpr auto get_if(const variant<_Types...>* _Ptr) noexcept {
     // get the address of *_Ptr's contained value if it holds alternative _Idx
     static_assert(_Idx < sizeof...(_Types), "variant index out of bounds");
-    return _Ptr && _Ptr->index() == _Idx ? _STD addressof(_Variant_raw_get<_Idx>(_Ptr->_Storage())) : nullptr;
+    return _Ptr && _Ptr->index() == _Idx ? _STD addressof(_STD _Variant_raw_get<_Idx>(_Ptr->_Storage())) : nullptr;
 }
 
 _EXPORT_STD template <class _Ty, class... _Types>
@@ -1312,7 +1317,7 @@ struct _Variant_relop_visitor2 { // evaluate _Op with the contained value of two
         // determine the relationship between the stored values of _Left and _Right
         // pre: _Left.index() == _Idx && _Right.index() == _Idx
         if constexpr (_Idx != variant_npos) {
-            return _Op{}(_Variant_raw_get<_Idx>(_Left), _Right._Val);
+            return _Op{}(_STD _Variant_raw_get<_Idx>(_Left), _Right._Val);
         } else { // return whatever _Op returns for equal values
             return _Op{}(0, 0);
         }
@@ -1326,7 +1331,7 @@ _NODISCARD constexpr bool operator==(const variant<_Types...>& _Left, const vari
     using _Visitor            = _Variant_relop_visitor2<equal_to<>, bool, _Types...>;
     const size_t _Right_index = _Right.index();
     return _Left.index() == _Right_index
-        && _Variant_raw_visit(_Right_index, _Right._Storage(), _Visitor{_Left._Storage()});
+        && _STD _Variant_raw_visit(_Right_index, _Right._Storage(), _Visitor{_Left._Storage()});
 }
 
 _EXPORT_STD template <class... _Types>
@@ -1336,7 +1341,7 @@ _NODISCARD constexpr bool operator!=(const variant<_Types...>& _Left, const vari
     using _Visitor            = _Variant_relop_visitor2<not_equal_to<>, bool, _Types...>;
     const size_t _Right_index = _Right.index();
     return _Left.index() != _Right_index
-        || _Variant_raw_visit(_Right_index, _Right._Storage(), _Visitor{_Left._Storage()});
+        || _STD _Variant_raw_visit(_Right_index, _Right._Storage(), _Visitor{_Left._Storage()});
 }
 
 _EXPORT_STD template <class... _Types>
@@ -1349,7 +1354,7 @@ _NODISCARD constexpr bool operator<(const variant<_Types...>& _Left, const varia
     const size_t _Right_offset = _Right.index() + 1;
     return _Left_offset < _Right_offset
         || (_Left_offset == _Right_offset
-            && _Variant_raw_visit(_Right_offset - 1, _Right._Storage(), _Visitor{_Left._Storage()}));
+            && _STD _Variant_raw_visit(_Right_offset - 1, _Right._Storage(), _Visitor{_Left._Storage()}));
 }
 
 _EXPORT_STD template <class... _Types>
@@ -1362,7 +1367,7 @@ _NODISCARD constexpr bool operator>(const variant<_Types...>& _Left, const varia
     const size_t _Right_offset = _Right.index() + 1;
     return _Left_offset > _Right_offset
         || (_Left_offset == _Right_offset
-            && _Variant_raw_visit(_Right_offset - 1, _Right._Storage(), _Visitor{_Left._Storage()}));
+            && _STD _Variant_raw_visit(_Right_offset - 1, _Right._Storage(), _Visitor{_Left._Storage()}));
 }
 
 _EXPORT_STD template <class... _Types>
@@ -1375,7 +1380,7 @@ _NODISCARD constexpr bool operator<=(const variant<_Types...>& _Left, const vari
     const size_t _Right_offset = _Right.index() + 1;
     return _Left_offset < _Right_offset
         || (_Left_offset == _Right_offset
-            && _Variant_raw_visit(_Right_offset - 1, _Right._Storage(), _Visitor{_Left._Storage()}));
+            && _STD _Variant_raw_visit(_Right_offset - 1, _Right._Storage(), _Visitor{_Left._Storage()}));
 }
 
 _EXPORT_STD template <class... _Types>
@@ -1388,7 +1393,7 @@ _NODISCARD constexpr bool operator>=(const variant<_Types...>& _Left, const vari
     const size_t _Right_offset = _Right.index() + 1;
     return _Left_offset > _Right_offset
         || (_Left_offset == _Right_offset
-            && _Variant_raw_visit(_Right_offset - 1, _Right._Storage(), _Visitor{_Left._Storage()}));
+            && _STD _Variant_raw_visit(_Right_offset - 1, _Right._Storage(), _Visitor{_Left._Storage()}));
 }
 
 #ifdef __cpp_lib_concepts
@@ -1407,8 +1412,9 @@ _NODISCARD constexpr common_comparison_category_t<compare_three_way_result_t<_Ty
     const size_t _Left_offset  = _Left.index() + 1;
     const size_t _Right_offset = _Right.index() + 1;
     const auto _Offset_order   = _Left_offset <=> _Right_offset;
-    return _Offset_order != 0 ? _Offset_order
-                              : _Variant_raw_visit(_Right_offset - 1, _Right._Storage(), _Visitor{_Left._Storage()});
+    return _Offset_order != 0
+             ? _Offset_order
+             : _STD _Variant_raw_visit(_Right_offset - 1, _Right._Storage(), _Visitor{_Left._Storage()});
 }
 #endif // __cpp_lib_concepts
 
@@ -1440,7 +1446,7 @@ struct _Variant_dispatcher<index_sequence<_Is...>> {
     _NODISCARD static constexpr _Ret _Dispatch2(_Callable&& _Obj, _Types&&... _Args) {
         if constexpr (_Any_valueless) {
             ((void) _Args, ...); // TRANSITION, VSO-1513409
-            _Throw_bad_variant_access();
+            _STD _Throw_bad_variant_access();
         }
 #if _HAS_CXX20
         else if constexpr (is_void_v<_Ret>) {
@@ -1718,7 +1724,7 @@ struct hash<variant<_Types...>> : _Conditionally_enabled_hash<variant<_Types...>
     _NODISCARD static size_t _Do_hash(const variant<_Types...>& _Var) noexcept(
         conjunction_v<_Is_nothrow_hashable<remove_const_t<_Types>>...>) {
         // called from the CRTP base to hash _Var iff the hash is enabled
-        return _Variant_raw_visit(_Var.index(), _Var._Storage(), _Variant_hash_visitor{});
+        return _STD _Variant_raw_visit(_Var.index(), _Var._Storage(), _Variant_hash_visitor{});
     }
 };
 

--- a/tests/std/tests/P0088R3_variant/test.cpp
+++ b/tests/std/tests/P0088R3_variant/test.cpp
@@ -6064,7 +6064,6 @@ template<class T> struct Holder { T t; };
 constexpr bool test(bool do_it)
 {
     if (do_it) {
-#if 0 // TRANSITION, GH-140
         std::variant<Holder<Incomplete>*, int> v = nullptr;
         std::visit([](auto){}, v);
         std::visit([](auto) -> Holder<Incomplete>* { return nullptr; }, v);
@@ -6072,7 +6071,6 @@ constexpr bool test(bool do_it)
         std::visit<void>([](auto){}, v);
         std::visit<void*>([](auto) -> Holder<Incomplete>* { return nullptr; }, v);
 #endif
-#endif // TRANSITION, GH-140
   }
     return true;
   }

--- a/tests/std/tests/P0088R3_variant/test.cpp
+++ b/tests/std/tests/P0088R3_variant/test.cpp
@@ -6071,9 +6071,9 @@ constexpr bool test(bool do_it)
         std::visit<void>([](auto){}, v);
         std::visit<void*>([](auto) -> Holder<Incomplete>* { return nullptr; }, v);
 #endif
-  }
+    }
     return true;
-  }
+}
 
 int run_test()
 {
@@ -6082,7 +6082,7 @@ int run_test()
     static_assert(test(true));
 #endif
     return 0;
-  }
+}
 } // namespace visit::robust_against_adl
 // -- END: test/std/utilities/variant/variant.visit/robust_against_adl.pass.cpp
 

--- a/tests/std/tests/P0088R3_variant/test.cpp
+++ b/tests/std/tests/P0088R3_variant/test.cpp
@@ -6064,6 +6064,7 @@ template<class T> struct Holder { T t; };
 constexpr bool test(bool do_it)
 {
     if (do_it) {
+#ifndef _M_CEE
         std::variant<Holder<Incomplete>*, int> v = nullptr;
         std::visit([](auto){}, v);
         std::visit([](auto) -> Holder<Incomplete>* { return nullptr; }, v);
@@ -6071,6 +6072,7 @@ constexpr bool test(bool do_it)
         std::visit<void>([](auto){}, v);
         std::visit<void*>([](auto) -> Holder<Incomplete>* { return nullptr; }, v);
 #endif
+#endif // _M_CEE
     }
     return true;
 }


### PR DESCRIPTION
Qualifies calls to namespace-scope functions in `<variant>`, and enables the libc++ ADL test that now passes.

Partially addresses #140
