### PR TITLE
Use wcschr instead of wmemchr

### DIFF
--- a/stl/src/xnotify.cpp
+++ b/stl/src/xnotify.cpp
@@ -46,12 +46,12 @@ void _Cnd_register_at_thread_exit(
 
             block = block->next;
         } else { // found block with available space
-            for (int i = 0; i < _Nitems; ++i) { // find empty slot
-                if (block->data[i].mtx == nullptr) { // store into empty slot
-                    block->data[i].id._Id = GetCurrentThreadId();
-                    block->data[i].mtx    = mtx;
-                    block->data[i].cnd    = cnd;
-                    block->data[i].res    = p;
+            for (auto& i : block->data) { // find empty slot
+                if (i.mtx == nullptr) { // store into empty slot
+                    i.id._Id = GetCurrentThreadId();
+                    i.mtx    = mtx;
+                    i.cnd    = cnd;
+                    i.res    = p;
                     ++block->num_used;
                     break;
                 }

--- a/stl/src/xstoxflt.cpp
+++ b/stl/src/xstoxflt.cpp
@@ -41,7 +41,7 @@ _In_range_(0, maxsig) int _Stoxflt(
         seen = 1;
     }
 
-    while ((pd = static_cast<const char*>(memchr(&digits[0], *s, 22))) != nullptr) {
+    while ((pd = strchr(&digits[0], *s)) != nullptr) {
         if (nsig <= maxsig) {
             buf[nsig++] = vals[pd - digits]; // accumulate a digit
         } else {
@@ -62,7 +62,7 @@ _In_range_(0, maxsig) int _Stoxflt(
         }
     }
 
-    while ((pd = static_cast<const char*>(memchr(&digits[0], *s, 22))) != nullptr) {
+    while ((pd = strchr(&digits[0], *s)) != nullptr) {
         if (nsig <= maxsig) { // accumulate a fraction digit
             buf[nsig++] = vals[pd - digits];
             --lo[0];

--- a/stl/src/xwstoxfl.cpp
+++ b/stl/src/xwstoxfl.cpp
@@ -41,7 +41,7 @@ _In_range_(0, maxsig) int _WStoxflt(const wchar_t* s0, const wchar_t* s, wchar_t
         seen = 1;
     }
 
-    while ((pd = wmemchr(&digits[0], *s, 22)) != nullptr) {
+    while ((pd = wcschr(&digits[0], *s)) != nullptr) {
         if (nsig <= maxsig) {
             buf[nsig++] = vals[pd - digits]; // accumulate a digit
         } else {
@@ -62,7 +62,7 @@ _In_range_(0, maxsig) int _WStoxflt(const wchar_t* s0, const wchar_t* s, wchar_t
         }
     }
 
-    while ((pd = wmemchr(&digits[0], *s, 22)) != nullptr) {
+    while ((pd = wcschr(&digits[0], *s)) != nullptr) {
         if (nsig <= maxsig) { // accumulate a fraction digit
             buf[nsig++] = vals[pd - digits];
             --lo[0];


### PR DESCRIPTION
memchr does not examine all the elements in the C string, including NULL termination.

wcschr works better in these situations.

<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
