### PR TITLE
Implement LWG-3836 `std::expected<bool, E1>` conversion constructor `expected(const expected<U, G>&)` should take precedence over `expected(U&&)` with `operator bool`

### DIFF
--- a/stl/inc/expected
+++ b/stl/inc/expected
@@ -238,14 +238,15 @@ public:
     // clang-format on
 
     template <class _Uty, class _UErr>
-    static constexpr bool _Allow_unwrapping = !is_constructible_v<_Ty, expected<_Uty, _UErr>&> //
-                                           && !is_constructible_v<_Ty, expected<_Uty, _UErr>> //
-                                           && !is_constructible_v<_Ty, const expected<_Uty, _UErr>&> //
-                                           && !is_constructible_v<_Ty, const expected<_Uty, _UErr>> //
-                                           && !is_convertible_v<expected<_Uty, _UErr>&, _Ty> //
-                                           && !is_convertible_v<expected<_Uty, _UErr>&&, _Ty> //
-                                           && !is_convertible_v<const expected<_Uty, _UErr>&, _Ty> //
-                                           && !is_convertible_v<const expected<_Uty, _UErr>&&, _Ty> //
+    static constexpr bool _Allow_unwrapping = disjunction_v<is_same<remove_cv_t<_Ty>, bool>,
+                                                  negation<disjunction<is_constructible<_Ty, expected<_Uty, _UErr>&>, //
+                                                      is_constructible<_Ty, expected<_Uty, _UErr>>, //
+                                                      is_constructible<_Ty, const expected<_Uty, _UErr>&>, //
+                                                      is_constructible<_Ty, const expected<_Uty, _UErr>>, //
+                                                      is_convertible<expected<_Uty, _UErr>&, _Ty>, //
+                                                      is_convertible<expected<_Uty, _UErr>&&, _Ty>, //
+                                                      is_convertible<const expected<_Uty, _UErr>&, _Ty>, //
+                                                      is_convertible<const expected<_Uty, _UErr>&&, _Ty>>>> //
                                            && !is_constructible_v<unexpected<_Err>, expected<_Uty, _UErr>&> //
                                            && !is_constructible_v<unexpected<_Err>, expected<_Uty, _UErr>> //
                                            && !is_constructible_v<unexpected<_Err>, const expected<_Uty, _UErr>&> //
@@ -280,7 +281,9 @@ public:
 
     template <class _Uty = _Ty>
         requires (!is_same_v<remove_cvref_t<_Uty>, in_place_t> && !is_same_v<remove_cvref_t<_Uty>, expected>
-                     && !_Is_specialization_v<remove_cvref_t<_Uty>, unexpected> && is_constructible_v<_Ty, _Uty>)
+                     && !_Is_specialization_v<remove_cvref_t<_Uty>, unexpected>
+                     && (!is_same_v<remove_cv_t<_Ty>, bool> || !_Is_specialization_v<remove_cvref_t<_Uty>, expected>)
+                     && is_constructible_v<_Ty, _Uty>)
     constexpr explicit(!is_convertible_v<_Uty, _Ty>)
         expected(_Uty&& _Other) noexcept(is_nothrow_constructible_v<_Ty, _Uty>) // strengthened
         : _Value(_STD forward<_Uty>(_Other)), _Has_value(true) {}

--- a/stl/inc/optional
+++ b/stl/inc/optional
@@ -239,7 +239,9 @@ public:
 
     template <class _Ty2>
     using _AllowDirectConversion = bool_constant<conjunction_v<negation<is_same<_Remove_cvref_t<_Ty2>, optional>>,
-        negation<is_same<_Remove_cvref_t<_Ty2>, in_place_t>>, is_constructible<_Ty, _Ty2>>>;
+        negation<is_same<_Remove_cvref_t<_Ty2>, in_place_t>>,
+        negation<conjunction<is_same<remove_cv_t<_Ty>, bool>, _Is_specialization<_Remove_cvref_t<_Ty2>, optional>>>,
+        is_constructible<_Ty, _Ty2>>>;
 
     template <class _Ty2 = _Ty, enable_if_t<_AllowDirectConversion<_Ty2>::value, int> = 0>
     constexpr explicit(!is_convertible_v<_Ty2, _Ty>)
@@ -247,11 +249,13 @@ public:
         : _Mybase(in_place, _STD forward<_Ty2>(_Right)) {}
 
     template <class _Ty2>
-    struct _AllowUnwrapping : bool_constant<!disjunction_v<is_same<_Ty, _Ty2>, is_constructible<_Ty, optional<_Ty2>&>,
-                                  is_constructible<_Ty, const optional<_Ty2>&>,
-                                  is_constructible<_Ty, const optional<_Ty2>>, is_constructible<_Ty, optional<_Ty2>>,
-                                  is_convertible<optional<_Ty2>&, _Ty>, is_convertible<const optional<_Ty2>&, _Ty>,
-                                  is_convertible<const optional<_Ty2>, _Ty>, is_convertible<optional<_Ty2>, _Ty>>> {};
+    struct _AllowUnwrapping
+        : bool_constant<disjunction_v<is_same<remove_cv_t<_Ty>, bool>,
+              negation<disjunction<is_same<_Ty, _Ty2>, is_constructible<_Ty, optional<_Ty2>&>,
+                  is_constructible<_Ty, const optional<_Ty2>&>, is_constructible<_Ty, const optional<_Ty2>>,
+                  is_constructible<_Ty, optional<_Ty2>>, is_convertible<optional<_Ty2>&, _Ty>,
+                  is_convertible<const optional<_Ty2>&, _Ty>, is_convertible<const optional<_Ty2>, _Ty>,
+                  is_convertible<optional<_Ty2>, _Ty>>>>> {};
 
     template <class _Ty2,
         enable_if_t<conjunction_v<_AllowUnwrapping<_Ty2>, is_constructible<_Ty, const _Ty2&>>, int> = 0>

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -120,6 +120,9 @@ std/language.support/support.limits/support.limits.general/format.version.compil
 # libc++ doesn't implement LWG-3670
 std/ranges/range.factories/range.iota.view/iterator/member_typedefs.compile.pass.cpp FAIL
 
+# libc++ doesn't implement LWG-3836
+std/utilities/expected/expected.expected/ctor/ctor.u.pass.cpp FAIL
+
 # libc++ doesn't implement LWG-3857
 std/strings/string.view/string.view.cons/from_range.pass.cpp FAIL
 std/strings/string.view/string.view.cons/from_string1.compile.fail.cpp FAIL

--- a/tests/std/tests/P0220R1_optional/test.cpp
+++ b/tests/std/tests/P0220R1_optional/test.cpp
@@ -8148,6 +8148,16 @@ namespace msvc {
         STATIC_ASSERT(!is_constructible_v<O, const in_place_t&>);
     } // namespace lwg2842
 
+    namespace lwg3836 {
+        STATIC_ASSERT(std::is_convertible_v<std::optional<int>, std::optional<bool>>);
+        STATIC_ASSERT(std::is_convertible_v<const std::optional<int>&, std::optional<bool>>);
+
+        constexpr std::optional<int> oi = 0;
+        constexpr std::optional<bool> ob = oi;
+        STATIC_ASSERT(!ob.value());
+        STATIC_ASSERT(!std::optional<bool>{std::optional<int>{0}}.value());
+    } // namespace lwg3836
+
     namespace vso406124 {
         // Defend against regression of VSO-406124
         void run_test() {

--- a/tests/std/tests/P0220R1_optional/test.cpp
+++ b/tests/std/tests/P0220R1_optional/test.cpp
@@ -8152,7 +8152,7 @@ namespace msvc {
         STATIC_ASSERT(std::is_convertible_v<std::optional<int>, std::optional<bool>>);
         STATIC_ASSERT(std::is_convertible_v<const std::optional<int>&, std::optional<bool>>);
 
-        constexpr std::optional<int> oi = 0;
+        constexpr std::optional<int> oi  = 0;
         constexpr std::optional<bool> ob = oi;
         STATIC_ASSERT(!ob.value());
         STATIC_ASSERT(!std::optional<bool>{std::optional<int>{0}}.value());

--- a/tests/std/tests/P0220R1_optional/test.cpp
+++ b/tests/std/tests/P0220R1_optional/test.cpp
@@ -8152,10 +8152,24 @@ namespace msvc {
         STATIC_ASSERT(std::is_convertible_v<std::optional<int>, std::optional<bool>>);
         STATIC_ASSERT(std::is_convertible_v<const std::optional<int>&, std::optional<bool>>);
 
-        constexpr std::optional<int> oi  = 0;
-        constexpr std::optional<bool> ob = oi;
-        STATIC_ASSERT(!ob.value());
-        STATIC_ASSERT(!std::optional<bool>{std::optional<int>{0}}.value());
+#if _HAS_CXX20
+#define CONSTEXPR20 constexpr
+#else // ^^^ _HAS_CXX20 / _HAS_CXX20 vvv
+#define CONSTEXPR20 inline
+#endif // ^^^ _HAS_CXX20 ^^^
+        CONSTEXPR20 bool run_test() {
+            std::optional<int> oi  = 0;
+            std::optional<bool> ob = oi;
+            assert(!ob.value());
+            assert(!std::optional<bool>{std::optional<int>{0}}.value());
+
+            return true;
+        }
+#undef CONSTEXPR20
+
+#if _HAS_CXX20
+        STATIC_ASSERT(run_test());
+#endif // _HAS_CXX20
     } // namespace lwg3836
 
     namespace vso406124 {
@@ -8343,6 +8357,8 @@ int main() {
     nonmembers::make_optional_explicit::run_test();
     nonmembers::make_optional_explicit_init_list::run_test();
     nonmembers::swap_::run_test();
+
+    msvc::lwg3836::run_test();
 
     msvc::vso406124::run_test();
     msvc::vso508126::run_test();

--- a/tests/std/tests/P0220R1_optional/test.cpp
+++ b/tests/std/tests/P0220R1_optional/test.cpp
@@ -8154,9 +8154,9 @@ namespace msvc {
 
 #if _HAS_CXX20
 #define CONSTEXPR20 constexpr
-#else // ^^^ _HAS_CXX20 / _HAS_CXX20 vvv
+#else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
 #define CONSTEXPR20 inline
-#endif // ^^^ _HAS_CXX20 ^^^
+#endif // ^^^ !_HAS_CXX20 ^^^
         CONSTEXPR20 bool run_test() {
             std::optional<int> oi  = 0;
             std::optional<bool> ob = oi;

--- a/tests/std/tests/P0323R12_expected/test.cpp
+++ b/tests/std/tests/P0323R12_expected/test.cpp
@@ -662,6 +662,14 @@ namespace test_expected {
         test_constructors<IsNothrowConstructible::Not, IsExplicitConstructible::Yes>();
         test_constructors<IsNothrowConstructible::Yes, IsExplicitConstructible::Not>();
         test_constructors<IsNothrowConstructible::Yes, IsExplicitConstructible::Yes>();
+
+        // LWG-3836
+        struct BaseError {};
+        struct DerivedError : BaseError {};
+
+        std::expected<bool, DerivedError> e1(false);
+        std::expected<bool, BaseError> e2(e1);
+        assert(!e2.value());
     }
 
     template <IsNothrowCopyConstructible nothrowCopyConstructible, IsNothrowMoveConstructible nothrowMoveConstructible,


### PR DESCRIPTION
Fixes #3433.