### PR TITLE
Update modules tests for `source_location` compiler fix

### DIFF
--- a/tests/std/include/test_header_units_and_modules.hpp
+++ b/tests/std/include/test_header_units_and_modules.hpp
@@ -651,7 +651,11 @@ constexpr bool impl_test_source_location() {
     using namespace std;
     const auto sl = source_location::current();
     assert(sl.line() == __LINE__ - 1);
+#ifdef _MSVC_INTERNAL_TESTING // TRANSITION, VS 2022 17.6 Preview 2
+    assert(sl.column() == 38);
+#else // ^^^ no workaround / workaround vvv
     assert(sl.column() == 1);
+#endif // ^^^ workaround ^^^
 #if defined(__clang__) || defined(__EDG__) // TRANSITION, DevCom-10199227 and LLVM-58951
     assert(sl.function_name() == "impl_test_source_location"sv);
 #else // ^^^ workaround / no workaround vvv


### PR DESCRIPTION
This is a mirror of internal MSVC-PR-442478 Iteration 3, which is fixing VSO-1592409 "Standard Library Modules: `source_location::column()` misbehaves in user headers". As is often the case, we need `#ifdef _MSVC_INTERNAL_TESTING` until the fixed compiler ships.