### PR TITLE
Implement LWG-3733 `ranges::to` misuses `cpp17-input-iterator`

### DIFF
--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -8388,7 +8388,8 @@ namespace ranges {
     template <class _Rng, class _Container, class... _Types>
     concept _Converts_and_common_constructible =
         _Ref_converts<_Rng, _Container> && common_range<_Rng> //
-        && _Cpp17_input_iterator<iterator_t<_Rng>> //
+        && requires { typename iterator_traits<iterator_t<_Rng>>::iterator_category; }
+        && derived_from<typename iterator_traits<iterator_t<_Rng>>::iterator_category, input_iterator_tag>
         && constructible_from<_Container, iterator_t<_Rng>, iterator_t<_Rng>, _Types...>;
 
     template <class _Container, class _Reference>

--- a/tests/std/tests/P1206R7_ranges_to_misc/test.cpp
+++ b/tests/std/tests/P1206R7_ranges_to_misc/test.cpp
@@ -137,6 +137,27 @@ constexpr bool test_nested_range() {
     return true;
 }
 
+struct ContainerLike {
+    template <std::input_iterator Iter>
+    constexpr ContainerLike(Iter first, Iter last) : dist(static_cast<std::ptrdiff_t>(ranges::distance(first, last))) {}
+
+    constexpr char* begin() {
+        return nullptr;
+    }
+    constexpr char* end() {
+        return nullptr;
+    }
+
+    std::ptrdiff_t dist;
+};
+
+constexpr bool test_lwg3733() {
+    auto nul_termination = std::views::take_while([](char ch) { return ch != '\0'; });
+    auto c               = nul_termination("1729") | std::views::common | ranges::to<ContainerLike>();
+    assert(c.dist == 4);
+    return true;
+}
+
 constexpr bool test_lwg3785() {
     std::vector<int> vec{42, 1729};
 
@@ -170,6 +191,9 @@ int main() {
 #if defined(__clang__) || defined(__EDG__) // TRANSITION, VSO-1588614
     static_assert(test_nested_range());
 #endif // defined(__clang__) || defined(__EDG__)
+
+    test_lwg3733();
+    static_assert(test_lwg3733());
 
     test_lwg3785();
     static_assert(test_lwg3785());


### PR DESCRIPTION
Fixes #3422.