### PR TITLE
Silence 3 static analysis warnings

### DIFF
--- a/stl/inc/charconv
+++ b/stl/inc/charconv
@@ -253,7 +253,10 @@ _NODISCARD _CONSTEXPR23 from_chars_result _Integer_from_chars(
 
     constexpr _Unsigned _Uint_max    = static_cast<_Unsigned>(-1);
     constexpr _Unsigned _Int_max     = static_cast<_Unsigned>(_Uint_max >> 1);
+#pragma warning(push)
+#pragma warning(disable : 26450) // TRANSITION, VSO-1828677
     constexpr _Unsigned _Abs_int_min = static_cast<_Unsigned>(_Int_max + 1);
+#pragma warning(pop)
 
     _Unsigned _Risky_val;
     _Unsigned _Max_digit;

--- a/stl/inc/memory_resource
+++ b/stl/inc/memory_resource
@@ -704,7 +704,10 @@ namespace pmr {
         static constexpr size_t _Scale(const size_t _Size) noexcept {
             // scale _Size by 1.5, rounding up to a multiple of alignof(_Header), saturating to _Max_allocation
             // (keep synchronized with monotonic_buffer_resource::release)
+#pragma warning(push)
+#pragma warning(disable : 26450) // TRANSITION, VSO-1828677
             constexpr auto _Max_size = (_Max_allocation - alignof(_Header) + 1) / 3 * 2;
+#pragma warning(pop)
             if (_Size >= _Max_size) {
                 return _Max_allocation;
             }

--- a/stl/inc/xlocale
+++ b/stl/inc/xlocale
@@ -257,7 +257,17 @@ public:
         }
     }
 
+#pragma warning(push)
+#pragma warning(disable : 26495) // Variable 'std::locale::_Ptr' is uninitialized.
+                                 // Always initialize a member variable (type.6).
+
+    // _Ptr must remain uninitialized here.
+    // In locale0.cpp, locale::_Init() uses True Placement New at classic_locale's address,
+    // and classic_locale is constructed from the _Noinit enumerator of type _Uninitialized.
+    // The sequencing is highly unusual; the True Placement New happens before the _Uninitialized construction,
+    // so attempting to initialize _Ptr here will overwrite the result of the True Placement New.
     locale(_Uninitialized) {} // defer construction
+#pragma warning(pop)
 
     locale(const locale& _Right) noexcept : _Ptr(_Right._Ptr) {
         _Ptr->_Incref();

--- a/stl/inc/xlocale
+++ b/stl/inc/xlocale
@@ -261,11 +261,12 @@ public:
 #pragma warning(disable : 26495) // Variable 'std::locale::_Ptr' is uninitialized.
                                  // Always initialize a member variable (type.6).
 
-    // _Ptr must remain uninitialized here.
+    // We must not explicitly initialize _Ptr here; we rely on it maintaining the value
+    // previously created in its storage. To be precise:
     // In locale0.cpp, locale::_Init() uses True Placement New at classic_locale's address,
     // and classic_locale is constructed from the _Noinit enumerator of type _Uninitialized.
     // The sequencing is highly unusual; the True Placement New happens before the _Uninitialized construction,
-    // so attempting to initialize _Ptr here will overwrite the result of the True Placement New.
+    // so while _Ptr here formally has indeterminate value, we expect it to actually keep the previous value.
     locale(_Uninitialized) {} // defer construction
 #pragma warning(pop)
 


### PR DESCRIPTION
Followup to #3734.

I've filed a tracking bug VSO-1828677 "False positive warning C26450 (arithmetic overflow) in charconv and memory_resource" for the static analysis team to investigate, and @dmitrykobets-msft has added fully reduced repros there. Our code is correct, so we need to silence this warning until the compiler is fixed.

For `locale::_Ptr`, attempting to initialize it will break the STL catastrophically. I'm permanently suppressing the warning, with an explanation of the squirrelly :chipmunk: behavior involved. In theory, this is not ABI-sensitive since `classic_locale` is isolated to the locale0.cpp TU, but iostreams is extremely complicated and fragile and I am not eager to mess with this logic at this time unless absolutely forced to.