### PR TITLE
Qualify calls to helpers that are in both _STD and _RANGES

### DIFF
--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -705,8 +705,8 @@ namespace ranges {
                     return false;
                 }
 
-                return _Equal_count(_STD move(_UFirst1), _STD move(_UFirst2), _Count, _Pass_fn(_Pred), _Pass_fn(_Proj1),
-                    _Pass_fn(_Proj2));
+                return _RANGES _Equal_count(_STD move(_UFirst1), _STD move(_UFirst2), _Count, _Pass_fn(_Pred),
+                    _Pass_fn(_Proj1), _Pass_fn(_Proj2));
             } else {
                 return _Equal_4(_STD move(_UFirst1), _STD move(_ULast1), _STD move(_UFirst2), _STD move(_ULast2),
                     _Pass_fn(_Pred), _Pass_fn(_Proj1), _Pass_fn(_Proj2));
@@ -725,7 +725,7 @@ namespace ranges {
                 if (_Count != static_cast<_Size2>(_RANGES size(_Range2))) {
                     return false;
                 }
-                return _Equal_count(
+                return _RANGES _Equal_count(
                     _Ubegin(_Range1), _Ubegin(_Range2), _Count, _Pass_fn(_Pred), _Pass_fn(_Proj1), _Pass_fn(_Proj2));
             } else {
                 return _Equal_4(_Ubegin(_Range1), _Uend(_Range1), _Ubegin(_Range2), _Uend(_Range2), _Pass_fn(_Pred),
@@ -1593,7 +1593,7 @@ namespace ranges {
             auto _UFirst = _Unwrap_iter<_Se1>(_STD move(_First));
             auto _ULast  = _Get_final_iterator_unwrapped<_It1>(_UFirst, _STD move(_Last));
             _Seek_wrapped(_First, _ULast);
-            _Result = _Move_backward_common(_STD move(_UFirst), _STD move(_ULast), _STD move(_Result));
+            _Result = _RANGES _Move_backward_common(_STD move(_UFirst), _STD move(_ULast), _STD move(_Result));
             return {_STD move(_First), _STD move(_Result)};
         }
 
@@ -1601,7 +1601,7 @@ namespace ranges {
             requires indirectly_movable<iterator_t<_Rng>, _It>
         constexpr move_backward_result<borrowed_iterator_t<_Rng>, _It> operator()(_Rng&& _Range, _It _Result) const {
             auto _ULast = _Get_final_iterator_unwrapped(_Range);
-            _Result     = _Move_backward_common(_Ubegin(_Range), _ULast, _STD move(_Result));
+            _Result     = _RANGES _Move_backward_common(_Ubegin(_Range), _ULast, _STD move(_Result));
             return {_Rewrap_iterator(_Range, _STD move(_ULast)), _STD move(_Result)};
         }
     };
@@ -2745,13 +2745,13 @@ namespace ranges {
             _Indirectly_binary_right_foldable<_Ty, _It> _Fn>
         _NODISCARD constexpr auto operator()(_It _First, _Se _Last, _Ty _Init, _Fn _Func) const {
             _Adl_verify_range(_First, _Last);
-            return _Fold_right_unchecked(_Unwrap_iter<_Se>(_STD move(_First)), _Unwrap_sent<_It>(_STD move(_Last)),
-                _STD move(_Init), _Pass_fn(_Func));
+            return _RANGES _Fold_right_unchecked(_Unwrap_iter<_Se>(_STD move(_First)),
+                _Unwrap_sent<_It>(_STD move(_Last)), _STD move(_Init), _Pass_fn(_Func));
         }
 
         template <bidirectional_range _Rng, class _Ty, _Indirectly_binary_right_foldable<_Ty, iterator_t<_Rng>> _Fn>
         _NODISCARD constexpr auto operator()(_Rng&& _Range, _Ty _Init, _Fn _Func) const {
-            return _Fold_right_unchecked(_Ubegin(_Range), _Uend(_Range), _STD move(_Init), _Pass_fn(_Func));
+            return _RANGES _Fold_right_unchecked(_Ubegin(_Range), _Uend(_Range), _STD move(_Init), _Pass_fn(_Func));
         }
     };
 
@@ -2920,7 +2920,7 @@ namespace ranges {
 
                 for (auto _Candidate = _First1 + (_Count1 - _Count2_as1);; --_Candidate) {
                     auto [_Match, _Mid1] =
-                        _Equal_rev_pred(_Candidate, _First2, _First2 + _Count2, _Pred, _Proj1, _Proj2);
+                        _RANGES _Equal_rev_pred(_Candidate, _First2, _First2 + _Count2, _Pred, _Proj1, _Proj2);
                     if (_Match) {
                         return {_STD move(_Candidate), _STD move(_Mid1)};
                     }
@@ -4854,8 +4854,8 @@ _CONSTEXPR20 _OutIt rotate_copy(_FwdIt _First, _FwdIt _Mid, _FwdIt _Last, _OutIt
     const auto _UMid   = _Get_unwrapped(_Mid);
     const auto _ULast  = _Get_unwrapped(_Last);
     auto _UDest        = _Get_unwrapped_n(_Dest, _Idl_distance<_FwdIt>(_UFirst, _ULast));
-    _UDest             = _Copy_unchecked(_UMid, _ULast, _UDest);
-    _Seek_wrapped(_Dest, _Copy_unchecked(_UFirst, _UMid, _UDest));
+    _UDest             = _STD _Copy_unchecked(_UMid, _ULast, _UDest);
+    _Seek_wrapped(_Dest, _STD _Copy_unchecked(_UFirst, _UMid, _UDest));
     return _Dest;
 }
 
@@ -5333,7 +5333,7 @@ constexpr _FwdIt shift_left(_FwdIt _First, const _FwdIt _Last, _Iter_diff_t<_Fwd
         }
     }
 
-    _Seek_wrapped(_First, _Move_unchecked(_Start_at, _ULast, _UFirst));
+    _Seek_wrapped(_First, _STD _Move_unchecked(_Start_at, _ULast, _UFirst));
     return _First;
 }
 
@@ -5393,7 +5393,7 @@ constexpr _FwdIt shift_right(_FwdIt _First, const _FwdIt _Last, _Iter_diff_t<_Fw
 
         for (; _Trail != _UResult; ++_Trail, (void) ++_Lead) {
             if (_Lead == _ULast) {
-                _Move_unchecked(_UFirst, _Trail, _UResult);
+                _STD _Move_unchecked(_UFirst, _Trail, _UResult);
 
                 return _First;
             }
@@ -5407,8 +5407,8 @@ constexpr _FwdIt shift_right(_FwdIt _First, const _FwdIt _Last, _Iter_diff_t<_Fw
             // advancing _Trail and _Lead by _Pos_to_shift
             for (auto _Mid = _UFirst; _Mid != _UResult; ++_Mid, (void) ++_Trail, ++_Lead) {
                 if (_Lead == _ULast) {
-                    _Trail = _Move_unchecked(_Mid, _UResult, _Trail);
-                    _Move_unchecked(_UFirst, _Mid, _Trail);
+                    _Trail = _STD _Move_unchecked(_Mid, _UResult, _Trail);
+                    _STD _Move_unchecked(_UFirst, _Mid, _Trail);
 
                     return _First;
                 }
@@ -5815,17 +5815,17 @@ _BidIt _Buffered_rotate_unchecked(const _BidIt _First, const _BidIt _Mid, const 
 
     if (_Count1 <= _Count2 && _Count1 <= _Capacity) { // buffer left range, then copy parts
         _Uninitialized_backout<_Iter_value_t<_BidIt>*> _Backout{
-            _Temp_ptr, _Uninitialized_move_unchecked(_First, _Mid, _Temp_ptr)};
-        const _BidIt _New_mid = _Move_unchecked(_Mid, _Last, _First);
-        _Move_unchecked(_Backout._First, _Backout._Last, _New_mid);
+            _Temp_ptr, _STD _Uninitialized_move_unchecked(_First, _Mid, _Temp_ptr)};
+        const _BidIt _New_mid = _STD _Move_unchecked(_Mid, _Last, _First);
+        _STD _Move_unchecked(_Backout._First, _Backout._Last, _New_mid);
         return _New_mid; // _Backout destroys elements in temporary buffer
     }
 
     if (_Count2 <= _Capacity) { // buffer right range, then copy parts
         _Uninitialized_backout<_Iter_value_t<_BidIt>*> _Backout{
-            _Temp_ptr, _Uninitialized_move_unchecked(_Mid, _Last, _Temp_ptr)};
+            _Temp_ptr, _STD _Uninitialized_move_unchecked(_Mid, _Last, _Temp_ptr)};
         _Move_backward_unchecked(_First, _Mid, _Last);
-        return _Move_unchecked(_Backout._First, _Backout._Last, _First); // ditto _Backout destroys elements
+        return _STD _Move_unchecked(_Backout._First, _Backout._Last, _First); // ditto _Backout destroys elements
     }
 
     // buffer too small, rotate in place
@@ -5859,7 +5859,7 @@ pair<_BidIt, _Iter_diff_t<_BidIt>> _Stable_partition_unchecked1(_BidIt _First, _
         // move the last true element, *_Last, to the end of the true range
         *_Next = _STD move(*_Last);
         ++_Next;
-        _Move_unchecked(_Backout._First, _Backout._Last, _Next); // copy back the false range
+        _STD _Move_unchecked(_Backout._First, _Backout._Last, _Next); // copy back the false range
         _Diff _True_distance = static_cast<_Diff>(_Count - static_cast<_Diff>(_Backout._Last - _Backout._First));
         return pair<_BidIt, _Diff>(_Next, _True_distance); // _Backout destroys elements
     }
@@ -6193,7 +6193,7 @@ _CONSTEXPR20 void push_heap(_RanIt _First, _RanIt _Last, _Pr _Pred) {
     _Diff _Count       = _ULast - _UFirst;
     if (2 <= _Count) {
         _Iter_value_t<_RanIt> _Val = _STD move(*--_ULast);
-        _Push_heap_by_index(_UFirst, --_Count, _Diff(0), _STD move(_Val), _Pass_fn(_Pred));
+        _STD _Push_heap_by_index(_UFirst, --_Count, _Diff(0), _STD move(_Val), _Pass_fn(_Pred));
     }
 }
 
@@ -6302,7 +6302,7 @@ _CONSTEXPR20 void _Pop_heap_hole_by_index(
         _Hole             = _Bottom - 1;
     }
 
-    _Push_heap_by_index(_First, _Hole, _Top, _STD forward<_Ty>(_Val), _Pred);
+    _STD _Push_heap_by_index(_First, _Hole, _Top, _STD forward<_Ty>(_Val), _Pred);
 }
 
 template <class _RanIt, class _Ty, class _Pr>
@@ -6312,7 +6312,7 @@ _CONSTEXPR20 void _Pop_heap_hole_unchecked(_RanIt _First, _RanIt _Last, _RanIt _
     // precondition: _First != _Dest
     *_Dest      = _STD move(*_First);
     using _Diff = _Iter_diff_t<_RanIt>;
-    _Pop_heap_hole_by_index(
+    _STD _Pop_heap_hole_by_index(
         _First, static_cast<_Diff>(0), static_cast<_Diff>(_Last - _First), _STD forward<_Ty>(_Val), _Pred);
 }
 
@@ -6322,7 +6322,7 @@ _CONSTEXPR20 void _Pop_heap_unchecked(_RanIt _First, _RanIt _Last, _Pr _Pred) {
     if (2 <= _Last - _First) {
         --_Last;
         _Iter_value_t<_RanIt> _Val = _STD move(*_Last);
-        _Pop_heap_hole_unchecked(_First, _Last, _Last, _STD move(_Val), _Pred);
+        _STD _Pop_heap_hole_unchecked(_First, _Last, _Last, _STD move(_Val), _Pred);
     }
 }
 
@@ -6330,7 +6330,7 @@ _EXPORT_STD template <class _RanIt, class _Pr>
 _CONSTEXPR20 void pop_heap(_RanIt _First, _RanIt _Last, _Pr _Pred) {
     // pop *_First to *(_Last - 1) and reheap
     _Adl_verify_range(_First, _Last);
-    _Pop_heap_unchecked(_Get_unwrapped(_First), _Get_unwrapped(_Last), _Pass_fn(_Pred));
+    _STD _Pop_heap_unchecked(_Get_unwrapped(_First), _Get_unwrapped(_Last), _Pass_fn(_Pred));
 }
 
 _EXPORT_STD template <class _RanIt>
@@ -6446,7 +6446,7 @@ _CONSTEXPR20 void _Make_heap_unchecked(_RanIt _First, _RanIt _Last, _Pr _Pred) {
         // reheap top half, bottom to top
         --_Hole;
         _Iter_value_t<_RanIt> _Val = _STD move(*(_First + _Hole));
-        _Pop_heap_hole_by_index(_First, _Hole, _Bottom, _STD move(_Val), _Pred);
+        _STD _Pop_heap_hole_by_index(_First, _Hole, _Bottom, _STD move(_Val), _Pred);
     }
 }
 
@@ -6529,7 +6529,8 @@ _EXPORT_STD template <class _RanIt, class _Pr>
 _NODISCARD _CONSTEXPR20 _RanIt is_heap_until(_RanIt _First, _RanIt _Last, _Pr _Pred) {
     // find extent of range that is a heap
     _Adl_verify_range(_First, _Last);
-    _Seek_wrapped(_First, _Is_heap_until_unchecked(_Get_unwrapped(_First), _Get_unwrapped(_Last), _Pass_fn(_Pred)));
+    _Seek_wrapped(
+        _First, _STD _Is_heap_until_unchecked(_Get_unwrapped(_First), _Get_unwrapped(_Last), _Pass_fn(_Pred)));
     return _First;
 }
 
@@ -6539,7 +6540,7 @@ _NODISCARD _CONSTEXPR20 bool is_heap(_RanIt _First, _RanIt _Last, _Pr _Pred) {
     _Adl_verify_range(_First, _Last);
     const auto _UFirst = _Get_unwrapped(_First);
     const auto _ULast  = _Get_unwrapped(_Last);
-    return _Is_heap_until_unchecked(_UFirst, _ULast, _Pass_fn(_Pred)) == _ULast;
+    return _STD _Is_heap_until_unchecked(_UFirst, _ULast, _Pass_fn(_Pred)) == _ULast;
 }
 
 _EXPORT_STD template <class _RanIt>
@@ -6663,7 +6664,7 @@ template <class _RanIt, class _Pr>
 _CONSTEXPR20 void _Sort_heap_unchecked(_RanIt _First, _RanIt _Last, _Pr _Pred) {
     // order heap by repeatedly popping
     for (; _Last - _First >= 2; --_Last) {
-        _Pop_heap_unchecked(_First, _Last, _Pred);
+        _STD _Pop_heap_unchecked(_First, _Last, _Pred);
     }
 }
 
@@ -6673,7 +6674,7 @@ _CONSTEXPR20 void sort_heap(_RanIt _First, _RanIt _Last, _Pr _Pred) { // order h
     const auto _UFirst = _Get_unwrapped(_First);
     const auto _ULast  = _Get_unwrapped(_Last);
 #if _ITERATOR_DEBUG_LEVEL == 2
-    const auto _Counterexample = _Is_heap_until_unchecked(_UFirst, _ULast, _Pass_fn(_Pred));
+    const auto _Counterexample = _STD _Is_heap_until_unchecked(_UFirst, _ULast, _Pass_fn(_Pred));
     if (_Counterexample != _ULast) {
         _STL_REPORT_ERROR("invalid heap in sort_heap()");
     }
@@ -6817,7 +6818,8 @@ namespace ranges {
             _Adl_verify_range(_First, _Last);
             auto _UFirst      = _Unwrap_iter<_Se>(_STD move(_First));
             const auto _Count = _RANGES distance(_UFirst, _Unwrap_sent<_It>(_STD move(_Last)));
-            _UFirst = _Upper_bound_unchecked(_STD move(_UFirst), _Count, _Val, _Pass_fn(_Pred), _Pass_fn(_Proj));
+            _UFirst =
+                _RANGES _Upper_bound_unchecked(_STD move(_UFirst), _Count, _Val, _Pass_fn(_Pred), _Pass_fn(_Proj));
             _Seek_wrapped(_First, _STD move(_UFirst));
             return _First;
         }
@@ -6827,8 +6829,9 @@ namespace ranges {
         _NODISCARD constexpr borrowed_iterator_t<_Rng> operator()(
             _Rng&& _Range, const _Ty& _Val, _Pr _Pred = {}, _Pj _Proj = {}) const {
             const auto _Count = _RANGES distance(_Range);
-            auto _UResult     = _Upper_bound_unchecked(_Ubegin(_Range), _Count, _Val, _Pass_fn(_Pred), _Pass_fn(_Proj));
-            auto _Result      = _RANGES begin(_Range);
+            auto _UResult =
+                _RANGES _Upper_bound_unchecked(_Ubegin(_Range), _Count, _Val, _Pass_fn(_Pred), _Pass_fn(_Proj));
+            auto _Result = _RANGES begin(_Range);
             _Seek_wrapped(_Result, _STD move(_UResult));
             return _Result;
         }
@@ -7048,8 +7051,8 @@ _CONSTEXPR20 _OutIt merge(_InIt1 _First1, _InIt1 _Last1, _InIt2 _First2, _InIt2 
         }
     }
 
-    _UDest = _Copy_unchecked(_UFirst1, _ULast1, _UDest); // copy any tail
-    _Seek_wrapped(_Dest, _Copy_unchecked(_UFirst2, _ULast2, _UDest));
+    _UDest = _STD _Copy_unchecked(_UFirst1, _ULast1, _UDest); // copy any tail
+    _Seek_wrapped(_Dest, _STD _Copy_unchecked(_UFirst2, _ULast2, _UDest));
     return _Dest;
 }
 
@@ -7186,7 +7189,7 @@ void _Rotate_one_left(_BidIt _First, _BidIt _Mid, _BidIt _Last) {
     // exchanges the range [_First, _Mid) with [_Mid, _Last)
     // pre: distance(_First, _Mid) is 1
     _Iter_value_t<_BidIt> _Temp(_STD move(*_First));
-    *_Move_unchecked(_Mid, _Last, _First) = _STD move(_Temp);
+    *_STD _Move_unchecked(_Mid, _Last, _First) = _STD move(_Temp);
 }
 
 template <class _BidIt, class _Pr>
@@ -7195,7 +7198,7 @@ void _Inplace_merge_buffer_left(
     // move the range [_First, _Mid) to _Temp_ptr, and merge it with [_Mid, _Last) to _First
     // usual invariants apply
     using _Ptr_ty = _Iter_value_t<_BidIt>*;
-    _Uninitialized_backout<_Ptr_ty> _Backout{_Temp_ptr, _Uninitialized_move_unchecked(_First, _Mid, _Temp_ptr)};
+    _Uninitialized_backout<_Ptr_ty> _Backout{_Temp_ptr, _STD _Uninitialized_move_unchecked(_First, _Mid, _Temp_ptr)};
     _Ptr_ty _Left_first      = _Temp_ptr;
     const _Ptr_ty _Left_last = _Backout._Last - 1; // avoid a compare with the highest element
     *_First                  = _STD move(*_Mid); // the lowest element is now in position
@@ -7207,7 +7210,7 @@ void _Inplace_merge_buffer_left(
             ++_First;
             ++_Mid;
             if (_Mid == _Last) {
-                _Move_unchecked(_Left_first, _Backout._Last, _First); // move any tail (and the highest element)
+                _STD _Move_unchecked(_Left_first, _Backout._Last, _First); // move any tail (and the highest element)
                 return;
             }
         } else { // take element from the left partition
@@ -7216,7 +7219,7 @@ void _Inplace_merge_buffer_left(
             ++_Left_first;
             if (_Left_first == _Left_last) {
                 // move the remaining right partition and highest element, since *_Left_first is highest
-                *_Move_unchecked(_Mid, _Last, _First) = _STD move(*_Left_last);
+                *_STD _Move_unchecked(_Mid, _Last, _First) = _STD move(*_Left_last);
                 return;
             }
         }
@@ -7229,7 +7232,7 @@ void _Inplace_merge_buffer_right(
     // move the range [_Mid, _Last) to _Temp_ptr, and merge it with [_First, _Mid) to _Last
     // usual invariants apply
     using _Ptr_ty = _Iter_value_t<_BidIt>*;
-    _Uninitialized_backout<_Ptr_ty> _Backout{_Temp_ptr, _Uninitialized_move_unchecked(_Mid, _Last, _Temp_ptr)};
+    _Uninitialized_backout<_Ptr_ty> _Backout{_Temp_ptr, _STD _Uninitialized_move_unchecked(_Mid, _Last, _Temp_ptr)};
     *--_Last                   = _STD move(*--_Mid); // move the highest element into position
     const _Ptr_ty _Right_first = _Temp_ptr;
     _Ptr_ty _Right_last        = _Backout._Last - 1;
@@ -7285,14 +7288,14 @@ void _Buffered_inplace_merge_divide_and_conquer(_BidIt _First, _BidIt _Mid, _Bid
         const _Diff _Count1n = _Count1 >> 1; // shift for codegen
         const _BidIt _Firstn = _STD next(_First, _Count1n);
         const _BidIt _Lastn  = _STD lower_bound(_Mid, _Last, *_Firstn, _Pred);
-        _Buffered_inplace_merge_divide_and_conquer2(_First, _Mid, _Last, _Count1, _Count2, _Temp_ptr, _Capacity, _Pred,
-            _Firstn, _Lastn, _Count1n, _STD distance(_Mid, _Lastn));
+        _STD _Buffered_inplace_merge_divide_and_conquer2(_First, _Mid, _Last, _Count1, _Count2, _Temp_ptr, _Capacity,
+            _Pred, _Firstn, _Lastn, _Count1n, _STD distance(_Mid, _Lastn));
     } else {
         const _Diff _Count2n = _Count2 >> 1; // shift for codegen
         const _BidIt _Lastn  = _STD next(_Mid, _Count2n);
         const _BidIt _Firstn = _STD upper_bound(_First, _Mid, *_Lastn, _Pred);
-        _Buffered_inplace_merge_divide_and_conquer2(_First, _Mid, _Last, _Count1, _Count2, _Temp_ptr, _Capacity, _Pred,
-            _Firstn, _Lastn, _STD distance(_First, _Firstn), _Count2n);
+        _STD _Buffered_inplace_merge_divide_and_conquer2(_First, _Mid, _Last, _Count1, _Count2, _Temp_ptr, _Capacity,
+            _Pred, _Firstn, _Lastn, _STD distance(_First, _Firstn), _Count2n);
     }
 }
 
@@ -7302,11 +7305,12 @@ void _Buffered_inplace_merge_unchecked_impl(_BidIt _First, _BidIt _Mid, _BidIt _
     // merge sorted [_First, _Mid) with sorted [_Mid, _Last)
     // usual invariants apply
     if (_Count1 <= _Count2 && _Count1 <= _Capacity) {
-        _Inplace_merge_buffer_left(_First, _Mid, _Last, _Temp_ptr, _Pred);
+        _STD _Inplace_merge_buffer_left(_First, _Mid, _Last, _Temp_ptr, _Pred);
     } else if (_Count2 <= _Capacity) {
-        _Inplace_merge_buffer_right(_First, _Mid, _Last, _Temp_ptr, _Pred);
+        _STD _Inplace_merge_buffer_right(_First, _Mid, _Last, _Temp_ptr, _Pred);
     } else {
-        _Buffered_inplace_merge_divide_and_conquer(_First, _Mid, _Last, _Count1, _Count2, _Temp_ptr, _Capacity, _Pred);
+        _STD _Buffered_inplace_merge_divide_and_conquer(
+            _First, _Mid, _Last, _Count1, _Count2, _Temp_ptr, _Capacity, _Pred);
     }
 }
 
@@ -7338,7 +7342,7 @@ void _Buffered_inplace_merge_unchecked(_BidIt _First, _BidIt _Mid, _BidIt _Last,
         --_Last;
         --_Count2;
         if (_Mid == _Last) {
-            _Rotate_one_right(_First, _Mid, ++_Last);
+            _STD _Rotate_one_right(_First, _Mid, ++_Last);
             return;
         }
     } while (!_Pred(*_Last, *_Highest));
@@ -7347,7 +7351,7 @@ void _Buffered_inplace_merge_unchecked(_BidIt _First, _BidIt _Mid, _BidIt _Last,
     ++_Count2;
 
     if (_Count1 == 1) {
-        _Rotate_one_left(_First, _Mid, _Last);
+        _STD _Rotate_one_left(_First, _Mid, _Last);
         return;
     }
 
@@ -7385,7 +7389,7 @@ void inplace_merge(_BidIt _First, _BidIt _Mid, _BidIt _Last, _Pr _Pred) {
     do {
         --_ULast;
         if (_UMid == _ULast) { // rotate only element remaining in right partition to the beginning, without allocating
-            _Rotate_one_right(_UFirst, _UMid, ++_ULast);
+            _STD _Rotate_one_right(_UFirst, _UMid, ++_ULast);
             return;
         }
     } while (!_Pred(*_ULast, *_Highest)); // found that *_Highest goes in *_ULast's position
@@ -7395,7 +7399,7 @@ void inplace_merge(_BidIt _First, _BidIt _Mid, _BidIt _Last, _Pr _Pred) {
     using _Diff         = _Iter_diff_t<_BidIt>;
     const _Diff _Count1 = _STD distance(_UFirst, _UMid);
     if (_Count1 == 1) { // rotate only element remaining in left partition to the end, without allocating
-        _Rotate_one_left(_UFirst, _UMid, _ULast);
+        _STD _Rotate_one_left(_UFirst, _UMid, _ULast);
         return;
     }
 
@@ -8110,7 +8114,7 @@ namespace ranges {
 
             for (;;) {
                 if (_Last - _First <= _ISORT_MAX) { // small
-                    _Insertion_sort_common(_STD move(_First), _STD move(_Last), _Pred, _Proj);
+                    _RANGES _Insertion_sort_common(_STD move(_First), _STD move(_Last), _Pred, _Proj);
                     return;
                 }
 
@@ -8158,7 +8162,7 @@ _Ty* _Uninitialized_merge_move(_FwdIt _First, const _FwdIt _Mid, const _FwdIt _L
             ++_Next;
 
             if (_Next == _Last) {
-                _Backout._Last = _Uninitialized_move_unchecked(_First, _Mid, _Backout._Last);
+                _Backout._Last = _STD _Uninitialized_move_unchecked(_First, _Mid, _Backout._Last);
                 return _Backout._Release();
             }
         } else {
@@ -8166,7 +8170,7 @@ _Ty* _Uninitialized_merge_move(_FwdIt _First, const _FwdIt _Mid, const _FwdIt _L
             ++_First;
 
             if (_First == _Mid) {
-                _Backout._Last = _Uninitialized_move_unchecked(_Next, _Last, _Backout._Last);
+                _Backout._Last = _STD _Uninitialized_move_unchecked(_Next, _Last, _Backout._Last);
                 return _Backout._Release();
             }
         }
@@ -8185,7 +8189,7 @@ _OutIt _Merge_move(_InIt _First, const _InIt _Mid, const _InIt _Last, _OutIt _De
             ++_Next;
 
             if (_Next == _Last) {
-                return _Move_unchecked(_First, _Mid, _Dest);
+                return _STD _Move_unchecked(_First, _Mid, _Dest);
             }
         } else {
             *_Dest = _STD move(*_First);
@@ -8193,7 +8197,7 @@ _OutIt _Merge_move(_InIt _First, const _InIt _Mid, const _InIt _Last, _OutIt _De
             ++_First;
 
             if (_First == _Mid) {
-                return _Move_unchecked(_Next, _Last, _Dest);
+                return _STD _Move_unchecked(_Next, _Last, _Dest);
             }
         }
     }
@@ -8216,7 +8220,7 @@ void _Uninitialized_chunked_merge_unchecked2(
         _First             = _Mid2;
     }
 
-    _Uninitialized_move_unchecked(_First, _Last, _Backout._Last); // copy partial last chunk
+    _STD _Uninitialized_move_unchecked(_First, _Last, _Backout._Last); // copy partial last chunk
     _Backout._Release();
 }
 
@@ -8236,7 +8240,7 @@ void _Chunked_merge_unchecked(_BidIt _First, const _BidIt _Last, _OutIt _Dest, c
         _First             = _Mid2;
     }
 
-    _Move_unchecked(_First, _Last, _Dest); // copy partial last chunk
+    _STD _Move_unchecked(_First, _Last, _Dest); // copy partial last chunk
 }
 
 template <class _BidIt, class _Pr>
@@ -8609,7 +8613,7 @@ _CONSTEXPR20 void partial_sort(_RanIt _First, _RanIt _Mid, _RanIt _Last, _Pr _Pr
     for (auto _UNext = _UMid; _UNext < _ULast; ++_UNext) {
         if (_DEBUG_LT_PRED(_Pred, *_UNext, *_UFirst)) { // replace top with new largest
             _Iter_value_t<_RanIt> _Val = _STD move(*_UNext);
-            _Pop_heap_hole_unchecked(_UFirst, _UMid, _UNext, _STD move(_Val), _Pass_fn(_Pred));
+            _STD _Pop_heap_hole_unchecked(_UFirst, _UMid, _UNext, _STD move(_Val), _Pass_fn(_Pred));
         }
     }
 
@@ -8732,7 +8736,7 @@ _CONSTEXPR20 _RanIt partial_sort_copy(_InIt _First1, _InIt _Last1, _RanIt _First
             if (_DEBUG_LT_PRED(_Pred, *_UFirst1, *_UFirst2)) {
                 // replace top with new largest:
                 using _Diff = _Iter_diff_t<_RanIt>;
-                _Pop_heap_hole_by_index(
+                _STD _Pop_heap_hole_by_index(
                     _UFirst2, static_cast<_Diff>(0), static_cast<_Diff>(_UMid2 - _UFirst2), *_UFirst1, _Pass_fn(_Pred));
             }
         }
@@ -8973,7 +8977,7 @@ namespace ranges {
             }
 
             // sort any remainder
-            _Insertion_sort_common(_STD move(_First), _STD move(_Last), _Pred, _Proj);
+            _RANGES _Insertion_sort_common(_STD move(_First), _STD move(_Last), _Pred, _Proj);
         }
     };
 
@@ -9132,8 +9136,8 @@ _CONSTEXPR20 _OutIt set_union(_InIt1 _First1, _InIt1 _Last1, _InIt2 _First2, _In
         }
     }
 
-    _UDest = _Copy_unchecked(_UFirst1, _ULast1, _UDest);
-    _Seek_wrapped(_Dest, _Copy_unchecked(_UFirst2, _ULast2, _UDest));
+    _UDest = _STD _Copy_unchecked(_UFirst1, _ULast1, _UDest);
+    _Seek_wrapped(_Dest, _STD _Copy_unchecked(_UFirst2, _ULast2, _UDest));
     return _Dest;
 }
 
@@ -9405,7 +9409,7 @@ _CONSTEXPR20 _OutIt set_difference(
         }
     }
 
-    _Seek_wrapped(_Dest, _Copy_unchecked(_UFirst1, _ULast1, _UDest));
+    _Seek_wrapped(_Dest, _STD _Copy_unchecked(_UFirst1, _ULast1, _UDest));
     return _Dest;
 }
 
@@ -9536,8 +9540,8 @@ _CONSTEXPR20 _OutIt set_symmetric_difference(
         }
     }
 
-    _UDest = _Copy_unchecked(_UFirst1, _ULast1, _UDest);
-    _Seek_wrapped(_Dest, _Copy_unchecked(_UFirst2, _ULast2, _UDest));
+    _UDest = _STD _Copy_unchecked(_UFirst1, _ULast1, _UDest);
+    _Seek_wrapped(_Dest, _STD _Copy_unchecked(_UFirst2, _ULast2, _UDest));
     return _Dest;
 }
 
@@ -9719,7 +9723,7 @@ _EXPORT_STD template <class _FwdIt, class _Pr>
 _NODISCARD constexpr pair<_FwdIt, _FwdIt> minmax_element(_FwdIt _First, _FwdIt _Last, _Pr _Pred) {
     // find smallest and largest elements
     _Adl_verify_range(_First, _Last);
-    const auto _Result = _Minmax_element_unchecked(_Get_unwrapped(_First), _Get_unwrapped(_Last), _Pass_fn(_Pred));
+    const auto _Result = _STD _Minmax_element_unchecked(_Get_unwrapped(_First), _Get_unwrapped(_Last), _Pass_fn(_Pred));
     _Seek_wrapped(_Last, _Result.second);
     _Seek_wrapped(_First, _Result.first);
     return {_First, _Last};
@@ -9866,7 +9870,7 @@ _NODISCARD constexpr pair<const _Ty&, const _Ty&> minmax(const _Ty& _Left, const
 _EXPORT_STD template <class _Ty, class _Pr>
 _NODISCARD constexpr pair<_Ty, _Ty> minmax(initializer_list<_Ty> _Ilist, _Pr _Pred) {
     // return {leftmost/smallest, rightmost/largest}
-    pair<const _Ty*, const _Ty*> _Res = _Minmax_element_unchecked(_Ilist.begin(), _Ilist.end(), _Pass_fn(_Pred));
+    pair<const _Ty*, const _Ty*> _Res = _STD _Minmax_element_unchecked(_Ilist.begin(), _Ilist.end(), _Pass_fn(_Pred));
     return pair<_Ty, _Ty>(*_Res.first, *_Res.second);
 }
 
@@ -10262,7 +10266,7 @@ namespace ranges {
         _NODISCARD constexpr bool operator()(_It _First, _Se _Last, _Pr _Pred = {}, _Pj _Proj = {}) const {
             _Adl_verify_range(_First, _Last);
             const auto _ULast  = _Unwrap_sent<_It>(_STD move(_Last));
-            const auto _UFirst = _Is_sorted_until_unchecked(
+            const auto _UFirst = _RANGES _Is_sorted_until_unchecked(
                 _Unwrap_iter<_Se>(_STD move(_First)), _ULast, _Pass_fn(_Pred), _Pass_fn(_Proj));
             return _UFirst == _ULast;
         }
@@ -10270,8 +10274,9 @@ namespace ranges {
         template <forward_range _Rng, class _Pj = identity,
             indirect_strict_weak_order<projected<iterator_t<_Rng>, _Pj>> _Pr = ranges::less>
         _NODISCARD constexpr bool operator()(_Rng&& _Range, _Pr _Pred = {}, _Pj _Proj = {}) const {
-            const auto _ULast  = _Uend(_Range);
-            const auto _UFirst = _Is_sorted_until_unchecked(_Ubegin(_Range), _ULast, _Pass_fn(_Pred), _Pass_fn(_Proj));
+            const auto _ULast = _Uend(_Range);
+            const auto _UFirst =
+                _RANGES _Is_sorted_until_unchecked(_Ubegin(_Range), _ULast, _Pass_fn(_Pred), _Pass_fn(_Proj));
             return _UFirst == _ULast;
         }
     };
@@ -10286,7 +10291,7 @@ namespace ranges {
             indirect_strict_weak_order<projected<_It, _Pj>> _Pr = ranges::less>
         _NODISCARD constexpr _It operator()(_It _First, _Se _Last, _Pr _Pred = {}, _Pj _Proj = {}) const {
             _Adl_verify_range(_First, _Last);
-            auto _UFirst = _Is_sorted_until_unchecked(_Unwrap_iter<_Se>(_STD move(_First)),
+            auto _UFirst = _RANGES _Is_sorted_until_unchecked(_Unwrap_iter<_Se>(_STD move(_First)),
                 _Unwrap_sent<_It>(_STD move(_Last)), _Pass_fn(_Pred), _Pass_fn(_Proj));
             _Seek_wrapped(_First, _STD move(_UFirst));
             return _First;
@@ -10296,7 +10301,7 @@ namespace ranges {
             indirect_strict_weak_order<projected<iterator_t<_Rng>, _Pj>> _Pr = ranges::less>
         _NODISCARD constexpr borrowed_iterator_t<_Rng> operator()(_Rng&& _Range, _Pr _Pred = {}, _Pj _Proj = {}) const {
             auto _First  = _RANGES begin(_Range);
-            auto _UFirst = _Is_sorted_until_unchecked(
+            auto _UFirst = _RANGES _Is_sorted_until_unchecked(
                 _Unwrap_range_iter<_Rng>(_First), _Uend(_Range), _Pass_fn(_Pred), _Pass_fn(_Proj));
             _Seek_wrapped(_First, _STD move(_UFirst));
             return _First;

--- a/stl/inc/execution
+++ b/stl/inc/execution
@@ -1348,7 +1348,7 @@ _NODISCARD _FwdIt find(_ExPo&& _Exec, _FwdIt _First, const _FwdIt _Last, const _
     _Adl_verify_range(_First, _Last);
     _Seek_wrapped(_First,
         _Find_parallel_unchecked(_STD forward<_ExPo>(_Exec), _Get_unwrapped(_First), _Get_unwrapped(_Last),
-            [&](const _UFwdIt _LFirst, const _UFwdIt _LLast) { return _Find_unchecked(_LFirst, _LLast, _Val); }));
+            [&](const _UFwdIt _LFirst, const _UFwdIt _LLast) { return _STD _Find_unchecked(_LFirst, _LLast, _Val); }));
     return _First;
 }
 
@@ -2564,7 +2564,7 @@ struct _Static_partitioned_remove_if2 {
             if (_Results == _Merge_first) { // entire range up to now had no removals, don't bother moving
                 _Results = _Merge_new_end;
             } else {
-                _Results = _Move_unchecked(_Merge_first, _Merge_new_end, _Results);
+                _Results = _STD _Move_unchecked(_Merge_first, _Merge_new_end, _Results);
             }
 
             _Merge_chunk_data._State.store(_Chunk_state::_Done);

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -927,11 +927,11 @@ public:
         // Returns the first occurrence of _Val as an encoded character (and not, for example, as a
         // continuation byte) in [_First, _Last).
         if constexpr (_Statically_Utf8) {
-            return _Find_unchecked(_First, _Last, _Val);
+            return _STD _Find_unchecked(_First, _Last, _Val);
         } else {
             if (this->_Cvt._Mbcurmax == 1 || this->_Cvt._Mbcurmax == 4) {
                 // As above and in _Mbrtowc, assume 4-byte encodings are UTF-8
-                return _Find_unchecked(_First, _Last, _Val);
+                return _STD _Find_unchecked(_First, _Last, _Val);
             }
 
             while (_First != _Last && *_First != _Val) {
@@ -977,7 +977,7 @@ class _Fmt_codec<wchar_t, _Statically_Utf8> {
 public:
     _NODISCARD constexpr const wchar_t* _Find_encoded(
         const wchar_t* const _First, const wchar_t* const _Last, const wchar_t _Val) const {
-        return _Find_unchecked(_First, _Last, _Val);
+        return _STD _Find_unchecked(_First, _Last, _Val);
     }
     _NODISCARD constexpr int _Units_in_next_character(
         const wchar_t* _First, const wchar_t* const _Last) const noexcept {

--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -190,7 +190,7 @@ _NoThrowFwdIt uninitialized_move(const _InIt _First, const _InIt _Last, _NoThrow
     const auto _UFirst = _Get_unwrapped(_First);
     const auto _ULast  = _Get_unwrapped(_Last);
     const auto _UDest  = _Get_unwrapped_n(_Dest, _Idl_distance<_InIt>(_UFirst, _ULast));
-    _Seek_wrapped(_Dest, _Uninitialized_move_unchecked(_UFirst, _ULast, _UDest));
+    _Seek_wrapped(_Dest, _STD _Uninitialized_move_unchecked(_UFirst, _ULast, _UDest));
     return _Dest;
 }
 

--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -2309,7 +2309,7 @@ _OutIt _Regex_replace1(_OutIt _Result, _BidIt _First, _BidIt _Last, const basic_
             _Flags |= regex_constants::match_prev_avail;
         }
     }
-    return _Flgs & regex_constants::format_no_copy ? _Result : _Copy_unchecked(_Pos, _Last, _Result);
+    return _Flgs & regex_constants::format_no_copy ? _Result : _STD _Copy_unchecked(_Pos, _Last, _Result);
 }
 
 _EXPORT_STD template <class _OutIt, class _BidIt, class _RxTraits, class _Elem, class _Traits, class _Alloc>

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -1248,7 +1248,7 @@ private:
                 _RERAISE;
                 _CATCH_END
 
-                _Move_unchecked(_Whereptr + 2 * _Count, _Mylast, _Whereptr + _Count);
+                _STD _Move_unchecked(_Whereptr + 2 * _Count, _Mylast, _Whereptr + _Count);
                 _Destroy_range(_Oldlast, _Mylast, _Al);
                 _Mylast = _Oldlast;
                 _RERAISE;
@@ -1789,7 +1789,7 @@ public:
 #endif // _ITERATOR_DEBUG_LEVEL == 2
 
         _Orphan_range(_Whereptr, _Mylast);
-        _Move_unchecked(_Whereptr + 1, _Mylast, _Whereptr);
+        _STD _Move_unchecked(_Whereptr + 1, _Mylast, _Whereptr);
         _Alty_traits::destroy(_Getal(), _Unfancy(_Mylast - 1));
         _ASAN_VECTOR_MODIFY(-1);
         --_Mylast;
@@ -1812,7 +1812,7 @@ public:
         if (_Firstptr != _Lastptr) { // something to do, invalidate iterators
             _Orphan_range(_Firstptr, _Mylast);
 
-            const pointer _Newlast = _Move_unchecked(_Lastptr, _Mylast, _Firstptr);
+            const pointer _Newlast = _STD _Move_unchecked(_Lastptr, _Mylast, _Firstptr);
             _Destroy_range(_Newlast, _Mylast, _Getal());
             _ASAN_VECTOR_MODIFY(static_cast<difference_type>(_Newlast - _Mylast)); // negative when destroying elements
             _Mylast = _Newlast;
@@ -2178,7 +2178,7 @@ private:
         const auto _Oldsize = static_cast<size_type>(_Mylast - _Myfirst);
         if (_Newsize > _Oldsize) {
             const pointer _Mid = _First + _Oldsize;
-            _Move_unchecked(_First, _Mid, _Myfirst);
+            _STD _Move_unchecked(_First, _Mid, _Myfirst);
 
             if constexpr (_Nothrow_construct) {
                 _ASAN_VECTOR_MODIFY(static_cast<difference_type>(_Newsize - _Oldsize));
@@ -2190,7 +2190,7 @@ private:
             }
         } else {
             const pointer _Newlast = _Myfirst + _Newsize;
-            _Move_unchecked(_First, _Last, _Myfirst);
+            _STD _Move_unchecked(_First, _Last, _Myfirst);
             _Destroy_range(_Newlast, _Mylast, _Al);
             _ASAN_VECTOR_MODIFY(static_cast<difference_type>(_Newsize - _Oldsize));
             _Mylast = _Newlast;
@@ -3405,13 +3405,13 @@ public:
             const auto _Length = static_cast<size_t>(_STD distance(_UFirst, _ULast));
             const auto _Count  = _Convert_size<size_type>(_Length);
             const auto _Off    = static_cast<difference_type>(_Insert_x(_Where, _Count));
-            _Copy_unchecked(_UFirst, _ULast, begin() + _Off);
+            _STD _Copy_unchecked(_UFirst, _ULast, begin() + _Off);
 #ifdef __cpp_lib_concepts
         } else if constexpr (forward_iterator<_Iter>) {
             const auto _Length = _To_unsigned_like(_RANGES distance(_UFirst, _ULast));
             const auto _Count  = _Convert_size<size_type>(_Length);
             const auto _Off    = static_cast<difference_type>(_Insert_x(_Where, _Count));
-            _Copy_unchecked(_UFirst, _ULast, begin() + _Off);
+            _STD _Copy_unchecked(_UFirst, _ULast, begin() + _Off);
 #endif // __cpp_lib_concepts
         } else {
             const auto _Old_size = this->_Mysize;

--- a/stl/inc/xlocnum
+++ b/stl/inc/xlocnum
@@ -69,10 +69,10 @@ inline float _Stofx_v2(const char* _Str, char** _Endptr, int _Pten, int* _Perr) 
 }
 
 template <class _Elem, size_t _Base_size>
-size_t _Find_elem(const _Elem (&_Base)[_Base_size],
-    const _Elem _Ch) { // lookup _Ch in array storing NUL-terminated string _Base
-                       // pre: _Base contains no nulls except for _Base[_Base_size - 1]
-    return static_cast<size_t>(_Find_unchecked(_Base, _Base + (_Base_size - 1), _Ch) - _Base);
+size_t _Find_elem(const _Elem (&_Base)[_Base_size], const _Elem _Ch) {
+    // lookup _Ch in array storing NUL-terminated string _Base
+    // pre: _Base contains no nulls except for _Base[_Base_size - 1]
+    return static_cast<size_t>(_STD _Find_unchecked(_Base, _Base + (_Base_size - 1), _Ch) - _Base);
 }
 
 inline wchar_t* _Maklocwcs(const wchar_t* _Ptr) { // copy NTWCS to allocated storage

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -2043,7 +2043,7 @@ _NODISCARD_REMOVE_ALG _CONSTEXPR20 _FwdIt remove(_FwdIt _First, const _FwdIt _La
     _Adl_verify_range(_First, _Last);
     auto _UFirst      = _Get_unwrapped(_First);
     const auto _ULast = _Get_unwrapped(_Last);
-    _UFirst           = _Find_unchecked(_UFirst, _ULast, _Val);
+    _UFirst           = _STD _Find_unchecked(_UFirst, _ULast, _Val);
     auto _UNext       = _UFirst;
     if (_UFirst != _ULast) {
         while (++_UFirst != _ULast) {

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -829,7 +829,7 @@ concept permutable = forward_iterator<_It> && indirectly_movable_storable<_It, _
 
 namespace ranges {
     _EXPORT_STD struct less;
-}
+} // namespace ranges
 
 _EXPORT_STD template <class _It1, class _It2, class _Out, class _Pr = ranges::less, class _Pj1 = identity,
     class _Pj2 = identity>
@@ -4478,7 +4478,7 @@ _CONSTEXPR20 _OutIt copy(_InIt _First, _InIt _Last, _OutIt _Dest) { // copy [_Fi
     const auto _UFirst = _Get_unwrapped(_First);
     const auto _ULast  = _Get_unwrapped(_Last);
     const auto _UDest  = _Get_unwrapped_n(_Dest, _Idl_distance<_InIt>(_UFirst, _ULast));
-    _Seek_wrapped(_Dest, _Copy_unchecked(_UFirst, _ULast, _UDest));
+    _Seek_wrapped(_Dest, _STD _Copy_unchecked(_UFirst, _ULast, _UDest));
     return _Dest;
 }
 
@@ -4766,7 +4766,7 @@ _CONSTEXPR20 _OutIt move(_InIt _First, _InIt _Last, _OutIt _Dest) {
     const auto _UFirst = _Get_unwrapped(_First);
     const auto _ULast  = _Get_unwrapped(_Last);
     const auto _UDest  = _Get_unwrapped_n(_Dest, _Idl_distance<_InIt>(_UFirst, _ULast));
-    _Seek_wrapped(_Dest, _Move_unchecked(_UFirst, _ULast, _UDest));
+    _Seek_wrapped(_Dest, _STD _Move_unchecked(_UFirst, _ULast, _UDest));
     return _Dest;
 }
 
@@ -5681,7 +5681,7 @@ _NODISCARD _CONSTEXPR20 _InIt find(_InIt _First, const _InIt _Last, const _Ty& _
     if constexpr (_Is_vb_iterator<_InIt> && is_same_v<_Ty, bool>) {
         return _Find_vbool(_First, _Last, _Val);
     } else {
-        _Seek_wrapped(_First, _Find_unchecked(_Get_unwrapped(_First), _Get_unwrapped(_Last), _Val));
+        _Seek_wrapped(_First, _STD _Find_unchecked(_Get_unwrapped(_First), _Get_unwrapped(_Last), _Val));
         return _First;
     }
 }
@@ -6505,7 +6505,7 @@ constexpr _FwdIt _Max_element_unchecked(_FwdIt _First, _FwdIt _Last, _Pr _Pred) 
 _EXPORT_STD template <class _FwdIt, class _Pr>
 _NODISCARD constexpr _FwdIt max_element(_FwdIt _First, _FwdIt _Last, _Pr _Pred) { // find largest element
     _Adl_verify_range(_First, _Last);
-    _Seek_wrapped(_First, _Max_element_unchecked(_Get_unwrapped(_First), _Get_unwrapped(_Last), _Pass_fn(_Pred)));
+    _Seek_wrapped(_First, _STD _Max_element_unchecked(_Get_unwrapped(_First), _Get_unwrapped(_Last), _Pass_fn(_Pred)));
     return _First;
 }
 
@@ -6598,7 +6598,7 @@ namespace ranges {
 _EXPORT_STD template <class _Ty, class _Pr>
 _NODISCARD constexpr _Ty(max)(initializer_list<_Ty> _Ilist, _Pr _Pred) {
     // return leftmost/largest
-    const _Ty* _Res = _Max_element_unchecked(_Ilist.begin(), _Ilist.end(), _Pass_fn(_Pred));
+    const _Ty* _Res = _STD _Max_element_unchecked(_Ilist.begin(), _Ilist.end(), _Pass_fn(_Pred));
     return *_Res;
 }
 
@@ -6700,7 +6700,7 @@ constexpr _FwdIt _Min_element_unchecked(_FwdIt _First, _FwdIt _Last, _Pr _Pred) 
 _EXPORT_STD template <class _FwdIt, class _Pr>
 _NODISCARD constexpr _FwdIt min_element(_FwdIt _First, _FwdIt _Last, _Pr _Pred) { // find smallest element
     _Adl_verify_range(_First, _Last);
-    _Seek_wrapped(_First, _Min_element_unchecked(_Get_unwrapped(_First), _Get_unwrapped(_Last), _Pass_fn(_Pred)));
+    _Seek_wrapped(_First, _STD _Min_element_unchecked(_Get_unwrapped(_First), _Get_unwrapped(_Last), _Pass_fn(_Pred)));
     return _First;
 }
 
@@ -6793,7 +6793,7 @@ namespace ranges {
 _EXPORT_STD template <class _Ty, class _Pr>
 _NODISCARD constexpr _Ty(min)(initializer_list<_Ty> _Ilist, _Pr _Pred) {
     // return leftmost/smallest
-    const _Ty* _Res = _Min_element_unchecked(_Ilist.begin(), _Ilist.end(), _Pass_fn(_Pred));
+    const _Ty* _Res = _STD _Min_element_unchecked(_Ilist.begin(), _Ilist.end(), _Pass_fn(_Pred));
     return *_Res;
 }
 

--- a/tests/std/tests/P0784R7_library_machinery/test.cpp
+++ b/tests/std/tests/P0784R7_library_machinery/test.cpp
@@ -58,7 +58,7 @@ constexpr bool test() {
         int_wrapper_copy input[]   = {1, 2, 3, 4};
         int_wrapper_copy output[4] = {5, 6, 7, 8};
 
-        const auto result = _Copy_unchecked(begin(input), end(input), begin(output));
+        const auto result = _STD _Copy_unchecked(begin(input), end(input), begin(output));
         static_assert(is_same_v<remove_const_t<decltype(result)>, int_wrapper_copy*>);
         assert(result == end(output));
         assert(equal(begin(expected_copy), end(expected_copy), begin(output), end(output)));
@@ -98,7 +98,7 @@ constexpr bool test() {
         int_wrapper_move input[]   = {1, 2, 3, 4};
         int_wrapper_move output[4] = {5, 6, 7, 8};
 
-        const auto result = _Move_unchecked(begin(input), end(input), begin(output));
+        const auto result = _STD _Move_unchecked(begin(input), end(input), begin(output));
         static_assert(is_same_v<remove_const_t<decltype(result)>, int_wrapper_move*>);
         assert(result == end(output));
         assert(equal(begin(expected_move), end(expected_move), begin(output), end(output)));


### PR DESCRIPTION
I've also consistently qualified calls to namespace-scope function templates ("things") defined in `_RANGES` that have both qualified and unqualified calls. I have _not_ qualified calls to things defined only in either `_STD` or `_RANGES` for which all existing calls are unqualified. (This isn't trying to be a "let's qualify all ugly calls" change, but only "let's make it clear that we're fixing #3203".)

Fixes #3203
