### PR TITLE
`<memory>`: Workaround for MSVC bug on `operator<=>` (`shared_ptr` only)

### DIFF
--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -1883,7 +1883,12 @@ _NODISCARD bool operator==(const shared_ptr<_Ty1>& _Left, const shared_ptr<_Ty2>
 #if _HAS_CXX20
 _EXPORT_STD template <class _Ty1, class _Ty2>
 _NODISCARD strong_ordering operator<=>(const shared_ptr<_Ty1>& _Left, const shared_ptr<_Ty2>& _Right) noexcept {
+#if !defined(__EDG__) && !defined(__clang__) // TRANSITION, DevCom-10334808
+    using _Common_ptr_t = decltype(false ? _Left.get() : _Right.get());
+    return static_cast<_Common_ptr_t>(_Left.get()) <=> static_cast<_Common_ptr_t>(_Right.get());
+#else // ^^^ workaround / no workaround vvv
     return _Left.get() <=> _Right.get();
+#endif // ^^^ no workaround ^^^
 }
 #else // ^^^ _HAS_CXX20 / !_HAS_CXX20 vvv
 template <class _Ty1, class _Ty2>

--- a/tests/std/tests/P1614R2_spaceship/test.cpp
+++ b/tests/std/tests/P1614R2_spaceship/test.cpp
@@ -1023,7 +1023,7 @@ void ordering_test_cases() {
     }
     { // shared_ptr, heterogeneous
         std::shared_ptr<const int> p1{};
-        std::shared_ptr<void> p2{}
+        std::shared_ptr<void> p2{};
         std::shared_ptr<volatile int> p3{};
 
         std::shared_ptr<int> p4{new int};

--- a/tests/std/tests/P1614R2_spaceship/test.cpp
+++ b/tests/std/tests/P1614R2_spaceship/test.cpp
@@ -1021,6 +1021,18 @@ void ordering_test_cases() {
         spaceship_test<std::strong_ordering>(p1, p3, p5);
         spaceship_test<std::strong_ordering>(p1, nullptr, p4);
     }
+    { // shared_ptr, heterogeneous
+        std::shared_ptr<const int> p1{};
+        std::shared_ptr<void> p2{}
+        std::shared_ptr<volatile int> p3{};
+
+        std::shared_ptr<int> p4{new int};
+
+        spaceship_test<std::strong_ordering>(p1, p2, p4);
+        spaceship_test<std::strong_ordering>(p1, p3, p4);
+        spaceship_test<std::strong_ordering>(p2, p3, p4);
+        spaceship_test<std::strong_ordering>(p1, nullptr, p4);
+    }
     { // slice
         std::slice a1(2, 3, 4);
         std::slice a2(2, 3, 4);


### PR DESCRIPTION
Fixes #3646.

I think similar handling for `unique_ptr` is definitely wanted, but it seems that we can't achieve a complete workaround for `unique_ptr` due to the arbitrability of `unique_ptr::pointer`.