### PR TITLE
Implement LWG-3746 `optional`'s spaceship with `U` with a type derived from `optional` causes infinite constraint meta-recursion

### DIFF
--- a/stl/inc/optional
+++ b/stl/inc/optional
@@ -926,7 +926,7 @@ _NODISCARD constexpr bool operator>=(const _Ty1& _Left, const optional<_Ty2>& _R
 #ifdef __cpp_lib_concepts
 // clang-format off
 _EXPORT_STD template <class _Ty1, class _Ty2>
-    requires (!_Is_specialization_v<_Ty2, optional>)
+    requires (!_Derived_from_specialization_of<_Ty2, optional>)
         && three_way_comparable_with<_Ty1, _Ty2>
 _NODISCARD constexpr compare_three_way_result_t<_Ty1, _Ty2>
     operator<=>(const optional<_Ty1>& _Left, const _Ty2& _Right)

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -404,9 +404,10 @@ template <template <class...> class _Template, class... _Args>
 void _Derived_from_specialization_impl(const _Template<_Args...>&);
 
 template <class _Ty, template <class...> class _Template>
-concept _Derived_from_specialization_of = requires(const _Ty& _Obj) {
-    _STD _Derived_from_specialization_impl<_Template>(_Obj); // qualified: avoid ADL, handle incomplete types
-};
+concept _Derived_from_specialization_of =
+    requires(const _Ty& _Obj) {
+        _STD _Derived_from_specialization_impl<_Template>(_Obj); // qualified: avoid ADL, handle incomplete types
+    };
 
 namespace ranges {
     namespace _Iter_move {

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -400,6 +400,14 @@ using _Algorithm_int_t = conditional_t<is_integral_v<_Ty>, _Ty, ptrdiff_t>;
 template <class _Ty>
 concept _Destructible_object = is_object_v<_Ty> && destructible<_Ty>;
 
+template <template <class...> class _Template, class... _Args>
+void _Derived_from_specialization_impl(const _Template<_Args...>&);
+
+template <class _Ty, template <class...> class _Template>
+concept _Derived_from_specialization_of = requires(const _Ty& _Obj) {
+    _STD _Derived_from_specialization_impl<_Template>(_Obj); // qualified: avoid ADL, handle incomplete types
+};
+
 namespace ranges {
     namespace _Iter_move {
         void iter_move(); // Block unqualified name lookup
@@ -2916,15 +2924,9 @@ namespace ranges {
 
     _EXPORT_STD struct view_base {};
 
-    template <template <class...> class _Template, class... _Args>
-    void _Derived_from_specialization_impl(const _Template<_Args...>&);
-
     template <class _Ty, template <class...> class _Template>
-    concept _Derived_from_specialization_of =
-        is_object_v<_Ty> && requires(const _Ty& _Obj) {
-                                _RANGES _Derived_from_specialization_impl<_Template>(
-                                    _Obj); // qualified: avoid ADL, handle incompletable types
-                            };
+    concept _Strictly_derived_from_specialization_of =
+        is_object_v<_Ty> && _Derived_from_specialization_of<_Ty, _Template>;
 
     _EXPORT_STD template <class _Derived>
         requires is_class_v<_Derived> && same_as<_Derived, remove_cv_t<_Derived>>
@@ -2932,7 +2934,7 @@ namespace ranges {
 
     _EXPORT_STD template <class _Ty>
     inline constexpr bool enable_view =
-        derived_from<_Ty, view_base> || _Derived_from_specialization_of<_Ty, view_interface>;
+        derived_from<_Ty, view_base> || _Strictly_derived_from_specialization_of<_Ty, view_interface>;
 
     _EXPORT_STD template <class _Ty>
     concept view = range<_Ty> && movable<_Ty> && enable_view<_Ty>;

--- a/tests/std/tests/P1614R2_spaceship/test.cpp
+++ b/tests/std/tests/P1614R2_spaceship/test.cpp
@@ -320,6 +320,7 @@ constexpr bool optional_test() {
 
         static_assert(!std::three_way_comparable<derived_optional<decltype(SmallVal)>>);
 
+        assert(spaceship_test<ReturnType>(o1, EqualVal, LargeVal));
         assert(spaceship_test<ReturnType>(o1, derived1, derived2));
     }
     {

--- a/tests/std/tests/P1614R2_spaceship/test.cpp
+++ b/tests/std/tests/P1614R2_spaceship/test.cpp
@@ -290,6 +290,9 @@ constexpr bool tuple_like_test() {
     return true;
 }
 
+template <class T>
+struct derived_optional : std::optional<T> {};
+
 template <auto SmallVal, decltype(SmallVal) EqualVal, decltype(EqualVal) LargeVal>
 constexpr bool optional_test() {
     using ReturnType = std::compare_three_way_result_t<decltype(SmallVal)>;
@@ -312,6 +315,13 @@ constexpr bool optional_test() {
         constexpr std::optional o1(SmallVal);
 
         assert(spaceship_test<ReturnType>(o1, EqualVal, LargeVal));
+    }
+    {
+        constexpr std::optional o1(SmallVal);
+        constexpr derived_optional<decltype(SmallVal)> derived1{std::optional(SmallVal)};
+        constexpr derived_optional<decltype(SmallVal)> derived2{std::optional(LargeVal)};
+
+        assert(spaceship_test<ReturnType>(o1, derived1, derived2));
     }
     {
         constexpr std::optional<decltype(SmallVal)> o1(std::nullopt);

--- a/tests/std/tests/P1614R2_spaceship/test.cpp
+++ b/tests/std/tests/P1614R2_spaceship/test.cpp
@@ -291,7 +291,9 @@ constexpr bool tuple_like_test() {
 }
 
 template <class T>
-struct derived_optional : std::optional<T> {};
+struct derived_optional : std::optional<T> {
+    friend bool operator==(const derived_optional&, const derived_optional&) = default;
+};
 
 template <auto SmallVal, decltype(SmallVal) EqualVal, decltype(EqualVal) LargeVal>
 constexpr bool optional_test() {
@@ -313,13 +315,10 @@ constexpr bool optional_test() {
     }
     {
         constexpr std::optional o1(SmallVal);
-
-        assert(spaceship_test<ReturnType>(o1, EqualVal, LargeVal));
-    }
-    {
-        constexpr std::optional o1(SmallVal);
         constexpr derived_optional<decltype(SmallVal)> derived1{std::optional(SmallVal)};
         constexpr derived_optional<decltype(SmallVal)> derived2{std::optional(LargeVal)};
+
+        static_assert(!std::three_way_comparable<derived_optional<decltype(SmallVal)>>);
 
         assert(spaceship_test<ReturnType>(o1, derived1, derived2));
     }


### PR DESCRIPTION
Fixes #3225.

I found that MSVC's behavior is strange during testing ([Godbolt link](https://godbolt.org/z/dfhqqKaPn)), so currently I haven't add the [original example](https://godbolt.org/z/T7f4sr8jv) yet.

```C++
#include <optional>

struct derived_optional : std::optional<int> {
    friend bool operator==(const derived_optional&, const derived_optional&) = default;
    friend auto operator<=>(const derived_optional&, const derived_optional&) = default;
};

int main()
{
    derived_optional a;
    std::optional<derived_optional> b;
#ifdef LESS // If b < a is not skipped, then MSVC accepts b <=> a.
    (void) (b < a);
#endif
    (void) (b <=> a);
}
```