### PR TITLE
LWG-3875: `ranges::repeat_view<T, IntegerClass>::iterator` may be ill-formed

### DIFF
--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -1389,9 +1389,13 @@ namespace ranges {
     } // namespace views
 
 #if _HAS_CXX23
+    template <class _Ty>
+    concept _Integer_like_with_usable_difference_type = _Signed_integer_like<_Ty>
+                                                     || (_Integer_like<_Ty> && weakly_incrementable<_Ty>);
+
     _EXPORT_STD template <move_constructible _Ty, semiregular _Bo = unreachable_sentinel_t>
         requires (is_object_v<_Ty> && same_as<_Ty, remove_cv_t<_Ty>>
-                  && (_Integer_like<_Bo> || same_as<_Bo, unreachable_sentinel_t>) )
+                  && (_Integer_like_with_usable_difference_type<_Bo> || same_as<_Bo, unreachable_sentinel_t>) )
     class repeat_view : public view_interface<repeat_view<_Ty, _Bo>> {
     private:
         friend views::_Take_fn;
@@ -1412,12 +1416,21 @@ namespace ranges {
                 }
             }
 
+            template <class _Uty>
+            struct _Difference_type {
+                using type = _Iota_diff_t<_Uty>;
+            };
+
+            template <_Signed_integer_like _Uty>
+            struct _Difference_type<_Uty> {
+                using type = _Uty;
+            };
+
         public:
             using iterator_concept  = random_access_iterator_tag;
             using iterator_category = random_access_iterator_tag;
             using value_type        = _Ty;
-            using difference_type =
-                conditional_t<_Signed_integer_like<_Index_type>, _Index_type, _Iota_diff_t<_Index_type>>;
+            using difference_type   = typename _Difference_type<_Index_type>::type;
 
             _Iterator() = default;
 

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -1393,6 +1393,16 @@ namespace ranges {
     concept _Integer_like_with_usable_difference_type = _Signed_integer_like<_Ty>
                                                      || (_Integer_like<_Ty> && weakly_incrementable<_Ty>);
 
+    template <class _Ty>
+    struct _Repeat_view_difference_type {
+        using type = _Iota_diff_t<_Ty>;
+    };
+
+    template <_Signed_integer_like _Ty>
+    struct _Repeat_view_difference_type<_Ty> {
+        using type = _Ty;
+    };
+
     _EXPORT_STD template <move_constructible _Ty, semiregular _Bo = unreachable_sentinel_t>
         requires (is_object_v<_Ty> && same_as<_Ty, remove_cv_t<_Ty>>
                   && (_Integer_like_with_usable_difference_type<_Bo> || same_as<_Bo, unreachable_sentinel_t>) )
@@ -1416,21 +1426,11 @@ namespace ranges {
                 }
             }
 
-            template <class _Uty>
-            struct _Difference_type {
-                using type = _Iota_diff_t<_Uty>;
-            };
-
-            template <_Signed_integer_like _Uty>
-            struct _Difference_type<_Uty> {
-                using type = _Uty;
-            };
-
         public:
             using iterator_concept  = random_access_iterator_tag;
             using iterator_category = random_access_iterator_tag;
             using value_type        = _Ty;
-            using difference_type   = typename _Difference_type<_Index_type>::type;
+            using difference_type   = typename _Repeat_view_difference_type<_Index_type>::type;
 
             _Iterator() = default;
 

--- a/tests/std/tests/P2474R2_views_repeat/test.cpp
+++ b/tests/std/tests/P2474R2_views_repeat/test.cpp
@@ -334,6 +334,7 @@ static_assert(
 
 // Check GH-3392
 static_assert(ranges::range<decltype(views::repeat('3', 100ull) | views::take(3))>);
+static_assert(ranges::range<decltype(views::repeat('3', 100ull) | views::drop(3))>);
 
 int main() {
     assert(test());

--- a/tests/std/tests/P2474R2_views_repeat/test.cpp
+++ b/tests/std/tests/P2474R2_views_repeat/test.cpp
@@ -325,6 +325,19 @@ constexpr bool test() {
     return true;
 }
 
+// Check LWG-3875
+static_assert(CanViewRepeat<string, long long>);
+static_assert(CanViewRepeat<string, unsigned long long>);
+static_assert(CanViewRepeat<string, _Signed128>);
+static_assert(
+    !CanViewRepeat<string, _Unsigned128>); // _Unsigned128 does not satisfy 'integer-like-with-usable-difference-type'
+
+void test_gh_3392() { // COMPILE-ONLY
+    const auto rice                        = views::repeat("🌾"s, 100ull);
+    [[maybe_unused]] const auto taken_rice = rice | views::take(3);
+    static_assert(ranges::range<decltype(taken_rice)>);
+}
+
 int main() {
     assert(test());
     static_assert(test());

--- a/tests/std/tests/P2474R2_views_repeat/test.cpp
+++ b/tests/std/tests/P2474R2_views_repeat/test.cpp
@@ -332,11 +332,8 @@ static_assert(CanViewRepeat<string, _Signed128>);
 static_assert(
     !CanViewRepeat<string, _Unsigned128>); // _Unsigned128 does not satisfy 'integer-like-with-usable-difference-type'
 
-void test_gh_3392() { // COMPILE-ONLY
-    const auto rice                        = views::repeat("🌾"s, 100ull);
-    [[maybe_unused]] const auto taken_rice = rice | views::take(3);
-    static_assert(ranges::range<decltype(taken_rice)>);
-}
+// Check GH-3392
+static_assert(ranges::range<decltype(views::repeat('3', 100ull) | views::take(3))>);
 
 int main() {
     assert(test());


### PR DESCRIPTION
Closes #3430.
Fixes #3392.