### PR TITLE
`<__msvc_int128.hpp>`: Remove unnecessary `common_type` partial specializations

### DIFF
--- a/stl/inc/__msvc_int128.hpp
+++ b/stl/inc/__msvc_int128.hpp
@@ -1026,22 +1026,6 @@ public:
     static constexpr int digits10   = 38;
 };
 
-#ifdef __cpp_lib_concepts
-template <integral _Ty>
-struct common_type<_Ty, _Unsigned128> {
-    using type = _Unsigned128;
-};
-template <integral _Ty>
-struct common_type<_Unsigned128, _Ty> {
-    using type = _Unsigned128;
-};
-#else // ^^^ defined(__cpp_lib_concepts) / !defined(__cpp_lib_concepts) vvv
-template <class _Ty>
-struct common_type<_Ty, _Unsigned128> : enable_if<is_integral_v<_Ty>, _Unsigned128> {};
-template <class _Ty>
-struct common_type<_Unsigned128, _Ty> : enable_if<is_integral_v<_Ty>, _Unsigned128> {};
-#endif // ^^^ !defined(__cpp_lib_concepts) ^^^
-
 struct _Signed128 : _Base128 {
     using _Signed_type   = _Signed128;
     using _Unsigned_type = _Unsigned128;
@@ -1426,22 +1410,6 @@ public:
     static constexpr int digits   = 127;
     static constexpr int digits10 = 38;
 };
-
-#ifdef __cpp_lib_concepts
-template <integral _Ty>
-struct common_type<_Ty, _Signed128> {
-    using type = _Signed128;
-};
-template <integral _Ty>
-struct common_type<_Signed128, _Ty> {
-    using type = _Signed128;
-};
-#else // ^^^ defined(__cpp_lib_concepts) / !defined(__cpp_lib_concepts) vvv
-template <class _Ty>
-struct common_type<_Ty, _Signed128> : enable_if<is_integral_v<_Ty>, _Signed128> {};
-template <class _Ty>
-struct common_type<_Signed128, _Ty> : enable_if<is_integral_v<_Ty>, _Signed128> {};
-#endif // ^^^ !defined(__cpp_lib_concepts) ^^^
 
 template <>
 struct common_type<_Signed128, _Unsigned128> {

--- a/tests/std/tests/P1522R1_difference_type/test.cpp
+++ b/tests/std/tests/P1522R1_difference_type/test.cpp
@@ -125,6 +125,18 @@ constexpr bool test_unsigned() {
     STATIC_ASSERT(SAME_AS<std::common_type_t<_Unsigned128, unsigned long long>, _Unsigned128>);
     STATIC_ASSERT(SAME_AS<std::common_type_t<_Unsigned128, _Signed128>, _Unsigned128>);
 
+    struct ConversionSource {
+        constexpr operator _Unsigned128() const {
+            return _Unsigned128{};
+        }
+    };
+    STATIC_ASSERT(SAME_AS<std::common_type_t<_Unsigned128, ConversionSource>, _Unsigned128>);
+
+    struct ConversionTarget {
+        constexpr ConversionTarget(_Unsigned128) {}
+    };
+    STATIC_ASSERT(SAME_AS<std::common_type_t<_Unsigned128, ConversionTarget>, ConversionTarget>);
+
 #ifdef __cpp_lib_concepts // TRANSITION, GH-395
     STATIC_ASSERT(std::_Integer_class<_Unsigned128>);
     STATIC_ASSERT(std::_Integer_like<_Unsigned128>);
@@ -445,6 +457,18 @@ constexpr bool test_signed() {
     STATIC_ASSERT(SAME_AS<std::common_type_t<_Signed128, unsigned long>, _Signed128>);
     STATIC_ASSERT(SAME_AS<std::common_type_t<_Signed128, long long>, _Signed128>);
     STATIC_ASSERT(SAME_AS<std::common_type_t<_Signed128, unsigned long long>, _Signed128>);
+
+    struct ConversionSource {
+        constexpr operator _Signed128() const {
+            return _Signed128{};
+        }
+    };
+    STATIC_ASSERT(SAME_AS<std::common_type_t<_Signed128, ConversionSource>, _Signed128>);
+
+    struct ConversionTarget {
+        constexpr ConversionTarget(_Signed128) {}
+    };
+    STATIC_ASSERT(SAME_AS<std::common_type_t<_Signed128, ConversionTarget>, ConversionTarget>);
 
 #ifdef __cpp_lib_concepts // TRANSITION, GH-395
     STATIC_ASSERT(std::_Integer_class<_Signed128>);


### PR DESCRIPTION
These partial specializations are unnecessary, because the default mechanisms (the conditional operator and implicit conversions) are already doing right things. It's surprising that the necessity of these specializations hasn't been discussed in #2518.
https://github.com/microsoft/STL/blob/1fe4d4319b74d6d0738420b549fdfdacb304a647/stl/inc/__msvc_int128.hpp#L1029-L1043
https://github.com/microsoft/STL/blob/1fe4d4319b74d6d0738420b549fdfdacb304a647/stl/inc/__msvc_int128.hpp#L1430-L1444

And the non-concept versions (added by me) may do evil - they may opt-out common types when there can be valid ones. Although this is probably not a conformance issue, as when concepts are not available, these integer-class types are just implementation details.