### PR TITLE
standardize `^^^ x / !x vvv` comments

### DIFF
--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -8123,7 +8123,7 @@ namespace ranges {
                 // divide and conquer by quicksort
 #if defined(__clang__) || defined(__EDG__) // TRANSITION, DevCom-1559808
                 auto [_Mid_first, _Mid_last] = _Partition_by_median_guess_common(_First, _Last, _Pred, _Proj);
-#else // ^^^ no workaround // workaround vvv
+#else // ^^^ no workaround / workaround vvv
                 auto _Mid       = _Partition_by_median_guess_common(_First, _Last, _Pred, _Proj);
                 auto _Mid_first = _Mid.begin();
                 auto _Mid_last  = _Mid.end();

--- a/stl/inc/array
+++ b/stl/inc/array
@@ -104,7 +104,7 @@ public:
     _NODISCARD constexpr strong_ordering operator<=>(const _Array_const_iterator& _Right) const noexcept {
         return _Ptr <=> _Right._Ptr;
     }
-#else // ^^^ _HAS_CXX20 ^^^ / vvv !_HAS_CXX20 vvv
+#else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
     _NODISCARD _CONSTEXPR17 bool operator<(const _Array_const_iterator& _Right) const noexcept {
         return _Ptr < _Right._Ptr;
     }
@@ -209,7 +209,7 @@ private:
         _Compat(_Right);
         return _Idx <=> _Right._Idx;
     }
-#else // ^^^ _HAS_CXX20 ^^^ / vvv !_HAS_CXX20 vvv
+#else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
     _NODISCARD _CONSTEXPR17 bool operator<(const _Array_const_iterator& _Right) const noexcept {
         _Compat(_Right);
         return _Idx < _Right._Idx;

--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -32,7 +32,7 @@ _STL_DISABLE_CLANG_WARNINGS
 #ifdef _WIN64
 #if _STD_ATOMIC_ALWAYS_USE_CMPXCHG16B == 1
 #define _STD_COMPARE_EXCHANGE_128 _InterlockedCompareExchange128
-#else // ^^^ _STD_ATOMIC_ALWAYS_USE_CMPXCHG16B == 1 // _STD_ATOMIC_ALWAYS_USE_CMPXCHG16B == 0 vvv
+#else // ^^^ _STD_ATOMIC_ALWAYS_USE_CMPXCHG16B == 1 / _STD_ATOMIC_ALWAYS_USE_CMPXCHG16B == 0 vvv
 // 16-byte atomics are separately compiled for x64, as not all x64 hardware has the cmpxchg16b
 // instruction; in the event this instruction is not available, the fallback is a global
 // synchronization object shared by all 16-byte atomics.
@@ -2067,7 +2067,7 @@ using _Choose_atomic_base2_t =
 template <class _TVal, class _Ty = _TVal>
 using _Choose_atomic_base_t = typename _Select<is_floating_point_v<_TVal>>::template _Apply<_Atomic_floating<_Ty>,
     _Choose_atomic_base2_t<_TVal, _Ty>>;
-#else // ^^^ _HAS_CXX20 // !_HAS_CXX20 vvv
+#else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
 template <class _TVal, class _Ty = _TVal>
 using _Choose_atomic_base_t = _Choose_atomic_base2_t<_TVal, _Ty>;
 #endif // _HAS_CXX20

--- a/stl/inc/bitset
+++ b/stl/inc/bitset
@@ -69,7 +69,7 @@ public:
     static _CONSTEXPR23 void _Validate(const size_t _Pos) noexcept { // verify that _Pos is within bounds
 #if _ITERATOR_DEBUG_LEVEL == 0
         (void) _Pos;
-#else // ^^^ _ITERATOR_DEBUG_LEVEL == 0 ^^^ / vvv _ITERATOR_DEBUG_LEVEL != 0 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL == 0 / _ITERATOR_DEBUG_LEVEL != 0 vvv
         _STL_VERIFY(_Pos < _Bits, "bitset index outside range");
 #endif // _ITERATOR_DEBUG_LEVEL == 0
     }

--- a/stl/inc/bitset
+++ b/stl/inc/bitset
@@ -69,7 +69,7 @@ public:
     static _CONSTEXPR23 void _Validate(const size_t _Pos) noexcept { // verify that _Pos is within bounds
 #if _ITERATOR_DEBUG_LEVEL == 0
         (void) _Pos;
-#else // ^^^ _ITERATOR_DEBUG_LEVEL == 0 ^^^ // vvv _ITERATOR_DEBUG_LEVEL != 0 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL == 0 ^^^ / vvv _ITERATOR_DEBUG_LEVEL != 0 vvv
         _STL_VERIFY(_Pos < _Bits, "bitset index outside range");
 #endif // _ITERATOR_DEBUG_LEVEL == 0
     }

--- a/stl/inc/cmath
+++ b/stl/inc/cmath
@@ -15,7 +15,7 @@
 #if !defined(__clang__) && !defined(__CUDACC__) && !defined(__INTEL_COMPILER) \
     && !defined(_M_CEE) // TRANSITION, VSO-1663104
 #define _HAS_CMATH_INTRINSICS 1
-#else // ^^^ intrinsics available ^^^ / vvv intrinsics unavailable vvv
+#else // ^^^ intrinsics available / intrinsics unavailable vvv
 #define _HAS_CMATH_INTRINSICS 0
 #endif // ^^^ intrinsics unavailable ^^^
 
@@ -71,7 +71,7 @@ _NODISCARD _Check_return_ inline float ceil(_In_ float _Xx) noexcept /* strength
     return __ceilf(_Xx);
 #elif defined(__clang__)
     return __builtin_ceilf(_Xx);
-#else // ^^^ defined(__clang__) ^^^ / vvv intrinsics unavailable vvv
+#else // ^^^ defined(__clang__) / intrinsics unavailable vvv
     return _CSTD ceilf(_Xx);
 #endif // ^^^ intrinsics unavailable ^^^
 }
@@ -81,7 +81,7 @@ _NODISCARD _Check_return_ inline float copysign(_In_ float _Number, _In_ float _
     return __copysignf(_Number, _Sign);
 #elif defined(__clang__)
     return __builtin_copysignf(_Number, _Sign);
-#else // ^^^ defined(__clang__) ^^^ / vvv intrinsics unavailable vvv
+#else // ^^^ defined(__clang__) / intrinsics unavailable vvv
     return _CSTD copysignf(_Number, _Sign);
 #endif // ^^^ intrinsics unavailable ^^^
 }
@@ -127,7 +127,7 @@ _NODISCARD _Check_return_ inline float floor(_In_ float _Xx) noexcept /* strengt
     return __floorf(_Xx);
 #elif defined(__clang__)
     return __builtin_floorf(_Xx);
-#else // ^^^ defined(__clang__) ^^^ / vvv intrinsics unavailable vvv
+#else // ^^^ defined(__clang__) / intrinsics unavailable vvv
     return _CSTD floorf(_Xx);
 #endif // ^^^ intrinsics unavailable ^^^
 }
@@ -241,7 +241,7 @@ _NODISCARD _Check_return_ inline float round(_In_ float _Xx) noexcept /* strengt
     return __roundf(_Xx);
 #elif defined(__clang__)
     return __builtin_roundf(_Xx);
-#else // ^^^ defined(__clang__) ^^^ / vvv intrinsics unavailable vvv
+#else // ^^^ defined(__clang__) / intrinsics unavailable vvv
     return _CSTD roundf(_Xx);
 #endif // ^^^ intrinsics unavailable ^^^
 }
@@ -283,7 +283,7 @@ _NODISCARD _Check_return_ inline float trunc(_In_ float _Xx) noexcept /* strengt
     return __truncf(_Xx);
 #elif defined(__clang__)
     return __builtin_truncf(_Xx);
-#else // ^^^ defined(__clang__) ^^^ / vvv intrinsics unavailable vvv
+#else // ^^^ defined(__clang__) / intrinsics unavailable vvv
     return _CSTD truncf(_Xx);
 #endif // ^^^ intrinsics unavailable ^^^
 }
@@ -326,7 +326,7 @@ _NODISCARD _Check_return_ inline long double ceil(_In_ long double _Xx) noexcept
     return __ceil(static_cast<double>(_Xx));
 #elif defined(__clang__)
     return __builtin_ceill(_Xx);
-#else // ^^^ defined(__clang__) ^^^ / vvv intrinsics unavailable vvv
+#else // ^^^ defined(__clang__) / intrinsics unavailable vvv
     return _CSTD ceill(_Xx);
 #endif // ^^^ intrinsics unavailable ^^^
 }
@@ -337,7 +337,7 @@ _NODISCARD _Check_return_ inline long double copysign(_In_ long double _Number, 
     return __copysign(static_cast<double>(_Number), static_cast<double>(_Sign));
 #elif defined(__clang__)
     return __builtin_copysignl(_Number, _Sign);
-#else // ^^^ defined(__clang__) ^^^ / vvv intrinsics unavailable vvv
+#else // ^^^ defined(__clang__) / intrinsics unavailable vvv
     return _CSTD copysignl(_Number, _Sign);
 #endif // ^^^ intrinsics unavailable ^^^
 }
@@ -384,7 +384,7 @@ _NODISCARD _Check_return_ inline long double floor(_In_ long double _Xx) noexcep
     return __floor(static_cast<double>(_Xx));
 #elif defined(__clang__)
     return __builtin_floorl(_Xx);
-#else // ^^^ defined(__clang__) ^^^ / vvv intrinsics unavailable vvv
+#else // ^^^ defined(__clang__) / intrinsics unavailable vvv
     return _CSTD floorl(_Xx);
 #endif // ^^^ intrinsics unavailable ^^^
 }
@@ -507,7 +507,7 @@ _NODISCARD _Check_return_ inline long double round(_In_ long double _Xx) noexcep
     return __round(static_cast<double>(_Xx));
 #elif defined(__clang__)
     return __builtin_roundl(_Xx);
-#else // ^^^ defined(__clang__) ^^^ / vvv intrinsics unavailable vvv
+#else // ^^^ defined(__clang__) / intrinsics unavailable vvv
     return _CSTD roundl(_Xx);
 #endif // ^^^ intrinsics unavailable ^^^
 }
@@ -549,7 +549,7 @@ _NODISCARD _Check_return_ inline long double trunc(_In_ long double _Xx) noexcep
     return __trunc(static_cast<double>(_Xx));
 #elif defined(__clang__)
     return __builtin_truncl(_Xx);
-#else // ^^^ defined(__clang__) ^^^ / vvv intrinsics unavailable vvv
+#else // ^^^ defined(__clang__) / intrinsics unavailable vvv
     return _CSTD truncl(_Xx);
 #endif // ^^^ intrinsics unavailable ^^^
 }
@@ -606,7 +606,7 @@ _STD _Common_float_type_t<_Ty1, _Ty2> remquo(_Ty1 _Left, _Ty2 _Right, int* _Pquo
 #define _GENERIC_MATH1I(FUN, CLANG_INTRIN, MSVC_INTRIN) _GENERIC_MATH1_BASE(FUN, double, MSVC_INTRIN)
 #elif defined(__clang__)
 #define _GENERIC_MATH1I(FUN, CLANG_INTRIN, MSVC_INTRIN) _GENERIC_MATH1_BASE(FUN, double, CLANG_INTRIN)
-#else // ^^^ defined(__clang__) ^^^ / vvv intrinsics unavailable vvv
+#else // ^^^ defined(__clang__) / intrinsics unavailable vvv
 #define _GENERIC_MATH1I(FUN, CLANG_INTRIN, MSVC_INTRIN) _GENERIC_MATH1_BASE(FUN, double, _CSTD FUN)
 #endif // ^^^ intrinsics unavailable ^^^
 
@@ -630,7 +630,7 @@ _STD _Common_float_type_t<_Ty1, _Ty2> remquo(_Ty1 _Left, _Ty2 _Right, int* _Pquo
 #define _GENERIC_MATH2I(FUN, CLANG_INTRIN, MSVC_INTRIN) _GENERIC_MATH2_BASE(FUN, MSVC_INTRIN)
 #elif defined(__clang__)
 #define _GENERIC_MATH2I(FUN, CLANG_INTRIN, MSVC_INTRIN) _GENERIC_MATH2_BASE(FUN, CLANG_INTRIN)
-#else // ^^^ defined(__clang__) ^^^ / vvv intrinsics unavailable vvv
+#else // ^^^ defined(__clang__) / intrinsics unavailable vvv
 #define _GENERIC_MATH2I(FUN, CLANG_INTRIN, MSVC_INTRIN) _GENERIC_MATH2_BASE(FUN, _CSTD FUN)
 #endif // ^^^ intrinsics unavailable ^^^
 

--- a/stl/inc/coroutine
+++ b/stl/inc/coroutine
@@ -13,7 +13,7 @@
 _EMIT_STL_WARNING(STL4039, "The contents of <coroutine> are not available with /await. "
                            "Remove /await or use /await:strict for standard coroutines. "
                            "Use <experimental/coroutine> for legacy /await support.");
-#else // ^^^ /await ^^^ / vvv no /await vvv
+#else // ^^^ /await / no /await vvv
 #ifndef __cpp_lib_coroutine
 _EMIT_STL_WARNING(STL4038, "The contents of <coroutine> are available only with C++20 or later or /await:strict.");
 #else // ^^^ <coroutine> is not available / <coroutine> is available vvv

--- a/stl/inc/deque
+++ b/stl/inc/deque
@@ -407,7 +407,7 @@ public:
     void _Verify_offset(const difference_type _Off) const noexcept {
 #if _ITERATOR_DEBUG_LEVEL == 0
         (void) _Off;
-#else // ^^^ _ITERATOR_DEBUG_LEVEL == 0 ^^^ // vvv _ITERATOR_DEBUG_LEVEL != 0 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL == 0 ^^^ / vvv _ITERATOR_DEBUG_LEVEL != 0 vvv
         if (_Off != 0) {
             const auto _Mycont = static_cast<const _Mydeque*>(this->_Getcont());
             _STL_VERIFY(_Mycont, "cannot use value-initialized deque iterator");

--- a/stl/inc/deque
+++ b/stl/inc/deque
@@ -118,7 +118,7 @@ public:
     _NODISCARD strong_ordering operator<=>(const _Deque_unchecked_const_iterator& _Right) const noexcept {
         return _Myoff <=> _Right._Myoff;
     }
-#else // ^^^ _HAS_CXX20 ^^^ / vvv !_HAS_CXX20 vvv
+#else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
     _NODISCARD bool operator!=(const _Deque_unchecked_const_iterator& _Right) const noexcept {
         return !(*this == _Right);
     }
@@ -363,7 +363,7 @@ public:
         _Compat(_Right);
         return this->_Myoff <=> _Right._Myoff;
     }
-#else // ^^^ _HAS_CXX20 ^^^ / vvv !_HAS_CXX20 vvv
+#else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
     _NODISCARD bool operator!=(const _Deque_const_iterator& _Right) const noexcept {
         return !(*this == _Right);
     }
@@ -407,7 +407,7 @@ public:
     void _Verify_offset(const difference_type _Off) const noexcept {
 #if _ITERATOR_DEBUG_LEVEL == 0
         (void) _Off;
-#else // ^^^ _ITERATOR_DEBUG_LEVEL == 0 ^^^ / vvv _ITERATOR_DEBUG_LEVEL != 0 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL == 0 / _ITERATOR_DEBUG_LEVEL != 0 vvv
         if (_Off != 0) {
             const auto _Mycont = static_cast<const _Mydeque*>(this->_Getcont());
             _STL_VERIFY(_Mycont, "cannot use value-initialized deque iterator");

--- a/stl/inc/execution
+++ b/stl/inc/execution
@@ -33,7 +33,7 @@ _EXTERN_C
 using __std_TP_WORK              = void;
 using __std_TP_CALLBACK_INSTANCE = void;
 using __std_TP_CALLBACK_ENVIRON  = void;
-#else // ^^^ _M_CEE ^^^ // vvv !_M_CEE vvv
+#else // ^^^ _M_CEE ^^^ / vvv !_M_CEE vvv
 struct __std_TP_WORK; // not defined
 struct __std_TP_CALLBACK_INSTANCE; // not defined
 struct __std_TP_CALLBACK_ENVIRON; // not defined
@@ -2811,7 +2811,7 @@ inline size_t _Get_stable_sort_tree_height(const size_t _Count, const size_t _Hw
     const size_t _Log_ideal_chunks     = _Floor_of_log_2(_Ideal_chunks);
 #ifdef _WIN64
     const size_t _Max_tree_height      = 62; // to avoid ptrdiff_t overflow
-#else // ^^^ _WIN64 ^^^ // vvv !_WIN64 vvv
+#else // ^^^ _WIN64 ^^^ / vvv !_WIN64 vvv
     const size_t _Max_tree_height = 30;
 #endif // _WIN64
     const size_t _Clamped_ideal_chunks = (_STD min)(_Max_tree_height, _Log_ideal_chunks);

--- a/stl/inc/execution
+++ b/stl/inc/execution
@@ -33,7 +33,7 @@ _EXTERN_C
 using __std_TP_WORK              = void;
 using __std_TP_CALLBACK_INSTANCE = void;
 using __std_TP_CALLBACK_ENVIRON  = void;
-#else // ^^^ _M_CEE ^^^ / vvv !_M_CEE vvv
+#else // ^^^ _M_CEE / !_M_CEE vvv
 struct __std_TP_WORK; // not defined
 struct __std_TP_CALLBACK_INSTANCE; // not defined
 struct __std_TP_CALLBACK_ENVIRON; // not defined
@@ -2811,7 +2811,7 @@ inline size_t _Get_stable_sort_tree_height(const size_t _Count, const size_t _Hw
     const size_t _Log_ideal_chunks     = _Floor_of_log_2(_Ideal_chunks);
 #ifdef _WIN64
     const size_t _Max_tree_height      = 62; // to avoid ptrdiff_t overflow
-#else // ^^^ _WIN64 ^^^ / vvv !_WIN64 vvv
+#else // ^^^ _WIN64 / !_WIN64 vvv
     const size_t _Max_tree_height = 30;
 #endif // _WIN64
     const size_t _Clamped_ideal_chunks = (_STD min)(_Max_tree_height, _Log_ideal_chunks);

--- a/stl/inc/forward_list
+++ b/stl/inc/forward_list
@@ -1462,7 +1462,7 @@ private:
         // splice _Right (_Prev, _Prev + 2) after _Where
 #if _ITERATOR_DEBUG_LEVEL == 0
         (void) _Right;
-#else // ^^^ _ITERATOR_DEBUG_LEVEL == 0 // _ITERATOR_DEBUG_LEVEL != 0 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL == 0 / _ITERATOR_DEBUG_LEVEL != 0 vvv
         if constexpr (!_Alnode_traits::is_always_equal::value) {
             _STL_VERIFY(_Getal() == _Right._Getal(), "forward_list containers incompatible for splice_after");
         }
@@ -1491,7 +1491,7 @@ private:
         // splice _Right (_First, _Last) just after _Where
 #if _ITERATOR_DEBUG_LEVEL == 0
         (void) _Right;
-#else // ^^^ _ITERATOR_DEBUG_LEVEL == 0 // _ITERATOR_DEBUG_LEVEL != 0 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL == 0 / _ITERATOR_DEBUG_LEVEL != 0 vvv
         if constexpr (!_Alnode_traits::is_always_equal::value) {
             _STL_VERIFY(_Getal() == _Right._Getal(), "forward_list containers incompatible for splice_after");
         }

--- a/stl/inc/iterator
+++ b/stl/inc/iterator
@@ -1590,7 +1590,7 @@ public:
             "cannot compare incompatible checked_array_iterators");
         return _Myindex <=> _Right._Myindex;
     }
-#else // ^^^ _HAS_CXX20 ^^^ / vvv !_HAS_CXX20 vvv
+#else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
     _NODISCARD constexpr bool operator!=(const checked_array_iterator& _Right) const noexcept {
         return !(*this == _Right);
     }
@@ -1746,7 +1746,7 @@ public:
     _NODISCARD constexpr _STD strong_ordering operator<=>(const unchecked_array_iterator& _Right) const noexcept {
         return _Myptr <=> _Right._Myptr;
     }
-#else // ^^^ _HAS_CXX20 ^^^ / vvv !_HAS_CXX20 vvv
+#else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
     _NODISCARD constexpr bool operator!=(const unchecked_array_iterator& _Right) const noexcept {
         return !(*this == _Right);
     }

--- a/stl/inc/iterator
+++ b/stl/inc/iterator
@@ -132,7 +132,7 @@ public:
 #ifdef __cpp_lib_concepts
     using difference_type = ptrdiff_t;
     using _Wrapped_iter   = ranges::iterator_t<_Container>;
-#else // ^^^ implementing Ranges // no Ranges vvv
+#else // ^^^ implementing Ranges / no Ranges vvv
     using difference_type = void;
     using _Wrapped_iter   = typename _Container::iterator;
 #endif // __cpp_lib_concepts

--- a/stl/inc/limits
+++ b/stl/inc/limits
@@ -19,7 +19,7 @@
 #if (defined(_M_ARM64) || defined(_M_ARM64EC)) && !defined(_M_CEE_PURE) && !defined(__CUDACC__) \
     && !defined(__INTEL_COMPILER) && !defined(__clang__) // TRANSITION, LLVM-51488
 #define _HAS_NEON_INTRINSICS 1
-#else // ^^^ intrinsics available ^^^ / vvv intrinsics unavailable vvv
+#else // ^^^ intrinsics available / intrinsics unavailable vvv
 #define _HAS_NEON_INTRINSICS 0
 #endif // ^^^ intrinsics unavailable ^^^
 
@@ -1054,7 +1054,7 @@ _NODISCARD constexpr int _Popcount_fallback(_Ty _Val) noexcept {
 #if (defined(_M_IX86) || (defined(_M_X64) && !defined(_M_ARM64EC))) && !defined(_M_CEE_PURE) && !defined(__CUDACC__) \
     && !defined(__INTEL_COMPILER)
 #define _HAS_TZCNT_BSF_INTRINSICS 1
-#else // ^^^ intrinsics available ^^^ / vvv intrinsics unavailable vvv
+#else // ^^^ intrinsics available / intrinsics unavailable vvv
 #define _HAS_TZCNT_BSF_INTRINSICS 0
 #endif // ^^^ intrinsics unavailable ^^^
 
@@ -1153,7 +1153,7 @@ _NODISCARD int _Checked_x86_x64_countr_zero(const _Ty _Val) noexcept {
 #if (defined(_M_IX86) || (defined(_M_X64) && !defined(_M_ARM64EC))) && !defined(_M_CEE_PURE) && !defined(__CUDACC__) \
     && !defined(__INTEL_COMPILER)
 #define _HAS_POPCNT_INTRINSICS 1
-#else // ^^^ intrinsics available ^^^ / vvv intrinsics unavailable vvv
+#else // ^^^ intrinsics available / intrinsics unavailable vvv
 #define _HAS_POPCNT_INTRINSICS 0
 #endif // ^^^ intrinsics unavailable ^^^
 
@@ -1217,7 +1217,7 @@ constexpr decltype(auto) _Select_countr_zero_impl(_Fn _Callback) {
     if (!_STD is_constant_evaluated()) {
 #ifdef __AVX2__
         return _Callback([](_Ty _Val) { return _Countr_zero_tzcnt(_Val); });
-#else // ^^^ AVX2 ^^^ / vvv not AVX2 vvv
+#else // ^^^ AVX2 / not AVX2 vvv
         const bool _Definitely_have_tzcnt = __isa_available >= __ISA_AVAILABLE_AVX2;
         if (_Definitely_have_tzcnt) {
             return _Callback([](_Ty _Val) { return _Countr_zero_tzcnt(_Val); });
@@ -1240,7 +1240,7 @@ _NODISCARD _CONSTEXPR20 int _Popcount(const _Ty _Val) noexcept {
     {
 #if _HAS_POPCNT_INTRINSICS
         return _Checked_x86_x64_popcount(_Val);
-#elif _HAS_NEON_INTRINSICS // ^^^ x86/x64 intrinsics available ^^^ / vvv ARM64 intrinsics available vvv
+#elif _HAS_NEON_INTRINSICS // ^^^ x86/x64 intrinsics available / ARM64 intrinsics available vvv
         return _Arm64_popcount(_Val);
 #endif // ^^^ ARM64 intrinsics available ^^^
     }
@@ -1264,7 +1264,7 @@ _CONSTEXPR20 decltype(auto) _Select_popcount_impl(_Fn _Callback) {
         }
 #endif // !defined(__AVX__)
         return _Callback([](_Ty _Val) { return _Unchecked_x86_x64_popcount(_Val); });
-#elif _HAS_NEON_INTRINSICS // ^^^ x86/x64 intrinsics available ^^^ / vvv ARM64 intrinsics available vvv
+#elif _HAS_NEON_INTRINSICS // ^^^ x86/x64 intrinsics available / ARM64 intrinsics available vvv
         return _Callback([](_Ty _Val) { return _Arm64_popcount(_Val); });
 #endif // ^^^ ARM64 intrinsics available ^^^
     }

--- a/stl/inc/list
+++ b/stl/inc/list
@@ -369,7 +369,7 @@ public:
                 *_Pnext             = *_Pnextnext;
             }
         }
-#else // ^^^ _ITERATOR_DEBUG_LEVEL == 2 ^^^ // vvv _ITERATOR_DEBUG_LEVEL != 2 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL == 2 ^^^ / vvv _ITERATOR_DEBUG_LEVEL != 2 vvv
         (void) _Ptr;
 #endif // _ITERATOR_DEBUG_LEVEL == 2
     }
@@ -981,7 +981,7 @@ public:
 
 #if _HAS_CXX17
         return _Result;
-#else // ^^^ _HAS_CXX17 // !_HAS_CXX17 vvv
+#else // ^^^ _HAS_CXX17 / !_HAS_CXX17 vvv
         (void) _Result;
 #endif // _HAS_CXX17
     }
@@ -992,7 +992,7 @@ public:
 
 #if _HAS_CXX17
         return _Result;
-#else // ^^^ _HAS_CXX17 // !_HAS_CXX17 vvv
+#else // ^^^ _HAS_CXX17 / !_HAS_CXX17 vvv
         (void) _Result;
 #endif // _HAS_CXX17
     }

--- a/stl/inc/list
+++ b/stl/inc/list
@@ -369,7 +369,7 @@ public:
                 *_Pnext             = *_Pnextnext;
             }
         }
-#else // ^^^ _ITERATOR_DEBUG_LEVEL == 2 ^^^ / vvv _ITERATOR_DEBUG_LEVEL != 2 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL == 2 / _ITERATOR_DEBUG_LEVEL != 2 vvv
         (void) _Ptr;
 #endif // _ITERATOR_DEBUG_LEVEL == 2
     }

--- a/stl/inc/new
+++ b/stl/inc/new
@@ -101,7 +101,7 @@ _NODISCARD_LAUNDER constexpr _Ty* launder(_Ty* _Ptr) noexcept {
 #if defined(_M_IX86) || defined(_M_X64) || defined(_M_ARM) || defined(_M_ARM64)
 _EXPORT_STD inline constexpr size_t hardware_constructive_interference_size = 64;
 _EXPORT_STD inline constexpr size_t hardware_destructive_interference_size  = 64;
-#else // ^^^ supported hardware ^^^ / vvv unsupported hardware vvv
+#else // ^^^ supported hardware / unsupported hardware vvv
 #error Unsupported architecture
 #endif // hardware
 

--- a/stl/inc/new
+++ b/stl/inc/new
@@ -101,7 +101,7 @@ _NODISCARD_LAUNDER constexpr _Ty* launder(_Ty* _Ptr) noexcept {
 #if defined(_M_IX86) || defined(_M_X64) || defined(_M_ARM) || defined(_M_ARM64)
 _EXPORT_STD inline constexpr size_t hardware_constructive_interference_size = 64;
 _EXPORT_STD inline constexpr size_t hardware_destructive_interference_size  = 64;
-#else // ^^^ supported hardware ^^^ // vvv unsupported hardware vvv
+#else // ^^^ supported hardware ^^^ / vvv unsupported hardware vvv
 #error Unsupported architecture
 #endif // hardware
 

--- a/stl/inc/numeric
+++ b/stl/inc/numeric
@@ -30,7 +30,7 @@ _NODISCARD _CONSTEXPR20 _Ty accumulate(const _InIt _First, const _InIt _Last, _T
     for (; _UFirst != _ULast; ++_UFirst) {
 #if _HAS_CXX20
         _Val = _Reduce_op(_STD move(_Val), *_UFirst);
-#else // ^^^ _HAS_CXX20 ^^^ // vvv !_HAS_CXX20 vvv
+#else // ^^^ _HAS_CXX20 ^^^ / vvv !_HAS_CXX20 vvv
         _Val = _Reduce_op(_Val, *_UFirst);
 #endif // _HAS_CXX20
     }
@@ -62,7 +62,7 @@ _Ty _Reduce_plus_arithmetic_ranges(_InIt _First, const _InIt _Last, _Ty _Val) {
 }
 #pragma float_control(pop)
 
-#else // ^^^ _STD_VECTORIZE_WITH_FLOAT_CONTROL ^^^ // vvv !_STD_VECTORIZE_WITH_FLOAT_CONTROL vvv
+#else // ^^^ _STD_VECTORIZE_WITH_FLOAT_CONTROL ^^^ / vvv !_STD_VECTORIZE_WITH_FLOAT_CONTROL vvv
 template <class _InIt, class _Ty, class _BinOp>
 inline constexpr bool _Plus_on_arithmetic_ranges_reduction_v = false;
 #endif // _STD_VECTORIZE_WITH_FLOAT_CONTROL
@@ -134,7 +134,7 @@ _NODISCARD _CONSTEXPR20 _Ty inner_product(
     for (; _UFirst1 != _ULast1; ++_UFirst1, (void) ++_UFirst2) {
 #if _HAS_CXX20
         _Val = _Reduce_op(_STD move(_Val), _Transform_op(*_UFirst1, *_UFirst2)); // Requirement missing from N4713
-#else // ^^^ _HAS_CXX20 ^^^ // vvv !_HAS_CXX20 vvv
+#else // ^^^ _HAS_CXX20 ^^^ / vvv !_HAS_CXX20 vvv
         _Val = _Reduce_op(_Val, _Transform_op(*_UFirst1, *_UFirst2)); // Requirement missing from N4713
 #endif // _HAS_CXX20
     }
@@ -167,7 +167,7 @@ _Ty _Transform_reduce_arithmetic_defaults(_InIt1 _First1, const _InIt1 _Last1, _
     return _Val;
 }
 #pragma float_control(pop)
-#else // ^^^ _STD_VECTORIZE_WITH_FLOAT_CONTROL ^^^ // vvv !_STD_VECTORIZE_WITH_FLOAT_CONTROL vvv
+#else // ^^^ _STD_VECTORIZE_WITH_FLOAT_CONTROL ^^^ / vvv !_STD_VECTORIZE_WITH_FLOAT_CONTROL vvv
 template <class _InIt1, class _InIt2, class _Ty, class _BinOp1, class _BinOp2>
 inline constexpr bool _Default_ops_transform_reduce_v = false;
 #endif // _STD_VECTORIZE_WITH_FLOAT_CONTROL
@@ -259,7 +259,7 @@ _CONSTEXPR20 _OutIt partial_sum(const _InIt _First, const _InIt _Last, _OutIt _D
             }
 #if _HAS_CXX20
             _Val = _Reduce_op(_STD move(_Val), *_UFirst);
-#else // ^^^ _HAS_CXX20 ^^^ // vvv !_HAS_CXX20 vvv
+#else // ^^^ _HAS_CXX20 ^^^ / vvv !_HAS_CXX20 vvv
             _Val      = _Reduce_op(_Val, *_UFirst);
 #endif // _HAS_CXX20
         }
@@ -483,7 +483,7 @@ _CONSTEXPR20 _OutIt adjacent_difference(const _InIt _First, const _InIt _Last, _
             _Iter_value_t<_InIt> _Tmp = *_UFirst;
 #if _HAS_CXX20
             *++_UDest = _Func(_Tmp, _STD move(_Val));
-#else // ^^^ _HAS_CXX20 ^^^ // vvv !_HAS_CXX20 vvv
+#else // ^^^ _HAS_CXX20 ^^^ / vvv !_HAS_CXX20 vvv
             *++_UDest = _Func(_Tmp, _Val);
 #endif // _HAS_CXX20
             _Val = _STD move(_Tmp);

--- a/stl/inc/numeric
+++ b/stl/inc/numeric
@@ -30,7 +30,7 @@ _NODISCARD _CONSTEXPR20 _Ty accumulate(const _InIt _First, const _InIt _Last, _T
     for (; _UFirst != _ULast; ++_UFirst) {
 #if _HAS_CXX20
         _Val = _Reduce_op(_STD move(_Val), *_UFirst);
-#else // ^^^ _HAS_CXX20 ^^^ / vvv !_HAS_CXX20 vvv
+#else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
         _Val = _Reduce_op(_Val, *_UFirst);
 #endif // _HAS_CXX20
     }
@@ -62,7 +62,7 @@ _Ty _Reduce_plus_arithmetic_ranges(_InIt _First, const _InIt _Last, _Ty _Val) {
 }
 #pragma float_control(pop)
 
-#else // ^^^ _STD_VECTORIZE_WITH_FLOAT_CONTROL ^^^ / vvv !_STD_VECTORIZE_WITH_FLOAT_CONTROL vvv
+#else // ^^^ _STD_VECTORIZE_WITH_FLOAT_CONTROL / !_STD_VECTORIZE_WITH_FLOAT_CONTROL vvv
 template <class _InIt, class _Ty, class _BinOp>
 inline constexpr bool _Plus_on_arithmetic_ranges_reduction_v = false;
 #endif // _STD_VECTORIZE_WITH_FLOAT_CONTROL
@@ -134,7 +134,7 @@ _NODISCARD _CONSTEXPR20 _Ty inner_product(
     for (; _UFirst1 != _ULast1; ++_UFirst1, (void) ++_UFirst2) {
 #if _HAS_CXX20
         _Val = _Reduce_op(_STD move(_Val), _Transform_op(*_UFirst1, *_UFirst2)); // Requirement missing from N4713
-#else // ^^^ _HAS_CXX20 ^^^ / vvv !_HAS_CXX20 vvv
+#else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
         _Val = _Reduce_op(_Val, _Transform_op(*_UFirst1, *_UFirst2)); // Requirement missing from N4713
 #endif // _HAS_CXX20
     }
@@ -167,7 +167,7 @@ _Ty _Transform_reduce_arithmetic_defaults(_InIt1 _First1, const _InIt1 _Last1, _
     return _Val;
 }
 #pragma float_control(pop)
-#else // ^^^ _STD_VECTORIZE_WITH_FLOAT_CONTROL ^^^ / vvv !_STD_VECTORIZE_WITH_FLOAT_CONTROL vvv
+#else // ^^^ _STD_VECTORIZE_WITH_FLOAT_CONTROL / !_STD_VECTORIZE_WITH_FLOAT_CONTROL vvv
 template <class _InIt1, class _InIt2, class _Ty, class _BinOp1, class _BinOp2>
 inline constexpr bool _Default_ops_transform_reduce_v = false;
 #endif // _STD_VECTORIZE_WITH_FLOAT_CONTROL
@@ -259,7 +259,7 @@ _CONSTEXPR20 _OutIt partial_sum(const _InIt _First, const _InIt _Last, _OutIt _D
             }
 #if _HAS_CXX20
             _Val = _Reduce_op(_STD move(_Val), *_UFirst);
-#else // ^^^ _HAS_CXX20 ^^^ / vvv !_HAS_CXX20 vvv
+#else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
             _Val      = _Reduce_op(_Val, *_UFirst);
 #endif // _HAS_CXX20
         }
@@ -483,7 +483,7 @@ _CONSTEXPR20 _OutIt adjacent_difference(const _InIt _First, const _InIt _Last, _
             _Iter_value_t<_InIt> _Tmp = *_UFirst;
 #if _HAS_CXX20
             *++_UDest = _Func(_Tmp, _STD move(_Val));
-#else // ^^^ _HAS_CXX20 ^^^ / vvv !_HAS_CXX20 vvv
+#else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
             *++_UDest = _Func(_Tmp, _Val);
 #endif // _HAS_CXX20
             _Val = _STD move(_Tmp);

--- a/stl/inc/scoped_allocator
+++ b/stl/inc/scoped_allocator
@@ -233,7 +233,7 @@ public:
                     _Scoped_outermost(*this), _Ptr, _STD forward<decltype(_New_args)>(_New_args)...);
             },
             _STD uses_allocator_construction_args<_Ty>(inner_allocator(), _STD forward<_Types>(_Args)...));
-#else // ^^^ _HAS_CXX20 ^^^ / vvv !_HAS_CXX20 vvv
+#else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
         _Uses_allocator_construct(_Ptr, _Scoped_outermost(*this), inner_allocator(), _STD forward<_Types>(_Args)...);
 #endif // ^^^ !_HAS_CXX20 ^^^
     }

--- a/stl/inc/span
+++ b/stl/inc/span
@@ -606,7 +606,7 @@ public:
     _NODISCARD constexpr iterator begin() const noexcept {
 #if _ITERATOR_DEBUG_LEVEL >= 1
         return {_Mydata, _Mydata, _Mydata + _Mysize};
-#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 ^^^ // vvv _ITERATOR_DEBUG_LEVEL == 0 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 ^^^ / vvv _ITERATOR_DEBUG_LEVEL == 0 vvv
         return {_Mydata};
 #endif // _ITERATOR_DEBUG_LEVEL
     }
@@ -615,7 +615,7 @@ public:
         const auto _End = _Mydata + _Mysize;
 #if _ITERATOR_DEBUG_LEVEL >= 1
         return {_End, _Mydata, _End};
-#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 ^^^ // vvv _ITERATOR_DEBUG_LEVEL == 0 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 ^^^ / vvv _ITERATOR_DEBUG_LEVEL == 0 vvv
         return {_End};
 #endif // _ITERATOR_DEBUG_LEVEL
     }

--- a/stl/inc/span
+++ b/stl/inc/span
@@ -606,7 +606,7 @@ public:
     _NODISCARD constexpr iterator begin() const noexcept {
 #if _ITERATOR_DEBUG_LEVEL >= 1
         return {_Mydata, _Mydata, _Mydata + _Mysize};
-#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 ^^^ / vvv _ITERATOR_DEBUG_LEVEL == 0 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 / _ITERATOR_DEBUG_LEVEL == 0 vvv
         return {_Mydata};
 #endif // _ITERATOR_DEBUG_LEVEL
     }
@@ -615,7 +615,7 @@ public:
         const auto _End = _Mydata + _Mysize;
 #if _ITERATOR_DEBUG_LEVEL >= 1
         return {_End, _Mydata, _End};
-#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 ^^^ / vvv _ITERATOR_DEBUG_LEVEL == 0 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 / _ITERATOR_DEBUG_LEVEL == 0 vvv
         return {_End};
 #endif // _ITERATOR_DEBUG_LEVEL
     }

--- a/stl/inc/stacktrace
+++ b/stl/inc/stacktrace
@@ -267,7 +267,7 @@ public:
 
 #ifdef __cpp_lib_concepts
         return _STD lexicographical_compare_three_way(_Lhs.begin(), _Lhs.end(), _Rhs.begin(), _Rhs.end());
-#else // ^^^ __cpp_lib_concepts ^^^ / vvv !__cpp_lib_concepts vvv
+#else // ^^^ __cpp_lib_concepts / !__cpp_lib_concepts vvv
         for (size_t _Ix = 0, _Mx = _Lhs._Frames.size(); _Ix != _Mx; ++_Ix) {
             if (_Lhs._Frames[_Ix] != _Rhs._Frames[_Ix]) {
                 return _Lhs._Frames[_Ix] <=> _Rhs._Frames[_Ix];

--- a/stl/inc/string
+++ b/stl/inc/string
@@ -445,7 +445,7 @@ _NODISCARD _Elem* _UIntegral_to_buff(_Elem* _RNext, _UTy _UVal) {
 
 #ifdef _WIN64
     auto _UVal_trunc = _UVal;
-#else // ^^^ _WIN64 ^^^ / vvv !_WIN64 vvv
+#else // ^^^ _WIN64 / !_WIN64 vvv
 
     constexpr bool _Big_uty = sizeof(_UTy) > 4;
     if constexpr (_Big_uty) { // For 64-bit numbers, work in chunks to avoid 64-bit divisions.

--- a/stl/inc/string
+++ b/stl/inc/string
@@ -445,7 +445,7 @@ _NODISCARD _Elem* _UIntegral_to_buff(_Elem* _RNext, _UTy _UVal) {
 
 #ifdef _WIN64
     auto _UVal_trunc = _UVal;
-#else // ^^^ _WIN64 ^^^ // vvv !_WIN64 vvv
+#else // ^^^ _WIN64 ^^^ / vvv !_WIN64 vvv
 
     constexpr bool _Big_uty = sizeof(_UTy) > 4;
     if constexpr (_Big_uty) { // For 64-bit numbers, work in chunks to avoid 64-bit divisions.

--- a/stl/inc/system_error
+++ b/stl/inc/system_error
@@ -339,7 +339,7 @@ private:
 _NODISCARD inline bool _System_error_equal(const error_code& _Left, const error_condition& _Right) noexcept {
     return _Left.category().equivalent(_Left.value(), _Right) || _Right.category().equivalent(_Left, _Right.value());
 }
-#else // ^^^ _STL_OPTIMIZE_SYSTEM_ERROR_OPERATORS // !_STL_OPTIMIZE_SYSTEM_ERROR_OPERATORS vvv
+#else // ^^^ _STL_OPTIMIZE_SYSTEM_ERROR_OPERATORS / !_STL_OPTIMIZE_SYSTEM_ERROR_OPERATORS vvv
 _EXPORT_STD _NODISCARD inline bool operator==(const error_code& _Left, const error_code& _Right) noexcept {
     return _Left.category() == _Right.category() && _Left.value() == _Right.value();
 }

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -448,7 +448,7 @@ _NON_MEMBER_CALL(_IS_MEMFUNPTR_EXPLICIT_THIS_GUIDES, , , noexcept)
 #ifdef __clang__
 _EXPORT_STD template <class _Ty>
 _INLINE_VAR constexpr bool is_member_function_pointer_v = __is_member_function_pointer(_Ty);
-#else // ^^^ Clang ^^^ / vvv Other vvv
+#else // ^^^ Clang / Other vvv
 _EXPORT_STD template <class _Ty>
 _INLINE_VAR constexpr bool is_member_function_pointer_v = _Is_memfunptr<remove_cv_t<_Ty>>::_Bool_type::value;
 #endif // ^^^ Other ^^^

--- a/stl/inc/variant
+++ b/stl/inc/variant
@@ -374,7 +374,7 @@ struct variant_alternative<_Idx, variant<_Types...>> {
 
 #ifdef __clang__
     using type = __type_pack_element<_Idx, _Types...>;
-#else // ^^^ __clang__ ^^^ / vvv !__clang__ vvv
+#else // ^^^ __clang__ / !__clang__ vvv
     using type = _Meta_at_c<variant<_Types...>, _Idx>;
 #endif // __clang__
 };
@@ -1121,7 +1121,7 @@ public:
                             constexpr size_t _That_idx = decltype(_That_ref)::_Idx;
 #ifdef __EDG__ // TRANSITION, VSO-657455
                             constexpr size_t _My_idx   = decltype(_My_ref)::_Idx + 0 * _That_idx;
-#else // ^^^ workaround ^^^ / vvv no workaround vvv
+#else // ^^^ workaround / no workaround vvv
                             constexpr size_t _My_idx = decltype(_My_ref)::_Idx;
 #endif // TRANSITION, VSO-657455
                             if constexpr (_My_idx == _That_idx) { // Same alternatives...
@@ -1139,7 +1139,7 @@ public:
 #ifdef __EDG__ // TRANSITION, VSO-657455
                                 using _Workaround = enable_if_t<_That_idx != variant_npos, decltype(_My_ref._Val)>;
                                 auto _Tmp         = _STD move(static_cast<_Workaround>(_My_ref._Val));
-#else // ^^^ workaround ^^^ / vvv no workaround vvv
+#else // ^^^ workaround / no workaround vvv
                                 auto _Tmp = _STD move(_My_ref._Val);
 #endif // TRANSITION, VSO-657455
                                 this->template _Reset<_My_idx>();

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -101,7 +101,7 @@ public:
     _CONSTEXPR20 void _Verify_offset(const difference_type _Off) const noexcept {
 #if _ITERATOR_DEBUG_LEVEL == 0
         (void) _Off;
-#else // ^^^ _ITERATOR_DEBUG_LEVEL == 0 ^^^ / vvv _ITERATOR_DEBUG_LEVEL != 0 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL == 0 / _ITERATOR_DEBUG_LEVEL != 0 vvv
         const auto _Mycont = static_cast<const _Myvec*>(this->_Getcont());
         _STL_VERIFY(_Off == 0 || _Ptr, "cannot seek value-initialized vector iterator");
         if (_Off < 0) {
@@ -161,7 +161,7 @@ public:
         _Compat(_Right);
         return _Unfancy(_Ptr) <=> _Unfancy(_Right._Ptr);
     }
-#else // ^^^ _HAS_CXX20 ^^^ / vvv !_HAS_CXX20 vvv
+#else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
     _NODISCARD bool operator!=(const _Vector_const_iterator& _Right) const noexcept {
         return !(*this == _Right);
     }
@@ -188,7 +188,7 @@ public:
         // test for compatible iterator pair
 #if _ITERATOR_DEBUG_LEVEL == 0
         (void) _Right;
-#else // ^^^ _ITERATOR_DEBUG_LEVEL == 0 ^^^ / vvv _ITERATOR_DEBUG_LEVEL != 0 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL == 0 / _ITERATOR_DEBUG_LEVEL != 0 vvv
         _STL_VERIFY(this->_Getcont() == _Right._Getcont(), "vector iterators incompatible");
 #endif // _ITERATOR_DEBUG_LEVEL == 0
     }
@@ -430,13 +430,13 @@ constexpr _Ty* _Unfancy_maybe_null(_Ty* _Ptr) noexcept { // do nothing for plain
 #if defined(__SANITIZE_ADDRESS__)
 #define _ACTIVATE_VECTOR_ANNOTATION
 #define _INSERT_VECTOR_ANNOTATION
-#elif defined(__clang__) && defined(__has_feature) // ^^^ __SANITIZE_ADDRESS__ ^^^ / vvv __clang__ vvv
+#elif defined(__clang__) && defined(__has_feature) // ^^^ __SANITIZE_ADDRESS__ / __clang__ vvv
 #if __has_feature(address_sanitizer)
 #define _ACTIVATE_VECTOR_ANNOTATION
 #define _INSERT_VECTOR_ANNOTATION
 #pragma comment(linker, "/INFERASANLIBS")
 #endif // __has_feature(address_sanitizer)
-#elif defined(_ANNOTATE_VECTOR) // ^^^ __clang__ ^^^ / vvv _ANNOTATE_VECTOR vvv
+#elif defined(_ANNOTATE_VECTOR) // ^^^ __clang__ / _ANNOTATE_VECTOR vvv
 #define _INSERT_VECTOR_ANNOTATION
 #endif // _ANNOTATE_VECTOR
 #endif // !_M_CEE_PURE && !_DISABLE_VECTOR_ANNOTATION
@@ -486,7 +486,7 @@ template <class _Vec>
 _INLINE_VAR constexpr bool
     _Has_minimum_allocation_alignment<_Vec, void_t<decltype(_Vec::allocator_type::_Minimum_allocation_alignment)>> =
         _Vec::allocator_type::_Minimum_allocation_alignment >= _Asan_granularity;
-#else // ^^^ _INSERT_VECTOR_ANNOTATION ^^^ / vvv !_INSERT_VECTOR_ANNOTATION vvv
+#else // ^^^ _INSERT_VECTOR_ANNOTATION / !_INSERT_VECTOR_ANNOTATION vvv
 #pragma detect_mismatch("annotate_vector", "0")
 #endif // !_INSERT_VECTOR_ANNOTATION
 
@@ -652,7 +652,7 @@ private:
 #define _ASAN_VECTOR_CREATE_GUARD    _Asan_create_guard _Annotator(*this)
 #define _ASAN_VECTOR_EXTEND_GUARD(n) _Asan_extend_guard _Annotator(this, (n))
 #define _ASAN_VECTOR_RELEASE_GUARD   _Annotator._Release()
-#else // ^^^ _INSERT_VECTOR_ANNOTATION ^^^ / vvv !_INSERT_VECTOR_ANNOTATION vvv
+#else // ^^^ _INSERT_VECTOR_ANNOTATION / !_INSERT_VECTOR_ANNOTATION vvv
 #define _ASAN_VECTOR_MODIFY(n)
 #define _ASAN_VECTOR_REMOVE
 #define _ASAN_VECTOR_CREATE
@@ -927,7 +927,7 @@ public:
         _Ty& _Result = _Emplace_one_at_back(_STD forward<_Valty>(_Val)...);
 #if _HAS_CXX17
         return _Result;
-#else // ^^^ _HAS_CXX17 ^^^ / vvv !_HAS_CXX17 vvv
+#else // ^^^ _HAS_CXX17 / !_HAS_CXX17 vvv
         (void) _Result;
 #endif // _HAS_CXX17
     }
@@ -2236,7 +2236,7 @@ private:
             _Orphan_range_locked(_First, _Last);
         }
     }
-#else // ^^^ _ITERATOR_DEBUG_LEVEL == 2 ^^^ / vvv _ITERATOR_DEBUG_LEVEL != 2 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL == 2 / _ITERATOR_DEBUG_LEVEL != 2 vvv
     _CONSTEXPR20 void _Orphan_range(pointer, pointer) const {}
 #endif // _ITERATOR_DEBUG_LEVEL != 2
 
@@ -2668,7 +2668,7 @@ public:
         }
         return this->_Myoff <=> _Right._Myoff;
     }
-#else // ^^^ _HAS_CXX20 ^^^ / vvv !_HAS_CXX20 vvv
+#else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
     _NODISCARD bool operator!=(const _Vb_const_iterator& _Right) const noexcept {
         return !(*this == _Right);
     }
@@ -3005,7 +3005,7 @@ public:
 #if _ITERATOR_DEBUG_LEVEL == 0
         this->_Myvec  = _STD move(_Right._Myvec);
         this->_Mysize = _STD exchange(_Right._Mysize, size_type{0});
-#else // ^^^ _ITERATOR_DEBUG_LEVEL == 0 ^^^ / vvv _ITERATOR_DEBUG_LEVEL != 0 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL == 0 / _ITERATOR_DEBUG_LEVEL != 0 vvv
         this->_Orphan_all();
         auto& _Al = this->_Getal();
         auto& _Right_al = _Right._Getal();
@@ -3088,7 +3088,7 @@ public:
 #if _ITERATOR_DEBUG_LEVEL == 0
         this->_Myvec  = _Right._Myvec;
         this->_Mysize = _Right._Mysize;
-#else // ^^^ _ITERATOR_DEBUG_LEVEL == 0 ^^^ / vvv _ITERATOR_DEBUG_LEVEL != 0 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL == 0 / _ITERATOR_DEBUG_LEVEL != 0 vvv
         this->_Orphan_all();
         auto& _Al = this->_Getal();
         auto& _Right_al = _Right._Getal();

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -101,7 +101,7 @@ public:
     _CONSTEXPR20 void _Verify_offset(const difference_type _Off) const noexcept {
 #if _ITERATOR_DEBUG_LEVEL == 0
         (void) _Off;
-#else // ^^^ _ITERATOR_DEBUG_LEVEL == 0 ^^^ // vvv _ITERATOR_DEBUG_LEVEL != 0 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL == 0 ^^^ / vvv _ITERATOR_DEBUG_LEVEL != 0 vvv
         const auto _Mycont = static_cast<const _Myvec*>(this->_Getcont());
         _STL_VERIFY(_Off == 0 || _Ptr, "cannot seek value-initialized vector iterator");
         if (_Off < 0) {
@@ -188,7 +188,7 @@ public:
         // test for compatible iterator pair
 #if _ITERATOR_DEBUG_LEVEL == 0
         (void) _Right;
-#else // ^^^ _ITERATOR_DEBUG_LEVEL == 0 ^^^ // vvv _ITERATOR_DEBUG_LEVEL != 0 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL == 0 ^^^ / vvv _ITERATOR_DEBUG_LEVEL != 0 vvv
         _STL_VERIFY(this->_Getcont() == _Right._Getcont(), "vector iterators incompatible");
 #endif // _ITERATOR_DEBUG_LEVEL == 0
     }
@@ -430,13 +430,13 @@ constexpr _Ty* _Unfancy_maybe_null(_Ty* _Ptr) noexcept { // do nothing for plain
 #if defined(__SANITIZE_ADDRESS__)
 #define _ACTIVATE_VECTOR_ANNOTATION
 #define _INSERT_VECTOR_ANNOTATION
-#elif defined(__clang__) && defined(__has_feature) // ^^^ __SANITIZE_ADDRESS__ ^^^ // vvv __clang__ vvv
+#elif defined(__clang__) && defined(__has_feature) // ^^^ __SANITIZE_ADDRESS__ ^^^ / vvv __clang__ vvv
 #if __has_feature(address_sanitizer)
 #define _ACTIVATE_VECTOR_ANNOTATION
 #define _INSERT_VECTOR_ANNOTATION
 #pragma comment(linker, "/INFERASANLIBS")
 #endif // __has_feature(address_sanitizer)
-#elif defined(_ANNOTATE_VECTOR) // ^^^ __clang__ ^^^ // vvv _ANNOTATE_VECTOR vvv
+#elif defined(_ANNOTATE_VECTOR) // ^^^ __clang__ ^^^ / vvv _ANNOTATE_VECTOR vvv
 #define _INSERT_VECTOR_ANNOTATION
 #endif // _ANNOTATE_VECTOR
 #endif // !_M_CEE_PURE && !_DISABLE_VECTOR_ANNOTATION
@@ -486,7 +486,7 @@ template <class _Vec>
 _INLINE_VAR constexpr bool
     _Has_minimum_allocation_alignment<_Vec, void_t<decltype(_Vec::allocator_type::_Minimum_allocation_alignment)>> =
         _Vec::allocator_type::_Minimum_allocation_alignment >= _Asan_granularity;
-#else // ^^^ _INSERT_VECTOR_ANNOTATION ^^^ // vvv !_INSERT_VECTOR_ANNOTATION vvv
+#else // ^^^ _INSERT_VECTOR_ANNOTATION ^^^ / vvv !_INSERT_VECTOR_ANNOTATION vvv
 #pragma detect_mismatch("annotate_vector", "0")
 #endif // !_INSERT_VECTOR_ANNOTATION
 
@@ -652,7 +652,7 @@ private:
 #define _ASAN_VECTOR_CREATE_GUARD    _Asan_create_guard _Annotator(*this)
 #define _ASAN_VECTOR_EXTEND_GUARD(n) _Asan_extend_guard _Annotator(this, (n))
 #define _ASAN_VECTOR_RELEASE_GUARD   _Annotator._Release()
-#else // ^^^ _INSERT_VECTOR_ANNOTATION ^^^ // vvv !_INSERT_VECTOR_ANNOTATION vvv
+#else // ^^^ _INSERT_VECTOR_ANNOTATION ^^^ / vvv !_INSERT_VECTOR_ANNOTATION vvv
 #define _ASAN_VECTOR_MODIFY(n)
 #define _ASAN_VECTOR_REMOVE
 #define _ASAN_VECTOR_CREATE
@@ -927,7 +927,7 @@ public:
         _Ty& _Result = _Emplace_one_at_back(_STD forward<_Valty>(_Val)...);
 #if _HAS_CXX17
         return _Result;
-#else // ^^^ _HAS_CXX17 ^^^ // vvv !_HAS_CXX17 vvv
+#else // ^^^ _HAS_CXX17 ^^^ / vvv !_HAS_CXX17 vvv
         (void) _Result;
 #endif // _HAS_CXX17
     }
@@ -2236,7 +2236,7 @@ private:
             _Orphan_range_locked(_First, _Last);
         }
     }
-#else // ^^^ _ITERATOR_DEBUG_LEVEL == 2 ^^^ // vvv _ITERATOR_DEBUG_LEVEL != 2 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL == 2 ^^^ / vvv _ITERATOR_DEBUG_LEVEL != 2 vvv
     _CONSTEXPR20 void _Orphan_range(pointer, pointer) const {}
 #endif // _ITERATOR_DEBUG_LEVEL != 2
 
@@ -3005,7 +3005,7 @@ public:
 #if _ITERATOR_DEBUG_LEVEL == 0
         this->_Myvec  = _STD move(_Right._Myvec);
         this->_Mysize = _STD exchange(_Right._Mysize, size_type{0});
-#else // ^^^ _ITERATOR_DEBUG_LEVEL == 0 ^^^ // vvv _ITERATOR_DEBUG_LEVEL != 0 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL == 0 ^^^ / vvv _ITERATOR_DEBUG_LEVEL != 0 vvv
         this->_Orphan_all();
         auto& _Al = this->_Getal();
         auto& _Right_al = _Right._Getal();
@@ -3088,7 +3088,7 @@ public:
 #if _ITERATOR_DEBUG_LEVEL == 0
         this->_Myvec  = _Right._Myvec;
         this->_Mysize = _Right._Mysize;
-#else // ^^^ _ITERATOR_DEBUG_LEVEL == 0 ^^^ // vvv _ITERATOR_DEBUG_LEVEL != 0 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL == 0 ^^^ / vvv _ITERATOR_DEBUG_LEVEL != 0 vvv
         this->_Orphan_all();
         auto& _Al = this->_Getal();
         auto& _Right_al = _Right._Getal();

--- a/stl/inc/xbit_ops.h
+++ b/stl/inc/xbit_ops.h
@@ -28,7 +28,7 @@ _NODISCARD inline unsigned long _Floor_of_log_2(size_t _Value) noexcept { // ret
 #ifdef _M_CEE_PURE
 #ifdef _WIN64
     _Result = 63;
-#else // ^^^ 64-bit ^^^ / vvv 32-bit vvv
+#else // ^^^ 64-bit / 32-bit vvv
     _Result = 31;
 #endif // 64 vs. 32-bit
 
@@ -36,10 +36,10 @@ _NODISCARD inline unsigned long _Floor_of_log_2(size_t _Value) noexcept { // ret
         --_Result;
     }
 
-#else // ^^^ _M_CEE_PURE ^^^ / vvv !_M_CEE_PURE vvv
+#else // ^^^ _M_CEE_PURE / !_M_CEE_PURE vvv
 #ifdef _WIN64
     _BitScanReverse64(&_Result, _Value);
-#else // ^^^ 64-bit ^^^ / vvv 32-bit vvv
+#else // ^^^ 64-bit / 32-bit vvv
     _BitScanReverse(&_Result, _Value);
 #endif // 64 vs. 32-bit
 #endif // _M_CEE_PURE
@@ -69,7 +69,7 @@ _NODISCARD inline uint32_t _Bit_scan_reverse(const uint64_t _Value) noexcept {
     if (_BitScanReverse64(&_Index, _Value)) {
         return _Index + 1;
     }
-#else // ^^^ 64-bit ^^^ / vvv 32-bit vvv
+#else // ^^^ 64-bit / 32-bit vvv
     uint32_t _Ui32 = static_cast<uint32_t>(_Value >> 32);
 
     if (_BitScanReverse(&_Index, _Ui32)) {

--- a/stl/inc/xbit_ops.h
+++ b/stl/inc/xbit_ops.h
@@ -36,7 +36,7 @@ _NODISCARD inline unsigned long _Floor_of_log_2(size_t _Value) noexcept { // ret
         --_Result;
     }
 
-#else // ^^^ _M_CEE_PURE ^^^ // vvv !_M_CEE_PURE vvv
+#else // ^^^ _M_CEE_PURE ^^^ / vvv !_M_CEE_PURE vvv
 #ifdef _WIN64
     _BitScanReverse64(&_Result, _Value);
 #else // ^^^ 64-bit ^^^ / vvv 32-bit vvv

--- a/stl/inc/xcharconv_ryu.h
+++ b/stl/inc/xcharconv_ryu.h
@@ -47,7 +47,7 @@
 
 #if defined(_M_X64) && !defined(_M_ARM64EC)
 #define _HAS_CHARCONV_INTRINSICS 1
-#else // ^^^ intrinsics available ^^^ / vvv intrinsics unavailable vvv
+#else // ^^^ intrinsics available / intrinsics unavailable vvv
 #define _HAS_CHARCONV_INTRINSICS 0
 #endif // ^^^ intrinsics unavailable ^^^
 
@@ -161,7 +161,7 @@ _NODISCARD inline uint64_t __ryu_shiftright128(const uint64_t __lo, const uint64
   return __shiftright128(__lo, __hi, static_cast<unsigned char>(__dist));
 }
 
-#else // ^^^ intrinsics available ^^^ / vvv intrinsics unavailable vvv
+#else // ^^^ intrinsics available / intrinsics unavailable vvv
 
 _NODISCARD __forceinline uint64_t __ryu_umul128(const uint64_t __a, const uint64_t __b, uint64_t* const __productHi) {
   // TRANSITION, VSO-634761
@@ -200,7 +200,7 @@ _NODISCARD inline uint64_t __ryu_shiftright128(const uint64_t __lo, const uint64
 #ifdef _WIN64
   _STL_INTERNAL_CHECK(__dist > 0);
   return (__hi << (64 - __dist)) | (__lo >> __dist);
-#else // ^^^ 64-bit ^^^ / vvv 32-bit vvv
+#else // ^^^ 64-bit / 32-bit vvv
   // Avoid a 64-bit shift by taking advantage of the range of shift values.
   _STL_INTERNAL_CHECK(__dist >= 32);
   return (__hi << (64 - __dist)) | (static_cast<uint32_t>(__lo >> 32) >> (__dist - 32));
@@ -266,7 +266,7 @@ _NODISCARD inline uint32_t __mod1e9(const uint64_t __x) {
   return static_cast<uint32_t>(__x) - 1000000000 * static_cast<uint32_t>(__div1e9(__x));
 }
 
-#else // ^^^ 32-bit ^^^ / vvv 64-bit vvv
+#else // ^^^ 32-bit / 64-bit vvv
 
 _NODISCARD inline uint64_t __div5(const uint64_t __x) {
   return __x / 5;
@@ -383,7 +383,7 @@ _NODISCARD inline uint32_t __mulShift_mod1e9(const uint64_t __m, const uint64_t*
   const uint64_t __shiftedhigh = __s1high >> __dist;
   const uint64_t __shiftedlow = __ryu_shiftright128(__s1low, __s1high, __dist);
   return __uint128_mod1e9(__shiftedhigh, __shiftedlow);
-#else // ^^^ intrinsics available ^^^ / vvv intrinsics unavailable vvv
+#else // ^^^ intrinsics available / intrinsics unavailable vvv
   if (__j < 160) { // __j: [128, 160)
     const uint64_t __r0 = __mod1e9(__s1high);
     const uint64_t __r1 = __mod1e9((__r0 << 32) | (__s1low >> 32));
@@ -1027,7 +1027,7 @@ _NODISCARD inline uint32_t __mulShift(const uint32_t __m, const uint64_t __facto
   __bits1Hi += (__bits1Lo < __bits0Hi);
   const int32_t __s = __shift - 32;
   return (__bits1Hi << (32 - __s)) | (__bits1Lo >> __s);
-#else // ^^^ 32-bit ^^^ / vvv 64-bit vvv
+#else // ^^^ 32-bit / 64-bit vvv
   const uint64_t __sum = (__bits0 >> 32) + __bits1;
   const uint64_t __shiftedSum = __sum >> (__shift - 32);
   _STL_INTERNAL_CHECK(__shiftedSum <= UINT32_MAX);
@@ -1681,7 +1681,7 @@ _NODISCARD inline uint64_t __mulShiftAll(const uint64_t __m, const uint64_t* con
   return __mulShift(4 * __m, __mul, __j);
 }
 
-#else // ^^^ intrinsics available ^^^ / vvv intrinsics unavailable vvv
+#else // ^^^ intrinsics available / intrinsics unavailable vvv
 
 _NODISCARD __forceinline uint64_t __mulShiftAll(uint64_t __m, const uint64_t* const __mul, const int32_t __j,
   uint64_t* const __vp, uint64_t* const __vm, const uint32_t __mmShift) { // TRANSITION, VSO-634761
@@ -2050,7 +2050,7 @@ _NODISCARD pair<_CharT*, errc> __to_chars(_CharT* const _First, _CharT* const _L
         unsigned long _Trailing_zero_bits;
 #ifdef _WIN64
         (void) _BitScanForward64(&_Trailing_zero_bits, __v.__mantissa); // __v.__mantissa is guaranteed nonzero
-#else // ^^^ 64-bit ^^^ / vvv 32-bit vvv
+#else // ^^^ 64-bit / 32-bit vvv
         const uint32_t _Low_mantissa = static_cast<uint32_t>(__v.__mantissa);
         if (_Low_mantissa != 0) {
           (void) _BitScanForward(&_Trailing_zero_bits, _Low_mantissa);

--- a/stl/inc/xhash
+++ b/stl/inc/xhash
@@ -999,7 +999,7 @@ private:
         _Mylist& _List;
         const _Nodeptr _First;
         _Nodeptr _Next;
-#else // ^^^ _ITERATOR_DEBUG_LEVEL == 2 // _ITERATOR_DEBUG_LEVEL != 2 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL == 2 / _ITERATOR_DEBUG_LEVEL != 2 vvv
       // Destroy the nodes as we encounter them to avoid a second traversal of the linked list.
         _Range_eraser(_Mylist& _List_, const _Nodeptr _First_) noexcept
             : _List(_List_), _Predecessor(_First_->_Prev), _Next(_First_) {}

--- a/stl/inc/xlocnum
+++ b/stl/inc/xlocnum
@@ -626,7 +626,7 @@ protected:
             char* _Ep;
 #ifdef _WIN64
             _Val = reinterpret_cast<void*>(_CSTD _Stoullx(_Ac, &_Ep, _Base, &_Errno));
-#else // ^^^ _WIN64 ^^^ // vvv !_WIN64 vvv
+#else // ^^^ _WIN64 ^^^ / vvv !_WIN64 vvv
             _Val = reinterpret_cast<void*>(_CSTD _Stoulx(_Ac, &_Ep, _Base, &_Errno));
 #endif // _WIN64
             if (_Ep == _Ac || _Errno != 0) {

--- a/stl/inc/xlocnum
+++ b/stl/inc/xlocnum
@@ -626,7 +626,7 @@ protected:
             char* _Ep;
 #ifdef _WIN64
             _Val = reinterpret_cast<void*>(_CSTD _Stoullx(_Ac, &_Ep, _Base, &_Errno));
-#else // ^^^ _WIN64 ^^^ / vvv !_WIN64 vvv
+#else // ^^^ _WIN64 / !_WIN64 vvv
             _Val = reinterpret_cast<void*>(_CSTD _Stoulx(_Ac, &_Ep, _Base, &_Errno));
 #endif // _WIN64
             if (_Ep == _Ac || _Errno != 0) {

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -119,7 +119,7 @@ _INLINE_VAR constexpr size_t _Non_user_size           = sizeof(void*) + _Big_all
 
 #ifdef _WIN64
 _INLINE_VAR constexpr size_t _Big_allocation_sentinel = 0xFAFAFAFAFAFAFAFAULL;
-#else // ^^^ _WIN64 ^^^ // vvv !_WIN64 vvv
+#else // ^^^ _WIN64 ^^^ / vvv !_WIN64 vvv
 _INLINE_VAR constexpr size_t _Big_allocation_sentinel = 0xFAFAFAFAUL;
 #endif // _WIN64
 
@@ -157,7 +157,7 @@ inline void _Adjust_manually_vector_aligned(void*& _Ptr, size_t& _Bytes) {
     // in range [_Min_back_shift, _Non_user_size]
 #ifdef _DEBUG
     constexpr uintptr_t _Min_back_shift = 2 * sizeof(void*);
-#else // ^^^ _DEBUG ^^^ // vvv !_DEBUG vvv
+#else // ^^^ _DEBUG ^^^ / vvv !_DEBUG vvv
     constexpr uintptr_t _Min_back_shift = sizeof(void*);
 #endif // _DEBUG
     const uintptr_t _Back_shift = reinterpret_cast<uintptr_t>(_Ptr) - _Ptr_container;

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -119,7 +119,7 @@ _INLINE_VAR constexpr size_t _Non_user_size           = sizeof(void*) + _Big_all
 
 #ifdef _WIN64
 _INLINE_VAR constexpr size_t _Big_allocation_sentinel = 0xFAFAFAFAFAFAFAFAULL;
-#else // ^^^ _WIN64 ^^^ / vvv !_WIN64 vvv
+#else // ^^^ _WIN64 / !_WIN64 vvv
 _INLINE_VAR constexpr size_t _Big_allocation_sentinel = 0xFAFAFAFAUL;
 #endif // _WIN64
 
@@ -157,7 +157,7 @@ inline void _Adjust_manually_vector_aligned(void*& _Ptr, size_t& _Bytes) {
     // in range [_Min_back_shift, _Non_user_size]
 #ifdef _DEBUG
     constexpr uintptr_t _Min_back_shift = 2 * sizeof(void*);
-#else // ^^^ _DEBUG ^^^ / vvv !_DEBUG vvv
+#else // ^^^ _DEBUG / !_DEBUG vvv
     constexpr uintptr_t _Min_back_shift = sizeof(void*);
 #endif // _DEBUG
     const uintptr_t _Back_shift = reinterpret_cast<uintptr_t>(_Ptr) - _Ptr_container;
@@ -212,7 +212,7 @@ _CONSTEXPR20 void _Deallocate(void* _Ptr, const size_t _Bytes) noexcept {
 }
 
 #define _HAS_ALIGNED_NEW 1
-#else // ^^^ __cpp_aligned_new ^^^ / vvv !__cpp_aligned_new vvv
+#else // ^^^ __cpp_aligned_new / !__cpp_aligned_new vvv
 #define _HAS_ALIGNED_NEW 0
 #endif // __cpp_aligned_new
 
@@ -1111,7 +1111,7 @@ public:
         {
             _Assign_locked(_Right);
         }
-#else // ^^^ _ITERATOR_DEBUG_LEVEL == 2 ^^^ / vvv _ITERATOR_DEBUG_LEVEL != 2 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL == 2 / _ITERATOR_DEBUG_LEVEL != 2 vvv
         _Myproxy = _Right._Myproxy;
 #endif // _ITERATOR_DEBUG_LEVEL != 2
         return *this;
@@ -1139,7 +1139,7 @@ public:
             _Adopt_locked(_Parent);
         }
     }
-#else // ^^^ _ITERATOR_DEBUG_LEVEL == 2 ^^^ / vvv _ITERATOR_DEBUG_LEVEL != 2 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL == 2 / _ITERATOR_DEBUG_LEVEL != 2 vvv
     _CONSTEXPR20 void _Adopt(const _Container_base12* _Parent) noexcept {
         if (_Parent) { // have a parent, do adoption
             _Myproxy = _Parent->_Myproxy;
@@ -1270,7 +1270,7 @@ _CONSTEXPR20 void _Container_base12::_Swap_proxy_and_iterators(_Container_base12
     {
         _Swap_proxy_and_iterators_locked(_Right);
     }
-#else // ^^^ _ITERATOR_DEBUG_LEVEL == 2 ^^^ / vvv _ITERATOR_DEBUG_LEVEL != 2 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL == 2 / _ITERATOR_DEBUG_LEVEL != 2 vvv
     _Swap_proxy_and_iterators_unlocked(_Right);
 #endif // _ITERATOR_DEBUG_LEVEL != 2
 }
@@ -1999,7 +1999,7 @@ struct _Alloc_temporary2 {
     _NODISCARD _CONSTEXPR20 const value_type& _Get_value() const noexcept {
         return _Storage._Value;
     }
-#else // ^^^ workaround for VSO-586813 "T^ is not allowed in a union" ^^^ / vvv no workaround vvv
+#else // ^^^ workaround for VSO-586813 "T^ is not allowed in a union" / no workaround vvv
     union {
         value_type _Value;
     };

--- a/stl/inc/xpolymorphic_allocator.h
+++ b/stl/inc/xpolymorphic_allocator.h
@@ -263,7 +263,7 @@ namespace pmr {
             // propagate allocator *this if uses_allocator_v<_Uty, polymorphic_allocator>
 #if _HAS_CXX20
             _STD uninitialized_construct_using_allocator(_Ptr, *this, _STD forward<_Types>(_Args)...);
-#else // ^^^ _HAS_CXX20 ^^^ / vvv !_HAS_CXX20 vvv
+#else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
             allocator<char> _Al{};
             _Uses_allocator_construct(_Ptr, _Al, *this, _STD forward<_Types>(_Args)...);
 #endif // ^^^ !_HAS_CXX20 ^^^

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -965,7 +965,7 @@ private:
 #if _ITERATOR_DEBUG_LEVEL >= 1
     constexpr _String_view_iterator(const pointer _Data, const size_t _Size, const size_t _Off) noexcept
         : _Mydata(_Data), _Mysize(_Size), _Myoff(_Off) {}
-#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 ^^^ // vvv _ITERATOR_DEBUG_LEVEL == 0 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 ^^^ / vvv _ITERATOR_DEBUG_LEVEL == 0 vvv
     constexpr explicit _String_view_iterator(const pointer _Ptr) noexcept : _Myptr(_Ptr) {}
 #endif // _ITERATOR_DEBUG_LEVEL
 
@@ -975,7 +975,7 @@ public:
         _STL_VERIFY(_Mydata, "cannot dereference value-initialized string_view iterator");
         _STL_VERIFY(_Myoff < _Mysize, "cannot dereference end string_view iterator");
         return _Mydata[_Myoff];
-#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 ^^^ // vvv _ITERATOR_DEBUG_LEVEL == 0 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 ^^^ / vvv _ITERATOR_DEBUG_LEVEL == 0 vvv
         return *_Myptr;
 #endif // _ITERATOR_DEBUG_LEVEL
     }
@@ -985,7 +985,7 @@ public:
         _STL_VERIFY(_Mydata, "cannot dereference value-initialized string_view iterator");
         _STL_VERIFY(_Myoff < _Mysize, "cannot dereference end string_view iterator");
         return _Mydata + _Myoff;
-#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 ^^^ // vvv _ITERATOR_DEBUG_LEVEL == 0 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 ^^^ / vvv _ITERATOR_DEBUG_LEVEL == 0 vvv
         return _Myptr;
 #endif // _ITERATOR_DEBUG_LEVEL
     }
@@ -995,7 +995,7 @@ public:
         _STL_VERIFY(_Mydata, "cannot increment value-initialized string_view iterator");
         _STL_VERIFY(_Myoff < _Mysize, "cannot increment string_view iterator past end");
         ++_Myoff;
-#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 ^^^ // vvv _ITERATOR_DEBUG_LEVEL == 0 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 ^^^ / vvv _ITERATOR_DEBUG_LEVEL == 0 vvv
         ++_Myptr;
 #endif // _ITERATOR_DEBUG_LEVEL
         return *this;
@@ -1012,7 +1012,7 @@ public:
         _STL_VERIFY(_Mydata, "cannot decrement value-initialized string_view iterator");
         _STL_VERIFY(_Myoff != 0, "cannot decrement string_view iterator before begin");
         --_Myoff;
-#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 ^^^ // vvv _ITERATOR_DEBUG_LEVEL == 0 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 ^^^ / vvv _ITERATOR_DEBUG_LEVEL == 0 vvv
         --_Myptr;
 #endif // _ITERATOR_DEBUG_LEVEL
         return *this;
@@ -1038,7 +1038,7 @@ public:
         if (_Off > 0) {
             _STL_VERIFY(_Mysize - _Myoff >= static_cast<size_t>(_Off), "cannot seek string_view iterator after end");
         }
-#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 ^^^ // vvv _ITERATOR_DEBUG_LEVEL == 0 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 ^^^ / vvv _ITERATOR_DEBUG_LEVEL == 0 vvv
         (void) _Off;
 #endif // _ITERATOR_DEBUG_LEVEL >= 1
     }
@@ -1047,7 +1047,7 @@ public:
 #if _ITERATOR_DEBUG_LEVEL >= 1
         _Verify_offset(_Off);
         _Myoff += static_cast<size_t>(_Off);
-#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 ^^^ // vvv _ITERATOR_DEBUG_LEVEL == 0 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 ^^^ / vvv _ITERATOR_DEBUG_LEVEL == 0 vvv
         _Myptr += _Off;
 #endif // _ITERATOR_DEBUG_LEVEL
 
@@ -1082,7 +1082,7 @@ public:
         }
 
         _Myoff -= static_cast<size_t>(_Off);
-#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 ^^^ // vvv _ITERATOR_DEBUG_LEVEL == 0 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 ^^^ / vvv _ITERATOR_DEBUG_LEVEL == 0 vvv
         _Myptr -= _Off;
 #endif // _ITERATOR_DEBUG_LEVEL
 
@@ -1100,7 +1100,7 @@ public:
         _STL_VERIFY(_Mydata == _Right._Mydata && _Mysize == _Right._Mysize,
             "cannot subtract incompatible string_view iterators");
         return static_cast<difference_type>(_Myoff - _Right._Myoff);
-#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 ^^^ // vvv _ITERATOR_DEBUG_LEVEL == 0 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 ^^^ / vvv _ITERATOR_DEBUG_LEVEL == 0 vvv
         return _Myptr - _Right._Myptr;
 #endif // _ITERATOR_DEBUG_LEVEL
     }
@@ -1114,7 +1114,7 @@ public:
         _STL_VERIFY(_Mydata == _Right._Mydata && _Mysize == _Right._Mysize,
             "cannot compare incompatible string_view iterators for equality");
         return _Myoff == _Right._Myoff;
-#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 ^^^ // vvv _ITERATOR_DEBUG_LEVEL == 0 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 ^^^ / vvv _ITERATOR_DEBUG_LEVEL == 0 vvv
         return _Myptr == _Right._Myptr;
 #endif // _ITERATOR_DEBUG_LEVEL
     }
@@ -1125,7 +1125,7 @@ public:
         _STL_VERIFY(_Mydata == _Right._Mydata && _Mysize == _Right._Mysize,
             "cannot compare incompatible string_view iterators");
         return _Myoff <=> _Right._Myoff;
-#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 ^^^ // vvv _ITERATOR_DEBUG_LEVEL == 0 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 ^^^ / vvv _ITERATOR_DEBUG_LEVEL == 0 vvv
         return _Myptr <=> _Right._Myptr;
 #endif // _ITERATOR_DEBUG_LEVEL
     }
@@ -1139,7 +1139,7 @@ public:
         _STL_VERIFY(_Mydata == _Right._Mydata && _Mysize == _Right._Mysize,
             "cannot compare incompatible string_view iterators");
         return _Myoff < _Right._Myoff;
-#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 ^^^ // vvv _ITERATOR_DEBUG_LEVEL == 0 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 ^^^ / vvv _ITERATOR_DEBUG_LEVEL == 0 vvv
         return _Myptr < _Right._Myptr;
 #endif // _ITERATOR_DEBUG_LEVEL
     }
@@ -1170,7 +1170,7 @@ public:
     _NODISCARD constexpr pointer _Unwrapped() const noexcept {
 #if _ITERATOR_DEBUG_LEVEL >= 1
         return _Mydata + _Myoff;
-#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 ^^^ // vvv _ITERATOR_DEBUG_LEVEL == 0 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 ^^^ / vvv _ITERATOR_DEBUG_LEVEL == 0 vvv
         return _Myptr;
 #endif // _ITERATOR_DEBUG_LEVEL
     }
@@ -1180,7 +1180,7 @@ public:
     constexpr void _Seek_to(pointer _It) noexcept {
 #if _ITERATOR_DEBUG_LEVEL >= 1
         _Myoff = static_cast<size_t>(_It - _Mydata);
-#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 ^^^ // vvv _ITERATOR_DEBUG_LEVEL == 0 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 ^^^ / vvv _ITERATOR_DEBUG_LEVEL == 0 vvv
         _Myptr = _It;
 #endif // _ITERATOR_DEBUG_LEVEL
     }
@@ -1190,7 +1190,7 @@ private:
     pointer _Mydata = nullptr;
     size_t _Mysize  = 0;
     size_t _Myoff   = 0;
-#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 ^^^ // vvv _ITERATOR_DEBUG_LEVEL == 0 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 ^^^ / vvv _ITERATOR_DEBUG_LEVEL == 0 vvv
     pointer _Myptr = nullptr;
 #endif // _ITERATOR_DEBUG_LEVEL
 };
@@ -1289,7 +1289,7 @@ public:
     _NODISCARD constexpr const_iterator begin() const noexcept {
 #if _ITERATOR_DEBUG_LEVEL >= 1
         return const_iterator(_Mydata, _Mysize, 0);
-#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 ^^^ // vvv _ITERATOR_DEBUG_LEVEL == 0 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 ^^^ / vvv _ITERATOR_DEBUG_LEVEL == 0 vvv
         return const_iterator(_Mydata);
 #endif // _ITERATOR_DEBUG_LEVEL
     }
@@ -1297,7 +1297,7 @@ public:
     _NODISCARD constexpr const_iterator end() const noexcept {
 #if _ITERATOR_DEBUG_LEVEL >= 1
         return const_iterator(_Mydata, _Mysize, _Mysize);
-#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 ^^^ // vvv _ITERATOR_DEBUG_LEVEL == 0 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 ^^^ / vvv _ITERATOR_DEBUG_LEVEL == 0 vvv
         return const_iterator(_Mydata + _Mysize);
 #endif // _ITERATOR_DEBUG_LEVEL
     }
@@ -1989,7 +1989,7 @@ public:
             const auto _Left = _Mycont->_Mysize - static_cast<_Size_type>(_Rawptr - _Contptr);
             _STL_VERIFY(static_cast<_Size_type>(_Off) <= _Left, "cannot seek string iterator after end");
         }
-#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 ^^^ // vvv _ITERATOR_DEBUG_LEVEL == 0 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 ^^^ / vvv _ITERATOR_DEBUG_LEVEL == 0 vvv
         (void) _Off;
 #endif // _ITERATOR_DEBUG_LEVEL >= 1
     }
@@ -2071,7 +2071,7 @@ public:
 #if _ITERATOR_DEBUG_LEVEL >= 1
         _STL_VERIFY(this->_Getcont() == _Right._Getcont(), "string iterators incompatible (e.g."
                                                            " point to different string instances)");
-#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 ^^^ // vvv _ITERATOR_DEBUG_LEVEL == 0 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 ^^^ / vvv _ITERATOR_DEBUG_LEVEL == 0 vvv
         (void) _Right;
 #endif // _ITERATOR_DEBUG_LEVEL
     }
@@ -2371,13 +2371,13 @@ struct _String_constructor_rvalue_allocator_tag {
 #if defined(__SANITIZE_ADDRESS__)
 #define _ACTIVATE_STRING_ANNOTATION
 #define _INSERT_STRING_ANNOTATION
-#elif defined(__clang__) && defined(__has_feature) // ^^^ __SANITIZE_ADDRESS__ ^^^ // vvv __clang__ vvv
+#elif defined(__clang__) && defined(__has_feature) // ^^^ __SANITIZE_ADDRESS__ ^^^ / vvv __clang__ vvv
 #if __has_feature(address_sanitizer)
 #define _ACTIVATE_STRING_ANNOTATION
 #define _INSERT_STRING_ANNOTATION
 #pragma comment(linker, "/INFERASANLIBS")
 #endif // __has_feature(address_sanitizer)
-#elif defined(_ANNOTATE_STRING) // ^^^ __clang__ ^^^ // vvv _ANNOTATE_STRING vvv
+#elif defined(_ANNOTATE_STRING) // ^^^ __clang__ ^^^ / vvv _ANNOTATE_STRING vvv
 #define _INSERT_STRING_ANNOTATION
 #endif // _ANNOTATE_STRING
 #endif // !_M_CEE_PURE && !_DISABLE_STRING_ANNOTATION
@@ -2429,7 +2429,7 @@ template <class _String>
 _INLINE_VAR constexpr bool _Has_minimum_allocation_alignment_string<_String,
     void_t<decltype(_String::allocator_type::_Minimum_allocation_alignment)>> =
     _String::allocator_type::_Minimum_allocation_alignment >= _Asan_granularity;
-#else // ^^^ _INSERT_STRING_ANNOTATION ^^^ // vvv !_INSERT_STRING_ANNOTATION vvv
+#else // ^^^ _INSERT_STRING_ANNOTATION ^^^ / vvv !_INSERT_STRING_ANNOTATION vvv
 #pragma detect_mismatch("annotate_string", "0")
 #endif // !_INSERT_STRING_ANNOTATION
 
@@ -2602,7 +2602,7 @@ private:
 #define _ASAN_STRING_MODIFY(n)    _Modify_annotation((n))
 #define _ASAN_STRING_REMOVE(_Str) (_Str)._Remove_annotation()
 #define _ASAN_STRING_CREATE(_Str) (_Str)._Create_annotation()
-#else // ^^^ _INSERT_STRING_ANNOTATION ^^^ // vvv !_INSERT_STRING_ANNOTATION vvv
+#else // ^^^ _INSERT_STRING_ANNOTATION ^^^ / vvv !_INSERT_STRING_ANNOTATION vvv
 #define _ASAN_STRING_MODIFY(n)
 #define _ASAN_STRING_REMOVE(_Str)
 #define _ASAN_STRING_CREATE(_Str)
@@ -2753,7 +2753,7 @@ private:
             } else { // _Strat == _Construct_strategy::_From_string
 #ifdef _INSERT_STRING_ANNOTATION
                 _Traits::move(_My_data._Bx._Buf, _Arg, _Count);
-#else // ^^^ _INSERT_STRING_ANNOTATION ^^^ // vvv !_INSERT_STRING_ANNOTATION vvv
+#else // ^^^ _INSERT_STRING_ANNOTATION ^^^ / vvv !_INSERT_STRING_ANNOTATION vvv
                 _Traits::move(_My_data._Bx._Buf, _Arg, _BUF_SIZE);
 #endif // !_INSERT_STRING_ANNOTATION
             }

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -26,7 +26,7 @@ _STL_DISABLE_CLANG_WARNINGS
 
 #ifdef __clang__
 #define _HAS_MEMCPY_MEMMOVE_INTRINSICS 1
-#else // ^^^ use __builtin_memcpy and __builtin_memmove ^^^ / vvv use workaround vvv
+#else // ^^^ use __builtin_memcpy and __builtin_memmove / use workaround vvv
 #define _HAS_MEMCPY_MEMMOVE_INTRINSICS 0 // TRANSITION, DevCom-1046483 (MSVC) and VSO-1129974 (EDG)
 #endif // ^^^ use workaround ^^^
 
@@ -49,7 +49,7 @@ struct _Char_traits { // properties of a string or stream element
         // copy [_First2, _First2 + _Count) to [_First1, ...)
 #if _HAS_MEMCPY_MEMMOVE_INTRINSICS
         __builtin_memcpy(_First1, _First2, _Count * sizeof(_Elem));
-#else // ^^^ _HAS_MEMCPY_MEMMOVE_INTRINSICS ^^^ / vvv !_HAS_MEMCPY_MEMMOVE_INTRINSICS vvv
+#else // ^^^ _HAS_MEMCPY_MEMMOVE_INTRINSICS / !_HAS_MEMCPY_MEMMOVE_INTRINSICS vvv
 #if _HAS_CXX20
         if (_STD is_constant_evaluated()) {
             // pre: [_First1, _First1 + _Count) and [_First2, _First2 + _Count) do not overlap; see LWG-3085
@@ -80,7 +80,7 @@ struct _Char_traits { // properties of a string or stream element
         // copy [_First2, _First2 + _Count) to [_First1, ...), allowing overlap
 #if _HAS_MEMCPY_MEMMOVE_INTRINSICS
         __builtin_memmove(_First1, _First2, _Count * sizeof(_Elem));
-#else // ^^^ _HAS_MEMCPY_MEMMOVE_INTRINSICS ^^^ / vvv !_HAS_MEMCPY_MEMMOVE_INTRINSICS vvv
+#else // ^^^ _HAS_MEMCPY_MEMMOVE_INTRINSICS / !_HAS_MEMCPY_MEMMOVE_INTRINSICS vvv
 #if _HAS_CXX20
         if (_STD is_constant_evaluated()) {
             // dest: [_First1, _First1 + _Count)
@@ -965,7 +965,7 @@ private:
 #if _ITERATOR_DEBUG_LEVEL >= 1
     constexpr _String_view_iterator(const pointer _Data, const size_t _Size, const size_t _Off) noexcept
         : _Mydata(_Data), _Mysize(_Size), _Myoff(_Off) {}
-#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 ^^^ / vvv _ITERATOR_DEBUG_LEVEL == 0 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 / _ITERATOR_DEBUG_LEVEL == 0 vvv
     constexpr explicit _String_view_iterator(const pointer _Ptr) noexcept : _Myptr(_Ptr) {}
 #endif // _ITERATOR_DEBUG_LEVEL
 
@@ -975,7 +975,7 @@ public:
         _STL_VERIFY(_Mydata, "cannot dereference value-initialized string_view iterator");
         _STL_VERIFY(_Myoff < _Mysize, "cannot dereference end string_view iterator");
         return _Mydata[_Myoff];
-#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 ^^^ / vvv _ITERATOR_DEBUG_LEVEL == 0 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 / _ITERATOR_DEBUG_LEVEL == 0 vvv
         return *_Myptr;
 #endif // _ITERATOR_DEBUG_LEVEL
     }
@@ -985,7 +985,7 @@ public:
         _STL_VERIFY(_Mydata, "cannot dereference value-initialized string_view iterator");
         _STL_VERIFY(_Myoff < _Mysize, "cannot dereference end string_view iterator");
         return _Mydata + _Myoff;
-#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 ^^^ / vvv _ITERATOR_DEBUG_LEVEL == 0 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 / _ITERATOR_DEBUG_LEVEL == 0 vvv
         return _Myptr;
 #endif // _ITERATOR_DEBUG_LEVEL
     }
@@ -995,7 +995,7 @@ public:
         _STL_VERIFY(_Mydata, "cannot increment value-initialized string_view iterator");
         _STL_VERIFY(_Myoff < _Mysize, "cannot increment string_view iterator past end");
         ++_Myoff;
-#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 ^^^ / vvv _ITERATOR_DEBUG_LEVEL == 0 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 / _ITERATOR_DEBUG_LEVEL == 0 vvv
         ++_Myptr;
 #endif // _ITERATOR_DEBUG_LEVEL
         return *this;
@@ -1012,7 +1012,7 @@ public:
         _STL_VERIFY(_Mydata, "cannot decrement value-initialized string_view iterator");
         _STL_VERIFY(_Myoff != 0, "cannot decrement string_view iterator before begin");
         --_Myoff;
-#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 ^^^ / vvv _ITERATOR_DEBUG_LEVEL == 0 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 / _ITERATOR_DEBUG_LEVEL == 0 vvv
         --_Myptr;
 #endif // _ITERATOR_DEBUG_LEVEL
         return *this;
@@ -1038,7 +1038,7 @@ public:
         if (_Off > 0) {
             _STL_VERIFY(_Mysize - _Myoff >= static_cast<size_t>(_Off), "cannot seek string_view iterator after end");
         }
-#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 ^^^ / vvv _ITERATOR_DEBUG_LEVEL == 0 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 / _ITERATOR_DEBUG_LEVEL == 0 vvv
         (void) _Off;
 #endif // _ITERATOR_DEBUG_LEVEL >= 1
     }
@@ -1047,7 +1047,7 @@ public:
 #if _ITERATOR_DEBUG_LEVEL >= 1
         _Verify_offset(_Off);
         _Myoff += static_cast<size_t>(_Off);
-#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 ^^^ / vvv _ITERATOR_DEBUG_LEVEL == 0 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 / _ITERATOR_DEBUG_LEVEL == 0 vvv
         _Myptr += _Off;
 #endif // _ITERATOR_DEBUG_LEVEL
 
@@ -1082,7 +1082,7 @@ public:
         }
 
         _Myoff -= static_cast<size_t>(_Off);
-#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 ^^^ / vvv _ITERATOR_DEBUG_LEVEL == 0 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 / _ITERATOR_DEBUG_LEVEL == 0 vvv
         _Myptr -= _Off;
 #endif // _ITERATOR_DEBUG_LEVEL
 
@@ -1100,7 +1100,7 @@ public:
         _STL_VERIFY(_Mydata == _Right._Mydata && _Mysize == _Right._Mysize,
             "cannot subtract incompatible string_view iterators");
         return static_cast<difference_type>(_Myoff - _Right._Myoff);
-#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 ^^^ / vvv _ITERATOR_DEBUG_LEVEL == 0 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 / _ITERATOR_DEBUG_LEVEL == 0 vvv
         return _Myptr - _Right._Myptr;
 #endif // _ITERATOR_DEBUG_LEVEL
     }
@@ -1114,7 +1114,7 @@ public:
         _STL_VERIFY(_Mydata == _Right._Mydata && _Mysize == _Right._Mysize,
             "cannot compare incompatible string_view iterators for equality");
         return _Myoff == _Right._Myoff;
-#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 ^^^ / vvv _ITERATOR_DEBUG_LEVEL == 0 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 / _ITERATOR_DEBUG_LEVEL == 0 vvv
         return _Myptr == _Right._Myptr;
 #endif // _ITERATOR_DEBUG_LEVEL
     }
@@ -1125,11 +1125,11 @@ public:
         _STL_VERIFY(_Mydata == _Right._Mydata && _Mysize == _Right._Mysize,
             "cannot compare incompatible string_view iterators");
         return _Myoff <=> _Right._Myoff;
-#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 ^^^ / vvv _ITERATOR_DEBUG_LEVEL == 0 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 / _ITERATOR_DEBUG_LEVEL == 0 vvv
         return _Myptr <=> _Right._Myptr;
 #endif // _ITERATOR_DEBUG_LEVEL
     }
-#else // ^^^ _HAS_CXX20 ^^^ / vvv !_HAS_CXX20 vvv
+#else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
     _NODISCARD constexpr bool operator!=(const _String_view_iterator& _Right) const noexcept {
         return !(*this == _Right);
     }
@@ -1139,7 +1139,7 @@ public:
         _STL_VERIFY(_Mydata == _Right._Mydata && _Mysize == _Right._Mysize,
             "cannot compare incompatible string_view iterators");
         return _Myoff < _Right._Myoff;
-#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 ^^^ / vvv _ITERATOR_DEBUG_LEVEL == 0 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 / _ITERATOR_DEBUG_LEVEL == 0 vvv
         return _Myptr < _Right._Myptr;
 #endif // _ITERATOR_DEBUG_LEVEL
     }
@@ -1170,7 +1170,7 @@ public:
     _NODISCARD constexpr pointer _Unwrapped() const noexcept {
 #if _ITERATOR_DEBUG_LEVEL >= 1
         return _Mydata + _Myoff;
-#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 ^^^ / vvv _ITERATOR_DEBUG_LEVEL == 0 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 / _ITERATOR_DEBUG_LEVEL == 0 vvv
         return _Myptr;
 #endif // _ITERATOR_DEBUG_LEVEL
     }
@@ -1180,7 +1180,7 @@ public:
     constexpr void _Seek_to(pointer _It) noexcept {
 #if _ITERATOR_DEBUG_LEVEL >= 1
         _Myoff = static_cast<size_t>(_It - _Mydata);
-#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 ^^^ / vvv _ITERATOR_DEBUG_LEVEL == 0 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 / _ITERATOR_DEBUG_LEVEL == 0 vvv
         _Myptr = _It;
 #endif // _ITERATOR_DEBUG_LEVEL
     }
@@ -1190,7 +1190,7 @@ private:
     pointer _Mydata = nullptr;
     size_t _Mysize  = 0;
     size_t _Myoff   = 0;
-#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 ^^^ / vvv _ITERATOR_DEBUG_LEVEL == 0 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 / _ITERATOR_DEBUG_LEVEL == 0 vvv
     pointer _Myptr = nullptr;
 #endif // _ITERATOR_DEBUG_LEVEL
 };
@@ -1289,7 +1289,7 @@ public:
     _NODISCARD constexpr const_iterator begin() const noexcept {
 #if _ITERATOR_DEBUG_LEVEL >= 1
         return const_iterator(_Mydata, _Mysize, 0);
-#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 ^^^ / vvv _ITERATOR_DEBUG_LEVEL == 0 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 / _ITERATOR_DEBUG_LEVEL == 0 vvv
         return const_iterator(_Mydata);
 #endif // _ITERATOR_DEBUG_LEVEL
     }
@@ -1297,7 +1297,7 @@ public:
     _NODISCARD constexpr const_iterator end() const noexcept {
 #if _ITERATOR_DEBUG_LEVEL >= 1
         return const_iterator(_Mydata, _Mysize, _Mysize);
-#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 ^^^ / vvv _ITERATOR_DEBUG_LEVEL == 0 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 / _ITERATOR_DEBUG_LEVEL == 0 vvv
         return const_iterator(_Mydata + _Mysize);
 #endif // _ITERATOR_DEBUG_LEVEL
     }
@@ -1989,7 +1989,7 @@ public:
             const auto _Left = _Mycont->_Mysize - static_cast<_Size_type>(_Rawptr - _Contptr);
             _STL_VERIFY(static_cast<_Size_type>(_Off) <= _Left, "cannot seek string iterator after end");
         }
-#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 ^^^ / vvv _ITERATOR_DEBUG_LEVEL == 0 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 / _ITERATOR_DEBUG_LEVEL == 0 vvv
         (void) _Off;
 #endif // _ITERATOR_DEBUG_LEVEL >= 1
     }
@@ -2043,7 +2043,7 @@ public:
         _Compat(_Right);
         return _Unfancy(_Ptr) <=> _Unfancy(_Right._Ptr);
     }
-#else // ^^^ _HAS_CXX20 ^^^ / vvv !_HAS_CXX20 vvv
+#else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
     _NODISCARD bool operator!=(const _String_const_iterator& _Right) const noexcept {
         return !(*this == _Right);
     }
@@ -2071,7 +2071,7 @@ public:
 #if _ITERATOR_DEBUG_LEVEL >= 1
         _STL_VERIFY(this->_Getcont() == _Right._Getcont(), "string iterators incompatible (e.g."
                                                            " point to different string instances)");
-#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 ^^^ / vvv _ITERATOR_DEBUG_LEVEL == 0 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL >= 1 / _ITERATOR_DEBUG_LEVEL == 0 vvv
         (void) _Right;
 #endif // _ITERATOR_DEBUG_LEVEL
     }
@@ -2372,13 +2372,13 @@ struct _String_constructor_rvalue_allocator_tag {
 #if defined(__SANITIZE_ADDRESS__)
 #define _ACTIVATE_STRING_ANNOTATION
 #define _INSERT_STRING_ANNOTATION
-#elif defined(__clang__) && defined(__has_feature) // ^^^ __SANITIZE_ADDRESS__ ^^^ / vvv __clang__ vvv
+#elif defined(__clang__) && defined(__has_feature) // ^^^ __SANITIZE_ADDRESS__ / __clang__ vvv
 #if __has_feature(address_sanitizer)
 #define _ACTIVATE_STRING_ANNOTATION
 #define _INSERT_STRING_ANNOTATION
 #pragma comment(linker, "/INFERASANLIBS")
 #endif // __has_feature(address_sanitizer)
-#elif defined(_ANNOTATE_STRING) // ^^^ __clang__ ^^^ / vvv _ANNOTATE_STRING vvv
+#elif defined(_ANNOTATE_STRING) // ^^^ __clang__ / _ANNOTATE_STRING vvv
 #define _INSERT_STRING_ANNOTATION
 #endif // _ANNOTATE_STRING
 #endif // !_M_CEE_PURE && !_DISABLE_STRING_ANNOTATION
@@ -2430,7 +2430,7 @@ template <class _String>
 _INLINE_VAR constexpr bool _Has_minimum_allocation_alignment_string<_String,
     void_t<decltype(_String::allocator_type::_Minimum_allocation_alignment)>> =
     _String::allocator_type::_Minimum_allocation_alignment >= _Asan_granularity;
-#else // ^^^ _INSERT_STRING_ANNOTATION ^^^ / vvv !_INSERT_STRING_ANNOTATION vvv
+#else // ^^^ _INSERT_STRING_ANNOTATION / !_INSERT_STRING_ANNOTATION vvv
 #pragma detect_mismatch("annotate_string", "0")
 #endif // !_INSERT_STRING_ANNOTATION
 
@@ -2603,7 +2603,7 @@ private:
 #define _ASAN_STRING_MODIFY(n)    _Modify_annotation((n))
 #define _ASAN_STRING_REMOVE(_Str) (_Str)._Remove_annotation()
 #define _ASAN_STRING_CREATE(_Str) (_Str)._Create_annotation()
-#else // ^^^ _INSERT_STRING_ANNOTATION ^^^ / vvv !_INSERT_STRING_ANNOTATION vvv
+#else // ^^^ _INSERT_STRING_ANNOTATION / !_INSERT_STRING_ANNOTATION vvv
 #define _ASAN_STRING_MODIFY(n)
 #define _ASAN_STRING_REMOVE(_Str)
 #define _ASAN_STRING_CREATE(_Str)
@@ -2756,7 +2756,7 @@ private:
             } else { // _Strat == _Construct_strategy::_From_string
 #ifdef _INSERT_STRING_ANNOTATION
                 _Traits::move(_My_data._Bx._Buf, _Arg, _Count + 1);
-#else // ^^^ _INSERT_STRING_ANNOTATION ^^^ / vvv !_INSERT_STRING_ANNOTATION vvv
+#else // ^^^ _INSERT_STRING_ANNOTATION / !_INSERT_STRING_ANNOTATION vvv
                 _Traits::move(_My_data._Bx._Buf, _Arg, _BUF_SIZE);
 #endif // !_INSERT_STRING_ANNOTATION
             }

--- a/stl/inc/xtree
+++ b/stl/inc/xtree
@@ -212,7 +212,7 @@ public:
         _Nodeptr _Ptrsav = this->_Ptr;
         _Mybase::operator--();
         _STL_VERIFY(_Ptrsav != this->_Ptr, "cannot decrement begin map/set iterator");
-#else // ^^^ _ITERATOR_DEBUG_LEVEL == 2 ^^^ // vvv _ITERATOR_DEBUG_LEVEL != 2 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL == 2 ^^^ / vvv _ITERATOR_DEBUG_LEVEL != 2 vvv
         _Mybase::operator--();
 #endif // _ITERATOR_DEBUG_LEVEL == 2
 
@@ -725,7 +725,7 @@ public:
                 *_Pnext             = (*_Pnext)->_Mynextiter;
             }
         }
-#else // ^^^ _ITERATOR_DEBUG_LEVEL == 2 ^^^ // vvv _ITERATOR_DEBUG_LEVEL != 2 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL == 2 ^^^ / vvv _ITERATOR_DEBUG_LEVEL != 2 vvv
         (void) _Ptr;
 #endif // _ITERATOR_DEBUG_LEVEL == 2
     }

--- a/stl/inc/xtree
+++ b/stl/inc/xtree
@@ -212,7 +212,7 @@ public:
         _Nodeptr _Ptrsav = this->_Ptr;
         _Mybase::operator--();
         _STL_VERIFY(_Ptrsav != this->_Ptr, "cannot decrement begin map/set iterator");
-#else // ^^^ _ITERATOR_DEBUG_LEVEL == 2 ^^^ / vvv _ITERATOR_DEBUG_LEVEL != 2 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL == 2 / _ITERATOR_DEBUG_LEVEL != 2 vvv
         _Mybase::operator--();
 #endif // _ITERATOR_DEBUG_LEVEL == 2
 
@@ -725,7 +725,7 @@ public:
                 *_Pnext             = (*_Pnext)->_Mynextiter;
             }
         }
-#else // ^^^ _ITERATOR_DEBUG_LEVEL == 2 ^^^ / vvv _ITERATOR_DEBUG_LEVEL != 2 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL == 2 / _ITERATOR_DEBUG_LEVEL != 2 vvv
         (void) _Ptr;
 #endif // _ITERATOR_DEBUG_LEVEL == 2
     }

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -253,7 +253,7 @@ _NODISCARD constexpr void* _Voidify_iter(_Iter _It) noexcept {
 #ifdef __EDG__ // TRANSITION, DevCom-1691516
 _EXPORT_STD template <class _Ty, class... _Types,
     class = void_t<decltype(::new(_STD declval<void*>()) _Ty(_STD declval<_Types>()...))>>
-#else // ^^^ no workaround // workaround vvv
+#else // ^^^ no workaround / workaround vvv
 _EXPORT_STD template <class _Ty, class... _Types,
     void_t<decltype(::new(_STD declval<void*>()) _Ty(_STD declval<_Types>()...))>* = nullptr>
 #endif // TRANSITION, DevCom-1691516

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -4233,7 +4233,7 @@ _NODISCARD constexpr auto _To_address(const _Iter& _Val) noexcept {
     _STL_INTERNAL_STATIC_ASSERT(contiguous_iterator<_Iter>);
     return _STD to_address(_Val);
 }
-#else // ^^^ defined(__cpp_lib_concepts) ^^^ / vvv !defined(__cpp_lib_concepts) vvv
+#else // ^^^ defined(__cpp_lib_concepts) / !defined(__cpp_lib_concepts) vvv
 // When concepts aren't available, we can detect pointers. (Iterators should be unwrapped before using this.)
 template <class _Iter>
 _INLINE_VAR constexpr bool _Iterator_is_contiguous = is_pointer_v<_Iter>;
@@ -5620,7 +5620,7 @@ _NODISCARD _CONSTEXPR20 _InIt _Find_unchecked(_InIt _First, const _InIt _Last, c
             } else {
                 return _First + (_Result - _First_ptr);
             }
-#else // ^^^ _USE_STD_VECTOR_ALGORITHMS ^^^ / vvv not _USE_STD_VECTOR_ALGORITHMS vvv
+#else // ^^^ _USE_STD_VECTOR_ALGORITHMS / not _USE_STD_VECTOR_ALGORITHMS vvv
             if constexpr (sizeof(_Iter_value_t<_InIt>) == 1) {
                 const auto _First_ptr = _To_address(_First);
                 const auto _Result    = static_cast<remove_reference_t<_Iter_ref_t<_InIt>>*>(
@@ -5706,7 +5706,7 @@ namespace ranges {
                 } else {
                     return _RANGES next(_STD move(_First), _Result - _First_ptr);
                 }
-#else // ^^^ _USE_STD_VECTOR_ALGORITHMS ^^^ / vvv not _USE_STD_VECTOR_ALGORITHMS vvv
+#else // ^^^ _USE_STD_VECTOR_ALGORITHMS / not _USE_STD_VECTOR_ALGORITHMS vvv
                 if constexpr (sizeof(_Iter_value_t<_It>) == 1 && _Is_sized /* TRANSITION, DevCom-1615707 */) {
                     size_t _Count;
                     if constexpr (_Is_sized) {

--- a/stl/inc/yvals.h
+++ b/stl/inc/yvals.h
@@ -157,7 +157,7 @@ _STL_DISABLE_CLANG_WARNINGS
 #ifndef _CONTAINER_DEBUG_LEVEL
 #if _ITERATOR_DEBUG_LEVEL == 0
 #define _CONTAINER_DEBUG_LEVEL 0
-#else // ^^^ _ITERATOR_DEBUG_LEVEL == 0 // _ITERATOR_DEBUG_LEVEL != 0 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL == 0 / _ITERATOR_DEBUG_LEVEL != 0 vvv
 #define _CONTAINER_DEBUG_LEVEL 1
 #endif // _ITERATOR_DEBUG_LEVEL == 0
 #endif // _CONTAINER_DEBUG_LEVEL
@@ -194,7 +194,7 @@ _STL_DISABLE_CLANG_WARNINGS
     }                                                                                      \
     while (false)                                                                          \
     _Pragma("clang diagnostic pop")
-#else // ^^^ Clang // MSVC vvv
+#else // ^^^ Clang / MSVC vvv
 #define _STL_VERIFY(cond, mesg)                                     \
     do {                                                            \
         if (cond) { /* contextually convertible to bool paranoia */ \
@@ -208,20 +208,20 @@ _STL_DISABLE_CLANG_WARNINGS
 
 #ifdef _DEBUG
 #define _STL_ASSERT(cond, mesg) _STL_VERIFY(cond, mesg)
-#else // ^^^ _DEBUG ^^^ // vvv !_DEBUG vvv
+#else // ^^^ _DEBUG ^^^ / vvv !_DEBUG vvv
 #define _STL_ASSERT(cond, mesg) _Analysis_assume_(cond)
 #endif // _DEBUG
 
 #ifdef _ENABLE_STL_INTERNAL_CHECK
 #define _STL_INTERNAL_CHECK(...) _STL_VERIFY(__VA_ARGS__, "STL internal check: " #__VA_ARGS__)
-#else // ^^^ _ENABLE_STL_INTERNAL_CHECK ^^^ // vvv !_ENABLE_STL_INTERNAL_CHECK vvv
+#else // ^^^ _ENABLE_STL_INTERNAL_CHECK ^^^ / vvv !_ENABLE_STL_INTERNAL_CHECK vvv
 #define _STL_INTERNAL_CHECK(...) _Analysis_assume_(__VA_ARGS__)
 #endif // _ENABLE_STL_INTERNAL_CHECK
 
 #ifndef _ENABLE_ATOMIC_REF_ALIGNMENT_CHECK
 #ifdef _DEBUG
 #define _ENABLE_ATOMIC_REF_ALIGNMENT_CHECK 1
-#else // ^^^ _DEBUG ^^^ // vvv !_DEBUG vvv
+#else // ^^^ _DEBUG ^^^ / vvv !_DEBUG vvv
 #define _ENABLE_ATOMIC_REF_ALIGNMENT_CHECK 0
 #endif // _DEBUG
 #endif // _ENABLE_ATOMIC_REF_ALIGNMENT_CHECK
@@ -330,7 +330,7 @@ _EMIT_STL_WARNING(STL4001, "/clr:pure is deprecated and will be REMOVED.");
 #ifndef _STD_ATOMIC_ALWAYS_USE_CMPXCHG16B
 #if _STL_WIN32_WINNT >= _STL_WIN32_WINNT_WINBLUE && defined(_WIN64)
 #define _STD_ATOMIC_ALWAYS_USE_CMPXCHG16B 1
-#else // ^^^ modern 64-bit // less modern or 32-bit vvv
+#else // ^^^ modern 64-bit / less modern or 32-bit vvv
 #define _STD_ATOMIC_ALWAYS_USE_CMPXCHG16B 0
 #endif // _STL_WIN32_WINNT >= _STL_WIN32_WINNT_WINBLUE && defined(_WIN64)
 #endif // _STD_ATOMIC_ALWAYS_USE_CMPXCHG16B

--- a/stl/inc/yvals.h
+++ b/stl/inc/yvals.h
@@ -208,20 +208,20 @@ _STL_DISABLE_CLANG_WARNINGS
 
 #ifdef _DEBUG
 #define _STL_ASSERT(cond, mesg) _STL_VERIFY(cond, mesg)
-#else // ^^^ _DEBUG ^^^ / vvv !_DEBUG vvv
+#else // ^^^ _DEBUG / !_DEBUG vvv
 #define _STL_ASSERT(cond, mesg) _Analysis_assume_(cond)
 #endif // _DEBUG
 
 #ifdef _ENABLE_STL_INTERNAL_CHECK
 #define _STL_INTERNAL_CHECK(...) _STL_VERIFY(__VA_ARGS__, "STL internal check: " #__VA_ARGS__)
-#else // ^^^ _ENABLE_STL_INTERNAL_CHECK ^^^ / vvv !_ENABLE_STL_INTERNAL_CHECK vvv
+#else // ^^^ _ENABLE_STL_INTERNAL_CHECK / !_ENABLE_STL_INTERNAL_CHECK vvv
 #define _STL_INTERNAL_CHECK(...) _Analysis_assume_(__VA_ARGS__)
 #endif // _ENABLE_STL_INTERNAL_CHECK
 
 #ifndef _ENABLE_ATOMIC_REF_ALIGNMENT_CHECK
 #ifdef _DEBUG
 #define _ENABLE_ATOMIC_REF_ALIGNMENT_CHECK 1
-#else // ^^^ _DEBUG ^^^ / vvv !_DEBUG vvv
+#else // ^^^ _DEBUG / !_DEBUG vvv
 #define _ENABLE_ATOMIC_REF_ALIGNMENT_CHECK 0
 #endif // _DEBUG
 #endif // _ENABLE_ATOMIC_REF_ALIGNMENT_CHECK

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -1818,7 +1818,7 @@ compiler option, or define _ALLOW_RTCc_IN_STL to suppress this error.
 #elif defined(_M_ARM) || defined(_ONECORE) || defined(_CRT_APP)
 // The first ARM or OneCore or App Windows was Windows 8
 #define _STL_WIN32_WINNT _STL_WIN32_WINNT_WIN8
-#else // ^^^ default to Win8 // default to Win7 vvv
+#else // ^^^ default to Win8 / default to Win7 vvv
 // The earliest Windows supported by this implementation is Windows 7
 #define _STL_WIN32_WINNT _STL_WIN32_WINNT_WIN7
 #endif // ^^^ !defined(_M_ARM) && !defined(_M_ARM64) && !defined(_ONECORE) && !defined(_CRT_APP) ^^^
@@ -1838,7 +1838,7 @@ compiler option, or define _ALLOW_RTCc_IN_STL to suppress this error.
 
 #ifdef _ENABLE_STL_INTERNAL_CHECK
 #define _STL_INTERNAL_STATIC_ASSERT(...) static_assert(__VA_ARGS__, #__VA_ARGS__)
-#else // ^^^ _ENABLE_STL_INTERNAL_CHECK ^^^ // vvv !_ENABLE_STL_INTERNAL_CHECK vvv
+#else // ^^^ _ENABLE_STL_INTERNAL_CHECK ^^^ / vvv !_ENABLE_STL_INTERNAL_CHECK vvv
 #define _STL_INTERNAL_STATIC_ASSERT(...)
 #endif // _ENABLE_STL_INTERNAL_CHECK
 

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -513,7 +513,7 @@
 
 #if defined(__CUDACC__) && !defined(__clang__) // TRANSITION, VSO-568006
 #define _NODISCARD_FRIEND friend
-#else // ^^^ workaround ^^^ / vvv no workaround vvv
+#else // ^^^ workaround / no workaround vvv
 #define _NODISCARD_FRIEND _NODISCARD friend
 #endif // TRANSITION, VSO-568006
 
@@ -588,7 +588,7 @@
 #define _NODISCARD_LOCK
 #define _NODISCARD_CTOR_LOCK
 
-#else // ^^^ defined(_SILENCE_NODISCARD_LOCK_WARNINGS) ^^^ / vvv !defined(_SILENCE_NODISCARD_LOCK_WARNINGS) vvv
+#else // ^^^ defined(_SILENCE_NODISCARD_LOCK_WARNINGS) / !defined(_SILENCE_NODISCARD_LOCK_WARNINGS) vvv
 
 #define _NODISCARD_LOCK                                                                                                \
     _NODISCARD_MSG("A lock should be stored in a variable to protect the scope. If you're intentionally constructing " \
@@ -1832,13 +1832,13 @@ compiler option, or define _ALLOW_RTCc_IN_STL to suppress this error.
 
 #ifdef __clang__
 #define _STL_UNREACHABLE __builtin_unreachable()
-#else // ^^^ clang ^^^ / vvv other vvv
+#else // ^^^ clang / other vvv
 #define _STL_UNREACHABLE __assume(false)
 #endif // __clang__
 
 #ifdef _ENABLE_STL_INTERNAL_CHECK
 #define _STL_INTERNAL_STATIC_ASSERT(...) static_assert(__VA_ARGS__, #__VA_ARGS__)
-#else // ^^^ _ENABLE_STL_INTERNAL_CHECK ^^^ / vvv !_ENABLE_STL_INTERNAL_CHECK vvv
+#else // ^^^ _ENABLE_STL_INTERNAL_CHECK / !_ENABLE_STL_INTERNAL_CHECK vvv
 #define _STL_INTERNAL_STATIC_ASSERT(...)
 #endif // _ENABLE_STL_INTERNAL_CHECK
 

--- a/stl/src/atomic_wait.cpp
+++ b/stl/src/atomic_wait.cpp
@@ -92,7 +92,7 @@ namespace {
 #ifndef _ATOMIC_WAIT_ON_ADDRESS_STATICALLY_AVAILABLE
 #if _STL_WIN32_WINNT >= _STL_WIN32_WINNT_WIN8
 #define _ATOMIC_WAIT_ON_ADDRESS_STATICALLY_AVAILABLE 1
-#else // ^^^ _STL_WIN32_WINNT >= _STL_WIN32_WINNT_WIN8 // _STL_WIN32_WINNT < _STL_WIN32_WINNT_WIN8 vvv
+#else // ^^^ _STL_WIN32_WINNT >= _STL_WIN32_WINNT_WIN8 / _STL_WIN32_WINNT < _STL_WIN32_WINNT_WIN8 vvv
 #define _ATOMIC_WAIT_ON_ADDRESS_STATICALLY_AVAILABLE 0
 #endif // ^^^ _STL_WIN32_WINNT < _STL_WIN32_WINNT_WIN8 ^^^
 #endif // _ATOMIC_WAIT_ON_ADDRESS_STATICALLY_AVAILABLE
@@ -360,7 +360,7 @@ __std_atomic_api_level __stdcall __std_atomic_set_api_level(__std_atomic_api_lev
 #if _ATOMIC_WAIT_ON_ADDRESS_STATICALLY_AVAILABLE
     (void) _Requested_api_level;
     return __std_atomic_api_level::__has_wait_on_address;
-#else // ^^^ _ATOMIC_WAIT_ON_ADDRESS_STATICALLY_AVAILABLE // !_ATOMIC_WAIT_ON_ADDRESS_STATICALLY_AVAILABLE vvv
+#else // ^^^ _ATOMIC_WAIT_ON_ADDRESS_STATICALLY_AVAILABLE / !_ATOMIC_WAIT_ON_ADDRESS_STATICALLY_AVAILABLE vvv
     switch (_Requested_api_level) {
     case __std_atomic_api_level::__not_set:
     case __std_atomic_api_level::__detecting:
@@ -404,7 +404,7 @@ _NODISCARD unsigned char __stdcall __std_atomic_compare_exchange_128(_Inout_byte
     return __std_atomic_compare_exchange_128_fallback(_Destination, _ExchangeHigh, _ExchangeLow, _ComparandResult);
 #elif _STD_ATOMIC_ALWAYS_USE_CMPXCHG16B == 1
     return _InterlockedCompareExchange128(_Destination, _ExchangeHigh, _ExchangeLow, _ComparandResult);
-#else // ^^^ _STD_ATOMIC_ALWAYS_USE_CMPXCHG16B == 1 // _STD_ATOMIC_ALWAYS_USE_CMPXCHG16B == 0 vvv
+#else // ^^^ _STD_ATOMIC_ALWAYS_USE_CMPXCHG16B == 1 / _STD_ATOMIC_ALWAYS_USE_CMPXCHG16B == 0 vvv
     if (__std_atomic_has_cmpxchg16b()) {
         return _InterlockedCompareExchange128(_Destination, _ExchangeHigh, _ExchangeLow, _ComparandResult);
     }
@@ -418,7 +418,7 @@ _NODISCARD char __stdcall __std_atomic_has_cmpxchg16b() noexcept {
     return false;
 #elif _STD_ATOMIC_ALWAYS_USE_CMPXCHG16B == 1
     return true;
-#else // ^^^ _STD_ATOMIC_ALWAYS_USE_CMPXCHG16B == 1 // _STD_ATOMIC_ALWAYS_USE_CMPXCHG16B == 0 vvv
+#else // ^^^ _STD_ATOMIC_ALWAYS_USE_CMPXCHG16B == 1 / _STD_ATOMIC_ALWAYS_USE_CMPXCHG16B == 0 vvv
     constexpr char _Cmpxchg_Absent  = 0;
     constexpr char _Cmpxchg_Present = 1;
     constexpr char _Cmpxchg_Unknown = 2;

--- a/stl/src/excptptr.cpp
+++ b/stl/src/excptptr.cpp
@@ -169,7 +169,7 @@ namespace {
 
 #if _EH_RELATIVE_TYPEINFO
         const auto _CopyFunc = reinterpret_cast<void*>(_ThrowImageBase + _PType->copyFunction);
-#else // ^^^ _EH_RELATIVE_TYPEINFO // !_EH_RELATIVE_TYPEINFO vvv
+#else // ^^^ _EH_RELATIVE_TYPEINFO / !_EH_RELATIVE_TYPEINFO vvv
         const auto _CopyFunc = _PType->copyFunction;
 #endif // _EH_RELATIVE_TYPEINFO
 
@@ -177,13 +177,13 @@ namespace {
         if (_PType->properties & CT_HasVirtualBase) {
 #ifdef _M_CEE_PURE
             reinterpret_cast<void(__clrcall*)(void*, void*, int)>(_CopyFunc)(_Dest, _Adjusted, 1);
-#else // ^^^ _M_CEE_PURE // !_M_CEE_PURE vvv
+#else // ^^^ _M_CEE_PURE / !_M_CEE_PURE vvv
             _CallMemberFunction2(_Dest, _CopyFunc, _Adjusted, 1);
 #endif // _M_CEE_PURE
         } else {
 #ifdef _M_CEE_PURE
             reinterpret_cast<void(__clrcall*)(void*, void*)>(_CopyFunc)(_Dest, _Adjusted);
-#else // ^^^ _M_CEE_PURE // !_M_CEE_PURE vvv
+#else // ^^^ _M_CEE_PURE / !_M_CEE_PURE vvv
             _CallMemberFunction1(_Dest, _CopyFunc, _Adjusted);
 #endif // _M_CEE_PURE
         }
@@ -268,7 +268,7 @@ namespace {
                 static_cast<uintptr_t>(_PThrow->pCatchableTypeArray) + _ThrowImageBase);
             const auto _PType = reinterpret_cast<CatchableType*>(
                 static_cast<uintptr_t>(_CatchableTypeArray->arrayOfCatchableTypes[0]) + _ThrowImageBase);
-#else // ^^^ _EH_RELATIVE_TYPEINFO // !_EH_RELATIVE_TYPEINFO vvv
+#else // ^^^ _EH_RELATIVE_TYPEINFO / !_EH_RELATIVE_TYPEINFO vvv
             const auto _PType = _PThrow->pCatchableTypeArray->arrayOfCatchableTypes[0];
 #endif // _EH_RELATIVE_TYPEINFO
 
@@ -279,7 +279,7 @@ namespace {
 #elif _EH_RELATIVE_TYPEINFO
                 _CallMemberFunction0(_CppEhRecord.params.pExceptionObject,
                     reinterpret_cast<void*>(_PThrow->pmfnUnwind + _ThrowImageBase));
-#else // ^^^ _EH_RELATIVE_TYPEINFO && !defined(_M_CEE_PURE) // !_EH_RELATIVE_TYPEINFO && !defined(_M_CEE_PURE) vvv
+#else // ^^^ _EH_RELATIVE_TYPEINFO && !defined(_M_CEE_PURE) / !_EH_RELATIVE_TYPEINFO && !defined(_M_CEE_PURE) vvv
                 _CallMemberFunction0(_CppEhRecord.params.pExceptionObject, _PThrow->pmfnUnwind);
 #endif
             } else if (_PType->properties & CT_IsWinRTHandle) {
@@ -335,7 +335,7 @@ namespace {
             static_cast<uintptr_t>(_PThrow->pCatchableTypeArray) + _ThrowImageBase);
         const auto _PType = reinterpret_cast<CatchableType*>(
             static_cast<uintptr_t>(_CatchableTypeArray->arrayOfCatchableTypes[0]) + _ThrowImageBase);
-#else // ^^^ _EH_RELATIVE_TYPEINFO // !_EH_RELATIVE_TYPEINFO vvv
+#else // ^^^ _EH_RELATIVE_TYPEINFO / !_EH_RELATIVE_TYPEINFO vvv
         const auto _PType = _PThrow->pCatchableTypeArray->arrayOfCatchableTypes[0];
 #endif // _EH_RELATIVE_TYPEINFO
 
@@ -384,7 +384,7 @@ namespace {
                 static_cast<uintptr_t>(_PInnerThrow->pCatchableTypeArray) + _InnerThrowImageBase);
             const auto _PInnerType = reinterpret_cast<CatchableType*>(
                 static_cast<uintptr_t>(_InnerCatchableTypeArray->arrayOfCatchableTypes[0]) + _InnerThrowImageBase);
-#else // ^^^ _EH_RELATIVE_TYPEINFO // !_EH_RELATIVE_TYPEINFO vvv
+#else // ^^^ _EH_RELATIVE_TYPEINFO / !_EH_RELATIVE_TYPEINFO vvv
             const auto _PInnerType = _PInnerThrow->pCatchableTypeArray->arrayOfCatchableTypes[0];
 #endif // _EH_RELATIVE_TYPEINFO
 
@@ -509,7 +509,7 @@ _CRTIMP2_PURE void __CLRCALL_PURE_OR_CDECL __ExceptionPtrCurrentException(void* 
 #if _EH_RELATIVE_TYPEINFO
         const auto _PType = reinterpret_cast<CatchableType*>(
             static_cast<uintptr_t>(_CatchableTypeArray->arrayOfCatchableTypes[0]) + _ThrowImageBase);
-#else // ^^^ _EH_RELATIVE_TYPEINFO // !_EH_RELATIVE_TYPEINFO vvv
+#else // ^^^ _EH_RELATIVE_TYPEINFO / !_EH_RELATIVE_TYPEINFO vvv
         const auto _PType              = _PThrow->pCatchableTypeArray->arrayOfCatchableTypes[0];
 #endif // _EH_RELATIVE_TYPEINFO
 

--- a/stl/src/filesystem.cpp
+++ b/stl/src/filesystem.cpp
@@ -34,7 +34,7 @@ namespace {
         return 0;
     }
 #define __vcrt_CreateSymbolicLinkW _Not_supported_CreateSymbolicLinkW
-#else // ^^^ _CRT_APP ^^^ / vvv !_CRT_APP vvv
+#else // ^^^ _CRT_APP / !_CRT_APP vvv
 #define __vcrt_CreateSymbolicLinkW CreateSymbolicLinkW
 #endif // _CRT_APP
 
@@ -51,7 +51,7 @@ namespace {
         _Create_file_parameters.hTemplateFile        = _Template_file;
         return CreateFile2(_File_name, _Desired_access, _Share, _Creation_disposition, &_Create_file_parameters);
     }
-#else // ^^^ _CRT_APP ^^^ / vvv !_CRT_APP vvv
+#else // ^^^ _CRT_APP / !_CRT_APP vvv
 #define __vcp_CreateFile CreateFileW
 #endif // _CRT_APP
 
@@ -77,7 +77,7 @@ namespace {
 
         // take lower bits to undo HRESULT_FROM_WIN32
         return {false, __std_win_error{_Copy_result & 0x0000FFFFU}};
-#else // ^^^ defined(_CRT_APP) ^^^ / vvv !defined(_CRT_APP) vvv
+#else // ^^^ defined(_CRT_APP) / !defined(_CRT_APP) vvv
         if (CopyFileW(_Source, _Target, _Fail_if_exists)) {
             return {true, __std_win_error::_Success};
         }
@@ -463,7 +463,7 @@ _Success_(return == __std_win_error::_Success) __std_win_error
     (void) _File_name;
     (void) _Existing_file_name;
     return __std_win_error::_Not_supported;
-#else // ^^^ defined(_CRT_APP) ^^^ / vvv !defined(_CRT_APP) vvv
+#else // ^^^ defined(_CRT_APP) / !defined(_CRT_APP) vvv
     if (CreateHardLinkW(_File_name, _Existing_file_name, nullptr)) {
         return __std_win_error::_Success;
     }
@@ -997,7 +997,7 @@ namespace {
 #if defined(_CRT_APP)
     (void) _Template_directory;
     return __std_fs_create_directory(_New_directory);
-#else // ^^^ defined(_CRT_APP) ^^^ / vvv !defined(_CRT_APP) vvv
+#else // ^^^ defined(_CRT_APP) / !defined(_CRT_APP) vvv
     if (CreateDirectoryExW(_Template_directory, _New_directory, nullptr)) {
         return {true, __std_win_error::_Success};
     }

--- a/stl/src/filesystem.cpp
+++ b/stl/src/filesystem.cpp
@@ -34,7 +34,7 @@ namespace {
         return 0;
     }
 #define __vcrt_CreateSymbolicLinkW _Not_supported_CreateSymbolicLinkW
-#else // ^^^ _CRT_APP ^^^ // vvv !_CRT_APP vvv
+#else // ^^^ _CRT_APP ^^^ / vvv !_CRT_APP vvv
 #define __vcrt_CreateSymbolicLinkW CreateSymbolicLinkW
 #endif // _CRT_APP
 
@@ -51,7 +51,7 @@ namespace {
         _Create_file_parameters.hTemplateFile        = _Template_file;
         return CreateFile2(_File_name, _Desired_access, _Share, _Creation_disposition, &_Create_file_parameters);
     }
-#else // ^^^ _CRT_APP ^^^ // vvv !_CRT_APP vvv
+#else // ^^^ _CRT_APP ^^^ / vvv !_CRT_APP vvv
 #define __vcp_CreateFile CreateFileW
 #endif // _CRT_APP
 
@@ -77,7 +77,7 @@ namespace {
 
         // take lower bits to undo HRESULT_FROM_WIN32
         return {false, __std_win_error{_Copy_result & 0x0000FFFFU}};
-#else // ^^^ defined(_CRT_APP) ^^^ // vvv !defined(_CRT_APP) vvv
+#else // ^^^ defined(_CRT_APP) ^^^ / vvv !defined(_CRT_APP) vvv
         if (CopyFileW(_Source, _Target, _Fail_if_exists)) {
             return {true, __std_win_error::_Success};
         }
@@ -463,7 +463,7 @@ _Success_(return == __std_win_error::_Success) __std_win_error
     (void) _File_name;
     (void) _Existing_file_name;
     return __std_win_error::_Not_supported;
-#else // ^^^ defined(_CRT_APP) ^^^ // vvv !defined(_CRT_APP) vvv
+#else // ^^^ defined(_CRT_APP) ^^^ / vvv !defined(_CRT_APP) vvv
     if (CreateHardLinkW(_File_name, _Existing_file_name, nullptr)) {
         return __std_win_error::_Success;
     }
@@ -997,7 +997,7 @@ namespace {
 #if defined(_CRT_APP)
     (void) _Template_directory;
     return __std_fs_create_directory(_New_directory);
-#else // ^^^ defined(_CRT_APP) ^^^ // vvv !defined(_CRT_APP) vvv
+#else // ^^^ defined(_CRT_APP) ^^^ / vvv !defined(_CRT_APP) vvv
     if (CreateDirectoryExW(_Template_directory, _New_directory, nullptr)) {
         return {true, __std_win_error::_Success};
     }

--- a/stl/src/taskscheduler.cpp
+++ b/stl/src/taskscheduler.cpp
@@ -40,7 +40,7 @@ namespace Concurrency {
                 (void) _Flags;
                 (void) _Addr;
                 return nullptr;
-#else // ^^^ defined(_CRT_APP) ^^^ // vvv !defined(_CRT_APP) vvv
+#else // ^^^ defined(_CRT_APP) ^^^ / vvv !defined(_CRT_APP) vvv
                 HMODULE _Result;
                 if (!GetModuleHandleExW(_Flags, _Addr, &_Result)) {
                     return nullptr;
@@ -55,7 +55,7 @@ namespace Concurrency {
             _STL_host_status _Get_STL_host_status() {
 #ifdef CRTDLL2
                 return _STL_host_status::_Dll;
-#else // ^^^ CRTDLL2 ^^^ // vvv !CRTDLL2 vvv
+#else // ^^^ CRTDLL2 ^^^ / vvv !CRTDLL2 vvv
                 HANDLE _HExe = _Call_get_module_handle_ex(GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT, nullptr);
                 if (_HExe == nullptr) {
                     return _STL_host_status::_Unknown;
@@ -73,7 +73,7 @@ namespace Concurrency {
             // code is sufficient.
             void _Increment_outstanding() {}
             void _Decrement_outstanding() {}
-#else // ^^^ CRTDLL2 ^^^ // vvv !CRTDLL2 vvv
+#else // ^^^ CRTDLL2 ^^^ / vvv !CRTDLL2 vvv
             size_t _Outstanding_tasks = 0;
             _STD mutex _Task_cv_mutex;
             _STD condition_variable _Task_cv;

--- a/stl/src/taskscheduler.cpp
+++ b/stl/src/taskscheduler.cpp
@@ -41,7 +41,7 @@ namespace Concurrency {
                 (void) _Flags;
                 (void) _Addr;
                 return nullptr;
-#else // ^^^ defined(_CRT_APP) ^^^ / vvv !defined(_CRT_APP) vvv
+#else // ^^^ defined(_CRT_APP) / !defined(_CRT_APP) vvv
                 HMODULE _Result;
                 if (!GetModuleHandleExW(_Flags, _Addr, &_Result)) {
                     return nullptr;
@@ -56,7 +56,7 @@ namespace Concurrency {
             _STL_host_status _Get_STL_host_status() {
 #ifdef CRTDLL2
                 return _STL_host_status::_Dll;
-#else // ^^^ CRTDLL2 ^^^ / vvv !CRTDLL2 vvv
+#else // ^^^ CRTDLL2 / !CRTDLL2 vvv
                 HANDLE _HExe = _Call_get_module_handle_ex(GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT, nullptr);
                 if (_HExe == nullptr) {
                     return _STL_host_status::_Unknown;
@@ -74,7 +74,7 @@ namespace Concurrency {
             // code is sufficient.
             void _Increment_outstanding() {}
             void _Decrement_outstanding() {}
-#else // ^^^ CRTDLL2 ^^^ / vvv !CRTDLL2 vvv
+#else // ^^^ CRTDLL2 / !CRTDLL2 vvv
             size_t _Outstanding_tasks = 0;
             _STD mutex _Task_cv_mutex;
             _STD condition_variable _Task_cv;

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -673,7 +673,7 @@ namespace {
 
 #ifdef _M_IX86
         static constexpr bool _Has_portion_max = false;
-#else // ^^^ 32-bit ^^^ / vvv 64-bit vvv
+#else // ^^^ 32-bit / 64-bit vvv
         static constexpr bool _Has_portion_max = true;
         static constexpr size_t _Portion_max = 0x1'0000'0000ULL;
 #endif // ^^^ 64-bit ^^^
@@ -792,7 +792,7 @@ namespace {
             return static_cast<_Signed_t>(
                 (static_cast<_Unsigned_t>(static_cast<uint32_t>(_mm_extract_epi32(_Cur, 1))) << 32)
                 | static_cast<_Unsigned_t>(static_cast<uint32_t>(_mm_cvtsi128_si32(_Cur))));
-#else // ^^^ x86 ^^^ / vvv x64 vvv
+#else // ^^^ x86 / x64 vvv
             return static_cast<_Signed_t>(_mm_cvtsi128_si64(_Cur));
 #endif // ^^^ x64 ^^^
         }

--- a/tests/std/include/instantiate_algorithms.hpp
+++ b/tests/std/include/instantiate_algorithms.hpp
@@ -161,7 +161,7 @@ namespace std_testing {
             std::merge(in1, in1, in2, in2, out, COMP{});
             std::set_union(in1, in1, in2, in2, out);
             std::set_union(in1, in1, in2, in2, out, COMP{});
-#else // ^^^ SPLIT_MODE 1 ^^^ // vvv SPLIT_MODE 2 vvv //
+#else // ^^^ SPLIT_MODE 1 ^^^ / vvv SPLIT_MODE 2 vvv
             std::set_intersection(in1, in1, in2, in2, out);
             std::set_intersection(in1, in1, in2, in2, out, COMP{});
             std::set_difference(in1, in1, in2, in2, out);
@@ -288,7 +288,7 @@ namespace std_testing {
             FLST.assign(in1, in1);
             FLST.insert_after(FLST.begin(), in1, in1);
 
-#else // ^^^ SPLIT_MODE 1 ^^^ // vvv SPLIT_MODE 2 vvv //
+#else // ^^^ SPLIT_MODE 1 ^^^ / vvv SPLIT_MODE 2 vvv
             (void) std::all_of(in1, in1, PRED{});
             (void) std::any_of(in1, in1, PRED{});
             (void) std::none_of(in1, in1, PRED{});

--- a/tests/std/include/instantiate_algorithms.hpp
+++ b/tests/std/include/instantiate_algorithms.hpp
@@ -161,7 +161,7 @@ namespace std_testing {
             std::merge(in1, in1, in2, in2, out, COMP{});
             std::set_union(in1, in1, in2, in2, out);
             std::set_union(in1, in1, in2, in2, out, COMP{});
-#else // ^^^ SPLIT_MODE 1 ^^^ / vvv SPLIT_MODE 2 vvv
+#else // ^^^ SPLIT_MODE 1 / SPLIT_MODE 2 vvv
             std::set_intersection(in1, in1, in2, in2, out);
             std::set_intersection(in1, in1, in2, in2, out, COMP{});
             std::set_difference(in1, in1, in2, in2, out);
@@ -288,7 +288,7 @@ namespace std_testing {
             FLST.assign(in1, in1);
             FLST.insert_after(FLST.begin(), in1, in1);
 
-#else // ^^^ SPLIT_MODE 1 ^^^ / vvv SPLIT_MODE 2 vvv
+#else // ^^^ SPLIT_MODE 1 / SPLIT_MODE 2 vvv
             (void) std::all_of(in1, in1, PRED{});
             (void) std::any_of(in1, in1, PRED{});
             (void) std::none_of(in1, in1, PRED{});

--- a/tests/std/include/parallel_algorithms_utilities.hpp
+++ b/tests/std/include/parallel_algorithms_utilities.hpp
@@ -11,7 +11,7 @@
 const size_t max_parallel_test_case_n = 4096;
 // the number of linear steps a test case that is quadratic should attempt:
 const size_t quadratic_complexity_case_limit = std::numeric_limits<std::size_t>::max();
-#else // ^^^ EXHAUSTIVE ^^^ / vvv !EXHAUSTIVE vvv
+#else // ^^^ EXHAUSTIVE / !EXHAUSTIVE vvv
 // The constant 32 comes from std::_Oversubscription_multiplier
 const size_t max_parallel_test_case_n        = std::max(4u, std::thread::hardware_concurrency() * 32) + 1;
 const size_t quadratic_complexity_case_limit = 128;
@@ -24,7 +24,7 @@ void parallel_test_case(Fx fn, Args&... vals) {
     // call fn with "interesting" test case sizes and additional parameters
 #ifdef EXHAUSTIVE
     for (size_t testSize = 0; testSize < max_parallel_test_case_n; ++testSize) {
-#else // ^^^ EXHAUSTIVE ^^^ / vvv !EXHAUSTIVE vvv
+#else // ^^^ EXHAUSTIVE / !EXHAUSTIVE vvv
     static const size_t cases[] = {
         0, 1, 2, max_parallel_test_case_n - 2, max_parallel_test_case_n - 1, max_parallel_test_case_n};
     for (size_t testSize : cases) {

--- a/tests/std/include/parallel_algorithms_utilities.hpp
+++ b/tests/std/include/parallel_algorithms_utilities.hpp
@@ -11,7 +11,7 @@
 const size_t max_parallel_test_case_n = 4096;
 // the number of linear steps a test case that is quadratic should attempt:
 const size_t quadratic_complexity_case_limit = std::numeric_limits<std::size_t>::max();
-#else // ^^^ EXHAUSTIVE ^^^ // vvv !EXHAUSTIVE vvv
+#else // ^^^ EXHAUSTIVE ^^^ / vvv !EXHAUSTIVE vvv
 // The constant 32 comes from std::_Oversubscription_multiplier
 const size_t max_parallel_test_case_n        = std::max(4u, std::thread::hardware_concurrency() * 32) + 1;
 const size_t quadratic_complexity_case_limit = 128;
@@ -24,7 +24,7 @@ void parallel_test_case(Fx fn, Args&... vals) {
     // call fn with "interesting" test case sizes and additional parameters
 #ifdef EXHAUSTIVE
     for (size_t testSize = 0; testSize < max_parallel_test_case_n; ++testSize) {
-#else // ^^^ EXHAUSTIVE ^^^ // vvv !EXHAUSTIVE vvv
+#else // ^^^ EXHAUSTIVE ^^^ / vvv !EXHAUSTIVE vvv
     static const size_t cases[] = {
         0, 1, 2, max_parallel_test_case_n - 2, max_parallel_test_case_n - 1, max_parallel_test_case_n};
     for (size_t testSize : cases) {

--- a/tests/std/tests/Dev11_0535636_functional_overhaul/test.cpp
+++ b/tests/std/tests/Dev11_0535636_functional_overhaul/test.cpp
@@ -1217,7 +1217,7 @@ STATIC_ASSERT(TestRWTypes<Pmf2, None, None, None, None>::value);
 STATIC_ASSERT(TestRWTypes<Pmf0c, None, None, None, None>::value);
 STATIC_ASSERT(TestRWTypes<Pmf1c, None, None, None, None>::value);
 STATIC_ASSERT(TestRWTypes<Pmf2c, None, None, None, None>::value);
-#else // ^^^ _HAS_CXX20 // !_HAS_CXX20 vvv
+#else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
 STATIC_ASSERT(TestTypes<reference_wrapper<Fxn0>, char, None, None, None>::value);
 STATIC_ASSERT(TestTypes<reference_wrapper<Fxn1>, short, short*, None, None>::value);
 STATIC_ASSERT(TestTypes<reference_wrapper<Fxn2>, int, None, int*, int**>::value);
@@ -1281,7 +1281,7 @@ STATIC_ASSERT(TestRWTypes<OnlySecond, None, None, None, None>::value);
 STATIC_ASSERT(TestRWTypes<BothFirstSecond, None, None, None, None>::value);
 STATIC_ASSERT(TestRWTypes<NormalOne, None, None, None, None>::value);
 STATIC_ASSERT(TestRWTypes<NormalTwo, None, None, None, None>::value);
-#else // ^^^ _HAS_CXX20 // !_HAS_CXX20 vvv
+#else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
 STATIC_ASSERT(TestRWTypes<OnlyRes, bool, None, None, None>::value);
 STATIC_ASSERT(TestRWTypes<OnlyArg, None, bool*, None, None>::value);
 STATIC_ASSERT(TestRWTypes<OnlyFirst, None, None, None, None>::value);
@@ -1306,7 +1306,7 @@ struct SameResults : UnaryFunction<int, bool>, BinaryFunction<short, long, bool>
 
 #if _HAS_CXX20
 STATIC_ASSERT(TestRWTypes<SameResults, None, None, None, None>::value);
-#else // ^^^ _HAS_CXX20 // !_HAS_CXX20 vvv
+#else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
 STATIC_ASSERT(TestRWTypes<SameResults, bool, int, short, long>::value);
 #endif // _HAS_CXX20
 
@@ -1314,7 +1314,7 @@ struct DifferentResults : UnaryFunction<unsigned int, float>, BinaryFunction<uns
 
 #if _HAS_CXX20
 STATIC_ASSERT(TestRWTypes<DifferentResults, None, None, None, None>::value);
-#else // ^^^ _HAS_CXX20 // !_HAS_CXX20 vvv
+#else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
 STATIC_ASSERT(TestRWTypes<DifferentResults, None, unsigned int, unsigned short, unsigned long>::value);
 #endif // _HAS_CXX20
 

--- a/tests/std/tests/GH_000431_equal_family/test.cpp
+++ b/tests/std/tests/GH_000431_equal_family/test.cpp
@@ -624,7 +624,7 @@ void test_algorithms(EqualFn equal_fn) {
 
 #if _HAS_CXX20 && !defined(__clang__) && !defined(__EDG__) // TRANSITION, DevCom-1535084
 #define assert2(x)
-#else // ^^^ ICE ^^^ / vvv no ICE vvv
+#else // ^^^ ICE / no ICE vvv
 #define assert2 assert
 #endif // ^^^ no ICE ^^^
 

--- a/tests/std/tests/GH_000431_equal_memcmp_is_safe/test.compile.pass.cpp
+++ b/tests/std/tests/GH_000431_equal_memcmp_is_safe/test.compile.pass.cpp
@@ -441,7 +441,7 @@ STATIC_ASSERT(test_equal_memcmp_is_safe_for_pred<true, volatile void*, void*, eq
 constexpr bool enable_derived_to_base =
 #ifdef __cpp_lib_is_pointer_interconvertible
     true
-#else // ^^^ __cpp_lib_is_pointer_interconvertible ^^^ / vvv !__cpp_lib_is_pointer_interconvertible vvv
+#else // ^^^ __cpp_lib_is_pointer_interconvertible / !__cpp_lib_is_pointer_interconvertible vvv
     false
 #endif // ^^^ !__cpp_lib_is_pointer_interconvertible ^^^
     ;

--- a/tests/std/tests/GH_000431_iter_copy_move_cat/test.compile.pass.cpp
+++ b/tests/std/tests/GH_000431_iter_copy_move_cat/test.compile.pass.cpp
@@ -387,7 +387,7 @@ void iter_cat_test_cases() {
     constexpr bool enable_derived_to_base =
 #ifdef __cpp_lib_is_pointer_interconvertible
         true
-#else // ^^^ __cpp_lib_is_pointer_interconvertible ^^^ / vvv !__cpp_lib_is_pointer_interconvertible vvv
+#else // ^^^ __cpp_lib_is_pointer_interconvertible / !__cpp_lib_is_pointer_interconvertible vvv
         false
 #endif // ^^^ !__cpp_lib_is_pointer_interconvertible ^^^
         ;

--- a/tests/std/tests/GH_002030_asan_annotate_string/test.cpp
+++ b/tests/std/tests/GH_002030_asan_annotate_string/test.cpp
@@ -193,7 +193,7 @@ bool verify_string(basic_string<CharType, char_traits<CharType>, Alloc>& str) {
     const void* aligned_mid = mid > aligned_start ? mid : aligned_start;
 
     return __sanitizer_verify_contiguous_container(aligned_start, aligned_mid, end) != 0;
-#else // ^^^ ASan instrumentation enabled ^^^ / vvv ASan instrumentation disabled vvv
+#else // ^^^ ASan instrumentation enabled / ASan instrumentation disabled vvv
     (void) str;
     return true;
 #endif // ASan instrumentation disabled

--- a/tests/std/tests/GH_002030_asan_annotate_string/test.cpp
+++ b/tests/std/tests/GH_002030_asan_annotate_string/test.cpp
@@ -193,7 +193,7 @@ bool verify_string(basic_string<CharType, char_traits<CharType>, Alloc>& str) {
     const void* aligned_mid = mid > aligned_start ? mid : aligned_start;
 
     return __sanitizer_verify_contiguous_container(aligned_start, aligned_mid, end) != 0;
-#else // ^^^ ASan instrumentation enabled ^^^ // vvv ASan instrumentation disabled vvv
+#else // ^^^ ASan instrumentation enabled ^^^ / vvv ASan instrumentation disabled vvv
     (void) str;
     return true;
 #endif // ASan instrumentation disabled

--- a/tests/std/tests/GH_002030_asan_annotate_vector/test.cpp
+++ b/tests/std/tests/GH_002030_asan_annotate_vector/test.cpp
@@ -178,7 +178,7 @@ bool verify_vector(vector<T, Alloc>& vec) {
     __asan_describe_address(bad_address);
 
     return false;
-#else // ^^^ ASan instrumentation enabled ^^^ / vvv ASan instrumentation disabled vvv
+#else // ^^^ ASan instrumentation enabled / ASan instrumentation disabled vvv
     (void) vec;
     return true;
 #endif // Asan instrumentation disabled

--- a/tests/std/tests/GH_002030_asan_annotate_vector/test.cpp
+++ b/tests/std/tests/GH_002030_asan_annotate_vector/test.cpp
@@ -178,7 +178,7 @@ bool verify_vector(vector<T, Alloc>& vec) {
     __asan_describe_address(bad_address);
 
     return false;
-#else // ^^^ ASan instrumentation enabled ^^^ // vvv ASan instrumentation disabled vvv
+#else // ^^^ ASan instrumentation enabled ^^^ / vvv ASan instrumentation disabled vvv
     (void) vec;
     return true;
 #endif // Asan instrumentation disabled

--- a/tests/std/tests/GH_002769_handle_deque_block_pointers/test.cpp
+++ b/tests/std/tests/GH_002769_handle_deque_block_pointers/test.cpp
@@ -140,7 +140,7 @@ public:
     friend bool operator==(const counting_ptr& lhs, const counting_ptr& rhs) = default;
 
     friend auto operator<=>(const counting_ptr& lhs, const counting_ptr& rhs) = default;
-#else // ^^^ _HAS_CXX20 ^^^ / vvv !_HAS_CXX20 vvv
+#else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
     friend bool operator==(nullptr_t, const counting_ptr& p) noexcept {
         return p.p_ == nullptr;
     }

--- a/tests/std/tests/P0024R2_parallel_algorithms_all_of/test.cpp
+++ b/tests/std/tests/P0024R2_parallel_algorithms_all_of/test.cpp
@@ -23,7 +23,7 @@ void test_case_all_of_parallel(const size_t testSize) {
         assert(!all_of(par, c.begin(), c.end(), read_char_as_bool));
         b = true;
     }
-#else // ^^^ EXHAUSTIVE ^^^ / vvv !EXHAUSTIVE vvv
+#else // ^^^ EXHAUSTIVE / !EXHAUSTIVE vvv
     if (testSize != 0) {
         c[testSize / 2] = false;
         assert(!all_of(par, c.begin(), c.end(), read_char_as_bool));

--- a/tests/std/tests/P0024R2_parallel_algorithms_all_of/test.cpp
+++ b/tests/std/tests/P0024R2_parallel_algorithms_all_of/test.cpp
@@ -23,7 +23,7 @@ void test_case_all_of_parallel(const size_t testSize) {
         assert(!all_of(par, c.begin(), c.end(), read_char_as_bool));
         b = true;
     }
-#else // ^^^ EXHAUSTIVE ^^^ // vvv !EXHAUSTIVE vvv
+#else // ^^^ EXHAUSTIVE ^^^ / vvv !EXHAUSTIVE vvv
     if (testSize != 0) {
         c[testSize / 2] = false;
         assert(!all_of(par, c.begin(), c.end(), read_char_as_bool));

--- a/tests/std/tests/P0024R2_parallel_algorithms_equal/test.cpp
+++ b/tests/std/tests/P0024R2_parallel_algorithms_equal/test.cpp
@@ -68,7 +68,7 @@ void test_case_equal_parallel(const size_t testSize) {
             assert(!equal(par, defaults.begin(), defaults.end(), tmp.begin(), tmp.end()));
             b = {};
         }
-#else // ^^^ EXHAUSTIVE ^^^ / vvv !EXHAUSTIVE vvv
+#else // ^^^ EXHAUSTIVE / !EXHAUSTIVE vvv
         if (testSize != 0) {
             auto middle = tmp.begin();
             advance(middle, static_cast<ptrdiff_t>(testSize / 2));

--- a/tests/std/tests/P0024R2_parallel_algorithms_equal/test.cpp
+++ b/tests/std/tests/P0024R2_parallel_algorithms_equal/test.cpp
@@ -68,7 +68,7 @@ void test_case_equal_parallel(const size_t testSize) {
             assert(!equal(par, defaults.begin(), defaults.end(), tmp.begin(), tmp.end()));
             b = {};
         }
-#else // ^^^ EXHAUSTIVE ^^^ // vvv !EXHAUSTIVE vvv
+#else // ^^^ EXHAUSTIVE ^^^ / vvv !EXHAUSTIVE vvv
         if (testSize != 0) {
             auto middle = tmp.begin();
             advance(middle, static_cast<ptrdiff_t>(testSize / 2));

--- a/tests/std/tests/P0024R2_parallel_algorithms_find/test.cpp
+++ b/tests/std/tests/P0024R2_parallel_algorithms_find/test.cpp
@@ -42,7 +42,7 @@ void test_case_find_parallel(const size_t testSize) {
             assert(find_if_not(par, tmp.begin(), tmp.end(), is_zero) == target);
             *target = zero;
         }
-#else // ^^^ EXHAUSTIVE ^^^ // vvv !EXHAUSTIVE vvv
+#else // ^^^ EXHAUSTIVE ^^^ / vvv !EXHAUSTIVE vvv
         if (testSize != 0) {
             auto middle = tmp.begin();
             advance(middle, static_cast<ptrdiff_t>(testSize / 2));

--- a/tests/std/tests/P0024R2_parallel_algorithms_find/test.cpp
+++ b/tests/std/tests/P0024R2_parallel_algorithms_find/test.cpp
@@ -42,7 +42,7 @@ void test_case_find_parallel(const size_t testSize) {
             assert(find_if_not(par, tmp.begin(), tmp.end(), is_zero) == target);
             *target = zero;
         }
-#else // ^^^ EXHAUSTIVE ^^^ / vvv !EXHAUSTIVE vvv
+#else // ^^^ EXHAUSTIVE / !EXHAUSTIVE vvv
         if (testSize != 0) {
             auto middle = tmp.begin();
             advance(middle, static_cast<ptrdiff_t>(testSize / 2));

--- a/tests/std/tests/P0040R3_extending_memory_management_tools/test.cpp
+++ b/tests/std/tests/P0040R3_extending_memory_management_tools/test.cpp
@@ -62,7 +62,7 @@ struct uninitialized_storage {
         size_t space      = sizeof(storage);
         return static_cast<T*>(align(alignof(T), sizeof(T), storageVoid, space));
     }
-#else // ^^^ _M_CEE ^^^ / vvv !_M_CEE vvv
+#else // ^^^ _M_CEE / !_M_CEE vvv
     alignas(T) char storage[sizeof(T) * Count];
 
     T* begin() {

--- a/tests/std/tests/P0040R3_extending_memory_management_tools/test.cpp
+++ b/tests/std/tests/P0040R3_extending_memory_management_tools/test.cpp
@@ -62,7 +62,7 @@ struct uninitialized_storage {
         size_t space      = sizeof(storage);
         return static_cast<T*>(align(alignof(T), sizeof(T), storageVoid, space));
     }
-#else // ^^^ _M_CEE ^^^ // vvv !_M_CEE vvv
+#else // ^^^ _M_CEE ^^^ / vvv !_M_CEE vvv
     alignas(T) char storage[sizeof(T) * Count];
 
     T* begin() {

--- a/tests/std/tests/P0088R3_variant/test.cpp
+++ b/tests/std/tests/P0088R3_variant/test.cpp
@@ -7917,6 +7917,6 @@ int main() {
     msvc::DevCom1031281::run_test();
     msvc::gh2770::run_test();
 }
-#else // ^^^ not x86 or not /analyze ^^^ / vvv x86 /analyze vvv
+#else // ^^^ not x86 or not /analyze / x86 /analyze vvv
 int main() {}
 #endif // !defined(_PREFAST_) || !defined(_M_IX86)

--- a/tests/std/tests/P0288R9_move_only_function/test.cpp
+++ b/tests/std/tests/P0288R9_move_only_function/test.cpp
@@ -393,7 +393,7 @@ void test_noexcept() {
     static_assert(!noexcept(declval<f_x>()()));
 #ifdef __cpp_noexcept_function_type
     static_assert(noexcept(declval<f_nx>()()));
-#else // ^^^ defined(__cpp_noexcept_function_type) ^^^ / vvv !defined(__cpp_noexcept_function_type) vvv
+#else // ^^^ defined(__cpp_noexcept_function_type) / !defined(__cpp_noexcept_function_type) vvv
     static_assert(!noexcept(declval<f_nx>()()));
 #endif // ^^^ !defined(__cpp_noexcept_function_type) ^^^
 
@@ -405,7 +405,7 @@ void test_noexcept() {
 
 #ifdef __cpp_noexcept_function_type
     static_assert(!is_constructible_v<f_nx, test_noexcept_t<false>>);
-#else // ^^^ defined(__cpp_noexcept_function_type) ^^^ / vvv !defined(__cpp_noexcept_function_type) vvv
+#else // ^^^ defined(__cpp_noexcept_function_type) / !defined(__cpp_noexcept_function_type) vvv
     static_assert(is_constructible_v<f_nx, test_noexcept_t<false>>);
     assert(f_nx(test_noexcept_t<false>{})() == 888);
 #endif // ^^^ !defined(__cpp_noexcept_function_type) ^^^

--- a/tests/std/tests/P0513R0_poisoning_the_hash/test.cpp
+++ b/tests/std/tests/P0513R0_poisoning_the_hash/test.cpp
@@ -173,7 +173,7 @@ void test_string_T_hash_invariants(const CharT* const exampleStr) {
     hash<basic_string<CharT>> hString;
     hash<basic_string_view<CharT>> hStringView;
     assert(hString(exampleStr) == hStringView(exampleStr));
-#else // ^^^ _HAS_CXX17 ^^^ / vvv !_HAS_CXX17 vvv
+#else // ^^^ _HAS_CXX17 / !_HAS_CXX17 vvv
     (void) exampleStr;
 #endif // _HAS_CXX17
 }

--- a/tests/std/tests/P0513R0_poisoning_the_hash/test.cpp
+++ b/tests/std/tests/P0513R0_poisoning_the_hash/test.cpp
@@ -173,7 +173,7 @@ void test_string_T_hash_invariants(const CharT* const exampleStr) {
     hash<basic_string<CharT>> hString;
     hash<basic_string_view<CharT>> hStringView;
     assert(hString(exampleStr) == hStringView(exampleStr));
-#else // ^^^ _HAS_CXX17 ^^^ // vvv !_HAS_CXX17 vvv
+#else // ^^^ _HAS_CXX17 ^^^ / vvv !_HAS_CXX17 vvv
     (void) exampleStr;
 #endif // _HAS_CXX17
 }

--- a/tests/std/tests/P0881R7_stacktrace/test.cpp
+++ b/tests/std/tests/P0881R7_stacktrace/test.cpp
@@ -17,7 +17,7 @@
 
 #ifdef HAS_EXPORT
 #define MAYBE_EXPORT __declspec(dllexport)
-#else // ^^^ HAS_EXPORT ^^^ / vvv !HAS_EXPORT vvv
+#else // ^^^ HAS_EXPORT / !HAS_EXPORT vvv
 #define MAYBE_EXPORT
 #endif // ^^^ !HAS_EXPORT ^^^
 
@@ -175,7 +175,7 @@ void test_impl() {
     assert(all.at(1).source_line() == base_line + 9);
     assert(all.at(2).source_line() == base_line + 13);
     assert(all.at(3).source_line() == base_line + 17);
-#else // ^^^ HAS_DEBUG_INFO ^^^ / vvv !HAS_DEBUG_INFO vvv
+#else // ^^^ HAS_DEBUG_INFO / !HAS_DEBUG_INFO vvv
     assert(filesystem::path(all.at(0).source_file()).filename() == ""sv);
     assert(filesystem::path(all.at(1).source_file()).filename() == ""sv);
     assert(filesystem::path(all.at(2).source_file()).filename() == ""sv);
@@ -192,7 +192,7 @@ void test_impl() {
     assert(trim_past_plus(all.at(1).description()) == "P0881R7_stacktrace!all_inner"sv);
     assert(trim_past_plus(all.at(2).description()) == "P0881R7_stacktrace!all_outer"sv);
     assert(trim_past_plus(all.at(3).description()) == "P0881R7_stacktrace!all_outermost"sv);
-#else // ^^^ HAS_NAMES ^^^ / vvv !HAS_NAMES vvv
+#else // ^^^ HAS_NAMES / !HAS_NAMES vvv
     assert(trim_past_plus(all.at(0).description()) == "P0881R7_stacktrace"sv);
     assert(trim_past_plus(all.at(1).description()) == "P0881R7_stacktrace"sv);
     assert(trim_past_plus(all.at(2).description()) == "P0881R7_stacktrace"sv);
@@ -210,7 +210,7 @@ void test_impl() {
     assert(all_but_top[0].source_line() == base_line + 25);
     assert(all_but_top[1].source_line() == base_line + 29);
     assert(all_but_top[2].source_line() == base_line + 33);
-#else // ^^^ HAS_DEBUG_INFO ^^^ / vvv !HAS_DEBUG_INFO vvv
+#else // ^^^ HAS_DEBUG_INFO / !HAS_DEBUG_INFO vvv
     assert(filesystem::path(all_but_top[0].source_file()).filename() == ""sv);
     assert(filesystem::path(all_but_top[1].source_file()).filename() == ""sv);
     assert(filesystem::path(all_but_top[2].source_file()).filename() == ""sv);
@@ -224,7 +224,7 @@ void test_impl() {
     assert(trim_past_plus(all_but_top[0].description()) == "P0881R7_stacktrace!all_but_top_inner"sv);
     assert(trim_past_plus(all_but_top[1].description()) == "P0881R7_stacktrace!all_but_top_outer"sv);
     assert(trim_past_plus(all_but_top[2].description()) == "P0881R7_stacktrace!all_but_top_outermost"sv);
-#else // ^^^ HAS_NAMES ^^^ / vvv !HAS_NAMES vvv
+#else // ^^^ HAS_NAMES / !HAS_NAMES vvv
     assert(trim_past_plus(all_but_top[0].description()) == "P0881R7_stacktrace"sv);
     assert(trim_past_plus(all_but_top[1].description()) == "P0881R7_stacktrace"sv);
     assert(trim_past_plus(all_but_top[2].description()) == "P0881R7_stacktrace"sv);
@@ -240,7 +240,7 @@ void test_impl() {
     assert(three_excluding_top[0].source_line() == base_line + 41);
     assert(three_excluding_top[1].source_line() == base_line + 45);
     assert(three_excluding_top[2].source_line() == base_line + 49);
-#else // ^^^ HAS_DEBUG_INFO ^^^ / vvv !HAS_DEBUG_INFO vvv
+#else // ^^^ HAS_DEBUG_INFO / !HAS_DEBUG_INFO vvv
     assert(filesystem::path(three_excluding_top[0].source_file()).filename() == ""sv);
     assert(filesystem::path(three_excluding_top[1].source_file()).filename() == ""sv);
     assert(filesystem::path(three_excluding_top[2].source_file()).filename() == ""sv);
@@ -255,7 +255,7 @@ void test_impl() {
     assert(trim_past_plus(three_excluding_top[1].description()) == "P0881R7_stacktrace!three_excluding_top_outer"sv);
     assert(
         trim_past_plus(three_excluding_top[2].description()) == "P0881R7_stacktrace!three_excluding_top_outermost"sv);
-#else // ^^^ HAS_NAMES ^^^ / vvv !HAS_NAMES vvv
+#else // ^^^ HAS_NAMES / !HAS_NAMES vvv
     assert(trim_past_plus(three_excluding_top[0].description()) == "P0881R7_stacktrace"sv);
     assert(trim_past_plus(three_excluding_top[1].description()) == "P0881R7_stacktrace"sv);
     assert(trim_past_plus(three_excluding_top[2].description()) == "P0881R7_stacktrace"sv);

--- a/tests/std/tests/P0896R4_ranges_alg_find_first_of/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_find_first_of/test.cpp
@@ -70,7 +70,7 @@ int main() {
     STATIC_ASSERT((test_in_fwd<instantiator, const P, const int>(), true));
     test_in_fwd<instantiator, const P, const int>();
 }
-#else // ^^^ test all range combinations // test only interesting range combos vvv
+#else // ^^^ test all range combinations / test only interesting range combos vvv
 constexpr bool run_tests() {
     // The algorithm is oblivious to anything except maybe proxies so take the bare minimum input/forward range
     using in_test_range  = test::range<input_iterator_tag, const P, test::Sized::no, test::CanDifference::no,

--- a/tests/std/tests/P0896R4_ranges_alg_is_permutation/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_is_permutation/test.cpp
@@ -154,7 +154,7 @@ int main() {
     // No constexpr test here; this test_fwd_fwd call exceeds the maximum number of steps in a constexpr computation.
     test_fwd_fwd<instantiator, const P, const int>();
 }
-#else // ^^^ test all range combinations // test only interesting range combos vvv
+#else // ^^^ test all range combinations / test only interesting range combos vvv
 template <class Elem, test::Sized IsSized>
 using fwd_test_range = test::range<forward_iterator_tag, Elem, IsSized, test::CanDifference::no, test::Common::no,
     test::CanCompare::yes, test::ProxyRef::yes>;

--- a/tests/std/tests/P0896R4_ranges_alg_partial_sort_copy/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_partial_sort_copy/test.cpp
@@ -101,7 +101,7 @@ int main() {
     test_in_random<instantiator1, const P, P>();
     test_in_random<instantiator2, const P, P>();
 }
-#else // ^^^ test all range combinations // test only interesting range combos vvv
+#else // ^^^ test all range combinations / test only interesting range combos vvv
 constexpr void run_tests() {
     using namespace test;
     using test::iterator, test::range;

--- a/tests/std/tests/P0896R4_ranges_alg_search/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_search/test.cpp
@@ -120,7 +120,7 @@ int main() {
     // No constexpr test here; the test_fwd_fwd call exceeds the maximum number of steps in a constexpr computation.
     test_fwd_fwd<instantiator, Elem1, Elem2>();
 }
-#else // ^^^ test all range combinations // test only interesting range combos vvv
+#else // ^^^ test all range combinations / test only interesting range combos vvv
 template <class Elem, test::Sized IsSized>
 using fwd_test_range = test::range<forward_iterator_tag, Elem, IsSized, test::CanDifference::no, test::Common::no,
     test::CanCompare::yes, test::ProxyRef::yes>;

--- a/tests/std/tests/P0896R4_ranges_alg_transform_binary/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_transform_binary/test.cpp
@@ -103,7 +103,7 @@ int main() {
     // No constexpr test here; the test_in_in_write call exceeds the maximum number of steps in a constexpr computation.
     test_in_in_write<instantiator, Elem1, Elem2, Elem3>();
 }
-#else // ^^^ test all range combinations // test only interesting range combos vvv
+#else // ^^^ test all range combinations / test only interesting range combos vvv
 template <class Elem, test::Sized IsSized>
 using in_test_range = test::range<input_iterator_tag, Elem, IsSized, test::CanDifference::no, test::Common::no,
     test::CanCompare::yes, test::ProxyRef::yes>;

--- a/tests/std/tests/P0980R1_constexpr_strings/test.cpp
+++ b/tests/std/tests/P0980R1_constexpr_strings/test.cpp
@@ -170,7 +170,7 @@ template <class Range1, class Range2>
 constexpr bool equalRanges(const Range1& range1, const Range2& range2) noexcept {
 #ifdef __cpp_lib_concepts
     return ranges::equal(range1, range2);
-#else // ^^^ __cpp_lib_concepts ^^^ / vvv !__cpp_lib_concepts vvv
+#else // ^^^ __cpp_lib_concepts / !__cpp_lib_concepts vvv
     return equal(begin(range1), end(range1), begin(range2), end(range2));
 #endif // !__cpp_lib_concepts
 }

--- a/tests/std/tests/P1425R4_queue_stack_constructors/test.cpp
+++ b/tests/std/tests/P1425R4_queue_stack_constructors/test.cpp
@@ -92,7 +92,7 @@ void test_container() {
 #if _HAS_CXX17
     priority_queue pq1(range.begin(), range.end());
     static_assert(is_same_v<decltype(pq1), priority_queue<int, vector<int>, less<int>>>);
-#else // ^^^ _HAS_CXX17 ^^^ / vvv !_HAS_CXX17 vvv
+#else // ^^^ _HAS_CXX17 / !_HAS_CXX17 vvv
     priority_queue<int, vector<int>, less<int>> pq1(range.begin(), range.end());
 #endif // !_HAS_CXX17
     assert(pq1.size() == size(some_data));
@@ -105,7 +105,7 @@ void test_container() {
 #if _HAS_CXX17
     priority_queue pq2(range.begin(), range.end(), greater<int>{});
     static_assert(is_same_v<decltype(pq2), priority_queue<int, vector<int>, greater<int>>>);
-#else // ^^^ _HAS_CXX17 ^^^ / vvv !_HAS_CXX17 vvv
+#else // ^^^ _HAS_CXX17 / !_HAS_CXX17 vvv
     priority_queue<int, vector<int>, greater<int>> pq2(range.begin(), range.end(), greater<int>{});
 #endif // !_HAS_CXX17
     assert(pq2.size() == size(some_data));
@@ -118,7 +118,7 @@ void test_container() {
 #if _HAS_CXX17
     priority_queue pq3(range.begin(), range.end(), custom_allocator<int>{});
     static_assert(is_same_v<decltype(pq3), priority_queue<int, vector<int, custom_allocator<int>>, less<int>>>);
-#else // ^^^ _HAS_CXX17 ^^^ / vvv !_HAS_CXX17 vvv
+#else // ^^^ _HAS_CXX17 / !_HAS_CXX17 vvv
     priority_queue<int, vector<int, custom_allocator<int>>, less<int>> pq3(
         range.begin(), range.end(), custom_allocator<int>{});
 #endif // !_HAS_CXX17
@@ -132,7 +132,7 @@ void test_container() {
 #if _HAS_CXX17
     priority_queue pq4(range.begin(), range.end(), greater<int>{}, custom_allocator<int>{});
     static_assert(is_same_v<decltype(pq4), priority_queue<int, vector<int, custom_allocator<int>>, greater<int>>>);
-#else // ^^^ _HAS_CXX17 ^^^ / vvv !_HAS_CXX17 vvv
+#else // ^^^ _HAS_CXX17 / !_HAS_CXX17 vvv
     priority_queue<int, vector<int, custom_allocator<int>>, greater<int>> pq4(
         range.begin(), range.end(), greater<int>{}, custom_allocator<int>{});
 #endif // !_HAS_CXX17
@@ -147,7 +147,7 @@ void test_container() {
 #if _HAS_CXX17
     priority_queue pq5(range.begin(), range.end(), greater<int>{}, cont);
     static_assert(is_same_v<decltype(pq5), priority_queue<int, deque<int>, greater<int>>>);
-#else // ^^^ _HAS_CXX17 ^^^ / vvv !_HAS_CXX17 vvv
+#else // ^^^ _HAS_CXX17 / !_HAS_CXX17 vvv
     priority_queue<int, deque<int>, greater<int>> pq5(range.begin(), range.end(), greater<int>{}, cont);
 #endif // !_HAS_CXX17
     assert(pq5.size() == size(some_data) + size(additional_data));
@@ -161,7 +161,7 @@ void test_container() {
     priority_queue pq6(
         range.begin(), range.end(), greater<int>{}, deque<int>{begin(additional_data), end(additional_data)});
     static_assert(is_same_v<decltype(pq6), priority_queue<int, deque<int>, greater<int>>>);
-#else // ^^^ _HAS_CXX17 ^^^ / vvv !_HAS_CXX17 vvv
+#else // ^^^ _HAS_CXX17 / !_HAS_CXX17 vvv
     priority_queue<int, deque<int>, greater<int>> pq6(
         range.begin(), range.end(), greater<int>{}, deque<int>{begin(additional_data), end(additional_data)});
 #endif // !_HAS_CXX17
@@ -176,7 +176,7 @@ void test_container() {
 #if _HAS_CXX17
     priority_queue pq7(range.begin(), range.end(), greater<int>{}, cont2, custom_allocator<int>{});
     static_assert(is_same_v<decltype(pq7), priority_queue<int, deque<int, custom_allocator<int>>, greater<int>>>);
-#else // ^^^ _HAS_CXX17 ^^^ / vvv !_HAS_CXX17 vvv
+#else // ^^^ _HAS_CXX17 / !_HAS_CXX17 vvv
     priority_queue<int, deque<int, custom_allocator<int>>, greater<int>> pq7(
         range.begin(), range.end(), greater<int>{}, cont2, custom_allocator<int>{});
 #endif // !_HAS_CXX17
@@ -191,7 +191,7 @@ void test_container() {
     priority_queue pq8(range.begin(), range.end(), greater<int>{},
         deque<int, custom_allocator<int>>{begin(additional_data), end(additional_data)}, custom_allocator<int>{});
     static_assert(is_same_v<decltype(pq8), priority_queue<int, deque<int, custom_allocator<int>>, greater<int>>>);
-#else // ^^^ _HAS_CXX17 ^^^ / vvv !_HAS_CXX17 vvv
+#else // ^^^ _HAS_CXX17 / !_HAS_CXX17 vvv
     priority_queue<int, deque<int, custom_allocator<int>>, greater<int>> pq8(range.begin(), range.end(), greater<int>{},
         deque<int, custom_allocator<int>>{begin(additional_data), end(additional_data)}, custom_allocator<int>{});
 #endif // !_HAS_CXX17

--- a/tests/std/tests/P2302R4_ranges_alg_contains_subrange/test.cpp
+++ b/tests/std/tests/P2302R4_ranges_alg_contains_subrange/test.cpp
@@ -66,7 +66,7 @@ int main() {
     STATIC_ASSERT((test_fwd_fwd<instantiator, Elem1, Elem2>(), true));
     test_fwd_fwd<instantiator, Elem1, Elem2>();
 }
-#else // ^^^ test all range combinations // test only interesting range combos vvv
+#else // ^^^ test all range combinations / test only interesting range combos vvv
 template <class Elem, test::Sized IsSized>
 using fwd_test_range = test::range<forward_iterator_tag, Elem, IsSized, test::CanDifference::no, test::Common::no,
     test::CanCompare::yes, test::ProxyRef::yes>;

--- a/tests/std/tests/P2321R2_views_zip/test.cpp
+++ b/tests/std/tests/P2321R2_views_zip/test.cpp
@@ -778,13 +778,13 @@ constexpr bool instantiation_test() {
 
 #if defined(TEST_INPUT)
     return instantiation_test_for_category<input_iterator_tag, InstantiatorType>();
-#elif defined(TEST_FORWARD) // ^^^ TEST_INPUT ^^^ / vvv TEST_FORWARD vvv
+#elif defined(TEST_FORWARD) // ^^^ TEST_INPUT / TEST_FORWARD vvv
     return instantiation_test_for_category<forward_iterator_tag, InstantiatorType>();
-#elif defined(TEST_BIDIRECTIONAL) // ^^^ TEST_FORWARD ^^^ / vvv TEST_BIDIRECTIONAL vvv
+#elif defined(TEST_BIDIRECTIONAL) // ^^^ TEST_FORWARD / TEST_BIDIRECTIONAL vvv
     return instantiation_test_for_category<bidirectional_iterator_tag, InstantiatorType>();
-#elif defined(TEST_RANDOM) // ^^^ TEST_BIDIRECTIONAL ^^^ / vvv TEST_RANDOM vvv
+#elif defined(TEST_RANDOM) // ^^^ TEST_BIDIRECTIONAL / TEST_RANDOM vvv
     return instantiation_test_for_category<random_access_iterator_tag, InstantiatorType>();
-#else // ^^^ TEST_RANDOM ^^^ / vvv UNKNOWN vvv
+#else // ^^^ TEST_RANDOM / UNKNOWN vvv
     static_assert(false, "ERROR: A defined test macro was never specified when executing test P2321R2_views_zip!");
     return false;
 #endif // ^^^ UNKNOWN ^^^

--- a/tests/std/tests/VSO_0000000_initialize_everything/test.cpp
+++ b/tests/std/tests/VSO_0000000_initialize_everything/test.cpp
@@ -16,7 +16,7 @@ using namespace std;
 
 #ifdef _WIN64
 const size_t bad_size = 0xCCCC'CCCC'CCCC'CCCCULL;
-#else // ^^^ _WIN64 ^^^ // vvv !_WIN64 vvv
+#else // ^^^ _WIN64 ^^^ / vvv !_WIN64 vvv
 const size_t bad_size = 0xCCCC'CCCCUL;
 #endif // _WIN64
 const unsigned long long default_state = 0xB01DFACEDEBAC1EULL;

--- a/tests/std/tests/VSO_0000000_initialize_everything/test.cpp
+++ b/tests/std/tests/VSO_0000000_initialize_everything/test.cpp
@@ -16,7 +16,7 @@ using namespace std;
 
 #ifdef _WIN64
 const size_t bad_size = 0xCCCC'CCCC'CCCC'CCCCULL;
-#else // ^^^ _WIN64 ^^^ / vvv !_WIN64 vvv
+#else // ^^^ _WIN64 / !_WIN64 vvv
 const size_t bad_size = 0xCCCC'CCCCUL;
 #endif // _WIN64
 const unsigned long long default_state = 0xB01DFACEDEBAC1EULL;

--- a/tests/std/tests/VSO_0000000_list_iterator_debugging/test.cpp
+++ b/tests/std/tests/VSO_0000000_list_iterator_debugging/test.cpp
@@ -143,7 +143,7 @@ struct throwing_merge_fixture {
 #if _ITERATOR_DEBUG_LEVEL == 0
     static constexpr size_t ensureOrderedF1Size = 0;
     static constexpr size_t ensureOrderedF2Size = 0;
-#else // ^^^ _ITERATOR_DEBUG_LEVEL == 0 // _ITERATOR_DEBUG_LEVEL != 0 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL == 0 / _ITERATOR_DEBUG_LEVEL != 0 vvv
     static constexpr size_t ensureOrderedF1Size = startF1Size - 1;
     static constexpr size_t ensureOrderedF2Size = startF2Size - 1;
 #endif // _ITERATOR_DEBUG_LEVEL == 0

--- a/tests/std/tests/VSO_0105317_expression_sfinae/test.cpp
+++ b/tests/std/tests/VSO_0105317_expression_sfinae/test.cpp
@@ -519,7 +519,7 @@ using FP_noexcept                                 = int (*)(int) noexcept;
 using FR_noexcept                                 = int (&)(int) noexcept;
 using PMF_noexcept                                = int (X::*)(int) noexcept;
 inline constexpr bool noexcept_in_the_type_system = true;
-#else // ^^^ __cpp_noexcept_function_type // !__cpp_noexcept_function_type vvv
+#else // ^^^ __cpp_noexcept_function_type / !__cpp_noexcept_function_type vvv
 using FP_noexcept                                 = int (*)(int);
 using FR_noexcept                                 = int (&)(int);
 using PMF_noexcept                                = int (X::*)(int);

--- a/tests/std/tests/VSO_0677157_flist_merge_edge_cases/test.cpp
+++ b/tests/std/tests/VSO_0677157_flist_merge_edge_cases/test.cpp
@@ -141,7 +141,7 @@ struct throwing_merge_fixture {
 #if _ITERATOR_DEBUG_LEVEL == 0
     static constexpr size_t ensureOrderedF1Size = 0;
     static constexpr size_t ensureOrderedF2Size = 0;
-#else // ^^^ _ITERATOR_DEBUG_LEVEL == 0 // _ITERATOR_DEBUG_LEVEL != 0 vvv
+#else // ^^^ _ITERATOR_DEBUG_LEVEL == 0 / _ITERATOR_DEBUG_LEVEL != 0 vvv
     static constexpr size_t ensureOrderedF1Size = startF1Size - 1;
     static constexpr size_t ensureOrderedF2Size = startF2Size - 1;
 #endif // _ITERATOR_DEBUG_LEVEL == 0


### PR DESCRIPTION
Sometimes we use `// ^^^ no workaround / workaround vvv` and sometimes `// ^^^ no workaround // workaround vvv`.
It looks like `/` is used more often. So I replaced all of `//` which I had found.
I used `//.+//` regexp and VS code.
Driven by: https://github.com/microsoft/STL/pull/3206#discussion_r1020755546