### PR TITLE
P2278R4: `views::as_const`

### DIFF
--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -5126,7 +5126,8 @@ namespace ranges {
             static constexpr bool _Can_reconstruct_ref_view_v = false;
 
             template <class _Ty>
-            static constexpr bool _Can_reconstruct_ref_view_v<ref_view<_Ty>> = constant_range<const _Ty>;
+                requires constant_range<const _Ty>
+            static constexpr bool _Can_reconstruct_ref_view_v<ref_view<_Ty>> = true;
 
             template <class _Rng>
             _NODISCARD static _CONSTEVAL _Choice_t<_St> _Choose() noexcept {

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -5120,7 +5120,13 @@ namespace ranges {
 
         class _As_const_fn : public _Pipe::_Base<_As_const_fn> {
         private:
-            enum class _St { _None, _All, _Span, _Ref, _As_const };
+            enum class _St { _None, _All, _Reconstruct_span, _Reconstruct_ref, _Ref, _As_const };
+
+            template <class>
+            static constexpr bool _Can_reconstruct_ref_view_v = false;
+
+            template <class _Ty>
+            static constexpr bool _Can_reconstruct_ref_view_v<ref_view<_Ty>> = constant_range<const _Ty>;
 
             template <class _Rng>
             _NODISCARD static _CONSTEVAL _Choice_t<_St> _Choose() noexcept {
@@ -5129,10 +5135,11 @@ namespace ranges {
                 if constexpr (constant_range<views::all_t<_Rng>>) {
                     return {_St::_All, noexcept(views::all(_STD declval<_Rng>()))};
                 } else if constexpr (_Is_span_v<_Ty>) {
-                    using _Element_type = typename _Ty::element_type;
-                    return {_St::_Span, noexcept(span<const _Element_type, _Ty::extent>{_STD declval<_Rng>()})};
+                    return {_St::_Reconstruct_span, true};
+                } else if constexpr (_Can_reconstruct_ref_view_v<_Ty>) {
+                    return {_St::_Reconstruct_ref, noexcept(ref_view{_STD as_const(_STD declval<_Rng>().base())})};
                 } else if constexpr (is_lvalue_reference_v<_Rng> && constant_range<const _Ty> && !view<_Ty>) {
-                    return {_St::_Ref, noexcept(ref_view{static_cast<const _Ty&>(_STD declval<_Rng>())})};
+                    return {_St::_Ref, noexcept(ref_view{_STD as_const(_STD declval<_Rng>())})};
                 } else if constexpr (_Can_as_const<_Rng>) {
                     return {_St::_As_const, noexcept(as_const_view{_STD declval<_Rng>()})};
                 } else {
@@ -5152,11 +5159,12 @@ namespace ranges {
 
                 if constexpr (_Strat == _St::_All) {
                     return views::all(_STD forward<_Rng>(_Range));
-                } else if constexpr (_Strat == _St::_Span) {
-                    using _Element_type = typename _Ty::element_type;
-                    return span<const _Element_type, _Ty::extent>{_STD forward<_Rng>(_Range)};
+                } else if constexpr (_Strat == _St::_Reconstruct_span) {
+                    return span<const typename _Ty::element_type, _Ty::extent>{_STD forward<_Rng>(_Range)};
+                } else if constexpr (_Strat == _St::_Reconstruct_ref) {
+                    return ref_view{_STD as_const(_STD forward<_Rng>(_Range).base())};
                 } else if constexpr (_Strat == _St::_Ref) {
-                    return ref_view{static_cast<const _Ty&>(_STD forward<_Rng>(_Range))};
+                    return ref_view{_STD as_const(_STD forward<_Rng>(_Range))};
                 } else if constexpr (_Strat == _St::_As_const) {
                     return as_const_view{_STD forward<_Rng>(_Range)};
                 } else {

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -5046,6 +5046,129 @@ namespace ranges {
         _EXPORT_STD inline constexpr _Reverse_fn reverse;
     } // namespace views
 
+#if _HAS_CXX23
+    _EXPORT_STD template <view _Vw>
+        requires input_range<_Vw>
+    class as_const_view : public view_interface<as_const_view<_Vw>> {
+    private:
+        /* [[no_unique_address]] */ _Vw _Range{};
+
+    public:
+        // clang-format off
+        as_const_view() requires default_initializable<_Vw> = default;
+        // clang-format on
+
+        constexpr explicit as_const_view(_Vw _Range_) noexcept(is_nothrow_move_constructible_v<_Vw>) // strengthened
+            : _Range(_STD move(_Range_)) {}
+
+        _NODISCARD constexpr _Vw base() const& noexcept(is_nothrow_copy_constructible_v<_Vw>) // strengthened
+            requires copy_constructible<_Vw>
+        {
+            return _Range;
+        }
+
+        _NODISCARD constexpr _Vw base() && noexcept(is_nothrow_move_constructible_v<_Vw>) /* strengthened */ {
+            return _STD move(_Range);
+        }
+
+        _NODISCARD constexpr auto begin() noexcept(noexcept(_RANGES cbegin(_Range))) // strengthened
+            requires (!_Simple_view<_Vw>)
+        {
+            return _RANGES cbegin(_Range);
+        }
+
+        _NODISCARD constexpr auto begin() const noexcept(noexcept(_RANGES cbegin(_Range))) // strengthened
+            requires range<const _Vw>
+        {
+            return _RANGES cbegin(_Range);
+        }
+
+        _NODISCARD constexpr auto end() noexcept(noexcept(_RANGES cend(_Range))) // strengthened
+            requires (!_Simple_view<_Vw>)
+        {
+            return _RANGES cend(_Range);
+        }
+
+        _NODISCARD constexpr auto end() const noexcept(noexcept(_RANGES cend(_Range))) // strengthened
+            requires range<const _Vw>
+        {
+            return _RANGES cend(_Range);
+        }
+
+        _NODISCARD constexpr auto size() noexcept(noexcept(_RANGES size(_Range))) // strengthened
+            requires sized_range<_Vw>
+        {
+            return _RANGES size(_Range);
+        }
+
+        _NODISCARD constexpr auto size() const noexcept(noexcept(_RANGES size(_Range))) // strengthened
+            requires sized_range<const _Vw>
+        {
+            return _RANGES size(_Range);
+        }
+    };
+
+    template <class _Rng>
+    as_const_view(_Rng&&) -> as_const_view<views::all_t<_Rng>>;
+
+    template <class _Rng>
+    inline constexpr bool enable_borrowed_range<as_const_view<_Rng>> = enable_borrowed_range<_Rng>;
+
+    namespace views {
+        template <class _Rng>
+        concept _Can_as_const = requires(_Rng&& __r) { as_const_view{static_cast<_Rng&&>(__r)}; };
+
+        class _As_const_fn : public _Pipe::_Base<_As_const_fn> {
+        private:
+            enum class _St { _None, _All, _Span, _Ref, _As_const };
+
+            template <class _Rng>
+            _NODISCARD static _CONSTEVAL _Choice_t<_St> _Choose() noexcept {
+                using _Ty = remove_cvref_t<_Rng>;
+
+                if constexpr (constant_range<views::all_t<_Rng>>) {
+                    return {_St::_All, noexcept(views::all(_STD declval<_Rng>()))};
+                } else if constexpr (_Is_span_v<_Ty>) {
+                    using _Element_type = typename _Ty::element_type;
+                    return {_St::_Span, noexcept(span<const _Element_type, _Ty::extent>{_STD declval<_Rng>()})};
+                } else if constexpr (is_lvalue_reference_v<_Rng> && constant_range<const _Ty> && !view<_Ty>) {
+                    return {_St::_Ref, noexcept(ref_view{static_cast<const _Ty&>(_STD declval<_Rng>())})};
+                } else if constexpr (_Can_as_const<_Rng>) {
+                    return {_St::_As_const, noexcept(as_const_view{_STD declval<_Rng>()})};
+                } else {
+                    return {_St::_None};
+                }
+            }
+
+            template <class _Rng>
+            static constexpr _Choice_t<_St> _Choice = _Choose<_Rng>();
+
+        public:
+            template <viewable_range _Rng>
+                requires (_Choice<_Rng>._Strategy != _St::_None)
+            _NODISCARD constexpr auto operator()(_Rng&& _Range) const noexcept(_Choice<_Rng>._No_throw) {
+                using _Ty            = remove_cvref_t<_Rng>;
+                constexpr _St _Strat = _Choice<_Rng>._Strategy;
+
+                if constexpr (_Strat == _St::_All) {
+                    return views::all(_STD forward<_Rng>(_Range));
+                } else if constexpr (_Strat == _St::_Span) {
+                    using _Element_type = typename _Ty::element_type;
+                    return span<const _Element_type, _Ty::extent>{_STD forward<_Rng>(_Range)};
+                } else if constexpr (_Strat == _St::_Ref) {
+                    return ref_view{static_cast<const _Ty&>(_STD forward<_Rng>(_Range))};
+                } else if constexpr (_Strat == _St::_As_const) {
+                    return as_const_view{_STD forward<_Rng>(_Range)};
+                } else {
+                    static_assert(_Always_false<_Rng>, "Should be unreachable");
+                }
+            }
+        };
+
+        _EXPORT_STD inline constexpr _As_const_fn as_const;
+    } // namespace views
+#endif // _HAS_CXX23
+
     template <class _Tuple, size_t _Index>
     concept _Has_tuple_element = //
         requires(_Tuple __t) {

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -325,7 +325,6 @@
 // P2186R2 Removing Garbage Collection Support
 // P2273R3 constexpr unique_ptr
 // P2278R4 cbegin Should Always Return A Constant Iterator
-//     (missing views::as_const)
 // P2291R3 constexpr Integral <charconv>
 // P2302R4 ranges::contains, ranges::contains_subrange
 // P2321R2 zip
@@ -1673,6 +1672,7 @@ _EMIT_STL_ERROR(STL1004, "C++98 unexpected() is incompatible with C++23 unexpect
 
 #ifdef __cpp_lib_concepts
 #define __cpp_lib_out_ptr                 202106L
+#define __cpp_lib_ranges_as_const         202207L
 #define __cpp_lib_ranges_as_rvalue        202207L
 #define __cpp_lib_ranges_chunk            202202L
 #define __cpp_lib_ranges_chunk_by         202202L

--- a/tests/std/test.lst
+++ b/tests/std/test.lst
@@ -551,6 +551,7 @@ tests\P2278R4_basic_const_iterator
 tests\P2278R4_const_span
 tests\P2278R4_ranges_const_iterator_machinery
 tests\P2278R4_ranges_const_range_machinery
+tests\P2278R4_views_as_const
 tests\P2302R4_ranges_alg_contains
 tests\P2302R4_ranges_alg_contains_subrange
 tests\P2321R2_proxy_reference

--- a/tests/std/tests/P2278R4_views_as_const/env.lst
+++ b/tests/std/tests/P2278R4_views_as_const/env.lst
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+RUNALL_INCLUDE ..\concepts_latest_matrix.lst

--- a/tests/std/tests/P2278R4_views_as_const/test.cpp
+++ b/tests/std/tests/P2278R4_views_as_const/test.cpp
@@ -1,0 +1,516 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <algorithm>
+#include <cassert>
+#include <forward_list>
+#include <iterator>
+#include <ranges>
+#include <span>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include <range_algorithm_support.hpp>
+
+using namespace std;
+
+template <class Rng>
+concept CanViewAsConst = requires(Rng&& r) { views::as_const(forward<Rng>(r)); };
+
+template <ranges::input_range Rng, class Expected>
+constexpr bool test_one(Rng&& rng, Expected&& expected) {
+    using ranges::as_const_view, ranges::begin, ranges::end, ranges::iterator_t, ranges::sentinel_t, ranges::prev,
+        ranges::forward_range, ranges::bidirectional_range, ranges::random_access_range, ranges::contiguous_range,
+        ranges::common_range, ranges::sized_range, ranges::constant_range;
+    using V = views::all_t<Rng>;
+    using R = as_const_view<V>;
+
+    constexpr bool is_view = ranges::view<remove_cvref_t<Rng>>;
+
+    STATIC_ASSERT(ranges::view<R>);
+    STATIC_ASSERT(ranges::input_range<R> == ranges::input_range<V>);
+    STATIC_ASSERT(forward_range<R> == forward_range<V>);
+    STATIC_ASSERT(bidirectional_range<R> == bidirectional_range<V>);
+    STATIC_ASSERT(random_access_range<R> == random_access_range<V>);
+    STATIC_ASSERT(contiguous_range<R> == contiguous_range<V>);
+    STATIC_ASSERT(constant_range<R>);
+
+    STATIC_ASSERT(!indirectly_writable<iterator_t<R>, ranges::range_value_t<Rng>>);
+    STATIC_ASSERT(!indirectly_writable<iterator_t<R>, ranges::range_reference_t<Rng>>);
+
+    // Validate default-initializability
+    STATIC_ASSERT(default_initializable<R> == default_initializable<V>);
+
+    // Validate borrowed_range
+    STATIC_ASSERT(ranges::borrowed_range<R> == ranges::borrowed_range<V>);
+
+    // Validate range adaptor object
+    if constexpr (constant_range<V>) { // range adaptor results in views::all_t
+        // ... with lvalue argument
+        STATIC_ASSERT(CanViewAsConst<Rng&> == (!is_view || copy_constructible<V>) );
+        if constexpr (CanViewAsConst<Rng&>) {
+            constexpr bool is_noexcept = !is_view || is_nothrow_copy_constructible_v<V>;
+
+            STATIC_ASSERT(same_as<decltype(views::as_const(std::forward<Rng>(rng))), V>);
+            STATIC_ASSERT(noexcept(views::as_const(std::forward<Rng>(rng))) == is_noexcept);
+
+            STATIC_ASSERT(same_as<decltype(std::forward<Rng>(rng) | views::as_const), V>);
+            STATIC_ASSERT(noexcept(std::forward<Rng>(rng) | views::as_const) == is_noexcept);
+        }
+
+        // ... with const lvalue argument
+        STATIC_ASSERT(CanViewAsConst<const remove_reference_t<Rng>&> == (!is_view || copy_constructible<V>) );
+        if constexpr (CanViewAsConst<const remove_reference_t<Rng>&>) {
+            using VC                   = views::all_t<const remove_reference_t<Rng>&>;
+            constexpr bool is_noexcept = !is_view || is_nothrow_copy_constructible_v<V>;
+
+            STATIC_ASSERT(same_as<decltype(views::as_const(as_const(rng))), VC>);
+            STATIC_ASSERT(noexcept(views::as_const(as_const(rng))) == is_noexcept);
+
+            STATIC_ASSERT(same_as<decltype(as_const(rng) | views::as_const), VC>);
+            STATIC_ASSERT(noexcept(as_const(rng) | views::as_const) == is_noexcept);
+        }
+
+        // ... with rvalue argument
+        STATIC_ASSERT(CanViewAsConst<remove_reference_t<Rng>> == (is_view || movable<remove_reference_t<Rng>>) );
+        if constexpr (CanViewAsConst<remove_reference_t<Rng>>) {
+            using VS                   = views::all_t<remove_reference_t<Rng>>;
+            constexpr bool is_noexcept = is_nothrow_move_constructible_v<V>;
+
+            STATIC_ASSERT(same_as<decltype(views::as_const(std::move(rng))), VS>);
+            STATIC_ASSERT(noexcept(views::as_const(std::move(rng))) == is_noexcept);
+
+            STATIC_ASSERT(same_as<decltype(std::move(rng) | views::as_const), VS>);
+            STATIC_ASSERT(noexcept(std::move(rng) | views::as_const) == is_noexcept);
+        }
+
+        // ... with const rvalue argument
+        STATIC_ASSERT(CanViewAsConst<const remove_reference_t<Rng>> == (is_view && copy_constructible<V>) );
+        if constexpr (CanViewAsConst<const remove_reference_t<Rng>>) {
+            constexpr bool is_noexcept = is_nothrow_copy_constructible_v<V>;
+
+            STATIC_ASSERT(same_as<decltype(views::as_const(std::move(as_const(rng)))), V>);
+            STATIC_ASSERT(noexcept(views::as_const(std::move(as_const(rng)))) == is_noexcept);
+
+            STATIC_ASSERT(same_as<decltype(std::move(as_const(rng)) | views::as_const), V>);
+            STATIC_ASSERT(noexcept(std::move(as_const(rng)) | views::as_const) == is_noexcept);
+        }
+    } else if constexpr (_Is_span_v<V>) { // range adaptor results in span<const X>
+        using ConstSpan = span<const typename V::element_type, V::extent>;
+
+        // ... with lvalue argument
+        STATIC_ASSERT(CanViewAsConst<Rng&> == (!is_view || copy_constructible<V>) );
+        if constexpr (CanViewAsConst<Rng&>) {
+            constexpr bool is_noexcept = !is_view || is_nothrow_copy_constructible_v<V>;
+
+            STATIC_ASSERT(same_as<decltype(views::as_const(std::forward<Rng>(rng))), ConstSpan>);
+            STATIC_ASSERT(noexcept(views::as_const(std::forward<Rng>(rng))) == is_noexcept);
+
+            STATIC_ASSERT(same_as<decltype(std::forward<Rng>(rng) | views::as_const), ConstSpan>);
+            STATIC_ASSERT(noexcept(std::forward<Rng>(rng) | views::as_const) == is_noexcept);
+        }
+
+        // ... with const lvalue argument
+        STATIC_ASSERT(CanViewAsConst<const remove_reference_t<Rng>&> == (!is_view || copy_constructible<V>) );
+        if constexpr (CanViewAsConst<const remove_reference_t<Rng>&>) {
+            constexpr bool is_noexcept = !is_view || is_nothrow_copy_constructible_v<V>;
+
+            STATIC_ASSERT(same_as<decltype(views::as_const(as_const(rng))), ConstSpan>);
+            STATIC_ASSERT(noexcept(views::as_const(as_const(rng))) == is_noexcept);
+
+            STATIC_ASSERT(same_as<decltype(as_const(rng) | views::as_const), ConstSpan>);
+            STATIC_ASSERT(noexcept(as_const(rng) | views::as_const) == is_noexcept);
+        }
+
+        // ... with rvalue argument
+        STATIC_ASSERT(CanViewAsConst<remove_reference_t<Rng>> == (is_view || movable<remove_reference_t<Rng>>) );
+        if constexpr (CanViewAsConst<remove_reference_t<Rng>>) {
+            constexpr bool is_noexcept = is_nothrow_move_constructible_v<V>;
+
+            STATIC_ASSERT(same_as<decltype(views::as_const(std::move(rng))), ConstSpan>);
+            STATIC_ASSERT(noexcept(views::as_const(std::move(rng))) == is_noexcept);
+
+            STATIC_ASSERT(same_as<decltype(std::move(rng) | views::as_const), ConstSpan>);
+            STATIC_ASSERT(noexcept(std::move(rng) | views::as_const) == is_noexcept);
+        }
+
+        // ... with const rvalue argument
+        STATIC_ASSERT(CanViewAsConst<const remove_reference_t<Rng>> == (is_view && copy_constructible<V>) );
+        if constexpr (CanViewAsConst<const remove_reference_t<Rng>>) {
+            constexpr bool is_noexcept = is_nothrow_copy_constructible_v<V>;
+
+            STATIC_ASSERT(same_as<decltype(views::as_const(std::move(as_const(rng)))), ConstSpan>);
+            STATIC_ASSERT(noexcept(views::as_const(std::move(as_const(rng)))) == is_noexcept);
+
+            STATIC_ASSERT(same_as<decltype(std::move(as_const(rng)) | views::as_const), ConstSpan>);
+            STATIC_ASSERT(noexcept(std::move(as_const(rng)) | views::as_const) == is_noexcept);
+        }
+    } else if constexpr (is_lvalue_reference_v<Rng> && constant_range<const remove_cvref_t<Rng>>
+                         && !is_view) { // range adaptor results in ref_view<const X>
+        using ConstRefView = ranges::ref_view<const remove_cvref_t<Rng>>;
+
+        // ... with lvalue argument
+        STATIC_ASSERT(CanViewAsConst<Rng&> == copy_constructible<V>);
+        if constexpr (CanViewAsConst<Rng&>) {
+            STATIC_ASSERT(same_as<decltype(views::as_const(std::forward<Rng>(rng))), ConstRefView>);
+            STATIC_ASSERT(noexcept(views::as_const(std::forward<Rng>(rng))));
+
+            STATIC_ASSERT(same_as<decltype(std::forward<Rng>(rng) | views::as_const), ConstRefView>);
+            STATIC_ASSERT(noexcept(std::forward<Rng>(rng) | views::as_const));
+        }
+
+        // ... with const lvalue argument
+        STATIC_ASSERT(CanViewAsConst<const remove_reference_t<Rng>&> == copy_constructible<V>);
+        if constexpr (CanViewAsConst<const remove_reference_t<Rng>&>) {
+            STATIC_ASSERT(same_as<decltype(views::as_const(as_const(rng))), ConstRefView>);
+            STATIC_ASSERT(noexcept(views::as_const(as_const(rng))));
+
+            STATIC_ASSERT(same_as<decltype(as_const(rng) | views::as_const), ConstRefView>);
+            STATIC_ASSERT(noexcept(as_const(rng) | views::as_const));
+        }
+    } else { // range adaptor results in as_const_view
+        // ... with lvalue argument
+        STATIC_ASSERT(CanViewAsConst<Rng&> == (!is_view || copy_constructible<V>) );
+        if constexpr (CanViewAsConst<Rng&>) {
+            constexpr bool is_noexcept = !is_view || is_nothrow_copy_constructible_v<V>;
+
+            STATIC_ASSERT(same_as<decltype(views::as_const(std::forward<Rng>(rng))), R>);
+            STATIC_ASSERT(noexcept(views::as_const(std::forward<Rng>(rng))) == is_noexcept);
+
+            STATIC_ASSERT(same_as<decltype(std::forward<Rng>(rng) | views::as_const), R>);
+            STATIC_ASSERT(noexcept(std::forward<Rng>(rng) | views::as_const) == is_noexcept);
+        }
+
+        // ... with const lvalue argument
+        STATIC_ASSERT(CanViewAsConst<const remove_reference_t<Rng>&> == (!is_view || copy_constructible<V>) );
+        if constexpr (CanViewAsConst<const remove_reference_t<Rng>&>
+                      && !constant_range<const remove_reference_t<Rng>&>) {
+            using RC                   = as_const_view<views::all_t<const remove_reference_t<Rng>&>>;
+            constexpr bool is_noexcept = !is_view || is_nothrow_copy_constructible_v<V>;
+
+            STATIC_ASSERT(same_as<decltype(views::as_const(as_const(rng))), RC>);
+            STATIC_ASSERT(noexcept(views::as_const(as_const(rng))) == is_noexcept);
+
+            STATIC_ASSERT(same_as<decltype(as_const(rng) | views::as_const), RC>);
+            STATIC_ASSERT(noexcept(as_const(rng) | views::as_const) == is_noexcept);
+        }
+
+        // ... with rvalue argument
+        STATIC_ASSERT(CanViewAsConst<remove_reference_t<Rng>> == (is_view || movable<remove_reference_t<Rng>>) );
+        if constexpr (CanViewAsConst<remove_reference_t<Rng>>) {
+            using RS                   = as_const_view<views::all_t<remove_reference_t<Rng>>>;
+            constexpr bool is_noexcept = is_nothrow_move_constructible_v<V>;
+
+            STATIC_ASSERT(same_as<decltype(views::as_const(std::move(rng))), RS>);
+            STATIC_ASSERT(noexcept(views::as_const(std::move(rng))) == is_noexcept);
+
+            STATIC_ASSERT(same_as<decltype(std::move(rng) | views::as_const), RS>);
+            STATIC_ASSERT(noexcept(std::move(rng) | views::as_const) == is_noexcept);
+        }
+
+        // ... with const rvalue argument
+        STATIC_ASSERT(CanViewAsConst<const remove_reference_t<Rng>> == (is_view && copy_constructible<V>) );
+        if constexpr (CanViewAsConst<const remove_reference_t<Rng>>) {
+            constexpr bool is_noexcept = is_nothrow_copy_constructible_v<V>;
+
+            STATIC_ASSERT(same_as<decltype(views::as_const(std::move(as_const(rng)))), R>);
+            STATIC_ASSERT(noexcept(views::as_const(std::move(as_const(rng)))) == is_noexcept);
+
+            STATIC_ASSERT(same_as<decltype(std::move(as_const(rng)) | views::as_const), R>);
+            STATIC_ASSERT(noexcept(std::move(as_const(rng)) | views::as_const) == is_noexcept);
+        }
+    }
+
+    // Validate deduction guide
+    same_as<R> auto r = as_const_view{std::forward<Rng>(rng)};
+
+    // Validate as_const_view::size
+    STATIC_ASSERT(CanMemberSize<R> == sized_range<V>);
+    if constexpr (CanMemberSize<R>) {
+        same_as<ranges::range_size_t<V>> auto s = r.size();
+        assert(_To_unsigned_like(s) == ranges::size(expected));
+        STATIC_ASSERT(noexcept(r.size()) == noexcept(ranges::size(as_const(rng))));
+    }
+
+    // Validate as_const_view::size (const)
+    STATIC_ASSERT(CanMemberSize<const R> == sized_range<const V>);
+    if constexpr (CanMemberSize<const R>) {
+        same_as<ranges::range_size_t<const V>> auto s = as_const(r).size();
+        assert(_To_unsigned_like(s) == ranges::size(expected));
+        STATIC_ASSERT(noexcept(as_const(r).size()) == noexcept(ranges::size(rng)));
+    }
+
+    const bool is_empty = ranges::empty(expected);
+
+    // Validate view_interface::empty and operator bool
+    STATIC_ASSERT(CanMemberEmpty<R> == (forward_range<V> || sized_range<V>) );
+    STATIC_ASSERT(CanBool<R> == CanEmpty<R>);
+    if constexpr (CanMemberEmpty<R>) {
+        assert(r.empty() == is_empty);
+        assert(static_cast<bool>(r) == !is_empty);
+    }
+
+    // Validate view_interface::empty and operator bool (const)
+    STATIC_ASSERT(CanMemberEmpty<const R> == (forward_range<const Rng> || sized_range<const V>) );
+    STATIC_ASSERT(CanBool<const R> == CanEmpty<const R>);
+    if constexpr (CanMemberEmpty<const R>) {
+        assert(as_const(r).empty() == is_empty);
+        assert(static_cast<bool>(as_const(r)) == !is_empty);
+    }
+
+    assert(ranges::equal(r, expected));
+    if (!forward_range<V>) { // intentionally not if constexpr
+        return true;
+    }
+
+    // Validate as_const_view::begin
+    STATIC_ASSERT(CanMemberBegin<R>);
+    {
+        const same_as<iterator_t<R>> auto i = r.begin();
+        if (!is_empty) {
+            assert(*i == *begin(expected));
+        }
+
+        if constexpr (copy_constructible<V>) {
+            auto r2                              = r;
+            const same_as<iterator_t<R>> auto i2 = r2.begin();
+            if (!is_empty) {
+                assert(*i2 == *i);
+            }
+        }
+    }
+
+    // Validate as_const_view::begin (const)
+    STATIC_ASSERT(CanMemberBegin<const R> == ranges::range<const V>);
+    if constexpr (CanMemberBegin<const R>) {
+        const same_as<iterator_t<const R>> auto ci = as_const(r).begin();
+        if (!is_empty) {
+            assert(*ci == *begin(expected));
+        }
+
+        if constexpr (copy_constructible<V>) {
+            const auto cr2                              = r;
+            const same_as<iterator_t<const R>> auto ci2 = cr2.begin();
+            if (!is_empty) {
+                assert(*ci2 == *ci);
+            }
+        }
+    }
+
+    // Validate as_const_view::end
+    STATIC_ASSERT(CanMemberEnd<R>);
+    {
+        const same_as<sentinel_t<R>> auto s = r.end();
+        assert((r.begin() == s) == is_empty);
+        STATIC_ASSERT(common_range<R> == common_range<V>);
+        if constexpr (common_range<R> && bidirectional_range<V>) {
+            if (!is_empty) {
+                assert(*prev(s) == *prev(end(expected)));
+            }
+
+            if constexpr (copy_constructible<V>) {
+                auto r2 = r;
+                if (!is_empty) {
+                    assert(*prev(r2.end()) == *prev(end(expected)));
+                }
+            }
+        }
+    }
+
+    // Validate as_const_view::end (const)
+    STATIC_ASSERT(CanMemberEnd<const R> == ranges::range<const V>);
+    if constexpr (CanMemberEnd<const R>) {
+        const same_as<sentinel_t<const R>> auto cs = as_const(r).end();
+        assert((as_const(r).begin() == cs) == is_empty);
+        STATIC_ASSERT(common_range<const R> == common_range<const V>);
+        if constexpr (common_range<const R> && bidirectional_range<const V>) {
+            if (!is_empty) {
+                assert(*prev(cs) == *prev(end(expected)));
+            }
+
+            if constexpr (copy_constructible<V>) {
+                const auto r2 = r;
+                if (!is_empty) {
+                    assert(*prev(r2.end()) == *prev(end(expected)));
+                }
+            }
+        }
+    }
+
+    // Validate view_interface::data
+    STATIC_ASSERT(CanMemberData<R> == contiguous_range<V>);
+    STATIC_ASSERT(CanData<R&> == contiguous_range<V>);
+    if constexpr (contiguous_range<V>) {
+        const same_as<const remove_reference_t<ranges::range_reference_t<V>>*> auto ptr = r.data();
+        assert(ptr == to_address(r.begin()));
+    }
+
+    // Validate view_interface::data (const)
+    STATIC_ASSERT(CanMemberData<const R> == contiguous_range<const V>);
+    STATIC_ASSERT(CanData<const R&> == contiguous_range<const V>);
+    if constexpr (contiguous_range<const V>) {
+        const same_as<const remove_reference_t<ranges::range_reference_t<const V>>*> auto ptr = as_const(r).data();
+        assert(ptr == to_address(as_const(r).begin()));
+    }
+
+    if (!is_empty) {
+        // Validate view_interface::operator[]
+        STATIC_ASSERT(CanIndex<R> == random_access_range<V>);
+        if constexpr (CanIndex<R>) {
+            assert(r[0] == expected[0]);
+        }
+
+        // Validate view_interface::operator[] (const)
+        STATIC_ASSERT(CanIndex<const R> == random_access_range<const V>);
+        if constexpr (CanIndex<const R>) {
+            assert(as_const(r)[0] == expected[0]);
+        }
+
+        // Validate view_interface::front
+        STATIC_ASSERT(CanMemberFront<R> == forward_range<V>);
+        if constexpr (CanMemberFront<R>) {
+            assert(r.front() == *begin(expected));
+        }
+
+        // Validate view_interface::front (const)
+        STATIC_ASSERT(CanMemberFront<const R> == forward_range<const V>);
+        if constexpr (CanMemberFront<const R>) {
+            assert(as_const(r).front() == *begin(expected));
+        }
+
+        // Validate view_interface::back
+        STATIC_ASSERT(CanMemberBack<R> == (bidirectional_range<V> && common_range<V>) );
+        if constexpr (CanMemberBack<R>) {
+            assert(r.back() == *prev(end(expected)));
+        }
+
+        // Validate view_interface::back (const)
+        STATIC_ASSERT(CanMemberBack<const R> == (bidirectional_range<const V> && common_range<const V>) );
+        if constexpr (CanMemberBack<const R>) {
+            assert(as_const(r).back() == *prev(end(expected)));
+        }
+    }
+
+    // Validate as_const_view::base() const&
+    STATIC_ASSERT(CanMemberBase<const R&> == copy_constructible<V>);
+    if constexpr (copy_constructible<V>) {
+        same_as<V> auto b1 = as_const(r).base();
+        STATIC_ASSERT(noexcept(as_const(r).base()) == is_nothrow_copy_constructible_v<V>);
+        if (!is_empty) {
+            assert(*b1.begin() == *begin(expected));
+        }
+    }
+
+    // Validate as_const_view::base() &&
+    same_as<V> auto b2 = std::move(r).base();
+    STATIC_ASSERT(noexcept(std::move(r).base()) == is_nothrow_move_constructible_v<V>);
+    if (!is_empty) {
+        assert(*b2.begin() == *begin(expected));
+    }
+
+    return true;
+}
+
+constexpr int some_ints[] = {0, 3, 6, 9, 12, 15};
+
+struct instantiator {
+    template <ranges::input_range R>
+    static constexpr void call() {
+        R r{some_ints};
+        test_one(r, span{some_ints});
+    }
+};
+
+template <class Category, test::Common IsCommon, test::Sized IsSized>
+using test_range =
+    test::range<Category, const int, IsSized, test::CanDifference{derived_from<Category, random_access_iterator_tag>},
+        IsCommon, test::CanCompare{derived_from<Category, forward_iterator_tag> || IsCommon == test::Common::yes},
+        test::ProxyRef{!derived_from<Category, contiguous_iterator_tag>}>;
+
+constexpr bool instantiation_test() {
+#ifdef TEST_EVERYTHING
+    test_in<instantiator, const int>();
+#else // ^^^ test all input permutations / test only "interesting" permutations vvv
+    using test::Common, test::Sized;
+
+    // The view is sensitive to category, commonality, and size, but oblivious to differencing and proxyness
+    instantiator::call<test_range<input_iterator_tag, Common::no, Sized::yes>>();
+    instantiator::call<test_range<input_iterator_tag, Common::no, Sized::no>>();
+    instantiator::call<test_range<input_iterator_tag, Common::yes, Sized::yes>>();
+    instantiator::call<test_range<input_iterator_tag, Common::yes, Sized::no>>();
+
+    instantiator::call<test_range<forward_iterator_tag, Common::no, Sized::yes>>();
+    instantiator::call<test_range<forward_iterator_tag, Common::no, Sized::no>>();
+    instantiator::call<test_range<forward_iterator_tag, Common::yes, Sized::yes>>();
+    instantiator::call<test_range<forward_iterator_tag, Common::yes, Sized::no>>();
+
+    instantiator::call<test_range<bidirectional_iterator_tag, Common::no, Sized::yes>>();
+    instantiator::call<test_range<bidirectional_iterator_tag, Common::no, Sized::no>>();
+    instantiator::call<test_range<bidirectional_iterator_tag, Common::yes, Sized::yes>>();
+    instantiator::call<test_range<bidirectional_iterator_tag, Common::yes, Sized::no>>();
+
+    instantiator::call<test_range<random_access_iterator_tag, Common::no, Sized::yes>>();
+    instantiator::call<test_range<random_access_iterator_tag, Common::no, Sized::no>>();
+    instantiator::call<test_range<random_access_iterator_tag, Common::yes, Sized::yes>>();
+    instantiator::call<test_range<random_access_iterator_tag, Common::yes, Sized::no>>();
+
+    instantiator::call<test_range<contiguous_iterator_tag, Common::no, Sized::yes>>();
+    instantiator::call<test_range<contiguous_iterator_tag, Common::no, Sized::no>>();
+    instantiator::call<test_range<contiguous_iterator_tag, Common::yes, Sized::yes>>();
+    instantiator::call<test_range<contiguous_iterator_tag, Common::yes, Sized::no>>();
+#endif // TEST_EVERYTHING
+    return true;
+}
+
+template <class Category, test::Common IsCommon, bool is_random = derived_from<Category, random_access_iterator_tag>>
+using move_only_view = test::range<Category, const int, test::Sized{is_random}, test::CanDifference{is_random},
+    IsCommon, test::CanCompare::yes, test::ProxyRef{!derived_from<Category, contiguous_iterator_tag>},
+    test::CanView::yes, test::Copyability::move_only>;
+
+int main() {
+#ifndef __clang__ // TRANSITION, LLVM-44833
+    { // Validate views
+        // ... copyable
+        constexpr span<const int> s{some_ints};
+        STATIC_ASSERT(test_one(s, some_ints));
+        test_one(s, some_ints);
+    }
+#endif // TRANSITION, LLVM-44833
+
+    { // ... move-only
+        test_one(move_only_view<input_iterator_tag, test::Common::no>{some_ints}, some_ints);
+        test_one(move_only_view<input_iterator_tag, test::Common::yes>{some_ints}, some_ints);
+        test_one(move_only_view<forward_iterator_tag, test::Common::no>{some_ints}, some_ints);
+        test_one(move_only_view<forward_iterator_tag, test::Common::yes>{some_ints}, some_ints);
+        test_one(move_only_view<bidirectional_iterator_tag, test::Common::no>{some_ints}, some_ints);
+        test_one(move_only_view<bidirectional_iterator_tag, test::Common::yes>{some_ints}, some_ints);
+        test_one(move_only_view<random_access_iterator_tag, test::Common::no>{some_ints}, some_ints);
+        test_one(move_only_view<random_access_iterator_tag, test::Common::yes>{some_ints}, some_ints);
+    }
+
+    { // Validate non-views
+        STATIC_ASSERT(test_one(some_ints, some_ints));
+        test_one(some_ints, some_ints);
+
+        // Test with lvalue and rvalue non-views
+        auto vec = some_ints | ranges::to<vector>();
+        test_one(vec, some_ints);
+        test_one(some_ints | ranges::to<vector>(), some_ints);
+
+        auto lst = some_ints | ranges::to<forward_list>();
+        test_one(lst, some_ints);
+        test_one(some_ints | ranges::to<forward_list>(), some_ints);
+    }
+
+#ifndef __clang__ // TRANSITION, LLVM-44833
+    { // empty range
+        using Span = span<int>;
+        STATIC_ASSERT(test_one(Span{}, Span{}));
+        test_one(Span{}, Span{});
+    }
+#endif // TRANSITION, LLVM-44833
+
+    STATIC_ASSERT(instantiation_test());
+    instantiation_test();
+}

--- a/tests/std/tests/P2278R4_views_as_const/test.cpp
+++ b/tests/std/tests/P2278R4_views_as_const/test.cpp
@@ -527,7 +527,7 @@ int main() {
         STATIC_ASSERT(test_one(some_ints, some_ints));
         test_one(some_ints, some_ints);
 
-        // Test with lvalue, rvalue and wrapped in ref_view non-views
+        // Test with lvalue, rvalue, and wrapped in ref_view non-views
         auto vec = some_ints | ranges::to<vector>();
         test_one(vec, some_ints);
         test_one(ranges::ref_view{vec}, some_ints);

--- a/tests/std/tests/P2278R4_views_as_const/test.cpp
+++ b/tests/std/tests/P2278R4_views_as_const/test.cpp
@@ -21,9 +21,9 @@ concept CanViewAsConst = requires(Rng&& r) { views::as_const(forward<Rng>(r)); }
 template <class>
 struct RefViewUnderlyingType {};
 
-template <class _Ty>
-struct RefViewUnderlyingType<ranges::ref_view<_Ty>> {
-    using type = _Ty;
+template <class T>
+struct RefViewUnderlyingType<ranges::ref_view<T>> {
+    using type = T;
 };
 
 template <class>

--- a/tests/std/tests/P2278R4_views_as_const/test.cpp
+++ b/tests/std/tests/P2278R4_views_as_const/test.cpp
@@ -27,10 +27,10 @@ struct RefViewUnderlyingType<ranges::ref_view<T>> {
 };
 
 template <class>
-static constexpr bool CanReconstructRefView = false;
+constexpr bool CanReconstructRefView = false;
 
 template <class T>
-static constexpr bool CanReconstructRefView<ranges::ref_view<T>> = ranges::constant_range<const T>;
+constexpr bool CanReconstructRefView<ranges::ref_view<T>> = ranges::constant_range<const T>;
 
 template <ranges::input_range Rng, class Expected>
 constexpr bool test_one(Rng&& rng, Expected&& expected) {

--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
@@ -1519,6 +1519,20 @@ STATIC_ASSERT(__cpp_lib_ranges == 202110L);
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
+#ifndef __cpp_lib_ranges_as_const
+#error __cpp_lib_ranges_as_const is not defined
+#elif __cpp_lib_ranges_as_const != 202207L
+#error __cpp_lib_ranges_as_const is not 202207L
+#else
+STATIC_ASSERT(__cpp_lib_ranges_as_const == 202207L);
+#endif
+#else
+#ifdef __cpp_lib_ranges_as_const
+#error __cpp_lib_ranges_as_const is defined
+#endif
+#endif
+
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
 #ifndef __cpp_lib_ranges_as_rvalue
 #error __cpp_lib_ranges_as_rvalue is not defined
 #elif __cpp_lib_ranges_as_rvalue != 202207L


### PR DESCRIPTION
Closes #2918 - "`cbegin` should always return a constant iterator".

* Implemented ["As const view"](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p2278r4.html#as-const-view-range.as.const) section from the paper,
* Implemented LWG-3811.