### PR TITLE
`<xhash>`: Use ceiling instead of rounding when calculating number of buckets

### DIFF
--- a/stl/inc/xhash
+++ b/stl/inc/xhash
@@ -926,7 +926,7 @@ public:
     }
 
     void reserve(size_type _Maxcount) { // rebuild table with room for _Maxcount elements
-        rehash(static_cast<size_type>(static_cast<float>(_Maxcount) / max_load_factor() + 0.5F));
+        rehash(_Min_load_factor_buckets(_Maxcount));
     }
 
     conditional_t<_Multi, iterator, pair<iterator, bool>> insert(const value_type& _Val) {

--- a/tests/std/test.lst
+++ b/tests/std/test.lst
@@ -171,6 +171,7 @@ tests\GH_000545_include_compare
 tests\GH_000625_vector_bool_optimization
 tests\GH_000685_condition_variable_any
 tests\GH_000690_overaligned_function
+tests\GH_000732_hash_reserve
 tests\GH_000890_pow_template
 tests\GH_000935_complex_numerical_accuracy
 tests\GH_000940_missing_valarray_copy

--- a/tests/std/tests/GH_000732_hash_reserve/env.lst
+++ b/tests/std/tests/GH_000732_hash_reserve/env.lst
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+RUNALL_INCLUDE ..\usual_matrix.lst

--- a/tests/std/tests/GH_000732_hash_reserve/test.cpp
+++ b/tests/std/tests/GH_000732_hash_reserve/test.cpp
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <cassert>
+#include <unordered_set>
+
+using namespace std;
+
+int main() {
+    unordered_set<int> a;
+    a.max_load_factor(24.0f / 64.25f);
+    a.reserve(24);
+    assert(a.bucket_count() > 64);
+    return 0;
+}


### PR DESCRIPTION
Fixes #732.
