### PR TITLE
Cleanups: Split type and object definitions

### DIFF
--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -2325,7 +2325,8 @@ public:
         value_type _Buf[_BUF_SIZE];
         pointer _Ptr;
         char _Alias[_BUF_SIZE]; // TRANSITION, ABI: _Alias is preserved for binary compatibility (especially /clr)
-    } _Bx;
+    };
+    _Bxty _Bx;
 
     size_type _Mysize = 0; // current length of string
     size_type _Myres  = 0; // current storage reserved for string

--- a/stl/src/ppltasks.cpp
+++ b/stl/src/ppltasks.cpp
@@ -132,7 +132,8 @@ namespace Concurrency {
                     this);
                 return m_isSupported;
             }
-        } asyncCausalityTracer;
+        };
+        AsyncCausalityTracer asyncCausalityTracer;
 
         // GUID used for identifying causality logs from PPLTask
         const GUID PPLTaskCausalityPlatformID = {

--- a/stl/src/taskscheduler.cpp
+++ b/stl/src/taskscheduler.cpp
@@ -113,7 +113,8 @@ namespace Concurrency {
                     _STD unique_lock<_STD mutex> _Lck(_Task_cv_mutex);
                     _Task_cv.wait(_Lck, [] { return _Outstanding_tasks == 0; });
                 }
-            } _Task_scheduler_main_block_instance;
+            };
+            _Task_scheduler_main_block _Task_scheduler_main_block_instance;
 #endif // CRTDLL2
 
             void CALLBACK _Task_scheduler_callback(PTP_CALLBACK_INSTANCE _Pci, PVOID _Args, PTP_WORK) noexcept {

--- a/tests/std/tests/Dev11_0235721_async_and_packaged_task/test.cpp
+++ b/tests/std/tests/Dev11_0235721_async_and_packaged_task/test.cpp
@@ -351,7 +351,9 @@ struct use_async_in_a_global_tester {
     ~use_async_in_a_global_tester() {
         (void) async([] { return 1729; }).get();
     }
-} use_async_in_a_global_instance;
+};
+
+use_async_in_a_global_tester use_async_in_a_global_instance;
 #endif // _M_CEE
 
 int main() {

--- a/tests/std/tests/P0019R8_atomic_ref/test.cpp
+++ b/tests/std/tests/P0019R8_atomic_ref/test.cpp
@@ -45,7 +45,8 @@ void test_ops() {
 
     struct alignas(std::atomic_ref<ValueType>::required_alignment) Padded {
         ValueType vals[unique] = {};
-    } padded;
+    };
+    Padded padded;
 
     auto& vals = padded.vals;
 

--- a/tests/std/tests/VSO_0000000_list_iterator_debugging/test.cpp
+++ b/tests/std/tests/VSO_0000000_list_iterator_debugging/test.cpp
@@ -265,7 +265,8 @@ struct erase_fixture {
         ~liveness_empty_asserter() {
             assert(liveness_alive_objects == 0);
         }
-    } instance_empty; // destroyed after theList
+    };
+    liveness_empty_asserter instance_empty; // destroyed after theList
 
     list<int, liveness_allocator<int>> theList;
 
@@ -278,7 +279,8 @@ struct erase_fixture {
             // tests that the whole container is iterable
             assert(is_sorted(theList.begin(), theList.end()));
         }
-    } instance_nonempty; // destroyed before theList
+    };
+    post_asserter instance_nonempty; // destroyed before theList
 
     void assert_iterators_consistent(const vector<list<int>::const_iterator>& iterators) {
         assert(theList.size() == iterators.size() - 1);

--- a/tests/std/tests/VSO_0961751_hash_range_erase/test.cpp
+++ b/tests/std/tests/VSO_0961751_hash_range_erase/test.cpp
@@ -57,7 +57,8 @@ struct erase_fixture {
         ~liveness_empty_asserter() {
             assert(liveness_alive_objects == 0);
         }
-    } instance_empty; // destroyed after theHash
+    };
+    liveness_empty_asserter instance_empty; // destroyed after theHash
 
     using container = unordered_set<int, hash<int>, equal_to<>, liveness_allocator<int>>;
     using iterator  = container::iterator;
@@ -72,7 +73,8 @@ struct erase_fixture {
                    == (_ITERATOR_DEBUG_LEVEL != 0) * 2 + 1 + theHash.size() + theHash.bucket_count() * 2);
             theHash._Stl_internal_check_container_invariants();
         }
-    } instance_nonempty; // destroyed before theHash
+    };
+    post_asserter instance_nonempty; // destroyed before theHash
 
     void assert_iterators_consistent(const vector<iterator>& iterators) {
         assert(theHash.size() == iterators.size() - 1);
@@ -293,7 +295,8 @@ struct erase_bucket_consistency_fixture {
         ~liveness_empty_asserter() {
             assert(liveness_alive_objects == 0);
         }
-    } instance_empty; // destroyed after theHash
+    };
+    liveness_empty_asserter instance_empty; // destroyed after theHash
 
     using container = unordered_set<elem, hash<elem>, equal_to<>, liveness_allocator<elem>>;
     container theHash;
@@ -308,7 +311,8 @@ struct erase_bucket_consistency_fixture {
             assert(distance(theHash.begin(), theHash.end()) == static_cast<ptrdiff_t>(theHash.size()));
             theHash._Stl_internal_check_container_invariants();
         }
-    } instance_nonempty; // destroyed before theHash
+    };
+    post_asserter instance_nonempty; // destroyed before theHash
 
     size_t zeroBucket;
     size_t midBucket;


### PR DESCRIPTION
There are a few cases where we prefer to spend extra lines for clarity. (Examples: In modern code we strongly prefer to avoid packing too many side-effects into an expression, we avoid defining multiple variables on a single line, and we usually prefer to avoid elaborate conditional operators.)

One such case is simultaneously defining a type and an object. We prefer to do this separately, because they happen in different "domains". (Only lambdas get to be special!)

We accumulated a few occurrences throughput the codebase, which I tracked down. I consider this convention important enough (and the transformation simple enough) to be worth updating `tests/std`.