### PR TITLE
Cleanups for `<mutex>`  etc.

### DIFF
--- a/stl/inc/mutex
+++ b/stl/inc/mutex
@@ -762,18 +762,6 @@ private:
         }
     }
 
-    template <class _Predicate>
-    bool _Wait_until1(unique_lock<mutex>& _Lck, const _timespec64* _Abs_time, _Predicate& _Pred) {
-        // wait for signal with timeout and check predicate
-        while (!_Pred()) {
-            if (_Wait_until_sys_time(_Lck, _Abs_time) == cv_status::timeout) {
-                return _Pred();
-            }
-        }
-
-        return true;
-    }
-
     template <class _Clock, class _Duration, class _Predicate>
     bool _Wait_until1(
         unique_lock<mutex>& _Lck, const chrono::time_point<_Clock, _Duration>& _Abs_time, _Predicate& _Pred) {

--- a/stl/inc/mutex
+++ b/stl/inc/mutex
@@ -843,8 +843,12 @@ public:
         return try_lock_until(_To_absolute_time(_Rel_time));
     }
 
-    template <class _Time>
-    bool _Try_lock_until(_Time _Abs_time) { // try to lock the mutex with timeout
+    template <class _Clock, class _Duration>
+    _NODISCARD_TRY_CHANGE_STATE bool try_lock_until(const chrono::time_point<_Clock, _Duration>& _Abs_time) {
+        // try to lock the mutex with timeout
+#if _HAS_CXX20
+        static_assert(chrono::is_clock_v<_Clock>, "Clock type required");
+#endif // _HAS_CXX20
         unique_lock<mutex> _Lock(_My_mutex);
         if (!_My_cond.wait_until(_Lock, _Abs_time, _UInt_is_zero{_My_locked})) {
             return false;
@@ -852,15 +856,6 @@ public:
 
         _My_locked = UINT_MAX;
         return true;
-    }
-
-    template <class _Clock, class _Duration>
-    _NODISCARD_TRY_CHANGE_STATE bool try_lock_until(const chrono::time_point<_Clock, _Duration>& _Abs_time) {
-        // try to lock the mutex with timeout
-#if _HAS_CXX20
-        static_assert(chrono::is_clock_v<_Clock>, "Clock type required");
-#endif // _HAS_CXX20
-        return _Try_lock_until(_Abs_time);
     }
 
 private:
@@ -944,8 +939,12 @@ public:
         return try_lock_until(_To_absolute_time(_Rel_time));
     }
 
-    template <class _Time>
-    bool _Try_lock_until(_Time _Abs_time) { // try to lock the mutex with timeout
+    template <class _Clock, class _Duration>
+    _NODISCARD_TRY_CHANGE_STATE bool try_lock_until(const chrono::time_point<_Clock, _Duration>& _Abs_time) {
+        // try to lock the mutex with timeout
+#if _HAS_CXX20
+        static_assert(chrono::is_clock_v<_Clock>, "Clock type required");
+#endif // _HAS_CXX20
         const thread::id _Tid = this_thread::get_id();
 
         unique_lock<mutex> _Lock(_My_mutex);
@@ -965,15 +964,6 @@ public:
             _My_owner  = _Tid;
         }
         return true;
-    }
-
-    template <class _Clock, class _Duration>
-    _NODISCARD_TRY_CHANGE_STATE bool try_lock_until(const chrono::time_point<_Clock, _Duration>& _Abs_time) {
-        // try to lock the mutex with timeout
-#if _HAS_CXX20
-        static_assert(chrono::is_clock_v<_Clock>, "Clock type required");
-#endif // _HAS_CXX20
-        return _Try_lock_until(_Abs_time);
     }
 
 private:

--- a/stl/inc/shared_mutex
+++ b/stl/inc/shared_mutex
@@ -166,8 +166,12 @@ public:
         return try_lock_shared_until(_To_absolute_time(_Rel_time));
     }
 
-    template <class _Time>
-    bool _Try_lock_shared_until(_Time _Abs_time) { // try to lock non-exclusive until absolute time
+    template <class _Clock, class _Duration>
+    _NODISCARD_TRY_CHANGE_STATE bool try_lock_shared_until(const chrono::time_point<_Clock, _Duration>& _Abs_time) {
+        // try to lock non-exclusive until absolute time
+#if _HAS_CXX20
+        static_assert(chrono::is_clock_v<_Clock>, "Clock type required");
+#endif // _HAS_CXX20
         const auto _Can_acquire = [this] { return !_Writing && _Readers < _Max_readers; };
 
         unique_lock<mutex> _Lock(_Mymtx);
@@ -178,15 +182,6 @@ public:
 
         ++_Readers;
         return true;
-    }
-
-    template <class _Clock, class _Duration>
-    _NODISCARD_TRY_CHANGE_STATE bool try_lock_shared_until(const chrono::time_point<_Clock, _Duration>& _Abs_time) {
-        // try to lock non-exclusive until absolute time
-#if _HAS_CXX20
-        static_assert(chrono::is_clock_v<_Clock>, "Clock type required");
-#endif // _HAS_CXX20
-        return _Try_lock_shared_until(_Abs_time);
     }
 
     void unlock_shared() { // unlock non-exclusive


### PR DESCRIPTION
- Removes `condition_variable::_Wait_until1(...const _timespec64*...)`, which is not called anywhere.
- Fuses some ugly methods like `timed_mutex::_Try_lock_until`.