### PR TITLE
Mirror changes to `stl/msbuild`

### DIFF
--- a/stl/msbuild/stl_1/msvcp_1.settings.targets
+++ b/stl/msbuild/stl_1/msvcp_1.settings.targets
@@ -12,7 +12,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         <TargetCoreSystem Condition="'$(MsvcpFlavor)' == 'onecore'">true</TargetCoreSystem>
         <TargetNetFx Condition="'$(MsvcpFlavor)' == 'netfx'">true</TargetNetFx>
 
-        <TargetType>DYNLINK</TargetType>
+        <ConfigurationType>DynamicLibrary</ConfigurationType>
     </PropertyGroup>
 
     <Import Project="$(MSBuildThisFileDirectory)..\..\..\..\crt_build.settings.targets"/>

--- a/stl/msbuild/stl_2/msvcp_2.settings.targets
+++ b/stl/msbuild/stl_2/msvcp_2.settings.targets
@@ -12,7 +12,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         <TargetCoreSystem Condition="'$(MsvcpFlavor)' == 'onecore'">true</TargetCoreSystem>
         <TargetNetFx Condition="'$(MsvcpFlavor)' == 'netfx'">true</TargetNetFx>
 
-        <TargetType>DYNLINK</TargetType>
+        <ConfigurationType>DynamicLibrary</ConfigurationType>
     </PropertyGroup>
 
     <Import Project="$(MSBuildThisFileDirectory)..\..\..\..\crt_build.settings.targets"/>

--- a/stl/msbuild/stl_asan/stl_asan.settings.targets
+++ b/stl/msbuild/stl_asan/stl_asan.settings.targets
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
     <PropertyGroup>
         <FinalBinary>p_stl_asan</FinalBinary>
-        <TargetType>LIBRARY</TargetType>
+        <ConfigurationType>StaticLibrary</ConfigurationType>
         <Arm64CombinedPdb>true</Arm64CombinedPdb>
     </PropertyGroup>
 

--- a/stl/msbuild/stl_atomic_wait/msvcp_atomic_wait.settings.targets
+++ b/stl/msbuild/stl_atomic_wait/msvcp_atomic_wait.settings.targets
@@ -12,7 +12,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         <TargetCoreSystem Condition="'$(MsvcpFlavor)' == 'onecore'">true</TargetCoreSystem>
         <TargetNetFx Condition="'$(MsvcpFlavor)' == 'netfx'">true</TargetNetFx>
 
-        <TargetType>DYNLINK</TargetType>
+        <ConfigurationType>DynamicLibrary</ConfigurationType>
     </PropertyGroup>
 
     <Import Project="$(MSBuildThisFileDirectory)..\..\..\..\crt_build.settings.targets"/>

--- a/stl/msbuild/stl_base/libcp.settings.targets
+++ b/stl/msbuild/stl_base/libcp.settings.targets
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
     <PropertyGroup>
         <FinalBinary>p</FinalBinary>
-        <TargetType>LIBRARY</TargetType>
+        <ConfigurationType>StaticLibrary</ConfigurationType>
         <TargetAppFamily Condition="'$(MsvcpFlavor)' == 'app'">true</TargetAppFamily>
         <TargetCoreSystem Condition="'$(MsvcpFlavor)' == 'onecore'">true</TargetCoreSystem>
         <DependsOnConcRT Condition="'$(MsvcpFlavor)' == 'kernel32'">true</DependsOnConcRT>

--- a/stl/msbuild/stl_base/msvcp.settings.targets
+++ b/stl/msbuild/stl_base/msvcp.settings.targets
@@ -16,7 +16,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         <TargetCoreSystem Condition="'$(MsvcpFlavor)' == 'onecore'">true</TargetCoreSystem>
         <TargetNetFx Condition="'$(MsvcpFlavor)' == 'netfx'">true</TargetNetFx>
 
-        <TargetType>DYNLINK</TargetType>
+        <ConfigurationType>DynamicLibrary</ConfigurationType>
     </PropertyGroup>
 
     <Import Project="$(MSBuildThisFileDirectory)..\..\..\..\crt_build.settings.targets"/>

--- a/stl/msbuild/stl_codecvt_ids/msvcp_codecvt_ids.settings.targets
+++ b/stl/msbuild/stl_codecvt_ids/msvcp_codecvt_ids.settings.targets
@@ -12,7 +12,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         <TargetCoreSystem Condition="'$(MsvcpFlavor)' == 'onecore'">true</TargetCoreSystem>
         <TargetNetFx Condition="'$(MsvcpFlavor)' == 'netfx'">true</TargetNetFx>
 
-        <TargetType>DYNLINK</TargetType>
+        <ConfigurationType>DynamicLibrary</ConfigurationType>
     </PropertyGroup>
 
     <Import Project="$(MSBuildThisFileDirectory)..\..\..\..\crt_build.settings.targets"/>

--- a/stl/msbuild/stl_post/msvcp_post.settings.targets
+++ b/stl/msbuild/stl_post/msvcp_post.settings.targets
@@ -12,7 +12,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         <TargetCoreSystem Condition="'$(MsvcpFlavor)' == 'onecore'">true</TargetCoreSystem>
         <TargetNetFx Condition="'$(MsvcpFlavor)' == 'netfx'">true</TargetNetFx>
 
-        <TargetType>LIBRARY</TargetType>
+        <ConfigurationType>StaticLibrary</ConfigurationType>
     </PropertyGroup>
 
     <Import Project="$(MSBuildThisFileDirectory)..\..\..\..\crt_build.settings.targets"/>


### PR DESCRIPTION
This is a mirror of @d-winsor's internal MSVC-PR-432919 "Restructure all Project files for future vcxproj conversion", updating the legacy MSBuild system.

Note: This MSVC-PR is targeted at `prod/be`, unlike most STL work which lands in `prod/fe`. So, there will be temporary divergence between GitHub and `prod/fe`, which is tolerable because these changes are small, `stl/msbuild` files are rarely changed by STL work, and when they are, these specific locations aren't changed.