### PR TITLE
Remove some workaround for Clang

### DIFF
--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -2340,11 +2340,6 @@ namespace ranges {
         _EXPORT_STD inline constexpr _Filter_fn filter;
     } // namespace views
 
-#ifdef __clang__
-    template <class _Rng, class _Fn> // TRANSITION, LLVM-47414
-    concept _Can_const_transform = range<const _Rng> && regular_invocable<const _Fn&, range_reference_t<const _Rng>>;
-#endif // ^^^ workaround ^^^
-
     _EXPORT_STD template <input_range _Vw, _Valid_movable_box_object _Fn>
         requires view<_Vw> && regular_invocable<_Fn&, range_reference_t<_Vw>>
               && _Can_reference<invoke_result_t<_Fn&, range_reference_t<_Vw>>>
@@ -2708,11 +2703,7 @@ namespace ranges {
 
         _NODISCARD constexpr _Iterator<true> begin() const noexcept(
             noexcept(_RANGES begin(_Range)) && is_nothrow_move_constructible_v<iterator_t<_Vw>>) /* strengthened */
-#ifdef __clang__ // TRANSITION, LLVM-47414
-            requires _Can_const_transform<_Vw, _Fn>
-#else // ^^^ workaround / no workaround vvv
             requires range<const _Vw> && regular_invocable<const _Fn&, range_reference_t<const _Vw>>
-#endif // TRANSITION, LLVM-47414
         {
             return _Iterator<true>{*this, _RANGES begin(_Range)};
         }
@@ -2731,11 +2722,7 @@ namespace ranges {
         // clang-format off
         _NODISCARD constexpr auto end() const noexcept(noexcept(
             _RANGES end(_Range)) && is_nothrow_move_constructible_v<decltype(_RANGES end(_Range))>) /* strengthened */
-#ifdef __clang__ // TRANSITION, LLVM-47414
-            requires _Can_const_transform<_Vw, _Fn>
-#else // ^^^ workaround / no workaround vvv
             requires range<const _Vw> && regular_invocable<const _Fn&, range_reference_t<const _Vw>>
-#endif // TRANSITION, LLVM-47414
         {
             // clang-format on
             if constexpr (common_range<_Vw>) {
@@ -3070,11 +3057,6 @@ namespace ranges {
         _EXPORT_STD inline constexpr _Take_fn take;
     } // namespace views
 
-#ifdef __clang__
-    template <class _Vw, class _Pr> // TRANSITION, LLVM-47414
-    concept _Can_take_while_const = range<const _Vw> && indirect_unary_predicate<const _Pr, iterator_t<const _Vw>>;
-#endif // ^^^ workaround ^^^
-
     _EXPORT_STD template <view _Vw, class _Pr>
         requires input_range<_Vw> && is_object_v<_Pr> && indirect_unary_predicate<const _Pr, iterator_t<_Vw>>
     class take_while_view : public view_interface<take_while_view<_Vw, _Pr>> {
@@ -3190,11 +3172,7 @@ namespace ranges {
         }
 
         _NODISCARD constexpr auto begin() const noexcept(noexcept(_RANGES begin(_Range))) /* strengthened */
-#ifdef __clang__ // TRANSITION, LLVM-47414
-            requires _Can_take_while_const<_Vw, _Pr>
-#else // ^^^ workaround / no workaround vvv
             requires range<const _Vw> && indirect_unary_predicate<const _Pr, iterator_t<const _Vw>>
-#endif // TRANSITION, LLVM-47414
         {
             return _RANGES begin(_Range);
         }
@@ -3211,11 +3189,7 @@ namespace ranges {
 
         _NODISCARD constexpr auto end() const noexcept(
             noexcept(_RANGES end(_Range)) && is_nothrow_move_constructible_v<_Sentinel<true>>) /* strengthened */
-#ifdef __clang__ // TRANSITION, LLVM-47414
-            requires _Can_take_while_const<_Vw, _Pr>
-#else // ^^^ workaround / no workaround vvv
             requires range<const _Vw> && indirect_unary_predicate<const _Pr, iterator_t<const _Vw>>
-#endif // TRANSITION, LLVM-47414
         {
 #if _CONTAINER_DEBUG_LEVEL > 0
             _STL_VERIFY(_Pred, "cannot call end on a take_while_view with no predicate");
@@ -3561,12 +3535,6 @@ namespace ranges {
 
         _EXPORT_STD inline constexpr _Drop_while_fn drop_while;
     } // namespace views
-
-#ifdef __clang__
-    template <class _Rng> // TRANSITION, LLVM-47414
-    concept _Can_const_join = forward_range<const _Rng> && is_reference_v<range_reference_t<const _Rng>>
-                           && input_range<range_reference_t<const _Rng>>;
-#endif // ^^^ workaround ^^^
 
     template <class _Ty>
     _NODISCARD constexpr _Ty& _As_lvalue(_Ty&& _Val) noexcept {
@@ -3934,11 +3902,7 @@ namespace ranges {
         }
 
         _NODISCARD constexpr _Iterator<true> begin() const
-#ifdef __clang__ // TRANSITION, LLVM-47414
-            requires _Can_const_join<_Vw>
-#else // ^^^ workaround / no workaround vvv
             requires forward_range<const _Vw> && is_reference_v<_InnerRng<true>> && input_range<_InnerRng<true>>
-#endif // TRANSITION, LLVM-47414
         {
             return _Iterator<true>{*this, _RANGES begin(_Range)};
         }
@@ -3953,11 +3917,7 @@ namespace ranges {
         }
 
         _NODISCARD constexpr auto end() const
-#ifdef __clang__ // TRANSITION, LLVM-47414
-            requires _Can_const_join<_Vw>
-#else // ^^^ workaround / no workaround vvv
             requires forward_range<const _Vw> && is_reference_v<_InnerRng<true>> && input_range<_InnerRng<true>>
-#endif // TRANSITION, LLVM-47414
         {
             if constexpr (forward_range<_InnerRng<true>> && common_range<const _Vw> && common_range<_InnerRng<true>>) {
                 return _Iterator<true>{*this, _RANGES end(_Range)};
@@ -3993,13 +3953,6 @@ namespace ranges {
         common_with<range_value_t<_Rng>, range_value_t<_Pat>>
         && common_reference_with<range_reference_t<_Rng>, range_reference_t<_Pat>>
         && common_reference_with<range_rvalue_reference_t<_Rng>, range_rvalue_reference_t<_Pat>>;
-
-#ifdef __clang__
-    template <class _Rng, class _Pat> // TRANSITION, LLVM-47414
-    concept _Can_const_join_with =
-        forward_range<const _Rng> && forward_range<const _Pat> && is_reference_v<range_reference_t<const _Rng>>
-        && input_range<range_reference_t<const _Rng>>;
-#endif // ^^^ workaround ^^^
 
     _EXPORT_STD template <input_range _Vw, forward_range _Pat>
         requires view<_Vw> && input_range<range_reference_t<_Vw>> && view<_Pat>
@@ -4450,12 +4403,8 @@ namespace ranges {
         }
 
         _NODISCARD constexpr auto begin() const
-#ifdef __clang__ // TRANSITION, LLVM-47414
-            requires _Can_const_join_with<_Vw, _Pat>
-#else // ^^^ workaround / no workaround vvv
             requires forward_range<const _Vw> && forward_range<const _Pat> && is_reference_v<_InnerRng<true>>
                   && input_range<_InnerRng<true>>
-#endif // TRANSITION, LLVM-47414
         {
             return _Iterator<true>{*this, _RANGES begin(_Range)};
         }
@@ -4472,12 +4421,8 @@ namespace ranges {
         }
 
         _NODISCARD constexpr auto end() const
-#ifdef __clang__ // TRANSITION, LLVM-47414
-            requires _Can_const_join_with<_Vw, _Pat>
-#else // ^^^ workaround / no workaround vvv
             requires forward_range<const _Vw> && forward_range<const _Pat> && is_reference_v<_InnerRng<true>>
                   && input_range<_InnerRng<true>>
-#endif // TRANSITION, LLVM-47414
         {
             if constexpr (forward_range<_InnerRng<true>> && common_range<_Vw> && common_range<_InnerRng<true>>) {
                 return _Iterator<true>{*this, _RANGES end(_Range)};
@@ -8013,16 +7958,6 @@ namespace ranges {
         return _Evaluate_equality_closure(index_sequence_for<_LHSTupleTypes...>{});
     }
 
-#ifdef __clang__
-    template <bool _IsConst, class... _ViewTypes> // TRANSITION, LLVM-47414
-    concept _Zip_iter_converts =
-        _IsConst && (convertible_to<iterator_t<_ViewTypes>, iterator_t<const _ViewTypes>> && ...);
-
-    template <bool _IsConst, class... _ViewTypes> // TRANSITION, LLVM-47414
-    concept _Zip_sent_converts =
-        _IsConst && (convertible_to<sentinel_t<_ViewTypes>, sentinel_t<const _ViewTypes>> && ...);
-#endif // ^^^ workaround ^^^
-
     template <class _Func, class... _Views>
     concept _Zip_transform_constraints =
         move_constructible<_Func> && is_object_v<_Func> && (sizeof...(_Views) > 0) && (input_range<_Views> && ...)
@@ -8074,13 +8009,8 @@ namespace ranges {
 
             constexpr _Iterator(_Iterator<!_IsConst> _Rhs) noexcept(
                 (is_nothrow_convertible_v<iterator_t<_ViewTypes>, iterator_t<const _ViewTypes>> && ...)) // strengthened
-#ifdef __clang__ // TRANSITION, LLVM-47414
-                requires _Zip_iter_converts<_IsConst, _ViewTypes...>
-#else // ^^^ workaround / no workaround vvv
                 requires (_IsConst && (convertible_to<iterator_t<_ViewTypes>, iterator_t<const _ViewTypes>> && ...))
-#endif // __clang__
-                : _Current(_STD move(_Rhs._Current)) {
-            }
+                : _Current(_STD move(_Rhs._Current)) {}
 
             _NODISCARD constexpr auto operator*() const
                 noexcept((noexcept(*(_STD declval<iterator_t<_Maybe_const<_IsConst, _ViewTypes>>&>()))
@@ -8285,13 +8215,8 @@ namespace ranges {
 
             constexpr _Sentinel(_Sentinel<!_IsConst> _Rhs) noexcept(
                 (is_nothrow_convertible_v<sentinel_t<_ViewTypes>, sentinel_t<const _ViewTypes>> && ...)) // strengthened
-#ifdef __clang__ // TRANSITION, LLVM-47414
-                requires _Zip_sent_converts<_IsConst, _ViewTypes...>
-#else // ^^^ workaround / no workaround vvv
                 requires (_IsConst && (convertible_to<sentinel_t<_ViewTypes>, sentinel_t<const _ViewTypes>> && ...))
-#endif // __clang__
-                : _End(_STD move(_Rhs._End)) {
-            }
+                : _End(_STD move(_Rhs._End)) {}
 
             template <bool _IteratorConst>
                 requires (sentinel_for<sentinel_t<_Maybe_const<_IsConst, _ViewTypes>>,

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -2673,7 +2673,9 @@ namespace ranges {
         using _Begin_on_const = decltype(_RANGES begin(_RANGES _Possibly_const_range(_STD declval<_Ty&>())));
 
         template <_Should_range_access _Ty>
-            requires requires(_Ty& _Val) { //
+            requires requires(_Ty& _Val) {
+                typename _Begin_on_const<_Ty>;
+                typename const_iterator<_Begin_on_const<_Ty>>;
                 const_iterator<_Begin_on_const<_Ty>>{_RANGES begin(_RANGES _Possibly_const_range(_Val))};
             }
         _NODISCARD constexpr auto operator()(_Ty&& _Val) const noexcept(
@@ -2701,7 +2703,9 @@ namespace ranges {
         using _End_on_const = decltype(_RANGES end(_RANGES _Possibly_const_range(_STD declval<_Ty&>())));
 
         template <_Should_range_access _Ty>
-            requires requires(_Ty& _Val) { //
+            requires requires(_Ty& _Val) {
+                typename _End_on_const<_Ty>;
+                typename const_sentinel<_End_on_const<_Ty>>;
                 const_sentinel<_End_on_const<_Ty>>{_RANGES end(_RANGES _Possibly_const_range(_Val))};
             }
         _NODISCARD constexpr auto operator()(_Ty&& _Val) const
@@ -2868,7 +2872,9 @@ namespace ranges {
         using _Rbegin_on_const = decltype(_RANGES rbegin(_RANGES _Possibly_const_range(_STD declval<_Ty&>())));
 
         template <_Should_range_access _Ty>
-            requires requires(_Ty& _Val) { //
+            requires requires(_Ty& _Val) {
+                typename _Rbegin_on_const<_Ty>;
+                typename const_iterator<_Rbegin_on_const<_Ty>>;
                 const_iterator<_Rbegin_on_const<_Ty>>{_RANGES rbegin(_RANGES _Possibly_const_range(_Val))};
             }
         _NODISCARD constexpr auto operator()(_Ty&& _Val) const noexcept(
@@ -2896,7 +2902,9 @@ namespace ranges {
         using _Rend_on_const = decltype(_RANGES rend(_RANGES _Possibly_const_range(_STD declval<_Ty&>())));
 
         template <_Should_range_access _Ty>
-            requires requires(_Ty& _Val) { //
+            requires requires(_Ty& _Val) {
+                typename _Rend_on_const<_Ty>;
+                typename const_sentinel<_Rend_on_const<_Ty>>;
                 const_sentinel<_Rend_on_const<_Ty>>{_RANGES rend(_RANGES _Possibly_const_range(_Val))};
             }
         _NODISCARD constexpr auto operator()(_Ty&& _Val) const

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -1975,10 +1975,8 @@ struct _Const_sentinel<_Sent> {
 _EXPORT_STD template <semiregular _Sent>
 using const_sentinel = typename _Const_sentinel<_Sent>::type;
 
-// clang-format off
 template <class _Ty>
 concept _Not_a_const_iterator = !_Is_specialization_v<_Ty, basic_const_iterator>;
-// clang-format on
 
 template <class>
 struct _Basic_const_iterator_category {};
@@ -1987,18 +1985,6 @@ template <forward_iterator _Iter>
 struct _Basic_const_iterator_category<_Iter> {
     using iterator_category = typename iterator_traits<_Iter>::iterator_category;
 };
-
-// TRANSITION, LLVM-55945: These are distinct concepts as a workaround
-template <class _Ty, class _Iter>
-concept _Bci_order = _Different_from<_Ty, basic_const_iterator<_Iter>> && random_access_iterator<_Iter>
-                  && totally_ordered_with<_Iter, _Ty>;
-
-template <class _Ty, class _Iter>
-concept _Bci_order_3way = _Bci_order<_Ty, _Iter> && three_way_comparable_with<_Iter, _Ty>;
-
-template <class _Ty, class _Iter>
-concept _Not_bci_order =
-    _Not_a_const_iterator<_Ty> && random_access_iterator<_Iter> && totally_ordered_with<_Iter, _Ty>;
 
 _EXPORT_STD template <input_iterator _Iter>
 class basic_const_iterator : public _Basic_const_iterator_category<_Iter> {
@@ -2168,55 +2154,65 @@ public:
         return _Current <=> _Right._Current;
     }
 
-    template <_Bci_order<_Iter> _Other>
+    template <_Different_from<basic_const_iterator> _Other>
+        requires random_access_iterator<_Iter> && totally_ordered_with<_Iter, _Other>
     _NODISCARD constexpr bool operator<(const _Other& _Right) const
         noexcept(noexcept(_Fake_copy_init<bool>(_Current < _Right))) /* strengthened */ {
         return _Current < _Right;
     }
 
-    template <_Bci_order<_Iter> _Other>
+    template <_Different_from<basic_const_iterator> _Other>
+        requires random_access_iterator<_Iter> && totally_ordered_with<_Iter, _Other>
     _NODISCARD constexpr bool operator>(const _Other& _Right) const
         noexcept(noexcept(_Fake_copy_init<bool>(_Current > _Right))) /* strengthened */ {
         return _Current > _Right;
     }
 
-    template <_Bci_order<_Iter> _Other>
+    template <_Different_from<basic_const_iterator> _Other>
+        requires random_access_iterator<_Iter> && totally_ordered_with<_Iter, _Other>
     _NODISCARD constexpr bool operator<=(const _Other& _Right) const
         noexcept(noexcept(_Fake_copy_init<bool>(_Current <= _Right))) /* strengthened */ {
         return _Current <= _Right;
     }
 
-    template <_Bci_order<_Iter> _Other>
+    template <_Different_from<basic_const_iterator> _Other>
+        requires random_access_iterator<_Iter> && totally_ordered_with<_Iter, _Other>
     _NODISCARD constexpr bool operator>=(const _Other& _Right) const
         noexcept(noexcept(_Fake_copy_init<bool>(_Current >= _Right))) /* strengthened */ {
         return _Current >= _Right;
     }
 
-    template <_Bci_order_3way<_Iter> _Other>
+    template <_Different_from<basic_const_iterator> _Other>
+        requires random_access_iterator<_Iter> && totally_ordered_with<_Iter, _Other>
+              && three_way_comparable_with<_Iter, _Other>
     _NODISCARD constexpr auto operator<=>(const _Other& _Right) const
         noexcept(noexcept(_Current <=> _Right)) /* strengthened */ {
         return _Current <=> _Right;
     }
 
-    template <_Not_bci_order<_Iter> _Other>
+    template <_Not_a_const_iterator _Other>
+        requires random_access_iterator<_Iter> && totally_ordered_with<_Iter, _Other>
     _NODISCARD_FRIEND constexpr bool operator<(const _Other& _Left, const basic_const_iterator& _Right) noexcept(
         noexcept(_Fake_copy_init<bool>(_Left < _Right._Current))) /* strengthened */ {
         return _Left < _Right._Current;
     }
 
-    template <_Not_bci_order<_Iter> _Other>
+    template <_Not_a_const_iterator _Other>
+        requires random_access_iterator<_Iter> && totally_ordered_with<_Iter, _Other>
     _NODISCARD_FRIEND constexpr bool operator>(const _Other& _Left, const basic_const_iterator& _Right) noexcept(
         noexcept(_Fake_copy_init<bool>(_Left > _Right._Current))) /* strengthened */ {
         return _Left > _Right._Current;
     }
 
-    template <_Not_bci_order<_Iter> _Other>
+    template <_Not_a_const_iterator _Other>
+        requires random_access_iterator<_Iter> && totally_ordered_with<_Iter, _Other>
     _NODISCARD_FRIEND constexpr bool operator<=(const _Other& _Left, const basic_const_iterator& _Right) noexcept(
         noexcept(_Fake_copy_init<bool>(_Left <= _Right._Current))) /* strengthened */ {
         return _Left <= _Right._Current;
     }
 
-    template <_Not_bci_order<_Iter> _Other>
+    template <_Not_a_const_iterator _Other>
+        requires random_access_iterator<_Iter> && totally_ordered_with<_Iter, _Other>
     _NODISCARD_FRIEND constexpr bool operator>=(const _Other& _Left, const basic_const_iterator& _Right) noexcept(
         noexcept(_Fake_copy_init<bool>(_Left >= _Right._Current))) /* strengthened */ {
         return _Left >= _Right._Current;
@@ -2669,29 +2665,17 @@ namespace ranges {
     _NODISCARD constexpr auto _As_const_pointer(const _Ty* _Ptr) noexcept {
         return _Ptr;
     }
-
-    template <class _Ty>
-    using _Begin_on_const = decltype(_RANGES begin(_RANGES _Possibly_const_range(_STD declval<_Ty&>())));
-
-    // TRANSITION, LLVM-55945
-    template <class _Ty>
-    concept _Range_accessible_and_begin_adaptable = _Should_range_access<_Ty> && requires(_Ty& _Val) {
-        const_iterator<_Begin_on_const<_Ty>>{_RANGES begin(_RANGES _Possibly_const_range(_Val))};
-    };
-
-    template <class _Ty>
-    using _End_on_const = decltype(_RANGES end(_RANGES _Possibly_const_range(_STD declval<_Ty&>())));
-
-    // TRANSITION, LLVM-55945
-    template <class _Ty>
-    concept _Range_accessible_and_end_adaptable = _Should_range_access<_Ty> && requires(_Ty& _Val) {
-        const_sentinel<_End_on_const<_Ty>>{_RANGES end(_RANGES _Possibly_const_range(_Val))};
-    };
 #endif // _HAS_CXX23
 
     struct _Cbegin_fn {
 #if _HAS_CXX23
-        template <_Range_accessible_and_begin_adaptable _Ty>
+        template <class _Ty>
+        using _Begin_on_const = decltype(_RANGES begin(_RANGES _Possibly_const_range(_STD declval<_Ty&>())));
+
+        template <_Should_range_access _Ty>
+            requires requires(_Ty& _Val) { //
+                const_iterator<_Begin_on_const<_Ty>>{_RANGES begin(_RANGES _Possibly_const_range(_Val))};
+            }
         _NODISCARD constexpr auto operator()(_Ty&& _Val) const noexcept(
             noexcept(const_iterator<_Begin_on_const<_Ty>>{_RANGES begin(_RANGES _Possibly_const_range(_Val))})) {
             return const_iterator<_Begin_on_const<_Ty>>{_RANGES begin(_RANGES _Possibly_const_range(_Val))};
@@ -2713,7 +2697,13 @@ namespace ranges {
 
     struct _Cend_fn {
 #if _HAS_CXX23
-        template <_Range_accessible_and_end_adaptable _Ty>
+        template <class _Ty>
+        using _End_on_const = decltype(_RANGES end(_RANGES _Possibly_const_range(_STD declval<_Ty&>())));
+
+        template <_Should_range_access _Ty>
+            requires requires(_Ty& _Val) { //
+                const_sentinel<_End_on_const<_Ty>>{_RANGES end(_RANGES _Possibly_const_range(_Val))};
+            }
         _NODISCARD constexpr auto operator()(_Ty&& _Val) const
             noexcept(noexcept(const_sentinel<_End_on_const<_Ty>>{_RANGES end(_RANGES _Possibly_const_range(_Val))})) {
             return const_sentinel<_End_on_const<_Ty>>{_RANGES end(_RANGES _Possibly_const_range(_Val))};
@@ -2872,29 +2862,15 @@ namespace ranges {
         _EXPORT_STD inline constexpr _Rend::_Cpo rend;
     }
 
-#if _HAS_CXX23
-    template <class _Ty>
-    using _Rbegin_on_const = decltype(_RANGES rbegin(_RANGES _Possibly_const_range(_STD declval<_Ty&>())));
-
-    // TRANSITION, LLVM-55945
-    template <class _Ty>
-    concept _Range_accessible_and_rbegin_adaptable = _Should_range_access<_Ty> && requires(_Ty& _Val) {
-        const_iterator<_Rbegin_on_const<_Ty>>{_RANGES rbegin(_RANGES _Possibly_const_range(_Val))};
-    };
-
-    template <class _Ty>
-    using _Rend_on_const = decltype(_RANGES rend(_RANGES _Possibly_const_range(_STD declval<_Ty&>())));
-
-    // TRANSITION, LLVM-55945
-    template <class _Ty>
-    concept _Range_accessible_and_rend_adaptable = _Should_range_access<_Ty> && requires(_Ty& _Val) {
-        const_sentinel<_Rend_on_const<_Ty>>{_RANGES rend(_RANGES _Possibly_const_range(_Val))};
-    };
-#endif // _HAS_CXX23
-
     struct _Crbegin_fn {
 #if _HAS_CXX23
-        template <_Range_accessible_and_rbegin_adaptable _Ty>
+        template <class _Ty>
+        using _Rbegin_on_const = decltype(_RANGES rbegin(_RANGES _Possibly_const_range(_STD declval<_Ty&>())));
+
+        template <_Should_range_access _Ty>
+            requires requires(_Ty& _Val) { //
+                const_iterator<_Rbegin_on_const<_Ty>>{_RANGES rbegin(_RANGES _Possibly_const_range(_Val))};
+            }
         _NODISCARD constexpr auto operator()(_Ty&& _Val) const noexcept(
             noexcept(const_iterator<_Rbegin_on_const<_Ty>>{_RANGES rbegin(_RANGES _Possibly_const_range(_Val))})) {
             return const_iterator<_Rbegin_on_const<_Ty>>{_RANGES rbegin(_RANGES _Possibly_const_range(_Val))};
@@ -2916,7 +2892,13 @@ namespace ranges {
 
     struct _Crend_fn {
 #if _HAS_CXX23
-        template <_Range_accessible_and_rend_adaptable _Ty>
+        template <class _Ty>
+        using _Rend_on_const = decltype(_RANGES rend(_RANGES _Possibly_const_range(_STD declval<_Ty&>())));
+
+        template <_Should_range_access _Ty>
+            requires requires(_Ty& _Val) { //
+                const_sentinel<_Rend_on_const<_Ty>>{_RANGES rend(_RANGES _Possibly_const_range(_Val))};
+            }
         _NODISCARD constexpr auto operator()(_Ty&& _Val) const
             noexcept(noexcept(const_sentinel<_Rend_on_const<_Ty>>{_RANGES rend(_RANGES _Possibly_const_range(_Val))})) {
             return const_sentinel<_Rend_on_const<_Ty>>{_RANGES rend(_RANGES _Possibly_const_range(_Val))};
@@ -3137,6 +3119,31 @@ namespace ranges {
 
     inline namespace _Cpos {
         _EXPORT_STD inline constexpr _Data::_Cpo data;
+    }
+
+    struct _Cdata_fn {
+#if _HAS_CXX23
+        template <_Should_range_access _Ty>
+            requires requires(_Ty& _Val) { //
+                _RANGES _As_const_pointer(_RANGES data(_RANGES _Possibly_const_range(_Val)));
+            }
+        _NODISCARD constexpr auto operator()(_Ty&& _Val) const
+            noexcept(noexcept(_RANGES data(_RANGES _Possibly_const_range(_Val)))) {
+            return _RANGES _As_const_pointer(_RANGES data(_RANGES _Possibly_const_range(_Val)));
+        }
+#else // ^^^ C++23 / C++20 vvv
+        template <class _Ty, class _CTy = _Const_thru_ref<_Ty>>
+        _NODISCARD constexpr auto operator()(_Ty&& _Val) const
+            noexcept(noexcept(_RANGES data(static_cast<_CTy&&>(_Val))))
+            requires requires { _RANGES data(static_cast<_CTy&&>(_Val)); }
+        {
+            return _RANGES data(static_cast<_CTy&&>(_Val));
+        }
+#endif // C++20
+    };
+
+    inline namespace _Cpos {
+        _EXPORT_STD inline constexpr _Cdata_fn cdata;
     }
 
 #if _HAS_CXX23

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -3146,36 +3146,6 @@ namespace ranges {
         _EXPORT_STD inline constexpr _Cdata_fn cdata;
     }
 
-#if _HAS_CXX23
-    // TRANSITION, LLVM-55945
-    template <class _Ty>
-    concept _Range_accessible_and_data_adaptable = _Should_range_access<_Ty> && requires(_Ty& _Val) {
-        _RANGES _As_const_pointer(_RANGES data(_RANGES _Possibly_const_range(_Val)));
-    };
-#endif // _HAS_CXX23
-
-    struct _Cdata_fn {
-#if _HAS_CXX23
-        template <_Range_accessible_and_data_adaptable _Ty>
-        _NODISCARD constexpr auto operator()(_Ty&& _Val) const
-            noexcept(noexcept(_RANGES data(_RANGES _Possibly_const_range(_Val)))) {
-            return _RANGES _As_const_pointer(_RANGES data(_RANGES _Possibly_const_range(_Val)));
-        }
-#else // ^^^ C++23 / C++20 vvv
-        template <class _Ty, class _CTy = _Const_thru_ref<_Ty>>
-        _NODISCARD constexpr auto operator()(_Ty&& _Val) const
-            noexcept(noexcept(_RANGES data(static_cast<_CTy&&>(_Val))))
-            requires requires { _RANGES data(static_cast<_CTy&&>(_Val)); }
-        {
-            return _RANGES data(static_cast<_CTy&&>(_Val));
-        }
-#endif // C++20
-    };
-
-    inline namespace _Cpos {
-        _EXPORT_STD inline constexpr _Cdata_fn cdata;
-    }
-
     _EXPORT_STD template <class _Rng>
     concept sized_range = range<_Rng> && requires(_Rng& __r) { _RANGES size(__r); };
 

--- a/tests/std/tests/P1522R1_difference_type/test.cpp
+++ b/tests/std/tests/P1522R1_difference_type/test.cpp
@@ -41,12 +41,6 @@ namespace ordtest {
 #define CONSTEVAL constexpr
 #endif // ^^^ !_HAS_CXX20 ^^^
 
-#if _HAS_CXX20 && !defined(__clang__) // TRANSITION, LLVM-51840
-#define CONSTEVAL_CLANG_WORKAROUND consteval
-#else // ^^^ _HAS_CXX20 && !defined(__clang__) / !_HAS_CXX20 || defined(__clang__) vvv
-#define CONSTEVAL_CLANG_WORKAROUND constexpr
-#endif // ^^^ !_HAS_CXX20 || defined(__clang__) ^^^
-
 using std::_Signed128;
 using std::_Unsigned128;
 
@@ -62,7 +56,7 @@ namespace i128_udl_detail {
         _Unsigned128 value;
     };
 
-    [[nodiscard]] CONSTEVAL_CLANG_WORKAROUND unsigned int char_to_digit(const char c) noexcept {
+    [[nodiscard]] CONSTEVAL unsigned int char_to_digit(const char c) noexcept {
         if (c >= '0' && c <= '9') {
             return static_cast<unsigned int>(c - '0');
         }


### PR DESCRIPTION
LLVM-47414, LLVM-51580, LLVM-55945, and LLVM-56379 should have been fixed in Clang16. Let's remove the workarounds.