### PR TITLE
Implement LWG-2309 `mutex::lock()` should not throw `device_or_resource_busy`

### DIFF
--- a/stl/inc/mutex
+++ b/stl/inc/mutex
@@ -49,6 +49,7 @@ public:
             // undefined behavior, only occurs for plain mutexes (N4928 [thread.mutex.requirements.mutex.general]/6)
             _STD _Throw_Cpp_error(_RESOURCE_DEADLOCK_WOULD_OCCUR);
         }
+
         if (_Ownership_levels() == INT_MAX) {
             // only occurs for recursive mutexes (N4928 [thread.mutex.recursive]/3)
             --_Ownership_levels();
@@ -63,11 +64,13 @@ public:
             // undefined behavior, only occurs for plain mutexes (N4928 [thread.mutex.requirements.mutex.general]/6)
             return false;
         }
+
         if (_Ownership_levels() == INT_MAX) {
             // only occurs for recursive mutexes (N4928 [thread.mutex.recursive]/3)
             --_Ownership_levels();
             return false;
         }
+
         return true;
     }
 
@@ -92,7 +95,7 @@ private:
     }
 
     int& _Ownership_levels() noexcept { // the count is denoted by an int subobject at the end of _Mtx_storage
-        return *reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(&_Mtx_storage + 1) - sizeof(int));
+        return reinterpret_cast<int*>(&_Mtx_storage + 1)[-1];
     }
 };
 

--- a/stl/inc/mutex
+++ b/stl/inc/mutex
@@ -31,6 +31,34 @@ _STD_BEGIN
 _EXPORT_STD class condition_variable;
 _EXPORT_STD class condition_variable_any;
 
+struct _Mtx_internal_imp_mirror {
+#ifdef _CRT_WINDOWS
+#ifdef _WIN64
+    static constexpr size_t _Critical_section_size = 8;
+#else // _WIN64
+    static constexpr size_t _Critical_section_size = 4;
+#endif // _WIN64
+#else // _CRT_WINDOWS
+#ifdef _WIN64
+    static constexpr size_t _Critical_section_size = 56;
+#else // _WIN64
+    static constexpr size_t _Critical_section_size = 32;
+#endif // _WIN64
+#endif // _CRT_WINDOWS
+
+    int _Type;
+    const void* _Vptr;
+    union {
+        void* _Srw_lock_placeholder;
+        unsigned char _Padding[_Critical_section_size];
+    };
+    long _Thread_id;
+    int _Count;
+};
+
+static_assert(sizeof(_Mtx_internal_imp_mirror) == _Mtx_internal_imp_size, "inconsistent size for mutex");
+static_assert(alignof(_Mtx_internal_imp_mirror) == _Mtx_internal_imp_alignment, "inconsistent alignment for mutex");
+
 class _Mutex_base { // base class for all mutex types
 public:
     _Mutex_base(int _Flags = 0) noexcept {
@@ -50,9 +78,8 @@ public:
             _STD _Throw_Cpp_error(_RESOURCE_DEADLOCK_WOULD_OCCUR);
         }
 
-        if (_Ownership_levels() == INT_MAX) {
+        if (!_Verify_ownership_levels()) {
             // only occurs for recursive mutexes (N4928 [thread.mutex.recursive]/3)
-            --_Ownership_levels();
             // POSIX specifies EAGAIN in the corresponding situation:
             // https://pubs.opengroup.org/onlinepubs/9699919799/functions/pthread_mutex_lock.html
             _STD _Throw_Cpp_error(_RESOURCE_UNAVAILABLE_TRY_AGAIN);
@@ -60,18 +87,8 @@ public:
     }
 
     _NODISCARD_TRY_CHANGE_STATE bool try_lock() noexcept /* strengthened */ {
-        if (_Mtx_trylock(_Mymtx()) != _Thrd_success) {
-            // undefined behavior for plain mutexes (N4928 [thread.mutex.requirements.mutex.general]/6)
-            return false;
-        }
-
-        if (_Ownership_levels() == INT_MAX) {
-            // only occurs for recursive mutexes (N4928 [thread.mutex.recursive]/3)
-            --_Ownership_levels();
-            return false;
-        }
-
-        return true;
+        // false may be from undefined behavior for plain mutexes (N4928 [thread.mutex.requirements.mutex.general]/6)
+        return _Mtx_trylock(_Mymtx()) == _Thrd_success;
     }
 
     void unlock() noexcept /* strengthened */ {
@@ -84,20 +101,33 @@ public:
         return _Mtx_getconcrtcs(_Mymtx());
     }
 
+protected:
+    _NODISCARD_TRY_CHANGE_STATE bool _Verify_ownership_levels() noexcept {
+        if (_Mtx_storage_mirror._Count == INT_MAX) {
+            // only occurs for recursive mutexes (N4928 [thread.mutex.recursive]/3)
+            --_Mtx_storage_mirror._Count;
+            return false;
+        }
+
+        return true;
+    }
+
 private:
     friend condition_variable;
     friend condition_variable_any;
 
-    _Aligned_storage_t<_Mtx_internal_imp_size, _Mtx_internal_imp_alignment> _Mtx_storage;
+    union {
+        _Aligned_storage_t<_Mtx_internal_imp_size, _Mtx_internal_imp_alignment> _Mtx_storage;
+        _Mtx_internal_imp_mirror _Mtx_storage_mirror;
+    };
 
     _Mtx_t _Mymtx() noexcept { // get pointer to _Mtx_internal_imp_t inside _Mtx_storage
         return reinterpret_cast<_Mtx_t>(&_Mtx_storage);
     }
-
-    int& _Ownership_levels() noexcept { // the count is denoted by an int subobject at the end of _Mtx_storage
-        return reinterpret_cast<int*>(&_Mtx_storage + 1)[-1];
-    }
 };
+
+static_assert(sizeof(_Mutex_base) == _Mtx_internal_imp_size, "inconsistent size for mutex");
+static_assert(alignof(_Mutex_base) == _Mtx_internal_imp_alignment, "inconsistent alignment for mutex");
 
 _EXPORT_STD class mutex : public _Mutex_base { // class for mutual exclusion
 public:
@@ -114,7 +144,7 @@ public:
         : _Mutex_base(_Mtx_recursive) {}
 
     _NODISCARD_TRY_CHANGE_STATE bool try_lock() noexcept {
-        return _Mutex_base::try_lock();
+        return _Mutex_base::try_lock() && _Verify_ownership_levels();
     }
 
     recursive_mutex(const recursive_mutex&)            = delete;

--- a/stl/inc/mutex
+++ b/stl/inc/mutex
@@ -61,7 +61,7 @@ public:
 
     _NODISCARD_TRY_CHANGE_STATE bool try_lock() noexcept /* strengthened */ {
         if (_Mtx_trylock(_Mymtx()) != _Thrd_success) {
-            // undefined behavior, only occurs for plain mutexes (N4928 [thread.mutex.requirements.mutex.general]/6)
+            // undefined behavior for plain mutexes (N4928 [thread.mutex.requirements.mutex.general]/6)
             return false;
         }
 

--- a/stl/inc/mutex
+++ b/stl/inc/mutex
@@ -45,11 +45,30 @@ public:
     _Mutex_base& operator=(const _Mutex_base&) = delete;
 
     void lock() {
-        _Check_C_return(_Mtx_lock(_Mymtx()));
+        if (_Mtx_lock(_Mymtx()) != _Thrd_success) {
+            // undefined behavior, only occurs for plain mutexes (N4928 [thread.mutex.requirements.mutex.general]/6)
+            _STD _Throw_Cpp_error(_RESOURCE_DEADLOCK_WOULD_OCCUR);
+        }
+        if (_Ownership_levels() == INT_MAX) {
+            // only occurs for recursive mutexes (N4928 [thread.mutex.recursive]/3)
+            --_Ownership_levels();
+            // POSIX specifies EAGAIN in the corresponding situation:
+            // https://pubs.opengroup.org/onlinepubs/9699919799/functions/pthread_mutex_lock.html
+            _STD _Throw_Cpp_error(_RESOURCE_UNAVAILABLE_TRY_AGAIN);
+        }
     }
 
     _NODISCARD_TRY_CHANGE_STATE bool try_lock() noexcept /* strengthened */ {
-        return _Mtx_trylock(_Mymtx()) == _Thrd_success;
+        if (_Mtx_trylock(_Mymtx()) != _Thrd_success) {
+            // undefined behavior, only occurs for plain mutexes (N4928 [thread.mutex.requirements.mutex.general]/6)
+            return false;
+        }
+        if (_Ownership_levels() == INT_MAX) {
+            // only occurs for recursive mutexes (N4928 [thread.mutex.recursive]/3)
+            --_Ownership_levels();
+            return false;
+        }
+        return true;
     }
 
     void unlock() noexcept /* strengthened */ {
@@ -70,6 +89,10 @@ private:
 
     _Mtx_t _Mymtx() noexcept { // get pointer to _Mtx_internal_imp_t inside _Mtx_storage
         return reinterpret_cast<_Mtx_t>(&_Mtx_storage);
+    }
+
+    int& _Ownership_levels() noexcept { // the count is denoted by an int subobject at the end of _Mtx_storage
+        return *reinterpret_cast<int*>(reinterpret_cast<unsigned char*>(&_Mtx_storage + 1) - sizeof(int));
     }
 };
 
@@ -852,7 +875,9 @@ public:
             if (_My_locked < UINT_MAX) {
                 ++_My_locked;
             } else {
-                _Throw_system_error(errc::device_or_resource_busy);
+                // POSIX specifies EAGAIN in the corresponding situation:
+                // https://pubs.opengroup.org/onlinepubs/9699919799/functions/pthread_mutex_lock.html
+                _STD _Throw_system_error(errc::resource_unavailable_try_again);
             }
         } else {
             while (_My_locked != 0) {


### PR DESCRIPTION
Fixes #75. Fixes #3407.

----

This PR is currently subject to further changes, but decision is probably needed.

1. In the description of LWG-2309, SG1 suggested that `resource_deadlock_would_occur` should be thrown in the UB case; [POSIX](https://pubs.opengroup.org/onlinepubs/9699919799/functions/pthread_mutex_lock.html) specifies `EAGAIN` (corresponding to `resource_unavailable_try_again`) on ownership level overflowing. While @BillyONeal preferred `abort()` for UB, and mentioned that SG1 suggested `terminate()` for overflowing (which, however, needs another LWG issue).
2. When implementing this, I strongly felt that it'd be better to divorce `mutex::lock` and `recursive_mutex::lock` because they have entirely different failing cases (same for `try_lock`). I guess they should be different functions.
3. The current changes are header-only. But I suspect that it'd be better to change `mutex.cpp`, although this will affect redist.
4. Test coverage is missing, because I wrote a test program like the following which succeeded but spent over 10 minutes running on my machine (in debug build). Most of the time were spent by operations of `recursive_timed_mutex`. While operations of `recursive_mutex` were far faster, they still took over 1 minute to run.

The extremely time-consuming test program:
```C++
#include <cassert>
#include <cstdint>
#include <mutex>
#include <system_error>

using namespace std;

template <class Mtx>
void test_overflowing_lock_levels() {
    constexpr uint64_t large_count = 0x20'0000'0000ULL;

    Mtx m{};
    bool thrown  = false;
    uint64_t cnt = 0ULL;

    try {
        for (; cnt != large_count; ++cnt) {
            m.lock();
        }
    } catch (const std::system_error& e) {
        thrown = true;
        assert(e.code().value() == static_cast<int>(std::errc::resource_unavailable_try_again));
    } catch (...) {
        assert(false);
    }

    assert(thrown);

    while (cnt != 0) {
        --cnt;
        m.unlock();
    }
}

int main() {
    test_overflowing_lock_levels<recursive_mutex>();
    test_overflowing_lock_levels<recursive_timed_mutex>();
}
```