### PR TITLE
Cleanups for `<future>`

### DIFF
--- a/stl/inc/future
+++ b/stl/inc/future
@@ -395,12 +395,6 @@ public:
     }
 
 protected:
-    void _Make_ready_at_thread_exit() { // set ready status at thread exit
-        if (_Ready_at_thread_exit) {
-            _Ready = true;
-        }
-    }
-
     void _Maybe_run_deferred_function(unique_lock<mutex>& _Lock) { // run a deferred function if not already done
         if (!_Running) { // run the function
             _Running = true;
@@ -415,7 +409,7 @@ public:
     condition_variable _Cond;
     bool _Retrieved;
     int _Ready;
-    bool _Ready_at_thread_exit;
+    bool _Ready_at_thread_exit;// TRANSITION, ABI: always fasle.
     bool _Has_stored_result;
     bool _Running;
 

--- a/stl/inc/future
+++ b/stl/inc/future
@@ -405,7 +405,7 @@ public:
     condition_variable _Cond;
     bool _Retrieved;
     int _Ready;
-    bool _Ready_at_thread_exit;// TRANSITION, ABI: always fasle.
+    bool _Ready_at_thread_exit; // TRANSITION, ABI: preserved for binary compatibility
     bool _Has_stored_result;
     bool _Running;
 

--- a/stl/inc/future
+++ b/stl/inc/future
@@ -370,10 +370,6 @@ public:
         return _Ready != 0;
     }
 
-    bool _Is_ready_at_thread_exit() const noexcept {
-        return _Ready_at_thread_exit;
-    }
-
     bool _Already_has_stored_result() const noexcept { // Has a result or an exception
         if constexpr (is_default_constructible_v<_Ty>) {
             return _Has_stored_result;
@@ -853,10 +849,6 @@ public:
         return _Assoc_state && _Assoc_state->_Is_ready();
     }
 
-    bool _Is_ready_at_thread_exit() const noexcept {
-        return _Assoc_state && _Assoc_state->_Is_ready_at_thread_exit();
-    }
-
 private:
     _Associated_state<_Ty>* _Assoc_state = nullptr;
     bool _Get_only_once                  = false;
@@ -1084,10 +1076,6 @@ public:
         return _State._Is_ready();
     }
 
-    bool _Is_ready_at_thread_exit() const noexcept {
-        return _State._Is_ready_at_thread_exit();
-    }
-
     _Promise(const _Promise&)            = delete;
     _Promise& operator=(const _Promise&) = delete;
 
@@ -1115,7 +1103,7 @@ public:
     }
 
     ~promise() noexcept {
-        if (_MyPromise._Is_valid() && !_MyPromise._Is_ready() && !_MyPromise._Is_ready_at_thread_exit()) {
+        if (_MyPromise._Is_valid() && !_MyPromise._Is_ready()) {
             // exception if destroyed before function object returns
             future_error _Fut(_STD make_error_code(future_errc::broken_promise));
             _MyPromise._Get_state()._Set_exception(_STD make_exception_ptr(_Fut), false);
@@ -1177,7 +1165,7 @@ public:
     }
 
     ~promise() noexcept {
-        if (_MyPromise._Is_valid() && !_MyPromise._Is_ready() && !_MyPromise._Is_ready_at_thread_exit()) {
+        if (_MyPromise._Is_valid() && !_MyPromise._Is_ready()) {
             // exception if destroyed before function object returns
             future_error _Fut(_STD make_error_code(future_errc::broken_promise));
             _MyPromise._Get_state()._Set_exception(_STD make_exception_ptr(_Fut), false);
@@ -1231,7 +1219,7 @@ public:
     }
 
     ~promise() noexcept {
-        if (_MyPromise._Is_valid() && !_MyPromise._Is_ready() && !_MyPromise._Is_ready_at_thread_exit()) {
+        if (_MyPromise._Is_valid() && !_MyPromise._Is_ready()) {
             // exception if destroyed before function object returns
             future_error _Fut(_STD make_error_code(future_errc::broken_promise));
             _MyPromise._Get_state()._Set_exception(_STD make_exception_ptr(_Fut), false);

--- a/stl/inc/future
+++ b/stl/inc/future
@@ -405,7 +405,7 @@ public:
     condition_variable _Cond;
     bool _Retrieved;
     int _Ready;
-    bool _Ready_at_thread_exit; // TRANSITION, ABI: preserved for binary compatibility
+    bool _Ready_at_thread_exit; // TRANSITION, ABI
     bool _Has_stored_result;
     bool _Running;
 


### PR DESCRIPTION
`_Associated_state::_Ready_at_thread_exit` is always-false and has no real effect(#3740). This pr removes all relevant non-functional logics.

`_State_manager::_Get_only_once` may have similar issues, but I'm not too confident now so it is kept untouched.