### PR TITLE
`<mdspan>`: Document CTAD workaround

### DIFF
--- a/stl/inc/mdspan
+++ b/stl/inc/mdspan
@@ -616,7 +616,7 @@ public:
         }
     }
 
-#ifndef __clang__ // TRANSITION, MSVC messes up CTAD when concepts are used here (needs further investigation)
+#ifndef __clang__ // TRANSITION, DevCom-10360833
     template <class _OtherIndexType, enable_if_t<is_convertible_v<const _OtherIndexType&, index_type>
                                                      && is_nothrow_constructible_v<index_type, const _OtherIndexType&>,
                                          int> = 0>
@@ -629,7 +629,7 @@ public:
         : mapping(_Exts_, _Strides_, make_index_sequence<extents_type::rank()>{}) {
     }
 
-#ifndef __clang__ // TRANSITION, MSVC messes up CTAD when concepts are used here (needs further investigation)
+#ifndef __clang__ // TRANSITION, DevCom-10360833
     template <class _OtherIndexType, enable_if_t<is_convertible_v<const _OtherIndexType&, index_type>
                                                      && is_nothrow_constructible_v<index_type, const _OtherIndexType&>,
                                          int> = 0>

--- a/tests/std/tests/P0009R18_mdspan_layout_stride/test.cpp
+++ b/tests/std/tests/P0009R18_mdspan_layout_stride/test.cpp
@@ -164,6 +164,14 @@ constexpr void check_members(extents<IndexType, Extents...> ext, const array<int
     check_members_with_different_strides_index_type<unsigned long long>(ext, strides);
 }
 
+constexpr void check_ctad() {
+    extents<size_t, 2, 3> e;
+    array<size_t, 2> s{1, 2};
+    layout_stride::mapping m{e, s};
+    assert(m.extents() == e);
+    assert(m.strides() == s);
+}
+
 constexpr bool test() {
     // Check signed integers
     check_members(extents<signed char, 5>{5}, array{1});
@@ -178,6 +186,8 @@ constexpr bool test() {
     check_members(extents<unsigned int, 3, dynamic_extent>{3}, array{1, 3});
     check_members(extents<unsigned long, 4>{}, array{1});
     check_members(extents<unsigned long long, 3, 2, dynamic_extent>{3}, array{1, 3, 6});
+
+    check_ctad();
 
     // TRANSITION more tests
     return true;


### PR DESCRIPTION
* Document DevCom-10360833 workaround,
* Add test coverage in `P0009R18_mdspan_layout_stride/test.cpp`,
  * Test coverage is also in old test suite `P0009R18_mdspan/test.cpp`.