### PR TITLE
Standard Library Modules: Add `modules/modules.json`

### DIFF
--- a/stl/CMakeLists.txt
+++ b/stl/CMakeLists.txt
@@ -256,14 +256,15 @@ foreach(header ${HEADERS})
     configure_file("${header}" "${PROJECT_BINARY_DIR}/out/inc/${_header_path}" COPYONLY)
 endforeach()
 
-set(IXX_FILES
+set(MODULE_FILES
+    ${CMAKE_CURRENT_LIST_DIR}/modules/modules.json
     ${CMAKE_CURRENT_LIST_DIR}/modules/std.ixx
     ${CMAKE_CURRENT_LIST_DIR}/modules/std.compat.ixx
 )
 
-foreach(ixx_file ${IXX_FILES})
-    file(RELATIVE_PATH _ixx_file_path "${CMAKE_CURRENT_LIST_DIR}/modules" "${ixx_file}")
-    configure_file("${ixx_file}" "${PROJECT_BINARY_DIR}/out/modules/${_ixx_file_path}" COPYONLY)
+foreach(module_file ${MODULE_FILES})
+    file(RELATIVE_PATH _module_file_path "${CMAKE_CURRENT_LIST_DIR}/modules" "${module_file}")
+    configure_file("${module_file}" "${PROJECT_BINARY_DIR}/out/modules/${_module_file_path}" COPYONLY)
 endforeach()
 
 # Objs that implement aliases; these are completely independent of the configuration

--- a/stl/modules/modules.json
+++ b/stl/modules/modules.json
@@ -1,0 +1,14 @@
+{
+    "version": 1,
+    "revision": 0,
+    "library": "microsoft/STL",
+    "modules": {
+        "std": {
+            "source": "std.ixx"
+        },
+        "std.compat": {
+            "source": "std.compat.ixx",
+            "requires": ["std"]
+        }
+    }
+}


### PR DESCRIPTION
This is a reverse mirror of MSVC-PR-445938. The goal is for the MSVC toolset to communicate to the IDE, MSBuild, and CMake where the Standard Library Modules are located, and the simple dependency relationship between them, so that `import std;` can automatically work with as little user effort as possible. (There will be more changes in the MSVC and VS repos to add properties and environment variables to communicate where this file is located.)

`modules.json` is JSON without comments, because multiple tools will need to read this file, and some might not support JSON-with-comments. (Accordingly, it lacks our usual banners.)

I've verified that `modules.json` is copied to the output directory (e.g. to `D:\GitHub\STL\out\x64\out\modules\modules.json`).