### PR TITLE
P2165R4: Compatibility Between `tuple`, `pair`, And tuple-like Objects (changes to `pair` only)

### DIFF
--- a/stl/inc/__msvc_iter_core.hpp
+++ b/stl/inc/__msvc_iter_core.hpp
@@ -8,7 +8,11 @@
 #define __MSVC_ITER_CORE_HPP
 #include <yvals_core.h>
 #if _STL_COMPILER_PREPROCESSOR
-#include <utility>
+#include <type_traits>
+
+#ifdef __cpp_lib_concepts
+#include <concepts>
+#endif // __cpp_lib_concepts
 
 #pragma pack(push, _CRT_PACKING)
 #pragma warning(push, _STL_WARNING_LEVEL)
@@ -28,6 +32,29 @@ _EXPORT_STD struct forward_iterator_tag : input_iterator_tag {};
 _EXPORT_STD struct bidirectional_iterator_tag : forward_iterator_tag {};
 
 _EXPORT_STD struct random_access_iterator_tag : bidirectional_iterator_tag {};
+
+// from <utility>
+_EXPORT_STD template <class _Tuple>
+struct tuple_size;
+
+_EXPORT_STD template <size_t _Index, class _Tuple>
+struct tuple_element;
+
+#if _HAS_CXX20
+#ifdef __cpp_lib_concepts
+template <class _Ty>
+using _With_reference = _Ty&;
+
+template <class _Ty>
+concept _Can_reference = requires { typename _With_reference<_Ty>; };
+#else // ^^^ __cpp_lib_concepts / vvv !__cpp_lib_concepts
+template <class _Ty, class = void>
+inline constexpr bool _Can_reference = false;
+
+template <class _Ty>
+inline constexpr bool _Can_reference<_Ty, void_t<_Ty&>> = true;
+#endif // !__cpp_lib_concepts
+#endif // _HAS_CXX20
 
 #ifdef __cpp_lib_concepts
 _EXPORT_STD struct contiguous_iterator_tag : random_access_iterator_tag {};

--- a/stl/inc/__msvc_iter_core.hpp
+++ b/stl/inc/__msvc_iter_core.hpp
@@ -8,11 +8,7 @@
 #define __MSVC_ITER_CORE_HPP
 #include <yvals_core.h>
 #if _STL_COMPILER_PREPROCESSOR
-#include <type_traits>
-
-#ifdef __cpp_lib_concepts
-#include <concepts>
-#endif // __cpp_lib_concepts
+#include <utility>
 
 #pragma pack(push, _CRT_PACKING)
 #pragma warning(push, _STL_WARNING_LEVEL)
@@ -32,29 +28,6 @@ _EXPORT_STD struct forward_iterator_tag : input_iterator_tag {};
 _EXPORT_STD struct bidirectional_iterator_tag : forward_iterator_tag {};
 
 _EXPORT_STD struct random_access_iterator_tag : bidirectional_iterator_tag {};
-
-// from <utility>
-_EXPORT_STD template <class _Tuple>
-struct tuple_size;
-
-_EXPORT_STD template <size_t _Index, class _Tuple>
-struct tuple_element;
-
-#if _HAS_CXX20
-#ifdef __cpp_lib_concepts
-template <class _Ty>
-using _With_reference = _Ty&;
-
-template <class _Ty>
-concept _Can_reference = requires { typename _With_reference<_Ty>; };
-#else // ^^^ __cpp_lib_concepts / vvv !__cpp_lib_concepts
-template <class _Ty, class = void>
-inline constexpr bool _Can_reference = false;
-
-template <class _Ty>
-inline constexpr bool _Can_reference<_Ty, void_t<_Ty&>> = true;
-#endif // !__cpp_lib_concepts
-#endif // _HAS_CXX20
 
 #ifdef __cpp_lib_concepts
 _EXPORT_STD struct contiguous_iterator_tag : random_access_iterator_tag {};
@@ -455,6 +428,9 @@ namespace ranges {
 } // namespace ranges
 
 _EXPORT_STD using ranges::get;
+
+template <class _It, class _Se, ranges::subrange_kind _Ki>
+inline constexpr bool _Is_subrange_v<ranges::subrange<_It, _Se, _Ki>> = true;
 
 template <class _It, class _Se, ranges::subrange_kind _Ki>
 struct tuple_size<ranges::subrange<_It, _Se, _Ki>> : integral_constant<size_t, 2> {};

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -2694,11 +2694,6 @@ namespace ranges {
     inline constexpr bool enable_borrowed_range<take_view<_Rng>> = enable_borrowed_range<_Rng>;
 
     namespace views {
-        template <class>
-        inline constexpr bool _Is_subrange = false;
-        template <class _It, class _Se, subrange_kind _Ki>
-        inline constexpr bool _Is_subrange<subrange<_It, _Se, _Ki>> = true;
-
         template <class _Rng>
         concept _Random_sized_range = random_access_range<_Rng> && sized_range<_Rng>;
 
@@ -2726,7 +2721,7 @@ namespace ranges {
                 } else if constexpr (_Random_sized_range<_Ty> && _Is_specialization_v<_Ty, iota_view>) {
                     return {_St::_Reconstruct_iota_view,
                         noexcept(_RANGES begin(_STD declval<_Rng&>()) + _RANGES distance(_STD declval<_Rng&>()))};
-                } else if constexpr (_Random_sized_range<_Ty> && _Is_subrange<_Ty>) {
+                } else if constexpr (_Random_sized_range<_Ty> && _Is_subrange_v<_Ty>) {
                     return {_St::_Reconstruct_subrange,
                         noexcept(subrange(_RANGES begin(_STD declval<_Rng&>()),
                             _RANGES begin(_STD declval<_Rng&>()) + _RANGES distance(_STD declval<_Rng&>())))};
@@ -3094,7 +3089,7 @@ namespace ranges {
                     return {_St::_Reconstruct_span, true};
                 } else if constexpr (_Is_specialization_v<_Ty, basic_string_view>) {
                     return {_St::_Reconstruct_other, true};
-                } else if constexpr (_Random_sized_range<_Ty> && _Is_subrange<_Ty>) {
+                } else if constexpr (_Random_sized_range<_Ty> && _Is_subrange_v<_Ty>) {
                     if constexpr (sized_sentinel_for<sentinel_t<_Ty>, iterator_t<_Ty>>) {
                         return {_St::_Reconstruct_subrange,
                             noexcept(_Ty(_RANGES begin(_STD declval<_Rng&>()) + _RANGES distance(_STD declval<_Rng&>()),

--- a/stl/inc/span
+++ b/stl/inc/span
@@ -222,9 +222,6 @@ struct _Span_extent_type<_Ty, dynamic_extent> {
     size_t _Mysize{0};
 };
 
-_EXPORT_STD template <class _Ty, size_t _Size>
-class array;
-
 _EXPORT_STD template <class _Ty, size_t _Extent>
 class span;
 

--- a/stl/inc/span
+++ b/stl/inc/span
@@ -242,12 +242,6 @@ inline constexpr bool _Is_span_v = false;
 template <class _Ty, size_t _Extent>
 inline constexpr bool _Is_span_v<span<_Ty, _Extent>> = true;
 
-template <class>
-inline constexpr bool _Is_std_array_v = false;
-
-template <class _Ty, size_t _Size>
-inline constexpr bool _Is_std_array_v<array<_Ty, _Size>> = true;
-
 // clang-format off
 template <class _It, class _Ty>
 concept _Span_compatible_iterator = contiguous_iterator<_It>

--- a/stl/inc/tuple
+++ b/stl/inc/tuple
@@ -11,8 +11,8 @@
 #ifdef __cpp_lib_concepts
 #include <compare>
 #endif // __cpp_lib_concepts
+#include <__msvc_iter_core.hpp>
 #include <type_traits>
-#include <utility>
 
 #pragma pack(push, _CRT_PACKING)
 #pragma warning(push, _STL_WARNING_LEVEL)

--- a/stl/inc/tuple
+++ b/stl/inc/tuple
@@ -179,9 +179,6 @@ struct _Alloc_unpack_tuple_t {
     explicit _Alloc_unpack_tuple_t() = default;
 }; // tag type to disambiguate construction (from an allocator and unpacking a tuple/pair)
 
-_EXPORT_STD template <class... _Types>
-class tuple;
-
 template <>
 class tuple<> { // empty tuple
 public:
@@ -823,9 +820,6 @@ _EXPORT_STD template <class... _Types>
 _NODISCARD constexpr tuple<_Types&&...> forward_as_tuple(_Types&&... _Args) noexcept { // forward arguments in a tuple
     return tuple<_Types&&...>(_STD forward<_Types>(_Args)...);
 }
-
-_EXPORT_STD template <class _Ty, size_t _Size>
-class array;
 
 _EXPORT_STD template <size_t _Idx, class _Ty, size_t _Size>
 _NODISCARD constexpr _Ty& get(array<_Ty, _Size>& _Arr) noexcept;

--- a/stl/inc/tuple
+++ b/stl/inc/tuple
@@ -11,8 +11,8 @@
 #ifdef __cpp_lib_concepts
 #include <compare>
 #endif // __cpp_lib_concepts
-#include <__msvc_iter_core.hpp>
 #include <type_traits>
+#include <utility>
 
 #pragma pack(push, _CRT_PACKING)
 #pragma warning(push, _STL_WARNING_LEVEL)

--- a/stl/inc/tuple
+++ b/stl/inc/tuple
@@ -821,18 +821,6 @@ _NODISCARD constexpr tuple<_Types&&...> forward_as_tuple(_Types&&... _Args) noex
     return tuple<_Types&&...>(_STD forward<_Types>(_Args)...);
 }
 
-_EXPORT_STD template <size_t _Idx, class _Ty, size_t _Size>
-_NODISCARD constexpr _Ty& get(array<_Ty, _Size>& _Arr) noexcept;
-
-_EXPORT_STD template <size_t _Idx, class _Ty, size_t _Size>
-_NODISCARD constexpr const _Ty& get(const array<_Ty, _Size>& _Arr) noexcept;
-
-_EXPORT_STD template <size_t _Idx, class _Ty, size_t _Size>
-_NODISCARD constexpr _Ty&& get(array<_Ty, _Size>&& _Arr) noexcept;
-
-_EXPORT_STD template <size_t _Idx, class _Ty, size_t _Size>
-_NODISCARD constexpr const _Ty&& get(const array<_Ty, _Size>&& _Arr) noexcept;
-
 template <class _Ty, class _Kx_arg, class _Ix_arg, size_t _Ix_next, class... _Sequences>
 struct _Tuple_cat2;
 

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -130,7 +130,7 @@ struct uses_allocator : _Has_allocator_type<_Ty, _Alloc>::type {
 _EXPORT_STD template <class _Ty, class _Alloc>
 _INLINE_VAR constexpr bool uses_allocator_v = uses_allocator<_Ty, _Alloc>::value;
 
-_EXPORT_STD template <class...>
+_EXPORT_STD template <class... _Types>
 class tuple;
 
 _EXPORT_STD template <class _Ty1, class _Ty2>

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -387,7 +387,7 @@ struct pair { // store a pair of values
         requires _Different_from<_Other, pair> && (!_Is_subrange_v<remove_cvref_t<_Other>>)
               && is_assignable_v<const _Ty1&, decltype(_STD get<0>(_STD declval<_Other>()))>
               && is_assignable_v<const _Ty2&, decltype(_STD get<1>(_STD declval<_Other>()))>
-    constexpr pair& operator=(_Other&& _Right) const noexcept(
+    constexpr const pair& operator=(_Other&& _Right) const noexcept(
         is_nothrow_assignable_v<const _Ty1&, decltype(_STD get<0>(_STD declval<_Other>()))>&&
             is_nothrow_assignable_v<const _Ty2&, decltype(_STD get<1>(_STD declval<_Other>()))>) /* strengthened */ {
         first  = _STD get<0>(_STD forward<_Other>(_Right));

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -8,8 +8,12 @@
 #define _UTILITY_
 #include <yvals_core.h>
 #if _STL_COMPILER_PREPROCESSOR
-#include <__msvc_iter_core.hpp>
+#include <type_traits>
 #include <xstddef>
+
+#ifdef __cpp_lib_concepts
+#include <concepts>
+#endif // __cpp_lib_concepts
 
 #if _HAS_CXX20
 #include <compare>
@@ -139,8 +143,14 @@ struct pair;
 _EXPORT_STD template <class _Ty, size_t _Size>
 class array;
 
+_EXPORT_STD template <class _Tuple>
+struct tuple_size;
+
 _EXPORT_STD template <class _Ty>
 _INLINE_VAR constexpr size_t tuple_size_v = tuple_size<_Ty>::value;
+
+_EXPORT_STD template <size_t _Index, class _Tuple>
+struct tuple_element;
 
 _EXPORT_STD template <size_t _Index, class _Tuple>
 using tuple_element_t = typename tuple_element<_Index, _Tuple>::type;
@@ -184,9 +194,6 @@ inline constexpr bool _Is_std_array_v<array<_Ty, _Size>> = true;
 
 template <class>
 inline constexpr bool _Is_subrange_v = false;
-
-template <class _It, class _Se, ranges::subrange_kind _Ki>
-inline constexpr bool _Is_subrange_v<ranges::subrange<_It, _Se, _Ki>> = true;
 
 #if _HAS_CXX23
 template <class _Ty>
@@ -885,6 +892,20 @@ _NODISCARD constexpr bool in_range(const _Ty _Value) noexcept {
 
     return true;
 }
+
+#ifdef __cpp_lib_concepts
+template <class _Ty>
+using _With_reference = _Ty&;
+
+template <class _Ty>
+concept _Can_reference = requires { typename _With_reference<_Ty>; };
+#else // ^^^ __cpp_lib_concepts / vvv !__cpp_lib_concepts
+template <class _Ty, class = void>
+inline constexpr bool _Can_reference = false;
+
+template <class _Ty>
+inline constexpr bool _Can_reference<_Ty, void_t<_Ty&>> = true;
+#endif // !__cpp_lib_concepts
 #endif // _HAS_CXX20
 
 #if _HAS_CXX23

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -899,13 +899,13 @@ using _With_reference = _Ty&;
 
 template <class _Ty>
 concept _Can_reference = requires { typename _With_reference<_Ty>; };
-#else // ^^^ __cpp_lib_concepts / vvv !__cpp_lib_concepts
+#else // __cpp_lib_concepts
 template <class _Ty, class = void>
 inline constexpr bool _Can_reference = false;
 
 template <class _Ty>
 inline constexpr bool _Can_reference<_Ty, void_t<_Ty&>> = true;
-#endif // !__cpp_lib_concepts
+#endif // __cpp_lib_concepts
 #endif // _HAS_CXX20
 
 #if _HAS_CXX23

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -148,6 +148,30 @@ using tuple_element_t = typename tuple_element<_Index, _Tuple>::type;
 _EXPORT_STD /* TRANSITION, VSO-1538698 */ template <size_t _Index, class... _Types>
 _NODISCARD constexpr auto&& _Tuple_get(tuple<_Types...>&& _Tuple) noexcept;
 
+_EXPORT_STD template <size_t _Index, class... _Types>
+_NODISCARD constexpr tuple_element_t<_Index, tuple<_Types...>>& get(tuple<_Types...>& _Tuple) noexcept;
+
+_EXPORT_STD template <size_t _Index, class... _Types>
+_NODISCARD constexpr const tuple_element_t<_Index, tuple<_Types...>>& get(const tuple<_Types...>& _Tuple) noexcept;
+
+_EXPORT_STD template <size_t _Index, class... _Types>
+_NODISCARD constexpr tuple_element_t<_Index, tuple<_Types...>>&& get(tuple<_Types...>&& _Tuple) noexcept;
+
+_EXPORT_STD template <size_t _Index, class... _Types>
+_NODISCARD constexpr const tuple_element_t<_Index, tuple<_Types...>>&& get(const tuple<_Types...>&& _Tuple) noexcept;
+
+_EXPORT_STD template <size_t _Idx, class _Ty, size_t _Size>
+_NODISCARD constexpr _Ty& get(array<_Ty, _Size>& _Arr) noexcept;
+
+_EXPORT_STD template <size_t _Idx, class _Ty, size_t _Size>
+_NODISCARD constexpr const _Ty& get(const array<_Ty, _Size>& _Arr) noexcept;
+
+_EXPORT_STD template <size_t _Idx, class _Ty, size_t _Size>
+_NODISCARD constexpr _Ty&& get(array<_Ty, _Size>&& _Arr) noexcept;
+
+_EXPORT_STD template <size_t _Idx, class _Ty, size_t _Size>
+_NODISCARD constexpr const _Ty&& get(const array<_Ty, _Size>&& _Arr) noexcept;
+
 #ifdef __cpp_lib_concepts
 template <class _Ty1, class _Ty2>
 concept _Different_from = (!same_as<remove_cvref_t<_Ty1>, remove_cvref_t<_Ty2>>);

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -198,6 +198,13 @@ concept _Tuple_like = _Tuple_like_impl<remove_cvref_t<_Ty>>;
 
 template <class _Ty>
 concept _Pair_like = _Tuple_like<_Ty> && tuple_size_v<remove_cvref_t<_Ty>> == 2;
+
+#ifdef __clang__ // TRANSITION, LLVM-59827
+template <class _PairLike, class _Ty1, class _Ty2>
+concept _Can_construct_from_pair_like =
+    _Pair_like<_PairLike> && is_constructible_v<_Ty1, decltype(_STD get<0>(_STD declval<_PairLike>()))>
+    && is_constructible_v<_Ty2, decltype(_STD get<1>(_STD declval<_PairLike>()))>;
+#endif // __clang__
 #endif // _HAS_CXX23
 #endif // __cpp_lib_concepts
 
@@ -270,17 +277,19 @@ struct pair { // store a pair of values
         : first(_STD forward<const _Other1>(_Right.first)), second(_STD forward<const _Other2>(_Right.second)) {}
 
 #ifdef __cpp_lib_concepts
-    // clang-format off
+#ifdef __clang__ // TRANSITION, LLVM-59827
+    template <class _Other, enable_if_t<_Can_construct_from_pair_like<_Other, _Ty1, _Ty2>, int> = 0>
+#else // ^^^ workaround / no workaround vvv
     template <_Pair_like _Other>
         requires conjunction_v<is_constructible<_Ty1, decltype(_STD get<0>(_STD declval<_Other>()))>,
-                               is_constructible<_Ty2, decltype(_STD get<1>(_STD declval<_Other>()))>>
+                     is_constructible<_Ty2, decltype(_STD get<1>(_STD declval<_Other>()))>>
+#endif // __clang__
     constexpr explicit(!conjunction_v<is_convertible<decltype(_STD get<0>(_STD declval<_Other>())), _Ty1>,
-                                      is_convertible<decltype(_STD get<1>(_STD declval<_Other>())), _Ty2>>)
-        pair(_Other&& _Right)
-            noexcept(is_nothrow_constructible_v<_Ty1, decltype(_STD get<0>(_STD declval<_Other>()))> &&
-                     is_nothrow_constructible_v<_Ty2, decltype(_STD get<1>(_STD declval<_Other>()))>) // strengthened
-        : first(_STD get<0>(_STD forward<_Other>(_Right))), second(_STD get<1>(_STD forward<_Other>(_Right))) {}
-    // clang-format on
+                       is_convertible<decltype(_STD get<1>(_STD declval<_Other>())), _Ty2>>)
+        pair(_Other&& _Right) noexcept(is_nothrow_constructible_v<_Ty1, decltype(_STD get<0>(_STD declval<_Other>()))>&&
+                is_nothrow_constructible_v<_Ty2, decltype(_STD get<1>(_STD declval<_Other>()))>) // strengthened
+        : first(_STD get<0>(_STD forward<_Other>(_Right))), second(_STD get<1>(_STD forward<_Other>(_Right))) {
+    }
 #endif // __cpp_lib_concepts
 #endif // _HAS_CXX23
 

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -244,6 +244,20 @@ struct pair { // store a pair of values
         pair(const pair<_Other1, _Other2>&& _Right) noexcept(is_nothrow_constructible_v<_Ty1, const _Other1>&&
                 is_nothrow_constructible_v<_Ty2, const _Other2>) // strengthened
         : first(_STD forward<const _Other1>(_Right.first)), second(_STD forward<const _Other2>(_Right.second)) {}
+
+#ifdef __cpp_lib_concepts
+    // clang-format off
+    template <_Pair_like _Other>
+        requires conjunction_v<is_constructible<_Ty1, decltype(_STD get<0>(_STD declval<_Other>()))>,
+                               is_constructible<_Ty2, decltype(_STD get<1>(_STD declval<_Other>()))>>
+    constexpr explicit(!conjunction_v<is_convertible<decltype(_STD get<0>(_STD declval<_Other>())), _Ty1>,
+                                      is_convertible<decltype(_STD get<1>(_STD declval<_Other>())), _Ty2>>)
+        pair(_Other&& _Right)
+            noexcept(is_nothrow_constructible_v<_Ty1, decltype(_STD get<0>(_STD declval<_Other>()))> &&
+                     is_nothrow_constructible_v<_Ty2, decltype(_STD get<1>(_STD declval<_Other>()))>) // strengthened
+        : first(_STD get<0>(_STD forward<_Other>(_Right))), second(_STD get<1>(_STD forward<_Other>(_Right))) {}
+    // clang-format on
+#endif // __cpp_lib_concepts
 #endif // _HAS_CXX23
 
     template <class _Tuple1, class _Tuple2, size_t... _Indexes1, size_t... _Indexes2>
@@ -355,6 +369,32 @@ struct pair { // store a pair of values
         second = _STD forward<_Other2>(_Right.second);
         return *this;
     }
+
+#ifdef __cpp_lib_concepts
+    template <_Pair_like _Other>
+        requires _Different_from<_Other, pair> && (!_Is_subrange_v<remove_cvref_t<_Other>>)
+              && is_assignable_v<_Ty1&, decltype(_STD get<0>(_STD declval<_Other>()))>
+              && is_assignable_v<_Ty2&, decltype(_STD get<1>(_STD declval<_Other>()))>
+    constexpr pair& operator=(_Other&& _Right) noexcept(
+        is_nothrow_assignable_v<_Ty1&, decltype(_STD get<0>(_STD declval<_Other>()))>&&
+            is_nothrow_assignable_v<_Ty2&, decltype(_STD get<1>(_STD declval<_Other>()))>) /* strengthened */ {
+        first  = _STD get<0>(_STD forward<_Other>(_Right));
+        second = _STD get<1>(_STD forward<_Other>(_Right));
+        return *this;
+    }
+
+    template <_Pair_like _Other>
+        requires _Different_from<_Other, pair> && (!_Is_subrange_v<remove_cvref_t<_Other>>)
+              && is_assignable_v<const _Ty1&, decltype(_STD get<0>(_STD declval<_Other>()))>
+              && is_assignable_v<const _Ty2&, decltype(_STD get<1>(_STD declval<_Other>()))>
+    constexpr pair& operator=(_Other&& _Right) const noexcept(
+        is_nothrow_assignable_v<const _Ty1&, decltype(_STD get<0>(_STD declval<_Other>()))>&&
+            is_nothrow_assignable_v<const _Ty2&, decltype(_STD get<1>(_STD declval<_Other>()))>) /* strengthened */ {
+        first  = _STD get<0>(_STD forward<_Other>(_Right));
+        second = _STD get<1>(_STD forward<_Other>(_Right));
+        return *this;
+    }
+#endif // __cpp_lib_concepts
 #endif // _HAS_CXX23
 
     _CONSTEXPR20 void swap(pair& _Right) noexcept(

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -8,12 +8,8 @@
 #define _UTILITY_
 #include <yvals_core.h>
 #if _STL_COMPILER_PREPROCESSOR
-#include <type_traits>
+#include <__msvc_iter_core.hpp>
 #include <xstddef>
-
-#ifdef __cpp_lib_concepts
-#include <concepts>
-#endif // __cpp_lib_concepts
 
 #if _HAS_CXX20
 #include <compare>
@@ -137,8 +133,49 @@ _INLINE_VAR constexpr bool uses_allocator_v = uses_allocator<_Ty, _Alloc>::value
 _EXPORT_STD template <class...>
 class tuple;
 
+_EXPORT_STD template <class _Ty1, class _Ty2>
+struct pair;
+
+_EXPORT_STD template <class _Ty, size_t _Size>
+class array;
+
+_EXPORT_STD template <class _Ty>
+_INLINE_VAR constexpr size_t tuple_size_v = tuple_size<_Ty>::value;
+
+_EXPORT_STD template <size_t _Index, class _Tuple>
+using tuple_element_t = typename tuple_element<_Index, _Tuple>::type;
+
 _EXPORT_STD /* TRANSITION, VSO-1538698 */ template <size_t _Index, class... _Types>
 _NODISCARD constexpr auto&& _Tuple_get(tuple<_Types...>&& _Tuple) noexcept;
+
+#ifdef __cpp_lib_concepts
+template <class _Ty1, class _Ty2>
+concept _Different_from = (!same_as<remove_cvref_t<_Ty1>, remove_cvref_t<_Ty2>>);
+
+template <class>
+inline constexpr bool _Is_std_array_v = false;
+
+template <class _Ty, size_t _Size>
+inline constexpr bool _Is_std_array_v<array<_Ty, _Size>> = true;
+
+template <class>
+inline constexpr bool _Is_subrange_v = false;
+
+template <class _It, class _Se, ranges::subrange_kind _Ki>
+inline constexpr bool _Is_subrange_v<ranges::subrange<_It, _Se, _Ki>> = true;
+
+#if _HAS_CXX23
+template <class _Ty>
+inline constexpr bool _Tuple_like_impl =
+    _Is_specialization_v<_Ty, tuple> || _Is_specialization_v<_Ty, pair> || _Is_std_array_v<_Ty> || _Is_subrange_v<_Ty>;
+
+template <class _Ty>
+concept _Tuple_like = _Tuple_like_impl<remove_cvref_t<_Ty>>;
+
+template <class _Ty>
+concept _Pair_like = _Tuple_like<_Ty> && tuple_size_v<remove_cvref_t<_Ty>> == 2;
+#endif // _HAS_CXX23
+#endif // __cpp_lib_concepts
 
 _EXPORT_STD template <class _Ty1, class _Ty2>
 struct pair { // store a pair of values
@@ -469,9 +506,6 @@ namespace _CXX20_DEPRECATE_REL_OPS rel_ops {
     }
 } // namespace _CXX20_DEPRECATE_REL_OPS rel_ops
 
-_EXPORT_STD template <class _Tuple>
-struct tuple_size;
-
 template <class _Tuple, class = void>
 struct _Tuple_size_sfinae {}; // selected when tuple_size<_Tuple>::value isn't well-formed
 
@@ -487,12 +521,6 @@ struct _CXX20_DEPRECATE_VOLATILE tuple_size<volatile _Tuple> : _Tuple_size_sfina
 
 template <class _Tuple>
 struct _CXX20_DEPRECATE_VOLATILE tuple_size<const volatile _Tuple> : _Tuple_size_sfinae<_Tuple> {}; // ignore cv
-
-_EXPORT_STD template <class _Ty>
-_INLINE_VAR constexpr size_t tuple_size_v = tuple_size<_Ty>::value;
-
-_EXPORT_STD template <size_t _Index, class _Tuple>
-struct tuple_element;
 
 template <size_t _Index, class _Tuple>
 struct _MSVC_KNOWN_SEMANTICS tuple_element<_Index, const _Tuple> : tuple_element<_Index, _Tuple> {
@@ -513,12 +541,6 @@ struct _CXX20_DEPRECATE_VOLATILE _MSVC_KNOWN_SEMANTICS tuple_element<_Index, con
     using _Mybase = tuple_element<_Index, _Tuple>;
     using type    = add_cv_t<typename _Mybase::type>;
 };
-
-_EXPORT_STD template <size_t _Index, class _Tuple>
-using tuple_element_t = typename tuple_element<_Index, _Tuple>::type;
-
-_EXPORT_STD template <class _Ty, size_t _Size>
-class array;
 
 template <class _Ty, size_t _Size>
 struct tuple_size<array<_Ty, _Size>> : integral_constant<size_t, _Size> {}; // size of array
@@ -790,20 +812,6 @@ _NODISCARD constexpr bool in_range(const _Ty _Value) noexcept {
 
     return true;
 }
-
-#ifdef __cpp_lib_concepts
-template <class _Ty>
-using _With_reference = _Ty&;
-
-template <class _Ty>
-concept _Can_reference = requires { typename _With_reference<_Ty>; };
-#else // __cpp_lib_concepts
-template <class _Ty, class = void>
-inline constexpr bool _Can_reference = false;
-
-template <class _Ty>
-inline constexpr bool _Can_reference<_Ty, void_t<_Ty&>> = true;
-#endif // __cpp_lib_concepts
 #endif // _HAS_CXX20
 
 #if _HAS_CXX23

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -8,11 +8,10 @@
 #define _XUTILITY_
 #include <yvals.h>
 #if _STL_COMPILER_PREPROCESSOR
-
-#include <__msvc_iter_core.hpp>
 #include <climits>
 #include <cstdlib>
 #include <cstring>
+#include <utility>
 
 #pragma pack(push, _CRT_PACKING)
 #pragma warning(push, _STL_WARNING_LEVEL)
@@ -1762,9 +1761,6 @@ _NODISCARD constexpr const _Elem* data(initializer_list<_Elem> _Ilist) noexcept 
 }
 
 #ifdef __cpp_lib_concepts
-template <class _Ty1, class _Ty2>
-concept _Different_from = (!same_as<remove_cvref_t<_Ty1>, remove_cvref_t<_Ty2>>);
-
 #if _HAS_CXX23
 _EXPORT_STD template <indirectly_readable _Ty>
 using iter_const_reference_t = common_reference_t<const iter_value_t<_Ty>&&, iter_reference_t<_Ty>>;

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -8,10 +8,11 @@
 #define _XUTILITY_
 #include <yvals.h>
 #if _STL_COMPILER_PREPROCESSOR
+
+#include <__msvc_iter_core.hpp>
 #include <climits>
 #include <cstdlib>
 #include <cstring>
-#include <utility>
 
 #pragma pack(push, _CRT_PACKING)
 #pragma warning(push, _STL_WARNING_LEVEL)

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -322,7 +322,7 @@
 // P2077R3 Heterogeneous Erasure Overloads For Associative Containers
 // P2136R3 invoke_r()
 // P2165R4 Compatibility Between tuple, pair, And tuple-like Objects
-//     (changes to views::zip only)
+//     (changes to views::zip and pair only)
 // P2166R1 Prohibiting basic_string And basic_string_view Construction From nullptr
 // P2186R2 Removing Garbage Collection Support
 // P2273R3 constexpr unique_ptr

--- a/tests/std/test.lst
+++ b/tests/std/test.lst
@@ -550,6 +550,7 @@ tests\P1899R3_views_stride_death
 tests\P1951R1_default_arguments_pair_forward_ctor
 tests\P2136R3_invoke_r
 tests\P2162R2_std_visit_for_derived_classes_from_variant
+tests\P2165R4_tuple_like_pair
 tests\P2231R1_complete_constexpr_optional_variant
 tests\P2273R3_constexpr_unique_ptr
 tests\P2278R4_basic_const_iterator

--- a/tests/std/tests/P2165R4_tuple_like_pair/env.lst
+++ b/tests/std/tests/P2165R4_tuple_like_pair/env.lst
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+RUNALL_INCLUDE ..\concepts_latest_matrix.lst

--- a/tests/std/tests/P2165R4_tuple_like_pair/env.lst
+++ b/tests/std/tests/P2165R4_tuple_like_pair/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst

--- a/tests/std/tests/P2165R4_tuple_like_pair/env.lst
+++ b/tests/std/tests/P2165R4_tuple_like_pair/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\concepts_latest_matrix.lst

--- a/tests/std/tests/P2165R4_tuple_like_pair/test.cpp
+++ b/tests/std/tests/P2165R4_tuple_like_pair/test.cpp
@@ -132,7 +132,7 @@ constexpr bool test_pair_like_assignment() {
 
 template <template <class> class PairLike>
 constexpr bool test_pair_like_const_assignment() {
-    using Ref  = std::vector<bool>::reference;
+    using Ref  = vector<bool>::reference;
     using Pair = pair<Ref, Ref>;
 
     static_assert(is_assignable_v<const Pair&, PairLike<bool>&>);
@@ -140,8 +140,8 @@ constexpr bool test_pair_like_const_assignment() {
     static_assert(is_assignable_v<const Pair&, PairLike<bool>>);
     static_assert(is_assignable_v<const Pair&, const PairLike<bool>>);
 
-    std::vector<bool> bools = {false, true};
-    PairLike<bool> a        = {true, false};
+    vector<bool> bools = {false, true};
+    PairLike<bool> a   = {true, false};
 
     const Pair p1{bools[0], bools[1]};
     p1 = a;

--- a/tests/std/tests/P2165R4_tuple_like_pair/test.cpp
+++ b/tests/std/tests/P2165R4_tuple_like_pair/test.cpp
@@ -6,10 +6,12 @@
 #include <tuple>
 #include <type_traits>
 #include <utility>
+#include <vector>
 
 using namespace std;
 
 struct TmpInt {
+    constexpr TmpInt() : TmpInt(0) {}
     constexpr TmpInt(int v) : val{v} {}
 
     constexpr TmpInt(const TmpInt&) = default;
@@ -26,12 +28,6 @@ struct TmpInt {
     int val;
     constexpr bool operator==(const TmpInt&) const = default;
 };
-
-template <class T>
-using BinaryTuple = tuple<T, T>;
-
-template <class T>
-using BinaryArray = array<T, 2>;
 
 template <template <class> class PairLike>
 constexpr bool test_pair_like_constructor() {
@@ -71,45 +67,123 @@ constexpr bool test_pair_like_constructor() {
     pair<TmpInt&, TmpInt&> p2(a);
     assert(&p2.first == &get<0>(a) && &p2.second == &get<1>(a));
 
-    pair<const TmpInt&, const TmpInt&> p3 = a;
+    pair<const TmpInt&, const TmpInt&> p3(a);
     assert(&p3.first == &get<0>(a) && &p3.second == &get<1>(a));
 
-    pair<TmpInt, TmpInt> p4 = as_const(a);
+    pair<TmpInt, TmpInt> p4(as_const(a));
     assert(p4.first == 1 && p4.second == 2 && get<0>(a) == 1 && get<1>(a) == 2);
 
-    pair<const TmpInt&, const TmpInt&> p5 = as_const(a);
+    pair<const TmpInt&, const TmpInt&> p5(as_const(a));
     assert(&p5.first == &get<0>(a) && &p5.second == &get<1>(a));
 
-    pair<TmpInt, TmpInt> p6 = std::move(a);
+    pair<TmpInt, TmpInt> p6(std::move(a));
     assert(p6.first == 1 && p6.second == 2 && get<0>(a) == -1 && get<1>(a) == -1);
     tie(get<0>(a), get<1>(a)) = std::move(p6);
 
-    pair<const TmpInt&, const TmpInt&> p7 = std::move(a);
+    pair<const TmpInt&, const TmpInt&> p7(std::move(a));
     assert(&p7.first == &get<0>(a) && &p7.second == &get<1>(a));
 
-    pair<TmpInt&&, TmpInt&&> p8 = std::move(a);
+    pair<TmpInt&&, TmpInt&&> p8(std::move(a));
     assert(&p8.first == &get<0>(a) && &p8.second == &get<1>(a));
 
-    pair<const TmpInt&&, const TmpInt&&> p9 = std::move(a);
+    pair<const TmpInt&&, const TmpInt&&> p9(std::move(a));
     assert(&p9.first == &get<0>(a) && &p9.second == &get<1>(a));
 
-    pair<TmpInt, TmpInt> p10 = std::move(as_const(a));
+    pair<TmpInt, TmpInt> p10(std::move(as_const(a)));
     assert(p10.first == 1 && p10.second == 2 && get<0>(a) == 1 && get<1>(a) == 2);
 
-    pair<const TmpInt&, const TmpInt&> p11 = std::move(as_const(a));
+    pair<const TmpInt&, const TmpInt&> p11(std::move(as_const(a)));
     assert(p11.first == 1 && p11.second == 2 && get<0>(a) == 1 && get<1>(a) == 2);
 
-    pair<const TmpInt&&, const TmpInt&&> p12 = std::move(as_const(a));
+    pair<const TmpInt&&, const TmpInt&&> p12(std::move(as_const(a)));
     assert(p12.first == 1 && p12.second == 2 && get<0>(a) == 1 && get<1>(a) == 2);
 
     return true;
 }
 
-// FIXME test assignment operators
+template <template <class> class PairLike>
+constexpr bool test_pair_like_assignment() {
+    static_assert(is_assignable_v<pair<int, int>&, PairLike<int>&>);
+    static_assert(is_assignable_v<pair<int, int>&, const PairLike<int>&>);
+    static_assert(is_assignable_v<pair<int, int>&, PairLike<int>>);
+    static_assert(is_assignable_v<pair<int, int>&, const PairLike<int>>);
+
+    PairLike<TmpInt> a = {1, 2};
+
+    pair<TmpInt, TmpInt> p1;
+    p1 = a;
+    assert(p1.first == 1 && p1.second == 2 && get<0>(a) == 1 && get<1>(a) == 2);
+
+    pair<TmpInt, TmpInt> p2;
+    p2 = as_const(a);
+    assert(p2.first == 1 && p2.second == 2 && get<0>(a) == 1 && get<1>(a) == 2);
+
+    pair<TmpInt, TmpInt> p3;
+    p3 = std::move(a);
+    assert(p3.first == 1 && p3.second == 2 && get<0>(a) == -1 && get<1>(a) == -1);
+    tie(get<0>(a), get<1>(a)) = std::move(p3);
+
+    pair<TmpInt, TmpInt> p4;
+    p4 = std::move(as_const(a));
+    assert(p4.first == 1 && p4.second == 2 && get<0>(a) == 1 && get<1>(a) == 2);
+
+    return true;
+}
+
+template <template <class> class PairLike>
+constexpr bool test_pair_like_const_assignment() {
+    using Ref  = std::vector<bool>::reference;
+    using Pair = pair<Ref, Ref>;
+
+    static_assert(is_assignable_v<const Pair&, PairLike<bool>&>);
+    static_assert(is_assignable_v<const Pair&, const PairLike<bool>&>);
+    static_assert(is_assignable_v<const Pair&, PairLike<bool>>);
+    static_assert(is_assignable_v<const Pair&, const PairLike<bool>>);
+
+    std::vector<bool> bools = {false, true};
+    PairLike<bool> a        = {true, false};
+
+    Pair p1{bools[0], bools[1]};
+    p1 = a;
+    assert(p1.first == true && p1.second == false);
+    bools = {false, true};
+
+    Pair p2{bools[0], bools[1]};
+    p2 = as_const(a);
+    assert(p2.first == true && p2.second == false);
+    bools = {false, true};
+
+    Pair p3{bools[0], bools[1]};
+    p3 = std::move(a);
+    assert(p3.first == true && p3.second == false);
+    bools = {false, true};
+
+    Pair p4{bools[0], bools[1]};
+    p4 = std::move(as_const(a));
+    assert(p4.first == true && p4.second == false);
+
+    return true;
+}
+
+template <class T>
+using BinaryTuple = tuple<T, T>;
+
+template <class T>
+using BinaryArray = array<T, 2>;
 
 int main() {
     static_assert(test_pair_like_constructor<BinaryArray>());
     assert((test_pair_like_constructor<BinaryArray>()));
     static_assert(test_pair_like_constructor<BinaryTuple>());
     assert((test_pair_like_constructor<BinaryTuple>()));
+
+    static_assert(test_pair_like_assignment<BinaryArray>());
+    assert((test_pair_like_assignment<BinaryArray>()));
+    static_assert(test_pair_like_assignment<BinaryTuple>());
+    assert((test_pair_like_assignment<BinaryTuple>()));
+
+    static_assert(test_pair_like_const_assignment<BinaryArray>());
+    assert((test_pair_like_const_assignment<BinaryArray>()));
+    static_assert(test_pair_like_const_assignment<BinaryTuple>());
+    assert((test_pair_like_const_assignment<BinaryTuple>()));
 }

--- a/tests/std/tests/P2165R4_tuple_like_pair/test.cpp
+++ b/tests/std/tests/P2165R4_tuple_like_pair/test.cpp
@@ -143,22 +143,22 @@ constexpr bool test_pair_like_const_assignment() {
     std::vector<bool> bools = {false, true};
     PairLike<bool> a        = {true, false};
 
-    Pair p1{bools[0], bools[1]};
+    const Pair p1{bools[0], bools[1]};
     p1 = a;
     assert(p1.first == true && p1.second == false);
     bools = {false, true};
 
-    Pair p2{bools[0], bools[1]};
+    const Pair p2{bools[0], bools[1]};
     p2 = as_const(a);
     assert(p2.first == true && p2.second == false);
     bools = {false, true};
 
-    Pair p3{bools[0], bools[1]};
+    const Pair p3{bools[0], bools[1]};
     p3 = std::move(a);
     assert(p3.first == true && p3.second == false);
     bools = {false, true};
 
-    Pair p4{bools[0], bools[1]};
+    const Pair p4{bools[0], bools[1]};
     p4 = std::move(as_const(a));
     assert(p4.first == true && p4.second == false);
 

--- a/tests/std/tests/P2165R4_tuple_like_pair/test.cpp
+++ b/tests/std/tests/P2165R4_tuple_like_pair/test.cpp
@@ -1,0 +1,115 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <array>
+#include <cassert>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+using namespace std;
+
+struct TmpInt {
+    constexpr TmpInt(int v) : val{v} {}
+
+    constexpr TmpInt(const TmpInt&) = default;
+    constexpr TmpInt(TmpInt&& other) : val{exchange(other.val, -1)} {}
+
+    constexpr TmpInt& operator=(const TmpInt&) = default;
+    constexpr TmpInt& operator=(TmpInt&& other) {
+        if (this != &other) {
+            val = exchange(other.val, -1);
+        }
+        return *this;
+    }
+
+    int val;
+    constexpr bool operator==(const TmpInt&) const = default;
+};
+
+template <class T>
+using BinaryTuple = tuple<T, T>;
+
+template <class T>
+using BinaryArray = array<T, 2>;
+
+template <template <class> class PairLike>
+constexpr bool test_pair_like_constructor() {
+    // Test pair(pair-like) constructor with PairLike<int>&
+    static_assert(constructible_from<pair<int, int>, PairLike<int>&>);
+    static_assert(constructible_from<pair<int&, int&>, PairLike<int>&>);
+    static_assert(constructible_from<pair<const int&, const int&>, PairLike<int>&>);
+    static_assert(!constructible_from<pair<int&&, int&&>, PairLike<int>&>);
+    static_assert(!constructible_from<pair<const int&&, const int&&>, PairLike<int>&>);
+
+    // Test pair(pair-like) constructor with const PairLike<int>&
+    static_assert(constructible_from<pair<int, int>, const PairLike<int>&>);
+    static_assert(!constructible_from<pair<int&, int&>, const PairLike<int>&>);
+    static_assert(constructible_from<pair<const int&, const int&>, const PairLike<int>&>);
+    static_assert(!constructible_from<pair<int&&, int&&>, const PairLike<int>&>);
+    static_assert(!constructible_from<pair<const int&&, const int&&>, const PairLike<int>&>);
+
+    // Test pair(pair-like) constructor with PairLike<int>
+    static_assert(constructible_from<pair<int, int>, PairLike<int>>);
+    static_assert(!constructible_from<pair<int&, int&>, PairLike<int>>);
+    static_assert(constructible_from<pair<const int&, const int&>, PairLike<int>>);
+    static_assert(constructible_from<pair<int&&, int&&>, PairLike<int>>);
+    static_assert(constructible_from<pair<const int&&, const int&&>, PairLike<int>>);
+
+    // Test pair(pair-like) constructor with const PairLike<int>
+    static_assert(constructible_from<pair<int, int>, const PairLike<int>>);
+    static_assert(!constructible_from<pair<int&, int&>, const PairLike<int>>);
+    static_assert(constructible_from<pair<const int&, const int&>, const PairLike<int>>);
+    static_assert(!constructible_from<pair<int&&, int&&>, const PairLike<int>>);
+    static_assert(constructible_from<pair<const int&&, const int&&>, const PairLike<int>>);
+
+    PairLike<TmpInt> a = {1, 2};
+
+    pair<TmpInt, TmpInt> p1(a);
+    assert(p1.first == 1 && p1.second == 2 && get<0>(a) == 1 && get<1>(a) == 2);
+
+    pair<TmpInt&, TmpInt&> p2(a);
+    assert(&p2.first == &get<0>(a) && &p2.second == &get<1>(a));
+
+    pair<const TmpInt&, const TmpInt&> p3 = a;
+    assert(&p3.first == &get<0>(a) && &p3.second == &get<1>(a));
+
+    pair<TmpInt, TmpInt> p4 = as_const(a);
+    assert(p4.first == 1 && p4.second == 2 && get<0>(a) == 1 && get<1>(a) == 2);
+
+    pair<const TmpInt&, const TmpInt&> p5 = as_const(a);
+    assert(&p5.first == &get<0>(a) && &p5.second == &get<1>(a));
+
+    pair<TmpInt, TmpInt> p6 = std::move(a);
+    assert(p6.first == 1 && p6.second == 2 && get<0>(a) == -1 && get<1>(a) == -1);
+    tie(get<0>(a), get<1>(a)) = std::move(p6);
+
+    pair<const TmpInt&, const TmpInt&> p7 = std::move(a);
+    assert(&p7.first == &get<0>(a) && &p7.second == &get<1>(a));
+
+    pair<TmpInt&&, TmpInt&&> p8 = std::move(a);
+    assert(&p8.first == &get<0>(a) && &p8.second == &get<1>(a));
+
+    pair<const TmpInt&&, const TmpInt&&> p9 = std::move(a);
+    assert(&p9.first == &get<0>(a) && &p9.second == &get<1>(a));
+
+    pair<TmpInt, TmpInt> p10 = std::move(as_const(a));
+    assert(p10.first == 1 && p10.second == 2 && get<0>(a) == 1 && get<1>(a) == 2);
+
+    pair<const TmpInt&, const TmpInt&> p11 = std::move(as_const(a));
+    assert(p11.first == 1 && p11.second == 2 && get<0>(a) == 1 && get<1>(a) == 2);
+
+    pair<const TmpInt&&, const TmpInt&&> p12 = std::move(as_const(a));
+    assert(p12.first == 1 && p12.second == 2 && get<0>(a) == 1 && get<1>(a) == 2);
+
+    return true;
+}
+
+// FIXME test assignment operators
+
+int main() {
+    static_assert(test_pair_like_constructor<BinaryArray>());
+    assert((test_pair_like_constructor<BinaryArray>()));
+    static_assert(test_pair_like_constructor<BinaryTuple>());
+    assert((test_pair_like_constructor<BinaryTuple>()));
+}


### PR DESCRIPTION
Towards #2917. Implements changes to [[pairs]](http://eel.is/c++draft/pairs) section.

The other goal of this PR is to move around some stuff, so that implementation of *`tuple-like`* concept is possible:
  * Move `_Different_from` concept from `<xutility>` to `<utility>`,
  * Move `_Is_subrange` variable template from `<ranges>` to `<utility>` and rename it to `_Is_subrange_v`,
  * Move `_Is_std_array_v` variable from `<span>` to `<utility>`,
  * Remove some redundant forward declarations.