### PR TITLE
Cleanups: Simplify `thread` and `condition_variable`, identify unused dllexports

### DIFF
--- a/stl/inc/condition_variable
+++ b/stl/inc/condition_variable
@@ -224,16 +224,8 @@ public:
             // but unfortunately our ABI speaks struct xtime, which is relative to the system clock.
             _CSTD xtime _Tgt;
             (void) _To_xtime_10_day_clamped(_Tgt, _Rel_time);
-            const int _Res = _Cnd_timedwait(_Mycnd(), _Myptr->_Mymtx(), &_Tgt);
+            (void) _Cnd_timedwait(_Mycnd(), _Myptr->_Mymtx(), &_Tgt);
             _Guard_unlocks_before_locking_outer.unlock();
-
-            switch (_Res) {
-            case _Thrd_timedout:
-            case _Thrd_success:
-                break;
-            default:
-                _Throw_C_error(_Res);
-            }
         } // relock
 
         return _Pred();
@@ -262,13 +254,10 @@ private:
         const int _Res = _Cnd_timedwait(_Mycnd(), _Ptr->_Mymtx(), _Abs_time);
         _Guard.unlock();
 
-        switch (_Res) {
-        case _Thrd_success:
+        if (_Res == _Thrd_success) {
             return cv_status::no_timeout;
-        case _Thrd_timedout:
+        } else {
             return cv_status::timeout;
-        default:
-            _Throw_C_error(_Res);
         }
     }
 };

--- a/stl/inc/mutex
+++ b/stl/inc/mutex
@@ -746,13 +746,11 @@ public:
 
         // Nothing to do to comply with LWG-2135 because std::mutex lock/unlock are nothrow
         const int _Res = _Cnd_timedwait(_Mycnd(), _Lck.mutex()->_Mymtx(), _Abs_time);
-        switch (_Res) {
-        case _Thrd_success:
+
+        if (_Res == _Thrd_success) {
             return cv_status::no_timeout;
-        case _Thrd_timedout:
+        } else {
             return cv_status::timeout;
-        default:
-            _Throw_C_error(_Res);
         }
     }
 

--- a/stl/inc/thread
+++ b/stl/inc/thread
@@ -137,10 +137,8 @@ public:
             _Throw_Cpp_error(_INVALID_ARGUMENT);
         }
 
-        const int _Res = _Thrd_detach(_Thr);
-
-        if (_Res != _Thrd_success) {
-            _Throw_C_error(_Res);
+        if (_Thrd_detach(_Thr) != _Thrd_success) {
+            _Throw_Cpp_error(_INVALID_ARGUMENT);
         }
 
         _Thr = {};

--- a/stl/inc/thread
+++ b/stl/inc/thread
@@ -137,7 +137,12 @@ public:
             _Throw_Cpp_error(_INVALID_ARGUMENT);
         }
 
-        _Check_C_return(_Thrd_detach(_Thr));
+        const int _Res = _Thrd_detach(_Thr);
+
+        if (_Res != _Thrd_success) {
+            _Throw_C_error(_Res);
+        }
+
         _Thr = {};
     }
 

--- a/stl/inc/xthreads.h
+++ b/stl/inc/xthreads.h
@@ -131,14 +131,6 @@ enum { // constants for error codes
 
 extern "C++" [[noreturn]] _CRTIMP2_PURE void __cdecl _Throw_C_error(int _Code);
 extern "C++" [[noreturn]] _CRTIMP2_PURE void __cdecl _Throw_Cpp_error(int _Code);
-
-inline int _Check_C_return(int _Res) { // throw exception on failure
-    if (_Res != _Thrd_success) {
-        _Throw_C_error(_Res);
-    }
-
-    return _Res;
-}
 _STD_END
 #pragma pop_macro("new")
 _STL_RESTORE_CLANG_WARNINGS

--- a/stl/inc/xthreads.h
+++ b/stl/inc/xthreads.h
@@ -129,7 +129,6 @@ enum { // constants for error codes
     _RESOURCE_UNAVAILABLE_TRY_AGAIN
 };
 
-extern "C++" [[noreturn]] _CRTIMP2_PURE void __cdecl _Throw_C_error(int _Code);
 extern "C++" [[noreturn]] _CRTIMP2_PURE void __cdecl _Throw_Cpp_error(int _Code);
 _STD_END
 #pragma pop_macro("new")

--- a/stl/inc/xtimec.h
+++ b/stl/inc/xtimec.h
@@ -27,7 +27,6 @@ struct xtime { // store time with nanosecond resolution
 
 _CRTIMP2_PURE int __cdecl xtime_get(xtime*, int);
 
-_CRTIMP2_PURE long __cdecl _Xtime_diff_to_millis(const xtime*);
 _CRTIMP2_PURE long __cdecl _Xtime_diff_to_millis2(const xtime*, const xtime*);
 _CRTIMP2_PURE long long __cdecl _Xtime_get_ticks();
 

--- a/stl/src/thread0.cpp
+++ b/stl/src/thread0.cpp
@@ -35,6 +35,7 @@ static constexpr errc codes[] = {
     _THROW(system_error(static_cast<int>(codes[code]), _STD generic_category(), msgs[code]));
 }
 
+// TRANSITION, ABI: preserved for binary compatibility
 [[noreturn]] _CRTIMP2_PURE void __cdecl _Throw_C_error(int code) { // throw error object for C error
     switch (code) { // select the exception
     case _Thrd_nomem:

--- a/stl/src/xtime.cpp
+++ b/stl/src/xtime.cpp
@@ -65,6 +65,7 @@ _CRTIMP2_PURE long __cdecl _Xtime_diff_to_millis2(const xtime* xt1, const xtime*
     return static_cast<long>(diff.sec * _Msec_per_sec + (diff.nsec + _Nsec_per_msec - 1) / _Nsec_per_msec);
 }
 
+// TRANSITION, ABI: preserved for binary compatibility
 _CRTIMP2_PURE long __cdecl _Xtime_diff_to_millis(const xtime* xt) { // convert time to milliseconds
     xtime now;
     xtime_get(&now, TIME_UTC);


### PR DESCRIPTION
This PR contains fairly simple logic transformations - they aren't exactly trivial (as one must consult other code to verify their correctness), but they're far from complicated. There's no behavioral impact, no changes to dllexports, and no interaction with the "unlocked" state of the redist.

* First, `_Xtime_diff_to_millis()` is unused. We can drop its declaration in `inc/xtimec.h` and mark its definition in `src/xtime.cpp` as preserved for bincompat. When doing this, all we need to do is verify that the declaration and the definition contain all of the same annotations (in particular, `_CRTIMP2_PURE` controls dllexporting).
* Simplify `thread::detach()`, part 1.
  + `inc/xthreads.h` provided an `inline` helper `_Check_C_return()`. Originally, it may have been used widely, but now there's only one usage. We can manually fuse it into `thread::detach()`.
* Simplify `thread::detach()`, part 2.
  + `_Thrd_detach()` returns either `_Thrd_success` or `_Thrd_error`: https://github.com/microsoft/STL/blob/16bb556afe5c56fe70a5508a6116842c226dd3be/stl/src/cthread.cpp#L71-L73
  + `_Throw_C_error()` translates that to `_Throw_Cpp_error(_INVALID_ARGUMENT)`: https://github.com/microsoft/STL/blob/16bb556afe5c56fe70a5508a6116842c226dd3be/stl/src/thread0.cpp#L47-L48
  + Thus, we can simplify the logic even more. Now it resembles `thread::join()` above, and more clearly shows what exception will be thrown.
* Simplify threads, part 3.
  + `_Cnd_timedwait()` returns only `_Thrd_success` or `_Thrd_timedout`. There's only one `return`, and only two values that `res` can take: https://github.com/microsoft/STL/blob/16bb556afe5c56fe70a5508a6116842c226dd3be/stl/src/cond.cpp#L63-L83
  + This allows us to simplify the calls to `_Cnd_timedwait()`, as we don't need to worry about unexpected return values.
  + After this, `_Throw_C_error()` is unused, so we can drop its declaration and mark its definition as preserved for bincompat.
  + There's one difference between the declaration and the definition, but we don't need the `extern "C++"` from the declaration in `inc/xthreads.h` - that's for Standard Library Modules, but `src/thread0.cpp` is always built classically.