### PR TITLE
fix codeql warnings

### DIFF
--- a/stl/inc/charconv
+++ b/stl/inc/charconv
@@ -444,13 +444,10 @@ _NODISCARD inline uint32_t _Bit_scan_reverse(const _Big_integer_flt& _Xval) noex
 
     const uint32_t _Bx = _Xval._Myused - 1;
 
-    _STL_INTERNAL_CHECK(_Xval._Mydata[_Bx] != 0); // _Big_integer_flt should always be trimmed
-
     unsigned long _Index; // Intentionally uninitialized for better codegen
 
-    // assumes _Xval._Mydata[_Bx] != 0
-    _BitScanReverse(
-        &_Index, _Xval._Mydata[_Bx]); // lgtm [cpp/conditionallyuninitializedvariable] _Xval._Mydata[_Bx] != 0
+    _STL_INTERNAL_CHECK(_Xval._Mydata[_Bx] != 0); // _Big_integer_flt should always be trimmed
+    _BitScanReverse(&_Index, _Xval._Mydata[_Bx]); // lgtm [cpp/conditionallyuninitializedvariable]
 
     return _Index + 1 + _Bx * _Big_integer_flt::_Element_bits;
 }

--- a/stl/inc/charconv
+++ b/stl/inc/charconv
@@ -448,7 +448,9 @@ _NODISCARD inline uint32_t _Bit_scan_reverse(const _Big_integer_flt& _Xval) noex
 
     unsigned long _Index; // Intentionally uninitialized for better codegen
 
-    _BitScanReverse(&_Index, _Xval._Mydata[_Bx]); // assumes _Xval._Mydata[_Bx] != 0
+    // assumes _Xval._Mydata[_Bx] != 0
+    _BitScanReverse(
+        &_Index, _Xval._Mydata[_Bx]); // lgtm [cpp/conditionallyuninitializedvariable] _Xval._Mydata[_Bx] != 0
 
     return _Index + 1 + _Bx * _Big_integer_flt::_Element_bits;
 }

--- a/stl/inc/system_error
+++ b/stl/inc/system_error
@@ -579,8 +579,8 @@ public:
             constexpr size_t _Unknown_error_length = sizeof(_Unknown_error) - 1; // TRANSITION, DevCom-906503
             return string{_Unknown_error, _Unknown_error_length};
         } else {
-            return string{_Msg._Str,
-                _Msg._Length}; // lgtm [cpp/uninitializedptrfield] _Msg._Length != 0 \implies _Msg._Str is initialized
+            _STL_INTERNAL_CHECK(_Msg._Str != nullptr);
+            return string{_Msg._Str, _Msg._Length}; // lgtm [cpp/uninitializedptrfield]
         }
     }
 

--- a/stl/inc/system_error
+++ b/stl/inc/system_error
@@ -579,7 +579,8 @@ public:
             constexpr size_t _Unknown_error_length = sizeof(_Unknown_error) - 1; // TRANSITION, DevCom-906503
             return string{_Unknown_error, _Unknown_error_length};
         } else {
-            return string{_Msg._Str, _Msg._Length};
+            return string{_Msg._Str,
+                _Msg._Length}; // lgtm [cpp/uninitializedptrfield] _Msg._Length != 0 \implies _Msg._Str is initialized
         }
     }
 


### PR DESCRIPTION
Same as #3478 but not from a microsoft/STL branch.

Link to internal codeql bugs:

* [VSO-1746341](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1746341)
* [VSO-1746390](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1746390)

I'm still not sure if we should have these, and I'm unsure how to test these changes.