### PR TITLE
`<ranges>`: Fix misused list-initializations

### DIFF
--- a/stl/inc/iterator
+++ b/stl/inc/iterator
@@ -187,13 +187,13 @@ public:
     constexpr move_sentinel() = default;
 
     constexpr explicit move_sentinel(_Se _Val) noexcept(is_nothrow_move_constructible_v<_Se>) // strengthened
-        : _Last{_STD move(_Val)} {}
+        : _Last(_STD move(_Val)) {}
 
     template <class _Se2>
         requires convertible_to<const _Se2&, _Se>
     constexpr move_sentinel(const move_sentinel<_Se2>& _Val) noexcept(
         is_nothrow_constructible_v<_Se, const _Se2&>) // strengthened
-        : _Last{_Val._Get_last()} {}
+        : _Last(_Val._Get_last()) {}
 
     template <class _Se2>
         requires assignable_from<_Se&, const _Se2&>

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -5539,7 +5539,7 @@ namespace ranges {
             constexpr _Iterator(_Iterator<!_Const> _It) noexcept(
                 is_nothrow_constructible_v<iterator_t<_Base>, iterator_t<_Vw>>) // strengthened
                 requires _Const && convertible_to<iterator_t<_Vw>, iterator_t<_Base>>
-                : _Current{_STD move(_It._Current)} {}
+                : _Current(_STD move(_It._Current)) {}
 
             _NODISCARD constexpr const iterator_t<_Base>& base() const& noexcept {
                 return _Current;

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -2380,12 +2380,10 @@ namespace ranges {
 #endif // _ITERATOR_DEBUG_LEVEL != 0
             }
 
-            // clang-format off
-            constexpr _Iterator(_Iterator<!_Const> _It)
-                noexcept(is_nothrow_constructible_v<iterator_t<_Base>, iterator_t<_Vw>>) // strengthened
+            constexpr _Iterator(_Iterator<!_Const> _It) noexcept(
+                is_nothrow_constructible_v<iterator_t<_Base>, iterator_t<_Vw>>) // strengthened
                 requires _Const && convertible_to<iterator_t<_Vw>, iterator_t<_Base>>
-                : _Current{_STD move(_It._Current)}, _Parent{_It._Parent} {}
-            // clang-format on
+                : _Current(_STD move(_It._Current)), _Parent(_It._Parent) {}
 
             _NODISCARD constexpr const iterator_t<_Base>& base() const& noexcept {
                 return _Current;

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -3692,7 +3692,7 @@ namespace ranges {
             constexpr _Iterator(_Iterator<!_Const> _It)
                 requires _Const && convertible_to<iterator_t<_Vw>, _OuterIter>
                           && convertible_to<iterator_t<_InnerRng<false>>, _InnerIter>
-                : _Outer{_STD move(_It._Outer)}, _Inner{_STD move(_It._Inner)}, _Parent{_It._Parent} {}
+                : _Outer(_STD move(_It._Outer)), _Inner(_STD move(_It._Inner)), _Parent(_It._Parent) {}
 
             _NODISCARD constexpr decltype(auto) operator*() const noexcept(noexcept(**_Inner)) /* strengthened */ {
 #if _ITERATOR_DEBUG_LEVEL != 0

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -4018,7 +4018,7 @@ namespace ranges {
             _Variantish<_PatternIter, _InnerIter> _Inner_it{};
 
             constexpr _Iterator(_Parent_t& _Parent_, iterator_t<_Base> _Outer_)
-                : _Parent{_STD addressof(_Parent_)}, _Outer_it{_STD move(_Outer_)} {
+                : _Parent(_STD addressof(_Parent_)), _Outer_it(_STD move(_Outer_)) {
                 if (_Outer_it != _RANGES end(_Parent->_Range)) {
                     auto&& _Inner = _Update_inner();
                     _Inner_it._Emplace_second(_RANGES begin(_Inner));
@@ -4102,7 +4102,7 @@ namespace ranges {
                           && convertible_to<iterator_t<_Vw>, _OuterIter> //
                           && convertible_to<iterator_t<_InnerRng<false>>, _InnerIter> //
                           && convertible_to<iterator_t<_Pat>, _PatternIter> //
-                : _Outer_it(_STD move(_It._Outer_it)), _Parent(_It._Parent) {
+                : _Parent(_It._Parent), _Outer_it(_STD move(_It._Outer_it)) {
                 switch (_It._Inner_it._Contains) {
                 case _Variantish_state::_Holds_first:
                     _Inner_it._Emplace_first(_STD move(_It._Inner_it._First));

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -4102,7 +4102,7 @@ namespace ranges {
                           && convertible_to<iterator_t<_Vw>, _OuterIter> //
                           && convertible_to<iterator_t<_InnerRng<false>>, _InnerIter> //
                           && convertible_to<iterator_t<_Pat>, _PatternIter> //
-                : _Outer_it{_STD move(_It._Outer_it)}, _Parent{_It._Parent} {
+                : _Outer_it(_STD move(_It._Outer_it)), _Parent(_It._Parent) {
                 switch (_It._Inner_it._Contains) {
                 case _Variantish_state::_Holds_first:
                     _Inner_it._Emplace_first(_STD move(_It._Inner_it._First));
@@ -4292,7 +4292,7 @@ namespace ranges {
             constexpr _Sentinel(_Sentinel<!_Const> _Se) noexcept(
                 is_nothrow_constructible_v<sentinel_t<_Base>, sentinel_t<_Vw>>) // strengthened
                 requires _Const && convertible_to<sentinel_t<_Vw>, sentinel_t<_Base>>
-                : _Last{_STD move(_Se._Last)} {}
+                : _Last(_STD move(_Se._Last)) {}
 
             template <bool _OtherConst>
                 requires sentinel_for<sentinel_t<_Base>, iterator_t<_Maybe_const<_OtherConst, _Vw>>>

--- a/tests/std/include/range_algorithm_support.hpp
+++ b/tests/std/include/range_algorithm_support.hpp
@@ -403,7 +403,7 @@ namespace test {
         template <class U>
         init_list_not_constructible_iterator(std::initializer_list<U>) = delete;
 
-        T operator*() const; // not defined
+        T& operator*() const; // not defined
         init_list_not_constructible_iterator& operator++(); // not defined
         init_list_not_constructible_iterator operator++(int); // not defined
 

--- a/tests/std/include/range_algorithm_support.hpp
+++ b/tests/std/include/range_algorithm_support.hpp
@@ -383,6 +383,37 @@ struct std::basic_common_reference<::test::proxy_reference<Cat1, Elem1>, ::test:
 };
 
 namespace test {
+    template <class T>
+    struct init_list_not_constructible_sentinel {
+        init_list_not_constructible_sentinel() = default;
+        init_list_not_constructible_sentinel(T*) {}
+
+        template <class U>
+        init_list_not_constructible_sentinel(std::initializer_list<U>) = delete;
+    };
+
+    template <class T>
+    struct init_list_not_constructible_iterator {
+        using difference_type = int;
+        using value_type      = T;
+
+        init_list_not_constructible_iterator() = default;
+        init_list_not_constructible_iterator(T*) {}
+
+        template <class U>
+        init_list_not_constructible_iterator(std::initializer_list<U>) = delete;
+
+        T operator*() const; // not defined
+        init_list_not_constructible_iterator& operator++(); // not defined
+        init_list_not_constructible_iterator operator++(int); // not defined
+
+        bool operator==(init_list_not_constructible_sentinel<T>) const; // not defined
+    };
+
+    static_assert(std::input_iterator<init_list_not_constructible_iterator<int>>);
+    static_assert(
+        std::sentinel_for<init_list_not_constructible_sentinel<int>, init_list_not_constructible_iterator<int>>);
+
     template <class Category, class Element,
         // Model sized_sentinel_for along with sentinel?
         CanDifference Diff = CanDifference{derived_from<Category, random>},

--- a/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
@@ -11,12 +11,11 @@
 #include <utility>
 #include <vector>
 
+#include <range_algorithm_support.hpp>
+
 #define STATIC_ASSERT(...) static_assert(__VA_ARGS__, #__VA_ARGS__)
 
 namespace ranges = std::ranges;
-
-template <class>
-inline constexpr bool always_false = false;
 
 template <class T>
 using reference_to = T&;
@@ -3447,6 +3446,15 @@ namespace move_iterator_test {
         !has_greater_eq<move_iterator<simple_random_iter<sentinel_base>>, move_sentinel<std::default_sentinel_t>>);
     STATIC_ASSERT(!three_way_comparable<move_iterator<simple_random_iter<sentinel_base>>,
                   move_sentinel<std::default_sentinel_t>>);
+
+    void test_gh_3014() { // COMPILE-ONLY
+        using S = test::init_list_not_constructible_sentinel<int>;
+        S s;
+        [[maybe_unused]] move_sentinel<S> y{s}; // Check 'move_sentinel(S s)'
+
+        move_sentinel<int*> s2;
+        [[maybe_unused]] move_sentinel<S> z{s2}; // Check 'move_sentinel(const move_sentinel<S2>& s2)'
+    }
 
     constexpr bool test() {
         // Validate iter_move

--- a/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
@@ -13,10 +13,6 @@
 
 #include <range_algorithm_support.hpp>
 
-#define STATIC_ASSERT(...) static_assert(__VA_ARGS__, #__VA_ARGS__)
-
-namespace ranges = std::ranges;
-
 template <class T>
 using reference_to = T&;
 template <class T>

--- a/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
@@ -3447,6 +3447,7 @@ namespace move_iterator_test {
     STATIC_ASSERT(!three_way_comparable<move_iterator<simple_random_iter<sentinel_base>>,
                   move_sentinel<std::default_sentinel_t>>);
 
+    // GH-3014 "<ranges>: list-initialization is misused"
     void test_gh_3014() { // COMPILE-ONLY
         using S = test::init_list_not_constructible_sentinel<int>;
         S s;

--- a/tests/std/tests/P0896R4_views_elements/test.cpp
+++ b/tests/std/tests/P0896R4_views_elements/test.cpp
@@ -394,6 +394,27 @@ constexpr void instantiation_test() {
 #endif // TEST_EVERYTHING
 }
 
+// GH-3014 "<ranges>: list-initialization is misused"
+void test_gh_3014() { // COMPILE-ONLY
+    using P = pair<int, int>;
+    struct InRange {
+        P* begin() {
+            return nullptr;
+        }
+
+        test::init_list_not_constructible_iterator<P> begin() const {
+            return nullptr;
+        }
+
+        unreachable_sentinel_t end() const {
+            return {};
+        }
+    };
+
+    auto r                                           = InRange{} | views::elements<0>;
+    [[maybe_unused]] decltype(as_const(r).begin()) i = r.begin(); // Check 'iterator(iterator<!Const> i)'
+}
+
 int main() {
     { // Validate copyable views
         constexpr span<const P> s{some_pairs};

--- a/tests/std/tests/P0896R4_views_elements/test.cpp
+++ b/tests/std/tests/P0896R4_views_elements/test.cpp
@@ -396,7 +396,6 @@ constexpr void instantiation_test() {
 
 // GH-3014 "<ranges>: list-initialization is misused"
 void test_gh_3014() { // COMPILE-ONLY
-    using P = pair<int, int>;
     struct InRange {
         P* begin() {
             return nullptr;

--- a/tests/std/tests/P0896R4_views_join/test.cpp
+++ b/tests/std/tests/P0896R4_views_join/test.cpp
@@ -503,6 +503,26 @@ void test_non_trivially_destructible_type() { // COMPILE-ONLY
     auto r2 = views::empty<Inner> | views::transform([](Inner& r) { return r; }) | views::join;
 }
 
+// GH-3014 "<ranges>: list-initialization is misused"
+void test_gh_3014() { // COMPILE-ONLY
+    struct InRange {
+        string* begin() {
+            return nullptr;
+        }
+
+        test::init_list_not_constructible_iterator<string> begin() const {
+            return nullptr;
+        }
+
+        unreachable_sentinel_t end() const {
+            return {};
+        }
+    };
+
+    auto r                                           = InRange{} | views::join;
+    [[maybe_unused]] decltype(as_const(r).begin()) i = r.begin(); // Check 'iterator(iterator<!Const> i)'
+}
+
 int main() {
     // Validate views
     constexpr string_view expected = "Hello World!"sv;

--- a/tests/std/tests/P0896R4_views_transform/test.cpp
+++ b/tests/std/tests/P0896R4_views_transform/test.cpp
@@ -811,6 +811,26 @@ void test_gh_1709() {
     }
 }
 
+// GH-3014 "<ranges>: list-initialization is misused"
+void test_gh_3014() { // COMPILE-ONLY
+    struct InRange {
+        int* begin() {
+            return nullptr;
+        }
+
+        test::init_list_not_constructible_iterator<int> begin() const {
+            return nullptr;
+        }
+
+        unreachable_sentinel_t end() const {
+            return {};
+        }
+    };
+
+    auto r                                           = InRange{} | views::transform(identity{});
+    [[maybe_unused]] decltype(as_const(r).begin()) i = r.begin(); // Check 'iterator(iterator<!Const> i)'
+}
+
 int main() {
     { // Validate copyable views
         constexpr span<const int> s{some_ints};

--- a/tests/std/tests/P2441R2_views_join_with/test.cpp
+++ b/tests/std/tests/P2441R2_views_join_with/test.cpp
@@ -558,6 +558,41 @@ void test_valueless_iterator() {
     }
 }
 
+// GH-3014 "<ranges>: list-initialization is misused"
+struct FakeStr {
+    const char* begin() {
+        return nullptr;
+    }
+
+    unreachable_sentinel_t end() {
+        return {};
+    }
+};
+
+void test_gh_3014() { // COMPILE-ONLY
+    struct InRange {
+        FakeStr* begin() {
+            return nullptr;
+        }
+
+        test::init_list_not_constructible_iterator<FakeStr> begin() const {
+            return nullptr;
+        }
+
+        FakeStr* end() {
+            return nullptr;
+        }
+
+        test::init_list_not_constructible_sentinel<FakeStr> end() const {
+            return nullptr;
+        }
+    };
+
+    auto r                                           = InRange{} | views::join_with('-');
+    [[maybe_unused]] decltype(as_const(r).begin()) i = r.begin(); // Check 'iterator(iterator<!Const> i)'
+    [[maybe_unused]] decltype(as_const(r).end()) s   = r.end(); // Check 'sentinel(sentinel<!Const> s)'
+}
+
 int main() {
     {
         auto filtered_and_joined =


### PR DESCRIPTION
Fixes #3014.

Library parts affected by this issue:
* `move_sentinel<S>` (two constructors),
* `transform_view<R, F>::_Iterator`,
* `join_view<R>::_Iterator`,
* `join_with_view<R, P>::_Iterator` (two constructors),
* `join_with_view<R, P>::_Sentinel`
* `elements_view<R, N>::_Iterator`.