### PR TITLE
Strengthen exception specifications for stream types

### DIFF
--- a/stl/inc/fstream
+++ b/stl/inc/fstream
@@ -189,7 +189,7 @@ public:
     using pos_type = typename _Traits::pos_type;
     using off_type = typename _Traits::off_type;
 
-    basic_filebuf(_Uninitialized) : _Mysb(_Noinit) {}
+    basic_filebuf(_Uninitialized) noexcept : _Mysb(_Noinit) {}
 
     basic_filebuf(basic_filebuf&& _Right) {
         _Init(_Right._Myfile, _Newfl); // match buffering styles
@@ -209,7 +209,7 @@ public:
         }
     }
 
-    void swap(basic_filebuf& _Right) {
+    void swap(basic_filebuf& _Right) noexcept /* strengthened */ {
         if (this != _STD addressof(_Right)) {
             FILE* _Myfile_sav                       = _Myfile;
             const _Cvt* _Pcvt_sav                   = _Pcvt;
@@ -276,7 +276,7 @@ public:
         _Closefl
     };
 
-    _NODISCARD bool is_open() const {
+    _NODISCARD bool is_open() const noexcept /* strengthened */ {
         return static_cast<bool>(_Myfile);
     }
 
@@ -699,7 +699,7 @@ protected:
         _Initcvt(_STD use_facet<_Cvt>(_Loc));
     }
 
-    void _Init(FILE* _File, _Initfl _Which) { // initialize to C stream _File after {new, open, close}
+    void _Init(FILE* _File, _Initfl _Which) noexcept { // initialize to C stream _File after {new, open, close}
         using _State_type = typename _Traits::state_type;
 
         __PURE_APPDOMAIN_GLOBAL static _State_type _Stinit; // initial state
@@ -763,7 +763,7 @@ protected:
         }
     }
 
-    void _Initcvt(const _Cvt& _Newcvt) { // initialize codecvt pointer
+    void _Initcvt(const _Cvt& _Newcvt) noexcept { // initialize codecvt pointer
         if (_Newcvt.always_noconv()) {
             _Pcvt = nullptr; // nothing to do
         } else { // set up for nontrivial codecvt facet
@@ -780,13 +780,13 @@ private:
     bool _Closef; // true if C stream must be closed
     FILE* _Myfile; // pointer to C stream
 
-    void _Reset_back() { // restore buffer after putback
+    void _Reset_back() noexcept { // restore buffer after putback
         if (_Mysb::eback() == &_Mychar) {
             _Mysb::setg(_Set_eback, _Set_eback, _Set_egptr);
         }
     }
 
-    void _Set_back() { // set up putback area
+    void _Set_back() noexcept { // set up putback area
         if (_Mysb::eback() != &_Mychar) { // save current get buffer
             _Set_eback = _Mysb::eback();
             _Set_egptr = _Mysb::egptr();
@@ -799,7 +799,7 @@ private:
 };
 
 _EXPORT_STD template <class _Elem, class _Traits>
-void swap(basic_filebuf<_Elem, _Traits>& _Left, basic_filebuf<_Elem, _Traits>& _Right) {
+void swap(basic_filebuf<_Elem, _Traits>& _Left, basic_filebuf<_Elem, _Traits>& _Right) noexcept /* strengthened */ {
     _Left.swap(_Right);
 }
 
@@ -872,7 +872,7 @@ public:
         }
     }
 
-    void swap(basic_ifstream& _Right) {
+    void swap(basic_ifstream& _Right) noexcept /* strengthened */ {
         if (this != _STD addressof(_Right)) {
             _Mybase::swap(_Right);
             _Filebuffer.swap(_Right._Filebuffer);
@@ -943,11 +943,11 @@ public:
 
     __CLR_OR_THIS_CALL ~basic_ifstream() noexcept override {}
 
-    _NODISCARD _Myfb* rdbuf() const {
+    _NODISCARD _Myfb* rdbuf() const noexcept /* strengthened */ {
         return const_cast<_Myfb*>(_STD addressof(_Filebuffer));
     }
 
-    _NODISCARD bool is_open() const {
+    _NODISCARD bool is_open() const noexcept /* strengthened */ {
         return _Filebuffer.is_open();
     }
 
@@ -983,7 +983,7 @@ private:
 };
 
 _EXPORT_STD template <class _Elem, class _Traits>
-void swap(basic_ifstream<_Elem, _Traits>& _Left, basic_ifstream<_Elem, _Traits>& _Right) {
+void swap(basic_ifstream<_Elem, _Traits>& _Left, basic_ifstream<_Elem, _Traits>& _Right) noexcept /* strengthened */ {
     _Left.swap(_Right);
 }
 
@@ -1055,7 +1055,7 @@ public:
         }
     }
 
-    void swap(basic_ofstream& _Right) {
+    void swap(basic_ofstream& _Right) noexcept /* strengthened */ {
         if (this != _STD addressof(_Right)) {
             _Mybase::swap(_Right);
             _Filebuffer.swap(_Right._Filebuffer);
@@ -1126,11 +1126,11 @@ public:
 
     __CLR_OR_THIS_CALL ~basic_ofstream() noexcept override {}
 
-    _NODISCARD _Myfb* rdbuf() const {
+    _NODISCARD _Myfb* rdbuf() const noexcept /* strengthened */ {
         return const_cast<_Myfb*>(_STD addressof(_Filebuffer));
     }
 
-    _NODISCARD bool is_open() const {
+    _NODISCARD bool is_open() const noexcept /* strengthened */ {
         return _Filebuffer.is_open();
     }
 
@@ -1166,7 +1166,7 @@ private:
 };
 
 _EXPORT_STD template <class _Elem, class _Traits>
-void swap(basic_ofstream<_Elem, _Traits>& _Left, basic_ofstream<_Elem, _Traits>& _Right) {
+void swap(basic_ofstream<_Elem, _Traits>& _Left, basic_ofstream<_Elem, _Traits>& _Right) noexcept /* strengthened */ {
     _Left.swap(_Right);
 }
 
@@ -1243,7 +1243,7 @@ public:
         }
     }
 
-    void swap(basic_fstream& _Right) {
+    void swap(basic_fstream& _Right) noexcept /* strengthened */ {
         if (this != _STD addressof(_Right)) {
             _Mybase::swap(_Right);
             _Filebuffer.swap(_Right._Filebuffer);
@@ -1315,11 +1315,11 @@ public:
 
     __CLR_OR_THIS_CALL ~basic_fstream() noexcept override {}
 
-    _NODISCARD _Myfb* rdbuf() const {
+    _NODISCARD _Myfb* rdbuf() const noexcept /* strengthened */ {
         return const_cast<_Myfb*>(_STD addressof(_Filebuffer));
     }
 
-    _NODISCARD bool is_open() const {
+    _NODISCARD bool is_open() const noexcept /* strengthened */ {
         return _Filebuffer.is_open();
     }
 
@@ -1356,7 +1356,7 @@ private:
 };
 
 _EXPORT_STD template <class _Elem, class _Traits>
-void swap(basic_fstream<_Elem, _Traits>& _Left, basic_fstream<_Elem, _Traits>& _Right) {
+void swap(basic_fstream<_Elem, _Traits>& _Left, basic_fstream<_Elem, _Traits>& _Right) noexcept /* strengthened */ {
     _Left.swap(_Right);
 }
 _STD_END

--- a/stl/inc/ios
+++ b/stl/inc/ios
@@ -47,8 +47,8 @@ public:
     }
 #endif // _HAS_OLD_IOSTREAMS_MEMBERS
 
-    void __CLR_OR_THIS_CALL setstate(
-        iostate _State, bool _Reraise = false) { // merge _State into state, possibly reraise exception
+    void __CLR_OR_THIS_CALL setstate(iostate _State, bool _Reraise = false) {
+        // merge _State into state, possibly reraise exception
         clear(rdstate() | _State, _Reraise);
     }
 
@@ -65,17 +65,17 @@ public:
         return *this;
     }
 
-    _Myos* __CLR_OR_THIS_CALL tie() const {
+    _Myos* __CLR_OR_THIS_CALL tie() const noexcept /* strengthened */ {
         return _Tiestr;
     }
 
-    _Myos* __CLR_OR_THIS_CALL tie(_Myos* _Newtie) { // set tie pointer
+    _Myos* __CLR_OR_THIS_CALL tie(_Myos* _Newtie) noexcept /* strengthened */ { // set tie pointer
         _Myos* _Oldtie = _Tiestr;
         _Tiestr        = _Newtie;
         return _Oldtie;
     }
 
-    _NODISCARD _Mysb* __CLR_OR_THIS_CALL rdbuf() const {
+    _NODISCARD _Mysb* __CLR_OR_THIS_CALL rdbuf() const noexcept /* strengthened */ {
         return _Mystrbuf;
     }
 
@@ -96,11 +96,11 @@ public:
         return _Oldlocale;
     }
 
-    _Elem __CLR_OR_THIS_CALL fill() const {
+    _Elem __CLR_OR_THIS_CALL fill() const noexcept /* strengthened */ {
         return _Fillch;
     }
 
-    _Elem __CLR_OR_THIS_CALL fill(_Elem _Newfill) { // set fill character
+    _Elem __CLR_OR_THIS_CALL fill(_Elem _Newfill) noexcept /* strengthened */ { // set fill character
         _Elem _Oldfill = _Fillch;
         _Fillch        = _Newfill;
         return _Oldfill;
@@ -114,7 +114,7 @@ public:
         return _STD use_facet<_Ctype>(getloc()).widen(_Byte);
     }
 
-    void __CLR_OR_THIS_CALL move(basic_ios& _Right) {
+    void __CLR_OR_THIS_CALL move(basic_ios& _Right) noexcept /* strengthened */ {
         if (this != _STD addressof(_Right)) {
             _Mystrbuf = nullptr;
             _Tiestr   = nullptr;
@@ -122,7 +122,7 @@ public:
         }
     }
 
-    void __CLR_OR_THIS_CALL move(basic_ios&& _Right) {
+    void __CLR_OR_THIS_CALL move(basic_ios&& _Right) noexcept /* strengthened */ {
         if (this != _STD addressof(_Right)) {
             _Mystrbuf = nullptr;
             _Tiestr   = nullptr;
@@ -136,13 +136,14 @@ public:
         _STD swap(_Tiestr, _Right._Tiestr);
     }
 
-    void __CLR_OR_THIS_CALL set_rdbuf(_Mysb* _Strbuf) { // set stream buffer pointer without changing state
+    void __CLR_OR_THIS_CALL set_rdbuf(_Mysb* _Strbuf) noexcept /* strengthened */ {
+        // set stream buffer pointer without changing state
         _Mystrbuf = _Strbuf;
     }
 
 protected:
-    void __CLR_OR_THIS_CALL init(_Mysb* _Strbuf = nullptr,
-        bool _Isstd                             = false) { // initialize with stream buffer pointer
+    void __CLR_OR_THIS_CALL init(_Mysb* _Strbuf = nullptr, bool _Isstd = false) {
+        // initialize with stream buffer pointer
         _Init(); // initialize ios_base
         _Mystrbuf = _Strbuf;
         _Tiestr   = nullptr;

--- a/stl/inc/istream
+++ b/stl/inc/istream
@@ -54,12 +54,12 @@ protected:
         _Right._Chcount = 0;
     }
 
-    basic_istream& __CLR_OR_THIS_CALL operator=(basic_istream&& _Right) {
+    basic_istream& __CLR_OR_THIS_CALL operator=(basic_istream&& _Right) noexcept /* strengthened */ {
         this->swap(_Right);
         return *this;
     }
 
-    void __CLR_OR_THIS_CALL swap(basic_istream& _Right) {
+    void __CLR_OR_THIS_CALL swap(basic_istream& _Right) noexcept /* strengthened */ {
         _Myios::swap(_Right);
         _STD swap(_Chcount, _Right._Chcount);
     }
@@ -205,7 +205,7 @@ private:
     }
 
     template <class = void>
-    void _Increment_gcount() {
+    void _Increment_gcount() noexcept {
         if (_Chcount != (numeric_limits<streamsize>::max)()) {
             ++_Chcount;
         }
@@ -605,7 +605,8 @@ public:
         return *this;
     }
 
-    _NODISCARD streamsize __CLR_OR_THIS_CALL gcount() const { // get count from last extraction
+    _NODISCARD streamsize __CLR_OR_THIS_CALL gcount() const noexcept /* strengthened */ {
+        // get count from last extraction
         return _Chcount;
     }
 
@@ -743,12 +744,12 @@ protected:
         _Myios::move(_STD move(_Right));
     }
 
-    basic_iostream& __CLR_OR_THIS_CALL operator=(basic_iostream&& _Right) {
+    basic_iostream& __CLR_OR_THIS_CALL operator=(basic_iostream&& _Right) noexcept /* strengthened */ {
         this->swap(_Right);
         return *this;
     }
 
-    void __CLR_OR_THIS_CALL swap(basic_iostream& _Right) {
+    void __CLR_OR_THIS_CALL swap(basic_iostream& _Right) noexcept /* strengthened */ {
         if (this != _STD addressof(_Right)) {
             _Myios::swap(_Right);
         }

--- a/stl/inc/ostream
+++ b/stl/inc/ostream
@@ -44,12 +44,12 @@ protected:
         _Myios::move(_STD move(_Right));
     }
 
-    basic_ostream& __CLR_OR_THIS_CALL operator=(basic_ostream&& _Right) {
+    basic_ostream& __CLR_OR_THIS_CALL operator=(basic_ostream&& _Right) noexcept /* strengthened */ {
         this->swap(_Right);
         return *this;
     }
 
-    void __CLR_OR_THIS_CALL swap(basic_ostream& _Right) {
+    void __CLR_OR_THIS_CALL swap(basic_ostream& _Right) noexcept /* strengthened */ {
         if (this != _STD addressof(_Right)) {
             _Myios::swap(_Right);
         }
@@ -147,11 +147,11 @@ public:
     }
 
     // TRANSITION, ABI: non-Standard osfx() is preserved for binary compatibility
-    void __CLR_OR_THIS_CALL osfx() { // perform any wrapup
+    void __CLR_OR_THIS_CALL osfx() noexcept { // perform any wrapup
         _Osfx();
     }
 
-    void __CLR_OR_THIS_CALL _Osfx() { // perform any wrapup
+    void __CLR_OR_THIS_CALL _Osfx() noexcept { // perform any wrapup
         _TRY_BEGIN
         if (this->good() && this->flags() & ios_base::unitbuf) {
             if (_Myios::rdbuf()->pubsync() == -1) { // flush stream as needed

--- a/stl/inc/spanstream
+++ b/stl/inc/spanstream
@@ -66,7 +66,7 @@ public:
 
     basic_spanbuf& operator=(basic_spanbuf&& _Right) noexcept /* strengthened */ {
         if (this != _STD addressof(_Right)) {
-            this->_Buf = _STD span<_Elem>{};
+            _Buf = _STD span<_Elem>{};
             this->setp(nullptr, nullptr, nullptr);
             this->setg(nullptr, nullptr, nullptr);
             this->swap(_Right);
@@ -367,7 +367,7 @@ public:
         return *this;
     }
 
-    // N4928 [spanstream.assign], swap
+    // N4928 [spanstream.swap], swap
     void swap(basic_spanstream& _Right) noexcept /* strengthened */ {
         _Mybase::swap(_Right);
         _Buf.swap(_Right._Buf);

--- a/stl/inc/spanstream
+++ b/stl/inc/spanstream
@@ -44,7 +44,7 @@ public:
     using off_type    = typename _Traits::off_type;
     using traits_type = _Traits;
 
-    // N4892 [spanbuf.ctor], constructors
+    // N4928 [spanbuf.cons], constructors
     basic_spanbuf() = default;
 
     explicit basic_spanbuf(ios_base::openmode _Which) : _Mysb(), _Mode(_Which) {}
@@ -56,27 +56,31 @@ public:
 
     basic_spanbuf(const basic_spanbuf&) = delete;
     basic_spanbuf(basic_spanbuf&& _Right)
-        : _Mysb(_STD move(_Right)), _Mode(_STD move(_Right._Mode)), _Buf(_STD exchange(_Right._Buf, {})) {
+        : _Mysb(_STD move(_Right)), _Mode(_Right._Mode), _Buf(_STD exchange(_Right._Buf, {})) {
         _Right.setp(nullptr, nullptr, nullptr);
         _Right.setg(nullptr, nullptr, nullptr);
     }
 
-    // N4892 [spanbuf.assign], assignment and swap
+    // N4928 [spanbuf.assign], assignment and swap
     basic_spanbuf& operator=(const basic_spanbuf&) = delete;
 
-    basic_spanbuf& operator=(basic_spanbuf&& _Right) {
-        basic_spanbuf _Tmp{_STD move(_Right)};
-        this->swap(_Tmp);
+    basic_spanbuf& operator=(basic_spanbuf&& _Right) noexcept /* strengthened */ {
+        if (this != _STD addressof(_Right)) {
+            this->_Buf = _STD span<_Elem>{};
+            this->setp(nullptr, nullptr, nullptr);
+            this->setg(nullptr, nullptr, nullptr);
+            this->swap(_Right);
+        }
         return *this;
     }
 
-    void swap(basic_spanbuf& _Right) {
+    void swap(basic_spanbuf& _Right) noexcept /* strengthened */ {
         _Mysb::swap(_Right);
         _STD swap(_Mode, _Right._Mode);
         _STD swap(_Buf, _Right._Buf);
     }
 
-    // N4892 [spanbuf.members], member functions
+    // N4928 [spanbuf.members], member functions
     _NODISCARD _STD span<_Elem> span() const noexcept {
         if (_Mode & ios_base::out) {
             return _STD span<_Elem>{_Mysb::pbase(), _Mysb::pptr()};
@@ -103,22 +107,22 @@ public:
     }
 
 protected:
-    // N4892 [spanbuf.virtuals], overridden virtual functions
+    // N4928 [spanbuf.virtuals], overridden virtual functions
     pos_type seekoff(
         off_type _Off, ios_base::seekdir _Way, ios_base::openmode _Which = ios_base::in | ios_base::out) override {
         const bool _Sequence_in  = _Which & ios_base::in;
         const bool _Sequence_out = _Which & ios_base::out;
         switch (_Way) {
         case ios_base::beg:
-            // N4892 [spanbuf.virtuals]/4.1 baseoff = 0
+            // N4928 [spanbuf.virtuals]/4.1 baseoff = 0
             if (static_cast<size_t>(_Off) > _Buf.size()) { // negative wraparound to positive to save a compare
-                return pos_type(off_type(-1)); // N4892 [spanbuf.virtuals]/5 report failure
+                return pos_type(off_type(-1)); // N4928 [spanbuf.virtuals]/5 report failure
             }
 
             break;
         case ios_base::end:
             {
-                // N4892 [spanbuf.virtuals]/4.3 baseoff =
+                // N4928 [spanbuf.virtuals]/4.3 baseoff =
                 const auto _Baseoff = (_Mode & ios_base::out) && !(_Mode & ios_base::in)
                                         ? static_cast<off_type>(_Mysb::pptr() - _Mysb::pbase())
                                         : static_cast<off_type>(_Buf.size());
@@ -128,7 +132,7 @@ protected:
 
                 _Off += _Baseoff;
                 if (static_cast<size_t>(_Off) > _Buf.size()) { // negative wraparound to positive to save a compare
-                    return pos_type(off_type(-1)); // N4892 [spanbuf.virtuals]/5 report failure
+                    return pos_type(off_type(-1)); // N4928 [spanbuf.virtuals]/5 report failure
                 }
 
                 break;
@@ -153,7 +157,7 @@ protected:
             return pos_type(off_type(-1)); // report failure
         }
 
-        // N4892 [spanbuf.virtuals]/4: For a sequence to be positioned, if its next pointer is a null pointer and newoff
+        // N4928 [spanbuf.virtuals]/4: For a sequence to be positioned, if its next pointer is a null pointer and newoff
         // is not equal to 0, the positioning operation fails.
         if (_Off != 0 && ((_Sequence_in && !_Mysb::gptr()) || (_Sequence_out && !_Mysb::pptr()))) {
             return pos_type(off_type(-1)); // report failure
@@ -185,7 +189,7 @@ private:
 };
 
 _EXPORT_STD template <class _Elem, class _Traits>
-void swap(basic_spanbuf<_Elem, _Traits>& _Left, basic_spanbuf<_Elem, _Traits>& _Right) {
+void swap(basic_spanbuf<_Elem, _Traits>& _Left, basic_spanbuf<_Elem, _Traits>& _Right) noexcept /* strengthened */ {
     _Left.swap(_Right);
 }
 
@@ -202,7 +206,7 @@ public:
     using off_type    = typename _Traits::off_type;
     using traits_type = _Traits;
 
-    // N4892 [ispanstream.ctor], constructors
+    // N4928 [ispanstream.cons], constructors
     explicit basic_ispanstream(_STD span<_Elem> _Span, ios_base::openmode _Which = ios_base::in)
         : _Mybase(_STD addressof(_Buf)), _Buf(_Span, _Which | ios_base::in) {}
 
@@ -223,21 +227,21 @@ public:
     // clang-format on
 #endif // __cpp_lib_concepts
 
-    // N4892 [ispanstream.assign], assignment and swap
     basic_ispanstream& operator=(const basic_ispanstream&) = delete;
 
-    basic_ispanstream& operator=(basic_ispanstream&& _Right) {
+    basic_ispanstream& operator=(basic_ispanstream&& _Right) noexcept /* strengthened */ {
         _Mybase::swap(_Right);
         _Buf.swap(_Right._Buf);
         return *this;
     }
 
-    void swap(basic_ispanstream& _Right) {
+    // N4928 [ispanstream.swap], swap
+    void swap(basic_ispanstream& _Right) noexcept /* strengthened */ {
         _Mybase::swap(_Right);
         _Buf.swap(_Right._Buf);
     }
 
-    // N4892 [ispanstream.members], member functions
+    // N4928 [ispanstream.members], member functions
     _NODISCARD _Mysb* rdbuf() const noexcept {
         return const_cast<_Mysb*>(_STD addressof(_Buf));
     }
@@ -267,7 +271,8 @@ private:
 };
 
 _EXPORT_STD template <class _Elem, class _Traits>
-void swap(basic_ispanstream<_Elem, _Traits>& _Left, basic_ispanstream<_Elem, _Traits>& _Right) {
+void swap(basic_ispanstream<_Elem, _Traits>& _Left, basic_ispanstream<_Elem, _Traits>& _Right) noexcept
+/* strengthened */ {
     _Left.swap(_Right);
 }
 
@@ -284,7 +289,7 @@ public:
     using off_type    = typename _Traits::off_type;
     using traits_type = _Traits;
 
-    // N4892 [ospanstream.ctor], constructors
+    // N4928 [ospanstream.cons], constructors
     explicit basic_ospanstream(_STD span<_Elem> _Span, ios_base::openmode _Which = ios_base::out)
         : _Mybase(_STD addressof(_Buf)), _Buf(_Span, _Which | ios_base::out) {}
 
@@ -294,21 +299,21 @@ public:
         _Mybase::set_rdbuf(_STD addressof(_Buf));
     }
 
-    // N4892 [ospanstream.assign], assignment and swap
     basic_ospanstream& operator=(const basic_ospanstream&) = delete;
 
-    basic_ospanstream& operator=(basic_ospanstream&& _Right) {
+    basic_ospanstream& operator=(basic_ospanstream&& _Right) noexcept /* strengthened */ {
         _Mybase::swap(_Right);
         _Buf.swap(_Right._Buf);
         return *this;
     }
 
-    void swap(basic_ospanstream& _Right) {
+    // N4928 [ospanstream.swap], swap
+    void swap(basic_ospanstream& _Right) noexcept /* strengthened */ {
         _Mybase::swap(_Right);
         _Buf.swap(_Right._Buf);
     }
 
-    // N4892 [ospanstream.members], member functions
+    // N4928 [ospanstream.members], member functions
     _NODISCARD _Mysb* rdbuf() const noexcept {
         return const_cast<_Mysb*>(_STD addressof(_Buf));
     }
@@ -326,7 +331,8 @@ private:
 };
 
 _EXPORT_STD template <class _Elem, class _Traits>
-void swap(basic_ospanstream<_Elem, _Traits>& _Left, basic_ospanstream<_Elem, _Traits>& _Right) {
+void swap(basic_ospanstream<_Elem, _Traits>& _Left, basic_ospanstream<_Elem, _Traits>& _Right) noexcept
+/* strengthened */ {
     _Left.swap(_Right);
 }
 
@@ -343,7 +349,7 @@ public:
     using off_type    = typename _Traits::off_type;
     using traits_type = _Traits;
 
-    // N4892 [spanstream.ctor], constructors
+    // N4928 [spanstream.cons], constructors
     explicit basic_spanstream(_STD span<_Elem> _Span, ios_base::openmode _Which = ios_base::out | ios_base::in)
         : _Mybase(_STD addressof(_Buf)), _Buf(_Span, _Which) {}
 
@@ -353,21 +359,21 @@ public:
         _Mybase::set_rdbuf(_STD addressof(_Buf));
     }
 
-    // N4892 [spanstream.assign], assignment and swap
     basic_spanstream& operator=(const basic_spanstream&) = delete;
 
-    basic_spanstream& operator=(basic_spanstream&& _Right) {
+    basic_spanstream& operator=(basic_spanstream&& _Right) noexcept /* strengthened */ {
         _Mybase::swap(_Right);
         _Buf.swap(_Right._Buf);
         return *this;
     }
 
-    void swap(basic_spanstream& _Right) {
+    // N4928 [spanstream.assign], swap
+    void swap(basic_spanstream& _Right) noexcept /* strengthened */ {
         _Mybase::swap(_Right);
         _Buf.swap(_Right._Buf);
     }
 
-    // N4892 [spanstream.members], member functions
+    // N4928 [spanstream.members], member functions
     _NODISCARD _Mysb* rdbuf() const noexcept {
         return const_cast<_Mysb*>(_STD addressof(_Buf));
     }
@@ -385,7 +391,8 @@ private:
 };
 
 _EXPORT_STD template <class _Elem, class _Traits>
-void swap(basic_spanstream<_Elem, _Traits>& _Left, basic_spanstream<_Elem, _Traits>& _Right) {
+void swap(basic_spanstream<_Elem, _Traits>& _Left, basic_spanstream<_Elem, _Traits>& _Right) noexcept
+/* strengthened */ {
     _Left.swap(_Right);
 }
 

--- a/stl/inc/sstream
+++ b/stl/inc/sstream
@@ -585,7 +585,7 @@ public:
     void _Assign_rv(basic_istringstream&& _Right) noexcept {
         if (this != _STD addressof(_Right)) {
             _Mybase::swap(_Right);
-            _Stringbuffer._Assign_rv(_STD move(_Right));
+            _Stringbuffer._Assign_rv(_STD move(_Right._Stringbuffer));
         }
     }
 
@@ -705,7 +705,7 @@ public:
     void _Assign_rv(basic_ostringstream&& _Right) noexcept {
         if (this != _STD addressof(_Right)) {
             _Mybase::swap(_Right);
-            _Stringbuffer._Assign_rv(_STD move(_Right));
+            _Stringbuffer._Assign_rv(_STD move(_Right._Stringbuffer));
         }
     }
 
@@ -831,7 +831,7 @@ public:
     void _Assign_rv(basic_stringstream&& _Right) noexcept {
         if (this != _STD addressof(_Right)) {
             _Mybase::swap(_Right);
-            _Stringbuffer._Assign_rv(_STD move(_Right));
+            _Stringbuffer._Assign_rv(_STD move(_Right._Stringbuffer));
         }
     }
 

--- a/stl/inc/sstream
+++ b/stl/inc/sstream
@@ -348,8 +348,7 @@ protected:
         case ios_base::cur:
             {
                 constexpr auto _Both = ios_base::in | ios_base::out;
-                if ((_Mode & _Both)
-                    != _Both) { // prohibited by N4928 [stringbuf.virtuals] Table 127 "seekoff positioning"
+                if ((_Mode & _Both) != _Both) { // prohibited by N4928 [tab:stringbuf.seekoff.pos]
                     if (_Mode & ios_base::in) {
                         if (_Gptr_old || !_Seeklow) {
                             _Newoff = _Gptr_old - _Seeklow;

--- a/stl/inc/sstream
+++ b/stl/inc/sstream
@@ -584,9 +584,8 @@ public:
 
     void _Assign_rv(basic_istringstream&& _Right) noexcept {
         if (this != _STD addressof(_Right)) {
-            _Stringbuffer._Tidy();
-            _Stringbuffer.swap(_Right._Stringbuffer);
-            this->swap(_Right);
+            _Mybase::swap(_Right);
+            _Stringbuffer._Assign_rv(_STD move(_Right));
         }
     }
 
@@ -705,9 +704,8 @@ public:
 
     void _Assign_rv(basic_ostringstream&& _Right) noexcept {
         if (this != _STD addressof(_Right)) {
-            _Stringbuffer._Tidy();
-            _Stringbuffer.swap(_Right._Stringbuffer);
-            this->swap(_Right);
+            _Mybase::swap(_Right);
+            _Stringbuffer._Assign_rv(_STD move(_Right));
         }
     }
 
@@ -832,9 +830,8 @@ public:
 
     void _Assign_rv(basic_stringstream&& _Right) noexcept {
         if (this != _STD addressof(_Right)) {
-            _Stringbuffer._Tidy();
-            _Stringbuffer.swap(_Right._Stringbuffer);
-            this->swap(_Right);
+            _Mybase::swap(_Right);
+            _Stringbuffer._Assign_rv(_STD move(_Right));
         }
     }
 

--- a/stl/inc/sstream
+++ b/stl/inc/sstream
@@ -76,12 +76,12 @@ public:
         _Assign_rv(_STD move(_Right));
     }
 
-    basic_stringbuf& operator=(basic_stringbuf&& _Right) {
+    basic_stringbuf& operator=(basic_stringbuf&& _Right) noexcept /* strengthened */ {
         _Assign_rv(_STD move(_Right));
         return *this;
     }
 
-    void _Assign_rv(basic_stringbuf&& _Right) {
+    void _Assign_rv(basic_stringbuf&& _Right) noexcept {
         if (this != _STD addressof(_Right)) {
             _Tidy();
             this->swap(_Right);
@@ -349,7 +349,7 @@ protected:
             {
                 constexpr auto _Both = ios_base::in | ios_base::out;
                 if ((_Mode & _Both)
-                    != _Both) { // prohibited by N4727 [stringbuf.virtuals] Table 107 "seekoff positioning"
+                    != _Both) { // prohibited by N4928 [stringbuf.virtuals] Table 127 "seekoff positioning"
                     if (_Mode & ios_base::in) {
                         if (_Gptr_old || !_Seeklow) {
                             _Newoff = _Gptr_old - _Seeklow;
@@ -499,7 +499,7 @@ private:
         _MINSIZE = 32
     };
 
-    static int _Getstate(ios_base::openmode _Mode) { // convert open mode to stream state bits
+    static int _Getstate(ios_base::openmode _Mode) noexcept { // convert open mode to stream state bits
         int _State = 0;
         if (!(_Mode & ios_base::in)) {
             _State |= _Noread;
@@ -577,19 +577,20 @@ public:
         _Assign_rv(_STD move(_Right));
     }
 
-    basic_istringstream& operator=(basic_istringstream&& _Right) {
+    basic_istringstream& operator=(basic_istringstream&& _Right) noexcept /* strengthened */ {
         _Assign_rv(_STD move(_Right));
         return *this;
     }
 
-    void _Assign_rv(basic_istringstream&& _Right) {
+    void _Assign_rv(basic_istringstream&& _Right) noexcept {
         if (this != _STD addressof(_Right)) {
-            _Stringbuffer.str(_Mystr());
+            _Stringbuffer._Tidy();
+            _Stringbuffer.swap(_Right._Stringbuffer);
             this->swap(_Right);
         }
     }
 
-    void swap(basic_istringstream& _Right) {
+    void swap(basic_istringstream& _Right) noexcept /* strengthened */ {
         if (this != _STD addressof(_Right)) {
             _Mybase::swap(_Right);
             _Stringbuffer.swap(_Right._Stringbuffer);
@@ -601,7 +602,7 @@ public:
 
     ~basic_istringstream() noexcept override {}
 
-    _NODISCARD _Mysb* rdbuf() const {
+    _NODISCARD _Mysb* rdbuf() const noexcept /* strengthened */ {
         return const_cast<_Mysb*>(_STD addressof(_Stringbuffer));
     }
 
@@ -647,7 +648,8 @@ private:
 };
 
 _EXPORT_STD template <class _Elem, class _Traits, class _Alloc>
-void swap(basic_istringstream<_Elem, _Traits, _Alloc>& _Left, basic_istringstream<_Elem, _Traits, _Alloc>& _Right) {
+void swap(basic_istringstream<_Elem, _Traits, _Alloc>& _Left,
+    basic_istringstream<_Elem, _Traits, _Alloc>& _Right) noexcept /* strengthened */ {
     _Left.swap(_Right);
 }
 
@@ -696,19 +698,20 @@ public:
         _Assign_rv(_STD move(_Right));
     }
 
-    basic_ostringstream& operator=(basic_ostringstream&& _Right) {
+    basic_ostringstream& operator=(basic_ostringstream&& _Right) noexcept /* strengthened */ {
         _Assign_rv(_STD move(_Right));
         return *this;
     }
 
-    void _Assign_rv(basic_ostringstream&& _Right) {
+    void _Assign_rv(basic_ostringstream&& _Right) noexcept {
         if (this != _STD addressof(_Right)) {
-            _Stringbuffer.str(_Mystr());
+            _Stringbuffer._Tidy();
+            _Stringbuffer.swap(_Right._Stringbuffer);
             this->swap(_Right);
         }
     }
 
-    void swap(basic_ostringstream& _Right) {
+    void swap(basic_ostringstream& _Right) noexcept /* strengthened */ {
         if (this != _STD addressof(_Right)) {
             _Mybase::swap(_Right);
             _Stringbuffer.swap(_Right._Stringbuffer);
@@ -720,7 +723,7 @@ public:
 
     ~basic_ostringstream() noexcept override {}
 
-    _NODISCARD _Mysb* rdbuf() const {
+    _NODISCARD _Mysb* rdbuf() const noexcept /* strengthened */ {
         return const_cast<_Mysb*>(_STD addressof(_Stringbuffer));
     }
 
@@ -766,7 +769,8 @@ private:
 };
 
 _EXPORT_STD template <class _Elem, class _Traits, class _Alloc>
-void swap(basic_ostringstream<_Elem, _Traits, _Alloc>& _Left, basic_ostringstream<_Elem, _Traits, _Alloc>& _Right) {
+void swap(basic_ostringstream<_Elem, _Traits, _Alloc>& _Left,
+    basic_ostringstream<_Elem, _Traits, _Alloc>& _Right) noexcept /* strengthened */ {
     _Left.swap(_Right);
 }
 
@@ -821,19 +825,20 @@ public:
         _Assign_rv(_STD move(_Right));
     }
 
-    basic_stringstream& operator=(basic_stringstream&& _Right) {
+    basic_stringstream& operator=(basic_stringstream&& _Right) noexcept /* strengthened */ {
         _Assign_rv(_STD move(_Right));
         return *this;
     }
 
-    void _Assign_rv(basic_stringstream&& _Right) {
+    void _Assign_rv(basic_stringstream&& _Right) noexcept {
         if (this != _STD addressof(_Right)) {
-            _Stringbuffer.str(_Mystr());
+            _Stringbuffer._Tidy();
+            _Stringbuffer.swap(_Right._Stringbuffer);
             this->swap(_Right);
         }
     }
 
-    void swap(basic_stringstream& _Right) {
+    void swap(basic_stringstream& _Right) noexcept /* strengthened */ {
         if (this != _STD addressof(_Right)) {
             _Mybase::swap(_Right);
             _Stringbuffer.swap(_Right._Stringbuffer);
@@ -845,7 +850,7 @@ public:
 
     ~basic_stringstream() noexcept override {}
 
-    _NODISCARD _Mysb* rdbuf() const {
+    _NODISCARD _Mysb* rdbuf() const noexcept /* strengthened */ {
         return const_cast<_Mysb*>(_STD addressof(_Stringbuffer));
     }
 
@@ -891,7 +896,8 @@ private:
 };
 
 _EXPORT_STD template <class _Elem, class _Traits, class _Alloc>
-void swap(basic_stringstream<_Elem, _Traits, _Alloc>& _Left, basic_stringstream<_Elem, _Traits, _Alloc>& _Right) {
+void swap(basic_stringstream<_Elem, _Traits, _Alloc>& _Left,
+    basic_stringstream<_Elem, _Traits, _Alloc>& _Right) noexcept /* strengthened */ {
     _Left.swap(_Right);
 }
 _STD_END

--- a/stl/inc/streambuf
+++ b/stl/inc/streambuf
@@ -25,7 +25,7 @@ protected:
         _Init();
     }
 
-    __CLR_OR_THIS_CALL basic_streambuf(_Uninitialized) {}
+    __CLR_OR_THIS_CALL basic_streambuf(_Uninitialized) noexcept {}
 
     __CLR_OR_THIS_CALL basic_streambuf(const basic_streambuf& _Right) : _Plocale(new locale(_Right.getloc())) {
         _Init();
@@ -42,7 +42,7 @@ protected:
         return *this;
     }
 
-    void __CLR_OR_THIS_CALL swap(basic_streambuf& _Right) {
+    void __CLR_OR_THIS_CALL swap(basic_streambuf& _Right) noexcept /* strengthened */ {
         if (this != _STD addressof(_Right)) {
             _Elem* _Pfirst0 = pbase();
             _Elem* _Pnext0  = pptr();
@@ -109,7 +109,7 @@ public:
         return _Oldlocale;
     }
 
-    locale __CLR_OR_THIS_CALL getloc() const { // get locale
+    locale __CLR_OR_THIS_CALL getloc() const noexcept /* strengthened */ { // get locale
         return *_Plocale;
     }
 
@@ -177,88 +177,92 @@ public:
     virtual void __CLR_OR_THIS_CALL _Unlock() {} // clear the thread lock (overridden by basic_filebuf)
 
 protected:
-    _Elem* __CLR_OR_THIS_CALL eback() const {
+    _Elem* __CLR_OR_THIS_CALL eback() const noexcept /* strengthened */ {
         return *_IGfirst;
     }
 
-    _Elem* __CLR_OR_THIS_CALL gptr() const {
+    _Elem* __CLR_OR_THIS_CALL gptr() const noexcept /* strengthened */ {
         return *_IGnext;
     }
 
-    _Elem* __CLR_OR_THIS_CALL pbase() const {
+    _Elem* __CLR_OR_THIS_CALL pbase() const noexcept /* strengthened */ {
         return *_IPfirst;
     }
 
-    _Elem* __CLR_OR_THIS_CALL pptr() const {
+    _Elem* __CLR_OR_THIS_CALL pptr() const noexcept /* strengthened */ {
         return *_IPnext;
     }
 
-    _Elem* __CLR_OR_THIS_CALL egptr() const {
+    _Elem* __CLR_OR_THIS_CALL egptr() const noexcept /* strengthened */ {
         return *_IGnext + *_IGcount;
     }
 
-    void __CLR_OR_THIS_CALL gbump(int _Off) { // alter current position in read buffer by _Off
+    void __CLR_OR_THIS_CALL gbump(int _Off) noexcept /* strengthened */ {
+        // alter current position in read buffer by _Off
         *_IGcount -= _Off;
         *_IGnext += _Off;
     }
 
-    void __CLR_OR_THIS_CALL setg(_Elem* _First, _Elem* _Next, _Elem* _Last) { // set pointers for read buffer
+    void __CLR_OR_THIS_CALL setg(_Elem* _First, _Elem* _Next, _Elem* _Last) noexcept /* strengthened */ {
+        // set pointers for read buffer
         *_IGfirst = _First;
         *_IGnext  = _Next;
         *_IGcount = static_cast<int>(_Last - _Next);
     }
 
-    _Elem* __CLR_OR_THIS_CALL epptr() const {
+    _Elem* __CLR_OR_THIS_CALL epptr() const noexcept /* strengthened */ {
         return *_IPnext + *_IPcount;
     }
 
-    _Elem* __CLR_OR_THIS_CALL _Gndec() { // decrement current position in read buffer
+    _Elem* __CLR_OR_THIS_CALL _Gndec() noexcept { // decrement current position in read buffer
         ++*_IGcount;
         return --*_IGnext;
     }
 
-    _Elem* __CLR_OR_THIS_CALL _Gninc() { // increment current position in read buffer
+    _Elem* __CLR_OR_THIS_CALL _Gninc() noexcept { // increment current position in read buffer
         --*_IGcount;
         return (*_IGnext)++;
     }
 
-    _Elem* __CLR_OR_THIS_CALL _Gnpreinc() { // preincrement current position in read buffer
+    _Elem* __CLR_OR_THIS_CALL _Gnpreinc() noexcept { // preincrement current position in read buffer
         --*_IGcount;
         return ++(*_IGnext);
     }
 
-    streamsize __CLR_OR_THIS_CALL _Gnavail() const { // count number of available elements in read buffer
+    streamsize __CLR_OR_THIS_CALL _Gnavail() const noexcept { // count number of available elements in read buffer
         return *_IGnext ? *_IGcount : 0;
     }
 
-    void __CLR_OR_THIS_CALL pbump(int _Off) { // alter current position in write buffer by _Off
+    void __CLR_OR_THIS_CALL pbump(int _Off) noexcept /* strengthened */ {
+        // alter current position in write buffer by _Off
         *_IPcount -= _Off;
         *_IPnext += _Off;
     }
 
-    void __CLR_OR_THIS_CALL setp(_Elem* _First, _Elem* _Last) { // set pointers for write buffer
+    void __CLR_OR_THIS_CALL setp(_Elem* _First, _Elem* _Last) noexcept /* strengthened */ {
+        // set pointers for write buffer
         *_IPfirst = _First;
         *_IPnext  = _First;
         *_IPcount = static_cast<int>(_Last - _First);
     }
 
-    void __CLR_OR_THIS_CALL setp(
-        _Elem* _First, _Elem* _Next, _Elem* _Last) { // set pointers for write buffer, extended version
+    void __CLR_OR_THIS_CALL setp(_Elem* _First, _Elem* _Next, _Elem* _Last) noexcept /* strengthened */ {
+        // set pointers for write buffer, extended version
         *_IPfirst = _First;
         *_IPnext  = _Next;
         *_IPcount = static_cast<int>(_Last - _Next);
     }
 
-    _Elem* __CLR_OR_THIS_CALL _Pninc() { // increment current position in write buffer
+    _Elem* __CLR_OR_THIS_CALL _Pninc() noexcept { // increment current position in write buffer
         --*_IPcount;
         return (*_IPnext)++;
     }
 
-    streamsize __CLR_OR_THIS_CALL _Pnavail() const { // count number of available positions in write buffer
+    streamsize __CLR_OR_THIS_CALL _Pnavail() const noexcept { // count number of available positions in write buffer
         return *_IPnext ? *_IPcount : 0;
     }
 
-    void __CLR_OR_THIS_CALL _Init() { // initialize buffer parameters for no buffers
+    void __CLR_OR_THIS_CALL _Init() noexcept { // initialize buffer parameters for no buffers
         _IGfirst = &_Gfirst;
         _IPfirst = &_Pfirst;
         _IGnext  = &_Gnext;
@@ -269,7 +273,7 @@ protected:
         setg(nullptr, nullptr, nullptr);
     }
 
-    void __CLR_OR_THIS_CALL _Init(_Elem** _Gf, _Elem** _Gn, int* _Gc, _Elem** _Pf, _Elem** _Pn, int* _Pc) {
+    void __CLR_OR_THIS_CALL _Init(_Elem** _Gf, _Elem** _Gn, int* _Gc, _Elem** _Pf, _Elem** _Pn, int* _Pc) noexcept {
         // initialize buffer parameters as specified
         _IGfirst = _Gf;
         _IPfirst = _Pf;

--- a/stl/inc/strstream
+++ b/stl/inc/strstream
@@ -271,8 +271,7 @@ protected:
         case ios_base::cur:
             {
                 constexpr auto _Both = ios_base::in | ios_base::out;
-                if ((_Which & _Both)
-                    == _Both) { // prohibited by N4928 [depr.strstreambuf.virtuals] Table 151 "seekoff positioning"
+                if ((_Which & _Both) == _Both) { // prohibited by N4928 [tab:depr.strstreambuf.seekoff.pos]
                     return pos_type(off_type(-1));
                 }
 

--- a/stl/inc/strstream
+++ b/stl/inc/strstream
@@ -73,19 +73,19 @@ public:
         _Assign_rv(_STD move(_Right));
     }
 
-    strstreambuf& __CLR_OR_THIS_CALL operator=(strstreambuf&& _Right) {
+    strstreambuf& __CLR_OR_THIS_CALL operator=(strstreambuf&& _Right) noexcept /* strengthened */ {
         _Assign_rv(_STD move(_Right));
         return *this;
     }
 
-    void __CLR_OR_THIS_CALL _Assign_rv(strstreambuf&& _Right) {
+    void __CLR_OR_THIS_CALL _Assign_rv(strstreambuf&& _Right) noexcept {
         if (this != _STD addressof(_Right)) {
             _Tidy();
             this->swap(_Right);
         }
     }
 
-    void __CLR_OR_THIS_CALL swap(strstreambuf& _Right) {
+    void __CLR_OR_THIS_CALL swap(strstreambuf& _Right) noexcept { // non-Standard
         if (this != _STD addressof(_Right)) {
             _Mysb::swap(_Right);
             _STD swap(_Minsize, _Right._Minsize);
@@ -101,7 +101,7 @@ public:
         _Tidy();
     }
 
-    void __CLR_OR_THIS_CALL freeze(bool _Freezeit = true) { // freeze or unfreeze writing
+    void __CLR_OR_THIS_CALL freeze(bool _Freezeit = true) noexcept /* strengthened */ { // freeze or unfreeze writing
         if (_Strmode & _Dynamic) {
             if (_Freezeit && !(_Strmode & _Frozen)) { // disable writing
                 _Strmode |= _Frozen;
@@ -114,12 +114,13 @@ public:
         }
     }
 
-    _NODISCARD char* __CLR_OR_THIS_CALL str() { // freeze and return pointer to character array
+    _NODISCARD char* __CLR_OR_THIS_CALL str() noexcept /* strengthened */ {
+        // freeze and return pointer to character array
         freeze();
         return eback();
     }
 
-    _NODISCARD streamsize __CLR_OR_THIS_CALL pcount() const {
+    _NODISCARD streamsize __CLR_OR_THIS_CALL pcount() const noexcept /* strengthened */ {
         return pptr() ? static_cast<streamsize>(pptr() - pbase()) : 0;
     }
 
@@ -134,7 +135,7 @@ public:
         _Init(_Count, const_cast<char*>(reinterpret_cast<const char*>(_Getptr)), nullptr, _Constant);
     }
 
-    void clear() { // free any allocated storage
+    void clear() noexcept /* strengthened */ { // free any allocated storage
         _Tidy();
     }
 
@@ -239,7 +240,7 @@ protected:
         }
 
         if ((_Which & ios_base::in && !gptr())
-            || (_Which & ios_base::out && !pptr())) { // N4727 [depr.strstreambuf.virtuals]/14:
+            || (_Which & ios_base::out && !pptr())) { // N4928 [depr.strstreambuf.virtuals]/15:
                                                       // For a sequence to be positioned, if its next pointer
                                                       // is a null pointer, the positioning operation fails.
             return pos_type(off_type(-1));
@@ -248,7 +249,7 @@ protected:
         const auto _Seeklow  = eback();
         const auto _Seekdist = _Seekhigh - _Seeklow;
 
-        // N4727 [depr.strstreambuf.virtuals]/15 effectively says check that the result will be in range
+        // N4928 [depr.strstreambuf.virtuals]/16 effectively says check that the result will be in range
         // [_Seeklow, _Seekhigh]; but we want to calculate this without potential integer overflow
         switch (_Way) {
         case ios_base::beg:
@@ -271,7 +272,7 @@ protected:
             {
                 constexpr auto _Both = ios_base::in | ios_base::out;
                 if ((_Which & _Both)
-                    == _Both) { // prohibited by N4727 [depr.strstreambuf.virtuals] Table 137 "seekoff positioning"
+                    == _Both) { // prohibited by N4928 [depr.strstreambuf.virtuals] Table 151 "seekoff positioning"
                     return pos_type(off_type(-1));
                 }
 
@@ -341,7 +342,7 @@ protected:
     }
 
     void __CLR_OR_THIS_CALL _Init(
-        streamsize _Count = 0, char* _Gp = nullptr, char* _Pp = nullptr, _Strstate _Mode = 0) {
+        streamsize _Count = 0, char* _Gp = nullptr, char* _Pp = nullptr, _Strstate _Mode = 0) noexcept {
         // initialize with possibly static buffer
         streambuf::_Init();
         _Minsize  = _MINSIZE;
@@ -417,7 +418,7 @@ private:
     void(__CLRCALL_OR_CDECL* _Pfree)(void*); // the pointer to free function
 };
 
-inline void swap(strstreambuf& _Left, strstreambuf& _Right) {
+inline void swap(strstreambuf& _Left, strstreambuf& _Right) noexcept { // non-Standard
     _Left.swap(_Right);
 }
 
@@ -448,19 +449,19 @@ public:
         _Assign_rv(_STD move(_Right));
     }
 
-    istrstream& __CLR_OR_THIS_CALL operator=(istrstream&& _Right) {
+    istrstream& __CLR_OR_THIS_CALL operator=(istrstream&& _Right) noexcept /* strengthened */ {
         _Assign_rv(_STD move(_Right));
         return *this;
     }
 
-    void __CLR_OR_THIS_CALL _Assign_rv(istrstream&& _Right) {
+    void __CLR_OR_THIS_CALL _Assign_rv(istrstream&& _Right) noexcept {
         if (this != _STD addressof(_Right)) {
             _Strbuffer.clear();
             this->swap(_Right);
         }
     }
 
-    void __CLR_OR_THIS_CALL swap(istrstream& _Right) {
+    void __CLR_OR_THIS_CALL swap(istrstream& _Right) noexcept { // non-Standard
         if (this != _STD addressof(_Right)) {
             _Mybase::swap(_Right);
             _Strbuffer.swap(_Right._Strbuffer);
@@ -469,11 +470,12 @@ public:
 
     __CLR_OR_THIS_CALL ~istrstream() noexcept override {}
 
-    _NODISCARD _Mysb* __CLR_OR_THIS_CALL rdbuf() const {
+    _NODISCARD _Mysb* __CLR_OR_THIS_CALL rdbuf() const noexcept /* strengthened */ {
         return const_cast<_Mysb*>(&_Strbuffer);
     }
 
-    _NODISCARD char* __CLR_OR_THIS_CALL str() { // freeze and return pointer to character array
+    _NODISCARD char* __CLR_OR_THIS_CALL str() noexcept /* strengthened */ {
+        // freeze and return pointer to character array
         return _Strbuffer.str();
     }
 
@@ -481,7 +483,7 @@ private:
     _Mysb _Strbuffer; // the string buffer
 };
 
-inline void swap(istrstream& _Left, istrstream& _Right) {
+inline void swap(istrstream& _Left, istrstream& _Right) noexcept { // non-Standard
     _Left.swap(_Right);
 }
 
@@ -503,19 +505,19 @@ public:
         _Assign_rv(_STD move(_Right));
     }
 
-    ostrstream& __CLR_OR_THIS_CALL operator=(ostrstream&& _Right) {
+    ostrstream& __CLR_OR_THIS_CALL operator=(ostrstream&& _Right) noexcept /* strengthened */ {
         _Assign_rv(_STD move(_Right));
         return *this;
     }
 
-    void __CLR_OR_THIS_CALL _Assign_rv(ostrstream&& _Right) {
+    void __CLR_OR_THIS_CALL _Assign_rv(ostrstream&& _Right) noexcept {
         if (this != _STD addressof(_Right)) {
             _Strbuffer.clear();
             this->swap(_Right);
         }
     }
 
-    void __CLR_OR_THIS_CALL swap(ostrstream& _Right) {
+    void __CLR_OR_THIS_CALL swap(ostrstream& _Right) noexcept { // non-Standard
         if (this != _STD addressof(_Right)) {
             _Mybase::swap(_Right);
             _Strbuffer.swap(_Right._Strbuffer);
@@ -524,19 +526,20 @@ public:
 
     __CLR_OR_THIS_CALL ~ostrstream() noexcept override {}
 
-    _NODISCARD _Mysb* __CLR_OR_THIS_CALL rdbuf() const {
+    _NODISCARD _Mysb* __CLR_OR_THIS_CALL rdbuf() const noexcept /* strengthened */ {
         return const_cast<_Mysb*>(&_Strbuffer);
     }
 
-    void __CLR_OR_THIS_CALL freeze(bool _Freezeit = true) { // freeze or unfreeze writing
+    void __CLR_OR_THIS_CALL freeze(bool _Freezeit = true) noexcept /* strengthened */ { // freeze or unfreeze writing
         _Strbuffer.freeze(_Freezeit);
     }
 
-    _NODISCARD char* __CLR_OR_THIS_CALL str() { // freeze and return pointer to character array
+    _NODISCARD char* __CLR_OR_THIS_CALL str() noexcept /* strengthened */ {
+        // freeze and return pointer to character array
         return _Strbuffer.str();
     }
 
-    _NODISCARD streamsize __CLR_OR_THIS_CALL pcount() const {
+    _NODISCARD streamsize __CLR_OR_THIS_CALL pcount() const noexcept /* strengthened */ {
         return _Strbuffer.pcount();
     }
 
@@ -544,7 +547,7 @@ private:
     _Mysb _Strbuffer; // the string buffer
 };
 
-inline void swap(ostrstream& _Left, ostrstream& _Right) {
+inline void swap(ostrstream& _Left, ostrstream& _Right) noexcept { // non-Standard
     _Left.swap(_Right);
 }
 
@@ -571,19 +574,19 @@ public:
         _Assign_rv(_STD move(_Right));
     }
 
-    strstream& __CLR_OR_THIS_CALL operator=(strstream&& _Right) {
+    strstream& __CLR_OR_THIS_CALL operator=(strstream&& _Right) noexcept /* strengthened */ {
         _Assign_rv(_STD move(_Right));
         return *this;
     }
 
-    void __CLR_OR_THIS_CALL _Assign_rv(strstream&& _Right) {
+    void __CLR_OR_THIS_CALL _Assign_rv(strstream&& _Right) noexcept {
         if (this != _STD addressof(_Right)) {
             _Strbuffer.clear();
             this->swap(_Right);
         }
     }
 
-    void __CLR_OR_THIS_CALL swap(strstream& _Right) {
+    void __CLR_OR_THIS_CALL swap(strstream& _Right) noexcept { // non-Standard
         if (this != _STD addressof(_Right)) {
             _Mybase::swap(_Right);
             _Strbuffer.swap(_Right._Strbuffer);
@@ -592,19 +595,20 @@ public:
 
     __CLR_OR_THIS_CALL ~strstream() noexcept override {}
 
-    _NODISCARD _Mysb* __CLR_OR_THIS_CALL rdbuf() const {
+    _NODISCARD _Mysb* __CLR_OR_THIS_CALL rdbuf() const noexcept /* strengthened */ {
         return const_cast<_Mysb*>(&_Strbuffer);
     }
 
-    void __CLR_OR_THIS_CALL freeze(bool _Freezeit = true) { // freeze or unfreeze writing
+    void __CLR_OR_THIS_CALL freeze(bool _Freezeit = true) noexcept /* strengthened */ { // freeze or unfreeze writing
         _Strbuffer.freeze(_Freezeit);
     }
 
-    _NODISCARD char* __CLR_OR_THIS_CALL str() { // freeze and return pointer to character array
+    _NODISCARD char* __CLR_OR_THIS_CALL str() noexcept /* strengthened */ {
+        // freeze and return pointer to character array
         return _Strbuffer.str();
     }
 
-    _NODISCARD streamsize __CLR_OR_THIS_CALL pcount() const {
+    _NODISCARD streamsize __CLR_OR_THIS_CALL pcount() const noexcept /* strengthened */ {
         return _Strbuffer.pcount();
     }
 
@@ -612,7 +616,7 @@ private:
     _Mysb _Strbuffer; // the string buffer
 };
 
-inline void swap(strstream& _Left, strstream& _Right) {
+inline void swap(strstream& _Left, strstream& _Right) noexcept { // non-Standard
     _Left.swap(_Right);
 }
 _STL_RESTORE_DEPRECATED_WARNING

--- a/stl/inc/syncstream
+++ b/stl/inc/syncstream
@@ -56,7 +56,7 @@ protected:
         _Swap(_Right);
     }
 
-    void _Swap(_Basic_syncbuf_impl& _Right) {
+    void _Swap(_Basic_syncbuf_impl& _Right) noexcept {
         _Mysb::swap(_Right);
         _STD swap(_Emit_on_sync, _Right._Emit_on_sync);
         _STD swap(_Sync_recorded, _Right._Sync_recorded);
@@ -145,7 +145,7 @@ public:
         return *this;
     }
 
-    void swap(basic_syncbuf& _Right) {
+    void swap(basic_syncbuf& _Right) noexcept /* strengthened */ {
         if (this != _STD addressof(_Right)) {
             _Pocs(_Getal(), _Right._Getal());
             _Swap_except_al(_Right);
@@ -255,7 +255,7 @@ private:
         }
     }
 
-    void _Swap_except_al(basic_syncbuf& _Right) {
+    void _Swap_except_al(basic_syncbuf& _Right) noexcept {
         _Mybase::_Swap(_Right);
         _STD swap(_Wrapped, _Right._Wrapped);
         _STD swap(_Get_mutex(), _Right._Get_mutex());
@@ -309,7 +309,8 @@ private:
 };
 
 _EXPORT_STD template <class _Elem, class _Traits, class _Alloc>
-void swap(basic_syncbuf<_Elem, _Traits, _Alloc>& _Left, basic_syncbuf<_Elem, _Traits, _Alloc>& _Right) {
+void swap(basic_syncbuf<_Elem, _Traits, _Alloc>& _Left, basic_syncbuf<_Elem, _Traits, _Alloc>& _Right) noexcept
+/* strengthened */ {
     _Left.swap(_Right);
 }
 

--- a/stl/inc/xiosbase
+++ b/stl/inc/xiosbase
@@ -231,11 +231,11 @@ public:
         static int& __cdecl _Init_cnt_func();
     };
 
-    explicit __CLR_OR_THIS_CALL operator bool() const {
+    explicit __CLR_OR_THIS_CALL operator bool() const noexcept /* strengthened */ {
         return !fail();
     }
 
-    _NODISCARD bool __CLR_OR_THIS_CALL operator!() const {
+    _NODISCARD bool __CLR_OR_THIS_CALL operator!() const noexcept /* strengthened */ {
         return fail();
     }
 
@@ -271,7 +271,7 @@ public:
     }
 #endif // _HAS_OLD_IOSTREAMS_MEMBERS
 
-    _NODISCARD iostate __CLR_OR_THIS_CALL rdstate() const {
+    _NODISCARD iostate __CLR_OR_THIS_CALL rdstate() const noexcept /* strengthened */ {
         return _Mystate;
     }
 
@@ -290,23 +290,23 @@ public:
     }
 #endif // _HAS_OLD_IOSTREAMS_MEMBERS
 
-    _NODISCARD bool __CLR_OR_THIS_CALL good() const {
+    _NODISCARD bool __CLR_OR_THIS_CALL good() const noexcept /* strengthened */ {
         return rdstate() == ios_base::goodbit;
     }
 
-    _NODISCARD bool __CLR_OR_THIS_CALL eof() const {
+    _NODISCARD bool __CLR_OR_THIS_CALL eof() const noexcept /* strengthened */ {
         return rdstate() & ios_base::eofbit;
     }
 
-    _NODISCARD bool __CLR_OR_THIS_CALL fail() const {
+    _NODISCARD bool __CLR_OR_THIS_CALL fail() const noexcept /* strengthened */ {
         return rdstate() & (ios_base::badbit | ios_base::failbit);
     }
 
-    _NODISCARD bool __CLR_OR_THIS_CALL bad() const {
+    _NODISCARD bool __CLR_OR_THIS_CALL bad() const noexcept /* strengthened */ {
         return rdstate() & ios_base::badbit;
     }
 
-    _NODISCARD iostate __CLR_OR_THIS_CALL exceptions() const {
+    _NODISCARD iostate __CLR_OR_THIS_CALL exceptions() const noexcept /* strengthened */ {
         return _Except;
     }
 
@@ -321,54 +321,59 @@ public:
     }
 #endif // _HAS_OLD_IOSTREAMS_MEMBERS
 
-    _NODISCARD fmtflags __CLR_OR_THIS_CALL flags() const {
+    _NODISCARD fmtflags __CLR_OR_THIS_CALL flags() const noexcept /* strengthened */ {
         return _Fmtfl;
     }
 
-    fmtflags __CLR_OR_THIS_CALL flags(fmtflags _Newfmtflags) { // set format flags to argument
+    fmtflags __CLR_OR_THIS_CALL flags(fmtflags _Newfmtflags) noexcept /* strengthened */ {
+        // set format flags to argument
         const fmtflags _Oldfmtflags = _Fmtfl;
         _Fmtfl                      = _Newfmtflags & _Fmtmask;
         return _Oldfmtflags;
     }
 
-    fmtflags __CLR_OR_THIS_CALL setf(fmtflags _Newfmtflags) { // merge in format flags argument
+    fmtflags __CLR_OR_THIS_CALL setf(fmtflags _Newfmtflags) noexcept /* strengthened */ {
+        // merge in format flags argument
         const ios_base::fmtflags _Oldfmtflags = _Fmtfl;
         _Fmtfl |= _Newfmtflags & _Fmtmask;
         return _Oldfmtflags;
     }
 
-    fmtflags __CLR_OR_THIS_CALL setf(
-        fmtflags _Newfmtflags, fmtflags _Mask) { // merge in format flags argument under mask argument
+    fmtflags __CLR_OR_THIS_CALL setf(fmtflags _Newfmtflags, fmtflags _Mask) noexcept /* strengthened */ {
+        // merge in format flags argument under mask argument
         const ios_base::fmtflags _Oldfmtflags = _Fmtfl;
         _Fmtfl                                = (_Oldfmtflags & ~_Mask) | (_Newfmtflags & _Mask & _Fmtmask);
         return _Oldfmtflags;
     }
 
-    void __CLR_OR_THIS_CALL unsetf(fmtflags _Mask) { // clear format flags under mask argument
+    void __CLR_OR_THIS_CALL unsetf(fmtflags _Mask) noexcept /* strengthened */ {
+        // clear format flags under mask argument
         _Fmtfl &= ~_Mask;
     }
 
-    _NODISCARD streamsize __CLR_OR_THIS_CALL precision() const {
+    _NODISCARD streamsize __CLR_OR_THIS_CALL precision() const noexcept /* strengthened */ {
         return _Prec;
     }
 
-    streamsize __CLR_OR_THIS_CALL precision(streamsize _Newprecision) { // set precision to argument
+    streamsize __CLR_OR_THIS_CALL precision(streamsize _Newprecision) noexcept /* strengthened */ {
+        // set precision to argument
         const streamsize _Oldprecision = _Prec;
         _Prec                          = _Newprecision;
         return _Oldprecision;
     }
 
-    _NODISCARD streamsize __CLR_OR_THIS_CALL width() const {
+    _NODISCARD streamsize __CLR_OR_THIS_CALL width() const noexcept /* strengthened */ {
         return _Wide;
     }
 
-    streamsize __CLR_OR_THIS_CALL width(streamsize _Newwidth) { // set width to argument
+    streamsize __CLR_OR_THIS_CALL width(streamsize _Newwidth) noexcept /* strengthened */ {
+        // set width to argument
         const streamsize _Oldwidth = _Wide;
         _Wide                      = _Newwidth;
         return _Oldwidth;
     }
 
-    _NODISCARD locale __CLR_OR_THIS_CALL getloc() const { // get locale
+    _NODISCARD locale __CLR_OR_THIS_CALL getloc() const noexcept /* strengthened */ { // get locale
         return *_Ploc;
     }
 
@@ -393,8 +398,8 @@ public:
         return _Findarr(_Idx)._Vp;
     }
 
-    void __CLR_OR_THIS_CALL register_callback(event_callback _Pfn,
-        int _Idx) { // register event handler
+    void __CLR_OR_THIS_CALL register_callback(event_callback _Pfn, int _Idx) {
+        // register event handler
         _Calls = new _Fnarray(_Idx, _Pfn, _Calls);
     }
 
@@ -424,8 +429,8 @@ public:
         return *this;
     }
 
-    static bool __CLRCALL_OR_CDECL sync_with_stdio(
-        bool _Newsync = true) { // set C/C++ synchronization flag from argument
+    static bool __CLRCALL_OR_CDECL sync_with_stdio(bool _Newsync = true) {
+        // set C/C++ synchronization flag from argument
         _BEGIN_LOCK(_LOCK_STREAM) // lock thread to ensure atomicity
         const bool _Oldsync = _Sync;
         _Sync               = _Newsync;
@@ -433,7 +438,7 @@ public:
         _END_LOCK()
     }
 
-    void __CLR_OR_THIS_CALL swap(ios_base& _Right) {
+    void __CLR_OR_THIS_CALL swap(ios_base& _Right) noexcept /* strengthened */ {
         if (this != _STD addressof(_Right)) {
             _STD swap(_Mystate, _Right._Mystate);
             _STD swap(_Except, _Right._Except);

--- a/tests/std/tests/GH_001858_iostream_exception/test.cpp
+++ b/tests/std/tests/GH_001858_iostream_exception/test.cpp
@@ -389,8 +389,10 @@ static_assert(is_nothrow_swappable_v<wstringstream>);
 static_assert(is_nothrow_swappable_v<syncbuf>);
 static_assert(is_nothrow_swappable_v<wsyncbuf>);
 
+#ifndef __EDG__
 static_assert(is_nothrow_move_assignable_v<osyncstream>); // mandatory
 static_assert(is_nothrow_move_assignable_v<wosyncstream>); // mandatory
+#endif // __EDG__
 
 static_assert(has_nothrow_rdbuf<osyncstream>); // mandatory
 static_assert(has_nothrow_rdbuf<wosyncstream>); // mandatory

--- a/tests/std/tests/GH_001858_iostream_exception/test.cpp
+++ b/tests/std/tests/GH_001858_iostream_exception/test.cpp
@@ -389,10 +389,7 @@ static_assert(is_nothrow_swappable_v<wstringstream>);
 static_assert(is_nothrow_swappable_v<syncbuf>);
 static_assert(is_nothrow_swappable_v<wsyncbuf>);
 
-#ifndef __EDG__
-static_assert(is_nothrow_move_assignable_v<osyncstream>); // mandatory
-static_assert(is_nothrow_move_assignable_v<wosyncstream>); // mandatory
-#endif // __EDG__
+// TRANSITION, GH-3355: "<syncstream>: is_nothrow_move_assignable_v<osyncstream> is squirrelly"
 
 static_assert(has_nothrow_rdbuf<osyncstream>); // mandatory
 static_assert(has_nothrow_rdbuf<wosyncstream>); // mandatory

--- a/tests/std/tests/GH_001858_iostream_exception/test.cpp
+++ b/tests/std/tests/GH_001858_iostream_exception/test.cpp
@@ -2,10 +2,24 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include <cassert>
+#include <fstream>
 #include <ios>
 #include <istream>
 #include <ostream>
+#include <sstream>
 #include <streambuf>
+#include <type_traits>
+#include <utility>
+
+#if _HAS_CXX20
+#include <syncstream>
+#endif // _HAS_CXX20
+
+#if _HAS_CXX23
+#include <spanstream>
+#endif // _HAS_CXX23
+
+#define STATIC_ASSERT(...) static_assert(#__VA_ARGS__)
 
 using namespace std;
 
@@ -208,6 +222,204 @@ void test_ostream_exceptions() {
         }
     }
 }
+
+// Also test strengthened and mandatory exception specifications.
+template <class, class = void>
+constexpr bool has_nothrow_rdbuf = false;
+
+template <class T>
+constexpr bool has_nothrow_rdbuf<T, void_t<decltype(declval<const T&>().rdbuf())>> =
+    noexcept(declval<const T&>().rdbuf());
+
+template <class, class = void>
+constexpr bool has_nothrow_is_open = false;
+
+template <class T>
+constexpr bool has_nothrow_is_open<T, void_t<decltype(declval<const T&>().is_open())>> =
+    noexcept(declval<const T&>().is_open());
+
+template <class, class = void>
+constexpr bool is_nothrow_std_swappable = false;
+
+template <class T>
+constexpr bool is_nothrow_std_swappable<T, void_t<decltype(std::swap(declval<T&>(), declval<T&>()))>> =
+    noexcept(std::swap(declval<T&>(), declval<T&>()));
+
+STATIC_ASSERT(noexcept(static_cast<bool>(cin)));
+STATIC_ASSERT(noexcept(!cin));
+
+STATIC_ASSERT(noexcept(cin.rdstate()));
+STATIC_ASSERT(noexcept(cin.good()));
+STATIC_ASSERT(noexcept(cin.eof()));
+STATIC_ASSERT(noexcept(cin.fail()));
+STATIC_ASSERT(noexcept(cin.bad()));
+STATIC_ASSERT(noexcept(cin.exceptions()));
+STATIC_ASSERT(noexcept(cin.flags()));
+STATIC_ASSERT(noexcept(cin.flags(ios_base::fmtflags{})));
+STATIC_ASSERT(noexcept(cin.setf(ios_base::fmtflags{})));
+STATIC_ASSERT(noexcept(cin.setf(ios_base::fmtflags{}, ios_base::fmtflags{})));
+STATIC_ASSERT(noexcept(cin.unsetf(ios_base::fmtflags{})));
+STATIC_ASSERT(noexcept(cin.precision()));
+STATIC_ASSERT(noexcept(cin.precision(0)));
+STATIC_ASSERT(noexcept(cin.width()));
+STATIC_ASSERT(noexcept(cin.width(0)));
+STATIC_ASSERT(noexcept(cin.getloc()));
+
+STATIC_ASSERT(noexcept(cin.tie()));
+STATIC_ASSERT(noexcept(cin.tie(nullptr)));
+
+STATIC_ASSERT(noexcept(cin.fill()));
+STATIC_ASSERT(noexcept(cin.fill('*')));
+
+STATIC_ASSERT(noexcept(cin.gcount()));
+
+STATIC_ASSERT(!has_nothrow_rdbuf<ios_base>);
+STATIC_ASSERT(!has_nothrow_is_open<ios_base>);
+
+STATIC_ASSERT(!is_nothrow_std_swappable<ios_base>);
+
+STATIC_ASSERT(!is_nothrow_std_swappable<streambuf>);
+STATIC_ASSERT(!is_nothrow_std_swappable<wstreambuf>);
+
+STATIC_ASSERT(has_nothrow_rdbuf<ios>);
+STATIC_ASSERT(has_nothrow_rdbuf<wios>);
+
+STATIC_ASSERT(has_nothrow_rdbuf<ifstream>);
+STATIC_ASSERT(has_nothrow_rdbuf<wifstream>);
+STATIC_ASSERT(has_nothrow_rdbuf<ofstream>);
+STATIC_ASSERT(has_nothrow_rdbuf<wofstream>);
+STATIC_ASSERT(has_nothrow_rdbuf<fstream>);
+STATIC_ASSERT(has_nothrow_rdbuf<wfstream>);
+
+STATIC_ASSERT(is_nothrow_std_swappable<filebuf>);
+STATIC_ASSERT(is_nothrow_std_swappable<wfilebuf>);
+STATIC_ASSERT(is_nothrow_std_swappable<ifstream>);
+STATIC_ASSERT(is_nothrow_std_swappable<wifstream>);
+STATIC_ASSERT(is_nothrow_std_swappable<ofstream>);
+STATIC_ASSERT(is_nothrow_std_swappable<wofstream>);
+STATIC_ASSERT(is_nothrow_std_swappable<fstream>);
+STATIC_ASSERT(is_nothrow_std_swappable<wfstream>);
+
+STATIC_ASSERT(has_nothrow_is_open<filebuf>);
+STATIC_ASSERT(has_nothrow_is_open<wfilebuf>);
+STATIC_ASSERT(has_nothrow_is_open<ifstream>);
+STATIC_ASSERT(has_nothrow_is_open<wifstream>);
+STATIC_ASSERT(has_nothrow_is_open<ofstream>);
+STATIC_ASSERT(has_nothrow_is_open<wofstream>);
+STATIC_ASSERT(has_nothrow_is_open<fstream>);
+STATIC_ASSERT(has_nothrow_is_open<wfstream>);
+
+STATIC_ASSERT(is_nothrow_move_assignable_v<stringbuf>);
+STATIC_ASSERT(is_nothrow_move_assignable_v<wstringbuf>);
+STATIC_ASSERT(is_nothrow_move_assignable_v<istringstream>);
+STATIC_ASSERT(is_nothrow_move_assignable_v<wistringstream>);
+STATIC_ASSERT(is_nothrow_move_assignable_v<ostringstream>);
+STATIC_ASSERT(is_nothrow_move_assignable_v<wostringstream>);
+STATIC_ASSERT(is_nothrow_move_assignable_v<stringstream>);
+STATIC_ASSERT(is_nothrow_move_assignable_v<wstringstream>);
+
+STATIC_ASSERT(is_nothrow_std_swappable<stringbuf>);
+STATIC_ASSERT(is_nothrow_std_swappable<wstringbuf>);
+STATIC_ASSERT(is_nothrow_std_swappable<istringstream>);
+STATIC_ASSERT(is_nothrow_std_swappable<wistringstream>);
+STATIC_ASSERT(is_nothrow_std_swappable<ostringstream>);
+STATIC_ASSERT(is_nothrow_std_swappable<wostringstream>);
+STATIC_ASSERT(is_nothrow_std_swappable<stringstream>);
+STATIC_ASSERT(is_nothrow_std_swappable<wstringstream>);
+
+STATIC_ASSERT(has_nothrow_rdbuf<istringstream>);
+STATIC_ASSERT(has_nothrow_rdbuf<wistringstream>);
+STATIC_ASSERT(has_nothrow_rdbuf<ostringstream>);
+STATIC_ASSERT(has_nothrow_rdbuf<wostringstream>);
+STATIC_ASSERT(has_nothrow_rdbuf<stringstream>);
+STATIC_ASSERT(has_nothrow_rdbuf<wstringstream>);
+
+STATIC_ASSERT(is_nothrow_move_assignable_v<strstreambuf>);
+STATIC_ASSERT(is_nothrow_move_assignable_v<istrstream>);
+STATIC_ASSERT(is_nothrow_move_assignable_v<ostrstream>);
+STATIC_ASSERT(is_nothrow_move_assignable_v<strstream>);
+
+STATIC_ASSERT(noexcept(declval<strstreambuf&>().clear()));
+
+STATIC_ASSERT(noexcept(declval<strstreambuf&>().freeze()));
+STATIC_ASSERT(noexcept(declval<istrstream&>().freeze()));
+STATIC_ASSERT(noexcept(declval<ostrstream&>().freeze()));
+STATIC_ASSERT(noexcept(declval<strstream&>().freeze()));
+
+STATIC_ASSERT(noexcept(declval<strstreambuf&>().str()));
+STATIC_ASSERT(noexcept(declval<istrstream&>().str()));
+STATIC_ASSERT(noexcept(declval<ostrstream&>().str()));
+STATIC_ASSERT(noexcept(declval<strstream&>().str()));
+
+STATIC_ASSERT(noexcept(declval<strstreambuf&>().pcount()));
+STATIC_ASSERT(noexcept(declval<istrstream&>().pcount()));
+STATIC_ASSERT(noexcept(declval<ostrstream&>().pcount()));
+STATIC_ASSERT(noexcept(declval<strstream&>().pcount()));
+
+#if !_HAS_CXX23 // non-Standard overloads
+STATIC_ASSERT(is_nothrow_std_swappable<strstreambuf>);
+STATIC_ASSERT(is_nothrow_std_swappable<istrstream>);
+STATIC_ASSERT(is_nothrow_std_swappable<ostrstream>);
+STATIC_ASSERT(is_nothrow_std_swappable<strstream>);
+#endif // !_HAS_CXX23
+
+#if _HAS_CXX17
+static_assert(is_nothrow_swappable_v<filebuf>);
+static_assert(is_nothrow_swappable_v<wfilebuf>);
+static_assert(is_nothrow_swappable_v<ifstream>);
+static_assert(is_nothrow_swappable_v<wifstream>);
+static_assert(is_nothrow_swappable_v<ofstream>);
+static_assert(is_nothrow_swappable_v<wofstream>);
+static_assert(is_nothrow_swappable_v<fstream>);
+static_assert(is_nothrow_swappable_v<wfstream>);
+
+static_assert(is_nothrow_swappable_v<stringbuf>);
+static_assert(is_nothrow_swappable_v<wstringbuf>);
+static_assert(is_nothrow_swappable_v<istringstream>);
+static_assert(is_nothrow_swappable_v<wistringstream>);
+static_assert(is_nothrow_swappable_v<ostringstream>);
+static_assert(is_nothrow_swappable_v<wostringstream>);
+static_assert(is_nothrow_swappable_v<stringstream>);
+static_assert(is_nothrow_swappable_v<wstringstream>);
+#endif // _HAS_CXX17
+
+#if _HAS_CXX20
+static_assert(is_nothrow_swappable_v<syncbuf>);
+static_assert(is_nothrow_swappable_v<wsyncbuf>);
+
+static_assert(is_nothrow_move_assignable_v<osyncstream>); // mandatory
+static_assert(is_nothrow_move_assignable_v<wosyncstream>); // mandatory
+
+static_assert(has_nothrow_rdbuf<osyncstream>); // mandatory
+static_assert(has_nothrow_rdbuf<wosyncstream>); // mandatory
+#endif // _HAS_CXX20
+
+#if _HAS_CXX23
+static_assert(is_nothrow_swappable_v<spanbuf>);
+static_assert(is_nothrow_swappable_v<wspanbuf>);
+static_assert(is_nothrow_swappable_v<ispanstream>);
+static_assert(is_nothrow_swappable_v<wispanstream>);
+static_assert(is_nothrow_swappable_v<ospanstream>);
+static_assert(is_nothrow_swappable_v<wospanstream>);
+static_assert(is_nothrow_swappable_v<spanstream>);
+static_assert(is_nothrow_swappable_v<wspanstream>);
+
+static_assert(is_nothrow_move_assignable_v<spanbuf>);
+static_assert(is_nothrow_move_assignable_v<wspanbuf>);
+static_assert(is_nothrow_move_assignable_v<ispanstream>);
+static_assert(is_nothrow_move_assignable_v<wispanstream>);
+static_assert(is_nothrow_move_assignable_v<ospanstream>);
+static_assert(is_nothrow_move_assignable_v<wospanstream>);
+static_assert(is_nothrow_move_assignable_v<spanstream>);
+static_assert(is_nothrow_move_assignable_v<wspanstream>);
+
+static_assert(has_nothrow_rdbuf<ispanstream>); // mandatory
+static_assert(has_nothrow_rdbuf<wispanstream>); // mandatory
+static_assert(has_nothrow_rdbuf<ospanstream>); // mandatory
+static_assert(has_nothrow_rdbuf<wospanstream>); // mandatory
+static_assert(has_nothrow_rdbuf<spanstream>); // mandatory
+static_assert(has_nothrow_rdbuf<wspanstream>); // mandatory
+#endif // _HAS_CXX23
 
 int main() {
     test_istream_exceptions<char>();

--- a/tests/std/tests/GH_001858_iostream_exception/test.cpp
+++ b/tests/std/tests/GH_001858_iostream_exception/test.cpp
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#define _SILENCE_CXX17_STRSTREAM_DEPRECATION_WARNING
+
 #include <cassert>
 #include <fstream>
 #include <ios>
@@ -9,6 +11,7 @@
 #include <ostream>
 #include <sstream>
 #include <streambuf>
+#include <strstream>
 #include <type_traits>
 #include <utility>
 

--- a/tests/std/tests/GH_001858_iostream_exception/test.cpp
+++ b/tests/std/tests/GH_001858_iostream_exception/test.cpp
@@ -4,6 +4,7 @@
 #include <cassert>
 #include <fstream>
 #include <ios>
+#include <iostream>
 #include <istream>
 #include <ostream>
 #include <sstream>
@@ -19,7 +20,7 @@
 #include <spanstream>
 #endif // _HAS_CXX23
 
-#define STATIC_ASSERT(...) static_assert(#__VA_ARGS__)
+#define STATIC_ASSERT(...) static_assert(__VA_ARGS__, #__VA_ARGS__)
 
 using namespace std;
 
@@ -342,7 +343,6 @@ STATIC_ASSERT(is_nothrow_move_assignable_v<strstream>);
 STATIC_ASSERT(noexcept(declval<strstreambuf&>().clear()));
 
 STATIC_ASSERT(noexcept(declval<strstreambuf&>().freeze()));
-STATIC_ASSERT(noexcept(declval<istrstream&>().freeze()));
 STATIC_ASSERT(noexcept(declval<ostrstream&>().freeze()));
 STATIC_ASSERT(noexcept(declval<strstream&>().freeze()));
 
@@ -352,7 +352,6 @@ STATIC_ASSERT(noexcept(declval<ostrstream&>().str()));
 STATIC_ASSERT(noexcept(declval<strstream&>().str()));
 
 STATIC_ASSERT(noexcept(declval<strstreambuf&>().pcount()));
-STATIC_ASSERT(noexcept(declval<istrstream&>().pcount()));
 STATIC_ASSERT(noexcept(declval<ostrstream&>().pcount()));
 STATIC_ASSERT(noexcept(declval<strstream&>().pcount()));
 


### PR DESCRIPTION
This PR partially addresses #3278, but also strengthens exception specifications for some other functions. References to working draft are also updated to WG21-N4928.

Move assignment operators and `swap` functions are generally marked with `noexcept`. But I think move assignment operators of `basic_filebuf` and `basic_(i|o)fstream` shouldn't be `noexcept`, because they call `basic_filebuf::close` which may in turn call virtual functions that are possibly overridden. In other words, exception may be thrown from these move assignment operators. `basic_syncbuf`'s should neither be `noexcept` due to LWG-3498.

Many move constructors remain non-`noexcept`, because they need to _copy-construct_ a `basic_streambuf`, and hence need to dynamically allocate storage for `locale`. Maybe we should fix this in vNext.

----

Currently EDG wrongly calculates `std::is_nothrow_move_assignable_v<std::osyncstream>` and `std::is_nothrow_move_assignable_v<std::wosyncstream>` as `false`, so these two `static_assert`s are skipped for EDG.