### PR TITLE
Remove redundant template parameters for `_XX_iter_types`

### DIFF
--- a/stl/inc/deque
+++ b/stl/inc/deque
@@ -518,7 +518,8 @@ public:
     }
 };
 
-template <class _Value_type, class _Size_type, class _Difference_type, class _Pointer, class _Const_pointer, class _Mapptr_type>
+template <class _Value_type, class _Size_type, class _Difference_type, class _Pointer, class _Const_pointer,
+    class _Mapptr_type>
 struct _Deque_iter_types {
     using value_type      = _Value_type;
     using size_type       = _Size_type;

--- a/stl/inc/deque
+++ b/stl/inc/deque
@@ -518,8 +518,7 @@ public:
     }
 };
 
-template <class _Value_type, class _Size_type, class _Difference_type, class _Pointer, class _Const_pointer,
-    class _Reference, class _Const_reference, class _Mapptr_type>
+template <class _Value_type, class _Size_type, class _Difference_type, class _Pointer, class _Const_pointer, class _Mapptr_type>
 struct _Deque_iter_types {
     using value_type      = _Value_type;
     using size_type       = _Size_type;
@@ -587,7 +586,7 @@ private:
 
     using _Scary_val = _Deque_val<conditional_t<_Is_simple_alloc_v<_Alty>, _Deque_simple_types<_Ty>,
         _Deque_iter_types<_Ty, typename _Alty_traits::size_type, typename _Alty_traits::difference_type,
-            typename _Alty_traits::pointer, typename _Alty_traits::const_pointer, _Ty&, const _Ty&, _Mapptr>>>;
+            typename _Alty_traits::pointer, typename _Alty_traits::const_pointer, _Mapptr>>>;
 
     static constexpr int _Minimum_map_size = 8;
     static constexpr int _Block_size       = _Scary_val::_Block_size;

--- a/stl/inc/forward_list
+++ b/stl/inc/forward_list
@@ -226,8 +226,7 @@ public:
     }
 };
 
-template <class _Value_type, class _Size_type, class _Difference_type, class _Pointer, class _Const_pointer,
-    class _Reference, class _Const_reference, class _Nodeptr_type>
+template <class _Value_type, class _Size_type, class _Difference_type, class _Pointer, class _Const_pointer, class _Nodeptr_type>
 struct _Flist_iter_types {
     using value_type      = _Value_type;
     using size_type       = _Size_type;
@@ -524,7 +523,7 @@ private:
 
     using _Scary_val = _Flist_val<conditional_t<_Is_simple_alloc_v<_Alnode>, _Flist_simple_types<_Ty>,
         _Flist_iter_types<_Ty, typename _Alty_traits::size_type, typename _Alty_traits::difference_type,
-            typename _Alty_traits::pointer, typename _Alty_traits::const_pointer, _Ty&, const _Ty&, _Nodeptr>>>;
+            typename _Alty_traits::pointer, typename _Alty_traits::const_pointer, _Nodeptr>>>;
 
 public:
     using value_type      = _Ty;

--- a/stl/inc/forward_list
+++ b/stl/inc/forward_list
@@ -226,7 +226,8 @@ public:
     }
 };
 
-template <class _Value_type, class _Size_type, class _Difference_type, class _Pointer, class _Const_pointer, class _Nodeptr_type>
+template <class _Value_type, class _Size_type, class _Difference_type, class _Pointer, class _Const_pointer,
+    class _Nodeptr_type>
 struct _Flist_iter_types {
     using value_type      = _Value_type;
     using size_type       = _Size_type;

--- a/stl/inc/list
+++ b/stl/inc/list
@@ -272,7 +272,8 @@ public:
     }
 };
 
-template <class _Value_type, class _Size_type, class _Difference_type, class _Pointer, class _Const_pointer, class _Nodeptr_type>
+template <class _Value_type, class _Size_type, class _Difference_type, class _Pointer, class _Const_pointer,
+    class _Nodeptr_type>
 struct _List_iter_types {
     using value_type      = _Value_type;
     using size_type       = _Size_type;

--- a/stl/inc/list
+++ b/stl/inc/list
@@ -272,8 +272,7 @@ public:
     }
 };
 
-template <class _Value_type, class _Size_type, class _Difference_type, class _Pointer, class _Const_pointer,
-    class _Reference, class _Const_reference, class _Nodeptr_type>
+template <class _Value_type, class _Size_type, class _Difference_type, class _Pointer, class _Const_pointer, class _Nodeptr_type>
 struct _List_iter_types {
     using value_type      = _Value_type;
     using size_type       = _Size_type;
@@ -769,7 +768,7 @@ private:
 
     using _Val_types = conditional_t<_Is_simple_alloc_v<_Alnode>, _List_simple_types<_Ty>,
         _List_iter_types<_Ty, typename _Alty_traits::size_type, typename _Alty_traits::difference_type,
-            typename _Alty_traits::pointer, typename _Alty_traits::const_pointer, _Ty&, const _Ty&, _Nodeptr>>;
+            typename _Alty_traits::pointer, typename _Alty_traits::const_pointer, _Nodeptr>>;
 
     using _Scary_val = _List_val<_Val_types>;
 

--- a/stl/inc/vector
+++ b/stl/inc/vector
@@ -370,8 +370,7 @@ struct pointer_traits<_Vector_iterator<_Myvec>> {
 };
 #endif // _HAS_CXX20
 
-template <class _Value_type, class _Size_type, class _Difference_type, class _Pointer, class _Const_pointer,
-    class _Reference, class _Const_reference>
+template <class _Value_type, class _Size_type, class _Difference_type, class _Pointer, class _Const_pointer>
 struct _Vec_iter_types {
     using value_type      = _Value_type;
     using size_type       = _Size_type;
@@ -599,7 +598,7 @@ private:
 #endif // !_INSERT_VECTOR_ANNOTATION
 
     using _Scary_val = _Vector_val<conditional_t<_Is_simple_alloc_v<_Alty>, _Simple_types<_Ty>,
-        _Vec_iter_types<_Ty, size_type, difference_type, pointer, const_pointer, _Ty&, const _Ty&>>>;
+        _Vec_iter_types<_Ty, size_type, difference_type, pointer, const_pointer>>>;
 
 public:
     using iterator               = _Vector_iterator<_Scary_val>;

--- a/stl/inc/xhash
+++ b/stl/inc/xhash
@@ -253,8 +253,7 @@ struct _Hash_vec {
     using difference_type   = typename _Aliter_traits::difference_type;
     using pointer           = typename _Aliter_traits::pointer;
     using _Aliter_scary_val = _Vector_val<conditional_t<_Is_simple_alloc_v<_Aliter>, _Simple_types<value_type>,
-        _Vec_iter_types<value_type, size_type, difference_type, pointer, typename _Aliter_traits::const_pointer,
-            value_type&, const value_type&>>>;
+        _Vec_iter_types<value_type, size_type, difference_type, pointer, typename _Aliter_traits::const_pointer>>>;
 
     _Hash_vec() : _Mypair(_Zero_then_variadic_args_t{}) {
         _Mypair._Myval2._Alloc_proxy(_GET_PROXY_ALLOCATOR(_Aliter, _Mypair._Get_first()));

--- a/stl/inc/xstring
+++ b/stl/inc/xstring
@@ -2190,8 +2190,7 @@ struct pointer_traits<_String_iterator<_Mystr>> {
 };
 #endif // _HAS_CXX20
 
-template <class _Value_type, class _Size_type, class _Difference_type, class _Pointer, class _Const_pointer,
-    class _Reference, class _Const_reference>
+template <class _Value_type, class _Size_type, class _Difference_type, class _Pointer, class _Const_pointer>
 struct _String_iter_types {
     using value_type      = _Value_type;
     using size_type       = _Size_type;
@@ -2329,7 +2328,7 @@ private:
 
     using _Scary_val = _String_val<conditional_t<_Is_simple_alloc_v<_Alty>, _Simple_types<_Elem>,
         _String_iter_types<_Elem, typename _Alty_traits::size_type, typename _Alty_traits::difference_type,
-            typename _Alty_traits::pointer, typename _Alty_traits::const_pointer, _Elem&, const _Elem&>>>;
+            typename _Alty_traits::pointer, typename _Alty_traits::const_pointer>>>;
 
     static_assert(!_ENFORCE_MATCHING_ALLOCATORS || is_same_v<_Elem, typename _Alloc::value_type>,
         _MISMATCHED_ALLOCATOR_MESSAGE("basic_string<T, Traits, Allocator>", "T"));

--- a/stl/inc/xtree
+++ b/stl/inc/xtree
@@ -308,7 +308,8 @@ public:
     }
 };
 
-template <class _Value_type, class _Size_type, class _Difference_type, class _Pointer, class _Const_pointer, class _Nodeptr_type>
+template <class _Value_type, class _Size_type, class _Difference_type, class _Pointer, class _Const_pointer,
+    class _Nodeptr_type>
 struct _Tree_iter_types {
     using value_type      = _Value_type;
     using size_type       = _Size_type;

--- a/stl/inc/xtree
+++ b/stl/inc/xtree
@@ -308,8 +308,7 @@ public:
     }
 };
 
-template <class _Value_type, class _Size_type, class _Difference_type, class _Pointer, class _Const_pointer,
-    class _Reference, class _Const_reference, class _Nodeptr_type>
+template <class _Value_type, class _Size_type, class _Difference_type, class _Pointer, class _Const_pointer, class _Nodeptr_type>
 struct _Tree_iter_types {
     using value_type      = _Value_type;
     using size_type       = _Size_type;
@@ -842,8 +841,7 @@ protected:
 
     using _Scary_val = _Tree_val<conditional_t<_Is_simple_alloc_v<_Alnode>, _Tree_simple_types<value_type>,
         _Tree_iter_types<value_type, typename _Alty_traits::size_type, typename _Alty_traits::difference_type,
-            typename _Alty_traits::pointer, typename _Alty_traits::const_pointer, value_type&, const value_type&,
-            _Nodeptr>>>;
+            typename _Alty_traits::pointer, typename _Alty_traits::const_pointer, _Nodeptr>>>;
 
     static constexpr bool _Multi  = _Traits::_Multi;
     static constexpr bool _Is_set = is_same_v<key_type, value_type>;


### PR DESCRIPTION
Removes `_Reference` and `_Const_reference` for `_[List/Deque/Tree/Vec/String/Flist]_iter_types`.