### PR TITLE
Fix CodeQL warnings, part 2

### DIFF
--- a/stl/inc/xbit_ops.h
+++ b/stl/inc/xbit_ops.h
@@ -39,9 +39,9 @@ _NODISCARD inline unsigned long _Floor_of_log_2(size_t _Value) noexcept { // ret
 
 #else // ^^^ _M_CEE_PURE / !_M_CEE_PURE vvv
 #ifdef _WIN64
-    _BitScanReverse64(&_Result, _Value);
+    _BitScanReverse64(&_Result, _Value); // lgtm [cpp/conditionallyuninitializedvariable]
 #else // ^^^ 64-bit / 32-bit vvv
-    _BitScanReverse(&_Result, _Value);
+    _BitScanReverse(&_Result, _Value); // lgtm [cpp/conditionallyuninitializedvariable]
 #endif // 64 vs. 32-bit
 #endif // _M_CEE_PURE
 

--- a/stl/inc/xtimec.h
+++ b/stl/inc/xtimec.h
@@ -25,10 +25,13 @@ struct xtime { // store time with nanosecond resolution
     long nsec;
 };
 
-_CRTIMP2_PURE int __cdecl xtime_get(xtime*, int);
-
 _CRTIMP2_PURE long __cdecl _Xtime_diff_to_millis2(const xtime*, const xtime*);
 _CRTIMP2_PURE long long __cdecl _Xtime_get_ticks();
+
+#ifdef _CRTBLD
+// Used by several src files, but not dllexported.
+void _Xtime_get2(xtime*);
+#endif // _CRTBLD
 
 _CRTIMP2_PURE long long __cdecl _Query_perf_counter();
 _CRTIMP2_PURE long long __cdecl _Query_perf_frequency();

--- a/stl/src/cond.cpp
+++ b/stl/src/cond.cpp
@@ -69,10 +69,10 @@ int _Cnd_timedwait(const _Cnd_t cond, const _Mtx_t mtx, const xtime* const targe
         _Mtx_reset_owner(mtx);
     } else { // target time specified, wait for it
         xtime now;
-        xtime_get(&now, TIME_UTC);
+        _Xtime_get2(&now);
         _Mtx_clear_owner(mtx);
         if (!cond->_get_cv()->wait_for(cs, _Xtime_diff_to_millis2(target, &now))) { // report timeout
-            xtime_get(&now, TIME_UTC);
+            _Xtime_get2(&now);
             if (_Xtime_diff_to_millis2(target, &now) == 0) {
                 res = _Thrd_timedout;
             }

--- a/stl/src/cthread.cpp
+++ b/stl/src/cthread.cpp
@@ -74,10 +74,10 @@ int _Thrd_detach(_Thrd_t thr) { // tell OS to release thread's resources when it
 
 void _Thrd_sleep(const xtime* xt) { // suspend thread until time xt
     xtime now;
-    xtime_get(&now, TIME_UTC);
+    _Xtime_get2(&now);
     do { // sleep and check time
         Sleep(_Xtime_diff_to_millis2(xt, &now));
-        xtime_get(&now, TIME_UTC);
+        _Xtime_get2(&now);
     } while (now.sec < xt->sec || now.sec == xt->sec && now.nsec < xt->nsec);
 }
 

--- a/stl/src/mutex.cpp
+++ b/stl/src/mutex.cpp
@@ -116,7 +116,7 @@ static int mtx_do_lock(_Mtx_t mtx, const xtime* target) { // lock mutex
 
         } else { // check timeout
             xtime now;
-            xtime_get(&now, TIME_UTC);
+            _Xtime_get2(&now);
             while (now.sec < target->sec || now.sec == target->sec && now.nsec < target->nsec) { // time has not expired
                 if (mtx->thread_id == static_cast<long>(GetCurrentThreadId())
                     || mtx->_get_cs()->try_lock_for(_Xtime_diff_to_millis2(target, &now))) { // stop waiting
@@ -126,7 +126,7 @@ static int mtx_do_lock(_Mtx_t mtx, const xtime* target) { // lock mutex
                     res = WAIT_TIMEOUT;
                 }
 
-                xtime_get(&now, TIME_UTC);
+                _Xtime_get2(&now);
             }
         }
 

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -1245,7 +1245,7 @@ namespace {
             _Bingo &= _Mask;
             if (_Bingo != 0) {
                 unsigned long _Offset;
-                _BitScanForward(&_Offset, _Bingo);
+                _BitScanForward(&_Offset, _Bingo); // lgtm [cpp/conditionallyuninitializedvariable]
                 _Advance_bytes(_First, _Offset);
                 return _First;
             }
@@ -1256,7 +1256,7 @@ namespace {
 
                 if (_Bingo != 0) {
                     unsigned long _Offset;
-                    _BitScanForward(&_Offset, _Bingo);
+                    _BitScanForward(&_Offset, _Bingo); // lgtm [cpp/conditionallyuninitializedvariable]
                     _Advance_bytes(_First, _Offset);
                     return _First;
                 }
@@ -1303,7 +1303,7 @@ namespace {
 
                 if (_Bingo != 0) {
                     unsigned long _Offset;
-                    _BitScanForward(&_Offset, _Bingo);
+                    _BitScanForward(&_Offset, _Bingo); // lgtm [cpp/conditionallyuninitializedvariable]
                     _Advance_bytes(_First, _Offset);
                     return _First;
                 }

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -879,7 +879,10 @@ namespace {
                             // Select the smallest vertical indices from the smallest element mask
                             _Mask &= _mm_movemask_epi8(_Traits::_Cmp_eq(_Idx_min, _Idx_min_val));
                             unsigned long _H_pos;
-                            _BitScanForward(&_H_pos, _Mask); // Find the smallest horizontal index
+
+                            // Find the smallest horizontal index
+                            _BitScanForward(&_H_pos, _Mask); // lgtm [cpp/conditionallyuninitializedvariable]
+
                             const auto _V_pos = _Traits::_Get_v_pos(_Cur_idx_min, _H_pos); // Extract its vertical index
                             _Res._Min         = _Base + _V_pos * 16 + _H_pos; // Finally, compute the pointer
                         }
@@ -908,7 +911,10 @@ namespace {
                                 const __m128i _Idx_max = _Traits::_H_max_u(_Idx_max_val); // The greatest indices
                                 // Select the greatest vertical indices from the largest element mask
                                 _Mask &= _mm_movemask_epi8(_Traits::_Cmp_eq(_Idx_max, _Idx_max_val));
-                                _BitScanReverse(&_H_pos, _Mask); // Find the largest horizontal index
+
+                                // Find the largest horizontal index
+                                _BitScanReverse(&_H_pos, _Mask); // lgtm [cpp/conditionallyuninitializedvariable]
+
                                 _H_pos -= sizeof(_Cur_max_val) - 1; // Correct from highest val bit to lowest
                             } else {
                                 // Looking for the first occurrence of maximum
@@ -918,7 +924,9 @@ namespace {
                                 const __m128i _Idx_max     = _Traits::_H_min_u(_Idx_max_val); // The smallest indices
                                 // Select the smallest vertical indices from the largest element mask
                                 _Mask &= _mm_movemask_epi8(_Traits::_Cmp_eq(_Idx_max, _Idx_max_val));
-                                _BitScanForward(&_H_pos, _Mask); // Find the smallest horizontal index
+
+                                // Find the smallest horizontal index
+                                _BitScanForward(&_H_pos, _Mask); // lgtm [cpp/conditionallyuninitializedvariable]
                             }
 
                             const auto _V_pos = _Traits::_Get_v_pos(_Cur_idx_max, _H_pos); // Extract its vertical index

--- a/stl/src/vector_algorithms.cpp
+++ b/stl/src/vector_algorithms.cpp
@@ -1206,7 +1206,8 @@ namespace {
             __m256i _Data       = _mm256_load_si256(static_cast<const __m256i*>(_First));
             unsigned int _Bingo = static_cast<unsigned int>(_mm256_movemask_epi8(_Traits::_Cmp_avx(_Data, _Comparand)));
 
-            if ((_Bingo &= _Mask) != 0) {
+            _Bingo &= _Mask;
+            if (_Bingo != 0) {
                 unsigned long _Offset = _tzcnt_u32(_Bingo);
                 _Advance_bytes(_First, _Offset);
                 return _First;
@@ -1241,7 +1242,8 @@ namespace {
             __m128i _Data       = _mm_load_si128(static_cast<const __m128i*>(_First));
             unsigned int _Bingo = static_cast<unsigned int>(_mm_movemask_epi8(_Traits::_Cmp_sse(_Data, _Comparand)));
 
-            if ((_Bingo &= _Mask) != 0) {
+            _Bingo &= _Mask;
+            if (_Bingo != 0) {
                 unsigned long _Offset;
                 _BitScanForward(&_Offset, _Bingo);
                 _Advance_bytes(_First, _Offset);

--- a/stl/src/xtime.cpp
+++ b/stl/src/xtime.cpp
@@ -53,7 +53,8 @@ _CRTIMP2_PURE long long __cdecl _Xtime_get_ticks() { // get system time in 100-n
     return ((static_cast<long long>(ft.dwHighDateTime)) << 32) + static_cast<long long>(ft.dwLowDateTime) - _Epoch;
 }
 
-static void sys_get_time(xtime* xt) { // get system time with nanosecond resolution
+// Used by several src files, but not dllexported.
+void _Xtime_get2(xtime* xt) { // get system time with nanosecond resolution
     unsigned long long now = _Xtime_get_ticks();
     xt->sec                = static_cast<__time64_t>(now / _Nsec100_per_sec);
     xt->nsec               = static_cast<long>(now % _Nsec100_per_sec) * 100;
@@ -67,15 +68,16 @@ _CRTIMP2_PURE long __cdecl _Xtime_diff_to_millis2(const xtime* xt1, const xtime*
 // TRANSITION, ABI: preserved for binary compatibility
 _CRTIMP2_PURE long __cdecl _Xtime_diff_to_millis(const xtime* xt) { // convert time to milliseconds
     xtime now;
-    xtime_get(&now, TIME_UTC);
+    _Xtime_get2(&now);
     return _Xtime_diff_to_millis2(xt, &now);
 }
 
+// TRANSITION, ABI: preserved for binary compatibility
 _CRTIMP2_PURE int __cdecl xtime_get(xtime* xt, int type) { // get current time
     if (type != TIME_UTC || xt == nullptr) {
         type = 0;
     } else {
-        sys_get_time(xt);
+        _Xtime_get2(xt);
     }
 
     return type;


### PR DESCRIPTION
Part 1: #3489

CodeQL is emitting more warnings in the STL's separately compiled sources, resulting in the automatic creation of high-priority bugs in the internal database.

This PR introduces no behavioral changes, nor does it affect the STL's dllexports.

`xtime_get`
===
* Fix `xtime_get` CodeQL warnings.
  + Bugs: VSO-1773907, VSO-1773908, VSO-1773909, VSO-1773910
  + This is the `[cpp/conditionallyuninitializedvariable]` warning:
    > The status of this call to `xtime_get` is not checked, potentially leaving `now` uninitialized.

This is the most interesting one. We never documented or supported the non-Standard `xtime` API (and we really should get rid of these non-Standard identifiers someday). All of our calls to `xtime_get` are in `src`, and all of them are exactly `xtime_get(&now, TIME_UTC)`. In this case, it always succeeds and calls the `static` helper `sys_get_time`. So, we can clean up this code and eradicate all occurrences of this warning.

* In `inc/xtimec.h`, we're going to drop the declaration of `xtime_get`. This is paired with marking the definition in `src/xtime.cpp` as preserved for bincompat.
  + As recently seen in #3532, this does **not** affect the dllexport surface, because the declaration and the definition match (specifically `_CRTIMP2_PURE` and `__cdecl`).
  + This prevents both users and other STL TUs from seeing this non-Standard API that's likely to make CodeQL unhappy.
* Then, `inc/xtimec.h` declares `_Xtime_get2`, but only when building the STL. (This is because we don't have any convenient header in `src` that's dragged in by the relevant TUs.)
  + As the comment explains, this declaration lacks `_CRTIMP2_PURE` and `__cdecl` because it is **not** dllexported - it allows STL TUs to call a function defined in another STL TU, but it isn't for users to interact with. (The `_Ugly` name will have external linkage when static linking, but is unobservable to users.)
* All usage is mechanically converted to the simpler function.
* Finally, `src/xtime.cpp` changes the `static` helper `sys_get_time` (unobservable by all other TUs) into the `_Xtime_get2` helper (for STL TUs), with the same comment.

`<xbit_ops.h>`
===
* Silence `<xbit_ops.h>` CodeQL warnings.
  + Bug: VSO-1772889
  + This is the `[cpp/conditionallyuninitializedvariable]` warning:
    > The status of this call to externally defined (SAL) `_BitScanReverse` is not checked, potentially leaving `_Result` uninitialized.
  + This code is safe because `_Floor_of_log_2()` begins with:
    ```cpp
    _Value |= size_t{1}; // avoid undefined answer from _BitScanReverse for 0
    ```

`vector_algorithms.cpp`
===
* Cleanup: Perform compound assignments before `if`-statements.
  + In modern code, we conventionally avoid mixing mutation and branching. This separation makes `if (_Bingo != 0)` easier to see in the following change:
* Silence `vector_algorithms.cpp` CodeQL warnings.
  + Bugs: VSO-1772915, VSO-1772918, VSO-1772919
  + This is the `[cpp/conditionallyuninitializedvariable]` warning:
    > The status of this call to externally defined (SAL) `_BitScanForward` is not checked, potentially leaving `_Offset` uninitialized.
  + This code is safe because each callsite has tested `if (_Bingo != 0)`.
* Silence more `vector_algorithms.cpp` CodeQL warnings.
  + Bugs: VSO-1772995, VSO-1772900, VSO-1772896
  + These `[cpp/conditionallyuninitializedvariable]` warnings are of the form:
    > The status of this call to externally defined (SAL) `_BitScanReverse` is not checked, potentially leaving `_H_pos` uninitialized.
  + We're looking for a known element in these vector registers, so we have a guarantee that `_Mask` is non-zero and therefore `_H_pos` is always initialized.
