### PR TITLE
Implement LWG-3821 `uses_allocator_construction_args` should have overload for `pair-like`

### DIFF
--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -208,9 +208,9 @@ concept _Pair_like = _Tuple_like<_Ty> && tuple_size_v<remove_cvref_t<_Ty>> == 2;
 
 #ifdef __clang__ // TRANSITION, LLVM-59827
 template <class _PairLike, class _Ty1, class _Ty2>
-concept _Can_construct_from_pair_like =
-    _Pair_like<_PairLike> && is_constructible_v<_Ty1, decltype(_STD get<0>(_STD declval<_PairLike>()))>
-    && is_constructible_v<_Ty2, decltype(_STD get<1>(_STD declval<_PairLike>()))>;
+concept _Can_construct_from_pair_like = _Pair_like<_PairLike> && (!_Is_subrange_v<remove_cvref_t<_PairLike>>)
+                                     && is_constructible_v<_Ty1, decltype(_STD get<0>(_STD declval<_PairLike>()))>
+                                     && is_constructible_v<_Ty2, decltype(_STD get<1>(_STD declval<_PairLike>()))>;
 #endif // __clang__
 #endif // _HAS_CXX23
 #endif // __cpp_lib_concepts
@@ -289,7 +289,8 @@ struct pair { // store a pair of values
 #else // ^^^ workaround / no workaround vvv
     template <_Pair_like _Other>
         requires conjunction_v<is_constructible<_Ty1, decltype(_STD get<0>(_STD declval<_Other>()))>,
-                     is_constructible<_Ty2, decltype(_STD get<1>(_STD declval<_Other>()))>>
+                     is_constructible<_Ty2, decltype(_STD get<1>(_STD declval<_Other>()))>,
+                     bool_constant<!_Is_subrange_v<remove_cvref_t<_Other>>>>
 #endif // __clang__
     constexpr explicit(!conjunction_v<is_convertible<decltype(_STD get<0>(_STD declval<_Other>())), _Ty1>,
                        is_convertible<decltype(_STD get<1>(_STD declval<_Other>())), _Ty2>>)

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -288,9 +288,9 @@ struct pair { // store a pair of values
     template <class _Other, enable_if_t<_Can_construct_from_pair_like<_Other, _Ty1, _Ty2>, int> = 0>
 #else // ^^^ workaround / no workaround vvv
     template <_Pair_like _Other>
-        requires conjunction_v<is_constructible<_Ty1, decltype(_STD get<0>(_STD declval<_Other>()))>,
-                     is_constructible<_Ty2, decltype(_STD get<1>(_STD declval<_Other>()))>,
-                     bool_constant<!_Is_subrange_v<remove_cvref_t<_Other>>>>
+        requires conjunction_v<bool_constant<!_Is_subrange_v<remove_cvref_t<_Other>>>,
+                     is_constructible<_Ty1, decltype(_STD get<0>(_STD declval<_Other>()))>,
+                     is_constructible<_Ty2, decltype(_STD get<1>(_STD declval<_Other>()))>>
 #endif // __clang__
     constexpr explicit(!conjunction_v<is_convertible<decltype(_STD get<0>(_STD declval<_Other>())), _Ty1>,
                        is_convertible<decltype(_STD get<1>(_STD declval<_Other>())), _Ty2>>)

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -2407,10 +2407,12 @@ _NODISCARD constexpr auto uses_allocator_construction_args(const _Alloc& _Al, _U
     if constexpr (_Pair_like<_Uty> && !_Is_subrange_v<remove_cvref_t<_Ty>>) {
         // equivalent to
         // return _STD uses_allocator_construction_args<_Ty>(_Al, piecewise_construct,
-        //     _STD forward_as_tuple(_STD get<0>(_STD move(_Ux)), _STD forward_as_tuple(_STD get<1>(_STD move(_Ux)));
+        //     _STD forward_as_tuple(_STD get<0>(_STD forward<_Uty>(_Ux)),
+        //     _STD forward_as_tuple(_STD get<1>(_STD forward<_Uty>(_Ux)));
         return _STD make_tuple(piecewise_construct,
-            _STD uses_allocator_construction_args<typename _Ty::first_type>(_Al, _STD get<0>(_STD move(_Ux))),
-            _STD uses_allocator_construction_args<typename _Ty::second_type>(_Al, _STD get<1>(_STD move(_Ux))));
+            _STD uses_allocator_construction_args<typename _Ty::first_type>(_Al, _STD get<0>(_STD forward<_Uty>(_Ux))),
+            _STD uses_allocator_construction_args<typename _Ty::second_type>(
+                _Al, _STD get<1>(_STD forward<_Uty>(_Ux))));
     } else
 #endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
     {

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -2304,8 +2304,13 @@ _NODISCARD constexpr auto uses_allocator_construction_args(
     const _Alloc& _Al, const pair<_Uty1, _Uty2>&& _Pair) noexcept;
 #endif // _HAS_CXX23
 
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
+_EXPORT_STD template <class _Ty, class _Alloc, class _Uty>
+    requires _Is_cv_pair<_Ty> && (_Pair_like<_Uty> || !_Is_deducible_as_pair<_Uty&>)
+#else // ^^^ C++23 with concepts / C++20 or no concepts vvv
 _EXPORT_STD template <class _Ty, class _Alloc, class _Uty,
     enable_if_t<_Is_cv_pair<_Ty> && !_Is_deducible_as_pair<_Uty&>, int> = 0>
+#endif // ^^^ C++20 or no concepts ^^^
 _NODISCARD constexpr auto uses_allocator_construction_args(const _Alloc& _Al, _Uty&& _Ux) noexcept;
 
 _EXPORT_STD template <class _Ty, class _Alloc, class _Tuple1, class _Tuple2, enable_if_t<_Is_cv_pair<_Ty>, int> = 0>
@@ -2390,41 +2395,58 @@ _NODISCARD constexpr auto uses_allocator_construction_args(
 }
 #endif // _HAS_CXX23
 
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
+_EXPORT_STD template <class _Ty, class _Alloc, class _Uty>
+    requires _Is_cv_pair<_Ty> && (_Pair_like<_Uty> || !_Is_deducible_as_pair<_Uty&>)
+#else // ^^^ C++23 with concepts / C++20 or no concepts vvv
 _EXPORT_STD template <class _Ty, class _Alloc, class _Uty,
     enable_if_t<_Is_cv_pair<_Ty> && !_Is_deducible_as_pair<_Uty&>, int>>
+#endif // ^^^ C++20 or no concepts ^^^
 _NODISCARD constexpr auto uses_allocator_construction_args(const _Alloc& _Al, _Uty&& _Ux) noexcept {
-    struct _Pair_remaker {
-        const _Alloc& _Al;
-        _Uty& _Ux;
+#if _HAS_CXX23 && defined(__cpp_lib_concepts)
+    if constexpr (_Pair_like<_Uty> && !_Is_subrange_v<remove_cvref_t<_Ty>>) {
+        // equivalent to
+        // return _STD uses_allocator_construction_args<_Ty>(_Al, piecewise_construct,
+        //     _STD forward_as_tuple(_STD get<0>(_STD move(_Ux)), _STD forward_as_tuple(_STD get<1>(_STD move(_Ux)));
+        return _STD make_tuple(piecewise_construct,
+            _STD uses_allocator_construction_args<typename _Ty::first_type>(_Al, _STD get<0>(_STD move(_Ux))),
+            _STD uses_allocator_construction_args<typename _Ty::second_type>(_Al, _STD get<1>(_STD move(_Ux))));
+    } else
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
+    {
+        struct _Pair_remaker {
+            const _Alloc& _Al;
+            _Uty& _Ux;
 
-        constexpr operator remove_cv_t<_Ty>() const {
-            using _Pair_t = remove_cv_t<_Ty>;
-            static_assert(_Is_normally_bindable<_Pair_t, _Uty>,
-                "The argument must be bindable to a reference to the std::pair type.");
+            constexpr operator remove_cv_t<_Ty>() const {
+                using _Pair_t = remove_cv_t<_Ty>;
+                static_assert(_Is_normally_bindable<_Pair_t, _Uty>,
+                    "The argument must be bindable to a reference to the std::pair type.");
 
-            using _Pair_first_t   = typename _Pair_t::first_type;
-            using _Pair_second_t  = typename _Pair_t::second_type;
-            using _Pair_ref_t     = _Normally_bound_ref<_Pair_t, _Uty>;
-            _Pair_ref_t _Pair_ref = _STD forward<_Uty>(_Ux);
-            if constexpr (is_same_v<_Pair_ref_t, const _Pair_t&>) {
-                // equivalent to
-                // return _STD make_obj_using_allocator<_Pair_t>(_Al, _Pair_ref);
-                return _Pair_t{piecewise_construct,
-                    _STD uses_allocator_construction_args<_Pair_first_t>(_Al, _Pair_ref.first),
-                    _STD uses_allocator_construction_args<_Pair_second_t>(_Al, _Pair_ref.second)};
-            } else {
-                // equivalent to
-                // return _STD make_obj_using_allocator<_Pair_t>(_Al, _STD move(_Pair_ref));
-                return _Pair_t{piecewise_construct,
-                    _STD uses_allocator_construction_args<_Pair_first_t>(_Al, _STD get<0>(_STD move(_Pair_ref))),
-                    _STD uses_allocator_construction_args<_Pair_second_t>(_Al, _STD get<1>(_STD move(_Pair_ref)))};
+                using _Pair_first_t   = typename _Pair_t::first_type;
+                using _Pair_second_t  = typename _Pair_t::second_type;
+                using _Pair_ref_t     = _Normally_bound_ref<_Pair_t, _Uty>;
+                _Pair_ref_t _Pair_ref = _STD forward<_Uty>(_Ux);
+                if constexpr (is_same_v<_Pair_ref_t, const _Pair_t&>) {
+                    // equivalent to
+                    // return _STD make_obj_using_allocator<_Pair_t>(_Al, _Pair_ref);
+                    return _Pair_t{piecewise_construct,
+                        _STD uses_allocator_construction_args<_Pair_first_t>(_Al, _Pair_ref.first),
+                        _STD uses_allocator_construction_args<_Pair_second_t>(_Al, _Pair_ref.second)};
+                } else {
+                    // equivalent to
+                    // return _STD make_obj_using_allocator<_Pair_t>(_Al, _STD move(_Pair_ref));
+                    return _Pair_t{piecewise_construct,
+                        _STD uses_allocator_construction_args<_Pair_first_t>(_Al, _STD get<0>(_STD move(_Pair_ref))),
+                        _STD uses_allocator_construction_args<_Pair_second_t>(_Al, _STD get<1>(_STD move(_Pair_ref)))};
+                }
             }
-        }
-    };
+        };
 
-    // equivalent to
-    // return _STD make_tuple(_Pair_remaker{_Al, _Ux});
-    return tuple<_Pair_remaker>({_Al, _Ux});
+        // equivalent to
+        // return _STD make_tuple(_Pair_remaker{_Al, _Ux});
+        return tuple<_Pair_remaker>({_Al, _Ux});
+    }
 }
 
 _EXPORT_STD template <class _Ty, class _Alloc, class... _Types>

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -2404,7 +2404,7 @@ _EXPORT_STD template <class _Ty, class _Alloc, class _Uty,
 #endif // ^^^ C++20 or no concepts ^^^
 _NODISCARD constexpr auto uses_allocator_construction_args(const _Alloc& _Al, _Uty&& _Ux) noexcept {
 #if _HAS_CXX23 && defined(__cpp_lib_concepts)
-    if constexpr (_Pair_like<_Uty> && !_Is_subrange_v<remove_cvref_t<_Ty>>) {
+    if constexpr (_Pair_like<_Uty> && !_Is_subrange_v<remove_cvref_t<_Uty>>) {
         // equivalent to
         // return _STD uses_allocator_construction_args<_Ty>(_Al, piecewise_construct,
         //     _STD forward_as_tuple(_STD get<0>(_STD forward<_Uty>(_Ux)),

--- a/tests/std/tests/P0475R1_P0591R4_uses_allocator_construction/test.cpp
+++ b/tests/std/tests/P0475R1_P0591R4_uses_allocator_construction/test.cpp
@@ -182,11 +182,10 @@ constexpr bool test_P0591R4() {
         tuple tpl(i, i);
         auto tuple14 = uses_allocator_construction_args<pair<int, AllocatorArgConstructible>>(alloc, tpl);
         static_assert(
-            is_same_v<decltype(tuple14), tuple<piecewise_construct_t, tuple<int&&>, MovedAllocatorArgConstructArgs>>);
+            is_same_v<decltype(tuple14), tuple<piecewise_construct_t, tuple<int&>, AllocatorArgConstructArgs>>);
 
         auto tuple15 = uses_allocator_construction_args<pair<AllocatorConstructible, int>>(alloc, tpl);
-        static_assert(
-            is_same_v<decltype(tuple15), tuple<piecewise_construct_t, MovedAllocatorConstructArgs, tuple<int&&>>>);
+        static_assert(is_same_v<decltype(tuple15), tuple<piecewise_construct_t, AllocatorConstructArgs, tuple<int&>>>);
 
         auto tuple16 = uses_allocator_construction_args<pair<int, AllocatorArgConstructible>>(alloc, move(tpl));
         static_assert(
@@ -198,11 +197,11 @@ constexpr bool test_P0591R4() {
 
         auto tuple18 = uses_allocator_construction_args<pair<int, AllocatorArgConstructible>>(alloc, as_const(tpl));
         static_assert(is_same_v<decltype(tuple18),
-            tuple<piecewise_construct_t, tuple<const int&&>, MovedConstAllocatorArgConstructArgs>>);
+            tuple<piecewise_construct_t, tuple<const int&>, ConstAllocatorArgConstructArgs>>);
 
         auto tuple19 = uses_allocator_construction_args<pair<AllocatorConstructible, int>>(alloc, as_const(tpl));
-        static_assert(is_same_v<decltype(tuple19),
-            tuple<piecewise_construct_t, MovedConstAllocatorConstructArgs, tuple<const int&&>>>);
+        static_assert(
+            is_same_v<decltype(tuple19), tuple<piecewise_construct_t, ConstAllocatorConstructArgs, tuple<const int&>>>);
 
         auto tuple20 =
             uses_allocator_construction_args<pair<int, AllocatorArgConstructible>>(alloc, move(as_const(tpl)));

--- a/tests/std/tests/P0475R1_P0591R4_uses_allocator_construction/test.cpp
+++ b/tests/std/tests/P0475R1_P0591R4_uses_allocator_construction/test.cpp
@@ -177,6 +177,44 @@ constexpr bool test_P0591R4() {
     }
 #endif // _HAS_CXX23
 
+#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
+    { // pair(PairLike&&) overload
+        tuple tpl(i, i);
+        auto tuple14 = uses_allocator_construction_args<pair<int, AllocatorArgConstructible>>(alloc, tpl);
+        static_assert(
+            is_same_v<decltype(tuple14), tuple<piecewise_construct_t, tuple<int&&>, MovedAllocatorArgConstructArgs>>);
+
+        auto tuple15 = uses_allocator_construction_args<pair<AllocatorConstructible, int>>(alloc, tpl);
+        static_assert(
+            is_same_v<decltype(tuple15), tuple<piecewise_construct_t, MovedAllocatorConstructArgs, tuple<int&&>>>);
+
+        auto tuple16 = uses_allocator_construction_args<pair<int, AllocatorArgConstructible>>(alloc, move(tpl));
+        static_assert(
+            is_same_v<decltype(tuple16), tuple<piecewise_construct_t, tuple<int&&>, MovedAllocatorArgConstructArgs>>);
+
+        auto tuple17 = uses_allocator_construction_args<pair<AllocatorConstructible, int>>(alloc, move(tpl));
+        static_assert(
+            is_same_v<decltype(tuple17), tuple<piecewise_construct_t, MovedAllocatorConstructArgs, tuple<int&&>>>);
+
+        auto tuple18 = uses_allocator_construction_args<pair<int, AllocatorArgConstructible>>(alloc, as_const(tpl));
+        static_assert(is_same_v<decltype(tuple18),
+            tuple<piecewise_construct_t, tuple<const int&&>, MovedConstAllocatorArgConstructArgs>>);
+
+        auto tuple19 = uses_allocator_construction_args<pair<AllocatorConstructible, int>>(alloc, as_const(tpl));
+        static_assert(is_same_v<decltype(tuple19),
+            tuple<piecewise_construct_t, MovedConstAllocatorConstructArgs, tuple<const int&&>>>);
+
+        auto tuple20 =
+            uses_allocator_construction_args<pair<int, AllocatorArgConstructible>>(alloc, move(as_const(tpl)));
+        static_assert(is_same_v<decltype(tuple20),
+            tuple<piecewise_construct_t, tuple<const int&&>, MovedConstAllocatorArgConstructArgs>>);
+
+        auto tuple21 = uses_allocator_construction_args<pair<AllocatorConstructible, int>>(alloc, move(as_const(tpl)));
+        static_assert(is_same_v<decltype(tuple21),
+            tuple<piecewise_construct_t, MovedConstAllocatorConstructArgs, tuple<const int&&>>>);
+    }
+#endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
+
     {
         auto obj1 = make_obj_using_allocator<AllocatorArgConstructible>(alloc, i);
         static_assert(is_same_v<decltype(obj1), AllocatorArgConstructible>);


### PR DESCRIPTION
Fixes #3415.

LWG-3821 patches [P2165R4](https://wg21.link/p2165r4), so it should only be applied to C++23 mode. I think the overload added by LWG-3821 can be merged with the one added by LWG-3525.