### PR TITLE
Standard Library Modules: Fix spurious `_Init_locks` dllexport

### DIFF
--- a/stl/inc/yvals.h
+++ b/stl/inc/yvals.h
@@ -454,26 +454,6 @@ private:
 #endif // _M_CEE
 
 #ifdef _CRTBLD
-class _CRTIMP2_PURE_IMPORT _Init_locks { // initialize mutexes
-public:
-#ifdef _M_CEE_PURE
-    __CLR_OR_THIS_CALL _Init_locks() noexcept {
-        _Init_locks_ctor(this);
-    }
-
-    __CLR_OR_THIS_CALL ~_Init_locks() noexcept {
-        _Init_locks_dtor(this);
-    }
-
-#else // _M_CEE_PURE
-    __thiscall _Init_locks() noexcept;
-    __thiscall ~_Init_locks() noexcept;
-#endif // _M_CEE_PURE
-
-private:
-    static void __cdecl _Init_locks_ctor(_Init_locks*) noexcept;
-    static void __cdecl _Init_locks_dtor(_Init_locks*) noexcept;
-};
 
 #ifdef _M_CEE
 #define _RELIABILITY_CONTRACT                                                    \

--- a/stl/src/cerr.cpp
+++ b/stl/src/cerr.cpp
@@ -6,6 +6,8 @@
 #include <fstream>
 #include <iostream>
 
+#include "init_locks.hpp"
+
 #pragma warning(disable : 4074)
 #pragma init_seg(compiler)
 static std::_Init_locks initlocks;

--- a/stl/src/cin.cpp
+++ b/stl/src/cin.cpp
@@ -6,6 +6,8 @@
 #include <fstream>
 #include <iostream>
 
+#include "init_locks.hpp"
+
 #pragma warning(disable : 4074)
 #pragma init_seg(compiler)
 static std::_Init_locks initlocks;

--- a/stl/src/clog.cpp
+++ b/stl/src/clog.cpp
@@ -6,6 +6,8 @@
 #include <fstream>
 #include <iostream>
 
+#include "init_locks.hpp"
+
 #ifndef MRTDLL
 #pragma warning(disable : 4074)
 #pragma init_seg(compiler)

--- a/stl/src/cout.cpp
+++ b/stl/src/cout.cpp
@@ -6,6 +6,8 @@
 #include <fstream>
 #include <iostream>
 
+#include "init_locks.hpp"
+
 #pragma warning(disable : 4074)
 #pragma init_seg(compiler)
 static std::_Init_locks initlocks;

--- a/stl/src/init_locks.hpp
+++ b/stl/src/init_locks.hpp
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#pragma once
+
+#include <yvals.h>
+
+_STD_BEGIN
+
+class _CRTIMP2_PURE_IMPORT _Init_locks { // initialize mutexes
+public:
+#ifdef _M_CEE_PURE
+    __CLR_OR_THIS_CALL _Init_locks() noexcept {
+        _Init_locks_ctor(this);
+    }
+
+    __CLR_OR_THIS_CALL ~_Init_locks() noexcept {
+        _Init_locks_dtor(this);
+    }
+
+#else // _M_CEE_PURE
+    __thiscall _Init_locks() noexcept;
+    __thiscall ~_Init_locks() noexcept;
+#endif // _M_CEE_PURE
+
+private:
+    static void __cdecl _Init_locks_ctor(_Init_locks*) noexcept;
+    static void __cdecl _Init_locks_dtor(_Init_locks*) noexcept;
+};
+
+_STD_END

--- a/stl/src/iosptrs.cpp
+++ b/stl/src/iosptrs.cpp
@@ -6,6 +6,9 @@
 #include <iostream>
 
 #include <Windows.h>
+
+#include "init_locks.hpp"
+
 _STD_BEGIN
 
 #if defined(_M_CEE) && !defined(_M_CEE_MIXED)

--- a/stl/src/stacktrace.cpp
+++ b/stl/src/stacktrace.cpp
@@ -6,8 +6,6 @@
 // Do not include or define anything else here.
 // In particular, basic_string must not be included here.
 
-#include <yvals.h>
-
 #include <cstdio>
 #include <cstdlib>
 
@@ -166,7 +164,9 @@ namespace {
 
                 off = string_fill(fill, off + max_disp_num, str, [displacement, off](char* s, size_t) {
                     const int ret = std::snprintf(s + off, max_disp_num, "+0x%llX", displacement);
-                    _STL_VERIFY(ret > 0, "formatting error");
+                    if (ret <= 0) {
+                        std::abort(); // formatting error
+                    }
                     return off + ret;
                 });
             }
@@ -230,7 +230,9 @@ namespace {
 
                 off = string_fill(fill, off + max_line_num, str, [line, off](char* s, size_t) {
                     const int ret = std::snprintf(s + off, max_line_num, "(%u): ", line);
-                    _STL_VERIFY(ret > 0, "formatting error");
+                    if (ret <= 0) {
+                        std::abort(); // formatting error
+                    }
                     return off + ret;
                 });
             }
@@ -331,7 +333,9 @@ void __stdcall __std_stacktrace_to_string(const void* const* const _Addresses, c
 
         off = string_fill(_Fill, off + max_entry_num, _Str, [off, i](char* s, size_t) {
             const int ret = std::snprintf(s + off, max_entry_num, "%u> ", static_cast<unsigned int>(i));
-            _STL_VERIFY(ret > 0, "formatting error");
+            if (ret <= 0) {
+                std::abort(); // formatting error
+            }
             return off + ret;
         });
 

--- a/stl/src/syncstream.cpp
+++ b/stl/src/syncstream.cpp
@@ -11,6 +11,8 @@
 #include <shared_mutex>
 #include <utility>
 
+#include "init_locks.hpp"
+
 #pragma warning(disable : 4074)
 #pragma init_seg(compiler)
 static std::_Init_locks initlocks;

--- a/stl/src/taskscheduler.cpp
+++ b/stl/src/taskscheduler.cpp
@@ -9,6 +9,7 @@
 #include <Windows.h>
 
 #include "awint.hpp"
+#include "init_locks.hpp"
 
 #pragma warning(disable : 4074)
 #pragma init_seg(compiler)

--- a/stl/src/wcerr.cpp
+++ b/stl/src/wcerr.cpp
@@ -6,6 +6,8 @@
 #include <fstream>
 #include <iostream>
 
+#include "init_locks.hpp"
+
 #pragma warning(disable : 4074)
 #pragma init_seg(compiler)
 static std::_Init_locks initlocks;

--- a/stl/src/wcin.cpp
+++ b/stl/src/wcin.cpp
@@ -6,6 +6,8 @@
 #include <fstream>
 #include <iostream>
 
+#include "init_locks.hpp"
+
 #pragma warning(disable : 4074)
 #pragma init_seg(compiler)
 static std::_Init_locks initlocks;

--- a/stl/src/wclog.cpp
+++ b/stl/src/wclog.cpp
@@ -6,6 +6,8 @@
 #include <fstream>
 #include <iostream>
 
+#include "init_locks.hpp"
+
 #pragma warning(disable : 4074)
 #pragma init_seg(compiler)
 static std::_Init_locks initlocks;

--- a/stl/src/wcout.cpp
+++ b/stl/src/wcout.cpp
@@ -6,6 +6,8 @@
 #include <fstream>
 #include <iostream>
 
+#include "init_locks.hpp"
+
 #pragma warning(disable : 4074)
 #pragma init_seg(compiler)
 static std::_Init_locks initlocks;

--- a/stl/src/xlock.cpp
+++ b/stl/src/xlock.cpp
@@ -8,6 +8,7 @@
 #include <clocale>
 #include <cstdlib>
 
+#include "init_locks.hpp"
 #include "xmtx.hpp"
 
 _STD_BEGIN


### PR DESCRIPTION
I observed a curious message "Creating library meow.lib and object meow.exp" when consuming `import std;` with VS 2022 17.5 Preview 1. This doesn't repro when using the 17.5p1 compiler to consume `import std;` from microsoft/STL `main`; it repros only with the shipped machinery. I haven't figured out what the difference is yet, but I did find the root cause of the message.

The problem is that when we inject `stacktrace.cpp` into the import lib, it drags in `yvals.h` and the headache-inducing `_Init_locks`. In #3019, we guarded `_Init_locks` with `_CRTBLD` so it wouldn't affect users of `stl/inc`, but the problem here is that `stacktrace.cpp` *is* part of the STL's build, so `_Init_locks` is being emitted.

I have two fixes for this (either alone would be sufficient but I want to be extra sure here). First, `stacktrace.cpp` directly includes `yvals.h` but barely needs it. We can replace its use of `_STL_VERIFY` with direct calls to `std::abort()`, since these should only fail due to STL-internal logic errors (or something catastrophic happening at runtime).

Second, let's take the additional effort to fully remove `_Init_locks` from `stl/inc` and move it into an `stl/src` source-header that is then included by only the files that need `_Init_locks` - never those injected into the import lib.

(I experimented with a third strategy, enforcing all import lib files to be core-only via the recently-added `_ENFORCE_ONLY_CORE_HEADERS`. This is currently not possible, even after fixing `stacktrace.cpp`, due to `nothrow.cpp` including `<new>` (which would be fairly easy to disconnect) and `locale0_implib.cpp` eventually including `<xfacet>` which would be harder and scarier to rework. For the time being, I have abandoned that approach.)

Note: Unlike user-visible headers, our source-headers can be very lightweight, i.e. they don't need push-pop defenses and all that. We're currently inconsistent about how to give them idempotency guards, but I went with the lightweight `#pragma once`.

Here is the full repro that shows how I tracked this down to `stacktrace.cpp`:

```
C:\Temp\REPRO>"C:\Program Files\Microsoft Visual Studio\2022\Preview\VC\Auxiliary\Build\vcvars64.bat"
**********************************************************************
** Visual Studio 2022 Developer Command Prompt v17.5.0-pre.1.0
** Copyright (c) 2022 Microsoft Corporation
**********************************************************************
[vcvarsall.bat] Environment initialized for: 'x64'

C:\Temp\REPRO>type meow.cpp
import std;
int main() {
    std::cout << "Hello, modules world!\n";
}

C:\Temp\REPRO>cl /EHsc /nologo /W4 /std:c++latest /MDd /Od /c "C:\Program Files\Microsoft Visual Studio\2022\Preview\VC\Tools\MSVC\14.35.32019\modules\std.ixx"
std.ixx

C:\Temp\REPRO>cl /EHsc /nologo /W4 /std:c++latest /MDd /Od meow.cpp std.obj
meow.cpp
   Creating library meow.lib and object meow.exp

C:\Temp\REPRO>meow.exe
Hello, modules world!

C:\Temp\REPRO>dumpbin /exports meow.exe | findstr "_Init_locks"
          1    0 000019A0 ??4_Init_locks@std@@QEAAAEAV01@AEBV01@@Z

C:\Temp\REPRO>copy "C:\Program Files\Microsoft Visual Studio\2022\Preview\VC\Tools\MSVC\14.35.32019\lib\x64\msvcprtd.lib" .
        1 file(s) copied.

C:\Temp\REPRO>lib /list msvcprtd.lib | findstr ".obj"
D:\a\_work\1\s\Intermediate\crt\github\stl\msbuild\stl_base\xmd\msvcp_kernel32\msvcp.nativeproj\objd\amd64\xonce2.obj
D:\a\_work\1\s\Intermediate\crt\github\stl\msbuild\stl_base\xmd\msvcp_kernel32\msvcp.nativeproj\objd\amd64\xcharconv_tables_float.obj
D:\a\_work\1\s\Intermediate\crt\github\stl\msbuild\stl_base\xmd\msvcp_kernel32\msvcp.nativeproj\objd\amd64\xcharconv_tables_double.obj
D:\a\_work\1\s\Intermediate\crt\github\stl\msbuild\stl_base\xmd\msvcp_kernel32\msvcp.nativeproj\objd\amd64\xcharconv_ryu_tables.obj
D:\a\_work\1\s\Intermediate\crt\github\stl\msbuild\stl_base\xmd\msvcp_kernel32\msvcp.nativeproj\objd\amd64\vector_algorithms.obj
D:\a\_work\1\s\Intermediate\crt\github\stl\msbuild\stl_base\xmd\msvcp_kernel32\msvcp.nativeproj\objd\amd64\syserror_import_lib.obj
D:\a\_work\1\s\Intermediate\crt\github\stl\msbuild\stl_base\xmd\msvcp_kernel32\msvcp.nativeproj\objd\amd64\stacktrace.obj
D:\a\_work\1\s\Intermediate\crt\github\stl\msbuild\stl_base\xmd\msvcp_kernel32\msvcp.nativeproj\objd\amd64\sharedmutex.obj
D:\a\_work\1\s\Intermediate\crt\github\stl\msbuild\stl_base\xmd\msvcp_kernel32\msvcp.nativeproj\objd\amd64\nothrow.obj
D:\a\_work\1\s\Intermediate\crt\github\stl\msbuild\stl_base\xmd\msvcp_kernel32\msvcp.nativeproj\objd\amd64\locale0_implib.obj
D:\a\_work\1\s\Intermediate\crt\github\stl\msbuild\stl_base\xmd\msvcp_kernel32\msvcp.nativeproj\objd\amd64\format.obj
D:\a\_work\1\s\Intermediate\crt\github\stl\msbuild\stl_base\xmd\msvcp_kernel32\msvcp.nativeproj\objd\amd64\filesystem.obj
D:\a\_work\1\s\Intermediate\crt\github\stl\msbuild\stl_base\xmd\msvcp_kernel32\msvcp.nativeproj\objd\amd64\charconv.obj
D:\a\_work\1\s\Intermediate\crt\github\stl\msbuild\stl_base\xmd\msvcp_kernel32\msvcp.nativeproj\objd\amd64\asan_noop.obj
D:\a\_work\1\s\Intermediate\crt\github\stl\msbuild\stl_base\xmd\msvcp_kernel32\msvcp.nativeproj\objd\amd64\alias_init_once_complete.obj
D:\a\_work\1\s\Intermediate\crt\github\stl\msbuild\stl_base\xmd\msvcp_kernel32\msvcp.nativeproj\objd\amd64\alias_init_once_begin_initialize.obj

C:\Temp\REPRO>for %I in (alias_init_once_begin_initialize.obj alias_init_once_complete.obj asan_noop.obj charconv.obj filesystem.obj format.obj locale0_implib.obj nothrow.obj sharedmutex.obj stacktrace.obj syserror_import_lib.obj vector_algorithms.obj xcharconv_ryu_tables.obj xcharconv_tables_double.obj xcharconv_tables_float.obj xonce2.obj) do @lib /nologo msvcprtd.lib /extract:D:\a\_work\1\s\Intermediate\crt\github\stl\msbuild\stl_base\xmd\msvcp_kernel32\msvcp.nativeproj\objd\amd64\%I /out:extracted_%I

C:\Temp\REPRO>for %I in (extracted_*.obj) do @(dumpbin /symbols %I | findstr "_Init_locks" && echo Found in %I)
3E9 00000000 SECT131 notype ()    External    | ??4_Init_locks@std@@QEAAAEAV01@AEBV01@@Z (public: class std::_Init_locks & __cdecl std::_Init_locks::operator=(class std::_Init_locks const &))
Found in extracted_stacktrace.obj
```

:warning: Note to self:
===
This will require MSVC-internal changes to add the new source-header.