### PR TITLE
`<system_error>`: Use uglified `[[clang::require_constant_initialization]]` attribute

### DIFF
--- a/stl/inc/system_error
+++ b/stl/inc/system_error
@@ -643,7 +643,7 @@ _NODISCARD const _Ty& _Immortalize_memcpy_image() noexcept {
 #elif defined(__clang__)
 template <class _Ty>
 _NODISCARD const _Ty& _Immortalize_memcpy_image() noexcept {
-    [[clang::require_constant_initialization]] static _Ty _Static;
+    [[_Clang::__require_constant_initialization__]] static _Ty _Static;
     return _Static;
 }
 #elif !defined(_M_CEE) // TRANSITION, VSO-1153256


### PR DESCRIPTION
Currently `<system_error>` header uses non-reserved identifiers `clang` and `require_constant_initialization` which is incorrect (see #2645):

```console
PS D:\stl-playground> type .\clang_rci.cpp
// Non-reserved identifiers
#define clang
#define require_constant_initialization

#include <system_error> // Whoops!
PS D:\stl-playground> clang .\clang_rci.cpp
In file included from .\clang_rci.cpp:5:
D:\stl\out\build\x64\out\inc\system_error:646:7: error: expected ']'
    [[clang::require_constant_initialization]] static _Ty _Static;
      ^
1 error generated.
```

This PR simply uglifies this attribute.