### PR TITLE
Minor modules modifications

### DIFF
--- a/stl/inc/ctime
+++ b/stl/inc/ctime
@@ -30,46 +30,46 @@ _EXPORT_STD using _CSTD strftime;
 _EXPORT_STD using _CSTD timespec;
 #endif // _HAS_CXX17
 
-#if _HAS_CXX23 && defined(_BUILD_STD_MODULE) // TRANSITION, DevCom-1126857
+#if _HAS_CXX23 && defined(_BUILD_STD_MODULE) // TRANSITION, OS-33790456
 _STL_DISABLE_DEPRECATED_WARNING
 
-// These workaround functions intentionally aren't inline.
 _EXPORT_STD
-_Check_return_ _CRT_INSECURE_DEPRECATE(ctime_s)
-char* __CRTDECL ctime(_In_ const time_t* const _Time) noexcept /* strengthened */ {
+_Check_return_ _CRT_INSECURE_DEPRECATE(ctime_s) inline char* __CRTDECL ctime(_In_ const time_t* const _Time) noexcept
+/* strengthened */ {
     return _CSTD _ctime64(_Time);
 }
 
 _EXPORT_STD
-_Check_return_ double __CRTDECL difftime(_In_ const time_t _Time1, _In_ const time_t _Time2) noexcept
+_Check_return_ inline double __CRTDECL difftime(_In_ const time_t _Time1, _In_ const time_t _Time2) noexcept
 /* strengthened */ {
     return _CSTD _difftime64(_Time1, _Time2);
 }
 
 _EXPORT_STD
-_Check_return_ _CRT_INSECURE_DEPRECATE(gmtime_s)
-tm* __CRTDECL gmtime(_In_ const time_t* const _Time) noexcept /* strengthened */ {
+_Check_return_ _CRT_INSECURE_DEPRECATE(gmtime_s) inline tm* __CRTDECL gmtime(_In_ const time_t* const _Time) noexcept
+/* strengthened */ {
     return _CSTD _gmtime64(_Time);
 }
 
 _EXPORT_STD
 _CRT_INSECURE_DEPRECATE(localtime_s)
-tm* __CRTDECL localtime(_In_ const time_t* const _Time) noexcept /* strengthened */ {
+inline tm* __CRTDECL localtime(_In_ const time_t* const _Time) noexcept /* strengthened */ {
     return _CSTD _localtime64(_Time);
 }
 
 _EXPORT_STD
-_Check_return_opt_ time_t __CRTDECL mktime(_Inout_ tm* const _Tm) noexcept /* strengthened */ {
+_Check_return_opt_ inline time_t __CRTDECL mktime(_Inout_ tm* const _Tm) noexcept /* strengthened */ {
     return _CSTD _mktime64(_Tm);
 }
 
 _EXPORT_STD
-time_t __CRTDECL time(_Out_opt_ time_t* const _Time) noexcept /* strengthened */ {
+inline time_t __CRTDECL time(_Out_opt_ time_t* const _Time) noexcept /* strengthened */ {
     return _CSTD _time64(_Time);
 }
 
 _EXPORT_STD
-_Check_return_ int __CRTDECL timespec_get(_Out_ timespec* const _Ts, _In_ const int _Base) noexcept /* strengthened */ {
+_Check_return_ inline int __CRTDECL timespec_get(_Out_ timespec* const _Ts, _In_ const int _Base) noexcept
+/* strengthened */ {
     return _CSTD _timespec64_get(reinterpret_cast<_timespec64*>(_Ts), _Base);
 }
 

--- a/stl/modules/std.ixx
+++ b/stl/modules/std.ixx
@@ -1,10 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// In a module-file, the optional `module;` must appear first; see [cpp.pre].
+module;
+
 // This named module expects to be built with classic headers, not header units.
 #define _BUILD_STD_MODULE
-
-module;
 
 // The subset of "C headers" [tab:c.headers] corresponding to
 // the "C++ headers for C library facilities" [tab:headers.cpp.c]


### PR DESCRIPTION
* Technically a bugfix: `module;` must appear first, although MSVC doesn't enforce this rule yet.

* Mark `<ctime>` workarounds as `inline`. This isn't necessary, but was recommended by @cdacamar.

* Update citation: DevCom-1126857 was "closed as lower priority" but OS-33790456 "`static inline` functions cannot be called when using modules" remains active.