### PR TITLE
Workaround for non-_Ugly attribute tokens

### DIFF
--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -25,6 +25,10 @@ _STL_DISABLE_CLANG_WARNINGS
 #pragma push_macro("new")
 #undef new
 
+// TRANSITION, non-_Ugly attribute tokens
+#pragma push_macro("msvc")
+#undef msvc
+
 _STD_BEGIN
 #if _HAS_CXX17
 #define _REQUIRE_PARALLEL_LVALUE_ITERATOR(_Iter)                                                                     \

--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -4361,6 +4361,10 @@ namespace _DEPRECATE_TR1_NAMESPACE tr1 {
 #endif // _HAS_TR1_NAMESPACE
 
 _STD_END
+
+// TRANSITION, non-_Ugly attribute tokens
+#pragma pop_macro("msvc")
+
 #pragma pop_macro("new")
 _STL_RESTORE_CLANG_WARNINGS
 #pragma warning(pop)

--- a/stl/inc/system_error
+++ b/stl/inc/system_error
@@ -29,6 +29,12 @@ _STL_DISABLE_CLANG_WARNINGS
 #pragma push_macro("new")
 #undef new
 
+// TRANSITION, non-_Ugly attribute tokens
+#pragma push_macro("msvc")
+#pragma push_macro("noop_dtor")
+#undef msvc
+#undef noop_dtor
+
 _STD_BEGIN
 _EXPORT_STD enum class io_errc { // error codes for ios_base::failure
     stream = 1
@@ -727,6 +733,10 @@ _NODISCARD inline error_code _Make_ec(__std_win_error _Errno) noexcept { // make
 }
 _STD_END
 #endif // _HAS_CXX17
+
+// TRANSITION, non-_Ugly attribute tokens
+#pragma pop_macro("noop_dtor")
+#pragma pop_macro("msvc")
 
 #pragma pop_macro("new")
 _STL_RESTORE_CLANG_WARNINGS

--- a/stl/inc/type_traits
+++ b/stl/inc/type_traits
@@ -19,6 +19,14 @@ _STL_DISABLE_CLANG_WARNINGS
 #pragma push_macro("new")
 #undef new
 
+// TRANSITION, non-_Ugly attribute tokens
+#pragma push_macro("msvc")
+#pragma push_macro("intrinsic")
+#pragma push_macro("known_semantics")
+#undef msvc
+#undef intrinsic
+#undef known_semantics
+
 _STD_BEGIN
 template <class>
 // TRANSITION, CWG-2518: false value attached to a dependent name (for static_assert)
@@ -2581,6 +2589,11 @@ _STL_RESTORE_DEPRECATED_WARNING
 #endif // _HAS_TR1_NAMESPACE
 
 _STD_END
+
+// TRANSITION, non-_Ugly attribute tokens
+#pragma pop_macro("known_semantics")
+#pragma pop_macro("intrinsic")
+#pragma pop_macro("msvc")
 
 #pragma pop_macro("new")
 _STL_RESTORE_CLANG_WARNINGS

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -30,6 +30,14 @@ _STL_DISABLE_CLANG_WARNINGS
 #pragma push_macro("new")
 #undef new
 
+// TRANSITION, non-_Ugly attribute tokens
+#pragma push_macro("msvc")
+#pragma push_macro("intrinsic")
+#pragma push_macro("known_semantics")
+#undef msvc
+#undef intrinsic
+#undef known_semantics
+
 _STD_BEGIN
 _EXPORT_STD template <class _Ty, _Ty... _Vals>
 struct integer_sequence { // sequence of integer parameters
@@ -955,6 +963,11 @@ namespace _DEPRECATE_TR1_NAMESPACE tr1 {
 #endif // _HAS_TR1_NAMESPACE
 
 _STD_END
+
+// TRANSITION, non-_Ugly attribute tokens
+#pragma pop_macro("known_semantics")
+#pragma pop_macro("intrinsic")
+#pragma pop_macro("msvc")
 
 #pragma pop_macro("new")
 _STL_RESTORE_CLANG_WARNINGS

--- a/stl/inc/xtr1common
+++ b/stl/inc/xtr1common
@@ -16,6 +16,12 @@ _STL_DISABLE_CLANG_WARNINGS
 #pragma push_macro("new")
 #undef new
 
+// TRANSITION, non-_Ugly attribute tokens
+#pragma push_macro("msvc")
+#pragma push_macro("known_semantics")
+#undef msvc
+#undef known_semantics
+
 _STD_BEGIN
 _EXPORT_STD template <class _Ty, _Ty _Val>
 struct integral_constant {
@@ -237,6 +243,11 @@ struct remove_cvref {
 #endif // _HAS_CXX20
 
 _STD_END
+
+// TRANSITION, non-_Ugly attribute tokens
+#pragma pop_macro("known_semantics")
+#pragma pop_macro("msvc")
+
 #pragma pop_macro("new")
 _STL_RESTORE_CLANG_WARNINGS
 #pragma warning(pop)

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -7239,10 +7239,11 @@ _NODISCARD constexpr bool _Mul_overflow(const _Int _Left, const _Int _Right, _In
 }
 #endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 
+_STD_END
+
 // TRANSITION, non-_Ugly attribute tokens
 #pragma pop_macro("msvc")
 
-_STD_END
 #pragma pop_macro("new")
 _STL_RESTORE_CLANG_WARNINGS
 #pragma warning(pop)

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -25,6 +25,10 @@ _STL_DISABLE_CLANG_WARNINGS
 #pragma push_macro("new")
 #undef new
 
+// TRANSITION, non-_Ugly attribute tokens
+#pragma push_macro("msvc")
+#undef msvc
+
 #if defined(_CRTBLD) && defined(CRTDLL2)
 // TRANSITION, ABI: The vector algorithms are compiled into the import lib, so we disable their usage when building
 // the DLL. (We could additionally link them into the DLL - not as exports, just for internal usage - but we
@@ -7234,6 +7238,9 @@ _NODISCARD constexpr bool _Mul_overflow(const _Int _Left, const _Int _Right, _In
     }
 }
 #endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
+
+// TRANSITION, non-_Ugly attribute tokens
+#pragma pop_macro("msvc")
 
 _STD_END
 #pragma pop_macro("new")

--- a/tests/std/tests/GH_002206_unreserved_names/test.compile.pass.cpp
+++ b/tests/std/tests/GH_002206_unreserved_names/test.compile.pass.cpp
@@ -29,7 +29,7 @@
 
 #if lifetimebound != 4
 #error bad macro expansion
-#endif // intrinsic != 4
+#endif // lifetimebound != 4
 
 #if noop_dtor != 5
 #error bad macro expansion

--- a/tests/std/tests/GH_002206_unreserved_names/test.compile.pass.cpp
+++ b/tests/std/tests/GH_002206_unreserved_names/test.compile.pass.cpp
@@ -6,4 +6,31 @@
 #define xtime     delete
 #define xtime_get delete
 
+// Also test GH-2645: <yvals_core.h>: Conformance issue on [[msvc::known_semantics]]
+#define msvc            1
+#define known_semantics 2
+#define intrinsic       3
+#define lifetimebound   4
+#define noop_dtor       5
+
 #include <__msvc_all_public_headers.hpp>
+
+#if msvc != 1
+#error bad macro expansion
+#endif // msvc != 1
+
+#if known_semantics != 2
+#error bad macro expansion
+#endif // known_semantics != 2
+
+#if intrinsic != 3
+#error bad macro expansion
+#endif // intrinsic != 3
+
+#if lifetimebound != 4
+#error bad macro expansion
+#endif // intrinsic != 4
+
+#if noop_dtor != 5
+#error bad macro expansion
+#endif // noop_dtor != 5


### PR DESCRIPTION
This PR is trying to push and pop these attribute tokens like `new`. Considering `[[msvc::lifetimebound]]` which is about to be used (#3754).

Fixes #2645.