### PR TITLE
LWG-3853: `basic_const_iterator<volatile int*>::operator->` is ill-formed

### DIFF
--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -1862,7 +1862,7 @@ public:
         return static_cast<_Reference>(*_Current);
     }
 
-    _NODISCARD constexpr const value_type* operator->() const
+    _NODISCARD constexpr const auto* operator->() const
         noexcept(contiguous_iterator<_Iter> || noexcept(*_Current)) /* strengthened */
         requires is_lvalue_reference_v<iter_reference_t<_Iter>>
               && same_as<remove_cvref_t<iter_reference_t<_Iter>>, value_type>

--- a/tests/std/tests/P2278R4_basic_const_iterator/test.cpp
+++ b/tests/std/tests/P2278R4_basic_const_iterator/test.cpp
@@ -250,6 +250,11 @@ constexpr void test_one(It iter) {
     }
 }
 
+void test_lwg3853() { // COMPILE-ONLY
+    basic_const_iterator<volatile int*> it;
+    [[maybe_unused]] same_as<const volatile int*> auto ptr = it.operator->();
+}
+
 static constexpr int some_ints[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
 
 struct instantiator {


### PR DESCRIPTION
Closes #3427.