### PR TITLE
Implement LWG-3737 `take_view::sentinel` should provide `operator-`

### DIFF
--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -2626,7 +2626,7 @@ namespace ranges {
                 }
             } else if constexpr (sized_sentinel_for<sentinel_t<_Vw>, iterator_t<_Vw>>) {
                 auto _Iter       = _RANGES begin(_Range);
-                const auto _Size = _STD min(_Count, _RANGES end(_Range) - _Iter);
+                const auto _Size = (_STD min)(_Count, _RANGES end(_Range) - _Iter);
                 return counted_iterator(_STD move(_Iter), _Size);
             } else {
                 return counted_iterator(_RANGES begin(_Range), _Count);
@@ -2645,7 +2645,7 @@ namespace ranges {
                 }
             } else if constexpr (sized_sentinel_for<sentinel_t<const _Vw>, iterator_t<const _Vw>>) {
                 auto _Iter       = _RANGES begin(_Range);
-                const auto _Size = _STD min(_Count, _RANGES end(_Range) - _Iter);
+                const auto _Size = (_STD min)(_Count, _RANGES end(_Range) - _Iter);
                 return counted_iterator(_STD move(_Iter), _Size);
             } else {
                 return counted_iterator(_RANGES begin(_Range), _Count);

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -2624,6 +2624,10 @@ namespace ranges {
                     const auto _Size = static_cast<range_difference_t<_Vw>>(size());
                     return counted_iterator(_RANGES begin(_Range), _Size);
                 }
+            } else if constexpr (sized_sentinel_for<sentinel_t<_Vw>, iterator_t<_Vw>>) {
+                auto _Iter       = _RANGES begin(_Range);
+                const auto _Size = _STD min(_Count, _RANGES end(_Range) - _Iter);
+                return counted_iterator(_STD move(_Iter), _Size);
             } else {
                 return counted_iterator(_RANGES begin(_Range), _Count);
             }
@@ -2639,6 +2643,10 @@ namespace ranges {
                     const auto _Size = static_cast<range_difference_t<_Vw>>(size());
                     return counted_iterator(_RANGES begin(_Range), _Size);
                 }
+            } else if constexpr (sized_sentinel_for<sentinel_t<const _Vw>, iterator_t<const _Vw>>) {
+                auto _Iter       = _RANGES begin(_Range);
+                const auto _Size = _STD min(_Count, _RANGES end(_Range) - _Iter);
+                return counted_iterator(_STD move(_Iter), _Size);
             } else {
                 return counted_iterator(_RANGES begin(_Range), _Count);
             }
@@ -2653,6 +2661,8 @@ namespace ranges {
                 } else {
                     return default_sentinel;
                 }
+            } else if constexpr (sized_sentinel_for<sentinel_t<_Vw>, iterator_t<_Vw>>) {
+                return default_sentinel;
             } else {
                 return _Sentinel<false>{_RANGES end(_Range)};
             }
@@ -2667,6 +2677,8 @@ namespace ranges {
                 } else {
                     return default_sentinel;
                 }
+            } else if constexpr (sized_sentinel_for<sentinel_t<const _Vw>, iterator_t<const _Vw>>) {
+                return default_sentinel;
             } else {
                 return _Sentinel<true>{_RANGES end(_Range)};
             }

--- a/tests/std/tests/P0896R4_views_take/test.cpp
+++ b/tests/std/tests/P0896R4_views_take/test.cpp
@@ -508,6 +508,7 @@ void test_DevCom_1397309() {
 
     assert(ranges::equal(values | ranges::views::take(2) | ranges::views::keys, expected));
 }
+
 struct read_some_int_range : ranges::subrange<counted_iterator<istream_iterator<int>>, default_sentinel_t> {
     using ranges::subrange<counted_iterator<istream_iterator<int>>, default_sentinel_t>::subrange;
 };
@@ -535,9 +536,7 @@ void test_lwg3737() {
     static_assert(is_same_v<ranges::sentinel_t<const result_range>, default_sentinel_t>);
 
     vector<int> vec{};
-    for (const int elem : rng) {
-        vec.push_back(elem);
-    }
+    ranges::copy(rng, back_inserter(vec));
 
     assert(ranges::size(vec) == 2);
     assert((vec == vector<int>{0, 1}));

--- a/tests/std/tests/P0896R4_views_take/test.cpp
+++ b/tests/std/tests/P0896R4_views_take/test.cpp
@@ -534,7 +534,11 @@ void test_lwg3737() {
         is_same_v<ranges::iterator_t<const result_range>, counted_iterator<counted_iterator<istream_iterator<int>>>>);
     static_assert(is_same_v<ranges::sentinel_t<const result_range>, default_sentinel_t>);
 
-    vector<int> vec{from_range, rng};
+    vector<int> vec{};
+    for (const int elem : rng) {
+        vec.push_back(elem);
+    }
+
     assert(ranges::size(vec) == 2);
     assert((vec == vector<int>{0, 1}));
 }

--- a/tests/std/tests/P0896R4_views_take/test.cpp
+++ b/tests/std/tests/P0896R4_views_take/test.cpp
@@ -7,6 +7,8 @@
 #include <map>
 #include <ranges>
 #include <span>
+#include <sstream>
+#include <string>
 #include <string_view>
 #include <type_traits>
 #include <utility>
@@ -506,6 +508,36 @@ void test_DevCom_1397309() {
 
     assert(ranges::equal(values | ranges::views::take(2) | ranges::views::keys, expected));
 }
+struct read_some_int_range : ranges::subrange<counted_iterator<istream_iterator<int>>, default_sentinel_t> {
+    using ranges::subrange<counted_iterator<istream_iterator<int>>, default_sentinel_t>::subrange;
+};
+
+template <>
+inline constexpr bool ranges::disable_sized_range<read_some_int_range> = true;
+
+void test_lwg3737() {
+    static_assert(ranges::input_range<read_some_int_range>);
+    static_assert(ranges::input_range<const read_some_int_range>);
+    static_assert(!ranges::sized_range<read_some_int_range>);
+    static_assert(!ranges::sized_range<const read_some_int_range>);
+
+    istringstream stream{"0 1 42 1729"};
+    auto rng =
+        read_some_int_range{counted_iterator{istream_iterator<int>{stream}, 4}, default_sentinel} | views::take(2);
+
+    using result_range = decltype(rng);
+    static_assert(
+        is_same_v<ranges::iterator_t<result_range>, counted_iterator<counted_iterator<istream_iterator<int>>>>);
+    static_assert(is_same_v<ranges::sentinel_t<result_range>, default_sentinel_t>);
+
+    static_assert(
+        is_same_v<ranges::iterator_t<const result_range>, counted_iterator<counted_iterator<istream_iterator<int>>>>);
+    static_assert(is_same_v<ranges::sentinel_t<const result_range>, default_sentinel_t>);
+
+    vector<int> vec{from_range, rng};
+    assert(ranges::size(vec) == 2);
+    assert((vec == vector<int>{0, 1}));
+}
 
 int main() {
     // Validate views
@@ -576,4 +608,6 @@ int main() {
     }
 
     test_DevCom_1397309();
+
+    test_lwg3737();
 }


### PR DESCRIPTION
Fixes #3223.

(`counted_iterator<counted_iterator<T>>` seems a bit messy. Should I add a prettier test case?)