### PR TITLE
`<chrono>`: Optimize `to_sys` and `to_local`

### DIFF
--- a/stl/inc/__msvc_tzdb.hpp
+++ b/stl/inc/__msvc_tzdb.hpp
@@ -67,7 +67,11 @@ struct __std_tzdb_sys_info {
 };
 
 enum class __std_tzdb_sys_info_type : char {
-    _Full,
+    // TRANSITION, ABI: In order to be compatible with existing object files which do not know about
+    // `__std_tzdb_sys_info_type`, the type is passed in the after-end byte of a string passed with its length to
+    // `__std_tzdb_get_sys_info`. Since older object files always pass the `.c_str()` of a `std::string`
+    // to that function, the after-end byte will always be '\0'.
+    _Full = '\0',
     _Offset_only,
     _Offset_and_range,
 };

--- a/stl/inc/__msvc_tzdb.hpp
+++ b/stl/inc/__msvc_tzdb.hpp
@@ -66,7 +66,7 @@ struct __std_tzdb_sys_info {
     const char* _Abbrev;
 };
 
-enum class __std_tzdb_sys_info_type {
+enum class __std_tzdb_sys_info_type : char {
     _Full,
     _Offset_only,
     _Offset_and_range,

--- a/stl/inc/__msvc_tzdb.hpp
+++ b/stl/inc/__msvc_tzdb.hpp
@@ -66,14 +66,20 @@ struct __std_tzdb_sys_info {
     const char* _Abbrev;
 };
 
+enum class __std_tzdb_sys_info_type {
+    _Full,
+    _Offset_only,
+    _Offset_and_range,
+};
+
 _NODISCARD __std_tzdb_time_zones_info* __stdcall __std_tzdb_get_time_zones() noexcept;
 void __stdcall __std_tzdb_delete_time_zones(__std_tzdb_time_zones_info* _Info) noexcept;
 
 _NODISCARD __std_tzdb_current_zone_info* __stdcall __std_tzdb_get_current_zone() noexcept;
 void __stdcall __std_tzdb_delete_current_zone(__std_tzdb_current_zone_info* _Info) noexcept;
 
-_NODISCARD __std_tzdb_sys_info* __stdcall __std_tzdb_get_sys_info(
-    const char* _Tz, size_t _Tz_len, __std_tzdb_epoch_milli _Local) noexcept;
+_NODISCARD __std_tzdb_sys_info* __stdcall __std_tzdb_get_sys_info_v2(
+    const char* _Tz, size_t _Tz_len, __std_tzdb_epoch_milli _Local, __std_tzdb_sys_info_type _Type) noexcept;
 void __stdcall __std_tzdb_delete_sys_info(__std_tzdb_sys_info* _Info) noexcept;
 
 _NODISCARD __std_tzdb_leap_info* __stdcall __std_tzdb_get_leap_seconds(

--- a/stl/inc/__msvc_tzdb.hpp
+++ b/stl/inc/__msvc_tzdb.hpp
@@ -78,8 +78,8 @@ void __stdcall __std_tzdb_delete_time_zones(__std_tzdb_time_zones_info* _Info) n
 _NODISCARD __std_tzdb_current_zone_info* __stdcall __std_tzdb_get_current_zone() noexcept;
 void __stdcall __std_tzdb_delete_current_zone(__std_tzdb_current_zone_info* _Info) noexcept;
 
-_NODISCARD __std_tzdb_sys_info* __stdcall __std_tzdb_get_sys_info_v2(
-    const char* _Tz, size_t _Tz_len, __std_tzdb_epoch_milli _Local, __std_tzdb_sys_info_type _Type) noexcept;
+_NODISCARD __std_tzdb_sys_info* __stdcall __std_tzdb_get_sys_info(
+    const char* _Tz, size_t _Tz_len, __std_tzdb_epoch_milli _Local) noexcept;
 void __stdcall __std_tzdb_delete_sys_info(__std_tzdb_sys_info* _Info) noexcept;
 
 _NODISCARD __std_tzdb_leap_info* __stdcall __std_tzdb_get_leap_seconds(

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -1765,20 +1765,95 @@ namespace chrono {
 
         template <class _Duration>
         _NODISCARD sys_info get_info(const sys_time<_Duration>& _Sys) const {
-            return _Get_info(_Sys.time_since_epoch());
+            return _Get_info(_Sys.time_since_epoch(), __std_tzdb_sys_info_type::_Full);
         }
 
         template <class _Duration>
         _NODISCARD local_info get_info(const local_time<_Duration>& _Local) const {
+            return _Get_local_info(_Local, __std_tzdb_sys_info_type::_Full);
+        }
+
+        template <class _Duration>
+        _NODISCARD sys_time<common_type_t<_Duration, seconds>> to_sys(const local_time<_Duration>& _Local) const {
+            const auto _Info = get_info(_Local);
+            if (_Info.result == local_info::nonexistent) {
+                _Throw_nonexistent_local_time(_Local, _Info);
+            } else if (_Info.result == local_info::ambiguous) {
+                _Throw_ambiguous_local_time(_Local, _Info);
+            }
+
+            return sys_time<common_type_t<_Duration, seconds>>{_Local.time_since_epoch() - _Info.first.offset};
+        }
+
+        template <class _Duration>
+        _NODISCARD sys_time<common_type_t<_Duration, seconds>> to_sys(
+            const local_time<_Duration>& _Local, const choose _Choose) const {
+            const auto _Info = _Get_local_info(_Local, __std_tzdb_sys_info_type::_Offset_and_range);
+            if (_Info.result == local_info::nonexistent) {
+                return _Info.first.end;
+            }
+
+            const auto _Offset = (_Info.result == local_info::unique || _Choose == choose::earliest)
+                                   ? _Info.first.offset
+                                   : _Info.second.offset;
+            return sys_time<common_type_t<_Duration, seconds>>{_Local.time_since_epoch() - _Offset};
+        }
+
+        template <class _Duration>
+        _NODISCARD local_time<common_type_t<_Duration, seconds>> to_local(const sys_time<_Duration>& _Sys) const {
+            const auto _Info = _Get_info(_Sys.time_since_epoch(), __std_tzdb_sys_info_type::_Offset_only);
+            return local_time<common_type_t<_Duration, seconds>>{_Sys.time_since_epoch() + _Info.offset};
+        }
+
+        static constexpr sys_seconds _Min_seconds{sys_days{(year::min)() / January / 1}};
+        static constexpr sys_seconds _Max_seconds{sys_seconds{sys_days{(year::max)() / December / 32}} - seconds{1}};
+
+    private:
+        template <class _Duration>
+        _NODISCARD sys_info _Get_info(const _Duration& _Dur, __std_tzdb_sys_info_type _Type) const {
+            using _Internal_duration = duration<__std_tzdb_epoch_milli, milli>;
+            const auto _Internal_dur = _CHRONO duration_cast<_Internal_duration>(_Dur);
+            const unique_ptr<__std_tzdb_sys_info, _Tzdb_deleter<__std_tzdb_sys_info>> _Info{
+                __std_tzdb_get_sys_info_v2(_Name.c_str(), _Name.length(), _Internal_dur.count(), _Type)};
+            if (_Info == nullptr) {
+                _Xbad_alloc();
+            } else if (_Info->_Err == __std_tzdb_error::_Win_error) {
+                _XGetLastError();
+            } else if (_Info->_Err == __std_tzdb_error::_Icu_error) {
+                _Xruntime_error("Internal error loading IANA database information");
+            }
+
+            constexpr auto _Min_internal =
+                _CHRONO duration_cast<_Internal_duration>(_Min_seconds.time_since_epoch()).count();
+            constexpr auto _Max_internal =
+                _CHRONO duration_cast<_Internal_duration>(_Max_seconds.time_since_epoch()).count();
+            const auto _Begin =
+                _Info->_Begin <= _Min_internal
+                    ? _Min_seconds
+                    : sys_seconds{_CHRONO duration_cast<sys_seconds::duration>(_Internal_duration{_Info->_Begin})};
+            const auto _End =
+                _Info->_End >= _Max_internal
+                    ? _Max_seconds
+                    : sys_seconds{_CHRONO duration_cast<sys_seconds::duration>(_Internal_duration{_Info->_End})};
+            return {.begin = _Begin,
+                .end       = _End,
+                .offset    = _CHRONO duration_cast<seconds>(_Internal_duration{_Info->_Offset}),
+                .save      = _CHRONO duration_cast<minutes>(_Internal_duration{_Info->_Save}),
+                .abbrev    = _Info->_Abbrev ? _Info->_Abbrev : ""};
+        }
+
+        template <class _Duration>
+        _NODISCARD local_info _Get_local_info(
+            const local_time<_Duration>& _Local, __std_tzdb_sys_info_type _Type) const {
             local_info _Info{};
             const auto _Time_since_ep = _Local.time_since_epoch();
-            _Info.first               = _Get_info(_Time_since_ep);
+            _Info.first               = _Get_info(_Time_since_ep, _Type);
 
             const sys_seconds _Local_sys{_CHRONO duration_cast<sys_seconds::duration>(_Time_since_ep)};
             const auto _Curr_sys = _Local_sys - _Info.first.offset;
             if (_Info.first.begin != _Min_seconds && _Curr_sys < _Info.first.begin + days{1}) {
                 // get previous transition information
-                _Info.second = get_info(_Info.first.begin - seconds{1});
+                _Info.second = _Get_info((_Info.first.begin - seconds{1}).time_since_epoch(), _Type);
 
                 const auto _Transition = _Info.first.begin;
                 const auto _Prev_sys   = _Local_sys - _Info.second.offset;
@@ -1802,7 +1877,7 @@ namespace chrono {
                 }
             } else if (_Info.first.end != _Max_seconds && _Curr_sys > _Info.first.end - days{1}) {
                 // get next transition information
-                _Info.second = get_info(_Info.first.end + seconds{1});
+                _Info.second = _Get_info((_Info.first.end + seconds{1}).time_since_epoch(), _Type);
 
                 const auto _Transition = _Info.first.end;
                 const auto _Next_sys   = _Local_sys - _Info.second.offset;
@@ -1829,75 +1904,6 @@ namespace chrono {
             }
 
             return _Info;
-        }
-
-        template <class _Duration>
-        _NODISCARD sys_time<common_type_t<_Duration, seconds>> to_sys(const local_time<_Duration>& _Local) const {
-            const auto _Info = get_info(_Local);
-            if (_Info.result == local_info::nonexistent) {
-                _Throw_nonexistent_local_time(_Local, _Info);
-            } else if (_Info.result == local_info::ambiguous) {
-                _Throw_ambiguous_local_time(_Local, _Info);
-            }
-
-            return sys_time<common_type_t<_Duration, seconds>>{_Local.time_since_epoch() - _Info.first.offset};
-        }
-
-        template <class _Duration>
-        _NODISCARD sys_time<common_type_t<_Duration, seconds>> to_sys(
-            const local_time<_Duration>& _Local, const choose _Choose) const {
-            const auto _Info = get_info(_Local);
-            if (_Info.result == local_info::nonexistent) {
-                return _Info.first.end;
-            }
-
-            const auto _Offset = (_Info.result == local_info::unique || _Choose == choose::earliest)
-                                   ? _Info.first.offset
-                                   : _Info.second.offset;
-            return sys_time<common_type_t<_Duration, seconds>>{_Local.time_since_epoch() - _Offset};
-        }
-
-        template <class _Duration>
-        _NODISCARD local_time<common_type_t<_Duration, seconds>> to_local(const sys_time<_Duration>& _Sys) const {
-            const auto _Info = get_info(_Sys);
-            return local_time<common_type_t<_Duration, seconds>>{_Sys.time_since_epoch() + _Info.offset};
-        }
-
-        static constexpr sys_seconds _Min_seconds{sys_days{(year::min)() / January / 1}};
-        static constexpr sys_seconds _Max_seconds{sys_seconds{sys_days{(year::max)() / December / 32}} - seconds{1}};
-
-    private:
-        template <class _Duration>
-        _NODISCARD sys_info _Get_info(const _Duration& _Dur) const {
-            using _Internal_duration = duration<__std_tzdb_epoch_milli, milli>;
-            const auto _Internal_dur = _CHRONO duration_cast<_Internal_duration>(_Dur);
-            const unique_ptr<__std_tzdb_sys_info, _Tzdb_deleter<__std_tzdb_sys_info>> _Info{
-                __std_tzdb_get_sys_info(_Name.c_str(), _Name.length(), _Internal_dur.count())};
-            if (_Info == nullptr) {
-                _Xbad_alloc();
-            } else if (_Info->_Err == __std_tzdb_error::_Win_error) {
-                _XGetLastError();
-            } else if (_Info->_Err == __std_tzdb_error::_Icu_error) {
-                _Xruntime_error("Internal error loading IANA database information");
-            }
-
-            constexpr auto _Min_internal =
-                _CHRONO duration_cast<_Internal_duration>(_Min_seconds.time_since_epoch()).count();
-            constexpr auto _Max_internal =
-                _CHRONO duration_cast<_Internal_duration>(_Max_seconds.time_since_epoch()).count();
-            const auto _Begin =
-                _Info->_Begin <= _Min_internal
-                    ? _Min_seconds
-                    : sys_seconds{_CHRONO duration_cast<sys_seconds::duration>(_Internal_duration{_Info->_Begin})};
-            const auto _End =
-                _Info->_End >= _Max_internal
-                    ? _Max_seconds
-                    : sys_seconds{_CHRONO duration_cast<sys_seconds::duration>(_Internal_duration{_Info->_End})};
-            return {.begin = _Begin,
-                .end       = _End,
-                .offset    = _CHRONO duration_cast<seconds>(_Internal_duration{_Info->_Offset}),
-                .save      = _CHRONO duration_cast<minutes>(_Internal_duration{_Info->_Save}),
-                .abbrev    = _Info->_Abbrev};
         }
 
         string _Name;

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -1813,8 +1813,22 @@ namespace chrono {
         _NODISCARD sys_info _Get_info(const _Duration& _Dur, __std_tzdb_sys_info_type _Type) const {
             using _Internal_duration = duration<__std_tzdb_epoch_milli, milli>;
             const auto _Internal_dur = _CHRONO duration_cast<_Internal_duration>(_Dur);
+
+            // TRANSITION, vNext
+            // Because the signature of __std_tzdb_get_sys_info cannot be changed, the option is encoded in the
+            // time zone name. In vNext, this should be a dedicated argument.
+            auto _Tz_arg = _Name;
+            if (_Type == __std_tzdb_sys_info_type::_Offset_only) {
+                _Tz_arg.push_back('!');
+            } else if (_Type == __std_tzdb_sys_info_type::_Offset_and_range) {
+                _Tz_arg.push_back('#');
+            }
+
+            const auto _Tz_len = _Name.length();
+
             const unique_ptr<__std_tzdb_sys_info, _Tzdb_deleter<__std_tzdb_sys_info>> _Info{
-                __std_tzdb_get_sys_info_v2(_Name.c_str(), _Name.length(), _Internal_dur.count(), _Type)};
+                __std_tzdb_get_sys_info(_Tz_arg.c_str(), _Tz_len, _Internal_dur.count())};
+
             if (_Info == nullptr) {
                 _Xbad_alloc();
             } else if (_Info->_Err == __std_tzdb_error::_Win_error) {

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -1815,14 +1815,9 @@ namespace chrono {
             const auto _Internal_dur = _CHRONO duration_cast<_Internal_duration>(_Dur);
 
             // TRANSITION, vNext
-            // Because the signature of __std_tzdb_get_sys_info cannot be changed, the option is encoded in the
+            // Because the signature of __std_tzdb_get_sys_info cannot be changed, _Type is encoded in the
             // time zone name. In vNext, this should be a dedicated argument.
-            auto _Tz_arg = _Name;
-            if (_Type == __std_tzdb_sys_info_type::_Offset_only) {
-                _Tz_arg.push_back('!');
-            } else if (_Type == __std_tzdb_sys_info_type::_Offset_and_range) {
-                _Tz_arg.push_back('#');
-            }
+            const string _Tz_arg = _Name + static_cast<char>(_Type);
 
             const auto _Tz_len = _Name.length();
 

--- a/stl/src/msvcp_atomic_wait.src
+++ b/stl/src/msvcp_atomic_wait.src
@@ -35,7 +35,6 @@ EXPORTS
     __std_tzdb_delete_time_zones
     __std_tzdb_get_current_zone
     __std_tzdb_get_leap_seconds
-    __std_tzdb_get_sys_info_v2
     __std_tzdb_get_sys_info
     __std_tzdb_get_time_zones
     __std_wait_for_threadpool_work_callbacks

--- a/stl/src/msvcp_atomic_wait.src
+++ b/stl/src/msvcp_atomic_wait.src
@@ -35,6 +35,7 @@ EXPORTS
     __std_tzdb_delete_time_zones
     __std_tzdb_get_current_zone
     __std_tzdb_get_leap_seconds
+    __std_tzdb_get_sys_info_v2
     __std_tzdb_get_sys_info
     __std_tzdb_get_time_zones
     __std_wait_for_threadpool_work_callbacks

--- a/stl/src/tzdb.cpp
+++ b/stl/src/tzdb.cpp
@@ -502,6 +502,10 @@ void __stdcall __std_tzdb_delete_current_zone(__std_tzdb_current_zone_info* cons
         return _Report_error(_Info, __std_tzdb_error::_Win_error);
     }
 
+    // Get the option stored after the time zone name. If there's no option, _Tz[_Tz_len] is the null terminator in the
+    // std::string, and will be treated the same as __std_tzdb_sys_info_type::_Full.
+    const auto _Type = static_cast<__std_tzdb_sys_info_type>(_Tz[_Tz_len]);
+
     // TRANSITION, vNext
     // Profiling shows that _Get_cal is a hot path. Its result should be cached (preferably in the time_zone object).
     const auto _Cal = _Get_cal(_Tz, _Tz_len, _Info->_Err);
@@ -530,9 +534,7 @@ void __stdcall __std_tzdb_delete_current_zone(__std_tzdb_current_zone_info* cons
         return _Report_error(_Info, __std_tzdb_error::_Icu_error);
     }
 
-    // Additional options could be stored after the time zone name. _Tz[_Tz_len] might be the one-past-the-end element,
-    // but it's safe to read, because _Tz is known to be obtained from a std::string.
-    if (_Tz[_Tz_len] == '!') {
+    if (_Type == __std_tzdb_sys_info_type::_Offset_only) {
         return _Info.release();
     }
 
@@ -553,7 +555,7 @@ void __stdcall __std_tzdb_delete_current_zone(__std_tzdb_current_zone_info* cons
         return _Report_error(_Info, __std_tzdb_error::_Icu_error);
     }
 
-    if (_Tz[_Tz_len] == '#') {
+    if (_Type == __std_tzdb_sys_info_type::_Offset_and_range) {
         return _Info.release();
     }
 


### PR DESCRIPTION
... by only retrieving necessary information.

This makes `to_local` 3x faster on my machine (although it's still hundreds times slower than `localtime`).