### PR TITLE
Cleanups: Friendship is magic

### DIFF
--- a/stl/inc/bitset
+++ b/stl/inc/bitset
@@ -29,7 +29,7 @@ public:
 #pragma warning(pop)
 
     class reference { // proxy for an element
-        friend bitset<_Bits>;
+        friend bitset;
 
     public:
         _CONSTEXPR23 reference(const reference&) = default;

--- a/stl/inc/exception
+++ b/stl/inc/exception
@@ -135,6 +135,8 @@ protected:
     }
 };
 
+class bad_array_new_length;
+
 class bad_alloc : public exception { // base of all bad allocation exceptions
 public:
     __CLR_OR_THIS_CALL bad_alloc() noexcept
@@ -143,7 +145,7 @@ public:
     __CLR_OR_THIS_CALL ~bad_alloc() noexcept override {}
 
 private:
-    friend class bad_array_new_length;
+    friend bad_array_new_length;
 
     __CLR_OR_THIS_CALL bad_alloc(const char* _Message) noexcept
         : exception(_Message, 1) {} // construct from message string with no memory allocation

--- a/stl/inc/filesystem
+++ b/stl/inc/filesystem
@@ -2081,6 +2081,9 @@ namespace filesystem {
     using file_time_type = _CHRONO time_point<filesystem::_File_time_clock>;
 #endif // ^^^ !_HAS_CXX20
 
+    struct _Dir_enum_impl;
+    struct _Recursive_dir_enum_impl;
+
     _EXPORT_STD class directory_entry {
     public:
         // [fs.dir.entry.cons], constructors and destructor
@@ -2473,8 +2476,8 @@ namespace filesystem {
             return _Error;
         }
 
-        friend struct _Dir_enum_impl;
-        friend struct _Recursive_dir_enum_impl;
+        friend _Dir_enum_impl;
+        friend _Recursive_dir_enum_impl;
         friend void _Copy_impl(
             const directory_entry& _From, const _STD filesystem::path& _To, copy_options _Options, error_code& _Ec);
 

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -2328,9 +2328,6 @@ namespace ranges {
         /* [[no_unique_address]] */ _Movable_box<_Fn> _Fun{};
 
         template <bool _Const>
-        class _Sentinel;
-
-        template <bool _Const>
         struct _Category_base {};
 
         template <bool _Const>
@@ -2347,10 +2344,7 @@ namespace ranges {
         template <bool _Const>
         class _Iterator : public _Category_base<_Const> {
         private:
-            template <bool>
-            friend class _Iterator;
-            template <bool>
-            friend class _Sentinel;
+            friend transform_view;
 
             using _Parent_t = _Maybe_const<_Const, transform_view>;
             using _Base     = _Maybe_const<_Const, _Vw>;
@@ -2600,8 +2594,7 @@ namespace ranges {
         template <bool _Const>
         class _Sentinel {
         private:
-            template <bool>
-            friend class _Sentinel;
+            friend transform_view;
 
             using _Parent_t = _Maybe_const<_Const, transform_view>;
             using _Base     = _Maybe_const<_Const, _Vw>;
@@ -2773,8 +2766,7 @@ namespace ranges {
         template <bool _Const, bool _Wrapped = true>
         class _Sentinel {
         private:
-            template <bool, bool>
-            friend class _Sentinel;
+            friend take_view;
 
             using _Base_t        = _Maybe_const<_Const, _Vw>;
             using _Base_sentinel = _Maybe_wrapped<_Wrapped, sentinel_t<_Base_t>>;
@@ -3067,8 +3059,7 @@ namespace ranges {
         template <bool _Const, bool _Wrapped = true>
         class _Sentinel {
         private:
-            template <bool, bool>
-            friend class _Sentinel;
+            friend take_while_view;
 
             using _Base_t        = _Maybe_const<_Const, _Vw>;
             using _Base_iterator = _Maybe_wrapped<_Wrapped, iterator_t<_Base_t>>;
@@ -4472,9 +4463,7 @@ namespace ranges {
         template <bool _Const>
         class _Outer_iter : public _Outer_iter_base<iterator_t<_Maybe_const<_Const, _Vw>>> {
         private:
-            template <bool>
-            friend class _Inner_iter;
-            friend _Outer_iter<true>;
+            friend lazy_split_view;
 
             using _Mybase   = _Outer_iter_base<iterator_t<_Maybe_const<_Const, _Vw>>>;
             using _ParentTy = _Maybe_const<_Const, lazy_split_view>;
@@ -4844,11 +4833,9 @@ namespace ranges {
         /* [[no_unique_address]] */ _Pat _Pattern{};
         _Non_propagating_cache<subrange<iterator_t<_Vw>>> _Next{};
 
-        class _Sentinel;
-
         class _Iterator {
         private:
-            friend _Sentinel;
+            friend split_view;
 
             split_view* _Parent             = nullptr;
             iterator_t<_Vw> _Current        = {};
@@ -5511,9 +5498,6 @@ namespace ranges {
     private:
         /* [[no_unique_address]] */ _Vw _Range{};
 
-        template <bool _Const>
-        class _Sentinel;
-
         template <class _Base>
         struct _Category_base {};
 
@@ -5529,10 +5513,7 @@ namespace ranges {
         template <bool _Const>
         class _Iterator : public _Category_base<_Maybe_const<_Const, _Vw>> {
         private:
-            template <bool>
-            friend class _Iterator;
-            template <bool>
-            friend class _Sentinel;
+            friend elements_view;
 
             using _Base = _Maybe_const<_Const, _Vw>;
 
@@ -5760,8 +5741,7 @@ namespace ranges {
         template <bool _Const>
         class _Sentinel {
         private:
-            template <bool>
-            friend class _Sentinel;
+            friend elements_view;
 
             using _Base = _Maybe_const<_Const, _Vw>;
             template <bool _OtherConst>
@@ -6269,10 +6249,9 @@ namespace ranges {
         range_difference_t<_Vw> _Remainder = 0;
         _Non_propagating_cache<iterator_t<_Vw>> _Current{};
 
-        class _Outer_iterator;
         class _Inner_iterator {
         private:
-            friend struct _Outer_iterator::value_type;
+            friend chunk_view;
             chunk_view* _Parent{};
 
             constexpr explicit _Inner_iterator(chunk_view* _Parent_) noexcept : _Parent(_Parent_) {}

--- a/stl/inc/xlocale
+++ b/stl/inc/xlocale
@@ -115,8 +115,6 @@ public:
         __PURE_APPDOMAIN_GLOBAL static int _Id_cnt;
     };
 
-    class _Locimp;
-
     class _CRTIMP2_PURE_IMPORT facet : public _Facet_base, public _Crt_new_delete {
         // base class for all locale facets, performs reference counting
     private:

--- a/stl/inc/xlocale
+++ b/stl/inc/xlocale
@@ -115,10 +115,12 @@ public:
         __PURE_APPDOMAIN_GLOBAL static int _Id_cnt;
     };
 
+    struct _Facet_guard;
+
     class _CRTIMP2_PURE_IMPORT facet : public _Facet_base, public _Crt_new_delete {
         // base class for all locale facets, performs reference counting
     private:
-        friend struct _Facet_guard;
+        friend _Facet_guard;
 
     public:
         static size_t __CLRCALL_OR_CDECL _Getcat(const facet** = nullptr, const locale* = nullptr) {


### PR DESCRIPTION
* When granting friendship to `bitset`, use its injected-class-name.
* In `<ranges>`, consistently grant access to the parent `meow_view`. This avoids needing forward declarations.
  + `join_view` is being updated by #3466, so I'm not changing it here.
  + This takes advantage of a C++ rule: nested classes are members of their parent class, so they have the same access rights as any other member. This means that if `Nested1` grants friendship to its `Parent`, then `Nested2` can now access `Nested1`'s internals.
  + Several other views/iterators are already using this scheme, so this increases consistency. It does widen the scope of friendship, but that doesn't really matter - a view and its iterators/sentinels are tightly coupled, so it's okay for the different parts to have access to one another.
* Drop unnecessary forward declaration of `_Locimp`.
  + This is an unrelated micro-cleanup, grouped here because I want to make an edit in the same area:
* Use forward declarations and extended friends instead of elaborated-type-specifiers.
  + We consider it confusing that `friend struct Meow;` can declare `Meow`. The rules for this are complicated and we'd prefer not to have to think so hard. It's easier if we have separate forward declarations, followed by the "extended friend" syntax. Although this consumes an extra line, it's simpler because `friend Meow;` is incapable of introducing a declaration.