### PR TITLE
Remove some unnecessary clang-format hacks

### DIFF
--- a/stl/inc/__msvc_iter_core.hpp
+++ b/stl/inc/__msvc_iter_core.hpp
@@ -165,8 +165,8 @@ template <class>
 struct _Iterator_traits_base {};
 
 template <class _It>
-concept _Has_iter_types = _Has_member_difference_type<_It> && _Has_member_value_type<_It> //
-                       && _Has_member_reference<_It> && _Has_member_iterator_category<_It>;
+concept _Has_iter_types = _Has_member_difference_type<_It> && _Has_member_value_type<_It> && _Has_member_reference<_It>
+                       && _Has_member_iterator_category<_It>;
 
 template <bool _Has_member_typedef>
 struct _Old_iter_traits_pointer {

--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -4588,8 +4588,7 @@ namespace ranges {
     concept _Is_input_with_value_type = input_iterator<_It> && same_as<iter_value_t<_It>, _Ty>;
 
     template <class _It, class _Out>
-    concept _Can_reread_or_store = forward_iterator<_It> //
-                                || _Is_input_with_value_type<_Out, iter_value_t<_It>> //
+    concept _Can_reread_or_store = forward_iterator<_It> || _Is_input_with_value_type<_Out, iter_value_t<_It>>
                                 || indirectly_copyable_storable<_It, _Out>;
 
     class _Unique_copy_fn : private _Not_quite_object {
@@ -6324,9 +6323,8 @@ _CONSTEXPR20 void _Push_heap_by_index(
     _RanIt _First, _Iter_diff_t<_RanIt> _Hole, _Iter_diff_t<_RanIt> _Top, _Ty&& _Val, _Pr _Pred) {
     // percolate _Hole to _Top or where _Val belongs
     using _Diff = _Iter_diff_t<_RanIt>;
-    for (_Diff _Idx = (_Hole - 1) >> 1; // shift for codegen
-         _Top < _Hole && _DEBUG_LT_PRED(_Pred, *(_First + _Idx), _Val); //
-         _Idx = (_Hole - 1) >> 1) { // shift for codegen
+    for (_Diff _Idx                                                          = (_Hole - 1) >> 1; // shift for codegen
+         _Top < _Hole && _DEBUG_LT_PRED(_Pred, *(_First + _Idx), _Val); _Idx = (_Hole - 1) >> 1) { // shift for codegen
         // move _Hole up to parent
         *(_First + _Hole) = _STD move(*(_First + _Idx));
         _Hole             = _Idx;
@@ -10631,9 +10629,9 @@ namespace ranges {
             using _Memcmp_classification_pred = _Lex_compare_memcmp_classify<_It1, _It2, _Pr>;
             constexpr bool _Is_sized1         = sized_sentinel_for<_Se1, _It1>;
             constexpr bool _Is_sized2         = sized_sentinel_for<_Se2, _It2>;
-            if constexpr (!is_void_v<_Memcmp_classification_pred> && _Sized_or_unreachable_sentinel_for<_Se1, _It1> //
-                          && _Sized_or_unreachable_sentinel_for<_Se2, _It2> //
-                          && same_as<_Pj1, identity> && same_as<_Pj2, identity>) {
+            if constexpr (!is_void_v<_Memcmp_classification_pred> && _Sized_or_unreachable_sentinel_for<_Se1, _It1>
+                          && _Sized_or_unreachable_sentinel_for<_Se2, _It2> && same_as<_Pj1, identity>
+                          && same_as<_Pj2, identity>) {
                 if (!_STD is_constant_evaluated()) {
                     size_t _Num1;
                     if constexpr (_Is_sized1) {

--- a/stl/inc/chrono
+++ b/stl/inc/chrono
@@ -1601,7 +1601,7 @@ namespace chrono {
 
         constexpr hh_mm_ss() noexcept : hh_mm_ss{_Duration::zero()} {}
         constexpr explicit hh_mm_ss(_Duration _Dur)
-            : _Is_neg{_Dur < _Duration::zero()}, //
+            : _Is_neg{_Dur < _Duration::zero()},
               _Hours{_Duration_cast_underflow_to_zero<_CHRONO hours>(_CHRONO abs(_Dur))},
               _Mins{_Duration_cast_underflow_to_zero<_CHRONO minutes>(
                   _Remove_duration_part<_CHRONO hours>(_CHRONO abs(_Dur)))},
@@ -2989,12 +2989,10 @@ namespace chrono {
         if constexpr (is_invocable_v<clock_time_conversion<_DestClock, _SourceClock>, _Tp>) {
             return _Clock_cast_strategy::_Direct;
         } else {
-            constexpr bool _Has_sys = _Has_two_step_conversion< //
-                clock_time_conversion<_DestClock, system_clock>, //
+            constexpr bool _Has_sys = _Has_two_step_conversion<clock_time_conversion<_DestClock, system_clock>,
                 clock_time_conversion<system_clock, _SourceClock>, _Tp>;
 
-            constexpr bool _Has_utc = _Has_two_step_conversion< //
-                clock_time_conversion<_DestClock, utc_clock>, //
+            constexpr bool _Has_utc = _Has_two_step_conversion<clock_time_conversion<_DestClock, utc_clock>,
                 clock_time_conversion<utc_clock, _SourceClock>, _Tp>;
 
             if constexpr (_Has_sys && _Has_utc) {
@@ -5816,60 +5814,46 @@ struct formatter<_CHRONO duration<_Rep, _Period>, _CharT>
     : _Fill_tm_formatter<_CHRONO duration<_Rep, _Period>, _CharT> {};
 
 template <class _CharT>
-struct formatter<_CHRONO day, _CharT> //
-    : _Fill_tm_formatter<_CHRONO day, _CharT> {};
+struct formatter<_CHRONO day, _CharT> : _Fill_tm_formatter<_CHRONO day, _CharT> {};
 
 template <class _CharT>
-struct formatter<_CHRONO month, _CharT> //
-    : _Fill_tm_formatter<_CHRONO month, _CharT> {};
+struct formatter<_CHRONO month, _CharT> : _Fill_tm_formatter<_CHRONO month, _CharT> {};
 
 template <class _CharT>
-struct formatter<_CHRONO year, _CharT> //
-    : _Fill_tm_formatter<_CHRONO year, _CharT> {};
+struct formatter<_CHRONO year, _CharT> : _Fill_tm_formatter<_CHRONO year, _CharT> {};
 
 template <class _CharT>
-struct formatter<_CHRONO weekday, _CharT> //
-    : _Fill_tm_formatter<_CHRONO weekday, _CharT> {};
+struct formatter<_CHRONO weekday, _CharT> : _Fill_tm_formatter<_CHRONO weekday, _CharT> {};
 
 template <class _CharT>
-struct formatter<_CHRONO weekday_indexed, _CharT> //
-    : _Fill_tm_formatter<_CHRONO weekday_indexed, _CharT> {};
+struct formatter<_CHRONO weekday_indexed, _CharT> : _Fill_tm_formatter<_CHRONO weekday_indexed, _CharT> {};
 
 template <class _CharT>
-struct formatter<_CHRONO weekday_last, _CharT> //
-    : _Fill_tm_formatter<_CHRONO weekday_last, _CharT> {};
+struct formatter<_CHRONO weekday_last, _CharT> : _Fill_tm_formatter<_CHRONO weekday_last, _CharT> {};
 
 template <class _CharT>
-struct formatter<_CHRONO month_day, _CharT> //
-    : _Fill_tm_formatter<_CHRONO month_day, _CharT> {};
+struct formatter<_CHRONO month_day, _CharT> : _Fill_tm_formatter<_CHRONO month_day, _CharT> {};
 
 template <class _CharT>
-struct formatter<_CHRONO month_day_last, _CharT> //
-    : _Fill_tm_formatter<_CHRONO month_day_last, _CharT> {};
+struct formatter<_CHRONO month_day_last, _CharT> : _Fill_tm_formatter<_CHRONO month_day_last, _CharT> {};
 
 template <class _CharT>
-struct formatter<_CHRONO month_weekday, _CharT> //
-    : _Fill_tm_formatter<_CHRONO month_weekday, _CharT> {};
+struct formatter<_CHRONO month_weekday, _CharT> : _Fill_tm_formatter<_CHRONO month_weekday, _CharT> {};
 
 template <class _CharT>
-struct formatter<_CHRONO month_weekday_last, _CharT> //
-    : _Fill_tm_formatter<_CHRONO month_weekday_last, _CharT> {};
+struct formatter<_CHRONO month_weekday_last, _CharT> : _Fill_tm_formatter<_CHRONO month_weekday_last, _CharT> {};
 
 template <class _CharT>
-struct formatter<_CHRONO year_month, _CharT> //
-    : _Fill_tm_formatter<_CHRONO year_month, _CharT> {};
+struct formatter<_CHRONO year_month, _CharT> : _Fill_tm_formatter<_CHRONO year_month, _CharT> {};
 
 template <class _CharT>
-struct formatter<_CHRONO year_month_day, _CharT> //
-    : _Fill_tm_formatter<_CHRONO year_month_day, _CharT> {};
+struct formatter<_CHRONO year_month_day, _CharT> : _Fill_tm_formatter<_CHRONO year_month_day, _CharT> {};
 
 template <class _CharT>
-struct formatter<_CHRONO year_month_day_last, _CharT> //
-    : _Fill_tm_formatter<_CHRONO year_month_day_last, _CharT> {};
+struct formatter<_CHRONO year_month_day_last, _CharT> : _Fill_tm_formatter<_CHRONO year_month_day_last, _CharT> {};
 
 template <class _CharT>
-struct formatter<_CHRONO year_month_weekday, _CharT> //
-    : _Fill_tm_formatter<_CHRONO year_month_weekday, _CharT> {};
+struct formatter<_CHRONO year_month_weekday, _CharT> : _Fill_tm_formatter<_CHRONO year_month_weekday, _CharT> {};
 
 template <class _CharT>
 struct formatter<_CHRONO year_month_weekday_last, _CharT>
@@ -5880,12 +5864,10 @@ struct formatter<_CHRONO hh_mm_ss<_CHRONO duration<_Rep, _Period>>, _CharT>
     : _Fill_tm_formatter<_CHRONO hh_mm_ss<_CHRONO duration<_Rep, _Period>>, _CharT> {};
 
 template <class _CharT>
-struct formatter<_CHRONO sys_info, _CharT> //
-    : _Fill_tm_formatter<_CHRONO sys_info, _CharT> {};
+struct formatter<_CHRONO sys_info, _CharT> : _Fill_tm_formatter<_CHRONO sys_info, _CharT> {};
 
 template <class _CharT>
-struct formatter<_CHRONO local_info, _CharT> //
-    : _Fill_tm_formatter<_CHRONO local_info, _CharT> {};
+struct formatter<_CHRONO local_info, _CharT> : _Fill_tm_formatter<_CHRONO local_info, _CharT> {};
 
 template <class _Duration, class _CharT>
 struct formatter<_CHRONO sys_time<_Duration>, _CharT> {
@@ -5974,8 +5956,7 @@ private:
 };
 
 template <class _Duration, class _CharT>
-struct formatter<_CHRONO local_time<_Duration>, _CharT> //
-    : _Fill_tm_formatter<_CHRONO local_time<_Duration>, _CharT> {};
+struct formatter<_CHRONO local_time<_Duration>, _CharT> : _Fill_tm_formatter<_CHRONO local_time<_Duration>, _CharT> {};
 
 template <class _Duration, class _CharT>
 struct formatter<_CHRONO _Local_time_format_t<_Duration>, _CharT>

--- a/stl/inc/execution
+++ b/stl/inc/execution
@@ -3883,10 +3883,8 @@ _FwdIt3 set_intersection(_ExPo&&, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _Firs
     const auto _ULast2 = _Get_unwrapped(_Last2);
     auto _UDest        = _Get_unwrapped_unverified(_Dest);
     using _Diff        = _Common_diff_t<_FwdIt1, _FwdIt2, _FwdIt3>;
-    if constexpr (remove_reference_t<_ExPo>::_Parallelize //
-                  && _Is_ranges_random_iter_v<_FwdIt1> //
-                  && _Is_ranges_random_iter_v<_FwdIt2> //
-                  && _Is_cpp17_random_iter_v<_FwdIt3>) {
+    if constexpr (remove_reference_t<_ExPo>::_Parallelize && _Is_ranges_random_iter_v<_FwdIt1>
+                  && _Is_ranges_random_iter_v<_FwdIt2> && _Is_cpp17_random_iter_v<_FwdIt3>) {
         // only parallelize if desired, and all of the iterators given are random access
         const size_t _Hw_threads = __std_parallel_algorithms_hw_threads();
         if (_Hw_threads > 1) { // parallelize on multiprocessor machines
@@ -3975,10 +3973,8 @@ _FwdIt3 set_difference(_ExPo&&, _FwdIt1 _First1, _FwdIt1 _Last1, _FwdIt2 _First2
     const auto _ULast2 = _Get_unwrapped(_Last2);
     auto _UDest        = _Get_unwrapped_unverified(_Dest);
     using _Diff        = _Common_diff_t<_FwdIt1, _FwdIt2, _FwdIt3>;
-    if constexpr (remove_reference_t<_ExPo>::_Parallelize //
-                  && _Is_ranges_random_iter_v<_FwdIt1> //
-                  && _Is_ranges_random_iter_v<_FwdIt2> //
-                  && _Is_cpp17_random_iter_v<_FwdIt3>) {
+    if constexpr (remove_reference_t<_ExPo>::_Parallelize && _Is_ranges_random_iter_v<_FwdIt1>
+                  && _Is_ranges_random_iter_v<_FwdIt2> && _Is_cpp17_random_iter_v<_FwdIt3>) {
         // only parallelize if desired, and all of the iterators given are random access
         const size_t _Hw_threads = __std_parallel_algorithms_hw_threads();
         if (_Hw_threads > 1) { // parallelize on multiprocessor machines

--- a/stl/inc/expected
+++ b/stl/inc/expected
@@ -390,7 +390,7 @@ public:
         is_nothrow_copy_constructible_v<_Ty>&& is_nothrow_copy_constructible_v<_Err> //
             && is_nothrow_copy_assignable_v<_Ty>&& is_nothrow_copy_assignable_v<_Err>) // strengthened
         requires is_copy_assignable_v<_Ty> && is_copy_constructible_v<_Ty> //
-              && is_copy_assignable_v<_Err> && is_copy_constructible_v<_Err> //
+              && is_copy_assignable_v<_Err> && is_copy_constructible_v<_Err>
               && (is_nothrow_move_constructible_v<_Ty> || is_nothrow_move_constructible_v<_Err>)
     {
         if (_Has_value && _Other._Has_value) {
@@ -409,9 +409,9 @@ public:
 
     constexpr expected& operator=(expected&& _Other) noexcept(
         is_nothrow_move_constructible_v<_Ty>&& is_nothrow_move_constructible_v<_Err> //
-            && is_nothrow_move_assignable_v<_Ty>&& is_nothrow_move_assignable_v<_Err>) //
+            && is_nothrow_move_assignable_v<_Ty>&& is_nothrow_move_assignable_v<_Err>)
         requires is_move_assignable_v<_Ty> && is_move_constructible_v<_Ty> //
-              && is_move_assignable_v<_Err> && is_move_constructible_v<_Err> //
+              && is_move_assignable_v<_Err> && is_move_constructible_v<_Err>
               && (is_nothrow_move_constructible_v<_Ty> || is_nothrow_move_constructible_v<_Err>)
     {
         if (_Has_value && _Other._Has_value) {
@@ -514,9 +514,9 @@ public:
 
     // [expected.object.swap]
     constexpr void swap(expected& _Other) noexcept(is_nothrow_move_constructible_v<_Ty>&& is_nothrow_swappable_v<_Ty>&&
-            is_nothrow_move_constructible_v<_Err>&& is_nothrow_swappable_v<_Err>) //
+            is_nothrow_move_constructible_v<_Err>&& is_nothrow_swappable_v<_Err>)
         requires is_swappable_v<_Ty> && is_swappable_v<_Err> //
-              && is_move_constructible_v<_Ty> && is_move_constructible_v<_Err> //
+              && is_move_constructible_v<_Ty> && is_move_constructible_v<_Err>
               && (is_nothrow_move_constructible_v<_Ty> || is_nothrow_move_constructible_v<_Err>)
     {
         using _STD swap;
@@ -567,9 +567,9 @@ public:
     }
 
     friend constexpr void swap(expected& _Lhs, expected& _Rhs) noexcept(is_nothrow_move_constructible_v<_Ty>&&
-            is_nothrow_swappable_v<_Ty>&& is_nothrow_move_constructible_v<_Err>&& is_nothrow_swappable_v<_Err>) //
+            is_nothrow_swappable_v<_Ty>&& is_nothrow_move_constructible_v<_Err>&& is_nothrow_swappable_v<_Err>)
         requires is_swappable_v<_Ty> && is_swappable_v<_Err> //
-              && is_move_constructible_v<_Ty> && is_move_constructible_v<_Err> //
+              && is_move_constructible_v<_Ty> && is_move_constructible_v<_Err>
               && (is_nothrow_move_constructible_v<_Ty> || is_nothrow_move_constructible_v<_Err>)
     {
         _Lhs.swap(_Rhs);
@@ -1221,14 +1221,14 @@ public:
 
     template <class _UErr>
         requires is_constructible_v<_Err, const _UErr&>
-    constexpr explicit(!is_convertible_v<const _UErr&, _Err>) expected(const unexpected<_UErr>& _Other) //
-        noexcept(is_nothrow_constructible_v<_Err, const _UErr&>) // strengthened
+    constexpr explicit(!is_convertible_v<const _UErr&, _Err>) expected(const unexpected<_UErr>& _Other) noexcept(
+        is_nothrow_constructible_v<_Err, const _UErr&>) // strengthened
         : _Unexpected(_Other._Unexpected), _Has_value(false) {}
 
     template <class _UErr>
         requires is_constructible_v<_Err, _UErr>
-    constexpr explicit(!is_convertible_v<_UErr, _Err>) expected(unexpected<_UErr>&& _Other) //
-        noexcept(is_nothrow_constructible_v<_Err, _UErr>) // strengthened
+    constexpr explicit(!is_convertible_v<_UErr, _Err>)
+        expected(unexpected<_UErr>&& _Other) noexcept(is_nothrow_constructible_v<_Err, _UErr>) // strengthened
         : _Unexpected(_STD move(_Other._Unexpected)), _Has_value(false) {}
 
     constexpr explicit expected(in_place_t) noexcept : _Has_value(true) {}

--- a/stl/inc/memory
+++ b/stl/inc/memory
@@ -93,7 +93,7 @@ namespace ranges {
             constexpr bool _Is_sized1 = sized_sentinel_for<_Se, _It>;
             constexpr bool _Is_sized2 = sized_sentinel_for<_OSe, _Out>;
             if constexpr (_Iter_copy_cat<_It, _Out>::_Bitcopy_constructible
-                          && _Sized_or_unreachable_sentinel_for<_Se, _It> //
+                          && _Sized_or_unreachable_sentinel_for<_Se, _It>
                           && _Sized_or_unreachable_sentinel_for<_OSe, _Out>) {
                 if constexpr (_Is_sized1 && _Is_sized2) {
                     return _Copy_memcpy_common(_IFirst, _RANGES next(_IFirst, _STD move(_ILast)), _OFirst,
@@ -3348,10 +3348,8 @@ public:
 
     template <class _Uty, class _Is_nullptr = is_same<_Uty, nullptr_t>>
     using _Enable_ctor_reset =
-        enable_if_t<is_same_v<_Uty, pointer> //
-                        || _Is_nullptr::value //
-                        || (is_same_v<pointer, element_type*> //
-                            && is_pointer_v<_Uty> //
+        enable_if_t<is_same_v<_Uty, pointer> || _Is_nullptr::value
+                        || (is_same_v<pointer, element_type*> && is_pointer_v<_Uty>
                             && is_convertible_v<remove_pointer_t<_Uty> (*)[], element_type (*)[]>),
             int>;
 

--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -144,10 +144,9 @@ namespace ranges {
         _Pipeline(_Ty1, _Ty2) -> _Pipeline<_Ty1, _Ty2>;
 
         _EXPORT_STD template <class _Left, class _Right>
-            requires _Range_adaptor_closure_object<_Left> //
-                  && _Range_adaptor_closure_object<_Right> //
-                  && constructible_from<remove_cvref_t<_Left>, _Left> //
-                  && constructible_from<remove_cvref_t<_Right>, _Right> //
+            requires _Range_adaptor_closure_object<_Left> && _Range_adaptor_closure_object<_Right>
+                  && constructible_from<remove_cvref_t<_Left>, _Left>
+                  && constructible_from<remove_cvref_t<_Right>, _Right>
         _NODISCARD constexpr auto operator|(_Left&& __l, _Right&& __r) noexcept(
             noexcept(_Pipeline{static_cast<_Left&&>(__l), static_cast<_Right&&>(__r)})) {
             return _Pipeline{static_cast<_Left&&>(__l), static_cast<_Right&&>(__r)};
@@ -3913,8 +3912,8 @@ namespace ranges {
         }
 
         _NODISCARD constexpr auto end() {
-            if constexpr (forward_range<_Vw> && is_reference_v<_InnerRng<false>> //
-                          && forward_range<_InnerRng<false>> && common_range<_Vw> && common_range<_InnerRng<false>>) {
+            if constexpr (forward_range<_Vw> && is_reference_v<_InnerRng<false>> && forward_range<_InnerRng<false>>
+                          && common_range<_Vw> && common_range<_InnerRng<false>>) {
                 return _Iterator<_Simple_view<_Vw>>{*this, _RANGES end(_Range)};
             } else {
                 return _Sentinel<_Simple_view<_Vw>>{*this};
@@ -4155,9 +4154,9 @@ namespace ranges {
             }
 
         public:
-            using iterator_concept = //
-                conditional_t<_Deref_is_glvalue && bidirectional_range<_Base> //
-                                  && _Bidi_common_range<_InnerRng<_Const>> && _Bidi_common_range<_PatternBase>,
+            using iterator_concept =
+                conditional_t<_Deref_is_glvalue && bidirectional_range<_Base> && _Bidi_common_range<_InnerRng<_Const>>
+                                  && _Bidi_common_range<_PatternBase>,
                     bidirectional_iterator_tag,
                     conditional_t<_Deref_is_glvalue && forward_range<_Base> && forward_range<_InnerRng<_Const>>,
                         forward_iterator_tag, input_iterator_tag>>;
@@ -4169,10 +4168,9 @@ namespace ranges {
             // clang-format on
 
             constexpr _Iterator(_Iterator<!_Const> _It)
-                requires _Const //
-                          && convertible_to<iterator_t<_Vw>, _OuterIter> //
-                          && convertible_to<iterator_t<_InnerRng<false>>, _InnerIter> //
-                          && convertible_to<iterator_t<_Pat>, _PatternIter> //
+                requires _Const && convertible_to<iterator_t<_Vw>, _OuterIter>
+                          && convertible_to<iterator_t<_InnerRng<false>>, _InnerIter>
+                          && convertible_to<iterator_t<_Pat>, _PatternIter>
                 : _Mybase(_STD move(_It._Outer_it)), _Parent(_It._Parent) {
                 switch (_It._Inner_it._Contains) {
                 case _Variantish_state::_Holds_first:
@@ -4219,8 +4217,8 @@ namespace ranges {
             }
 
             constexpr _Iterator& operator--()
-                requires _Deref_is_glvalue && bidirectional_range<_Base> //
-                      && _Bidi_common_range<_InnerRng<_Const>> && _Bidi_common_range<_PatternBase>
+                requires _Deref_is_glvalue && bidirectional_range<_Base> && _Bidi_common_range<_InnerRng<_Const>>
+                      && _Bidi_common_range<_PatternBase>
             {
                 auto& _Outer_it = _Get_outer();
                 if (_Outer_it == _RANGES end(_Parent->_Range)) {
@@ -4263,8 +4261,8 @@ namespace ranges {
             }
 
             constexpr _Iterator operator--(int)
-                requires _Deref_is_glvalue && bidirectional_range<_Base> //
-                      && _Bidi_common_range<_InnerRng<_Const>> && _Bidi_common_range<_PatternBase>
+                requires _Deref_is_glvalue && bidirectional_range<_Base> && _Bidi_common_range<_InnerRng<_Const>>
+                      && _Bidi_common_range<_PatternBase>
             {
                 auto _Tmp = *this;
                 --*this;
@@ -4416,8 +4414,7 @@ namespace ranges {
 
         _NODISCARD constexpr auto end() {
             constexpr bool _Both_simple = _Simple_view<_Vw> && _Simple_view<_Pat>;
-            if constexpr (forward_range<_Vw> //
-                          && is_reference_v<_InnerRng<false>> && forward_range<_InnerRng<false>> //
+            if constexpr (forward_range<_Vw> && is_reference_v<_InnerRng<false>> && forward_range<_InnerRng<false>>
                           && common_range<_Vw> && common_range<_InnerRng<false>>) {
                 return _Iterator<_Both_simple>{*this, _RANGES end(_Range)};
             } else {
@@ -6176,8 +6173,8 @@ namespace ranges {
 
             template <bool _OtherConst>
                 requires sentinel_for<_Base_sentinel, iterator_t<_Maybe_const<_OtherConst, _Vw>>>
-            _NODISCARD_FRIEND constexpr bool operator==(const _Iterator<_OtherConst>& _It, const _Sentinel& _Se) //
-                noexcept(noexcept(_Se._Equal(_It))) /* strengthened */ {
+            _NODISCARD_FRIEND constexpr bool operator==(const _Iterator<_OtherConst>& _It,
+                const _Sentinel& _Se) noexcept(noexcept(_Se._Equal(_It))) /* strengthened */ {
                 return _Se._Equal(_It);
             }
 
@@ -6574,7 +6571,7 @@ namespace ranges {
             range_difference_t<_Base> _Count   = 0;
             range_difference_t<_Base> _Missing = 0;
 
-            constexpr _Iterator(_ParentTy* _Parent, _Base_iterator _Current_, //
+            constexpr _Iterator(_ParentTy* _Parent, _Base_iterator _Current_,
                 range_difference_t<_Base> _Missing_ = 0) //
                 noexcept(noexcept(_RANGES end(_Parent->_Range)) && is_nothrow_move_constructible_v<_Base_iterator> //
                          && is_nothrow_move_constructible_v<_Base_sentinel>) /* strengthened */
@@ -6900,10 +6897,10 @@ namespace ranges {
     concept _Slide_caches_nothing = random_access_range<_Vw> && sized_range<_Vw>;
 
     template <class _Vw>
-    concept _Slide_caches_last = (!_Slide_caches_nothing<_Vw>) &&bidirectional_range<_Vw> && common_range<_Vw>;
+    concept _Slide_caches_last = !_Slide_caches_nothing<_Vw> && bidirectional_range<_Vw> && common_range<_Vw>;
 
     template <class _Vw>
-    concept _Slide_caches_first = (!_Slide_caches_nothing<_Vw>) &&(!_Slide_caches_last<_Vw>);
+    concept _Slide_caches_first = !_Slide_caches_nothing<_Vw> && !_Slide_caches_last<_Vw>;
 
     _EXPORT_STD template <forward_range _Vw>
         requires view<_Vw>
@@ -7877,8 +7874,8 @@ namespace ranges {
     } // namespace views
 
     template <class... _RangeTypes>
-    concept _Zip_is_common = (sizeof...(_RangeTypes) == 1 && (common_range<_RangeTypes> && ...)) //
-                          || (!(bidirectional_range<_RangeTypes> && ...) && (common_range<_RangeTypes> && ...)) //
+    concept _Zip_is_common = (sizeof...(_RangeTypes) == 1 && (common_range<_RangeTypes> && ...))
+                          || (!(bidirectional_range<_RangeTypes> && ...) && (common_range<_RangeTypes> && ...))
                           || ((random_access_range<_RangeTypes> && ...) && (sized_range<_RangeTypes> && ...));
 
     template <class _CallbackType>
@@ -10066,11 +10063,11 @@ namespace ranges {
 
     template <class _Rng, class _Container>
     concept _Ref_converts =
-        (!input_range<_Container>) || convertible_to<range_reference_t<_Rng>, range_value_t<_Container>>;
+        !input_range<_Container> || convertible_to<range_reference_t<_Rng>, range_value_t<_Container>>;
 
     template <class _Rng, class _Container, class... _Types>
-    concept _Converts_direct_constructible = _Ref_converts<_Rng, _Container> //
-                                          && constructible_from<_Container, _Rng, _Types...>;
+    concept _Converts_direct_constructible =
+        _Ref_converts<_Rng, _Container> && constructible_from<_Container, _Rng, _Types...>;
 
     template <class _Rng, class _Container, class... _Types>
     concept _Converts_tag_constructible = _Ref_converts<_Rng, _Container>

--- a/stl/inc/tuple
+++ b/stl/inc/tuple
@@ -190,9 +190,8 @@ inline constexpr bool _Can_construct_values_from_tuple_like_v<tuple<_Types...>, 
 #ifdef __clang__ // TRANSITION, LLVM-59827
 template <class _TupleLike, class _Tuple>
 concept _Can_construct_from_tuple_like =
-    _Different_from<_TupleLike, _Tuple> && _Tuple_like<_TupleLike>
-    && (!_Is_subrange_v<remove_cvref_t<_TupleLike>>) &&(
-        tuple_size_v<_Tuple>
+    _Different_from<_TupleLike, _Tuple> && _Tuple_like<_TupleLike> && !_Is_subrange_v<remove_cvref_t<_TupleLike>>
+    && (tuple_size_v<_Tuple>
         == tuple_size_v<remove_cvref_t<_TupleLike>>) &&_Can_construct_values_from_tuple_like_v<_Tuple, _TupleLike>
     && (tuple_size_v<_Tuple> != 1
         || (!is_convertible_v<_TupleLike, tuple_element_t<0, _Tuple>>
@@ -217,7 +216,7 @@ using _Three_way_comparison_result_with_tuple_like_t =
     typename _Three_way_comparison_result_with_tuple_like<_TTuple, _UTuple>::type;
 
 template <class _Ty>
-concept _Tuple_like_non_tuple = (!_Is_specialization_v<_Ty, tuple>) &&_Tuple_like<_Ty>;
+concept _Tuple_like_non_tuple = !_Is_specialization_v<_Ty, tuple> && _Tuple_like<_Ty>;
 #endif // _HAS_CXX23 && defined(__cpp_lib_concepts)
 
 template <>

--- a/stl/inc/utility
+++ b/stl/inc/utility
@@ -180,7 +180,7 @@ _NODISCARD constexpr const _Ty&& get(const array<_Ty, _Size>&& _Arr) noexcept;
 
 #ifdef __cpp_lib_concepts
 template <class _Ty1, class _Ty2>
-concept _Different_from = (!same_as<remove_cvref_t<_Ty1>, remove_cvref_t<_Ty2>>);
+concept _Different_from = !same_as<remove_cvref_t<_Ty1>, remove_cvref_t<_Ty2>>;
 
 template <class>
 inline constexpr bool _Is_std_array_v = false;
@@ -204,9 +204,8 @@ concept _Pair_like = _Tuple_like<_Ty> && tuple_size_v<remove_cvref_t<_Ty>> == 2;
 
 #ifdef __clang__ // TRANSITION, LLVM-59827
 template <class _PairLike, class _Ty1, class _Ty2>
-concept _Can_construct_from_pair_like = _Pair_like<_PairLike>
-                                     && (!_Is_subrange_v<remove_cvref_t<_PairLike>>) &&is_constructible_v<_Ty1,
-                                         decltype(_STD get<0>(_STD declval<_PairLike>()))>
+concept _Can_construct_from_pair_like = _Pair_like<_PairLike> && !_Is_subrange_v<remove_cvref_t<_PairLike>>
+                                     && is_constructible_v<_Ty1, decltype(_STD get<0>(_STD declval<_PairLike>()))>
                                      && is_constructible_v<_Ty2, decltype(_STD get<1>(_STD declval<_PairLike>()))>;
 #endif // __clang__
 #endif // _HAS_CXX23

--- a/stl/inc/xmemory
+++ b/stl/inc/xmemory
@@ -1646,8 +1646,7 @@ _CONSTEXPR20 _NoThrowFwdIt _Uninitialized_move_unchecked(_InIt _First, const _In
 namespace ranges {
     template <class _It>
     concept _No_throw_input_iterator =
-        input_iterator<_It> //
-        && is_lvalue_reference_v<iter_reference_t<_It>> //
+        input_iterator<_It> && is_lvalue_reference_v<iter_reference_t<_It>>
         && same_as<remove_cvref_t<iter_reference_t<_It>>, remove_reference_t<iter_reference_t<_It>>> // per LWG-3888
         && same_as<remove_cvref_t<iter_reference_t<_It>>, iter_value_t<_It>>;
 
@@ -1655,18 +1654,15 @@ namespace ranges {
     concept _No_throw_sentinel_for = sentinel_for<_Se, _It>;
 
     template <class _It>
-    concept _No_throw_forward_iterator = _No_throw_input_iterator<_It> //
-                                      && forward_iterator<_It> //
-                                      && _No_throw_sentinel_for<_It, _It>;
+    concept _No_throw_forward_iterator =
+        _No_throw_input_iterator<_It> && forward_iterator<_It> && _No_throw_sentinel_for<_It, _It>;
 
     template <class _Rng>
-    concept _No_throw_input_range = range<_Rng> //
-                                 && _No_throw_input_iterator<iterator_t<_Rng>> //
+    concept _No_throw_input_range = range<_Rng> && _No_throw_input_iterator<iterator_t<_Rng>>
                                  && _No_throw_sentinel_for<sentinel_t<_Rng>, iterator_t<_Rng>>;
 
     template <class _Rng>
-    concept _No_throw_forward_range = _No_throw_input_range<_Rng> //
-                                   && _No_throw_forward_iterator<iterator_t<_Rng>>;
+    concept _No_throw_forward_range = _No_throw_input_range<_Rng> && _No_throw_forward_iterator<iterator_t<_Rng>>;
 
     template <class _InIt, class _OutIt>
     in_out_result<_InIt, _OutIt> _Copy_memcpy_count(_InIt _IFirst, _OutIt _OFirst, const size_t _Count) noexcept {
@@ -1755,8 +1751,7 @@ namespace ranges {
         _It _IFirst, _Se _ILast, _Out _OFirst, _OSe _OLast) {
         constexpr bool _Is_sized1 = sized_sentinel_for<_Se, _It>;
         constexpr bool _Is_sized2 = sized_sentinel_for<_OSe, _Out>;
-        if constexpr (_Iter_move_cat<_It, _Out>::_Bitcopy_constructible
-                      && _Sized_or_unreachable_sentinel_for<_Se, _It> //
+        if constexpr (_Iter_move_cat<_It, _Out>::_Bitcopy_constructible && _Sized_or_unreachable_sentinel_for<_Se, _It>
                       && _Sized_or_unreachable_sentinel_for<_OSe, _Out>) {
             if constexpr (_Is_sized1 && _Is_sized2) {
                 return _Copy_memcpy_common(_IFirst, _RANGES next(_IFirst, _STD move(_ILast)), _OFirst,

--- a/stl/inc/xutility
+++ b/stl/inc/xutility
@@ -1011,11 +1011,9 @@ namespace ranges {
 
 _EXPORT_STD template <class _It1, class _It2, class _Out, class _Pr = ranges::less, class _Pj1 = identity,
     class _Pj2 = identity>
-concept mergeable = input_iterator<_It1> && input_iterator<_It2> //
-                 && weakly_incrementable<_Out> //
-                 && indirectly_copyable<_It1, _Out> //
-                 && indirectly_copyable<_It2, _Out> //
-                 && indirect_strict_weak_order<_Pr, projected<_It1, _Pj1>, projected<_It2, _Pj2>>;
+concept mergeable =
+    input_iterator<_It1> && input_iterator<_It2> && weakly_incrementable<_Out> && indirectly_copyable<_It1, _Out>
+    && indirectly_copyable<_It2, _Out> && indirect_strict_weak_order<_Pr, projected<_It1, _Pj1>, projected<_It2, _Pj2>>;
 
 _EXPORT_STD template <class _It, class _Pr = ranges::less, class _Proj = identity>
 concept sortable = permutable<_It> && indirect_strict_weak_order<_Pr, projected<_It, _Proj>>;
@@ -2316,10 +2314,9 @@ namespace ranges {
         };
 
         template <class _Ty>
-        concept _Has_ADL = _Has_class_or_enum_type<_Ty> //
-                        && requires(_Ty __t) {
-                               { _Fake_copy_init(begin(__t)) } -> input_or_output_iterator; // intentional ADL
-                           };
+        concept _Has_ADL = _Has_class_or_enum_type<_Ty> && requires(_Ty __t) {
+            { _Fake_copy_init(begin(__t)) } -> input_or_output_iterator; // intentional ADL
+        };
 
         class _Cpo {
         private:
@@ -2385,10 +2382,9 @@ namespace ranges {
         };
 
         template <class _Ty>
-        concept _Has_ADL = _Has_class_or_enum_type<_Ty> //
-                        && requires(_Ty __t) {
-                               { _Fake_copy_init(end(__t)) } -> sentinel_for<iterator_t<_Ty>>; // intentional ADL
-                           };
+        concept _Has_ADL = _Has_class_or_enum_type<_Ty> && requires(_Ty __t) {
+            { _Fake_copy_init(end(__t)) } -> sentinel_for<iterator_t<_Ty>>; // intentional ADL
+        };
 
         class _Cpo {
         private:
@@ -2465,18 +2461,18 @@ namespace ranges {
     concept _Weakly_unwrappable_sentinel = _Weakly_unwrappable<const remove_reference_t<_Sent>&>;
 
     template <class _Iter>
-    concept _Weakly_unwrappable_iterator = //
-        _Weakly_unwrappable<_Iter> //
-        && requires(
-            _Iter&& _It, remove_cvref_t<_Iter>& _MutIt) { _MutIt._Seek_to(_STD forward<_Iter>(_It)._Unwrapped()); };
+    concept _Weakly_unwrappable_iterator =
+        _Weakly_unwrappable<_Iter> && requires(_Iter&& _It, remove_cvref_t<_Iter>& _MutIt) {
+            _MutIt._Seek_to(_STD forward<_Iter>(_It)._Unwrapped());
+        };
 
     template <class _Sent, class _Iter>
-    concept _Unwrappable_sentinel_for = //
-        _Weakly_unwrappable_sentinel<_Sent> //
-        && _Weakly_unwrappable_iterator<_Iter> //
-        && requires(_Iter&& _It, const remove_reference_t<_Sent>& _Se) {
-               { _Se._Unwrapped() } -> sentinel_for<decltype(_STD forward<_Iter>(_It)._Unwrapped())>;
-           };
+    concept _Unwrappable_sentinel_for = _Weakly_unwrappable_sentinel<_Sent> && _Weakly_unwrappable_iterator<_Iter>
+                                     && requires(_Iter&& _It, const remove_reference_t<_Sent>& _Se) {
+                                            {
+                                                _Se._Unwrapped()
+                                            } -> sentinel_for<decltype(_STD forward<_Iter>(_It)._Unwrapped())>;
+                                        };
 
     template <class _Sent, class _Iter>
     _NODISCARD constexpr decltype(auto) _Unwrap_iter(_Iter&& _It) noexcept(
@@ -2740,10 +2736,9 @@ namespace ranges {
         };
 
         template <class _Ty>
-        concept _Has_ADL = _Has_class_or_enum_type<_Ty> //
-                        && requires(_Ty __t) {
-                               { _Fake_copy_init(rbegin(__t)) } -> input_or_output_iterator; // intentional ADL
-                           };
+        concept _Has_ADL = _Has_class_or_enum_type<_Ty> && requires(_Ty __t) {
+            { _Fake_copy_init(rbegin(__t)) } -> input_or_output_iterator; // intentional ADL
+        };
 
         template <class _Ty>
         concept _Can_make_reverse = requires(_Ty __t) {
@@ -2809,11 +2804,10 @@ namespace ranges {
         };
 
         template <class _Ty>
-        concept _Has_ADL = _Has_class_or_enum_type<_Ty> //
-                        && requires(_Ty __t) {
-                               // intentional ADL
-                               { _Fake_copy_init(rend(__t)) } -> sentinel_for<decltype(_RANGES rbegin(__t))>;
-                           };
+        concept _Has_ADL = _Has_class_or_enum_type<_Ty> && requires(_Ty __t) {
+            // intentional ADL
+            { _Fake_copy_init(rend(__t)) } -> sentinel_for<decltype(_RANGES rbegin(__t))>;
+        };
 
         template <class _Ty>
         concept _Can_make_reverse = requires(_Ty __t) {
@@ -2937,17 +2931,14 @@ namespace ranges {
 #endif // ^^^ workaround ^^^
 
         template <class _Ty, class _UnCV>
-        concept _Has_member = (!disable_sized_range<_UnCV>) //
-            &&requires(_Ty __t) {
-                { _Fake_copy_init(__t.size()) } -> _Integer_like;
-            };
+        concept _Has_member = !disable_sized_range<_UnCV> && requires(_Ty __t) {
+            { _Fake_copy_init(__t.size()) } -> _Integer_like;
+        };
 
         template <class _Ty, class _UnCV>
-        concept _Has_ADL = _Has_class_or_enum_type<_Ty>
-                        && (!disable_sized_range<_UnCV>) //
-                        &&requires(_Ty __t) {
-                            { _Fake_copy_init(size(__t)) } -> _Integer_like; // intentional ADL
-                        };
+        concept _Has_ADL = _Has_class_or_enum_type<_Ty> && !disable_sized_range<_UnCV> && requires(_Ty __t) {
+            { _Fake_copy_init(size(__t)) } -> _Integer_like; // intentional ADL
+        };
 
         template <class _Ty>
         concept _Can_difference = requires(_Ty __t) {
@@ -3683,15 +3674,15 @@ namespace ranges {
     template <class _From, class _To>
     concept _Uses_nonqualification_pointer_conversion =
         is_pointer_v<_From> && is_pointer_v<_To>
-        && (!convertible_to<remove_pointer_t<_From> (*)[], remove_pointer_t<_To> (*)[]>);
+        && !convertible_to<remove_pointer_t<_From> (*)[], remove_pointer_t<_To> (*)[]>;
 
     template <class _From, class _To>
     concept _Convertible_to_non_slicing =
-        convertible_to<_From, _To> && (!_Uses_nonqualification_pointer_conversion<decay_t<_From>, decay_t<_To>>);
+        convertible_to<_From, _To> && !_Uses_nonqualification_pointer_conversion<decay_t<_From>, decay_t<_To>>;
 
 #if !_HAS_CXX23
     template <class _Ty>
-    concept _Pair_like = (!is_reference_v<_Ty>) &&requires(_Ty __t) {
+    concept _Pair_like = !is_reference_v<_Ty> && requires(_Ty __t) {
         typename tuple_size<_Ty>::type;
         requires derived_from<tuple_size<_Ty>, integral_constant<size_t, 2>>;
         typename tuple_element_t<0, remove_const_t<_Ty>>;
@@ -3702,17 +3693,16 @@ namespace ranges {
 #endif // !_HAS_CXX23
 
     template <class _Ty, class _First, class _Second>
-    concept _Pair_like_convertible_from =
-        (!range<_Ty>)
+    concept _Pair_like_convertible_from = !range<_Ty>
 #if _HAS_CXX23
-        &&(!is_reference_v<_Ty>)
+                                       && !is_reference_v<_Ty>
 #endif // _HAS_CXX23
-        &&_Pair_like<_Ty>
-        && constructible_from<_Ty, _First, _Second> && _Convertible_to_non_slicing<_First, tuple_element_t<0, _Ty>>
-        && convertible_to<_Second, tuple_element_t<1, _Ty>>;
+                                       && _Pair_like<_Ty> && constructible_from<_Ty, _First, _Second>
+                                       && _Convertible_to_non_slicing<_First, tuple_element_t<0, _Ty>>
+                                       && convertible_to<_Second, tuple_element_t<1, _Ty>>;
 
     template <class _It, class _Se, subrange_kind _Ki>
-    concept _Store_size = (_Ki == subrange_kind::sized) && (!sized_sentinel_for<_Se, _It>);
+    concept _Store_size = (_Ki == subrange_kind::sized) && !sized_sentinel_for<_Se, _It>;
 
     template <class _It, class _Se, subrange_kind _Ki>
     class _Subrange_base : public view_interface<subrange<_It, _Se, _Ki>> {
@@ -4452,8 +4442,8 @@ struct _False_trivial_cat {
 };
 
 template <class _SourceIt, class _DestIt,
-    bool _Are_contiguous = _Iterators_are_contiguous<_SourceIt, _DestIt> //
-                        && !_Iterator_is_volatile<_SourceIt> && !_Iterator_is_volatile<_DestIt>>
+    bool _Are_contiguous = _Iterators_are_contiguous<_SourceIt, _DestIt> && !_Iterator_is_volatile<_SourceIt>
+                        && !_Iterator_is_volatile<_DestIt>>
 struct _Iter_move_cat : _Trivial_cat<_Iter_value_t<_SourceIt>, _Iter_value_t<_DestIt>,
                             remove_reference_t<_Iter_ref_t<_SourceIt>>&&, _Iter_ref_t<_DestIt>> {};
 
@@ -4464,8 +4454,8 @@ template <class _SourceIt, class _DestIt>
 struct _Iter_move_cat<move_iterator<_SourceIt>, _DestIt, false> : _Iter_move_cat<_SourceIt, _DestIt> {};
 
 template <class _SourceIt, class _DestIt,
-    bool _Are_contiguous = _Iterators_are_contiguous<_SourceIt, _DestIt> //
-                        && !_Iterator_is_volatile<_SourceIt> && !_Iterator_is_volatile<_DestIt>>
+    bool _Are_contiguous = _Iterators_are_contiguous<_SourceIt, _DestIt> && !_Iterator_is_volatile<_SourceIt>
+                        && !_Iterator_is_volatile<_DestIt>>
 struct _Iter_copy_cat
     : _Trivial_cat<_Iter_value_t<_SourceIt>, _Iter_value_t<_DestIt>, _Iter_ref_t<_SourceIt>, _Iter_ref_t<_DestIt>> {};
 
@@ -5214,8 +5204,7 @@ _INLINE_VAR constexpr bool _Can_memcmp_elements_with_pred<_Elem1, _Elem2, _RANGE
 // It ignores top-level constness on the iterators and on the elements.
 template <class _Iter1, class _Iter2, class _Pr>
 _INLINE_VAR constexpr bool _Equal_memcmp_is_safe_helper =
-    _Iterators_are_contiguous<_Iter1, _Iter2> //
-    && !_Iterator_is_volatile<_Iter1> && !_Iterator_is_volatile<_Iter2> //
+    _Iterators_are_contiguous<_Iter1, _Iter2> && !_Iterator_is_volatile<_Iter1> && !_Iterator_is_volatile<_Iter2>
     && _Can_memcmp_elements_with_pred<_Iter_value_t<_Iter1>, _Iter_value_t<_Iter2>, _Pr>;
 
 template <class _Iter1, class _Iter2, class _Pr>

--- a/tests/std/tests/P0896R4_common_iterator/test.cpp
+++ b/tests/std/tests/P0896R4_common_iterator/test.cpp
@@ -23,7 +23,7 @@ concept CanDifference = requires(Iter it) {
 };
 
 template <class Iter>
-concept HasProxy = (!is_reference_v<iter_reference_t<Iter>>);
+concept HasProxy = !is_reference_v<iter_reference_t<Iter>>;
 
 template <class Iter>
 concept CanArrow = requires(const Iter& i) {

--- a/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_iterator_machinery/test.cpp
@@ -1256,7 +1256,7 @@ namespace iterator_cust_swap_test {
 
     // N4928 [iterator.cust.swap]/4.4: "Otherwise, ranges::iter_swap(E1, E2) is ill-formed."
     template <class T, class U>
-    concept bullet4 = (!can_iter_swap<T, U>);
+    concept bullet4 = !can_iter_swap<T, U>;
 
     STATIC_ASSERT(bullet4<void, void>);
     STATIC_ASSERT(bullet4<int, int>);

--- a/tests/std/tests/P1899R3_views_stride/test.cpp
+++ b/tests/std/tests/P1899R3_views_stride/test.cpp
@@ -376,8 +376,8 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
                           || same_as<IterCat, C>);
         }
 
-        constexpr bool constructible_from_nonconst = convertible_to<iterator_t<V>, iterator_t<const V>> //
-                                                  && convertible_to<sentinel_t<V>, sentinel_t<const V>>;
+        constexpr bool constructible_from_nonconst =
+            convertible_to<iterator_t<V>, iterator_t<const V>> && convertible_to<sentinel_t<V>, sentinel_t<const V>>;
 
         if constexpr (forward_range<const R>) {
             [[maybe_unused]] const iterator_t<const R> const_defaulted;

--- a/tests/std/tests/P2164R9_views_enumerate/test.cpp
+++ b/tests/std/tests/P2164R9_views_enumerate/test.cpp
@@ -442,8 +442,8 @@ constexpr bool test_one(Rng&& rng, Expected&& expected) {
         // Check iterator_category
         STATIC_ASSERT(same_as<typename iterator_t<const R>::iterator_category, input_iterator_tag>);
 
-        constexpr bool constructible_from_nonconst = convertible_to<iterator_t<V>, iterator_t<const V>> //
-                                                  && convertible_to<sentinel_t<V>, sentinel_t<const V>>;
+        constexpr bool constructible_from_nonconst =
+            convertible_to<iterator_t<V>, iterator_t<const V>> && convertible_to<sentinel_t<V>, sentinel_t<const V>>;
         if constexpr (forward_range<const R>) {
             [[maybe_unused]] const iterator_t<const R> const_defaulted;
         }

--- a/tests/std/tests/P2374R4_views_cartesian_product/test.cpp
+++ b/tests/std/tests/P2374R4_views_cartesian_product/test.cpp
@@ -53,7 +53,7 @@ template <class... Ranges>
 concept CanViewCartesianProduct = requires(Ranges&&... rs) { views::cartesian_product(forward<Ranges>(rs)...); };
 
 template <class T>
-concept UnsignedIntegerLike = _Integer_like<T> && (!_Signed_integer_like<T>);
+concept UnsignedIntegerLike = _Integer_like<T> && !_Signed_integer_like<T>;
 
 template <class First, class... Rest>
 constexpr bool is_iter_move_nothrow() {

--- a/tests/std/tests/P2387R3_pipe_support_for_user_defined_range_adaptors/test.cpp
+++ b/tests/std/tests/P2387R3_pipe_support_for_user_defined_range_adaptors/test.cpp
@@ -34,8 +34,8 @@ using TestRange = array<int, 1>;
 
 template <class T>
 constexpr bool is_range_adaptor_closure() {
-    return CanPipe<TestRange, T&> || CanPipe<TestRange, const T&> //
-        || CanPipe<TestRange, T&&> || CanPipe<TestRange, const T&&>;
+    return CanPipe<TestRange, T&> || CanPipe<TestRange, const T&> || CanPipe<TestRange, T&&>
+        || CanPipe<TestRange, const T&&>;
 }
 
 struct IdentityRangeAdaptorClosure : ranges::range_adaptor_closure<IdentityRangeAdaptorClosure> {


### PR DESCRIPTION
clang-format 16 doesn't need these anymore, and in fact they often make things _worse_. Note that "I don't like how clang formats this" isn't enough reason to mess with the formatting; the threshold for using annotations is "the code without annotations is so bad that having noise from annotations is an improvement."