### PR TITLE
Mark constructors that do not throw exceptions as noexcept

### DIFF
--- a/stl/inc/__msvc_int128.hpp
+++ b/stl/inc/__msvc_int128.hpp
@@ -319,7 +319,7 @@ struct
     }
 
 #if _HAS_CXX20
-    _NODISCARD_FRIEND constexpr bool operator==(const _Base128&, const _Base128&) noexcept = default;
+    _NODISCARD_FRIEND constexpr bool operator==(const _Base128&, const _Base128&) = default;
 #else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
     _NODISCARD_FRIEND constexpr bool operator==(const _Base128& _Left, const _Base128& _Right) noexcept {
         return _Left._Word[0] == _Right._Word[0] && _Left._Word[1] == _Right._Word[1];

--- a/stl/inc/__msvc_tzdb.hpp
+++ b/stl/inc/__msvc_tzdb.hpp
@@ -125,9 +125,9 @@ public:
     using propagate_on_container_move_assignment = true_type;
     using is_always_equal                        = true_type;
 
-    constexpr _Crt_allocator() noexcept = default;
+    constexpr _Crt_allocator() = default;
 
-    constexpr _Crt_allocator(const _Crt_allocator&) noexcept = default;
+    constexpr _Crt_allocator(const _Crt_allocator&) = default;
     template <class _Other>
     constexpr _Crt_allocator(const _Crt_allocator<_Other>&) noexcept {}
 

--- a/stl/inc/atomic
+++ b/stl/inc/atomic
@@ -2357,7 +2357,7 @@ public:
         }
     }
 
-    atomic_ref(const atomic_ref&) noexcept = default;
+    atomic_ref(const atomic_ref&) = default;
 
     atomic_ref& operator=(const atomic_ref&) = delete;
 
@@ -2848,7 +2848,7 @@ _EXPORT_STD struct atomic_flag { // flag with test-and-set semantics
         _Storage.store(false, _Order);
     }
 
-    constexpr atomic_flag() noexcept = default;
+    constexpr atomic_flag() = default;
 
 #if _HAS_CXX20
     void wait(const bool _Expected, const memory_order _Order = memory_order_seq_cst) const noexcept {

--- a/stl/inc/compare
+++ b/stl/inc/compare
@@ -45,7 +45,7 @@ _EXPORT_STD struct partial_ordering {
         return _Val._Value == 0;
     }
 
-    _NODISCARD_FRIEND constexpr bool operator==(partial_ordering, partial_ordering) noexcept = default;
+    _NODISCARD_FRIEND constexpr bool operator==(partial_ordering, partial_ordering) = default;
 
     _NODISCARD_FRIEND constexpr bool operator<(const partial_ordering _Val, _Literal_zero) noexcept {
         return _Val._Value == static_cast<_Compare_t>(_Compare_ord::less);
@@ -114,7 +114,7 @@ _EXPORT_STD struct weak_ordering {
         return _Val._Value == 0;
     }
 
-    _NODISCARD_FRIEND constexpr bool operator==(weak_ordering, weak_ordering) noexcept = default;
+    _NODISCARD_FRIEND constexpr bool operator==(weak_ordering, weak_ordering) = default;
 
     _NODISCARD_FRIEND constexpr bool operator<(const weak_ordering _Val, _Literal_zero) noexcept {
         return _Val._Value < 0;
@@ -181,7 +181,7 @@ _EXPORT_STD struct strong_ordering {
         return _Val._Value == 0;
     }
 
-    _NODISCARD_FRIEND constexpr bool operator==(strong_ordering, strong_ordering) noexcept = default;
+    _NODISCARD_FRIEND constexpr bool operator==(strong_ordering, strong_ordering) = default;
 
     _NODISCARD_FRIEND constexpr bool operator<(const strong_ordering _Val, _Literal_zero) noexcept {
         return _Val._Value < 0;

--- a/stl/inc/coroutine
+++ b/stl/inc/coroutine
@@ -51,7 +51,7 @@ struct coroutine_handle;
 
 template <>
 struct coroutine_handle<void> {
-    constexpr coroutine_handle() noexcept = default;
+    constexpr coroutine_handle() = default;
     constexpr coroutine_handle(nullptr_t) noexcept {}
 
     coroutine_handle& operator=(nullptr_t) noexcept {
@@ -95,7 +95,7 @@ private:
 
 _EXPORT_STD template <class _Promise>
 struct coroutine_handle {
-    constexpr coroutine_handle() noexcept = default;
+    constexpr coroutine_handle() = default;
     constexpr coroutine_handle(nullptr_t) noexcept {}
 
     _NODISCARD static coroutine_handle from_promise(_Promise& _Prom) noexcept { // strengthened
@@ -227,7 +227,7 @@ struct coroutine_handle<noop_coroutine_promise> {
     }
 
 private:
-    coroutine_handle() noexcept = default;
+    coroutine_handle() = default;
 
     void* _Ptr = __builtin_coro_noop();
 };

--- a/stl/inc/exception
+++ b/stl/inc/exception
@@ -336,7 +336,7 @@ public:
     nested_exception() noexcept : _Exc(_STD current_exception()) {}
 
     nested_exception(const nested_exception&) noexcept            = default;
-    nested_exception& operator=(const nested_exception&) noexcept = default;
+    nested_exception& operator=(const nested_exception&) = default;
     virtual ~nested_exception() noexcept {}
 
     [[noreturn]] void rethrow_nested() const { // throw wrapped exception_ptr
@@ -399,7 +399,7 @@ void rethrow_if_nested(const _Ty&) = delete; // requires /GR option
 _EXPORT_STD class bad_variant_access
     : public exception { // exception for visit of a valueless variant or get<I> on a variant with index() != I
 public:
-    bad_variant_access() noexcept = default;
+    bad_variant_access() = default;
 
     _NODISCARD const char* __CLR_OR_THIS_CALL what() const noexcept override {
         return "bad variant access";

--- a/stl/inc/expected
+++ b/stl/inc/expected
@@ -233,7 +233,7 @@ public:
     }
 
     // clang-format off
-    expected(expected&&) requires
+    expected(expected&&)  noexcept requires
         is_trivially_move_constructible_v<_Ty> && is_trivially_move_constructible_v<_Err> = default;
     // clang-format on
 
@@ -1185,7 +1185,7 @@ public:
     }
 
     // clang-format off
-    expected(expected&&) requires is_trivially_move_constructible_v<_Err> = default;
+    expected(expected&&)  noexcept requires is_trivially_move_constructible_v<_Err> = default;
     // clang-format on
 
     template <class _Uty, class _UErr>

--- a/stl/inc/experimental/filesystem
+++ b/stl/inc/experimental/filesystem
@@ -129,7 +129,7 @@ public:
         : _Myftype(_Ftype), _Myperms(_Prms) {}
 
     file_status(const file_status&) noexcept            = default;
-    file_status& operator=(const file_status&) = default;
+    file_status& operator=(const file_status&) noexcept = default;
 
     file_status(file_status&&)            = default;
     file_status& operator=(file_status&&) = default;
@@ -1476,7 +1476,7 @@ public:
     _Directory_iterator(const _Directory_iterator&)            = default;
     _Directory_iterator& operator=(const _Directory_iterator&) = default;
 
-    _Directory_iterator(_Directory_iterator&&) noexcept            = default;
+    _Directory_iterator(_Directory_iterator&&) noexcept   = default;
     _Directory_iterator& operator=(_Directory_iterator&&) = default;
 
     _NODISCARD const value_type& operator*() const {

--- a/stl/inc/experimental/filesystem
+++ b/stl/inc/experimental/filesystem
@@ -129,7 +129,7 @@ public:
         : _Myftype(_Ftype), _Myperms(_Prms) {}
 
     file_status(const file_status&) noexcept            = default;
-    file_status& operator=(const file_status&) noexcept = default;
+    file_status& operator=(const file_status&) = default;
 
     file_status(file_status&&)            = default;
     file_status& operator=(file_status&&) = default;
@@ -1476,7 +1476,7 @@ public:
     _Directory_iterator(const _Directory_iterator&)            = default;
     _Directory_iterator& operator=(const _Directory_iterator&) = default;
 
-    _Directory_iterator(_Directory_iterator&&)            = default;
+    _Directory_iterator(_Directory_iterator&&) noexcept            = default;
     _Directory_iterator& operator=(_Directory_iterator&&) = default;
 
     _NODISCARD const value_type& operator*() const {

--- a/stl/inc/filesystem
+++ b/stl/inc/filesystem
@@ -632,12 +632,12 @@ namespace filesystem {
 
         enum format { auto_format, native_format, generic_format };
 
-        path()                       = default;
-        path(const path&)            = default;
-        path(path&&)                 = default;
-        ~path()                      = default;
-        path& operator=(const path&) = default;
-        path& operator=(path&&)      = default;
+        path()                           = default;
+        path(const path&)                = default;
+        path(path&&)                     = default;
+        ~path()                          = default;
+        path& operator=(const path&)     = default;
+        path& operator=(path&&) noexcept = default;
 
         path(string_type&& _Source) : _Text(_STD move(_Source)) {}
 
@@ -1905,15 +1905,15 @@ namespace filesystem {
     _EXPORT_STD class file_status {
     public:
         // [fs.file_status.cons], constructors and destructor
-        file_status() = default;
+        file_status() noexcept = default;
         explicit file_status(file_type _Ft, perms _Perms = perms::unknown) noexcept : _Myftype(_Ft), _Myperms(_Perms) {}
-        file_status(const file_status&)     = default;
-        file_status(file_status&&) noexcept = default;
-        ~file_status() noexcept             = default;
+        file_status(const file_status&) noexcept = default;
+        file_status(file_status&&) noexcept      = default;
+        ~file_status() noexcept                  = default;
 
         // assignments
-        file_status& operator=(const file_status&)     = default;
-        file_status& operator=(file_status&&) noexcept = default;
+        file_status& operator=(const file_status&) noexcept = default;
+        file_status& operator=(file_status&&) noexcept      = default;
 
         // [fs.file_status.mods], modifiers
         void type(file_type _Ft) noexcept {
@@ -2088,8 +2088,8 @@ namespace filesystem {
         // [fs.dir.entry.cons], constructors and destructor
         directory_entry() noexcept : _Cached_data{}, _Path() {}
 
-        directory_entry(const directory_entry&) = default;
-        directory_entry(directory_entry&&)      = default;
+        directory_entry(const directory_entry&)     = default;
+        directory_entry(directory_entry&&) noexcept = default;
         explicit directory_entry(const filesystem::path& _Path_arg) : _Cached_data{}, _Path(_Path_arg) {
             refresh();
         }
@@ -2104,8 +2104,8 @@ namespace filesystem {
         ~directory_entry() = default;
 
         // assignments
-        directory_entry& operator=(const directory_entry&) = default;
-        directory_entry& operator=(directory_entry&&)      = default;
+        directory_entry& operator=(const directory_entry&)     = default;
+        directory_entry& operator=(directory_entry&&) noexcept = default;
 
         // [fs.dir.entry.mods], modifiers
         void assign(const filesystem::path& _Path_arg) {
@@ -2615,7 +2615,7 @@ namespace filesystem {
         using reference         = const directory_entry&;
 
         // [fs.dir.itr.members], member functions
-        directory_iterator() = default;
+        directory_iterator() noexcept = default;
         explicit directory_iterator(const path& _Path) {
             const auto _Error = _Dir_enum_impl::_Initialize_dir_enum(_Impl, _Path);
             if (_Error != __std_win_error::_Success) {
@@ -2638,12 +2638,12 @@ namespace filesystem {
             _Ec = _Make_ec(_Dir_enum_impl::_Initialize_dir_enum(_Impl, _Path, _Options));
         }
 
-        directory_iterator(const directory_iterator&)     = default; // strengthened
-        directory_iterator(directory_iterator&&) noexcept = default;
-        ~directory_iterator() noexcept                    = default;
+        directory_iterator(const directory_iterator&) noexcept = default; // strengthened
+        directory_iterator(directory_iterator&&) noexcept      = default;
+        ~directory_iterator() noexcept                         = default;
 
-        directory_iterator& operator=(const directory_iterator&)     = default; // strengthened
-        directory_iterator& operator=(directory_iterator&&) noexcept = default;
+        directory_iterator& operator=(const directory_iterator&) noexcept = default; // strengthened
+        directory_iterator& operator=(directory_iterator&&) noexcept      = default;
 
         _NODISCARD const directory_entry& operator*() const noexcept /* strengthened */ {
             return _Impl->_Entry;
@@ -2840,7 +2840,7 @@ namespace filesystem {
 
         // [fs.rec.dir.itr.members], constructors and destructor
 
-        recursive_directory_iterator() = default;
+        recursive_directory_iterator() noexcept = default;
         explicit recursive_directory_iterator(const path& _Path) {
             const auto _Error = _Dir_enum_impl::_Initialize_dir_enum(_Impl, _Path);
             if (_Error != __std_win_error::_Success) {
@@ -2863,9 +2863,9 @@ namespace filesystem {
             _Ec = _Make_ec(_Dir_enum_impl::_Initialize_dir_enum(_Impl, _Path));
         }
 
-        recursive_directory_iterator(const recursive_directory_iterator&)     = default; // strengthened
-        recursive_directory_iterator(recursive_directory_iterator&&) noexcept = default;
-        ~recursive_directory_iterator() noexcept                              = default;
+        recursive_directory_iterator(const recursive_directory_iterator&) noexcept = default; // strengthened
+        recursive_directory_iterator(recursive_directory_iterator&&) noexcept      = default;
+        ~recursive_directory_iterator() noexcept                                   = default;
 
         // [fs.rec.dir.itr.members], observers
         _NODISCARD directory_options options() const noexcept /* strengthened */ {
@@ -2892,8 +2892,8 @@ namespace filesystem {
         }
 
         // [fs.rec.dir.itr.members], modifiers
-        recursive_directory_iterator& operator=(recursive_directory_iterator&&) noexcept = default;
-        recursive_directory_iterator& operator=(const recursive_directory_iterator&)     = default; // strengthened
+        recursive_directory_iterator& operator=(recursive_directory_iterator&&) noexcept      = default;
+        recursive_directory_iterator& operator=(const recursive_directory_iterator&) noexcept = default; // strengthened
 
         recursive_directory_iterator& operator++() {
             const auto _Error = _Recursive_dir_enum_impl::_Advance_and_reset_if_no_more_files(_Impl);
@@ -3673,7 +3673,7 @@ namespace filesystem {
         uintmax_t available;
 
 #if _HAS_CXX20
-        _NODISCARD_FRIEND constexpr bool operator==(const space_info&, const space_info&) = default;
+        _NODISCARD_FRIEND constexpr bool operator==(const space_info&, const space_info&) noexcept = default;
 #endif // _HAS_CXX20
     };
 

--- a/stl/inc/filesystem
+++ b/stl/inc/filesystem
@@ -586,7 +586,7 @@ namespace filesystem {
     struct _Find_file_handle {
         __std_fs_dir_handle _Handle = __std_fs_dir_handle::_Invalid;
 
-        _Find_file_handle() = default;
+        _Find_file_handle() noexcept = default;
         _Find_file_handle(_Find_file_handle&& _Rhs) noexcept
             : _Handle(_STD exchange(_Rhs._Handle, __std_fs_dir_handle::_Invalid)) {}
 
@@ -632,12 +632,12 @@ namespace filesystem {
 
         enum format { auto_format, native_format, generic_format };
 
-        path()                           = default;
-        path(const path&)                = default;
-        path(path&&)                     = default;
-        ~path()                          = default;
-        path& operator=(const path&)     = default;
-        path& operator=(path&&) = default;
+        path()                       = default;
+        path(const path&)            = default;
+        path(path&&)                 = default;
+        ~path()                      = default;
+        path& operator=(const path&) = default;
+        path& operator=(path&&)      = default;
 
         path(string_type&& _Source) : _Text(_STD move(_Source)) {}
 
@@ -1412,10 +1412,10 @@ namespace filesystem {
         _Path_iterator(const _Base_iter& _Position_, path&& _Element_, const path* _Mypath_)
             : _Position(_Position_), _Element(_STD move(_Element_)), _Mypath(_Mypath_) {}
 
-        _Path_iterator(const _Path_iterator&)                = default;
-        _Path_iterator(_Path_iterator&&) noexcept            = default;
-        _Path_iterator& operator=(const _Path_iterator&)     = default;
-        _Path_iterator& operator=(_Path_iterator&&) = default;
+        _Path_iterator(const _Path_iterator&)            = default;
+        _Path_iterator(_Path_iterator&&) noexcept        = default;
+        _Path_iterator& operator=(const _Path_iterator&) = default;
+        _Path_iterator& operator=(_Path_iterator&&)      = default;
 
         _NODISCARD reference operator*() const noexcept {
             return _Element;
@@ -1907,13 +1907,13 @@ namespace filesystem {
         // [fs.file_status.cons], constructors and destructor
         file_status() = default;
         explicit file_status(file_type _Ft, perms _Perms = perms::unknown) noexcept : _Myftype(_Ft), _Myperms(_Perms) {}
-        file_status(const file_status&) = default;
-        file_status(file_status&&) noexcept      = default;
-        ~file_status() noexcept                  = default;
+        file_status(const file_status&)     = default;
+        file_status(file_status&&) noexcept = default;
+        ~file_status() noexcept             = default;
 
         // assignments
-        file_status& operator=(const file_status&) = default;
-        file_status& operator=(file_status&&) noexcept      = default;
+        file_status& operator=(const file_status&)     = default;
+        file_status& operator=(file_status&&) noexcept = default;
 
         // [fs.file_status.mods], modifiers
         void type(file_type _Ft) noexcept {
@@ -2088,8 +2088,8 @@ namespace filesystem {
         // [fs.dir.entry.cons], constructors and destructor
         directory_entry() noexcept : _Cached_data{}, _Path() {}
 
-        directory_entry(const directory_entry&)     = default;
-        directory_entry(directory_entry&&) = default;
+        directory_entry(const directory_entry&) = default;
+        directory_entry(directory_entry&&)      = default;
         explicit directory_entry(const filesystem::path& _Path_arg) : _Cached_data{}, _Path(_Path_arg) {
             refresh();
         }
@@ -2104,8 +2104,8 @@ namespace filesystem {
         ~directory_entry() = default;
 
         // assignments
-        directory_entry& operator=(const directory_entry&)     = default;
-        directory_entry& operator=(directory_entry&&) = default;
+        directory_entry& operator=(const directory_entry&) = default;
+        directory_entry& operator=(directory_entry&&)      = default;
 
         // [fs.dir.entry.mods], modifiers
         void assign(const filesystem::path& _Path_arg) {
@@ -2638,12 +2638,12 @@ namespace filesystem {
             _Ec = _Make_ec(_Dir_enum_impl::_Initialize_dir_enum(_Impl, _Path, _Options));
         }
 
-        directory_iterator(const directory_iterator&) = default; // strengthened
-        directory_iterator(directory_iterator&&) noexcept      = default;
-        ~directory_iterator() noexcept                         = default;
+        directory_iterator(const directory_iterator&)     = default; // strengthened
+        directory_iterator(directory_iterator&&) noexcept = default;
+        ~directory_iterator() noexcept                    = default;
 
-        directory_iterator& operator=(const directory_iterator&) = default; // strengthened
-        directory_iterator& operator=(directory_iterator&&) noexcept      = default;
+        directory_iterator& operator=(const directory_iterator&)     = default; // strengthened
+        directory_iterator& operator=(directory_iterator&&) noexcept = default;
 
         _NODISCARD const directory_entry& operator*() const noexcept /* strengthened */ {
             return _Impl->_Entry;
@@ -2863,9 +2863,9 @@ namespace filesystem {
             _Ec = _Make_ec(_Dir_enum_impl::_Initialize_dir_enum(_Impl, _Path));
         }
 
-        recursive_directory_iterator(const recursive_directory_iterator&) = default; // strengthened
-        recursive_directory_iterator(recursive_directory_iterator&&) noexcept      = default;
-        ~recursive_directory_iterator() noexcept                                   = default;
+        recursive_directory_iterator(const recursive_directory_iterator&)     = default; // strengthened
+        recursive_directory_iterator(recursive_directory_iterator&&) noexcept = default;
+        ~recursive_directory_iterator() noexcept                              = default;
 
         // [fs.rec.dir.itr.members], observers
         _NODISCARD directory_options options() const noexcept /* strengthened */ {
@@ -2892,8 +2892,8 @@ namespace filesystem {
         }
 
         // [fs.rec.dir.itr.members], modifiers
-        recursive_directory_iterator& operator=(recursive_directory_iterator&&) noexcept      = default;
-        recursive_directory_iterator& operator=(const recursive_directory_iterator&) = default; // strengthened
+        recursive_directory_iterator& operator=(recursive_directory_iterator&&) noexcept = default;
+        recursive_directory_iterator& operator=(const recursive_directory_iterator&)     = default; // strengthened
 
         recursive_directory_iterator& operator++() {
             const auto _Error = _Recursive_dir_enum_impl::_Advance_and_reset_if_no_more_files(_Impl);

--- a/stl/inc/filesystem
+++ b/stl/inc/filesystem
@@ -586,7 +586,7 @@ namespace filesystem {
     struct _Find_file_handle {
         __std_fs_dir_handle _Handle = __std_fs_dir_handle::_Invalid;
 
-        _Find_file_handle() noexcept = default;
+        _Find_file_handle() = default;
         _Find_file_handle(_Find_file_handle&& _Rhs) noexcept
             : _Handle(_STD exchange(_Rhs._Handle, __std_fs_dir_handle::_Invalid)) {}
 
@@ -637,7 +637,7 @@ namespace filesystem {
         path(path&&)                     = default;
         ~path()                          = default;
         path& operator=(const path&)     = default;
-        path& operator=(path&&) noexcept = default;
+        path& operator=(path&&) = default;
 
         path(string_type&& _Source) : _Text(_STD move(_Source)) {}
 
@@ -1412,10 +1412,10 @@ namespace filesystem {
         _Path_iterator(const _Base_iter& _Position_, path&& _Element_, const path* _Mypath_)
             : _Position(_Position_), _Element(_STD move(_Element_)), _Mypath(_Mypath_) {}
 
-        _Path_iterator(const _Path_iterator&)            = default;
-        _Path_iterator(_Path_iterator&&)                 = default;
-        _Path_iterator& operator=(const _Path_iterator&) = default;
-        _Path_iterator& operator=(_Path_iterator&&)      = default;
+        _Path_iterator(const _Path_iterator&)                = default;
+        _Path_iterator(_Path_iterator&&) noexcept            = default;
+        _Path_iterator& operator=(const _Path_iterator&)     = default;
+        _Path_iterator& operator=(_Path_iterator&&) = default;
 
         _NODISCARD reference operator*() const noexcept {
             return _Element;
@@ -1905,14 +1905,14 @@ namespace filesystem {
     _EXPORT_STD class file_status {
     public:
         // [fs.file_status.cons], constructors and destructor
-        file_status() noexcept = default;
+        file_status() = default;
         explicit file_status(file_type _Ft, perms _Perms = perms::unknown) noexcept : _Myftype(_Ft), _Myperms(_Perms) {}
-        file_status(const file_status&) noexcept = default;
+        file_status(const file_status&) = default;
         file_status(file_status&&) noexcept      = default;
         ~file_status() noexcept                  = default;
 
         // assignments
-        file_status& operator=(const file_status&) noexcept = default;
+        file_status& operator=(const file_status&) = default;
         file_status& operator=(file_status&&) noexcept      = default;
 
         // [fs.file_status.mods], modifiers
@@ -2089,7 +2089,7 @@ namespace filesystem {
         directory_entry() noexcept : _Cached_data{}, _Path() {}
 
         directory_entry(const directory_entry&)     = default;
-        directory_entry(directory_entry&&) noexcept = default;
+        directory_entry(directory_entry&&) = default;
         explicit directory_entry(const filesystem::path& _Path_arg) : _Cached_data{}, _Path(_Path_arg) {
             refresh();
         }
@@ -2105,7 +2105,7 @@ namespace filesystem {
 
         // assignments
         directory_entry& operator=(const directory_entry&)     = default;
-        directory_entry& operator=(directory_entry&&) noexcept = default;
+        directory_entry& operator=(directory_entry&&) = default;
 
         // [fs.dir.entry.mods], modifiers
         void assign(const filesystem::path& _Path_arg) {
@@ -2615,7 +2615,7 @@ namespace filesystem {
         using reference         = const directory_entry&;
 
         // [fs.dir.itr.members], member functions
-        directory_iterator() noexcept = default;
+        directory_iterator() = default;
         explicit directory_iterator(const path& _Path) {
             const auto _Error = _Dir_enum_impl::_Initialize_dir_enum(_Impl, _Path);
             if (_Error != __std_win_error::_Success) {
@@ -2638,11 +2638,11 @@ namespace filesystem {
             _Ec = _Make_ec(_Dir_enum_impl::_Initialize_dir_enum(_Impl, _Path, _Options));
         }
 
-        directory_iterator(const directory_iterator&) noexcept = default; // strengthened
+        directory_iterator(const directory_iterator&) = default; // strengthened
         directory_iterator(directory_iterator&&) noexcept      = default;
         ~directory_iterator() noexcept                         = default;
 
-        directory_iterator& operator=(const directory_iterator&) noexcept = default; // strengthened
+        directory_iterator& operator=(const directory_iterator&) = default; // strengthened
         directory_iterator& operator=(directory_iterator&&) noexcept      = default;
 
         _NODISCARD const directory_entry& operator*() const noexcept /* strengthened */ {
@@ -2840,7 +2840,7 @@ namespace filesystem {
 
         // [fs.rec.dir.itr.members], constructors and destructor
 
-        recursive_directory_iterator() noexcept = default;
+        recursive_directory_iterator() = default;
         explicit recursive_directory_iterator(const path& _Path) {
             const auto _Error = _Dir_enum_impl::_Initialize_dir_enum(_Impl, _Path);
             if (_Error != __std_win_error::_Success) {
@@ -2863,7 +2863,7 @@ namespace filesystem {
             _Ec = _Make_ec(_Dir_enum_impl::_Initialize_dir_enum(_Impl, _Path));
         }
 
-        recursive_directory_iterator(const recursive_directory_iterator&) noexcept = default; // strengthened
+        recursive_directory_iterator(const recursive_directory_iterator&) = default; // strengthened
         recursive_directory_iterator(recursive_directory_iterator&&) noexcept      = default;
         ~recursive_directory_iterator() noexcept                                   = default;
 
@@ -2893,7 +2893,7 @@ namespace filesystem {
 
         // [fs.rec.dir.itr.members], modifiers
         recursive_directory_iterator& operator=(recursive_directory_iterator&&) noexcept      = default;
-        recursive_directory_iterator& operator=(const recursive_directory_iterator&) noexcept = default; // strengthened
+        recursive_directory_iterator& operator=(const recursive_directory_iterator&) = default; // strengthened
 
         recursive_directory_iterator& operator++() {
             const auto _Error = _Recursive_dir_enum_impl::_Advance_and_reset_if_no_more_files(_Impl);
@@ -3673,7 +3673,7 @@ namespace filesystem {
         uintmax_t available;
 
 #if _HAS_CXX20
-        _NODISCARD_FRIEND constexpr bool operator==(const space_info&, const space_info&) noexcept = default;
+        _NODISCARD_FRIEND constexpr bool operator==(const space_info&, const space_info&) = default;
 #endif // _HAS_CXX20
     };
 

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -376,7 +376,7 @@ private:
     _State_t _State = _Start;
 
 public:
-    _NODISCARD constexpr bool operator==(const _GB11_LeftHand_regex&) const noexcept = default;
+    _NODISCARD constexpr bool operator==(const _GB11_LeftHand_regex&) const = default;
 
     _NODISCARD constexpr bool _Match(
         const _Grapheme_Break_property_values _Left_gbp, _Extended_Pictographic_property_values _Left_ExtPic) noexcept {
@@ -415,7 +415,7 @@ public:
         return _WrappedIter == default_sentinel;
     }
 
-    _NODISCARD constexpr bool operator==(const _Grapheme_break_property_iterator&) const noexcept = default;
+    _NODISCARD constexpr bool operator==(const _Grapheme_break_property_iterator&) const = default;
 
     using difference_type = ptrdiff_t;
     using value_type      = iter_value_t<_Wrapped_iter_type>;
@@ -1906,7 +1906,7 @@ class _Format_arg_store<_Context> {};
 _EXPORT_STD template <class _Context>
 class basic_format_args {
 public:
-    basic_format_args() noexcept = default;
+    basic_format_args() = default;
 
     basic_format_args(const _Format_arg_store<_Context>&) noexcept {}
 
@@ -2981,7 +2981,7 @@ private:
     _Grapheme_break_property_iterator<_CharT> _WrappedIter;
 
 public:
-    _NODISCARD constexpr bool operator==(const _Measure_string_prefix_iterator_utf&) const noexcept = default;
+    _NODISCARD constexpr bool operator==(const _Measure_string_prefix_iterator_utf&) const = default;
 
     _NODISCARD constexpr bool operator==(default_sentinel_t) const noexcept {
         return _WrappedIter == default_sentinel;

--- a/stl/inc/functional
+++ b/stl/inc/functional
@@ -1367,7 +1367,7 @@ public:
 
     _Move_only_function_data _Data;
 
-    _Move_only_function_base() noexcept = default; // leaves fields uninitialized
+    _Move_only_function_base() = default; // leaves fields uninitialized
 
     _Move_only_function_base(_Move_only_function_base&& _Other) noexcept {
         _Checked_move(_Data, _Other._Data);
@@ -1768,7 +1768,7 @@ public:
         this->_Construct_with_null();
     }
 
-    move_only_function(move_only_function&&) noexcept = default;
+    move_only_function(move_only_function&&) = default;
 
     template <class _Fn, enable_if_t<_Enable_one_arg_constructor<_Fn>, int> = 0>
     move_only_function(_Fn&& _Callable) {
@@ -1818,7 +1818,7 @@ public:
         return *this;
     }
 
-    move_only_function& operator=(move_only_function&& _Other) {
+    move_only_function& operator=(move_only_function&& _Other) noexcept(false) {
         if (this != _STD addressof(_Other)) {
             this->_Move_assign(_STD move(_Other));
         }

--- a/stl/inc/future
+++ b/stl/inc/future
@@ -1434,7 +1434,7 @@ public:
         _STD terminate(); // Very Bad Things
     }
 
-    _Fake_no_copy_callable_adapter(_Fake_no_copy_callable_adapter&& _Other)          = default;
+    _Fake_no_copy_callable_adapter(_Fake_no_copy_callable_adapter&& _Other) = default;
     _Fake_no_copy_callable_adapter& operator=(const _Fake_no_copy_callable_adapter&) = delete;
     _Fake_no_copy_callable_adapter& operator=(_Fake_no_copy_callable_adapter&&)      = delete;
 

--- a/stl/inc/hash_map
+++ b/stl/inc/hash_map
@@ -170,7 +170,7 @@ namespace stdext {
             return *this;
         }
 
-        hash_map(hash_map&& _Right) : _Mybase(_STD move(_Right)) {}
+        hash_map(hash_map&& _Right) noexcept : _Mybase(_STD move(_Right)) {}
 
         hash_map(hash_map&& _Right, const allocator_type& _Al) : _Mybase(_STD move(_Right), _Al) {}
 
@@ -356,7 +356,7 @@ namespace stdext {
             return *this;
         }
 
-        hash_multimap(hash_multimap&& _Right) : _Mybase(_STD move(_Right)) {}
+        hash_multimap(hash_multimap&& _Right) noexcept : _Mybase(_STD move(_Right)) {}
 
         hash_multimap(hash_multimap&& _Right, const allocator_type& _Al) : _Mybase(_STD move(_Right), _Al) {}
 

--- a/stl/inc/hash_set
+++ b/stl/inc/hash_set
@@ -143,7 +143,7 @@ namespace stdext {
             return *this;
         }
 
-        hash_set(hash_set&& _Right) : _Mybase(_STD move(_Right)) {}
+        hash_set(hash_set&& _Right) noexcept : _Mybase(_STD move(_Right)) {}
 
         hash_set(hash_set&& _Right, const allocator_type& _Al) : _Mybase(_STD move(_Right), _Al) {}
 
@@ -286,7 +286,7 @@ namespace stdext {
             return *this;
         }
 
-        hash_multiset(hash_multiset&& _Right) : _Mybase(_STD move(_Right)) {}
+        hash_multiset(hash_multiset&& _Right) noexcept : _Mybase(_STD move(_Right)) {}
 
         hash_multiset(hash_multiset&& _Right, const allocator_type& _Al) : _Mybase(_STD move(_Right), _Al) {}
 

--- a/stl/inc/iterator
+++ b/stl/inc/iterator
@@ -616,7 +616,7 @@ public:
     }
 
     // clang-format off
-    constexpr _Variantish(_Variantish&&) requires is_trivially_move_constructible_v<_Ty1>
+    constexpr _Variantish(_Variantish&&)  noexcept requires is_trivially_move_constructible_v<_Ty1>
         && is_trivially_move_constructible_v<_Ty2> = default;
     // clang-format on
 
@@ -687,7 +687,7 @@ public:
     }
 
     // clang-format off
-    constexpr _Variantish& operator=(_Variantish&&) requires is_trivially_destructible_v<_Ty1>
+    constexpr _Variantish& operator=(_Variantish&&)  noexcept requires is_trivially_destructible_v<_Ty1>
         && is_trivially_destructible_v<_Ty2>
         && is_trivially_move_constructible_v<_Ty1>
         && is_trivially_move_constructible_v<_Ty2>

--- a/stl/inc/list
+++ b/stl/inc/list
@@ -894,7 +894,7 @@ public:
     }
 #endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 
-    list(list&& _Right) : _Mypair(_One_then_variadic_args_t{}, _STD move(_Right._Getal())) {
+    list(list&& _Right) noexcept : _Mypair(_One_then_variadic_args_t{}, _STD move(_Right._Getal())) {
         _Alloc_sentinel_and_proxy();
         _Swap_val(_Right);
     }

--- a/stl/inc/map
+++ b/stl/inc/map
@@ -161,7 +161,7 @@ public:
         return *this;
     }
 
-    map(map&& _Right) : _Mybase(_STD move(_Right)) {}
+    map(map&& _Right) noexcept : _Mybase(_STD move(_Right)) {}
 
     map(map&& _Right, const allocator_type& _Al) : _Mybase(_STD move(_Right), _Al) {}
 
@@ -539,7 +539,7 @@ public:
         return *this;
     }
 
-    multimap(multimap&& _Right) : _Mybase(_STD move(_Right)) {}
+    multimap(multimap&& _Right) noexcept : _Mybase(_STD move(_Right)) {}
 
     multimap(multimap&& _Right, const allocator_type& _Al) : _Mybase(_STD move(_Right), _Al) {}
 

--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -1128,7 +1128,7 @@ private:
     _Atomic_counter_t _Weaks = 1;
 
 protected:
-    constexpr _Ref_count_base() noexcept = default; // non-atomic initializations
+    constexpr _Ref_count_base() = default; // non-atomic initializations
 
 public:
     _Ref_count_base(const _Ref_count_base&)            = delete;
@@ -1325,7 +1325,7 @@ protected:
         return _Ptr;
     }
 
-    constexpr _Ptr_base() noexcept = default;
+    constexpr _Ptr_base() = default;
 
     ~_Ptr_base() = default;
 
@@ -1560,7 +1560,7 @@ public:
     using weak_type = weak_ptr<_Ty>;
 #endif // _HAS_CXX17
 
-    constexpr shared_ptr() noexcept = default;
+    constexpr shared_ptr() = default;
 
     constexpr shared_ptr(nullptr_t) noexcept {} // construct empty shared_ptr
 
@@ -3153,7 +3153,7 @@ private:
 
 _EXPORT_STD template <class _Ty>
 struct default_delete { // default deleter for unique_ptr
-    constexpr default_delete() noexcept = default;
+    constexpr default_delete() = default;
 
     template <class _Ty2, enable_if_t<is_convertible_v<_Ty2*, _Ty*>, int> = 0>
     _CONSTEXPR23 default_delete(const default_delete<_Ty2>&) noexcept {}
@@ -3166,7 +3166,7 @@ struct default_delete { // default deleter for unique_ptr
 
 template <class _Ty>
 struct default_delete<_Ty[]> { // default deleter for unique_ptr to array of unknown size
-    constexpr default_delete() noexcept = default;
+    constexpr default_delete() = default;
 
     template <class _Uty, enable_if_t<is_convertible_v<_Uty (*)[], _Ty (*)[]>, int> = 0>
     _CONSTEXPR23 default_delete(const default_delete<_Uty[]>&) noexcept {}
@@ -3850,7 +3850,7 @@ template <class _Ty>
 class alignas(2 * sizeof(void*)) _Atomic_ptr_base {
     // overalignment is to allow potential future use of cmpxchg16b
 protected:
-    constexpr _Atomic_ptr_base() noexcept = default;
+    constexpr _Atomic_ptr_base() = default;
 
     _Atomic_ptr_base(remove_extent_t<_Ty>* const _Px, _Ref_count_base* const _Ref) noexcept
         : _Ptr(_Px), _Repptr(_Ref) {}
@@ -3975,7 +3975,7 @@ public:
     using _Base::notify_all;
     using _Base::notify_one;
 
-    constexpr atomic() noexcept = default;
+    constexpr atomic() = default;
 
     constexpr atomic(nullptr_t) noexcept : atomic() {}
 
@@ -4094,7 +4094,7 @@ public:
     using _Base::notify_all;
     using _Base::notify_one;
 
-    constexpr atomic() noexcept = default;
+    constexpr atomic() = default;
 
     atomic(const weak_ptr<_Ty> _Value) noexcept : _Base(_Value._Ptr, _Value._Rep) {
         _Value._Incwref();

--- a/stl/inc/memory_resource
+++ b/stl/inc/memory_resource
@@ -164,7 +164,7 @@ namespace pmr {
 
         _STL_INTERNAL_STATIC_ASSERT(is_base_of_v<_Link_type, _Ty>);
 
-        constexpr _Intrusive_stack() noexcept = default;
+        constexpr _Intrusive_stack() = default;
         constexpr _Intrusive_stack(_Intrusive_stack&& _That) noexcept : _Head{_That._Head} {
             _That._Head = nullptr;
         }

--- a/stl/inc/mutex
+++ b/stl/inc/mutex
@@ -172,7 +172,7 @@ class unique_lock { // whizzy class with destructor that unlocks mutex
 public:
     using mutex_type = _Mutex;
 
-    unique_lock() noexcept = default;
+    unique_lock() = default;
 
     _NODISCARD_CTOR_LOCK explicit unique_lock(_Mutex& _Mtx)
         : _Pmtx(_STD addressof(_Mtx)), _Owns(false) { // construct and lock

--- a/stl/inc/ostream
+++ b/stl/inc/ostream
@@ -865,7 +865,6 @@ basic_ostream<_Elem, _Traits>& operator<<(basic_ostream<_Elem, _Traits>& _Ostr, 
         if (_State == ios_base::goodbit && _Ostr.rdbuf()->sputn(_Val, _Count) != _Count) {
             _State |= ios_base::badbit;
         }
-
         if (_State == ios_base::goodbit) {
             for (; 0 < _Pad; --_Pad) { // pad on right
                 if (_Traits::eq_int_type(_Traits::eof(), _Ostr.rdbuf()->sputc(_Ostr.fill()))) {

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -295,10 +295,10 @@ namespace ranges {
         }
 
         // clang-format off
-        _Movable_box(_Movable_box&&) requires is_trivially_move_constructible_v<_Ty> = default;
+        _Movable_box(_Movable_box&&)  noexcept requires is_trivially_move_constructible_v<_Ty> = default;
         // clang-format on
 
-        constexpr _Movable_box(_Movable_box&& _That) : _Engaged{_That._Engaged} {
+        constexpr _Movable_box(_Movable_box&& _That) noexcept : _Engaged{_That._Engaged} {
             if (_That._Engaged) {
                 _Construct_in_place(_Val, _STD move(_That._Val));
             }
@@ -442,12 +442,12 @@ namespace ranges {
             is_nothrow_constructible_v<_Ty, _Types...>) // strengthened
             : _Val(_STD forward<_Types>(_Args)...) {}
 
-        _Movable_box(const _Movable_box&) = default;
-        _Movable_box(_Movable_box&&)      = default;
+        _Movable_box(const _Movable_box&)     = default;
+        _Movable_box(_Movable_box&&) = default;
 
         // clang-format off
         _Movable_box& operator=(const _Movable_box&) requires copyable<_Ty> = default;
-        _Movable_box& operator=(_Movable_box&&) requires movable<_Ty> = default;
+        _Movable_box& operator=(_Movable_box&&)  noexcept requires movable<_Ty> = default;
         // clang-format on
 
         constexpr _Movable_box& operator=(const _Movable_box& _That) noexcept
@@ -512,10 +512,10 @@ namespace ranges {
         }
 
         // clang-format off
-        _Defaultabox(_Defaultabox&&) requires is_trivially_move_constructible_v<_Ty> = default;
+        _Defaultabox(_Defaultabox&&)  noexcept requires is_trivially_move_constructible_v<_Ty> = default;
         // clang-format on
 
-        constexpr _Defaultabox(_Defaultabox&& _That) : _Engaged{_That._Engaged} {
+        constexpr _Defaultabox(_Defaultabox&& _That) noexcept : _Engaged{_That._Engaged} {
             if (_That._Engaged) {
                 _Construct_in_place(_Val, _STD move(_That._Val));
             }
@@ -1651,11 +1651,11 @@ namespace ranges {
 
             constexpr explicit _Iterator(basic_istream_view& _Parent_) noexcept : _Parent{_STD addressof(_Parent_)} {}
 
-            _Iterator(const _Iterator&) = delete;
-            _Iterator(_Iterator&&)      = default;
+            _Iterator(const _Iterator&)     = delete;
+            _Iterator(_Iterator&&) = default;
 
-            _Iterator& operator=(const _Iterator&) = delete;
-            _Iterator& operator=(_Iterator&&)      = default;
+            _Iterator& operator=(const _Iterator&)     = delete;
+            _Iterator& operator=(_Iterator&&) = default;
 
             _Iterator& operator++() {
 #if _ITERATOR_DEBUG_LEVEL != 0
@@ -1809,7 +1809,7 @@ namespace ranges {
         constexpr owning_view(_Rng&& _Range_) noexcept(is_nothrow_move_constructible_v<_Rng>) // strengthened
             : _Range(_STD move(_Range_)) {}
 
-        owning_view(owning_view&&)            = default;
+        owning_view(owning_view&&) noexcept            = default;
         owning_view& operator=(owning_view&&) = default;
 
         _NODISCARD constexpr _Rng& base() & noexcept {
@@ -6364,7 +6364,7 @@ namespace ranges {
             using difference_type  = range_difference_t<_Vw>;
             using value_type       = range_value_t<_Vw>;
 
-            _Inner_iterator(_Inner_iterator&&)            = default;
+            _Inner_iterator(_Inner_iterator&&) noexcept            = default;
             _Inner_iterator& operator=(_Inner_iterator&&) = default;
 
             _NODISCARD constexpr const iterator_t<_Vw>& base() const& noexcept /* strengthened */ {
@@ -6489,7 +6489,7 @@ namespace ranges {
                 }
             };
 
-            _Outer_iterator(_Outer_iterator&&)            = default;
+            _Outer_iterator(_Outer_iterator&&) noexcept            = default;
             _Outer_iterator& operator=(_Outer_iterator&&) = default;
 
             _NODISCARD constexpr value_type operator*() const noexcept /* strengthened */ {

--- a/stl/inc/scoped_allocator
+++ b/stl/inc/scoped_allocator
@@ -80,10 +80,10 @@ struct _Scoped_base<_Outer, _Inner0, _Inner...> : _Outer { // nest of allocators
         // also handles rebinding
     }
 
-    _Scoped_base(const _Scoped_base&)            = default;
-    _Scoped_base(_Scoped_base&&)                 = default;
-    _Scoped_base& operator=(const _Scoped_base&) = default;
-    _Scoped_base& operator=(_Scoped_base&&)      = default;
+    _Scoped_base(const _Scoped_base&)                = default;
+    _Scoped_base(_Scoped_base&&) noexcept            = default;
+    _Scoped_base& operator=(const _Scoped_base&)     = default;
+    _Scoped_base& operator=(_Scoped_base&&) = default;
 
     _NODISCARD _Myadaptor select_on_container_copy_construction() const { // make new adaptor
         return _Myadaptor(_Secret_scoped_allocator_construct_tag{},
@@ -110,10 +110,10 @@ struct _Scoped_base<_Outer> : _Outer { // nest of allocators, one deep
     template <class _Other1, enable_if_t<!is_base_of_v<_Scoped_base, decay_t<_Other1>>, int> = 0>
     _Scoped_base(_Other1&& _Outer_arg) : _Outer(_STD forward<_Other1>(_Outer_arg)) {} // also handles rebinding
 
-    _Scoped_base(const _Scoped_base&)            = default;
-    _Scoped_base(_Scoped_base&&)                 = default;
-    _Scoped_base& operator=(const _Scoped_base&) = default;
-    _Scoped_base& operator=(_Scoped_base&&)      = default;
+    _Scoped_base(const _Scoped_base&)                = default;
+    _Scoped_base(_Scoped_base&&) noexcept            = default;
+    _Scoped_base& operator=(const _Scoped_base&)     = default;
+    _Scoped_base& operator=(_Scoped_base&&) = default;
 
     _NODISCARD _Myadaptor select_on_container_copy_construction() const { // make new adaptor
         return _Myadaptor(
@@ -187,8 +187,8 @@ public:
         const inner_allocator_type& _Inner_arg) noexcept
         : _Mybase(_Outer_arg, _Inner_arg) {}
 
-    scoped_allocator_adaptor& operator=(const scoped_allocator_adaptor&) = default;
-    scoped_allocator_adaptor& operator=(scoped_allocator_adaptor&&)      = default;
+    scoped_allocator_adaptor& operator=(const scoped_allocator_adaptor&)     = default;
+    scoped_allocator_adaptor& operator=(scoped_allocator_adaptor&&) = default;
 
     _NODISCARD inner_allocator_type& inner_allocator() noexcept { // get reference to inner allocator
         return this->_Get_inner_object(*this);

--- a/stl/inc/shared_mutex
+++ b/stl/inc/shared_mutex
@@ -225,7 +225,7 @@ class shared_lock { // shareable lock
 public:
     using mutex_type = _Mutex;
 
-    shared_lock() noexcept = default;
+    shared_lock() = default;
 
     _NODISCARD_CTOR_LOCK explicit shared_lock(mutex_type& _Mtx)
         : _Pmtx(_STD addressof(_Mtx)), _Owns(true) { // construct with mutex and lock shared

--- a/stl/inc/source_location
+++ b/stl/inc/source_location
@@ -39,7 +39,7 @@ _EXPORT_STD struct source_location {
         return _Result;
     }
 
-    _NODISCARD_CTOR constexpr source_location() noexcept = default;
+    _NODISCARD_CTOR constexpr source_location() = default;
 
     _NODISCARD constexpr uint_least32_t line() const noexcept {
         return _Line;

--- a/stl/inc/span
+++ b/stl/inc/span
@@ -201,7 +201,7 @@ template <class _Ty, size_t _Extent>
 struct _Span_extent_type {
     using pointer = _Ty*;
 
-    constexpr _Span_extent_type() noexcept = default;
+    constexpr _Span_extent_type() = default;
 
     constexpr explicit _Span_extent_type(const pointer _Data, size_t) noexcept : _Mydata{_Data} {}
 
@@ -213,7 +213,7 @@ template <class _Ty>
 struct _Span_extent_type<_Ty, dynamic_extent> {
     using pointer = _Ty*;
 
-    constexpr _Span_extent_type() noexcept = default;
+    constexpr _Span_extent_type() = default;
 
     constexpr explicit _Span_extent_type(const pointer _Data, const size_t _Size) noexcept
         : _Mydata{_Data}, _Mysize{_Size} {}

--- a/stl/inc/sstream
+++ b/stl/inc/sstream
@@ -67,12 +67,12 @@ public:
         const basic_string<_Elem, _Traits, _Alloc2>& _Str, ios_base::openmode _Mode = ios_base::in | ios_base::out)
         : basic_stringbuf(_Str, _Mode, _Alloc{}) {}
 
-    basic_stringbuf(basic_stringbuf&& _Right, const _Alloc& _Al_) : _Al(_Al_) {
+    basic_stringbuf(basic_stringbuf&& _Right, const _Alloc& _Al_) : _Mystate(0), _Al(_Al_) {
         _Assign_rv(_STD move(_Right));
     }
 #endif // _HAS_CXX20
 
-    basic_stringbuf(basic_stringbuf&& _Right) {
+    basic_stringbuf(basic_stringbuf&& _Right) : _Mystate(0) {
         _Assign_rv(_STD move(_Right));
     }
 
@@ -269,7 +269,7 @@ protected:
 
         _Mysb::setp(_Newptr, _New_pnext, _Newptr + _Newsize);
         if (_Mystate & _Noread) { // maintain eback() == allocated pointer invariant
-            _Mysb::setg(_Newptr, nullptr, _Newptr);
+            _Mysb::setg(_Newptr, _Newptr, _Newptr);
         } else { // if readable, set the get area to initialized region
             _Mysb::setg(_Newptr, _Newptr + (_Mysb::gptr() - _Oldptr), _Seekhigh);
         }
@@ -328,6 +328,12 @@ protected:
 
     pos_type seekoff(
         off_type _Off, ios_base::seekdir _Way, ios_base::openmode _Mode = ios_base::in | ios_base::out) override {
+        const bool _Need_read_but_cannot  = (_Mode & ios_base::in) != 0 && (_Mystate & _Noread) != 0;
+        const bool _Need_write_but_cannot = (_Mode & ios_base::out) != 0 && (_Mystate & _Constant) != 0;
+        if (_Need_read_but_cannot || _Need_write_but_cannot) {
+            return pos_type{off_type{-1}};
+        }
+
         // change position by _Off, according to _Way, _Mode
         const auto _Gptr_old = _Mysb::gptr();
         const auto _Pptr_old = (_Mystate & _Constant) ? nullptr : _Mysb::pptr();
@@ -388,6 +394,12 @@ protected:
     }
 
     pos_type seekpos(pos_type _Pos, ios_base::openmode _Mode = ios_base::in | ios_base::out) override {
+        const bool _Need_read_but_cannot  = (_Mode & ios_base::in) != 0 && (_Mystate & _Noread) != 0;
+        const bool _Need_write_but_cannot = (_Mode & ios_base::out) != 0 && (_Mystate & _Constant) != 0;
+        if (_Need_read_but_cannot || _Need_write_but_cannot) {
+            return pos_type{off_type{-1}};
+        }
+
         // change position to _Pos, according to _Mode
         const auto _Off      = static_cast<streamoff>(_Pos);
         const auto _Gptr_old = _Mysb::gptr();
@@ -440,7 +452,7 @@ protected:
                 _Mysb::setp(_Pnew, (_State & (_Atend | _Append)) ? _Seekhigh : _Pnew, _Seekhigh);
 
                 if (_State & _Noread) { // maintain "_Allocated == eback() points to buffer base" invariant
-                    _Mysb::setg(_Pnew, nullptr, _Pnew);
+                    _Mysb::setg(_Pnew, _Pnew, _Pnew);
                 }
             }
 
@@ -469,7 +481,7 @@ protected:
 
         _Mysb::setp(_Pnew, _Next, _End_buffer);
         if (_State & _Noread) { // maintain "_Allocated == eback() points to buffer base" invariant
-            _Mysb::setg(_Pnew, nullptr, _Pnew);
+            _Mysb::setg(_Pnew, _Pnew, _Pnew);
         } else {
             _Mysb::setg(_Pnew, _Pnew, _Seekhigh);
         }

--- a/stl/inc/stacktrace
+++ b/stl/inc/stacktrace
@@ -79,7 +79,7 @@ public:
 
     constexpr stacktrace_entry() noexcept                                   = default;
     constexpr stacktrace_entry(const stacktrace_entry&) noexcept            = default;
-    constexpr stacktrace_entry& operator=(const stacktrace_entry&) noexcept = default;
+    constexpr stacktrace_entry& operator=(const stacktrace_entry&) = default;
 
     ~stacktrace_entry() = default;
 
@@ -107,10 +107,10 @@ public:
         return __std_stacktrace_source_line(_Address);
     }
 
-    _NODISCARD_FRIEND constexpr bool operator==(const stacktrace_entry&, const stacktrace_entry&) noexcept = default;
+    _NODISCARD_FRIEND constexpr bool operator==(const stacktrace_entry&, const stacktrace_entry&) = default;
 
     _NODISCARD_FRIEND constexpr strong_ordering operator<=>(
-        const stacktrace_entry&, const stacktrace_entry&) noexcept = default;
+        const stacktrace_entry&, const stacktrace_entry&) = default;
 
 private:
     void* _Address = nullptr;
@@ -184,7 +184,7 @@ public:
     explicit basic_stacktrace(const allocator_type& _Al) noexcept : _Frames(_Al) {}
 
     basic_stacktrace(const basic_stacktrace&)     = default;
-    basic_stacktrace(basic_stacktrace&&) noexcept = default;
+    basic_stacktrace(basic_stacktrace&&) = default;
     basic_stacktrace(const basic_stacktrace& _Other, const allocator_type& _Al)
         : _Frames(_Other._Frames, _Al), _Hash(_Other._Hash) {}
 
@@ -306,7 +306,7 @@ private:
                                     || allocator_traits<_Alloc>::is_always_equal::value;
 
     struct _Internal_t {
-        explicit _Internal_t() noexcept = default;
+        explicit _Internal_t() = default;
     };
 
     basic_stacktrace(_Internal_t, size_type _Max_depth, const allocator_type& _Al) : _Frames(_Max_depth, _Al) {}

--- a/stl/inc/stop_token
+++ b/stl/inc/stop_token
@@ -163,7 +163,7 @@ public:
         return _Local != nullptr && _Local->_Stop_possible();
     }
 
-    _NODISCARD_FRIEND bool operator==(const stop_token& _Lhs, const stop_token& _Rhs) noexcept = default;
+    _NODISCARD_FRIEND bool operator==(const stop_token& _Lhs, const stop_token& _Rhs) = default;
 
     friend void swap(stop_token& _Lhs, stop_token& _Rhs) noexcept {
         _STD swap(_Lhs._State, _Rhs._State);
@@ -235,7 +235,7 @@ public:
         return _Local && _Local->_Request_stop();
     }
 
-    _NODISCARD_FRIEND bool operator==(const stop_source& _Lhs, const stop_source& _Rhs) noexcept = default;
+    _NODISCARD_FRIEND bool operator==(const stop_source& _Lhs, const stop_source& _Rhs) = default;
 
     friend void swap(stop_source& _Lhs, stop_source& _Rhs) noexcept {
         _STD swap(_Lhs._State, _Rhs._State);

--- a/stl/inc/system_error
+++ b/stl/inc/system_error
@@ -79,7 +79,7 @@ public:
 #pragma warning(pop)
 #endif // ^^^ !defined(_M_CEE_PURE) ^^^
 
-    _CONSTEXPR20 virtual ~error_category() noexcept = default;
+    _CONSTEXPR20 virtual ~error_category() = default;
 
     _NODISCARD virtual const char* name() const noexcept = 0;
 

--- a/stl/inc/thread
+++ b/stl/inc/thread
@@ -210,7 +210,7 @@ namespace this_thread {
 
 class thread::id { // thread id
 public:
-    id() noexcept = default; // id for no thread
+    id() = default; // id for no thread
 
 private:
     explicit id(_Thrd_id_t _Other_id) noexcept : _Id(_Other_id) {}

--- a/stl/inc/tuple
+++ b/stl/inc/tuple
@@ -219,7 +219,7 @@ using _Three_way_comparison_result_with_tuple_like_t =
 template <>
 class tuple<> { // empty tuple
 public:
-    constexpr tuple() noexcept = default; /* strengthened */
+    constexpr tuple() = default; /* strengthened */
 
     constexpr tuple(const tuple&) noexcept /* strengthened */ {} // TRANSITION, ABI: should be defaulted
 

--- a/stl/inc/unordered_set
+++ b/stl/inc/unordered_set
@@ -244,7 +244,7 @@ public:
         return *this;
     }
 
-    unordered_set(unordered_set&& _Right) : _Mybase(_STD move(_Right)) {}
+    unordered_set(unordered_set&& _Right) noexcept : _Mybase(_STD move(_Right)) {}
 
     unordered_set(unordered_set&& _Right, const allocator_type& _Al) : _Mybase(_STD move(_Right), _Al) {}
 
@@ -528,7 +528,7 @@ public:
         return *this;
     }
 
-    unordered_multiset(unordered_multiset&& _Right) : _Mybase(_STD move(_Right)) {}
+    unordered_multiset(unordered_multiset&& _Right) noexcept : _Mybase(_STD move(_Right)) {}
 
     unordered_multiset(unordered_multiset&& _Right, const allocator_type& _Al) : _Mybase(_STD move(_Right), _Al) {}
 

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -247,8 +247,8 @@ struct pair { // store a pair of values
         : first(_STD forward<_Other1>(_Val1)), second(_STD forward<_Other2>(_Val2)) {
     }
 
-    pair(const pair&) = default;
-    pair(pair&&)      = default;
+    pair(const pair&)     = default;
+    pair(pair&&) = default;
 
 #if _HAS_CXX23
     template <class _Other1, class _Other2,

--- a/stl/inc/variant
+++ b/stl/inc/variant
@@ -433,10 +433,10 @@ public:
         is_nothrow_constructible_v<_Variant_storage<_Rest...>, integral_constant<size_t, _Idx - 1>, _Types...>)
         : _Tail(integral_constant<size_t, _Idx - 1>{}, static_cast<_Types&&>(_Args)...) {} // initialize _Tail (recurse)
 
-    _Variant_storage_(_Variant_storage_&&)                 = default;
-    _Variant_storage_(const _Variant_storage_&)            = default;
-    _Variant_storage_& operator=(_Variant_storage_&&)      = default;
-    _Variant_storage_& operator=(const _Variant_storage_&) = default;
+    _Variant_storage_(_Variant_storage_&&) noexcept            = default;
+    _Variant_storage_(const _Variant_storage_&)                = default;
+    _Variant_storage_& operator=(_Variant_storage_&&) = default;
+    _Variant_storage_& operator=(const _Variant_storage_&)     = default;
 
     _NODISCARD constexpr _First& _Get() & noexcept {
         return _Head;
@@ -874,11 +874,11 @@ struct _Variant_destroy_layer_ : _Variant_base<_Types...> { // destruction behav
         this->_Destroy();
     }
 
-    _Variant_destroy_layer_()                                          = default;
-    _Variant_destroy_layer_(const _Variant_destroy_layer_&)            = default;
-    _Variant_destroy_layer_(_Variant_destroy_layer_&&)                 = default;
-    _Variant_destroy_layer_& operator=(const _Variant_destroy_layer_&) = default;
-    _Variant_destroy_layer_& operator=(_Variant_destroy_layer_&&)      = default;
+    _Variant_destroy_layer_()                                              = default;
+    _Variant_destroy_layer_(const _Variant_destroy_layer_&)                = default;
+    _Variant_destroy_layer_(_Variant_destroy_layer_&&) noexcept            = default;
+    _Variant_destroy_layer_& operator=(const _Variant_destroy_layer_&)     = default;
+    _Variant_destroy_layer_& operator=(_Variant_destroy_layer_&&) = default;
 };
 
 template <class... _Types>

--- a/stl/inc/xhash
+++ b/stl/inc/xhash
@@ -394,7 +394,7 @@ protected:
 #endif // _ENABLE_STL_INTERNAL_CHECK
     }
 
-    _Hash(_Hash&& _Right)
+    _Hash(_Hash&& _Right) noexcept
         : _Traitsobj(_Right._Traitsobj), _List(_Move_allocator_tag{}, _Right._List._Getal()),
           _Vec(_STD move(_Right._Vec._Mypair._Get_first())) {
         _Vec._Assign_grow(_Min_buckets * 2, _Unchecked_end());
@@ -501,7 +501,7 @@ private:
 #endif // _ENABLE_STL_INTERNAL_CHECK
 
 public:
-    _Hash& operator=(_Hash&& _Right) { // assign by moving _Right
+    _Hash& operator=(_Hash&& _Right) noexcept { // assign by moving _Right
         if (this == _STD addressof(_Right)) {
             return *this;
         }

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -946,7 +946,7 @@ public:
 
     constexpr allocator() noexcept {}
 
-    constexpr allocator(const allocator&) noexcept = default;
+    constexpr allocator(const allocator&) = default;
     template <class _Other>
     constexpr allocator(const allocator<_Other>&) noexcept {}
     _CONSTEXPR20 ~allocator()                           = default;
@@ -1171,7 +1171,7 @@ struct _Iterator_base0 {
 
 struct _Container_base12;
 struct _Container_proxy { // store head of iterator chain and back pointer
-    _CONSTEXPR20 _Container_proxy() noexcept = default;
+    _CONSTEXPR20 _Container_proxy() = default;
     _CONSTEXPR20 _Container_proxy(_Container_base12* _Mycont_) noexcept : _Mycont(_Mycont_) {}
 
     const _Container_base12* _Mycont       = nullptr;
@@ -1180,7 +1180,7 @@ struct _Container_proxy { // store head of iterator chain and back pointer
 
 struct _Container_base12 {
 public:
-    _CONSTEXPR20 _Container_base12() noexcept = default;
+    _CONSTEXPR20 _Container_base12() = default;
 
     _Container_base12(const _Container_base12&)            = delete;
     _Container_base12& operator=(const _Container_base12&) = delete;
@@ -1224,7 +1224,7 @@ private:
 
 struct _Iterator_base12 { // store links to container proxy, next iterator
 public:
-    _CONSTEXPR20 _Iterator_base12() noexcept = default; // construct orphaned iterator
+    _CONSTEXPR20 _Iterator_base12() = default; // construct orphaned iterator
 
     _CONSTEXPR20 _Iterator_base12(const _Iterator_base12& _Right) noexcept {
         *this = _Right;

--- a/stl/inc/xpolymorphic_allocator.h
+++ b/stl/inc/xpolymorphic_allocator.h
@@ -129,7 +129,7 @@ void _Uses_alloc_construct_pair(_CvPair* const _Ptr, _Outer_alloc& _Outer, _Inne
 namespace pmr {
     _EXPORT_STD class __declspec(novtable) memory_resource {
     public:
-        virtual ~memory_resource() noexcept = default;
+        virtual ~memory_resource() = default;
 
         _NODISCARD_RAW_PTR_ALLOC __declspec(allocator) void* allocate(_CRT_GUARDOVERFLOW const size_t _Bytes,
             const size_t _Align = alignof(max_align_t)) { // allocate _Bytes bytes of memory with alignment _Align
@@ -206,7 +206,7 @@ namespace pmr {
 
         using value_type = _Ty;
 
-        polymorphic_allocator() noexcept = default;
+        polymorphic_allocator() = default;
 
         /* implicit */ polymorphic_allocator(memory_resource* const _Resource_) noexcept // strengthened
             : _Resource{_Resource_} { // initialize with _Resource_

--- a/stl/inc/xsmf_control.h
+++ b/stl/inc/xsmf_control.h
@@ -29,9 +29,9 @@ struct _Non_trivial_copy : _Base { // non-trivial copy construction facade
         noexcept(_Base::_Construct_from(static_cast<const _Base&>(_That)))) {
         _Base::_Construct_from(static_cast<const _Base&>(_That));
     }
-    _Non_trivial_copy(_Non_trivial_copy&&)                 = default;
-    _Non_trivial_copy& operator=(const _Non_trivial_copy&) = default;
-    _Non_trivial_copy& operator=(_Non_trivial_copy&&)      = default;
+    _Non_trivial_copy(_Non_trivial_copy&&) noexcept            = default;
+    _Non_trivial_copy& operator=(const _Non_trivial_copy&)     = default;
+    _Non_trivial_copy& operator=(_Non_trivial_copy&&) = default;
 };
 
 template <class _Base, class... _Types>
@@ -50,8 +50,8 @@ struct _Non_trivial_move : _SMF_control_copy<_Base, _Types...> { // non-trivial 
         noexcept(_Mybase::_Construct_from(static_cast<_Base&&>(_That)))) {
         _Mybase::_Construct_from(static_cast<_Base&&>(_That));
     }
-    _Non_trivial_move& operator=(const _Non_trivial_move&) = default;
-    _Non_trivial_move& operator=(_Non_trivial_move&&)      = default;
+    _Non_trivial_move& operator=(const _Non_trivial_move&)     = default;
+    _Non_trivial_move& operator=(_Non_trivial_move&&) = default;
 };
 
 template <class _Base, class... _Types>
@@ -64,9 +64,9 @@ struct _Non_trivial_copy_assign : _SMF_control_move<_Base, _Types...> { // non-t
     using _Mybase = _SMF_control_move<_Base, _Types...>;
     using _Mybase::_Mybase;
 
-    _Non_trivial_copy_assign()                                = default;
-    _Non_trivial_copy_assign(const _Non_trivial_copy_assign&) = default;
-    _Non_trivial_copy_assign(_Non_trivial_copy_assign&&)      = default;
+    _Non_trivial_copy_assign()                                    = default;
+    _Non_trivial_copy_assign(const _Non_trivial_copy_assign&)     = default;
+    _Non_trivial_copy_assign(_Non_trivial_copy_assign&&) = default;
 
     _CONSTEXPR20 _Non_trivial_copy_assign& operator=(const _Non_trivial_copy_assign& _That) noexcept(
         noexcept(_Mybase::_Assign_from(static_cast<const _Base&>(_That)))) {
@@ -81,11 +81,11 @@ struct _Deleted_copy_assign : _SMF_control_move<_Base, _Types...> { // deleted c
     using _Mybase = _SMF_control_move<_Base, _Types...>;
     using _Mybase::_Mybase;
 
-    _Deleted_copy_assign()                                       = default;
-    _Deleted_copy_assign(const _Deleted_copy_assign&)            = default;
-    _Deleted_copy_assign(_Deleted_copy_assign&&)                 = default;
-    _Deleted_copy_assign& operator=(const _Deleted_copy_assign&) = delete;
-    _Deleted_copy_assign& operator=(_Deleted_copy_assign&&)      = default;
+    _Deleted_copy_assign()                                           = default;
+    _Deleted_copy_assign(const _Deleted_copy_assign&)                = default;
+    _Deleted_copy_assign(_Deleted_copy_assign&&) noexcept            = default;
+    _Deleted_copy_assign& operator=(const _Deleted_copy_assign&)     = delete;
+    _Deleted_copy_assign& operator=(_Deleted_copy_assign&&) = default;
 };
 
 template <class _Base, class... _Types>
@@ -103,7 +103,7 @@ struct _Non_trivial_move_assign : _SMF_control_copy_assign<_Base, _Types...> { /
 
     _Non_trivial_move_assign()                                           = default;
     _Non_trivial_move_assign(const _Non_trivial_move_assign&)            = default;
-    _Non_trivial_move_assign(_Non_trivial_move_assign&&)                 = default;
+    _Non_trivial_move_assign(_Non_trivial_move_assign&&) noexcept        = default;
     _Non_trivial_move_assign& operator=(const _Non_trivial_move_assign&) = default;
 
     _CONSTEXPR20 _Non_trivial_move_assign& operator=(_Non_trivial_move_assign&& _That) noexcept(
@@ -120,7 +120,7 @@ struct _Deleted_move_assign : _SMF_control_copy_assign<_Base, _Types...> { // de
 
     _Deleted_move_assign()                                       = default;
     _Deleted_move_assign(const _Deleted_move_assign&)            = default;
-    _Deleted_move_assign(_Deleted_move_assign&&)                 = default;
+    _Deleted_move_assign(_Deleted_move_assign&&) noexcept        = default;
     _Deleted_move_assign& operator=(const _Deleted_move_assign&) = default;
     _Deleted_move_assign& operator=(_Deleted_move_assign&&)      = delete;
 };

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -942,7 +942,7 @@ public:
     using pointer           = const value_type*;
     using reference         = const value_type&;
 
-    constexpr _String_view_iterator() noexcept = default;
+    constexpr _String_view_iterator() = default;
 
 private:
     friend basic_string_view<value_type, _Traits>;
@@ -1227,7 +1227,7 @@ public:
     constexpr basic_string_view() noexcept : _Mydata(), _Mysize(0) {}
 
     constexpr basic_string_view(const basic_string_view&) noexcept            = default;
-    constexpr basic_string_view& operator=(const basic_string_view&) noexcept = default;
+    constexpr basic_string_view& operator=(const basic_string_view&) = default;
 
     /* implicit */ constexpr basic_string_view(_In_z_ const const_pointer _Ntcts) noexcept // strengthened
         : _Mydata(_Ntcts), _Mysize(_Traits::length(_Ntcts)) {}

--- a/stl/inc/xtree
+++ b/stl/inc/xtree
@@ -901,7 +901,7 @@ public:
         _Proxy._Release();
     }
 
-    _Tree(_Tree&& _Right)
+    _Tree(_Tree&& _Right) noexcept
         : _Mypair(_One_then_variadic_args_t{}, _Right.key_comp(), // intentionally copy comparator, see LWG-2227
             _One_then_variadic_args_t{}, _STD move(_Right._Getal())) {
         _Alloc_sentinel_and_proxy();


### PR DESCRIPTION
By ensuring we strength each move constructor with noexcept as we can, we can avoid needless exception checking and handling.

<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
