### PR TITLE
`stl/CMakeLists.txt`: Fix `add_compile_options()` ordering

### DIFF
--- a/stl/CMakeLists.txt
+++ b/stl/CMakeLists.txt
@@ -1,6 +1,10 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+##################################################
+# Lists of files. (We can also copy files here.) #
+##################################################
+
 set(HEADERS
     ${CMAKE_CURRENT_LIST_DIR}/inc/__msvc_all_public_headers.hpp
     ${CMAKE_CURRENT_LIST_DIR}/inc/__msvc_chrono.hpp
@@ -463,7 +467,9 @@ set(SATELLITE_DLL_SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/src/dllmain_satellite.cpp
 )
 
-add_compile_definitions(_CRTBLD _VCRT_ALLOW_INTERNALS _HAS_OLD_IOSTREAMS_MEMBERS=1 _STL_CONCRT_SUPPORT)
+####################
+# Toolset options. #
+####################
 
 set(CMAKE_CXX_FLAGS "")
 set(CMAKE_CXX_FLAGS_DEBUG "")
@@ -483,10 +489,22 @@ set(CMAKE_SHARED_LINKER_FLAGS "/DEBUG:FULL /WX /RELEASE /SUBSYSTEM:Console /NODE
 set(CMAKE_SHARED_LINKER_FLAGS_DEBUG "")
 set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "")
 
+add_compile_definitions(_CRTBLD _VCRT_ALLOW_INTERNALS _HAS_OLD_IOSTREAMS_MEMBERS=1 _STL_CONCRT_SUPPORT)
+
+add_compile_options(/WX /Gy
+    "$<$<COMPILE_LANGUAGE:CXX>:/diagnostics:caret;/W4;/w14265;/w15038;/fastfail;/guard:cf;/Z7;/Zp8;/std:c++latest;/permissive-;/Zc:threadSafeInit-;/Zl>"
+    # note that /Zi generates debug info inside the object file, it's the same as /Z7 for msvc
+    "$<$<COMPILE_LANGUAGE:ASM_MASM>:/Zi;/W3;/nologo>"
+)
+
 include_directories(BEFORE
     "${CMAKE_CURRENT_LIST_DIR}/inc"
     "${TOOLSET_ROOT_DIR}/crt/src/vcruntime"
 )
+
+####################################################################################################################
+# CMake is order-sensitive! add_compile_options() must appear before add_library() for the options to take effect. #
+####################################################################################################################
 
 if(VCLIBS_TARGET_ARCHITECTURE MATCHES "^(x86|x64)$")
     add_library(stl_alias_objects OBJECT ${ALIAS_SOURCES_X86_X64})
@@ -496,12 +514,6 @@ else()
     # on ARM64 and ARM, we can unconditionally expect Synchronization.lib to exist
     string(APPEND CMAKE_CXX_STANDARD_LIBRARIES " Synchronization.lib")
 endif()
-
-add_compile_options(/WX /Gy
-    "$<$<COMPILE_LANGUAGE:CXX>:/diagnostics:caret;/W4;/w14265;/w15038;/fastfail;/guard:cf;/Z7;/Zp8;/std:c++latest;/permissive-;/Zc:threadSafeInit-;/Zl>"
-    # note that /Zi generates debug info inside the object file, it's the same as /Z7 for msvc
-    "$<$<COMPILE_LANGUAGE:ASM_MASM>:/Zi;/W3;/nologo>"
-)
 
 function(target_stl_compile_options tgt rel_or_dbg)
     if(rel_or_dbg STREQUAL "Release")

--- a/stl/CMakeLists.txt
+++ b/stl/CMakeLists.txt
@@ -489,6 +489,7 @@ set(CMAKE_SHARED_LINKER_FLAGS "/DEBUG:FULL /WX /RELEASE /SUBSYSTEM:Console /NODE
 set(CMAKE_SHARED_LINKER_FLAGS_DEBUG "")
 set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "")
 
+# Toolset options must appear before add_library() for the options to take effect.
 add_compile_definitions(_CRTBLD _VCRT_ALLOW_INTERNALS _HAS_OLD_IOSTREAMS_MEMBERS=1 _STL_CONCRT_SUPPORT)
 
 add_compile_options(/WX /Gy
@@ -502,9 +503,9 @@ include_directories(BEFORE
     "${TOOLSET_ROOT_DIR}/crt/src/vcruntime"
 )
 
-####################################################################################################################
-# CMake is order-sensitive! add_compile_options() must appear before add_library() for the options to take effect. #
-####################################################################################################################
+###########################
+# End of toolset options. #
+###########################
 
 if(VCLIBS_TARGET_ARCHITECTURE MATCHES "^(x86|x64)$")
     add_library(stl_alias_objects OBJECT ${ALIAS_SOURCES_X86_X64})


### PR DESCRIPTION
Our `ASM_MASM` options were being ignored (!) because they appeared after `add_library()`. This was visible in the output because `/nologo` was missing, we just didn't notice. (See output below.) This regression happened in #2780.

To fix this and prevent any recurrence, I'm slightly reorganizing this file. First, I'm introducing 3 prominent box comments, dividing the file into clear sections. The actual fix is to move `add_compile_options()` up. Finally, I'm moving `add_compile_definitions()` down slightly, so that the compile definitions, compile options, and include directories are grouped together.

I've additionally verified the fix by looking at the verbose build output; our desired options are now being passed to MASM.

### Before
```
D:\GitHub\STL>ninja -C out\x64
ninja: Entering directory `out\x64'
[1/1014] Building ASM_MASM object stl\CMakeFiles\stl_alias_objects.dir\src\alias_init_once_begin_initialize.asm.obj
Microsoft (R) Macro Assembler (x64) Version 14.35.32213.0
Copyright (C) Microsoft Corporation.  All rights reserved.

 Assembling: D:\GitHub\STL\stl\src\alias_init_once_begin_initialize.asm
[2/1014] Building ASM_MASM object stl\CMakeFiles\stl_alias_objects.dir\src\alias_init_once_complete.asm.obj
Microsoft (R) Macro Assembler (x64) Version 14.35.32213.0
Copyright (C) Microsoft Corporation.  All rights reserved.

 Assembling: D:\GitHub\STL\stl\src\alias_init_once_complete.asm
[1014/1014] Linking CXX static library out\lib\amd64\libcpmtd0.lib
```

### After
```
D:\GitHub\STL>ninja -C out\x64
ninja: Entering directory `out\x64'
[1/1014] Building ASM_MASM object stl\CMakeFiles\stl_alias_objects.dir\src\alias_init_once_complete.asm.obj
 Assembling: D:\GitHub\STL\stl\src\alias_init_once_complete.asm
[2/1014] Building ASM_MASM object stl\CMakeFiles\stl_alias_objects.dir\src\alias_init_once_begin_initialize.asm.obj
 Assembling: D:\GitHub\STL\stl\src\alias_init_once_begin_initialize.asm
[1014/1014] Linking CXX static library out\lib\amd64\libcpmtd0.lib
```

### Note
I've implemented a `/quiet` option for MASM in VS 2022 17.7 Preview 1 that will allow the "Assembling" messages to be suppressed, making the output here ideal - that's how I discovered this.