### PR TITLE
Implement LWG-3629 `make_error_code` and `make_error_condition` are customization points

### DIFF
--- a/stl/inc/future
+++ b/stl/inc/future
@@ -387,7 +387,7 @@ public:
     void _Abandon() { // abandon shared state
         unique_lock<mutex> _Lock(_Mtx);
         if (!_Already_has_stored_result()) { // queue exception
-            future_error _Fut(make_error_code(future_errc::broken_promise));
+            future_error _Fut(_STD make_error_code(future_errc::broken_promise));
             _Set_exception_raw(_STD make_exception_ptr(_Fut), &_Lock, false);
         }
     }
@@ -1180,7 +1180,7 @@ public:
     ~promise() noexcept {
         if (_MyPromise._Is_valid() && !_MyPromise._Is_ready() && !_MyPromise._Is_ready_at_thread_exit()) {
             // exception if destroyed before function object returns
-            future_error _Fut(make_error_code(future_errc::broken_promise));
+            future_error _Fut(_STD make_error_code(future_errc::broken_promise));
             _MyPromise._Get_state()._Set_exception(_STD make_exception_ptr(_Fut), false);
         }
     }
@@ -1242,7 +1242,7 @@ public:
     ~promise() noexcept {
         if (_MyPromise._Is_valid() && !_MyPromise._Is_ready() && !_MyPromise._Is_ready_at_thread_exit()) {
             // exception if destroyed before function object returns
-            future_error _Fut(make_error_code(future_errc::broken_promise));
+            future_error _Fut(_STD make_error_code(future_errc::broken_promise));
             _MyPromise._Get_state()._Set_exception(_STD make_exception_ptr(_Fut), false);
         }
     }
@@ -1296,7 +1296,7 @@ public:
     ~promise() noexcept {
         if (_MyPromise._Is_valid() && !_MyPromise._Is_ready() && !_MyPromise._Is_ready_at_thread_exit()) {
             // exception if destroyed before function object returns
-            future_error _Fut(make_error_code(future_errc::broken_promise));
+            future_error _Fut(_STD make_error_code(future_errc::broken_promise));
             _MyPromise._Get_state()._Set_exception(_STD make_exception_ptr(_Fut), false);
         }
     }

--- a/stl/inc/system_error
+++ b/stl/inc/system_error
@@ -170,7 +170,7 @@ public:
     template <class _Enum, enable_if_t<is_error_code_enum_v<_Enum>, int> = 0>
     error_code(_Enum _Errcode) noexcept : _Myval(0), _Mycat(nullptr) {
         using _Ensure_adl::make_error_code;
-        *this = make_error_code(_Errcode); // using ADL
+        *this = make_error_code(_Errcode); // intentional ADL
     }
 
     void assign(int _Val, const error_category& _Cat) noexcept {
@@ -181,7 +181,7 @@ public:
     template <class _Enum, enable_if_t<is_error_code_enum_v<_Enum>, int> = 0>
     error_code& operator=(_Enum _Errcode) noexcept {
         using _Ensure_adl::make_error_code;
-        *this = make_error_code(_Errcode); // using ADL
+        *this = make_error_code(_Errcode); // intentional ADL
         return *this;
     }
 
@@ -263,7 +263,7 @@ public:
     template <class _Enum, enable_if_t<is_error_condition_enum_v<_Enum>, int> = 0>
     error_condition(_Enum _Errcode) noexcept : _Myval(0), _Mycat(nullptr) {
         using _Ensure_adl::make_error_condition;
-        *this = make_error_condition(_Errcode); // using ADL
+        *this = make_error_condition(_Errcode); // intentional ADL
     }
 
     void assign(int _Val, const error_category& _Cat) noexcept {
@@ -274,7 +274,7 @@ public:
     template <class _Enum, enable_if_t<is_error_condition_enum_v<_Enum>, int> = 0>
     error_condition& operator=(_Enum _Errcode) noexcept {
         using _Ensure_adl::make_error_condition;
-        *this = make_error_condition(_Errcode); // using ADL
+        *this = make_error_condition(_Errcode); // intentional ADL
         return *this;
     }
 

--- a/stl/inc/system_error
+++ b/stl/inc/system_error
@@ -54,10 +54,11 @@ _INLINE_VAR constexpr bool is_error_condition_enum_v = is_error_condition_enum<_
 
 _EXPORT_STD class error_code;
 _EXPORT_STD class error_condition;
-_EXPORT_STD _NODISCARD error_code make_error_code(errc) noexcept;
-_EXPORT_STD _NODISCARD error_code make_error_code(io_errc) noexcept;
-_EXPORT_STD _NODISCARD error_condition make_error_condition(errc) noexcept;
-_EXPORT_STD _NODISCARD error_condition make_error_condition(io_errc) noexcept;
+
+namespace _Ensure_adl {
+    void make_error_code()      = delete;
+    void make_error_condition() = delete;
+} // namespace _Ensure_adl
 
 _EXPORT_STD class error_category;
 
@@ -168,6 +169,7 @@ public:
 
     template <class _Enum, enable_if_t<is_error_code_enum_v<_Enum>, int> = 0>
     error_code(_Enum _Errcode) noexcept : _Myval(0), _Mycat(nullptr) {
+        using _Ensure_adl::make_error_code;
         *this = make_error_code(_Errcode); // using ADL
     }
 
@@ -178,6 +180,7 @@ public:
 
     template <class _Enum, enable_if_t<is_error_code_enum_v<_Enum>, int> = 0>
     error_code& operator=(_Enum _Errcode) noexcept {
+        using _Ensure_adl::make_error_code;
         *this = make_error_code(_Errcode); // using ADL
         return *this;
     }
@@ -259,6 +262,7 @@ public:
 
     template <class _Enum, enable_if_t<is_error_condition_enum_v<_Enum>, int> = 0>
     error_condition(_Enum _Errcode) noexcept : _Myval(0), _Mycat(nullptr) {
+        using _Ensure_adl::make_error_condition;
         *this = make_error_condition(_Errcode); // using ADL
     }
 
@@ -269,6 +273,7 @@ public:
 
     template <class _Enum, enable_if_t<is_error_condition_enum_v<_Enum>, int> = 0>
     error_condition& operator=(_Enum _Errcode) noexcept {
+        using _Ensure_adl::make_error_condition;
         *this = make_error_condition(_Errcode); // using ADL
         return *this;
     }

--- a/stl/inc/valarray
+++ b/stl/inc/valarray
@@ -1166,7 +1166,7 @@ _NODISCARD valarray<_Ty> abs(const valarray<_Ty>& _Left) {
     const size_t _Size = _Left.size();
     valarray<_Ty> _Ans(_Size);
     for (size_t _Idx = 0; _Idx < _Size; ++_Idx) {
-        _Ans[_Idx] = abs(_Left[_Idx]); // using ADL, N4835 [valarray.transcend]/1
+        _Ans[_Idx] = abs(_Left[_Idx]); // intentional ADL, N4835 [valarray.transcend]/1
     }
     return _Ans;
 }
@@ -1176,7 +1176,7 @@ _NODISCARD valarray<_Ty> acos(const valarray<_Ty>& _Left) {
     const size_t _Size = _Left.size();
     valarray<_Ty> _Ans(_Size);
     for (size_t _Idx = 0; _Idx < _Size; ++_Idx) {
-        _Ans[_Idx] = acos(_Left[_Idx]); // using ADL, N4835 [valarray.transcend]/1
+        _Ans[_Idx] = acos(_Left[_Idx]); // intentional ADL, N4835 [valarray.transcend]/1
     }
     return _Ans;
 }
@@ -1186,7 +1186,7 @@ _NODISCARD valarray<_Ty> asin(const valarray<_Ty>& _Left) {
     const size_t _Size = _Left.size();
     valarray<_Ty> _Ans(_Size);
     for (size_t _Idx = 0; _Idx < _Size; ++_Idx) {
-        _Ans[_Idx] = asin(_Left[_Idx]); // using ADL, N4835 [valarray.transcend]/1
+        _Ans[_Idx] = asin(_Left[_Idx]); // intentional ADL, N4835 [valarray.transcend]/1
     }
     return _Ans;
 }
@@ -1196,7 +1196,7 @@ _NODISCARD valarray<_Ty> atan(const valarray<_Ty>& _Left) {
     const size_t _Size = _Left.size();
     valarray<_Ty> _Ans(_Size);
     for (size_t _Idx = 0; _Idx < _Size; ++_Idx) {
-        _Ans[_Idx] = atan(_Left[_Idx]); // using ADL, N4835 [valarray.transcend]/1
+        _Ans[_Idx] = atan(_Left[_Idx]); // intentional ADL, N4835 [valarray.transcend]/1
     }
     return _Ans;
 }
@@ -1206,7 +1206,7 @@ _NODISCARD valarray<_Ty> atan2(const valarray<_Ty>& _Left, const valarray<_Ty>& 
     const size_t _Size = _Left.size();
     valarray<_Ty> _Ans(_Size);
     for (size_t _Idx = 0; _Idx < _Size; ++_Idx) {
-        _Ans[_Idx] = atan2(_Left[_Idx], _Right[_Idx]); // using ADL, N4835 [valarray.transcend]/1
+        _Ans[_Idx] = atan2(_Left[_Idx], _Right[_Idx]); // intentional ADL, N4835 [valarray.transcend]/1
     }
     return _Ans;
 }
@@ -1216,7 +1216,7 @@ _NODISCARD valarray<_Ty> atan2(const valarray<_Ty>& _Left, const typename valarr
     const size_t _Size = _Left.size();
     valarray<_Ty> _Ans(_Size);
     for (size_t _Idx = 0; _Idx < _Size; ++_Idx) {
-        _Ans[_Idx] = atan2(_Left[_Idx], _Right); // using ADL, N4835 [valarray.transcend]/1
+        _Ans[_Idx] = atan2(_Left[_Idx], _Right); // intentional ADL, N4835 [valarray.transcend]/1
     }
     return _Ans;
 }
@@ -1226,7 +1226,7 @@ _NODISCARD valarray<_Ty> atan2(const typename valarray<_Ty>::value_type& _Left, 
     const size_t _Size = _Right.size();
     valarray<_Ty> _Ans(_Size);
     for (size_t _Idx = 0; _Idx < _Size; ++_Idx) {
-        _Ans[_Idx] = atan2(_Left, _Right[_Idx]); // using ADL, N4835 [valarray.transcend]/1
+        _Ans[_Idx] = atan2(_Left, _Right[_Idx]); // intentional ADL, N4835 [valarray.transcend]/1
     }
     return _Ans;
 }
@@ -1236,7 +1236,7 @@ _NODISCARD valarray<_Ty> cos(const valarray<_Ty>& _Left) {
     const size_t _Size = _Left.size();
     valarray<_Ty> _Ans(_Size);
     for (size_t _Idx = 0; _Idx < _Size; ++_Idx) {
-        _Ans[_Idx] = cos(_Left[_Idx]); // using ADL, N4835 [valarray.transcend]/1
+        _Ans[_Idx] = cos(_Left[_Idx]); // intentional ADL, N4835 [valarray.transcend]/1
     }
     return _Ans;
 }
@@ -1246,7 +1246,7 @@ _NODISCARD valarray<_Ty> cosh(const valarray<_Ty>& _Left) {
     const size_t _Size = _Left.size();
     valarray<_Ty> _Ans(_Size);
     for (size_t _Idx = 0; _Idx < _Size; ++_Idx) {
-        _Ans[_Idx] = cosh(_Left[_Idx]); // using ADL, N4835 [valarray.transcend]/1
+        _Ans[_Idx] = cosh(_Left[_Idx]); // intentional ADL, N4835 [valarray.transcend]/1
     }
     return _Ans;
 }
@@ -1256,7 +1256,7 @@ _NODISCARD valarray<_Ty> exp(const valarray<_Ty>& _Left) {
     const size_t _Size = _Left.size();
     valarray<_Ty> _Ans(_Size);
     for (size_t _Idx = 0; _Idx < _Size; ++_Idx) {
-        _Ans[_Idx] = exp(_Left[_Idx]); // using ADL, N4835 [valarray.transcend]/1
+        _Ans[_Idx] = exp(_Left[_Idx]); // intentional ADL, N4835 [valarray.transcend]/1
     }
     return _Ans;
 }
@@ -1266,7 +1266,7 @@ _NODISCARD valarray<_Ty> log(const valarray<_Ty>& _Left) {
     const size_t _Size = _Left.size();
     valarray<_Ty> _Ans(_Size);
     for (size_t _Idx = 0; _Idx < _Size; ++_Idx) {
-        _Ans[_Idx] = log(_Left[_Idx]); // using ADL, N4835 [valarray.transcend]/1
+        _Ans[_Idx] = log(_Left[_Idx]); // intentional ADL, N4835 [valarray.transcend]/1
     }
     return _Ans;
 }
@@ -1276,7 +1276,7 @@ _NODISCARD valarray<_Ty> log10(const valarray<_Ty>& _Left) {
     const size_t _Size = _Left.size();
     valarray<_Ty> _Ans(_Size);
     for (size_t _Idx = 0; _Idx < _Size; ++_Idx) {
-        _Ans[_Idx] = log10(_Left[_Idx]); // using ADL, N4835 [valarray.transcend]/1
+        _Ans[_Idx] = log10(_Left[_Idx]); // intentional ADL, N4835 [valarray.transcend]/1
     }
     return _Ans;
 }
@@ -1286,7 +1286,7 @@ _NODISCARD valarray<_Ty> pow(const valarray<_Ty>& _Left, const valarray<_Ty>& _R
     const size_t _Size = _Left.size();
     valarray<_Ty> _Ans(_Size);
     for (size_t _Idx = 0; _Idx < _Size; ++_Idx) {
-        _Ans[_Idx] = pow(_Left[_Idx], _Right[_Idx]); // using ADL, N4835 [valarray.transcend]/1
+        _Ans[_Idx] = pow(_Left[_Idx], _Right[_Idx]); // intentional ADL, N4835 [valarray.transcend]/1
     }
     return _Ans;
 }
@@ -1296,7 +1296,7 @@ _NODISCARD valarray<_Ty> pow(const valarray<_Ty>& _Left, const typename valarray
     const size_t _Size = _Left.size();
     valarray<_Ty> _Ans(_Size);
     for (size_t _Idx = 0; _Idx < _Size; ++_Idx) {
-        _Ans[_Idx] = pow(_Left[_Idx], _Right); // using ADL, N4835 [valarray.transcend]/1
+        _Ans[_Idx] = pow(_Left[_Idx], _Right); // intentional ADL, N4835 [valarray.transcend]/1
     }
     return _Ans;
 }
@@ -1306,7 +1306,7 @@ _NODISCARD valarray<_Ty> pow(const typename valarray<_Ty>::value_type& _Left, co
     const size_t _Size = _Right.size();
     valarray<_Ty> _Ans(_Size);
     for (size_t _Idx = 0; _Idx < _Size; ++_Idx) {
-        _Ans[_Idx] = pow(_Left, _Right[_Idx]); // using ADL, N4835 [valarray.transcend]/1
+        _Ans[_Idx] = pow(_Left, _Right[_Idx]); // intentional ADL, N4835 [valarray.transcend]/1
     }
     return _Ans;
 }
@@ -1316,7 +1316,7 @@ _NODISCARD valarray<_Ty> sin(const valarray<_Ty>& _Left) {
     const size_t _Size = _Left.size();
     valarray<_Ty> _Ans(_Size);
     for (size_t _Idx = 0; _Idx < _Size; ++_Idx) {
-        _Ans[_Idx] = sin(_Left[_Idx]); // using ADL, N4835 [valarray.transcend]/1
+        _Ans[_Idx] = sin(_Left[_Idx]); // intentional ADL, N4835 [valarray.transcend]/1
     }
     return _Ans;
 }
@@ -1326,7 +1326,7 @@ _NODISCARD valarray<_Ty> sinh(const valarray<_Ty>& _Left) {
     const size_t _Size = _Left.size();
     valarray<_Ty> _Ans(_Size);
     for (size_t _Idx = 0; _Idx < _Size; ++_Idx) {
-        _Ans[_Idx] = sinh(_Left[_Idx]); // using ADL, N4835 [valarray.transcend]/1
+        _Ans[_Idx] = sinh(_Left[_Idx]); // intentional ADL, N4835 [valarray.transcend]/1
     }
     return _Ans;
 }
@@ -1336,7 +1336,7 @@ _NODISCARD valarray<_Ty> sqrt(const valarray<_Ty>& _Left) {
     const size_t _Size = _Left.size();
     valarray<_Ty> _Ans(_Size);
     for (size_t _Idx = 0; _Idx < _Size; ++_Idx) {
-        _Ans[_Idx] = sqrt(_Left[_Idx]); // using ADL, N4835 [valarray.transcend]/1
+        _Ans[_Idx] = sqrt(_Left[_Idx]); // intentional ADL, N4835 [valarray.transcend]/1
     }
     return _Ans;
 }
@@ -1346,7 +1346,7 @@ _NODISCARD valarray<_Ty> tan(const valarray<_Ty>& _Left) {
     const size_t _Size = _Left.size();
     valarray<_Ty> _Ans(_Size);
     for (size_t _Idx = 0; _Idx < _Size; ++_Idx) {
-        _Ans[_Idx] = tan(_Left[_Idx]); // using ADL, N4835 [valarray.transcend]/1
+        _Ans[_Idx] = tan(_Left[_Idx]); // intentional ADL, N4835 [valarray.transcend]/1
     }
     return _Ans;
 }
@@ -1356,7 +1356,7 @@ _NODISCARD valarray<_Ty> tanh(const valarray<_Ty>& _Left) {
     const size_t _Size = _Left.size();
     valarray<_Ty> _Ans(_Size);
     for (size_t _Idx = 0; _Idx < _Size; ++_Idx) {
-        _Ans[_Idx] = tanh(_Left[_Idx]); // using ADL, N4835 [valarray.transcend]/1
+        _Ans[_Idx] = tanh(_Left[_Idx]); // intentional ADL, N4835 [valarray.transcend]/1
     }
     return _Ans;
 }

--- a/stl/inc/xiosbase
+++ b/stl/inc/xiosbase
@@ -198,10 +198,10 @@ public:
 
     class failure : public system_error { // base of all iostreams exceptions
     public:
-        explicit failure(const string& _Message, const error_code& _Errcode = make_error_code(io_errc::stream))
+        explicit failure(const string& _Message, const error_code& _Errcode = _STD make_error_code(io_errc::stream))
             : system_error(_Errcode, _Message) {} // construct with message
 
-        explicit failure(const char* _Message, const error_code& _Errcode = make_error_code(io_errc::stream))
+        explicit failure(const char* _Message, const error_code& _Errcode = _STD make_error_code(io_errc::stream))
             : system_error(_Errcode, _Message) {} // construct with message
 
 #if !_HAS_EXCEPTIONS

--- a/tests/std/tests/Dev11_0493504_error_category_lifetime/test.cpp
+++ b/tests/std/tests/Dev11_0493504_error_category_lifetime/test.cpp
@@ -90,13 +90,13 @@ namespace test_ns {
         }
     };
 
-    struct converted_errc : enable_if<false> {
+    struct converted_errc : enable_if<false> { // std is an associated namespace of this type
         operator errc() const {
             return errc{};
         }
     };
 
-    struct converted_io_errc : enable_if<false> {
+    struct converted_io_errc : enable_if<false> { // std is an associated namespace of this type
         operator io_errc() const {
             return io_errc{};
         }

--- a/tests/std/tests/Dev11_0493504_error_category_lifetime/test.cpp
+++ b/tests/std/tests/Dev11_0493504_error_category_lifetime/test.cpp
@@ -4,11 +4,11 @@
 // Intentially declare variables of these names before the inclusion of standard headers. See LWG-3629.
 struct InvalidFunctor {
     template <class T>
-    void operator()(T&&) = delete;
+    void operator()(T&&) const = delete;
 };
 
-constexpr InvalidFunctor make_error_code{};
-constexpr InvalidFunctor make_error_condition{};
+InvalidFunctor make_error_code{};
+InvalidFunctor make_error_condition{};
 
 #include <cassert>
 #include <cctype>
@@ -50,6 +50,9 @@ void test_lwg_3598() {
 
 // Also test GH-2572: WAIT_TIMEOUT is not matched against by std::errc::timed_out
 void test_gh_2572() {
+    using std::make_error_code;
+    using std::make_error_condition;
+
     assert((errc::timed_out == error_code{WAIT_TIMEOUT, system_category()}));
     assert((make_error_condition(errc::timed_out) == error_code{WAIT_TIMEOUT, system_category()}));
 
@@ -62,6 +65,9 @@ void test_gh_2572() {
 
 // Also test GH-2893 <system_error>: Several Windows system errors are not mapped
 void test_gh_2893() {
+    using std::make_error_code;
+    using std::make_error_condition;
+
     assert((errc::filename_too_long == error_code{ERROR_FILENAME_EXCED_RANGE, system_category()}));
     assert(
         (make_error_condition(errc::filename_too_long) == error_code{ERROR_FILENAME_EXCED_RANGE, system_category()}));
@@ -74,61 +80,64 @@ void test_gh_2893() {
 // Also test LWG-3629 make_error_code and make_error_condition are customization points
 namespace test_ns {
     struct friendly_error {
-        friend std::error_code make_error_code(friendly_error) {
-            return std::error_code{};
+        friend error_code make_error_code(friendly_error) {
+            return error_code{};
         }
 
-        friend std::error_condition make_error_condition(friendly_error) {
-            return std::error_condition{};
-        }
-    };
-
-    struct converted_errc : std::enable_if<false> {
-        operator std::errc() const {
-            return std::errc{};
+        friend error_condition make_error_condition(friendly_error) {
+            return error_condition{};
         }
     };
 
-    struct converted_io_errc : std::enable_if<false> {
-        operator std::io_errc() const {
-            return std::io_errc{};
+    struct converted_errc : enable_if<false> {
+        operator errc() const {
+            return errc{};
+        }
+    };
+
+    struct converted_io_errc : enable_if<false> {
+        operator io_errc() const {
+            return io_errc{};
         }
     };
 } // namespace test_ns
 
 template <>
-struct std::is_error_code_enum<test_ns::friendly_error> : std::true_type {};
+struct is_error_code_enum<test_ns::friendly_error> : true_type {};
 
 template <>
-struct std::is_error_code_enum<test_ns::converted_io_errc> : std::true_type {};
+struct is_error_code_enum<test_ns::converted_io_errc> : true_type {};
 
 template <>
-struct std::is_error_condition_enum<test_ns::friendly_error> : std::true_type {};
+struct is_error_condition_enum<test_ns::friendly_error> : true_type {};
 
 template <>
-struct std::is_error_condition_enum<test_ns::converted_errc> : std::true_type {};
+struct is_error_condition_enum<test_ns::converted_errc> : true_type {};
 
 void test_lwg_3629() {
 #ifndef _M_CEE_PURE
-    std::error_code err_future{std::future_errc{}};
+    error_code err_future{future_errc{}};
     (void) err_future;
 #endif // _M_CEE_PURE
-    std::error_code err_io{std::io_errc{}};
+    error_code err_io{io_errc{}};
     (void) err_io;
-    std::error_condition errcond{std::errc{}};
+    error_condition errcond{errc{}};
     (void) errcond;
 
-    std::error_code ec_friendly{test_ns::friendly_error{}};
+    error_code ec_friendly{test_ns::friendly_error{}};
     (void) ec_friendly;
-    std::error_code ec_converted_io{test_ns::converted_io_errc{}};
+    error_code ec_converted_io{test_ns::converted_io_errc{}};
     (void) ec_converted_io;
-    std::error_condition econd_friendly{test_ns::friendly_error{}};
+    error_condition econd_friendly{test_ns::friendly_error{}};
     (void) econd_friendly;
-    std::error_condition econd_converted{test_ns::converted_errc{}};
+    error_condition econd_converted{test_ns::converted_errc{}};
     (void) econd_converted;
 }
 
 int main() {
+    using std::make_error_code;
+    using std::make_error_condition;
+
     // Also test DevDiv-781294 "<system_error>: Visual C++ 2013 RC system_category().equivalent function does not work".
     const error_code code(ERROR_NOT_ENOUGH_MEMORY, system_category());
 

--- a/tests/std/tests/Dev11_0493504_error_category_lifetime/test.cpp
+++ b/tests/std/tests/Dev11_0493504_error_category_lifetime/test.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// Intentially declare variables of these names before the inclusion of standard headers. See LWG-3629.
+// Intentionally declare variables of these names before the inclusion of standard headers. See LWG-3629.
 struct InvalidFunctor {
     template <class T>
     void operator()(T&&) const = delete;
@@ -14,6 +14,7 @@ InvalidFunctor make_error_condition{};
 #include <cctype>
 #include <ios>
 #include <system_error>
+#include <type_traits>
 
 #ifndef _M_CEE_PURE
 #include <future>


### PR DESCRIPTION
Fixes #3216.

Also adding `_STD`-qualifications to calls in `<future>` and `<xiosbase>`, because these calls always find overloads declared in `std::` and it is unnecessary to enable ADL for them.

Some previously accepted codes will be rejected after these changes. Unfortunately, I don't know how to examine such cases in tests, because only hard errors would occur.