### PR TITLE
Don't include `<cwchar>` in `<limits>`

### DIFF
--- a/stl/inc/limits
+++ b/stl/inc/limits
@@ -10,7 +10,6 @@
 #if _STL_COMPILER_PREPROCESSOR
 #include <cfloat>
 #include <climits>
-#include <cwchar>
 #include <isa_availability.h>
 #include <xstddef>
 
@@ -459,11 +458,11 @@ template <>
 class numeric_limits<wchar_t> : public _Num_int_base {
 public:
     _NODISCARD static constexpr wchar_t(min)() noexcept {
-        return WCHAR_MIN;
+        return 0;
     }
 
     _NODISCARD static constexpr wchar_t(max)() noexcept {
-        return WCHAR_MAX;
+        return 0xffff;
     }
 
     _NODISCARD static constexpr wchar_t lowest() noexcept {


### PR DESCRIPTION
Separated from #3482. Towards #3599.