### PR TITLE
Don't include `<xmemory>` in `<optional>` and `<variant>`

### DIFF
--- a/stl/inc/optional
+++ b/stl/inc/optional
@@ -11,7 +11,13 @@
 #if !_HAS_CXX17
 _EMIT_STL_WARNING(STL4038, "The contents of <optional> are available only with C++17 or later.");
 #else // ^^^ !_HAS_CXX17 / _HAS_CXX17 vvv
+#if _HAS_CXX20
+#include <compare>
+#endif // _HAS_CXX20
 #include <exception>
+#include <initializer_list>
+#include <type_traits>
+#include <utility>
 #include <xsmf_control.h>
 #include <xutility>
 
@@ -98,7 +104,7 @@ struct _Optional_destruct_base<_Ty, false> { // either contains a value of _Ty o
 
     _CONSTEXPR20 ~_Optional_destruct_base() noexcept {
         if (_Has_value) {
-            _Value.~decltype(_Value)();
+            _Value.~_Ty();
         }
     }
 
@@ -123,7 +129,7 @@ struct _Optional_destruct_base<_Ty, false> { // either contains a value of _Ty o
 
     _CONSTEXPR20 void reset() noexcept {
         if (_Has_value) {
-            _Value.~decltype(_Value)();
+            _Value.~_Ty();
             _Has_value = false;
         }
     }

--- a/stl/inc/optional
+++ b/stl/inc/optional
@@ -98,7 +98,7 @@ struct _Optional_destruct_base<_Ty, false> { // either contains a value of _Ty o
 
     _CONSTEXPR20 ~_Optional_destruct_base() noexcept {
         if (_Has_value) {
-            _Value.~decltype(_Value);
+            _Value.~decltype(_Value)();
         }
     }
 
@@ -123,7 +123,7 @@ struct _Optional_destruct_base<_Ty, false> { // either contains a value of _Ty o
 
     _CONSTEXPR20 void reset() noexcept {
         if (_Has_value) {
-            _Value.~decltype(_Value);
+            _Value.~decltype(_Value)();
             _Has_value = false;
         }
     }

--- a/stl/inc/optional
+++ b/stl/inc/optional
@@ -11,15 +11,9 @@
 #if !_HAS_CXX17
 _EMIT_STL_WARNING(STL4038, "The contents of <optional> are available only with C++17 or later.");
 #else // ^^^ !_HAS_CXX17 / _HAS_CXX17 vvv
-#if _HAS_CXX20
-#include <compare>
-#endif // _HAS_CXX20
 #include <exception>
-#include <initializer_list>
-#include <type_traits>
-#include <utility>
-#include <xmemory>
 #include <xsmf_control.h>
+#include <xutility>
 
 #pragma pack(push, _CRT_PACKING)
 #pragma warning(push, _STL_WARNING_LEVEL)
@@ -104,7 +98,7 @@ struct _Optional_destruct_base<_Ty, false> { // either contains a value of _Ty o
 
     _CONSTEXPR20 ~_Optional_destruct_base() noexcept {
         if (_Has_value) {
-            _Destroy_in_place(_Value);
+            _Value.~decltype(_Value);
         }
     }
 
@@ -129,7 +123,7 @@ struct _Optional_destruct_base<_Ty, false> { // either contains a value of _Ty o
 
     _CONSTEXPR20 void reset() noexcept {
         if (_Has_value) {
-            _Destroy_in_place(_Value);
+            _Value.~decltype(_Value);
             _Has_value = false;
         }
     }

--- a/stl/inc/variant
+++ b/stl/inc/variant
@@ -13,12 +13,8 @@
 _EMIT_STL_WARNING(STL4038, "The contents of <variant> are available only with C++17 or later.");
 #else // ^^^ !_HAS_CXX17 / _HAS_CXX17 vvv
 #include <exception>
-#include <initializer_list>
-#include <type_traits>
-#include <utility>
-#include <xmemory>
 #include <xsmf_control.h>
-#include <xstddef>
+#include <xutility>
 
 #pragma pack(push, _CRT_PACKING)
 #pragma warning(push, _STL_WARNING_LEVEL)
@@ -808,8 +804,9 @@ public:
     _CONSTEXPR20 void _Destroy() noexcept {
         // destroy the contained value
         // pre: _Idx == index()
-        if constexpr (_Idx != variant_npos && !is_trivially_destructible_v<_Meta_at_c<variant<_Types...>, _Idx>>) {
-            _STD _Destroy_in_place(_STD _Variant_raw_get<_Idx>(_Storage()));
+        using _Indexed_value_type = remove_cv_t<_Meta_at_c<variant<_Types...>, _Idx>>;
+        if constexpr (_Idx != variant_npos && !is_trivially_destructible_v<_Indexed_value_type>) {
+            _STD _Variant_raw_get<_Idx>(_Storage()).~_Indexed_value_type();
         }
     }
 
@@ -817,7 +814,8 @@ public:
         if constexpr (!conjunction_v<is_trivially_destructible<_Types>...>) {
             _STD _Variant_raw_visit(index(), _Storage(), [](auto _Ref) noexcept {
                 if constexpr (decltype(_Ref)::_Idx != variant_npos) {
-                    _STD _Destroy_in_place(_Ref._Val);
+                    using _Indexed_value_type = _Remove_cvref_t<decltype(_Ref._Val)>;
+                    _Ref._Val.~_Indexed_value_type();
                 }
             });
         }

--- a/stl/inc/variant
+++ b/stl/inc/variant
@@ -12,7 +12,13 @@
 #if !_HAS_CXX17
 _EMIT_STL_WARNING(STL4038, "The contents of <variant> are available only with C++17 or later.");
 #else // ^^^ !_HAS_CXX17 / _HAS_CXX17 vvv
+#if _HAS_CXX20
+#include <compare>
+#endif // _HAS_CXX20
 #include <exception>
+#include <initializer_list>
+#include <type_traits>
+#include <utility>
 #include <xsmf_control.h>
 #include <xutility>
 

--- a/stl/inc/variant
+++ b/stl/inc/variant
@@ -689,10 +689,12 @@ _NODISCARD constexpr _Variant_raw_visit_t<_Fn, _Storage> _Variant_raw_visit(
 template <class...>
 class _Variant_base;
 
+inline constexpr size_t _Schar_max_as_size = static_cast<unsigned char>(-1) / 2;
+inline constexpr size_t _Short_max_as_size = static_cast<unsigned short>(-1) / 2;
+
 template <size_t _Count>
 using _Variant_index_t = // signed so that conversion of -1 to size_t can cheaply sign extend
-    conditional_t<(_Count < static_cast<size_t>((numeric_limits<signed char>::max)())), signed char,
-        conditional_t<(_Count < static_cast<size_t>((numeric_limits<short>::max)())), short, int>>;
+    conditional_t<(_Count < _Schar_max_as_size), signed char, conditional_t<(_Count < _Short_max_as_size), short, int>>;
 
 template <class... _Types>
 struct _Variant_construct_visitor { // visitor that constructs the same alternative in a target _Variant_base as is


### PR DESCRIPTION
Separated from #3623.

`std::variant` and `std::optional` forbid using an array type as component, so it's unnecessary to include `<xmemory>` to obtain `_Destroy_in_place`.

~I think it's OK to write `<xutility>` for short. Several other headers, including conditionally included `<compare>`, are already handled in `<xutility>`.~ Edit: dropping this due to review comments.

Edit: I also need to reduce the `numeric_limits` depedency (needed for EDG?). I expect that the current approach is transient.