### PR TITLE
Ensure _Idx is only worked on if it has to be.

### DIFF
--- a/stl/inc/valarray
+++ b/stl/inc/valarray
@@ -1537,7 +1537,8 @@ public:
             _Ans += _Indexarr[_Idx] * _Stride[_Idx]; // compute offset
         }
 
-        while (0 < _Idx--) {
+        while (0 < _Idx) {
+            --_Idx;
             if (++_Indexarr[_Idx] < _Len[_Idx]) {
                 break; // increment done, quit
             } else {


### PR DESCRIPTION
I don't know if whatever compile is supposed to compile this will notice, but this is the only place where this structure appears, so it seems best that the incrementation be done within the loop.