### PR TITLE
Improve `views::elements` tests

### DIFF
--- a/tests/std/tests/P0896R4_views_elements/test.cpp
+++ b/tests/std/tests/P0896R4_views_elements/test.cpp
@@ -223,25 +223,65 @@ constexpr bool test_one(Rng&& rng) {
         same_as<sentinel_t<R>> auto i = r.end();
         static_assert(common_range<R> == common_range<V>);
         if constexpr (bidirectional_range<R> && common_range<R>) {
-#if defined(__clang__) || defined(__EDG__) // TRANSITION, VSO-1243263
             assert(*prev(i) == *prev(end(expected_keys)));
-#else // ^^^ no workaround / workaround vvv
-            assert(*ranges::prev(i) == *ranges::prev(end(expected_keys)));
-#endif // ^^^ workaround ^^^
         }
 
         if constexpr (CanEnd<const R&>) {
             same_as<sentinel_t<const R>> auto i2 = as_const(r).end();
             static_assert(common_range<const R> == common_range<const V>);
             if constexpr (bidirectional_range<const R> && common_range<const R>) {
-#if defined(__clang__) || defined(__EDG__) // TRANSITION, VSO-1243263
                 assert(*prev(i2) == *prev(end(expected_keys)));
-#else // ^^^ no workaround / workaround vvv
-                assert(*ranges::prev(i2) == *ranges::prev(end(expected_keys)));
-#endif // ^^^ workaround ^^^
             }
         }
     }
+
+#if _HAS_CXX23
+    using ranges::const_iterator_t, ranges::const_sentinel_t, ranges::cbegin, ranges::cend;
+
+    // Validate view_interface::cbegin
+    STATIC_ASSERT(CanMemberCBegin<R>);
+    STATIC_ASSERT(CanMemberCBegin<const R&> == range<const V>);
+    if (forward_range<V>) { // intentionally not if constexpr
+        const same_as<const_iterator_t<R>> auto i = r.cbegin();
+        if (!is_empty) {
+            assert(*i == *cbegin(expected_keys));
+        }
+
+        if constexpr (copyable<V>) {
+            auto r2                                    = r;
+            const same_as<const_iterator_t<R>> auto i2 = r2.cbegin();
+            if (!is_empty) {
+                assert(*i2 == *i);
+            }
+        }
+
+        if constexpr (CanCBegin<const R&>) {
+            const same_as<const_iterator_t<const R>> auto i3 = as_const(r).cbegin();
+            if (!is_empty) {
+                assert(*i3 == *i);
+            }
+        }
+    }
+
+    // Validate view_interface::cend
+    STATIC_ASSERT(CanMemberCEnd<R>);
+    STATIC_ASSERT(CanMemberCEnd<const R&> == range<const V>);
+    if (!is_empty) {
+        same_as<const_sentinel_t<R>> auto i = r.cend();
+        static_assert(common_range<R> == common_range<V>);
+        if constexpr (bidirectional_range<R> && common_range<R>) {
+            assert(*prev(i) == *prev(cend(expected_keys)));
+        }
+
+        if constexpr (CanCEnd<const R&>) {
+            same_as<const_sentinel_t<const R>> auto i2 = as_const(r).cend();
+            static_assert(common_range<const R> == common_range<const V>);
+            if constexpr (bidirectional_range<const R> && common_range<const R>) {
+                assert(*prev(i2) == *prev(cend(expected_keys)));
+            }
+        }
+    }
+#endif // _HAS_CXX23
 
     // Validate view_interface::data
     STATIC_ASSERT(!CanData<R>);
@@ -256,11 +296,7 @@ constexpr bool test_one(Rng&& rng) {
 
         STATIC_ASSERT(CanMemberBack<R> == (bidirectional_range<V> && common_range<V>) );
         if constexpr (CanMemberBack<R>) {
-#if defined(__clang__) || defined(__EDG__) // TRANSITION, VSO-1243263
             assert(r.back() == *prev(end(expected_keys)));
-#else // ^^^ no workaround / workaround vvv
-            assert(r.back() == *ranges::prev(end(expected_keys)));
-#endif // ^^^ workaround ^^^
         }
 
         STATIC_ASSERT(CanMemberFront<const R> == (forward_range<const V>) );
@@ -270,11 +306,7 @@ constexpr bool test_one(Rng&& rng) {
 
         STATIC_ASSERT(CanMemberBack<const R> == (bidirectional_range<const V> && common_range<const V>) );
         if constexpr (CanMemberBack<const R>) {
-#if defined(__clang__) || defined(__EDG__) // TRANSITION, VSO-1243263
             assert(as_const(r).back() == *prev(end(expected_keys)));
-#else // ^^^ no workaround / workaround vvv
-            assert(as_const(r).back() == *ranges::prev(end(expected_keys)));
-#endif // ^^^ workaround ^^^
         }
     }
 
@@ -299,11 +331,7 @@ constexpr bool test_one(Rng&& rng) {
         if (!is_empty) {
             assert((*b1.begin() == pair{0, -1})); // NB: depends on the test data
             if constexpr (bidirectional_range<V> && common_range<V>) {
-#if defined(__clang__) || defined(__EDG__) // TRANSITION, VSO-1243263
                 assert((*prev(b1.end()) == pair{7, -8})); // NB: depends on the test data
-#else // ^^^ no workaround / workaround vvv
-                assert((*ranges::prev(b1.end()) == pair{7, -8})); // NB: depends on the test data
-#endif // ^^^ workaround ^^^
             }
         }
     }
@@ -315,11 +343,7 @@ constexpr bool test_one(Rng&& rng) {
         if (!is_empty) {
             assert((*b2.begin() == pair{0, -1})); // NB: depends on the test data
             if constexpr (bidirectional_range<V> && common_range<V>) {
-#if defined(__clang__) || defined(__EDG__) // TRANSITION, VSO-1243263
                 assert((*prev(b2.end()) == pair{7, -8})); // NB: depends on the test data
-#else // ^^^ no workaround / workaround vvv
-                assert((*ranges::prev(b2.end()) == pair{7, -8})); // NB: depends on the test data
-#endif // ^^^ workaround ^^^
             }
         }
     }


### PR DESCRIPTION
This PR:
* Removes workarounds for VSO-1243263,
* Adds tests for `view_interface::cbegin` and `view_interface::cend`.