### PR TITLE
Fallback to language id 0 with `FormatMessageA` if the error messages are not available in system locale

### DIFF
--- a/stl/src/syserror_import_lib.cpp
+++ b/stl/src/syserror_import_lib.cpp
@@ -57,6 +57,7 @@ _NODISCARD size_t __CLRCALL_PURE_OR_STDCALL __std_system_error_allocate_message(
     if (_Chars == 0 && _Lang_id != 0) {
         const DWORD _Last_error = GetLastError();
         if (_Last_error == ERROR_MUI_FILE_NOT_FOUND || _Last_error == ERROR_RESOURCE_LANG_NOT_FOUND) {
+            LocalFree(*_Ptr_str);
             _Chars = FormatMessageA(
                 FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, nullptr,
                 _Message_id, 0, reinterpret_cast<char*>(_Ptr_str), 0, nullptr);

--- a/stl/src/syserror_import_lib.cpp
+++ b/stl/src/syserror_import_lib.cpp
@@ -54,7 +54,14 @@ _NODISCARD size_t __CLRCALL_PURE_OR_STDCALL __std_system_error_allocate_message(
     const unsigned long _Chars =
         FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
             nullptr, _Message_id, _Lang_id, reinterpret_cast<char*>(_Ptr_str), 0, nullptr);
-
+    if (_Chars == 0 && _Lang_id != 0) {
+        const DWORD _Last_error = GetLastError();
+        if (_Last_error == ERROR_MUI_FILE_NOT_FOUND || _Last_error == ERROR_RESOURCE_LANG_NOT_FOUND) {
+            _Chars = FormatMessageA(
+                FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, nullptr,
+                _Message_id, 0, reinterpret_cast<char*>(_Ptr_str), 0, nullptr);
+        }
+    }
     return _CSTD __std_get_string_size_without_trailing_whitespace(*_Ptr_str, _Chars);
 }
 

--- a/stl/src/syserror_import_lib.cpp
+++ b/stl/src/syserror_import_lib.cpp
@@ -51,7 +51,7 @@ _NODISCARD size_t __CLRCALL_PURE_OR_STDCALL __std_system_error_allocate_message(
     if (_Ret == 0) {
         _Lang_id = 0;
     }
-    const unsigned long _Chars =
+    unsigned long _Chars =
         FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
             nullptr, _Message_id, _Lang_id, reinterpret_cast<char*>(_Ptr_str), 0, nullptr);
     if (_Chars == 0 && _Lang_id != 0) {


### PR DESCRIPTION
After #2669, `std::system_category` used the locale system language with `FormatMessageA` to get the error message which fixed a problem and introduced another one. As reported in #3254 the error messages may not be available in the system locale, but they are available in en-US locale shipped with windows so `FormatMessageA` failed with `ERROR_MUI_FILE_NOT_FOUND` and `std::system_category` returned hard coded "unknown error". It was working before because if the language id is 0 it will eventually fall back to en-US locale and return an error message in that locale.

I reproduced the problem on following windows installations:
- Windows 10 and Windows 11 with locale set to ar-EG and the Arabic langauge pack installed but `FormatMessageA` failed with `ERROR_MUI_FILE_NOT_FOUND`. Seems that there are no error messages in the Arabic mui because windows apps, explorer and login screen can show properly in arabic and right to left layout
- Windows 11 installed with locale en-GB set during installation by mistake then I removed the English UK keyboard and added English US and left the system locale set to en-GB. I was getting "unknown error" until I changed the locale back to "en-US"

This should fix https://github.com/microsoft/STL/issues/3254