### PR TITLE
enable P0943R6_stdatomic_h test for clang

### DIFF
--- a/tests/std/tests/P0943R6_stdatomic_h/test.compile.pass.cpp
+++ b/tests/std/tests/P0943R6_stdatomic_h/test.compile.pass.cpp
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef __clang__ // TRANSITION, GH-2862
 #include <__msvc_cxx_stdatomic.hpp>
 
 static_assert(ATOMIC_BOOL_LOCK_FREE == 2);
@@ -116,6 +115,5 @@ namespace test {
 
 static_assert(std::atomic_thread_fence == atomic_thread_fence);
 static_assert(std::atomic_signal_fence == atomic_signal_fence);
-#endif // TRANSITION, GH-2862
 
 int main() {} // COMPILE-ONLY


### PR DESCRIPTION
Fixes #2862