### PR TITLE
`<mdspan>`: `layout_left` improvements

### DIFF
--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -587,7 +587,7 @@ public:
               && is_nothrow_constructible_v<index_type, const _OtherIndexType&>
 #endif // ^^^ no workaround ^^^
     constexpr mapping(const extents_type& _Exts_, const span<_OtherIndexType, extents_type::rank()> _Strides_) noexcept
-        : _Exts{_Exts_} {
+        : _Exts(_Exts_) {
         for (rank_type _Idx = 0; _Idx < extents_type::rank(); ++_Idx) {
             _Strides[_Idx] = _Strides_[_Idx];
         }
@@ -604,7 +604,7 @@ public:
 #endif // ^^^ no workaround ^^^
     constexpr mapping(
         const extents_type& _Exts_, const array<_OtherIndexType, extents_type::rank()>& _Strides_) noexcept
-        : _Exts{_Exts_} {
+        : _Exts(_Exts_) {
         for (rank_type _Idx = 0; _Idx < extents_type::rank(); ++_Idx) {
             _Strides[_Idx] = _Strides_[_Idx];
         }

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -240,6 +240,15 @@ public:
         }
     }
 
+    // TRANSITION, LWG ISSUE? I believe that this function should return 'index_type'
+    _NODISCARD constexpr index_type _Fwd_prod_of_extents(const rank_type _Idx) const noexcept {
+        index_type _Result = 1;
+        for (rank_type _Dim = 0; _Dim < _Idx; ++_Dim) {
+            _Result *= extent(_Dim);
+        }
+        return _Result;
+    }
+
     _NODISCARD static _CONSTEVAL bool _Is_index_space_size_representable() {
         if constexpr (rank_dynamic() == 0 && rank() > 0) {
             return _STD in_range<index_type>((_Extents * ...));
@@ -314,24 +323,52 @@ public:
     constexpr mapping() noexcept               = default;
     constexpr mapping(const mapping&) noexcept = default;
 
-    constexpr mapping(const extents_type& _Exts_) noexcept : _Exts(_Exts_) {}
+    constexpr mapping(const extents_type& _Exts_) noexcept : _Exts(_Exts_) {
+        // TRANSITION, CHECK [mdspan.layout.left.cons]/1 (REQUIRES '_Multiply_with_overflow_check' FROM #3561)
+    }
 
     template <class _OtherExtents>
         requires is_constructible_v<extents_type, _OtherExtents>
     constexpr explicit(!is_convertible_v<_OtherExtents, extents_type>)
         mapping(const mapping<_OtherExtents>& _Other) noexcept
-        : _Exts(_Other.extents()) {}
+        : _Exts(_Other.extents()) {
+        _STL_VERIFY(_STD in_range<index_type>(_Other.required_span_size()),
+            "Value of other.required_span_size() must be representable as a value of type index_type (N4944 "
+            "[mdspan.layout.left.cons]/4).");
+    }
 
     template <class _OtherExtents>
         requires (extents_type::rank() <= 1) && is_constructible_v<extents_type, _OtherExtents>
     constexpr explicit(!is_convertible_v<_OtherExtents, extents_type>)
         mapping(const layout_right::mapping<_OtherExtents>& _Other) noexcept
-        : _Exts(_Other.extents()) {}
+        : _Exts(_Other.extents()) {
+        _STL_VERIFY(_STD in_range<index_type>(_Other.required_span_size()),
+            "Value of other.required_span_size() must be representable as a value of type index_type (N4944 "
+            "[mdspan.layout.left.cons]/7).");
+    }
 
     template <class _OtherExtents>
         requires is_constructible_v<extents_type, _OtherExtents>
     constexpr explicit(extents_type::rank() > 0) mapping(const layout_stride::template mapping<_OtherExtents>& _Other)
-        : _Exts(_Other.extents()) {}
+        : _Exts(_Other.extents()) {
+        if constexpr (extents_type::rank() > 0) {
+            const bool _Verify = [&]<size_t... _Indices>(index_sequence<_Indices...>) {
+                index_type _Prod = 1;
+                return (
+                    (_Other.stride(_Indices)
+                        == (_Indices + 1 == extents_type::rank()
+                                ? _Prod
+                                : _STD exchange(_Prod, static_cast<index_type>(_Prod * _Exts.extent(_Indices + 1)))))
+                    && ...);
+            }
+            (make_index_sequence<extents_type::rank()>{});
+            _STL_VERIFY(_Verify, "For all r in the range [0, extents_type::rank()), other.stride(r) must be equal to "
+                                 "extents().fwd-prod-of-extents(r) (N4944 [mdspan.layout.left.cons]/10.1).");
+        }
+        _STL_VERIFY(_STD in_range<index_type>(_Other.required_span_size()),
+            "Value of other.required_span_size() must be representable as a value of type index_type (N4944 "
+            "[mdspan.layout.left.cons]/10.2).");
+    }
 
     constexpr mapping& operator=(const mapping&) noexcept = default;
 
@@ -340,19 +377,14 @@ public:
     }
 
     _NODISCARD constexpr index_type required_span_size() const noexcept {
-        index_type _Result = 1;
-        for (rank_type _Dim = 0; _Dim < extents_type::rank(); ++_Dim) {
-            _Result *= _Exts.extent(_Dim);
-        }
-        return _Result;
+        return _Exts._Fwd_prod_of_extents(extents_type::rank());
     }
 
-    template <class... _Indices>
-        requires (sizeof...(_Indices) == extents_type::rank()) && (is_convertible_v<_Indices, index_type> && ...)
-              && (is_nothrow_constructible_v<index_type, _Indices> && ...)
-    _NODISCARD constexpr index_type operator()(_Indices... _Idx) const noexcept {
-        return _Index_impl<conditional_t<true, index_type, _Indices>...>(
-            static_cast<index_type>(_Idx)..., make_index_sequence<extents_type::rank()>{});
+    template <class... _IndexTypes>
+        requires (sizeof...(_IndexTypes) == extents_type::rank()) && (is_convertible_v<_IndexTypes, index_type> && ...)
+              && (is_nothrow_constructible_v<index_type, _IndexTypes> && ...)
+    _NODISCARD constexpr index_type operator()(_IndexTypes... _Indices) const noexcept {
+        return _Index_impl(make_index_sequence<extents_type::rank()>{}, _Indices...);
     }
 
     _NODISCARD static constexpr bool is_always_unique() noexcept {
@@ -367,44 +399,40 @@ public:
         return true;
     }
 
-    _NODISCARD constexpr bool is_unique() const noexcept {
+    _NODISCARD static constexpr bool is_unique() noexcept {
         return true;
     }
 
-    _NODISCARD constexpr bool is_exhaustive() const noexcept {
+    _NODISCARD static constexpr bool is_exhaustive() noexcept {
         return true;
     }
 
-    _NODISCARD constexpr bool is_strided() const noexcept {
+    _NODISCARD static constexpr bool is_strided() noexcept {
         return true;
     }
 
-    _NODISCARD constexpr index_type stride(const rank_type _Rank) const noexcept
+    _NODISCARD constexpr index_type stride(const rank_type _Idx) const noexcept
         requires (extents_type::rank() > 0)
     {
-        index_type _Result = 1;
-        for (rank_type _Dim = 0; _Dim < _Rank; ++_Dim) {
-            _Result *= _Exts.extent(_Dim);
-        }
-
-        return _Result;
+        _STL_VERIFY(_Idx < extents_type::rank(),
+            "Value of i must be less than extents_type::rank() (N4944 [mdspan.layout.left.obs]/6).");
+        return _Exts._Fwd_prod_of_extents(_Idx);
     }
 
     template <class _OtherExtents>
         requires (extents_type::rank() == _OtherExtents::rank())
     _NODISCARD_FRIEND constexpr bool operator==(const mapping& _Left, const mapping<_OtherExtents>& _Right) noexcept {
-        return _Left.extents() == _Right.extents();
+        return _Left._Exts == _Right.extents();
     }
 
 private:
     extents_type _Exts{};
 
-    template <class... _IndexType, size_t... _Seq>
-    constexpr index_type _Index_impl(_IndexType... _Idx, index_sequence<_Seq...>) const noexcept {
-        // return _Extents::rank() > 0 ? ((_Idx * stride(_Seq)) + ... + 0) : 0;
+    template <class... _IndexTypes, size_t... _Seq>
+    constexpr index_type _Index_impl(index_sequence<_Seq...>, _IndexTypes... _Indices) const noexcept {
         index_type _Stride = 1;
         index_type _Result = 0;
-        (((_Result += _Idx * _Stride), (void) (_Stride *= _Exts.extent(_Seq))), ...);
+        (((_Result += static_cast<index_type>(_Indices) * _Stride), (_Stride *= _Exts.extent(_Seq))), ...);
         return _Result;
     }
 };
@@ -789,7 +817,6 @@ public:
     template <class... _OtherIndexTypes>
         requires (is_convertible_v<_OtherIndexTypes, index_type> && ...)
                   && (is_nothrow_constructible_v<index_type, _OtherIndexTypes> && ...)
-                  && (sizeof...(_OtherIndexTypes) > 0)
                   && (sizeof...(_OtherIndexTypes) == rank() || sizeof...(_OtherIndexTypes) == rank_dynamic())
                   && is_constructible_v<mapping_type, extents_type> && is_default_constructible_v<accessor_type>
     constexpr explicit mdspan(data_handle_type _Ptr_, _OtherIndexTypes... _Exts)

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -384,7 +384,7 @@ public:
         requires (sizeof...(_IndexTypes) == extents_type::rank()) && (is_convertible_v<_IndexTypes, index_type> && ...)
               && (is_nothrow_constructible_v<index_type, _IndexTypes> && ...)
     _NODISCARD constexpr index_type operator()(_IndexTypes... _Indices) const noexcept {
-        return _Index_impl(make_index_sequence<extents_type::rank()>{}, _Indices...);
+        return _Index_impl(make_index_sequence<extents_type::rank()>{}, static_cast<index_type>(_Indices)...);
     }
 
     _NODISCARD static constexpr bool is_always_unique() noexcept {
@@ -430,9 +430,10 @@ private:
 
     template <class... _IndexTypes, size_t... _Seq>
     constexpr index_type _Index_impl(index_sequence<_Seq...>, _IndexTypes... _Indices) const noexcept {
+        _STL_INTERNAL_STATIC_ASSERT((same_as<_IndexTypes, index_type> && ...));
         index_type _Stride = 1;
         index_type _Result = 0;
-        (((_Result += static_cast<index_type>(_Indices) * _Stride), (_Stride *= _Exts.extent(_Seq))), ...);
+        (((_Result += _Indices * _Stride), (_Stride *= _Exts.extent(_Seq))), ...);
         return _Result;
     }
 };

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -429,7 +429,7 @@ private:
     extents_type _Exts{};
 
     template <class... _IndexTypes, size_t... _Seq>
-    constexpr index_type _Index_impl(index_sequence<_Seq...>, _IndexTypes... _Indices) const noexcept {
+    _NODISCARD constexpr index_type _Index_impl(index_sequence<_Seq...>, _IndexTypes... _Indices) const noexcept {
         _STL_INTERNAL_STATIC_ASSERT((same_as<_IndexTypes, index_type> && ...));
         index_type _Stride = 1;
         index_type _Result = 0;

--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -873,8 +873,8 @@ public:
         requires (is_convertible_v<_OtherIndexTypes, index_type> && ...)
               && (is_nothrow_constructible_v<index_type, _OtherIndexTypes> && ...)
               && (sizeof...(_OtherIndexTypes) == rank())
-    _NODISCARD constexpr reference operator()(const _OtherIndexTypes... _Indices) const {
-        return _Acc.access(_Ptr, _Map(static_cast<index_type>(_STD move(_Indices))...));
+    _NODISCARD constexpr reference operator()(_OtherIndexTypes... _Indices) const {
+        return _Acc.access(_Ptr, static_cast<size_t>(_Map(static_cast<index_type>(_STD move(_Indices))...)));
     }
 
     template <class _OtherIndexType>

--- a/tests/std/include/test_mdspan_support.hpp
+++ b/tests/std/include/test_mdspan_support.hpp
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#pragma once
+
+#include <concepts>
+#include <utility>
+
+enum class IsNothrow : bool { no, yes };
+
+template <class Int, IsNothrow Nothrow = IsNothrow::yes>
+struct ConvertibleToInt {
+    constexpr operator Int() const noexcept(std::to_underlying(Nothrow)) {
+        return Int{1};
+    }
+};
+
+struct NonConvertibleToAnything {};
+
+template <class T>
+constexpr void check_implicit_conversion(T); // not defined
+
+// clang-format off
+template <class T, class... Args>
+concept NotImplicitlyConstructibleFrom =
+    std::constructible_from<T, Args...>
+    && !requires(Args&&... args) { check_implicit_conversion<T>({std::forward<Args>(args)...}); };
+// clang-format on

--- a/tests/std/include/test_mdspan_support.hpp
+++ b/tests/std/include/test_mdspan_support.hpp
@@ -69,11 +69,15 @@ concept CheckStaticFunctionsOfLayoutMapping = requires(const M m) {
                                                   bool_constant<M::is_always_unique()>::value;
                                               };
 
+// clang-format off
 template <class M, class... Indices>
-concept CheckCallOperatorOfLayoutMapping = requires(const M m, Indices... i) {
-                                               { m(i...) } -> same_as<typename M::index_type>;
-                                               { m(i...) == m(i...) } -> same_as<bool>;
-                                           };
+concept CheckCallOperatorOfLayoutMapping =
+    requires(const M m, Indices... i) {
+        { m(i...) } -> same_as<typename M::index_type>;
+        { m(i...) == m(static_cast<typename M::index_type>(i)...) } -> same_as<bool>;
+    };
+// clang-format on
+
 template <class M>
 concept CheckStrideMemberFunc = requires(M mapping, typename M::rank_type i) {
                                     { mapping.stride(i) } -> same_as<typename M::index_type>;

--- a/tests/std/include/test_mdspan_support.hpp
+++ b/tests/std/include/test_mdspan_support.hpp
@@ -4,13 +4,17 @@
 #pragma once
 
 #include <concepts>
+#include <mdspan>
+#include <type_traits>
 #include <utility>
+
+using namespace std;
 
 enum class IsNothrow : bool { no, yes };
 
 template <class Int, IsNothrow Nothrow = IsNothrow::yes>
 struct ConvertibleToInt {
-    constexpr operator Int() const noexcept(std::to_underlying(Nothrow)) {
+    constexpr operator Int() const noexcept(to_underlying(Nothrow)) {
         return Int{1};
     }
 };
@@ -23,6 +27,87 @@ constexpr void check_implicit_conversion(T); // not defined
 // clang-format off
 template <class T, class... Args>
 concept NotImplicitlyConstructibleFrom =
-    std::constructible_from<T, Args...>
-    && !requires(Args&&... args) { check_implicit_conversion<T>({std::forward<Args>(args)...}); };
+    constructible_from<T, Args...>
+    && !requires(Args&&... args) { check_implicit_conversion<T>({forward<Args>(args)...}); };
 // clang-format on
+
+template <class T>
+inline constexpr bool is_extents_v = false;
+
+template <class T, size_t... E>
+inline constexpr bool is_extents_v<extents<T, E...>> = true;
+
+template <class Layout, class Mapping>
+inline constexpr bool is_mapping_of_v =
+    is_same_v<typename Layout::template mapping<typename Mapping::extents_type>, Mapping>;
+
+template <class M>
+concept CheckNestedTypesOfLayoutMapping =
+    requires {
+        requires is_extents_v<typename M::extents_type>;
+        requires same_as<typename M::index_type, typename M::extents_type::index_type>;
+        requires same_as<typename M::rank_type, typename M::extents_type::rank_type>;
+        requires is_mapping_of_v<typename M::layout_type, M>;
+    };
+
+template <class M>
+concept CheckMemberFunctionsOfLayoutMapping = requires(const M m) {
+                                                  { m.extents() } -> same_as<const typename M::extents_type&>;
+                                                  { m.required_span_size() } -> same_as<typename M::index_type>;
+                                                  { m.is_unique() } -> same_as<bool>;
+                                                  { m.is_exhaustive() } -> same_as<bool>;
+                                                  { m.is_strided() } -> same_as<bool>;
+                                              };
+
+template <class M>
+concept CheckStaticFunctionsOfLayoutMapping = requires(const M m) {
+                                                  { M::is_always_strided() } -> same_as<bool>;
+                                                  { M::is_always_exhaustive() } -> same_as<bool>;
+                                                  { M::is_always_unique() } -> same_as<bool>;
+                                                  bool_constant<M::is_always_strided()>::value;
+                                                  bool_constant<M::is_always_exhaustive()>::value;
+                                                  bool_constant<M::is_always_unique()>::value;
+                                              };
+
+template <class M, class... Indices>
+concept CheckCallOperatorOfLayoutMapping = requires(const M m, Indices... i) {
+                                               { m(i...) } -> same_as<typename M::index_type>;
+                                               { m(i...) == m(i...) } -> same_as<bool>;
+                                           };
+template <class M>
+concept CheckStrideMemberFunc = requires(M mapping, typename M::rank_type i) {
+                                    { mapping.stride(i) } -> same_as<typename M::index_type>;
+                                };
+
+template <class M>
+constexpr bool check_layout_mapping_requirements() {
+    static_assert(copyable<M>);
+    static_assert(equality_comparable<M>);
+    static_assert(is_nothrow_move_constructible_v<M>);
+    static_assert(is_nothrow_move_assignable_v<M>);
+    static_assert(is_nothrow_swappable_v<M>);
+    static_assert(CheckNestedTypesOfLayoutMapping<M>);
+    static_assert(CheckMemberFunctionsOfLayoutMapping<M>);
+    static_assert(CheckStaticFunctionsOfLayoutMapping<M>);
+
+    []<size_t... Indices>(index_sequence<Indices...>) {
+        static_assert(CheckCallOperatorOfLayoutMapping<M, decltype(Indices)...>);
+    }
+    (make_index_sequence<M::extents_type::rank()>{});
+
+    if constexpr (requires(M m, typename M::rank_type i) { m.stride(i); }) {
+        static_assert(CheckStrideMemberFunc<M>);
+    }
+
+    return true;
+}
+
+template <class MP, class E>
+    requires is_extents_v<E>
+constexpr bool check_layout_mapping_policy_requirements() {
+    using X = MP::template mapping<E>;
+    static_assert(check_layout_mapping_requirements<X>());
+    static_assert(same_as<typename X::layout_type, MP>);
+    static_assert(same_as<typename X::extents_type, E>);
+    return true;
+}

--- a/tests/std/include/test_mdspan_support.hpp
+++ b/tests/std/include/test_mdspan_support.hpp
@@ -78,9 +78,9 @@ concept CheckCallOperatorOfLayoutMapping =
 // clang-format on
 
 template <class M>
-concept CheckStrideMemberFunc = requires(M mapping, typename M::rank_type i) {
-                                    { mapping.stride(i) } -> std::same_as<typename M::index_type>;
-                                };
+concept CheckStrideMemberFunction = requires(M mapping, typename M::rank_type i) {
+                                        { mapping.stride(i) } -> std::same_as<typename M::index_type>;
+                                    };
 
 template <class M>
 constexpr bool check_layout_mapping_requirements() {
@@ -99,7 +99,7 @@ constexpr bool check_layout_mapping_requirements() {
     (std::make_index_sequence<M::extents_type::rank()>{});
 
     if constexpr (requires(M m, typename M::rank_type i) { m.stride(i); }) {
-        static_assert(CheckStrideMemberFunc<M>);
+        static_assert(CheckStrideMemberFunction<M>);
     }
 
     return true;

--- a/tests/std/include/test_mdspan_support.hpp
+++ b/tests/std/include/test_mdspan_support.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <concepts>
+#include <cstddef>
 #include <mdspan>
 #include <type_traits>
 #include <utility>

--- a/tests/std/include/test_mdspan_support.hpp
+++ b/tests/std/include/test_mdspan_support.hpp
@@ -109,7 +109,7 @@ constexpr bool check_layout_mapping_requirements() {
 template <class MP, class E>
     requires is_extents_v<E>
 constexpr bool check_layout_mapping_policy_requirements() {
-    using X = MP::template mapping<E>;
+    using X = typename MP::template mapping<E>;
     static_assert(check_layout_mapping_requirements<X>());
     static_assert(same_as<typename X::layout_type, MP>);
     static_assert(same_as<typename X::extents_type, E>);

--- a/tests/std/include/test_mdspan_support.hpp
+++ b/tests/std/include/test_mdspan_support.hpp
@@ -8,13 +8,11 @@
 #include <type_traits>
 #include <utility>
 
-using namespace std;
-
 enum class IsNothrow : bool { no, yes };
 
 template <class Int, IsNothrow Nothrow = IsNothrow::yes>
 struct ConvertibleToInt {
-    constexpr operator Int() const noexcept(to_underlying(Nothrow)) {
+    constexpr operator Int() const noexcept(std::to_underlying(Nothrow)) {
         return Int{1};
     }
 };
@@ -27,77 +25,77 @@ constexpr void check_implicit_conversion(T); // not defined
 // clang-format off
 template <class T, class... Args>
 concept NotImplicitlyConstructibleFrom =
-    constructible_from<T, Args...>
-    && !requires(Args&&... args) { check_implicit_conversion<T>({forward<Args>(args)...}); };
+    std::constructible_from<T, Args...>
+    && !requires(Args&&... args) { check_implicit_conversion<T>({std::forward<Args>(args)...}); };
 // clang-format on
 
 template <class T>
 inline constexpr bool is_extents_v = false;
 
 template <class T, size_t... E>
-inline constexpr bool is_extents_v<extents<T, E...>> = true;
+inline constexpr bool is_extents_v<std::extents<T, E...>> = true;
 
 template <class Layout, class Mapping>
 inline constexpr bool is_mapping_of_v =
-    is_same_v<typename Layout::template mapping<typename Mapping::extents_type>, Mapping>;
+    std::is_same_v<typename Layout::template mapping<typename Mapping::extents_type>, Mapping>;
 
 template <class M>
 concept CheckNestedTypesOfLayoutMapping =
     requires {
         requires is_extents_v<typename M::extents_type>;
-        requires same_as<typename M::index_type, typename M::extents_type::index_type>;
-        requires same_as<typename M::rank_type, typename M::extents_type::rank_type>;
+        requires std::same_as<typename M::index_type, typename M::extents_type::index_type>;
+        requires std::same_as<typename M::rank_type, typename M::extents_type::rank_type>;
         requires is_mapping_of_v<typename M::layout_type, M>;
     };
 
 template <class M>
 concept CheckMemberFunctionsOfLayoutMapping = requires(const M m) {
-                                                  { m.extents() } -> same_as<const typename M::extents_type&>;
-                                                  { m.required_span_size() } -> same_as<typename M::index_type>;
-                                                  { m.is_unique() } -> same_as<bool>;
-                                                  { m.is_exhaustive() } -> same_as<bool>;
-                                                  { m.is_strided() } -> same_as<bool>;
+                                                  { m.extents() } -> std::same_as<const typename M::extents_type&>;
+                                                  { m.required_span_size() } -> std::same_as<typename M::index_type>;
+                                                  { m.is_unique() } -> std::same_as<bool>;
+                                                  { m.is_exhaustive() } -> std::same_as<bool>;
+                                                  { m.is_strided() } -> std::same_as<bool>;
                                               };
 
 template <class M>
 concept CheckStaticFunctionsOfLayoutMapping = requires(const M m) {
-                                                  { M::is_always_strided() } -> same_as<bool>;
-                                                  { M::is_always_exhaustive() } -> same_as<bool>;
-                                                  { M::is_always_unique() } -> same_as<bool>;
-                                                  bool_constant<M::is_always_strided()>::value;
-                                                  bool_constant<M::is_always_exhaustive()>::value;
-                                                  bool_constant<M::is_always_unique()>::value;
+                                                  { M::is_always_strided() } -> std::same_as<bool>;
+                                                  { M::is_always_exhaustive() } -> std::same_as<bool>;
+                                                  { M::is_always_unique() } -> std::same_as<bool>;
+                                                  std::bool_constant<M::is_always_strided()>::value;
+                                                  std::bool_constant<M::is_always_exhaustive()>::value;
+                                                  std::bool_constant<M::is_always_unique()>::value;
                                               };
 
 // clang-format off
 template <class M, class... Indices>
 concept CheckCallOperatorOfLayoutMapping =
     requires(const M m, Indices... i) {
-        { m(i...) } -> same_as<typename M::index_type>;
-        { m(i...) == m(static_cast<typename M::index_type>(i)...) } -> same_as<bool>;
+        { m(i...) } -> std::same_as<typename M::index_type>;
+        { m(i...) == m(static_cast<typename M::index_type>(i)...) } -> std::same_as<bool>;
     };
 // clang-format on
 
 template <class M>
 concept CheckStrideMemberFunc = requires(M mapping, typename M::rank_type i) {
-                                    { mapping.stride(i) } -> same_as<typename M::index_type>;
+                                    { mapping.stride(i) } -> std::same_as<typename M::index_type>;
                                 };
 
 template <class M>
 constexpr bool check_layout_mapping_requirements() {
-    static_assert(copyable<M>);
-    static_assert(equality_comparable<M>);
-    static_assert(is_nothrow_move_constructible_v<M>);
-    static_assert(is_nothrow_move_assignable_v<M>);
-    static_assert(is_nothrow_swappable_v<M>);
+    static_assert(std::copyable<M>);
+    static_assert(std::equality_comparable<M>);
+    static_assert(std::is_nothrow_move_constructible_v<M>);
+    static_assert(std::is_nothrow_move_assignable_v<M>);
+    static_assert(std::is_nothrow_swappable_v<M>);
     static_assert(CheckNestedTypesOfLayoutMapping<M>);
     static_assert(CheckMemberFunctionsOfLayoutMapping<M>);
     static_assert(CheckStaticFunctionsOfLayoutMapping<M>);
 
-    []<size_t... Indices>(index_sequence<Indices...>) {
+    []<size_t... Indices>(std::index_sequence<Indices...>) {
         static_assert(CheckCallOperatorOfLayoutMapping<M, decltype(Indices)...>);
     }
-    (make_index_sequence<M::extents_type::rank()>{});
+    (std::make_index_sequence<M::extents_type::rank()>{});
 
     if constexpr (requires(M m, typename M::rank_type i) { m.stride(i); }) {
         static_assert(CheckStrideMemberFunc<M>);
@@ -111,7 +109,7 @@ template <class MP, class E>
 constexpr bool check_layout_mapping_policy_requirements() {
     using X = typename MP::template mapping<E>;
     static_assert(check_layout_mapping_requirements<X>());
-    static_assert(same_as<typename X::layout_type, MP>);
-    static_assert(same_as<typename X::extents_type, E>);
+    static_assert(std::same_as<typename X::layout_type, MP>);
+    static_assert(std::same_as<typename X::extents_type, E>);
     return true;
 }

--- a/tests/std/test.lst
+++ b/tests/std/test.lst
@@ -233,6 +233,8 @@ tests\P0009R18_mdspan
 tests\P0009R18_mdspan_default_accessor
 tests\P0009R18_mdspan_extents
 tests\P0009R18_mdspan_extents_death
+tests\P0009R18_mdspan_layout_left
+tests\P0009R18_mdspan_layout_left_death
 tests\P0019R8_atomic_ref
 tests\P0024R2_parallel_algorithms_adjacent_difference
 tests\P0024R2_parallel_algorithms_adjacent_find

--- a/tests/std/tests/P0009R18_mdspan_extents/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_extents/test.cpp
@@ -12,6 +12,8 @@
 
 #include "test_mdspan_support.hpp"
 
+using namespace std;
+
 template <class IndexType, size_t... Extents, size_t... Indices>
 constexpr void do_check_members(index_sequence<Indices...>) {
     using Ext = extents<IndexType, Extents...>;

--- a/tests/std/tests/P0009R18_mdspan_extents/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_extents/test.cpp
@@ -10,28 +10,9 @@
 #include <type_traits>
 #include <utility>
 
+#include "test_mdspan_support.hpp"
+
 using namespace std;
-
-enum class IsNothrow : bool { no, yes };
-
-template <class Int, IsNothrow Nothrow = IsNothrow::yes>
-struct ConvertibleToInt {
-    constexpr operator Int() const noexcept(to_underlying(Nothrow)) {
-        return Int{1};
-    }
-};
-
-struct NonConvertibleToAnything {};
-
-template <class T>
-constexpr void check_implicit_conversion(T); // not defined
-
-// clang-format off
-template <class T, class... Args>
-concept NotImplicitlyConstructibleFrom =
-    constructible_from<T, Args...>
-    && !requires(Args&&... args) { check_implicit_conversion<T>({forward<Args>(args)...}); };
-// clang-format on
 
 template <class IndexType, size_t... Extents, size_t... Indices>
 constexpr void do_check_members(index_sequence<Indices...>) {

--- a/tests/std/tests/P0009R18_mdspan_extents/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_extents/test.cpp
@@ -12,8 +12,6 @@
 
 #include "test_mdspan_support.hpp"
 
-using namespace std;
-
 template <class IndexType, size_t... Extents, size_t... Indices>
 constexpr void do_check_members(index_sequence<Indices...>) {
     using Ext = extents<IndexType, Extents...>;

--- a/tests/std/tests/P0009R18_mdspan_extents/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_extents/test.cpp
@@ -216,7 +216,7 @@ constexpr void check_construction_from_array_and_span() {
         static_assert(!is_constructible_v<Ext, span<NonConvertibleToAnything, 2>>);
     }
 
-    { // Check construciton with integers with mismatched signs
+    { // Check construction with integers with mismatched signs
         using Ext = extents<long long, dynamic_extent>;
 
         array arr = {4ull};

--- a/tests/std/tests/P0009R18_mdspan_layout_left/env.lst
+++ b/tests/std/tests/P0009R18_mdspan_layout_left/env.lst
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+RUNALL_INCLUDE ..\concepts_latest_matrix.lst

--- a/tests/std/tests/P0009R18_mdspan_layout_left/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_layout_left/test.cpp
@@ -14,8 +14,8 @@
 using namespace std;
 
 template <class Mapping, class... Indices>
-concept CanInvokeCallOperatorOfMapping = requires(Mapping mapping, Indices... i) {
-                                             { mapping(i...) } -> same_as<typename Mapping::index_type>;
+concept CanInvokeCallOperatorOfMapping = requires(Mapping m, Indices... i) {
+                                             { m(i...) } -> same_as<typename Mapping::index_type>;
                                          };
 
 template <class IndexType, size_t... Extents, size_t... Indices>
@@ -38,16 +38,16 @@ constexpr void do_check_members(const extents<IndexType, Extents...>& ext, index
     static_assert(same_as<typename Mapping::layout_type, layout_left>);
 
     { // Check default and copy constructor
-        Mapping mapping;
-        Mapping copy = mapping;
-        assert(copy == mapping);
+        Mapping m;
+        Mapping cpy = m;
+        assert(cpy == m);
         static_assert(is_nothrow_default_constructible_v<Mapping>);
         static_assert(is_nothrow_copy_constructible_v<Mapping>);
     }
 
     { // Check construction from extents_type
-        Mapping mapping{ext};
-        assert(mapping.extents() == ext);
+        Mapping m{ext};
+        assert(m.extents() == ext);
         static_assert(is_nothrow_constructible_v<Mapping, Ext>);
     }
 
@@ -56,9 +56,9 @@ constexpr void do_check_members(const extents<IndexType, Extents...>& ext, index
     using Mapping2       = layout_left::mapping<Ext2>;
 
     { // Check construction from other layout_left::mapping
-        Mapping mapping{ext};
-        Mapping2 mapping2{mapping};
-        assert(mapping == mapping2);
+        Mapping m1{ext};
+        Mapping2 m2{m1};
+        assert(m1 == m2);
         static_assert(is_nothrow_constructible_v<Mapping2, Mapping>);
         // Other tests are defined in 'check_construction_from_other_left_mapping' function
     }
@@ -67,9 +67,9 @@ constexpr void do_check_members(const extents<IndexType, Extents...>& ext, index
         using RightMapping = layout_right::mapping<Ext>;
         if constexpr (Ext::rank() <= 1) {
             RightMapping right_mapping{ext};
-            [[maybe_unused]] Mapping mapping{right_mapping};
-            [[maybe_unused]] Mapping2 mapping2{right_mapping};
-            assert(mapping == mapping2);
+            [[maybe_unused]] Mapping m1{right_mapping};
+            [[maybe_unused]] Mapping2 m2{right_mapping};
+            assert(m1 == m2);
             static_assert(is_nothrow_constructible_v<Mapping, RightMapping>);
             static_assert(is_nothrow_constructible_v<Mapping2, RightMapping>);
         } else {
@@ -89,29 +89,29 @@ constexpr void do_check_members(const extents<IndexType, Extents...>& ext, index
 
         using StrideMapping = layout_stride::mapping<Ext>;
         StrideMapping stride_mapping{ext, strides};
-        [[maybe_unused]] Mapping mapping{stride_mapping};
+        [[maybe_unused]] Mapping m{stride_mapping};
         // Other tests are defined in 'check_construction_from_other_stride_mapping' function
     }
 #pragma warning(pop) // TRANSITION, "/analyze:only" BUG?
 
-    Mapping mapping{ext}; // For later use
+    Mapping m{ext}; // For later use
 
     { // Check 'extents' function
-        assert(mapping.extents() == ext);
-        static_assert(noexcept(mapping.extents()));
+        assert(m.extents() == ext);
+        static_assert(noexcept(m.extents()));
     }
 
     { // Check 'required_span_size' function
         const IndexType expected_value = static_cast<IndexType>((ext.extent(Indices) * ... * 1));
-        assert(mapping.required_span_size() == expected_value);
-        static_assert(noexcept(mapping.required_span_size()));
+        assert(m.required_span_size() == expected_value);
+        static_assert(noexcept(m.required_span_size()));
     }
 
     { // Check operator()
-        assert(mapping(((void) Indices, 0)...) == 0);
-        assert(mapping((ext.extent(Indices) - 1)...) == static_cast<IndexType>((ext.extent(Indices) * ... * 1)) - 1);
-        static_assert(noexcept(mapping(((void) Indices, 0)...)));
-        static_assert(noexcept(mapping((ext.extent(Indices) - 1)...)));
+        assert(m(((void) Indices, 0)...) == 0);
+        assert(m((ext.extent(Indices) - 1)...) == static_cast<IndexType>((ext.extent(Indices) * ... * 1)) - 1);
+        static_assert(noexcept(m(((void) Indices, 0)...)));
+        static_assert(noexcept(m((ext.extent(Indices) - 1)...)));
         // Other tests are defined in 'check_call_operator' function
     }
 
@@ -130,16 +130,16 @@ constexpr void do_check_members(const extents<IndexType, Extents...>& ext, index
     if constexpr (Ext::rank() > 0) { // Check 'stride' function
         const IndexType expected_value =
             static_cast<IndexType>((ext.extent(Indices) * ... * 1) / ext.extent(Ext::rank() - 1));
-        assert(mapping.stride(Ext::rank() - 1) == expected_value);
-        assert(mapping.stride(0) == 1);
-        static_assert(noexcept(mapping.stride(Ext::rank() - 1)));
-        static_assert(noexcept(mapping.stride(0)));
+        assert(m.stride(Ext::rank() - 1) == expected_value);
+        assert(m.stride(0) == 1);
+        static_assert(noexcept(m.stride(Ext::rank() - 1)));
+        static_assert(noexcept(m.stride(0)));
     } else {
         static_assert(!CheckStrideMemberFunction<Mapping>);
     }
 
     { // Check comparisons
-        assert(mapping == mapping);
+        assert(m == m);
         // Other tests are defined in 'check_comparisons' function
     }
 }
@@ -251,22 +251,22 @@ constexpr void check_call_operator() {
     }
 
     { // Check various mappings
-        layout_left::mapping<extents<short>> mapping1;
-        assert(mapping1() == 0);
+        layout_left::mapping<extents<short>> m1;
+        assert(m1() == 0);
 
-        layout_left::mapping<extents<int, 3>> mapping2;
-        assert(mapping2(0) == 0);
-        assert(mapping2(1) == 1);
-        assert(mapping2(2) == 2);
+        layout_left::mapping<extents<int, 3>> m2;
+        assert(m2(0) == 0);
+        assert(m2(1) == 1);
+        assert(m2(2) == 2);
 
-        layout_left::mapping<dextents<long, 2>> mapping3{dextents<int, 2>{5, 6}};
-        assert(mapping3(0, 0) == 0);
-        assert(mapping3(1, 0) == 1);
-        assert(mapping3(0, 1) == 5);
-        assert(mapping3(1, 1) == 6);
-        assert(mapping3(2, 1) == 7);
-        assert(mapping3(1, 2) == 11);
-        assert(mapping3(4, 5) == 29);
+        layout_left::mapping<dextents<long, 2>> m3{dextents<int, 2>{5, 6}};
+        assert(m3(0, 0) == 0);
+        assert(m3(1, 0) == 1);
+        assert(m3(0, 1) == 5);
+        assert(m3(1, 1) == 6);
+        assert(m3(2, 1) == 7);
+        assert(m3(1, 2) == 11);
+        assert(m3(4, 5) == 29);
     }
 }
 
@@ -281,12 +281,12 @@ constexpr void check_comparisons() {
     }
 
     { // Check correctness
-        StaticMapping mapping1;
-        DynamicMapping mapping2{dextents<int, 1>{3}};
-        DynamicMapping mapping3{dextents<int, 1>{2}};
-        assert(mapping1 == mapping2);
-        assert(mapping2 != mapping3);
-        assert(mapping1 != mapping3);
+        StaticMapping m1;
+        DynamicMapping m2{dextents<int, 1>{3}};
+        DynamicMapping m3{dextents<int, 1>{2}};
+        assert(m1 == m2);
+        assert(m2 != m3);
+        assert(m1 != m3);
     }
 }
 

--- a/tests/std/tests/P0009R18_mdspan_layout_left/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_layout_left/test.cpp
@@ -1,0 +1,370 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <array>
+#include <cassert>
+#include <concepts>
+#include <cstddef>
+#include <mdspan>
+#include <span>
+#include <type_traits>
+
+#include "test_mdspan_support.hpp"
+
+template <class Mapping, class... Indices>
+concept CanInvokeCallOperatorOfMapping = requires(Mapping mapping, Indices... i) {
+                                             { mapping(i...) } -> same_as<typename Mapping::index_type>;
+                                         };
+
+template <class IndexType, size_t... Extents, size_t... Indices>
+constexpr void do_check_members(const extents<IndexType, Extents...>& ext, index_sequence<Indices...>) {
+    using Ext     = extents<IndexType, Extents...>;
+    using Mapping = layout_left::mapping<Ext>;
+
+    // Check layout mapping requirements
+    static_assert(check_layout_mapping_policy_requirements<layout_left, Ext>());
+
+    // layout_left​::​mapping<Ext> is a trivially copyable type that models regular for each Ext
+    static_assert(is_trivially_copyable_v<Ext>);
+    static_assert(regular<Ext>);
+
+    // Check member types
+    static_assert(same_as<typename Mapping::extents_type, Ext>);
+    static_assert(same_as<typename Mapping::index_type, typename Ext::index_type>);
+    static_assert(same_as<typename Mapping::size_type, typename Ext::size_type>);
+    static_assert(same_as<typename Mapping::rank_type, typename Ext::rank_type>);
+    static_assert(same_as<typename Mapping::layout_type, layout_left>);
+
+    { // Check default and copy constructor
+        Mapping mapping;
+        Mapping copy = mapping;
+        assert(copy == mapping);
+        static_assert(is_nothrow_default_constructible_v<Mapping>);
+        static_assert(is_nothrow_copy_constructible_v<Mapping>);
+    }
+
+    { // Check construction from extents_type
+        Mapping mapping{ext};
+        assert(mapping.extents() == ext);
+        static_assert(is_nothrow_constructible_v<Mapping, Ext>);
+    }
+
+    using OtherIndexType = long long;
+    using Ext2           = extents<OtherIndexType, Extents...>;
+    using Mapping2       = layout_left::mapping<Ext2>;
+
+    { // Check construction from other layout_left::mapping
+        Mapping mapping{ext};
+        Mapping2 mapping2{mapping};
+        assert(mapping == mapping2);
+        static_assert(is_nothrow_constructible_v<Mapping2, Mapping>);
+        // Other tests are defined in 'check_construction_from_other_left_mapping' function
+    }
+
+    { // Check construction from layout_right::mapping
+        using RightMapping = layout_right::mapping<Ext>;
+        if constexpr (Ext::rank() <= 1) {
+            RightMapping right_mapping{ext};
+            [[maybe_unused]] Mapping mapping{right_mapping};
+            [[maybe_unused]] Mapping2 mapping2{right_mapping};
+            assert(mapping == mapping2);
+            static_assert(is_nothrow_constructible_v<Mapping, RightMapping>);
+            static_assert(is_nothrow_constructible_v<Mapping2, RightMapping>);
+        } else {
+            static_assert(!is_constructible_v<Mapping, RightMapping>);
+            static_assert(!is_constructible_v<Mapping2, RightMapping>);
+        }
+        // Other tests are defined in 'check_construction_from_other_right_mapping' function
+    }
+
+#pragma warning(push) // TRANSITION, "/analyze:only" BUG?
+#pragma warning(disable : 28020) // The expression '0<=_Param_(1)&&_Param_(1)<=1-1' is not true at this call
+    { // Check construction from layout_stride::mapping
+        array<IndexType, Ext::rank()> strides{1};
+        for (size_t i = 1; i < Ext::rank(); ++i) {
+            strides[i] = static_cast<IndexType>(strides[i - 1] * ext.extent(i));
+        }
+
+        using StrideMapping = layout_stride::mapping<Ext>;
+        StrideMapping stride_mapping{ext, strides};
+        [[maybe_unused]] Mapping mapping{stride_mapping};
+        // Other tests are defined in 'check_construction_from_other_stride_mapping' function
+    }
+#pragma warning(pop) // TRANSITION, "/analyze:only" BUG?
+
+    Mapping mapping{ext}; // For later use
+
+    { // Check 'extents' function
+        assert(mapping.extents() == ext);
+        static_assert(noexcept(mapping.extents()));
+    }
+
+    { // Check 'required_span_size' function
+        const IndexType expected_value = static_cast<IndexType>((ext.extent(Indices) * ... * 1));
+        assert(mapping.required_span_size() == expected_value);
+        static_assert(noexcept(mapping.required_span_size()));
+    }
+
+    { // Check operator()
+        assert(mapping(((void) Indices, 0)...) == 0);
+        assert(mapping((ext.extent(Indices) - 1)...) == static_cast<IndexType>((ext.extent(Indices) * ... * 1)) - 1);
+        static_assert(noexcept(mapping(((void) Indices, 0)...)));
+        static_assert(noexcept(mapping((ext.extent(Indices) - 1)...)));
+        // Other tests are defined in 'check_call_operator' function
+    }
+
+    { // Check 'is_always_[unique/exhaustive/strided]' functions
+        static_assert(Mapping::is_always_unique());
+        static_assert(Mapping::is_always_exhaustive());
+        static_assert(Mapping::is_always_strided());
+    }
+
+    { // Check 'is_[unique/exhaustive/strided]' functions
+        static_assert(Mapping::is_unique());
+        static_assert(Mapping::is_exhaustive());
+        static_assert(Mapping::is_strided());
+    }
+
+    if constexpr (Ext::rank() > 0) { // Check 'stride' function
+        const IndexType expected_value =
+            static_cast<IndexType>((ext.extent(Indices) * ... * 1) / ext.extent(Ext::rank() - 1));
+        assert(mapping.stride(Ext::rank() - 1) == expected_value);
+        assert(mapping.stride(0) == 1);
+        static_assert(noexcept(mapping.stride(Ext::rank() - 1)));
+        static_assert(noexcept(mapping.stride(0)));
+    } else {
+        static_assert(!CheckStrideMemberFunc<Mapping>);
+    }
+
+    { // Check comparisons
+        assert(mapping == mapping);
+        // Other tests are defined in 'check_comparisons' function
+    }
+}
+
+template <class IndexType, size_t... Extents>
+constexpr void check_members(extents<IndexType, Extents...> ext) {
+    do_check_members<IndexType, Extents...>(ext, make_index_sequence<sizeof...(Extents)>{});
+}
+
+constexpr void check_construction_from_other_left_mapping() {
+    { // Check invalid construction
+        using Mapping = layout_left::mapping<extents<int, 3, 3>>;
+        static_assert(!is_constructible_v<Mapping, layout_left::mapping<extents<int, 3>>>);
+        static_assert(!is_constructible_v<Mapping, layout_left::mapping<extents<int, 3, 3, 3>>>);
+    }
+
+    { // Check implicit conversions
+        static_assert(!NotImplicitlyConstructibleFrom<layout_left::mapping<extents<int, 3>>,
+                      layout_left::mapping<extents<int, 3>>>);
+        static_assert(NotImplicitlyConstructibleFrom<layout_left::mapping<extents<int, 3>>,
+            layout_left::mapping<extents<long long, 3>>>);
+        static_assert(NotImplicitlyConstructibleFrom<layout_left::mapping<extents<int, 3, 3>>,
+            layout_left::mapping<extents<int, dynamic_extent, 3>>>);
+        static_assert(NotImplicitlyConstructibleFrom<layout_left::mapping<extents<int, 3, 3>>,
+            layout_left::mapping<extents<int, dynamic_extent, dynamic_extent>>>);
+    }
+}
+
+constexpr void check_construction_from_other_right_mapping() {
+    { // Check construction from layout_right::mapping<E> with various values of E::rank()
+        static_assert(
+            is_constructible_v<layout_left::mapping<dextents<int, 0>>, layout_right::mapping<dextents<int, 0>>>);
+        static_assert(
+            is_constructible_v<layout_left::mapping<dextents<int, 1>>, layout_right::mapping<dextents<int, 1>>>);
+        static_assert(
+            !is_constructible_v<layout_left::mapping<dextents<int, 2>>, layout_right::mapping<dextents<int, 2>>>);
+        static_assert(
+            !is_constructible_v<layout_left::mapping<dextents<int, 3>>, layout_right::mapping<dextents<int, 3>>>);
+    }
+
+    { // Check construction from layout_right::mapping<E> when E is invalid
+        using Mapping = layout_left::mapping<extents<int, 3>>;
+        static_assert(!is_constructible_v<Mapping, layout_right::mapping<extents<int, 1>>>);
+        static_assert(!is_constructible_v<Mapping, layout_right::mapping<extents<int, 2>>>);
+    }
+
+    { // Check implicit conversions
+        static_assert(!NotImplicitlyConstructibleFrom<layout_left::mapping<extents<int, 3>>,
+                      layout_right::mapping<extents<int, 3>>>);
+        static_assert(NotImplicitlyConstructibleFrom<layout_left::mapping<extents<int, 3>>,
+            layout_right::mapping<extents<long long, 3>>>);
+        static_assert(NotImplicitlyConstructibleFrom<layout_left::mapping<extents<int, 3>>,
+            layout_right::mapping<extents<int, dynamic_extent>>>);
+    }
+}
+
+constexpr void check_construction_from_other_stride_mapping() {
+    { // Check construction from layout_stride::mapping<E> with various values of E::rank()
+        static_assert(
+            is_constructible_v<layout_left::mapping<dextents<int, 0>>, layout_stride::mapping<dextents<int, 0>>>);
+        static_assert(
+            is_constructible_v<layout_left::mapping<dextents<int, 1>>, layout_stride::mapping<dextents<int, 1>>>);
+        static_assert(
+            is_constructible_v<layout_left::mapping<dextents<int, 2>>, layout_stride::mapping<dextents<int, 2>>>);
+        static_assert(
+            is_constructible_v<layout_left::mapping<dextents<int, 3>>, layout_stride::mapping<dextents<int, 3>>>);
+    }
+
+    { // Check construction from layout_stride::mapping<E> when E is invalid
+        using Mapping = layout_left::mapping<extents<int, 3>>;
+        static_assert(!is_constructible_v<Mapping, layout_stride::mapping<extents<int, 1>>>);
+        static_assert(!is_constructible_v<Mapping, layout_stride::mapping<extents<int, 2>>>);
+    }
+
+    { // Check implicit conversions
+        static_assert(
+            !NotImplicitlyConstructibleFrom<layout_left::mapping<extents<int>>, layout_stride::mapping<extents<int>>>);
+        static_assert(NotImplicitlyConstructibleFrom<layout_left::mapping<extents<int, 3>>,
+            layout_stride::mapping<extents<int, 3>>>);
+        static_assert(NotImplicitlyConstructibleFrom<layout_left::mapping<extents<int, 3>>,
+            layout_stride::mapping<extents<long long, 3>>>);
+        static_assert(NotImplicitlyConstructibleFrom<layout_left::mapping<extents<int, 3>>,
+            layout_stride::mapping<extents<int, dynamic_extent>>>);
+    }
+}
+
+constexpr void check_call_operator() {
+    { // Check call with invalid amount of indices
+        using Mapping = layout_left::mapping<dextents<int, 3>>;
+        static_assert(!CanInvokeCallOperatorOfMapping<Mapping, int>);
+        static_assert(!CanInvokeCallOperatorOfMapping<Mapping, int, int>);
+        static_assert(CanInvokeCallOperatorOfMapping<Mapping, int, int, int>);
+        static_assert(!CanInvokeCallOperatorOfMapping<Mapping, int, int, int, int>);
+    }
+
+    { // Check call with invalid types
+        using Mapping = layout_left::mapping<dextents<long, 2>>;
+        static_assert(CanInvokeCallOperatorOfMapping<Mapping, long, long>);
+        static_assert(CanInvokeCallOperatorOfMapping<Mapping, long, short>);
+        static_assert(CanInvokeCallOperatorOfMapping<Mapping, long, ConvertibleToInt<long>>);
+        static_assert(CanInvokeCallOperatorOfMapping<Mapping, long, ConvertibleToInt<short>>);
+        static_assert(!CanInvokeCallOperatorOfMapping<Mapping, long, NonConvertibleToAnything>);
+    }
+
+    { // Check call with types that might throw during conversion
+        using Mapping = layout_left::mapping<dextents<long long, 1>>;
+        static_assert(CanInvokeCallOperatorOfMapping<Mapping, ConvertibleToInt<long long, IsNothrow::yes>>);
+        static_assert(!CanInvokeCallOperatorOfMapping<Mapping, ConvertibleToInt<long long, IsNothrow::no>>);
+    }
+
+    { // Check various mappings
+        layout_left::mapping<extents<short>> mapping1;
+        assert(mapping1() == 0);
+
+        layout_left::mapping<extents<int, 3>> mapping2;
+        assert(mapping2(0) == 0);
+        assert(mapping2(1) == 1);
+        assert(mapping2(2) == 2);
+
+        layout_left::mapping<dextents<long, 2>> mapping3{dextents<int, 2>{5, 6}};
+        assert(mapping3(0, 0) == 0);
+        assert(mapping3(1, 0) == 1);
+        assert(mapping3(0, 1) == 5);
+        assert(mapping3(1, 1) == 6);
+        assert(mapping3(2, 1) == 7);
+        assert(mapping3(1, 2) == 11);
+        assert(mapping3(4, 5) == 29);
+    }
+}
+
+constexpr void check_comparisons() {
+    using StaticMapping  = layout_left::mapping<extents<int, 3>>;
+    using DynamicMapping = layout_left::mapping<dextents<int, 1>>;
+
+    { // Check equality_comparable_with concept
+        static_assert(equality_comparable_with<StaticMapping, DynamicMapping>);
+        static_assert(!equality_comparable_with<StaticMapping, layout_left::mapping<extents<int, 3, 3>>>);
+        static_assert(!equality_comparable_with<DynamicMapping, layout_left::mapping<dextents<int, 2>>>);
+    }
+
+    { // Check correctness
+        StaticMapping mapping1;
+        DynamicMapping mapping2{dextents<int, 1>{3}};
+        DynamicMapping mapping3{dextents<int, 1>{2}};
+        assert(mapping1 == mapping2);
+        assert(mapping2 != mapping3);
+        assert(mapping1 != mapping3);
+    }
+}
+
+constexpr void check_correctness() {
+    { // empty extents
+        const array<int, 0> values{};
+        mdspan<const int, extents<int>, layout_left> nothing{values.data()};
+        assert(nothing.size() == 1);
+    }
+
+    { // regular vector
+        const array values{0, 1, 2};
+        mdspan<const int, extents<int, 3>, layout_left> vec{values.data()};
+
+        // TRANSITION, use operator[]
+        assert(vec(0) == 0);
+        assert(vec(1) == 1);
+        assert(vec(2) == 2);
+    }
+
+    { // 3x2 matrix with column-major order
+        const array values{0, 1, 2, 3, 4, 5};
+        mdspan<const int, extents<int, 3, 2>, layout_left> matrix{values.data()};
+
+        // TRANSITION, use operator[]
+        assert(matrix(0, 0) == 0);
+        assert(matrix(1, 0) == 1);
+        assert(matrix(2, 0) == 2);
+        assert(matrix(0, 1) == 3);
+        assert(matrix(1, 1) == 4);
+        assert(matrix(2, 1) == 5);
+    }
+
+    { // 3x2x4 tensor
+        const array values{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23};
+        mdspan<const int, dextents<size_t, 3>, layout_left> tensor{values.data(), 3, 2, 4};
+
+        // TRANSITION, use operator[]
+        assert(tensor(0, 0, 0) == 0);
+        assert(tensor(2, 0, 0) == 2);
+        assert(tensor(1, 1, 1) == 10);
+        assert(tensor(0, 0, 3) == 18);
+        assert(tensor(2, 2, 2) == 20);
+        assert(tensor(2, 1, 3) == 23);
+    }
+
+    { // 2x3x2x3 tensor
+        const array values{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
+            26, 27, 28, 29, 30, 31, 32, 33, 34, 35};
+        mdspan<const int, extents<long, 2, 3, dynamic_extent, dynamic_extent>, layout_left> tensor{values.data(), 2, 3};
+
+        // TRANSITION, use operator[]
+        assert(tensor(0, 0, 0, 0) == 0);
+        assert(tensor(1, 0, 0, 0) == 1);
+        assert(tensor(0, 1, 1, 0) == 8);
+        assert(tensor(0, 0, 0, 1) == 12);
+        assert(tensor(0, 0, 0, 2) == 24);
+        assert(tensor(0, 2, 0, 2) == 28);
+        assert(tensor(1, 2, 1, 2) == 35);
+    }
+}
+
+constexpr bool test() {
+    check_members(extents<short>{});
+    check_members(extents<int, 1, 2, 3>{});
+    check_members(extents<unsigned short, 4, 4>{});
+    check_members(extents<unsigned long long, dynamic_extent, 4, 5>{3});
+    check_members(extents<short, dynamic_extent, dynamic_extent, 6>{4, 5});
+    check_members(extents<unsigned char, dynamic_extent, dynamic_extent, dynamic_extent>{3, 3, 3});
+    check_construction_from_other_left_mapping();
+    check_construction_from_other_right_mapping();
+    check_construction_from_other_stride_mapping();
+    check_call_operator();
+    check_comparisons();
+    check_correctness();
+    return true;
+}
+
+
+int main() {
+    static_assert(test());
+    test();
+}

--- a/tests/std/tests/P0009R18_mdspan_layout_left/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_layout_left/test.cpp
@@ -23,12 +23,13 @@ constexpr void do_check_members(const extents<IndexType, Extents...>& ext, index
     using Ext     = extents<IndexType, Extents...>;
     using Mapping = layout_left::mapping<Ext>;
 
-    // Check layout mapping requirements
+    // layout_left meets the layout mapping policy requirements and is a trivial type
     static_assert(check_layout_mapping_policy_requirements<layout_left, Ext>());
+    static_assert(is_trivial_v<layout_left>);
 
     // layout_left::mapping<Ext> is a trivially copyable type that models regular for each Ext
-    static_assert(is_trivially_copyable_v<Ext>);
-    static_assert(regular<Ext>);
+    static_assert(is_trivially_copyable_v<Mapping>);
+    static_assert(regular<Mapping>);
 
     // Check member types
     static_assert(same_as<typename Mapping::extents_type, Ext>);

--- a/tests/std/tests/P0009R18_mdspan_layout_left/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_layout_left/test.cpp
@@ -11,6 +11,8 @@
 
 #include "test_mdspan_support.hpp"
 
+using namespace std;
+
 template <class Mapping, class... Indices>
 concept CanInvokeCallOperatorOfMapping = requires(Mapping mapping, Indices... i) {
                                              { mapping(i...) } -> same_as<typename Mapping::index_type>;

--- a/tests/std/tests/P0009R18_mdspan_layout_left/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_layout_left/test.cpp
@@ -135,7 +135,7 @@ constexpr void do_check_members(const extents<IndexType, Extents...>& ext, index
         static_assert(noexcept(mapping.stride(Ext::rank() - 1)));
         static_assert(noexcept(mapping.stride(0)));
     } else {
-        static_assert(!CheckStrideMemberFunc<Mapping>);
+        static_assert(!CheckStrideMemberFunction<Mapping>);
     }
 
     { // Check comparisons

--- a/tests/std/tests/P0009R18_mdspan_layout_left/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_layout_left/test.cpp
@@ -24,7 +24,7 @@ constexpr void do_check_members(const extents<IndexType, Extents...>& ext, index
     // Check layout mapping requirements
     static_assert(check_layout_mapping_policy_requirements<layout_left, Ext>());
 
-    // layout_left​::​mapping<Ext> is a trivially copyable type that models regular for each Ext
+    // layout_left::mapping<Ext> is a trivially copyable type that models regular for each Ext
     static_assert(is_trivially_copyable_v<Ext>);
     static_assert(regular<Ext>);
 

--- a/tests/std/tests/P0009R18_mdspan_layout_left/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_layout_left/test.cpp
@@ -363,7 +363,6 @@ constexpr bool test() {
     return true;
 }
 
-
 int main() {
     static_assert(test());
     test();

--- a/tests/std/tests/P0009R18_mdspan_layout_left_death/env.lst
+++ b/tests/std/tests/P0009R18_mdspan_layout_left_death/env.lst
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+RUNALL_INCLUDE ..\concepts_latest_matrix.lst

--- a/tests/std/tests/P0009R18_mdspan_layout_left_death/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_layout_left_death/test.cpp
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <array>
+#include <cstddef>
+#include <mdspan>
+#include <span>
+
+#include <test_death.hpp>
+
+using namespace std;
+
+// TRANSITION, Test Construction From extents_type
+
+void test_construction_from_other_left_mapping() {
+    layout_left::mapping<dextents<int, 1>> mapping1{dextents<int, 1>{256}};
+    // Value of other.required_span_size() must be representable as a value of type index_type
+    layout_left::mapping<dextents<unsigned char, 1>> mapping2{mapping1};
+}
+
+void test_construction_from_other_right_mapping() {
+    layout_right::mapping<dextents<int, 1>> mapping1{dextents<int, 1>{256}};
+    // Value of other.required_span_size() must be representable as a value of type index_type
+    layout_left::mapping<dextents<unsigned char, 1>> mapping2{mapping1};
+}
+
+#pragma warning(push) // TRANSITION, "/analyze:only" BUG?
+#pragma warning(disable : 28020) // The expression '0<=_Param_(1)&&_Param_(1)<=1-1' is not true at this call
+void test_construction_from_other_stride_mapping_1() {
+    using Ext = extents<int, 2, 4>;
+    layout_stride::mapping<Ext> mapping1{Ext{}, array{1, 1}};
+    // For all r in the range [0, extents_type::rank()), other.stride(r) must be equal to
+    // extents().fwd-prod-of-extents(r)
+    layout_left::mapping<Ext> mapping2{mapping1};
+}
+
+void test_construction_from_other_stride_mapping_2() {
+    layout_stride::mapping<dextents<int, 1>> mapping1{dextents<int, 1>{256}, array{1}};
+    // Value of other.required_span_size() must be representable as a value of type index_type
+    layout_left::mapping<dextents<unsigned char, 1>> mapping2{mapping1};
+}
+#pragma warning(pop) // TRANSITION, "/analyze:only" BUG?
+
+void test_stride_function() {
+    layout_left::mapping<extents<int, 3>> mapping;
+    // Value of i must be less than extents_type::rank()
+    (void) mapping.stride(1);
+}
+
+int main(int argc, char* argv[]) {
+    std_testing::death_test_executive exec;
+    exec.add_death_tests({
+        // TRANSITION Construction From extents_type
+        test_construction_from_other_left_mapping,
+        test_construction_from_other_right_mapping,
+        test_construction_from_other_stride_mapping_1,
+        test_construction_from_other_stride_mapping_2,
+        test_stride_function,
+    });
+    return exec.run(argc, argv);
+}

--- a/tests/std/tests/P0009R18_mdspan_layout_left_death/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_layout_left_death/test.cpp
@@ -13,38 +13,38 @@ using namespace std;
 // TRANSITION, Test Construction From extents_type
 
 void test_construction_from_other_left_mapping() {
-    layout_left::mapping<dextents<int, 1>> mapping1{dextents<int, 1>{256}};
+    layout_left::mapping<dextents<int, 1>> m1{dextents<int, 1>{256}};
     // Value of other.required_span_size() must be representable as a value of type index_type
-    layout_left::mapping<dextents<unsigned char, 1>> mapping2{mapping1};
+    layout_left::mapping<dextents<unsigned char, 1>> m2{m1};
 }
 
 void test_construction_from_other_right_mapping() {
-    layout_right::mapping<dextents<int, 1>> mapping1{dextents<int, 1>{256}};
+    layout_right::mapping<dextents<int, 1>> m1{dextents<int, 1>{256}};
     // Value of other.required_span_size() must be representable as a value of type index_type
-    layout_left::mapping<dextents<unsigned char, 1>> mapping2{mapping1};
+    layout_left::mapping<dextents<unsigned char, 1>> m2{m1};
 }
 
 #pragma warning(push) // TRANSITION, "/analyze:only" BUG?
 #pragma warning(disable : 28020) // The expression '0<=_Param_(1)&&_Param_(1)<=1-1' is not true at this call
 void test_construction_from_other_stride_mapping_1() {
     using Ext = extents<int, 2, 4>;
-    layout_stride::mapping<Ext> mapping1{Ext{}, array{1, 1}};
+    layout_stride::mapping<Ext> m1{Ext{}, array{1, 1}};
     // For all r in the range [0, extents_type::rank()), other.stride(r) must be equal to
     // extents().fwd-prod-of-extents(r)
-    layout_left::mapping<Ext> mapping2{mapping1};
+    layout_left::mapping<Ext> m2{m1};
 }
 
 void test_construction_from_other_stride_mapping_2() {
-    layout_stride::mapping<dextents<int, 1>> mapping1{dextents<int, 1>{256}, array{1}};
+    layout_stride::mapping<dextents<int, 1>> m1{dextents<int, 1>{256}, array{1}};
     // Value of other.required_span_size() must be representable as a value of type index_type
-    layout_left::mapping<dextents<unsigned char, 1>> mapping2{mapping1};
+    layout_left::mapping<dextents<unsigned char, 1>> m2{m1};
 }
 #pragma warning(pop) // TRANSITION, "/analyze:only" BUG?
 
 void test_stride_function() {
-    layout_left::mapping<extents<int, 3>> mapping;
+    layout_left::mapping<extents<int, 3>> m;
     // Value of i must be less than extents_type::rank()
-    (void) mapping.stride(1);
+    (void) m.stride(1);
 }
 
 int main(int argc, char* argv[]) {


### PR DESCRIPTION
`<mdspan>`:
* Implement `layout_left::mapping`'s preconditions,
* Fix `is_(unique/exhaustive/strided)` functions - they should be `static`,
* Add exposition-only public member *`_Fwd_prod_of_extents`* to `extents`,
* Fix some issues with signed-unsigned conversions,
* Fix `mdspan`'s constructor constraints,
* Address https://github.com/microsoft/STL/pull/3593#discussion_r1148923347.

Testing:
* Introduce `test_mdspan_support.hpp` header,
* Add separate tests for `layout_left`: regular tests and death tests.