### PR TITLE
Implement LWG-3594 `inout_ptr` - inconsistent `release()` in destructor

### DIFF
--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -4190,21 +4190,23 @@ public:
     inout_ptr_t(const inout_ptr_t&) = delete;
 
     ~inout_ptr_t() {
+        using _Sp = _Pointer_of_or<_SmartPtr, _Pointer>;
+        if constexpr (!is_pointer_v<_SmartPtr>) {
+            _Smart_ptr.release();
+        }
+
         if (!_Get_ptr()) {
             return;
         }
 
         _STD apply(
             [this](auto&&... _Args_) {
-                using _Sp = _Pointer_of_or<_SmartPtr, _Pointer>;
                 if constexpr (is_pointer_v<_SmartPtr>) {
                     _Smart_ptr = _SmartPtr(static_cast<_Sp>(_Get_ptr()), _STD forward<_ArgsT>(_Args_)...);
                 } else if constexpr (_Resettable_pointer<_SmartPtr, _Sp, _Pointer, _ArgsT...>) {
-                    _Smart_ptr.release();
                     _Smart_ptr.reset(static_cast<_Sp>(_Get_ptr()), _STD forward<_ArgsT>(_Args_)...);
                 } else {
                     static_assert(is_constructible_v<_SmartPtr, _Sp, _ArgsT...>, "(N4892 [inout.ptr.t]/11.4)");
-                    _Smart_ptr.release();
                     _Smart_ptr = _SmartPtr(static_cast<_Sp>(_Get_ptr()), _STD forward<_ArgsT>(_Args_)...);
                 }
             },

--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -4190,7 +4190,6 @@ public:
     inout_ptr_t(const inout_ptr_t&) = delete;
 
     ~inout_ptr_t() {
-        using _Sp = _Pointer_of_or<_SmartPtr, _Pointer>;
         if constexpr (!is_pointer_v<_SmartPtr>) {
             _Smart_ptr.release();
         }
@@ -4201,6 +4200,7 @@ public:
 
         _STD apply(
             [this](auto&&... _Args_) {
+                using _Sp = _Pointer_of_or<_SmartPtr, _Pointer>;
                 if constexpr (is_pointer_v<_SmartPtr>) {
                     _Smart_ptr = _SmartPtr(static_cast<_Sp>(_Get_ptr()), _STD forward<_ArgsT>(_Args_)...);
                 } else if constexpr (_Resettable_pointer<_SmartPtr, _Sp, _Pointer, _ArgsT...>) {

--- a/tests/std/tests/P1132R7_out_ptr/test.cpp
+++ b/tests/std/tests/P1132R7_out_ptr/test.cpp
@@ -118,6 +118,18 @@ void test_smart_ptr(Args&&... args) {
 
         assert(*int_ptr == 19);
     }
+
+    // LWG_3594
+    {
+        const auto f = [](int** ptr) {
+            delete *ptr;
+            *ptr = nullptr;
+        };
+
+        f(inout_ptr<int*>(int_ptr, forward<Args>(args)...));
+
+        assert(int_ptr.get() == nullptr);
+    }
 }
 
 struct reset_tag {};

--- a/tests/std/tests/P1132R7_out_ptr/test.cpp
+++ b/tests/std/tests/P1132R7_out_ptr/test.cpp
@@ -119,7 +119,7 @@ void test_smart_ptr(Args&&... args) {
         assert(*int_ptr == 19);
     }
 
-    // LWG_3594
+    // LWG-3594 inout_ptr - inconsistent release() in destructor
     {
         const auto f = [](int** ptr) {
             delete *ptr;


### PR DESCRIPTION
Fixes #3218