### PR TITLE
`<numbers>`: Rework the implementation when concepts are missing

### DIFF
--- a/stl/inc/numbers
+++ b/stl/inc/numbers
@@ -14,7 +14,7 @@ _EMIT_STL_WARNING(STL4038, "The contents of <numbers> are available only with C+
 #ifdef __cpp_lib_concepts
 #include <concepts>
 #else // ^^^ defined(__cpp_lib_concepts) / !defined(__cpp_lib_concepts) vvv
-#include <xstddef>
+#include <xtr1common>
 #endif // ^^^ !defined(__cpp_lib_concepts) ^^^
 
 #pragma pack(push, _CRT_PACKING)
@@ -26,10 +26,11 @@ _STL_DISABLE_CLANG_WARNINGS
 
 _STD_BEGIN
 namespace numbers {
+#ifdef __cpp_lib_concepts
     template <class _Ty>
     struct _Invalid {
         static_assert(_Always_false<_Ty>, "A program that instantiates a primary template of a mathematical constant "
-                                          "variable template is ill-formed. (N4835 [math.constants]/3)");
+                                          "variable template is ill-formed. (N4944 [math.constants]/3)");
     };
 
     _EXPORT_STD template <class _Ty>
@@ -59,7 +60,6 @@ namespace numbers {
     _EXPORT_STD template <class _Ty>
     inline constexpr _Ty phi_v = _Invalid<_Ty>{};
 
-#ifdef __cpp_lib_concepts
     template <floating_point _Floating>
     inline constexpr _Floating e_v<_Floating> = static_cast<_Floating>(2.718281828459045);
     template <floating_point _Floating>
@@ -87,86 +87,42 @@ namespace numbers {
     template <floating_point _Floating>
     inline constexpr _Floating phi_v<_Floating> = static_cast<_Floating>(1.618033988749895);
 #else // ^^^ defined(__cpp_lib_concepts) / !defined(__cpp_lib_concepts) vvv
-    template <>
-    inline constexpr double e_v<double> = 2.718281828459045;
-    template <>
-    inline constexpr double log2e_v<double> = 1.4426950408889634;
-    template <>
-    inline constexpr double log10e_v<double> = 0.4342944819032518;
-    template <>
-    inline constexpr double pi_v<double> = 3.141592653589793;
-    template <>
-    inline constexpr double inv_pi_v<double> = 0.3183098861837907;
-    template <>
-    inline constexpr double inv_sqrtpi_v<double> = 0.5641895835477563;
-    template <>
-    inline constexpr double ln2_v<double> = 0.6931471805599453;
-    template <>
-    inline constexpr double ln10_v<double> = 2.302585092994046;
-    template <>
-    inline constexpr double sqrt2_v<double> = 1.4142135623730951;
-    template <>
-    inline constexpr double sqrt3_v<double> = 1.7320508075688772;
-    template <>
-    inline constexpr double inv_sqrt3_v<double> = 0.5773502691896257;
-    template <>
-    inline constexpr double egamma_v<double> = 0.5772156649015329;
-    template <>
-    inline constexpr double phi_v<double> = 1.618033988749895;
+    template <class _Ty>
+    struct _Reject_primary_template {
+        static_assert(is_floating_point_v<_Ty>, "A program that instantiates a primary template of a mathematical "
+                                                "constant variable template is ill-formed. (N4944 [math.constants]/3)");
+        using type = _Ty;
+    };
 
-    template <>
-    inline constexpr float e_v<float> = static_cast<float>(e_v<double>);
-    template <>
-    inline constexpr float log2e_v<float> = static_cast<float>(log2e_v<double>);
-    template <>
-    inline constexpr float log10e_v<float> = static_cast<float>(log10e_v<double>);
-    template <>
-    inline constexpr float pi_v<float> = static_cast<float>(pi_v<double>);
-    template <>
-    inline constexpr float inv_pi_v<float> = static_cast<float>(inv_pi_v<double>);
-    template <>
-    inline constexpr float inv_sqrtpi_v<float> = static_cast<float>(inv_sqrtpi_v<double>);
-    template <>
-    inline constexpr float ln2_v<float> = static_cast<float>(ln2_v<double>);
-    template <>
-    inline constexpr float ln10_v<float> = static_cast<float>(ln10_v<double>);
-    template <>
-    inline constexpr float sqrt2_v<float> = static_cast<float>(sqrt2_v<double>);
-    template <>
-    inline constexpr float sqrt3_v<float> = static_cast<float>(sqrt3_v<double>);
-    template <>
-    inline constexpr float inv_sqrt3_v<float> = static_cast<float>(inv_sqrt3_v<double>);
-    template <>
-    inline constexpr float egamma_v<float> = static_cast<float>(egamma_v<double>);
-    template <>
-    inline constexpr float phi_v<float> = static_cast<float>(phi_v<double>);
+    template<class _Ty>
+    using _Reject_primary_template_t = typename _Reject_primary_template<_Ty>::type;
 
-    template <>
-    inline constexpr long double e_v<long double> = e_v<double>;
-    template <>
-    inline constexpr long double log2e_v<long double> = log2e_v<double>;
-    template <>
-    inline constexpr long double log10e_v<long double> = log10e_v<double>;
-    template <>
-    inline constexpr long double pi_v<long double> = pi_v<double>;
-    template <>
-    inline constexpr long double inv_pi_v<long double> = inv_pi_v<double>;
-    template <>
-    inline constexpr long double inv_sqrtpi_v<long double> = inv_sqrtpi_v<double>;
-    template <>
-    inline constexpr long double ln2_v<long double> = ln2_v<double>;
-    template <>
-    inline constexpr long double ln10_v<long double> = ln10_v<double>;
-    template <>
-    inline constexpr long double sqrt2_v<long double> = sqrt2_v<double>;
-    template <>
-    inline constexpr long double sqrt3_v<long double> = sqrt3_v<double>;
-    template <>
-    inline constexpr long double inv_sqrt3_v<long double> = inv_sqrt3_v<double>;
-    template <>
-    inline constexpr long double egamma_v<long double> = egamma_v<double>;
-    template <>
-    inline constexpr long double phi_v<long double> = phi_v<double>;
+    _EXPORT_STD template <class _Ty>
+    inline constexpr _Ty e_v = static_cast<_Reject_primary_template_t<_Ty>>(2.718281828459045);
+    _EXPORT_STD template <class _Ty>
+    inline constexpr _Ty log2e_v = static_cast<_Reject_primary_template_t<_Ty>>(1.4426950408889634);
+    _EXPORT_STD template <class _Ty>
+    inline constexpr _Ty log10e_v = static_cast<_Reject_primary_template_t<_Ty>>(0.4342944819032518);
+    _EXPORT_STD template <class _Ty>
+    inline constexpr _Ty pi_v = static_cast<_Reject_primary_template_t<_Ty>>(3.141592653589793);
+    _EXPORT_STD template <class _Ty>
+    inline constexpr _Ty inv_pi_v = static_cast<_Reject_primary_template_t<_Ty>>(0.3183098861837907);
+    _EXPORT_STD template <class _Ty>
+    inline constexpr _Ty inv_sqrtpi_v = static_cast<_Reject_primary_template_t<_Ty>>(0.5641895835477563);
+    _EXPORT_STD template <class _Ty>
+    inline constexpr _Ty ln2_v = static_cast<_Reject_primary_template_t<_Ty>>(0.6931471805599453);
+    _EXPORT_STD template <class _Ty>
+    inline constexpr _Ty ln10_v = static_cast<_Reject_primary_template_t<_Ty>>(2.302585092994046);
+    _EXPORT_STD template <class _Ty>
+    inline constexpr _Ty sqrt2_v = static_cast<_Reject_primary_template_t<_Ty>>(1.4142135623730951);
+    _EXPORT_STD template <class _Ty>
+    inline constexpr _Ty sqrt3_v = static_cast<_Reject_primary_template_t<_Ty>>(1.7320508075688772);
+    _EXPORT_STD template <class _Ty>
+    inline constexpr _Ty inv_sqrt3_v = static_cast<_Reject_primary_template_t<_Ty>>(0.5773502691896257);
+    _EXPORT_STD template <class _Ty>
+    inline constexpr _Ty egamma_v = static_cast<_Reject_primary_template_t<_Ty>>(0.5772156649015329);
+    _EXPORT_STD template <class _Ty>
+    inline constexpr _Ty phi_v = static_cast<_Reject_primary_template_t<_Ty>>(1.618033988749895);
 #endif // ^^^ !defined(__cpp_lib_concepts) ^^^
 
     _EXPORT_STD inline constexpr double e          = e_v<double>;

--- a/stl/inc/numbers
+++ b/stl/inc/numbers
@@ -88,41 +88,41 @@ namespace numbers {
     inline constexpr _Floating phi_v<_Floating> = static_cast<_Floating>(1.618033988749895);
 #else // ^^^ defined(__cpp_lib_concepts) / !defined(__cpp_lib_concepts) vvv
     template <class _Ty>
-    struct _Reject_primary_template {
+    struct _Reject_invalid {
         static_assert(is_floating_point_v<_Ty>, "A program that instantiates a primary template of a mathematical "
                                                 "constant variable template is ill-formed. (N4944 [math.constants]/3)");
         using type = _Ty;
     };
 
     template <class _Ty>
-    using _Reject_primary_template_t = typename _Reject_primary_template<_Ty>::type;
+    using _Reject_invalid_t = typename _Reject_invalid<_Ty>::type;
 
     _EXPORT_STD template <class _Ty>
-    inline constexpr _Ty e_v = static_cast<_Reject_primary_template_t<_Ty>>(2.718281828459045);
+    inline constexpr _Ty e_v = static_cast<_Reject_invalid_t<_Ty>>(2.718281828459045);
     _EXPORT_STD template <class _Ty>
-    inline constexpr _Ty log2e_v = static_cast<_Reject_primary_template_t<_Ty>>(1.4426950408889634);
+    inline constexpr _Ty log2e_v = static_cast<_Reject_invalid_t<_Ty>>(1.4426950408889634);
     _EXPORT_STD template <class _Ty>
-    inline constexpr _Ty log10e_v = static_cast<_Reject_primary_template_t<_Ty>>(0.4342944819032518);
+    inline constexpr _Ty log10e_v = static_cast<_Reject_invalid_t<_Ty>>(0.4342944819032518);
     _EXPORT_STD template <class _Ty>
-    inline constexpr _Ty pi_v = static_cast<_Reject_primary_template_t<_Ty>>(3.141592653589793);
+    inline constexpr _Ty pi_v = static_cast<_Reject_invalid_t<_Ty>>(3.141592653589793);
     _EXPORT_STD template <class _Ty>
-    inline constexpr _Ty inv_pi_v = static_cast<_Reject_primary_template_t<_Ty>>(0.3183098861837907);
+    inline constexpr _Ty inv_pi_v = static_cast<_Reject_invalid_t<_Ty>>(0.3183098861837907);
     _EXPORT_STD template <class _Ty>
-    inline constexpr _Ty inv_sqrtpi_v = static_cast<_Reject_primary_template_t<_Ty>>(0.5641895835477563);
+    inline constexpr _Ty inv_sqrtpi_v = static_cast<_Reject_invalid_t<_Ty>>(0.5641895835477563);
     _EXPORT_STD template <class _Ty>
-    inline constexpr _Ty ln2_v = static_cast<_Reject_primary_template_t<_Ty>>(0.6931471805599453);
+    inline constexpr _Ty ln2_v = static_cast<_Reject_invalid_t<_Ty>>(0.6931471805599453);
     _EXPORT_STD template <class _Ty>
-    inline constexpr _Ty ln10_v = static_cast<_Reject_primary_template_t<_Ty>>(2.302585092994046);
+    inline constexpr _Ty ln10_v = static_cast<_Reject_invalid_t<_Ty>>(2.302585092994046);
     _EXPORT_STD template <class _Ty>
-    inline constexpr _Ty sqrt2_v = static_cast<_Reject_primary_template_t<_Ty>>(1.4142135623730951);
+    inline constexpr _Ty sqrt2_v = static_cast<_Reject_invalid_t<_Ty>>(1.4142135623730951);
     _EXPORT_STD template <class _Ty>
-    inline constexpr _Ty sqrt3_v = static_cast<_Reject_primary_template_t<_Ty>>(1.7320508075688772);
+    inline constexpr _Ty sqrt3_v = static_cast<_Reject_invalid_t<_Ty>>(1.7320508075688772);
     _EXPORT_STD template <class _Ty>
-    inline constexpr _Ty inv_sqrt3_v = static_cast<_Reject_primary_template_t<_Ty>>(0.5773502691896257);
+    inline constexpr _Ty inv_sqrt3_v = static_cast<_Reject_invalid_t<_Ty>>(0.5773502691896257);
     _EXPORT_STD template <class _Ty>
-    inline constexpr _Ty egamma_v = static_cast<_Reject_primary_template_t<_Ty>>(0.5772156649015329);
+    inline constexpr _Ty egamma_v = static_cast<_Reject_invalid_t<_Ty>>(0.5772156649015329);
     _EXPORT_STD template <class _Ty>
-    inline constexpr _Ty phi_v = static_cast<_Reject_primary_template_t<_Ty>>(1.618033988749895);
+    inline constexpr _Ty phi_v = static_cast<_Reject_invalid_t<_Ty>>(1.618033988749895);
 #endif // ^^^ !defined(__cpp_lib_concepts) ^^^
 
     _EXPORT_STD inline constexpr double e          = e_v<double>;

--- a/stl/inc/numbers
+++ b/stl/inc/numbers
@@ -94,7 +94,7 @@ namespace numbers {
         using type = _Ty;
     };
 
-    template<class _Ty>
+    template <class _Ty>
     using _Reject_primary_template_t = typename _Reject_primary_template<_Ty>::type;
 
     _EXPORT_STD template <class _Ty>

--- a/tests/std/tests/P0631R8_numbers_math_constants/test.cpp
+++ b/tests/std/tests/P0631R8_numbers_math_constants/test.cpp
@@ -22,7 +22,7 @@ enum class modify_cv {
     add_cv,
 };
 
-template <modify_cv Modfication, class T>
+template <modify_cv Modification, class T>
 struct apply_modify_cv {
     using type = T;
 };
@@ -42,8 +42,8 @@ struct apply_modify_cv<modify_cv::add_cv, T> {
     using type = const volatile T;
 };
 
-template <modify_cv Modfication, class T>
-using apply_modify_cv_t = typename apply_modify_cv<Modfication, T>::type;
+template <modify_cv Modification, class T>
+using apply_modify_cv_t = typename apply_modify_cv<Modification, T>::type;
 
 template <modify_cv Modification>
 constexpr bool test_cv_floating_point() {

--- a/tests/std/tests/P0631R8_numbers_math_constants/test.cpp
+++ b/tests/std/tests/P0631R8_numbers_math_constants/test.cpp
@@ -107,19 +107,19 @@ constexpr bool test_cv_floating_point() {
 }
 
 constexpr bool test_double() {
-    assert(test_case(std::numbers::e /**/, 0x1.5bf0a8b145769p+1));
-    assert(test_case(std::numbers::log2e /**/, 0x1.71547652b82fep+0));
-    assert(test_case(std::numbers::log10e /**/, 0x1.bcb7b1526e50ep-2));
-    assert(test_case(std::numbers::pi /**/, 0x1.921fb54442d18p+1));
-    assert(test_case(std::numbers::inv_pi /**/, 0x1.45f306dc9c883p-2));
-    assert(test_case(std::numbers::inv_sqrtpi /**/, 0x1.20dd750429b6dp-1));
-    assert(test_case(std::numbers::ln2 /**/, 0x1.62e42fefa39efp-1));
-    assert(test_case(std::numbers::ln10 /**/, 0x1.26bb1bbb55516p+1));
-    assert(test_case(std::numbers::sqrt2 /**/, 0x1.6a09e667f3bcdp+0));
-    assert(test_case(std::numbers::sqrt3 /**/, 0x1.bb67ae8584caap+0));
-    assert(test_case(std::numbers::inv_sqrt3 /**/, 0x1.279a74590331cp-1));
-    assert(test_case(std::numbers::egamma /**/, 0x1.2788cfc6fb619p-1));
-    assert(test_case(std::numbers::phi /**/, 0x1.9e3779b97f4a8p+0));
+    assert(test_case(std::numbers::e, 0x1.5bf0a8b145769p+1));
+    assert(test_case(std::numbers::log2e, 0x1.71547652b82fep+0));
+    assert(test_case(std::numbers::log10e, 0x1.bcb7b1526e50ep-2));
+    assert(test_case(std::numbers::pi, 0x1.921fb54442d18p+1));
+    assert(test_case(std::numbers::inv_pi, 0x1.45f306dc9c883p-2));
+    assert(test_case(std::numbers::inv_sqrtpi, 0x1.20dd750429b6dp-1));
+    assert(test_case(std::numbers::ln2, 0x1.62e42fefa39efp-1));
+    assert(test_case(std::numbers::ln10, 0x1.26bb1bbb55516p+1));
+    assert(test_case(std::numbers::sqrt2, 0x1.6a09e667f3bcdp+0));
+    assert(test_case(std::numbers::sqrt3, 0x1.bb67ae8584caap+0));
+    assert(test_case(std::numbers::inv_sqrt3, 0x1.279a74590331cp-1));
+    assert(test_case(std::numbers::egamma, 0x1.2788cfc6fb619p-1));
+    assert(test_case(std::numbers::phi, 0x1.9e3779b97f4a8p+0));
 
     return true;
 }

--- a/tests/std/tests/P0631R8_numbers_math_constants/test.cpp
+++ b/tests/std/tests/P0631R8_numbers_math_constants/test.cpp
@@ -1,18 +1,130 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include <cassert>
 #include <numbers>
 #include <type_traits>
 
+#pragma warning(disable : 4197) // '%s': top-level volatile in cast is ignored
+
 #define STATIC_ASSERT(...) static_assert(__VA_ARGS__, #__VA_ARGS__)
 
-template <typename T, typename U>
+template <class T, class U>
 [[nodiscard]] constexpr bool test_case(T& actual, const U expected) {
-    STATIC_ASSERT(std::is_same_v<T, const U>);
+    STATIC_ASSERT(std::is_same_v<const std::remove_cv_t<T>, const U>);
     return actual == expected;
 }
 
-// N4835 [math.constants]/2: "a program may partially or explicitly specialize a mathematical constant
+enum class modify_cv {
+    type_identity,
+    add_const,
+    add_volatile,
+    add_cv,
+};
+
+template <modify_cv Modfication, class T>
+struct apply_modify_cv {
+    using type = T;
+};
+
+template <class T>
+struct apply_modify_cv<modify_cv::add_const, T> {
+    using type = const T;
+};
+
+template <class T>
+struct apply_modify_cv<modify_cv::add_volatile, T> {
+    using type = volatile T;
+};
+
+template <class T>
+struct apply_modify_cv<modify_cv::add_cv, T> {
+    using type = const volatile T;
+};
+
+template <modify_cv Modfication, class T>
+using apply_modify_cv_t = typename apply_modify_cv<Modfication, T>::type;
+
+template <modify_cv Modification>
+constexpr bool test_cv_floating_point() {
+    using F = apply_modify_cv_t<Modification, float>;
+    using D = apply_modify_cv_t<Modification, double>;
+    using L = apply_modify_cv_t<Modification, long double>;
+
+    assert(test_case(std::numbers::e_v<F>, 0x1.5bf0a8p+1f));
+    assert(test_case(std::numbers::e_v<D>, 0x1.5bf0a8b145769p+1));
+    assert(test_case(std::numbers::e_v<L>, 0x1.5bf0a8b145769p+1L));
+
+    assert(test_case(std::numbers::log2e_v<F>, 0x1.715476p+0f));
+    assert(test_case(std::numbers::log2e_v<D>, 0x1.71547652b82fep+0));
+    assert(test_case(std::numbers::log2e_v<L>, 0x1.71547652b82fep+0L));
+
+    assert(test_case(std::numbers::log10e_v<F>, 0x1.bcb7b2p-2f));
+    assert(test_case(std::numbers::log10e_v<D>, 0x1.bcb7b1526e50ep-2));
+    assert(test_case(std::numbers::log10e_v<L>, 0x1.bcb7b1526e50ep-2L));
+
+    assert(test_case(std::numbers::pi_v<F>, 0x1.921fb6p+1f));
+    assert(test_case(std::numbers::pi_v<D>, 0x1.921fb54442d18p+1));
+    assert(test_case(std::numbers::pi_v<L>, 0x1.921fb54442d18p+1L));
+
+    assert(test_case(std::numbers::inv_pi_v<F>, 0x1.45f306p-2f));
+    assert(test_case(std::numbers::inv_pi_v<D>, 0x1.45f306dc9c883p-2));
+    assert(test_case(std::numbers::inv_pi_v<L>, 0x1.45f306dc9c883p-2L));
+
+    assert(test_case(std::numbers::inv_sqrtpi_v<F>, 0x1.20dd76p-1f));
+    assert(test_case(std::numbers::inv_sqrtpi_v<D>, 0x1.20dd750429b6dp-1));
+    assert(test_case(std::numbers::inv_sqrtpi_v<L>, 0x1.20dd750429b6dp-1L));
+
+    assert(test_case(std::numbers::ln2_v<F>, 0x1.62e430p-1f));
+    assert(test_case(std::numbers::ln2_v<D>, 0x1.62e42fefa39efp-1));
+    assert(test_case(std::numbers::ln2_v<L>, 0x1.62e42fefa39efp-1L));
+
+    assert(test_case(std::numbers::ln10_v<F>, 0x1.26bb1cp+1f));
+    assert(test_case(std::numbers::ln10_v<D>, 0x1.26bb1bbb55516p+1));
+    assert(test_case(std::numbers::ln10_v<L>, 0x1.26bb1bbb55516p+1L));
+
+    assert(test_case(std::numbers::sqrt2_v<F>, 0x1.6a09e6p+0f));
+    assert(test_case(std::numbers::sqrt2_v<D>, 0x1.6a09e667f3bcdp+0));
+    assert(test_case(std::numbers::sqrt2_v<L>, 0x1.6a09e667f3bcdp+0L));
+
+    assert(test_case(std::numbers::sqrt3_v<F>, 0x1.bb67aep+0f));
+    assert(test_case(std::numbers::sqrt3_v<D>, 0x1.bb67ae8584caap+0));
+    assert(test_case(std::numbers::sqrt3_v<L>, 0x1.bb67ae8584caap+0L));
+
+    assert(test_case(std::numbers::inv_sqrt3_v<F>, 0x1.279a74p-1f));
+    assert(test_case(std::numbers::inv_sqrt3_v<D>, 0x1.279a74590331cp-1));
+    assert(test_case(std::numbers::inv_sqrt3_v<L>, 0x1.279a74590331cp-1L));
+
+    assert(test_case(std::numbers::egamma_v<F>, 0x1.2788d0p-1f));
+    assert(test_case(std::numbers::egamma_v<D>, 0x1.2788cfc6fb619p-1));
+    assert(test_case(std::numbers::egamma_v<L>, 0x1.2788cfc6fb619p-1L));
+
+    assert(test_case(std::numbers::phi_v<F>, 0x1.9e377ap+0f));
+    assert(test_case(std::numbers::phi_v<D>, 0x1.9e3779b97f4a8p+0));
+    assert(test_case(std::numbers::phi_v<L>, 0x1.9e3779b97f4a8p+0L));
+
+    return true;
+}
+
+constexpr bool test_double() {
+    assert(test_case(std::numbers::e /**/, 0x1.5bf0a8b145769p+1));
+    assert(test_case(std::numbers::log2e /**/, 0x1.71547652b82fep+0));
+    assert(test_case(std::numbers::log10e /**/, 0x1.bcb7b1526e50ep-2));
+    assert(test_case(std::numbers::pi /**/, 0x1.921fb54442d18p+1));
+    assert(test_case(std::numbers::inv_pi /**/, 0x1.45f306dc9c883p-2));
+    assert(test_case(std::numbers::inv_sqrtpi /**/, 0x1.20dd750429b6dp-1));
+    assert(test_case(std::numbers::ln2 /**/, 0x1.62e42fefa39efp-1));
+    assert(test_case(std::numbers::ln10 /**/, 0x1.26bb1bbb55516p+1));
+    assert(test_case(std::numbers::sqrt2 /**/, 0x1.6a09e667f3bcdp+0));
+    assert(test_case(std::numbers::sqrt3 /**/, 0x1.bb67ae8584caap+0));
+    assert(test_case(std::numbers::inv_sqrt3 /**/, 0x1.279a74590331cp-1));
+    assert(test_case(std::numbers::egamma /**/, 0x1.2788cfc6fb619p-1));
+    assert(test_case(std::numbers::phi /**/, 0x1.9e3779b97f4a8p+0));
+
+    return true;
+}
+
+// N4944 [math.constants]/2: "a program may partially or explicitly specialize a mathematical constant
 // variable template provided that the specialization depends on a program-defined type."
 struct Meow {
     int val;
@@ -45,87 +157,34 @@ inline constexpr Meow std::numbers::egamma_v<Meow>{-120};
 template <>
 inline constexpr Meow std::numbers::phi_v<Meow>{-130};
 
+constexpr bool test_program_defined_specialization() {
+    assert(test_case(std::numbers::e_v<Meow>.val, -10));
+    assert(test_case(std::numbers::log2e_v<Meow>.val, -20));
+    assert(test_case(std::numbers::log10e_v<Meow>.val, -30));
+    assert(test_case(std::numbers::pi_v<Meow>.val, -40));
+    assert(test_case(std::numbers::inv_pi_v<Meow>.val, -50));
+    assert(test_case(std::numbers::inv_sqrtpi_v<Meow>.val, -60));
+    assert(test_case(std::numbers::ln2_v<Meow>.val, -70));
+    assert(test_case(std::numbers::ln10_v<Meow>.val, -80));
+    assert(test_case(std::numbers::sqrt2_v<Meow>.val, -90));
+    assert(test_case(std::numbers::sqrt3_v<Meow>.val, -100));
+    assert(test_case(std::numbers::inv_sqrt3_v<Meow>.val, -110));
+    assert(test_case(std::numbers::egamma_v<Meow>.val, -120));
+    assert(test_case(std::numbers::phi_v<Meow>.val, -130));
+
+    return true;
+}
+
+STATIC_ASSERT(test_cv_floating_point<modify_cv::type_identity>());
+STATIC_ASSERT(test_cv_floating_point<modify_cv::add_const>());
+STATIC_ASSERT(test_double());
+STATIC_ASSERT(test_program_defined_specialization());
+
 int main() {
-    STATIC_ASSERT(test_case(std::numbers::e_v<Meow>.val, -10));
-    STATIC_ASSERT(test_case(std::numbers::log2e_v<Meow>.val, -20));
-    STATIC_ASSERT(test_case(std::numbers::log10e_v<Meow>.val, -30));
-    STATIC_ASSERT(test_case(std::numbers::pi_v<Meow>.val, -40));
-    STATIC_ASSERT(test_case(std::numbers::inv_pi_v<Meow>.val, -50));
-    STATIC_ASSERT(test_case(std::numbers::inv_sqrtpi_v<Meow>.val, -60));
-    STATIC_ASSERT(test_case(std::numbers::ln2_v<Meow>.val, -70));
-    STATIC_ASSERT(test_case(std::numbers::ln10_v<Meow>.val, -80));
-    STATIC_ASSERT(test_case(std::numbers::sqrt2_v<Meow>.val, -90));
-    STATIC_ASSERT(test_case(std::numbers::sqrt3_v<Meow>.val, -100));
-    STATIC_ASSERT(test_case(std::numbers::inv_sqrt3_v<Meow>.val, -110));
-    STATIC_ASSERT(test_case(std::numbers::egamma_v<Meow>.val, -120));
-    STATIC_ASSERT(test_case(std::numbers::phi_v<Meow>.val, -130));
-
-    using F = float;
-    using D = double;
-    using L = long double;
-
-    STATIC_ASSERT(test_case(std::numbers::e_v<F>, 0x1.5bf0a8p+1f));
-    STATIC_ASSERT(test_case(std::numbers::e_v<D>, 0x1.5bf0a8b145769p+1));
-    STATIC_ASSERT(test_case(std::numbers::e_v<L>, 0x1.5bf0a8b145769p+1L));
-    STATIC_ASSERT(test_case(std::numbers::e /**/, 0x1.5bf0a8b145769p+1));
-
-    STATIC_ASSERT(test_case(std::numbers::log2e_v<F>, 0x1.715476p+0f));
-    STATIC_ASSERT(test_case(std::numbers::log2e_v<D>, 0x1.71547652b82fep+0));
-    STATIC_ASSERT(test_case(std::numbers::log2e_v<L>, 0x1.71547652b82fep+0L));
-    STATIC_ASSERT(test_case(std::numbers::log2e /**/, 0x1.71547652b82fep+0));
-
-    STATIC_ASSERT(test_case(std::numbers::log10e_v<F>, 0x1.bcb7b2p-2f));
-    STATIC_ASSERT(test_case(std::numbers::log10e_v<D>, 0x1.bcb7b1526e50ep-2));
-    STATIC_ASSERT(test_case(std::numbers::log10e_v<L>, 0x1.bcb7b1526e50ep-2L));
-    STATIC_ASSERT(test_case(std::numbers::log10e /**/, 0x1.bcb7b1526e50ep-2));
-
-    STATIC_ASSERT(test_case(std::numbers::pi_v<F>, 0x1.921fb6p+1f));
-    STATIC_ASSERT(test_case(std::numbers::pi_v<D>, 0x1.921fb54442d18p+1));
-    STATIC_ASSERT(test_case(std::numbers::pi_v<L>, 0x1.921fb54442d18p+1L));
-    STATIC_ASSERT(test_case(std::numbers::pi /**/, 0x1.921fb54442d18p+1));
-
-    STATIC_ASSERT(test_case(std::numbers::inv_pi_v<F>, 0x1.45f306p-2f));
-    STATIC_ASSERT(test_case(std::numbers::inv_pi_v<D>, 0x1.45f306dc9c883p-2));
-    STATIC_ASSERT(test_case(std::numbers::inv_pi_v<L>, 0x1.45f306dc9c883p-2L));
-    STATIC_ASSERT(test_case(std::numbers::inv_pi /**/, 0x1.45f306dc9c883p-2));
-
-    STATIC_ASSERT(test_case(std::numbers::inv_sqrtpi_v<F>, 0x1.20dd76p-1f));
-    STATIC_ASSERT(test_case(std::numbers::inv_sqrtpi_v<D>, 0x1.20dd750429b6dp-1));
-    STATIC_ASSERT(test_case(std::numbers::inv_sqrtpi_v<L>, 0x1.20dd750429b6dp-1L));
-    STATIC_ASSERT(test_case(std::numbers::inv_sqrtpi /**/, 0x1.20dd750429b6dp-1));
-
-    STATIC_ASSERT(test_case(std::numbers::ln2_v<F>, 0x1.62e430p-1f));
-    STATIC_ASSERT(test_case(std::numbers::ln2_v<D>, 0x1.62e42fefa39efp-1));
-    STATIC_ASSERT(test_case(std::numbers::ln2_v<L>, 0x1.62e42fefa39efp-1L));
-    STATIC_ASSERT(test_case(std::numbers::ln2 /**/, 0x1.62e42fefa39efp-1));
-
-    STATIC_ASSERT(test_case(std::numbers::ln10_v<F>, 0x1.26bb1cp+1f));
-    STATIC_ASSERT(test_case(std::numbers::ln10_v<D>, 0x1.26bb1bbb55516p+1));
-    STATIC_ASSERT(test_case(std::numbers::ln10_v<L>, 0x1.26bb1bbb55516p+1L));
-    STATIC_ASSERT(test_case(std::numbers::ln10 /**/, 0x1.26bb1bbb55516p+1));
-
-    STATIC_ASSERT(test_case(std::numbers::sqrt2_v<F>, 0x1.6a09e6p+0f));
-    STATIC_ASSERT(test_case(std::numbers::sqrt2_v<D>, 0x1.6a09e667f3bcdp+0));
-    STATIC_ASSERT(test_case(std::numbers::sqrt2_v<L>, 0x1.6a09e667f3bcdp+0L));
-    STATIC_ASSERT(test_case(std::numbers::sqrt2 /**/, 0x1.6a09e667f3bcdp+0));
-
-    STATIC_ASSERT(test_case(std::numbers::sqrt3_v<F>, 0x1.bb67aep+0f));
-    STATIC_ASSERT(test_case(std::numbers::sqrt3_v<D>, 0x1.bb67ae8584caap+0));
-    STATIC_ASSERT(test_case(std::numbers::sqrt3_v<L>, 0x1.bb67ae8584caap+0L));
-    STATIC_ASSERT(test_case(std::numbers::sqrt3 /**/, 0x1.bb67ae8584caap+0));
-
-    STATIC_ASSERT(test_case(std::numbers::inv_sqrt3_v<F>, 0x1.279a74p-1f));
-    STATIC_ASSERT(test_case(std::numbers::inv_sqrt3_v<D>, 0x1.279a74590331cp-1));
-    STATIC_ASSERT(test_case(std::numbers::inv_sqrt3_v<L>, 0x1.279a74590331cp-1L));
-    STATIC_ASSERT(test_case(std::numbers::inv_sqrt3 /**/, 0x1.279a74590331cp-1));
-
-    STATIC_ASSERT(test_case(std::numbers::egamma_v<F>, 0x1.2788d0p-1f));
-    STATIC_ASSERT(test_case(std::numbers::egamma_v<D>, 0x1.2788cfc6fb619p-1));
-    STATIC_ASSERT(test_case(std::numbers::egamma_v<L>, 0x1.2788cfc6fb619p-1L));
-    STATIC_ASSERT(test_case(std::numbers::egamma /**/, 0x1.2788cfc6fb619p-1));
-
-    STATIC_ASSERT(test_case(std::numbers::phi_v<F>, 0x1.9e377ap+0f));
-    STATIC_ASSERT(test_case(std::numbers::phi_v<D>, 0x1.9e3779b97f4a8p+0));
-    STATIC_ASSERT(test_case(std::numbers::phi_v<L>, 0x1.9e3779b97f4a8p+0L));
-    STATIC_ASSERT(test_case(std::numbers::phi /**/, 0x1.9e3779b97f4a8p+0));
+    assert(test_cv_floating_point<modify_cv::type_identity>());
+    assert(test_cv_floating_point<modify_cv::add_const>());
+    assert(test_cv_floating_point<modify_cv::add_volatile>()); // constexpr-incompatible
+    assert(test_cv_floating_point<modify_cv::add_cv>()); // constexpr-incompatible
+    assert(test_double());
+    assert(test_program_defined_specialization());
 }


### PR DESCRIPTION
In recent PR #3623 I noticed that the implementation of `<numbers>` when concepts are unavailable didn't seem correct enough. These variable templates are required to support possibly cv-qualified floating-point types due to `std::floating_point`, but the current concept-free implementation only supports cv-unqualified FP types.

This PR is adding test coverage for cv-qualified FP types, and rewriting the concept-free implementation. Technically, only the primary template is used, but I believe that the difference from the standard wording is unobservable.

Warning [C4197](https://learn.microsoft.com/sv-se/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4197?view=msvc-140) was encountered during local test. I think it's OK to only suppress that warning in testing, because it's already weird to use something that is both `constexpr` and `volatile`.