### PR TITLE
Toolset update: VS 2022 17.5 Preview 2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.24)
+cmake_minimum_required(VERSION 3.25)
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 project(msvc_standard_libraries LANGUAGES CXX)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 cmake_minimum_required(VERSION 3.25)
+
+# TRANSITION, CMake-24249
+cmake_policy(SET CMP0141 OLD)
+
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 project(msvc_standard_libraries LANGUAGES CXX)
 

--- a/README.md
+++ b/README.md
@@ -141,11 +141,11 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With The Visual Studio IDE
 
-1. Install Visual Studio 2022 17.5 Preview 1 or later.
+1. Install Visual Studio 2022 17.5 Preview 2 or later.
     * Select "Windows 11 SDK (10.0.22000.0)" in the VS Installer.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
-    * Otherwise, install [CMake][] 3.24 or later, and [Ninja][] 1.11.0 or later.
+    * Otherwise, install [CMake][] 3.25 or later, and [Ninja][] 1.11.0 or later.
     * We recommend selecting "Python 3 64-bit" in the VS Installer.
     * Otherwise, make sure [Python][] 3.9 or later is available to CMake.
 2. Open Visual Studio, and choose the "Clone or check out code" option. Enter the URL of this repository,
@@ -157,11 +157,11 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With A Native Tools Command Prompt
 
-1. Install Visual Studio 2022 17.5 Preview 1 or later.
+1. Install Visual Studio 2022 17.5 Preview 2 or later.
     * Select "Windows 11 SDK (10.0.22000.0)" in the VS Installer.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
-    * Otherwise, install [CMake][] 3.24 or later, and [Ninja][] 1.11.0 or later.
+    * Otherwise, install [CMake][] 3.25 or later, and [Ninja][] 1.11.0 or later.
     * We recommend selecting "Python 3 64-bit" in the VS Installer.
     * Otherwise, make sure [Python][] 3.9 or later is available to CMake.
 2. Open a command prompt.

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -91,7 +91,7 @@ if ([string]::IsNullOrEmpty($AdminUserPassword)) {
   $PsExecPath = Join-Path $ExtractedPsToolsPath 'PsExec64.exe'
 
   # https://github.com/PowerShell/PowerShell/releases/latest
-  $PowerShellZipUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.3.0/PowerShell-7.3.0-win-x64.zip'
+  $PowerShellZipUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.3.1/PowerShell-7.3.1-win-x64.zip'
   Write-Host "Downloading: $PowerShellZipUrl"
   $ExtractedPowerShellPath = DownloadAndExtractZip -Url $PowerShellZipUrl
   $PwshPath = Join-Path $ExtractedPowerShellPath 'pwsh.exe'
@@ -141,7 +141,7 @@ $Workloads = @(
 $ReleaseInPath = 'Preview'
 $Sku = 'Enterprise'
 $VisualStudioBootstrapperUrl = 'https://aka.ms/vs/17/pre/vs_enterprise.exe'
-$PythonUrl = 'https://www.python.org/ftp/python/3.11.0/python-3.11.0-amd64.exe'
+$PythonUrl = 'https://www.python.org/ftp/python/3.11.1/python-3.11.1-amd64.exe'
 
 $CudaUrl = 'https://developer.download.nvidia.com/compute/cuda/11.6.0/local_installers/cuda_11.6.0_511.23_windows.exe'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ variables:
   benchmarkBuildOutputLocation: 'D:\benchmark'
 
 pool:
-  name: 'StlBuild-2022-11-08T1904-Pool'
+  name: 'StlBuild-2022-12-13T1747-Pool'
   demands: EnableSpotVM -equals true
 
 pr:

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.24)
+cmake_minimum_required(VERSION 3.25)
 project(msvc_standard_libraries_benchmarks LANGUAGES CXX)
 
 if(DEFINED STL_BINARY_DIR)

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -376,24 +376,7 @@ public:
         _In_reads_(_Count) const _Elem* const _First2, const size_t _Count) noexcept /* strengthened */ {
         // compare [_First1, _First1 + _Count) with [_First2, ...)
 #if _HAS_CXX17
-#if _HAS_CXX20 && defined(__EDG__) // TRANSITION, VSO-1675318
-        if (_STD is_constant_evaluated()) {
-            for (size_t _Idx = 0; _Idx != _Count; ++_Idx) {
-                if (static_cast<unsigned char>(_First1[_Idx]) < static_cast<unsigned char>(_First2[_Idx])) {
-                    return -1;
-                }
-
-                if (static_cast<unsigned char>(_First2[_Idx]) < static_cast<unsigned char>(_First1[_Idx])) {
-                    return 1;
-                }
-            }
-            return 0;
-        } else {
-            return _CSTD memcmp(_First1, _First2, _Count);
-        }
-#else // ^^^ workaround for EDG / no workaround needed for MSVC and Clang vvv
         return __builtin_memcmp(_First1, _First2, _Count);
-#endif // ^^^ no workaround needed for MSVC and Clang ^^^
 #else // _HAS_CXX17
         return _CSTD memcmp(_First1, _First2, _Count);
 #endif // _HAS_CXX17

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -810,8 +810,8 @@ _EMIT_STL_ERROR(STL1002, "Unexpected compiler version, expected CUDA 11.6 or new
 _EMIT_STL_ERROR(STL1000, "Unexpected compiler version, expected Clang 15.0.0 or newer.");
 #endif // ^^^ old Clang ^^^
 #elif defined(_MSC_VER)
-#if _MSC_VER < 1934 // Coarse-grained, not inspecting _MSC_FULL_VER
-_EMIT_STL_ERROR(STL1001, "Unexpected compiler version, expected MSVC 19.34 or newer.");
+#if _MSC_VER < 1935 // Coarse-grained, not inspecting _MSC_FULL_VER
+_EMIT_STL_ERROR(STL1001, "Unexpected compiler version, expected MSVC 19.35 or newer.");
 #endif // ^^^ old MSVC ^^^
 #else // vvv other compilers vvv
 // not attempting to detect other compilers

--- a/tests/std/tests/P2321R2_views_zip/test.cpp
+++ b/tests/std/tests/P2321R2_views_zip/test.cpp
@@ -301,21 +301,6 @@ constexpr bool test_one(TestContainerType& test_container, RangeTypes&&... range
         const auto const_tuple_element_arr = as_const(test_container).get_element_tuple_arr();
 
         // Validate zip_view::size()
-#if defined(_MSVC_INTERNAL_TESTING) && !defined(__clang__) && !defined(__EDG__) // TRANSITION, VSO-1655459
-        STATIC_ASSERT(CanMemberSize<ZipType> == (ranges::sized_range<AllView<RangeTypes>> && ...));
-        if constexpr (CanMemberSize<ZipType>) {
-            auto zip_size = zipped_range.size();
-
-            assert(zip_size == ranges::size(tuple_element_arr));
-        }
-
-        STATIC_ASSERT(CanMemberSize<const ZipType> == (ranges::sized_range<const AllView<RangeTypes>> && ...));
-        if constexpr (CanMemberSize<const ZipType>) {
-            auto zip_size = as_const(zipped_range).size();
-
-            assert(zip_size == ranges::size(tuple_element_arr));
-        }
-#else // ^^^ workaround / no workaround vvv
         STATIC_ASSERT(CanMemberSize<ZipType> == (ranges::sized_range<AllView<RangeTypes>> && ...));
         if constexpr (CanMemberSize<ZipType>) {
             using expected_size_type =
@@ -338,7 +323,6 @@ constexpr bool test_one(TestContainerType& test_container, RangeTypes&&... range
                 noexcept(as_const(zipped_range).size())
                 == (noexcept(static_cast<expected_size_type>(declval<const AllView<RangeTypes>>().size())) && ...));
         }
-#endif // ^^^ no workaround ^^^
 
         const bool is_empty = ranges::empty(tuple_element_arr);
 

--- a/tests/std/tests/P2465R3_standard_library_modules/env.lst
+++ b/tests/std/tests/P2465R3_standard_library_modules/env.lst
@@ -13,5 +13,6 @@ PM_CL="/MD"
 PM_CL="/MDd"
 PM_CL="/MT"
 PM_CL="/MTd"
-PM_CL="/MDd /analyze:only /analyze:autolog-"
+# TRANSITION, VSO-1705654
+# PM_CL="/MDd /analyze:only /analyze:autolog-"
 PM_CL="/MDd /GR- /D_HAS_STATIC_RTTI=0"

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.24)
+cmake_minimum_required(VERSION 3.25)
 project(msvc_standard_libraries_tools LANGUAGES CXX)
 
 add_subdirectory(format)

--- a/tools/format/CMakeLists.txt
+++ b/tools/format/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.24)
+cmake_minimum_required(VERSION 3.25)
 project(msvc_standard_libraries_format NONE)
 
 set(did_search OFF)

--- a/tools/validate/CMakeLists.txt
+++ b/tools/validate/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.24)
+cmake_minimum_required(VERSION 3.25)
 project(msvc_standard_libraries_validate LANGUAGES CXX)
 
 add_executable(validate-binary validate.cpp)


### PR DESCRIPTION
* Updated dependencies.
  + Updated build compiler to VS 2022 17.5 Preview 2 (now required).
  + Updated CMake to 3.25 (now required).
  + Updated Python to 3.11.1.
* New 1ES Hosted Pool, containing Patch Tuesday.
* Use PowerShell 7.3.1 while preparing the VM.
* Remove workaround for VSO-1655459 "C1XX Assertion failed ... in ParseTree.cpp, with C++23 `zip_view`".
* Remove workaround for VSO-1675318 "EDG `__builtin_memcmp` misbehavior, part 3".
* Add workaround for VSO-1705654 "Standard Library Modules: `/analyze` ICE".
* Add workaround for CMake-24249 'Error when requiring CMake 3.25: "`MSVC_DEBUG_INFORMATION_FORMAT` value `'ProgramDatabase'` not known for this `ASM_MASM` compiler"'.
