### PR TITLE
Remove SpectreBuildDebug flag from MSBuild

### DIFF
--- a/stl/msbuild/stl_1/xmd/dirs.proj
+++ b/stl/msbuild/stl_1/xmd/dirs.proj
@@ -7,7 +7,6 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
     <Import Project="$(MSBuildThisFileDirectory)..\..\..\..\..\crt-common.settings.targets" />
 
     <ItemGroup Condition="('$(SpectreBuildMode)' == '' or
-                           '$(SpectreBuildDebug)' == 'true' or
                            '$(Configuration)' == 'chk' or
                            '$(Configuration)' == 'dbg')">
         <ProjectFile Include="msvcp_1_app\msvcp_1.nativeproj" />
@@ -15,7 +14,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         <ProjectFile Include="msvcp_1_onecore\msvcp_1.nativeproj" />
     </ItemGroup>
 
-    <ItemGroup Condition="('$(SpectreBuildMode)' == '' or '$(SpectreBuildDebug)' == 'true')">
+    <ItemGroup Condition="'$(SpectreBuildMode)' == ''">
         <ProjectFile Include="msvcp_1_netfx\msvcp_1.nativeproj" Condition="'$(BuildArchitecture)' != 'chpe'" />
     </ItemGroup>
 

--- a/stl/msbuild/stl_2/xmd/dirs.proj
+++ b/stl/msbuild/stl_2/xmd/dirs.proj
@@ -7,7 +7,6 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
     <Import Project="$(MSBuildThisFileDirectory)..\..\..\..\..\crt-common.settings.targets" />
 
     <ItemGroup Condition="('$(SpectreBuildMode)' == '' or
-                           '$(SpectreBuildDebug)' == 'true' or
                            '$(Configuration)' == 'chk' or
                            '$(Configuration)' == 'dbg')">
         <ProjectFile Include="msvcp_2_app\msvcp_2.nativeproj" />
@@ -15,7 +14,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         <ProjectFile Include="msvcp_2_onecore\msvcp_2.nativeproj" />
     </ItemGroup>
 
-    <ItemGroup Condition="('$(SpectreBuildMode)' == '' or '$(SpectreBuildDebug)' == 'true')">
+    <ItemGroup Condition="'$(SpectreBuildMode)' == ''">
         <ProjectFile Include="msvcp_2_netfx\msvcp_2.nativeproj" Condition="'$(BuildArchitecture)' != 'chpe'" />
     </ItemGroup>
 

--- a/stl/msbuild/stl_atomic_wait/xmd/dirs.proj
+++ b/stl/msbuild/stl_atomic_wait/xmd/dirs.proj
@@ -7,7 +7,6 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
     <Import Project="$(MSBuildThisFileDirectory)..\..\..\..\..\crt-common.settings.targets" />
 
     <ItemGroup Condition="('$(SpectreBuildMode)' == '' or
-                           '$(SpectreBuildDebug)' == 'true' or
                            '$(Configuration)' == 'chk' or
                            '$(Configuration)' == 'dbg')">
         <ProjectFile Include="msvcp_atomic_wait_app\msvcp_atomic_wait.nativeproj" />
@@ -15,7 +14,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         <ProjectFile Include="msvcp_atomic_wait_onecore\msvcp_atomic_wait.nativeproj" />
     </ItemGroup>
 
-    <ItemGroup Condition="('$(SpectreBuildMode)' == '' or '$(SpectreBuildDebug)' == 'true')">
+    <ItemGroup Condition="'$(SpectreBuildMode)' == ''">
         <ProjectFile Include="msvcp_atomic_wait_netfx\msvcp_atomic_wait.nativeproj" Condition="'$(BuildArchitecture)' != 'chpe'" />
     </ItemGroup>
 

--- a/stl/msbuild/stl_base/dirs.proj
+++ b/stl/msbuild/stl_base/dirs.proj
@@ -12,8 +12,8 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         <ProjectFile Condition="'$(CrtBuildMT)'  != 'false'" Include="mt\dirs.proj" />
         <ProjectFile Condition="'$(CrtBuildMT)'  != 'false'" Include="mt1\dirs.proj" />
         <ProjectFile Condition="'$(CrtBuildXMT)' != 'false'" Include="xmt\dirs.proj" />
-        <ProjectFile Condition="'$(CrtBuildXMT)' != 'false' and ('$(SpectreBuildMode)' == '' or '$(SpectreBuildDebug)' == 'true')" Include="xmt0\dirs.proj" />
-        <ProjectFile Condition="'$(CrtBuildXMT)' != 'false' and ('$(SpectreBuildMode)' == '' or '$(SpectreBuildDebug)' == 'true')" Include="xmt1\dirs.proj" />
+        <ProjectFile Condition="'$(CrtBuildXMT)' != 'false' and '$(SpectreBuildMode)' == ''" Include="xmt0\dirs.proj" />
+        <ProjectFile Condition="'$(CrtBuildXMT)' != 'false' and '$(SpectreBuildMode)' == ''" Include="xmt1\dirs.proj" />
     </ItemGroup>
 
     <Import Project="$(RepoSrc)\tools\Microsoft.DevDiv.Traversal.targets" />

--- a/stl/msbuild/stl_base/xmd/dirs.proj
+++ b/stl/msbuild/stl_base/xmd/dirs.proj
@@ -7,7 +7,6 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
     <Import Project="$(MSBuildThisFileDirectory)..\..\..\..\..\crt-common.settings.targets" />
 
     <ItemGroup Condition="('$(SpectreBuildMode)' == '' or
-                           '$(SpectreBuildDebug)' == 'true' or
                            '$(Configuration)' == 'chk' or
                            '$(Configuration)' == 'dbg')">
         <!-- Other components in dbg and chk builds depend on msvcprtd.lib -->
@@ -16,7 +15,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         <ProjectFile Include="msvcp_onecore\msvcp.nativeproj" />
     </ItemGroup>
 
-    <ItemGroup Condition="('$(SpectreBuildMode)' == '' or '$(SpectreBuildDebug)' == 'true')">
+    <ItemGroup Condition="'$(SpectreBuildMode)' == ''">
         <ProjectFile Include="msvcp_netfx\msvcp.nativeproj" Condition="'$(BuildArchitecture)' != 'chpe'" />
     </ItemGroup>
 

--- a/stl/msbuild/stl_base/xmt/dirs.proj
+++ b/stl/msbuild/stl_base/xmt/dirs.proj
@@ -8,11 +8,10 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
     <ItemGroup>
         <ProjectFile Condition="'$(SpectreBuildMode)' == '' or
-                                '$(SpectreBuildDebug)' == 'true' or
                                 '$(Configuration)' == 'chk' or
                                 '$(Configuration)' == 'dbg'"
                      Include="libcpmt_kernel32\libcpmt.nativeproj" />
-        <ProjectFile Condition="'$(SpectreBuildMode)' == '' or '$(SpectreBuildDebug)' == 'true'" Include="libcpmt_onecore\libcpmt.nativeproj" />
+        <ProjectFile Condition="'$(SpectreBuildMode)' == ''" Include="libcpmt_onecore\libcpmt.nativeproj" />
     </ItemGroup>
 
     <Import Project="$(RepoSrc)\tools\Microsoft.DevDiv.Traversal.targets" />

--- a/stl/msbuild/stl_codecvt_ids/xmd/dirs.proj
+++ b/stl/msbuild/stl_codecvt_ids/xmd/dirs.proj
@@ -7,7 +7,6 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
     <Import Project="$(MSBuildThisFileDirectory)..\..\..\..\..\crt-common.settings.targets" />
 
     <ItemGroup Condition="('$(SpectreBuildMode)' == '' or
-                           '$(SpectreBuildDebug)' == 'true' or
                            '$(Configuration)' == 'chk' or
                            '$(Configuration)' == 'dbg')">
         <ProjectFile Include="msvcp_codecvt_ids_app\msvcp_codecvt_ids.nativeproj" />
@@ -15,7 +14,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         <ProjectFile Include="msvcp_codecvt_ids_onecore\msvcp_codecvt_ids.nativeproj" />
     </ItemGroup>
 
-    <ItemGroup Condition="('$(SpectreBuildMode)' == '' or '$(SpectreBuildDebug)' == 'true')">
+    <ItemGroup Condition="'$(SpectreBuildMode)' == ''">
         <ProjectFile Include="msvcp_codecvt_ids_netfx\msvcp_codecvt_ids.nativeproj" Condition="'$(BuildArchitecture)' != 'chpe' and '$(BuildArchitecture)' != 'arm64ec'" />
     </ItemGroup>
 

--- a/stl/msbuild/stl_post/xmd/dirs.proj
+++ b/stl/msbuild/stl_post/xmd/dirs.proj
@@ -7,7 +7,6 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
     <Import Project="$(MSBuildThisFileDirectory)..\..\..\..\..\crt-common.settings.targets" />
 
     <ItemGroup Condition="('$(SpectreBuildMode)' == '' or
-                           '$(SpectreBuildDebug)' == 'true' or
                            '$(Configuration)' == 'chk' or
                            '$(Configuration)' == 'dbg')">
         <ProjectFile Include="msvcp_post_app\msvcp_post.nativeproj" />
@@ -15,7 +14,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         <ProjectFile Include="msvcp_post_onecore\msvcp_post.nativeproj" />
     </ItemGroup>
 
-    <ItemGroup Condition="('$(SpectreBuildMode)' == '' or '$(SpectreBuildDebug)' == 'true')">
+    <ItemGroup Condition="'$(SpectreBuildMode)' == ''">
         <ProjectFile Include="msvcp_post_netfx\msvcp_post.nativeproj" Condition="'$(BuildArchitecture)' != 'chpe'" />
     </ItemGroup>
 


### PR DESCRIPTION
Port STL changes from MSVC-PR-471952.
tldr; the `SpectreBuildDebug` isn't being used now or in the future, so remove it.