### PR TITLE
Allow zero sigma for normal_distribution

### DIFF
--- a/stl/inc/random
+++ b/stl/inc/random
@@ -2996,7 +2996,7 @@ public:
         }
 
         void _Init(_Ty _Mean0, _Ty _Sigma0) { // set internal state
-            _STL_ASSERT(0.0 < _Sigma0, "invalid sigma argument for normal_distribution");
+            _STL_ASSERT(0.0 <= _Sigma0, "invalid sigma argument for normal_distribution");
             _Mean  = _Mean0;
             _Sigma = _Sigma0;
         }


### PR DESCRIPTION
For simulation purposes a constant output is sometimes desired (setting sigma to zero, but be able to change it to other values if desired without recompilation). The implementation is able to realize this: `return _Res * _Par0._Sigma + _Par0._Mean;`

