### PR TITLE
`_Weakly_unwrappable` should use `_Allow_inheriting_unwrap_v`

### DIFF
--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -2287,9 +2287,8 @@ namespace ranges {
     using sentinel_t = decltype(_RANGES end(_STD declval<_Rng&>()));
 
     template <class _Wrapped>
-    concept _Weakly_unwrappable =
-        same_as<typename remove_cvref_t<_Wrapped>::_Prevent_inheriting_unwrap, remove_cvref_t<_Wrapped>>
-        && requires(_Wrapped&& _Wr) { _STD forward<_Wrapped>(_Wr)._Unwrapped(); };
+    concept _Weakly_unwrappable = _Allow_inheriting_unwrap_v<remove_cvref_t<_Wrapped>>
+                               && requires(_Wrapped&& _Wr) { _STD forward<_Wrapped>(_Wr)._Unwrapped(); };
 
     template <class _Sent>
     concept _Weakly_unwrappable_sentinel = _Weakly_unwrappable<const remove_reference_t<_Sent>&>;


### PR DESCRIPTION
... so as not to require `_Prevent_inheriting_unwrap`; the intent of the unwrapping design is that `_Prevent_inheriting_unwrap` is optional.

I'm willing to be convinced that `_Prevent_inheriting_unwrap` should be made mandatory, in which case we should still accept this change and also make changes to `_Allow_inheriting_unwrap_v` to maintain consistency between Ranges and non-Ranges unwrapping machinery.