### PR TITLE
Fix `hh_mm_ss` formatting for values >= 1 day

### DIFF
--- a/stl/inc/__msvc_chrono.hpp
+++ b/stl/inc/__msvc_chrono.hpp
@@ -501,7 +501,7 @@ namespace chrono {
         is_arithmetic_v<_Rep>) /* strengthened */ {
         // create a duration whose count() is the absolute value of _Dur.count()
         if (_Dur < duration<_Rep, _Period>::zero()) {
-            return duration<_Rep, _Period>::zero() - _Dur;
+            return -_Dur;
         } else {
             return _Dur;
         }

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -5609,9 +5609,12 @@ namespace chrono {
                 _Os << _CharT{'/'};
                 _Custom_write(_Os, {._Type = 'y'}, _Time, _Val);
                 return true;
+            case 'H':
+                // Print hour even if >= 24.
+                _Os << _STD format(_STATICALLY_WIDEN(_CharT, "{:02}"), _Time.tm_hour);
+                return true;
             case 'T':
-                // Alias for %H:%M:%S but we need to allow for hours > 23 and rewrite %S to display fractions of a
-                // second.
+                // Alias for %H:%M:%S but we allow hours > 23 and rewrite %S to display fractions of a second.
                 _Os << _STD format(_STATICALLY_WIDEN(_CharT, "{:02}:{:02}:"), _Time.tm_hour, _Time.tm_min);
                 [[fallthrough]];
             case 'S':

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -1601,10 +1601,12 @@ namespace chrono {
 
         constexpr hh_mm_ss() noexcept : hh_mm_ss{_Duration::zero()} {}
         constexpr explicit hh_mm_ss(_Duration _Dur)
-            : _Is_neg{_Dur < _Duration::zero()}, //
+            : _Is_neg{_Dur < _Duration::zero()},
               _Hours{_Duration_cast_underflow_to_zero<_CHRONO hours>(_CHRONO abs(_Dur))},
-              _Mins{_Duration_cast_underflow_to_zero<_CHRONO minutes>(_CHRONO abs(_Dur) - _Hours)},
-              _Secs{_Duration_cast_underflow_to_zero<_CHRONO seconds>(_CHRONO abs(_Dur) - _Hours - _Mins)} {
+              _Mins{_Duration_cast_underflow_to_zero<_CHRONO minutes>(
+                  _Remove_duration_part<_CHRONO hours>(_CHRONO abs(_Dur)))},
+              _Secs{_Duration_cast_underflow_to_zero<_CHRONO seconds>(
+                  _Remove_duration_part<_CHRONO minutes>(_Remove_duration_part<_CHRONO hours>(_CHRONO abs(_Dur))))} {
             if constexpr (treat_as_floating_point_v<typename precision::rep>) {
                 // no need to deal with underflow here, because floating durations allow it
                 _Sub_secs = _CHRONO abs(_Dur) - hours() - minutes() - seconds();

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -1603,8 +1603,8 @@ namespace chrono {
         constexpr explicit hh_mm_ss(_Duration _Dur)
             : _Is_neg{_Dur < _Duration::zero()}, //
               _Hours{_Duration_cast_underflow_to_zero<_CHRONO hours>(_CHRONO abs(_Dur))},
-              _Mins{_Duration_cast_underflow_to_zero<_CHRONO minutes>(_CHRONO abs(_Dur)) - _Hours},
-              _Secs{_Duration_cast_underflow_to_zero<_CHRONO seconds>(_CHRONO abs(_Dur)) - _Hours - _Mins} {
+              _Mins{_Duration_cast_underflow_to_zero<_CHRONO minutes>(_CHRONO abs(_Dur) - _Hours)},
+              _Secs{_Duration_cast_underflow_to_zero<_CHRONO seconds>(_CHRONO abs(_Dur) - _Hours - _Mins)} {
             if constexpr (treat_as_floating_point_v<typename precision::rep>) {
                 // no need to deal with underflow here, because floating durations allow it
                 _Sub_secs = _CHRONO abs(_Dur) - hours() - minutes() - seconds();

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -1603,10 +1603,8 @@ namespace chrono {
         constexpr explicit hh_mm_ss(_Duration _Dur)
             : _Is_neg{_Dur < _Duration::zero()}, //
               _Hours{_Duration_cast_underflow_to_zero<_CHRONO hours>(_CHRONO abs(_Dur))},
-              _Mins{_Duration_cast_underflow_to_zero<_CHRONO minutes>(
-                  _Remove_duration_part<_CHRONO hours>(_CHRONO abs(_Dur)))},
-              _Secs{_Duration_cast_underflow_to_zero<_CHRONO seconds>(
-                  _Remove_duration_part<_CHRONO minutes>(_CHRONO abs(_Dur)))} {
+              _Mins{_Duration_cast_underflow_to_zero<_CHRONO minutes>(_CHRONO abs(_Dur)) - _Hours},
+              _Secs{_Duration_cast_underflow_to_zero<_CHRONO seconds>(_CHRONO abs(_Dur)) - _Hours - _Mins} {
             if constexpr (treat_as_floating_point_v<typename precision::rep>) {
                 // no need to deal with underflow here, because floating durations allow it
                 _Sub_secs = _CHRONO abs(_Dur) - hours() - minutes() - seconds();
@@ -4942,11 +4940,6 @@ namespace chrono {
         _STL_INTERNAL_CHECK(false);
     }
 
-    template <class _Duration>
-    _NODISCARD constexpr auto _Hh_mm_ss_part_underflow_to_zero(const _Duration& _Val) {
-        return hh_mm_ss<common_type_t<days, _Duration>>{_Remove_duration_part<days>(_Val)};
-    }
-
     template <unsigned int _Fractional_width, class _CharT, class _Traits, class _Precision>
     void _Write_fractional_seconds(
         basic_ostream<_CharT, _Traits>& _Os, const seconds& _Seconds, const _Precision& _Subseconds) {
@@ -4993,7 +4986,7 @@ namespace chrono {
 
     template <class _CharT, class _Traits, class _Rep, class _Period>
     void _Write_seconds(basic_ostream<_CharT, _Traits>& _Os, const duration<_Rep, _Period>& _Val) {
-        _Write_seconds(_Os, _Hh_mm_ss_part_underflow_to_zero(_Val));
+        _Write_seconds(_Os, hh_mm_ss{_Val});
     }
 
     template <class _Ty>
@@ -5008,7 +5001,7 @@ namespace chrono {
         int _Seconds        = 0;
 
         if constexpr (_Is_specialization_v<_Ty, duration>) {
-            return _Fill_tm(_Hh_mm_ss_part_underflow_to_zero(_Val));
+            return _Fill_tm(hh_mm_ss{_Val});
         } else if constexpr (_Is_specialization_v<_Ty, _Local_time_format_t>) {
             return _Fill_tm(_Val._Time);
         } else if constexpr (is_same_v<_Ty, day>) {
@@ -5617,9 +5610,9 @@ namespace chrono {
                 _Custom_write(_Os, {._Type = 'y'}, _Time, _Val);
                 return true;
             case 'T':
-                // Alias for %H:%M:%S but we need to rewrite %S to display fractions of a second.
-                _Validate_specifiers({._Type = 'H'}, _Val);
-                _Os << _STD put_time(&_Time, _STATICALLY_WIDEN(_CharT, "%H:%M:"));
+                // Alias for %H:%M:%S but we need to allow for hours > 23 and rewrite %S to display fractions of a
+                // second.
+                _Os << _STD format(_STATICALLY_WIDEN(_CharT, "{:02}:{:02}:"), _Time.tm_hour, _Time.tm_min);
                 [[fallthrough]];
             case 'S':
                 if (_Has_modifier) {
@@ -5674,14 +5667,8 @@ namespace chrono {
         template <class _Ty>
         static void _Validate_specifiers(const _Chrono_spec<_CharT>& _Spec, const _Ty& _Val) {
             if constexpr (_Is_specialization_v<_Ty, duration> || is_same_v<_Ty, sys_info>
-                          || _Is_specialization_v<_Ty, time_point> || _Is_specialization_v<_Ty, _Local_time_format_t>) {
-                return;
-            }
-
-            if constexpr (_Is_specialization_v<_Ty, hh_mm_ss>) {
-                if (_Spec._Type == 'H' && _Val.hours() >= hours{24}) {
-                    _Throw_format_error("Cannot localize hh_mm_ss with an absolute value of 24 hours or more.");
-                }
+                          || _Is_specialization_v<_Ty, time_point> || _Is_specialization_v<_Ty, _Local_time_format_t>
+                          || _Is_specialization_v<_Ty, hh_mm_ss>) {
                 return;
             }
 

--- a/tests/std/test.lst
+++ b/tests/std/test.lst
@@ -223,6 +223,7 @@ tests\GH_003105_piecewise_densities
 tests\GH_003119_error_category_ctor
 tests\GH_003246_cmath_narrowing
 tests\GH_003617_vectorized_meow_element
+tests\GH_003676_format_large_hh_mm_ss_values
 tests\LWG2381_num_get_floating_point
 tests\LWG2597_complex_branch_cut
 tests\LWG3018_shared_ptr_function

--- a/tests/std/tests/GH_003676_format_large_hh_mm_ss_values/env.lst
+++ b/tests/std/tests/GH_003676_format_large_hh_mm_ss_values/env.lst
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+RUNALL_INCLUDE ..\usual_20_matrix.lst

--- a/tests/std/tests/GH_003676_format_large_hh_mm_ss_values/env.lst
+++ b/tests/std/tests/GH_003676_format_large_hh_mm_ss_values/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\usual_20_matrix.lst
+RUNALL_INCLUDE ..\concepts_20_matrix.lst

--- a/tests/std/tests/GH_003676_format_large_hh_mm_ss_values/test.cpp
+++ b/tests/std/tests/GH_003676_format_large_hh_mm_ss_values/test.cpp
@@ -45,4 +45,7 @@ int main() {
     assert_duration_format_equal(duration<float, days::period>{-1.55f}, "-37:12:00");
     assert_duration_format_equal(2ms, "00:00:00.002");
     assert_duration_format_equal(-2ms, "-00:00:00.002");
+
+    assert_equal("24", format("{:%H}", 24h));
+    assert_equal("-24", format("{:%H}", -24h));
 }

--- a/tests/std/tests/GH_003676_format_large_hh_mm_ss_values/test.cpp
+++ b/tests/std/tests/GH_003676_format_large_hh_mm_ss_values/test.cpp
@@ -22,11 +22,17 @@ void assert_equal(const auto& expected, const auto& value) {
 }
 
 template <typename R, typename P>
-void assert_duration_format_equal(const duration<R, P>& duration, const char* str) {
+void assert_duration_format_equal(const duration<R, P>& duration, const string& str) {
     stringstream ss;
     ss << hh_mm_ss{duration};
     assert_equal(str, ss.str());
     assert_equal(str, format("{:%T}", duration));
+}
+
+template <typename R, typename P>
+void assert_duration_format_equal_positive(const duration<R, P>& duration, const string& str) {
+    assert_duration_format_equal(duration, str);
+    assert_duration_format_equal(-duration, '-' + str);
 }
 
 int main() {
@@ -34,18 +40,11 @@ int main() {
     assert_duration_format_equal(-0h, "00:00:00");
     assert_duration_format_equal(years{0}, "00:00:00");
 
-    assert_duration_format_equal(3h, "03:00:00");
-    assert_duration_format_equal(-3h, "-03:00:00");
-    assert_duration_format_equal(10h + 20min + 30s, "10:20:30");
-    assert_duration_format_equal(-10h - 20min - 30s, "-10:20:30");
-    assert_duration_format_equal(days{3}, "72:00:00");
-    assert_duration_format_equal(-days{3}, "-72:00:00");
-    assert_duration_format_equal(-years{1}, "-8765:49:12");
-    assert_duration_format_equal(duration<float, days::period>{1.55f}, "37:12:00");
-    assert_duration_format_equal(duration<float, days::period>{-1.55f}, "-37:12:00");
-    assert_duration_format_equal(2ms, "00:00:00.002");
-    assert_duration_format_equal(-2ms, "-00:00:00.002");
-
-    assert_equal("24", format("{:%H}", 24h));
-    assert_equal("-24", format("{:%H}", -24h));
+    assert_duration_format_equal_positive(3h, "03:00:00");
+    assert_duration_format_equal_positive(10h + 20min + 30s, "10:20:30");
+    assert_duration_format_equal_positive(days{3}, "72:00:00");
+    assert_duration_format_equal_positive(years{1}, "8765:49:12");
+    assert_duration_format_equal_positive(duration<float, days::period>{1.55f}, "37:12:00");
+    assert_duration_format_equal_positive(2ms, "00:00:00.002");
+    assert_duration_format_equal_positive(60min, "01:00:00");
 }

--- a/tests/std/tests/GH_003676_format_large_hh_mm_ss_values/test.cpp
+++ b/tests/std/tests/GH_003676_format_large_hh_mm_ss_values/test.cpp
@@ -44,7 +44,7 @@ int main() {
     assert_duration_format_equal_positive(10h + 20min + 30s, "10:20:30");
     assert_duration_format_equal_positive(days{3}, "72:00:00");
     assert_duration_format_equal_positive(years{1}, "8765:49:12");
-    assert_duration_format_equal_positive(duration<float, days::period>{1.55f}, "37:12:00");
+    assert_duration_format_equal_positive(duration<float, days::period>{1.55f}, "37:11:59");
     assert_duration_format_equal_positive(2ms, "00:00:00.002");
     assert_duration_format_equal_positive(60min, "01:00:00");
 }

--- a/tests/std/tests/GH_003676_format_large_hh_mm_ss_values/test.cpp
+++ b/tests/std/tests/GH_003676_format_large_hh_mm_ss_values/test.cpp
@@ -6,10 +6,10 @@
 #include <format>
 #include <iostream>
 #include <sstream>
+#include <string>
 
 using namespace std;
 using namespace chrono;
-using namespace chrono_literals;
 
 void assert_equal(const auto& expected, const auto& value) {
     if (expected == value) {
@@ -22,17 +22,17 @@ void assert_equal(const auto& expected, const auto& value) {
 }
 
 template <typename R, typename P>
-void assert_duration_format_equal(const duration<R, P>& duration, const string& str) {
-    stringstream ss;
-    ss << hh_mm_ss{duration};
-    assert_equal(str, ss.str());
-    assert_equal(str, format("{:%T}", duration));
+void assert_duration_format_equal(const duration<R, P>& dur, const string& str) {
+    ostringstream oss;
+    oss << hh_mm_ss{dur};
+    assert_equal(str, oss.str());
+    assert_equal(str, format("{:%T}", dur));
 }
 
 template <typename R, typename P>
-void assert_duration_format_equal_positive(const duration<R, P>& duration, const string& str) {
-    assert_duration_format_equal(duration, str);
-    assert_duration_format_equal(-duration, '-' + str);
+void assert_duration_format_equal_positive(const duration<R, P>& dur, const string& str) {
+    assert_duration_format_equal(dur, str);
+    assert_duration_format_equal(-dur, '-' + str);
 }
 
 int main() {

--- a/tests/std/tests/GH_003676_format_large_hh_mm_ss_values/test.cpp
+++ b/tests/std/tests/GH_003676_format_large_hh_mm_ss_values/test.cpp
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <cassert>
+#include <chrono>
+#include <format>
+#include <iostream>
+#include <sstream>
+
+using namespace std;
+using namespace chrono;
+using namespace chrono_literals;
+
+void assert_equal(const auto& expected, const auto& value) {
+    if (expected == value) {
+        return;
+    }
+
+    cout << "Expected: " << expected << endl;
+    cout << "Got:      " << value << endl;
+    assert(false);
+}
+
+template <typename R, typename P>
+void assert_duration_format_equal(const duration<R, P>& duration, const char* str) {
+    stringstream ss;
+    ss << hh_mm_ss{duration};
+    assert_equal(str, ss.str());
+    assert_equal(str, format("{:%T}", duration));
+}
+
+int main() {
+    assert_duration_format_equal(0ns, "00:00:00.000000000");
+    assert_duration_format_equal(-0h, "00:00:00");
+    assert_duration_format_equal(years{0}, "00:00:00");
+
+    assert_duration_format_equal(3h, "03:00:00");
+    assert_duration_format_equal(-3h, "-03:00:00");
+    assert_duration_format_equal(10h + 20min + 30s, "10:20:30");
+    assert_duration_format_equal(-10h - 20min - 30s, "-10:20:30");
+    assert_duration_format_equal(days{3}, "72:00:00");
+    assert_duration_format_equal(-days{3}, "-72:00:00");
+    assert_duration_format_equal(-years{1}, "-8765:49:12");
+    assert_duration_format_equal(duration<float, days::period>{1.55f}, "37:12:00");
+    assert_duration_format_equal(duration<float, days::period>{-1.55f}, "-37:12:00");
+    assert_duration_format_equal(2ms, "00:00:00.002");
+    assert_duration_format_equal(-2ms, "-00:00:00.002");
+}

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
@@ -280,8 +280,8 @@ void test_duration_formatter() {
     assert(format(STR("{:%T %j %q %Q}"), -days{4} - 30min) == STR("-96:30:00 4 min 5790"));
     assert(format(STR("{:%T %j}"), days{4} + 23h + 30min) == STR("119:30:00 4"));
     assert(format(STR("{:%T %j}"), -days{4} - 23h - 30min) == STR("-119:30:00 4"));
-    assert(format(STR("{:%T %j}"), duration<float, days::period>{1.55f}) == STR("37:12:00 1"));
-    assert(format(STR("{:%T %j}"), duration<float, days::period>{-1.55f}) == STR("-37:12:00 1"));
+    assert(format(STR("{:%T %j}"), duration<float, days::period>{1.55f}) == STR("37:11:59 1"));
+    assert(format(STR("{:%T %j}"), duration<float, days::period>{-1.55f}) == STR("-37:11:59 1"));
 }
 
 template <typename CharT>

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
@@ -775,6 +775,10 @@ void test_hh_mm_ss_formatter() {
     assert(format(STR("{:%H %I %M %S %r %R %T %p}"), hh_mm_ss{-13h - 14min - 15351ms})
            == STR("-13 01 14 15.351 01:14:15 PM 13:14 13:14:15.351 PM"));
 
+    assert(format(STR("{}"), hh_mm_ss{24h}) == STR("24:00:00"));
+    assert(format(STR("{}"), hh_mm_ss{-24h}) == STR("-24:00:00"));
+    assert(format(STR("{:%H}"), hh_mm_ss{24h}) == STR("24"));
+    assert(format(STR("{:%H}"), hh_mm_ss{-24h}) == STR("-24"));
     assert(format(STR("{:%M %S}"), hh_mm_ss{27h + 12min + 30s}) == STR("12 30"));
 }
 

--- a/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
+++ b/tests/std/tests/P0355R7_calendars_and_time_zones_formatting/test.cpp
@@ -276,12 +276,12 @@ void test_duration_formatter() {
     assert(format(STR("{:%T}"), 4083007ms) == STR("01:08:03.007"));
     assert(format(STR("{:%T}"), -4083007ms) == STR("-01:08:03.007"));
 
-    assert(format(STR("{:%T %j %q %Q}"), days{4} + 30min) == STR("00:30:00 4 min 5790"));
-    assert(format(STR("{:%T %j %q %Q}"), -days{4} - 30min) == STR("-00:30:00 4 min 5790"));
-    assert(format(STR("{:%T %j}"), days{4} + 23h + 30min) == STR("23:30:00 4"));
-    assert(format(STR("{:%T %j}"), -days{4} - 23h - 30min) == STR("-23:30:00 4"));
-    assert(format(STR("{:%T %j}"), duration<float, days::period>{1.55f}) == STR("13:11:59 1"));
-    assert(format(STR("{:%T %j}"), duration<float, days::period>{-1.55f}) == STR("-13:11:59 1"));
+    assert(format(STR("{:%T %j %q %Q}"), days{4} + 30min) == STR("96:30:00 4 min 5790"));
+    assert(format(STR("{:%T %j %q %Q}"), -days{4} - 30min) == STR("-96:30:00 4 min 5790"));
+    assert(format(STR("{:%T %j}"), days{4} + 23h + 30min) == STR("119:30:00 4"));
+    assert(format(STR("{:%T %j}"), -days{4} - 23h - 30min) == STR("-119:30:00 4"));
+    assert(format(STR("{:%T %j}"), duration<float, days::period>{1.55f}) == STR("37:12:00 1"));
+    assert(format(STR("{:%T %j}"), duration<float, days::period>{-1.55f}) == STR("-37:12:00 1"));
 }
 
 template <typename CharT>
@@ -775,8 +775,6 @@ void test_hh_mm_ss_formatter() {
     assert(format(STR("{:%H %I %M %S %r %R %T %p}"), hh_mm_ss{-13h - 14min - 15351ms})
            == STR("-13 01 14 15.351 01:14:15 PM 13:14 13:14:15.351 PM"));
 
-    throw_helper(STR("{}"), hh_mm_ss{24h});
-    throw_helper(STR("{}"), hh_mm_ss{-24h});
     assert(format(STR("{:%M %S}"), hh_mm_ss{27h + 12min + 30s}) == STR("12 30"));
 }
 


### PR DESCRIPTION
## Summary of changes:
- Remove explicit assertion that prevents formatting `hh_mm_ss`s >= 1 day
- Change `hh_mm_ss`' formatting implementation to use the hours and minutes explicitly (`put_time` does not deal with hours >= 24, which is desired behavior)
- Remove `_Hh_mm_ss_part_underflow_to_zero` and instead cast every `duration` to be formatted this way to `hh_mm_ss` directly (this is the `format("{:%T}", some_duration) == "00:00:00"` bug discussed in the original issue (not the same bug, but closely related ;))
- Simplified `abs` for `duration`s slightly.
- Added custom `%H` format override.

Fixes #3676 