### PR TITLE
`<mutex>`: Make `_Mtx_internal_imp_mirror` more closely match `_Mtx_internal_imp_t`

### DIFF
--- a/stl/CMakeLists.txt
+++ b/stl/CMakeLists.txt
@@ -494,7 +494,7 @@ set(CMAKE_SHARED_LINKER_FLAGS_DEBUG "")
 set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "")
 
 # Toolset options must appear before add_library() for the options to take effect.
-add_compile_definitions(_CRTBLD _VCRT_ALLOW_INTERNALS _HAS_OLD_IOSTREAMS_MEMBERS=1 _STL_CONCRT_SUPPORT)
+add_compile_definitions(_CRTBLD _VCRT_ALLOW_INTERNALS _HAS_OLD_IOSTREAMS_MEMBERS=1)
 
 # /Z7 for MSVC, /Zi for MASM
 set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT "Embedded")

--- a/stl/inc/mutex
+++ b/stl/inc/mutex
@@ -34,24 +34,22 @@ _EXPORT_STD class condition_variable_any;
 struct _Mtx_internal_imp_mirror {
 #ifdef _CRT_WINDOWS
 #ifdef _WIN64
-    static constexpr size_t _Critical_section_size = 8;
+    static constexpr size_t _Critical_section_size = 16;
 #else // _WIN64
-    static constexpr size_t _Critical_section_size = 4;
+    static constexpr size_t _Critical_section_size = 8;
 #endif // _WIN64
 #else // _CRT_WINDOWS
 #ifdef _WIN64
-    static constexpr size_t _Critical_section_size = 56;
+    static constexpr size_t _Critical_section_size = 64;
 #else // _WIN64
-    static constexpr size_t _Critical_section_size = 32;
+    static constexpr size_t _Critical_section_size = 36;
 #endif // _WIN64
 #endif // _CRT_WINDOWS
 
+    static constexpr size_t _Critical_section_align = alignof(void*);
+
     int _Type;
-    const void* _Vptr;
-    union {
-        void* _Srw_lock_placeholder;
-        unsigned char _Padding[_Critical_section_size];
-    };
+    _Aligned_storage_t<_Critical_section_size, _Critical_section_align> _Cs;
     long _Thread_id;
     int _Count;
 };

--- a/stl/msbuild/stl_base/libcp.settings.targets
+++ b/stl/msbuild/stl_base/libcp.settings.targets
@@ -10,7 +10,6 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         <TargetType>LIBRARY</TargetType>
         <TargetAppFamily Condition="'$(MsvcpFlavor)' == 'app'">true</TargetAppFamily>
         <TargetCoreSystem Condition="'$(MsvcpFlavor)' == 'onecore'">true</TargetCoreSystem>
-        <DependsOnConcRT Condition="'$(MsvcpFlavor)' == 'kernel32'">true</DependsOnConcRT>
         <Arm64CombinedPdb>true</Arm64CombinedPdb>
     </PropertyGroup>
 

--- a/stl/msbuild/stl_base/libcp.settings.targets
+++ b/stl/msbuild/stl_base/libcp.settings.targets
@@ -26,7 +26,6 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
     <PropertyGroup>
         <ClProgramDataBaseFileName>$(OutputLibPdbPath)$(OutputName)$(PdbVerName).pdb</ClProgramDataBaseFileName>
-        <ClDefines Condition="'$(DependsOnConcRT)' == 'true'">$(ClDefines);_STL_CONCRT_SUPPORT</ClDefines>
         <ClDefines>$(ClDefines);_VCRT_ALLOW_INTERNALS;_ANNOTATE_VECTOR;_ANNOTATE_STRING</ClDefines>
     </PropertyGroup>
 

--- a/stl/msbuild/stl_base/msvcp.settings.targets
+++ b/stl/msbuild/stl_base/msvcp.settings.targets
@@ -10,7 +10,6 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
         <DependsOnVCStartupLib>$(MsvcpFlavor)</DependsOnVCStartupLib>
         <DependsOnVCRuntimeLib>$(MsvcpFlavor)</DependsOnVCRuntimeLib>
-        <DependsOnConcRT Condition="'$(MsvcpFlavor)' == 'kernel32'">true</DependsOnConcRT>
 
         <TargetAppFamily Condition="'$(MsvcpFlavor)' == 'app'">true</TargetAppFamily>
         <TargetCoreSystem Condition="'$(MsvcpFlavor)' == 'onecore'">true</TargetCoreSystem>

--- a/stl/msbuild/stl_base/msvcp.settings.targets
+++ b/stl/msbuild/stl_base/msvcp.settings.targets
@@ -40,7 +40,6 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
         <IntermediateImportLibOutput>$(CrtBuildDir)\msvcprt_base$(BuildSuffix).$(MsvcpFlavor).import_only.lib</IntermediateImportLibOutput>
         <DllDefName>$(LibOutputFileName).$(MsvcpFlavor)</DllDefName>
         <DllDef>$(IntermediateOutputDirectory)\$(DllDefName).def</DllDef>
-        <ClDefines Condition="'$(DependsOnConcRT)' == 'true'">$(ClDefines);_STL_CONCRT_SUPPORT</ClDefines>
 
         <LinkGenerateDebugInformation>true</LinkGenerateDebugInformation>
         <LinkProgramDataBaseFileName>$(OutputPath)\$(OutputName)$(_PDB_VER_NAME_)$(DllPdbFlavorSuffix)</LinkProgramDataBaseFileName>

--- a/stl/src/cond.cpp
+++ b/stl/src/cond.cpp
@@ -21,8 +21,8 @@ struct _Cnd_internal_imp_t { // condition variable implementation for ConcRT
     }
 };
 
-static_assert(sizeof(_Cnd_internal_imp_t) <= _Cnd_internal_imp_size, "incorrect _Cnd_internal_imp_size");
-static_assert(alignof(_Cnd_internal_imp_t) <= _Cnd_internal_imp_alignment, "incorrect _Cnd_internal_imp_alignment");
+static_assert(sizeof(_Cnd_internal_imp_t) == _Cnd_internal_imp_size, "incorrect _Cnd_internal_imp_size");
+static_assert(alignof(_Cnd_internal_imp_t) == _Cnd_internal_imp_alignment, "incorrect _Cnd_internal_imp_alignment");
 
 void _Cnd_init_in_situ(const _Cnd_t cond) { // initialize condition variable in situ
     Concurrency::details::create_stl_condition_variable(cond->_get_cv());

--- a/stl/src/mutex.cpp
+++ b/stl/src/mutex.cpp
@@ -48,8 +48,8 @@ struct _Mtx_internal_imp_t { // ConcRT mutex
     }
 };
 
-static_assert(sizeof(_Mtx_internal_imp_t) <= _Mtx_internal_imp_size, "incorrect _Mtx_internal_imp_size");
-static_assert(alignof(_Mtx_internal_imp_t) <= _Mtx_internal_imp_alignment, "incorrect _Mtx_internal_imp_alignment");
+static_assert(sizeof(_Mtx_internal_imp_t) == _Mtx_internal_imp_size, "incorrect _Mtx_internal_imp_size");
+static_assert(alignof(_Mtx_internal_imp_t) == _Mtx_internal_imp_alignment, "incorrect _Mtx_internal_imp_alignment");
 
 static_assert(
     std::_Mtx_internal_imp_mirror::_Critical_section_size == Concurrency::details::stl_critical_section_max_size);

--- a/stl/src/mutex.cpp
+++ b/stl/src/mutex.cpp
@@ -6,6 +6,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <internal_shared.h>
+#include <mutex>
 #include <type_traits>
 #include <xthreads.h>
 #include <xtimec.h>
@@ -49,6 +50,11 @@ struct _Mtx_internal_imp_t { // ConcRT mutex
 
 static_assert(sizeof(_Mtx_internal_imp_t) <= _Mtx_internal_imp_size, "incorrect _Mtx_internal_imp_size");
 static_assert(alignof(_Mtx_internal_imp_t) <= _Mtx_internal_imp_alignment, "incorrect _Mtx_internal_imp_alignment");
+
+static_assert(
+    std::_Mtx_internal_imp_mirror::_Critical_section_size == Concurrency::details::stl_critical_section_max_size);
+static_assert(
+    std::_Mtx_internal_imp_mirror::_Critical_section_align == Concurrency::details::stl_critical_section_max_alignment);
 
 void _Mtx_init_in_situ(_Mtx_t mtx, int type) { // initialize mutex in situ
     Concurrency::details::create_stl_critical_section(mtx->_get_cs());

--- a/stl/src/primitives.hpp
+++ b/stl/src/primitives.hpp
@@ -123,13 +123,10 @@ namespace Concurrency {
 #if defined(_CRT_WINDOWS)
         const size_t stl_critical_section_max_size   = sizeof(stl_critical_section_win7);
         const size_t stl_condition_variable_max_size = sizeof(stl_condition_variable_win7);
-#elif defined(_STL_CONCRT_SUPPORT)
+#else // vvv !defined(_CRT_WINDOWS) vvv
         const size_t stl_critical_section_max_size        = sizeof_stl_critical_section_concrt;
         const size_t stl_condition_variable_max_size      = sizeof_stl_condition_variable_concrt;
-#else // vvv !defined(_CRT_WINDOWS) && !defined(_STL_CONCRT_SUPPORT) vvv
-        const size_t stl_critical_section_max_size   = sizeof_stl_critical_section_vista;
-        const size_t stl_condition_variable_max_size = sizeof_stl_condition_variable_vista;
-#endif // ^^^ !defined(_CRT_WINDOWS) && !defined(_STL_CONCRT_SUPPORT) ^^^
+#endif // ^^^ !defined(_CRT_WINDOWS) ^^^
 
         // concrt, vista, and win7 alignments are all identical to alignof(void*)
         const size_t stl_critical_section_max_alignment   = alignof(stl_critical_section_win7);

--- a/stl/src/primitives.hpp
+++ b/stl/src/primitives.hpp
@@ -108,21 +108,16 @@ namespace Concurrency {
             new (p) stl_condition_variable_win7;
         }
 
-#ifdef _WIN64
-        const size_t sizeof_stl_critical_section_concrt   = 64;
-        const size_t sizeof_stl_condition_variable_concrt = 72;
-#else // ^^^ 64-bit / 32-bit vvv
-        const size_t sizeof_stl_critical_section_concrt   = 36;
-        const size_t sizeof_stl_condition_variable_concrt = 40;
-#endif // ^^^ 32-bit ^^^
-
-#if defined(_CRT_WINDOWS)
+#if defined(_CRT_WINDOWS) // for Windows-internal code
         const size_t stl_critical_section_max_size   = 2 * sizeof(void*);
         const size_t stl_condition_variable_max_size = 2 * sizeof(void*);
-#else // vvv !defined(_CRT_WINDOWS) vvv
-        const size_t stl_critical_section_max_size        = sizeof_stl_critical_section_concrt;
-        const size_t stl_condition_variable_max_size      = sizeof_stl_condition_variable_concrt;
-#endif // ^^^ !defined(_CRT_WINDOWS) ^^^
+#elif defined(_WIN64) // ordinary 64-bit code
+        const size_t stl_critical_section_max_size   = 64;
+        const size_t stl_condition_variable_max_size = 72;
+#else // vvv ordinary 32-bit code vvv
+        const size_t stl_critical_section_max_size   = 36;
+        const size_t stl_condition_variable_max_size = 40;
+#endif // ^^^ ordinary 32-bit code ^^^
 
         const size_t stl_critical_section_max_alignment   = alignof(void*);
         const size_t stl_condition_variable_max_alignment = alignof(void*);

--- a/stl/src/primitives.hpp
+++ b/stl/src/primitives.hpp
@@ -117,15 +117,14 @@ namespace Concurrency {
 #endif // ^^^ 32-bit ^^^
 
 #if defined(_CRT_WINDOWS)
-        const size_t stl_critical_section_max_size   = sizeof(stl_critical_section_win7);
-        const size_t stl_condition_variable_max_size = sizeof(stl_condition_variable_win7);
+        const size_t stl_critical_section_max_size   = 2 * sizeof(void*);
+        const size_t stl_condition_variable_max_size = 2 * sizeof(void*);
 #else // vvv !defined(_CRT_WINDOWS) vvv
         const size_t stl_critical_section_max_size        = sizeof_stl_critical_section_concrt;
         const size_t stl_condition_variable_max_size      = sizeof_stl_condition_variable_concrt;
 #endif // ^^^ !defined(_CRT_WINDOWS) ^^^
 
-        // concrt, vista, and win7 alignments are all identical to alignof(void*)
-        const size_t stl_critical_section_max_alignment   = alignof(stl_critical_section_win7);
-        const size_t stl_condition_variable_max_alignment = alignof(stl_condition_variable_win7);
+        const size_t stl_critical_section_max_alignment   = alignof(void*);
+        const size_t stl_condition_variable_max_alignment = alignof(void*);
     } // namespace details
 } // namespace Concurrency

--- a/stl/src/primitives.hpp
+++ b/stl/src/primitives.hpp
@@ -111,13 +111,9 @@ namespace Concurrency {
 #ifdef _WIN64
         const size_t sizeof_stl_critical_section_concrt   = 64;
         const size_t sizeof_stl_condition_variable_concrt = 72;
-        const size_t sizeof_stl_critical_section_vista    = 48;
-        const size_t sizeof_stl_condition_variable_vista  = 16;
 #else // ^^^ 64-bit / 32-bit vvv
         const size_t sizeof_stl_critical_section_concrt   = 36;
         const size_t sizeof_stl_condition_variable_concrt = 40;
-        const size_t sizeof_stl_critical_section_vista    = 28;
-        const size_t sizeof_stl_condition_variable_vista  = 8;
 #endif // ^^^ 32-bit ^^^
 
 #if defined(_CRT_WINDOWS)


### PR DESCRIPTION
`<mutex>` doesn't need to know the layout of the critical section member. Specifying the layout is both unnecessary and error-prone (if we ever decide to change `stl_critical_section_win7`).

This also makes it possible to verify that `_Critical_section_size` matches `stl_critical_section_max_size`.

This fixes a bug on UWP where locking a `mutex` could throw a bogus exception.