### PR TITLE
LWG-3810: CTAD for `basic_format_args`

### DIFF
--- a/stl/inc/format
+++ b/stl/inc/format
@@ -1991,6 +1991,9 @@ private:
     const _Format_arg_index* _Index_array = nullptr;
 };
 
+template <class _Context, class... _Args>
+basic_format_args(_Format_arg_store<_Context, _Args...>) -> basic_format_args<_Context>;
+
 // _Lazy_locale is used instead of a std::locale so that the locale is only
 // constructed when needed, and is never constructed if the format string does not
 // contain locale-sensitive format specifiers. Note that this means that a new locale

--- a/tests/std/tests/P0645R10_text_formatting_args/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_args/test.cpp
@@ -229,6 +229,19 @@ void test_visit_monostate() {
     assert(visit_format_arg(visitor<Context>, basic_format_arg<Context>()) == Arg_type::none);
 }
 
+template <class Context, class FormatArgs>
+constexpr bool verify_lwg3810 = false;
+
+template <class Context>
+constexpr bool verify_lwg3810<Context, basic_format_args<Context>> = true;
+
+template <class Context>
+void test_lwg3810() {
+    auto args_store                         = make_format_args<Context>(1, 2, 3);
+    [[maybe_unused]] basic_format_args args = args_store;
+    static_assert(verify_lwg3810<Context, decltype(args)>);
+}
+
 int main() {
     test_basic_format_arg<format_context>();
     test_basic_format_arg<wformat_context>();
@@ -236,4 +249,6 @@ int main() {
     test_format_arg_store<wformat_context>();
     test_visit_monostate<format_context>();
     test_visit_monostate<wformat_context>();
+    test_lwg3810<format_context>();
+    test_lwg3810<wformat_context>();
 }

--- a/tests/std/tests/P0645R10_text_formatting_args/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_args/test.cpp
@@ -229,17 +229,10 @@ void test_visit_monostate() {
     assert(visit_format_arg(visitor<Context>, basic_format_arg<Context>()) == Arg_type::none);
 }
 
-template <class Context, class FormatArgs>
-constexpr bool verify_lwg3810 = false;
-
-template <class Context>
-constexpr bool verify_lwg3810<Context, basic_format_args<Context>> = true;
-
 template <class Context>
 void test_lwg3810() {
-    auto args_store                         = make_format_args<Context>(1, 2, 3);
-    [[maybe_unused]] basic_format_args args = args_store;
-    static_assert(verify_lwg3810<Context, decltype(args)>);
+    [[maybe_unused]] auto args_store = make_format_args<Context>(1, 2, 3);
+    static_assert(same_as<decltype(basic_format_args{args_store}), basic_format_args<Context>>);
 }
 
 int main() {


### PR DESCRIPTION
Closes #3414.