### PR TITLE
Implement LWG-3823 Unnecessary precondition for `is_aggregate` (workaround)

### DIFF
--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -615,11 +615,22 @@ struct has_unique_object_representations : bool_constant<__has_unique_object_rep
 _EXPORT_STD template <class _Ty>
 _INLINE_VAR constexpr bool has_unique_object_representations_v = __has_unique_object_representations(_Ty);
 
+#if 1 // TRANSITION, DevCom-10201896, LLVM-59002, EDG's __is_aggregate isn't suitable for LWG-3823
+template <class _Ty>
+struct _Is_aggregate_impl : bool_constant<__is_aggregate(_Ty)> {};
+
+_EXPORT_STD template <class _Ty>
+_INLINE_VAR constexpr bool is_aggregate_v = disjunction_v<is_array<_Ty>, _Is_aggregate_impl<_Ty>>;
+
+_EXPORT_STD template <class _Ty>
+struct is_aggregate : bool_constant<is_aggregate_v<_Ty>> {}; // determine whether _Ty is an aggregate
+#else // ^^^ workaround / no workaround vvv
 _EXPORT_STD template <class _Ty>
 struct is_aggregate : bool_constant<__is_aggregate(_Ty)> {}; // determine whether _Ty is an aggregate
 
 _EXPORT_STD template <class _Ty>
 _INLINE_VAR constexpr bool is_aggregate_v = __is_aggregate(_Ty);
+#endif // ^^^ no workaround ^^^
 #endif // _HAS_CXX17
 
 _EXPORT_STD template <class _Ty, class... _Args>

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -615,7 +615,7 @@ struct has_unique_object_representations : bool_constant<__has_unique_object_rep
 _EXPORT_STD template <class _Ty>
 _INLINE_VAR constexpr bool has_unique_object_representations_v = __has_unique_object_representations(_Ty);
 
-#if 1 // TRANSITION, DevCom-10201896, LLVM-59002, EDG's __is_aggregate isn't suitable for LWG-3823
+#if 1 // TRANSITION, DevCom-10201896 and LLVM-59002
 template <class _Ty>
 struct _Is_aggregate_impl : bool_constant<__is_aggregate(_Ty)> {};
 
@@ -623,10 +623,10 @@ _EXPORT_STD template <class _Ty>
 _INLINE_VAR constexpr bool is_aggregate_v = disjunction_v<is_array<_Ty>, _Is_aggregate_impl<_Ty>>;
 
 _EXPORT_STD template <class _Ty>
-struct is_aggregate : bool_constant<is_aggregate_v<_Ty>> {}; // determine whether _Ty is an aggregate
+struct is_aggregate : bool_constant<is_aggregate_v<_Ty>> {};
 #else // ^^^ workaround / no workaround vvv
 _EXPORT_STD template <class _Ty>
-struct is_aggregate : bool_constant<__is_aggregate(_Ty)> {}; // determine whether _Ty is an aggregate
+struct is_aggregate : bool_constant<__is_aggregate(_Ty)> {};
 
 _EXPORT_STD template <class _Ty>
 _INLINE_VAR constexpr bool is_aggregate_v = __is_aggregate(_Ty);

--- a/tests/std/tests/VSO_0493909_is_aggregate/test.compile.pass.cpp
+++ b/tests/std/tests/VSO_0493909_is_aggregate/test.compile.pass.cpp
@@ -234,6 +234,8 @@ STATIC_ASSERT(!is_aggregate_v<NonAggVirtualBaseFunc>);
 struct NonAggVirtualBaseIndirect : NonAggVirtualBase {};
 STATIC_ASSERT(!is_aggregate_v<NonAggVirtualBaseIndirect>);
 
+struct Incomplete;
+
 STATIC_ASSERT(is_aggregate_v<int[10]>);
 STATIC_ASSERT(is_aggregate_v<int[]>);
 STATIC_ASSERT(is_aggregate_v<Cxx14Agg[]>);
@@ -242,11 +244,14 @@ STATIC_ASSERT(is_aggregate_v<NonAggDefaultCtor[]>);
 STATIC_ASSERT(is_aggregate_v<int* [10]>);
 STATIC_ASSERT(is_aggregate_v<NonAggDefaultCtor[2][3]>);
 STATIC_ASSERT(is_aggregate_v<Empty[10]>);
+STATIC_ASSERT(is_aggregate_v<Incomplete[]>);
+STATIC_ASSERT(is_aggregate_v<Incomplete[10]>);
 
 STATIC_ASSERT(!is_aggregate_v<int&>);
 STATIC_ASSERT(!is_aggregate_v<const int*>);
 STATIC_ASSERT(!is_aggregate_v<const Cxx14Agg&>);
 STATIC_ASSERT(!is_aggregate_v<Cxx14Agg*>);
+STATIC_ASSERT(!is_aggregate_v<Incomplete*>);
 
 template <typename T>
 struct AggTemplateClass {


### PR DESCRIPTION
Fixes #3229.

I suppose this is a temporary workaround. It would become unnecessary when compiler changes land.