### PR TITLE
comparison of identical zoned_time objects fails

### DIFF
--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -2560,7 +2560,7 @@ namespace chrono {
     _EXPORT_STD template <class _Duration1, class _Duration2, class _TimeZonePtr>
     _NODISCARD bool operator==(
         const zoned_time<_Duration1, _TimeZonePtr>& _Left, const zoned_time<_Duration2, _TimeZonePtr>& _Right) {
-        return _Left.get_time_zone() == _Right.get_time_zone() && _Left.get_sys_time() == _Right.get_sys_time();
+        return *(_Left.get_time_zone()) == *(_Right.get_time_zone()) && _Left.get_sys_time() == _Right.get_sys_time();
     }
 
     // [time.clock.utc]


### PR DESCRIPTION
the reason for the error in comparison is, that .get_time_zone() returns a _TimeZonePtr so in this case, the adresses of the pointers are compared

   using timePoint_T = std::chrono::zoned_time<std::chrono::system_clock::duration>;

   auto now = std::chrono::system_clock::now();
   timePoint_T x{std::chrono::current_zone(), now};
   timePoint_T y{std::chrono::current_zone(), now};

   assert (x == y);

<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
