### PR TITLE
`<mdspan>`: Add `_EXPORT_STD`, tiny cleanups

### DIFF
--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -186,14 +186,14 @@ public:
               && is_nothrow_constructible_v<index_type, const _OtherIndexType&>
               && (_Size == rank_dynamic() || _Size == rank())
     constexpr explicit(_Size != rank_dynamic()) extents(span<_OtherIndexType, _Size> _Exts) noexcept
-        : _Mybase{_Exts, _STD make_index_sequence<rank_dynamic()>{}} {}
+        : _Mybase{_Exts, make_index_sequence<rank_dynamic()>{}} {}
 
     template <class _OtherIndexType, size_t _Size>
         requires is_convertible_v<const _OtherIndexType&, index_type>
               && is_nothrow_constructible_v<index_type, const _OtherIndexType&>
               && (_Size == rank_dynamic() || _Size == rank())
     constexpr explicit(_Size != rank_dynamic()) extents(const array<_OtherIndexType, _Size>& _Exts) noexcept
-        : _Mybase{span{_Exts}, _STD make_index_sequence<rank_dynamic()>{}} {}
+        : _Mybase{span{_Exts}, make_index_sequence<rank_dynamic()>{}} {}
 
     template <class _OtherIndexType, size_t... _OtherExtents>
     _NODISCARD_FRIEND constexpr bool operator==(

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -494,10 +494,6 @@ public:
 private:
     _Extents _Myext{};
 
-    static constexpr size_t _Multiply(size_t _X, size_t _Y) {
-        return _X * _Y;
-    }
-
     template <class... _IndexType, size_t... _Seq>
     constexpr index_type _Index_impl(_IndexType... _Idx, index_sequence<_Seq...>) const noexcept {
         index_type _Result = 0;

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -117,6 +117,7 @@ struct _Mdspan_extent_type<_IndexType, 0> {
     }
 };
 
+_EXPORT_STD
 template <class _IndexType, size_t... _Extents>
 class extents : private _Mdspan_extent_type<_IndexType, ((_Extents == dynamic_extent) + ... + 0), _Extents...> {
 public:
@@ -231,6 +232,7 @@ public:
     }
 };
 
+_EXPORT_STD
 template <class _IndexType, size_t _Rank>
 using dextents =
     decltype([]<class _IndexType2, size_t... _Seq>(const _IndexType2, const index_sequence<_Seq...>) constexpr {
@@ -267,16 +269,19 @@ template <class _Layout, class _Mapping>
 inline constexpr bool _Is_mapping_of =
     is_same_v<typename _Layout::template mapping<typename _Mapping::extents_type>, _Mapping>;
 
+_EXPORT_STD
 struct layout_left {
     template <class _Extents>
     class mapping;
 };
 
+_EXPORT_STD
 struct layout_right {
     template <class _Extents>
     class mapping;
 };
 
+_EXPORT_STD
 struct layout_stride {
     template <class _Extents>
     class mapping;
@@ -681,6 +686,7 @@ private:
     }
 };
 
+_EXPORT_STD
 template <class _ElementType>
 struct default_accessor {
     using offset_policy    = default_accessor;
@@ -705,6 +711,7 @@ struct default_accessor {
     }
 };
 
+_EXPORT_STD
 template <class _ElementType, class _Extents, class _LayoutPolicy = layout_right,
     class _AccessorPolicy = default_accessor<_ElementType>>
 class mdspan {


### PR DESCRIPTION
* Drop `_STD` qualification for `make_index_sequence`.
* Remove dead `_Multiply()`. Also, `_X` and `_Y` were macro-like.
* All shall love `_EXPORT_STD` and despair. :elf_woman: