### PR TITLE
Add checks for invalid iterator when _ITERATOR_DEBUG_LEVEL is non-zero

### DIFF
--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -269,6 +269,7 @@ public:
 #if _ITERATOR_DEBUG_LEVEL != 0
         const auto _Mycont = static_cast<const _Myvec*>(this->_Getcont());
         _STL_VERIFY(this->_Ptr, "can't dereference value-initialized vector iterator");
+        _STL_VERIFY(_Mycont, "can't dereference invalidated vector iterator");
         _STL_VERIFY(_Mycont->_Myfirst <= this->_Ptr && this->_Ptr < _Mycont->_Mylast,
             "can't dereference out of range vector iterator");
 #endif // _ITERATOR_DEBUG_LEVEL != 0

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -46,6 +46,7 @@ public:
 #if _ITERATOR_DEBUG_LEVEL != 0
         const auto _Mycont = static_cast<const _Myvec*>(this->_Getcont());
         _STL_VERIFY(_Ptr, "can't dereference value-initialized vector iterator");
+        _STL_VERIFY(_Mycont, "can't dereference invalidated vector iterator");
         _STL_VERIFY(
             _Mycont->_Myfirst <= _Ptr && _Ptr < _Mycont->_Mylast, "can't dereference out of range vector iterator");
 #endif // _ITERATOR_DEBUG_LEVEL != 0
@@ -57,6 +58,7 @@ public:
 #if _ITERATOR_DEBUG_LEVEL != 0
         const auto _Mycont = static_cast<const _Myvec*>(this->_Getcont());
         _STL_VERIFY(_Ptr, "can't dereference value-initialized vector iterator");
+        _STL_VERIFY(_Mycont, "can't dereference invalidated vector iterator");
         _STL_VERIFY(
             _Mycont->_Myfirst <= _Ptr && _Ptr < _Mycont->_Mylast, "can't dereference out of range vector iterator");
 #endif // _ITERATOR_DEBUG_LEVEL != 0
@@ -68,6 +70,7 @@ public:
 #if _ITERATOR_DEBUG_LEVEL != 0
         const auto _Mycont = static_cast<const _Myvec*>(this->_Getcont());
         _STL_VERIFY(_Ptr, "can't increment value-initialized vector iterator");
+        _STL_VERIFY(_Mycont, "can't increment invalidated vector iterator");
         _STL_VERIFY(_Ptr < _Mycont->_Mylast, "can't increment vector iterator past end");
 #endif // _ITERATOR_DEBUG_LEVEL != 0
 
@@ -85,6 +88,7 @@ public:
 #if _ITERATOR_DEBUG_LEVEL != 0
         const auto _Mycont = static_cast<const _Myvec*>(this->_Getcont());
         _STL_VERIFY(_Ptr, "can't decrement value-initialized vector iterator");
+        _STL_VERIFY(_Mycont, "can't decrement invalidated vector iterator");
         _STL_VERIFY(_Mycont->_Myfirst < _Ptr, "can't decrement vector iterator before begin");
 #endif // _ITERATOR_DEBUG_LEVEL != 0
 


### PR DESCRIPTION
fixes #3281 