### PR TITLE
Unmention DevCom-10111923 in test `P0088R3_variant`

### DIFF
--- a/tests/std/tests/P0088R3_variant/test.cpp
+++ b/tests/std/tests/P0088R3_variant/test.cpp
@@ -7673,8 +7673,10 @@ namespace msvc {
                 };
 
                 using VarTestConv = std::variant<convertible_to_immobile_one, convertible_to_immobile_other>;
+#if defined(__clang__) || defined(__EDG__) // TRANSITION, DevCom-10112408
                 assert(std::visit<R>(std::identity{}, VarTestConv{convertible_to_immobile_one{}}).x == 1729);
                 assert(std::visit<R>(std::identity{}, VarTestConv{convertible_to_immobile_other{}}).x == 1138);
+#endif // TRANSITION, DevCom-10112408
                 auto immobile_converter = [](auto src) -> immobile_data { return src; };
                 assert(std::visit<R>(immobile_converter, VarTestConv{convertible_to_immobile_one{}}).x == 1729);
                 assert(std::visit<R>(immobile_converter, VarTestConv{convertible_to_immobile_other{}}).x == 1138);

--- a/tests/std/tests/P0088R3_variant/test.cpp
+++ b/tests/std/tests/P0088R3_variant/test.cpp
@@ -7673,10 +7673,8 @@ namespace msvc {
                 };
 
                 using VarTestConv = std::variant<convertible_to_immobile_one, convertible_to_immobile_other>;
-#if defined(__clang__) || defined(__EDG__) // TRANSITION, DevCom-10111923 and DevCom-10112408
                 assert(std::visit<R>(std::identity{}, VarTestConv{convertible_to_immobile_one{}}).x == 1729);
                 assert(std::visit<R>(std::identity{}, VarTestConv{convertible_to_immobile_other{}}).x == 1138);
-#endif // TRANSITION, DevCom-10111923 and DevCom-10112408
                 auto immobile_converter = [](auto src) -> immobile_data { return src; };
                 assert(std::visit<R>(immobile_converter, VarTestConv{convertible_to_immobile_one{}}).x == 1729);
                 assert(std::visit<R>(immobile_converter, VarTestConv{convertible_to_immobile_other{}}).x == 1138);


### PR DESCRIPTION
DevCom-10111923 and DevCom-10112408 (mistakenly treated as duplicate of the former) are reported as fixed in 17.4. I've tried to test the relative cases (added in #2971), but the tests still failed.

With some local tests, I'm sure that DevCom-10111923 is fixed in 17.4, but DevCom-10112408 is still not fixed (the posted example still fails to compile).