### PR TITLE
multiply by -1 instead of doing a subtraction

### DIFF
--- a/stl/inc/memory_resource
+++ b/stl/inc/memory_resource
@@ -681,7 +681,7 @@ namespace pmr {
         };
 
         static constexpr size_t _Min_allocation = 2 * sizeof(_Header);
-        static constexpr size_t _Max_allocation = 0 - alignof(_Header);
+        static constexpr size_t _Max_allocation = -1 * alignof(_Header);
 
         static constexpr size_t _Round(const size_t _Size) noexcept {
             // return the smallest multiple of alignof(_Header) greater than _Size,

--- a/stl/inc/string
+++ b/stl/inc/string
@@ -480,7 +480,7 @@ _NODISCARD basic_string<_Elem> _Integral_to_string(const _Ty _Val) {
     _Elem* _RNext          = _Buff_end;
     const auto _UVal       = static_cast<_UTy>(_Val);
     if (_Val < 0) {
-        _RNext    = _UIntegral_to_buff(_RNext, 0 - _UVal);
+        _RNext    = _UIntegral_to_buff(_RNext, -1 * _UVal);
         *--_RNext = '-';
     } else {
         _RNext = _UIntegral_to_buff(_RNext, _UVal);

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -2611,7 +2611,7 @@ public:
         }
 #endif // _ITERATOR_DEBUG_LEVEL != 0
 
-        if (_Off < 0 && this->_Myoff < 0 - static_cast<_Size_type>(_Off)) { // add negative increment
+        if (_Off < 0 && this->_Myoff < -1 * static_cast<_Size_type>(_Off)) { // add negative increment
             this->_Myoff += static_cast<_Size_type>(_Off);
             this->_Myptr -= 1 + (static_cast<_Size_type>(-1) - this->_Myoff) / _VBITS;
             this->_Myoff %= _VBITS;

--- a/stl/src/xstol.cpp
+++ b/stl/src/xstol.cpp
@@ -37,7 +37,7 @@ _CRTIMP2_PURE long __CLRCALL_PURE_OR_CDECL _Stolx(
     }
 
     if (s == *endptr && x != 0 || sign == '+' && LONG_MAX < x
-        || sign == '-' && 0 - static_cast<unsigned long>(LONG_MIN) < x) { // overflow
+        || sign == '-' && -1 * static_cast<unsigned long>(LONG_MIN) < x) { // overflow
         errno = ERANGE;
         if (perr != nullptr) {
             *perr = 1;
@@ -46,7 +46,7 @@ _CRTIMP2_PURE long __CLRCALL_PURE_OR_CDECL _Stolx(
         return sign == '-' ? LONG_MIN : LONG_MAX;
     }
 
-    return static_cast<long>(sign == '-' ? 0 - x : x);
+    return static_cast<long>(sign == '-' ? -1 * x : x);
 }
 
 _END_EXTERN_C_UNLESS_PURE

--- a/stl/src/xstoll.cpp
+++ b/stl/src/xstoll.cpp
@@ -37,7 +37,7 @@ _CRTIMP2_PURE long long __CLRCALL_PURE_OR_CDECL _Stollx(
     }
 
     if (s == *endptr && x != 0 || sign == '+' && LLONG_MAX < x
-        || sign == '-' && 0 - static_cast<unsigned long long>(LLONG_MIN) < x) { // overflow
+        || sign == '-' && -1 * static_cast<unsigned long long>(LLONG_MIN) < x) { // overflow
         errno = ERANGE;
         if (perr != nullptr) {
             *perr = 1;
@@ -46,7 +46,7 @@ _CRTIMP2_PURE long long __CLRCALL_PURE_OR_CDECL _Stollx(
         return sign == '-' ? LLONG_MIN : LLONG_MAX;
     }
 
-    return static_cast<long long>(sign == '-' ? 0 - x : x);
+    return static_cast<long long>(sign == '-' ? -1 * x : x);
 }
 
 _CRTIMP2_PURE long long(__CLRCALL_PURE_OR_CDECL _Stoll)(

--- a/stl/src/xstoul.cpp
+++ b/stl/src/xstoul.cpp
@@ -99,7 +99,7 @@ _CRTIMP2_PURE unsigned long __CLRCALL_PURE_OR_CDECL _Stoulx(
     }
 
     if (sign == '-') { // get final value
-        x = 0 - x;
+        x = -1 * x;
     }
 
     if (endptr != nullptr) {

--- a/stl/src/xstoull.cpp
+++ b/stl/src/xstoull.cpp
@@ -97,7 +97,7 @@ _CRTIMP2_PURE unsigned long long __CLRCALL_PURE_OR_CDECL _Stoullx(
     }
 
     if (sign == '-') { // get final value
-        x = 0 - x;
+        x = -1 * x;
     }
 
     if (endptr != nullptr) {


### PR DESCRIPTION
This lets the compiler know we are doing a negation, and a deliberate one at that.

<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
