### PR TITLE
[vscode settings] add `git.ignoredRepositories`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,6 +21,11 @@
     "files.insertFinalNewline": true,
     "files.trimFinalNewlines": true,
     "files.trimTrailingWhitespace": true,
+    "git.ignoredRepositories": [
+        "benchmarks/google-benchmark",
+        "llvm-project",
+        "boost-math"
+    ],
     "python.analysis.extraPaths": [
         "./llvm-project/libcxx/utils",
         "./llvm-project/llvm/utils/lit",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,17 +14,17 @@
     "files.eol": "\r\n",
     "files.exclude": {
         "benchmarks/google-benchmark": true,
+        "boost-math": true,
         "llvm-project": true,
-        "stl/msbuild": true,
-        "boost-math": true
+        "stl/msbuild": true
     },
     "files.insertFinalNewline": true,
     "files.trimFinalNewlines": true,
     "files.trimTrailingWhitespace": true,
     "git.ignoredRepositories": [
         "benchmarks/google-benchmark",
-        "llvm-project",
-        "boost-math"
+        "boost-math",
+        "llvm-project"
     ],
     "python.analysis.extraPaths": [
         "./llvm-project/libcxx/utils",


### PR DESCRIPTION
This is a workaround for microsoft/vscode#103235.

I kept being annoyed that my submodules would open in VS Code, despite turning detection off. This fixes that issue.