### PR TITLE
Don't warn when using operator<=> with 0

### DIFF
--- a/stl/inc/compare
+++ b/stl/inc/compare
@@ -27,24 +27,22 @@ _STL_DISABLE_CLANG_WARNINGS
 #undef new
 
 _STD_BEGIN
-struct partial_ordering;
-struct weak_ordering;
-struct strong_ordering;
+_EXPORT_STD struct partial_ordering;
+_EXPORT_STD struct weak_ordering;
+_EXPORT_STD struct strong_ordering;
 
 void _Literal_zero_is_expected();
 
 struct _Literal_zero {
-
-    consteval _Literal_zero(int _Zero) noexcept {
+    template <class _Ty, enable_if_t<is_same_v<_Ty, int>, int> = 0>
+    consteval _Literal_zero(_Ty _Zero) noexcept {
         // Can't use _STL_VERIFY because this is a core header
         if (_Zero != 0) {
             _Literal_zero_is_expected();
         }
     }
-
-    template <class _Ty, class = enable_if_t<!_Is_any_of_v<_Ty, int, partial_ordering, weak_ordering, strong_ordering>>>
-    _Literal_zero(_Ty) = delete;
 };
+
 using _Compare_t = signed char;
 
 // These "pretty" enumerator names are safe since they reuse names of user-facing entities.

--- a/stl/inc/compare
+++ b/stl/inc/compare
@@ -27,8 +27,20 @@ _STL_DISABLE_CLANG_WARNINGS
 #undef new
 
 _STD_BEGIN
-using _Literal_zero = decltype(nullptr);
-using _Compare_t    = signed char;
+struct partial_ordering;
+struct weak_ordering;
+struct strong_ordering;
+
+struct _Literal_zero {
+
+    consteval _Literal_zero(int _Zero) noexcept {
+        _STL_VERIFY(_Zero == 0, "A literal zero is expected");
+    }
+
+    template <class _Ty, class = enable_if_t<!_Is_any_of_v<_Ty, int, partial_ordering, weak_ordering, strong_ordering>>>
+    _Literal_zero(_Ty) = delete;
+};
+using _Compare_t = signed char;
 
 // These "pretty" enumerator names are safe since they reuse names of user-facing entities.
 enum class _Compare_eq : _Compare_t { equal = 0, equivalent = equal };

--- a/stl/inc/compare
+++ b/stl/inc/compare
@@ -31,10 +31,15 @@ struct partial_ordering;
 struct weak_ordering;
 struct strong_ordering;
 
+void __Literal_zero_is_expected();
+
 struct _Literal_zero {
 
     consteval _Literal_zero(int _Zero) noexcept {
-        _STL_VERIFY(_Zero == 0, "A literal zero is expected");
+        // Can't use _STL_VERIFY because this is a core header
+        if (_Zero != 0) {
+            __Literal_zero_is_expected();
+        }
     }
 
     template <class _Ty, class = enable_if_t<!_Is_any_of_v<_Ty, int, partial_ordering, weak_ordering, strong_ordering>>>

--- a/stl/inc/compare
+++ b/stl/inc/compare
@@ -27,10 +27,6 @@ _STL_DISABLE_CLANG_WARNINGS
 #undef new
 
 _STD_BEGIN
-_EXPORT_STD struct partial_ordering;
-_EXPORT_STD struct weak_ordering;
-_EXPORT_STD struct strong_ordering;
-
 void _Literal_zero_is_expected();
 
 struct _Literal_zero {

--- a/stl/inc/compare
+++ b/stl/inc/compare
@@ -31,14 +31,14 @@ struct partial_ordering;
 struct weak_ordering;
 struct strong_ordering;
 
-void __Literal_zero_is_expected();
+void _Literal_zero_is_expected();
 
 struct _Literal_zero {
 
     consteval _Literal_zero(int _Zero) noexcept {
         // Can't use _STL_VERIFY because this is a core header
         if (_Zero != 0) {
-            __Literal_zero_is_expected();
+            _Literal_zero_is_expected();
         }
     }
 

--- a/tests/std/tests/P0768R1_spaceship_operator/test.cpp
+++ b/tests/std/tests/P0768R1_spaceship_operator/test.cpp
@@ -7,7 +7,7 @@
 #include <compare>
 #include <type_traits>
 
-// See https://github.com/microsoft/STL/pull/3581 for details
+// See GH-3581 for details
 #ifdef __clang__
 #pragma clang diagnostic error "-Wzero-as-null-pointer-constant"
 #endif // __clang__

--- a/tests/std/tests/P0768R1_spaceship_operator/test.cpp
+++ b/tests/std/tests/P0768R1_spaceship_operator/test.cpp
@@ -7,6 +7,10 @@
 #include <compare>
 #include <type_traits>
 
+#ifdef __clang__
+#pragma clang diagnostic error "-Wzero-as-null-pointer-constant"
+#endif // __clang__
+
 enum class comp { equal, less, greater, unordered };
 
 template <comp Z, class T>

--- a/tests/std/tests/P0768R1_spaceship_operator/test.cpp
+++ b/tests/std/tests/P0768R1_spaceship_operator/test.cpp
@@ -7,6 +7,7 @@
 #include <compare>
 #include <type_traits>
 
+// See https://github.com/microsoft/STL/pull/3581 for details
 #ifdef __clang__
 #pragma clang diagnostic error "-Wzero-as-null-pointer-constant"
 #endif // __clang__


### PR DESCRIPTION
LLVM has an issue: https://github.com/llvm/llvm-project/issues/43670

That issue marked as `libc++` but actually every C++ standard library affected , and MSVC STL and libstdc++.

```c++
#include <compare>

auto b = 1 <=> 2 < 0;

int main() {}
```

```
clang-cl /std:c++20 -Wzero-as-null-pointer-constant main.cpp
main.cpp(3,20): warning: zero as null pointer constant [-Wzero-as-null-pointer-constant]
auto b = 1 <=> 2 < 0;
                   ^
                   nullptr
1 warning generated.
```

![изображение](https://user-images.githubusercontent.com/4289847/226155150-8f526649-488e-4dbd-875b-17c9ae49dc34.png)

I also created: https://reviews.llvm.org/D146372

Yes, after that patch we accept 
```c++
auto b = 1 <=> 2 < (1-1);
```
but probably this is fine because the behavior is undefined. At least we don't warn on valid code.