### PR TITLE
Various cleanups

### DIFF
--- a/azure-devops/cmake-configure-build.yml
+++ b/azure-devops/cmake-configure-build.yml
@@ -57,8 +57,6 @@ steps:
     cmake ${{ parameters.cmakeAdditionalFlags}} -G Ninja ^
     -DCMAKE_CXX_COMPILER=cl ^
     -DCMAKE_BUILD_TYPE=Release ^
-    -DLIT_FLAGS=$(litFlags) ^
-    -DSTL_USE_ANALYZE=ON ^
     -DSTL_BINARY_DIR=$(${{ parameters.buildOutputLocationVar }}) ^
     -S $(Build.SourcesDirectory)/benchmarks -B $(${{ parameters.benchmarkBuildOutputLocationVar }})
   displayName: 'Configure the benchmarks'

--- a/stl/inc/expected
+++ b/stl/inc/expected
@@ -321,7 +321,6 @@ public:
     }
 
     // clang-format off
-    // TRANSITION, LLVM-46269, destructor order is significant
     ~expected() requires is_trivially_destructible_v<_Ty> && is_trivially_destructible_v<_Err> = default;
     // clang-format on
 
@@ -842,7 +841,6 @@ public:
     }
 
     // clang-format off
-    // TRANSITION, LLVM-46269, destructor order is significant
     ~expected() requires is_trivially_destructible_v<_Err> = default;
     // clang-format on
 

--- a/stl/inc/iterator
+++ b/stl/inc/iterator
@@ -639,7 +639,6 @@ public:
         _Raw_clear();
     }
 
-    // TRANSITION, LLVM-46269, destructor order is significant
     // clang-format off
     constexpr ~_Variantish() requires is_trivially_destructible_v<_Ty1> && is_trivially_destructible_v<_Ty2> = default;
 

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -265,7 +265,6 @@ namespace ranges {
             }
         }
 
-        // TRANSITION, LLVM-46269, destructor order is significant
         // clang-format off
         ~_Movable_box() requires is_trivially_destructible_v<_Ty> = default;
 
@@ -480,7 +479,6 @@ namespace ranges {
             }
         }
 
-        // TRANSITION, LLVM-46269, destructor order is significant
         // clang-format off
         ~_Defaultabox() requires is_trivially_destructible_v<_Ty> = default;
 
@@ -698,7 +696,6 @@ namespace ranges {
             }
         }
 
-        // TRANSITION, LLVM-46269, destructor order is significant
         // clang-format off
         ~_Non_propagating_cache() requires is_trivially_destructible_v<_Ty> = default;
         // clang-format on

--- a/stl/inc/string
+++ b/stl/inc/string
@@ -69,21 +69,21 @@ _EXPORT_STD template <class _Elem, class _Traits, class _Alloc>
 basic_istream<_Elem, _Traits>& getline(
     basic_istream<_Elem, _Traits>&& _Istr, basic_string<_Elem, _Traits, _Alloc>& _Str) {
     // get characters into string, discard newline
-    return getline(_Istr, _Str, _Istr.widen('\n'));
+    return _STD getline(_STD move(_Istr), _Str, _Istr.widen('\n'));
 }
 
 _EXPORT_STD template <class _Elem, class _Traits, class _Alloc>
 basic_istream<_Elem, _Traits>& getline(
     basic_istream<_Elem, _Traits>& _Istr, basic_string<_Elem, _Traits, _Alloc>& _Str, const _Elem _Delim) {
     // get characters into string, discard delimiter
-    return getline(_STD move(_Istr), _Str, _Delim);
+    return _STD getline(_STD move(_Istr), _Str, _Delim);
 }
 
 _EXPORT_STD template <class _Elem, class _Traits, class _Alloc>
 basic_istream<_Elem, _Traits>& getline(
     basic_istream<_Elem, _Traits>& _Istr, basic_string<_Elem, _Traits, _Alloc>& _Str) {
     // get characters into string, discard newline
-    return getline(_STD move(_Istr), _Str, _Istr.widen('\n'));
+    return _STD getline(_STD move(_Istr), _Str, _Istr.widen('\n'));
 }
 
 _EXPORT_STD _NODISCARD inline int stoi(const string& _Str, size_t* _Idx = nullptr, int _Base = 10) {

--- a/stl/inc/xlocinfo
+++ b/stl/inc/xlocinfo
@@ -102,14 +102,6 @@ _Success_(return > 0) _ACRTIMP size_t __cdecl _Wcsftime(
     _Out_writes_z_(_Maxsize) wchar_t*, _In_ size_t _Maxsize, _In_z_ const wchar_t*, _In_ const tm*, _In_opt_ void*);
 _END_EXTERN_C
 
-#ifdef _M_CEE_PURE
-[System::Runtime::InteropServices::DllImport(_CRT_MSVCP_CURRENT, EntryPoint = "_GetLocaleForCP",
-    CallingConvention = System::Runtime::InteropServices::CallingConvention::Cdecl)] extern "C" _locale_t
-    _GetLocaleForCP(unsigned int);
-#else // _M_CEE_PURE
-_MRTIMP2 _locale_t __cdecl _GetLocaleForCP(unsigned int);
-#endif // _M_CEE_PURE
-
 _STD_BEGIN
 extern "C++" class _CRTIMP2_PURE_IMPORT _Timevec { // smart pointer to information used by _Strftime
 public:

--- a/stl/inc/xlocinfo
+++ b/stl/inc/xlocinfo
@@ -60,10 +60,6 @@ _MRTIMP2 _Success_(return >= 0) int __cdecl _Mbrtowc(
     _When_(_Max_multibyte != 0, _Out_) wchar_t*, const char*, size_t _Max_multibyte, mbstate_t*, const _Cvtvec*);
 #endif // _M_CEE_PURE
 
-_CRTIMP2_PURE float __CLRCALL_PURE_OR_CDECL _Stof(const char*, _Out_opt_ _Deref_post_opt_valid_ char**, long);
-_CRTIMP2_PURE double __CLRCALL_PURE_OR_CDECL _Stod(const char*, _Out_opt_ _Deref_post_opt_valid_ char**, long);
-_CRTIMP2_PURE long double __CLRCALL_PURE_OR_CDECL _Stold(const char*, _Out_opt_ _Deref_post_opt_valid_ char**, long);
-
 _CRTIMP2_PURE int __CLRCALL_PURE_OR_CDECL _Strcoll(const char*, const char*, const char*, const char*, const _Collvec*);
 _CRTIMP2_PURE size_t __CLRCALL_PURE_OR_CDECL _Strxfrm(_Out_writes_(_End1 - _String1)
                                                           _Post_readable_size_(return) char* _String1,

--- a/stl/inc/xlocnum
+++ b/stl/inc/xlocnum
@@ -24,10 +24,6 @@ _STL_DISABLE_CLANG_WARNINGS
 
 _EXTERN_C_UNLESS_PURE
 
-_CRTIMP2_PURE float __CLRCALL_PURE_OR_CDECL _Stofx(const char*, _Out_opt_ _Deref_post_opt_valid_ char**, long, int*);
-_CRTIMP2_PURE double __CLRCALL_PURE_OR_CDECL _Stodx(const char*, _Out_opt_ _Deref_post_opt_valid_ char**, long, int*);
-_CRTIMP2_PURE long double __CLRCALL_PURE_OR_CDECL _Stoldx(
-    const char*, _Out_opt_ _Deref_post_opt_valid_ char**, long, int*);
 _CRTIMP2_PURE long __CLRCALL_PURE_OR_CDECL _Stolx(const char*, _Out_opt_ _Deref_post_opt_valid_ char**, int, int*);
 _CRTIMP2_PURE unsigned long __CLRCALL_PURE_OR_CDECL _Stoulx(
     const char*, _Out_opt_ _Deref_post_opt_valid_ char**, int, int*);

--- a/stl/src/special_math.cpp
+++ b/stl/src/special_math.cpp
@@ -8,6 +8,7 @@
 #include <utility>
 
 #pragma warning(push)
+#pragma warning(disable : 4702) // unreachable code
 #pragma warning(disable : 6326) // potential comparison of a constant with another constant
 
 #define BOOST_MATH_DOMAIN_ERROR_POLICY   errno_on_error

--- a/stl/src/special_math.cpp
+++ b/stl/src/special_math.cpp
@@ -14,8 +14,6 @@
 #pragma warning(disable : 5219) // implicit conversion from '%s' to '%s', possible loss of data
 #pragma warning(disable : 6326) // potential comparison of a constant with another constant
 
-#define BOOST_CHRONO_HEADER_ONLY
-#define BOOST_CONFIG_SUPPRESS_OUTDATED_MESSAGE
 #define BOOST_MATH_DOMAIN_ERROR_POLICY   errno_on_error
 #define BOOST_MATH_OVERFLOW_ERROR_POLICY ignore_error
 

--- a/stl/src/special_math.cpp
+++ b/stl/src/special_math.cpp
@@ -8,10 +8,6 @@
 #include <utility>
 
 #pragma warning(push)
-#pragma warning(disable : 4619) // #pragma warning: there is no warning number '%d'
-#pragma warning(disable : 4643) // Forward declaring '%s' in namespace std is not permitted by the C++ Standard
-#pragma warning(disable : 4702) // unreachable code
-#pragma warning(disable : 5219) // implicit conversion from '%s' to '%s', possible loss of data
 #pragma warning(disable : 6326) // potential comparison of a constant with another constant
 
 #define BOOST_MATH_DOMAIN_ERROR_POLICY   errno_on_error

--- a/stl/src/xstod.cpp
+++ b/stl/src/xstod.cpp
@@ -13,9 +13,11 @@
 
 _EXTERN_C_UNLESS_PURE
 
+// TRANSITION, ABI: preserved for binary compatibility
 _CRTIMP2_PURE FTYPE __CLRCALL_PURE_OR_CDECL _Stodx(const CTYPE* s, CTYPE** endptr, long pten, int* perr)
 #include "xxstod.hpp"
 
+    // TRANSITION, ABI: preserved for binary compatibility
     _CRTIMP2_PURE FTYPE __CLRCALL_PURE_OR_CDECL
     _Stod(const CTYPE* s, CTYPE** endptr, long pten) { // convert string, discard error code
     return _Stodx(s, endptr, pten, nullptr);

--- a/stl/src/xstof.cpp
+++ b/stl/src/xstof.cpp
@@ -13,9 +13,11 @@
 
 _EXTERN_C_UNLESS_PURE
 
+// TRANSITION, ABI: preserved for binary compatibility
 _CRTIMP2_PURE FTYPE __CLRCALL_PURE_OR_CDECL _Stofx(const CTYPE* s, CTYPE** endptr, long pten, int* perr)
 #include "xxstod.hpp"
 
+    // TRANSITION, ABI: preserved for binary compatibility
     _CRTIMP2_PURE FTYPE __CLRCALL_PURE_OR_CDECL
     _Stof(const CTYPE* s, CTYPE** endptr, long pten) { // convert string, discard error code
     return _Stofx(s, endptr, pten, nullptr);

--- a/stl/src/xstold.cpp
+++ b/stl/src/xstold.cpp
@@ -13,9 +13,11 @@
 
 _EXTERN_C_UNLESS_PURE
 
+// TRANSITION, ABI: preserved for binary compatibility
 _CRTIMP2_PURE FTYPE __CLRCALL_PURE_OR_CDECL _Stoldx(const CTYPE* s, CTYPE** endptr, long pten, int* perr)
 #include "xxstod.hpp"
 
+    // TRANSITION, ABI: preserved for binary compatibility
     _CRTIMP2_PURE FTYPE __CLRCALL_PURE_OR_CDECL
     _Stold(const CTYPE* s, CTYPE** endptr, long pten) { // convert string, discard error code
     return _Stoldx(s, endptr, pten, nullptr);

--- a/stl/src/xwstod.cpp
+++ b/stl/src/xwstod.cpp
@@ -12,9 +12,11 @@
 
 _EXTERN_C_UNLESS_PURE
 
+// TRANSITION, ABI: preserved for binary compatibility
 _CRTIMP2_PURE FTYPE __CLRCALL_PURE_OR_CDECL _WStodx(const CTYPE* s, CTYPE** endptr, long pten, int* perr)
 #include "xxstod.hpp"
 
+    // TRANSITION, ABI: preserved for binary compatibility
     _CRTIMP2_PURE FTYPE __CLRCALL_PURE_OR_CDECL
     _WStod(const CTYPE* s, CTYPE** endptr, long pten) { // convert string, discard error code
     return _WStodx(s, endptr, pten, nullptr);

--- a/stl/src/xwstof.cpp
+++ b/stl/src/xwstof.cpp
@@ -11,9 +11,11 @@
 
 _EXTERN_C_UNLESS_PURE
 
+// TRANSITION, ABI: preserved for binary compatibility
 _CRTIMP2_PURE FTYPE __CLRCALL_PURE_OR_CDECL _WStofx(const CTYPE* s, CTYPE** endptr, long pten, int* perr)
 #include "xxstod.hpp"
 
+    // TRANSITION, ABI: preserved for binary compatibility
     _CRTIMP2_PURE FTYPE __CLRCALL_PURE_OR_CDECL
     _WStof(const CTYPE* s, CTYPE** endptr, long pten) { // convert string, discard error code
     return _WStofx(s, endptr, pten, nullptr);

--- a/stl/src/xwstold.cpp
+++ b/stl/src/xwstold.cpp
@@ -11,9 +11,11 @@
 
 _EXTERN_C_UNLESS_PURE
 
+// TRANSITION, ABI: preserved for binary compatibility
 _CRTIMP2_PURE FTYPE __CLRCALL_PURE_OR_CDECL _WStoldx(const CTYPE* s, CTYPE** endptr, long pten, int* perr)
 #include "xxstod.hpp"
 
+    // TRANSITION, ABI: preserved for binary compatibility
     _CRTIMP2_PURE FTYPE __CLRCALL_PURE_OR_CDECL
     _WStold(const CTYPE* s, CTYPE** endptr, long pten) { // convert string, discard error code
     return _WStoldx(s, endptr, pten, nullptr);

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -1038,6 +1038,10 @@ std/utilities/meta/meta.unary/meta.unary.prop/is_nothrow_copy_assignable.pass.cp
 std/utilities/meta/meta.unary/meta.unary.prop/is_nothrow_move_assignable.pass.cpp:0 FAIL
 std/utilities/tuple/tuple.tuple/tuple.cnstr/convert_const_move.pass.cpp FAIL
 
+# Not yet analyzed, possible path length issue. With a repo root of D:\GitHub\STL (13 characters), fails with:
+# "error RC2136 : missing '=' in EXSTYLE=<flags>" followed by "LINK : fatal error LNK1327: failure during running rc.exe"
+std/thread/thread.mutex/thread.mutex.requirements/thread.sharedtimedmutex.requirements/thread.sharedtimedmutex.class/try_lock_until_deadlock_bug.pass.cpp SKIPPED
+
 
 # *** XFAILs WHICH PASS ***
 # Nothing here! :-)

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -1038,6 +1038,10 @@ utilities\meta\meta.unary\meta.unary.prop\is_nothrow_copy_assignable.pass.cpp
 utilities\meta\meta.unary\meta.unary.prop\is_nothrow_move_assignable.pass.cpp
 utilities\tuple\tuple.tuple\tuple.cnstr\convert_const_move.pass.cpp
 
+# Not yet analyzed, possible path length issue. With a repo root of D:\GitHub\STL (13 characters), fails with:
+# "error RC2136 : missing '=' in EXSTYLE=<flags>" followed by "LINK : fatal error LNK1327: failure during running rc.exe"
+thread\thread.mutex\thread.mutex.requirements\thread.sharedtimedmutex.requirements\thread.sharedtimedmutex.class\try_lock_until_deadlock_bug.pass.cpp
+
 
 # *** SKIPPED FOR MSVC-INTERNAL CONTEST ONLY ***
 # "XFAIL: msvc" or "XFAIL: clang"

--- a/tests/std/tests/P0323R12_expected/test.cpp
+++ b/tests/std/tests/P0323R12_expected/test.cpp
@@ -247,9 +247,7 @@ namespace test_expected {
 
         { // Check payload type
             using Expected = expected<payload_copy_constructor, int>;
-#ifndef __clang__ // TRANSITION, LLVM-46269
             static_assert(is_trivially_copy_constructible_v<Expected> == should_be_trivial);
-#endif // !__clang__
             static_assert(is_copy_constructible_v<Expected>);
 
             const Expected with_value{in_place};
@@ -267,9 +265,7 @@ namespace test_expected {
 
         { // Check error type
             using Expected = expected<int, payload_copy_constructor>;
-#ifndef __clang__ // TRANSITION, LLVM-46269
             static_assert(is_trivially_copy_constructible_v<Expected> == should_be_trivial);
-#endif // !__clang__
             static_assert(is_copy_constructible_v<Expected>);
 
             const Expected with_value{in_place};
@@ -287,9 +283,7 @@ namespace test_expected {
 
         { // Check void payload
             using Expected = expected<void, payload_copy_constructor>;
-#ifndef __clang__ // TRANSITION, LLVM-46269
             static_assert(is_trivially_copy_constructible_v<Expected> == should_be_trivial);
-#endif // !__clang__
             static_assert(is_copy_constructible_v<Expected>);
 
             const Expected with_value{in_place};
@@ -339,9 +333,7 @@ namespace test_expected {
 
         { // Check payload type
             using Expected = expected<payload_move_constructor, int>;
-#ifndef __clang__ // TRANSITION, LLVM-46269
             static_assert(is_trivially_move_constructible_v<Expected> == should_be_trivial);
-#endif // !__clang__
             static_assert(is_move_constructible_v<Expected>);
 
             Expected value_input{in_place};
@@ -359,9 +351,7 @@ namespace test_expected {
 
         { // Check error type
             using Expected = expected<int, payload_move_constructor>;
-#ifndef __clang__ // TRANSITION, LLVM-46269
             static_assert(is_trivially_move_constructible_v<Expected> == should_be_trivial);
-#endif // !__clang__
             static_assert(is_move_constructible_v<Expected>);
 
             Expected value_input{in_place};
@@ -379,9 +369,7 @@ namespace test_expected {
 
         { // Check void payload
             using Expected = expected<void, payload_move_constructor>;
-#ifndef __clang__ // TRANSITION, LLVM-46269
             static_assert(is_trivially_move_constructible_v<Expected> == should_be_trivial);
-#endif // !__clang__
             static_assert(is_move_constructible_v<Expected>);
 
             Expected value_input{in_place};
@@ -410,15 +398,12 @@ namespace test_expected {
     template <IsTriviallyDestructible triviallyDestructible>
     struct payload_destructor {
         constexpr payload_destructor(bool& destructor_called) : _destructor_called(destructor_called) {}
-        bool& _destructor_called;
-    };
-    template <> // TRANSITION, LLVM-46269
-    struct payload_destructor<IsTriviallyDestructible::Not> {
-        constexpr payload_destructor(bool& destructor_called) : _destructor_called(destructor_called) {}
-        payload_destructor(const payload_destructor&) = default;
+        // clang-format off
+        constexpr ~payload_destructor() requires (IsYes(triviallyDestructible)) = default;
+        // clang-format on
         constexpr ~payload_destructor() {
             _destructor_called = true;
-        };
+        }
 
         bool& _destructor_called;
     };
@@ -428,9 +413,7 @@ namespace test_expected {
         bool destructor_called    = false;
         { // Check payload
             using Expected = expected<payload_destructor<triviallyDestructible>, int>;
-#ifndef __clang__ // TRANSITION, LLVM-46269
             static_assert(is_trivially_destructible_v<Expected> == is_trivial);
-#endif // !__clang__
 
             Expected val{in_place, destructor_called};
         }
@@ -439,9 +422,7 @@ namespace test_expected {
 
         { // Check error
             using Expected = expected<int, payload_destructor<triviallyDestructible>>;
-#ifndef __clang__ // TRANSITION, LLVM-46269
             static_assert(is_trivially_destructible_v<Expected> == is_trivial);
-#endif // !__clang__
 
             Expected err{unexpect, destructor_called};
         }
@@ -450,9 +431,7 @@ namespace test_expected {
 
         { // Check void error
             using Expected = expected<void, payload_destructor<triviallyDestructible>>;
-#ifndef __clang__ // TRANSITION, LLVM-46269
             static_assert(is_trivially_destructible_v<Expected> == is_trivial);
-#endif // !__clang__
 
             Expected err{unexpect, destructor_called};
         }

--- a/tests/std/tests/P0896R4_ranges_alg_is_permutation/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_is_permutation/test.cpp
@@ -142,7 +142,8 @@ struct instantiator {
 
                 NonCopyableBool()                       = default;
                 NonCopyableBool(const NonCopyableBool&) = delete;
-            } b;
+            };
+            NonCopyableBool b;
             assert(ranges::is_permutation(range2, range2, [&](auto, auto) -> NonCopyableBool& { return b; }));
         }
     }


### PR DESCRIPTION
These non-overlapping changes are structured as a series of fine-grained commits for easy reviewing but are collected into a single PR to reduce the load on the CI system.

* `<xlocinfo>`, `<xlocnum>`: The `_Stof` and `_Stofx` families are unused, so we can remove their declarations from `stl/inc`.
  + `xstof.cpp`, `xstod.cpp`, `xstold.cpp`: We can comment their definitions as preserved for bincompat in `stl/src`.
  + `xwstof.cpp`, `xwstod.cpp`, `xwstold.cpp`: Also comment the wide definitions, which didn't have declarations.
  + Note that all of these definitions are marked as `_CRTIMP2_PURE`, so they'll continue to be exported.
* `<xlocinfo>`: `_GetLocaleForCP` was declared but never defined, so we can drop this extremely complicated declaration.
* `<string>`: Qualify `_STD getline()`.
  + This revealed a more subtle problem: the first overload being changed here was calling the second (unintentionally *relying* on ADL :scream_cat: because the second hadn't been declared yet), also spending an unnecessary function call. Adding `_STD move(_Istr)` fixes this, and makes all of these overloads call the actual implementation above.
* `special_math.cpp`: Now that we've merged #3077 to always use the standalone `boost-math` submodule, we can simplify this:
  + We don't need to define `BOOST_CHRONO_HEADER_ONLY` and `BOOST_CONFIG_SUPPRESS_OUTDATED_MESSAGE`.
  + We can suppress fewer warnings. We still need to suppress C6326, reported upstream as https://github.com/boostorg/math/issues/853. We also need to suppress C4702 for the MSVC-internal build's chpe architecture.
* `P0896R4_ranges_alg_is_permutation/test.cpp`: Nitpick, we conventionally avoid defining a struct and a variable simultaneously. Define `NonCopyableBool` and `b` separately.
* Skip a libcxx test due to a possible path length issue.
  + This is consistently failing on my local machine. I suspect this was introduced when #2976 updated LLVM, although I didn't verify that.
* Remove compiler bug workarounds for LLVM-46269 which was fixed in Clang 15.
  + Thanks to @CaseyCarter for providing the desired definition of `payload_destructor`, also removing an unnecessary semicolon.
* `azure-devops/cmake-configure-build.yml`: Followup to #3151, drop unused variables when configuring the benchmarks. This fixes a warning message printed by Azure Pipelines:
```
CMake Warning:
    Manually-specified variables were not used by the project:

    LIT_FLAGS
    STL_USE_ANALYZE
```
