### PR TITLE
use `_Make_unsigned_like_t` instead of `make_unsigned_t` for `_Max_possible_v`

### DIFF
--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -1025,7 +1025,7 @@ struct _Distance_unknown {
 };
 
 template <class _Diff>
-_INLINE_VAR constexpr _Diff _Max_possible_v{static_cast<make_unsigned_t<_Diff>>(-1) >> 1};
+_INLINE_VAR constexpr _Diff _Max_possible_v{static_cast<_Make_unsigned_like_t<_Diff>>(-1) >> 1};
 
 template <class _Diff>
 _INLINE_VAR constexpr _Diff _Min_possible_v{-_Max_possible_v<_Diff> - 1};

--- a/tests/std/tests/P0896R4_views_drop/test.cpp
+++ b/tests/std/tests/P0896R4_views_drop/test.cpp
@@ -528,4 +528,11 @@ int main() {
         auto r2 = s | views::drop(evil_convertible_to_difference{});
         assert(ranges::equal(r2, only_four_ints));
     }
+
+    { // GH-3025 <iterator>: ranges::prev maybe ill-formed in debug mode
+       auto r = std::views::iota(0ull, 5ull);
+       auto it = r.end();
+       auto prev = std::ranges::prev(it, 3);
+       assert(*prev == 2ull);
+    }
 }


### PR DESCRIPTION
Fixes #3025 

Yes, I saw @frederick-vs-ja 's [comment](https://github.com/microsoft/STL/issues/3025#issuecomment-1211627565) and we can change every use `_Make_unsigned_like_t` to `make_unsigned_t` when the C++ standard will be changed.