### PR TITLE
Implement LWG-3843 `std::expected<T,E>::value() &` assumes `E` is copy constructible

### DIFF
--- a/stl/inc/expected
+++ b/stl/inc/expected
@@ -636,6 +636,12 @@ public:
         _Throw_bad_expected_access_lv();
     }
     _NODISCARD constexpr const _Ty&& value() const&& {
+        // TRANSITION, DevCom-1638273 and LLVM-53224
+        static_assert(
+            is_copy_constructible_v<_Err>, "is_copy_constructible_v<E> must be true. N4950 [expected.object.obs]/11");
+        static_assert(is_move_constructible_v<_Err>,
+            "is_constructible_v<E, const E&&> must be true. N4950 [expected.object.obs]/11");
+
         if (_Has_value) {
             return _STD move(_Value);
         }
@@ -643,6 +649,12 @@ public:
         _Throw_bad_expected_access_rv();
     }
     _NODISCARD constexpr _Ty&& value() && {
+        // TRANSITION, DevCom-1638273 and LLVM-53224
+        static_assert(
+            is_copy_constructible_v<_Err>, "is_copy_constructible_v<E> must be true. N4950 [expected.object.obs]/11");
+        static_assert(
+            is_move_constructible_v<_Err>, "is_constructible_v<E, E&&> must be true. N4950 [expected.object.obs]/11");
+
         if (_Has_value) {
             return _STD move(_Value);
         }
@@ -1133,9 +1145,6 @@ private:
     [[noreturn]] void _Throw_bad_expected_access_lv() const {
         _THROW(bad_expected_access{_Unexpected});
     }
-    [[noreturn]] void _Throw_bad_expected_access_lv() {
-        _THROW(bad_expected_access{_Unexpected});
-    }
     [[noreturn]] void _Throw_bad_expected_access_rv() const {
         _THROW(bad_expected_access{_STD move(_Unexpected)});
     }
@@ -1414,6 +1423,11 @@ public:
         }
     }
     constexpr void value() && {
+        // per LWG issue unnumbered as of 2023-05-26
+        // TRANSITION, DevCom-1638273 and LLVM-53224
+        static_assert(is_copy_constructible_v<_Err>, "is_copy_constructible_v<E> must be true");
+        static_assert(is_move_constructible_v<_Err>, "is_move_constructible_v<E> must be true");
+
         if (!_Has_value) {
             _Throw_bad_expected_access_rv();
         }

--- a/stl/inc/expected
+++ b/stl/inc/expected
@@ -639,7 +639,7 @@ public:
         // TRANSITION, DevCom-1638273 and LLVM-53224
         static_assert(
             is_copy_constructible_v<_Err>, "is_copy_constructible_v<E> must be true. N4950 [expected.object.obs]/11");
-        static_assert(is_move_constructible_v<_Err>,
+        static_assert(is_constructible_v<_Err, const _Err&&>,
             "is_constructible_v<E, const E&&> must be true. N4950 [expected.object.obs]/11");
 
         if (_Has_value) {

--- a/stl/inc/expected
+++ b/stl/inc/expected
@@ -1423,7 +1423,7 @@ public:
         }
     }
     constexpr void value() && {
-        // per LWG issue unnumbered as of 2023-05-26
+        // per LWG-3940
         // TRANSITION, DevCom-1638273 and LLVM-53224
         static_assert(is_copy_constructible_v<_Err>, "is_copy_constructible_v<E> must be true");
         static_assert(is_move_constructible_v<_Err>, "is_move_constructible_v<E> must be true");

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -152,6 +152,9 @@ std/utilities/memory/specialized.algorithms/uninitialized.fill.n/ranges_uninitia
 std/utilities/memory/specialized.algorithms/uninitialized.move/ranges_uninitialized_move.pass.cpp FAIL
 std/utilities/memory/specialized.algorithms/uninitialized.move/ranges_uninitialized_move_n.pass.cpp FAIL
 
+# libc++ doesn't implement LWG-3843
+std/utilities/expected/expected.expected/observers/value.pass.cpp
+
 # libc++ doesn't implement P1957R2 "Converting from `T*` to `bool` should be considered narrowing"
 std/utilities/variant/variant.variant/variant.assign/conv.pass.cpp FAIL
 std/utilities/variant/variant.variant/variant.assign/T.pass.cpp FAIL

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -153,7 +153,7 @@ std/utilities/memory/specialized.algorithms/uninitialized.move/ranges_uninitiali
 std/utilities/memory/specialized.algorithms/uninitialized.move/ranges_uninitialized_move_n.pass.cpp FAIL
 
 # libc++ doesn't implement LWG-3843
-std/utilities/expected/expected.expected/observers/value.pass.cpp
+std/utilities/expected/expected.expected/observers/value.pass.cpp FAIL
 
 # libc++ doesn't implement P1957R2 "Converting from `T*` to `bool` should be considered narrowing"
 std/utilities/variant/variant.variant/variant.assign/conv.pass.cpp FAIL

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -131,6 +131,9 @@ std/ranges/range.factories/range.iota.view/iterator/member_typedefs.compile.pass
 # libc++ doesn't implement LWG-3836
 std/utilities/expected/expected.expected/ctor/ctor.u.pass.cpp FAIL
 
+# libc++ doesn't implement LWG-3843
+std/utilities/expected/expected.expected/observers/value.pass.cpp FAIL
+
 # libc++ doesn't implement LWG-3857
 std/strings/string.view/string.view.cons/from_range.pass.cpp FAIL
 std/strings/string.view/string.view.cons/from_string1.compile.fail.cpp FAIL
@@ -152,8 +155,7 @@ std/utilities/memory/specialized.algorithms/uninitialized.fill.n/ranges_uninitia
 std/utilities/memory/specialized.algorithms/uninitialized.move/ranges_uninitialized_move.pass.cpp FAIL
 std/utilities/memory/specialized.algorithms/uninitialized.move/ranges_uninitialized_move_n.pass.cpp FAIL
 
-# libc++ doesn't implement LWG-3843
-std/utilities/expected/expected.expected/observers/value.pass.cpp FAIL
+# libc++ doesn't speculatively implement LWG-3940
 std/utilities/expected/expected.void/observers/value.pass.cpp FAIL
 
 # libc++ doesn't implement P1957R2 "Converting from `T*` to `bool` should be considered narrowing"

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -154,6 +154,7 @@ std/utilities/memory/specialized.algorithms/uninitialized.move/ranges_uninitiali
 
 # libc++ doesn't implement LWG-3843
 std/utilities/expected/expected.expected/observers/value.pass.cpp FAIL
+std/utilities/expected/expected.void/observers/value.pass.cpp FAIL
 
 # libc++ doesn't implement P1957R2 "Converting from `T*` to `bool` should be considered narrowing"
 std/utilities/variant/variant.variant/variant.assign/conv.pass.cpp FAIL

--- a/tests/std/tests/P0323R12_expected/test.cpp
+++ b/tests/std/tests/P0323R12_expected/test.cpp
@@ -2060,6 +2060,81 @@ struct Data {
 };
 static_assert(((void) expected<void, Data>{unexpect, {1, 2, 3}}, true));
 
+void test_lwg_3843() {
+    struct Indicator {
+        Indicator() = default;
+
+        Indicator(Indicator& other) noexcept : count(other.count + 256) {}
+        Indicator(const Indicator& other) noexcept : count(other.count + 1024) {}
+
+        Indicator(Indicator&& other) noexcept : count(other.count + 1) {}
+        Indicator(const Indicator&& other) noexcept : count(other.count + 16) {}
+
+        Indicator& operator=(const Indicator&) = default;
+        Indicator& operator=(Indicator&&)      = default;
+
+        int count = 0;
+    };
+
+    {
+        expected<int, Indicator> exv{unexpect};
+        assert(exv.error().count == 0);
+
+        try {
+            (void) exv.value();
+        } catch (const bad_expected_access<Indicator>& e) {
+            assert(e.error().count == 1025);
+        }
+
+        try {
+            (void) as_const(exv).value();
+        } catch (const bad_expected_access<Indicator>& e) {
+            assert(e.error().count == 1025);
+        }
+
+        try {
+            (void) move(exv).value();
+        } catch (const bad_expected_access<Indicator>& e) {
+            assert(e.error().count == 2);
+        }
+
+        try {
+            (void) move(as_const(exv)).value();
+        } catch (const bad_expected_access<Indicator>& e) {
+            assert(e.error().count == 17);
+        }
+    }
+
+    {
+        expected<void, Indicator> exv{unexpect};
+        assert(exv.error().count == 0);
+
+        try {
+            (void) exv.value();
+        } catch (const bad_expected_access<Indicator>& e) {
+            assert(e.error().count == 1025);
+        }
+
+        try {
+            (void) as_const(exv).value();
+        } catch (const bad_expected_access<Indicator>& e) {
+            assert(e.error().count == 1025);
+        }
+
+        try {
+            (void) move(exv).value();
+        } catch (const bad_expected_access<Indicator>& e) {
+            assert(e.error().count == 2);
+        }
+
+        try {
+            (void) move(as_const(exv)).value();
+        } catch (const bad_expected_access<Indicator>& e) {
+            assert(e.error().count == 1025);
+        }
+    }
+}
+
 int main() {
     test_unexpected::test_all();
     static_assert(test_unexpected::test_all());
@@ -2075,4 +2150,5 @@ int main() {
     static_assert(is_convertible_v<bad_expected_access<int>*, exception*>);
 
     test_reinit_regression();
+    test_lwg_3843();
 }


### PR DESCRIPTION
Per LWG-3843, `std::expected<int, std::unique_ptr<int>>{}.value()` needs to be rejected. But currently MSVC and Clang incorrectly accept it (DevCom-1638273 and LLVM-53224).

We also need to ensure that the `value() &` overload also treats `_Err` as a const lvalue on copy.

The mandating is missing in the standard wording in [[expected.void.obs]](https://eel.is/c++draft/expected.void.obs) currently, which is likely another LWG issue. I've mailed LWG chair for this.

Edit: the issue is now LWG-3940.