### PR TITLE
LWG-3772 repeat_view's piecewise constructor is missing Postconditions

### DIFF
--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -1561,12 +1561,16 @@ namespace ranges {
         }
         template <class... _TArgs, class... _BArgs>
             requires constructible_from<_Ty, _TArgs...> && constructible_from<_Bo, _BArgs...>
-        // clang-format off
-        _NODISCARD_CTOR constexpr explicit repeat_view(piecewise_construct_t,
-            tuple<_TArgs...> _Val_args, tuple<_BArgs...> _Bound_args = tuple<>{})
-            noexcept(is_nothrow_constructible_v<_Ty, _TArgs...>) // strengthened
-            // clang-format on
-            : repeat_view(_Val_args, index_sequence_for<_TArgs...>{}, _STD make_from_tuple<_Bo>(_Bound_args)) {}
+        _NODISCARD_CTOR constexpr explicit repeat_view(piecewise_construct_t, tuple<_TArgs...> _Val_args,
+            tuple<_BArgs...> _Bound_args = tuple<>{}) noexcept(is_nothrow_constructible_v<_Ty,
+            _TArgs...>&& noexcept(_STD make_from_tuple<_Bo>(_Bound_args))) // strengthened
+            : repeat_view(_Val_args, index_sequence_for<_TArgs...>{}, _STD make_from_tuple<_Bo>(_Bound_args)) {
+#if _CONTAINER_DEBUG_LEVEL > 0
+            if constexpr (_Signed_integer_like<_Bo>) {
+                _STL_VERIFY(_Bound >= 0, "Bound must be >= 0");
+            }
+#endif
+        }
 
         _NODISCARD constexpr _Iterator begin() const noexcept /* strengthened */ {
             return _Iterator{_STD addressof(*_Value)};

--- a/stl/inc/tuple
+++ b/stl/inc/tuple
@@ -871,7 +871,8 @@ constexpr decltype(auto) apply(_Callable&& _Obj, _Tuple&& _Tpl) noexcept(
 }
 
 template <class _Ty, class _Tuple, size_t... _Indices>
-constexpr _Ty _Make_from_tuple_impl(_Tuple&& _Tpl, index_sequence<_Indices...>) {
+constexpr _Ty _Make_from_tuple_impl(_Tuple&& _Tpl, index_sequence<_Indices...>) noexcept(
+    is_nothrow_constructible_v<_Ty, decltype(_STD get<_Indices>(_STD forward<_Tuple>(_Tpl)))...>) {
     // construct _Ty from the elements of _Tpl
     static_assert(is_constructible_v<_Ty, decltype(_STD get<_Indices>(_STD forward<_Tuple>(_Tpl)))...>,
         "the target type must be constructible from the fields of the argument tuple (N4892 [tuple.apply]/2).");
@@ -879,7 +880,9 @@ constexpr _Ty _Make_from_tuple_impl(_Tuple&& _Tpl, index_sequence<_Indices...>) 
 }
 
 _EXPORT_STD template <class _Ty, class _Tuple>
-_NODISCARD constexpr _Ty make_from_tuple(_Tuple&& _Tpl) { // construct _Ty from the elements of _Tpl
+_NODISCARD constexpr _Ty make_from_tuple(_Tuple&& _Tpl) noexcept(noexcept(_Make_from_tuple_impl<_Ty>(
+    _STD forward<_Tuple>(_Tpl), make_index_sequence<tuple_size_v<remove_reference_t<_Tuple>>>{}))) /* strengthened */ {
+    // construct _Ty from the elements of _Tpl
     return _Make_from_tuple_impl<_Ty>(
         _STD forward<_Tuple>(_Tpl), make_index_sequence<tuple_size_v<remove_reference_t<_Tuple>>>{});
 }


### PR DESCRIPTION
Enforce the precondition when `_CONTAINER_DEBUG_LEVEL > 0`.

Drive-by: Fix conditional noexcept on the constructor, which requires adding conditional noexcept to `make_from_tuple`.
