### PR TITLE
Implement LWG-3785 `ranges::to` is over-constrained on the destination type being a range

### DIFF
--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -7668,7 +7668,8 @@ namespace ranges {
     // clang-format on
 
     template <class _Rng, class _Container>
-    concept _Ref_converts = convertible_to<range_reference_t<_Rng>, range_value_t<_Container>>;
+    concept _Ref_converts =
+        (!input_range<_Container>) || convertible_to<range_reference_t<_Rng>, range_value_t<_Container>>;
 
     template <class _Rng, class _Container, class... _Types>
     concept _Converts_direct_constructible = _Ref_converts<_Rng, _Container> //

--- a/tests/std/tests/P1206R7_ranges_to_misc/test.cpp
+++ b/tests/std/tests/P1206R7_ranges_to_misc/test.cpp
@@ -3,6 +3,7 @@
 
 #include <cassert>
 #include <cstddef>
+#include <optional>
 #include <ranges>
 #include <vector>
 
@@ -136,6 +137,28 @@ constexpr bool test_nested_range() {
     return true;
 }
 
+constexpr bool test_lwg3785() {
+    std::vector<int> vec{42, 1729};
+
+    auto expe1 = ranges::to<std::optional<std::vector<int>>>(vec);
+    assert(expe1.has_value());
+    assert(*expe1 == vec);
+
+    auto expe2 = vec | ranges::to<std::optional<std::vector<int>>>();
+    assert(expe2.has_value());
+    assert(*expe2 == vec);
+
+    auto expe3 = ranges::to<std::optional>(vec);
+    assert(expe3.has_value());
+    assert(*expe3 == vec);
+
+    auto expe4 = vec | ranges::to<std::optional>();
+    assert(expe4.has_value());
+    assert(*expe4 == vec);
+
+    return true;
+}
+
 int main() {
     test_reservable();
     static_assert(test_reservable());
@@ -147,4 +170,7 @@ int main() {
 #if defined(__clang__) || defined(__EDG__) // TRANSITION, VSO-1588614
     static_assert(test_nested_range());
 #endif // defined(__clang__) || defined(__EDG__)
+
+    test_lwg3785();
+    static_assert(test_lwg3785());
 }


### PR DESCRIPTION
Fixes #3227.

I failed to figure out how to "convert a range of `expected<T, E>` to `expected<vector<T>, E>`" with `ranges::to`, so I just added some trivial test cases...