### PR TITLE
`<map>`, `<unordered_map>`: Allow `MapLike<K, V&>` again

### DIFF
--- a/stl/inc/map
+++ b/stl/inc/map
@@ -77,8 +77,6 @@ public:
         _MISMATCHED_ALLOCATOR_MESSAGE("map<Key, Value, Compare, Allocator>", "pair<const Key, Value>"));
     static_assert(is_object_v<_Kty>, "The C++ Standard forbids containers of non-object types "
                                      "because of [container.requirements].");
-    static_assert(is_object_v<_Ty>, "The C++ Standard forbids containers of non-object types "
-                                    "because of [container.requirements].");
 
     using _Mybase                = _Tree<_Tmap_traits<_Kty, _Ty, _Pr, _Alloc, false>>;
     using _Nodeptr               = typename _Mybase::_Nodeptr;
@@ -463,8 +461,6 @@ public:
         _MISMATCHED_ALLOCATOR_MESSAGE("multimap<Key, Value, Compare, Allocator>", "pair<const Key, Value>"));
     static_assert(is_object_v<_Kty>, "The C++ Standard forbids containers of non-object types "
                                      "because of [container.requirements].");
-    static_assert(is_object_v<_Ty>, "The C++ Standard forbids containers of non-object types "
-                                    "because of [container.requirements].");
 
     using _Mybase                = _Tree<_Tmap_traits<_Kty, _Ty, _Pr, _Alloc, true>>;
     using key_type               = _Kty;

--- a/stl/inc/unordered_map
+++ b/stl/inc/unordered_map
@@ -71,8 +71,6 @@ public:
         _MISMATCHED_ALLOCATOR_MESSAGE("unordered_map<Key, Value, Hasher, Eq, Allocator>", "pair<const Key, Value>"));
     static_assert(is_object_v<_Kty>, "The C++ Standard forbids containers of non-object types "
                                      "because of [container.requirements].");
-    static_assert(is_object_v<_Ty>, "The C++ Standard forbids containers of non-object types "
-                                    "because of [container.requirements].");
 
 private:
     using _Mytraits      = _Uhash_compare<_Kty, _Hasher, _Keyeq>;
@@ -563,8 +561,6 @@ public:
             "unordered_multimap<Key, Value, Hasher, Eq, Allocator>", "pair<const Key, Value>"));
     static_assert(is_object_v<_Kty>, "The C++ Standard forbids containers of non-object types "
                                      "because of [container.requirements].");
-    static_assert(is_object_v<_Ty>, "The C++ Standard forbids containers of non-object types "
-                                    "because of [container.requirements].");
 
 private:
     using _Mytraits      = _Uhash_compare<_Kty, _Hasher, _Keyeq>;

--- a/tests/std/tests/Dev11_0437519_container_requirements/test.compile.pass.cpp
+++ b/tests/std/tests/Dev11_0437519_container_requirements/test.compile.pass.cpp
@@ -3048,6 +3048,17 @@ void assert_container() {
     check_all_specific_requirements<Tag>();
 }
 
+// MapLike<K, V&> is squirrelly, but appears to be permitted.
+template <template <class...> class MapLike>
+void check_reference_as_mapped_type() {
+    double dbl = 3.14;
+
+    MapLike<int, double&> ml;
+    ml.emplace(10, dbl);
+
+    STATIC_ASSERT(std::is_same_v<decltype(ml.find(10)->second), double&>);
+}
+
 void assert_all() {
     assert_container<tag_deque>();
     assert_container<tag_forward_list>();
@@ -3063,4 +3074,9 @@ void assert_all() {
     assert_container<tag_unordered_multimap>();
     assert_container<tag_unordered_multiset>();
     assert_container<tag_unordered_set>();
+
+    check_reference_as_mapped_type<std::map>();
+    check_reference_as_mapped_type<std::multimap>();
+    check_reference_as_mapped_type<std::unordered_map>();
+    check_reference_as_mapped_type<std::unordered_multimap>();
 }


### PR DESCRIPTION
One of the changes that I pushed to #2436 was damaging - while map-like types can't tolerate references as key types, using references as mapped types appears to be permitted (by the Standard, libstdc++, and libc++), and there are 4 projects across vcpkg and Real World Code that are doing this.

Fortunately, we can fix this before changes stop flowing into VS 2022 17.7 Preview 2, so users will never be affected. I'm removing my bad `static_assert`s, and adding test coverage to minimally verify that this scenario compiles.

(I suppose we could instead assert that the mapped types aren't function types or void types, but I'd rather just drop it entirely. Such usage is extremely unlikely and will still be rejected, just with lengthy diagnostics.)