### PR TITLE
`<ranges>`: Test `c(begin|end)` members of range factories

### DIFF
--- a/tests/std/tests/P0896R4_istream_view/test.cpp
+++ b/tests/std/tests/P0896R4_istream_view/test.cpp
@@ -123,7 +123,7 @@ void test_one_type() {
     { // Using ranges::istream_view with const iterators
         istringstream intstream{"0 1 2 3"};
         T input[] = {-1, -1, -1, -1, -1};
-        auto v    = ranges::istream_view<T>(intstream);
+        ranges::istream_view<T> v(intstream);
         ranges::copy(v.cbegin(), v.cend(), input);
         assert(ranges::equal(input, expected_vals));
     }
@@ -131,7 +131,7 @@ void test_one_type() {
     { // Using ranges::wistream_view with const iterators
         wistringstream wintstream{L"0 1 2 3"};
         T input[] = {-1, -1, -1, -1, -1};
-        auto v    = ranges::wistream_view<T>(wintstream);
+        ranges::wistream_view<T> v(wintstream);
         ranges::copy(v.cbegin(), v.cend(), input);
         assert(ranges::equal(input, expected_vals));
     }

--- a/tests/std/tests/P0896R4_istream_view/test.cpp
+++ b/tests/std/tests/P0896R4_istream_view/test.cpp
@@ -119,6 +119,23 @@ void test_one_type() {
         static_assert(noexcept(views::istream<T>(wintstream)));
         assert(ranges::equal(input, expected_vals));
     }
+#if _HAS_CXX23
+    { // Using ranges::istream_view with const iterators
+        istringstream intstream{"0 1 2 3"};
+        T input[] = {-1, -1, -1, -1, -1};
+        auto v    = ranges::istream_view<T>(intstream);
+        ranges::copy(v.cbegin(), v.cend(), input);
+        assert(ranges::equal(input, expected_vals));
+    }
+
+    { // Using ranges::wistream_view with const iterators
+        wistringstream wintstream{L"0 1 2 3"};
+        T input[] = {-1, -1, -1, -1, -1};
+        auto v    = ranges::wistream_view<T>(wintstream);
+        ranges::copy(v.cbegin(), v.cend(), input);
+        assert(ranges::equal(input, expected_vals));
+    }
+#endif // _HAS_CXX23
 }
 
 istringstream some_stream{"42"};

--- a/tests/std/tests/P0896R4_views_empty/test.cpp
+++ b/tests/std/tests/P0896R4_views_empty/test.cpp
@@ -51,7 +51,7 @@ constexpr bool test_one_type() {
     static_assert(noexcept(ranges::empty(r)));
 
 #if _HAS_CXX23
-    // validate cbegin, and cend
+    // validate members cbegin and cend inherited from view_interface
     static_assert(same_as<decltype(r.cbegin()), const_iterator<T*>>);
     static_assert(r.cbegin() == nullptr);
 
@@ -59,7 +59,7 @@ constexpr bool test_one_type() {
     static_assert(r.cend() == nullptr);
 #endif // _HAS_CXX23
 
-    // validate members inherited from view_interface
+    // validate other members inherited from view_interface
     assert(!r);
 
     return true;

--- a/tests/std/tests/P0896R4_views_empty/test.cpp
+++ b/tests/std/tests/P0896R4_views_empty/test.cpp
@@ -20,7 +20,7 @@ constexpr bool test_one_type() {
     static_assert(ranges::view<R> && ranges::contiguous_range<R> && ranges::sized_range<R> && ranges::common_range<R>);
     static_assert(ranges::borrowed_range<R>);
     static_assert(same_as<const R, decltype(views::empty<T>)>);
-    auto& r = views::empty<T>;
+    constexpr auto& r = views::empty<T>;
 
     // validate member size
     static_assert(same_as<decltype(R::size()), size_t>);
@@ -49,6 +49,15 @@ constexpr bool test_one_type() {
     static_assert(R::empty() == true);
     static_assert(noexcept(R::empty()));
     static_assert(noexcept(ranges::empty(r)));
+
+#if _HAS_CXX23
+    // validate cbegin, and cend
+    static_assert(same_as<decltype(r.cbegin()), const_iterator<T*>>);
+    static_assert(r.cbegin() == nullptr);
+
+    static_assert(same_as<decltype(r.cend()), const_iterator<T*>>);
+    static_assert(r.cend() == nullptr);
+#endif // _HAS_CXX23
 
     // validate members inherited from view_interface
     assert(!r);

--- a/tests/std/tests/P0896R4_views_iota/test.cpp
+++ b/tests/std/tests/P0896R4_views_iota/test.cpp
@@ -197,6 +197,14 @@ constexpr void test_integral() {
         static_assert(noexcept(first != last)); // strengthened
         assert(last - first == 8);
         static_assert(noexcept(last - first)); // strengthened
+
+#if _HAS_CXX23
+        const same_as<ranges::const_iterator_t<R>> auto cfirst = rng.cbegin();
+        assert(cfirst == first);
+        const same_as<ranges::const_sentinel_t<R>> auto clast = rng.cend();
+        assert(clast == last);
+        assert(clast - cfirst == 8);
+#endif // _HAS_CXX23
     }
 
     {
@@ -234,6 +242,21 @@ constexpr void test_integral() {
         }
 
         static_assert(!CanSize<ranges::iota_view<T>>);
+
+#if _HAS_CXX23
+        {
+            const same_as<R> auto rng = views::iota(low);
+            const ranges::subrange crng{rng.cbegin(), rng.cend()};
+
+            auto i = low;
+            for (const auto& e : crng) {
+                assert(e == i);
+                if (++i == high) {
+                    break;
+                }
+            }
+        }
+#endif // _HAS_CXX23
     }
 }
 

--- a/tests/std/tests/P0896R4_views_single/test.cpp
+++ b/tests/std/tests/P0896R4_views_single/test.cpp
@@ -94,6 +94,23 @@ constexpr bool test_one_type(T value, Args&&... args) {
     static_assert(noexcept(cr0.end()));
     static_assert(noexcept(ranges::end(cr0)));
 
+#if _HAS_CXX23
+    // validate members cbegin and cend
+    static_assert(same_as<decltype(r0.cbegin()), const T*>);
+    assert(*r0.cbegin() == value);
+    assert(r0.cbegin() == ptr);
+
+    static_assert(same_as<decltype(r0.cend()), const T*>);
+    assert(r0.cend() == ptr + 1);
+
+    static_assert(same_as<decltype(cr0.cbegin()), const T*>);
+    assert(*cr0.cbegin() == value);
+    assert(cr0.cbegin() == cptr);
+
+    static_assert(same_as<decltype(cr0.cend()), const T*>);
+    assert(cr0.cend() == cptr + 1);
+#endif // _HAS_CXX23
+
     // validate CTAD and T&& constructor
     const same_as<R> auto cr1 = ranges::single_view{move(value)};
     assert(cr1.data() != nullptr);

--- a/tests/std/tests/P2474R2_views_repeat/test.cpp
+++ b/tests/std/tests/P2474R2_views_repeat/test.cpp
@@ -252,6 +252,16 @@ constexpr void test_common(T val, B bound = unreachable_sentinel) {
         assert(cmp_equal(last - first, rng.size()));
         static_assert(noexcept(last - first)); // strengthened
     }
+
+    const same_as<ranges::const_iterator_t<R>> auto cfirst = rng.cbegin();
+    assert(cfirst == first);
+    const same_as<ranges::const_sentinel_t<R>> auto clast = rng.cend();
+    if constexpr (ranges::common_range<R>) {
+        assert(clast == last);
+        assert(cmp_equal(clast - cfirst, rng.size()));
+    } else {
+        static_assert(same_as<remove_const_t<decltype(clast)>, unreachable_sentinel_t>);
+    }
 }
 
 struct move_tester {


### PR DESCRIPTION
Towards #3391.
This PR adds extra tests for `c(begin|end)` members of C++ range factories ([[range.factories]](http://eel.is/c++draft/range.factories)):
* `views::empty`,
* `views::single`,
* `views::iota`,
* `views::repeat`,
* `views::istream`.
