### PR TITLE
Cleanups: Avoid almost always `auto`

### DIFF
--- a/stl/inc/__msvc_int128.hpp
+++ b/stl/inc/__msvc_int128.hpp
@@ -139,7 +139,7 @@ struct
     static constexpr void _Knuth_4_3_1_M(
         const uint32_t (&__u)[__m], const uint32_t (&__v)[__n], uint32_t (&__w)[__n + __m]) noexcept {
 #ifdef _ENABLE_STL_INTERNAL_CHECK
-        constexpr auto _Int_max = size_t{(numeric_limits<int>::max)()};
+        constexpr auto _Int_max = static_cast<size_t>((numeric_limits<int>::max)());
         _STL_INTERNAL_STATIC_ASSERT(__m <= _Int_max);
         _STL_INTERNAL_STATIC_ASSERT(__n <= _Int_max);
 #endif // _ENABLE_STL_INTERNAL_CHECK
@@ -188,7 +188,7 @@ struct
     static constexpr void _Knuth_4_3_1_D(uint32_t* const __u, const size_t __u_size, const uint32_t* const __v,
         const size_t __v_size, uint32_t* const __q) noexcept {
         // Pre: __u + [0, __u_size), __v + [0, __v_size), and __q + [0, __u_size - __v_size) are all valid ranges
-        // constexpr auto _Int_max = size_t{(numeric_limits<int>::max)()};
+        // constexpr auto _Int_max = static_cast<size_t>((numeric_limits<int>::max)());
         // _STL_INTERNAL_CHECK(__v_size <= _Int_max);
         const int __n = static_cast<int>(__v_size);
         // _STL_INTERNAL_CHECK(__u_size > __v_size);

--- a/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
+++ b/tests/std/tests/P0645R10_text_formatting_formatting/test.cpp
@@ -999,7 +999,7 @@ void test_pointer_specs() {
 template <class charT>
 void test_string_specs() {
     auto cstr = STR("scully");
-    auto view = basic_string_view{cstr};
+    basic_string_view view{cstr};
 
     assert(format(STR("{:}"), cstr) == cstr);
     assert(format(STR("{:}"), view) == cstr);

--- a/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
@@ -3208,7 +3208,7 @@ namespace reverse_iterator_test {
     constexpr bool test() {
         // Validate iter_move
         int count = 0;
-        auto i    = reverse_iterator{proxy_iterator<0>{&count}};
+        reverse_iterator i{proxy_iterator<0>{&count}};
         assert(ranges::iter_move(i) == 42);
         assert(count == 1);
 
@@ -3456,7 +3456,7 @@ namespace move_iterator_test {
     constexpr bool test() {
         // Validate iter_move
         int count = 0;
-        auto i    = move_iterator{proxy_iterator<0>{&count}};
+        move_iterator i{proxy_iterator<0>{&count}};
         assert(ranges::iter_move(i) == 42);
         assert(count == 1);
 

--- a/tests/std/tests/P0896R4_views_transform/test.cpp
+++ b/tests/std/tests/P0896R4_views_transform/test.cpp
@@ -619,7 +619,7 @@ struct iterator_instantiator {
             assert((0 + I{}).base().peek() == nullptr);
             STATIC_ASSERT(NOEXCEPT_IDL0(2 + i));
 
-            auto vi = I{};
+            I vi{};
             assert(&(i += 5) == &i);
             assert(i.base().peek() == mutable_ints + 5);
             assert(&(vi += 0) == &vi);

--- a/tests/std/tests/P1522R1_difference_type/test.cpp
+++ b/tests/std/tests/P1522R1_difference_type/test.cpp
@@ -748,7 +748,7 @@ constexpr bool test_signed() {
         assert(product._Word[1] == 0x05050505'05050505);
     }
     {
-        auto product = _Signed128{0x01010101'01010101, 0x01010101'01010101};
+        _Signed128 product{0x01010101'01010101, 0x01010101'01010101};
         product *= product;
         assert(product == 0x100f0e0d'0c0b0a09'08070605'04030201_i128);
         assert(product._Word[0] == 0x08070605'04030201);

--- a/tests/std/tests/P2321R2_views_zip/test.cpp
+++ b/tests/std/tests/P2321R2_views_zip/test.cpp
@@ -679,28 +679,25 @@ private:
         (Diff == test::CanDifference::yes ? test::CanDifference::no : test::CanDifference::yes)>;
 
     template <class ContainerType>
-    static constexpr void test_single_range(ContainerType&& container) {
+    static constexpr void test_single_range(ContainerType&& single_element_container) {
         // Create a copy of the container. That way, we can always test iter_swap,
         // even if container has const elements.
-        auto writable_single_element_container = container;
-        auto single_range =
-            tuple_element_t<0, standard_range_tuple_type>{writable_single_element_container.get_element_span()};
+        auto writable = single_element_container;
+        tuple_element_t<0, standard_range_tuple_type> single_range{writable.get_element_span()};
 
-        test_one(writable_single_element_container, single_range);
+        test_one(writable, single_range);
     }
 
     template <class DifferingRangeType, class ContainerType>
-    static constexpr void test_three_ranges(ContainerType&& container) {
+    static constexpr void test_three_ranges(ContainerType&& three_element_container) {
         // Create a copy of the container. That way, we can always test iter_swap,
         // even if container has const elements.
-        auto writable_three_element_container = container;
-        auto first_range  = DifferingRangeType{writable_three_element_container.template get_element_span<0>()};
-        auto second_range = tuple_element_t<1, standard_range_tuple_type>{
-            writable_three_element_container.template get_element_span<1>()};
-        auto third_range = tuple_element_t<2, standard_range_tuple_type>{
-            writable_three_element_container.template get_element_span<2>()};
+        auto writable = three_element_container;
+        DifferingRangeType first_range{writable.template get_element_span<0>()};
+        tuple_element_t<1, standard_range_tuple_type> second_range{writable.template get_element_span<1>()};
+        tuple_element_t<2, standard_range_tuple_type> third_range{writable.template get_element_span<2>()};
 
-        test_one(writable_three_element_container, first_range, second_range, third_range);
+        test_one(writable, first_range, second_range, third_range);
     }
 
 public:


### PR DESCRIPTION
We conventionally avoid the pattern `auto variable = Type{args};` because it is strictly more complicated than `Type variable{args};`. Following this convention reserves `auto` for the cases where it's doing real work to deduce a type.

We've accumulated a few cases which I'm cleaning up here. (There are a few more cases which I am reluctantly not changing, because `auto` results in code lining up nicely. I thought about it, though.)

In `P2321R2_views_zip`, I'm also performing some renames. We can name the parameters `single_element_container` and `three_element_container`, as that's relevant to the caller. Then we can rename the local copy to just `writable`, which avoids wrapping lines.

In `<__msvc_int128.hpp>`, I'm using `static_cast`. MSVC emits a signed/unsigned warning if we attempt to directly initialize `_Int_max` (possibly because `numeric_limits::max()` is `constexpr` but not `consteval`). Since we're intentionally changing the type from `int` to `size_t`, it seems stylistically best to emphasize this with a `static_cast` anyways.