### PR TITLE
Implement LWG-3720 Restrict the valid types of arg-id for width and precision in std-format-spec

### DIFF
--- a/stl/inc/format
+++ b/stl/inc/format
@@ -1411,8 +1411,8 @@ _NODISCARD constexpr basic_format_arg<_Context> _Get_arg(const _Context& _Ctx, c
 }
 
 template <class _Ty>
-constexpr bool _Standard_signed_or_unsigned_integer = _Is_any_of_v<remove_cv_t<_Ty>, signed char, unsigned char, short,
-    unsigned short, int, unsigned int, long, unsigned long, long long, unsigned long long>;
+inline constexpr bool _Standard_signed_or_unsigned_integer = _Is_any_of_v<remove_cv_t<_Ty>, signed char, unsigned char,
+    short, unsigned short, int, unsigned int, long, unsigned long, long long, unsigned long long>;
 
 // Checks that the type and value of an argument associated with a dynamic
 // width specifier are valid.

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -1411,8 +1411,8 @@ _NODISCARD constexpr basic_format_arg<_Context> _Get_arg(const _Context& _Ctx, c
 }
 
 template <class _Ty>
-inline constexpr bool _Standard_signed_or_unsigned_integer = _Is_any_of_v<remove_cv_t<_Ty>, signed char, unsigned char,
-    short, unsigned short, int, unsigned int, long, unsigned long, long long, unsigned long long>;
+inline constexpr bool _Is_standard_signed_or_unsigned_integer =
+    _Is_any_of_v<remove_cv_t<_Ty>, int, unsigned int, long, unsigned long, long long, unsigned long long>;
 
 // Checks that the type and value of an argument associated with a dynamic
 // width specifier are valid.
@@ -1420,7 +1420,7 @@ class _Width_checker {
 public:
     template <class _Ty>
     _NODISCARD constexpr unsigned long long operator()(const _Ty _Value) const {
-        if constexpr (_Standard_signed_or_unsigned_integer<_Ty>) {
+        if constexpr (_Is_standard_signed_or_unsigned_integer<_Ty>) {
             if constexpr (is_signed_v<_Ty>) {
                 if (_Value < 0) {
                     _Throw_format_error("Negative width.");
@@ -1439,7 +1439,7 @@ class _Precision_checker {
 public:
     template <class _Ty>
     _NODISCARD constexpr unsigned long long operator()(const _Ty _Value) const {
-        if constexpr (_Standard_signed_or_unsigned_integer<_Ty>) {
+        if constexpr (_Is_standard_signed_or_unsigned_integer<_Ty>) {
             if constexpr (is_signed_v<_Ty>) {
                 if (_Value < 0) {
                     _Throw_format_error("Negative precision.");

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -1411,7 +1411,7 @@ _NODISCARD constexpr basic_format_arg<_Context> _Get_arg(const _Context& _Ctx, c
 }
 
 template <class _Ty>
-inline constexpr bool _Is_standard_signed_or_unsigned_integer =
+inline constexpr bool _Is_signed_or_unsigned_large_integer_t =
     _Is_any_of_v<remove_cv_t<_Ty>, int, unsigned int, long, unsigned long, long long, unsigned long long>;
 
 // Checks that the type and value of an argument associated with a dynamic
@@ -1420,7 +1420,7 @@ class _Width_checker {
 public:
     template <class _Ty>
     _NODISCARD constexpr unsigned long long operator()(const _Ty _Value) const {
-        if constexpr (_Is_standard_signed_or_unsigned_integer<_Ty>) {
+        if constexpr (_Is_signed_or_unsigned_large_integer_t<_Ty>) {
             if constexpr (is_signed_v<_Ty>) {
                 if (_Value < 0) {
                     _Throw_format_error("Negative width.");
@@ -1439,7 +1439,7 @@ class _Precision_checker {
 public:
     template <class _Ty>
     _NODISCARD constexpr unsigned long long operator()(const _Ty _Value) const {
-        if constexpr (_Is_standard_signed_or_unsigned_integer<_Ty>) {
+        if constexpr (_Is_signed_or_unsigned_large_integer_t<_Ty>) {
             if constexpr (is_signed_v<_Ty>) {
                 if (_Value < 0) {
                     _Throw_format_error("Negative precision.");

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -1410,13 +1410,17 @@ _NODISCARD constexpr basic_format_arg<_Context> _Get_arg(const _Context& _Ctx, c
     return _Arg;
 }
 
+template <class _Ty>
+constexpr bool _Standard_signed_or_unsigned_integer = _Is_any_of_v<remove_cv_t<_Ty>, signed char, unsigned char, short,
+    unsigned short, int, unsigned int, long, unsigned long, long long, unsigned long long>;
+
 // Checks that the type and value of an argument associated with a dynamic
 // width specifier are valid.
 class _Width_checker {
 public:
     template <class _Ty>
     _NODISCARD constexpr unsigned long long operator()(const _Ty _Value) const {
-        if constexpr (is_integral_v<_Ty>) {
+        if constexpr (_Standard_signed_or_unsigned_integer<_Ty>) {
             if constexpr (is_signed_v<_Ty>) {
                 if (_Value < 0) {
                     _Throw_format_error("Negative width.");
@@ -1435,7 +1439,7 @@ class _Precision_checker {
 public:
     template <class _Ty>
     _NODISCARD constexpr unsigned long long operator()(const _Ty _Value) const {
-        if constexpr (is_integral_v<_Ty>) {
+        if constexpr (_Standard_signed_or_unsigned_integer<_Ty>) {
             if constexpr (is_signed_v<_Ty>) {
                 if (_Value < 0) {
                     _Throw_format_error("Negative precision.");

--- a/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
@@ -1360,9 +1360,8 @@ void libfmt_formatter_test_runtime_width() {
 
     // LWG-3720: Restrict the valid types of arg-id for width and precision in std-format-spec
     throw_helper(STR("{:*^{}}"), 'a', true);
-#ifdef _NATIVE_WCHAR_T_DEFINED
     throw_helper(STR("{:*^{}}"), 'a', '0');
-#endif
+    assert(format(STR("{:*^{}}"), 'a', static_cast<signed char>(2)) == STR("a*"));
 
     assert(format(STR("{0:{1}}"), 42, 0) == STR("42")); // LWG-3721: zero dynamic width is OK
 
@@ -1414,9 +1413,8 @@ void libfmt_formatter_test_runtime_precision() {
 
     // LWG-3720: Restrict the valid types of arg-id for width and precision in std-format-spec
     throw_helper(STR("{:.{}f}"), 3.14f, true);
-#ifdef _NATIVE_WCHAR_T_DEFINED
     throw_helper(STR("{:.{}f}"), 3.14f, '0');
-#endif
+    assert(format(STR("{:.{}f}"), 3.14f, static_cast<signed char>(2)) == STR("3.14"));
 }
 
 template <class charT>

--- a/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
@@ -1356,9 +1356,13 @@ void libfmt_formatter_test_runtime_width() {
     throw_helper(STR("{0:{1}}"), 0, (int_max + 1u));
     throw_helper(STR("{0:{1}}"), 0, -1l);
     throw_helper(STR("{0:{1}}"), 0, (int_max + 1ul));
-    assert(format(STR("{0:{1}}"), 0, '0')
-           == STR("                                               0")); // behavior differs from libfmt, but conforms
     throw_helper(STR("{0:{1}}"), 0, 0.0);
+
+    // LWG-3720: Restrict the valid types of arg-id for width and precision in std-format-spec
+    throw_helper(STR("{:*^{}}"), 'a', true);
+#ifdef _NATIVE_WCHAR_T_DEFINED
+    throw_helper(STR("{:*^{}}"), 'a', '0');
+#endif
 
     assert(format(STR("{0:{1}}"), 42, 0) == STR("42")); // LWG-3721: zero dynamic width is OK
 
@@ -1407,6 +1411,12 @@ void libfmt_formatter_test_runtime_precision() {
     throw_helper(STR("{0:.{1}}"), reinterpret_cast<void*>(0xcafe), 2);
     throw_helper(STR("{0:.{1}f}"), reinterpret_cast<void*>(0xcafe), 2);
     assert(format(STR("{0:.{1}}"), STR("str"), 2) == STR("st"));
+
+    // LWG-3720: Restrict the valid types of arg-id for width and precision in std-format-spec
+    throw_helper(STR("{:.{}f}"), 3.14f, true);
+#ifdef _NATIVE_WCHAR_T_DEFINED
+    throw_helper(STR("{:.{}f}"), 3.14f, '0');
+#endif
 }
 
 template <class charT>

--- a/tests/std/tests/P0645R10_text_formatting_parse_contexts/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_parse_contexts/test.cpp
@@ -96,40 +96,6 @@ constexpr bool test_basic_format_parse_context() {
     return true;
 }
 
-// LWG-3720: Restrict the valid types of arg-id for width and precision in std-format-spec
-void test_lwg3720() {
-    // Width
-    {
-        try {
-            (void) format("{:*^{}}\n", 'a', true);
-            assert(false);
-        } catch (const format_error&) {
-        }
-    }
-    {
-        try {
-            (void) format("{:*^{}}\n", 'a', '0');
-            assert(false);
-        } catch (const format_error&) {
-        }
-    }
-    // Precision
-    {
-        try {
-            (void) format("{:.{}f}", 3.14f, true);
-            assert(false);
-        } catch (const format_error&) {
-        }
-    }
-    {
-        try {
-            (void) format("{:.{}f}", 3.14f, '0');
-            assert(false);
-        } catch (const format_error&) {
-        }
-    }
-}
-
 int main() {
     test_basic_format_parse_context<char>();
     test_basic_format_parse_context<wchar_t>();
@@ -140,6 +106,4 @@ int main() {
     assert(check_arg_id_not_constexpr_char);
     assert(check_arg_id_is_constexpr_wchar);
     assert(check_arg_id_not_constexpr_wchar);
-
-    test_lwg3720();
 }

--- a/tests/std/tests/P0645R10_text_formatting_parse_contexts/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_parse_contexts/test.cpp
@@ -96,6 +96,40 @@ constexpr bool test_basic_format_parse_context() {
     return true;
 }
 
+// LWG-3720: Restrict the valid types of arg-id for width and precision in std-format-spec
+void test_lwg3720() {
+    // Width
+    {
+        try {
+            (void) format("{:*^{}}\n", 'a', true);
+            assert(false);
+        } catch (const format_error&) {
+        }
+    }
+    {
+        try {
+            (void) format("{:*^{}}\n", 'a', '0');
+            assert(false);
+        } catch (const format_error&) {
+        }
+    }
+    // Precision
+    {
+        try {
+            (void) format("{:.{}f}", 3.14f, true);
+            assert(false);
+        } catch (const format_error&) {
+        }
+    }
+    {
+        try {
+            (void) format("{:.{}f}", 3.14f, '0');
+            assert(false);
+        } catch (const format_error&) {
+        }
+    }
+}
+
 int main() {
     test_basic_format_parse_context<char>();
     test_basic_format_parse_context<wchar_t>();
@@ -106,4 +140,6 @@ int main() {
     assert(check_arg_id_not_constexpr_char);
     assert(check_arg_id_is_constexpr_wchar);
     assert(check_arg_id_not_constexpr_wchar);
+
+    test_lwg3720();
 }


### PR DESCRIPTION
Fixes #3425 