### PR TITLE
Don't use `<intrin0.h>` with Clang

### DIFF
--- a/stl/inc/__msvc_int128.hpp
+++ b/stl/inc/__msvc_int128.hpp
@@ -10,7 +10,7 @@
 #include <yvals_core.h>
 #if _STL_COMPILER_PREPROCESSOR
 #include <cstdint>
-#include <intrin.h> // TRANSITION, GH-2520
+#include _STL_INTRIN_HEADER
 #include <limits>
 #include <type_traits>
 

--- a/stl/inc/bit
+++ b/stl/inc/bit
@@ -12,7 +12,7 @@
 _EMIT_STL_WARNING(STL4038, "The contents of <bit> are available only with C++20 or later.");
 #else // ^^^ !_HAS_CXX20 / _HAS_CXX20 vvv
 
-#include <intrin0.h>
+#include _STL_INTRIN_HEADER
 #include <isa_availability.h>
 #include <limits>
 #include <type_traits>

--- a/stl/inc/charconv
+++ b/stl/inc/charconv
@@ -13,7 +13,7 @@
 _EMIT_STL_WARNING(STL4038, "The contents of <charconv> are available only with C++17 or later.");
 #else // ^^^ !_HAS_CXX17 / _HAS_CXX17 vvv
 #include <cstring>
-#include <intrin0.h>
+#include _STL_INTRIN_HEADER
 #include <xbit_ops.h>
 #include <xcharconv.h>
 #include <xcharconv_ryu.h>

--- a/stl/inc/cmath
+++ b/stl/inc/cmath
@@ -20,7 +20,7 @@
 #endif // ^^^ intrinsics unavailable ^^^
 
 #if _HAS_CMATH_INTRINSICS
-#include <intrin0.h>
+#include _STL_INTRIN_HEADER
 #endif // _HAS_CMATH_INTRINSICS
 
 #if _HAS_CXX20

--- a/stl/inc/limits
+++ b/stl/inc/limits
@@ -11,7 +11,7 @@
 #include <cfloat>
 #include <climits>
 #include <cwchar>
-#include <intrin0.h>
+#include _STL_INTRIN_HEADER
 #include <isa_availability.h>
 #include <xstddef>
 

--- a/stl/inc/xatomic.h
+++ b/stl/inc/xatomic.h
@@ -9,7 +9,7 @@
 #include <yvals_core.h>
 #if _STL_COMPILER_PREPROCESSOR
 
-#include <intrin0.h>
+#include _STL_INTRIN_HEADER
 #include <type_traits>
 
 #pragma pack(push, _CRT_PACKING)

--- a/stl/inc/xbit_ops.h
+++ b/stl/inc/xbit_ops.h
@@ -10,7 +10,7 @@
 #if _STL_COMPILER_PREPROCESSOR
 
 #include <cstdint>
-#include <intrin0.h>
+#include _STL_INTRIN_HEADER
 
 #pragma pack(push, _CRT_PACKING)
 #pragma warning(push, _STL_WARNING_LEVEL)

--- a/stl/inc/xcharconv_ryu.h
+++ b/stl/inc/xcharconv_ryu.h
@@ -52,7 +52,7 @@
 #endif // ^^^ intrinsics unavailable ^^^
 
 #if _HAS_CHARCONV_INTRINSICS
-#include <intrin0.h> // for _umul128() and __shiftright128()
+#include _STL_INTRIN_HEADER // for _umul128() and __shiftright128()
 #endif // ^^^ intrinsics available ^^^
 
 #if !_HAS_CXX17

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -1833,9 +1833,11 @@ compiler option, or define _ALLOW_RTCc_IN_STL to suppress this error.
 #endif // __cpp_noexcept_function_type
 
 #ifdef __clang__
-#define _STL_UNREACHABLE __builtin_unreachable()
+#define _STL_INTRIN_HEADER <intrin.h>
+#define _STL_UNREACHABLE   __builtin_unreachable()
 #else // ^^^ clang / other vvv
-#define _STL_UNREACHABLE __assume(false)
+#define _STL_INTRIN_HEADER <intrin0.h>
+#define _STL_UNREACHABLE   __assume(false)
 #endif // __clang__
 
 #ifdef _ENABLE_STL_INTERNAL_CHECK

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -15,7 +15,7 @@
 #include <cstdint>
 #include <emmintrin.h>
 #include <immintrin.h>
-#include <intrin0.h>
+#include <intrin.h>
 #include <isa_availability.h>
 
 extern "C" long __isa_enabled;

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -13,8 +13,6 @@
 #if (defined(_M_IX86) || defined(_M_X64)) && !defined(_M_ARM64EC)
 
 #include <cstdint>
-#include <emmintrin.h>
-#include <immintrin.h>
 #include <intrin.h>
 #include <isa_availability.h>
 

--- a/tests/std/tests/Dev11_1086953_call_once_overhaul/test.cpp
+++ b/tests/std/tests/Dev11_1086953_call_once_overhaul/test.cpp
@@ -7,7 +7,7 @@
 #include <cstdlib>
 #include <exception>
 #include <functional>
-#include <intrin0.h>
+#include <intrin.h>
 #include <mutex>
 #include <stdexcept>
 #include <string>


### PR DESCRIPTION
Addresses the problem mentioned in https://github.com/microsoft/STL/issues/2520#issuecomment-1345822701. We've had several issues with Clang and `intrin0.h` in the past, hopefully we can fix them "forever" by avoiding `intrin0.h` when compiling with Clang.

The existence of `intrin0.h` is purely an optimization in that it allows us to avoid including the entirety of `intrin.h`. We could support this optimization with Clang in the future by adding an `intrin0.h` to Clang's set of override headers. If we were to do so we should synchronize with libc++ on the proper set of intrinsics to move into `intrin0.h`.