### PR TITLE
Eliminate spaces in `operator"" name()`

### DIFF
--- a/stl/inc/__msvc_chrono.hpp
+++ b/stl/inc/__msvc_chrono.hpp
@@ -730,12 +730,12 @@ inline namespace literals {
             return _CHRONO duration<double, ratio<3600>>(_Val);
         }
 
-        _EXPORT_STD _NODISCARD constexpr _CHRONO minutes(operator""min)(unsigned long long _Val) noexcept
+        _EXPORT_STD _NODISCARD constexpr _CHRONO minutes operator""min(unsigned long long _Val) noexcept
         /* strengthened */ {
             return _CHRONO minutes(_Val);
         }
 
-        _EXPORT_STD _NODISCARD constexpr _CHRONO duration<double, ratio<60>>(operator""min)(long double _Val) noexcept
+        _EXPORT_STD _NODISCARD constexpr _CHRONO duration<double, ratio<60>> operator""min(long double _Val) noexcept
         /* strengthened */ {
             return _CHRONO duration<double, ratio<60>>(_Val);
         }

--- a/stl/inc/__msvc_chrono.hpp
+++ b/stl/inc/__msvc_chrono.hpp
@@ -720,62 +720,62 @@ _NODISCARD bool _To_xtime_10_day_clamped(_CSTD xtime& _Xt, const _CHRONO duratio
 
 inline namespace literals {
     inline namespace chrono_literals {
-        _EXPORT_STD _NODISCARD constexpr _CHRONO hours operator"" h(unsigned long long _Val) noexcept
+        _EXPORT_STD _NODISCARD constexpr _CHRONO hours operator""h(unsigned long long _Val) noexcept
         /* strengthened */ {
             return _CHRONO hours(_Val);
         }
 
-        _EXPORT_STD _NODISCARD constexpr _CHRONO duration<double, ratio<3600>> operator"" h(long double _Val) noexcept
+        _EXPORT_STD _NODISCARD constexpr _CHRONO duration<double, ratio<3600>> operator""h(long double _Val) noexcept
         /* strengthened */ {
             return _CHRONO duration<double, ratio<3600>>(_Val);
         }
 
-        _EXPORT_STD _NODISCARD constexpr _CHRONO minutes(operator"" min)(unsigned long long _Val) noexcept
+        _EXPORT_STD _NODISCARD constexpr _CHRONO minutes(operator""min)(unsigned long long _Val) noexcept
         /* strengthened */ {
             return _CHRONO minutes(_Val);
         }
 
-        _EXPORT_STD _NODISCARD constexpr _CHRONO duration<double, ratio<60>>(operator"" min)(long double _Val) noexcept
+        _EXPORT_STD _NODISCARD constexpr _CHRONO duration<double, ratio<60>>(operator""min)(long double _Val) noexcept
         /* strengthened */ {
             return _CHRONO duration<double, ratio<60>>(_Val);
         }
 
-        _EXPORT_STD _NODISCARD constexpr _CHRONO seconds operator"" s(unsigned long long _Val) noexcept
+        _EXPORT_STD _NODISCARD constexpr _CHRONO seconds operator""s(unsigned long long _Val) noexcept
         /* strengthened */ {
             return _CHRONO seconds(_Val);
         }
 
-        _EXPORT_STD _NODISCARD constexpr _CHRONO duration<double> operator"" s(long double _Val) noexcept
+        _EXPORT_STD _NODISCARD constexpr _CHRONO duration<double> operator""s(long double _Val) noexcept
         /* strengthened */ {
             return _CHRONO duration<double>(_Val);
         }
 
-        _EXPORT_STD _NODISCARD constexpr _CHRONO milliseconds operator"" ms(unsigned long long _Val) noexcept
+        _EXPORT_STD _NODISCARD constexpr _CHRONO milliseconds operator""ms(unsigned long long _Val) noexcept
         /* strengthened */ {
             return _CHRONO milliseconds(_Val);
         }
 
-        _EXPORT_STD _NODISCARD constexpr _CHRONO duration<double, milli> operator"" ms(long double _Val) noexcept
+        _EXPORT_STD _NODISCARD constexpr _CHRONO duration<double, milli> operator""ms(long double _Val) noexcept
         /* strengthened */ {
             return _CHRONO duration<double, milli>(_Val);
         }
 
-        _EXPORT_STD _NODISCARD constexpr _CHRONO microseconds operator"" us(unsigned long long _Val) noexcept
+        _EXPORT_STD _NODISCARD constexpr _CHRONO microseconds operator""us(unsigned long long _Val) noexcept
         /* strengthened */ {
             return _CHRONO microseconds(_Val);
         }
 
-        _EXPORT_STD _NODISCARD constexpr _CHRONO duration<double, micro> operator"" us(long double _Val) noexcept
+        _EXPORT_STD _NODISCARD constexpr _CHRONO duration<double, micro> operator""us(long double _Val) noexcept
         /* strengthened */ {
             return _CHRONO duration<double, micro>(_Val);
         }
 
-        _EXPORT_STD _NODISCARD constexpr _CHRONO nanoseconds operator"" ns(unsigned long long _Val) noexcept
+        _EXPORT_STD _NODISCARD constexpr _CHRONO nanoseconds operator""ns(unsigned long long _Val) noexcept
         /* strengthened */ {
             return _CHRONO nanoseconds(_Val);
         }
 
-        _EXPORT_STD _NODISCARD constexpr _CHRONO duration<double, nano> operator"" ns(long double _Val) noexcept
+        _EXPORT_STD _NODISCARD constexpr _CHRONO duration<double, nano> operator""ns(long double _Val) noexcept
         /* strengthened */ {
             return _CHRONO duration<double, nano>(_Val);
         }

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -6019,10 +6019,10 @@ namespace chrono {
 
 inline namespace literals {
     inline namespace chrono_literals {
-        _EXPORT_STD _NODISCARD constexpr _CHRONO day operator"" d(unsigned long long _Day) noexcept {
+        _EXPORT_STD _NODISCARD constexpr _CHRONO day operator""d(unsigned long long _Day) noexcept {
             return _CHRONO day{static_cast<unsigned int>(_Day)};
         }
-        _EXPORT_STD _NODISCARD constexpr _CHRONO year operator"" y(unsigned long long _Year) noexcept {
+        _EXPORT_STD _NODISCARD constexpr _CHRONO year operator""y(unsigned long long _Year) noexcept {
             return _CHRONO year{static_cast<int>(_Year)};
         }
     } // namespace chrono_literals

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -1847,26 +1847,26 @@ basic_ostream<_Elem, _Traits>& operator<<(
 
 inline namespace literals {
     inline namespace string_view_literals {
-        _EXPORT_STD _NODISCARD constexpr string_view operator"" sv(const char* _Str, size_t _Len) noexcept {
+        _EXPORT_STD _NODISCARD constexpr string_view operator""sv(const char* _Str, size_t _Len) noexcept {
             return string_view(_Str, _Len);
         }
 
-        _EXPORT_STD _NODISCARD constexpr wstring_view operator"" sv(const wchar_t* _Str, size_t _Len) noexcept {
+        _EXPORT_STD _NODISCARD constexpr wstring_view operator""sv(const wchar_t* _Str, size_t _Len) noexcept {
             return wstring_view(_Str, _Len);
         }
 
 #ifdef __cpp_char8_t
-        _EXPORT_STD _NODISCARD constexpr basic_string_view<char8_t> operator"" sv(
+        _EXPORT_STD _NODISCARD constexpr basic_string_view<char8_t> operator""sv(
             const char8_t* _Str, size_t _Len) noexcept {
             return basic_string_view<char8_t>(_Str, _Len);
         }
 #endif // __cpp_char8_t
 
-        _EXPORT_STD _NODISCARD constexpr u16string_view operator"" sv(const char16_t* _Str, size_t _Len) noexcept {
+        _EXPORT_STD _NODISCARD constexpr u16string_view operator""sv(const char16_t* _Str, size_t _Len) noexcept {
             return u16string_view(_Str, _Len);
         }
 
-        _EXPORT_STD _NODISCARD constexpr u32string_view operator"" sv(const char32_t* _Str, size_t _Len) noexcept {
+        _EXPORT_STD _NODISCARD constexpr u32string_view operator""sv(const char32_t* _Str, size_t _Len) noexcept {
             return u32string_view(_Str, _Len);
         }
     } // namespace string_view_literals
@@ -5225,25 +5225,25 @@ basic_ostream<_Elem, _Traits>& operator<<(
 
 inline namespace literals {
     inline namespace string_literals {
-        _EXPORT_STD _NODISCARD _CONSTEXPR20 string operator"" s(const char* _Str, size_t _Len) {
+        _EXPORT_STD _NODISCARD _CONSTEXPR20 string operator""s(const char* _Str, size_t _Len) {
             return string{_Str, _Len};
         }
 
-        _EXPORT_STD _NODISCARD _CONSTEXPR20 wstring operator"" s(const wchar_t* _Str, size_t _Len) {
+        _EXPORT_STD _NODISCARD _CONSTEXPR20 wstring operator""s(const wchar_t* _Str, size_t _Len) {
             return wstring{_Str, _Len};
         }
 
 #ifdef __cpp_char8_t
-        _EXPORT_STD _NODISCARD _CONSTEXPR20 basic_string<char8_t> operator"" s(const char8_t* _Str, size_t _Len) {
+        _EXPORT_STD _NODISCARD _CONSTEXPR20 basic_string<char8_t> operator""s(const char8_t* _Str, size_t _Len) {
             return basic_string<char8_t>{_Str, _Len};
         }
 #endif // __cpp_char8_t
 
-        _EXPORT_STD _NODISCARD _CONSTEXPR20 u16string operator"" s(const char16_t* _Str, size_t _Len) {
+        _EXPORT_STD _NODISCARD _CONSTEXPR20 u16string operator""s(const char16_t* _Str, size_t _Len) {
             return u16string{_Str, _Len};
         }
 
-        _EXPORT_STD _NODISCARD _CONSTEXPR20 u32string operator"" s(const char32_t* _Str, size_t _Len) {
+        _EXPORT_STD _NODISCARD _CONSTEXPR20 u32string operator""s(const char32_t* _Str, size_t _Len) {
             return u32string{_Str, _Len};
         }
     } // namespace string_literals

--- a/tests/std/tests/P0092R1_polishing_chrono/test.cpp
+++ b/tests/std/tests/P0092R1_polishing_chrono/test.cpp
@@ -166,7 +166,7 @@ namespace floating_point_conversions {
 // Make sure round() handles cases where taking half the divisor itself
 // truncates.
 using odd_divisor = duration<intmax_t, ratio<1, 7>>;
-inline constexpr odd_divisor operator"" _odd(unsigned long long val) {
+inline constexpr odd_divisor operator""_odd(unsigned long long val) {
     return odd_divisor(val);
 }
 

--- a/tests/std/tests/P1522R1_difference_type/test.cpp
+++ b/tests/std/tests/P1522R1_difference_type/test.cpp
@@ -132,7 +132,7 @@ namespace i128_udl_detail {
 } // namespace i128_udl_detail
 
 template <char... Chars>
-[[nodiscard]] CONSTEVAL _Unsigned128 operator"" _u128() noexcept {
+[[nodiscard]] CONSTEVAL _Unsigned128 operator""_u128() noexcept {
     constexpr auto parsed_result = i128_udl_detail::parse_u128<Chars...>::parse();
     static_assert(parsed_result.status_code != i128_udl_detail::u128_parse_status::invalid,
         "Invalid characters in the integer literal");
@@ -142,7 +142,7 @@ template <char... Chars>
 }
 
 template <char... Chars>
-[[nodiscard]] CONSTEVAL _Signed128 operator"" _i128() noexcept {
+[[nodiscard]] CONSTEVAL _Signed128 operator""_i128() noexcept {
     constexpr auto parsed_result = i128_udl_detail::parse_u128<Chars...>::parse();
     static_assert(parsed_result.status_code != i128_udl_detail::u128_parse_status::invalid,
         "Invalid characters in the integer literal");


### PR DESCRIPTION
[CWG-2521](https://cplusplus.github.io/CWG/issues/2521.html) is recently accepted. It deprecates such form of literal operators.

Although such deprecation is not yet implemented as far, I think we can get rid of such form now.