### PR TITLE
Finalize `modules.json` format

### DIFF
--- a/stl/modules/modules.json
+++ b/stl/modules/modules.json
@@ -2,13 +2,8 @@
     "version": 1,
     "revision": 0,
     "library": "microsoft/STL",
-    "modules": {
-        "std": {
-            "source": "std.ixx"
-        },
-        "std.compat": {
-            "source": "std.compat.ixx",
-            "requires": ["std"]
-        }
-    }
+    "module-sources": [
+        "std.ixx",
+        "std.compat.ixx"
+    ]
 }


### PR DESCRIPTION
@olgaark has requested that `modules.json` follow a new format before VS 2022 17.6 ships. This simply lists the source files for the Standard Library Modules in an array; the build system will discover what modules they provide, and their dependency relationship. As this has not yet shipped to users for General Availablity, the version number is still specified as 1.0.