### PR TITLE
Prefer fill_n over fill where applicable

### DIFF
--- a/stl/inc/deque
+++ b/stl/inc/deque
@@ -1488,7 +1488,7 @@ private:
                 }
 
                 _Mid = begin() + static_cast<difference_type>(_Count);
-                _STD fill(_Mid, _Mid + static_cast<difference_type>(_Off), _Val); // fill in rest of values
+                _STD fill_n(_Mid, _Off, _Val); // fill in rest of values
             } else { // insert not longer than prefix
                 for (_Num = _Count; _Num > 0; --_Num) {
                     push_front(begin()[static_cast<difference_type>(_Count - 1)]); // push part of prefix
@@ -1514,7 +1514,7 @@ private:
                 }
 
                 _Mid = begin() + static_cast<difference_type>(_Off);
-                _STD fill(_Mid, _Mid + static_cast<difference_type>(_Rem), _Val); // fill in rest of values
+                _STD fill_n(_Mid, _Rem, _Val); // fill in rest of values
             } else { // insert not longer than prefix
                 for (_Num = 0; _Num < _Count; ++_Num) {
                     _Emplace_back_internal(
@@ -1525,8 +1525,7 @@ private:
                 _Alloc_temporary2<_Alty> _Tmp(_Getal(), _Val); // in case _Val is in sequence
                 _STD move_backward(_Mid, _Mid + static_cast<difference_type>(_Rem - _Count),
                     _Mid + static_cast<difference_type>(_Rem)); // copy rest of prefix
-                _STD fill(_Mid, _Mid + static_cast<difference_type>(_Count),
-                    _Tmp._Get_value()); // fill in values
+                _STD fill_n(_Mid, _Count, _Tmp._Get_value()); // fill in values
             }
             _Guard._Container = nullptr;
         }

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -1076,7 +1076,7 @@ public:
             } else { // new stuff can all be assigned
                 _Mylast = _Uninitialized_move(_Oldlast - _Count, _Oldlast, _Oldlast, _Al);
                 _Move_backward_unchecked(_Whereptr, _Oldlast - _Count, _Oldlast);
-                _STD fill(_Whereptr, _Whereptr + _Count, _Tmp);
+                _STD fill_n(_Whereptr, _Count, _Tmp);
             }
             _ASAN_VECTOR_RELEASE_GUARD;
         }
@@ -3458,7 +3458,7 @@ public:
     _CONSTEXPR20 iterator _Insert_n(const_iterator _Where, size_type _Count, const bool& _Val) {
         size_type _Off     = _Insert_x(_Where, _Count);
         const auto _Result = begin() + static_cast<difference_type>(_Off);
-        _STD fill(_Result, _Result + static_cast<difference_type>(_Count), _Val);
+        _STD fill_n(_Result, _Count, _Val);
         return _Result;
     }
 


### PR DESCRIPTION
We can avoid doing the addition ourselves when we do this.