### PR TITLE
`<ranges>`: Fix `cartesian_product_view::size` in debug mode

### DIFF
--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -10061,11 +10061,14 @@ namespace ranges {
         {
             return [&]<size_t... _Indices>(index_sequence<_Indices...>) {
 #if _CONTAINER_DEBUG_LEVEL > 0
+                const array _Sizes   = {static_cast<_Size_type<false>>(_RANGES size(_STD get<_Indices>(_Bases)))...};
+                const bool _Any_zero = ((_Sizes[_Indices] == 0) || ...);
+                if (_Any_zero) {
+                    return _Size_type<false>{0};
+                }
+
                 _Size_type<false> _Product{1};
-                const bool _Overflow =
-                    (_Mul_overflow(
-                         _Product, static_cast<_Size_type<false>>(_RANGES size(_STD get<_Indices>(_Bases))), _Product)
-                        || ...);
+                const bool _Overflow = (_Mul_overflow(_Product, _Sizes[_Indices], _Product) || ...);
                 _STL_VERIFY(!_Overflow, "Size of cartesian product cannot be represented by size type (N4950 "
                                         "[range.cartesian.view]/10).");
                 return _Product;
@@ -10080,11 +10083,14 @@ namespace ranges {
         {
             return [&]<size_t... _Indices>(index_sequence<_Indices...>) {
 #if _CONTAINER_DEBUG_LEVEL > 0
+                const array _Sizes   = {static_cast<_Size_type<true>>(_RANGES size(_STD get<_Indices>(_Bases)))...};
+                const bool _Any_zero = ((_Sizes[_Indices] == 0) || ...);
+                if (_Any_zero) {
+                    return _Size_type<true>{0};
+                }
+
                 _Size_type<true> _Product{1};
-                const bool _Overflow =
-                    (_Mul_overflow(
-                         _Product, static_cast<_Size_type<true>>(_RANGES size(_STD get<_Indices>(_Bases))), _Product)
-                        || ...);
+                const bool _Overflow = (_Mul_overflow(_Product, _Sizes[_Indices], _Product) || ...);
                 _STL_VERIFY(!_Overflow, "Size of cartesian product cannot be represented by size type (N4950 "
                                         "[range.cartesian.view]/10).");
                 return _Product;

--- a/tests/std/tests/P2374R4_views_cartesian_product/test.cpp
+++ b/tests/std/tests/P2374R4_views_cartesian_product/test.cpp
@@ -973,6 +973,8 @@ namespace check_recommended_practice_implementation { // MSVC STL specific behav
     STATIC_ASSERT(sizeof(range_difference_t<cartesian_product_view<all_t<Vec>, all_t<Vec>>>) > sizeof(ptrdiff_t));
 } // namespace check_recommended_practice_implementation
 
+// GH-3733: cartesian_product_view would incorrectly reject a call to size() claiming that big*big*big*0 is not
+// representable as range_size_t because big*big*big is not.
 constexpr void test_gh_3733() {
     const auto r1   = views::repeat(0, (numeric_limits<ptrdiff_t>::max)());
     const auto r2   = views::repeat(1, 0);

--- a/tests/std/tests/P2374R4_views_cartesian_product/test.cpp
+++ b/tests/std/tests/P2374R4_views_cartesian_product/test.cpp
@@ -973,7 +973,7 @@ namespace check_recommended_practice_implementation { // MSVC STL specific behav
     STATIC_ASSERT(sizeof(range_difference_t<cartesian_product_view<all_t<Vec>, all_t<Vec>>>) > sizeof(ptrdiff_t));
 } // namespace check_recommended_practice_implementation
 
-constexpr void test_gh_NNNN() {
+constexpr void test_gh_3733() {
     const auto r1   = views::repeat(0, (numeric_limits<ptrdiff_t>::max)());
     const auto r2   = views::repeat(1, 0);
     const auto cart = views::cartesian_product(r1, r1, r1, r2);
@@ -1038,6 +1038,6 @@ int main() {
 #endif // TRANSITION, GH-1030
     instantiation_test();
 
-    STATIC_ASSERT((test_gh_NNNN(), true));
-    test_gh_NNNN();
+    STATIC_ASSERT((test_gh_3733(), true));
+    test_gh_3733();
 }

--- a/tests/std/tests/P2374R4_views_cartesian_product/test.cpp
+++ b/tests/std/tests/P2374R4_views_cartesian_product/test.cpp
@@ -973,6 +973,14 @@ namespace check_recommended_practice_implementation { // MSVC STL specific behav
     STATIC_ASSERT(sizeof(range_difference_t<cartesian_product_view<all_t<Vec>, all_t<Vec>>>) > sizeof(ptrdiff_t));
 } // namespace check_recommended_practice_implementation
 
+constexpr void test_gh_NNNN() {
+    const auto r1   = views::repeat(0, (numeric_limits<ptrdiff_t>::max)());
+    const auto r2   = views::repeat(1, 0);
+    const auto cart = views::cartesian_product(r1, r1, r1, r2);
+    assert(cart.size() == 0);
+    assert(as_const(cart).size() == 0);
+}
+
 int main() {
     // Check views
     { // ... copyable
@@ -1029,4 +1037,7 @@ int main() {
     STATIC_ASSERT((instantiation_test(), true));
 #endif // TRANSITION, GH-1030
     instantiation_test();
+
+    STATIC_ASSERT((test_gh_NNNN(), true));
+    test_gh_NNNN();
 }


### PR DESCRIPTION
Per [[range.cartesian.view]/9-10](http://eel.is/c++draft/range.cartesian.view):
> Let *p* be the product of the sizes of all the ranges in bases_.
> *Preconditions*: *p* can be represented by the return type.

Currently `cartesian_product_view::size` may fail when *p* can be represented by return type:
```c++
#include <ranges>

using namespace std;

int main() {
  const auto r1 = views::repeat(0, (numeric_limits<ptrdiff_t>::max)());
  const auto r2 = views::repeat(1, 0);
  (void)views::cartesian_product(r1, r1, r1, r2).size(); // FAIL!
}
```

Obviously `0` can be represented by any unsigned integral type. This PR fixes this bug.