### PR TITLE
Implement P0009R18 `<mdspan>`

### DIFF
--- a/stl/CMakeLists.txt
+++ b/stl/CMakeLists.txt
@@ -170,6 +170,7 @@ set(HEADERS
     ${CMAKE_CURRENT_LIST_DIR}/inc/list
     ${CMAKE_CURRENT_LIST_DIR}/inc/locale
     ${CMAKE_CURRENT_LIST_DIR}/inc/map
+    ${CMAKE_CURRENT_LIST_DIR}/inc/mdspan
     ${CMAKE_CURRENT_LIST_DIR}/inc/memory
     ${CMAKE_CURRENT_LIST_DIR}/inc/memory_resource
     ${CMAKE_CURRENT_LIST_DIR}/inc/mutex

--- a/stl/inc/__msvc_all_public_headers.hpp
+++ b/stl/inc/__msvc_all_public_headers.hpp
@@ -106,6 +106,7 @@
 #include <list>
 #include <locale>
 #include <map>
+#include <mdspan>
 #include <memory>
 #include <memory_resource>
 #include <new>

--- a/stl/inc/header-units.json
+++ b/stl/inc/header-units.json
@@ -80,6 +80,7 @@
         "list",
         "locale",
         "map",
+        "mdspan",
         "memory",
         "memory_resource",
         "mutex",

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -1,0 +1,899 @@
+// mdspan standard header
+
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#pragma once
+#ifndef _MDSPAN_
+#define _MDSPAN_
+#include <yvals.h>
+#if _STL_COMPILER_PREPROCESSOR
+#if !_HAS_CXX23
+_EMIT_STL_WARNING(STL4038, "The contents of <mdspan> are available only with C++23 or later.");
+#else // ^^^ !_HAS_CXX23 / _HAS_CXX23 vvv
+#include <algorithm>
+#include <array>
+#include <span>
+#include <tuple>
+#include <type_traits>
+
+#pragma pack(push, _CRT_PACKING)
+#pragma warning(push, _STL_WARNING_LEVEL)
+#pragma warning(disable : _STL_DISABLED_WARNINGS)
+_STL_DISABLE_CLANG_WARNINGS
+#pragma push_macro("new")
+#undef new
+
+_STD_BEGIN
+
+template <class _IndexType, size_t _Rank_dynamic, size_t... _Extents>
+struct _Mdspan_extent_type {
+    using index_type = _IndexType;
+
+    index_type _Dynamic_extents[_Rank_dynamic]                           = {};
+    static constexpr size_t _Static_extents[sizeof...(_Extents)]         = {_Extents...};
+    static constexpr array<size_t, sizeof...(_Extents)> _Dynamic_indexes = []() constexpr {
+        array<size_t, sizeof...(_Extents)> result;
+        size_t _Counter = 0;
+        for (size_t i = 0; i < sizeof...(_Extents); ++i) {
+            result[i] = _Counter;
+            if (_Static_extents[i] == dynamic_extent) {
+                ++_Counter;
+            }
+        }
+        return result;
+    }();
+
+    constexpr _Mdspan_extent_type() noexcept = default;
+
+    template <class... _OtherIndexTypes,
+        enable_if_t<sizeof...(_OtherIndexTypes) == _Rank_dynamic && (is_same_v<_OtherIndexTypes, index_type> && ...),
+            int> = 0>
+    constexpr _Mdspan_extent_type(_OtherIndexTypes... _OtherExtents) noexcept : _Dynamic_extents{_OtherExtents...} {}
+
+    template <class _OtherIndexType, size_t _Size, size_t... _Idx, enable_if_t<_Size == _Rank_dynamic, int> = 0>
+    constexpr _Mdspan_extent_type(span<_OtherIndexType, _Size> _Data, index_sequence<_Idx...>) noexcept
+        : _Dynamic_extents{static_cast<index_type>(_STD as_const(_Data[_Idx]))...} {}
+
+
+    template <class... _OtherIndexTypes,
+        enable_if_t<sizeof...(_OtherIndexTypes) == sizeof...(_Extents) && sizeof...(_Extents) != _Rank_dynamic
+                        && (is_same_v<_OtherIndexTypes, index_type> && ...),
+            int> = 0>
+    constexpr _Mdspan_extent_type(_OtherIndexTypes... _OtherExtents) noexcept {
+        auto _It = _Dynamic_extents;
+        ((_Extents == dynamic_extent ? void(*_It++ = _OtherExtents) : void(_OtherExtents)), ...);
+    }
+
+    template <class _OtherIndexType, size_t _Size, size_t... _Idx,
+        enable_if_t<_Size == sizeof...(_Extents) && sizeof...(_Extents) != _Rank_dynamic, int> = 0>
+    constexpr _Mdspan_extent_type(span<_OtherIndexType, _Size> _Data, index_sequence<_Idx...>) noexcept
+        : _Dynamic_extents{{static_cast<index_type>(_STD as_const(_Data[_Dynamic_indexes[_Idx]]))...}} {}
+
+    constexpr index_type* _Begin_dynamic_extents() noexcept {
+        return _Dynamic_extents;
+    }
+
+    constexpr const index_type* _Begin_dynamic_extents() const noexcept {
+        return _Dynamic_extents;
+    }
+};
+
+template <class _IndexType, size_t... _Extents>
+struct _Mdspan_extent_type<_IndexType, 0, _Extents...> {
+    using index_type = _IndexType;
+
+    static constexpr size_t _Static_extents[sizeof...(_Extents)] = {_Extents...};
+
+    constexpr _Mdspan_extent_type() noexcept = default;
+
+    template <class... _IndexTypes, enable_if_t<sizeof...(_IndexTypes) == sizeof...(_Extents), int> = 0>
+    constexpr _Mdspan_extent_type(_IndexTypes... /*_OtherExtents*/) noexcept {}
+
+    template <class _OtherIndexType, size_t _Size, size_t... _Idx,
+        enable_if_t<_Size == sizeof...(_Extents) || _Size == 0, int> = 0>
+    constexpr _Mdspan_extent_type(span<_OtherIndexType, _Size>, index_sequence<_Idx...>) noexcept {}
+
+    constexpr index_type* _Begin_dynamic_extents() noexcept {
+        return nullptr;
+    }
+
+    constexpr const index_type* _Begin_dynamic_extents() const noexcept {
+        return nullptr;
+    }
+};
+
+template <class _IndexType>
+struct _Mdspan_extent_type<_IndexType, 0> {
+    using index_type = _IndexType;
+
+    constexpr index_type* _Begin_dynamic_extents() {
+        return nullptr;
+    }
+
+    constexpr const index_type* _Begin_dynamic_extents() const noexcept {
+        return nullptr;
+    }
+};
+
+template <class _IndexType, size_t... _Extents>
+class extents : private _Mdspan_extent_type<_IndexType, ((_Extents == dynamic_extent) + ... + 0), _Extents...> {
+public:
+    using _Mybase    = _Mdspan_extent_type<_IndexType, ((_Extents == dynamic_extent) + ... + 0), _Extents...>;
+    using index_type = typename _Mybase::index_type;
+    using size_type  = make_unsigned_t<index_type>;
+    using rank_type  = size_t;
+
+    // TRANSITION: doesn't account for extended integer types
+    static_assert(_Is_any_of_v<remove_cv_t<_IndexType>, signed char, unsigned char, short, unsigned short, int,
+                      unsigned int, long, unsigned long, long long, unsigned long long>,
+        "N4928 [mdspan.extents.overview]/2 "
+        "requires that extents::index_type be a signed or unsigned integer type.");
+
+    static_assert(((_Extents == dynamic_extent || _Extents <= (numeric_limits<_IndexType>::max)()) && ...));
+
+    _NODISCARD static constexpr rank_type rank() noexcept {
+        return sizeof...(_Extents);
+    }
+
+    _NODISCARD static constexpr rank_type rank_dynamic() noexcept {
+        return ((_Extents == dynamic_extent) + ... + 0);
+    }
+
+    _NODISCARD static constexpr size_t static_extent(const rank_type _Idx) noexcept {
+        return _Mybase::_Static_extents[_Idx];
+    }
+
+    _NODISCARD constexpr index_type extent(const rank_type _Idx) const noexcept {
+        if constexpr (rank_dynamic() == 0) {
+            return static_cast<index_type>(_Mybase::_Static_extents[_Idx]);
+        } else if constexpr (rank_dynamic() == rank()) {
+            return _Mybase::_Dynamic_extents[_Idx];
+        } else {
+            const auto _Static_extent = _Mybase::_Static_extents[_Idx];
+            if (_Static_extent == dynamic_extent) {
+                return _Mybase::_Dynamic_extents[_Mybase::_Dynamic_indexes[_Idx]];
+            } else {
+                return static_cast<index_type>(_Static_extent);
+            }
+        }
+    }
+
+    constexpr extents() noexcept = default;
+
+    template <class _OtherIndexType, size_t... _OtherExtents,
+        enable_if_t<sizeof...(_OtherExtents) == sizeof...(_Extents)
+                        && ((_OtherExtents == dynamic_extent || _Extents == dynamic_extent || _OtherExtents == _Extents)
+                            && ...),
+            int> = 0>
+    explicit((((_Extents != dynamic_extent) && (_OtherExtents == dynamic_extent)) || ...)
+             || numeric_limits<index_type>::max()
+                    < numeric_limits<_OtherIndexType>::max()) constexpr extents(const extents<_OtherIndexType,
+        _OtherExtents...>& _Other) noexcept {
+        auto _Dynamic_it = _Mybase::_Begin_dynamic_extents();
+        for (rank_type _Dim = 0; _Dim < sizeof...(_Extents); ++_Dim) {
+            if (_Mybase::_Static_extents[_Dim] == dynamic_extent) {
+                *_Dynamic_it++ = _Other.extent(_Dim);
+            }
+        }
+    }
+
+    template <class... _OtherIndexTypes,
+        enable_if_t<(is_convertible_v<_OtherIndexTypes, index_type> && ...)
+                        && (is_nothrow_constructible_v<index_type, _OtherIndexTypes> && ...)
+                        && (sizeof...(_OtherIndexTypes) == rank_dynamic() || sizeof...(_OtherIndexTypes) == rank()),
+            int> = 0>
+    explicit constexpr extents(_OtherIndexTypes... _Exts) noexcept
+        : _Mybase{static_cast<index_type>(_STD move(_Exts))...} {}
+
+    template <class _OtherIndexType, size_t _Size,
+        enable_if_t<is_convertible_v<const _OtherIndexType&, index_type>
+                        && is_nothrow_constructible_v<index_type, const _OtherIndexType&>
+                        && (_Size == rank_dynamic() || _Size == rank()),
+            int> = 0>
+    explicit(_Size != rank_dynamic()) constexpr extents(const array<_OtherIndexType, _Size>& _Exts) noexcept
+        : _Mybase{span{_Exts}, _STD make_index_sequence<rank_dynamic()>{}} {}
+
+    template <class _OtherIndexType, size_t _Size,
+        enable_if_t<is_convertible_v<const _OtherIndexType&, index_type>
+                        && is_nothrow_constructible_v<index_type, const _OtherIndexType&>
+                        && (_Size == rank_dynamic() || _Size == rank()),
+            int> = 0>
+    explicit(_Size != rank_dynamic()) constexpr extents(span<_OtherIndexType, _Size> _Exts) noexcept
+        : _Mybase{_Exts, _STD make_index_sequence<rank_dynamic()>{}} {}
+
+
+    template <class _OtherIndexType, size_t... _OtherExtents>
+    _NODISCARD_FRIEND constexpr bool operator==(
+        const extents& _Lhs, const extents<_OtherIndexType, _OtherExtents...>& _Rhs) noexcept {
+        if constexpr (sizeof...(_Extents) != sizeof...(_OtherExtents)) {
+            return false;
+        }
+
+        for (size_t _Dim = 0; _Dim < sizeof...(_Extents); ++_Dim) {
+            if (_Lhs.extent(_Dim) != _Rhs.extent(_Dim)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    constexpr void _Fill_extents(index_type* _Out) const noexcept {
+        auto _Dynamic_it = _Mybase::_Begin_dynamic_extents();
+        for (size_t _Dim = 0; _Dim < sizeof...(_Extents); ++_Dim) {
+            if (_Mybase::_Static_extents[_Dim] == dynamic_extent) {
+                *_Out++ = *_Dynamic_it++;
+            } else {
+                *_Out++ = static_cast<index_type>(_Mybase::_Static_extents[_Dim]);
+            }
+        }
+    }
+};
+
+template <class _IndexType, size_t _Rank>
+using dextents =
+    decltype([]<class _IndexType2, size_t... _Seq>(const _IndexType2, const index_sequence<_Seq...>) constexpr {
+        return extents<_IndexType2, ((void) _Seq, dynamic_extent)...>{};
+    }(_IndexType{0}, make_index_sequence<_Rank>{}));
+
+// TRANSITION: why not `((void) _Ext, dynamic_extent)...`?!
+template <class... _Integrals, enable_if_t<(is_convertible_v<_Integrals, size_t> && ...), int> = 0>
+extents(_Integrals... _Ext)
+    -> extents<size_t, conditional_t<true, integral_constant<size_t, dynamic_extent>, _Integrals>::value...>;
+
+
+template <class _Type>
+constexpr bool _Is_extents = false;
+
+template <class _IndexType, size_t... _Args>
+constexpr bool _Is_extents<extents<_IndexType, _Args...>> = true;
+
+
+template <class _Mapping, class = void>
+struct _Layout_mapping_alike_helper : false_type {};
+
+template <class _Mapping>
+struct _Layout_mapping_alike_helper<_Mapping,
+    void_t<is_same<bool, decltype(_Mapping::is_always_strided())>,
+        is_same<bool, decltype(_Mapping::is_always_exhaustive())>,
+        is_same<bool, decltype(_Mapping::is_always_unique())>, bool_constant<_Mapping::is_always_strided()>,
+        bool_constant<_Mapping::is_always_exhaustive()>, bool_constant<_Mapping::is_always_unique()>>>
+    : bool_constant<_Is_extents<typename _Mapping::extents_type>> {};
+
+template <class _Mapping>
+struct _Layout_mapping_alike : bool_constant<_Layout_mapping_alike_helper<_Mapping>::value> {};
+
+
+template <class _Layout, class _Mapping>
+constexpr bool _Is_mapping_of =
+    is_same_v<typename _Layout::template mapping<typename _Mapping::extents_type>, _Mapping>;
+
+
+struct layout_left {
+    template <class _Extents>
+    class mapping;
+};
+
+struct layout_right {
+    template <class _Extents>
+    class mapping;
+};
+
+struct layout_stride {
+    template <class _Extents>
+    class mapping;
+};
+
+template <class _Extents>
+class layout_left::mapping {
+public:
+    using extents_type = _Extents;
+    using index_type   = typename _Extents::index_type;
+    using size_type    = typename _Extents::size_type;
+    using rank_type    = typename _Extents::rank_type;
+    using layout_type  = layout_left;
+
+    constexpr mapping() noexcept               = default;
+    constexpr mapping(const mapping&) noexcept = default;
+
+    constexpr mapping(const _Extents& e) noexcept : _Myext(e){};
+
+    template <class _OtherExtents, enable_if_t<is_constructible_v<_Extents, _OtherExtents>, int> = 0>
+    explicit(!is_convertible_v<_OtherExtents, _Extents>) constexpr mapping(
+        const mapping<_OtherExtents>& _Other) noexcept
+        : _Myext{_Other.extents()} {};
+
+    template <class _OtherExtents,
+        enable_if_t<_Extents::rank() <= 1 && is_constructible_v<_Extents, _OtherExtents>, int> = 0>
+    explicit(!is_convertible_v<_OtherExtents, _Extents>) constexpr mapping(
+        const layout_right::mapping<_OtherExtents>& _Other) noexcept
+        : _Myext{_Other.extents()} {}
+
+    template <class _OtherExtents, enable_if_t<is_constructible_v<_Extents, _OtherExtents>, int> = 0>
+    explicit(_Extents::rank() > 0) constexpr mapping(const layout_stride::template mapping<_OtherExtents>& _Other)
+        : _Myext{_Other.extents()} {}
+
+    constexpr mapping& operator=(const mapping&) noexcept = default;
+
+    _NODISCARD constexpr const extents_type& extents() const noexcept {
+        return _Myext;
+    }
+
+    _NODISCARD constexpr index_type required_span_size() const noexcept {
+        index_type _Result = 1;
+        for (rank_type _Dim = 0; _Dim < _Extents::rank(); ++_Dim) {
+            _Result *= _Myext.extent(_Dim);
+        }
+
+        return _Result;
+    }
+
+    template <class... _Indices,
+        enable_if_t<sizeof...(_Indices) == _Extents::rank() && (is_convertible_v<_Indices, index_type> && ...)
+                        && (is_nothrow_constructible_v<index_type, _Indices> && ...),
+            int> = 0>
+    _NODISCARD constexpr index_type operator()(_Indices... _Idx) const noexcept {
+        return _Index_impl<conditional_t<true, index_type, _Indices>...>(
+            static_cast<index_type>(_Idx)..., make_index_sequence<_Extents::rank()>{});
+    }
+
+    _NODISCARD static constexpr bool is_always_unique() noexcept {
+        return true;
+    }
+    _NODISCARD static constexpr bool is_always_exhaustive() noexcept {
+        return true;
+    }
+    _NODISCARD static constexpr bool is_always_strided() noexcept {
+        return true;
+    }
+
+    _NODISCARD constexpr bool is_unique() const noexcept {
+        return true;
+    }
+    _NODISCARD constexpr bool is_exhaustive() const noexcept {
+        return true;
+    }
+    _NODISCARD constexpr bool is_strided() const noexcept {
+        return true;
+    }
+
+    template <class _Ext = _Extents, enable_if_t<(_Ext::rank() > 0), int> = 0>
+    _NODISCARD constexpr index_type stride(const rank_type _Rank) const noexcept {
+        index_type _Result = 1;
+        for (rank_type _Dim = 0; _Dim < _Rank; ++_Dim) {
+            _Result *= _Myext.extent(_Dim);
+        }
+
+        return _Result;
+    }
+
+    template <class OtherExtents>
+    _NODISCARD friend constexpr bool operator==(const mapping& _Lhs, const mapping<OtherExtents>& _Rhs) noexcept {
+        return _Lhs.extents() == _Rhs.extents();
+    }
+
+private:
+    _Extents _Myext{};
+
+    template <class... _IndexType, size_t... _Seq>
+    constexpr index_type _Index_impl(_IndexType... _Idx, index_sequence<_Seq...>) const noexcept {
+        // return _Extents::rank() > 0 ? ((_Idx * stride(_Seq)) + ... + 0) : 0;
+        index_type _Stride = 1;
+        index_type _Result = 0;
+        (((_Result += _Idx * _Stride), (void) (_Stride *= _Myext.extent(_Seq))), ...);
+        return _Result;
+    }
+};
+
+template <class _Extents>
+class layout_right::mapping {
+public:
+    using extents_type = _Extents;
+    using index_type   = typename _Extents::index_type;
+    using size_type    = typename _Extents::size_type;
+    using rank_type    = typename _Extents::rank_type;
+    using layout_type  = layout_right;
+
+    constexpr mapping() noexcept               = default;
+    constexpr mapping(const mapping&) noexcept = default;
+
+    constexpr mapping(const _Extents& e) noexcept : _Myext(e){};
+
+    template <class _OtherExtents, enable_if_t<is_constructible_v<_Extents, _OtherExtents>, int> = 0>
+    explicit(!is_convertible_v<_OtherExtents, _Extents>) constexpr mapping(
+        const mapping<_OtherExtents>& _Other) noexcept
+        : _Myext{_Other.extents()} {};
+
+    template <class _OtherExtents,
+        enable_if_t<_Extents::rank() <= 1 && is_constructible_v<_Extents, _OtherExtents>, int> = 0>
+    explicit(!is_convertible_v<_OtherExtents, _Extents>) constexpr mapping(
+        const layout_left::mapping<_OtherExtents>& _Other) noexcept
+        : _Myext{_Other.extents()} {}
+
+    template <class _OtherExtents, enable_if_t<is_constructible_v<_Extents, _OtherExtents>, int> = 0>
+    explicit(_Extents::rank() > 0) constexpr mapping(const layout_stride::template mapping<_OtherExtents>& _Other)
+        : _Myext{_Other.extents()} {}
+
+
+    constexpr mapping& operator=(const mapping&) noexcept = default;
+
+    _NODISCARD constexpr const extents_type& extents() const noexcept {
+        return _Myext;
+    }
+
+    _NODISCARD constexpr index_type required_span_size() const noexcept {
+        index_type _Result = 1;
+        for (rank_type _Dim = 0; _Dim < _Extents::rank(); ++_Dim) {
+            _Result *= _Myext.extent(_Dim);
+        }
+
+        return _Result;
+    }
+
+    template <class... _Indices,
+        enable_if_t<sizeof...(_Indices) == _Extents::rank() && (is_convertible_v<_Indices, index_type> && ...)
+                        && (is_nothrow_constructible_v<index_type, _Indices> && ...),
+            int> = 0>
+    _NODISCARD constexpr index_type operator()(_Indices... _Idx) const noexcept {
+        return _Index_impl<conditional_t<true, index_type, _Indices>...>(
+            static_cast<index_type>(_Idx)..., make_index_sequence<_Extents::rank()>{});
+    }
+
+    _NODISCARD static constexpr bool is_always_unique() noexcept {
+        return true;
+    }
+    _NODISCARD static constexpr bool is_always_exhaustive() noexcept {
+        return true;
+    }
+    _NODISCARD static constexpr bool is_always_strided() noexcept {
+        return true;
+    }
+
+    _NODISCARD constexpr bool is_unique() const noexcept {
+        return true;
+    }
+    _NODISCARD constexpr bool is_exhaustive() const noexcept {
+        return true;
+    }
+    _NODISCARD constexpr bool is_strided() const noexcept {
+        return true;
+    }
+
+    template <class _Ext = _Extents, enable_if_t<(_Ext::rank() > 0), int> = 0>
+    _NODISCARD constexpr index_type stride(const rank_type _Rank) const noexcept {
+        index_type _Result = 1;
+        for (rank_type _Dim = _Rank + 1; _Dim < _Extents::rank(); ++_Dim) {
+            _Result *= _Myext.extent(_Dim);
+        }
+
+        return _Result;
+    }
+
+    template <class OtherExtents>
+    _NODISCARD friend constexpr bool operator==(const mapping& _Lhs, const mapping<OtherExtents>& _Rhs) noexcept {
+        return _Lhs.extents() == _Rhs.extents();
+    }
+
+private:
+    _Extents _Myext{};
+
+    static constexpr size_t _Multiply(size_t _X, size_t _Y) {
+        return _X * _Y;
+    }
+
+    template <class... _IndexType, size_t... _Seq>
+    constexpr index_type _Index_impl(_IndexType... _Idx, index_sequence<_Seq...>) const noexcept {
+        index_type _Result = 0;
+        ((void) (_Result = _Idx + _Myext.extent(_Seq) * _Result), ...);
+        return _Result;
+    }
+};
+
+
+template <class _Extents>
+class layout_stride::mapping {
+public:
+    using extents_type = _Extents;
+    using index_type   = typename _Extents::index_type;
+    using size_type    = typename _Extents::size_type;
+    using rank_type    = typename _Extents::rank_type;
+    using layout_type  = layout_stride;
+
+    constexpr mapping() noexcept               = default;
+    constexpr mapping(const mapping&) noexcept = default;
+
+    template <class _OtherIndexType, enable_if_t<is_convertible_v<_OtherIndexType, index_type>, int> = 0>
+    constexpr mapping(const _Extents& _E_, const array<_OtherIndexType, _Extents::rank()>& _S_) noexcept : _Myext{_E_} {
+        for (rank_type _Idx = 0; _Idx < _Extents::rank(); ++_Idx) {
+            _Mystrides[_Idx] = _S_[_Idx];
+        }
+    };
+
+    template <class _OtherIndexType, enable_if_t<is_convertible_v<_OtherIndexType, index_type>, int> = 0>
+    constexpr mapping(const _Extents& _E_, const span<_OtherIndexType, _Extents::rank()> _S_) noexcept : _Myext{_E_} {
+        for (rank_type _Idx = 0; _Idx < _Extents::rank(); ++_Idx) {
+            _Mystrides[_Idx] = _S_[_Idx];
+        }
+    };
+
+    template <class _OtherExtents, enable_if_t<is_constructible_v<_Extents, _OtherExtents>, int> = 0>
+    explicit(!is_convertible_v<_OtherExtents, _Extents>) constexpr mapping(
+        const mapping<_OtherExtents>& _Other) noexcept
+        : _Myext{_Other.extents()}, _Mystrides{_Other.strides()} {
+        for (rank_type _Idx = 0; _Idx < _Extents::rank(); ++_Idx) {
+            _Mystrides[_Idx] = _Other.stride(_Idx);
+        }
+    }
+
+    template <class _StridedLayoutMapping,
+        enable_if_t<_Layout_mapping_alike<_StridedLayoutMapping>::value
+                        && is_constructible_v<extents_type, typename _StridedLayoutMapping::extents_type>
+                        && _StridedLayoutMapping::is_always_unique() && _StridedLayoutMapping::is_always_strided(),
+            int> = 0>
+    explicit(
+        !is_convertible_v<typename _StridedLayoutMapping::extents_type, extents_type>
+        && (_Is_mapping_of<layout_left, _StridedLayoutMapping> || _Is_mapping_of<layout_right, _StridedLayoutMapping>
+            || _Is_mapping_of<layout_stride, _StridedLayoutMapping>) ) constexpr mapping(const _StridedLayoutMapping&
+            _Other) noexcept
+        : _Myext(_Other.extents()) {
+        for (rank_type _Dim = 0; _Dim < _Extents::rank(); ++_Dim) {
+            _Mystrides[_Dim] = _Other.stride(_Dim);
+        }
+    }
+
+    constexpr mapping& operator=(const mapping&) noexcept = default;
+
+    _NODISCARD constexpr const extents_type& extents() const noexcept {
+        return _Myext;
+    }
+
+    _NODISCARD constexpr array<index_type, _Extents::rank()> strides() const noexcept {
+        return _Mystrides;
+    }
+
+    _NODISCARD constexpr index_type required_span_size() const noexcept {
+        if (_Extents::rank() > 0) {
+            index_type _Result = 1;
+            for (rank_type _Dim = 0; _Dim < _Extents::rank(); ++_Dim) {
+                const auto _Ext = _Myext.extent(_Dim);
+                if (_Ext == 0) {
+                    return 0;
+                }
+
+                _Result += (_Ext - 1) * _Mystrides[_Dim];
+            }
+
+            return _Result;
+        } else {
+            return 1;
+        }
+    }
+
+    template <class... _Indices,
+        enable_if_t<sizeof...(_Indices) == _Extents::rank() && (is_convertible_v<_Indices, index_type> && ...)
+                        && (is_nothrow_constructible_v<index_type, _Indices> && ...),
+            int> = 0>
+    _NODISCARD constexpr index_type operator()(_Indices... _Idx) const noexcept {
+        return _Index_impl<conditional_t<true, index_type, _Indices>...>(
+            static_cast<index_type>(_Idx)..., make_index_sequence<_Extents::rank()>{});
+    }
+
+    _NODISCARD static constexpr bool is_always_unique() noexcept {
+        return true;
+    }
+
+    _NODISCARD static constexpr bool is_always_exhaustive() noexcept {
+        return false;
+    }
+
+    _NODISCARD static constexpr bool is_always_strided() noexcept {
+        return true;
+    }
+
+    _NODISCARD constexpr bool is_unique() const noexcept {
+        return true;
+    }
+
+    _NODISCARD constexpr bool is_exhaustive() const noexcept {
+        index_type _Ext_size = 1;
+        for (rank_type _Dim = 0; _Dim < _Extents::rank(); ++_Dim) {
+            _Ext_size *= _Myext.extent(_Dim);
+        }
+
+        return required_span_size() == _Ext_size;
+    }
+
+    _NODISCARD constexpr bool is_strided() const noexcept {
+        return true;
+    }
+
+    template <class _Ext = extents_type, enable_if_t<(_Ext::rank() > 0), int> = 0>
+    _NODISCARD constexpr index_type stride(const rank_type _Idx) const noexcept {
+        return _Mystrides[_Idx];
+    }
+
+    template <class _OtherMapping, enable_if_t<_Layout_mapping_alike<_OtherMapping>::value
+                                                   && extents_type::rank() == _OtherMapping::extents_type::rank()
+                                                   && _OtherMapping::is_always_strided(),
+                                       int> = 0>
+    _NODISCARD friend constexpr bool operator==(const mapping& _Lhs, const _OtherMapping& _Rhs) noexcept {
+        if (_Lhs.extents() != _Rhs.extents()) {
+            return false;
+        }
+
+        constexpr rank_type _Rank = extents_type::rank();
+        for (rank_type _Dim = 0; _Dim < _Rank; ++_Dim) {
+            if (_Lhs.stride(_Dim) != _Rhs.stride(_Dim)) {
+                return false;
+            }
+        }
+
+        index_type _Offset;
+        if constexpr (_Rank == 0) {
+            _Offset = _Rhs();
+        } else {
+            bool _Is_empty = false;
+            for (rank_type _Dim = 0; _Dim < _Rank; ++_Dim) {
+                if (_Lhs.extents().extent(_Dim) == 0) {
+                    _Is_empty = true;
+                    break;
+                }
+            }
+
+            if (_Is_empty) {
+                _Offset = 0;
+            } else {
+                _Offset = [&_Rhs]<size_t... _Idx>(index_sequence<_Idx...>) {
+                    return _Rhs(((void) _Idx, 0)...);
+                }
+                (make_index_sequence<_Rank>{});
+            }
+
+            return _Offset == 0;
+        }
+    }
+
+private:
+    _Extents _Myext{};
+    array<index_type, _Extents::rank()> _Mystrides = {};
+
+    template <class... _IndexType, size_t... _Seq>
+    constexpr index_type _Index_impl(_IndexType... _Idx, index_sequence<_Seq...>) const noexcept {
+        return ((_Idx * _Mystrides[_Seq]) + ...);
+    }
+};
+
+template <class _ElementType>
+struct default_accessor {
+    using offset_policy    = default_accessor;
+    using element_type     = _ElementType;
+    using reference        = _ElementType&;
+    using data_handle_type = _ElementType*;
+
+    constexpr default_accessor() noexcept = default;
+
+    template <class _OtherElementType,
+        enable_if_t<
+            is_convertible_v<typename default_accessor<_OtherElementType>::element_type (*)[], _ElementType (*)[]>,
+            int> = 0>
+    constexpr default_accessor(default_accessor<_OtherElementType>) noexcept {}
+
+    _NODISCARD constexpr data_handle_type offset(data_handle_type _Ptr, size_t _Idx) const noexcept {
+        return _Ptr + _Idx;
+    }
+
+    _NODISCARD constexpr reference access(data_handle_type _Ptr, size_t _Idx) const noexcept {
+        return _Ptr[_Idx];
+    }
+};
+
+template <class _ElementType, class _Extents, class _LayoutPolicy = layout_right,
+    class _AccessorPolicy = default_accessor<_ElementType>>
+class mdspan {
+public:
+    // Domain and codomain types
+    using extents_type     = _Extents;
+    using layout_type      = _LayoutPolicy;
+    using accessor_type    = _AccessorPolicy;
+    using mapping_type     = typename layout_type::template mapping<extents_type>;
+    using element_type     = _ElementType;
+    using value_type       = remove_cv_t<element_type>;
+    using index_type       = typename extents_type::index_type;
+    using size_type        = typename extents_type::size_type;
+    using rank_type        = typename extents_type::rank_type;
+    using data_handle_type = typename accessor_type::data_handle_type;
+    using reference        = typename accessor_type::reference;
+
+    _NODISCARD static constexpr rank_type rank() noexcept {
+        return _Extents::rank();
+    }
+    _NODISCARD static constexpr rank_type rank_dynamic() noexcept {
+        return _Extents::rank_dynamic();
+    }
+    _NODISCARD static constexpr size_t static_extent(const rank_type r) noexcept {
+        return _Extents::static_extent(r);
+    }
+
+    template <class _Mapping = mapping_type,
+        enable_if_t<(rank_dynamic() > 0) && is_default_constructible_v<data_handle_type>
+                        && is_default_constructible_v<_Mapping> && is_default_constructible_v<accessor_type>,
+            int>             = 0>
+    constexpr mdspan() {}
+    constexpr mdspan(const mdspan& rhs) = default;
+    constexpr mdspan(mdspan&& rhs)      = default;
+
+    template <class _Mapping = mapping_type,
+        enable_if_t<(rank() == 0 || rank_dynamic() == 0)
+                        && is_constructible_v<_Mapping, extents_type> && is_default_constructible_v<accessor_type>,
+            int>             = 0>
+    explicit constexpr mdspan(data_handle_type _Ptr_) : _Ptr{_STD move(_Ptr_)}, _Map{extents_type{}} {}
+
+    template <class... _OtherIndexTypes,
+        enable_if_t<((sizeof...(_OtherIndexTypes) > 0)) && (is_convertible_v<_OtherIndexTypes, index_type> && ...)
+                        && (is_nothrow_constructible_v<index_type, _OtherIndexTypes> && ...)
+                        //&& (sizeof...(_OtherIndexTypes) == rank() || sizeof...(_OtherIndexTypes) == rank_dynamic())
+                        && is_constructible_v<mapping_type, extents_type> && is_default_constructible_v<accessor_type>,
+            int> = 0>
+    explicit constexpr mdspan(data_handle_type _Ptr_, _OtherIndexTypes... _Exts)
+        : _Ptr{_STD move(_Ptr_)}, _Map{extents_type{static_cast<index_type>(_STD move(_Exts))...}} {}
+
+    template <class _OtherIndexType, size_t _Size,
+        enable_if_t<is_convertible_v<_OtherIndexType, index_type>
+                        && is_nothrow_constructible_v<index_type, const _OtherIndexType&>
+                        && (_Size == rank() || _Size == rank_dynamic())
+                        && is_constructible_v<mapping_type, _Extents> && is_default_constructible_v<accessor_type>,
+            int> = 0>
+    explicit(_Size != rank_dynamic()) constexpr mdspan(data_handle_type _Ptr_, span<_OtherIndexType, _Size>& _Exts)
+        : _Ptr{_Ptr_}, _Map{_Extents{_Exts}} {}
+
+    template <class _OtherIndexType, size_t _Size,
+        enable_if_t<is_convertible_v<_OtherIndexType, index_type>
+                        && is_nothrow_constructible_v<index_type, const _OtherIndexType&>
+                        && (_Size == rank() || _Size == rank_dynamic())
+                        && is_constructible_v<mapping_type, _Extents> && is_default_constructible_v<accessor_type>,
+            int> = 0>
+    explicit(_Size != rank_dynamic()) constexpr mdspan(
+        data_handle_type _Ptr_, const array<_OtherIndexType, _Size>& _Exts)
+        : _Ptr{_Ptr_}, _Map{_Extents{_Exts}} {}
+
+
+    template <class _Extents2 = _Extents,
+        enable_if_t<is_constructible_v<mapping_type, _Extents2> && is_default_constructible_v<accessor_type>, int> = 0>
+    constexpr mdspan(data_handle_type _Ptr_, const _Extents& _Ext) : _Ptr{_Ptr_}, _Map{_Ext} {}
+
+    template <class _Accessor = accessor_type, enable_if_t<is_default_constructible_v<_Accessor>, int> = 0>
+    constexpr mdspan(data_handle_type _Ptr_, const mapping_type& _Map_) : _Ptr{_Ptr_}, _Map{_Map_} {}
+
+    constexpr mdspan(data_handle_type _Ptr_, const mapping_type& _Map_, const accessor_type& _Acc_)
+        : _Ptr{_Ptr_}, _Map{_Map_}, _Acc{_Acc_} {}
+
+    template <class _OtherElementType, class _OtherExtents, class _OtherLayoutPolicy, class _OtherAccessor,
+        enable_if_t<is_constructible_v<mapping_type, const typename _OtherLayoutPolicy::template mapping<_OtherExtents>&>
+                        && is_constructible_v<accessor_type, const _OtherAccessor&>,
+            int> = 0>
+    constexpr explicit(!is_convertible_v<const typename _OtherLayoutPolicy::template mapping<_OtherExtents>&, mapping_type>
+                       || !is_convertible_v<const _OtherAccessor&, accessor_type>)
+        mdspan(const mdspan<_OtherElementType, _OtherExtents, _OtherLayoutPolicy, _OtherAccessor>& _Other)
+        : _Ptr{_Other._Ptr}, _Map{_Other._Map}, _Acc{_Other._Acc} {
+        static_assert(is_constructible_v<data_handle_type, const typename _OtherAccessor ::data_handle_type&>);
+        static_assert(is_constructible_v<extents_type, _OtherExtents>);
+    }
+
+    constexpr mdspan& operator=(const mdspan& rhs) = default;
+    constexpr mdspan& operator=(mdspan&& rhs)      = default;
+
+    // TRANSITION operator[](const _OtherIndexTypes... _Indices)
+    template <class... _OtherIndexTypes,
+        enable_if_t<(is_convertible_v<_OtherIndexTypes, index_type> && ...)
+                        && (is_nothrow_constructible_v<index_type, _OtherIndexTypes> && ...),
+            /*&& sizeof...(_OtherIndexTypes) == rank(),*/
+            int> = 0>
+    _NODISCARD constexpr reference operator()(const _OtherIndexTypes... _Indices) const {
+        return _Acc.access(_Ptr, _Map(static_cast<index_type>(_STD move(_Indices))...));
+    }
+
+    template <class _OtherIndexType, enable_if_t<is_convertible_v<const _OtherIndexType&, index_type>, int> = 0>
+    _NODISCARD constexpr reference operator[](span<_OtherIndexType, rank()> _Indices) const {
+        return _Index_impl(_Indices, make_index_sequence<rank()>{});
+    }
+
+    template <class _OtherIndexType, enable_if_t<is_convertible_v<const _OtherIndexType&, index_type>, int> = 0>
+    _NODISCARD constexpr reference operator[](const array<_OtherIndexType, rank()>& _Indices) const {
+        return _Index_impl(_Indices, make_index_sequence<rank()>{});
+    }
+
+    _NODISCARD constexpr const extents_type& extents() const noexcept {
+        return _Map.extents();
+    }
+
+    _NODISCARD constexpr const data_handle_type& data_handle() const noexcept {
+        return _Ptr;
+    }
+
+    _NODISCARD constexpr const mapping_type& mapping() const noexcept {
+        return _Map;
+    }
+
+    _NODISCARD constexpr const accessor_type& accessor() const noexcept {
+        return _Acc;
+    }
+
+    _NODISCARD constexpr index_type extent(const rank_type r) const noexcept {
+        const auto& _Ext = _Map.extents();
+        return _Ext.extent(r);
+    }
+
+    _NODISCARD constexpr size_type size() const noexcept {
+        const auto& _Ext  = _Map.extents();
+        size_type _Result = 1;
+        for (rank_type _Dim = 0; _Dim < rank(); ++_Dim) {
+            _Result *= _Ext.extent(_Dim);
+        }
+        return _Result;
+    }
+
+    _NODISCARD constexpr bool empty() const noexcept {
+        for (rank_type _Dim = 0; _Dim < rank(); ++_Dim) {
+            if (_Map.extents().extent(_Dim) == 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    friend constexpr void swap(mdspan& _Lhs, mdspan& _Rhs) noexcept {
+        swap(_Lhs._Ptr, _Rhs._Ptr);
+        swap(_Lhs._Map, _Rhs._Map);
+        swap(_Lhs._Acc, _Rhs._Acc);
+    }
+
+    _NODISCARD static constexpr bool is_always_unique() {
+        return mapping_type::is_always_unique();
+    }
+
+    _NODISCARD static constexpr bool is_always_exhaustive() {
+        return mapping_type::is_always_exhaustive();
+    }
+
+    _NODISCARD static constexpr bool is_always_strided() {
+        return mapping_type::is_always_strided();
+    }
+
+    _NODISCARD constexpr bool is_unique() const {
+        return _Map.is_unique();
+    }
+
+    _NODISCARD constexpr bool is_exhaustive() const {
+        return _Map.is_exhaustive();
+    }
+
+    _NODISCARD constexpr bool is_strided() const {
+        return _Map.is_strided();
+    }
+
+    _NODISCARD constexpr index_type stride(const size_t _Dim) const {
+        return _Map.stride(_Dim);
+    }
+
+private:
+    template <class _IndexContainer, size_t... _Idx>
+    _NODISCARD constexpr reference _Index_impl(_IndexContainer&& _Indices, index_sequence<_Idx...>) const {
+        return _Acc.access(_Ptr, _Map(_STD as_const(_STD forward<_IndexContainer>(_Indices)[_Idx])...));
+    }
+
+    data_handle_type _Ptr{};
+    mapping_type _Map{};
+    accessor_type _Acc{};
+};
+
+_STD_END
+
+#pragma pop_macro("new")
+_STL_RESTORE_CLANG_WARNINGS
+#pragma warning(pop)
+#pragma pack(pop)
+#endif // _HAS_CXX23
+#endif // _STL_COMPILER_PREPROCESSOR
+#endif // _MDSPAN_

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -295,6 +295,7 @@
 // Other C++20 deprecation warnings
 
 // _HAS_CXX23 directly controls:
+// P0009R18 <mdspan>
 // P0288R9 move_only_function
 // P0323R12 <expected>
 // P0401R6 Providing Size Feedback In The Allocator Interface
@@ -349,7 +350,11 @@
 // P2499R0 string_view Range Constructor Should Be explicit
 // P2505R5 Monadic Functions For expected
 // P2549R1 unexpected<E>::error()
+// P2599R2 mdspan: index_type, size_type
 // P2602R2 Poison Pills Are Too Toxic
+// P2604R0 mdspan: data_handle_type, data_handle(), exhaustive
+// P2613R1 mdspan: empty()
+// P2763R1 Fixing layout_stride's Default Constructor For Fully Static Extents
 
 // Parallel Algorithms Notes
 // C++ allows an implementation to implement parallel algorithms as calls to the serial algorithms.
@@ -1687,6 +1692,7 @@ _EMIT_STL_ERROR(STL1004, "C++98 unexpected() is incompatible with C++23 unexpect
 #define __cpp_lib_invoke_r       202106L
 #define __cpp_lib_ios_noreplace  202207L
 #define __cpp_lib_is_scoped_enum 202011L
+#define __cpp_lib_mdspan         202207L
 
 #if !defined(__clang__) && !defined(__EDG__) // TRANSITION, Clang and EDG support for modules
 #define __cpp_lib_modules 202207L

--- a/stl/modules/std.ixx
+++ b/stl/modules/std.ixx
@@ -76,6 +76,7 @@ export module std;
 #include <list>
 #include <locale>
 #include <map>
+#include <mdspan>
 #include <memory>
 #include <memory_resource>
 #include <mutex>

--- a/tests/std/test.lst
+++ b/tests/std/test.lst
@@ -227,6 +227,7 @@ tests\LWG3422_seed_seq_ctors
 tests\LWG3480_directory_iterator_range
 tests\LWG3545_pointer_traits_sfinae
 tests\LWG3610_iota_view_size_and_integer_class
+tests\P0009R18_mdspan
 tests\P0019R8_atomic_ref
 tests\P0024R2_parallel_algorithms_adjacent_difference
 tests\P0024R2_parallel_algorithms_adjacent_find

--- a/tests/std/tests/P0009R18_mdspan/env.lst
+++ b/tests/std/tests/P0009R18_mdspan/env.lst
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+RUNALL_INCLUDE ..\usual_latest_matrix.lst

--- a/tests/std/tests/P0009R18_mdspan/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan/test.cpp
@@ -1,0 +1,1117 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <cassert>
+#include <concepts>
+#include <mdspan>
+#include <type_traits>
+#include <vector>
+
+using namespace std;
+
+#ifdef __cpp_lib_concepts
+// A type that's regular and trivially copyable, and also maximally nothrow.
+template <class T>
+using is_regular_trivial_nothrow = std::conjunction<std::bool_constant<std::regular<T>>, is_trivially_copyable<T>,
+    is_nothrow_default_constructible<T>, is_nothrow_copy_constructible<T>, is_nothrow_move_constructible<T>,
+    is_nothrow_copy_assignable<T>, is_nothrow_move_assignable<T>, is_nothrow_swappable<T>>;
+
+template <class T>
+inline constexpr bool is_regular_trivial_nothrow_v = is_regular_trivial_nothrow<T>::value;
+#endif // __cpp_lib_concepts
+
+struct Constructible {
+    // noexcept constructible for size_t, but not convertible
+    explicit operator size_t() noexcept;
+};
+
+struct Convertible {
+    // convertible, but not noexcept constructible
+    operator size_t();
+};
+
+struct ConstructibleAndConvertible {
+    // convertible and noexcept constuctible
+    constexpr operator size_t() noexcept {
+        return size_t{0};
+    };
+};
+
+struct ConstructibleAndConvertibleConst {
+    // convertible and noexcept constuctible
+    constexpr operator size_t() const noexcept {
+        return size_t{0};
+    };
+};
+
+
+void extent_tests_traits() {
+#ifdef __cpp_lib_concepts
+    static_assert(is_regular_trivial_nothrow_v<extents<size_t>>);
+    static_assert(is_regular_trivial_nothrow_v<extents<size_t, 2, 3>>);
+    static_assert(is_regular_trivial_nothrow_v<extents<size_t, dynamic_extent, 3>>);
+    static_assert(is_regular_trivial_nothrow_v<extents<size_t, 2, dynamic_extent>>);
+    static_assert(is_regular_trivial_nothrow_v<extents<size_t, dynamic_extent, dynamic_extent>>);
+#endif // __cpp_lib_concepts
+
+    static_assert(is_same_v<dextents<size_t, 1>, extents<size_t, dynamic_extent>>);
+    static_assert(is_same_v<dextents<size_t, 2>, extents<size_t, dynamic_extent, dynamic_extent>>);
+    static_assert(is_same_v<dextents<short, 1>, extents<short, dynamic_extent>>);
+    static_assert(is_same_v<dextents<short, 2>, extents<short, dynamic_extent, dynamic_extent>>);
+
+    constexpr extents e(2, 3);
+    static_assert(is_same_v<remove_cvref_t<decltype(e)>, dextents<size_t, 2>>);
+    static_assert(e.static_extent(0) == dynamic_extent);
+    static_assert(e.static_extent(1) == dynamic_extent);
+    static_assert(e.extent(0) == 2);
+    static_assert(e.extent(1) == 3);
+
+    constexpr dextents<int, 1> ex0(1);
+    (void) ex0;
+    static_assert(!is_constructible_v<dextents<int, 1>, int*>);
+
+    extents<signed char>();
+    extents<unsigned char>();
+    extents<short>();
+    extents<unsigned short>();
+    extents<int>();
+    extents<unsigned int>();
+    extents<long>();
+    extents<unsigned long>();
+    extents<long long>();
+    extents<unsigned long long>();
+}
+
+void extent_tests_rank() {
+    static_assert(extents<size_t>::rank() == 0);
+    static_assert(extents<size_t>::rank_dynamic() == 0);
+
+    static_assert(extents<size_t, 2>::rank() == 1);
+    static_assert(extents<size_t, 2>::rank_dynamic() == 0);
+
+    static_assert(extents<size_t, dynamic_extent>::rank() == 1);
+    static_assert(extents<size_t, dynamic_extent>::rank_dynamic() == 1);
+
+    static_assert(extents<size_t, 2, 3>::rank() == 2);
+    static_assert(extents<size_t, 2, 3>::rank_dynamic() == 0);
+
+    static_assert(extents<size_t, 2, dynamic_extent>::rank() == 2);
+    static_assert(extents<size_t, 2, dynamic_extent>::rank_dynamic() == 1);
+
+    static_assert(extents<size_t, dynamic_extent, 3>::rank() == 2);
+    static_assert(extents<size_t, dynamic_extent, 3>::rank_dynamic() == 1);
+
+    static_assert(extents<size_t, dynamic_extent, dynamic_extent>::rank() == 2);
+    static_assert(extents<size_t, dynamic_extent, dynamic_extent>::rank_dynamic() == 2);
+}
+
+void extent_tests_static_extent() {
+    static_assert(extents<size_t, 2, 3>::static_extent(0) == 2);
+    static_assert(extents<size_t, 2, 3>::static_extent(1) == 3);
+
+    static_assert(extents<size_t, 2, dynamic_extent>::static_extent(0) == 2);
+    static_assert(extents<size_t, 2, dynamic_extent>::static_extent(1) == dynamic_extent);
+
+    static_assert(extents<size_t, dynamic_extent, 3>::static_extent(0) == dynamic_extent);
+    static_assert(extents<size_t, dynamic_extent, 3>::static_extent(1) == 3);
+
+    static_assert(extents<size_t, dynamic_extent, dynamic_extent>::static_extent(0) == dynamic_extent);
+    static_assert(extents<size_t, dynamic_extent, dynamic_extent>::static_extent(1) == dynamic_extent);
+}
+
+void extent_tests_extent() {
+    constexpr extents<size_t, 2, 3> e_23;
+    static_assert(e_23.extent(0) == 2);
+    static_assert(e_23.extent(1) == 3);
+
+    constexpr extents<size_t, 2, dynamic_extent> e_2d{3};
+    static_assert(e_2d.extent(0) == 2);
+    static_assert(e_2d.extent(1) == 3);
+
+    constexpr extents<size_t, dynamic_extent, dynamic_extent> e_dd{2, 3};
+    static_assert(e_dd.extent(0) == 2);
+    static_assert(e_dd.extent(1) == 3);
+
+    constexpr extents<size_t, 2, dynamic_extent, dynamic_extent> e_2dd{3, 5};
+    static_assert(e_2dd.extent(0) == 2);
+    static_assert(e_2dd.extent(1) == 3);
+    static_assert(e_2dd.extent(2) == 5);
+}
+
+void extent_tests_ctor_other_sizes() {
+    static_assert(!is_constructible_v<extents<size_t, 2>, Constructible>);
+    static_assert(!is_constructible_v<extents<size_t, 2>, Convertible>);
+    // static_assert(is_constructible_v<extents<size_t, 2>, ConstructibleAndConvertible>);
+    constexpr extents<size_t, 2> ex0{ConstructibleAndConvertible{}};
+    // static_assert(is_constructible_v<extents<size_t, 2>, ConstructibleAndConvertibleConst>);
+    constexpr extents<size_t, 2> ex1{ConstructibleAndConvertibleConst{}};
+
+    // static_assert(is_constructible_v<extents<int, dynamic_extent, 2, 2>, int>);
+    constexpr extents<int, dynamic_extent, 2, 2> ex2(1);
+    static_assert(!is_constructible_v<extents<int, dynamic_extent, 2, 2>, int, int>);
+    // static_assert(is_constructible_v<extents<int, dynamic_extent, 2, 2>, int, int, int>);
+    extents<int, dynamic_extent, 2, 2> ex3(1, 2, 3);
+
+    (void) ex0;
+    (void) ex1;
+    (void) ex2;
+    (void) ex3;
+
+    extents<size_t, 2, 3> e0;
+    assert(e0.extent(0) == 2);
+    assert(e0.extent(1) == 3);
+
+    extents<size_t, 2, dynamic_extent> e1(5);
+    assert(e1.extent(0) == 2);
+    assert(e1.extent(1) == 5);
+
+    extents<size_t, dynamic_extent, 3> e2(5);
+    assert(e2.extent(0) == 5);
+    assert(e2.extent(1) == 3);
+
+    extents<size_t, dynamic_extent, dynamic_extent> e3(5, 7);
+    assert(e3.extent(0) == 5);
+    assert(e3.extent(1) == 7);
+}
+
+void extent_tests_copy_ctor_other() {
+    // Rank and value of static extents must match.
+    static_assert(!is_constructible_v<extents<size_t, 2>, extents<size_t, 2, 3>>);
+    static_assert(!is_constructible_v<extents<size_t, 2, 3>, extents<size_t, 2>>);
+    static_assert(!is_constructible_v<extents<size_t, 2, 3>, extents<size_t, 3, 2>>);
+
+    // Static extents are constuctible, but not convertible, from dynamic extents.
+    // static_assert(is_constructible_v<extents<size_t, 2, 3>, extents<size_t, 2, dynamic_extent>>);
+    constexpr extents<size_t, 2, 3> ex0{extents<size_t, 2, dynamic_extent>{}};
+    (void) ex0;
+    static_assert(!is_convertible_v<extents<size_t, 2, dynamic_extent>, extents<size_t, 2, 3>>);
+
+    // Dynamic extents are constuctible and convertible from static extents.
+    static_assert(is_constructible_v<extents<size_t, 2, dynamic_extent>, extents<size_t, 2, 3>>);
+    extents<size_t, 2, dynamic_extent>{extents<size_t, 2, 3>{}};
+    static_assert(is_convertible_v<extents<size_t, 2, 3>, extents<size_t, 2, dynamic_extent>>);
+
+    // Can implicitly convert from narrower to wider size_type, but not vice-versa.
+    static_assert(is_convertible_v<extents<uint32_t, dynamic_extent>, extents<uint64_t, dynamic_extent>>);
+    static_assert(!is_convertible_v<extents<uint64_t, dynamic_extent>, extents<uint32_t, dynamic_extent>>);
+
+    extents<size_t, 2, dynamic_extent> e_dyn(3);
+    extents<size_t, 2, 3> e(e_dyn);
+    (void) e;
+
+    using E = extents<size_t, 2, 3>;
+
+    extents<size_t, 2, 3> e0{extents<size_t, 2, 3>{}};
+    E e1(extents<size_t, dynamic_extent, 3>(2u));
+    extents<size_t, 2, 3> e2{extents<size_t, 2, dynamic_extent>{3u}};
+    extents<size_t, 2, 3> e3{extents<size_t, dynamic_extent, dynamic_extent>{2u, 3u}};
+
+    (void) e0;
+    (void) e1;
+    (void) e2;
+    (void) e3;
+}
+
+template <class T, class IndexType, size_t N, class = void>
+struct is_array_cons_avail : std::false_type {};
+
+template <class T, class IndexType, size_t N>
+struct is_array_cons_avail<T, IndexType, N,
+    std::enable_if_t<std::is_same<decltype(T{std::declval<std::array<IndexType, N>>()}), T>::value>> : std::true_type {
+};
+
+template <class T, class IndexType, size_t N>
+constexpr bool is_array_cons_avail_v = is_array_cons_avail<T, IndexType, N>::value;
+
+void extent_tests_ctor_array() {
+    static_assert(!is_constructible_v<extents<size_t, 2>, array<Constructible, 1>>);
+    static_assert(!is_constructible_v<extents<size_t, 2>, array<Convertible, 1>>);
+    static_assert(!is_constructible_v<extents<size_t, 2>, array<ConstructibleAndConvertible, 1>>);
+    static_assert(is_constructible_v<extents<size_t, 2>, array<ConstructibleAndConvertibleConst, 1>>);
+    constexpr extents<size_t, 2> ex0{array<ConstructibleAndConvertibleConst, 1>{}};
+    (void) ex0;
+
+    static_assert(is_constructible_v<extents<int, dynamic_extent, 2, 2>, array<int, 1>>);
+    constexpr extents<int, dynamic_extent, 2, 2> ex1{array<int, 1>{}};
+    static_assert(!is_constructible_v<extents<int, dynamic_extent, 2, 2>, array<int, 2>>);
+    static_assert(is_constructible_v<extents<int, dynamic_extent, 2, 2>, array<int, 3>>);
+    constexpr extents<int, dynamic_extent, 2, 2> ex2{array<int, 3>{1, 2, 2}};
+    (void) ex1;
+    (void) ex2;
+
+    static_assert(is_constructible_v<extents<int, 10>, array<int, 0>>);
+    constexpr extents<int, 10> ex3{array<int, 0>{}};
+    static_assert(is_constructible_v<extents<int, 10>, array<int, 1>>);
+    constexpr extents<int, 10> ex4{array<int, 1>{}};
+    static_assert(!is_constructible_v<extents<int, 10>, array<int, 2>>);
+    (void) ex3;
+    (void) ex4;
+
+    extents<size_t, 2, 3> e0;
+    assert(e0.extent(0) == 2u);
+    assert(e0.extent(1) == 3u);
+
+    // native extent::size_type
+    extents<size_t, 2, dynamic_extent> e1(to_array<size_t>({5}));
+    assert(e1.extent(0) == 2u);
+    assert(e1.extent(1) == 5u);
+
+    extents<size_t, dynamic_extent, 3> e2(to_array<size_t>({5}));
+    assert(e2.extent(0) == 5u);
+    assert(e2.extent(1) == 3u);
+
+    extents<size_t, dynamic_extent, dynamic_extent> e3(to_array<size_t>({5, 7}));
+    assert(e3.extent(0) == 5u);
+    assert(e3.extent(1) == 7u);
+
+    // convertible size type
+    extents<size_t, 2, dynamic_extent> e4(to_array<int>({5}));
+    assert(e4.extent(0) == 2u);
+    assert(e4.extent(1) == 5u);
+
+    extents<size_t, dynamic_extent, 3> e5(to_array<int>({5}));
+    assert(e5.extent(0) == 5u);
+    assert(e5.extent(1) == 3u);
+
+    extents<size_t, dynamic_extent, dynamic_extent> e6(to_array<int>({5, 7}));
+    assert(e6.extent(0) == 5u);
+    assert(e6.extent(1) == 7u);
+}
+
+void extent_tests_ctor_span() {
+    static_assert(!is_constructible_v<extents<size_t, 2>, span<Constructible, 1>>);
+    static_assert(!is_constructible_v<extents<size_t, 2>, span<Convertible, 1>>);
+    static_assert(!is_constructible_v<extents<size_t, 2>, span<ConstructibleAndConvertible, 1>>);
+    static_assert(is_constructible_v<extents<size_t, 2>, span<ConstructibleAndConvertibleConst, 1>>);
+    ConstructibleAndConvertibleConst arr0[1] = {{}};
+    constexpr extents<size_t, 2> ex0{span<ConstructibleAndConvertibleConst, 1>{arr0}};
+    (void) ex0;
+
+    static_assert(is_constructible_v<extents<int, dynamic_extent, 2, 2>, span<int, 1>>);
+    constexpr int arr1[1] = {1};
+    constexpr extents<int, dynamic_extent, 2, 2> ex1{span<const int, 1>{arr1}};
+    static_assert(!is_constructible_v<extents<int, dynamic_extent, 2, 2>, span<int, 2>>);
+    static_assert(is_constructible_v<extents<int, dynamic_extent, 2, 2>, span<int, 3>>);
+    constexpr int arr2[3] = {3, 2, 2};
+    constexpr extents<int, dynamic_extent, 2, 2> ex2{span<const int, 3>{arr2}};
+    (void) ex1;
+    (void) ex2;
+
+
+    extents<size_t, 2, 3> e0;
+    assert(e0.extent(0) == 2u);
+    assert(e0.extent(1) == 3u);
+
+    // native extent::size_type
+    constexpr int one_int[] = {5};
+    constexpr int two_int[] = {5, 7};
+    extents<size_t, 2, dynamic_extent> e1(span{one_int});
+    assert(e1.extent(0) == 2);
+    assert(e1.extent(1) == 5);
+
+    extents<size_t, dynamic_extent, 3> e2(span{one_int});
+    assert(e2.extent(0) == 5);
+    assert(e2.extent(1) == 3);
+
+    extents<size_t, dynamic_extent, dynamic_extent> e3(span{two_int});
+    assert(e3.extent(0) == 5);
+    assert(e3.extent(1) == 7);
+
+    // convertible size type
+    constexpr size_t one_sizet[] = {5};
+    constexpr size_t two_sizet[] = {5, 7};
+    extents<size_t, 2, dynamic_extent> e4(span{one_sizet});
+    assert(e4.extent(0) == 2);
+    assert(e4.extent(1) == 5);
+
+    extents<size_t, dynamic_extent, 3> e5(span{one_sizet});
+    assert(e5.extent(0) == 5);
+    assert(e5.extent(1) == 3);
+
+    extents<size_t, dynamic_extent, dynamic_extent> e6(span{two_sizet});
+    assert(e6.extent(0) == 5);
+    assert(e6.extent(1) == 7);
+}
+
+void extent_tests_equality() {
+    static_assert(extents<size_t, 2, 3>{} == extents<size_t, 2, 3>{});
+    static_assert(extents<size_t, 2, 3>{} != extents<size_t, 3, 2>{});
+    static_assert(extents<size_t, 2>{} != extents<size_t, 2, 3>{});
+
+    extents<size_t, 2, 3> e_23;
+    extents<size_t, 2, dynamic_extent> e_2d{3};
+    extents<size_t, dynamic_extent, 3> e_d3{2};
+    extents<size_t, dynamic_extent, dynamic_extent> e_dd{2, 3};
+
+    assert(e_23 == e_2d);
+    assert(e_23 == e_d3);
+    assert(e_23 == e_dd);
+    assert(e_2d == e_d3);
+}
+
+template <class Mapping, enable_if_t<Mapping::extents_type::rank() == 2, int> = 0>
+void TestMapping(const Mapping& map) {
+    using IndexT = typename Mapping::index_type;
+    using RankT  = typename Mapping::rank_type;
+    static_assert(is_same_v<IndexT, decltype(declval<Mapping>()(IndexT{0}, IndexT{0}))>);
+    static_assert(is_same_v<IndexT, decltype(declval<Mapping>().stride(RankT{0}))>);
+
+    array<IndexT, Mapping::extents_type::rank()> s;
+    const auto& e      = map.extents();
+    size_t num_entries = 1;
+    for (size_t i = 0; i < Mapping::extents_type::rank(); ++i) {
+        num_entries *= e.extent(i);
+        s[i] = map.stride(i);
+    }
+
+    vector<IndexT> indices;
+    indices.reserve(num_entries);
+
+    for (IndexT i = 0; i < e.extent(0); ++i) {
+        for (IndexT j = 0; j < e.extent(1); ++j) {
+            const auto idx = i * s[0] + j * s[1];
+            assert(map(i, j) == idx);
+            indices.push_back(idx);
+        }
+    }
+
+    bool is_unique  = true;
+    bool is_exhaust = true;
+    sort(indices.begin(), indices.end());
+    for (size_t i = 1; i < indices.size(); ++i) {
+        const auto diff = indices[i] - indices[i - 1];
+        if (diff == 0) {
+            is_unique = false;
+        } else if (diff != 1) {
+            is_exhaust = false;
+        }
+    }
+
+    assert(map.is_unique() == is_unique);
+    assert(map.is_exhaustive() == is_exhaust);
+    assert(map.required_span_size() == indices.back() + 1);
+}
+
+template <class Mapping, enable_if_t<Mapping::extents_type::rank() == 3, int> = 0>
+void TestMapping(const Mapping& map) {
+    using IndexT = typename Mapping::index_type;
+    using RankT  = typename Mapping::rank_type;
+    static_assert(is_same_v<IndexT, decltype(declval<Mapping>()(IndexT{0}, IndexT{0}, IndexT{0}))>);
+    static_assert(is_same_v<IndexT, decltype(declval<Mapping>().stride(RankT{0}))>);
+
+    array<IndexT, Mapping::extents_type::rank()> s;
+    const auto& e      = map.extents();
+    size_t num_entries = 1;
+    for (size_t i = 0; i < Mapping::extents_type::rank(); ++i) {
+        num_entries *= e.extent(i);
+        s[i] = map.stride(i);
+    }
+
+    vector<IndexT> indices;
+    indices.reserve(num_entries);
+
+    for (IndexT i = 0; i < e.extent(0); ++i) {
+        for (IndexT j = 0; j < e.extent(1); ++j) {
+            for (IndexT k = 0; k < e.extent(2); ++k) {
+                const auto idx = i * s[0] + j * s[1] + k * s[2];
+                assert(map(i, j, k) == idx);
+                indices.push_back(idx);
+            }
+        }
+    }
+
+    bool is_unique  = true;
+    bool is_exhaust = true;
+    sort(indices.begin(), indices.end());
+    for (size_t i = 1; i < indices.size(); ++i) {
+        const auto diff = indices[i] - indices[i - 1];
+        if (diff == 0) {
+            is_unique = false;
+        } else if (diff != 1) {
+            is_exhaust = false;
+        }
+    }
+
+    assert(map.is_unique() == is_unique);
+    assert(map.is_exhaustive() == is_exhaust);
+    assert(map.required_span_size() == indices.back() + 1);
+}
+
+void layout_left_tests_traits() {
+#ifdef __cpp_lib_concepts
+    static_assert(is_regular_trivial_nothrow_v<layout_left::mapping<extents<size_t, 2, 3>>>);
+    static_assert(is_regular_trivial_nothrow_v<layout_left::mapping<extents<size_t, dynamic_extent, 3>>>);
+    static_assert(is_regular_trivial_nothrow_v<layout_left::mapping<extents<size_t, 2, dynamic_extent>>>);
+    static_assert(is_regular_trivial_nothrow_v<layout_left::mapping<extents<size_t, dynamic_extent, dynamic_extent>>>);
+#endif // __cpp_lib_concepts
+
+    using E = extents<int, 2, 3>;
+    static_assert(is_same_v<layout_left::mapping<E>::extents_type, E>);
+    static_assert(is_same_v<layout_left::mapping<E>::index_type, E::index_type>);
+    static_assert(is_same_v<layout_left::mapping<E>::size_type, E::size_type>);
+    static_assert(is_same_v<layout_left::mapping<E>::rank_type, E::rank_type>);
+    static_assert(is_same_v<layout_left::mapping<E>::layout_type, layout_left>);
+}
+
+void layout_right_tests_traits() {
+#ifdef __cpp_lib_concepts
+    static_assert(is_regular_trivial_nothrow_v<layout_right::mapping<extents<size_t, 2, 3>>>);
+    static_assert(is_regular_trivial_nothrow_v<layout_right::mapping<extents<size_t, dynamic_extent, 3>>>);
+    static_assert(is_regular_trivial_nothrow_v<layout_right::mapping<extents<size_t, 2, dynamic_extent>>>);
+    static_assert(is_regular_trivial_nothrow_v<layout_right::mapping<extents<size_t, dynamic_extent, dynamic_extent>>>);
+#endif // __cpp_lib_concepts
+
+    using E = extents<int, 2, 3>;
+    static_assert(is_same_v<layout_right::mapping<E>::extents_type, E>);
+    static_assert(is_same_v<layout_right::mapping<E>::index_type, E::index_type>);
+    static_assert(is_same_v<layout_right::mapping<E>::size_type, E::size_type>);
+    static_assert(is_same_v<layout_right::mapping<E>::rank_type, E::rank_type>);
+    static_assert(is_same_v<layout_right::mapping<E>::layout_type, layout_right>);
+}
+
+void layout_stride_tests_traits() {
+#ifdef __cpp_lib_concepts
+    static_assert(is_regular_trivial_nothrow_v<layout_stride::mapping<extents<size_t, 2, 3>>>);
+    static_assert(is_regular_trivial_nothrow_v<layout_stride::mapping<extents<size_t, dynamic_extent, 3>>>);
+    static_assert(is_regular_trivial_nothrow_v<layout_stride::mapping<extents<size_t, 2, dynamic_extent>>>);
+    static_assert(
+        is_regular_trivial_nothrow_v<layout_stride::mapping<extents<size_t, dynamic_extent, dynamic_extent>>>);
+#endif // __cpp_lib_concepts
+
+    using E = extents<int, 2, 3>;
+    static_assert(is_same_v<layout_stride::mapping<E>::extents_type, E>);
+    static_assert(is_same_v<layout_stride::mapping<E>::index_type, E::index_type>);
+    static_assert(is_same_v<layout_stride::mapping<E>::size_type, E::size_type>);
+    static_assert(is_same_v<layout_stride::mapping<E>::rank_type, E::rank_type>);
+    static_assert(is_same_v<layout_stride::mapping<E>::layout_type, layout_stride>);
+}
+
+void layout_left_tests_properties() {
+    constexpr layout_left::mapping<extents<size_t, 2, 3>> map{};
+    static_assert(map.is_unique() == true);
+    static_assert(map.is_exhaustive() == true);
+    static_assert(map.is_strided() == true);
+
+    static_assert(decltype(map)::is_always_unique() == true);
+    static_assert(decltype(map)::is_always_exhaustive() == true);
+    static_assert(decltype(map)::is_always_strided() == true);
+}
+
+void layout_right_tests_properties() {
+    constexpr layout_right::mapping<extents<size_t, 2, 3>> map{};
+    static_assert(map.is_unique() == true);
+    static_assert(map.is_exhaustive() == true);
+    static_assert(map.is_strided() == true);
+
+    static_assert(decltype(map)::is_always_unique() == true);
+    static_assert(decltype(map)::is_always_exhaustive() == true);
+    static_assert(decltype(map)::is_always_strided() == true);
+}
+
+void layout_stride_tests_properties() {
+    constexpr layout_stride::mapping<extents<size_t, 2, 3>> map{};
+    static_assert(map.is_unique() == true);
+    static_assert(map.is_strided() == true);
+
+    static_assert(decltype(map)::is_always_unique() == true);
+    static_assert(decltype(map)::is_always_exhaustive() == false);
+    static_assert(decltype(map)::is_always_strided() == true);
+}
+
+void layout_left_tests_extents_ctor() {
+    constexpr extents<size_t, 2, 3> e1;
+    constexpr extents<size_t, 5, dynamic_extent> e2{7};
+    constexpr extents<size_t, dynamic_extent, 13> e3{11};
+    constexpr extents<size_t, dynamic_extent, dynamic_extent> e4{17, 19};
+
+    constexpr layout_left::mapping m1{e1};
+    static_assert(m1.extents() == e1);
+
+    constexpr layout_left::mapping m2{e2};
+    static_assert(m2.extents() == e2);
+
+    constexpr layout_left::mapping m3{e3};
+    static_assert(m3.extents() == e3);
+
+    constexpr layout_left::mapping m4{e4};
+    static_assert(m4.extents() == e4);
+}
+
+void layout_right_tests_extents_ctor() {
+    constexpr extents<size_t, 2, 3> e1;
+    constexpr extents<size_t, 5, dynamic_extent> e2{7};
+    constexpr extents<size_t, dynamic_extent, 13> e3{11};
+    constexpr extents<size_t, dynamic_extent, dynamic_extent> e4{17, 19};
+
+    constexpr layout_right::mapping m1{e1};
+    static_assert(m1.extents() == e1);
+
+    constexpr layout_right::mapping m2{e2};
+    static_assert(m2.extents() == e2);
+
+    constexpr layout_right::mapping m3{e3};
+    static_assert(m3.extents() == e3);
+
+    constexpr layout_right::mapping m4{e4};
+    static_assert(m4.extents() == e4);
+}
+
+void layout_stride_tests_extents_ctor() {
+    constexpr extents<size_t, 2, 3> e1;
+    constexpr array<size_t, 2> s1{1, 2};
+
+    constexpr layout_stride::mapping m1{e1, s1};
+    static_assert(m1.extents() == e1);
+    static_assert(m1.strides() == s1);
+
+    constexpr extents<size_t, 5, dynamic_extent> e2{7};
+    constexpr array<size_t, 2> s2{7, 1};
+
+    constexpr layout_stride::mapping m2{e2, s2};
+    static_assert(m2.extents() == e2);
+    static_assert(m2.strides() == s2);
+}
+
+template <class Extents>
+void copy_ctor_helper_left(const Extents& e) {
+    const layout_left::mapping m1{e};
+    const layout_left::mapping m2{m1};
+    assert(m1 == m2);
+}
+
+template <class Extents>
+void copy_ctor_helper_right(const Extents& e) {
+    const layout_right::mapping m1{e};
+    const layout_right::mapping m2{m1};
+    assert(m1 == m2);
+}
+
+void layout_left_tests_copy_ctor() {
+    copy_ctor_helper_left(extents<size_t, 2, 3>{});
+    copy_ctor_helper_left(extents<size_t, 5, dynamic_extent>{7});
+    copy_ctor_helper_left(extents<size_t, dynamic_extent, 13>{11});
+    copy_ctor_helper_left(extents<size_t, dynamic_extent, dynamic_extent>{17, 19});
+}
+
+void layout_right_tests_copy_ctor() {
+    copy_ctor_helper_right(extents<size_t, 2, 3>{});
+    copy_ctor_helper_right(extents<size_t, 5, dynamic_extent>{7});
+    copy_ctor_helper_right(extents<size_t, dynamic_extent, 13>{11});
+    copy_ctor_helper_right(extents<size_t, dynamic_extent, dynamic_extent>{17, 19});
+}
+
+void layout_left_tests_copy_other_extent() {
+    using E1 = extents<size_t, 2, 3>;
+    using E2 = extents<size_t, 2, dynamic_extent>;
+    constexpr E1 e1;
+    constexpr E2 e2{3};
+    constexpr layout_left::mapping<E1> m1(static_cast<E1>(e2));
+    constexpr layout_left::mapping<E2> m2(e1);
+
+    static_assert(m1.extents() == e1);
+    static_assert(m2.extents() == e1);
+    static_assert(m1.extents() == e2);
+    static_assert(m2.extents() == e2);
+}
+
+void layout_right_tests_copy_ctor_other() {
+    using E1 = extents<size_t, 2, 3>;
+    using E2 = extents<size_t, 2, dynamic_extent>;
+    constexpr E1 e1;
+    constexpr E2 e2{3};
+    constexpr layout_right::mapping<E1> m1(static_cast<E1>(e2));
+    constexpr layout_right::mapping<E2> m2(e1);
+
+    static_assert(m1.extents() == e1);
+    static_assert(m2.extents() == e1);
+    static_assert(m1.extents() == e2);
+    static_assert(m2.extents() == e2);
+}
+
+template <class Extents>
+void assign_helper_left(const Extents& e) {
+    const layout_left::mapping m1{e};
+    layout_left::mapping<Extents> m2;
+    m2 = m1;
+    assert(m1 == m2);
+}
+
+template <class Extents>
+void assign_helper_right(const Extents& e) {
+    const layout_right::mapping m1{e};
+    layout_right::mapping<Extents> m2;
+    m2 = m1;
+    assert(m1 == m2);
+}
+
+void layout_left_tests_assign() {
+    assign_helper_left(extents<size_t, 2, 3>{});
+    assign_helper_left(extents<size_t, 5, dynamic_extent>{7});
+    assign_helper_left(extents<size_t, dynamic_extent, 13>{11});
+    assign_helper_left(extents<size_t, dynamic_extent, dynamic_extent>{17, 19});
+}
+
+void layout_right_tests_assign() {
+    assign_helper_right(extents<size_t, 2, 3>{});
+    assign_helper_right(extents<size_t, 5, dynamic_extent>{7});
+    assign_helper_right(extents<size_t, dynamic_extent, 13>{11});
+    assign_helper_right(extents<size_t, dynamic_extent, dynamic_extent>{17, 19});
+}
+
+void layout_left_tests_ctor_other_layout() {
+    using E = extents<size_t, 1>;
+
+    // from layout_left
+    using OE1 = extents<size_t, 1>;
+    static_assert(is_nothrow_constructible_v<layout_left::mapping<E>, layout_right::mapping<OE1>>);
+    static_assert(is_nothrow_convertible_v<layout_right::mapping<OE1>, layout_left::mapping<E>>);
+
+    using OE2 = extents<size_t, dynamic_extent>; // not convertible
+    static_assert(is_nothrow_constructible_v<layout_left::mapping<E>, layout_right::mapping<OE2>>);
+    static_assert(!is_convertible_v<layout_right::mapping<OE2>, layout_left::mapping<E>>);
+
+    using OE3 = extents<size_t, 1, 2>; // not constructible, rank > 1
+    static_assert(!is_constructible_v<layout_left::mapping<E>, layout_right::mapping<OE3>>);
+    static_assert(!is_convertible_v<layout_right::mapping<OE3>, layout_left::mapping<E>>);
+
+    static_assert(!is_constructible_v<layout_left::mapping<OE3>, layout_right::mapping<OE3>>);
+    static_assert(!is_convertible_v<layout_right::mapping<OE3>, layout_left::mapping<OE3>>);
+
+    // from layout_stride
+    static_assert(is_constructible_v<layout_left::mapping<extents<size_t>>, layout_stride::mapping<extents<size_t>>>);
+    static_assert(is_convertible_v<layout_stride::mapping<extents<size_t>>, layout_left::mapping<extents<size_t>>>);
+
+    static_assert(is_constructible_v<layout_left::mapping<E>, layout_stride::mapping<OE1>>);
+    static_assert(!is_convertible_v<layout_stride::mapping<OE1>, layout_left::mapping<E>>);
+
+    static_assert(!is_constructible_v<layout_left::mapping<E>, layout_stride::mapping<OE3>>);
+    static_assert(!is_convertible_v<layout_stride::mapping<OE3>, layout_left::mapping<E>>);
+}
+
+void layout_right_tests_ctor_other_layout() {
+    using E = extents<size_t, 1>;
+
+    // from layout_left
+    using OE1 = extents<size_t, 1>;
+    static_assert(is_nothrow_constructible_v<layout_right::mapping<E>, layout_left::mapping<OE1>>);
+    static_assert(is_nothrow_convertible_v<layout_left::mapping<OE1>, layout_right::mapping<E>>);
+
+    using OE2 = extents<size_t, dynamic_extent>; // not convertible
+    static_assert(is_nothrow_constructible_v<layout_right::mapping<E>, layout_left::mapping<OE2>>);
+    static_assert(!is_convertible_v<layout_left::mapping<OE2>, layout_right::mapping<E>>);
+
+    using OE3 = extents<size_t, 1, 2>; // not constructible, rank > 1
+    static_assert(!is_constructible_v<layout_right::mapping<E>, layout_left::mapping<OE3>>);
+    static_assert(!is_convertible_v<layout_left::mapping<OE3>, layout_right::mapping<E>>);
+
+    static_assert(!is_constructible_v<layout_right::mapping<OE3>, layout_left::mapping<OE3>>);
+    static_assert(!is_convertible_v<layout_left::mapping<OE3>, layout_right::mapping<OE3>>);
+
+    // from layout_stride
+    static_assert(is_constructible_v<layout_right::mapping<extents<size_t>>, layout_stride::mapping<extents<size_t>>>);
+    static_assert(is_convertible_v<layout_stride::mapping<extents<size_t>>, layout_right::mapping<extents<size_t>>>);
+
+    static_assert(is_constructible_v<layout_right::mapping<E>, layout_stride::mapping<OE1>>);
+    static_assert(!is_convertible_v<layout_stride::mapping<OE1>, layout_right::mapping<E>>);
+
+    static_assert(!is_constructible_v<layout_right::mapping<E>, layout_stride::mapping<OE3>>);
+    static_assert(!is_convertible_v<layout_stride::mapping<OE3>, layout_right::mapping<E>>);
+}
+
+void layout_left_tests_strides() {
+    using E = extents<size_t, 2, 3, 5, 7>;
+    layout_left::mapping<E> map;
+    static_assert(map.stride(0) == 1);
+    static_assert(map.stride(1) == 2);
+    static_assert(map.stride(2) == 2 * 3);
+    static_assert(map.stride(3) == 2 * 3 * 5);
+}
+
+void layout_right_tests_strides() {
+    using E = extents<size_t, 2, 3, 5, 7>;
+    layout_right::mapping<E> map;
+    static_assert(map.stride(0) == 7 * 5 * 3);
+    static_assert(map.stride(1) == 7 * 5);
+    static_assert(map.stride(2) == 7);
+    static_assert(map.stride(3) == 1);
+}
+
+void layout_stride_tests_strides() {
+    using E = extents<size_t, 3, 5>;
+    constexpr array<size_t, 2> s{1, 3};
+    constexpr layout_stride::mapping<E> map{E{}, s};
+    static_assert(map.stride(0) == s[0]);
+    static_assert(map.stride(1) == s[1]);
+    static_assert(map.strides() == s);
+}
+
+void layout_left_tests_indexing() {
+    static_assert(layout_left::mapping<extents<size_t>>{}() == 0);
+    TestMapping(layout_left::mapping<extents<size_t, 2, 3>>{});
+    TestMapping(layout_left::mapping<extents<int, 2, 3>>{});
+}
+
+void layout_right_tests_indexing() {
+    static_assert(layout_right::mapping<extents<size_t>>{}() == 0);
+    TestMapping(layout_right::mapping<extents<size_t, 2, 3>>{});
+    TestMapping(layout_right::mapping<extents<int, 2, 3>>{});
+}
+
+template <class Extents>
+void copy_ctor_helper_stride(const Extents& e) {
+    const layout_stride::mapping<Extents> m1{layout_right::mapping<Extents>{e}};
+    const layout_stride::mapping<Extents> m2{m1};
+    assert(m1 == m2);
+}
+
+void layout_stride_tests_copy_ctor() {
+    copy_ctor_helper_stride(extents<size_t, 2, 3>{});
+    copy_ctor_helper_stride(extents<size_t, 5, dynamic_extent>{7});
+    copy_ctor_helper_stride(extents<size_t, dynamic_extent, 13>{11});
+    copy_ctor_helper_stride(extents<size_t, dynamic_extent, dynamic_extent>{17, 19});
+}
+
+void layout_stride_tests_ctor_other_extents() {
+    constexpr extents<size_t, 2, 3> e1;
+    constexpr extents<size_t, 2, dynamic_extent> e2{3};
+    constexpr array<size_t, 2> s{3, 1};
+
+    constexpr layout_stride::mapping<decltype(e1)> m1(e1, s);
+    constexpr layout_stride::mapping<decltype(e2)> m2(m1);
+
+    static_assert(m2.extents() == e1);
+    static_assert(m2.strides() == s);
+}
+
+template <class LayoutMapping>
+void other_mapping_helper() {
+    constexpr LayoutMapping other;
+    constexpr layout_stride::mapping<typename LayoutMapping::extents_type> map{other};
+    static_assert(map.extents() == other.extents());
+    for (size_t i = 0; i < LayoutMapping::extents_type::rank(); ++i) {
+        assert(map.stride(i) == other.stride(i));
+    }
+}
+void layout_stride_tests_ctor_other_mapping() {
+    using E = extents<size_t, 2, 3>;
+    other_mapping_helper<layout_left::mapping<E>>();
+    other_mapping_helper<layout_right::mapping<E>>();
+}
+
+template <class Extents>
+void assign_helper_stride(const Extents& e) {
+    const layout_stride::mapping<Extents> m1{layout_right::mapping<Extents>{e}};
+    layout_stride::mapping<Extents> m2;
+    m2 = m1;
+    assert(m1 == m2);
+}
+
+void layout_stride_tests_assign() {
+    assign_helper_stride(extents<size_t, 2, 3>{});
+    assign_helper_stride(extents<size_t, 5, dynamic_extent>{7});
+    assign_helper_stride(extents<size_t, dynamic_extent, 13>{11});
+    assign_helper_stride(extents<size_t, dynamic_extent, dynamic_extent>{17, 19});
+}
+
+void layout_stride_tests_indexing_static() {
+    using E = extents<size_t, 2, 3>;
+    TestMapping(layout_stride::mapping<E>{E{}, array<size_t, 2>{1, 2}});
+    TestMapping(layout_stride::mapping<E>{E{}, array<size_t, 2>{3, 1}});
+
+    // non-exhaustive mappings
+    TestMapping(layout_stride::mapping<E>{E{}, array<size_t, 2>{1, 3}});
+    TestMapping(layout_stride::mapping<E>{E{}, array<size_t, 2>{4, 1}});
+    TestMapping(layout_stride::mapping<E>{E{}, array<size_t, 2>{2, 3}});
+
+    // exhaustive mappings with singleton dimensions
+    using E1 = extents<int, 2, 1, 3>;
+    TestMapping(layout_stride::mapping<E1>{E1{}, array<int, 3>{3, 1, 1}});
+    TestMapping(layout_stride::mapping<E1>{E1{}, array<int, 3>{3, 7, 1}});
+
+    using E2 = extents<int, 2, 3, 1>;
+    TestMapping(layout_stride::mapping<E2>{E2{}, array<int, 3>{3, 1, 1}});
+    TestMapping(layout_stride::mapping<E2>{E2{}, array<int, 3>{3, 1, 11}});
+
+    using E3 = extents<int, 3, 2, 1>;
+    TestMapping(layout_stride::mapping<E3>{E3{}, array<int, 3>{1, 3, 1}});
+    TestMapping(layout_stride::mapping<E3>{E3{}, array<int, 3>{1, 3, 13}});
+}
+
+
+void layout_stride_tests_equality() {
+    using E = extents<size_t, 2, 3>;
+    constexpr layout_stride::mapping<E> map1(layout_right::mapping<E>{});
+    constexpr layout_stride::mapping<E> map2(layout_right::mapping<E>{});
+    static_assert(map1 == map2);
+
+    constexpr layout_stride::mapping<E> map3{layout_left::mapping<E>{}};
+    static_assert(map1 != map3);
+
+    using ED = extents<size_t, dynamic_extent, dynamic_extent>;
+    constexpr layout_stride::mapping<ED> map4{ED{2, 3}, map1.strides()};
+    static_assert(map1 == map4);
+}
+
+void accessor_tests_general() {
+    default_accessor<double> a;
+    double arr[4] = {};
+    static_assert(a.offset(arr, 3) == &arr[3]);
+
+    a.access(arr, 2) = 42;
+    assert(arr[2] == 42);
+
+    static_assert(is_constructible_v<default_accessor<const double>, default_accessor<double>>);
+    static_assert(!is_constructible_v<default_accessor<double>, default_accessor<const double>>);
+}
+
+namespace Pathological {
+
+    struct Empty {};
+
+    struct Extents {
+        using index_type = int;
+        using size_type  = std::make_unsigned_t<index_type>;
+        using rank_type  = size_t;
+
+        explicit Extents(Empty) {}
+
+        template <size_t N>
+        explicit Extents(const array<Empty, N>&) {}
+
+        static constexpr size_t rank() {
+            return 0;
+        }
+
+        static constexpr size_t rank_dynamic() {
+            return 0;
+        }
+    };
+
+    struct Layout {
+        template <class E>
+        struct mapping {
+            using extents_type = E;
+            using layout_type  = Layout;
+            mapping(Extents) {}
+        };
+    };
+
+    struct Accessor {
+        using data_handle_type = int*;
+        using reference        = int&;
+        Accessor(int) {}
+    };
+} // namespace Pathological
+
+void mdspan_tests_traits() {
+    using M = mdspan<const int, extents<size_t, 2, 3>>;
+    static_assert(is_trivially_copyable_v<M> /*&& is_default_constructible_v<M>*/
+                  && is_copy_constructible_v<M> && is_move_constructible_v<M> && is_copy_assignable_v<M>
+                  && is_move_assignable_v<M>);
+
+    static_assert(is_same_v<M::extents_type, extents<size_t, 2, 3>>);
+    static_assert(is_same_v<M::layout_type, layout_right>);
+    static_assert(is_same_v<M::accessor_type, default_accessor<const int>>);
+    static_assert(is_same_v<M::mapping_type, layout_right::mapping<extents<size_t, 2, 3>>>);
+    static_assert(is_same_v<M::element_type, const int>);
+    static_assert(is_same_v<M::value_type, int>);
+    static_assert(is_same_v<M::size_type, size_t>);
+    static_assert(is_same_v<M::data_handle_type, const int*>);
+    static_assert(is_same_v<M::reference, const int&>);
+}
+
+void mdspan_tests_ctor_sizes() {
+    static constexpr int arr[6] = {};
+    constexpr mdspan<const int, extents<size_t, dynamic_extent, 3>> mds1(arr, 2);
+    static_assert(mds1.data_handle() == arr);
+    static_assert((mds1.extents() == extents<size_t, 2, 3>{}));
+    static_assert(mds1.is_exhaustive());
+
+    static_assert(!is_constructible_v<mdspan<int, Pathological::Extents, Pathological::Layout>, int*,
+                  Pathological::Empty>); // Empty not convertible to size_type
+
+    // TRANSITION: this assert should be true
+    // static_assert(!is_constructible_v<mdspan<int, Pathological::Extents, Pathological::Layout>, int*,
+    //              int>); // Pathological::Extents not constructible from int
+
+    static_assert(!is_constructible_v<mdspan<int, extents<size_t, dynamic_extent>, Pathological::Layout>, int*,
+                  int>); // Pathological::Layout not constructible from extents<size_t, dynamic_extent>
+
+    static_assert(
+        !is_constructible_v<mdspan<int, extents<size_t, dynamic_extent>, layout_right, Pathological::Accessor>, int*,
+            int>); // Pathological::Accessor not default constructible
+}
+
+void mdspan_tests_ctor_array() {
+    static constexpr int arr[6] = {};
+    constexpr mdspan<const int, extents<size_t, dynamic_extent, 3>> mds1(arr, array{2});
+    static_assert(mds1.data_handle() == arr);
+    static_assert(mds1.extents() == extents<size_t, 2, 3>{});
+
+    static_assert(!is_constructible_v<mdspan<int, Pathological::Extents, Pathological::Layout>, int*,
+                  array<Pathological::Empty, 1>>); // Empty not convertible to size_type
+
+    static_assert(!is_constructible_v<mdspan<int, Pathological::Extents, Pathological::Layout>, int*,
+                  array<int, 1>>); // Pathological::Extents not constructible from int
+
+    static_assert(!is_constructible_v<mdspan<int, extents<size_t, dynamic_extent>, Pathological::Layout>, int*,
+                  array<int, 1>>); // Pathological::Layout not constructible from extents<size_t, dynamic_extent>
+
+    static_assert(
+        !is_constructible_v<mdspan<int, extents<size_t, dynamic_extent>, layout_right, Pathological::Accessor>, int*,
+            array<int, 1>>); // Pathological::Accessor not default constructible
+}
+
+void mdspan_tests_ctor_extents() {
+    static constexpr int arr[6] = {};
+    constexpr mdspan<const int, extents<size_t, dynamic_extent, 3>> mds1(arr, extents<size_t, dynamic_extent, 3>{2});
+    static_assert(mds1.data_handle() == arr);
+    static_assert(mds1.extents() == extents<size_t, 2, 3>{});
+
+    static_assert(!is_constructible_v<mdspan<int, extents<size_t, dynamic_extent>, Pathological::Layout>, int*,
+                  extents<size_t, dynamic_extent>>); // Pathological::Layout not constructible from extents<size_t,
+                                                     // dynamic_extent>
+
+    static_assert(
+        !is_constructible_v<mdspan<int, extents<size_t, dynamic_extent>, layout_right, Pathological::Accessor>, int*,
+            extents<size_t, dynamic_extent>>); // Pathological::Accessor not default constructible
+}
+
+void mdspan_tests_ctor_mapping() {
+    static constexpr int arr[6] = {};
+    using E                     = extents<size_t, dynamic_extent, 3>;
+    constexpr layout_left::mapping<extents<size_t, 2, 3>> map(extents<size_t, 2, 3>{});
+
+    constexpr mdspan<const int, E, layout_left> mds1(arr, map);
+    static_assert(mds1.data_handle() == arr);
+    static_assert(mds1.extents() == extents<size_t, 2, 3>{});
+    static_assert(mds1.mapping() == map);
+
+    static_assert(
+        !is_constructible_v<mdspan<int, extents<size_t, dynamic_extent>, layout_right, Pathological::Accessor>, int*,
+            extents<size_t, dynamic_extent>>); // Pathological::Accessor not default constructible
+}
+
+template <class Type>
+struct stateful_accessor {
+    using data_handle_type = Type*;
+    using reference        = Type&;
+
+    constexpr stateful_accessor(int i_) : i(i_){};
+    int i = 0;
+};
+
+void mdspan_tests_ctor_accessor() {
+    static constexpr int arr[6] = {};
+    using E                     = extents<size_t, dynamic_extent, 3>;
+    constexpr layout_left::mapping<extents<size_t, 2, 3>> map(extents<size_t, 2, 3>{});
+    constexpr stateful_accessor<const int> acc(1);
+
+    constexpr mdspan<const int, E, layout_left, stateful_accessor<const int>> mds1(arr, map, acc);
+    static_assert(mds1.data_handle() == arr);
+    static_assert(mds1.extents() == extents<size_t, 2, 3>{});
+    static_assert(mds1.mapping() == map);
+    static_assert(mds1.accessor().i == 1);
+
+    static_assert(
+        !is_constructible_v<mdspan<int, extents<size_t, dynamic_extent>, layout_right, Pathological::Accessor>, int*,
+            extents<size_t, dynamic_extent>>); // Pathological::Accessor not default constructible
+}
+
+void mdspan_tests_assign() {
+    using E2   = extents<size_t, 2>;
+    int arr[6] = {};
+    mdspan<int, extents<size_t, dynamic_extent>> mds1(arr, 2);
+    mdspan<int, extents<size_t, dynamic_extent>> mds2(nullptr, 3);
+    mds2 = mds1;
+    assert(mds2.data_handle() == arr);
+    assert(mds2.extents() == E2{});
+    assert(mds2.mapping() == mds1.mapping());
+}
+
+void mdspan_tests_observers() {
+    using E             = extents<size_t, dynamic_extent, 3>;
+    static constexpr int arr[] = {0, 1, 2, 3, 4, 5, 6, 7};
+    constexpr mdspan<const int, E, layout_stride> mds{arr, layout_stride::mapping<E>{E{2}, array<size_t, 2>{1, 3}}};
+
+    static_assert(mds.rank() == 2);
+    static_assert(mds.rank_dynamic() == 1);
+
+    static_assert(mds.static_extent(0) == dynamic_extent);
+    static_assert(mds.static_extent(1) == 3);
+    static_assert(mds.extent(0) == 2);
+    static_assert(mds.extent(1) == 3);
+    static_assert(mds.size() == 6);
+
+    static_assert(mds.stride(0) == 1);
+    static_assert(mds.stride(1) == 3);
+
+    static_assert(mds.is_always_unique());
+    static_assert(!mds.is_always_exhaustive());
+    static_assert(mds.is_always_strided());
+
+    static_assert(mds.is_unique());
+    static_assert(!mds.is_exhaustive());
+    static_assert(mds.is_strided());
+
+    static_assert(mds(1, 0) == 1);
+    static_assert(mds(1, 2) == 7);
+
+    static_assert(mds[array{0, 1}] == 3);
+    static_assert(mds[array{1, 1}] == 4);
+}
+
+int main() {
+    extent_tests_rank();
+    extent_tests_static_extent();
+    extent_tests_extent();
+    extent_tests_ctor_other_sizes();
+    extent_tests_copy_ctor_other();
+    extent_tests_ctor_array();
+    extent_tests_ctor_span();
+    extent_tests_equality();
+
+    layout_left_tests_traits();
+    layout_left_tests_properties();
+    layout_left_tests_extents_ctor();
+    layout_left_tests_copy_ctor();
+    layout_left_tests_copy_other_extent();
+    layout_left_tests_assign();
+    layout_left_tests_ctor_other_layout();
+    layout_left_tests_strides();
+    layout_left_tests_indexing();
+
+    layout_right_tests_traits();
+    layout_right_tests_properties();
+    layout_right_tests_extents_ctor();
+    layout_right_tests_copy_ctor();
+    layout_right_tests_copy_ctor_other();
+    layout_right_tests_assign();
+    layout_right_tests_ctor_other_layout();
+    layout_right_tests_strides();
+    layout_right_tests_indexing();
+
+    layout_stride_tests_traits();
+    layout_stride_tests_properties();
+    layout_stride_tests_extents_ctor();
+    layout_stride_tests_strides();
+    layout_stride_tests_copy_ctor();
+    layout_stride_tests_ctor_other_extents();
+    layout_stride_tests_ctor_other_mapping();
+    layout_stride_tests_assign();
+    layout_stride_tests_indexing_static();
+    layout_stride_tests_equality();
+
+    accessor_tests_general();
+
+    mdspan_tests_traits();
+    mdspan_tests_ctor_sizes();
+    mdspan_tests_ctor_array();
+    mdspan_tests_ctor_extents();
+    mdspan_tests_ctor_mapping();
+    mdspan_tests_ctor_accessor();
+    mdspan_tests_assign();
+    mdspan_tests_observers();
+
+    return 0;
+}

--- a/tests/std/tests/P1502R1_standard_library_header_units/importable_cxx_library_headers.jsonc
+++ b/tests/std/tests/P1502R1_standard_library_header_units/importable_cxx_library_headers.jsonc
@@ -40,6 +40,7 @@
     "list",
     "locale",
     "map",
+    "mdspan",
     "memory",
     "memory_resource",
     "mutex",

--- a/tests/std/tests/P1502R1_standard_library_header_units/test.cpp
+++ b/tests/std/tests/P1502R1_standard_library_header_units/test.cpp
@@ -46,6 +46,7 @@ import <limits>;
 import <list>;
 import <locale>;
 import <map>;
+import <mdspan>;
 import <memory>;
 import <memory_resource>;
 import <mutex>;

--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
@@ -1324,6 +1324,20 @@ STATIC_ASSERT(__cpp_lib_math_special_functions == 201603L);
 #endif
 #endif
 
+#if _HAS_CXX23
+#ifndef __cpp_lib_mdspan
+#error __cpp_lib_mdspan is not defined
+#elif __cpp_lib_mdspan != 202207L
+#error __cpp_lib_mdspan is not 202207L
+#else
+STATIC_ASSERT(__cpp_lib_mdspan == 202207L);
+#endif
+#else
+#ifdef __cpp_lib_mdspan
+#error __cpp_lib_mdspan is defined
+#endif
+#endif
+
 #if _HAS_CXX17
 #ifndef __cpp_lib_memory_resource
 #error __cpp_lib_memory_resource is not defined


### PR DESCRIPTION
I've been working on this for a while, but it's gotten to the point where if I hold it until it's fully implemented and tested, there won't be much time left to benchmark. Particularly for `extents` and `layout_strided`, there are different choices you could make about how to store the extents and strides that will affect codegen. If we want to investigate alternatives, it has to be done before ABI is locked. So @StephanTLavavej suggested I just submit what I have to a feature branch. I hope it's a useful starting point.

I think `extents`, `layout_left`, and `layout_right` are in the best shape. When there are constraints on constructors, I've tried to set up tests that each fail exactly one constraint. However, I've lately become doubtful about `is_constructible` due to https://godbolt.org/z/q1M46rf6j. The last two `static_assert`s fail, yet the corresponding definitions just above them don't compile. I've been replacing some of the positive `is_constructible` tests with actual definitions, but it's a work in progress.

Other things that I know are not tested thoroughly:
 - `index_type` vs. `size_type` vs. `rank_type` vs. `size_t`.
 - extended integer types should be allowed
 - correct behavior for rank-zero spaces (equivalent to a scalar) and spaces that have non-zero rank but are empty because at least one extent is zero.

As for optimization, these are what I would look at if I had time:
 - How to access the static extents. I've chosen to store them similar to a `std::array`, as a base class with a special case for zero dimensions, but without the indirection and debug codegen of using as actual `std::array`. Other options I can think of are just using a `std::array` for simplicity, use one of the various algorithms for extracting the n-th member of a parameter pack, or use a recursive base class scheme like `tuple`.
 - The same goes for `layout_stride`. Here I just used a `std::array`, to get the implementation done as quickly as possible.
 - Where an `index_sequence` is used, sometimes I pass it to a function template and sometimes to a generic lambda. The lambda could cause code bloat if it's treated like an anonymous namespace, with internal linkage. But I *think* that identical instantiations in different TUs are supposed to be the same type and `inline`, so the linker will discard the duplicates. If that's not the case, it might be better to convert everything to function templates.
 - Fold expressions vs. `for` loops. I've usually preferred the latter for clarity, but you could probably convert any of them to a fold expression, possibly by introducing an `index_sequence`. I have no intution, though, about whether that would be better, worse, or about the same.

I still hope to be involved, but it will likely have to be on narrow issues, as and when time permits.