### PR TITLE
LWG-3848: `slide_view` missing `base` accessor

### DIFF
--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -6753,6 +6753,16 @@ namespace ranges {
 #endif // _CONTAINER_DEBUG_LEVEL > 0
         }
 
+        _NODISCARD constexpr _Vw base() const& noexcept(is_nothrow_copy_constructible_v<_Vw>) // strengthened
+            requires copy_constructible<_Vw>
+        {
+            return _Range;
+        }
+
+        _NODISCARD constexpr _Vw base() && noexcept(is_nothrow_move_constructible_v<_Vw>) /* strengthened */ {
+            return _STD move(_Range);
+        }
+
         // clang-format off
         _NODISCARD constexpr auto begin() requires (!(_Simple_view<_Vw> && _Slide_caches_nothing<const _Vw>) ) {
             // clang-format on

--- a/tests/std/tests/P2442R1_views_slide/test.cpp
+++ b/tests/std/tests/P2442R1_views_slide/test.cpp
@@ -403,9 +403,7 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
     // Validate slide_view::base() &&
     same_as<V> auto b2 = move(r).base();
     STATIC_ASSERT(noexcept(move(r).base()) == is_nothrow_move_constructible_v<V>);
-    if (!is_empty) {
-        assert(*b2.begin() == *begin(*begin(expected)));
-    }
+    assert(*b2.begin() == *begin(*begin(expected)));
 
     return true;
 }

--- a/tests/std/tests/P2442R1_views_slide/test.cpp
+++ b/tests/std/tests/P2442R1_views_slide/test.cpp
@@ -392,6 +392,21 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
         }
     }
 
+    // Validate slide_view::base() const&
+    STATIC_ASSERT(CanMemberBase<const R&> == copy_constructible<V>);
+    if constexpr (copy_constructible<V>) {
+        same_as<V> auto b1 = as_const(r).base();
+        STATIC_ASSERT(noexcept(as_const(r).base()) == is_nothrow_copy_constructible_v<V>);
+        assert(*b1.begin() == *begin(*begin(expected)));
+    }
+
+    // Validate slide_view::base() &&
+    same_as<V> auto b2 = move(r).base();
+    STATIC_ASSERT(noexcept(move(r).base()) == is_nothrow_move_constructible_v<V>);
+    if (!is_empty) {
+        assert(*b2.begin() == *begin(*begin(expected)));
+    }
+
     return true;
 }
 

--- a/tests/std/tests/P2442R1_views_slide/test.cpp
+++ b/tests/std/tests/P2442R1_views_slide/test.cpp
@@ -201,14 +201,14 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
     if constexpr (CanMemberSize<R>) {
         same_as<_Make_unsigned_like_t<ranges::range_difference_t<V>>> auto s = r.size();
         assert(s == ranges::size(expected));
-        STATIC_ASSERT(noexcept(r.size()));
+        STATIC_ASSERT(noexcept(r.size()) == noexcept(ranges::size(rng))); // strengthened
     }
 
     STATIC_ASSERT(CanMemberSize<const R> == sized_range<const V>);
     if constexpr (CanMemberSize<const R>) {
         same_as<_Make_unsigned_like_t<ranges::range_difference_t<const V>>> auto s = as_const(r).size();
         assert(s == ranges::size(expected));
-        STATIC_ASSERT(noexcept(as_const(r).size()));
+        STATIC_ASSERT(noexcept(as_const(r).size()) == noexcept(ranges::size(rng))); // strengthened
     }
 
     if (is_empty) {
@@ -396,13 +396,13 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
     STATIC_ASSERT(CanMemberBase<const R&> == copy_constructible<V>);
     if constexpr (copy_constructible<V>) {
         same_as<V> auto b1 = as_const(r).base();
-        STATIC_ASSERT(noexcept(as_const(r).base()) == is_nothrow_copy_constructible_v<V>);
+        STATIC_ASSERT(noexcept(as_const(r).base()) == is_nothrow_copy_constructible_v<V>); // strengthened
         assert(*b1.begin() == *begin(*begin(expected)));
     }
 
     // Validate slide_view::base() &&
     same_as<V> auto b2 = move(r).base();
-    STATIC_ASSERT(noexcept(move(r).base()) == is_nothrow_move_constructible_v<V>);
+    STATIC_ASSERT(noexcept(move(r).base()) == is_nothrow_move_constructible_v<V>); // strengthened
     assert(*b2.begin() == *begin(*begin(expected)));
 
     return true;


### PR DESCRIPTION
This PR adds `base` accessor to `ranges::slide_view` implemented in #2670.

Fixes #3409.