### PR TITLE
Update LLVM submodule

### DIFF
--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -227,7 +227,7 @@ std/utilities/format/format.tuple/parse.pass.cpp FAIL
 std/utilities/format/format.tuple/set_brackets.pass.cpp FAIL
 std/utilities/format/format.tuple/set_separator.pass.cpp FAIL
 
-# Missing mrbtoc8 and c8rtomb
+# Missing mbrtoc8 and c8rtomb
 std/depr/depr.c.headers/uchar_h.compile.pass.cpp FAIL
 std/strings/c.strings/cuchar.compile.pass.cpp FAIL
 
@@ -643,7 +643,7 @@ std/ranges/range.access/rbegin.pass.cpp FAIL
 std/ranges/range.access/rend.pass.cpp FAIL
 std/ranges/range.access/size.pass.cpp FAIL
 
-# C5101: use of preprocessor directive in function-like macro argument list is undefined behavior
+# warning C5101: use of preprocessor directive in function-like macro argument list is undefined behavior
 std/time/time.syn/formatter.year_month.pass.cpp:0 FAIL
 std/time/time.syn/formatter.year_month_day_last.pass.cpp:0 FAIL
 std/time/time.syn/formatter.year_month_weekday.pass.cpp:0 FAIL

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -34,7 +34,7 @@ std/utilities/template.bitset/bitset.cons/string_ctor.pass.cpp FAIL
 std/thread/futures/futures.task/futures.task.members/dtor.pass.cpp SKIPPED
 std/thread/futures/futures.unique_future/wait_until.pass.cpp SKIPPED
 
-# libcxx is incorrect on what the type passed to allocator::construct should be (https://reviews.llvm.org/D61364)
+# libcxx is incorrect on what the type passed to allocator::construct should be (LLVM-D61364)
 std/containers/associative/map/map.modifiers/insert_and_emplace_allocator_requirements.pass.cpp FAIL
 std/containers/associative/set/insert_and_emplace_allocator_requirements.pass.cpp FAIL
 std/containers/unord/unord.map/unord.map.modifiers/insert_and_emplace_allocator_requirements.pass.cpp FAIL
@@ -42,18 +42,6 @@ std/containers/unord/unord.set/insert_and_emplace_allocator_requirements.pass.cp
 
 # Bogus test believes that copyability of array<T, 0> must be the same as array<T, 1>
 std/containers/sequences/array/array.cons/implicit_copy.pass.cpp FAIL
-
-# Bogus test returns a non-const int& using a const iterator's member variable
-std/ranges/range.adaptors/range.zip/end.pass.cpp FAIL
-
-# libc++ doesn't implement LWG-3648: "format should not print bool with 'c'"
-std/utilities/format/format.functions/vformat_to.locale.pass.cpp FAIL
-std/utilities/format/format.functions/vformat_to.pass.cpp FAIL
-std/utilities/format/format.functions/vformat.locale.pass.cpp FAIL
-std/utilities/format/format.functions/vformat.pass.cpp FAIL
-
-# libc++ fix allocator in allocator_propagation test (LLVM-D131079)
-std/strings/basic.string/string.nonmembers/string_op+/allocator_propagation.pass.cpp FAIL
 
 # libc++ hasn't updated move_iterator for P2520R0
 std/iterators/predef.iterators/move.iterators/move.iterator/types.pass.cpp FAIL
@@ -66,20 +54,23 @@ std/ranges/range.access/end.pass.cpp FAIL
 std/ranges/range.access/rbegin.pass.cpp FAIL
 std/ranges/range.access/rend.pass.cpp FAIL
 
-# libc++ doesn't implement LWG-3692: "zip_view::iterator's operator<=> is overconstrained"
-std/ranges/range.adaptors/range.zip/iterator/compare.pass.cpp FAIL
+# Various bogosity (LLVM-D141004)
+std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/construct_pair_const_lvalue_pair.pass.cpp:0 FAIL
+std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/construct_pair_values.pass.cpp:0 FAIL
+std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/resource.pass.cpp FAIL
+std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/select_on_container_copy_construction.pass.cpp FAIL
+std/utilities/utility/mem.res/mem.res.pool/mem.res.pool.ctor/ctor_does_not_allocate.pass.cpp FAIL
+std/utilities/utility/mem.res/mem.res.pool/mem.res.pool.ctor/sync_with_default_resource.pass.cpp FAIL
+std/utilities/utility/mem.res/mem.res.pool/mem.res.pool.ctor/unsync_with_default_resource.pass.cpp FAIL
+std/utilities/utility/mem.res/mem.res.pool/mem.res.pool.mem/sync_allocate.pass.cpp FAIL
+std/utilities/utility/mem.res/mem.res.pool/mem.res.pool.mem/sync_allocate_overaligned_request.pass.cpp FAIL
+std/utilities/utility/mem.res/mem.res.pool/mem.res.pool.mem/sync_deallocate_matches_allocate.pass.cpp FAIL
+std/utilities/utility/mem.res/mem.res.pool/mem.res.pool.mem/unsync_allocate.pass.cpp FAIL
+std/utilities/utility/mem.res/mem.res.pool/mem.res.pool.mem/unsync_allocate_overaligned_request.pass.cpp FAIL
+std/utilities/utility/mem.res/mem.res.pool/mem.res.pool.mem/unsync_deallocate_matches_allocate.pass.cpp FAIL
 
-# libc++ is incorrect on the constraints for constructors of zip_view::iterator and zip_view::sentinel
-std/ranges/range.adaptors/range.zip/begin.pass.cpp SKIPPED
-std/ranges/range.adaptors/range.zip/sentinel/ctor.default.pass.cpp SKIPPED
-
-# libc++ has not implemented P2165R4: "Compatibility between tuple, pair, and tuple-like objects"
-# for zip_view
-std/ranges/range.adaptors/range.zip/cpo.pass.cpp FAIL
-std/ranges/range.adaptors/range.zip/ctor.default.pass.cpp FAIL
-std/ranges/range.adaptors/range.zip/iterator/deref.pass.cpp FAIL
-std/ranges/range.adaptors/range.zip/iterator/member_types.compile.pass.cpp FAIL
-std/ranges/range.adaptors/range.zip/iterator/subscript.pass.cpp FAIL
+# Too many constexpr operations
+std/utilities/charconv/charconv.to.chars/integral.pass.cpp FAIL
 
 
 # *** INTERACTIONS WITH CONTEST / C1XX THAT UPSTREAM LIKELY WON'T FIX ***
@@ -215,12 +206,30 @@ std/utilities/tuple/tuple.tuple/tuple.cnstr/recursion_depth.pass.cpp SKIPPED
 
 
 # *** MISSING STL FEATURES ***
+# P1169R4 static operator()
+std/thread/futures/futures.task/futures.task.members/ctad.static.compile.pass.cpp FAIL
+
 # P2321R2 zip
 std/language.support/support.limits/support.limits.general/tuple.version.compile.pass.cpp FAIL
 std/language.support/support.limits/support.limits.general/utility.version.compile.pass.cpp FAIL
 
 # P2255R2 "Type Traits To Detect References Binding To Temporaries"
 std/language.support/support.limits/support.limits.general/type_traits.version.compile.pass.cpp FAIL
+
+# P2286R8 Formatting Ranges
+std/utilities/format/format.formattable/concept.formattable.compile.pass.cpp FAIL
+std/utilities/format/format.range/format.range.fmtkind/format_kind.compile.pass.cpp FAIL
+std/utilities/format/format.range/format.range.fmtkind/range_format.compile.pass.cpp FAIL
+std/utilities/format/format.tuple/format.functions.format.pass.cpp FAIL
+std/utilities/format/format.tuple/format.functions.vformat.pass.cpp FAIL
+std/utilities/format/format.tuple/format.pass.cpp FAIL
+std/utilities/format/format.tuple/parse.pass.cpp FAIL
+std/utilities/format/format.tuple/set_brackets.pass.cpp FAIL
+std/utilities/format/format.tuple/set_separator.pass.cpp FAIL
+
+# Missing mrbtoc8 and c8rtomb
+std/depr/depr.c.headers/uchar_h.compile.pass.cpp FAIL
+std/strings/c.strings/cuchar.compile.pass.cpp FAIL
 
 
 # *** MISSING COMPILER FEATURES ***
@@ -239,6 +248,9 @@ std/thread/futures/futures.promise/set_rvalue_at_thread_exit.pass.cpp FAIL
 std/thread/futures/futures.promise/set_value_at_thread_exit_const.pass.cpp FAIL
 std/thread/futures/futures.promise/set_value_at_thread_exit_void.pass.cpp FAIL
 std/thread/futures/futures.task/futures.task.members/make_ready_at_thread_exit.pass.cpp FAIL
+
+# LWG-3120 "Unclear behavior of monotonic_buffer_resource::release()" (vNext)
+std/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.mem/allocate_from_underaligned_buffer.pass.cpp FAIL
 
 # LWG-3633 "Atomics are copy constructible and copy assignable from volatile atomics" (Open)
 std/atomics/atomics.types.generic/copy_semantics_traits.pass.cpp FAIL
@@ -307,6 +319,10 @@ std/language.support/support.dynamic/new.delete/new.delete.single/sized_delete14
 # Not yet analyzed. Clang apparently defines platform macros differently from C1XX.
 std/language.support/support.limits/limits/numeric.limits.members/traps.pass.cpp:1 FAIL
 
+# Not yet analyzed. Possibly C++20 equality operator rewrite issues.
+std/utilities/expected/expected.expected/equality/equality.other_expected.pass.cpp:1 FAIL
+std/utilities/expected/expected.void/equality/equality.other_expected.pass.cpp:1 FAIL
+
 
 # *** STL BUGS ***
 # GH-1112 <locale>: the enum value of std::money_base is not correct
@@ -369,6 +385,9 @@ std/numerics/c.math/cmath.pass.cpp FAIL
 
 # GH-1374: Spaceship CPO wording in [cmp.alg] needs an overhaul
 # (Technically an STL bug until the wording in the working draft is fixed to agree.)
+std/language.support/cmp/cmp.alg/compare_partial_order_fallback.pass.cpp FAIL
+std/language.support/cmp/cmp.alg/compare_strong_order_fallback.pass.cpp FAIL
+std/language.support/cmp/cmp.alg/compare_weak_order_fallback.pass.cpp FAIL
 std/language.support/cmp/cmp.alg/partial_order.pass.cpp FAIL
 std/language.support/cmp/cmp.alg/strong_order.pass.cpp FAIL
 std/language.support/cmp/cmp.alg/weak_order.pass.cpp FAIL
@@ -379,6 +398,9 @@ std/strings/basic.string/string.modifiers/robust_against_adl.pass.cpp FAIL
 
 # GH-3100: <memory> etc.: ADL should be avoided when calling _Construct_in_place and its friends
 std/utilities/function.objects/func.wrap/func.wrap.func/robust_against_adl.pass.cpp FAIL
+
+# GH-3336: Failure to format basic_string_view with non-standard traits
+std/utilities/format/format.arguments/format.arg/visit_format_arg.pass.cpp FAIL
 
 
 # *** CRT BUGS ***
@@ -524,15 +546,6 @@ std/iterators/iterator.primitives/iterator.operations/robust_against_adl.pass.cp
 # Non-Standard assumption that std::filesystem::file_time_type::duration::period is std::nano
 std/input.output/filesystems/fs.filesystem.synopsis/file_time_type_resolution.compile.pass.cpp FAIL
 
-# Uses-allocator class constructor wants non-const allocator ref and mismatched piecewise_construct's value category
-std/utilities/allocator.adaptor/allocator.adaptor.members/construct.pass.cpp FAIL
-std/utilities/allocator.adaptor/allocator.adaptor.members/construct_pair.pass.cpp FAIL
-std/utilities/allocator.adaptor/allocator.adaptor.members/construct_pair_const_lvalue_pair.pass.cpp FAIL
-std/utilities/allocator.adaptor/allocator.adaptor.members/construct_pair_piecewise.pass.cpp FAIL
-std/utilities/allocator.adaptor/allocator.adaptor.members/construct_pair_rvalue.pass.cpp FAIL
-std/utilities/allocator.adaptor/allocator.adaptor.members/construct_pair_values.pass.cpp FAIL
-std/utilities/allocator.adaptor/allocator.adaptor.members/construct_type.pass.cpp FAIL
-
 # Tests expect __cpp_lib_ranges to have the old value 201811L for P0896R4; we define the C++20 value 201911L for P1716R3.
 std/language.support/support.limits/support.limits.general/algorithm.version.compile.pass.cpp FAIL
 std/language.support/support.limits/support.limits.general/functional.version.compile.pass.cpp FAIL
@@ -565,20 +578,8 @@ std/utilities/format/format.formatter/format.formatter.spec/formatter.pointer.pa
 std/utilities/format/format.formatter/format.formatter.spec/formatter.signed_integral.pass.cpp FAIL
 std/utilities/format/format.formatter/format.formatter.spec/formatter.string.pass.cpp FAIL
 std/utilities/format/format.formatter/format.formatter.spec/formatter.unsigned_integral.pass.cpp FAIL
-std/utilities/format/format.formatter/format.formatter.spec/types.compile.pass.cpp FAIL
 std/utilities/format/format.formatter/format.formatter.spec/formatter.char.pass.cpp FAIL
 std/utilities/format/format.formatter/format.formatter.spec/formatter.floating_point.pass.cpp FAIL
-
-# Tests fail because -NaN is formatted differently (and other reasons).
-std/utilities/format/format.functions/format.pass.cpp FAIL
-std/utilities/format/format.functions/format.locale.pass.cpp FAIL
-std/utilities/format/format.functions/format_to.locale.pass.cpp FAIL
-std/utilities/format/format.functions/format_to.pass.cpp FAIL
-std/utilities/format/format.functions/format_to_n.pass.cpp FAIL
-std/utilities/format/format.functions/format_to_n.locale.pass.cpp FAIL
-std/utilities/format/format.functions/formatted_size.pass.cpp FAIL
-std/utilities/format/format.functions/formatted_size.locale.pass.cpp FAIL
-std/utilities/format/format.functions/locale-specific_form.pass.cpp FAIL
 
 # libc++ chose option A for [time.clock.file.members], and we chose option B.
 std/time/time.clock/time.clock.file/to_from_sys.pass.cpp FAIL
@@ -593,7 +594,9 @@ std/language.support/support.limits/support.limits.general/ranges.version.compil
 std/containers/sequences/vector/vector.cons/assign_copy.pass.cpp FAIL
 
 # LIT's ADDITIONAL_COMPILE_FLAGS is problematic
-std/utilities/function.objects/func.wrap/func.wrap.func/func.wrap.func.con/copy_move.pass.cpp SKIPPED
+std/utilities/meta/meta.unary/dependent_return_type.compile.pass.cpp SKIPPED
+std/utilities/format/format.functions/escaped_output.ascii.pass.cpp SKIPPED
+std/utilities/variant/variant.variant/implicit_ctad.pass.cpp SKIPPED
 
 # MoveOnlyForwardIterator (a misnomer) has mixed-type comparisons and conversions
 std/ranges/range.utility/range.subrange/primitives.pass.cpp:0 FAIL
@@ -630,7 +633,7 @@ std/utilities/variant/variant.variant/variant.assign/T.pass.cpp FAIL
 std/utilities/variant/variant.variant/variant.ctor/conv.pass.cpp FAIL
 std/utilities/variant/variant.variant/variant.ctor/T.pass.cpp FAIL
 
-# libc++ is missing a requires-clause on variant's operator<=> (llvm/llvm-project#58192)
+# libc++ is missing a requires-clause on variant's operator<=> (LLVM-58192)
 std/utilities/variant/variant.relops/three_way.pass.cpp FAIL
 
 # libc++ doesn't yet implement P2602R2 "Poison Pills Are Too Toxic"
@@ -639,6 +642,11 @@ std/ranges/range.access/end.pass.cpp FAIL
 std/ranges/range.access/rbegin.pass.cpp FAIL
 std/ranges/range.access/rend.pass.cpp FAIL
 std/ranges/range.access/size.pass.cpp FAIL
+
+# C5101: use of preprocessor directive in function-like macro argument list is undefined behavior
+std/time/time.syn/formatter.year_month.pass.cpp:0 FAIL
+std/time/time.syn/formatter.year_month_day_last.pass.cpp:0 FAIL
+std/time/time.syn/formatter.year_month_weekday.pass.cpp:0 FAIL
 
 
 # *** LIKELY STL BUGS ***
@@ -742,8 +750,9 @@ std/localization/locale.categories/category.ctype/locale.codecvt/locale.codecvt.
 std/localization/locale.categories/category.ctype/locale.codecvt/locale.codecvt.members/char32_t_encoding.pass.cpp FAIL
 std/localization/locale.categories/category.ctype/locale.codecvt/locale.codecvt.members/char32_t_max_length.pass.cpp FAIL
 
-# Likely STL bug in <format>: we check argument ids at compiletime in next_arg_id
+# Likely STL bugs in <format>
 std/utilities/format/format.formatter/format.parse.ctx/next_arg_id.pass.cpp FAIL
+std/time/time.syn/formatter.month_day_last.pass.cpp FAIL
 
 # Likely STL bug in `bind_front`: we don't respect deletion of the target call operator
 std/utilities/function.objects/func.bind_front/bind_front.pass.cpp FAIL
@@ -756,6 +765,9 @@ std/ranges/range.adaptors/range.join.view/iterator/iter.swap.pass.cpp:0 FAIL
 std/ranges/range.adaptors/range.join.view/iterator/star.pass.cpp:0 FAIL
 std/ranges/range.adaptors/range.join.view/sentinel/ctor.parent.pass.cpp:1 FAIL
 std/ranges/range.adaptors/range.join.view/sentinel/eq.pass.cpp:1 FAIL
+
+# Our monotonic_buffer_resource takes "user" space for metadata, which it probably should not do.
+std/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.mem/allocate_with_initial_size.pass.cpp FAIL
 
 
 # *** NOT YET ANALYZED ***
@@ -787,7 +799,7 @@ std/utilities/tuple/tuple.tuple/tuple.cnstr/deduct.pass.cpp:0 FAIL
 # Not yet analyzed. Frequent timeouts
 std/containers/sequences/deque/deque.modifiers/insert_iter_iter.pass.cpp SKIPPED
 
-# Not yet analyzed. Failing after https://reviews.llvm.org/D75622.
+# Not yet analyzed. Failing after LLVM-D75622.
 std/re/re.const/re.matchflag/match_prev_avail.pass.cpp FAIL
 
 # Not yet analyzed. Many diagnostics.
@@ -843,15 +855,6 @@ std/numerics/rand/rand.dist/rand.dist.pois/rand.dist.pois.poisson/eval_param.pas
 std/numerics/rand/rand.dist/rand.dist.bern/rand.dist.bern.bin/eval_param.pass.cpp FAIL
 std/numerics/rand/rand.dist/rand.dist.bern/rand.dist.bern.bin/eval.pass.cpp FAIL
 
-# Not yet analyzed
-# MSVC is saying "note: failure was caused by a read of a variable outside its lifetime"
-# for constant evaluation failure, which is buggy.
-# compare_strong_order_fallback.pass.cpp and compare_weak_order_fallback.pass.cpp are
-# using _VSTD, perhaps we should replace it with std, or some conditionally defined macro.
-std/language.support/cmp/cmp.alg/compare_partial_order_fallback.pass.cpp FAIL
-std/language.support/cmp/cmp.alg/compare_strong_order_fallback.pass.cpp FAIL
-std/language.support/cmp/cmp.alg/compare_weak_order_fallback.pass.cpp FAIL
-
 # Not yet analyzed. Runs forever
 std/numerics/rand/rand.dist/rand.dist.pois/rand.dist.pois.poisson/eval.pass.cpp SKIPPED
 
@@ -875,7 +878,6 @@ std/localization/locale.categories/category.numeric/locale.nm.put/facet.num.put.
 
 # Not yet analyzed. These tests use characters that cannot be represented in legacy character encodings
 std/utilities/format/format.functions/ascii.pass.cpp FAIL
-std/utilities/format/format.functions/unicode.pass.cpp:0 FAIL
 
 # Not yet analyzed. "constexpr evaluation hit maximum step limit; possible infinite loop?"
 std/utilities/template.bitset/bitset.members/left_shift_eq.pass.cpp FAIL
@@ -918,10 +920,6 @@ std/algorithms/alg.sorting/alg.sort/partial.sort.copy/ranges_partial_sort_copy.p
 std/algorithms/algorithms.results/in_found_result.pass.cpp:0 FAIL
 std/algorithms/algorithms.results/min_max_result.pass.cpp:0 FAIL
 std/algorithms/ranges_robust_against_dangling.pass.cpp FAIL
-std/algorithms/ranges_robust_against_differing_projections.pass.cpp FAIL
-std/algorithms/ranges_robust_against_nonbool_predicates.pass.cpp FAIL
-std/algorithms/ranges_robust_against_omitting_invoke.pass.cpp FAIL
-std/algorithms/ranges_robust_against_proxy_iterators.pass.cpp FAIL
 std/algorithms/robust_against_proxy_iterators_lifetime_bugs.pass.cpp FAIL
 std/concepts/concepts.lang/concept.default.init/default_initializable.compile.pass.cpp:0 FAIL
 std/containers/sequences/deque/abi.compile.pass.cpp FAIL
@@ -958,7 +956,6 @@ std/iterators/predef.iterators/move.iterators/move.iterator/iterator_concept_con
 std/language.support/support.limits/support.limits.general/cmath.version.compile.pass.cpp FAIL
 std/language.support/support.limits/support.limits.general/cstdlib.version.compile.pass.cpp FAIL
 std/language.support/support.limits/support.limits.general/new.version.compile.pass.cpp FAIL
-std/localization/locale.categories/category.monetary/locale.money.get/locale.money.get.members/get_long_double_zh_CN.pass.cpp:0 FAIL
 std/ranges/range.adaptors/range.filter/iterator/arrow.pass.cpp FAIL
 std/ranges/range.adaptors/range.filter/iterator/base.pass.cpp FAIL
 std/ranges/range.adaptors/range.filter/iterator/compare.pass.cpp FAIL
@@ -1008,7 +1005,24 @@ std/ranges/range.adaptors/range.lazy.split/range.lazy.split.outer/types.compile.
 std/ranges/range.adaptors/range.lazy.split/view_interface.pass.cpp FAIL
 std/ranges/range.adaptors/range.take/adaptor.pass.cpp FAIL
 std/ranges/range.factories/range.single.view/cpo.pass.cpp FAIL
-std/strings/basic.string/string.cons/dtor.pass.cpp FAIL
+std/thread/futures/futures.task/futures.task.members/ctor2.compile.pass.cpp FAIL
+std/utilities/format/format.functions/escaped_output.ascii.pass.cpp FAIL
+std/utilities/format/format.functions/format.locale.pass.cpp FAIL
+std/utilities/format/format.functions/format.pass.cpp FAIL
+std/utilities/format/format.functions/locale-specific_form.pass.cpp FAIL
+std/utilities/format/format.functions/vformat.locale.pass.cpp FAIL
+std/utilities/format/format.functions/vformat.pass.cpp FAIL
+std/utilities/function.objects/func.wrap/func.wrap.func/func.wrap.func.con/ctad.static.compile.pass.cpp FAIL
+std/utilities/function.objects/func.wrap/func.wrap.func/func.wrap.func.inv/invoke.pass.cpp:0 FAIL
+std/utilities/function.objects/refwrap/refwrap.const/type_conv_ctor.pass.cpp:0 FAIL
+std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.create/allocate_shared.array.unbounded.pass.cpp FAIL
+std/utilities/meta/meta.logical/conjunction.compile.pass.cpp FAIL
+std/utilities/meta/meta.logical/disjunction.compile.pass.cpp FAIL
+std/utilities/meta/meta.unary/meta.unary.prop/is_nothrow_copy_assignable.pass.cpp:0 FAIL
+std/utilities/meta/meta.unary/meta.unary.prop/is_nothrow_move_assignable.pass.cpp:0 FAIL
+std/utilities/tuple/tuple.tuple/tuple.cnstr/convert_const_move.pass.cpp FAIL
+
+# Not yet analyzed, probably MSVC constexpr issue(s)
 std/strings/basic.string/string.modifiers/string_erase/iter.pass.cpp:0 FAIL
 std/strings/basic.string/string.modifiers/string_erase/iter_iter.pass.cpp:0 FAIL
 std/strings/basic.string/string.modifiers/string_insert/iter_iter_iter.pass.cpp:0 FAIL
@@ -1019,36 +1033,13 @@ std/strings/basic.string/string.modifiers/string_replace/iter_iter_pointer_size.
 std/strings/basic.string/string.modifiers/string_replace/iter_iter_size_char.pass.cpp:0 FAIL
 std/strings/basic.string/string.modifiers/string_replace/iter_iter_string.pass.cpp:0 FAIL
 std/strings/basic.string/string.modifiers/string_replace/iter_iter_string_view.pass.cpp:0 FAIL
-std/thread/futures/futures.task/futures.task.members/ctor2.compile.pass.cpp FAIL
-std/utilities/function.objects/func.wrap/func.wrap.func/addressof.pass.cpp:0 FAIL
-std/utilities/function.objects/func.wrap/func.wrap.func/func.wrap.func.alg/swap.pass.cpp:0 FAIL
-std/utilities/function.objects/func.wrap/func.wrap.func/func.wrap.func.cap/operator_bool.pass.cpp:0 FAIL
-std/utilities/function.objects/func.wrap/func.wrap.func/func.wrap.func.con/copy_assign.pass.cpp:0 FAIL
-std/utilities/function.objects/func.wrap/func.wrap.func/func.wrap.func.con/default.pass.cpp:0 FAIL
-std/utilities/function.objects/func.wrap/func.wrap.func/func.wrap.func.con/F.pass.cpp:0 FAIL
-std/utilities/function.objects/func.wrap/func.wrap.func/func.wrap.func.con/F_assign.pass.cpp:0 FAIL
-std/utilities/function.objects/func.wrap/func.wrap.func/func.wrap.func.con/F_incomplete.pass.cpp:0 FAIL
-std/utilities/function.objects/func.wrap/func.wrap.func/func.wrap.func.con/F_nullptr.pass.cpp:0 FAIL
-std/utilities/function.objects/func.wrap/func.wrap.func/func.wrap.func.con/nullptr_t.pass.cpp:0 FAIL
-std/utilities/function.objects/func.wrap/func.wrap.func/func.wrap.func.con/nullptr_t_assign.pass.cpp:0 FAIL
-std/utilities/function.objects/func.wrap/func.wrap.func/func.wrap.func.inv/invoke.pass.cpp:0 FAIL
-std/utilities/function.objects/func.wrap/func.wrap.func/func.wrap.func.mod/assign_F_alloc.pass.cpp:0 FAIL
-std/utilities/function.objects/func.wrap/func.wrap.func/func.wrap.func.mod/swap.pass.cpp:0 FAIL
-std/utilities/function.objects/func.wrap/func.wrap.func/func.wrap.func.nullptr/operator_==.pass.cpp:0 FAIL
-std/utilities/function.objects/func.wrap/func.wrap.func/func.wrap.func.targ/target.pass.cpp:0 FAIL
-std/utilities/function.objects/func.wrap/func.wrap.func/func.wrap.func.targ/target_type.pass.cpp:0 FAIL
-std/utilities/function.objects/func.wrap/func.wrap.func/types.pass.cpp:0 FAIL
-std/utilities/function.objects/refwrap/refwrap.const/type_conv_ctor.pass.cpp:0 FAIL
-std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.create/allocate_shared.array.unbounded.pass.cpp FAIL
-std/utilities/meta/meta.logical/conjunction.compile.pass.cpp FAIL
-std/utilities/meta/meta.logical/disjunction.compile.pass.cpp FAIL
-std/utilities/meta/meta.unary/meta.unary.prop/is_nothrow_copy_assignable.pass.cpp:0 FAIL
-std/utilities/meta/meta.unary/meta.unary.prop/is_nothrow_move_assignable.pass.cpp:0 FAIL
-std/utilities/tuple/tuple.tuple/tuple.cnstr/convert_const_move.pass.cpp FAIL
 
 # Not yet analyzed, possible path length issue. With a repo root of D:\GitHub\STL (13 characters), fails with:
 # "error RC2136 : missing '=' in EXSTYLE=<flags>" followed by "LINK : fatal error LNK1327: failure during running rc.exe"
 std/thread/thread.mutex/thread.mutex.requirements/thread.sharedtimedmutex.requirements/thread.sharedtimedmutex.class/try_lock_until_deadlock_bug.pass.cpp SKIPPED
+
+# Not yet analyzed, possible bug in uses_allocator_construction_args
+std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/construct_piecewise_pair_evil.pass.cpp FAIL
 
 
 # *** XFAILs WHICH PASS ***

--- a/tests/libcxx/magic_comments.txt
+++ b/tests/libcxx/magic_comments.txt
@@ -9,3 +9,5 @@
 // REQUIRES: stdlib=libc++
 // UNSUPPORTED: c++14, c++17, c++2a
 // UNSUPPORTED: msvc
+// UNSUPPORTED: msvc, target={{.+}}-windows-gnu
+// UNSUPPORTED: windows

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -34,7 +34,7 @@ utilities\template.bitset\bitset.cons\string_ctor.pass.cpp
 thread\futures\futures.task\futures.task.members\dtor.pass.cpp
 thread\futures\futures.unique_future\wait_until.pass.cpp
 
-# libcxx is incorrect on what the type passed to allocator::construct should be (https://reviews.llvm.org/D61364)
+# libcxx is incorrect on what the type passed to allocator::construct should be (LLVM-D61364)
 containers\associative\map\map.modifiers\insert_and_emplace_allocator_requirements.pass.cpp
 containers\associative\set\insert_and_emplace_allocator_requirements.pass.cpp
 containers\unord\unord.map\unord.map.modifiers\insert_and_emplace_allocator_requirements.pass.cpp
@@ -42,18 +42,6 @@ containers\unord\unord.set\insert_and_emplace_allocator_requirements.pass.cpp
 
 # Bogus test believes that copyability of array<T, 0> must be the same as array<T, 1>
 containers\sequences\array\array.cons\implicit_copy.pass.cpp
-
-# Bogus test returns a non-const int& using a const iterator's member variable
-ranges\range.adaptors\range.zip\end.pass.cpp
-
-# libc++ doesn't implement LWG-3648: "format should not print bool with 'c'"
-utilities\format\format.functions\vformat_to.locale.pass.cpp
-utilities\format\format.functions\vformat_to.pass.cpp
-utilities\format\format.functions\vformat.locale.pass.cpp
-utilities\format\format.functions\vformat.pass.cpp
-
-# libc++ fix allocator in allocator_propagation test (LLVM-D131079)
-strings\basic.string\string.nonmembers\string_op+\allocator_propagation.pass.cpp
 
 # libc++ hasn't updated move_iterator for P2520R0
 iterators\predef.iterators\move.iterators\move.iterator\types.pass.cpp
@@ -66,20 +54,23 @@ ranges\range.access\end.pass.cpp
 ranges\range.access\rbegin.pass.cpp
 ranges\range.access\rend.pass.cpp
 
-# libc++ doesn't implement LWG-3692: "zip_view::iterator's operator<=> is overconstrained"
-ranges\range.adaptors\range.zip\iterator\compare.pass.cpp
+# Various bogosity (LLVM-D141004)
+utilities\utility\mem.res\mem.poly.allocator.class\mem.poly.allocator.mem\construct_pair_const_lvalue_pair.pass.cpp
+utilities\utility\mem.res\mem.poly.allocator.class\mem.poly.allocator.mem\construct_pair_values.pass.cpp
+utilities\utility\mem.res\mem.poly.allocator.class\mem.poly.allocator.mem\resource.pass.cpp
+utilities\utility\mem.res\mem.poly.allocator.class\mem.poly.allocator.mem\select_on_container_copy_construction.pass.cpp
+utilities\utility\mem.res\mem.res.pool\mem.res.pool.ctor\ctor_does_not_allocate.pass.cpp
+utilities\utility\mem.res\mem.res.pool\mem.res.pool.ctor\sync_with_default_resource.pass.cpp
+utilities\utility\mem.res\mem.res.pool\mem.res.pool.ctor\unsync_with_default_resource.pass.cpp
+utilities\utility\mem.res\mem.res.pool\mem.res.pool.mem\sync_allocate.pass.cpp
+utilities\utility\mem.res\mem.res.pool\mem.res.pool.mem\sync_allocate_overaligned_request.pass.cpp
+utilities\utility\mem.res\mem.res.pool\mem.res.pool.mem\sync_deallocate_matches_allocate.pass.cpp
+utilities\utility\mem.res\mem.res.pool\mem.res.pool.mem\unsync_allocate.pass.cpp
+utilities\utility\mem.res\mem.res.pool\mem.res.pool.mem\unsync_allocate_overaligned_request.pass.cpp
+utilities\utility\mem.res\mem.res.pool\mem.res.pool.mem\unsync_deallocate_matches_allocate.pass.cpp
 
-# libc++ is incorrect on the constraints for constructors of zip_view::iterator and zip_view::sentinel
-ranges\range.adaptors\range.zip\begin.pass.cpp
-ranges\range.adaptors\range.zip\sentinel\ctor.default.pass.cpp
-
-# libc++ has not implemented P2165R4: "Compatibility between tuple, pair, and tuple-like objects"
-# for zip_view
-ranges\range.adaptors\range.zip\cpo.pass.cpp
-ranges\range.adaptors\range.zip\ctor.default.pass.cpp
-ranges\range.adaptors\range.zip\iterator\deref.pass.cpp
-ranges\range.adaptors\range.zip\iterator\member_types.compile.pass.cpp
-ranges\range.adaptors\range.zip\iterator\subscript.pass.cpp
+# Too many constexpr operations
+utilities\charconv\charconv.to.chars\integral.pass.cpp
 
 
 # *** INTERACTIONS WITH CONTEST / C1XX THAT UPSTREAM LIKELY WON'T FIX ***
@@ -215,12 +206,30 @@ utilities\tuple\tuple.tuple\tuple.cnstr\recursion_depth.pass.cpp
 
 
 # *** MISSING STL FEATURES ***
+# P1169R4 static operator()
+thread\futures\futures.task\futures.task.members\ctad.static.compile.pass.cpp
+
 # P2321R2 zip
 language.support\support.limits\support.limits.general\tuple.version.compile.pass.cpp
 language.support\support.limits\support.limits.general\utility.version.compile.pass.cpp
 
 # P2255R2 "Type Traits To Detect References Binding To Temporaries"
 language.support\support.limits\support.limits.general\type_traits.version.compile.pass.cpp
+
+# P2286R8 Formatting Ranges
+utilities\format\format.formattable\concept.formattable.compile.pass.cpp
+utilities\format\format.range\format.range.fmtkind\format_kind.compile.pass.cpp
+utilities\format\format.range\format.range.fmtkind\range_format.compile.pass.cpp
+utilities\format\format.tuple\format.functions.format.pass.cpp
+utilities\format\format.tuple\format.functions.vformat.pass.cpp
+utilities\format\format.tuple\format.pass.cpp
+utilities\format\format.tuple\parse.pass.cpp
+utilities\format\format.tuple\set_brackets.pass.cpp
+utilities\format\format.tuple\set_separator.pass.cpp
+
+# Missing mrbtoc8 and c8rtomb
+depr\depr.c.headers\uchar_h.compile.pass.cpp
+strings\c.strings\cuchar.compile.pass.cpp
 
 
 # *** MISSING COMPILER FEATURES ***
@@ -239,6 +248,9 @@ thread\futures\futures.promise\set_rvalue_at_thread_exit.pass.cpp
 thread\futures\futures.promise\set_value_at_thread_exit_const.pass.cpp
 thread\futures\futures.promise\set_value_at_thread_exit_void.pass.cpp
 thread\futures\futures.task\futures.task.members\make_ready_at_thread_exit.pass.cpp
+
+# LWG-3120 "Unclear behavior of monotonic_buffer_resource::release()" (vNext)
+utilities\utility\mem.res\mem.res.monotonic.buffer\mem.res.monotonic.buffer.mem\allocate_from_underaligned_buffer.pass.cpp
 
 # LWG-3633 "Atomics are copy constructible and copy assignable from volatile atomics" (Open)
 atomics\atomics.types.generic\copy_semantics_traits.pass.cpp
@@ -307,6 +319,10 @@ language.support\support.dynamic\new.delete\new.delete.single\sized_delete14.pas
 # Not yet analyzed. Clang apparently defines platform macros differently from C1XX.
 language.support\support.limits\limits\numeric.limits.members\traps.pass.cpp
 
+# Not yet analyzed. Possibly C++20 equality operator rewrite issues.
+utilities\expected\expected.expected\equality\equality.other_expected.pass.cpp
+utilities\expected\expected.void\equality\equality.other_expected.pass.cpp
+
 
 # *** STL BUGS ***
 # GH-1112 <locale>: the enum value of std::money_base is not correct
@@ -369,6 +385,9 @@ numerics\c.math\cmath.pass.cpp
 
 # GH-1374: Spaceship CPO wording in [cmp.alg] needs an overhaul
 # (Technically an STL bug until the wording in the working draft is fixed to agree.)
+language.support\cmp\cmp.alg\compare_partial_order_fallback.pass.cpp
+language.support\cmp\cmp.alg\compare_strong_order_fallback.pass.cpp
+language.support\cmp\cmp.alg\compare_weak_order_fallback.pass.cpp
 language.support\cmp\cmp.alg\partial_order.pass.cpp
 language.support\cmp\cmp.alg\strong_order.pass.cpp
 language.support\cmp\cmp.alg\weak_order.pass.cpp
@@ -379,6 +398,9 @@ strings\basic.string\string.modifiers\robust_against_adl.pass.cpp
 
 # GH-3100: <memory> etc.: ADL should be avoided when calling _Construct_in_place and its friends
 utilities\function.objects\func.wrap\func.wrap.func\robust_against_adl.pass.cpp
+
+# GH-3336: Failure to format basic_string_view with non-standard traits
+utilities\format\format.arguments\format.arg\visit_format_arg.pass.cpp
 
 
 # *** CRT BUGS ***
@@ -524,15 +546,6 @@ iterators\iterator.primitives\iterator.operations\robust_against_adl.pass.cpp
 # Non-Standard assumption that std::filesystem::file_time_type::duration::period is std::nano
 input.output\filesystems\fs.filesystem.synopsis\file_time_type_resolution.compile.pass.cpp
 
-# Uses-allocator class constructor wants non-const allocator ref and mismatched piecewise_construct's value category
-utilities\allocator.adaptor\allocator.adaptor.members\construct.pass.cpp
-utilities\allocator.adaptor\allocator.adaptor.members\construct_pair.pass.cpp
-utilities\allocator.adaptor\allocator.adaptor.members\construct_pair_const_lvalue_pair.pass.cpp
-utilities\allocator.adaptor\allocator.adaptor.members\construct_pair_piecewise.pass.cpp
-utilities\allocator.adaptor\allocator.adaptor.members\construct_pair_rvalue.pass.cpp
-utilities\allocator.adaptor\allocator.adaptor.members\construct_pair_values.pass.cpp
-utilities\allocator.adaptor\allocator.adaptor.members\construct_type.pass.cpp
-
 # Tests expect __cpp_lib_ranges to have the old value 201811L for P0896R4; we define the C++20 value 201911L for P1716R3.
 language.support\support.limits\support.limits.general\algorithm.version.compile.pass.cpp
 language.support\support.limits\support.limits.general\functional.version.compile.pass.cpp
@@ -565,20 +578,8 @@ utilities\format\format.formatter\format.formatter.spec\formatter.pointer.pass.c
 utilities\format\format.formatter\format.formatter.spec\formatter.signed_integral.pass.cpp
 utilities\format\format.formatter\format.formatter.spec\formatter.string.pass.cpp
 utilities\format\format.formatter\format.formatter.spec\formatter.unsigned_integral.pass.cpp
-utilities\format\format.formatter\format.formatter.spec\types.compile.pass.cpp
 utilities\format\format.formatter\format.formatter.spec\formatter.char.pass.cpp
 utilities\format\format.formatter\format.formatter.spec\formatter.floating_point.pass.cpp
-
-# Tests fail because -NaN is formatted differently (and other reasons).
-utilities\format\format.functions\format.pass.cpp
-utilities\format\format.functions\format.locale.pass.cpp
-utilities\format\format.functions\format_to.locale.pass.cpp
-utilities\format\format.functions\format_to.pass.cpp
-utilities\format\format.functions\format_to_n.pass.cpp
-utilities\format\format.functions\format_to_n.locale.pass.cpp
-utilities\format\format.functions\formatted_size.pass.cpp
-utilities\format\format.functions\formatted_size.locale.pass.cpp
-utilities\format\format.functions\locale-specific_form.pass.cpp
 
 # libc++ chose option A for [time.clock.file.members], and we chose option B.
 time\time.clock\time.clock.file\to_from_sys.pass.cpp
@@ -593,7 +594,9 @@ language.support\support.limits\support.limits.general\ranges.version.compile.pa
 containers\sequences\vector\vector.cons\assign_copy.pass.cpp
 
 # LIT's ADDITIONAL_COMPILE_FLAGS is problematic
-utilities\function.objects\func.wrap\func.wrap.func\func.wrap.func.con\copy_move.pass.cpp
+utilities\meta\meta.unary\dependent_return_type.compile.pass.cpp
+utilities\format\format.functions\escaped_output.ascii.pass.cpp
+utilities\variant\variant.variant\implicit_ctad.pass.cpp
 
 # MoveOnlyForwardIterator (a misnomer) has mixed-type comparisons and conversions
 ranges\range.utility\range.subrange\primitives.pass.cpp
@@ -630,7 +633,7 @@ utilities\variant\variant.variant\variant.assign\T.pass.cpp
 utilities\variant\variant.variant\variant.ctor\conv.pass.cpp
 utilities\variant\variant.variant\variant.ctor\T.pass.cpp
 
-# libc++ is missing a requires-clause on variant's operator<=> (llvm/llvm-project#58192)
+# libc++ is missing a requires-clause on variant's operator<=> (LLVM-58192)
 utilities\variant\variant.relops\three_way.pass.cpp
 
 # libc++ doesn't yet implement P2602R2 "Poison Pills Are Too Toxic"
@@ -639,6 +642,11 @@ ranges\range.access\end.pass.cpp
 ranges\range.access\rbegin.pass.cpp
 ranges\range.access\rend.pass.cpp
 ranges\range.access\size.pass.cpp
+
+# C5101: use of preprocessor directive in function-like macro argument list is undefined behavior
+time\time.syn\formatter.year_month.pass.cpp
+time\time.syn\formatter.year_month_day_last.pass.cpp
+time\time.syn\formatter.year_month_weekday.pass.cpp
 
 
 # *** LIKELY STL BUGS ***
@@ -742,8 +750,9 @@ localization\locale.categories\category.ctype\locale.codecvt\locale.codecvt.memb
 localization\locale.categories\category.ctype\locale.codecvt\locale.codecvt.members\char32_t_encoding.pass.cpp
 localization\locale.categories\category.ctype\locale.codecvt\locale.codecvt.members\char32_t_max_length.pass.cpp
 
-# Likely STL bug in <format>: we check argument ids at compiletime in next_arg_id
+# Likely STL bugs in <format>
 utilities\format\format.formatter\format.parse.ctx\next_arg_id.pass.cpp
+time\time.syn\formatter.month_day_last.pass.cpp
 
 # Likely STL bug in `bind_front`: we don't respect deletion of the target call operator
 utilities\function.objects\func.bind_front\bind_front.pass.cpp
@@ -756,6 +765,9 @@ ranges\range.adaptors\range.join.view\iterator\iter.swap.pass.cpp
 ranges\range.adaptors\range.join.view\iterator\star.pass.cpp
 ranges\range.adaptors\range.join.view\sentinel\ctor.parent.pass.cpp
 ranges\range.adaptors\range.join.view\sentinel\eq.pass.cpp
+
+# Our monotonic_buffer_resource takes "user" space for metadata, which it probably should not do.
+utilities\utility\mem.res\mem.res.monotonic.buffer\mem.res.monotonic.buffer.mem\allocate_with_initial_size.pass.cpp
 
 
 # *** NOT YET ANALYZED ***
@@ -787,7 +799,7 @@ utilities\tuple\tuple.tuple\tuple.cnstr\deduct.pass.cpp
 # Not yet analyzed. Frequent timeouts
 containers\sequences\deque\deque.modifiers\insert_iter_iter.pass.cpp
 
-# Not yet analyzed. Failing after https://reviews.llvm.org/D75622.
+# Not yet analyzed. Failing after LLVM-D75622.
 re\re.const\re.matchflag\match_prev_avail.pass.cpp
 
 # Not yet analyzed. Many diagnostics.
@@ -843,15 +855,6 @@ numerics\rand\rand.dist\rand.dist.pois\rand.dist.pois.poisson\eval_param.pass.cp
 numerics\rand\rand.dist\rand.dist.bern\rand.dist.bern.bin\eval_param.pass.cpp
 numerics\rand\rand.dist\rand.dist.bern\rand.dist.bern.bin\eval.pass.cpp
 
-# Not yet analyzed
-# MSVC is saying "note: failure was caused by a read of a variable outside its lifetime"
-# for constant evaluation failure, which is buggy.
-# compare_strong_order_fallback.pass.cpp and compare_weak_order_fallback.pass.cpp are
-# using _VSTD, perhaps we should replace it with std, or some conditionally defined macro.
-language.support\cmp\cmp.alg\compare_partial_order_fallback.pass.cpp
-language.support\cmp\cmp.alg\compare_strong_order_fallback.pass.cpp
-language.support\cmp\cmp.alg\compare_weak_order_fallback.pass.cpp
-
 # Not yet analyzed. Runs forever
 numerics\rand\rand.dist\rand.dist.pois\rand.dist.pois.poisson\eval.pass.cpp
 
@@ -875,7 +878,6 @@ localization\locale.categories\category.numeric\locale.nm.put\facet.num.put.memb
 
 # Not yet analyzed. These tests use characters that cannot be represented in legacy character encodings
 utilities\format\format.functions\ascii.pass.cpp
-utilities\format\format.functions\unicode.pass.cpp
 
 # Not yet analyzed. "constexpr evaluation hit maximum step limit; possible infinite loop?"
 utilities\template.bitset\bitset.members\left_shift_eq.pass.cpp
@@ -918,10 +920,6 @@ algorithms\alg.sorting\alg.sort\partial.sort.copy\ranges_partial_sort_copy.pass.
 algorithms\algorithms.results\in_found_result.pass.cpp
 algorithms\algorithms.results\min_max_result.pass.cpp
 algorithms\ranges_robust_against_dangling.pass.cpp
-algorithms\ranges_robust_against_differing_projections.pass.cpp
-algorithms\ranges_robust_against_nonbool_predicates.pass.cpp
-algorithms\ranges_robust_against_omitting_invoke.pass.cpp
-algorithms\ranges_robust_against_proxy_iterators.pass.cpp
 algorithms\robust_against_proxy_iterators_lifetime_bugs.pass.cpp
 concepts\concepts.lang\concept.default.init\default_initializable.compile.pass.cpp
 containers\sequences\deque\abi.compile.pass.cpp
@@ -958,7 +956,6 @@ iterators\predef.iterators\move.iterators\move.iterator\iterator_concept_conform
 language.support\support.limits\support.limits.general\cmath.version.compile.pass.cpp
 language.support\support.limits\support.limits.general\cstdlib.version.compile.pass.cpp
 language.support\support.limits\support.limits.general\new.version.compile.pass.cpp
-localization\locale.categories\category.monetary\locale.money.get\locale.money.get.members\get_long_double_zh_CN.pass.cpp
 ranges\range.adaptors\range.filter\iterator\arrow.pass.cpp
 ranges\range.adaptors\range.filter\iterator\base.pass.cpp
 ranges\range.adaptors\range.filter\iterator\compare.pass.cpp
@@ -1008,7 +1005,24 @@ ranges\range.adaptors\range.lazy.split\range.lazy.split.outer\types.compile.pass
 ranges\range.adaptors\range.lazy.split\view_interface.pass.cpp
 ranges\range.adaptors\range.take\adaptor.pass.cpp
 ranges\range.factories\range.single.view\cpo.pass.cpp
-strings\basic.string\string.cons\dtor.pass.cpp
+thread\futures\futures.task\futures.task.members\ctor2.compile.pass.cpp
+utilities\format\format.functions\escaped_output.ascii.pass.cpp
+utilities\format\format.functions\format.locale.pass.cpp
+utilities\format\format.functions\format.pass.cpp
+utilities\format\format.functions\locale-specific_form.pass.cpp
+utilities\format\format.functions\vformat.locale.pass.cpp
+utilities\format\format.functions\vformat.pass.cpp
+utilities\function.objects\func.wrap\func.wrap.func\func.wrap.func.con\ctad.static.compile.pass.cpp
+utilities\function.objects\func.wrap\func.wrap.func\func.wrap.func.inv\invoke.pass.cpp
+utilities\function.objects\refwrap\refwrap.const\type_conv_ctor.pass.cpp
+utilities\memory\util.smartptr\util.smartptr.shared\util.smartptr.shared.create\allocate_shared.array.unbounded.pass.cpp
+utilities\meta\meta.logical\conjunction.compile.pass.cpp
+utilities\meta\meta.logical\disjunction.compile.pass.cpp
+utilities\meta\meta.unary\meta.unary.prop\is_nothrow_copy_assignable.pass.cpp
+utilities\meta\meta.unary\meta.unary.prop\is_nothrow_move_assignable.pass.cpp
+utilities\tuple\tuple.tuple\tuple.cnstr\convert_const_move.pass.cpp
+
+# Not yet analyzed, probably MSVC constexpr issue(s)
 strings\basic.string\string.modifiers\string_erase\iter.pass.cpp
 strings\basic.string\string.modifiers\string_erase\iter_iter.pass.cpp
 strings\basic.string\string.modifiers\string_insert\iter_iter_iter.pass.cpp
@@ -1019,36 +1033,13 @@ strings\basic.string\string.modifiers\string_replace\iter_iter_pointer_size.pass
 strings\basic.string\string.modifiers\string_replace\iter_iter_size_char.pass.cpp
 strings\basic.string\string.modifiers\string_replace\iter_iter_string.pass.cpp
 strings\basic.string\string.modifiers\string_replace\iter_iter_string_view.pass.cpp
-thread\futures\futures.task\futures.task.members\ctor2.compile.pass.cpp
-utilities\function.objects\func.wrap\func.wrap.func\addressof.pass.cpp
-utilities\function.objects\func.wrap\func.wrap.func\func.wrap.func.alg\swap.pass.cpp
-utilities\function.objects\func.wrap\func.wrap.func\func.wrap.func.cap\operator_bool.pass.cpp
-utilities\function.objects\func.wrap\func.wrap.func\func.wrap.func.con\copy_assign.pass.cpp
-utilities\function.objects\func.wrap\func.wrap.func\func.wrap.func.con\default.pass.cpp
-utilities\function.objects\func.wrap\func.wrap.func\func.wrap.func.con\F.pass.cpp
-utilities\function.objects\func.wrap\func.wrap.func\func.wrap.func.con\F_assign.pass.cpp
-utilities\function.objects\func.wrap\func.wrap.func\func.wrap.func.con\F_incomplete.pass.cpp
-utilities\function.objects\func.wrap\func.wrap.func\func.wrap.func.con\F_nullptr.pass.cpp
-utilities\function.objects\func.wrap\func.wrap.func\func.wrap.func.con\nullptr_t.pass.cpp
-utilities\function.objects\func.wrap\func.wrap.func\func.wrap.func.con\nullptr_t_assign.pass.cpp
-utilities\function.objects\func.wrap\func.wrap.func\func.wrap.func.inv\invoke.pass.cpp
-utilities\function.objects\func.wrap\func.wrap.func\func.wrap.func.mod\assign_F_alloc.pass.cpp
-utilities\function.objects\func.wrap\func.wrap.func\func.wrap.func.mod\swap.pass.cpp
-utilities\function.objects\func.wrap\func.wrap.func\func.wrap.func.nullptr\operator_==.pass.cpp
-utilities\function.objects\func.wrap\func.wrap.func\func.wrap.func.targ\target.pass.cpp
-utilities\function.objects\func.wrap\func.wrap.func\func.wrap.func.targ\target_type.pass.cpp
-utilities\function.objects\func.wrap\func.wrap.func\types.pass.cpp
-utilities\function.objects\refwrap\refwrap.const\type_conv_ctor.pass.cpp
-utilities\memory\util.smartptr\util.smartptr.shared\util.smartptr.shared.create\allocate_shared.array.unbounded.pass.cpp
-utilities\meta\meta.logical\conjunction.compile.pass.cpp
-utilities\meta\meta.logical\disjunction.compile.pass.cpp
-utilities\meta\meta.unary\meta.unary.prop\is_nothrow_copy_assignable.pass.cpp
-utilities\meta\meta.unary\meta.unary.prop\is_nothrow_move_assignable.pass.cpp
-utilities\tuple\tuple.tuple\tuple.cnstr\convert_const_move.pass.cpp
 
 # Not yet analyzed, possible path length issue. With a repo root of D:\GitHub\STL (13 characters), fails with:
 # "error RC2136 : missing '=' in EXSTYLE=<flags>" followed by "LINK : fatal error LNK1327: failure during running rc.exe"
 thread\thread.mutex\thread.mutex.requirements\thread.sharedtimedmutex.requirements\thread.sharedtimedmutex.class\try_lock_until_deadlock_bug.pass.cpp
+
+# Not yet analyzed, possible bug in uses_allocator_construction_args
+utilities\utility\mem.res\mem.poly.allocator.class\mem.poly.allocator.mem\construct_piecewise_pair_evil.pass.cpp
 
 
 # *** SKIPPED FOR MSVC-INTERNAL CONTEST ONLY ***
@@ -1101,10 +1092,10 @@ containers\sequences\deque\iterator_concept_conformance.compile.pass.cpp
 containers\sequences\deque\range_concept_conformance.compile.pass.cpp
 containers\sequences\forwardlist\forwardlist.cons\assign_copy.addressof.compile.pass.cpp
 containers\sequences\forwardlist\forwardlist.iter\iterator_concept_conformance.compile.pass.cpp
-containers\sequences\forwardlist\forwardlist.ops\merge_lvalue.addressof.compile.pass.cpp
 containers\sequences\forwardlist\forwardlist.ops\merge_lvalue_pred.addressof.compile.pass.cpp
-containers\sequences\forwardlist\forwardlist.ops\merge_rvalue.addressof.compile.pass.cpp
+containers\sequences\forwardlist\forwardlist.ops\merge_lvalue.addressof.compile.pass.cpp
 containers\sequences\forwardlist\forwardlist.ops\merge_rvalue_pred.addressof.compile.pass.cpp
+containers\sequences\forwardlist\forwardlist.ops\merge_rvalue.addressof.compile.pass.cpp
 containers\sequences\forwardlist\range_concept_conformance.compile.pass.cpp
 containers\sequences\list\iterator_concept_conformance.compile.pass.cpp
 containers\sequences\list\list.cons\assign_copy.addressof.compile.pass.cpp
@@ -1115,8 +1106,8 @@ containers\sequences\list\list.modifiers\insert_iter_rvalue.addressof.compile.pa
 containers\sequences\list\list.modifiers\insert_iter_size_value.addressof.compile.pass.cpp
 containers\sequences\list\list.modifiers\insert_iter_value.addressof.compile.pass.cpp
 containers\sequences\list\list.ops\merge_comp.addressof.compile.pass.cpp
-containers\sequences\list\list.ops\splice_pos_list_iter.addressof.compile.pass.cpp
 containers\sequences\list\list.ops\splice_pos_list_iter_iter.addressof.compile.pass.cpp
+containers\sequences\list\list.ops\splice_pos_list_iter.addressof.compile.pass.cpp
 containers\sequences\list\list.special\swap.addressof.compile.pass.cpp
 containers\sequences\list\range_concept_conformance.compile.pass.cpp
 containers\sequences\vector.bool\iterator_concept_conformance.compile.pass.cpp
@@ -1128,21 +1119,21 @@ containers\sequences\vector\vector.cons\assign_copy.addressof.compile.pass.cpp
 containers\sequences\vector\vector.cons\assign_move.addressof.compile.pass.cpp
 containers\sequences\vector\vector.cons\move.addressof.compile.pass.cpp
 containers\sequences\vector\vector.modifiers\emplace.addressof.compile.pass.cpp
-containers\sequences\vector\vector.modifiers\erase_iter.addressof.compile.pass.cpp
 containers\sequences\vector\vector.modifiers\erase_iter_iter.addressof.compile.pass.cpp
+containers\sequences\vector\vector.modifiers\erase_iter.addressof.compile.pass.cpp
 containers\sequences\vector\vector.modifiers\insert_iter_iter_iter.addressof.compile.pass.cpp
 containers\sequences\vector\vector.modifiers\insert_iter_rvalue.addressof.compile.pass.cpp
 containers\sequences\vector\vector.modifiers\insert_iter_size_value.addressof.compile.pass.cpp
 containers\sequences\vector\vector.modifiers\insert_iter_value.addressof.compile.pass.cpp
-containers\sequences\vector\vector.special\swap.addressof.compile.pass.cpp
 containers\sequences\vector\vector.special\swap_noexcept.compile.pass.cpp
-containers\unord\unord.map\iterator.operators.addressof.compile.pass.cpp
+containers\sequences\vector\vector.special\swap.addressof.compile.pass.cpp
 containers\unord\unord.map\iterator_concept_conformance.compile.pass.cpp
+containers\unord\unord.map\iterator.operators.addressof.compile.pass.cpp
 containers\unord\unord.map\range_concept_conformance.compile.pass.cpp
 containers\unord\unord.map\unord.map.cnstr\assign_copy.addressof.compile.pass.cpp
 containers\unord\unord.map\unord.map.cnstr\assign_move.addressof.compile.pass.cpp
-containers\unord\unord.map\unord.map.cnstr\move.addressof.compile.pass.cpp
 containers\unord\unord.map\unord.map.cnstr\move_alloc.addressof.compile.pass.cpp
+containers\unord\unord.map\unord.map.cnstr\move.addressof.compile.pass.cpp
 containers\unord\unord.map\unord.map.modifiers\emplace_hint.addressof.compile.pass.cpp
 containers\unord\unord.map\unord.map.modifiers\erase_const_iter.addressof.compile.pass.cpp
 containers\unord\unord.map\unord.map.modifiers\erase_range.addressof.compile.pass.cpp
@@ -1154,23 +1145,23 @@ containers\unord\unord.map\unord.map.swap\swap.addressof.compile.pass.cpp
 containers\unord\unord.multimap\iterator_concept_conformance.compile.pass.cpp
 containers\unord\unord.multimap\range_concept_conformance.compile.pass.cpp
 containers\unord\unord.multimap\unord.multimap.cnstr\assign_copy.addressof.compile.pass.cpp
-containers\unord\unord.multimap\unord.multimap.cnstr\move.addressof.compile.pass.cpp
 containers\unord\unord.multimap\unord.multimap.cnstr\move_alloc.addressof.compile.pass.cpp
+containers\unord\unord.multimap\unord.multimap.cnstr\move.addressof.compile.pass.cpp
 containers\unord\unord.multimap\unord.multimap.modifiers\emplace_hint.addressof.compile.pass.cpp
 containers\unord\unord.multiset\iterator_concept_conformance.compile.pass.cpp
 containers\unord\unord.multiset\range_concept_conformance.compile.pass.cpp
 containers\unord\unord.multiset\unord.multiset.cnstr\assign_copy.addressof.compile.pass.cpp
-containers\unord\unord.multiset\unord.multiset.cnstr\move.addressof.compile.pass.cpp
 containers\unord\unord.multiset\unord.multiset.cnstr\move_alloc.addressof.compile.pass.cpp
+containers\unord\unord.multiset\unord.multiset.cnstr\move.addressof.compile.pass.cpp
 containers\unord\unord.set\emplace_hint.addressof.compile.pass.cpp
 containers\unord\unord.set\insert_hint_const_lvalue.addressof.compile.pass.cpp
 containers\unord\unord.set\insert_hint_rvalue.addressof.compile.pass.cpp
-containers\unord\unord.set\iterator.operators.addressof.compile.pass.cpp
 containers\unord\unord.set\iterator_concept_conformance.compile.pass.cpp
+containers\unord\unord.set\iterator.operators.addressof.compile.pass.cpp
 containers\unord\unord.set\range_concept_conformance.compile.pass.cpp
 containers\unord\unord.set\unord.set.cnstr\assign_copy.addressof.compile.pass.cpp
-containers\unord\unord.set\unord.set.cnstr\move.addressof.compile.pass.cpp
 containers\unord\unord.set\unord.set.cnstr\move_alloc.addressof.compile.pass.cpp
+containers\unord\unord.set\unord.set.cnstr\move.addressof.compile.pass.cpp
 containers\views\views.span\enable_borrowed_range.compile.pass.cpp
 containers\views\views.span\range_concept_conformance.compile.pass.cpp
 containers\views\views.span\span.cons\span.dtor.compile.pass.cpp
@@ -1190,14 +1181,14 @@ iterators\iterator.primitives\iterator.traits\cxx20_iterator_traits.compile.pass
 iterators\iterator.primitives\iterator.traits\iter_reference_t.compile.pass.cpp
 iterators\iterator.primitives\range.iter.ops\range.iter.ops.next\constraints.compile.pass.cpp
 iterators\iterator.primitives\range.iter.ops\range.iter.ops.prev\constraints.compile.pass.cpp
-iterators\iterator.requirements\alg.req.ind.copy\indirectly_copyable.compile.pass.cpp
-iterators\iterator.requirements\alg.req.ind.copy\indirectly_copyable.subsumption.compile.pass.cpp
 iterators\iterator.requirements\alg.req.ind.copy\indirectly_copyable_storable.compile.pass.cpp
 iterators\iterator.requirements\alg.req.ind.copy\indirectly_copyable_storable.subsumption.compile.pass.cpp
-iterators\iterator.requirements\alg.req.ind.move\indirectly_movable.compile.pass.cpp
-iterators\iterator.requirements\alg.req.ind.move\indirectly_movable.subsumption.compile.pass.cpp
+iterators\iterator.requirements\alg.req.ind.copy\indirectly_copyable.compile.pass.cpp
+iterators\iterator.requirements\alg.req.ind.copy\indirectly_copyable.subsumption.compile.pass.cpp
 iterators\iterator.requirements\alg.req.ind.move\indirectly_movable_storable.compile.pass.cpp
 iterators\iterator.requirements\alg.req.ind.move\indirectly_movable_storable.subsumption.compile.pass.cpp
+iterators\iterator.requirements\alg.req.ind.move\indirectly_movable.compile.pass.cpp
+iterators\iterator.requirements\alg.req.ind.move\indirectly_movable.subsumption.compile.pass.cpp
 iterators\iterator.requirements\alg.req.ind.swap\indirectly_swappable.compile.pass.cpp
 iterators\iterator.requirements\alg.req.ind.swap\indirectly_swappable.subsumption.compile.pass.cpp
 iterators\iterator.requirements\alg.req.mergeable\mergeable.compile.pass.cpp
@@ -1259,8 +1250,8 @@ iterators\stream.iterators\istream.iterator\iterator_concept_conformance.compile
 iterators\stream.iterators\istreambuf.iterator\iterator_concept_conformance.compile.pass.cpp
 iterators\stream.iterators\ostream.iterator\iterator_concept_conformance.compile.pass.cpp
 iterators\stream.iterators\ostreambuf.iterator\iterator_concept_conformance.compile.pass.cpp
-language.support\cmp\cmp.concept\three_way_comparable.compile.pass.cpp
 language.support\cmp\cmp.concept\three_way_comparable_with.compile.pass.cpp
+language.support\cmp\cmp.concept\three_way_comparable.compile.pass.cpp
 language.support\cmp\cmp.result\compare_three_way_result.compile.pass.cpp
 language.support\support.dynamic\hardware_inference_size.compile.pass.cpp
 language.support\support.limits\support.limits.general\algorithm.version.compile.pass.cpp
@@ -1282,6 +1273,7 @@ language.support\support.limits\support.limits.general\cstdlib.version.compile.p
 language.support\support.limits\support.limits.general\deque.version.compile.pass.cpp
 language.support\support.limits\support.limits.general\exception.version.compile.pass.cpp
 language.support\support.limits\support.limits.general\execution.version.compile.pass.cpp
+language.support\support.limits\support.limits.general\expected.version.compile.pass.cpp
 language.support\support.limits\support.limits.general\filesystem.version.compile.pass.cpp
 language.support\support.limits\support.limits.general\format.version.compile.pass.cpp
 language.support\support.limits\support.limits.general\forward_list.version.compile.pass.cpp
@@ -1294,6 +1286,7 @@ language.support\support.limits\support.limits.general\limits.version.compile.pa
 language.support\support.limits\support.limits.general\list.version.compile.pass.cpp
 language.support\support.limits\support.limits.general\locale.version.compile.pass.cpp
 language.support\support.limits\support.limits.general\map.version.compile.pass.cpp
+language.support\support.limits\support.limits.general\memory_resource.version.compile.pass.cpp
 language.support\support.limits\support.limits.general\memory.version.compile.pass.cpp
 language.support\support.limits\support.limits.general\mutex.version.compile.pass.cpp
 language.support\support.limits\support.limits.general\new.version.compile.pass.cpp
@@ -1311,8 +1304,8 @@ language.support\support.limits\support.limits.general\shared_mutex.version.comp
 language.support\support.limits\support.limits.general\span.version.compile.pass.cpp
 language.support\support.limits\support.limits.general\stack.version.compile.pass.cpp
 language.support\support.limits\support.limits.general\stdatomic.h.version.compile.pass.cpp
-language.support\support.limits\support.limits.general\string.version.compile.pass.cpp
 language.support\support.limits\support.limits.general\string_view.version.compile.pass.cpp
+language.support\support.limits\support.limits.general\string.version.compile.pass.cpp
 language.support\support.limits\support.limits.general\thread.version.compile.pass.cpp
 language.support\support.limits\support.limits.general\tuple.version.compile.pass.cpp
 language.support\support.limits\support.limits.general\type_traits.version.compile.pass.cpp
@@ -1335,6 +1328,9 @@ ranges\range.adaptors\range.all\range.owning.view\borrowing.compile.pass.cpp
 ranges\range.adaptors\range.all\range.ref.view\borrowing.compile.pass.cpp
 ranges\range.adaptors\range.common.view\borrowing.compile.pass.cpp
 ranges\range.adaptors\range.common.view\ctad.compile.pass.cpp
+ranges\range.adaptors\range.drop.while\borrowed.compile.pass.cpp
+ranges\range.adaptors\range.drop.while\ctad.compile.pass.cpp
+ranges\range.adaptors\range.drop.while\range.concept.compile.pass.cpp
 ranges\range.adaptors\range.drop\ctad.compile.pass.cpp
 ranges\range.adaptors\range.empty\borrowing.compile.pass.cpp
 ranges\range.adaptors\range.filter\constraints.compile.pass.cpp
@@ -1348,6 +1344,8 @@ ranges\range.adaptors\range.lazy.split\range.lazy.split.outer\types.compile.pass
 ranges\range.adaptors\range.reverse\borrowing.compile.pass.cpp
 ranges\range.adaptors\range.reverse\ctad.compile.pass.cpp
 ranges\range.adaptors\range.reverse\range_concept_conformance.compile.pass.cpp
+ranges\range.adaptors\range.take.while\ctad.compile.pass.cpp
+ranges\range.adaptors\range.take.while\range.concept.compile.pass.cpp
 ranges\range.adaptors\range.take\borrowing.compile.pass.cpp
 ranges\range.adaptors\range.take\ctad.compile.pass.cpp
 ranges\range.adaptors\range.take\range_concept_conformance.compile.pass.cpp
@@ -1362,6 +1360,8 @@ ranges\range.factories\range.iota.view\ctad.compile.pass.cpp
 ranges\range.factories\range.iota.view\iterator\member_typedefs.compile.pass.cpp
 ranges\range.factories\range.iota.view\range_concept_conformance.compile.pass.cpp
 ranges\range.factories\range.iota.view\type.compile.pass.cpp
+ranges\range.factories\range.istream.view\iterator\member_types.compile.pass.cpp
+ranges\range.factories\range.istream.view\range.concept.compile.pass.cpp
 ranges\range.factories\range.single.view\borrowing.compile.pass.cpp
 ranges\range.factories\range.single.view\ctad.compile.pass.cpp
 ranges\range.factories\range.single.view\range_concept_conformance.compile.pass.cpp
@@ -1370,8 +1370,8 @@ ranges\range.req\range.range\borrowed_range.subsumption.compile.pass.cpp
 ranges\range.req\range.range\enable_borrowed_range.compile.pass.cpp
 ranges\range.req\range.range\helper_aliases.compile.pass.cpp
 ranges\range.req\range.range\iterator_t.compile.pass.cpp
-ranges\range.req\range.range\range.compile.pass.cpp
 ranges\range.req\range.range\range_size_t.compile.pass.cpp
+ranges\range.req\range.range\range.compile.pass.cpp
 ranges\range.req\range.range\sentinel_t.compile.pass.cpp
 ranges\range.req\range.refinements\bidirectional_range.compile.pass.cpp
 ranges\range.req\range.refinements\common_range.compile.pass.cpp
@@ -1385,9 +1385,9 @@ ranges\range.req\range.refinements\viewable_range.compile.pass.cpp
 ranges\range.req\range.sized\sized_range.compile.pass.cpp
 ranges\range.req\range.sized\subsumption.compile.pass.cpp
 ranges\range.req\range.view\enable_view.compile.pass.cpp
+ranges\range.req\range.view\view_base.compile.pass.cpp
 ranges\range.req\range.view\view.compile.pass.cpp
 ranges\range.req\range.view\view.subsumption.compile.pass.cpp
-ranges\range.req\range.view\view_base.compile.pass.cpp
 ranges\range.utility\range.dangling\borrowed_iterator.compile.pass.cpp
 ranges\range.utility\range.dangling\borrowed_subrange.compile.pass.cpp
 ranges\range.utility\range.subrange\borrowing.compile.pass.cpp
@@ -1401,11 +1401,11 @@ strings\basic.string\range_concept_conformance.compile.pass.cpp
 strings\basic.string\string.cons\nullptr.compile.pass.cpp
 strings\basic.string\string.iterators\iterator_concept_conformance.compile.pass.cpp
 strings\c.strings\cuchar.compile.pass.cpp
+strings\char.traits\char.traits.specializations\char.traits.specializations.char\types.compile.pass.cpp
 strings\char.traits\char.traits.specializations\char.traits.specializations.char16_t\types.compile.pass.cpp
 strings\char.traits\char.traits.specializations\char.traits.specializations.char32_t\types.compile.pass.cpp
 strings\char.traits\char.traits.specializations\char.traits.specializations.char8_t\types.compile.pass.cpp
-strings\char.traits\char.traits.specializations\char.traits.specializations.char\types.compile.pass.cpp
-strings\char.traits\char.traits.specializations\char.traits.specializations.wchar.t\types.compile.pass.cpp
+strings\char.traits\char.traits.specializations\char.traits.specializations.wchar_t\types.compile.pass.cpp
 strings\string.classes\typedefs.compile.pass.cpp
 strings\string.view\enable_borrowed_range.compile.pass.cpp
 strings\string.view\range_concept_conformance.compile.pass.cpp
@@ -1413,25 +1413,32 @@ strings\string.view\string.view.cons\nullptr.compile.pass.cpp
 strings\string.view\string.view.io\stream_insert_decl_present.compile.pass.cpp
 strings\string.view\string.view.iterators\iterator_concept_conformance.compile.pass.cpp
 strings\string.view\trivially_copyable.compile.pass.cpp
+thread\futures\futures.task\futures.task.members\ctad.compile.pass.cpp
+thread\futures\futures.task\futures.task.members\ctad.static.compile.pass.cpp
 thread\futures\futures.task\futures.task.members\ctor2.compile.pass.cpp
 thread\thread.semaphore\ctor.compile.pass.cpp
+utilities\expected\expected.bad\what.noexcept.compile.pass.cpp
+utilities\expected\expected.unexpected\ctad.compile.pass.cpp
 utilities\format\format.fmt.string\types.compile.pass.cpp
-utilities\format\format.formatter\format.formatter.spec\types.compile.pass.cpp
+utilities\format\format.formattable\concept.formattable.compile.pass.cpp
+utilities\format\format.range\format.range.fmtkind\format_kind.compile.pass.cpp
+utilities\format\format.range\format.range.fmtkind\range_format.compile.pass.cpp
 utilities\function.objects\comparisons\transparent_three_way.compile.pass.cpp
+utilities\function.objects\func.wrap\func.wrap.func\func.wrap.func.con\ctad.static.compile.pass.cpp
 utilities\memory\default.allocator\PR50299.compile.pass.cpp
 utilities\memory\storage.iterator\types.compile.pass.cpp
 utilities\memory\unique.ptr\iterator_concept_conformance.compile.pass.cpp
 utilities\memory\util.smartptr\util.smartptr.shared\iterator_concept_conformance.compile.pass.cpp
 utilities\meta\meta.logical\conjunction.compile.pass.cpp
 utilities\meta\meta.logical\disjunction.compile.pass.cpp
-utilities\meta\meta.rel\is_invocable_r.compile.pass.cpp
 utilities\meta\meta.rel\is_invocable_r_v.compile.pass.cpp
+utilities\meta\meta.rel\is_invocable_r.compile.pass.cpp
+utilities\meta\meta.unary\dependent_return_type.compile.pass.cpp
 utilities\optional\iterator_concept_conformance.compile.pass.cpp
-utilities\smartptr\unique.ptr\unique.ptr.msvc\test.compile.pass.cpp
 utilities\tuple\tuple.tuple\tuple.cnstr\cnstr_with_any.compile.pass.cpp
 utilities\tuple\tuple.tuple\tuple.cnstr\empty_tuple_trivial.compile.pass.cpp
 utilities\tuple\tuple.tuple\tuple.rel\size_incompatible_three_way.compile.pass.cpp
-utilities\utility\utility.unreachable\unreachable.compile.pass.cpp
+utilities\utility\mem.res\mem.poly.allocator.class\mem.poly.allocator.mem\default_type.compile.pass.cpp
 
 # .verify.cpp tests use clang-verify to validate warnings; GitHub knows not to run them,
 # Contest must be told.
@@ -1528,6 +1535,7 @@ strings\basic.string\char.bad.verify.cpp
 strings\basic.string\string.capacity\empty.verify.cpp
 strings\basic.string\string.capacity\reserve.deprecated_in_cxx20.verify.cpp
 strings\basic.string\traits_mismatch.verify.cpp
+strings\c.strings\no_c8rtomb_mbrtoc8.verify.cpp
 strings\string.view\string_view.literals\literal.verify.cpp
 strings\string.view\string.view.capacity\empty.verify.cpp
 strings\string.view\string.view.comparison\comparison.verify.cpp
@@ -1550,12 +1558,17 @@ utilities\format\format.functions\format.locale.verify.cpp
 utilities\format\format.functions\format.verify.cpp
 utilities\format\format.functions\formatted_size.locale.verify.cpp
 utilities\format\format.functions\formatted_size.verify.cpp
+utilities\format\format.range\format.range.fmtkind\format_kind.verify.cpp
+utilities\format\format.tuple\format.functions.format.verify.cpp
 utilities\function.objects\func.bind_front\bind_front.verify.cpp
+utilities\function.objects\func.wrap\func.wrap.func\derive_from.verify.cpp
 utilities\function.objects\func.wrap\func.wrap.func\func.wrap.func.con\alloc_F.verify.cpp
 utilities\function.objects\func.wrap\func.wrap.func\func.wrap.func.con\alloc_function.verify.cpp
 utilities\function.objects\func.wrap\func.wrap.func\func.wrap.func.con\alloc_nullptr.verify.cpp
 utilities\function.objects\func.wrap\func.wrap.func\func.wrap.func.con\alloc_rfunction.verify.cpp
 utilities\function.objects\func.wrap\func.wrap.func\func.wrap.func.con\alloc.verify.cpp
+utilities\function.objects\func.wrap\func.wrap.func\func.wrap.func.con\deduct_F.verify.cpp
+utilities\function.objects\func.wrap\func.wrap.func\func.wrap.func.inv\invoke.verify.cpp
 utilities\function.objects\negators\binary_negate.depr_in_cxx17.verify.cpp
 utilities\function.objects\negators\not1.depr_in_cxx17.verify.cpp
 utilities\function.objects\negators\not2.depr_in_cxx17.verify.cpp
@@ -1576,6 +1589,8 @@ utilities\smartptr\unique.ptr\unique.ptr.class\unique.ptr.observers\dereference.
 utilities\smartptr\unique.ptr\unique.ptr.class\unique.ptr.observers\op_arrow.verify.cpp
 utilities\tuple\tuple.tuple\tuple.cnstr\default.lazy.verify.cpp
 utilities\tuple\tuple.tuple\tuple.rel\size_incompatible_comparison.verify.cpp
+utilities\utility\mem.res\mem.poly.allocator.class\mem.poly.allocator.mem\allocate_deallocate_vocabulary.nodiscard.verify.cpp
+utilities\utility\mem.res\nodiscard.verify.cpp
 utilities\utility\utility.underlying\to_underlying.verify.cpp
 utilities\utility\utility.unreachable\unreachable.verify.cpp
 

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -227,7 +227,7 @@ utilities\format\format.tuple\parse.pass.cpp
 utilities\format\format.tuple\set_brackets.pass.cpp
 utilities\format\format.tuple\set_separator.pass.cpp
 
-# Missing mrbtoc8 and c8rtomb
+# Missing mbrtoc8 and c8rtomb
 depr\depr.c.headers\uchar_h.compile.pass.cpp
 strings\c.strings\cuchar.compile.pass.cpp
 
@@ -643,7 +643,7 @@ ranges\range.access\rbegin.pass.cpp
 ranges\range.access\rend.pass.cpp
 ranges\range.access\size.pass.cpp
 
-# C5101: use of preprocessor directive in function-like macro argument list is undefined behavior
+# warning C5101: use of preprocessor directive in function-like macro argument list is undefined behavior
 time\time.syn\formatter.year_month.pass.cpp
 time\time.syn\formatter.year_month_day_last.pass.cpp
 time\time.syn\formatter.year_month_weekday.pass.cpp

--- a/tests/libcxx/usual_matrix.lst
+++ b/tests/libcxx/usual_matrix.lst
@@ -3,7 +3,7 @@
 
 RUNALL_INCLUDE ..\universal_prefix.lst
 RUNALL_CROSSLIST
-PM_CL="/EHsc /MTd /std:c++latest /permissive- /FImsvc_stdlib_force_include.h /wd4643 /D_STL_CALL_ABORT_INSTEAD_OF_INVALID_PARAMETER /D_USE_JOIN_VIEW_INPUT_RANGE"
+PM_CL="/EHsc /MTd /std:c++latest /permissive- /utf-8 /FImsvc_stdlib_force_include.h /wd4643 /D_STL_CALL_ABORT_INSTEAD_OF_INVALID_PARAMETER /D_USE_JOIN_VIEW_INPUT_RANGE"
 RUNALL_CROSSLIST
-PM_CL="/analyze:autolog- /Zc:preprocessor"
+PM_CL="/analyze:autolog- /Zc:preprocessor /wd6262"
 PM_COMPILER="clang-cl" PM_CL="-fno-ms-compatibility -fno-delayed-template-parsing -Wno-unqualified-std-cast-call"

--- a/tests/utils/stl/test/features.py
+++ b/tests/utils/stl/test/features.py
@@ -26,6 +26,7 @@ def getDefaultFeatures(config, litConfig):
     locales = {
       'en_US.UTF-8':     ['en_US.UTF-8', 'en_US.utf8', 'English_United States.1252'],
       'fr_FR.UTF-8':     ['fr_FR.UTF-8', 'fr_FR.utf8', 'French_France.1252'],
+      'ja_JP.UTF-8':     ['ja_JP.UTF-8', 'ja_JP.utf8', 'Japanese_Japan.932'],
       'ru_RU.UTF-8':     ['ru_RU.UTF-8', 'ru_RU.utf8', 'Russian_Russia.1251'],
       'zh_CN.UTF-8':     ['zh_CN.UTF-8', 'zh_CN.utf8', 'Chinese_China.936'],
       'fr_CA.ISO8859-1': ['fr_CA.ISO8859-1', 'French_Canada.1252'],


### PR DESCRIPTION
Update SHA and skip list(s), and some other changes:
* Tell `features.py` that we support `ja_JP.UTF-8`. Some of the libcxx `<format>`/`chronat` tests use that locale.
* Build libcxx tests with `/utf-8`. They write tests with the expectation that the source and execution character sets are both UTF-8, we should make it so to avoid failures.
* Build libcxx tests with [C6262 "Excessive stack size"](https://learn.microsoft.com/en-us/cpp/code-quality/c6262?view=msvc-170) disabled. A few tests use a ton of stack, and run just fine. It's not product code, and IMO not worth our time or theirs to rewrite such tests.
