### PR TITLE
Expand `std::iter_swap` and remove `_Swap_adl`

### DIFF
--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -3430,6 +3430,11 @@ _FwdIt2 swap_ranges(_ExPo&&, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _Dest) noe
 }
 #endif // _HAS_CXX17
 
+_EXPORT_STD template <class _FwdIt1, class _FwdIt2>
+_CONSTEXPR20 void iter_swap(_FwdIt1 _Left, _FwdIt2 _Right) { // swap *_Left and *_Right
+    swap(*_Left, *_Right); // intentional ADL
+}
+
 _EXPORT_STD template <class _InIt, class _OutIt, class _Fn>
 _CONSTEXPR20 _OutIt transform(const _InIt _First, const _InIt _Last, _OutIt _Dest, _Fn _Func) {
     // transform [_First, _Last) with _Func
@@ -5349,7 +5354,7 @@ void _Random_shuffle1(_RanIt _First, _RanIt _Last, _RngFn& _RngFunc) {
         _Diff _Off = _RngFunc(static_cast<_Diff>(_Target_index + 1));
         _STL_ASSERT(0 <= _Off && _Off <= _Target_index, "random value out of range");
         if (_Off != _Target_index) { // avoid self-move-assignment
-            _STD iter_swap(_UTarget, _UFirst + _Off);
+            swap(*_UTarget, *(_UFirst + _Off)); // intentional ADL
         }
     }
 }
@@ -5559,7 +5564,7 @@ constexpr _FwdIt shift_right(_FwdIt _First, const _FwdIt _Last, _Iter_diff_t<_Fw
 
                     return _First;
                 }
-                _Swap_adl(*_Mid, *_Trail);
+                swap(*_Mid, *_Trail); // intentional ADL
             }
         }
     }
@@ -5830,7 +5835,7 @@ _CONSTEXPR20 _FwdIt partition(_FwdIt _First, const _FwdIt _Last, _Pr _Pred) {
                 }
             } while (!_Pred(*_ULast));
 
-            _STD iter_swap(_UFirst, _ULast); // out of place, swap and loop
+            swap(*_UFirst, *_ULast); // out of place, swap and loop; intentional ADL
             ++_UFirst;
         }
     } else {
@@ -5849,7 +5854,7 @@ _CONSTEXPR20 _FwdIt partition(_FwdIt _First, const _FwdIt _Last, _Pr _Pred) {
 
         for (auto _UNext = _UFirst; ++_UNext != _ULast;) {
             if (_Pred(*_UNext)) {
-                _STD iter_swap(_UFirst, _UNext); // out of place, swap and loop
+                swap(*_UFirst, *_UNext); // out of place, swap and loop; intentional ADL
                 ++_UFirst;
             }
         }
@@ -7924,14 +7929,14 @@ template <class _RanIt, class _Pr>
 _CONSTEXPR20 void _Med3_unchecked(_RanIt _First, _RanIt _Mid, _RanIt _Last, _Pr _Pred) {
     // sort median of three elements to middle
     if (_DEBUG_LT_PRED(_Pred, *_Mid, *_First)) {
-        _STD iter_swap(_Mid, _First);
+        swap(*_Mid, *_First); // intentional ADL
     }
 
     if (_DEBUG_LT_PRED(_Pred, *_Last, *_Mid)) { // swap middle and last, then test first again
-        _STD iter_swap(_Last, _Mid);
+        swap(*_Last, *_Mid); // intentional ADL
 
         if (_DEBUG_LT_PRED(_Pred, *_Mid, *_First)) {
-            _STD iter_swap(_Mid, _First);
+            swap(*_Mid, *_First); // intentional ADL
         }
     }
 }
@@ -7980,7 +7985,7 @@ _CONSTEXPR20 pair<_RanIt, _RanIt> _Partition_by_median_guess_unchecked(_RanIt _F
             } else if (_Pred(*_Gfirst, *_Pfirst)) {
                 break;
             } else if (_Plast != _Gfirst) {
-                _STD iter_swap(_Plast, _Gfirst);
+                swap(*_Plast, *_Gfirst); // intentional ADL
                 ++_Plast;
             } else {
                 ++_Plast;
@@ -7988,12 +7993,13 @@ _CONSTEXPR20 pair<_RanIt, _RanIt> _Partition_by_median_guess_unchecked(_RanIt _F
         }
 
         for (; _First < _Glast; --_Glast) {
-            if (_DEBUG_LT_PRED(_Pred, *_Prev_iter(_Glast), *_Pfirst)) {
+            const auto _Glast_prev = _Prev_iter(_Glast);
+            if (_DEBUG_LT_PRED(_Pred, *_Glast_prev, *_Pfirst)) {
                 continue;
-            } else if (_Pred(*_Pfirst, *_Prev_iter(_Glast))) {
+            } else if (_Pred(*_Pfirst, *_Glast_prev)) {
                 break;
-            } else if (--_Pfirst != _Prev_iter(_Glast)) {
-                _STD iter_swap(_Pfirst, _Prev_iter(_Glast));
+            } else if (--_Pfirst != _Glast_prev) {
+                swap(*_Pfirst, *_Glast_prev); // intentional ADL
             }
         }
 
@@ -8003,21 +8009,21 @@ _CONSTEXPR20 pair<_RanIt, _RanIt> _Partition_by_median_guess_unchecked(_RanIt _F
 
         if (_Glast == _First) { // no room at bottom, rotate pivot upward
             if (_Plast != _Gfirst) {
-                _STD iter_swap(_Pfirst, _Plast);
+                swap(*_Pfirst, *_Plast); // intentional ADL
             }
 
             ++_Plast;
-            _STD iter_swap(_Pfirst, _Gfirst);
+            swap(*_Pfirst, *_Gfirst); // intentional ADL
             ++_Pfirst;
             ++_Gfirst;
         } else if (_Gfirst == _Last) { // no room at top, rotate pivot downward
             if (--_Glast != --_Pfirst) {
-                _STD iter_swap(_Glast, _Pfirst);
+                swap(*_Glast, *_Pfirst); // intentional ADL
             }
 
-            _STD iter_swap(_Pfirst, --_Plast);
+            swap(*_Pfirst, *--_Plast); // intentional ADL
         } else {
-            _STD iter_swap(_Gfirst, --_Glast);
+            swap(*_Gfirst, *--_Glast); // intentional ADL
             ++_Gfirst;
         }
     }
@@ -10217,7 +10223,7 @@ _CONSTEXPR20 bool next_permutation(_BidIt _First, _BidIt _Last, _Pr _Pred) {
                 --_UMid;
             } while (!_DEBUG_LT_PRED(_Pred, *_UNext, *_UMid));
 
-            _STD iter_swap(_UNext, _UMid);
+            swap(*_UNext, *_UMid); // intentional ADL
             _STD reverse(_UNext1, _ULast);
             return true;
         }
@@ -10321,7 +10327,7 @@ _CONSTEXPR20 bool prev_permutation(_BidIt _First, _BidIt _Last, _Pr _Pred) {
                 --_UMid;
             } while (!_DEBUG_LT_PRED(_Pred, *_UMid, *_UNext));
 
-            _STD iter_swap(_UNext, _UMid);
+            swap(*_UNext, *_UMid); // intentional ADL
             _STD reverse(_UNext1, _ULast);
             return true;
         }

--- a/stl/inc/deque
+++ b/stl/inc/deque
@@ -1460,7 +1460,7 @@ public:
             auto& _My_data    = _Get_data();
             auto& _Right_data = _Right._Get_data();
             _My_data._Swap_proxy_and_iterators(_Right_data);
-            _Swap_adl(_My_data._Map, _Right_data._Map);
+            swap(_My_data._Map, _Right_data._Map); // intentional ADL
             _STD swap(_My_data._Mapsize, _Right_data._Mapsize);
             _STD swap(_My_data._Myoff, _Right_data._Myoff);
             _STD swap(_My_data._Mysize, _Right_data._Mysize);

--- a/stl/inc/execution
+++ b/stl/inc/execution
@@ -3346,7 +3346,7 @@ pair<_FwdIt, _Iter_diff_t<_FwdIt>> _Partition_with_count_unchecked(_FwdIt _First
                 }
             } while (!_Pred(*_Last));
 
-            _STD iter_swap(_First, _Last); // out of place, swap and loop
+            swap(*_First, *_Last); // out of place, swap and loop; intentional ADL
             ++_First;
             ++_Trues;
         }
@@ -3367,7 +3367,7 @@ pair<_FwdIt, _Iter_diff_t<_FwdIt>> _Partition_with_count_unchecked(_FwdIt _First
 
         for (_FwdIt _Next = _First; ++_Next != _Last;) {
             if (_Pred(*_Next)) {
-                _STD iter_swap(_First, _Next); // out of place, swap and loop
+                swap(*_First, *_Next); // out of place, swap and loop; intentional ADL
                 ++_First;
                 ++_Trues;
             }
@@ -3387,7 +3387,7 @@ pair<_FwdIt, _Iter_diff_t<_FwdIt>> _Partition_swap_backward(
         while (_First != _Last) {
             --_Last;
             if (_Pred(*_Last)) {
-                _STD iter_swap(_Beginning_of_falses, _Last);
+                swap(*_Beginning_of_falses, *_Last); // intentional ADL
                 ++_Beginning_of_falses;
                 ++_Trues;
                 if (_Beginning_of_falses == _First) {
@@ -3399,7 +3399,7 @@ pair<_FwdIt, _Iter_diff_t<_FwdIt>> _Partition_swap_backward(
     } else {
         for (; _First != _Last; ++_First) {
             if (_Pred(*_First)) {
-                _STD iter_swap(_First, _Beginning_of_falses);
+                swap(*_First, *_Beginning_of_falses); // intentional ADL
                 ++_Beginning_of_falses;
                 ++_Trues;
             }

--- a/stl/inc/expected
+++ b/stl/inc/expected
@@ -83,7 +83,7 @@ public:
     // [expected.un.swap]
     constexpr void swap(unexpected& _Other) noexcept(is_nothrow_swappable_v<_Err>) {
         static_assert(is_swappable_v<_Err>, "E must be swappable");
-        _Swap_adl(_Unexpected, _Other._Unexpected);
+        swap(_Unexpected, _Other._Unexpected); // intentional ADL
     }
 
     friend constexpr void swap(unexpected& _Left, unexpected& _Right) noexcept(is_nothrow_swappable_v<_Err>)
@@ -519,7 +519,7 @@ public:
               && (is_nothrow_move_constructible_v<_Ty> || is_nothrow_move_constructible_v<_Err>)
     {
         if (_Has_value && _Other._Has_value) {
-            _Swap_adl(_Value, _Other._Value);
+            swap(_Value, _Other._Value); // intentional ADL
         } else if (_Has_value) {
             if constexpr (is_nothrow_move_constructible_v<_Err>) {
                 _Err _Tmp(_STD move(_Other._Unexpected));
@@ -560,7 +560,7 @@ public:
         } else if (_Other._Has_value) {
             _Other.swap(*this);
         } else {
-            _Swap_adl(_Unexpected, _Other._Unexpected);
+            swap(_Unexpected, _Other._Unexpected); // intentional ADL
         }
     }
 
@@ -1361,7 +1361,7 @@ public:
             _Has_value        = true;
             _Other._Has_value = false;
         } else {
-            _Swap_adl(_Unexpected, _Other._Unexpected);
+            swap(_Unexpected, _Other._Unexpected); // intentional ADL
         }
     }
 
@@ -1386,7 +1386,7 @@ public:
             _Left._Has_value  = true;
             _Right._Has_value = false;
         } else {
-            _Swap_adl(_Left._Unexpected, _Right._Unexpected);
+            swap(_Left._Unexpected, _Right._Unexpected); // intentional ADL
         }
     }
 

--- a/stl/inc/forward_list
+++ b/stl/inc/forward_list
@@ -1100,7 +1100,7 @@ public:
         if (this != _STD addressof(_Right)) {
             _Pocs(_Getal(), _Right._Getal());
             _Swap_proxy_and_iterators(_Right);
-            _Swap_adl(_Mypair._Myval2._Myhead, _Right._Mypair._Myval2._Myhead);
+            swap(_Mypair._Myval2._Myhead, _Right._Mypair._Myval2._Myhead); // intentional ADL
         }
     }
 

--- a/stl/inc/hash_map
+++ b/stl/inc/hash_map
@@ -30,7 +30,6 @@ namespace stdext {
     using _STD swap;
     using _STD _Hash;
     using _STD _Is_nothrow_swappable;
-    using _STD _Swap_adl;
     using _STD _Xout_of_range;
 
     template <class _Kty, // key type
@@ -102,7 +101,7 @@ namespace stdext {
         }
 
         void swap(_Hmap_traits& _Rhs) noexcept(_Is_nothrow_swappable<_Tr>::value) {
-            _Swap_adl(static_cast<_Tr&>(*this), static_cast<_Tr&>(_Rhs));
+            swap(static_cast<_Tr&>(*this), static_cast<_Tr&>(_Rhs)); // intentional ADL
             _STD swap(_Max_buckets, _Rhs._Max_buckets);
         }
 

--- a/stl/inc/hash_set
+++ b/stl/inc/hash_set
@@ -27,7 +27,6 @@ namespace stdext {
     using _STD swap;
     using _STD _Hash;
     using _STD _Is_nothrow_swappable;
-    using _STD _Swap_adl;
 
     template <class _Kty, // key type (same as value type)
         class _Tr, // comparator predicate type
@@ -79,7 +78,7 @@ namespace stdext {
         }
 
         void swap(_Hset_traits& _Rhs) noexcept(_Is_nothrow_swappable<_Tr>::value) {
-            _Swap_adl(static_cast<_Tr&>(*this), static_cast<_Tr&>(_Rhs));
+            swap(static_cast<_Tr&>(*this), static_cast<_Tr&>(_Rhs)); // intentional ADL
             _STD swap(_Max_buckets, _Rhs._Max_buckets);
         }
 

--- a/stl/inc/list
+++ b/stl/inc/list
@@ -960,7 +960,7 @@ private:
         auto& _My_data    = _Mypair._Myval2;
         auto& _Right_data = _Right._Mypair._Myval2;
         _My_data._Swap_proxy_and_iterators(_Right_data);
-        _Swap_adl(_My_data._Myhead, _Right_data._Myhead);
+        swap(_My_data._Myhead, _Right_data._Myhead); // intentional ADL
         _STD swap(_My_data._Mysize, _Right_data._Mysize);
     }
 

--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -3278,8 +3278,8 @@ public:
     }
 
     _CONSTEXPR23 void swap(unique_ptr& _Right) noexcept {
-        _Swap_adl(_Mypair._Myval2, _Right._Mypair._Myval2);
-        _Swap_adl(_Mypair._Get_first(), _Right._Mypair._Get_first());
+        swap(_Mypair._Myval2, _Right._Mypair._Myval2); // intentional ADL
+        swap(_Mypair._Get_first(), _Right._Mypair._Get_first()); // intentional ADL
     }
 
     _CONSTEXPR23 ~unique_ptr() noexcept {
@@ -3416,8 +3416,8 @@ public:
     }
 
     _CONSTEXPR23 void swap(unique_ptr& _Right) noexcept {
-        _Swap_adl(_Mypair._Myval2, _Right._Mypair._Myval2);
-        _Swap_adl(_Mypair._Get_first(), _Right._Mypair._Get_first());
+        swap(_Mypair._Myval2, _Right._Mypair._Myval2); // intentional ADL
+        swap(_Mypair._Get_first(), _Right._Mypair._Get_first()); // intentional ADL
     }
 
     _CONSTEXPR23 ~unique_ptr() noexcept {

--- a/stl/inc/optional
+++ b/stl/inc/optional
@@ -358,7 +358,7 @@ public:
             const bool _Engaged = this->_Has_value;
             if (_Engaged == _Right._Has_value) {
                 if (_Engaged) {
-                    _Swap_adl(**this, *_Right);
+                    swap(**this, *_Right); // intentional ADL
                 }
             } else {
                 optional& _Source = _Engaged ? *this : _Right;

--- a/stl/inc/queue
+++ b/stl/inc/queue
@@ -146,7 +146,7 @@ public:
     }
 
     void swap(queue& _Right) noexcept(_Is_nothrow_swappable<_Container>::value) {
-        _Swap_adl(c, _Right.c);
+        swap(c, _Right.c); // intentional ADL
     }
 
     _NODISCARD const _Container& _Get_container() const noexcept {
@@ -405,8 +405,8 @@ public:
 
     void swap(priority_queue& _Right) noexcept(
         _Is_nothrow_swappable<_Container>::value&& _Is_nothrow_swappable<_Pr>::value) {
-        _Swap_adl(c, _Right.c);
-        _Swap_adl(comp, _Right.comp);
+        swap(c, _Right.c); // intentional ADL
+        swap(comp, _Right.comp); // intentional ADL
     }
 
 protected:

--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -1138,7 +1138,7 @@ public:
 
     void swap(match_results& _Right) noexcept(_Is_nothrow_swappable<_BidIt>::value) /* strengthened */ {
         _STD swap(_Ready, _Right._Ready);
-        _Swap_adl(_Org, _Right._Org);
+        swap(_Org, _Right._Org); // intentional ADL
         _Matches.swap(_Right._Matches);
         _STD swap(_Prefix, _Right._Prefix);
         _STD swap(_Suffix, _Right._Suffix);
@@ -3135,8 +3135,8 @@ void _Builder<_FwdIt, _Elem, _RxTraits>::_Add_rep(int _Min, int _Max, bool _Gree
         _Insert_node(_Pos, _If_expr);
 
         if (!_Greedy) {
-            _Swap_adl(_If_expr->_Next->_Prev, _If_empty_str->_Next->_Prev);
-            _Swap_adl(_If_expr->_Next, _If_empty_str->_Next);
+            swap(_If_expr->_Next->_Prev, _If_empty_str->_Next->_Prev); // intentional ADL
+            swap(_If_expr->_Next, _If_empty_str->_Next); // intentional ADL
         }
     } else {
         _Node_end_rep* _Node0 = new _Node_end_rep();

--- a/stl/inc/stack
+++ b/stl/inc/stack
@@ -136,7 +136,7 @@ public:
     }
 
     void swap(stack& _Right) noexcept(_Is_nothrow_swappable<_Container>::value) {
-        _Swap_adl(c, _Right.c);
+        swap(c, _Right.c); // intentional ADL
     }
 
     _NODISCARD const _Container& _Get_container() const noexcept {

--- a/stl/inc/tuple
+++ b/stl/inc/tuple
@@ -733,7 +733,7 @@ public:
 
     _CONSTEXPR20 void swap(tuple& _Right) noexcept(
         conjunction_v<_Is_nothrow_swappable<_This>, _Is_nothrow_swappable<_Rest>...>) {
-        _Swap_adl(_Myfirst._Val, _Right._Myfirst._Val);
+        swap(_Myfirst._Val, _Right._Myfirst._Val); // intentional ADL
         _Mybase::swap(_Right._Get_rest());
     }
 
@@ -741,7 +741,7 @@ public:
     template <int = 0> // see GH-3013
     constexpr void swap(const tuple& _Right) const
         noexcept(conjunction_v<is_nothrow_swappable<const _This>, is_nothrow_swappable<const _Rest>...>) {
-        _Swap_adl(_Myfirst._Val, _Right._Myfirst._Val);
+        swap(_Myfirst._Val, _Right._Myfirst._Val); // intentional ADL
         _Mybase::swap(_Right._Get_rest());
     }
 #endif // _HAS_CXX23

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -77,11 +77,6 @@ _NODISCARD constexpr _Ty(min)(initializer_list<_Ty>, _Pr); // implemented in <al
 _EXPORT_STD template <class _Ty>
 _NODISCARD constexpr _Ty(min)(initializer_list<_Ty>); // implemented in <algorithm>
 
-_EXPORT_STD template <class _FwdIt1, class _FwdIt2>
-_CONSTEXPR20 void iter_swap(_FwdIt1 _Left, _FwdIt2 _Right) { // swap *_Left and *_Right
-    swap(*_Left, *_Right);
-}
-
 _EXPORT_STD template <class _Ty, size_t _Size, enable_if_t<_Is_swappable<_Ty>::value, int> /* = 0 */>
 _CONSTEXPR20 void swap(_Ty (&_Left)[_Size], _Ty (&_Right)[_Size]) noexcept(_Is_nothrow_swappable<_Ty>::value) {
     if (&_Left != &_Right) {
@@ -89,7 +84,7 @@ _CONSTEXPR20 void swap(_Ty (&_Left)[_Size], _Ty (&_Right)[_Size]) noexcept(_Is_n
         _Ty* _Last1  = _First1 + _Size;
         _Ty* _First2 = _Right;
         for (; _First1 != _Last1; ++_First1, ++_First2) {
-            _STD iter_swap(_First1, _First2);
+            swap(*_First1, *_First2); // intentional ADL
         }
     }
 }
@@ -104,11 +99,6 @@ _CONSTEXPR20 void swap(_Ty& _Left, _Ty& _Right) noexcept(
     _Ty _Tmp = _STD move(_Left);
     _Left    = _STD move(_Right);
     _Right   = _STD move(_Tmp);
-}
-
-template <class _Ty>
-_CONSTEXPR20 void _Swap_adl(_Ty& _Left, _Ty& _Right) noexcept(_Is_nothrow_swappable<_Ty>::value) {
-    swap(_Left, _Right);
 }
 
 _EXPORT_STD struct piecewise_construct_t { // tag type for pair tuple arguments
@@ -445,8 +435,8 @@ struct pair { // store a pair of values
     _CONSTEXPR20 void swap(pair& _Right) noexcept(
         _Is_nothrow_swappable<_Ty1>::value&& _Is_nothrow_swappable<_Ty2>::value) {
         if (this != _STD addressof(_Right)) {
-            _Swap_adl(first, _Right.first);
-            _Swap_adl(second, _Right.second);
+            swap(first, _Right.first); // intentional ADL
+            swap(second, _Right.second); // intentional ADL
         }
     }
 
@@ -455,8 +445,8 @@ struct pair { // store a pair of values
     constexpr void swap(const pair& _Right) const
         noexcept(is_nothrow_swappable_v<const _Ty1>&& is_nothrow_swappable_v<const _Ty2>) {
         if (this != _STD addressof(_Right)) {
-            _Swap_adl(first, _Right.first);
-            _Swap_adl(second, _Right.second);
+            swap(first, _Right.first); // intentional ADL
+            swap(second, _Right.second); // intentional ADL
         }
     }
 #endif // _HAS_CXX23

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -402,9 +402,9 @@ public:
 
     _CONSTEXPR20 void _Swap_val(_Vector_val& _Right) noexcept {
         this->_Swap_proxy_and_iterators(_Right);
-        _Swap_adl(_Myfirst, _Right._Myfirst);
-        _Swap_adl(_Mylast, _Right._Mylast);
-        _Swap_adl(_Myend, _Right._Myend);
+        swap(_Myfirst, _Right._Myfirst); // intentional ADL
+        swap(_Mylast, _Right._Mylast); // intentional ADL
+        swap(_Myend, _Right._Myend); // intentional ADL
     }
 
     _CONSTEXPR20 void _Take_contents(_Vector_val& _Right) noexcept {

--- a/stl/inc/xhash
+++ b/stl/inc/xhash
@@ -164,10 +164,10 @@ public:
 
     void swap(_Uhash_compare& _Rhs) noexcept(
         conjunction_v<_Is_nothrow_swappable<_Hasher>, _Is_nothrow_swappable<_Keyeq>>) {
-        _Swap_adl(_Mypair._Get_first(), _Rhs._Mypair._Get_first());
+        swap(_Mypair._Get_first(), _Rhs._Mypair._Get_first()); // intentional ADL
         auto& _Lsecond = _Mypair._Myval2;
         auto& _Rsecond = _Rhs._Mypair._Myval2;
-        _Swap_adl(_Lsecond._Get_first(), _Rsecond._Get_first());
+        swap(_Lsecond._Get_first(), _Rsecond._Get_first()); // intentional ADL
         _STD swap(_Lsecond._Myval2, _Rsecond._Myval2);
     }
 

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -1072,7 +1072,7 @@ _CONSTEXPR20 void _Pocma(_Alloc& _Left, _Alloc& _Right) noexcept { // (maybe) pr
 template <class _Alloc>
 _CONSTEXPR20 void _Pocs(_Alloc& _Left, _Alloc& _Right) noexcept {
     if constexpr (allocator_traits<_Alloc>::propagate_on_container_swap::value) {
-        _Swap_adl(_Left, _Right);
+        swap(_Left, _Right); // intentional ADL
     } else {
         _STL_ASSERT(_Left == _Right, "containers incompatible for swap");
     }

--- a/stl/inc/xnode_handle.h
+++ b/stl/inc/xnode_handle.h
@@ -192,7 +192,7 @@ public:
             _Construct_in_place(_Getal(), _STD move(_That_al));
             _Destroy_in_place(_That_al);
         }
-        _Swap_adl(_Ptr, _That._Ptr);
+        swap(_Ptr, _That._Ptr); // intentional ADL
     }
     friend void swap(_Node_handle& _Left, _Node_handle& _Right) noexcept /* strengthened */ {
         _Left.swap(_Right);

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -4286,7 +4286,7 @@ public:
 #endif // !defined(_INSERT_STRING_ANNOTATION)
 
         if (_My_large && _Right_large) { // swap buffers, iterators preserved
-            _Swap_adl(_My_data._Bx._Ptr, _Right_data._Bx._Ptr);
+            swap(_My_data._Bx._Ptr, _Right_data._Bx._Ptr); // intentional ADL
         } else if (_My_large) { // swap large with small
             _Swap_bx_large_with_small(_My_data, _Right_data);
         } else if (_Right_large) { // swap small with large

--- a/stl/inc/xtree
+++ b/stl/inc/xtree
@@ -985,7 +985,7 @@ private:
         const auto _Scary       = _Get_scary();
         const auto _Right_scary = _Right._Get_scary();
         _Scary->_Swap_proxy_and_iterators(*_Right_scary);
-        _Swap_adl(_Scary->_Myhead, _Right_scary->_Myhead);
+        swap(_Scary->_Myhead, _Right_scary->_Myhead); // intentional ADL
         _STD swap(_Scary->_Mysize, _Right_scary->_Mysize);
     }
 
@@ -1485,7 +1485,7 @@ public:
         if (this != _STD addressof(_Right)) {
             _Pocs(_Getal(), _Right._Getal());
             _Swap_val_excluding_comp(_Right);
-            _Swap_adl(_Getcomp(), _Right._Getcomp());
+            swap(_Getcomp(), _Right._Getcomp()); // intentional ADL
         }
     }
 

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -6316,7 +6316,7 @@ _CONSTEXPR20 void reverse(const _BidIt _First, const _BidIt _Last) { // reverse 
 #endif // _USE_STD_VECTOR_ALGORITHMS
 
     for (; _UFirst != _ULast && _UFirst != --_ULast; ++_UFirst) {
-        _STD iter_swap(_UFirst, _ULast);
+        swap(*_UFirst, *_ULast); // intentional ADL
     }
 }
 
@@ -6333,7 +6333,7 @@ template <class _BidIt>
 constexpr pair<_BidIt, _BidIt> _Reverse_until_sentinel_unchecked(_BidIt _First, _BidIt _Sentinel, _BidIt _Last) {
     // reverse until either _First or _Last hits _Sentinel
     while (_First != _Sentinel && _Last != _Sentinel) {
-        _STD iter_swap(_First, --_Last);
+        swap(*_First, *--_Last); // intentional ADL
         ++_First;
     }
 
@@ -6372,7 +6372,7 @@ _CONSTEXPR20 _FwdIt rotate(_FwdIt _First, _FwdIt _Mid, _FwdIt _Last) {
     } else {
         auto _UNext = _UMid;
         do { // rotate the first cycle
-            _STD iter_swap(_UFirst, _UNext);
+            swap(*_UFirst, *_UNext); // intentional ADL
             ++_UFirst;
             ++_UNext;
             if (_UFirst == _UMid) {
@@ -6383,7 +6383,7 @@ _CONSTEXPR20 _FwdIt rotate(_FwdIt _First, _FwdIt _Mid, _FwdIt _Last) {
         while (_UMid != _ULast) { // rotate subsequent cycles
             _UNext = _UMid;
             do {
-                _STD iter_swap(_UFirst, _UNext);
+                swap(*_UFirst, *_UNext); // intentional ADL
                 ++_UFirst;
                 ++_UNext;
                 if (_UFirst == _UMid) {
@@ -7202,7 +7202,7 @@ _CONSTEXPR20 _FwdIt2 _Swap_ranges_unchecked(_FwdIt1 _First1, const _FwdIt1 _Last
 #endif // _USE_STD_VECTOR_ALGORITHMS
 
     for (; _First1 != _Last1; ++_First1, (void) ++_First2) {
-        _STD iter_swap(_First1, _First2);
+        swap(*_First1, *_First2); // intentional ADL
     }
 
     return _First2;


### PR DESCRIPTION
Also
- Move `std::iter_swap` from `<utility>` to `<algorithm>`.
- In `_Partition_by_median_guess_unchecked`, only evaluate `_Prev_iter(_Glast)` once.

Fixes #2692.

In WG21-N4140 and WG21-N4659, the `std::swap` overload for arrays relied on `std::swap_ranges` ([N4140 [utility.swap]/6](https://timsong-cpp.github.io/cppwp/n4140/utility.swap#6), [N4659 [utility.swap]/6](https://timsong-cpp.github.io/cppwp/n4659/utility.swap#6)), while `std::swap_ranges` recursively relied on `std::swap` ([N4140 [alg.swap]/2](https://timsong-cpp.github.io/cppwp/n4140/alg.swap#2), [N4659 [alg.swap]/2](https://timsong-cpp.github.io/cppwp/n4659/alg.swap#2)). So I believe even if old standards allowed specializing `std::iter_swap` with making its behavior different (which is not a fact IMO), `std::swap` shouldn't be affected.

`std::iter_swap` is only specified to be used for `std::reverse` ([N4140 [alg.reverse]/2](https://timsong-cpp.github.io/cppwp/n4140/alg.reverse#2), [N4659 [alg.reverse]/2](https://timsong-cpp.github.io/cppwp/n4659/alg.reverse#2), [N4868 [alg.reverse]/2](https://timsong-cpp.github.io/cppwp/n4868/alg.reverse#2)). As said in https://github.com/microsoft/STL/issues/2692#issuecomment-1114096592, I think it should be OK to inline `std::iter_swap` in `std::reverse` even in old modes.
