### PR TITLE
Fix modules test by using `static constexpr` arrays

### DIFF
--- a/tests/std/include/test_header_units_and_modules.hpp
+++ b/tests/std/include/test_header_units_and_modules.hpp
@@ -331,7 +331,7 @@ void test_istream() {
 void test_iterator() {
     using namespace std;
     puts("Testing <iterator>.");
-    constexpr int arr[]{10, 20, 30, 40, 50};
+    static constexpr int arr[]{10, 20, 30, 40, 50};
     constexpr reverse_iterator<const int*> ri{end(arr)};
     assert(*ri == 50);
     assert(*next(ri) == 40);
@@ -675,7 +675,7 @@ void test_source_location() {
 void test_span() {
     using namespace std;
     puts("Testing <span>.");
-    constexpr int arr[]{11, 22, 33, 44, 55};
+    static constexpr int arr[]{11, 22, 33, 44, 55};
     constexpr span<const int, 5> whole{arr};
     constexpr span<const int, 3> mid = whole.subspan<1, 3>();
     assert(mid[0] == 22 && mid[1] == 33 && mid[2] == 44);


### PR DESCRIPTION
This mirrors the library test changes from @JonCavesMSFT's MSVC-PR-460102.

In the header units and named modules test, I was unintentionally being a bad kitty :smirk_cat: and was exercising an accepts-invalid codepath in the MSVC compiler, which is now being fixed. Specifically, WG21-N4928 \[expr.const\]/12.2:

> A *constant expression* is either a glvalue core constant expression that refers to an entity that is a permitted result of a constant expression (as defined below), or a prvalue core constant expression whose value satisfies the following constraints:
> [...]
> if the value is of pointer type, it contains the address of an object with static storage duration, the address past the end of such an object (7.6.6), the address of a non-immediate function, or a null pointer value,

In my test code, I was constructing `constexpr` `reverse_iterator`s and `span`s by taking the address of a **non-`static`** `constexpr` array at function scope. This is forbidden; the array must be `static constexpr` for it to work.

With this change, the code is now conformant, and accepted by both the old and new compilers, so we can make the change simultaneously in MSVC and GitHub. Thanks Jonathan! :heart_eyes_cat:

(It's worth noting that both Clang and GCC correctly enforce this rule. However, the header units and named modules test currently runs for MSVC only, not EDG or Clang, which is why I missed this.)