### PR TITLE
Toolset update: VS 2022 17.5 Preview 1, Python 3.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With The Visual Studio IDE
 
-1. Install Visual Studio 2022 17.4 Preview 3 or later.
+1. Install Visual Studio 2022 17.5 Preview 1 or later.
     * Select "Windows 11 SDK (10.0.22000.0)" in the VS Installer.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
@@ -157,7 +157,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With A Native Tools Command Prompt
 
-1. Install Visual Studio 2022 17.4 Preview 3 or later.
+1. Install Visual Studio 2022 17.5 Preview 1 or later.
     * Select "Windows 11 SDK (10.0.22000.0)" in the VS Installer.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -91,7 +91,7 @@ if ([string]::IsNullOrEmpty($AdminUserPassword)) {
   $PsExecPath = Join-Path $ExtractedPsToolsPath 'PsExec64.exe'
 
   # https://github.com/PowerShell/PowerShell/releases/latest
-  $PowerShellZipUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.2.6/PowerShell-7.2.6-win-x64.zip'
+  $PowerShellZipUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.3.0/PowerShell-7.3.0-win-x64.zip'
   Write-Host "Downloading: $PowerShellZipUrl"
   $ExtractedPowerShellPath = DownloadAndExtractZip -Url $PowerShellZipUrl
   $PwshPath = Join-Path $ExtractedPowerShellPath 'pwsh.exe'

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -141,7 +141,7 @@ $Workloads = @(
 $ReleaseInPath = 'Preview'
 $Sku = 'Enterprise'
 $VisualStudioBootstrapperUrl = 'https://aka.ms/vs/17/pre/vs_enterprise.exe'
-$PythonUrl = 'https://www.python.org/ftp/python/3.10.8/python-3.10.8-amd64.exe'
+$PythonUrl = 'https://www.python.org/ftp/python/3.11.0/python-3.11.0-amd64.exe'
 
 $CudaUrl = 'https://developer.download.nvidia.com/compute/cuda/11.6.0/local_installers/cuda_11.6.0_511.23_windows.exe'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ variables:
   benchmarkBuildOutputLocation: 'D:\benchmark'
 
 pool:
-  name: 'StlBuild-2022-10-11T1916-Pool'
+  name: 'StlBuild-2022-11-08T1904-Pool'
   demands: EnableSpotVM -equals true
 
 pr:

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -376,7 +376,24 @@ public:
         _In_reads_(_Count) const _Elem* const _First2, const size_t _Count) noexcept /* strengthened */ {
         // compare [_First1, _First1 + _Count) with [_First2, ...)
 #if _HAS_CXX17
+#if _HAS_CXX20 && defined(__EDG__) // TRANSITION, VSO-1675318
+        if (_STD is_constant_evaluated()) {
+            for (size_t _Idx = 0; _Idx != _Count; ++_Idx) {
+                if (static_cast<unsigned char>(_First1[_Idx]) < static_cast<unsigned char>(_First2[_Idx])) {
+                    return -1;
+                }
+
+                if (static_cast<unsigned char>(_First2[_Idx]) < static_cast<unsigned char>(_First1[_Idx])) {
+                    return 1;
+                }
+            }
+            return 0;
+        } else {
+            return _CSTD memcmp(_First1, _First2, _Count);
+        }
+#else // ^^^ workaround for EDG / no workaround needed for MSVC and Clang vvv
         return __builtin_memcmp(_First1, _First2, _Count);
+#endif // ^^^ no workaround needed for MSVC and Clang ^^^
 #else // _HAS_CXX17
         return _CSTD memcmp(_First1, _First2, _Count);
 #endif // _HAS_CXX17

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -376,24 +376,7 @@ public:
         _In_reads_(_Count) const _Elem* const _First2, const size_t _Count) noexcept /* strengthened */ {
         // compare [_First1, _First1 + _Count) with [_First2, ...)
 #if _HAS_CXX17
-#if _HAS_CXX20 && defined(__EDG__) // TRANSITION, VSO-1641993
-        if (_STD is_constant_evaluated()) {
-            for (size_t _Idx = 0; _Idx != _Count; ++_Idx) {
-                if (static_cast<unsigned char>(_First1[_Idx]) < static_cast<unsigned char>(_First2[_Idx])) {
-                    return -1;
-                }
-
-                if (static_cast<unsigned char>(_First2[_Idx]) < static_cast<unsigned char>(_First1[_Idx])) {
-                    return 1;
-                }
-            }
-            return 0;
-        } else {
-            return _CSTD memcmp(_First1, _First2, _Count);
-        }
-#else // ^^^ workaround for EDG / no workaround needed for MSVC and Clang vvv
         return __builtin_memcmp(_First1, _First2, _Count);
-#endif // ^^^ no workaround needed for MSVC and Clang ^^^
 #else // _HAS_CXX17
         return _CSTD memcmp(_First1, _First2, _Count);
 #endif // _HAS_CXX17

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -5350,38 +5350,27 @@ basic_ostream<_Elem, _Traits>& operator<<(
 
 inline namespace literals {
     inline namespace string_literals {
-
-#ifdef __EDG__ // TRANSITION, VSO-1273381
-#define _CONSTEXPR20_STRING_LITERALS inline
-#else // ^^^ workaround / no workaround vvv
-#define _CONSTEXPR20_STRING_LITERALS _CONSTEXPR20
-#endif // ^^^ no workaround ^^^
-
-        _EXPORT_STD _NODISCARD _CONSTEXPR20_STRING_LITERALS string operator"" s(const char* _Str, size_t _Len) {
+        _EXPORT_STD _NODISCARD _CONSTEXPR20 string operator"" s(const char* _Str, size_t _Len) {
             return string{_Str, _Len};
         }
 
-        _EXPORT_STD _NODISCARD _CONSTEXPR20_STRING_LITERALS wstring operator"" s(const wchar_t* _Str, size_t _Len) {
+        _EXPORT_STD _NODISCARD _CONSTEXPR20 wstring operator"" s(const wchar_t* _Str, size_t _Len) {
             return wstring{_Str, _Len};
         }
 
 #ifdef __cpp_char8_t
-        _EXPORT_STD _NODISCARD _CONSTEXPR20_STRING_LITERALS basic_string<char8_t> operator"" s(
-            const char8_t* _Str, size_t _Len) {
+        _EXPORT_STD _NODISCARD _CONSTEXPR20 basic_string<char8_t> operator"" s(const char8_t* _Str, size_t _Len) {
             return basic_string<char8_t>{_Str, _Len};
         }
 #endif // __cpp_char8_t
 
-        _EXPORT_STD _NODISCARD _CONSTEXPR20_STRING_LITERALS u16string operator"" s(const char16_t* _Str, size_t _Len) {
+        _EXPORT_STD _NODISCARD _CONSTEXPR20 u16string operator"" s(const char16_t* _Str, size_t _Len) {
             return u16string{_Str, _Len};
         }
 
-        _EXPORT_STD _NODISCARD _CONSTEXPR20_STRING_LITERALS u32string operator"" s(const char32_t* _Str, size_t _Len) {
+        _EXPORT_STD _NODISCARD _CONSTEXPR20 u32string operator"" s(const char32_t* _Str, size_t _Len) {
             return u32string{_Str, _Len};
         }
-
-#undef _CONSTEXPR20_STRING_LITERALS // TRANSITION, VSO-1273381
-
     } // namespace string_literals
 } // namespace literals
 

--- a/tests/std/tests/Dev10_816787_swap_vector_bool_elements/test.cpp
+++ b/tests/std/tests/Dev10_816787_swap_vector_bool_elements/test.cpp
@@ -17,7 +17,6 @@ int main() {
     assert(all_of(x.begin(), x.end(), is_false));
     assert(all_of(y.begin(), y.end(), is_true));
 
-#if !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 // TRANSITION, VSO-1273381
     swap(x[12], y[34]);
 
     assert(all_of(x.begin(), x.begin() + 12, is_false));
@@ -27,5 +26,4 @@ int main() {
     assert(all_of(y.begin(), y.begin() + 34, is_true));
     assert(!y[34]);
     assert(all_of(y.begin() + 35, y.end(), is_true));
-#endif // !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2
 }

--- a/tests/std/tests/P0980R1_constexpr_strings/test.cpp
+++ b/tests/std/tests/P0980R1_constexpr_strings/test.cpp
@@ -238,7 +238,7 @@ template <class CharType>
 constexpr bool test_interface() {
     using str = basic_string<CharType>;
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL != 0 // TRANSITION, VSO-1273296
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
     if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
     { // constructors
@@ -296,7 +296,7 @@ constexpr bool test_interface() {
         assert(equalRanges(conversion_start_length_constructed, "llo"sv));
     }
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL != 0 // TRANSITION, VSO-1273296
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
     if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
     { // allocator constructors
@@ -347,7 +347,7 @@ constexpr bool test_interface() {
         assert(equalRanges(conversion_start_length_constructed, "llo"sv));
     }
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL != 0 // TRANSITION, VSO-1273296
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
     if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
     { // assignment operator
@@ -380,7 +380,7 @@ constexpr bool test_interface() {
         assert(equalRanges(conversion_assigned, literal_constructed));
     }
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL != 0 // TRANSITION, VSO-1273296
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
     if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
     { // assign
@@ -499,7 +499,7 @@ constexpr bool test_interface() {
         assert(char_traits<CharType>::length(cs) == literal_constructed.size());
     }
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL != 0 // TRANSITION, VSO-1273296
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
     if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
     { // iterators
@@ -623,7 +623,7 @@ constexpr bool test_interface() {
         assert(cleared.capacity() == str{get_literal_input<CharType>()}.capacity());
     }
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL != 0 // TRANSITION, VSO-1273296
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
     if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
     { // insert
@@ -703,7 +703,7 @@ constexpr bool test_interface() {
         assert(equalRanges(insert_iter_count_char, "Hellooooo fluffy kittens"sv));
     }
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL != 0 // TRANSITION, VSO-1273296
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
     if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
     { // erase
@@ -752,7 +752,7 @@ constexpr bool test_interface() {
         assert(pushed.back() == CharType{'y'});
     }
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL != 0 // TRANSITION, VSO-1273296
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
     if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
     { // append
@@ -800,7 +800,7 @@ constexpr bool test_interface() {
         assert(equalRanges(append_conversion_start_length, "bbllo"sv));
     }
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL != 0 // TRANSITION, VSO-1273296
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
     if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
     { // operator+=
@@ -828,9 +828,6 @@ constexpr bool test_interface() {
         assert(equalRanges(plus_conversion, "bbHello fluffy kittens"sv));
     }
 
-#ifdef __EDG__ // TRANSITION, VSO-1273296
-    if (!is_constant_evaluated())
-#endif // ^^^ workaround ^^^
     { // compare
         const str first  = get_literal_input<CharType>();
         const str second = get_cat<CharType>();
@@ -945,9 +942,6 @@ constexpr bool test_interface() {
         assert(comp_pos_count_conversion_pos_count_greater == 1);
     }
 
-#ifdef __EDG__ // TRANSITION, VSO-1273296
-    if (!is_constant_evaluated())
-#endif // ^^^ workaround ^^^
     { // starts_with
         const str starts            = get_literal_input<CharType>();
         const str input_string_true = starts.substr(0, 5);
@@ -963,9 +957,6 @@ constexpr bool test_interface() {
         assert(!input_string_false.starts_with(get_literal_input<CharType>()));
     }
 
-#ifdef __EDG__ // TRANSITION, VSO-1273296
-    if (!is_constant_evaluated())
-#endif // ^^^ workaround ^^^
     { // ends_with
         const str ends              = get_literal_input<CharType>();
         const str input_string_true = ends.substr(5);
@@ -982,9 +973,6 @@ constexpr bool test_interface() {
     }
 
 #if _HAS_CXX23
-#ifdef __EDG__ // TRANSITION, VSO-1273296
-    if (!is_constant_evaluated())
-#endif // ^^^ workaround ^^^
     { // contains
         const str hello_fluffy_kittens = get_literal_input<CharType>(); // "Hello fluffy kittens"
         constexpr auto kitten_ptr      = get_cat<CharType>(); // "kitten"
@@ -1000,7 +988,7 @@ constexpr bool test_interface() {
     }
 #endif // _HAS_CXX23
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL != 0 // TRANSITION, VSO-1273296
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
     if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
     { // replace
@@ -1092,7 +1080,7 @@ constexpr bool test_interface() {
         assert(equalRanges(replaced_pos_count_conversion_pos_count, "dfluffy"sv));
     }
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL != 0 // TRANSITION, VSO-1273296
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
     if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
     { // substr
@@ -1117,7 +1105,7 @@ constexpr bool test_interface() {
         assert(equalRanges(copy_count_pos, "fluffy"sv));
     }
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL != 0 // TRANSITION, VSO-1273296
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
     if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
     { // resize
@@ -1134,9 +1122,6 @@ constexpr bool test_interface() {
     }
 
 #if _HAS_CXX23
-#ifdef __EDG__ // TRANSITION, VSO-1273296
-    if (!is_constant_evaluated())
-#endif // ^^^ workaround ^^^
     { // resize_and_overwrite
         constexpr basic_string_view hello_fluffy_kittens = get_view_input<CharType>();
         constexpr basic_string_view hello                = hello_fluffy_kittens.substr(0, 5);
@@ -1253,9 +1238,6 @@ constexpr bool test_interface() {
         assert(equalRanges(first, expected_second));
     }
 
-#ifdef __EDG__ // TRANSITION, VSO-1273296
-    if (!is_constant_evaluated())
-#endif // ^^^ workaround ^^^
     { // find
         const str input     = get_literal_input<CharType>();
         const str needle    = get_cat<CharType>();
@@ -1314,9 +1296,6 @@ constexpr bool test_interface() {
         assert(find_convertible_pos == str::npos);
     }
 
-#ifdef __EDG__ // TRANSITION, VSO-1273296
-    if (!is_constant_evaluated())
-#endif // ^^^ workaround ^^^
     { // rfind
         const str input     = get_literal_input<CharType>();
         const str needle    = get_cat<CharType>();
@@ -1603,7 +1582,7 @@ constexpr bool test_interface() {
         assert(find_last_not_of_convertible_pos == str::npos);
     }
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL != 0 // TRANSITION, VSO-1273296
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
     if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
     { // operator+
@@ -1647,9 +1626,6 @@ constexpr bool test_interface() {
         assert(equalRanges(op_char_rstr, "!dog"sv));
     }
 
-#ifdef __EDG__ // TRANSITION, VSO-1273296
-    if (!is_constant_evaluated())
-#endif // ^^^ workaround ^^^
     { // comparison
         str first(get_view_input<CharType>());
         str second(get_view_input<CharType>());
@@ -1738,7 +1714,7 @@ constexpr bool test_interface() {
 }
 
 constexpr bool test_udls() {
-#ifdef __EDG__ // TRANSITION, VSO-1273296
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
     if (is_constant_evaluated()) {
         return true;
     }
@@ -1777,7 +1753,7 @@ constexpr bool test_iterators() {
         cit = cit2;
     }
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL != 0 // TRANSITION, VSO-1273296
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
     if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
     { // op->
@@ -1791,7 +1767,7 @@ constexpr bool test_iterators() {
         assert(cc == CharType{'x'});
     }
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL != 0 // TRANSITION, VSO-1273296
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
     if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
     { // increment
@@ -1806,7 +1782,7 @@ constexpr bool test_iterators() {
         assert(*cit == CharType{'l'});
     }
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL != 0 // TRANSITION, VSO-1273296
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
     if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
     { // advance
@@ -1825,7 +1801,7 @@ constexpr bool test_iterators() {
         assert(*cit == CharType{'f'});
     }
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL != 0 // TRANSITION, VSO-1273296
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
     if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
     { // decrement
@@ -1840,7 +1816,7 @@ constexpr bool test_iterators() {
         assert(*cit == CharType{'n'});
     }
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL != 0 // TRANSITION, VSO-1273296
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
     if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
     { // advance back
@@ -1885,7 +1861,7 @@ constexpr bool test_iterators() {
         assert((it3 <=> it1) == strong_ordering::greater);
     }
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL != 0 // TRANSITION, VSO-1273296
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
     if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
     { // access
@@ -1943,7 +1919,7 @@ constexpr bool test_growth() {
         assert(v.capacity() == 1510);
     }
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL != 0 // TRANSITION, VSO-1273296
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
     if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
     {
@@ -1960,7 +1936,7 @@ constexpr bool test_growth() {
         assert(v.capacity() == 1510);
     }
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL != 0 // TRANSITION, VSO-1273296
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
     if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
     {
@@ -1981,7 +1957,7 @@ constexpr bool test_growth() {
         }
     }
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL != 0 // TRANSITION, VSO-1273296
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
     if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
     {
@@ -1996,7 +1972,7 @@ constexpr bool test_growth() {
         assert(v.capacity() == 1510);
     }
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL != 0 // TRANSITION, VSO-1273296
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
     if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
     {
@@ -2020,7 +1996,7 @@ constexpr bool test_growth() {
 
 template <class CharType>
 constexpr void test_copy_ctor() {
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL != 0 // TRANSITION, VSO-1273296
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
     if (is_constant_evaluated()) {
         return;
     }
@@ -2049,7 +2025,7 @@ constexpr void test_copy_ctor() {
 
 template <class CharType>
 constexpr void test_copy_alloc_ctor(const size_t id1, const size_t id2) {
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL != 0 // TRANSITION, VSO-1273296
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
     if (is_constant_evaluated()) {
         return;
     }
@@ -2078,7 +2054,7 @@ constexpr void test_copy_alloc_ctor(const size_t id1, const size_t id2) {
 
 template <class CharType, class Alloc>
 constexpr void test_copy_assign(const size_t id1, const size_t id2, const size_t id3) {
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL != 0 // TRANSITION, VSO-1273296
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
     if (is_constant_evaluated()) {
         return;
     }
@@ -2134,7 +2110,7 @@ constexpr void test_copy_assign(const size_t id1, const size_t id2, const size_t
 
 template <class CharType>
 constexpr void test_move_ctor() {
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL != 0 // TRANSITION, VSO-1273296
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
     if (is_constant_evaluated()) {
         return;
     }
@@ -2168,7 +2144,7 @@ constexpr void test_move_ctor() {
 
 template <class CharType>
 constexpr void test_move_alloc_ctor(const size_t id1, const size_t id2) {
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL != 0 // TRANSITION, VSO-1273296
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
     if (is_constant_evaluated()) {
         return;
     }
@@ -2202,7 +2178,7 @@ constexpr void test_move_alloc_ctor(const size_t id1, const size_t id2) {
 
 template <class CharType, class Alloc>
 constexpr void test_move_assign(const size_t id1, const size_t id2, const size_t id3) {
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL != 0 // TRANSITION, VSO-1273296
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
     if (is_constant_evaluated()) {
         return;
     }
@@ -2306,7 +2282,7 @@ constexpr void test_swap(const size_t id1, const size_t id2) {
         assert(rhs.get_allocator().id() == id1);
     }
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL != 0 // TRANSITION, VSO-1273296
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
     if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
     { // Allocated to Allocated

--- a/tests/std/tests/P1004R2_constexpr_vector/test.cpp
+++ b/tests/std/tests/P1004R2_constexpr_vector/test.cpp
@@ -66,55 +66,71 @@ constexpr bool test_interface() {
         // Non allocator constructors
         vec size_default_constructed(5);
         assert(size_default_constructed.size() == 5);
-#ifndef __EDG__ // TRANSITION, VSO-1273296
         assert(all_of(
             size_default_constructed.begin(), size_default_constructed.end(), [](const int val) { return val == 0; }));
-#endif // __EDG__
 
         vec size_value_constructed(5, 7);
         assert(size_value_constructed.size() == 5);
-#if !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 // TRANSITION, VSO-1273365
         assert(all_of(
             size_value_constructed.begin(), size_value_constructed.end(), [](const int val) { return val == 7; }));
-#endif // !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2
 
         vec range_constructed(begin(input), end(input));
-#if !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 // TRANSITION, VSO-1274387
-        assert(equal(range_constructed.begin(), range_constructed.end(), begin(input), end(input)));
-#endif // !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+        if (!is_constant_evaluated())
+#endif // ^^^ workaround ^^^
+        {
+            assert(equal(range_constructed.begin(), range_constructed.end(), begin(input), end(input)));
+        }
 
         vec initializer_list_constructed({2, 3, 4, 5});
-#if !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 // TRANSITION, VSO-1274387
-        assert(equal(
-            initializer_list_constructed.begin(), initializer_list_constructed.end(), begin(input) + 2, end(input)));
-#endif // !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+        if (!is_constant_evaluated())
+#endif // ^^^ workaround ^^^
+        {
+            assert(equal(initializer_list_constructed.begin(), initializer_list_constructed.end(), begin(input) + 2,
+                end(input)));
+        }
 
         // special member functions
         vec default_constructed;
         assert(default_constructed.empty());
         vec copy_constructed(size_default_constructed);
-#if !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 // TRANSITION, VSO-1274387
-        assert(equal(copy_constructed.begin(), copy_constructed.end(), size_default_constructed.begin(),
-            size_default_constructed.end()));
-#endif // !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+        if (!is_constant_evaluated())
+#endif // ^^^ workaround ^^^
+        {
+            assert(equal(copy_constructed.begin(), copy_constructed.end(), size_default_constructed.begin(),
+                size_default_constructed.end()));
+        }
 
         vec move_constructed(move(copy_constructed));
-#if !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 // TRANSITION, VSO-1274387
-        assert(equal(move_constructed.begin(), move_constructed.end(), size_default_constructed.begin(),
-            size_default_constructed.end()));
-#endif // !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+        if (!is_constant_evaluated())
+#endif // ^^^ workaround ^^^
+        {
+            assert(equal(move_constructed.begin(), move_constructed.end(), size_default_constructed.begin(),
+                size_default_constructed.end()));
+        }
 
         assert(copy_constructed.empty()); // implementation-specific assumption that moved-from is empty
 
         vec copy_assigned = range_constructed;
-#if !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 // TRANSITION, VSO-1274387
-        assert(equal(copy_assigned.begin(), copy_assigned.end(), range_constructed.begin(), range_constructed.end()));
-#endif // !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+        if (!is_constant_evaluated())
+#endif // ^^^ workaround ^^^
+        {
+            assert(
+                equal(copy_assigned.begin(), copy_assigned.end(), range_constructed.begin(), range_constructed.end()));
+        }
 
         vec move_assigned = move(copy_assigned);
-#if !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 // TRANSITION, VSO-1274387
-        assert(equal(move_assigned.begin(), move_assigned.end(), range_constructed.begin(), range_constructed.end()));
-#endif // !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+        if (!is_constant_evaluated())
+#endif // ^^^ workaround ^^^
+        {
+            assert(
+                equal(move_assigned.begin(), move_assigned.end(), range_constructed.begin(), range_constructed.end()));
+        }
         assert(copy_assigned.empty()); // implementation-specific assumption that moved-from is empty
 
         // allocator constructors
@@ -128,55 +144,55 @@ constexpr bool test_interface() {
         assert(al_default_constructed.get_allocator().soccc_generation == 3);
 
         vec al_copy_constructed(size_value_constructed, alloc);
-#if !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 // TRANSITION, VSO-1273365
         assert(all_of(al_copy_constructed.begin(), al_copy_constructed.end(), [](const int val) { return val == 7; }));
-#endif // !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2
         assert(al_copy_constructed.get_allocator().id == 4);
         assert(al_copy_constructed.get_allocator().soccc_generation == 3);
 
         vec al_move_constructed(move(al_copy_constructed), alloc);
-#if !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 // TRANSITION, VSO-1273365
         assert(all_of(al_move_constructed.begin(), al_move_constructed.end(), [](const int val) { return val == 7; }));
-#endif // !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2
         assert(al_copy_constructed.empty()); // implementation-specific assumption that moved-from is empty
         assert(al_move_constructed.get_allocator().id == 4);
         assert(al_move_constructed.get_allocator().soccc_generation == 3);
 
         vec al_size_default_constructed(5, alloc);
         assert(al_size_default_constructed.size() == 5);
-#ifndef __EDG__ // TRANSITION, VSO-1273296
         assert(all_of(al_size_default_constructed.begin(), al_size_default_constructed.end(),
             [](const int val) { return val == 0; }));
-#endif // __EDG__
         assert(al_size_default_constructed.get_allocator().id == 4);
         assert(al_size_default_constructed.get_allocator().soccc_generation == 3);
 
         vec al_size_value_constructed(5, 7, alloc);
         assert(al_size_value_constructed.size() == 5);
-#if !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 // TRANSITION, VSO-1273365
         assert(all_of(al_size_value_constructed.begin(), al_size_value_constructed.end(),
             [](const int val) { return val == 7; }));
-#endif // !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2
         assert(al_size_value_constructed.get_allocator().id == 4);
         assert(al_size_value_constructed.get_allocator().soccc_generation == 3);
 
         vec al_range_constructed(begin(input), end(input), alloc);
-#if !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 // TRANSITION, VSO-1274387
-        assert(equal(al_range_constructed.begin(), al_range_constructed.end(), begin(input), end(input)));
-#endif // !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+        if (!is_constant_evaluated())
+#endif // ^^^ workaround ^^^
+        {
+            assert(equal(al_range_constructed.begin(), al_range_constructed.end(), begin(input), end(input)));
+        }
         assert(al_range_constructed.get_allocator().id == 4);
         assert(al_range_constructed.get_allocator().soccc_generation == 3);
 
         vec al_initializer_list_constructed({2, 3, 4, 5}, alloc);
-#if !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 // TRANSITION, VSO-1274387
-        assert(equal(al_initializer_list_constructed.begin(), al_initializer_list_constructed.end(), begin(input) + 2,
-            end(input)));
-#endif // !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+        if (!is_constant_evaluated())
+#endif // ^^^ workaround ^^^
+        {
+            assert(equal(al_initializer_list_constructed.begin(), al_initializer_list_constructed.end(),
+                begin(input) + 2, end(input)));
+        }
         assert(al_initializer_list_constructed.get_allocator().id == 4);
         assert(al_initializer_list_constructed.get_allocator().soccc_generation == 3);
     }
 
-#if !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 // TRANSITION, VSO-1274387
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+    if (!is_constant_evaluated())
+#endif // ^^^ workaround ^^^
     { // assignment
         vec range_constructed(begin(input), end(input));
 
@@ -209,7 +225,6 @@ constexpr bool test_interface() {
         assert(equal(
             assigned.begin(), assigned.end(), begin(expected_assign_initializer), end(expected_assign_initializer)));
     }
-#endif // !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2
 
     { // allocator
         vec default_constructed;
@@ -219,11 +234,13 @@ constexpr bool test_interface() {
         assert(alloc.soccc_generation == 0);
     }
 
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+    if (!is_constant_evaluated())
+#endif // ^^^ workaround ^^^
     { // iterators
         vec range_constructed(begin(input), end(input));
         const vec const_range_constructed(begin(input), end(input));
 
-#if !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 // TRANSITION, VSO-1273381
         const auto b = range_constructed.begin();
         static_assert(is_same_v<remove_const_t<decltype(b)>, vec::iterator>);
         assert(*b == 0);
@@ -271,7 +288,6 @@ constexpr bool test_interface() {
         const auto cre2 = const_range_constructed.rend();
         static_assert(is_same_v<remove_const_t<decltype(cre2)>, reverse_iterator<vec::const_iterator>>);
         assert(*prev(cre2) == 0);
-#endif // !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2
     }
 
     { // access
@@ -358,6 +374,9 @@ constexpr bool test_interface() {
         assert(c2 == 6);
     }
 
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+    if (!is_constant_evaluated())
+#endif // ^^^ workaround ^^^
     { // modifiers
         vec range_constructed(begin(input), end(input));
 
@@ -368,7 +387,6 @@ constexpr bool test_interface() {
 
         vec inserted;
 
-#ifndef __EDG__ // TRANSITION, VSO-1273386, VSO-1274387
         const int to_be_inserted = 3;
         inserted.insert(inserted.begin(), to_be_inserted);
         assert(inserted.size() == 1);
@@ -386,9 +404,7 @@ constexpr bool test_interface() {
         inserted.insert(inserted.cbegin(), 2);
         assert(inserted.size() == 4);
         assert(inserted.front() == 2);
-#endif // __EDG__
 
-#ifndef __EDG__ // TRANSITION, VSO-1273381, VSO-1273296
         const auto it = inserted.insert(inserted.begin(), begin(input), end(input));
         assert(inserted.size() == 10);
         assert(it == inserted.begin());
@@ -400,9 +416,7 @@ constexpr bool test_interface() {
         const auto it3 = inserted.insert(inserted.begin(), {2, 3, 4});
         assert(inserted.size() == 19);
         assert(it3 == inserted.begin());
-#endif // __EDG__
 
-#ifndef __EDG__ // TRANSITION, VSO-1274387, VSO-1273296
         inserted.insert(inserted.cbegin(), {2, 3, 4});
         assert(inserted.size() == 22);
 
@@ -449,10 +463,8 @@ constexpr bool test_interface() {
         emplaced.emplace(emplaced.cbegin(), 42);
         assert(emplaced.size() == 24);
         assert(emplaced.front() == 42);
-#endif // __EDG__
     }
 
-#if !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 // TRANSITION, VSO-1273365
     { // swap
         vec first{2, 3, 4};
         vec second{5, 6, 7, 8};
@@ -463,9 +475,10 @@ constexpr bool test_interface() {
         assert(equal(first.begin(), first.end(), begin(expected_first), end(expected_first)));
         assert(equal(second.begin(), second.end(), begin(expected_second), end(expected_second)));
     }
-#endif // !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2
 
-#if !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 // TRANSITION, VSO-1273365
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+    if (!is_constant_evaluated())
+#endif // ^^^ workaround ^^^
     { // erase
         vec erased{1, 2, 3, 4, 2, 3, 2};
         erase(erased, 2);
@@ -476,7 +489,6 @@ constexpr bool test_interface() {
         constexpr int expected_erase_if[] = {4};
         assert(equal(erased.begin(), erased.end(), begin(expected_erase_if), end(expected_erase_if)));
     }
-#endif // !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2
 
     { // comparison
         vec first(begin(input), end(input));
@@ -514,7 +526,9 @@ constexpr bool test_interface() {
 constexpr bool test_iterators() {
     vec range_constructed(begin(input), end(input));
 
-#if !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 // TRANSITION, VSO-1273381
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+    if (!is_constant_evaluated())
+#endif // ^^^ workaround ^^^
     { // increment
         auto it = range_constructed.begin();
         assert(*++it == 1);
@@ -527,6 +541,9 @@ constexpr bool test_iterators() {
         assert(*cit == 2);
     }
 
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+    if (!is_constant_evaluated())
+#endif // ^^^ workaround ^^^
     { // advance
         auto it = range_constructed.begin() + 2;
         assert(*it == 2);
@@ -539,6 +556,9 @@ constexpr bool test_iterators() {
         assert(*cit == 4);
     }
 
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+    if (!is_constant_evaluated())
+#endif // ^^^ workaround ^^^
     { // decrement
         auto it = range_constructed.end();
         assert(*--it == 5);
@@ -551,6 +571,9 @@ constexpr bool test_iterators() {
         assert(*cit == 4);
     }
 
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+    if (!is_constant_evaluated())
+#endif // ^^^ workaround ^^^
     { // advance back
         auto it = range_constructed.end() - 2;
         assert(*it == 4);
@@ -589,6 +612,9 @@ constexpr bool test_iterators() {
         assert(it3 >= it1);
     }
 
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+    if (!is_constant_evaluated())
+#endif // ^^^ workaround ^^^
     { // access
         const auto it = range_constructed.begin() + 2;
         it[2]         = 3;
@@ -604,8 +630,6 @@ constexpr bool test_iterators() {
         const auto cit2 = vec2.cbegin();
         assert(cit2->first == 1);
     }
-
-#endif // !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2
 
     return true;
 }
@@ -655,12 +679,15 @@ constexpr bool test_growth() {
 
         vector<int> l(3, 47);
 
-#if !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 // TRANSITION, VSO-1274387
-        v.insert(v.end(), l.begin(), l.end());
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+        if (!is_constant_evaluated())
+#endif // ^^^ workaround ^^^
+        {
+            v.insert(v.end(), l.begin(), l.end());
 
-        assert(v.size() == 1003);
-        assert(v.capacity() == 1500);
-#endif // !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2
+            assert(v.size() == 1003);
+            assert(v.capacity() == 1500);
+        }
     }
 
     {
@@ -671,12 +698,15 @@ constexpr bool test_growth() {
 
         vector<int> l(7000, 47);
 
-#if !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 // TRANSITION, VSO-1274387
-        v.insert(v.end(), l.begin(), l.end());
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+        if (!is_constant_evaluated())
+#endif // ^^^ workaround ^^^
+        {
+            v.insert(v.end(), l.begin(), l.end());
 
-        assert(v.size() == 8000);
-        assert(v.capacity() == 8000);
-#endif // !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2
+            assert(v.size() == 8000);
+            assert(v.capacity() == 8000);
+        }
     }
 
     {
@@ -685,12 +715,15 @@ constexpr bool test_growth() {
         assert(v.size() == 1000);
         assert(v.capacity() == 1000);
 
-#ifndef __EDG__ // TRANSITION, VSO-1273386, VSO-1274387
-        v.insert(v.end(), 3, 47);
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+        if (!is_constant_evaluated())
+#endif // ^^^ workaround ^^^
+        {
+            v.insert(v.end(), 3, 47);
 
-        assert(v.size() == 1003);
-        assert(v.capacity() == 1500);
-#endif // __EDG__
+            assert(v.size() == 1003);
+            assert(v.capacity() == 1500);
+        }
     }
 
     {
@@ -699,12 +732,15 @@ constexpr bool test_growth() {
         assert(v.size() == 1000);
         assert(v.capacity() == 1000);
 
-#ifndef __EDG__ // TRANSITION, VSO-1273386, VSO-1274387
-        v.insert(v.end(), 7000, 47);
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+        if (!is_constant_evaluated())
+#endif // ^^^ workaround ^^^
+        {
+            v.insert(v.end(), 7000, 47);
 
-        assert(v.size() == 8000);
-        assert(v.capacity() == 8000);
-#endif // __EDG__
+            assert(v.size() == 8000);
+            assert(v.capacity() == 8000);
+        }
     }
 
     return true;

--- a/tests/std/tests/P1004R2_constexpr_vector_bool/test.cpp
+++ b/tests/std/tests/P1004R2_constexpr_vector_bool/test.cpp
@@ -98,130 +98,146 @@ using vec = vector<bool, soccc_allocator<bool>>;
 constexpr bool test_interface() {
     { // constructors
 
-// Non allocator constructors
-#ifndef __EDG__ // TRANSITION, VSO-1274387
+        // Non allocator constructors
         vec size_default_constructed(5);
         assert(size_default_constructed.size() == 5);
-#if !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 // TRANSITION, VSO-1273296
-        assert(all_of(
-            size_default_constructed.begin(), size_default_constructed.end(), [](const bool val) { return !val; }));
-#endif // !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2
-#endif // __EDG__
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+        if (!is_constant_evaluated())
+#endif // ^^^ workaround ^^^
+        {
+            assert(all_of(
+                size_default_constructed.begin(), size_default_constructed.end(), [](const bool val) { return !val; }));
+        }
 
-#ifndef __EDG__ // TRANSITION, VSO-1274387
         vec size_value_constructed(5, true);
         assert(size_value_constructed.size() == 5);
-#if !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 // TRANSITION, VSO-1273296
-        assert(
-            all_of(size_value_constructed.begin(), size_value_constructed.end(), [](const bool val) { return val; }));
-#endif // !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2
-#endif // __EDG__
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+        if (!is_constant_evaluated())
+#endif // ^^^ workaround ^^^
+        {
+            assert(all_of(
+                size_value_constructed.begin(), size_value_constructed.end(), [](const bool val) { return val; }));
+        }
 
-#if !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 // TRANSITION, VSO-1273365
-#ifndef __EDG__ // TRANSITION, VSO-1274387
-        vec range_constructed(begin(input), end(input));
-        assert(equal(range_constructed.begin(), range_constructed.end(), begin(input), end(input)));
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+        if (!is_constant_evaluated())
+#endif // ^^^ workaround ^^^
+        {
+            vec range_constructed(begin(input), end(input));
+            assert(equal(range_constructed.begin(), range_constructed.end(), begin(input), end(input)));
 
-        vec initializer_list_constructed({true, true, false, true});
-        assert(equal(
-            initializer_list_constructed.begin(), initializer_list_constructed.end(), begin(input) + 2, end(input)));
-#endif // __EDG__
-#endif // !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2
+            vec initializer_list_constructed({true, true, false, true});
+            assert(equal(initializer_list_constructed.begin(), initializer_list_constructed.end(), begin(input) + 2,
+                end(input)));
+
+            vec copy_assigned = range_constructed;
+            assert(
+                equal(copy_assigned.begin(), copy_assigned.end(), range_constructed.begin(), range_constructed.end()));
+
+            vec move_assigned = move(copy_assigned);
+            assert(
+                equal(move_assigned.begin(), move_assigned.end(), range_constructed.begin(), range_constructed.end()));
+            assert(copy_assigned.empty()); // implementation-specific assumption that moved-from is empty
+        }
 
         // special member functions
-#ifndef __EDG__ // TRANSITION, VSO-1274387
         vec default_constructed;
         assert(default_constructed.empty());
         vec copy_constructed(size_default_constructed);
-#if !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 // TRANSITION, VSO-1273296
-        assert(equal(copy_constructed.begin(), copy_constructed.end(), size_default_constructed.begin(),
-            size_default_constructed.end()));
-#endif // !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+        if (!is_constant_evaluated())
+#endif // ^^^ workaround ^^^
+        {
+            assert(equal(copy_constructed.begin(), copy_constructed.end(), size_default_constructed.begin(),
+                size_default_constructed.end()));
+        }
 
         vec move_constructed(move(copy_constructed));
-#if !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 // TRANSITION, VSO-1273296
-        assert(equal(move_constructed.begin(), move_constructed.end(), size_default_constructed.begin(),
-            size_default_constructed.end()));
-#endif // !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+        if (!is_constant_evaluated())
+#endif // ^^^ workaround ^^^
+        {
+            assert(equal(move_constructed.begin(), move_constructed.end(), size_default_constructed.begin(),
+                size_default_constructed.end()));
+        }
         assert(copy_constructed.empty()); // implementation-specific assumption that moved-from is empty
-#endif // __EDG__
-
-#if !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 // TRANSITION, VSO-1273365
-#ifndef __EDG__ // TRANSITION, VSO-1274387, VSO-1273296
-        vec copy_assigned = range_constructed;
-        assert(equal(copy_assigned.begin(), copy_assigned.end(), range_constructed.begin(), range_constructed.end()));
-
-        vec move_assigned = move(copy_assigned);
-        assert(equal(move_assigned.begin(), move_assigned.end(), range_constructed.begin(), range_constructed.end()));
-        assert(copy_assigned.empty()); // implementation-specific assumption that moved-from is empty
-#endif // __EDG__
-#endif // !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2
 
         // allocator constructors
         soccc_allocator<int> alloc(2, 3);
         assert(alloc.id == 2);
         assert(alloc.soccc_generation == 3);
 
-#ifndef __EDG__ // TRANSITION, VSO-1274387
         vec al_default_constructed(alloc);
         assert(al_default_constructed.empty());
         assert(al_default_constructed.get_allocator().id == 4);
         assert(al_default_constructed.get_allocator().soccc_generation == 3);
 
         vec al_copy_constructed(size_value_constructed, alloc);
-#if !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 // TRANSITION, VSO-1273296
-        assert(all_of(al_copy_constructed.begin(), al_copy_constructed.end(), [](const bool val) { return val; }));
-#endif // !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+        if (!is_constant_evaluated())
+#endif // ^^^ workaround ^^^
+        {
+            assert(all_of(al_copy_constructed.begin(), al_copy_constructed.end(), [](const bool val) { return val; }));
+        }
         assert(al_copy_constructed.get_allocator().id == 4);
         assert(al_copy_constructed.get_allocator().soccc_generation == 3);
 
         vec al_move_constructed(move(al_copy_constructed), alloc);
-#if !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 // TRANSITION, VSO-1273296
-        assert(all_of(al_move_constructed.begin(), al_move_constructed.end(), [](const bool val) { return val; }));
-#endif // !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+        if (!is_constant_evaluated())
+#endif // ^^^ workaround ^^^
+        {
+            assert(all_of(al_move_constructed.begin(), al_move_constructed.end(), [](const bool val) { return val; }));
+        }
         assert(al_copy_constructed.empty()); // implementation-specific assumption that moved-from is empty
         assert(al_move_constructed.get_allocator().id == 4);
         assert(al_move_constructed.get_allocator().soccc_generation == 3);
 
         vec al_size_default_constructed(5, alloc);
         assert(al_size_default_constructed.size() == 5);
-#if !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 // TRANSITION, VSO-1273296
-        assert(all_of(al_size_default_constructed.begin(), al_size_default_constructed.end(),
-            [](const bool val) { return !val; }));
-#endif // !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+        if (!is_constant_evaluated())
+#endif // ^^^ workaround ^^^
+        {
+            assert(all_of(al_size_default_constructed.begin(), al_size_default_constructed.end(),
+                [](const bool val) { return !val; }));
+        }
         assert(al_size_default_constructed.get_allocator().id == 4);
         assert(al_size_default_constructed.get_allocator().soccc_generation == 3);
 
         vec al_size_value_constructed(5, true, alloc);
         assert(al_size_value_constructed.size() == 5);
-#if !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 // TRANSITION, VSO-1273296
-        assert(all_of(
-            al_size_value_constructed.begin(), al_size_value_constructed.end(), [](const bool val) { return val; }));
-#endif // !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+        if (!is_constant_evaluated())
+#endif // ^^^ workaround ^^^
+        {
+            assert(all_of(al_size_value_constructed.begin(), al_size_value_constructed.end(),
+                [](const bool val) { return val; }));
+        }
         assert(al_size_value_constructed.get_allocator().id == 4);
         assert(al_size_value_constructed.get_allocator().soccc_generation == 3);
-#endif // __EDG__
 
-#if !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 // TRANSITION, VSO-1273365
-#ifndef __EDG__ // TRANSITION, VSO-1274387
-        vec al_range_constructed(begin(input), end(input), alloc);
-        assert(equal(al_range_constructed.begin(), al_range_constructed.end(), begin(input), end(input)));
-        assert(al_range_constructed.get_allocator().id == 4);
-        assert(al_range_constructed.get_allocator().soccc_generation == 3);
-#endif // __EDG__
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+        if (!is_constant_evaluated())
+#endif // ^^^ workaround ^^^
+        {
+            vec al_range_constructed(begin(input), end(input), alloc);
+            assert(equal(al_range_constructed.begin(), al_range_constructed.end(), begin(input), end(input)));
+            assert(al_range_constructed.get_allocator().id == 4);
+            assert(al_range_constructed.get_allocator().soccc_generation == 3);
 
-#ifndef __EDG__ // TRANSITION, VSO-1274387
-        vec al_initializer_list_constructed({true, true, false, true}, alloc);
-        assert(equal(al_initializer_list_constructed.begin(), al_initializer_list_constructed.end(), begin(input) + 2,
-            end(input)));
-        assert(al_initializer_list_constructed.get_allocator().id == 4);
-        assert(al_initializer_list_constructed.get_allocator().soccc_generation == 3);
-#endif // __EDG__
-#endif // !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2
+            vec al_initializer_list_constructed({true, true, false, true}, alloc);
+            assert(equal(al_initializer_list_constructed.begin(), al_initializer_list_constructed.end(),
+                begin(input) + 2, end(input)));
+            assert(al_initializer_list_constructed.get_allocator().id == 4);
+            assert(al_initializer_list_constructed.get_allocator().soccc_generation == 3);
+        }
     }
 
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+    if (!is_constant_evaluated())
+#endif // ^^^ workaround ^^^
     { // assignment
-#ifndef __EDG__ // TRANSITION, VSO-1274387
         vec range_constructed(begin(input), end(input));
 
         vec copy_constructed;
@@ -252,25 +268,23 @@ constexpr bool test_interface() {
         assigned.assign({true, false, true, true, false, true});
         assert(equal(
             assigned.begin(), assigned.end(), begin(expected_assign_initializer), end(expected_assign_initializer)));
-#endif // __EDG__
     }
 
     { // allocator
-#ifndef __EDG__ // TRANSITION, VSO-1274387
         vec default_constructed;
         const auto alloc = default_constructed.get_allocator();
         static_assert(is_same_v<remove_const_t<decltype(alloc)>, soccc_allocator<bool>>);
         assert(alloc.id == 1);
         assert(alloc.soccc_generation == 0);
-#endif // __EDG__
     }
 
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+    if (!is_constant_evaluated())
+#endif // ^^^ workaround ^^^
     { // iterators
-#ifndef __EDG__ // TRANSITION, VSO-1274387
         vec range_constructed(begin(input), end(input));
         const vec const_range_constructed(begin(input), end(input));
 
-#if !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 // TRANSITION, VSO-1273381
         const auto b = range_constructed.begin();
         static_assert(is_same_v<remove_const_t<decltype(b)>, vec::iterator>);
         assert(*b);
@@ -318,16 +332,15 @@ constexpr bool test_interface() {
         const auto cre2 = const_range_constructed.rend();
         static_assert(is_same_v<remove_const_t<decltype(cre2)>, reverse_iterator<vec::const_iterator>>);
         assert(*prev(cre2));
-#endif // defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2
-#endif // __EDG__
     }
 
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+    if (!is_constant_evaluated())
+#endif // ^^^ workaround ^^^
     { // access
-#ifndef __EDG__ // TRANSITION, VSO-1274387
         vec range_constructed(begin(input), end(input));
         const vec const_range_constructed(begin(input), end(input));
 
-#if !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 // TRANSITION, VSO-1273381
         const auto at = range_constructed.at(2);
         static_assert(is_same_v<remove_const_t<decltype(at)>, _Iter_ref_t<vec::iterator>>);
         assert(at);
@@ -370,12 +383,12 @@ constexpr bool test_interface() {
         const auto cb = const_range_constructed.back();
         static_assert(is_same_v<remove_const_t<decltype(cb)>, _Iter_ref_t<vec::const_iterator>>);
         assert(cb);
-#endif // !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2
-#endif // __EDG__
     }
 
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+    if (!is_constant_evaluated())
+#endif // ^^^ workaround ^^^
     { // capacity
-#ifndef __EDG__ // TRANSITION, VSO-1274387
         vec range_constructed(begin(input), end(input));
 
         const auto e = range_constructed.empty();
@@ -401,11 +414,12 @@ constexpr bool test_interface() {
         const auto c2 = range_constructed.capacity();
         static_assert(is_same_v<remove_const_t<decltype(c2)>, size_t>);
         assert(c2 == 32);
-#endif // __EDG__
     }
 
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+    if (!is_constant_evaluated())
+#endif // ^^^ workaround ^^^
     { // modifiers
-#ifndef __EDG__ // TRANSITION, VSO-1274387
         vec range_constructed(begin(input), end(input));
 
         vec flipped = range_constructed;
@@ -439,7 +453,6 @@ constexpr bool test_interface() {
         assert(inserted.size() == 4);
         assert(inserted.front() == false);
 
-#if !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 // TRANSITION, VSO-1273381
         const auto it = inserted.insert(inserted.begin(), begin(input), end(input));
         assert(inserted.size() == 10);
         assert(it == inserted.begin());
@@ -451,7 +464,6 @@ constexpr bool test_interface() {
         const auto it3 = inserted.insert(inserted.begin(), {true, false, true});
         assert(inserted.size() == 19);
         assert(it3 == inserted.begin());
-#endif // !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2
 
         inserted.insert(inserted.cbegin(), {false, true, false});
         assert(inserted.size() == 22);
@@ -495,23 +507,27 @@ constexpr bool test_interface() {
 
         emplaced.erase(emplaced.begin(), emplaced.begin() + 2);
         assert(emplaced.size() == 22);
-
-        {
-            // GH-2440: we were incorrectly reallocating _before_ orphaning iterators
-            // (resulting in UB) while inserting ranges of unknown length
-
-            vector<bool> input_inserted;
-            const auto result =
-                input_inserted.insert(input_inserted.end(), demoterator{begin(num_arr)}, demoterator{end(num_arr)});
-            static_assert(is_same_v<decltype(result), const vector<bool>::iterator>);
-            assert(result == input_inserted.begin());
-            assert(input_inserted.size() == size(num_arr));
-        }
-#endif // __EDG__
     }
 
+#ifdef __EDG__ // TRANSITION, VSO-1674154 (invalid arithmetic on non-array pointer)
+    if (!is_constant_evaluated())
+#endif // ^^^ workaround ^^^
+    {
+        // GH-2440: we were incorrectly reallocating _before_ orphaning iterators
+        // (resulting in UB) while inserting ranges of unknown length
+
+        vector<bool> input_inserted;
+        const auto result =
+            input_inserted.insert(input_inserted.end(), demoterator{begin(num_arr)}, demoterator{end(num_arr)});
+        static_assert(is_same_v<decltype(result), const vector<bool>::iterator>);
+        assert(result == input_inserted.begin());
+        assert(input_inserted.size() == size(num_arr));
+    }
+
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+    if (!is_constant_evaluated())
+#endif // ^^^ workaround ^^^
     { // swap
-#ifndef __EDG__ // TRANSITION, VSO-1274387
         vec first{true, false, true};
         vec second{false, false, true, false};
         swap(first, second);
@@ -520,11 +536,12 @@ constexpr bool test_interface() {
         constexpr bool expected_second[] = {true, false, true};
         assert(equal(first.begin(), first.end(), begin(expected_first), end(expected_first)));
         assert(equal(second.begin(), second.end(), begin(expected_second), end(expected_second)));
-#endif // __EDG__
     }
 
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+    if (!is_constant_evaluated())
+#endif // ^^^ workaround ^^^
     { // erase
-#ifndef __EDG__ // TRANSITION, VSO-1274387
         vec erased{false, false, true, false, true};
         erase(erased, false);
         constexpr bool expected_erased[] = {true, true};
@@ -534,11 +551,12 @@ constexpr bool test_interface() {
         erase_if(erased_if, [](const bool val) { return val; });
         constexpr bool expected_erase_if[] = {false, false, false};
         assert(equal(erased_if.begin(), erased_if.end(), begin(expected_erase_if), end(expected_erase_if)));
-#endif // __EDG__
     }
 
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+    if (!is_constant_evaluated())
+#endif // ^^^ workaround ^^^
     { // comparison
-#ifndef __EDG__ // TRANSITION, VSO-1274387
         vec first(begin(input), end(input));
         vec second(begin(input), end(input));
         vec third{true, false, true};
@@ -566,17 +584,20 @@ constexpr bool test_interface() {
         const auto ge = first >= third;
         static_assert(is_same_v<remove_const_t<decltype(ge)>, bool>);
         assert(ge);
-#endif // __EDG__
     }
 
     return true;
 }
 
 constexpr bool test_iterators() {
-#ifndef __EDG__ // TRANSITION, VSO-1274387
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+    if (is_constant_evaluated()) {
+        return true;
+    }
+#endif // ^^^ workaround ^^^
+
     vec range_constructed(begin(input), end(input));
 
-#if !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2 // TRANSITION, VSO-1273381
     { // increment
         auto it = range_constructed.begin();
         assert(*++it == false);
@@ -659,8 +680,6 @@ constexpr bool test_iterators() {
         const auto cit = range_constructed.cbegin() + 2;
         assert(cit[2] == false);
     }
-#endif // __EDG__
-#endif // !defined(__EDG__) || _ITERATOR_DEBUG_LEVEL != 2
 
     return true;
 }

--- a/tests/std/tests/P2321R2_proxy_reference/test.cpp
+++ b/tests/std/tests/P2321R2_proxy_reference/test.cpp
@@ -274,9 +274,9 @@ constexpr bool test() {
 
     { // Test vector<bool>::reference
         static_assert(is_assignable_v<const vector<bool>::reference, bool>);
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL != 0 // TRANSITION, VSO-1274387, VSO-1273296
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
         if (!is_constant_evaluated())
-#endif // defined(__EDG__) && _ITERATOR_DEBUG_LEVEL != 0
+#endif // ^^^ workaround ^^^
         {
             vector<bool> vb{false};
             const vector<bool>::reference r = vb[0];

--- a/tests/std/tests/VSO_0000000_allocator_propagation/test.cpp
+++ b/tests/std/tests/VSO_0000000_allocator_propagation/test.cpp
@@ -295,6 +295,13 @@ _CONSTEXPR20 void test_sequence_swap(const size_t id1, const size_t id2) {
 
 template <template <class, class> class Sequence>
 _CONSTEXPR20 bool test_sequence() {
+#if _HAS_CXX20 && defined(__EDG__) \
+    && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+    if (is_constant_evaluated()) {
+        return true;
+    }
+#endif // ^^^ workaround ^^^
+
     test_sequence_copy_ctor<Sequence>();
 
     test_sequence_copy_alloc_ctor<Sequence>(11, 11); // equal allocators
@@ -1652,9 +1659,9 @@ int main() {
     test_sequence<deque>();
     test_sequence<list>();
     test_sequence<vector>();
-#if _HAS_CXX20 && !defined(__EDG__) // TRANSITION, VSO-1273365 && DevCom-1520773
+#if _HAS_CXX20
     static_assert(test_sequence<vector>());
-#endif // _HAS_CXX20 && !defined(__EDG__)
+#endif // _HAS_CXX20
 
     test_flist();
     test_string();


### PR DESCRIPTION
* New 1ES Hosted Pool, containing Patch Tuesday.
* New toolset, VS 2022 17.5 Preview 1.
  + This is not yet required in `<yvals_core.h>`, because the MSVC-internal build is still using MSVC 19.34.
* This also contains Python 3.11.0 (with major performance improvements, although it doesn't make a massive difference for our test runs, which are dominated by compile time).
  + Not updating the minimum required version, as the VS Installer still offers Python 3.9.7.
* Use PowerShell 7.3.0 while preparing the VM.
  + Note that PowerShell 7.3.0 can't be used locally while preparing the 1ES Hosted Pool. As mentioned in the [Checklist for Toolset Updates](https://github.com/microsoft/STL/wiki/Checklist-for-Toolset-Updates), there's an active Azure PowerShell bug about this.
* Remove EDG compiler bug workarounds:
  + Update citation from VSO-1641993 "REPORTED: EDG `__builtin_memcmp` misbehavior, part 2" to VSO-1675318 "EDG `__builtin_memcmp` misbehavior, part 3".
  + Remove `_CONSTEXPR20_STRING_LITERALS` workaround.
  + Remove workaround in `Dev10_816787_swap_vector_bool_elements`.
* Overhaul the `constexpr` `string`/`vector` tests, which had accumulated a mess of EDG workarounds. :scream_cat: This was problematic because there were overlapping ifdefs, some became unnecessary due to fixes over time, some could be debug-only, and many were working around a real problem but the reported bugs were resolved, so no action was being taken.
  + The diff looks *horrible* (I'd recommend focusing on the end result, and trusting that I haven't damaged things along the way; in a few cases I needed to move test code around a bit). Ultimately, this irons out everything into a highly systematic workaround, slightly refined from what `P0980R1_constexpr_strings` was doing. When we're (1) EDG and (2) IDL=2 and (3) compile-time, we skip test code. This activates as much test code as possible.
  + I verified that each remaining workaround is necessary, and is working around the same error message, which I've reported as VSO-1674140 "EDG rejects `constexpr` `string`/`vector` in debug mode with 'attempt to access expired storage' errors".
  + One workaround is unique, in that it's specific to `vector<bool>` and applies to release mode too. That has been reported as VSO-1674154 "EDG rejects `constexpr` `vector<bool>` with 'invalid arithmetic on non-array pointer' error".
