### PR TITLE
`<algorithm>`: `ranges::minmax` should dereference iterators only once

### DIFF
--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -10105,7 +10105,7 @@ namespace ranges {
                 // Avoid repeatedly initializing objects from the result of an iterator dereference when doing so might
                 // not be idempotent. The `if constexpr` to avoid the extra branch in cases where it's not needed
                 if constexpr (!same_as<remove_cvref_t<range_reference_t<_Rng>>, _Vty>
-                              || !is_lvalue_reference_v<range_reference_t<_Rng>>) {
+                              || is_rvalue_reference_v<range_reference_t<_Rng>>) {
                     if (_Found.min == _Found.max) {
                         // This initialization is correct, similar to WG21-N4928 [dcl.init.aggr]/6 example
                         minmax_result<_Vty> _Result = {static_cast<_Vty>(*_Found.min), _Result.min};

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -10104,12 +10104,12 @@ namespace ranges {
                     _STD move(_UFirst), _STD move(_ULast), _Pass_fn(_Pred), _Pass_fn(_Proj));
                 if (_Found.min == _Found.max) {
                     _Vty _Temp{*_Found.min};
-                    return {_Temp, _Temp};
+                    return {_Temp, _STD move(_Temp)};
                 }
                 return {static_cast<_Vty>(*_Found.min), static_cast<_Vty>(*_Found.max)};
             } else {
                 _Vty _Temp{*_UFirst};
-                minmax_result<_Vty> _Found = {_Temp, _Temp};
+                minmax_result<_Vty> _Found = {_Temp, _STD move(_Temp)};
                 if (_UFirst == _ULast) {
                     return _Found;
                 }

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -10102,6 +10102,9 @@ namespace ranges {
             if constexpr (forward_range<_Rng> && _Prefer_iterator_copies<iterator_t<_Rng>>) {
                 const auto _Found = _RANGES _Minmax_element_unchecked(
                     _STD move(_UFirst), _STD move(_ULast), _Pass_fn(_Pred), _Pass_fn(_Proj));
+                // We can dereference normal pointers many times but some iterators could move their value after
+                // dereferencing so we should dereference them only once. The if constexpr is a pure optimization, we
+                // don't want an additional branch for normal pointers.
                 if constexpr (!is_pointer_v<iterator_t<_Rng>>) {
                     if (_Found.min == _Found.max) {
                         auto _Temp = static_cast<_Vty>(*_Found.min);

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -10102,13 +10102,15 @@ namespace ranges {
             if constexpr (forward_range<_Rng> && _Prefer_iterator_copies<iterator_t<_Rng>>) {
                 const auto _Found = _RANGES _Minmax_element_unchecked(
                     _STD move(_UFirst), _STD move(_ULast), _Pass_fn(_Pred), _Pass_fn(_Proj));
-                if (_Found.min == _Found.max) {
-                    _Vty _Temp{*_Found.min};
-                    return {_Temp, _STD move(_Temp)};
+                if constexpr (!is_pointer_v<iterator_t<_Rng>>) {
+                    if (_Found.min == _Found.max) {
+                        auto _Temp = static_cast<_Vty>(*_Found.min);
+                        return {_Temp, _STD move(_Temp)};
+                    }
                 }
                 return {static_cast<_Vty>(*_Found.min), static_cast<_Vty>(*_Found.max)};
             } else {
-                _Vty _Temp{*_UFirst};
+                auto _Temp                 = static_cast<_Vty>(*_UFirst);
                 minmax_result<_Vty> _Found = {_Temp, _STD move(_Temp)};
                 if (_UFirst == _ULast) {
                     return _Found;

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -10102,16 +10102,19 @@ namespace ranges {
             if constexpr (forward_range<_Rng> && _Prefer_iterator_copies<iterator_t<_Rng>>) {
                 const auto _Found = _RANGES _Minmax_element_unchecked(
                     _STD move(_UFirst), _STD move(_ULast), _Pass_fn(_Pred), _Pass_fn(_Proj));
-                // We need to detect move_iterators (and similar types) to avoid dereferencing them more than once.
-                // The `if constexpr` is a pure optimization; we don't want an additional branch for normal iterators.
-                if constexpr (!is_lvalue_reference_v<range_reference_t<_Rng>>) {
+                // Avoid repeatedly initializing objects from the result of an iterator dereference when doing so might
+                // not be idempotent. The `if constexpr` to avoid the extra branch in cases where it's not needed
+                if constexpr (same_as<remove_cvref_t<range_reference_t<_Rng>>, _Vty>
+                              && !is_lvalue_reference_v<range_reference_t<_Rng>>) {
                     if (_Found.min == _Found.max) {
+                        // This initialization is correct, similar to WG21-N4928 [dcl.init.aggr]/6 example
                         minmax_result<_Vty> _Result = {static_cast<_Vty>(*_Found.min), _Result.min};
                         return _Result;
                     }
                 }
                 return {static_cast<_Vty>(*_Found.min), static_cast<_Vty>(*_Found.max)};
             } else {
+                // This initialization is correct, similar to WG21-N4928 [dcl.init.aggr]/6 example
                 minmax_result<_Vty> _Found = {static_cast<_Vty>(*_UFirst), _Found.min};
                 if (_UFirst == _ULast) {
                     return _Found;

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -10102,9 +10102,8 @@ namespace ranges {
             if constexpr (forward_range<_Rng> && _Prefer_iterator_copies<iterator_t<_Rng>>) {
                 const auto _Found = _RANGES _Minmax_element_unchecked(
                     _STD move(_UFirst), _STD move(_ULast), _Pass_fn(_Pred), _Pass_fn(_Proj));
-                // Some iterators could move their value after dereferencing so we should dereference them only once.
-                // The `if constexpr` is a pure optimization;
-                // we don't want an additional branch if iterators dereference return lvalue reference.
+                // We need to detect move_iterators (and similar types) to avoid dereferencing them more than once.
+                // The `if constexpr` is a pure optimization; we don't want an additional branch for normal iterators.
                 if constexpr (!is_lvalue_reference_v<range_reference_t<_Rng>>) {
                     if (_Found.min == _Found.max) {
                         minmax_result<_Vty> _Result = {static_cast<_Vty>(*_Found.min), _Result.min};

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -10102,10 +10102,10 @@ namespace ranges {
             if constexpr (forward_range<_Rng> && _Prefer_iterator_copies<iterator_t<_Rng>>) {
                 const auto _Found = _RANGES _Minmax_element_unchecked(
                     _STD move(_UFirst), _STD move(_ULast), _Pass_fn(_Pred), _Pass_fn(_Proj));
-                // We can dereference normal pointers many times but some iterators could move their value after
-                // dereferencing so we should dereference them only once. The `if constexpr` is a pure optimization;
-                // we don't want an additional branch for normal pointers.
-                if constexpr (!is_pointer_v<iterator_t<_Rng>>) {
+                // Some iterators could move their value after dereferencing so we should dereference them only once.
+                // The `if constexpr` is a pure optimization;
+                // we don't want an additional branch if iterators dereference return lvalue reference.
+                if constexpr (!is_lvalue_reference_v<reference_t<_Rng>>) {
                     if (_Found.min == _Found.max) {
                         minmax_result<_Vty> _Result = {static_cast<_Vty>(*_Found.min), _Result.min};
                         return _Result;

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -10102,9 +10102,14 @@ namespace ranges {
             if constexpr (forward_range<_Rng> && _Prefer_iterator_copies<iterator_t<_Rng>>) {
                 const auto _Found = _RANGES _Minmax_element_unchecked(
                     _STD move(_UFirst), _STD move(_ULast), _Pass_fn(_Pred), _Pass_fn(_Proj));
+                if (_Found.min == _Found.max) {
+                    _Vty _Temp{*_Found.min};
+                    return {_Temp, _Temp};
+                }
                 return {static_cast<_Vty>(*_Found.min), static_cast<_Vty>(*_Found.max)};
             } else {
-                minmax_result<_Vty> _Found = {static_cast<_Vty>(*_UFirst), static_cast<_Vty>(*_UFirst)};
+                _Vty _Temp{*_UFirst};
+                minmax_result<_Vty> _Found = {_Temp, _Temp};
                 if (_UFirst == _ULast) {
                     return _Found;
                 }

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -10107,14 +10107,13 @@ namespace ranges {
                 // we don't want an additional branch for normal pointers.
                 if constexpr (!is_pointer_v<iterator_t<_Rng>>) {
                     if (_Found.min == _Found.max) {
-                        auto _Temp = static_cast<_Vty>(*_Found.min);
-                        return {_Temp, _STD move(_Temp)};
+                        minmax_result<_Vty> _Result = {static_cast<_Vty>(*_Found.min), _Result.min};
+                        return _Result;
                     }
                 }
                 return {static_cast<_Vty>(*_Found.min), static_cast<_Vty>(*_Found.max)};
             } else {
-                auto _Temp                 = static_cast<_Vty>(*_UFirst);
-                minmax_result<_Vty> _Found = {_Temp, _STD move(_Temp)};
+                minmax_result<_Vty> _Found = {static_cast<_Vty>(*_UFirst), _Found.min};
                 if (_UFirst == _ULast) {
                     return _Found;
                 }

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -10104,8 +10104,8 @@ namespace ranges {
                     _STD move(_UFirst), _STD move(_ULast), _Pass_fn(_Pred), _Pass_fn(_Proj));
                 // Avoid repeatedly initializing objects from the result of an iterator dereference when doing so might
                 // not be idempotent. The `if constexpr` to avoid the extra branch in cases where it's not needed
-                if constexpr (same_as<remove_cvref_t<range_reference_t<_Rng>>, _Vty>
-                              && !is_lvalue_reference_v<range_reference_t<_Rng>>) {
+                if constexpr (!same_as<remove_cvref_t<range_reference_t<_Rng>>, _Vty>
+                              || !is_lvalue_reference_v<range_reference_t<_Rng>>) {
                     if (_Found.min == _Found.max) {
                         // This initialization is correct, similar to WG21-N4928 [dcl.init.aggr]/6 example
                         minmax_result<_Vty> _Result = {static_cast<_Vty>(*_Found.min), _Result.min};

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -10105,7 +10105,7 @@ namespace ranges {
                 // Some iterators could move their value after dereferencing so we should dereference them only once.
                 // The `if constexpr` is a pure optimization;
                 // we don't want an additional branch if iterators dereference return lvalue reference.
-                if constexpr (!is_lvalue_reference_v<reference_t<_Rng>>) {
+                if constexpr (!is_lvalue_reference_v<range_reference_t<_Rng>>) {
                     if (_Found.min == _Found.max) {
                         minmax_result<_Vty> _Result = {static_cast<_Vty>(*_Found.min), _Result.min};
                         return _Result;

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -10103,18 +10103,18 @@ namespace ranges {
                 const auto _Found = _RANGES _Minmax_element_unchecked(
                     _STD move(_UFirst), _STD move(_ULast), _Pass_fn(_Pred), _Pass_fn(_Proj));
                 // Avoid repeatedly initializing objects from the result of an iterator dereference when doing so might
-                // not be idempotent. The `if constexpr` to avoid the extra branch in cases where it's not needed
+                // not be idempotent. The `if constexpr` avoids the extra branch in cases where it's not needed.
                 if constexpr (!same_as<remove_cvref_t<range_reference_t<_Rng>>, _Vty>
                               || is_rvalue_reference_v<range_reference_t<_Rng>>) {
                     if (_Found.min == _Found.max) {
-                        // This initialization is correct, similar to WG21-N4928 [dcl.init.aggr]/6 example
+                        // This initialization is correct, similar to the N4928 [dcl.init.aggr]/6 example
                         minmax_result<_Vty> _Result = {static_cast<_Vty>(*_Found.min), _Result.min};
                         return _Result;
                     }
                 }
                 return {static_cast<_Vty>(*_Found.min), static_cast<_Vty>(*_Found.max)};
             } else {
-                // This initialization is correct, similar to WG21-N4928 [dcl.init.aggr]/6 example
+                // This initialization is correct, similar to the N4928 [dcl.init.aggr]/6 example
                 minmax_result<_Vty> _Found = {static_cast<_Vty>(*_UFirst), _Found.min};
                 if (_UFirst == _ULast) {
                     return _Found;

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -10103,8 +10103,8 @@ namespace ranges {
                 const auto _Found = _RANGES _Minmax_element_unchecked(
                     _STD move(_UFirst), _STD move(_ULast), _Pass_fn(_Pred), _Pass_fn(_Proj));
                 // We can dereference normal pointers many times but some iterators could move their value after
-                // dereferencing so we should dereference them only once. The if constexpr is a pure optimization, we
-                // don't want an additional branch for normal pointers.
+                // dereferencing so we should dereference them only once. The `if constexpr` is a pure optimization;
+                // we don't want an additional branch for normal pointers.
                 if constexpr (!is_pointer_v<iterator_t<_Rng>>) {
                     if (_Found.min == _Found.max) {
                         auto _Temp = static_cast<_Vty>(*_Found.min);

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -908,7 +908,6 @@ std/algorithms/alg.sorting/alg.heap.operations/push.heap/ranges_push_heap.pass.c
 std/algorithms/alg.sorting/alg.heap.operations/sort.heap/ranges_sort_heap.pass.cpp FAIL
 std/algorithms/alg.sorting/alg.merge/ranges_inplace_merge.pass.cpp FAIL
 std/algorithms/alg.sorting/alg.merge/ranges_merge.pass.cpp FAIL
-std/algorithms/alg.sorting/alg.min.max/ranges.minmax.pass.cpp FAIL
 std/algorithms/alg.sorting/alg.min.max/requires_forward_iterator.fail.cpp FAIL
 std/algorithms/alg.sorting/alg.nth.element/ranges_nth_element.pass.cpp FAIL
 std/algorithms/alg.sorting/alg.partitions/ranges.is_partitioned.pass.cpp:0 FAIL

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -908,7 +908,6 @@ algorithms\alg.sorting\alg.heap.operations\push.heap\ranges_push_heap.pass.cpp
 algorithms\alg.sorting\alg.heap.operations\sort.heap\ranges_sort_heap.pass.cpp
 algorithms\alg.sorting\alg.merge\ranges_inplace_merge.pass.cpp
 algorithms\alg.sorting\alg.merge\ranges_merge.pass.cpp
-algorithms\alg.sorting\alg.min.max\ranges.minmax.pass.cpp
 algorithms\alg.sorting\alg.min.max\requires_forward_iterator.fail.cpp
 algorithms\alg.sorting\alg.nth.element\ranges_nth_element.pass.cpp
 algorithms\alg.sorting\alg.partitions\ranges.is_partitioned.pass.cpp

--- a/tests/std/tests/P0896R4_ranges_alg_minmax/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_minmax/test.cpp
@@ -392,7 +392,7 @@ public:
         return tmp;
     }
 
-    friend bool operator==(const input_move_iterator& a, const input_move_iterator& b) = default;
+    friend bool operator==(const input_move_iterator&, const input_move_iterator&) = default;
 
 private:
     shared_ptr<int>* m_ptr{nullptr};

--- a/tests/std/tests/P0896R4_ranges_alg_minmax/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_minmax/test.cpp
@@ -13,6 +13,7 @@
 #include <span>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include <range_algorithm_support.hpp>
 
@@ -364,10 +365,11 @@ void test_gh_1893() {
 void test_gh_2900() {
     // GH-2900: <algorithm>: ranges::minmax initializes minmax_result with the moved value
     {
-        vector<string> v{"1"};
-        auto [min, max] = ranges::minmax(ranges::subrange{make_move_iterator(v.begin()), make_move_iterator(v.end())});
-        assert(min == "1");
-        assert(max == "1");
+        const string str{"this long string will be dynamically allocated"};
+        vector<string> v{str};
+        auto result = ranges::minmax(ranges::subrange{move_iterator{v.begin()}, move_iterator{v.end()}});
+        assert(result.min == str);
+        assert(result.max == str);
     }
 }
 

--- a/tests/std/tests/P0896R4_ranges_alg_minmax/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_minmax/test.cpp
@@ -392,9 +392,7 @@ public:
         return tmp;
     }
 
-    friend bool operator==(const input_move_iterator& a, const input_move_iterator& b) {
-        return a.m_ptr == b.m_ptr;
-    }
+    friend bool operator==(const input_move_iterator& a, const input_move_iterator& b) = default;
 
 private:
     shared_ptr<int>* m_ptr{nullptr};

--- a/tests/std/tests/P0896R4_ranges_alg_minmax/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_minmax/test.cpp
@@ -373,51 +373,49 @@ public:
     using reference         = shared_ptr<int>&&;
 
     input_move_iterator() = default;
-    input_move_iterator(shared_ptr<int>* ptr) : m_ptr(ptr) {}
+    explicit input_move_iterator(shared_ptr<int>* ptr) : m_ptr(ptr) {}
 
     reference operator*() const {
         return ranges::iter_move(m_ptr);
     }
-    pointer operator->() {
+    pointer operator->() const {
         return m_ptr;
     }
 
     input_move_iterator& operator++() {
-        m_ptr++;
+        ++m_ptr;
         return *this;
     }
     input_move_iterator operator++(int) {
         input_move_iterator tmp = *this;
-        ++(*this);
+        ++*this;
         return tmp;
     }
 
     friend bool operator==(const input_move_iterator& a, const input_move_iterator& b) {
         return a.m_ptr == b.m_ptr;
-    };
-    friend bool operator!=(const input_move_iterator& a, const input_move_iterator& b) {
-        return a.m_ptr != b.m_ptr;
-    };
+    }
 
 private:
-    shared_ptr<int>* m_ptr;
+    shared_ptr<int>* m_ptr{nullptr};
 };
 
 void test_gh_2900() {
     // GH-2900: <algorithm>: ranges::minmax initializes minmax_result with the moved value
     {
-        // check that the range access iterator isn't moved from multiple times
+        // check that the random access iterator isn't moved from multiple times
         const string str{"this long string will be dynamically allocated"};
         vector<string> v{str};
-        auto result = ranges::minmax(ranges::subrange{move_iterator{v.begin()}, move_iterator{v.end()}});
+        ranges::subrange rng{move_iterator{v.begin()}, move_iterator{v.end()}};
+        auto result = ranges::minmax(rng);
         assert(result.min == str);
         assert(result.max == str);
     }
     {
         // check that the input iterator isn't moved from multiple times
         shared_ptr<int> a[] = {make_shared<int>(42)};
-        auto range          = ranges::subrange(input_move_iterator(a), input_move_iterator(a + 1));
-        auto result         = ranges::minmax(range);
+        ranges::subrange rng{input_move_iterator{a}, input_move_iterator{a + 1}};
+        auto result = ranges::minmax(rng);
         assert(a[0] == nullptr);
         assert(result.min != nullptr);
         assert(result.max == result.min);

--- a/tests/std/tests/P0896R4_ranges_alg_minmax/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_minmax/test.cpp
@@ -361,6 +361,16 @@ void test_gh_1893() {
     ASSERT(val == "meow");
 }
 
+void test_gh_2900() {
+    // GH-2900: <algorithm>: ranges::minmax initializes minmax_result with the moved value
+    {
+        vector<string> v{"1"};
+        auto [min, max] = ranges::minmax(ranges::subrange{make_move_iterator(v.begin()), make_move_iterator(v.end())});
+        assert(min == "1");
+        assert(max == "1");
+    }
+}
+
 int main() {
     STATIC_ASSERT((nonrange_tests(), true));
     nonrange_tests();
@@ -378,4 +388,5 @@ int main() {
     test_in<mm, const P>();
 
     test_gh_1893();
+    test_gh_2900();
 }

--- a/tests/std/tests/P0896R4_ranges_alg_minmax/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_minmax/test.cpp
@@ -9,6 +9,7 @@
 #include <cassert>
 #include <concepts>
 #include <functional>
+#include <memory>
 #include <ranges>
 #include <span>
 #include <string>
@@ -362,14 +363,65 @@ void test_gh_1893() {
     ASSERT(val == "meow");
 }
 
+class input_move_iterator {
+public:
+    using iterator_category = input_iterator_tag;
+    using iterator_concept  = input_iterator_tag;
+    using difference_type   = ptrdiff_t;
+    using value_type        = shared_ptr<int>;
+    using pointer           = shared_ptr<int>*;
+    using reference         = shared_ptr<int>&&;
+
+    input_move_iterator() = default;
+    input_move_iterator(shared_ptr<int>* ptr) : m_ptr(ptr) {}
+
+    reference operator*() const {
+        return ranges::iter_move(m_ptr);
+    }
+    pointer operator->() {
+        return m_ptr;
+    }
+
+    input_move_iterator& operator++() {
+        m_ptr++;
+        return *this;
+    }
+    input_move_iterator operator++(int) {
+        input_move_iterator tmp = *this;
+        ++(*this);
+        return tmp;
+    }
+
+    friend bool operator==(const input_move_iterator& a, const input_move_iterator& b) {
+        return a.m_ptr == b.m_ptr;
+    };
+    friend bool operator!=(const input_move_iterator& a, const input_move_iterator& b) {
+        return a.m_ptr != b.m_ptr;
+    };
+
+private:
+    shared_ptr<int>* m_ptr;
+};
+
 void test_gh_2900() {
     // GH-2900: <algorithm>: ranges::minmax initializes minmax_result with the moved value
     {
+        // check that the range access iterator isn't moved from multiple times
         const string str{"this long string will be dynamically allocated"};
         vector<string> v{str};
         auto result = ranges::minmax(ranges::subrange{move_iterator{v.begin()}, move_iterator{v.end()}});
         assert(result.min == str);
         assert(result.max == str);
+    }
+    {
+        // check that the input iterator isn't moved from multiple times
+        shared_ptr<int> a[] = {make_shared<int>(42)};
+        auto range          = ranges::subrange(input_move_iterator(a), input_move_iterator(a + 1));
+        auto result         = ranges::minmax(range);
+        assert(a[0] == nullptr);
+        assert(result.min != nullptr);
+        assert(result.max == result.min);
+        assert(*result.max == 42);
     }
 }
 


### PR DESCRIPTION
Fixes #2900 

After https://github.com/microsoft/STL/pull/2958 the original repro works, but the issue still exists.

I also found that if we have only one element we also have the issue.