### PR TITLE
Implement LWG-3887 Version macro for `allocate_at_least`

### DIFF
--- a/stl/inc/yvals_core.h
+++ b/stl/inc/yvals_core.h
@@ -1694,11 +1694,7 @@ _EMIT_STL_ERROR(STL1004, "C++98 unexpected() is incompatible with C++23 unexpect
 // C++23
 #if _HAS_CXX23
 #define __cpp_lib_adaptor_iterator_pair_constructor 202106L
-
-#ifdef __cpp_lib_concepts
-#define __cpp_lib_allocate_at_least 202106L
-#endif // __cpp_lib_concepts
-
+#define __cpp_lib_allocate_at_least                 202302L
 #define __cpp_lib_associative_heterogeneous_erasure 202110L
 #define __cpp_lib_bind_back                         202202L
 #define __cpp_lib_byteswap                          202110L

--- a/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
+++ b/tests/std/tests/VSO_0157762_feature_test_macros/test.compile.pass.cpp
@@ -42,13 +42,13 @@ STATIC_ASSERT(__cpp_lib_algorithm_iterator_requirements == 202207L);
 #endif
 #endif
 
-#if _HAS_CXX23 && defined(__cpp_lib_concepts) // TRANSITION, GH-395
+#if _HAS_CXX23
 #ifndef __cpp_lib_allocate_at_least
 #error __cpp_lib_allocate_at_least is not defined
-#elif __cpp_lib_allocate_at_least != 202106L
-#error __cpp_lib_allocate_at_least is not 202106L
+#elif __cpp_lib_allocate_at_least != 202302L
+#error __cpp_lib_allocate_at_least is not 202302L
 #else
-STATIC_ASSERT(__cpp_lib_allocate_at_least == 202106L);
+STATIC_ASSERT(__cpp_lib_allocate_at_least == 202302L);
 #endif
 #else
 #ifdef __cpp_lib_allocate_at_least


### PR DESCRIPTION
The change has been adoped into the C++ Working Draft by commit https://github.com/cplusplus/draft/commit/6e7fd98b684a92405934de981abf01414a67ddbd. However, it isn't contained in WG21-N4944. A newer WD (and perhaps the published C++23 Standard?) will contain it.

Driven-by change: concept dependency of `allocator_at_least` was removed by #3542, so the feature-test macro should also be enabled even if the concept support is absent.