### PR TITLE
`vscode`: add vertical ruler

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,7 @@
     "[cpp]": {
         "editor.formatOnSave": true
     },
+    "editor.rulers": [120],
     "files.associations": {
         ".clang-format": "yaml",
         "header-units.json": "jsonc",


### PR DESCRIPTION
This tiny PR adds vertical ruler that indicates max line length (120). Example:

![ruler](https://i.imgur.com/Gu8cyJx.png)

<details>
  <summary>If it's not obvious</summary>
  <img src="https://i.imgur.com/mKGHz9p.png" alt="ruler"/>
</details>

I've decided to add this ruler to **all** file types, but LMK if I should limit it to extensions mentioned in `validate.cpp`.

https://github.com/microsoft/STL/blob/fbed7eaec0df4fefec2e447604e12d39d9eab857/tools/validate/validate.cpp#L180-L191