### PR TITLE
Update comments for approved LWG issues

### DIFF
--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -2626,46 +2626,44 @@ _Ty atomic_fetch_xor_explicit(
 
 #if _HAS_CXX20
 _EXPORT_STD template <class _Ty>
-void atomic_wait(const volatile atomic<_Ty>* const _Mem, const typename atomic<_Ty>::value_type _Expected) noexcept
-/* strengthened */ {
+void atomic_wait(const volatile atomic<_Ty>* const _Mem, const typename atomic<_Ty>::value_type _Expected) noexcept {
     _Mem->wait(_Expected);
 }
 
 _EXPORT_STD template <class _Ty>
-void atomic_wait(const atomic<_Ty>* const _Mem, const typename atomic<_Ty>::value_type _Expected) noexcept
-/* strengthened */ {
+void atomic_wait(const atomic<_Ty>* const _Mem, const typename atomic<_Ty>::value_type _Expected) noexcept {
     _Mem->wait(_Expected);
 }
 
 _EXPORT_STD template <class _Ty>
 void atomic_wait_explicit(const volatile atomic<_Ty>* const _Mem, const typename atomic<_Ty>::value_type _Expected,
-    const memory_order _Order) noexcept /* strengthened */ {
+    const memory_order _Order) noexcept {
     _Mem->wait(_Expected, _Order);
 }
 
 _EXPORT_STD template <class _Ty>
 void atomic_wait_explicit(const atomic<_Ty>* const _Mem, const typename atomic<_Ty>::value_type _Expected,
-    const memory_order _Order) noexcept /* strengthened */ {
+    const memory_order _Order) noexcept {
     _Mem->wait(_Expected, _Order);
 }
 
 _EXPORT_STD template <class _Ty>
-void atomic_notify_one(volatile atomic<_Ty>* const _Mem) noexcept /* strengthened */ {
+void atomic_notify_one(volatile atomic<_Ty>* const _Mem) noexcept {
     _Mem->notify_one();
 }
 
 _EXPORT_STD template <class _Ty>
-void atomic_notify_one(atomic<_Ty>* const _Mem) noexcept /* strengthened */ {
+void atomic_notify_one(atomic<_Ty>* const _Mem) noexcept {
     _Mem->notify_one();
 }
 
 _EXPORT_STD template <class _Ty>
-void atomic_notify_all(volatile atomic<_Ty>* const _Mem) noexcept /* strengthened */ {
+void atomic_notify_all(volatile atomic<_Ty>* const _Mem) noexcept {
     _Mem->notify_all();
 }
 
 _EXPORT_STD template <class _Ty>
-void atomic_notify_all(atomic<_Ty>* const _Mem) noexcept /* strengthened */ {
+void atomic_notify_all(atomic<_Ty>* const _Mem) noexcept {
     _Mem->notify_all();
 }
 #endif // _HAS_CXX20

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -3328,7 +3328,9 @@ namespace ranges {
             static constexpr bool _Deref_is_glvalue = is_reference_v<_InnerRng<_Const>>;
 
             /* [[no_unique_address]] */ _OuterIter _Outer{};
-            /* [[no_unique_address]] */ _Defaultabox<_InnerIter> _Inner{}; // per LWG-3569
+            /* [[no_unique_address]] */ _Defaultabox<_InnerIter> _Inner{}; // Non-standard extension: when _Inner_iter
+                                                                           // is default-constructible, we don't wrap in
+                                                                           // an optional-like.
             _Parent_t* _Parent{};
 
             constexpr auto&& _Update_inner() {
@@ -3383,7 +3385,7 @@ namespace ranges {
             using difference_type = common_type_t<range_difference_t<_Base>, range_difference_t<_InnerRng<_Const>>>;
 
             // clang-format off
-            _Iterator() requires default_initializable<_OuterIter> = default; // per LWG-3569
+            _Iterator() requires default_initializable<_OuterIter> = default;
             // clang-format on
 
             constexpr _Iterator(_Parent_t& _Parent_, _OuterIter _Outer_)

--- a/stl/inc/thread
+++ b/stl/inc/thread
@@ -310,7 +310,6 @@ public:
     jthread& operator=(const jthread&) = delete;
 
     jthread& operator=(jthread&& _Other) noexcept {
-        // Per LWG-3788
         if (this == _STD addressof(_Other)) {
             return *this;
         }

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -1894,8 +1894,8 @@ private:
 public:
     template <class... _Types>
     _CONSTEXPR20 auto operator()(_Types&&... _Args) const
-        noexcept(noexcept(_STD invoke(*_Ptr, static_cast<_Types&&>(_Args)...))) // strengthened
-        -> decltype(_STD invoke(*_Ptr, static_cast<_Types&&>(_Args)...)) {
+        noexcept(noexcept(_STD invoke(*_Ptr, static_cast<_Types&&>(_Args)...)))
+            -> decltype(_STD invoke(*_Ptr, static_cast<_Types&&>(_Args)...)) {
         return _STD invoke(*_Ptr, static_cast<_Types&&>(_Args)...);
     }
 };

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -3319,10 +3319,10 @@ namespace ranges {
 #ifdef __clang__ // TRANSITION, LLVM-44833
         template <class _Dx = _Derived>
         _NODISCARD constexpr auto cbegin()
-            requires input_range<_Dx> // Per LWG-3766
+            requires input_range<_Dx>
 #else // ^^^ workaround / no workaround vvv
         _NODISCARD constexpr auto cbegin()
-            requires input_range<_Derived> // Per LWG-3766
+            requires input_range<_Derived>
 #endif // TRANSITION, LLVM-44833
         {
             return _RANGES cbegin(_Cast());
@@ -3331,10 +3331,10 @@ namespace ranges {
 #ifdef __clang__ // TRANSITION, LLVM-44833
         template <class _Dx = _Derived>
         _NODISCARD constexpr auto cbegin() const
-            requires input_range<const _Dx> // Per LWG-3766
+            requires input_range<const _Dx>
 #else // ^^^ workaround / no workaround vvv
         _NODISCARD constexpr auto cbegin() const
-            requires input_range<const _Derived> // Per LWG-3766
+            requires input_range<const _Derived>
 #endif // TRANSITION, LLVM-44833
         {
             return _RANGES cbegin(_Cast());
@@ -3343,10 +3343,10 @@ namespace ranges {
 #ifdef __clang__ // TRANSITION, LLVM-44833
         template <class _Dx = _Derived>
         _NODISCARD constexpr auto cend()
-            requires input_range<_Dx> // Per LWG-3766
+            requires input_range<_Dx>
 #else // ^^^ workaround / no workaround vvv
         _NODISCARD constexpr auto cend()
-            requires input_range<_Derived> // Per LWG-3766
+            requires input_range<_Derived>
 #endif // TRANSITION, LLVM-44833
         {
             return _RANGES cend(_Cast());
@@ -3355,10 +3355,10 @@ namespace ranges {
 #ifdef __clang__ // TRANSITION, LLVM-44833
         template <class _Dx = _Derived>
         _NODISCARD constexpr auto cend() const
-            requires input_range<const _Dx> // Per LWG-3766
+            requires input_range<const _Dx>
 #else // ^^^ workaround / no workaround vvv
         _NODISCARD constexpr auto cend() const
-            requires input_range<const _Derived> // Per LWG-3766
+            requires input_range<const _Derived>
 #endif // TRANSITION, LLVM-44833
         {
             return _RANGES cend(_Cast());

--- a/tests/std/tests/P0660R10_jthread_and_cv_any/test.cpp
+++ b/tests/std/tests/P0660R10_jthread_and_cv_any/test.cpp
@@ -92,7 +92,7 @@ int main() {
         assert(!worker_b.joinable());
     }
 
-    { // self move assign, as of LWG-3788 defined to not do anything
+    { // self move assign, defined to have no effects
         jthread worker{[] {}};
         auto old_id = worker.get_id();
         assert(old_id != jthread::id{});


### PR DESCRIPTION
We no longer need comments for LWG issues that are now Standard. This includes comment cleanup for:
* LWG-3569,
* LWG-3766, and
* LWG-3788.

This also removes `/* strengthened */` comments for functions that are now `noexcept`:
* `atomic_meow` functions made `noexcept` by LWG-3745, and
* `reference_wrapper::operator()` made conditionally `noexcept` by LWG-3764.
