### PR TITLE
Mark constructors that do not throw exceptions as noexcept

### DIFF
--- a/stl/inc/expected
+++ b/stl/inc/expected
@@ -233,7 +233,7 @@ public:
     }
 
     // clang-format off
-    expected(expected&&) requires
+    expected(expected&&) noexcept requires
         is_trivially_move_constructible_v<_Ty> && is_trivially_move_constructible_v<_Err> = default;
     // clang-format on
 
@@ -1185,7 +1185,7 @@ public:
     }
 
     // clang-format off
-    expected(expected&&) requires is_trivially_move_constructible_v<_Err> = default;
+    expected(expected&&) noexcept requires is_trivially_move_constructible_v<_Err> = default;
     // clang-format on
 
     template <class _Uty, class _UErr>

--- a/stl/inc/hash_map
+++ b/stl/inc/hash_map
@@ -170,7 +170,7 @@ namespace stdext {
             return *this;
         }
 
-        hash_map(hash_map&& _Right) : _Mybase(_STD move(_Right)) {}
+        hash_map(hash_map&& _Right) noexcept : _Mybase(_STD move(_Right)) {}
 
         hash_map(hash_map&& _Right, const allocator_type& _Al) : _Mybase(_STD move(_Right), _Al) {}
 
@@ -356,7 +356,7 @@ namespace stdext {
             return *this;
         }
 
-        hash_multimap(hash_multimap&& _Right) : _Mybase(_STD move(_Right)) {}
+        hash_multimap(hash_multimap&& _Right) noexcept : _Mybase(_STD move(_Right)) {}
 
         hash_multimap(hash_multimap&& _Right, const allocator_type& _Al) : _Mybase(_STD move(_Right), _Al) {}
 

--- a/stl/inc/iterator
+++ b/stl/inc/iterator
@@ -616,7 +616,7 @@ public:
     }
 
     // clang-format off
-    constexpr _Variantish(_Variantish&&) requires is_trivially_move_constructible_v<_Ty1>
+    constexpr _Variantish(_Variantish&&) noexcept requires is_trivially_move_constructible_v<_Ty1>
         && is_trivially_move_constructible_v<_Ty2> = default;
     // clang-format on
 
@@ -687,7 +687,7 @@ public:
     }
 
     // clang-format off
-    constexpr _Variantish& operator=(_Variantish&&) requires is_trivially_destructible_v<_Ty1>
+    constexpr _Variantish& operator=(_Variantish&&) noexcept requires is_trivially_destructible_v<_Ty1>
         && is_trivially_destructible_v<_Ty2>
         && is_trivially_move_constructible_v<_Ty1>
         && is_trivially_move_constructible_v<_Ty2>

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -298,7 +298,7 @@ namespace ranges {
         _Movable_box(_Movable_box&&) requires is_trivially_move_constructible_v<_Ty> = default;
         // clang-format on
 
-        constexpr _Movable_box(_Movable_box&& _That) : _Engaged{_That._Engaged} {
+        constexpr _Movable_box(_Movable_box&& _That) noexcept : _Engaged{_That._Engaged} {
             if (_That._Engaged) {
                 _Construct_in_place(_Val, _STD move(_That._Val));
             }
@@ -515,7 +515,7 @@ namespace ranges {
         _Defaultabox(_Defaultabox&&) requires is_trivially_move_constructible_v<_Ty> = default;
         // clang-format on
 
-        constexpr _Defaultabox(_Defaultabox&& _That) : _Engaged{_That._Engaged} {
+        constexpr _Defaultabox(_Defaultabox&& _That) noexcept : _Engaged{_That._Engaged} {
             if (_That._Engaged) {
                 _Construct_in_place(_Val, _STD move(_That._Val));
             }

--- a/stl/inc/sstream
+++ b/stl/inc/sstream
@@ -72,7 +72,7 @@ public:
     }
 #endif // _HAS_CXX20
 
-    basic_stringbuf(basic_stringbuf&& _Right) : _Mystate(0) {
+    basic_stringbuf(basic_stringbuf&& _Right) noexcept : _Mystate(0) {
         _Assign_rv(_STD move(_Right));
     }
 
@@ -584,7 +584,7 @@ public:
         : _Mybase(_STD addressof(_Stringbuffer)), _Stringbuffer(_Str, _Mode | ios_base::in) {}
 #endif // _HAS_CXX20
 
-    basic_istringstream(basic_istringstream&& _Right) : _Mybase(_STD addressof(_Stringbuffer)) {
+    basic_istringstream(basic_istringstream&& _Right) noexcept : _Mybase(_STD addressof(_Stringbuffer)) {
         _Assign_rv(_STD move(_Right));
     }
 
@@ -704,7 +704,7 @@ public:
         : _Mybase(_STD addressof(_Stringbuffer)), _Stringbuffer(_Str, _Mode | ios_base::out) {}
 #endif // _HAS_CXX20
 
-    basic_ostringstream(basic_ostringstream&& _Right) : _Mybase(_STD addressof(_Stringbuffer)) {
+    basic_ostringstream(basic_ostringstream&& _Right) noexcept : _Mybase(_STD addressof(_Stringbuffer)) {
         _Assign_rv(_STD move(_Right));
     }
 
@@ -830,7 +830,7 @@ public:
         : _Mybase(_STD addressof(_Stringbuffer)), _Stringbuffer(_Str, _Mode) {}
 #endif // _HAS_CXX20
 
-    basic_stringstream(basic_stringstream&& _Right) : _Mybase(_STD addressof(_Stringbuffer)) {
+    basic_stringstream(basic_stringstream&& _Right) noexcept : _Mybase(_STD addressof(_Stringbuffer)) {
         _Assign_rv(_STD move(_Right));
     }
 


### PR DESCRIPTION
By ensuring we strength each move constructor with noexcept as we can, we can avoid needless exception checking and handling.

Had to open a new PR because GitHub wouldn't let me reopen the last one because it turns out editing commit history when the PR is closed is not good.