### PR TITLE
Speculatively implement LWG-3857

### DIFF
--- a/stl/inc/format
+++ b/stl/inc/format
@@ -853,13 +853,13 @@ _NODISCARD constexpr bool _Is_execution_charset_self_synchronizing() {
 #endif // ^^^ EDG workaround ^^^
 }
 
-inline constexpr char32_t _Width_estimate_intervals[] = { // Per N4885 [format.string.std]/11
+inline constexpr char32_t _Width_estimate_intervals[] = { // Per N4928 [format.string.std]/12
     0x1100u, 0x1160u, 0x2329u, 0x232Bu, 0x2E80u, 0x303Fu, 0x3040u, 0xA4D0u, 0xAC00u, 0xD7A4u, 0xF900u, 0xFB00u, 0xFE10u,
     0xFE1Au, 0xFE30u, 0xFE70u, 0xFF00u, 0xFF61u, 0xFFE0u, 0xFFE7u, 0x1F300u, 0x1F650u, 0x1F900u, 0x1FA00u, 0x20000u,
     0x2FFFEu, 0x30000u, 0x3FFFEu};
 
 _NODISCARD constexpr int _Unicode_width_estimate(const char32_t _Ch) noexcept {
-    // Computes the width estimation for Unicode characters from N4885 [format.string.std]/11
+    // Computes the width estimation for Unicode characters from N4928 [format.string.std]/12
     int _Result = 1;
     for (const auto& _Bound : _Width_estimate_intervals) {
         if (_Ch < _Bound) {
@@ -1731,13 +1731,13 @@ struct _Format_arg_traits {
     using _Char_type = typename _Context::char_type;
 
     // These overloads mirror the exposition-only single-argument constructor
-    // set of basic_format_arg (N4885 [format.arg]). They determine the mapping
+    // set of basic_format_arg (N4928 [format.arg]). They determine the mapping
     // from "raw" to "erased" argument type for _Format_arg_store.
     template <_Has_formatter<_Context> _Ty>
     static auto _Phony_basic_format_arg_constructor(_Ty&&) {
         // per the proposed resolution of LWG-3631
         using _Td = remove_cvref_t<_Ty>;
-        // See N4885 [format.arg]/5
+        // See N4928 [format.arg]/5
         if constexpr (is_same_v<_Td, bool>) {
             return bool{};
         } else if constexpr (is_same_v<_Td, _Char_type>) {
@@ -1783,20 +1783,6 @@ struct _Format_arg_traits {
 
     template <class _Ty>
     static constexpr size_t _Storage_size = sizeof(_Storage_type<_Ty>);
-
-#if !_HAS_CXX23
-    // Workaround towards N4928 [format.arg]/9 and /10 in C++20
-    template <class _Traits>
-    static auto _Deduce_converted_string_type(basic_string_view<_Char_type, _Traits>)
-        -> basic_string_view<_Char_type, _Traits>; // not defined
-
-    template <class _Traits, class _Alloc>
-    static auto _Deduce_converted_string_type(basic_string<_Char_type, _Traits, _Alloc>)
-        -> const basic_string<_Char_type, _Traits, _Alloc>&; // not defined
-
-    template <class _Ty>
-    using _Converted_string_type = decltype(_Deduce_converted_string_type(_STD declval<_Ty&>()));
-#endif // !_HAS_CXX23
 };
 
 struct _Format_arg_index {
@@ -1895,8 +1881,7 @@ private:
 #if !_HAS_CXX23
         // Workaround towards N4928 [format.arg]/9 and /10 in C++20
         if constexpr (is_same_v<_Erased_type, basic_string_view<_CharType>>) {
-            typename _Traits::template _Converted_string_type<_Ty> _Str = _Val;
-            _Store_impl<_Erased_type>(_Arg_index, _Arg_type, _Erased_type{_Str.data(), _Str.size()});
+            _Store_impl<_Erased_type>(_Arg_index, _Arg_type, _Erased_type{_Val.data(), _Val.size()});
         } else
 #endif // !_HAS_CXX23
         {
@@ -3291,7 +3276,7 @@ struct _Format_handler {
 };
 
 // Generic formatter definition, the deleted default constructor
-// makes it "disabled" as per N4885 [format.formatter.spec]/5
+// makes it "disabled" as per N4928 [format.formatter.spec]/5
 _EXPORT_STD template <class _Ty, class _CharT>
 struct formatter {
     formatter()                           = delete;
@@ -3420,7 +3405,7 @@ _EXPORT_STD template <class _Context = format_context, class... _Args>
 _NODISCARD auto make_format_args(_Args&&... _Vals) {
     static_assert((_Has_formatter<_Args, _Context> && ...),
         "Cannot format an argument. To make type T formattable, provide a formatter<T> specialization. "
-        "See N4917 [format.arg.store]/2 and [formatter.requirements].");
+        "See N4928 [format.arg.store]/2 and [formatter.requirements].");
     return _Format_arg_store<_Context, _Args...>{_Vals...};
 }
 
@@ -3428,7 +3413,7 @@ _EXPORT_STD template <class... _Args>
 _NODISCARD auto make_wformat_args(_Args&&... _Vals) {
     static_assert((_Has_formatter<_Args, wformat_context> && ...),
         "Cannot format an argument. To make type T formattable, provide a formatter<T> specialization. "
-        "See N4917 [format.arg.store]/2 and [formatter.requirements].");
+        "See N4928 [format.arg.store]/2 and [formatter.requirements].");
     return _Format_arg_store<wformat_context, _Args...>{_Vals...};
 }
 

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -1783,6 +1783,20 @@ struct _Format_arg_traits {
 
     template <class _Ty>
     static constexpr size_t _Storage_size = sizeof(_Storage_type<_Ty>);
+
+#if !_HAS_CXX23
+    // Workaround towards N4928 [format.arg]/9 and /10 in C++20
+    template <class _Traits>
+    static auto _Deduce_converted_string_type(basic_string_view<_Char_type, _Traits>)
+        -> basic_string_view<_Char_type, _Traits>; // not defined
+
+    template <class _Traits, class _Alloc>
+    static auto _Deduce_converted_string_type(basic_string<_Char_type, _Traits, _Alloc>)
+        -> const basic_string<_Char_type, _Traits, _Alloc>&; // not defined
+
+    template <class _Ty>
+    using _Converted_string_type = decltype(_Deduce_converted_string_type(_STD declval<_Ty&>()));
+#endif // !_HAS_CXX23
 };
 
 struct _Format_arg_index {
@@ -1878,7 +1892,16 @@ private:
             _Arg_type = _Basic_format_arg_type::_Custom_type;
         }
 
-        _Store_impl<_Erased_type>(_Arg_index, _Arg_type, static_cast<_Erased_type>(_Val));
+#if !_HAS_CXX23
+        // Workaround towards N4928 [format.arg]/9 and /10 in C++20
+        if constexpr (is_same_v<_Erased_type, basic_string_view<_CharType>>) {
+            typename _Traits::template _Converted_string_type<_Ty> _Str = _Val;
+            _Store_impl<_Erased_type>(_Arg_index, _Arg_type, _Erased_type{_Str.data(), _Str.size()});
+        } else
+#endif // !_HAS_CXX23
+        {
+            _Store_impl<_Erased_type>(_Arg_index, _Arg_type, static_cast<_Erased_type>(_Val));
+        }
     }
 
 public:

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -1260,10 +1260,7 @@ public:
             && (!is_convertible_v<_Range, const _Elem*>)
             && (!requires(remove_cvref_t<_Range>& _Rng) {
                 _Rng.operator _STD basic_string_view<_Elem, _Traits>();
-            })
-            && (!requires {
-                typename remove_reference_t<_Range>::traits_type;
-            } || same_as<typename remove_reference_t<_Range>::traits_type, _Traits>))
+            })) // doesn't check member type traits_type, per LWG-3857
     constexpr explicit basic_string_view(_Range&& _Rng) noexcept(
         noexcept(_RANGES data(_Rng)) && noexcept(_RANGES size(_Rng))) // strengthened
         : _Mydata(_RANGES data(_Rng)), _Mysize(static_cast<size_t>(_RANGES size(_Rng))) {}

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -607,6 +607,11 @@ std/language.support/support.limits/support.limits.general/format.version.compil
 # libc++ doesn't yet implement LWG-3670
 std/ranges/range.factories/range.iota.view/iterator/member_typedefs.compile.pass.cpp FAIL
 
+# libc++ doesn't speculatively implement LWG-3857
+std/strings/string.view/string.view.cons/from_range.pass.cpp FAIL
+std/strings/string.view/string.view.cons/from_string1.compile.fail.cpp FAIL
+std/strings/string.view/string.view.cons/from_string2.compile.fail.cpp FAIL
+
 # This test assumes that std::array<int, 4>::iterator is int*, but on MSVC STL it's _Array_iterator.
 # Other std/algorithm test failures likely have the same cause.
 std/algorithms/alg.modifying.operations/alg.copy/ranges.copy.pass.cpp FAIL

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -607,6 +607,11 @@ language.support\support.limits\support.limits.general\format.version.compile.pa
 # libc++ doesn't yet implement LWG-3670
 ranges\range.factories\range.iota.view\iterator\member_typedefs.compile.pass.cpp
 
+# libc++ doesn't speculatively implement LWG-3857
+strings\string.view\string.view.cons\from_range.pass.cpp
+strings\string.view\string.view.cons\from_string1.compile.fail.cpp
+strings\string.view\string.view.cons\from_string2.compile.fail.cpp
+
 # This test assumes that std::array<int, 4>::iterator is int*, but on MSVC STL it's _Array_iterator.
 # Other std/algorithm test failures likely have the same cause.
 algorithms\alg.modifying.operations\alg.copy\ranges.copy.pass.cpp

--- a/tests/std/tests/P0220R1_string_view/test.cpp
+++ b/tests/std/tests/P0220R1_string_view/test.cpp
@@ -367,8 +367,18 @@ constexpr bool test_case_range_constructor() {
     static_assert(!is_constructible_v<string_view, vector<unsigned char>>); // different elements
     static_assert(!is_convertible_v<vector<unsigned char>, string_view>);
 
-    static_assert(!is_constructible_v<string_view, basic_string<char, constexpr_char_traits>>); // different traits
-    static_assert(!is_convertible_v<basic_string<char, constexpr_char_traits>, string_view>);
+    static_assert(!is_convertible_v<basic_string<char, constexpr_char_traits>, string_view>); // different traits
+    static_assert(!is_convertible_v<basic_string_view<char, constexpr_char_traits>, string_view>);
+
+    static_assert(!is_convertible_v<string_view, basic_string_view<char, constexpr_char_traits>>);
+    static_assert(!is_convertible_v<basic_string_view<char, constexpr_char_traits>, string>);
+
+    // LWG-3857 basic_string_view should allow explicit conversion when only traits vary
+    static_assert(is_constructible_v<string_view, basic_string<char, constexpr_char_traits>>);
+    static_assert(is_constructible_v<basic_string_view<char, constexpr_char_traits>, string_view>);
+
+    static_assert(is_constructible_v<string_view, basic_string_view<char, constexpr_char_traits>>);
+    static_assert(is_constructible_v<basic_string_view<char, constexpr_char_traits>, string>);
 #endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 
     return true;

--- a/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
@@ -59,7 +59,7 @@ struct alternative_char_traits : char_traits<CharT> {};
 template <class CharT>
 using alternative_basic_string_view = basic_string_view<CharT, alternative_char_traits<CharT>>;
 
-template <class CharT, class Alloc = std::allocator<CharT>>
+template <class CharT, class Alloc = allocator<CharT>>
 using alternative_basic_string = basic_string<CharT, alternative_char_traits<CharT>, Alloc>;
 
 template <class charT, class... Args>


### PR DESCRIPTION
Fixes #3336.

The involved constructor of `basic_string_view` is introduced in C++23, so this PR also fixes the issue in C++20 mode in an alternative way.

Also updates references to working darft in `<format>` to WG21-N4928.