### PR TITLE
`<system_error>`: Optimize internal class `_System_error`

### DIFF
--- a/stl/inc/system_error
+++ b/stl/inc/system_error
@@ -473,6 +473,8 @@ private:
     }
 
 protected:
+    _System_error(error_code _Errcode) : runtime_error(_Errcode.message()), _Mycode(_Errcode) {}
+
     _System_error(error_code _Errcode, const string& _Message)
         : runtime_error(_Makestr(_Errcode, _Message)), _Mycode(_Errcode) {}
 
@@ -484,13 +486,13 @@ private:
     using _Mybase = _System_error;
 
 public:
-    system_error(error_code _Errcode) : _Mybase(_Errcode, "") {}
+    system_error(error_code _Errcode) : _Mybase(_Errcode) {}
 
     system_error(error_code _Errcode, const string& _Message) : _Mybase(_Errcode, _Message) {}
 
     system_error(error_code _Errcode, const char* _Message) : _Mybase(_Errcode, _Message) {}
 
-    system_error(int _Errval, const error_category& _Errcat) : _Mybase(error_code(_Errval, _Errcat), "") {}
+    system_error(int _Errval, const error_category& _Errcat) : _Mybase(error_code(_Errval, _Errcat)) {}
 
     system_error(int _Errval, const error_category& _Errcat, const string& _Message)
         : _Mybase(error_code(_Errval, _Errcat), _Message) {}


### PR DESCRIPTION
Hello, from a conversation that occurred on the STL Discord server, I noted that a call to ctor of the internal class `_System_error` appeared to take some extra unnecessary steps when the error message was empty.
As suggested by Stephan I opened a pull request in an attempt to simplify the code.

The goal of this pull request is to skip entirely the call to the internal function `_Makestr` since it would have no effect on an empty string. I think my pull request does not have any unintended consequences. This is also my first contribution so please let me know if I messed something up. I have been lurking on the activity on this repo for a while and on the Discord server so I tried my best to follow the code conventions 😄 