### PR TITLE
`<ranges>`: improve `views::istream` constraints

### DIFF
--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -1465,11 +1465,21 @@ namespace ranges {
     using wistream_view = basic_istream_view<_Ty, wchar_t>;
 
     namespace views {
+        template <class _Elem, class _Stream, class _CharT, class _Traits>
+        concept _Istreamable_impl = derived_from<_Stream, basic_istream<_CharT, _Traits>>
+                                 && constructible_from<basic_istream_view<_Elem, _CharT, _Traits>, _Stream&>;
+        template <class _Elem, class _Stream>
+        concept _Istreamable =
+            requires {
+                typename _Stream::char_type;
+                typename _Stream::traits_type;
+                requires _Istreamable_impl<_Elem, _Stream, typename _Stream::char_type, typename _Stream::traits_type>;
+            };
+
         template <class _Ty>
         struct _Istream_fn {
             template <class _StreamTy>
-                requires derived_from<_StreamTy,
-                    basic_istream<typename _StreamTy::char_type, typename _StreamTy::traits_type>>
+                requires _Istreamable<_Ty, _StreamTy>
             _NODISCARD constexpr auto operator()(_StreamTy& _Stream) const
                 noexcept(is_nothrow_default_constructible_v<_Ty>) /* strengthened */ {
                 return basic_istream_view<_Ty, typename _StreamTy::char_type, typename _StreamTy::traits_type>(_Stream);

--- a/tests/std/tests/P0896R4_istream_view/test.cpp
+++ b/tests/std/tests/P0896R4_istream_view/test.cpp
@@ -134,6 +134,19 @@ constexpr bool test_constexpr() {
     return true;
 }
 
+// Negative test cases
+struct not_streamable {};
+static_assert(!invocable<decltype(views::istream<not_streamable>), istream&>);
+static_assert(!invocable<decltype(views::istream<int>), const istream&>);
+static_assert(!invocable<decltype(views::istream<int>), volatile istream&>);
+static_assert(!invocable<decltype(views::istream<int>), const volatile istream&>);
+static_assert(invocable<decltype(views::istream<int>), istream> == is_permissive);
+static_assert(!invocable<decltype(views::istream<int>), const istream>);
+static_assert(!invocable<decltype(views::istream<int>), volatile istream>);
+static_assert(!invocable<decltype(views::istream<int>), const volatile istream>);
+static_assert(!invocable<decltype(views::istream<int>), int&>);
+static_assert(!invocable<decltype(views::istream<int>), int>);
+
 int main() {
     test_one_type<int>();
     test_one_type<streamable>();


### PR DESCRIPTION
`views::istream<T>::operator()` currently emits "hard" errors when its argument is correctly `derived_from` a specialization of `basic_istream` but any of the other requirements isn't satisfied. This is non-conforming, since the CPO wording requires CPOs not to participate in overload resolution for sets of arguments that don't meet the CPOs requirements.

Let's flesh out the constraints, and add some negative test cases to ensure we get SFINAE instead of hard errors.
