### PR TITLE
Cleanup elements when `resize` fails in `deque(n)`

### DIFF
--- a/stl/inc/deque
+++ b/stl/inc/deque
@@ -623,7 +623,9 @@ public:
         : _Mypair(_One_then_variadic_args_t{}, _Al) {
         _Alproxy_ty _Alproxy(_Getal());
         _Container_proxy_ptr12<_Alproxy_ty> _Proxy(_Alproxy, _Get_data());
+        _Tidy_guard<deque> _Guard{this};
         resize(_Count);
+        _Guard._Target = nullptr;
         _Proxy._Release();
     }
 


### PR DESCRIPTION
Fixes #3717
