### PR TITLE
LWG-3847 `ranges::to` can still return views

### DIFF
--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -8404,6 +8404,7 @@ namespace ranges {
     _NODISCARD constexpr _Container to(_Rng&& _Range, _Types&&... _Args) {
         static_assert(!is_const_v<_Container>, "C must not be const. (N4928 [range.utility.conv.to])");
         static_assert(!is_volatile_v<_Container>, "C must not be volatile. (N4928 [range.utility.conv.to])");
+        static_assert(is_class_v<_Container>, "C must be a class type. (N4928 [range.utility.conv.to])");
         if constexpr (_Converts_direct_constructible<_Rng, _Container, _Types...>) {
             return _Container(_STD forward<_Rng>(_Range), _STD forward<_Types>(_Args)...);
         } else if constexpr (_Converts_tag_constructible<_Rng, _Container, _Types...>) {
@@ -8431,6 +8432,7 @@ namespace ranges {
     struct _To_class_fn {
         _STL_INTERNAL_STATIC_ASSERT(!is_const_v<_Container>);
         _STL_INTERNAL_STATIC_ASSERT(!is_volatile_v<_Container>);
+        _STL_INTERNAL_STATIC_ASSERT(is_class_v<_Container>);
         _STL_INTERNAL_STATIC_ASSERT(!view<_Container>);
 
         template <input_range _Rng, class... _Types>
@@ -8446,6 +8448,7 @@ namespace ranges {
     _NODISCARD constexpr auto to(_Types&&... _Args) {
         static_assert(!is_const_v<_Container>, "C must not be const. (N4928 [range.utility.conv.adaptors])");
         static_assert(!is_volatile_v<_Container>, "C must not be volatile. (N4928 [range.utility.conv.adaptors])");
+        static_assert(is_class_v<_Container>, "C must be a class type. (N4928 [range.utility.conv.to])");
         return _Range_closure<_To_class_fn<_Container>, decay_t<_Types>...>{_STD forward<_Types>(_Args)...};
     }
 

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -8402,9 +8402,9 @@ namespace ranges {
     _EXPORT_STD template <class _Container, input_range _Rng, class... _Types>
         requires (!view<_Container>)
     _NODISCARD constexpr _Container to(_Rng&& _Range, _Types&&... _Args) {
-        static_assert(!is_const_v<_Container>, "C must not be const. (N4928 [range.utility.conv.to])");
-        static_assert(!is_volatile_v<_Container>, "C must not be volatile. (N4928 [range.utility.conv.to])");
-        static_assert(is_class_v<_Container>, "C must be a class type. (N4928 [range.utility.conv.to])");
+        static_assert(!is_const_v<_Container>, "C must not be const. ([range.utility.conv.to])");
+        static_assert(!is_volatile_v<_Container>, "C must not be volatile. ([range.utility.conv.to])");
+        static_assert(is_class_v<_Container>, "C must be a class type. ([range.utility.conv.to])");
         if constexpr (_Converts_direct_constructible<_Rng, _Container, _Types...>) {
             return _Container(_STD forward<_Rng>(_Range), _STD forward<_Types>(_Args)...);
         } else if constexpr (_Converts_tag_constructible<_Rng, _Container, _Types...>) {
@@ -8446,9 +8446,9 @@ namespace ranges {
     _EXPORT_STD template <class _Container, class... _Types>
         requires (!view<_Container>)
     _NODISCARD constexpr auto to(_Types&&... _Args) {
-        static_assert(!is_const_v<_Container>, "C must not be const. (N4928 [range.utility.conv.adaptors])");
-        static_assert(!is_volatile_v<_Container>, "C must not be volatile. (N4928 [range.utility.conv.adaptors])");
-        static_assert(is_class_v<_Container>, "C must be a class type. (N4928 [range.utility.conv.to])");
+        static_assert(!is_const_v<_Container>, "C must not be const. ([range.utility.conv.adaptors])");
+        static_assert(!is_volatile_v<_Container>, "C must not be volatile. ([range.utility.conv.adaptors])");
+        static_assert(is_class_v<_Container>, "C must be a class type. ([range.utility.conv.adaptors])");
         return _Range_closure<_To_class_fn<_Container>, decay_t<_Types>...>{_STD forward<_Types>(_Args)...};
     }
 

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -8402,8 +8402,8 @@ namespace ranges {
     _EXPORT_STD template <class _Container, input_range _Rng, class... _Types>
         requires (!view<_Container>)
     _NODISCARD constexpr _Container to(_Rng&& _Range, _Types&&... _Args) {
-        static_assert(!is_const_v<_Container>, "the target type must be cv-unqualified");
-        static_assert(!is_volatile_v<_Container>, "the target type must be cv-unqualified");
+        static_assert(!is_const_v<_Container>, "C must not be const. (N4928 [range.utility.conv.to])");
+        static_assert(!is_volatile_v<_Container>, "C must not be volatile. (N4928 [range.utility.conv.to])");
         if constexpr (_Converts_direct_constructible<_Rng, _Container, _Types...>) {
             return _Container(_STD forward<_Rng>(_Range), _STD forward<_Types>(_Args)...);
         } else if constexpr (_Converts_tag_constructible<_Rng, _Container, _Types...>) {
@@ -8429,8 +8429,8 @@ namespace ranges {
 
     template <class _Container>
     struct _To_class_fn {
-        _STL_INTERNAL_STATIC_ASSERT(!is_const_v<_Container>, "the target type must be cv-unqualified");
-        _STL_INTERNAL_STATIC_ASSERT(!is_volatile_v<_Container>, "the target type must be cv-unqualified");
+        _STL_INTERNAL_STATIC_ASSERT(!is_const_v<_Container>);
+        _STL_INTERNAL_STATIC_ASSERT(!is_volatile_v<_Container>);
         _STL_INTERNAL_STATIC_ASSERT(!view<_Container>);
 
         template <input_range _Rng, class... _Types>
@@ -8444,8 +8444,8 @@ namespace ranges {
     _EXPORT_STD template <class _Container, class... _Types>
         requires (!view<_Container>)
     _NODISCARD constexpr auto to(_Types&&... _Args) {
-        static_assert(!is_const_v<_Container>, "the target type must be cv-unqualified");
-        static_assert(!is_volatile_v<_Container>, "the target type must be cv-unqualified");
+        static_assert(!is_const_v<_Container>, "C must not be const. (N4928 [range.utility.conv.adaptors])");
+        static_assert(!is_volatile_v<_Container>, "C must not be volatile. (N4928 [range.utility.conv.adaptors])");
         return _Range_closure<_To_class_fn<_Container>, decay_t<_Types>...>{_STD forward<_Types>(_Args)...};
     }
 

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -8399,15 +8399,11 @@ namespace ranges {
         }
     }
 
-    // clang-format off
-    template <class _Container>
-    concept _Is_cv_unqualified = !is_const_v<_Container> && !is_volatile_v<_Container>;
-    // clang-format on
-
-
     _EXPORT_STD template <class _Container, input_range _Rng, class... _Types>
-        requires (_Is_cv_unqualified<_Container> && !view<_Container>)
+        requires (!view<_Container>)
     _NODISCARD constexpr _Container to(_Rng&& _Range, _Types&&... _Args) {
+        static_assert(!is_const_v<_Container>, "the target type must be cv-unqualified");
+        static_assert(!is_volatile_v<_Container>, "the target type must be cv-unqualified");
         if constexpr (_Converts_direct_constructible<_Rng, _Container, _Types...>) {
             return _Container(_STD forward<_Rng>(_Range), _STD forward<_Types>(_Args)...);
         } else if constexpr (_Converts_tag_constructible<_Rng, _Container, _Types...>) {
@@ -8433,7 +8429,8 @@ namespace ranges {
 
     template <class _Container>
     struct _To_class_fn {
-        _STL_INTERNAL_STATIC_ASSERT(_Is_cv_unqualified<_Container>);
+        _STL_INTERNAL_STATIC_ASSERT(!is_const_v<_Container>, "the target type must be cv-unqualified");
+        _STL_INTERNAL_STATIC_ASSERT(!is_volatile_v<_Container>, "the target type must be cv-unqualified");
         _STL_INTERNAL_STATIC_ASSERT(!view<_Container>);
 
         template <input_range _Rng, class... _Types>
@@ -8445,8 +8442,10 @@ namespace ranges {
     };
 
     _EXPORT_STD template <class _Container, class... _Types>
-        requires (_Is_cv_unqualified<_Container> && !view<_Container>)
+        requires (!view<_Container>)
     _NODISCARD constexpr auto to(_Types&&... _Args) {
+        static_assert(!is_const_v<_Container>, "the target type must be cv-unqualified");
+        static_assert(!is_volatile_v<_Container>, "the target type must be cv-unqualified");
         return _Range_closure<_To_class_fn<_Container>, decay_t<_Types>...>{_STD forward<_Types>(_Args)...};
     }
 

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -8399,8 +8399,14 @@ namespace ranges {
         }
     }
 
+    // clang-format off
+    template <class _Container>
+    concept _Is_cv_unqualified = !is_const_v<_Container> && !is_volatile_v<_Container>;
+    // clang-format on
+
+
     _EXPORT_STD template <class _Container, input_range _Rng, class... _Types>
-        requires (!view<_Container>)
+        requires (_Is_cv_unqualified<_Container> && !view<_Container>)
     _NODISCARD constexpr _Container to(_Rng&& _Range, _Types&&... _Args) {
         if constexpr (_Converts_direct_constructible<_Rng, _Container, _Types...>) {
             return _Container(_STD forward<_Rng>(_Range), _STD forward<_Types>(_Args)...);
@@ -8427,6 +8433,7 @@ namespace ranges {
 
     template <class _Container>
     struct _To_class_fn {
+        _STL_INTERNAL_STATIC_ASSERT(_Is_cv_unqualified<_Container>);
         _STL_INTERNAL_STATIC_ASSERT(!view<_Container>);
 
         template <input_range _Rng, class... _Types>
@@ -8438,7 +8445,7 @@ namespace ranges {
     };
 
     _EXPORT_STD template <class _Container, class... _Types>
-        requires (!view<_Container>)
+        requires (_Is_cv_unqualified<_Container> && !view<_Container>)
     _NODISCARD constexpr auto to(_Types&&... _Args) {
         return _Range_closure<_To_class_fn<_Container>, decay_t<_Types>...>{_STD forward<_Types>(_Args)...};
     }


### PR DESCRIPTION
Adds extra constraints on type_Container that it can't be cv-qualified
Fixes #3417

Note: This is just a best guess attempt at a solution. I'm expecting I missed somethings here and will need to update

<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
