### PR TITLE
Assign new pull requests to Code Review

### DIFF
--- a/.github/workflows/assign-new-prs.yml
+++ b/.github/workflows/assign-new-prs.yml
@@ -11,12 +11,23 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
-  add-new-prs-to-code-review:
+  initial-review:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
-    name: Assign New PR To Code Reviews
+    name: Initial Review
     steps:
     - name: Assign the New Pull Request
       uses: srggrs/assign-one-project-github-action@1.2.1
       with:
         project: 'https://github.com/microsoft/STL/projects/1'
         column_name: 'Initial Review'
+  work-in-progress:
+    if: github.event.pull_request.draft == true
+    runs-on: ubuntu-latest
+    name: Work In Progress
+    steps:
+    - name: Assign the New Pull Request
+      uses: srggrs/assign-one-project-github-action@1.2.1
+      with:
+        project: 'https://github.com/microsoft/STL/projects/1'
+        column_name: 'Work In Progress'

--- a/.github/workflows/assign-new-prs.yml
+++ b/.github/workflows/assign-new-prs.yml
@@ -17,7 +17,7 @@ jobs:
     name: Initial Review
     steps:
     - name: Assign the New Pull Request
-      uses: srggrs/assign-one-project-github-action@1.2.1
+      uses: srggrs/assign-one-project-github-action@1.3.1
       with:
         project: 'https://github.com/microsoft/STL/projects/1'
         column_name: 'Initial Review'
@@ -27,7 +27,7 @@ jobs:
     name: Work In Progress
     steps:
     - name: Assign the New Pull Request
-      uses: srggrs/assign-one-project-github-action@1.2.1
+      uses: srggrs/assign-one-project-github-action@1.3.1
       with:
         project: 'https://github.com/microsoft/STL/projects/1'
         column_name: 'Work In Progress'

--- a/.github/workflows/assign-new-prs.yml
+++ b/.github/workflows/assign-new-prs.yml
@@ -3,7 +3,7 @@
 
 name: Assign New PR
 on:
-  pull_request:
+  pull_request_target:
     types: [opened]
     branch:
       - main

--- a/.github/workflows/assign-new-prs.yml
+++ b/.github/workflows/assign-new-prs.yml
@@ -1,0 +1,22 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+name: Assign New PR
+on:
+  pull_request:
+    types: [opened]
+    branch:
+      - main
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  add-new-prs-to-code-review:
+    runs-on: ubuntu-latest
+    name: Assign New PR To Code Reviews
+    steps:
+    - name: Assign the New Pull Request
+      uses: srggrs/assign-one-project-github-action@1.2.1
+      with:
+        project: 'https://github.com/microsoft/STL/projects/1'
+        column_name: 'Initial Review'


### PR DESCRIPTION
Add a workflow to automatically assign a newly opened pull request to "Code Reviews" project.

This problem arose from https://github.com/microsoft/STL/pull/3390, where the `/pr` commands were used without the pull request being in the project.

Tested with https://github.com/sam20908/STL-PR-Workflow/pull/5.