### PR TITLE
pool resources: respect `max_blocks_per_chunk`

### DIFF
--- a/stl/inc/memory_resource
+++ b/stl/inc/memory_resource
@@ -513,6 +513,10 @@ namespace pmr {
 
             void _Increase_capacity(unsynchronized_pool_resource& _Pool_resource) {
                 // this pool has no free blocks; get a new chunk from upstream
+                if (_Next_capacity > _Pool_resource._Options.max_blocks_per_chunk) {
+                    // This is a fresh pool, _Next_capacity hasn't yet been bounded by max_blocks_per_chunk:
+                    _Next_capacity = _Pool_resource._Options.max_blocks_per_chunk;
+                }
                 const size_t _Size               = _Size_for_capacity(_Next_capacity);
                 memory_resource* const _Resource = _Pool_resource.upstream_resource();
                 void* const _Ptr                 = _Resource->allocate(_Size, _Block_size);

--- a/tests/std/tests/P0220R1_polymorphic_memory_resources/test.cpp
+++ b/tests/std/tests/P0220R1_polymorphic_memory_resources/test.cpp
@@ -1546,6 +1546,19 @@ namespace {
             al.construct(static_cast<const volatile PairType*>(raw_ptr), mem_pair_conv{});
         }
     } // namespace map_containers
+
+    void test_gh3408() {
+        // We ignored the possibility that max_blocks_per_chunk could be less than _Default_next_capacity
+        recording_resource upstream;
+        std::pmr::pool_options options{};
+        options.max_blocks_per_chunk = 1;
+        std::pmr::unsynchronized_pool_resource res{options, &upstream};
+        const std::size_t size = 0x8009;
+        (void) res.allocate(size);
+        const allocation& alloc = upstream.allocations_[upstream.allocations_.size() - 1];
+        CHECK(alloc.size >= 0x10000);
+        CHECK(alloc.size < 2 * 0x10000);
+    }
 } // unnamed namespace
 
 int main() {
@@ -1591,4 +1604,6 @@ int main() {
     map_containers::test();
 
     map_containers::lwg3677_test();
+
+    test_gh3408();
 }


### PR DESCRIPTION
... even when less than `_Default_next_capacity`.

Fixes #3408
