### PR TITLE
`<__msvc_chrono.hpp>`: Use `_Xtime_get_ticks` in `_To_timespec64_sys_10_day_clamped` for consistency

### DIFF
--- a/stl/inc/__msvc_chrono.hpp
+++ b/stl/inc/__msvc_chrono.hpp
@@ -703,7 +703,7 @@ _NODISCARD bool _To_timespec64_sys_10_day_clamped(
     // Every function calling this one is TRANSITION, ABI
     constexpr _CHRONO nanoseconds _Ten_days{_CHRONO hours{24} * 10};
     constexpr _CHRONO duration<double> _Ten_days_d{_Ten_days};
-    _CHRONO nanoseconds _Tx0 = _CHRONO system_clock::now().time_since_epoch();
+    _CHRONO nanoseconds _Tx0 = _CHRONO system_clock::duration{_Xtime_get_ticks()};
     const bool _Clamped      = _Ten_days_d < _Rel_time;
     if (_Clamped) {
         _Tx0 += _Ten_days;


### PR DESCRIPTION
Part of #1588.

`_Xtime_get_ticks` and `system_clock::now` would no longer be equal after a future leap second when #1520 is eventually fixed. This PR changes the clock used in `_To_timespec64_sys_10_day_clamped` to be consistent with code that consumes its result, e.g. `target` in https://github.com/microsoft/STL/blob/091cad2eaaa5bc25873eb7261cae57ab123592f3/stl/src/cond.cpp#L72-L80

@BillyONeal pointed out (on Discord) that this PR could break (already somewhat broken) timed wait ABI:
> `_To_xtime_10_day_clamped`, used by `condition_variable::wait_for`, `this_thread::sleep_for`, etc., calls `system_clock::now()` internally to compute a value interpreted as `GetSystemTimeAsFileTime + offset` by another component. My understanding is that if the linker picks the old version of `_To_xtime_10_day_clamped` and the new version of `system_clock::now()` from different object files, all those wait functions could wait for a few seconds too short (assuming positive leap seconds) after future leap seconds.

<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
