### PR TITLE
Check for last error instead of assuming the error in question was a bad filepath

### DIFF
--- a/stl/src/filesys.cpp
+++ b/stl/src/filesys.cpp
@@ -114,7 +114,7 @@ _FS_DLL void* __CLRCALL_PURE_OR_CDECL _Open_dir(
     void* _Handle =
         FindFirstFileExW(_Wildname.c_str(), FindExInfoStandard, &_Dentry, FindExSearchNameMatch, nullptr, 0);
     if (_Handle == INVALID_HANDLE_VALUE) { // report failure
-        _Errno = ERROR_BAD_PATHNAME;
+        _Errno = GetLastError();
         *_Dest = L'\0';
         return nullptr;
     }


### PR DESCRIPTION
The error in question could also be that the directory in question is not a directory but a file, or does not exist.