### PR TITLE
Fix for `std::numeric_limits<std::_Signed128>::is_signed`

### DIFF
--- a/stl/inc/__msvc_int128.hpp
+++ b/stl/inc/__msvc_int128.hpp
@@ -1407,8 +1407,9 @@ public:
         return 0;
     }
 
-    static constexpr int digits   = 127;
-    static constexpr int digits10 = 38;
+    static constexpr bool is_signed = true;
+    static constexpr int digits     = 127;
+    static constexpr int digits10   = 38;
 };
 
 template <>

--- a/stl/inc/__msvc_int128.hpp
+++ b/stl/inc/__msvc_int128.hpp
@@ -1407,9 +1407,9 @@ public:
         return 0;
     }
 
-    static constexpr bool is_signed = true;
     static constexpr int digits     = 127;
     static constexpr int digits10   = 38;
+    static constexpr bool is_signed = true;
 };
 
 template <>

--- a/tests/std/tests/P1522R1_difference_type/test.cpp
+++ b/tests/std/tests/P1522R1_difference_type/test.cpp
@@ -193,9 +193,15 @@ constexpr bool test_unsigned() {
     STATIC_ASSERT(std::three_way_comparable<_Unsigned128, ordtest::strong_ordering>);
 #endif // __cpp_lib_concepts
 
+    STATIC_ASSERT(std::numeric_limits<_Unsigned128>::is_specialized);
+    STATIC_ASSERT(std::numeric_limits<_Unsigned128>::is_exact);
+    STATIC_ASSERT(std::numeric_limits<_Unsigned128>::is_integer);
+    STATIC_ASSERT(!std::numeric_limits<_Unsigned128>::is_signed);
+    STATIC_ASSERT(std::numeric_limits<_Unsigned128>::is_bounded);
     STATIC_ASSERT(std::numeric_limits<_Unsigned128>::min() == 0);
     STATIC_ASSERT(std::numeric_limits<_Unsigned128>::max() == ~_Unsigned128{});
     STATIC_ASSERT(std::numeric_limits<_Unsigned128>::digits == 128);
+    STATIC_ASSERT(std::numeric_limits<_Unsigned128>::radix == 2);
     STATIC_ASSERT(std::numeric_limits<_Unsigned128>::is_modulo);
 
     STATIC_ASSERT(SAME_AS<std::common_type_t<bool, _Unsigned128>, _Unsigned128>);
@@ -528,9 +534,15 @@ constexpr bool test_signed() {
     STATIC_ASSERT(std::three_way_comparable<_Signed128, ordtest::strong_ordering>);
 #endif // __cpp_lib_concepts
 
+    STATIC_ASSERT(std::numeric_limits<_Signed128>::is_specialized);
+    STATIC_ASSERT(std::numeric_limits<_Signed128>::is_exact);
+    STATIC_ASSERT(std::numeric_limits<_Signed128>::is_integer);
+    STATIC_ASSERT(std::numeric_limits<_Signed128>::is_signed);
+    STATIC_ASSERT(std::numeric_limits<_Signed128>::is_bounded);
     STATIC_ASSERT(std::numeric_limits<_Signed128>::min() == _Signed128{0, 1ull << 63});
     STATIC_ASSERT(std::numeric_limits<_Signed128>::max() == _Signed128{~0ull, ~0ull >> 1});
     STATIC_ASSERT(std::numeric_limits<_Signed128>::digits == 127);
+    STATIC_ASSERT(std::numeric_limits<_Signed128>::radix == 2);
     STATIC_ASSERT(!std::numeric_limits<_Signed128>::is_modulo);
 
     STATIC_ASSERT(SAME_AS<std::common_type_t<bool, _Signed128>, _Signed128>);


### PR DESCRIPTION
Hello,

I've noticed that the MSVC's STL provides `std::numeric_limits` template specialization
for the `std::_Signed128` (a type which models the `signed-integer-class` concept) slightly incorrectly,
that is the `std::numeric_limits<std::_Signed128>::is_signed` is `false` instead of `true`:

- https://godbolt.org/z/EcbE7Mrnq

This change fixes that issue and adds a couple of compile-time checks
verifying that the `std::numeric_limits<std::_Signed128>` is properly specialized.