### PR TITLE
`<ranges>`: Fix `ranges::equal` for ranges with integer-class `range_difference_t`

### DIFF
--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -638,7 +638,7 @@ _NODISCARD pair<_FwdIt1, _FwdIt2> mismatch(
 
 #ifdef __cpp_lib_concepts
 namespace ranges {
-    template <input_iterator _It1, input_iterator _It2, integral _Size, class _Pr, class _Pj1, class _Pj2>
+    template <input_iterator _It1, input_iterator _It2, _Integer_like _Size, class _Pr, class _Pj1, class _Pj2>
         requires indirectly_comparable<_It1, _It2, _Pr, _Pj1, _Pj2>
     _NODISCARD constexpr bool _Equal_count(
         _It1 _First1, _It2 _First2, _Size _Count, _Pr _Pred, _Pj1 _Proj1, _Pj2 _Proj2) {

--- a/tests/std/tests/P0896R4_ranges_alg_equal/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_equal/test.cpp
@@ -79,11 +79,13 @@ constexpr void smoke_test() {
         assert(!equal(begin(arr1), unreachable_sentinel, begin(arr2), end(arr2)));
         assert(!equal(begin(arr1), end(arr1), begin(arr2), unreachable_sentinel));
     }
+#ifndef _M_CEE // TRANSITION, VSO-1666180
     {
         // Validate GH-3550: "<ranges>: ranges::equal does not work for ranges with integer-class range_difference_t"
         auto v = ranges::subrange{std::views::iota(0ull, 10ull)} | std::views::drop(2);
         assert(equal(v, v));
     }
+#endif // _M_CEE
 }
 
 int main() {

--- a/tests/std/tests/P0896R4_ranges_alg_equal/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_equal/test.cpp
@@ -81,7 +81,7 @@ constexpr void smoke_test() {
     }
     {
         // Validate GH-3550: "<ranges>: ranges::equal does not work for ranges with integer-class range_difference_t"
-        auto v = std::ranges::subrange{std::views::iota(0ull, 10ull)} | std::views::drop(2);
+        auto v = ranges::subrange{std::views::iota(0ull, 10ull)} | std::views::drop(2);
         assert(equal(v, v));
     }
 }

--- a/tests/std/tests/P0896R4_ranges_alg_equal/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_equal/test.cpp
@@ -79,6 +79,11 @@ constexpr void smoke_test() {
         assert(!equal(begin(arr1), unreachable_sentinel, begin(arr2), end(arr2)));
         assert(!equal(begin(arr1), end(arr1), begin(arr2), unreachable_sentinel));
     }
+    {
+        // Validate GH-3550: "<ranges>: ranges::equal does not work for ranges with integer-class range_difference_t"
+        auto v = std::ranges::subrange{std::views::iota(0ull, 10ull)} | std::views::drop(2);
+        assert(equal(v, v));
+    }
 }
 
 int main() {


### PR DESCRIPTION
Closes #3550.