### PR TITLE
`<ranges>`: Diagnose the precondition added by LWG-3597

### DIFF
--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -1335,7 +1335,7 @@ namespace ranges {
             is_nothrow_move_constructible_v<_Wi>&& is_nothrow_default_constructible_v<_Bo>) // strengthened
             : _Value(_STD move(_Value_)) {
             if constexpr (totally_ordered_with<_Wi, _Bo>) {
-                _STL_ASSERT(_Value_ <= _Bound, "Per N4950 [range.iota.view]/6, the first argument must precede the "
+                _STL_ASSERT(_Value_ <= _Bound, "Per N4950 [range.iota.view]/6, the first argument must not exceed the "
                                                "value-initialized bound when their types are totally ordered.");
             }
         }
@@ -1344,7 +1344,7 @@ namespace ranges {
             is_nothrow_move_constructible_v<_Wi>&& is_nothrow_move_constructible_v<_Bo>) // strengthened
             : _Value(_STD move(_Value_)), _Bound(_STD move(_Bound_)) {
             if constexpr (totally_ordered_with<_Wi, _Bo>) {
-                _STL_ASSERT(_Value_ <= _Bound_, "Per N4950 [range.iota.view]/8, the first argument must precede the "
+                _STL_ASSERT(_Value_ <= _Bound_, "Per N4950 [range.iota.view]/8, the first argument must not exceed the "
                                                 "second when their types are totally ordered.");
             }
         }

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -1333,7 +1333,12 @@ namespace ranges {
 
         constexpr explicit iota_view(_Wi _Value_) noexcept(
             is_nothrow_move_constructible_v<_Wi>&& is_nothrow_default_constructible_v<_Bo>) // strengthened
-            : _Value(_STD move(_Value_)) {}
+            : _Value(_STD move(_Value_)) {
+            if constexpr (totally_ordered_with<_Wi, _Bo>) {
+                _STL_ASSERT(_Value_ <= _Bound, "Per N4950 [range.iota.view]/6, the first argument must precede the "
+                                               "value-initialized bound when their types are totally ordered.");
+            }
+        }
 
         constexpr explicit iota_view(type_identity_t<_Wi> _Value_, type_identity_t<_Bo> _Bound_) noexcept(
             is_nothrow_move_constructible_v<_Wi>&& is_nothrow_move_constructible_v<_Bo>) // strengthened

--- a/tests/std/test.lst
+++ b/tests/std/test.lst
@@ -455,6 +455,7 @@ tests\P0896R4_views_filter
 tests\P0896R4_views_filter_death
 tests\P0896R4_views_filter_iterator
 tests\P0896R4_views_iota
+tests\P0896R4_views_iota_death
 tests\P0896R4_views_join
 tests\P0896R4_views_lazy_split
 tests\P0896R4_views_reverse

--- a/tests/std/tests/P0896R4_views_iota_death/env.lst
+++ b/tests/std/tests/P0896R4_views_iota_death/env.lst
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-RUNALL_INCLUDE ..\strict_concepts_20_matrix.lst
+RUNALL_INCLUDE ..\concepts_20_matrix.lst

--- a/tests/std/tests/P0896R4_views_iota_death/env.lst
+++ b/tests/std/tests/P0896R4_views_iota_death/env.lst
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+RUNALL_INCLUDE ..\strict_concepts_20_matrix.lst

--- a/tests/std/tests/P0896R4_views_iota_death/test.cpp
+++ b/tests/std/tests/P0896R4_views_iota_death/test.cpp
@@ -27,7 +27,7 @@ void test_misordered_start_bound_ptr() {
 
 template <class T>
 void test_misordered_start_bound_vector_iter() {
-    std::vector<T> vec(1);
+    vector<T> vec(1);
     ranges::iota_view{vec.end(), vec.begin()};
 }
 

--- a/tests/std/tests/P0896R4_views_iota_death/test.cpp
+++ b/tests/std/tests/P0896R4_views_iota_death/test.cpp
@@ -32,33 +32,41 @@ int main(int argc, char* argv[]) {
     struct S {};
 
     exec.add_death_tests({
-        test_misordered_start_bound_int<signed char>, test_misordered_start_bound_int<unsigned char>,
-            test_misordered_start_bound_int<short>, test_misordered_start_bound_int<unsigned short>,
-            test_misordered_start_bound_int<int>, test_misordered_start_bound_int<unsigned int>,
-            test_misordered_start_bound_int<long>, test_misordered_start_bound_int<unsigned long>,
-            test_misordered_start_bound_int<long long>, test_misordered_start_bound_int<unsigned long long>,
+        test_misordered_start_bound_int<signed char>,
+        test_misordered_start_bound_int<unsigned char>,
+        test_misordered_start_bound_int<short>,
+        test_misordered_start_bound_int<unsigned short>,
+        test_misordered_start_bound_int<int>,
+        test_misordered_start_bound_int<unsigned int>,
+        test_misordered_start_bound_int<long>,
+        test_misordered_start_bound_int<unsigned long>,
+        test_misordered_start_bound_int<long long>,
+        test_misordered_start_bound_int<unsigned long long>,
 
-            test_misordered_start_bound_int<char>,
+        test_misordered_start_bound_int<char>,
 #ifdef __cpp_char8_t
-            test_misordered_start_bound_int<char8_t>,
+        test_misordered_start_bound_int<char8_t>,
 #endif // __cpp_char8_t
-            test_misordered_start_bound_int<char16_t>, test_misordered_start_bound_int<char32_t>,
-            test_misordered_start_bound_int<wchar_t>,
+        test_misordered_start_bound_int<char16_t>,
+        test_misordered_start_bound_int<char32_t>,
+        test_misordered_start_bound_int<wchar_t>,
 
-            test_misordered_start_bound_uint_value_init<unsigned char>,
-            test_misordered_start_bound_uint_value_init<unsigned short>,
-            test_misordered_start_bound_uint_value_init<unsigned int>,
-            test_misordered_start_bound_uint_value_init<unsigned long>,
-            test_misordered_start_bound_uint_value_init<unsigned long long>,
-            test_misordered_start_bound_uint_value_init<unsigned long long>,
+        test_misordered_start_bound_uint_value_init<unsigned char>,
+        test_misordered_start_bound_uint_value_init<unsigned short>,
+        test_misordered_start_bound_uint_value_init<unsigned int>,
+        test_misordered_start_bound_uint_value_init<unsigned long>,
+        test_misordered_start_bound_uint_value_init<unsigned long long>,
+        test_misordered_start_bound_uint_value_init<unsigned long long>,
 #ifdef __cpp_char8_t
-            test_misordered_start_bound_uint_value_init<char8_t>,
+        test_misordered_start_bound_uint_value_init<char8_t>,
 #endif // __cpp_char8_t
-            test_misordered_start_bound_uint_value_init<char16_t>,
-            test_misordered_start_bound_uint_value_init<char32_t>, test_misordered_start_bound_uint_value_init<wchar_t>,
+        test_misordered_start_bound_uint_value_init<char16_t>,
+        test_misordered_start_bound_uint_value_init<char32_t>,
+        test_misordered_start_bound_uint_value_init<wchar_t>,
 
-            test_misordered_start_bound_ptr<char>, test_misordered_start_bound_ptr<int>,
-            test_misordered_start_bound_ptr<S>,
+        test_misordered_start_bound_ptr<char>,
+        test_misordered_start_bound_ptr<int>,
+        test_misordered_start_bound_ptr<S>,
     });
 #endif // _DEBUG
 

--- a/tests/std/tests/P0896R4_views_iota_death/test.cpp
+++ b/tests/std/tests/P0896R4_views_iota_death/test.cpp
@@ -25,6 +25,12 @@ void test_misordered_start_bound_ptr() {
     ranges::iota_view{arr + 1, arr + 0};
 }
 
+template <class T>
+void test_misordered_start_bound_vector_iter() {
+    std::vector<T> vec(1);
+    ranges::iota_view{vec.end(), vec.begin()};
+}
+
 int main(int argc, char* argv[]) {
     std_testing::death_test_executive exec;
 
@@ -67,6 +73,10 @@ int main(int argc, char* argv[]) {
         test_misordered_start_bound_ptr<char>,
         test_misordered_start_bound_ptr<int>,
         test_misordered_start_bound_ptr<S>,
+
+        test_misordered_start_bound_vector_iter<char>,
+        test_misordered_start_bound_vector_iter<int>,
+        test_misordered_start_bound_vector_iter<S>,
     });
 #endif // _DEBUG
 

--- a/tests/std/tests/P0896R4_views_iota_death/test.cpp
+++ b/tests/std/tests/P0896R4_views_iota_death/test.cpp
@@ -30,6 +30,7 @@ void test_misordered_start_bound_ptr() {
 int main(int argc, char* argv[]) {
     std_testing::death_test_executive exec;
 
+#ifdef _DEBUG
     struct S {};
 
     exec.add_death_tests({
@@ -61,6 +62,7 @@ int main(int argc, char* argv[]) {
             test_misordered_start_bound_ptr<char>, test_misordered_start_bound_ptr<int>,
             test_misordered_start_bound_ptr<S>,
     });
+#endif // _DEBUG
 
     return exec.run(argc, argv);
 }

--- a/tests/std/tests/P0896R4_views_iota_death/test.cpp
+++ b/tests/std/tests/P0896R4_views_iota_death/test.cpp
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#define _CONTAINER_DEBUG_LEVEL 1
+
+#include <cassert>
+#include <cstddef>
+#include <ranges>
+#include <vector>
+
+#include <test_death.hpp>
+using namespace std;
+
+template <class I>
+void test_misordered_start_bound_int() {
+    ranges::iota_view{I{42}, I{1}};
+}
+
+template <class UI>
+void test_misordered_start_bound_uint_value_init() {
+    ranges::iota_view<UI, UI>{UI{42}};
+}
+
+template <class T>
+void test_misordered_start_bound_ptr() {
+    T arr[1]{};
+    ranges::iota_view{arr + 1, arr + 0};
+}
+
+int main(int argc, char* argv[]) {
+    std_testing::death_test_executive exec;
+
+    struct S {};
+
+    exec.add_death_tests({
+        test_misordered_start_bound_int<signed char>, test_misordered_start_bound_int<unsigned char>,
+            test_misordered_start_bound_int<short>, test_misordered_start_bound_int<unsigned short>,
+            test_misordered_start_bound_int<int>, test_misordered_start_bound_int<unsigned int>,
+            test_misordered_start_bound_int<long>, test_misordered_start_bound_int<unsigned long>,
+            test_misordered_start_bound_int<long long>, test_misordered_start_bound_int<unsigned long long>,
+
+            test_misordered_start_bound_int<char>,
+#if __cpp_char8_t
+            test_misordered_start_bound_int<char8_t>,
+#endif // __cpp_char8_t
+            test_misordered_start_bound_int<char16_t>, test_misordered_start_bound_int<char32_t>,
+            test_misordered_start_bound_int<wchar_t>,
+
+            test_misordered_start_bound_uint_value_init<unsigned char>,
+            test_misordered_start_bound_uint_value_init<unsigned short>,
+            test_misordered_start_bound_uint_value_init<unsigned int>,
+            test_misordered_start_bound_uint_value_init<unsigned long>,
+            test_misordered_start_bound_uint_value_init<unsigned long long>,
+            test_misordered_start_bound_uint_value_init<unsigned long long>,
+#if __cpp_char8_t
+            test_misordered_start_bound_uint_value_init<char8_t>,
+#endif // __cpp_char8_t
+            test_misordered_start_bound_uint_value_init<char16_t>,
+            test_misordered_start_bound_uint_value_init<char32_t>, test_misordered_start_bound_uint_value_init<wchar_t>,
+
+            test_misordered_start_bound_ptr<char>, test_misordered_start_bound_ptr<int>,
+            test_misordered_start_bound_ptr<S>,
+    });
+
+    return exec.run(argc, argv);
+}

--- a/tests/std/tests/P0896R4_views_iota_death/test.cpp
+++ b/tests/std/tests/P0896R4_views_iota_death/test.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include <cassert>
-#include <cstddef>
 #include <ranges>
 #include <vector>
 
@@ -61,7 +59,6 @@ int main(int argc, char* argv[]) {
         test_misordered_start_bound_uint_value_init<unsigned short>,
         test_misordered_start_bound_uint_value_init<unsigned int>,
         test_misordered_start_bound_uint_value_init<unsigned long>,
-        test_misordered_start_bound_uint_value_init<unsigned long long>,
         test_misordered_start_bound_uint_value_init<unsigned long long>,
 #ifdef __cpp_char8_t
         test_misordered_start_bound_uint_value_init<char8_t>,

--- a/tests/std/tests/P0896R4_views_iota_death/test.cpp
+++ b/tests/std/tests/P0896R4_views_iota_death/test.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#define _CONTAINER_DEBUG_LEVEL 1
-
 #include <cassert>
 #include <cstddef>
 #include <ranges>
@@ -41,7 +39,7 @@ int main(int argc, char* argv[]) {
             test_misordered_start_bound_int<long long>, test_misordered_start_bound_int<unsigned long long>,
 
             test_misordered_start_bound_int<char>,
-#if __cpp_char8_t
+#ifdef __cpp_char8_t
             test_misordered_start_bound_int<char8_t>,
 #endif // __cpp_char8_t
             test_misordered_start_bound_int<char16_t>, test_misordered_start_bound_int<char32_t>,
@@ -53,7 +51,7 @@ int main(int argc, char* argv[]) {
             test_misordered_start_bound_uint_value_init<unsigned long>,
             test_misordered_start_bound_uint_value_init<unsigned long long>,
             test_misordered_start_bound_uint_value_init<unsigned long long>,
-#if __cpp_char8_t
+#ifdef __cpp_char8_t
             test_misordered_start_bound_uint_value_init<char8_t>,
 #endif // __cpp_char8_t
             test_misordered_start_bound_uint_value_init<char16_t>,


### PR DESCRIPTION
And add death test for `iota_view`.