### PR TITLE
`<ranges>`: Strengthen exception specification for `_Defaultabox`

### DIFF
--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -525,7 +525,7 @@ namespace ranges {
             requires copy_constructible<_Ty> && is_trivially_copy_constructible_v<_Ty> = default;
         // clang-format on
 
-        constexpr _Defaultabox(const _Defaultabox& _That) noexcept(is_nothrow_copy_constructible_v<_Ty>) // strengthened
+        constexpr _Defaultabox(const _Defaultabox& _That) noexcept(is_nothrow_copy_constructible_v<_Ty>)
             requires copy_constructible<_Ty>
             : _Engaged{_That._Engaged} {
             if (_That._Engaged) {
@@ -546,8 +546,7 @@ namespace ranges {
 
         template <_Different_from<_Ty> _Uty>
             requires convertible_to<const _Uty&, _Ty>
-        constexpr _Defaultabox(const _Defaultabox<_Uty>& _That) noexcept(
-            is_nothrow_constructible_v<_Ty, const _Uty&>) // strengthened
+        constexpr _Defaultabox(const _Defaultabox<_Uty>& _That) noexcept(is_nothrow_constructible_v<_Ty, const _Uty&>)
             : _Engaged{_That} {
             if (_That) {
                 _STD _Construct_in_place(_Val, *_That);
@@ -556,8 +555,7 @@ namespace ranges {
 
         template <_Different_from<_Ty> _Uty>
             requires convertible_to<_Uty, _Ty>
-        constexpr _Defaultabox(_Defaultabox<_Uty>&& _That) noexcept(
-            is_nothrow_constructible_v<_Ty, _Uty>) // strengthened
+        constexpr _Defaultabox(_Defaultabox<_Uty>&& _That) noexcept(is_nothrow_constructible_v<_Ty, _Uty>)
             : _Engaged{_That} {
             if (_That) {
                 _STD _Construct_in_place(_Val, _STD move(*_That));
@@ -570,7 +568,7 @@ namespace ranges {
         // clang-format on
 
         constexpr _Defaultabox& operator=(const _Defaultabox& _That) noexcept(
-            is_nothrow_copy_constructible_v<_Ty>&& is_nothrow_copy_assignable_v<_Ty>) // strengthened
+            is_nothrow_copy_constructible_v<_Ty>&& is_nothrow_copy_assignable_v<_Ty>)
             requires copyable<_Ty>
         {
             if (_Engaged) {
@@ -597,7 +595,7 @@ namespace ranges {
         // clang-format on
 
         constexpr _Defaultabox& operator=(_Defaultabox&& _That) noexcept(
-            is_nothrow_move_constructible_v<_Ty>&& is_nothrow_move_assignable_v<_Ty>) /* strengthened */ {
+            is_nothrow_move_constructible_v<_Ty>&& is_nothrow_move_assignable_v<_Ty>) {
             if (_Engaged) {
                 if (_That._Engaged) {
                     static_cast<_Ty&>(_Val) = static_cast<_Ty&&>(_That._Val);
@@ -686,8 +684,7 @@ namespace ranges {
         template <_Different_from<_Ty> _Uty>
             requires convertible_to<const _Uty&, _Ty>
         constexpr _Defaultabox(const _Defaultabox<_Uty>& _That) noexcept(
-            is_default_constructible_v<_Ty>&& noexcept(_Value = static_cast<_Ty>(*_That))) // strengthened
-        {
+            is_default_constructible_v<_Ty>&& noexcept(_Value = static_cast<_Ty>(*_That))) {
             if (_That) {
                 _Value = static_cast<_Ty>(*_That);
             }
@@ -696,8 +693,7 @@ namespace ranges {
         template <_Different_from<_Ty> _Uty>
             requires convertible_to<_Uty, _Ty>
         constexpr _Defaultabox(_Defaultabox<_Uty>&& _That) noexcept(
-            is_default_constructible_v<_Ty>&& noexcept(_Value = static_cast<_Ty>(_STD move(*_That)))) // strengthened
-        {
+            is_default_constructible_v<_Ty>&& noexcept(_Value = static_cast<_Ty>(_STD move(*_That)))) {
             if (_That) {
                 _Value = static_cast<_Ty>(_STD move(*_That));
             }

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -684,7 +684,7 @@ namespace ranges {
         template <_Different_from<_Ty> _Uty>
             requires convertible_to<const _Uty&, _Ty>
         constexpr _Defaultabox(const _Defaultabox<_Uty>& _That) noexcept(
-            is_default_constructible_v<_Ty>&& noexcept(_Value = static_cast<_Ty>(*_That))) {
+            is_nothrow_default_constructible_v<_Ty>&& noexcept(_Value = static_cast<_Ty>(*_That))) {
             if (_That) {
                 _Value = static_cast<_Ty>(*_That);
             }
@@ -693,7 +693,7 @@ namespace ranges {
         template <_Different_from<_Ty> _Uty>
             requires convertible_to<_Uty, _Ty>
         constexpr _Defaultabox(_Defaultabox<_Uty>&& _That) noexcept(
-            is_default_constructible_v<_Ty>&& noexcept(_Value = static_cast<_Ty>(_STD move(*_That)))) {
+            is_nothrow_default_constructible_v<_Ty>&& noexcept(_Value = static_cast<_Ty>(_STD move(*_That)))) {
             if (_That) {
                 _Value = static_cast<_Ty>(_STD move(*_That));
             }

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -525,7 +525,7 @@ namespace ranges {
             requires copy_constructible<_Ty> && is_trivially_copy_constructible_v<_Ty> = default;
         // clang-format on
 
-        constexpr _Defaultabox(const _Defaultabox& _That)
+        constexpr _Defaultabox(const _Defaultabox& _That) noexcept(is_nothrow_copy_constructible_v<_Ty>) // strengthened
             requires copy_constructible<_Ty>
             : _Engaged{_That._Engaged} {
             if (_That._Engaged) {
@@ -537,7 +537,8 @@ namespace ranges {
         _Defaultabox(_Defaultabox&&) requires is_trivially_move_constructible_v<_Ty> = default;
         // clang-format on
 
-        constexpr _Defaultabox(_Defaultabox&& _That) : _Engaged{_That._Engaged} {
+        constexpr _Defaultabox(_Defaultabox&& _That) noexcept(is_nothrow_move_constructible_v<_Ty>)
+            : _Engaged{_That._Engaged} {
             if (_That._Engaged) {
                 _STD _Construct_in_place(_Val, static_cast<_Ty&&>(_That._Val));
             }
@@ -545,7 +546,9 @@ namespace ranges {
 
         template <_Different_from<_Ty> _Uty>
             requires convertible_to<const _Uty&, _Ty>
-        constexpr _Defaultabox(const _Defaultabox<_Uty>& _That) : _Engaged{_That} {
+        constexpr _Defaultabox(const _Defaultabox<_Uty>& _That) noexcept(
+            is_nothrow_constructible_v<_Ty, const _Uty&>) // strengthened
+            : _Engaged{_That} {
             if (_That) {
                 _STD _Construct_in_place(_Val, *_That);
             }
@@ -553,7 +556,9 @@ namespace ranges {
 
         template <_Different_from<_Ty> _Uty>
             requires convertible_to<_Uty, _Ty>
-        constexpr _Defaultabox(_Defaultabox<_Uty>&& _That) : _Engaged{_That} {
+        constexpr _Defaultabox(_Defaultabox<_Uty>&& _That) noexcept(
+            is_nothrow_constructible_v<_Ty, _Uty>) // strengthened
+            : _Engaged{_That} {
             if (_That) {
                 _STD _Construct_in_place(_Val, _STD move(*_That));
             }
@@ -680,7 +685,9 @@ namespace ranges {
 
         template <_Different_from<_Ty> _Uty>
             requires convertible_to<const _Uty&, _Ty>
-        constexpr _Defaultabox(const _Defaultabox<_Uty>& _That) {
+        constexpr _Defaultabox(const _Defaultabox<_Uty>& _That) noexcept(
+            is_default_constructible_v<_Ty>&& noexcept(_Value = static_cast<_Ty>(*_That))) // strengthened
+        {
             if (_That) {
                 _Value = static_cast<_Ty>(*_That);
             }
@@ -688,7 +695,9 @@ namespace ranges {
 
         template <_Different_from<_Ty> _Uty>
             requires convertible_to<_Uty, _Ty>
-        constexpr _Defaultabox(_Defaultabox<_Uty>&& _That) {
+        constexpr _Defaultabox(_Defaultabox<_Uty>&& _That) noexcept(
+            is_default_constructible_v<_Ty>&& noexcept(_Value = static_cast<_Ty>(_STD move(*_That)))) // strengthened
+        {
             if (_That) {
                 _Value = static_cast<_Ty>(_STD move(*_That));
             }


### PR DESCRIPTION
One non-defaulted move constructor for `_Defaultabox` is currently _never_ `noexcept`, which is probably a bug. ~So I decided not to add `// strengthened` to that move constructor. Some similar constructors are made conditionally `noexcept`, and I think `// strengthened` is suitable for them.~

`_Defaultabox` is used for `join_view::_Iterator` and `lazy_split_view`, while the standard wording uses `optional` and _`non-propagating-cache`_ respectively. And thus I'm afraid that the exception specifications are not yet strong enough for `lazy_split_view`. But further strengthening seems dangerous.