### PR TITLE
fix stl.natvis `std::optional<*>`

### DIFF
--- a/stl/debugger/STL.natvis
+++ b/stl/debugger/STL.natvis
@@ -105,7 +105,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
   <Type Name="std::optional&lt;*&gt;">
       <DisplayString Condition="!_Has_value">nullopt</DisplayString>
-      <DisplayString Condition="_Has_value">some {_Value}</DisplayString>
+      <DisplayString Condition="_Has_value">{_Value}</DisplayString>
       <Expand>
           <Item Condition="_Has_value" Name="value">_Value</Item>
       </Expand>

--- a/stl/debugger/STL.natvis
+++ b/stl/debugger/STL.natvis
@@ -105,8 +105,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
   <Type Name="std::optional&lt;*&gt;">
       <DisplayString Condition="!_Has_value">nullopt</DisplayString>
-
-      <DisplayString Condition="_Has_value">{_Value}</DisplayString>
+      <DisplayString Condition="_Has_value">some {_Value}</DisplayString>
       <Expand>
           <Item Condition="_Has_value" Name="value">_Value</Item>
       </Expand>

--- a/stl/debugger/STL.natvis
+++ b/stl/debugger/STL.natvis
@@ -104,7 +104,8 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
   </Type>
 
   <Type Name="std::optional&lt;*&gt;">
-      <DisplayString Condition="_Has_value">nullopt</DisplayString>
+      <DisplayString Condition="!_Has_value">nullopt</DisplayString>
+
       <DisplayString Condition="_Has_value">{_Value}</DisplayString>
       <Expand>
           <Item Condition="_Has_value" Name="value">_Value</Item>

--- a/stl/debugger/STL.natvis
+++ b/stl/debugger/STL.natvis
@@ -104,12 +104,10 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
   </Type>
 
   <Type Name="std::optional&lt;*&gt;">
-      <Intrinsic Name="has_value" Expression="_Has_value"/>
-      <Intrinsic Name="value" Expression="_Value"/>
-      <DisplayString Condition="!has_value()">nullopt</DisplayString>
-      <DisplayString Condition="has_value()">{value()}</DisplayString>
+      <DisplayString Condition="_Has_value">nullopt</DisplayString>
+      <DisplayString Condition="_Has_value">{_Value}</DisplayString>
       <Expand>
-          <Item Condition="has_value()" Name="value">value()</Item>
+          <Item Condition="_Has_value" Name="value">_Value</Item>
       </Expand>
   </Type>
 


### PR DESCRIPTION
`optional<*>` originally used `<Intrinsic>`s for `_Has_value` and `_Value`; however, apparently VS doesn't like doing custom visualizers for `<Intrinsic>` calls.

Fixes VSO-1631025 / DevCom-10155697