### PR TITLE
Cleanups: Test code using `ranges` as an identifier, plus more

### DIFF
--- a/tests/std/tests/Dev09_056375_locale_cleanup/test.cpp
+++ b/tests/std/tests/Dev09_056375_locale_cleanup/test.cpp
@@ -29,7 +29,7 @@ void test_dll() {
     HMODULE hLibrary = LoadLibraryExW(L"testdll.dll", nullptr, 0);
     assert(hLibrary != nullptr);
     typedef void (*TheFuncProc)();
-    TheFuncProc pFunc = (TheFuncProc) GetProcAddress(hLibrary, "DllTest");
+    TheFuncProc pFunc = reinterpret_cast<TheFuncProc>(GetProcAddress(hLibrary, "DllTest"));
     assert(pFunc != nullptr);
     pFunc();
     FreeLibrary(hLibrary);

--- a/tests/std/tests/Dev09_056375_locale_cleanup/test.cpp
+++ b/tests/std/tests/Dev09_056375_locale_cleanup/test.cpp
@@ -25,7 +25,7 @@ void test_dll() {
         as->GetType("Test")->GetMethod("DllTest")->Invoke(nullptr, nullptr);
         AppDomain::Unload(ad);
     }
-#else
+#else // ^^^ defined(_M_CEE) / !defined(_M_CEE) vvv
     HMODULE hLibrary = LoadLibraryExW(L"testdll.dll", nullptr, 0);
     assert(hLibrary != nullptr);
     typedef void (*TheFuncProc)();
@@ -33,7 +33,7 @@ void test_dll() {
     assert(pFunc != nullptr);
     pFunc();
     FreeLibrary(hLibrary);
-#endif
+#endif // ^^^ !defined(_M_CEE) ^^^
 }
 
 void test_exe_part1() {

--- a/tests/std/tests/Dev09_056375_locale_cleanup/test.cpp
+++ b/tests/std/tests/Dev09_056375_locale_cleanup/test.cpp
@@ -51,9 +51,6 @@ void test_exe_part2() {
 }
 
 int main() {
-#ifdef _M_CEE
-    using namespace System;
-#endif
     test_exe_part1();
     test_dll();
     test_exe_part2();

--- a/tests/std/tests/Dev09_192736_tr1_prngs_not_copyconstructible/test.cpp
+++ b/tests/std/tests/Dev09_192736_tr1_prngs_not_copyconstructible/test.cpp
@@ -157,10 +157,10 @@ int main() {
     test_distribution(piecewise_constant_distribution<float>(begin(rangesf), end(rangesf), begin(weightsf)));
     test_distribution(piecewise_linear_distribution<float>(begin(rangesf), end(rangesf), begin(weightsf)));
 
-    vector<double> ranges{0.0, 10.0, 90.0, 100.0};
-    vector<double> weights{1.0, 0.0, 0.0, 1.0};
-    test_distribution(piecewise_constant_distribution<double>(begin(ranges), end(ranges), begin(weights)));
-    test_distribution(piecewise_linear_distribution<double>(begin(ranges), end(ranges), begin(weights)));
+    vector<double> rangesd{0.0, 10.0, 90.0, 100.0};
+    vector<double> weightsd{1.0, 0.0, 0.0, 1.0};
+    test_distribution(piecewise_constant_distribution<double>(begin(rangesd), end(rangesd), begin(weightsd)));
+    test_distribution(piecewise_linear_distribution<double>(begin(rangesd), end(rangesd), begin(weightsd)));
 
     vector<long double> rangesl{0.0l, 10.0l, 90.0l, 100.0l};
     vector<long double> weightsl{1.0l, 0.0l, 0.0l, 1.0l};

--- a/tests/std/tests/P2321R2_views_zip/test.cpp
+++ b/tests/std/tests/P2321R2_views_zip/test.cpp
@@ -17,7 +17,7 @@
 using namespace std;
 
 template <class... RangeTypes>
-concept CanViewZip = requires(RangeTypes&&... ranges) { views::zip(std::forward<RangeTypes>(ranges)...); };
+concept CanViewZip = requires(RangeTypes&&... rngs) { views::zip(std::forward<RangeTypes>(rngs)...); };
 
 template <class RangeType>
 using AllView = views::all_t<RangeType>;
@@ -226,7 +226,7 @@ constexpr bool do_tuples_reference_same_objects(const LHSTupleType& lhs_tuple, c
 #pragma warning(disable : 4100) // unreferenced formal parameter
 
 template <class TestContainerType, ranges::input_range... RangeTypes>
-constexpr bool test_one(TestContainerType& test_container, RangeTypes&&... ranges) {
+constexpr bool test_one(TestContainerType& test_container, RangeTypes&&... rngs) {
     // Ignore instances where one of the generated test ranges does not model
     // ranges::viewable_range.
     if constexpr ((ranges::viewable_range<RangeTypes&> && ...)) {
@@ -258,8 +258,8 @@ constexpr bool test_one(TestContainerType& test_container, RangeTypes&&... range
             using ExpectedZipType      = ZipType;
             constexpr bool is_noexcept = (is_nothrow_copy_constructible_v<AllView<RangeTypes>> && ...);
 
-            STATIC_ASSERT(same_as<decltype(views::zip(ranges...)), ExpectedZipType>);
-            STATIC_ASSERT(noexcept(views::zip(ranges...)) == is_noexcept);
+            STATIC_ASSERT(same_as<decltype(views::zip(rngs...)), ExpectedZipType>);
+            STATIC_ASSERT(noexcept(views::zip(rngs...)) == is_noexcept);
         }
 
         // ... with const lvalue arguments
@@ -269,8 +269,8 @@ constexpr bool test_one(TestContainerType& test_container, RangeTypes&&... range
             using ExpectedZipType      = ranges::zip_view<AllView<const remove_reference_t<RangeTypes>&>...>;
             constexpr bool is_noexcept = (is_nothrow_copy_constructible_v<AllView<RangeTypes>> && ...);
 
-            STATIC_ASSERT(same_as<decltype(views::zip(as_const(ranges)...)), ExpectedZipType>);
-            STATIC_ASSERT(noexcept(views::zip(as_const(ranges)...)) == is_noexcept);
+            STATIC_ASSERT(same_as<decltype(views::zip(as_const(rngs)...)), ExpectedZipType>);
+            STATIC_ASSERT(noexcept(views::zip(as_const(rngs)...)) == is_noexcept);
         }
 
         // ... with rvalue argument
@@ -280,8 +280,8 @@ constexpr bool test_one(TestContainerType& test_container, RangeTypes&&... range
             using ExpectedZipType      = ranges::zip_view<AllView<remove_reference_t<RangeTypes>>...>;
             constexpr bool is_noexcept = (is_nothrow_move_constructible_v<AllView<RangeTypes>> && ...);
 
-            STATIC_ASSERT(same_as<decltype(views::zip(std::move(ranges)...)), ExpectedZipType>);
-            STATIC_ASSERT(noexcept(views::zip(std::move(ranges)...)) == is_noexcept);
+            STATIC_ASSERT(same_as<decltype(views::zip(std::move(rngs)...)), ExpectedZipType>);
+            STATIC_ASSERT(noexcept(views::zip(std::move(rngs)...)) == is_noexcept);
         }
 
         // ... with const rvalue argument
@@ -291,12 +291,12 @@ constexpr bool test_one(TestContainerType& test_container, RangeTypes&&... range
             using ExpectedZipType      = ranges::zip_view<AllView<const remove_reference_t<RangeTypes>>...>;
             constexpr bool is_noexcept = (is_nothrow_copy_constructible_v<AllView<RangeTypes>> && ...);
 
-            STATIC_ASSERT(same_as<decltype(views::zip(std::move(as_const(ranges))...)), ExpectedZipType>);
-            STATIC_ASSERT(noexcept(views::zip(std::move(as_const(ranges))...)) == is_noexcept);
+            STATIC_ASSERT(same_as<decltype(views::zip(std::move(as_const(rngs))...)), ExpectedZipType>);
+            STATIC_ASSERT(noexcept(views::zip(std::move(as_const(rngs))...)) == is_noexcept);
         }
 
         // Validate deduction guide
-        same_as<ZipType> auto zipped_range = ranges::zip_view{std::forward<RangeTypes>(ranges)...};
+        same_as<ZipType> auto zipped_range = ranges::zip_view{std::forward<RangeTypes>(rngs)...};
         const auto tuple_element_arr       = test_container.get_element_tuple_arr();
         const auto const_tuple_element_arr = as_const(test_container).get_element_tuple_arr();
 


### PR DESCRIPTION
* `P2321R2_views_zip` was using `ranges` as an identifier. :scream_cat: Rename this to `rngs`, avoiding confusion.
* `Dev09_192736_tr1_prngs_not_copyconstructible`, written a billion years ago, also had `ranges`. While this isn't *really* a problem, let's add a `d` suffix (also to the following `weights`), which is consistent with the preceding and following `vector<float> rangesf` and `vector<long double> rangesl`.
* `Dev09_056375_locale_cleanup`, written a trillion years ago, could use some extremely minor cleanups:
  + Add preprocessor comments.
  + Drop a totally unnecessary `using`-directive.
    - In general, we should be wary of changing tests in ways that could disturb what they were testing, but there is *no way* that this had any effect, being scoped to `main()`.
  + Change a C cast to `reinterpret_cast`.