### PR TITLE
<yvals_core.h>: Update _MSVC_STL_UPDATE to November 2022

### DIFF
--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -793,7 +793,7 @@
 
 #define _CPPLIB_VER       650
 #define _MSVC_STL_VERSION 143
-#define _MSVC_STL_UPDATE  202210L
+#define _MSVC_STL_UPDATE  202211L
 
 #ifndef _ALLOW_COMPILER_AND_STL_VERSION_MISMATCH
 #if defined(__CUDACC__) && defined(__CUDACC_VER_MAJOR__)


### PR DESCRIPTION
Updates _MSVC_STL_UPDATE to "202211L" (November 2022).
Resolves #3189 