### PR TITLE
Revert the ppltasks change that introduced an `ole32.dll` dependency

### DIFF
--- a/stl/CMakeLists.txt
+++ b/stl/CMakeLists.txt
@@ -576,7 +576,7 @@ function(add_stl_dlls D_SUFFIX REL_OR_DBG)
     target_stl_compile_options(msvcp${D_SUFFIX}_eha_objects ${REL_OR_DBG})
 
     add_library(msvcp${D_SUFFIX} SHARED)
-    target_link_libraries(msvcp${D_SUFFIX} PRIVATE msvcp${D_SUFFIX}_eha_objects msvcp${D_SUFFIX}_objects msvcp${D_SUFFIX}_init_objects "${TOOLSET_LIB}/vcruntime${D_SUFFIX}.lib" "${TOOLSET_LIB}/msvcrt${D_SUFFIX}.lib" "ucrt${D_SUFFIX}.lib" "ole32.lib")
+    target_link_libraries(msvcp${D_SUFFIX} PRIVATE msvcp${D_SUFFIX}_eha_objects msvcp${D_SUFFIX}_objects msvcp${D_SUFFIX}_init_objects "${TOOLSET_LIB}/vcruntime${D_SUFFIX}.lib" "${TOOLSET_LIB}/msvcrt${D_SUFFIX}.lib" "ucrt${D_SUFFIX}.lib")
     set_target_properties(msvcp${D_SUFFIX} PROPERTIES ARCHIVE_OUTPUT_NAME "msvcp140_base${D_SUFFIX}${VCLIBS_SUFFIX}")
     set_target_properties(msvcp${D_SUFFIX} PROPERTIES ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
     set_target_properties(msvcp${D_SUFFIX} PROPERTIES OUTPUT_NAME "msvcp140${D_SUFFIX}${VCLIBS_SUFFIX}")

--- a/stl/msbuild/stl_base/msvcp.settings.targets
+++ b/stl/msbuild/stl_base/msvcp.settings.targets
@@ -51,8 +51,6 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         <LinkAdditionalOptions Condition="$(DebugBuild) == 'true'">-opt:ref,noicf $(LinkAdditionalOptions)</LinkAdditionalOptions>
         <LinkAdditionalOptions>-nodefaultlib:libcpmt$(BuildSuffix).lib $(LinkAdditionalOptions)</LinkAdditionalOptions>
         <LinkAdditionalOptions>-nodefaultlib:$(LibOutputFile) $(LinkAdditionalOptions)</LinkAdditionalOptions>
-        <LinkingWithMinCore Condition="'$(MsvcpFlavor)' == 'app' or '$(MsvcpFlavor)' == 'onecore'">true</LinkingWithMinCore>
-        <LinkAdditionalOptions Condition="'$(LinkingWithMinCore)' != 'true'">ole32.lib $(LinkAdditionalOptions)</LinkAdditionalOptions>
 
         <LinkGenerateMapFile>true</LinkGenerateMapFile>
         <LinkRelease>true</LinkRelease>

--- a/stl/src/ppltasks.cpp
+++ b/stl/src/ppltasks.cpp
@@ -289,13 +289,6 @@ namespace Concurrency {
         }
 
         _CRTIMP2 bool __cdecl _Task_impl_base::_IsNonBlockingThread() {
-// TRANSITION, ABI: This preprocessor directive attempts to fix VSO-1684985 (a bincompat issue affecting VS 2015 code)
-// while preserving as much of GH-2654 as possible. When we can break ABI, we should:
-// * Remove this preprocessor directive - it should be unnecessary after <ppltasks.h> was changed on 2018-01-12.
-// * In <ppltasks.h>, reconsider whether _Task_impl_base::_Wait() should throw invalid_operation;
-//   it's questionable whether that's conforming, and if users want to block their UI threads, we should let them.
-// * Investigate whether we can avoid the ppltasks dependency entirely, making all of these issues irrelevant.
-#if defined(_CRT_APP) || defined(UNDOCKED_WINDOWS_UCRT)
             APTTYPE _AptType;
             APTTYPEQUALIFIER _AptTypeQualifier;
 
@@ -321,8 +314,6 @@ namespace Concurrency {
                     break;
                 }
             }
-#endif // defined(_CRT_APP) || defined(UNDOCKED_WINDOWS_UCRT)
-
             return false;
         }
     } // namespace details

--- a/stl/src/ppltasks.cpp
+++ b/stl/src/ppltasks.cpp
@@ -7,6 +7,7 @@
 
 #include <Windows.h>
 
+#if defined(_CRT_APP) || defined(UNDOCKED_WINDOWS_UCRT)
 #ifndef UNDOCKED_WINDOWS_UCRT
 #pragma warning(push)
 #pragma warning(disable : 4265) // non-virtual destructor in base class
@@ -18,8 +19,7 @@
 #include <ctxtcall.h>
 #include <mutex>
 #include <windows.foundation.diagnostics.h>
-
-#pragma comment(lib, "ole32")
+#endif
 
 // This IID is exported by ole32.dll; we cannot depend on ole32.dll on OneCore.
 static GUID const Local_IID_ICallbackWithNoReentrancyToApplicationSTA = {
@@ -219,6 +219,7 @@ namespace Concurrency {
         _CRTIMP2 void __thiscall _TaskEventLogger::_LogWorkItemCompleted() {}
 #endif
 
+#if defined(_CRT_APP) || defined(UNDOCKED_WINDOWS_UCRT)
         using namespace ABI::Windows::Foundation;
         using namespace ABI::Windows::Foundation::Diagnostics;
         using namespace Microsoft::WRL;
@@ -316,6 +317,26 @@ namespace Concurrency {
             }
             return false;
         }
+
+#else
+        _CRTIMP2 void __thiscall _ContextCallback::_CallInContext(_CallbackFunction _Func, bool) const {
+            _Func();
+        }
+
+        _CRTIMP2 void __thiscall _ContextCallback::_Capture() {}
+
+        _CRTIMP2 void __thiscall _ContextCallback::_Reset() {}
+
+        _CRTIMP2 void __thiscall _ContextCallback::_Assign(void*) {}
+
+        _CRTIMP2 bool __cdecl _ContextCallback::_IsCurrentOriginSTA() {
+            return false;
+        }
+
+        _CRTIMP2 bool __cdecl _Task_impl_base::_IsNonBlockingThread() {
+            return false;
+        }
+#endif
     } // namespace details
 
 #ifdef _CRT_APP


### PR DESCRIPTION
This is a clean revert (no manual changes) of #2654 and the following #3255 (in reverse order). #3255 was a targeted fix (partial revert) for an incredibly disruptive bincompat bug, but #2654 has caused even more trouble. This full revert:

* Fixes #3257, where the newly added dependency on `ole32.dll` was disruptive to certain exotic scenarios, and
* Fixes a "sandboxed process" scenario for the XStore team (reported by @vaboca), also disrupted by `ole32.dll`.
  + Don't ask me to explain this in any more detail, I don't know what's going on here. :exploding_head: That's the whole problem with this change - nobody fully understood the implications - and that's why we need to fully revert it, not mess around with it more.

By performing a full revert, we no longer need the partial revert. This returns us to the state that we successfully lived with in VS 2015 through VS 2022 17.2 inclusive.

@Scottj1s, the original author of #2654, agrees with the full revert here, and has confirmed that the original affected customer who needed that change has the ability to use a workaround in perpetuity.

:mirror: The mirror of this PR, MSVC-PR-462260, additionally reverts the non-GitHub change in MSVC-PR-339372 affecting `<ppltasks.h>`.

:grey_exclamation: By changing `ppltasks.cpp` again, this affects the VCRedist. For the bincompat scenario involving mixing VS 2015, this should be unquestionably safe (the partial revert and the full revert result in the same behavior for the function in question, that's why the partial revert worked). For the question of when we can ship this fix, because it is urgently needed by the XStore team, we are planning to port this fix to VS 2022 17.6 before it reaches General Availability, which will require unlocking its redist, and then that unlocked redist will flow into VS 2022 17.7, so there should be no remaining mix-and-match nightmares (I hope).

I am not performing any other changes or cleanups at this time (I may come back to `ppltasks.cpp` in the future to add some `#endif` comments, but no logic changes, I have had a lifetime of being burned here).

I've filed #3606 to capture the vNext comments that are being reverted here.

:warning: Note to self: Remember to start the 17.6 backport process after merging this.