### PR TITLE
README.md: Adjust Compiler Explorer link wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ reproducing the bug.
 
 * You should be reasonably confident that you're looking at an actual implementation bug, instead of undefined behavior
 or surprising-yet-Standard behavior. Comparing against other implementations can help (but remember that implementations
-can differ while conforming to the Standard); try Godbolt's [Compiler Explorer][]. If you still aren't
+can differ while conforming to the Standard); try [Compiler Explorer][]. If you still aren't
 sure, ask the nearest C++ expert.
 
 * You should prepare a self-contained command-line test case, ideally as small as possible. We need a source file, a


### PR DESCRIPTION
I asked Matt Godbolt how he'd prefer this sentence, he said

> I don't have a strong opinion, I'd probably just say Compiler Explorer if it were up to me though