### PR TITLE
Don't include `<algorithm>` in `<chrono>`

### DIFF
--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -18,7 +18,6 @@
 
 #if _HAS_CXX20
 #include <__msvc_tzdb.hpp>
-#include <algorithm>
 #include <atomic>
 #include <cmath>
 #include <compare>
@@ -2250,14 +2249,19 @@ namespace chrono {
             auto [_Leap_sec, _All_ls_positive] = _Tzdb_generate_leap_seconds(_Tzdb_list.front().leap_seconds.size());
             if (!_Leap_sec.empty()) {
                 const auto& _Tzdb = _Tzdb_list.front();
+
                 vector<time_zone> _Zones;
-                _STD transform(_Tzdb.zones.begin(), _Tzdb.zones.end(), _STD back_inserter(_Zones),
-                    [](const auto& _Tz) { return time_zone{_Tz.name()}; });
+                _Zones.reserve(_Tzdb.zones.size());
+                for (const auto& _Tz : _Tzdb.zones) {
+                    _Zones.emplace_back(_Tz.name());
+                }
+
                 vector<time_zone_link> _Links;
-                _STD transform(
-                    _Tzdb.links.begin(), _Tzdb.links.end(), _STD back_inserter(_Links), [](const auto& _Link) {
-                        return time_zone_link{_Link.name(), _Link.target()};
-                    });
+                _Links.reserve(_Tzdb.links.size());
+                for (const auto& _Link : _Tzdb.links) {
+                    _Links.emplace_back(_Link.name(), _Link.target());
+                }
+
                 auto _Version = _Tzdb_update_version(_Tzdb.version, _Leap_sec.size());
                 _Tzdb_list.emplace_front(tzdb{
                     _STD move(_Version), _STD move(_Zones), _STD move(_Links), _STD move(_Leap_sec), _All_ls_positive});


### PR DESCRIPTION
Separated from #3623. Towards #3599.

It seems to me that we don't need to use `transform` for `tzdb_list`. `emplace_back` in loop looks better.