### PR TITLE
LWG-3872: `basic_const_iterator` should have custom `iter_move`

### DIFF
--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -1758,6 +1758,9 @@ _NODISCARD constexpr const _Elem* data(initializer_list<_Elem> _Ilist) noexcept 
 _EXPORT_STD template <indirectly_readable _Ty>
 using iter_const_reference_t = common_reference_t<const iter_value_t<_Ty>&&, iter_reference_t<_Ty>>;
 
+template <indirectly_readable _Iter>
+using _Iter_const_rvalue_reference_t = common_reference_t<const iter_value_t<_Iter>&&, iter_rvalue_reference_t<_Iter>>;
+
 template <class _Ty>
 concept _Constant_iterator = input_iterator<_Ty> && same_as<iter_const_reference_t<_Ty>, iter_reference_t<_Ty>>;
 
@@ -1810,7 +1813,8 @@ class basic_const_iterator : public _Basic_const_iterator_category<_Iter> {
 private:
     /* [[no_unique_address]] */ _Iter _Current{};
 
-    using _Reference = iter_const_reference_t<_Iter>;
+    using _Reference        = iter_const_reference_t<_Iter>;
+    using _Rvalue_reference = _Iter_const_rvalue_reference_t<_Iter>;
 
     _NODISCARD static _CONSTEVAL auto _Get_iter_concept() noexcept {
         if constexpr (contiguous_iterator<_Iter>) {
@@ -2062,6 +2066,11 @@ public:
     _NODISCARD_FRIEND constexpr difference_type operator-(const _Sent& _Se, const basic_const_iterator& _It) noexcept(
         noexcept(_Se - _It._Current)) /* strengthened */ { // per LWG-3769
         return _Se - _It._Current;
+    }
+
+    _NODISCARD_FRIEND constexpr _Rvalue_reference iter_move(const basic_const_iterator& _It) noexcept(
+        noexcept(static_cast<_Rvalue_reference>(_RANGES iter_move(_It._Current)))) {
+        return static_cast<_Rvalue_reference>(_RANGES iter_move(_It._Current));
     }
 };
 

--- a/tests/std/tests/P2278R4_basic_const_iterator/env.lst
+++ b/tests/std/tests/P2278R4_basic_const_iterator/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\concepts_latest_matrix.lst
+RUNALL_INCLUDE ..\strict_concepts_latest_matrix.lst

--- a/tests/std/tests/P2278R4_basic_const_iterator/test.cpp
+++ b/tests/std/tests/P2278R4_basic_const_iterator/test.cpp
@@ -4,6 +4,7 @@
 #include <cassert>
 #include <iterator>
 #include <memory>
+#include <ranges>
 #include <type_traits>
 #include <utility>
 
@@ -239,6 +240,13 @@ constexpr void test_one(It iter) {
         static_assert(noexcept(citer == sent) == noexcept(iter == sent)); // strengthened
     }
 
+    { // Validate basic_const_iterator::iter_move()
+        using Expected = common_reference_t<const iter_value_t<It>&&, iter_rvalue_reference_t<It>>;
+        [[maybe_unused]] same_as<Expected> decltype(auto) val = ranges::iter_move(citer);
+        static_assert(
+            noexcept(ranges::iter_move(citer)) == noexcept(static_cast<Expected>(ranges::iter_move(citer.base()))));
+    }
+
     { // Validate basic_const_iterator::base() const&
         [[maybe_unused]] same_as<const It&> decltype(auto) base = citer.base();
         static_assert(noexcept(citer.base()));
@@ -251,6 +259,10 @@ constexpr void test_one(It iter) {
 }
 
 static constexpr int some_ints[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+
+// Check LWG-3872
+using Zipped = decltype(views::zip(some_ints) | views::as_const | views::as_rvalue);
+static_assert(same_as<ranges::range_reference_t<Zipped>, tuple<const int&&>>);
 
 struct instantiator {
     template <input_iterator It>


### PR DESCRIPTION
Closes #3429.