### PR TITLE
`<xlocale>`: Avoid allocation when comparing two `locale` values

### DIFF
--- a/stl/inc/xlocale
+++ b/stl/inc/xlocale
@@ -380,12 +380,12 @@ public:
         return nullptr; // no entry in current locale
     }
 
-    _NODISCARD bool operator==(const locale& _Loc) const { // compare locales for equality
-        return _Ptr == _Loc._Ptr || (name().compare("*") != 0 && name().compare(_Loc.name()) == 0);
+    _NODISCARD bool operator==(const locale& _Loc) const noexcept /* strengthened */ { // compare locales for equality
+        return _Ptr == _Loc._Ptr || (_CSTD strcmp(_C_str(), "*") != 0 && _CSTD strcmp(_C_str(), _Loc._C_str()) == 0);
     }
 
 #if !_HAS_CXX20
-    _NODISCARD bool operator!=(const locale& _Right) const {
+    _NODISCARD bool operator!=(const locale& _Right) const noexcept /* strengthened */ {
         return !(*this == _Right);
     }
 #endif // !_HAS_CXX20

--- a/tests/std/tests/Dev09_056375_locale_cleanup/test.cpp
+++ b/tests/std/tests/Dev09_056375_locale_cleanup/test.cpp
@@ -11,6 +11,9 @@ using namespace std;
 
 #define STATIC_ASSERT(...) static_assert(__VA_ARGS__, #__VA_ARGS__)
 
+STATIC_ASSERT(noexcept(locale{} == locale{}));
+STATIC_ASSERT(noexcept(locale{} != locale{}));
+
 void test_dll() {
     puts("Calling dll");
 #ifdef _M_CEE


### PR DESCRIPTION
And then the exception specification can be strengthened.

`_C_str` always returns a non-null pointer to an NTBS, so it's safe to directly pass the result to `strcmp`.