### PR TITLE
Cleanups: Consistently comment `enable_if_t` definitions

### DIFF
--- a/stl/inc/__msvc_chrono.hpp
+++ b/stl/inc/__msvc_chrono.hpp
@@ -417,7 +417,7 @@ namespace chrono {
     }
 #endif // defined(__cpp_lib_concepts)
 
-    _EXPORT_STD template <class _To, class _Rep, class _Period, enable_if_t<_Is_duration_v<_To>, int> _Enabled>
+    _EXPORT_STD template <class _To, class _Rep, class _Period, enable_if_t<_Is_duration_v<_To>, int> /* = 0 */>
     _NODISCARD constexpr _To duration_cast(const duration<_Rep, _Period>& _Dur) noexcept(
         is_arithmetic_v<_Rep>&& is_arithmetic_v<typename _To::rep>) /* strengthened */ {
         // convert duration to another duration; truncate

--- a/stl/inc/bit
+++ b/stl/inc/bit
@@ -314,7 +314,7 @@ _NODISCARD constexpr int countr_zero(const _Ty _Val) noexcept {
     return _Countr_zero(_Val);
 }
 
-_EXPORT_STD template <class _Ty, enable_if_t<_Is_standard_unsigned_integer<_Ty>, int> _Enabled = 0>
+_EXPORT_STD template <class _Ty, enable_if_t<_Is_standard_unsigned_integer<_Ty>, int> = 0>
 _NODISCARD constexpr int countr_one(const _Ty _Val) noexcept {
     return _Countr_zero(static_cast<_Ty>(~_Val));
 }

--- a/stl/inc/bit
+++ b/stl/inc/bit
@@ -117,7 +117,7 @@ _NODISCARD constexpr _Ty rotl(const _Ty _Val, const int _Rotation) noexcept {
     }
 }
 
-_EXPORT_STD template <class _Ty, enable_if_t<_Is_standard_unsigned_integer<_Ty>, int> _Enabled>
+_EXPORT_STD template <class _Ty, enable_if_t<_Is_standard_unsigned_integer<_Ty>, int> /* = 0 */>
 _NODISCARD constexpr _Ty rotr(const _Ty _Val, const int _Rotation) noexcept {
     constexpr auto _Digits = numeric_limits<_Ty>::digits;
 
@@ -289,7 +289,7 @@ _NODISCARD constexpr unsigned long long _Byteswap_uint64(const unsigned long lon
 }
 #endif // _HAS_CXX23
 
-_EXPORT_STD template <class _Ty, enable_if_t<_Is_standard_unsigned_integer<_Ty>, int> _Enabled>
+_EXPORT_STD template <class _Ty, enable_if_t<_Is_standard_unsigned_integer<_Ty>, int> /* = 0 */>
 _NODISCARD constexpr int countl_zero(const _Ty _Val) noexcept {
 #if defined(_M_IX86) || (defined(_M_X64) && !defined(_M_ARM64EC))
     if (!_STD is_constant_evaluated()) {

--- a/stl/inc/limits
+++ b/stl/inc/limits
@@ -1231,7 +1231,7 @@ constexpr decltype(auto) _Select_countr_zero_impl(_Fn _Callback) {
     return _Callback([](_Ty _Val) { return _Countr_zero_fallback(_Val); });
 }
 
-template <class _Ty, enable_if_t<_Is_standard_unsigned_integer<_Ty>, int> _Enabled = 0>
+template <class _Ty, enable_if_t<_Is_standard_unsigned_integer<_Ty>, int> = 0>
 _NODISCARD _CONSTEXPR20 int _Popcount(const _Ty _Val) noexcept {
 #if _HAS_POPCNT_INTRINSICS || _HAS_NEON_INTRINSICS
 #if _HAS_CXX20

--- a/stl/inc/tuple
+++ b/stl/inc/tuple
@@ -1009,13 +1009,13 @@ _NODISCARD constexpr const _Ty&& get(const tuple<_Types...>&& _Tuple) noexcept {
 }
 
 template <class _This, class... _Rest>
-template <class _Tag, class _Tpl, size_t... _Indices, enable_if_t<is_same_v<_Tag, _STD _Unpack_tuple_t>, int>>
+template <class _Tag, class _Tpl, size_t... _Indices, enable_if_t<is_same_v<_Tag, _STD _Unpack_tuple_t>, int> /* = 0 */>
 constexpr tuple<_This, _Rest...>::tuple(_Tag, _Tpl&& _Right, index_sequence<_Indices...>)
     : tuple(_Exact_args_t{}, _STD get<_Indices>(_STD forward<_Tpl>(_Right))...) {}
 
 template <class _This, class... _Rest>
 template <class _Tag, class _Alloc, class _Tpl, size_t... _Indices,
-    enable_if_t<is_same_v<_Tag, _STD _Alloc_unpack_tuple_t>, int>>
+    enable_if_t<is_same_v<_Tag, _STD _Alloc_unpack_tuple_t>, int> /* = 0 */>
 constexpr tuple<_This, _Rest...>::tuple(_Tag, const _Alloc& _Al, _Tpl&& _Right, index_sequence<_Indices...>)
     : tuple(_Alloc_exact_args_t{}, _Al, _STD get<_Indices>(_STD forward<_Tpl>(_Right))...) {}
 

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -78,7 +78,7 @@ _CONSTEXPR20 void iter_swap(_FwdIt1 _Left, _FwdIt2 _Right) { // swap *_Left and 
     swap(*_Left, *_Right);
 }
 
-_EXPORT_STD template <class _Ty, size_t _Size, enable_if_t<_Is_swappable<_Ty>::value, int> _Enabled>
+_EXPORT_STD template <class _Ty, size_t _Size, enable_if_t<_Is_swappable<_Ty>::value, int> /* = 0 */>
 _CONSTEXPR20 void swap(_Ty (&_Left)[_Size], _Ty (&_Right)[_Size]) noexcept(_Is_nothrow_swappable<_Ty>::value) {
     if (&_Left != &_Right) {
         _Ty* _First1 = _Left;

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -91,9 +91,9 @@ _CONSTEXPR20 void swap(_Ty (&_Left)[_Size], _Ty (&_Right)[_Size]) noexcept(_Is_n
 }
 
 #if _HAS_CXX17
-_EXPORT_STD template <class _Ty, enable_if_t<is_move_constructible_v<_Ty> && is_move_assignable_v<_Ty>, int> _Enabled>
+_EXPORT_STD template <class _Ty, enable_if_t<is_move_constructible_v<_Ty> && is_move_assignable_v<_Ty>, int> /* = 0 */>
 #else // ^^^ _HAS_CXX17 / !_HAS_CXX17 vvv
-template <class _Ty, int _Enabled>
+template <class _Ty, int _Enabled /* = 0 */>
 #endif // _HAS_CXX17
 _CONSTEXPR20 void swap(_Ty& _Left, _Ty& _Right) noexcept(
     is_nothrow_move_constructible_v<_Ty>&& is_nothrow_move_assignable_v<_Ty>) {

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -2331,7 +2331,7 @@ _NODISCARD constexpr auto uses_allocator_construction_args(
             _STD forward<_Tuple2>(_Tup2)));
 }
 
-_EXPORT_STD template <class _Ty, class _Alloc, enable_if_t<_Is_cv_pair<_Ty>, int>>
+_EXPORT_STD template <class _Ty, class _Alloc, enable_if_t<_Is_cv_pair<_Ty>, int> /* = 0 */>
 _NODISCARD constexpr auto uses_allocator_construction_args(const _Alloc& _Al) noexcept {
     // equivalent to
     // return _STD uses_allocator_construction_args<_Ty>(_Al, piecewise_construct, tuple<>{}, tuple<>{});
@@ -2339,7 +2339,7 @@ _NODISCARD constexpr auto uses_allocator_construction_args(const _Alloc& _Al) no
         _STD uses_allocator_construction_args<typename _Ty::second_type>(_Al));
 }
 
-_EXPORT_STD template <class _Ty, class _Alloc, class _Uty1, class _Uty2, enable_if_t<_Is_cv_pair<_Ty>, int>>
+_EXPORT_STD template <class _Ty, class _Alloc, class _Uty1, class _Uty2, enable_if_t<_Is_cv_pair<_Ty>, int> /* = 0 */>
 _NODISCARD constexpr auto uses_allocator_construction_args(const _Alloc& _Al, _Uty1&& _Val1, _Uty2&& _Val2) noexcept {
     // equivalent to
     // return _STD uses_allocator_construction_args<_Ty>(_Al, piecewise_construct,
@@ -2350,7 +2350,7 @@ _NODISCARD constexpr auto uses_allocator_construction_args(const _Alloc& _Al, _U
 }
 
 #if _HAS_CXX23
-_EXPORT_STD template <class _Ty, class _Alloc, class _Uty1, class _Uty2, enable_if_t<_Is_cv_pair<_Ty>, int>>
+_EXPORT_STD template <class _Ty, class _Alloc, class _Uty1, class _Uty2, enable_if_t<_Is_cv_pair<_Ty>, int> /* = 0 */>
 _NODISCARD constexpr auto uses_allocator_construction_args(const _Alloc& _Al, pair<_Uty1, _Uty2>& _Pair) noexcept {
     // equivalent to
     // return _STD uses_allocator_construction_args<_Ty>(_Al, piecewise_construct,
@@ -2361,7 +2361,7 @@ _NODISCARD constexpr auto uses_allocator_construction_args(const _Alloc& _Al, pa
 }
 #endif // _HAS_CXX23
 
-_EXPORT_STD template <class _Ty, class _Alloc, class _Uty1, class _Uty2, enable_if_t<_Is_cv_pair<_Ty>, int>>
+_EXPORT_STD template <class _Ty, class _Alloc, class _Uty1, class _Uty2, enable_if_t<_Is_cv_pair<_Ty>, int> /* = 0 */>
 _NODISCARD constexpr auto uses_allocator_construction_args(
     const _Alloc& _Al, const pair<_Uty1, _Uty2>& _Pair) noexcept {
     // equivalent to
@@ -2372,7 +2372,7 @@ _NODISCARD constexpr auto uses_allocator_construction_args(
         _STD uses_allocator_construction_args<typename _Ty::second_type>(_Al, _Pair.second));
 }
 
-_EXPORT_STD template <class _Ty, class _Alloc, class _Uty1, class _Uty2, enable_if_t<_Is_cv_pair<_Ty>, int>>
+_EXPORT_STD template <class _Ty, class _Alloc, class _Uty1, class _Uty2, enable_if_t<_Is_cv_pair<_Ty>, int> /* = 0 */>
 _NODISCARD constexpr auto uses_allocator_construction_args(const _Alloc& _Al, pair<_Uty1, _Uty2>&& _Pair) noexcept {
     // equivalent to
     // return _STD uses_allocator_construction_args<_Ty>(_Al, piecewise_construct,
@@ -2383,7 +2383,7 @@ _NODISCARD constexpr auto uses_allocator_construction_args(const _Alloc& _Al, pa
 }
 
 #if _HAS_CXX23
-_EXPORT_STD template <class _Ty, class _Alloc, class _Uty1, class _Uty2, enable_if_t<_Is_cv_pair<_Ty>, int>>
+_EXPORT_STD template <class _Ty, class _Alloc, class _Uty1, class _Uty2, enable_if_t<_Is_cv_pair<_Ty>, int> /* = 0 */>
 _NODISCARD constexpr auto uses_allocator_construction_args(
     const _Alloc& _Al, const pair<_Uty1, _Uty2>&& _Pair) noexcept {
     // equivalent to
@@ -2400,7 +2400,7 @@ _EXPORT_STD template <class _Ty, class _Alloc, class _Uty>
     requires _Is_cv_pair<_Ty> && (_Pair_like<_Uty> || !_Is_deducible_as_pair<_Uty&>)
 #else // ^^^ C++23 with concepts / C++20 or no concepts vvv
 _EXPORT_STD template <class _Ty, class _Alloc, class _Uty,
-    enable_if_t<_Is_cv_pair<_Ty> && !_Is_deducible_as_pair<_Uty&>, int>>
+    enable_if_t<_Is_cv_pair<_Ty> && !_Is_deducible_as_pair<_Uty&>, int> /* = 0 */>
 #endif // ^^^ C++20 or no concepts ^^^
 _NODISCARD constexpr auto uses_allocator_construction_args(const _Alloc& _Al, _Uty&& _Ux) noexcept {
 #if _HAS_CXX23 && defined(__cpp_lib_concepts)


### PR DESCRIPTION
For C++17's parallel algorithms, where we separately declare and define many of them, we developed a convention where the declaration is ` = 0` and the definition is `/* = 0 */`. This is a reminder that while the default template argument can't be repeated, we haven't simply forgotten it:

https://github.com/microsoft/STL/blob/994f94199c561a38a4a8e15584030160095bc25a/stl/inc/algorithm#L1124-L1125
https://github.com/microsoft/STL/blob/994f94199c561a38a4a8e15584030160095bc25a/stl/inc/execution#L1119-L1120

Thanks to Michael Grier for noticing that we've accumulated inconsistency elsewhere, with relics of an older convention where we'd name the template parameter in the definition `_Enabled`. That older convention was less clear and doesn't really provide new information (as we're already using `enable_if_t`).

* Change `_Enabled = 0` to ` = 0` for `countr_one()` and `_Popcount()`.
  + There are no other declarations.
* Change `_Enabled` to `/* = 0 */` for `duration_cast()`, `rotr()`, `countl_zero()`, and `swap()` for arrays.
* Cleanup `swap(_Ty&, _Ty&)`.
  + For C++17, follow the convention where the declaration is ` = 0` and the definition is `/* = 0 */`.
  + For C++14, we want to emphasize the purpose of the second template parameter, so the declaration is `int _Enabled = 0` and the definition is `int _Enabled /* = 0 */`.
* Add `/* = 0 */` to `tuple`'s ctors and `uses_allocator_construction_args()`.

After this cleanup, the only remaining uses of `_Enabled` in product code are in other contexts. I've audited all occurrences where `enable_if_t` appears in separate declarations and definitions, including through helper typedefs, so this cleanup should be fairly exhaustive.