### PR TITLE
Toolset update: VS 2022 17.5 Preview 3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,12 +50,6 @@ set(VCLIBS_SUFFIX "_oss" CACHE STRING "suffix for built DLL names to avoid confl
 
 option(STL_USE_ANALYZE "Pass the /analyze flag to MSVC" OFF)
 
-if(STL_BUILD_BENCHMARKING)
-    message(WARNING "Due to issues with building google benchmark, "
-        "STL_BUILD_BENCHMARKING is no longer allowed as part of the STL build. "
-        "Instead, build the `benchmarks` directory with the STL_BINARY_DIR option.")
-endif()
-
 if("${VCLIBS_TARGET_ARCHITECTURE}" MATCHES "^x86$")
     set(VCLIBS_TARGET_ARCHITECTURE "x86")
     set(VCLIBS_I386_OR_AMD64 "i386")

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With The Visual Studio IDE
 
-1. Install Visual Studio 2022 17.5 Preview 2 or later.
+1. Install Visual Studio 2022 17.5 Preview 3 or later.
     * Select "Windows 11 SDK (10.0.22000.0)" in the VS Installer.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
@@ -157,7 +157,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With A Native Tools Command Prompt
 
-1. Install Visual Studio 2022 17.5 Preview 2 or later.
+1. Install Visual Studio 2022 17.5 Preview 3 or later.
     * Select "Windows 11 SDK (10.0.22000.0)" in the VS Installer.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ variables:
   benchmarkBuildOutputLocation: 'D:\benchmark'
 
 pool:
-  name: 'StlBuild-2023-01-10T1341-Pool'
+  name: 'StlBuild-2023-01-18T1600-Pool'
   demands: EnableSpotVM -equals true
 
 pr:

--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -3242,33 +3242,18 @@ public:
                             && is_convertible_v<remove_pointer_t<_Uty> (*)[], element_type (*)[]>),
             int>;
 
-#ifdef _M_CEE // TRANSITION, VSO-1595465
-    template <class _Uty, class _Dx2 = _Dx, _Unique_ptr_enable_default_t<_Dx2> = 0, class = _Enable_ctor_reset<_Uty>>
-#else // ^^^ workaround / no workaround vvv
     template <class _Uty, class _Dx2 = _Dx, _Unique_ptr_enable_default_t<_Dx2> = 0, _Enable_ctor_reset<_Uty> = 0>
-#endif // ^^^ no workaround ^^^
-    _CONSTEXPR23 explicit unique_ptr(_Uty _Ptr) noexcept : _Mypair(_Zero_then_variadic_args_t{}, _Ptr) {
-    }
+    _CONSTEXPR23 explicit unique_ptr(_Uty _Ptr) noexcept : _Mypair(_Zero_then_variadic_args_t{}, _Ptr) {}
 
     template <class _Uty, class _Dx2 = _Dx, enable_if_t<is_constructible_v<_Dx2, const _Dx2&>, int> = 0,
-#ifdef _M_CEE // TRANSITION, VSO-1595465
-        class = _Enable_ctor_reset<_Uty>>
-#else // ^^^ workaround / no workaround vvv
         _Enable_ctor_reset<_Uty> = 0>
-#endif // ^^^ no workaround ^^^
-    _CONSTEXPR23 unique_ptr(_Uty _Ptr, const _Dx& _Dt) noexcept : _Mypair(_One_then_variadic_args_t{}, _Dt, _Ptr) {
-    }
+    _CONSTEXPR23 unique_ptr(_Uty _Ptr, const _Dx& _Dt) noexcept : _Mypair(_One_then_variadic_args_t{}, _Dt, _Ptr) {}
 
     template <class _Uty, class _Dx2 = _Dx,
         enable_if_t<conjunction_v<negation<is_reference<_Dx2>>, is_constructible<_Dx2, _Dx2>>, int> = 0,
-#ifdef _M_CEE // TRANSITION, VSO-1595465
-        class = _Enable_ctor_reset<_Uty>>
-#else // ^^^ workaround / no workaround vvv
-        _Enable_ctor_reset<_Uty> = 0>
-#endif // ^^^ no workaround ^^^
+        _Enable_ctor_reset<_Uty>                                                                    = 0>
     _CONSTEXPR23 unique_ptr(_Uty _Ptr, _Dx&& _Dt) noexcept
-        : _Mypair(_One_then_variadic_args_t{}, _STD move(_Dt), _Ptr) {
-    }
+        : _Mypair(_One_then_variadic_args_t{}, _STD move(_Dt), _Ptr) {}
 
     template <class _Uty, class _Dx2 = _Dx,
         enable_if_t<conjunction_v<is_reference<_Dx2>, is_constructible<_Dx2, remove_reference_t<_Dx2>>>, int> = 0>
@@ -3296,22 +3281,12 @@ public:
         int>;
 
     template <class _Uty, class _Ex,
-#ifdef _M_CEE // TRANSITION, VSO-1595465
-        class = _Enable_conversion<_Uty, _Ex,
-            conditional_t<is_reference_v<_Dx>, is_same<_Ex, _Dx>, is_convertible<_Ex, _Dx>>>>
-#else // ^^^ workaround / no workaround vvv
         _Enable_conversion<_Uty, _Ex, conditional_t<is_reference_v<_Dx>, is_same<_Ex, _Dx>, is_convertible<_Ex, _Dx>>> =
             0>
-#endif // ^^^ no workaround ^^^
     _CONSTEXPR23 unique_ptr(unique_ptr<_Uty, _Ex>&& _Right) noexcept
-        : _Mypair(_One_then_variadic_args_t{}, _STD forward<_Ex>(_Right.get_deleter()), _Right.release()) {
-    }
+        : _Mypair(_One_then_variadic_args_t{}, _STD forward<_Ex>(_Right.get_deleter()), _Right.release()) {}
 
-#ifdef _M_CEE // TRANSITION, VSO-1595465
-    template <class _Uty, class _Ex, class = _Enable_conversion<_Uty, _Ex, is_assignable<_Dx&, _Ex>>>
-#else // ^^^ workaround / no workaround vvv
     template <class _Uty, class _Ex, _Enable_conversion<_Uty, _Ex, is_assignable<_Dx&, _Ex>> = 0>
-#endif // ^^^ no workaround ^^^
     _CONSTEXPR23 unique_ptr& operator=(unique_ptr<_Uty, _Ex>&& _Right) noexcept {
         reset(_Right.release());
         _Mypair._Get_first() = _STD forward<_Ex>(_Right._Mypair._Get_first());
@@ -3365,11 +3340,7 @@ public:
         return _STD exchange(_Mypair._Myval2, nullptr);
     }
 
-#ifdef _M_CEE // TRANSITION, VSO-1595465
-    template <class _Uty, class = _Enable_ctor_reset<_Uty, false_type>>
-#else // ^^^ workaround / no workaround vvv
     template <class _Uty, _Enable_ctor_reset<_Uty, false_type> = 0>
-#endif // ^^^ no workaround ^^^
     _CONSTEXPR23 void reset(_Uty _Ptr) noexcept {
         pointer _Old = _STD exchange(_Mypair._Myval2, _Ptr);
         if (_Old) {

--- a/stl/src/special_math.cpp
+++ b/stl/src/special_math.cpp
@@ -9,7 +9,6 @@
 
 #pragma warning(push)
 #pragma warning(disable : 4702) // unreachable code
-#pragma warning(disable : 6326) // potential comparison of a constant with another constant
 
 #define BOOST_MATH_DOMAIN_ERROR_POLICY   errno_on_error
 #define BOOST_MATH_OVERFLOW_ERROR_POLICY ignore_error

--- a/tests/std/tests/GH_002030_asan_annotate_string/env.lst
+++ b/tests/std/tests/GH_002030_asan_annotate_string/env.lst
@@ -29,8 +29,6 @@ PM_CL="-fsanitize=address /EHsc /MTd /std:c++latest /permissive /fno-sanitize-ad
 PM_CL="-fsanitize=address /EHsc /MTd /std:c++latest /permissive- /analyze:only /analyze:autolog- /fno-sanitize-address-vcasan-lib"
 PM_CL="-fsanitize=address /EHsc /MTd /std:c++latest /permissive- /fp:strict /fno-sanitize-address-vcasan-lib"
 PM_CL="-fsanitize=address /EHsc /MTd /std:c++latest /permissive- /fno-sanitize-address-vcasan-lib"
-PM_CL="-fsanitize=address /Za /EHsc /MD /std:c++latest /permissive- /fno-sanitize-address-vcasan-lib"
-PM_CL="-fsanitize=address /Za /EHsc /MDd /std:c++latest /permissive- /fno-sanitize-address-vcasan-lib"
 PM_CL="/D_ANNOTATE_STRING /BE /c /EHsc /MD /std:c++14 /fno-sanitize-address-vcasan-lib"
 PM_CL="/D_ANNOTATE_STRING /BE /c /EHsc /MDd /std:c++17 /permissive- /fno-sanitize-address-vcasan-lib"
 PM_CL="/D_ANNOTATE_STRING /BE /c /EHsc /MT /std:c++20 /permissive- /fno-sanitize-address-vcasan-lib"
@@ -53,8 +51,6 @@ PM_CL="/D_ANNOTATE_STRING /EHsc /MTd /std:c++latest /permissive /fno-sanitize-ad
 PM_CL="/D_ANNOTATE_STRING /EHsc /MTd /std:c++latest /permissive- /analyze:only /analyze:autolog- /fno-sanitize-address-vcasan-lib"
 PM_CL="/D_ANNOTATE_STRING /EHsc /MTd /std:c++latest /permissive- /fp:strict /fno-sanitize-address-vcasan-lib"
 PM_CL="/D_ANNOTATE_STRING /EHsc /MTd /std:c++latest /permissive- /fno-sanitize-address-vcasan-lib"
-PM_CL="/D_ANNOTATE_STRING /Za /EHsc /MD /std:c++latest /permissive- /fno-sanitize-address-vcasan-lib"
-PM_CL="/D_ANNOTATE_STRING /Za /EHsc /MDd /std:c++latest /permissive- /fno-sanitize-address-vcasan-lib"
 # TRANSITION, clang-cl does not support /alternatename so we cannot test /D_ANNOTATE_STRING without -fsanitize=address
 PM_COMPILER="clang-cl" PM_CL="-fsanitize=address -fno-ms-compatibility -fno-delayed-template-parsing -Wno-unqualified-std-cast-call /EHsc /MD /std:c++14"
 PM_COMPILER="clang-cl" PM_CL="-fsanitize=address -fno-ms-compatibility -fno-delayed-template-parsing -Wno-unqualified-std-cast-call /EHsc /MD /std:c++17"

--- a/tests/std/tests/P0980R1_constexpr_strings/test.cpp
+++ b/tests/std/tests/P0980R1_constexpr_strings/test.cpp
@@ -238,9 +238,6 @@ template <class CharType>
 constexpr bool test_interface() {
     using str = basic_string<CharType>;
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
-    if (!is_constant_evaluated())
-#endif // ^^^ workaround ^^^
     { // constructors
         // range constructors
         str literal_constructed{get_literal_input<CharType>()};
@@ -296,9 +293,6 @@ constexpr bool test_interface() {
         assert(equalRanges(conversion_start_length_constructed, "llo"sv));
     }
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
-    if (!is_constant_evaluated())
-#endif // ^^^ workaround ^^^
     { // allocator constructors
         allocator<CharType> alloc;
 
@@ -347,9 +341,6 @@ constexpr bool test_interface() {
         assert(equalRanges(conversion_start_length_constructed, "llo"sv));
     }
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
-    if (!is_constant_evaluated())
-#endif // ^^^ workaround ^^^
     { // assignment operator
         str literal_constructed = get_literal_input<CharType>();
 
@@ -380,9 +371,6 @@ constexpr bool test_interface() {
         assert(equalRanges(conversion_assigned, literal_constructed));
     }
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
-    if (!is_constant_evaluated())
-#endif // ^^^ workaround ^^^
     { // assign
         str literal_constructed = get_literal_input<CharType>();
 
@@ -499,9 +487,6 @@ constexpr bool test_interface() {
         assert(char_traits<CharType>::length(cs) == literal_constructed.size());
     }
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
-    if (!is_constant_evaluated())
-#endif // ^^^ workaround ^^^
     { // iterators
         str literal_constructed             = get_literal_input<CharType>();
         const str const_literal_constructed = get_literal_input<CharType>();
@@ -752,9 +737,6 @@ constexpr bool test_interface() {
         assert(pushed.back() == CharType{'y'});
     }
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
-    if (!is_constant_evaluated())
-#endif // ^^^ workaround ^^^
     { // append
         const str literal_constructed = get_literal_input<CharType>();
 
@@ -800,9 +782,6 @@ constexpr bool test_interface() {
         assert(equalRanges(append_conversion_start_length, "bbllo"sv));
     }
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
-    if (!is_constant_evaluated())
-#endif // ^^^ workaround ^^^
     { // operator+=
         str literal_constructed = get_literal_input<CharType>();
 
@@ -1105,9 +1084,6 @@ constexpr bool test_interface() {
         assert(equalRanges(copy_count_pos, "fluffy"sv));
     }
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
-    if (!is_constant_evaluated())
-#endif // ^^^ workaround ^^^
     { // resize
         str resized = get_literal_input<CharType>();
         resized.resize(3);
@@ -1753,9 +1729,6 @@ constexpr bool test_iterators() {
         cit = cit2;
     }
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
-    if (!is_constant_evaluated())
-#endif // ^^^ workaround ^^^
     { // op->
         basic_string<CharLikeType<CharType>> bs{CharType{'x'}};
         auto it = bs.begin();
@@ -1767,9 +1740,6 @@ constexpr bool test_iterators() {
         assert(cc == CharType{'x'});
     }
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
-    if (!is_constant_evaluated())
-#endif // ^^^ workaround ^^^
     { // increment
         auto it = literal_constructed.begin();
         assert(*++it == CharType{'e'});
@@ -1801,9 +1771,6 @@ constexpr bool test_iterators() {
         assert(*cit == CharType{'f'});
     }
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
-    if (!is_constant_evaluated())
-#endif // ^^^ workaround ^^^
     { // decrement
         auto it = literal_constructed.end();
         assert(*--it == CharType{'s'});
@@ -1996,12 +1963,6 @@ constexpr bool test_growth() {
 
 template <class CharType>
 constexpr void test_copy_ctor() {
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
-    if (is_constant_evaluated()) {
-        return;
-    }
-#endif // ^^^ workaround ^^^
-
     using Str = basic_string<CharType, char_traits<CharType>, StationaryAlloc<CharType>>;
 
     { // Allocated
@@ -2025,12 +1986,6 @@ constexpr void test_copy_ctor() {
 
 template <class CharType>
 constexpr void test_copy_alloc_ctor(const size_t id1, const size_t id2) {
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
-    if (is_constant_evaluated()) {
-        return;
-    }
-#endif // ^^^ workaround ^^^
-
     using Str = basic_string<CharType, char_traits<CharType>, StationaryAlloc<CharType>>;
 
     { // Allocated
@@ -2054,12 +2009,6 @@ constexpr void test_copy_alloc_ctor(const size_t id1, const size_t id2) {
 
 template <class CharType, class Alloc>
 constexpr void test_copy_assign(const size_t id1, const size_t id2, const size_t id3) {
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
-    if (is_constant_evaluated()) {
-        return;
-    }
-#endif // ^^^ workaround ^^^
-
     using Str = basic_string<CharType, char_traits<CharType>, Alloc>;
 
     { // Allocated to SSO
@@ -2282,9 +2231,6 @@ constexpr void test_swap(const size_t id1, const size_t id2) {
         assert(rhs.get_allocator().id() == id1);
     }
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
-    if (!is_constant_evaluated())
-#endif // ^^^ workaround ^^^
     { // Allocated to Allocated
         Str lhs(get_view_input<CharType>(), Alloc{id1});
         Str rhs(get_view_input<CharType>(), Alloc{id2});

--- a/tests/std/tests/P0980R1_constexpr_strings/test.cpp
+++ b/tests/std/tests/P0980R1_constexpr_strings/test.cpp
@@ -608,7 +608,7 @@ constexpr bool test_interface() {
         assert(cleared.capacity() == str{get_literal_input<CharType>()}.capacity());
     }
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1726722 (attempt to access expired storage)
     if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
     { // insert
@@ -688,7 +688,7 @@ constexpr bool test_interface() {
         assert(equalRanges(insert_iter_count_char, "Hellooooo fluffy kittens"sv));
     }
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1726722 (attempt to access expired storage)
     if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
     { // erase
@@ -967,7 +967,7 @@ constexpr bool test_interface() {
     }
 #endif // _HAS_CXX23
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1726722 (attempt to access expired storage)
     if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
     { // replace
@@ -1059,7 +1059,7 @@ constexpr bool test_interface() {
         assert(equalRanges(replaced_pos_count_conversion_pos_count, "dfluffy"sv));
     }
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1726722 (attempt to access expired storage)
     if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
     { // substr
@@ -1558,7 +1558,7 @@ constexpr bool test_interface() {
         assert(find_last_not_of_convertible_pos == str::npos);
     }
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1726722 (attempt to access expired storage)
     if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
     { // operator+
@@ -1690,7 +1690,7 @@ constexpr bool test_interface() {
 }
 
 constexpr bool test_udls() {
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1726722 (attempt to access expired storage)
     if (is_constant_evaluated()) {
         return true;
     }
@@ -1752,7 +1752,7 @@ constexpr bool test_iterators() {
         assert(*cit == CharType{'l'});
     }
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1726722 (attempt to access expired storage)
     if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
     { // advance
@@ -1783,7 +1783,7 @@ constexpr bool test_iterators() {
         assert(*cit == CharType{'n'});
     }
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1726722 (attempt to access expired storage)
     if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
     { // advance back
@@ -1828,7 +1828,7 @@ constexpr bool test_iterators() {
         assert((it3 <=> it1) == strong_ordering::greater);
     }
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1726722 (attempt to access expired storage)
     if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
     { // access
@@ -1886,7 +1886,7 @@ constexpr bool test_growth() {
         assert(v.capacity() == 1510);
     }
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1726722 (attempt to access expired storage)
     if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
     {
@@ -1903,7 +1903,7 @@ constexpr bool test_growth() {
         assert(v.capacity() == 1510);
     }
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1726722 (attempt to access expired storage)
     if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
     {
@@ -1924,7 +1924,7 @@ constexpr bool test_growth() {
         }
     }
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1726722 (attempt to access expired storage)
     if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
     {
@@ -1939,7 +1939,7 @@ constexpr bool test_growth() {
         assert(v.capacity() == 1510);
     }
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1726722 (attempt to access expired storage)
     if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
     {
@@ -2059,7 +2059,7 @@ constexpr void test_copy_assign(const size_t id1, const size_t id2, const size_t
 
 template <class CharType>
 constexpr void test_move_ctor() {
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1726722 (attempt to access expired storage)
     if (is_constant_evaluated()) {
         return;
     }
@@ -2093,7 +2093,7 @@ constexpr void test_move_ctor() {
 
 template <class CharType>
 constexpr void test_move_alloc_ctor(const size_t id1, const size_t id2) {
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1726722 (attempt to access expired storage)
     if (is_constant_evaluated()) {
         return;
     }
@@ -2127,7 +2127,7 @@ constexpr void test_move_alloc_ctor(const size_t id1, const size_t id2) {
 
 template <class CharType, class Alloc>
 constexpr void test_move_assign(const size_t id1, const size_t id2, const size_t id3) {
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1726722 (attempt to access expired storage)
     if (is_constant_evaluated()) {
         return;
     }

--- a/tests/std/tests/P1004R2_constexpr_vector/test.cpp
+++ b/tests/std/tests/P1004R2_constexpr_vector/test.cpp
@@ -428,7 +428,7 @@ constexpr bool test_interface() {
         assert(equal(second.begin(), second.end(), begin(expected_second), end(expected_second)));
     }
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1726722 (attempt to access expired storage)
     if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
     { // erase
@@ -490,7 +490,7 @@ constexpr bool test_iterators() {
         assert(*cit == 2);
     }
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1726722 (attempt to access expired storage)
     if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
     { // advance
@@ -517,7 +517,7 @@ constexpr bool test_iterators() {
         assert(*cit == 4);
     }
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1726722 (attempt to access expired storage)
     if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
     { // advance back
@@ -558,7 +558,7 @@ constexpr bool test_iterators() {
         assert(it3 >= it1);
     }
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1726722 (attempt to access expired storage)
     if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
     { // access
@@ -625,7 +625,7 @@ constexpr bool test_growth() {
 
         vector<int> l(3, 47);
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1726722 (attempt to access expired storage)
         if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
         {
@@ -644,7 +644,7 @@ constexpr bool test_growth() {
 
         vector<int> l(7000, 47);
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1726722 (attempt to access expired storage)
         if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
         {
@@ -661,7 +661,7 @@ constexpr bool test_growth() {
         assert(v.size() == 1000);
         assert(v.capacity() == 1000);
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1726722 (attempt to access expired storage)
         if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
         {
@@ -678,7 +678,7 @@ constexpr bool test_growth() {
         assert(v.size() == 1000);
         assert(v.capacity() == 1000);
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1726722 (attempt to access expired storage)
         if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
         {

--- a/tests/std/tests/P1004R2_constexpr_vector/test.cpp
+++ b/tests/std/tests/P1004R2_constexpr_vector/test.cpp
@@ -326,7 +326,7 @@ constexpr bool test_interface() {
         assert(c2 == 6);
     }
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1726729 (attempt to access run-time storage)
     if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
     { // modifiers

--- a/tests/std/tests/P1004R2_constexpr_vector/test.cpp
+++ b/tests/std/tests/P1004R2_constexpr_vector/test.cpp
@@ -75,62 +75,30 @@ constexpr bool test_interface() {
             size_value_constructed.begin(), size_value_constructed.end(), [](const int val) { return val == 7; }));
 
         vec range_constructed(begin(input), end(input));
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
-        if (!is_constant_evaluated())
-#endif // ^^^ workaround ^^^
-        {
-            assert(equal(range_constructed.begin(), range_constructed.end(), begin(input), end(input)));
-        }
+        assert(equal(range_constructed.begin(), range_constructed.end(), begin(input), end(input)));
 
         vec initializer_list_constructed({2, 3, 4, 5});
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
-        if (!is_constant_evaluated())
-#endif // ^^^ workaround ^^^
-        {
-            assert(equal(initializer_list_constructed.begin(), initializer_list_constructed.end(), begin(input) + 2,
-                end(input)));
-        }
+        assert(equal(
+            initializer_list_constructed.begin(), initializer_list_constructed.end(), begin(input) + 2, end(input)));
 
         // special member functions
         vec default_constructed;
         assert(default_constructed.empty());
         vec copy_constructed(size_default_constructed);
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
-        if (!is_constant_evaluated())
-#endif // ^^^ workaround ^^^
-        {
-            assert(equal(copy_constructed.begin(), copy_constructed.end(), size_default_constructed.begin(),
-                size_default_constructed.end()));
-        }
+        assert(equal(copy_constructed.begin(), copy_constructed.end(), size_default_constructed.begin(),
+            size_default_constructed.end()));
 
         vec move_constructed(move(copy_constructed));
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
-        if (!is_constant_evaluated())
-#endif // ^^^ workaround ^^^
-        {
-            assert(equal(move_constructed.begin(), move_constructed.end(), size_default_constructed.begin(),
-                size_default_constructed.end()));
-        }
+        assert(equal(move_constructed.begin(), move_constructed.end(), size_default_constructed.begin(),
+            size_default_constructed.end()));
 
         assert(copy_constructed.empty()); // implementation-specific assumption that moved-from is empty
 
         vec copy_assigned = range_constructed;
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
-        if (!is_constant_evaluated())
-#endif // ^^^ workaround ^^^
-        {
-            assert(
-                equal(copy_assigned.begin(), copy_assigned.end(), range_constructed.begin(), range_constructed.end()));
-        }
+        assert(equal(copy_assigned.begin(), copy_assigned.end(), range_constructed.begin(), range_constructed.end()));
 
         vec move_assigned = move(copy_assigned);
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
-        if (!is_constant_evaluated())
-#endif // ^^^ workaround ^^^
-        {
-            assert(
-                equal(move_assigned.begin(), move_assigned.end(), range_constructed.begin(), range_constructed.end()));
-        }
+        assert(equal(move_assigned.begin(), move_assigned.end(), range_constructed.begin(), range_constructed.end()));
         assert(copy_assigned.empty()); // implementation-specific assumption that moved-from is empty
 
         // allocator constructors
@@ -169,30 +137,17 @@ constexpr bool test_interface() {
         assert(al_size_value_constructed.get_allocator().soccc_generation == 3);
 
         vec al_range_constructed(begin(input), end(input), alloc);
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
-        if (!is_constant_evaluated())
-#endif // ^^^ workaround ^^^
-        {
-            assert(equal(al_range_constructed.begin(), al_range_constructed.end(), begin(input), end(input)));
-        }
+        assert(equal(al_range_constructed.begin(), al_range_constructed.end(), begin(input), end(input)));
         assert(al_range_constructed.get_allocator().id == 4);
         assert(al_range_constructed.get_allocator().soccc_generation == 3);
 
         vec al_initializer_list_constructed({2, 3, 4, 5}, alloc);
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
-        if (!is_constant_evaluated())
-#endif // ^^^ workaround ^^^
-        {
-            assert(equal(al_initializer_list_constructed.begin(), al_initializer_list_constructed.end(),
-                begin(input) + 2, end(input)));
-        }
+        assert(equal(al_initializer_list_constructed.begin(), al_initializer_list_constructed.end(), begin(input) + 2,
+            end(input)));
         assert(al_initializer_list_constructed.get_allocator().id == 4);
         assert(al_initializer_list_constructed.get_allocator().soccc_generation == 3);
     }
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
-    if (!is_constant_evaluated())
-#endif // ^^^ workaround ^^^
     { // assignment
         vec range_constructed(begin(input), end(input));
 
@@ -234,9 +189,6 @@ constexpr bool test_interface() {
         assert(alloc.soccc_generation == 0);
     }
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
-    if (!is_constant_evaluated())
-#endif // ^^^ workaround ^^^
     { // iterators
         vec range_constructed(begin(input), end(input));
         const vec const_range_constructed(begin(input), end(input));
@@ -526,9 +478,6 @@ constexpr bool test_interface() {
 constexpr bool test_iterators() {
     vec range_constructed(begin(input), end(input));
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
-    if (!is_constant_evaluated())
-#endif // ^^^ workaround ^^^
     { // increment
         auto it = range_constructed.begin();
         assert(*++it == 1);
@@ -556,9 +505,6 @@ constexpr bool test_iterators() {
         assert(*cit == 4);
     }
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
-    if (!is_constant_evaluated())
-#endif // ^^^ workaround ^^^
     { // decrement
         auto it = range_constructed.end();
         assert(*--it == 5);

--- a/tests/std/tests/P1004R2_constexpr_vector_bool/test.cpp
+++ b/tests/std/tests/P1004R2_constexpr_vector_bool/test.cpp
@@ -101,7 +101,7 @@ constexpr bool test_interface() {
         // Non allocator constructors
         vec size_default_constructed(5);
         assert(size_default_constructed.size() == 5);
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1726722 (attempt to access expired storage)
         if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
         {
@@ -111,7 +111,7 @@ constexpr bool test_interface() {
 
         vec size_value_constructed(5, true);
         assert(size_value_constructed.size() == 5);
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1726722 (attempt to access expired storage)
         if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
         {
@@ -119,7 +119,7 @@ constexpr bool test_interface() {
                 size_value_constructed.begin(), size_value_constructed.end(), [](const bool val) { return val; }));
         }
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1726722 (attempt to access expired storage)
         if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
         {
@@ -144,7 +144,7 @@ constexpr bool test_interface() {
         vec default_constructed;
         assert(default_constructed.empty());
         vec copy_constructed(size_default_constructed);
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1726722 (attempt to access expired storage)
         if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
         {
@@ -153,7 +153,7 @@ constexpr bool test_interface() {
         }
 
         vec move_constructed(move(copy_constructed));
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1726722 (attempt to access expired storage)
         if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
         {
@@ -173,7 +173,7 @@ constexpr bool test_interface() {
         assert(al_default_constructed.get_allocator().soccc_generation == 3);
 
         vec al_copy_constructed(size_value_constructed, alloc);
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1726722 (attempt to access expired storage)
         if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
         {
@@ -183,7 +183,7 @@ constexpr bool test_interface() {
         assert(al_copy_constructed.get_allocator().soccc_generation == 3);
 
         vec al_move_constructed(move(al_copy_constructed), alloc);
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1726722 (attempt to access expired storage)
         if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
         {
@@ -195,7 +195,7 @@ constexpr bool test_interface() {
 
         vec al_size_default_constructed(5, alloc);
         assert(al_size_default_constructed.size() == 5);
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1726722 (attempt to access expired storage)
         if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
         {
@@ -207,7 +207,7 @@ constexpr bool test_interface() {
 
         vec al_size_value_constructed(5, true, alloc);
         assert(al_size_value_constructed.size() == 5);
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1726722 (attempt to access expired storage)
         if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
         {
@@ -217,7 +217,7 @@ constexpr bool test_interface() {
         assert(al_size_value_constructed.get_allocator().id == 4);
         assert(al_size_value_constructed.get_allocator().soccc_generation == 3);
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1726722 (attempt to access expired storage)
         if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
         {
@@ -234,7 +234,7 @@ constexpr bool test_interface() {
         }
     }
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1726722 (attempt to access expired storage)
     if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
     { // assignment
@@ -278,7 +278,7 @@ constexpr bool test_interface() {
         assert(alloc.soccc_generation == 0);
     }
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1726722 (attempt to access expired storage)
     if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
     { // iterators
@@ -334,7 +334,7 @@ constexpr bool test_interface() {
         assert(*prev(cre2));
     }
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1726722 (attempt to access expired storage)
     if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
     { // access
@@ -385,7 +385,7 @@ constexpr bool test_interface() {
         assert(cb);
     }
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1726722 (attempt to access expired storage)
     if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
     { // capacity
@@ -416,7 +416,7 @@ constexpr bool test_interface() {
         assert(c2 == 32);
     }
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1726722 (attempt to access expired storage)
     if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
     { // modifiers
@@ -524,7 +524,7 @@ constexpr bool test_interface() {
         assert(input_inserted.size() == size(num_arr));
     }
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1726722 (attempt to access expired storage)
     if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
     { // swap
@@ -538,7 +538,7 @@ constexpr bool test_interface() {
         assert(equal(second.begin(), second.end(), begin(expected_second), end(expected_second)));
     }
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1726722 (attempt to access expired storage)
     if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
     { // erase
@@ -553,7 +553,7 @@ constexpr bool test_interface() {
         assert(equal(erased_if.begin(), erased_if.end(), begin(expected_erase_if), end(expected_erase_if)));
     }
 
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1726722 (attempt to access expired storage)
     if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
     { // comparison
@@ -590,7 +590,7 @@ constexpr bool test_interface() {
 }
 
 constexpr bool test_iterators() {
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1726722 (attempt to access expired storage)
     if (is_constant_evaluated()) {
         return true;
     }

--- a/tests/std/tests/P1004R2_constexpr_vector_bool/test.cpp
+++ b/tests/std/tests/P1004R2_constexpr_vector_bool/test.cpp
@@ -509,7 +509,7 @@ constexpr bool test_interface() {
         assert(emplaced.size() == 22);
     }
 
-#ifdef __EDG__ // TRANSITION, VSO-1674154 (invalid arithmetic on non-array pointer)
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1726722 (attempt to access expired storage)
     if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
     {

--- a/tests/std/tests/P2321R2_proxy_reference/test.cpp
+++ b/tests/std/tests/P2321R2_proxy_reference/test.cpp
@@ -274,7 +274,7 @@ constexpr bool test() {
 
     { // Test vector<bool>::reference
         static_assert(is_assignable_v<const vector<bool>::reference, bool>);
-#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+#if defined(__EDG__) && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1726722 (attempt to access expired storage)
         if (!is_constant_evaluated())
 #endif // ^^^ workaround ^^^
         {

--- a/tests/std/tests/VSO_0000000_allocator_propagation/test.cpp
+++ b/tests/std/tests/VSO_0000000_allocator_propagation/test.cpp
@@ -296,7 +296,7 @@ _CONSTEXPR20 void test_sequence_swap(const size_t id1, const size_t id2) {
 template <template <class, class> class Sequence>
 _CONSTEXPR20 bool test_sequence() {
 #if _HAS_CXX20 && defined(__EDG__) \
-    && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1674140 (attempt to access expired storage)
+    && _ITERATOR_DEBUG_LEVEL == 2 // TRANSITION, VSO-1726722 (attempt to access expired storage)
     if (is_constant_evaluated()) {
         return true;
     }


### PR DESCRIPTION
* Toolset update: VS 2022 17.5 Preview 3.
* Remove workarounds for VSO-1595465 "`/clr` `/std:c++17` ICE with `int = 0` SFINAE".
  + Verified with an internal build.
* Remove workaround for boostorg/math#853.
  + We picked up the fix with #3312.
* Drop `/Za` configs from `GH_002030_asan_annotate_string/env.lst`.
  + The rest of these were dropped by #2714 on 2022-05-12, then this file was added by #2196 on 2022-05-16.
* Drop the `STL_BUILD_BENCHMARKING` message.
  + This machinery was removed by #3151 on 2022-10-24, and we don't need to worry about anyone following the old instructions now.
* Update EDG bug workarounds:
  + VSO-1674140 (attempt to access expired storage) was partially fixed, so we can remove some workarounds.
  + Update the remaining workarounds to cite VSO-1726722 "EDG rejects `constexpr string/vector` in debug mode with 'attempt to access expired storage' errors, part 2".
  + One workaround involves a slightly different error message now, so cite VSO-1726729 "EDG rejects `constexpr vector insert()` in debug mode with 'attempt to access run-time storage' errors".
  + VSO-1674154 (invalid arithmetic on non-array pointer) was definitely fixed, but we're still blocked by the "expired storage" bug, so restrict the workaround to IDL=2 and update the citation.
