### PR TITLE
`<xlocnum>`: Fix grouping for `num_get`

### DIFF
--- a/stl/inc/xlocnum
+++ b/stl/inc/xlocnum
@@ -244,7 +244,10 @@ __PURE_APPDOMAIN_GLOBAL locale::id numpunct<_Elem>::id;
 #endif // !defined(_CRTBLD) || defined(CRTDLL2) || !defined(_DLL) || defined(_M_CEE_PURE)
 
 struct _Num_get_parse_result {
-    int8_t _Base; // 0 for parsing failure, otherwise 10 or 16
+    // For integers: negative values mean for parsing failure, while the "actual" base (used by _Getifld) is ~_Base.
+    // Otherwise, 0, 8, 10, or 16.
+    // For floating-point numbers: 0 for parsing failure, otherwise 10 or 16.
+    int8_t _Base;
     bool _Bad_grouping;
 };
 
@@ -362,20 +365,19 @@ protected:
             }
         } else { // get long value
             char _Ac[_MAX_INT_DIG];
-            const int _Base = _Getifld(_Ac, _First, _Last, _Iosbase.flags(), _Iosbase.getloc()); // gather field
-            if (_Ac[0] == '\0') { // Handle N4944 [facet.num.get.virtuals]/3.9:
-                                  //  "zero, if the conversion function does not convert the entire field."
-                                  // We should still do numeric conversion with bad digit separators, instead of
-                                  // setting 0, but we can't distinguish that from _Getifld's interface, and _Getifld's
-                                  // interface can't be changed as it is an exported function.
-                                  // TRANSITION, ABI: Fixing that when ABI allows is tracked by VSO-591516.
+            const auto _Parse_result =
+                _Parse_int_with_locale(_Ac, _First, _Last, _Iosbase.flags(), _Iosbase.getloc()); // gather field
+            if (_Parse_result._Base < 0) {
+                // N4944 [facet.num.get.virtuals]/3.9:
+                //  "zero, if the conversion function does not convert the entire field."
                 _Val   = false;
                 _State = ios_base::failbit;
             } else {
                 char* _Ep;
                 int _Errno;
-                const long _Ans = _CSTD _Stolx(_Ac, &_Ep, _Base, &_Errno); // convert
-                if (_Ep == _Ac || _Errno != 0) {
+                const long _Ans = _CSTD _Stolx(_Ac, &_Ep, _Parse_result._Base, &_Errno); // convert
+                if (_Ep == _Ac || _Errno != 0 // N4944 [facet.num.get.virtuals]/3
+                    || _Parse_result._Bad_grouping) { // N4944 [facet.num.get.virtuals]/4
                     _Val   = true;
                     _State = ios_base::failbit;
                 } else {
@@ -398,8 +400,9 @@ protected:
         unsigned short& _Val) const { // get unsigned short from [_First, _Last) into _Val
         _Adl_verify_range(_First, _Last);
         char _Ac[_MAX_INT_DIG];
-        const int _Base = _Getifld(_Ac, _First, _Last, _Iosbase.flags(), _Iosbase.getloc()); // gather field
-        if (_Ac[0] == '\0') { // ditto "fails to convert the entire field" / VSO-591516
+        const auto _Parse_result =
+            _Parse_int_with_locale(_Ac, _First, _Last, _Iosbase.flags(), _Iosbase.getloc()); // gather field
+        if (_Parse_result._Base < 0) { // ditto "fails to convert the entire field"
             _State = ios_base::failbit;
             _Val   = 0;
         } else {
@@ -413,14 +416,18 @@ protected:
 
             char* _Ep;
             int _Errno;
-            const unsigned long _Tmp = _CSTD _Stoulx(_Digits, &_Ep, _Base, &_Errno); // convert
+            const unsigned long _Tmp = _CSTD _Stoulx(_Digits, &_Ep, _Parse_result._Base, &_Errno); // convert
             _Val                     = static_cast<unsigned short>(_Tmp);
-            if (_Ep == _Digits || _Errno != 0 || _Tmp > USHRT_MAX) {
+            if (_Ep == _Digits || _Errno != 0 || _Tmp > USHRT_MAX) { // N4944 [facet.num.get.virtuals]/3
                 _State = ios_base::failbit;
                 _Val   = USHRT_MAX;
             } else if (_Minus) { // C11 7.22.1.4/5:  If the subject sequence begins with a minus sign,
                                  // the value resulting from the conversion is negated (in the return type).
                 _Val = static_cast<unsigned short>(0 - _Val);
+            }
+
+            if (_Parse_result._Bad_grouping) { // N4944 [facet.num.get.virtuals]/4
+                _State = ios_base::failbit;
             }
         }
 
@@ -445,15 +452,17 @@ protected:
         long& _Val) const { // get long from [_First, _Last) into _Val
         _Adl_verify_range(_First, _Last);
         char _Ac[_MAX_INT_DIG];
-        const int _Base = _Getifld(_Ac, _First, _Last, _Iosbase.flags(), _Iosbase.getloc()); // gather field
-        if (_Ac[0] == '\0') { // ditto "fails to convert the entire field" / VSO-591516
+        const auto _Parse_result =
+            _Parse_int_with_locale(_Ac, _First, _Last, _Iosbase.flags(), _Iosbase.getloc()); // gather field
+        if (_Parse_result._Base < 0) { // ditto "fails to convert the entire field"
             _State = ios_base::failbit;
             _Val   = 0;
         } else {
             char* _Ep;
             int _Errno;
-            _Val = _CSTD _Stolx(_Ac, &_Ep, _Base, &_Errno); // convert
-            if (_Ep == _Ac || _Errno != 0) {
+            _Val = _CSTD _Stolx(_Ac, &_Ep, _Parse_result._Base, &_Errno); // convert
+            if (_Ep == _Ac || _Errno != 0 // N4944 [facet.num.get.virtuals]/3
+                || _Parse_result._Bad_grouping) { // N4944 [facet.num.get.virtuals]/4
                 _State = ios_base::failbit;
             }
         }
@@ -469,15 +478,17 @@ protected:
         unsigned long& _Val) const { // get unsigned long from [_First, _Last) into _Val
         _Adl_verify_range(_First, _Last);
         char _Ac[_MAX_INT_DIG];
-        const int _Base = _Getifld(_Ac, _First, _Last, _Iosbase.flags(), _Iosbase.getloc()); // gather field
-        if (_Ac[0] == '\0') { // ditto "fails to convert the entire field" / VSO-591516
+        const auto _Parse_result =
+            _Parse_int_with_locale(_Ac, _First, _Last, _Iosbase.flags(), _Iosbase.getloc()); // gather field
+        if (_Parse_result._Base < 0) { // ditto "fails to convert the entire field"
             _State = ios_base::failbit;
             _Val   = 0;
         } else {
             char* _Ep;
             int _Errno;
-            _Val = _CSTD _Stoulx(_Ac, &_Ep, _Base, &_Errno); // convert
-            if (_Ep == _Ac || _Errno != 0) {
+            _Val = _CSTD _Stoulx(_Ac, &_Ep, _Parse_result._Base, &_Errno); // convert
+            if (_Ep == _Ac || _Errno != 0 // N4944 [facet.num.get.virtuals]/3
+                || _Parse_result._Bad_grouping) { // N4944 [facet.num.get.virtuals]/4
                 _State = ios_base::failbit;
             }
         }
@@ -493,15 +504,17 @@ protected:
         long long& _Val) const { // get long long from [_First, _Last) into _Val
         _Adl_verify_range(_First, _Last);
         char _Ac[_MAX_INT_DIG];
-        const int _Base = _Getifld(_Ac, _First, _Last, _Iosbase.flags(), _Iosbase.getloc());
-        if (_Ac[0] == '\0') { // ditto "fails to convert the entire field" / VSO-591516
+        const auto _Parse_result =
+            _Parse_int_with_locale(_Ac, _First, _Last, _Iosbase.flags(), _Iosbase.getloc()); // gather field
+        if (_Parse_result._Base < 0) { // ditto "fails to convert the entire field"
             _State = ios_base::failbit;
             _Val   = 0;
         } else {
             char* _Ep;
             int _Errno;
-            _Val = _CSTD _Stollx(_Ac, &_Ep, _Base, &_Errno); // convert
-            if (_Ep == _Ac || _Errno != 0) {
+            _Val = _CSTD _Stollx(_Ac, &_Ep, _Parse_result._Base, &_Errno); // convert
+            if (_Ep == _Ac || _Errno != 0 // N4944 [facet.num.get.virtuals]/3
+                || _Parse_result._Bad_grouping) { // N4944 [facet.num.get.virtuals]/4
                 _State = ios_base::failbit;
             }
         }
@@ -517,15 +530,17 @@ protected:
         unsigned long long& _Val) const { // get unsigned long long from [_First, _Last) into _Val
         _Adl_verify_range(_First, _Last);
         char _Ac[_MAX_INT_DIG];
-        const int _Base = _Getifld(_Ac, _First, _Last, _Iosbase.flags(), _Iosbase.getloc());
-        if (_Ac[0] == '\0') { // ditto "fails to convert the entire field" / VSO-591516
+        const auto _Parse_result =
+            _Parse_int_with_locale(_Ac, _First, _Last, _Iosbase.flags(), _Iosbase.getloc()); // gather field
+        if (_Parse_result._Base < 0) { // ditto "fails to convert the entire field"
             _State = ios_base::failbit;
             _Val   = 0;
         } else {
             int _Errno;
             char* _Ep;
-            _Val = _CSTD _Stoullx(_Ac, &_Ep, _Base, &_Errno); // convert
-            if (_Ep == _Ac || _Errno != 0) {
+            _Val = _CSTD _Stoullx(_Ac, &_Ep, _Parse_result._Base, &_Errno); // convert
+            if (_Ep == _Ac || _Errno != 0 // N4944 [facet.num.get.virtuals]/3
+                || _Parse_result._Bad_grouping) { // N4944 [facet.num.get.virtuals]/4
                 _State = ios_base::failbit;
             }
         }
@@ -606,21 +621,26 @@ protected:
         void*& _Val) const { // get void pointer from [_First, _Last) into _Val
         _Adl_verify_range(_First, _Last);
         char _Ac[_MAX_INT_DIG];
-        const int _Base = _Getifld(_Ac, _First, _Last, ios_base::hex, _Iosbase.getloc()); // gather field
-        if (_Ac[0] == '\0') { // ditto "fails to convert the entire field" / VSO-591516
+        const auto _Parse_result =
+            _Parse_int_with_locale(_Ac, _First, _Last, ios_base::hex, _Iosbase.getloc()); // gather field
+        if (_Parse_result._Base < 0) { // ditto "fails to convert the entire field"
             _State = ios_base::failbit;
             _Val   = nullptr;
         } else {
             int _Errno;
             char* _Ep;
 #ifdef _WIN64
-            _Val = reinterpret_cast<void*>(_CSTD _Stoullx(_Ac, &_Ep, _Base, &_Errno));
+            _Val = reinterpret_cast<void*>(_CSTD _Stoullx(_Ac, &_Ep, _Parse_result._Base, &_Errno));
 #else // ^^^ _WIN64 / !_WIN64 vvv
-            _Val = reinterpret_cast<void*>(_CSTD _Stoulx(_Ac, &_Ep, _Base, &_Errno));
+            _Val = reinterpret_cast<void*>(_CSTD _Stoulx(_Ac, &_Ep, _Parse_result._Base, &_Errno));
 #endif // _WIN64
-            if (_Ep == _Ac || _Errno != 0) {
+            if (_Ep == _Ac || _Errno != 0) { // N4944 [facet.num.get.virtuals]/3
                 _State = ios_base::failbit;
                 _Val   = nullptr;
+            }
+
+            if (_Parse_result._Bad_grouping) { // N4944 [facet.num.get.virtuals]/4
+                _State = ios_base::failbit;
             }
         }
 
@@ -632,8 +652,10 @@ protected:
     }
 
 private:
-    int __CLRCALL_OR_CDECL _Getifld(char* _Ac, _InIt& _First, _InIt& _Last, ios_base::fmtflags _Basefield,
-        const locale& _Loc) const { // get integer field from [_First, _Last) into _Ac
+    template <int = 0> // TRANSITON, ABI
+    static _Num_get_parse_result _Parse_int_with_locale(
+        char* const _Ac, _InIt& _First, _InIt& _Last, ios_base::fmtflags _Basefield, const locale& _Loc) {
+        // get integer field from [_First, _Last) into _Ac
         const auto& _Punct_fac  = _STD use_facet<numpunct<_Elem>>(_Loc);
         const string _Grouping  = _Punct_fac.grouping();
         const _Elem _Kseparator = _Grouping.empty() ? _Elem{} : _Punct_fac.thousands_sep();
@@ -644,6 +666,16 @@ private:
         _Elem _Atoms[sizeof(_Src)];
         const ctype<_Elem>& _Ctype_fac = _STD use_facet<ctype<_Elem>>(_Loc);
         _Ctype_fac.widen(_STD begin(_Src), _STD end(_Src), _Atoms);
+
+        bool _Bad_grouping = false;
+
+        // skip leading separators before the sign
+        if (_Kseparator != _Elem{}) {
+            while (_First != _Last && *_First == _Kseparator) {
+                ++_First;
+                _Bad_grouping = true;
+            }
+        }
 
         char* _Ptr = _Ac;
 
@@ -657,9 +689,17 @@ private:
             }
         }
 
+        // skip leading separator before digits
+        if (_Kseparator != _Elem{}) {
+            while (_First != _Last && *_First == _Kseparator) {
+                ++_First;
+                _Bad_grouping = true;
+            }
+        }
+
         _Basefield &= ios_base::basefield;
 
-        int _Base;
+        int8_t _Base;
         if (_Basefield == ios_base::oct) {
             _Base = 8;
         } else if (_Basefield == ios_base::hex) {
@@ -703,8 +743,10 @@ private:
                 if (_Groups[_Groups_arr_idx] != CHAR_MAX) {
                     ++_Groups[_Groups_arr_idx];
                 }
-            } else if (_Groups[_Groups_arr_idx] == '\0' || _Kseparator == _Elem{} || *_First != _Kseparator) {
+            } else if (_Kseparator == _Elem{} || *_First != _Kseparator) {
                 break; // not a group separator, done
+            } else if (_Groups[_Groups_arr_idx] == '\0') {
+                _Bad_grouping = true; // adjacent separators, fail
             } else { // add a new group to _Groups string
                 _Groups.push_back('\0');
                 ++_Groups_arr_idx;
@@ -715,13 +757,21 @@ private:
             if (_Groups[_Groups_arr_idx] > '\0') {
                 ++_Groups_arr_idx; // add trailing group to group count
             } else {
-                _Seendigit = false; // trailing separator, fail
+                _Bad_grouping = true; // trailing separator, fail
+            }
+        }
+
+        // skip trailing separators
+        if (_Kseparator != _Elem{}) {
+            while (_First != _Last && *_First == _Kseparator) {
+                ++_First;
+                _Bad_grouping = true;
             }
         }
 
         const char* _Grouping_iter      = _Grouping.data();
-        const char* const _Grouping_end = _Grouping.data() + _Grouping.size();
-        for (char _Current_grouping_count = '\0'; _Seendigit && _Groups_arr_idx > 0;) {
+        const char* const _Grouping_end = _Grouping_iter + _Grouping.size();
+        for (char _Current_grouping_count = '\0'; _Seendigit && !_Bad_grouping && _Groups_arr_idx > 0;) {
             if (_Grouping_iter != _Grouping_end) { // keep the last value when _Grouping is exhausted
                 _Current_grouping_count = *_Grouping_iter; // if _Grouping is empty, '\0' is used
                 ++_Grouping_iter;
@@ -731,19 +781,21 @@ private:
             if ((_Current_grouping_count > '\0' && _Current_grouping_count != CHAR_MAX)
                 && ((_Groups_arr_idx > 0 && _Groups[_Groups_arr_idx] != _Current_grouping_count)
                     || (_Groups_arr_idx == 0 && _Groups[_Groups_arr_idx] > _Current_grouping_count))) {
-                _Seendigit = false; // bad group size, fail
+                _Bad_grouping = true; // bad group size, fail
             }
             // group size okay, advance to next test
         }
 
-        if (_Seendigit && !_Nonzero) {
+        if (!_Seendigit) {
+            return {static_cast<int8_t>(~_Base), false};
+        }
+
+        if (!_Nonzero) {
             *_Ptr++ = '0'; // zero field, replace stripped zero(s)
-        } else if (!_Seendigit) {
-            _Ptr = _Ac; // roll back pointer to indicate failure
         }
 
         *_Ptr = '\0';
-        return _Base;
+        return {_Base, _Bad_grouping};
     }
 
     template <int = 0> // TRANSITION, ABI
@@ -771,6 +823,20 @@ private:
         const _Elem _Negative_sign = _Atoms[_Offset_neg_sign];
         const _Elem _Zero_wc       = _Atoms[0];
 
+        const auto& _Punct_fac  = _STD use_facet<numpunct<_Elem>>(_Loc);
+        const string _Grouping  = _Punct_fac.grouping();
+        const _Elem _Kseparator = _Grouping.empty() ? _Elem{} : _Punct_fac.thousands_sep();
+
+        bool _Bad_grouping = false;
+
+        // skip leading separators before the sign
+        if (!_Grouping.empty()) {
+            while (_First != _Last && *_First == _Kseparator) {
+                ++_First;
+                _Bad_grouping = true;
+            }
+        }
+
         if (_First != _Last) {
             if (*_First == _Positive_sign) { // gather plus sign
                 *_Ptr++ = '+';
@@ -790,7 +856,7 @@ private:
             ++_First;
             if (_First == _Last) { // "0" only
                 *_Ptr = '\0';
-                return {10, false};
+                return {10, _Bad_grouping};
             }
 
             if (*_First == _Atoms[_Offset_lower_x] || *_First == _Atoms[_Offset_upper_x]) { // 0x or 0X
@@ -804,13 +870,10 @@ private:
         }
 
         bool _Has_unaccumulated_digits = false;
-        bool _Bad_grouping             = false;
         int _Significant               = 0; // number of significant digits
         ptrdiff_t _Power_of_rep_base   = 0; // power of 10 or 16
 
         const size_t _Offset_digit_end = _Parse_hex ? _Offset_hex_digit_end : _Offset_dec_digit_end;
-        const auto& _Punct_fac         = _STD use_facet<numpunct<_Elem>>(_Loc);
-        const string _Grouping         = _Punct_fac.grouping();
         if (_Grouping.empty()) {
             for (size_t _Idx; _First != _Last && (_Idx = _STD _Find_elem(_Atoms, *_First)) < _Offset_digit_end;
                  _Seendigit = true, (void) ++_First) {
@@ -825,7 +888,12 @@ private:
                 }
             }
         } else {
-            const _Elem _Kseparator = _Punct_fac.thousands_sep();
+            // skip leading separators before digits
+            while (_First != _Last && *_First == _Kseparator) {
+                ++_First;
+                _Bad_grouping = true;
+            }
+
             string _Groups(1, _Initial_dec_leading_zero); // Groups are detected in the reversed order of _Groups.
             size_t _Groups_arr_idx = 0;
 
@@ -846,8 +914,10 @@ private:
                     if (_Groups[_Groups_arr_idx] != CHAR_MAX) {
                         ++_Groups[_Groups_arr_idx];
                     }
-                } else if (_Groups[_Groups_arr_idx] == '\0' || *_First != _Kseparator) {
+                } else if (*_First != _Kseparator) {
                     break; // not a group separator, done
+                } else if (_Groups[_Groups_arr_idx] == '\0') {
+                    _Bad_grouping = true; // adjacent separators, fail
                 } else { // add a new group to _Groups string
                     _Groups.push_back('\0');
                     ++_Groups_arr_idx;
@@ -860,6 +930,12 @@ private:
                 } else {
                     _Bad_grouping = true; // trailing separator, fail
                 }
+            }
+
+            // skip trailing separators
+            while (_First != _Last && *_First == _Kseparator) {
+                ++_First;
+                _Bad_grouping = true;
             }
 
             const char* _Grouping_iter      = _Grouping.data();
@@ -1027,12 +1103,27 @@ private:
         return {static_cast<int8_t>(_Parse_hex ? 16 : 10), _Bad_grouping};
     }
 
+    // TRANSITION, ABI, unused now, tracked by VSO-591516.
+    int __CLRCALL_OR_CDECL _Getifld(
+        char* _Ac, _InIt& _First, _InIt& _Last, ios_base::fmtflags _Basefield, const locale& _Loc) const {
+        // get integer field from [_First, _Last) into _Ac
+        static constexpr char _Src[] = "0123456789ABCDEFabcdef-+Xx"; // TRANSITION, ABI, was implicitly dllexported
+        const char* volatile _Ptr    = _Src;
+        (void) _Ptr;
+
+        const auto _Parse_result = _Parse_int_with_locale(_Ac, _First, _Last, _Basefield, _Loc);
+        if (_Parse_result._Base < 0 || _Parse_result._Bad_grouping) { // TRANSITION, ABI, old behavior
+            *_Ac = '\0';
+        }
+        return _Parse_result._Base < 0 ? ~_Parse_result._Base : _Parse_result._Base;
+    }
+
 // TRANSITION, ABI: Sentinel value used by num_get::do_get()
 // to enable correct "V2" behavior in _Getffld() and _Getffldx()
 #define _ENABLE_V2_BEHAVIOR 1000000000
 
+    // TRANSITION, ABI, unused now
     int __CLRCALL_OR_CDECL _Getffld(char* _Ac, _InIt& _First, _InIt& _Last, ios_base& _Iosbase, int* _Phexexp) const {
-        // TRANSITION, ABI, unused now
         // get floating-point field from [_First, _Last) into _Ac
         static constexpr char _Src[] = "0123456789-+Ee"; // TRANSITION, ABI, was implicitly dllexported
         const char* volatile _Ptr    = &_Src[0];
@@ -1049,8 +1140,8 @@ private:
         return 0; // power of 10 multiplier, unnecessary now
     }
 
+    // TRANSITION, ABI, unused now
     int __CLRCALL_OR_CDECL _Getffldx(char* _Ac, _InIt& _First, _InIt& _Last, ios_base& _Iosbase, int* _Phexexp) const {
-        // TRANSITION, ABI, unused now
         // get floating-point field from [_First, _Last) into _Ac
         static constexpr char _Src[] = "0123456789ABCDEFabcdef-+XxPp"; // TRANSITION, ABI, was implicitly dllexported
         const char* volatile _Ptr    = &_Src[0];

--- a/stl/inc/xlocnum
+++ b/stl/inc/xlocnum
@@ -368,7 +368,7 @@ protected:
             const auto _Parse_result =
                 _Parse_int_with_locale(_Ac, _First, _Last, _Iosbase.flags(), _Iosbase.getloc()); // gather field
             if (_Parse_result._Base < 0) {
-                // N4944 [facet.num.get.virtuals]/3.9:
+                // N4950 [facet.num.get.virtuals]/3.9:
                 //  "zero, if the conversion function does not convert the entire field."
                 _Val   = false;
                 _State = ios_base::failbit;
@@ -376,8 +376,8 @@ protected:
                 char* _Ep;
                 int _Errno;
                 const long _Ans = _CSTD _Stolx(_Ac, &_Ep, _Parse_result._Base, &_Errno); // convert
-                if (_Ep == _Ac || _Errno != 0 // N4944 [facet.num.get.virtuals]/3
-                    || _Parse_result._Bad_grouping) { // N4944 [facet.num.get.virtuals]/4
+                if (_Ep == _Ac || _Errno != 0 // N4950 [facet.num.get.virtuals]/3
+                    || _Parse_result._Bad_grouping) { // N4950 [facet.num.get.virtuals]/4
                     _Val   = true;
                     _State = ios_base::failbit;
                 } else {
@@ -418,7 +418,7 @@ protected:
             int _Errno;
             const unsigned long _Tmp = _CSTD _Stoulx(_Digits, &_Ep, _Parse_result._Base, &_Errno); // convert
             _Val                     = static_cast<unsigned short>(_Tmp);
-            if (_Ep == _Digits || _Errno != 0 || _Tmp > USHRT_MAX) { // N4944 [facet.num.get.virtuals]/3
+            if (_Ep == _Digits || _Errno != 0 || _Tmp > USHRT_MAX) { // N4950 [facet.num.get.virtuals]/3
                 _State = ios_base::failbit;
                 _Val   = USHRT_MAX;
             } else if (_Minus) { // C11 7.22.1.4/5:  If the subject sequence begins with a minus sign,
@@ -426,7 +426,7 @@ protected:
                 _Val = static_cast<unsigned short>(0 - _Val);
             }
 
-            if (_Parse_result._Bad_grouping) { // N4944 [facet.num.get.virtuals]/4
+            if (_Parse_result._Bad_grouping) { // N4950 [facet.num.get.virtuals]/4
                 _State = ios_base::failbit;
             }
         }
@@ -461,8 +461,8 @@ protected:
             char* _Ep;
             int _Errno;
             _Val = _CSTD _Stolx(_Ac, &_Ep, _Parse_result._Base, &_Errno); // convert
-            if (_Ep == _Ac || _Errno != 0 // N4944 [facet.num.get.virtuals]/3
-                || _Parse_result._Bad_grouping) { // N4944 [facet.num.get.virtuals]/4
+            if (_Ep == _Ac || _Errno != 0 // N4950 [facet.num.get.virtuals]/3
+                || _Parse_result._Bad_grouping) { // N4950 [facet.num.get.virtuals]/4
                 _State = ios_base::failbit;
             }
         }
@@ -487,8 +487,8 @@ protected:
             char* _Ep;
             int _Errno;
             _Val = _CSTD _Stoulx(_Ac, &_Ep, _Parse_result._Base, &_Errno); // convert
-            if (_Ep == _Ac || _Errno != 0 // N4944 [facet.num.get.virtuals]/3
-                || _Parse_result._Bad_grouping) { // N4944 [facet.num.get.virtuals]/4
+            if (_Ep == _Ac || _Errno != 0 // N4950 [facet.num.get.virtuals]/3
+                || _Parse_result._Bad_grouping) { // N4950 [facet.num.get.virtuals]/4
                 _State = ios_base::failbit;
             }
         }
@@ -513,8 +513,8 @@ protected:
             char* _Ep;
             int _Errno;
             _Val = _CSTD _Stollx(_Ac, &_Ep, _Parse_result._Base, &_Errno); // convert
-            if (_Ep == _Ac || _Errno != 0 // N4944 [facet.num.get.virtuals]/3
-                || _Parse_result._Bad_grouping) { // N4944 [facet.num.get.virtuals]/4
+            if (_Ep == _Ac || _Errno != 0 // N4950 [facet.num.get.virtuals]/3
+                || _Parse_result._Bad_grouping) { // N4950 [facet.num.get.virtuals]/4
                 _State = ios_base::failbit;
             }
         }
@@ -539,8 +539,8 @@ protected:
             int _Errno;
             char* _Ep;
             _Val = _CSTD _Stoullx(_Ac, &_Ep, _Parse_result._Base, &_Errno); // convert
-            if (_Ep == _Ac || _Errno != 0 // N4944 [facet.num.get.virtuals]/3
-                || _Parse_result._Bad_grouping) { // N4944 [facet.num.get.virtuals]/4
+            if (_Ep == _Ac || _Errno != 0 // N4950 [facet.num.get.virtuals]/3
+                || _Parse_result._Bad_grouping) { // N4950 [facet.num.get.virtuals]/4
                 _State = ios_base::failbit;
             }
         }
@@ -634,12 +634,12 @@ protected:
 #else // ^^^ _WIN64 / !_WIN64 vvv
             _Val = reinterpret_cast<void*>(_CSTD _Stoulx(_Ac, &_Ep, _Parse_result._Base, &_Errno));
 #endif // _WIN64
-            if (_Ep == _Ac || _Errno != 0) { // N4944 [facet.num.get.virtuals]/3
+            if (_Ep == _Ac || _Errno != 0) { // N4950 [facet.num.get.virtuals]/3
                 _State = ios_base::failbit;
                 _Val   = nullptr;
             }
 
-            if (_Parse_result._Bad_grouping) { // N4944 [facet.num.get.virtuals]/4
+            if (_Parse_result._Bad_grouping) { // N4950 [facet.num.get.virtuals]/4
                 _State = ios_base::failbit;
             }
         }

--- a/stl/inc/xlocnum
+++ b/stl/inc/xlocnum
@@ -244,7 +244,7 @@ __PURE_APPDOMAIN_GLOBAL locale::id numpunct<_Elem>::id;
 #endif // !defined(_CRTBLD) || defined(CRTDLL2) || !defined(_DLL) || defined(_M_CEE_PURE)
 
 struct _Num_get_parse_result {
-    // For integers: negative values mean for parsing failure, while the "actual" base (used by _Getifld) is ~_Base.
+    // For integers: negative values mean parsing failure, while the "actual" base (used by _Getifld) is ~_Base.
     // Otherwise, 0, 8, 10, or 16.
     // For floating-point numbers: 0 for parsing failure, otherwise 10 or 16.
     int8_t _Base;
@@ -652,7 +652,7 @@ protected:
     }
 
 private:
-    template <int = 0> // TRANSITON, ABI
+    template <int = 0> // TRANSITION, ABI
     static _Num_get_parse_result _Parse_int_with_locale(
         char* const _Ac, _InIt& _First, _InIt& _Last, ios_base::fmtflags _Basefield, const locale& _Loc) {
         // get integer field from [_First, _Last) into _Ac
@@ -689,7 +689,7 @@ private:
             }
         }
 
-        // skip leading separator before digits
+        // skip leading separators before digits
         if (_Kseparator != _Elem{}) {
             while (_First != _Last && *_First == _Kseparator) {
                 ++_First;

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -448,9 +448,6 @@ std/containers/sequences/array/array.swap/swap.fail.cpp FAIL
 std/algorithms/alg.sorting/alg.merge/inplace_merge_comp.pass.cpp FAIL
 std/algorithms/alg.sorting/alg.min.max/minmax_init_list_comp.pass.cpp FAIL
 
-# GH-1277 <xlocnum>: We don't match numpunct groups correctly in do_get
-std/localization/locale.categories/category.numeric/locale.num.get/facet.num.get.members/get_long.pass.cpp FAIL
-
 # GH-1275 <locale>: missing some locale names
 # We don't have the locale names libcxx wants specialized in platform_support.hpp
 # More bugs may be uncovered when the locale names are present.

--- a/tests/std/test.lst
+++ b/tests/std/test.lst
@@ -184,6 +184,7 @@ tests\GH_001086_partial_sort_copy
 tests\GH_001103_countl_zero_correctness
 tests\GH_001105_custom_streambuf_throws
 tests\GH_001123_random_cast_out_of_range
+tests\GH_001277_num_get_bad_grouping
 tests\GH_001411_core_headers
 tests\GH_001530_binomial_accuracy
 tests\GH_001541_case_sensitive_boolalpha

--- a/tests/std/tests/GH_001277_num_get_bad_grouping/env.lst
+++ b/tests/std/tests/GH_001277_num_get_bad_grouping/env.lst
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+RUNALL_INCLUDE ..\usual_matrix.lst

--- a/tests/std/tests/GH_001277_num_get_bad_grouping/test.cpp
+++ b/tests/std/tests/GH_001277_num_get_bad_grouping/test.cpp
@@ -272,7 +272,6 @@ void test_good_and_bad_grouping() {
 
 class my_numput : public num_put<char, char*> {
 public:
-public:
     explicit my_numput(size_t refs = 0) : num_put<char, char*>(refs) {}
 };
 

--- a/tests/std/tests/GH_001277_num_get_bad_grouping/test.cpp
+++ b/tests/std/tests/GH_001277_num_get_bad_grouping/test.cpp
@@ -1,0 +1,460 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <ios>
+#include <locale>
+#include <string>
+#include <type_traits>
+
+using namespace std;
+
+class my_facet : public num_get<char, const char*> {
+public:
+    explicit my_facet(size_t refs = 0) : num_get<char, const char*>(refs) {}
+};
+
+class special_numpunct : public numpunct<char> {
+public:
+    special_numpunct() : numpunct<char>() {}
+
+protected:
+    string do_grouping() const override {
+        return "\1\2\1"s;
+    }
+};
+
+// Test good and bad grouping for integers
+template <class Integer, enable_if_t<is_integral_v<Integer>, int> = 0>
+void test_good_and_bad_grouping() {
+    const my_facet f(1);
+    ios instr(nullptr);
+    instr.imbue(locale(locale(), new special_numpunct));
+
+    instr.setf(ios_base::fmtflags{}, ios_base::basefield);
+
+    Integer v = 0;
+    {
+        v                     = static_cast<Integer>(-1);
+        const char sep_str[]  = "0,17,7";
+        const size_t len      = sizeof(sep_str) - 1;
+        ios_base::iostate err = instr.goodbit;
+        const char* iter      = f.get(sep_str, sep_str + len + 1, instr, err, v);
+        assert(iter == sep_str + len);
+        assert(err == instr.goodbit);
+        assert(v == static_cast<Integer>(0177));
+    }
+    {
+        v                     = static_cast<Integer>(-1);
+        const char sep_str[]  = "01,77";
+        const size_t len      = sizeof(sep_str) - 1;
+        ios_base::iostate err = instr.goodbit;
+        const char* iter      = f.get(sep_str, sep_str + len + 1, instr, err, v);
+        assert(iter == sep_str + len);
+        assert(err == instr.failbit);
+        assert(v == static_cast<Integer>(0177));
+    }
+    {
+        v                     = static_cast<Integer>(-1);
+        const char sep_str[]  = "1,72,9";
+        const size_t len      = sizeof(sep_str) - 1;
+        ios_base::iostate err = instr.goodbit;
+        const char* iter      = f.get(sep_str, sep_str + len + 1, instr, err, v);
+        assert(iter == sep_str + len);
+        assert(err == instr.goodbit);
+        assert(v == static_cast<Integer>(1729));
+    }
+    {
+        v                     = static_cast<Integer>(-1);
+        const char sep_str[]  = "172,9";
+        const size_t len      = sizeof(sep_str) - 1;
+        ios_base::iostate err = instr.goodbit;
+        const char* iter      = f.get(sep_str, sep_str + len + 1, instr, err, v);
+        assert(iter == sep_str + len);
+        assert(err == instr.failbit);
+        assert(v == static_cast<Integer>(1729));
+    }
+    {
+        v                     = static_cast<Integer>(-1);
+        const char sep_str[]  = "0x1,72,9";
+        const size_t len      = sizeof(sep_str) - 1;
+        ios_base::iostate err = instr.goodbit;
+        const char* iter      = f.get(sep_str, sep_str + len + 1, instr, err, v);
+        assert(iter == sep_str + len);
+        assert(err == instr.goodbit);
+        assert(v == static_cast<Integer>(0x1729));
+    }
+    {
+        v                     = static_cast<Integer>(-1);
+        const char sep_str[]  = "0x1,729";
+        const size_t len      = sizeof(sep_str) - 1;
+        ios_base::iostate err = instr.goodbit;
+        const char* iter      = f.get(sep_str, sep_str + len + 1, instr, err, v);
+        assert(iter == sep_str + len);
+        assert(err == instr.failbit);
+        assert(v == static_cast<Integer>(0x1729));
+    }
+}
+
+// Test good and bad grouping for floating-point numbers
+template <class Flt, enable_if_t<is_floating_point_v<Flt>, int> = 0>
+void test_good_and_bad_grouping() {
+    const my_facet f(1);
+    ios instr(nullptr);
+    instr.imbue(locale(locale(), new special_numpunct));
+
+    Flt v = 0;
+    {
+        v                     = static_cast<Flt>(-1);
+        const char sep_str[]  = "1,72,9";
+        const size_t len      = sizeof(sep_str) - 1;
+        ios_base::iostate err = instr.goodbit;
+        const char* iter      = f.get(sep_str, sep_str + len + 1, instr, err, v);
+        assert(iter == sep_str + len);
+        assert(err == instr.goodbit);
+        assert(v == static_cast<Flt>(1729.0));
+    }
+    {
+        v                     = static_cast<Flt>(-1);
+        const char sep_str[]  = "1,72,9.0";
+        const size_t len      = sizeof(sep_str) - 1;
+        ios_base::iostate err = instr.goodbit;
+        const char* iter      = f.get(sep_str, sep_str + len + 1, instr, err, v);
+        assert(iter == sep_str + len);
+        assert(err == instr.goodbit);
+        assert(v == static_cast<Flt>(1729.0));
+    }
+    {
+        v                     = static_cast<Flt>(-1);
+        const char sep_str[]  = "1,72,9.125";
+        const size_t len      = sizeof(sep_str) - 1;
+        ios_base::iostate err = instr.goodbit;
+        const char* iter      = f.get(sep_str, sep_str + len + 1, instr, err, v);
+        assert(iter == sep_str + len);
+        assert(err == instr.goodbit);
+        assert(v == static_cast<Flt>(1729.125));
+    }
+    {
+        v                     = static_cast<Flt>(-1);
+        const char sep_str[]  = "0x1,72,9";
+        const size_t len      = sizeof(sep_str) - 1;
+        ios_base::iostate err = instr.goodbit;
+        const char* iter      = f.get(sep_str, sep_str + len + 1, instr, err, v);
+        assert(iter == sep_str + len);
+        assert(err == instr.goodbit);
+        assert(v == static_cast<Flt>(0x1729.0p0));
+    }
+    {
+        v                     = static_cast<Flt>(-1);
+        const char sep_str[]  = "0x1,72,9.0";
+        const size_t len      = sizeof(sep_str) - 1;
+        ios_base::iostate err = instr.goodbit;
+        const char* iter      = f.get(sep_str, sep_str + len + 1, instr, err, v);
+        assert(iter == sep_str + len);
+        assert(err == instr.goodbit);
+        assert(v == static_cast<Flt>(0x1729.0p0));
+    }
+    {
+        v                     = static_cast<Flt>(-1);
+        const char sep_str[]  = "0x1,72,9.3";
+        const size_t len      = sizeof(sep_str) - 1;
+        ios_base::iostate err = instr.goodbit;
+        const char* iter      = f.get(sep_str, sep_str + len + 1, instr, err, v);
+        assert(iter == sep_str + len);
+        assert(err == instr.goodbit);
+        assert(v == static_cast<Flt>(0x1729.3p0));
+    }
+    {
+        v                     = static_cast<Flt>(-1);
+        const char sep_str[]  = "1,729";
+        const size_t len      = sizeof(sep_str) - 1;
+        ios_base::iostate err = instr.goodbit;
+        const char* iter      = f.get(sep_str, sep_str + len + 1, instr, err, v);
+        assert(iter == sep_str + len);
+        assert(err == instr.failbit);
+        assert(v == static_cast<Flt>(1729.0));
+    }
+    {
+        v                     = static_cast<Flt>(-1);
+        const char sep_str[]  = "1,729.0";
+        const size_t len      = sizeof(sep_str) - 1;
+        ios_base::iostate err = instr.goodbit;
+        const char* iter      = f.get(sep_str, sep_str + len + 1, instr, err, v);
+        assert(iter == sep_str + len);
+        assert(err == instr.failbit);
+        assert(v == static_cast<Flt>(1729.0));
+    }
+    {
+        v                     = static_cast<Flt>(-1);
+        const char sep_str[]  = "1,729.125";
+        const size_t len      = sizeof(sep_str) - 1;
+        ios_base::iostate err = instr.goodbit;
+        const char* iter      = f.get(sep_str, sep_str + len + 1, instr, err, v);
+        assert(iter == sep_str + len);
+        assert(err == instr.failbit);
+        assert(v == static_cast<Flt>(1729.125));
+    }
+    {
+        v                     = static_cast<Flt>(-1);
+        const char sep_str[]  = "0x172,9";
+        const size_t len      = sizeof(sep_str) - 1;
+        ios_base::iostate err = instr.goodbit;
+        const char* iter      = f.get(sep_str, sep_str + len + 1, instr, err, v);
+        assert(iter == sep_str + len);
+        assert(err == instr.failbit);
+        assert(v == static_cast<Flt>(0x1729.0p0));
+    }
+    {
+        v                     = static_cast<Flt>(-1);
+        const char sep_str[]  = "0x172,9.0";
+        const size_t len      = sizeof(sep_str) - 1;
+        ios_base::iostate err = instr.goodbit;
+        const char* iter      = f.get(sep_str, sep_str + len + 1, instr, err, v);
+        assert(iter == sep_str + len);
+        assert(err == instr.failbit);
+        assert(v == static_cast<Flt>(0x1729.0p0));
+    }
+    {
+        v                     = static_cast<Flt>(-1);
+        const char sep_str[]  = "0x172,9.3";
+        const size_t len      = sizeof(sep_str) - 1;
+        ios_base::iostate err = instr.goodbit;
+        const char* iter      = f.get(sep_str, sep_str + len + 1, instr, err, v);
+        assert(iter == sep_str + len);
+        assert(err == instr.failbit);
+        assert(v == static_cast<Flt>(0x1729.3p0));
+    }
+
+    // separators at unexpected places
+    {
+        v                     = static_cast<Flt>(-1);
+        const char sep_str[]  = ",1,72,9";
+        const size_t len      = sizeof(sep_str) - 1;
+        ios_base::iostate err = instr.goodbit;
+        const char* iter      = f.get(sep_str, sep_str + len + 1, instr, err, v);
+        assert(iter == sep_str + len);
+        assert(err == instr.failbit);
+        assert(v == static_cast<Flt>(1729.0));
+    }
+    {
+        v                     = static_cast<Flt>(-1);
+        const char sep_str[]  = "1,72,9,,";
+        const size_t len      = sizeof(sep_str) - 1;
+        ios_base::iostate err = instr.goodbit;
+        const char* iter      = f.get(sep_str, sep_str + len + 1, instr, err, v);
+        assert(iter == sep_str + len);
+        assert(err == instr.failbit);
+        assert(v == static_cast<Flt>(1729.0));
+    }
+    {
+        v                     = static_cast<Flt>(-1);
+        const char sep_str[]  = ",+1,72,9";
+        const size_t len      = sizeof(sep_str) - 1;
+        ios_base::iostate err = instr.goodbit;
+        const char* iter      = f.get(sep_str, sep_str + len + 1, instr, err, v);
+        assert(iter == sep_str + len);
+        assert(err == instr.failbit);
+        assert(v == static_cast<Flt>(1729.0));
+    }
+    {
+        v                     = static_cast<Flt>(-1);
+        const char sep_str[]  = "-,172,9,,.0e0";
+        const size_t len      = sizeof(sep_str) - 1;
+        ios_base::iostate err = instr.goodbit;
+        const char* iter      = f.get(sep_str, sep_str + len + 1, instr, err, v);
+        assert(iter == sep_str + len);
+        assert(err == instr.failbit);
+        assert(v == static_cast<Flt>(-1729.0));
+    }
+}
+
+class my_numput : public num_put<char, char*> {
+public:
+public:
+    explicit my_numput(size_t refs = 0) : num_put<char, char*>(refs) {}
+};
+
+class another_numpunct : public numpunct<char> {
+public:
+    another_numpunct() : numpunct<char>() {}
+
+protected:
+    string do_grouping() const override {
+        return "\2\3\4"s;
+    }
+};
+
+// Test good and bad grouping for void*
+void test_good_and_bad_grouping_pointer() {
+    const void* ptr = reinterpret_cast<const void*>(static_cast<uintptr_t>(0xdeadbeef));
+    const my_facet f(1);
+    const my_numput of(1);
+    ios instr(nullptr);
+    instr.imbue(locale(locale(), new special_numpunct));
+
+    {
+        ios ostr(nullptr);
+        ostr.imbue(locale(locale(), new special_numpunct));
+
+        char buf[32];
+        const auto written_end = of.put(buf, ostr, '\0', ptr);
+
+        void* p               = nullptr;
+        ios_base::iostate err = instr.goodbit;
+        const auto read_end   = f.get(buf, buf + sizeof(buf), instr, err, p);
+        assert(read_end == written_end);
+        assert(err == instr.goodbit);
+        assert(p == ptr);
+    }
+    {
+        ios ostr(nullptr);
+        ostr.imbue(locale(locale(), new another_numpunct));
+
+        char buf[32];
+        const auto written_end = of.put(buf, ostr, '\0', ptr);
+
+        void* p               = nullptr;
+        ios_base::iostate err = instr.goodbit;
+        const auto read_end   = f.get(buf, buf + sizeof(buf), instr, err, p);
+        assert(read_end == written_end);
+        assert(err == instr.failbit);
+        assert(p == ptr);
+    }
+}
+
+class mid_zero_numpunct : public numpunct<char> {
+public:
+    mid_zero_numpunct() : numpunct<char>() {}
+
+protected:
+    string do_grouping() const override {
+        return "\1\0\2"s;
+    }
+};
+
+// Also test non-ending unlimited grouping for integers
+template <class Integer, enable_if_t<is_integral_v<Integer>, int> = 0>
+void test_nonending_unlimited_grouping() {
+    const my_facet f(1);
+    ios instr(nullptr);
+    instr.imbue(locale(locale(), new mid_zero_numpunct));
+
+    Integer v = 0;
+    {
+        v                     = static_cast<Integer>(-1);
+        const char sep_str[]  = "17,2,9";
+        const size_t len      = sizeof(sep_str) - 1;
+        ios_base::iostate err = instr.goodbit;
+        const char* iter      = f.get(sep_str, sep_str + len + 1, instr, err, v);
+        assert(iter == sep_str + len);
+        assert(err == instr.goodbit);
+        assert(v == static_cast<Integer>(1729));
+    }
+    {
+        v                     = static_cast<Integer>(-1);
+        const char sep_str[]  = "17,222,9";
+        const size_t len      = sizeof(sep_str) - 1;
+        ios_base::iostate err = instr.goodbit;
+        const char* iter      = f.get(sep_str, sep_str + len + 1, instr, err, v);
+        assert(iter == sep_str + len);
+        assert(err == instr.goodbit);
+        assert(v == static_cast<Integer>(172229));
+    }
+    {
+        v                     = static_cast<Integer>(-1);
+        const char sep_str[]  = "0x17,2,9";
+        const size_t len      = sizeof(sep_str) - 1;
+        ios_base::iostate err = instr.goodbit;
+
+        instr.flags(ios_base::fmtflags{});
+        const char* iter = f.get(sep_str, sep_str + len + 1, instr, err, v);
+        assert(iter == sep_str + len);
+        assert(err == instr.goodbit);
+        assert(v == static_cast<Integer>(0x1729));
+    }
+    {
+        v                     = static_cast<Integer>(-1);
+        const char sep_str[]  = "0x17,222,9";
+        const size_t len      = sizeof(sep_str) - 1;
+        ios_base::iostate err = instr.goodbit;
+
+        instr.flags(ios_base::fmtflags{});
+        const char* iter = f.get(sep_str, sep_str + len + 1, instr, err, v);
+        assert(iter == sep_str + len);
+        assert(err == instr.goodbit);
+        assert(v == static_cast<Integer>(0x172229));
+    }
+}
+
+// Also test non-ending unlimited grouping for FP numbers
+template <class Flt, enable_if_t<is_floating_point_v<Flt>, int> = 0>
+void test_nonending_unlimited_grouping() {
+    const my_facet f(1);
+    ios instr(nullptr);
+    instr.imbue(locale(locale(), new mid_zero_numpunct));
+    Flt v = 0;
+    {
+        v                     = -1;
+        const char sep_str[]  = "17,2,9.0";
+        const size_t len      = sizeof(sep_str) - 1;
+        ios_base::iostate err = instr.goodbit;
+        const char* iter      = f.get(sep_str, sep_str + len + 1, instr, err, v);
+        assert(iter == sep_str + len);
+        assert(err == instr.goodbit);
+        assert(v == 1729.0);
+    }
+    {
+        v                     = -1;
+        const char sep_str[]  = "17,222,9.0";
+        const size_t len      = sizeof(sep_str) - 1;
+        ios_base::iostate err = instr.goodbit;
+        const char* iter      = f.get(sep_str, sep_str + len + 1, instr, err, v);
+        assert(iter == sep_str + len);
+        assert(err == instr.goodbit);
+        assert(v == 172229.0);
+    }
+    {
+        v                     = -1;
+        const char sep_str[]  = "0x17,2,9.0";
+        const size_t len      = sizeof(sep_str) - 1;
+        ios_base::iostate err = instr.goodbit;
+        const char* iter      = f.get(sep_str, sep_str + len + 1, instr, err, v);
+        assert(iter == sep_str + len);
+        assert(err == instr.goodbit);
+        assert(v == 0x1729.0p0);
+    }
+    {
+        v                     = -1;
+        const char sep_str[]  = "0x17,222,9.0";
+        const size_t len      = sizeof(sep_str) - 1;
+        ios_base::iostate err = instr.goodbit;
+        const char* iter      = f.get(sep_str, sep_str + len + 1, instr, err, v);
+        assert(iter == sep_str + len);
+        assert(err == instr.goodbit);
+        assert(v == 0x172229.0p0);
+    }
+}
+
+int main() {
+    test_good_and_bad_grouping<unsigned short>();
+    test_good_and_bad_grouping<unsigned int>();
+    test_good_and_bad_grouping<long>();
+    test_good_and_bad_grouping<unsigned long>();
+    test_good_and_bad_grouping<long long>();
+    test_good_and_bad_grouping<unsigned long long>();
+    test_good_and_bad_grouping<float>();
+    test_good_and_bad_grouping<double>();
+    test_good_and_bad_grouping<long double>();
+    test_good_and_bad_grouping_pointer();
+
+    test_nonending_unlimited_grouping<unsigned int>();
+    test_nonending_unlimited_grouping<long>();
+    test_nonending_unlimited_grouping<unsigned long>();
+    test_nonending_unlimited_grouping<long long>();
+    test_nonending_unlimited_grouping<unsigned long long>();
+    test_nonending_unlimited_grouping<float>();
+    test_nonending_unlimited_grouping<double>();
+    test_nonending_unlimited_grouping<long double>();
+}

--- a/tests/std/tests/GH_001277_num_get_bad_grouping/test.cpp
+++ b/tests/std/tests/GH_001277_num_get_bad_grouping/test.cpp
@@ -300,6 +300,7 @@ void test_good_and_bad_grouping_pointer() {
 
         char buf[32];
         const auto written_end = of.put(buf, ostr, '\0', ptr);
+        *written_end           = '\0';
 
         void* p               = nullptr;
         ios_base::iostate err = instr.goodbit;
@@ -314,6 +315,7 @@ void test_good_and_bad_grouping_pointer() {
 
         char buf[32];
         const auto written_end = of.put(buf, ostr, '\0', ptr);
+        *written_end           = '\0';
 
         void* p               = nullptr;
         ios_base::iostate err = instr.goodbit;

--- a/tests/std/tests/LWG2381_num_get_floating_point/test.cpp
+++ b/tests/std/tests/LWG2381_num_get_floating_point/test.cpp
@@ -40,16 +40,6 @@ public:
     explicit my_facet(size_t refs = 0) : num_get<char, const char*>(refs) {}
 };
 
-class mid_zero_numpunct : public numpunct<char> {
-public:
-    mid_zero_numpunct() : numpunct<char>() {}
-
-protected:
-    string do_grouping() const override {
-        return "\1\0\2"s;
-    }
-};
-
 class my_numpunct : public numpunct<char> {
 public:
     my_numpunct() : numpunct<char>() {}
@@ -251,109 +241,6 @@ void test() {
         str_instr >> v;
         assert(v == 0);
         assert(str_instr.good());
-    }
-}
-
-// Also test non-ending unlimited grouping for FP numbers
-template <class Flt, enable_if_t<is_floating_point_v<Flt>, int> = 0>
-void test_nonending_unlimited_grouping() {
-    const my_facet f(1);
-    ios instr(nullptr);
-    instr.imbue(locale(locale(), new mid_zero_numpunct));
-    Flt v = 0;
-    {
-        v                     = -1;
-        const char sep_str[]  = "17,2,9.0";
-        const size_t len      = sizeof(sep_str) - 1;
-        ios_base::iostate err = instr.goodbit;
-        const char* iter      = f.get(sep_str, sep_str + len + 1, instr, err, v);
-        assert(iter == sep_str + len);
-        assert(err == instr.goodbit);
-        assert(v == 1729.0);
-    }
-    {
-        v                     = -1;
-        const char sep_str[]  = "17,222,9.0";
-        const size_t len      = sizeof(sep_str) - 1;
-        ios_base::iostate err = instr.goodbit;
-        const char* iter      = f.get(sep_str, sep_str + len + 1, instr, err, v);
-        assert(iter == sep_str + len);
-        assert(err == instr.goodbit);
-        assert(v == 172229.0);
-    }
-    {
-        v                     = -1;
-        const char sep_str[]  = "0x17,2,9.0";
-        const size_t len      = sizeof(sep_str) - 1;
-        ios_base::iostate err = instr.goodbit;
-        const char* iter      = f.get(sep_str, sep_str + len + 1, instr, err, v);
-        assert(iter == sep_str + len);
-        assert(err == instr.goodbit);
-        assert(v == 0x1729.0p0);
-    }
-    {
-        v                     = -1;
-        const char sep_str[]  = "0x17,222,9.0";
-        const size_t len      = sizeof(sep_str) - 1;
-        ios_base::iostate err = instr.goodbit;
-        const char* iter      = f.get(sep_str, sep_str + len + 1, instr, err, v);
-        assert(iter == sep_str + len);
-        assert(err == instr.goodbit);
-        assert(v == 0x172229.0p0);
-    }
-}
-
-// Also test non-ending unlimited grouping for integers
-template <class Integer, enable_if_t<is_integral_v<Integer>, int> = 0>
-void test_nonending_unlimited_grouping() {
-    const my_facet f(1);
-    ios instr(nullptr);
-    instr.imbue(locale(locale(), new mid_zero_numpunct));
-
-    Integer v = 0;
-    {
-        v                     = static_cast<Integer>(-1);
-        const char sep_str[]  = "17,2,9";
-        const size_t len      = sizeof(sep_str) - 1;
-        ios_base::iostate err = instr.goodbit;
-        const char* iter      = f.get(sep_str, sep_str + len + 1, instr, err, v);
-        assert(iter == sep_str + len);
-        assert(err == instr.goodbit);
-        assert(v == static_cast<Integer>(1729));
-    }
-    {
-        v                     = static_cast<Integer>(-1);
-        const char sep_str[]  = "17,222,9";
-        const size_t len      = sizeof(sep_str) - 1;
-        ios_base::iostate err = instr.goodbit;
-        const char* iter      = f.get(sep_str, sep_str + len + 1, instr, err, v);
-        assert(iter == sep_str + len);
-        assert(err == instr.goodbit);
-        assert(v == static_cast<Integer>(172229));
-    }
-    {
-        v                     = static_cast<Integer>(-1);
-        const char sep_str[]  = "0x17,2,9";
-        const size_t len      = sizeof(sep_str) - 1;
-        ios_base::iostate err = instr.goodbit;
-
-        instr.flags(ios_base::fmtflags{});
-        const char* iter = f.get(sep_str, sep_str + len + 1, instr, err, v);
-        assert(iter == sep_str + len);
-        assert(err == instr.goodbit);
-        assert(v == static_cast<Integer>(0x1729));
-    }
-    {
-        v                     = static_cast<Integer>(-1);
-        const char sep_str[]  = "0x17,222,9";
-        const size_t len      = sizeof(sep_str) - 1;
-        ios_base::iostate err = instr.goodbit;
-
-        instr.flags(ios_base::fmtflags{});
-        const char* iter = f.get(sep_str, sep_str + len + 1, instr, err, v);
-        assert(iter == sep_str + len);
-        assert(err == instr.goodbit);
-        assert(v == static_cast<Integer>(0x172229));
     }
 }
 
@@ -686,16 +573,6 @@ int main() {
     test<float>();
     test<double>();
     test<long double>();
-
-    test_nonending_unlimited_grouping<float>();
-    test_nonending_unlimited_grouping<double>();
-    test_nonending_unlimited_grouping<long double>();
-
-    test_nonending_unlimited_grouping<unsigned int>();
-    test_nonending_unlimited_grouping<long>();
-    test_nonending_unlimited_grouping<unsigned long>();
-    test_nonending_unlimited_grouping<long long>();
-    test_nonending_unlimited_grouping<unsigned long long>();
 
     test_gh_1582<float>();
     test_gh_1582<double>();


### PR DESCRIPTION
Fixes #1277.

Unblocking one libcxx test:
- `std/localization/locale.categories/category.numeric/locale.num.get/facet.num.get.members/get_long.pass.cpp`

Also moves the test for non-ending unlimited grouping to the new test file.

I'm not sure when the grouping string is `"\0"s` which means grouping is not limited:
- whether `"17,,29"` can be parsed without setting `failbit`, and
- whether `"0,x1729"` should be parsed as a whole...