### PR TITLE
Toolset update: VS 2022 17.6 Preview 1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.25)
-
-# TRANSITION, CMake-24249
-cmake_policy(SET CMP0141 OLD)
+cmake_minimum_required(VERSION 3.25.2)
 
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 project(msvc_standard_libraries LANGUAGES CXX)

--- a/README.md
+++ b/README.md
@@ -141,11 +141,11 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With The Visual Studio IDE
 
-1. Install Visual Studio 2022 17.5 Preview 6 or later.
+1. Install Visual Studio 2022 17.6 Preview 1 or later.
     * Select "Windows 11 SDK (10.0.22000.0)" in the VS Installer.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
-    * Otherwise, install [CMake][] 3.25 or later, and [Ninja][] 1.11.0 or later.
+    * Otherwise, install [CMake][] 3.25.2 or later, and [Ninja][] 1.11.0 or later.
     * We recommend selecting "Python 3 64-bit" in the VS Installer.
     * Otherwise, make sure [Python][] 3.9 or later is available to CMake.
 2. Open Visual Studio, and choose the "Clone or check out code" option. Enter the URL of this repository,
@@ -157,11 +157,11 @@ Just try to follow these rules, so we can spend more time fixing bugs and implem
 
 # How To Build With A Native Tools Command Prompt
 
-1. Install Visual Studio 2022 17.5 Preview 6 or later.
+1. Install Visual Studio 2022 17.6 Preview 1 or later.
     * Select "Windows 11 SDK (10.0.22000.0)" in the VS Installer.
     * We recommend selecting "C++ CMake tools for Windows" in the VS Installer.
     This will ensure that you're using supported versions of CMake and Ninja.
-    * Otherwise, install [CMake][] 3.25 or later, and [Ninja][] 1.11.0 or later.
+    * Otherwise, install [CMake][] 3.25.2 or later, and [Ninja][] 1.11.0 or later.
     * We recommend selecting "Python 3 64-bit" in the VS Installer.
     * Otherwise, make sure [Python][] 3.9 or later is available to CMake.
 2. Open a command prompt.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ variables:
   benchmarkBuildOutputLocation: 'D:\benchmark'
 
 pool:
-  name: 'StlBuild-2023-02-14T1520-Pool'
+  name: 'StlBuild-2023-02-21T1058-Pool'
   demands: EnableSpotVM -equals true
 
 pr:

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.25.2)
 project(msvc_standard_libraries_benchmarks LANGUAGES CXX)
 
 if(DEFINED STL_BINARY_DIR)

--- a/stl/CMakeLists.txt
+++ b/stl/CMakeLists.txt
@@ -492,10 +492,12 @@ set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "")
 # Toolset options must appear before add_library() for the options to take effect.
 add_compile_definitions(_CRTBLD _VCRT_ALLOW_INTERNALS _HAS_OLD_IOSTREAMS_MEMBERS=1 _STL_CONCRT_SUPPORT)
 
+# /Z7 for MSVC, /Zi for MASM
+set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT "Embedded")
+
 add_compile_options(/WX /Gy
-    "$<$<COMPILE_LANGUAGE:CXX>:/diagnostics:caret;/W4;/w14265;/w15038;/fastfail;/guard:cf;/Z7;/Zp8;/std:c++latest;/permissive-;/Zc:threadSafeInit-;/Zl>"
-    # note that /Zi generates debug info inside the object file, it's the same as /Z7 for msvc
-    "$<$<COMPILE_LANGUAGE:ASM_MASM>:/Zi;/W3;/nologo>"
+    "$<$<COMPILE_LANGUAGE:CXX>:/diagnostics:caret;/W4;/w14265;/w15038;/fastfail;/guard:cf;/Zp8;/std:c++latest;/permissive-;/Zc:threadSafeInit-;/Zl>"
+    "$<$<COMPILE_LANGUAGE:ASM_MASM>:/W3;/nologo>"
 )
 
 include_directories(BEFORE

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -615,8 +615,8 @@ struct has_unique_object_representations : bool_constant<__has_unique_object_rep
 _EXPORT_STD template <class _Ty>
 _INLINE_VAR constexpr bool has_unique_object_representations_v = __has_unique_object_representations(_Ty);
 
-// TRANSITION, Clang 16, VSO-1690654, and VS17.6p1
-#if defined(__clang__) || defined(__EDG__) || !defined(_MSVC_INTERNAL_TESTING)
+// TRANSITION, Clang 16 and VSO-1690654
+#if defined(__clang__) || defined(__EDG__)
 template <class _Ty>
 struct _Is_aggregate_impl : bool_constant<__is_aggregate(_Ty)> {};
 

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -829,8 +829,8 @@ _EMIT_STL_ERROR(STL1002, "Unexpected compiler version, expected CUDA 11.6 or new
 _EMIT_STL_ERROR(STL1000, "Unexpected compiler version, expected Clang 15.0.0 or newer.");
 #endif // ^^^ old Clang ^^^
 #elif defined(_MSC_VER)
-#if _MSC_VER < 1935 // Coarse-grained, not inspecting _MSC_FULL_VER
-_EMIT_STL_ERROR(STL1001, "Unexpected compiler version, expected MSVC 19.35 or newer.");
+#if _MSC_VER < 1936 // Coarse-grained, not inspecting _MSC_FULL_VER
+_EMIT_STL_ERROR(STL1001, "Unexpected compiler version, expected MSVC 19.36 or newer.");
 #endif // ^^^ old MSVC ^^^
 #else // vvv other compilers vvv
 // not attempting to detect other compilers

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -364,9 +364,6 @@ std/language.support/support.coroutines/end.to.end/go.pass.cpp:0 FAIL
 # DevCom-10026599: conditional expression has two different types
 std/concepts/concepts.compare/concept.equalitycomparable/equality_comparable_with.compile.pass.cpp:0 FAIL
 
-# DevCom-10165380: [ICE] constexpr evaluation confused by complicated use of string literals
-std/utilities/format/format.fmt.string/get.pass.cpp:0 FAIL
-
 # DevCom-10284753: Overload resolution is sometimes wrong for templated classes whose template argument are cv void
 std/utilities/function.objects/func.wrap/func.wrap.func/noncopyable_return_type.pass.cpp SKIPPED
 
@@ -647,9 +644,6 @@ std/containers/sequences/vector/vector.cons/assign_copy.pass.cpp FAIL
 std/utilities/meta/meta.unary/dependent_return_type.compile.pass.cpp SKIPPED
 std/utilities/format/format.functions/escaped_output.ascii.pass.cpp SKIPPED
 std/utilities/variant/variant.variant/implicit_ctad.pass.cpp SKIPPED
-
-# MoveOnlyForwardIterator (a misnomer) has mixed-type comparisons and conversions
-std/ranges/range.utility/range.subrange/primitives.pass.cpp:0 FAIL
 
 # libc++ speculatively implements LWG-3645
 std/strings/basic.string/string.capacity/resize_and_overwrite.pass.cpp FAIL

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.25.2)
 project(msvc_standard_libraries_tools LANGUAGES CXX)
 
 add_subdirectory(format)

--- a/tools/format/CMakeLists.txt
+++ b/tools/format/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.25.2)
 project(msvc_standard_libraries_format NONE)
 
 set(did_search OFF)

--- a/tools/validate/CMakeLists.txt
+++ b/tools/validate/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.25.2)
 project(msvc_standard_libraries_validate LANGUAGES CXX)
 
 add_executable(validate-binary validate.cpp)


### PR DESCRIPTION
* Updated dependencies.
  + Updated build compiler to VS 2022 17.6 Preview 1 (now required).
  + Updated CMake to 3.25.2 (now required).
* Removed compiler bug workarounds.
  + MSVC-PR-436582 updated C1XX's `__is_aggregate` for LWG-3823.
  + We can enable a couple of libcxx tests that were marked as FAILing for MSVC.
* CMake 3.25.2 fixed CMake-24249, so we can enable the [`CMP0141` policy](https://cmake.org/cmake/help/latest/policy/CMP0141.html).
  + Then, we need to set [`CMAKE_MSVC_DEBUG_INFORMATION_FORMAT`](https://cmake.org/cmake/help/latest/variable/CMAKE_MSVC_DEBUG_INFORMATION_FORMAT.html) to `Embedded`. This will pass the correct options to MSVC and MASM, avoiding `cl : Command line warning D9025 : overriding '/Zi' with '/Z7'`.