### PR TITLE
`<ranges>`: Explicitly specify the template parameters for `tuple`

### DIFF
--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -9849,7 +9849,8 @@ namespace ranges {
 
             template <size_t... _Indices>
             _NODISCARD constexpr auto _End_tuple(index_sequence<_Indices...>) const {
-                return tuple{_RANGES end(_STD get<0>(_Parent->_Bases)),
+                return tuple<sentinel_t<_Maybe_const<_Const, _First>>, iterator_t<_Maybe_const<_Const, _Rest>>...>{
+                    _RANGES end(_STD get<0>(_Parent->_Bases)),
                     _RANGES begin(_STD get<_Indices + 1>(_Parent->_Bases))...};
             }
 
@@ -10089,7 +10090,7 @@ namespace ranges {
             (make_index_sequence<sizeof...(_Rest)>{});
 
             const auto _Make_iter_tuple = [&]<size_t... _Indices>(index_sequence<_Indices...>) {
-                return tuple{_Begin_or_first_end<_Indices>(_Is_empty)...};
+                return tuple<iterator_t<_First>, iterator_t<_Rest>...>{_Begin_or_first_end<_Indices>(_Is_empty)...};
             };
             return _Iterator<false>{*this, _Make_iter_tuple(make_index_sequence<1 + sizeof...(_Rest)>{})};
         }
@@ -10103,7 +10104,8 @@ namespace ranges {
             (make_index_sequence<sizeof...(_Rest)>{});
 
             const auto _Make_iter_tuple = [&]<size_t... _Indices>(index_sequence<_Indices...>) {
-                return tuple{_Begin_or_first_end<_Indices>(_Is_empty)...};
+                return tuple<iterator_t<const _First>, iterator_t<const _Rest>...>{
+                    _Begin_or_first_end<_Indices>(_Is_empty)...};
             };
             return _Iterator<true>{*this, _Make_iter_tuple(make_index_sequence<1 + sizeof...(_Rest)>{})};
         }


### PR DESCRIPTION
Class template argument deduction for `std::tuple` does not always result in a `tuple` of the arguments (e.g. when the first argument is a `pair`). This PR adds the template parameters to ensure that these uses of `tuple` behave as expected in pathological cases.

<details>
<summary>example</summary>

```c++
#include <ranges>
#include <utility>

struct Tag {};

using Sent = std::pair<Tag, int>;

bool operator==(int*, Sent);
std::ptrdiff_t operator-(int*, Sent);
std::ptrdiff_t operator-(Sent, int*);

struct Rng {
    int* begin();
    Sent end();
};

int main() {
    auto x  = std::views::cartesian_product(Rng{});
    (void) (x.begin() - std::default_sentinel); // `operator-` calls `_It._Distance_from(_It._End_tuple(...))`
    // Before: `_End_tuple` returns a `tuple<Tag, int>`, which results in an error in `_Distance_from`
    // After: `_End_tuple` returns a `tuple<Sent>` as expected
}
```
</details>