### PR TITLE
`<barrier>`: Declare victory!

### DIFF
--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -285,6 +285,7 @@
 // P2432R1 Fix istream_view
 // P2508R1 basic_format_string, format_string, wformat_string
 // P2520R0 move_iterator<T*> Should Be A Random-Access Iterator
+// P2588R3 barrier's Phase Completion Guarantees
 
 // _HAS_CXX20 indirectly controls:
 // P0619R4 Removing C++17-Deprecated Features
@@ -1586,7 +1587,7 @@ _EMIT_STL_ERROR(STL1004, "C++98 unexpected() is incompatible with C++23 unexpect
 #define __cpp_lib_atomic_ref                    201806L
 #define __cpp_lib_atomic_shared_ptr             201711L
 #define __cpp_lib_atomic_wait                   201907L
-#define __cpp_lib_barrier                       201907L
+#define __cpp_lib_barrier                       202302L
 #define __cpp_lib_bind_front                    201907L
 #define __cpp_lib_bit_cast                      201806L
 #define __cpp_lib_bitops                        201907L

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -85,6 +85,9 @@ std/utilities/charconv/charconv.to.chars/integral.pass.cpp FAIL
 # libc++ has not implemented P2505R5: "Monadic Functions for std::expected"
 std/language.support/support.limits/support.limits.general/expected.version.compile.pass.cpp FAIL
 
+# libc++ doesn't implement P2588R3 barrier's Phase Completion Guarantees
+std/language.support/support.limits/support.limits.general/barrier.version.compile.pass.cpp FAIL
+
 
 # *** INTERACTIONS WITH CONTEST / C1XX THAT UPSTREAM LIKELY WON'T FIX ***
 # Tracked by VSO-593630 "<filesystem> Enable libcxx filesystem tests"
@@ -560,9 +563,6 @@ std/input.output/filesystems/fs.filesystem.synopsis/file_time_type_resolution.co
 std/language.support/support.limits/support.limits.general/algorithm.version.compile.pass.cpp FAIL
 std/language.support/support.limits/support.limits.general/functional.version.compile.pass.cpp FAIL
 std/language.support/support.limits/support.limits.general/iterator.version.compile.pass.cpp FAIL
-
-# libc++ doesn't implement P2588R3 barrier's Phase Completion Guarantees
-std/language.support/support.limits/support.limits.general/barrier.version.compile.pass.cpp FAIL
 
 # Test expects __cpp_lib_chrono to have the old value 201611L for P0505R0; we define the C++20 value 201907L for P1466R3.
 std/language.support/support.limits/support.limits.general/chrono.version.compile.pass.cpp FAIL

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -561,6 +561,9 @@ std/language.support/support.limits/support.limits.general/algorithm.version.com
 std/language.support/support.limits/support.limits.general/functional.version.compile.pass.cpp FAIL
 std/language.support/support.limits/support.limits.general/iterator.version.compile.pass.cpp FAIL
 
+# libc++ doesn't implement P2588R3 barrier's Phase Completion Guarantees
+std/language.support/support.limits/support.limits.general/barrier.version.compile.pass.cpp
+
 # Test expects __cpp_lib_chrono to have the old value 201611L for P0505R0; we define the C++20 value 201907L for P1466R3.
 std/language.support/support.limits/support.limits.general/chrono.version.compile.pass.cpp FAIL
 

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -562,7 +562,7 @@ std/language.support/support.limits/support.limits.general/functional.version.co
 std/language.support/support.limits/support.limits.general/iterator.version.compile.pass.cpp FAIL
 
 # libc++ doesn't implement P2588R3 barrier's Phase Completion Guarantees
-std/language.support/support.limits/support.limits.general/barrier.version.compile.pass.cpp
+std/language.support/support.limits/support.limits.general/barrier.version.compile.pass.cpp FAIL
 
 # Test expects __cpp_lib_chrono to have the old value 201611L for P0505R0; we define the C++20 value 201907L for P1466R3.
 std/language.support/support.limits/support.limits.general/chrono.version.compile.pass.cpp FAIL

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -85,6 +85,9 @@ utilities\charconv\charconv.to.chars\integral.pass.cpp
 # libc++ has not implemented P2505R5: "Monadic Functions for std::expected"
 language.support\support.limits\support.limits.general\expected.version.compile.pass.cpp
 
+# libc++ doesn't implement P2588R3 barrier's Phase Completion Guarantees
+language.support\support.limits\support.limits.general\barrier.version.compile.pass.cpp
+
 
 # *** INTERACTIONS WITH CONTEST / C1XX THAT UPSTREAM LIKELY WON'T FIX ***
 # Tracked by VSO-593630 "<filesystem> Enable libcxx filesystem tests"
@@ -560,9 +563,6 @@ input.output\filesystems\fs.filesystem.synopsis\file_time_type_resolution.compil
 language.support\support.limits\support.limits.general\algorithm.version.compile.pass.cpp
 language.support\support.limits\support.limits.general\functional.version.compile.pass.cpp
 language.support\support.limits\support.limits.general\iterator.version.compile.pass.cpp
-
-# libc++ doesn't implement P2588R3 barrier's Phase Completion Guarantees
-language.support\support.limits\support.limits.general\barrier.version.compile.pass.cpp
 
 # Test expects __cpp_lib_chrono to have the old value 201611L for P0505R0; we define the C++20 value 201907L for P1466R3.
 language.support\support.limits\support.limits.general\chrono.version.compile.pass.cpp

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -561,6 +561,9 @@ language.support\support.limits\support.limits.general\algorithm.version.compile
 language.support\support.limits\support.limits.general\functional.version.compile.pass.cpp
 language.support\support.limits\support.limits.general\iterator.version.compile.pass.cpp
 
+# libc++ doesn't implement P2588R3 barrier's Phase Completion Guarantees
+language.support\support.limits\support.limits.general\barrier.version.compile.pass.cpp
+
 # Test expects __cpp_lib_chrono to have the old value 201611L for P0505R0; we define the C++20 value 201907L for P1466R3.
 language.support\support.limits\support.limits.general\chrono.version.compile.pass.cpp
 

--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
@@ -261,10 +261,10 @@ STATIC_ASSERT(__cpp_lib_atomic_wait == 201907L);
 #if _HAS_CXX20
 #ifndef __cpp_lib_barrier
 #error __cpp_lib_barrier is not defined
-#elif __cpp_lib_barrier != 201907L
-#error __cpp_lib_barrier is not 201907L
+#elif __cpp_lib_barrier != 202302L
+#error __cpp_lib_barrier is not 202302L
 #else
-STATIC_ASSERT(__cpp_lib_barrier == 201907L);
+STATIC_ASSERT(__cpp_lib_barrier == 202302L);
 #endif
 #else
 #ifdef __cpp_lib_barrier


### PR DESCRIPTION
No lines in `<barrier>` were actually touched.

I have verified that we have no test coverage on guarantees we eliminate.

Resolves #3440