### PR TITLE
`<typeinfo>`: Error with `import std;` and `typeid(T).name()`

### DIFF
--- a/stl/inc/typeinfo
+++ b/stl/inc/typeinfo
@@ -22,9 +22,7 @@ _STL_DISABLE_CLANG_WARNINGS
 
 #include <vcruntime_typeinfo.h>
 
-extern "C++" { // attach declarations to the global module, see N4944 [module.unit]/7
-_EXPORT_STD class type_info; // for typeid, MSVC looks for type_info in the global namespace
-} // extern "C++"
+_EXPORT_STD extern "C++" class type_info; // for typeid, MSVC looks for type_info in the global namespace
 
 _STD_BEGIN
 

--- a/stl/inc/typeinfo
+++ b/stl/inc/typeinfo
@@ -22,6 +22,10 @@ _STL_DISABLE_CLANG_WARNINGS
 
 #include <vcruntime_typeinfo.h>
 
+extern "C++" { // attach declarations to the global module, see N4944 [module.unit]/7
+_EXPORT_STD class type_info; // for typeid, MSVC looks for type_info in the global namespace
+} // extern "C++"
+
 _STD_BEGIN
 
 // size in pointers of std::function and std::any (roughly 3 pointers larger than std::string when building debug)

--- a/tests/std/include/test_header_units_and_modules.hpp
+++ b/tests/std/include/test_header_units_and_modules.hpp
@@ -937,6 +937,8 @@ void test_typeinfo() {
     const type_info& t3 = typeid(double);
     assert(t1 == t2);
     assert(t1 != t3);
+
+    assert(typeid(double).name() == "double"sv); // also test DevCom-10349749
 }
 
 void test_unordered_map() {


### PR DESCRIPTION
@cdacamar explained that in this case, the MSVC compiler looks for the True Name of `type_info` in the global namespace, so we need to export it as a special exception.

I'm adding test coverage for this scenario. The `using namespace std;` in this test doesn't actually affect the repro, so I didn't bother to remove it.

Fixes DevCom-10349749 and internal VSO-1810086 / AB#1810086 .
