### PR TITLE
Prefer `consteval` to `_CONSTEVAL`, enable `<source_location>` for Clang

### DIFF
--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -2970,7 +2970,7 @@ namespace chrono {
         void_t<decltype(_Conv1{}(_Conv2{}(_Conv3{}(_STD declval<_Tp>()))))>> = true;
 
     template <class _DestClock, class _SourceClock, class _Duration>
-    _NODISCARD _CONSTEVAL _Clock_cast_strategy _Choose_clock_cast() noexcept {
+    _NODISCARD consteval _Clock_cast_strategy _Choose_clock_cast() noexcept {
         using _Tp = const time_point<_SourceClock, _Duration>&;
 
         if constexpr (is_invocable_v<clock_time_conversion<_DestClock, _SourceClock>, _Tp>) {

--- a/stl/inc/compare
+++ b/stl/inc/compare
@@ -383,7 +383,7 @@ namespace _Strong_order {
         enum class _St { _None, _Adl, _Floating, _Three };
 
         template <class _Ty1, class _Ty2>
-        _NODISCARD static _CONSTEVAL _Choice_t<_St> _Choose() noexcept {
+        _NODISCARD static consteval _Choice_t<_St> _Choose() noexcept {
             if constexpr (!same_as<decay_t<_Ty1>, decay_t<_Ty2>>) {
                 return {_St::_None};
             } else if constexpr (_Has_ADL<_Ty1, _Ty2>) {
@@ -486,7 +486,7 @@ namespace _Weak_order {
         enum class _St { _None, _Adl, _Floating, _Three, _Strong };
 
         template <class _Ty1, class _Ty2>
-        _NODISCARD static _CONSTEVAL _Choice_t<_St> _Choose() noexcept {
+        _NODISCARD static consteval _Choice_t<_St> _Choose() noexcept {
             if constexpr (!same_as<decay_t<_Ty1>, decay_t<_Ty2>>) {
                 return {_St::_None};
             } else if constexpr (_Has_ADL<_Ty1, _Ty2>) {
@@ -615,7 +615,7 @@ namespace _Partial_order {
         enum class _St { _None, _Adl, _Three, _Weak, _Strong };
 
         template <class _Ty1, class _Ty2>
-        _NODISCARD static _CONSTEVAL _Choice_t<_St> _Choose() noexcept {
+        _NODISCARD static consteval _Choice_t<_St> _Choose() noexcept {
             if constexpr (!same_as<decay_t<_Ty1>, decay_t<_Ty2>>) {
                 return {_St::_None};
             } else if constexpr (_Has_ADL<_Ty1, _Ty2>) {
@@ -684,7 +684,7 @@ namespace _Compare_strong_order_fallback {
         enum class _St { _None, _Strong, _Fallback };
 
         template <class _Ty1, class _Ty2>
-        _NODISCARD static _CONSTEVAL _Choice_t<_St> _Choose() noexcept {
+        _NODISCARD static consteval _Choice_t<_St> _Choose() noexcept {
             if constexpr (!same_as<decay_t<_Ty1>, decay_t<_Ty2>>) {
                 return {_St::_None};
             } else if constexpr (_Can_strong_order<_Ty1, _Ty2>) {
@@ -734,7 +734,7 @@ namespace _Compare_weak_order_fallback {
         enum class _St { _None, _Weak, _Fallback };
 
         template <class _Ty1, class _Ty2>
-        _NODISCARD static _CONSTEVAL _Choice_t<_St> _Choose() noexcept {
+        _NODISCARD static consteval _Choice_t<_St> _Choose() noexcept {
             if constexpr (!same_as<decay_t<_Ty1>, decay_t<_Ty2>>) {
                 return {_St::_None};
             } else if constexpr (_Can_weak_order<_Ty1, _Ty2>) {
@@ -791,7 +791,7 @@ namespace _Compare_partial_order_fallback {
         enum class _St { _None, _Partial, _Fallback };
 
         template <class _Ty1, class _Ty2>
-        _NODISCARD static _CONSTEVAL _Choice_t<_St> _Choose() noexcept {
+        _NODISCARD static consteval _Choice_t<_St> _Choose() noexcept {
             if constexpr (!same_as<decay_t<_Ty1>, decay_t<_Ty2>>) {
                 return {_St::_None};
             } else if constexpr (_Can_partial_order<_Ty1, _Ty2>) {

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -1894,7 +1894,7 @@ namespace ranges {
             enum class _St { _None, _View, _Ref, _Own };
 
             template <class _Rng>
-            _NODISCARD static _CONSTEVAL _Choice_t<_St> _Choose() noexcept {
+            _NODISCARD static consteval _Choice_t<_St> _Choose() noexcept {
                 if constexpr (view<remove_cvref_t<_Rng>>) {
                     if constexpr (convertible_to<_Rng, remove_cvref_t<_Rng>>) {
                         return {_St::_View, is_nothrow_convertible_v<_Rng, remove_cvref_t<_Rng>>};
@@ -2026,7 +2026,7 @@ namespace ranges {
             enum class _St { _None, _All, _As_rvalue };
 
             template <class _Rng>
-            _NODISCARD static _CONSTEVAL _Choice_t<_St> _Choose() noexcept {
+            _NODISCARD static consteval _Choice_t<_St> _Choose() noexcept {
                 if constexpr (same_as<range_rvalue_reference_t<_Rng>, range_reference_t<_Rng>>) {
                     return {_St::_All, noexcept(views::all(_STD declval<_Rng>()))};
                 } else if constexpr (_Can_as_rvalue<_Rng>) {
@@ -2967,7 +2967,7 @@ namespace ranges {
             };
 
             template <class _Rng>
-            _NODISCARD static _CONSTEVAL _Choice_t<_St> _Choose() noexcept {
+            _NODISCARD static consteval _Choice_t<_St> _Choose() noexcept {
                 using _Ty = remove_cvref_t<_Rng>;
 
                 if constexpr (_Is_specialization_v<_Ty, empty_view>) {
@@ -3366,7 +3366,7 @@ namespace ranges {
             };
 
             template <class _Rng>
-            _NODISCARD static _CONSTEVAL _Choice_t<_St> _Choose() noexcept {
+            _NODISCARD static _CONSTconstevalEVAL _Choice_t<_St> _Choose() noexcept {
                 using _Ty = remove_cvref_t<_Rng>;
 
                 if constexpr (_Is_specialization_v<_Ty, empty_view>) {
@@ -5115,7 +5115,7 @@ namespace ranges {
             enum class _St { _None, _Span, _Subrange, _Subrange_counted };
 
             template <class _It>
-            _NODISCARD static _CONSTEVAL _Choice_t<_St> _Choose() noexcept {
+            _NODISCARD static consteval _Choice_t<_St> _Choose() noexcept {
                 using _Decayed = decay_t<_It>;
                 _STL_INTERNAL_STATIC_ASSERT(input_or_output_iterator<_Decayed>);
                 if constexpr (contiguous_iterator<_Decayed>) {
@@ -5244,7 +5244,7 @@ namespace ranges {
             enum class _St { _None, _All, _Common };
 
             template <class _Rng>
-            _NODISCARD static _CONSTEVAL _Choice_t<_St> _Choose() noexcept {
+            _NODISCARD static consteval _Choice_t<_St> _Choose() noexcept {
                 if constexpr (common_range<_Rng>) {
                     return {_St::_All, noexcept(views::all(_STD declval<_Rng>()))};
                 } else if constexpr (copyable<iterator_t<_Rng>>) {
@@ -5376,7 +5376,7 @@ namespace ranges {
                 static_cast<int>(_Ki);
 
             template <class _Rng>
-            _NODISCARD static _CONSTEVAL _Choice_t<_St> _Choose() noexcept {
+            _NODISCARD static consteval _Choice_t<_St> _Choose() noexcept {
                 using _Ty = remove_cvref_t<_Rng>;
 
                 if constexpr (_Is_specialization_v<_Ty, reverse_view>) {
@@ -5510,7 +5510,7 @@ namespace ranges {
             static constexpr bool _Can_reconstruct_ref_view_v<ref_view<_Ty>> = true;
 
             template <class _Rng>
-            _NODISCARD static _CONSTEVAL _Choice_t<_St> _Choose() noexcept {
+            _NODISCARD static consteval _Choice_t<_St> _Choose() noexcept {
                 using _Ty = remove_cvref_t<_Rng>;
 
                 if constexpr (constant_range<views::all_t<_Rng>>) {
@@ -8304,7 +8304,7 @@ namespace ranges {
         };
 
         template <bool _IsConst>
-        _NODISCARD static _CONSTEVAL bool _Is_end_noexcept() noexcept {
+        _NODISCARD static consteval bool _Is_end_noexcept() noexcept {
             if constexpr (!_Zip_is_common<_Maybe_const<_IsConst, _ViewTypes>...>) {
                 return noexcept(_Sentinel<_IsConst>{
                     _Tuple_transform(_RANGES end, _STD declval<_Maybe_const<_IsConst, tuple<_ViewTypes...>>&>())});
@@ -8396,7 +8396,7 @@ namespace ranges {
         struct _Zip_fn {
         private:
             template <class... _Types>
-            _NODISCARD static _CONSTEVAL bool _Is_invocation_noexcept() {
+            _NODISCARD static consteval bool _Is_invocation_noexcept() {
                 if constexpr (sizeof...(_Types) == 0) {
                     // NOTE: views::empty<tuple<>> is nothrow copy-constructible.
                     return true;
@@ -8666,7 +8666,7 @@ namespace ranges {
         };
 
         template <bool _IsConst>
-        _NODISCARD static _CONSTEVAL bool _Is_end_noexcept() noexcept {
+        _NODISCARD static consteval bool _Is_end_noexcept() noexcept {
             if constexpr (common_range<_Maybe_const<_IsConst, _Inner_view>>) {
                 return noexcept(_Iterator<_IsConst>{_STD declval<_Maybe_const<_IsConst, zip_transform_view>&>(),
                     _STD declval<_Maybe_const<_IsConst, _Inner_view>&>().end()});

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -3366,7 +3366,7 @@ namespace ranges {
             };
 
             template <class _Rng>
-            _NODISCARD static _CONSTconstevalEVAL _Choice_t<_St> _Choose() noexcept {
+            _NODISCARD static consteval _Choice_t<_St> _Choose() noexcept {
                 using _Ty = remove_cvref_t<_Rng>;
 
                 if constexpr (_Is_specialization_v<_Ty, empty_view>) {

--- a/stl/inc/source_location
+++ b/stl/inc/source_location
@@ -8,9 +8,9 @@
 #define _SOURCE_LOCATION_
 #include <yvals_core.h>
 #if _STL_COMPILER_PREPROCESSOR
-#ifndef __cpp_consteval
-_EMIT_STL_WARNING(STL4038, "The contents of <source_location> are available only with C++20 consteval support.");
-#else // ^^^ !defined(__cpp_consteval) / defined(__cpp_consteval) vvv
+#if !_HAS_CXX20
+_EMIT_STL_WARNING(STL4038, "The contents of <source_location> are available only with C++20 or later.");
+#else // ^^^ !_HAS_CXX20 / _HAS_CXX20 vvv
 
 #include <cstdint>
 
@@ -66,6 +66,6 @@ _STD_END
 _STL_RESTORE_CLANG_WARNINGS
 #pragma warning(pop)
 #pragma pack(pop)
-#endif // !defined(__cpp_consteval)
+#endif // _HAS_CXX20
 #endif // _STL_COMPILER_PREPROCESSOR
 #endif // _SOURCE_LOCATION_

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -848,7 +848,7 @@ _NODISCARD constexpr bool cmp_greater_equal(const _Ty1 _Left, const _Ty2 _Right)
 }
 
 template <class _Ty>
-_NODISCARD _CONSTEVAL _Ty _Min_limit() noexcept { // same as (numeric_limits<_Ty>::min)(), less throughput cost
+_NODISCARD consteval _Ty _Min_limit() noexcept { // same as (numeric_limits<_Ty>::min)(), less throughput cost
     static_assert(_Is_standard_integer<_Ty>); // doesn't attempt to handle all types
     if constexpr (is_signed_v<_Ty>) {
         constexpr auto _Unsigned_max = static_cast<make_unsigned_t<_Ty>>(-1);
@@ -859,7 +859,7 @@ _NODISCARD _CONSTEVAL _Ty _Min_limit() noexcept { // same as (numeric_limits<_Ty
 }
 
 template <class _Ty>
-_NODISCARD _CONSTEVAL _Ty _Max_limit() noexcept { // same as (numeric_limits<_Ty>::max)(), less throughput cost
+_NODISCARD consteval _Ty _Max_limit() noexcept { // same as (numeric_limits<_Ty>::max)(), less throughput cost
     static_assert(_Is_standard_integer<_Ty>); // doesn't attempt to handle all types
     if constexpr (is_signed_v<_Ty>) {
         constexpr auto _Unsigned_max = static_cast<make_unsigned_t<_Ty>>(-1);

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -445,7 +445,7 @@ namespace ranges {
             enum class _St { _None, _Custom, _Fallback };
 
             template <class _Ty>
-            _NODISCARD static _CONSTEVAL _Choice_t<_St> _Choose() noexcept {
+            _NODISCARD static consteval _Choice_t<_St> _Choose() noexcept {
                 if constexpr (_Has_ADL<_Ty>) {
                     return {_St::_Custom, noexcept(iter_move(_STD declval<_Ty>()))}; // intentional ADL
                 } else if constexpr (_Can_deref<_Ty>) {
@@ -770,7 +770,7 @@ namespace ranges {
             enum class _St { _None, _Custom, _Swap, _Exchange };
 
             template <class _Ty1, class _Ty2>
-            _NODISCARD static _CONSTEVAL _Choice_t<_St> _Choose() noexcept {
+            _NODISCARD static consteval _Choice_t<_St> _Choose() noexcept {
                 if constexpr (_Has_ADL<_Ty1, _Ty2>) {
                     return {_St::_Custom,
                         noexcept(iter_swap(_STD declval<_Ty1>(), _STD declval<_Ty2>()))}; // intentional ADL
@@ -1833,7 +1833,7 @@ private:
     using _Reference        = iter_const_reference_t<_Iter>;
     using _Rvalue_reference = _Iter_const_rvalue_reference_t<_Iter>;
 
-    _NODISCARD static _CONSTEVAL auto _Get_iter_concept() noexcept {
+    _NODISCARD static consteval auto _Get_iter_concept() noexcept {
         if constexpr (contiguous_iterator<_Iter>) {
             return contiguous_iterator_tag{};
         } else if constexpr (random_access_iterator<_Iter>) {
@@ -2155,7 +2155,7 @@ namespace ranges {
             enum class _St { _None, _Array, _Member, _Non_member };
 
             template <class _Ty>
-            _NODISCARD static _CONSTEVAL _Choice_t<_St> _Choose() noexcept {
+            _NODISCARD static consteval _Choice_t<_St> _Choose() noexcept {
                 _STL_INTERNAL_STATIC_ASSERT(is_lvalue_reference_v<_Ty>);
                 if constexpr (is_array_v<remove_reference_t<_Ty>>) {
                     static_assert(_Has_complete_elements<_Ty>,
@@ -2224,7 +2224,7 @@ namespace ranges {
             enum class _St { _None, _Array, _Member, _Non_member };
 
             template <class _Ty>
-            _NODISCARD static _CONSTEVAL _Choice_t<_St> _Choose() noexcept {
+            _NODISCARD static consteval _Choice_t<_St> _Choose() noexcept {
                 _STL_INTERNAL_STATIC_ASSERT(is_lvalue_reference_v<_Ty>);
                 using _UnRef = remove_reference_t<_Ty>;
 
@@ -2371,7 +2371,7 @@ namespace ranges {
             enum class _St { _None, _Member, _Unwrap };
 
             template <class _Ty>
-            _NODISCARD static _CONSTEVAL _Choice_t<_St> _Choose() noexcept {
+            _NODISCARD static consteval _Choice_t<_St> _Choose() noexcept {
                 _STL_INTERNAL_STATIC_ASSERT(is_lvalue_reference_v<_Ty>);
                 if constexpr (_Has_member<_Ty>) {
                     _STL_INTERNAL_STATIC_ASSERT(
@@ -2425,7 +2425,7 @@ namespace ranges {
             enum class _St { _None, _Member, _Unwrap };
 
             template <class _Ty>
-            _NODISCARD static _CONSTEVAL _Choice_t<_St> _Choose() noexcept {
+            _NODISCARD static consteval _Choice_t<_St> _Choose() noexcept {
                 _STL_INTERNAL_STATIC_ASSERT(is_lvalue_reference_v<_Ty>);
                 if constexpr (_Has_member<_Ty>) {
                     return {_St::_Member, noexcept(_STD declval<_Ty>()._Unchecked_end())};
@@ -2590,7 +2590,7 @@ namespace ranges {
             enum class _St { _None, _Member, _Non_member, _Make_reverse };
 
             template <class _Ty>
-            _NODISCARD static _CONSTEVAL _Choice_t<_St> _Choose() noexcept {
+            _NODISCARD static consteval _Choice_t<_St> _Choose() noexcept {
                 _STL_INTERNAL_STATIC_ASSERT(is_lvalue_reference_v<_Ty>);
                 if constexpr (_Has_member<_Ty>) {
                     return {_St::_Member, noexcept(_Fake_copy_init(_STD declval<_Ty>().rbegin()))};
@@ -2660,7 +2660,7 @@ namespace ranges {
             enum class _St { _None, _Member, _Non_member, _Make_reverse };
 
             template <class _Ty>
-            _NODISCARD static _CONSTEVAL _Choice_t<_St> _Choose() noexcept {
+            _NODISCARD static consteval _Choice_t<_St> _Choose() noexcept {
                 _STL_INTERNAL_STATIC_ASSERT(is_lvalue_reference_v<_Ty>);
                 if constexpr (_Has_member<_Ty>) {
                     return {_St::_Member, noexcept(_Fake_copy_init(_STD declval<_Ty>().rend()))};
@@ -2799,7 +2799,7 @@ namespace ranges {
             enum class _St { _None, _Array, _Member, _Non_member, _Subtract };
 
             template <class _Ty>
-            _NODISCARD static _CONSTEVAL _Choice_t<_St> _Choose() noexcept {
+            _NODISCARD static consteval _Choice_t<_St> _Choose() noexcept {
                 _STL_INTERNAL_STATIC_ASSERT(is_lvalue_reference_v<_Ty>);
                 using _UnCV = remove_cvref_t<_Ty>;
 
@@ -2869,7 +2869,7 @@ namespace ranges {
             enum class _St { _None, _Member, _Size, _Compare };
 
             template <class _Ty>
-            _NODISCARD static _CONSTEVAL _Choice_t<_St> _Choose() noexcept {
+            _NODISCARD static consteval _Choice_t<_St> _Choose() noexcept {
                 _STL_INTERNAL_STATIC_ASSERT(is_lvalue_reference_v<_Ty>);
                 if constexpr (is_unbounded_array_v<remove_reference_t<_Ty>>) {
                     return {_St::_None};
@@ -2933,7 +2933,7 @@ namespace ranges {
             enum class _St { _None, _Member, _Address };
 
             template <class _Ty>
-            _NODISCARD static _CONSTEVAL _Choice_t<_St> _Choose() noexcept {
+            _NODISCARD static consteval _Choice_t<_St> _Choose() noexcept {
                 _STL_INTERNAL_STATIC_ASSERT(is_lvalue_reference_v<_Ty>);
                 if constexpr (_Has_member<_Ty>) {
                     return {_St::_Member, noexcept(_STD declval<_Ty>().data())};

--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -1671,15 +1671,11 @@ _EMIT_STL_ERROR(STL1004, "C++98 unexpected() is incompatible with C++23 unexpect
 #define __cpp_lib_remove_cvref            201711L
 #define __cpp_lib_semaphore               201907L
 #define __cpp_lib_smart_ptr_for_overwrite 202002L
-
-#ifdef __cpp_consteval
-#define __cpp_lib_source_location 201907L
-#endif // __cpp_consteval
-
-#define __cpp_lib_span             202002L
-#define __cpp_lib_ssize            201902L
-#define __cpp_lib_starts_ends_with 201711L
-#define __cpp_lib_syncbuf          201803L
+#define __cpp_lib_source_location         201907L
+#define __cpp_lib_span                    202002L
+#define __cpp_lib_ssize                   201902L
+#define __cpp_lib_starts_ends_with        201711L
+#define __cpp_lib_syncbuf                 201803L
 
 #ifdef __cpp_lib_concepts
 #define __cpp_lib_three_way_comparison 201907L

--- a/tests/std/tests/P1208R6_source_location/header.h
+++ b/tests/std/tests/P1208R6_source_location/header.h
@@ -10,7 +10,11 @@ constexpr void header_test() {
     using namespace std;
     const auto x = source_location::current();
     assert(x.line() == __LINE__ - 1);
+#ifdef __clang__
+    assert(x.column() == 20);
+#else // ^^^ defined(__clang__) / !defined(__clang__) vvv
     assert(x.column() == 37);
+#endif // ^^^ !defined(__clang__) ^^^
 #if defined(__clang__) || defined(__EDG__) // TRANSITION, DevCom-10199227 and LLVM-58951
     assert(x.function_name() == "header_test"sv);
 #else // ^^^ workaround / no workaround vvv

--- a/tests/std/tests/P1208R6_source_location/test.cpp
+++ b/tests/std/tests/P1208R6_source_location/test.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#if defined(__cpp_consteval) && !defined(__EDG__) // TRANSITION, VSO-1285779
+#ifndef __EDG__ // TRANSITION, VSO-1285779
 #include "header.h"
 #include <cassert>
 #include <functional>
@@ -207,6 +207,6 @@ int main() {
     static_assert(test());
     return 0;
 }
-#else // ^^^ defined(__cpp_consteval) && !defined(__EDG__) / !defined(__cpp_consteval) || defined(__EDG__) vvv
+#else // ^^^ !defined(__EDG__) / defined(__EDG__) vvv
 int main() {}
-#endif // ^^^ !defined(__cpp_consteval) || defined(__EDG__) ^^^
+#endif // ^^^ defined(__EDG__) ^^^

--- a/tests/std/tests/P1208R6_source_location/test.cpp
+++ b/tests/std/tests/P1208R6_source_location/test.cpp
@@ -19,7 +19,11 @@ constexpr auto test_cpp = "test.cpp"sv;
 
 constexpr auto g = source_location::current();
 static_assert(g.line() == __LINE__ - 1);
+#ifdef __clang__
+static_assert(g.column() == 20);
+#else // ^^^ defined(__clang__) / !defined(__clang__) vvv
 static_assert(g.column() == 37);
+#endif // ^^^ !defined(__clang__) ^^^
 static_assert(g.function_name() == ""sv);
 static_assert(string_view{g.file_name()}.ends_with(test_cpp));
 
@@ -49,7 +53,11 @@ constexpr void copy_test() {
 constexpr void local_test() {
     const auto x = source_location::current();
     assert(x.line() == __LINE__ - 1);
+#ifdef __clang__
+    assert(x.column() == 20);
+#else // ^^^ defined(__clang__) / !defined(__clang__) vvv
     assert(x.column() == 37);
+#endif // ^^^ !defined(__clang__) ^^^
 #if defined(__clang__) || defined(__EDG__) // TRANSITION, DevCom-10199227 and LLVM-58951
     assert(x.function_name() == "local_test"sv);
 #else // ^^^ workaround / no workaround vvv
@@ -135,8 +143,13 @@ constexpr void lambda_test() {
     const auto x2 = l2();
     assert(x1.line() == __LINE__ - 4);
     assert(x2.line() == __LINE__ - 4);
+#ifdef __clang__
+    assert(x1.column() == 28);
+    assert(x2.column() == 33);
+#else // ^^^ defined(__clang__) / !defined(__clang__) vvv
     assert(x1.column() == 52);
     assert(x2.column() == 50);
+#endif // ^^^ !defined(__clang__) ^^^
 #if defined(__clang__) || defined(__EDG__) // TRANSITION, DevCom-10199227 and LLVM-58951
     assert(x1.function_name() == "lambda_test"sv);
     assert(x2.function_name() == "operator()"sv);
@@ -162,7 +175,11 @@ constexpr source_location function_template() {
 constexpr void function_template_test() {
     const auto x1 = function_template<void>();
     assert(x1.line() == __LINE__ - 5);
+#ifdef __clang__
+    assert(x1.column() == 12);
+#else // ^^^ defined(__clang__) / !defined(__clang__) vvv
     assert(x1.column() == 29);
+#endif // ^^^ !defined(__clang__) ^^^
 #if defined(__clang__) || defined(__EDG__) // TRANSITION, DevCom-10199227 and LLVM-58951
     assert(x1.function_name() == "function_template"sv);
 #else // ^^^ workaround / no workaround vvv
@@ -184,12 +201,21 @@ constexpr void function_template_test() {
 constexpr bool test() {
     copy_test();
     local_test();
+#ifndef __clang__ // TRANSITION, LLVM-56379
     argument_test(__LINE__, 5);
+#endif // __clang__
+#ifdef __clang__
+    const auto loc = source_location::current();
+    argument_test(__LINE__ - 1, 22, loc);
+#else // ^^^ defined(__clang__) / !defined(__clang__)
     const auto loc = source_location::current();
     argument_test(__LINE__ - 1, 39, loc);
+#endif // ^^^ !defined(__clang__) ^^^
+#ifndef __clang__ // TRANSITION, LLVM-56379
     sloc_constructor_test();
     different_constructor_test();
     sub_member_test();
+#endif // __clang__
     lambda_test();
     function_template_test();
     header_test();

--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
@@ -1954,7 +1954,7 @@ STATIC_ASSERT(__cpp_lib_smart_ptr_for_overwrite == 202002L);
 #endif
 #endif
 
-#if _HAS_CXX20 && defined(__cpp_consteval)
+#if _HAS_CXX20
 #ifndef __cpp_lib_source_location
 #error __cpp_lib_source_location is not defined
 #elif __cpp_lib_source_location != 201907L


### PR DESCRIPTION
And enable support for `source_location` for Clang.

I've observed that there're already some unprotected uses of `consteval` in C++20/23 modes, which should have proved that `consteval` gets well with MSVC and Clang. EDG is not well tested, but it is [claimed](https://docs.google.com/spreadsheets/d/1H-aqjzVI2a-XQKGtw0xaS0tyjD0FcoQP8ttJI9JZQTc) that immediate functions are supported since 5.1. So I think `consteval` is also well supported.

I think `_CONSTEVAL` is still useful since there may be some other candidate functions for `_CONSTEVAL` that are needed for pre-C++20.

After this change, there'll be only one occurrence of `_CONSTEVAL`, which is in `<random>`:
https://github.com/microsoft/STL/blob/5116678ea11245b232a6e43824aad25fb60b9c6e/stl/inc/random#L1002

----
Edit:
- It seems that Clang15 doesn't define `__cpp_consteval` but accepts `consteval` without error.
- I have to address the (possibly reasonable) implementation divergence on `__builtin_COLUMN()`.
  - The results of `__builtin_COLUMN()` seem unchanged between Clang15 and 17 ([Godbolt link](https://godbolt.org/z/scoW9K69T)).