### PR TITLE
Casey's miscellaneous branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,19 +198,19 @@ ensures that other components wanting to be a "guest in your process", like prin
 export surface of the STL they were built with. Otherwise, the "`msvcp140.dll`" you deployed in the same directory as
 your .exe would "win" over the versions in System32.
 
-## Complete Example Using x64 DLL Flavor
-
 The compiler looks for include directories according to the `INCLUDE` environment variable, and the linker looks for
 import library directories according to the `LIB` environment variable, and the Windows loader will (eventually) look
-for DLL dependencies according to directories in the `PATH` environment variable. From an
-"x64 Native Tools Command Prompt for VS 2022 Preview":
+for DLL dependencies according to directories in the `PATH` environment variable.
+The build generates a batch script named `set_environment.bat` in the output directory. If you run this script in a VS
+Developer Command Prompt, it will insert the proper directories into the `INCLUDE`, `LIB`, and `PATH` environment
+variables to ensure that the built headers and libraries are used.
+
+## Complete Example Using x64 DLL Flavor
+
+From an "x64 Native Tools Command Prompt for VS 2022 Preview":
 
 ```
-C:\Users\username\Desktop>set INCLUDE=C:\Dev\STL\out\build\x64\out\inc;%INCLUDE%
-
-C:\Users\username\Desktop>set LIB=C:\Dev\STL\out\build\x64\out\lib\amd64;%LIB%
-
-C:\Users\username\Desktop>set PATH=C:\Dev\STL\out\build\x64\out\bin\amd64;%PATH%
+C:\Users\username\Desktop>C:\Dev\STL\out\build\x64\set_environment.bat
 
 C:\Users\username\Desktop>type example.cpp
 #include <iostream>
@@ -225,7 +225,7 @@ example.cpp
 C:\Users\username\Desktop>.\example.exe
 Hello STL OSS world!
 
-C:\Users\username\Desktop>dumpbin /IMPORTS .\example.exe | findstr msvcp
+C:\Users\username\Desktop>dumpbin /DEPENDENTS .\example.exe | findstr msvcp
     msvcp140d_oss.dll
 ```
 

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -615,7 +615,8 @@ struct has_unique_object_representations : bool_constant<__has_unique_object_rep
 _EXPORT_STD template <class _Ty>
 _INLINE_VAR constexpr bool has_unique_object_representations_v = __has_unique_object_representations(_Ty);
 
-#if 1 // TRANSITION, DevCom-10201896 and LLVM-59002
+// TRANSITION, Clang 16, VSO-1690654, and VS17.6p1
+#if defined(__clang__) || defined(__EDG__) || !defined(_MSVC_INTERNAL_TESTING)
 template <class _Ty>
 struct _Is_aggregate_impl : bool_constant<__is_aggregate(_Ty)> {};
 

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -110,6 +110,7 @@ public:
 #else // ^^^ _ITERATOR_DEBUG_LEVEL == 0 / _ITERATOR_DEBUG_LEVEL != 0 vvv
         const auto _Mycont = static_cast<const _Myvec*>(this->_Getcont());
         _STL_VERIFY(_Off == 0 || _Ptr, "cannot seek value-initialized vector iterator");
+        _STL_VERIFY(_Off == 0 || _Mycont, "cannot seek invalidated vector iterator");
         if (_Off < 0) {
             _STL_VERIFY(_Off >= _Mycont->_Myfirst - _Ptr, "cannot seek vector iterator before begin");
         }

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -560,11 +560,6 @@ struct _Make_signed_like_impl<false> {
 template <class _Ty>
 using _Make_signed_like_t = typename _Make_signed_like_impl<_Integer_class<_Ty>>::template _Apply<_Ty>;
 
-template <_Integer_like _Ty>
-_NODISCARD constexpr auto _To_signed_like(const _Ty _Value) noexcept {
-    return static_cast<_Make_signed_like_t<_Ty>>(_Value);
-}
-
 _EXPORT_STD template <class _Ty>
 concept incrementable = regular<_Ty> && weakly_incrementable<_Ty> && requires(_Ty __t) {
                                                                          { __t++ } -> same_as<_Ty>;

--- a/tests/std/include/range_algorithm_support.hpp
+++ b/tests/std/include/range_algorithm_support.hpp
@@ -68,16 +68,16 @@ struct boolish {
     }
 };
 
-template <class T, size_t N>
+template <class T, std::size_t N>
 struct holder {
-    STATIC_ASSERT(N < ~size_t{0} / sizeof(T));
+    STATIC_ASSERT(N < ~std::size_t{0} / sizeof(T));
 
 #ifdef _M_CEE // TRANSITION, VSO-1659408
     unsigned char space[(N + 1) * sizeof(T)];
 
     auto as_span() {
-        void* buffer_ptr  = space;
-        size_t buffer_len = sizeof(space);
+        void* buffer_ptr       = space;
+        std::size_t buffer_len = sizeof(space);
         return std::span<T, N>{static_cast<T*>(std::align(alignof(T), sizeof(T), buffer_ptr, buffer_len)), N};
     }
 #else // ^^^ workaround / no workaround vvv
@@ -1452,7 +1452,7 @@ constexpr void test_in_in_write() {
     with_input_ranges<with_input_ranges<with_writable_iterators<Instantiator, Element3>, Element2>, Element1>::call();
 }
 
-template <size_t I>
+template <std::size_t I>
 struct get_nth_fn {
     template <class T>
     [[nodiscard]] constexpr auto&& operator()(T&& t) const noexcept


### PR DESCRIPTION
Some changes too small to submit individually that I've been accumulating.

* `ranges_algorithm_support.hpp` includes `<cstddef>` but uses `size_t` unqualified; add `std::`-qualifications.
* MSVC (unreleased) and Clang (unreleased) have fixed `__is_aggregate`, but EDG has not. Disable the workaround in internal testing to avoid regression, and update the TRANSITION comment appropriately.
* `_To_signed_like` is unused, remove it.
* Improve error when `_Verify_offset` is called on an invalidated `vector` iterator.
* Mention `set_environment.bat` in `README.md`, and use it in the "How To Consume" example.
