### PR TITLE
Fix handling of array rvalues for `ranges::cbegin` and its friends

### DIFF
--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -2497,7 +2497,7 @@ namespace ranges {
     concept _Range_accessible_and_end_adaptable =
         _Should_range_access<_Ty>
         && requires {
-               const_iterator<_End_adapted<_Ty>>{_RANGES end(_RANGES _Possibly_const_range(_STD declval<_Ty&>()))};
+               const_sentinel<_End_adapted<_Ty>>{_RANGES end(_RANGES _Possibly_const_range(_STD declval<_Ty&>()))};
            };
 #endif // _HAS_CXX23
 
@@ -2702,7 +2702,7 @@ namespace ranges {
     concept _Range_accessible_and_rend_adaptable =
         _Should_range_access<_Ty>
         && requires {
-               const_iterator<_Begin_adapted<_Ty>>{_RANGES rend(_RANGES _Possibly_const_range(_STD declval<_Ty&>()))};
+               const_sentinel<_Begin_adapted<_Ty>>{_RANGES rend(_RANGES _Possibly_const_range(_STD declval<_Ty&>()))};
            };
 #endif // _HAS_CXX23
 

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -2481,29 +2481,32 @@ namespace ranges {
     }
 
     template <class _Ty>
-    using _Begin_adapted = decltype(_RANGES begin(_RANGES _Possibly_const_range(_STD declval<_Ty&>())));
+    using _Begin_on_const = decltype(_RANGES begin(_RANGES _Possibly_const_range(_STD declval<_Ty&>())));
 
+    // TRANSITION, LLVM-55945
     template <class _Ty>
     concept _Range_accessible_and_begin_adaptable =
         _Should_range_access<_Ty>
         && requires(
-            _Ty& _Val) { const_iterator<_Begin_adapted<_Ty>>{_RANGES begin(_RANGES _Possibly_const_range(_Val))}; };
+            _Ty& _Val) { const_iterator<_Begin_on_const<_Ty>>{_RANGES begin(_RANGES _Possibly_const_range(_Val))}; };
 
     template <class _Ty>
-    using _End_adapted = decltype(_RANGES end(_RANGES _Possibly_const_range(_STD declval<_Ty&>())));
+    using _End_on_const = decltype(_RANGES end(_RANGES _Possibly_const_range(_STD declval<_Ty&>())));
 
+    // TRANSITION, LLVM-55945
     template <class _Ty>
     concept _Range_accessible_and_end_adaptable =
         _Should_range_access<_Ty>
-        && requires(_Ty& _Val) { const_sentinel<_End_adapted<_Ty>>{_RANGES end(_RANGES _Possibly_const_range(_Val))}; };
+        && requires(
+            _Ty& _Val) { const_sentinel<_End_on_const<_Ty>>{_RANGES end(_RANGES _Possibly_const_range(_Val))}; };
 #endif // _HAS_CXX23
 
     struct _Cbegin_fn {
 #if _HAS_CXX23
         template <_Range_accessible_and_begin_adaptable _Ty>
         _NODISCARD constexpr auto operator()(_Ty&& _Val) const noexcept(
-            noexcept(const_iterator<_Begin_adapted<_Ty>>{_RANGES begin(_RANGES _Possibly_const_range(_Val))})) {
-            return const_iterator<_Begin_adapted<_Ty>>{_RANGES begin(_RANGES _Possibly_const_range(_Val))};
+            noexcept(const_iterator<_Begin_on_const<_Ty>>{_RANGES begin(_RANGES _Possibly_const_range(_Val))})) {
+            return const_iterator<_Begin_on_const<_Ty>>{_RANGES begin(_RANGES _Possibly_const_range(_Val))};
         }
 #else // ^^^ C++23 / C++20 vvv
         template <class _Ty, class _CTy = _Const_thru_ref<_Ty>>
@@ -2524,8 +2527,8 @@ namespace ranges {
 #if _HAS_CXX23
         template <_Range_accessible_and_end_adaptable _Ty>
         _NODISCARD constexpr auto operator()(_Ty&& _Val) const
-            noexcept(noexcept(const_sentinel<_End_adapted<_Ty>>{_RANGES end(_RANGES _Possibly_const_range(_Val))})) {
-            return const_sentinel<_End_adapted<_Ty>>{_RANGES end(_RANGES _Possibly_const_range(_Val))};
+            noexcept(noexcept(const_sentinel<_End_on_const<_Ty>>{_RANGES end(_RANGES _Possibly_const_range(_Val))})) {
+            return const_sentinel<_End_on_const<_Ty>>{_RANGES end(_RANGES _Possibly_const_range(_Val))};
         }
 #else // ^^^ C++23 / C++20 vvv
         template <class _Ty, class _CTy = _Const_thru_ref<_Ty>>
@@ -2683,30 +2686,32 @@ namespace ranges {
 
 #if _HAS_CXX23
     template <class _Ty>
-    using _Rbegin_adapted = decltype(_RANGES rbegin(_RANGES _Possibly_const_range(_STD declval<_Ty&>())));
+    using _Rbegin_on_const = decltype(_RANGES rbegin(_RANGES _Possibly_const_range(_STD declval<_Ty&>())));
 
+    // TRANSITION, LLVM-55945
     template <class _Ty>
     concept _Range_accessible_and_rbegin_adaptable =
         _Should_range_access<_Ty>
         && requires(
-            _Ty& _Val) { const_iterator<_Rbegin_adapted<_Ty>>{_RANGES rbegin(_RANGES _Possibly_const_range(_Val))}; };
+            _Ty& _Val) { const_iterator<_Rbegin_on_const<_Ty>>{_RANGES rbegin(_RANGES _Possibly_const_range(_Val))}; };
 
     template <class _Ty>
-    using _Rend_adapted = decltype(_RANGES rend(_RANGES _Possibly_const_range(_STD declval<_Ty&>())));
+    using _Rend_on_const = decltype(_RANGES rend(_RANGES _Possibly_const_range(_STD declval<_Ty&>())));
 
+    // TRANSITION, LLVM-55945
     template <class _Ty>
     concept _Range_accessible_and_rend_adaptable =
         _Should_range_access<_Ty>
         && requires(
-            _Ty& _Val) { const_sentinel<_Rend_adapted<_Ty>>{_RANGES rend(_RANGES _Possibly_const_range(_Val))}; };
+            _Ty& _Val) { const_sentinel<_Rend_on_const<_Ty>>{_RANGES rend(_RANGES _Possibly_const_range(_Val))}; };
 #endif // _HAS_CXX23
 
     struct _Crbegin_fn {
 #if _HAS_CXX23
         template <_Range_accessible_and_rbegin_adaptable _Ty>
         _NODISCARD constexpr auto operator()(_Ty&& _Val) const noexcept(
-            noexcept(const_iterator<_Rbegin_adapted<_Ty>>{_RANGES rbegin(_RANGES _Possibly_const_range(_Val))})) {
-            return const_iterator<_Rbegin_adapted<_Ty>>{_RANGES rbegin(_RANGES _Possibly_const_range(_Val))};
+            noexcept(const_iterator<_Rbegin_on_const<_Ty>>{_RANGES rbegin(_RANGES _Possibly_const_range(_Val))})) {
+            return const_iterator<_Rbegin_on_const<_Ty>>{_RANGES rbegin(_RANGES _Possibly_const_range(_Val))};
         }
 #else // ^^^ C++23 / C++20 vvv
         template <class _Ty, class _CTy = _Const_thru_ref<_Ty>>
@@ -2727,8 +2732,8 @@ namespace ranges {
 #if _HAS_CXX23
         template <_Range_accessible_and_rend_adaptable _Ty>
         _NODISCARD constexpr auto operator()(_Ty&& _Val) const
-            noexcept(noexcept(const_sentinel<_Rend_adapted<_Ty>>{_RANGES rend(_RANGES _Possibly_const_range(_Val))})) {
-            return const_sentinel<_Rend_adapted<_Ty>>{_RANGES rend(_RANGES _Possibly_const_range(_Val))};
+            noexcept(noexcept(const_sentinel<_Rend_on_const<_Ty>>{_RANGES rend(_RANGES _Possibly_const_range(_Val))})) {
+            return const_sentinel<_Rend_on_const<_Ty>>{_RANGES rend(_RANGES _Possibly_const_range(_Val))};
         }
 #else // ^^^ C++23 / C++20 vvv
         template <class _Ty, class _CTy = _Const_thru_ref<_Ty>>
@@ -2948,6 +2953,7 @@ namespace ranges {
     }
 
 #if _HAS_CXX23
+    // TRANSITION, LLVM-55945
     template <class _Ty>
     concept _Range_accessible_and_data_adaptable =
         _Should_range_access<_Ty>

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -2479,19 +2479,35 @@ namespace ranges {
     _NODISCARD constexpr auto _As_const_pointer(const _Ty* _Ptr) noexcept {
         return _Ptr;
     }
+
+    template <class _Ty>
+    using _Begin_adapted = decltype(_RANGES begin(_RANGES _Possibly_const_range(_STD declval<_Ty&>())));
+
+    template <class _Ty>
+    concept _Range_accessible_and_begin_adaptable =
+        _Should_range_access<_Ty>
+        && requires {
+               const_iterator<_Begin_adapted<_Ty>>{_RANGES begin(_RANGES _Possibly_const_range(_STD declval<_Ty>()))};
+           };
+
+    template <class _Ty>
+    using _End_adapted = decltype(_RANGES end(_RANGES _Possibly_const_range(_STD declval<_Ty&>())));
+
+    template <class _Ty>
+    concept _Range_accessible_and_end_adaptable =
+        _Should_range_access<_Ty>
+        && requires {
+               const_iterator<_End_adapted<_Ty>>{_RANGES end(_RANGES _Possibly_const_range(_STD declval<_Ty>()))};
+           };
 #endif // _HAS_CXX23
 
     struct _Cbegin_fn {
 #if _HAS_CXX23
-        template <class _Ty>
-        using _Adapted = decltype(_RANGES begin(_RANGES _Possibly_const_range(_STD declval<_Ty&>())));
-
-        template <_Should_range_access _Ty>
+        template <_Range_accessible_and_begin_adaptable _Ty>
         _NODISCARD constexpr auto operator()(_Ty&& _Val) const
-            noexcept(noexcept(const_iterator<_Adapted<_Ty>>{_RANGES begin(_RANGES _Possibly_const_range(_Val))}))
-            requires requires { const_iterator<_Adapted<_Ty>>{_RANGES begin(_RANGES _Possibly_const_range(_Val))}; }
+            noexcept(noexcept(const_iterator<_Begin_adapted<_Ty>>{_RANGES begin(_RANGES _Possibly_const_range(_Val))}))
         {
-            return const_iterator<_Adapted<_Ty>>{_RANGES begin(_RANGES _Possibly_const_range(_Val))};
+            return const_iterator<_Begin_adapted<_Ty>>{_RANGES begin(_RANGES _Possibly_const_range(_Val))};
         }
 #else // ^^^ C++23 / C++20 vvv
         template <class _Ty, class _CTy = _Const_thru_ref<_Ty>>
@@ -2510,15 +2526,11 @@ namespace ranges {
 
     struct _Cend_fn {
 #if _HAS_CXX23
-        template <class _Ty>
-        using _Adapted = decltype(_RANGES end(_RANGES _Possibly_const_range(_STD declval<_Ty&>())));
-
-        template <_Should_range_access _Ty>
+        template <_Range_accessible_and_end_adaptable _Ty>
         _NODISCARD constexpr auto operator()(_Ty&& _Val) const
-            noexcept(noexcept(const_sentinel<_Adapted<_Ty>>{_RANGES end(_RANGES _Possibly_const_range(_Val))}))
-            requires requires { const_sentinel<_Adapted<_Ty>>{_RANGES end(_RANGES _Possibly_const_range(_Val))}; }
+            noexcept(noexcept(const_sentinel<_End_adapted<_Ty>>{_RANGES end(_RANGES _Possibly_const_range(_Val))}))
         {
-            return const_sentinel<_Adapted<_Ty>>{_RANGES end(_RANGES _Possibly_const_range(_Val))};
+            return const_sentinel<_End_adapted<_Ty>>{_RANGES end(_RANGES _Possibly_const_range(_Val))};
         }
 #else // ^^^ C++23 / C++20 vvv
         template <class _Ty, class _CTy = _Const_thru_ref<_Ty>>
@@ -2674,17 +2686,35 @@ namespace ranges {
         _EXPORT_STD inline constexpr _Rend::_Cpo rend;
     }
 
+#if _HAS_CXX23
+    template <class _Ty>
+    using _Rbegin_adapted = decltype(_RANGES rbegin(_RANGES _Possibly_const_range(_STD declval<_Ty&>())));
+
+    template <class _Ty>
+    concept _Range_accessible_and_rbegin_adaptable =
+        _Should_range_access<_Ty>
+        && requires {
+               const_iterator<_Rbegin_adapted<_Ty>>{_RANGES rbegin(_RANGES _Possibly_const_range(_STD declval<_Ty>()))};
+           };
+
+    template <class _Ty>
+    using _Rend_adapted = decltype(_RANGES rend(_RANGES _Possibly_const_range(_STD declval<_Ty&>())));
+
+    template <class _Ty>
+    concept _Range_accessible_and_rend_adaptable =
+        _Should_range_access<_Ty>
+        && requires {
+               const_iterator<_Begin_adapted<_Ty>>{_RANGES rend(_RANGES _Possibly_const_range(_STD declval<_Ty>()))};
+           };
+#endif // _HAS_CXX23
+
     struct _Crbegin_fn {
 #if _HAS_CXX23
-        template <class _Ty>
-        using _Adapted = decltype(_RANGES rbegin(_RANGES _Possibly_const_range(_STD declval<_Ty&>())));
-
-        template <_Should_range_access _Ty>
-        _NODISCARD constexpr auto operator()(_Ty&& _Val) const
-            noexcept(noexcept(const_iterator<_Adapted<_Ty>>{_RANGES rbegin(_RANGES _Possibly_const_range(_Val))}))
-            requires requires { const_iterator<_Adapted<_Ty>>{_RANGES rbegin(_RANGES _Possibly_const_range(_Val))}; }
+        template <_Range_accessible_and_rbegin_adaptable _Ty>
+        _NODISCARD constexpr auto operator()(_Ty&& _Val) const noexcept(
+            noexcept(const_iterator<_Rbegin_adapted<_Ty>>{_RANGES rbegin(_RANGES _Possibly_const_range(_Val))}))
         {
-            return const_iterator<_Adapted<_Ty>>{_RANGES rbegin(_RANGES _Possibly_const_range(_Val))};
+            return const_iterator<_Rbegin_adapted<_Ty>>{_RANGES rbegin(_RANGES _Possibly_const_range(_Val))};
         }
 #else // ^^^ C++23 / C++20 vvv
         template <class _Ty, class _CTy = _Const_thru_ref<_Ty>>
@@ -2703,15 +2733,11 @@ namespace ranges {
 
     struct _Crend_fn {
 #if _HAS_CXX23
-        template <class _Ty>
-        using _Adapted = decltype(_RANGES rend(_RANGES _Possibly_const_range(_STD declval<_Ty&>())));
-
-        template <_Should_range_access _Ty>
+        template <_Range_accessible_and_rend_adaptable _Ty>
         _NODISCARD constexpr auto operator()(_Ty&& _Val) const
-            noexcept(noexcept(const_sentinel<_Adapted<_Ty>>{_RANGES rend(_RANGES _Possibly_const_range(_Val))}))
-            requires requires { const_sentinel<_Adapted<_Ty>>{_RANGES rend(_RANGES _Possibly_const_range(_Val))}; }
+            noexcept(noexcept(const_sentinel<_Rend_adapted<_Ty>>{_RANGES rend(_RANGES _Possibly_const_range(_Val))}))
         {
-            return const_sentinel<_Adapted<_Ty>>{_RANGES rend(_RANGES _Possibly_const_range(_Val))};
+            return const_sentinel<_Rend_adapted<_Ty>>{_RANGES rend(_RANGES _Possibly_const_range(_Val))};
         }
 #else // ^^^ C++23 / C++20 vvv
         template <class _Ty, class _CTy = _Const_thru_ref<_Ty>>

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -2486,9 +2486,8 @@ namespace ranges {
     template <class _Ty>
     concept _Range_accessible_and_begin_adaptable =
         _Should_range_access<_Ty>
-        && requires {
-               const_iterator<_Begin_adapted<_Ty>>{_RANGES begin(_RANGES _Possibly_const_range(_STD declval<_Ty&>()))};
-           };
+        && requires(
+            _Ty& _Val) { const_iterator<_Begin_adapted<_Ty>>{_RANGES begin(_RANGES _Possibly_const_range(_Val))}; };
 
     template <class _Ty>
     using _End_adapted = decltype(_RANGES end(_RANGES _Possibly_const_range(_STD declval<_Ty&>())));
@@ -2496,9 +2495,7 @@ namespace ranges {
     template <class _Ty>
     concept _Range_accessible_and_end_adaptable =
         _Should_range_access<_Ty>
-        && requires {
-               const_sentinel<_End_adapted<_Ty>>{_RANGES end(_RANGES _Possibly_const_range(_STD declval<_Ty&>()))};
-           };
+        && requires(_Ty& _Val) { const_sentinel<_End_adapted<_Ty>>{_RANGES end(_RANGES _Possibly_const_range(_Val))}; };
 #endif // _HAS_CXX23
 
     struct _Cbegin_fn {
@@ -2690,10 +2687,9 @@ namespace ranges {
 
     template <class _Ty>
     concept _Range_accessible_and_rbegin_adaptable =
-        _Should_range_access<_Ty> && requires {
-                                         const_iterator<_Rbegin_adapted<_Ty>>{
-                                             _RANGES rbegin(_RANGES _Possibly_const_range(_STD declval<_Ty&>()))};
-                                     };
+        _Should_range_access<_Ty>
+        && requires(
+            _Ty& _Val) { const_iterator<_Rbegin_adapted<_Ty>>{_RANGES rbegin(_RANGES _Possibly_const_range(_Val))}; };
 
     template <class _Ty>
     using _Rend_adapted = decltype(_RANGES rend(_RANGES _Possibly_const_range(_STD declval<_Ty&>())));
@@ -2701,9 +2697,8 @@ namespace ranges {
     template <class _Ty>
     concept _Range_accessible_and_rend_adaptable =
         _Should_range_access<_Ty>
-        && requires {
-               const_sentinel<_Rend_adapted<_Ty>>{_RANGES rend(_RANGES _Possibly_const_range(_STD declval<_Ty&>()))};
-           };
+        && requires(
+            _Ty& _Val) { const_sentinel<_Rend_adapted<_Ty>>{_RANGES rend(_RANGES _Possibly_const_range(_Val))}; };
 #endif // _HAS_CXX23
 
     struct _Crbegin_fn {
@@ -2952,13 +2947,18 @@ namespace ranges {
         _EXPORT_STD inline constexpr _Data::_Cpo data;
     }
 
+#if _HAS_CXX23
+    template <class _Ty>
+    concept _Range_accessible_and_data_adaptable =
+        _Should_range_access<_Ty>
+        && requires(_Ty& _Val) { _RANGES _As_const_pointer(_RANGES data(_RANGES _Possibly_const_range(_Val))); };
+#endif // _HAS_CXX23
+
     struct _Cdata_fn {
 #if _HAS_CXX23
-        template <_Should_range_access _Ty>
+        template <_Range_accessible_and_data_adaptable _Ty>
         _NODISCARD constexpr auto operator()(_Ty&& _Val) const
-            noexcept(noexcept(_RANGES data(_RANGES _Possibly_const_range(_Val))))
-            requires requires { _RANGES _As_const_pointer(_RANGES data(_RANGES _Possibly_const_range(_Val))); }
-        {
+            noexcept(noexcept(_RANGES data(_RANGES _Possibly_const_range(_Val)))) {
             return _RANGES _As_const_pointer(_RANGES data(_RANGES _Possibly_const_range(_Val)));
         }
 #else // ^^^ C++23 / C++20 vvv

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -2702,7 +2702,7 @@ namespace ranges {
     concept _Range_accessible_and_rend_adaptable =
         _Should_range_access<_Ty>
         && requires {
-               const_sentinel<_Begin_adapted<_Ty>>{_RANGES rend(_RANGES _Possibly_const_range(_STD declval<_Ty&>()))};
+               const_sentinel<_Rend_adapted<_Ty>>{_RANGES rend(_RANGES _Possibly_const_range(_STD declval<_Ty&>()))};
            };
 #endif // _HAS_CXX23
 

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -2504,9 +2504,8 @@ namespace ranges {
     struct _Cbegin_fn {
 #if _HAS_CXX23
         template <_Range_accessible_and_begin_adaptable _Ty>
-        _NODISCARD constexpr auto operator()(_Ty&& _Val) const
-            noexcept(noexcept(const_iterator<_Begin_adapted<_Ty>>{_RANGES begin(_RANGES _Possibly_const_range(_Val))}))
-        {
+        _NODISCARD constexpr auto operator()(_Ty&& _Val) const noexcept(
+            noexcept(const_iterator<_Begin_adapted<_Ty>>{_RANGES begin(_RANGES _Possibly_const_range(_Val))})) {
             return const_iterator<_Begin_adapted<_Ty>>{_RANGES begin(_RANGES _Possibly_const_range(_Val))};
         }
 #else // ^^^ C++23 / C++20 vvv
@@ -2528,8 +2527,7 @@ namespace ranges {
 #if _HAS_CXX23
         template <_Range_accessible_and_end_adaptable _Ty>
         _NODISCARD constexpr auto operator()(_Ty&& _Val) const
-            noexcept(noexcept(const_sentinel<_End_adapted<_Ty>>{_RANGES end(_RANGES _Possibly_const_range(_Val))}))
-        {
+            noexcept(noexcept(const_sentinel<_End_adapted<_Ty>>{_RANGES end(_RANGES _Possibly_const_range(_Val))})) {
             return const_sentinel<_End_adapted<_Ty>>{_RANGES end(_RANGES _Possibly_const_range(_Val))};
         }
 #else // ^^^ C++23 / C++20 vvv
@@ -2712,8 +2710,7 @@ namespace ranges {
 #if _HAS_CXX23
         template <_Range_accessible_and_rbegin_adaptable _Ty>
         _NODISCARD constexpr auto operator()(_Ty&& _Val) const noexcept(
-            noexcept(const_iterator<_Rbegin_adapted<_Ty>>{_RANGES rbegin(_RANGES _Possibly_const_range(_Val))}))
-        {
+            noexcept(const_iterator<_Rbegin_adapted<_Ty>>{_RANGES rbegin(_RANGES _Possibly_const_range(_Val))})) {
             return const_iterator<_Rbegin_adapted<_Ty>>{_RANGES rbegin(_RANGES _Possibly_const_range(_Val))};
         }
 #else // ^^^ C++23 / C++20 vvv
@@ -2735,8 +2732,7 @@ namespace ranges {
 #if _HAS_CXX23
         template <_Range_accessible_and_rend_adaptable _Ty>
         _NODISCARD constexpr auto operator()(_Ty&& _Val) const
-            noexcept(noexcept(const_sentinel<_Rend_adapted<_Ty>>{_RANGES rend(_RANGES _Possibly_const_range(_Val))}))
-        {
+            noexcept(noexcept(const_sentinel<_Rend_adapted<_Ty>>{_RANGES rend(_RANGES _Possibly_const_range(_Val))})) {
             return const_sentinel<_Rend_adapted<_Ty>>{_RANGES rend(_RANGES _Possibly_const_range(_Val))};
         }
 #else // ^^^ C++23 / C++20 vvv

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -2483,13 +2483,15 @@ namespace ranges {
 
     struct _Cbegin_fn {
 #if _HAS_CXX23
-        template <_Should_range_access _Ty,
-            class _Uty = decltype(_RANGES begin(_RANGES _Possibly_const_range(_STD declval<_Ty&>())))>
+        template <class _Ty>
+        using _Adapted = decltype(_RANGES begin(_RANGES _Possibly_const_range(_STD declval<_Ty&>())));
+
+        template <_Should_range_access _Ty>
         _NODISCARD constexpr auto operator()(_Ty&& _Val) const
-            noexcept(noexcept(const_iterator<_Uty>{_RANGES begin(_RANGES _Possibly_const_range(_Val))}))
-            requires requires { const_iterator<_Uty>{_RANGES begin(_RANGES _Possibly_const_range(_Val))}; }
+            noexcept(noexcept(const_iterator<_Adapted<_Ty>>{_RANGES begin(_RANGES _Possibly_const_range(_Val))}))
+            requires requires { const_iterator<_Adapted<_Ty>>{_RANGES begin(_RANGES _Possibly_const_range(_Val))}; }
         {
-            return const_iterator<_Uty>{_RANGES begin(_RANGES _Possibly_const_range(_Val))};
+            return const_iterator<_Adapted<_Ty>>{_RANGES begin(_RANGES _Possibly_const_range(_Val))};
         }
 #else // ^^^ C++23 / C++20 vvv
         template <class _Ty, class _CTy = _Const_thru_ref<_Ty>>
@@ -2508,13 +2510,15 @@ namespace ranges {
 
     struct _Cend_fn {
 #if _HAS_CXX23
-        template <_Should_range_access _Ty,
-            class _Uty = decltype(_RANGES end(_RANGES _Possibly_const_range(_STD declval<_Ty&>())))>
+        template <class _Ty>
+        using _Adapted = decltype(_RANGES end(_RANGES _Possibly_const_range(_STD declval<_Ty&>())));
+
+        template <_Should_range_access _Ty>
         _NODISCARD constexpr auto operator()(_Ty&& _Val) const
-            noexcept(noexcept(const_sentinel<_Uty>{_RANGES end(_RANGES _Possibly_const_range(_Val))}))
-            requires requires { const_sentinel<_Uty>{_RANGES end(_RANGES _Possibly_const_range(_Val))}; }
+            noexcept(noexcept(const_sentinel<_Adapted<_Ty>>{_RANGES end(_RANGES _Possibly_const_range(_Val))}))
+            requires requires { const_sentinel<_Adapted<_Ty>>{_RANGES end(_RANGES _Possibly_const_range(_Val))}; }
         {
-            return const_sentinel<_Uty>{_RANGES end(_RANGES _Possibly_const_range(_Val))};
+            return const_sentinel<_Adapted<_Ty>>{_RANGES end(_RANGES _Possibly_const_range(_Val))};
         }
 #else // ^^^ C++23 / C++20 vvv
         template <class _Ty, class _CTy = _Const_thru_ref<_Ty>>
@@ -2672,13 +2676,15 @@ namespace ranges {
 
     struct _Crbegin_fn {
 #if _HAS_CXX23
-        template <_Should_range_access _Ty,
-            class _Uty = decltype(_RANGES rbegin(_RANGES _Possibly_const_range(_STD declval<_Ty&>())))>
+        template <class _Ty>
+        using _Adapted = decltype(_RANGES rbegin(_RANGES _Possibly_const_range(_STD declval<_Ty&>())));
+
+        template <_Should_range_access _Ty>
         _NODISCARD constexpr auto operator()(_Ty&& _Val) const
-            noexcept(noexcept(const_iterator<_Uty>{_RANGES rbegin(_RANGES _Possibly_const_range(_Val))}))
-            requires requires { const_iterator<_Uty>{_RANGES rbegin(_RANGES _Possibly_const_range(_Val))}; }
+            noexcept(noexcept(const_iterator<_Adapted<_Ty>>{_RANGES rbegin(_RANGES _Possibly_const_range(_Val))}))
+            requires requires { const_iterator<_Adapted<_Ty>>{_RANGES rbegin(_RANGES _Possibly_const_range(_Val))}; }
         {
-            return const_iterator<_Uty>{_RANGES rbegin(_RANGES _Possibly_const_range(_Val))};
+            return const_iterator<_Adapted<_Ty>>{_RANGES rbegin(_RANGES _Possibly_const_range(_Val))};
         }
 #else // ^^^ C++23 / C++20 vvv
         template <class _Ty, class _CTy = _Const_thru_ref<_Ty>>
@@ -2697,13 +2703,15 @@ namespace ranges {
 
     struct _Crend_fn {
 #if _HAS_CXX23
-        template <_Should_range_access _Ty,
-            class _Uty = decltype(_RANGES rend(_RANGES _Possibly_const_range(_STD declval<_Ty&>())))>
+        template <class _Ty>
+        using _Adapted = decltype(_RANGES rend(_RANGES _Possibly_const_range(_STD declval<_Ty&>())));
+
+        template <_Should_range_access _Ty>
         _NODISCARD constexpr auto operator()(_Ty&& _Val) const
-            noexcept(noexcept(const_sentinel<_Uty>{_RANGES rend(_RANGES _Possibly_const_range(_Val))}))
-            requires requires { const_sentinel<_Uty>{_RANGES rend(_RANGES _Possibly_const_range(_Val))}; }
+            noexcept(noexcept(const_sentinel<_Adapted<_Ty>>{_RANGES rend(_RANGES _Possibly_const_range(_Val))}))
+            requires requires { const_sentinel<_Adapted<_Ty>>{_RANGES rend(_RANGES _Possibly_const_range(_Val))}; }
         {
-            return const_sentinel<_Uty>{_RANGES rend(_RANGES _Possibly_const_range(_Val))};
+            return const_sentinel<_Adapted<_Ty>>{_RANGES rend(_RANGES _Possibly_const_range(_Val))};
         }
 #else // ^^^ C++23 / C++20 vvv
         template <class _Ty, class _CTy = _Const_thru_ref<_Ty>>

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -2487,7 +2487,7 @@ namespace ranges {
     concept _Range_accessible_and_begin_adaptable =
         _Should_range_access<_Ty>
         && requires {
-               const_iterator<_Begin_adapted<_Ty>>{_RANGES begin(_RANGES _Possibly_const_range(_STD declval<_Ty>()))};
+               const_iterator<_Begin_adapted<_Ty>>{_RANGES begin(_RANGES _Possibly_const_range(_STD declval<_Ty&>()))};
            };
 
     template <class _Ty>
@@ -2497,7 +2497,7 @@ namespace ranges {
     concept _Range_accessible_and_end_adaptable =
         _Should_range_access<_Ty>
         && requires {
-               const_iterator<_End_adapted<_Ty>>{_RANGES end(_RANGES _Possibly_const_range(_STD declval<_Ty>()))};
+               const_iterator<_End_adapted<_Ty>>{_RANGES end(_RANGES _Possibly_const_range(_STD declval<_Ty&>()))};
            };
 #endif // _HAS_CXX23
 
@@ -2690,10 +2690,10 @@ namespace ranges {
 
     template <class _Ty>
     concept _Range_accessible_and_rbegin_adaptable =
-        _Should_range_access<_Ty>
-        && requires {
-               const_iterator<_Rbegin_adapted<_Ty>>{_RANGES rbegin(_RANGES _Possibly_const_range(_STD declval<_Ty>()))};
-           };
+        _Should_range_access<_Ty> && requires {
+                                         const_iterator<_Rbegin_adapted<_Ty>>{
+                                             _RANGES rbegin(_RANGES _Possibly_const_range(_STD declval<_Ty&>()))};
+                                     };
 
     template <class _Ty>
     using _Rend_adapted = decltype(_RANGES rend(_RANGES _Possibly_const_range(_STD declval<_Ty&>())));
@@ -2702,7 +2702,7 @@ namespace ranges {
     concept _Range_accessible_and_rend_adaptable =
         _Should_range_access<_Ty>
         && requires {
-               const_iterator<_Begin_adapted<_Ty>>{_RANGES rend(_RANGES _Possibly_const_range(_STD declval<_Ty>()))};
+               const_iterator<_Begin_adapted<_Ty>>{_RANGES rend(_RANGES _Possibly_const_range(_STD declval<_Ty&>()))};
            };
 #endif // _HAS_CXX23
 

--- a/tests/std/tests/P0896R4_ranges_range_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_range_machinery/test.cpp
@@ -660,6 +660,20 @@ struct initially_incomplete;
 extern initially_incomplete array_of_incomplete[42];
 STATIC_ASSERT(ranges::size(array_of_incomplete) == 42);
 STATIC_ASSERT(!ranges::empty(array_of_incomplete));
+
+// begin, end, rbegin, rend, and data (and their c variations) should reject rvalues of array of incomplete elements
+// with substitution failures
+STATIC_ASSERT(!CanBegin<initially_incomplete (&&)[42]>);
+STATIC_ASSERT(!CanCBegin<initially_incomplete (&&)[42]>);
+STATIC_ASSERT(!CanEnd<initially_incomplete (&&)[42]>);
+STATIC_ASSERT(!CanCEnd<initially_incomplete (&&)[42]>);
+STATIC_ASSERT(!CanRBegin<initially_incomplete (&&)[42]>);
+STATIC_ASSERT(!CanCRBegin<initially_incomplete (&&)[42]>);
+STATIC_ASSERT(!CanREnd<initially_incomplete (&&)[42]>);
+STATIC_ASSERT(!CanCREnd<initially_incomplete (&&)[42]>);
+STATIC_ASSERT(!CanData<initially_incomplete (&&)[42]>);
+STATIC_ASSERT(!CanCData<initially_incomplete (&&)[42]>);
+
 struct initially_incomplete {};
 initially_incomplete array_of_incomplete[42];
 


### PR DESCRIPTION
When the argument is an _rvalue_ of an array, `ranges::cbegin`, `ranges::cend`, `ranges::crbegin`, and `ranges::crend` should reject it with substitution failures, despite of whether the element type is complete or not. I think such requirements haven't been changed by [P2278R4](https://wg21.link/p2278r4) (i.e. unchanged between C++20 and C++23).

(On the other hand, if the argument is an _lvalue_ of an array of an incomplete element type, the program is ill-formed, no diagnostic required.)

I originally discovered the bug of implementation in https://github.com/microsoft/STL/pull/3187#discussion_r1011340383, but hadn't determined how to fix it at that time. 

----
Clang 15 is buggy - it fails to perform shortcut in concept substitution when using requires-clause. This is probably LLVM-55945 and fixed in Clang 16 ([Godbolt link](https://godbolt.org/z/W75M6h9Ph)).

The current workaround is combining constraints into one concept and using the abbreviated syntax.