### PR TITLE
Restore test workarounds for the MSVC-internal Contest infrastructure

### DIFF
--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -1596,6 +1596,7 @@ thread\thread.condition\thread.condition.condvarany\wait_terminates.sh.cpp
 utilities\format\format.arguments\format.arg.store\make_format_args.sh.cpp
 
 # REQUIRES: locale.en_US.UTF-8
+# (The Windows version on Contest VMs doesn't always understand ".UTF-8".)
 input.output\iostream.format\ext.manip\get_time.pass.cpp
 input.output\iostream.format\ext.manip\put_time.pass.cpp
 localization\locale.categories\category.collate\locale.collate.byname\compare.pass.cpp

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -1594,3 +1594,16 @@ namespace\addressable_functions.sh.cpp
 strings\basic.string\string.capacity\shrink_to_fit.explicit_instantiation.sh.cpp
 thread\thread.condition\thread.condition.condvarany\wait_terminates.sh.cpp
 utilities\format\format.arguments\format.arg.store\make_format_args.sh.cpp
+
+# REQUIRES: locale.en_US.UTF-8
+input.output\iostream.format\ext.manip\get_time.pass.cpp
+input.output\iostream.format\ext.manip\put_time.pass.cpp
+localization\locale.categories\category.collate\locale.collate.byname\compare.pass.cpp
+localization\locale.categories\category.collate\locale.collate.byname\transform.pass.cpp
+localization\locale.categories\category.ctype\locale.ctype.byname\narrow_1.pass.cpp
+localization\locale.categories\category.ctype\locale.ctype.byname\narrow_many.pass.cpp
+localization\locale.categories\category.ctype\locale.ctype.byname\tolower_1.pass.cpp
+localization\locale.categories\category.ctype\locale.ctype.byname\tolower_many.pass.cpp
+localization\locale.categories\category.ctype\locale.ctype.byname\toupper_1.pass.cpp
+localization\locale.categories\category.ctype\locale.ctype.byname\toupper_many.pass.cpp
+re\re.traits\translate_nocase.pass.cpp

--- a/tests/std/include/timezone_data.hpp
+++ b/tests/std/include/timezone_data.hpp
@@ -157,7 +157,21 @@ namespace LA {
 template <class TestFunction>
 void run_tz_test(TestFunction test_function) {
     try {
+#ifdef _MSVC_INTERNAL_TESTING
+        try {
+            (void) get_tzdb();
+        } catch (const system_error& ex) {
+            if (ex.code() == error_code{126 /* ERROR_MOD_NOT_FOUND */, system_category()}) {
+                // Skip testing when we can't load icu.dll on an internal test machine running an older OS.
+                exit(EXIT_SUCCESS);
+            }
+
+            throw; // Report any other errors.
+        }
+#endif // _MSVC_INTERNAL_TESTING
+
         test_function();
+
     } catch (const system_error& ex) {
         cerr << "Test threw system_error: " << ex.what() << "\n";
         cerr << "With error_code: " << ex.code() << "\n";

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
@@ -1120,8 +1120,10 @@ void test() {
 #if !defined(_DLL) || _ITERATOR_DEBUG_LEVEL == DEFAULT_IDL_SETTING
     test_locale<wchar_t>();
     test_locale<char>();
+#ifndef _MSVC_INTERNAL_TESTING // TRANSITION, the Windows version on Contest VMs doesn't always understand ".UTF-8"
     assert(setlocale(LC_ALL, ".UTF-8") != nullptr);
     test_locale<char>();
+#endif // _MSVC_INTERNAL_TESTING
 #endif // !defined(_DLL) || _ITERATOR_DEBUG_LEVEL == DEFAULT_IDL_SETTING
 }
 

--- a/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
@@ -1381,12 +1381,14 @@ void libfmt_formatter_test_runtime_precision() {
 
 template <class charT>
 void test_locale_specific_formatting_without_locale() {
+#ifndef _MSVC_INTERNAL_TESTING // TRANSITION, the Windows version on Contest VMs doesn't always understand ".UTF-8"
 #if !defined(_DLL) || _ITERATOR_DEBUG_LEVEL == DEFAULT_IDL_SETTING
     locale loc("en-US.UTF-8");
     locale::global(loc);
     assert(format(STR("{:L}"), 12345) == STR("12,345"));
     locale::global(locale::classic());
 #endif // !defined(_DLL) || _ITERATOR_DEBUG_LEVEL == DEFAULT_IDL_SETTING
+#endif // _MSVC_INTERNAL_TESTING
 }
 
 template <class charT>

--- a/tests/std/tests/P0645R10_text_formatting_utf8/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_utf8/test.cpp
@@ -156,6 +156,8 @@ int main() {
     assert(setlocale(LC_ALL, ".932") != nullptr);
     run_tests();
 
+#ifndef _MSVC_INTERNAL_TESTING // TRANSITION, the Windows version on Contest VMs doesn't always understand ".UTF-8"
     assert(setlocale(LC_ALL, ".UTF-8") != nullptr);
     run_tests();
+#endif
 }

--- a/tests/std/tests/VSO_0644691_utf_8_codecvt/test.cpp
+++ b/tests/std/tests/VSO_0644691_utf_8_codecvt/test.cpp
@@ -253,6 +253,7 @@ void test_codecvt_encoding(const codecvt<wchar_t, char, mbstate_t>& f) {
 }
 
 int main() {
+#ifndef _MSVC_INTERNAL_TESTING // TRANSITION, the Windows version on Contest VMs doesn't always understand ".UTF-8"
     try {
         locale loc("en-US.UTF-8");
         test_fstream(loc);
@@ -262,4 +263,5 @@ int main() {
         puts(ex.what());
         assert(false);
     }
+#endif // _MSVC_INTERNAL_TESTING
 }


### PR DESCRIPTION
Our MSVC-internal "Contest" infrastructure uses some machines running older OSes, which don't understand ICU and UTF-8 locales. We had removed test workarounds in #2791 (2022-06-15), operating under the belief that this infrastructure would be updated soon. That hasn't happened yet. The affected tests are showing up as "flaky test failures" whenever any MSVC devs run the `std` or `libcxx` suites in Contest.

This PR contains the test workarounds that I've been temporarily applying whenever I mirror GitHub PRs to MSVC. (It's a bit more than just reverting the relevant changes in #2791, as we've had an LLVM update since then.) Note that the changes to `tests/libcxx/skipped_tests.txt` occur at the bottom, which is an MSVC-only section, and therefore are *not* replicated to `expected_results.txt` (which is for the GitHub/Python harness).

Fixes VSO-1601209.