### PR TITLE
Uncomment resolutions of applied LWG issues

### DIFF
--- a/stl/inc/deque
+++ b/stl/inc/deque
@@ -809,7 +809,7 @@ public:
             }
 
             const auto _Num = static_cast<difference_type>(_Mysize() - _Oldsize);
-            _STD reverse(begin(), begin() + _Num); // Per LWG-3742
+            _STD reverse(begin(), begin() + _Num);
         }
         _Guard._Container = nullptr;
     }

--- a/stl/inc/queue
+++ b/stl/inc/queue
@@ -377,7 +377,7 @@ public:
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
     template <_Container_compatible_range<_Ty> _Rng>
-    void push_range(_Rng&& _Range) { // per LWG-3723
+    void push_range(_Rng&& _Range) {
         if constexpr (requires { c.append_range(_Range); }) {
             c.append_range(_Range);
         } else {

--- a/stl/inc/syncstream
+++ b/stl/inc/syncstream
@@ -346,7 +346,7 @@ public:
 
     ~basic_osyncstream() = default;
 
-    basic_osyncstream& operator=(basic_osyncstream&&) = default; // per LWG-3867
+    basic_osyncstream& operator=(basic_osyncstream&&) = default;
 
     void emit() {
         ios_base::iostate _State = ios_base::goodbit;

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -54,7 +54,7 @@ struct _Char_traits { // properties of a string or stream element
 #else // ^^^ _HAS_MEMCPY_MEMMOVE_INTRINSICS / !_HAS_MEMCPY_MEMMOVE_INTRINSICS vvv
 #if _HAS_CXX20
         if (_STD is_constant_evaluated()) {
-            // pre: [_First1, _First1 + _Count) and [_First2, _First2 + _Count) do not overlap; see LWG-3085
+            // pre: [_First1, _First1 + _Count) and [_First2, _First2 + _Count) do not overlap
             for (size_t _Idx = 0; _Idx != _Count; ++_Idx) {
                 _First1[_Idx] = _First2[_Idx];
             }
@@ -1257,10 +1257,10 @@ public:
             && _RANGES contiguous_range<_Range>
             && _RANGES sized_range<_Range>
             && same_as<_RANGES range_value_t<_Range>, _Elem>
-            && (!is_convertible_v<_Range, const _Elem*>)
-            && (!requires(remove_cvref_t<_Range>& _Rng) {
+            && !is_convertible_v<_Range, const _Elem*>
+            && !requires(remove_cvref_t<_Range>& _Rng) {
                 _Rng.operator _STD basic_string_view<_Elem, _Traits>();
-            })) // doesn't check member type traits_type, per LWG-3857
+            })
     constexpr explicit basic_string_view(_Range&& _Rng) noexcept(
         noexcept(_RANGES data(_Rng)) && noexcept(_RANGES size(_Rng))) // strengthened
         : _Mydata(_RANGES data(_Rng)), _Mysize(static_cast<size_t>(_RANGES size(_Rng))) {}

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -3135,15 +3135,15 @@ namespace ranges {
         template <class _It, sentinel_for<_It> _Se>
             requires (!sized_sentinel_for<_Se, _It>)
         _NODISCARD constexpr iter_difference_t<_It> operator()(_It _First, _Se _Last) const
-            noexcept(noexcept(_Distance_unchecked(_Get_unwrapped(_STD move(_First)),
-                _Get_unwrapped(_STD move(_Last))))) /* strengthened */ { // Per LWG-3664
+            noexcept(noexcept(_Distance_unchecked(
+                _Get_unwrapped(_STD move(_First)), _Get_unwrapped(_STD move(_Last))))) /* strengthened */ {
             _Adl_verify_range(_First, _Last);
             return _Distance_unchecked(_Unwrap_iter<_Se>(_STD move(_First)), _Unwrap_sent<_It>(_STD move(_Last)));
         }
 
         template <class _It, sized_sentinel_for<decay_t<_It>> _Se>
         _NODISCARD constexpr iter_difference_t<decay_t<_It>> operator()(_It&& _First, const _Se _Last) const
-            noexcept(noexcept(_Last - static_cast<const decay_t<_It>&>(_First))) /* strengthened */ { // Per LWG-3664
+            noexcept(noexcept(_Last - static_cast<const decay_t<_It>&>(_First))) /* strengthened */ {
             return _Last - static_cast<const decay_t<_It>&>(_First);
         }
 

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -1701,7 +1701,7 @@ _EMIT_STL_ERROR(STL1004, "C++98 unexpected() is incompatible with C++23 unexpect
 #define __cpp_lib_ranges_chunk            202202L
 #define __cpp_lib_ranges_chunk_by         202202L
 #define __cpp_lib_ranges_contains         202207L
-#define __cpp_lib_ranges_find_last        202207L // per LWG-3807
+#define __cpp_lib_ranges_find_last        202207L
 #define __cpp_lib_ranges_fold             202207L
 #define __cpp_lib_ranges_iota             202202L
 #define __cpp_lib_ranges_join_with        202202L

--- a/tests/std/tests/P0220R1_string_view/test.cpp
+++ b/tests/std/tests/P0220R1_string_view/test.cpp
@@ -373,7 +373,6 @@ constexpr bool test_case_range_constructor() {
     static_assert(!is_convertible_v<string_view, basic_string_view<char, constexpr_char_traits>>);
     static_assert(!is_convertible_v<basic_string_view<char, constexpr_char_traits>, string>);
 
-    // LWG-3857 basic_string_view should allow explicit conversion when only traits vary
     static_assert(is_constructible_v<string_view, basic_string<char, constexpr_char_traits>>);
     static_assert(is_constructible_v<basic_string_view<char, constexpr_char_traits>, string_view>);
 

--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
@@ -1597,7 +1597,7 @@ STATIC_ASSERT(__cpp_lib_ranges_contains == 202207L);
 #endif
 
 #if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
-#ifndef __cpp_lib_ranges_find_last // per LWG-3807
+#ifndef __cpp_lib_ranges_find_last
 #error __cpp_lib_ranges_find_last is not defined
 #elif __cpp_lib_ranges_find_last != 202207L
 #error __cpp_lib_ranges_find_last is not 202207L


### PR DESCRIPTION
Covers:
* LWG-3085
* LWG-3664
* LWG-3723
* LWG-3742
* LWG-3807
* LWG-3857
* LWG-3867

I've verified that we completely implement the resolutions of these issues.

Drive-by: remove extraneous `()` in the constraints on `basic_string_view`'s range constructor.
