### PR TITLE
Fix `C4365: '=': signed/unsigned mismatch` with `/J`

### DIFF
--- a/stl/inc/xcharconv_ryu.h
+++ b/stl/inc/xcharconv_ryu.h
@@ -904,7 +904,7 @@ _NODISCARD inline to_chars_result __d2exp_buffered_n(char* _First, char* const _
         __roundUp = 1;
       } else {
         if (__roundUp == 1 || __c % 2 != 0) {
-          _Round[0] = __c + 1;
+          _Round[0] = static_cast<char>(__c + 1);
         }
         break;
       }

--- a/tests/std/tests/GH_002711_Zc_alignedNew-/env.lst
+++ b/tests/std/tests/GH_002711_Zc_alignedNew-/env.lst
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\usual_matrix.lst
+RUNALL_INCLUDE ..\impure_matrix.lst
 RUNALL_CROSSLIST
 PM_CL="/Zc:alignedNew-"
 PM_CL="/J"

--- a/tests/std/tests/GH_002711_Zc_alignedNew-/env.lst
+++ b/tests/std/tests/GH_002711_Zc_alignedNew-/env.lst
@@ -4,3 +4,4 @@
 RUNALL_INCLUDE ..\usual_matrix.lst
 RUNALL_CROSSLIST
 PM_CL="/Zc:alignedNew-"
+PM_CL="/J"

--- a/tests/std/tests/GH_002711_Zc_alignedNew-/test.compile.pass.cpp
+++ b/tests/std/tests/GH_002711_Zc_alignedNew-/test.compile.pass.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 // GH-2711 <functional>: incompatible with /std:c++latest and /Zc:alignedNew-
+// GH-3294 <chrono>: building with -J emits C4365
 #include <__msvc_all_public_headers.hpp>
 
 int main() {} // COMPILE-ONLY


### PR DESCRIPTION
Fixes #3294 