### PR TITLE
Avoid new warning C5267 for deprecated implicit copy ctor/assign

### DIFF
--- a/stl/inc/bitset
+++ b/stl/inc/bitset
@@ -32,7 +32,7 @@ public:
         friend bitset<_Bits>;
 
     public:
-        _CONSTEXPR23 reference(const reference&) noexcept = default;
+        _CONSTEXPR23 reference(const reference&) = default;
 
         _CONSTEXPR23 ~reference() noexcept {} // TRANSITION, ABI
 
@@ -46,17 +46,17 @@ public:
             return *this;
         }
 
-        _CONSTEXPR23 reference& flip() noexcept {
-            _Pbitset->_Flip_unchecked(_Mypos);
-            return *this;
-        }
-
         _NODISCARD _CONSTEXPR23 bool operator~() const noexcept {
             return !_Pbitset->_Subscript(_Mypos);
         }
 
         _CONSTEXPR23 operator bool() const noexcept {
             return _Pbitset->_Subscript(_Mypos);
+        }
+
+        _CONSTEXPR23 reference& flip() noexcept {
+            _Pbitset->_Flip_unchecked(_Mypos);
+            return *this;
         }
 
     private:

--- a/stl/inc/bitset
+++ b/stl/inc/bitset
@@ -32,6 +32,8 @@ public:
         friend bitset<_Bits>;
 
     public:
+        _CONSTEXPR23 reference(const reference&) noexcept = default;
+
         _CONSTEXPR23 ~reference() noexcept {} // TRANSITION, ABI
 
         _CONSTEXPR23 reference& operator=(const bool _Val) noexcept {

--- a/tests/std/tests/Dev08_576265_list_remove/test.cpp
+++ b/tests/std/tests/Dev08_576265_list_remove/test.cpp
@@ -9,6 +9,8 @@ struct Val {
     unsigned int canary;
     Val() : value(0), canary(0xDEADBEEF) {}
     Val(int val) : value(val), canary(0x600DF00D) {}
+    Val(const Val&)            = default;
+    Val& operator=(const Val&) = default;
     ~Val() {
         canary = 0xDEADBEEF;
     }

--- a/tests/std/tests/Dev11_0437519_container_behavior/test.cpp
+++ b/tests/std/tests/Dev11_0437519_container_behavior/test.cpp
@@ -23,6 +23,8 @@ void assert_forward_list_resize_empty() {
 
 struct A {
     A(unsigned int value) : _value(value) {}
+    A(const A&)            = default;
+    A& operator=(const A&) = default;
     ~A() {
         _value = 0;
     }

--- a/tests/std/tests/GH_002488_promise_not_default_constructible_types/test.cpp
+++ b/tests/std/tests/GH_002488_promise_not_default_constructible_types/test.cpp
@@ -22,6 +22,7 @@ struct has_default {
     has_default(const has_default& v) : x(v.x) {
         ++has_default_objects;
     }
+    has_default& operator=(const has_default&) = default;
 
     ~has_default() {
         --has_default_objects;
@@ -38,6 +39,7 @@ struct no_default {
     no_default(const no_default& v) : x(v.x) {
         ++no_default_objects;
     }
+    no_default& operator=(const no_default&) = default;
 
     ~no_default() {
         --no_default_objects;

--- a/tests/std/tests/P0220R1_any/test.cpp
+++ b/tests/std/tests/P0220R1_any/test.cpp
@@ -1211,6 +1211,8 @@ namespace modifiers::emplace {
 struct Tracked {
   static int count;
   Tracked()  {++count;}
+  Tracked(const Tracked&) noexcept {++count;}
+  Tracked& operator=(const Tracked&) = default;
   ~Tracked() { --count; }
 };
 int Tracked::count = 0;
@@ -2976,6 +2978,10 @@ namespace msvc {
             Tracked() {
                 ++count;
             }
+            Tracked(const Tracked&) noexcept {
+                ++count;
+            }
+            Tracked& operator=(const Tracked&) = default;
             ~Tracked() {
                 --count;
             }

--- a/tests/std/tests/P0220R1_any/test.cpp
+++ b/tests/std/tests/P0220R1_any/test.cpp
@@ -1211,8 +1211,8 @@ namespace modifiers::emplace {
 struct Tracked {
   static int count;
   Tracked()  {++count;}
-  Tracked(const Tracked&) noexcept {++count;}
-  Tracked& operator=(const Tracked&) = default;
+  Tracked(Tracked const&) noexcept {++count;}
+  Tracked& operator=(Tracked const&) = default;
   ~Tracked() { --count; }
 };
 int Tracked::count = 0;
@@ -2978,10 +2978,10 @@ namespace msvc {
             Tracked() {
                 ++count;
             }
-            Tracked(const Tracked&) noexcept {
+            Tracked(Tracked const&) noexcept {
                 ++count;
             }
-            Tracked& operator=(const Tracked&) = default;
+            Tracked& operator=(Tracked const&) = default;
             ~Tracked() {
                 --count;
             }

--- a/tests/std/tests/P0220R1_optional/test.cpp
+++ b/tests/std/tests/P0220R1_optional/test.cpp
@@ -2372,6 +2372,8 @@ public:
     static bool dtor_called;
     Y() = default;
     Y(int) { TEST_THROW(6);}
+    Y(const Y&) = default;
+    Y& operator=(const Y&) = default;
     ~Y() {dtor_called = true;}
 };
 
@@ -2659,6 +2661,8 @@ public:
     constexpr X(int i, bool& dtor_called) : i_(i), dtor_called_(&dtor_called) {}
     constexpr X(std::initializer_list<int> il, bool& dtor_called)
     : i_(il.begin()[0]), j_(il.begin()[1]), dtor_called_(&dtor_called) {}
+    X(const X&) = default;
+    X& operator=(const X&) = default;
     TEST_CONSTEXPR_CXX20 ~X() {*dtor_called_ = true;}
 
     friend constexpr bool operator==(const X& x, const X& y)
@@ -2688,6 +2692,8 @@ public:
     Z(int i) : i_(i) {}
     Z(std::initializer_list<int> il) : i_(il.begin()[0]), j_(il.begin()[1])
         { TEST_THROW(6);}
+    Z(const Z&) = default;
+    Z& operator=(const Z&) = default;
     ~Z() {dtor_called = true;}
 
     friend bool operator==(const Z& x, const Z& y)
@@ -5336,6 +5342,8 @@ class X
 public:
     static bool dtor_called;
     X() = default;
+    X(const X&) = default;
+    X& operator=(const X&) = default;
     ~X() {dtor_called = true;}
 };
 
@@ -5401,6 +5409,9 @@ using std::optional;
 struct X
 {
     static bool dtor_called;
+    X() = default;
+    X(const X&) = default;
+    X& operator=(const X&) = default;
     ~X() {dtor_called = true;}
 };
 

--- a/tests/std/tests/P0608R3_improved_variant_converting_constructor/test.cpp
+++ b/tests/std/tests/P0608R3_improved_variant_converting_constructor/test.cpp
@@ -21,7 +21,6 @@ struct double_double {
 };
 struct convertible_bool {
     convertible_bool(bool x) : x_(x) {}
-    ~convertible_bool() = default;
 
     operator bool() const noexcept {
         return x_;

--- a/tests/std/tests/P0674R1_make_shared_for_arrays/test.cpp
+++ b/tests/std/tests/P0674R1_make_shared_for_arrays/test.cpp
@@ -643,6 +643,10 @@ struct WeirdDeleter {
         delete ptr;
     }
 
+    WeirdDeleter()                               = default;
+    WeirdDeleter(const WeirdDeleter&)            = default;
+    WeirdDeleter& operator=(const WeirdDeleter&) = default;
+
     ~WeirdDeleter() noexcept(false) {}
 };
 static_assert(!is_nothrow_destructible_v<WeirdDeleter<int>>);

--- a/tests/std/tests/P0784R7_library_support_for_more_constexpr_containers/test.cpp
+++ b/tests/std/tests/P0784R7_library_support_for_more_constexpr_containers/test.cpp
@@ -263,8 +263,10 @@ template <class T>
 struct A {
     T value;
 
-    constexpr A() noexcept = default;
-    constexpr ~A()         = default;
+    constexpr A() noexcept                    = default;
+    constexpr A(const A&) noexcept            = default;
+    constexpr A& operator=(const A&) noexcept = default;
+    constexpr ~A()                            = default;
 };
 
 template <class T>
@@ -272,6 +274,8 @@ struct nontrivial_A {
     T value;
 
     constexpr nontrivial_A(T in = T{}) noexcept : value(in) {}
+    constexpr nontrivial_A(const nontrivial_A&) noexcept            = default;
+    constexpr nontrivial_A& operator=(const nontrivial_A&) noexcept = default;
     constexpr ~nontrivial_A() {}
 };
 

--- a/tests/std/tests/P0896R4_views_join/test.cpp
+++ b/tests/std/tests/P0896R4_views_join/test.cpp
@@ -477,6 +477,13 @@ void test_non_trivially_destructible_type() { // COMPILE-ONLY
         using difference_type = int;
         using value_type      = int;
 
+        // Provide some way to construct this type.
+        non_trivially_destructible_input_iterator(double, double) {}
+
+        non_trivially_destructible_input_iterator(const non_trivially_destructible_input_iterator&) = default;
+        non_trivially_destructible_input_iterator& operator=(
+            const non_trivially_destructible_input_iterator&) = default;
+
         ~non_trivially_destructible_input_iterator() {}
 
         // To test the correct specialization of _Defaultabox, this type must not be default constructible.

--- a/tests/std/tests/P2231R1_complete_constexpr_optional_variant/test.cpp
+++ b/tests/std/tests/P2231R1_complete_constexpr_optional_variant/test.cpp
@@ -24,6 +24,8 @@ struct With_nontrivial_destructor {
     int _val = 0;
     constexpr With_nontrivial_destructor(const int val) noexcept : _val(val) {}
     constexpr With_nontrivial_destructor(initializer_list<int> vals) noexcept : _val(*vals.begin()) {}
+    With_nontrivial_destructor(const With_nontrivial_destructor&)            = default;
+    With_nontrivial_destructor& operator=(const With_nontrivial_destructor&) = default;
     constexpr ~With_nontrivial_destructor() {}
 
     constexpr bool operator==(const int right) const noexcept {


### PR DESCRIPTION
@JonCavesMSFT just implemented a new off-by-default warning for VS 2022 17.7 Preview 1 (internal MSVC-PR-452406) that some internal teams are very interested in using. This warns about the deprecated case in WG21-N4928 [\[class.copy.ctor\]/6](https://eel.is/c++draft/class.copy.ctor#6) (emphasis mine):

> If the class definition does not explicitly declare a copy constructor, a non-explicit one is declared implicitly. If the class definition declares a move constructor or move assignment operator, the implicitly declared copy constructor is defined as deleted; otherwise, it is defaulted (9.5). **The latter case is deprecated** if the class has a user-declared copy assignment operator or a user-declared destructor (D.8).

and [\[class.copy.assign\]/2](https://eel.is/c++draft/class.copy.assign#2) (emphasis mine):

> If the class definition does not explicitly declare a copy assignment operator, one is declared implicitly. If the class definition declares a move constructor or move assignment operator, the implicitly declared copy assignment operator is defined as deleted; otherwise, it is defaulted (9.5). **The latter case is deprecated** if the class has a user-declared copy constructor or a user-declared destructor (D.8).

The warning (which uses the same number for copy ctors and copy assigns) looks like:

```    
warning C5267: definition of implicit copy constructor for 'X' is deprecated because it has a user-provided destructor
warning C5267: definition of implicit assignment operator for 'X' is deprecated because it has a user-provided copy constructor
```

We can't enable the warning until 17.7 Preview 1 ships, but we can clean up the product and test code now. (When we enable the warning, the proper places to do so will likely be `tests/std/tests/prefix.lst` and `tests/tr1/prefix.lst`, unless `libcxx` receives numerous cleanups, in which case `tests/universal_prefix.lst` will be the place.)

I have filed VSO-1753270 "`/clr` C++20 `alignas` with defaulted SMFs emits fatal error C1193: an error expected in ...\yyaction.cpp(2976) not reached", which prevents one type from being cleaned up here (`aligned_type` in `P0220R1_any`).

### Notes

* `bitset`
  + This is the only affected product code that I found.
  + Copy ctors are ABI-relevant (did you ever hear the tragedy of Darth `tuple<>` The Wise?). However, this should be ABI-safe because the copy ctor is being defaulted and therefore remains trivial.
  + I marked this as `_CONSTEXPR23` to match the WP. (It is implicitly `noexcept`.)
  + One unrelated cleanup affecting nearby but different code: move `reference::flip` to match the WP's order.
* `P0220R1_any`
  + I've chosen to user-provide copy ctors that increment `count`, to keep it balanced with the destructor. They must be marked `noexcept` so that these types remain eligible for `any`'s Small Object Optimization: https://github.com/microsoft/STL/blob/86acfb1ac279a1e97c5b600d344dca36cc897bf4/stl/inc/any#L51-L53
* `P0220R1_optional`
  + The last `X` also needs a defaulted default ctor (otherwise the defaulted copy ctor will suppress it).
* `P0608R3_improved_variant_converting_constructor`
  + `convertible_bool` didn't need a defaulted destructor at all, so I have simply dropped it.
* `P0674R1_make_shared_for_arrays`
  + Similarly, `WeirdDeleter` needs a defaulted default ctor.
* `P0784R7_library_support_for_more_constexpr_containers`
  + I've chosen to mark these defaulted functions as `constexpr` and `noexcept` for local consistency, although I could be persuaded otherwise.
* `P0896R4_views_join`
  + I noticed that `non_trivially_destructible_input_iterator` didn't have any way to construct a fresh object (it intentionally deletes its default ctor below). I've seen compilers warn about that, so it seems prudent to introduce a hypothetical ctor, which I've commented.
