### PR TITLE
Use FindFirstFileW instead of FindFirstFileExW

### DIFF
--- a/stl/src/filesys.cpp
+++ b/stl/src/filesys.cpp
@@ -111,8 +111,7 @@ _FS_DLL void* __CLRCALL_PURE_OR_CDECL _Open_dir(
         _Wildname.append(L"\\*");
     }
 
-    void* _Handle =
-        FindFirstFileExW(_Wildname.c_str(), FindExInfoStandard, &_Dentry, FindExSearchNameMatch, nullptr, 0);
+    void* _Handle = FindFirstFileW(_Wildname.c_str(), &_Dentry);
     if (_Handle == INVALID_HANDLE_VALUE) { // report failure
         _Errno = ERROR_BAD_PATHNAME;
         *_Dest = L'\0';


### PR DESCRIPTION
FindFirstFileW works fine, and searches for name match by default

<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
