### PR TITLE
Implement LWG-3778 `vector<bool>` missing exception specifications

### DIFF
--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -1763,7 +1763,7 @@ public:
         if (_Myfirst == _Mylast) { // already empty, nothing to do
             // This is an optimization for debug mode: we can avoid taking the debug lock to invalidate iterators.
             // Note that when clearing an empty vector, this will preserve past-the-end iterators, which is allowed by
-            // N4928 [sequence.reqmts] "a.clear() [...] may invalidate the past-the-end iterator".
+            // N4928 [sequence.reqmts]/54 "a.clear() [...] may invalidate the past-the-end iterator".
             return;
         }
 

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -881,7 +881,7 @@ private:
         // insert range [_First, _Last) at end
 
         // For one-at-back, provide strong guarantee.
-        // Otherwise, provide basic guarantee (despite N4659 26.3.11.5 [vector.modifiers]/1).
+        // Otherwise, provide basic guarantee (despite N4928 [vector.modifiers]/2).
         // Performance note: except for one-at-back, _Emplace_one_at_back()'s strong guarantee is unnecessary here.
 
         for (; _First != _Last; ++_First) {
@@ -1763,7 +1763,7 @@ public:
         if (_Myfirst == _Mylast) { // already empty, nothing to do
             // This is an optimization for debug mode: we can avoid taking the debug lock to invalidate iterators.
             // Note that when clearing an empty vector, this will preserve past-the-end iterators, which is allowed by
-            // N4901 [tab:container.seq.req] "a.clear() [...] may invalidate the past-the-end iterator".
+            // N4928 [sequence.reqmts] "a.clear() [...] may invalidate the past-the-end iterator".
             return;
         }
 

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -2775,8 +2775,7 @@ public:
         this->_Alloc_proxy(_GET_PROXY_ALLOCATOR(_Alvbase, _Getal()));
     }
 
-    _CONSTEXPR20 _Vb_val(const _Alloc& _Al) noexcept(is_nothrow_constructible_v<_Vectype, _Alvbase>)
-        : _Myvec(static_cast<_Alvbase>(_Al)), _Mysize(0) {
+    _CONSTEXPR20 _Vb_val(const _Alloc& _Al) noexcept : _Myvec(static_cast<_Alvbase>(_Al)), _Mysize(0) {
         this->_Alloc_proxy(_GET_PROXY_ALLOCATOR(_Alvbase, _Getal()));
     }
 
@@ -2875,12 +2874,9 @@ public:
     static const int _VBITS = _STD _VBITS;
     enum { _EEN_VBITS = _VBITS }; // helper for expression evaluator
 
-    _CONSTEXPR20 vector() noexcept(is_nothrow_default_constructible_v<_Mybase>) // strengthened
-        : _Mybase() {}
+    _CONSTEXPR20 vector() noexcept(is_nothrow_default_constructible_v<_Alloc>) : _Mybase(_Alloc()) {}
 
-    _CONSTEXPR20 explicit vector(const _Alloc& _Al) noexcept(
-        is_nothrow_constructible_v<_Mybase, const _Alloc&>) // strengthened
-        : _Mybase(_Al) {}
+    _CONSTEXPR20 explicit vector(const _Alloc& _Al) noexcept : _Mybase(_Al) {}
 
     _CONSTEXPR20 explicit vector(_CRT_GUARDOVERFLOW size_type _Count, const _Alloc& _Al = _Alloc())
         : _Mybase(_Count, false, _Al) {
@@ -2914,13 +2910,12 @@ public:
     }
 #endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 
-    _CONSTEXPR20 vector(vector&& _Right) noexcept(is_nothrow_move_constructible_v<_Mybase>) // strengthened
-        : _Mybase(_STD move(_Right)) {
+    _CONSTEXPR20 vector(vector&& _Right) noexcept : _Mybase(_STD move(_Right)) {
         this->_Swap_proxy_and_iterators(_Right);
     }
 
     _CONSTEXPR20 vector(vector&& _Right, const _Identity_t<_Alloc>& _Al) noexcept(
-        is_nothrow_constructible_v<_Mybase, _Mybase, const _Alloc&>)
+        is_nothrow_constructible_v<_Mybase, _Mybase, const _Alloc&>) // strengthened
         : _Mybase(_STD move(_Right), _Al) {
         if constexpr (!_Alvbase_traits::is_always_equal::value) {
             if (this->_Getal() != _Right._Getal()) {
@@ -2931,7 +2926,8 @@ public:
         this->_Swap_proxy_and_iterators(_Right);
     }
 
-    _CONSTEXPR20 vector& operator=(vector&& _Right) noexcept(is_nothrow_move_assignable_v<_Mybase>) {
+    _CONSTEXPR20 vector& operator=(vector&& _Right) noexcept(
+        _Choose_pocma_v<_Alvbase> != _Pocma_values::_No_propagate_allocators) {
         if (this == _STD addressof(_Right)) {
             return *this;
         }

--- a/tests/std/tests/P1004R2_constexpr_vector_bool/test.cpp
+++ b/tests/std/tests/P1004R2_constexpr_vector_bool/test.cpp
@@ -274,7 +274,7 @@ constexpr bool test_interface() {
         vec default_constructed;
         const auto alloc = default_constructed.get_allocator();
         static_assert(is_same_v<remove_const_t<decltype(alloc)>, soccc_allocator<bool>>);
-        assert(alloc.id == 1);
+        assert(alloc.id == 2);
         assert(alloc.soccc_generation == 0);
     }
 


### PR DESCRIPTION
Fixes #3226.

Notes:
- The default constructor of `vector<bool, _Alloc>` need to default-construct an `_Alloc` instead of `_Alvbase` in order to implement the required exception specification. I think this is not related to allocator propagation and thus possibly not covered by LWG-3267.
  - Edit: I have to change the test `P1004R2_constexpr_vector_bool` due to this. Not sure whether such change is right now...
- The constructor of `_Vb_val` from an allocator is always `noexcept`, so I changed the superfluous conditional `noexcept` to unconditional one.
- The constructor of `vector<bool, _Alloc>` from `(vector&&, const _Identity_t<_Alloc>&)` is not `noexcept` in the current working draft, so I added `// strengthened`.
- Exception specification of the move assignment operator of `vector<bool, _Alloc>` detect the properties of `_Alvbase`, which is consistent with other containers that need allocator rebinding.
  - I've mailed LWG chair to propose a more complete resolution of LWG-3267 (said in https://github.com/microsoft/STL/issues/3226#issuecomment-1369344144), which would be able to resolve the divergence between standard requirements and actual implementations.
  - The old exception specification is meaningless, since `_Vb_val` is not even move-assignable - the explicitly declared move constructor make the move assignment operator not declared, and the copy assignment operator implicitly deleted.
- As small driven-by changes, references to the working draft are updated to refer to WG21-N4928.