### PR TITLE
Implement LWG-3736 `move_iterator` missing `disable_sized_sentinel_for` specialization

### DIFF
--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -4241,6 +4241,10 @@ _NODISCARD _CONSTEXPR17 move_iterator<_Iter> make_move_iterator(_Iter _It) noexc
 }
 
 #ifdef __cpp_lib_concepts
+template <class _Iter1, class _Iter2>
+    requires (!sized_sentinel_for<_Iter1, _Iter2>)
+inline constexpr bool disable_sized_sentinel_for<move_iterator<_Iter1>, move_iterator<_Iter2>> = true;
+
 _EXPORT_STD struct default_sentinel_t {};
 
 _EXPORT_STD inline constexpr default_sentinel_t default_sentinel{};

--- a/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
@@ -3411,6 +3411,26 @@ namespace move_iterator_test {
         return true;
     }
     STATIC_ASSERT(test());
+
+    // Validate disable_sized_sentinel_for partial specialization for move_iterator (LWG-3736)
+    struct weird_difference_base {
+        template <class T>
+        long operator-(T const&) const {
+            return 42;
+        }
+
+        bool operator==(weird_difference_base const&) const = default;
+    };
+    using simple_no_difference = simple_bidi_iter<weird_difference_base>;
+} // namespace move_iterator_test
+
+template <>
+inline constexpr bool std::disable_sized_sentinel_for<move_iterator_test::simple_no_difference,
+    move_iterator_test::simple_no_difference> = true;
+
+namespace move_iterator_test {
+    STATIC_ASSERT(!std::sized_sentinel_for<simple_no_difference, simple_no_difference>);
+    STATIC_ASSERT(!std::sized_sentinel_for<move_iterator<simple_no_difference>, move_iterator<simple_no_difference>>);
 } // namespace move_iterator_test
 
 namespace counted_iterator_test {


### PR DESCRIPTION
Fixes #3222.