### PR TITLE
Move `_Char_traits_eq` and `_Char_traits_lt` from `<xstring>` to `<regex>`

### DIFF
--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -178,6 +178,38 @@ struct _Cl_names { // structure to associate class name with mask value
     }
 };
 
+template <class _Traits>
+struct _Char_traits_eq {
+    using _Elem = typename _Traits::char_type;
+
+    bool operator()(_Elem _Left, _Elem _Right) const noexcept {
+        return _Traits::eq(_Left, _Right);
+    }
+};
+
+template <class _Traits>
+struct _Char_traits_lt {
+    using _Elem = typename _Traits::char_type;
+
+    bool operator()(_Elem _Left, _Elem _Right) const noexcept {
+        return _Traits::lt(_Left, _Right);
+    }
+};
+
+// library-provided char_traits::eq behaves like equal_to<_Elem>
+// TRANSITION: This should not be activated for user-defined specializations of char_traits
+template <class _Elem>
+_INLINE_VAR constexpr bool _Can_memcmp_elements_with_pred<_Elem, _Elem, _Char_traits_eq<char_traits<_Elem>>> =
+    _Can_memcmp_elements<_Elem, _Elem>;
+
+// library-provided char_traits::lt behaves like less<make_unsigned_t<_Elem>>
+// TRANSITION: This should not be activated for user-defined specializations of char_traits
+template <class _Elem>
+struct _Lex_compare_memcmp_classify_pred<_Elem, _Elem, _Char_traits_lt<char_traits<_Elem>>> {
+    using _UElem = make_unsigned_t<_Elem>;
+    using _Pred  = conditional_t<_Lex_compare_memcmp_classify_elements<_UElem, _UElem>, less<int>, void>;
+};
+
 template <class _RxTraits>
 struct _Cmp_cs { // functor to compare two character values for equality
     using _Elem = typename _RxTraits::char_type;

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -536,38 +536,6 @@ basic_ostream<_Elem, _Traits>& _Insert_string(
 }
 
 template <class _Traits>
-struct _Char_traits_eq {
-    using _Elem = typename _Traits::char_type;
-
-    bool operator()(_Elem _Left, _Elem _Right) const noexcept {
-        return _Traits::eq(_Left, _Right);
-    }
-};
-
-template <class _Traits>
-struct _Char_traits_lt {
-    using _Elem = typename _Traits::char_type;
-
-    bool operator()(_Elem _Left, _Elem _Right) const noexcept {
-        return _Traits::lt(_Left, _Right);
-    }
-};
-
-// library-provided char_traits::eq behaves like equal_to<_Elem>
-// TRANSITION: This should not be activated for user-defined specializations of char_traits
-template <class _Elem>
-_INLINE_VAR constexpr bool _Can_memcmp_elements_with_pred<_Elem, _Elem, _Char_traits_eq<char_traits<_Elem>>> =
-    _Can_memcmp_elements<_Elem, _Elem>;
-
-// library-provided char_traits::lt behaves like less<make_unsigned_t<_Elem>>
-// TRANSITION: This should not be activated for user-defined specializations of char_traits
-template <class _Elem>
-struct _Lex_compare_memcmp_classify_pred<_Elem, _Elem, _Char_traits_lt<char_traits<_Elem>>> {
-    using _UElem = make_unsigned_t<_Elem>;
-    using _Pred  = conditional_t<_Lex_compare_memcmp_classify_elements<_UElem, _UElem>, less<int>, void>;
-};
-
-template <class _Traits>
 using _Traits_ch_t = typename _Traits::char_type;
 
 template <class _Traits>

--- a/tests/std/tests/GH_000431_equal_memcmp_is_safe/test.compile.pass.cpp
+++ b/tests/std/tests/GH_000431_equal_memcmp_is_safe/test.compile.pass.cpp
@@ -7,6 +7,7 @@
 #include <functional>
 #include <iterator>
 #include <list>
+#include <regex>
 #include <string>
 #include <type_traits>
 #include <vector>

--- a/tests/std/tests/GH_000431_lex_compare_memcmp_classify/test.compile.pass.cpp
+++ b/tests/std/tests/GH_000431_lex_compare_memcmp_classify/test.compile.pass.cpp
@@ -7,6 +7,7 @@
 #include <functional>
 #include <iterator>
 #include <list>
+#include <regex>
 #include <string>
 #include <type_traits>
 #include <vector>


### PR DESCRIPTION
As these functors are only used in `<regex>`. Separated from #3623.