### PR TITLE
Fix the behavior of `vector<bool, HugeAlloc>` whose size overflows `uint32_t`

### DIFF
--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -2378,6 +2378,8 @@ public:
     using _Difference_type = typename allocator_traits<_Alvbase>::difference_type;
     using _Mycont          = vector<bool, _Rebind_alloc_t<_Alvbase, bool>>;
 
+    static constexpr _Difference_type _VBITS_DIFF = _VBITS;
+
     _CONSTEXPR20 _Vb_iter_base() = default;
 
     _CONSTEXPR20 _Vb_iter_base(const _Vbase* _Ptr, _Size_type _Off, const _Container_base* _Mypvbool) noexcept
@@ -2393,8 +2395,7 @@ public:
 
 #if _ITERATOR_DEBUG_LEVEL != 0
     _CONSTEXPR20 _Difference_type _Total_off(const _Mycont* _Cont) const noexcept {
-        return static_cast<_Difference_type>(
-            static_cast<_Difference_type>(_VBITS) * (_Myptr - _Cont->_Myvec.data()) + _Myoff);
+        return static_cast<_Difference_type>(_VBITS_DIFF * (_Myptr - _Cont->_Myvec.data()) + _Myoff);
     }
 #endif // _ITERATOR_DEBUG_LEVEL != 0
 
@@ -2583,7 +2584,7 @@ public:
 
     _NODISCARD _CONSTEXPR20 difference_type operator-(const _Vb_const_iterator& _Right) const noexcept {
         _Compat(_Right);
-        return static_cast<difference_type>(static_cast<difference_type>(_VBITS) * (this->_Myptr - _Right._Myptr))
+        return static_cast<difference_type>(_Mybase::_VBITS_DIFF * (this->_Myptr - _Right._Myptr))
              + static_cast<difference_type>(this->_Myoff) - static_cast<difference_type>(_Right._Myoff);
     }
 
@@ -2873,7 +2874,7 @@ public:
     using reverse_iterator       = _STD reverse_iterator<iterator>;
     using const_reverse_iterator = _STD reverse_iterator<const_iterator>;
 
-    static const int _VBITS = _STD _VBITS;
+    static constexpr difference_type _VBITS_DIFF = _VBITS;
     enum { _EEN_VBITS = _VBITS }; // helper for expression evaluator
 
     _CONSTEXPR20 vector() noexcept(is_nothrow_default_constructible_v<_Alloc>) : _Mybase(_Alloc()) {}
@@ -3504,8 +3505,7 @@ public:
                 *_Pnext         = _Temp->_Mynextiter;
                 continue;
             }
-            const auto _Off = static_cast<size_type>(static_cast<difference_type>(_VBITS) * (_Pnextiter._Myptr - _Base))
-                            + _Pnextiter._Myoff;
+            const auto _Off = static_cast<size_type>(_VBITS_DIFF * (_Pnextiter._Myptr - _Base)) + _Pnextiter._Myoff;
             if (_Off < _Offlo || _Offhi < _Off) {
                 _Pnext = &_Temp->_Mynextiter;
             } else { // orphan the iterator

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -2392,7 +2392,7 @@ public:
     }
 
 #if _ITERATOR_DEBUG_LEVEL != 0
-    _CONSTEXPR20_CONTAINER _Difference_type _Total_off(const _Mycont* _Cont) const noexcept {
+    _CONSTEXPR20 _Difference_type _Total_off(const _Mycont* _Cont) const noexcept {
         return static_cast<_Difference_type>(
             static_cast<_Difference_type>(_VBITS) * (_Myptr - _Cont->_Myvec.data()) + _Myoff);
     }

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -2874,7 +2874,6 @@ public:
     using reverse_iterator       = _STD reverse_iterator<iterator>;
     using const_reverse_iterator = _STD reverse_iterator<const_iterator>;
 
-    static constexpr difference_type _VBITS_DIFF = _VBITS;
     enum { _EEN_VBITS = _VBITS }; // helper for expression evaluator
 
     _CONSTEXPR20 vector() noexcept(is_nothrow_default_constructible_v<_Alloc>) : _Mybase(_Alloc()) {}
@@ -3505,7 +3504,8 @@ public:
                 *_Pnext         = _Temp->_Mynextiter;
                 continue;
             }
-            const auto _Off = static_cast<size_type>(_VBITS_DIFF * (_Pnextiter._Myptr - _Base)) + _Pnextiter._Myoff;
+            const auto _Off =
+                static_cast<size_type>(const_iterator::_VBITS_DIFF * (_Pnextiter._Myptr - _Base)) + _Pnextiter._Myoff;
             if (_Off < _Offlo || _Offhi < _Off) {
                 _Pnext = &_Temp->_Mynextiter;
             } else { // orphan the iterator

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -2392,8 +2392,9 @@ public:
     }
 
 #if _ITERATOR_DEBUG_LEVEL != 0
-    _CONSTEXPR20 _Difference_type _Total_off(const _Mycont* _Cont) const noexcept {
-        return static_cast<_Difference_type>(_VBITS * (_Myptr - _Cont->_Myvec.data()) + _Myoff);
+    _CONSTEXPR20_CONTAINER _Difference_type _Total_off(const _Mycont* _Cont) const noexcept {
+        return static_cast<_Difference_type>(
+            static_cast<_Difference_type>(_VBITS) * (_Myptr - _Cont->_Myvec.data()) + _Myoff);
     }
 #endif // _ITERATOR_DEBUG_LEVEL != 0
 
@@ -2582,7 +2583,7 @@ public:
 
     _NODISCARD _CONSTEXPR20 difference_type operator-(const _Vb_const_iterator& _Right) const noexcept {
         _Compat(_Right);
-        return static_cast<difference_type>(_VBITS * (this->_Myptr - _Right._Myptr))
+        return static_cast<difference_type>(static_cast<difference_type>(_VBITS) * (this->_Myptr - _Right._Myptr))
              + static_cast<difference_type>(this->_Myoff) - static_cast<difference_type>(_Right._Myoff);
     }
 
@@ -3503,7 +3504,8 @@ public:
                 *_Pnext         = _Temp->_Mynextiter;
                 continue;
             }
-            const auto _Off = static_cast<size_type>(_VBITS * (_Pnextiter._Myptr - _Base)) + _Pnextiter._Myoff;
+            const auto _Off = static_cast<size_type>(static_cast<difference_type>(_VBITS) * (_Pnextiter._Myptr - _Base))
+                            + _Pnextiter._Myoff;
             if (_Off < _Offlo || _Offhi < _Off) {
                 _Pnext = &_Temp->_Mynextiter;
             } else { // orphan the iterator

--- a/tests/std/tests/GH_000625_vector_bool_optimization/test.cpp
+++ b/tests/std/tests/GH_000625_vector_bool_optimization/test.cpp
@@ -3,7 +3,9 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cstdint>
 #include <cstdlib>
+#include <memory>
 #include <vector>
 
 using namespace std;
@@ -213,8 +215,48 @@ bool test_count() {
     return true;
 }
 
+// Also test the behavior of a huge vector<bool, A> whose size is greater than SIZE_MAX, which is pratical on 32-bit
+// platforms.
+template <class T>
+struct huge_allocator {
+    huge_allocator() = default;
+    template <class U>
+    constexpr huge_allocator(const huge_allocator<U>) noexcept {}
+
+    using value_type      = T;
+    using size_type       = uint64_t;
+    using difference_type = int64_t;
+
+    T* allocate(uint64_t n) {
+        return allocator<T>{}.allocate(static_cast<size_t>(n));
+    }
+
+    void deallocate(T* p, uint64_t n) {
+        allocator<T>{}.deallocate(p, static_cast<size_t>(n));
+    }
+};
+
+void test_huge_vector_bool() {
+    constexpr uint64_t small_bit_length = 0x7000'4321ULL;
+    constexpr uint64_t large_bit_length = 0x1'2000'4321ULL; // overflows uint32_t
+    constexpr auto large_bit_diff       = static_cast<int64_t>(large_bit_length);
+
+    vector<bool, huge_allocator<bool>> v(small_bit_length);
+    v.resize(large_bit_length);
+    assert(v.end() - v.begin() == large_bit_diff);
+
+    v.back() = true;
+    assert(find(v.begin(), v.end(), true) - v.begin() == large_bit_diff - 1);
+
+    v[small_bit_length] = true;
+    v[large_bit_length - small_bit_length] = true;
+    assert(count(v.begin(), v.end(), false) == large_bit_diff - 3);
+}
+
 int main() {
     test_fill();
     test_find();
     test_count();
+
+    test_huge_vector_bool();
 }

--- a/tests/std/tests/GH_000625_vector_bool_optimization/test.cpp
+++ b/tests/std/tests/GH_000625_vector_bool_optimization/test.cpp
@@ -215,13 +215,13 @@ bool test_count() {
     return true;
 }
 
-// Also test the behavior of a huge vector<bool, A> whose size is greater than SIZE_MAX, which is pratical on 32-bit
-// platforms.
+// Also test the behavior of a huge vector<bool, A> whose size is greater than SIZE_MAX,
+// which is practical on 32-bit platforms.
 template <class T>
 struct huge_allocator {
     huge_allocator() = default;
     template <class U>
-    constexpr huge_allocator(const huge_allocator<U>) noexcept {}
+    constexpr huge_allocator(const huge_allocator<U>&) noexcept {}
 
     using value_type      = T;
     using size_type       = uint64_t;

--- a/tests/std/tests/GH_000625_vector_bool_optimization/test.cpp
+++ b/tests/std/tests/GH_000625_vector_bool_optimization/test.cpp
@@ -248,7 +248,7 @@ void test_huge_vector_bool() {
     v.back() = true;
     assert(find(v.begin(), v.end(), true) - v.begin() == large_bit_diff - 1);
 
-    v[small_bit_length] = true;
+    v[small_bit_length]                    = true;
     v[large_bit_length - small_bit_length] = true;
     assert(count(v.begin(), v.end(), false) == large_bit_diff - 3);
 }


### PR DESCRIPTION
On 32-bit platforms, the following program currently behaves incorrectly with MSVC STL - assertions fail (but pass on 64-bit platforms). [Godbolt link](https://godbolt.org/z/5bqYv1G6h).

```C++
#include <algorithm>
#include <cassert>
#include <cstddef>
#include <cstdint>
#include <memory>
#include <vector>

template <class T>
struct huge_allocator {
    huge_allocator() = default;
    template <class U>
    constexpr huge_allocator(const huge_allocator<U>) noexcept {}

    using value_type      = T;
    using size_type       = std::uint64_t;
    using difference_type = std::int64_t;

    T* allocate(std::uint64_t n) {
        return std::allocator<T>{}.allocate(static_cast<std::size_t>(n));
    }

    void deallocate(T* p, std::uint64_t n) {
        std::allocator<T>{}.deallocate(p, static_cast<std::size_t>(n));
    }
};

int main() {
    constexpr std::uint64_t small_bit_length = 0x7000'4321ULL;
    constexpr std::uint64_t large_bit_length = 0x1'2000'4321ULL; // overflows uint32_t
    constexpr auto large_bit_diff            = static_cast<std::int64_t>(large_bit_length);

    std::vector<bool, huge_allocator<bool>> v(small_bit_length);
    v.resize(large_bit_length);
    assert(v.end() - v.begin() == large_bit_diff);

    v.back() = true;
    assert(std::find(v.begin(), v.end(), true) - v.begin() == large_bit_diff - 1);

    v[small_bit_length]                    = true;
    v[large_bit_length - small_bit_length] = true;
    assert(std::count(v.begin(), v.end(), false) == large_bit_diff - 3);
}
```

The cause of this issue is that multiplication of `_VBITS` (of type `int` after lvalue-to-rvalue conversion) and differences of pointers (of type `ptrdiff_t`) may overflow `int32_t`. IMO it's still reasonable for a 32-bit program to allocate ~600MiB storage for a dynamic bitset, so this issue probably needs fix.

This PR casts `_VBITS` to `difference_type`/`_Difference_type` (which is `int64_t` when using `huge_allocator`) before multiplication in order to fix the issue.
