### PR TITLE
`<future>`: Support `future<const int>` and `promise<const int>`

### DIFF
--- a/stl/inc/future
+++ b/stl/inc/future
@@ -312,17 +312,52 @@ public:
         }
     }
 
+    // TRANSITION, keeps _Result living
+    struct _Reconstruction_guard {
+        _Ty* _Res_addr;
+
+        _Reconstruction_guard& operator=(const _Reconstruction_guard&) = delete;
+        _Reconstruction_guard& operator=(_Reconstruction_guard&&) = delete;
+
+        ~_Reconstruction_guard() {
+            if (_Res_addr != nullptr) {
+                ::new (_STD _Voidify_iter(_Res_addr)) _Ty; // terminates if the default-initialization throws
+            }
+        }
+    };
+
+    template <class _Ty2>
+    void _Reconstruct_result(_Ty2&& _Val) {
+        if constexpr (is_nothrow_constructible_v<_Ty, _Ty2>) {
+            if constexpr (!is_trivially_destructible_v<_Ty>) {
+                _Result.~_Ty();
+            }
+            ::new (_STD _Voidify_iter(_STD addressof(_Result))) _Ty(_STD forward<_Ty2>(_Val));
+        } else if constexpr (is_nothrow_move_constructible_v<remove_cv_t<_Ty>>) {
+            remove_cv_t<_Ty> _Tmp(_STD forward<_Ty2>(_Val));
+            if constexpr (!is_trivially_destructible_v<_Ty>) {
+                _Result.~_Ty();
+            }
+            ::new (_STD _Voidify_iter(_STD addressof(_Result))) _Ty(_STD move(_Tmp));
+        } else {
+            _Reconstruction_guard _Guard{_STD addressof(_Result)};
+            if constexpr (!is_trivially_destructible_v<_Ty>) {
+                _Result.~_Ty();
+            }
+            ::new (_STD _Voidify_iter(_STD addressof(_Result))) _Ty(_STD forward<_Ty2>(_Val));
+            _Guard._Res_addr = nullptr;
+        }
+    }
+
     template <class _Ty2>
     void _Emplace_result(_Ty2&& _Val) {
+        // TRANSITION, keeps _Result living when _Ty is default initializable
         if constexpr (_Is_default_newable<_Ty>) {
             // TRANSITION, incorrectly assigns _Result when _Ty is default initializable and assignable
             if constexpr (is_assignable_v<_Ty&, _Ty2>) {
                 _Result = _STD forward<_Ty2>(_Val);
             } else {
-                if constexpr (!is_trivially_destructible_v<_Ty>) {
-                    _Result.~_Ty();
-                }
-                ::new (_STD _Voidify_iter(_STD addressof(_Result))) _Ty(_STD forward<_Ty2>(_Val));
+                _Reconstruct_result(_STD forward<_Ty2>(_Val));
             }
         } else {
             ::new (_STD _Voidify_iter(_STD addressof(_Result._Held_value))) _Ty(_STD forward<_Ty2>(_Val));

--- a/stl/inc/future
+++ b/stl/inc/future
@@ -186,6 +186,12 @@ struct _State_deleter : _Deleter_base<_Ty> { // manage allocator and deletion st
     _Alloc _My_alloc;
 };
 
+template <class, class = void>
+_INLINE_VAR constexpr bool _Is_default_newable = false;
+
+template <class _Ty>
+_INLINE_VAR constexpr bool _Is_default_newable<_Ty, void_t<decltype(::new _Ty)>> = true;
+
 template <class _Ty>
 union _Result_holder {
     _Result_holder() {}
@@ -200,7 +206,7 @@ public:
     using _State_type = _Ty;
     using _Mydel      = _Deleter_base<_Ty>;
 
-    // TRANSITION, incorrectly default constructs _Result when _Ty is default constructible
+    // TRANSITION, incorrectly default constructs _Result when _Ty is default initializable
     _Associated_state(_Mydel* _Dp = nullptr)
         : _Refs(1), // non-atomic initialization
           _Exception(), _Retrieved(false), _Ready(false), _Ready_at_thread_exit(false), _Has_stored_result(false),
@@ -211,7 +217,7 @@ public:
             _Cond._Unregister(_Mtx);
         }
 
-        if constexpr (!is_default_constructible_v<_Ty>) {
+        if constexpr (!_Is_default_newable<_Ty>) {
             if (_Has_stored_result) {
                 _Result._Held_value.~_Ty();
             }
@@ -299,7 +305,7 @@ public:
             _STD rethrow_exception(_Exception);
         }
 
-        if constexpr (is_default_constructible_v<_Ty>) {
+        if constexpr (_Is_default_newable<_Ty>) {
             return _Result;
         } else {
             return _Result._Held_value;
@@ -308,11 +314,18 @@ public:
 
     template <class _Ty2>
     void _Emplace_result(_Ty2&& _Val) {
-        // TRANSITION, incorrectly assigns _Result when _Ty is default constructible
-        if constexpr (is_default_constructible_v<_Ty>) {
-            _Result = _STD forward<_Ty2>(_Val);
+        if constexpr (_Is_default_newable<_Ty>) {
+            // TRANSITION, incorrectly assigns _Result when _Ty is default initializable and assignable
+            if constexpr (is_assignable_v<_Ty&, _Ty2>) {
+                _Result = _STD forward<_Ty2>(_Val);
+            } else {
+                if constexpr (!is_trivially_destructible_v<_Ty>) {
+                    _Result.~_Ty();
+                }
+                ::new (_STD _Voidify_iter(_STD addressof(_Result))) _Ty(_STD forward<_Ty2>(_Val));
+            }
         } else {
-            ::new (static_cast<void*>(_STD addressof(_Result._Held_value))) _Ty(_STD forward<_Ty2>(_Val));
+            ::new (_STD _Voidify_iter(_STD addressof(_Result._Held_value))) _Ty(_STD forward<_Ty2>(_Val));
             _Has_stored_result = true;
         }
     }
@@ -373,7 +386,7 @@ public:
     }
 
     bool _Already_has_stored_result() const { // Has a result or an exception
-        if constexpr (is_default_constructible_v<_Ty>) {
+        if constexpr (_Is_default_newable<_Ty>) {
             return _Has_stored_result;
         } else {
             return _Has_stored_result || _Exception;
@@ -407,7 +420,7 @@ protected:
     }
 
 public:
-    conditional_t<is_default_constructible_v<_Ty>, _Ty, _Result_holder<_Ty>> _Result;
+    conditional_t<_Is_default_newable<_Ty>, _Ty, _Result_holder<_Ty>> _Result;
     exception_ptr _Exception;
     mutex _Mtx;
     condition_variable _Cond;
@@ -426,7 +439,7 @@ private:
 
     virtual void _Do_notify(unique_lock<mutex>* _Lock, bool _At_thread_exit) { // notify waiting threads
         // TRANSITION, ABI: This is virtual, but never overridden.
-        if constexpr (is_default_constructible_v<_Ty>) {
+        if constexpr (_Is_default_newable<_Ty>) {
             _Has_stored_result = true;
         }
 

--- a/stl/inc/future
+++ b/stl/inc/future
@@ -317,7 +317,7 @@ public:
         _Ty* _Res_addr;
 
         _Reconstruction_guard& operator=(const _Reconstruction_guard&) = delete;
-        _Reconstruction_guard& operator=(_Reconstruction_guard&&) = delete;
+        _Reconstruction_guard& operator=(_Reconstruction_guard&&)      = delete;
 
         ~_Reconstruction_guard() {
             if (_Res_addr != nullptr) {

--- a/stl/inc/future
+++ b/stl/inc/future
@@ -294,7 +294,7 @@ public:
         }
 
         // TRANSITION: `_Retrieved` should be assigned before `_Exception` is thrown so that a `future::get`
-        // that throws a stored exception invalidates the future (N4901 [futures.unique.future]/17)
+        // that throws a stored exception invalidates the future (N4917 [futures.unique.future]/17)
         _Retrieved = true;
         _Maybe_run_deferred_function(_Lock);
         while (!_Ready) {
@@ -372,7 +372,7 @@ public:
         }
 
         _STL_ASSERT(_Exc != nullptr, "promise<T>::set_exception/set_exception_at_thread_exit called with a null "
-                                     "std::exception_ptr, which is invalid per N4901 32.9.6 [futures.promise]/20");
+                                     "std::exception_ptr, which is invalid per N4917 [futures.promise]/20");
         _Exception = _Exc;
         _Do_notify(_Lock, _At_thread_exit);
     }
@@ -904,7 +904,7 @@ private:
 
 public:
     static_assert(!is_array_v<_Ty> && is_object_v<_Ty> && is_destructible_v<_Ty>,
-        "T in future<T> must meet the Cpp17Destructible requirements (N4878 [futures.unique.future]/4).");
+        "T in future<T> must meet the Cpp17Destructible requirements (N4917 [futures.unique.future]/4).");
 
     future() noexcept {}
 
@@ -1007,7 +1007,7 @@ private:
 
 public:
     static_assert(!is_array_v<_Ty> && is_object_v<_Ty> && is_destructible_v<_Ty>,
-        "T in shared_future<T> must meet the Cpp17Destructible requirements (N4878 [futures.shared.future]/4).");
+        "T in shared_future<T> must meet the Cpp17Destructible requirements (N4917 [futures.shared.future]/4).");
 
     shared_future() noexcept {}
 
@@ -1176,7 +1176,7 @@ _EXPORT_STD template <class _Ty>
 class promise { // class that defines an asynchronous provider that holds a value
 public:
     static_assert(!is_array_v<_Ty> && is_object_v<_Ty> && is_destructible_v<_Ty>,
-        "T in promise<T> must meet the Cpp17Destructible requirements (N4878 [futures.promise]/1).");
+        "T in promise<T> must meet the Cpp17Destructible requirements (N4917 [futures.promise]/1).");
 
     promise() : _MyPromise(new _Associated_state<_Ty>) {}
 

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -724,9 +724,6 @@ std/input.output/iostream.format/ext.manip/get_money.pass.cpp FAIL
 std/input.output/iostream.format/ext.manip/put_money.pass.cpp FAIL
 std/input.output/iostreams.base/ios/basic.ios.members/copyfmt.pass.cpp FAIL
 
-# Likely STL bug: Looks like we shouldn't be using assignment.
-std/thread/futures/futures.promise/set_rvalue.pass.cpp FAIL
-
 # Possible STL bugs in pair and tuple.
 std/utilities/tuple/tuple.tuple/tuple.cnstr/PR23256_constrain_UTypes_ctor.pass.cpp:0 FAIL
 std/utilities/tuple/tuple.tuple/tuple.cnstr/PR31384.pass.cpp:0 FAIL

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -724,9 +724,6 @@ input.output\iostream.format\ext.manip\get_money.pass.cpp
 input.output\iostream.format\ext.manip\put_money.pass.cpp
 input.output\iostreams.base\ios\basic.ios.members\copyfmt.pass.cpp
 
-# Likely STL bug: Looks like we shouldn't be using assignment.
-thread\futures\futures.promise\set_rvalue.pass.cpp
-
 # Possible STL bugs in pair and tuple.
 utilities\tuple\tuple.tuple\tuple.cnstr\PR23256_constrain_UTypes_ctor.pass.cpp
 utilities\tuple\tuple.tuple\tuple.cnstr\PR31384.pass.cpp

--- a/tests/std/tests/GH_002488_promise_not_default_constructible_types/test.cpp
+++ b/tests/std/tests/GH_002488_promise_not_default_constructible_types/test.cpp
@@ -215,7 +215,7 @@ void run_scalar_tests() {
     {
         Promise p;
         Future f = p.get_future();
-        T v = 10;
+        T v      = 10;
         p.set_value(v);
         assert(f.get() == 10);
         assert_throws_future_error([&] { p.set_value(v); }, std::future_errc::promise_already_satisfied);


### PR DESCRIPTION
Default-initializable but not assignable types are specially handled.

Fixes #2599. Also addresses #1190. Updating the referenced document number to [N4917](https://wg21.link/n4917) with section numbers dropped (towards #182).

Unblocking one libcxx test:
- `std/thread/futures/futures.promise/set_rvalue.pass.cpp`