### PR TITLE
`<optional>`: Set has_value=false before destroying optional

### DIFF
--- a/stl/inc/optional
+++ b/stl/inc/optional
@@ -129,8 +129,8 @@ struct _Optional_destruct_base<_Ty, false> { // either contains a value of _Ty o
 
     _CONSTEXPR20 void reset() noexcept {
         if (_Has_value) {
-            _Destroy_in_place(_Value);
             _Has_value = false;
+            _Destroy_in_place(_Value);
         }
     }
 };


### PR DESCRIPTION
<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
Align with GCC and Clang, and in general have a behavior that makes more sense.
Reference: https://stackoverflow.com/q/74163649/2604492