### PR TITLE
Add static for some `_Xxxx()` member functions

### DIFF
--- a/stl/inc/array
+++ b/stl/inc/array
@@ -570,11 +570,12 @@ public:
         return _Elems;
     }
 
-    [[noreturn]] void _Xran() const {
+    _Ty _Elems[_Size];
+    
+private:
+    [[noreturn]] static void _Xran() {
         _Xout_of_range("invalid array<T, N> subscript");
     }
-
-    _Ty _Elems[_Size];
 };
 
 #if _HAS_CXX17
@@ -758,13 +759,14 @@ public:
         return nullptr;
     }
 
-    [[noreturn]] void _Xran() const {
-        _Xout_of_range("invalid array<T, 0> subscript");
-    }
-
     conditional_t<disjunction_v<is_default_constructible<_Ty>, _Is_implicitly_default_constructible<_Ty>>, _Ty,
         _Empty_array_element>
         _Elems[1];
+
+private:
+    [[noreturn]] static void _Xran() {
+        _Xout_of_range("invalid array<T, 0> subscript");
+    }
 };
 
 _EXPORT_STD template <class _Ty, size_t _Size, enable_if_t<_Size == 0 || _Is_swappable<_Ty>::value, int> = 0>

--- a/stl/inc/array
+++ b/stl/inc/array
@@ -571,7 +571,7 @@ public:
     }
 
     _Ty _Elems[_Size];
-    
+
 private:
     [[noreturn]] static void _Xran() {
         _Xout_of_range("invalid array<T, N> subscript");

--- a/stl/inc/bitset
+++ b/stl/inc/bitset
@@ -479,15 +479,15 @@ private:
         return *this;
     }
 
-    [[noreturn]] void _Xinv() const {
+    [[noreturn]] static void _Xinv() {
         _Xinvalid_argument("invalid bitset char");
     }
 
-    [[noreturn]] void _Xoflo() const {
+    [[noreturn]] static void _Xoflo() {
         _Xoverflow_error("bitset overflow");
     }
 
-    [[noreturn]] void _Xran() const {
+    [[noreturn]] static void _Xran() {
         _Xout_of_range("invalid bitset position");
     }
 

--- a/stl/inc/deque
+++ b/stl/inc/deque
@@ -1536,11 +1536,11 @@ private:
         }
     }
 
-    [[noreturn]] void _Xlen() const {
+    [[noreturn]] static void _Xlen() {
         _Xlength_error("deque<T> too long");
     }
 
-    [[noreturn]] void _Xran() const {
+    [[noreturn]] static void _Xran() {
         _Xout_of_range("invalid deque<T> subscript");
     }
 

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -3551,11 +3551,11 @@ public:
         }
     }
 
-    [[noreturn]] void _Xlen() const {
+    [[noreturn]] static void _Xlen() {
         _Xlength_error("vector<bool> too long");
     }
 
-    [[noreturn]] void _Xran() const {
+    [[noreturn]] static void _Xran() {
         _Xout_of_range("invalid vector<bool> subscript");
     }
 };


### PR DESCRIPTION
For example, `void _Xran() const` ~> `static void _Xran()`.