### PR TITLE
`<mdspan>`: Diversify integer types used in tests

### DIFF
--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -601,7 +601,7 @@ public:
             _Strides.back() = 1;
             for (rank_type _Idx = extents_type::_Rank - 1; _Idx-- > 0;) {
                 // TRANSITION USE `_Multiply_with_overflow_check` IN DEBUG MODE
-                _Strides[_Idx] = _Strides[_Idx + 1] * _Exts.extent(_Idx + 1);
+                _Strides[_Idx] = static_cast<index_type>(_Strides[_Idx + 1] * _Exts.extent(_Idx + 1));
             }
         }
     }
@@ -752,7 +752,7 @@ public:
             }
 
             for (rank_type _Idx = 0; _Idx < extents_type::_Rank; ++_Idx) {
-                if (_Left.stride(_Idx) != _Right.stride(_Idx)) {
+                if (_STD cmp_not_equal(_Left.stride(_Idx), _Right.stride(_Idx))) {
                     return false;
                 }
             }
@@ -786,7 +786,7 @@ private:
     template <class... _IndexTypes, size_t... _Seq>
     _NODISCARD constexpr index_type _Index_impl(index_sequence<_Seq...>, _IndexTypes... _Indices) const noexcept {
         _STL_INTERNAL_STATIC_ASSERT((same_as<_IndexTypes, index_type> && ...));
-        return ((_Indices * _Strides[_Seq]) + ... + 0);
+        return static_cast<index_type>(((_Indices * _Strides[_Seq]) + ... + 0));
     }
 };
 

--- a/tests/std/include/test_mdspan_support.hpp
+++ b/tests/std/include/test_mdspan_support.hpp
@@ -3,9 +3,11 @@
 
 #pragma once
 
+#include <algorithm>
 #include <concepts>
 #include <cstddef>
 #include <mdspan>
+#include <span>
 #include <type_traits>
 #include <utility>
 
@@ -155,4 +157,66 @@ constexpr bool check_accessor_policy_requirements() {
     static_assert(detail::CheckNestedTypesOfAccessorPolicy<A>);
     static_assert(detail::CheckMemberFunctionsOfAccessorPolicy<A>);
     return true;
+}
+
+namespace details {
+    template <size_t... Extents, class TestFn>
+    constexpr void check_members_with_mixed_extents(TestFn&& fn) {
+        auto select_extent = [](size_t e) consteval {
+            return e == std::dynamic_extent ? std::min<size_t>(sizeof...(Extents), 3) : e;
+        };
+
+        // Check signed integers
+        fn(std::extents<signed char, Extents...>{select_extent(Extents)...});
+        fn(std::extents<short, Extents...>{select_extent(Extents)...});
+        fn(std::extents<int, Extents...>{select_extent(Extents)...});
+        fn(std::extents<long, Extents...>{select_extent(Extents)...});
+        fn(std::extents<long long, Extents...>{select_extent(Extents)...});
+
+        // Check unsigned integers
+        fn(std::extents<unsigned char, Extents...>{select_extent(Extents)...});
+        fn(std::extents<unsigned short, Extents...>{select_extent(Extents)...});
+        fn(std::extents<unsigned, Extents...>{select_extent(Extents)...});
+        fn(std::extents<unsigned long, Extents...>{select_extent(Extents)...});
+        fn(std::extents<unsigned long long, Extents...>{select_extent(Extents)...});
+    }
+
+    template <class TestFn, size_t... Seq>
+    constexpr void check_members_with_various_extents_impl(TestFn&& fn, std::index_sequence<Seq...>) {
+        auto static_or_dynamic = [](size_t i) consteval {
+            return i == 0 ? std::dynamic_extent : std::min<size_t>(sizeof...(Seq), 3);
+        };
+
+        // Check with mixed Extents
+        if constexpr (sizeof...(Seq) <= 1) {
+            check_members_with_mixed_extents<>(std::forward<TestFn>(fn));
+        } else if constexpr (sizeof...(Seq) <= 2) {
+            (check_members_with_mixed_extents<static_or_dynamic(Seq)>(std::forward<TestFn>(fn)), ...);
+        } else if constexpr (sizeof...(Seq) <= 4) {
+            (check_members_with_mixed_extents<static_or_dynamic(Seq & 0x2), static_or_dynamic(Seq & 0x1)>(
+                 std::forward<TestFn>(fn)),
+                ...);
+        } else if constexpr (sizeof...(Seq) <= 8) {
+            (check_members_with_mixed_extents<static_or_dynamic(Seq & 0x4), static_or_dynamic(Seq & 0x2),
+                 static_or_dynamic(Seq & 0x1)>(std::forward<TestFn>(fn)),
+                ...);
+        } else if constexpr (sizeof...(Seq) <= 16) {
+            (check_members_with_mixed_extents<static_or_dynamic(Seq & 0x8), static_or_dynamic(Seq & 0x4),
+                 static_or_dynamic(Seq & 0x2), static_or_dynamic(Seq & 0x1)>(std::forward<TestFn>(fn)),
+                ...);
+        } else {
+            static_assert(sizeof...(Seq) <= 16, "We don't need more testing.");
+        }
+    }
+} // namespace details
+
+template <class TestFn>
+constexpr void check_members_with_various_extents(TestFn&& fn) {
+    details::check_members_with_various_extents_impl(std::forward<TestFn>(fn), std::make_index_sequence<1>{});
+    details::check_members_with_various_extents_impl(std::forward<TestFn>(fn), std::make_index_sequence<2>{});
+    details::check_members_with_various_extents_impl(std::forward<TestFn>(fn), std::make_index_sequence<4>{});
+    details::check_members_with_various_extents_impl(std::forward<TestFn>(fn), std::make_index_sequence<8>{});
+#if _PREFAST_ == 0
+    details::check_members_with_various_extents_impl(std::forward<TestFn>(fn), std::make_index_sequence<16>{});
+#endif // _PREFAST_ == 0
 }

--- a/tests/std/include/test_mdspan_support.hpp
+++ b/tests/std/include/test_mdspan_support.hpp
@@ -163,7 +163,7 @@ namespace details {
     template <size_t... Extents, class Fn>
     constexpr void check_members_with_mixed_extents(Fn&& fn) {
         auto select_extent = [](size_t e) consteval {
-            return e == std::dynamic_extent ? std::min<size_t>(sizeof...(Extents), 3) : e;
+            return e == std::dynamic_extent ? std::min(sizeof...(Extents), size_t{3}) : e;
         };
 
         // Check signed integers
@@ -176,7 +176,7 @@ namespace details {
         // Check unsigned integers
         fn(std::extents<unsigned char, Extents...>{select_extent(Extents)...});
         fn(std::extents<unsigned short, Extents...>{select_extent(Extents)...});
-        fn(std::extents<unsigned, Extents...>{select_extent(Extents)...});
+        fn(std::extents<unsigned int, Extents...>{select_extent(Extents)...});
         fn(std::extents<unsigned long, Extents...>{select_extent(Extents)...});
         fn(std::extents<unsigned long long, Extents...>{select_extent(Extents)...});
     }
@@ -184,7 +184,7 @@ namespace details {
     template <class Fn, size_t... Seq>
     constexpr void check_members_with_various_extents_impl(Fn&& fn, std::index_sequence<Seq...>) {
         auto static_or_dynamic = [](size_t i) consteval {
-            return i == 0 ? std::dynamic_extent : std::min<size_t>(sizeof...(Seq), 3);
+            return i == 0 ? std::dynamic_extent : std::min(sizeof...(Seq), size_t{3});
         };
 
         if constexpr (sizeof...(Seq) <= 1) {
@@ -215,7 +215,7 @@ constexpr void check_members_with_various_extents(Fn&& fn) {
     details::check_members_with_various_extents_impl(std::forward<Fn>(fn), std::make_index_sequence<2>{});
     details::check_members_with_various_extents_impl(std::forward<Fn>(fn), std::make_index_sequence<4>{});
     details::check_members_with_various_extents_impl(std::forward<Fn>(fn), std::make_index_sequence<8>{});
-#if _PREFAST_ == 0
+#ifndef _PREFAST_
     details::check_members_with_various_extents_impl(std::forward<Fn>(fn), std::make_index_sequence<16>{});
-#endif // _PREFAST_ == 0
+#endif // _PREFAST_
 }

--- a/tests/std/tests/P0009R18_mdspan_extents/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_extents/test.cpp
@@ -292,16 +292,26 @@ constexpr void check_equality_operator() {
 }
 
 constexpr bool test() {
-    check_members<short>();
-    check_members<int, 1, 2, 3>();
-    check_members<unsigned short, 4, 4>();
-    check_members<unsigned long long, dynamic_extent, 4, 5>();
-    check_members<short, dynamic_extent, dynamic_extent, 6>();
-    check_members<unsigned char, dynamic_extent, dynamic_extent, dynamic_extent>();
+    // Check signed integers
+    check_members<signed char, 127>();
+    check_members<short, 4, dynamic_extent>();
+    check_members<int, 5, dynamic_extent, 5>();
+    check_members<long, dynamic_extent, dynamic_extent>();
+    check_members<long long, dynamic_extent, dynamic_extent, dynamic_extent, 8>();
+
+    // Check unsigned integers
+    check_members<unsigned char, dynamic_extent>();
+    check_members<unsigned short, dynamic_extent, 4>();
+    check_members<unsigned, dynamic_extent, 5, dynamic_extent>();
+    check_members<unsigned long, 7, 7>();
+    check_members<unsigned long long, 8, 8, 8, dynamic_extent>();
+
+    // Other checks
     check_construction_from_other_extents();
     check_construction_from_extents_pack();
     check_construction_from_array_and_span();
     check_equality_operator();
+
     return true;
 }
 

--- a/tests/std/tests/P0009R18_mdspan_extents/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_extents/test.cpp
@@ -15,7 +15,7 @@
 using namespace std;
 
 template <class IndexType, size_t... Extents, size_t... Indices>
-constexpr void do_check_members(index_sequence<Indices...>) {
+constexpr void check_members(index_sequence<Indices...>) {
     using Ext = extents<IndexType, Extents...>;
 
     // Each specialization of extents models regular and is trivially copyable
@@ -78,11 +78,6 @@ constexpr void do_check_members(index_sequence<Indices...>) {
         static_assert(is_nothrow_constructible_v<Ext2, decltype(s)>);
         // Other tests are defined in 'check_construction_from_array_and_span' function
     }
-}
-
-template <class IndexType, size_t... Extents>
-constexpr void check_members() {
-    do_check_members<IndexType, Extents...>(make_index_sequence<sizeof...(Extents)>{});
 }
 
 constexpr void check_construction_from_other_extents() {
@@ -292,21 +287,9 @@ constexpr void check_equality_operator() {
 }
 
 constexpr bool test() {
-    // Check signed integers
-    check_members<signed char, 127>();
-    check_members<short, 4, dynamic_extent>();
-    check_members<int, 5, dynamic_extent, 5>();
-    check_members<long, dynamic_extent, dynamic_extent>();
-    check_members<long long, dynamic_extent, dynamic_extent, dynamic_extent, 8>();
-
-    // Check unsigned integers
-    check_members<unsigned char, dynamic_extent>();
-    check_members<unsigned short, dynamic_extent, 4>();
-    check_members<unsigned, dynamic_extent, 5, dynamic_extent>();
-    check_members<unsigned long, 7, 7>();
-    check_members<unsigned long long, 8, 8, 8, dynamic_extent>();
-
-    // Other checks
+    check_members_with_various_extents([]<class IndexType, size_t... Extents>(const extents<IndexType, Extents...>&) {
+        check_members<IndexType, Extents...>(make_index_sequence<sizeof...(Extents)>{});
+    });
     check_construction_from_other_extents();
     check_construction_from_extents_pack();
     check_construction_from_array_and_span();

--- a/tests/std/tests/P0009R18_mdspan_layout_left/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_layout_left/test.cpp
@@ -14,7 +14,7 @@
 using namespace std;
 
 template <class IndexType, size_t... Extents, size_t... Indices>
-constexpr void do_check_members(const extents<IndexType, Extents...>& ext, index_sequence<Indices...>) {
+constexpr void check_members(const extents<IndexType, Extents...>& ext, index_sequence<Indices...>) {
     using Ext     = extents<IndexType, Extents...>;
     using Mapping = layout_left::mapping<Ext>;
 
@@ -142,11 +142,6 @@ constexpr void do_check_members(const extents<IndexType, Extents...>& ext, index
         assert(!(m != m));
         // Other tests are defined in 'check_comparisons' function
     }
-}
-
-template <class IndexType, size_t... Extents>
-constexpr void check_members(extents<IndexType, Extents...> ext) {
-    do_check_members<IndexType, Extents...>(ext, make_index_sequence<sizeof...(Extents)>{});
 }
 
 constexpr void check_construction_from_other_left_mapping() {
@@ -356,21 +351,10 @@ constexpr void check_correctness() {
 }
 
 constexpr bool test() {
-    // Check signed integers
-    check_members(extents<signed char, 5>{5});
-    check_members(extents<short>{});
-    check_members(extents<int, 1, 2, 3>{});
-    check_members(extents<long, dynamic_extent, dynamic_extent, 6>{4, 5});
-    check_members(extents<long long, dynamic_extent, dynamic_extent, 6>{4, 5});
-
-    // Check unsigned integers
-    check_members(extents<unsigned char, dynamic_extent, dynamic_extent, dynamic_extent>{3, 3, 3});
-    check_members(extents<unsigned short, 4, 4>{});
-    check_members(extents<unsigned, dynamic_extent, 4>{4, 4});
-    check_members(extents<unsigned long, 1, dynamic_extent, 3>{1, 2, 3});
-    check_members(extents<unsigned long long, dynamic_extent, 4, 5>{3});
-
-    // Other checks
+    check_members_with_various_extents(
+        []<class IndexType, size_t... Extents>(const extents<IndexType, Extents...>& ext) {
+            check_members(ext, make_index_sequence<sizeof...(Extents)>{});
+        });
     check_construction_from_other_left_mapping();
     check_construction_from_other_right_mapping();
     check_construction_from_other_stride_mapping();

--- a/tests/std/tests/P0009R18_mdspan_layout_left/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_layout_left/test.cpp
@@ -356,18 +356,28 @@ constexpr void check_correctness() {
 }
 
 constexpr bool test() {
+    // Check signed integers
+    check_members(extents<signed char, 5>{5});
     check_members(extents<short>{});
     check_members(extents<int, 1, 2, 3>{});
-    check_members(extents<unsigned short, 4, 4>{});
-    check_members(extents<unsigned long long, dynamic_extent, 4, 5>{3});
-    check_members(extents<short, dynamic_extent, dynamic_extent, 6>{4, 5});
+    check_members(extents<long, dynamic_extent, dynamic_extent, 6>{4, 5});
+    check_members(extents<long long, dynamic_extent, dynamic_extent, 6>{4, 5});
+
+    // Check unsigned integers
     check_members(extents<unsigned char, dynamic_extent, dynamic_extent, dynamic_extent>{3, 3, 3});
+    check_members(extents<unsigned short, 4, 4>{});
+    check_members(extents<unsigned, dynamic_extent, 4>{4, 4});
+    check_members(extents<unsigned long, 1, dynamic_extent, 3>{1, 2, 3});
+    check_members(extents<unsigned long long, dynamic_extent, 4, 5>{3});
+
+    // Other checks
     check_construction_from_other_left_mapping();
     check_construction_from_other_right_mapping();
     check_construction_from_other_stride_mapping();
     check_call_operator();
     check_comparisons();
     check_correctness();
+
     return true;
 }
 

--- a/tests/std/tests/P0009R18_mdspan_layout_right/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_layout_right/test.cpp
@@ -14,7 +14,7 @@
 using namespace std;
 
 template <class IndexType, size_t... Extents, size_t... Indices>
-constexpr void do_check_members(const extents<IndexType, Extents...>& ext, index_sequence<Indices...>) {
+constexpr void check_members(const extents<IndexType, Extents...>& ext, index_sequence<Indices...>) {
     using Ext     = extents<IndexType, Extents...>;
     using Mapping = layout_right::mapping<Ext>;
 
@@ -51,6 +51,8 @@ constexpr void do_check_members(const extents<IndexType, Extents...>& ext, index
     using Ext2           = extents<OtherIndexType, Extents...>;
     using Mapping2       = layout_right::mapping<Ext2>;
 
+#pragma warning(push) // TRANSITION, "/analyze:only" BUG?
+#pragma warning(disable : 28020) // The expression '0<=_Param_(1)&&_Param_(1)<=1-1' is not true at this call
     { // Check construction from other layout_right::mapping
         Mapping m1{ext};
         Mapping2 m2{m1};
@@ -138,11 +140,7 @@ constexpr void do_check_members(const extents<IndexType, Extents...>& ext, index
         assert(!(m != m));
         // Other tests are defined in 'check_comparisons' function
     }
-}
-
-template <class IndexType, size_t... Extents>
-constexpr void check_members(extents<IndexType, Extents...> ext) {
-    do_check_members<IndexType, Extents...>(ext, make_index_sequence<sizeof...(Extents)>{});
+#pragma warning(pop) // TRANSITION, "/analyze:only" BUG?
 }
 
 constexpr void check_construction_from_other_right_mapping() {
@@ -367,21 +365,10 @@ constexpr void check_correctness() {
 }
 
 constexpr bool test() {
-    // Check signed integers
-    check_members(extents<signed char>{});
-    check_members(extents<short, dynamic_extent, dynamic_extent, 6>{4, 5});
-    check_members(extents<int, 1, 2, 3>{});
-    check_members(extents<long, 3, dynamic_extent, dynamic_extent>{3, 2, 1});
-    check_members(extents<long long, 9, dynamic_extent, 7>{4});
-
-    // Check unsigned integers
-    check_members(extents<unsigned char, dynamic_extent, dynamic_extent, dynamic_extent>{3, 3, 3});
-    check_members(extents<unsigned short, 4, 4>{});
-    check_members(extents<unsigned, dynamic_extent, dynamic_extent, dynamic_extent>{7, 5, 3});
-    check_members(extents<unsigned long, 9, 6, dynamic_extent>{3});
-    check_members(extents<unsigned long long, dynamic_extent, 4, 5>{3});
-
-    // Other checks
+    check_members_with_various_extents(
+        []<class IndexType, size_t... Extents>(const extents<IndexType, Extents...>& ext) {
+            check_members(ext, make_index_sequence<sizeof...(Extents)>{});
+        });
     check_construction_from_other_right_mapping();
     check_construction_from_other_left_mapping();
     check_construction_from_other_stride_mapping();

--- a/tests/std/tests/P0009R18_mdspan_layout_right/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_layout_right/test.cpp
@@ -367,18 +367,28 @@ constexpr void check_correctness() {
 }
 
 constexpr bool test() {
-    check_members(extents<short>{});
-    check_members(extents<int, 1, 2, 3>{});
-    check_members(extents<unsigned short, 4, 4>{});
-    check_members(extents<unsigned long long, dynamic_extent, 4, 5>{3});
+    // Check signed integers
+    check_members(extents<signed char>{});
     check_members(extents<short, dynamic_extent, dynamic_extent, 6>{4, 5});
+    check_members(extents<int, 1, 2, 3>{});
+    check_members(extents<long, 3, dynamic_extent, dynamic_extent>{3, 2, 1});
+    check_members(extents<long long, 9, dynamic_extent, 7>{4});
+
+    // Check unsigned integers
     check_members(extents<unsigned char, dynamic_extent, dynamic_extent, dynamic_extent>{3, 3, 3});
+    check_members(extents<unsigned short, 4, 4>{});
+    check_members(extents<unsigned, dynamic_extent, dynamic_extent, dynamic_extent>{7, 5, 3});
+    check_members(extents<unsigned long, 9, 6, dynamic_extent>{3});
+    check_members(extents<unsigned long long, dynamic_extent, 4, 5>{3});
+
+    // Other checks
     check_construction_from_other_right_mapping();
     check_construction_from_other_left_mapping();
     check_construction_from_other_stride_mapping();
     check_call_operator();
     check_comparisons();
     check_correctness();
+
     return true;
 }
 

--- a/tests/std/tests/P0009R18_mdspan_layout_stride/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_layout_stride/test.cpp
@@ -166,18 +166,18 @@ constexpr void check_members(extents<IndexType, Extents...> ext, const array<int
 
 constexpr bool test() {
     // Check signed integers
-    check_members(extents<signed char, 5>{5}, array<int, 1>{1});
-    check_members(extents<short, 6, 7>{}, array<int, 2>{1, 6});
-    check_members(extents<int, 3, dynamic_extent>{3}, array<int, 2>{1, 3});
-    check_members(extents<long, 4>{}, array<int, 1>{1});
-    check_members(extents<long long, 3, 2, dynamic_extent>{3}, array<int, 3>{1, 3, 6});
+    check_members(extents<signed char, 5>{5}, array{1});
+    check_members(extents<short, 6, 7>{}, array{1, 6});
+    check_members(extents<int, 3, dynamic_extent>{3}, array{1, 3});
+    check_members(extents<long, 4>{}, array{1});
+    check_members(extents<long long, 3, 2, dynamic_extent>{3}, array{1, 3, 6});
 
     // Check unsigned integers
-    check_members(extents<unsigned char, 5>{5}, array<int, 1>{1});
-    check_members(extents<unsigned short, 6, 7>{}, array<int, 2>{1, 6});
-    check_members(extents<unsigned, 3, dynamic_extent>{3}, array<int, 2>{1, 3});
-    check_members(extents<unsigned long, 4>{}, array<int, 1>{1});
-    check_members(extents<unsigned long long, 3, 2, dynamic_extent>{3}, array<int, 3>{1, 3, 6});
+    check_members(extents<unsigned char, 5>{5}, array{1});
+    check_members(extents<unsigned short, 6, 7>{}, array{1, 6});
+    check_members(extents<unsigned, 3, dynamic_extent>{3}, array{1, 3});
+    check_members(extents<unsigned long, 4>{}, array{1});
+    check_members(extents<unsigned long long, 3, 2, dynamic_extent>{3}, array{1, 3, 6});
 
     // TRANSITION more tests
     return true;

--- a/tests/std/tests/P0009R18_mdspan_layout_stride/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_layout_stride/test.cpp
@@ -16,7 +16,7 @@ using namespace std;
 
 struct CmpEqual {
     template <class T, class U>
-    constexpr bool operator()(T t, U u) {
+    [[nodiscard]] constexpr bool operator()(T t, U u) const noexcept {
         return cmp_equal(t, u);
     }
 };

--- a/tests/std/tests/P0009R18_mdspan_layout_stride/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_layout_stride/test.cpp
@@ -159,7 +159,7 @@ constexpr void check_members(extents<IndexType, Extents...> ext, const array<int
     // Check unsigned strides
     check_members_with_different_strides_index_type<unsigned char>(ext, strides);
     check_members_with_different_strides_index_type<unsigned short>(ext, strides);
-    check_members_with_different_strides_index_type<unsigned>(ext, strides);
+    check_members_with_different_strides_index_type<unsigned int>(ext, strides);
     check_members_with_different_strides_index_type<unsigned long>(ext, strides);
     check_members_with_different_strides_index_type<unsigned long long>(ext, strides);
 }
@@ -175,7 +175,7 @@ constexpr bool test() {
     // Check unsigned integers
     check_members(extents<unsigned char, 5>{5}, array{1});
     check_members(extents<unsigned short, 6, 7>{}, array{1, 6});
-    check_members(extents<unsigned, 3, dynamic_extent>{3}, array{1, 3});
+    check_members(extents<unsigned int, 3, dynamic_extent>{3}, array{1, 3});
     check_members(extents<unsigned long, 4>{}, array{1});
     check_members(extents<unsigned long long, 3, 2, dynamic_extent>{3}, array{1, 3, 6});
 


### PR DESCRIPTION
* Improve tests of `extents` and layout mappings:
  * Check all 10 standard signed and unsigned integer types,
  * Check various combinations of static and dynamic extents.
* Fix integral conversions in `layout_stride::mapping`.