### PR TITLE
`<mdspan>`: Cleanup `extents`'s deduction guide

### DIFF
--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -267,16 +267,12 @@ public:
     }
 };
 
-#if defined(__clang__) || defined(__EDG__) // TRANSITION, REQUIRES REPORT (ICE)
+template <class>
+inline constexpr size_t _Repeat_dynamic_extent = dynamic_extent;
+
 template <class... _Integrals>
     requires (is_convertible_v<_Integrals, size_t> && ...)
-extents(_Integrals... _Exts) -> extents<size_t, ((void) _Exts, dynamic_extent)...>;
-#else // ^^^ no workaround / workaround vvv
-template <class... _Integrals>
-    requires (is_convertible_v<_Integrals, size_t> && ...)
-extents(_Integrals...)
-    -> extents<size_t, conditional_t<true, integral_constant<size_t, dynamic_extent>, _Integrals>::value...>;
-#endif // ^^^ workaround ^^^
+extents(_Integrals...) -> extents<size_t, _Repeat_dynamic_extent<_Integrals>...>;
 
 template <class _IndexType, class _Indices>
 struct _Dextents_impl;

--- a/tests/std/tests/P0009R18_mdspan_layout_right/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_layout_right/test.cpp
@@ -183,12 +183,10 @@ constexpr void check_construction_from_other_left_mapping() {
     }
 
     { // Check implicit conversions
-        static_assert(!NotImplicitlyConstructibleFrom<layout_right::mapping<extents<int, 3>>,
-                      layout_left::mapping<extents<int, 3>>>);
-        static_assert(NotImplicitlyConstructibleFrom<layout_right::mapping<extents<int, 3>>,
-            layout_left::mapping<extents<long long, 3>>>);
-        static_assert(NotImplicitlyConstructibleFrom<layout_right::mapping<extents<int, 3>>,
-            layout_left::mapping<extents<int, dynamic_extent>>>);
+        using Mapping = layout_right::mapping<extents<int, 4>>;
+        static_assert(!NotImplicitlyConstructibleFrom<Mapping, layout_left::mapping<extents<int, 4>>>);
+        static_assert(NotImplicitlyConstructibleFrom<Mapping, layout_left::mapping<extents<long long, 4>>>);
+        static_assert(NotImplicitlyConstructibleFrom<Mapping, layout_left::mapping<extents<int, dynamic_extent>>>);
     }
 }
 


### PR DESCRIPTION
This small PR removes workaround for `extents`'s deduction guide ICE. It looks like the code was incorrect anyway (meaning it is ICE on invalid) and Clang incorrectly accepts it.

Here is a minimal repro: https://godbolt.org/z/Wdjq5boG3, feel free to report it to both LLVM and MSVC (and maybe to GCC, this error message is awful).

Drive-by: address [comment](https://github.com/microsoft/STL/pull/3615#discussion_r1156571002) from previous PR.