### PR TITLE
Fix static analysis warnings

### DIFF
--- a/stl/inc/charconv
+++ b/stl/inc/charconv
@@ -395,7 +395,11 @@ _EXPORT_STD _CONSTEXPR23 from_chars_result from_chars(const char* const _First, 
 // - Otherwise, no initialization is performed."
 // Therefore, _Mydata's elements are not initialized.
 struct _Big_integer_flt {
+#pragma warning(push)
+#pragma warning(disable : 26495) // Variable 'std::_Big_integer_flt::_Mydata' is uninitialized.
+                                 // Always initialize a member variable (type.6).
     _Big_integer_flt() noexcept : _Myused(0) {}
+#pragma warning(pop)
 
     _Big_integer_flt(const _Big_integer_flt& _Other) noexcept : _Myused(_Other._Myused) {
         _CSTD memcpy(_Mydata, _Other._Mydata, _Other._Myused * sizeof(uint32_t));

--- a/stl/inc/charconv
+++ b/stl/inc/charconv
@@ -1024,7 +1024,10 @@ _NODISCARD inline uint64_t _Right_shift_with_rounding(
     constexpr uint32_t _Total_number_of_bits = 64;
     if (_Shift >= _Total_number_of_bits) {
         if (_Shift == _Total_number_of_bits) {
+#pragma warning(push)
+#pragma warning(disable : 26454) // TRANSITION, VSO-1826196
             constexpr uint64_t _Extra_bits_mask = (1ULL << (_Total_number_of_bits - 1)) - 1;
+#pragma warning(pop)
             constexpr uint64_t _Round_bit_mask  = (1ULL << (_Total_number_of_bits - 1));
 
             const bool _Round_bit = (_Value & _Round_bit_mask) != 0;

--- a/stl/inc/exception
+++ b/stl/inc/exception
@@ -305,8 +305,8 @@ private:
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-private-field"
 #endif // __clang__
-    void* _Data1;
-    void* _Data2;
+    void* _Data1{};
+    void* _Data2{};
 #ifdef __clang__
 #pragma clang diagnostic pop
 #endif // __clang__

--- a/stl/inc/format
+++ b/stl/inc/format
@@ -1892,8 +1892,8 @@ struct _Format_arg_index {
         _Type_ = static_cast<size_t>(_Val);
     }
 
-    size_t _Index : (sizeof(size_t) * 8 - 4);
-    size_t _Type_ : 4;
+    size_t _Index : (sizeof(size_t) * 8 - 4){};
+    size_t _Type_ : 4 {};
 };
 
 _EXPORT_STD template <class _Context>

--- a/stl/inc/future
+++ b/stl/inc/future
@@ -205,8 +205,8 @@ public:
     // TRANSITION, incorrectly default constructs _Result when _Ty is default constructible
     _Associated_state(_Mydel* _Dp = nullptr)
         : _Refs(1), // non-atomic initialization
-          _Exception(), _Retrieved(false), _Ready(false), _Ready_at_thread_exit(false), _Has_stored_result(false),
-          _Running(false), _Deleter(_Dp) {}
+          _Result(), _Exception(), _Retrieved(false), _Ready(false), _Ready_at_thread_exit(false),
+          _Has_stored_result(false), _Running(false), _Deleter(_Dp) {}
 
     virtual ~_Associated_state() noexcept {
         if (_Already_has_stored_result() && !_Ready) { // registered for release at thread exit
@@ -409,7 +409,7 @@ protected:
     }
 
 public:
-    conditional_t<is_default_constructible_v<_Ty>, _Ty, _Result_holder<_Ty>> _Result{};
+    conditional_t<is_default_constructible_v<_Ty>, _Ty, _Result_holder<_Ty>> _Result;
     exception_ptr _Exception;
     mutex _Mtx;
     condition_variable _Cond;

--- a/stl/inc/future
+++ b/stl/inc/future
@@ -409,7 +409,7 @@ protected:
     }
 
 public:
-    conditional_t<is_default_constructible_v<_Ty>, _Ty, _Result_holder<_Ty>> _Result;
+    conditional_t<is_default_constructible_v<_Ty>, _Ty, _Result_holder<_Ty>> _Result{};
     exception_ptr _Exception;
     mutex _Mtx;
     condition_variable _Cond;

--- a/stl/inc/ios
+++ b/stl/inc/ios
@@ -161,9 +161,9 @@ protected:
     __CLR_OR_THIS_CALL basic_ios() {}
 
 private:
-    _Mysb* _Mystrbuf; // pointer to stream buffer
-    _Myos* _Tiestr; // pointer to tied output stream
-    _Elem _Fillch; // the fill character
+    _Mysb* _Mystrbuf{}; // pointer to stream buffer
+    _Myos* _Tiestr{}; // pointer to tied output stream
+    _Elem _Fillch{}; // the fill character
 
 public:
     __CLR_OR_THIS_CALL basic_ios(const basic_ios&)            = delete;

--- a/stl/inc/istream
+++ b/stl/inc/istream
@@ -686,7 +686,7 @@ public:
     }
 
 private:
-    streamsize _Chcount; // the character count
+    streamsize _Chcount{}; // the character count
 };
 
 #pragma vtordisp(pop) // compiler bug workaround

--- a/stl/inc/istream
+++ b/stl/inc/istream
@@ -48,7 +48,7 @@ public:
     }
 
 protected:
-    __CLR_OR_THIS_CALL basic_istream(basic_istream&& _Right) : _Chcount(_Right._Chcount) {
+    __CLR_OR_THIS_CALL basic_istream(basic_istream&& _Right) noexcept(false) : _Chcount(_Right._Chcount) {
         _Myios::init();
         _Myios::move(_STD move(_Right));
         _Right._Chcount = 0;
@@ -739,7 +739,8 @@ public:
         : _Myis(_Strbuf, false), _Myos(_Noinit, false) {}
 
 protected:
-    __CLR_OR_THIS_CALL basic_iostream(basic_iostream&& _Right) : _Myis(_Right.rdbuf(), false), _Myos(_Noinit, false) {
+    __CLR_OR_THIS_CALL basic_iostream(basic_iostream&& _Right) noexcept(false)
+        : _Myis(_Right.rdbuf(), false), _Myos(_Noinit, false) {
         _Myios::init();
         _Myios::move(_STD move(_Right));
     }

--- a/stl/inc/list
+++ b/stl/inc/list
@@ -896,7 +896,7 @@ public:
     }
 #endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 
-    list(list&& _Right) : _Mypair(_One_then_variadic_args_t{}, _STD move(_Right._Getal())) {
+    list(list&& _Right) noexcept(false) : _Mypair(_One_then_variadic_args_t{}, _STD move(_Right._Getal())) {
         _Alloc_sentinel_and_proxy();
         _Swap_val(_Right);
     }

--- a/stl/inc/list
+++ b/stl/inc/list
@@ -745,8 +745,8 @@ struct _List_node_insert_op2 {
 private:
     _Alnode& _Al;
     size_type _Added; // if 0, the values of _Head and _Tail are indeterminate
-    pointer _Tail; // points to the most recently appended element; it doesn't have _Next constructed
-    pointer _Head; // points to the first appended element; it doesn't have _Prev constructed
+    pointer _Tail{}; // points to the most recently appended element; it doesn't have _Next constructed
+    pointer _Head{}; // points to the first appended element; it doesn't have _Prev constructed
 };
 
 template <class _Traits>

--- a/stl/inc/ostream
+++ b/stl/inc/ostream
@@ -45,7 +45,7 @@ public:
     }
 
 protected:
-    __CLR_OR_THIS_CALL basic_ostream(basic_ostream&& _Right) {
+    __CLR_OR_THIS_CALL basic_ostream(basic_ostream&& _Right) noexcept(false) {
         _Myios::init();
         _Myios::move(_STD move(_Right));
     }

--- a/stl/inc/regex
+++ b/stl/inc/regex
@@ -1367,7 +1367,7 @@ public:
         static_assert(sizeof(_Refs) == sizeof(_Atomic_counter_t), "invalid _Refs size");
     }
 
-    regex_constants::syntax_option_type _Fl;
+    regex_constants::syntax_option_type _Fl{};
     unsigned int _Loops;
     unsigned int _Marks;
     unsigned int _Refs;

--- a/stl/inc/streambuf
+++ b/stl/inc/streambuf
@@ -381,22 +381,22 @@ protected:
     virtual void __CLR_OR_THIS_CALL imbue(const locale&) {} // set locale to argument (do nothing)
 
 private:
-    _Elem* _Gfirst; // beginning of read buffer
-    _Elem* _Pfirst; // beginning of write buffer
-    _Elem** _IGfirst; // pointer to beginning of read buffer
-    _Elem** _IPfirst; // pointer to beginning of write buffer
-    _Elem* _Gnext; // current position in read buffer
-    _Elem* _Pnext; // current position in write buffer
-    _Elem** _IGnext; // pointer to current position in read buffer
-    _Elem** _IPnext; // pointer to current position in write buffer
+    _Elem* _Gfirst{}; // beginning of read buffer
+    _Elem* _Pfirst{}; // beginning of write buffer
+    _Elem** _IGfirst{}; // pointer to beginning of read buffer
+    _Elem** _IPfirst{}; // pointer to beginning of write buffer
+    _Elem* _Gnext{}; // current position in read buffer
+    _Elem* _Pnext{}; // current position in write buffer
+    _Elem** _IGnext{}; // pointer to current position in read buffer
+    _Elem** _IPnext{}; // pointer to current position in write buffer
 
-    int _Gcount; // length of read buffer
-    int _Pcount; // length of write buffer
-    int* _IGcount; // pointer to length of read buffer
-    int* _IPcount; // pointer to length of write buffer
+    int _Gcount{}; // length of read buffer
+    int _Pcount{}; // length of write buffer
+    int* _IGcount{}; // pointer to length of read buffer
+    int* _IPcount{}; // pointer to length of write buffer
 
 protected:
-    locale* _Plocale; // pointer to imbued locale object
+    locale* _Plocale{}; // pointer to imbued locale object
 };
 
 #if defined(_DLL_CPPLIB)

--- a/stl/inc/xiosbase
+++ b/stl/inc/xiosbase
@@ -468,11 +468,11 @@ private:
         _Calls = nullptr;
     }
 
-    iostate _Mystate; // stream state
-    iostate _Except; // exception mask
-    fmtflags _Fmtfl; // format flags
-    streamsize _Prec; // field precision
-    streamsize _Wide; // field width
+    iostate _Mystate{}; // stream state
+    iostate _Except{}; // exception mask
+    fmtflags _Fmtfl{}; // format flags
+    streamsize _Prec{}; // field precision
+    streamsize _Wide{}; // field width
     _Iosarray* _Arr{nullptr}; // pointer to first node of long/pointer array
     _Fnarray* _Calls{nullptr}; // pointer to first node of call list
     locale* _Ploc{nullptr}; // pointer to locale

--- a/stl/inc/xlocale
+++ b/stl/inc/xlocale
@@ -407,7 +407,7 @@ private:
         return _CSTD strcmp(_Lobj._Getname(), "*") == 0;
     }
 
-    _Locimp* _Ptr{}; // pointer to locale implementation object
+    _Locimp* _Ptr; // pointer to locale implementation object
 };
 
 template <class _Facet>

--- a/stl/inc/xlocale
+++ b/stl/inc/xlocale
@@ -407,7 +407,7 @@ private:
         return _CSTD strcmp(_Lobj._Getname(), "*") == 0;
     }
 
-    _Locimp* _Ptr; // pointer to locale implementation object
+    _Locimp* _Ptr{}; // pointer to locale implementation object
 };
 
 template <class _Facet>

--- a/stl/src/atomic.cpp
+++ b/stl/src/atomic.cpp
@@ -18,6 +18,7 @@ _CRTIMP2_PURE void __cdecl _Lock_shared_ptr_spin_lock() { // TRANSITION, ABI: "s
 }
 
 _CRTIMP2_PURE void __cdecl _Unlock_shared_ptr_spin_lock() { // release previously obtained lock
+    _Analysis_assume_lock_held_(_Shared_ptr_lock);
     ReleaseSRWLockExclusive(&_Shared_ptr_lock);
 }
 

--- a/stl/src/excptptr.cpp
+++ b/stl/src/excptptr.cpp
@@ -300,7 +300,7 @@ namespace {
         }
 
         _EXCEPTION_RECORD _ExRecord;
-        void* _Unused_alignment_padding;
+        void* _Unused_alignment_padding{};
     };
 
     // We aren't using alignas because this file might be compiled with _M_CEE_PURE

--- a/stl/src/ppltasks.cpp
+++ b/stl/src/ppltasks.cpp
@@ -27,8 +27,9 @@ static GUID const Local_IID_ICallbackWithNoReentrancyToApplicationSTA = {
 
 // Introduce stacktrace API for Debug CRT_APP
 #if defined(_CRT_APP) && defined(_DEBUG)
-extern "C" NTSYSAPI WORD NTAPI RtlCaptureStackBackTrace(_In_ DWORD FramesToSkip, _In_ DWORD FramesToCapture,
-    _Out_writes_to_(FramesToCapture, return) PVOID* BackTrace, _Out_opt_ PDWORD BackTraceHash);
+extern "C" NTSYSAPI _Success_(return != 0) WORD NTAPI
+    RtlCaptureStackBackTrace(_In_ DWORD FramesToSkip, _In_ DWORD FramesToCapture,
+        _Out_writes_to_(FramesToCapture, return) PVOID* BackTrace, _Out_opt_ PDWORD BackTraceHash);
 #endif
 
 namespace Concurrency {

--- a/stl/src/primitives.hpp
+++ b/stl/src/primitives.hpp
@@ -52,6 +52,7 @@ namespace Concurrency {
             }
 
             void unlock() override {
+                _Analysis_assume_lock_held_(m_srw_lock);
                 ReleaseSRWLockExclusive(&m_srw_lock);
             }
 

--- a/stl/src/sharedmutex.cpp
+++ b/stl/src/sharedmutex.cpp
@@ -29,6 +29,7 @@ int __cdecl _Smtx_try_lock_shared(_Smtx_t* smtx) { // try to lock shared mutex n
 }
 
 void __cdecl _Smtx_unlock_exclusive(_Smtx_t* smtx) { // unlock exclusive shared mutex
+    _Analysis_assume_lock_held_(*reinterpret_cast<PSRWLOCK>(smtx));
     ReleaseSRWLockExclusive(reinterpret_cast<PSRWLOCK>(smtx));
 }
 

--- a/stl/src/winapisupp.cpp
+++ b/stl/src/winapisupp.cpp
@@ -325,6 +325,7 @@ extern "C" VOID __cdecl __crtAcquireSRWLockExclusive(_Inout_ PSRWLOCK const pLoc
 
 // TRANSITION, ABI: preserved for binary compatibility
 extern "C" VOID __cdecl __crtReleaseSRWLockExclusive(_Inout_ PSRWLOCK const pLock) {
+    _Analysis_assume_lock_held_(*pLock);
     ReleaseSRWLockExclusive(pLock);
 }
 

--- a/stl/src/xstol.cpp
+++ b/stl/src/xstol.cpp
@@ -36,8 +36,7 @@ _CRTIMP2_PURE long __CLRCALL_PURE_OR_CDECL _Stolx(
         *endptr = const_cast<char*>(s);
     }
 
-    if (s == *endptr && x != 0 || sign == '+' && LONG_MAX < x
-        || sign == '-' && 0 - static_cast<unsigned long>(LONG_MIN) < x) { // overflow
+    if (s == *endptr && x != 0 || sign == '+' && LONG_MAX < x || sign == '-' && (1ul << 31) < x) { // overflow
         errno = ERANGE;
         if (perr != nullptr) {
             *perr = 1;

--- a/stl/src/xstoll.cpp
+++ b/stl/src/xstoll.cpp
@@ -36,8 +36,7 @@ _CRTIMP2_PURE long long __CLRCALL_PURE_OR_CDECL _Stollx(
         *endptr = const_cast<char*>(s);
     }
 
-    if (s == *endptr && x != 0 || sign == '+' && LLONG_MAX < x
-        || sign == '-' && 0 - static_cast<unsigned long long>(LLONG_MIN) < x) { // overflow
+    if (s == *endptr && x != 0 || sign == '+' && LLONG_MAX < x || sign == '-' && (1ull << 63) < x) { // overflow
         errno = ERANGE;
         if (perr != nullptr) {
             *perr = 1;


### PR DESCRIPTION
The MSVC-internal repo is making another push to enable and clean up static analysis warnings in the build. The STL was previously unaffected as we've built our tests with plain `/analyze` for 3000 years, but now additional rulesets are being enabled and the STL is emitting warnings.

* Add empty braces to fix warning C26495 "Variable 'MEOW' is uninitialized. Always initialize a member variable (type.6)."
  + This is safe because Zero Is A Strict Subset Of Garbage.
* Permanently silence warning C26495 (uninitialized member variable) for `_Big_integer_flt::_Mydata`.
  + As the big comment explains, leaving this uninitialized is important for performance.
* Fix warning C28252 "Inconsistent annotation for `'RtlCaptureStackBackTrace'`: return/function has `'SAL_success(return!=0)'` on the prior instance. See `[...]\winnt.h(20721)`."
  + The return annotation was indeed missing.
* Fix warning C26439 "This kind of function should not throw. Declare it `'noexcept'` (f.6)."
  + Add `noexcept(false)` because these move ctors call `basic_ios::init()` => `ios_base::_Init()` => `new locale`.
  + `list` dynamically allocates a sentinel node.
* Fix warning C26450 "Arithmetic overflow: `'-'` operation causes overflow at compile time. Use a wider type to store the operands (io.1)." and warning C26454 "Arithmetic overflow: `'-'` operation produces a negative unsigned result at compile time (io.5)."
  + We can avoid these warnings by directly forming the values, which is also easier to read.
    ```
    C:\Temp>type meow.cpp
    ```
    ```cpp
    #include <climits>
    #include <iostream>
    using namespace std;
    
    static_assert((1ul << 31) == 0 - static_cast<unsigned long>(LONG_MIN));
    static_assert((1ull << 63) == 0 - static_cast<unsigned long long>(LLONG_MIN));
    
    int main() {
        cout << 0 - static_cast<unsigned long>(LONG_MIN) << endl;
        cout << (1ul << 31) << endl;
    
        cout << 0 - static_cast<unsigned long long>(LLONG_MIN) << endl;
        cout << (1ull << 63) << endl;
    }
    ```
    ```
    C:\Temp>cl /EHsc /nologo /W4 meow.cpp && meow
    meow.cpp
    2147483648
    2147483648
    9223372036854775808
    9223372036854775808
    ```
* Silence warning C26110 "Caller failing to hold lock 'MEOW' before calling function `'ReleaseSRWLockExclusive'`."
  + We're implementing lock machinery, so we have to assume that the lock is held here.
* In `<charconv>`, work around VSO-1826196 "False positive C26454 in charconv". This has already been fixed in the latest compiler sources, we just need to wait for the MSVC-internal toolset to be updated. Thanks to @dmitrykobets-msft for investigating this.