### PR TITLE
Fix XPASSing `visit_format_arg.pass.cpp`

### DIFF
--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -399,9 +399,6 @@ std/strings/basic.string/string.modifiers/robust_against_adl.pass.cpp FAIL
 # GH-3100: <memory> etc.: ADL should be avoided when calling _Construct_in_place and its friends
 std/utilities/function.objects/func.wrap/func.wrap.func/robust_against_adl.pass.cpp FAIL
 
-# GH-3336: Failure to format basic_string_view with non-standard traits
-std/utilities/format/format.arguments/format.arg/visit_format_arg.pass.cpp FAIL
-
 
 # *** CRT BUGS ***
 # We're permanently missing aligned_alloc().

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -399,9 +399,6 @@ strings\basic.string\string.modifiers\robust_against_adl.pass.cpp
 # GH-3100: <memory> etc.: ADL should be avoided when calling _Construct_in_place and its friends
 utilities\function.objects\func.wrap\func.wrap.func\robust_against_adl.pass.cpp
 
-# GH-3336: Failure to format basic_string_view with non-standard traits
-utilities\format\format.arguments\format.arg\visit_format_arg.pass.cpp
-
 
 # *** CRT BUGS ***
 # We're permanently missing aligned_alloc().


### PR DESCRIPTION
The libcxx test `visit_format_arg.pass.cpp` is "unexpectedly passing" due to a stealth merge conflict:

* #3344 added this test, marked as a known failure
* #3348 fixed the bug that was causing this test to fail

MSVC-internal PR/CI runs aren't affected because they completely skip things in `skipped_tests.txt`. However, the GitHub CI noticed that the test was marked as `FAIL` yet was passing.

(I sometimes create GitHub PRs for testing purposes when merging a big stack of PRs, but didn't do so this time, which is how I missed it.)