### PR TITLE
Toolset update: VS 2022 17.5 Preview 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With The Visual Studio IDE
 
-1. Install Visual Studio 2022 17.5 Preview 3 or later.
+1. Install Visual Studio 2022 17.5 Preview 6 or later.
     * Select "Windows 11 SDK (10.0.22000.0)" in the VS Installer.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
@@ -157,7 +157,7 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With A Native Tools Command Prompt
 
-1. Install Visual Studio 2022 17.5 Preview 3 or later.
+1. Install Visual Studio 2022 17.5 Preview 6 or later.
     * Select "Windows 11 SDK (10.0.22000.0)" in the VS Installer.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.

--- a/azure-devops/create-1es-hosted-pool.ps1
+++ b/azure-devops/create-1es-hosted-pool.ps1
@@ -284,7 +284,7 @@ $Gallery = New-AzGallery `
 ####################################################################################################
 Display-ProgressBar -Status 'Granting access to 1ES Resource Management'
 
-$ServicePrincipalObjectId = (Get-AzADServicePrincipal -DisplayName '1ES Resource Management').Id
+$ServicePrincipalObjectId = (Get-AzADServicePrincipal -DisplayName '1ES Resource Management' -First 1).Id
 
 New-AzRoleAssignment `
   -ObjectId $ServicePrincipalObjectId `

--- a/azure-devops/provision-image.ps1
+++ b/azure-devops/provision-image.ps1
@@ -91,7 +91,7 @@ if ([string]::IsNullOrEmpty($AdminUserPassword)) {
   $PsExecPath = Join-Path $ExtractedPsToolsPath 'PsExec64.exe'
 
   # https://github.com/PowerShell/PowerShell/releases/latest
-  $PowerShellZipUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.3.1/PowerShell-7.3.1-win-x64.zip'
+  $PowerShellZipUrl = 'https://github.com/PowerShell/PowerShell/releases/download/v7.3.2/PowerShell-7.3.2-win-x64.zip'
   Write-Host "Downloading: $PowerShellZipUrl"
   $ExtractedPowerShellPath = DownloadAndExtractZip -Url $PowerShellZipUrl
   $PwshPath = Join-Path $ExtractedPowerShellPath 'pwsh.exe'
@@ -141,7 +141,7 @@ $Workloads = @(
 $ReleaseInPath = 'Preview'
 $Sku = 'Enterprise'
 $VisualStudioBootstrapperUrl = 'https://aka.ms/vs/17/pre/vs_enterprise.exe'
-$PythonUrl = 'https://www.python.org/ftp/python/3.11.1/python-3.11.1-amd64.exe'
+$PythonUrl = 'https://www.python.org/ftp/python/3.11.2/python-3.11.2-amd64.exe'
 
 $CudaUrl = 'https://developer.download.nvidia.com/compute/cuda/11.6.0/local_installers/cuda_11.6.0_511.23_windows.exe'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ variables:
   benchmarkBuildOutputLocation: 'D:\benchmark'
 
 pool:
-  name: 'StlBuild-2023-01-18T1600-Pool'
+  name: 'StlBuild-2023-02-14T1520-Pool'
   demands: EnableSpotVM -equals true
 
 pr:


### PR DESCRIPTION
* February 2023 Patch Tuesday.
* VS 2022 17.5 Preview 6.
* Python 3.11.2.
* Prepared with PowerShell 7.3.2.

Finally, we need to ask `Get-AzADServicePrincipal` to return the first result - we want `System.String` instead of `System.Object[]`. (I'm not sure when this breaking change appeared - if it was an update to Azure PowerShell, or if 1ES just started returning new results.)