### PR TITLE
`<optional>`: Fix exception specification for `optional`'s transform-construction

### DIFF
--- a/stl/inc/optional
+++ b/stl/inc/optional
@@ -65,6 +65,26 @@ _STL_INTERNAL_STATIC_ASSERT(!is_trivially_default_constructible_v<_Nontrivial_du
 struct _Construct_from_invoke_result_tag {
     explicit _Construct_from_invoke_result_tag() = default;
 };
+
+#ifdef __cpp_lib_concepts // TRANSITION, GH-395
+template <class _Ty, class _Fn, class... _Args>
+inline constexpr bool _Is_nothrow_constructible_from_invocation = requires(void* __vp, _Fn&& __fx, _Args&&... __args) {
+    { ::new (__vp) _Ty(_STD invoke(_STD forward<_Fn>(__fx), _STD forward<_Args>(__args)...)) } noexcept;
+};
+#else // ^^^ no workaround / workaround vvv
+template <class _Void, class _Ty, class _Fn, class... _Args>
+inline constexpr bool _Is_nothrow_constructible_from_invocation_impl = false;
+
+template <class _Ty, class _Fn, class... _Args>
+inline constexpr bool _Is_nothrow_constructible_from_invocation_impl<
+    void_t<decltype(::new (_STD declval<void*>()) _Ty(_STD invoke(_STD declval<_Fn>(), _STD declval<_Args>()...)))>,
+    _Ty, _Fn, _Args...> = noexcept(::new (_STD declval<void*>())
+        _Ty(_STD invoke(_STD declval<_Fn>(), _STD declval<_Args>()...)));
+
+template <class _Ty, class _Fn, class... _Args>
+inline constexpr bool _Is_nothrow_constructible_from_invocation =
+    _Is_nothrow_constructible_from_invocation_impl<void, _Ty, _Fn, _Args...>;
+#endif // ^^^ workaround ^^^
 #endif // _HAS_CXX23
 
 template <class _Ty, bool = is_trivially_destructible_v<_Ty>>
@@ -85,7 +105,7 @@ struct _Optional_destruct_base { // either contains a value of _Ty or is empty (
 #if _HAS_CXX23
     template <class _Fn, class _Ux>
     constexpr _Optional_destruct_base(_Construct_from_invoke_result_tag, _Fn&& _Func, _Ux&& _Arg) noexcept(
-        is_nothrow_constructible_v<_Ty, invoke_result_t<_Fn, _Ux>>)
+        _Is_nothrow_constructible_from_invocation<_Ty, _Fn, _Ux>)
         : _Value(_STD invoke(_STD forward<_Fn>(_Func), _STD forward<_Ux>(_Arg))), _Has_value{true} {}
 #endif // _HAS_CXX23
 
@@ -118,7 +138,7 @@ struct _Optional_destruct_base<_Ty, false> { // either contains a value of _Ty o
 #if _HAS_CXX23
     template <class _Fn, class _Ux>
     constexpr _Optional_destruct_base(_Construct_from_invoke_result_tag, _Fn&& _Func, _Ux&& _Arg) noexcept(
-        is_nothrow_constructible_v<_Ty, invoke_result_t<_Fn, _Ux>>)
+        _Is_nothrow_constructible_from_invocation<_Ty, _Fn, _Ux>)
         : _Value(_STD invoke(_STD forward<_Fn>(_Func), _STD forward<_Ux>(_Arg))), _Has_value{true} {}
 #endif // _HAS_CXX23
 

--- a/stl/inc/optional
+++ b/stl/inc/optional
@@ -68,9 +68,10 @@ struct _Construct_from_invoke_result_tag {
 
 #ifdef __cpp_lib_concepts // TRANSITION, GH-395
 template <class _Ty, class _Fn, class... _Args>
-inline constexpr bool _Is_nothrow_constructible_from_invocation = requires(void* __vp, _Fn&& __fx, _Args&&... __args) {
-    { ::new (__vp) _Ty(_STD invoke(_STD forward<_Fn>(__fx), _STD forward<_Args>(__args)...)) } noexcept;
-};
+inline constexpr bool _Is_nothrow_constructible_from_invocation =
+    requires(void* __vp, _Fn&& __fx, _Args&&... __args) {
+        { ::new (__vp) _Ty(_STD invoke(_STD forward<_Fn>(__fx), _STD forward<_Args>(__args)...)) } noexcept;
+    };
 #else // ^^^ no workaround / workaround vvv
 template <class _Void, class _Ty, class _Fn, class... _Args>
 inline constexpr bool _Is_nothrow_constructible_from_invocation_impl = false;
@@ -78,8 +79,8 @@ inline constexpr bool _Is_nothrow_constructible_from_invocation_impl = false;
 template <class _Ty, class _Fn, class... _Args>
 inline constexpr bool _Is_nothrow_constructible_from_invocation_impl<
     void_t<decltype(::new (_STD declval<void*>()) _Ty(_STD invoke(_STD declval<_Fn>(), _STD declval<_Args>()...)))>,
-    _Ty, _Fn, _Args...> = noexcept(::new (_STD declval<void*>())
-        _Ty(_STD invoke(_STD declval<_Fn>(), _STD declval<_Args>()...)));
+    _Ty, _Fn, _Args...> =
+    noexcept(::new (_STD declval<void*>()) _Ty(_STD invoke(_STD declval<_Fn>(), _STD declval<_Args>()...)));
 
 template <class _Ty, class _Fn, class... _Args>
 inline constexpr bool _Is_nothrow_constructible_from_invocation =

--- a/stl/inc/optional
+++ b/stl/inc/optional
@@ -65,27 +65,6 @@ _STL_INTERNAL_STATIC_ASSERT(!is_trivially_default_constructible_v<_Nontrivial_du
 struct _Construct_from_invoke_result_tag {
     explicit _Construct_from_invoke_result_tag() = default;
 };
-
-#ifdef __cpp_lib_concepts // TRANSITION, GH-395
-template <class _Ty, class _Fn, class... _Args>
-inline constexpr bool _Is_nothrow_constructible_from_invocation =
-    requires(void* __vp, _Fn&& __fx, _Args&&... __args) {
-        { ::new (__vp) _Ty(_STD invoke(_STD forward<_Fn>(__fx), _STD forward<_Args>(__args)...)) } noexcept;
-    };
-#else // ^^^ no workaround / workaround vvv
-template <class _Void, class _Ty, class _Fn, class... _Args>
-inline constexpr bool _Is_nothrow_constructible_from_invocation_impl = false;
-
-template <class _Ty, class _Fn, class... _Args>
-inline constexpr bool _Is_nothrow_constructible_from_invocation_impl<
-    void_t<decltype(::new (_STD declval<void*>()) _Ty(_STD invoke(_STD declval<_Fn>(), _STD declval<_Args>()...)))>,
-    _Ty, _Fn, _Args...> =
-    noexcept(::new (_STD declval<void*>()) _Ty(_STD invoke(_STD declval<_Fn>(), _STD declval<_Args>()...)));
-
-template <class _Ty, class _Fn, class... _Args>
-inline constexpr bool _Is_nothrow_constructible_from_invocation =
-    _Is_nothrow_constructible_from_invocation_impl<void, _Ty, _Fn, _Args...>;
-#endif // ^^^ workaround ^^^
 #endif // _HAS_CXX23
 
 template <class _Ty, bool = is_trivially_destructible_v<_Ty>>
@@ -106,7 +85,7 @@ struct _Optional_destruct_base { // either contains a value of _Ty or is empty (
 #if _HAS_CXX23
     template <class _Fn, class _Ux>
     constexpr _Optional_destruct_base(_Construct_from_invoke_result_tag, _Fn&& _Func, _Ux&& _Arg) noexcept(
-        _Is_nothrow_constructible_from_invocation<_Ty, _Fn, _Ux>)
+        noexcept(static_cast<_Ty>(_STD invoke(_STD forward<_Fn>(_Func), _STD forward<_Ux>(_Arg)))))
         : _Value(_STD invoke(_STD forward<_Fn>(_Func), _STD forward<_Ux>(_Arg))), _Has_value{true} {}
 #endif // _HAS_CXX23
 
@@ -139,7 +118,7 @@ struct _Optional_destruct_base<_Ty, false> { // either contains a value of _Ty o
 #if _HAS_CXX23
     template <class _Fn, class _Ux>
     constexpr _Optional_destruct_base(_Construct_from_invoke_result_tag, _Fn&& _Func, _Ux&& _Arg) noexcept(
-        _Is_nothrow_constructible_from_invocation<_Ty, _Fn, _Ux>)
+        noexcept(static_cast<_Ty>(_STD invoke(_STD forward<_Fn>(_Func), _STD forward<_Ux>(_Arg)))))
         : _Value(_STD invoke(_STD forward<_Fn>(_Func), _STD forward<_Ux>(_Arg))), _Has_value{true} {}
 #endif // _HAS_CXX23
 
@@ -298,7 +277,7 @@ public:
 #if _HAS_CXX23
     template <class _Fn, class _Ux>
     constexpr optional(_Construct_from_invoke_result_tag _Tag, _Fn&& _Func, _Ux&& _Arg) noexcept(
-        _Is_nothrow_constructible_from_invocation<_Ty, _Fn, _Ux>)
+        noexcept(static_cast<_Ty>(_STD invoke(_STD forward<_Fn>(_Func), _STD forward<_Ux>(_Arg)))))
         : _Mybase(_Tag, _STD forward<_Fn>(_Func), _STD forward<_Ux>(_Arg)) {}
 #endif // _HAS_CXX23
 

--- a/stl/inc/optional
+++ b/stl/inc/optional
@@ -298,7 +298,7 @@ public:
 #if _HAS_CXX23
     template <class _Fn, class _Ux>
     constexpr optional(_Construct_from_invoke_result_tag _Tag, _Fn&& _Func, _Ux&& _Arg) noexcept(
-        is_nothrow_constructible_v<_Ty, invoke_result_t<_Fn, _Ux>>)
+        _Is_nothrow_constructible_from_invocation<_Ty, _Fn, _Ux>)
         : _Mybase(_Tag, _STD forward<_Fn>(_Func), _STD forward<_Ux>(_Arg)) {}
 #endif // _HAS_CXX23
 

--- a/tests/std/tests/P0798R8_monadic_operations_for_std_optional/test.cpp
+++ b/tests/std/tests/P0798R8_monadic_operations_for_std_optional/test.cpp
@@ -115,10 +115,7 @@ void test_gh3667() {
 
     try {
         optional<int> opt(1);
-        opt.transform([](int) {
-            throw unique_exception{};
-            return 0;
-        });
+        opt.transform([](int) -> int { throw unique_exception{}; });
     } catch (const unique_exception&) {
         return;
     } catch (...) {

--- a/tests/std/tests/P0798R8_monadic_operations_for_std_optional/test.cpp
+++ b/tests/std/tests/P0798R8_monadic_operations_for_std_optional/test.cpp
@@ -109,7 +109,26 @@ constexpr bool test() {
     return true;
 }
 
+void test_gh3667() {
+    class unique_exception : public exception {};
+
+    try {
+        optional<int> opt(1);
+        opt.transform([](int) {
+            throw unique_exception{};
+            return 0;
+        });
+    } catch (const unique_exception&) {
+        return;
+    } catch (...) {
+        assert(false); // shouldn't terminate or reach here
+    }
+    assert(false); // shouldn't terminate or reach here
+}
+
 int main() {
     test();
     static_assert(test());
+
+    test_gh3667();
 }

--- a/tests/std/tests/P0798R8_monadic_operations_for_std_optional/test.cpp
+++ b/tests/std/tests/P0798R8_monadic_operations_for_std_optional/test.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include <cassert>
+#include <exception>
 #include <optional>
 #include <type_traits>
 #include <utility>

--- a/tests/std/tests/P0798R8_monadic_operations_for_std_optional/test.cpp
+++ b/tests/std/tests/P0798R8_monadic_operations_for_std_optional/test.cpp
@@ -110,7 +110,8 @@ constexpr bool test() {
     return true;
 }
 
-void test_gh3667() {
+void test_gh_3667() {
+    // GH-3667 <optional>: Throwing transformers will cause the program to terminate
     class unique_exception : public exception {};
 
     try {
@@ -128,5 +129,5 @@ int main() {
     test();
     static_assert(test());
 
-    test_gh3667();
+    test_gh_3667();
 }

--- a/tests/std/tests/P0798R8_monadic_operations_for_std_optional/test.cpp
+++ b/tests/std/tests/P0798R8_monadic_operations_for_std_optional/test.cpp
@@ -4,6 +4,7 @@
 #include <cassert>
 #include <exception>
 #include <optional>
+#include <string>
 #include <type_traits>
 #include <utility>
 
@@ -110,13 +111,14 @@ constexpr bool test() {
     return true;
 }
 
+template <class T>
 void test_gh_3667() {
     // GH-3667 <optional>: Throwing transformers will cause the program to terminate
     class unique_exception : public exception {};
 
     try {
-        optional<int> opt(1);
-        opt.transform([](int) -> int { throw unique_exception{}; });
+        optional<T> opt(in_place);
+        opt.transform([](const T&) -> T { throw unique_exception{}; });
     } catch (const unique_exception&) {
         return;
     } catch (...) {
@@ -129,5 +131,6 @@ int main() {
     test();
     static_assert(test());
 
-    test_gh_3667();
+    test_gh_3667<int>(); // trivial destructor
+    test_gh_3667<string>(); // non-trivial destructor
 }


### PR DESCRIPTION
Fixes #3667.