### PR TITLE
`<expected>`: Workaround LLVM-59854

### DIFF
--- a/stl/inc/expected
+++ b/stl/inc/expected
@@ -308,7 +308,7 @@ public:
         : _Unexpected(_Ilist, _STD forward<_Args>(_Vals)...), _Has_value(false) {}
 
     // [expected.object.dtor]
-    constexpr ~expected() noexcept {
+    constexpr ~expected() {
         if (_Has_value) {
             if constexpr (!is_trivially_destructible_v<_Ty>) {
                 _Value.~_Ty();
@@ -834,7 +834,7 @@ public:
         : _Unexpected(_Ilist, _STD forward<_Args>(_Vals)...), _Has_value(false) {}
 
     // [expected.void.dtor]
-    constexpr ~expected() noexcept {
+    constexpr ~expected() {
         if (!_Has_value) {
             _Unexpected.~_Err();
         }

--- a/stl/inc/expected
+++ b/stl/inc/expected
@@ -309,7 +309,7 @@ public:
 
     // [expected.object.dtor]
     constexpr ~expected()
-#ifndef __clang__ // TRANSITION, llvm/llvm-project#59854
+#ifndef __clang__ // TRANSITION, LLVM-59854
         noexcept
 #endif // __clang__
     {
@@ -839,7 +839,7 @@ public:
 
     // [expected.void.dtor]
     constexpr ~expected()
-#ifndef __clang__ // TRANSITION, llvm/llvm-project#59854
+#ifndef __clang__ // TRANSITION, LLVM-59854
         noexcept
 #endif // __clang__
     {

--- a/stl/inc/expected
+++ b/stl/inc/expected
@@ -308,7 +308,11 @@ public:
         : _Unexpected(_Ilist, _STD forward<_Args>(_Vals)...), _Has_value(false) {}
 
     // [expected.object.dtor]
-    constexpr ~expected() {
+    constexpr ~expected()
+#ifndef __clang__ // TRANSITION, llvm/llvm-project#59854
+        noexcept
+#endif // __clang__
+    {
         if (_Has_value) {
             if constexpr (!is_trivially_destructible_v<_Ty>) {
                 _Value.~_Ty();
@@ -834,7 +838,11 @@ public:
         : _Unexpected(_Ilist, _STD forward<_Args>(_Vals)...), _Has_value(false) {}
 
     // [expected.void.dtor]
-    constexpr ~expected() {
+    constexpr ~expected()
+#ifndef __clang__ // TRANSITION, llvm/llvm-project#59854
+        noexcept
+#endif // __clang__
+    {
         if (!_Has_value) {
             _Unexpected.~_Err();
         }

--- a/tests/std/tests/P0323R12_expected/test.cpp
+++ b/tests/std/tests/P0323R12_expected/test.cpp
@@ -7,9 +7,9 @@
 #include <concepts>
 #include <exception>
 #include <expected>
-#include <initializer_list>
 #include <type_traits>
 #include <utility>
+#include <vector>
 
 using namespace std;
 
@@ -2043,6 +2043,14 @@ void test_reinit_regression() {
         assert(i == magic);
     }
 }
+
+// Defend against regression of llvm-project#59854, in which clang is confused
+// by the explicit `noexcept` on `expected`'s destructors.
+struct Data {
+    vector<int> vec_;
+    constexpr Data(initializer_list<int> il) : vec_(il) {}
+};
+static_assert(((void) expected<void, Data>{unexpect, {1, 2, 3}}, true));
 
 int main() {
     test_unexpected::test_all();


### PR DESCRIPTION
Clang is confused by explicit `noexcept` on a constexpr destructor for (I think) objects with non-trivially destructible anonymous union members. The workaround is to remove the explicit `noexcept` and let the compiler default it. ~~I think this is fine as a permanent condition, so I've added no transition comments.~~
