### PR TITLE
Convert arguments to double in `_GENERIC_MATH2_BASE`

### DIFF
--- a/stl/inc/cmath
+++ b/stl/inc/cmath
@@ -620,8 +620,7 @@ _STD _Common_float_type_t<_Ty1, _Ty2> remquo(_Ty1 _Left, _Ty2 _Right, int* _Pquo
     template <class _Ty1, class _Ty2,                                                                            \
         _STD enable_if_t<_STD is_arithmetic_v<_Ty1> && _STD is_arithmetic_v<_Ty2>, int> = 0>                     \
     _NODISCARD _STD _Common_float_type_t<_Ty1, _Ty2> NAME(_Ty1 _Left, _Ty2 _Right) noexcept /* strengthened */ { \
-        using _Common = _STD _Common_float_type_t<_Ty1, _Ty2>;                                                   \
-        return FUN(static_cast<_Common>(_Left), static_cast<_Common>(_Right));                                   \
+        return FUN(static_cast<double>(_Left), static_cast<double>(_Right));                                     \
     }
 
 #define _GENERIC_MATH2(FUN) _GENERIC_MATH2_BASE(FUN, _CSTD FUN)

--- a/stl/inc/cmath
+++ b/stl/inc/cmath
@@ -620,7 +620,8 @@ _STD _Common_float_type_t<_Ty1, _Ty2> remquo(_Ty1 _Left, _Ty2 _Right, int* _Pquo
 // non-template overloads to the templates generated from this macro. The templates generated from
 // this macro are only selected by overload resolution when both arguments have integral type, or
 // when the types of the two arguments differ, in which case _Common_float_type_t is either double
-// or long double.
+// or long double. Note that double and long double have the same underlying representation on our
+// supported platforms.
 #define _GENERIC_MATH2_BASE(NAME, FUN)                                                                           \
     template <class _Ty1, class _Ty2,                                                                            \
         _STD enable_if_t<_STD is_arithmetic_v<_Ty1> && _STD is_arithmetic_v<_Ty2>, int> = 0>                     \

--- a/stl/inc/cmath
+++ b/stl/inc/cmath
@@ -616,6 +616,9 @@ _STD _Common_float_type_t<_Ty1, _Ty2> remquo(_Ty1 _Left, _Ty2 _Right, int* _Pquo
         return _CSTD FUN(static_cast<double>(_Left), _Arg2);                   \
     }
 
+// The templates generated from this macro are only selected by overload resolution when both
+// arguments have integral type or the types of the two arguments differ, in which case
+// _Common_float_type_t is either double or long double.
 #define _GENERIC_MATH2_BASE(NAME, FUN)                                                                           \
     template <class _Ty1, class _Ty2,                                                                            \
         _STD enable_if_t<_STD is_arithmetic_v<_Ty1> && _STD is_arithmetic_v<_Ty2>, int> = 0>                     \

--- a/stl/inc/cmath
+++ b/stl/inc/cmath
@@ -616,9 +616,11 @@ _STD _Common_float_type_t<_Ty1, _Ty2> remquo(_Ty1 _Left, _Ty2 _Right, int* _Pquo
         return _CSTD FUN(static_cast<double>(_Left), _Arg2);                   \
     }
 
-// The templates generated from this macro are only selected by overload resolution when both
-// arguments have integral type or the types of the two arguments differ, in which case
-// _Common_float_type_t is either double or long double.
+// When the arguments are both floats or both long doubles, overload resolution prefers the
+// non-template overloads to the templates generated from this macro. The templates generated from
+// this macro are only selected by overload resolution when both arguments have integral type, or
+// when the types of the two arguments differ, in which case _Common_float_type_t is either double
+// or long double.
 #define _GENERIC_MATH2_BASE(NAME, FUN)                                                                           \
     template <class _Ty1, class _Ty2,                                                                            \
         _STD enable_if_t<_STD is_arithmetic_v<_Ty1> && _STD is_arithmetic_v<_Ty2>, int> = 0>                     \

--- a/tests/std/test.lst
+++ b/tests/std/test.lst
@@ -217,6 +217,7 @@ tests\GH_002992_unwrappable_iter_sent_pairs
 tests\GH_003022_substr_allocator
 tests\GH_003105_piecewise_densities
 tests\GH_003119_error_category_ctor
+tests\GH_003246_cmath_narrowing
 tests\LWG2597_complex_branch_cut
 tests\LWG3018_shared_ptr_function
 tests\LWG3121_constrained_tuple_forwarding_ctor

--- a/tests/std/tests/GH_003246_cmath_narrowing/env.lst
+++ b/tests/std/tests/GH_003246_cmath_narrowing/env.lst
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+RUNALL_INCLUDE ..\usual_matrix.lst

--- a/tests/std/tests/GH_003246_cmath_narrowing/test.compile.pass.cpp
+++ b/tests/std/tests/GH_003246_cmath_narrowing/test.compile.pass.cpp
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <cmath>
+
+int main() {} // COMPILE-ONLY
+
+// Ensure the compiler doesn't warn about narrowing long double to double in <cmath> GENERIC_MATH2 templates
+#define TEST(meow) \
+    long double test_##meow(long double x) { return std::meow(x, 1); }
+
+TEST(atan2)
+TEST(hypot)
+TEST(pow)
+TEST(fmod)
+TEST(remainder)
+TEST(copysign)
+TEST(nextafter)
+TEST(fdim)
+TEST(fmax)
+TEST(fmin)


### PR DESCRIPTION
This template implements the "sufficient additional overloads" for two-argument `<cmath>` functions (`atan2`, `hypot`, `pow`, `fmod`, `remainder`, `copysign`, `nextafter`, `fdim`, `fmax`, and `fmin`) by calling either an intrinsic or a C library function either of which expects `double` arguments. We previously converted the arguments to `_Common_float_type_t` which is `long double` when at least one argument is `long double`, resulting in narrowing conversion warnings at `/W4`. We now convert the arguments to `double` instead of `_Common_float_type_t`.

Fixes #3246
