### PR TITLE
`ios_base` constants should have bitmask types

### DIFF
--- a/stl/inc/xiosbase
+++ b/stl/inc/xiosbase
@@ -30,54 +30,54 @@ public:
     };
 
     // These variables should have type std::ios_base::fmtflags, TRANSITION, ABI
-    static constexpr _Fmtflags skipws     = static_cast<_Fmtflags>(0x0001);
-    static constexpr _Fmtflags unitbuf    = static_cast<_Fmtflags>(0x0002);
-    static constexpr _Fmtflags uppercase  = static_cast<_Fmtflags>(0x0004);
-    static constexpr _Fmtflags showbase   = static_cast<_Fmtflags>(0x0008);
-    static constexpr _Fmtflags showpoint  = static_cast<_Fmtflags>(0x0010);
-    static constexpr _Fmtflags showpos    = static_cast<_Fmtflags>(0x0020);
-    static constexpr _Fmtflags left       = static_cast<_Fmtflags>(0x0040);
-    static constexpr _Fmtflags right      = static_cast<_Fmtflags>(0x0080);
-    static constexpr _Fmtflags internal   = static_cast<_Fmtflags>(0x0100);
-    static constexpr _Fmtflags dec        = static_cast<_Fmtflags>(0x0200);
-    static constexpr _Fmtflags oct        = static_cast<_Fmtflags>(0x0400);
-    static constexpr _Fmtflags hex        = static_cast<_Fmtflags>(0x0800);
-    static constexpr _Fmtflags scientific = static_cast<_Fmtflags>(0x1000);
-    static constexpr _Fmtflags fixed      = static_cast<_Fmtflags>(0x2000);
+    static constexpr int skipws     = 0x0001;
+    static constexpr int unitbuf    = 0x0002;
+    static constexpr int uppercase  = 0x0004;
+    static constexpr int showbase   = 0x0008;
+    static constexpr int showpoint  = 0x0010;
+    static constexpr int showpos    = 0x0020;
+    static constexpr int left       = 0x0040;
+    static constexpr int right      = 0x0080;
+    static constexpr int internal   = 0x0100;
+    static constexpr int dec        = 0x0200;
+    static constexpr int oct        = 0x0400;
+    static constexpr int hex        = 0x0800;
+    static constexpr int scientific = 0x1000;
+    static constexpr int fixed      = 0x2000;
 
-    static constexpr _Fmtflags hexfloat = static_cast<_Fmtflags>(0x3000); // TRANSITION, ABI, GH-3296
+    static constexpr int hexfloat = 0x3000; // TRANSITION, ABI, GH-3296
 
-    static constexpr _Fmtflags boolalpha   = static_cast<_Fmtflags>(0x4000);
-    static constexpr _Fmtflags _Stdio      = static_cast<_Fmtflags>(0x8000);
-    static constexpr _Fmtflags adjustfield = static_cast<_Fmtflags>(0x01C0); // left | right | internal
-    static constexpr _Fmtflags basefield   = static_cast<_Fmtflags>(0x0E00); // dec | oct | hex
-    static constexpr _Fmtflags floatfield  = static_cast<_Fmtflags>(0x3000); // scientific | fixed
+    static constexpr int boolalpha   = 0x4000;
+    static constexpr int _Stdio      = 0x8000;
+    static constexpr int adjustfield = 0x01C0; // left | right | internal
+    static constexpr int basefield   = 0x0E00; // dec | oct | hex
+    static constexpr int floatfield  = 0x3000; // scientific | fixed
 
     enum _Iostate { // constants for stream states
         _Statmask = 0x17
     };
 
     // These variables should have type std::ios_base::iostate, TRANSITION, ABI
-    static constexpr _Iostate goodbit = static_cast<_Iostate>(0x0);
-    static constexpr _Iostate eofbit  = static_cast<_Iostate>(0x1);
-    static constexpr _Iostate failbit = static_cast<_Iostate>(0x2);
-    static constexpr _Iostate badbit  = static_cast<_Iostate>(0x4);
+    static constexpr int goodbit = 0x0;
+    static constexpr int eofbit  = 0x1;
+    static constexpr int failbit = 0x2;
+    static constexpr int badbit  = 0x4;
 
     enum _Openmode { // constants for file opening options
         _Openmask = 0xff
     };
 
     // These variables should have type std::ios_base::openmode, TRANSITION, ABI
-    static constexpr _Openmode in         = static_cast<_Openmode>(0x01);
-    static constexpr _Openmode out        = static_cast<_Openmode>(0x02);
-    static constexpr _Openmode ate        = static_cast<_Openmode>(0x04);
-    static constexpr _Openmode app        = static_cast<_Openmode>(0x08);
-    static constexpr _Openmode trunc      = static_cast<_Openmode>(0x10);
-    static constexpr _Openmode _Nocreate  = static_cast<_Openmode>(0x40);
-    static constexpr _Openmode _Noreplace = static_cast<_Openmode>(0x80);
-    static constexpr _Openmode binary     = static_cast<_Openmode>(0x20);
+    static constexpr int in         = 0x01;
+    static constexpr int out        = 0x02;
+    static constexpr int ate        = 0x04;
+    static constexpr int app        = 0x08;
+    static constexpr int trunc      = 0x10;
+    static constexpr int _Nocreate  = 0x40;
+    static constexpr int _Noreplace = 0x80;
+    static constexpr int binary     = 0x20;
 #if _HAS_CXX23
-    static constexpr _Openmode noreplace = _Noreplace;
+    static constexpr int noreplace = _Noreplace;
 #endif
 
     enum _Seekdir { // constants for file positioning options
@@ -87,9 +87,9 @@ public:
     };
 
     // These variables should have type std::ios_base::seekdir, TRANSITION, ABI
-    static constexpr _Seekdir beg = _Seekbeg;
-    static constexpr _Seekdir cur = _Seekcur;
-    static constexpr _Seekdir end = _Seekend;
+    static constexpr int beg = _Seekbeg;
+    static constexpr int cur = _Seekcur;
+    static constexpr int end = _Seekend;
 
     enum { // TRANSITION, ABI
         _Openprot = _SH_DENYNO

--- a/stl/inc/xiosbase
+++ b/stl/inc/xiosbase
@@ -29,7 +29,6 @@ public:
         _Fmtzero = 0
     };
 
-    // These variables should have type std::ios_base::fmtflags, TRANSITION, ABI
     static constexpr int skipws     = 0x0001;
     static constexpr int unitbuf    = 0x0002;
     static constexpr int uppercase  = 0x0004;
@@ -57,7 +56,6 @@ public:
         _Statmask = 0x17
     };
 
-    // These variables should have type std::ios_base::iostate, TRANSITION, ABI
     static constexpr int goodbit = 0x0;
     static constexpr int eofbit  = 0x1;
     static constexpr int failbit = 0x2;
@@ -67,7 +65,6 @@ public:
         _Openmask = 0xff
     };
 
-    // These variables should have type std::ios_base::openmode, TRANSITION, ABI
     static constexpr int in         = 0x01;
     static constexpr int out        = 0x02;
     static constexpr int ate        = 0x04;
@@ -86,7 +83,6 @@ public:
         _Seekend
     };
 
-    // These variables should have type std::ios_base::seekdir, TRANSITION, ABI
     static constexpr int beg = _Seekbeg;
     static constexpr int cur = _Seekcur;
     static constexpr int end = _Seekend;

--- a/stl/inc/xiosbase
+++ b/stl/inc/xiosbase
@@ -28,34 +28,6 @@ public:
         _Fmtmask = 0xffff,
         _Fmtzero = 0
     };
-    friend constexpr _Fmtflags operator&(_Fmtflags _First, _Fmtflags _Second) noexcept {
-        return static_cast<_Fmtflags>(static_cast<unsigned int>(_First) & static_cast<unsigned int>(_Second));
-    }
-
-    friend constexpr _Fmtflags& operator&=(_Fmtflags& _First, _Fmtflags _Second) noexcept {
-        _First = _First & _Second;
-        return _First;
-    }
-
-    friend constexpr _Fmtflags operator|(_Fmtflags _First, _Fmtflags _Second) noexcept {
-        return static_cast<_Fmtflags>(static_cast<unsigned int>(_First) | static_cast<unsigned int>(_Second));
-    }
-    friend constexpr _Fmtflags& operator|=(_Fmtflags& _First, _Fmtflags _Second) noexcept {
-        _First = _First | _Second;
-        return _First;
-    }
-
-    friend constexpr _Fmtflags operator^(_Fmtflags _First, _Fmtflags _Second) noexcept {
-        return static_cast<_Fmtflags>(static_cast<unsigned int>(_First) ^ static_cast<unsigned int>(_Second));
-    }
-    friend constexpr _Fmtflags& operator^=(_Fmtflags& _First, _Fmtflags _Second) noexcept {
-        _First = _First ^ _Second;
-        return _First;
-    }
-
-    friend constexpr _Fmtflags operator~(_Fmtflags _Mode) noexcept {
-        return static_cast<_Fmtflags>(~static_cast<unsigned int>(_Mode));
-    }
 
     // These variables should have type std::ios_base::fmtflags, TRANSITION, ABI
     static constexpr _Fmtflags skipws     = static_cast<_Fmtflags>(0x0001);
@@ -84,34 +56,6 @@ public:
     enum _Iostate { // constants for stream states
         _Statmask = 0x17
     };
-    friend constexpr _Iostate operator&(_Iostate _First, _Iostate _Second) noexcept {
-        return static_cast<_Iostate>(static_cast<unsigned int>(_First) & static_cast<unsigned int>(_Second));
-    }
-
-    friend constexpr _Iostate& operator&=(_Iostate& _First, _Iostate _Second) noexcept {
-        _First = _First & _Second;
-        return _First;
-    }
-
-    friend constexpr _Iostate operator|(_Iostate _First, _Iostate _Second) noexcept {
-        return static_cast<_Iostate>(static_cast<unsigned int>(_First) | static_cast<unsigned int>(_Second));
-    }
-    friend constexpr _Iostate& operator|=(_Iostate& _First, _Iostate _Second) noexcept {
-        _First = _First | _Second;
-        return _First;
-    }
-
-    friend constexpr _Iostate operator^(_Iostate _First, _Iostate _Second) noexcept {
-        return static_cast<_Iostate>(static_cast<unsigned int>(_First) ^ static_cast<unsigned int>(_Second));
-    }
-    friend constexpr _Iostate& operator^=(_Iostate& _First, _Iostate _Second) noexcept {
-        _First = _First ^ _Second;
-        return _First;
-    }
-
-    friend constexpr _Iostate operator~(_Iostate _Mode) noexcept {
-        return static_cast<_Iostate>(~static_cast<unsigned int>(_Mode));
-    }
 
     // These variables should have type std::ios_base::iostate, TRANSITION, ABI
     static constexpr _Iostate goodbit = static_cast<_Iostate>(0x0);
@@ -122,35 +66,6 @@ public:
     enum _Openmode { // constants for file opening options
         _Openmask = 0xff
     };
-
-    friend constexpr _Openmode operator&(_Openmode _First, _Openmode _Second) noexcept {
-        return static_cast<_Openmode>(static_cast<unsigned int>(_First) & static_cast<unsigned int>(_Second));
-    }
-
-    friend constexpr _Openmode& operator&=(_Openmode& _First, _Openmode _Second) noexcept {
-        _First = _First & _Second;
-        return _First;
-    }
-
-    friend constexpr _Openmode operator|(_Openmode _First, _Openmode _Second) noexcept {
-        return static_cast<_Openmode>(static_cast<unsigned int>(_First) | static_cast<unsigned int>(_Second));
-    }
-    friend constexpr _Openmode& operator|=(_Openmode& _First, _Openmode _Second) noexcept {
-        _First = _First | _Second;
-        return _First;
-    }
-
-    friend constexpr _Openmode operator^(_Openmode _First, _Openmode _Second) noexcept {
-        return static_cast<_Openmode>(static_cast<unsigned int>(_First) ^ static_cast<unsigned int>(_Second));
-    }
-    friend constexpr _Openmode& operator^=(_Openmode& _First, _Openmode _Second) noexcept {
-        _First = _First ^ _Second;
-        return _First;
-    }
-
-    friend constexpr _Openmode operator~(_Openmode _Mode) noexcept {
-        return static_cast<_Openmode>(~static_cast<unsigned int>(_Mode));
-    }
 
     // These variables should have type std::ios_base::openmode, TRANSITION, ABI
     static constexpr _Openmode in         = static_cast<_Openmode>(0x01);
@@ -171,35 +86,6 @@ public:
         _Seekend
     };
 
-    friend constexpr _Seekdir operator&(_Seekdir _First, _Seekdir _Second) noexcept {
-        return static_cast<_Seekdir>(static_cast<unsigned int>(_First) & static_cast<unsigned int>(_Second));
-    }
-
-    friend constexpr _Seekdir& operator&=(_Seekdir& _First, _Seekdir _Second) noexcept {
-        _First = _First & _Second;
-        return _First;
-    }
-
-    friend constexpr _Seekdir operator|(_Seekdir _First, _Seekdir _Second) noexcept {
-        return static_cast<_Seekdir>(static_cast<unsigned int>(_First) | static_cast<unsigned int>(_Second));
-    }
-    friend constexpr _Seekdir& operator|=(_Seekdir& _First, _Seekdir _Second) noexcept {
-        _First = _First | _Second;
-        return _First;
-    }
-
-    friend constexpr _Seekdir operator^(_Seekdir _First, _Seekdir _Second) noexcept {
-        return static_cast<_Seekdir>(static_cast<unsigned int>(_First) ^ static_cast<unsigned int>(_Second));
-    }
-    friend constexpr _Seekdir& operator^=(_Seekdir& _First, _Seekdir _Second) noexcept {
-        _First = _First ^ _Second;
-        return _First;
-    }
-
-    friend constexpr _Seekdir operator~(_Seekdir _Mode) noexcept {
-        return static_cast<_Seekdir>(~static_cast<unsigned int>(_Mode));
-    }
-
     // These variables should have type std::ios_base::seekdir, TRANSITION, ABI
     static constexpr _Seekdir beg = _Seekbeg;
     static constexpr _Seekdir cur = _Seekcur;
@@ -211,6 +97,11 @@ public:
 
     static constexpr int _Default_open_prot = _SH_DENYNO; // constant for default file opening protection
 };
+
+_BITMASK_OPS(_EXPORT_STD, _Iosb<int>::_Fmtflags)
+_BITMASK_OPS(_EXPORT_STD, _Iosb<int>::_Iostate)
+_BITMASK_OPS(_EXPORT_STD, _Iosb<int>::_Openmode)
+_BITMASK_OPS(_EXPORT_STD, _Iosb<int>::_Seekdir)
 
 _EXPORT_STD extern "C++" class _CRTIMP2_PURE_IMPORT ios_base : public _Iosb<int> { // base class for ios
 public:

--- a/stl/inc/xiosbase
+++ b/stl/inc/xiosbase
@@ -98,11 +98,6 @@ public:
     static constexpr int _Default_open_prot = _SH_DENYNO; // constant for default file opening protection
 };
 
-_BITMASK_OPS(_EXPORT_STD, _Iosb<int>::_Fmtflags)
-_BITMASK_OPS(_EXPORT_STD, _Iosb<int>::_Iostate)
-_BITMASK_OPS(_EXPORT_STD, _Iosb<int>::_Openmode)
-_BITMASK_OPS(_EXPORT_STD, _Iosb<int>::_Seekdir)
-
 _EXPORT_STD extern "C++" class _CRTIMP2_PURE_IMPORT ios_base : public _Iosb<int> { // base class for ios
 public:
     using fmtflags = int;

--- a/stl/inc/xiosbase
+++ b/stl/inc/xiosbase
@@ -28,7 +28,36 @@ public:
         _Fmtmask = 0xffff,
         _Fmtzero = 0
     };
+    friend constexpr _Fmtflags operator&(_Fmtflags _First, _Fmtflags _Second) noexcept {
+        return static_cast<_Fmtflags>(static_cast<unsigned int>(_First) & static_cast<unsigned int>(_Second));
+    }
 
+    friend constexpr _Fmtflags& operator&=(_Fmtflags& _First, _Fmtflags _Second) noexcept {
+        _First = _First & _Second;
+        return _First;
+    }
+
+    friend constexpr _Fmtflags operator|(_Fmtflags _First, _Fmtflags _Second) noexcept {
+        return static_cast<_Fmtflags>(static_cast<unsigned int>(_First) | static_cast<unsigned int>(_Second));
+    }
+    friend constexpr _Fmtflags& operator|=(_Fmtflags& _First, _Fmtflags _Second) noexcept {
+        _First = _First | _Second;
+        return _First;
+    }
+
+    friend constexpr _Fmtflags operator^(_Fmtflags _First, _Fmtflags _Second) noexcept {
+        return static_cast<_Fmtflags>(static_cast<unsigned int>(_First) ^ static_cast<unsigned int>(_Second));
+    }
+    friend constexpr _Fmtflags& operator^=(_Fmtflags& _First, _Fmtflags _Second) noexcept {
+        _First = _First ^ _Second;
+        return _First;
+    }
+
+    friend constexpr _Fmtflags operator~(_Fmtflags _Mode) noexcept {
+        return static_cast<_Fmtflags>(~static_cast<unsigned int>(_Mode));
+    }
+
+    // These variables should have type std::ios_base::fmtflags, TRANSITION, ABI
     static constexpr _Fmtflags skipws     = static_cast<_Fmtflags>(0x0001);
     static constexpr _Fmtflags unitbuf    = static_cast<_Fmtflags>(0x0002);
     static constexpr _Fmtflags uppercase  = static_cast<_Fmtflags>(0x0004);
@@ -55,7 +84,36 @@ public:
     enum _Iostate { // constants for stream states
         _Statmask = 0x17
     };
+    friend constexpr _Iostate operator&(_Iostate _First, _Iostate _Second) noexcept {
+        return static_cast<_Iostate>(static_cast<unsigned int>(_First) & static_cast<unsigned int>(_Second));
+    }
 
+    friend constexpr _Iostate& operator&=(_Iostate& _First, _Iostate _Second) noexcept {
+        _First = _First & _Second;
+        return _First;
+    }
+
+    friend constexpr _Iostate operator|(_Iostate _First, _Iostate _Second) noexcept {
+        return static_cast<_Iostate>(static_cast<unsigned int>(_First) | static_cast<unsigned int>(_Second));
+    }
+    friend constexpr _Iostate& operator|=(_Iostate& _First, _Iostate _Second) noexcept {
+        _First = _First | _Second;
+        return _First;
+    }
+
+    friend constexpr _Iostate operator^(_Iostate _First, _Iostate _Second) noexcept {
+        return static_cast<_Iostate>(static_cast<unsigned int>(_First) ^ static_cast<unsigned int>(_Second));
+    }
+    friend constexpr _Iostate& operator^=(_Iostate& _First, _Iostate _Second) noexcept {
+        _First = _First ^ _Second;
+        return _First;
+    }
+
+    friend constexpr _Iostate operator~(_Iostate _Mode) noexcept {
+        return static_cast<_Iostate>(~static_cast<unsigned int>(_Mode));
+    }
+
+    // These variables should have type std::ios_base::iostate, TRANSITION, ABI
     static constexpr _Iostate goodbit = static_cast<_Iostate>(0x0);
     static constexpr _Iostate eofbit  = static_cast<_Iostate>(0x1);
     static constexpr _Iostate failbit = static_cast<_Iostate>(0x2);
@@ -65,6 +123,36 @@ public:
         _Openmask = 0xff
     };
 
+    friend constexpr _Openmode operator&(_Openmode _First, _Openmode _Second) noexcept {
+        return static_cast<_Openmode>(static_cast<unsigned int>(_First) & static_cast<unsigned int>(_Second));
+    }
+
+    friend constexpr _Openmode& operator&=(_Openmode& _First, _Openmode _Second) noexcept {
+        _First = _First & _Second;
+        return _First;
+    }
+
+    friend constexpr _Openmode operator|(_Openmode _First, _Openmode _Second) noexcept {
+        return static_cast<_Openmode>(static_cast<unsigned int>(_First) | static_cast<unsigned int>(_Second));
+    }
+    friend constexpr _Openmode& operator|=(_Openmode& _First, _Openmode _Second) noexcept {
+        _First = _First | _Second;
+        return _First;
+    }
+
+    friend constexpr _Openmode operator^(_Openmode _First, _Openmode _Second) noexcept {
+        return static_cast<_Openmode>(static_cast<unsigned int>(_First) ^ static_cast<unsigned int>(_Second));
+    }
+    friend constexpr _Openmode& operator^=(_Openmode& _First, _Openmode _Second) noexcept {
+        _First = _First ^ _Second;
+        return _First;
+    }
+
+    friend constexpr _Openmode operator~(_Openmode _Mode) noexcept {
+        return static_cast<_Openmode>(~static_cast<unsigned int>(_Mode));
+    }
+
+    // These variables should have type std::ios_base::openmode, TRANSITION, ABI
     static constexpr _Openmode in         = static_cast<_Openmode>(0x01);
     static constexpr _Openmode out        = static_cast<_Openmode>(0x02);
     static constexpr _Openmode ate        = static_cast<_Openmode>(0x04);
@@ -83,6 +171,36 @@ public:
         _Seekend
     };
 
+    friend constexpr _Seekdir operator&(_Seekdir _First, _Seekdir _Second) noexcept {
+        return static_cast<_Seekdir>(static_cast<unsigned int>(_First) & static_cast<unsigned int>(_Second));
+    }
+
+    friend constexpr _Seekdir& operator&=(_Seekdir& _First, _Seekdir _Second) noexcept {
+        _First = _First & _Second;
+        return _First;
+    }
+
+    friend constexpr _Seekdir operator|(_Seekdir _First, _Seekdir _Second) noexcept {
+        return static_cast<_Seekdir>(static_cast<unsigned int>(_First) | static_cast<unsigned int>(_Second));
+    }
+    friend constexpr _Seekdir& operator|=(_Seekdir& _First, _Seekdir _Second) noexcept {
+        _First = _First | _Second;
+        return _First;
+    }
+
+    friend constexpr _Seekdir operator^(_Seekdir _First, _Seekdir _Second) noexcept {
+        return static_cast<_Seekdir>(static_cast<unsigned int>(_First) ^ static_cast<unsigned int>(_Second));
+    }
+    friend constexpr _Seekdir& operator^=(_Seekdir& _First, _Seekdir _Second) noexcept {
+        _First = _First ^ _Second;
+        return _First;
+    }
+
+    friend constexpr _Seekdir operator~(_Seekdir _Mode) noexcept {
+        return static_cast<_Seekdir>(~static_cast<unsigned int>(_Mode));
+    }
+
+    // These variables should have type std::ios_base::seekdir, TRANSITION, ABI
     static constexpr _Seekdir beg = _Seekbeg;
     static constexpr _Seekdir cur = _Seekcur;
     static constexpr _Seekdir end = _Seekend;

--- a/tests/std/tests/P2467R1_exclusive_mode_fstreams/test.cpp
+++ b/tests/std/tests/P2467R1_exclusive_mode_fstreams/test.cpp
@@ -44,10 +44,10 @@ void test_file_create_fail(const std::ios_base::openmode bad_mode) {
     assert(!fs::exists(test_file));
 }
 
+// Also test GH-3401: <ios>: std::ios_base::openmode is not a bitmask type
 constexpr bool test_gh_3401() {
-    // <ios>: std::ios_base::openmode is not a bitmask type
+    using IB = std::ios_base;
     {
-        using IB   = std::ios_base;
         auto flags = IB::binary;
         assert(flags & IB::binary);
 
@@ -72,7 +72,6 @@ constexpr bool test_gh_3401() {
         assert(!(flags & IB::app));
     }
     {
-        using IB   = std::ios_base;
         auto flags = IB::dec;
         assert(flags & IB::dec);
 
@@ -97,7 +96,6 @@ constexpr bool test_gh_3401() {
         assert(!(flags & IB::oct));
     }
     {
-        using IB   = std::ios_base;
         auto flags = IB::badbit;
         assert(flags & IB::badbit);
 
@@ -122,7 +120,6 @@ constexpr bool test_gh_3401() {
         assert(!(flags & IB::failbit));
     }
     {
-        using IB   = std::ios_base;
         auto flags = IB::cur;
         assert(flags & IB::cur);
 

--- a/tests/std/tests/P2467R1_exclusive_mode_fstreams/test.cpp
+++ b/tests/std/tests/P2467R1_exclusive_mode_fstreams/test.cpp
@@ -44,6 +44,112 @@ void test_file_create_fail(const std::ios_base::openmode bad_mode) {
     assert(!fs::exists(test_file));
 }
 
+constexpr bool test_gh_3401() {
+    // <ios>: std::ios_base::openmode is not a bitmask type
+    {
+        using IB   = std::ios_base;
+        auto flags = IB::binary;
+        assert(flags & IB::binary);
+
+        flags |= IB::app;
+        assert(flags & IB::binary);
+        assert(flags & IB::app);
+
+        flags &= ~IB::app;
+        assert(flags & IB::binary);
+        assert(!(flags & IB::app));
+
+        flags = IB::binary | IB::app;
+        assert(flags & IB::binary);
+        assert(flags & IB::app);
+
+        flags = IB::binary ^ IB::app;
+        assert(flags & IB::binary);
+        assert(flags & IB::app);
+
+        flags ^= IB::app;
+        assert(flags & IB::binary);
+        assert(!(flags & IB::app));
+    }
+    {
+        using IB   = std::ios_base;
+        auto flags = IB::dec;
+        assert(flags & IB::dec);
+
+        flags |= IB::oct;
+        assert(flags & IB::dec);
+        assert(flags & IB::oct);
+
+        flags &= ~IB::oct;
+        assert(flags & IB::dec);
+        assert(!(flags & IB::oct));
+
+        flags = IB::dec | IB::oct;
+        assert(flags & IB::dec);
+        assert(flags & IB::oct);
+
+        flags = IB::dec ^ IB::oct;
+        assert(flags & IB::dec);
+        assert(flags & IB::oct);
+
+        flags ^= IB::oct;
+        assert(flags & IB::dec);
+        assert(!(flags & IB::oct));
+    }
+    {
+        using IB   = std::ios_base;
+        auto flags = IB::badbit;
+        assert(flags & IB::badbit);
+
+        flags |= IB::failbit;
+        assert(flags & IB::badbit);
+        assert(flags & IB::failbit);
+
+        flags &= ~IB::failbit;
+        assert(flags & IB::badbit);
+        assert(!(flags & IB::failbit));
+
+        flags = IB::failbit | IB::badbit;
+        assert(flags & IB::badbit);
+        assert(flags & IB::failbit);
+
+        flags = IB::badbit ^ IB::failbit;
+        assert(flags & IB::badbit);
+        assert(flags & IB::failbit);
+
+        flags ^= IB::failbit;
+        assert(flags & IB::badbit);
+        assert(!(flags & IB::failbit));
+    }
+    {
+        using IB   = std::ios_base;
+        auto flags = IB::cur;
+        assert(flags & IB::cur);
+
+        flags |= IB::end;
+        assert(flags & IB::cur);
+        assert(flags & IB::end);
+
+        flags &= ~IB::end;
+        assert(flags & IB::cur);
+        assert(!(flags & IB::end));
+
+        flags = IB::end | IB::cur;
+        assert(flags & IB::cur);
+        assert(flags & IB::end);
+
+        flags = IB::cur ^ IB::end;
+        assert(flags & IB::cur);
+        assert(flags & IB::end);
+
+        flags ^= IB::end;
+        assert(flags & IB::cur);
+        assert(!(flags & IB::end));
+    }
+
+    return true;
+}
+
 int main() {
     using IB = std::ios_base;
 
@@ -65,4 +171,7 @@ int main() {
     test_file_create_fail(IB::in | IB::trunc | IB::noreplace);
     test_file_create_fail(IB::in | IB::binary | IB::noreplace);
     test_file_create_fail(IB::in | IB::binary | IB::trunc | IB::noreplace);
+
+    test_gh_3401();
+    static_assert(test_gh_3401());
 }

--- a/tests/std/tests/P2467R1_exclusive_mode_fstreams/test.cpp
+++ b/tests/std/tests/P2467R1_exclusive_mode_fstreams/test.cpp
@@ -5,6 +5,7 @@
 #include <filesystem>
 #include <fstream>
 #include <ios>
+#include <type_traits>
 
 namespace fs = std::filesystem;
 
@@ -46,7 +47,8 @@ void test_file_create_fail(const std::ios_base::openmode bad_mode) {
 
 // Also test GH-3401: <ios>: std::ios_base::openmode is not a bitmask type
 constexpr bool test_gh_3401() {
-    using IB        = std::ios_base;
+    using IB = std::ios_base;
+    using namespace std;
     auto test_flags = [](const auto first, const auto second) {
         auto flags = first;
         assert(flags & first);
@@ -75,6 +77,45 @@ constexpr bool test_gh_3401() {
     test_flags(IB::dec, IB::oct);
     test_flags(IB::badbit, IB::failbit);
     test_flags(IB::cur, IB::end);
+
+    static_assert(is_same_v<remove_const_t<decltype(IB::beg)>, IB::seekdir>);
+    static_assert(is_same_v<remove_const_t<decltype(IB::cur)>, IB::seekdir>);
+    static_assert(is_same_v<remove_const_t<decltype(IB::end)>, IB::seekdir>);
+
+    static_assert(is_same_v<remove_const_t<decltype(IB::in)>, IB::openmode>);
+    static_assert(is_same_v<remove_const_t<decltype(IB::out)>, IB::openmode>);
+    static_assert(is_same_v<remove_const_t<decltype(IB::ate)>, IB::openmode>);
+    static_assert(is_same_v<remove_const_t<decltype(IB::app)>, IB::openmode>);
+    static_assert(is_same_v<remove_const_t<decltype(IB::trunc)>, IB::openmode>);
+    static_assert(is_same_v<remove_const_t<decltype(IB::binary)>, IB::openmode>);
+#if _HAS_CXX23
+    static_assert(is_same_v<remove_const_t<decltype(IB::noreplace)>, IB::openmode>);
+#endif
+
+    static_assert(is_same_v<remove_const_t<decltype(IB::goodbit)>, IB::iostate>);
+    static_assert(is_same_v<remove_const_t<decltype(IB::eofbit)>, IB::iostate>);
+    static_assert(is_same_v<remove_const_t<decltype(IB::failbit)>, IB::iostate>);
+    static_assert(is_same_v<remove_const_t<decltype(IB::badbit)>, IB::iostate>);
+
+    static_assert(is_same_v<remove_const_t<decltype(IB::skipws)>, IB::fmtflags>);
+    static_assert(is_same_v<remove_const_t<decltype(IB::unitbuf)>, IB::fmtflags>);
+    static_assert(is_same_v<remove_const_t<decltype(IB::uppercase)>, IB::fmtflags>);
+    static_assert(is_same_v<remove_const_t<decltype(IB::showbase)>, IB::fmtflags>);
+    static_assert(is_same_v<remove_const_t<decltype(IB::showpoint)>, IB::fmtflags>);
+    static_assert(is_same_v<remove_const_t<decltype(IB::showpos)>, IB::fmtflags>);
+    static_assert(is_same_v<remove_const_t<decltype(IB::left)>, IB::fmtflags>);
+    static_assert(is_same_v<remove_const_t<decltype(IB::right)>, IB::fmtflags>);
+    static_assert(is_same_v<remove_const_t<decltype(IB::internal)>, IB::fmtflags>);
+    static_assert(is_same_v<remove_const_t<decltype(IB::dec)>, IB::fmtflags>);
+    static_assert(is_same_v<remove_const_t<decltype(IB::oct)>, IB::fmtflags>);
+    static_assert(is_same_v<remove_const_t<decltype(IB::hex)>, IB::fmtflags>);
+    static_assert(is_same_v<remove_const_t<decltype(IB::scientific)>, IB::fmtflags>);
+    static_assert(is_same_v<remove_const_t<decltype(IB::fixed)>, IB::fmtflags>);
+    static_assert(is_same_v<remove_const_t<decltype(IB::boolalpha)>, IB::fmtflags>);
+    static_assert(is_same_v<remove_const_t<decltype(IB::adjustfield)>, IB::fmtflags>);
+    static_assert(is_same_v<remove_const_t<decltype(IB::boolalpha)>, IB::fmtflags>);
+    static_assert(is_same_v<remove_const_t<decltype(IB::basefield)>, IB::fmtflags>);
+    static_assert(is_same_v<remove_const_t<decltype(IB::floatfield)>, IB::fmtflags>);
 
     return true;
 }

--- a/tests/std/tests/P2467R1_exclusive_mode_fstreams/test.cpp
+++ b/tests/std/tests/P2467R1_exclusive_mode_fstreams/test.cpp
@@ -47,8 +47,8 @@ void test_file_create_fail(const std::ios_base::openmode bad_mode) {
 
 // Also test GH-3401: <ios>: std::ios_base::openmode is not a bitmask type
 constexpr bool test_gh_3401() {
-    using IB = std::ios_base;
     using namespace std;
+    using IB        = ios_base;
     auto test_flags = [](const auto first, const auto second) {
         auto flags = first;
         assert(flags & first);
@@ -113,7 +113,6 @@ constexpr bool test_gh_3401() {
     static_assert(is_same_v<remove_const_t<decltype(IB::fixed)>, IB::fmtflags>);
     static_assert(is_same_v<remove_const_t<decltype(IB::boolalpha)>, IB::fmtflags>);
     static_assert(is_same_v<remove_const_t<decltype(IB::adjustfield)>, IB::fmtflags>);
-    static_assert(is_same_v<remove_const_t<decltype(IB::boolalpha)>, IB::fmtflags>);
     static_assert(is_same_v<remove_const_t<decltype(IB::basefield)>, IB::fmtflags>);
     static_assert(is_same_v<remove_const_t<decltype(IB::floatfield)>, IB::fmtflags>);
 

--- a/tests/std/tests/P2467R1_exclusive_mode_fstreams/test.cpp
+++ b/tests/std/tests/P2467R1_exclusive_mode_fstreams/test.cpp
@@ -46,103 +46,35 @@ void test_file_create_fail(const std::ios_base::openmode bad_mode) {
 
 // Also test GH-3401: <ios>: std::ios_base::openmode is not a bitmask type
 constexpr bool test_gh_3401() {
-    using IB = std::ios_base;
-    {
-        auto flags = IB::binary;
-        assert(flags & IB::binary);
+    using IB        = std::ios_base;
+    auto test_flags = [](const auto first, const auto second) {
+        auto flags = first;
+        assert(flags & first);
 
-        flags |= IB::app;
-        assert(flags & IB::binary);
-        assert(flags & IB::app);
+        flags |= second;
+        assert(flags & first);
+        assert(flags & second);
 
-        flags &= ~IB::app;
-        assert(flags & IB::binary);
-        assert(!(flags & IB::app));
+        flags &= ~second;
+        assert(flags & first);
+        assert(!(flags & second));
 
-        flags = IB::binary | IB::app;
-        assert(flags & IB::binary);
-        assert(flags & IB::app);
+        flags = first | second;
+        assert(flags & first);
+        assert(flags & second);
 
-        flags = IB::binary ^ IB::app;
-        assert(flags & IB::binary);
-        assert(flags & IB::app);
+        flags = first ^ second;
+        assert(flags & first);
+        assert(flags & second);
 
-        flags ^= IB::app;
-        assert(flags & IB::binary);
-        assert(!(flags & IB::app));
-    }
-    {
-        auto flags = IB::dec;
-        assert(flags & IB::dec);
-
-        flags |= IB::oct;
-        assert(flags & IB::dec);
-        assert(flags & IB::oct);
-
-        flags &= ~IB::oct;
-        assert(flags & IB::dec);
-        assert(!(flags & IB::oct));
-
-        flags = IB::dec | IB::oct;
-        assert(flags & IB::dec);
-        assert(flags & IB::oct);
-
-        flags = IB::dec ^ IB::oct;
-        assert(flags & IB::dec);
-        assert(flags & IB::oct);
-
-        flags ^= IB::oct;
-        assert(flags & IB::dec);
-        assert(!(flags & IB::oct));
-    }
-    {
-        auto flags = IB::badbit;
-        assert(flags & IB::badbit);
-
-        flags |= IB::failbit;
-        assert(flags & IB::badbit);
-        assert(flags & IB::failbit);
-
-        flags &= ~IB::failbit;
-        assert(flags & IB::badbit);
-        assert(!(flags & IB::failbit));
-
-        flags = IB::failbit | IB::badbit;
-        assert(flags & IB::badbit);
-        assert(flags & IB::failbit);
-
-        flags = IB::badbit ^ IB::failbit;
-        assert(flags & IB::badbit);
-        assert(flags & IB::failbit);
-
-        flags ^= IB::failbit;
-        assert(flags & IB::badbit);
-        assert(!(flags & IB::failbit));
-    }
-    {
-        auto flags = IB::cur;
-        assert(flags & IB::cur);
-
-        flags |= IB::end;
-        assert(flags & IB::cur);
-        assert(flags & IB::end);
-
-        flags &= ~IB::end;
-        assert(flags & IB::cur);
-        assert(!(flags & IB::end));
-
-        flags = IB::end | IB::cur;
-        assert(flags & IB::cur);
-        assert(flags & IB::end);
-
-        flags = IB::cur ^ IB::end;
-        assert(flags & IB::cur);
-        assert(flags & IB::end);
-
-        flags ^= IB::end;
-        assert(flags & IB::cur);
-        assert(!(flags & IB::end));
-    }
+        flags ^= second;
+        assert(flags & first);
+        assert(!(flags & second));
+    };
+    test_flags(IB::binary, IB::app);
+    test_flags(IB::dec, IB::oct);
+    test_flags(IB::badbit, IB::failbit);
+    test_flags(IB::cur, IB::end);
 
     return true;
 }


### PR DESCRIPTION
Fixes #3401 

If I understand correctly we can't change types of the variables but we can add operators.