### PR TITLE
sizeof(value_type)>0 itself is wrong

### DIFF
--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -947,7 +947,6 @@ public:
     }
 
     _NODISCARD_RAW_PTR_ALLOC _CONSTEXPR20 __declspec(allocator) _Ty* allocate(_CRT_GUARDOVERFLOW const size_t _Count) {
-        static_assert(sizeof(value_type) > 0, "value_type must be complete before calling allocate.");
         return static_cast<_Ty*>(_Allocate<_New_alignof<_Ty>>(_Get_size_of_n<sizeof(_Ty)>(_Count)));
     }
 


### PR DESCRIPTION
I think `sizeof(value_type)>0` itself is wrong. If it is an incomplete type, sizeof operation just failed in compile time, not static_assert. And I don't realize any type which sizeof(it) is equal zero, even if it is an empty struct or void type, sizeof(it) equals 1.

So, this static_assert line is wrong and contains misleading message.  

<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
