### PR TITLE
Cleanups: Very minor logic changes

### DIFF
--- a/stl/inc/numeric
+++ b/stl/inc/numeric
@@ -623,12 +623,11 @@ _NODISCARD constexpr common_type_t<_Mt, _Nt> gcd(const _Mt _Mx, const _Nt _Nx) n
 
             _Nx_magnitude -= _Mx_magnitude;
             if (_Nx_magnitude == 0U) {
-                break;
+                return static_cast<_Common>(_Mx_magnitude << _Common_factors_of_2);
             }
 
             _Nx_trailing_zeroes = static_cast<unsigned long>(_Countr_zero_impl(_Nx_magnitude));
         }
-        return static_cast<_Common>(_Mx_magnitude << _Common_factors_of_2);
     });
 }
 

--- a/stl/src/fiopen.cpp
+++ b/stl/src/fiopen.cpp
@@ -50,8 +50,8 @@ namespace {
             ios_base::out | ios_base::in | ios_base::trunc | ios_base::binary | ios_base::_Noreplace,
         };
 
-        FILE* fp                     = nullptr;
-        ios_base::openmode atendflag = mode & ios_base::ate;
+        FILE* fp          = nullptr;
+        const bool at_end = (mode & ios_base::ate) != 0;
 
         if (mode & ios_base::_Nocreate) {
             mode |= ios_base::in; // file must exist
@@ -75,7 +75,7 @@ namespace {
             return nullptr; // open failed
         }
 
-        if (atendflag && fseek(fp, 0, SEEK_END) != 0) {
+        if (at_end && fseek(fp, 0, SEEK_END) != 0) {
             fclose(fp); // can't position at end
             return nullptr;
         }

--- a/stl/src/ppltasks.cpp
+++ b/stl/src/ppltasks.cpp
@@ -306,7 +306,6 @@ namespace Concurrency {
                 case APTTYPE_STA:
                 case APTTYPE_MAINSTA:
                     return true;
-                    break;
                 case APTTYPE_NA:
                     switch (_AptTypeQualifier) {
                         // A thread executing in a neutral apartment is either STA or MTA. To find out if this thread is
@@ -316,7 +315,6 @@ namespace Concurrency {
                     case APTTYPEQUALIFIER_NA_ON_STA:
                     case APTTYPEQUALIFIER_NA_ON_MAINSTA:
                         return true;
-                        break;
                     }
                     break;
                 }


### PR DESCRIPTION
* Drop `break;` after `return true;` in `ppltasks.cpp`.
  + This was the deadest of dead code. :zombie: :brain:
* In `gcd()`, fuse `break` followed by `return`.
  + There's no other way out of this infinite loop, and no clarity advantage to having the `return` further away.
* In `fiopen.cpp`, change `ios_base::openmode atendflag` to `const bool at_end`.
  + We don't modify it, and it's simpler to immediately boil it down to a `bool`.
