### PR TITLE
Cleanups: Follow Standard order for `byteswap` in `<bit>`

### DIFF
--- a/stl/inc/bit
+++ b/stl/inc/bit
@@ -34,6 +34,49 @@ _NODISCARD constexpr _To bit_cast(const _From& _Val) noexcept {
     return __builtin_bit_cast(_To, _Val);
 }
 
+#if _HAS_CXX23
+_NODISCARD constexpr unsigned short _Byteswap_ushort(const unsigned short _Val) noexcept {
+    if (_STD is_constant_evaluated()) {
+        return static_cast<unsigned short>((_Val << 8) | (_Val >> 8));
+    } else {
+        return _byteswap_ushort(_Val);
+    }
+}
+
+_NODISCARD constexpr unsigned long _Byteswap_ulong(const unsigned long _Val) noexcept {
+    if (_STD is_constant_evaluated()) {
+        return (_Val << 24) | ((_Val << 8) & 0x00FF'0000) | ((_Val >> 8) & 0x0000'FF00) | (_Val >> 24);
+    } else {
+        return _byteswap_ulong(_Val);
+    }
+}
+
+_NODISCARD constexpr unsigned long long _Byteswap_uint64(const unsigned long long _Val) noexcept {
+    if (_STD is_constant_evaluated()) {
+        return (_Val << 56) | ((_Val << 40) & 0x00FF'0000'0000'0000) | ((_Val << 24) & 0x0000'FF00'0000'0000)
+             | ((_Val << 8) & 0x0000'00FF'0000'0000) | ((_Val >> 8) & 0x0000'0000'FF00'0000)
+             | ((_Val >> 24) & 0x0000'0000'00FF'0000) | ((_Val >> 40) & 0x0000'0000'0000'FF00) | (_Val >> 56);
+    } else {
+        return _byteswap_uint64(_Val);
+    }
+}
+
+_EXPORT_STD template <class _Ty, enable_if_t<is_integral_v<_Ty>, int> = 0>
+_NODISCARD constexpr _Ty byteswap(const _Ty _Val) noexcept {
+    if constexpr (sizeof(_Ty) == 1) {
+        return _Val;
+    } else if constexpr (sizeof(_Ty) == 2) {
+        return static_cast<_Ty>(_Byteswap_ushort(static_cast<unsigned short>(_Val)));
+    } else if constexpr (sizeof(_Ty) == 4) {
+        return static_cast<_Ty>(_Byteswap_ulong(static_cast<unsigned long>(_Val)));
+    } else if constexpr (sizeof(_Ty) == 8) {
+        return static_cast<_Ty>(_Byteswap_uint64(static_cast<unsigned long long>(_Val)));
+    } else {
+        static_assert(_Always_false<_Ty>, "Unexpected integer size");
+    }
+}
+#endif // _HAS_CXX23
+
 _EXPORT_STD template <class _Ty, enable_if_t<_Is_standard_unsigned_integer<_Ty>, int> = 0>
 _NODISCARD constexpr int countl_zero(_Ty _Val) noexcept;
 
@@ -261,34 +304,6 @@ _NODISCARD int _Checked_arm_arm64_countl_zero(const _Ty _Val) noexcept {
 }
 #endif // defined(_M_ARM) || defined(_M_ARM64)
 
-#if _HAS_CXX23
-_NODISCARD constexpr unsigned short _Byteswap_ushort(const unsigned short _Val) noexcept {
-    if (_STD is_constant_evaluated()) {
-        return static_cast<unsigned short>((_Val << 8) | (_Val >> 8));
-    } else {
-        return _byteswap_ushort(_Val);
-    }
-}
-
-_NODISCARD constexpr unsigned long _Byteswap_ulong(const unsigned long _Val) noexcept {
-    if (_STD is_constant_evaluated()) {
-        return (_Val << 24) | ((_Val << 8) & 0x00FF'0000) | ((_Val >> 8) & 0x0000'FF00) | (_Val >> 24);
-    } else {
-        return _byteswap_ulong(_Val);
-    }
-}
-
-_NODISCARD constexpr unsigned long long _Byteswap_uint64(const unsigned long long _Val) noexcept {
-    if (_STD is_constant_evaluated()) {
-        return (_Val << 56) | ((_Val << 40) & 0x00FF'0000'0000'0000) | ((_Val << 24) & 0x0000'FF00'0000'0000)
-             | ((_Val << 8) & 0x0000'00FF'0000'0000) | ((_Val >> 8) & 0x0000'0000'FF00'0000)
-             | ((_Val >> 24) & 0x0000'0000'00FF'0000) | ((_Val >> 40) & 0x0000'0000'0000'FF00) | (_Val >> 56);
-    } else {
-        return _byteswap_uint64(_Val);
-    }
-}
-#endif // _HAS_CXX23
-
 _EXPORT_STD template <class _Ty, enable_if_t<_Is_standard_unsigned_integer<_Ty>, int> _Enabled>
 _NODISCARD constexpr int countl_zero(const _Ty _Val) noexcept {
 #if defined(_M_IX86) || (defined(_M_X64) && !defined(_M_ARM64EC))
@@ -323,23 +338,6 @@ _EXPORT_STD template <class _Ty, enable_if_t<_Is_standard_unsigned_integer<_Ty>,
 _NODISCARD constexpr int popcount(const _Ty _Val) noexcept {
     return _Popcount(_Val);
 }
-
-#if _HAS_CXX23
-_EXPORT_STD template <class _Ty, enable_if_t<is_integral_v<_Ty>, int> = 0>
-_NODISCARD constexpr _Ty byteswap(const _Ty _Val) noexcept {
-    if constexpr (sizeof(_Ty) == 1) {
-        return _Val;
-    } else if constexpr (sizeof(_Ty) == 2) {
-        return static_cast<_Ty>(_Byteswap_ushort(static_cast<unsigned short>(_Val)));
-    } else if constexpr (sizeof(_Ty) == 4) {
-        return static_cast<_Ty>(_Byteswap_ulong(static_cast<unsigned long>(_Val)));
-    } else if constexpr (sizeof(_Ty) == 8) {
-        return static_cast<_Ty>(_Byteswap_uint64(static_cast<unsigned long long>(_Val)));
-    } else {
-        static_assert(_Always_false<_Ty>, "Unexpected integer size");
-    }
-}
-#endif // _HAS_CXX23
 
 _EXPORT_STD enum class endian { little = 0, big = 1, native = little };
 


### PR DESCRIPTION
Coalesce `_Byteswap_meow` and `byteswap`, follow Standard order - see WG21-N4928 [\[bit.syn\]](https://eel.is/c++draft/bit.syn).

Programmer archaeology: This was introduced by #2235, where we simply didn't mention Standard order while reviewing. It appears that the rationale for separating the helpers was that this grouped Standard functions together. These days, we prefer to follow Standard order unless there's a strong reason not to, and we're comfortable with interleaving helpers along the way (this makes it easier to see what the helpers are doing).

Note: There will be a trivial merge conflict between this PR's code movement and #3539 editing `countl_zero`'s adjacent definition.