### PR TITLE
Don't include `<bit>` in `<compare>`

### DIFF
--- a/stl/inc/compare
+++ b/stl/inc/compare
@@ -13,7 +13,6 @@
 _EMIT_STL_WARNING(STL4038, "The contents of <compare> are available only with C++20 or later.");
 #else // ^^^ !_HAS_CXX20 / _HAS_CXX20 vvv
 #ifdef __cpp_lib_concepts
-#include <bit>
 #include <concepts>
 #else // ^^^ __cpp_lib_concepts / !__cpp_lib_concepts vvv
 #include <xtr1common>
@@ -427,8 +426,8 @@ namespace _Strong_order {
                 using _Uint_type     = typename _Traits::_Uint_type;
                 using _Sint_type     = make_signed_t<_Uint_type>;
 
-                const auto _Left_uint  = _STD bit_cast<_Uint_type>(_Left);
-                const auto _Right_uint = _STD bit_cast<_Uint_type>(_Right);
+                const auto _Left_uint  = __builtin_bit_cast(_Uint_type, _Left);
+                const auto _Right_uint = __builtin_bit_cast(_Uint_type, _Right);
 
                 // 1. Ultra-fast path: equal representations are equal.
                 if (_Left_uint == _Right_uint) {
@@ -534,8 +533,8 @@ namespace _Weak_order {
                 using _Uint_type     = typename _Traits::_Uint_type;
                 using _Sint_type     = make_signed_t<_Uint_type>;
 
-                auto _Left_uint  = _STD bit_cast<_Uint_type>(_Left);
-                auto _Right_uint = _STD bit_cast<_Uint_type>(_Right);
+                auto _Left_uint  = __builtin_bit_cast(_Uint_type, _Left);
+                auto _Right_uint = __builtin_bit_cast(_Uint_type, _Right);
 
                 // 1. Ultra-fast path: equal representations are equivalent.
                 if (_Left_uint == _Right_uint) {

--- a/stl/inc/compare
+++ b/stl/inc/compare
@@ -426,8 +426,8 @@ namespace _Strong_order {
                 using _Uint_type     = typename _Traits::_Uint_type;
                 using _Sint_type     = make_signed_t<_Uint_type>;
 
-                const auto _Left_uint  = __builtin_bit_cast(_Uint_type, _Left);
-                const auto _Right_uint = __builtin_bit_cast(_Uint_type, _Right);
+                const auto _Left_uint  = _Bit_cast<_Uint_type>(_Left);
+                const auto _Right_uint = _Bit_cast<_Uint_type>(_Right);
 
                 // 1. Ultra-fast path: equal representations are equal.
                 if (_Left_uint == _Right_uint) {
@@ -533,8 +533,8 @@ namespace _Weak_order {
                 using _Uint_type     = typename _Traits::_Uint_type;
                 using _Sint_type     = make_signed_t<_Uint_type>;
 
-                auto _Left_uint  = __builtin_bit_cast(_Uint_type, _Left);
-                auto _Right_uint = __builtin_bit_cast(_Uint_type, _Right);
+                auto _Left_uint  = _Bit_cast<_Uint_type>(_Left);
+                auto _Right_uint = _Bit_cast<_Uint_type>(_Right);
 
                 // 1. Ultra-fast path: equal representations are equivalent.
                 if (_Left_uint == _Right_uint) {

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -44,6 +44,7 @@ _EMIT_STL_WARNING(STL4038, "The contents of <format> are available only with C++
 #else // ^^^ !defined(__cpp_lib_concepts) / defined(__cpp_lib_concepts) vvv
 
 #include <__msvc_format_ucd_tables.hpp>
+#include <bit>
 #include <charconv>
 #include <concepts>
 #include <cstdint>
@@ -1982,7 +1983,7 @@ private:
     template <class _Ty>
     _NODISCARD static auto _Get_value_from_memory(const unsigned char* const _Val) noexcept {
         auto& _Temp = *reinterpret_cast<const unsigned char(*)[sizeof(_Ty)]>(_Val);
-        return _Bit_cast<_Ty>(_Temp);
+        return _STD bit_cast<_Ty>(_Temp);
     }
 
     size_t _Num_args                      = 0;

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -2344,6 +2344,14 @@ struct _Floating_type_traits<long double> : _Floating_type_traits<double> {};
 
 // ^^^^^^^^^^ DERIVED FROM corecrt_internal_fltintrn.h ^^^^^^^^^^
 
+template <class _To, class _From,
+    enable_if_t<conjunction_v<bool_constant<sizeof(_To) == sizeof(_From)>, is_trivially_copyable<_To>,
+                    is_trivially_copyable<_From>>,
+        int> = 0>
+_NODISCARD constexpr _To _Bit_cast(const _From& _Val) noexcept {
+    return __builtin_bit_cast(_To, _Val);
+}
+
 #if _HAS_TR1_NAMESPACE
 _STL_DISABLE_DEPRECATED_WARNING
 namespace _DEPRECATE_TR1_NAMESPACE tr1 {

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -186,14 +186,6 @@ _Ty* __std_max_element(_Ty* _First, _Ty* _Last) noexcept {
 
 _STD_BEGIN
 
-template <class _To, class _From,
-    enable_if_t<conjunction_v<bool_constant<sizeof(_To) == sizeof(_From)>, is_trivially_copyable<_To>,
-                    is_trivially_copyable<_From>>,
-        int> = 0>
-_NODISCARD constexpr _To _Bit_cast(const _From& _Val) noexcept {
-    return __builtin_bit_cast(_To, _Val);
-}
-
 template <class _Ty>
 struct _Get_first_parameter;
 


### PR DESCRIPTION
Separated from #3623. Towards #3599.

Once `<compare>` doesn't include `<bit>`, `<format>` needs to include `<bit>` directly. I think it's better to use the standard `std::bit_cast` in `<format>`.

~I have no good idea how to move `std::bit_cast` to another header. So currently this PR uses the `__builtin_bit_cast` intrinsic.~

The current decision is moving `_Bit_cast` from `<xutility>` to `<type_traits>` and using it in `<compare>`.