### PR TITLE
Eliminate `xtime` and its member `sec`, `nsec`

### DIFF
--- a/stl/inc/__msvc_chrono.hpp
+++ b/stl/inc/__msvc_chrono.hpp
@@ -696,7 +696,7 @@ namespace chrono {
 
 template <class _Rep, class _Period>
 _NODISCARD bool _To_timespec64_sys_10_day_clamped(
-    _timespec64& _Xt, const _CHRONO duration<_Rep, _Period>& _Rel_time) noexcept(is_arithmetic_v<_Rep>) {
+    _timespec64& _Ts64, const _CHRONO duration<_Rep, _Period>& _Rel_time) noexcept(is_arithmetic_v<_Rep>) {
     // Convert duration to _timespec64 representing system time, maximum 10 days from now, returns whether clamping
     // occurred. If clamped, timeouts will be transformed into spurious non-timeout wakes, due to ABI restrictions where
     // the other side of the DLL boundary overflows int32_t milliseconds.
@@ -712,9 +712,9 @@ _NODISCARD bool _To_timespec64_sys_10_day_clamped(
     }
 
     const auto _Whole_seconds = _CHRONO duration_cast<_CHRONO seconds>(_Tx0);
-    _Xt.tv_sec                = _Whole_seconds.count();
+    _Ts64.tv_sec              = _Whole_seconds.count();
     _Tx0 -= _Whole_seconds;
-    _Xt.tv_nsec = static_cast<long>(_Tx0.count());
+    _Ts64.tv_nsec = static_cast<long>(_Tx0.count());
     return _Clamped;
 }
 

--- a/stl/inc/__msvc_chrono.hpp
+++ b/stl/inc/__msvc_chrono.hpp
@@ -695,10 +695,10 @@ namespace chrono {
 } // namespace chrono
 
 template <class _Rep, class _Period>
-_NODISCARD bool _To_xtime_10_day_clamped(_CSTD xtime& _Xt, const _CHRONO duration<_Rep, _Period>& _Rel_time) noexcept(
-    is_arithmetic_v<_Rep>) {
-    // Convert duration to xtime, maximum 10 days from now, returns whether clamping occurred.
-    // If clamped, timeouts will be transformed into spurious non-timeout wakes, due to ABI restrictions where
+_NODISCARD bool _To_timespec64_sys_10_day_clamped(
+    _timespec64& _Xt, const _CHRONO duration<_Rep, _Period>& _Rel_time) noexcept(is_arithmetic_v<_Rep>) {
+    // Convert duration to _timespec64 representing system time, maximum 10 days from now, returns whether clamping
+    // occurred. If clamped, timeouts will be transformed into spurious non-timeout wakes, due to ABI restrictions where
     // the other side of the DLL boundary overflows int32_t milliseconds.
     // Every function calling this one is TRANSITION, ABI
     constexpr _CHRONO nanoseconds _Ten_days{_CHRONO hours{24} * 10};
@@ -712,9 +712,9 @@ _NODISCARD bool _To_xtime_10_day_clamped(_CSTD xtime& _Xt, const _CHRONO duratio
     }
 
     const auto _Whole_seconds = _CHRONO duration_cast<_CHRONO seconds>(_Tx0);
-    _Xt.sec                   = _Whole_seconds.count();
+    _Xt.tv_sec                = _Whole_seconds.count();
     _Tx0 -= _Whole_seconds;
-    _Xt.nsec = static_cast<long>(_Tx0.count());
+    _Xt.tv_nsec = static_cast<long>(_Tx0.count());
     return _Clamped;
 }
 

--- a/stl/inc/condition_variable
+++ b/stl/inc/condition_variable
@@ -140,7 +140,7 @@ public:
     }
 
     template <class _Lock, class _Predicate>
-    bool wait_until(_Lock& _Lck, const _timespec64* const _Abs_time, _Predicate _Pred) {
+    bool _Wait_until_sys_time(_Lock& _Lck, const _timespec64* const _Abs_time, _Predicate _Pred) {
         // wait for signal with timeout and check predicate
         while (!_Pred()) {
             if (_Wait_until_sys_time(_Lck, _Abs_time) == cv_status::timeout) {

--- a/stl/inc/condition_variable
+++ b/stl/inc/condition_variable
@@ -139,33 +139,6 @@ public:
         return wait_until(_Lck, _To_absolute_time(_Rel_time), _STD move(_Pred));
     }
 
-    template <class _Lock, class _Predicate>
-    bool _Wait_until_sys_time(_Lock& _Lck, const _timespec64* const _Abs_time, _Predicate _Pred) {
-        // wait for signal with timeout and check predicate
-        while (!_Pred()) {
-            if (_Wait_until_sys_time(_Lck, _Abs_time) == cv_status::timeout) {
-                return _Pred();
-            }
-        }
-        return true;
-    }
-
-    // wait for signal with timeout
-    template <class _Lock>
-    cv_status _Wait_until_sys_time(_Lock& _Lck, const _timespec64* const _Abs_time) {
-        const shared_ptr<mutex> _Ptr = _Myptr; // for immunity to *this destruction
-        unique_lock<mutex> _Guard{*_Ptr};
-        _Unlock_guard<_Lock> _Unlock_outer{_Lck};
-        const int _Res = _Cnd_timedwait(_Mycnd(), _Ptr->_Mymtx(), _Abs_time);
-        _Guard.unlock();
-
-        if (_Res == _Thrd_success) {
-            return cv_status::no_timeout;
-        } else {
-            return cv_status::timeout;
-        }
-    }
-
 #if _HAS_CXX20
 private:
     struct _Cv_any_notify_all {
@@ -255,6 +228,22 @@ private:
 
     _NODISCARD _Cnd_t _Mycnd() noexcept { // get pointer to _Cnd_internal_imp_t inside _Cnd_storage
         return reinterpret_cast<_Cnd_t>(&_Cnd_storage);
+    }
+
+    template <class _Lock>
+    cv_status _Wait_until_sys_time(_Lock& _Lck, const _timespec64* const _Abs_time) {
+        // wait for signal with timeout
+        const shared_ptr<mutex> _Ptr = _Myptr; // for immunity to *this destruction
+        unique_lock<mutex> _Guard{*_Ptr};
+        _Unlock_guard<_Lock> _Unlock_outer{_Lck};
+        const int _Res = _Cnd_timedwait(_Mycnd(), _Ptr->_Mymtx(), _Abs_time);
+        _Guard.unlock();
+
+        if (_Res == _Thrd_success) {
+            return cv_status::no_timeout;
+        } else {
+            return cv_status::timeout;
+        }
     }
 };
 

--- a/stl/inc/condition_variable
+++ b/stl/inc/condition_variable
@@ -122,10 +122,10 @@ public:
         }
 
         // TRANSITION, ABI: The standard says that we should use a steady clock,
-        // but unfortunately our ABI speaks struct xtime, which is relative to the system clock.
-        _CSTD xtime _Tgt;
-        const bool _Clamped     = _To_xtime_10_day_clamped(_Tgt, _Rel_time);
-        const cv_status _Result = _Wait_until(_Lck, &_Tgt);
+        // but unfortunately our ABI relies on the system clock.
+        _timespec64 _Tgt;
+        const bool _Clamped     = _To_timespec64_sys_10_day_clamped(_Tgt, _Rel_time);
+        const cv_status _Result = _Wait_until_sys_time(_Lck, &_Tgt);
         if (_Clamped) {
             return cv_status::no_timeout;
         }
@@ -139,20 +139,31 @@ public:
         return wait_until(_Lck, _To_absolute_time(_Rel_time), _STD move(_Pred));
     }
 
-    template <class _Lock>
-    cv_status wait_until(_Lock& _Lck, const xtime* const _Abs_time) { // wait for signal with timeout
-        return _Wait_until(_Lck, _Abs_time);
-    }
-
     template <class _Lock, class _Predicate>
-    bool wait_until(_Lock& _Lck, const xtime* const _Abs_time, _Predicate _Pred) {
+    bool wait_until(_Lock& _Lck, const _timespec64* const _Abs_time, _Predicate _Pred) {
         // wait for signal with timeout and check predicate
         while (!_Pred()) {
-            if (_Wait_until(_Lck, _Abs_time) == cv_status::timeout) {
+            if (_Wait_until_sys_time(_Lck, _Abs_time) == cv_status::timeout) {
                 return _Pred();
             }
         }
         return true;
+    }
+
+    // wait for signal with timeout
+    template <class _Lock>
+    cv_status _Wait_until_sys_time(_Lock& _Lck, const _timespec64* const _Abs_time) {
+        const shared_ptr<mutex> _Ptr = _Myptr; // for immunity to *this destruction
+        unique_lock<mutex> _Guard{*_Ptr};
+        _Unlock_guard<_Lock> _Unlock_outer{_Lck};
+        const int _Res = _Cnd_timedwait(_Mycnd(), _Ptr->_Mymtx(), _Abs_time);
+        _Guard.unlock();
+
+        if (_Res == _Thrd_success) {
+            return cv_status::no_timeout;
+        } else {
+            return cv_status::timeout;
+        }
     }
 
 #if _HAS_CXX20
@@ -221,9 +232,9 @@ public:
 
             const auto _Rel_time = _Abs_time - _Now;
             // TRANSITION, ABI: The standard says that we should use a steady clock,
-            // but unfortunately our ABI speaks struct xtime, which is relative to the system clock.
-            _CSTD xtime _Tgt;
-            (void) _To_xtime_10_day_clamped(_Tgt, _Rel_time);
+            // but unfortunately our ABI relies on the system clock.
+            _timespec64 _Tgt;
+            (void) _To_timespec64_sys_10_day_clamped(_Tgt, _Rel_time);
             (void) _Cnd_timedwait(_Mycnd(), _Myptr->_Mymtx(), &_Tgt);
             _Guard_unlocks_before_locking_outer.unlock();
         } // relock
@@ -244,21 +255,6 @@ private:
 
     _NODISCARD _Cnd_t _Mycnd() noexcept { // get pointer to _Cnd_internal_imp_t inside _Cnd_storage
         return reinterpret_cast<_Cnd_t>(&_Cnd_storage);
-    }
-
-    template <class _Lock>
-    cv_status _Wait_until(_Lock& _Lck, const xtime* const _Abs_time) { // wait for signal with timeout
-        const shared_ptr<mutex> _Ptr = _Myptr; // for immunity to *this destruction
-        unique_lock<mutex> _Guard{*_Ptr};
-        _Unlock_guard<_Lock> _Unlock_outer{_Lck};
-        const int _Res = _Cnd_timedwait(_Mycnd(), _Ptr->_Mymtx(), _Abs_time);
-        _Guard.unlock();
-
-        if (_Res == _Thrd_success) {
-            return cv_status::no_timeout;
-        } else {
-            return cv_status::timeout;
-        }
     }
 };
 

--- a/stl/inc/mutex
+++ b/stl/inc/mutex
@@ -167,6 +167,10 @@ _EXPORT_STD _INLINE_VAR constexpr adopt_lock_t adopt_lock{};
 _EXPORT_STD _INLINE_VAR constexpr defer_lock_t defer_lock{};
 _EXPORT_STD _INLINE_VAR constexpr try_to_lock_t try_to_lock{};
 
+struct _Until_sys_time_tag {
+    explicit _Until_sys_time_tag() = default;
+};
+
 _EXPORT_STD template <class _Mutex>
 class unique_lock { // whizzy class with destructor that unlocks mutex
 public:
@@ -202,9 +206,9 @@ public:
 #endif // _HAS_CXX20
     }
 
-    _NODISCARD_CTOR_LOCK unique_lock(_Mutex& _Mtx, const xtime* _Abs_time)
+    _NODISCARD_CTOR_LOCK unique_lock(_Mutex& _Mtx, _Until_sys_time_tag, const _timespec64* _Abs_time)
         : _Pmtx(_STD addressof(_Mtx)), _Owns(false) { // try to lock until _Abs_time
-        _Owns = _Pmtx->try_lock_until(_Abs_time);
+        _Owns = _Pmtx->_Try_lock_until_sys_time(_Abs_time);
     }
 
     _NODISCARD_CTOR_LOCK unique_lock(unique_lock&& _Other) noexcept : _Pmtx(_Other._Pmtx), _Owns(_Other._Owns) {
@@ -264,9 +268,9 @@ public:
         return _Owns;
     }
 
-    _NODISCARD_TRY_CHANGE_STATE bool try_lock_until(const xtime* _Abs_time) {
+    _NODISCARD_TRY_CHANGE_STATE bool _Try_lock_until_sys_time(const _timespec64* _Abs_time) {
         _Validate();
-        _Owns = _Pmtx->try_lock_until(_Abs_time);
+        _Owns = _Pmtx->_Try_lock_until_sys_time(_Abs_time);
         return _Owns;
     }
 
@@ -690,10 +694,10 @@ public:
         }
 
         // TRANSITION, ABI: The standard says that we should use a steady clock,
-        // but unfortunately our ABI speaks struct xtime, which is relative to the system clock.
-        _CSTD xtime _Tgt;
-        const bool _Clamped     = _To_xtime_10_day_clamped(_Tgt, _Rel_time);
-        const cv_status _Result = wait_until(_Lck, &_Tgt);
+        // but unfortunately our ABI relies on the system clock.
+        _timespec64 _Tgt;
+        const bool _Clamped     = _To_timespec64_sys_10_day_clamped(_Tgt, _Rel_time);
+        const cv_status _Result = _Wait_until_sys_time(_Lck, &_Tgt);
         if (_Clamped) {
             return cv_status::no_timeout;
         }
@@ -719,9 +723,9 @@ public:
                 return cv_status::timeout;
             }
 
-            _CSTD xtime _Tgt;
-            (void) _To_xtime_10_day_clamped(_Tgt, _Abs_time - _Now);
-            const cv_status _Result = wait_until(_Lck, &_Tgt);
+            _timespec64 _Tgt;
+            (void) _To_timespec64_sys_10_day_clamped(_Tgt, _Abs_time - _Now);
+            const cv_status _Result = _Wait_until_sys_time(_Lck, &_Tgt);
             if (_Result == cv_status::no_timeout) {
                 return cv_status::no_timeout;
             }
@@ -738,7 +742,7 @@ public:
         return _Wait_until1(_Lck, _Abs_time, _Pred);
     }
 
-    cv_status wait_until(unique_lock<mutex>& _Lck, const xtime* _Abs_time) {
+    cv_status _Wait_until_sys_time(unique_lock<mutex>& _Lck, const _timespec64* _Abs_time) {
         // wait for signal with timeout
         if (!_Mtx_current_owns(_Lck.mutex()->_Mymtx())) {
             _Throw_Cpp_error(_OPERATION_NOT_PERMITTED);
@@ -755,7 +759,7 @@ public:
     }
 
     template <class _Predicate>
-    bool wait_until(unique_lock<mutex>& _Lck, const xtime* _Abs_time, _Predicate _Pred) {
+    bool _Wait_until_sys_time(unique_lock<mutex>& _Lck, const _timespec64* _Abs_time, _Predicate _Pred) {
         // wait for signal with timeout and check predicate
         return _Wait_until1(_Lck, _Abs_time, _Pred);
     }
@@ -780,10 +784,10 @@ private:
     }
 
     template <class _Predicate>
-    bool _Wait_until1(unique_lock<mutex>& _Lck, const xtime* _Abs_time, _Predicate& _Pred) {
+    bool _Wait_until1(unique_lock<mutex>& _Lck, const _timespec64* _Abs_time, _Predicate& _Pred) {
         // wait for signal with timeout and check predicate
         while (!_Pred()) {
-            if (wait_until(_Lck, _Abs_time) == cv_status::timeout) {
+            if (_Wait_until_sys_time(_Lck, _Abs_time) == cv_status::timeout) {
                 return _Pred();
             }
         }
@@ -800,9 +804,9 @@ private:
                 return false;
             }
 
-            _CSTD xtime _Tgt;
-            const bool _Clamped = _To_xtime_10_day_clamped(_Tgt, _Abs_time - _Now);
-            if (wait_until(_Lck, &_Tgt) == cv_status::timeout && !_Clamped) {
+            _timespec64 _Tgt;
+            const bool _Clamped = _To_timespec64_sys_10_day_clamped(_Tgt, _Abs_time - _Now);
+            if (_Wait_until_sys_time(_Lck, &_Tgt) == cv_status::timeout && !_Clamped) {
                 return _Pred();
             }
         }
@@ -863,8 +867,14 @@ public:
     template <class _Time>
     bool _Try_lock_until(_Time _Abs_time) { // try to lock the mutex with timeout
         unique_lock<mutex> _Lock(_My_mutex);
-        if (!_My_cond.wait_until(_Lock, _Abs_time, _UInt_is_zero{_My_locked})) {
-            return false;
+        if constexpr (is_same_v<_Time, const _timespec64*>) {
+            if (!_My_cond._Wait_until_sys_time(_Lock, _Abs_time, _UInt_is_zero{_My_locked})) {
+                return false;
+            }
+        } else {
+            if (!_My_cond.wait_until(_Lock, _Abs_time, _UInt_is_zero{_My_locked})) {
+                return false;
+            }
         }
 
         _My_locked = UINT_MAX;
@@ -880,7 +890,8 @@ public:
         return _Try_lock_until(_Abs_time);
     }
 
-    _NODISCARD_TRY_CHANGE_STATE bool try_lock_until(const xtime* _Abs_time) { // try to lock the mutex with timeout
+    // try to lock the mutex with timeout
+    _NODISCARD_TRY_CHANGE_STATE bool _Try_lock_until_sys_time(const _timespec64* _Abs_time) {
         return _Try_lock_until(_Abs_time);
     }
 
@@ -978,8 +989,14 @@ public:
                 return false;
             }
         } else {
-            if (!_My_cond.wait_until(_Lock, _Abs_time, _UInt_is_zero{_My_locked})) {
-                return false;
+            if constexpr (is_same_v<_Time, const _timespec64*>) {
+                if (!_My_cond._Wait_until_sys_time(_Lock, _Abs_time, _UInt_is_zero{_My_locked})) {
+                    return false;
+                }
+            } else {
+                if (!_My_cond.wait_until(_Lock, _Abs_time, _UInt_is_zero{_My_locked})) {
+                    return false;
+                }
             }
 
             _My_locked = 1;
@@ -997,7 +1014,8 @@ public:
         return _Try_lock_until(_Abs_time);
     }
 
-    _NODISCARD_TRY_CHANGE_STATE bool try_lock_until(const xtime* _Abs_time) { // try to lock the mutex with timeout
+    // try to lock the mutex with timeout
+    _NODISCARD_TRY_CHANGE_STATE bool _Try_lock_until_sys_time(const _timespec64* _Abs_time) {
         return _Try_lock_until(_Abs_time);
     }
 

--- a/stl/inc/mutex
+++ b/stl/inc/mutex
@@ -167,10 +167,6 @@ _EXPORT_STD _INLINE_VAR constexpr adopt_lock_t adopt_lock{};
 _EXPORT_STD _INLINE_VAR constexpr defer_lock_t defer_lock{};
 _EXPORT_STD _INLINE_VAR constexpr try_to_lock_t try_to_lock{};
 
-struct _Until_sys_time_tag {
-    explicit _Until_sys_time_tag() = default;
-};
-
 _EXPORT_STD template <class _Mutex>
 class unique_lock { // whizzy class with destructor that unlocks mutex
 public:
@@ -204,11 +200,6 @@ public:
 #if _HAS_CXX20
         static_assert(chrono::is_clock_v<_Clock>, "Clock type required");
 #endif // _HAS_CXX20
-    }
-
-    _NODISCARD_CTOR_LOCK unique_lock(_Mutex& _Mtx, _Until_sys_time_tag, const _timespec64* _Abs_time)
-        : _Pmtx(_STD addressof(_Mtx)), _Owns(false) { // try to lock until _Abs_time
-        _Owns = _Pmtx->_Try_lock_until_sys_time(_Abs_time);
     }
 
     _NODISCARD_CTOR_LOCK unique_lock(unique_lock&& _Other) noexcept : _Pmtx(_Other._Pmtx), _Owns(_Other._Owns) {
@@ -265,12 +256,6 @@ public:
 #endif // _HAS_CXX20
         _Validate();
         _Owns = _Pmtx->try_lock_until(_Abs_time);
-        return _Owns;
-    }
-
-    _NODISCARD_TRY_CHANGE_STATE bool _Try_lock_until_sys_time(const _timespec64* _Abs_time) {
-        _Validate();
-        _Owns = _Pmtx->_Try_lock_until_sys_time(_Abs_time);
         return _Owns;
     }
 
@@ -742,28 +727,6 @@ public:
         return _Wait_until1(_Lck, _Abs_time, _Pred);
     }
 
-    cv_status _Wait_until_sys_time(unique_lock<mutex>& _Lck, const _timespec64* _Abs_time) {
-        // wait for signal with timeout
-        if (!_Mtx_current_owns(_Lck.mutex()->_Mymtx())) {
-            _Throw_Cpp_error(_OPERATION_NOT_PERMITTED);
-        }
-
-        // Nothing to do to comply with LWG-2135 because std::mutex lock/unlock are nothrow
-        const int _Res = _Cnd_timedwait(_Mycnd(), _Lck.mutex()->_Mymtx(), _Abs_time);
-
-        if (_Res == _Thrd_success) {
-            return cv_status::no_timeout;
-        } else {
-            return cv_status::timeout;
-        }
-    }
-
-    template <class _Predicate>
-    bool _Wait_until_sys_time(unique_lock<mutex>& _Lck, const _timespec64* _Abs_time, _Predicate _Pred) {
-        // wait for signal with timeout and check predicate
-        return _Wait_until1(_Lck, _Abs_time, _Pred);
-    }
-
     _NODISCARD native_handle_type native_handle() noexcept /* strengthened */ {
         return _Mycnd();
     }
@@ -781,6 +744,22 @@ private:
 
     _Cnd_t _Mycnd() noexcept { // get pointer to _Cnd_internal_imp_t inside _Cnd_storage
         return reinterpret_cast<_Cnd_t>(&_Cnd_storage);
+    }
+
+    cv_status _Wait_until_sys_time(unique_lock<mutex>& _Lck, const _timespec64* _Abs_time) {
+        // wait for signal with timeout
+        if (!_Mtx_current_owns(_Lck.mutex()->_Mymtx())) {
+            _Throw_Cpp_error(_OPERATION_NOT_PERMITTED);
+        }
+
+        // Nothing to do to comply with LWG-2135 because std::mutex lock/unlock are nothrow
+        const int _Res = _Cnd_timedwait(_Mycnd(), _Lck.mutex()->_Mymtx(), _Abs_time);
+
+        if (_Res == _Thrd_success) {
+            return cv_status::no_timeout;
+        } else {
+            return cv_status::timeout;
+        }
     }
 
     template <class _Predicate>
@@ -867,14 +846,8 @@ public:
     template <class _Time>
     bool _Try_lock_until(_Time _Abs_time) { // try to lock the mutex with timeout
         unique_lock<mutex> _Lock(_My_mutex);
-        if constexpr (is_same_v<_Time, const _timespec64*>) {
-            if (!_My_cond._Wait_until_sys_time(_Lock, _Abs_time, _UInt_is_zero{_My_locked})) {
-                return false;
-            }
-        } else {
-            if (!_My_cond.wait_until(_Lock, _Abs_time, _UInt_is_zero{_My_locked})) {
-                return false;
-            }
+        if (!_My_cond.wait_until(_Lock, _Abs_time, _UInt_is_zero{_My_locked})) {
+            return false;
         }
 
         _My_locked = UINT_MAX;
@@ -887,11 +860,6 @@ public:
 #if _HAS_CXX20
         static_assert(chrono::is_clock_v<_Clock>, "Clock type required");
 #endif // _HAS_CXX20
-        return _Try_lock_until(_Abs_time);
-    }
-
-    // try to lock the mutex with timeout
-    _NODISCARD_TRY_CHANGE_STATE bool _Try_lock_until_sys_time(const _timespec64* _Abs_time) {
         return _Try_lock_until(_Abs_time);
     }
 
@@ -989,14 +957,8 @@ public:
                 return false;
             }
         } else {
-            if constexpr (is_same_v<_Time, const _timespec64*>) {
-                if (!_My_cond._Wait_until_sys_time(_Lock, _Abs_time, _UInt_is_zero{_My_locked})) {
-                    return false;
-                }
-            } else {
-                if (!_My_cond.wait_until(_Lock, _Abs_time, _UInt_is_zero{_My_locked})) {
-                    return false;
-                }
+            if (!_My_cond.wait_until(_Lock, _Abs_time, _UInt_is_zero{_My_locked})) {
+                return false;
             }
 
             _My_locked = 1;
@@ -1011,11 +973,6 @@ public:
 #if _HAS_CXX20
         static_assert(chrono::is_clock_v<_Clock>, "Clock type required");
 #endif // _HAS_CXX20
-        return _Try_lock_until(_Abs_time);
-    }
-
-    // try to lock the mutex with timeout
-    _NODISCARD_TRY_CHANGE_STATE bool _Try_lock_until_sys_time(const _timespec64* _Abs_time) {
         return _Try_lock_until(_Abs_time);
     }
 

--- a/stl/inc/shared_mutex
+++ b/stl/inc/shared_mutex
@@ -172,14 +172,8 @@ public:
 
         unique_lock<mutex> _Lock(_Mymtx);
 
-        if constexpr (is_same_v<_Time, const _timespec64*>) {
-            if (!_Write_queue._Wait_until_sys_time(_Lock, _Abs_time, _Can_acquire)) {
-                return false;
-            }
-        } else {
-            if (!_Write_queue.wait_until(_Lock, _Abs_time, _Can_acquire)) {
-                return false;
-            }
+        if (!_Write_queue.wait_until(_Lock, _Abs_time, _Can_acquire)) {
+            return false;
         }
 
         ++_Readers;
@@ -192,11 +186,6 @@ public:
 #if _HAS_CXX20
         static_assert(chrono::is_clock_v<_Clock>, "Clock type required");
 #endif // _HAS_CXX20
-        return _Try_lock_shared_until(_Abs_time);
-    }
-
-    // try to lock non-exclusive until absolute time
-    _NODISCARD_TRY_CHANGE_STATE bool _Try_lock_shared_until_sys_time(const _timespec64* _Abs_time) {
         return _Try_lock_shared_until(_Abs_time);
     }
 

--- a/stl/inc/shared_mutex
+++ b/stl/inc/shared_mutex
@@ -172,8 +172,14 @@ public:
 
         unique_lock<mutex> _Lock(_Mymtx);
 
-        if (!_Write_queue.wait_until(_Lock, _Abs_time, _Can_acquire)) {
-            return false;
+        if constexpr (is_same_v<_Time, const _timespec64*>) {
+            if (!_Write_queue._Wait_until_sys_time(_Lock, _Abs_time, _Can_acquire)) {
+                return false;
+            }
+        } else {
+            if (!_Write_queue.wait_until(_Lock, _Abs_time, _Can_acquire)) {
+                return false;
+            }
         }
 
         ++_Readers;
@@ -189,8 +195,8 @@ public:
         return _Try_lock_shared_until(_Abs_time);
     }
 
-    _NODISCARD_TRY_CHANGE_STATE bool try_lock_shared_until(
-        const xtime* _Abs_time) { // try to lock non-exclusive until absolute time
+    // try to lock non-exclusive until absolute time
+    _NODISCARD_TRY_CHANGE_STATE bool _Try_lock_shared_until_sys_time(const _timespec64* _Abs_time) {
         return _Try_lock_shared_until(_Abs_time);
     }
 

--- a/stl/inc/thread
+++ b/stl/inc/thread
@@ -181,10 +181,6 @@ namespace this_thread {
         _Thrd_yield();
     }
 
-    inline void _Sleep_until_sys_time(const _timespec64* _Abs_time) {
-        _Thrd_sleep(_Abs_time);
-    }
-
     _EXPORT_STD template <class _Clock, class _Duration>
     void sleep_until(const chrono::time_point<_Clock, _Duration>& _Abs_time) {
 #if _HAS_CXX20

--- a/stl/inc/thread
+++ b/stl/inc/thread
@@ -181,7 +181,7 @@ namespace this_thread {
         _Thrd_yield();
     }
 
-    inline void sleep_until(const xtime* _Abs_time) {
+    inline void _Sleep_until_sys_time(const _timespec64* _Abs_time) {
         _Thrd_sleep(_Abs_time);
     }
 
@@ -196,8 +196,8 @@ namespace this_thread {
                 return;
             }
 
-            _CSTD xtime _Tgt;
-            (void) _To_xtime_10_day_clamped(_Tgt, _Abs_time - _Now);
+            _timespec64 _Tgt;
+            (void) _To_timespec64_sys_10_day_clamped(_Tgt, _Abs_time - _Now);
             _Thrd_sleep(&_Tgt);
         }
     }

--- a/stl/inc/xthreads.h
+++ b/stl/inc/xthreads.h
@@ -67,7 +67,7 @@ enum { _Thrd_success, _Thrd_nomem, _Thrd_timedout, _Thrd_busy, _Thrd_error };
 // threads
 _CRTIMP2_PURE int __cdecl _Thrd_detach(_Thrd_t);
 _CRTIMP2_PURE int __cdecl _Thrd_join(_Thrd_t, int*);
-_CRTIMP2_PURE void __cdecl _Thrd_sleep(const xtime*);
+_CRTIMP2_PURE void __cdecl _Thrd_sleep(const _timespec64*);
 _CRTIMP2_PURE void __cdecl _Thrd_yield();
 _CRTIMP2_PURE unsigned int __cdecl _Thrd_hardware_concurrency();
 _CRTIMP2_PURE _Thrd_id_t __cdecl _Thrd_id();
@@ -87,7 +87,7 @@ _CRTIMP2_PURE void __cdecl _Mtx_destroy_in_situ(_Mtx_t);
 _CRTIMP2_PURE int __cdecl _Mtx_current_owns(_Mtx_t);
 _CRTIMP2_PURE int __cdecl _Mtx_lock(_Mtx_t);
 _CRTIMP2_PURE int __cdecl _Mtx_trylock(_Mtx_t);
-_CRTIMP2_PURE int __cdecl _Mtx_timedlock(_Mtx_t, const xtime*);
+_CRTIMP2_PURE int __cdecl _Mtx_timedlock(_Mtx_t, const _timespec64*);
 _CRTIMP2_PURE int __cdecl _Mtx_unlock(_Mtx_t); // TRANSITION, ABI: always returns _Thrd_success
 
 _CRTIMP2_PURE void* __cdecl _Mtx_getconcrtcs(_Mtx_t);
@@ -110,7 +110,7 @@ _CRTIMP2_PURE void __cdecl _Cnd_destroy(_Cnd_t);
 _CRTIMP2_PURE void __cdecl _Cnd_init_in_situ(_Cnd_t);
 _CRTIMP2_PURE void __cdecl _Cnd_destroy_in_situ(_Cnd_t);
 _CRTIMP2_PURE int __cdecl _Cnd_wait(_Cnd_t, _Mtx_t); // TRANSITION, ABI: Always returns _Thrd_success
-_CRTIMP2_PURE int __cdecl _Cnd_timedwait(_Cnd_t, _Mtx_t, const xtime*);
+_CRTIMP2_PURE int __cdecl _Cnd_timedwait(_Cnd_t, _Mtx_t, const _timespec64*);
 _CRTIMP2_PURE int __cdecl _Cnd_broadcast(_Cnd_t); // TRANSITION, ABI: Always returns _Thrd_success
 _CRTIMP2_PURE int __cdecl _Cnd_signal(_Cnd_t); // TRANSITION, ABI: Always returns _Thrd_success
 _CRTIMP2_PURE void __cdecl _Cnd_register_at_thread_exit(_Cnd_t, _Mtx_t, int*);

--- a/stl/inc/xtimec.h
+++ b/stl/inc/xtimec.h
@@ -20,17 +20,12 @@ _STL_DISABLE_CLANG_WARNINGS
 
 _EXTERN_C
 
-struct xtime { // store time with nanosecond resolution
-    __time64_t sec;
-    long nsec;
-};
-
-_CRTIMP2_PURE long __cdecl _Xtime_diff_to_millis2(const xtime*, const xtime*);
+_CRTIMP2_PURE long __cdecl _Xtime_diff_to_millis2(const _timespec64*, const _timespec64*);
 _CRTIMP2_PURE long long __cdecl _Xtime_get_ticks();
 
 #ifdef _CRTBLD
 // Used by several src files, but not dllexported.
-void _Xtime_get2(xtime*);
+void _Timespec64_get_sys(_timespec64*);
 #endif // _CRTBLD
 
 _CRTIMP2_PURE long long __cdecl _Query_perf_counter();

--- a/stl/src/cond.cpp
+++ b/stl/src/cond.cpp
@@ -60,7 +60,8 @@ int _Cnd_wait(const _Cnd_t cond, const _Mtx_t mtx) { // wait until signaled
     return _Thrd_success; // TRANSITION, ABI: Always returns _Thrd_success
 }
 
-int _Cnd_timedwait(const _Cnd_t cond, const _Mtx_t mtx, const xtime* const target) { // wait until signaled or timeout
+// wait until signaled or timeout
+int _Cnd_timedwait(const _Cnd_t cond, const _Mtx_t mtx, const _timespec64* const target) {
     int res       = _Thrd_success;
     const auto cs = static_cast<Concurrency::details::stl_critical_section_interface*>(_Mtx_getconcrtcs(mtx));
     if (target == nullptr) { // no target time specified, wait on mutex
@@ -68,11 +69,11 @@ int _Cnd_timedwait(const _Cnd_t cond, const _Mtx_t mtx, const xtime* const targe
         cond->_get_cv()->wait(cs);
         _Mtx_reset_owner(mtx);
     } else { // target time specified, wait for it
-        xtime now;
-        _Xtime_get2(&now);
+        _timespec64 now;
+        _Timespec64_get_sys(&now);
         _Mtx_clear_owner(mtx);
         if (!cond->_get_cv()->wait_for(cs, _Xtime_diff_to_millis2(target, &now))) { // report timeout
-            _Xtime_get2(&now);
+            _Timespec64_get_sys(&now);
             if (_Xtime_diff_to_millis2(target, &now) == 0) {
                 res = _Thrd_timedout;
             }

--- a/stl/src/cthread.cpp
+++ b/stl/src/cthread.cpp
@@ -72,13 +72,13 @@ int _Thrd_detach(_Thrd_t thr) { // tell OS to release thread's resources when it
     return CloseHandle(thr._Hnd) ? _Thrd_success : _Thrd_error;
 }
 
-void _Thrd_sleep(const xtime* xt) { // suspend thread until time xt
-    xtime now;
-    _Xtime_get2(&now);
+void _Thrd_sleep(const _timespec64* xt) { // suspend thread until time xt
+    _timespec64 now;
+    _Timespec64_get_sys(&now);
     do { // sleep and check time
         Sleep(_Xtime_diff_to_millis2(xt, &now));
-        _Xtime_get2(&now);
-    } while (now.sec < xt->sec || now.sec == xt->sec && now.nsec < xt->nsec);
+        _Timespec64_get_sys(&now);
+    } while (now.tv_sec < xt->tv_sec || now.tv_sec == xt->tv_sec && now.tv_nsec < xt->tv_nsec);
 }
 
 void _Thrd_yield() { // surrender remainder of timeslice

--- a/stl/src/mutex.cpp
+++ b/stl/src/mutex.cpp
@@ -84,7 +84,7 @@ void _Mtx_destroy(_Mtx_t mtx) { // destroy mutex
     }
 }
 
-static int mtx_do_lock(_Mtx_t mtx, const xtime* target) { // lock mutex
+static int mtx_do_lock(_Mtx_t mtx, const _timespec64* target) { // lock mutex
     if ((mtx->type & ~_Mtx_recursive) == _Mtx_plain) { // set the lock
         if (mtx->thread_id != static_cast<long>(GetCurrentThreadId())) { // not current thread, do lock
             mtx->_get_cs()->lock();
@@ -102,7 +102,7 @@ static int mtx_do_lock(_Mtx_t mtx, const xtime* target) { // lock mutex
 
             res = WAIT_OBJECT_0;
 
-        } else if (target->sec < 0 || target->sec == 0 && target->nsec <= 0) {
+        } else if (target->tv_sec < 0 || target->tv_sec == 0 && target->tv_nsec <= 0) {
             // target time <= 0 --> plain trylock or timed wait for time that has passed; try to lock with 0 timeout
             if (mtx->thread_id != static_cast<long>(GetCurrentThreadId())) { // not this thread, lock it
                 if (mtx->_get_cs()->try_lock()) {
@@ -115,9 +115,10 @@ static int mtx_do_lock(_Mtx_t mtx, const xtime* target) { // lock mutex
             }
 
         } else { // check timeout
-            xtime now;
-            _Xtime_get2(&now);
-            while (now.sec < target->sec || now.sec == target->sec && now.nsec < target->nsec) { // time has not expired
+            _timespec64 now;
+            _Timespec64_get_sys(&now);
+            while (now.tv_sec < target->tv_sec || now.tv_sec == target->tv_sec && now.tv_nsec < target->tv_nsec) {
+                // time has not expired
                 if (mtx->thread_id == static_cast<long>(GetCurrentThreadId())
                     || mtx->_get_cs()->try_lock_for(_Xtime_diff_to_millis2(target, &now))) { // stop waiting
                     res = WAIT_OBJECT_0;
@@ -126,7 +127,7 @@ static int mtx_do_lock(_Mtx_t mtx, const xtime* target) { // lock mutex
                     res = WAIT_TIMEOUT;
                 }
 
-                _Xtime_get2(&now);
+                _Timespec64_get_sys(&now);
             }
         }
 
@@ -147,7 +148,7 @@ static int mtx_do_lock(_Mtx_t mtx, const xtime* target) { // lock mutex
             return _Thrd_success;
 
         case WAIT_TIMEOUT:
-            if (target == nullptr || (target->sec == 0 && target->nsec == 0)) {
+            if (target == nullptr || (target->tv_sec == 0 && target->tv_nsec == 0)) {
                 return _Thrd_busy;
             } else {
                 return _Thrd_timedout;
@@ -175,14 +176,14 @@ int _Mtx_lock(_Mtx_t mtx) { // lock mutex
 }
 
 int _Mtx_trylock(_Mtx_t mtx) { // attempt to lock try_mutex
-    xtime xt;
+    _timespec64 xt;
     _THREAD_ASSERT((mtx->type & (_Mtx_try | _Mtx_timed)) != 0, "trylock not supported by mutex");
-    xt.sec  = 0;
-    xt.nsec = 0;
+    xt.tv_sec  = 0;
+    xt.tv_nsec = 0;
     return mtx_do_lock(mtx, &xt);
 }
 
-int _Mtx_timedlock(_Mtx_t mtx, const xtime* xt) { // attempt to lock timed mutex
+int _Mtx_timedlock(_Mtx_t mtx, const _timespec64* xt) { // attempt to lock timed mutex
     int res;
 
     _THREAD_ASSERT((mtx->type & _Mtx_timed) != 0, "timedlock not supported by mutex");

--- a/stl/src/xtime.cpp
+++ b/stl/src/xtime.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// xtime functions
+// _timespec64 functions for system time
 
 #include <atomic>
 #include <xtimec.h>
@@ -12,32 +12,32 @@ constexpr long _Nsec_per_sec  = 1000000000L;
 constexpr long _Nsec_per_msec = 1000000L;
 constexpr int _Msec_per_sec   = 1000;
 
-static void xtime_normalize(xtime* xt) { // adjust so that 0 <= nsec < 1 000 000 000
-    while (xt->nsec < 0) { // normalize target time
-        xt->sec -= 1;
-        xt->nsec += _Nsec_per_sec;
+static void _timespec64_normalize(_timespec64* xt) { // adjust so that 0 <= tv_nsec < 1 000 000 000
+    while (xt->tv_nsec < 0) { // normalize target time
+        xt->tv_sec -= 1;
+        xt->tv_nsec += _Nsec_per_sec;
     }
-    while (_Nsec_per_sec <= xt->nsec) { // normalize target time
-        xt->sec += 1;
-        xt->nsec -= _Nsec_per_sec;
+    while (_Nsec_per_sec <= xt->tv_nsec) { // normalize target time
+        xt->tv_sec += 1;
+        xt->tv_nsec -= _Nsec_per_sec;
     }
 }
 
-static xtime xtime_diff(const xtime* xt,
-    const xtime* now) { // return xtime object holding difference between xt and now, treating negative difference as 0
-    xtime diff = *xt;
-    xtime_normalize(&diff);
-    if (diff.nsec < now->nsec) { // avoid underflow
-        diff.sec -= now->sec + 1;
-        diff.nsec += _Nsec_per_sec - now->nsec;
+// return _timespec64 object holding difference between xt and now, treating negative difference as 0
+static _timespec64 _timespec64_diff(const _timespec64* xt, const _timespec64* now) {
+    _timespec64 diff = *xt;
+    _timespec64_normalize(&diff);
+    if (diff.tv_nsec < now->tv_nsec) { // avoid underflow
+        diff.tv_sec -= now->tv_sec + 1;
+        diff.tv_nsec += _Nsec_per_sec - now->tv_nsec;
     } else { // no underflow
-        diff.sec -= now->sec;
-        diff.nsec -= now->nsec;
+        diff.tv_sec -= now->tv_sec;
+        diff.tv_nsec -= now->tv_nsec;
     }
 
-    if (diff.sec < 0 || (diff.sec == 0 && diff.nsec <= 0)) { // time is zero
-        diff.sec  = 0;
-        diff.nsec = 0;
+    if (diff.tv_sec < 0 || (diff.tv_sec == 0 && diff.tv_nsec <= 0)) { // time is zero
+        diff.tv_sec  = 0;
+        diff.tv_nsec = 0;
     }
     return diff;
 }
@@ -54,30 +54,31 @@ _CRTIMP2_PURE long long __cdecl _Xtime_get_ticks() { // get system time in 100-n
 }
 
 // Used by several src files, but not dllexported.
-void _Xtime_get2(xtime* xt) { // get system time with nanosecond resolution
+void _Timespec64_get_sys(_timespec64* xt) { // get system time with nanosecond resolution
     unsigned long long now = _Xtime_get_ticks();
-    xt->sec                = static_cast<__time64_t>(now / _Nsec100_per_sec);
-    xt->nsec               = static_cast<long>(now % _Nsec100_per_sec) * 100;
+    xt->tv_sec             = static_cast<__time64_t>(now / _Nsec100_per_sec);
+    xt->tv_nsec            = static_cast<long>(now % _Nsec100_per_sec) * 100;
 }
 
-_CRTIMP2_PURE long __cdecl _Xtime_diff_to_millis2(const xtime* xt1, const xtime* xt2) { // convert time to milliseconds
-    xtime diff = xtime_diff(xt1, xt2);
-    return static_cast<long>(diff.sec * _Msec_per_sec + (diff.nsec + _Nsec_per_msec - 1) / _Nsec_per_msec);
+// convert time to milliseconds
+_CRTIMP2_PURE long __cdecl _Xtime_diff_to_millis2(const _timespec64* xt1, const _timespec64* xt2) {
+    _timespec64 diff = _timespec64_diff(xt1, xt2);
+    return static_cast<long>(diff.tv_sec * _Msec_per_sec + (diff.tv_nsec + _Nsec_per_msec - 1) / _Nsec_per_msec);
 }
 
 // TRANSITION, ABI: preserved for binary compatibility
-_CRTIMP2_PURE long __cdecl _Xtime_diff_to_millis(const xtime* xt) { // convert time to milliseconds
-    xtime now;
-    _Xtime_get2(&now);
+_CRTIMP2_PURE long __cdecl _Xtime_diff_to_millis(const _timespec64* xt) { // convert time to milliseconds
+    _timespec64 now;
+    _Timespec64_get_sys(&now);
     return _Xtime_diff_to_millis2(xt, &now);
 }
 
 // TRANSITION, ABI: preserved for binary compatibility
-_CRTIMP2_PURE int __cdecl xtime_get(xtime* xt, int type) { // get current time
+_CRTIMP2_PURE int __cdecl xtime_get(_timespec64* xt, int type) { // get current time
     if (type != TIME_UTC || xt == nullptr) {
         type = 0;
     } else {
-        _Xtime_get2(xt);
+        _Timespec64_get_sys(xt);
     }
 
     return type;

--- a/tests/std/test.lst
+++ b/tests/std/test.lst
@@ -199,6 +199,7 @@ tests\GH_002045_put_time_changes_errno
 tests\GH_002058_debug_iterator_race
 tests\GH_002120_streambuf_seekpos_and_seekoff
 tests\GH_002168_regex_overflow
+tests\GH_002206_unreserved_names
 tests\GH_002299_implicit_sfinae_constraints
 tests\GH_002307_usual_scope_guard
 tests\GH_002334_branchless_clamp

--- a/tests/std/tests/GH_002206_unreserved_names/env.lst
+++ b/tests/std/tests/GH_002206_unreserved_names/env.lst
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+RUNALL_INCLUDE ..\usual_matrix.lst

--- a/tests/std/tests/GH_002206_unreserved_names/test.compile.pass.cpp
+++ b/tests/std/tests/GH_002206_unreserved_names/test.compile.pass.cpp
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#define nsec      delete
+#define sec       delete
+#define xtime     delete
+#define xtime_get delete
+
+#include <__msvc_all_public_headers.hpp>

--- a/tests/std/tests/VSO_0226079_mutex/test.cpp
+++ b/tests/std/tests/VSO_0226079_mutex/test.cpp
@@ -339,45 +339,45 @@ struct mutex_test_fixture {
 #endif // TRANSITION, GH-1472
     }
 
-    // nonstandard xtime type
+    // nonstandard _timespec64 type
     template <class Rep, class Period>
-    xtime to_xtime(const chrono::duration<Rep, Period>& rel_time) { // convert duration to xtime
-        xtime xt;
+    _timespec64 to_timespec64(const chrono::duration<Rep, Period>& rel_time) { // convert duration to _timespec64
+        _timespec64 ts64;
         if (rel_time <= chrono::duration<Rep, Period>::zero()) { // negative or zero relative time, return zero
-            xt.sec  = 0;
-            xt.nsec = 0;
+            ts64.tv_sec  = 0;
+            ts64.tv_nsec = 0;
         } else { // positive relative time, convert
             chrono::nanoseconds t0 = chrono::system_clock::now().time_since_epoch();
             t0 += chrono::duration_cast<chrono::nanoseconds>(rel_time);
-            xt.sec = chrono::duration_cast<chrono::seconds>(t0).count();
-            t0 -= chrono::seconds(xt.sec);
-            xt.nsec = static_cast<long>(t0.count());
+            ts64.tv_sec = chrono::duration_cast<chrono::seconds>(t0).count();
+            t0 -= chrono::seconds(ts64.tv_sec);
+            ts64.tv_nsec = static_cast<long>(t0.count());
         }
-        return xt;
+        return ts64;
     }
 
     void test_timed_lockable_xtime() {
         assert(time_execution([this] {
-            const auto xt = to_xtime(24h);
-            assert(mtx.try_lock_until(&xt));
+            const auto ts64 = to_timespec64(24h);
+            assert(mtx._Try_lock_until_sys_time(&ts64));
         }) < 1h);
         mtx.unlock();
         assert(time_execution([this] {
-            const auto xt = to_xtime(24h);
+            const auto ts64 = to_timespec64(24h);
             unique_lock<Mutex> ul(mtx, defer_lock);
-            assert(ul.try_lock_until(&xt));
+            assert(ul._Try_lock_until_sys_time(&ts64));
         }) < 1h);
 
 #if 0 // TRANSITION, GH-1472
         ot.lock();
         assert(time_execution([this] {
-            const auto xt = to_xtime(50ms);
-            assert(!mtx.try_lock_until(&xt));
+            const auto ts64 = to_timespec64(50ms);
+            assert(!mtx._Try_lock_until_sys_time(&ts64));
         }) >= 50ms);
         assert(time_execution([this] {
-            const auto xt = to_xtime(50ms);
+            const auto ts64 = to_timespec64(50ms);
             unique_lock<Mutex> ul(mtx, defer_lock);
-            assert(!ul.try_lock_until(&xt));
+            assert(!ul._Try_lock_until_sys_time(&ts64));
         }) >= 50ms);
         ot.unlock();
 #endif // TRANSITION, GH-1472

--- a/tests/std/tests/VSO_0226079_mutex/test.cpp
+++ b/tests/std/tests/VSO_0226079_mutex/test.cpp
@@ -478,7 +478,6 @@ int main() {
         mutex_test_fixture<timed_mutex> fixture;
         fixture.test_lockable();
         fixture.test_timed_lockable();
-        fixture.test_timed_lockable_xtime();
     }
 
     {
@@ -491,7 +490,6 @@ int main() {
         mutex_test_fixture<recursive_timed_mutex> fixture;
         fixture.test_lockable();
         fixture.test_timed_lockable();
-        fixture.test_timed_lockable_xtime();
         fixture.test_recursive_lockable();
     }
 


### PR DESCRIPTION
This PR is currently trying to replace uses of `xtime` with `_timespec64`, because `_timespec64` is
- of a reserved name, and
- having the same member names as the standard `timespec`, and
- already available in all modes via `<time.h>`, and
- layout-compatible with `xtime`.

Definition of `_timespec64` (not available in this repo):
```C++
struct _timespec64
{
    __time64_t tv_sec;
    long       tv_nsec;
};
```
Definition of `xtime`:
https://github.com/microsoft/STL/blob/5e603826ea2f4bfbe3d72b33967193b2edf75ce5/stl/inc/xtimec.h#L23-L26

Working towards #2206.

Every function in MSVC STL that has external linkage and involves `xtime` is either `extern "C"` or inline, so I think this PR doesn't break ABI.

~I'm also trying to change the name of every function, except for constructor, involving `xtime`/`_timespec64` in order to avoid polluting overload sets.~

~For constructor of `unique_lock`, I'm adding an explicit construction tag type - perhaps we can simply remove that ctor, and some other non-standard functions.~

Edit: This PR is now removing non-standard overloads. One non-standard `condition_variable::wait_until` overload is changed to `_Wait_until_sys_time` and made `private`.