### PR TITLE
Status Chart: Weekly updates, drop es-module-shims, hide Combined Wait

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,8 +8,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>STL Status Chart</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@primer/css@20.8.3/dist/primer.min.css" />
-    <script async src="https://cdn.jsdelivr.net/npm/es-module-shims@1.7.0/dist/es-module-shims.min.js"
-        crossorigin="anonymous"></script>
     <script type="importmap">
         { "imports": {
             "@kurkle/color": "https://cdn.jsdelivr.net/npm/@kurkle/color@0.3.2/dist/color.esm.min.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,9 +26,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.17.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.12.tgz",
-      "integrity": "sha512-E/sgkvwoIfj4aMAPL2e35VnUJspzVYl7+M1B2cqeubdBhADV4uPon0KCc8p2G+LqSJ6i8ocYPCqY3A4GGq0zkQ==",
+      "version": "0.17.16",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.16.tgz",
+      "integrity": "sha512-baLqRpLe4JnKrUXLJChoTN0iXZH7El/mu58GE3WIA6/H834k0XWvLRmGLG8y8arTRS9hJJibPnF0tiGhmWeZgw==",
       "cpu": [
         "arm"
       ],
@@ -41,9 +41,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.17.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.12.tgz",
-      "integrity": "sha512-WQ9p5oiXXYJ33F2EkE3r0FRDFVpEdcDiwNX3u7Xaibxfx6vQE0Sb8ytrfQsA5WO6kDn6mDfKLh6KrPBjvkk7xA==",
+      "version": "0.17.16",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.16.tgz",
+      "integrity": "sha512-QX48qmsEZW+gcHgTmAj+x21mwTz8MlYQBnzF6861cNdQGvj2jzzFjqH0EBabrIa/WVZ2CHolwMoqxVryqKt8+Q==",
       "cpu": [
         "arm64"
       ],
@@ -56,9 +56,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.17.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.12.tgz",
-      "integrity": "sha512-m4OsaCr5gT+se25rFPHKQXARMyAehHTQAz4XX1Vk3d27VtqiX0ALMBPoXZsGaB6JYryCLfgGwUslMqTfqeLU0w==",
+      "version": "0.17.16",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.16.tgz",
+      "integrity": "sha512-G4wfHhrrz99XJgHnzFvB4UwwPxAWZaZBOFXh+JH1Duf1I4vIVfuYY9uVLpx4eiV2D/Jix8LJY+TAdZ3i40tDow==",
       "cpu": [
         "x64"
       ],
@@ -71,9 +71,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.17.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.12.tgz",
-      "integrity": "sha512-O3GCZghRIx+RAN0NDPhyyhRgwa19MoKlzGonIb5hgTj78krqp9XZbYCvFr9N1eUxg0ZQEpiiZ4QvsOQwBpP+lg==",
+      "version": "0.17.16",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.16.tgz",
+      "integrity": "sha512-/Ofw8UXZxuzTLsNFmz1+lmarQI6ztMZ9XktvXedTbt3SNWDn0+ODTwxExLYQ/Hod91EZB4vZPQJLoqLF0jvEzA==",
       "cpu": [
         "arm64"
       ],
@@ -86,9 +86,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.17.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.12.tgz",
-      "integrity": "sha512-5D48jM3tW27h1qjaD9UNRuN+4v0zvksqZSPZqeSWggfMlsVdAhH3pwSfQIFJwcs9QJ9BRibPS4ViZgs3d2wsCA==",
+      "version": "0.17.16",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.16.tgz",
+      "integrity": "sha512-SzBQtCV3Pdc9kyizh36Ol+dNVhkDyIrGb/JXZqFq8WL37LIyrXU0gUpADcNV311sCOhvY+f2ivMhb5Tuv8nMOQ==",
       "cpu": [
         "x64"
       ],
@@ -101,9 +101,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.17.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.12.tgz",
-      "integrity": "sha512-OWvHzmLNTdF1erSvrfoEBGlN94IE6vCEaGEkEH29uo/VoONqPnoDFfShi41Ew+yKimx4vrmmAJEGNoyyP+OgOQ==",
+      "version": "0.17.16",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.16.tgz",
+      "integrity": "sha512-ZqftdfS1UlLiH1DnS2u3It7l4Bc3AskKeu+paJSfk7RNOMrOxmeFDhLTMQqMxycP1C3oj8vgkAT6xfAuq7ZPRA==",
       "cpu": [
         "arm64"
       ],
@@ -116,9 +116,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.17.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.12.tgz",
-      "integrity": "sha512-A0Xg5CZv8MU9xh4a+7NUpi5VHBKh1RaGJKqjxe4KG87X+mTjDE6ZvlJqpWoeJxgfXHT7IMP9tDFu7IZ03OtJAw==",
+      "version": "0.17.16",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.16.tgz",
+      "integrity": "sha512-rHV6zNWW1tjgsu0dKQTX9L0ByiJHHLvQKrWtnz8r0YYJI27FU3Xu48gpK2IBj1uCSYhJ+pEk6Y0Um7U3rIvV8g==",
       "cpu": [
         "x64"
       ],
@@ -131,9 +131,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.17.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.12.tgz",
-      "integrity": "sha512-WsHyJ7b7vzHdJ1fv67Yf++2dz3D726oO3QCu8iNYik4fb5YuuReOI9OtA+n7Mk0xyQivNTPbl181s+5oZ38gyA==",
+      "version": "0.17.16",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.16.tgz",
+      "integrity": "sha512-n4O8oVxbn7nl4+m+ISb0a68/lcJClIbaGAoXwqeubj/D1/oMMuaAXmJVfFlRjJLu/ZvHkxoiFJnmbfp4n8cdSw==",
       "cpu": [
         "arm"
       ],
@@ -146,9 +146,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.17.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.12.tgz",
-      "integrity": "sha512-cK3AjkEc+8v8YG02hYLQIQlOznW+v9N+OI9BAFuyqkfQFR+DnDLhEM5N8QRxAUz99cJTo1rLNXqRrvY15gbQUg==",
+      "version": "0.17.16",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.16.tgz",
+      "integrity": "sha512-8yoZhGkU6aHu38WpaM4HrRLTFc7/VVD9Q2SvPcmIQIipQt2I/GMTZNdEHXoypbbGao5kggLcxg0iBKjo0SQYKA==",
       "cpu": [
         "arm64"
       ],
@@ -161,9 +161,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.17.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.12.tgz",
-      "integrity": "sha512-jdOBXJqcgHlah/nYHnj3Hrnl9l63RjtQ4vn9+bohjQPI2QafASB5MtHAoEv0JQHVb/xYQTFOeuHnNYE1zF7tYw==",
+      "version": "0.17.16",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.16.tgz",
+      "integrity": "sha512-9ZBjlkdaVYxPNO8a7OmzDbOH9FMQ1a58j7Xb21UfRU29KcEEU3VTHk+Cvrft/BNv0gpWJMiiZ/f4w0TqSP0gLA==",
       "cpu": [
         "ia32"
       ],
@@ -176,9 +176,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.17.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.12.tgz",
-      "integrity": "sha512-GTOEtj8h9qPKXCyiBBnHconSCV9LwFyx/gv3Phw0pa25qPYjVuuGZ4Dk14bGCfGX3qKF0+ceeQvwmtI+aYBbVA==",
+      "version": "0.17.16",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.16.tgz",
+      "integrity": "sha512-TIZTRojVBBzdgChY3UOG7BlPhqJz08AL7jdgeeu+kiObWMFzGnQD7BgBBkWRwOtKR1i2TNlO7YK6m4zxVjjPRQ==",
       "cpu": [
         "loong64"
       ],
@@ -191,9 +191,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.17.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.12.tgz",
-      "integrity": "sha512-o8CIhfBwKcxmEENOH9RwmUejs5jFiNoDw7YgS0EJTF6kgPgcqLFjgoc5kDey5cMHRVCIWc6kK2ShUePOcc7RbA==",
+      "version": "0.17.16",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.16.tgz",
+      "integrity": "sha512-UPeRuFKCCJYpBbIdczKyHLAIU31GEm0dZl1eMrdYeXDH+SJZh/i+2cAmD3A1Wip9pIc5Sc6Kc5cFUrPXtR0XHA==",
       "cpu": [
         "mips64el"
       ],
@@ -206,9 +206,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.17.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.12.tgz",
-      "integrity": "sha512-biMLH6NR/GR4z+ap0oJYb877LdBpGac8KfZoEnDiBKd7MD/xt8eaw1SFfYRUeMVx519kVkAOL2GExdFmYnZx3A==",
+      "version": "0.17.16",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.16.tgz",
+      "integrity": "sha512-io6yShgIEgVUhExJejJ21xvO5QtrbiSeI7vYUnr7l+v/O9t6IowyhdiYnyivX2X5ysOVHAuyHW+Wyi7DNhdw6Q==",
       "cpu": [
         "ppc64"
       ],
@@ -221,9 +221,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.17.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.12.tgz",
-      "integrity": "sha512-jkphYUiO38wZGeWlfIBMB72auOllNA2sLfiZPGDtOBb1ELN8lmqBrlMiucgL8awBw1zBXN69PmZM6g4yTX84TA==",
+      "version": "0.17.16",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.16.tgz",
+      "integrity": "sha512-WhlGeAHNbSdG/I2gqX2RK2gfgSNwyJuCiFHMc8s3GNEMMHUI109+VMBfhVqRb0ZGzEeRiibi8dItR3ws3Lk+cA==",
       "cpu": [
         "riscv64"
       ],
@@ -236,9 +236,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.17.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.12.tgz",
-      "integrity": "sha512-j3ucLdeY9HBcvODhCY4b+Ds3hWGO8t+SAidtmWu/ukfLLG/oYDMaA+dnugTVAg5fnUOGNbIYL9TOjhWgQB8W5g==",
+      "version": "0.17.16",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.16.tgz",
+      "integrity": "sha512-gHRReYsJtViir63bXKoFaQ4pgTyah4ruiMRQ6im9YZuv+gp3UFJkNTY4sFA73YDynmXZA6hi45en4BGhNOJUsw==",
       "cpu": [
         "s390x"
       ],
@@ -251,9 +251,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.17.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.12.tgz",
-      "integrity": "sha512-uo5JL3cgaEGotaqSaJdRfFNSCUJOIliKLnDGWaVCgIKkHxwhYMm95pfMbWZ9l7GeW9kDg0tSxcy9NYdEtjwwmA==",
+      "version": "0.17.16",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.16.tgz",
+      "integrity": "sha512-mfiiBkxEbUHvi+v0P+TS7UnA9TeGXR48aK4XHkTj0ZwOijxexgMF01UDFaBX7Q6CQsB0d+MFNv9IiXbIHTNd4g==",
       "cpu": [
         "x64"
       ],
@@ -266,9 +266,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.17.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.12.tgz",
-      "integrity": "sha512-DNdoRg8JX+gGsbqt2gPgkgb00mqOgOO27KnrWZtdABl6yWTST30aibGJ6geBq3WM2TIeW6COs5AScnC7GwtGPg==",
+      "version": "0.17.16",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.16.tgz",
+      "integrity": "sha512-n8zK1YRDGLRZfVcswcDMDM0j2xKYLNXqei217a4GyBxHIuPMGrrVuJ+Ijfpr0Kufcm7C1k/qaIrGy6eG7wvgmA==",
       "cpu": [
         "x64"
       ],
@@ -281,9 +281,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.17.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.12.tgz",
-      "integrity": "sha512-aVsENlr7B64w8I1lhHShND5o8cW6sB9n9MUtLumFlPhG3elhNWtE7M1TFpj3m7lT3sKQUMkGFjTQBrvDDO1YWA==",
+      "version": "0.17.16",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.16.tgz",
+      "integrity": "sha512-lEEfkfsUbo0xC47eSTBqsItXDSzwzwhKUSsVaVjVji07t8+6KA5INp2rN890dHZeueXJAI8q0tEIfbwVRYf6Ew==",
       "cpu": [
         "x64"
       ],
@@ -296,9 +296,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.17.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.12.tgz",
-      "integrity": "sha512-qbHGVQdKSwi0JQJuZznS4SyY27tYXYF0mrgthbxXrZI3AHKuRvU+Eqbg/F0rmLDpW/jkIZBlCO1XfHUBMNJ1pg==",
+      "version": "0.17.16",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.16.tgz",
+      "integrity": "sha512-jlRjsuvG1fgGwnE8Afs7xYDnGz0dBgTNZfgCK6TlvPH3Z13/P5pi6I57vyLE8qZYLrGVtwcm9UbUx1/mZ8Ukag==",
       "cpu": [
         "x64"
       ],
@@ -311,9 +311,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.17.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.12.tgz",
-      "integrity": "sha512-zsCp8Ql+96xXTVTmm6ffvoTSZSV2B/LzzkUXAY33F/76EajNw1m+jZ9zPfNJlJ3Rh4EzOszNDHsmG/fZOhtqDg==",
+      "version": "0.17.16",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.16.tgz",
+      "integrity": "sha512-TzoU2qwVe2boOHl/3KNBUv2PNUc38U0TNnzqOAcgPiD/EZxT2s736xfC2dYQbszAwo4MKzzwBV0iHjhfjxMimg==",
       "cpu": [
         "arm64"
       ],
@@ -326,9 +326,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.17.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.12.tgz",
-      "integrity": "sha512-FfrFjR4id7wcFYOdqbDfDET3tjxCozUgbqdkOABsSFzoZGFC92UK7mg4JKRc/B3NNEf1s2WHxJ7VfTdVDPN3ng==",
+      "version": "0.17.16",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.16.tgz",
+      "integrity": "sha512-B8b7W+oo2yb/3xmwk9Vc99hC9bNolvqjaTZYEfMQhzdpBsjTvZBlXQ/teUE55Ww6sg//wlcDjOaqldOKyigWdA==",
       "cpu": [
         "ia32"
       ],
@@ -341,9 +341,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.17.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.12.tgz",
-      "integrity": "sha512-JOOxw49BVZx2/5tW3FqkdjSD/5gXYeVGPDcB0lvap0gLQshkh1Nyel1QazC+wNxus3xPlsYAgqU1BUmrmCvWtw==",
+      "version": "0.17.16",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.16.tgz",
+      "integrity": "sha512-xJ7OH/nanouJO9pf03YsL9NAFQBHd8AqfrQd7Pf5laGyyTt/gToul6QYOA/i5i/q8y9iaM5DQFNTgpi995VkOg==",
       "cpu": [
         "x64"
       ],
@@ -437,19 +437,19 @@
       }
     },
     "node_modules/@types/luxon": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.2.0.tgz",
-      "integrity": "sha512-lGmaGFoaXHuOLXFvuju2bfvZRqxAqkHPx9Y9IQdQABrinJJshJwfNCKV+u7rR3kJbiqfTF/NhOkcxxAFrObyaA=="
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.3.0.tgz",
+      "integrity": "sha512-uKRI5QORDnrGFYgcdAVnHvEIvEZ8noTpP/Bg+HeUzZghwinDlIS87DEenV5r1YoOF9G4x600YsUXLWZ19rmTmg=="
     },
     "node_modules/@types/node": {
-      "version": "18.15.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.3.tgz",
-      "integrity": "sha512-p6ua9zBxz5otCmbpb5D3U4B5Nanw6Pk3PPyX05xnxbB/fRv71N7CPmORg7uAD5P70T0xmx1pzAx/FUfa5X+3cw=="
+      "version": "18.15.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.11.tgz",
+      "integrity": "sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q=="
     },
     "node_modules/@types/yargs": {
-      "version": "17.0.22",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.22.tgz",
-      "integrity": "sha512-pet5WJ9U8yPVRhkwuEIp5ktAeAqRZOq4UdAyWLWzxbtpyXnzbtLdKiXAjJzi/KLmPGS9wk86lUFWZFN6sISo4g==",
+      "version": "17.0.24",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.24.tgz",
+      "integrity": "sha512-6i0aC7jV6QzQB8ne1joVZ0eSFIstHsCrobmOtghM11yGlH0j43FKL2UhWdELkyps0zuf7qVTUVCCR+tgSlyLLw==",
       "dependencies": {
         "@types/yargs-parser": "*"
       }
@@ -622,9 +622,9 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "node_modules/esbuild": {
-      "version": "0.17.12",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.12.tgz",
-      "integrity": "sha512-bX/zHl7Gn2CpQwcMtRogTTBf9l1nl+H6R8nUbjk+RuKqAE3+8FDulLA+pHvX7aA7Xe07Iwa+CWvy9I8Y2qqPKQ==",
+      "version": "0.17.16",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.16.tgz",
+      "integrity": "sha512-aeSuUKr9aFVY9Dc8ETVELGgkj4urg5isYx8pLf4wlGgB0vTFjxJQdHnNH6Shmx4vYYrOTLCHtRI5i1XZ9l2Zcg==",
       "hasInstallScript": true,
       "bin": {
         "esbuild": "bin/esbuild"
@@ -633,28 +633,28 @@
         "node": ">=12"
       },
       "optionalDependencies": {
-        "@esbuild/android-arm": "0.17.12",
-        "@esbuild/android-arm64": "0.17.12",
-        "@esbuild/android-x64": "0.17.12",
-        "@esbuild/darwin-arm64": "0.17.12",
-        "@esbuild/darwin-x64": "0.17.12",
-        "@esbuild/freebsd-arm64": "0.17.12",
-        "@esbuild/freebsd-x64": "0.17.12",
-        "@esbuild/linux-arm": "0.17.12",
-        "@esbuild/linux-arm64": "0.17.12",
-        "@esbuild/linux-ia32": "0.17.12",
-        "@esbuild/linux-loong64": "0.17.12",
-        "@esbuild/linux-mips64el": "0.17.12",
-        "@esbuild/linux-ppc64": "0.17.12",
-        "@esbuild/linux-riscv64": "0.17.12",
-        "@esbuild/linux-s390x": "0.17.12",
-        "@esbuild/linux-x64": "0.17.12",
-        "@esbuild/netbsd-x64": "0.17.12",
-        "@esbuild/openbsd-x64": "0.17.12",
-        "@esbuild/sunos-x64": "0.17.12",
-        "@esbuild/win32-arm64": "0.17.12",
-        "@esbuild/win32-ia32": "0.17.12",
-        "@esbuild/win32-x64": "0.17.12"
+        "@esbuild/android-arm": "0.17.16",
+        "@esbuild/android-arm64": "0.17.16",
+        "@esbuild/android-x64": "0.17.16",
+        "@esbuild/darwin-arm64": "0.17.16",
+        "@esbuild/darwin-x64": "0.17.16",
+        "@esbuild/freebsd-arm64": "0.17.16",
+        "@esbuild/freebsd-x64": "0.17.16",
+        "@esbuild/linux-arm": "0.17.16",
+        "@esbuild/linux-arm64": "0.17.16",
+        "@esbuild/linux-ia32": "0.17.16",
+        "@esbuild/linux-loong64": "0.17.16",
+        "@esbuild/linux-mips64el": "0.17.16",
+        "@esbuild/linux-ppc64": "0.17.16",
+        "@esbuild/linux-riscv64": "0.17.16",
+        "@esbuild/linux-s390x": "0.17.16",
+        "@esbuild/linux-x64": "0.17.16",
+        "@esbuild/netbsd-x64": "0.17.16",
+        "@esbuild/openbsd-x64": "0.17.16",
+        "@esbuild/sunos-x64": "0.17.16",
+        "@esbuild/win32-arm64": "0.17.16",
+        "@esbuild/win32-ia32": "0.17.16",
+        "@esbuild/win32-x64": "0.17.16"
       }
     },
     "node_modules/escalade": {
@@ -1030,9 +1030,9 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "node_modules/typescript": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.2.tgz",
-      "integrity": "sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,17 +11,17 @@
       "dependencies": {
         "@octokit/graphql": "^5.0.5",
         "@types/cli-progress": "^3.11.0",
-        "@types/luxon": "^3.2.0",
-        "@types/node": "^18.15.3",
-        "@types/yargs": "^17.0.22",
+        "@types/luxon": "^3.3.0",
+        "@types/node": "^18.15.11",
+        "@types/yargs": "^17.0.24",
         "chart.js": "^4.2.1",
         "chartjs-adapter-luxon": "^1.3.1",
         "cli-progress": "^3.12.0",
         "dotenv": "^16.0.3",
-        "esbuild": "^0.17.12",
+        "esbuild": "^0.17.16",
         "http-server": "^14.1.1",
         "luxon": "^3.3.0",
-        "typescript": "^5.0.2",
+        "typescript": "^5.0.4",
         "yargs": "^17.7.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -32,17 +32,17 @@
   "dependencies": {
     "@octokit/graphql": "^5.0.5",
     "@types/cli-progress": "^3.11.0",
-    "@types/luxon": "^3.2.0",
-    "@types/node": "^18.15.3",
-    "@types/yargs": "^17.0.22",
+    "@types/luxon": "^3.3.0",
+    "@types/node": "^18.15.11",
+    "@types/yargs": "^17.0.24",
     "chart.js": "^4.2.1",
     "chartjs-adapter-luxon": "^1.3.1",
     "cli-progress": "^3.12.0",
     "dotenv": "^16.0.3",
-    "esbuild": "^0.17.12",
+    "esbuild": "^0.17.16",
     "http-server": "^14.1.1",
     "luxon": "^3.3.0",
-    "typescript": "^5.0.2",
+    "typescript": "^5.0.4",
     "yargs": "^17.7.1"
   }
 }

--- a/src/status_chart.ts
+++ b/src/status_chart.ts
@@ -87,7 +87,7 @@ function load_charts() {
                 new DatasetInfo('avg_age', 'Average Age', 'leftAxis', '--color-neutral-emphasis', true),
                 new DatasetInfo('avg_wait', 'Average Wait', 'leftAxis', '--color-sponsors-emphasis', true),
                 new DatasetInfo('sum_age', 'Combined Age', 'rightAxis', '--color-fg-default'),
-                new DatasetInfo('sum_wait', 'Combined Wait', 'rightAxis', '--color-done-emphasis'),
+                new DatasetInfo('sum_wait', 'Combined Wait', 'rightAxis', '--color-done-emphasis', true),
 
                 new DatasetInfo('merged', 'Line: Sliding Window', 'mergeAxis', '--color-accent-emphasis'),
                 new DatasetInfo('merge_bar', 'Bars: Calendar Months', 'mergeAxis', '--color-border-default'),

--- a/src/weekly_table.ts
+++ b/src/weekly_table.ts
@@ -309,4 +309,6 @@ export const weekly_table: WeeklyRow[] = [
     { date: '2023-03-10', vso: 187, libcxx: 731 },
     { date: '2023-03-17', vso: 195, libcxx: 731 },
     { date: '2023-03-24', vso: 190, libcxx: 731 },
+    { date: '2023-03-31', vso: 187, libcxx: 742 },
+    { date: '2023-04-07', vso: 191, libcxx: 742 },
 ];

--- a/src_gather/video_table.ts
+++ b/src_gather/video_table.ts
@@ -55,11 +55,12 @@ export const video_table: VideoRow[] = [
     { pr_id: 2981, review_date: '2022-08-04' },
     { pr_id: 2211, review_date: '2022-08-25', upload_date: '2022-11-10' },
     { pr_id: 3099, review_date: '2022-09-15' },
-    { pr_id: 3035, review_date: '2022-10-13' },
+    { pr_id: 3035, review_date: '2022-10-13', upload_date: '2023-03-30' },
     { pr_id: 3164, review_date: '2022-11-03' },
     { pr_id: 3268, review_date: '2022-12-08' },
     { pr_id: 3322, review_date: '2023-01-12' },
     { pr_id: 3361, review_date: '2023-02-07' },
     { pr_id: 3353, review_date: '2023-02-23' },
     { pr_id: 3337, review_date: '2023-03-16' },
+    { pr_id: 3364, review_date: '2023-04-06' },
 ];

--- a/usernames_maintainers.txt
+++ b/usernames_maintainers.txt
@@ -10,4 +10,5 @@ cbezault
 MahmoudGSaleh
 mnatsuhara
 StephanTLavavej
+strega-nil
 strega-nil-ms


### PR DESCRIPTION
* Weekly updates.
* Dependency updates.
* `index.html`: Drop es-module-shims.
  + Import maps are now supported by the latest versions of all major browsers (and the Status Chart makes no attempt to support older versions).
* Hide 'Combined Wait' by default.
  + This line was an interesting idea, but it's more distracting than useful (in my opinion).
* Update `usernames_maintainers.txt`.

As usual, this contains a "DROP BEFORE MERGING: Regen files." commit to make the live preview work.

:chart_with_downwards_trend: Live preview: [stephantlavavej.github.io/STL/](https://stephantlavavej.github.io/STL/)
===