### PR TITLE
Implement P2167R3 Improving `boolean-testable` Usage (for comparison fallback CPOs)

### DIFF
--- a/stl/inc/compare
+++ b/stl/inc/compare
@@ -641,8 +641,8 @@ inline namespace _Cpos {
 
 template <class _Ty1, class _Ty2>
 concept _Can_fallback_eq_lt = requires(_Ty1& _Left, _Ty2& _Right) {
-                                  { _Left == _Right } -> _Implicitly_convertible_to<bool>;
-                                  { _Left < _Right } -> _Implicitly_convertible_to<bool>;
+                                  { _Left == _Right } -> _Boolean_testable;
+                                  { _Left < _Right } -> _Boolean_testable;
                               };
 
 template <class _Ty1, class _Ty2>
@@ -751,9 +751,9 @@ concept _Can_partial_order = requires(_Ty1& _Left, _Ty2& _Right) { _STD partial_
 namespace _Compare_partial_order_fallback {
     template <class _Ty1, class _Ty2>
     concept _Can_fallback_eq_lt_twice = requires(_Ty1& _Left, _Ty2& _Right) {
-                                            { _Left == _Right } -> _Implicitly_convertible_to<bool>;
-                                            { _Left < _Right } -> _Implicitly_convertible_to<bool>;
-                                            { _Right < _Left } -> _Implicitly_convertible_to<bool>;
+                                            { _Left == _Right } -> _Boolean_testable;
+                                            { _Left < _Right } -> _Boolean_testable;
+                                            { _Right < _Left } -> _Boolean_testable;
                                         };
 
     class _Cpo {

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -265,6 +265,7 @@
 // P2102R0 Making "Implicit Expression Variations" More Explicit
 // P2106R0 Range Algorithm Result Types
 // P2116R0 Removing tuple-Like Protocol Support From Fixed-Extent span
+// P2167R3 Improving boolean-testable Usage
 // P2210R2 Superior String Splitting
 // P2216R3 std::format Improvements
 // P2231R1 Completing constexpr In optional And variant

--- a/tests/std/tests/P0768R1_spaceship_cpos/test.cpp
+++ b/tests/std/tests/P0768R1_spaceship_cpos/test.cpp
@@ -326,6 +326,65 @@ namespace {
     static_assert(is_same_v<CpoResult<compare_partial_order_fallback, F<13>, const F<13>>, Partial>); // [cmp.alg]/6.3
 } // namespace
 
+// Test strengthened requirements in P2162R3: compare_*_order_fallback CPOs require return types to be boolean-testable.
+enum class ResultKind : bool {
+    Bad,
+    Good,
+};
+
+template <ResultKind K>
+struct ComparisonResult {
+    bool value;
+
+    constexpr operator bool() const noexcept {
+        return value;
+    }
+
+    constexpr auto operator!() const noexcept {
+        if constexpr (K == ResultKind::Good) {
+            return ComparisonResult{!value};
+        }
+    }
+};
+
+template <ResultKind EqKind, ResultKind LeKind>
+struct BoolTestType {
+    friend constexpr ComparisonResult<EqKind> operator==(BoolTestType, BoolTestType) noexcept {
+        return ComparisonResult<EqKind>{true};
+    }
+
+    friend constexpr ComparisonResult<LeKind> operator<(BoolTestType, BoolTestType) noexcept {
+        return ComparisonResult<LeKind>{false};
+    }
+};
+
+static_assert(is_same_v<CpoResult<compare_strong_order_fallback, BoolTestType<ResultKind::Bad, ResultKind::Bad>>,
+    IllFormed>); // [cmp.alg]/4.3
+static_assert(is_same_v<CpoResult<compare_strong_order_fallback, BoolTestType<ResultKind::Bad, ResultKind::Good>>,
+    IllFormed>); // [cmp.alg]/4.3
+static_assert(is_same_v<CpoResult<compare_strong_order_fallback, BoolTestType<ResultKind::Good, ResultKind::Bad>>,
+    IllFormed>); // [cmp.alg]/4.3
+static_assert(is_same_v<CpoResult<compare_strong_order_fallback, BoolTestType<ResultKind::Good, ResultKind::Good>>,
+    strong_ordering>); // [cmp.alg]/4.3
+
+static_assert(is_same_v<CpoResult<compare_weak_order_fallback, BoolTestType<ResultKind::Bad, ResultKind::Bad>>,
+    IllFormed>); // [cmp.alg]/5.3
+static_assert(is_same_v<CpoResult<compare_weak_order_fallback, BoolTestType<ResultKind::Bad, ResultKind::Good>>,
+    IllFormed>); // [cmp.alg]/5.3
+static_assert(is_same_v<CpoResult<compare_weak_order_fallback, BoolTestType<ResultKind::Good, ResultKind::Bad>>,
+    IllFormed>); // [cmp.alg]/5.3
+static_assert(is_same_v<CpoResult<compare_weak_order_fallback, BoolTestType<ResultKind::Good, ResultKind::Good>>,
+    weak_ordering>); // [cmp.alg]/5.3
+
+static_assert(is_same_v<CpoResult<compare_partial_order_fallback, BoolTestType<ResultKind::Bad, ResultKind::Bad>>,
+    IllFormed>); // [cmp.alg]/6.3
+static_assert(is_same_v<CpoResult<compare_partial_order_fallback, BoolTestType<ResultKind::Bad, ResultKind::Good>>,
+    IllFormed>); // [cmp.alg]/6.3
+static_assert(is_same_v<CpoResult<compare_partial_order_fallback, BoolTestType<ResultKind::Good, ResultKind::Bad>>,
+    IllFormed>); // [cmp.alg]/6.3
+static_assert(is_same_v<CpoResult<compare_partial_order_fallback, BoolTestType<ResultKind::Good, ResultKind::Good>>,
+    partial_ordering>); // [cmp.alg]/6.3
+
 // Test when the type is comparable through ADL. Part B, exception specifications.
 static_assert(!NoexceptCpo<std::strong_order, TestAdl::StrongType<Throwing>>); // [cmp.alg]/1.2
 static_assert(!NoexceptCpo<std::weak_order, TestAdl::WeakType<Throwing>>); // [cmp.alg]/2.2

--- a/tests/std/tests/P0768R1_spaceship_cpos/test.cpp
+++ b/tests/std/tests/P0768R1_spaceship_cpos/test.cpp
@@ -326,7 +326,7 @@ namespace {
     static_assert(is_same_v<CpoResult<compare_partial_order_fallback, F<13>, const F<13>>, Partial>); // [cmp.alg]/6.3
 } // namespace
 
-// Test strengthened requirements in P2162R3: compare_*_order_fallback CPOs require return types to be boolean-testable.
+// Test strengthened requirements in P2167R3: compare_*_order_fallback CPOs require return types to be boolean-testable.
 enum class ResultKind : bool {
     Bad,
     Good,


### PR DESCRIPTION
Fixes #3211. I believe that these changes should be applied to C++20 mode, as the paper is very near to an LWG DR.

No change is needed for the rest of P2167R3, because it's "something that increases the restrictions placed on users, but implementers aren't expected to enforce those restrictions".